### PR TITLE
Add an option to hide the "dump" item

### DIFF
--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -55,6 +55,7 @@ namespace {
                         default_columns_widths[i].second,
                         RangedValidator<int>(1, 200));
         }
+        db.Add<bool>("UI.objects-hide-dump", UserStringNop("OPTIONS_DB_OBJECT_HIDE_DUMP_DESC"), true,  Validator<bool>());
     }
     bool temp_bool = RegisterOptions(&AddOptions);
 
@@ -2351,7 +2352,8 @@ void ObjectListWnd::ObjectRightClicked(GG::ListBox::iterator it, const GG::Pt& p
 
     // create popup menu with object commands in it
     GG::MenuItem menu_contents;
-    menu_contents.next_level.push_back(GG::MenuItem(UserString("DUMP"), 1, false, false));
+    if (!GetOptionsDB().Get<bool>("UI.objects-hide-dump"))
+        menu_contents.next_level.push_back(GG::MenuItem(UserString("DUMP"), 1, false, false));
 
     TemporaryPtr<const UniverseObject> obj = GetUniverseObject(object_id);
     //DebugLogger() << "ObjectListBox::ObjectStateChanged: " << obj->Name();

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1331,6 +1331,9 @@ Toggles inclusion of auto-generated text in tech, building or ship part descript
 OPTIONS_DB_VERBOSE_LOGGING_DESC
 Toggles verbose logging of universe contents and effect evaluation.
 
+OPTIONS_DB_OBJECT_HIDE_DUMP_DESC
+Toggles the "dump" command in object list window (this command is for developers).
+
 OPTIONS_DB_VERBOSE_COMBAT_LOGGING_DESC
 Toggles verbose logging of combat resolution information.
 


### PR DESCRIPTION
from the object list window contextual menu, it is only
of interest to developers.

Now that we have persistent_config.xml support, we can
default to hide this for uninterested mere mortals.

Signed-off-by: Vincent Legoll vincent.legoll@gmail.com
