### PR TITLE
AI: Allow ShipDesigner to use unavailable parts

### DIFF
--- a/default/AI/ResearchAI.py
+++ b/default/AI/ResearchAI.py
@@ -465,17 +465,17 @@ def generate_research_orders():
         if not (unlocked_parts or unlocked_hulls):
             print "No new ship parts/hulls unlocked by tech %s" % tech
             continue
-        old_designs = ShipDesignAI.MilitaryShipDesigner().optimize_design()
-        new_designs = ShipDesignAI.MilitaryShipDesigner().optimize_design(additional_hulls=unlocked_hulls, additional_parts=unlocked_parts)
+        old_designs = ShipDesignAI.MilitaryShipDesigner().optimize_design(consider_fleet_count=False)
+        new_designs = ShipDesignAI.MilitaryShipDesigner().optimize_design(additional_hulls=unlocked_hulls, additional_parts=unlocked_parts, consider_fleet_count=False)
         old_rating, old_pid, old_design_id, old_cost = old_designs[0]
         old_design = fo.getShipDesign(old_design_id)
         new_rating, new_pid, new_design_id, new_cost = new_designs[0]
         new_design = fo.getShipDesign(new_design_id)
-        if new_rating*old_cost > old_rating*old_cost:  # TODO: Check if cost-normalization is necessary / fix (as design cost probably is adjusted by fleet upkeep)
+        if new_rating > old_rating:
             print "Tech %s gives access to a better design!" % tech
-            print "old best design: Rating %.1f (at planet %d with cost %d)" % (old_rating, old_pid, old_cost)
+            print "old best design: Rating %.5f" % old_rating
             print "old design specs: %s - " % old_design.hull, list(old_design.parts)
-            print "new best design: Rating %.1f (at planet %d with cost %d)" % (new_rating, new_pid, new_cost)
+            print "new best design: Rating %.5f" % new_rating
             print "new design specs: %s - " % new_design.hull, list(new_design.parts)
         else:
             print "Tech %s gives access to new parts or hulls but there seems to be no military advantage." % tech


### PR DESCRIPTION
- Allow ShipDesign to simulate designs with not-yet-unlocked parts and
  hulls by passing them as additional parameters to optimize_design()
- Add Example code for its use in ResearchAI to assess the military value of a tech
- Enhance cost_cache functionality and add some safety net for
  possible future implementation errors (accessing non-cached items)

Example output:
2015-07-06 10:45:56.273733 [debug] AI : Tech SHP_WEAPON_4_2 unlocks a ShipPart: SR_WEAPON_4_2
2015-07-06 10:45:56.300735 [debug] AI : Tech SHP_WEAPON_4_2 gives access to a better design!
2015-07-06 10:45:56.300735 [debug] AI : old best design: Rating 1.9 (at planet 155 with cost 76)
2015-07-06 10:45:56.301735 [debug] AI : old design specs: SH_STANDARD -  ['SR_WEAPON_1_1', 'SR_WEAPON_1_1', 'AR_STD_PLATE', '']
2015-07-06 10:45:56.301735 [debug] AI : new best design: Rating 6.2 (at planet 155 with cost 161)
2015-07-06 10:45:56.301735 [debug] AI : new design specs: SH_STANDARD -  ['SR_WEAPON_4_2', 'SR_WEAPON_4_2', 'AR_STD_PLATE', 'FU_BASIC_TANK']
2015-07-06 10:45:56.301735 [debug] AI : Tech SHP_TRANSSPACE_DRIVE unlocks a ShipHull: SH_TRANSSPATIAL
2015-07-06 10:45:56.301735 [debug] AI : Tech SHP_TRANSSPACE_DRIVE unlocks a ShipPart: FU_TRANSPATIAL_DRIVE
2015-07-06 10:45:56.321736 [debug] AI : Tech SHP_TRANSSPACE_DRIVE gives access to new parts or hulls but there seems to be no military advantage.
