### PR TITLE
Updated the calculation of planetary troops:

### DIFF
--- a/default/buildings.txt
+++ b/default/buildings.txt
@@ -705,7 +705,7 @@ BuildingType
             ]
             activation = Source
             stackinggroup = "BLD_MEGALITH_EFFECT"
-            effects = SetMaxSupply value = Value + 2
+            effects = SetMaxSupply value = Value + 1
     ]
     icon = "icons/building/megalith.png"
 

--- a/default/species.txt
+++ b/default/species.txt
@@ -2917,19 +2917,13 @@ EffectsGroup
             accountinglabel = "BAD_TROOPS_LABEL"
             effects = SetMaxTroops value = Value * 0.5
             
-    [[PROTECTION_FOCUS_TROOPS]]
+    [[AFTER_SPECIES_MULTIPLICATOR_TROOPS]]
 '''
 
 AVERAGE_GROUND_TROOPS
 '''[[BASIC_GROUND_TROOPS]]
-
-EffectsGroup
-            scope = Source
-            activation = Planet
-            accountinglabel = "AVERAGE_TROOPS_LABEL"
-            effects = SetMaxTroops value = Value * 1
             
-    [[PROTECTION_FOCUS_TROOPS]]
+    [[AFTER_SPECIES_MULTIPLICATOR_TROOPS]]
 '''
 
 GOOD_GROUND_TROOPS
@@ -2941,7 +2935,7 @@ EffectsGroup
             accountinglabel = "GOOD_TROOPS_LABEL"
             effects = SetMaxTroops value = Value * 1.5
             
-    [[PROTECTION_FOCUS_TROOPS]]
+    [[AFTER_SPECIES_MULTIPLICATOR_TROOPS]]
 '''
 
 GREAT_GROUND_TROOPS
@@ -2953,7 +2947,7 @@ EffectsGroup
             accountinglabel = "GREAT_TROOPS_LABEL"
             effects = SetMaxTroops value = Value * 2
             
