### PR TITLE
Add docstrings to python wrapper

### DIFF
--- a/python/AI/AIWrapper.cpp
+++ b/python/AI/AIWrapper.cpp
@@ -112,26 +112,26 @@ namespace FreeOrionPython {
      */
     void WrapAI()
     {
-        def("playerName",               AIIntPlayerNameVoid,            return_value_policy<copy_const_reference>());
-        def("playerName",               AIIntPlayerNameInt,             return_value_policy<copy_const_reference>());
+        def("playerName",               AIIntPlayerNameVoid,            return_value_policy<copy_const_reference>(), "Returns the name (string) of this AI player.");
+        def("playerName",               AIIntPlayerNameInt,             return_value_policy<copy_const_reference>(), "Returns the name (string) of the player with the indicated playerID (int).");
 
-        def("playerID",                 AIInterface::PlayerID);
-        def("empirePlayerID",           AIInterface::EmpirePlayerID);
-        def("allPlayerIDs",             AIInterface::AllPlayerIDs,      return_value_policy<return_by_value>());
+        def("playerID",                 AIInterface::PlayerID, "Returns the integer id of this AI player.");
+        def("empirePlayerID",           AIInterface::EmpirePlayerID, "Returns the player ID (int) of the player who is controlling the empire with the indicated empireID (int).");
+        def("allPlayerIDs",             AIInterface::AllPlayerIDs,      return_value_policy<return_by_value>(), "Returns an object (intVec) that contains the player IDs of all players in the game.");
 
-        def("playerIsAI",               AIInterface::PlayerIsAI);
-        def("playerIsHost",             AIInterface::PlayerIsHost);
+        def("playerIsAI",               AIInterface::PlayerIsAI, "Returns True (boolean) if the player with the indicated playerID (int) is controlled by an AI and false (boolean) otherwise.");
+        def("playerIsHost",             AIInterface::PlayerIsHost, "Returns True (boolean) if the player with the indicated playerID (int) is the host player for the game and false (boolean) otherwise.");
 
-        def("empireID",                 AIInterface::EmpireID);
-        def("playerEmpireID",           AIInterface::PlayerEmpireID);
-        def("allEmpireIDs",             AIInterface::AllEmpireIDs,      return_value_policy<return_by_value>());
+        def("empireID",                 AIInterface::EmpireID, "Returns the empire ID (int) of this AI player's empire.");
+        def("playerEmpireID",           AIInterface::PlayerEmpireID, "Returns the empire ID (int) of the player with the specified player ID (int).");
+        def("allEmpireIDs",             AIInterface::AllEmpireIDs,      return_value_policy<return_by_value>(), "Returns an object (intVec) that contains the empire IDs of all empires in the game.");
 
-        def("getEmpire",                AIIntGetEmpireVoid,             return_value_policy<reference_existing_object>());
-        def("getEmpire",                AIIntGetEmpireInt,              return_value_policy<reference_existing_object>());
+        def("getEmpire",                AIIntGetEmpireVoid,             return_value_policy<reference_existing_object>(), "Returns the empire object (Empire) of this AI player");
+        def("getEmpire",                AIIntGetEmpireInt,              return_value_policy<reference_existing_object>(), "Returns the empire object (Empire) with the specified empire ID (int)");
 
-        def("getUniverse",              AIInterface::GetUniverse,       return_value_policy<reference_existing_object>());
+        def("getUniverse",              AIInterface::GetUniverse,       return_value_policy<reference_existing_object>(), "Returns the universe object (Universe)");
 
-        def("currentTurn",              AIInterface::CurrentTurn);
+        def("currentTurn",              AIInterface::CurrentTurn, "Returns the current game turn (int).");
 
         def("getAIConfigStr",           AIInterface::GetAIConfigStr,    return_value_policy<return_by_value>());
         def("getAIDir",                 AIInterface::GetAIDir,          return_value_policy<return_by_value>());
@@ -143,33 +143,33 @@ namespace FreeOrionPython {
         def("updateResearchQueue",                  AIInterface::UpdateResearchQueue);
         def("updateProductionQueue",                AIInterface::UpdateProductionQueue);
 
-        def("issueFleetMoveOrder",                  AIInterface::IssueFleetMoveOrder);
-        def("issueRenameOrder",                     AIInterface::IssueRenameOrder);
-        def("issueScrapOrder",                      AIIntScrap);
-        def("issueNewFleetOrder",                   AIIntNewFleet);
-        def("issueFleetTransferOrder",              AIInterface::IssueFleetTransferOrder);
-        def("issueColonizeOrder",                   AIInterface::IssueColonizeOrder);
-        def("issueInvadeOrder",                     AIInterface::IssueInvadeOrder);
-        def("issueBombardOrder",                    AIInterface::IssueBombardOrder);
+        def("issueFleetMoveOrder",                  AIInterface::IssueFleetMoveOrder, "Orders the fleet with indicated fleetID (int) to move to the system with the indicated destinationID (int). Returns 1 (int) on success or 0 (int) on failure due to not finding the indicated fleet or system.");
+        def("issueRenameOrder",                     AIInterface::IssueRenameOrder, "Orders the renaming of the object with indicated objectID (int) to the new indicated name (string). Returns 1 (int) on success or 0 (int) on failure due to this AI player not being able to rename the indicated object (which this player must fully own, and which must be a fleet, ship or planet).");
+        def("issueScrapOrder",                      AIIntScrap, "Orders the ship or building with the indicated objectID (int) to be scrapped. Returns 1 (int) on success or 0 (int) on failure due to not finding a ship or building with the indicated ID, or if the indicated ship or building is not owned by this AI client's empire.");
+        def("issueNewFleetOrder",                   AIIntNewFleet, "Orders a new fleet to be created with the indicated name (string) and containing the indicated shipIDs (IntVec). The ships must be located in the same system and must all be owned by this player. Returns 1 (int) on success or 0 (int) on failure due to one of the noted conditions not being met.");
+        def("issueFleetTransferOrder",              AIInterface::IssueFleetTransferOrder, "Orders the ship with ID shipID (int) to be transferred to the fleet with ID newFleetID. Returns 1 (int) on success, or 0 (int) on failure due to not finding the fleet or ship, or the client's empire not owning either, or the two not being in the same system (or either not being in a system) or the ship already being in the fleet.");
+        def("issueColonizeOrder",                   AIInterface::IssueColonizeOrder, "Orders the ship with ID shipID (int) to colonize the planet with ID planetID (int). Returns 1 (int) on success or 0 (int) on failure due to not finding the indicated ship or planet, this client's player not owning the indicated ship, the planet already being colonized, or the planet and ship not being in the same system.");
+        def("issueInvadeOrder",                     AIInterface::IssueInvadeOrder, "");
+        def("issueBombardOrder",                    AIInterface::IssueBombardOrder, "");
         def("issueAggressionOrder",                 AIInterface::IssueAggressionOrder);
         def("issueGiveObjectToEmpireOrder",         AIInterface::IssueGiveObjectToEmpireOrder);
-        def("issueChangeFocusOrder",                AIInterface::IssueChangeFocusOrder);
-        def("issueEnqueueTechOrder",                AIInterface::IssueEnqueueTechOrder);
-        def("issueDequeueTechOrder",                AIInterface::IssueDequeueTechOrder);
-        def("issueEnqueueBuildingProductionOrder",  AIInterface::IssueEnqueueBuildingProductionOrder);
-        def("issueEnqueueShipProductionOrder",      AIInterface::IssueEnqueueShipProductionOrder);
+        def("issueChangeFocusOrder",                AIInterface::IssueChangeFocusOrder, "Orders the planet with ID planetID (int) to use focus setting focus (string). Returns 1 (int) on success or 0 (int) on failure if the planet can't be found or isn't owned by this player, or if the specified focus is not valid on the planet.");
+        def("issueEnqueueTechOrder",                AIInterface::IssueEnqueueTechOrder, "Orders the tech with name techName (string) to be added to the tech queue at position (int) on the queue. Returns 1 (int) on success or 0 (int) on failure if the indicated tech can't be found. Will return 1 (int) but do nothing if the indicated tech can't be enqueued by this player's empire.");
+        def("issueDequeueTechOrder",                AIInterface::IssueDequeueTechOrder, "Orders the tech with name techName (string) to be removed from the queue. Returns 1 (int) on success or 0 (int) on failure if the indicated tech can't be found. Will return 1 (int) but do nothing if the indicated tech isn't on this player's empire's tech queue.");
+        def("issueEnqueueBuildingProductionOrder",  AIInterface::IssueEnqueueBuildingProductionOrder, "Orders the building with name (string) to be added to the production queue at the location of the planet with id locationID. Returns 1 (int) on success or 0 (int) on failure if there is no such building or it is not available to this player's empire, or if the building can't be produced at the specified location.");
+        def("issueEnqueueShipProductionOrder",      AIInterface::IssueEnqueueShipProductionOrder, "Orders the ship design with ID designID (int) to be added to the production queue at the location of the planet with id locationID (int). Returns 1 (int) on success or 0 (int) on failure there is no such ship design or it not available to this player's empire, or if the design can't be produced at the specified location.");
         def("issueChangeProductionQuantityOrder",   AIInterface::IssueChangeProductionQuantityOrder);
-        def("issueRequeueProductionOrder",          AIInterface::IssueRequeueProductionOrder);
-        def("issueDequeueProductionOrder",          AIInterface::IssueDequeueProductionOrder);
-        def("issueCreateShipDesignOrder",           IssueCreateShipDesignOrderWrapper);
+        def("issueRequeueProductionOrder",          AIInterface::IssueRequeueProductionOrder, "Orders the item on the production queue at index oldQueueIndex (int) to be moved to index newQueueIndex (int). Returns 1 (int) on success or 0 (int) on failure if the old and new queue indices are equal, if either queue index is less than 0 or greater than the largest indexed item on the queue.");
+        def("issueDequeueProductionOrder",          AIInterface::IssueDequeueProductionOrder, "Orders the item on the production queue at index queueIndex (int) to be removed form the production queue. Returns 1 (int) on success or 0 (int) on failure if the queue index is less than 0 or greater than the largest indexed item on the queue.");
+        def("issueCreateShipDesignOrder",           IssueCreateShipDesignOrderWrapper, "Orders the creation of a new ship design with the name (string), description (string), hull (string), parts vector partsVec (StringVec), graphic (string) and model (string). model should be left as an empty string as of this writing. There is currently no easy way to find the id of the new design, though the client's empire should have the new design after this order is issued successfully. Returns 1 (int) on success or 0 (int) on failure if any of the name, description, hull or graphic are empty strings, if the design is invalid (due to not following number and type of slot requirements for the hull) or if creating the design fails for some reason.");
 
-        def("sendChatMessage",          AIInterface::SendPlayerChatMessage);
+        def("sendChatMessage",          AIInterface::SendPlayerChatMessage, "Sends the indicated message (string) to the player with the indicated recipientID (int) or to all players if recipientID is -1.");
         def("sendDiplomaticMessage",    AIInterface::SendDiplomaticMessage);
 
-        def("setSaveStateString",       SetStaticSaveStateString);
-        def("getSaveStateString",       GetStaticSaveStateString,       return_value_policy<copy_const_reference>());
+        def("setSaveStateString",       SetStaticSaveStateString, "Sets the save state string (string). This is a persistant storage space for the AI script to retain state information when the game is saved and reloaded. Any AI state information to be saved should be stored in a single string (likely using Python's pickle module) and stored using this function when the prepareForSave() Python function is called.");
+        def("getSaveStateString",       GetStaticSaveStateString,       return_value_policy<copy_const_reference>(), "Returns the previously-saved state string (string). Can be used to retrieve the last-set save state string at any time, although this string is also passed to the resumeLoadedGame(savedStateString) Python function when a game is loaded, so this function isn't necessary to use if resumeLoadedGame stores the passed string. ");
 
-        def("doneTurn",                 AIInterface::DoneTurn);
+        def("doneTurn",                 AIInterface::DoneTurn, "Ends the AI player's turn, indicating to the server that all orders have been issued and turn processing may commence.");
         def("userString",               make_function(&UserString,          return_value_policy<copy_const_reference>()));
         def("userStringExists",         make_function(&UserStringExists,    return_value_policy<return_by_value>()));
         def("userStringList",           &GetUserStringList);

--- a/python/EmpireWrapper.cpp
+++ b/python/EmpireWrapper.cpp
@@ -501,18 +501,18 @@ namespace FreeOrionPython {
                                                         boost::mpl::vector<std::vector<std::string>, const Tech&, int>()
                                                     ))
         ;
-        def("getTech",                              &GetTech,                               return_value_policy<reference_existing_object>());
-        def("getTechCategories",                    &TechManager::CategoryNames,            return_value_policy<return_by_value>());
+        def("getTech",                              &GetTech,                               return_value_policy<reference_existing_object>(), "Returns the tech (Tech) with the indicated name (string).");
+        def("getTechCategories",                    &TechManager::CategoryNames,            return_value_policy<return_by_value>(), "Returns the names of all tech categories (StringVec).");
         def("techs",                                make_function(
                                                         boost::bind(TechNamesMemberFunc, &(GetTechManager())),
                                                         return_value_policy<return_by_value>(),
                                                         boost::mpl::vector<std::vector<std::string> >()
-                                                    ));
+                                                    ), "Returns the names of all techs (StringVec).");
         def("techsInCategory",                      make_function(
                                                         boost::bind(TechNamesCategoryMemberFunc, &(GetTechManager()), _1),
                                                         return_value_policy<return_by_value>(),
                                                         boost::mpl::vector<std::vector<std::string>, const std::string&>()
-                                                    ));
+                                                    ), "Returns the names of all techs (StringVec) in the indicated tech category name (string).");
         class_<ItemSpec>("itemSpec")
             .add_property("type",               &ItemSpec::type)
             .add_property("name",               &ItemSpec::name)

