### PR TITLE
[AI] Add getters for inner colonization variables

### DIFF
--- a/default/AI/ColonisationAI.py
+++ b/default/AI/ColonisationAI.py
@@ -61,6 +61,35 @@ PHOTO_MAP = {fo.starType.blue: 3, fo.starType.white: 1.5, fo.starType.red: -1, f
              fo.starType.blackHole: -10, fo.starType.noStar: -10}
 
 
+def get_medium_pilot_rating():
+    return curMidPilotRating
+
+
+def get_best_pilot_rating():
+    return cur_best_pilot_rating
+
+
+def have_computronium():
+    return got_computronium
+
+
+def have_asteroids():
+    return got_ast
+
+
+def have_gas_giant():
+    return got_gg
+
+
+def have_ruins():
+    return gotRuins
+
+
+def have_nest():
+    return got_nest
+
+
+
 # mods per environ uninhab hostile poor adequate good
 POP_SIZE_MOD_MAP = {
     "environment_bonus": [0, -4, -2, 0, 3],
@@ -850,7 +879,7 @@ def evaluate_planet(planet_id, mission_type, spec_name, empire, detail=None):
     pilot_val = pilot_rating = 0
     if species and species.canProduceShips:
         pilot_val = pilot_rating = rate_piloting_tag(species.tags)
-        if pilot_val > cur_best_pilot_rating:
+        if pilot_val > get_best_pilot_rating():
             pilot_val *= 2
         if pilot_val > 2:
             retval += discount_multiplier * 5 * pilot_val
@@ -980,7 +1009,7 @@ def evaluate_planet(planet_id, mission_type, spec_name, empire, detail=None):
         if "PHOTOTROPHIC" in tag_list:
             star_pop_mod = PHOTO_MAP.get(system.starType, 0)
             detail.append("PHOTOTROPHIC popMod %.1f" % star_pop_mod)
-        elif pilot_rating >= cur_best_pilot_rating:
+        elif pilot_rating >= get_best_pilot_rating():
             if system.starType == fo.starType.red and tech_is_complete("LRN_STELLAR_TOMOGRAPHY"):
                 star_bonus += 40 * discount_multiplier # can be used for artif'l black hole and solar hull
                 detail.append("Red Star for Art Black Hole for solar hull %.1f" % (40 * discount_multiplier))
@@ -1347,7 +1376,7 @@ def evaluate_planet(planet_id, mission_type, spec_name, empire, detail=None):
                 comp_bonus = (0.5 * AIDependencies.TECH_COST_MULTIPLIER * AIDependencies.RESEARCH_PER_POP *
                               AIDependencies.COMPUTRONIUM_RES_MULTIPLIER * empire_status['researchers'] *
                               discount_multiplier)
-                if got_computronium:
+                if have_computronium():
                     comp_bonus *= backup_factor
                 research_bonus += comp_bonus
                 detail.append("COMPUTRONIUM_SPECIAL")

--- a/default/AI/PriorityAI.py
+++ b/default/AI/PriorityAI.py
@@ -122,8 +122,8 @@ def calculateResearchPriority():
     totalRP = empire.resourceProduction(fo.resourceType.research)
     industrySurge = ((foAI.foAIstate.aggression > fo.aggression.cautious) and
                      ((totalPP + 1.6 * totalRP) <(50* foAI.foAIstate.aggression)) and
-                     (((orb_gen_tech in researchQueueList[:2] or got_orb_gen) and ColonisationAI.got_gg) or
-                      ((mgrav_prod_tech in researchQueueList[:2] or got_mgrav_prod) and ColonisationAI.got_ast)) and
+                     (((orb_gen_tech in researchQueueList[:2] or got_orb_gen) and ColonisationAI.have_gas_giant()) or
+                      ((mgrav_prod_tech in researchQueueList[:2] or got_mgrav_prod) and ColonisationAI.have_asteroids())) and
                      (not (len(AIstate.popCtrIDs) >= 12 )))
     # get current industry production & Target
     ownedPlanetIDs = PlanetUtilsAI.get_owned_planets_by_empire(universe.planetIDs)
@@ -204,11 +204,11 @@ def calculateExplorationPriority():
                 queuedScoutShips += element.remaining * element.blocksize
 
     milShips = MilitaryAI.num_milships
-    # intent of the following calc is essentially 
+    # intent of the following calc is essentially
     # new_scouts_needed = min(need_cap_A, need_cap_B, base_need) - already_got_or_queued
-    # where need_cap_A is to help prevent scouting needs from swamping military needs, and 
+    # where need_cap_A is to help prevent scouting needs from swamping military needs, and
     # need_cap_B is to help regulate investment into scouting while the empire is small.
-    # These caps could perhaps instead be tied more directly to military priority and 
+    # These caps could perhaps instead be tied more directly to military priority and
     # total empire production.
     scoutsNeeded = max(0, min( 4+int(milShips/5), 4+int(fo.currentTurn()/50) , 2+ numUnexploredSystems**0.5 ) - numScouts - queuedScoutShips )
     explorationPriority = int(40*scoutsNeeded)

--- a/default/AI/ProductionAI.py
+++ b/default/AI/ProductionAI.py
@@ -363,9 +363,9 @@ def generateProductionOrders():
 #TODO: add totalPP checks below, so don't overload queue
 
     best_pilot_locs = sorted([(rating, pid) for pid, rating in ColonisationAI.pilot_ratings.items()
-                              if rating == ColonisationAI.cur_best_pilot_rating], reverse = True)
+                              if rating == ColonisationAI.get_best_pilot_rating()], reverse=True)
     best_pilot_facilities = ColonisationAI.facilities_by_species_grade.get(
-        "WEAPONS_%.1f"%ColonisationAI.cur_best_pilot_rating, {})
+        "WEAPONS_%.1f"%ColonisationAI.get_best_pilot_rating(), {})
 
     print "best_pilot_facilities: \n %s" % best_pilot_facilities
 
