### PR TITLE
initial ship damage tooltip attempt; the display is still 

### DIFF
--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -932,7 +932,7 @@ void ShipDataPanel::Refresh() {
         it->second->SetValue(StatValue(it->first));
 
         it->second->ClearBrowseInfoWnd();
-        if (it->first == METER_DAMAGE) {
+        if (false && it->first == METER_DAMAGE) {
             boost::shared_ptr<GG::BrowseInfoWnd> browse_wnd(new IconTextBrowseWnd(
                 DamageIcon(), UserString("SHIP_DAMAGE_STAT_TITLE"),
                 UserString("SHIP_DAMAGE_STAT_MAIN")));

--- a/UI/MeterBrowseWnd.cpp
+++ b/UI/MeterBrowseWnd.cpp
@@ -219,7 +219,7 @@ void MeterBrowseWnd::UpdateSummary() {
         breakdown_total = obj->InitialMeterValue(m_primary_meter_type);
         breakdown_meter_name = MeterToUserString(m_primary_meter_type);
     } else {
-        ErrorLogger() << "MeterBrowseWnd::UpdateSummary can't get primary meter";
+        ErrorLogger() << "MeterBrowseWnd::UpdateSummary can't get primary meter for meter type " << m_primary_meter_type;
         return;
     }
 

--- a/universe/Ship.cpp
+++ b/universe/Ship.cpp
@@ -62,6 +62,7 @@ Ship::Ship(int empire_id, int design_id, const std::string& species_name,
     AddMeter(METER_RESEARCH);
     AddMeter(METER_TARGET_TRADE);
     AddMeter(METER_TRADE);
+    AddMeter(METER_DAMAGE);
 
     const std::vector<std::string>& part_names = Design()->Parts();
     for (std::size_t i = 0; i < part_names.size(); ++i) {
@@ -531,6 +532,7 @@ void Ship::ResetTargetMaxUnpairedMeters() {
     UniverseObject::GetMeter(METER_DETECTION)->ResetCurrent();
     UniverseObject::GetMeter(METER_SPEED)->ResetCurrent();
     UniverseObject::GetMeter(METER_SPEED)->ResetCurrent();
+    UniverseObject::GetMeter(METER_DAMAGE)->ResetCurrent();
 
     for (PartMeterMap::iterator it = m_part_meters.begin(); it != m_part_meters.end(); ++it)
     { it->second.ResetCurrent(); }
@@ -566,6 +568,7 @@ void Ship::ClampMeters() {
     UniverseObject::GetMeter(METER_DETECTION)->ClampCurrentToRange();
     UniverseObject::GetMeter(METER_SPEED)->ClampCurrentToRange();
     UniverseObject::GetMeter(METER_SPEED)->ClampCurrentToRange();
+    UniverseObject::GetMeter(METER_DAMAGE)->ClampCurrentToRange();
 
     for (PartMeterMap::iterator it = m_part_meters.begin(); it != m_part_meters.end(); ++it)
         it->second.ClampCurrentToRange();

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -189,6 +189,7 @@ void PartType::Init(const std::vector<boost::shared_ptr<Effect::EffectsGroup> >&
         case PC_MISSILES:
         case PC_FIGHTERS:
             m_effects.push_back(IncreaseMeter(METER_DAMAGE,         m_name, m_capacity, false));
+            m_effects.push_back(IncreaseMeter(METER_DAMAGE,         m_capacity));
             break;
         case PC_COLONY:
         case PC_TROOPS:


### PR DESCRIPTION
not fully correct, as you can see below: 
![](http://i.imgur.com/VgGdrIh.png)

I can confirm that, as hoped, adding the ship damage meter (to support the tooltip) does not appear to affect combat at all.

I am a bit too tired/busy to sort this out just now, but I think it would be really great if we had this in place for 0.4.5, since the info is a great help in assessing damage against ship shields.  So, if anyone is inspired to get this fixed, please go ahead and cherrypick this commit, fix it up and submit it yourself.
