### PR TITLE
Forbid dragging SitRep entries.

### DIFF
--- a/UI/SitRepPanel.cpp
+++ b/UI/SitRepPanel.cpp
@@ -300,7 +300,6 @@ namespace {
         {
             SetName("SitRepRow");
             SetChildClippingMode(ClipToClient);
-            SetDragDropDataType("SitRepRow");
             m_panel = new SitRepDataPanel(w, h, sitrep);
             push_back(m_panel);
         }


### PR DESCRIPTION
@Vezzra This is about as far away from a critical bug as it gets, but it's such a small fix I think it could still go in v0.4.5?
