### PR TITLE
Consider margin in pedia entry sizes. (Fix #379)

### DIFF
--- a/GG/GG/MultiEdit.h
+++ b/GG/GG/MultiEdit.h
@@ -72,6 +72,9 @@ public:
 
     /** \name Accessors */ ///@{
     virtual Pt MinUsableSize() const;
+
+    /** Returns the size to show the whole text without scrollbars. */
+    Pt FullSize() const;
     virtual Pt ClientLowerRight() const;
 
     /** Returns the style flags for this MultiEdit. */

--- a/GG/src/Edit.cpp
+++ b/GG/src/Edit.cpp
@@ -141,7 +141,7 @@ void Edit::Render()
         const StrSize INDEX_2 = StringIndexOf(0, std::min(high_cursor_pos, last_visible_char), GetLineData());
 
         // draw text
-        X text_x_pos = ul.x + PIXEL_MARGIN;
+        X text_x_pos = client_ul.x;
         glColor(text_color_to_use);
 
         // TODO: Use subrange RenderTex()
@@ -287,7 +287,7 @@ X Edit::FirstCharOffset() const
 X Edit::ScreenPosOfChar(CPSize idx) const
 {
     X first_char_offset = FirstCharOffset();
-    return Left() + PIXEL_MARGIN + ((idx ? GetLineData()[0].char_data[Value(idx - 1)].extent : X0) - first_char_offset);
+    return ClientUpperLeft().x + ((idx ? GetLineData()[0].char_data[Value(idx - 1)].extent : X0) - first_char_offset);
 }
 
 CPSize Edit::LastVisibleChar() const
@@ -295,7 +295,7 @@ CPSize Edit::LastVisibleChar() const
     X first_char_offset = FirstCharOffset();
     CPSize retval = m_first_char_shown;
     for ( ; retval < Length(); ++retval) {
-        if (Size().x - 2 * PIXEL_MARGIN <= (retval ? GetLineData()[0].char_data[Value(retval - 1)].extent : X0) - first_char_offset)
+        if (ClientSize().x <= (retval ? GetLineData()[0].char_data[Value(retval - 1)].extent : X0) - first_char_offset)
             break;
     }
     return retval;
@@ -315,7 +315,7 @@ void Edit::LButtonDown(const Pt& pt, Flags<ModKey> mod_keys)
     if (Disabled())
         return;
     //std::cout << "Edit::LButtonDown start" << std::endl;
-    X click_xpos = ScreenToWindow(pt).x - PIXEL_MARGIN; // x coord of click within text space
+    X click_xpos = ScreenToClient(pt).x; // x coord of click within text space
     CPSize idx = CharIndexOf(click_xpos);
     //std::cout << "Edit::LButtonDown got idx: " << idx << std::endl;
     m_cursor_pos.first = m_cursor_pos.second = idx;
@@ -330,7 +330,7 @@ void Edit::LDrag(const Pt& pt, const Pt& move, Flags<ModKey> mod_keys)
     if (Disabled())
         return;
 
-    X xpos = ScreenToWindow(pt).x - PIXEL_MARGIN; // x coord for mouse position within text space
+    X xpos = ScreenToClient(pt).x; // x coord for mouse position within text space
     CPSize idx = CharIndexOf(xpos);
     if (m_in_double_click_mode) {
         std::pair<CPSize, CPSize> word_indices =
@@ -357,7 +357,7 @@ void Edit::LDrag(const Pt& pt, const Pt& move, Flags<ModKey> mod_keys)
     } else {
         // when a single-click drag occurs, move m_cursor_pos.second to where the mouse is, which selects a range of characters
         m_cursor_pos.second = idx;
-        if (xpos < 0 || Size().x - 2 * PIXEL_MARGIN < xpos) // if we're dragging past the currently visible text
+        if (xpos < 0 || ClientSize().x < xpos) // if we're dragging past the currently visible text
             AdjustView();
     }
 }
