### PR TITLE
Implemented priority-based effects execution.

### DIFF
--- a/default/buildings.txt
+++ b/default/buildings.txt
@@ -19,17 +19,17 @@ BuildingType
         EffectsGroup
             scope = Object id = Source.PlanetID
             accountinglabel = "research_times_2"
-            priority = 101
+            priority = [[EARLY_PRIORITY]]
             effects = SetTargetResearch value = Value * 2
         EffectsGroup
             scope = Object id = Source.PlanetID
             accountinglabel = "industry_plus_5"
-            priority = 101
+            priority = [[DEFAULT_PRIORITY]]
             effects = SetTargetIndustry value = Value + 5
         EffectsGroup
             scope = Object id = Source.PlanetID
             accountinglabel = "industry_times_2"
-            priority = 100
+            priority = [[LATE_PRIORITY]]
             effects = SetTargetIndustry value = Value * 2
 */
 /*  // testing effects

--- a/default/buildings.txt
+++ b/default/buildings.txt
@@ -19,17 +19,17 @@ BuildingType
         EffectsGroup
             scope = Object id = Source.PlanetID
             accountinglabel = "research_times_2"
-            priority = 1
+            priority = 101
             effects = SetTargetResearch value = Value * 2
         EffectsGroup
             scope = Object id = Source.PlanetID
             accountinglabel = "industry_plus_5"
-            priority = 1
+            priority = 101
             effects = SetTargetIndustry value = Value + 5
         EffectsGroup
             scope = Object id = Source.PlanetID
             accountinglabel = "industry_times_2"
-            priority = 0
+            priority = 100
             effects = SetTargetIndustry value = Value * 2
 */
 /*  // testing effects

--- a/default/buildings.txt
+++ b/default/buildings.txt
@@ -9,6 +9,29 @@ BuildingType
     tags = "ANTIQUATED"
     location = Described description = "NOWHERE" condition = Not All
     effectsgroups = [
+/*  // testing priority
+    // Research should see a x2 bonus, then a +5 bonus.
+    // Industry should see a +5 bonus, then a x2 bonus.
+        EffectsGroup
+            scope = Object id = Source.PlanetID
+            accountinglabel = "research_plus_5"
+            effects = SetTargetResearch value = Value + 5
+        EffectsGroup
+            scope = Object id = Source.PlanetID
+            accountinglabel = "research_times_2"
+            priority = 1
+            effects = SetTargetResearch value = Value * 2
+        EffectsGroup
+            scope = Object id = Source.PlanetID
+            accountinglabel = "industry_plus_5"
+            priority = 1
+            effects = SetTargetIndustry value = Value + 5
+        EffectsGroup
+            scope = Object id = Source.PlanetID
+            accountinglabel = "industry_times_2"
+            priority = 0
+            effects = SetTargetIndustry value = Value * 2
+*/
 /*  // testing effects
         EffectsGroup
             scope = And [

--- a/default/shared_macros.txt
+++ b/default/shared_macros.txt
@@ -163,3 +163,16 @@ COLONY_UPKEEP_MULTIPLICATOR
 
 FLEET_UPKEEP_MULTIPLICATOR
 '''(1 + 0.01 * ShipDesignsOwned empire = Source.Owner)'''
+
+/*   E F F E C T S   P R I O R I T I E S   */
+
+// Default = 100
+
+EARLY_PRIORITY
+'''90'''
+
+DEFAULT_PRIORITY
+'''100'''
+
+LATE_PRIORITY
+'''110'''

