### PR TITLE
Added output of source file name and line number to ErrorLogger and FatalLogger macros

### DIFF
--- a/util/Logger.h
+++ b/util/Logger.h
@@ -14,6 +14,8 @@ FO_COMMON_API void InitLogger(const std::string& logFile, const std::string& pat
 /** Accessors for the App's logger */
 FO_COMMON_API void SetLoggerPriority(int priority);
 
+#define __BASE_FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : strrchr(__FILE__, '\\') ? strrchr(__FILE__, '\\') + 1 : __FILE__)
+
 #define TraceLogger()\
     BOOST_LOG_TRIVIAL(trace)
 
@@ -21,10 +23,10 @@ FO_COMMON_API void SetLoggerPriority(int priority);
     BOOST_LOG_TRIVIAL(debug)
 
 #define ErrorLogger()\
-    BOOST_LOG_TRIVIAL(error)
+    BOOST_LOG_TRIVIAL(error) << __BASE_FILENAME__ << " @ " << __LINE__ << ": "
 
 #define FatalLogger()\
-    BOOST_LOG_TRIVIAL(fatal)
+    BOOST_LOG_TRIVIAL(fatal) << __BASE_FILENAME__ << " @ " << __LINE__ << ": "
 
 extern int g_indent;
 


### PR DESCRIPTION
As suggested by @geoffthemedio [here](https://github.com/freeorion/freeorion/pull/381#discussion_r45558961). Although there might be cases where the source file name and line number aren't really required or helpful, it doesn't hurt to have them, so I think adding that to the ErrorLogger and FatalLogger macros is preferable. 

As the `__LINE__` macro gives the full absolute path of the source file, I decided to define and use a macro (which I called `__BASE_FILENAME__`) I found in [a discussion at stackoverflow.com](http://stackoverflow.com/questions/8487986/file-macro-shows-full-path). This should work on all platforms, tests on OSX were successful. Tests on Linux and Windows are probably advisable.
