### PR TITLE
Make empires remember the enemies they saw in battle.

### DIFF
--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -699,6 +699,14 @@ namespace {
                 std::swap(shuffled[pos1], shuffled[pos2]);
             }
         }
+        
+        /// Ensures that the empire has at least basic visibility of the object.
+        /// This is likely the result of the object shooting at something of the empires
+        void MakeCombatVisible(int object_id, int empire_id) {
+            empire_infos[empire_id].target_ids.insert(object_id);
+            combat_info.empire_object_visibility[empire_id][object_id] = std::max(combat_info.empire_object_visibility[empire_id][object_id], VIS_PARTIAL_VISIBILITY);
+        }
+        
     private:
         typedef std::set<int>::const_iterator const_id_iterator;
 
@@ -819,7 +827,7 @@ namespace {
             // mark attackers as valid targets for attacked object's owners, so
             // attacker they can be counter-attacked in subsequent rounds if it
             // was not already attackable
-            combat_state.empire_infos[target->Owner()].target_ids.insert(attacker->ID());
+            combat_state.MakeCombatVisible(attacker->ID(), target->Owner());
         } // end for over weapons
     }
 

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1657,6 +1657,17 @@ namespace {
              combat_it != combats.end(); ++combat_it)
         {
             const CombatInfo& combat_info = *combat_it;
+            
+            // update visibilities.
+            for (Universe::EmpireObjectVisibilityMap::const_iterator empire_it = combat_info.empire_object_visibility.begin();
+                 empire_it != combat_info.empire_object_visibility.end();
+            ++empire_it)
+            {
+                for (Universe::ObjectVisibilityMap::const_iterator object_it = empire_it->second.begin(); object_it != empire_it->second.end(); ++object_it) {
+                    Visibility vis = object_it->second;
+                    universe.SetEmpireObjectVisibility(empire_it->first, object_it->first, vis);
+                }
+            }
 
             // indexed by fleet id, which empire ids to inform that a fleet is destroyed
             std::map<int, std::set<int> > empires_to_update_of_fleet_destruction;
@@ -2805,7 +2816,7 @@ void ServerApp::PostCombatProcessTurns() {
     ObjectMap& objects = m_universe.Objects();
 
     // post-combat visibility update
-    m_universe.UpdateEmpireObjectVisibilities();
+    m_universe.UpdateEmpireObjectVisibilities(false);
     m_universe.UpdateEmpireLatestKnownObjectsAndVisibilityTurns();
 
 
@@ -2952,7 +2963,7 @@ void ServerApp::PostCombatProcessTurns() {
     m_universe.UpdateEmpireLatestKnownObjectsAndVisibilityTurns();
 
     // post-production and meter-effects visibility update
-    m_universe.UpdateEmpireObjectVisibilities();
+    m_universe.UpdateEmpireObjectVisibilities(false);
 
     m_universe.UpdateEmpireStaleObjectKnowledge();
 
@@ -2971,7 +2982,7 @@ void ServerApp::PostCombatProcessTurns() {
     DebugLogger() << "ServerApp::PostCombatProcessTurns Turn number incremented to " << m_current_turn;
 
 
-    // new turn visibility update
+    // new turn visibility update. Forget combat results now, since the combat happened last turn.
     m_universe.UpdateEmpireObjectVisibilities();
     m_universe.UpdateEmpireLatestKnownObjectsAndVisibilityTurns();
 

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -3048,9 +3048,11 @@ namespace {
             }
         }
     }
+    
+    
 }
 
-void Universe::UpdateEmpireObjectVisibilities() {
+void Universe::UpdateEmpireObjectVisibilities(bool reset) {
     // ensure Universe knows empires have knowledge of designs the empire is specifically remembering
     for (EmpireManager::iterator empire_it = Empires().begin();
          empire_it != Empires().end(); ++empire_it)
@@ -3063,7 +3065,9 @@ void Universe::UpdateEmpireObjectVisibilities() {
         { m_empire_known_ship_design_ids[empire_id].insert(*design_it); }
     }
 
-    m_empire_object_visibility.clear();
+    if (reset) {
+        m_empire_object_visibility.clear();
+    }
     m_empire_object_visible_specials.clear();
 
     if (m_all_objects_visible) {

--- a/universe/Universe.h
+++ b/universe/Universe.h
@@ -304,8 +304,10 @@ public:
     void            BackPropegateObjectMeters(const std::vector<int>& object_ids);
 
     /** Determines which empires can see which objects at what visibility
-      * level, based on  */
-    void            UpdateEmpireObjectVisibilities();
+      * level, based on empire detection strength and ships with detection
+      * \param reset If true, old visibility information is discarded before the update
+      */
+    void            UpdateEmpireObjectVisibilities(bool reset = true);
 
     /** Sets visibility for indicated \a empire_id of object with \a object_id
       * a vis */


### PR DESCRIPTION
This is relevant if they have stealth or if all ships that could
see them are destroyed.

I made sure that this compiles, but do not have time to make sure it still works.
It did merge cleanly, though, and I don't see any relevant changes in the associated code that should have broken it since it was made.
