### PR TITLE
[AI] Change shipDesign.name to property

### DIFF
--- a/default/AI/ColonisationAI.py
+++ b/default/AI/ColonisationAI.py
@@ -656,7 +656,7 @@ def get_colony_fleets():
                 EnumsAI.AIPriorityType.PRIORITY_PRODUCTION_ORBITAL_OUTPOST, loc)
             if best_ship is None:
                 print "Error: can't get standard best outpost base design that can be built at ", PlanetUtilsAI.planet_name_ids([loc])
-                outpost_base_design_ids = [design for design in empire.availableShipDesigns if "SD_OUTPOST_BASE" == fo.getShipDesign(design).name(False)]
+                outpost_base_design_ids = [design for design in empire.availableShipDesigns if "SD_OUTPOST_BASE" == fo.getShipDesign(design).name]
                 if outpost_base_design_ids:
                     print "trying fallback outpost base design SD_OUTPOST_BASE"
                     best_ship = outpost_base_design_ids.pop()

--- a/default/AI/ProductionAI.py
+++ b/default/AI/ProductionAI.py
@@ -1124,7 +1124,7 @@ def generateProductionOrders():
         if homeworld:
             for shipDesignID in empire.availableShipDesigns:
                 shipDesign = fo.getShipDesign(shipDesignID)
-                print "    " + str(shipDesign.name(True)) + " cost:" + str(shipDesign.productionCost(empire.empireID, homeworld.id) )+ " time:" + str(shipDesign.productionTime(empire.empireID, homeworld.id))
+                print "    " + shipDesign.name + " cost:" + str(shipDesign.productionCost(empire.empireID, homeworld.id) )+ " time:" + str(shipDesign.productionTime(empire.empireID, homeworld.id))
 
     print
     print "Projects already in Production Queue:"
@@ -1192,7 +1192,7 @@ def generateProductionOrders():
             if troopersNeededForcing>0 and totalPP > 3*perTurnCost*queuedTroopShips and foAI.foAIstate.aggression >= fo.aggression.typical:
                 retval = fo.issueEnqueueShipProductionOrder(bestDesignID, loc)
                 if retval !=0:
-                    print "forcing %d new ship(s) to production queue: %s; per turn production cost %.1f"%(numShips, bestDesign.name(True), numShips*perTurnCost)
+                    print "forcing %d new ship(s) to production queue: %s; per turn production cost %.1f"%(numShips, bestDesign.name, numShips*perTurnCost)
                     print
                     if numShips>1:
                         fo.issueChangeProductionQuantityOrder(productionQueue.size -1, 1, numShips)
@@ -1308,7 +1308,7 @@ def generateProductionOrders():
                 del localPriorities[priority] #must be missing a shipyard -- TODO build a shipyard if necessary
                 continue
             bestShips[priority] = [bestDesignID, bestDesign, buildChoices ]
-            print "bestShips[%s] = %s \t locs are %s from %s"%( EnumsAI.AIPriorityNames[priority], bestDesign.name(False) , buildChoices, pSet)
+            print "bestShips[%s] = %s \t locs are %s from %s"%( EnumsAI.AIPriorityNames[priority], bestDesign.name, buildChoices, pSet)
 
         if len(localPriorities)==0:
             print "Alert!! need shipyards in systemSet ", ppstring(PlanetUtilsAI.sys_name_ids(set(PlanetUtilsAI.get_systems( sorted(pSet)))))
@@ -1387,7 +1387,7 @@ def generateProductionOrders():
             retval = fo.issueEnqueueShipProductionOrder(bestDesignID, loc)
             if retval !=0:
                 prioritized = False
-                print "adding %d new ship(s) at location %s to production queue: %s; per turn production cost %.1f"%(numShips, ppstring(PlanetUtilsAI.planet_name_ids([loc])), bestDesign.name(True), perTurnCost)
+                print "adding %d new ship(s) at location %s to production queue: %s; per turn production cost %.1f"%(numShips, ppstring(PlanetUtilsAI.planet_name_ids([loc])), bestDesign.name, perTurnCost)
                 print
                 if numShips>1:
                     fo.issueChangeProductionQuantityOrder(productionQueue.size -1, 1, numShips)

