### PR TITLE
Fix missing untranslated species name in ProductionWnd

### DIFF
--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -2,6 +2,7 @@
 
 #include "../util/Logger.h"
 #include "../util/Random.h"
+#include "../util/i18n.h"
 #include "UniverseObject.h"
 #include "Universe.h"
 #include "Building.h"
@@ -3279,8 +3280,14 @@ std::string Condition::PlanetEnvironment::Description(bool negated/* = false*/) 
         }
     }
     std::string species_str;
-    if (m_species_name)
-        species_str = m_species_name->Description();
+    if (m_species_name) {
+        if (ValueRef::ConstantExpr(m_species_name)) {
+            species_str = boost::lexical_cast<std::string>(m_species_name->Eval());
+            if (UserStringExists(species_str))
+                species_str = UserString(species_str);
+        } else
+            species_str = m_species_name->Description();
+    }
     if (species_str.empty())
         species_str = UserString("DESC_PLANET_ENVIRONMENT_CUR_SPECIES");
     return str(FlexibleFormat((!negated)


### PR DESCRIPTION
A colony building, blocked by an habitability condition is showing as :
"...that is not a uninhabitable planet for the species SP_ABADDONI"

That SP_ABADDONI should be translated, so add the missing UserString()
call. Also ensure that the species string is translatable.

Signed-off-by: Vincent Legoll vincent.legoll@gmail.com
