### PR TITLE
Add more way to specify path for debug handlers.

### DIFF
--- a/default/AI/freeorion_debug/handlers/README.md
+++ b/default/AI/freeorion_debug/handlers/README.md
@@ -5,7 +5,7 @@
   - Create python file
   - Add call of `register_pre_handler` or `register_post_handler` on file import
   - Add handler to config file (section: `main`, key: `handler` space separated paths to python files)
-    path can be relative form AI folder or absolute. Backslashes should be escaped.
+    path can be absolute, single_name(in same folder as config file) or relative form AI folder. Backslashes should be escaped.
   - run game with param `--ai-config <path to config file>`
 
   If game freezes on stat check log for error.

--- a/default/AI/freeorion_debug/handlers/__init__.py
+++ b/default/AI/freeorion_debug/handlers/__init__.py
@@ -11,11 +11,17 @@ handlers = split(get_option_dict()[HANDLERS])
 
 for handler in handlers:
     module = os.path.basename(handler)[:-3]
+
+    # There is 3 way to specify path:
+    # - absolute path to module
+    # - single name, then module should be in same directory as config
+    # - relative path, then use AI folder as base path.
     if os.path.exists(handler):
         module_path = os.path.dirname(handler)
+    elif not os.path.dirname(handler):
+        module_path = os.path.dirname(fo.getAIConfigStr())
     else:
         module_path = os.path.join(fo.getAIDir(), os.path.dirname(handler))
-
     sys.path.insert(0, module_path)
     try:
         __import__(module)

--- a/default/AI/freeorion_debug/option_tools.py
+++ b/default/AI/freeorion_debug/option_tools.py
@@ -81,28 +81,10 @@ def _parse_options():
             sectioned_options[section][k] = v
 
 
-def _get_AI_folder_path():
-    # hack to allow lunch this code separately to dump default config
-    try:
-        return fo.getAIDir()
-    except AttributeError as e:
-        print "Cant get options file", e
-        return None
-
-
-def _get_option_file_name():
-    # hack to allow lunch this code separately to dump default config
-    try:
-        return fo.getAIConfigStr()
-    except AttributeError as e:
-        print "Cant get options file", e
-        return None
-
-
 def _get_option_file_path():
     # hack to allow lunch this code separately to dump default config
-    ai_path = _get_AI_folder_path()
-    option_file = _get_option_file_name()
+    ai_path = fo.getAIDir()
+    option_file = fo.getAIConfigStr()
     if ai_path and option_file:
         return os.path.join(ai_path, option_file)
     else:
@@ -111,7 +93,7 @@ def _get_option_file_path():
 
 def _get_default_file_path():
     # TODO: determine more robust treatment in case ResourceDir is not writable by user
-    return os.path.join(_get_AI_folder_path() or ".", DEFAULT_CONFIG_FILE)
+    return os.path.join(fo.getAIDir() or ".", DEFAULT_CONFIG_FILE)
 
 
 def _get_preset_default_ai_options():


### PR DESCRIPTION
I plan to store handlers code in `freeorion-utilities` repo. This update will help to use config files directly from repo without changes.   See example for dumpers in my branch https://github.com/Cjkjvfnby/freeorion-utilities/tree/dump_reader/dump_writer

This changes should be in master too. Should I cherry pick them and made other PR?
