### PR TITLE
Added support for the Windows clipboard.

### DIFF
--- a/GG/GG/Clipboard.h
+++ b/GG/GG/Clipboard.h
@@ -1,0 +1,6 @@
+#ifdef WIN32
+    #include <GG/Clipboard_Windows.h>
+#else
+    // TODO: Include more platform specific clipboard implementations.
+    #include <GG/Clipboard_Generic.h>
+#endif

--- a/GG/GG/Clipboard_Generic.h
+++ b/GG/GG/Clipboard_Generic.h
@@ -1,0 +1,23 @@
+#ifndef CLIPBOARD_GENERIC_H
+#define CLIPBOARD_GENERIC_H
+
+#include <string>
+
+namespace GG {
+
+    /** Non-platform specific clipboard class.  Uses an application-specific
+      * clipboard instead of the system clipboard. */
+    class Clipboard {
+    public:
+        std::string Text();
+        bool SetText(const std::string&);
+
+    private:
+        friend Clipboard GetClipboard();
+        Clipboard() = default;
+    };
+
+    Clipboard GetClipboard();
+}
+
+#endif

--- a/GG/GG/Clipboard_Windows.h
+++ b/GG/GG/Clipboard_Windows.h
@@ -1,0 +1,28 @@
+#ifndef CLIPBOARD_WINDOWS_H
+#define CLIPBOARD_WINDOWS_H
+
+#include <string>
+
+namespace GG {
+
+    class Clipboard {
+    public:
+        Clipboard(Clipboard&&);
+        ~Clipboard();
+
+        std::string Text();
+        bool SetText(const std::string&);
+
+    private:
+        friend Clipboard GetClipboard();
+        Clipboard();
+
+        bool DataAvailable(unsigned format);
+        bool UnicodeAvailable();
+        bool m_clipboard_owner;
+    };
+
+    Clipboard GetClipboard();
+}
+
+#endif

--- a/GG/src/CMakeLists.txt
+++ b/GG/src/CMakeLists.txt
@@ -30,6 +30,8 @@ add_library(GiGi
     Base.cpp
     BrowseInfoWnd.cpp
     Button.cpp
+    Clipboard_Generic.cpp
+    Clipboard_Windows.cpp
     ClrConstants.cpp
     Control.cpp
     Cursor.cpp

--- a/GG/src/Clipboard_Generic.cpp
+++ b/GG/src/Clipboard_Generic.cpp
@@ -1,0 +1,23 @@
+#ifndef WIN32
+
+#include <GG/Clipboard_Generic.h>
+
+namespace {
+    static std::string clipboard_text;
+}
+
+namespace GG {
+    std::string Clipboard::Text()
+    { return clipboard_text; }
+
+    bool Clipboard::SetText(const std::string& text) {
+        clipboard_text = text;
+        return true;
+    }
+
+    Clipboard GetClipboard() {
+        return Clipboard();
+    }
+}
+
+#endif

--- a/GG/src/Clipboard_Windows.cpp
+++ b/GG/src/Clipboard_Windows.cpp
@@ -1,0 +1,79 @@
+#ifdef WIN32
+
+#include <GG/Clipboard_Windows.h>
+
+#include <Windows.h>
+#include <locale>
+#include <codecvt>
+
+
+namespace GG {
+    Clipboard::Clipboard() {
+        m_clipboard_owner = (OpenClipboard(nullptr) != 0);
+    }
+
+    Clipboard::Clipboard(Clipboard&& clipboard) {
+        // Not thread-safe.  Shouldn't be an issue in practice.
+        m_clipboard_owner = clipboard.m_clipboard_owner;
+        clipboard.m_clipboard_owner = false;
+    }
+
+    Clipboard::~Clipboard() {
+        if (m_clipboard_owner) CloseClipboard();
+    }
+
+    std::string Clipboard::Text() {
+        if (!UnicodeAvailable()) return "";
+
+        HGLOBAL data = GetClipboardData(CF_UNICODETEXT);
+        if (data == 0) return "";
+
+        std::u16string utf16_text((char16_t*)GlobalLock(data));
+        GlobalUnlock(data);
+
+        std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> conversion;
+        std::string text = conversion.to_bytes(utf16_text);
+
+        return text;
+    }
+
+    bool Clipboard::SetText(const std::string& text) {
+        EmptyClipboard();
+
+        std::wstring_convert<std::codecvt_utf8_utf16<char16_t>, char16_t> conversion;
+        std::u16string utf16_text = conversion.from_bytes(text);
+        
+        HGLOBAL data = GlobalAlloc(GMEM_MOVEABLE, (utf16_text.size() + 1) * 2);
+        if (data == 0) return false;
+
+        memcpy(GlobalLock(data), utf16_text.c_str(), (utf16_text.size() + 1) * 2);
+        GlobalUnlock(data);
+
+        if (!SetClipboardData(CF_UNICODETEXT, data)) {
+            GlobalFree(data);
+            return false;
+        }
+
+        return true;
+    }
+
+    bool Clipboard::DataAvailable(unsigned format) {
+        UINT result = 0;
+        do {
+            result = EnumClipboardFormats(result);
+            if (result == format) return true;
+        } while (result != 0);
+
+        return false;
+    }
+
+    bool Clipboard::UnicodeAvailable() {
+        return DataAvailable(CF_UNICODETEXT);
+    }
+
+    Clipboard GetClipboard() {
+        return Clipboard();
+    }
+}
+
+#endif

--- a/GG/src/GUI.cpp
+++ b/GG/src/GUI.cpp
@@ -35,6 +35,7 @@
 #include <GG/Timer.h>
 #include <GG/ZList.h>
 #include <GG/utf8/checked.h>
+#include <GG/Clipboard.h>
 
 #if GG_HAVE_LIBPNG
 # if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ > 7)
@@ -240,8 +241,6 @@ struct GG::GUIImpl
 
     const Wnd* m_save_as_png_wnd;
     std::string m_save_as_png_filename;
-
-    std::string m_clipboard_text;
 };
 
 GUIImpl::GUIImpl() :
