### PR TITLE
Remove the extra padding from the ends of dropdown lists.

### DIFF
--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -408,6 +408,11 @@ public:
       * they are. */
     void            NormalizeRowsOnInsert(bool enable = true);
 
+    /** Sets whether to add padding at the end of the scrolls when the ListBox is
+     *  bigger than the client area, so that any row can be scrolled all the way to
+     *  the top (true), or only use as much space as it needs. */
+    void            AddPaddingAtEnd(bool enable = true);
+
     /** Allows Rows with data type \a str to be dropped over this ListBox when
         drag-and-drop is enabled. \note Passing "" enables all drop types. */
     void            AllowDropType(const std::string& str);
@@ -554,6 +559,8 @@ private:
     Timer           m_auto_scroll_timer;
 
     bool            m_normalize_rows_on_insert;
+
+    bool            m_add_padding_at_end;
 
     iterator*       m_iterator_being_erased;
 

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -443,6 +443,7 @@ ListBox::ListBox(Clr color, Clr interior/* = CLR_ZERO*/) :
     m_auto_scrolling_right(false),
     m_auto_scroll_timer(250),
     m_normalize_rows_on_insert(true),
+    m_add_padding_at_end(true),
     m_iterator_being_erased(0)
 {
     Control::SetColor(color);
@@ -1111,6 +1112,9 @@ void ListBox::SetRowAlignment(iterator it, Alignment align)
 
 void ListBox::NormalizeRowsOnInsert(bool enable)
 { m_normalize_rows_on_insert = enable; }
+
+void ListBox::AddPaddingAtEnd(bool enable)
+{ m_add_padding_at_end = enable; }
 
 void ListBox::AllowDropType(const std::string& str)
 { m_allowed_drop_types.insert(str); }
@@ -1863,15 +1867,20 @@ void ListBox::AdjustScrolls(bool adjust_for_resize)
                           (cl_sz.x < total_x_extent - SCROLL_WIDTH &&
                            cl_sz.y < total_y_extent - SCROLL_WIDTH));
 
-    // This probably looks a little odd.  We only want to show scrolls if they
-    // are needed, that is if the data shown exceed the bounds of the client
-    // area.  However, if we are going to show scrolls, we want to allow them
-    // to range such that the first row/column shown can be any of the N
-    // rows/columns.  Dead space after the last row/column is fine.
-    if (!m_col_widths.empty() && m_col_widths.back() < cl_sz.x)
-        total_x_extent += cl_sz.x - m_col_widths.back();
-    if (!m_rows.empty() && m_rows.back()->Height() < cl_sz.y)
-        total_y_extent += cl_sz.y - m_rows.back()->Height();
+
+    if (m_add_padding_at_end) {
+        // This probably looks a little odd. We only want to show scrolls if they
+        // are needed, that is if the data shown exceed the bounds of the client
+        // area. However, if we are going to show scrolls, we want to allow them
+        // to range such that the first row/column shown can be any of the N
+        // rows/columns. This is necessary since otherwise the bottom row may get
+        // cut off. Dead space after the last row/column is the result, even if it
+        // may look slightly ugly.
+        if (!m_col_widths.empty() && m_col_widths.back() < cl_sz.x)
+            total_x_extent += cl_sz.x - m_col_widths.back();
+        if (!m_rows.empty() && m_rows.back()->Height() < cl_sz.y)
+            total_y_extent += cl_sz.y - m_rows.back()->Height();
+    }
 
     boost::shared_ptr<StyleFactory> style = GetStyleFactory();
 

