### PR TITLE
Make some techs, buildings and planets detection depend on Infrastructure

### DIFF
--- a/default/buildings.txt
+++ b/default/buildings.txt
@@ -225,12 +225,6 @@ BuildingType
         EffectsGroup
             scope = NumberOf number = 1 condition = System
             effects = SetStealth value = Value - 1
-            
-        EffectsGroup
-            scope = And [ 
-                Planet 
-                Object id = Source.PlanetID
-            ]
     ]
     icon = "icons/building/lighthouse.png"
 */

--- a/default/buildings.txt
+++ b/default/buildings.txt
@@ -231,7 +231,6 @@ BuildingType
                 Planet 
                 Object id = Source.PlanetID
             ]
-            effects = SetTargetConstruction value = Value - 10
     ]
     icon = "icons/building/lighthouse.png"
 */
@@ -249,13 +248,6 @@ BuildingType
         OwnedBy empire = Source.Owner
     ]
     EnqueueLocation = [[ENQUEUE_BUILD_ONE_PER_PLANET]]
-    effectsgroups =
-        EffectsGroup
-            scope = And [ 
-                Object id = Source.PlanetID
-                Planet
-            ]
-            effects = SetTargetConstruction value = Value - 10
     icon = "icons/building/shipyard.png"
 
 BuildingType
@@ -274,7 +266,7 @@ BuildingType
         OwnedBy empire = Source.Owner
     ]
     EnqueueLocation = [[ENQUEUE_BUILD_ONE_PER_PLANET]]
-    effectsgroups = [
+    effectsgroups =
         EffectsGroup
             scope = And [
                 Ship
@@ -296,14 +288,6 @@ BuildingType
                     ]
                     empire = Source.Owner
             ]
-            
-        EffectsGroup
-            scope = And [
-                Object id = Source.PlanetID
-                Planet
-            ]
-            effects = SetTargetConstruction value = Value - 15
-        ]
     icon = "icons/building/shipyard-1.png"
 
 BuildingType
@@ -611,44 +595,42 @@ BuildingType
     ]
     EnqueueLocation = [[ENQUEUE_BUILD_ONE_PER_PLANET]]
     effectsgroups = [
-        EffectsGroup
+	    EffectsGroup
             scope = And [
                 PopulationCenter
                 OwnedBy empire = Source.Owner
                 ResourceSupplyConnected empire = Source.Owner condition = Source
                 Focus type = "FOCUS_INDUSTRY"
-            ]
-            activation = And [
-                OwnerHasTech name = "PRO_INDUSTRY_CENTER_I"
-                Not OwnerHasTech name = "PRO_INDUSTRY_CENTER_II"
-            ]
-            stackinggroup = "INDUSTRY_CENTER_STACK"
-            effects = SetTargetIndustry value = Value + Target.Population * 1.0 * [[INDUSTRY_PER_POP]]
-
-        EffectsGroup
-            scope = And [
-                PopulationCenter
-                OwnedBy empire = Source.Owner
-                ResourceSupplyConnected empire = Source.Owner condition = Source
-                Focus type = "FOCUS_INDUSTRY"
-            ]
-            activation = And [
-                OwnerHasTech name = "PRO_INDUSTRY_CENTER_II"
-                Not OwnerHasTech name = "PRO_INDUSTRY_CENTER_III"
-            ]
-            stackinggroup = "INDUSTRY_CENTER_STACK"
-            effects = SetTargetIndustry value = Value + Target.Population * 2 * [[INDUSTRY_PER_POP]]
-
-        EffectsGroup
-            scope = And [
-                PopulationCenter
-                OwnedBy empire = Source.Owner
-                ResourceSupplyConnected empire = Source.Owner condition = Source
-                Focus type = "FOCUS_INDUSTRY"
+				Construction low = 30
             ]
             activation = OwnerHasTech name = "PRO_INDUSTRY_CENTER_III"
             stackinggroup = "INDUSTRY_CENTER_STACK"
             effects = SetTargetIndustry value = Value + Target.Population * 3 * [[INDUSTRY_PER_POP]]
+			
+		EffectsGroup
+            scope = And [
+                PopulationCenter
+                OwnedBy empire = Source.Owner
+                ResourceSupplyConnected empire = Source.Owner condition = Source
+                Focus type = "FOCUS_INDUSTRY"
+				Construction low = 20
+            ]
+            activation = OwnerHasTech name = "PRO_INDUSTRY_CENTER_II"
+            stackinggroup = "INDUSTRY_CENTER_STACK"
+            effects = SetTargetIndustry value = Value + Target.Population * 2 * [[INDUSTRY_PER_POP]]
+			
+        EffectsGroup
+            scope = And [
+                PopulationCenter
+                OwnedBy empire = Source.Owner
+                ResourceSupplyConnected empire = Source.Owner condition = Source
+                Focus type = "FOCUS_INDUSTRY"
+				Construction low = 10
+            ]
+            activation = OwnerHasTech name = "PRO_INDUSTRY_CENTER_I"
+            stackinggroup = "INDUSTRY_CENTER_STACK"
+            effects = SetTargetIndustry value = Value + Target.Population * 1.0 * [[INDUSTRY_PER_POP]]
+
     ]
     icon = "icons/tech/industrial_centre_ii.png"
 
@@ -686,6 +668,7 @@ BuildingType
                 PopulationCenter
                 OwnedBy empire = Source.Owner
                 TargetPopulation low = 1
+				Construction low = 30
             ]
             activation = Source
             stackinggroup = "BLD_MEGALITH_EFFECT"
@@ -941,6 +924,7 @@ BuildingType
                 Focus type = "FOCUS_INDUSTRY"
                 OwnedBy empire = Source.Owner
                 ResourceSupplyConnected empire = Source.Owner condition = Source
+				Construction low = 30
             ]
             activation = Star type = [Blue White]
             stackinggroup = "BLD_SOL_ORB_GEN_EFFECT"
@@ -952,6 +936,7 @@ BuildingType
                 Focus type = "FOCUS_INDUSTRY"
                 OwnedBy empire = Source.Owner
                 ResourceSupplyConnected empire = Source.Owner condition = Source
+				Construction low = 30
             ]
             activation = And [
                 Star type = [Yellow Orange]
@@ -970,6 +955,7 @@ BuildingType
                 Focus type = "FOCUS_INDUSTRY"
                 OwnedBy empire = Source.Owner
                 ResourceSupplyConnected empire = Source.Owner condition = Source
+				Construction low = 30
             ]
             activation = And [
                 Star type = Red
@@ -1263,6 +1249,7 @@ BuildingType
                 Focus type = "FOCUS_INDUSTRY"
                 OwnedBy empire = Source.Owner
                 ResourceSupplyConnected empire = Source.Owner condition = Source
+				Construction low = 40
             ]
             activation = Star type = BlackHole
             stackinggroup = "BLD_BLACK_HOLE_POW_GEN_PRIMARY_EFFECT"
@@ -1617,6 +1604,7 @@ BuildingType
                 Focus type = "FOCUS_INDUSTRY"
                 NOT Population high = 0
                 OwnedBy empire = Source.Owner
+				Construction low = 20 
             ]
             stackinggroup = "GAS_GIANT_GEN_STACK"
             effects = SetTargetIndustry value = Value + 10

--- a/default/buildings.txt
+++ b/default/buildings.txt
@@ -67,7 +67,7 @@ BuildingType
                 SetTargetIndustry value = Value + Target.Population / 2
                 //SetDetection value = Value + 10000
             ]
-            
+
         EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
@@ -75,14 +75,14 @@ BuildingType
                 OwnedBy empire = Source.Owner
                 Not HasSpecial name = "HEAD_ON_A_SPIKE_SPECIAL"
             ]
-            activation = Not ProducedByEmpire empire = Source.Owner                
+            activation = Not ProducedByEmpire empire = Source.Owner
             effects = [
                 AddSpecial name = "HEAD_ON_A_SPIKE_SPECIAL"
                 GenerateSitRepMessage
                     message = "HEAD_ON_A_SPIKE_MESSAGE"
                     icon = "icons/sitrep/empire_eliminated.png"
                     parameters = [
-                        tag = "empire" data = Source.ProducedByEmpireID                        
+                        tag = "empire" data = Source.ProducedByEmpireID
                     ]
             ]
     ]
@@ -134,20 +134,20 @@ BuildingType
         // must own production location planet
         Planet
         OwnedBy empire = Source.Owner
-        
+
         // can't build where another palace exists (even if not owned by this empire)
         Not Contains Building name = "BLD_IMPERIAL_PALACE"
-        
+
         // must have a non-trivial population
         TargetPopulation low = 1
-        
+
         // can't enqueue if already own a self-built palace
         Number low = 0 high = 0 condition = And [
             Building name = "BLD_IMPERIAL_PALACE"
             OwnedBy empire = Source.Owner
             ProducedByEmpire empire = Source.Owner
         ]
