### PR TITLE
Hide dict_from_map_usage.

### DIFF
--- a/default/AI/AIFleetMission.py
+++ b/default/AI/AIFleetMission.py
@@ -10,8 +10,6 @@ import ProductionAI
 import MilitaryAI
 import InvasionAI
 import PlanetUtilsAI
-import math
-from freeorion_tools import dict_from_map
 from AITarget import AITarget
 from EnumsAI import FLEET_MISSION_TYPES, AIFleetMissionType, AIFleetOrderType
 

--- a/default/AI/AIFleetOrder.py
+++ b/default/AI/AIFleetOrder.py
@@ -5,7 +5,6 @@ import FreeOrionAI as foAI
 import MilitaryAI
 import MoveUtilsAI
 import PlanetUtilsAI
-from freeorion_tools import dict_from_map
 
 AIFleetOrderTypeNames = AIFleetOrderType()
 AIFleetMissionTypeNames = AIFleetMissionType()

--- a/default/AI/AIstate.py
+++ b/default/AI/AIstate.py
@@ -12,7 +12,7 @@ import ResourcesAI
 from EnumsAI import AIFleetMissionType, AIExplorableSystemType, TargetType
 from MilitaryAI import MinThreat
 import PlanetUtilsAI
-from freeorion_tools import dict_from_map, get_ai_tag_grade
+from freeorion_tools import get_ai_tag_grade
 
 
 ## moving ALL or NEARLY ALL 'global' variables into AIState object rather than module
@@ -444,7 +444,7 @@ class AIstate(object):
                 sysStatus['myFleetRating'] = myattack * myhealth
 
             system = universe.getSystem(sysID)
-            neighborDict = dict_from_map(universe.getSystemNeighborsMap(sysID, self.empireID))
+            neighborDict = universe.getSystemNeighborsMap(sysID, self.empireID)
             neighbors = set(neighborDict.keys())
             sysStatus['neighbors'] = neighbors
             

--- a/default/AI/ColonisationAI.py
+++ b/default/AI/ColonisationAI.py
@@ -11,7 +11,7 @@ import ProductionAI
 import TechsListsAI
 from EnumsAI import AIFleetMissionType, AIExplorableSystemType, TargetType, AIFocusType
 import EnumsAI
-from freeorion_tools import dict_from_map, tech_is_complete, get_ai_tag_grade
+from freeorion_tools import tech_is_complete, get_ai_tag_grade
 from freeorion_debug import Timer
 
 colonization_timer = Timer('getColonyFleets()')
@@ -167,7 +167,7 @@ def check_supply():
     new_supply_map = empire.supplyProjections(-3, False)
     print "New Supply Calc:"
     print "Known Systems:", list(universe.systemIDs)
-    print "Base Supply:", dict_from_map(empire.systemSupplyRanges)
+    print "Base Supply:", empire.systemSupplyRanges
     for el in new_supply_map:
         # print PlanetUtilsAI.sys_name_ids([el.key()]), ' -- ', el.data()
         systems_by_supply_tier.setdefault(min(0, el.data()), []).append(el.key())
@@ -468,8 +468,7 @@ def get_colony_fleets():
     print "Outpost Fleets Without Missions: %s" % num_outpost_fleets
     colonization_timer.start('Identify colony base targets')
 
-    available_pp = dict([(tuple(el.key()), el.data()) for el in
-                         empire.planetsWithAvailablePP])  # keys are sets of ints; data is doubles
+    available_pp = empire.planetsWithAvailablePP  # keys are tuple of unique ints; values are doubles
     avail_pp_by_sys = {}
     for p_set in available_pp:
         avail_pp_by_sys.update([(sys_id, available_pp[p_set]) for sys_id in set(PlanetUtilsAI.get_systems(p_set))])

--- a/default/AI/ExplorationAI.py
+++ b/default/AI/ExplorationAI.py
@@ -5,7 +5,6 @@ from EnumsAI import AIFleetMissionType, TargetType
 import AITarget
 import MoveUtilsAI
 import PlanetUtilsAI
-from freeorion_tools import dict_from_map
 
 
 TARGET_POP = 'targetPop'
@@ -149,8 +148,7 @@ def follow_vis_system_connections(start_system_id, home_system_id):
             foAI.foAIstate.visInteriorSystemIDs[cur_system_id] = 1
             if cur_system_id in foAI.foAIstate.visBorderSystemIDs:
                 del foAI.foAIstate.visBorderSystemIDs[cur_system_id]
