### PR TITLE
Improve "reset default window positions" feature

### DIFF
--- a/GG/GG/GUI.h
+++ b/GG/GG/GUI.h
@@ -154,10 +154,6 @@ public:
         accel_end(). */
     typedef std::set<std::pair<Key, Flags<ModKey> > >::const_iterator const_accel_iterator;
 
-    /** The type of iterator returned by const modal_begin() and
-        modal_end(). */
-    typedef std::list<std::pair<Wnd*, Wnd*> >::const_iterator const_modal_iterator;
-
     /** \name Structors */ ///@{
     virtual ~GUI(); ///< virtual dtor
     //@}
@@ -212,9 +208,6 @@ public:
 
     /** Returns an iterator to one past the last defined keyboard accelerator. */
     const_accel_iterator accel_end() const;
-
-    const_modal_iterator modal_begin() const;   ///< returns an iterator to the first registered modal wnd
-    const_modal_iterator modal_end() const;     ///< returns an iterator to one past the last registered modal wnd
 
     /** Returns the signal that is emitted when the requested keyboard accelerator is invoked. */
     AcceleratorSignalType& AcceleratorSignal(Key key, Flags<ModKey> mod_keys = MOD_KEY_NONE) const;

--- a/GG/src/GUI.cpp
+++ b/GG/src/GUI.cpp
@@ -1103,12 +1103,6 @@ void GUI::RegisterModal(Wnd* wnd)
     }
 }
 
-GUI::const_modal_iterator GUI::modal_begin() const
-{ return s_impl->m_modal_wnds.begin(); }
-
-GUI::const_modal_iterator GUI::modal_end() const
-{ return s_impl->m_modal_wnds.end(); }
-
 void GUI::Remove(Wnd* wnd)
 {
     if (wnd) {

--- a/UI/BuildDesignatorWnd.h
+++ b/UI/BuildDesignatorWnd.h
@@ -105,6 +105,8 @@ private:
     void            BuildQuantityChanged(int queue_idx, int quantity);
     void            SetBuild(int queue_idx);
 
+    void            InitializeWindows();
+
     EncyclopediaDetailPanel*    m_enc_detail_panel;
     BuildSelector*              m_build_selector;
     SidePanel*                  m_side_panel;

--- a/UI/CUIWnd.h
+++ b/UI/CUIWnd.h
@@ -125,6 +125,10 @@ public:
     virtual void    PinClicked();                       //!< called when window is pinned or unpinned via the pin button
     //@}
 
+    //! \name Statics //@{
+    static void     RemoveUnusedOptions();              //!< removes unregistered and registered-but-unused window options from the OptionsDB so that new windows fall back to their default properties.
+    //@}
+
 protected:
     //! \name Accessors //@{
     virtual GG::Pt  MinimizedSize() const;              //!< the size of a minimized CUIWnd
@@ -146,6 +150,7 @@ protected:
                                               GG::X left = GG::X0, GG::Y top = GG::Y0,
                                               GG::X width = GG::X(400), GG::Y height = GG::Y(200),
                                               bool visible = false, bool pinned = false, bool minimized = false);    //!< overload that accepts GG::X and GG::Y instead of ints
+    static void              RemoveWindowOptions(const std::string& config_name);           //!< removes options containing \a config_name, logs an error instead if "UI.windows."+config_name+".initialized" exists (i.e. if a window is currently using that name)
     //@}
 
     //! \name Mutators //@{

--- a/UI/CUIWnd.h
+++ b/UI/CUIWnd.h
@@ -141,7 +141,7 @@ public:
     //@}
 
     //! \name Statics //@{
-    static void     RemoveUnusedOptions();              //!< removes unregistered and registered-but-unused window options from the OptionsDB so that new windows fall back to their default properties.
+    static void     InvalidateUnusedOptions();          //!< removes unregistered and registered-but-unused window options from the OptionsDB so that new windows fall back to their default properties.
     //@}
 
 protected:
@@ -167,7 +167,7 @@ protected:
                                               GG::X left, GG::Y top, GG::X width, GG::Y height,
                                               bool visible, bool pinned, bool minimized);   //!< overload that accepts GG::X and GG::Y instead of ints
 
-    static void              RemoveWindowOptions(const std::string& config_name);           //!< removes options containing \a config_name, logs an error instead if "UI.windows."+config_name+".initialized" exists (i.e. if a window is currently using that name)
+    static void              InvalidateWindowOptions(const std::string& config_name);       //!< removes options containing \a config_name, logs an error instead if "UI.windows."+config_name+".initialized" exists (i.e. if a window is currently using that name)
     //@}
 
     //! \name Mutators //@{

--- a/UI/CUIWnd.h
+++ b/UI/CUIWnd.h
@@ -86,13 +86,27 @@ extern GG::WndFlag PINABLE;        ///< allows the window to be pinned
 class CUIWnd : public GG::Wnd {
 public:
     //! \name Structors //@{
+    /** Constructs the window to be a CUI window. Specifying \a config_name
+      * causes the window to save its position and other properties to the
+      * OptionsDB under that name, if no other windows are currently using that
+      * name. */
     CUIWnd(const std::string& t,
-           GG::X x, GG::Y y,
-           GG::X w, GG::Y h,
+           GG::X x, GG::Y y, GG::X w, GG::Y h,
            GG::Flags<GG::WndFlag> flags = GG::INTERACTIVE,
            const std::string& config_name = "",
-           bool visible = true); //!< Constructs the window to be a CUI window. Specifying \a config_name causes the window to save its position and other properties to the OptionsDB under that name, if no other windows are currently using that name.
-    virtual ~CUIWnd();  //!< Destructor
+           bool visible = true);
+
+    /** Constructs a CUI window without specifying the initial (default)
+      * position, either call InitSizeMove() if the window is positioned by
+      * something else or override CalculatePosition() then call
+      * ResetDefaultPosition() for windows that position themselves. */
+    CUIWnd(const std::string& t,
+           GG::Flags<GG::WndFlag> flags = GG::INTERACTIVE,
+           const std::string& config_name = "",
+           bool visible = true);
+
+    /** Virtual destructor. */
+    virtual ~CUIWnd();
     //@}
 
     //! \name Accessors //@{
@@ -117,7 +131,8 @@ public:
 
     void            ToggleMinimized() { MinimizeClicked(); }
     void            Close()           { CloseClicked(); }
-    void            ValidatePosition();                 //!< positions window entirely within the parent window/app window
+    void            ValidatePosition();                                 //!< calls SizeMove() to trigger position-checking and position the window entirely within the parent window/app window
+    void            InitSizeMove(const GG::Pt& ul, const GG::Pt& lr);   //!< sets default positions and if default positions were set beforehand, calls SizeMove()
     //@}
 
     //! \name Mutators //@{
@@ -139,17 +154,19 @@ protected:
     int             InnerBorderAngleOffset() const;     //!< the distance from where the lower right corner of the inner border should be to where the angled portion of the inner border meets the right and bottom lines of the border
     bool            InResizeTab(const GG::Pt& pt) const;//!< returns true iff the specified \a pt is in the region where dragging will resize this Wnd
     void            SaveOptions() const;                //!< saves options for this window to the OptionsDB if config_name was specified in the constructor
+
+    virtual GG::Rect    CalculatePosition() const;      //!< override this if a class determines its own position/size and return the calculated values, called by ResetDefaultPosition()
     //@}
 
     //! \name Statics //@{
     static const std::string AddWindowOptions(const std::string& config_name,
-                                              int left = 0, int top = 0,
-                                              int width = 400, int height = 200,
-                                              bool visible = false, bool pinned = false, bool minimized = false);    //!< Adds OptionsDB entries for a window under a given name along with default values.
+                                              int left, int top, int width, int height,
+                                              bool visible, bool pinned, bool minimized);   //!< Adds OptionsDB entries for a window under a given name along with default values.
+
     static const std::string AddWindowOptions(const std::string& config_name,
-                                              GG::X left = GG::X0, GG::Y top = GG::Y0,
-                                              GG::X width = GG::X(400), GG::Y height = GG::Y(200),
-                                              bool visible = false, bool pinned = false, bool minimized = false);    //!< overload that accepts GG::X and GG::Y instead of ints
+                                              GG::X left, GG::Y top, GG::X width, GG::Y height,
+                                              bool visible, bool pinned, bool minimized);   //!< overload that accepts GG::X and GG::Y instead of ints
+
     static void              RemoveWindowOptions(const std::string& config_name);           //!< removes options containing \a config_name, logs an error instead if "UI.windows."+config_name+".initialized" exists (i.e. if a window is currently using that name)
     //@}
 
