### PR TITLE
Fix warnings about constructor ordering

### DIFF
--- a/UI/CombatReport/GraphicalSummary.cpp
+++ b/UI/CombatReport/GraphicalSummary.cpp
@@ -106,9 +106,9 @@ public:
         m_max_total_max_health(-1.0f),
         m_max_units_on_a_side(-1),
         m_sum_of_max_max_healths(0),
-        m_summaries(combat_summaries),
+        m_min_of_max_max_healths(-1.f),
         m_available_space(available_size),
-        m_min_of_max_max_healths(-1.f)
+        m_summaries(combat_summaries)
     {
         // We want to measure health on a single scale that shows as much as possible
         // while fitting the data of both sides.


### PR DESCRIPTION
/home/vince/repo/upstream/freeorion/freeorion/UI/CombatReport/GraphicalSummary.cpp: In constructor ‘BarSizer::BarSizer(const CombatSummaryMap&, const GG::Pt&)’:
/home/vince/repo/upstream/freeorion/freeorion/UI/CombatReport/GraphicalSummary.cpp:236:29: warning: ‘BarSizer::m_summaries’ will be initialized after [-Wreorder]
     const CombatSummaryMap& m_summaries;
                             ^
/home/vince/repo/upstream/freeorion/freeorion/UI/CombatReport/GraphicalSummary.cpp:231:12: warning:   ‘GG::Pt BarSizer::m_available_space’ [-Wreorder]
     GG::Pt m_available_space;
            ^
/home/vince/repo/upstream/freeorion/freeorion/UI/CombatReport/GraphicalSummary.cpp:105:5: warning:   when initialized here [-Wreorder]
     BarSizer( const CombatSummaryMap& combat_summaries , const GG::Pt& available_size):
     ^
/home/vince/repo/upstream/freeorion/freeorion/UI/CombatReport/GraphicalSummary.cpp:231:12: warning: ‘BarSizer::m_available_space’ will be initialized after [-Wreorder]
     GG::Pt m_available_space;
            ^
/home/vince/repo/upstream/freeorion/freeorion/UI/CombatReport/GraphicalSummary.cpp:230:11: warning:   ‘float BarSizer::m_min_of_max_max_healths’ [-Wreorder]
     float  m_min_of_max_max_healths;            //< Used to determine minimum size required for TOGGLE_GRAPH_HEIGHT_PROPORTIONAL mode.
           ^
/home/vince/repo/upstream/freeorion/freeorion/UI/CombatReport/GraphicalSummary.cpp:105:5: warning:   when initialized here [-Wreorder]
     BarSizer( const CombatSummaryMap& combat_summaries , const GG::Pt& available_size):
     ^

Signed-off-by: Vincent Legoll vincent.legoll@gmail.com
