### PR TITLE
Species homeworld pedia page

### DIFF
--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -235,10 +235,10 @@ namespace {
                         if (TemporaryPtr<const Planet> homeworld = GetPlanet(*hw_it)) {
                             known_homeworlds.insert(*hw_it);
                             // if known, add to beginning
-                            homeworld_info = LinkTaggedIDText(VarText::PLANET_ID_TAG, *hw_it, homeworld->PublicName(client_empire_id)) + ";  " + homeworld_info;
+                            homeworld_info = LinkTaggedIDText(VarText::PLANET_ID_TAG, *hw_it, homeworld->PublicName(client_empire_id)) + "   " + homeworld_info;
                         } else { 
                             // add to end
-                            homeworld_info += UserString("UNKNOWN_PLANET") + ";  ";
+                            homeworld_info += UserString("UNKNOWN_PLANET") + "   ";
                         }
                     }
                     species_entry += homeworld_info;
@@ -256,33 +256,33 @@ namespace {
                 }
                 if (!species_occupied_planets.empty()) {
                     if (species_occupied_planets.size() >= 5) {
-                        species_entry += "  |  " + boost::lexical_cast<std::string>(species_occupied_planets.size()) + UserString("OCCUPIED_PLANETS");
+                        species_entry += "  |   " + boost::lexical_cast<std::string>(species_occupied_planets.size()) + UserString("OCCUPIED_PLANETS");
                         continue;
                     }
-                    species_entry += "  |  " + UserString("OCCUPIED_PLANETS") + ":  ";
+                    species_entry += "  |   " + UserString("OCCUPIED_PLANETS") + ":  ";
                     for (std::vector<TemporaryPtr<const Planet> >::const_iterator planet_it =
                             species_occupied_planets.begin();
                         planet_it != species_occupied_planets.end(); ++planet_it)
                     {
                         TemporaryPtr<const Planet> planet = *planet_it;
-                        species_entry += LinkTaggedIDText(VarText::PLANET_ID_TAG, planet->ID(), planet->PublicName(client_empire_id)) + ";  ";
+                        species_entry += LinkTaggedIDText(VarText::PLANET_ID_TAG, planet->ID(), planet->PublicName(client_empire_id)) + "   ";
                     }
                     species_entry += "";
                 }
                 sorted_entries_list.insert(std::make_pair(UserString(it->first),
-                    std::make_pair(species_entry + "\n",
-                                   it->first)));
+                    std::make_pair(species_entry + "\n", it->first)));
             }
+            sorted_entries_list.insert(std::make_pair("⃠ ",
+                std::make_pair("\n\n", "  ")));
             for (SpeciesManager::iterator it = species_manager.begin();
                  it != species_manager.end(); ++it)
             {
                 Species* species = it->second;
                 if (species->Homeworlds().empty()) {
-                    std::string species_entry = "⃠ " + UserString(it->first) + ":  ";
-                    species_entry += UserString("NO_HOMEWORLD") + "";
-                    sorted_entries_list.insert(std::make_pair( "⃠ " + UserString(it->first),
-                        std::make_pair(LinkTaggedPresetText(VarText::SPECIES_TAG, it->first, species_entry) + "\n",
-                                    it->first)));
+                    std::string species_entry = LinkTaggedText(VarText::SPECIES_TAG, it->first) + ":  ";
+                    species_entry += UserString("NO_HOMEWORLD");
+                    sorted_entries_list.insert(std::make_pair( "⃠⃠" + std::string( "⃠ ") + UserString(it->first),
+                        std::make_pair(species_entry + "\n", it->first)));
                 }
             } 
 

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -256,10 +256,10 @@ namespace {
                 }
                 if (!species_occupied_planets.empty()) {
                     if (species_occupied_planets.size() >= 5) {
-                        species_entry += " |||| " + boost::lexical_cast<std::string>(species_occupied_planets.size()) + UserString("OCCUPIED_PLANETS");
+                        species_entry += "  |  " + boost::lexical_cast<std::string>(species_occupied_planets.size()) + UserString("OCCUPIED_PLANETS");
                         continue;
                     }
-                    species_entry += " |||| " + UserString("OCCUPIED_PLANETS") + ":  ";
+                    species_entry += "  |  " + UserString("OCCUPIED_PLANETS") + ":  ";
                     for (std::vector<TemporaryPtr<const Planet> >::const_iterator planet_it =
                             species_occupied_planets.begin();
                         planet_it != species_occupied_planets.end(); ++planet_it)

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -93,6 +93,9 @@ namespace {
             sorted_entries_list.insert(std::make_pair(UserString("ENC_SPECIES"),
                 std::make_pair(LinkTaggedText(TextLinker::ENCYCLOPEDIA_TAG, "ENC_SPECIES") + "\n",
                                "ENC_SPECIES")));
+            sorted_entries_list.insert(std::make_pair(UserString("ENC_HOMEWORLDS"),
+                std::make_pair(LinkTaggedText(TextLinker::ENCYCLOPEDIA_TAG, "ENC_HOMEWORLDS") + "\n",
+                               "ENC_HOMEWORLDS")));
             sorted_entries_list.insert(std::make_pair(UserString("ENC_FIELD_TYPE"),
                 std::make_pair(LinkTaggedText(TextLinker::ENCYCLOPEDIA_TAG, "ENC_FIELD_TYPE") + "\n",
                                "ENC_FIELD_TYPE")));
@@ -208,6 +211,80 @@ namespace {
                     std::make_pair(LinkTaggedText(VarText::SPECIES_TAG, it->first) + "\n",
                                    it->first)));
             }
