### PR TITLE
Universe generation: additional requirement for home system selection

### DIFF
--- a/default/python/universe_generation/options.py
+++ b/default/python/universe_generation/options.py
@@ -26,18 +26,32 @@ NAMING_LARGE_GALAXY_SIZE = 200  # a galaxy with 200+ star systems is considered 
 ## HOME SYSTEM SELECTION OPTIONS ##
 ###################################
 
-# These options are needed in the home system selection/placement process. They determines the minimum number of
-# planets that a home system must have in its near vicinity, and define the extend of this "near vicinity".
+# These options are needed in the home system selection/placement process. They determine the minimum number of
+# systems and planets that a home system must have in its near vicinity, define the extend of this "near vicinity", etc.
 
-# The following two options are used to determine the minimum number of planets. This limit is
-# HS_MIN_PLANETS_IN_VICINITY_PER_SYSTEM planets per system within the near vicinity of a home system, capped at
-# HS_MIN_PLANETS_IN_VICINITY_TOTAL
+# The following two options are used to determine the minimum number of systems and planets. This limit is
+# HS_MIN_SYSTEMS_IN_VICINITY systems and HS_MIN_PLANETS_IN_VICINITY_PER_SYSTEM planets per system within the near
+# vicinity of a home system, capped at HS_MIN_PLANETS_IN_VICINITY_TOTAL
+HS_MIN_SYSTEMS_IN_VICINITY = 8
 HS_MIN_PLANETS_IN_VICINITY_TOTAL = 10
 HS_MIN_PLANETS_IN_VICINITY_PER_SYSTEM = 1
 
 # This option defines the extend of what is considered the "near vicinity" of a home system. This are all systems that
 # are within the number of jumps specified by HS_VICINITY_RANGE.
 HS_VICINITY_RANGE = 3
+
+# This options sets the maximum starting value for the minimum jump distance limit required between home systems.
+# With large galaxies an excessive amount of time can be used in failed attempts to select home systems, so defining
+# an upper limit for the home system selection process to use when calculating the starting value for the minimum
+# jump distance limit is reasonable.
+HS_MAX_JUMP_DISTANCE_LIMIT = 10
+
+# This options defines the minimum jump distance limit between home systems that should be considered high priority.
+# As long as the jump distance limit which home systems must at least be apart does not get reduced below this limit
+# during the home system selection process, the minimum systems in home system vicinity requirement takes
+# precedence over the jump distance limit. If the jump distance limit drops below this minimum jump distance limit,
+# the process is restarted giving th jump distance limit precedence.
+HS_MIN_DISTANCE_PRIORITY_LIMIT = 5
 
 # These two options define which types of planets are counted when determining the number of planets in the near
 # vicinity of a home system. HS_ACCEPTABLE_PLANET_SIZES is actually only needed for the process of adding planets


### PR DESCRIPTION
An attempt to address the issue [discussed here](http://www.freeorion.org/forum/viewtopic.php?f=6&t=9570). I've expanded the code that selects the home worlds and added a minimum number of systems in the near vicinity limit (in addition to the already existing minimum number of planets limit). I've set that limit to 8 (subject to testing and change of course).

Of course, having an additional limit makes things considerably complicated, as prioritizing all these limits/requirements becomes an issue now. In this first draft I give having a higher min distance between home systems priority over having a sufficient min number of systems in the near vicinity (pls look at the code changes for details).

Feedback, thoughts, comments?
