### PR TITLE
Basic diplomacy

### DIFF
--- a/AI/PythonAI.cpp
+++ b/AI/PythonAI.cpp
@@ -38,6 +38,7 @@ using boost::python::import;
 using boost::python::error_already_set;
 using boost::python::exec;
 using boost::python::dict;
+using boost::python::list;
 using boost::python::extract;
 
 
@@ -76,6 +77,17 @@ namespace {
             parts.push_back(boost::python::extract<std::string>(partsList[i]));
         int result = AIInterface::IssueCreateShipDesignOrder(name, description, hull, parts, icon, model, nameDescInStringTable);
         return result;
+    }
+
+    boost::python::list GetUserStringList(const std::string& list_key) {
+        std::list<std::string> retval;
+        UserStringList(list_key, retval);
+        boost::python::list ret_list;
+        for (std::list< std::string >::iterator it = retval.begin(); it != retval.end(); it++)
+            ret_list.append(*it);
+//         boost::python::object get_iter = boost::python::iterator<std::list<std::string> >();
+//         boost::python::object iter = get_iter(retval);
+        return ret_list;
     }
 }
 
@@ -162,7 +174,9 @@ BOOST_PYTHON_MODULE(freeOrionAIInterface)
     def("getSaveStateString",       GetStaticSaveStateString,       return_value_policy<copy_const_reference>());
 
     def("doneTurn",                 AIInterface::DoneTurn);
-    def("userString",               make_function(&UserString,      return_value_policy<copy_const_reference>()));
+    def("userString",               make_function(&UserString,          return_value_policy<copy_const_reference>()));
+    def("userStringExists",         make_function(&UserStringExists,    return_value_policy<return_by_value>()));
+    def("userStringList",           &GetUserStringList);
 
     def("getGalaxySetupData",       AIInterface::GetGalaxySetupData,    return_value_policy<copy_const_reference>());
 

--- a/default/AI/AIstate.py
+++ b/default/AI/AIstate.py
@@ -1101,7 +1101,7 @@ class AIstate(object):
         log_index = (initiating_empire_id, recipient_empire_id)
         peace_requests.setdefault(log_index, []).append(fo.currentTurn())
 
-    def log_war_declarations(self, initiating_empire_id, recipient_empire_id):
+    def log_war_declaration(self, initiating_empire_id, recipient_empire_id):
         """Keep a record of war declarations made or received by this empire."""
 
         # if war declaration is made on turn 1, don't hold it against them

--- a/default/AI/AIstate.py
+++ b/default/AI/AIstate.py
@@ -62,6 +62,7 @@ class AIstate(object):
         self.__fleetRoleByID = {}
         self.designStats = {}
         self.design_rating_adjustments = {}
+        self.diplomatic_logs = {}
         self.__priorityByType = {}
 
         #self.__explorableSystemByType = {}
@@ -110,7 +111,8 @@ class AIstate(object):
         for dict_attrib in ['qualifyingColonyBaseTargets',
                             'qualifyingOutpostBaseTargets',
                             'qualifyingTroopBaseTargets',
-                            'planet_status']:
+                            'planet_status',
+                            'diplomatic_logs']:
             if dict_attrib not in state_dict:
                 self.__dict__[dict_attrib] = {}
         for std_attrib in ['empire_standard_fighter', 'empire_standard_enemy']:
@@ -1091,3 +1093,20 @@ class AIstate(object):
                 print "\t from splitting fleet ID %4d with %d ships, got %d new fleets:" % (fleet_id, fleet_len, len(new_fleets))
                 # old fleet may have different role after split, later will be again identified
                 #self.remove_fleet_role(fleet_id)  # in current system, orig new fleet will not yet have been assigned a role
+
+    def log_peace_request(self, initiating_empire_id, recipient_empire_id):
+        """Keep a record of peace requests made or received by this empire."""
+
+        peace_requests = self.diplomatic_logs.setdefault('peace_requests', {})
+        log_index = (initiating_empire_id, recipient_empire_id)
+        peace_requests.setdefault(log_index, []).append(fo.currentTurn())
+
+    def log_war_declarations(self, initiating_empire_id, recipient_empire_id):
+        """Keep a record of war declarations made or received by this empire."""
+
+        # if war declaration is made on turn 1, don't hold it against them
+        if fo.currentTurn() == 1:
+            return
+        war_declarations = self.diplomatic_logs.setdefault('war_declarations', {})
+        log_index = (initiating_empire_id, recipient_empire_id)
+        war_declarations.setdefault(log_index, []).append(fo.currentTurn())

