### PR TITLE
Revised implementation of random galaxy setup option picking

### DIFF
--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1222,6 +1222,8 @@ void ServerApp::GenerateUniverse(std::map<int, PlayerSetupData>& player_setup_da
     Seed(seed);
     DebugLogger() << "GenerateUniverse with seed: " << seed;
 
+    // Do the random picking for all setup options that have been set to their respective "random" values
+    GetGalaxySetupData().DoRandomPicks();
     // Reset the universe object for a new universe
     universe.ResetUniverse();
     // Add predefined ship designs to universe

--- a/util/MultiplayerCommon.cpp
+++ b/util/MultiplayerCommon.cpp
@@ -118,13 +118,11 @@ GG::Clr XMLToClr(const XMLElement& clr) {
 // GalaxySetupData
 /////////////////////////////////////////////////////
 namespace {
-    // returns number in range 0 to one less than the interger representation of
-    // enum_vals_count, determined by the random seed
-    template <typename T1, typename T2>
-    int GetIdx(const T1& enum_vals_count, const T2& seed) {
-        static boost::hash<T2> T2_hasher;
-        size_t hashed_seed = T2_hasher(seed);
-        return hashed_seed % static_cast<int>(enum_vals_count);
+    // returns randomly picked galaxy setup option in range min_option to one less than GALAXY_SETUP_RANDOM
+    // (so that the random option itself is excluded)
+    GalaxySetupOption PickRandomOption(const GalaxySetupOption min_option) {
+        return static_cast<GalaxySetupOption>(RandSmallInt(static_cast<int>(min_option),
+                                                           static_cast<int>(GALAXY_SETUP_RANDOM) - 1));
     }
 }
 
@@ -134,51 +132,39 @@ const std::string& GalaxySetupData::GetSeed() const
 int GalaxySetupData::GetSize() const
 { return m_size; }
 
-Shape GalaxySetupData::GetShape() const {
-    if (m_shape != RANDOM)
-        return m_shape;
-    size_t num_shapes = static_cast<size_t>(GALAXY_SHAPES) - 1; // -1 so that RANDOM isn't counted
-    return static_cast<Shape>(GetIdx(num_shapes, m_seed));
-}
+Shape GalaxySetupData::GetShape() const
+{ return (m_shape == RANDOM ? m_picked_shape : m_shape); }
 
-GalaxySetupOption GalaxySetupData::GetAge() const {
-    if (m_age != GALAXY_SETUP_RANDOM)
-        return m_age;
-    return static_cast<GalaxySetupOption>(GetIdx(3, m_seed) + 1);   // need range 1-3 for age
-}
+GalaxySetupOption GalaxySetupData::GetAge() const
+{ return (m_age == GALAXY_SETUP_RANDOM ? m_picked_age : m_age); }
 
-GalaxySetupOption GalaxySetupData::GetStarlaneFreq() const {
-    if (m_starlane_freq != GALAXY_SETUP_RANDOM)
-        return m_starlane_freq;
-    return static_cast<GalaxySetupOption>(GetIdx(3, m_seed) + 1);   // need range 1-3 for starlane freq
-}
+GalaxySetupOption GalaxySetupData::GetStarlaneFreq() const
+{ return (m_starlane_freq == GALAXY_SETUP_RANDOM ? m_picked_starlane_freq : m_starlane_freq); }
 
-GalaxySetupOption GalaxySetupData::GetPlanetDensity() const {
-    if (m_planet_density != GALAXY_SETUP_RANDOM)
-        return m_planet_density;
-    return static_cast<GalaxySetupOption>(GetIdx(3, m_seed) + 1);   // need range 1-3 for planet density
-}
+GalaxySetupOption GalaxySetupData::GetPlanetDensity() const
+{ return (m_planet_density == GALAXY_SETUP_RANDOM ? m_picked_planet_density : m_planet_density); }
 
-GalaxySetupOption GalaxySetupData::GetSpecialsFreq() const {
-    if (m_specials_freq != GALAXY_SETUP_RANDOM)
-        return m_specials_freq;
-    return static_cast<GalaxySetupOption>(GetIdx(4, m_seed));       // need range 0-3 for planet density
-}
+GalaxySetupOption GalaxySetupData::GetSpecialsFreq() const
+{ return (m_specials_freq == GALAXY_SETUP_RANDOM ? m_picked_specials_freq : m_specials_freq); }
 
-GalaxySetupOption GalaxySetupData::GetMonsterFreq() const {
-    if (m_monster_freq != GALAXY_SETUP_RANDOM)
-        return m_monster_freq;
-    return static_cast<GalaxySetupOption>(GetIdx(4, m_seed));       // need range 0-3 for monster frequency
-}
+GalaxySetupOption GalaxySetupData::GetMonsterFreq() const
+{ return (m_monster_freq == GALAXY_SETUP_RANDOM ? m_picked_monster_freq : m_monster_freq); }
 
-GalaxySetupOption GalaxySetupData::GetNativeFreq() const {
-    if (m_native_freq != GALAXY_SETUP_RANDOM)
-        return m_native_freq;
-    return static_cast<GalaxySetupOption>(GetIdx(4, m_seed));       // need range 0-3 for native frequency
-}
+GalaxySetupOption GalaxySetupData::GetNativeFreq() const
+{ return (m_native_freq == GALAXY_SETUP_RANDOM ? m_picked_native_freq : m_native_freq); }
 
 Aggression GalaxySetupData::GetAggression() const
 { return m_ai_aggr; }
+
+void GalaxySetupData::DoRandomPicks() {
+    m_picked_shape = static_cast<Shape>(RandSmallInt(0, static_cast<int>(RANDOM) - 1));  // -1 so that RANDOM isn't counted
+    m_picked_age = PickRandomOption(GALAXY_SETUP_LOW);  // need range LOW to HIGH for age
+    m_picked_starlane_freq = PickRandomOption(GALAXY_SETUP_LOW);  // need range LOW to HIGH for starlane frequency
+    m_picked_planet_density = PickRandomOption(GALAXY_SETUP_LOW);  // need range LOW to HIGH for planet density
+    m_picked_specials_freq = PickRandomOption(GALAXY_SETUP_NONE);  // need range NONE to HIGH for specials frequency
+    m_picked_monster_freq = PickRandomOption(GALAXY_SETUP_NONE);  // need range NONE to HIGH for monster frequency
+    m_picked_native_freq = PickRandomOption(GALAXY_SETUP_NONE);  // need range NONE to HIGH for native frequency
+}
 
 
 /////////////////////////////////////////////////////

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -39,7 +39,14 @@ struct FO_COMMON_API GalaxySetupData {
         m_specials_freq(GALAXY_SETUP_MEDIUM),
         m_monster_freq(GALAXY_SETUP_MEDIUM),
         m_native_freq(GALAXY_SETUP_MEDIUM),
-        m_ai_aggr(MANIACAL)
+        m_ai_aggr(MANIACAL),
+        m_picked_shape(INVALID_SHAPE),
+        m_picked_age(INVALID_GALAXY_SETUP_OPTION),
+        m_picked_starlane_freq(INVALID_GALAXY_SETUP_OPTION),
+        m_picked_planet_density(INVALID_GALAXY_SETUP_OPTION),
+        m_picked_specials_freq(INVALID_GALAXY_SETUP_OPTION),
+        m_picked_monster_freq(INVALID_GALAXY_SETUP_OPTION),
+        m_picked_native_freq(INVALID_GALAXY_SETUP_OPTION)
     {}
     //@}
     /** \name Accessors */ //@{
@@ -55,6 +62,11 @@ struct FO_COMMON_API GalaxySetupData {
     Aggression          GetAggression() const;
     //@}
 
+    /** \name Mutators */ //@{
+    // Picks the random options for all galaxy setup options that are set to their respective "random" values
+    void                DoRandomPicks();
+    //@}
+
     std::string         m_seed;
     int                 m_size;
     Shape               m_shape;
@@ -67,6 +79,14 @@ struct FO_COMMON_API GalaxySetupData {
     Aggression          m_ai_aggr;
 
 private:
+    Shape               m_picked_shape;
+    GalaxySetupOption   m_picked_age;
+    GalaxySetupOption   m_picked_starlane_freq;
+    GalaxySetupOption   m_picked_planet_density;
+    GalaxySetupOption   m_picked_specials_freq;
+    GalaxySetupOption   m_picked_monster_freq;
+    GalaxySetupOption   m_picked_native_freq;
+
     friend class boost::serialization::access;
     template <class Archive>
     void serialize(Archive& ar, const unsigned int version);

--- a/util/SerializeMultiplayerCommon.cpp
+++ b/util/SerializeMultiplayerCommon.cpp
@@ -18,7 +18,14 @@ void GalaxySetupData::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_specials_freq)
         & BOOST_SERIALIZATION_NVP(m_monster_freq)
         & BOOST_SERIALIZATION_NVP(m_native_freq)
-        & BOOST_SERIALIZATION_NVP(m_ai_aggr);
+        & BOOST_SERIALIZATION_NVP(m_ai_aggr)
+        & BOOST_SERIALIZATION_NVP(m_picked_shape)
+        & BOOST_SERIALIZATION_NVP(m_picked_age)
+        & BOOST_SERIALIZATION_NVP(m_picked_starlane_freq)
+        & BOOST_SERIALIZATION_NVP(m_picked_planet_density)
+        & BOOST_SERIALIZATION_NVP(m_picked_specials_freq)
+        & BOOST_SERIALIZATION_NVP(m_picked_monster_freq)
+        & BOOST_SERIALIZATION_NVP(m_picked_native_freq);
 }
 
 template void GalaxySetupData::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, const unsigned int);


### PR DESCRIPTION
Using a hash of the seed and the number of available options to determine the option to pick for "random" selections produced the same pick for all settings that had the same number of options to pick from, which isn't sufficiently random.

This alternative approach extends the GalaxySetupData structure with additional private m_picked_\* fields for all settings that offer a "random" option, and a member function that executes the random picking for all those settings (which gets called at the start of universe generation, right after the RNG has been initialized with the seed). The random picks are stored in the corresponding m_picked_\* fields, and upon retrieval of an option the corresponding accessor function checks if the "random" option is set, in which case the value of the corresponding m_picked_\* field is returned.
