### PR TITLE
amends intro custom sitreps, responsive to Issue #253

### DIFF
--- a/default/customizations/common_user_customizations.txt
+++ b/default/customizations/common_user_customizations.txt
@@ -45,7 +45,7 @@ FUNCTIONAL_SHIP_PART_REDUNDANCY_SKIP_LIST
 ## entries will not work correctly if they contain spaces; use underscores "_" instead.
 
 FUNCTIONAL_SITREP_PRIORITY_ORDER
-'''SITREP_WELCOME
+'''SITREP_WELCOME_LABEL
 CUSTOM_1
 CUSTOM_2
 CUSTOM_3

--- a/default/customizations/custom_sitreps.txt
+++ b/default/customizations/custom_sitreps.txt
@@ -57,6 +57,7 @@ EffectsGroup
 
 EffectsGroup
     scope = And [
+        Planet
         Planet Type = GasGiant
         Ownedby empire = Source.Owner
         Not Contains Building name = "BLD_GAS_GIANT_GEN"
@@ -102,6 +103,7 @@ EffectsGroup
 
 // EffectsGroup
 //     scope = And [
+//         Planet
 //         Planet Type = GasGiant
 //         Ownedby empire = Source.Owner
 //         Not Contains Building name = "BLD_GAS_GIANT_GEN"

--- a/default/customizations/custom_sitreps.txt
+++ b/default/customizations/custom_sitreps.txt
@@ -20,7 +20,7 @@ EffectsGroup
     effects =
         GenerateSitRepMessage
             message = "CUSTOM_SITREP_INTRODUCTION"
-            label = "CUSTOM_1"
+            label = "SITREP_WELCOME_LABEL"
             icon = "icons/tech/categories/spy.png"
             parameters = [
                 tag = "tech" data = "SPY_CUSTOM_ADVISORIES"
@@ -28,10 +28,10 @@ EffectsGroup
             ]
             empire = Source.Owner
 
-// for reference, the following is fully custom format (in english) of the intrduction sitrep above.
+// for reference, the following is fully custom format (in english) of the intrduction sitrep above, except that it has a different label.
 // Note that the message and label are directly provided here rather than being stringtable keys,
 // and the NoStringtableLookup keyword is used afer the label is given.
-// If you are using a stringtable other than English, your translator may have translate the four preset labels for you, 
+// If you are using a stringtable other than English, your translator may have translated the four preset labels for you, 
 // so instead of the "Custom_1" below it might be something else for you.  The actual labels can be seen in the Pedia entry for 
 // the SPY_CUSTOM_ADVISORIES tech (the tech is named "Empire Intelligence Agency" in the English version)
 //
@@ -51,10 +51,6 @@ EffectsGroup
 //            empire = Source.Owner
 
 
-//*********************************************************************************************************************************************************
-// The other example sitreps below are left in English, but can be translated just by changing the strings provided below for the messages and labels below.
-// It is important to note that, unlike the above entry, these entries all use the  NoStringtableLookup keyword after the label.
-//*********************************************************************************************************************************************************
 
 // Reminder if a Gas Giant you own in a system along with another planet you also own, populated by a species with Industry Focus, and you have the Orbital Generation tech
 // but haven't yet built or enqueued a GG Generator in that system yet
@@ -83,9 +79,8 @@ EffectsGroup
     activation = OwnerHasTech name = "PRO_ORBITAL_GEN"
     effects =
         GenerateSitRepMessage
-            message = "%planet% is a prime location for a %buildingtype%, but none is being built there"
-            label = "Custom_2"
-            NoStringtableLookup
+            message = "SITREP_GAS_GIANT_GENERATION_REMINDER"
+            label = "CUSTOM_2"
             icon = "icons/building/gas-giant-generator.png"
             parameters = [
                 tag = "buildingtype" data = "BLD_GAS_GIANT_GEN"
@@ -96,63 +91,106 @@ EffectsGroup
 
 
 
+
+//*********************************************************************************************************************************************************
+// The other example sitreps below are left in English, but can be translated just by changing the strings provided below for the messages and labels below.
+// It is important to note that, unlike the above entry, these entries all use the  NoStringtableLookup keyword after the label.
+//*********************************************************************************************************************************************************
+
+// Reminder if a Gas Giant you own in a system along with another planet you also own, populated by a species with Industry Focus, and you have the Orbital Generation tech
+// but haven't yet built or enqueued a GG Generator in that system yet
+
+// EffectsGroup
+//     scope = And [
+//         Planet Type = GasGiant
+//         Ownedby empire = Source.Owner
+//         Not Contains Building name = "BLD_GAS_GIANT_GEN"
+//         ContainedBy And [
+//             Contains And [
+//                 Planet 
+//                 Location type = Focus name = LocalCandidate.Species name = "FOCUS_INDUSTRY"
+//                 OwnedBy empire = Source.Owner
+//             ]
+//             Not Contains And [
+//                 Planet
+//                 OwnedBy empire = Source.Owner
+//                 Or [
+//                     Contains Building name = "BLD_GAS_GIANT_GEN"
+//                     Enqueued type = Building name = "BLD_GAS_GIANT_GEN"
+//                 ]
+//             ]
+//         ]
+//     ]
+//     activation = OwnerHasTech name = "PRO_ORBITAL_GEN"
+//     effects =
+//         GenerateSitRepMessage
+//             message = "%planet% is a prime location for a %buildingtype%, but none is being built there"
+//             label = "Custom_2"
+//             NoStringtableLookup
+//             icon = "icons/building/gas-giant-generator.png"
+//             parameters = [
+//                 tag = "buildingtype" data = "BLD_GAS_GIANT_GEN"
+//                 tag = "planet" data = Target.ID
+//             ]
+//             empire = Source.Owner
+
+
+
+
 // Reminder if you own a planet with a monster nest but haven't yet researched SHP_DOMESTIC_MONSTER
 // but haven't yet built or enqueued a GG Generator in that system yet
 
-EffectsGroup
-    scope = And [
-        Planet
-        Ownedby empire = Source.Owner
-        Or [
-            HasSpecial name = "KRAKEN_NEST_SPECIAL"
-            HasSpecial name = "SNOWFLAKE_NEST_SPECIAL"
-            HasSpecial name = "JUGGERNAUT_NEST_SPECIAL"
-        ]
-    ]
-    activation = Not OwnerHasTech name = "SHP_DOMESTIC_MONSTER"
-    effects =
-        GenerateSitRepMessage
-            message = "You own %planet%, with a monster nest, but haven't yet researched %tech%"
-            label = "Custom_2"
-            NoStringtableLookup
-            icon = "icons/monsters/kraken-1.png"
-            parameters = [
-                tag = "planet" data = Target.ID
-                tag = "tech" data = "SHP_DOMESTIC_MONSTER"
-            ]
-            empire = Source.Owner
+// EffectsGroup
+//     scope = And [
+//         Planet
+//         Ownedby empire = Source.Owner
+//         Or [
+//             HasSpecial name = "KRAKEN_NEST_SPECIAL"
+//             HasSpecial name = "SNOWFLAKE_NEST_SPECIAL"
+//             HasSpecial name = "JUGGERNAUT_NEST_SPECIAL"
+//         ]
+//     ]
+//     activation = Not OwnerHasTech name = "SHP_DOMESTIC_MONSTER"
+//     effects =
+//         GenerateSitRepMessage
+//             message = "You own %planet%, with a monster nest, but haven't yet researched %tech%"
+//             label = "Custom_2"
+//             NoStringtableLookup
+//             icon = "icons/monsters/kraken-1.png"
+//             parameters = [
+//                 tag = "planet" data = Target.ID
+//                 tag = "tech" data = "SHP_DOMESTIC_MONSTER"
+//             ]
+//             empire = Source.Owner
 
 
 
 // A Call to Arms
 // A prime candidate for being snoozed, but probably good to be periodically reminded about
-EffectsGroup
-    scope = And [
-        Planet
-        Species
-        UnOwned
-        MaxDefense high = 0
-        ContainedBy And [
-            System
-            Not Contains Monster
-        ]
-        Or [ 
-            VisibleToEmpire empire = Source.Owner
-            ExploredByEmpire empire = Source.Owner
-        ]
-    ]
-    activation = Source
-    effects =
-        GenerateSitRepMessage
-            message = "There are defenseless natives at %planet%!  Go invade them with <encyclopedia TROOP_TITLE>Troops</encyclopedia>!"
-            label = "Custom_4"
-            NoStringtableLookup
-            icon = "icons/meter/troops.png"
-            parameters = [
-                tag = "planet" data = Target.ID
-            ]
-            empire = Source.Owner
-
+// EffectsGroup
+//     scope = And [
+//         Planet
+//         Species
+//         UnOwned
+//         MaxDefense high = 0
+//         ContainedBy And [
+//             System
+//             Not Contains Monster
+//         ]
+//         VisibleToEmpire empire = Source.Owner
+//     ]
+//     activation = Source
+//     effects =
+//         GenerateSitRepMessage
+//             message = "There are defenseless natives at %planet%!  Go invade them with <encyclopedia TROOP_TITLE>Troops</encyclopedia>!"
+//             label = "Custom_4"
+//             NoStringtableLookup
+//             icon = "icons/meter/troops.png"
+//             parameters = [
+//                 tag = "planet" data = Target.ID
+//             ]
+//             empire = Source.Owner
+// 
 
 
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -4384,6 +4384,9 @@ SITREP_WELCOME
 SITREP_WELCOME_LABEL
 Welcome
 
+SITREP_GAS_GIANT_GENERATION_REMINDER
+'''%planet% is a prime location for a %buildingtype%, but none is being built there'''
+
 SITREP_SHIP_BUILT
 At %system%: a new %shipdesign%, the '%ship%', has been produced.
 SITREP_SHIP_BUILT_LABEL
@@ -4783,7 +4786,7 @@ HEAD_ON_A_SPIKE_MESSAGE_LABEL
 Empire Capital Captured
 
 CUSTOM_SITREP_INTRODUCTION
-This is a sample Custom Sitrep, which is enabled by %tech% and all the busy empire servants reporting information back to %system%
+Welcome to the intial Situation Report Briefing.  Pursuant to the %tech% Directive, all the busy empire servants endeavor to collect important information and send it back to %system%, where it is compiled into Situation Reports, such as this, providing notice of important events and other reminders selected by the empire leadership.
 
 # Translators: Important Note-- use underscores "_" not spaces in the translations for
 # CUSTOM_1 through CUSTOM_4 -- any spaces will prevent them from working properly
@@ -8342,7 +8345,8 @@ SPY_CUSTOM_ADVISORIES_DESC
 '''The Empire Intelligence Agency gathers and organizes information from many sources, including spies, common informers, and official chains of command reporting.  The most important items of information are presented each turn as Situation Reports (SitReps).  If a SitRep is repeated from turn to turn more often than you really need for remembering the information, you can dismiss the SitRep for the current turn by double-clicking its icon, or for multiple turns via right-click menu on the SitRep's icon.
 
 Many of the SitReps are determined automatically, but additional custom SitReps can be specified by editing the file default/customizations/custom_sitreps.txt
-More particulars on the FreeOrion scripting, such as for these custom SitReps, can be found at our wiki:  http://www.freeorion.org/index.php/Free_Orion_Content_Script_(FOCS)
+(Note: in a multiplayer game, the content files of the Server are the ones which determine what SitReps are sent to empires.)
+More particulars on the FreeOrion scripting language, such as for these custom SitReps, can be found at our wiki:  http://www.freeorion.org/index.php/Free_Orion_Content_Script_(FOCS)
 There are four preset (possibly translated) labels for use with custom sitreps, so that they get placement at the top of the SitRep window.  More information on how to use the labels can be found on the wiki, and in the custom_sitreps.txt. 
 These four labels are
 "[[CUSTOM_1]]"

--- a/default/techs.txt
+++ b/default/techs.txt
@@ -1939,6 +1939,7 @@ Tech
             effects = [
                 GenerateSitRepMessage
                     message = "SITREP_WELCOME"
+                    label = "SITREP_WELCOME_LABEL"  // explicitly provided so that the custom SitRep intro message can share the same SitRepPanel filter
                     icon = "icons/sitrep/fo_logo.png"
                     empire = Source.Owner
                 ]


### PR DESCRIPTION
- Rewords intro custom sitrep message to not be immersion-breaking
- causes the intro custom sitrep message to share the same filer as the 'Welcome' message
- makes one more sample sitrep be translated, and comments out the others so that English language SitReps need not be presented to users who have selected some other stringtable language
- notes in the tech description that in a multiplayer game SitReps are governed by server content files.
