### PR TITLE
Changes to the experimentor outpost:

### DIFF
--- a/default/buildings.txt
+++ b/default/buildings.txt
@@ -1732,10 +1732,12 @@ BuildingType
                     message = "SITREP_VICTORY_CAPTURE"
                     icon = "icons/sitrep/victory.png"
                     empire = Source.Owner
-                AddStarlanes endpoint = NumberOf number = 1 condition = And [
-                    WithinDistance distance = 100 condition = Source
-                    System
-                ]
+                [[EXPERIMENTOR_ADD_STARLANE]]
+                [[EXPERIMENTOR_ADD_STARLANE]]
+                [[EXPERIMENTOR_ADD_STARLANE]]
+                [[EXPERIMENTOR_ADD_STARLANE]]
+                [[EXPERIMENTOR_ADD_STARLANE]]
+                Destroy
             ]
 
         EffectsGroup

--- a/default/buildings.txt
+++ b/default/buildings.txt
@@ -1657,6 +1657,12 @@ EXPERIMENTOR_SPAWN_CALC_A
 EXPERIMENTOR_SPAWN_START_TURN
 ''' ( [[EXPERIMENTOR_SPAWN_CALC_A]] * ((Max(1, 3 - GalaxyPlanetDensity))^0.5) * ((Max(1, GalaxySize / 200))^0.4))'''
 
+EXPERIMENTOR_ADD_STARLANE
+'''AddStarlanes endpoint = NumberOf number = 1 condition = And [
+   WithinDistance distance = 100 condition = Source
+   System
+]'''
+
 BuildingType
     name = "BLD_EXPERIMENTOR_OUTPOST"
     description = "BLD_EXPERIMENTOR_OUTPOST_DESC"
@@ -1706,7 +1712,7 @@ BuildingType
                     Planet
             ]
             activation = Or [
-                Turn high = [[EXPERIMENTOR_SPAWN_START_TURN]]      // always remove lanes before spawn start turn
+                Turn high = [[EXPERIMENTOR_SPAWN_START_TURN]]
                 Not ContainedBy Contains And [ Ship OwnedBy affiliation = AnyEmpire ]
             ]
             effects = [
@@ -1730,27 +1736,18 @@ BuildingType
                     WithinDistance distance = 100 condition = Source
                     System
                 ]
-                Destroy
             ]
 
         EffectsGroup
-            scope = Source
+            scope = And [
+                Source
+                Not OwnedBy affiliation = AnyEmpire
+            ]
             activation = Or [
                 Turn high = [[EXPERIMENTOR_SPAWN_START_TURN]]      // always remove lanes before spawn start turn
-                Not ContainedBy Contains And [ Monster Unowned Armed]
+                Not ContainedBy Contains And [ Monster Unowned Not Design name = "SM_EXP_OUTPOST"]
             ]
             effects = RemoveStarlanes endpoint = WithinStarlaneJumps jumps = 1 condition = Source
-
-        EffectsGroup
-            scope = Source
-            activation = And [
-                Turn low = [[EXPERIMENTOR_SPAWN_START_TURN]]       // don't create lanes before spawn start turn
-                ContainedBy Contains And [ Monster Unowned Armed]
-            ]
-            effects = AddStarlanes endpoint = NumberOf number = 1 condition = And [
-                WithinDistance distance = 100 condition = Source
-                System
-            ]
 
         EffectsGroup
             scope = Source
@@ -1771,6 +1768,7 @@ BuildingType
                         tag = "species" data = "SP_EXPERIMENTOR"
                         tag = "rawtext" data = "3"
                     ]
+                [[EXPERIMENTOR_ADD_STARLANE]]
             ]
 
         EffectsGroup
@@ -1791,6 +1789,7 @@ BuildingType
                         tag = "species" data = "SP_EXPERIMENTOR"
                         tag = "rawtext" data = "2"
                     ]
+                [[EXPERIMENTOR_ADD_STARLANE]]
             ]
 
         EffectsGroup
@@ -1812,6 +1811,7 @@ BuildingType
                         tag = "species" data = "SP_EXPERIMENTOR"
                         tag = "rawtext" data = "3"
                     ]
+                [[EXPERIMENTOR_ADD_STARLANE]]
             ]
 
         EffectsGroup
@@ -1832,6 +1832,7 @@ BuildingType
                         tag = "species" data = "SP_EXPERIMENTOR"
                         tag = "rawtext" data = "2"
                     ]
+                [[EXPERIMENTOR_ADD_STARLANE]]
             ]
 
         EffectsGroup
@@ -1853,6 +1854,7 @@ BuildingType
                         tag = "species" data = "SP_EXPERIMENTOR"
                         tag = "rawtext" data = "3"
                     ]
+                [[EXPERIMENTOR_ADD_STARLANE]]
             ]
 
         EffectsGroup
@@ -1873,6 +1875,7 @@ BuildingType
                         tag = "species" data = "SP_EXPERIMENTOR"
                         tag = "rawtext" data = "2"
                     ]
+                [[EXPERIMENTOR_ADD_STARLANE]]
             ]
 
         EffectsGroup
@@ -1892,6 +1895,7 @@ BuildingType
                         tag = "species" data = "SP_EXPERIMENTOR"
                         tag = "rawtext" data = "1"
                     ]
+                [[EXPERIMENTOR_ADD_STARLANE]]
             ]
     ]
     icon = ""


### PR DESCRIPTION
- Starlanes will be created whenever monsters are spawned (not the turn later).
- The experimentor building won't destroy itself after being conquered and will go on creating starlanes and spawning monsters for the owner.
