### PR TITLE
default stringtable as backup for key expansion/reference during stringtable load

### DIFF
--- a/util/StringTable.h
+++ b/util/StringTable.h
@@ -52,7 +52,9 @@ public:
     StringTable_();  //!< default construction, uses S_DEFAULT_FILENAME
 
     //! @param filename A file containing the data for this StringTable_
-    StringTable_(const std::string& filename);   //!< construct a StringTable_ from the given filename
+    //! @param lookups_fallback_table A StringTable_ to be used as fallback expansions lookup
+    StringTable_(const std::string& filename, const StringTable_* lookups_fallback_table = 0);   //!< construct a StringTable_ from the given filename
+
     ~StringTable_();                             //!< default destructor
     //!@}
 
@@ -85,7 +87,11 @@ public:
 private:
     //! \name Internal Functions
     //!@{
-    void Load();    //!< Loads the String table file from m_filename
+    //! @param lookups_fallback_table A StringTable_ to be used as fallback expansions lookup
+    void Load(const StringTable_* lookups_fallback_table = 0);    //!< Loads the String table file from m_filename
+
+    const std::map<std::string, std::string>& GetStrings() const {return m_strings;}    //!< returns a const reference to the strings in this table
+
     //!@}
 
     //! \name Data Members

--- a/util/i18n.cpp
+++ b/util/i18n.cpp
@@ -24,14 +24,24 @@ namespace {
         if (stringtable_filename.empty())
             stringtable_filename = GetStringTableFileName();
 
+        // ensure the default stringtable is loaded first
+        std::map<std::string, const StringTable_*>::const_iterator default_stringtable_it =
+            stringtables.find(GetDefaultStringTableFileName());
+        if (default_stringtable_it == stringtables.end()) {
+            const StringTable_* table = new StringTable_(GetDefaultStringTableFileName());
+            stringtables[GetDefaultStringTableFileName()] = table;
+            default_stringtable_it = stringtables.find(GetDefaultStringTableFileName());
+        }
+
         // attempt to find requested stringtable...
         std::map<std::string, const StringTable_*>::const_iterator it =
             stringtables.find(stringtable_filename);
         if (it != stringtables.end())
             return *(it->second);
 
-        // if already loaded, load, store, and return
-        const StringTable_* table = new StringTable_(stringtable_filename);
+        // if not already loaded, load, store, and return,
+        // using default stringtable for fallback expansion lookups
+        const StringTable_* table = new StringTable_(stringtable_filename, default_stringtable_it->second);
         stringtables[stringtable_filename] = table;
 
         return *table;


### PR DESCRIPTION
enabled use of default stringtable as backup for key expansion/reference lookups during stringtable loading

As easy check is using the modified fr.txt stringtable from https://github.com/Cjkjvfnby/freeorion/blob/fr_with_comments/default/stringtables/fr.txt
Use the pedia, go to  "Particularité planétaire et spatiale" and then select "Colonie Abandonnée" -- it has a reference to [[encyclopedia INFRASTRUCTURE_TITLE]] which is not found in the above stringtable; standard code logs an error and leaves the key as-is; with this commit it properly looks up the reference in the default stringtable