-        
+
         // can't enqueue if already have an enqueued palace anywhere
         Number low = 0 high = 0 condition = And [
             Planet
@@ -225,10 +225,10 @@ BuildingType
         EffectsGroup
             scope = NumberOf number = 1 condition = System
             effects = SetStealth value = Value - 1
-            
+
         EffectsGroup
-            scope = And [ 
-                Planet 
+            scope = And [
+                Planet
                 Object id = Source.PlanetID
             ]
     ]
@@ -366,7 +366,7 @@ BuildingType
         Not Contains Building name = "BLD_SHIPYARD_AST"
         Planet type = Asteroids
         OwnedBy empire = Source.Owner
-        
+
         /* TODO: Check that one, seems to be weird */
         Not Contains And [
             Building name = "BLD_SHIPYARD_AST"
@@ -595,37 +595,37 @@ BuildingType
     ]
     EnqueueLocation = [[ENQUEUE_BUILD_ONE_PER_PLANET]]
     effectsgroups = [
-	    EffectsGroup
-            scope = And [
-                PopulationCenter
-                OwnedBy empire = Source.Owner
-                ResourceSupplyConnected empire = Source.Owner condition = Source
-                Focus type = "FOCUS_INDUSTRY"
-				Construction low = 30
-            ]
-            activation = OwnerHasTech name = "PRO_INDUSTRY_CENTER_III"
-            stackinggroup = "INDUSTRY_CENTER_STACK"
-            effects = SetTargetIndustry value = Value + Target.Population * 3 * [[INDUSTRY_PER_POP]]
-			
-		EffectsGroup
-            scope = And [
-                PopulationCenter
-                OwnedBy empire = Source.Owner
-                ResourceSupplyConnected empire = Source.Owner condition = Source
-                Focus type = "FOCUS_INDUSTRY"
-				Construction low = 20
-            ]
-            activation = OwnerHasTech name = "PRO_INDUSTRY_CENTER_II"
-            stackinggroup = "INDUSTRY_CENTER_STACK"
-            effects = SetTargetIndustry value = Value + Target.Population * 2 * [[INDUSTRY_PER_POP]]
-			
         EffectsGroup
             scope = And [
                 PopulationCenter
                 OwnedBy empire = Source.Owner
                 ResourceSupplyConnected empire = Source.Owner condition = Source
                 Focus type = "FOCUS_INDUSTRY"
-				Construction low = 10
+                Construction low = 30
+            ]
+            activation = OwnerHasTech name = "PRO_INDUSTRY_CENTER_III"
+            stackinggroup = "INDUSTRY_CENTER_STACK"
+            effects = SetTargetIndustry value = Value + Target.Population * 3 * [[INDUSTRY_PER_POP]]
+
+        EffectsGroup
+            scope = And [
+                PopulationCenter
+                OwnedBy empire = Source.Owner
+                ResourceSupplyConnected empire = Source.Owner condition = Source
+                Focus type = "FOCUS_INDUSTRY"
+                Construction low = 20
+            ]
+            activation = OwnerHasTech name = "PRO_INDUSTRY_CENTER_II"
+            stackinggroup = "INDUSTRY_CENTER_STACK"
+            effects = SetTargetIndustry value = Value + Target.Population * 2 * [[INDUSTRY_PER_POP]]
+
+        EffectsGroup
+            scope = And [
+                PopulationCenter
+                OwnedBy empire = Source.Owner
+                ResourceSupplyConnected empire = Source.Owner condition = Source
+                Focus type = "FOCUS_INDUSTRY"
+                Construction low = 10
             ]
             activation = OwnerHasTech name = "PRO_INDUSTRY_CENTER_I"
             stackinggroup = "INDUSTRY_CENTER_STACK"
@@ -668,7 +668,7 @@ BuildingType
                 PopulationCenter
                 OwnedBy empire = Source.Owner
                 TargetPopulation low = 1
-				Construction low = 30
+                Construction low = 30
             ]
             activation = Source
             stackinggroup = "BLD_MEGALITH_EFFECT"
@@ -831,7 +831,7 @@ BuildingType
             effects = Destroy
     ]
     icon = "icons/specials_huge/gaia.png"
-    
+
 BuildingType
     name = "BLD_ART_BLACK_HOLE"
     description = "BLD_ART_BLACK_HOLE_DESC"
@@ -924,7 +924,7 @@ BuildingType
                 Focus type = "FOCUS_INDUSTRY"
                 OwnedBy empire = Source.Owner
                 ResourceSupplyConnected empire = Source.Owner condition = Source
-				Construction low = 30
+                Construction low = 30
             ]
             activation = Star type = [Blue White]
             stackinggroup = "BLD_SOL_ORB_GEN_EFFECT"
@@ -936,7 +936,7 @@ BuildingType
                 Focus type = "FOCUS_INDUSTRY"
                 OwnedBy empire = Source.Owner
                 ResourceSupplyConnected empire = Source.Owner condition = Source
-				Construction low = 30
+                Construction low = 30
             ]
             activation = And [
                 Star type = [Yellow Orange]
@@ -955,7 +955,7 @@ BuildingType
                 Focus type = "FOCUS_INDUSTRY"
                 OwnedBy empire = Source.Owner
                 ResourceSupplyConnected empire = Source.Owner condition = Source
-				Construction low = 30
+                Construction low = 30
             ]
             activation = And [
                 Star type = Red
@@ -1223,7 +1223,7 @@ BuildingType
             activation =  ContainedBy AND [
                 Not HasSpecial name = "CONC_CAMP_MASTER_SPECIAL"
                 Not HasSpecial name = "CONC_CAMP_SLAVE_SPECIAL"
-                Industry High = Source.Planet.TargetIndustry + 2 
+                Industry High = Source.Planet.TargetIndustry + 2
             ]
             effects = Destroy
     ]
@@ -1249,7 +1249,7 @@ BuildingType
                 Focus type = "FOCUS_INDUSTRY"
                 OwnedBy empire = Source.Owner
                 ResourceSupplyConnected empire = Source.Owner condition = Source
-				Construction low = 40
+                Construction low = 40
             ]
             activation = Star type = BlackHole
             stackinggroup = "BLD_BLACK_HOLE_POW_GEN_PRIMARY_EFFECT"
@@ -1604,7 +1604,7 @@ BuildingType
                 Focus type = "FOCUS_INDUSTRY"
                 NOT Population high = 0
                 OwnedBy empire = Source.Owner
-				Construction low = 20 
+                Construction low = 20
             ]
             stackinggroup = "GAS_GIANT_GEN_STACK"
             effects = SetTargetIndustry value = Value + 10
@@ -1714,9 +1714,9 @@ EXPERIMENTOR_SPAWN_START_TURN
 '''( [[EXPERIMENTOR_SPAWN_CALC_A]] * ((1.2 - ( GalaxyPlanetDensity / 10 ))) * ((Max(1, GalaxySize / 200))^0.4))'''
 
 EXPERIMENTOR_ADD_STARLANE
