### PR TITLE
Add required buildings pedia links...

### DIFF
--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -206,187 +206,187 @@ Cannot be produced
 SD_SCOUT
 Scout
 SD_SCOUT_DESC
-Small and cheap unarmed vessel designed for recon and exploration. Further research aimed at improving [[encyclopedia DETECTION_RANGE_TITLE]] would allow for better designs.
+Small and cheap unarmed vessel designed for recon and exploration. Further [[encyclopedia RESEARCH_TITLE]] aimed at improving [[encyclopedia DETECTION_RANGE_TITLE]] would allow for better designs. This vessel can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]].
 
 SD_AST_SCOUT
 Asteroid Scout
 SD_AST_SCOUT_DESC
-Small and cheap unarmed vessel made from a hollowed-out asteroid, designed for recon and exploration. Further research aimed at improving [[encyclopedia DETECTION_RANGE_TITLE]] would allow for better designs. Asteroid ships can only be built in systems with an [[buildingtype BLD_SHIPYARD_AST]].
+Small and cheap unarmed vessel made from a hollowed-out asteroid, designed for recon and exploration. Further [[encyclopedia RESEARCH_TITLE]] aimed at improving [[encyclopedia DETECTION_RANGE_TITLE]] would allow for better designs. This vessel can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]] in a system with an [[buildingtype BLD_SHIPYARD_AST]].
 
 SD_SCOUT_2
 Scout II
 SD_SCOUT_2_DESC
-Small and cheap unarmed vessel equipped with improved [[encyclopedia DETECTION_RANGE_TITLE]] designed for recon and exploration.
+Small and cheap unarmed vessel equipped with improved [[encyclopedia DETECTION_RANGE_TITLE]] designed for recon and exploration. Can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]].
 
 SD_SCOUT_3
 Scout III
 SD_SCOUT_3_DESC
-Small and cheap unarmed vessel equipped with improved [[encyclopedia DETECTION_RANGE_TITLE]] designed for recon and exploration.
+Small and cheap unarmed vessel equipped with improved [[encyclopedia DETECTION_RANGE_TITLE]] designed for recon and exploration. Can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]].
 
 SD_SCOUT_4
 Scout IV
 SD_SCOUT_4_DESC
-Small and cheap unarmed vessel equipped with improved [[encyclopedia DETECTION_RANGE_TITLE]] designed for recon and exploration.
+Small and cheap unarmed vessel equipped with improved [[encyclopedia DETECTION_RANGE_TITLE]] designed for recon and exploration. Can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]].
 
 SD_ENG_SCOUT
 Energy Scout
 SD_ENG_SCOUT_DESC
-Small and fast unarmed vessel designed for recon and exploration. Further research aimed at improving [[encyclopedia DETECTION_RANGE_TITLE]] would allow for better designs. This vessel can only be built at a colony with an [[buildingtype BLD_SHIPYARD_ENRG_COMP]] in systems with blue, white or black hole star types.
+Small and fast unarmed vessel designed for recon and exploration. Further [[encyclopedia RESEARCH_TITLE]] aimed at improving [[encyclopedia DETECTION_RANGE_TITLE]] would allow for better designs. This vessel can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]] and an [[buildingtype BLD_SHIPYARD_ENRG_COMP]], in systems with blue, white or black hole star types.
 
 SD_SMALL_MARK_1
 Corvette I
 SD_SMALL_MARK1_DESC
-Small and cheap mass-driver ship.
+Small and cheap mass-driver ship. Can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]].
 
 SD_SMALL_MARK_2
 Corvette II
 SD_SMALL_MARK2_DESC
-Small and cheap mass-driver ship.
+Small and cheap mass-driver ship. Can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]].
 
 SD_MARK_1
 Frigate I
 SD_MARK1_DESC
-Basic mass-driver frigate.
+Basic mass-driver frigate. Can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]].
 
 SD_MARK_2
 Frigate II
 SD_MARK2_DESC
-Improved mass-driver frigate.
+Improved mass-driver frigate. Can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]].
 
 SD_MARK_3
 Frigate III
 SD_MARK3_DESC
