### PR TITLE
added ProductionQueue support for frontloading and/or topping-up, 

### DIFF
--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1210,6 +1210,12 @@ Sets width of queues on research and production screens.
 OPTIONS_DB_UI_PROD_QUEUE_LOCATION
 Sets whether to show the production location for items on the production queue
 
+OPTIONS_DB_PROD_QUEUE_FRONTLOAD
+Sets a maximum percentage of total item cost for the frontloading of allocation towards an item being built, spread over the initial turns of construction; in any given case the frontloading factor will also be constrained to not reduce the minimum build time
+
+OPTIONS_DB_PROD_QUEUE_TOPPING_UP
+Sets a maximum percentage  of total item cost for the topping-up of allocation towards an item being built, allowed on the final turn of construction if costs have increased; in any given case the frontloading factor will also be constrained to not reduce the minimum build time.  Furthermore, any allowed frontloading of allocation will reduce the range of allowed topping-up.
+
 OPTIONS_DB_GAMESETUP_SEED
 '''The seed used for randomly generating the galaxy.
 Galaxies generated with the same settings and the same seed will be identical.'''


### PR DESCRIPTION
controlled by OptionsDB options.  The purpose of this is to allow a mechanism for some allocation leeway to deal with mid-build cost increases (such as due to fleet upkeep increases) without causing the project completion to take an extra turn because of the small bit of increased cost.  I've tested both options moderately and they appear to work as intended.

The two options both have safeguards against being used to decrease the minimum build time.  They differ in the timing of the extra allocation allowed, and that makes for different pros and cons for each.
- Making the frontloaded option nonzero increases the per-turn allocation cap by the specified percentage (so it always spreads the extra allocation across all turns).
- Making the topping-up option nonzero allows the final turn allocation cap to be increased by the specified percentage of the total cost, if needed (and then subject to availability of course)

They can both be nonzero, although to avoid that introducing too much interaction complexity into the minimum build time safeguard for topping-up, the topping-up percentage will be reduced by the frontloading setting.  I put the maximum in the validator at 30%, although there wouldn't necessarily be anything wrong with letting it be higher.   The current defaults are zero for frontloading and 30% for topping-up.  I did not yet make and OptionsWnd widget for these, they can be adjusted at command line or in the config file:

```
        db.Add("empire.production-queue-frontload-factor",      UserStringNop("OPTIONS_DB_PROD_QUEUE_FRONTLOAD"), 0.0f, RangedValidator<float>(0.0f, 0.3f));
        db.Add("empire.production-queue-topping-up-factor",     UserStringNop("OPTIONS_DB_PROD_QUEUE_TOPPING_UP"), 0.3f, RangedValidator<float>(0.0f, 0.3f));
```

 Note that for very small values of the options (less than 5%), when dealing with very low cost items the effect/protection may be noticeably less than expected because of interactions with the ProductionQueue Epsilon value (0.01)

  I've not done anything to the production queue display to try explaining in that display itself why a turns' allocation might be higher that the normal limit.  This should wind up going into a Pedia explanation though.
