### PR TITLE
Improve the behaviour of left-clicking on build queue entries.

### DIFF
--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -954,7 +954,7 @@ void BuildDesignatorWnd::SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
     }
 }
 
-void BuildDesignatorWnd::CenterOnBuild(int queue_idx) {
+void BuildDesignatorWnd::CenterOnBuild(int queue_idx, bool open) {
     SetBuild(queue_idx);
 
     const ObjectMap& objects = GetUniverse().Objects();
@@ -974,8 +974,10 @@ void BuildDesignatorWnd::CenterOnBuild(int queue_idx) {
             int system_id = build_location->SystemID();
             MapWnd* map = ClientUI::GetClientUI()->GetMapWnd();
             map->CenterOnObject(system_id);
-            SelectSystem(system_id);
-            SelectPlanet(location_id);
+            if (open) {
+                SelectSystem(system_id);
+                SelectPlanet(location_id);
+            }
         }
     }
 }

--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -974,6 +974,8 @@ void BuildDesignatorWnd::CenterOnBuild(int queue_idx) {
             int system_id = build_location->SystemID();
             MapWnd* map = ClientUI::GetClientUI()->GetMapWnd();
             map->CenterOnObject(system_id);
+            SelectSystem(system_id);
+            SelectPlanet(location_id);
         }
     }
 }

--- a/UI/BuildDesignatorWnd.h
+++ b/UI/BuildDesignatorWnd.h
@@ -31,10 +31,10 @@ public:
     /** \name Mutators */ //@{
     virtual void    SizeMove(const GG::Pt& ul, const GG::Pt& lr);
 
-    /** Centres map wnd on location of item on queue with index \a queue_idx,
-      * displays info about that item in encyclopedia window, and sets it as
-      * the selected planet. */
-    void            CenterOnBuild(int queue_idx);
+    /** Centres map wnd on location of item on queue with index \a queue_idx
+      * and displays info about that item in encyclopedia window
+      * If \a open is true, the location is set as the selected planet. */
+    void            CenterOnBuild(int queue_idx, bool open = false);
 
     /** Programatically sets this Wnd's selected system.
       * Does not emit a SystemSelectedSignal. */

--- a/UI/BuildDesignatorWnd.h
+++ b/UI/BuildDesignatorWnd.h
@@ -31,8 +31,9 @@ public:
     /** \name Mutators */ //@{
     virtual void    SizeMove(const GG::Pt& ul, const GG::Pt& lr);
 
-    /** Centres map wnd on location of item on queue with index \a queue_idx
-      * and displays info about that item in encyclopedia window. */
+    /** Centres map wnd on location of item on queue with index \a queue_idx,
+      * displays info about that item in encyclopedia window, and sets it as
+      * the selected planet. */
     void            CenterOnBuild(int queue_idx);
 
     /** Programatically sets this Wnd's selected system.

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -673,6 +673,7 @@ ProductionWnd::ProductionWnd(GG::X w, GG::Y h) :
     GG::Connect(m_build_designator_wnd->BuildQuantityChangedSignal,     &ProductionWnd::ChangeBuildQuantitySlot, this);
     GG::Connect(m_build_designator_wnd->SystemSelectedSignal,           SystemSelectedSignal);
     GG::Connect(m_queue_wnd->GetQueueListBox()->QueueItemMovedSignal,   &ProductionWnd::QueueItemMoved, this);
+    GG::Connect(m_queue_wnd->GetQueueListBox()->QueueItemDeletedSignal, &ProductionWnd::DeleteQueueItem, this);
     GG::Connect(m_queue_wnd->GetQueueListBox()->LeftClickedSignal,      &ProductionWnd::QueueItemClickedSlot, this);
     GG::Connect(m_queue_wnd->GetQueueListBox()->DoubleClickedSignal,    &ProductionWnd::QueueItemDoubleClickedSlot, this);
 
@@ -763,8 +764,8 @@ void ProductionWnd::ShowBuildingTypeInEncyclopedia(const std::string& building_t
 void ProductionWnd::ShowShipDesignInEncyclopedia(int design_id)
 { m_build_designator_wnd->ShowShipDesignInEncyclopedia(design_id); }
 
-void ProductionWnd::CenterOnBuild(int queue_idx)
-{ m_build_designator_wnd->CenterOnBuild(queue_idx); }
+void ProductionWnd::CenterOnBuild(int queue_idx, bool open)
+{ m_build_designator_wnd->CenterOnBuild(queue_idx, open); }
 
 void ProductionWnd::SelectPlanet(int planet_id)
 { m_build_designator_wnd->SelectPlanet(planet_id); }
@@ -965,7 +966,7 @@ void ProductionWnd::QueueItemClickedSlot(GG::ListBox::iterator it, const GG::Pt&
 
 void ProductionWnd::QueueItemDoubleClickedSlot(GG::ListBox::iterator it) {
     if (m_queue_wnd->GetQueueListBox()->DisplayingValidQueueItems()) {
-        DeleteQueueItem(it);
+        m_build_designator_wnd->CenterOnBuild(std::distance(m_queue_wnd->GetQueueListBox()->begin(), it), true);
     }
 }
 

--- a/UI/ProductionWnd.h
+++ b/UI/ProductionWnd.h
@@ -45,8 +45,9 @@ public:
     void            ShowShipDesignInEncyclopedia(int design_id);
 
     /** Centres map wnd on location of item on queue with index \a queue_idx
-      * and displays info about that item in encyclopedia window. */
-    void            CenterOnBuild(int queue_idx);
+      * and displays info about that item in encyclopedia window.
+      * If \a open is true, the location is set as the selected planet. */
+    void            CenterOnBuild(int queue_idx, bool open = false);
 
     /** Programatically sets this Wnd's selected system.
       * Does not emit a SystemSelectedSignal. */

