### PR TITLE
Suitability refactoring & ObjlistWnd create colony building

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -162,6 +162,7 @@ set (freeorioncommon_HEADER
     universe/Ship.h
     universe/Special.h
     universe/Species.h
+    universe/Suitability.h
     universe/System.h
     universe/Tech.h
     universe/Universe.h
@@ -225,6 +226,7 @@ set (freeorioncommon_SOURCE
     universe/ShipDesign.cpp
     universe/Special.cpp
     universe/Species.cpp
+    universe/Suitability.cpp
     universe/System.cpp
     universe/Tech.cpp
     universe/Universe.cpp

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -15,6 +15,7 @@
 #include "../universe/Fleet.h"
 #include "../universe/Ship.h"
 #include "../universe/ShipDesign.h"
+#include "../universe/Suitability.h"
 #include "../universe/Planet.h"
 #include "../universe/Building.h"
 #include "../universe/Field.h"
@@ -2356,11 +2357,36 @@ void ObjectListWnd::ObjectRightClicked(GG::ListBox::iterator it, const GG::Pt& p
         return;
 
     const int MENUITEM_SET_FOCUS_BASE = 20;
-    int menuitem_id = MENUITEM_SET_FOCUS_BASE;
+    const int MENUITEM_CREATE_COLONY_BASE = 30;
+    int menuitem_id_focus = MENUITEM_SET_FOCUS_BASE;
+    int menuitem_id_colony = MENUITEM_CREATE_COLONY_BASE;
+
     std::map<std::string, int> all_foci;
     UniverseObjectType type = obj->ObjectType();
     if (type == OBJ_PLANET) {
         menu_contents.next_level.push_back(GG::MenuItem(UserString("SP_PLANET_SUITABILITY"), 2, false, false));
+
+        TemporaryPtr<Planet> planet = GetPlanet(object_id);
+        // My planet is empty, we may now want to create a colony there...
+        if (planet->OwnedBy(app->EmpireID()) && planet->GetMeter(METER_POPULATION)->Current() == 0.0f) {
+                if (Empire* emp = GetEmpire(app->EmpireID())) {
+                    GG::MenuItem colonyMenuItem(UserString("MENUITEM_CREATE_COLONY"), 6, false, false);
+
+                    std::set<std::string> species = GetColonizerSpecies(emp, planet);
+
+                    for (std::set<std::string>::const_iterator it = species.begin(); it != species.end(); ++it) {
+                        std::string species_name = *it;
+                        const Species* species = GetSpecies(species_name);
+                        PlanetEnvironment planet_environment = species->GetPlanetEnvironment(planet->Type());
+                        if (planet_environment != PE_UNINHABITABLE) {
+                            menuitem_id_colony++;
+                            colonyMenuItem.next_level.push_back(GG::MenuItem(UserString(species_name), menuitem_id_colony, false, false));
+                        }
+                    }
+                    if (menuitem_id_colony > MENUITEM_CREATE_COLONY_BASE)
+                        menu_contents.next_level.push_back(colonyMenuItem);
+                }
+        }
 
         const GG::ListBox::SelectionSet sel = m_list_box->Selections();
         for (GG::ListBox::SelectionSet::const_iterator it = sel.begin(); it != sel.end(); ++it) {
@@ -2376,12 +2402,12 @@ void ObjectListWnd::ObjectRightClicked(GG::ListBox::iterator it, const GG::Pt& p
         }
         GG::MenuItem focusMenuItem(UserString("MENUITEM_SET_FOCUS"), 3, false, false);
         for (std::map<std::string, int>::iterator it = all_foci.begin(); it != all_foci.end(); ++it) {
-            menuitem_id++;
+            menuitem_id_focus++;
             std::stringstream out;
             out << UserString(it->first) << " (" << it->second << ")";
-            focusMenuItem.next_level.push_back(GG::MenuItem(out.str(), menuitem_id, false, false));
+            focusMenuItem.next_level.push_back(GG::MenuItem(out.str(), menuitem_id_focus, false, false));
         }
-        if (menuitem_id > MENUITEM_SET_FOCUS_BASE)
+        if (menuitem_id_focus > MENUITEM_SET_FOCUS_BASE)
             menu_contents.next_level.push_back(focusMenuItem);
     }
     // moderator actions...
@@ -2407,6 +2433,10 @@ void ObjectListWnd::ObjectRightClicked(GG::ListBox::iterator it, const GG::Pt& p
                 // should never happen, Set Focus parent menu item is disabled
                 break;
         }
+        case 6: {
+                // should never happen, create colony parent menu item is disabled
+                break;
+        }
         case 10: {
             net.SendMessage(ModeratorActionMessage(app->PlayerID(), Moderator::DestroyUniverseObject(object_id)));
             break;
@@ -2417,7 +2447,7 @@ void ObjectListWnd::ObjectRightClicked(GG::ListBox::iterator it, const GG::Pt& p
         }
         default: {
             int id = popup.MenuID();
-            if (id > MENUITEM_SET_FOCUS_BASE && id <= menuitem_id) {
+            if (id > MENUITEM_SET_FOCUS_BASE && id <= menuitem_id_focus) {
                 std::map<std::string, int>::iterator it = all_foci.begin();
                 std::advance(it, id - MENUITEM_SET_FOCUS_BASE - 1);
                 std::string focus = it->first;
@@ -2432,11 +2462,27 @@ void ObjectListWnd::ObjectRightClicked(GG::ListBox::iterator it, const GG::Pt& p
                          }
                     }
                 }
+                std::set<int> sel_ids = SelectedObjectIDs();
+                Refresh();
+                SetSelectedObjects(sel_ids);
+                ObjectSelectionChanged(m_list_box->Selections());
+            } else if (id > MENUITEM_CREATE_COLONY_BASE && id <= menuitem_id_colony) {
+                Empire* empire = GetEmpire(app->EmpireID());
+                std::set<std::string> species = GetColonizerSpecies(empire, GetPlanet(object_id), false);
+
+                std::set<std::string>::const_iterator it = species.begin();
+                std::advance(it, id - MENUITEM_CREATE_COLONY_BASE - 1);
+
+                std::string species_name = *it; // SP_ABADDONI
+                std::string building_name = "BLD_COL_" + species_name.substr(3); // BLD_COL_ABADDONI
+
+                if (!empire->ProducibleItem(BT_BUILDING, building_name, object_id)) {
+                    ErrorLogger() << "Cannot produce building at that location";
+                } else {
+                app->Orders().IssueOrder(OrderPtr(
+                    new ProductionQueueOrder(app->EmpireID(), BT_BUILDING, building_name, 1, object_id)));
+                }
             }
-            std::set<int> sel_ids = SelectedObjectIDs();
-            Refresh();
-            SetSelectedObjects(sel_ids);
-            ObjectSelectionChanged(m_list_box->Selections());
             break;
         }
         }

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -2471,6 +2471,9 @@ Latest known [[encyclopedia STEALTH_TITLE]] is out of date. Actual stealth excee
 MENUITEM_SET_FOCUS
 Set focus
 
+MENUITEM_CREATE_COLONY
+Create colony
+
 ## Resources Panel ##########
 
 RP_FOCUS_TOOLTIP

--- a/universe/Suitability.cpp
+++ b/universe/Suitability.cpp
@@ -1,0 +1,133 @@
+#include "Suitability.h"
+
+#include "Building.h"
+#include "Fleet.h"
+#include "Ship.h"
+#include "ShipDesign.h"
+#include "Planet.h"
+#include "Predicates.h"
+#include "Species.h"
+#include "System.h"
+#include "Field.h"
+#include "Universe.h"
+#include "UniverseObject.h"
+#include "Condition.h"
+#include "Suitability.h"
+#include "../Empire/EmpireManager.h"
+#include "../Empire/Empire.h"
+#include "../util/Random.h"
+#include "../util/Logger.h"
+#include "../util/MultiplayerCommon.h"
+
+std::string GetBestSuitable(std::map<std::string, std::pair<PlanetEnvironment, float> > suitabilities)
+{
+    float best_suitable = -100000000000000.0f;
+    std::string best_species;
+    for (std::map<std::string, std::pair<PlanetEnvironment, float> >::const_iterator it = suitabilities.begin(); it != suitabilities.end(); it++)
+    {
+        std::string species_name = it->first;
+        float suitability = it->second.second;
+        if (suitability > best_suitable) {
+            best_suitable = suitability;
+            best_species = species_name;
+        }
+    }
+    return best_species;
+}
+
+std::map<std::string, std::pair<PlanetEnvironment, float> > GetSuitabilitiesForSpecies(int empire_id, int planet_id, std::set<std::string> species_names)
+{
+    TemporaryPtr<Planet> planet = GetPlanet(planet_id);
+    std::map<std::string, std::pair<PlanetEnvironment, float> > population_counts;
+
+    // Back original values up to restore later
+    std::string original_planet_species = planet->SpeciesName();
+    int original_owner_id = planet->Owner();
+    float orig_initial_target_pop = planet->GetMeter(METER_TARGET_POPULATION)->Initial();
+
+    // We don't want to notify universe about what we are about to change
+    GetUniverse().InhibitUniverseObjectSignals(true);
+
+    // Set owner to allow computing planet meters with this empire
+    planet->SetOwner(empire_id);
+
+    for (std::set<std::string>::const_iterator it = species_names.begin();
+         it != species_names.end(); it++)
+    {
+        std::string species_name = *it;
+
+        const Species* species = GetSpecies(species_name);
+        if (!species)
+            continue;
+
+        PlanetEnvironment planet_environment = species->GetPlanetEnvironment(planet->Type());
+        population_counts[species_name].first = planet_environment;
+        population_counts[species_name].second = 0.0f;
+
+        if (planet_environment != PE_UNINHABITABLE) {
+            // Setting the planet's species allows all of its meters to reflect
+            // species (and empire) properties, such as environment type
+            // preferences and techs.
+            // @see also: MapWnd::UpdateMeterEstimates()
+            planet->SetSpecies(species_name);
+            planet->GetMeter(METER_TARGET_POPULATION)->Set(0.0, 0.0);
+
+            // Compute the meter values, for newly set species
+            GetUniverse().UpdateMeterEstimates(planet_id);
+
+            // Store the value we're interested in
+            population_counts[species_name].second = planet->CurrentMeterValue(METER_TARGET_POPULATION);
+        }
+    }
+
+    // Restore planet's original values
+    planet->SetSpecies(original_planet_species);
+    planet->SetOwner(original_owner_id);
+    planet->GetMeter(METER_TARGET_POPULATION)->Set(orig_initial_target_pop, orig_initial_target_pop);
+
+    // Restore meters
+    GetUniverse().UpdateMeterEstimates(planet_id);
+
+    // Restore signalling
+    GetUniverse().InhibitUniverseObjectSignals(false);
+
+    return population_counts;
+}
+
+std::set<std::string> GetColonizerSpecies(Empire* empire, TemporaryPtr<const Planet> planet, bool all_species /* = true */)
+{
+    std::set<std::string> species_names;
+
+    if (all_species) {
+        const SpeciesManager& species_manager = GetSpeciesManager();
+        for (SpeciesManager::iterator it = species_manager.begin(); it != species_manager.end(); ++it)
+        {
+            if (it->second && (it->second->Tags().find("CTRL_ALWAYS_REPORT") != it->second->Tags().end()))
+                    species_names.insert(it->first);
+        }
+    }
+
+    const std::vector<int> pop_center_ids = empire->GetPopulationPool().PopCenterIDs();
+    for (std::vector<int>::const_iterator it = pop_center_ids.begin(); it != pop_center_ids.end(); it++) {
+        TemporaryPtr<const UniverseObject> obj = GetUniverseObject(*it);
+        TemporaryPtr<const PopCenter> pc = boost::dynamic_pointer_cast<const PopCenter>(obj);
+        if (!pc)
+            continue;
+
+        const std::string& species_name = pc->SpeciesName();
+        if (species_name.empty())
+            continue;
+
+        const Species* species = GetSpecies(species_name);
+        if (!species)
+            continue;
+
+        // Exclude species that can't colonize UNLESS they
+        // are already here (aka: it's their home planet). Showing them on
+        // their own planet allows comparison vs other races, which might
+        // be better suited to this planet. 
+        if (species->CanColonize() || species_name == planet->SpeciesName())
+            species_names.insert(species_name);
+    }
+    return species_names;
+}

--- a/universe/Suitability.h
+++ b/universe/Suitability.h
@@ -1,0 +1,21 @@
+// -*- C++ -*-
+#ifndef _Suitability_h_
+#define _Suitability_h_
+
+#include "Enums.h"
+#include "TemporaryPtr.h"
+
+#include "../util/Export.h"
+
+#include <set>
+#include <map>
+#include <string>
+
+class Empire;
+class Planet;
+
+FO_COMMON_API std::set<std::string> GetColonizerSpecies(Empire* empire, TemporaryPtr<const Planet> planet, bool all_species = true); ///< get a set of all the species from the given empire that can colonize this planet
+FO_COMMON_API std::map<std::string, std::pair<PlanetEnvironment, float> > GetSuitabilitiesForSpecies(int empire_id, int planet_id, std::set<std::string> species_names); ///< get the species, suitability pairs for all relevant species of the given empire and planet
+FO_COMMON_API std::string GetBestSuitable(std::map<std::string, std::pair<PlanetEnvironment, float> > suitabilities); ///< choose the best suitable species from the given set
+
+#endif // _Suitability_h_


### PR DESCRIPTION
First commit extract EDP code related to suitability computation, and refactor some parts of it into standalone helper functions without the intremingled UI parts of it.

Second commit use those helper functions in EDP to replace the suitability computation.

Third commit add a objlistwnd context menu for planets to schedule a colony building being built there.
