### PR TITLE
Segregated game-start Welcome SitRep messages from the plethora...

### DIFF
--- a/default/customizations/custom_sitreps.txt
+++ b/default/customizations/custom_sitreps.txt
@@ -16,7 +16,7 @@ effectsgroups = [
 
 EffectsGroup
     scope = Source
-    activation = Turn high = 1
+    activation = Turn low = 0 high = 0
     effects =
         GenerateSitRepMessage
             message = "CUSTOM_SITREP_INTRODUCTION"
@@ -37,7 +37,7 @@ EffectsGroup
 //
 //EffectsGroup
 //    scope = Capital
-//    activation = Turn high = 1
+//    activation = Turn low = 0 high = 0
 //    effects =
 //        GenerateSitRepMessage
 //            message = "This is a sample Custom Sitrep, which is enabled by %tech% and all the busy empire servants reporting information back to %system%"

--- a/default/techs.txt
+++ b/default/techs.txt
@@ -1935,7 +1935,7 @@ Tech
 
         EffectsGroup
             scope = Source
-            activation = Turn high = 1
+            activation = Turn low = 0 high = 0
             effects = [
                 GenerateSitRepMessage
                     message = "SITREP_WELCOME"

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -674,7 +674,13 @@ void ServerApp::NewGameInit(const GalaxySetupData& galaxy_setup_data,
     // m_current_turn set above so that every UniverseObject created before game
     // starts will have m_created_on_turn BEFORE_FIRST_TURN
     GenerateUniverse(active_players_id_setup_data);
-    // after all game initialization stuff has been created, can set current turn to 1 for start of game
+
+    // after all game initialization stuff has been created, set current turn to 0 and apply only GenerateSitRep Effects
+    // so that a set of SitReps intended as the player's initial greeting will be segregated
+    m_current_turn = 0;
+    m_universe.ApplyGenerateSitRepEffects();
+
+    //can set current turn to 1 for start of game
     m_current_turn = 1;
 
 

--- a/universe/Effect.cpp
+++ b/universe/Effect.cpp
@@ -265,7 +265,8 @@ void EffectsGroup::Execute(const Effect::TargetsCauses& targets_causes,
                            AccountingMap* accounting_map/* = 0*/,
                            bool only_meter_effects/* = false*/,
                            bool only_appearance_effects/* = false*/,
-                           bool include_empire_meter_effects/* = false*/) const
+                           bool include_empire_meter_effects/* = false*/,
+                           bool only_generate_sitrep_effects/* = false*/) const
 {
     // execute each effect of the group one by one, unless filtered by flags
     for (std::vector<EffectBase*>::const_iterator effect_it = m_effects.begin();
@@ -276,7 +277,8 @@ void EffectsGroup::Execute(const Effect::TargetsCauses& targets_causes,
                               accounting_map,
                               only_meter_effects,
                               only_appearance_effects,
-                              include_empire_meter_effects);
+                              include_empire_meter_effects,
+                              only_generate_sitrep_effects);
     }
 }
 
@@ -370,7 +372,8 @@ void EffectBase::Execute(const Effect::TargetsCauses& targets_causes,
                          AccountingMap* accounting_map/* = 0*/,
                          bool only_meter_effects/* = false*/,
                          bool only_appearance_effects/* = false*/,
-                         bool include_empire_meter_effects/* = false*/) const
+                         bool include_empire_meter_effects/* = false*/,
+                         bool only_generate_sitrep_effects/* = false*/) const
 {
     bool log_verbose = GetOptionsDB().Get<bool>("verbose-logging");
 
@@ -400,6 +403,9 @@ void EffectBase::Execute(const Effect::TargetsCauses& targets_causes,
             if (!dynamic_cast<const SetEmpireMeter*>(this))
                 return;
         }
+    } else if (only_generate_sitrep_effects) {
+        if (!dynamic_cast<const GenerateSitRepMessage*>(this) && !dynamic_cast<const GenerateSitRepMessage*>(this))
+            return;
     }
 
     // apply this effect to each source causing it

--- a/universe/Effect.h
+++ b/universe/Effect.h
@@ -101,7 +101,8 @@ public:
                     AccountingMap* accounting_map = 0,
                     bool only_meter_effects = false,
                     bool only_appearance_effects = false,
-                    bool include_empire_meter_effects = false) const;
+                    bool include_empire_meter_effects = false,
+                    bool only_generate_sitrep_effects = false) const;
 
     const std::string&              StackingGroup() const       { return m_stacking_group; }
     Condition::ConditionBase* Scope() const               { return m_scope; }
