### PR TITLE
AI: Remove hardcoded dependencies on ship parts

### DIFF
--- a/default/AI/AIFleetMission.py
+++ b/default/AI/AIFleetMission.py
@@ -320,7 +320,7 @@ class AIFleetMission(object):
                 open_targets.append(pid)
         if not open_targets:
             return
-        troop_pod_tally = FleetUtilsAI.count_parts_fleetwide(fleet_id, ["GT_TROOP_POD"])
+        troops_in_fleet = FleetUtilsAI.count_troops_in_fleet(fleet_id)
         target_id = -1
         best_score = -1
         target_troops = 0
@@ -330,7 +330,7 @@ class AIFleetMission(object):
         for pid, rating in InvasionAI.assign_invasion_values(open_targets, AIFleetMissionType.FLEET_MISSION_INVASION, fleet_supplyable_planet_ids, empire).items():
             p_score, p_troops = rating
             if p_score > best_score:
-                if p_troops >= 2 * troop_pod_tally:
+                if p_troops >= troops_in_fleet:
                     continue
                 best_score = p_score
                 target_id = pid
@@ -342,10 +342,11 @@ class AIFleetMission(object):
         new_fleets = FleetUtilsAI.split_fleet(fleet_id)
         self.clear_targets(-1)  # TODO: clear from foAIstate
         self.clear_fleet_orders()
-        pods_needed = max(0, math.ceil((target_troops - 2 * (FleetUtilsAI.count_parts_fleetwide(fleet_id, ["GT_TROOP_POD"])) + 0.05) / 2.0))
+        # pods_needed = max(0, math.ceil((target_troops - 2 * (FleetUtilsAI.count_parts_fleetwide(fleet_id, ["GT_TROOP_POD"])) + 0.05) / 2.0))
+        troops_needed = max(0, target_troops - FleetUtilsAI.count_troops_in_fleet(fleet_id))
         found_stats = {}