--- a/default/AI/DiplomaticCorp.py
+++ b/default/AI/DiplomaticCorp.py
@@ -1,0 +1,78 @@
+"""Handle diplomatic messages and response determination."""
+
+import random
+
+import freeOrionAIInterface as fo  # pylint: disable=import-error
+import FreeOrionAI as foAI
+import AIstate
+from freeorion_tools import UserString, UserStringList, chat_on_error, print_error
+
+
+@chat_on_error
+def handle_diplomatic_message(message):  # pylint: disable=invalid-name
+    """Handle a diplomatic message update from the server,
+    such as if another player declares war, accepts peace, or cancels a proposed peace treaty.
+    :param message:
+    :return:
+    """
+    print "Received diplomatic %s message from empire %s to empire %s" % (message.type, message.sender, message.recipient)
+    print "my empire id: %s" % fo.empireID()
+    if message.recipient != fo.empireID():
+        return
+    reply_sender = message.recipient
+    reply_recipient = message.sender
+    if message.type == fo.diplomaticMessageType.peaceProposal:
+        foAI.foAIstate.log_peace_request(message.sender, message.recipient)
+        proposal_sender_player = fo.empirePlayerID(message.sender)
+        suffix = "MILD" if foAI.foAIstate.aggression <= fo.aggression.typical else "HARSH"
+        possible_acknowledgments = UserStringList("AI_PEACE_PROPOSAL_ACKNOWLEDGEMENTS_" + suffix + "_LIST")
+        acknowledgement = random.choice(possible_acknowledgments)
+        print "Acknowledging proposal with initial message (from %d choices): '%s'" % \
+              (len(possible_acknowledgments), acknowledgement)
+        fo.sendChatMessage(proposal_sender_player, acknowledgement)
+        attitude = evaluate_diplomatic_attitude(message.sender)
+        if attitude > 0:
+            reply_text = random.choice(UserStringList("AI_PEACE_PROPOSAL_RESPONSES_YES_" + suffix + "_LIST"))
+            diplo_reply = fo.diplomaticMessage(reply_sender, reply_recipient, fo.diplomaticMessageType.acceptProposal)
+        else:
+            reply_text = random.choice(UserStringList("AI_PEACE_PROPOSAL_RESPONSES_NO_" + suffix + "_LIST"))
+            diplo_reply = None
+        fo.sendChatMessage(proposal_sender_player, reply_text)
+        print "sending chat to player %d of empire %d, message body: '%s'" % \
+              (proposal_sender_player, reply_recipient, reply_text)
+        if diplo_reply:
+            print "Sending diplomatic message to empire %s of type %s" % (reply_recipient, diplo_reply.type)
+            fo.sendDiplomaticMessage(diplo_reply)
+    elif message.type == fo.diplomaticMessageType.warDeclaration:
+        foAI.foAIstate.log_peace_request(message.sender, message.recipient)
+
+
+
+@chat_on_error
+def handle_diplomatic_status_update(status_update):  # pylint: disable=invalid-name
+    """Handle an update about the diplomatic status between players, which may
+    or may not include this player."""
+    print "Received diplomatic status update to %s about empire %s and empire %s" % \
+          (status_update.status, status_update.empire1, status_update.empire2)
+
+
+@chat_on_error
+def evaluate_diplomatic_attitude(other_empire_id):
+    """Evaluate this empire's diplomatic attitude regarding the other empire.
+    :param other_empire_id: integer
+    :return: a numeric rating, currently in the range [-10 : 10]
+    """
+
+    # TODO: consider proximity, competitive needs, relations with other empires, past history with this empire, etc.
+    # in the meantime, somewhat random
+    if foAI.foAIstate.aggression == fo.aggression.maniacal:
+        return -9
+    elif foAI.foAIstate.aggression == fo.aggression.beginner:
+        return 9
+    log_index = (other_empire_id, fo.empireID())
+    num_peace_requests = len(foAI.foAIstate.diplomatic_logs.get('peace_requests', {}).get(log_index, []))
+    num_war_declarations = len(foAI.foAIstate.diplomatic_logs.get('war_declarations', {}).get(log_index, []))
+    # Too many requests for peace irritate the AI, as do any war declarations
+    irritation = (foAI.foAIstate.aggression * (2.0 + num_peace_requests/10.0 + 2.0 * num_war_declarations) + 0.5)
+    attitude = 10 * random.random() - irritation
+    return min(10, max(-10, attitude))

--- a/default/AI/DiplomaticCorp.py
+++ b/default/AI/DiplomaticCorp.py
@@ -44,7 +44,7 @@ def handle_diplomatic_message(message):  # pylint: disable=invalid-name
             print "Sending diplomatic message to empire %s of type %s" % (reply_recipient, diplo_reply.type)
             fo.sendDiplomaticMessage(diplo_reply)
     elif message.type == fo.diplomaticMessageType.warDeclaration:
-        foAI.foAIstate.log_peace_request(message.sender, message.recipient)
+        foAI.foAIstate.log_war_declaration(message.sender, message.recipient)
 
 
 

