### PR TITLE
Wrapper for fo.issueCreateShipDesignOrder and minor bugfixes

### DIFF
--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -2255,6 +2255,7 @@ namespace {
 
         // show image of planet environment at the top of the suitability report
         std::string planet_type = boost::lexical_cast<std::string>(planet->Type());
+        boost::algorithm::to_lower(planet_type);
         detailed_description += "<img src=\"encyclopedia/planet_environments/" + planet_type + ".png\"></img>";
 
         std::string original_planet_species = planet->SpeciesName();


### PR DESCRIPTION
Bugfix 1: with case-sensitive filesystem the planet type environment images in the encyclopedia was never shown (but a big red X) since the file names are all lowercase but the planet_type is uppercase 
Bugfix 2: don't create warning message in parse_tokens(tokendict, is_hull=False) of the python AI if AIDependencies.STACKING_RULES appears. 

Wrapper: The wrapper creates an easier interface to issueCreateShipDesignOrder and updates the cache on success.