-        min_stats = {'rating': 0, 'troopPods': pods_needed}
-        target_stats = {'rating': 10, 'troopPods': pods_needed}
+        min_stats = {'rating': 0, 'troopCapacity': troops_needed}
+        target_stats = {'rating': 10, 'troopCapacity': troops_needed}
         found_fleets = []
         # TODO check if next statement does not mutate any global states and can be removed
         _ = FleetUtilsAI.get_fleets_for_mission(1, target_stats, min_stats, found_stats, "",

--- a/default/AI/FleetUtilsAI.py
+++ b/default/AI/FleetUtilsAI.py
@@ -339,27 +339,28 @@ def assess_fleet_role(fleet_id):
 
 
 def assess_ship_design_role(design):
-    parts = [fo.getPartType(partname) for partname in design.parts if partname]
-    if any((p.partClass == fo.shipPartClass.colony and p.capacity == 0) for p in parts):
+    parts = [fo.getPartType(partname) for partname in design.parts if partname and fo.getPartType(partname)]
+
+    if any(p.partClass == fo.shipPartClass.colony and p.capacity == 0 for p in parts):
         if design.starlaneSpeed > 0:
             return AIShipRoleType.SHIP_ROLE_CIVILIAN_OUTPOST
         else:
             return AIShipRoleType.SHIP_ROLE_BASE_OUTPOST
 
-    if any((p.partClass == fo.shipPartClass.colony and p.capacity > 0 for p in parts)):
+    if any(p.partClass == fo.shipPartClass.colony and p.capacity > 0 for p in parts):
         if design.starlaneSpeed > 0:
             return AIShipRoleType.SHIP_ROLE_CIVILIAN_COLONISATION
         else:
             return AIShipRoleType.SHIP_ROLE_BASE_COLONISATION
 
-    if any((p.partClass == fo.shipPartClass.troops for p in parts)):
+    if any(p.partClass == fo.shipPartClass.troops for p in parts):
         if design.starlaneSpeed > 0:
             return AIShipRoleType.SHIP_ROLE_MILITARY_INVASION
         else:
             return AIShipRoleType.SHIP_ROLE_BASE_INVASION
 
     if design.starlaneSpeed == 0:
-        if len(parts) == 0 or parts[0].partClass == fo.shipPartClass.shields:
+        if not parts or parts[0].partClass == fo.shipPartClass.shields:  # ToDo: Update logic for new ship designs
             return AIShipRoleType.SHIP_ROLE_BASE_DEFENSE
         else:
             return AIShipRoleType.SHIP_ROLE_INVALID
@@ -368,7 +369,7 @@ def assess_ship_design_role(design):
     rating = stats['attack'] * (stats['structure'] + stats['shields'])
     if rating > 0:  # positive attack stat
         return AIShipRoleType.SHIP_ROLE_MILITARY
-    if any((p.partClass == fo.shipPartClass.detection for p in parts)):
+    if any(p.partClass == fo.shipPartClass.detection for p in parts):
         return AIShipRoleType.SHIP_ROLE_CIVILIAN_EXPLORATION
     else:   # if no suitable role found, use as (bad) scout as it still has inherent detection
         return AIShipRoleType.SHIP_ROLE_CIVILIAN_EXPLORATION

--- a/default/AI/FleetUtilsAI.py
+++ b/default/AI/FleetUtilsAI.py
@@ -37,6 +37,23 @@ def count_parts_fleetwide(fleet_id, parts_list):
     return tally
 
 
+def count_troops_in_fleet(fleet_id):
+    """
+    :param fleet_id:
+    :return: total troopCapacity of the fleet
+    """
+    universe = fo.getUniverse()
+    fleet = universe.getFleet(fleet_id)
+    if not fleet:
+        return 0
+    fleet_troop_capacity = 0
+    for ship_id in fleet.shipIDs:
+        ship = universe.getShip(ship_id)
+        if ship:
+            fleet_troop_capacity += ship.troopCapacity
+    return fleet_troop_capacity
+
+
 def get_fleets_for_mission(nships, target_stats, min_stats, cur_stats, species, systems_to_check, systems_checked, fleet_pool_set, fleet_list,
                                                             take_any=False, extend_search=True, tried_fleets=None, verbose=False, depth=0):
     """Implements breadth-first search through systems
@@ -83,12 +100,13 @@ def get_fleets_for_mission(nships, target_stats, min_stats, cur_stats, species, 
                 if has_species == species:
                     meets_species_req = True
                     break
-        has_pods = 0
-        needs_troops = 'troopPods' in target_stats
+        troop_capacity = 0
+        needs_troops = 'troopCapacity' in target_stats
         if needs_troops:
-            has_pods = count_parts_fleetwide(fleet_id, ["GT_TROOP_POD"])
+            troop_capacity = count_troops_in_fleet(fleet_id)
 
-        use_fleet = ((not needs_species and not has_species) or meets_species_req) and ((needs_troops and has_pods > 0) or (not needs_troops and not has_pods))
+        use_fleet = ((not needs_species and not has_species) or meets_species_req)\
+                    and ((needs_troops and troop_capacity > 0) or (not needs_troops and not troop_capacity))
         if use_fleet:
             fleet_list.append(fleet_id)
             fleet_pool_set.remove(fleet_id)
@@ -96,9 +114,10 @@ def get_fleets_for_mission(nships, target_stats, min_stats, cur_stats, species, 
             cur_stats['attack'] = cur_stats.get('attack', 0) + this_rating['attack']
             cur_stats['health'] = cur_stats.get('health', 0) + this_rating['health']
             cur_stats['rating'] = cur_stats['attack'] * cur_stats['health']
-            if 'troopPods' in target_stats:
-                cur_stats['troopPods'] = cur_stats.get('troopPods', 0) + count_parts_fleetwide(fleet_id, ["GT_TROOP_POD"])
-            if (sum([len(universe.getFleet(fid).shipIDs) for fid in fleet_list]) >= nships) and stats_meet_reqs(cur_stats, target_stats):
+            if 'troopCapacity' in target_stats:
+                cur_stats['troopCapacity'] = cur_stats.get('troopCapacity', 0) + count_troops_in_fleet(fleet_id)  # ToDo: Check if replacable by troop_capacity
+            if (sum([len(universe.getFleet(fid).shipIDs) for fid in fleet_list]) >= nships)\
+                    and stats_meet_reqs(cur_stats, target_stats):
                 if verbose:
                     print "returning fleetlist: %s" % fleet_list
                 return fleet_list
@@ -320,41 +339,39 @@ def assess_fleet_role(fleet_id):
 
 
 def assess_ship_design_role(design):
-    if "CO_OUTPOST_POD" in design.parts:
+    parts = [fo.getPartType(partname) for partname in design.parts if partname]
+    if any((p.partClass == fo.shipPartClass.colony and p.capacity == 0) for p in parts):
         if design.starlaneSpeed > 0:
             return AIShipRoleType.SHIP_ROLE_CIVILIAN_OUTPOST
         else:
             return AIShipRoleType.SHIP_ROLE_BASE_OUTPOST
 
-    if "CO_COLONY_POD" in design.parts or "CO_SUSPEND_ANIM_POD" in design.parts:
+    if any((p.partClass == fo.shipPartClass.colony and p.capacity > 0 for p in parts)):
         if design.starlaneSpeed > 0:
             return AIShipRoleType.SHIP_ROLE_CIVILIAN_COLONISATION
         else:
             return AIShipRoleType.SHIP_ROLE_BASE_COLONISATION
 
-    if "GT_TROOP_POD" in design.parts:
+    if any((p.partClass == fo.shipPartClass.troops for p in parts)):
         if design.starlaneSpeed > 0:
             return AIShipRoleType.SHIP_ROLE_MILITARY_INVASION
         else:
             return AIShipRoleType.SHIP_ROLE_BASE_INVASION
 
     if design.starlaneSpeed == 0:
-        if len(design.parts) == 0 or design.parts[0] in ["SH_DEFENSE_GRID", "SH_DEFLECTOR", "SH_MULTISPEC"] or (len(design.parts) == 1 and design.parts[0] == ''):
+        if len(parts) == 0 or parts[0].partClass == fo.shipPartClass.shields:
             return AIShipRoleType.SHIP_ROLE_BASE_DEFENSE
         else:
             return AIShipRoleType.SHIP_ROLE_INVALID
 
     stats = foAI.foAIstate.get_design_id_stats(design.id)
     rating = stats['attack'] * (stats['structure'] + stats['shields'])
-    scout_names = AIShipDesignTypes.explorationShip.keys()
-    if "SD_SCOUT" in design.name(False) or design.name(False).split('-')[0] in scout_names:
-        for part in design.parts:
-            if "DT_DETECTOR" in part:
-                return AIShipRoleType.SHIP_ROLE_CIVILIAN_EXPLORATION
     if rating > 0:  # positive attack stat
         return AIShipRoleType.SHIP_ROLE_MILITARY
-    else:
-        return AIShipRoleType.SHIP_ROLE_CIVILIAN_EXPLORATION  # let this be the default since even without detection part a ship has some inherent
+    if any((p.partClass == fo.shipPartClass.detection for p in parts)):
+        return AIShipRoleType.SHIP_ROLE_CIVILIAN_EXPLORATION
+    else:   # if no suitable role found, use as (bad) scout as it still has inherent detection
+        return AIShipRoleType.SHIP_ROLE_CIVILIAN_EXPLORATION
 
 
 def generate_fleet_orders_for_fleet_missions():

--- a/default/AI/InvasionAI.py
+++ b/default/AI/InvasionAI.py
@@ -401,8 +401,8 @@ def send_invasion_fleets(fleet_ids, evaluated_planets, mission_type):
     if not invasion_fleet_pool:
         return
 
-    for pID, pscore, ptroops in evaluated_planets:
-        planet = universe.getPlanet(pID)
+    for planet_id, pscore, ptroops in evaluated_planets:
+        planet = universe.getPlanet(planet_id)
         if not planet:
             continue
         sys_id = planet.systemID
@@ -422,7 +422,7 @@ def send_invasion_fleets(fleet_ids, evaluated_planets, mission_type):
                 continue
             else:
                 these_fleets = found_fleets
-        target = AITarget.AITarget(EnumsAI.TargetType.TARGET_PLANET, pID)
+        target = AITarget.AITarget(EnumsAI.TargetType.TARGET_PLANET, planet_id)
         print "assigning invasion fleets %s to target %s" % (these_fleets, target)
         for fleetID in these_fleets:
             fleet_mission = foAI.foAIstate.get_fleet_mission(fleetID)
@@ -432,7 +432,7 @@ def send_invasion_fleets(fleet_ids, evaluated_planets, mission_type):
 
 
 def assign_invasion_fleets_to_invade():
-    """assign fleet targets to invadable planets"""
+    """Assign fleet targets to invadable planets."""
     universe = fo.getUniverse()
     empire = fo.getEmpire()
     fleet_supplyable_system_ids = empire.fleetSupplyableSystemIDs

--- a/default/AI/PriorityAI.py
+++ b/default/AI/PriorityAI.py
@@ -294,73 +294,74 @@ def calculateInvasionPriority():
     if foAI.foAIstate.aggression <= fo.aggression.turtle:
         return 0
     
-    troopsPerPod=2
-    empire=fo.getEmpire()
-    enemies_sighted = foAI.foAIstate.misc.get('enemies_sighted',{})
+    empire = fo.getEmpire()
+    enemies_sighted = foAI.foAIstate.misc.get('enemies_sighted', {})
     multiplier = 1
-    num_colonies = len( list(AIstate.popCtrIDs) )
+    num_colonies = len(list(AIstate.popCtrIDs))
     if num_colonies > colonyGrowthBarrier:
         return 0.0
     
     if len(foAI.foAIstate.colonisablePlanetIDs) > 0:
-        bestColonyScore = max( 2, foAI.foAIstate.colonisablePlanetIDs.items()[0][1][0] )
+        best_colony_score = max(2, foAI.foAIstate.colonisablePlanetIDs.items()[0][1][0])
     else:
-        bestColonyScore = 2
+        best_colony_score = 2
 
-    if foAI.foAIstate.aggression==fo.aggression.beginner and fo.currentTurn()<150:
+    if foAI.foAIstate.aggression == fo.aggression.beginner and fo.currentTurn() < 150:
         return 0
 
-    allottedInvasionTargets = 1+ int(fo.currentTurn()/25)
-    totalVal = 0
-    troopsNeeded = 0
+    allottedInvasionTargets = 1 + int(fo.currentTurn()/25)
+    total_val = 0
+    troops_needed = 0
     for pid, pscore, trp in AIstate.invasionTargets[:allottedInvasionTargets]:
-        if pscore > bestColonyScore:
+        if pscore > best_colony_score:
             multiplier += 1
-            totalVal += 2 * pscore
+            total_val += 2 * pscore
         else:
-            totalVal += pscore
-        troopsNeeded += trp+4
+            total_val += pscore
+        troops_needed += trp+4  # ToDo: This seems like it could be improved by some dynamic calculation of buffer
 
-    if totalVal == 0:
+    if total_val == 0:
         return 0
-    opponentTroopPods = int(troopsNeeded/troopsPerPod)
 
-    productionQueue = empire.productionQueue
-    queuedTroopPods=0
-    for queue_index in range(0, len(productionQueue)):
-        element=productionQueue[queue_index]
+    production_queue = empire.productionQueue
+    queued_troop_capacity = 0
+    for queue_index in range(0, len(production_queue)):
+        element = production_queue[queue_index]
         if element.buildType == EnumsAI.AIEmpireProductionTypes.BT_SHIP:
-            if foAI.foAIstate.get_ship_role(element.designID) in [ EnumsAI.AIShipRoleType.SHIP_ROLE_MILITARY_INVASION, EnumsAI.AIShipRoleType.SHIP_ROLE_BASE_INVASION] :
+            if foAI.foAIstate.get_ship_role(element.designID) in [EnumsAI.AIShipRoleType.SHIP_ROLE_MILITARY_INVASION,
+                                                                  EnumsAI.AIShipRoleType.SHIP_ROLE_BASE_INVASION]:
                 design = fo.getShipDesign(element.designID)
-                queuedTroopPods += element.remaining*element.blocksize * list(design.parts).count("GT_TROOP_POD")
-    bestShip, bestDesign, buildChoices = ProductionAI.getBestShipInfo( EnumsAI.AIPriorityType.PRIORITY_PRODUCTION_INVASION)
-    if bestDesign:
-        troopsPerBestShip = troopsPerPod*( list(bestDesign.parts).count("GT_TROOP_POD") )
+                queued_troop_capacity += element.remaining * element.blocksize * design.troopCapacity
+    _, best_design, _ = ProductionAI.getBestShipInfo(EnumsAI.AIPriorityType.PRIORITY_PRODUCTION_INVASION)
+    if best_design:
+        troops_per_best_ship = best_design.troopCapacity
     else:
-        troopsPerBestShip=troopsPerPod #may actually not have any troopers available, but this num will do for now
+        return 1e-6  # if we can not build troop ships, we don't want to build (non-existing) invasion ships
 
-    #don't cound troop bases here since if through misplanning cannot be used where made, cannot be redeployed
-    #troopFleetIDs = FleetUtilsAI.get_empire_fleet_ids_by_role(AIFleetMissionType.FLEET_MISSION_INVASION) + FleetUtilsAI.get_empire_fleet_ids_by_role(AIFleetMissionType.FLEET_MISSION_ORBITAL_INVASION)
-    troopFleetIDs = FleetUtilsAI.get_empire_fleet_ids_by_role(EnumsAI.AIFleetMissionType.FLEET_MISSION_INVASION)
-    numTroopPods = sum([ FleetUtilsAI.count_parts_fleetwide(fleetID, ["GT_TROOP_POD"]) for fleetID in troopFleetIDs])
-    troopShipsNeeded = math.ceil((opponentTroopPods - (numTroopPods+ queuedTroopPods ))/troopsPerBestShip)
+    # don't count troop bases hereas these cannot be redeployed after misplaning
+    # troopFleetIDs = FleetUtilsAI.get_empire_fleet_ids_by_role(AIFleetMissionType.FLEET_MISSION_INVASION)\
+    #                 + FleetUtilsAI.get_empire_fleet_ids_by_role(AIFleetMissionType.FLEET_MISSION_ORBITAL_INVASION)
+    troop_fleet_ids = FleetUtilsAI.get_empire_fleet_ids_by_role(EnumsAI.AIFleetMissionType.FLEET_MISSION_INVASION)
+    total_troop_capacity = sum([FleetUtilsAI.count_troops_in_fleet(fid) for fid in troop_fleet_ids])
+    troop_ships_needed = \
+        math.ceil((troops_needed - (total_troop_capacity+queued_troop_capacity)) / troops_per_best_ship)
 
-    #invasionPriority = max( 10+ 200*max(0, troopShipsNeeded ) , int(0.1* totalVal) )
-    invasionPriority = multiplier * (30+ 150*max(0, troopShipsNeeded ))
+    # invasion_priority = max( 10+ 200*max(0, troop_ships_needed ) , int(0.1* total_val) )
+    invasion_priority = multiplier * (30 + 150*max(0, troop_ships_needed))
     if not ColonisationAI.colony_status.get('colonies_under_attack', []):
         if not ColonisationAI.colony_status.get('colonies_under_threat', []):
-            invasionPriority *= 2.0
+            invasion_priority *= 2.0
         else:
-            invasionPriority *= 1.5
+            invasion_priority *= 1.5
     if not enemies_sighted:
-        invasionPriority *= 1.5
+        invasion_priority *= 1.5
         
-    if invasionPriority < 0:
+    if invasion_priority < 0:
         return 0
-    if foAI.foAIstate.aggression==fo.aggression.beginner:
-        return 0.5* invasionPriority
+    if foAI.foAIstate.aggression == fo.aggression.beginner:
+        return 0.5 * invasion_priority
     else:
-        return invasionPriority
+        return invasion_priority
 
 
 def calculateMilitaryPriority():


### PR DESCRIPTION
-new function count_troops_in_fleet(fleed_id) in FleetUtilsAI.py
-use new Ship/Design attribute troopCapacity instead of counting troop pods
-generalize the assignment to colonization and outpost ship roles to generic colonisation parts
-many PEP8-compliance edits in the functions reworked
