### PR TITLE
High Tech Natives patch

### DIFF
--- a/default/buildings.txt
+++ b/default/buildings.txt
@@ -83,6 +83,31 @@ BuildingType
     icon = "icons/building/archive.png"
 
 BuildingType
+    name = "BLD_CULTURE_LIBRARY"
+    description = "BLD_CULTURE_LIBRARY_DESC"
+    buildcost = 200
+    buildtime = 1
+    tags = "ANTIQUATED"
+    location = Not All
+    effectsgroups = [
+        EffectsGroup
+            scope = And [
+                Object id = Source.PlanetID
+                Planet
+            ]
+            effects = SetTargetResearch value = Value + 5
+
+	EffectsGroup	// Destroy cultural library when the species is no longer present
+	    scope = Source
+            activation = ContainedBy And [
+                Object id = Source.PlanetID
+                Population high = 0
+            ]
+            effects = Destroy
+    ]
+    icon = "icons/building/archive.png"
+
+BuildingType
     name = "BLD_IMPERIAL_PALACE"
     description = "BLD_IMPERIAL_PALACE_DESC"
     buildcost = 10

--- a/default/specials.txt
+++ b/default/specials.txt
@@ -22,6 +22,11 @@ Special
                 SetMaxTroops value = Value + 10
                 SetDetection value = Value + 20
             ]
+
+        EffectsGroup
+            scope = Source
+            activation = OwnedBy affiliation = AnyEmpire
+            effects = RemoveSpecial name = "MODERATE_TECH_NATIVES_SPECIAL"
     ]
     graphic = "icons/tech/categories/learning.png"
 
@@ -47,6 +52,24 @@ Special
                 SetMaxTroops value = Value + 30
                 SetDetection value = Value + 60
             ]
+
+        EffectsGroup
+            scope = Source
+            activation = Turn low = 1 high = 1
+            effects = CreateBuilding name = "BLD_CULTURE_LIBRARY"
+
+        EffectsGroup
+            scope = Source
+            activation = AND [
+                Random probability = 0.2
+                Turn low = 1 high = 1
+            ]
+            effects = CreateBuilding name = "BLD_SCANNING_FACILITY"
+
+        EffectsGroup
+            scope = Source
+            activation = OwnedBy affiliation = AnyEmpire
+            effects = RemoveSpecial name = "HIGH_TECH_NATIVES_SPECIAL"
     ]
     graphic = "icons/tech/categories/learning.png"
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -8666,6 +8666,14 @@ BLD_CULTURE_ARCHIVES_DESC
 
 Stores the sum accumulated knowledge from thousands of years of life on this planet, giving bonuses to many aspects of planetary productivity.'''
 
+BLD_CULTURE_LIBRARY
+Cultural Library
+
+BLD_CULTURE_LIBRARY_DESC
+'''Increases target [[encyclopedia RESEARCH_TITLE]] by 5.
+
+Stores the accumulated knowledge from thousands of years of life on this planet, giving a bonuses to research. This building will be destroyed when the population of the high tech natives reaches zero.'''
+
 BLD_IMPERIAL_PALACE
 Imperial Palace
 


### PR DESCRIPTION
- The High Tech Natives special will create a cultural archives building which boosts research. 20% chance of also creating a Scanning Facility.
- The High Tech Natives special will be removed once owned by any empire. The cultural archives will remain for as long as the population is > 0.
