### PR TITLE
Statistics on expressions

### DIFF
--- a/default/empire_statistics.txt
+++ b/default/empire_statistics.txt
@@ -1,3 +1,11 @@
+
+Statistic name = "MILITARY_STRENGTH_STAT" value =
+    Sum value = (LocalCandidate.Attack * (LocalCandidate.Structure + 2 * LocalCandidate.MaxShield))
+        condition = And [
+            Ship
+            OwnedBy empire = Source.Owner
+        ]
+
 Statistic name = "PP_OUTPUT" value =
     Sum value = LocalCandidate.Industry condition = And [
         Planet

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -3156,6 +3156,9 @@ This design is a duplicate of "%1%".
 ################
 SHIP_COUNT
 Ship Count
+
+MILITARY_STRENGTH_STAT
+Rough Estimate of Total Military Strength
     
 PP_OUTPUT
 Production Output

--- a/parse/DoubleValueRefParser.cpp
+++ b/parse/DoubleValueRefParser.cpp
@@ -47,6 +47,7 @@ namespace {
                 |   tok.NextTurnPopGrowth_
                 |   tok.Size_
                 |   tok.DistanceFromOriginalType_
+                |   tok.Attack_
                 ;
 
             free_variable_name

--- a/parse/DoubleValueRefParser.cpp
+++ b/parse/DoubleValueRefParser.cpp
@@ -71,17 +71,8 @@ namespace {
 
             initialize_bound_variable_parser<double>(bound_variable, bound_variable_name);
 
-            statistic_sub_value_ref
-                =   constant
-                |   free_variable
-                |   bound_variable
-                |   int_bound_variable_cast
-                |   double_var_complex()
-                |   int_complex_variable_cast
-            ;
-
             initialize_numeric_statistic_parser<double>(statistic, statistic_1, statistic_2,
-                                                        statistic_sub_value_ref);
+                                                        primary_expr);
 
             initialize_numeric_expression_parsers<double>(function_expr,
                                                           exponential_expr,
@@ -162,7 +153,6 @@ namespace {
         statistic_rule      statistic_1;
         statistic_rule      statistic_2;
         statistic_rule      statistic;
-        rule                statistic_sub_value_ref;
         rule                int_bound_variable_cast;
         rule                int_statistic_cast;
         rule                int_complex_variable_cast;

--- a/parse/Tokens.h
+++ b/parse/Tokens.h
@@ -27,6 +27,7 @@
     (Article)                                   \
     (Application)                               \
     (Asteroids)                                 \
+    (Attack)                                    \
     (Barren)                                    \
     (BlackHole)                                 \
     (Blue)                                      \

--- a/universe/ValueRef.cpp
+++ b/universe/ValueRef.cpp
@@ -611,6 +611,11 @@ namespace ValueRef {
         } else if (property_name == "CurrentTurn") {
             return CurrentTurn();
 
+        } else if (property_name == "Attack") {
+            if (TemporaryPtr<const Fleet> fleet = boost::dynamic_pointer_cast<const Fleet>(object))
+                return fleet->Damage();
+            if (TemporaryPtr<const Ship> ship = boost::dynamic_pointer_cast<const Ship>(object))
+                return ship->TotalWeaponsDamage();
         }
 
         ErrorLogger() << "Variable<double>::Eval unrecognized object property: " << TraceReference(m_property_name, m_ref_type, context);


### PR DESCRIPTION
The three commits are related, in that each depends on the preceding, but each is useful even if we didn't proceed to the next.  The first is quite simple and is really part of a PR just to make sure that it doesn't cause trouble on Windows or MacOSX (probably best to also check other Linux setups as well), since there had been some trouble related to it in the past (entirely or mostly on Linux though, so I expect it is most likely fine for Windows and MacOSX).

An example of what this title refers to is in the third commit (bear in mind, the example is a very rough estimate, the translated title is 'Rough Estimate of Total Military Strength': 

```
Statistic name = "MILITARY_STRENGTH_STAT" value =
    Sum value = (LocalCandidate.Attack * (LocalCandidate.Structure + 2 * LocalCandidate.MaxShield))
        condition = And [
            Ship
            OwnedBy empire = Source.Owner
        ]
```

And of course in this particular case this is the kind of info we will probably want to eventually have gated by espionage techs, but it's still important to be able to support calculations along these lines-- when we get around to working on AI alliances, for example, we will probably want to make some kind of similar 'Dominance' stat/calculation available.

I think that back when Geoff and I were working a lot on the parsers, we must have tried this at an earlier stage where it made problems (at least for me on Linux, initialization races with these parsers was a lingering problem).   But then it seems we made other changes that now allow it.  I had actually started on a more complex implementation, when I decided I should double check this very simple adjustment in the first commit, and to my surprise, Voilà!
