### PR TITLE
Attempted fix for issue #294

### DIFF
--- a/default/python/universe_generation/universe_generator.py
+++ b/default/python/universe_generation/universe_generator.py
@@ -10,7 +10,7 @@ from fields import generate_fields
 from natives import generate_natives
 from monsters import generate_monsters
 from specials import distribute_specials
-from util import seed_rng, report_error, error_list
+from util import int_hash, seed_rng, report_error, error_list
 import statistics
 
 
@@ -32,8 +32,11 @@ def create_universe(psd_map):
     total_players = len(psd_map)
 
     # initialize RNG
-    seed_rng(gsd.seed)
+    h = int_hash(gsd.seed)
+    print "Using hashed seed", h
+    seed_rng(h)
     seed_pool = [random.random() for _ in range(100)]
+    print "Seed pool:", seed_pool
 
     # make sure there are enough systems for the given number of players
     print "Universe creation requested with %d systems for %d players" % (gsd.size, total_players)

--- a/default/python/universe_generation/util.py
+++ b/default/python/universe_generation/util.py
@@ -1,9 +1,16 @@
 import sys
 import math
 import random
+from hashlib import md5
 
 
 error_list = []
+
+
+def int_hash(s):
+    h = md5()
+    h.update(s)
+    return int(h.hexdigest(), 16)
 
 
 def seed_rng(seed):


### PR DESCRIPTION
Apparently calling Pythons random.seed() function with a string as seed does not reliably produce the same sequence of pseudo random values independent of Python version and platforms. To circumvent that, use the MD5 hash of the passed in seed value instead.

Please test if that solves issue #294. Look at the server log, it should contain the actually used seed value and a seed pool with 100 values, should be easy to compare.
