### PR TITLE
quick fix for a MacOSX compile problem Vezzra reported

### DIFF
--- a/UI/GalaxySetupWnd.cpp
+++ b/UI/GalaxySetupWnd.cpp
@@ -273,10 +273,6 @@ GalaxySetupPanel::GalaxySetupPanel(GG::X w, GG::Y h) :
     SettingsChangedSignal();
 }
 
-GalaxySetupPanel::GalaxySetupPanel() :
-    GalaxySetupPanel::GalaxySetupPanel(GalaxySetupPanel::DEFAULT_WIDTH, GAL_SETUP_PANEL_HT) {}
-
-
 namespace {
     // set of characters from which to generate random seed that excludes some ambiguous letter/number pairs
     static char alphanum[] = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";

--- a/UI/GalaxySetupWnd.h
+++ b/UI/GalaxySetupWnd.h
@@ -18,8 +18,7 @@ public:
     static const GG::X DEFAULT_WIDTH;
 
     /** \name Structors*/ //!@{
-    GalaxySetupPanel(GG::X w, GG::Y h);
-    GalaxySetupPanel();
+    GalaxySetupPanel(GG::X w = GG::X(305), GG::Y h = GG::Y(330));
     //!@}
 
     /** \name Accessors*/ //!@{


### PR DESCRIPTION
here: https://github.com/freeorion/freeorion/commit/9353cd1e37e68fcb87ef9cde1497215c57561772#commitcomment-12488221

@Vezzra I don't like simply repeating the constants, leaves them subject to getting out of sync if/when later changes are made, but I am super pressed for time right now and at least this should let you compile.
