### PR TITLE
Supply Reworking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,7 @@ set (freeorioncommon_HEADER
     Empire/Empire.h
     Empire/EmpireManager.h
     Empire/ResourcePool.h
+    Empire/Supply.h
     network/Message.h
     network/MessageQueue.h
     network/Networking.h
@@ -218,6 +219,7 @@ set (freeorioncommon_SOURCE
     Empire/Empire.cpp
     Empire/EmpireManager.cpp
     Empire/ResourcePool.cpp
+    Empire/Supply.cpp
     network/Message.cpp
     network/MessageQueue.cpp
     network/Networking.cpp

--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -21,6 +21,7 @@
 #include "../universe/UniverseObject.h"
 #include "ResourcePool.h"
 #include "EmpireManager.h"
+#include "Supply.h"
 
 #include <algorithm>
 
@@ -3009,12 +3010,7 @@ void Empire::InitResourcePools() {
 
 
     // inform the blockadeable resource pools about systems that can share
-    // TODO: Uncomment when implemented...
-    //const std::map<int, std::set<std::set<int> > >& empires_resource_supply_groups = GetSupplyManager().ResourceSupplyGroups();
-    //std::map<int, std::set<std::set<int> > >::const_iterator it = empires_resource_supply_groups.find(m_id);
-    //if (it != empires_resource_supply_groups.end())
-    //    m_resource_pools[RE_INDUSTRY]->SetConnectedSupplyGroups(it->second);
-
+    m_resource_pools[RE_INDUSTRY]->SetConnectedSupplyGroups(GetSupplyManager().ResourceSupplyGroups(m_id));
 
     // set non-blockadeable resource pools to share resources between all systems
     std::set<std::set<int> > sets_set;

--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -1878,7 +1878,7 @@ void Empire::UpdateSupplyUnobstructedSystems() {
 }
 
 void Empire::UpdateSupplyUnobstructedSystems(const std::set<int>& known_systems) {
-    DebugLogger() << "UpdateSupplyUnobstructedSystems for empire " << m_id;
+    //DebugLogger() << "UpdateSupplyUnobstructedSystems for empire " << m_id;
     m_supply_unobstructed_systems.clear();
 
     // get systems with historically at least partial visibility
@@ -1917,7 +1917,7 @@ void Empire::UpdateSupplyUnobstructedSystems(const std::set<int>& known_systems)
             continue; //known to be destroyed so can't affect supply, important just in case being updated on client side
         }
         int fleet_id = fleet->ID();
-        DebugLogger() << "Fleet " << fleet_id << " is in system " << system_id << " with next system " << fleet->NextSystemID() << " and is owned by " << fleet->Owner() << " armed: " << fleet->HasArmedShips() << " and agressive: " << fleet->Aggressive();
+        //DebugLogger() << "Fleet " << fleet_id << " is in system " << system_id << " with next system " << fleet->NextSystemID() << " and is owned by " << fleet->Owner() << " armed: " << fleet->HasArmedShips() << " and agressive: " << fleet->Aggressive();
         if (fleet->HasArmedShips() && fleet->Aggressive()) {
             if (fleet->OwnedBy(m_id)) {
                 if (fleet->NextSystemID() == INVALID_OBJECT_ID || fleet->NextSystemID() == fleet->SystemID()) {
@@ -1938,11 +1938,11 @@ void Empire::UpdateSupplyUnobstructedSystems(const std::set<int>& known_systems)
         }
     }
 
-    std::stringstream ss;
-    for (std::set<int>::iterator it = systems_containing_obstructing_objects.begin();
-         it != systems_containing_obstructing_objects.end(); ++it)
-    { ss << *it << ", "; }
-    DebugLogger() << "systems with obstructing objects for empire " << m_id << " : " << ss.str();
+    //std::stringstream ss;
+    //for (std::set<int>::iterator it = systems_containing_obstructing_objects.begin();
+    //     it != systems_containing_obstructing_objects.end(); ++it)
+    //{ ss << *it << ", "; }
+    //DebugLogger() << "systems with obstructing objects for empire " << m_id << " : " << ss.str();
 
 
     // check each potential supplyable system for whether it can propagate supply.
@@ -1950,7 +1950,7 @@ void Empire::UpdateSupplyUnobstructedSystems(const std::set<int>& known_systems)
          known_systems_it != known_systems.end(); ++known_systems_it)
     {
         int sys_id = *known_systems_it;
-        DebugLogger() << "deciding unobstructedness for system " << sys_id;
+        //DebugLogger() << "deciding unobstructedness for system " << sys_id;
 
         // has empire ever seen this system with partial or better visibility?
         if (systems_with_at_least_partial_visibility_at_some_point.find(sys_id) ==

--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -24,10 +24,7 @@
 
 #include <algorithm>
 
-#include <boost/filesystem/fstream.hpp>
 #include <boost/lexical_cast.hpp>
-#include <boost/graph/adjacency_list.hpp>
-#include <boost/graph/connected_components.hpp>
 #include <boost/timer.hpp>
 #include "boost/date_time/posix_time/posix_time.hpp"
 
@@ -1808,10 +1805,10 @@ void Empire::UpdateSystemSupplyRanges(const std::set<int>& known_objects) {
         // check if object has a supply meter
         if (obj->GetMeter(METER_SUPPLY)) {
             // get resource supply range for next turn for this object
-            int supply_range = static_cast<int>(floor(obj->NextTurnCurrentMeterValue(METER_SUPPLY)));
+            float supply_range = obj->NextTurnCurrentMeterValue(METER_SUPPLY);
 
             // if this object can provide more supply range than the best previously checked object in this system, record its range as the new best for the system
-            std::map<int, int>::iterator system_it = m_supply_system_ranges.find(system_id);               // try to find a previous entry for this system's supply range
+            std::map<int, float>::iterator system_it = m_supply_system_ranges.find(system_id);               // try to find a previous entry for this system's supply range
             if (system_it == m_supply_system_ranges.end() || supply_range > system_it->second) {  // if there is no previous entry, or the previous entry is shorter than the new one, add or replace the entry
                 //std::cout << " ... object " << obj->Name() << " has resource supply range: " << resource_supply_range << std::endl;
                 m_supply_system_ranges[system_id] = supply_range;
@@ -1998,7 +1995,7 @@ void Empire::UpdateAvailableLanes() {
     m_pending_system_exit_lanes.clear(); // TODO: consider: not really necessary, & may be more efficient to not clear.
 }
 
-const std::map<int, int>& Empire::SystemSupplyRanges() const
+const std::map<int, float>& Empire::SystemSupplyRanges() const
 { return m_supply_system_ranges; }
 
 const std::set<int>& Empire::SupplyUnobstructedSystems() const

--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -1769,10 +1769,6 @@ void Empire::Eliminate() {
     // m_ship_names_used;
     m_supply_system_ranges.clear();
     m_supply_unobstructed_systems.clear();
-    m_supply_starlane_traversals.clear();
-    m_supply_starlane_obstructed_traversals.clear();
-    m_fleet_supplyable_system_ids.clear();
-    m_resource_supply_groups.clear();
 }
 
 bool Empire::Won() const {
@@ -1898,8 +1894,8 @@ void Empire::UpdateSupplyUnobstructedSystems(const std::set<int>& known_systems)
     const std::vector<TemporaryPtr<Fleet> > fleets = GetUniverse().Objects().FindObjects<Fleet>();
     const std::set<int>& known_destroyed_objects = GetUniverse().EmpireKnownDestroyedObjectIDs(this->EmpireID());
 
-    // find systems that contain fleets that can either maintaining supply or block supply
-    // to affect supply in either manner a fleet must be armed & aggressive, & must be not 
+    // find systems that contain fleets that can either maintain supply or block supply.
+    // to affect supply in either manner, a fleet must be armed & aggressive, & must be not
     // trying to depart the systme.  Qualifying enemy fleets will blockade if no friendly fleets
     // are present, or if the friendly fleets were already blockade-restricted and the enemy
     // fleets were not (meaning that the enemy fleets were continuing an existing blockade)
@@ -2002,241 +1998,11 @@ void Empire::UpdateAvailableLanes() {
     m_pending_system_exit_lanes.clear(); // TODO: consider: not really necessary, & may be more efficient to not clear.
 }
 
-void Empire::UpdateSupply()
-{ UpdateSupply(this->KnownStarlanes()); }
-
-void Empire::UpdateSupply(const std::map<int, std::set<int> >& starlanes) {
-    //std::cout << "Empire::UpdateSupply for empire " << this->Name() << std::endl;
-
-    // Please also update PythonEmpireWrapper.cpp:CalculateSupplyUpdate if there is a change to the supply propagation rules: 
-    // (i) there is a set of supply sources in systems, (ii) propagating supply drops one per starlane jump, (iii) propagation is blocked
-    // into and out of any systems not in SupplyUnobstructedSystems, and (iv) a system gets the highest supply thus available to it.
-
-    m_supply_starlane_traversals.clear();
-    m_supply_starlane_obstructed_traversals.clear();
-    m_fleet_supplyable_system_ids.clear();
-    m_resource_supply_groups.clear();
-
-    // need to get a set of sets of systems that can exchange resources.  some
-    // sets may be just one system, in which resources can be exchanged between
-    // UniverseObjects producing or consuming them, but which can't exchange
-    // with any other systems.
-
-    // map from system id to set of systems that are supply-connected to it
-    // directly (which may involve multiple starlane jumps
-    std::map<int, std::set<int> > supply_groups_map;
-
-
-    // store supply range in jumps of all unobstructed systems before
-    // propegation, and add to list of systems to propegate from.
-    std::map<int, int> propegating_supply_ranges;
-    std::list<int> propegating_systems_list;
-    for (std::map<int, int>::const_iterator it = m_supply_system_ranges.begin();
-         it != m_supply_system_ranges.end(); ++it)
-    {
-        if (m_supply_unobstructed_systems.find(it->first) != m_supply_unobstructed_systems.end())
-            propegating_supply_ranges.insert(*it);
-
-        // system can supply itself, so store this fact
-        supply_groups_map[it->first].insert(it->first);
-
-        // add system to list of systems to popegate supply from
-        propegating_systems_list.push_back(it->first);
-
-        // Currently, only supply sources whose meter is above zero provide any fleet supply, and this
-        // is handled by the propegating_systems_list loop below. If it becomes intended that a supply 
-        // source with supply meter at zero could still provide fleet supply at its own system, 
-        // then uncomment the following line
-        //m_fleet_supplyable_system_ids.insert(it->first);
-    }
-
-
-    // iterate through list of accessible systems, processing each in order it
-    // was added (like breadth first search) until no systems are left able to
-    // further propregate
-    std::list<int>::iterator sys_list_it = propegating_systems_list.begin();
-    std::list<int>::iterator sys_list_end = propegating_systems_list.end();
-    while (sys_list_it != sys_list_end) {
-        int cur_sys_id = *sys_list_it;
-        int cur_sys_range = propegating_supply_ranges[cur_sys_id];    // range away from this system that supplies can be transported
-
-        // any unobstructed system can share resources within itself
-        supply_groups_map[cur_sys_id].insert(cur_sys_id);
-
-        if (cur_sys_range <= 0) {
-            // can't propegate supply out a system that has no range
-            ++sys_list_it;
-            continue;
-        }
-
-        // any system with nonzero fleet supply range can provide fleet supply
-        m_fleet_supplyable_system_ids.insert(cur_sys_id);
-
-        // can propegate further, if adjacent systems have smaller supply range
-        // than one less than this system's range
-        std::map<int, std::set<int> >::const_iterator system_it = starlanes.find(cur_sys_id);
-        if (system_it == starlanes.end()) {
-            // no starlanes out of this system
-            ++sys_list_it;
-            continue;
-        }
-
-
-        const std::set<int>& starlane_ends = system_it->second;
-        for (std::set<int>::const_iterator lane_it = starlane_ends.begin();
-             lane_it != starlane_ends.end(); ++lane_it)
-        {
-            int lane_end_sys_id = *lane_it;
-
-            if (m_supply_unobstructed_systems.find(lane_end_sys_id) == m_supply_unobstructed_systems.end()) {
-                // can't propegate here
-                m_supply_starlane_obstructed_traversals.insert(std::make_pair(cur_sys_id, lane_end_sys_id));
-                continue;
-            }
-
-            // can supply fleets here
-            m_fleet_supplyable_system_ids.insert(lane_end_sys_id);
-
-            // compare next system's supply range to this system's supply range.  propegate if necessary.
-            std::map<int, int>::const_iterator lane_end_sys_it = propegating_supply_ranges.find(lane_end_sys_id);
-            if (lane_end_sys_it == propegating_supply_ranges.end() || lane_end_sys_it->second <= cur_sys_range) {
-                // next system has no supply yet, or its range equal to or smaller than this system's
-
-                // update next system's range, if propegating from this system would make it larger
-                if (lane_end_sys_it == propegating_supply_ranges.end() || lane_end_sys_it->second < cur_sys_range - 1) {
-                    // update with new range
-                    propegating_supply_ranges[lane_end_sys_id] = cur_sys_range - 1;
-                    // add next system to list of systems to propegate further
-                    propegating_systems_list.push_back(lane_end_sys_id);
-                }
-
-                // regardless of whether propegating from current to next system
-                // increased its range, add the traversed lane to show
-                // redundancies in supply network to player
-                m_supply_starlane_traversals.insert(std::make_pair(cur_sys_id, lane_end_sys_id));
-
-                // current system can share resources with next system
-                supply_groups_map[cur_sys_id].insert(lane_end_sys_id);
-                supply_groups_map[lane_end_sys_id].insert(cur_sys_id);
-                //DebugLogger() << "added sys(" << lane_end_sys_id << ") to supply_groups_map[ " << cur_sys_id<<"]";
-                //DebugLogger() << "added sys(" << cur_sys_id << ") to supply_groups_map[ " << lane_end_sys_id <<"]";
-            }
-        }
-        ++sys_list_it;
-        sys_list_end = propegating_systems_list.end();
-    }
-
-    // Need to merge interconnected supply groups into as few sets of mutually-
-    // supply-exchanging systems as possible.  This requires finding the
-    // connected components of an undirected graph, where the node
-    // adjacency are the directly-connected systems determined above.
-
-    // create graph
-    boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS> graph;
-
-    // boost expects vertex labels to range from 0 to num vertices - 1, so need
-    // to map from system id to graph id and back when accessing vertices
-    std::vector<int> graph_id_to_sys_id;
-    graph_id_to_sys_id.reserve(supply_groups_map.size());
-
-    std::map<int, int> sys_id_to_graph_id;
-    int graph_id = 0;
-    for (std::map<int, std::set<int> >::const_iterator sys_it = supply_groups_map.begin();
-         sys_it != supply_groups_map.end(); ++sys_it, ++graph_id)
-    {
-        int sys_id = sys_it->first;
-        //TemporaryPtr<const System> sys = GetSystem(sys_id);
-        //std::string name = sys->Name();
-        //DebugLogger() << "supply-exchanging system: " << name << " ID (" << sys_id <<")";
-
-        boost::add_vertex(graph);   // should add with index = graph_id
-
-        graph_id_to_sys_id.push_back(sys_id);
-        sys_id_to_graph_id[sys_id] = graph_id;
-    }
-
-    // add edges for all direct connections between systems
-    for (std::map<int, std::set<int> >::const_iterator maps_it = supply_groups_map.begin();
-         maps_it != supply_groups_map.end(); ++maps_it)
-    {
-        int start_graph_id = sys_id_to_graph_id[maps_it->first];
-        const std::set<int>& set = maps_it->second;
-        for(std::set<int>::const_iterator set_it = set.begin(); set_it != set.end(); ++set_it) {
-            int end_graph_id = sys_id_to_graph_id[*set_it];
-            boost::add_edge(start_graph_id, end_graph_id, graph);
-
-            //int sys_id1 = graph_id_to_sys_id[start_graph_id];
-            //TemporaryPtr<const System> sys1 = GetSystem(sys_id1);
-            //std::string name1 = sys1->Name();
-            //int sys_id2 = graph_id_to_sys_id[end_graph_id];
-            //TemporaryPtr<const System> sys2 = GetSystem(sys_id2);
-            //std::string name2 = sys2->Name();
-            //DebugLogger() << "added edge to graph: " << name1 << " and " << name2;
-        }
-    }
-
-    // declare storage and fill with the component id (group id of connected systems) for each graph vertex
-    std::vector<int> components(boost::num_vertices(graph));
-    boost::connected_components(graph, &components[0]);
-
-    //for (std::vector<int>::size_type i = 0; i != components.size(); ++i) {
-    //    int sys_id = graph_id_to_sys_id[i];
-    //    TemporaryPtr<const System> sys = GetSystem(sys_id);
-    //    std::string name = sys->Name();
-    //    DebugLogger() << "system " << name <<" is in component " << components[i];
-    //}
-    //std::cout << std::endl;
-
-    // convert results back from graph id to system id, and into desired output format
-    // output: std::set<std::set<int> >& m_resource_supply_groups
-
-    // first, sort into a map from component id to set of system ids in component
-    std::map<int, std::set<int> > component_sets_map;
-    for (std::size_t graph_id = 0; graph_id != components.size(); ++graph_id) {
-        int label = components[graph_id];
-        int sys_id = graph_id_to_sys_id[graph_id];
-        component_sets_map[label].insert(sys_id);
-    }
-
-    // copy sets in map into set of sets
-    for (std::map<int, std::set<int> >::const_iterator map_it = component_sets_map.begin(); map_it != component_sets_map.end(); ++map_it) {
-        m_resource_supply_groups.insert(map_it->second);
-
-        //// DEBUG!
-        //DebugLogger() << "Set: ";
-        //for (std::set<int>::const_iterator set_it = map_it->second.begin(); set_it != map_it->second.end(); ++set_it) {
-        //    TemporaryPtr<const UniverseObject> obj = GetUniverse().Object(*set_it);
-        //    if (!obj) {
-        //        DebugLogger() << " ... missing object!";
-        //        continue;
-        //    }
-        //    DebugLogger() << " ... " << obj->Name();
-        //}
-    }
-}
-
 const std::map<int, int>& Empire::SystemSupplyRanges() const
 { return m_supply_system_ranges; }
 
 const std::set<int>& Empire::SupplyUnobstructedSystems() const
 { return m_supply_unobstructed_systems; }
-
-const std::set<std::pair<int, int> >& Empire::SupplyStarlaneTraversals() const
-{ return m_supply_starlane_traversals; }
-
-const std::set<std::pair<int, int> >& Empire::SupplyObstructedStarlaneTraversals() const
-{ return m_supply_starlane_obstructed_traversals; }
-
-const std::set<int>& Empire::FleetSupplyableSystemIDs() const
-{ return m_fleet_supplyable_system_ids; }
-
-bool Empire::SystemHasFleetSupply(int system_id) const {
-    if (system_id == INVALID_OBJECT_ID)
-        return false;
-    if (m_fleet_supplyable_system_ids.find(system_id) != m_fleet_supplyable_system_ids.end())
-        return true;
-    return false;
-}
 
 const bool Empire::UnrestrictedLaneTravel(int start_system_id, int dest_system_id) const {
     std::map<int, std::set<int> >::const_iterator find_it = m_available_system_exit_lanes.find(start_system_id);
@@ -2246,9 +2012,6 @@ const bool Empire::UnrestrictedLaneTravel(int start_system_id, int dest_system_i
     }
     return false;
 }
-
-const std::set<std::set<int> >& Empire::ResourceSupplyGroups() const
-{ return m_resource_supply_groups; }
 
 Empire::TechItr Empire::TechBegin() const
 { return m_techs.begin(); }
@@ -3249,7 +3012,11 @@ void Empire::InitResourcePools() {
 
 
     // inform the blockadeable resource pools about systems that can share
-    m_resource_pools[RE_INDUSTRY]->SetConnectedSupplyGroups(m_resource_supply_groups);
+    // TODO: Uncomment when implemented...
+    //const std::map<int, std::set<std::set<int> > >& empires_resource_supply_groups = GetSupplyManager().ResourceSupplyGroups();
+    //std::map<int, std::set<std::set<int> > >::const_iterator it = empires_resource_supply_groups.find(m_id);
+    //if (it != empires_resource_supply_groups.end())
+    //    m_resource_pools[RE_INDUSTRY]->SetConnectedSupplyGroups(it->second);
 
 
     // set non-blockadeable resource pools to share resources between all systems

--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -363,7 +363,7 @@ public:
 
     /** Returns distance in jumps away from each system that this empire can
       * propegate supply. */
-    const std::map<int, int>&               SystemSupplyRanges() const;
+    const std::map<int, float>&             SystemSupplyRanges() const;
 
     /** Returns set of system ids that are able to propagate supply from one
       * system to the next, or at which supply can be delivered to fleets if
@@ -645,10 +645,10 @@ private:
     std::map<std::string, int>      m_building_types_scrapped;  ///< how many buildings of each type has this empire scrapped?
 
     // cached calculation results, returned by reference
-    std::map<int, int>              m_supply_system_ranges;                 ///< number of starlane jumps away from each system (by id) supply can be conveyed.  This is the number due to a system's contents conveying supply and is computed and set by UpdateSystemSupplyRanges
-    std::set<int>                   m_supply_unobstructed_systems;          ///< ids of system that don't block supply from flowing
-    std::map<int, std::set<int> >   m_available_system_exit_lanes;          ///< for each system known to this empire, the set of available/non-blockaded exit lanes for fleet travel
-    std::map<int, std::set<int> >   m_pending_system_exit_lanes;            ///< pending updates to m_available_system_exit_lanes
+    std::map<int, float>            m_supply_system_ranges;         ///< number of starlane jumps away from each system (by id) supply can be conveyed.  This is the number due to a system's contents conveying supply and is computed and set by UpdateSystemSupplyRanges
+    std::set<int>                   m_supply_unobstructed_systems;  ///< ids of system that don't block supply from flowing
+    std::map<int, std::set<int> >   m_available_system_exit_lanes;  ///< for each system known to this empire, the set of available/non-blockaded exit lanes for fleet travel
+    std::map<int, std::set<int> >   m_pending_system_exit_lanes;    ///< pending updates to m_available_system_exit_lanes
 
     friend class boost::serialization::access;
     Empire();

--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -364,30 +364,16 @@ public:
     /** Returns distance in jumps away from each system that this empire can
       * propegate supply. */
     const std::map<int, int>&               SystemSupplyRanges() const;
+
     /** Returns set of system ids that are able to propagate supply from one
       * system to the next, or at which supply can be delivered to fleets if
       * supply can reach the system from elsewhere, or in which planets can
       * exchange supply between themselves (even if not leaving the system). */
     const std::set<int>&                    SupplyUnobstructedSystems() const;
-    /** Returns set of directed starlane traversals along which supply can flow.
-      * Results are pairs of system ids of start and end system of traversal. */
-    const std::set<std::pair<int, int> >&   SupplyStarlaneTraversals() const;
-    /** Returns set of directed starlane traversals along which supply could
-      * flow for this empire, but which can't due to some obstruction in one
-      * of the systems. */
-    const std::set<std::pair<int, int> >&   SupplyObstructedStarlaneTraversals() const;
-    /** Returns set of system ids where fleets can be supplied by this empire
-      * (as determined by object supply meters and rules of supply propagation
-      * and blockade). */
-    const std::set<int>&                    FleetSupplyableSystemIDs() const;
-    /** Returns true if system with id \a system_id is fleet supplyable or in
-      * one of the resource supply groups of this empire. */
-    bool                                    SystemHasFleetSupply(int system_id) const;
-    /** Returns true if the start system is known to this empire and travel to the dest system is not restricted by blockade */
+
+    /** Returns true if the start system is known to this empire and travel to
+        the dest system is not restricted by blockade.  */
     const bool                              UnrestrictedLaneTravel(int start_system_id, int dest_system_id) const;
-    /** Returns set of sets of systems that can share industry (systems in
-      * separate groups are blockaded or otherwise separated). */
-    const std::set<std::set<int> >&         ResourceSupplyGroups() const;
 
     const std::set<int>&                    ExploredSystems() const;    ///< returns set of ids of systems that this empire has explored
     const std::map<int, std::set<int> >     KnownStarlanes() const;     ///< returns map from system id (start) to set of system ids (endpoints) of all starlanes known to this empire
@@ -501,15 +487,6 @@ public:
     void        RecordPendingLaneUpdate(int start_system_id, int dest_system_id);
     /** Processes all the pending lane access updates.  This is managed as a two step process to avoid order-of-processing issues. */
     void        UpdateAvailableLanes();
-    /** Calculates systems at which fleets of this empire can be supplied, and
-      * groups of systems that can exchange resources, and the starlane
-      * traversals used to do so, using the indicated \a starlanes but subject
-      * to obstruction of supply by various factors.  Call
-      * UpdateSystemSupplyRanges and UpdateSupplyUnobstructedSystems before
-      * calling this. */
-    void        UpdateSupply(const std::map<int, std::set<int> >& starlanes);
-    /** Updates supply using this empire's set of known starlanes. */
-    void        UpdateSupply();
 
     /** Checks for production projects that have been completed, and places them
       * at their respective production sites.  Which projects have been
@@ -670,12 +647,8 @@ private:
     // cached calculation results, returned by reference
     std::map<int, int>              m_supply_system_ranges;                 ///< number of starlane jumps away from each system (by id) supply can be conveyed.  This is the number due to a system's contents conveying supply and is computed and set by UpdateSystemSupplyRanges
     std::set<int>                   m_supply_unobstructed_systems;          ///< ids of system that don't block supply from flowing
-    std::set<std::pair<int, int> >  m_supply_starlane_traversals;           ///< ordered pairs of system ids between which a starlane runs that can be used to convey resources between systems
-    std::set<std::pair<int, int> >  m_supply_starlane_obstructed_traversals;///< ordered pairs of system ids between which a starlane could be used to convey resources between system, but is not because something is obstructing the resource flow.  That is, the resource flow isn't limited by range, but by something blocking its flow.
     std::map<int, std::set<int> >   m_available_system_exit_lanes;          ///< for each system known to this empire, the set of available/non-blockaded exit lanes for fleet travel
     std::map<int, std::set<int> >   m_pending_system_exit_lanes;            ///< pending updates to m_available_system_exit_lanes
-    std::set<int>                   m_fleet_supplyable_system_ids;          ///< ids of systems where fleets can remain for a turn to be resupplied.
-    std::set<std::set<int> >        m_resource_supply_groups;               ///< sets of system ids that are connected by supply lines and are able to share resources between systems or between objects in systems
 
     friend class boost::serialization::access;
     Empire();

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -1,14 +1,58 @@
 #include "Supply.h"
 
 #include "EmpireManager.h"
+#include "../universe/UniverseObject.h"
 
 #include <boost/graph/connected_components.hpp>
-//
-//void Supply::UpdateSupply()
+
+SupplyManager::SupplyManager() :
+    m_supply_starlane_traversals(),
+    m_supply_starlane_obstructed_traversals(),
+    m_fleet_supplyable_system_ids(),
+    m_resource_supply_groups()
+{}
+
+SupplyManager& SupplyManager::operator=(const SupplyManager& rhs) {
+    m_supply_starlane_traversals =              rhs.m_supply_starlane_traversals;
+    m_supply_starlane_obstructed_traversals =   rhs.m_supply_starlane_obstructed_traversals;
+    m_fleet_supplyable_system_ids =             rhs.m_fleet_supplyable_system_ids;
+    m_resource_supply_groups =                  rhs.m_resource_supply_groups;
+    return *this;
+}
+
+const std::map<int, std::set<std::pair<int, int> > >& SupplyManager::SupplyStarlaneTraversals() const
+{ return m_supply_starlane_traversals; }
+
+const std::map<int, std::set<std::pair<int, int> > >& SupplyManager::SupplyObstructedStarlaneTraversals() const
+{ return m_supply_starlane_obstructed_traversals; }
+
+const std::map<int, std::set<int> >& SupplyManager::FleetSupplyableSystemIDs() const
+{ return m_fleet_supplyable_system_ids; }
+
+const std::map<int, std::set<std::set<int> > >& SupplyManager::ResourceSupplyGroups() const
+{ return m_resource_supply_groups; }
+
+bool SupplyManager::SystemHasFleetSupply(int system_id, int empire_id) const {
+    if (system_id == INVALID_OBJECT_ID)
+        return false;
+    if (empire_id == ALL_EMPIRES)
+        return false;
+    std::map<int, std::set<int> >::const_iterator it = m_fleet_supplyable_system_ids.find(empire_id);
+    if (it == m_fleet_supplyable_system_ids.end())
+        return false;
+    const std::set<int>& sys_set = it->second;
+    if (sys_set.find(system_id) != sys_set.end())
+        return true;
+    return false;
+}
+
+
+
+//void SupplyManager::UpdateSupply()
 //{ UpdateSupply(this->KnownStarlanes()); }
 //
-//void Supply::UpdateSupply(const std::map<int, std::set<int> >& starlanes) {
-//    //std::cout << "Supply::UpdateSupply for empire " << this->Name() << std::endl;
+//void SupplyManager::UpdateSupply(const std::map<int, std::set<int> >& starlanes) {
+//    //std::cout << "SupplyManager::UpdateSupply for empire " << this->Name() << std::endl;
 //
 //    // Please also update PythonEmpireWrapper.cpp:CalculateSupplyUpdate if there is a change to the supply propagation rules: 
 //    // (i) there is a set of supply sources in systems, (ii) propagating supply drops one per starlane jump, (iii) propagation is blocked
@@ -217,22 +261,3 @@
 //    }
 //}
 //
-//const std::set<std::pair<int, int> >& Supply::SupplyStarlaneTraversals() const
-//{ return m_supply_starlane_traversals; }
-//
-//const std::set<std::pair<int, int> >& Supply::SupplyObstructedStarlaneTraversals() const
-//{ return m_supply_starlane_obstructed_traversals; }
-//
-//const std::set<int>& Supply::FleetSupplyableSystemIDs() const
-//{ return m_fleet_supplyable_system_ids; }
-//
-//bool Supply::SystemHasFleetSupply(int system_id) const {
-//    if (system_id == INVALID_OBJECT_ID)
-//        return false;
-//    if (m_fleet_supplyable_system_ids.find(system_id) != m_fleet_supplyable_system_ids.end())
-//        return true;
-//    return false;
-//}
-//
-//const std::set<std::set<int> >& Supply::ResourceSupplyGroups() const
-//{ return m_resource_supply_groups; }

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -409,21 +409,25 @@ void SupplyManager::Update() {
             std::set<std::pair<int, int> >& obstructed_traversals = m_supply_starlane_obstructed_traversals[empire_id];
             std::set<std::pair<int, int> > obstrcuted_traversals_initial = obstructed_traversals;
 
-            // remove from traversals involving this system for this empire
+            // remove from traversals departing from or going to this system for this empire,
+            // and set any traversals going to this system as obstructed
             for (std::set<std::pair<int, int> >::iterator traversals_it = lane_traversals_initial.begin();
                  traversals_it != lane_traversals_initial.end(); ++traversals_it)
             {
-                if (traversals_it->first == sys_id || traversals_it->second == sys_id) {
-                    lane_traversals.erase(std::make_pair(traversals_it->first, traversals_it->second));
-                    obstructed_traversals.insert(std::make_pair(traversals_it->first, traversals_it->second));
+                if (traversals_it->first == sys_id) {
+                    lane_traversals.erase(std::make_pair(sys_id, traversals_it->second));
+                }
+                if (traversals_it->second == sys_id) {
+                    lane_traversals.erase(std::make_pair(traversals_it->first, sys_id));
+                    obstructed_traversals.insert(std::make_pair(traversals_it->first, sys_id));
                 }
             }
 
-            // remove from obstructed traverals involving this system for this empire
+            // remove from obstructed traverals departing from this system
             for (std::set<std::pair<int, int> >::iterator traversals_it = obstrcuted_traversals_initial.begin();
                  traversals_it != obstrcuted_traversals_initial.end(); ++traversals_it)
             {
-                if (traversals_it->first == sys_id /*|| traversals_it->second == sys_id*/)
+                if (traversals_it->first == sys_id)
                     obstructed_traversals.erase(std::make_pair(traversals_it->first, traversals_it->second));
             }
         }

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -448,7 +448,7 @@ void SupplyManager::Update() {
 
 
                     // does another empire have as much or more supply here?
-                    float other_empire_biggest_range = 0.0f;
+                    float other_empire_biggest_range = -10000.0f;   // arbitrary big numbeer
                     for (std::map<int, std::map<int, float> >::const_iterator prev_other_empire_it = empire_propegating_supply_ranges.begin();
                          prev_other_empire_it != empire_propegating_supply_ranges.end(); ++prev_other_empire_it)
                     {

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -470,17 +470,12 @@ void SupplyManager::Update() {
 
                     // otherwise, propegate into system...
 
-                    // add traversal (regardless of whether it is needed to
-                    // increase the adjacent system's range for this empire
-                    m_supply_starlane_traversals[empire_id].insert(std::make_pair(system_id, lane_end_sys_id));
-
-                    // get adjacent system's current range
-                    float adj_sys_existing_range = empire_propegating_supply_ranges[empire_id][lane_end_sys_id];
-
-                    // if propegating supply would increase the range of the
-                    // adjacent system, do so.
-                    if (range_after_one_more_jump > adj_sys_existing_range)
+                    // if propegating supply would increase or equal the range
+                    // of the adjacent system, do so.
+                    if (range_after_one_more_jump >= empire_propegating_supply_ranges[empire_id][lane_end_sys_id]) {
                         empire_propegating_supply_ranges_next[empire_id][lane_end_sys_id] = range_after_one_more_jump;
+                        m_supply_starlane_traversals[empire_id].insert(std::make_pair(system_id, lane_end_sys_id));
+                    }
                 }
             }
         }

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -1,8 +1,14 @@
 #include "Supply.h"
 
 #include "EmpireManager.h"
+#include "Empire.h"
+#include "../universe/Universe.h"
 #include "../universe/UniverseObject.h"
+#include "../universe/System.h"
+#include "../util/AppInterface.h"
 
+#include <boost/graph/connected_components.hpp>
+#include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/connected_components.hpp>
 
 SupplyManager::SupplyManager() :
@@ -80,218 +86,271 @@ bool SupplyManager::SystemHasFleetSupply(int system_id, int empire_id) const {
     return false;
 }
 
+void SupplyManager::Update() {
+    m_supply_starlane_traversals.clear();
+    m_supply_starlane_obstructed_traversals.clear();
+    m_fleet_supplyable_system_ids.clear();
+    m_resource_supply_groups.clear();
 
+    // for each empire, need to get a set of sets of systems that can exchange
+    // resources.  some sets may be just one system, in which resources can be
+    // exchanged between UniverseObjects producing or consuming them, but which
+    // can't exchange with any other systems.
 
-//void SupplyManager::UpdateSupply()
-//{ UpdateSupply(this->KnownStarlanes()); }
-//
-//void SupplyManager::UpdateSupply(const std::map<int, std::set<int> >& starlanes) {
-//    //std::cout << "SupplyManager::UpdateSupply for empire " << this->Name() << std::endl;
-//
-//    // Please also update PythonEmpireWrapper.cpp:CalculateSupplyUpdate if there is a change to the supply propagation rules: 
-//    // (i) there is a set of supply sources in systems, (ii) propagating supply drops one per starlane jump, (iii) propagation is blocked
-//    // into and out of any systems not in SupplyUnobstructedSystems, and (iv) a system gets the highest supply thus available to it.
-//
-//    m_supply_starlane_traversals.clear();
-//    m_supply_starlane_obstructed_traversals.clear();
-//    m_fleet_supplyable_system_ids.clear();
-//    m_resource_supply_groups.clear();
-//
-//    // need to get a set of sets of systems that can exchange resources.  some
-//    // sets may be just one system, in which resources can be exchanged between
-//    // UniverseObjects producing or consuming them, but which can't exchange
-//    // with any other systems.
-//
-//    // map from system id to set of systems that are supply-connected to it
-//    // directly (which may involve multiple starlane jumps
-//    std::map<int, std::set<int> > supply_groups_map;
-//
-//
-//    // store supply range in jumps of all unobstructed systems before
-//    // propegation, and add to list of systems to propegate from.
-//    std::map<int, int> propegating_supply_ranges;
-//    std::list<int> propegating_systems_list;
-//    for (std::map<int, int>::const_iterator it = m_supply_system_ranges.begin();
-//         it != m_supply_system_ranges.end(); ++it)
-//    {
-//        if (m_supply_unobstructed_systems.find(it->first) != m_supply_unobstructed_systems.end())
-//            propegating_supply_ranges.insert(*it);
-//
-//        // system can supply itself, so store this fact
-//        supply_groups_map[it->first].insert(it->first);
-//
-//        // add system to list of systems to popegate supply from
-//        propegating_systems_list.push_back(it->first);
-//
-//        // Currently, only supply sources whose meter is above zero provide any fleet supply, and this
-//        // is handled by the propegating_systems_list loop below. If it becomes intended that a supply 
-//        // source with supply meter at zero could still provide fleet supply at its own system, 
-//        // then uncomment the following line
-//        //m_fleet_supplyable_system_ids.insert(it->first);
-//    }
-//
-//
-//    // iterate through list of accessible systems, processing each in order it
-//    // was added (like breadth first search) until no systems are left able to
-//    // further propregate
-//    std::list<int>::iterator sys_list_it = propegating_systems_list.begin();
-//    std::list<int>::iterator sys_list_end = propegating_systems_list.end();
-//    while (sys_list_it != sys_list_end) {
-//        int cur_sys_id = *sys_list_it;
-//        int cur_sys_range = propegating_supply_ranges[cur_sys_id];    // range away from this system that supplies can be transported
-//
-//        // any unobstructed system can share resources within itself
-//        supply_groups_map[cur_sys_id].insert(cur_sys_id);
-//
-//        if (cur_sys_range <= 0) {
-//            // can't propegate supply out a system that has no range
-//            ++sys_list_it;
-//            continue;
-//        }
-//
-//        // any system with nonzero fleet supply range can provide fleet supply
-//        m_fleet_supplyable_system_ids.insert(cur_sys_id);
-//
-//        // can propegate further, if adjacent systems have smaller supply range
-//        // than one less than this system's range
-//        std::map<int, std::set<int> >::const_iterator system_it = starlanes.find(cur_sys_id);
-//        if (system_it == starlanes.end()) {
-//            // no starlanes out of this system
-//            ++sys_list_it;
-//            continue;
-//        }
-//
-//
-//        const std::set<int>& starlane_ends = system_it->second;
-//        for (std::set<int>::const_iterator lane_it = starlane_ends.begin();
-//             lane_it != starlane_ends.end(); ++lane_it)
-//        {
-//            int lane_end_sys_id = *lane_it;
-//
-//            if (m_supply_unobstructed_systems.find(lane_end_sys_id) == m_supply_unobstructed_systems.end()) {
-//                // can't propegate here
-//                m_supply_starlane_obstructed_traversals.insert(std::make_pair(cur_sys_id, lane_end_sys_id));
-//                continue;
-//            }
-//
-//            // can supply fleets here
-//            m_fleet_supplyable_system_ids.insert(lane_end_sys_id);
-//
-//            // compare next system's supply range to this system's supply range.  propegate if necessary.
-//            std::map<int, int>::const_iterator lane_end_sys_it = propegating_supply_ranges.find(lane_end_sys_id);
-//            if (lane_end_sys_it == propegating_supply_ranges.end() || lane_end_sys_it->second <= cur_sys_range) {
-//                // next system has no supply yet, or its range equal to or smaller than this system's
-//
-//                // update next system's range, if propegating from this system would make it larger
-//                if (lane_end_sys_it == propegating_supply_ranges.end() || lane_end_sys_it->second < cur_sys_range - 1) {
-//                    // update with new range
-//                    propegating_supply_ranges[lane_end_sys_id] = cur_sys_range - 1;
-//                    // add next system to list of systems to propegate further
-//                    propegating_systems_list.push_back(lane_end_sys_id);
-//                }
-//
-//                // regardless of whether propegating from current to next system
-//                // increased its range, add the traversed lane to show
-//                // redundancies in supply network to player
-//                m_supply_starlane_traversals.insert(std::make_pair(cur_sys_id, lane_end_sys_id));
-//
-//                // current system can share resources with next system
-//                supply_groups_map[cur_sys_id].insert(lane_end_sys_id);
-//                supply_groups_map[lane_end_sys_id].insert(cur_sys_id);
-//                //DebugLogger() << "added sys(" << lane_end_sys_id << ") to supply_groups_map[ " << cur_sys_id<<"]";
-//                //DebugLogger() << "added sys(" << cur_sys_id << ") to supply_groups_map[ " << lane_end_sys_id <<"]";
-//            }
-//        }
-//        ++sys_list_it;
-//        sys_list_end = propegating_systems_list.end();
-//    }
-//
-//    // Need to merge interconnected supply groups into as few sets of mutually-
-//    // supply-exchanging systems as possible.  This requires finding the
-//    // connected components of an undirected graph, where the node
-//    // adjacency are the directly-connected systems determined above.
-//
-//    // create graph
-//    boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS> graph;
-//
-//    // boost expects vertex labels to range from 0 to num vertices - 1, so need
-//    // to map from system id to graph id and back when accessing vertices
-//    std::vector<int> graph_id_to_sys_id;
-//    graph_id_to_sys_id.reserve(supply_groups_map.size());
-//
-//    std::map<int, int> sys_id_to_graph_id;
-//    int graph_id = 0;
-//    for (std::map<int, std::set<int> >::const_iterator sys_it = supply_groups_map.begin();
-//         sys_it != supply_groups_map.end(); ++sys_it, ++graph_id)
-//    {
-//        int sys_id = sys_it->first;
-//        //TemporaryPtr<const System> sys = GetSystem(sys_id);
-//        //std::string name = sys->Name();
-//        //DebugLogger() << "supply-exchanging system: " << name << " ID (" << sys_id <<")";
-//
-//        boost::add_vertex(graph);   // should add with index = graph_id
-//
-//        graph_id_to_sys_id.push_back(sys_id);
-//        sys_id_to_graph_id[sys_id] = graph_id;
-//    }
-//
-//    // add edges for all direct connections between systems
-//    for (std::map<int, std::set<int> >::const_iterator maps_it = supply_groups_map.begin();
-//         maps_it != supply_groups_map.end(); ++maps_it)
-//    {
-//        int start_graph_id = sys_id_to_graph_id[maps_it->first];
-//        const std::set<int>& set = maps_it->second;
-//        for(std::set<int>::const_iterator set_it = set.begin(); set_it != set.end(); ++set_it) {
-//            int end_graph_id = sys_id_to_graph_id[*set_it];
-//            boost::add_edge(start_graph_id, end_graph_id, graph);
-//
-//            //int sys_id1 = graph_id_to_sys_id[start_graph_id];
-//            //TemporaryPtr<const System> sys1 = GetSystem(sys_id1);
-//            //std::string name1 = sys1->Name();
-//            //int sys_id2 = graph_id_to_sys_id[end_graph_id];
-//            //TemporaryPtr<const System> sys2 = GetSystem(sys_id2);
-//            //std::string name2 = sys2->Name();
-//            //DebugLogger() << "added edge to graph: " << name1 << " and " << name2;
-//        }
-//    }
-//
-//    // declare storage and fill with the component id (group id of connected systems) for each graph vertex
-//    std::vector<int> components(boost::num_vertices(graph));
-//    boost::connected_components(graph, &components[0]);
-//
-//    //for (std::vector<int>::size_type i = 0; i != components.size(); ++i) {
-//    //    int sys_id = graph_id_to_sys_id[i];
-//    //    TemporaryPtr<const System> sys = GetSystem(sys_id);
-//    //    std::string name = sys->Name();
-//    //    DebugLogger() << "system " << name <<" is in component " << components[i];
-//    //}
-//    //std::cout << std::endl;
-//
-//    // convert results back from graph id to system id, and into desired output format
-//    // output: std::set<std::set<int> >& m_resource_supply_groups
-//
-//    // first, sort into a map from component id to set of system ids in component
-//    std::map<int, std::set<int> > component_sets_map;
-//    for (std::size_t graph_id = 0; graph_id != components.size(); ++graph_id) {
-//        int label = components[graph_id];
-//        int sys_id = graph_id_to_sys_id[graph_id];
-//        component_sets_map[label].insert(sys_id);
-//    }
-//
-//    // copy sets in map into set of sets
-//    for (std::map<int, std::set<int> >::const_iterator map_it = component_sets_map.begin(); map_it != component_sets_map.end(); ++map_it) {
-//        m_resource_supply_groups.insert(map_it->second);
-//
-//        //// DEBUG!
-//        //DebugLogger() << "Set: ";
-//        //for (std::set<int>::const_iterator set_it = map_it->second.begin(); set_it != map_it->second.end(); ++set_it) {
-//        //    TemporaryPtr<const UniverseObject> obj = GetUniverse().Object(*set_it);
-//        //    if (!obj) {
-//        //        DebugLogger() << " ... missing object!";
-//        //        continue;
-//        //    }
-//        //    DebugLogger() << " ... " << obj->Name();
-//        //}
-//    }
-//}
-//
+    // which systems can share resources depends on system supply ranges, which
+    // systems have obstructions to supply propegation for reach empire, and
+    // the ranges and obstructions of other empires' supply, as only one empire
+    // can supply each system or popegate along each starlane. one empire's
+    // propegating supply can push back another's, if the pusher's range is
+    // larger.
+
+    // map from empire id to map from system id to set of systems that are
+    // supply-connected to it directly (which may involve multiple starlane jumps
+    std::map<int, std::map<int, float> > empire_system_supply_ranges;
+    // map from empire id to which systems are obstructed for it for supply
+    // propegation
+    std::map<int, std::set<int> > empire_supply_unobstructed_systems;
+
+    for (EmpireManager::const_iterator it = Empires().begin(); it != Empires().end(); ++it) {
+        const Empire* empire = it->second;
+        empire_system_supply_ranges[it->first] = empire->SystemSupplyRanges();
+        empire_supply_unobstructed_systems[it->first] = empire->SupplyUnobstructedSystems();
+    }
+
+    // system connections each empire can see / use for supply propegation
+    std::map<int, std::map<int, std::set<int> > > empire_visible_starlanes;
+    for (EmpireManager::const_iterator it = Empires().begin(); it != Empires().end(); ++it) {
+        const Empire* empire = it->second;
+        empire_visible_starlanes[it->first] = empire->VisibleStarlanes();
+    }
+
+    // store supply range in jumps of all unobstructed systems before
+    // propegation, and add to list of systems to propegate from.
+    std::map<int, std::map<int, float> > empire_propegating_supply_ranges;
+    float max_range = 0.0f;
+    for (std::map<int, std::map<int, float> >::const_iterator empire_it = empire_system_supply_ranges.begin();
+         empire_it != empire_system_supply_ranges.end(); ++empire_it)
+    {
+        int empire_id = empire_it->first;
+        const std::map<int, float>& system_supply_ranges = empire_it->second;
+        const std::set<int>& unobstructed_systems = empire_supply_unobstructed_systems[empire_id];
+
+        for (std::map<int, float>::const_iterator it = system_supply_ranges.begin();
+             it != system_supply_ranges.end(); ++it)
+        {
+            int system_id = it->first;
+            if (unobstructed_systems.find(system_id) != unobstructed_systems.end()) {
+                empire_propegating_supply_ranges[empire_id][system_id] = it->second;
+                if (it->second > max_range)
+                    max_range = it->second;
+            }
+        }
+    }
+
+    // spread supply out from sources by "diffusion" like process, along unobjstructed
+    // starlanes, until the range is exhausted or spreading supply bumps into other
+    // empires' spreading supply. when multiple empires' supply spreads meet up, the
+    // higher-ranged supply takes precendence for a system. if two empires are evenly
+    // matched in a system, then neither supplies (to) it.
+    std::set<int> systems_with_supply_in_them;
+    for (int iteration = 0; iteration <= static_cast<int>(max_range); ++iteration) {
+        // initialize next iteration with current supply distribution
+        std::map<int, std::map<int, float> > empire_propegating_supply_ranges_next = empire_propegating_supply_ranges;
+
+        // for all sources of supply in current map, give adjacent systems one less
+        // supply in the next iteration (unless more is already there)
+        for (std::map<int, std::map<int, float> >::const_iterator prev_empire_it = empire_propegating_supply_ranges.begin();
+             prev_empire_it != empire_propegating_supply_ranges.end(); ++prev_empire_it)
+        {
+            int empire_id = prev_empire_it->first;
+            const std::map<int, float>& prev_sys_ranges = prev_empire_it->second;
+            const std::set<int>& unobstructed_systems = empire_supply_unobstructed_systems[empire_id];
+
+            for (std::map<int, float>::const_iterator prev_sys_it = prev_sys_ranges.begin();
+                 prev_sys_it != prev_sys_ranges.end(); ++prev_sys_it)
+            {
+                // record that each system has some supply in it for later use...
+                systems_with_supply_in_them.insert(prev_sys_it->first);
+
+                // does the source system has enough supply range to propegate outwards at all?
+                float range = prev_sys_it->second;
+                if (range < 1.0f)
+                    continue;   // need at least 1.0 range to propegate further.
+                float range_at_adj_sys = range - 1.0f;  // what to set adjacent systems' ranges to (at least)
+
+                // what starlanes can be used to propegate supply?
+                int system_id = prev_sys_it->first;
+                const std::set<int>& adjacent_systems = empire_visible_starlanes[empire_id][system_id];
+
+                // attempt to propegate to all adjacent systems...
+                for (std::set<int>::const_iterator lane_it = adjacent_systems.begin();
+                     lane_it != adjacent_systems.end(); ++lane_it)
+                {
+                    int lane_end_sys_id = *lane_it;
+                    float adj_sys_rng = empire_propegating_supply_ranges_next[empire_id][lane_end_sys_id];
+
+                    // is the supply at the adjacent system bigger than the source?
+                    if (range_at_adj_sys > adj_sys_rng) {
+                        // is this system obstructed?
+                        if (unobstructed_systems.find(lane_end_sys_id) != unobstructed_systems.end()) {
+                            // propegation obstructed!
+                            m_supply_starlane_obstructed_traversals[empire_id].insert(std::make_pair(system_id, lane_end_sys_id));
+                            continue;
+                        }
+                        // system not obstructed, record updated supply and the traversal
+                        empire_propegating_supply_ranges_next[empire_id][lane_end_sys_id] = range_at_adj_sys;
+                        m_supply_starlane_traversals[empire_id].insert(std::make_pair(system_id, lane_end_sys_id));
+                        // todo later: remove traversals blocked by opposing supply
+                    }
+                }
+            }
+        }
+
+        // save propegated results for next iteration
+        empire_propegating_supply_ranges = empire_propegating_supply_ranges_next;
+    }
+
+    // pass over all empire-supplied systems, removing supply and traversals for all
+    // but the empire with the highest supply range in each system
+    for (std::set<int>::const_iterator sys_it = systems_with_supply_in_them.begin();
+         sys_it != systems_with_supply_in_them.end(); ++sys_it)
+    {
+        int sys_id = *sys_it;
+        std::map<float, std::set<int> > empire_ranges_here;
+
+        // sort empires by range in this system
+        for (std::map<int, std::map<int, float> >::const_iterator empire_it = empire_propegating_supply_ranges.begin();
+             empire_it != empire_propegating_supply_ranges.end(); ++empire_it)
+        {
+            std::map<int, float>::const_iterator empire_supply_it = empire_it->second.find(sys_id);
+            // does this empire have any range in this system? if so, store it
+            if (empire_supply_it != empire_it->second.end()) {
+                empire_ranges_here[empire_supply_it->second].insert(empire_it->first);
+            }
+        }
+
+        // set to zero the range for all empires except the top, or all if there are
+        // multiple empires tied for top range in this system
+        std::map<float, std::set<int> >::reverse_iterator range_empire_it = empire_ranges_here.rbegin();
+        if (range_empire_it == empire_ranges_here.rend())
+            continue;   // nothing to do...
+        int top_range_empire_id = ALL_EMPIRES;
+        if (range_empire_it->second.size() == 1)
+            top_range_empire_id = *(range_empire_it->second.begin());
+        // remove range entries and traversals for all but top empire
+        for (std::map<int, std::map<int, float> >::iterator empire_it = empire_propegating_supply_ranges.begin();
+             empire_it != empire_propegating_supply_ranges.end(); ++empire_it)
+        {
+            int empire_id = empire_it->first;
+            if (empire_id == top_range_empire_id)
+                continue;   // this is the top empire, so leave as the sole empire supplying here
+
+            // remove from range entry...
+            std::map<int, float>& empire_ranges = empire_it->second;
+            empire_ranges.erase(empire_id);
+
+            // remove from traversals anything involving this system for this empire
+            std::set<std::pair<int, int> >& lane_traversals = m_supply_starlane_traversals[empire_id];
+            std::set<std::pair<int, int> > lane_traversals_initial = lane_traversals;
+            for (std::set<std::pair<int, int> >::iterator traversals_it = lane_traversals_initial.begin();
+                 traversals_it != lane_traversals_initial.end(); ++traversals_it)
+            {
+                if (traversals_it->first == sys_id || traversals_it->second == sys_id)
+                    lane_traversals.erase(std::make_pair(traversals_it->first, traversals_it->second));
+            }
+        }
+    }
+
+    // record which systems are fleet supplyable by each empire (after resolving conflicts in each system)
+    for (std::map<int, std::map<int, float> >::const_iterator empire_it = empire_propegating_supply_ranges.begin();
+         empire_it != empire_propegating_supply_ranges.end(); ++empire_it)
+    {
+        int empire_id = empire_it->first;
+        const std::map<int, float>& system_ranges = empire_it->second;
+        for (std::map<int, float>::const_iterator sys_it = system_ranges.begin();
+             sys_it != system_ranges.end(); ++sys_it)
+        {
+            if (sys_it->second < 0.0f)
+                continue;   // negative supply doesn't count... zero does (it just reaches)
+            m_fleet_supplyable_system_ids[empire_id].insert(sys_it->first);
+        }
+    }
+
+    // determine supply-connected groups of systems for each empire.
+    // need to merge interconnected supply groups into as few sets of mutually-
+    // supply-exchanging systems as possible.  This requires finding the
+    // connected components of an undirected graph, where the node
+    // adjacency are the directly-connected systems determined above.
+    for (std::map<int, std::map<int, float> >::const_iterator empire_it = empire_propegating_supply_ranges.begin();
+         empire_it != empire_propegating_supply_ranges.end(); ++empire_it)
+    {
+        int empire_id = empire_it->first;
+
+        // assemble all direct connections between systems from remaining traversals
+        std::map<int, std::set<int> > supply_groups_map;
+        const std::set<std::pair<int, int> >& traversals = m_supply_starlane_traversals[empire_id];
+        for (std::set<std::pair<int, int> >::const_iterator pair_it = traversals.begin();
+             pair_it != traversals.end(); ++pair_it)
+        {
+            supply_groups_map[pair_it->first].insert(pair_it->second);
+            supply_groups_map[pair_it->second].insert(pair_it->first);
+        }
+        if (supply_groups_map.empty())
+            continue;
+
+        // create graph
+        boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS> graph;
+
+        // boost expects vertex labels to range from 0 to num vertices - 1, so need
+        // to map from system id to graph id and back when accessing vertices
+        std::vector<int> graph_id_to_sys_id;
+        graph_id_to_sys_id.reserve(supply_groups_map.size());
+
+        std::map<int, int> sys_id_to_graph_id;
+        int graph_id = 0;
+        for (std::map<int, std::set<int> >::const_iterator sys_it = supply_groups_map.begin();
+             sys_it != supply_groups_map.end(); ++sys_it, ++graph_id)
+        {
+            int sys_id = sys_it->first;
+            boost::add_vertex(graph);   // should add with index = graph_id
+
+            graph_id_to_sys_id.push_back(sys_id);
+            sys_id_to_graph_id[sys_id] = graph_id;
+        }
+
+        // add edges for all direct connections between systems
+        for (std::map<int, std::set<int> >::const_iterator maps_it = supply_groups_map.begin();
+             maps_it != supply_groups_map.end(); ++maps_it)
+        {
+            int start_graph_id = sys_id_to_graph_id[maps_it->first];
+            const std::set<int>& set = maps_it->second;
+            for (std::set<int>::const_iterator set_it = set.begin(); set_it != set.end(); ++set_it) {
+                int end_graph_id = sys_id_to_graph_id[*set_it];
+                boost::add_edge(start_graph_id, end_graph_id, graph);
+            }
+        }
+
+        // declare storage and fill with the component id (group id of connected systems)
+        // for each graph vertex
+        std::vector<int> components(boost::num_vertices(graph));
+        boost::connected_components(graph, &components[0]);
+
+        // convert results back from graph id to system id, and into desired output format
+        // output: std::map<int, std::set<std::set<int> > >& m_resource_supply_groups
+
+        // first, sort into a map from component id to set of system ids in component
+        std::map<int, std::set<int> > component_sets_map;
+        for (std::size_t graph_id = 0; graph_id != components.size(); ++graph_id) {
+            int label = components[graph_id];
+            int sys_id = graph_id_to_sys_id[graph_id];
+            component_sets_map[label].insert(sys_id);
+        }
+
+        // copy sets in map into set of sets
+        for (std::map<int, std::set<int> >::const_iterator map_it = component_sets_map.begin();
+             map_it != component_sets_map.end(); ++map_it)
+        {
+            m_resource_supply_groups[empire_id].insert(map_it->second);
+        }
+    }
+}

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -169,6 +169,26 @@ std::string SupplyManager::Dump(int empire_id) const {
         retval += "\n\n";
     }
 
+    for (std::map<int, std::set<std::set<int> > >::const_iterator empire_it = m_resource_supply_groups.begin();
+         empire_it != m_resource_supply_groups.end(); ++empire_it)
+    {
+        retval += "Supply groups for empire " + boost::lexical_cast<std::string>(empire_it->first) + "\n";
+        for (std::set<std::set<int> >::const_iterator set_set_it = empire_it->second.begin();
+             set_set_it != empire_it->second.end(); ++set_set_it)
+        {
+            retval += "group: ";
+            for (std::set<int>::const_iterator set_it = set_set_it->begin();
+                 set_it != set_set_it->end(); ++set_it)
+            {
+                TemporaryPtr<const System> sys = GetSystem(*set_it);
+                if (!sys)
+                    continue;
+                retval += "\n" + sys->PublicName(empire_id) + " (" + boost::lexical_cast<std::string>(sys->ID()) + ") ";
+            }
+            retval += "\n";
+        }
+        retval += "\n\n";
+    }
     return retval;
 }
 

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -205,10 +205,10 @@ void SupplyManager::Update() {
                         continue;
                     }
                     // propegation can occur, get adjacent system's current range
-                    float adj_sys_existing_range = empire_propegating_supply_ranges_next[empire_id][lane_end_sys_id];
+                    float adj_sys_existing_range = empire_propegating_supply_ranges[empire_id][lane_end_sys_id];
 
-                    // is the supply at the adjacent system bigger than (the source after propegating)
-                    if (range_after_one_more_jump > adj_sys_existing_range) {
+                    // is the supply at the adjacent system equal to or bigger than (the source after propegating)
+                    if (range_after_one_more_jump >= adj_sys_existing_range) {  // allow = to fill in equipotential transversals
                         empire_propegating_supply_ranges_next[empire_id][lane_end_sys_id] = range_after_one_more_jump;
                         m_supply_starlane_traversals[empire_id].insert(std::make_pair(system_id, lane_end_sys_id));
                         // done later: remove traversals blocked by opposing supply

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -276,15 +276,19 @@ void SupplyManager::Update() {
                         m_supply_starlane_obstructed_traversals[empire_id].insert(std::make_pair(system_id, lane_end_sys_id));
                         continue;
                     }
-                    // propegation can occur, get adjacent system's current range
+                    // propegation not obstructed.
+
+                    // add traversal (regardless of whether it is needed to
+                    // increase the adjacent system's range
+                    m_supply_starlane_traversals[empire_id].insert(std::make_pair(system_id, lane_end_sys_id));
+
+                    // get adjacent system's current range
                     float adj_sys_existing_range = empire_propegating_supply_ranges[empire_id][lane_end_sys_id];
 
-                    // is the supply at the adjacent system equal to or bigger than (the source after propegating)
-                    if (range_after_one_more_jump >= adj_sys_existing_range) {  // allow = to fill in equipotential transversals
+                    // if propegating supply would increase the range of the
+                    // adjacent system, do so.
+                    if (range_after_one_more_jump > adj_sys_existing_range)
                         empire_propegating_supply_ranges_next[empire_id][lane_end_sys_id] = range_after_one_more_jump;
-                        m_supply_starlane_traversals[empire_id].insert(std::make_pair(system_id, lane_end_sys_id));
-                        // done later: remove traversals blocked by opposing supply
-                    }
                 }
             }
         }

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -20,21 +20,36 @@ SupplyManager& SupplyManager::operator=(const SupplyManager& rhs) {
     return *this;
 }
 
+namespace {
+    static const std::set<int> EMPTY_INT_SET;
+    static const std::set<std::set<int> > EMPTY_INT_SET_SET;
+    static const std::set<std::pair<int, int> > EMPTY_INT_PAIR_SET;
+}
+
 const std::map<int, std::set<std::pair<int, int> > >& SupplyManager::SupplyStarlaneTraversals() const
 { return m_supply_starlane_traversals; }
+
+const std::set<std::pair<int, int> >& SupplyManager::SupplyStarlaneTraversals(int empire_id) const {
+    std::map<int, std::set<std::pair<int, int> > >::const_iterator it = m_supply_starlane_traversals.find(empire_id);
+    if (it != m_supply_starlane_traversals.end())
+        return it->second;
+    return EMPTY_INT_PAIR_SET;
+}
 
 const std::map<int, std::set<std::pair<int, int> > >& SupplyManager::SupplyObstructedStarlaneTraversals() const
 { return m_supply_starlane_obstructed_traversals; }
 
+const std::set<std::pair<int, int> >& SupplyManager::SupplyObstructedStarlaneTraversals(int empire_id) const {
+    std::map<int, std::set<std::pair<int, int> > >::const_iterator it = m_supply_starlane_obstructed_traversals.find(empire_id);
+    if (it != m_supply_starlane_obstructed_traversals.end())
+        return it->second;
+    return EMPTY_INT_PAIR_SET;
+}
+
 const std::map<int, std::set<int> >& SupplyManager::FleetSupplyableSystemIDs() const
 { return m_fleet_supplyable_system_ids; }
 
-namespace {
-    static const std::set<int> EMPTY_INT_SET;
-    static const std::set<std::set<int> > EMPTY_INT_SET_SET;
-}
-
-const std::set<int>& SupplyManager::FleetSupplyableSystemID(int empire_id) {
+const std::set<int>& SupplyManager::FleetSupplyableSystemIDs(int empire_id) {
     std::map<int, std::set<int> >::const_iterator it = m_fleet_supplyable_system_ids.find(empire_id);
     if (it != m_fleet_supplyable_system_ids.end())
         return it->second;

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -232,7 +232,7 @@ void SupplyManager::Update() {
         for (std::set<int>::const_iterator sys_it = empire_supply_unobstructed_systems[it->first].begin();
              sys_it != empire_supply_unobstructed_systems[it->first].end(); ++sys_it)
         { ss << *sys_it << ", "; }
-        DebugLogger() << "Empire " << empire->EmpireID() << " unobstructed systems: " << ss.str();
+        //DebugLogger() << "Empire " << empire->EmpireID() << " unobstructed systems: " << ss.str();
     }
 
     // system connections each empire can see / use for supply propegation
@@ -273,7 +273,7 @@ void SupplyManager::Update() {
     for (float range_to_spread = max_range; range_to_spread >= 0;
          range_to_spread -= 1.0f)
     {
-        DebugLogger() << "!!!! Reduced spreading range to " << range_to_spread;
+        //DebugLogger() << "!!!! Reduced spreading range to " << range_to_spread;
 
         // update systems that have supply in them
         for (std::map<int, std::map<int, float> >::const_iterator empire_it = empire_propegating_supply_ranges.begin();
@@ -366,7 +366,7 @@ void SupplyManager::Update() {
             int top_range_empire_id = ALL_EMPIRES;
             if (range_empire_it->second.size() == 1)
                 top_range_empire_id = *(range_empire_it->second.begin());
-            DebugLogger() << "top ranged empire here: " << top_range_empire_id;
+            //DebugLogger() << "top ranged empire here: " << top_range_empire_id;
 
             // remove range entries and traversals for all but the top empire
             // (or all empires if there is no single top empire)
@@ -381,9 +381,7 @@ void SupplyManager::Update() {
                 std::map<int, float>& empire_ranges = empire_it->second;
                 empire_ranges.erase(sys_id);
 
-                //// DEBUG
-                DebugLogger() << "... removed empire " << empire_id << " system " << sys_id << " supply.";
-                //// DEBUG
+                //DebugLogger() << "... removed empire " << empire_id << " system " << sys_id << " supply.";
 
                 std::set<std::pair<int, int> >& lane_traversals = m_supply_starlane_traversals[empire_id];
                 std::set<std::pair<int, int> > lane_traversals_initial = lane_traversals;
@@ -441,7 +439,7 @@ void SupplyManager::Update() {
              prev_empire_it != empire_propegating_supply_ranges.end(); ++prev_empire_it)
         {
             int empire_id = prev_empire_it->first;
-            DebugLogger() << ">-< Doing supply propegation for empire " << empire_id << " >-<";
+            //DebugLogger() << ">-< Doing supply propegation for empire " << empire_id << " >-<";
             const std::map<int, float>& prev_sys_ranges = prev_empire_it->second;
             const std::set<int>& unobstructed_systems = empire_supply_unobstructed_systems[empire_id];
 
@@ -458,7 +456,7 @@ void SupplyManager::Update() {
                 int system_id = prev_sys_it->first;
                 const std::set<int>& adjacent_systems = empire_visible_starlanes[empire_id][system_id];
 
-                DebugLogger() << "propegating from system " << system_id << " which has range: " << range;
+                //DebugLogger() << "propegating from system " << system_id << " which has range: " << range;
 
                 // attempt to propegate to all adjacent systems...
                 for (std::set<int>::const_iterator lane_it = adjacent_systems.begin();
@@ -468,7 +466,7 @@ void SupplyManager::Update() {
                     // is propegation to the adjacent system obstructed?
                     if (unobstructed_systems.find(lane_end_sys_id) == unobstructed_systems.end()) {
                         // propegation obstructed!
-                        DebugLogger() << "Added obstructed traversal from " << system_id << " to " << lane_end_sys_id << " due to not being on unobstructed systems";
+                        //DebugLogger() << "Added obstructed traversal from " << system_id << " to " << lane_end_sys_id << " due to not being on unobstructed systems";
                         m_supply_starlane_obstructed_traversals[empire_id].insert(std::make_pair(system_id, lane_end_sys_id));
                         continue;
                     }
@@ -494,7 +492,7 @@ void SupplyManager::Update() {
                     // if so, add a blocked traversal and continue
                     if (range_after_one_more_jump <= other_empire_biggest_range) {
                         m_supply_starlane_obstructed_traversals[empire_id].insert(std::make_pair(system_id, lane_end_sys_id));
-                        DebugLogger() << "Added obstructed traversal from " << system_id << " to " << lane_end_sys_id << " due to other empire biggest range being " << other_empire_biggest_range;
+                        //DebugLogger() << "Added obstructed traversal from " << system_id << " to " << lane_end_sys_id << " due to other empire biggest range being " << other_empire_biggest_range;
                         continue;
                     }
 
@@ -504,23 +502,23 @@ void SupplyManager::Update() {
                     std::map<int, float>::const_iterator prev_range_it = prev_sys_ranges.find(lane_end_sys_id);
                     if (prev_range_it == prev_sys_ranges.end() || range_after_one_more_jump > prev_range_it->second) {
                         empire_propegating_supply_ranges_next[empire_id][lane_end_sys_id] = range_after_one_more_jump;
-                        DebugLogger() << "Set system " << lane_end_sys_id << " range to: " << range_after_one_more_jump;
+                        //DebugLogger() << "Set system " << lane_end_sys_id << " range to: " << range_after_one_more_jump;
                     }
                     // always record a traversal, so connectivity is calculated properly
                     m_supply_starlane_traversals[empire_id].insert(std::make_pair(system_id, lane_end_sys_id));
-                    DebugLogger() << "Added traversal from " << system_id << " to " << lane_end_sys_id;
+                    //DebugLogger() << "Added traversal from " << system_id << " to " << lane_end_sys_id;
 
                     // erase any previous obstructed traversal that just succeeded
                     if (m_supply_starlane_obstructed_traversals[empire_id].find(std::make_pair(system_id, lane_end_sys_id)) !=
                         m_supply_starlane_obstructed_traversals[empire_id].end())
                     {
-                        DebugLogger() << "Removed obstructed traversal from " << system_id << " to " << lane_end_sys_id;
+                        //DebugLogger() << "Removed obstructed traversal from " << system_id << " to " << lane_end_sys_id;
                         m_supply_starlane_obstructed_traversals[empire_id].erase(std::make_pair(system_id, lane_end_sys_id));
                     }
                     if (m_supply_starlane_obstructed_traversals[empire_id].find(std::make_pair(lane_end_sys_id, system_id)) !=
                         m_supply_starlane_obstructed_traversals[empire_id].end())
                     {
-                        DebugLogger() << "Removed obstructed traversal from " << lane_end_sys_id << " to " << system_id;
+                        //DebugLogger() << "Removed obstructed traversal from " << lane_end_sys_id << " to " << system_id;
                         m_supply_starlane_obstructed_traversals[empire_id].erase(std::make_pair(lane_end_sys_id, system_id));
                     }
                 }

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -1,0 +1,238 @@
+#include "Supply.h"
+
+#include "EmpireManager.h"
+
+#include <boost/graph/connected_components.hpp>
+//
+//void Supply::UpdateSupply()
+//{ UpdateSupply(this->KnownStarlanes()); }
+//
+//void Supply::UpdateSupply(const std::map<int, std::set<int> >& starlanes) {
+//    //std::cout << "Supply::UpdateSupply for empire " << this->Name() << std::endl;
+//
+//    // Please also update PythonEmpireWrapper.cpp:CalculateSupplyUpdate if there is a change to the supply propagation rules: 
+//    // (i) there is a set of supply sources in systems, (ii) propagating supply drops one per starlane jump, (iii) propagation is blocked
+//    // into and out of any systems not in SupplyUnobstructedSystems, and (iv) a system gets the highest supply thus available to it.
+//
+//    m_supply_starlane_traversals.clear();
+//    m_supply_starlane_obstructed_traversals.clear();
+//    m_fleet_supplyable_system_ids.clear();
+//    m_resource_supply_groups.clear();
+//
+//    // need to get a set of sets of systems that can exchange resources.  some
+//    // sets may be just one system, in which resources can be exchanged between
+//    // UniverseObjects producing or consuming them, but which can't exchange
+//    // with any other systems.
+//
+//    // map from system id to set of systems that are supply-connected to it
+//    // directly (which may involve multiple starlane jumps
+//    std::map<int, std::set<int> > supply_groups_map;
+//
+//
+//    // store supply range in jumps of all unobstructed systems before
+//    // propegation, and add to list of systems to propegate from.
+//    std::map<int, int> propegating_supply_ranges;
+//    std::list<int> propegating_systems_list;
+//    for (std::map<int, int>::const_iterator it = m_supply_system_ranges.begin();
+//         it != m_supply_system_ranges.end(); ++it)
+//    {
+//        if (m_supply_unobstructed_systems.find(it->first) != m_supply_unobstructed_systems.end())
+//            propegating_supply_ranges.insert(*it);
+//
+//        // system can supply itself, so store this fact
+//        supply_groups_map[it->first].insert(it->first);
+//
+//        // add system to list of systems to popegate supply from
+//        propegating_systems_list.push_back(it->first);
+//
+//        // Currently, only supply sources whose meter is above zero provide any fleet supply, and this
+//        // is handled by the propegating_systems_list loop below. If it becomes intended that a supply 
+//        // source with supply meter at zero could still provide fleet supply at its own system, 
+//        // then uncomment the following line
+//        //m_fleet_supplyable_system_ids.insert(it->first);
+//    }
+//
+//
+//    // iterate through list of accessible systems, processing each in order it
+//    // was added (like breadth first search) until no systems are left able to
+//    // further propregate
+//    std::list<int>::iterator sys_list_it = propegating_systems_list.begin();
+//    std::list<int>::iterator sys_list_end = propegating_systems_list.end();
+//    while (sys_list_it != sys_list_end) {
+//        int cur_sys_id = *sys_list_it;
+//        int cur_sys_range = propegating_supply_ranges[cur_sys_id];    // range away from this system that supplies can be transported
+//
+//        // any unobstructed system can share resources within itself
+//        supply_groups_map[cur_sys_id].insert(cur_sys_id);
+//
+//        if (cur_sys_range <= 0) {
+//            // can't propegate supply out a system that has no range
+//            ++sys_list_it;
+//            continue;
+//        }
+//
+//        // any system with nonzero fleet supply range can provide fleet supply
+//        m_fleet_supplyable_system_ids.insert(cur_sys_id);
+//
+//        // can propegate further, if adjacent systems have smaller supply range
+//        // than one less than this system's range
+//        std::map<int, std::set<int> >::const_iterator system_it = starlanes.find(cur_sys_id);
+//        if (system_it == starlanes.end()) {
+//            // no starlanes out of this system
+//            ++sys_list_it;
+//            continue;
+//        }
+//
+//
+//        const std::set<int>& starlane_ends = system_it->second;
+//        for (std::set<int>::const_iterator lane_it = starlane_ends.begin();
+//             lane_it != starlane_ends.end(); ++lane_it)
+//        {
+//            int lane_end_sys_id = *lane_it;
+//
+//            if (m_supply_unobstructed_systems.find(lane_end_sys_id) == m_supply_unobstructed_systems.end()) {
+//                // can't propegate here
+//                m_supply_starlane_obstructed_traversals.insert(std::make_pair(cur_sys_id, lane_end_sys_id));
+//                continue;
+//            }
+//
+//            // can supply fleets here
+//            m_fleet_supplyable_system_ids.insert(lane_end_sys_id);
+//
+//            // compare next system's supply range to this system's supply range.  propegate if necessary.
+//            std::map<int, int>::const_iterator lane_end_sys_it = propegating_supply_ranges.find(lane_end_sys_id);
+//            if (lane_end_sys_it == propegating_supply_ranges.end() || lane_end_sys_it->second <= cur_sys_range) {
+//                // next system has no supply yet, or its range equal to or smaller than this system's
+//
+//                // update next system's range, if propegating from this system would make it larger
+//                if (lane_end_sys_it == propegating_supply_ranges.end() || lane_end_sys_it->second < cur_sys_range - 1) {
+//                    // update with new range
+//                    propegating_supply_ranges[lane_end_sys_id] = cur_sys_range - 1;
+//                    // add next system to list of systems to propegate further
+//                    propegating_systems_list.push_back(lane_end_sys_id);
+//                }
+//
+//                // regardless of whether propegating from current to next system
+//                // increased its range, add the traversed lane to show
+//                // redundancies in supply network to player
+//                m_supply_starlane_traversals.insert(std::make_pair(cur_sys_id, lane_end_sys_id));
+//
+//                // current system can share resources with next system
+//                supply_groups_map[cur_sys_id].insert(lane_end_sys_id);
+//                supply_groups_map[lane_end_sys_id].insert(cur_sys_id);
+//                //DebugLogger() << "added sys(" << lane_end_sys_id << ") to supply_groups_map[ " << cur_sys_id<<"]";
+//                //DebugLogger() << "added sys(" << cur_sys_id << ") to supply_groups_map[ " << lane_end_sys_id <<"]";
+//            }
+//        }
+//        ++sys_list_it;
+//        sys_list_end = propegating_systems_list.end();
+//    }
+//
+//    // Need to merge interconnected supply groups into as few sets of mutually-
+//    // supply-exchanging systems as possible.  This requires finding the
+//    // connected components of an undirected graph, where the node
+//    // adjacency are the directly-connected systems determined above.
+//
+//    // create graph
+//    boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS> graph;
+//
+//    // boost expects vertex labels to range from 0 to num vertices - 1, so need
+//    // to map from system id to graph id and back when accessing vertices
+//    std::vector<int> graph_id_to_sys_id;
+//    graph_id_to_sys_id.reserve(supply_groups_map.size());
+//
+//    std::map<int, int> sys_id_to_graph_id;
+//    int graph_id = 0;
+//    for (std::map<int, std::set<int> >::const_iterator sys_it = supply_groups_map.begin();
+//         sys_it != supply_groups_map.end(); ++sys_it, ++graph_id)
+//    {
+//        int sys_id = sys_it->first;
+//        //TemporaryPtr<const System> sys = GetSystem(sys_id);
+//        //std::string name = sys->Name();
+//        //DebugLogger() << "supply-exchanging system: " << name << " ID (" << sys_id <<")";
+//
+//        boost::add_vertex(graph);   // should add with index = graph_id
+//
+//        graph_id_to_sys_id.push_back(sys_id);
+//        sys_id_to_graph_id[sys_id] = graph_id;
+//    }
+//
+//    // add edges for all direct connections between systems
+//    for (std::map<int, std::set<int> >::const_iterator maps_it = supply_groups_map.begin();
+//         maps_it != supply_groups_map.end(); ++maps_it)
+//    {
+//        int start_graph_id = sys_id_to_graph_id[maps_it->first];
+//        const std::set<int>& set = maps_it->second;
+//        for(std::set<int>::const_iterator set_it = set.begin(); set_it != set.end(); ++set_it) {
+//            int end_graph_id = sys_id_to_graph_id[*set_it];
+//            boost::add_edge(start_graph_id, end_graph_id, graph);
+//
+//            //int sys_id1 = graph_id_to_sys_id[start_graph_id];
+//            //TemporaryPtr<const System> sys1 = GetSystem(sys_id1);
+//            //std::string name1 = sys1->Name();
+//            //int sys_id2 = graph_id_to_sys_id[end_graph_id];
+//            //TemporaryPtr<const System> sys2 = GetSystem(sys_id2);
+//            //std::string name2 = sys2->Name();
+//            //DebugLogger() << "added edge to graph: " << name1 << " and " << name2;
+//        }
+//    }
+//
+//    // declare storage and fill with the component id (group id of connected systems) for each graph vertex
+//    std::vector<int> components(boost::num_vertices(graph));
+//    boost::connected_components(graph, &components[0]);
+//
+//    //for (std::vector<int>::size_type i = 0; i != components.size(); ++i) {
+//    //    int sys_id = graph_id_to_sys_id[i];
+//    //    TemporaryPtr<const System> sys = GetSystem(sys_id);
+//    //    std::string name = sys->Name();
+//    //    DebugLogger() << "system " << name <<" is in component " << components[i];
+//    //}
+//    //std::cout << std::endl;
+//
+//    // convert results back from graph id to system id, and into desired output format
+//    // output: std::set<std::set<int> >& m_resource_supply_groups
+//
+//    // first, sort into a map from component id to set of system ids in component
+//    std::map<int, std::set<int> > component_sets_map;
+//    for (std::size_t graph_id = 0; graph_id != components.size(); ++graph_id) {
+//        int label = components[graph_id];
+//        int sys_id = graph_id_to_sys_id[graph_id];
+//        component_sets_map[label].insert(sys_id);
+//    }
+//
+//    // copy sets in map into set of sets
+//    for (std::map<int, std::set<int> >::const_iterator map_it = component_sets_map.begin(); map_it != component_sets_map.end(); ++map_it) {
+//        m_resource_supply_groups.insert(map_it->second);
+//
+//        //// DEBUG!
+//        //DebugLogger() << "Set: ";
+//        //for (std::set<int>::const_iterator set_it = map_it->second.begin(); set_it != map_it->second.end(); ++set_it) {
+//        //    TemporaryPtr<const UniverseObject> obj = GetUniverse().Object(*set_it);
+//        //    if (!obj) {
+//        //        DebugLogger() << " ... missing object!";
+//        //        continue;
+//        //    }
+//        //    DebugLogger() << " ... " << obj->Name();
+//        //}
+//    }
+//}
+//
+//const std::set<std::pair<int, int> >& Supply::SupplyStarlaneTraversals() const
+//{ return m_supply_starlane_traversals; }
+//
+//const std::set<std::pair<int, int> >& Supply::SupplyObstructedStarlaneTraversals() const
+//{ return m_supply_starlane_obstructed_traversals; }
+//
+//const std::set<int>& Supply::FleetSupplyableSystemIDs() const
+//{ return m_fleet_supplyable_system_ids; }
+//
+//bool Supply::SystemHasFleetSupply(int system_id) const {
+//    if (system_id == INVALID_OBJECT_ID)
+//        return false;
+//    if (m_fleet_supplyable_system_ids.find(system_id) != m_fleet_supplyable_system_ids.end())
+//        return true;
+//    return false;
+//}
+//
+//const std::set<std::set<int> >& Supply::ResourceSupplyGroups() const
+//{ return m_resource_supply_groups; }

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -31,6 +31,7 @@ const std::map<int, std::set<int> >& SupplyManager::FleetSupplyableSystemIDs() c
 
 namespace {
     static const std::set<int> EMPTY_INT_SET;
+    static const std::set<std::set<int> > EMPTY_INT_SET_SET;
 }
 
 const std::set<int>& SupplyManager::FleetSupplyableSystemID(int empire_id) {
@@ -42,6 +43,13 @@ const std::set<int>& SupplyManager::FleetSupplyableSystemID(int empire_id) {
 
 const std::map<int, std::set<std::set<int> > >& SupplyManager::ResourceSupplyGroups() const
 { return m_resource_supply_groups; }
+
+const std::set<std::set<int> >& SupplyManager::ResourceSupplyGroups(int empire_id) const {
+    std::map<int, std::set<std::set<int> > >::const_iterator it = m_resource_supply_groups.find(empire_id);
+    if (it != m_resource_supply_groups.end())
+        return it->second;
+    return EMPTY_INT_SET_SET;
+}
 
 bool SupplyManager::SystemHasFleetSupply(int system_id, int empire_id) const {
     if (system_id == INVALID_OBJECT_ID)

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -101,94 +101,100 @@ bool SupplyManager::SystemHasFleetSupply(int system_id, int empire_id) const {
 
 std::string SupplyManager::Dump(int empire_id) const {
     std::string retval;
-    for (std::map<int, std::set<int> >::const_iterator empire_it = m_fleet_supplyable_system_ids.begin();
-         empire_it != m_fleet_supplyable_system_ids.end(); ++empire_it)
-    {
-        if (empire_id != ALL_EMPIRES && empire_it->first != empire_id)
-            continue;
-        retval += "Supplyable systems for empire " + boost::lexical_cast<std::string>(empire_it->first) + "\n";
-        for (std::set<int>::const_iterator set_it = empire_it->second.begin();
-             set_it != empire_it->second.end(); ++set_it)
+
+    try {
+        for (std::map<int, std::set<int> >::const_iterator empire_it = m_fleet_supplyable_system_ids.begin();
+             empire_it != m_fleet_supplyable_system_ids.end(); ++empire_it)
         {
-            TemporaryPtr<const System> sys = GetSystem(*set_it);
-            if (!sys)
+            if (empire_id != ALL_EMPIRES && empire_it->first != empire_id)
                 continue;
-            retval += "\n" + sys->PublicName(empire_id) + " (" + boost::lexical_cast<std::string>(sys->ID()) + ") ";
-
-            retval += "\nTraversals from here to: ";
-            const std::set<std::pair<int, int> >& traversals = m_supply_starlane_traversals.at(empire_it->first);
-            for (std::set<std::pair<int, int> >::const_iterator trav_it = traversals.begin();
-                 trav_it != traversals.end(); ++trav_it)
-            {
-                if (trav_it->first == sys->ID()) {
-                    TemporaryPtr<const UniverseObject> obj = GetUniverseObject(trav_it->second);
-                    if (obj)
-                        retval += obj->PublicName(empire_id) + " (" + boost::lexical_cast<std::string>(obj->ID()) + ")  ";
-                }
-            }
-            retval += "\n";
-
-            retval += "Traversals to here from: ";
-            for (std::set<std::pair<int, int> >::const_iterator trav_it = traversals.begin();
-                 trav_it != traversals.end(); ++trav_it)
-            {
-                if (trav_it->second == sys->ID()) {
-                    TemporaryPtr<const UniverseObject> obj = GetUniverseObject(trav_it->first);
-                    if (obj)
-                        retval += obj->PublicName(empire_id) + " (" + boost::lexical_cast<std::string>(obj->ID()) + ")  ";
-                }
-            }
-            retval += "\n";
-
-            retval += "Blocked Traversals from here to: ";
-            const std::set<std::pair<int, int> >& otraversals = m_supply_starlane_obstructed_traversals.at(empire_it->first);
-            for (std::set<std::pair<int, int> >::const_iterator trav_it = otraversals.begin();
-                 trav_it != otraversals.end(); ++trav_it)
-            {
-                if (trav_it->first == sys->ID()) {
-                    TemporaryPtr<const UniverseObject> obj = GetUniverseObject(trav_it->second);
-                    if (obj)
-                        retval += obj->PublicName(empire_id) + " (" + boost::lexical_cast<std::string>(obj->ID()) + ")  ";
-                }
-            }
-            retval += "\n";
-
-            retval += "Blocked Traversals to here from: ";
-            for (std::set<std::pair<int, int> >::const_iterator trav_it = otraversals.begin();
-                 trav_it != otraversals.end(); ++trav_it)
-            {
-                if (trav_it->second == sys->ID()) {
-                    TemporaryPtr<const UniverseObject> obj = GetUniverseObject(trav_it->first);
-                    if (obj)
-                        retval += obj->PublicName(empire_id) + " (" + boost::lexical_cast<std::string>(obj->ID()) + ")  ";
-                }
-            }
-            retval += "\n";
-
-        }
-        retval += "\n\n";
-    }
-
-    for (std::map<int, std::set<std::set<int> > >::const_iterator empire_it = m_resource_supply_groups.begin();
-         empire_it != m_resource_supply_groups.end(); ++empire_it)
-    {
-        retval += "Supply groups for empire " + boost::lexical_cast<std::string>(empire_it->first) + "\n";
-        for (std::set<std::set<int> >::const_iterator set_set_it = empire_it->second.begin();
-             set_set_it != empire_it->second.end(); ++set_set_it)
-        {
-            retval += "group: ";
-            for (std::set<int>::const_iterator set_it = set_set_it->begin();
-                 set_it != set_set_it->end(); ++set_it)
+            retval += "Supplyable systems for empire " + boost::lexical_cast<std::string>(empire_it->first) + "\n";
+            for (std::set<int>::const_iterator set_it = empire_it->second.begin();
+                 set_it != empire_it->second.end(); ++set_it)
             {
                 TemporaryPtr<const System> sys = GetSystem(*set_it);
                 if (!sys)
                     continue;
                 retval += "\n" + sys->PublicName(empire_id) + " (" + boost::lexical_cast<std::string>(sys->ID()) + ") ";
+
+                retval += "\nTraversals from here to: ";
+                const std::set<std::pair<int, int> >& traversals = m_supply_starlane_traversals.at(empire_it->first);
+                for (std::set<std::pair<int, int> >::const_iterator trav_it = traversals.begin();
+                     trav_it != traversals.end(); ++trav_it)
+                {
+                    if (trav_it->first == sys->ID()) {
+                        TemporaryPtr<const UniverseObject> obj = GetUniverseObject(trav_it->second);
+                        if (obj)
+                            retval += obj->PublicName(empire_id) + " (" + boost::lexical_cast<std::string>(obj->ID()) + ")  ";
+                    }
+                }
+                retval += "\n";
+
+                retval += "Traversals to here from: ";
+                for (std::set<std::pair<int, int> >::const_iterator trav_it = traversals.begin();
+                     trav_it != traversals.end(); ++trav_it)
+                {
+                    if (trav_it->second == sys->ID()) {
+                        TemporaryPtr<const UniverseObject> obj = GetUniverseObject(trav_it->first);
+                        if (obj)
+                            retval += obj->PublicName(empire_id) + " (" + boost::lexical_cast<std::string>(obj->ID()) + ")  ";
+                    }
+                }
+                retval += "\n";
+
+                retval += "Blocked Traversals from here to: ";
+                const std::set<std::pair<int, int> >& otraversals = m_supply_starlane_obstructed_traversals.at(empire_it->first);
+                for (std::set<std::pair<int, int> >::const_iterator trav_it = otraversals.begin();
+                     trav_it != otraversals.end(); ++trav_it)
+                {
+                    if (trav_it->first == sys->ID()) {
+                        TemporaryPtr<const UniverseObject> obj = GetUniverseObject(trav_it->second);
+                        if (obj)
+                            retval += obj->PublicName(empire_id) + " (" + boost::lexical_cast<std::string>(obj->ID()) + ")  ";
+                    }
+                }
+                retval += "\n";
+
+                retval += "Blocked Traversals to here from: ";
+                for (std::set<std::pair<int, int> >::const_iterator trav_it = otraversals.begin();
+                     trav_it != otraversals.end(); ++trav_it)
+                {
+                    if (trav_it->second == sys->ID()) {
+                        TemporaryPtr<const UniverseObject> obj = GetUniverseObject(trav_it->first);
+                        if (obj)
+                            retval += obj->PublicName(empire_id) + " (" + boost::lexical_cast<std::string>(obj->ID()) + ")  ";
+                    }
+                }
+                retval += "\n";
+
             }
-            retval += "\n";
+            retval += "\n\n";
         }
-        retval += "\n\n";
+
+        for (std::map<int, std::set<std::set<int> > >::const_iterator empire_it = m_resource_supply_groups.begin();
+             empire_it != m_resource_supply_groups.end(); ++empire_it)
+        {
+            retval += "Supply groups for empire " + boost::lexical_cast<std::string>(empire_it->first) + "\n";
+            for (std::set<std::set<int> >::const_iterator set_set_it = empire_it->second.begin();
+                 set_set_it != empire_it->second.end(); ++set_set_it)
+            {
+                retval += "group: ";
+                for (std::set<int>::const_iterator set_it = set_set_it->begin();
+                     set_it != set_set_it->end(); ++set_it)
+                {
+                    TemporaryPtr<const System> sys = GetSystem(*set_it);
+                    if (!sys)
+                        continue;
+                    retval += "\n" + sys->PublicName(empire_id) + " (" + boost::lexical_cast<std::string>(sys->ID()) + ") ";
+                }
+                retval += "\n";
+            }
+            retval += "\n\n";
+        }
+    } catch (const std::exception& e) {
+        ErrorLogger() << "SupplyManager::Dump caught exception: " << e.what();
     }
+
     return retval;
 }
 

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -11,6 +11,7 @@
 #include <boost/graph/connected_components.hpp>
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/connected_components.hpp>
+#include <boost/lexical_cast.hpp>
 
 SupplyManager::SupplyManager() :
     m_supply_starlane_traversals(),
@@ -95,6 +96,79 @@ bool SupplyManager::SystemHasFleetSupply(int system_id, int empire_id) const {
     if (sys_set.find(system_id) != sys_set.end())
         return true;
     return false;
+}
+
+std::string SupplyManager::Dump(int empire_id) const {
+    std::string retval;
+    for (std::map<int, std::set<int> >::const_iterator empire_it = m_fleet_supplyable_system_ids.begin();
+         empire_it != m_fleet_supplyable_system_ids.end(); ++empire_it)
+    {
+        if (empire_id != ALL_EMPIRES && empire_it->first != empire_id)
+            continue;
+        retval += "Supplyable systems for empire " + boost::lexical_cast<std::string>(empire_it->first) + "\n";
+        for (std::set<int>::const_iterator set_it = empire_it->second.begin();
+             set_it != empire_it->second.end(); ++set_it)
+        {
+            TemporaryPtr<const System> sys = GetSystem(*set_it);
+            if (!sys)
+                continue;
+            retval += "\n" + sys->PublicName(empire_id) + " (" + boost::lexical_cast<std::string>(sys->ID()) + ") ";
+
+            retval += "\nTraversals from here to: ";
+            const std::set<std::pair<int, int> >& traversals = m_supply_starlane_traversals.at(empire_it->first);
+            for (std::set<std::pair<int, int> >::const_iterator trav_it = traversals.begin();
+                 trav_it != traversals.end(); ++trav_it)
+            {
+                if (trav_it->first == sys->ID()) {
+                    TemporaryPtr<const UniverseObject> obj = GetUniverseObject(trav_it->second);
+                    if (obj)
+                        retval += obj->PublicName(empire_id) + " (" + boost::lexical_cast<std::string>(obj->ID()) + ")  ";
+                }
+            }
+            retval += "\n";
+
+            retval += "Traversals to here from: ";
+            for (std::set<std::pair<int, int> >::const_iterator trav_it = traversals.begin();
+                 trav_it != traversals.end(); ++trav_it)
+            {
+                if (trav_it->second == sys->ID()) {
+                    TemporaryPtr<const UniverseObject> obj = GetUniverseObject(trav_it->first);
+                    if (obj)
+                        retval += obj->PublicName(empire_id) + " (" + boost::lexical_cast<std::string>(obj->ID()) + ")  ";
+                }
+            }
+            retval += "\n";
+
+            retval += "Blocked Traversals from here to: ";
+            const std::set<std::pair<int, int> >& otraversals = m_supply_starlane_obstructed_traversals.at(empire_it->first);
+            for (std::set<std::pair<int, int> >::const_iterator trav_it = otraversals.begin();
+                 trav_it != otraversals.end(); ++trav_it)
+            {
+                if (trav_it->first == sys->ID()) {
+                    TemporaryPtr<const UniverseObject> obj = GetUniverseObject(trav_it->second);
+                    if (obj)
+                        retval += obj->PublicName(empire_id) + " (" + boost::lexical_cast<std::string>(obj->ID()) + ")  ";
+                }
+            }
+            retval += "\n";
+
+            retval += "Blocked Traversals to here from: ";
+            for (std::set<std::pair<int, int> >::const_iterator trav_it = otraversals.begin();
+                 trav_it != otraversals.end(); ++trav_it)
+            {
+                if (trav_it->second == sys->ID()) {
+                    TemporaryPtr<const UniverseObject> obj = GetUniverseObject(trav_it->first);
+                    if (obj)
+                        retval += obj->PublicName(empire_id) + " (" + boost::lexical_cast<std::string>(obj->ID()) + ")  ";
+                }
+            }
+            retval += "\n";
+
+        }
+        retval += "\n\n";
+    }
+
+    return retval;
 }
 
 void SupplyManager::Update() {

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -29,6 +29,17 @@ const std::map<int, std::set<std::pair<int, int> > >& SupplyManager::SupplyObstr
 const std::map<int, std::set<int> >& SupplyManager::FleetSupplyableSystemIDs() const
 { return m_fleet_supplyable_system_ids; }
 
+namespace {
+    static const std::set<int> EMPTY_INT_SET;
+}
+
+const std::set<int>& SupplyManager::FleetSupplyableSystemID(int empire_id) {
+    std::map<int, std::set<int> >::const_iterator it = m_fleet_supplyable_system_ids.find(empire_id);
+    if (it != m_fleet_supplyable_system_ids.end())
+        return it->second;
+    return EMPTY_INT_SET;
+}
+
 const std::map<int, std::set<std::set<int> > >& SupplyManager::ResourceSupplyGroups() const
 { return m_resource_supply_groups; }
 

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -56,11 +56,21 @@ const std::set<std::pair<int, int> >& SupplyManager::SupplyObstructedStarlaneTra
 const std::map<int, std::set<int> >& SupplyManager::FleetSupplyableSystemIDs() const
 { return m_fleet_supplyable_system_ids; }
 
-const std::set<int>& SupplyManager::FleetSupplyableSystemIDs(int empire_id) {
+const std::set<int>& SupplyManager::FleetSupplyableSystemIDs(int empire_id) const {
     std::map<int, std::set<int> >::const_iterator it = m_fleet_supplyable_system_ids.find(empire_id);
     if (it != m_fleet_supplyable_system_ids.end())
         return it->second;
     return EMPTY_INT_SET;
+}
+
+int SupplyManager::EmpireThatCanSupplyAt(int system_id) const {
+    for (std::map<int, std::set<int> >::const_iterator it = m_fleet_supplyable_system_ids.begin();
+         it != m_fleet_supplyable_system_ids.end(); ++it)
+    {
+        if (it->second.find(system_id) != it->second.end())
+            return it->first;
+    }
+    return ALL_EMPIRES;
 }
 
 const std::map<int, std::set<std::set<int> > >& SupplyManager::ResourceSupplyGroups() const

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -85,6 +85,9 @@ const std::set<std::set<int> >& SupplyManager::ResourceSupplyGroups(int empire_i
     return EMPTY_INT_SET_SET;
 }
 
+const std::map<int, float>& SupplyManager::PropegatedSupplyRanges() const
+{ return m_propegated_supply_ranges; }
+
 bool SupplyManager::SystemHasFleetSupply(int system_id, int empire_id) const {
     if (system_id == INVALID_OBJECT_ID)
         return false;
@@ -203,6 +206,7 @@ void SupplyManager::Update() {
     m_supply_starlane_obstructed_traversals.clear();
     m_fleet_supplyable_system_ids.clear();
     m_resource_supply_groups.clear();
+    m_propegated_supply_ranges.clear();
 
     // for each empire, need to get a set of sets of systems that can exchange
     // resources.  some sets may be just one system, in which resources can be
@@ -557,6 +561,8 @@ void SupplyManager::Update() {
             if (sys_it->second < 0.0f)
                 continue;   // negative supply doesn't count... zero does (it just reaches)
             m_fleet_supplyable_system_ids[empire_id].insert(sys_it->first);
+            // should be only one empire per system at this point, but use max just to be safe...
+            m_propegated_supply_ranges[sys_it->first] = std::max(sys_it->second, m_propegated_supply_ranges[sys_it->first]);
         }
     }
 

--- a/Empire/Supply.h
+++ b/Empire/Supply.h
@@ -44,6 +44,9 @@ public:
     const std::map<int, std::set<std::set<int> > >&         ResourceSupplyGroups() const;
     const std::set<std::set<int> >&                         ResourceSupplyGroups(int empire_id) const;
 
+    /** Returns the range from each system some empire can propegate supply.*/
+    const std::map<int, float>&                             PropegatedSupplyRanges() const;
+
     /** Returns true if system with id \a system_id is fleet supplyable or in
       * one of the resource supply groups for empire with id \a empire_id */
     bool        SystemHasFleetSupply(int system_id, int empire_id) const;
@@ -76,6 +79,10 @@ private:
         share resources between systems or between objects in systems. indexed
         by empire id. */
     std::map<int, std::set<std::set<int> > >        m_resource_supply_groups;
+
+    /** for whichever empire can propegate supply into this system, what is the
+        additional range from this system that empire can propegate supply */
+    std::map<int, float>                            m_propegated_supply_ranges;
 
     friend class boost::serialization::access;
     template <class Archive>

--- a/Empire/Supply.h
+++ b/Empire/Supply.h
@@ -8,6 +8,7 @@
 
 #include <map>
 #include <set>
+#include <string>
 
 extern const int ALL_EMPIRES;
 

--- a/Empire/Supply.h
+++ b/Empire/Supply.h
@@ -2,17 +2,21 @@
 #ifndef _Supply_h_
 #define _Supply_h_
 
-#include "Empire.h"
+#include "../util/Export.h"
+
+#include <boost/serialization/access.hpp>
+
+#include <map>
+#include <set>
 
 /** Used to calcuate all empires' supply distributions. */
-class FO_COMMON_API SupplySystem {
-private:
+class FO_COMMON_API SupplyManager {
+public:
     /** \name Structors */ //@{
-    SupplySystem();
-    ~SupplySystem();
+    SupplyManager();
+    SupplyManager& operator=(const SupplyManager& rhs);
     //@}
 
-public:
     /** \name Accessors */ //@{
     /** Returns set of directed starlane traversals along which supply can flow.
       * Results are pairs of system ids of start and end system of traversal. */

--- a/Empire/Supply.h
+++ b/Empire/Supply.h
@@ -9,6 +9,8 @@
 #include <map>
 #include <set>
 
+extern const int ALL_EMPIRES;
+
 /** Used to calcuate all empires' supply distributions. */
 class FO_COMMON_API SupplyManager {
 public:
@@ -43,7 +45,9 @@ public:
 
     /** Returns true if system with id \a system_id is fleet supplyable or in
       * one of the resource supply groups for empire with id \a empire_id */
-    bool    SystemHasFleetSupply(int system_id, int empire_id) const;
+    bool        SystemHasFleetSupply(int system_id, int empire_id) const;
+
+    std::string Dump(int empire_id = ALL_EMPIRES) const;
     //@}
 
     /** \name Mutators */ //@{

--- a/Empire/Supply.h
+++ b/Empire/Supply.h
@@ -21,17 +21,19 @@ public:
     /** Returns set of directed starlane traversals along which supply can flow.
       * Results are pairs of system ids of start and end system of traversal. */
     const std::map<int, std::set<std::pair<int, int> > >&   SupplyStarlaneTraversals() const;
+    const std::set<std::pair<int, int> >&                   SupplyStarlaneTraversals(int empire_id) const;
 
     /** Returns set of directed starlane traversals along which supply could
       * flow for this empire, but which can't due to some obstruction in one
       * of the systems. */
     const std::map<int, std::set<std::pair<int, int> > >&   SupplyObstructedStarlaneTraversals() const;
+    const std::set<std::pair<int, int> >&                   SupplyObstructedStarlaneTraversals(int empire_id) const;
 
     /** Returns set of system ids where fleets can be supplied by this empire
       * (as determined by object supply meters and rules of supply propagation
       * and blockade). */
     const std::map<int, std::set<int> >&                    FleetSupplyableSystemIDs() const;
-    const std::set<int>&                                    FleetSupplyableSystemID(int empire_id);
+    const std::set<int>&                                    FleetSupplyableSystemIDs(int empire_id);
 
     /** Returns set of sets of systems that can share industry (systems in
       * separate groups are blockaded or otherwise separated). */

--- a/Empire/Supply.h
+++ b/Empire/Supply.h
@@ -31,6 +31,7 @@ public:
       * (as determined by object supply meters and rules of supply propagation
       * and blockade). */
     const std::map<int, std::set<int> >&                    FleetSupplyableSystemIDs() const;
+    const std::set<int>&                                    FleetSupplyableSystemID(int empire_id);
 
     /** Returns set of sets of systems that can share industry (systems in
       * separate groups are blockaded or otherwise separated). */

--- a/Empire/Supply.h
+++ b/Empire/Supply.h
@@ -1,0 +1,69 @@
+// -*- C++ -*-
+#ifndef _Supply_h_
+#define _Supply_h_
+
+#include "Empire.h"
+
+/** Used to calcuate all empires' supply distributions. */
+class FO_COMMON_API SupplySystem {
+private:
+    /** \name Structors */ //@{
+    SupplySystem();
+    ~SupplySystem();
+    //@}
+
+public:
+    /** \name Accessors */ //@{
+    /** Returns set of directed starlane traversals along which supply can flow.
+      * Results are pairs of system ids of start and end system of traversal. */
+    const std::map<int, std::set<std::pair<int, int> > >&   SupplyStarlaneTraversals() const;
+
+    /** Returns set of directed starlane traversals along which supply could
+      * flow for this empire, but which can't due to some obstruction in one
+      * of the systems. */
+    const std::map<int, std::set<std::pair<int, int> > >&   SupplyObstructedStarlaneTraversals() const;
+
+    /** Returns set of system ids where fleets can be supplied by this empire
+      * (as determined by object supply meters and rules of supply propagation
+      * and blockade). */
+    const std::map<int, std::set<int> >&                    FleetSupplyableSystemIDs() const;
+
+    /** Returns set of sets of systems that can share industry (systems in
+      * separate groups are blockaded or otherwise separated). */
+    const std::map<int, std::set<std::set<int> > >&         ResourceSupplyGroups() const;
+
+    /** Returns true if system with id \a system_id is fleet supplyable or in
+      * one of the resource supply groups for empire with id \a empire_id */
+    bool    SystemHasFleetSupply(int system_id, int empire_id) const;
+    //@}
+
+    /** \name Mutators */ //@{
+    /** Calculates systems at which fleets of empires can be supplied, and
+      * groups of systems that can exchange resources, and the starlane
+      * traversals used to do so, using the indicated \a starlanes but subject
+      * to obstruction of supply by various factors. */
+    void    Update(const std::map<int, std::set<int> >& starlanes);
+    /** Updates supply using this empire's set of known starlanes. */
+    void    Update();
+    //@}
+
+private:
+    /** ordered pairs of system ids between which a starlane runs that can be
+        used to convey resources between systems. indexed first by empire id. */
+    std::map<int, std::set<std::pair<int, int> > >  m_supply_starlane_traversals;
+
+    /** ordered pairs of system ids between which a starlane could be used to
+        convey resources between system, but is not because something is
+        obstructing the resource flow.  That is, the resource flow isn't limited
+        by range, but by something blocking its flow. */
+    std::map<int, std::set<std::pair<int, int> > >  m_supply_starlane_obstructed_traversals;
+
+    /** ids of systems where fleets can be resupplied. */
+    std::map<int, std::set<int> >                   m_fleet_supplyable_system_ids;
+
+    /** sets of system ids that are connected by supply lines and are able to
+        share resources between systems or between objects in systems. */
+    std::map<int, std::set<std::set<int> > >        m_resource_supply_groups;
+};
+
+#endif // _Supply_h_

--- a/Empire/Supply.h
+++ b/Empire/Supply.h
@@ -48,10 +48,7 @@ public:
     /** \name Mutators */ //@{
     /** Calculates systems at which fleets of empires can be supplied, and
       * groups of systems that can exchange resources, and the starlane
-      * traversals used to do so, using the indicated \a starlanes but subject
-      * to obstruction of supply by various factors. */
-    void    Update(const std::map<int, std::set<int> >& starlanes);
-    /** Updates supply using this empire's set of known starlanes. */
+      * traversals used to do so. */
     void    Update();
     //@}
 
@@ -66,11 +63,12 @@ private:
         by range, but by something blocking its flow. */
     std::map<int, std::set<std::pair<int, int> > >  m_supply_starlane_obstructed_traversals;
 
-    /** ids of systems where fleets can be resupplied. */
+    /** ids of systems where fleets can be resupplied. indexed by empire id. */
     std::map<int, std::set<int> >                   m_fleet_supplyable_system_ids;
 
     /** sets of system ids that are connected by supply lines and are able to
-        share resources between systems or between objects in systems. */
+        share resources between systems or between objects in systems. indexed
+        by empire id. */
     std::map<int, std::set<std::set<int> > >        m_resource_supply_groups;
 };
 

--- a/Empire/Supply.h
+++ b/Empire/Supply.h
@@ -70,6 +70,10 @@ private:
         share resources between systems or between objects in systems. indexed
         by empire id. */
     std::map<int, std::set<std::set<int> > >        m_resource_supply_groups;
+
+    friend class boost::serialization::access;
+    template <class Archive>
+    void serialize(Archive& ar, const unsigned int version);
 };
 
 #endif // _Supply_h_

--- a/Empire/Supply.h
+++ b/Empire/Supply.h
@@ -33,7 +33,8 @@ public:
       * (as determined by object supply meters and rules of supply propagation
       * and blockade). */
     const std::map<int, std::set<int> >&                    FleetSupplyableSystemIDs() const;
-    const std::set<int>&                                    FleetSupplyableSystemIDs(int empire_id);
+    const std::set<int>&                                    FleetSupplyableSystemIDs(int empire_id) const;
+    int                                                     EmpireThatCanSupplyAt(int system_id) const;
 
     /** Returns set of sets of systems that can share industry (systems in
       * separate groups are blockaded or otherwise separated). */

--- a/Empire/Supply.h
+++ b/Empire/Supply.h
@@ -36,6 +36,7 @@ public:
     /** Returns set of sets of systems that can share industry (systems in
       * separate groups are blockaded or otherwise separated). */
     const std::map<int, std::set<std::set<int> > >&         ResourceSupplyGroups() const;
+    const std::set<std::set<int> >&                         ResourceSupplyGroups(int empire_id) const;
 
     /** Returns true if system with id \a system_id is fleet supplyable or in
       * one of the resource supply groups for empire with id \a empire_id */

--- a/GG/src/DrawUtil.cpp
+++ b/GG/src/DrawUtil.cpp
@@ -294,7 +294,7 @@ namespace { // file-scope constants and functions
     void CircleArc(Pt ul, Pt lr, Clr color, Clr border_color1, Clr border_color2,
                    unsigned int bevel_thick, double theta1, double theta2)
     {
-        std::cout << "GG::CircleArc ul: " << ul << "  lr: " << lr << " bevel thick: " << bevel_thick << "  theta1: " << theta1 << "  theta2: " << theta2 << std::flush << std::endl;
+        //std::cout << "GG::CircleArc ul: " << ul << "  lr: " << lr << " bevel thick: " << bevel_thick << "  theta1: " << theta1 << "  theta2: " << theta2 << std::flush << std::endl;
         X wd = lr.x - ul.x;
         Y ht = lr.y - ul.y;
         glDisable(GL_TEXTURE_2D);

--- a/GG/src/DrawUtil.cpp
+++ b/GG/src/DrawUtil.cpp
@@ -294,6 +294,7 @@ namespace { // file-scope constants and functions
     void CircleArc(Pt ul, Pt lr, Clr color, Clr border_color1, Clr border_color2,
                    unsigned int bevel_thick, double theta1, double theta2)
     {
+        std::cout << "GG::CircleArc ul: " << ul << "  lr: " << lr << " bevel thick: " << bevel_thick << "  theta1: " << theta1 << "  theta2: " << theta2 << std::flush << std::endl;
         X wd = lr.x - ul.x;
         Y ht = lr.y - ul.y;
         glDisable(GL_TEXTURE_2D);

--- a/UI/CUIDrawUtil.cpp
+++ b/UI/CUIDrawUtil.cpp
@@ -301,7 +301,7 @@ bool InIsoscelesTriangle(const GG::Pt& pt, const GG::Pt& ul, const GG::Pt& lr, S
 }
 
 void CircleArc(const GG::Pt& ul, const GG::Pt& lr, double theta1, double theta2, bool filled_shape) {
-    std::cout << "CircleArc ul: " << ul << "  lr: " << lr << "  theta1: " << theta1 << "  theta2: " << theta2 << "  filled: " << filled_shape << std::flush << std::endl;
+    //std::cout << "CircleArc ul: " << ul << "  lr: " << lr << "  theta1: " << theta1 << "  theta2: " << theta2 << "  filled: " << filled_shape << std::flush << std::endl;
     GG::GL2DVertexBuffer vert_buf;
     vert_buf.reserve(50);   // max number that BufferStoreCircleArcVertices might add
 

--- a/UI/CUIDrawUtil.cpp
+++ b/UI/CUIDrawUtil.cpp
@@ -301,6 +301,7 @@ bool InIsoscelesTriangle(const GG::Pt& pt, const GG::Pt& ul, const GG::Pt& lr, S
 }
 
 void CircleArc(const GG::Pt& ul, const GG::Pt& lr, double theta1, double theta2, bool filled_shape) {
+    std::cout << "CircleArc ul: " << ul << "  lr: " << lr << "  theta1: " << theta1 << "  theta2: " << theta2 << "  filled: " << filled_shape << std::flush << std::endl;
     GG::GL2DVertexBuffer vert_buf;
     vert_buf.reserve(50);   // max number that BufferStoreCircleArcVertices might add
 

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -2307,6 +2307,8 @@ void MapWnd::InitTurn() {
     DebugLogger() << "Initializing turn " << turn_number;
     ScopedTimer init_timer("MapWnd::InitTurn", true);
 
+    DebugLogger() << GetSupplyManager().Dump();
+
     Universe& universe = GetUniverse();
     const ObjectMap& objects = Objects();
 

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -2307,7 +2307,7 @@ void MapWnd::InitTurn() {
     DebugLogger() << "Initializing turn " << turn_number;
     ScopedTimer init_timer("MapWnd::InitTurn", true);
 
-    DebugLogger() << GetSupplyManager().Dump();
+    //DebugLogger() << GetSupplyManager().Dump();
 
     Universe& universe = GetUniverse();
     const ObjectMap& objects = Objects();

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -1731,9 +1731,19 @@ void MapWnd::RenderSystems() {
 
             // render circles around systems that have at least one starlane, if circles are enabled.
             if (circles) {
-                if (TemporaryPtr<const System> system = GetSystem(it->first))
-                    if (system->NumStarlanes() > 0)
+                if (TemporaryPtr<const System> system = GetSystem(it->first)) {
+                    if (system->NumStarlanes() > 0) {
+                        glColor(GetOptionsDB().Get<StreamableColor>("UI.unowned-starlane-colour").ToClr());
+
+                        int empire_id = GetSupplyManager().EmpireThatCanSupplyAt(it->first);
+                        if (empire_id != ALL_EMPIRES) {
+                            if (Empire* empire = GetEmpire(empire_id)) {
+                                glColor(empire->Color());
+                            }
+                        }
                         CircleArc(circle_ul, circle_lr, 0.0, TWO_PI, false);
+                    }
+                }
             }
         }
 

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -86,16 +86,24 @@ namespace {
     }
 
     ValueRef::Variable<std::string>* ObjectNameValueRef(const std::string& token) {
-        return new ValueRef::ObjectNameLookup(
+        return new ValueRef::NameLookup(
             new ValueRef::Variable<int>(
-                ValueRef::SOURCE_REFERENCE, std::vector<std::string>(1u, token)));
+                ValueRef::SOURCE_REFERENCE, std::vector<std::string>(1u, token)),
+            ValueRef::NameLookup::OBJECT_NAME);
+    }
+
+    ValueRef::Variable<std::string>* EmpireNameValueRef(const std::string& token) {
+        return new ValueRef::NameLookup(
+            new ValueRef::Variable<int>(
+                ValueRef::SOURCE_REFERENCE, std::vector<std::string>(1u, token)),
+            ValueRef::NameLookup::EMPIRE_NAME);
     }
 
     const std::map<std::string, ValueRef::ValueRefBase<std::string>*>& AvailableColumnTypes() {
         static std::map<std::string, ValueRef::ValueRefBase<std::string>*> col_types;
         if (col_types.empty()) {
             col_types[UserStringNop("NAME")] =                      StringValueRef("Name");
-            col_types[UserStringNop("OWNER")] =                     StringValueRef("OwnerName");
+            col_types[UserStringNop("OWNER")] =                     EmpireNameValueRef("Owner");
             col_types[UserStringNop("OBJECT_TYPE")] =               UserStringValueRef("TypeName");
             col_types[UserStringNop("SPECIES")] =                   UserStringValueRef("Species");
             col_types[UserStringNop("BUILDING_TYPE")] =             UserStringValueRef("BuildingType");
@@ -107,8 +115,9 @@ namespace {
             col_types[UserStringNop("AGE")] =                       StringCastedValueRef<int>("Age");
             col_types[UserStringNop("TURNS_SINCE_FOCUS_CHANGE")] =  StringCastedValueRef<int>("TurnsSinceFocusChange");
             col_types[UserStringNop("SUPPLY_RANGE")] =              StringCastedValueRef<double>("PropegatedSupplyRange");
+            col_types[UserStringNop("SUPPLYING_EMPIRE")] =          EmpireNameValueRef("SupplyingEmpire");
             col_types[UserStringNop("ETA")] =                       StringCastedValueRef<int>("ETA");
-            col_types[UserStringNop("PRODUCED_BY")] =               StringCastedValueRef<int>("ProducedByEmpireID");
+            col_types[UserStringNop("PRODUCED_BY")] =               EmpireNameValueRef("ProducedByEmpireID");
             col_types[UserStringNop("SYSTEM")] =                    ObjectNameValueRef("SystemID");
             col_types[UserStringNop("NEAREST_SYSTEM")] =            ObjectNameValueRef("NearestSystemID");
             col_types[UserStringNop("DESIGN_ID")] =                 StringCastedValueRef<int>("DesignID");

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -106,6 +106,7 @@ namespace {
             col_types[UserStringNop("CREATION_TURN")] =             StringCastedValueRef<int>("CreationTurn");
             col_types[UserStringNop("AGE")] =                       StringCastedValueRef<int>("Age");
             col_types[UserStringNop("TURNS_SINCE_FOCUS_CHANGE")] =  StringCastedValueRef<int>("TurnsSinceFocusChange");
+            col_types[UserStringNop("SUPPLY_RANGE")] =              StringCastedValueRef<double>("PropegatedSupplyRange");
             col_types[UserStringNop("ETA")] =                       StringCastedValueRef<int>("ETA");
             col_types[UserStringNop("PRODUCED_BY")] =               StringCastedValueRef<int>("ProducedByEmpireID");
             col_types[UserStringNop("SYSTEM")] =                    ObjectNameValueRef("SystemID");

--- a/Xcode/FreeOrion.xcodeproj/project.pbxproj
+++ b/Xcode/FreeOrion.xcodeproj/project.pbxproj
@@ -342,6 +342,7 @@
 		CEDABCF01C688D050085A4DC /* libboost_locale.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CEDABCEF1C688D050085A4DC /* libboost_locale.a */; };
 		CEDABCF31C688E290085A4DC /* libiconv.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = CEDABCF21C688E290085A4DC /* libiconv.dylib */; };
 		CEDC4AEF1BD3E361009BB38D /* EmpireWrapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 343EC6740F3F61D000782AD3 /* EmpireWrapper.cpp */; };
+		CEED195F1C79BA2F0085A4DC /* Supply.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CEED195D1C79BA2F0085A4DC /* Supply.cpp */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -1116,6 +1117,8 @@
 		CED6E5511C6DDC0F0085A4DC /* Fighter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Fighter.h; sourceTree = "<group>"; };
 		CEDABCEF1C688D050085A4DC /* libboost_locale.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libboost_locale.a; sourceTree = "<group>"; };
 		CEDABCF21C688E290085A4DC /* libiconv.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libiconv.dylib; path = usr/lib/libiconv.dylib; sourceTree = SDKROOT; };
+		CEED195D1C79BA2F0085A4DC /* Supply.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Supply.cpp; sourceTree = "<group>"; };
+		CEED195E1C79BA2F0085A4DC /* Supply.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Supply.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -1553,6 +1556,8 @@
 				471D5C780A98A3F900DA9C21 /* EmpireManager.h */,
 				471D5C790A98A3F900DA9C21 /* ResourcePool.cpp */,
 				471D5C7A0A98A3F900DA9C21 /* ResourcePool.h */,
+				CEED195D1C79BA2F0085A4DC /* Supply.cpp */,
+				CEED195E1C79BA2F0085A4DC /* Supply.h */,
 			);
 			path = Empire;
 			sourceTree = "<group>";
@@ -2451,6 +2456,7 @@
 				47103BF70CF04E5900A7DF2B /* SitRepEntry.cpp in Sources */,
 				47103BF80CF04E5900A7DF2B /* VarText.cpp in Sources */,
 				47103BF90CF04E5900A7DF2B /* XMLDoc.cpp in Sources */,
+				CEED195F1C79BA2F0085A4DC /* Supply.cpp in Sources */,
 				47103BFA0CF04E5900A7DF2B /* Building.cpp in Sources */,
 				82EC868B1B40504700D4584D /* Encyclopedia.cpp in Sources */,
 				47103BFB0CF04E5900A7DF2B /* Condition.cpp in Sources */,

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -171,7 +171,8 @@ void AIClientApp::HandleMessage(const Message& msg) {
 
             DebugLogger() << "Message::GAME_START loaded_game_data: " << loaded_game_data;
             if (loaded_game_data) {
-                DebugLogger() << "Message::GAME_START save_state_string: " << save_state_string;
+                if (GetOptionsDB().Get<bool>("verbose-logging"))
+                    DebugLogger() << "Message::GAME_START save_state_string: " << save_state_string;
                 m_AI->ResumeLoadedGame(save_state_string);
                 Orders().ApplyOrders();
             } else {

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -160,10 +160,10 @@ void AIClientApp::HandleMessage(const Message& msg) {
 
             ExtractMessageData(msg,                     single_player_game,     m_empire_id,
                                m_current_turn,          m_empires,              m_universe,
-                               GetSpeciesManager(),     GetCombatLogManager(),  m_player_info,
-                               m_orders,                loaded_game_data,       ui_data_available,
-                               ui_data,                 state_string_available, save_state_string,
-                               m_galaxy_setup_data);
+                               GetSpeciesManager(),     GetCombatLogManager(),  GetSupplyManager(),
+                               m_player_info,           m_orders,               loaded_game_data,
+                               ui_data_available,       ui_data,                state_string_available,
+                               save_state_string,       m_galaxy_setup_data);
 
             DebugLogger() << "Extracted GameStart message for turn: " << m_current_turn << " with empire: " << m_empire_id;
 
@@ -246,7 +246,7 @@ void AIClientApp::HandleMessage(const Message& msg) {
             //DebugLogger() << "AIClientApp::HandleMessage : extracting turn update message data";
             ExtractMessageData(msg,                     m_empire_id,        m_current_turn,
                                m_empires,               m_universe,         GetSpeciesManager(),
-                               GetCombatLogManager(),   m_player_info);
+                               GetCombatLogManager(),   GetSupplyManager(), m_player_info);
             //DebugLogger() << "AIClientApp::HandleMessage : generating orders";
             GetUniverse().InitializeSystemGraph(m_empire_id);
             m_AI->GenerateOrders();

--- a/client/ClientApp.cpp
+++ b/client/ClientApp.cpp
@@ -17,8 +17,7 @@ ClientApp::ClientApp() :
     m_universe(),
     m_empire_id(ALL_EMPIRES),
     m_current_turn(INVALID_GAME_TURN)
-{
-}
+{}
 
 ClientApp::~ClientApp()
 {}
@@ -49,6 +48,9 @@ EmpireManager& ClientApp::Empires()
 
 Empire* ClientApp::GetEmpire(int id)
 { return m_empires.GetEmpire(id); }
+
+SupplyManager& ClientApp::GetSupplyManager()
+{ return m_supply_manager; }
 
 TemporaryPtr<UniverseObject> ClientApp::GetUniverseObject(int object_id)
 { return GetUniverse().Objects().Object(object_id); }

--- a/client/ClientApp.h
+++ b/client/ClientApp.h
@@ -3,6 +3,7 @@
 #define _ClientApp_h_
 
 #include "../Empire/EmpireManager.h"
+#include "../Empire/Supply.h"
 #include "../network/ClientNetworking.h"
 #include "../universe/Universe.h"
 #include "../util/OrderSet.h"
@@ -51,6 +52,7 @@ public:
     GalaxySetupData&            GetGalaxySetupData();
     EmpireManager&              Empires();      ///< returns the set of known Empires
     Empire*                     GetEmpire(int id);
+    SupplyManager&              GetSupplyManager();
     TemporaryPtr<UniverseObject>GetUniverseObject(int object_id);
     ObjectMap&                  EmpireKnownObjects(int empire_id); ///< returns the server's map for known objects of specified empire. */
     TemporaryPtr<UniverseObject>EmpireKnownObject(int object_id, int empire_id);

--- a/client/ClientApp.h
+++ b/client/ClientApp.h
@@ -81,6 +81,7 @@ protected:
     Universe                    m_universe;
     GalaxySetupData             m_galaxy_setup_data;
     EmpireManager               m_empires;
+    SupplyManager               m_supply_manager;
     OrderSet                    m_orders;
     ClientNetworking            m_networking;
     int                         m_empire_id;

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -790,7 +790,12 @@ void HumanClientApp::HandleSystemEvents() {
     } else if (m_networking.MessageAvailable()) {
         Message msg;
         m_networking.GetMessage(msg);
-        HandleMessage(msg);
+        try {
+            HandleMessage(msg);
+        } catch (const std::exception& e) {
+            ErrorLogger() << "exception handing message: " << e.what();
+            ErrorLogger() << "message type: " << msg.Type() << " and text: " << msg.Text();
+        }
     }
 }
 

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -514,10 +514,10 @@ boost::statechart::result WaitingForGameStart::react(const GameStart& msg) {
 
     ExtractMessageData(msg.m_message,       single_player_game,             empire_id,
                        current_turn,        Empires(),                      GetUniverse(),
-                       GetSpeciesManager(), GetCombatLogManager(),          Client().Players(),
-                       orders,              loaded_game_data,               ui_data_available,
-                       ui_data,             save_state_string_available,    save_state_string,
-                       Client().GetGalaxySetupData());
+                       GetSpeciesManager(), GetCombatLogManager(),          GetSupplyManager(),
+                       Client().Players(),  orders,                         loaded_game_data,
+                       ui_data_available,   ui_data,                        save_state_string_available,
+                       save_state_string,   Client().GetGalaxySetupData());
 
     DebugLogger() << "Extracted GameStart message for turn: " << current_turn << " with empire: " << empire_id;
 
@@ -574,7 +574,7 @@ boost::statechart::result WaitingForTurnData::react(const TurnUpdate& msg) {
     try {
         ExtractMessageData(msg.m_message,           Client().EmpireID(),    current_turn,
                            Empires(),               GetUniverse(),          GetSpeciesManager(),
-                           GetCombatLogManager(),   Client().Players());
+                           GetCombatLogManager(),   GetSupplyManager(),     Client().Players());
     } catch (...) {
         Client().GetClientUI()->GetMessageWnd()->HandleLogMessage(UserString("ERROR_PROCESSING_SERVER_MESSAGE") + "\n");
         return discard_event();

--- a/default/AI/AIstate.py
+++ b/default/AI/AIstate.py
@@ -280,7 +280,7 @@ class AIstate(object):
                 continue
             for sys_id in this_enemy.fleetSupplyableSystemIDs:
                 actual_supply.setdefault(sys_id, []).append(enemy_id)
-            for sys_id, supply_val in this_enemy.supplyProjections(-3, False).items():
+            for sys_id, supply_val in this_enemy.supplyProjections().items():
                 if supply_val >= -2:
                     near_supply.setdefault(sys_id, []).append(enemy_id)
         return actual_supply, near_supply

--- a/default/AI/ColonisationAI.py
+++ b/default/AI/ColonisationAI.py
@@ -255,10 +255,8 @@ def check_supply():
     print "New Supply Calc:"
     print "Known Systems:", list(universe.systemIDs)
     print "Base Supply:", dict_from_map(empire.systemSupplyRanges)
-    # Note: empire.supplyProjections supply projection has one major difference from standard supply calculations-- if
-    # the final parameter (obstructed) is False then it intentionally ignores existing obstructions/blockades, so
-    # a Sentinel or somesuch might throw it off, That is an area for future improvement
-    system_supply.update(empire.supplyProjections(-1 - supply_distance, False))
+    # Note: empire.supplyProjections supply returns the number of jumps each system is from a fleet-supplied system for that empire (0 if a system is in supply)
+    system_supply.update(empire.supplyProjections())
     for sys_id, supply_val in system_supply.items():
         # print PlanetUtilsAI.sys_name_ids([sys_id]), ' -- ', supply_val
         systems_by_supply_tier.setdefault(min(0, supply_val), []).append(sys_id)

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -4376,6 +4376,9 @@ Age
 TURNS_SINCE_FOCUS_CHANGE
 Turns Since Focus Change
 
+SUPPLY_RANGE
+Supply Range
+
 ETA
 Turns To Destination
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -4379,6 +4379,9 @@ Turns Since Focus Change
 SUPPLY_RANGE
 Supply Range
 
+SUPPLYING_EMPIRE
+Supplying Empire
+
 ETA
 Turns To Destination
 

--- a/msvc2013/Common/Common.vcxproj
+++ b/msvc2013/Common/Common.vcxproj
@@ -205,6 +205,7 @@
     <ClInclude Include="..\..\Empire\Empire.h" />
     <ClInclude Include="..\..\Empire\EmpireManager.h" />
     <ClInclude Include="..\..\Empire\ResourcePool.h" />
+    <ClInclude Include="..\..\Empire\Supply.h" />
     <ClInclude Include="..\..\network\Message.h" />
     <ClInclude Include="..\..\network\MessageQueue.h" />
     <ClInclude Include="..\..\network\Networking.h" />
@@ -264,6 +265,7 @@
     <ClCompile Include="..\..\Empire\Empire.cpp" />
     <ClCompile Include="..\..\Empire\EmpireManager.cpp" />
     <ClCompile Include="..\..\Empire\ResourcePool.cpp" />
+    <ClCompile Include="..\..\Empire\Supply.cpp" />
     <ClCompile Include="..\..\network\Message.cpp" />
     <ClCompile Include="..\..\network\MessageQueue.cpp" />
     <ClCompile Include="..\..\network\Networking.cpp" />

--- a/msvc2013/Common/Common.vcxproj.filters
+++ b/msvc2013/Common/Common.vcxproj.filters
@@ -231,6 +231,11 @@
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\..\Empire\Supply.h">
+      <Filter>Header Files\Empire</Filter>
+    </ClInclude>
+  </ItemGroup>
+  <ItemGroup>
     <ClCompile Include="..\..\network\MessageQueue.cpp">
       <Filter>Source Files\network</Filter>
     </ClCompile>
@@ -404,6 +409,15 @@
     </ClCompile>
     <ClCompile Include="..\..\universe\Fighter.cpp">
       <Filter>Source Files\universe</Filter>
+    </ClCompile>
+  </ItemGroup>
+  <ItemGroup>
+    </ClCompile>
+    <ClCompile Include="..\..\util\DependencyVersions.cpp">
+      <Filter>Source Files\util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\Empire\Supply.cpp">
+      <Filter>Source Files\Empire</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/msvc2013/Common/Common.vcxproj.filters
+++ b/msvc2013/Common/Common.vcxproj.filters
@@ -229,8 +229,6 @@
     <ClInclude Include="..\..\universe\Fighter.h">
       <Filter>Header Files\universe</Filter>
     </ClInclude>
-  </ItemGroup>
-  <ItemGroup>
     <ClInclude Include="..\..\Empire\Supply.h">
       <Filter>Header Files\Empire</Filter>
     </ClInclude>
@@ -409,12 +407,6 @@
     </ClCompile>
     <ClCompile Include="..\..\universe\Fighter.cpp">
       <Filter>Source Files\universe</Filter>
-    </ClCompile>
-  </ItemGroup>
-  <ItemGroup>
-    </ClCompile>
-    <ClCompile Include="..\..\util\DependencyVersions.cpp">
-      <Filter>Source Files\util</Filter>
     </ClCompile>
     <ClCompile Include="..\..\Empire\Supply.cpp">
       <Filter>Source Files\Empire</Filter>

--- a/msvc2013/GiGi/GiGi.vcxproj
+++ b/msvc2013/GiGi/GiGi.vcxproj
@@ -99,7 +99,9 @@
     <ClCompile Include="..\..\GG\src\Font.cpp" />
     <ClCompile Include="..\..\GG\src\GLClientAndServerBuffer.cpp" />
     <ClCompile Include="..\..\GG\src\GroupBox.cpp" />
-    <ClCompile Include="..\..\GG\src\GUI.cpp" />
+    <ClCompile Include="..\..\GG\src\GUI.cpp">
+      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">4251; 4244; 4099; 4275;4351</DisableSpecificWarnings>
+    </ClCompile>
     <ClCompile Include="..\..\GG\src\Layout.cpp" />
     <ClCompile Include="..\..\GG\src\ListBox.cpp" />
     <ClCompile Include="..\..\GG\src\Menu.cpp" />
@@ -116,7 +118,9 @@
     <ClCompile Include="..\..\GG\src\StyleFactory.cpp" />
     <ClCompile Include="..\..\GG\src\TabWnd.cpp" />
     <ClCompile Include="..\..\GG\src\TextControl.cpp" />
-    <ClCompile Include="..\..\GG\src\Texture.cpp" />
+    <ClCompile Include="..\..\GG\src\Texture.cpp">
+      <DisableSpecificWarnings Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">4251; 4244; 4099; 4275;4351</DisableSpecificWarnings>
+    </ClCompile>
     <ClCompile Include="..\..\GG\src\Timer.cpp" />
     <ClCompile Include="..\..\GG\src\UnicodeCharsets.cpp" />
     <ClCompile Include="..\..\GG\src\Wnd.cpp" />

--- a/network/Message.cpp
+++ b/network/Message.cpp
@@ -2,6 +2,7 @@
 
 #include "../combat/CombatLogManager.h"
 #include "../Empire/EmpireManager.h"
+#include "../Empire/Supply.h"
 #include "../Empire/Diplomacy.h"
 #include "../util/Logger.h"
 #include "../util/MultiplayerCommon.h"
@@ -220,7 +221,7 @@ Message HostIDMessage(int host_player_id) {
 Message GameStartMessage(int player_id, bool single_player_game, int empire_id,
                          int current_turn, const EmpireManager& empires,
                          const Universe& universe, const SpeciesManager& species,
-                         const CombatLogManager& combat_logs,
+                         const CombatLogManager& combat_logs, const SupplyManager& supply,
                          const std::map<int, PlayerInfo>& players,
                          const GalaxySetupData& galaxy_setup_data,
                          bool use_binary_serialization)
@@ -235,7 +236,8 @@ Message GameStartMessage(int player_id, bool single_player_game, int empire_id,
             GetUniverse().EncodingEmpire() = empire_id;
             oa << BOOST_SERIALIZATION_NVP(empires)
                << BOOST_SERIALIZATION_NVP(species)
-               << BOOST_SERIALIZATION_NVP(combat_logs);
+               << BOOST_SERIALIZATION_NVP(combat_logs)
+               << BOOST_SERIALIZATION_NVP(supply);
             Serialize(oa, universe);
             bool loaded_game_data = false;
             oa << BOOST_SERIALIZATION_NVP(players)
@@ -249,7 +251,8 @@ Message GameStartMessage(int player_id, bool single_player_game, int empire_id,
             GetUniverse().EncodingEmpire() = empire_id;
             oa << BOOST_SERIALIZATION_NVP(empires)
                << BOOST_SERIALIZATION_NVP(species)
-               << BOOST_SERIALIZATION_NVP(combat_logs);
+               << BOOST_SERIALIZATION_NVP(combat_logs)
+               << BOOST_SERIALIZATION_NVP(supply);
             Serialize(oa, universe);
             bool loaded_game_data = false;
             oa << BOOST_SERIALIZATION_NVP(players)
@@ -263,7 +266,7 @@ Message GameStartMessage(int player_id, bool single_player_game, int empire_id,
 Message GameStartMessage(int player_id, bool single_player_game, int empire_id,
                          int current_turn, const EmpireManager& empires,
                          const Universe& universe, const SpeciesManager& species,
-                         const CombatLogManager& combat_logs,
+                         const CombatLogManager& combat_logs, const SupplyManager& supply,
                          const std::map<int, PlayerInfo>& players,
                          const OrderSet& orders, const SaveGameUIData* ui_data,
                          const GalaxySetupData& galaxy_setup_data,
@@ -279,7 +282,8 @@ Message GameStartMessage(int player_id, bool single_player_game, int empire_id,
             GetUniverse().EncodingEmpire() = empire_id;
             oa << BOOST_SERIALIZATION_NVP(empires)
                << BOOST_SERIALIZATION_NVP(species)
-               << BOOST_SERIALIZATION_NVP(combat_logs);
+               << BOOST_SERIALIZATION_NVP(combat_logs)
+               << BOOST_SERIALIZATION_NVP(supply);
             Serialize(oa, universe);
             bool loaded_game_data = true;
             oa << BOOST_SERIALIZATION_NVP(players)
@@ -300,7 +304,8 @@ Message GameStartMessage(int player_id, bool single_player_game, int empire_id,
             GetUniverse().EncodingEmpire() = empire_id;
             oa << BOOST_SERIALIZATION_NVP(empires)
                << BOOST_SERIALIZATION_NVP(species)
-               << BOOST_SERIALIZATION_NVP(combat_logs);
+               << BOOST_SERIALIZATION_NVP(combat_logs)
+               << BOOST_SERIALIZATION_NVP(supply);
             Serialize(oa, universe);
             bool loaded_game_data = true;
             oa << BOOST_SERIALIZATION_NVP(players)
@@ -321,7 +326,7 @@ Message GameStartMessage(int player_id, bool single_player_game, int empire_id,
 Message GameStartMessage(int player_id, bool single_player_game, int empire_id,
                          int current_turn, const EmpireManager& empires,
                          const Universe& universe, const SpeciesManager& species,
-                         const CombatLogManager& combat_logs,
+                         const CombatLogManager& combat_logs, const SupplyManager& supply,
                          const std::map<int, PlayerInfo>& players,
                          const OrderSet& orders, const std::string* save_state_string,
                          const GalaxySetupData& galaxy_setup_data,
@@ -337,7 +342,8 @@ Message GameStartMessage(int player_id, bool single_player_game, int empire_id,
             GetUniverse().EncodingEmpire() = empire_id;
             oa << BOOST_SERIALIZATION_NVP(empires)
                << BOOST_SERIALIZATION_NVP(species)
-               << BOOST_SERIALIZATION_NVP(combat_logs);
+               << BOOST_SERIALIZATION_NVP(combat_logs)
+               << BOOST_SERIALIZATION_NVP(supply);
             Serialize(oa, universe);
             bool loaded_game_data = true;
             oa << BOOST_SERIALIZATION_NVP(players)
@@ -358,7 +364,8 @@ Message GameStartMessage(int player_id, bool single_player_game, int empire_id,
             GetUniverse().EncodingEmpire() = empire_id;
             oa << BOOST_SERIALIZATION_NVP(empires)
                << BOOST_SERIALIZATION_NVP(species)
-               << BOOST_SERIALIZATION_NVP(combat_logs);
+               << BOOST_SERIALIZATION_NVP(combat_logs)
+               << BOOST_SERIALIZATION_NVP(supply);
             Serialize(oa, universe);
             bool loaded_game_data = true;
             oa << BOOST_SERIALIZATION_NVP(players)
@@ -416,6 +423,7 @@ Message PlayerStatusMessage(int player_id, int about_player_id, Message::PlayerS
 Message TurnUpdateMessage(int player_id, int empire_id, int current_turn,
                           const EmpireManager& empires, const Universe& universe,
                           const SpeciesManager& species, const CombatLogManager& combat_logs,
+                          const SupplyManager& supply,
                           const std::map<int, PlayerInfo>& players,
                           bool use_binary_serialization)
 {
@@ -427,7 +435,8 @@ Message TurnUpdateMessage(int player_id, int empire_id, int current_turn,
             oa << BOOST_SERIALIZATION_NVP(current_turn)
                << BOOST_SERIALIZATION_NVP(empires)
                << BOOST_SERIALIZATION_NVP(species)
-               << BOOST_SERIALIZATION_NVP(combat_logs);
+               << BOOST_SERIALIZATION_NVP(combat_logs)
+               << BOOST_SERIALIZATION_NVP(supply);
             Serialize(oa, universe);
             oa << BOOST_SERIALIZATION_NVP(players);
         } else {
@@ -436,7 +445,8 @@ Message TurnUpdateMessage(int player_id, int empire_id, int current_turn,
             oa << BOOST_SERIALIZATION_NVP(current_turn)
                << BOOST_SERIALIZATION_NVP(empires)
                << BOOST_SERIALIZATION_NVP(species)
-               << BOOST_SERIALIZATION_NVP(combat_logs);
+               << BOOST_SERIALIZATION_NVP(combat_logs)
+               << BOOST_SERIALIZATION_NVP(supply);
             Serialize(oa, universe);
             oa << BOOST_SERIALIZATION_NVP(players);
         }
@@ -674,6 +684,7 @@ void ExtractMessageData(const Message& msg, MultiplayerLobbyData& lobby_data) {
 
 void ExtractMessageData(const Message& msg, bool& single_player_game, int& empire_id, int& current_turn,
                         EmpireManager& empires, Universe& universe, SpeciesManager& species, CombatLogManager& combat_logs,
+                        SupplyManager& supply,
                         std::map<int, PlayerInfo>& players, OrderSet& orders, bool& loaded_game_data, bool& ui_data_available,
                         SaveGameUIData& ui_data, bool& save_state_string_available, std::string& save_state_string,
                         GalaxySetupData& galaxy_setup_data)
@@ -694,7 +705,8 @@ void ExtractMessageData(const Message& msg, bool& single_player_game, int& empir
             DebugLogger() << "ExtractMessage empire deserialization time " << (deserialize_timer.elapsed() * 1000.0);
 
             ia >> BOOST_SERIALIZATION_NVP(species)
-            >> BOOST_SERIALIZATION_NVP(combat_logs);
+               >> BOOST_SERIALIZATION_NVP(combat_logs)
+               >> BOOST_SERIALIZATION_NVP(supply);
 
             deserialize_timer.restart();
             Deserialize(ia, universe);
@@ -732,7 +744,8 @@ void ExtractMessageData(const Message& msg, bool& single_player_game, int& empir
             DebugLogger() << "ExtractMessage empire deserialization time " << (deserialize_timer.elapsed() * 1000.0);
 
             ia >> BOOST_SERIALIZATION_NVP(species)
-               >> BOOST_SERIALIZATION_NVP(combat_logs);
+               >> BOOST_SERIALIZATION_NVP(combat_logs)
+               >> BOOST_SERIALIZATION_NVP(supply);
 
             deserialize_timer.restart();
             Deserialize(ia, universe);
@@ -798,7 +811,8 @@ void ExtractMessageData(const Message& msg, OrderSet& orders) {
 }
 
 void ExtractMessageData(const Message& msg, int empire_id, int& current_turn, EmpireManager& empires, Universe& universe,
-                        SpeciesManager& species, CombatLogManager& combat_logs, std::map<int, PlayerInfo>& players)
+                        SpeciesManager& species, CombatLogManager& combat_logs, SupplyManager& supply,
+                        std::map<int, PlayerInfo>& players)
 {
     try {
         ScopedTimer timer("Turn Update Unpacking", true);
@@ -811,7 +825,8 @@ void ExtractMessageData(const Message& msg, int empire_id, int& current_turn, Em
             ia >> BOOST_SERIALIZATION_NVP(current_turn)
                >> BOOST_SERIALIZATION_NVP(empires)
                >> BOOST_SERIALIZATION_NVP(species)
-               >> BOOST_SERIALIZATION_NVP(combat_logs);
+               >> BOOST_SERIALIZATION_NVP(combat_logs)
+               >> BOOST_SERIALIZATION_NVP(supply);
             Deserialize(ia, universe);
             ia >> BOOST_SERIALIZATION_NVP(players);
 
@@ -823,7 +838,8 @@ void ExtractMessageData(const Message& msg, int empire_id, int& current_turn, Em
             ia >> BOOST_SERIALIZATION_NVP(current_turn)
                >> BOOST_SERIALIZATION_NVP(empires)
                >> BOOST_SERIALIZATION_NVP(species)
-               >> BOOST_SERIALIZATION_NVP(combat_logs);
+               >> BOOST_SERIALIZATION_NVP(combat_logs)
+               >> BOOST_SERIALIZATION_NVP(supply);
             Deserialize(ia, universe);
             ia >> BOOST_SERIALIZATION_NVP(players);
         }

--- a/network/Message.h
+++ b/network/Message.h
@@ -17,6 +17,7 @@
 #include <vector>
 
 class EmpireManager;
+class SupplyManager;
 class SpeciesManager;
 class CombatLogManager;
 class Message;

--- a/network/Message.h
+++ b/network/Message.h
@@ -192,7 +192,7 @@ FO_COMMON_API Message HostIDMessage(int host_player_id);
 FO_COMMON_API Message GameStartMessage(int player_id, bool single_player_game, int empire_id, int current_turn,
                                        const EmpireManager& empires, const Universe& universe,
                                        const SpeciesManager& species, const CombatLogManager& combat_logs,
-                                       const std::map<int, PlayerInfo>& players,
+                                       const SupplyManager& supply, const std::map<int, PlayerInfo>& players,
                                        const GalaxySetupData& galaxy_setup_data, bool use_binary_serialization);
 
 /** creates a GAME_START message.  Contains the initial game state visible to
@@ -200,6 +200,7 @@ FO_COMMON_API Message GameStartMessage(int player_id, bool single_player_game, i
 FO_COMMON_API Message GameStartMessage(int player_id, bool single_player_game, int empire_id, int current_turn,
                                        const EmpireManager& empires, const Universe& universe,
                                        const SpeciesManager& species, const CombatLogManager& combat_logs,
+                                       const SupplyManager& supply,
                                        const std::map<int, PlayerInfo>& players, const OrderSet& orders,
                                        const SaveGameUIData* ui_data,
                                        const GalaxySetupData& galaxy_setup_data, bool use_binary_serialization);
@@ -209,6 +210,7 @@ FO_COMMON_API Message GameStartMessage(int player_id, bool single_player_game, i
 FO_COMMON_API Message GameStartMessage(int player_id, bool single_player_game, int empire_id, int current_turn,
                                        const EmpireManager& empires, const Universe& universe,
                                        const SpeciesManager& species, const CombatLogManager& combat_logs,
+                                       const SupplyManager& supply,
                                        const std::map<int, PlayerInfo>& players, const OrderSet& orders,
                                        const std::string* save_state_string,
                                        const GalaxySetupData& galaxy_setup_data, bool use_binary_serialization);
@@ -238,6 +240,7 @@ FO_COMMON_API Message PlayerStatusMessage(int player_id, int about_player_id, Me
 FO_COMMON_API Message TurnUpdateMessage(int player_id, int empire_id, int current_turn,
                                         const EmpireManager& empires, const Universe& universe,
                                         const SpeciesManager& species, const CombatLogManager& combat_logs,
+                                        const SupplyManager& supply,
                                         const std::map<int, PlayerInfo>& players, bool use_binary_serialization);
 
 /** create a TURN_PARTIAL_UPDATE message. */
@@ -352,6 +355,7 @@ FO_COMMON_API void ExtractMessageData(const Message& msg, MultiplayerLobbyData& 
 FO_COMMON_API void ExtractMessageData(const Message& msg, bool& single_player_game, int& empire_id,
                                       int& current_turn, EmpireManager& empires, Universe& universe,
                                       SpeciesManager& species, CombatLogManager& combat_logs,
+                                      SupplyManager& supply,
                                       std::map<int, PlayerInfo>& players, OrderSet& orders,
                                       bool& loaded_game_data, bool& ui_data_available,
                                       SaveGameUIData& ui_data, bool& save_state_string_available,
@@ -364,7 +368,7 @@ FO_COMMON_API void ExtractMessageData(const Message& msg, OrderSet& orders);
 
 FO_COMMON_API void ExtractMessageData(const Message& msg, int empire_id, int& current_turn, EmpireManager& empires,
                                       Universe& universe, SpeciesManager& species, CombatLogManager& combat_logs,
-                                      std::map<int, PlayerInfo>& players);
+                                      SupplyManager& supply, std::map<int, PlayerInfo>& players);
 
 FO_COMMON_API void ExtractMessageData(const Message& msg, int empire_id, Universe& universe);
 

--- a/parse/DoubleValueRefParser.cpp
+++ b/parse/DoubleValueRefParser.cpp
@@ -48,6 +48,7 @@ namespace {
                 |   tok.Size_
                 |   tok.DistanceFromOriginalType_
                 |   tok.Attack_
+                |   tok.PropegatedSupplyRange_
                 ;
 
             free_variable_name

--- a/parse/EffectParser4.cpp
+++ b/parse/EffectParser4.cpp
@@ -247,18 +247,6 @@ namespace {
             parse::skipper_type
         > create_field_rule;
 
-        typedef boost::spirit::qi::rule<
-            parse::token_iterator,
-            Effect::EffectBase* (),
-            qi::locals<
-                std::string,
-                std::string,
-                std::vector<std::pair<std::string, ValueRef::ValueRefBase<std::string>*> >,
-                EmpireAffiliationType
-            >,
-            parse::skipper_type
-        > generate_sitrep_message_rule;
-
         create_planet_rule              create_planet;
         create_building_rule            create_building;
         create_ship_rule                create_ship_1;

--- a/parse/IntValueRefParser.cpp
+++ b/parse/IntValueRefParser.cpp
@@ -14,6 +14,7 @@ namespace {
             // "NumShips" should not follow.
             bound_variable_name
                 =   tok.Owner_
+                |   tok.SupplyingEmpire_
                 |   tok.ID_
                 |   tok.CreationTurn_
                 |   tok.Age_

--- a/parse/Tokens.h
+++ b/parse/Tokens.h
@@ -444,6 +444,7 @@
     (Structure)                                 \
     (Sum)                                       \
     (Supply)                                    \
+    (SupplyingEmpire)                           \
     (Swamp)                                     \
     (System)                                    \
     (SystemID)

--- a/parse/Tokens.h
+++ b/parse/Tokens.h
@@ -298,8 +298,9 @@
     (Product)                                   \
     (ProductionCenter)                          \
     (ProductionLocation)                        \
-    (Progress)                                  \
-    (Property)
+    (PropegatedSupplyRange)                     \
+    (Property)                                  \
+    (Progress)
 
 #define TOKEN_SEQ_10                            \
     (Radiated)                                  \

--- a/python/EmpireWrapper.cpp
+++ b/python/EmpireWrapper.cpp
@@ -179,10 +179,11 @@ namespace {
     }
 
     std::map<int,int> supplyProjectionsP(const Empire& empire, int min_tracked_supply, bool obstructed) {
-        std::map< int, std::set< int > >    starlanes = empire.KnownStarlanes();
-        std::map<int, int>                  supply_system_ranges(empire.SystemSupplyRanges());
-        std::map<int, int>                  propegating_supply_ranges;
-        const std::set<int>&                supply_unobstructed_systems = empire.SupplyUnobstructedSystems();
+        std::map<int, std::set<int> >   starlanes = empire.KnownStarlanes();
+        std::map<int, float>            supply_system_ranges(empire.SystemSupplyRanges());
+        std::map<int, int>              propegating_supply_ranges;
+        const std::set<int>&            supply_unobstructed_systems = empire.SupplyUnobstructedSystems();
+
         // taking the following sleet_supplyable info into account is necessary to reliably make negative
         // supply projections for an enemy empire into the client empire's territory
         if (min_tracked_supply < 0) {

--- a/python/EmpireWrapper.cpp
+++ b/python/EmpireWrapper.cpp
@@ -102,102 +102,12 @@ namespace {
                                int                                  min_tracked_supply = 0,
                                bool                                 obstructed = true) // Note: must be called with min_tracked_supply = 0 to give the standard result
     {
-        // store supply range in jumps of all unobstructed systems before
-        // propegation, and add to list of systems to propegate from.
-        std::list<int> propegating_systems_list;
-        for (std::map<int, int>::const_iterator it = supply_system_ranges.begin();
-             it != supply_system_ranges.end(); ++it)
-        {
-            if (!obstructed || (supply_unobstructed_systems.find(it->first) != supply_unobstructed_systems.end()))
-                propegating_supply_ranges.insert(*it);
-            else
-                propegating_supply_ranges[it->first] = min_tracked_supply;
-
-            // add system to list of systems to popegate supply from
-            propegating_systems_list.push_back(it->first);
-        }
-
-        // iterate through list of accessible systems, processing each in order it
-        // was added (like breadth first search) until no systems are left able to
-        // further propregate
-        std::list<int>::iterator sys_list_it = propegating_systems_list.begin();
-        std::list<int>::iterator sys_list_end = propegating_systems_list.end();
-        while (sys_list_it != sys_list_end) {
-            int cur_sys_id = *sys_list_it;
-            int cur_sys_range = propegating_supply_ranges[cur_sys_id];    // range away from this system that supplies can be transported
-
-            if (cur_sys_range <= min_tracked_supply) {
-                // can't propegate supply out a system that has no range if min_tracked_supply is zero;
-                // if min_tracked_supply is negative, then may be able to continue propagating. A negative supply 
-                // number indicates number of jumps to nearest supply
-                ++sys_list_it;
-                continue;
-            }
-
-            // can propegate further, if adjacent systems have smaller supply range
-            // than one less than this system's range
-            std::map<int, std::set<int> >::const_iterator system_it = starlanes.find(cur_sys_id);
-            if (system_it == starlanes.end()) {
-                // no starlanes out of this system
-                ++sys_list_it;
-                continue;
-            }
-
-            const std::set<int>& starlane_ends = system_it->second;
-            for (std::set<int>::const_iterator lane_it = starlane_ends.begin();
-                 lane_it != starlane_ends.end(); ++lane_it)
-            {
-                int lane_end_sys_id = *lane_it;
-
-                if (obstructed && (supply_unobstructed_systems.find(lane_end_sys_id) == supply_unobstructed_systems.end())) {
-                    // can't propegate here
-                    continue;
-                }
-
-                // compare next system's supply range to this system's supply range.  propegate if necessary.
-                std::map<int, int>::const_iterator lane_end_sys_it =
-                    propegating_supply_ranges.find(lane_end_sys_id);
-                if (lane_end_sys_it == propegating_supply_ranges.end() ||
-                    lane_end_sys_it->second <= cur_sys_range)
-                {
-                    // next system has no supply yet, or its range equal to or smaller than this system's
-
-                    // update next system's range, if propegating from this system would make it larger
-                    if (lane_end_sys_it == propegating_supply_ranges.end() ||
-                        lane_end_sys_it->second < cur_sys_range - 1)
-                    {
-                        // update with new range
-                        propegating_supply_ranges[lane_end_sys_id] = cur_sys_range - 1;
-                        // add next system to list of systems to propegate further
-                        propegating_systems_list.push_back(lane_end_sys_id);
-                    }
-                }
-            }
-            ++sys_list_it;
-            sys_list_end = propegating_systems_list.end();
-        }
+        // TODO
     }
 
     std::map<int,int> supplyProjectionsP(const Empire& empire, int min_tracked_supply, bool obstructed) {
-        std::map<int, std::set<int> >   starlanes = empire.KnownStarlanes();
-        std::map<int, float>            supply_system_ranges(empire.SystemSupplyRanges());
-        std::map<int, int>              propegating_supply_ranges;
-        const std::set<int>&            supply_unobstructed_systems = empire.SupplyUnobstructedSystems();
-
-        // taking the following sleet_supplyable info into account is necessary to reliably make negative
-        // supply projections for an enemy empire into the client empire's territory
-        if (min_tracked_supply < 0) {
-            const std::set<int>& supplyable_systems = GetSupplyManager().FleetSupplyableSystemIDs(empire.EmpireID());
-            for (std::set<int>::iterator sys_it = supplyable_systems.begin();
-                 sys_it != supplyable_systems.end(); sys_it++)
-            {
-                supply_system_ranges[*sys_it];  // ensures that at least the default value of zero is entered
-            }
-        }
-        // Note: must be called with min_tracked_supply = 0 to give the standard result
-        CalculateSupplyUpdate(starlanes, supply_system_ranges, supply_unobstructed_systems,
-                              propegating_supply_ranges, min_tracked_supply, obstructed);
-        return propegating_supply_ranges;
+        // TODO
+        return std::map<int,int>();
     }
     boost::function<std::map<int,int>(const Empire&, int min_tracked_supply, bool obstructed)> supplyProjectionsFunc =      &supplyProjectionsP;
 

--- a/python/UniverseWrapper.cpp
+++ b/python/UniverseWrapper.cpp
@@ -257,10 +257,13 @@ namespace FreeOrionPython {
         // Container Wrappers //
         ////////////////////////
         class_<std::map<int, int> >("IntIntMap")
-            .def(boost::python::map_indexing_suite<std::map<int, int>, true >())
+            .def(boost::python::map_indexing_suite<std::map<int, int>, true>())
         ;
         class_<std::map<int, double> >("IntDblMap")
-            .def(boost::python::map_indexing_suite<std::map<int, double>,true >())
+            .def(boost::python::map_indexing_suite<std::map<int, double>, true>())
+        ;
+        class_<std::map<int, float> >("IntFltMap")
+            .def(boost::python::map_indexing_suite<std::map<int, float>, true>())
         ;
         class_<std::map<Visibility,int> >("VisibilityIntMap")
             .def(boost::python::map_indexing_suite<std::map<Visibility, int>, true>())

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -2974,7 +2974,15 @@ void ServerApp::PostCombatProcessTurns() {
 
         empire->UpdateSupplyUnobstructedSystems();  // determines which systems can propegate fleet and resource (same for both)
         empire->UpdateSystemSupplyRanges();         // sets range systems can propegate fleet and resourse supply (separately)
-        empire->UpdateSupply();                     // determines which systems can access fleet supply and which groups of systems can exchange resources
+    }
+
+    // TODO: uncomment this when implemented
+    //GetSupplyManager().UpdateSupply();              // determines which systems can access fleet supply and which groups of systems can exchange resources for each empire
+
+    for (EmpireManager::iterator it = empires.begin(); it != empires.end(); ++it) {
+        Empire* empire = it->second;
+        if (empire->Eliminated())
+            continue;   // skip eliminated empires
         empire->InitResourcePools();                // determines population centers and resource centers of empire, tells resource pools the centers and groups of systems that can share resources (note that being able to share resources doesn't mean a system produces resources)
         empire->UpdateResourcePools();              // determines how much of each resources is available in each resource sharing group
     }

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -737,7 +737,15 @@ void ServerApp::NewGameInit(const GalaxySetupData& galaxy_setup_data,
 
         empire->UpdateSupplyUnobstructedSystems();  // determines which systems can propegate fleet and resource (same for both)
         empire->UpdateSystemSupplyRanges();         // sets range systems can propegate fleet and resourse supply (separately)
-        empire->UpdateSupply();                     // determines which systems can access fleet supply and which groups of systems can exchange resources
+    }
+
+    GetSupplyManager().Update();
+
+    for (EmpireManager::iterator it = empires.begin(); it != empires.end(); ++it) {
+        Empire* empire = it->second;
+        if (empire->Eliminated())
+            continue;
+
         empire->InitResourcePools();                // determines population centers and resource centers of empire, tells resource pools the centers and groups of systems that can share resources (note that being able to share resources doesn't mean a system produces resources)
         empire->UpdateResourcePools();              // determines how much of each resources is available in each resource sharing group
     }
@@ -1120,10 +1128,16 @@ void ServerApp::LoadGameInit(const std::vector<PlayerSaveGameData>& player_save_
         Empire* empire = it->second;
         if (empire->Eliminated())
             continue;   // skip eliminated empires.  presumably this shouldn't be an issue when initializing a new game, but apparently I thought this was worth checking for...
-
         empire->UpdateSupplyUnobstructedSystems();  // determines which systems can propegate fleet and resource (same for both)
         empire->UpdateSystemSupplyRanges();         // sets range systems can propegate fleet and resourse supply (separately)
-        empire->UpdateSupply();                     // determines which systems can access fleet supply and which groups of systems can exchange resources
+    }
+
+    GetSupplyManager().Update();
+
+    for (EmpireManager::iterator it = empires.begin(); it != empires.end(); ++it) {
+        Empire* empire = it->second;
+        if (empire->Eliminated())
+            continue;   // skip eliminated empires.  presumably this shouldn't be an issue when initializing a new game, but apparently I thought this was worth checking for...
         empire->InitResourcePools();                // determines population centers and resource centers of empire, tells resource pools the centers and groups of systems that can share resources (note that being able to share resources doesn't mean a system produces resources)
         empire->UpdateResourcePools();              // determines how much of each resources is available in each resource sharing group
     }
@@ -2979,8 +2993,7 @@ void ServerApp::PostCombatProcessTurns() {
         empire->UpdateSystemSupplyRanges();         // sets range systems can propegate fleet and resourse supply (separately)
     }
 
-    // TODO: uncomment this when implemented
-    //GetSupplyManager().UpdateSupply();              // determines which systems can access fleet supply and which groups of systems can exchange resources for each empire
+    GetSupplyManager().Update();
 
     for (EmpireManager::iterator it = empires.begin(); it != empires.end(); ++it) {
         Empire* empire = it->second;

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -286,6 +286,9 @@ EmpireManager& ServerApp::Empires()
 Empire* ServerApp::GetEmpire(int id)
 { return m_empires.GetEmpire(id); }
 
+SupplyManager& ServerApp::GetSupplyManager()
+{ return m_supply_manager; }
+
 TemporaryPtr<UniverseObject> ServerApp::GetUniverseObject(int object_id)
 { return m_universe.Objects().Object(object_id); }
 

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -765,8 +765,8 @@ void ServerApp::NewGameInit(const GalaxySetupData& galaxy_setup_data,
                                                         empire_id,              m_current_turn,
                                                         m_empires,              m_universe,
                                                         GetSpeciesManager(),    GetCombatLogManager(),
-                                                        player_info_map,        m_galaxy_setup_data,
-                                                        use_binary_serialization));
+                                                        GetSupplyManager(),     player_info_map,
+                                                        m_galaxy_setup_data,    use_binary_serialization));
     }
 }
 
@@ -1185,15 +1185,16 @@ void ServerApp::LoadGameInit(const std::vector<PlayerSaveGameData>& player_save_
             player_connection->SendMessage(GameStartMessage(player_id, m_single_player_game, empire_id,
                                                             m_current_turn, m_empires, m_universe,
                                                             GetSpeciesManager(), GetCombatLogManager(),
-                                                            player_info_map, *orders, sss,
+                                                            GetSupplyManager(), player_info_map, *orders, sss,
                                                             m_galaxy_setup_data, use_binary_serialization));
 
         } else if (client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER) {
             player_connection->SendMessage(GameStartMessage(player_id, m_single_player_game, empire_id,
                                                             m_current_turn, m_empires, m_universe,
                                                             GetSpeciesManager(), GetCombatLogManager(),
-                                                            player_info_map, *orders, psgd.m_ui_data.get(),
-                                                            m_galaxy_setup_data, use_binary_serialization));
+                                                            GetSupplyManager(),  player_info_map, *orders,
+                                                            psgd.m_ui_data.get(), m_galaxy_setup_data,
+                                                            use_binary_serialization));
 
         } else if (client_type == Networking::CLIENT_TYPE_HUMAN_OBSERVER ||
                    client_type == Networking::CLIENT_TYPE_HUMAN_MODERATOR)
@@ -1202,8 +1203,8 @@ void ServerApp::LoadGameInit(const std::vector<PlayerSaveGameData>& player_save_
             player_connection->SendMessage(GameStartMessage(player_id, m_single_player_game, ALL_EMPIRES,
                                                             m_current_turn, m_empires, m_universe,
                                                             GetSpeciesManager(), GetCombatLogManager(),
-                                                            player_info_map, m_galaxy_setup_data,
-                                                            use_binary_serialization));
+                                                            GetSupplyManager(), player_info_map,
+                                                            m_galaxy_setup_data, use_binary_serialization));
         } else {
             ErrorLogger() << "ServerApp::CommonGameInit unsupported client type: skipping game start message.";
         }
@@ -3152,8 +3153,8 @@ void ServerApp::PostCombatProcessTurns() {
         player->SendMessage(TurnUpdateMessage(player_id,                PlayerEmpireID(player_id),
                                               m_current_turn,           m_empires,
                                               m_universe,               GetSpeciesManager(),
-                                              GetCombatLogManager(),    players,
-                                              use_binary_serialization));
+                                              GetCombatLogManager(),    GetSupplyManager(),
+                                              players,                  use_binary_serialization));
     }
     DebugLogger() << "ServerApp::PostCombatProcessTurns done";
 }

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -4,6 +4,7 @@
 
 #include "../util/Process.h"
 #include "../Empire/EmpireManager.h"
+#include "../Empire/Supply.h"
 #include "../python/server/ServerFramework.h"
 #include "../network/ServerNetworking.h"
 #include "../universe/Universe.h"
@@ -173,6 +174,7 @@ public:
     Universe&                   GetUniverse();    ///< returns server's copy of Universe
     EmpireManager&              Empires();        ///< returns the server's copy of the Empires
     Empire*                     GetEmpire(int id);
+    SupplyManager&              GetSupplyManager();
     TemporaryPtr<UniverseObject>GetUniverseObject(int object_id);
     ObjectMap&                  EmpireKnownObjects(int empire_id); ///< returns the server's map for known objects of specified empire. */
     TemporaryPtr<UniverseObject>EmpireKnownObject(int object_id, int empire_id);
@@ -266,6 +268,7 @@ private:
 
     Universe                m_universe;
     EmpireManager           m_empires;
+    SupplyManager           m_supply_manager;
     ServerNetworking        m_networking;
     ServerFSM*              m_fsm;
     PythonServer            m_python_server;

--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -18,6 +18,7 @@
 #include "ValueRef.h"
 #include "../Empire/Empire.h"
 #include "../Empire/EmpireManager.h"
+#include "../Empire/Supply.h"
 
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/bind.hpp>
@@ -7265,8 +7266,12 @@ namespace {
             if (!empire)
                 return false;
 
-            const std::set<int>& supplyable_systems = empire->FleetSupplyableSystemIDs();
-            return supplyable_systems.find(candidate->SystemID()) != supplyable_systems.end();
+            const SupplyManager& supply = GetSupplyManager();
+            const std::map<int, std::set<int> >& empire_supplyable_systems = supply.FleetSupplyableSystemIDs();
+            std::map<int, std::set<int> >::const_iterator it = empire_supplyable_systems.find(m_empire_id);
+            if (it == empire_supplyable_systems.end())
+                return false;
+            return it->second.find(candidate->SystemID()) != it->second.find.end();
         }
 
         int m_empire_id;

--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -7271,7 +7271,7 @@ namespace {
             std::map<int, std::set<int> >::const_iterator it = empire_supplyable_systems.find(m_empire_id);
             if (it == empire_supplyable_systems.end())
                 return false;
-            return it->second.find(candidate->SystemID()) != it->second.find.end();
+            return it->second.find(candidate->SystemID()) != it->second.end();
         }
 
         int m_empire_id;
@@ -7376,10 +7376,9 @@ namespace {
                 return false;
             if (m_from_objects.empty())
                 return false;
-            const Empire* empire = GetEmpire(m_empire_id);
-            if (!empire)
+            const std::set<std::set<int> >& groups = GetSupplyManager().ResourceSupplyGroups(m_empire_id);
+            if (groups.empty())
                 return false;
-            const std::set<std::set<int> >& groups = empire->ResourceSupplyGroups();
 
             // is candidate object connected to a subcondition matching object by resource supply?
             for (Condition::ObjectSet::const_iterator it = m_from_objects.begin(); it != m_from_objects.end(); ++it) {

--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -219,9 +219,8 @@ const std::string& Fleet::PublicName(int empire_id) const {
         return UserString("OBJ_FLEET");
 }
 
-const std::list<int>& Fleet::TravelRoute() const {
-    return m_travel_route;
-}
+const std::list<int>& Fleet::TravelRoute() const
+{ return m_travel_route; }
 
 std::list<MovePathNode> Fleet::MovePath(bool flag_blockades /*= false*/) const
 { return MovePath(TravelRoute(), flag_blockades); }

--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -247,7 +247,7 @@ std::list<MovePathNode> Fleet::MovePath(const std::list<int>& route, bool flag_b
 
     // determine all systems where fleet(s) can be resupplied if fuel runs out
     const Empire* empire = GetEmpire(this->Owner());
-    const std::set<int>& fleet_supplied_systems = GetSupplyManager().FleetSupplyableSystemID(this->Owner());
+    const std::set<int>& fleet_supplied_systems = GetSupplyManager().FleetSupplyableSystemIDs(this->Owner());
     const std::set<int>& unobstructed_systems = empire ? empire->SupplyUnobstructedSystems() : EMPTY_SET;
 
     // determine if, given fuel available and supplyable systems, fleet will ever be able to move

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -1657,7 +1657,7 @@ namespace {
     {}
 
     std::pair<bool, Effect::TargetSet>* StoreTargetsAndCausesOfEffectsGroupsWorkItem::ConditionCache::Find(
-        const Condition::ConditionBase* cond, bool insert) 
+        const Condition::ConditionBase* cond, bool insert)
     {
         // have to iterate through cached condition matches, rather than using
         // find, since there is no operator< for comparing conditions by value

--- a/universe/ValueRef.cpp
+++ b/universe/ValueRef.cpp
@@ -16,6 +16,7 @@
 #include "Tech.h"
 #include "../Empire/EmpireManager.h"
 #include "../Empire/Empire.h"
+#include "../Empire/Supply.h"
 #include "../util/Random.h"
 #include "../util/Logger.h"
 #include "../util/MultiplayerCommon.h"
@@ -646,6 +647,13 @@ namespace ValueRef {
                 return fleet->Damage();
             if (TemporaryPtr<const Ship> ship = boost::dynamic_pointer_cast<const Ship>(object))
                 return ship->TotalWeaponsDamage();
+
+        } else if (property_name == "PropegatedSupplyRange") {
+            const std::map<int, float>& ranges = GetSupplyManager().PropegatedSupplyRanges();
+            std::map<int, float>::const_iterator range_it = ranges.find(object->SystemID());
+            if (range_it == ranges.end())
+                return 0.0;
+            return range_it->second;
         }
 
         ErrorLogger() << "Variable<double>::Eval unrecognized object property: "

--- a/universe/ValueRef.h
+++ b/universe/ValueRef.h
@@ -364,10 +364,17 @@ private:
     void serialize(Archive& ar, const unsigned int version);
 };
 
-/** Returns the in-game name of the object with a specified id. */
-struct FO_COMMON_API ValueRef::ObjectNameLookup : public ValueRef::Variable<std::string> {
-    ObjectNameLookup(ValueRef::ValueRefBase<int>* value_ref);
-    ~ObjectNameLookup();
+/** Returns the in-game name of the object / empire / etc. with a specified id. */
+struct FO_COMMON_API ValueRef::NameLookup : public ValueRef::Variable<std::string> {
+    enum LookupType {
+        INVALID_LOOKUP = -1,
+        OBJECT_NAME,
+        EMPIRE_NAME,
+        SHIP_DESIGN_NAME
+    };
+
+    NameLookup(ValueRef::ValueRefBase<int>* value_ref, LookupType lookup_type);
+    ~NameLookup();
 
     virtual bool        operator==(const ValueRef::ValueRefBase<std::string>& rhs) const;
     virtual std::string Eval(const ScriptingContext& context) const;
@@ -378,11 +385,13 @@ struct FO_COMMON_API ValueRef::ObjectNameLookup : public ValueRef::Variable<std:
     virtual std::string Description() const;
     virtual std::string Dump() const;
     const ValueRefBase<int>*    GetValueRef() const { return m_value_ref; }
+    LookupType                  GetLookupType() const { return m_lookup_type; }
 
     virtual void                SetTopLevelContent(const std::string& content_name);
 
 private:
     ValueRefBase<int>*  m_value_ref;
+    LookupType          m_lookup_type;
 
     friend class boost::serialization::access;
     template <class Archive>
@@ -1450,13 +1459,14 @@ void ValueRef::UserStringLookup::serialize(Archive& ar, const unsigned int versi
 }
 
 ///////////////////////////////////////////////////////////
-// ObjectNameLookup                                      //
+// NameLookup                                            //
 ///////////////////////////////////////////////////////////
 template <class Archive>
-void ValueRef::ObjectNameLookup::serialize(Archive& ar, const unsigned int version)
+void ValueRef::NameLookup::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(ValueRefBase<std::string>)
-        & BOOST_SERIALIZATION_NVP(m_value_ref);
+        & BOOST_SERIALIZATION_NVP(m_value_ref)
+        & BOOST_SERIALIZATION_NVP(m_lookup_type);
 }
 
 ///////////////////////////////////////////////////////////

--- a/universe/ValueRefFwd.h
+++ b/universe/ValueRefFwd.h
@@ -38,7 +38,7 @@ namespace ValueRef {
     template <class FromType, class ToType> struct StaticCast;
     template <class FromType> struct StringCast;
     struct UserStringLookup;
-    struct ObjectNameLookup;
+    struct NameLookup;
     template <class T> struct Operation;
     enum OpType {
         PLUS,

--- a/util/AppInterface.h
+++ b/util/AppInterface.h
@@ -8,6 +8,7 @@
 
 class EmpireManager;
 class Empire;
+class SupplyManager;
 class Universe;
 class UniverseObject;
 class ObjectMap;
@@ -32,6 +33,8 @@ public:
     virtual EmpireManager& Empires() = 0; ///< returns the set of known Empires for this application
 
     virtual Empire* GetEmpire(int id) = 0;
+
+    virtual SupplyManager& GetSupplyManager() = 0;
 
     virtual TemporaryPtr<UniverseObject> GetUniverseObject(int object_id) = 0;
 
@@ -75,6 +78,10 @@ inline EmpireManager& Empires()
 /** Accessor for Empires */
 inline Empire* GetEmpire(int id)
 { return IApp::GetApp()->GetEmpire(id); }
+
+/** Accessor for the App's empire supply manager */
+inline SupplyManager& GetSupplyManager()
+{ return IApp::GetApp()->GetSupplyManager(); }
 
 /** Accessor for the App's universe object */
 inline Universe& GetUniverse()

--- a/util/Random.cpp
+++ b/util/Random.cpp
@@ -6,7 +6,7 @@ namespace {
     GeneratorType gen; // the one random number generator driving the distributions below
 }
 
-void Seed(unsigned int seed) { 
+void Seed(unsigned int seed) {
     gen.seed(static_cast<boost::mt19937::result_type>(seed));
 }
 

--- a/util/SerializeEmpire.cpp
+++ b/util/SerializeEmpire.cpp
@@ -108,11 +108,7 @@ void Empire::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_available_hull_types)
         & BOOST_SERIALIZATION_NVP(m_supply_system_ranges)
         & BOOST_SERIALIZATION_NVP(m_supply_unobstructed_systems)
-        & BOOST_SERIALIZATION_NVP(m_supply_starlane_traversals)
-        & BOOST_SERIALIZATION_NVP(m_supply_starlane_obstructed_traversals)
-        & BOOST_SERIALIZATION_NVP(m_available_system_exit_lanes)
-        & BOOST_SERIALIZATION_NVP(m_fleet_supplyable_system_ids)
-        & BOOST_SERIALIZATION_NVP(m_resource_supply_groups);
+        & BOOST_SERIALIZATION_NVP(m_available_system_exit_lanes);
 
     if (GetUniverse().AllObjectsVisible() ||
         GetUniverse().EncodingEmpire() == ALL_EMPIRES ||

--- a/util/SerializeEmpire.cpp
+++ b/util/SerializeEmpire.cpp
@@ -197,7 +197,8 @@ void SupplyManager::serialize(Archive& ar, const unsigned int version)
     ar  & BOOST_SERIALIZATION_NVP(m_supply_starlane_traversals)
         & BOOST_SERIALIZATION_NVP(m_supply_starlane_obstructed_traversals)
         & BOOST_SERIALIZATION_NVP(m_fleet_supplyable_system_ids)
-        & BOOST_SERIALIZATION_NVP(m_resource_supply_groups);
+        & BOOST_SERIALIZATION_NVP(m_resource_supply_groups)
+        & BOOST_SERIALIZATION_NVP(m_propegated_supply_ranges);
 }
 
 template void SupplyManager::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, const unsigned int);

--- a/util/SerializeEmpire.cpp
+++ b/util/SerializeEmpire.cpp
@@ -4,6 +4,7 @@
 #include "SitRepEntry.h"
 #include "../Empire/Empire.h"
 #include "../Empire/EmpireManager.h"
+#include "../Empire/Supply.h"
 #include "../Empire/Diplomacy.h"
 #include "../universe/Universe.h"
 
@@ -190,3 +191,16 @@ template void DiplomaticMessage::serialize<freeorion_bin_iarchive>(freeorion_bin
 template void DiplomaticMessage::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, const unsigned int);
 template void DiplomaticMessage::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
 
+template <class Archive>
+void SupplyManager::serialize(Archive& ar, const unsigned int version)
+{
+    ar  & BOOST_SERIALIZATION_NVP(m_supply_starlane_traversals)
+        & BOOST_SERIALIZATION_NVP(m_supply_starlane_obstructed_traversals)
+        & BOOST_SERIALIZATION_NVP(m_fleet_supplyable_system_ids)
+        & BOOST_SERIALIZATION_NVP(m_resource_supply_groups);
+}
+
+template void SupplyManager::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, const unsigned int);
+template void SupplyManager::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, const unsigned int);
+template void SupplyManager::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, const unsigned int);
+template void SupplyManager::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);


### PR DESCRIPTION
Reworks supply propegation so that any system is only supplied by at most one empire, and one empire's supply can push back another's, depending on their supply ranges at the source systems.

Needs Python / AI input on how to rework the CalculateSupplyUpdate and supplyProjectionsP functions in EmpireWrapper, as these appeared to use a slightly modified version of the old supply propegation to calculate how far, in jumps, a system was from a fleet-supplyable system for an empire, but the new supply calculation doesn't really make sense to use in that way. A simple calculation of jump distance to a supplyable system could be implemented if needed.