--- a/parse/Parse.cpp
+++ b/parse/Parse.cpp
@@ -66,6 +66,7 @@ namespace {
             qi::_c_type _c;
             qi::_d_type _d;
             qi::_e_type _e;
+            qi::_f_type _f;
             qi::_val_type _val;
             qi::lit_type lit;
             using phoenix::construct;
@@ -78,12 +79,13 @@ namespace {
                 > -(parse::label(Activation_token)       > parse::detail::condition_parser [ _b = _1 ])
                 > -(parse::label(StackingGroup_token)    > tok.string [ _c = _1 ])
                 > -(parse::label(AccountingLabel_token)  > tok.string [ _e = _1 ])
+                > -(parse::label(Priority_token)         > tok.int_ [ _f = _1 ])
                 >   parse::label(Effects_token)
                 >   (
                             '[' > +parse::effect_parser() [ push_back(_d, _1) ] > ']'
                         |   parse::effect_parser() [ push_back(_d, _1) ]
                     )
-                    [ _val = new_<Effect::EffectsGroup>(_a, _b, _d, _e, _c) ]
+                    [ _val = new_<Effect::EffectsGroup>(_a, _b, _d, _e, _c, _f) ]
                 ;
 
             start
@@ -108,7 +110,8 @@ namespace {
                 Condition::ConditionBase*,
                 std::string,
                 std::vector<Effect::EffectBase*>,
-                std::string
+                std::string,
+                int
             >,
             parse::skipper_type
         > effects_group_rule;

--- a/parse/Parse.cpp
+++ b/parse/Parse.cpp
@@ -69,6 +69,7 @@ namespace {
             qi::_f_type _f;
             qi::_val_type _val;
             qi::lit_type lit;
+            qi::eps_type eps;
             using phoenix::construct;
             using phoenix::new_;
             using phoenix::push_back;
@@ -79,7 +80,7 @@ namespace {
                 > -(parse::label(Activation_token)       > parse::detail::condition_parser [ _b = _1 ])
                 > -(parse::label(StackingGroup_token)    > tok.string [ _c = _1 ])
                 > -(parse::label(AccountingLabel_token)  > tok.string [ _e = _1 ])
-                > -(parse::label(Priority_token)         > tok.int_ [ _f = _1 ])
+                > ((parse::label(Priority_token)         > tok.int_ [ _f = _1 ]) | eps [ _f = 100 ])
                 >   parse::label(Effects_token)
                 >   (
                             '[' > +parse::effect_parser() [ push_back(_d, _1) ] > ']'

--- a/parse/Tokens.h
+++ b/parse/Tokens.h
@@ -274,6 +274,7 @@
     (PreferredFocus)                            \
     (Prerequisites)                             \
     (PreviousSystemID)                          \
+    (Priority)                                  \
     (Probability)                               \
     (ProducedByEmpire)                          \
     (ProducedByEmpireID)                        \

--- a/universe/Effect.h
+++ b/universe/Effect.h
@@ -75,12 +75,13 @@ class FO_COMMON_API Effect::EffectsGroup {
 public:
     EffectsGroup(Condition::ConditionBase* scope, Condition::ConditionBase* activation,
                  const std::vector<EffectBase*>& effects, const std::string& accounting_label = "",
-                 const std::string& stacking_group = "") :
+                 const std::string& stacking_group = "", int priority = 0) :
         m_scope(scope),
         m_activation(activation),
         m_stacking_group(stacking_group),
         m_effects(effects),
-        m_accounting_label(accounting_label)
+        m_accounting_label(accounting_label),
+        m_priority(priority)
     {}
     virtual ~EffectsGroup();
 
@@ -105,6 +106,7 @@ public:
     const std::vector<EffectBase*>& EffectsList() const         { return m_effects; }
     std::string                     DescriptionString() const;
     const std::string&              AccountingLabel() const     { return m_accounting_label; }
+    int                             Priority() const      { return m_priority; }
     std::string                     Dump() const;
 
     void                            SetTopLevelContent(const std::string& content_name);
@@ -115,6 +117,7 @@ protected:
     std::string                 m_stacking_group;
     std::vector<EffectBase*>    m_effects;
     std::string                 m_accounting_label;
+    int                         m_priority;
 
 private:
     friend class boost::serialization::access;

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -2217,9 +2217,9 @@ void Universe::ExecuteEffects(const Effect::TargetsCauses& targets_causes,
     }
 
     // execute each effects group one by one
-    std::map<int, std::vector<std::pair<Effect::EffectsGroup*, Effect::TargetsCauses> > >::reverse_iterator priority_group_it;
-    for (priority_group_it = dispatched_targets_causes.rbegin();
-         priority_group_it != dispatched_targets_causes.rend(); ++priority_group_it)
+    std::map<int, std::vector<std::pair<Effect::EffectsGroup*, Effect::TargetsCauses> > >::iterator priority_group_it;
+    for (priority_group_it = dispatched_targets_causes.begin();
+         priority_group_it != dispatched_targets_causes.end(); ++priority_group_it)
     {
         std::vector<std::pair<Effect::EffectsGroup*, Effect::TargetsCauses> >::iterator effect_group_it;
         for (effect_group_it = priority_group_it->second.begin();

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -2196,10 +2196,10 @@ void Universe::ExecuteEffects(const Effect::TargetsCauses& targets_causes,
     // grouping targets causes by effects group
     // sorting by effects group has already been done in GetEffectsAndTargets()
     // FIXME: GetEffectsAndTargets already produces this separation, exploit that
-    std::vector<std::pair<Effect::EffectsGroup*, Effect::TargetsCauses> > dispatched_targets_causes;
+    std::map<int, std::vector<std::pair<Effect::EffectsGroup*, Effect::TargetsCauses> > > dispatched_targets_causes;
     {
         const Effect::EffectsGroup* last_effects_group   = 0;
-        Effect::TargetsCauses*      group_targets_causes = 0;
+        Effect::TargetsCauses*      group_targets_causes = 0; // Is this even used?  ~Bigjoe5
 
         for (Effect::TargetsCauses::const_iterator targets_it = targets_causes.begin();
              targets_it != targets_causes.end(); ++targets_it)
@@ -2209,77 +2209,82 @@ void Universe::ExecuteEffects(const Effect::TargetsCauses& targets_causes,
 
             if (effects_group != last_effects_group) {
                 last_effects_group = effects_group;
-                dispatched_targets_causes.push_back(std::make_pair(effects_group, Effect::TargetsCauses()));
-                group_targets_causes = &dispatched_targets_causes.back().second;
+                dispatched_targets_causes[effects_group->Priority()].push_back(std::make_pair(effects_group, Effect::TargetsCauses()));
+                group_targets_causes = &dispatched_targets_causes[effects_group->Priority()].back().second;
             }
             group_targets_causes->push_back(*targets_it);
         }
     }
 
     // execute each effects group one by one
-    std::vector<std::pair<Effect::EffectsGroup*, Effect::TargetsCauses> >::iterator effect_group_it;
-    for (effect_group_it = dispatched_targets_causes.begin();
-         effect_group_it != dispatched_targets_causes.end(); ++effect_group_it)
+    std::map<int, std::vector<std::pair<Effect::EffectsGroup*, Effect::TargetsCauses> > >::reverse_iterator priority_group_it;
+    for (priority_group_it = dispatched_targets_causes.rbegin();
+         priority_group_it != dispatched_targets_causes.rend(); ++priority_group_it)
     {
-        Effect::EffectsGroup*   effects_group        = effect_group_it->first;
-        Effect::TargetsCauses&  group_targets_causes = effect_group_it->second;
-        std::string             stacking_group       = effects_group->StackingGroup();
-        ScopedTimer update_timer(
-            "Universe::ExecuteEffects effgrp (" + effects_group->AccountingLabel() + ") from "
-            + boost::lexical_cast<std::string>(group_targets_causes.size()) + " sources"
-        );
+        std::vector<std::pair<Effect::EffectsGroup*, Effect::TargetsCauses> >::iterator effect_group_it;
+        for (effect_group_it = priority_group_it->second.begin();
+             effect_group_it != priority_group_it->second.end(); ++effect_group_it)
+        {
+            Effect::EffectsGroup*   effects_group        = effect_group_it->first;
+            Effect::TargetsCauses&  group_targets_causes = effect_group_it->second;
+            std::string             stacking_group       = effects_group->StackingGroup();
+            ScopedTimer update_timer(
+                "Universe::ExecuteEffects effgrp (" + effects_group->AccountingLabel() + ") from "
+                + boost::lexical_cast<std::string>(group_targets_causes.size()) + " sources"
+            );
 
-        // if other EffectsGroups or sources with the same stacking group have affected some of the 
-        // targets in the scope of the current EffectsGroup, skip them
-        // and add the remaining objects affected by it to executed_nonstacking_effects
-        if (!stacking_group.empty()) {
-            std::set<int>& non_stacking_targets = executed_nonstacking_effects[stacking_group];
+            // if other EffectsGroups or sources with the same stacking group have affected some of the 
+            // targets in the scope of the current EffectsGroup, skip them
+            // and add the remaining objects affected by it to executed_nonstacking_effects
+            if (!stacking_group.empty()) {
+                std::set<int>& non_stacking_targets = executed_nonstacking_effects[stacking_group];
 
-            for (Effect::TargetsCauses::iterator targets_it = group_targets_causes.begin();
-                 targets_it != group_targets_causes.end();)
-            {
-                Effect::TargetsAndCause&           targets_and_cause     = targets_it->second;
-                Effect::TargetSet&                 targets               = targets_and_cause.target_set;
-
-                // this is a set difference/union algorithm: 
-                // targets              -= non_stacking_targets
-                // non_stacking_targets += targets
-                for (Effect::TargetSet::iterator object_it = targets.begin();
-                        object_it != targets.end(); )
+                for (Effect::TargetsCauses::iterator targets_it = group_targets_causes.begin();
+                     targets_it != group_targets_causes.end();)
                 {
-                    int object_id                    = (*object_it)->ID();
-                    std::set<int>::const_iterator it = non_stacking_targets.find(object_id);
+                    Effect::TargetsAndCause&           targets_and_cause     = targets_it->second;
+                    Effect::TargetSet&                 targets               = targets_and_cause.target_set;
 
-                    if (it != non_stacking_targets.end()) {
-                        *object_it = targets.back();
-                        targets.pop_back();
+                    // this is a set difference/union algorithm: 
+                    // targets              -= non_stacking_targets
+                    // non_stacking_targets += targets
+                    for (Effect::TargetSet::iterator object_it = targets.begin();
+                         object_it != targets.end(); )
+                    {
+                        int object_id                    = (*object_it)->ID();
+                        std::set<int>::const_iterator it = non_stacking_targets.find(object_id);
+
+                        if (it != non_stacking_targets.end()) {
+                            *object_it = targets.back();
+                            targets.pop_back();
+                        } else {
+                            non_stacking_targets.insert(object_id);
+                            ++object_it;
+                        }
+                    }
+
+                    if (targets.empty()) {
+                        *targets_it = group_targets_causes.back();
+                        group_targets_causes.pop_back();
                     } else {
-                        non_stacking_targets.insert(object_id);
-                        ++object_it;
+                        ++targets_it;
                     }
                 }
-
-                if (targets.empty()) {
-                    *targets_it = group_targets_causes.back();
-                    group_targets_causes.pop_back();
-                } else {
-                    ++targets_it;
-                }
             }
+
+            if (group_targets_causes.empty())
+                continue;
+
+            if (log_verbose)
+                DebugLogger() << " * * * * * * * * * * * (new effects group log entry)";
+
+            // execute Effects in the EffectsGroup
+            effects_group->Execute(group_targets_causes,
+                update_effect_accounting ? &m_effect_accounting_map : NULL,
+                only_meter_effects,
+                only_appearance_effects,
+                include_empire_meter_effects);
         }
-
-        if (group_targets_causes.empty())
-            continue;
-
-        if (log_verbose)
-            DebugLogger() << " * * * * * * * * * * * (new effects group log entry)";
-
-        // execute Effects in the EffectsGroup
-        effects_group->Execute(group_targets_causes,
-                               update_effect_accounting ? &m_effect_accounting_map : NULL,
-                               only_meter_effects,
-                               only_appearance_effects,
-                               include_empire_meter_effects);
     }
 
     // actually do destroy effect action.  Executing the effect just marks


### PR DESCRIPTION
Added parsing for effects group priority, and altered the ExecuteEffects method to sort out the effects by priority before executing them from highest to lowest priority.  The previous effects ordering should still be effective as a secondary ordering.

Basically everything below line 2223 in the Universe.cpp diff is just the previous loop getting an extra indent for the new priority loop, so don't waste too much time looking at that.