-'''AddStarlanes endpoint = NumberOf number = 1 
+'''AddStarlanes endpoint = NumberOf number = 1
                                     condition = And [
-                                        MinimumNumberOf number = 5 
+                                        MinimumNumberOf number = 5
                                                         sortkey = DirectDistanceBetween object = Source.ID
                                                                                         object = LocalCandidate.ID
                                                         condition = System
@@ -1786,7 +1786,7 @@ BuildingType
             scope = And [
                 Source
                 OwnedBy affiliation = AnyEmpire
-                Species name = "SP_EXPERIMENTOR" 
+                Species name = "SP_EXPERIMENTOR"
             ]
             effects = [
                 Victory reason = "VICTORY_EXPERIMENTOR_CAPTURE"
@@ -2026,7 +2026,7 @@ BuildingType
         EffectsGroup            // remove population from location
             scope = And [
                 Object id = Source.PlanetID
-                Planet            
+                Planet
             ]
             activation = ContainedBy And [
                 PopulationCenter
@@ -2074,7 +2074,7 @@ BuildingType
             SetSpecies name = "SP_SUPER_TEST"
             SetPopulation value = max(Target.Population, 1)
         ]
-        
+
         EffectsGroup            // remove building when done
             scope = Source
             activation = Species name = "SP_SUPER_TEST"

--- a/default/buildings.txt
+++ b/default/buildings.txt
@@ -595,37 +595,37 @@ BuildingType
     ]
     EnqueueLocation = [[ENQUEUE_BUILD_ONE_PER_PLANET]]
     effectsgroups = [
-	    EffectsGroup
-            scope = And [
-                PopulationCenter
-                OwnedBy empire = Source.Owner
-                ResourceSupplyConnected empire = Source.Owner condition = Source
-                Focus type = "FOCUS_INDUSTRY"
-				Construction low = 30
-            ]
-            activation = OwnerHasTech name = "PRO_INDUSTRY_CENTER_III"
-            stackinggroup = "INDUSTRY_CENTER_STACK"
-            effects = SetTargetIndustry value = Value + Target.Population * 3 * [[INDUSTRY_PER_POP]]
-			
-		EffectsGroup
-            scope = And [
-                PopulationCenter
-                OwnedBy empire = Source.Owner
-                ResourceSupplyConnected empire = Source.Owner condition = Source
-                Focus type = "FOCUS_INDUSTRY"
-				Construction low = 20
-            ]
-            activation = OwnerHasTech name = "PRO_INDUSTRY_CENTER_II"
-            stackinggroup = "INDUSTRY_CENTER_STACK"
-            effects = SetTargetIndustry value = Value + Target.Population * 2 * [[INDUSTRY_PER_POP]]
-			
         EffectsGroup
             scope = And [
                 PopulationCenter
                 OwnedBy empire = Source.Owner
                 ResourceSupplyConnected empire = Source.Owner condition = Source
                 Focus type = "FOCUS_INDUSTRY"
-				Construction low = 10
+                Construction low = 30
+            ]
+            activation = OwnerHasTech name = "PRO_INDUSTRY_CENTER_III"
+            stackinggroup = "INDUSTRY_CENTER_STACK"
+            effects = SetTargetIndustry value = Value + Target.Population * 3 * [[INDUSTRY_PER_POP]]
+            
+        EffectsGroup
+            scope = And [
+                PopulationCenter
+                OwnedBy empire = Source.Owner
+                ResourceSupplyConnected empire = Source.Owner condition = Source
+                Focus type = "FOCUS_INDUSTRY"
+                Construction low = 20
+            ]
+            activation = OwnerHasTech name = "PRO_INDUSTRY_CENTER_II"
+            stackinggroup = "INDUSTRY_CENTER_STACK"
+            effects = SetTargetIndustry value = Value + Target.Population * 2 * [[INDUSTRY_PER_POP]]
+            
+        EffectsGroup
+            scope = And [
+                PopulationCenter
+                OwnedBy empire = Source.Owner
+                ResourceSupplyConnected empire = Source.Owner condition = Source
+                Focus type = "FOCUS_INDUSTRY"
+                Construction low = 10
             ]
             activation = OwnerHasTech name = "PRO_INDUSTRY_CENTER_I"
             stackinggroup = "INDUSTRY_CENTER_STACK"
@@ -668,7 +668,7 @@ BuildingType
                 PopulationCenter
                 OwnedBy empire = Source.Owner
                 TargetPopulation low = 1
-				Construction low = 30
+                Construction low = 30
             ]
             activation = Source
             stackinggroup = "BLD_MEGALITH_EFFECT"
@@ -924,7 +924,7 @@ BuildingType
                 Focus type = "FOCUS_INDUSTRY"
                 OwnedBy empire = Source.Owner
                 ResourceSupplyConnected empire = Source.Owner condition = Source
-				Construction low = 30
+                Construction low = 30
             ]
             activation = Star type = [Blue White]
             stackinggroup = "BLD_SOL_ORB_GEN_EFFECT"
@@ -936,7 +936,7 @@ BuildingType
                 Focus type = "FOCUS_INDUSTRY"
                 OwnedBy empire = Source.Owner
                 ResourceSupplyConnected empire = Source.Owner condition = Source
-				Construction low = 30
+                Construction low = 30
             ]
             activation = And [
                 Star type = [Yellow Orange]
@@ -955,7 +955,7 @@ BuildingType
                 Focus type = "FOCUS_INDUSTRY"
                 OwnedBy empire = Source.Owner
                 ResourceSupplyConnected empire = Source.Owner condition = Source
-				Construction low = 30
+                Construction low = 30
             ]
             activation = And [
                 Star type = Red
@@ -1249,7 +1249,7 @@ BuildingType
                 Focus type = "FOCUS_INDUSTRY"
                 OwnedBy empire = Source.Owner
                 ResourceSupplyConnected empire = Source.Owner condition = Source
-				Construction low = 40
+                Construction low = 40
             ]
             activation = Star type = BlackHole
             stackinggroup = "BLD_BLACK_HOLE_POW_GEN_PRIMARY_EFFECT"
@@ -1604,7 +1604,7 @@ BuildingType
                 Focus type = "FOCUS_INDUSTRY"
                 NOT Population high = 0
                 OwnedBy empire = Source.Owner
-				Construction low = 20 
+                Construction low = 20 
             ]
             stackinggroup = "GAS_GIANT_GEN_STACK"
             effects = SetTargetIndustry value = Value + 10

--- a/default/buildings.txt
+++ b/default/buildings.txt
@@ -67,7 +67,7 @@ BuildingType
                 SetTargetIndustry value = Value + Target.Population / 2
                 //SetDetection value = Value + 10000
             ]
-
+            
         EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
@@ -75,14 +75,14 @@ BuildingType
                 OwnedBy empire = Source.Owner
                 Not HasSpecial name = "HEAD_ON_A_SPIKE_SPECIAL"
             ]
-            activation = Not ProducedByEmpire empire = Source.Owner
+            activation = Not ProducedByEmpire empire = Source.Owner                
             effects = [
                 AddSpecial name = "HEAD_ON_A_SPIKE_SPECIAL"
                 GenerateSitRepMessage
                     message = "HEAD_ON_A_SPIKE_MESSAGE"
                     icon = "icons/sitrep/empire_eliminated.png"
                     parameters = [
-                        tag = "empire" data = Source.ProducedByEmpireID
+                        tag = "empire" data = Source.ProducedByEmpireID                        
                     ]
             ]
     ]
@@ -134,20 +134,20 @@ BuildingType
         // must own production location planet
         Planet
         OwnedBy empire = Source.Owner
-
+        
         // can't build where another palace exists (even if not owned by this empire)
         Not Contains Building name = "BLD_IMPERIAL_PALACE"
-
+        
         // must have a non-trivial population
         TargetPopulation low = 1
-
+        
         // can't enqueue if already own a self-built palace
         Number low = 0 high = 0 condition = And [
             Building name = "BLD_IMPERIAL_PALACE"
             OwnedBy empire = Source.Owner
             ProducedByEmpire empire = Source.Owner
         ]
-
+        
         // can't enqueue if already have an enqueued palace anywhere
         Number low = 0 high = 0 condition = And [
             Planet
@@ -225,10 +225,10 @@ BuildingType
         EffectsGroup
             scope = NumberOf number = 1 condition = System
             effects = SetStealth value = Value - 1
-
+            
         EffectsGroup
-            scope = And [
-                Planet
+            scope = And [ 
+                Planet 
                 Object id = Source.PlanetID
             ]
     ]
@@ -366,7 +366,7 @@ BuildingType
         Not Contains Building name = "BLD_SHIPYARD_AST"
         Planet type = Asteroids
         OwnedBy empire = Source.Owner
-
+        
         /* TODO: Check that one, seems to be weird */
         Not Contains And [
             Building name = "BLD_SHIPYARD_AST"
@@ -595,37 +595,37 @@ BuildingType
     ]
     EnqueueLocation = [[ENQUEUE_BUILD_ONE_PER_PLANET]]
     effectsgroups = [
-        EffectsGroup
+	    EffectsGroup
             scope = And [
                 PopulationCenter
                 OwnedBy empire = Source.Owner
                 ResourceSupplyConnected empire = Source.Owner condition = Source
                 Focus type = "FOCUS_INDUSTRY"
-                Construction low = 30
+				Construction low = 30
             ]
             activation = OwnerHasTech name = "PRO_INDUSTRY_CENTER_III"
             stackinggroup = "INDUSTRY_CENTER_STACK"
             effects = SetTargetIndustry value = Value + Target.Population * 3 * [[INDUSTRY_PER_POP]]
-
-        EffectsGroup
+			
+		EffectsGroup
             scope = And [
                 PopulationCenter
                 OwnedBy empire = Source.Owner
                 ResourceSupplyConnected empire = Source.Owner condition = Source
                 Focus type = "FOCUS_INDUSTRY"
-                Construction low = 20
+				Construction low = 20
             ]
             activation = OwnerHasTech name = "PRO_INDUSTRY_CENTER_II"
             stackinggroup = "INDUSTRY_CENTER_STACK"
             effects = SetTargetIndustry value = Value + Target.Population * 2 * [[INDUSTRY_PER_POP]]
-
+			
         EffectsGroup
             scope = And [
                 PopulationCenter
                 OwnedBy empire = Source.Owner
                 ResourceSupplyConnected empire = Source.Owner condition = Source
                 Focus type = "FOCUS_INDUSTRY"
-                Construction low = 10
+				Construction low = 10
             ]
             activation = OwnerHasTech name = "PRO_INDUSTRY_CENTER_I"
             stackinggroup = "INDUSTRY_CENTER_STACK"
@@ -668,7 +668,7 @@ BuildingType
                 PopulationCenter
                 OwnedBy empire = Source.Owner
                 TargetPopulation low = 1
-                Construction low = 30
+				Construction low = 30
             ]
             activation = Source
             stackinggroup = "BLD_MEGALITH_EFFECT"
@@ -831,7 +831,7 @@ BuildingType
             effects = Destroy
     ]
     icon = "icons/specials_huge/gaia.png"
-
+    
 BuildingType
     name = "BLD_ART_BLACK_HOLE"
     description = "BLD_ART_BLACK_HOLE_DESC"
@@ -924,7 +924,7 @@ BuildingType
                 Focus type = "FOCUS_INDUSTRY"
                 OwnedBy empire = Source.Owner
                 ResourceSupplyConnected empire = Source.Owner condition = Source
