### PR TITLE
Post combat visibility

### DIFF
--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -79,7 +79,8 @@ CombatInfo::CombatInfo(int system_id_, int turn_) :
     // objects again to assemble each participant empire's latest
     // known information about all objects in this battle
 
-    // system
+    // system and empire visibility of all objects in it
+    std::vector< int > local_object_ids = Objects().FindObjectIDs();
     for (std::set<int>::const_iterator empire_it = empire_ids.begin();
          empire_it != empire_ids.end(); ++empire_it)
     {
@@ -87,6 +88,12 @@ CombatInfo::CombatInfo(int system_id_, int turn_) :
         if (empire_id == ALL_EMPIRES)
             continue;
         empire_known_objects[empire_id].Insert(GetEmpireKnownSystem(system->ID(), empire_id));
+        empire_object_visibility[empire_id][system->ID()] = GetUniverse().GetObjectVisibilityByEmpire(empire_id, system->ID());
+        for (std::vector< int >::iterator obj_it = local_object_ids.begin(); obj_it != local_object_ids.end(); obj_it++) {
+            Visibility obj_vis = GetUniverse().GetObjectVisibilityByEmpire(empire_id, *obj_it);
+            if (obj_vis > VIS_NO_VISIBILITY)  // to ensure an empire doesn't wrongly get info that an object was present
+                empire_object_visibility[empire_id][*obj_it] = obj_vis;
+        }
     }
 
     // ships
@@ -896,10 +903,10 @@ namespace {
             // Also ensure that attacker (and their fleet if attacker was a ship) are
             // revealed with at least BASIC_VISIBILITY to the taget empire
             combat_state.combat_info.empire_object_visibility[target->Owner()][attacker->ID()] = 
-                    std::max(GetUniverse().GetObjectVisibilityByEmpire(attacker->ID(), target->Owner()), VIS_BASIC_VISIBILITY);
+                    std::max(combat_state.combat_info.empire_object_visibility[target->Owner()][attacker->ID()], VIS_BASIC_VISIBILITY);
             if (attacker->ObjectType() == OBJ_SHIP && attacker->ContainerObjectID() != INVALID_OBJECT_ID) {
                 combat_state.combat_info.empire_object_visibility[target->Owner()][attacker->ContainerObjectID()] = 
-                        std::max(GetUniverse().GetObjectVisibilityByEmpire(attacker->ContainerObjectID(), target->Owner()), VIS_BASIC_VISIBILITY);
+                        std::max(combat_state.combat_info.empire_object_visibility[target->Owner()][attacker->ContainerObjectID()], VIS_BASIC_VISIBILITY);
             }
         } // end for over weapons
     }

--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -80,7 +80,7 @@ CombatInfo::CombatInfo(int system_id_, int turn_) :
     // known information about all objects in this battle
 
     // system and empire visibility of all objects in it
