### PR TITLE
Revert commit 3323243

### DIFF
--- a/cmake/make_versioncpp.py
+++ b/cmake/make_versioncpp.py
@@ -3,6 +3,7 @@
 import sys
 import os
 from string import Template
+from datetime import datetime
 from subprocess import check_output
 from platform import system
 from glob import glob
@@ -117,7 +118,9 @@ try:
         branch = ""
     else:
         branch += " "
-    build_no = check_output(['git', 'show', '-s', '--format=%cd.%h', '--date=short', 'HEAD']).strip()
+    commit = check_output(["git", "show", "-s", "--format=%h", "HEAD"]).strip()
+    timestamp = float(check_output(["git", "show", "-s", "--format=%ct", "HEAD"]).strip())
+    build_no = ".".join([datetime.utcfromtimestamp(timestamp).strftime("%Y-%m-%d"), commit])
 except:
     print "WARNING: git not installed"
 


### PR DESCRIPTION
As "git show" returns the committer date as a local timestamp of the timezone of the committer, we can't use this for the build number. With that behavior it's possible that a later commit will produce a "lower" build number, which is not what we want. Reverting to the procedure which converts the timestamp to UTC before using it for the build number.

This is my proposal to address this problem. Anyone any objections?