-                Construction low = 30
+				Construction low = 30
             ]
             activation = Star type = [Blue White]
             stackinggroup = "BLD_SOL_ORB_GEN_EFFECT"
@@ -936,7 +936,7 @@ BuildingType
                 Focus type = "FOCUS_INDUSTRY"
                 OwnedBy empire = Source.Owner
                 ResourceSupplyConnected empire = Source.Owner condition = Source
-                Construction low = 30
+				Construction low = 30
             ]
             activation = And [
                 Star type = [Yellow Orange]
@@ -955,7 +955,7 @@ BuildingType
                 Focus type = "FOCUS_INDUSTRY"
                 OwnedBy empire = Source.Owner
                 ResourceSupplyConnected empire = Source.Owner condition = Source
-                Construction low = 30
+				Construction low = 30
             ]
             activation = And [
                 Star type = Red
@@ -1223,7 +1223,7 @@ BuildingType
             activation =  ContainedBy AND [
                 Not HasSpecial name = "CONC_CAMP_MASTER_SPECIAL"
                 Not HasSpecial name = "CONC_CAMP_SLAVE_SPECIAL"
-                Industry High = Source.Planet.TargetIndustry + 2
+                Industry High = Source.Planet.TargetIndustry + 2 
             ]
             effects = Destroy
     ]
@@ -1249,7 +1249,7 @@ BuildingType
                 Focus type = "FOCUS_INDUSTRY"
                 OwnedBy empire = Source.Owner
                 ResourceSupplyConnected empire = Source.Owner condition = Source
-                Construction low = 40
+				Construction low = 40
             ]
             activation = Star type = BlackHole
             stackinggroup = "BLD_BLACK_HOLE_POW_GEN_PRIMARY_EFFECT"
@@ -1604,7 +1604,7 @@ BuildingType
                 Focus type = "FOCUS_INDUSTRY"
                 NOT Population high = 0
                 OwnedBy empire = Source.Owner
-                Construction low = 20
+				Construction low = 20 
             ]
             stackinggroup = "GAS_GIANT_GEN_STACK"
             effects = SetTargetIndustry value = Value + 10
@@ -1714,9 +1714,9 @@ EXPERIMENTOR_SPAWN_START_TURN
 '''( [[EXPERIMENTOR_SPAWN_CALC_A]] * ((1.2 - ( GalaxyPlanetDensity / 10 ))) * ((Max(1, GalaxySize / 200))^0.4))'''
 
 EXPERIMENTOR_ADD_STARLANE
-'''AddStarlanes endpoint = NumberOf number = 1
+'''AddStarlanes endpoint = NumberOf number = 1 
                                     condition = And [
-                                        MinimumNumberOf number = 5
+                                        MinimumNumberOf number = 5 
                                                         sortkey = DirectDistanceBetween object = Source.ID
                                                                                         object = LocalCandidate.ID
                                                         condition = System
@@ -1786,7 +1786,7 @@ BuildingType
             scope = And [
                 Source
                 OwnedBy affiliation = AnyEmpire
-                Species name = "SP_EXPERIMENTOR"
+                Species name = "SP_EXPERIMENTOR" 
             ]
             effects = [
                 Victory reason = "VICTORY_EXPERIMENTOR_CAPTURE"
@@ -2026,7 +2026,7 @@ BuildingType
         EffectsGroup            // remove population from location
             scope = And [
                 Object id = Source.PlanetID
-                Planet
+                Planet            
             ]
             activation = ContainedBy And [
                 PopulationCenter
@@ -2074,7 +2074,7 @@ BuildingType
             SetSpecies name = "SP_SUPER_TEST"
             SetPopulation value = max(Target.Population, 1)
         ]
-
+        
         EffectsGroup            // remove building when done
             scope = Source
             activation = Species name = "SP_SUPER_TEST"

--- a/default/specials.txt
+++ b/default/specials.txt
@@ -1313,7 +1313,7 @@ Special
                 Ship
             ]
             effects = [
-                SetDetection value = Min(Target.Construction / 30, 1) * Value + 60
+                SetDetection value = Value + 60
                 RemoveSpecial name = "DERELICT_SPECIAL2"
             ]
 

--- a/default/specials.txt
+++ b/default/specials.txt
@@ -339,7 +339,7 @@ Special
             scope = Source
             activation = OwnedBy affiliation = AnyEmpire
             effects = [
-                SetDetection value = Value + 75
+                SetDetection value = Value + Min(Target.Construction / 30, 1) * 75
                 SetEmpireMeter empire = Source.Owner meter = "METER_DETECTION_STRENGTH" value = Value + 10
             ]
         EffectsGroup
@@ -580,6 +580,7 @@ Special
                 Planet
                 Focus type = "FOCUS_RESEARCH"
                 OwnedBy empire = Source.Owner
+                Construction low = 10
             ]
             activation = Focus type = "FOCUS_RESEARCH"
             stackinggroup = "COMPUTRONIUM_STACK"
@@ -660,6 +661,7 @@ Special
                 Focus type = "FOCUS_INDUSTRY"
                 OwnedBy empire = Source.Owner
                 ResourceSupplyConnected empire = Source.Owner condition = Source
+                Construction low = 10
             ]
             activation = Focus type = "FOCUS_INDUSTRY"
             stackinggroup = "HONEYCOMB_STACK"
@@ -1311,7 +1313,7 @@ Special
                 Ship
             ]
             effects = [
-                SetDetection value = Value + 60
+                SetDetection value = Min(Target.Construction / 30, 1) * Value + 60
                 RemoveSpecial name = "DERELICT_SPECIAL2"
             ]
 

--- a/default/species.txt
+++ b/default/species.txt
@@ -2169,7 +2169,7 @@ STANDARD_CONSTRUCTION
             scope = Source
             activation = Planet
             accountinglabel = "STANDARD_CONSTRUCTION_LABEL"
-            effects = SetTargetConstruction value = Value + 20
+            effects = SetTargetConstruction value = Value + 30
 '''
 
 NO_SUPPLY
@@ -2521,6 +2521,7 @@ GRO_HAB_MODIFIER
             activation = And [
                 Planet
                 OwnerHasTech name = "GRO_SUBTER_HAB"
+                Construction low = 10 
                 //TargetPopulation low = 0
             ]
             accountinglabel = "GRO_SUBTER_HAB"
@@ -2573,6 +2574,7 @@ POPULATION_TECHS
             activation = AND [
                 Planet
                 OwnerHasTech name = "CON_NDIM_STRC"
+                Construction low = 50 
                 //TargetPopulation low = 0
             ]
             accountinglabel = "NDIM_STRC_LABEL"
@@ -2584,6 +2586,7 @@ POPULATION_TECHS
             activation = AND [
                 Planet
                 OwnerHasTech name = "CON_ORBITAL_HAB"
+                Construction low = 20 
                 //TargetPopulation low = 0
             ]
             accountinglabel = "ORBITAL_HAB_LABEL"
@@ -2808,14 +2811,14 @@ ADVANCED_FOCUS_EFFECTS
                         OwnedBy empire = Source.Owner
                     ]
                 ]
-            	GenerateSitRepMessage
-            		message = "EFFECT_PLANET_DRIVE"
+                GenerateSitRepMessage
+                    message = "EFFECT_PLANET_DRIVE"
                     icon = "icons/focus/planet_drive.png"
-            		parameters = [
-            			tag = "planet" data = Source.ID
-            			tag = "system" data = Source.SystemID
-            		]
-            		empire = Source.Owner
+                    parameters = [
+                        tag = "planet" data = Source.ID
+                        tag = "system" data = Source.SystemID
+                    ]
+                    empire = Source.Owner
                 SetPopulation value = Value / 2
             ]
 
@@ -2829,15 +2832,15 @@ ADVANCED_FOCUS_EFFECTS
                 Not WithinDistance distance = 200 condition = Building name = "BLD_LIGHTHOUSE"
             ]
             effects = [
-            	GenerateSitRepMessage
-            		message = "SITREP_PLANET_DRIVE_FAILURE"
+                GenerateSitRepMessage
+                    message = "SITREP_PLANET_DRIVE_FAILURE"
                     icon = "icons/sitrep/colony_destroyed.png"
-            		parameters = [
-            			tag = "planet" data = Source.ID
-            			tag = "system" data = Source.SystemID
-            		]
-            		empire = Source.Owner
-            	Destroy
+                    parameters = [
+                        tag = "planet" data = Source.ID
+                        tag = "system" data = Source.SystemID
+                    ]
+                    empire = Source.Owner
+                Destroy
             ]
 
         EffectsGroup

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -7485,7 +7485,7 @@ CON_FRC_ENRG_STRC
 Force-Energy Structures
 
 CON_FRC_ENRG_STRC_DESC
-'''Increases the growth of resource meters below target value to 3 per turn, and the decay of resource meters above target value to 5 per turn. Require the planet to have at least 30 [[encyclopedia INFRASTRUCTURE_TITLE]].
+'''Increases the growth of resource meters below target value to 3 per turn, and the decay of resource meters above target value to 5 per turn.
 
 The flexibility and versatility of force-energy structures permits a colonies buildings to be more easily re-tooled to suit new purposes, increasing the rate at which focus changes can take effect.
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -5627,14 +5627,14 @@ This planet has a natural satellite, the orbital period of which is in 1:1 reson
 COMPUTRONIUM_SPECIAL
 Computronium Moon
 COMPUTRONIUM_SPECIAL_DESC
-'''When a planet with a Computronium Moon is focused on [[encyclopedia RESEARCH_TITLE]], all research focused planets in the empire gain 0.2 [[encyclopedia RESEARCH_TITLE]] per Population.
+'''When a planet with a Computronium Moon is focused on [[encyclopedia RESEARCH_TITLE]], all research focused planets with at least 10 [[encyclopedia INFRASTRUCTURE_TITLE]] in the empire gain 0.2 [[encyclopedia RESEARCH_TITLE]] per Population.
 
 Left by some vanished civilization, the entire moon - from surface to core - is a computing device of awesome power. It can complete the most complicated simulations and equations faster than they can be entered.'''
 
 HONEYCOMB_SPECIAL
 Honeycomb
 HONEYCOMB_SPECIAL_DESC
