### PR TITLE
Cleanup prints

### DIFF
--- a/default/AI/AIFleetMission.py
+++ b/default/AI/AIFleetMission.py
@@ -614,10 +614,15 @@ class AIFleetMission(object):
             universe = fo.getUniverse()
             fleet_id = self.target_id
             fleet = universe.getFleet(fleet_id)
-            targets_string = "fleet %4d (%14s) [ %10s mission ] : %3d ships , total Rating:%7d " % (fleet_id, (fleet and fleet.name) or "Fleet Invalid",
-                                                                                                 AIFleetMissionType.name(aiFleetMissionType), (fleet and len(fleet.shipIDs)) or 0, foAI.foAIstate.get_rating(fleet_id).get('overall', 0))
+            targets_string = "%-20s [%10s mission]: %3d ships, total rating: %7d" % (fleet,
+                                                                                     AIFleetMissionType.name(aiFleetMissionType),
+                                                                                     (fleet and len(fleet.shipIDs)) or 0,
+                                                                                     foAI.foAIstate.get_rating(fleet_id).get('overall', 0))
             targets = self.get_targets(aiFleetMissionType)
             for target in targets:
-                targets_string += str(target)
+                targets_string += ' %s' % target
             mission_strings.append(targets_string)
-        return "\n".join(mission_strings)
+        if mission_strings:
+            return "\n".join(mission_strings)
+        else:
+            return 'Mission with out mission types'

--- a/default/AI/AIstate.py
+++ b/default/AI/AIstate.py
@@ -1028,7 +1028,7 @@ class AIstate(object):
         print "--------------------"
         print "Map of Missions keyed by ID:"
         for item in self.get_fleet_missions_map().items():
-            print " %4d : %s " % item
+            print "    %-4d: %s" % item
         print "--------------------"
         # TODO: check length of fleets for losses or do in AIstat.__cleanRoles
         known_fleets = self.get_fleet_roles_map()

--- a/default/AI/FleetUtilsAI.py
+++ b/default/AI/FleetUtilsAI.py
@@ -186,12 +186,12 @@ def split_fleet(fleet_id):
         return []
     ship_ids = list(fleet.shipIDs)
     for ship_id in ship_ids[1:]:
-        new_fleet_id = fo.issueNewFleetOrder("Fleet %d" % ship_id, ship_id)
+        new_fleet_id = fo.issueNewFleetOrder("Fleet %4d" % ship_id, ship_id)
         if new_fleet_id:
             new_fleet = universe.getFleet(new_fleet_id)
             if not new_fleet:
                 print "Error: newly split fleet %d not available from universe" % new_fleet_id
-            fo.issueRenameOrder(new_fleet_id, "Fleet %5d" % new_fleet_id)  # to ease review of debugging logs
+            fo.issueRenameOrder(new_fleet_id, "Fleet %4d" % new_fleet_id)  # to ease review of debugging logs
             fo.issueAggressionOrder(new_fleet_id, True)
             foAI.foAIstate.get_rating(new_fleet_id)
             newfleets.append(new_fleet_id)


### PR DESCRIPTION
I noticed that `AIFleetMission` produce empty string in some cases. I add handle of this situation.

Also I noticed that fleet naming and renaming uses different templates, so I fix it too.

Current output example:

```
Map of Missions keyed by ID:
    377 : F_377<Scout Fleet>   [   explore mission]:   1 ships, total rating:       0 {  system : [ 288] Achird α}
    379 : Mission with out mission types
    381 : Mission with out mission types
    375 : F_375<Scout Fleet>   [   explore mission]:   1 ships, total rating:       0 {  system : [ 286] Turbin β}
```