@@ -460,7 +460,7 @@ def generateProductionOrders():
 
     top_pilot_systems={}
     for pid, rating in ColonisationAI.pilot_ratings.items() :
-        if (rating <= ColonisationAI.curMidPilotRating) and (rating < ColonisationAI.GREAT_PILOT_RATING):
+        if (rating <= ColonisationAI.get_medium_pilot_rating()) and (rating < ColonisationAI.GREAT_PILOT_RATING):
             continue
         top_pilot_systems.setdefault( universe.getPlanet(pid).systemID, [] ).append( (pid, rating) )
         if (pid in queuedShipyardLocs ) or not bldType.canBeProduced(empire.empireID, pid) :
@@ -476,15 +476,15 @@ def generateProductionOrders():
     red_popctrs = sorted([(ColonisationAI.pilot_ratings.get(pid, 0), pid) for pid in popCtrs
                           if colonySystems.get(pid, -1) in AIstate.empireStars.get(fo.starType.red, [])],
                          reverse = True)
-    red_pilots = [pid for rating, pid in red_popctrs if rating == ColonisationAI.cur_best_pilot_rating]
+    red_pilots = [pid for rating, pid in red_popctrs if rating == ColonisationAI.get_best_pilot_rating()]
     blue_popctrs = sorted([(ColonisationAI.pilot_ratings.get(pid, 0), pid) for pid in popCtrs
                            if colonySystems.get(pid, -1) in AIstate.empireStars.get(fo.starType.blue, [])],
                           reverse = True)
-    blue_pilots = [pid for rating, pid in blue_popctrs if rating == ColonisationAI.cur_best_pilot_rating]
+    blue_pilots = [pid for rating, pid in blue_popctrs if rating == ColonisationAI.get_best_pilot_rating()]
     bh_popctrs = sorted([(ColonisationAI.pilot_ratings.get(pid, 0), pid) for pid in popCtrs
                          if colonySystems.get(pid, -1) in AIstate.empireStars.get(fo.starType.blackHole, [])],
                         reverse = True)
-    bh_pilots = [pid for rating, pid in bh_popctrs if rating == ColonisationAI.cur_best_pilot_rating]
+    bh_pilots = [pid for rating, pid in bh_popctrs if rating == ColonisationAI.get_best_pilot_rating()]
     enrgyShipyardLocs={}
     for bldName in [ "BLD_SHIPYARD_ENRG_COMP"  ]:
         if empire.buildingTypeAvailable(bldName):
