### PR TITLE
Improving the production screen functionality

### DIFF
--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -1053,17 +1053,20 @@ void BuildDesignatorWnd::Update() {
 }
 
 void BuildDesignatorWnd::InitializeWindows() {
+
+    GG::X queue_width(GetOptionsDB().Get<int>("UI.queue-width"));
+
     const GG::X SIDEPANEL_WIDTH = GG::X(384); // Formerly "UI.sidepanel-width" default
     const GG::Y PANEL_HEIGHT    = GG::Y(240);
 
-    const GG::Pt pedia_ul(GG::X0, GG::Y0);
-    const GG::Pt pedia_wh(Width() - SIDEPANEL_WIDTH, PANEL_HEIGHT);
+    const GG::Pt pedia_ul(queue_width, GG::Y0);
+    const GG::Pt pedia_wh(Width() - SIDEPANEL_WIDTH - queue_width, PANEL_HEIGHT);
 
     const GG::Pt sidepanel_ul(Width() - SIDEPANEL_WIDTH, GG::Y0);
     const GG::Pt sidepanel_wh(SIDEPANEL_WIDTH, Height());
 
-    const GG::Pt selector_ul(GG::X0, Height() - PANEL_HEIGHT);
-    const GG::Pt selector_wh(Width() - SIDEPANEL_WIDTH, PANEL_HEIGHT);
+    const GG::Pt selector_ul(queue_width, Height() - PANEL_HEIGHT);
+    const GG::Pt selector_wh(Width() - SIDEPANEL_WIDTH - queue_width, PANEL_HEIGHT);
 
     m_enc_detail_panel->InitSizeMove(pedia_ul,      pedia_ul + pedia_wh);
     m_side_panel->      InitSizeMove(sidepanel_ul,  sidepanel_ul + sidepanel_wh);

--- a/UI/CUIControls.cpp
+++ b/UI/CUIControls.cpp
@@ -1388,10 +1388,10 @@ namespace {
     GG::Y VERTICAL_SECTION_GAP(4);
 }
 
-ProductionInfoPanel::ProductionInfoPanel(const std::string& title, const std::string& point_units_str,
-                                         GG::X w, GG::Y h) :
-    CUIWnd(title, GG::X0, GG::Y0, GG::X(120), GG::Y(120),
-           GG::INTERACTIVE | GG::RESIZABLE | GG::DRAGABLE | GG::ONTOP | PINABLE),
+ProductionInfoPanel::ProductionInfoPanel(const std::string& title, const std::string& point_units_str, const GG::X x, const GG::Y y,
+    const GG::X w, const GG::Y h, const std::string& config_name) :  
+
+    CUIWnd(title, x, y, w, h, GG::INTERACTIVE | GG::RESIZABLE | GG::DRAGABLE | GG::ONTOP | PINABLE, config_name),
     m_units_str(point_units_str),
     m_title_str(title),
     m_total_points_label(0),

--- a/UI/CUIControls.cpp
+++ b/UI/CUIControls.cpp
@@ -1389,7 +1389,7 @@ namespace {
 }
 
 ProductionInfoPanel::ProductionInfoPanel(const std::string& title, const std::string& point_units_str, const GG::X x, const GG::Y y,
-    const GG::X w, const GG::Y h, const std::string& config_name) :  
+                                         const GG::X w, const GG::Y h, const std::string& config_name) :  
 
     CUIWnd(title, x, y, w, h, GG::INTERACTIVE | GG::RESIZABLE | GG::DRAGABLE | GG::ONTOP | PINABLE, config_name),
     m_units_str(point_units_str),

--- a/UI/CUIControls.h
+++ b/UI/CUIControls.h
@@ -445,7 +445,7 @@ class ProductionInfoPanel : public CUIWnd {
 public:
     /** \name Structors */ //@{
     ProductionInfoPanel(const std::string& title, const std::string& point_units_str, const GG::X x, const GG::Y y,
-        const GG::X w, const GG::Y h, const std::string& config_name);
+                        const GG::X w, const GG::Y h, const std::string& config_name);
     //@}
 
     /** \name Accessors */ //@{

