### PR TITLE
Fix for boost link error on some Linux distros

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,9 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     add_definitions(
         -DFREEORION_LINUX
         -DENABLE_BINRELOC
+        -DBOOST_ALL_NO_LINK
         -DBOOST_ALL_DYN_LINK
+        -DBOOST_LOG_DYN_LINK
     )
     set (CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated -Wall -Wno-parentheses")
 elseif (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD")

--- a/GG/CMakeLists.txt
+++ b/GG/CMakeLists.txt
@@ -51,7 +51,11 @@ option(BUILD_DEVEL_PACKAGE
        ON)
 
 if (NOT DEFINED USE_STATIC_LIBS)
-    add_definitions(-DBOOST_ALL_DYN_LINK)
+    add_definitions(
+        -DBOOST_ALL_NO_LINK
+        -DBOOST_ALL_DYN_LINK
+        -DBOOST_LOG_DYN_LINK
+    )
 endif ()
 
 if (MSVC)


### PR DESCRIPTION
Added macro definitions BOOST_ALL_NO_LIB, BOOST_ALL_DYN_LINK and BOOST_LOG_DYN_LINK to CMakeLists.txt for building on Linux, and to GG/CMakeLists.txt when not using static libs to prevent reported boost link errors on some Linux distros.

This is an attempt to incorporate a fix provided by @codekiddy2 in issue #445 into master.
