### PR TITLE
Move encyclopedia data structure into common library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -142,6 +142,7 @@ set (freeorioncommon_HEADER
     universe/Condition.h
     universe/EffectAccounting.h
     universe/Effect.h
+    universe/Encyclopedia.h
     universe/Enums.h
     universe/Field.h
     universe/Fleet.h
@@ -204,6 +205,7 @@ set (freeorioncommon_SOURCE
     universe/Condition.cpp
     universe/EffectAccounting.cpp
     universe/Effect.cpp
+    universe/Encyclopedia.cpp
     universe/Enums.cpp
     universe/Field.cpp
     universe/Fleet.cpp

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -2,13 +2,13 @@
 
 #include "CUIControls.h"
 #include "DesignWnd.h"
-#include "Encyclopedia.h"
 #include "FleetWnd.h"
 #include "GraphControl.h"
 #include "Hotkeys.h"
 #include "LinkText.h"
 #include "MapWnd.h"
 #include "../universe/Condition.h"
+#include "../universe/Encyclopedia.h"
 #include "../universe/Universe.h"
 #include "../universe/Tech.h"
 #include "../universe/ShipDesign.h"
@@ -59,11 +59,6 @@ namespace {
 }
 
 namespace {
-    const Encyclopedia& GetEncyclopedia() {
-        static Encyclopedia encyclopedia;
-        return encyclopedia;
-    }
-
     void GetSortedPediaDirEntires(const std::string& dir_name,
                                   std::multimap<std::string,
                                                 std::pair<std::string,
@@ -2743,21 +2738,3 @@ void EncyclopediaDetailPanel::OnNext() {
 
 void EncyclopediaDetailPanel::CloseClicked()
 { ClosingSignal(); }
-
-Encyclopedia::Encyclopedia() :
-    articles()
-{
-    parse::encyclopedia_articles(GetResourceDir() / "encyclopedia.txt", *this);
-    if (GetOptionsDB().Get<bool>("verbose-logging")) {
-        DebugLogger() << "(Category) Encyclopedia Articles:";
-        for (std::map<std::string, std::vector<EncyclopediaArticle> >::const_iterator
-             category_it = articles.begin(); category_it != articles.end(); ++category_it)
-        {
-            const std::string& category = category_it->first;
-            const std::vector<EncyclopediaArticle>& article_vec = category_it->second;
-            for (std::vector<EncyclopediaArticle>::const_iterator article_it = article_vec.begin();
-                 article_it != article_vec.end(); ++article_it)
-            { DebugLogger() << "(" << UserString(category) << ") : " << UserString(article_it->name); }
-        }
-    }
-}

--- a/Xcode/FreeOrion.xcodeproj/project.pbxproj
+++ b/Xcode/FreeOrion.xcodeproj/project.pbxproj
@@ -324,6 +324,7 @@
 		82E958D3188EC86A00479B77 /* SaveLoad.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 471030490CEF569900A7DF2B /* SaveLoad.cpp */; };
 		82E9DDF119530E5D007E681B /* CombatEvent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 82E9DDED19530E5D007E681B /* CombatEvent.cpp */; };
 		82E9DDF219530E5D007E681B /* CombatEvents.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 82E9DDEF19530E5D007E681B /* CombatEvents.cpp */; };
+		82EC868B1B40504700D4584D /* Encyclopedia.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 82EC86891B40504700D4584D /* Encyclopedia.cpp */; };
 		82F55DE818B0FF0A00FA9E11 /* libboost_date_time.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 82483B7A15F4F24100D27614 /* libboost_date_time.a */; };
 		9E632AEC13AD24D1003D1874 /* libboost_python.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EEEEA7413ACB91A0085B1A0 /* libboost_python.a */; };
 		9E632AED13AD24D1003D1874 /* libboost_regex.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EEEEA7513ACB91A0085B1A0 /* libboost_regex.a */; };
