### PR TITLE
Fix species weapon effect. 

### DIFF
--- a/default/alignments.txt
+++ b/default/alignments.txt
@@ -28,6 +28,7 @@ AlignmentEffects effectsgroups = [
     EffectsGroup
         scope = And [
             Ship
+            Armed
             OwnedBy empire = Source.Owner
             Or [
                 DesignHasPartClass low = 1 high = 999 class = ShortRange

--- a/default/species.txt
+++ b/default/species.txt
@@ -3918,17 +3918,20 @@ BAD_WEAPONS
             scope = Source
             activation = And [
                 Ship
-                DesignHasPart name = "SR_WEAPON_1_1"
-                DesignHasPart name = "SR_WEAPON_2_1"
-                DesignHasPart name = "SR_WEAPON_3_1"
-                DesignHasPart name = "SR_WEAPON_4_1"
+                Armed
+                Or [
+                    DesignHasPart name = "SR_WEAPON_1_1"
+                    DesignHasPart name = "SR_WEAPON_2_1"
+                    DesignHasPart name = "SR_WEAPON_3_1"
+                    DesignHasPart name = "SR_WEAPON_4_1"
+                ]
             ]
             effects = [
                 SetMaxDamage partname = "SR_WEAPON_1_1" value = Value - 1
                 SetMaxDamage partname = "SR_WEAPON_2_1" value = Value - 2
                 SetMaxDamage partname = "SR_WEAPON_3_1" value = Value - 3
                 SetMaxDamage partname = "SR_WEAPON_4_1" value = Value - 5
-        ]
+            ]
 '''
 
 GOOD_WEAPONS
@@ -3937,17 +3940,20 @@ GOOD_WEAPONS
             scope = Source
             activation = And [
                 Ship
-                DesignHasPart name = "SR_WEAPON_1_1"
-                DesignHasPart name = "SR_WEAPON_2_1"
-                DesignHasPart name = "SR_WEAPON_3_1"
-                DesignHasPart name = "SR_WEAPON_4_1"
+                Armed
+                Or [
+                    DesignHasPart name = "SR_WEAPON_1_1"
+                    DesignHasPart name = "SR_WEAPON_2_1"
+                    DesignHasPart name = "SR_WEAPON_3_1"
+                    DesignHasPart name = "SR_WEAPON_4_1"
+                ]
             ]
             effects = [
                 SetMaxDamage partname = "SR_WEAPON_1_1" value = Value + 1
                 SetMaxDamage partname = "SR_WEAPON_2_1" value = Value + 2
                 SetMaxDamage partname = "SR_WEAPON_3_1" value = Value + 3
                 SetMaxDamage partname = "SR_WEAPON_4_1" value = Value + 5
-        ]
+            ]
 '''
 
 GREAT_WEAPONS
@@ -3956,17 +3962,20 @@ GREAT_WEAPONS
             scope = Source
             activation = And [
                 Ship
-                DesignHasPart name = "SR_WEAPON_1_1"
-                DesignHasPart name = "SR_WEAPON_2_1"
-                DesignHasPart name = "SR_WEAPON_3_1"
-                DesignHasPart name = "SR_WEAPON_4_1"
+                Armed
+                Or [
+                    DesignHasPart name = "SR_WEAPON_1_1"
+                    DesignHasPart name = "SR_WEAPON_2_1"
+                    DesignHasPart name = "SR_WEAPON_3_1"
+                    DesignHasPart name = "SR_WEAPON_4_1"
+                ]
             ]
             effects = [
                 SetMaxDamage partname = "SR_WEAPON_1_1" value = Value + 2
                 SetMaxDamage partname = "SR_WEAPON_2_1" value = Value + 4
                 SetMaxDamage partname = "SR_WEAPON_3_1" value = Value + 6
                 SetMaxDamage partname = "SR_WEAPON_4_1" value = Value + 10
-        ]
+            ]
 '''
 
 ULTIMATE_WEAPONS
@@ -3975,18 +3984,20 @@ ULTIMATE_WEAPONS
             scope = Source
             activation = And [
                 Ship
-                DesignHasPart name = "SR_WEAPON_1_1"
-                DesignHasPart name = "SR_WEAPON_2_1"
-                DesignHasPart name = "SR_WEAPON_3_1"
-                DesignHasPart name = "SR_WEAPON_4_1"
+                Armed
+                Or [
+                    DesignHasPart name = "SR_WEAPON_1_1"
+                    DesignHasPart name = "SR_WEAPON_2_1"
+                    DesignHasPart name = "SR_WEAPON_3_1"
+                    DesignHasPart name = "SR_WEAPON_4_1"
+                ]
             ]
             effects = [
                 SetMaxDamage partname = "SR_WEAPON_1_1" value = Value + 3
                 SetMaxDamage partname = "SR_WEAPON_2_1" value = Value + 6
                 SetMaxDamage partname = "SR_WEAPON_3_1" value = Value + 9
                 SetMaxDamage partname = "SR_WEAPON_4_1" value = Value + 15
-        ]
-
+            ]
 '''
 
 //#####      P L A N E T   S I Z E     #####//
@@ -4034,7 +4045,7 @@ SMALL_PLANET
 NOT_HUGE_PLANET
 '''EffectsGroup
         scope = Source
-        activation = AND [
+        activation = And [
             Planet
             Turn high = 0
             Planet Size = Huge


### PR DESCRIPTION
Fix species weapon effect.
A species should get its weapon bonus effect when it has installed to _any_ of the short range weapons
and not have to install _all_ 4 short range weapons.

Added cheap check if a ship is armed for speed-up.
Checking if a ship is Armed is cheap (cached) and will exclude all non-armed ships (all those troop carriers), while checking a ship parts class is relative expensive in comparison.

Question:
Is checking if a ship is armed not the same as checking if a ship has a part that belongs to a weapon class?