--- a/python/EmpireWrapper.cpp
+++ b/python/EmpireWrapper.cpp
@@ -501,18 +501,22 @@ namespace FreeOrionPython {
                                                         boost::mpl::vector<std::vector<std::string>, const Tech&, int>()
                                                     ))
         ;
+
         def("getTech",                              &GetTech,                               return_value_policy<reference_existing_object>(), "Returns the tech (Tech) with the indicated name (string).");
         def("getTechCategories",                    &TechManager::CategoryNames,            return_value_policy<return_by_value>(), "Returns the names of all tech categories (StringVec).");
-        def("techs",                                make_function(
-                                                        boost::bind(TechNamesMemberFunc, &(GetTechManager())),
-                                                        return_value_policy<return_by_value>(),
-                                                        boost::mpl::vector<std::vector<std::string> >()
-                                                    ), "Returns the names of all techs (StringVec).");
-        def("techsInCategory",                      make_function(
-                                                        boost::bind(TechNamesCategoryMemberFunc, &(GetTechManager()), _1),
-                                                        return_value_policy<return_by_value>(),
-                                                        boost::mpl::vector<std::vector<std::string>, const std::string&>()
-                                                    ), "Returns the names of all techs (StringVec) in the indicated tech category name (string).");
+
+        boost::python::object techsFunc = make_function(boost::bind(TechNamesMemberFunc, &(GetTechManager())),
+                                                        return_value_policy<boost::python::return_by_value>(),
+                                                        boost::mpl::vector<std::vector<std::string> >());
+        boost::python::setattr(techsFunc, "__doc__", boost::python::str("Returns the names of all techs (StringVec)."));
+        def("techs", techsFunc);
+
+        boost::python::object techsInCategoryFunc = make_function(boost::bind(TechNamesCategoryMemberFunc, &(GetTechManager()), _1),
+                                                                  return_value_policy<return_by_value>(),
+                                                                  boost::mpl::vector<std::vector<std::string>, const std::string&>());
+        boost::python::setattr(techsInCategoryFunc, "__doc__", boost::python::str("Returns the names of all techs (StringVec) in the indicated tech category name (string)."));
+        def("techsInCategory", techsInCategoryFunc);
+
         class_<ItemSpec>("itemSpec")
             .add_property("type",               &ItemSpec::type)
             .add_property("name",               &ItemSpec::name)

