### PR TITLE
Attempt to fix build error on Linux

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -112,7 +112,7 @@ set(LIB_SUFFIX ${OLD_LIB_SUFFIX})
 ########################################
 # Dependencies                         #
 ########################################
-find_package(Boost ${MINIMUM_BOOST_VERSION} COMPONENTS chrono date_time filesystem regex serialization signals system thread log REQUIRED)
+find_package(Boost ${MINIMUM_BOOST_VERSION} COMPONENTS chrono date_time filesystem iostreams regex serialization signals system thread log REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(Freetype REQUIRED)
 

--- a/server/CMakeLists.txt
+++ b/server/CMakeLists.txt
@@ -5,7 +5,7 @@ project(freeoriond)
 
 message("-- Configuring freeoriond")
 
-find_package(Boost ${MINIMUM_BOOST_VERSION} COMPONENTS python log REQUIRED)
+find_package(Boost ${MINIMUM_BOOST_VERSION} COMPONENTS iostreams python log REQUIRED)
 find_package(PythonLibs ${PYTHON_VERSION} REQUIRED)
 
 include_directories(


### PR DESCRIPTION
Apparently the boost iostreams library doesn't get linked against the FO binaries on Linux, causing link errors. Most likely because the cake files didn't get adjusted to the recent addition of compressed xml serialization, which requires boost iostreams with lib support enabled. This commit is an attempt to add the required adjustments to the cmake files. As I'm not on Linux, I can't test it, so further adjustments might be necessary.
