### PR TITLE
Graphical Combat Summary tweaks

### DIFF
--- a/UI/CombatReport/CombatReportWnd.cpp
+++ b/UI/CombatReport/CombatReportWnd.cpp
@@ -121,11 +121,11 @@ private:
 CombatReportWnd::CombatReportWnd() :
     CUIWnd(UserString("COMBAT_REPORT_TITLE"), GG::X(150), GG::Y(50), COMBAT_LOG_WIDTH, COMBAT_LOG_HEIGHT,
            GG::INTERACTIVE | GG::RESIZABLE | GG::DRAGABLE | GG::ONTOP | CLOSABLE),
-    m_impl(new CombatReportPrivate(*this))
-{ }
+    m_impl(0)
+{ m_impl.reset(new CombatReportPrivate(*this)); }
 
 CombatReportWnd::~CombatReportWnd()
-{}
+{ }
 
 void CombatReportWnd::SetLog(int log_id)
 { m_impl->SetLog(log_id); }

--- a/UI/CombatReport/CombatReportWnd.cpp
+++ b/UI/CombatReport/CombatReportWnd.cpp
@@ -17,20 +17,6 @@ namespace {
     GG::X COMBAT_LOG_WIDTH(400);
     GG::Y COMBAT_LOG_HEIGHT(300);
 
-    //// Duplicated from MapWnd.cpp - used here to find maximum size of the
-    //// combat report window.
-    //GG::X AppWidth() {
-    //    if(HumanClientApp* app = HumanClientApp::GetApp())
-    //        return app->AppWidth();
-    //    return GG::X0;
-    //}
-
-    //GG::Y AppHeight() {
-    //    if(HumanClientApp* app = HumanClientApp::GetApp())
-    //        return app->AppHeight();
-    //    return GG::Y0;
-    //}
-
     GG::Pt LimitToAppSize(const GG::Pt& sz_in) {
         if (HumanClientApp* app = HumanClientApp::GetApp()) {
             return GG::Pt(std::min(sz_in.x, app->AppWidth()),

--- a/UI/CombatReport/CombatReportWnd.cpp
+++ b/UI/CombatReport/CombatReportWnd.cpp
@@ -118,6 +118,17 @@ private:
         DebugLogger() << "RectangleHover " << data;
         SetFocus(data);
     }
+
+    void HandleTabChanged(int index) {
+        // This will handle multiple GraphicalSummaryWnds in the tab group.
+        // It would be simpler to call this class's DoLayout without the check,
+        // but updating the entire window is not necessary.
+        GraphicalSummaryWnd* selected_wnd =
+            dynamic_cast<GraphicalSummaryWnd*>(m_tabs->CurrentWnd());
+        if(selected_wnd) {
+            selected_wnd->DoLayout();
+        }
+    }
 };
 
 CombatReportWnd::CombatReportWnd() :

--- a/UI/CombatReport/CombatReportWnd.cpp
+++ b/UI/CombatReport/CombatReportWnd.cpp
@@ -17,22 +17,22 @@ namespace {
     GG::X COMBAT_LOG_WIDTH(400);
     GG::Y COMBAT_LOG_HEIGHT(300);
 
-    // Duplicated from MapWnd.cpp - used here to find maximum size of the
-    // combat report window.
-    GG::X AppWidth() {
-        if(HumanClientApp* app = HumanClientApp::GetApp())
-            return app->AppWidth();
-        return GG::X0;
-    }
+    //// Duplicated from MapWnd.cpp - used here to find maximum size of the
+    //// combat report window.
+    //GG::X AppWidth() {
+    //    if(HumanClientApp* app = HumanClientApp::GetApp())
+    //        return app->AppWidth();
+    //    return GG::X0;
+    //}
 
-    GG::Y AppHeight() {
-        if(HumanClientApp* app = HumanClientApp::GetApp())
-            return app->AppHeight();
-        return GG::Y0;
-    }
+    //GG::Y AppHeight() {
+    //    if(HumanClientApp* app = HumanClientApp::GetApp())
+    //        return app->AppHeight();
+    //    return GG::Y0;
+    //}
 
     GG::Pt LimitToAppSize(const GG::Pt& sz_in) {
-        if(HumanClientApp* app = HumanClientApp::GetApp()) {
+        if (HumanClientApp* app = HumanClientApp::GetApp()) {
             return GG::Pt(std::min(sz_in.x, app->AppWidth()),
                           std::min(sz_in.y, app->AppHeight()) );
         } else {
@@ -72,7 +72,7 @@ public:
         GG::Connect(m_graphical->MinSizeChangedSignal,
                     boost::bind(&CombatReportPrivate::UpdateMinSize, this));
 
-        if(HumanClientApp* app = HumanClientApp::GetApp()) {
+        if (HumanClientApp* app = HumanClientApp::GetApp()) {
             GG::Connect(HumanClientApp::GetApp()->WindowResizedSignal,
                         boost::bind(&CombatReportPrivate::UpdateMinSize, this));
         } else {
@@ -93,7 +93,7 @@ public:
 
     void DoLayout() {
         // Only update the selected window.
-        if(GraphicalSummaryWnd* graphical_wnd =
+        if (GraphicalSummaryWnd* graphical_wnd =
                dynamic_cast<GraphicalSummaryWnd*>(m_tabs->CurrentWnd()) ) {
             graphical_wnd->DoLayout();
         }
@@ -200,7 +200,7 @@ private:
         std::list<GG::Wnd*>::const_iterator layout_begin =
             m_tabs->GetLayout()->Children().begin();
         // First object in the layout should be the tab bar.
-        if(layout_begin != m_tabs->GetLayout()->Children().end()) {
+        if (layout_begin != m_tabs->GetLayout()->Children().end()) {
             GG::Pt tab_min_size = (*layout_begin)->MinUsableSize();
             m_min_size.x = std::max(tab_min_size.x, m_min_size.x);
             // TabBar::MinUsableSize does not seem to return the correct
@@ -209,7 +209,7 @@ private:
         }
 
         // If the window is currently too small, re-validate its size.
-        if(m_wnd.Width() < m_min_size.x || m_wnd.Height() < m_min_size.y) {
+        if (m_wnd.Width() < m_min_size.x || m_wnd.Height() < m_min_size.y) {
             m_wnd.Resize(m_wnd.Size());
         }
     }
@@ -249,7 +249,7 @@ void CombatReportWnd::SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
 }
 
 bool CombatReportWnd::EventFilter(GG::Wnd* w, const GG::WndEvent& wnd_event) {
-    switch(wnd_event.Type()) {
+    switch (wnd_event.Type()) {
         case GG::WndEvent::LDrag:
             LDrag(wnd_event.Point(), wnd_event.DragMove(), wnd_event.ModKeys());
             break;

--- a/UI/CombatReport/CombatReportWnd.h
+++ b/UI/CombatReport/CombatReportWnd.h
@@ -17,10 +17,6 @@ public:
     virtual void    CloseClicked();
     virtual void    SizeMove(const GG::Pt& ul, const GG::Pt& lr);
 
-protected:
-    /// Filter LMB events over the resize tab that are sent to the GraphicalSummaryWnd instead of this wnd.
-    virtual bool EventFilter(GG::Wnd* w, const GG::WndEvent& wnd_event);
-
 private:
     class CombatReportPrivate;
 

--- a/UI/CombatReport/CombatReportWnd.h
+++ b/UI/CombatReport/CombatReportWnd.h
@@ -14,9 +14,12 @@ public:
 
     /// Sets which combat to show.
     void            SetLog(int log_id);
-    virtual GG::Pt  ClientLowerRight() const;
     virtual void    CloseClicked();
     virtual void    SizeMove(const GG::Pt& ul, const GG::Pt& lr);
+
+protected:
+    /// Filter LMB events over the resize tab that are sent to the GraphicalSummaryWnd instead of this wnd.
+    virtual bool EventFilter(GG::Wnd* w, const GG::WndEvent& wnd_event);
 
 private:
     class CombatReportPrivate;

--- a/UI/CombatReport/CombatReportWnd.h
+++ b/UI/CombatReport/CombatReportWnd.h
@@ -20,6 +20,7 @@ public:
 
 private:
     class CombatReportPrivate;
+
     boost::scoped_ptr<CombatReportPrivate> m_impl;
 };
 

--- a/UI/CombatReport/GraphicalSummary.cpp
+++ b/UI/CombatReport/GraphicalSummary.cpp
@@ -96,11 +96,12 @@ public:
     typedef std::map<int, CombatSummary> CombatSummaryMap;
 
     BarSizer( const CombatSummaryMap& combat_summaries , const GG::Pt& available_size):
-    m_max_total_max_health(-1.0f),
-    m_max_units_on_a_side(-1),
-    m_sum_of_max_max_healths(0),
-    m_summaries(combat_summaries),
-    m_available_space(available_size) {
+        m_max_total_max_health(-1.0f),
+        m_max_units_on_a_side(-1),
+        m_sum_of_max_max_healths(0),
+        m_summaries(combat_summaries),
+        m_available_space(available_size)
+    {
         // We want to measure health on a single scale that shows as much as possible
         // while fitting the data of both sides.
         // Therefore we make the side with more health fill the window
@@ -177,15 +178,15 @@ public:
     }
 
 private:
-    float m_max_total_max_health;
-    int m_max_units_on_a_side;
-    float m_sum_of_max_max_healths;
-    const CombatSummaryMap& m_summaries;
+    float  m_max_total_max_health;
+    int    m_max_units_on_a_side;
+    float  m_sum_of_max_max_healths;
     GG::Pt m_available_space;
+    bool   m_use_relative_side_bar_heights;
 
-    bool m_use_relative_side_bar_heights;
+    const CombatSummaryMap& m_summaries;
 
-    GG::Pt GetSideBarSize( int empire_id ) const{
+    GG::Pt GetSideBarSize( int empire_id ) const {
         GG::Pt bar_size = m_available_space - GG::Pt(BEVEL_MARGIN_X, BEVEL_MARGIN_Y + static_cast<int>(m_summaries.size()) * SIDE_BOX_MARGIN);
 
         CombatSummaryMap::const_iterator summary_it = m_summaries.find(empire_id);
@@ -203,7 +204,7 @@ private:
     }
 };
 
-/// A Bar tha shows the health of a single battle participant
+/// A Bar that shows the health of a single battle participant
 class ParticipantBar : public GG::Wnd {
 public:
     ParticipantBar(const ParticipantSummary& participant, const BarSizer& sizer):
@@ -227,7 +228,6 @@ public:
     }
 
     virtual void Render() {
-
         GG::Clr base_color = Alive() ? m_wound_color : m_dead_color;
 
         // Always draw the red background, health will cover it
@@ -293,8 +293,8 @@ public:
         GG::Wnd(GG::X0, GG::Y0, GG::X1, GG::Y1, GG::INTERACTIVE),
         m_side_summary(combat_summary),
         m_x_axis_label(0),
-        m_sizer(sizer){
-
+        m_sizer(sizer)
+    {
         GG::Clr axis_label_color = combat_summary.SideColor();
 
         m_x_axis_label = new CUILabel( (boost::format( UserString("COMBAT_FLEET_HEALTH_AXIS_LABEL") )
@@ -328,8 +328,6 @@ public:
     }
 
     void DoLayout() {
-
-
         GG::Pt bar_size = m_sizer.GetSideBarSize(m_side_summary.empire);
         if( bar_size != Size() ) {
             Resize(bar_size);
@@ -487,8 +485,9 @@ public:
     boost::signals2::signal<void ()> ChangedSignal;
 
     OptionsBar(boost::scoped_ptr<BarSizer>& sizer):
-    GG::Wnd(),
-    m_sizer(sizer) {
+        GG::Wnd(),
+        m_sizer(sizer)
+    {
         m_toggles.push_back(new ToggleData(UserString("COMBAT_SUMMARY_PARTICIPANT_RELATIVE"),
                                            UserString("COMBAT_SUMMARY_PARTICIPANT_EQUAL"),
                                            UserString("COMBAT_SUMMARY_PARTICIPANT_RELATIVE_TIP"),
@@ -597,8 +596,8 @@ private:
 GraphicalSummaryWnd::GraphicalSummaryWnd() :
     GG::Wnd(GG::X0, GG::Y0, GG::X1, GG::Y1, GG::INTERACTIVE),
     m_sizer(0),
-    m_options_bar(0){
-    }
+    m_options_bar(0)
+{ }
 
 void GraphicalSummaryWnd::SetLog(int log_id) {
     MakeSummaries(log_id);
@@ -653,9 +652,9 @@ void GraphicalSummaryWnd::MakeSummaries(int log_id) {
                 if( m_summaries.find(owner_id) == m_summaries.end() ) {
                     m_summaries.insert( std::map<int, CombatSummary>::value_type(owner_id,CombatSummary(owner_id)) );
                 }
-                std::map<int, CombatParticipantState>::const_iterator it = log.participant_states.find(object_id);
-                if ( it != log.participant_states.end() ) {
-                    m_summaries[owner_id].AddUnit(object_id, it->second);
+                std::map<int, CombatParticipantState>::const_iterator map_it = log.participant_states.find(object_id);
+                if(map_it != log.participant_states.end()) {
+                    m_summaries[owner_id].AddUnit(object_id, map_it->second);
                 } else {
                     ErrorLogger() << "Participant state missing from log. Object id: " << object_id << " log id: " << log_id;
                 }

--- a/UI/CombatReport/GraphicalSummary.cpp
+++ b/UI/CombatReport/GraphicalSummary.cpp
@@ -670,9 +670,8 @@ private:
     };
 };
 
-
 GraphicalSummaryWnd::GraphicalSummaryWnd() :
-    GG::Wnd(GG::X0, GG::Y0, GG::X1, GG::Y1, GG::INTERACTIVE),
+    GG::Wnd(GG::X0, GG::Y0, GG::X1, GG::Y1, GG::NO_WND_FLAGS),
     m_sizer(0),
     m_options_bar(0)
 { }
@@ -730,9 +729,11 @@ void GraphicalSummaryWnd::DoLayout() {
 
 void GraphicalSummaryWnd::Render()
 {
-    GG::Pt one(GG::X(2), GG::Y1);
-    AngledCornerRectangle(UpperLeft(), LowerRight() - one, ClientUI::CtrlColor(), GG::CLR_ZERO,
-                          8, 1, false, true);
+    GG::FlatRectangle(UpperLeft() + GG::Pt(GG::X1, GG::Y0),
+                      LowerRight(),
+                      ClientUI::CtrlColor(),
+                      ClientUI::CtrlBorderColor(),
+                      1);
 }
 
 void GraphicalSummaryWnd::HandleButtonChanged() {

--- a/UI/CombatReport/GraphicalSummary.cpp
+++ b/UI/CombatReport/GraphicalSummary.cpp
@@ -194,15 +194,15 @@ public:
 
         m_available_side_bar_space =
             m_available_space -
-            GG::Pt(BEVEL_MARGIN_X,
-                   static_cast<int>(m_summaries.size() + 1) * SIDE_BOX_MARGIN);
+            GG::Pt( BEVEL_MARGIN_X,
+                    static_cast<int>(m_summaries.size() + 1) * SIDE_BOX_MARGIN );
 
         m_available_participant_bar_height =
-            std::max(GG::Y0,
-                     m_available_side_bar_space.y -
-                         (AXIS_HEIGHT + X_AXIS_LABEL_MARGIN + PARTICIPANT_BAR_UP_MARGIN) *
-                         static_cast<int>(m_summaries.size()) );
-}
+            std::max( GG::Y0,
+                      m_available_side_bar_space.y -
+                          (AXIS_HEIGHT + X_AXIS_LABEL_MARGIN + PARTICIPANT_BAR_UP_MARGIN) *
+                          static_cast<int>(m_summaries.size()) );
+    }
 
     bool Get(const std::string& option) const {
         return GetOptionsDB().Get<bool>(OPTIONS_ROOT + option);

--- a/UI/CombatReport/GraphicalSummary.h
+++ b/UI/CombatReport/GraphicalSummary.h
@@ -12,7 +12,13 @@ class OptionsBar;
 /// Shows a graphical summary of the battle results
 class GraphicalSummaryWnd : public GG::Wnd {
 public:
+    boost::signals2::signal<void()> MinSizeChangedSignal;
+
     GraphicalSummaryWnd();
+
+    /// Get the minimum size of this window required to show all of its
+    /// children
+    virtual GG::Pt MinUsableSize() const;
 
     /// Sets the log to show
     void SetLog(int log_id);
@@ -21,11 +27,14 @@ public:
     void DoLayout();
 
     virtual void Render();
+
 private:
     std::vector<SideBar*> m_side_boxes;
     std::map<int, CombatSummary> m_summaries;
     boost::scoped_ptr<BarSizer> m_sizer;
     OptionsBar* m_options_bar; // Is a child window->GG handles memory
+
+    void HandleButtonChanged();
 
     void MakeSummaries(int log_id);
 

--- a/UI/CombatReport/GraphicalSummary.h
+++ b/UI/CombatReport/GraphicalSummary.h
@@ -29,10 +29,10 @@ public:
     virtual void Render();
 
 private:
-    std::vector<SideBar*> m_side_boxes;
-    std::map<int, CombatSummary> m_summaries;
-    boost::scoped_ptr<BarSizer> m_sizer;
-    OptionsBar* m_options_bar; // Is a child window->GG handles memory
+    std::vector<SideBar*>           m_side_boxes;
+    std::map<int, CombatSummary>    m_summaries;
+    boost::scoped_ptr<BarSizer>     m_sizer;
+    OptionsBar*                     m_options_bar; // Is a child window->GG handles memory
 
     void HandleButtonChanged();
 

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -4426,6 +4426,7 @@ void MapWnd::Cleanup() {
     m_FPS->Hide();
     m_scale_line->Hide();
     m_zoom_slider->Hide();
+    m_combat_report_wnd->Hide();
     m_sitrep_panel->ShowSitRepsForTurn(INVALID_GAME_TURN);
     if (m_auto_end_turn)
         ToggleAutoEndTurn();


### PR DESCRIPTION
Addressed some of the things brought up in [this thread](http://www.freeorion.org/forum/viewtopic.php?f=9&t=9119).

The report window now checks its contents for a minimum size and tries to respect it (but won't become larger than the client app window), the resize tab in the lower-right corner no longer gets blocked by the graphical summary, the window disappears on resignation, it's all in the commit messages.

There are a couple of things I haven't gotten to such as handling Graph Height: Proportional mode when the two sides have vastly different health (e.g. a Scout vs a Sentinel) and dealing with hidden enemies (currently just doesn't show that side's graph and the minimum size check doesn't work).