-    std::vector< int > local_object_ids = system->ContainedObjectIDs();
+    std::set< int > local_object_ids = system->ContainedObjectIDs();
     for (std::set<int>::const_iterator empire_it = empire_ids.begin();
          empire_it != empire_ids.end(); ++empire_it)
     {
@@ -89,7 +89,7 @@ CombatInfo::CombatInfo(int system_id_, int turn_) :
             continue;
         empire_known_objects[empire_id].Insert(GetEmpireKnownSystem(system->ID(), empire_id));
         empire_object_visibility[empire_id][system->ID()] = GetUniverse().GetObjectVisibilityByEmpire(empire_id, system->ID());
-        for (std::vector< int >::iterator obj_it = local_object_ids.begin(); obj_it != local_object_ids.end(); obj_it++) {
+        for (std::set< int >::iterator obj_it = local_object_ids.begin(); obj_it != local_object_ids.end(); obj_it++) {
             Visibility obj_vis = GetUniverse().GetObjectVisibilityByEmpire(empire_id, *obj_it);
             if (obj_vis > VIS_NO_VISIBILITY)  // to ensure an empire doesn't wrongly get info that an object was present
                 empire_object_visibility[empire_id][*obj_it] = obj_vis;

--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -80,7 +80,7 @@ CombatInfo::CombatInfo(int system_id_, int turn_) :
     // known information about all objects in this battle
 
     // system and empire visibility of all objects in it
-    std::vector< int > local_object_ids = Objects().FindObjectIDs();
+    std::vector< int > local_object_ids = system->ContainedObjectIDs();
     for (std::set<int>::const_iterator empire_it = empire_ids.begin();
          empire_it != empire_ids.end(); ++empire_it)
     {

--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -889,10 +889,18 @@ namespace {
             // do actual attacks
             Attack(attacker, *weapon_it, target, combat_state.combat_info, bout, round);
 
-            // mark attackers as valid targets for attacked object's owners, so
-            // attacker they can be counter-attacked in subsequent rounds if it
+            // mark attacker as valid target for attacked object's owner, so that regardless
+            // of visibility the attacker can be counter-attacked in subsequent rounds if it
             // was not already attackable
             combat_state.empire_infos[target->Owner()].target_ids.insert(attacker->ID());
+            // Also ensure that attacker (and their fleet if attacker was a ship) are
+            // revealed with at least BASIC_VISIBILITY to the taget empire
+            combat_state.combat_info.empire_object_visibility[target->Owner()][attacker->ID()] = 
+                    std::max(GetUniverse().GetObjectVisibilityByEmpire(attacker->ID(), target->Owner()), VIS_BASIC_VISIBILITY);
+            if (attacker->ObjectType() == OBJ_SHIP && attacker->ContainerObjectID() != INVALID_OBJECT_ID) {
+                combat_state.combat_info.empire_object_visibility[target->Owner()][attacker->ContainerObjectID()] = 
+                        std::max(GetUniverse().GetObjectVisibilityByEmpire(attacker->ContainerObjectID(), target->Owner()), VIS_BASIC_VISIBILITY);
+            }
         } // end for over weapons
     }
 

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1666,8 +1666,8 @@ namespace {
                  empire_it != combat_info.empire_object_visibility.end(); ++empire_it)
             {
                 for (Universe::ObjectVisibilityMap::const_iterator object_it = empire_it->second.begin(); object_it != empire_it->second.end(); ++object_it) {
-                    Visibility vis = object_it->second;
-                    universe.SetEmpireObjectVisibility(empire_it->first, object_it->first, vis);
+                    if (object_it->second > GetUniverse().GetObjectVisibilityByEmpire(empire_it->first, object_it->first))
+                        universe.SetEmpireObjectVisibility(empire_it->first, object_it->first, object_it->second);
                 }
             }
 

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1661,6 +1661,16 @@ namespace {
             // indexed by fleet id, which empire ids to inform that a fleet is destroyed
             std::map<int, std::set<int> > empires_to_update_of_fleet_destruction;
 
+            // update visibilities.
+            for (Universe::EmpireObjectVisibilityMap::const_iterator empire_it = combat_info.empire_object_visibility.begin();
+                 empire_it != combat_info.empire_object_visibility.end(); ++empire_it)
+            {
+                for (Universe::ObjectVisibilityMap::const_iterator object_it = empire_it->second.begin(); object_it != empire_it->second.end(); ++object_it) {
+                    Visibility vis = object_it->second;
+                    universe.SetEmpireObjectVisibility(empire_it->first, object_it->first, vis);
+                }
+            }
+
             // update which empires know objects are destroyed.  this may
             // duplicate the destroyed object knowledge that is set when the
             // object is destroyed with Universe::Destroy, but there may also
@@ -2745,6 +2755,8 @@ void ServerApp::ProcessCombats() {
     UpdateEmpireCombatDestructionInfo(combats);
 
     DisseminateSystemCombatInfo(combats);
+    // update visibilities with any new info gleaned during combat
+    m_universe.UpdateEmpireLatestKnownObjectsAndVisibilityTurns();
 
     CreateCombatSitReps(combats);
 

--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -134,6 +134,10 @@ void Fleet::Copy(TemporaryPtr<const UniverseObject> copied_object, int empire_id
         this->m_arrived_this_turn =             copied_fleet->m_arrived_this_turn;
         this->m_arrival_starlane =              copied_fleet->m_arrival_starlane;
 
+        Meter* stealth_meter = this->GetMeter(METER_STEALTH);
+        const Meter* copied_stealth_meter = copied_fleet->GetMeter(METER_STEALTH);
+        stealth_meter->Set(copied_stealth_meter->Current(), copied_stealth_meter->Initial());
+        
         if (vis >= VIS_PARTIAL_VISIBILITY) {
             this->m_aggressive =                copied_fleet->m_aggressive;
             if (this->Unowned())

--- a/universe/Ship.cpp
+++ b/universe/Ship.cpp
@@ -124,6 +124,9 @@ void Ship::Copy(TemporaryPtr<const UniverseObject> copied_object, int empire_id)
             if (TemporaryPtr<Fleet> oldFleet = GetFleet(this->m_fleet_id)) 
                 oldFleet->RemoveShip(this->ID());
             this->m_fleet_id =              copied_ship->m_fleet_id; // as with other containers (Systems), actual insertion into fleet ships set is handled by the fleet
+        Meter* stealth_meter = this->GetMeter(METER_STEALTH);
+        const Meter* copied_stealth_meter = copied_ship->GetMeter(METER_STEALTH);
+        stealth_meter->Set(copied_stealth_meter->Current(), copied_stealth_meter->Initial());
         }
 
         if (vis >= VIS_PARTIAL_VISIBILITY) {


### PR DESCRIPTION
So, this PR is just submitted for discussion; it is a derivation from  Mitten's PR #29.  I only wound up using a portion of lines from that & so these commits just start from scratch rather than start from his and then revert 70% of it.  Perhaps I should do just that, though, or perhaps just make a new commit in his name with the portion of his that I kept-- someone with more experience with standard git practice please advise about recommended protocol here.

Anyway, I think this accomplishes 95% of what we want for this.  With this, stealthed attackers reveal Basic Visibility of themselves to their targets (as opposed to the Partial Vis granted in the Mittens PR).  It is broken into two commits in case Geoff prefers some other way than what I have in the second commit to deal with the MapWnd suppression issue, perhaps by adjusting the Universe::UpdateEmpireStaleObjectKnowledge() algorithm.  Geoff, I think this does address all your concerns mentioned regarding PR #29 (in our forum thread on it).

Below is a screenshot immediately post-combat after a stealthed Asteroid Snail killed my scout. ![post combat ghost ship](http://i.imgur.com/BaPrvAg.png).  Once I research Active Radar and observe the snail, its icon on the map, etc., gets updated properly.  The reason I say this is currently only 95% of what we want is because if the "Ship" link in the combat log is not working as an active link, and I haven't figured out why.  