-    [[PROTECTION_FOCUS_TROOPS]]
+    [[AFTER_SPECIES_MULTIPLICATOR_TROOPS]]
 '''
 
 ULTIMATE_GROUND_TROOPS
@@ -2965,118 +2959,30 @@ EffectsGroup
             accountinglabel = "ULTIMATE_TROOPS_LABEL"
             effects = SetMaxTroops value = Value * 3
             
-    [[PROTECTION_FOCUS_TROOPS]]
+    [[AFTER_SPECIES_MULTIPLICATOR_TROOPS]]
 '''
 
 BASIC_GROUND_TROOPS
 '''EffectsGroup
-            scope = And [
-                Planet
-                OwnedBy empire = Source.Owner
-            ]
-            activation = OwnerHasTech name = "DEF_GARRISON_4"
-            stackinggroup = "BASIC_TROOPS_STACK"
-            accountinglabel = "DEF_GARRISON_4"
-            effects = SetMaxTroops value = Value + 30  
-
-EffectsGroup
-            scope = And [
-                Planet
-                OwnedBy empire = Source.Owner
-            ]
-            activation = AND [
-                Planet
-                OwnerHasTech name = "DEF_GARRISON_3"
-            ]
-            stackinggroup = "BASIC_TROOPS_STACK"
-            accountinglabel = "DEF_GARRISON_3"
-            effects = SetMaxTroops value = Value + 20
-            
-EffectsGroup
-            scope = And [
-                Planet
-                OwnedBy empire = Source.Owner
-            ]
-            activation = AND [
-                Planet
-                OwnerHasTech name = "DEF_GARRISON_2"
-            ]
-            stackinggroup = "BASIC_TROOPS_STACK"
-            accountinglabel = "DEF_GARRISON_2"
-            effects = SetMaxTroops value = Value + 12
-
-EffectsGroup
-            scope = And [
-                Planet
-                OwnedBy empire = Source.Owner
-            ]
-            activation = AND [
-                Planet
-                OwnerHasTech name = "DEF_GARRISON_1"
-            ]
-            stackinggroup = "BASIC_TROOPS_STACK"
-            accountinglabel = "DEF_GARRISON_1"
-            effects = SetMaxTroops value = Value + 6        
-
-EffectsGroup
-            scope = And [
-                Planet
-                OwnedBy empire = Source.Owner
-            ]
+            scope = Source
             activation = And [
                 Planet
                 OwnerHasTech name = "DEF_ROOT_DEFENSE"
-            ]
-            stackinggroup = "POPULATION_TROOPS_STACK"
-            accountinglabel = "DEF_ROOT_DEFENSE"
-            effects = SetMaxTroops Value = Value + Target.Population * [[TROOPS_PER_POP]]
-
-EffectsGroup
-            scope = And [
-                Planet
-                OwnedBy empire = Source.Owner
-            ]
-            activation = And [
-                Planet
-                OwnerHasTech name = "GRO_CYBORG"
-            ]
-            stackinggroup = "CYBORG_TROOPS_STACK"
-            accountinglabel = "GRO_CYBORG"
-            effects = SetMaxTroops value = Value + Target.Population * [[TROOPS_PER_POP]]
-             
-EffectsGroup
-            scope = AND [
-                Planet
-                OwnedBy empire = Source.Owner
-                Population high = 0
-            ]
-            stackinggroup = "OUTPOST_TROOPS_STACK"
-            accountinglabel = "OUTPOST_TROOP_LABEL"
-            effects = SetMaxTroops value = Value * .5
-
-EffectsGroup
-            scope = And [
-                Planet
-                OwnedBy empire = Source.Owner
                 Contains Building name = "BLD_IMPERIAL_PALACE"
-            ]
-            activation = And [
-                Planet
-                OwnerHasTech name = "DEF_ROOT_DEFENSE"
             ]
             stackinggroup = "PALACE_TROOPS_STACK"
             accountinglabel = "BLD_IMPERIAL_PALACE"
-            effects = SetMaxTroops value = Value + 3
+            effects = SetMaxTroops value = Value + 6
 
 EffectsGroup
-            scope = AND [
+            scope = Source
+            activation = And [
                 Homeworld
-                OwnedBy empire = Source.Owner
+                Not Unowned
             ]
-            activation = Planet
             stackinggroup = "HOMEWORLD_TROOPS_STACK"
             accountinglabel = "HOMEWORLD_LABEL"
-            effects = SetMaxTroops value = Value + 2
+            effects = SetMaxTroops value = Value + 4
 
 EffectsGroup
             scope = Source
@@ -3086,12 +2992,105 @@ EffectsGroup
             ]
             stackinggroup = "BASIC_TROOPS_STACK"
             accountinglabel = "INDEPENDENT_TROOP_LABEL"
-            effects = SetMaxTroops value = Value + 10 + Target.Population * [[TROOPS_PER_POP]]
+            effects = SetMaxTroops value = Value + 10
 
+EffectsGroup
+            scope = Source
+            activation = Planet
+            stackinggroup = "POPULATION_TROOPS_STACK"
+            accountinglabel = "DEF_ROOT_DEFENSE"
+            effects = SetMaxTroops Value = Value + Target.Population * [[TROOPS_PER_POP]]
+
+EffectsGroup
+            scope = Source
+            activation = And [
+                Planet
+                OwnerHasTech name = "GRO_CYBORG"
+            ]
+            stackinggroup = "CYBORG_TROOPS_STACK"
+            accountinglabel = "GRO_CYBORG"
+            effects = SetMaxTroops value = Value + Target.Population * [[TROOPS_PER_POP]]
+            
+EffectsGroup
+            scope = Source
+            activation = And [
+                Planet
+                OwnerHasTech name = "DEF_GARRISON_2"
+            ]
+            stackinggroup = "GARRISON_2_TROOPS_STACK"
+            accountinglabel = "DEF_GARRISON_2"
+            effects = SetMaxTroops value = Value + Target.Population * 2 * [[TROOPS_PER_POP]]
+
+EffectsGroup
+            scope = Source
+            activation = And [
+                Planet
+                OwnerHasTech name = "DEF_GARRISON_4"
+            ]
+            stackinggroup = "GARRISON_4_TROOPS_STACK"
+            accountinglabel = "DEF_GARRISON_4"
+            effects = SetMaxTroops value = Value + Target.Population * 2 * [[TROOPS_PER_POP]]
 '''
 
