### PR TITLE
Adjusted/fixed ion storm effects and description

### DIFF
--- a/default/fields.txt
+++ b/default/fields.txt
@@ -37,7 +37,7 @@ FieldType
             scope = WithinDistance distance = Source.Size condition = Source
             stackinggroup = "ION_STORM_STEALTH_DETECTION_REDUCTION"
             effects = [
-                SetStealth value = Value - 40
+                SetStealth value = Value + 40
                 SetDetection value = Value - 40
             ]
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -694,7 +694,7 @@ FLD_ION_STORM
 Ion Storm
 
 FLD_ION_STORM_DESC
-Magnetic vortex of relativistic charged particles that can interfere with sensors and damage ships and planets.
+Magnetic vortex of relativistic charged particles that can interfere with sensors and obscures all objects within it.
 
 FLD_MOLECULAR_CLOUD
 Molecular Cloud


### PR DESCRIPTION
In my recent test game I realized that ion storms don't _obscure_ the objects within it, but actually make them _easier_ to detect by reducing their stealth. This strikes me as odd. I'd expect planets, ships etc. within an ion storm to be _harder_ to detect.

That those ships, planets etc. get their sensor range reduced at the same time makes sense, as their sensors are disrupted.

Also, the description of ion storms is partially wrong, as they don't damage ships and planets. So I adjusted that also.

Comments? Do these adjustments make sense?
