### PR TITLE
Fix missing UserString()

### DIFF
--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -3280,12 +3280,12 @@ std::string Condition::PlanetEnvironment::Description(bool negated/* = false*/) 
     if (m_species_name)
         species_str = m_species_name->Description();
     if (species_str.empty())
-        species_str = UserString("DESC_PLANET_ENVIRONMENT_CUR_SPECIES");
+        species_str = "DESC_PLANET_ENVIRONMENT_CUR_SPECIES";
     return str(FlexibleFormat((!negated)
         ? UserString("DESC_PLANET_ENVIRONMENT")
         : UserString("DESC_PLANET_ENVIRONMENT_NOT"))
         % values_str
-        % species_str);
+        % UserString(species_str));
 }
 
 std::string Condition::PlanetEnvironment::Dump() const {


### PR DESCRIPTION
A colony building, blocked by an habitability condition is showing as :
"...that is not a uninhabitable planet for the species SP_ABADDONI"

That SP_ABADDONI should be translated, so add the missing UserString()
call.

Signed-off-by: Vincent Legoll vincent.legoll@gmail.com