@@ -1031,7 +1032,6 @@
 		82B9AEA01AA71CCC00486B2A /* GraphicalSummary.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GraphicalSummary.h; sourceTree = "<group>"; };
 		82B9D445180C53FE0032F86D /* GraphControl.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = GraphControl.cpp; sourceTree = "<group>"; };
 		82B9D446180C53FE0032F86D /* GraphControl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = GraphControl.h; sourceTree = "<group>"; };
-		82BB838115AAD16C006F635F /* Encyclopedia.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Encyclopedia.h; sourceTree = "<group>"; };
 		82BB838215AAD20A006F635F /* EncyclopediaParser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = EncyclopediaParser.cpp; sourceTree = "<group>"; };
 		82BEB657159853B300B024CB /* Diplomacy.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Diplomacy.cpp; sourceTree = "<group>"; };
 		82BEB658159853B300B024CB /* Diplomacy.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Diplomacy.h; sourceTree = "<group>"; };
@@ -1068,6 +1068,8 @@
 		82E9DDEE19530E5D007E681B /* CombatEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CombatEvent.h; sourceTree = "<group>"; };
 		82E9DDEF19530E5D007E681B /* CombatEvents.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CombatEvents.cpp; sourceTree = "<group>"; };
 		82E9DDF019530E5D007E681B /* CombatEvents.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CombatEvents.h; sourceTree = "<group>"; };
+		82EC86891B40504700D4584D /* Encyclopedia.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Encyclopedia.cpp; sourceTree = "<group>"; };
+		82EC868A1B40504700D4584D /* Encyclopedia.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Encyclopedia.h; sourceTree = "<group>"; };
 		82ED913E194F5C85002F0A4A /* make_dmg.py */ = {isa = PBXFileReference; lastKnownFileType = text.script.python; path = make_dmg.py; sourceTree = "<group>"; };
 		82ED9141194F5CDD002F0A4A /* make_versioncpp.py */ = {isa = PBXFileReference; lastKnownFileType = text.script.python; name = make_versioncpp.py; path = ../cmake/make_versioncpp.py; sourceTree = "<group>"; };
 		82F06B6417B7C3BD00982965 /* TemporaryPtr.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TemporaryPtr.h; sourceTree = "<group>"; };
@@ -1601,7 +1603,6 @@
 				343EC6590F3F5B5300782AD3 /* DesignWnd.cpp */,
 				343EC65A0F3F5B5300782AD3 /* DesignWnd.h */,
 				471D5CB80A98A3F900DA9C21 /* doc */,
-				82BB838115AAD16C006F635F /* Encyclopedia.h */,
 				343EC65D0F3F5C7C00782AD3 /* EncyclopediaDetailPanel.cpp */,
 				343EC65E0F3F5C7C00782AD3 /* EncyclopediaDetailPanel.h */,
 				828C793D160778AA0075F220 /* FieldIcon.cpp */,
@@ -1708,6 +1709,8 @@
 				82592EEF147E381B00B840A5 /* EffectAccounting.cpp */,
 				82592EEE147E37FB00B840A5 /* EffectAccounting.h */,
 				8258927D17BBD04400818596 /* EnableTemporaryFromThis.h */,
+				82EC86891B40504700D4584D /* Encyclopedia.cpp */,
+				82EC868A1B40504700D4584D /* Encyclopedia.h */,
 				471D5CF20A98A3F900DA9C21 /* Enums.cpp */,
 				471D5CF30A98A3F900DA9C21 /* Enums.h */,
 				8250FDE315FCEFDD00523C1C /* Field.cpp */,
@@ -2360,6 +2363,7 @@
 				47103BF80CF04E5900A7DF2B /* VarText.cpp in Sources */,
 				47103BF90CF04E5900A7DF2B /* XMLDoc.cpp in Sources */,
 				47103BFA0CF04E5900A7DF2B /* Building.cpp in Sources */,
+				82EC868B1B40504700D4584D /* Encyclopedia.cpp in Sources */,
 				47103BFB0CF04E5900A7DF2B /* Condition.cpp in Sources */,
 				47103BFF0CF04E5900A7DF2B /* Effect.cpp in Sources */,
 				47103C010CF04E5900A7DF2B /* Enums.cpp in Sources */,

