### PR TITLE
Universe generation: migrated generation of spiral galaxy shapes to P…

### DIFF
--- a/python/server/PythonServerWrapper.cpp
+++ b/python/server/PythonServerWrapper.cpp
@@ -1277,7 +1277,6 @@ void WrapServerAPI() {
     def("specials_frequency",                   SpecialsFrequency);
     def("calc_typical_universe_width",          CalcTypicalUniverseWidth);
 
-    def("spiral_galaxy_calc_positions",         SpiralGalaxyCalcPositions);
     def("elliptical_galaxy_calc_positions",     EllipticalGalaxyCalcPositions);
     def("cluster_galaxy_calc_positions",        ClusterGalaxyCalcPositions);
     def("ring_galaxy_calc_positions",           RingGalaxyCalcPositions);

--- a/universe/UniverseGenerator.cpp
+++ b/universe/UniverseGenerator.cpp
@@ -50,66 +50,6 @@ namespace {
 double CalcTypicalUniverseWidth(int size)
 { return (1000.0 / std::sqrt(150.0)) * std::sqrt(static_cast<double>(size)); }
 
-void SpiralGalaxyCalcPositions(std::vector<SystemPosition>& positions,
-                               unsigned int arms, unsigned int stars, double width, double height)
-{
-    double arm_offset     = RandDouble(0.0,2.0*PI);
-    double arm_angle      = 2.0*PI / arms;
-    double arm_spread     = 0.3 * PI / arms;
-    double arm_length     = 1.5 * PI;
-    double center         = 0.25;
-    double x,y;
-
-    int i, attempts;
-
-    GaussianDistType  random_gaussian = GaussianDist(0.0, arm_spread);
-    SmallIntDistType  random_arm      = SmallIntDist(0  , arms);
-    DoubleDistType    random_angle    = DoubleDist  (0.0, 2.0*PI);
-    DoubleDistType    random_radius   = DoubleDist  (0.0, 1.0);
-
-    for (i = 0, attempts = 0; i < static_cast<int>(stars) && attempts < MAX_ATTEMPTS_PLACE_SYSTEM; ++i, ++attempts) {
-        double radius = random_radius();
-
-        if (radius < center) {
-            double angle = random_angle();
-            x = radius * cos( arm_offset + angle );
-            y = radius * sin( arm_offset + angle );
-        } else {
-            double arm    = static_cast<double>(random_arm()) * arm_angle;
-            double angle  = random_gaussian();
-
-            x = radius * cos( arm_offset + arm + angle + radius * arm_length );
-            y = radius * sin( arm_offset + arm + angle + radius * arm_length );
-        }
-
-        x = (x + 1) * width / 2.0;
-        y = (y + 1) * height / 2.0;
-
-        if (x < 0 || width <= x || y < 0 || height <= y)
-            continue;
-
-        // See if new star is too close to any existing star.
-        double lowest_dist = CalcNewPosNearestNeighbour(x, y, positions);
-
-        // If so, we try again or give up.
-        if (lowest_dist < MIN_SYSTEM_SEPARATION * MIN_SYSTEM_SEPARATION) {
-            if (attempts < MAX_ATTEMPTS_PLACE_SYSTEM - 1) {
-                --i; //try again for same star
-            } else {
-                attempts=0; //give up on this star, move on to next
-                DebugLogger() << "Giving up on placing star "<< i <<" with lowest dist squared " << lowest_dist;
-            }
-            continue;
-        }
-
-        // Add the new star location.
-        positions.push_back(SystemPosition(x, y));
-
-        // Note that attempts is reset for every star.
-        attempts = 0;
-    }
-}
-
 void EllipticalGalaxyCalcPositions(std::vector<SystemPosition>& positions,
                                    unsigned int stars, double width, double height)
 {

--- a/universe/UniverseGenerator.h
+++ b/universe/UniverseGenerator.h
@@ -95,9 +95,6 @@ double CalcTypicalUniverseWidth(int size);
 
 // Helper functions that calculate system positions for various
 // predefined galaxy shapes
-void SpiralGalaxyCalcPositions(std::vector<SystemPosition>& positions,
-                               unsigned int arms, unsigned int stars, double width, double height);
-
 void EllipticalGalaxyCalcPositions(std::vector<SystemPosition>& positions,
                                    unsigned int stars, double width, double height);
 


### PR DESCRIPTION
…ython

Migrating the calculation of the system positions of the various galaxy shapes has been planned anyway. Now, triggered by issue #294, I've started with the spiral galaxy shapes, in another attempt to address that issue.

Please test, especially to check if we now get identical maps across all platforms. Below is a screenshot of a game with seed 0, all settings on default, only galaxy shape set to spiral2 (OSX):

![seed0_spiral2](https://cloud.githubusercontent.com/assets/10279417/9331533/4ec2dd4c-45c0-11e5-9b39-87f6abc522ac.png)
