### PR TITLE
Fix #366: TextBlock shows only half of the last line.

### DIFF
--- a/GG/src/RichText/TextBlock.cpp
+++ b/GG/src/RichText/TextBlock.cpp
@@ -19,12 +19,17 @@ namespace GG {
 
     Pt TextBlock::SetMaxWidth(X width)
     {
-        // Reflow the text to the given width. Height is ignored.
-        m_text->Resize(GG::Pt(width, Y0));
+        // Reflow the text to the given width.
+        // We will actually listen to the height
+        // the text wants to be instead of forcing it to a given height,
+        // but the text layout code seems to get confused if you give it a height
+        // less than the height of the font so we use that.
+        m_text->Resize(GG::Pt(width, m_text->GetFont()->Height()));
 
         // Use the size the text requires.
-        Resize(m_text->MinUsableSize());
-        return m_text->MinUsableSize();
+        Pt text_size = m_text->MinUsableSize();
+        Resize(text_size);
+        return text_size;
     }
 
     // A factory for creating text blocks from tags.


### PR DESCRIPTION
The text extent calculation was confused by the zero I gave
it for height to tell I don't care.
Now I give it the height of the font instead.

Fixes #366.
