### PR TITLE
Clicking a sitrep planet handle will select the planet for production.

### DIFF
--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -635,9 +635,12 @@ bool ClientUI::ZoomToObject(int id) {
 }
 
 bool ClientUI::ZoomToPlanet(int id) {
-    // this just zooms to the appropriate system, until we create a planet window of some kind
-    if (TemporaryPtr<const Planet> planet = GetPlanet(id))
-        return ZoomToSystem(planet->SystemID());
+    if (TemporaryPtr<const Planet> planet = GetPlanet(id)) {
+        m_map_wnd->CenterOnObject(planet->SystemID());
+        m_map_wnd->SelectSystem(planet->SystemID());
+        m_map_wnd->SelectPlanet(id);
+        return true;
+    }        
     return false;
 }
 

--- a/UI/ClientUI.h
+++ b/UI/ClientUI.h
@@ -58,7 +58,7 @@ public:
 
     bool    ZoomToObject(const std::string& name);
     bool    ZoomToObject(int id);
-    bool    ZoomToPlanet(int id);                                       //!< Zooms to a particular planet on the galaxy map and opens the sidepanel to show it
+    bool    ZoomToPlanet(int id);                                       //!< Zooms to a particular planet on the galaxy map and opens the sidepanel to show it, or if production screen is open selects it
     bool    ZoomToPlanetPedia(int id);                                  //!< Opens the encyclodedia window and presents the entry for the given planet
     bool    ZoomToSystem(int id);                                       //!< Zooms to a particular system on the galaxy map and opens the sidepanel to show it
     bool    ZoomToFleet(int id);                                        //!< Zooms to a particular fleet on the galaxy map and opens the fleet window


### PR DESCRIPTION
(but will not open production screen when on the map screen)

as requested here:
http://freeorion.org/forum/viewtopic.php?f=6&p=81230#p81230
