### PR TITLE
Updated cmake files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,7 +125,7 @@ set(LIB_SUFFIX ${OLD_LIB_SUFFIX})
 ########################################
 # Dependencies                         #
 ########################################
-find_package(Boost ${MINIMUM_BOOST_VERSION} COMPONENTS chrono date_time filesystem iostreams regex serialization signals system thread log REQUIRED)
+find_package(Boost ${MINIMUM_BOOST_VERSION} COMPONENTS chrono date_time filesystem locale iostreams regex serialization signals system thread log REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(Freetype REQUIRED)
 


### PR DESCRIPTION
Added boost locale to the list of required boost libraries.

Tries to fix #475.