--- a/default/AI/ShipDesignAI.py
+++ b/default/AI/ShipDesignAI.py
@@ -310,11 +310,11 @@ class ShipDesignCache(object):
             print "WARNING: In ShipDesignAI.py: Cache._build_cache_after_load() called but cache is not empty."
         for design_id in fo.getEmpire().allShipDesigns:
             design = fo.getShipDesign(design_id)
-            if TESTDESIGN_NAME_BASE in design.name(False):
+            if TESTDESIGN_NAME_BASE in design.name:
                 continue
             reference_name = _build_reference_name(design.hull, design.parts)
-            self.map_reference_design_name[reference_name] = design.name(False)
-            self.design_id_by_name[design.name(False)] = design_id
+            self.map_reference_design_name[reference_name] = design.name
+            self.design_id_by_name[design.name] = design_id
 
     def _check_cache_for_consistency(self):
         """Check if the persistent cache is consistent with the gamestate and fix it if not.
@@ -342,12 +342,12 @@ class ShipDesignCache(object):
                 del self.design_id_by_name[designname]
                 continue
             try:
-                cached_name = fo.getShipDesign(self.design_id_by_name[designname]).name(False)
+                cached_name = fo.getShipDesign(self.design_id_by_name[designname]).name
                 if cached_name != designname:
                     print "WARNING: ShipID cache corrupted."
                     print "Expected: %s, got: %s. Repairing cache." % (designname, cached_name)
                     design_id = next(iter([shipDesignID for shipDesignID in fo.getEmpire().allShipDesigns
-                                          if designname == fo.getShipDesign(shipDesignID).name(False)]), None)
+                                          if designname == fo.getShipDesign(shipDesignID).name]), None)
                     if design_id is not None:
                         self.design_id_by_name[designname] = design_id
                     else:
@@ -356,7 +356,7 @@ class ShipDesignCache(object):
                 print "WARNING: ShipID cache corrupted. Could not get cached shipdesign. Repairing Cache."
                 print traceback.format_exc()  # do not print to stderr as this is an "expected" exception.
                 design_id = next(iter([shipDesignID for shipDesignID in fo.getEmpire().allShipDesigns
-                                      if designname == fo.getShipDesign(shipDesignID).name(False)]), None)
+                                      if designname == fo.getShipDesign(shipDesignID).name]), None)
                 if design_id is not None:
                     self.design_id_by_name[designname] = design_id
                 else:
@@ -404,8 +404,8 @@ class ShipDesignCache(object):
             print "WARNING: Tried to use '%s' as testhull but not in available_hulls." % TESTDESIGN_PREFERRED_HULL,
             print "Please update ShipDesignAI.py according to the new content."
             traceback.print_exc()
-        testdesign_names = [get_shipdesign(design_id).name(False) for design_id in empire.allShipDesigns
-                            if get_shipdesign(design_id).name(False).startswith(TESTDESIGN_NAME_BASE)]
+        testdesign_names = [get_shipdesign(design_id).name for design_id in empire.allShipDesigns
+                            if get_shipdesign(design_id).name.startswith(TESTDESIGN_NAME_BASE)]
         testdesign_names_hull = [name for name in testdesign_names if name.startswith(TESTDESIGN_NAME_HULL)]
         testdesign_names_part = [name for name in testdesign_names if name.startswith(TESTDESIGN_NAME_PART)]
         available_slot_types = {slottype for slotlist in [get_hulltype(hull).slots for hull in available_hulls]
@@ -1964,8 +1964,8 @@ def _update_design_by_name_cache(design_name, verbose=False):
     design = None
     for design_id in fo.getEmpire().allShipDesigns:
         if verbose:
-            print "Checking design %s in search for %s" % (fo.getShipDesign(design_id).name(False), design_name)
-        if fo.getShipDesign(design_id).name(False) == design_name:
+            print "Checking design %s in search for %s" % (fo.getShipDesign(design_id).name, design_name)
+        if fo.getShipDesign(design_id).name == design_name:
             design = fo.getShipDesign(design_id)
             break
 

--- a/default/AI/freeorion_debug/extend_free_orion_AI_interface.py
+++ b/default/AI/freeorion_debug/extend_free_orion_AI_interface.py
@@ -51,18 +51,6 @@ SHIP_DESIGN = 'D'
 EMPIRE = 'E'
 
 
-# TODO remove this block after c++ support
-# Change shipdesign.name function to property
-fo.shipDesign.get_name = fo.shipDesign.name
-
-
-def get_design_name(self):
-    return self.get_name(False)
-
-fo.shipDesign.name = property(get_design_name)
-# end of remove block
-
-
 def to_dict(method):
     @wraps(method)
     def wrapper(*args):

--- a/default/AI/freeorion_debug/extend_free_orion_AI_interface.py
+++ b/default/AI/freeorion_debug/extend_free_orion_AI_interface.py
@@ -51,6 +51,18 @@ SHIP_DESIGN = 'D'
 EMPIRE = 'E'
 
 
+# TODO remove this block after c++ support
+# Change shipdesign.name function to property
+fo.shipDesign.get_name = fo.shipDesign.name
+
+
+def get_design_name(self):
+    return self.get_name(False)
+
+fo.shipDesign.name = property(get_design_name)
+# end of remove block
+
+
 def to_dict(method):
     @wraps(method)
     def wrapper(*args):
@@ -73,7 +85,7 @@ def system_to_string(system):
 fo.system.__repr__ = system_to_string
 
 def design_to_string(design):
-    return to_str(SHIP_DESIGN, design.id, design.name(True))
+    return to_str(SHIP_DESIGN, design.id, design.name)
 fo.shipDesign.__repr__ = design_to_string
 
 

--- a/python/UniverseWrapper.cpp
+++ b/python/UniverseWrapper.cpp
@@ -171,6 +171,14 @@ namespace {
     const Ship::PartMeterMap&
                             (Ship::*ShipPartMeters)(void) const =                               &Ship::PartMeters;
 
+    const std::string&      ShipDesignName(const ShipDesign& ship_design)
+    { return ship_design.Name(false); }
+    boost::function<const std::string& (const ShipDesign&)> ShipDesignNameFunc =                &ShipDesignName;
+
+    const std::string&      ShipDesignDescription(const ShipDesign& ship_design)
+    { return ship_design.Description(false); }
+    boost::function<const std::string& (const ShipDesign&)> ShipDesignDescriptionFunc =         &ShipDesignDescription;
+
     bool                    (*ValidDesignHullAndParts)(const std::string& hull,
                                                        const std::vector<std::string>& parts) = &ShipDesign::ValidDesign;
     bool                    (*ValidDesignDesign)(const ShipDesign&) =                           &ShipDesign::ValidDesign;
@@ -446,8 +454,16 @@ namespace FreeOrionPython {
         //////////////////
         class_<ShipDesign, noncopyable>("shipDesign", no_init)
             .add_property("id",                 make_function(&ShipDesign::ID,              return_value_policy<return_by_value>()))
-            .def("name",                        make_function(&ShipDesign::Name,            return_value_policy<copy_const_reference>()))
-            .def("description",                 make_function(&ShipDesign::Description,     return_value_policy<copy_const_reference>()))
+            .add_property("name",               make_function(
+                                                    ShipDesignNameFunc,
+                                                    return_value_policy<copy_const_reference>(),
+                                                    boost::mpl::vector<const std::string&, const ShipDesign&>()
+                                                ))
+            .add_property("description",        make_function(
+                                                    ShipDesignDescriptionFunc,
+                                                    return_value_policy<copy_const_reference>(),
+                                                    boost::mpl::vector<const std::string&, const ShipDesign&>()
+                                                ))
             .add_property("designedOnTurn",     make_function(&ShipDesign::DesignedOnTurn,  return_value_policy<return_by_value>()))
             .add_property("speed",              make_function(&ShipDesign::Speed,           return_value_policy<return_by_value>()))
             .add_property("structure",          make_function(&ShipDesign::Structure,       return_value_policy<return_by_value>()))


### PR DESCRIPTION
Change `shipDesign.name` to property:
- add hack in python to override c++ behavior
- update all usages
- replace translated name in logs to inner name

This code works and can be merged. 

Next step (I need help with it):
- change c++ wrapper: `shipDesign.name` and `shipDesign.description`(not used) should be changed to properties
- revert changes  for `extend_free_orion_AI_interface.py`
