### PR TITLE
Adjusted calculation of background starfield stars size

### DIFF
--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -1485,7 +1485,7 @@ void MapWnd::RenderStarfields() {
     }
 
 
-    glPointSize(std::min(3.0, 3.0 * ZoomFactor() * ZoomFactor()));
+    glPointSize(std::min(5.0, 0.5 * ZoomFactor()));
     glEnable(GL_POINT_SMOOTH);
     glDisable(GL_TEXTURE_2D);
 


### PR DESCRIPTION
The galaxy map background starfield produced by the new implementation of its rendering had too big/prominent stars (at least at normal or zoomed out zoom levels). Adjusted the calculation of their size so that they are smaller and therefore more easy on the eyes on normal/zoomed out zoom levels, but also increased their max size so they are a bit more prominent if you zoom in very closely.
