### PR TITLE
Cleanup logger calls. Part 1

### DIFF
--- a/AI/AIInterface.cpp
+++ b/AI/AIInterface.cpp
@@ -219,7 +219,7 @@ namespace AIInterface {
         int empire_id = AIClientApp::GetApp()->EmpireID();
         Empire* empire = ::GetEmpire(empire_id);
         if (!empire) {
-            ErrorLogger() << "AIInterface::UpdateResearchQueue : couldn't get empire with id " << empire_id;
+            ErrorLogger() << "UpdateResearchQueue : couldn't get empire with id " << empire_id;
             return;
         }
         empire->UpdateResearchQueue();
@@ -229,7 +229,7 @@ namespace AIInterface {
         int empire_id = AIClientApp::GetApp()->EmpireID();
         Empire* empire = ::GetEmpire(empire_id);
         if (!empire) {
-            ErrorLogger() << "AIInterface::UpdateProductionQueue : couldn't get empire with id " << empire_id;
+            ErrorLogger() << "UpdateProductionQueue : couldn't get empire with id " << empire_id;
             return;
         }
         empire->UpdateProductionQueue();
@@ -238,13 +238,13 @@ namespace AIInterface {
     int IssueFleetMoveOrder(int fleet_id, int destination_id) {
         TemporaryPtr<const Fleet> fleet = GetFleet(fleet_id);
         if (!fleet) {
-            ErrorLogger() << "AIInterface::IssueFleetMoveOrder : passed an invalid fleet_id";
+            ErrorLogger() << "IssueFleetMoveOrder : passed an invalid fleet_id";
             return 0;
         }
 
         int empire_id = AIClientApp::GetApp()->EmpireID();
         if (!fleet->OwnedBy(empire_id)) {
-            ErrorLogger() << "AIInterface::IssueFleetMoveOrder : passed fleet_id of fleet not owned by player";
+            ErrorLogger() << "IssueFleetMoveOrder : passed fleet_id of fleet not owned by player";
             return 0;
         }
 
@@ -262,7 +262,7 @@ namespace AIInterface {
 
     int IssueRenameOrder(int object_id, const std::string& new_name) {
         if (new_name.empty()) {
-            ErrorLogger() << "AIInterface::IssueRenameOrder : passed an empty new name";
+            ErrorLogger() << "IssueRenameOrder : passed an empty new name";
             return 0;
         }
 
@@ -270,11 +270,11 @@ namespace AIInterface {
         TemporaryPtr<const UniverseObject> obj = GetUniverseObject(object_id);
 
         if (!obj) {
-            ErrorLogger() << "AIInterface::IssueRenameOrder : passed an invalid object_id";
+            ErrorLogger() << "IssueRenameOrder : passed an invalid object_id";
             return 0;
         }
         if (!obj->OwnedBy(empire_id)) {
-            ErrorLogger() << "AIInterface::IssueRenameOrder : passed object_id of object not owned by player";
+            ErrorLogger() << "IssueRenameOrder : passed object_id of object not owned by player";
             return 0;
         }
 
@@ -285,7 +285,7 @@ namespace AIInterface {
 
     int IssueScrapOrder(const std::vector<int>& object_ids) {
             if (object_ids.empty()) {
-                ErrorLogger() << "AIInterface::IssueScrapOrder : passed empty vector of object_ids";
+                ErrorLogger() << "IssueScrapOrder : passed empty vector of object_ids";
                 return 0;
             }
 
@@ -296,12 +296,12 @@ namespace AIInterface {
                 TemporaryPtr<const UniverseObject> obj = GetUniverseObject(*it);
 
                 if (!obj) {
-                    ErrorLogger() << "AIInterface::IssueScrapOrder : passed an invalid object_id";
+                    ErrorLogger() << "IssueScrapOrder : passed an invalid object_id";
                     return 0;
                 }
 
                 if (!obj->OwnedBy(empire_id)) {
-                    ErrorLogger() << "AIInterface::IssueScrapOrder : passed object_id of object not owned by player";
+                    ErrorLogger() << "IssueScrapOrder : passed object_id of object not owned by player";
                     return 0;
                 }
 
@@ -319,12 +319,12 @@ namespace AIInterface {
 
     int IssueNewFleetOrder(const std::string& fleet_name, const std::vector<int>& ship_ids) {
         if (ship_ids.empty()) {
-            ErrorLogger() << "AIInterface::IssueNewFleetOrder : passed empty vector of ship_ids";
+            ErrorLogger() << "IssueNewFleetOrder : passed empty vector of ship_ids";
             return 0;
         }
 
         if (fleet_name.empty()) {
-            ErrorLogger() << "AIInterface::IssueNewFleetOrder : tried to create a nameless fleet";
+            ErrorLogger() << "IssueNewFleetOrder : tried to create a nameless fleet";
             return 0;
         }
 
@@ -335,11 +335,11 @@ namespace AIInterface {
         for (std::vector<int>::const_iterator it = ship_ids.begin(); it != ship_ids.end(); ++it) {
             ship = GetShip(*it);
             if (!ship) {
-                ErrorLogger() << "AIInterface::IssueNewFleetOrder : passed an invalid ship_id";
+                ErrorLogger() << "IssueNewFleetOrder : passed an invalid ship_id";
                 return 0;
             }
             if (!ship->OwnedBy(empire_id)) {
-                ErrorLogger() << "AIInterface::IssueNewFleetOrder : passed ship_id of ship not owned by player";
+                ErrorLogger() << "IssueNewFleetOrder : passed ship_id of ship not owned by player";
                 return 0;
             }
         }
@@ -347,7 +347,7 @@ namespace AIInterface {
         // make sure all ships are at a system, and that all are at the same system
         int system_id = ship->SystemID();
         if (system_id == INVALID_OBJECT_ID) {
-            ErrorLogger() << "AIInterface::IssueNewFleetOrder : passed ship_ids of ships at different locations";
+            ErrorLogger() << "IssueNewFleetOrder : passed ship_ids of ships at different locations";
             return 0;
         }
 
@@ -355,7 +355,7 @@ namespace AIInterface {
         for (++it; it != ship_ids.end(); ++it) {
             TemporaryPtr<const Ship> ship2 = GetShip(*it);
             if (ship2->SystemID() != system_id) {
-                ErrorLogger() << "AIInterface::IssueNewFleetOrder : passed ship_ids of ships at different locations";
+                ErrorLogger() << "IssueNewFleetOrder : passed ship_ids of ships at different locations";
                 return 0;
             }
         }
@@ -378,36 +378,36 @@ namespace AIInterface {
 
         TemporaryPtr<const Ship> ship = GetShip(ship_id);
         if (!ship) {
-            ErrorLogger() << "AIInterface::IssueFleetTransferOrder : passed an invalid ship_id " << ship_id;
+            ErrorLogger() << "IssueFleetTransferOrder : passed an invalid ship_id " << ship_id;
             return 0;
         }
         int ship_sys_id = ship->SystemID();
         if (ship_sys_id == INVALID_OBJECT_ID) {
-            ErrorLogger() << "AIInterface::IssueFleetTransferOrder : ship is not in a system";
+            ErrorLogger() << "IssueFleetTransferOrder : ship is not in a system";
             return 0;
         }
         if (!ship->OwnedBy(empire_id)) {
-            ErrorLogger() << "AIInterface::IssueFleetTransferOrder : passed ship_id of ship not owned by player";
+            ErrorLogger() << "IssueFleetTransferOrder : passed ship_id of ship not owned by player";
             return 0;
         }
 
         TemporaryPtr<const Fleet> fleet = GetFleet(new_fleet_id);
         if (!fleet) {
-            ErrorLogger() << "AIInterface::IssueFleetTransferOrder : passed an invalid new_fleet_id " << new_fleet_id;
+            ErrorLogger() << "IssueFleetTransferOrder : passed an invalid new_fleet_id " << new_fleet_id;
             return 0;
         }
         int fleet_sys_id = fleet->SystemID();
         if (fleet_sys_id == INVALID_OBJECT_ID) {
-            ErrorLogger() << "AIInterface::IssueFleetTransferOrder : new fleet is not in a system";
+            ErrorLogger() << "IssueFleetTransferOrder : new fleet is not in a system";
             return 0;
         }
         if (!fleet->OwnedBy(empire_id)) {
-            ErrorLogger() << "AIInterface::IssueFleetTransferOrder : passed fleet_id "<< new_fleet_id << " of fleet not owned by player";
+            ErrorLogger() << "IssueFleetTransferOrder : passed fleet_id "<< new_fleet_id << " of fleet not owned by player";
             return 0;
         }
 
         if (fleet_sys_id != ship_sys_id) {
-            ErrorLogger() << "AIInterface::IssueFleetTransferOrder : new fleet in system " << fleet_sys_id << " and ship in system "<< ship_sys_id <<  " are not in the same system";
+            ErrorLogger() << "IssueFleetTransferOrder : new fleet in system " << fleet_sys_id << " and ship in system "<< ship_sys_id <<  " are not in the same system";
             return 0;
         }
 
@@ -424,45 +424,45 @@ namespace AIInterface {
         // make sure ship_id is a ship...
         TemporaryPtr<const Ship> ship = GetShip(ship_id);
         if (!ship) {
-            ErrorLogger() << "AIInterface::IssueColonizeOrder : passed an invalid ship_id";
+            ErrorLogger() << "IssueColonizeOrder : passed an invalid ship_id";
             return 0;
         }
 
         // get fleet of ship
         TemporaryPtr<const Fleet> fleet = GetFleet(ship->FleetID());
         if (!fleet) {
-            ErrorLogger() << "AIInterface::IssueColonizeOrder : ship with passed ship_id has invalid fleet_id";
+            ErrorLogger() << "IssueColonizeOrder : ship with passed ship_id has invalid fleet_id";
             return 0;
         }
 
         // make sure player owns ship and its fleet
         if (!fleet->OwnedBy(empire_id)) {
-            ErrorLogger() << "AIInterface::IssueColonizeOrder : empire does not own fleet of passed ship";
+            ErrorLogger() << "IssueColonizeOrder : empire does not own fleet of passed ship";
             return 0;
         }
         if (!ship->OwnedBy(empire_id)) {
-            ErrorLogger() << "AIInterface::IssueColonizeOrder : empire does not own passed ship";
+            ErrorLogger() << "IssueColonizeOrder : empire does not own passed ship";
             return 0;
         }
 
         // verify that planet exists and is un-occupied.
         TemporaryPtr<const Planet> planet = GetPlanet(planet_id);
         if (!planet) {
-            ErrorLogger() << "AIInterface::IssueColonizeOrder : no planet with passed planet_id";
+            ErrorLogger() << "IssueColonizeOrder : no planet with passed planet_id";
             return 0;
         }
         if ((!planet->Unowned()) && !( planet->OwnedBy(empire_id) && planet->CurrentMeterValue(METER_POPULATION)==0)) {
-            ErrorLogger() << "AIInterface::IssueColonizeOrder : planet with passed planet_id "<<planet_id<<" is already owned, or colonized by own empire";
+            ErrorLogger() << "IssueColonizeOrder : planet with passed planet_id "<<planet_id<<" is already owned, or colonized by own empire";
             return 0;
         }
 
         // verify that planet is in same system as the fleet
         if (planet->SystemID() != fleet->SystemID()) {
-            ErrorLogger() << "AIInterface::IssueColonizeOrder : fleet and planet are not in the same system";
+            ErrorLogger() << "IssueColonizeOrder : fleet and planet are not in the same system";
             return 0;
         }
         if (ship->SystemID() == INVALID_OBJECT_ID) {
-            ErrorLogger() << "AIInterface::IssueColonizeOrder : ship is not in a system";
+            ErrorLogger() << "IssueColonizeOrder : ship is not in a system";
             return 0;
         }
 
@@ -477,31 +477,31 @@ namespace AIInterface {
         // make sure ship_id is a ship...
         TemporaryPtr<const Ship> ship = GetShip(ship_id);
         if (!ship) {
-            ErrorLogger() << "AIInterface::IssueInvadeOrder : passed an invalid ship_id";
+            ErrorLogger() << "IssueInvadeOrder : passed an invalid ship_id";
             return 0;
         }
 
         // get fleet of ship
         TemporaryPtr<const Fleet> fleet = GetFleet(ship->FleetID());
         if (!fleet) {
-            ErrorLogger() << "AIInterface::IssueInvadeOrder : ship with passed ship_id has invalid fleet_id";
+            ErrorLogger() << "IssueInvadeOrder : ship with passed ship_id has invalid fleet_id";
             return 0;
         }
 
         // make sure player owns ship and its fleet
         if (!fleet->OwnedBy(empire_id)) {
-            ErrorLogger() << "AIInterface::IssueInvadeOrder : empire does not own fleet of passed ship";
+            ErrorLogger() << "IssueInvadeOrder : empire does not own fleet of passed ship";
             return 0;
         }
         if (!ship->OwnedBy(empire_id)) {
-            ErrorLogger() << "AIInterface::IssueInvadeOrder : empire does not own passed ship";
+            ErrorLogger() << "IssueInvadeOrder : empire does not own passed ship";
             return 0;
         }
 
         // verify that planet exists and is occupied by another empire
         TemporaryPtr<const Planet> planet = GetPlanet(planet_id);
         if (!planet) {
-            ErrorLogger() << "AIInterface::IssueInvadeOrder : no planet with passed planet_id";
+            ErrorLogger() << "IssueInvadeOrder : no planet with passed planet_id";
             return 0;
         }
         bool owned_by_invader = planet->OwnedBy(empire_id);
@@ -514,25 +514,25 @@ namespace AIInterface {
         //bool being_invaded = planet->IsAboutToBeInvaded();
         bool invadable = !owned_by_invader && vulnerable && (populated || !unowned) && visible ;// && !being_invaded; a 'being_invaded' check prevents AI from invading with multiple ships at once, which is important
         if (!invadable) {
-            ErrorLogger() << "AIInterface::IssueInvadeOrder : planet with passed planet_id " << planet_id
+            ErrorLogger() << "IssueInvadeOrder : planet with passed planet_id " << planet_id
                           << " and species " << this_species << " is not invadable due to one or more of: owned by invader empire, "
                           << "not visible to invader empire, has shields above zero, or is already being invaded.";
             if (!unowned) 
-                ErrorLogger() << "AIInterface::IssueInvadeOrder : planet (id " << planet_id << ") is not unowned";
+                ErrorLogger() << "IssueInvadeOrder : planet (id " << planet_id << ") is not unowned";
             if (!visible)
-                ErrorLogger() << "AIInterface::IssueInvadeOrder : planet (id " << planet_id << ") is not visible";
+                ErrorLogger() << "IssueInvadeOrder : planet (id " << planet_id << ") is not visible";
             if (!vulnerable)
-                ErrorLogger() << "AIInterface::IssueInvadeOrder : planet (id " << planet_id << ") is not vulnerable, shields at "<<shields;
+                ErrorLogger() << "IssueInvadeOrder : planet (id " << planet_id << ") is not vulnerable, shields at "<<shields;
             return 0;
         }
 
         // verify that planet is in same system as the fleet
         if (planet->SystemID() != fleet->SystemID()) {
-            ErrorLogger() << "AIInterface::IssueInvadeOrder : fleet and planet are not in the same system";
+            ErrorLogger() << "IssueInvadeOrder : fleet and planet are not in the same system";
             return 0;
         }
         if (ship->SystemID() == INVALID_OBJECT_ID) {
-            ErrorLogger() << "AIInterface::IssueInvadeOrder : ship is not in a system";
+            ErrorLogger() << "IssueInvadeOrder : ship is not in a system";
             return 0;
         }
 
@@ -547,15 +547,15 @@ namespace AIInterface {
         // make sure ship_id is a ship...
         TemporaryPtr<const Ship> ship = GetShip(ship_id);
         if (!ship) {
-            ErrorLogger() << "AIInterface::IssueBombardOrder : passed an invalid ship_id";
+            ErrorLogger() << "IssueBombardOrder : passed an invalid ship_id";
             return 0;
         }
         if (ship->TotalWeaponsDamage() <= 0) {
-            ErrorLogger() << "AIInterface::IssueBombardOrder : ship can't attack / bombard";
+            ErrorLogger() << "IssueBombardOrder : ship can't attack / bombard";
             return 0;
         }
         if (!ship->OwnedBy(empire_id)) {
-            ErrorLogger() << "AIInterface::IssueBombardOrder : ship isn't owned by the order-issuing empire";
+            ErrorLogger() << "IssueBombardOrder : ship isn't owned by the order-issuing empire";
             return 0;
         }
 
@@ -563,31 +563,31 @@ namespace AIInterface {
         // verify that planet exists and is occupied by another empire
         TemporaryPtr<const Planet> planet = GetPlanet(planet_id);
         if (!planet) {
-            ErrorLogger() << "AIInterface::IssueBombardOrder : no planet with passed planet_id";
+            ErrorLogger() << "IssueBombardOrder : no planet with passed planet_id";
             return 0;
         }
         if (planet->OwnedBy(empire_id)) {
-            ErrorLogger() << "AIInterface::IssueBombardOrder : planet is already owned by the order-issuing empire";
+            ErrorLogger() << "IssueBombardOrder : planet is already owned by the order-issuing empire";
             return 0;
         }
         if (!planet->Unowned() && Empires().GetDiplomaticStatus(planet->Owner(), empire_id) != DIPLO_WAR) {
-            ErrorLogger() << "AIInterface::IssueBombardOrder : planet owned by an empire not at war with order-issuing empire";
+            ErrorLogger() << "IssueBombardOrder : planet owned by an empire not at war with order-issuing empire";
             return 0;
         }
         if (GetUniverse().GetObjectVisibilityByEmpire(planet_id, empire_id) < VIS_BASIC_VISIBILITY) {
-            ErrorLogger() << "AIInterface::IssueBombardOrder : planet that empire reportedly has insufficient visibility of, but will be allowed to proceed pending investigation";
+            ErrorLogger() << "IssueBombardOrder : planet that empire reportedly has insufficient visibility of, but will be allowed to proceed pending investigation";
             //return;
         }
 
 
         int ship_system_id = ship->SystemID();
         if (ship_system_id == INVALID_OBJECT_ID) {
-            ErrorLogger() << "AIInterface::IssueBombardOrder : given id of ship not in a system";
+            ErrorLogger() << "IssueBombardOrder : given id of ship not in a system";
             return 0;
         }
         int planet_system_id = planet->SystemID();
         if (ship_system_id != planet_system_id) {
-            ErrorLogger() << "AIInterface::IssueBombardOrder : given ids of ship and planet not in the same system";
+            ErrorLogger() << "IssueBombardOrder : given ids of ship and planet not in the same system";
             return 0;
         }
 
@@ -605,11 +605,11 @@ namespace AIInterface {
 
         TemporaryPtr<const Fleet> fleet = GetFleet(object_id);
         if (!fleet) {
-            ErrorLogger() << "AIInterface::IssueAggressionOrder : no fleet with passed id";
+            ErrorLogger() << "IssueAggressionOrder : no fleet with passed id";
             return 0;
         }
         if (!fleet->OwnedBy(empire_id)) {
-            ErrorLogger() << "AIInterface::IssueAggressionOrder : passed object_id of object not owned by player";
+            ErrorLogger() << "IssueAggressionOrder : passed object_id of object not owned by player";
             return 0;
         }
 
@@ -623,34 +623,34 @@ namespace AIInterface {
         int empire_id = AIClientApp::GetApp()->EmpireID();
 
         if (GetEmpire(recipient_id) == 0) {
-            ErrorLogger() << "AIInterface::IssueGiveObjectToEmpireOrder : given invalid recipient empire id";
+            ErrorLogger() << "IssueGiveObjectToEmpireOrder : given invalid recipient empire id";
             return 0;
         }
 
         if (Empires().GetDiplomaticStatus(empire_id, recipient_id) != DIPLO_PEACE) {
-            ErrorLogger() << "AIInterface::IssueGiveObjectToEmpireOrder : attempting to give to empire not at peace";
+            ErrorLogger() << "IssueGiveObjectToEmpireOrder : attempting to give to empire not at peace";
             return 0;
         }
 
         TemporaryPtr<UniverseObject> obj = GetUniverseObject(object_id);
         if (!obj) {
-            ErrorLogger() << "AIInterface::IssueGiveObjectToEmpireOrder : passed invalid object id";
+            ErrorLogger() << "IssueGiveObjectToEmpireOrder : passed invalid object id";
             return 0;
         }
 
         if (!obj->OwnedBy(empire_id)) {
-            ErrorLogger() << "AIInterface::IssueGiveObjectToEmpireOrder : passed object not owned by player";
+            ErrorLogger() << "IssueGiveObjectToEmpireOrder : passed object not owned by player";
             return 0;
         }
 
         if (obj->ObjectType() != OBJ_FLEET && obj->ObjectType() != OBJ_PLANET) {
-            ErrorLogger() << "AIInterface::IssueGiveObjectToEmpireOrder : passed object that is not a fleet or planet";
+            ErrorLogger() << "IssueGiveObjectToEmpireOrder : passed object that is not a fleet or planet";
             return 0;
         }
 
         TemporaryPtr<System> system = GetSystem(obj->SystemID());
         if (!system) {
-            ErrorLogger() << "AIInterface::IssueGiveObjectToEmpireOrder : couldn't get system of object";
+            ErrorLogger() << "IssueGiveObjectToEmpireOrder : couldn't get system of object";
             return 0;
         }
 
@@ -668,7 +668,7 @@ namespace AIInterface {
             }
         }
         if (!recipient_has_something_here) {
-            ErrorLogger() << "AIInterface::IssueGiveObjectToEmpireOrder : recipient empire has nothing in system";
+            ErrorLogger() << "IssueGiveObjectToEmpireOrder : recipient empire has nothing in system";
             return 0;
         }
 
@@ -683,15 +683,15 @@ namespace AIInterface {
 
         TemporaryPtr<const Planet> planet = GetPlanet(planet_id);
         if (!planet) {
-            ErrorLogger() << "AIInterface::IssueChangeFocusOrder : no planet with passed planet_id "<<planet_id;
+            ErrorLogger() << "IssueChangeFocusOrder : no planet with passed planet_id "<<planet_id;
             return 0;
         }
         if (!planet->OwnedBy(empire_id)) {
-            ErrorLogger() << "AIInterface::IssueChangeFocusOrder : empire does not own planet with passed planet_id";
+            ErrorLogger() << "IssueChangeFocusOrder : empire does not own planet with passed planet_id";
             return 0;
         }
         if (false) {    // todo: verify that focus is valid for specified planet
-            ErrorLogger() << "AIInterface::IssueChangeFocusOrder : invalid focus specified";
+            ErrorLogger() << "IssueChangeFocusOrder : invalid focus specified";
             return 0;
         }
 
@@ -704,7 +704,7 @@ namespace AIInterface {
     int IssueEnqueueTechOrder(const std::string& tech_name, int position) {
         const Tech* tech = GetTech(tech_name);
         if (!tech) {
-            ErrorLogger() << "AIInterface::IssueEnqueueTechOrder : passed tech_name that is not the name of a tech.";
+            ErrorLogger() << "IssueEnqueueTechOrder : passed tech_name that is not the name of a tech.";
             return 0;
         }
 
@@ -719,7 +719,7 @@ namespace AIInterface {
     int IssueDequeueTechOrder(const std::string& tech_name) {
         const Tech* tech = GetTech(tech_name);
         if (!tech) {
-            ErrorLogger() << "AIInterface::IssueDequeueTechOrder : passed tech_name that is not the name of a tech.";
+            ErrorLogger() << "IssueDequeueTechOrder : passed tech_name that is not the name of a tech.";
             return 0;
         }
 
@@ -735,7 +735,7 @@ namespace AIInterface {
         Empire* empire = AIClientApp::GetApp()->GetEmpire(empire_id);
 
         if (!empire->ProducibleItem(BT_BUILDING, item_name, location_id)) {
-            ErrorLogger() << "AIInterface::IssueEnqueueBuildingProductionOrder : specified item_name and location_id that don't indicate an item that can be built at that location";
+            ErrorLogger() << "IssueEnqueueBuildingProductionOrder : specified item_name and location_id that don't indicate an item that can be built at that location";
             return 0;
         }
 
@@ -750,7 +750,7 @@ namespace AIInterface {
         Empire* empire = AIClientApp::GetApp()->GetEmpire(empire_id);
 
         if (!empire->ProducibleItem(BT_SHIP, design_id, location_id)) {
-            ErrorLogger() << "AIInterface::IssueEnqueueShipProductionOrder : specified design_id and location_id that don't indicate a design that can be built at that location";
+            ErrorLogger() << "IssueEnqueueShipProductionOrder : specified design_id and location_id that don't indicate a design that can be built at that location";
             return 0;
         }
 
@@ -766,11 +766,11 @@ namespace AIInterface {
 
         const ProductionQueue& queue = empire->GetProductionQueue();
         if (queue_index < 0 || static_cast<int>(queue.size()) <= queue_index) {
-            ErrorLogger() << "AIInterface::IssueChangeProductionQuantityOrder : passed queue_index outside range of items on queue.";
+            ErrorLogger() << "IssueChangeProductionQuantityOrder : passed queue_index outside range of items on queue.";
             return 0;
         }
         if (queue[queue_index].item.build_type != BT_SHIP) {
-            ErrorLogger() << "AIInterface::IssueChangeProductionQuantityOrder : passed queue_index for a non-ship item.";
+            ErrorLogger() << "IssueChangeProductionQuantityOrder : passed queue_index for a non-ship item.";
             return 0;
         }
 
@@ -782,7 +782,7 @@ namespace AIInterface {
 
     int IssueRequeueProductionOrder(int old_queue_index, int new_queue_index) {
         if (old_queue_index == new_queue_index) {
-            ErrorLogger() << "AIInterface::IssueRequeueProductionOrder : passed same old and new indexes... nothing to do.";
+            ErrorLogger() << "IssueRequeueProductionOrder : passed same old and new indexes... nothing to do.";
             return 0;
         }
 
@@ -791,7 +791,7 @@ namespace AIInterface {
 
         const ProductionQueue& queue = empire->GetProductionQueue();
         if (old_queue_index < 0 || static_cast<int>(queue.size()) <= old_queue_index) {
-            ErrorLogger() << "AIInterface::IssueRequeueProductionOrder : passed old_queue_index outside range of items on queue.";
+            ErrorLogger() << "IssueRequeueProductionOrder : passed old_queue_index outside range of items on queue.";
             return 0;
         }
 
@@ -803,7 +803,7 @@ namespace AIInterface {
             actual_new_index = new_queue_index - 1;
 
         if (new_queue_index < 0 || static_cast<int>(queue.size()) <= actual_new_index) {
-            ErrorLogger() << "AIInterface::IssueRequeueProductionOrder : passed new_queue_index outside range of items on queue.";
+            ErrorLogger() << "IssueRequeueProductionOrder : passed new_queue_index outside range of items on queue.";
             return 0;
         }
 
@@ -819,7 +819,7 @@ namespace AIInterface {
 
         const ProductionQueue& queue = empire->GetProductionQueue();
         if (queue_index < 0 || static_cast<int>(queue.size()) <= queue_index) {
-            ErrorLogger() << "AIInterface::IssueDequeueProductionOrder : passed queue_index outside range of items on queue.";
+            ErrorLogger() << "IssueDequeueProductionOrder : passed queue_index outside range of items on queue.";
             return 0;
         }
 
@@ -834,11 +834,11 @@ namespace AIInterface {
                                    const std::string& icon, const std::string& model, bool nameDescInStringTable)
     {
         if (name.empty() || description.empty() || hull.empty()) {
-            ErrorLogger() << "AIInterface::IssueCreateShipDesignOrderOrder : passed an empty name, description, or hull.";
+            ErrorLogger() << "IssueCreateShipDesignOrderOrder : passed an empty name, description, or hull.";
             return 0;
         }
         if (!ShipDesign::ValidDesign(hull, parts)) {
-            ErrorLogger() << "AIInterface::IssueCreateShipDesignOrderOrder : pass a hull and parts that do not make a valid ShipDesign";
+            ErrorLogger() << "IssueCreateShipDesignOrderOrder : pass a hull and parts that do not make a valid ShipDesign";
             return 0;
         }
 
@@ -850,7 +850,7 @@ namespace AIInterface {
                                             hull, parts, icon, model, nameDescInStringTable);
 
         if (!design) {
-            ErrorLogger() << "AIInterface::IssueCreateShipDesignOrderOrder failed to create a new ShipDesign object";
+            ErrorLogger() << "IssueCreateShipDesignOrderOrder failed to create a new ShipDesign object";
             return 0;
         }
 

--- a/client/ClientApp.cpp
+++ b/client/ClientApp.cpp
@@ -125,7 +125,7 @@ ClientNetworking& ClientApp::Networking()
 
 std::string ClientApp::GetVisibleObjectName(TemporaryPtr<const UniverseObject> object) {
     if (!object) {
-        ErrorLogger() << "ServerApp::GetVisibleObjectName(): expected non null object pointer.";
+        ErrorLogger() << "ClientApp::GetVisibleObjectName(): expected non null object pointer.";
         return std::string();
     }
 

--- a/python/server/PythonServerWrapper.cpp
+++ b/python/server/PythonServerWrapper.cpp
@@ -116,7 +116,7 @@ namespace {
         } else {
             Empire* empire = GetEmpire(empire_id);
             if (!empire) {
-                ErrorLogger() << "PythonServerWrapper::GenerateSitRep: couldn't get empire with ID " << empire_id;
+                ErrorLogger() << "GenerateSitRep: couldn't get empire with ID " << empire_id;
                 return;
             }
             empire->AddSitRepEntry(CreateSitRep(template_string, sitrep_turn, icon, params));

--- a/python/server/PythonServerWrapper.cpp
+++ b/python/server/PythonServerWrapper.cpp
@@ -132,7 +132,7 @@ namespace {
     object SpeciesPreferredFocus(const std::string& species_name) {
         const Species* species = GetSpecies(species_name);
         if (!species) {
-            ErrorLogger() << "PythonUniverseGenerator::SpeciesPreferredFocus: couldn't get species " << species_name;
+            ErrorLogger() << "SpeciesPreferredFocus: couldn't get species " << species_name;
             return object("");
         }
         return object(species->PreferredFocus());
@@ -141,7 +141,7 @@ namespace {
     PlanetEnvironment SpeciesGetPlanetEnvironment(const std::string& species_name, PlanetType planet_type) {
         const Species* species = GetSpecies(species_name);
         if (!species) {
-            ErrorLogger() << "PythonUniverseGenerator::SpeciesGetPlanetEnvironment: couldn't get species " << species_name;
+            ErrorLogger() << "SpeciesGetPlanetEnvironment: couldn't get species " << species_name;
             return INVALID_PLANET_ENVIRONMENT;
         }
         return species->GetPlanetEnvironment(planet_type);
@@ -150,7 +150,7 @@ namespace {
     void SpeciesAddHomeworld(const std::string& species_name, int homeworld_id) {
         Species* species = SpeciesManager::GetSpeciesManager().GetSpecies(species_name);
         if (!species) {
-            ErrorLogger() << "PythonUniverseGenerator::SpeciesAddHomeworld: couldn't get species " << species_name;
+            ErrorLogger() << "SpeciesAddHomeworld: couldn't get species " << species_name;
             return;
         }
         species->AddHomeworld(homeworld_id);
@@ -159,7 +159,7 @@ namespace {
     void SpeciesRemoveHomeworld(const std::string& species_name, int homeworld_id) {
         Species* species = SpeciesManager::GetSpeciesManager().GetSpecies(species_name);
         if (!species) {
-            ErrorLogger() << "PythonUniverseGenerator::SpeciesAddHomeworld: couldn't get species " << species_name;
+            ErrorLogger() << "SpeciesAddHomeworld: couldn't get species " << species_name;
             return;
         }
         species->RemoveHomeworld(homeworld_id);
@@ -168,7 +168,7 @@ namespace {
     bool SpeciesCanColonize(const std::string& species_name) {
         Species* species = SpeciesManager::GetSpeciesManager().GetSpecies(species_name);
         if (!species) {
-            ErrorLogger() << "PythonUniverseGenerator::SpeciesCanColonize: couldn't get species " << species_name;
+            ErrorLogger() << "SpeciesCanColonize: couldn't get species " << species_name;
             return false;
         }
         return species->CanColonize();
@@ -205,7 +205,7 @@ namespace {
     double SpecialSpawnRate(const std::string special_name) {
         const Special* special = GetSpecial(special_name);
         if (!special) {
-            ErrorLogger() << "PythonUniverseGenerator::SpecialSpawnRate: couldn't get special " << special_name;
+            ErrorLogger() << "SpecialSpawnRate: couldn't get special " << special_name;
             return 0.0;
         }
         return special->SpawnRate();
@@ -214,7 +214,7 @@ namespace {
     int SpecialSpawnLimit(const std::string special_name) {
         const Special* special = GetSpecial(special_name);
         if (!special) {
-            ErrorLogger() << "PythonUniverseGenerator::SpecialSpawnLimit: couldn't get special " << special_name;
+            ErrorLogger() << "SpecialSpawnLimit: couldn't get special " << special_name;
             return 0;
         }
         return special->SpawnLimit();
@@ -224,14 +224,14 @@ namespace {
         // get special and check if it exists
         const Special* special = GetSpecial(special_name);
         if (!special) {
-            ErrorLogger() << "PythonUniverseGenerator::SpecialLocation: couldn't get special " << special_name;
+            ErrorLogger() << "SpecialLocation: couldn't get special " << special_name;
             return false;
         }
 
         // get the universe object to test and check if it exists
         TemporaryPtr<UniverseObject> obj = GetUniverseObject(object_id);
         if (!obj) {
-            ErrorLogger() << "PythonUniverseGenerator::SpecialLocation: Couldn't get object with ID " << object_id;
+            ErrorLogger() << "SpecialLocation: Couldn't get object with ID " << object_id;
             return false;
         }
 
@@ -245,7 +245,7 @@ namespace {
         // get special and check if it exists
         const Special* special = GetSpecial(special_name);
         if (!special) {
-            ErrorLogger() << "PythonUniverseGenerator::SpecialHasLocation: couldn't get special " << special_name;
+            ErrorLogger() << "SpecialHasLocation: couldn't get special " << special_name;
             return false;
         }
         return special->Location();
@@ -264,7 +264,7 @@ namespace {
     void EmpireSetName(int empire_id, const std::string& name) {
         Empire* empire = GetEmpire(empire_id);
         if (!empire) {
-            ErrorLogger() << "PythonUniverseGenerator::EmpireSetName: couldn't get empire with ID " << empire_id;
+            ErrorLogger() << "EmpireSetName: couldn't get empire with ID " << empire_id;
             return;
         }
         empire->SetName(name);
@@ -273,7 +273,7 @@ namespace {
     bool EmpireSetHomeworld(int empire_id, int planet_id, const std::string& species_name) {
         Empire* empire = GetEmpire(empire_id);
         if (!empire) {
-            ErrorLogger() << "PythonUniverseGenerator::EmpireSetHomeworld: couldn't get empire with ID " << empire_id;
+            ErrorLogger() << "EmpireSetHomeworld: couldn't get empire with ID " << empire_id;
             return false;
         }
         return SetEmpireHomeworld(empire, planet_id, species_name);
@@ -282,7 +282,7 @@ namespace {
     void EmpireUnlockItem(int empire_id, UnlockableItemType item_type, const std::string& item_name) {
         Empire* empire = GetEmpire(empire_id);
         if (!empire) {
-            ErrorLogger() << "PythonUniverseGenerator::EmpireUnlockItem: couldn't get empire with ID " << empire_id;
+            ErrorLogger() << "EmpireUnlockItem: couldn't get empire with ID " << empire_id;
             return;
         }
         ItemSpec item = ItemSpec(item_type, item_name);
@@ -294,14 +294,14 @@ namespace {
 
         Empire* empire = GetEmpire(empire_id);
         if (!empire) {
-            ErrorLogger() << "PythonUniverseGenerator::EmpireAddShipDesign: couldn't get empire with ID " << empire_id;
+            ErrorLogger() << "EmpireAddShipDesign: couldn't get empire with ID " << empire_id;
             return;
         }
 
         // check if a ship design with ID ship_design_id has been added to the universe
         const ShipDesign* ship_design = universe.GetGenericShipDesign(design_name);
         if (!ship_design) {
-            ErrorLogger() << "PythonUniverseGenerator::EmpireAddShipDesign: no ship design with name " << design_name << " has been added to the universe";
+            ErrorLogger() << "EmpireAddShipDesign: no ship design with name " << design_name << " has been added to the universe";
             return;
         }
 
@@ -328,13 +328,13 @@ namespace {
         Universe& universe = GetUniverse();
         // Check for empty name
         if (name.empty()) {
-            ErrorLogger() << "PythonUniverseGenerator::CreateShipDesign: tried to create ship design without a name";
+            ErrorLogger() << "CreateShipDesign: tried to create ship design without a name";
             return false;
         }
 
         // check if a ship design with the same name has already been added to the universe
         if (universe.GetGenericShipDesign(name)) {
-            ErrorLogger() << "PythonUniverseGenerator::CreateShipDesign: a ship design with the name " << name
+            ErrorLogger() << "CreateShipDesign: a ship design with the name " << name
             << " has already been added to the universe";
             return false;
         }
@@ -347,18 +347,18 @@ namespace {
 
         // Check if design is valid
         if (!ShipDesign::ValidDesign(hull, parts)) {
-            ErrorLogger() << "PythonUniverseGenerator::CreateShipDesign: invalid ship design";
+            ErrorLogger() << "CreateShipDesign: invalid ship design";
             return false;
         }
 
         // Create the design and add it to the universe
         ShipDesign* design = new ShipDesign(name, description, BEFORE_FIRST_TURN, ALL_EMPIRES, hull, parts, icon, model, true, monster);
         if (!design) {
-            ErrorLogger() << "PythonUniverseGenerator::CreateShipDesign: couldn't create ship design";
+            ErrorLogger() << "CreateShipDesign: couldn't create ship design";
             return false;
         }
         if (universe.InsertShipDesign(design) == ShipDesign::INVALID_DESIGN_ID) {
-            ErrorLogger() << "PythonUniverseGenerator::CreateShipDesign: couldn't insert ship design into universe";
+            ErrorLogger() << "CreateShipDesign: couldn't insert ship design into universe";
             delete design;
             return false;
         }
@@ -481,7 +481,7 @@ namespace {
             // get the universe object to test and check if it exists
             TemporaryPtr<UniverseObject> obj = GetUniverseObject(object_id);
             if (!obj) {
-                ErrorLogger() << "PythonUniverseGenerator::MonsterFleetPlanWrapper::Location: Couldn't get object with ID " << object_id;
+                ErrorLogger() << "MonsterFleetPlanWrapper::Location: Couldn't get object with ID " << object_id;
                 return false;
             }
 
@@ -518,7 +518,7 @@ namespace {
     object GetName(int object_id) {
         TemporaryPtr<UniverseObject> obj = GetUniverseObject(object_id);
         if (!obj) {
-            ErrorLogger() << "PythonUniverseGenerator::GetName: Couldn't get object with ID " << object_id;
+            ErrorLogger() << "GetName: Couldn't get object with ID " << object_id;
             return object("");
         }
         return object(obj->Name());
@@ -527,7 +527,7 @@ namespace {
     void SetName(int object_id, const std::string& name) {
         TemporaryPtr<UniverseObject> obj = GetUniverseObject(object_id);
         if (!obj) {
-            ErrorLogger() << "PythonUniverseGenerator::RenameUniverseObject: Couldn't get object with ID " << object_id;
+            ErrorLogger() << "RenameUniverseObject: Couldn't get object with ID " << object_id;
             return;
         }
         obj->Rename(name);
@@ -536,7 +536,7 @@ namespace {
     double GetX(int object_id) {
         TemporaryPtr<UniverseObject> obj = GetUniverseObject(object_id);
         if (!obj) {
-            ErrorLogger() << "PythonUniverseGenerator::GetX: Couldn't get object with ID " << object_id;
+            ErrorLogger() << "GetX: Couldn't get object with ID " << object_id;
             return UniverseObject::INVALID_POSITION;
         }
         return obj->X();
@@ -545,7 +545,7 @@ namespace {
     double GetY(int object_id) {
         TemporaryPtr<UniverseObject> obj = GetUniverseObject(object_id);
         if (!obj) {
-            ErrorLogger() << "PythonUniverseGenerator::GetY: Couldn't get object with ID " << object_id;
+            ErrorLogger() << "GetY: Couldn't get object with ID " << object_id;
             return UniverseObject::INVALID_POSITION;
         }
         return obj->Y();
@@ -554,7 +554,7 @@ namespace {
     tuple GetPos(int object_id) {
         TemporaryPtr<UniverseObject> obj = GetUniverseObject(object_id);
         if (!obj) {
-            ErrorLogger() << "PythonUniverseGenerator::GetPos: Couldn't get object with ID " << object_id;
+            ErrorLogger() << "GetPos: Couldn't get object with ID " << object_id;
             return make_tuple(UniverseObject::INVALID_POSITION, UniverseObject::INVALID_POSITION);
         }
         return make_tuple(obj->X(), obj->Y());
@@ -563,7 +563,7 @@ namespace {
     int GetOwner(int object_id) {
         TemporaryPtr<UniverseObject> obj = GetUniverseObject(object_id);
         if (!obj) {
-            ErrorLogger() << "PythonUniverseGenerator::GetOwner: Couldn't get object with ID " << object_id;
+            ErrorLogger() << "GetOwner: Couldn't get object with ID " << object_id;
             return ALL_EMPIRES;
         }
         return obj->Owner();
@@ -573,13 +573,13 @@ namespace {
         // get the universe object and check if it exists
         TemporaryPtr<UniverseObject> obj = GetUniverseObject(object_id);
         if (!obj) {
-            ErrorLogger() << "PythonUniverseGenerator::AddSpecial: Couldn't get object with ID " << object_id;
+            ErrorLogger() << "AddSpecial: Couldn't get object with ID " << object_id;
             return;
         }
         // check if the special exists
         const Special* special = GetSpecial(special_name);
         if (!special) {
-            ErrorLogger() << "PythonUniverseGenerator::AddSpecial: couldn't get special " << special_name;
+            ErrorLogger() << "AddSpecial: couldn't get special " << special_name;
             return;
         }
 
@@ -592,12 +592,12 @@ namespace {
         // get the universe object and check if it exists
         TemporaryPtr<UniverseObject> obj = GetUniverseObject(object_id);
         if (!obj) {
-            ErrorLogger() << "PythonUniverseGenerator::RemoveSpecial: Couldn't get object with ID " << object_id;
+            ErrorLogger() << "RemoveSpecial: Couldn't get object with ID " << object_id;
             return;
         }
         // check if the special exists
         if (!GetSpecial(special_name)) {
-            ErrorLogger() << "PythonUniverseGenerator::RemoveSpecial: couldn't get special " << special_name;
+            ErrorLogger() << "RemoveSpecial: couldn't get special " << special_name;
             return;
         }
         obj->RemoveSpecial(special_name);
@@ -637,14 +637,14 @@ namespace {
     int CreateSystem(StarType star_type, const std::string& star_name, double x, double y) {
         // Check if star type is set to valid value
         if ((star_type == INVALID_STAR_TYPE) || (star_type == NUM_STAR_TYPES)) {
-            ErrorLogger() << "PythonUniverseGenerator::CreateSystem : Can't create a system with a star of type " << star_type;
+            ErrorLogger() << "CreateSystem : Can't create a system with a star of type " << star_type;
             return INVALID_OBJECT_ID;
         }
 
         // Create system and insert it into the object map
         TemporaryPtr<System> system = GetUniverse().CreateSystem(star_type, star_name, x, y);
         if (!system) {
-            ErrorLogger() << "PythonUniverseGenerator::CreateSystem : Attempt to insert system into the object map failed";
+            ErrorLogger() << "CreateSystem : Attempt to insert system into the object map failed";
             return INVALID_OBJECT_ID;
         }
 
@@ -657,45 +657,45 @@ namespace {
         // Perform some validity checks
         // Check if system with id system_id exists
         if (!system) {
-            ErrorLogger() << "PythonUniverseGenerator::CreatePlanet : Couldn't get system with ID " << system_id;
+            ErrorLogger() << "CreatePlanet : Couldn't get system with ID " << system_id;
             return INVALID_OBJECT_ID;
         }
 
         // Check if orbit number is within allowed range
         if ((orbit < 0) || (orbit >= system->Orbits())) {
-            ErrorLogger() << "PythonUniverseGenerator::CreatePlanet : There is no orbit " << orbit << " in system " << system_id;
+            ErrorLogger() << "CreatePlanet : There is no orbit " << orbit << " in system " << system_id;
             return INVALID_OBJECT_ID;
         }
 
         // Check if desired orbit is still empty
         if (system->OrbitOccupied(orbit)) {
-            ErrorLogger() << "PythonUniverseGenerator::CreatePlanet : Orbit " << orbit << " of system " << system_id << " already occupied";
+            ErrorLogger() << "CreatePlanet : Orbit " << orbit << " of system " << system_id << " already occupied";
             return INVALID_OBJECT_ID;
         }
 
         // Check if planet size is set to valid value
         if ((size < SZ_TINY) || (size > SZ_GASGIANT)) {
-            ErrorLogger() << "PythonUniverseGenerator::CreatePlanet : Can't create a planet of size " << size;
+            ErrorLogger() << "CreatePlanet : Can't create a planet of size " << size;
             return INVALID_OBJECT_ID;
         }
 
         // Check if planet type is set to valid value
         if ((planet_type < PT_SWAMP) || (planet_type > PT_GASGIANT)) {
-            ErrorLogger() << "PythonUniverseGenerator::CreatePlanet : Can't create a planet of type " << planet_type;
+            ErrorLogger() << "CreatePlanet : Can't create a planet of type " << planet_type;
             return INVALID_OBJECT_ID;
         }
 
         // Check if planet type and size match
         // if type is gas giant, size must be too, same goes for asteroids
         if (((planet_type == PT_GASGIANT) && (size != SZ_GASGIANT)) || ((planet_type == PT_ASTEROIDS) && (size != SZ_ASTEROIDS))) {
-            ErrorLogger() << "PythonUniverseGenerator::CreatePlanet : Planet of type " << planet_type << " can't have size " << size;
+            ErrorLogger() << "CreatePlanet : Planet of type " << planet_type << " can't have size " << size;
             return INVALID_OBJECT_ID;
         }
 
         // Create planet and insert it into the object map
         TemporaryPtr<Planet> planet = GetUniverse().CreatePlanet(planet_type, size);
         if (!planet) {
-            ErrorLogger() << "PythonUniverseGenerator::CreateSystem : Attempt to insert planet into the object map failed";
+            ErrorLogger() << "CreateSystem : Attempt to insert planet into the object map failed";
             return INVALID_OBJECT_ID;
         }
 
@@ -712,25 +712,25 @@ namespace {
     int CreateBuilding(const std::string& building_type, int planet_id, int empire_id) {
         TemporaryPtr<Planet> planet = Objects().Object<Planet>(planet_id);
         if (!planet) {
-            ErrorLogger() << "PythonUniverseGenerator::CreateBuilding: couldn't get planet with ID " << planet_id;
+            ErrorLogger() << "CreateBuilding: couldn't get planet with ID " << planet_id;
             return INVALID_OBJECT_ID;
         }
 
         TemporaryPtr<System> system = GetSystem(planet->SystemID());
         if (!system) {
-            ErrorLogger() << "PythonUniverseGenerator::CreateBuilding: couldn't get system for planet";
+            ErrorLogger() << "CreateBuilding: couldn't get system for planet";
             return INVALID_OBJECT_ID;
         }
 
         const Empire* empire = GetEmpire(empire_id);
         if (!empire) {
-            ErrorLogger() << "PythonUniverseGenerator::CreateBuilding: couldn't get empire with ID " << empire_id;
+            ErrorLogger() << "CreateBuilding: couldn't get empire with ID " << empire_id;
             return INVALID_OBJECT_ID;
         }
 
         TemporaryPtr<Building> building = GetUniverse().CreateBuilding(empire_id, building_type, empire_id);
         if (!building) {
-            ErrorLogger() << "PythonUniverseGenerator::CreateBuilding: couldn't create building";
+            ErrorLogger() << "CreateBuilding: couldn't create building";
             return INVALID_OBJECT_ID;
         }
 
@@ -744,14 +744,14 @@ namespace {
         // Get system and check if it exists
         TemporaryPtr<System> system = Objects().Object<System>(system_id);
         if (!system) {
-            ErrorLogger() << "PythonUniverseGenerator::CreateFleet: couldn't get system with ID " << system_id;
+            ErrorLogger() << "CreateFleet: couldn't get system with ID " << system_id;
             return INVALID_OBJECT_ID;
         }
 
         // Create new fleet at the position of the specified system
         TemporaryPtr<Fleet> fleet = GetUniverse().CreateFleet(name, system->X(), system->Y(), empire_id);
         if (!fleet) {
-            ErrorLogger() << "PythonUniverseGenerator::CreateFleet: couldn't create new fleet";
+            ErrorLogger() << "CreateFleet: couldn't create new fleet";
             return INVALID_OBJECT_ID;
         }
 
@@ -773,27 +773,27 @@ namespace {
 
         // check if we got a species name, if yes, check if species exists
         if (!species.empty() && !GetSpecies(species)) {
-            ErrorLogger() << "PythonUniverseGenerator::CreateShip: invalid species specified";
+            ErrorLogger() << "CreateShip: invalid species specified";
             return INVALID_OBJECT_ID;
         }
 
         // get ship design and check if it exists
         const ShipDesign* ship_design = universe.GetGenericShipDesign(design_name);
         if (!ship_design) {
-            ErrorLogger() << "PythonUniverseGenerator::CreateShip: couldn't get ship design " << design_name;
+            ErrorLogger() << "CreateShip: couldn't get ship design " << design_name;
             return INVALID_OBJECT_ID;
         }
 
         // get fleet and check if it exists
         TemporaryPtr<Fleet> fleet = GetFleet(fleet_id);
         if (!fleet) {
-            ErrorLogger() << "PythonUniverseGenerator::CreateShip: couldn't get fleet with ID " << fleet_id;
+            ErrorLogger() << "CreateShip: couldn't get fleet with ID " << fleet_id;
             return INVALID_OBJECT_ID;
         }
 
         TemporaryPtr<System> system = GetSystem(fleet->SystemID());
         if (!system) {
-            ErrorLogger() << "PythonUniverseGenerator::CreateShip: couldn't get system for fleet";
+            ErrorLogger() << "CreateShip: couldn't get system for fleet";
             return INVALID_OBJECT_ID;
         }
 
@@ -804,7 +804,7 @@ namespace {
         if (empire_id != ALL_EMPIRES) {
             empire = GetEmpire(empire_id);
             if (!empire) {
-                ErrorLogger() << "PythonUniverseGenerator::CreateShip: couldn't get empire with ID " << empire_id;
+                ErrorLogger() << "CreateShip: couldn't get empire with ID " << empire_id;
                 return INVALID_OBJECT_ID;
             }
         }
@@ -812,7 +812,7 @@ namespace {
         // create new ship
         TemporaryPtr<Ship> ship = universe.CreateShip(empire_id, ship_design->ID(), species, empire_id);
         if (!ship) {
-            ErrorLogger() << "PythonUniverseGenerator::CreateShip: couldn't create new ship";
+            ErrorLogger() << "CreateShip: couldn't create new ship";
             return INVALID_OBJECT_ID;
         }
         system->Insert(ship);
@@ -861,24 +861,24 @@ namespace {
         // check if a field type with the specified field type name exists and get the field type
         const FieldType* field_type = GetFieldType(field_type_name);
         if (!field_type) {
-            ErrorLogger() << "PythonUniverseGenerator::CreateFieldImpl: couldn't get field type with name: " << field_type_name;
+            ErrorLogger() << "CreateFieldImpl: couldn't get field type with name: " << field_type_name;
             return TemporaryPtr<Field>();
         }
 
         // check if the specified size is within sane limits, and reset its value if not
         if (size < 1.0) {
-            ErrorLogger() << "PythonUniverseGenerator::CreateFieldImpl given very small / negative size: " << size << ", resetting to 1.0";
+            ErrorLogger() << "CreateFieldImpl given very small / negative size: " << size << ", resetting to 1.0";
             size = 1.0;
         }
         if (size > 10000.0) {
-            ErrorLogger() << "PythonUniverseGenerator::CreateFieldImpl given very large size: " << size << ", so resetting to 10000.0";
+            ErrorLogger() << "CreateFieldImpl given very large size: " << size << ", so resetting to 10000.0";
             size = 10000.0;
         }
 
         // create the new field
         TemporaryPtr<Field> field = GetUniverse().CreateField(field_type->Name(), x, y, size);
         if (!field) {
-            ErrorLogger() << "PythonUniverseGenerator::CreateFieldImpl: couldn't create field";
+            ErrorLogger() << "CreateFieldImpl: couldn't create field";
             return TemporaryPtr<Field>();
         }
 
@@ -899,7 +899,7 @@ namespace {
         // check if system exists and get system
         TemporaryPtr<System> system = GetSystem(system_id);
         if (!system) {
-            ErrorLogger() << "PythonUniverseGenerator::CreateFieldInSystem: couldn't get system with ID" << system_id;
+            ErrorLogger() << "CreateFieldInSystem: couldn't get system with ID" << system_id;
             return INVALID_OBJECT_ID;
         }
         // create the field with the coordinates of the system
@@ -914,7 +914,7 @@ namespace {
     StarType SystemGetStarType(int system_id) {
         TemporaryPtr<System> system = GetSystem(system_id);
         if (!system) {
-            ErrorLogger() << "PythonUniverseGenerator::SystemGetStarType: couldn't get system with ID " << system_id;
+            ErrorLogger() << "SystemGetStarType: couldn't get system with ID " << system_id;
             return INVALID_STAR_TYPE;
         }
         return system->GetStarType();
@@ -923,13 +923,13 @@ namespace {
     void SystemSetStarType(int system_id, StarType star_type) {
         // Check if star type is set to valid value
         if ((star_type == INVALID_STAR_TYPE) || (star_type == NUM_STAR_TYPES)) {
-            ErrorLogger() << "PythonUniverseGenerator::SystemSetStarType : Can't create a system with a star of type " << star_type;
+            ErrorLogger() << "SystemSetStarType : Can't create a system with a star of type " << star_type;
             return;
         }
 
         TemporaryPtr<System> system = GetSystem(system_id);
         if (!system) {
-            ErrorLogger() << "PythonUniverseGenerator::SystemSetStarType : Couldn't get system with ID " << system_id;
+            ErrorLogger() << "SystemSetStarType : Couldn't get system with ID " << system_id;
             return;
         }
 
@@ -939,7 +939,7 @@ namespace {
     int SystemGetNumOrbits(int system_id) {
         TemporaryPtr<System> system = GetSystem(system_id);
         if (!system) {
-            ErrorLogger() << "PythonUniverseGenerator::SystemGetNumOrbits : Couldn't get system with ID " << system_id;
+            ErrorLogger() << "SystemGetNumOrbits : Couldn't get system with ID " << system_id;
             return 0;
         }
         return system->Orbits();
@@ -949,7 +949,7 @@ namespace {
         list py_orbits;
         TemporaryPtr<System> system = GetSystem(system_id);
         if (!system) {
-            ErrorLogger() << "PythonUniverseGenerator::SystemFreeOrbits : Couldn't get system with ID " << system_id;
+            ErrorLogger() << "SystemFreeOrbits : Couldn't get system with ID " << system_id;
             return py_orbits;
         }
         const std::set<int>& orbits = system->FreeOrbits();
@@ -962,7 +962,7 @@ namespace {
     bool SystemOrbitOccupied(int system_id, int orbit) {
         TemporaryPtr<System> system = GetSystem(system_id);
         if (!system) {
-            ErrorLogger() << "PythonUniverseGenerator::SystemOrbitOccupied : Couldn't get system with ID " << system_id;
+            ErrorLogger() << "SystemOrbitOccupied : Couldn't get system with ID " << system_id;
             return 0;
         }
         return system->OrbitOccupied(orbit);
@@ -971,7 +971,7 @@ namespace {
     int SystemOrbitOfPlanet(int system_id, int planet_id) {
         TemporaryPtr<System> system = GetSystem(system_id);
         if (!system) {
-            ErrorLogger() << "PythonUniverseGenerator::SystemOrbitOfPlanet : Couldn't get system with ID " << system_id;
+            ErrorLogger() << "SystemOrbitOfPlanet : Couldn't get system with ID " << system_id;
             return 0;
         }
         return system->OrbitOfPlanet(planet_id);
@@ -981,7 +981,7 @@ namespace {
         list py_planets;
         TemporaryPtr<System> system = GetSystem(system_id);
         if (!system) {
-            ErrorLogger() << "PythonUniverseGenerator::SystemGetPlanets : Couldn't get system with ID " << system_id;
+            ErrorLogger() << "SystemGetPlanets : Couldn't get system with ID " << system_id;
             return py_planets;
         }
         const std::set<int>& planets = system->PlanetIDs();
@@ -995,7 +995,7 @@ namespace {
         list py_fleets;
         TemporaryPtr<System> system = GetSystem(system_id);
         if (!system) {
-            ErrorLogger() << "PythonUniverseGenerator::SystemGetFleets : Couldn't get system with ID " << system_id;
+            ErrorLogger() << "SystemGetFleets : Couldn't get system with ID " << system_id;
             return py_fleets;
         }
         const std::set<int>& fleets = system->FleetIDs();
@@ -1010,7 +1010,7 @@ namespace {
         // get source system
         TemporaryPtr<System> system = GetSystem(system_id);
         if (!system) {
-            ErrorLogger() << "PythonUniverseGenerator::SystemGetStarlanes : Couldn't get system with ID " << system_id;
+            ErrorLogger() << "SystemGetStarlanes : Couldn't get system with ID " << system_id;
             return py_starlanes;
         }
         // get list of systems the source system has starlanes to
@@ -1032,12 +1032,12 @@ namespace {
         // get source and destination system, check that both exist
         TemporaryPtr<System> from_sys = GetSystem(from_sys_id);
         if (!from_sys) {
-            ErrorLogger() << "PythonUniverseGenerator::SystemAddStarlane : Couldn't find system with ID " << from_sys_id;
+            ErrorLogger() << "SystemAddStarlane : Couldn't find system with ID " << from_sys_id;
             return;
         }
         TemporaryPtr<System> to_sys = GetSystem(to_sys_id);
         if (!to_sys) {
-            ErrorLogger() << "PythonUniverseGenerator::SystemAddStarlane : Couldn't find system with ID " << to_sys_id;
+            ErrorLogger() << "SystemAddStarlane : Couldn't find system with ID " << to_sys_id;
             return;
         }
         // add the starlane on both ends
@@ -1049,12 +1049,12 @@ namespace {
         // get source and destination system, check that both exist
         TemporaryPtr<System> from_sys = GetSystem(from_sys_id);
         if (!from_sys) {
-            ErrorLogger() << "PythonUniverseGenerator::SystemRemoveStarlane : Couldn't find system with ID " << from_sys_id;
+            ErrorLogger() << "SystemRemoveStarlane : Couldn't find system with ID " << from_sys_id;
             return;
         }
         TemporaryPtr<System> to_sys = GetSystem(to_sys_id);
         if (!to_sys) {
-            ErrorLogger() << "PythonUniverseGenerator::SystemRemoveStarlane : Couldn't find system with ID " << to_sys_id;
+            ErrorLogger() << "SystemRemoveStarlane : Couldn't find system with ID " << to_sys_id;
             return;
         }
         // remove the starlane from both ends
@@ -1066,7 +1066,7 @@ namespace {
     PlanetType PlanetGetType(int planet_id) {
         TemporaryPtr<Planet> planet = GetPlanet(planet_id);
         if (!planet) {
-            ErrorLogger() << "PythonUniverseGenerator::PlanetGetType: Couldn't get planet with ID " << planet_id;
+            ErrorLogger() << "PlanetGetType: Couldn't get planet with ID " << planet_id;
             return INVALID_PLANET_TYPE;
         }
         return planet->Type();
@@ -1075,7 +1075,7 @@ namespace {
     void PlanetSetType(int planet_id, PlanetType planet_type) {
         TemporaryPtr<Planet> planet = GetPlanet(planet_id);
         if (!planet) {
-            ErrorLogger() << "PythonUniverseGenerator::PlanetSetType: Couldn't get planet with ID " << planet_id;
+            ErrorLogger() << "PlanetSetType: Couldn't get planet with ID " << planet_id;
             return;
         }
 
@@ -1093,7 +1093,7 @@ namespace {
     PlanetSize PlanetGetSize(int planet_id) {
         TemporaryPtr<Planet> planet = GetPlanet(planet_id);
         if (!planet) {
-            ErrorLogger() << "PythonUniverseGenerator::PlanetGetSize: Couldn't get planet with ID " << planet_id;
+            ErrorLogger() << "PlanetGetSize: Couldn't get planet with ID " << planet_id;
             return INVALID_PLANET_SIZE;
         }
         return planet->Size();
@@ -1102,7 +1102,7 @@ namespace {
     void PlanetSetSize(int planet_id, PlanetSize planet_size) {
         TemporaryPtr<Planet> planet = GetPlanet(planet_id);
         if (!planet) {
-            ErrorLogger() << "PythonUniverseGenerator::PlanetSetSize: Couldn't get planet with ID " << planet_id;
+            ErrorLogger() << "PlanetSetSize: Couldn't get planet with ID " << planet_id;
             return;
         }
 
@@ -1118,7 +1118,7 @@ namespace {
     object PlanetGetSpecies(int planet_id) {
         TemporaryPtr<Planet> planet = GetPlanet(planet_id);
         if (!planet) {
-            ErrorLogger() << "PythonUniverseGenerator::PlanetGetSpecies: Couldn't get planet with ID " << planet_id;
+            ErrorLogger() << "PlanetGetSpecies: Couldn't get planet with ID " << planet_id;
             return object("");
         }
         return object(planet->SpeciesName());
@@ -1127,7 +1127,7 @@ namespace {
     void PlanetSetSpecies(int planet_id, const std::string& species_name) {
         TemporaryPtr<Planet> planet = GetPlanet(planet_id);
         if (!planet) {
-            ErrorLogger() << "PythonUniverseGenerator::PlanetSetSpecies: Couldn't get planet with ID " << planet_id;
+            ErrorLogger() << "PlanetSetSpecies: Couldn't get planet with ID " << planet_id;
             return;
         }
         planet->SetSpecies(species_name);
@@ -1136,7 +1136,7 @@ namespace {
     object PlanetGetFocus(int planet_id) {
         TemporaryPtr<Planet> planet = GetPlanet(planet_id);
         if (!planet) {
-            ErrorLogger() << "PythonUniverseGenerator::PlanetGetFocus: Couldn't get planet with ID " << planet_id;
+            ErrorLogger() << "PlanetGetFocus: Couldn't get planet with ID " << planet_id;
             return object("");
         }
         return object(planet->Focus());
@@ -1145,7 +1145,7 @@ namespace {
     void PlanetSetFocus(int planet_id, const std::string& focus) {
         TemporaryPtr<Planet> planet = GetPlanet(planet_id);
         if (!planet) {
-            ErrorLogger() << "PythonUniverseGenerator::PlanetSetSpecies: Couldn't get planet with ID " << planet_id;
+            ErrorLogger() << "PlanetSetSpecies: Couldn't get planet with ID " << planet_id;
             return;
         }
         planet->SetFocus(focus);
@@ -1155,7 +1155,7 @@ namespace {
         list py_foci;
         TemporaryPtr<Planet> planet = GetPlanet(planet_id);
         if (!planet) {
-            ErrorLogger() << "PythonUniverseGenerator::PlanetAvailableFoci: Couldn't get planet with ID " << planet_id;
+            ErrorLogger() << "PlanetAvailableFoci: Couldn't get planet with ID " << planet_id;
             return py_foci;
         }
         std::vector<std::string> foci = planet->AvailableFoci();
@@ -1168,12 +1168,12 @@ namespace {
     bool PlanetMakeOutpost(int planet_id, int empire_id) {
         TemporaryPtr<Planet> planet = GetPlanet(planet_id);
         if (!planet) {
-            ErrorLogger() << "PythonUniverseGenerator::PlanetMakeOutpost: couldn't get planet with ID:" << planet_id;
+            ErrorLogger() << "PlanetMakeOutpost: couldn't get planet with ID:" << planet_id;
             return false;
         }
 
         if (!GetEmpire(empire_id)) {
-            ErrorLogger() << "PythonUniverseGenerator::PlanetMakeOutpost: couldn't get empire with ID " << empire_id;
+            ErrorLogger() << "PlanetMakeOutpost: couldn't get empire with ID " << empire_id;
             return false;
         }
 
@@ -1183,17 +1183,17 @@ namespace {
     bool PlanetMakeColony(int planet_id, int empire_id, const std::string& species, double population) {
         TemporaryPtr<Planet> planet = GetPlanet(planet_id);
         if (!planet) {
-            ErrorLogger() << "PythonUniverseGenerator::PlanetMakeColony: couldn't get planet with ID:" << planet_id;
+            ErrorLogger() << "PlanetMakeColony: couldn't get planet with ID:" << planet_id;
             return false;
         }
 
         if (!GetEmpire(empire_id)) {
-            ErrorLogger() << "PythonUniverseGenerator::PlanetMakeColony: couldn't get empire with ID " << empire_id;
+            ErrorLogger() << "PlanetMakeColony: couldn't get empire with ID " << empire_id;
             return false;
         }
 
         if (!GetSpecies(species)) {
-            ErrorLogger() << "PythonUniverseGenerator::PlanetMakeColony: couldn't get species with name: " << species;
+            ErrorLogger() << "PlanetMakeColony: couldn't get species with name: " << species;
             return false;
         }
 

--- a/universe/UniverseGenerator.cpp
+++ b/universe/UniverseGenerator.cpp
@@ -882,17 +882,17 @@ bool SetEmpireHomeworld(Empire* empire, int planet_id, std::string species_name)
     if (home_planet)
         home_system = GetSystem(home_planet->SystemID());
     if (!home_planet || !home_system) {
-        ErrorLogger() << "UniverseGenerator::SetEmpireHomeworld: couldn't get homeworld or system for empire" << empire->EmpireID();
+        ErrorLogger() << "SetEmpireHomeworld: couldn't get homeworld or system for empire" << empire->EmpireID();
         return false;
     }
 
-    DebugLogger() << "UniverseGenerator::SetEmpireHomeworld: setting system " << home_system->ID()
+    DebugLogger() << "SetEmpireHomeworld: setting system " << home_system->ID()
                   << " (planet " <<  home_planet->ID() << ") to be home system for empire " << empire->EmpireID();
 
     // get species, check if it exists
     Species* species = GetSpeciesManager().GetSpecies(species_name);
     if (!species) {
-        ErrorLogger() << "UniverseGenerator::SetEmpireHomeworld: couldn't get species \""
+        ErrorLogger() << "SetEmpireHomeworld: couldn't get species \""
                       << species_name << "\" to set with homeworld id " << home_planet->ID();
         return false;
     }
@@ -939,7 +939,7 @@ void InitEmpires(const std::map<int, PlayerSetupData>& player_setup_data)
     {
         int         player_id =     setup_data_it->first;
         if (player_id == Networking::INVALID_PLAYER_ID)
-            ErrorLogger() << "Universe::InitEmpires player id (" << player_id << ") is invalid";
+            ErrorLogger() << "InitEmpires player id (" << player_id << ") is invalid";
 
         // use player ID for empire ID so that the calling code can get the
         // correct empire for each player ID  in player_setup_data

--- a/util/SaveGamePreviewUtils.cpp
+++ b/util/SaveGamePreviewUtils.cpp
@@ -221,11 +221,11 @@ void LoadSaveGamePreviews(const fs::path& orig_path, const std::string& extensio
     }
 
     if (!fs::exists(path)) {
-        ErrorLogger() << "SaveFileListBox::LoadSaveGamePreviews: Save Game directory \"" << path << "\" not found";
+        ErrorLogger() << "LoadSaveGamePreviews: Save Game directory \"" << path << "\" not found";
         return;
     }
     if (!fs::is_directory(path)) {
-        ErrorLogger() << "SaveFileListBox::LoadSaveGamePreviews: Save Game directory \"" << path << "\" was not a directory";
+        ErrorLogger() << "LoadSaveGamePreviews: Save Game directory \"" << path << "\" was not a directory";
         return;
     }
 
@@ -239,7 +239,7 @@ void LoadSaveGamePreviews(const fs::path& orig_path, const std::string& extensio
                 }
             }
         } catch (const std::exception& e) {
-            ErrorLogger() << "SaveFileListBox::LoadSaveGamePreviews: Failed loading preview from " << it->path() << " because: " << e.what();
+            ErrorLogger() << "LoadSaveGamePreviews: Failed loading preview from " << it->path() << " because: " << e.what();
         }
     }
 }


### PR DESCRIPTION
Remove error log prefixes that match name of file.

According to search with `ErrorLogger\(\) << "\w*::` there is still 480 lines that should be checked.