@@ -283,8 +282,7 @@ GUIImpl::GUIImpl() :
     m_style_factory(new StyleFactory()),
     m_render_cursor(false),
     m_cursor(),
-    m_save_as_png_wnd(0),
-    m_clipboard_text()
+    m_save_as_png_wnd(0)
 {
     m_mouse_button_state[0] = m_mouse_button_state[1] = m_mouse_button_state[2] = false;
     m_drag_wnds[0] = m_drag_wnds[1] = m_drag_wnds[2] = 0;
@@ -1319,12 +1317,11 @@ void GUI::SetCursor(const boost::shared_ptr<Cursor>& cursor)
 { s_impl->m_cursor = cursor; }
 
 const std::string& GUI::ClipboardText() const
-{ return s_impl->m_clipboard_text; }
+{ return GetClipboard().Text(); }
 
 bool GUI::SetClipboardText(const std::string& text)
 {
-    s_impl->m_clipboard_text = text;
-    return true;
+    return GetClipboard().SetText(text);
 }
 
 bool GUI::CopyFocusWndText()
@@ -1376,7 +1373,7 @@ bool GUI::PasteWndText(Wnd* wnd, const std::string& text)
 
 bool GUI::PasteFocusWndClipboardText()
 {
-    return PasteFocusWndText(s_impl->m_clipboard_text);
+    return PasteFocusWndText(GetClipboard().Text());
 }
 
 bool GUI::CutFocusWndText()

--- a/msvc2010/GiGi/GiGi.vcxproj
+++ b/msvc2010/GiGi/GiGi.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -15,6 +15,9 @@
     <ClInclude Include="..\..\GG\GG\Base.h" />
     <ClInclude Include="..\..\GG\GG\BrowseInfoWnd.h" />
     <ClInclude Include="..\..\GG\GG\Button.h" />
+    <ClInclude Include="..\..\GG\GG\Clipboard.h" />
+    <ClInclude Include="..\..\GG\GG\Clipboard_Generic.h" />
+    <ClInclude Include="..\..\GG\GG\Clipboard_Windows.h" />
     <ClInclude Include="..\..\GG\GG\Clr.h" />
     <ClInclude Include="..\..\GG\GG\ClrConstants.h" />
     <ClInclude Include="..\..\GG\GG\Control.h" />
@@ -77,6 +80,8 @@
     <ClCompile Include="..\..\GG\src\Base.cpp" />
     <ClCompile Include="..\..\GG\src\BrowseInfoWnd.cpp" />
     <ClCompile Include="..\..\GG\src\Button.cpp" />
+    <ClCompile Include="..\..\GG\src\Clipboard_Generic.cpp" />
+    <ClCompile Include="..\..\GG\src\Clipboard_Windows.cpp" />
     <ClCompile Include="..\..\GG\src\ClrConstants.cpp" />
     <ClCompile Include="..\..\GG\src\Control.cpp" />
     <ClCompile Include="..\..\GG\src\Cursor.cpp" />

--- a/msvc2010/GiGi/GiGi.vcxproj.filters
+++ b/msvc2010/GiGi/GiGi.vcxproj.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
@@ -200,6 +200,15 @@
     <ClInclude Include="..\..\GG\GG\GLClientAndServerBuffer.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\GG\GG\Clipboard.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\GG\GG\Clipboard_Generic.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\GG\GG\Clipboard_Windows.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\GG\src\dialogs\FileDlg.cpp">
@@ -305,6 +314,12 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\GG\src\GLClientAndServerBuffer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\GG\src\Clipboard_Generic.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\GG\src\Clipboard_Windows.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>

--- a/msvc2013/GiGi/GiGi.vcxproj
+++ b/msvc2013/GiGi/GiGi.vcxproj
@@ -19,6 +19,9 @@
     <ClInclude Include="..\..\GG\GG\Base.h" />
     <ClInclude Include="..\..\GG\GG\BrowseInfoWnd.h" />
     <ClInclude Include="..\..\GG\GG\Button.h" />
+    <ClInclude Include="..\..\GG\GG\Clipboard.h" />
+    <ClInclude Include="..\..\GG\GG\Clipboard_Generic.h" />
+    <ClInclude Include="..\..\GG\GG\Clipboard_Windows.h" />
     <ClInclude Include="..\..\GG\GG\Clr.h" />
     <ClInclude Include="..\..\GG\GG\ClrConstants.h" />
     <ClInclude Include="..\..\GG\GG\Control.h" />
@@ -81,6 +84,8 @@
     <ClCompile Include="..\..\GG\src\Base.cpp" />
     <ClCompile Include="..\..\GG\src\BrowseInfoWnd.cpp" />
     <ClCompile Include="..\..\GG\src\Button.cpp" />
+    <ClCompile Include="..\..\GG\src\Clipboard_Generic.cpp" />
+    <ClCompile Include="..\..\GG\src\Clipboard_Windows.cpp" />
     <ClCompile Include="..\..\GG\src\ClrConstants.cpp" />
     <ClCompile Include="..\..\GG\src\Control.cpp" />
     <ClCompile Include="..\..\GG\src\Cursor.cpp" />

--- a/msvc2013/GiGi/GiGi.vcxproj.filters
+++ b/msvc2013/GiGi/GiGi.vcxproj.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
@@ -200,6 +200,15 @@
     <ClInclude Include="..\..\GG\GG\GLClientAndServerBuffer.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\GG\GG\Clipboard.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\GG\GG\Clipboard_Generic.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\..\GG\GG\Clipboard_Windows.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\GG\src\dialogs\FileDlg.cpp">
@@ -305,6 +314,12 @@
       <Filter>Source Files</Filter>
     </ClCompile>
     <ClCompile Include="..\..\GG\src\GLClientAndServerBuffer.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\GG\src\Clipboard_Generic.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\GG\src\Clipboard_Windows.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
   </ItemGroup>


### PR DESCRIPTION
http://www.freeorion.org/forum/viewtopic.php?f=9&t=9510
Generic clipboard code works properly when tested on Windows, and should be compiled in by default on non-windows systems, but should be tested on Linux and OS X.  @Vezzra @Dilvish-fo 
