### PR TITLE
Fix #244: Object window right click selects clearly.

### DIFF
--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -2358,7 +2358,7 @@ void ObjectListWnd::ObjectRightClicked(GG::ListBox::iterator it, const GG::Pt& p
         moderator = true;
 
     // Right click on an unselected row should automatically select it
-    m_list_box->SelectRow(it);
+    m_list_box->SelectRow(it, true);
 
     // create popup menu with object commands in it
     GG::MenuItem menu_contents;


### PR DESCRIPTION
Before, the object was selected, but the signal
was not given, which made it appear unselected for
the lifetime of the popup menu.

Edit: Seems links don't work in titles. Fixes: #244 
