### PR TITLE
Changes to fields:

### DIFF
--- a/default/fields.txt
+++ b/default/fields.txt
@@ -18,12 +18,12 @@ FieldType
                 ValueTest high = max((UniverseWidth ^ 1.1) / 50, 20) TestValue = Source.Age
                 Size high = 50
                ]
-            effects = SetSize value = Value + min(max(Value * RandomNumber(0.05, 0.1), 1.0), 5.0)
+            effects = SetSize value = Value + min(max(Value * RandomNumber(0.05, 0.1), 1.0), 3.0)
 
         EffectsGroup    // shrink size when old
             scope = Source
             activation = ValueTest low = max((UniverseWidth ^ 1.1) / 50, 20) TestValue = Source.Age
-            effects = SetSize value = Value - min(max(Value * RandomNumber(0.05, 0.1), 1.0), 5.0)
+            effects = SetSize value = Value - min(max(Value * RandomNumber(0.05, 0.1), 1.0), 3.0)
 /*
         EffectsGroup    // after reaching a certain age, shrink size a bit each turn when near systems
             scope = Source

--- a/default/python/turn_events/turn_events.py
+++ b/default/python/turn_events/turn_events.py
@@ -9,17 +9,17 @@ def execute_turn_events():
     print "Executing turn events for turn", fo.current_turn()
 
     # creating fields
-    if random() < max(0.00015 * fo.get_universe_width(), 0.05):
+    if random() < max(0.00015 * fo.get_universe_width(), 0.03):
         if random() < 0.4:
             field_type = "FLD_MOLECULAR_CLOUD"
-            size = 5.0
+            size = 15.0 + uniform(0, 15)
         else:
             field_type = "FLD_ION_STORM"
-            size = 5.0
+            size = 10.0 + uniform(0, 10)
 
         radius = fo.get_universe_width() / 2.0
         angle = random() * 2.0 * pi
-        dist_from_center = radius + uniform(min(radius * 0.02, 50.0), min(radius * 0.05, 100.0))
+        dist_from_center = radius + uniform(min(max(radius * 0.02, 10), 50.0), min(max(radius * 0.05, 20), 100.0))
         x = radius + (dist_from_center * sin(angle))
         y = radius + (dist_from_center * cos(angle))
 


### PR DESCRIPTION
- Reduced the spawn rate on small and normal sized maps to 0.03.
- The fields will start a little larger and added randomization to starting size.
- Increased the minimum distance of spawn location and galaxy center on smaller maps (width < 1000).
- Decreased the max growth and shrink amount of Ion Storms.