--- a/UI/CUIControls.h
+++ b/UI/CUIControls.h
@@ -444,8 +444,8 @@ public:
 class ProductionInfoPanel : public CUIWnd {
 public:
     /** \name Structors */ //@{
-    ProductionInfoPanel(const std::string& title, const std::string& point_units_str,
-                        GG::X w = GG::X1, GG::Y h = GG::Y1);
+    ProductionInfoPanel(const std::string& title, const std::string& point_units_str, const GG::X x, const GG::Y y,
+        const GG::X w, const GG::Y h, const std::string& config_name);
     //@}
 
     /** \name Accessors */ //@{

--- a/UI/CUIWnd.cpp
+++ b/UI/CUIWnd.cpp
@@ -623,7 +623,7 @@ GG::Rect CUIWnd::CalculatePosition() const
 
 void CUIWnd::SaveOptions() const {
     OptionsDB& db = GetOptionsDB();
-   
+
     // The default empty string means 'do not save/load properties'
     // Also do not save while the window is being dragged.
     if (m_config_name.empty() || !m_config_save || GG::GUI::GetGUI()->DragWnd(this, 0)) {

--- a/UI/CUIWnd.cpp
+++ b/UI/CUIWnd.cpp
@@ -623,7 +623,7 @@ GG::Rect CUIWnd::CalculatePosition() const
 
 void CUIWnd::SaveOptions() const {
     OptionsDB& db = GetOptionsDB();
-
+   
     // The default empty string means 'do not save/load properties'
     // Also do not save while the window is being dragged.
     if (m_config_name.empty() || !m_config_save || GG::GUI::GetGUI()->DragWnd(this, 0)) {
@@ -633,6 +633,7 @@ void CUIWnd::SaveOptions() const {
         return;
     } else if (!db.Get<bool>("UI.windows."+m_config_name+".initialized")) {
         // Don't save until the window has been given its proper default values
+        ErrorLogger() << "CUIWnd::SaveOptions() : \"" << m_config_name << "\" has not been initialized.";
         return;
     }
 

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -590,10 +590,10 @@ namespace {
 class ProductionQueueWnd : public CUIWnd {
 public:
     /** \name Structors */ //@{
-    explicit ProductionQueueWnd(GG::X w, GG::Y h) :
-        CUIWnd("", GG::X0, GG::Y0, w, h,
+    explicit ProductionQueueWnd(GG::X x, GG::Y y, GG::X w, GG::Y h) :
+        CUIWnd("", x, y, w, h,
                GG::INTERACTIVE | GG::RESIZABLE | GG::DRAGABLE | GG::ONTOP | PINABLE,
-               "ProductionQueueWnd"),
+               "production.ProductionQueueWnd"),
         m_queue_lb(0)
     {
         Init(HumanClientApp::GetApp()->EmpireID());
@@ -656,15 +656,11 @@ ProductionWnd::ProductionWnd(GG::X w, GG::Y h) :
 
     GG::X queue_width(GetOptionsDB().Get<int>("UI.queue-width"));
 
-    m_production_info_panel = new ProductionInfoPanel(UserString("PRODUCTION_WND_TITLE"),
-                                                      UserString("PRODUCTION_INFO_PP"),
-                                                      queue_width, GG::Y(100));
-
-    m_queue_wnd = new ProductionQueueWnd(queue_width, GG::Y(100));
-
-    GG::Pt buid_designator_wnd_size = ClientSize() - GG::Pt(queue_width, GG::Y0);
-    m_build_designator_wnd = new BuildDesignatorWnd(buid_designator_wnd_size.x, buid_designator_wnd_size.y);
-    m_build_designator_wnd->MoveTo(GG::Pt(queue_width, GG::Y0));
+    m_production_info_panel = new ProductionInfoPanel(UserString("PRODUCTION_WND_TITLE"), UserString("PRODUCTION_INFO_PP"),
+        GG::X0, GG::Y0, GG::X(queue_width), GG::Y(100), "production.InfoPanel");
+    m_queue_wnd = new ProductionQueueWnd(GG::X0, GG::Y(100), queue_width, GG::Y(ClientSize().y - 100));    
+    m_build_designator_wnd = new BuildDesignatorWnd(ClientSize().x, ClientSize().y);
+    
 
     SetChildClippingMode(ClipToClient);
 
@@ -702,19 +698,8 @@ void ProductionWnd::SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
         DoLayout();
 }
 
-void ProductionWnd::DoLayout() {
-    m_production_info_panel->MoveTo(GG::Pt(GG::X0, GG::Y0));
-    m_production_info_panel->Resize(GG::Pt(GG::X(GetOptionsDB().Get<int>("UI.queue-width")),
-                                           m_production_info_panel->MinUsableSize().y));
-    GG::Pt queue_ul = GG::Pt(GG::X(2), m_production_info_panel->Height());
-    GG::Pt queue_size = GG::Pt(m_production_info_panel->Width() - 4,
-                               ClientSize().y - 4 - m_production_info_panel->Height());
-    m_queue_wnd->SizeMove(queue_ul, queue_ul + queue_size);
-
-    GG::Pt build_wnd_size = ClientSize() - GG::Pt(m_production_info_panel->Width(), GG::Y0);
-    GG::Pt build_wnd_ul = GG::Pt(m_production_info_panel->Width(), GG::Y0);
-    m_build_designator_wnd->SizeMove(build_wnd_ul, build_wnd_ul + build_wnd_size);
-}
+void ProductionWnd::DoLayout()
+{}
 
 void ProductionWnd::Render()
 {}

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -675,8 +675,6 @@ ProductionWnd::ProductionWnd(GG::X w, GG::Y h) :
     AttachChild(m_production_info_panel);
     AttachChild(m_queue_wnd);
     AttachChild(m_build_designator_wnd);
-
-    DoLayout();
 }
 
 ProductionWnd::~ProductionWnd()
@@ -698,8 +696,18 @@ void ProductionWnd::SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
         DoLayout();
 }
 
-void ProductionWnd::DoLayout()
-{}
+void ProductionWnd::DoLayout() {
+
+    GG::X queue_width(GetOptionsDB().Get<int>("UI.queue-width"));
+
+    m_production_info_panel->MoveTo(GG::Pt(GG::X0, GG::Y0));
+    m_production_info_panel->Resize(GG::Pt(GG::X(queue_width), GG::Y(100)));
+
+    m_queue_wnd->MoveTo(GG::Pt(GG::X0, GG::Y(100)));
+    m_queue_wnd->Resize(GG::Pt(GG::X(queue_width), GG::Y(ClientSize().y - 100)));
+
+    m_build_designator_wnd->Resize(ClientSize());
+}
 
 void ProductionWnd::Render()
 {}

--- a/UI/ResearchWnd.cpp
+++ b/UI/ResearchWnd.cpp
@@ -205,7 +205,7 @@ ResearchWnd::ResearchWnd(GG::X w, GG::Y h) :
     GG::X queue_width(GetOptionsDB().Get<int>("UI.queue-width"));
 
     m_research_info_panel = new ProductionInfoPanel(UserString("RESEARCH_INFO_PANEL_TITLE"), UserString("RESEARCH_INFO_RP"),
-        GG::X0, GG::Y0, GG::X(queue_width), GG::Y(100), "research.InfoPanel");
+                                                    GG::X0, GG::Y0, GG::X(queue_width), GG::Y(100), "research.InfoPanel");
 
     m_queue_lb = new QueueListBox("RESEARCH_QUEUE_ROW", UserString("RESEARCH_QUEUE_PROMPT"));
     m_queue_lb->SetStyle(GG::LIST_NOSORT | GG::LIST_NOSEL | GG::LIST_USERDELETE);

--- a/UI/ResearchWnd.cpp
+++ b/UI/ResearchWnd.cpp
@@ -204,9 +204,8 @@ ResearchWnd::ResearchWnd(GG::X w, GG::Y h) :
 {
     GG::X queue_width(GetOptionsDB().Get<int>("UI.queue-width"));
 
-    m_research_info_panel = new ProductionInfoPanel(UserString("RESEARCH_INFO_PANEL_TITLE"),
-                                                    UserString("RESEARCH_INFO_RP"),
-                                                    queue_width, GG::Y(100));
+    m_research_info_panel = new ProductionInfoPanel(UserString("RESEARCH_INFO_PANEL_TITLE"), UserString("RESEARCH_INFO_RP"),
+        GG::X0, GG::Y0, GG::X(queue_width), GG::Y(100), "research.InfoPanel");
 
     m_queue_lb = new QueueListBox("RESEARCH_QUEUE_ROW", UserString("RESEARCH_QUEUE_PROMPT"));
     m_queue_lb->SetStyle(GG::LIST_NOSORT | GG::LIST_NOSEL | GG::LIST_USERDELETE);


### PR DESCRIPTION
- allow repositioning/resizing of production queue and production info panel
- allow production designator wnd and pedia to be moved to the left side of the screen

Can now arrange windows like this:
![prodscreen](https://cloud.githubusercontent.com/assets/12985960/12364895/aa86cda0-bbd1-11e5-9b3f-230dc5d556f9.jpg)