--- a/GG/src/StyleFactory.cpp
+++ b/GG/src/StyleFactory.cpp
@@ -115,7 +115,14 @@ TabBar* StyleFactory::NewTabBar(const boost::shared_ptr<Font>& font, Clr color, 
 { return new TabBar(font, color, text_color, style, INTERACTIVE); }
 
 ListBox* StyleFactory::NewDropDownListListBox(Clr color, Clr interior/* = CLR_ZERO*/) const
-{ return NewListBox(color, interior); }
+{
+    ListBox* lb = NewListBox(color, interior);
+    // Because the rows of DropDownLists must be the same size, there's
+    // no need to worry that the bottom entry will get cut off if the
+    // scrollbar ends exactly at the list's end.
+    lb->AddPaddingAtEnd(false);
+    return lb;
+}
 
 Scroll* StyleFactory::NewListBoxVScroll(Clr color, Clr interior) const
 { return NewScroll(VERTICAL, color, interior); }

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -722,10 +722,6 @@ namespace {
         return ClientUI::Pts()*1.5;
     }
 
-    GG::Y SystemNameTextControlHeight() {
-        return GG::Y(SystemNameFontSize()*4/3);
-    }
-
     class SystemRow : public GG::ListBox::Row {
     public:
         SystemRow(int system_id) :
@@ -771,14 +767,6 @@ namespace {
     }
 
     const GG::Y PLANET_PANEL_TOP = GG::Y(140);
-
-    GG::X ButtonWidth() {
-        return GG::X(Value(SystemNameTextControlHeight()));
-    }
-
-    GG::Y ButtonHeight() {
-        return SystemNameTextControlHeight();
-    }
 }
 
 ////////////////////////////////////////////////
@@ -2952,28 +2940,34 @@ void SidePanel::RefreshImpl() {
 }
 
 void SidePanel::DoLayout() {
+    if (m_system_name->CurrentItem() == m_system_name->end()) // no system to render
+        return;
+
+    const GG::Y name_height((*m_system_name->CurrentItem())->Height());
+    const GG::X button_width(Value(name_height));
+
     // left button
-    GG::Pt ul(GG::X(MaxPlanetDiameter()) + 2*EDGE_PAD, GG::Y(EDGE_PAD));
-    GG::Pt lr(ul + GG::Pt(ButtonWidth(), ButtonHeight()));
+    GG::Pt ul(GG::X(MaxPlanetDiameter()) + 2*EDGE_PAD, GG::Y0);
+    GG::Pt lr(ul + GG::Pt(button_width, name_height));
     m_button_prev->SizeMove(ul, lr);
 
     // right button
-    ul = GG::Pt(ClientWidth() - ButtonWidth() - 2*EDGE_PAD, GG::Y(EDGE_PAD));
-    lr = ul + GG::Pt(ButtonWidth(), ButtonHeight());
+    ul = GG::Pt(ClientWidth() - button_width - 2*EDGE_PAD, GG::Y0);
+    lr = ul + GG::Pt(button_width, name_height);
     m_button_next->SizeMove(ul, lr);
 
     // system name / droplist
     ul = GG::Pt(GG::X(MaxPlanetDiameter()), GG::Y0);
-    lr = ul + GG::Pt(ClientWidth() - GG::X(MaxPlanetDiameter()), SystemNameTextControlHeight());
+    lr = ul + GG::Pt(ClientWidth() - GG::X(MaxPlanetDiameter()), name_height);
     m_system_name->SizeMove(ul, lr);
 
     // system name droplist rows
-    GG::Pt row_size(ListRowSize());
+    const GG::X row_width(m_system_name->Width() - ClientUI::ScrollWidth() - 5);
     for (GG::ListBox::iterator it = m_system_name->begin(); it != m_system_name->end(); ++it)
-        (*it)->Resize(row_size);
+        (*it)->Resize(GG::Pt(row_width, (*it)->Height()));
 
     // star type text
-    ul = GG::Pt(GG::X(MaxPlanetDiameter()) + 2*EDGE_PAD, m_system_name->Height() + EDGE_PAD*4);
+    ul = GG::Pt(GG::X(MaxPlanetDiameter()) + 2*EDGE_PAD, name_height + EDGE_PAD*4);
     lr = GG::Pt(ClientWidth() - 1, ul.y + m_star_type_text->Height());
     m_star_type_text->SizeMove(ul, lr);
 
@@ -2989,9 +2983,6 @@ void SidePanel::DoLayout() {
         m_system_resource_summary->SizeMove(ul, lr);
     }
 }
-
-GG::Pt SidePanel::ListRowSize() const
-{ return GG::Pt(m_system_name->Width() - ClientUI::ScrollWidth() - 5, m_system_name->Height()); }
 
 void SidePanel::SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
     GG::Pt old_size = GG::Wnd::Size();

--- a/UI/SidePanel.h
+++ b/UI/SidePanel.h
@@ -103,7 +103,6 @@ private:
     class PlanetPanelContainer;
 
     void                DoLayout();
-    GG::Pt              ListRowSize() const;
 
     void                UpdateImpl();                   ///< updates contents quickly.  to be used when meters or other objects' data changes
     void                RefreshImpl();                  ///< fully refreshes contents.  to be used when objects are created, destroyed or added to system


### PR DESCRIPTION
It didn't go so well doing this across the board, but it works OK for just
dropdown lists, as explained in the comments.

It would be nice to get this working for the system name dropdown, but
there's some issue -- it works at first, but then when you scroll, text
in bold (such as your homeworld's system...) get bigger, which means that
there isn't enough space to show the bottom row.

Basically a follow-up to #228.
