### PR TITLE
Fixed issues with weapon ship part meters introduced by a72d77f

### DIFF
--- a/default/species.txt
+++ b/default/species.txt
@@ -3887,22 +3887,22 @@ BAD_WEAPONS
             description = "BAD_WEAPONS"
             scope = Source
             effects = [
-                SetDamage partname = "SR_WEAPON_1_1" value = Value - 1
-                SetDamage partname = "SR_WEAPON_1_2" value = Value - 1
-                SetDamage partname = "SR_WEAPON_1_3" value = Value - 2
-                SetDamage partname = "SR_WEAPON_1_4" value = Value - 2
-                SetDamage partname = "SR_WEAPON_2_1" value = Value - 2
-                SetDamage partname = "SR_WEAPON_2_2" value = Value - 2
-                SetDamage partname = "SR_WEAPON_2_3" value = Value - 3
-                SetDamage partname = "SR_WEAPON_2_4" value = Value - 3
-                SetDamage partname = "SR_WEAPON_3_1" value = Value - 3
-                SetDamage partname = "SR_WEAPON_3_2" value = Value - 3
-                SetDamage partname = "SR_WEAPON_3_3" value = Value - 4
-                SetDamage partname = "SR_WEAPON_3_4" value = Value - 5
-                SetDamage partname = "SR_WEAPON_4_1" value = Value - 4
-                SetDamage partname = "SR_WEAPON_4_2" value = Value - 5
-                SetDamage partname = "SR_WEAPON_4_3" value = Value - 7
-                SetDamage partname = "SR_WEAPON_4_4" value = Value - 8
+                SetMaxDamage partname = "SR_WEAPON_1_1" value = Value - 1
+                SetMaxDamage partname = "SR_WEAPON_1_2" value = Value - 1
+                SetMaxDamage partname = "SR_WEAPON_1_3" value = Value - 2
+                SetMaxDamage partname = "SR_WEAPON_1_4" value = Value - 2
+                SetMaxDamage partname = "SR_WEAPON_2_1" value = Value - 2
+                SetMaxDamage partname = "SR_WEAPON_2_2" value = Value - 2
+                SetMaxDamage partname = "SR_WEAPON_2_3" value = Value - 3
+                SetMaxDamage partname = "SR_WEAPON_2_4" value = Value - 3
+                SetMaxDamage partname = "SR_WEAPON_3_1" value = Value - 3
+                SetMaxDamage partname = "SR_WEAPON_3_2" value = Value - 3
+                SetMaxDamage partname = "SR_WEAPON_3_3" value = Value - 4
+                SetMaxDamage partname = "SR_WEAPON_3_4" value = Value - 5
+                SetMaxDamage partname = "SR_WEAPON_4_1" value = Value - 4
+                SetMaxDamage partname = "SR_WEAPON_4_2" value = Value - 5
+                SetMaxDamage partname = "SR_WEAPON_4_3" value = Value - 7
+                SetMaxDamage partname = "SR_WEAPON_4_4" value = Value - 8
         ]
 '''
 
@@ -3911,22 +3911,22 @@ GOOD_WEAPONS
             description = "GOOD_WEAPONS"
             scope = Source
             effects = [
-                SetDamage partname = "SR_WEAPON_1_1" value = Value + 1
-                SetDamage partname = "SR_WEAPON_1_2" value = Value + 1
-                SetDamage partname = "SR_WEAPON_1_3" value = Value + 2
-                SetDamage partname = "SR_WEAPON_1_4" value = Value + 2
-                SetDamage partname = "SR_WEAPON_2_1" value = Value + 2
-                SetDamage partname = "SR_WEAPON_2_2" value = Value + 2
-                SetDamage partname = "SR_WEAPON_2_3" value = Value + 3
-                SetDamage partname = "SR_WEAPON_2_4" value = Value + 3
-                SetDamage partname = "SR_WEAPON_3_1" value = Value + 3
-                SetDamage partname = "SR_WEAPON_3_2" value = Value + 3
-                SetDamage partname = "SR_WEAPON_3_3" value = Value + 4
-                SetDamage partname = "SR_WEAPON_3_4" value = Value + 5
-                SetDamage partname = "SR_WEAPON_4_1" value = Value + 4
-                SetDamage partname = "SR_WEAPON_4_2" value = Value + 5
-                SetDamage partname = "SR_WEAPON_4_3" value = Value + 7
-                SetDamage partname = "SR_WEAPON_4_4" value = Value + 8
+                SetMaxDamage partname = "SR_WEAPON_1_1" value = Value + 1
+                SetMaxDamage partname = "SR_WEAPON_1_2" value = Value + 1
+                SetMaxDamage partname = "SR_WEAPON_1_3" value = Value + 2
+                SetMaxDamage partname = "SR_WEAPON_1_4" value = Value + 2
+                SetMaxDamage partname = "SR_WEAPON_2_1" value = Value + 2
+                SetMaxDamage partname = "SR_WEAPON_2_2" value = Value + 2
+                SetMaxDamage partname = "SR_WEAPON_2_3" value = Value + 3
+                SetMaxDamage partname = "SR_WEAPON_2_4" value = Value + 3
+                SetMaxDamage partname = "SR_WEAPON_3_1" value = Value + 3
+                SetMaxDamage partname = "SR_WEAPON_3_2" value = Value + 3
+                SetMaxDamage partname = "SR_WEAPON_3_3" value = Value + 4
+                SetMaxDamage partname = "SR_WEAPON_3_4" value = Value + 5
+                SetMaxDamage partname = "SR_WEAPON_4_1" value = Value + 4
+                SetMaxDamage partname = "SR_WEAPON_4_2" value = Value + 5
+                SetMaxDamage partname = "SR_WEAPON_4_3" value = Value + 7
+                SetMaxDamage partname = "SR_WEAPON_4_4" value = Value + 8
         ]
 '''
 