-'''When a planet with a Honeycomb is focused on [[encyclopedia INDUSTRY_TITLE]], all industry focused [[encyclopedia SUPPLY_TITLE]] connected planets gain 0.5 [[encyclopedia INDUSTRY_TITLE]] per Population.
+'''When a planet with a Honeycomb is focused on [[encyclopedia INDUSTRY_TITLE]], all industry focused [[encyclopedia SUPPLY_TITLE]] connected planets with at least 10 [[encyclopedia INFRASTRUCTURE_TITLE]] gain 0.5 [[encyclopedia INDUSTRY_TITLE]] per Population.
 
 The Honeycomb is a planet that was prepared as a stash by the Builders in ancient times. Almost all other planets in surrounding systems were stripped of valuable materials and then dismantled. The materials were sorted and stored separately in gigantic tubes embedded into the planets crust. The sprectrum ranges from rare and valuable elementals to hard to produce molecules and a vast array of energy sources. What the Builders wanted to create with this treasure or why they didn't use it in the end, is unclear.'''
 
@@ -7142,7 +7142,7 @@ LRN_ARTIF_MINDS
 Nascent Artificial Intelligence
 
 LRN_ARTIF_MINDS_DESC
-'''Increases Target [[encyclopedia RESEARCH_TITLE]] on all planets by 2.
+'''Increases Target [[encyclopedia RESEARCH_TITLE]] on all planets by 2. Requires the planet to have at least 10 [[encyclopedia INFRASTRUCTURE_TITLE]].
 
 While traditional computers have nearly unfathomable intelligence and computational abilities, they lack the essential qualities of self-awareness, consciousness or sentience. While these traits remain elusive, reasonable facsimiles may be produced. These investigations open new avenues of research into cognitive sciences and novel metaparadigms.
 
@@ -7211,7 +7211,7 @@ LRN_QUANT_NET
 Quantum Networking
 
 LRN_QUANT_NET_DESC
-'''Increases target [[encyclopedia RESEARCH_TITLE]] on all planets with the Research focus by 0.5 per Population.
+'''Increases target [[encyclopedia RESEARCH_TITLE]] on all planets with the Research focus by 0.5 per Population. Require the planet to have at least 20 [[encyclopedia INFRASTRUCTURE_TITLE]].
 
 A massive, empire-wide data network able to transfer information instantaneously between any two places, rather than via the lengthy and indirect path of starlanes. This advancement greatly facilitates research throughout the empire.
 
@@ -7344,7 +7344,7 @@ PRO_MICROGRAV_MAN
 Microgravity Industry
 
 PRO_MICROGRAV_MAN_DESC
-'''Increases [[encyclopedia INDUSTRY_TITLE]] by +5 on all Industry-focused colonies in system with an asteroid belt outposts or colonies. Additional claimed asteroid belts do not provide additional benefit.
+'''Increases [[encyclopedia INDUSTRY_TITLE]] by +5 on all Industry-focused colonies in system with an asteroid belt outposts or colonies. Additional claimed asteroid belts do not provide additional benefit. Require the planet to have at least 10 [[encyclopedia INFRASTRUCTURE_TITLE]].
 
 Mineral resource extraction from sub-planetoid-sized bodies involves challenges and provides opportunities quite distinct from those of full-fledged planets. Lacking sufficient mass to self-liquefy and differentiate, asteroids can provide much easier access to some heavier elements, and lack of a gravity can make extraction for use in space much more efficient. Conversely, the limited size of each source asteroid requires fully portable self-sufficient extraction facilities. As well, the challenges of any microgravity environment must be overcome, requiring redesign of many traditional methods.
 
@@ -7364,7 +7364,7 @@ PRO_ROBOTIC_PROD
 Robotic Production
 
 PRO_ROBOTIC_PROD_DESC
-'''Increases target [[encyclopedia INDUSTRY_TITLE]] on all planets with the Industry focus by 0.1 per Population.
+'''Increases target [[encyclopedia INDUSTRY_TITLE]] on all planets with the Industry focus by 0.1 per Population. Require the planet to have at least 10 [[encyclopedia INFRASTRUCTURE_TITLE]].
 
 Exobots, as they become commonly known, are a marvel of form meets function. They are robots designed to fulfill nearly any manufacturing job, in fields as wide ranging as electronics to large-scale construction. Easily mass produced, they serve best on colonies that place a high priority on industry. Every world focused primarily on industry receives a team of Exobots, greatly increasing industrial production.
 
@@ -7385,7 +7385,7 @@ PRO_FUSION_GEN
 Fusion Generation
 
 PRO_FUSION_GEN_DESC
-'''Increases target [[encyclopedia INDUSTRY_TITLE]] on planets with the Industry focus by 0.2 per Population.
+'''Increases target [[encyclopedia INDUSTRY_TITLE]] on planets with the Industry focus by 0.2 per Population. Require the planet to have at least 10 [[encyclopedia INFRASTRUCTURE_TITLE]].
 
 Fusion plants, while expensive to produce and maintain, easily pay for themselves on industrialized worlds with ever increasing power demands. Reliance on old fission based nuclear plants will gradually become a thing of the past.
 
@@ -7409,7 +7409,7 @@ PRO_SENTIENT_AUTOMATION
 Adaptive Automation
 
 PRO_SENTIENT_AUTOMATION_DESC
-'''Increases target [[encyclopedia INDUSTRY_TITLE]] on all planets by 5.
+'''Increases target [[encyclopedia INDUSTRY_TITLE]] on all planets by 5. Require the planet to have at least 20 [[encyclopedia INFRASTRUCTURE_TITLE]].
 
 By producing automated factories that operate without direct supervision, it is possible to increase industrial output in an entirely automated facility. These factories can be built and maintained on any planet, regardless of focus, providing a bonus to industry on all worlds.
 
@@ -7433,7 +7433,9 @@ PRO_SINGULAR_GEN
 Singularity Generation
 
 PRO_SINGULAR_GEN_DESC