-Basic laser frigate.
+Basic laser frigate. Can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]].
 
 SD_MARK_4
 Frigate IV
 SD_MARK4_DESC
-Improved laser frigate.
+Improved laser frigate. Can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]].
 
 SD_LARGE_MARK_1
 Cruiser I
 SD_LARGE_MARK1_DESC
-Basic mass-driver fighter.
+Basic mass-driver fighter. Can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]].
 
 SD_LARGE_MARK_2
 Cruiser II
 SD_LARGE_MARK2_DESC
-Improved mass-driver fighter.
+Improved mass-driver fighter. Can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]].
 
 SD_LARGE_MARK_3
 Cruiser III
 SD_LARGE_MARK3_DESC
-Improved fighter with lasers.
+Improved fighter with lasers. Can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]].
 
 SD_LARGE_MARK_4
 Cruiser IV
 SD_LARGE_MARK4_DESC
-Improved fighter with heavy lasers and armor.
+Improved fighter with heavy lasers and armor. Can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]].
 
 SD_ROBOTIC1
 Robocruiser I
 SD_ROBOTIC1_DESC
-Robotic mass-driver fighter. Can only be built at a colony with an [[buildingtype BLD_SHIPYARD_ORBITAL_DRYDOCK]].
+Robotic mass-driver fighter. Can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]] and an [[buildingtype BLD_SHIPYARD_ORBITAL_DRYDOCK]].
 
 SD_ROBOTIC2
 Robocruiser II
 SD_ROBOTIC2_DESC
-Robotic fighter with lasers and heavy armor. Can only be built at a colony with an [[buildingtype BLD_SHIPYARD_ORBITAL_DRYDOCK]].
+Robotic fighter with lasers and heavy armor. Can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]] and an [[buildingtype BLD_SHIPYARD_ORBITAL_DRYDOCK]].
 
 SD_ROBOTIC3
 Robocruiser III
 SD_ROBOTIC3_DESC
-Improved robotic fighter with heavy lasers. Can only be built at a colony with an [[buildingtype BLD_SHIPYARD_ORBITAL_DRYDOCK]].
+Improved robotic fighter with heavy lasers. Can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]] and an [[buildingtype BLD_SHIPYARD_ORBITAL_DRYDOCK]].
 
 SD_ORGANIC1
 Organic I
 SD_ORGANIC1_DESC
-Organic fighter with preliminary weaponry and defence technology.
+Organic fighter with preliminary weaponry and defence technology. Can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]] and an [[buildingtype BLD_SHIPYARD_ORG_ORB_INC]].
 
 SD_ORGANIC2
 Organic II
 SD_ORGANIC2_DESC
-Organic fighter with lasers.
+Organic fighter with lasers. Can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]] and an [[buildingtype BLD_SHIPYARD_ORG_ORB_INC]].
 
 SD_ORGANIC3
 Organic III
 SD_ORGANIC3_DESC
-Organic fighter with heavy lasers and armor.
+Organic fighter with heavy lasers and armor. Can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]] and an [[buildingtype BLD_SHIPYARD_ORG_ORB_INC]].
 
 SD_SHIELD_BUG_1
 Shield Bug I
 SD_SHIELD_BUG_1_DESC
-Organic fighter with [[encyclopedia SHIELDS_TITLE]]. Effective against enemies with poor weapons.
+Organic fighter with [[encyclopedia SHIELDS_TITLE]]. Effective against enemies with poor weapons. Can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]] and an [[buildingtype BLD_SHIPYARD_ORG_ORB_INC]].
 
 SD_SHIELD_BUG_2
 Shield Bug II
 SD_SHIELD_BUG_2_DESC
-Organic fighter with [[encyclopedia SHIELDS_TITLE]]. Effective against enemies with poor weapons.
+Organic fighter with [[encyclopedia SHIELDS_TITLE]]. Effective against enemies with poor weapons. Can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]] and an [[buildingtype BLD_SHIPYARD_ORG_ORB_INC]].
 
 SD_SHIELD_BUG_3
 Shield Bug III
 SD_SHIELD_BUG_3_DESC
