### PR TITLE
Tweaked some spawn locations and regeneration of Dyson Forests:

### DIFF
--- a/default/ship_hulls.txt
+++ b/default/ship_hulls.txt
@@ -1736,10 +1736,12 @@ Hull
         EffectsGroup    // grow larger / stronger with age
             scope = Source
             accountinglabel = "AGE_BONUS"
-            effects = [
-                SetMaxStructure value = Value + Source.Age*3
-                SetStructure value = Value + 7
-            ]
+            effects = SetMaxStructure value = Value + Source.Age*3
+
+        EffectsGroup    // regeneration
+            scope = Source
+            activation = Turn low = LocalCandidate.System.LastTurnBattleHere + 1
+            effects = SetStructure value = Value + 7
 
         EffectsGroup    // spawn floaters to reproduce
             scope = Source

--- a/default/space_monster_spawn_fleets.txt
+++ b/default/space_monster_spawn_fleets.txt
@@ -23,7 +23,7 @@ MonsterFleet
     location = And [
         Star type = [Blue White Yellow Orange Red]
         Not Contains Monster
-        Not WithinStarlaneJumps jumps = 1 condition = Contains And [
+        Not WithinStarlaneJumps jumps = 2 condition = Contains And [
             Planet
             OwnedBy affiliation = AnyEmpire
         ]

--- a/default/specials.txt
+++ b/default/specials.txt
@@ -143,13 +143,19 @@ Special
         Planet
         Not Planet type = [Asteroids GasGiant]
         Not ContainedBy And [
-                System 
-                Contains Or [
-                    Capital
-                    And [ Planet HasSpecial name = "ANCIENT_RUINS_SPECIAL" ]
-                    Design name = "SM_EXP_OUTPOST"
-                ]
+            System 
+            Contains Or [
+                And [ Planet HasSpecial name = "ANCIENT_RUINS_SPECIAL" ]
+                Design name = "SM_EXP_OUTPOST"
             ]
+        ]
+        Not WithinStarlaneJumps jumps = 2 condition = And [
+            System
+            Contains And [
+                Planet
+                OwnedBy affiliation = AnyEmpire
+            ]
+        ]
     ]
     effectsgroups = [
         EffectsGroup
@@ -163,13 +169,6 @@ Special
                 Random probability = 0.9
                 ValueTest low = 1 testvalue = GalaxyMaxAIAggression
                 ValueTest low = 1 testvalue = GalaxyMonsterFrequency
-                Not WithinStarlaneJumps jumps = 1 condition = And [
-                    System
-                    Contains And [
-                        Planet
-                        OwnedBy affiliation = AnyEmpire
-                    ]
-                ]
             ]
             effects = CreateShip designname = "SM_GUARD_2"
             


### PR DESCRIPTION
- Ancient Ruins gets a location condition of at least 3 jumps from empire homes.
- Dyson Forests gets a location condition of at least 3 jumps from empire homes.
- Dyson Forest's regeneration effect receives a no-combat-last-turn-here condition.