--- a/default/AI/FreeOrionAI.py
+++ b/default/AI/FreeOrionAI.py
@@ -19,7 +19,7 @@ import PriorityAI
 import ProductionAI
 import ResearchAI
 import ResourcesAI
-from freeorion_tools import UserString, chat_on_error, print_error
+from freeorion_tools import UserString, UserStringList, chat_on_error, print_error
 from freeorion_debug import Timer
 
 main_timer = Timer('timer', write_log=True)
@@ -34,12 +34,12 @@ except:
     pass
 
 
-_capitols = {fo.aggression.beginner: UserString("AI_CAPITOL_NAMES_BEGINNER", ""),
-             fo.aggression.turtle: UserString("AI_CAPITOL_NAMES_TURTLE", ""),
-             fo.aggression.cautious: UserString("AI_CAPITOL_NAMES_CAUTIOUS", ""),
-             fo.aggression.typical: UserString("AI_CAPITOL_NAMES_TYPICAL", ""),
-             fo.aggression.aggressive: UserString("AI_CAPITOL_NAMES_AGGRESSIVE", ""),
-             fo.aggression.maniacal: UserString("AI_CAPITOL_NAMES_MANIACAL", "")}
+_capitals = {fo.aggression.beginner: UserStringList("AI_CAPITOL_NAMES_BEGINNER"),
+             fo.aggression.turtle: UserStringList("AI_CAPITOL_NAMES_TURTLE"),
+             fo.aggression.cautious: UserStringList("AI_CAPITOL_NAMES_CAUTIOUS"),
+             fo.aggression.typical: UserStringList("AI_CAPITOL_NAMES_TYPICAL"),
+             fo.aggression.aggressive: UserStringList("AI_CAPITOL_NAMES_AGGRESSIVE"),
+             fo.aggression.maniacal: UserStringList("AI_CAPITOL_NAMES_MANIACAL")}
 
 # AIstate
 foAIstate = None
@@ -68,8 +68,8 @@ def startNewGame(aggression=fo.aggression.aggressive):  # pylint: disable=invali
     universe = fo.getUniverse()
     if planet_id is not None and planet_id != -1:
         planet = universe.getPlanet(planet_id)
-        new_name = random.choice(_capitols.get(aggression, "").split('\n')).strip() + " " + planet.name
-        print "Capitol City Names are: ", _capitols
+        new_name = " ".join([random.choice(_capitals.get(aggression, []) or [" "]).strip(), planet.name])
+        print "Capitol City Names are: ", _capitals
         print "This Capitol New name is ", new_name
         res = fo.issueRenameOrder(planet_id, new_name)
         print "Capitol Rename attempt result: %d; planet now named %s" % (res, planet.name)

--- a/default/AI/FreeOrionAI.py
+++ b/default/AI/FreeOrionAI.py
@@ -11,6 +11,7 @@ import freeOrionAIInterface as fo  # interface used to interact with FreeOrion A
 import AIstate
 import ColonisationAI
 import ExplorationAI
+import DiplomaticCorp
 import FleetUtilsAI
 import InvasionAI
 import MilitaryAI
@@ -120,30 +121,14 @@ def handleChatMessage(sender_id, message_text):  # pylint: disable=invalid-name
 def handleDiplomaticMessage(message):  # pylint: disable=invalid-name
     """Called when this player receives a diplomatic message update from the server,
     such as if another player declares war, accepts peace, or cancels a proposed peace treaty."""
-    print "Received diplomatic %s message from empire %s to empire %s" % (message.type, message.sender, message.recipient)
-    print "my empire id: %s" % fo.empireID()
-    if message.type == fo.diplomaticMessageType.peaceProposal and message.recipient == fo.empireID():
-        reply_sender = message.recipient
-        reply_recipient = message.sender
-        proposal_sender_player = fo.empirePlayerID(message.sender)
-        fo.sendChatMessage(proposal_sender_player, "So, the Terran Hairless Plains Ape advising your empire wishes to scratch its belly for a while?")
-        if (foAIstate.aggression == fo.aggression.beginner or
-                foAIstate.aggression != fo.aggression.maniacal and random.random() < 1.0 / (((foAIstate.aggression + 0.01)*fo.currentTurn()/2)**0.5)):
-            fo.sendChatMessage(proposal_sender_player, "OK, Peace offer accepted.")
-            reply = fo.diplomaticMessage(reply_sender, reply_recipient, fo.diplomaticMessageType.acceptProposal)
-            print "Sending diplomatic message to empire %s of type %s" % (reply_recipient, reply.type)
-            fo.sendDiplomaticMessage(reply)
-        else:
-            fo.sendChatMessage(proposal_sender_player, "Maybe later. We are currently getting busy with Experimental Test Subject yo-Ma-ma.")
-
+    DiplomaticCorp.handle_diplomatic_message(message)
 
 
 @chat_on_error
 def handleDiplomaticStatusUpdate(status_update):  # pylint: disable=invalid-name
