### PR TITLE
Fix for Spatial Distortion Generator

### DIFF
--- a/default/species.txt
+++ b/default/species.txt
@@ -2777,18 +2777,20 @@ ADVANCED_FOCUS_EFFECTS
                 Fleet
                 Not Stationary
                 OwnedBy affiliation = EnemyOf empire = Source.Owner
-                WithinStarlaneJumps jumps = 1 condition = Source
+                WithinStarlaneJumps jumps = 0 condition = Source
                 Not WithinDistance distance = 0 condition = Source
             ]
             activation = And [
                 Planet
                 Focus type = "FOCUS_DISTORTION"
             ]
-            effects = MoveTo destination = And [
-                System
-                WithinStarlaneJumps jumps = 1 condition = Source
-                Not WithinDistance distance = 0 condition = Source
-            ]
+            effects = MoveTo destination = NumberOf
+                number = 1
+                condition = And [
+                    System
+                    WithinStarlaneJumps jumps = 1 condition = Source
+                    Not WithinDistance distance = 0 condition = Source
+                ]
 
         EffectsGroup
             scope = Source

--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -6486,17 +6486,9 @@ namespace {
 
             // is candidate object close enough to any subcondition matches?
             for (Condition::ObjectSet::const_iterator it = m_from_objects.begin(); it != m_from_objects.end(); ++it) {
-                if (m_jump_limit == 0) {
-                    // special case, since LeastJumpsPath() doesn't expect the start point to be the end point
-                    double delta_x = (*it)->X() - candidate->X();
-                    double delta_y = (*it)->Y() - candidate->Y();
-                    if (delta_x*delta_x + delta_y*delta_y == 0)
-                        return true;
-                } else {
-                    int jumps = GetUniverse().JumpDistanceBetweenObjects((*it)->ID(), candidate->ID());
-                    if (jumps != -1 && jumps <= m_jump_limit)
-                        return true;
-                }
+                int jumps = GetUniverse().JumpDistanceBetweenObjects((*it)->ID(), candidate->ID());
+                if (jumps != -1 && jumps <= m_jump_limit)
+                    return true;
             }
 
             return false;


### PR DESCRIPTION
This fixes issue #295. The problem was caused by a faulty special case handling in `WithinStarlaneJumpsSimpleMatch` for jumps = 0, which doesn't correctly handle fleets in transit between systems. As the reason for the special case handling mentioned in a comment does not apply (anymore?), I just removed the special case handling, which (together with an adjustment of the scope condition of the distortion focus in species.txt) fixed the problem.

I also adjusted the associated MoveTo effect so that not always the same neighbor system gets selected as destination for the "teleport" of the affected fleets.
