### PR TITLE
Fix padding in RichText.

### DIFF
--- a/GG/src/RichText/RichText.cpp
+++ b/GG/src/RichText/RichText.cpp
@@ -245,7 +245,7 @@ namespace GG {
 
             // Update the sizes of all blocks.
             void DoLayout() {
-                X width = m_owner->ClientWidth() - X(m_padding);
+                X width = m_owner->ClientWidth() - X(m_padding)*2;
                 Pt pos = Pt(X(m_padding), Y(m_padding));
 
                 // The contract between RichText and block controls is this:


### PR DESCRIPTION
Not 100% sure about this. Probably noone called a width + padding on only one side a ClientWidth value.
