### PR TITLE
Fix for the following warning in MarkupBox.cpp :

### DIFF
--- a/UI/MarkupBox.cpp
+++ b/UI/MarkupBox.cpp
@@ -29,26 +29,6 @@ namespace {
         markup_tags_registered = true;
     }
 
-
-    /** types of text that can appear in a MarkupBox input string, depending on present (or absence of) enclosing
-      * markup tags. */
-    enum MarkupTextBlockType {
-        INVALID_MARKUP_TEXT_BLOCK_TYPE = -1,
-        PLAIN_TEXT_MARKUP,
-        HEADING_MARKUP,
-        IMAGE_MARKUP,
-        NUM_MARKUP_TEXT_BLOCK_TYPES
-    };
-
-
-    /** contains text of a single type of markup text-block, and the parsed type and params of the tags. */
-    struct MarkupTextBlock {
-        std::string                 text;
-        MarkupTextBlockType         type;
-        std::vector<std::string>    params;
-    };
-
-
     /** Parses text and returns array of MarkupTextBlock that can be individually interpreted as a single type of 
       * object on MarkupSurface (heading, plain text, image...) */
     std::vector<MarkupTextBlock> ParseMarkupText(const std::string& text) {

--- a/UI/MarkupBox.h
+++ b/UI/MarkupBox.h
@@ -6,10 +6,22 @@
 #include <GG/GGFwd.h>
 #include <GG/Control.h>
 
-namespace {
-    struct MarkupTextBlock;
-}
+/** types of text that can appear in a MarkupBox input string, depending on present (or absence of) enclosing
+  * markup tags. */
+enum MarkupTextBlockType {
+    INVALID_MARKUP_TEXT_BLOCK_TYPE = -1,
+    PLAIN_TEXT_MARKUP,
+    HEADING_MARKUP,
+    IMAGE_MARKUP,
+    NUM_MARKUP_TEXT_BLOCK_TYPES
+};
 
+/** contains text of a single type of markup text-block, and the parsed type and params of the tags. */
+struct MarkupTextBlock {
+    std::string                 text;
+    MarkupTextBlockType         type;
+    std::vector<std::string>    params;
+};
 
 /** A control similar to GG::MultiEdit that displayed text, links, and images with layout determined
   * from HTML-like markup in the provided text. */


### PR DESCRIPTION
In file included from ./FreeOrion/UI/MarkupBox.cpp:1:0:
./FreeOrion/UI/MarkupBox.h:17:7: warning: ‘MarkupBox’ has
a field ‘MarkupBox::m_text_blocks’ whose type uses the
anonymous namespace [enabled by default]
 class MarkupBox : public GG::Control {
       ^

Signed-off-by: Vincent Legoll vincent.legoll@gmail.com
