### PR TITLE
Fix compiler error

### DIFF
--- a/UI/FleetButton.cpp
+++ b/UI/FleetButton.cpp
@@ -266,7 +266,7 @@ void FleetButton::Init(const std::vector<int>& fleet_IDs, SizeType size_type) {
             GG::Pt direction_vector = dest - cur;
 
             if (direction_vector.x != GG::X0 || direction_vector.y != GG::Y0)
-                pointing_angle = 360.0f / TWO_PI * std::atan2(Value(direction_vector.y), Value(direction_vector.x)) + 90;
+                pointing_angle = 360.0f / TWO_PI * std::atan2(static_cast<float>(Value(direction_vector.y)), static_cast<float>(Value(direction_vector.x))) + 90;
         }
     }
 


### PR DESCRIPTION
MSVC2010, Win7:

```
1>..\..\UI\FleetButton.cpp(269): error C2668: 'atan2': ambiguous call to overloaded function
1>          c:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\include\math.h(109): could be 'double atan2(double,double)'
1>          c:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\include\math.h(507): or 'float atan2(float,float)'
1>          c:\Program Files (x86)\Microsoft Visual Studio 10.0\VC\include\math.h(555): or 'long double atan2(long double,long double)'
1>        while trying to match the argument list '(int, int)'

```