--- a/client/human/CMakeLists.txt
+++ b/client/human/CMakeLists.txt
@@ -68,7 +68,6 @@ set(freeorion_HEADER
     ../../UI/CUIWnd.h
     ../../UI/DesignWnd.h
     ../../UI/EncyclopediaDetailPanel.h
-    ../../UI/Encyclopedia.h
     ../../UI/FieldIcon.h
     ../../UI/FleetButton.h
     ../../UI/FleetWnd.h

--- a/msvc2010/Common/Common.vcxproj
+++ b/msvc2010/Common/Common.vcxproj
@@ -149,6 +149,7 @@
     <ClInclude Include="..\..\universe\Effect.h" />
     <ClInclude Include="..\..\universe\EffectAccounting.h" />
     <ClInclude Include="..\..\universe\EnableTemporaryFromThis.h" />
+    <ClInclude Include="..\..\universe\Encyclopedia.h" />
     <ClInclude Include="..\..\universe\Enums.h" />
     <ClInclude Include="..\..\universe\Field.h" />
     <ClInclude Include="..\..\universe\Fleet.h" />
@@ -211,6 +212,7 @@
     <ClCompile Include="..\..\universe\Condition.cpp" />
     <ClCompile Include="..\..\universe\Effect.cpp" />
     <ClCompile Include="..\..\universe\EffectAccounting.cpp" />
+    <ClCompile Include="..\..\universe\Encyclopedia.cpp" />
     <ClCompile Include="..\..\universe\Enums.cpp" />
     <ClCompile Include="..\..\universe\Field.cpp" />
     <ClCompile Include="..\..\universe\Fleet.cpp" />

--- a/msvc2010/Common/Common.vcxproj.filters
+++ b/msvc2010/Common/Common.vcxproj.filters
@@ -85,6 +85,9 @@
     <ClInclude Include="..\..\universe\EffectAccounting.h">
       <Filter>Header Files\universe</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\universe\Encyclopedia.h">
+      <Filter>Header Files\universe</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\universe\Enums.h">
       <Filter>Header Files\universe</Filter>
     </ClInclude>
@@ -313,6 +316,9 @@
       <Filter>Source Files\universe</Filter>
     </ClCompile>
     <ClCompile Include="..\..\universe\EffectAccounting.cpp">
+      <Filter>Source Files\universe</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\universe\Encyclopedia.cpp">
       <Filter>Source Files\universe</Filter>
     </ClCompile>
     <ClCompile Include="..\..\universe\Enums.cpp">

--- a/msvc2010/FreeOrion/FreeOrion.vcxproj
+++ b/msvc2010/FreeOrion/FreeOrion.vcxproj
@@ -125,7 +125,6 @@
     <ClInclude Include="..\..\UI\CUIStyle.h" />
     <ClInclude Include="..\..\UI\CUIWnd.h" />
     <ClInclude Include="..\..\UI\DesignWnd.h" />
-    <ClInclude Include="..\..\UI\Encyclopedia.h" />
     <ClInclude Include="..\..\UI\EncyclopediaDetailPanel.h" />
     <ClInclude Include="..\..\UI\FieldIcon.h" />
     <ClInclude Include="..\..\UI\FleetButton.h" />

--- a/msvc2010/FreeOrion/FreeOrion.vcxproj.filters
+++ b/msvc2010/FreeOrion/FreeOrion.vcxproj.filters
@@ -363,9 +363,6 @@
     <ClInclude Include="..\..\universe\ObjectMap.h">
       <Filter>Header Files\universe</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\UI\Encyclopedia.h">
-      <Filter>Header Files\UI</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\UI\ObjectListWnd.h">
       <Filter>Header Files\UI</Filter>
     </ClInclude>

--- a/msvc2013/Common/Common.vcxproj
+++ b/msvc2013/Common/Common.vcxproj
@@ -213,6 +213,7 @@
     <ClInclude Include="..\..\universe\Effect.h" />
     <ClInclude Include="..\..\universe\EffectAccounting.h" />
     <ClInclude Include="..\..\universe\EnableTemporaryFromThis.h" />
+    <ClInclude Include="..\..\universe\Encyclopedia.h" />
     <ClInclude Include="..\..\universe\Enums.h" />
     <ClInclude Include="..\..\universe\Field.h" />
     <ClInclude Include="..\..\universe\Fleet.h" />
@@ -275,6 +276,7 @@
     <ClCompile Include="..\..\universe\Condition.cpp" />
     <ClCompile Include="..\..\universe\Effect.cpp" />
     <ClCompile Include="..\..\universe\EffectAccounting.cpp" />
+    <ClCompile Include="..\..\universe\Encyclopedia.cpp" />
     <ClCompile Include="..\..\universe\Enums.cpp" />
     <ClCompile Include="..\..\universe\Field.cpp" />
     <ClCompile Include="..\..\universe\Fleet.cpp" />

--- a/msvc2013/Common/Common.vcxproj.filters
+++ b/msvc2013/Common/Common.vcxproj.filters
@@ -85,6 +85,9 @@
     <ClInclude Include="..\..\universe\EffectAccounting.h">
       <Filter>Header Files\universe</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\universe\Encyclopedia.h">
+      <Filter>Header Files\universe</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\universe\Enums.h">
       <Filter>Header Files\universe</Filter>
     </ClInclude>
@@ -313,6 +316,9 @@
       <Filter>Source Files\universe</Filter>
     </ClCompile>
     <ClCompile Include="..\..\universe\EffectAccounting.cpp">
+      <Filter>Source Files\universe</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\universe\Encyclopedia.cpp">
       <Filter>Source Files\universe</Filter>
     </ClCompile>
     <ClCompile Include="..\..\universe\Enums.cpp">

--- a/msvc2013/FreeOrion/FreeOrion.vcxproj
+++ b/msvc2013/FreeOrion/FreeOrion.vcxproj
@@ -181,7 +181,6 @@
     <ClInclude Include="..\..\UI\CUIStyle.h" />
     <ClInclude Include="..\..\UI\CUIWnd.h" />
     <ClInclude Include="..\..\UI\DesignWnd.h" />
-    <ClInclude Include="..\..\UI\Encyclopedia.h" />
     <ClInclude Include="..\..\UI\EncyclopediaDetailPanel.h" />
     <ClInclude Include="..\..\UI\FieldIcon.h" />
     <ClInclude Include="..\..\UI\FleetButton.h" />

--- a/msvc2013/FreeOrion/FreeOrion.vcxproj.filters
+++ b/msvc2013/FreeOrion/FreeOrion.vcxproj.filters
@@ -363,9 +363,6 @@
     <ClInclude Include="..\..\universe\ObjectMap.h">
       <Filter>Header Files\universe</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\UI\Encyclopedia.h">
-      <Filter>Header Files\UI</Filter>
-    </ClInclude>
     <ClInclude Include="..\..\UI\ObjectListWnd.h">
       <Filter>Header Files\UI</Filter>
     </ClInclude>

--- a/parse/EncyclopediaParser.cpp
+++ b/parse/EncyclopediaParser.cpp
@@ -2,7 +2,7 @@
 #include "Parse.h"
 #include "ParseImpl.h"
 
-#include "../UI/Encyclopedia.h"
+#include "../universe/Encyclopedia.h"
 
 #include <boost/spirit/include/phoenix.hpp>
 

--- a/universe/Encyclopedia.cpp
+++ b/universe/Encyclopedia.cpp
@@ -1,0 +1,30 @@
+#include "Encyclopedia.h"
+
+#include "../util/i18n.h"
+#include "../util/Logger.h"
+#include "../util/OptionsDB.h"
+#include "../util/Directories.h"
+#include "../parse/Parse.h"
+
+const Encyclopedia& GetEncyclopedia() {
+    static Encyclopedia encyclopedia;
+    return encyclopedia;
+}
+
+Encyclopedia::Encyclopedia() :
+    articles()
+{
+    parse::encyclopedia_articles(GetResourceDir() / "encyclopedia.txt", *this);
+    if (GetOptionsDB().Get<bool>("verbose-logging")) {
+        DebugLogger() << "(Category) Encyclopedia Articles:";
+        for (std::map<std::string, std::vector<EncyclopediaArticle> >::const_iterator
+             category_it = articles.begin(); category_it != articles.end(); ++category_it)
+        {
+            const std::string& category = category_it->first;
+            const std::vector<EncyclopediaArticle>& article_vec = category_it->second;
+            for (std::vector<EncyclopediaArticle>::const_iterator article_it = article_vec.begin();
+                 article_it != article_vec.end(); ++article_it)
+            { DebugLogger() << "(" << UserString(category) << ") : " << UserString(article_it->name); }
+        }
+    }
+}

--- a/universe/Encyclopedia.h
+++ b/universe/Encyclopedia.h
@@ -6,7 +6,9 @@
 #include <map>
 #include <vector>
 
-struct EncyclopediaArticle {
+#include "../util/Export.h"
+
+struct FO_COMMON_API EncyclopediaArticle {
     EncyclopediaArticle(const std::string& name_, const std::string& category_,
                         const std::string& short_description_, const std::string& description_,
                         const std::string& icon_) :
@@ -23,9 +25,11 @@ struct EncyclopediaArticle {
     std::string icon;
 };
 
-struct Encyclopedia {
+struct FO_COMMON_API Encyclopedia {
     Encyclopedia();
     std::map<std::string, std::vector<EncyclopediaArticle> >   articles;
 };
+
+FO_COMMON_API const Encyclopedia& GetEncyclopedia();
 
 #endif


### PR DESCRIPTION
This cut down cross references between UI, parser and common code
modules.  The EncyclopediaDetailPanel does _way to much_ anyway, things
like link resolving and fulltext search should be done by the
Encycopedia itself.

@geoffthemedio

Could you please test if the msvc projects still compile properly?

@Vezzra

Could you please update the Xcode project accordingly and create a PR on my fork?
