### PR TITLE
Disabled save button tooltip

### DIFF
--- a/UI/InGameMenu.cpp
+++ b/UI/InGameMenu.cpp
@@ -4,6 +4,7 @@
 #include "CUIControls.h"
 #include "OptionsWnd.h"
 #include "SaveFileDialog.h"
+#include "TextBrowseWnd.h"
 #include "../client/human/HumanClientApp.h"
 #include "../network/Networking.h"
 #include "../util/i18n.h"
@@ -53,6 +54,9 @@ InGameMenu::InGameMenu():
 
     if (!HumanClientApp::GetApp()->CanSaveNow()) {
         m_save_btn->Disable();
+        m_save_btn->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
+        m_save_btn->SetBrowseInfoWnd(boost::shared_ptr<GG::BrowseInfoWnd>(
+            new TextBrowseWnd(UserString("BUTTON_DISABLED"), UserString("SAVE_DISABLED_BROWSE_TEXT"), GG::X(400))));
     }
 
     ResetDefaultPosition();

--- a/UI/TextBrowseWnd.cpp
+++ b/UI/TextBrowseWnd.cpp
@@ -10,12 +10,11 @@ namespace {
 
     const int       EDGE_PAD(3);
 
-    const GG::X     BROWSE_TEXT_WIDTH(200);
     const GG::Y     ICON_BROWSE_ICON_HEIGHT(64);
 }
 
-TextBrowseWnd::TextBrowseWnd(const std::string& title_text, const std::string& main_text) :
-    GG::BrowseInfoWnd(GG::X0, GG::Y0, BROWSE_TEXT_WIDTH, GG::Y1)
+TextBrowseWnd::TextBrowseWnd(const std::string& title_text, const std::string& main_text, GG::X w /* = GG::X(200) */) :
+    GG::BrowseInfoWnd(GG::X0, GG::Y0, w, GG::Y1)
 {
     const GG::Y ROW_HEIGHT(IconTextBrowseWndRowHeight());
 
@@ -23,19 +22,19 @@ TextBrowseWnd::TextBrowseWnd(const std::string& title_text, const std::string& m
 
     m_title_text = new CUILabel(title_text, GG::FORMAT_LEFT);
     m_title_text->MoveTo(GG::Pt(GG::X(EDGE_PAD) + m_offset.x, GG::Y0 + m_offset.y));
-    m_title_text->Resize(GG::Pt(BROWSE_TEXT_WIDTH, ROW_HEIGHT));
+    m_title_text->Resize(GG::Pt(w, ROW_HEIGHT));
     m_title_text->SetFont(ClientUI::GetBoldFont());
 
     m_main_text = new CUILabel(main_text, GG::FORMAT_LEFT | GG::FORMAT_TOP | GG::FORMAT_WORDBREAK);
     m_main_text->MoveTo(GG::Pt(GG::X(EDGE_PAD) + m_offset.x, ROW_HEIGHT + m_offset.y));
-    m_main_text->Resize(GG::Pt(BROWSE_TEXT_WIDTH, ICON_BROWSE_ICON_HEIGHT));
+    m_main_text->Resize(GG::Pt(w, ICON_BROWSE_ICON_HEIGHT));
     m_main_text->SetMinSize(true);
     m_main_text->Resize(m_main_text->MinSize());
 
     AttachChild(m_main_text);
     AttachChild(m_title_text);
 
-    Resize(GG::Pt(BROWSE_TEXT_WIDTH, ROW_HEIGHT + m_main_text->Height()));
+    Resize(GG::Pt(w, ROW_HEIGHT + m_main_text->Height()));
 }
 
 bool TextBrowseWnd::WndHasBrowseInfo(const Wnd* wnd, std::size_t mode) const {

--- a/UI/TextBrowseWnd.h
+++ b/UI/TextBrowseWnd.h
@@ -6,10 +6,11 @@
 #include <GG/BrowseInfoWnd.h>
 
 
+
 /** A popup tooltop for display when mousing over in-game icons.  A title and some detail text.*/
 class TextBrowseWnd : public GG::BrowseInfoWnd {
 public:
-    TextBrowseWnd(const std::string& title_text, const std::string& main_text);
+    TextBrowseWnd(const std::string& title_text, const std::string& main_text, GG::X w = GG::X(200));
     virtual bool WndHasBrowseInfo(const Wnd* wnd, std::size_t mode) const;
     virtual void Render();
 

--- a/default/AI/FreeOrionAI.py
+++ b/default/AI/FreeOrionAI.py
@@ -3,6 +3,7 @@ these methods in turn activate other portions of the python AI code."""
 import pickle  # Python object serialization library
 import sys
 import random
+from time import sleep
 
 # IMPORTANT! this import also execute python code to update freeOrionAIInterface interface,
 # removing this import will brake AI in unexpected way.
@@ -174,6 +175,7 @@ def generateOrders():  # pylint: disable=invalid-name
     at end of this function, fo.doneTurn() should be called to indicate to the client that orders are finished
     and can be sent to the server for processing."""
     turn = fo.currentTurn()
+    sleep(10)
     turn_uid = foAIstate.set_turn_uid()
     print "Start turn %s (%s) of game: %s" % (turn, turn_uid, foAIstate.uid)
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1735,6 +1735,12 @@ Resign
 GAME_MENU_SAVE_FILES
 Save Game Files
 
+BUTTON_DISABLED
+Button Disabled
+
+SAVE_DISABLED_BROWSE_TEXT
+The Save Game button is disabled, either because this is a multiplayer game in which you are neither Host nor Moderator, or because at the time this menu was opened at least one of the AIs had not yet finished submitting its moves for the turn (indicated by a green triangle status icon just to the left of its player-type icon in the Empires window).
+
 ###########################
 # Save Game Dialog        #
 ###########################


### PR DESCRIPTION
I'm in particular looking for feedback on the following:
- the tooltip text is admittedly long, but it seemed necessary to really be clear
- the standard width for tooltips was too narrow; the width used here seemed reasonable

Note:
- the second commit is just to facilitate in-game review of the first; I do not intend to commit the second to the master branch.