-'''Harnessing energy from a black hole is significantly more dangerous than harnessing energy from a regular star, but also has potential for significantly greater gains. By building a generator designed to tap into the energy of particle-antiparticle collisions on the event horizon of a singularity, tremendous benefits to industry may be obtained.
+'''Increase planet target infrastructure by 10, not stackable with [[tech CON_NDIM_STRC]].
+
+Harnessing energy from a black hole is significantly more dangerous than harnessing energy from a regular star, but also has potential for significantly greater gains. By building a generator designed to tap into the energy of particle-antiparticle collisions on the event horizon of a singularity, tremendous benefits to industry may be obtained.
 
 As matter is drawn towards a singularity by the intense space-time curvature, or gravitational field, the matter forms a greatly compressed and heated accretion disc. High energy radiation emitted from the disc may be captured and harnessed for power generation. The event horizon of the singularity itself also emits radiation due to the annihilation of virtual particle-antiparticle pairs that form in its vicinity. This method of power generation is significantly more delicate and unstable than the accretion disc method, but can produce an even greater output.'''
 
@@ -7483,7 +7485,7 @@ CON_FRC_ENRG_STRC
 Force-Energy Structures
 
 CON_FRC_ENRG_STRC_DESC
-'''Increases the growth of resource meters below target value to 3 per turn, and the decay of resource meters above target value to 5 per turn.
+'''Increases the growth of resource meters below target value to 3 per turn, and the decay of resource meters above target value to 5 per turn. Require the planet to have at least 30 [[encyclopedia INFRASTRUCTURE_TITLE]].
 
 The flexibility and versatility of force-energy structures permits a colonies buildings to be more easily re-tooled to suit new purposes, increasing the rate at which focus changes can take effect.
 
@@ -7493,7 +7495,7 @@ CON_CONTGRAV_ARCH
 Gravitic Architecture
 
 CON_CONTGRAV_ARCH_DESC
-'''Increases the [[encyclopedia SUPPLY_TITLE]] line range of all colonies and outposts by 1.
+'''Increases the [[encyclopedia SUPPLY_TITLE]] line range of all colonies by 1. Require the planet to have at least 20 [[encyclopedia INFRASTRUCTURE_TITLE]].
 
 By installing a massive null gravity generator at a planet's core, it becomes possible to turn a planet's gravity on or off like a light switch, but in a narrow well. The planet's industry then gains all the benefits of low-G and zero-G, but without the drawbacks. Reverse gravity wells can also be created, making space launches cost practically nothing.
 
@@ -7527,13 +7529,13 @@ CON_ORBITAL_HAB
 Orbital Habitation
 
 CON_ORBITAL_HAB_DESC
-Increases Population capacity by planet size on all habitable planets; Tiny: +1, Small: +2, Medium: +3, Large: +4, Huge: +5.
+Increases Population capacity by planet size on all habitable planets; Tiny: +1, Small: +2, Medium: +3, Large: +4, Huge: +5. Require the planet to have at least 20 [[encyclopedia INFRASTRUCTURE_TITLE]].
 
 CON_NDIM_STRC
 N-Dimensional Structures
 
 CON_NDIM_STRC_DESC
-'''Increases Population capacity by planet size on all habitable planets; Tiny: +2, Small: +4, Medium: +6, Large: +8, Huge: +10. Also increases target [[encyclopedia INFRASTRUCTURE_TITLE]] by 10 on populated.
+'''Increases Population capacity by planet size on all habitable planets; Tiny: +2, Small: +4, Medium: +6, Large: +8, Huge: +10. Also increases target [[encyclopedia INFRASTRUCTURE_TITLE]] by 20 on populated, superceding bonus given by [[tech PRO_SINGULAR_GEN]]. Require the planet to have at least 50 [[encyclopedia INFRASTRUCTURE_TITLE]].
 
 The primary limiting factors on a planets population capacity are environmental desirability and space. By phasing basic infrastructure development into multiple dimensions, spatial limitations are all but eliminated, and under ideal environmental conditions, the maximum population of a planet can be greatly increased.
 
@@ -7816,7 +7818,7 @@ CON_ORBITAL_CON
 Orbital Construction
 
 CON_ORBITAL_CON_DESC
-'''Increases the [[encyclopedia SUPPLY_TITLE]] line range of all colonies and outposts by 1.
+'''Increases the [[encyclopedia SUPPLY_TITLE]] line range of all colonies by 1. Require the planet to have at least 10 [[encyclopedia INFRASTRUCTURE_TITLE]].
 
 On a planet, there is always a fixed reference direction: "up". Microgravity is effectively isotropic. This single difference has a multitude of consequences for the types of structures that can be built, and which of those forms is the optimal use of space, materials and energy in each environment. As well, the interior configuration of spaces in orbit must be rethought. However, while it is appealing to attempt to completely revolutionize interior design in a paradigm completely independent of the styles used on planet surfaces, the practical use of these spaces will be initial primarily by those who are used to, and adapted for, those planet surfaces. Rather than a complete break from older styles, a gradual transition may be more effective.'''
 
@@ -7864,7 +7866,7 @@ GRO_SUBTER_HAB
 Subterranean Habitation
 
 GRO_SUBTER_HAB_DESC
-Increases the max population on all planets by planet size; Tiny: +1, Small: +2, Medium: +3, Large: +4, Huge: +5.
+Increases the max population on all planets by planet size; Tiny: +1, Small: +2, Medium: +3, Large: +4, Huge: +5. Require the planet to have at least 10 [[encyclopedia INFRASTRUCTURE_TITLE]].
 
 GRO_GENOME_BANK
 Genome Bank
@@ -7935,7 +7937,7 @@ LRN_DISTRIB_THOUGHT
 Distributed Thought Computing
 
 LRN_DISTRIB_THOUGHT_DESC
-'''Increases target [[encyclopedia RESEARCH_TITLE]] on all planets with any focus by 0.1 per Population.
+'''Increases target [[encyclopedia RESEARCH_TITLE]] on all planets with any focus by 0.1 per Population. Require the planet to have at least 10 [[encyclopedia INFRASTRUCTURE_TITLE]].
 
 The average citizen literally wastes his mind away, one of the finest computing devices in the universe. By tapping into the idle brain cycles of a sufficiently large population through a network of simple cybernetic transceivers, the research centers of a world can gain access to cheap and plentiful raw computing power.'''
 
@@ -7943,7 +7945,7 @@ LRN_STELLAR_TOMOGRAPHY
 Stellar Tomography
 
 LRN_STELLAR_TOMOGRAPHY_DESC
-'''Increases target [[encyclopedia RESEARCH_TITLE]] on planets with the Research focus per Population by 1, 0.75, 0.5, or 0.2 in systems with Black Hole stars, Neutron stars, Blue or white stars, and Yellow, Orange or Red stars, respectively.
+'''Increases target [[encyclopedia RESEARCH_TITLE]] on planets with the Research focus per Population by 1, 0.75, 0.5, or 0.2 in systems with Black Hole stars, Neutron stars, Blue or white stars, and Yellow, Orange or Red stars, respectively. Require the planet to have at least 30 [[encyclopedia INFRASTRUCTURE_TITLE]].
 
 A network of specialized satellites can use tomographic methods to reconstruct the activities occurring deep within a star. These otherwise costly-to-produce conditions are ideal for a variety of research endeavors, with larger benefits for more exotic star types.'''
 
@@ -7975,7 +7977,7 @@ LRN_PSY_DOM
 Psychogenic Domination
 
 LRN_PSY_DOM_DESC
-'''Has a 10% chance of taking control of enemy ships with non-telepathic crews in the same system as a planet with domination focus, unless the enemy empire also knows the [[tech LRN_PSY_DOM]].
+'''Has a 10% chance of taking control of enemy ships with non-telepathic crews in the same system as a planet with domination focus, unless the enemy empire also knows the [[tech LRN_PSY_DOM]]. Require the planet to have at least 30 [[encyclopedia INFRASTRUCTURE_TITLE]].
 
 It is difficult to force a conscious individual to submit to the total mental control of another entity against its will. By manipulating the timeframes involved however, the mental force exerted by a population over a period of hours may be brought to bear on a single individual in the span of a few seconds, creating an almost irresistible compulsion to join the unified mind.'''
 
@@ -8793,18 +8795,18 @@ BLD_INDUSTRY_CENTER
 Industrial Center
 
 BLD_INDUSTRY_CENTER_DESC
-'''Initially provides a bonus to [[encyclopedia INDUSTRY_TITLE]] on all [[encyclopedia SUPPLY_TITLE]] line connected planets with Industry focus by 0.2 per Population.
+'''Initially provides a bonus to [[encyclopedia INDUSTRY_TITLE]] on all [[encyclopedia SUPPLY_TITLE]] line connected planets with Industry focus by 0.2 per Population. Require the planet to have at least 10 [[encyclopedia INFRASTRUCTURE_TITLE]].
 [[NO_STACK_SUPPLY_CONNECTION_TEXT]]
 
-[[tech PRO_INDUSTRY_CENTER_II]] refinement doubles the bonus.
+[[tech PRO_INDUSTRY_CENTER_II]] refinement doubles the bonus, if the planet has at least 20 [[encyclopedia INFRASTRUCTURE_TITLE]].
 
-[[tech PRO_INDUSTRY_CENTER_III]] refinement further increases the bonus to triple the base bonus.'''
+[[tech PRO_INDUSTRY_CENTER_III]] refinement further increases the bonus to triple the base bonus, if the planet has at least 30 [[encyclopedia INFRASTRUCTURE_TITLE]].'''
 
 BLD_MEGALITH
 Megalith
 
 BLD_MEGALITH_DESC
-'''This building may only be built in the owner empire's capital, where it further adds to the splendor of the [[buildingtype BLD_IMPERIAL_PALACE]]. All resource meters for the planet on which it is built are able to reach target in a single turn. This planet also receives an increase of 30 to [[encyclopedia INFRASTRUCTURE_TITLE]]. Populated planets in the owning empire receive an increase of 1 to [[encyclopedia SUPPLY_TITLE]] line range. Populated planets within two starlane jumps have their [[encyclopedia TROOP_TITLE]] increased by 10.
+'''This building may only be built in the owner empire's capital, where it further adds to the splendor of the [[buildingtype BLD_IMPERIAL_PALACE]]. All resource meters for the planet on which it is built are able to reach target in a single turn. This planet also receives an increase of 30 to [[encyclopedia INFRASTRUCTURE_TITLE]]. Populated planets in the owning empire receive an increase of 1 to [[encyclopedia SUPPLY_TITLE]] line range if the planet has at least 30 [[encyclopedia INFRASTRUCTURE_TITLE]]. Populated planets within two starlane jumps have their [[encyclopedia TROOP_TITLE]] increased by 10.
 
 The Megalith is an abnormally massive starscraper, kilometers in diameter, and an inspiration to architects empire-wide.'''
 
@@ -8889,7 +8891,7 @@ BLD_SOL_ORB_GEN
 Solar Orbital Generator
 
 BLD_SOL_ORB_GEN_DESC