@@ -1371,14 +1371,14 @@ def generateProductionOrders():
             perTurnCost = (float(bestDesign.productionCost(empire.empireID, loc)) / bestDesign.productionTime(empire.empireID, loc))
             if thisPriority == EnumsAI.AIPriorityType.PRIORITY_PRODUCTION_MILITARY:
                 thisRating = ColonisationAI.pilot_ratings.get(loc, 0)
-                ratingRatio = float(thisRating) / ColonisationAI.cur_best_pilot_rating
+                ratingRatio = float(thisRating) / ColonisationAI.get_best_pilot_rating()
                 pname = ""
                 if ratingRatio < 0.1:
                     locPlanet = universe.getPlanet(loc)
                     if locPlanet:
                         pname = locPlanet.name
                         thisRating = ColonisationAI.rate_planetary_piloting(loc)
-                        ratingRatio = float(thisRating) / ColonisationAI.cur_best_pilot_rating
+                        ratingRatio = float(thisRating) / ColonisationAI.get_best_pilot_rating()
                         qualifier = ["", "suboptimal"][ratingRatio < 1.0]
                         print "Building mil ship at loc %d (%s) with %s pilot Rating: %.1f; ratio to empire best is %.1f"%(loc, pname, qualifier, thisRating, ratingRatio)
                 while totalPP > 40*perTurnCost:

--- a/default/AI/ResearchAI.py
+++ b/default/AI/ResearchAI.py
@@ -1,6 +1,5 @@
 from functools import partial
 import math
-from operator import attrgetter
 import random
 
 import freeOrionAIInterface as fo  # pylint: disable=import-error
@@ -51,12 +50,6 @@ COLONY_IDX = 2
 ZERO = 0.0
 LOW = 0.1
 DEFAULT_PRIORITY = 0.5
-
-# TODO: Move this functions to ColonisationAI
-have_asteroids = partial(attrgetter('got_ast'), ColonisationAI)
-have_gas_giant = partial(attrgetter('got_gg'), ColonisationAI)
-have_ruins = partial(attrgetter('gotRuins'), ColonisationAI)
-have_nest = partial(attrgetter('got_nest'), ColonisationAI)
 
 
 # TODO research AI no longer use this method, rename and move this method elsewhere
@@ -366,15 +359,15 @@ def init():
     ]
 
     tech_handlers = (
-        (Dep.PRO_MICROGRAV_MAN, conditional_priority(3.5, LOW, have_asteroids)),
-        (Dep.PRO_ORBITAL_GEN, conditional_priority(3.0, LOW, have_gas_giant)),
+        (Dep.PRO_MICROGRAV_MAN, conditional_priority(3.5, LOW, ColonisationAI.have_asteroids)),
+        (Dep.PRO_ORBITAL_GEN, conditional_priority(3.0, LOW, ColonisationAI.have_gas_giant)),
         (Dep.PRO_SINGULAR_GEN, conditional_priority(3.0, LOW, partial(has_star, fo.starType.blackHole))),
         (Dep.GRO_XENO_GENETICS, get_xeno_genetics_priority),
-        (Dep.LRN_XENOARCH, conditional_priority(LOW, conditional_priority(5.0, LOW, have_ruins), has_low_aggression)),
+        (Dep.LRN_XENOARCH, conditional_priority(LOW, conditional_priority(5.0, LOW, ColonisationAI.have_ruins), has_low_aggression)),
         (Dep.LRN_ART_BLACK_HOLE, get_artificial_black_hole_priority),
         (Dep.GRO_GENOME_BANK, LOW),
         (Dep.CON_CONC_CAMP, ZERO),
-        (Dep.NEST_DOMESTICATION_TECH, conditional_priority(ZERO, conditional_priority(3.0, LOW, have_nest), has_low_aggression)),
+        (Dep.NEST_DOMESTICATION_TECH, conditional_priority(ZERO, conditional_priority(3.0, LOW, ColonisationAI.have_nest), has_low_aggression)),
         (Dep.UNRESEARCHABLE_TECHS, -1.0),
         (Dep.UNUSED_TECHS, ZERO),
         (Dep.THEORY_TECHS, ZERO),


### PR DESCRIPTION
Colonization module give public access to variables that store some important game state.
I suggest to restrict access to variables directly and use getters instead.

@Dilvish-fo, this changes will be useful  for new ResearchAI.  I did not update `ResearchAI.py` to avoid conflicts.
