### PR TITLE
Add support for macros that take parameters

### DIFF
--- a/default/species.txt
+++ b/default/species.txt
@@ -339,10 +339,7 @@ Species
         [[GREAT_WEAPONS]]
         
         [[XENOPHOBIC_SELF]]        
-        [[XENOPHOBIC_OTHER_BEGIN]]
-                    stackinggroup = "XENOPHOBIC_LABEL_EAXAW_OTHER"
-                    accountinglabel = "XENOPHOBIC_LABEL_EAXAW_OTHER"
-        [[XENOPHOBIC_OTHER_END]]
+        [[XENOPHOBIC_OTHER(EAXAW)]]
         
         // not for description
         [[AVERAGE_PLANETARY_SHIELDS]]
@@ -1406,10 +1403,7 @@ Species
         
         [[XENOPHOBIC_SELF]]
         
-        [[XENOPHOBIC_OTHER_BEGIN]]
-                    stackinggroup = "XENOPHOBIC_LABEL_TRITH_OTHER"
-                    accountinglabel = "XENOPHOBIC_LABEL_TRITH_OTHER"
-        [[XENOPHOBIC_OTHER_END]]
+        [[XENOPHOBIC_OTHER(TRITH)]]
         
         // not for description
         [[AVERAGE_PLANETARY_SHIELDS]]
@@ -2279,7 +2273,8 @@ XENOPHOBIC_SELF
 
 '''
 
-XENOPHOBIC_OTHER_BEGIN
+// single argument should be the name of the species capitalized
+XENOPHOBIC_OTHER
 '''     EffectsGroup
             scope = And [
                 PopulationCenter
@@ -2293,10 +2288,8 @@ XENOPHOBIC_OTHER_BEGIN
                 WithinStarlaneJumps jumps = 5 condition = Source
             ]
             activation = PopulationCenter