-'''Increases target [[encyclopedia INDUSTRY_TITLE]] on [[encyclopedia SUPPLY_TITLE]] line connected planets by 0.4, 0.2 or 0.1 per Population when built in systems with Blue/White, Yellow/Orange, or Red stars, respectively.
+'''Increases target [[encyclopedia INDUSTRY_TITLE]] on [[encyclopedia SUPPLY_TITLE]] line connected planets by 0.4, 0.2 or 0.1 per Population when built in systems with Blue/White, Yellow/Orange, or Red stars, respectively, if the planet has at least 30 [[encyclopedia INFRASTRUCTURE_TITLE]].
 [[NO_STACK_SUPPLY_CONNECTION_TEXT]] The best bonus applies.
 
 A power generator in low solar orbit designed to tap directly into the star's energy. Since different star types produce different amounts of energy, the system-wide industry bonus is dependent on star type. This building can be built at an [[encyclopedia OUTPOSTS_TITLE]].'''
@@ -8965,7 +8967,7 @@ BLD_BLACK_HOLE_POW_GEN
 Black Hole Power Generator
 
 BLD_BLACK_HOLE_POW_GEN_DESC
-'''Increases [[encyclopedia INDUSTRY_TITLE]] on all [[encyclopedia SUPPLY_TITLE]] line connected planets with the Industry focus by 1.2 per Population. 
+'''Increases [[encyclopedia INDUSTRY_TITLE]] on all [[encyclopedia SUPPLY_TITLE]] line connected planets with the Industry focus by 1.2 per Population, if the planet has at least 40 [[encyclopedia INFRASTRUCTURE_TITLE]]. 
 [[NO_STACK_SUPPLY_CONNECTION_TEXT]]
 
 This building can be built at an [[encyclopedia OUTPOSTS_TITLE]], but must be in a black hole system.'''
@@ -9062,7 +9064,7 @@ BLD_GAS_GIANT_GEN
 Gas Giant Generator
 
 BLD_GAS_GIANT_GEN_DESC
-'''This building can only be constructed at a gas giant and gives a +10 [[encyclopedia INDUSTRY_TITLE]] bonus to planets with the Industry focus in the same system.
+'''This building can only be constructed at a gas giant and gives a +10 [[encyclopedia INDUSTRY_TITLE]] bonus to planets with the Industry focus in the same system. Requires the planet to have at least 20 [[encyclopedia INFRASTRUCTURE_TITLE]].
 Multiple copies in the same system do not stack.
 
 A power generator designed to harvest the energy of a Gas Giant.'''

--- a/default/techs.txt
+++ b/default/techs.txt
@@ -703,6 +703,7 @@ Tech
                 ProductionCenter
                 OwnedBy empire = Source.Owner
                 NOT TargetPopulation low = 0 high = 0
+                Construction low = 10 
             ]
             effects = SetTargetResearch value = Value + 10 * [[RESEARCH_PER_POP]]
     ]
@@ -723,6 +724,7 @@ Tech
                 ProductionCenter
                 OwnedBy empire = Source.Owner
                 // Focus type = "FOCUS_RESEARCH"  //Does not require research Focus
+                Construction low = 10 
             ]
             effects = SetTargetResearch value = Value + Target.Population * 0.5 * [[RESEARCH_PER_POP]]
     ]
@@ -783,6 +785,7 @@ Tech
                 ProductionCenter
                 OwnedBy empire = Source.Owner
                 Focus type = "FOCUS_RESEARCH"
+                Construction low = 20 
             ]
             effects = SetTargetResearch value = Value + Target.Population * 2.5 * [[RESEARCH_PER_POP]]
     ]
@@ -803,6 +806,7 @@ Tech
                 OwnedBy empire = Source.Owner
                 Star type = BlackHole
                 Focus type = "FOCUS_RESEARCH"
+                Construction low = 30 
             ]
             effects = SetTargetResearch value = Value + Target.Population * 5 * [[RESEARCH_PER_POP]]
 
@@ -812,6 +816,7 @@ Tech
                 OwnedBy empire = Source.Owner
                 Star type = Neutron
                 Focus type = "FOCUS_RESEARCH"
+                Construction low = 30 
             ]
             effects = SetTargetResearch value = Value + Target.Population * 3.75 * [[RESEARCH_PER_POP]]
 
@@ -821,6 +826,7 @@ Tech
                 OwnedBy empire = Source.Owner
                 Star type = [Blue White]
                 Focus type = "FOCUS_RESEARCH"
+                Construction low = 30 
             ]
             effects = SetTargetResearch value = Value + Target.Population * 2.5 * [[RESEARCH_PER_POP]]
 
@@ -830,6 +836,7 @@ Tech
                 OwnedBy empire = Source.Owner
                 Star type = [Red Orange Yellow]
                 Focus type = "FOCUS_RESEARCH"
+                Construction low = 30 
             ]
             effects = SetTargetResearch value = Value + Target.Population * 1 * [[RESEARCH_PER_POP]]
     ]
@@ -894,6 +901,7 @@ Tech
                         OwnedBy empire = Source.Owner
                         HasTag name = "TELEPATHIC"
                         Focus type = "FOCUS_DOMINATION"
+                        Construction low = 30 
                     ]
                 ]
             ]
@@ -1298,6 +1306,7 @@ Tech
                     ]
                 ]
                 Focus type = "FOCUS_INDUSTRY"
+                Construction low = 10
             ]
             effects = SetTargetIndustry value = Value + 5
     ]
@@ -1317,6 +1326,7 @@ Tech
                 ProductionCenter
                 OwnedBy empire = Source.Owner
                 Focus type = "FOCUS_INDUSTRY"
+                Construction low = 10
             ]
             effects = SetTargetIndustry value = Value + Target.Population * 0.5 * [[INDUSTRY_PER_POP]]
         ]
@@ -1350,6 +1360,7 @@ Tech
                 ProductionCenter
                 OwnedBy empire = Source.Owner
                 Focus type = "FOCUS_INDUSTRY"
+                Construction low = 10
             ]
             effects = SetTargetIndustry value = Value + Target.Population * 1.0 * [[INDUSTRY_PER_POP]]
     ]
@@ -1399,6 +1410,7 @@ Tech
                 ProductionCenter
                 OwnedBy empire = Source.Owner
                 NOT TargetPopulation low = 0 high = 0
+                Construction low = 20
              ]
              effects = SetTargetIndustry value = Value + 5
     ]
@@ -1429,6 +1441,15 @@ Tech
         "PRO_SOL_ORB_GEN"
     ]
     unlock = Item type = Building name = "BLD_BLACK_HOLE_POW_GEN"
+	effectsgroups = [
+        EffectsGroup
+            scope = And [
+                        Species
+                        OwnedBy empire = Source.Owner
+                    ]
+			stackinggroup = "INFRA_TECH_STACK"
+            effects = SetTargetConstruction value = Value + 10
+	]
     graphic = "icons/tech/artificial_black_hole.png"
 
 Tech
@@ -1584,6 +1605,7 @@ Tech
                 ProductionCenter
                 OwnedBy empire = Source.Owner
                 Industry high = RootCandidate.TargetIndustry - 3
+                Construction low = 30
             ]
             effects = SetIndustry value = Value + 2
 
@@ -1592,6 +1614,7 @@ Tech
                 ProductionCenter
                 OwnedBy empire = Source.Owner
                 Research high = RootCandidate.TargetResearch - 3
+                Construction low = 30
             ]
             effects = SetResearch value = Value + 2
 
@@ -1600,6 +1623,7 @@ Tech
                 ProductionCenter
                 OwnedBy empire = Source.Owner
                 Construction high = RootCandidate.TargetConstruction - 3
+                Construction low = 30
             ]
             effects = SetConstruction value = Value + 2
 
@@ -1608,6 +1632,7 @@ Tech
                 ProductionCenter
                 OwnedBy empire = Source.Owner
                 Industry low = RootCandidate.TargetIndustry - 3 high = RootCandidate.TargetIndustry
+                Construction low = 30
             ]
             effects = SetIndustry value = Target.TargetIndustry
 
@@ -1616,6 +1641,7 @@ Tech
                 ProductionCenter
                 OwnedBy empire = Source.Owner
                 Research low = RootCandidate.TargetResearch - 3 high = RootCandidate.TargetResearch
+                Construction low = 30
             ]
             effects = SetResearch value = Target.TargetResearch
 
@@ -1624,6 +1650,7 @@ Tech
                 ProductionCenter
                 OwnedBy empire = Source.Owner
                 Construction low = RootCandidate.TargetConstruction - 3 high = RootCandidate.TargetConstruction
+                Construction low = 30
             ]
             effects = SetConstruction value = Target.TargetConstruction
 
@@ -1632,6 +1659,7 @@ Tech
                 ProductionCenter
                 OwnedBy empire = Source.Owner
                 Industry low = RootCandidate.TargetIndustry + 5
+                Construction low = 30
             ]
             effects = SetIndustry value = Value - 3
 
@@ -1640,6 +1668,7 @@ Tech
                 ProductionCenter
                 OwnedBy empire = Source.Owner
                 Research low = RootCandidate.TargetResearch + 5
+                Construction low = 30
             ]
             effects = SetResearch value = Value - 3
 
@@ -1648,6 +1677,7 @@ Tech
                 ProductionCenter
                 OwnedBy empire = Source.Owner
                 Construction low = RootCandidate.TargetConstruction + 5