-Organic fighter with [[encyclopedia SHIELDS_TITLE]]. Effective against enemies with poor weapons.
+Organic fighter with [[encyclopedia SHIELDS_TITLE]]. Effective against enemies with poor weapons. Can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]] and an [[buildingtype BLD_SHIPYARD_ORG_ORB_INC]].
 
 SD_AST_1
 Rock I
 SD_AST_1_DESC
-A hollowed-out asteroid armed with lasers. Asteroid ships can only be built in systems with an [[buildingtype BLD_SHIPYARD_AST]].
+A hollowed-out asteroid armed with lasers. Can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]] in a system with an [[buildingtype BLD_SHIPYARD_AST]].
 
 SD_AST_2
 Rock II
 SD_AST_2_DESC
-A hollowed-out asteroid armed with plasma cannons. Asteroid ships can only be built in systems with an [[buildingtype BLD_SHIPYARD_AST]].
+A hollowed-out asteroid armed with plasma cannons. Can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]] in a system with an [[buildingtype BLD_SHIPYARD_AST]].
 
 SD_AST_3
 Rock III
 SD_AST_3_DESC
-A hollowed-out asteroid armed with heavy plasma cannons and reformed rock armor. Asteroid ships can only be built in systems with an [[buildingtype BLD_SHIPYARD_AST]].
+A hollowed-out asteroid armed with heavy plasma cannons and reformed rock armor. Can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]] in a system with an [[buildingtype BLD_SHIPYARD_AST]]. An [[buildingtype BLD_SHIPYARD_AST_REF]] is also required in any system owned by the empire.
 
 SD_HEAVY_AST_1
 Big Rock I
 SD_HEAVY_AST_1_DESC
-A large hollowed-out asteroid armed with plasma cannons. Asteroid ships can only be built in systems with an [[buildingtype BLD_SHIPYARD_AST]].
+A large hollowed-out asteroid armed with plasma cannons. Can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]] in a system with an [[buildingtype BLD_SHIPYARD_AST]].
 
 SD_HEAVY_AST_2
 Big Rock II
 SD_HEAVY_AST_2_DESC
-A large hollowed-out asteroid armed with heavy plasma cannons and reformed rock plate. Asteroid ships can only be built in systems with an [[buildingtype BLD_SHIPYARD_AST]].
+A large hollowed-out asteroid armed with heavy plasma cannons and reformed rock plate. Can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]] in a system with an [[buildingtype BLD_SHIPYARD_AST]]. An [[buildingtype BLD_SHIPYARD_AST_REF]] is also required in any system owned by the empire.
 
 SD_CRYSTAL
 Crystal
 SD_CRYSTAL_DESC
-A crystallized asteroid armed with heavy plasma cannons and crystal rock armor.
+A crystallized asteroid armed with heavy plasma cannons and crystal rock armor. Can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]] in a system with an [[buildingtype BLD_SHIPYARD_AST]]. An [[buildingtype BLD_SHIPYARD_AST_REF]] is also required in any system owned by the empire.
 
 SD_ENDO_1
 Endomorphic I
 SD_ENDO_1_DESC
-Advanced endomorphic fighter with heavy weaponry and armor.
+Advanced endomorphic fighter with heavy weaponry and armor. Can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]], an [[buildingtype BLD_SHIPYARD_ORG_ORB_INC]], and a [[buildingtype BLD_SHIPYARD_ORG_XENO_FAC]].
 
 SD_ENDO_2
 Endomorphic II
 SD_ENDO_2_DESC
-Advanced endomorphic fighter with heavy weaponry and armor.
+Advanced endomorphic fighter with heavy weaponry and armor. Can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]], an [[buildingtype BLD_SHIPYARD_ORG_ORB_INC]], and a [[buildingtype BLD_SHIPYARD_ORG_XENO_FAC]].
 
 SD_ENDO_3
 Endomorphic III
 SD_ENDO_3_DESC
