### PR TITLE
Make sorting stable in the object window .

### DIFF
--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -91,8 +91,7 @@ namespace {
 
         bool operator()(const ListBox::Row* l, const ListBox::Row* r)
         {
-            bool retval = m_cmp(*l, *r, m_sort_col);
-            return m_invert ? !retval : retval;
+            return m_invert ? m_cmp(*r, *l, m_sort_col) : m_cmp(*l, *r, m_sort_col);
         }
 
     private:

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -2054,6 +2054,10 @@ public:
 
         if (clicked_column < 0) {
             this->SetStyle(GG::LIST_NOSORT);
+
+            // Sorting and nesting don't really work well together. The user may have turned sorting off
+            // to get nesting to work. So let's rebuild the world to make sure nesting works again.
+            Refresh();
             //std::cout << "col -1 : set style to no sort" << std::endl;
 
         } else if (!GetColumnName(clicked_column).empty()) { // empty columns are not sort-worthy
@@ -2072,7 +2076,6 @@ public:
                 this->SetStyle(GG::LIST_SORTDESCENDING);
             }
         }
-        Refresh();
     }
 
     mutable boost::signals2::signal<void ()> ExpandCollapseSignal;


### PR DESCRIPTION
Stable sorting means that if two objects in the list
are equal (with respect to the current sort key),
their order won't change. This is useful
for example if you sort first by planet size, then by owner,
the planets of each empire will be shown in size order
with respect to each other.

The stability is achieved by not rebuilding the list
from scratch with Refresh every time the sort key is changed,
the list box is smart enough to resort itself (and does it stably).
As the comment in the code states, nesting and sorting don't
seem to mix. That is not a result of this change, but a pre-existing flaw,
as far as I can see.