-'''
-
-XENOPHOBIC_OTHER_END
-'''
+            stackinggroup = "XENOPHOBIC_LABEL_@1@_OTHER"
+            accountinglabel = "XENOPHOBIC_LABEL_@1@_OTHER"
             effects = SetTargetIndustry value = Value - Target.Population * 0.1
 '''
 

--- a/parse/Parse.cpp
+++ b/parse/Parse.cpp
@@ -235,7 +235,7 @@ namespace parse {
     const sregex MACRO_KEY = +_w;   // word character (alnum | _), one or more times, greedy
     const sregex MACRO_TEXT = -*_;  // any character, zero or more times, not greedy
     const sregex MACRO_DEFINITION = (s1 = MACRO_KEY) >> _n >> "'''" >> (s2 = MACRO_TEXT) >> "'''" >> _n;
-    const sregex MACRO_INSERTION = "[[" >> *space >> (s1 = MACRO_KEY) >> *space >> !("(" >> (s2 = -+~_n) >> ")") >> "]]";
+    const sregex MACRO_INSERTION = "[[" >> *space >> (s1 = MACRO_KEY) >> *space >> !("(" >> (s2 = +~(set = ')', '\n')) >> ")") >> "]]";
 
     void parse_and_erase_macro_definitions(std::string& text, std::map<std::string, std::string>& macros) {
         try {

--- a/parse/Parse.cpp
+++ b/parse/Parse.cpp
@@ -357,7 +357,8 @@ namespace parse {
                             for (boost::split_iterator<std::string::iterator> it =
                                     boost::make_split_iterator(macro_params, boost::first_finder(",", boost::is_iequal()));
                                 it != boost::split_iterator<std::string::iterator>();
-                                ++it, ++replace_number) {
+                                ++it, ++replace_number)
+                            {
                                 // not using %1% (and boost::fmt) because the replaced text may itself have %s inside it that will get eaten
                                 boost::replace_all(replacement, "@" + boost::lexical_cast<std::string>(replace_number) + "@", boost::copy_range<std::string>(*it));
                             }

--- a/parse/Parse.cpp
+++ b/parse/Parse.cpp
@@ -235,7 +235,7 @@ namespace parse {
     const sregex MACRO_KEY = +_w;   // word character (alnum | _), one or more times, greedy
     const sregex MACRO_TEXT = -*_;  // any character, zero or more times, not greedy
     const sregex MACRO_DEFINITION = (s1 = MACRO_KEY) >> _n >> "'''" >> (s2 = MACRO_TEXT) >> "'''" >> _n;
-    const sregex MACRO_INSERTION = "[[" >> *space >> (s1 = MACRO_KEY) >> *space >> !("(" >> (s2 = +~_n) >> ")") >> "]]";
+    const sregex MACRO_INSERTION = "[[" >> *space >> (s1 = MACRO_KEY) >> *space >> !("(" >> (s2 = -+~_n) >> ")") >> "]]";
 
     void parse_and_erase_macro_definitions(std::string& text, std::map<std::string, std::string>& macros) {
         try {

--- a/parse/Parse.cpp
+++ b/parse/Parse.cpp
@@ -16,6 +16,7 @@
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/spirit/include/phoenix.hpp>
+#include <boost/algorithm/string/find_iterator.hpp>
 
 #define DEBUG_PARSERS 0
 
@@ -234,9 +235,9 @@ namespace parse {
     const sregex MACRO_KEY = +_w;   // word character (alnum | _), one or more times, greedy
     const sregex MACRO_TEXT = -*_;  // any character, zero or more times, not greedy
     const sregex MACRO_DEFINITION = (s1 = MACRO_KEY) >> _n >> "'''" >> (s2 = MACRO_TEXT) >> "'''" >> _n;
-    const sregex MACRO_INSERTION = "[[" >> *space >> (s1 = MACRO_KEY) >> *space >> "]]";
+    const sregex MACRO_INSERTION = "[[" >> *space >> (s1 = MACRO_KEY) >> *space >> !("(" >> (s2 = +~_n) >> ")") >> "]]";
 
-    void parse_and_erase_macros_from_text(std::string& text, std::map<std::string, std::string>& macros) {
+    void parse_and_erase_macro_definitions(std::string& text, std::map<std::string, std::string>& macros) {
         try {
             std::string::iterator text_it = text.begin();
             while (true) {
@@ -338,7 +339,7 @@ namespace parse {
             smatch match;
             while (regex_search(text.begin() + position, text.end(), match, MACRO_INSERTION, regex_constants::match_default)) {
                 position += match.position();
-                const std::string& matched_text = match.str();  // [[MACRO_KEY]]
+                const std::string& matched_text = match.str();  // [[MACRO_KEY]] or [[MACRO_KEY(foo,bar,...)]]
                 const std::string& macro_key = match[1];        // just MACRO_KEY
                 // look up macro key to insert
                 std::map<std::string, std::string>::const_iterator macro_lookup_it = macros.find(macro_key);
@@ -349,8 +350,20 @@ namespace parse {
                         position += match.length();
                     } else {
                         // insert macro text in place of reference
-                        text.replace(position, matched_text.length(), macro_lookup_it->second);
-                        // recusrive replacement allowed, so don't skip past
+                        std::string replacement = macro_lookup_it->second;
+                        std::string macro_params = match[2]; // arg1,arg2,arg3,etc.
+                        if (!macro_params.empty()) { // found macro parameters
+                            int replace_number = 1;
+                            for (boost::split_iterator<std::string::iterator> it =
+                                    boost::make_split_iterator(macro_params, boost::first_finder(",", boost::is_iequal()));
+                                it != boost::split_iterator<std::string::iterator>();
+                                ++it, ++replace_number) {
+                                // not using %1% (and boost::fmt) because the replaced text may itself have %s inside it that will get eaten
+                                boost::replace_all(replacement, "@" + boost::lexical_cast<std::string>(replace_number) + "@", boost::copy_range<std::string>(*it));
+                            }
+                        }
+                        text.replace(position, matched_text.length(), replacement);
+                        // recursive replacement allowed, so don't skip past
                         // start of replacement text, so that inserted text can
                         // be matched on the next pass
                     }
@@ -370,7 +383,7 @@ namespace parse {
         //DebugLogger() << "macro_substitution for text:" << text;
         std::map<std::string, std::string> macros;
 
-        parse_and_erase_macros_from_text(text, macros);
+        parse_and_erase_macro_definitions(text, macros);
         check_for_cyclic_macro_references(macros);
 
         //DebugLogger() << "after macro pasring text:" << text;


### PR DESCRIPTION
[Vezzra](http://www.freeorion.org/forum/viewtopic.php?p=79376#p79376) recently brought this up, and it had been something I wanted to take a crack at anyway.

I'm not really fond of the `@1@` syntax, but it does the job of avoiding conflicts with FOCS syntax itself, which `%1%` would not.
