### PR TITLE
Fix CMake autogeneration of util/Version.cpp for first-time builds.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,9 +77,13 @@ endif ()
 
 find_package(PythonInterp ${PYTHON_VERSION} REQUIRED)
 
-# To run the version generation every compile we need to deferr the
-# execution to a separate target and the existing python command
-add_custom_target(freeorionversion
+# To update the version string every compile, we need to defer
+# execution of the existing python command to a separate target;
+# note the dummy "always built" output, which forces regeneration
+add_custom_command(
+    OUTPUT
+    "${CMAKE_SOURCE_DIR}/util/Version.cpp"
+    "always built"
     COMMAND
     "${PYTHON_EXECUTABLE}"
     "${CMAKE_SOURCE_DIR}/cmake/make_versioncpp.py"
@@ -262,8 +266,6 @@ add_library(freeorioncommon
     ${freeorioncommon_HEADER}
     ${freeorioncommon_SOURCE}
 )
-
-add_dependencies(freeorioncommon freeorionversion)
 
 if (CMAKE_CXX_COMPILER_ID STREQUAL Clang)
     set_property(


### PR DESCRIPTION
After freshly cloning from the git repository and running

```
cd freeorion
mkdir build
cd build
cmake ..
make
```

compilation fails due to an undefined reference to `FreeOrionVersionString()`.  This function is defined in util/Version.cpp, which is an automatically generated file.

After a failed build, running a subsequent `cmake . && make` fixes the problem, but this may not be obvious to the uninitiated.

The reason for this behavior is discussed in http://www.cmake.org/cmake/help/v3.0/policy/CMP0046.html.  CMake policy prior to version 3.0 (freeorion uses 2.6.4) is to silently ignore missing source dependencies, so upon the first call to `cmake`, the build doesn't realize it needs to compile and link util/Version.cpp.  It does, however, create the file, because that step is performed in an always-run custom target.  Subsequent calls to `cmake` can then detect and handle the file as appropriate, permitting successful builds.

The best fix to this problem is to replace the `freeorionversion` target in CMakeLists.txt with a rule that explicitly indicates it will build util/Version.cpp.  Such a rule might be written:

```
add_custom_command(
    OUTPUT
    "${CMAKE_SOURCE_DIR}/util/Version.cpp"
    "always built"
    COMMAND
    ...
)
```

Note the use of a dummy output `"always built"` to force the rule to always run.  Because this output is never actually created, `make` considers the rule to be perpetually out of date and thus rebuilds the version string with every compile.  The particular string "always built" is chosen because it results in grammatical log entries: "Generating ../util/Version.cpp, always built"

With the above modification, we can also remove the line

```
add_dependencies(freeorioncommon freeorionversion)
```

because dependency on the generation of util/Version.cpp is handled implicitly.