@@ -546,7 +546,7 @@ void Edit::ClearSelected()
 
 void Edit::AdjustView()
 {
-    X text_space = Size().x - 2 * PIXEL_MARGIN;
+    X text_space = ClientSize().x;
     X first_char_offset = FirstCharOffset();
     if (m_cursor_pos.second < m_first_char_shown) { // if the caret is at a place left of the current visible area
         if (m_first_char_shown - m_cursor_pos.second < 5) // if the caret is less than five characters before m_first_char_shown

--- a/GG/src/MultiEdit.cpp
+++ b/GG/src/MultiEdit.cpp
@@ -1013,7 +1013,7 @@ void MultiEdit::ValidateStyle()
     if (m_style & MULTI_RIGHT) ++dup_ct;
     if (m_style & MULTI_CENTER) ++dup_ct;
     if (dup_ct != 1) {   // exactly one must be picked; when none or multiples are picked, use MULTI_LEFT by default
-        m_style &= ~(MULTI_RIGHT | MULTI_LEFT);
+        m_style &= ~(MULTI_RIGHT | MULTI_CENTER);
         m_style |= MULTI_LEFT;
     }
 

--- a/GG/src/MultiEdit.cpp
+++ b/GG/src/MultiEdit.cpp
@@ -135,6 +135,11 @@ Pt MultiEdit::MinUsableSize() const
               Y(4 * SCROLL_WIDTH + 2 * BORDER_THICK));
 }
 
+Pt MultiEdit::FullSize() const
+{
+  return Pt(Width(), m_contents_sz.y + Y(PIXEL_MARGIN) * 2);
+}
+
 Pt MultiEdit::ClientLowerRight() const
 { return Edit::ClientLowerRight() - Pt(RightMargin(), BottomMargin()); }
 

--- a/GG/src/RichText/RichText.cpp
+++ b/GG/src/RichText/RichText.cpp
@@ -245,7 +245,7 @@ namespace GG {
 
             // Update the sizes of all blocks.
             void DoLayout() {
-                X width = m_owner->ClientWidth() - X(m_padding);
+                X width = m_owner->ClientWidth() - X(m_padding)*2;
                 Pt pos = Pt(X(m_padding), Y(m_padding));
 
                 // The contract between RichText and block controls is this:

--- a/GG/src/RichText/TextBlock.cpp
+++ b/GG/src/RichText/TextBlock.cpp
@@ -19,12 +19,8 @@ namespace GG {
 
     Pt TextBlock::SetMaxWidth(X width)
     {
-        // Reflow the text to the given width.
-        // We will actually listen to the height
-        // the text wants to be instead of forcing it to a given height,
-        // but the text layout code seems to get confused if you give it a height
-        // less than the height of the font so we use that.
-        m_text->Resize(GG::Pt(width, m_text->GetFont()->Height()));
+        // Reflow the text to the given width. Height is ignored.
+        m_text->Resize(GG::Pt(width, Y0));
 
         // Use the size the text requires.
         Pt text_size = m_text->MinUsableSize();

--- a/UI/CUILinkTextBlock.cpp
+++ b/UI/CUILinkTextBlock.cpp
@@ -19,8 +19,8 @@ m_link_text(new CUILinkTextMultiEdit(str, GG::MULTI_WORDBREAK | GG::MULTI_READ_O
 GG::Pt CUILinkTextBlock::SetMaxWidth(GG::X width)
 {
     m_link_text->Resize(GG::Pt(width, GG::Y1));
-    GG::Pt size = m_link_text->TextLowerRight() - m_link_text->TextUpperLeft();
-    size.x = width;
+    // Resize to have enough place to show the whole text.
+    GG::Pt size = m_link_text->FullSize();
 
     // Only resize when changed.
     if (size != m_link_text->Size())


### PR DESCRIPTION
The magic number 5 is GG::Edit::PIXEL_MARGIN, but it's protected. 
I also see this 5-s in CUIControls.cpp:803 and 806, can it be related?
(Can I show the lines, like those in the diff somehow?)

There could be problems with the scroll hiding the right part of the text, like it happened for SitRep.