@@ -149,7 +150,8 @@ public:
                                 AccountingMap* accounting_map = 0,
                                 bool only_meter_effects = false,
                                 bool only_appearance_effects = false,
-                                bool include_empire_meter_effects = false) const;
+                                bool include_empire_meter_effects = false,
+                                bool only_generate_sitrep_effects = false) const;
     virtual std::string Description() const = 0;
     virtual std::string Dump() const = 0;
 

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -1291,6 +1291,17 @@ void Universe::ApplyAppearanceEffects() {
     ExecuteEffects(targets_causes, false, false, true);
 }
 
+void Universe::ApplyGenerateSitRepEffects() {
+    ScopedTimer timer("Universe::ApplyGenerateSitRepEffects on all objects");
+
+    // cache all activation and scoping condition results before applying
+    // Effects, since the application of these Effects may affect the
+    // activation and scoping evaluations
+    Effect::TargetsCauses targets_causes;
+    GetEffectsAndTargets(targets_causes);
+    ExecuteEffects(targets_causes, false, false, false, true);
+}
+
 void Universe::InitMeterEstimatesAndDiscrepancies() {
     DebugLogger() << "Universe::InitMeterEstimatesAndDiscrepancies";
     ScopedTimer timer("Universe::InitMeterEstimatesAndDiscrepancies");
@@ -2229,7 +2240,8 @@ void Universe::ExecuteEffects(const Effect::TargetsCauses& targets_causes,
                               bool update_effect_accounting,
                               bool only_meter_effects/* = false*/,
                               bool only_appearance_effects/* = false*/,
-                              bool include_empire_meter_effects/* = false*/)
+                              bool include_empire_meter_effects/* = false*/,
+                              bool only_generate_sitrep_effects/* = false*/)
 {
     ScopedTimer timer("Universe::ExecuteEffects", true);
 
@@ -2328,7 +2340,8 @@ void Universe::ExecuteEffects(const Effect::TargetsCauses& targets_causes,
                 update_effect_accounting ? &m_effect_accounting_map : NULL,
                 only_meter_effects,
                 only_appearance_effects,
-                include_empire_meter_effects);
+                include_empire_meter_effects,
+                only_generate_sitrep_effects);
         }
     }
 

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -1299,7 +1299,7 @@ void Universe::ApplyGenerateSitRepEffects() {
     // activation and scoping evaluations
     Effect::TargetsCauses targets_causes;
     GetEffectsAndTargets(targets_causes);
-    ExecuteEffects(targets_causes, false, false, false, true);
+    ExecuteEffects(targets_causes, false, false, false, false, true);
 }
 
 void Universe::InitMeterEstimatesAndDiscrepancies() {

--- a/universe/Universe.h
+++ b/universe/Universe.h
@@ -284,6 +284,9 @@ public:
     /** Executes effects that modify objects' apperance for all objects. */
     void            ApplyAppearanceEffects();
 
+    /** Executes effects that modify objects' apperance for all objects. */
+    void            ApplyGenerateSitRepEffects();
+
     /** For all objects and meters, determines discrepancies between actual meter
       * maxes and what the known universe should produce, and and stores in
       * m_effect_discrepancy_map. */
@@ -508,7 +511,8 @@ private:
                            bool update_effect_accounting,
                            bool only_meter_effects = false,
                            bool only_appearance_effects = false,
-                           bool include_empire_meter_effects = false);
+                           bool include_empire_meter_effects = false,
+                           bool only_generate_sitrep_effects = false);
 
     /** Does actual updating of meter estimates after the public function have
       * processed objects_vec or whatever they were passed and cleared the


### PR DESCRIPTION
…of initialization / unlocking SitReps; responsive to Issue #254, if this is agreed upon for master I'll ask for it to be cherrypicked for 0.4.5
- added Universe::ApplyGenerateSitRepEffects() akin to ApplyAppearanceEffects,
- added corresponding supprt in EffectsGroups and Effects relevant Execute methods for an additional only_generate_sitrep_effects parameter, defaulting to false like the other only_X_effects parameters, and working in the same way
- Added a Server step after initialization of setting the turn to 0 and calling ApplyGenerateSitRepEffects()
- adjusted the two current Welcome SitReps to fire only on turn 1.
- conveniently, the SitRepPanel is already set to initialize to turn 1, skipping over the slew of unlocking-X SitReps when any SitReps are present for turn 1