+                Construction low = 30
             ]
             effects = SetConstruction value = Value - 3
 
@@ -1656,6 +1686,7 @@ Tech
                 ProductionCenter
                 OwnedBy empire = Source.Owner
                 Industry low = RootCandidate.TargetIndustry high = RootCandidate.TargetIndustry + 5
+                Construction low = 30
             ]
             effects = SetIndustry value = Target.TargetIndustry
 
@@ -1664,6 +1695,7 @@ Tech
                 ProductionCenter
                 OwnedBy empire = Source.Owner
                 Research low = RootCandidate.TargetResearch high = RootCandidate.TargetResearch + 5
+                Construction low = 30
             ]
             effects = SetResearch value = Target.TargetResearch
 
@@ -1672,6 +1704,7 @@ Tech
                 ProductionCenter
                 OwnedBy empire = Source.Owner
                 Construction low = RootCandidate.TargetConstruction high = RootCandidate.TargetConstruction + 5
+                Construction low = 30
             ]
             effects = SetConstruction value = Target.TargetConstruction
     ]
@@ -1700,13 +1733,15 @@ Tech
         "CON_FRC_ENRG_STRC"
         "LRN_NDIM_SUBSPACE"
     ]
-    effectsgroups = 
+    effectsgroups = [
         EffectsGroup
             scope = And [
                         Species
                         OwnedBy empire = Source.Owner
                     ]
-            effects = SetTargetConstruction value = Value + 10
+            stackinggroup = "INFRA_TECH_STACK"
+            effects = SetTargetConstruction value = Value + 20
+    ]
     graphic = "icons/tech/n-dimensional_structures.png"
 
 Tech
@@ -1753,6 +1788,7 @@ Tech
             scope = And [
                 Planet
                 OwnedBy empire = Source.Owner
+                Construction low = 20
             ]
             effects = SetMaxSupply value = Value + 1
     graphic = "icons/tech/controlled_gravity_architecture.png"
@@ -1782,6 +1818,7 @@ Tech
             scope = And [
                 Planet
                 OwnedBy empire = Source.Owner
+                Construction low = 10
             ]
             effects = SetMaxSupply value = Value + 1
     graphic = "icons/tech/orbital_construction.png"
@@ -3086,7 +3123,7 @@ Tech
                 Not OwnerHasTech name = "SPY_DETECT_4"
                 Not OwnerHasTech name = "SPY_DETECT_5"
             ]
-            effects = SetDetection value = Value + 50
+            effects = SetDetection value = Value + Min(Target.Construction / 30, 1) * 50
 
         EffectsGroup
             scope = Source
@@ -3123,7 +3160,7 @@ Tech
                 Not OwnerHasTech name = "SPY_DETECT_4"
                 Not OwnerHasTech name = "SPY_DETECT_5"
             ]
-            effects = SetDetection value = Value + 75
+            effects = SetDetection value = Value + Min(Target.Construction / 30, 1) * 75
 
         EffectsGroup
             scope = Source
@@ -3156,7 +3193,7 @@ Tech
                 Not OwnerHasTech name = "SPY_DETECT_4"
                 Not OwnerHasTech name = "SPY_DETECT_5"
                 ]
-            effects = SetDetection value = Value + 150
+            effects = SetDetection value = Value + Min(Target.Construction / 30, 1) * 150
 
         EffectsGroup
             scope = Source
@@ -3184,7 +3221,7 @@ Tech
                 OwnedBy empire = Source.Owner
             ]
             activation = Not OwnerHasTech name = "SPY_DETECT_5"
-            effects = SetDetection value = Value + 200
+            effects = SetDetection value = Value + Min(Target.Construction / 30, 1) * 200
 
         EffectsGroup
             scope = Source
@@ -3207,7 +3244,7 @@ Tech
                 Planet
                 OwnedBy empire = Source.Owner
             ]
-            effects = SetDetection value = Value + 300
+            effects = SetDetection value = Value + Min(Target.Construction / 30, 1) * 300
 
         EffectsGroup
             scope = Source

--- a/default/techs.txt
+++ b/default/techs.txt
@@ -1605,7 +1605,6 @@ Tech
                 ProductionCenter
                 OwnedBy empire = Source.Owner
                 Industry high = RootCandidate.TargetIndustry - 3
-                Construction low = 30
             ]
             effects = SetIndustry value = Value + 2
 
@@ -1614,7 +1613,6 @@ Tech
                 ProductionCenter
                 OwnedBy empire = Source.Owner
                 Research high = RootCandidate.TargetResearch - 3
-                Construction low = 30
             ]
             effects = SetResearch value = Value + 2
 
@@ -1623,7 +1621,6 @@ Tech
                 ProductionCenter
                 OwnedBy empire = Source.Owner
                 Construction high = RootCandidate.TargetConstruction - 3
-                Construction low = 30
             ]
             effects = SetConstruction value = Value + 2
 
@@ -1632,7 +1629,6 @@ Tech
                 ProductionCenter
                 OwnedBy empire = Source.Owner
                 Industry low = RootCandidate.TargetIndustry - 3 high = RootCandidate.TargetIndustry
-                Construction low = 30
             ]
             effects = SetIndustry value = Target.TargetIndustry
 
@@ -1641,7 +1637,6 @@ Tech
                 ProductionCenter
                 OwnedBy empire = Source.Owner
                 Research low = RootCandidate.TargetResearch - 3 high = RootCandidate.TargetResearch
-                Construction low = 30
             ]
             effects = SetResearch value = Target.TargetResearch
 
@@ -1650,7 +1645,6 @@ Tech
                 ProductionCenter
                 OwnedBy empire = Source.Owner
                 Construction low = RootCandidate.TargetConstruction - 3 high = RootCandidate.TargetConstruction
-                Construction low = 30
             ]
             effects = SetConstruction value = Target.TargetConstruction
 
@@ -1659,7 +1653,6 @@ Tech
                 ProductionCenter
                 OwnedBy empire = Source.Owner
                 Industry low = RootCandidate.TargetIndustry + 5
-                Construction low = 30
             ]
             effects = SetIndustry value = Value - 3
 
@@ -1668,7 +1661,6 @@ Tech
                 ProductionCenter
                 OwnedBy empire = Source.Owner
                 Research low = RootCandidate.TargetResearch + 5
-                Construction low = 30
             ]
             effects = SetResearch value = Value - 3
 
@@ -1677,7 +1669,6 @@ Tech
                 ProductionCenter
                 OwnedBy empire = Source.Owner
                 Construction low = RootCandidate.TargetConstruction + 5
-                Construction low = 30
             ]
             effects = SetConstruction value = Value - 3
 
@@ -1686,7 +1677,6 @@ Tech
                 ProductionCenter
                 OwnedBy empire = Source.Owner
                 Industry low = RootCandidate.TargetIndustry high = RootCandidate.TargetIndustry + 5
-                Construction low = 30
             ]
             effects = SetIndustry value = Target.TargetIndustry
 
@@ -1695,7 +1685,6 @@ Tech
                 ProductionCenter
                 OwnedBy empire = Source.Owner
                 Research low = RootCandidate.TargetResearch high = RootCandidate.TargetResearch + 5
-                Construction low = 30
             ]
             effects = SetResearch value = Target.TargetResearch
 
@@ -1704,7 +1693,6 @@ Tech
                 ProductionCenter
                 OwnedBy empire = Source.Owner
                 Construction low = RootCandidate.TargetConstruction high = RootCandidate.TargetConstruction + 5
-                Construction low = 30
             ]
             effects = SetConstruction value = Target.TargetConstruction
     ]

--- a/default/techs.txt
+++ b/default/techs.txt
@@ -1441,15 +1441,15 @@ Tech
         "PRO_SOL_ORB_GEN"
     ]
     unlock = Item type = Building name = "BLD_BLACK_HOLE_POW_GEN"
-	effectsgroups = [
+    effectsgroups = [
         EffectsGroup
             scope = And [
                         Species
                         OwnedBy empire = Source.Owner
                     ]
-			stackinggroup = "INFRA_TECH_STACK"
+            stackinggroup = "INFRA_TECH_STACK"
             effects = SetTargetConstruction value = Value + 10
-	]
+    ]
     graphic = "icons/tech/artificial_black_hole.png"
 
 Tech


### PR DESCRIPTION
As outlined in 
http://www.freeorion.org/forum/viewtopic.php?p=78577#p78577 and
http://www.freeorion.org/forum/viewtopic.php?p=76452#p76452

I can't wait for implementation so I go ahead and implement this myself :stuck_out_tongue: 

---
- protection focus isn't changed for now, in fact I am more inclined to change the defense techs instead, but leave that for now
- make detection tech affected by infrastructure, in order to implement planet detection grow over time.
- Removed infrastructure deduction due to shipyards as AIs tend to build them everywhere throttling the infrastructure.
- Changed base target infrastructure to 30, and make singularity-generation tech to give +10 target infra, and N-dim structure to give +20 infra (not stackable with each other) - so that the tech can get actually useful instead of being blocked by infrastructure not being able to reach the target
