### PR TITLE
Remove harmless log message from GraphicalSummaryWnd::DoLayout()

### DIFF
--- a/UI/CombatReport/GraphicalSummary.cpp
+++ b/UI/CombatReport/GraphicalSummary.cpp
@@ -657,7 +657,7 @@ GraphicalSummaryWnd::GraphicalSummaryWnd() :
     GG::Wnd(GG::X0, GG::Y0, GG::X1, GG::Y1, GG::NO_WND_FLAGS),
     m_sizer(0),
     m_options_bar(0)
-{ }
+{}
 
 GG::Pt GraphicalSummaryWnd::MinUsableSize() const {
     GG::Pt min_size(GG::X0, GG::Y0);
@@ -683,11 +683,8 @@ void GraphicalSummaryWnd::SetLog(int log_id)
 { MakeSummaries(log_id); }
 
 void GraphicalSummaryWnd::DoLayout() {
-    if (!m_sizer) {
-        ErrorLogger() << "GraphicalSummaryWnd::DoLayout() called before "
-                         "creating m_sizer.";
+    if (!m_sizer || !m_options_bar)
         return;
-    }
 
     GG::Pt ul(GG::X0, SIDE_BOX_MARGIN);
 


### PR DESCRIPTION
Decided to get rid of the log message from a null-pointer check before 0.4.5 is released.  Restructuring the class to leave it in a better state upon construction would look nicer but that can wait until afterwards, since the feature works as is.
