### PR TITLE
New production selection window tooltip

### DIFF
--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -275,7 +275,7 @@ namespace {
             const std::string& enqueue_and_location_condition_failed_text = EnqueueAndLocationConditionDescription(item.name, candidate_object_id, empire_id, true);
             if (!enqueue_and_location_condition_failed_text.empty())
                 if (TemporaryPtr<UniverseObject> location = GetUniverseObject(candidate_object_id)) {
-                    const std::string& failed_cond_loc = boost::io::str(FlexibleFormat(UserString("PRODUCTION_WND_TOOLTIP_FAILED_COND")) % location->Name());
+                    std::string failed_cond_loc = boost::io::str(FlexibleFormat(UserString("PRODUCTION_WND_TOOLTIP_FAILED_COND")) % location->Name());
                     main_text += "\n\n" + failed_cond_loc + ":\n" + enqueue_and_location_condition_failed_text;
             }
 

--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -247,6 +247,74 @@ namespace {
     boost::shared_ptr<GG::BrowseInfoWnd> ProductionItemRowBrowseWnd(const ProductionQueue::ProductionItem& item,
                                                                     int candidate_object_id, int empire_id)
     {
+        std::string title; 
+        std::string main_text;
+        float total_cost;
+        int production_time;
+
+        // production item is a building
+        if (item.build_type == BT_BUILDING) {
+            const BuildingType* building_type = GetBuildingType(item.name);
+            if (!building_type) {
+                boost::shared_ptr<GG::BrowseInfoWnd> browse_wnd;
+                return browse_wnd;
+            }
+
+            // create title, description, production time and cost
+            title = UserString(item.name);
+            main_text = UserString(building_type->Description());
+            total_cost = building_type->ProductionCost(empire_id, candidate_object_id);
+            production_time = building_type->ProductionTime(empire_id, candidate_object_id);
+
+            main_text += "\n\nProduction cost: " + DoubleToString(total_cost, 3, false);
+            main_text += "\nProduction time: " + boost::lexical_cast<std::string>(production_time);
+
+            // create tooltip
+            boost::shared_ptr<GG::BrowseInfoWnd> browse_wnd(new IconTextBrowseWnd(
+                ClientUI::BuildingIcon(item.name), title, main_text));
+            return browse_wnd;
+        }
+
+        // production item is a ship
+        if (item.build_type == BT_SHIP) {
+            const ShipDesign* design = GetShipDesign(item.design_id);
+            if (!design) {
+                boost::shared_ptr<GG::BrowseInfoWnd> browse_wnd;
+                return browse_wnd;
+            }
+
+            // create title, description, production time and cost
+            title = design->Name(true);
+            main_text = design->Description(true);
+            total_cost = design->ProductionCost(empire_id, candidate_object_id);
+            production_time = design->ProductionTime(empire_id, candidate_object_id);
+
+            main_text += "\n\nProduction cost: " + DoubleToString(total_cost, 3, false);
+            main_text += "\nProduction time: " + boost::lexical_cast<std::string>(production_time);
+
+            // load hull type and ship parts
+            std::string all_ship_parts;
+            std::vector<std::string, std::allocator<std::string>> parts = design->Parts();
+            
+            for (std::vector<std::string>::const_iterator it = parts.begin(); it != parts.end(); ++it)
+                if (UserStringExists(*it))
+                    all_ship_parts += UserString(*it) + ", ";
+            
+            main_text += "\n\nHull: " + UserString(design->Hull());
+            main_text += "\nParts: " + all_ship_parts.substr(0, all_ship_parts.length()-2);
+
+            // create tooltip
+            boost::shared_ptr<GG::BrowseInfoWnd> browse_wnd(new IconTextBrowseWnd(
+                ClientUI::ShipDesignIcon(item.design_id), title, main_text));
+            return browse_wnd;
+        }
+
+        // other production item (?)
+        else {
+            return boost::shared_ptr<GG::BrowseInfoWnd>();
+        }
+
+        /** old tooltip code
         if (item.build_type == BT_BUILDING) {
             boost::shared_ptr<GG::BrowseInfoWnd> browse_wnd(new IconTextBrowseWnd(
                 ClientUI::BuildingIcon(item.name), UserString(item.name),
@@ -261,7 +329,7 @@ namespace {
             return browse_wnd;
         } else {
             return boost::shared_ptr<GG::BrowseInfoWnd>();
-        }
+        } */
     }
 
     ////////////////////////////////////////////////

--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -312,7 +312,7 @@ namespace {
             // load ship parts, stack ship parts that are used multiple times
             std::string ship_parts_formatted;
             std::map<std::string, int> ship_part_names;
-            std::vector<std::string, std::allocator<std::string> > parts = design->Parts();
+            const std::vector<std::string> parts = design->Parts();
 
             for (std::vector<std::string>::const_iterator it = parts.begin(); it != parts.end(); ++it) {
                 if (ship_part_names.find(*it) != ship_part_names.end())

--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -277,11 +277,11 @@ namespace {
             main_text += "\n" + UserString("PRODUCTION_WND_TOOLTIP_PROD_TIME") + ": " + boost::lexical_cast<std::string>(production_time);
 
             // show build conditions
-            std::string EnqueueAndLocationConditionFailedText = EnqueueAndLocationConditionDescription(item.name, candidate_object_id, empire_id, true);
-            if (!EnqueueAndLocationConditionFailedText.empty())
+            std::string enqueue_and_location_condition_failed_text = EnqueueAndLocationConditionDescription(item.name, candidate_object_id, empire_id, true);
+            if (!enqueue_and_location_condition_failed_text.empty())
                 if (TemporaryPtr<UniverseObject> location = GetUniverseObject(candidate_object_id)) {
-                        std::string failed_cond_loc = boost::io::str(FlexibleFormat(UserString("PRODUCTION_WND_TOOLTIP_FAILED_COND")) % location->Name());
-                        main_text += "\n\n" + failed_cond_loc + ":\n" + EnqueueAndLocationConditionFailedText;
+                    std::string failed_cond_loc = boost::io::str(FlexibleFormat(UserString("PRODUCTION_WND_TOOLTIP_FAILED_COND")) % location->Name());
+                    main_text += "\n\n" + failed_cond_loc + ":\n" + enqueue_and_location_condition_failed_text;
             }
 
             // create tooltip
@@ -332,11 +332,11 @@ namespace {
             main_text += "\n" + UserString("PRODUCTION_WND_TOOLTIP_PARTS") + ": " + ship_parts_formatted.substr(0, ship_parts_formatted.length() - 2);
 
             // show build conditions
-            std::string LocationConditionFailedText = LocationConditionDescription(item.design_id, candidate_object_id, empire_id, true);
-            if (!LocationConditionFailedText.empty())
+            std::string location_condition_failed_text = LocationConditionDescription(item.design_id, candidate_object_id, empire_id, true);
+            if (!location_condition_failed_text.empty())
                 if (TemporaryPtr<UniverseObject> location = GetUniverseObject(candidate_object_id)) {
                     std::string failed_cond_loc = boost::io::str(FlexibleFormat(UserString("PRODUCTION_WND_TOOLTIP_FAILED_COND")) % location->Name());
-                    main_text += ("\n\n" + failed_cond_loc + ":\n" + LocationConditionFailedText);
+                    main_text += ("\n\n" + failed_cond_loc + ":\n" + location_condition_failed_text);
                 }
 
             // create tooltip

--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -263,19 +263,19 @@ namespace {
             }
 
             // create title, description, production time and cost
-            const std::string title = UserString(item.name);
+            const std::string& title = UserString(item.name);
             std::string main_text = UserString(building_type->Description());
-            const float total_cost = building_type->ProductionCost(empire_id, candidate_object_id);
-            const int production_time = building_type->ProductionTime(empire_id, candidate_object_id);
+            float total_cost = building_type->ProductionCost(empire_id, candidate_object_id);
+            int production_time = building_type->ProductionTime(empire_id, candidate_object_id);
 
             main_text += "\n\n" + UserString("PRODUCTION_WND_TOOLTIP_PROD_COST") + ": " + DoubleToString(total_cost, 3, false);
             main_text += "\n" + UserString("PRODUCTION_WND_TOOLTIP_PROD_TIME") + ": " + boost::lexical_cast<std::string>(production_time);
 
             // show build conditions
-            std::string enqueue_and_location_condition_failed_text = EnqueueAndLocationConditionDescription(item.name, candidate_object_id, empire_id, true);
+            const std::string& enqueue_and_location_condition_failed_text = EnqueueAndLocationConditionDescription(item.name, candidate_object_id, empire_id, true);
             if (!enqueue_and_location_condition_failed_text.empty())
                 if (TemporaryPtr<UniverseObject> location = GetUniverseObject(candidate_object_id)) {
-                    std::string failed_cond_loc = boost::io::str(FlexibleFormat(UserString("PRODUCTION_WND_TOOLTIP_FAILED_COND")) % location->Name());
+                    const std::string& failed_cond_loc = boost::io::str(FlexibleFormat(UserString("PRODUCTION_WND_TOOLTIP_FAILED_COND")) % location->Name());
                     main_text += "\n\n" + failed_cond_loc + ":\n" + enqueue_and_location_condition_failed_text;
             }
 
@@ -294,10 +294,10 @@ namespace {
             }
 
             // create title, description, production time and cost, hull type
-            const std::string title = design->Name(true);
+            const std::string& title = design->Name(true);
             std::string main_text = design->Description(true);
-            const float total_cost = design->ProductionCost(empire_id, candidate_object_id);
-            const int production_time = design->ProductionTime(empire_id, candidate_object_id);
+            float total_cost = design->ProductionCost(empire_id, candidate_object_id);
+            int production_time = design->ProductionTime(empire_id, candidate_object_id);
 
             main_text += "\n\n" + UserString("PRODUCTION_WND_TOOLTIP_PROD_COST") + ": " + DoubleToString(total_cost, 3, false);
             main_text += "\n" + UserString("PRODUCTION_WND_TOOLTIP_PROD_TIME") + ": " + boost::lexical_cast<std::string>(production_time);
@@ -326,10 +326,10 @@ namespace {
             main_text += "\n" + UserString("PRODUCTION_WND_TOOLTIP_PARTS") + ": " + ship_parts_formatted.substr(0, ship_parts_formatted.length() - 2);
 
             // show build conditions
-            std::string location_condition_failed_text = LocationConditionDescription(item.design_id, candidate_object_id, empire_id, true);
+            const std::string& location_condition_failed_text = LocationConditionDescription(item.design_id, candidate_object_id, empire_id, true);
             if (!location_condition_failed_text.empty())
                 if (TemporaryPtr<UniverseObject> location = GetUniverseObject(candidate_object_id)) {
-                    std::string failed_cond_loc = boost::io::str(FlexibleFormat(UserString("PRODUCTION_WND_TOOLTIP_FAILED_COND")) % location->Name());
+                    const std::string& failed_cond_loc = boost::io::str(FlexibleFormat(UserString("PRODUCTION_WND_TOOLTIP_FAILED_COND")) % location->Name());
                     main_text += ("\n\n" + failed_cond_loc + ":\n" + location_condition_failed_text);
                 }
 

--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -329,7 +329,7 @@ namespace {
             const std::string& location_condition_failed_text = LocationConditionDescription(item.design_id, candidate_object_id, empire_id, true);
             if (!location_condition_failed_text.empty())
                 if (TemporaryPtr<UniverseObject> location = GetUniverseObject(candidate_object_id)) {
-                    const std::string& failed_cond_loc = boost::io::str(FlexibleFormat(UserString("PRODUCTION_WND_TOOLTIP_FAILED_COND")) % location->Name());
+                    std::string failed_cond_loc = boost::io::str(FlexibleFormat(UserString("PRODUCTION_WND_TOOLTIP_FAILED_COND")) % location->Name());
                     main_text += ("\n\n" + failed_cond_loc + ":\n" + location_condition_failed_text);
                 }
 

--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -312,7 +312,7 @@ namespace {
             // load ship parts, stack ship parts that are used multiple times
             std::string ship_parts_formatted;
             std::map<std::string, int> ship_part_names;
-            std::vector<std::string, std::allocator<std::string>> parts = design->Parts();
+            std::vector<std::string, std::allocator<std::string> > parts = design->Parts();
 
             for (std::vector<std::string>::const_iterator it = parts.begin(); it != parts.end(); ++it) {
                 if (ship_part_names.find(*it) != ship_part_names.end())

--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -312,7 +312,7 @@ namespace {
             // load ship parts, stack ship parts that are used multiple times
             std::string ship_parts_formatted;
             std::map<std::string, int> ship_part_names;
-            const std::vector<std::string> parts = design->Parts();
+            const std::vector<std::string>& parts = design->Parts();
 
             for (std::vector<std::string>::const_iterator it = parts.begin(); it != parts.end(); ++it) {
                 if (ship_part_names.find(*it) != ship_part_names.end())

--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -254,11 +254,6 @@ namespace {
     boost::shared_ptr<GG::BrowseInfoWnd> ProductionItemRowBrowseWnd(const ProductionQueue::ProductionItem& item,
                                                                     int candidate_object_id, int empire_id)
     {
-        std::string title;
-        std::string main_text;
-        float total_cost;
-        int production_time;
-
         // production item is a building
         if (item.build_type == BT_BUILDING) {
             const BuildingType* building_type = GetBuildingType(item.name);
@@ -268,10 +263,10 @@ namespace {
             }
 
             // create title, description, production time and cost
-            title = UserString(item.name);
-            main_text = UserString(building_type->Description());
-            total_cost = building_type->ProductionCost(empire_id, candidate_object_id);
-            production_time = building_type->ProductionTime(empire_id, candidate_object_id);
+            const std::string title = UserString(item.name);
+            std::string main_text = UserString(building_type->Description());
+            const float total_cost = building_type->ProductionCost(empire_id, candidate_object_id);
+            const int production_time = building_type->ProductionTime(empire_id, candidate_object_id);
 
             main_text += "\n\n" + UserString("PRODUCTION_WND_TOOLTIP_PROD_COST") + ": " + DoubleToString(total_cost, 3, false);
             main_text += "\n" + UserString("PRODUCTION_WND_TOOLTIP_PROD_TIME") + ": " + boost::lexical_cast<std::string>(production_time);
@@ -299,14 +294,13 @@ namespace {
             }
 
             // create title, description, production time and cost, hull type
-            title = design->Name(true);
-            main_text = design->Description(true);
-            total_cost = design->ProductionCost(empire_id, candidate_object_id);
-            production_time = design->ProductionTime(empire_id, candidate_object_id);
+            const std::string title = design->Name(true);
+            std::string main_text = design->Description(true);
+            const float total_cost = design->ProductionCost(empire_id, candidate_object_id);
+            const int production_time = design->ProductionTime(empire_id, candidate_object_id);
 
             main_text += "\n\n" + UserString("PRODUCTION_WND_TOOLTIP_PROD_COST") + ": " + DoubleToString(total_cost, 3, false);
             main_text += "\n" + UserString("PRODUCTION_WND_TOOLTIP_PROD_TIME") + ": " + boost::lexical_cast<std::string>(production_time);
-
             main_text += "\n\n" + UserString("ENC_SHIP_HULL") + ": " + UserString(design->Hull());
 
             // load ship parts, stack ship parts that are used multiple times

--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -312,7 +312,7 @@ namespace {
             // load ship parts, stack ship parts that are used multiple times
             std::string ship_parts_formatted;
             std::map<std::string, int> ship_part_names;
-            const std::vector<std::string>& parts = design->Parts();
+            const std::vector<std::string> parts = design->Parts();
 
             for (std::vector<std::string>::const_iterator it = parts.begin(); it != parts.end(); ++it) {
                 if (ship_part_names.find(*it) != ship_part_names.end())

--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -273,13 +273,16 @@ namespace {
             total_cost = building_type->ProductionCost(empire_id, candidate_object_id);
             production_time = building_type->ProductionTime(empire_id, candidate_object_id);
 
-            main_text += "\n\nProduction cost: " + DoubleToString(total_cost, 3, false);
-            main_text += "\nProduction time: " + boost::lexical_cast<std::string>(production_time);
+            main_text += "\n\n" + UserString("PRODUCTION_WND_TOOLTIP_PROD_COST") + ": " + DoubleToString(total_cost, 3, false);
+            main_text += "\n" + UserString("PRODUCTION_WND_TOOLTIP_PROD_TIME") + ": " + boost::lexical_cast<std::string>(production_time);
 
             // show build conditions
             std::string EnqueueAndLocationConditionFailedText = EnqueueAndLocationConditionDescription(item.name, candidate_object_id, empire_id, true);
-            if (EnqueueAndLocationConditionFailedText.length() != 0)
-                main_text += "\n\n" + EnqueueAndLocationConditionFailedText;
+            if (!EnqueueAndLocationConditionFailedText.empty())
+                if (TemporaryPtr<UniverseObject> location = GetUniverseObject(candidate_object_id)) {
+                        std::string failed_cond_loc = boost::io::str(FlexibleFormat(UserString("PRODUCTION_WND_TOOLTIP_FAILED_COND")) % location->Name());
+                        main_text += "\n\n" + failed_cond_loc + ":\n" + EnqueueAndLocationConditionFailedText;
+            }
 
             // create tooltip
             boost::shared_ptr<GG::BrowseInfoWnd> browse_wnd(new IconTextBrowseWnd(
@@ -301,10 +304,10 @@ namespace {
             total_cost = design->ProductionCost(empire_id, candidate_object_id);
             production_time = design->ProductionTime(empire_id, candidate_object_id);
 
-            main_text += "\n\nProduction cost: " + DoubleToString(total_cost, 3, false);
-            main_text += "\nProduction time: " + boost::lexical_cast<std::string>(production_time);
+            main_text += "\n\n" + UserString("PRODUCTION_WND_TOOLTIP_PROD_COST") + ": " + DoubleToString(total_cost, 3, false);
+            main_text += "\n" + UserString("PRODUCTION_WND_TOOLTIP_PROD_TIME") + ": " + boost::lexical_cast<std::string>(production_time);
 
-            main_text += "\n\nHull: " + UserString(design->Hull());
+            main_text += "\n\n" + UserString("ENC_SHIP_HULL") + ": " + UserString(design->Hull());
 
             // load ship parts, stack ship parts that are used multiple times
             std::string ship_parts_formatted;
@@ -326,12 +329,15 @@ namespace {
                     ship_parts_formatted += (UserString(it->first) + " x" + boost::lexical_cast<std::string>(it->second) + ", ");
             }
 
-            main_text += "\nParts: " + ship_parts_formatted.substr(0, ship_parts_formatted.length() - 2);
+            main_text += "\n" + UserString("PRODUCTION_WND_TOOLTIP_PARTS") + ": " + ship_parts_formatted.substr(0, ship_parts_formatted.length() - 2);
 
             // show build conditions
             std::string LocationConditionFailedText = LocationConditionDescription(item.design_id, candidate_object_id, empire_id, true);
-            if (LocationConditionFailedText.length() != 0)
-                main_text += ("\n\n" + LocationConditionFailedText);
+            if (!LocationConditionFailedText.empty())
+                if (TemporaryPtr<UniverseObject> location = GetUniverseObject(candidate_object_id)) {
+                    std::string failed_cond_loc = boost::io::str(FlexibleFormat(UserString("PRODUCTION_WND_TOOLTIP_FAILED_COND")) % location->Name());
+                    main_text += ("\n\n" + failed_cond_loc + ":\n" + LocationConditionFailedText);
+                }
 
             // create tooltip
             boost::shared_ptr<GG::BrowseInfoWnd> browse_wnd(new IconTextBrowseWnd(

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1,4 +1,4 @@
-English
+﻿English
 
 #This is the English String Table file for FreeOrion
 #Translate this file to other languages.
@@ -3156,6 +3156,18 @@ Move to Queue Top
 
 MOVE_DOWN_QUEUE_ITEM
 Move to Queue Bottom
+
+PRODUCTION_WND_TOOLTIP_PROD_COST
+Production cost
+
+PRODUCTION_WND_TOOLTIP_PROD_TIME
+Production time
+
+PRODUCTION_WND_TOOLTIP_PARTS
+Ship Parts
+
+PRODUCTION_WND_TOOLTIP_FAILED_COND
+Unmet requirements to produce at %1%
 
 ###############
 #  DesignWnd  #

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1,4 +1,4 @@
-﻿English
+English
 
 #This is the English String Table file for FreeOrion
 #Translate this file to other languages.

--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -194,7 +194,10 @@ std::string ConditionFailedDescription(const std::vector<Condition::ConditionBas
             if (!it->second)
                  retval += UserString("FAILED") + " <rgba 255 0 0 255>" + it->first +"</rgba>\n";
 
-    return retval.substr(0, retval.length()-1);
+    // remove empty line from the end of the string
+    retval = retval.substr(0, retval.length() - 1);
+
+    return retval;
 }
 
 std::string ConditionDescription(const std::vector<Condition::ConditionBase*>& conditions,

--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -176,6 +176,27 @@ namespace {
     }
 }
 
+std::string ConditionFailedDescription(const std::vector<Condition::ConditionBase*>& conditions,
+    TemporaryPtr<const UniverseObject> candidate_object/* = 0*/,
+    TemporaryPtr<const UniverseObject> source_object/* = 0*/)
+{
+    if (conditions.empty())
+        return UserString("NONE");
+
+    ScriptingContext parent_context(source_object);
+    // test candidate against all input conditions, and store descriptions of each
+    std::map<std::string, bool> condition_description_and_test_results =
+        ConditionDescriptionAndTest(conditions, parent_context, candidate_object);
+    std::string retval;
+
+    for (std::map<std::string, bool>::const_iterator it = condition_description_and_test_results.begin();
+        it != condition_description_and_test_results.end(); ++it)
+            if (!it->second)
+                 retval += UserString("FAILED") + " <rgba 255 0 0 255>" + it->first +"</rgba>\n";
+
+    return retval.substr(0, retval.length()-1);
+}
+
 std::string ConditionDescription(const std::vector<Condition::ConditionBase*>& conditions,
                                  TemporaryPtr<const UniverseObject> candidate_object/* = 0*/,
                                  TemporaryPtr<const UniverseObject> source_object/* = 0*/)

--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -177,8 +177,8 @@ namespace {
 }
 
 std::string ConditionFailedDescription(const std::vector<Condition::ConditionBase*>& conditions,
-    TemporaryPtr<const UniverseObject> candidate_object/* = 0*/,
-    TemporaryPtr<const UniverseObject> source_object/* = 0*/)
+                                       TemporaryPtr<const UniverseObject> candidate_object/* = 0*/,
+                                       TemporaryPtr<const UniverseObject> source_object/* = 0*/)
 {
     if (conditions.empty())
         return UserString("NONE");

--- a/universe/Condition.h
+++ b/universe/Condition.h
@@ -124,10 +124,9 @@ namespace Condition {
 }
 
 /** Same as ConditionDescription, but returns a string only with conditions that have not been met. */
-
 FO_COMMON_API std::string ConditionFailedDescription(const std::vector<Condition::ConditionBase*>& conditions,
-                                               TemporaryPtr<const UniverseObject> candidate_object = TemporaryPtr<const UniverseObject>(),
-                                               TemporaryPtr<const UniverseObject> source_object = TemporaryPtr<const UniverseObject>());
+                                                     TemporaryPtr<const UniverseObject> candidate_object = TemporaryPtr<const UniverseObject>(),
+                                                     TemporaryPtr<const UniverseObject> source_object = TemporaryPtr<const UniverseObject>());
 
 /** Returns a single string which describes a vector of Conditions. If multiple
 * conditions are passed, they are treated as if they were contained by an And

--- a/universe/Condition.h
+++ b/universe/Condition.h
@@ -123,15 +123,21 @@ namespace Condition {
     struct Described;
 }
 
+/** Same as ConditionDescription, but returns a string only with conditions that have not been met. */
+
+FO_COMMON_API std::string ConditionFailedDescription(const std::vector<Condition::ConditionBase*>& conditions,
+                                               TemporaryPtr<const UniverseObject> candidate_object = TemporaryPtr<const UniverseObject>(),
+                                               TemporaryPtr<const UniverseObject> source_object = TemporaryPtr<const UniverseObject>());
+
 /** Returns a single string which describes a vector of Conditions. If multiple
-  * conditions are passed, they are treated as if they were contained by an And
-  * condition. Subconditions within an And (or nested And) are listed as
-  * lines in a list, with duplicates removed, titled something like "All of...".
-  * Subconditions within an Or (or nested Ors) are similarly listed as lines in
-  * a list, with duplicates removed, titled something like "One of...". If a
-  * candidate object is provided, the returned string will indicate which 
-  * subconditions the candidate matches, and indicate if the overall combination
-  * of conditions matches the object. */
+* conditions are passed, they are treated as if they were contained by an And
+* condition. Subconditions within an And (or nested And) are listed as
+* lines in a list, with duplicates removed, titled something like "All of...".
+* Subconditions within an Or (or nested Ors) are similarly listed as lines in
+* a list, with duplicates removed, titled something like "One of...". If a
+* candidate object is provided, the returned string will indicate which
+* subconditions the candidate matches, and indicate if the overall combination
+* of conditions matches the object. */
 FO_COMMON_API std::string ConditionDescription(const std::vector<Condition::ConditionBase*>& conditions,
                                                TemporaryPtr<const UniverseObject> candidate_object = TemporaryPtr<const UniverseObject>(),
                                                TemporaryPtr<const UniverseObject> source_object = TemporaryPtr<const UniverseObject>());

--- a/universe/Condition.h
+++ b/universe/Condition.h
@@ -129,14 +129,14 @@ FO_COMMON_API std::string ConditionFailedDescription(const std::vector<Condition
                                                      TemporaryPtr<const UniverseObject> source_object = TemporaryPtr<const UniverseObject>());
 
 /** Returns a single string which describes a vector of Conditions. If multiple
-* conditions are passed, they are treated as if they were contained by an And
-* condition. Subconditions within an And (or nested And) are listed as
-* lines in a list, with duplicates removed, titled something like "All of...".
-* Subconditions within an Or (or nested Ors) are similarly listed as lines in
-* a list, with duplicates removed, titled something like "One of...". If a
-* candidate object is provided, the returned string will indicate which
-* subconditions the candidate matches, and indicate if the overall combination
-* of conditions matches the object. */
+  * conditions are passed, they are treated as if they were contained by an And
+  * condition. Subconditions within an And (or nested And) are listed as
+  * lines in a list, with duplicates removed, titled something like "All of...".
+  * Subconditions within an Or (or nested Ors) are similarly listed as lines in
+  * a list, with duplicates removed, titled something like "One of...". If a
+  * candidate object is provided, the returned string will indicate which
+  * subconditions the candidate matches, and indicate if the overall combination
+  * of conditions matches the object. */
 FO_COMMON_API std::string ConditionDescription(const std::vector<Condition::ConditionBase*>& conditions,
                                                TemporaryPtr<const UniverseObject> candidate_object = TemporaryPtr<const UniverseObject>(),
                                                TemporaryPtr<const UniverseObject> source_object = TemporaryPtr<const UniverseObject>());


### PR DESCRIPTION
Replaces the old tooltip of the production selection window. The new tooltip will show description, production time and cost, and if it is a ship hull and ships parts of the selected item.

![tooltip](https://cloud.githubusercontent.com/assets/12985960/12626021/b75b0b54-c536-11e5-9804-d1d766018972.jpg)
