### PR TITLE
Fix by Hacklin for out of range bug

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -426,10 +426,13 @@ void ResearchQueue::Update(float RPs, const std::map<std::string, float>& resear
             dpResearchableTechs.insert(i);
         } else if ( dpsim_tech_status_map[ techname  ] == TS_UNRESEARCHABLE ) {
             std::set<std::string> thesePrereqs = tech->Prerequisites();
-            for (std::set<std::string>::iterator ptech_it = thesePrereqs.begin(); ptech_it != thesePrereqs.end(); ++ptech_it){
-                if (dpsim_tech_status_map[ *ptech_it ] == TS_COMPLETE ) {
-                    std::set<std::string>::iterator eraseit = ptech_it--;
-                    thesePrereqs.erase( eraseit);
+            for (std::set<std::string>::iterator ptech_it = thesePrereqs.begin(); ptech_it != thesePrereqs.end(); ) {
+                if (dpsim_tech_status_map[ *ptech_it ] != TS_COMPLETE) {
+                    ++ptech_it;
+                } else {
+                    std::set<std::string>::iterator erase_it = ptech_it;
+                    ++ptech_it;
+                    thesePrereqs.erase( erase_it );
                 }
             }
             waitingForPrereqs[ techname ] = thesePrereqs;


### PR DESCRIPTION
If the first prerequisite tech is complete, the tech iterator is set before begin() and the prerequisite tech at begin() is removed. This can cause an AI to hang with the error: "Player AI_? no longer has a connection to the server."

Pull request for fix suggested in issue #440.