--- a/UI/QueueListBox.cpp
+++ b/UI/QueueListBox.cpp
@@ -167,10 +167,6 @@ void QueueListBox::Clear() {
 }
 
 void QueueListBox::ItemRightClicked(GG::ListBox::iterator it, const GG::Pt& pt) {
-    // Create popup menu with a Delete Item command to provide same functionality as
-    // DoubleClick since under laggy conditions it DoubleClick can have trouble
-    // being interpreted correctly (can instead be treated as simply two unrelated left clicks)
-
     GG::MenuItem menu_contents;
     menu_contents.next_level.push_back(GG::MenuItem(UserString("MOVE_UP_QUEUE_ITEM"),   1, false, false));
     menu_contents.next_level.push_back(GG::MenuItem(UserString("MOVE_DOWN_QUEUE_ITEM"), 2, false, false));
@@ -192,7 +188,7 @@ void QueueListBox::ItemRightClicked(GG::ListBox::iterator it, const GG::Pt& pt) 
             break;
         }
         case 3: { // delete item
-            DoubleClickedSignal(it);
+            QueueItemDeletedSignal(it);
             break;
         }
 

--- a/UI/QueueListBox.h
+++ b/UI/QueueListBox.h
@@ -32,6 +32,7 @@ public:
     virtual void    Render();
 
     boost::signals2::signal<void (GG::ListBox::Row*, std::size_t)>  QueueItemMovedSignal;
+    boost::signals2::signal<void (GG::ListBox::iterator)>           QueueItemDeletedSignal;
 
 private:
     void    ItemRightClicked(GG::ListBox::iterator it, const GG::Pt& pt);

--- a/UI/ResearchWnd.cpp
+++ b/UI/ResearchWnd.cpp
@@ -212,6 +212,7 @@ ResearchWnd::ResearchWnd(GG::X w, GG::Y h) :
     m_queue_lb->SetStyle(GG::LIST_NOSORT | GG::LIST_NOSEL | GG::LIST_USERDELETE);
 
     GG::Connect(m_queue_lb->QueueItemMovedSignal,       &ResearchWnd::QueueItemMoved,               this);
+    GG::Connect(m_queue_lb->QueueItemDeletedSignal,     &ResearchWnd::DeleteQueueItem,               this);
     GG::Connect(m_queue_lb->LeftClickedSignal,          &ResearchWnd::QueueItemClickedSlot,         this);
     GG::Connect(m_queue_lb->DoubleClickedSignal,        &ResearchWnd::QueueItemDoubleClickedSlot,   this);
 


### PR DESCRIPTION
Instead of just jumping the map to the system where the planet is located,
open up that system in the sidepanel and select the planet. This should
be especially handy in late game, when double-clicking on a system can
get to be very slow and it helps to do everything in one step.

Yes, "left" should be correct here ;)
