### PR TITLE
Remove an unused building from content/stringtable files.

### DIFF
--- a/default/buildings.txt
+++ b/default/buildings.txt
@@ -1271,18 +1271,6 @@ BuildingType
     icon = "icons/building/blackhole.png"
 
 BuildingType
-    name = "BLD_REPLICATORS"
-    description = "BLD_REPLICATORS_DESC"
-    buildcost = 125
-    buildtime = 4
-    location = AND [
-        Not Contains Building name = "BLD_REPLICATORS"
-        OwnedBy empire = Source.Owner
-    ]
-    EnqueueLocation = [[ENQUEUE_BUILD_ONE_PER_PLANET]]
-    icon = ""
-
-BuildingType
     name = "BLD_PLANET_DRIVE"
     description = "BLD_PLANET_DRIVE_DESC"
     buildcost = 125

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -9067,14 +9067,6 @@ BLD_BLACK_HOLE_POW_GEN_DESC
 
 This building can be built at an [[encyclopedia OUTPOSTS_TITLE]], but must be in a black hole system.'''
 
-BLD_REPLICATORS
-Replicators
-
-BLD_REPLICATORS_DESC
-'''When activated, half of all industrial production in the empire goes towards replicating extra food or minerals at a 2:1 ratio. If the planet on which it is built has focus set to Food Replication, food will be produced at the expense of industry. When the focus is set to Mineral Replication, minerals will be produced at the expense of industry.
-
-Only one replication focus can take effect in the empire at one time.'''
-
 BLD_PLANET_DRIVE
 Planetary Starlane Drive
 

--- a/default/stringtables/es.txt
+++ b/default/stringtables/es.txt
@@ -3751,14 +3751,6 @@ Generador de Energía de Agujero Negro
 BLD_BLACK_HOLE_POW_GEN_DESC
 Este edificio proporciona una bonificación a la indústria máxima del doble de la población del planeta para todos los planetas en el imperio con enfoque en Indústria.  Este edificio puede ser construido en un puesto de avanzada.
 
-BLD_REPLICATORS
-Replicadores
-
-BLD_REPLICATORS_DESC
-'''Cuando se activan, la mitad de la producción industrial en el imperio se gasta en replicar alimento y minerales extra a un ratio de 2:1.  Si el planeta en el que se construye tiene enfoque en Replicación de Alimento, el alimento producido a expensas de la indústria.  Cuando el enfoque se establezca en Replicación de Mineral, los minerales serán producidos a costa de la indústria.
-
-Solo un enfoque de replicación puede tener efecto en el imperio a la vez.'''
-
 BLD_PLANET_DRIVE
 Motor Planetario de Línea Estelar
 

--- a/default/stringtables/fr.txt
+++ b/default/stringtables/fr.txt
@@ -9067,14 +9067,6 @@ BLD_BLACK_HOLE_POW_GEN_DESC
 
 Cette structure peut être construite sur un [[encyclopedia OUTPOSTS_TITLE]], mais doit se trouver dans un système abritant un Trou Noir.'''
 
-BLD_REPLICATORS
-Réplicateurs
-
-BLD_REPLICATORS_DESC
-'''Une fois activés, la moitié de toute la production industrielle de l'empire est utilisée pour la réplication de nourriture ou de minéraux supplémentaires à un taux de conversion de 2 pour 1. Si la planète sur laquelle est construite la structure est réglée sur le Focus Réplication Nourriture, la nourriture sera produite aux dépens de l'industrie. Lorsque le Focus est réglé sur Réplication Minéraux, des minéraux supplémentaires seront produits aux dépens de l'industrie.
-
-Un seul type de Focus de Réplication peut être activé simultanément à travers tout l'empire.'''
-
 BLD_PLANET_DRIVE
 Navigateur Planétaire
 

--- a/default/stringtables/ru.txt
+++ b/default/stringtables/ru.txt
@@ -6029,9 +6029,6 @@ BLD_BLACK_HOLE_POW_GEN
 BLD_BLACK_HOLE_POW_GEN_DESC
 Увеличивает [[encyclopedia INDUSTRY_TITLE]] на всех промышленно-ориентированных планетах, соединенных [[encyclopedia SUPPLY_TITLE]] на 1.2 * Население. Может быть построено на аванпостах.
 
-BLD_REPLICATORS
-Репликаторы
-
 BLD_PLANET_DRIVE
 Планетарный Межзвездный двигатель
 


### PR DESCRIPTION
Based on the description and commit logs, it hasn't been used since
farming was removed.

This wouldn't be worth bothering with, except that it shows up on the list of unproducible buildings and that's pretty annoying.
