### PR TITLE
Fix for potential boost link errors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,6 +75,19 @@ else ()
     message(FATAL_ERROR "Unknown platform type! Your setup is not a supported platform for FreeOrion.")
 endif ()
 
+# Need to know if the boost libraries are linked statically or dynamically
+# If dynamically, add some macro definitions to prevent potential link errors
+option(FO_LINK_STATIC_BOOST_LIBS "Link static boost libraries." OFF)
+
+if (NOT FO_LINK_STATIC_BOOST_LIBS)
+    add_definitions(
+        -DBOOST_ALL_NO_LINK
+        -DBOOST_ALL_DYN_LINK
+        -DBOOST_LOG_DYN_LINK
+    )
+endif ()
+
+
 find_package(PythonInterp ${PYTHON_VERSION} REQUIRED)
 
 # To run the version generation every compile we need to deferr the

--- a/GG/CMakeLists.txt
+++ b/GG/CMakeLists.txt
@@ -51,7 +51,11 @@ option(BUILD_DEVEL_PACKAGE
        ON)
 
 if (NOT DEFINED USE_STATIC_LIBS)
-    add_definitions(-DBOOST_ALL_DYN_LINK)
+    add_definitions(
+        -DBOOST_ALL_NO_LINK
+        -DBOOST_ALL_DYN_LINK
+        -DBOOST_LOG_DYN_LINK
+    )
 endif ()
 
 if (MSVC)


### PR DESCRIPTION
Added macro definitions BOOST_ALL_NO_LIB, BOOST_ALL_DYN_LINK and BOOST_LOG_DYN_LINK to CMakeLists.txt and to GG/CMakeLists.txt when not linking against static boost libs to prevent reported boost link errors.

This PR replaces PR #449. It is an attempt to implement a fix suggested by @codekiddy2 in issue #445. 
