### PR TITLE
removed the left-click dependence from the ProductionQueue quantity ...

### DIFF
--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -172,6 +172,8 @@ namespace {
                     quantity = quant;
                 }
             }
+            if ( (quantity != prevQuant) || (blocksize != prevBlocksize) )
+                QuantChangedSignal(quantity, blocksize);
         }
 
     private:
@@ -183,25 +185,6 @@ namespace {
         bool    amBlockType;
         bool    amOn;
         GG::Y   h;
-
-        void LosingFocus() {
-            amOn = false;
-            DropDownList::LosingFocus();
-        }
-
-        void LButtonDown(const GG::Pt&  pt, GG::Flags<GG::ModKey> mod_keys) {
-            amOn = !amOn;
-            DropDownList::LButtonDown(pt, mod_keys);
-        }
-
-        void LClick(const GG::Pt& pt, GG::Flags<GG::ModKey> mod_keys) {
-            if (this->Disabled())
-                return;
-
-            DropDownList::LClick(pt, mod_keys);
-            if ( (quantity != prevQuant) || (blocksize != prevBlocksize) )
-                QuantChangedSignal(quantity, blocksize);
-        }
     };
 
     //////////////////////////////////////////////////


### PR DESCRIPTION
...and block size dropdowns, so they are compatible with adjustment via mousewheel.

This seems to work fine for me, but apparently some similar type change had caused crashes on Windows (reported here http://www.freeorion.org/forum/viewtopic.php?p=80095#p80095) so I'm putting this in as a PR for testing.

I'll also note that it looks to me like some additional cleanup is probably possible, eliminating a number of the custom attributes (I'm thinking amOn, prevQuant and prevBlocksize), but I'm leaving that for later.