--- a/python/UniverseWrapper.cpp
+++ b/python/UniverseWrapper.cpp
@@ -498,9 +498,9 @@ namespace FreeOrionPython {
             .def("productionLocationForEmpire", &ShipDesign::ProductionLocation)
             .add_property("dump",               &ShipDesign::Dump)
         ;
-        def("validShipDesign",                  ValidDesignHullAndParts);
-        def("validShipDesign",                  ValidDesignDesign);
-        def("getShipDesign",                    &GetShipDesign,                             return_value_policy<reference_existing_object>());
+        def("validShipDesign",                  ValidDesignHullAndParts, "Returns true (boolean) if the passed hull (string) and parts (StringVec) make up a valid ship design, and false (boolean) otherwise. Valid ship designs don't have any parts in slots that can't accept that type of part, and contain only hulls and parts that exist (and may also need to contain the correct number of parts - this needs to be verified).");
+        def("validShipDesign",                  ValidDesignDesign, "Returns true (boolean) if the passed ship design (ShipDesign) is valid, and false otherwise.");
+        def("getShipDesign",                    &GetShipDesign,                             return_value_policy<reference_existing_object>(), "Returns the ship design (ShipDesign) with the indicated id number (int).");
 
         class_<PartType, noncopyable>("partType", no_init)
             .add_property("name",               make_function(&PartType::Name,              return_value_policy<copy_const_reference>()))
@@ -513,7 +513,7 @@ namespace FreeOrionPython {
             .add_property("costTimeLocationInvariant",
                                                 &PartType::ProductionCostTimeLocationInvariant)
         ;
-        def("getPartType",                      &GetPartType,                               return_value_policy<reference_existing_object>());
+        def("getPartType",                      &GetPartType,                               return_value_policy<reference_existing_object>(), "Returns the ship part (PartType) with the indicated name (string).");
 
         class_<HullType, noncopyable>("hullType", no_init)
             .add_property("name",               make_function(&HullType::Name,              return_value_policy<copy_const_reference>()))
@@ -534,7 +534,7 @@ namespace FreeOrionPython {
             .add_property("costTimeLocationInvariant",
                                                 &HullType::ProductionCostTimeLocationInvariant)
         ;
-        def("getHullType",                      &GetHullType,                               return_value_policy<reference_existing_object>());
+        def("getHullType",                      &GetHullType,                               return_value_policy<reference_existing_object>(), "Returns the ship hull (HullType) with the indicated name (string).");
 
         //////////////////
         //   Building   //
@@ -562,7 +562,7 @@ namespace FreeOrionPython {
                                                 &BuildingType::ProductionCostTimeLocationInvariant)
             .add_property("dump",               &BuildingType::Dump)
         ;
-        def("getBuildingType",                  &GetBuildingType,                           return_value_policy<reference_existing_object>());
+        def("getBuildingType",                  &GetBuildingType,                           return_value_policy<reference_existing_object>(), "Returns the building type (BuildingType) with the indicated name (string).");
         ////////////////////
         // ResourceCenter //
         ////////////////////
@@ -651,7 +651,7 @@ namespace FreeOrionPython {
             .add_property("dump",               &Special::Dump)
             .def("initialCapacity",             SpecialInitialCapacityOnObject)
         ;
-        def("getSpecial",                       &GetSpecial,                            return_value_policy<reference_existing_object>());
+        def("getSpecial",                       &GetSpecial,                            return_value_policy<reference_existing_object>(), "Returns the special (Special) with the indicated name (string).");
 
         /////////////////
         //   Species   //
@@ -669,7 +669,7 @@ namespace FreeOrionPython {
             .def("getPlanetEnvironment",        &Species::GetPlanetEnvironment)
             .add_property("dump",               &Species::Dump)
         ;
-        def("getSpecies",                       &GetSpecies,                            return_value_policy<reference_existing_object>());
+        def("getSpecies",                       &GetSpecies,                            return_value_policy<reference_existing_object>(), "Returns the species (Species) with the indicated name (string).");
     }
 
     void WrapGalaxySetupData() {


### PR DESCRIPTION
Its bad to have code and docs in different places. 

I copy paste docs for section `Free Functions` from here: http://freeorion.org/index.php/AI_Python_API and fix some.

After merge of this PR I plan to move other docs and remove API reference from this page.

PS. I don't compile game. And I don't know about c++ style and how to format long lines. 

PPS.  In example of python docstrings produces by boost I see that it is possible to have variable name in python:

http://www.boost.org/doc/libs/1_54_0/libs/python/doc/v2/docstring_options.html

```
foo1( (int)i) -> int : foo1 doc
C++ signature:
    foo1(int i) -> int
```

Freeorion code does not have variable name in docstrings:

```
C++ signature:
        boost::python::list userStringList(std::string)
```

It will be great to have one.
