### PR TITLE
Cleanup

### DIFF
--- a/default/AI/AIstate.py
+++ b/default/AI/AIstate.py
@@ -187,7 +187,7 @@ class AIstate(object):
         nametags = []
         for sys_id in newly_explored:
             newsys = universe.getSystem(sys_id)
-            nametags.append("ID:%4d -- %20s" % (sys_id, (newsys and newsys.name) or"name unknown"))  # an explored system *should* always be able to be gotten
+            nametags.append("ID:%4d -- %-20s" % (sys_id, (newsys and newsys.name) or "name unknown"))  # an explored system *should* always be able to be gotten
         if newly_explored:
             print "-------------------------------------------------"
             print "Newly explored systems:\n"+"\n".join(nametags)


### PR DESCRIPTION
- code style
- replace map+lambda with list comprehension
- prettify log prints
- remove optional function argument that never used

Log changes example (before - after):

```
Border Exploration Update (relative to S_101<Duna>
-------------------------------------------------
Considering border system S_101<Duna>
*** system ID 101 (Duna); previously a border system, new visibility turns info: ['basic: 1', 'partial: 1'] 
    previously knew of system 101 planets []
  * updating targetPop of planet 103 ( Eternal Duna II ) to 23.00 from 0.00
  * updating troops of planet 103 ( Eternal Duna II ) to 6.93 from 0.00
    now know of system 101 planets [102, 103]
    -- is  partially visible 
    -- is  visibly connected to homesystem
 -- has neighbors set([104, 107]) 
----------------------------------------------------------
*** system ID 107 (name unknown); previously a border system, new visibility turns info: ['basic: 1'] 
    -- is not partially visible 
    -- is  visibly connected to homesystem
----------------------------------------------------------
*** system ID 104 (name unknown); previously a border system, new visibility turns info: ['basic: 1'] 
    -- is not partially visible 
    -- is  visibly connected to homesystem
----------------------------------------------------------
Obstructed starlanes are: [(101, 104), (101, 107)]
Moved system 101 ( Duna ) from unexplored list to explored list
-------------------------------------------------
Newly explored systems:
ID: 101 --                 Duna
```

```
Border Exploration Update (relative to S_101<Duna>
-------------------------------------------------
Considering border system S_101<Duna>
*** system S_101<Duna>; previously a border system, new visibility turns info: basic: 1, partial: 1 
    previously knew planets: []
  * updating targetPop of planet P_103<Glorious Duna II> to 23.00 from 0.00
  * updating troops of planet P_103<Glorious Duna II> to 6.93 from 0.00
    known planets [102, 103]
    -- is  partially visible 
    -- is  visibly connected to homesystem
 -- has neighbors [104, 107]
----------------------------------------------------------
*** system S_107<>; previously a border system, new visibility turns info: basic: 1 
    -- is not partially visible 
    -- is  visibly connected to homesystem
----------------------------------------------------------
*** system S_104<>; previously a border system, new visibility turns info: basic: 1 
    -- is not partially visible 
    -- is visibly connected to homesystem
----------------------------------------------------------
Obstructed starlanes are: 101-104, 101-107
Moved system S_101<Duna> from unexplored list to explored list
-------------------------------------------------
Newly explored systems:
ID: 101 -- Duna 
```

That like it looks for me:
![log](https://cloud.githubusercontent.com/assets/171597/12372457/dc595df6-bc68-11e5-86c7-9382a2312584.png)