+
+        } else if (dir_name == "ENC_HOMEWORLDS") {
+            int client_empire_id = HumanClientApp::GetApp()->EmpireID();
+            const SpeciesManager& species_manager = GetSpeciesManager();
+            for (SpeciesManager::iterator it = species_manager.begin();
+                 it != species_manager.end(); ++it)
+            {
+                Species* species = it->second;
+                std::set<int> known_homeworlds;
+                //std::string species_entry = UserString(it->first) + ":  ";
+                std::string species_entry;
+                std::string homeworld_info;
+                species_entry += LinkTaggedText(VarText::SPECIES_TAG, it->first) + " ";
+                // homeworld
+                if (species->Homeworlds().empty()) {
+                    continue;
+                } else {
+                    species_entry += "(" + boost::lexical_cast<std::string>(species->Homeworlds().size()) + "):  ";
+                    for (std::set<int>::const_iterator hw_it = species->Homeworlds().begin();
+                        hw_it != species->Homeworlds().end(); ++hw_it)
+                    {
+                        if (TemporaryPtr<const Planet> homeworld = GetPlanet(*hw_it)) {
+                            known_homeworlds.insert(*hw_it);
+                            // if known, add to beginning
+                            homeworld_info = LinkTaggedIDText(VarText::PLANET_ID_TAG, *hw_it, homeworld->PublicName(client_empire_id)) + ";  " + homeworld_info;
+                        } else { 
+                            // add to end
+                            homeworld_info += UserString("UNKNOWN_PLANET") + ";  ";
+                        }
+                    }
+                    species_entry += homeworld_info;
+                }
+
+                // occupied planets
+                std::vector<TemporaryPtr<Planet> > planets = Objects().FindObjects<Planet>();
+                std::vector<TemporaryPtr<const Planet> > species_occupied_planets;
+                for (std::vector<TemporaryPtr<Planet> >::const_iterator planet_it = planets.begin();
+                    planet_it != planets.end(); ++planet_it)
+                {
+                    TemporaryPtr<const Planet> planet = *planet_it;
+                    if ((planet->SpeciesName() == it->first) && (known_homeworlds.find(planet->ID()) == known_homeworlds.end()))
+                        species_occupied_planets.push_back(planet);
+                }
+                if (!species_occupied_planets.empty()) {
+                    if (species_occupied_planets.size() >= 5) {
+                        species_entry += " |||| " + boost::lexical_cast<std::string>(species_occupied_planets.size()) + UserString("OCCUPIED_PLANETS");
+                        continue;
+                    }
+                    species_entry += " |||| " + UserString("OCCUPIED_PLANETS") + ":  ";
+                    for (std::vector<TemporaryPtr<const Planet> >::const_iterator planet_it =
+                            species_occupied_planets.begin();
+                        planet_it != species_occupied_planets.end(); ++planet_it)
+                    {
+                        TemporaryPtr<const Planet> planet = *planet_it;
+                        species_entry += LinkTaggedIDText(VarText::PLANET_ID_TAG, planet->ID(), planet->PublicName(client_empire_id)) + ";  ";
+                    }
+                    species_entry += "";
+                }
+                sorted_entries_list.insert(std::make_pair(UserString(it->first),
+                    std::make_pair(species_entry + "\n",
+                                   it->first)));
+            }
+            for (SpeciesManager::iterator it = species_manager.begin();
+                 it != species_manager.end(); ++it)
+            {
+                Species* species = it->second;
+                if (species->Homeworlds().empty()) {
+                    std::string species_entry = "⃠ " + UserString(it->first) + ":  ";
+                    species_entry += UserString("NO_HOMEWORLD") + "";
+                    sorted_entries_list.insert(std::make_pair( "⃠ " + UserString(it->first),
+                        std::make_pair(LinkTaggedPresetText(VarText::SPECIES_TAG, it->first, species_entry) + "\n",
+                                    it->first)));
+                }
+            } 
 
         } else if (dir_name == "ENC_FIELD_TYPE") {
             const FieldTypeManager& fields_manager = GetFieldTypeManager();
@@ -729,7 +806,7 @@ namespace {
             dir_names.push_back("ENC_FLEET");           dir_names.push_back("ENC_PLANET");
             dir_names.push_back("ENC_BUILDING");        dir_names.push_back("ENC_SYSTEM");
             dir_names.push_back("ENC_FIELD");           dir_names.push_back("ENC_GRAPH");
-            dir_names.push_back("ENC_GALAXY_SETUP");
+            dir_names.push_back("ENC_GALAXY_SETUP");    dir_names.push_back("ENC_HOMEWORLDS");
         }
         return dir_names;
     }

