### PR TITLE
platform.system is a function, so call it.

### DIFF
--- a/default/AI/freeorion_debug/option_tools.py
+++ b/default/AI/freeorion_debug/option_tools.py
@@ -55,7 +55,7 @@ def _parse_options():
         config = SafeConfigParser()
         config.read([default_file])
     else:
-        if platform.system != "Linux":
+        if platform.system() != "Linux":
             default_file = ""
         try:
             config = _create_default_config_file(default_file)


### PR DESCRIPTION
Although I don't get why to create a default config file in the AI directory, which I guess isn't in the home directory and probably unwriteable. It's even more unclear why do it only for linux.