@@ -160,6 +177,8 @@ protected:
 
     virtual void    InitBuffers();
     void            LoadOptions();                  //!< loads options for this window from the OptionsDB
+    void            Init(const std::string& t);     //!< performs initialization common to all CUIWnd constructors
+    void            ResetDefaultPosition();         //!< called via signal from the ClientUI, passes the value from CalculatePosition() to InitSizeMove()
     //@}
 
     bool                    m_resizable;            //!< true if the window is able to be resized

--- a/UI/ChatWnd.cpp
+++ b/UI/ChatWnd.cpp
@@ -269,12 +269,8 @@ bool MessageWndEdit::CompleteWord(const std::set<std::string>& names,
 ////////////////////
 //   MessageWnd   //
 ////////////////////
-MessageWnd::MessageWnd(GG::X default_x, GG::Y default_y,
-                       GG::X default_w, GG::Y default_h,
-                       const std::string& config_name) :
+MessageWnd::MessageWnd(const std::string& config_name) :
     CUIWnd(UserString("MESSAGES_PANEL_TITLE"),
-           default_x, default_y,
-           default_w, default_h,
            GG::INTERACTIVE | GG::DRAGABLE | GG::ONTOP | GG::RESIZABLE | CLOSABLE | PINABLE,
            config_name),
     m_display(0),

--- a/UI/ChatWnd.h
+++ b/UI/ChatWnd.h
@@ -16,9 +16,7 @@ class MessageWndEdit;
 class MessageWnd : public CUIWnd {
 public:
     //! \name Structors //@{
-    MessageWnd(GG::X default_x, GG::Y default_y,
-               GG::X default_w, GG::Y default_h,
-               const std::string& config_name = "");
+    MessageWnd(const std::string& config_name = "");
     //@}
 
     //! \name Mutators //@{

--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -553,7 +553,7 @@ ClientUI::ClientUI() :
 
     // Remove all window properties if asked to
     if (GetOptionsDB().Get<bool>("window-reset"))
-        CUIWnd::RemoveUnusedOptions();
+        CUIWnd::InvalidateUnusedOptions();
 
     m_message_wnd = new MessageWnd(MESSAGE_WND_NAME);
     m_player_list_wnd = new PlayerListWnd(PLAYER_LIST_WND_NAME);
@@ -574,7 +574,7 @@ ClientUI::ClientUI() :
     GG::Connect(HumanClientApp::GetApp()->RepositionWindowsSignal,
                 &ClientUI::InitializeWindows, this);
     GG::Connect(HumanClientApp::GetApp()->RepositionWindowsSignal,
-                &CUIWnd::RemoveUnusedOptions,
+                &CUIWnd::InvalidateUnusedOptions,
                 boost::signals2::at_front);
 
     // Connected at front to make sure CUIWnd::LoadOptions() doesn't overwrite

--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -529,6 +529,10 @@ ClientUI::ClientUI() :
     s_the_UI = this;
     Hotkey::ReadFromOptions(GetOptionsDB());
 
+    // Remove all window properties if asked to
+    if (GetOptionsDB().Get<bool>("window-reset"))
+        CUIWnd::RemoveUnusedOptions();
+
     m_message_wnd =             new MessageWnd(   GG::X0,                  GG::GUI::GetGUI()->AppHeight() - PANEL_HEIGHT,
                                                   MESSAGE_PANEL_WIDTH,     PANEL_HEIGHT,
                                                   MESSAGE_WND_NAME);

--- a/UI/ClientUI.h
+++ b/UI/ClientUI.h
@@ -87,7 +87,6 @@ public:
     void    DumpObject(int object_id);                                 //!< Displays debug info about specified object in messages window
 
     void    InitializeWindows();
-    void    RecalculateWindowDefaults();                               //!< Recalculates default positions for all windows based on the current app size
 
     /** Loads a texture at random from the set of files starting with \a prefix in directory \a dir. */
     boost::shared_ptr<GG::Texture> GetRandomTexture(const boost::filesystem::path& dir, const std::string& prefix, bool mipmap = false);
@@ -213,6 +212,9 @@ private:
     TexturesAndDist     PrefixedTexturesAndDist(const boost::filesystem::path& dir,
                                                 const std::string& prefix,
                                                 bool mipmap);
+
+    void                HandleSizeChange(bool fullscreen) const;
+    void                HandleFullscreenSwitch() const;
 
     MapWnd*                 m_map_wnd;              //!< the galaxy map
     MessageWnd*             m_message_wnd;          //!< the messages / chat display

--- a/UI/ClientUI.h
+++ b/UI/ClientUI.h
@@ -86,6 +86,9 @@ public:
 
     void    DumpObject(int object_id);                                 //!< Displays debug info about specified object in messages window
 
+    void    InitializeWindows();
+    void    RecalculateWindowDefaults();                               //!< Recalculates default positions for all windows based on the current app size
+
     /** Loads a texture at random from the set of files starting with \a prefix in directory \a dir. */
     boost::shared_ptr<GG::Texture> GetRandomTexture(const boost::filesystem::path& dir, const std::string& prefix, bool mipmap = false);
 

--- a/UI/CombatReport/CombatReportWnd.cpp
+++ b/UI/CombatReport/CombatReportWnd.cpp
@@ -175,12 +175,8 @@ private:
     }
 };
 
-CombatReportWnd::CombatReportWnd(GG::X default_x, GG::Y default_y,
-                                 GG::X default_w, GG::Y default_h,
-                                 const std::string& config_name) :
+CombatReportWnd::CombatReportWnd(const std::string& config_name) :
     CUIWnd(UserString("COMBAT_REPORT_TITLE"),
-           default_x, default_y,
-           default_w, default_h,
            GG::INTERACTIVE | GG::RESIZABLE | GG::DRAGABLE | GG::ONTOP | CLOSABLE,
            config_name, false),
     m_impl(0)

