### PR TITLE
added an optional mapscale circle overlay to MapWnd, centered on the …

### DIFF
--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -37,6 +37,7 @@
 #include "../util/Random.h"
 #include "../util/ModeratorAction.h"
 #include "../util/ScopedTimer.h"
+#include "../universe/Enums.h"
 #include "../universe/Fleet.h"
 #include "../universe/Planet.h"
 #include "../universe/Predicates.h"
@@ -54,6 +55,7 @@
 #include <boost/graph/graph_concepts.hpp>
 
 #include <GG/DrawUtil.h>
+#include <GG/PtRect.h>
 #include <GG/MultiEdit.h>
 #include <GG/WndEvent.h>
 #include <GG/Layout.h>
@@ -63,8 +65,8 @@
 #include <valarray>
 
 namespace {
-    const double    ZOOM_STEP_SIZE = std::pow(2.0, 1.0/3.0);
-    const double    ZOOM_IN_MAX_STEPS = 9.0;
+    const double    ZOOM_STEP_SIZE = std::pow(2.0, 1.0/4.0);
+    const double    ZOOM_IN_MAX_STEPS = 12.0;
     const double    ZOOM_IN_MIN_STEPS = -7.0;   // negative zoom steps indicates zooming out
     const double    ZOOM_MAX = std::pow(ZOOM_STEP_SIZE, ZOOM_IN_MAX_STEPS);
     const double    ZOOM_MIN = std::pow(ZOOM_STEP_SIZE, ZOOM_IN_MIN_STEPS);
@@ -284,7 +286,8 @@ public:
     {
         m_label = new ShadowedTextControl("", ClientUI::GetFont(), ClientUI::TextColor());
         AttachChild(m_label);
-        Update(1.0);
+        std::set<int> dummy = std::set<int>();
+        Update(1.0, dummy, INVALID_OBJECT_ID);
         GG::Connect(GetOptionsDB().OptionChangedSignal("UI.show-galaxy-map-scale"), &MapScaleLine::UpdateEnabled, this);
         UpdateEnabled();
     }
@@ -322,7 +325,38 @@ public:
         glLineWidth(1.0);
     }
 