--- a/UI/LinkText.cpp
+++ b/UI/LinkText.cpp
@@ -472,3 +472,6 @@ std::string LinkTaggedText(const std::string& tag, const std::string& stringtabl
 
 std::string LinkTaggedIDText(const std::string& tag, int id, const std::string& text)
 { return "<" + tag + " " + boost::lexical_cast<std::string>(id) + ">" + text + "</" + tag + ">"; }
+
+std::string LinkTaggedPresetText(const std::string& tag, const std::string& stringtable_entry, const std::string& display_text)
+{ return "<" + tag + " " + stringtable_entry + ">" + display_text + "</" + tag + ">"; }

--- a/UI/LinkText.h
+++ b/UI/LinkText.h
@@ -170,4 +170,6 @@ std::string LinkTaggedText(const std::string& tag, const std::string& stringtabl
 /// Helper for generating a link string
 std::string LinkTaggedIDText(const std::string& tag, int id, const std::string& text);
 
+/// Helper for generating a link string with preset display text (not to be looked up in stringtable)
+std::string LinkTaggedPresetText(const std::string& tag, const std::string& stringtable_entry, const std::string& display_text);
 #endif // _LinkText_h_

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -4648,7 +4648,7 @@ HOMEWORLD
 Homeworld:
 
 NO_HOMEWORLD
-No Known Homeworld
+No Homeworld
 
 UNKNOWN_PLANET
 Unknown Planet

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -3306,6 +3306,9 @@ ENC_SYSTEM
 ENC_FIELD
 [Game - Fields]
 
+ENC_HOMEWORLDS
+Species' Homeworlds
+
 ENC_INDEX
 Encyclopedia Index
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -4666,7 +4666,7 @@ CAN_COLONIZE
 Can Colonize Planets
 
 OCCUPIED_PLANETS
-Occupied Planets:
+Occupied Planets
 
 ENVIRONMENTAL_PREFERENCES
 Environmental Preferences:


### PR DESCRIPTION
Many times I want a quick way to double check if a species' homeworld has been discovered by my scouts (or is even in the game), and rather than going each species page by page in the pedia I like to have it all collected together in one spot, as below.  It also includes up to 5 of any other known occupied planets.  What say Ye?
![Screenshot of Species Homeworlds Pedia page](http://i.imgur.com/UPuqII9.png)
