### PR TITLE
Added support for an optional "persistent_config.xml" settings file…

### DIFF
--- a/client/AI/camain.cpp
+++ b/client/AI/camain.cpp
@@ -37,6 +37,11 @@ int wmain(int argc, wchar_t* argv[], wchar_t* envp[]) {
                 doc.ReadDoc(ifs);
                 GetOptionsDB().SetFromXML(doc);
             }
+            boost::filesystem::ifstream pifs(GetPersistentConfigPath());
+            if (pifs) {
+                doc.ReadDoc(pifs);
+                GetOptionsDB().SetFromXML(doc);
+            }
         }
         GetOptionsDB().SetFromCommandLine(args);
 

--- a/client/human/chmain.cpp
+++ b/client/human/chmain.cpp
@@ -131,6 +131,16 @@ int mainConfigOptionsSetup(const std::vector<std::string>& args) {
             } catch (const std::exception&) {
                 std::cerr << UserString("UNABLE_TO_READ_CONFIG_XML") << std::endl;
             }
+            try {
+                boost::filesystem::ifstream pifs(GetPersistentConfigPath());
+                if (pifs) {
+                    doc.ReadDoc(pifs);
+                    GetOptionsDB().SetFromXML(doc);
+                }
+            } catch (const std::exception&) {
+                std::cerr << UserString("UNABLE_TO_READ_PERSISTENT_CONFIG_XML")  << ": " 
+                          << GetPersistentConfigPath() << std::endl;
+            }
         }
 
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -784,6 +784,9 @@ Error when writing config.xml file. Unable to save options.
 UNABLE_TO_READ_CONFIG_XML
 Error when reading config.xml file. Using default options.
 
+UNABLE_TO_READ_PERSISTENT_CONFIG_XML
+Error when attempting to read the optional persistent_config.xml file (this is expected if it does not exist).
+
 UNABLE_TO_WRITE_SAVE_FILE
 Error when writing save file.
 

--- a/server/dmain.cpp
+++ b/server/dmain.cpp
@@ -41,6 +41,17 @@ int wmain(int argc, wchar_t* argv[], wchar_t* envp[]) {
                 doc.ReadDoc(ifs);
                 GetOptionsDB().SetFromXML(doc);
             }
+
+            try {
+                boost::filesystem::ifstream pifs(GetPersistentConfigPath());
+                if (pifs) {
+                    doc.ReadDoc(pifs);
+                    GetOptionsDB().SetFromXML(doc);
+                }
+            } catch (const std::exception&) {
+                ErrorLogger() << "main() unable to read persistent option config file: " 
+                              << GetPersistentConfigPath() << std::endl;
+            }
         }
 
         GetOptionsDB().SetFromCommandLine(args);

--- a/util/Directories.cpp
+++ b/util/Directories.cpp
@@ -300,6 +300,11 @@ const fs::path GetConfigPath() {
     return p;
 }
 
+const fs::path GetPersistentConfigPath() {
+    static const fs::path p = GetUserDir() / "persistent_config.xml";
+    return p;
+}
+
 const fs::path GetSaveDir() {
     // if save dir option has been set, use specified location.  otherwise,
     // use default location

--- a/util/Directories.h
+++ b/util/Directories.h
@@ -52,6 +52,9 @@ FO_COMMON_API const boost::filesystem::path GetPythonHome();
 /** Returns the full path to the configfile. */
 FO_COMMON_API const boost::filesystem::path GetConfigPath();
 
+/** Returns the full path to the configfile. */
+FO_COMMON_API const boost::filesystem::path GetPersistentConfigPath();
+
 /** Returns the directory where save files are located.  This is typically
   * the directory "save" within the user directory. */
 FO_COMMON_API const boost::filesystem::path GetSaveDir();


### PR DESCRIPTION
…which may contain a subset of settings from config.xml, and which will override config.xml.  These settings will persist even if config.xml itself overwritten.

This file must be manually created/edited.  One easy way is to copy config.xml and then remove any entries not desired to be in the permanent store.

A place to keep those personal settings one doesn't like always being overwritten...