-Advanced endomorphic fighter with heavy weaponry and armor.
+Advanced endomorphic fighter with heavy weaponry and armor. Can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]], an [[buildingtype BLD_SHIPYARD_ORG_ORB_INC]], and a [[buildingtype BLD_SHIPYARD_ORG_XENO_FAC]].
 
 SD_ENDO_4
 Endomorphic IV
 SD_ENDO_4_DESC
-Advanced endomorphic fighter with heavy weaponry and armor.
+Advanced endomorphic fighter with heavy weaponry and armor. Can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]], an [[buildingtype BLD_SHIPYARD_ORG_ORB_INC]], and a [[buildingtype BLD_SHIPYARD_ORG_XENO_FAC]].
 
 SD_GRAVITATING1
 Gravitating I
 SD_GRAVITATING1_DESC
-Massive state-of-art battleship armed and protected with the latest technology. Priced accordingly.
+Massive state-of-art battleship armed and protected with the latest technology. Priced accordingly. Can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]], an [[buildingtype BLD_SHIPYARD_ORBITAL_DRYDOCK]], and a [[buildingtype BLD_SHIPYARD_CON_GEOINT]].
 
 SD_FRACTAL_1
 Fractal I
 SD_FRACTAL_1_DESC
-An exotic warship made of fractal energy.
+An exotic warship made of fractal energy. Can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]] and an [[buildingtype BLD_SHIPYARD_ENRG_COMP]], in systems with blue, white or black hole star types.
 
 SD_COLONY_SHIP
 Colony Ship
@@ -396,7 +396,7 @@ Unarmed vessel capable of delivering millions of citizens safely to new colony s
 SD_ORG_COLONY_SHIP
 Organic Colony Ship
 SD_ORG_COLONY_SHIP_DESC
-Unarmed organic vessel capable of delivering millions of citizens safely to new colony sites. This vessel can only be built at a colony with a population of at least three, with an [[buildingtype BLD_SHIPYARD_ORG_ORB_INC]].
+Unarmed organic vessel capable of delivering millions of citizens safely to new colony sites. This vessel can only be built at a colony with a population of at least three, with a [[buildingtype BLD_SHIPYARD_BASE]] and an [[buildingtype BLD_SHIPYARD_ORG_ORB_INC]].
 
 SD_CRYONIC_COLONY_SHIP
 Cryonic Colony Ship
@@ -406,7 +406,7 @@ Unarmed vessel capable of delivering many millions of citizens safely to new col
 SD_ORG_CRYOCOL_SHIP
 Organic Cryonic Colony Ship
 SD_ORG_CRYOCOL_SHIP_DESC
-Unarmed organic vessel capable of delivering many millions of citizens safely to new colony sites. This vessel can only be built at a colony with a population of at least three, with an [[buildingtype BLD_SHIPYARD_ORG_ORB_INC]].
+Unarmed organic vessel capable of delivering many millions of citizens safely to new colony sites. This vessel can only be built at a colony with a population of at least three, with a [[buildingtype BLD_SHIPYARD_BASE]] and an [[buildingtype BLD_SHIPYARD_ORG_ORB_INC]].
 
 SD_AST_CRYOCOL_SHIP
 Cryonic Colony Asteroid
@@ -416,12 +416,12 @@ Unarmed asteroid vessel capable of delivering many millions of citizens safely t
 SD_OUTPOST_SHIP
 Outpost Ship
 SD_OUTPOST_SHIP_DESC
-Unarmed vessel capable of creating an [[encyclopedia OUTPOSTS_TITLE]] on an uninhabitable world.
+Unarmed vessel capable of creating an [[encyclopedia OUTPOSTS_TITLE]] on an uninhabitable world. Can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]].
 
 SD_ORG_OUTPOST_SHIP
 Organic Outpost Ship
 SD_ORG_OUTPOST_SHIP_DESC