-    """Called when this player receives and update about the diplomatic status between players, which may
+    """Called when this player receives an update about the diplomatic status between players, which may
     or may not include this player."""
-    print "Received diplomatic status update to %s about empire %s and empire %s" % (status_update.status, status_update.empire1, status_update.empire2)
-
+    DiplomaticCorp.handle_diplomatic_status_update(status_update)
 
 
 @chat_on_error

--- a/default/AI/freeorion_tools.py
+++ b/default/AI/freeorion_tools.py
@@ -34,7 +34,13 @@ def get_ai_tag_grade(tag_list, tag_type):
 
 
 def UserString(label, default=None):  # this name left with C naming style for compatibility with translation assistance procedures  #pylint: disable=invalid-name
-    """ A translation assistance tool is intended to search for this method to identify translatable strings."""
+    '''
+    A translation assistance tool is intended to search for this method to identify translatable strings.
+    :param label: a UserString key
+    :param default: a default value to return if there is a key error
+    :return: a translated string for the label
+    '''
+
     table_string = fo.userString(label)
 
     if "ERROR: " + label in table_string:  # implement test for string lookup not found error
@@ -42,6 +48,14 @@ def UserString(label, default=None):  # this name left with C naming style for c
     else:
         return table_string
 
+def UserStringList(label):  # this name left with C naming style for compatibility with translation assistance procedures  #pylint: disable=invalid-name
+    '''
+    A translation assistance tool is intended to search for this method to identify translatable strings.
+    :param label: a UserString key
+    :return: a python list of translated strings from the UserString list identified by the label
+    '''
+
+    return fo.userStringList(label)
 
 def tech_is_complete(tech):
     """

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -10685,6 +10685,53 @@ Invincible'''
 
 ### End of Capital Names Lists
 
+### AI Diplomacy Strings and Lists 
+### Translator Note: for AI Keys ending with "LIST", each line of the provided value should be an independent entry; each entry must be a single line.
+### For such lists, you may provide more or fewer entries than are provided in en.txt, unless otherwise indicated in a comment for that key
+
+AI_PEACE_PROPOSAL_ACKNOWLEDGEMENTS_MILD_LIST
+'''Nice to hear from you again.
+Receipt of transmission acknowledged.
+'''
+
+AI_PEACE_PROPOSAL_ACKNOWLEDGEMENTS_HARSH_LIST
+'''What? Aren't you dead yet?
+Oh, not another pathetic sob story, please!
+'''
+
+AI_PEACE_PROPOSAL_RESPONSES_YES_MILD_LIST
+'''We will be happy to trust your good intentions.
+Whatever you say, Boss.  Everyone says you are very trustworthy.
+'''
+
+AI_PEACE_PROPOSAL_RESPONSES_NO_MILD_LIST
+'''Unfortunately, that would be very inconvenient at this time.
+We regret to inform you that we are unable to comply with that request.
+'''
+
+AI_PEACE_PROPOSAL_RESPONSES_YES_HARSH_LIST
+'''Out of pity, we will agree to not attack you.  For now.
+Feeble Beings!  There would be little honor in vanquishing you.
+'''
+
+AI_PEACE_PROPOSAL_RESPONSES_NO_HARSH_LIST
+'''We will see you dead first!
+You will not have peace until all your base r belong to us!
+'''
+
+AI_WAR_REDECLARATION_MILD_LIST
+'''Oh dear! Apparently there were irregularities in our previous negotiations and the Peace Treaty was not ratified at all!  We regret to inform you that our empires are still at war.
+Today was the day that you said the other day that we would go to war together again, right?
+'''
+
+AI_WAR_REDECLARATION_HARSH_LIST
+'''Our Younglings thirst for you blood!  Prepare for War!
+You fools did not believe this peace would last, did you?
+'''
+
+### End of AI Diplomacy Message Lists
+
+
 #############################################################
 ####           HOTKEYS NAMES AND DESCRIPTIONS            ####
 #############################################################


### PR DESCRIPTION
This moves AI diplomacy into a dedicated module and slightly advances the actual diplomatic dealings.  The AI will now keep a log of peace requests and war declarations.  It now has an 'attitude' regarding the respective other empires, largely shaped by its aggression level but also affected by the diplomatic history between the empires.   Its response to a peace request will be controlled by this attitude.  The AI will also now have a more varied set of responses to peace requests, drawn from the stringtables.

There is obviously much more that can and will be done going forward.  I've tested this moderately & it seems to work fine, but I thought I'd post it for review & feedback before committing.  (Plus, it involves a change in the executables and so I thought I'd wait until closer to Vezzra's weekly build to commit.)