@@ -3935,22 +3935,22 @@ GREAT_WEAPONS
             description = "GREAT_WEAPONS"
             scope = Source
             effects = [
-                SetDamage partname = "SR_WEAPON_1_1" value = Value + 2
-                SetDamage partname = "SR_WEAPON_1_2" value = Value + 2
-                SetDamage partname = "SR_WEAPON_1_3" value = Value + 3
-                SetDamage partname = "SR_WEAPON_1_4" value = Value + 3
-                SetDamage partname = "SR_WEAPON_2_1" value = Value + 3
-                SetDamage partname = "SR_WEAPON_2_2" value = Value + 3
-                SetDamage partname = "SR_WEAPON_2_3" value = Value + 5
-                SetDamage partname = "SR_WEAPON_2_4" value = Value + 6
-                SetDamage partname = "SR_WEAPON_3_1" value = Value + 5
-                SetDamage partname = "SR_WEAPON_3_2" value = Value + 6
-                SetDamage partname = "SR_WEAPON_3_3" value = Value + 8
-                SetDamage partname = "SR_WEAPON_3_4" value = Value + 9
-                SetDamage partname = "SR_WEAPON_4_1" value = Value + 8
-                SetDamage partname = "SR_WEAPON_4_2" value = Value + 10
-                SetDamage partname = "SR_WEAPON_4_3" value = Value + 13
-                SetDamage partname = "SR_WEAPON_4_4" value = Value + 15
+                SetMaxDamage partname = "SR_WEAPON_1_1" value = Value + 2
+                SetMaxDamage partname = "SR_WEAPON_1_2" value = Value + 2
+                SetMaxDamage partname = "SR_WEAPON_1_3" value = Value + 3
+                SetMaxDamage partname = "SR_WEAPON_1_4" value = Value + 3
+                SetMaxDamage partname = "SR_WEAPON_2_1" value = Value + 3
+                SetMaxDamage partname = "SR_WEAPON_2_2" value = Value + 3
+                SetMaxDamage partname = "SR_WEAPON_2_3" value = Value + 5
+                SetMaxDamage partname = "SR_WEAPON_2_4" value = Value + 6
+                SetMaxDamage partname = "SR_WEAPON_3_1" value = Value + 5
+                SetMaxDamage partname = "SR_WEAPON_3_2" value = Value + 6
+                SetMaxDamage partname = "SR_WEAPON_3_3" value = Value + 8
+                SetMaxDamage partname = "SR_WEAPON_3_4" value = Value + 9
+                SetMaxDamage partname = "SR_WEAPON_4_1" value = Value + 8
+                SetMaxDamage partname = "SR_WEAPON_4_2" value = Value + 10
+                SetMaxDamage partname = "SR_WEAPON_4_3" value = Value + 13
+                SetMaxDamage partname = "SR_WEAPON_4_4" value = Value + 15
         ]
 '''
 
@@ -3959,22 +3959,22 @@ ULTIMATE_WEAPONS
             description = "ULTIMATE_WEAPONS"
             scope = Source
             effects = [
-                SetDamage partname = "SR_WEAPON_1_1" value = Value + 3
-                SetDamage partname = "SR_WEAPON_1_2" value = Value + 4
-                SetDamage partname = "SR_WEAPON_1_3" value = Value + 5
-                SetDamage partname = "SR_WEAPON_1_4" value = Value + 6
-                SetDamage partname = "SR_WEAPON_2_1" value = Value + 5
-                SetDamage partname = "SR_WEAPON_2_2" value = Value + 7
-                SetDamage partname = "SR_WEAPON_2_3" value = Value + 9
-                SetDamage partname = "SR_WEAPON_2_4" value = Value + 11
-                SetDamage partname = "SR_WEAPON_3_1" value = Value + 9
-                SetDamage partname = "SR_WEAPON_3_2" value = Value + 12
-                SetDamage partname = "SR_WEAPON_3_3" value = Value + 15
-                SetDamage partname = "SR_WEAPON_3_4" value = Value + 18
-                SetDamage partname = "SR_WEAPON_4_1" value = Value + 15
-                SetDamage partname = "SR_WEAPON_4_2" value = Value + 20
-                SetDamage partname = "SR_WEAPON_4_3" value = Value + 25
-                SetDamage partname = "SR_WEAPON_4_4" value = Value + 30
+                SetMaxDamage partname = "SR_WEAPON_1_1" value = Value + 3
+                SetMaxDamage partname = "SR_WEAPON_1_2" value = Value + 4
+                SetMaxDamage partname = "SR_WEAPON_1_3" value = Value + 5
+                SetMaxDamage partname = "SR_WEAPON_1_4" value = Value + 6
+                SetMaxDamage partname = "SR_WEAPON_2_1" value = Value + 5
+                SetMaxDamage partname = "SR_WEAPON_2_2" value = Value + 7
+                SetMaxDamage partname = "SR_WEAPON_2_3" value = Value + 9
+                SetMaxDamage partname = "SR_WEAPON_2_4" value = Value + 11
+                SetMaxDamage partname = "SR_WEAPON_3_1" value = Value + 9
+                SetMaxDamage partname = "SR_WEAPON_3_2" value = Value + 12
+                SetMaxDamage partname = "SR_WEAPON_3_3" value = Value + 15
+                SetMaxDamage partname = "SR_WEAPON_3_4" value = Value + 18
+                SetMaxDamage partname = "SR_WEAPON_4_1" value = Value + 15
+                SetMaxDamage partname = "SR_WEAPON_4_2" value = Value + 20
+                SetMaxDamage partname = "SR_WEAPON_4_3" value = Value + 25
+                SetMaxDamage partname = "SR_WEAPON_4_4" value = Value + 30
         ]
 
 '''