-    void Update(double zoom_factor) {
+    GG::X GetLength() {
+        return m_line_length;
+    }
+
+    void Update(double zoom_factor, std::set<int>& fleet_ids, int sel_system_id) {
+        std::set<double> fixed_distances;
+        for (std::set<int>::iterator it = fleet_ids.begin(); it != fleet_ids.end(); ++it) {
+            if (TemporaryPtr<const Fleet> fleet = GetFleet(*it)) {
+                if (fleet->Speed() > 20)
+                    fixed_distances.insert(fleet->Speed());
+                for (std::set< int >::iterator ship_it = fleet->ShipIDs().begin(); ship_it != fleet->ShipIDs().end(); ship_it++){
+                    if ( TemporaryPtr< Ship > ship = GetShip(*ship_it)) {
+                        const float ship_range = ship->CurrentMeterValue(METER_DETECTION);
+                        if (ship_range > 20)
+                            fixed_distances.insert(ship_range);
+                        const float ship_speed = ship->Speed();
+                        if (ship_speed > 20)
+                            fixed_distances.insert(ship_speed);
+                    }
+                }
+            }
+        }
+        if (const TemporaryPtr<const System> system = GetSystem(sel_system_id)) {
+            for (std::set< int >::iterator pid_it = system->PlanetIDs().begin(); pid_it != system->PlanetIDs().end(); pid_it++) {
+                if (const TemporaryPtr< Planet > planet = GetPlanet(*pid_it)) {
+                    const float planet_range = planet->CurrentMeterValue(METER_DETECTION);
+                    if (planet_range > 20)
+                        fixed_distances.insert(planet_range);
+                }
+            }
+        }
+
         zoom_factor = std::min(std::max(zoom_factor, ZOOM_MIN), ZOOM_MAX);  // sanity range limits to prevent divide by zero
         m_scale_factor = zoom_factor;
 
@@ -337,13 +371,35 @@ public:
 
         // get appropriate power of 10
         double pow10 = floor(log10(max_shown_length));
-        double shown_length = std::pow(10.0, pow10);
+        double init_length = std::pow(10.0, pow10);
+        double shown_length = init_length;
 
         // see if next higher multiples of 5 or 2 can be used
         if (shown_length * 5.0 <= max_shown_length)
             shown_length *= 5.0;
         else if (shown_length * 2.0 <= max_shown_length)
             shown_length *= 2.0;
+        
+        DebugLogger()  << "MapScaleLine::Update maxLen: " << max_shown_length
+                                << "; init_length: " << init_length
+                                << "; shown_length: " << shown_length;
+
+        for (std::set<double>::iterator it = fixed_distances.begin(); it != fixed_distances.end(); ++it) {
+            DebugLogger()  << " MapScaleLine::Update fleet speed: " << *it;
+        }
+        if (!fixed_distances.empty()) {
+            std::set<double>::iterator distance_ub = fixed_distances.upper_bound(max_shown_length/ZOOM_STEP_SIZE);
+            if (distance_ub != fixed_distances.end() && *distance_ub <= max_shown_length) {
+                DebugLogger()  << " MapScaleLine::Update distance_ub: " << *distance_ub;
+                shown_length = *distance_ub;
+            } else {
+                distance_ub = fixed_distances.upper_bound(shown_length);
+                if (distance_ub != fixed_distances.end() && *distance_ub <= max_shown_length) {
+                    DebugLogger()  << " MapScaleLine::Update distance_ub: " << *distance_ub;
+                    shown_length = *distance_ub;
+                }
+            }
+        }
 
         // determine end of drawn scale line
         m_line_length = GG::X(static_cast<int>(shown_length * m_scale_factor));
@@ -1091,7 +1147,8 @@ MapWnd::MapWnd() :
     m_scale_line = new MapScaleLine(GG::X(LAYOUT_MARGIN),   GG::Y(LAYOUT_MARGIN) + m_toolbar->Height(),
                                     SCALE_LINE_MAX_WIDTH,   SCALE_LINE_HEIGHT);
     GG::GUI::GetGUI()->Register(m_scale_line);
-    m_scale_line->Update(ZoomFactor());
+    int sel_system_id = SidePanel::SystemID();
+    m_scale_line->Update(ZoomFactor(), m_selected_fleet_ids, sel_system_id);
     m_scale_line->Hide();
 
     // Zoom slider
@@ -1460,10 +1517,31 @@ void MapWnd::RenderSystems() {
         fog_scanline_spacing = static_cast<float>(GetOptionsDB().Get<double>("UI.system-fog-of-war-spacing"));
     }
 
+    const double TWO_PI = 2.0*3.14159;
+    if (GetOptionsDB().Get<bool>("UI.show-galaxy-map-scale") && SidePanel::SystemID() != INVALID_OBJECT_ID) {
+        glPushMatrix();
+        glLoadIdentity();
+        glDisable(GL_TEXTURE_2D);
+        glEnable(GL_LINE_SMOOTH);
+        glLineWidth(2.0);
+        GG::X radius = m_scale_line->GetLength();
+        TemporaryPtr< System > selected_system = GetSystem(SidePanel::SystemID());
+        GG::Pt circle_centre = ScreenCoordsFromUniversePosition(selected_system->X(), selected_system->Y());
+        GG::Pt ul = circle_centre - GG::Pt(radius, GG::Y(Value(radius)));
+        GG::Pt lr = circle_centre + GG::Pt(radius, GG::Y(Value(radius)));
+        GG::Clr circle_colour = GG::CLR_WHITE;
+        circle_colour.a = 128;
+        glColor(circle_colour);
+        CircleArc(ul, lr,0.0, TWO_PI, false);
+        glDisable(GL_LINE_SMOOTH);
+        glEnable(GL_TEXTURE_2D);
+        glPopMatrix();
+        glLineWidth(1.0f);
+    }
+
     if (fog_scanlines || circles) {
         glPushMatrix();
         glLoadIdentity();
-        const double TWO_PI = 2.0*3.14159;
         glDisable(GL_TEXTURE_2D);
         glEnable(GL_LINE_SMOOTH);
         glLineWidth(1.5f);
@@ -3870,8 +3948,9 @@ void MapWnd::SetZoom(double steps_in, bool update_slide, const GG::Pt& position)
 
     MoveTo(move_to_pt - GG::Pt(AppWidth(), AppHeight()));
 
+    int sel_system_id = SidePanel::SystemID();
     if (m_scale_line)
-        m_scale_line->Update(ZoomFactor());
+        m_scale_line->Update(ZoomFactor(), m_selected_fleet_ids, sel_system_id);
     if (update_slide && m_zoom_slider)
         m_zoom_slider->SlideTo(m_zoom_steps_in);
 

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -94,6 +94,7 @@ namespace {
         db.Add("UI.galaxy-gas-background",          UserStringNop("OPTIONS_DB_GALAXY_MAP_GAS"),                     true,       Validator<bool>());
         db.Add("UI.galaxy-starfields",              UserStringNop("OPTIONS_DB_GALAXY_MAP_STARFIELDS"),              true,       Validator<bool>());
         db.Add("UI.show-galaxy-map-scale",          UserStringNop("OPTIONS_DB_GALAXY_MAP_SCALE_LINE"),              true,       Validator<bool>());
+        db.Add("UI.show-galaxy-map-scale-circle",   UserStringNop("OPTIONS_DB_GALAXY_MAP_SCALE_CIRCLE"),            false,      Validator<bool>());
         db.Add("UI.show-galaxy-map-zoom-slider",    UserStringNop("OPTIONS_DB_GALAXY_MAP_ZOOM_SLIDER"),             false,      Validator<bool>());
         db.Add("UI.optimized-system-rendering",     UserStringNop("OPTIONS_DB_OPTIMIZED_SYSTEM_RENDERING"),         true,       Validator<bool>());
         db.Add("UI.starlane-thickness",             UserStringNop("OPTIONS_DB_STARLANE_THICKNESS"),                 2.0,        RangedStepValidator<double>(0.25, 0.25, 10.0));
@@ -1540,7 +1541,9 @@ void MapWnd::RenderSystems() {
     }
 
     const double TWO_PI = 2.0*3.14159;
-    if (GetOptionsDB().Get<bool>("UI.show-galaxy-map-scale") && SidePanel::SystemID() != INVALID_OBJECT_ID) {
+    if (GetOptionsDB().Get<bool>("UI.show-galaxy-map-scale") && GetOptionsDB().Get<bool>("UI.show-galaxy-map-scale-circle") 
+            && SidePanel::SystemID() != INVALID_OBJECT_ID) 
+    {
         glPushMatrix();
         glLoadIdentity();
         glDisable(GL_TEXTURE_2D);

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -525,6 +525,7 @@ OptionsWnd::OptionsWnd():
     BoolOption(current_page, 0, "UI.galaxy-gas-background",       UserString("OPTIONS_GALAXY_MAP_GAS"));
     BoolOption(current_page, 0, "UI.galaxy-starfields",           UserString("OPTIONS_GALAXY_MAP_STARFIELDS"));
     BoolOption(current_page, 0, "UI.show-galaxy-map-scale",       UserString("OPTIONS_GALAXY_MAP_SCALE_LINE"));
+    BoolOption(current_page, 0, "UI.show-galaxy-map-scale-circle",UserString("OPTIONS_GALAXY_MAP_SCALE_CIRCLE"));
     BoolOption(current_page, 0, "UI.show-galaxy-map-zoom-slider", UserString("OPTIONS_GALAXY_MAP_ZOOM_SLIDER"));
     BoolOption(current_page, 0, "UI.show-detection-range",        UserString("OPTIONS_GALAXY_MAP_DETECTION_RANGE"));
     IntOption(current_page,  0, "UI.detection-range-opacity",     UserString("OPTIONS_GALAXY_MAP_DETECTION_RANGE_OPACITY"));

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -873,6 +873,9 @@ Render star fields around systems. May slow rendering on older systems.
 OPTIONS_DB_GALAXY_MAP_SCALE_LINE
 Show scale line for universe distance on galaxy map.
 
+OPTIONS_DB_GALAXY_MAP_SCALE_CIRCLE
+Show the map scale also as a circle centered on the currently selected System (only if the map scale line is also shown).
+
 OPTIONS_DB_GALAXY_MAP_ZOOM_SLIDER
 Toggles whether to show the zoom slider on galaxy map.
 
@@ -1957,6 +1960,9 @@ Galaxy map star fields rendering
 
 OPTIONS_GALAXY_MAP_SCALE_LINE
 Galaxy distance scale line
+
+OPTIONS_GALAXY_MAP_SCALE_CIRCLE
+Galaxy distance scale circle
 
 OPTIONS_GALAXY_MAP_ZOOM_SLIDER
 Galaxy map zoom slider


### PR DESCRIPTION
…currently selected system; also adjusts potential mapscale values to include speeds and detection ranges of currently selected fleets/ships/planets.   The circle is only shown if the map scale line is selected to be shown in the OptionsDB.  

I find this very helpful in a couple of ways-- the most common is for deciding what I (or an enemy) would have in detection range if a scout moves to some potential destination; I sometimes also use it to decide if an enemy could make a starlane jump in a single turn.  Another much more rare but in someone ways even more critical use is to decide where I can safely build a Collective Thought Network, and to see what starlanes I need to stay away from to avoid running afoul of its 200 uu no-move zone.

When I had posted this a long while back on the forums, it did not select so many of the likely-of-interest distances to add.  There was also a suggestion to possibly change it to a simple point-to-point line, but for many of these purposes that would be an unwieldy manner of use.

I've been using this for a year now and have been very happy with it, so I decided it should have a chance to make it in for 0.4.5.  Below is a screenshot where I was using it to assess the 200 uu distance when considering a location for a Collective Thought Network. ![map scale circle](http://i.imgur.com/7nUzw7T.png)
