### PR TITLE
made sitrep icon and font sizes controlled by a 'hidden' UI option

### DIFF
--- a/UI/SitRepPanel.cpp
+++ b/UI/SitRepPanel.cpp
@@ -242,7 +242,7 @@ namespace {
             AttachChild(m_icon);
 
             m_link_text = new LinkText(GG::X0, GG::Y0, GG::X1,
-                                       m_sitrep_entry.GetText() + " ", ClientUI::GetFont(GetOptionsDB().Get<int>("UI.sitrep-icon-size")),
+                                       m_sitrep_entry.GetText() + " ", ClientUI::GetFont(0.75*GetOptionsDB().Get<int>("UI.sitrep-icon-size")),
                                        GG::FORMAT_LEFT | GG::FORMAT_VCENTER | GG::FORMAT_WORDBREAK, ClientUI::TextColor());
             m_link_text->SetDecorator(VarText::EMPIRE_ID_TAG, new ColorEmpire());
             AttachChild(m_link_text);

--- a/UI/SitRepPanel.cpp
+++ b/UI/SitRepPanel.cpp
@@ -241,8 +241,8 @@ namespace {
             m_icon = new GG::StaticGraphic(icon, GG::GRAPHIC_FITGRAPHIC | GG::GRAPHIC_PROPSCALE);
             AttachChild(m_icon);
 
-            m_link_text = new LinkText(GG::X0, GG::Y0, GG::X1,
-                                       m_sitrep_entry.GetText() + " ", ClientUI::GetFont(0.75*GetOptionsDB().Get<int>("UI.sitrep-icon-size")),
+            m_link_text = new LinkText(GG::X0, GG::Y0, GG::X1, m_sitrep_entry.GetText() + " ", 
+                                       ClientUI::GetFont(std::max(1.0*ClientUI::Pts(), 0.75*GetOptionsDB().Get<int>("UI.sitrep-icon-size"))),
                                        GG::FORMAT_LEFT | GG::FORMAT_VCENTER | GG::FORMAT_WORDBREAK, ClientUI::TextColor());
             m_link_text->SetDecorator(VarText::EMPIRE_ID_TAG, new ColorEmpire());
             AttachChild(m_link_text);

--- a/UI/SitRepPanel.cpp
+++ b/UI/SitRepPanel.cpp
@@ -17,7 +17,6 @@
 
 
 namespace {
-    GG::X ICON_WIDTH(16);
     GG::X ICON_RIGHT_MARGIN(3);
     GG::Y ITEM_VERTICAL_PADDING(2);
 
@@ -25,8 +24,12 @@ namespace {
     void AddOptions(OptionsDB& db) {
         db.Add("verbose-sitrep", UserStringNop("OPTIONS_DB_VERBOSE_SITREP_DESC"),  false,  Validator<bool>());
         db.Add<std::string>("hidden-sitrep-templates", UserStringNop("OPTIONS_DB_HIDDEN_SITREP_TEMPLATES_DESC"), "");
+        db.Add("UI.sitrep-icon-size", UserStringNop("OPTIONS_DB_UI_SITREP_HEIGHT"), 16, RangedValidator<int>(12, 32));
     }
     bool temp_bool = RegisterOptions(&AddOptions);
+    
+    GG::X GetIconWidth()
+    { return GG::X(GetOptionsDB().Get<int>("UI.sitrep-icon-size")); }
 
     void HandleLinkClick(const std::string& link_type, const std::string& data) {
         using boost::lexical_cast;
@@ -215,13 +218,13 @@ namespace {
         void            DoLayout() {
             if (!m_initialized)
                 return;
-            const GG::Y ICON_HEIGHT(Value(ICON_WIDTH));
+            GG::Y ICON_HEIGHT(Value(GetIconWidth()));
 
             GG::X left(GG::X0);
             GG::Y bottom(ClientHeight());
 
-            m_icon->SizeMove(GG::Pt(left, bottom/2 - ICON_HEIGHT/2), GG::Pt(left + ICON_WIDTH, bottom/2 + ICON_HEIGHT/2));
-            left += ICON_WIDTH + ICON_RIGHT_MARGIN;
+            m_icon->SizeMove(GG::Pt(left, bottom/2 - ICON_HEIGHT/2), GG::Pt(left + GetIconWidth(), bottom/2 + ICON_HEIGHT/2));
+            left += GetIconWidth() + ICON_RIGHT_MARGIN;
 
             m_link_text->SizeMove(GG::Pt(left, GG::Y0), GG::Pt(ClientWidth(), bottom));
         }
@@ -239,7 +242,7 @@ namespace {
             AttachChild(m_icon);
 
             m_link_text = new LinkText(GG::X0, GG::Y0, GG::X1,
-                                       m_sitrep_entry.GetText() + " ", ClientUI::GetFont(),
+                                       m_sitrep_entry.GetText() + " ", ClientUI::GetFont(GetOptionsDB().Get<int>("UI.sitrep-icon-size")),
                                        GG::FORMAT_LEFT | GG::FORMAT_VCENTER | GG::FORMAT_WORDBREAK, ClientUI::TextColor());
             m_link_text->SetDecorator(VarText::EMPIRE_ID_TAG, new ColorEmpire());
             AttachChild(m_link_text);

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1334,6 +1334,9 @@ Toggles verbose logging of combat resolution information.
 OPTIONS_DB_VERBOSE_SITREP_DESC
 Toggles inclusion of situation report messages with errors.
 
+OPTIONS_DB_UI_SITREP_SIZE
+Sets the  sitrep icon width and height, and the text font size; default 16 (min 10, max 28)
+
 OPTIONS_DB_TECH_DEMO
 Try out the 3D combat tech demo.
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1335,7 +1335,7 @@ OPTIONS_DB_VERBOSE_SITREP_DESC
 Toggles inclusion of situation report messages with errors.
 
 OPTIONS_DB_UI_SITREP_SIZE
-Sets the  sitrep icon width and height, and the text font size; default 16 (min 10, max 28)
+Sets the  sitrep icon width and height, and the text font size will be set to 75% of that; default 16 (min 10, max 28)
 
 OPTIONS_DB_TECH_DEMO
 Try out the 3D combat tech demo.


### PR DESCRIPTION
"UI.sitrep-icon-size" default 16, range 10 to 32; font size is kept at 75% of the icon size, consistent with previous default values.

Currently Sitrep size is controllable via the overall font size setting, but there are many places where a substantial increase in font size is effectively prohibited, whereas the SitRep panel can easily adjust to larger font sizes.  So, this PR decouples sitrep font size from the overall font size setting and instead links it to a new "UI.sitrep-icon-size" option (currently 'hidden', without an OptionsWnd widget, for direct edit in config.xml  -- it was unclear this really deserves space in the OptionsWnd).

Somewhat responsive to request of The Silent One, http://www.freeorion.org/forum/viewtopic.php?f=10&t=9531

If it's not going to be given its own options widget, perhaps the value used should be the larger of (75% \* UI.sitrep-icon-size)  or the overall font size setting, since anyone increasing the font size would probably hope it to affect this as well.