--- a/universe/Ship.cpp
+++ b/universe/Ship.cpp
@@ -134,7 +134,7 @@ void Ship::Copy(TemporaryPtr<const UniverseObject> copied_object, int empire_id)
             this->m_design_id =             copied_ship->m_design_id;
             for (PartMeterMap::const_iterator it = copied_ship->m_part_meters.begin();
                  it != copied_ship->m_part_meters.end(); ++it)
-            { this->m_part_meters[it->first]; }
+            { this->m_part_meters = copied_ship->m_part_meters; }
             this->m_species_name =          copied_ship->m_species_name;
 
             if (vis >= VIS_FULL_VISIBILITY) {
@@ -143,7 +143,6 @@ void Ship::Copy(TemporaryPtr<const UniverseObject> copied_object, int empire_id)
                 this->m_ordered_invade_planet_id  = copied_ship->m_ordered_invade_planet_id;
                 this->m_ordered_bombard_planet_id = copied_ship->m_ordered_bombard_planet_id;
                 this->m_last_turn_active_in_combat= copied_ship->m_last_turn_active_in_combat;
-                this->m_part_meters =               copied_ship->m_part_meters;
                 this->m_produced_by_empire_id =     copied_ship->m_produced_by_empire_id;
             }
         }
@@ -590,6 +589,7 @@ void Ship::SetShipMetersToMax() {
         if (max_it == m_part_meters.end())
             continue;
 
+        max_it->second.SetCurrent(Meter::LARGE_VALUE);
         it->second.SetCurrent(Meter::LARGE_VALUE);
     }
 }


### PR DESCRIPTION
Changing the capacity ship part meter for weapons to a paired meter introduced several issues: space monsters that are created by the CreateShip effect had all their weapon strength set to 0, weapon species picks didn't get calculated correctly anymore, and the weapon strength of ships an empire has only partial visibility of were displayed incorrectly. This is an attempt to fix these issues.

There are other parts in the content scripts that affect weapon strength (experimenter outpost, head on a spike special) that might still be broken.

@geoffthemedio, can you check if these fixes are ok? I did some testing on OSX and it seems to work, but I'm not sure if my fixes might cause some unexpected side effects, especially the change to `Ship::Copy` to fix the visibility issue with the paired weapon ship part capacity meter.