-Unarmed organic vessel capable of creating an [[encyclopedia OUTPOSTS_TITLE]] on an uninhabitable world. This vessel can only be built at a colony with an [[buildingtype BLD_SHIPYARD_ORG_ORB_INC]].
+Unarmed organic vessel capable of creating an [[encyclopedia OUTPOSTS_TITLE]] on an uninhabitable world. This vessel can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]] and an [[buildingtype BLD_SHIPYARD_ORG_ORB_INC]].
 
 SD_COLONY_BASE
 Colony Base
@@ -446,37 +446,37 @@ Carries 2 units of ground [[encyclopedia TROOP_TITLE]] and equipment that can be
 SD_SMALL_TROOP_SHIP
 Small Troop Ship
 SD_SMALL_TROOP_SHIP_DESC
-Carries two units of ground [[encyclopedia TROOP_TITLE]] and equipment that can be used to invade a planet.
+Carries two units of ground [[encyclopedia TROOP_TITLE]] and equipment that can be used to invade a planet. Can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]].
 
 SD_TROOP_SHIP
 Troop Ship
 SD_TROOP_SHIP_DESC
-Carries six units of ground [[encyclopedia TROOP_TITLE]] and equipment that can be used to invade a planet.
+Carries six units of ground [[encyclopedia TROOP_TITLE]] and equipment that can be used to invade a planet. can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]].
 
 SD_ORG_TROOP_SHIP
 Organic Troop Ship
 SD_ORG_TROOP_SHIP_DESC
-Carries eight units of ground [[encyclopedia TROOP_TITLE]] and equipment that can be used to invade a planet. Organic vessels can only be built at planets with an [[buildingtype BLD_SHIPYARD_ORG_ORB_INC]].
+Carries eight units of ground [[encyclopedia TROOP_TITLE]] and equipment that can be used to invade a planet. Can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]] and an [[buildingtype BLD_SHIPYARD_ORG_ORB_INC]].
 
 SD_ENG_TROOP_SHIP
-Small Troop Ship
+Energy Troop Ship
 SD_ENG_TROOP_SHIP_DESC
-Carries two units of ground [[encyclopedia TROOP_TITLE]] and equipment that can be used to invade a planet. This vessel can only be built at a colony with an [[buildingtype BLD_SHIPYARD_ENRG_COMP]] in systems with blue, white or black hole star types.
+Carries two units of ground [[encyclopedia TROOP_TITLE]] and equipment that can be used to invade a planet. This vessel can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]] and an [[buildingtype BLD_SHIPYARD_ENRG_COMP]], in systems with blue, white or black hole star types.
 
 SD_ENG1
 Energy 1
 SD_ENG1_DESC
-Small fast combat vessel. This vessel can only be built at a colony with an [[buildingtype BLD_SHIPYARD_ENRG_COMP]] in systems with blue, white or black hole star types.
+Small fast combat vessel. This vessel can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]] and an [[buildingtype BLD_SHIPYARD_ENRG_COMP]], in systems with blue, white or black hole star types.
 
 SD_ENG2
 Energy 2
 SD_ENG2_DESC
-Small fast combat vessel, with improved weaponry. This vessel can only be built at a colony with an [[buildingtype BLD_SHIPYARD_ENRG_COMP]] in systems with blue, white or black hole star types.
+Small fast combat vessel, with improved weaponry. This vessel can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]] and an [[buildingtype BLD_SHIPYARD_ENRG_COMP]], in systems with blue, white or black hole star types.
 
 SD_DRAGON_TOOTH
 Dragon Tooth
 SD_DRAGON_TOOTH_DESC
-Ancient ship design with advanced weaponry and defensive systems.
+Ancient ship design with advanced weaponry and defensive systems. Can only be built at a colony with a [[buildingtype BLD_SHIPYARD_BASE]].
 
 ############
 # Monsters #


### PR DESCRIPTION
... in _Predefined Ship Designs_ section, to be consistent with _Ship Hulls_ descriptions, adding the "Asteroid Reformation Processor" if the ship has a Rock Armor or Crystal Plating. 

Line 462: modify the wrong name "Small Troop Ship" by "Energy Troop Ship"
