### PR TITLE
Remove double-space in version string when building master

### DIFF
--- a/Xcode/Info.plist.in
+++ b/Xcode/Info.plist.in
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleVersion</key>
-	<string>${FreeOrion_VERSION} ${FreeOrion_BRANCH} (build ${FreeOrion_BUILD_NO})</string>
+	<string>${FreeOrion_VERSION} ${FreeOrion_BRANCH_}(build ${FreeOrion_BUILD_NO})</string>
 	<key>CFBundleShortVersionString</key>
 	<string>${FreeOrion_VERSION} (build ${FreeOrion_BUILD_NO})</string>
 </dict>

--- a/Xcode/Info.plist.in
+++ b/Xcode/Info.plist.in
@@ -19,7 +19,7 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleVersion</key>
-	<string>${FreeOrion_VERSION} ${FreeOrion_BRANCH_}(build ${FreeOrion_BUILD_NO})</string>
+	<string>${FreeOrion_VERSION} ${FreeOrion_BRANCH}(build ${FreeOrion_BUILD_NO})</string>
 	<key>CFBundleShortVersionString</key>
 	<string>${FreeOrion_VERSION} (build ${FreeOrion_BUILD_NO})</string>
 </dict>

--- a/cmake/make_versioncpp.py
+++ b/cmake/make_versioncpp.py
@@ -29,15 +29,14 @@ class Generator(object):
         self.infile = infile
         self.outfile = outfile
 
-    def compile_output(self, template, version, branch, branch_space, build_no, build_sys):
+    def compile_output(self, template, version, branch, build_no, build_sys):
         return template.substitute(
             FreeOrion_VERSION=version,
             FreeOrion_BRANCH=branch,
-            FreeOrion_BRANCH_=branch_space,
             FreeOrion_BUILD_NO=build_no,
             FreeOrion_BUILDSYS=build_sys)
 
-    def execute(self, version, branch, branch_space, build_no, build_sys):
+    def execute(self, version, branch, build_no, build_sys):
         if build_no == INVALID_BUILD_NO:
             print "WARNING: Can't determine git commit, %s not updated!" % self.outfile
             return
@@ -56,7 +55,7 @@ class Generator(object):
 
         print "Writing file: %s" % self.outfile
         with open(self.outfile, "w") as generated_file:
-            generated_file.write(self.compile_output(template, version, branch, branch_space, build_no, build_sys))
+            generated_file.write(self.compile_output(template, version, branch, build_no, build_sys))
 
 
 class NsisInstScriptGenerator(Generator):
@@ -71,13 +70,12 @@ class NsisInstScriptGenerator(Generator):
                 accepted_dll_files.append(dll_file)
         return accepted_dll_files
 
-    def compile_output(self, template, version, branch, branch_space, build_no, build_sys):
+    def compile_output(self, template, version, branch, build_no, build_sys):
         dll_files = self.compile_dll_list()
         if dll_files:
             return template.substitute(
                 FreeOrion_VERSION=version,
                 FreeOrion_BRANCH=branch,
-                FreeOrion_BRANCH_=branch_space,
                 FreeOrion_BUILD_NO=build_no,
                 FreeOrion_BUILDSYS=build_sys,
                 FreeOrion_DLL_LIST_INSTALL="\n  ".join(['File "..\\' + fname + '"' for fname in dll_files]),
@@ -87,7 +85,6 @@ class NsisInstScriptGenerator(Generator):
             return template.substitute(
                 FreeOrion_VERSION=version,
                 FreeOrion_BRANCH=branch,
-                FreeOrion_BRANCH_=branch_space,
                 FreeOrion_BUILD_NO=build_no,
                 FreeOrion_BUILDSYS=build_sys,
                 FreeOrion_DLL_LIST_INSTALL="",
@@ -112,21 +109,19 @@ if system() == 'Darwin':
 
 version = "0.4.4+"
 branch = ""
-branch_space = ""
 build_no = INVALID_BUILD_NO
 
 try:
     branch = check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD']).strip()
     if branch == "master":
         branch = ""
-        branch_space = ""
     else:
-        branch_space = branch + " "
+        branch += " "
     build_no = check_output(['git', 'show', '-s', '--format=%cd.%h', '--date=short', 'HEAD']).strip()
 except:
     print "WARNING: git not installed"
 
 for generator in generators:
-    generator.execute(version, branch, branch_space, build_no, build_sys)
+    generator.execute(version, branch, build_no, build_sys)
 
-print "Building v%s %sbuild %s" % (version, branch_space, build_no)
+print "Building v%s %sbuild %s" % (version, branch, build_no)

--- a/util/Version.cpp.in
+++ b/util/Version.cpp.in
@@ -1,7 +1,7 @@
 #include "util/Version.h"
 
 namespace {
-    static const std::string retval = "v${FreeOrion_VERSION} ${FreeOrion_BRANCH} [build ${FreeOrion_BUILD_NO}] ${FreeOrion_BUILDSYS}";
+    static const std::string retval = "v${FreeOrion_VERSION} ${FreeOrion_BRANCH_}[build ${FreeOrion_BUILD_NO}] ${FreeOrion_BUILDSYS}";
 }
 
 const std::string& FreeOrionVersionString()

--- a/util/Version.cpp.in
+++ b/util/Version.cpp.in
@@ -1,7 +1,7 @@
 #include "util/Version.h"
 
 namespace {
-    static const std::string retval = "v${FreeOrion_VERSION} ${FreeOrion_BRANCH_}[build ${FreeOrion_BUILD_NO}] ${FreeOrion_BUILDSYS}";
+    static const std::string retval = "v${FreeOrion_VERSION} ${FreeOrion_BRANCH}[build ${FreeOrion_BUILD_NO}] ${FreeOrion_BUILDSYS}";
 }
 
 const std::string& FreeOrionVersionString()


### PR DESCRIPTION
It's just a cosmetic thing in the end, but I didn't like the two spaces left in a row when make_versioncpp.py uses an empty string for the master branch name.  I added a `FreeOrion_BRANCH_` template keyword to the generators which is like `FreeOrion_BRANCH` in that it still resolves to an empty string on master, but it appends a space to the branch name otherwise.  Changing
`[...] ${FreeOrion_BRANCH} [...]`
to
`[...] ${FreeOrion_BRANCH_}[...]`
then leaves one space between words for master as well :)

There are no longer any occurrences of `FreeOrion_BRANCH` left but I didn't remove it (yet) in case anyone had plans to use it in some generated file or other... Hope my Python is alright!