-            #neighbors= dict( [(el.key(), el.data()) for el in universe.getSystemNeighborsMap(cur_system_id, empire_id)] )  #
-            neighbors = set(dict_from_map(universe.getSystemNeighborsMap(cur_system_id, empire_id)).keys())
+            neighbors = set(universe.getSystemNeighborsMap(cur_system_id, empire_id))
             sys_status.setdefault('neighbors', set()).update(neighbors)
             sys_planets = sys_status.setdefault('planets', {})
             if fo.currentTurn() < 50:

--- a/default/AI/FleetUtilsAI.py
+++ b/default/AI/FleetUtilsAI.py
@@ -123,7 +123,7 @@ def get_fleets_for_mission(nships, target_stats, min_stats, cur_stats, species, 
                 return fleet_list
     # finished loop without meeting reqs
     if extend_search:
-        for neighborID in [el.key() for el in universe.getSystemNeighborsMap(this_system_id, foAI.foAIstate.empireID)]:
+        for neighborID in universe.getSystemNeighborsMap(this_system_id, foAI.foAIstate.empireID):
             if neighborID not in systems_checked and neighborID not in systems_to_check and neighborID in foAI.foAIstate.exploredSystemIDs:
                 systems_to_check.append(neighborID)
     try:

--- a/default/AI/InvasionAI.py
+++ b/default/AI/InvasionAI.py
@@ -86,9 +86,8 @@ def get_invasion_fleets():
     reserved_troop_base_targets = []
     if foAI.foAIstate.aggression > fo.aggression.typical:
         available_pp = {}
-        for el in empire.planetsWithAvailablePP:  # keys are sets of ints; data is doubles
-            avail_pp = el.data()
-            for pid in el.key():
+        for planets, avail_pp in empire.planetsWithAvailablePP.items():  # keys are tuple of unique ints; values are doubles
+            for pid in planets:
                 available_pp[pid] = avail_pp
         for pid in invadable_planet_ids:  # TODO: reorganize
             planet = universe.getPlanet(pid)

--- a/default/AI/ProductionAI.py
+++ b/default/AI/ProductionAI.py
@@ -10,12 +10,12 @@ import PriorityAI
 import ColonisationAI
 import EnumsAI
 import MilitaryAI
-from freeorion_tools import dict_from_map, ppstring
+from freeorion_tools import ppstring
 from TechsListsAI import EXOBOT_TECH_NAME
 from freeorion_tools import print_error
 
 bestMilRatingsHistory = {}  # dict of (rating, cost) keyed by turn
-design_cost_cache = {0: {(-1, -1): 0}} #outer dict indexed by cur_turn (currently only one turn kept); inner dict indexed by (design_id, pid)
+design_cost_cache = {0: {(-1, -1): 0}}  # outer dict indexed by cur_turn (currently only one turn kept); inner dict indexed by (design_id, pid)
 shipTypeMap = {EnumsAI.AIPriorityType.PRIORITY_PRODUCTION_EXPLORATION: EnumsAI.AIShipDesignTypes.explorationShip,
                EnumsAI.AIPriorityType.PRIORITY_PRODUCTION_OUTPOST: EnumsAI.AIShipDesignTypes.outpostShip,
                EnumsAI.AIPriorityType.PRIORITY_PRODUCTION_ORBITAL_OUTPOST: EnumsAI.AIShipDesignTypes.outpostBase,
@@ -677,8 +677,8 @@ def generateProductionOrders():
     productionQueue = empire.productionQueue
     totalPP = empire.productionPoints
     #prodResPool = empire.getResourcePool(fo.resourceType.industry)
-    #availablePP = dict_from_map(productionQueue.availablePP(prodResPool))
-    #allocatedPP = dict_from_map(productionQueue.allocatedPP)
+    # availablePP = productionQueue.availablePP(prodResPool)
+    # allocatedPP = productionQueue.allocatedPP
     #objectsWithWastedPP = productionQueue.objectsWithWastedPP(prodResPool)
     currentTurn = fo.currentTurn()
     print
@@ -1480,7 +1480,7 @@ def generateProductionOrders():
             if sysID in scannerLocs:
                 continue
             needScanner=False
-            for nSys in dict_from_map(universe.getSystemNeighborsMap(sysID, empire.empireID)):
+            for nSys in universe.getSystemNeighborsMap(sysID, empire.empireID):
                 if universe.getVisibility(nSys, empire.empireID) < fo.visibility.partial:
                     needScanner=True
                     break
@@ -1517,7 +1517,7 @@ def generateProductionOrders():
                                                (covered_drydoc_locs, covered_drydoc_locs) ]:  #coverage of neighbors up to 2 jumps away from a drydock
             for dd_sys_id in start_set.copy():
                 dest_set.add(dd_sys_id)
-                dd_neighbors = dict_from_map(universe.getSystemNeighborsMap(dd_sys_id, empire.empireID))
+                dd_neighbors = universe.getSystemNeighborsMap(dd_sys_id, empire.empireID)
                 dest_set.update( dd_neighbors.keys() )
             
         max_dock_builds = int(0.8 + empire.productionPoints/120.0)
@@ -1548,7 +1548,7 @@ def generateProductionOrders():
                 if res:
                     queued_locs.append( planet.systemID )
                     covered_drydoc_locs.add( planet.systemID )
-                    dd_neighbors = dict_from_map(universe.getSystemNeighborsMap(planet.systemID, empire.empireID))
+                    dd_neighbors = universe.getSystemNeighborsMap(planet.systemID, empire.empireID)
                     covered_drydoc_locs.update( dd_neighbors.keys() )
                     if max_dock_builds >= 2:
                         res=fo.issueRequeueProductionOrder(productionQueue.size -1, 0) # move to front
@@ -1716,8 +1716,8 @@ def generateProductionOrders():
         filteredPriorities[pty] **= scalingPower
 
 
-    availablePP = dict( [ (tuple(el.key()), el.data() ) for el in empire.planetsWithAvailablePP ])  #keys are sets of ints; data is doubles
-    allocatedPP = dict( [ (tuple(el.key()), el.data() ) for el in empire.planetsWithAllocatedPP ])  #keys are sets of ints; data is doubles
+    availablePP = empire.planetsWithAvailablePP  # keys are tuple of unique ints; values are doubles
+    allocatedPP = empire.planetsWithAllocatedPP  # keys are tuple of unique ints; values are doubles
     planetsWithWastedPP = set( [tuple(pidset) for pidset in empire.planetsWithWastedPP ] )
     print "availPP ( <systems> : pp ):"
     for pSet in availablePP:

--- a/default/AI/freeorion_debug/extend_free_orion_AI_interface.py
+++ b/default/AI/freeorion_debug/extend_free_orion_AI_interface.py
@@ -63,6 +63,21 @@ def to_map(method):
     return wrapper
 
 fo.universe.getVisibilityTurnsMap = to_map(fo.universe.getVisibilityTurnsMap)
+fo.universe.getSystemNeighborsMap = to_map(fo.universe.getSystemNeighborsMap)
+fo.productionQueue.availablePP = to_map(fo.productionQueue.availablePP)
+
+# update properties
+fo.empire.__systemSupplyRanges = fo.empire.systemSupplyRanges
+fo.empire.systemSupplyRanges = property(lambda self: dict_from_map(self.__systemSupplyRanges))
+
+fo.productionQueue.__allocatedPP = fo.productionQueue.allocatedPP
+fo.productionQueue.allocatedPP = property(lambda self: dict_from_map(self.__allocatedPP))
+
+fo.empire.__planetsWithAvailablePP = fo.empire.planetsWithAvailablePP
+fo.empire.planetsWithAvailablePP = property(lambda self: dict_from_map(self.__planetsWithAvailablePP))
+
+fo.empire.__planetsWithAllocatedPP = fo.empire.planetsWithAllocatedPP
+fo.empire.planetsWithAllocatedPP = property(lambda self: dict_from_map(self.__planetsWithAllocatedPP))
 
 
 def to_str(prefix, id, name):

--- a/default/AI/freeorion_tools.py
+++ b/default/AI/freeorion_tools.py
@@ -12,9 +12,20 @@ RED = '<rgba 255 0 0 255>%s</rgba>'
 WHITE = '<rgba 255 255 255 255>%s</rgba>'
 
 
+def __set_to_tuple(key):
+    """
+    Convert set to tuple, python does not support set as dict key.
+    Best hashable analog in python is frozenset, but all code examples used tuple.
+    """
+    if isinstance(key, set):
+        return tuple(key)
+    else:
+        return key
+
+
 def dict_from_map(thismap):
     """Convert C++ map to python dict."""
-    return {el.key(): el.data() for el in thismap}
+    return {__set_to_tuple(el.key()): el.data() for el in thismap}
 
 
 def get_ai_tag_grade(tag_list, tag_type):


### PR DESCRIPTION
### Update `freeOrionAIInterface`  from python side
- hide all `dict_from_map` calls from user. 
- convert functions and properties that return resPoolMap to return dict {tuple:int}
