### PR TITLE
Fixed DependencyVersions.cpp linux compilation errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,11 +114,13 @@ set(LIB_SUFFIX ${OLD_LIB_SUFFIX})
 ########################################
 find_package(Boost ${MINIMUM_BOOST_VERSION} COMPONENTS chrono date_time filesystem regex serialization signals system thread log REQUIRED)
 find_package(ZLIB REQUIRED)
+find_package(Freetype REQUIRED)
 
 include_directories(
     ${Boost_INCLUDE_DIRS}
     ${ZLIB_INCLUDE_DIR}
     ${CMAKE_SOURCE_DIR}
+    ${FREETYPE_INCLUDE_DIRS}
     GG
 )
 

--- a/util/DependencyVersions.cpp
+++ b/util/DependencyVersions.cpp
@@ -3,8 +3,8 @@
 #include "Logger.h"
 
 #include <SDL2/SDL_version.h>
-#include <zlib/zlib.h>
-#include <png/png.h>
+#include <zlib.h>
+#include <png.h>
 #include <python2.7/patchlevel.h>
 //#include <vorbis/codec.h>
 


### PR DESCRIPTION
I got compilation errors on linux from DependencyVersions.cpp.

These changes fixed them for me, and at least zlib is included without the directory also from the single other place it appears in, Message.cpp.

Before DependencyVersions, freetype was only used from GG so it was only included there, hence its addition to the root CMakeLists.txt here.
