### PR TITLE
aggressiv cache for _get_design_by_name

### DIFF
--- a/default/AI/EnumsAI.py
+++ b/default/AI/EnumsAI.py
@@ -152,6 +152,7 @@ class AIShipDesignTypes(object):
     outpostBase={"SD_OUTPOST_BASE":"A", "OutpostBase":"B"}
     troopBase={"SpaceInvaders":"A"}
     defenseBase={"Decoy":"A", "OrbitalGrid":"B", "OrbitalShield":"C", "OrbitalMultiShield":"D"}
+    SHIPDESIGN_INVALID = -1
 
 
 class AIShipRoleType(EnumsType):  # this is also used in determining fleetRoles


### PR DESCRIPTION
Storeing invalid designes in cache to increase cache hits. After
issueCreateShipDesignOrder the cache gets updated. Remove invalid
designs from cache durring cache consistency check at start of turn.
