### PR TITLE
Fix signed compare warning

### DIFF
--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -1006,7 +1006,7 @@ namespace {
 
         // Stealthed attackers have now revealed themselves to their targets.
         // Process this for each new combat event.
-        for (int event_index = init_event_index; event_index < combat_info.combat_events.size(); event_index++) {
+        for (unsigned int event_index = init_event_index; event_index < combat_info.combat_events.size(); event_index++) {
             // mark attacker as valid target for attacked object's owner, so that regardless
             // of visibility the attacker can be counter-attacked in subsequent rounds if it
             // was not already attackable


### PR DESCRIPTION
```
combat/CombatSystem.cpp: In function ‘void {anonymous}::CombatRound(int, CombatInfo&, {anonymous}::AutoresolveInfo&)’:
combat/CombatSystem.cpp:989:62: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
         for (int event_index = init_event_index; event_index < combat_info.combat_events.size(); event_index++) {
```

Signed-off-by: Vincent Legoll vincent.legoll@gmail.com
