### PR TITLE
Reduced dot size in new rendering implementation of the galaxy map background starfield to make the background stars less dominant

### DIFF
--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -1485,7 +1485,7 @@ void MapWnd::RenderStarfields() {
     }
 
 
-    glPointSize(std::min(3.0, 3.0 * ZoomFactor() * ZoomFactor()));
+    glPointSize(std::min(1.0, 1.0 * ZoomFactor() * ZoomFactor()));
     glEnable(GL_POINT_SMOOTH);
     glDisable(GL_TEXTURE_2D);
 


### PR DESCRIPTION
I've reduced the dot size of the background stars from 3 to 1. IMO that is much easier on the eyes, but that's just me. So I'm putting this up as a PR to get other opinions before I commit it.
