### PR TITLE
Fix warning: uninitialized use

### DIFF
--- a/GG/src/SDL/SDLGUI.cpp
+++ b/GG/src/SDL/SDLGUI.cpp
@@ -566,7 +566,7 @@ SDLGUI* SDLGUI::GetGUI()
 
 Key SDLGUI::GGKeyFromSDLKey(const SDL_Keysym& key)
 {
-    Key retval;
+    Key retval = GGK_UNKNOWN;
     if (m_key_map.find(key.sym) != m_key_map.end()) {
         retval = m_key_map[key.sym];
     }


### PR DESCRIPTION
[ 58%] Building CXX object GG/src/SDL/CMakeFiles/GiGiSDL.dir/SDLGUI.cpp.o
freeorion/GG/src/SDL/SDLGUI.cpp: In member function ‘GG::Key GG::SDLGUI::GGKeyFromSDLKey(const SDL_Keysym&)’:
freeorion/GG/src/SDL/SDLGUI.cpp:580:45: warning: ‘retval’ may be used uninitialized in this function [-Wmaybe-uninitialized]
             retval = Key(std::toupper(retval));

Signed-off-by: Vincent Legoll vincent.legoll@gmail.com