--- a/UI/CombatReport/CombatReportWnd.h
+++ b/UI/CombatReport/CombatReportWnd.h
@@ -8,9 +8,7 @@
 /// Shows a report on a combat
 class CombatReportWnd : public CUIWnd {
 public:
-    CombatReportWnd(GG::X default_x, GG::Y default_y,
-                    GG::X default_w, GG::Y default_h,
-                    const std::string& config_name = "");
+    CombatReportWnd(const std::string& config_name = "");
     // Must have explicit destructor since CombatReportPrivate is incomplete here
     virtual ~CombatReportWnd();
 

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -856,9 +856,7 @@ void PartsListBox::HideSuperfluousParts(bool refresh_list) {
 class DesignWnd::PartPalette : public CUIWnd {
 public:
     /** \name Structors */ //@{
-    PartPalette(GG::X default_x, GG::Y default_y,
-                GG::X default_w, GG::Y default_h,
-                const std::string& config_name);
+    PartPalette(const std::string& config_name);
     //@}
 
     /** \name Mutators */ //@{
@@ -895,12 +893,8 @@ private:
     CUIButton*                          m_superfluous_parts_button;
 };
 
-DesignWnd::PartPalette::PartPalette(GG::X default_x, GG::Y default_y,
-                                    GG::X default_w, GG::Y default_h,
-                                    const std::string& config_name) :
+DesignWnd::PartPalette::PartPalette(const std::string& config_name) :
     CUIWnd(UserString("DESIGN_WND_PART_PALETTE_TITLE"),
-           default_x, default_y,
-           default_w, default_h,
            GG::ONTOP | GG::INTERACTIVE | GG::DRAGABLE | GG::RESIZABLE,
            config_name),
     m_parts_list(0),
@@ -1983,9 +1977,7 @@ void BasesListBox::HideAvailability(bool available, bool refresh_list) {
 class DesignWnd::BaseSelector : public CUIWnd {
 public:
     /** \name Structors */ //@{
-    BaseSelector(GG::X default_x, GG::Y default_y,
-                 GG::X default_w, GG::Y default_h,
-                 const std::string& config_name);
+    BaseSelector(const std::string& config_name);
     //@}
 
     /** \name Mutators */ //@{
@@ -2020,12 +2012,8 @@ private:
     std::pair<CUIButton*, CUIButton*>   m_availability_buttons;
 };
 
-DesignWnd::BaseSelector::BaseSelector(GG::X default_x, GG::Y default_y,
-                                      GG::X default_w, GG::Y default_h,
-                                      const std::string& config_name) :
+DesignWnd::BaseSelector::BaseSelector(const std::string& config_name) :
     CUIWnd(UserString("DESIGN_WND_STARTS"),
-           default_x, default_y,
-           default_w, default_h,
            GG::INTERACTIVE | GG::RESIZABLE | GG::ONTOP | GG::DRAGABLE | PINABLE,
            config_name),
     m_tabs(0),
@@ -2449,9 +2437,7 @@ void SlotControl::EmitNullSlotContentsAlteredSignal()
 class DesignWnd::MainPanel : public CUIWnd {
 public:
     /** \name Structors */ //@{
-    MainPanel(GG::X default_x, GG::Y default_y,
-              GG::X default_w, GG::Y default_h,
-              const std::string& config_name);
+    MainPanel(const std::string& config_name);
     //@}
 
     /** \name Accessors */ //@{
@@ -2572,12 +2558,8 @@ private:
 // static
 DesignWnd::MainPanel::SetPartFuncPtrType const DesignWnd::MainPanel::s_set_part_func_ptr = &DesignWnd::MainPanel::SetPart;
 
-DesignWnd::MainPanel::MainPanel(GG::X default_x, GG::Y default_y,
-                                GG::X default_w, GG::Y default_h,
-                                const std::string& config_name) :
+DesignWnd::MainPanel::MainPanel(const std::string& config_name) :
     CUIWnd(UserString("DESIGN_WND_MAIN_PANEL_TITLE"),
-           default_x, default_y,
-           default_w, default_h,
            GG::INTERACTIVE | GG::DRAGABLE | GG::RESIZABLE,
            config_name),
     m_hull(0),
@@ -3195,28 +3177,15 @@ DesignWnd::DesignWnd(GG::X w, GG::Y h) :
     Sound::TempUISoundDisabler sound_disabler;
     SetChildClippingMode(ClipToClient);
 
-    GG::X base_selector_width(250);
-    GG::X most_panels_left = base_selector_width;
-    GG::X most_panels_width = ClientWidth() - most_panels_left;
-    GG::X detail_width = 5*most_panels_width/11;
-    GG::X part_palette_left = base_selector_width + detail_width;
-    GG::X part_palette_width = most_panels_width - detail_width;
-    GG::Y detail_top = GG::Y0;
-    GG::Y detail_height = 2*ClientHeight()/5;
-    GG::Y main_top = detail_top + detail_height;
-    GG::Y part_palette_height = detail_height;
-    GG::Y part_palette_top = detail_top;
-    GG::Y main_height = ClientHeight() - main_top;
+    m_detail_panel = new EncyclopediaDetailPanel(GG::ONTOP | GG::INTERACTIVE | GG::DRAGABLE | GG::RESIZABLE | PINABLE, DES_PEDIA_WND_NAME);
+    m_main_panel = new MainPanel(DES_MAIN_WND_NAME);
+    m_part_palette = new PartPalette(DES_PART_PALETTE_WND_NAME);
+    m_base_selector = new BaseSelector(DES_BASE_SELECTOR_WND_NAME);
+    InitializeWindows();
+    GG::Connect(HumanClientApp::GetApp()->RepositionWindowsSignal, &DesignWnd::InitializeWindows, this);
 
-    m_detail_panel = new EncyclopediaDetailPanel(most_panels_left, detail_top,
-                                                 detail_width, detail_height,
-                                                 GG::ONTOP | GG::INTERACTIVE | GG::DRAGABLE | GG::RESIZABLE | PINABLE,
-                                                 DES_PEDIA_WND_NAME);
     AttachChild(m_detail_panel);
 
-    m_main_panel = new MainPanel(most_panels_left, main_top,
-                                 most_panels_width, main_height,
-                                 DES_MAIN_WND_NAME);
     AttachChild(m_main_panel);
     GG::Connect(m_main_panel->PartTypeClickedSignal,            static_cast<void (EncyclopediaDetailPanel::*)(const PartType*)>(&EncyclopediaDetailPanel::SetItem),  m_detail_panel);
     GG::Connect(m_main_panel->HullTypeClickedSignal,            static_cast<void (EncyclopediaDetailPanel::*)(const HullType*)>(&EncyclopediaDetailPanel::SetItem),  m_detail_panel);
@@ -3232,16 +3201,10 @@ DesignWnd::DesignWnd(GG::X w, GG::Y h) :
     GG::Connect(m_main_panel->CompleteDesignClickedSignal,      static_cast<void (EncyclopediaDetailPanel::*)(int)>(&EncyclopediaDetailPanel::SetDesign),m_detail_panel);
     m_main_panel->Sanitize();
 
-    m_part_palette = new PartPalette(part_palette_left, part_palette_top,
-                                     part_palette_width, part_palette_height,
-                                     DES_PART_PALETTE_WND_NAME);
     AttachChild(m_part_palette);
     GG::Connect(m_part_palette->PartTypeClickedSignal,          static_cast<void (EncyclopediaDetailPanel::*)(const PartType*)>(&EncyclopediaDetailPanel::SetItem),  m_detail_panel);
     GG::Connect(m_part_palette->PartTypeDoubleClickedSignal,    &DesignWnd::MainPanel::AddPart,     m_main_panel);
 
-    m_base_selector = new BaseSelector(GG::X0, GG::Y0,
-                                       base_selector_width, ClientHeight(),
-                                       DES_BASE_SELECTOR_WND_NAME);
     AttachChild(m_base_selector);
 
     GG::Connect(m_base_selector->DesignSelectedSignal,          static_cast<void (MainPanel::*)(int)>(&MainPanel::SetDesign),
@@ -3296,6 +3259,28 @@ void DesignWnd::Render() {
     glEnd();
 
     glEnable(GL_TEXTURE_2D);
+}
+
+void DesignWnd::InitializeWindows() {
+    const GG::X selector_width = GG::X(250);
+    const GG::X main_width = ClientWidth() - selector_width;
+
+    const GG::Pt pedia_ul(selector_width, GG::Y0);
+    const GG::Pt pedia_wh(5*main_width/11, 2*ClientHeight()/5);
+
+    const GG::Pt main_ul(selector_width, pedia_ul.y + pedia_wh.y);
+    const GG::Pt main_wh(main_width, ClientHeight() - main_ul.y);
+
+    const GG::Pt palette_ul(selector_width + pedia_wh.x, pedia_ul.y);
+    const GG::Pt palette_wh(main_width - pedia_wh.x, pedia_wh.y);
+
+    const GG::Pt selector_ul(GG::X0, GG::Y0);
+    const GG::Pt selector_wh(selector_width, ClientHeight());
+
+    m_detail_panel-> InitSizeMove(pedia_ul,     pedia_ul + pedia_wh);
+    m_main_panel->   InitSizeMove(main_ul,      main_ul + main_wh);
+    m_part_palette-> InitSizeMove(palette_ul,   palette_ul + palette_wh);
+    m_base_selector->InitSizeMove(selector_ul,  selector_ul + selector_wh);
 }
 
 void DesignWnd::ShowPartTypeInEncyclopedia(const std::string& part_type)

--- a/UI/DesignWnd.h
+++ b/UI/DesignWnd.h
@@ -40,6 +40,8 @@ private:
 
     void    AddDesign();    ///< adds current design to those stored by this empire, allowing ships of this design to be produced
 
+    void    InitializeWindows();
+
     EncyclopediaDetailPanel*    m_detail_panel;
     BaseSelector*               m_base_selector;
     PartPalette*                m_part_palette;

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -468,12 +468,9 @@ namespace {
 std::list <std::pair<std::string, std::string> >            EncyclopediaDetailPanel::m_items = std::list<std::pair<std::string, std::string> >(0);
 std::list <std::pair<std::string, std::string> >::iterator  EncyclopediaDetailPanel::m_items_it = m_items.begin();
 
-EncyclopediaDetailPanel::EncyclopediaDetailPanel(GG::X default_x, GG::Y default_y,
-                                                 GG::X default_w, GG::Y default_h,
-                                                 GG::Flags<GG::WndFlag> flags,
+EncyclopediaDetailPanel::EncyclopediaDetailPanel(GG::Flags<GG::WndFlag> flags,
                                                  const std::string& config_name) :
     CUIWnd("",
-           default_x, default_y, default_w, default_h,
            flags,
            config_name, false),
     m_name_text(0),

--- a/UI/EncyclopediaDetailPanel.h
+++ b/UI/EncyclopediaDetailPanel.h
@@ -26,9 +26,7 @@ template <class T> class TemporaryPtr;
 class EncyclopediaDetailPanel : public CUIWnd {
 public:
     //! \name Structors //!@{
-    EncyclopediaDetailPanel(GG::X default_x, GG::Y default_y,
-                            GG::X default_w, GG::Y default_h,
-                            GG::Flags<GG::WndFlag> flags = GG::ONTOP | GG::INTERACTIVE | GG::DRAGABLE | GG::RESIZABLE | CLOSABLE | PINABLE,
+    EncyclopediaDetailPanel(GG::Flags<GG::WndFlag> flags = GG::ONTOP | GG::INTERACTIVE | GG::DRAGABLE | GG::RESIZABLE | CLOSABLE | PINABLE,
                             const std::string& config_name = "");
     virtual ~EncyclopediaDetailPanel();
     //!@}

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -2692,6 +2692,7 @@ void FleetWnd::Init(int selected_fleet_id) {
     ResetDefaultPosition();
     SetMinSize(GG::Pt(CUIWnd::MinimizedSize().x, BORDER_TOP + INNER_BORDER_ANGLE_OFFSET + BORDER_BOTTOM +
                                                  ListRowHeight() + 2*GG::Y(PAD)));
+    DoLayout();
 }
 
 GG::Rect FleetWnd::CalculatePosition() const {

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -2573,7 +2573,7 @@ FleetWnd::FleetWnd(const std::vector<int>& fleet_ids, bool order_issuing_enabled
          int selected_fleet_id/* = INVALID_OBJECT_ID*/,
          GG::Flags<GG::WndFlag> flags/* = INTERACTIVE | DRAGABLE | ONTOP | CLOSABLE | RESIZABLE*/,
          const std::string& config_name) :
-    MapWndPopup("", GG::X(5), GG::GUI::GetGUI()->AppHeight() - FLEET_WND_HEIGHT - 5, FLEET_WND_WIDTH, FLEET_WND_HEIGHT, flags, config_name),
+    MapWndPopup("", flags, config_name),
     m_fleet_ids(),
     m_empire_id(ALL_EMPIRES),
     m_system_id(INVALID_OBJECT_ID),
@@ -2592,7 +2592,7 @@ FleetWnd::FleetWnd(int system_id, int empire_id, bool order_issuing_enabled,
          int selected_fleet_id/* = INVALID_OBJECT_ID*/,
          GG::Flags<GG::WndFlag> flags/* = INTERACTIVE | DRAGABLE | ONTOP | CLOSABLE | RESIZABLE*/,
          const std::string& config_name) :
-    MapWndPopup("", GG::X(5), GG::GUI::GetGUI()->AppHeight() - FLEET_WND_HEIGHT - 5, FLEET_WND_WIDTH, FLEET_WND_HEIGHT, flags | GG::RESIZABLE, config_name),
+    MapWndPopup("", flags | GG::RESIZABLE, config_name),
     m_fleet_ids(),
     m_empire_id(empire_id),
     m_system_id(system_id),
@@ -2609,9 +2609,6 @@ FleetWnd::~FleetWnd() {
 }
 
 void FleetWnd::Init(int selected_fleet_id) {
-    SetMinSize(GG::Pt(CUIWnd::MinimizedSize().x, BORDER_TOP + INNER_BORDER_ANGLE_OFFSET + BORDER_BOTTOM +
-                                                 ListRowHeight() + 2*GG::Y(PAD)));
-
     Sound::TempUISoundDisabler sound_disabler;
 
     // add fleet aggregate stat icons
@@ -2692,7 +2689,15 @@ void FleetWnd::Init(int selected_fleet_id) {
         selected_fleet_id = INVALID_OBJECT_ID;
     }
 
-    DoLayout();
+    ResetDefaultPosition();
+    SetMinSize(GG::Pt(CUIWnd::MinimizedSize().x, BORDER_TOP + INNER_BORDER_ANGLE_OFFSET + BORDER_BOTTOM +
+                                                 ListRowHeight() + 2*GG::Y(PAD)));
+}
+
+GG::Rect FleetWnd::CalculatePosition() const {
+    GG::Pt ul(GG::X(5), GG::GUI::GetGUI()->AppHeight() - FLEET_WND_HEIGHT - 5);
+    GG::Pt wh(FLEET_WND_WIDTH, FLEET_WND_HEIGHT);
+    return GG::Rect(ul, ul + wh);
 }
 
 void FleetWnd::SetStatIconValues() {

--- a/UI/FleetWnd.h
+++ b/UI/FleetWnd.h
@@ -106,6 +106,7 @@ public:
     std::set<int>           SelectedFleetIDs() const;           ///< returns IDs of selected fleets in this FleetWnd
     std::set<int>           SelectedShipIDs() const;            ///< returns IDs of selected ships in this FleetWnd
     NewFleetAggression      GetNewFleetAggression() const;      ///< returns this FleetWnd's setting for new fleet aggression (auto, aggressive, or passive)
+    virtual GG::Rect        CalculatePosition() const;
     //@}
 
     //! \name Mutators //@{

--- a/UI/GalaxySetupWnd.cpp
+++ b/UI/GalaxySetupWnd.cpp
@@ -469,8 +469,7 @@ void GalaxySetupPanel::ShapeChanged(GG::DropDownList::iterator it)
 // GalaxySetupWnd
 ////////////////////////////////////////////////
 GalaxySetupWnd::GalaxySetupWnd() :
-    CUIWnd(UserString("GSETUP_WINDOW_TITLE"), (HumanClientApp::GetApp()->AppWidth() - GAL_SETUP_WND_WD) / 2,
-           (HumanClientApp::GetApp()->AppHeight() - GAL_SETUP_WND_HT) / 2, GAL_SETUP_WND_WD, GAL_SETUP_WND_HT,
+    CUIWnd(UserString("GSETUP_WINDOW_TITLE"),
            GG::INTERACTIVE | GG::MODAL),
     m_ended_with_ok(false),
     m_galaxy_setup_panel(0),
@@ -573,6 +572,7 @@ GalaxySetupWnd::GalaxySetupWnd() :
     AttachChild(m_ok);
     AttachChild(m_cancel);
 
+    ResetDefaultPosition();
     DoLayout();
 
     GG::Connect(m_galaxy_setup_panel->ImageChangedSignal,   &GalaxySetupWnd::PreviewImageChanged, this);
@@ -615,6 +615,13 @@ void GalaxySetupWnd::KeyPress(GG::Key key, boost::uint32_t key_code_point, GG::F
 void GalaxySetupWnd::SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
     CUIWnd::SizeMove(ul, lr);
     DoLayout();
+}
+
+GG::Rect GalaxySetupWnd::CalculatePosition() const {
+    GG::Pt new_ul((HumanClientApp::GetApp()->AppWidth() - GAL_SETUP_WND_WD) / 2,
+                  (HumanClientApp::GetApp()->AppHeight() - GAL_SETUP_WND_HT) / 2);
+    GG::Pt new_sz(GAL_SETUP_WND_WD, GAL_SETUP_WND_HT);
+    return GG::Rect(new_ul, new_ul + new_sz);
 }
 
 void GalaxySetupWnd::DoLayout() {

--- a/UI/GalaxySetupWnd.h
+++ b/UI/GalaxySetupWnd.h
@@ -111,6 +111,9 @@ public:
     virtual void SizeMove(const GG::Pt& ul, const GG::Pt& lr);
     //!@}
 
+protected:
+    virtual GG::Rect CalculatePosition() const;
+
 private:
     void DoLayout();
     void PreviewImageChanged(boost::shared_ptr<GG::Texture> new_image);

--- a/UI/InGameMenu.cpp
+++ b/UI/InGameMenu.cpp
@@ -26,9 +26,7 @@ namespace {
 
 InGameMenu::InGameMenu():
     CUIWnd(UserString("GAME_MENU_WINDOW_TITLE"),
-           (GG::GUI::GetGUI()->AppWidth() - IN_GAME_OPTIONS_WIDTH) / 2,
-           (GG::GUI::GetGUI()->AppHeight() - IN_GAME_OPTIONS_HEIGHT) / 2,
-           IN_GAME_OPTIONS_WIDTH, IN_GAME_OPTIONS_HEIGHT, GG::INTERACTIVE | GG::MODAL)
+           GG::INTERACTIVE | GG::MODAL)
 {
     m_save_btn = new CUIButton(UserString("GAME_MENU_SAVE"));
     m_load_btn = new CUIButton(UserString("GAME_MENU_LOAD"));
@@ -57,37 +55,26 @@ InGameMenu::InGameMenu():
         m_save_btn->Disable();
     }
 
-    ValidatePosition();
+    ResetDefaultPosition();
     DoLayout();
 }
 
 InGameMenu::~InGameMenu()
 {}
 
-void InGameMenu::SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
-    // This wnd determines its own size.
-    GG::Pt new_size(MinUsableSize());
-
-    // This wnd determines its own position.
-    GG::Pt new_ul(HumanClientApp::GetApp()->AppWidth()  * 0.5 - new_size.x/2,
-                  HumanClientApp::GetApp()->AppHeight() * 0.5 - new_size.y/2);
-    GG::Pt new_lr(HumanClientApp::GetApp()->AppWidth()  * 0.5 + new_size.x/2,
-                  HumanClientApp::GetApp()->AppHeight() * 0.5 + new_size.y/2);
-
-    CUIWnd::SizeMove(new_ul, new_lr);
-}
-
-GG::Pt InGameMenu::MinUsableSize() const {
+GG::Rect InGameMenu::CalculatePosition() const {
     const GG::X H_MAINMENU_MARGIN(40);  //horizontal empty space
     const GG::Y V_MAINMENU_MARGIN(40);  //vertical empty space
-    GG::X mainmenu_width(0);            //width of the mainmenu
-    GG::Y mainmenu_height(0);           //height of the mainmenu
 
     // Calculate window width and height
-    mainmenu_width  =        ButtonWidth()  + H_MAINMENU_MARGIN;
-    mainmenu_height = 5.75 * ButtonCellHeight() + V_MAINMENU_MARGIN; // 8 rows + 0.75 before exit button
+    GG::Pt new_size(ButtonWidth() + H_MAINMENU_MARGIN,
+                    5.75 * ButtonCellHeight() + V_MAINMENU_MARGIN); // 8 rows + 0.75 before exit button
 
-    return GG::Pt(mainmenu_width, mainmenu_height);
+    // This wnd determines its own position.
+    GG::Pt new_ul((HumanClientApp::GetApp()->AppWidth()  - new_size.x) / 2,
+                  (HumanClientApp::GetApp()->AppHeight() - new_size.y) / 2);
+
+    return GG::Rect(new_ul, new_ul + new_size);
 }
 
 GG::X InGameMenu::ButtonWidth() const {

--- a/UI/InGameMenu.h
+++ b/UI/InGameMenu.h
@@ -12,16 +12,14 @@ public:
     ~InGameMenu(); //!< dtor
     //@}
 
-    /** \name Accessors */ //@{
-    virtual GG::Pt MinUsableSize() const;
-    //@}
-
     /** \name Mutators */ //@{
     virtual void KeyPress (GG::Key key, boost::uint32_t key_code_point, GG::Flags<GG::ModKey> mod_keys);
-    virtual void SizeMove (const GG::Pt& ul, const GG::Pt& lr);
 
     void         DoLayout();
     //@}
+
+protected:
+    virtual GG::Rect CalculatePosition() const;
 
 private:
     void Save();        //!< when m_save_btn button is pressed

--- a/UI/MapWnd.h
+++ b/UI/MapWnd.h
@@ -198,6 +198,8 @@ private:
 
     class MapScaleLine;
 
+    void            InitializeWindows();
+
     void            Zoom(int delta);                            //!< changes the zoom level of the main map by zoom step size to the power of \a delta (adds delta to the current zoom exponent)
     void            Zoom(int delta, const GG::Pt& position);    //!< changes the zoom level of the main map by zoom step size to the power of \a delta (adds delta to the current zoom exponent) Keeps the screen position \a position in the same place after zooming
     void            ZoomSlid(double pos, double low, double high);
@@ -448,6 +450,9 @@ public:
     MapWndPopup(const std::string& t,
                 GG::X default_x, GG::Y default_y,
                 GG::X default_w, GG::Y default_h,
+                GG::Flags<GG::WndFlag> flags,
+                const std::string& config_name = "");
+    MapWndPopup(const std::string& t,
                 GG::Flags<GG::WndFlag> flags,
                 const std::string& config_name = "");
     virtual ~MapWndPopup();

--- a/UI/ModeratorActionsWnd.cpp
+++ b/UI/ModeratorActionsWnd.cpp
@@ -20,12 +20,8 @@ namespace {
 ////////////////////////////////////////////////
 // ModeratorActionsWnd
 ////////////////////////////////////////////////
-ModeratorActionsWnd::ModeratorActionsWnd(GG::X default_x, GG::Y default_y,
-                                         GG::X default_w, GG::Y default_h,
-                                         const std::string& config_name) :
+ModeratorActionsWnd::ModeratorActionsWnd(const std::string& config_name) :
     CUIWnd(UserString("MODERATOR"),
-           default_x, default_y,
-           default_w, default_h,
            GG::ONTOP | GG::INTERACTIVE | GG::DRAGABLE | GG::RESIZABLE | CLOSABLE | PINABLE,
            config_name, false),
     m_actions_enabled(true),

--- a/UI/ModeratorActionsWnd.h
+++ b/UI/ModeratorActionsWnd.h
@@ -14,9 +14,7 @@
 class ModeratorActionsWnd : public CUIWnd {
 public:
     //! \name Structors //!@{
-    ModeratorActionsWnd(GG::X default_x, GG::Y default_y,
-                        GG::X default_w, GG::Y default_h,
-                        const std::string& config_name = "");
+    ModeratorActionsWnd(const std::string& config_name = "");
     virtual ~ModeratorActionsWnd();
     //!@}
 

--- a/UI/MultiplayerLobbyWnd.cpp
+++ b/UI/MultiplayerLobbyWnd.cpp
@@ -374,9 +374,6 @@ namespace {
 
 MultiPlayerLobbyWnd::MultiPlayerLobbyWnd() :
     CUIWnd(UserString("MPLOBBY_WINDOW_TITLE"),
-           (GG::GUI::GetGUI()->AppWidth() - LOBBY_WND_WIDTH) / 2,
-           (GG::GUI::GetGUI()->AppHeight() - LOBBY_WND_HEIGHT) / 2,
-           LOBBY_WND_WIDTH, LOBBY_WND_HEIGHT,
            GG::ONTOP | GG::INTERACTIVE),
     m_chat_box(0),
     m_chat_input_edit(0),
@@ -444,6 +441,7 @@ MultiPlayerLobbyWnd::MultiPlayerLobbyWnd() :
     AttachChild(m_cancel_bn);
     AttachChild(m_start_conditions_text);
 
+    ResetDefaultPosition();
     DoLayout();
 
     // default settings (new game)
@@ -464,9 +462,16 @@ MultiPlayerLobbyWnd::MultiPlayerLobbyWnd() :
 
 void MultiPlayerLobbyWnd::SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
     const GG::Pt old_size = Size();
-    GG::Wnd::SizeMove(ul, lr);
+    CUIWnd::SizeMove(ul, lr);
     if (old_size != Size())
         DoLayout();
+}
+
+GG::Rect MultiPlayerLobbyWnd::CalculatePosition() const {
+    GG::Pt new_ul((GG::GUI::GetGUI()->AppWidth() - LOBBY_WND_WIDTH) / 2,
+                  (GG::GUI::GetGUI()->AppHeight() - LOBBY_WND_HEIGHT) / 2);
+    GG::Pt new_sz(LOBBY_WND_WIDTH, LOBBY_WND_HEIGHT);
+    return GG::Rect(new_ul, new_ul + new_sz);
 }
 
 bool MultiPlayerLobbyWnd::LoadGameSelected() const

--- a/UI/MultiplayerLobbyWnd.h
+++ b/UI/MultiplayerLobbyWnd.h
@@ -33,6 +33,9 @@ public:
     void            Refresh();
     //@}
 
+protected:
+    virtual GG::Rect CalculatePosition() const;
+
 private:
     void            DoLayout();
     void            NewLoadClicked(std::size_t idx);

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -920,12 +920,9 @@ private:
 ////////////////////////////////////////////////
 class FilterDialog : public CUIWnd {
 public:
-    FilterDialog(GG::X default_x, GG::Y default_y,
-                 const std::map<UniverseObjectType, std::set<VIS_DISPLAY> >& vis_filters,
+    FilterDialog(const std::map<UniverseObjectType, std::set<VIS_DISPLAY> >& vis_filters,
                  const Condition::ConditionBase* const condition_filter) :
         CUIWnd(UserString("FILTERS"),
-               default_x, default_y,
-               GG::X(400), GG::Y(250),
                GG::INTERACTIVE | GG::DRAGABLE | GG::MODAL,
                FILTER_OPTIONS_WND_NAME),
         m_vis_filters(vis_filters),
@@ -945,6 +942,10 @@ public:
     // caller takes ownership of returned ConditionBase*
     Condition::ConditionBase*                               GetConditionFilter()
     { return m_condition_widget->GetCondition(); }
+
+protected:
+    virtual GG::Rect CalculatePosition() const
+    { return GG::Rect(GG::X(100), GG::Y(100), GG::X(500), GG::Y(350)); }
 
 private:
     void    Init(const Condition::ConditionBase* const condition_filter) {
@@ -1028,6 +1029,8 @@ private:
 
         GG::Connect(m_cancel_button->LeftClickedSignal, &FilterDialog::CancelClicked,   this);
         GG::Connect(m_apply_button->LeftClickedSignal, &FilterDialog::AcceptClicked,   this);
+
+        ResetDefaultPosition();
 
         GG::Pt button_lr = this->ClientSize();
         m_cancel_button->Resize(GG::Pt(button_width, m_cancel_button->MinUsableSize().y));
@@ -2214,12 +2217,8 @@ private:
 ////////////////////////////////////////////////
 // ObjectListWnd
 ////////////////////////////////////////////////
-ObjectListWnd::ObjectListWnd(GG::X default_x, GG::Y default_y,
-                             GG::X default_w, GG::Y default_h,
-                             const std::string& config_name) :
+ObjectListWnd::ObjectListWnd(const std::string& config_name) :
     CUIWnd(UserString("MAP_BTN_OBJECTS"),
-           default_x, default_y,
-           default_w, default_h,
            GG::ONTOP | GG::INTERACTIVE | GG::DRAGABLE | GG::RESIZABLE | CLOSABLE | PINABLE,
            config_name, false),
     m_list_box(0),
@@ -2468,8 +2467,7 @@ int ObjectListWnd::ObjectInRow(GG::ListBox::iterator it) const {
 }
 
 void ObjectListWnd::FilterClicked() {
-    FilterDialog dlg(GG::X(100), GG::Y(100),
-                     m_list_box->Visibilities(), m_list_box->FilterCondition());
+    FilterDialog dlg(m_list_box->Visibilities(), m_list_box->FilterCondition());
     dlg.Run();
 
     if (dlg.ChangesAccepted()) {

--- a/UI/ObjectListWnd.h
+++ b/UI/ObjectListWnd.h
@@ -13,9 +13,7 @@ class ObjectListBox;
 class ObjectListWnd : public CUIWnd {
 public:
     //! \name Structors //!@{
-    ObjectListWnd(GG::X default_x, GG::Y default_y,
-                  GG::X default_w, GG::Y default_h,
-                  const std::string& config_name = "");
+    ObjectListWnd(const std::string& config_name = "");
     //!@}
 
     /** \name Mutators */ //@{

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -448,7 +448,7 @@ OptionsWnd::OptionsWnd():
     row->Resize(GG::Pt(ROW_WIDTH, window_reset_button->MinUsableSize().y + LAYOUT_MARGIN + 6));
     row->push_back(new RowContentsWnd(row->Width(), row->Height(), window_reset_button, 0));
     current_page->Insert(row);
-    GG::Connect(window_reset_button->LeftClickedSignal, &ClientUI::RecalculateWindowDefaults, ClientUI::GetClientUI());
+    GG::Connect(window_reset_button->LeftClickedSignal, HumanClientApp::GetApp()->RepositionWindowsSignal);
 
     FileOption(current_page, 0, "stringtable-filename",          UserString("OPTIONS_LANGUAGE"),
                GetRootDataDir() / "default" / "stringtables",

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -440,7 +440,6 @@ OptionsWnd::OptionsWnd():
     BoolOption(current_page, 0, "UI.multiple-fleet-windows",     UserString("OPTIONS_MULTIPLE_FLEET_WNDS"));
     BoolOption(current_page, 0, "UI.window-quickclose",          UserString("OPTIONS_QUICK_CLOSE_WNDS"));
     BoolOption(current_page, 0, "UI.sidepanel-planet-shown",     UserString("OPTIONS_SHOW_SIDEPANEL_PLANETS"));
-    BoolOption(current_page, 0, "window-reset",                  UserString("OPTIONS_WINDOW_RESET"));
     FileOption(current_page, 0, "stringtable-filename",          UserString("OPTIONS_LANGUAGE"),
                GetRootDataDir() / "default" / "stringtables",
                std::make_pair(UserString("OPTIONS_LANGUAGE_FILE"),

--- a/UI/OptionsWnd.h
+++ b/UI/OptionsWnd.h
@@ -27,6 +27,9 @@ public:
     virtual void SizeMove(const GG::Pt& ul, const GG::Pt& lr);
     //!@}
 
+protected:
+    virtual GG::Rect CalculatePosition() const;
+
 private:
     typedef void (OptionsWnd::* VolumeSliderHandler)(int, int, int);
 

--- a/UI/PlayerListWnd.cpp
+++ b/UI/PlayerListWnd.cpp
@@ -434,12 +434,8 @@ public:
 /////////////////////
 //  PlayerListWnd  //
 /////////////////////
-PlayerListWnd::PlayerListWnd(GG::X default_x, GG::Y default_y,
-                             GG::X default_w, GG::Y default_h,
-                             const std::string& config_name) :
+PlayerListWnd::PlayerListWnd(const std::string& config_name) :
     CUIWnd(UserString("PLAYERS_LIST_PANEL_TITLE"),
-           default_x, default_y,
-           default_w, default_h,
            GG::INTERACTIVE | GG::DRAGABLE | GG::ONTOP | GG::RESIZABLE | CLOSABLE | PINABLE,
            config_name),
     m_player_list(0)

--- a/UI/PlayerListWnd.h
+++ b/UI/PlayerListWnd.h
@@ -11,9 +11,7 @@ class PlayerListBox;
 class PlayerListWnd : public CUIWnd {
 public:
     //! \name Structors //@{
-    PlayerListWnd(GG::X default_x, GG::Y default_y,
-                  GG::X default_w, GG::Y default_h,
-                  const std::string& config_name);
+    PlayerListWnd(const std::string& config_name);
     //@}
 
     //! \name Accessors //@{

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -38,6 +38,8 @@ namespace {
     const GG::X SAVE_FILE_DIALOG_MIN_WIDTH ( 160 );
     const GG::Y SAVE_FILE_DIALOG_MIN_HEIGHT ( 100 );
 
+    const std::string SAVE_FILE_WND_NAME = "save-load";
+
     const GG::X PROMT_WIDTH ( 200 );
     const GG::Y PROMPT_HEIGHT ( 75 );
 
@@ -558,10 +560,8 @@ private:
 
 SaveFileDialog::SaveFileDialog (const std::string& extension, bool load) :
     CUIWnd(UserString("GAME_MENU_SAVE_FILES"),
-           (GG::GUI::GetGUI()->AppWidth() - SAVE_FILE_DIALOG_WIDTH) / 2,
-           (GG::GUI::GetGUI()->AppHeight() - SAVE_FILE_DIALOG_HEIGHT) / 2,
-           SAVE_FILE_DIALOG_WIDTH, SAVE_FILE_DIALOG_HEIGHT,
-           GG::INTERACTIVE | GG::DRAGABLE | GG::MODAL | GG::RESIZABLE)
+           GG::INTERACTIVE | GG::DRAGABLE | GG::MODAL | GG::RESIZABLE,
+           SAVE_FILE_WND_NAME)
 {
     m_extension = extension;
     m_load_only = load;
@@ -571,10 +571,8 @@ SaveFileDialog::SaveFileDialog (const std::string& extension, bool load) :
 
 SaveFileDialog::SaveFileDialog (bool load) :
     CUIWnd(UserString("GAME_MENU_SAVE_FILES"),
-           (GG::GUI::GetGUI()->AppWidth() - SAVE_FILE_DIALOG_WIDTH) / 2,
-           (GG::GUI::GetGUI()->AppHeight() - SAVE_FILE_DIALOG_HEIGHT) / 2,
-           SAVE_FILE_DIALOG_WIDTH, SAVE_FILE_DIALOG_HEIGHT,
-           GG::INTERACTIVE | GG::DRAGABLE | GG::MODAL | GG::RESIZABLE)
+           GG::INTERACTIVE | GG::DRAGABLE | GG::MODAL | GG::RESIZABLE,
+           SAVE_FILE_WND_NAME)
 {
     m_load_only = load;
     m_server_previews = true;
@@ -583,6 +581,7 @@ SaveFileDialog::SaveFileDialog (bool load) :
 }
 
 void SaveFileDialog::Init() {
+    ResetDefaultPosition();
     SetMinSize(GG::Pt(2*SAVE_FILE_DIALOG_MIN_WIDTH, 2*SAVE_FILE_DIALOG_MIN_HEIGHT));
 
     m_layout = new GG::Layout(GG::X0, GG::Y0,
@@ -666,6 +665,13 @@ void SaveFileDialog::Init() {
 
 SaveFileDialog::~SaveFileDialog()
 {}
+
+GG::Rect SaveFileDialog::CalculatePosition() const {
+    GG::Pt ul((GG::GUI::GetGUI()->AppWidth() - SAVE_FILE_DIALOG_WIDTH) / 2,
+              (GG::GUI::GetGUI()->AppHeight() - SAVE_FILE_DIALOG_HEIGHT) / 2);
+    GG::Pt wh(SAVE_FILE_DIALOG_WIDTH, SAVE_FILE_DIALOG_HEIGHT);
+    return GG::Rect(ul, ul + wh);
+}
 
 void SaveFileDialog::ModalInit() {
     GG::Wnd::ModalInit();

--- a/UI/SaveFileDialog.h
+++ b/UI/SaveFileDialog.h
@@ -42,6 +42,9 @@ public:
     /// Get the chosen save files full path
     std::string Result() const;
 
+protected:
+    virtual GG::Rect CalculatePosition() const;
+
 private:
     void Init();
 

--- a/UI/ServerConnectWnd.cpp
+++ b/UI/ServerConnectWnd.cpp
@@ -38,10 +38,9 @@ namespace {
     bool temp_bool = RegisterOptions(&AddOptions);
 }
 
-ServerConnectWnd::ServerConnectWnd() : 
+ServerConnectWnd::ServerConnectWnd() :
     CUIWnd(UserString("SCONNECT_WINDOW_TITLE"),
-           (GG::GUI::GetGUI()->AppWidth() - WINDOW_WIDTH) / 2, (GG::GUI::GetGUI()->AppHeight() - WINDOW_HEIGHT) / 2,
-           WINDOW_WIDTH, WINDOW_HEIGHT, GG::INTERACTIVE | GG::MODAL),
+           GG::INTERACTIVE | GG::MODAL),
     m_host_or_join_radio_group(0),
     m_LAN_game_label(0),
     m_servers_lb(0),
@@ -98,12 +97,21 @@ ServerConnectWnd::ServerConnectWnd() :
 
     SetLayout(layout);
 
+    ResetDefaultPosition();
+
     m_LAN_servers = HumanClientApp::GetApp()->Networking().DiscoverLANServers();
     Init();
 }
 
 void ServerConnectWnd::ModalInit()
 { GG::GUI::GetGUI()->SetFocusWnd(m_player_name_edit); }
+
+GG::Rect ServerConnectWnd::CalculatePosition() const {
+    GG::Pt new_ul((GG::GUI::GetGUI()->AppWidth() - WINDOW_WIDTH) / 2,
+                  (GG::GUI::GetGUI()->AppHeight() - WINDOW_HEIGHT) / 2);
+    GG::Pt new_sz(WINDOW_WIDTH, WINDOW_HEIGHT);
+    return GG::Rect(new_ul, new_ul + new_sz);
+}
 
 void ServerConnectWnd::KeyPress(GG::Key key, boost::uint32_t key_code_point, GG::Flags<GG::ModKey> mod_keys) {
     if (!m_ok_bn->Disabled() && (key == GG::GGK_RETURN || key == GG::GGK_KP_ENTER)) { // Same behaviour as if "OK" was pressed

--- a/UI/ServerConnectWnd.h
+++ b/UI/ServerConnectWnd.h
@@ -29,6 +29,8 @@ public:
     const std::pair<std::string, std::string>& Result() const;
     //@}
 
+protected:
+    virtual GG::Rect CalculatePosition() const;
 
 private:
     void Init();

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -2593,12 +2593,8 @@ boost::signals2::signal<void (int)>        SidePanel::BuildingRightClickedSignal
 boost::signals2::signal<void (int)>        SidePanel::SystemSelectedSignal;
 
 
-SidePanel::SidePanel(GG::X default_x, GG::Y default_y,
-                     GG::X default_w, GG::Y default_h,
-                     const std::string& config_name) :
+SidePanel::SidePanel(const std::string& config_name) :
     CUIWnd("SidePanel",
-           default_x, default_y,
-           default_w, default_h,
            GG::INTERACTIVE | GG::RESIZABLE | GG::DRAGABLE | GG::ONTOP,
            config_name),
     m_system_name(0),

--- a/UI/SidePanel.h
+++ b/UI/SidePanel.h
@@ -23,9 +23,7 @@ public:
     class PlanetPanel;
 
     /** \name Structors */ //@{
-    SidePanel(GG::X default_x, GG::Y default_y,
-              GG::X default_w, GG::Y default_h,
-              const std::string& config_name);
+    SidePanel(const std::string& config_name);
     ~SidePanel();
     //@}
 

--- a/UI/SitRepPanel.cpp
+++ b/UI/SitRepPanel.cpp
@@ -322,11 +322,8 @@ namespace {
     };
 }
 
-SitRepPanel::SitRepPanel(GG::X default_x, GG::Y default_y,
-                         GG::X default_w, GG::Y default_h,
-                         const std::string& config_name) :
+SitRepPanel::SitRepPanel(const std::string& config_name) :
     CUIWnd(UserString("SITREP_PANEL_TITLE"),
-           default_x, default_y, default_w, default_h,
            GG::ONTOP | GG::INTERACTIVE | GG::DRAGABLE | GG::RESIZABLE | CLOSABLE | PINABLE,
            config_name),
     m_sitreps_lb(0),

--- a/UI/SitRepPanel.h
+++ b/UI/SitRepPanel.h
@@ -12,9 +12,7 @@ class SitRepEntry;
 class SitRepPanel : public CUIWnd {
 public:
     /** \name Structors */ //@{
-    SitRepPanel(GG::X default_x, GG::Y default_y,
-                GG::X default_w, GG::Y default_h,
-                const std::string& config_name = ""); ///< basic ctor
+    SitRepPanel(const std::string& config_name = ""); ///< basic ctor
     //@}
 
     /** \name Accessors */ //@{

--- a/UI/TechTreeWnd.h
+++ b/UI/TechTreeWnd.h
@@ -74,6 +74,8 @@ private:
     void    TechDoubleClickedSlot(const std::string& tech_name,
                                   const GG::Flags<GG::ModKey>& modkeys);
 
+    void    InitializeWindows();
+
     TechTreeControls*           m_tech_tree_controls;
     EncyclopediaDetailPanel*    m_enc_detail_panel;
     LayoutPanel*                m_layout_panel;

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -828,6 +828,16 @@ void HumanClientApp::HandleWindowResize(GG::X w, GG::Y h) {
             intro_screen->Resize(GG::Pt(w, h));
             intro_screen->DoLayout();
         }
+
+        // Ignore fullscreen/windowed transitions and events that don't really
+        // resize the app (e.g. one is sent when the app is opened)
+        // TODO: properly check for fullscreen/windowed transitions
+        if (GetOptionsDB().Get<bool>("UI.auto-reposition-windows") &&
+            (GetOptionsDB().Get<int>("app-width-windowed") != w ||
+             GetOptionsDB().Get<int>("app-height-windowed") != h))
+        {
+            ui->RecalculateWindowDefaults();
+        }
     }
 
     // Notify all modal CUIWnds.

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -840,13 +840,6 @@ void HumanClientApp::HandleWindowResize(GG::X w, GG::Y h) {
         }
     }
 
-    // Notify all modal CUIWnds.
-    for (const_modal_iterator modal_it = modal_begin(); modal_it != modal_end(); ++modal_it) {
-        if (CUIWnd* cui_wnd = dynamic_cast<CUIWnd*>((*modal_it).first)) {
-            cui_wnd->ValidatePosition();
-        }
-    }
-
     // store resize if window is not full-screen (so that fullscreen
     // resolution doesn't overwrite windowed resolution)
     if (!GetOptionsDB().Get<bool>("fullscreen")) {

--- a/client/human/HumanClientApp.h
+++ b/client/human/HumanClientApp.h
@@ -26,6 +26,7 @@ public:
     class CleanQuit : public std::exception {};
 
     typedef boost::signals2::signal<void (bool)> FullscreenSwitchSignalType;
+    typedef boost::signals2::signal<void ()>     RepositionWindowsSignalType;
 
     /** \name Structors */ //@{
     HumanClientApp(int width, int height, bool calculate_FPS, const std::string& name, int x, int y, bool fullscreen, bool fake_mode_change);
@@ -71,7 +72,8 @@ public:
     void                HandleSaveGameDataRequest();
     //@}
 
-    mutable FullscreenSwitchSignalType FullscreenSwitchSignal;
+    mutable FullscreenSwitchSignalType  FullscreenSwitchSignal;
+    mutable RepositionWindowsSignalType RepositionWindowsSignal;
 
     static std::pair<int, int>  GetWindowWidthHeight();
     static std::pair<int, int>  GetWindowLeftTop();

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1957,7 +1957,7 @@ OPTIONS_FLUSH_STRINGTABLE
 Flush Stringtables
 
 OPTIONS_WINDOW_RESET
-Reposition Windows
+Reposition Windows Now
 
 OPTIONS_CHAT
 Chat

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1186,6 +1186,9 @@ If true, clicks on multiple fleet buttons will open multiple fleet windows at th
 OPTIONS_DB_UI_WINDOW_QUICKCLOSE
 Close open windows such as fleet windows and the system-view side panel when you right-click on the main map.
 
+OPTIONS_DB_UI_AUTO_REPOSITION_WINDOWS
+Toggles whether to automatically reposition windows when the application size changes.
+
 OPTIONS_DB_AUTO_ADD_SAVED_DESIGNS
 At game start automatically add all user-saved ship designs to the player-empire known designs.
 
@@ -1836,6 +1839,9 @@ Quick-close windows
 OPTIONS_SHOW_SIDEPANEL_PLANETS
 Show side panel planets
 
+OPTIONS_AUTO_REPOSITION_WINDOWS
+Automatically reposition windows
+
 OPTIONS_MISC_UI
 Miscellaneous UI Settings
 
@@ -1949,6 +1955,9 @@ Apply
 
 OPTIONS_FLUSH_STRINGTABLE
 Flush Stringtables
+
+OPTIONS_WINDOW_RESET
+Reposition Windows
 
 OPTIONS_CHAT
 Chat
@@ -2300,9 +2309,6 @@ Add All Saved Ship Designs at Game Start
 
 OPTIONS_USE_BINARY_SERIALIZATION
 Use Binary serialization
-
-OPTIONS_WINDOW_RESET
-Reset window properties to defaults
 
 ##################
 # CombatSetupWnd #

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1404,7 +1404,7 @@ OPTIONS_DB_UI_WINDOWS_MINIMIZED
 Toggles whether a window is minimized.
 
 OPTIONS_DB_WINDOW_RESET
-When checked, causes windows to use their default properties instead of remembering their previous positions.
+Causes windows to use their default properties instead of remembering their previous positions.
 
 #################
 # File Dialog   #

--- a/util/OptionsDB.cpp
+++ b/util/OptionsDB.cpp
@@ -305,6 +305,23 @@ void OptionsDB::Remove(const std::string& name) {
     OptionRemovedSignal(name);
 }
 
+void OptionsDB::RemoveUnrecognized(const std::string& prefix) {
+    std::map<std::string, Option>::iterator it = m_options.begin();
+    while (it != m_options.end()) {
+        if (!it->second.recognized && it->first.find(prefix) == 0)
+            Remove((it++)->first); // note postfix operator++
+        else
+            ++it;
+    }
+}
+
+void OptionsDB::FindOptions(std::set<std::string>& ret, const std::string& prefix) const {
+    ret.clear();
+    for (std::map<std::string, Option>::const_iterator it = m_options.begin(); it != m_options.end(); ++it)
+        if (it->second.recognized && it->first.find(prefix) == 0)
+            ret.insert(it->first);
+}
+
 void OptionsDB::SetFromCommandLine(const std::vector<std::string>& args) {
     //bool option_changed = false;
 

--- a/util/OptionsDB.h
+++ b/util/OptionsDB.h
@@ -167,6 +167,10 @@ public:
     /** returns the contents of the DB as an XMLDoc. */
     XMLDoc      GetXML() const;
 
+    /** find all registered Options that begin with \a prefix and store them in
+      * \a ret. */
+    void        FindOptions(std::set<std::string>& ret, const std::string& prefix) const;
+
     /** the option changed signal object for the given option */
     OptionChangedSignalType&    OptionChangedSignal(const std::string& option);
 
@@ -270,6 +274,10 @@ public:
 
     /** removes an Option */
     void        Remove(const std::string& name);
+
+    /** removes all unrecognized Options that begin with \a prefix.  A blank
+      * string will remove all unrecognized Options. */
+    void        RemoveUnrecognized(const std::string& prefix = "");
 
     /** sets the value of option \a name to \a value */
     template <class T>


### PR DESCRIPTION
Would have been nice to get this up well before the deadline but, well, it is what it is.  This is to implement the things discussed in PR #214 (towards the end of the comments).  Currently, enabling the "reset window positions" toggle in the options window will reset most windows to their default position as calculated when the app was opened (modal UI windows and the fleet window are only reset if they are opened while the toggle is enabled).

This PR changes the confusing stop-gap "reset window positions" toggle in the options window to always enforce the "default" window positions when enabled i.e. all window resize events ~~and fullscreen/windowed transitions~~ will cause all UI windows to recalculate their positions and those of their children.  There's also a button to do this only once.  I don't really forsee this large patch getting into the release branch, so I could just change the existing toggle to a button as a tiny change to sneak in to that branch.

Most of the changes in this PR involve moving position calculations out of ctors into helper functions, adding a few functions to CUIWnd and adding two functions to OptionsDB.  It also enables automatic repositioning for non-resizable, non-dragable windows such as GalaxySetupWnd, MultiPlayerLobbyWnd and ServerConnectWnd by simply reimplementing a virtual function.

Owners of CUIWnds (ClientUI, MapWnd, DesignWnd, TechTreeWnd and BuildDesignatorWnd) have an InitializeWindows() function that contains all of the position calculations, and is called from their ctors and connected to a signal.  This function calls CUIWnd::InitSizeMove() for the owned windows which will preserve any saved values the first time it is called (from the ctors) but overwrite them afterwards (when called via the signal).  This keeps all of the position calculations in one place.

A couple of static CUIWnd functions ~~remove~~ invalidate window options in the OptionsDB, causing windows to fall back onto their defaults when they are initialized.  A new CUIWnd ctor takes no position or size parameters but still loads them from the OptionsDB if available, and other functions exist to allow CUIWnds to reposition themselves.

OptionsDB functions were added that allow CUIWnd to find certain options ~~and request that they are removed~~.