-PROTECTION_FOCUS_TROOPS
+AFTER_SPECIES_MULTIPLICATOR_TROOPS
 '''EffectsGroup
+            scope = Or [
+                Source
+                And [
+                    Planet
+                    OwnedBy empire = Source.Owner
+                    Population high = 0
+                ]
+            ]
+            activation = And [
+                Planet
+                OwnerHasTech name = "DEF_GARRISON_1"
+            ]
+            stackinggroup = "GARRISON_1_TROOPS_STACK"
+            accountinglabel = "DEF_GARRISON_1"
+            effects = SetMaxTroops value = Value + 10   
+
+EffectsGroup
+            scope = Or [
+                Source
+                And [
+                    Planet
+                    OwnedBy empire = Source.Owner
+                    Population high = 0
+                ]
+            ]
+            activation = And [
+                Planet
+                OwnerHasTech name = "DEF_GARRISON_3"
+            ]
+            stackinggroup = "GARRISON_3_TROOPS_STACK"
+            accountinglabel = "DEF_GARRISON_3"
+            effects = SetMaxTroops value = Value + 16
+
+EffectsGroup
+            scope = Source
+            activation = And [
+                Planet
+                WithinStarlaneJumps jumps = 2 condition = And [
+                    Planet
+                    OwnedBy empire = Source.Owner
+                    Contains Building name = "BLD_MEGALITH"
+                ]
+            ]
+            accountinglabel = "MEGALITH_LABEL"
+            effects = SetMaxTroops value = Value + 10
+    
+EffectsGroup
+            scope = And [
+                Planet
+                OwnedBy empire = Source.Owner
+                Population high = 0
+            ]
+            stackinggroup = "OUTPOST_TROOPS_STACK"
+            accountinglabel = "OUTPOST_TROOP_LABEL"
+            effects = SetMaxTroops value = Value * .5
+
+EffectsGroup
             scope = Source
             activation = And [
                 Planet

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -8356,25 +8356,25 @@ DEF_GARRISON_1
 Planetary Garrison 1
 
 DEF_GARRISON_1_DESC
-Increases max [[encyclopedia TROOP_TITLE]] on all planets by 6.
+Increases max [[encyclopedia TROOP_TITLE]] on all planets by 10.
 
 DEF_GARRISON_2
 Planetary Garrison 2
 
 DEF_GARRISON_2_DESC
-Increases max [[encyclopedia TROOP_TITLE]] on all planets by 12, and causes troops to regenerate by an additional one per turn.
+Increases max [[encyclopedia TROOP_TITLE]] on all planets by 0.4 per population, and causes troops to regenerate by an additional one per turn.
 
 DEF_GARRISON_3
 Planetary Garrison 3
 
 DEF_GARRISON_3_DESC
-Increases max [[encyclopedia TROOP_TITLE]] on all planets by 20, and causes troops to regenerate by an additional two per turn in addition to that from [[DEF_GARRISON_2]].
+Increases max [[encyclopedia TROOP_TITLE]] on all planets by 16, and causes troops to regenerate by an additional two per turn in addition to that from [[DEF_GARRISON_2]].
 
 DEF_GARRISON_4
 Planetary Garrison 4
 
 DEF_GARRISON_4_DESC
-Increases max [[encyclopedia TROOP_TITLE]] on all planets by 30, and causes troops to regenerate by an additional three per turn in addition to that from [[DEF_GARRISON_3]] and [[DEF_GARRISON_2]].
+Increases max [[encyclopedia TROOP_TITLE]] on all planets by 0.4 per population, and causes troops to regenerate by an additional three per turn in addition to that from [[DEF_GARRISON_3]] and [[DEF_GARRISON_2]].
 
 DEF_PLANET_CLOAK
 Planetary Cloaking Device
@@ -8879,7 +8879,7 @@ BLD_IMPERIAL_PALACE
 Imperial Palace
 
 BLD_IMPERIAL_PALACE_DESC
-'''Increases [[encyclopedia SUPPLY_TITLE]] line range by 1, [[encyclopedia INFRASTRUCTURE_TITLE]] by 20, [[encyclopedia DEFENSE_TITLE]] by 5, and [[encyclopedia TROOP_TITLE]] by 3. Also sets the owner's Capital for the empire.
+'''Increases [[encyclopedia SUPPLY_TITLE]] line range by 1, [[encyclopedia INFRASTRUCTURE_TITLE]] by 20, [[encyclopedia DEFENSE_TITLE]] by 5, and [[encyclopedia TROOP_TITLE]] by 6. Also sets the owner's Capital for the empire.
 
 Represents imperial power and prestige and functions as a center of control for the empire's holdings.'''
 
@@ -9025,7 +9025,7 @@ BLD_MEGALITH
 Megalith
 
 BLD_MEGALITH_DESC
-'''Sets the owner empire's capital, overriding any existing [[buildingtype BLD_IMPERIAL_PALACE]]. All resource meters for the planet on which it is built are able to reach target in a single turn and receives an increase of 30 to [[encyclopedia INFRASTRUCTURE_TITLE]]. In addition, all planets in the owning empire receive an increase of 2 to [[encyclopedia SUPPLY_TITLE]] line range.
+'''Sets the owner empire's capital, overriding any existing [[buildingtype BLD_IMPERIAL_PALACE]]. All resource meters for the planet on which it is built are able to reach target in a single turn. This planet also receives an increase of 30 to [[encyclopedia INFRASTRUCTURE_TITLE]]. Populated planets in the owning empire receive an increase of 1 to [[encyclopedia SUPPLY_TITLE]] line range. Populated planets within two starlane jumps have their [[encyclopedia TROOP_TITLE]] increased by 10.
 
 The Megalith is an abnormally massive starscraper, kilometers in diameter, and an inspiration to architects empire-wide.'''
 
@@ -10803,6 +10803,9 @@ ULTIMATE_TROOPS_LABEL
 
 INDEPENDENT_TROOP_LABEL
 Independent Homeworld
+
+MEGALITH_LABEL
+Megalith
 
 OUTPOST_TROOP_LABEL
 Outpost


### PR DESCRIPTION
- Species trait multiplication will no longer apply to all boni.
- The Megalith will grant +10 troops to all populated planets within two starlane jumps, but the supply bonus was reduced to +1 (from +2).
- Lots of other boni were increased and some were switched to be population based:
  Imperial Palace + 6
  Homeworld + 4
  Planetary Garrison 1 + 10
  Planetary Garrison 2 + 0.4 per pop
  Planetary Garrison 3 + 16
  Planetary Garrison 4 + 0.4 per pop
