### PR TITLE
shiphulls without slots in shipdesigns - optional shipparts

### DIFF
--- a/parse/ShipDesignsParser.cpp
+++ b/parse/ShipDesignsParser.cpp
@@ -70,10 +70,12 @@ namespace {
 
             design
                 =    design_prefix(_a, _b, _c, _f)
-                >    parse::label(Parts_token)
-                >    (
+                >    -(
+                         parse::label(Parts_token)
+                     >   (
                             '[' > +tok.string [ push_back(_d, _1) ] > ']'
-                        |   tok.string [ push_back(_d, _1) ]
+                         |   tok.string [ push_back(_d, _1) ]
+                         )
                      )
                 >   -(
                         parse::label(Icon_token)     > tok.string [ _e = _1 ]

--- a/parse/ShipHullsParser.cpp
+++ b/parse/ShipHullsParser.cpp
@@ -107,7 +107,7 @@ namespace {
                             '[' > +slot [ push_back(_r1, _1) ] > ']'
                             |   slot [ push_back(_r1, _1) ]
                         )
-                     )
+                    )
                 ;
 
             location

--- a/parse/test/ship_designs
+++ b/parse/test/ship_designs
@@ -1,2 +1,3 @@
 ShipDesign  Name = "Foo 0"  Description = "Bar"  Hull = "Foo"  Parts = "Foo"  Icon = "Baz"  Model = "Baz"
 ShipDesign  Name = "Foo 1"  Description = "Bar"  Hull = "Foo"  Parts = [ "Foo" "Foo" ]  Model = "Baz"
+ShipDesign  Name = "Foo 2"  Description = "Bar"  Hull = "Foo"  Model = "Baz"

--- a/parse/test/ship_designs_errors
+++ b/parse/test/ship_designs_errors
@@ -34,3 +34,15 @@ ShipDesign Name = "Foo 1" Description = "Bar" Hull = "Foo" Parts = [ "Foo" "Foo"
 ShipDesign Name = "Foo 1" Description = "Bar" Hull = "Foo" Parts = [ "Foo" "Foo" ] Graphic = "Baz"
 ShipDesign Name = "Foo 1" Description = "Bar" Hull = "Foo" Parts = [ "Foo" "Foo" ] Graphic = "Baz" Model
 ShipDesign Name = "Foo 1" Description = "Bar" Hull = "Foo" Parts = [ "Foo" "Foo" ] Graphic = "Baz" Model =
+ShipDesign Name = "Foo 2"
+ShipDesign Name = "Foo 2" Description
+ShipDesign Name = "Foo 2" Description =
+ShipDesign Name = "Foo 2" Description = "Bar"
+ShipDesign Name = "Foo 2" Description = "Bar" Hull
+ShipDesign Name = "Foo 2" Description = "Bar" Hull =
+ShipDesign Name = "Foo 2" Description = "Bar" Hull = "Foo"
+ShipDesign Name = "Foo 2" Description = "Bar" Hull = "Foo" Graphic
+ShipDesign Name = "Foo 2" Description = "Bar" Hull = "Foo" Graphic =
+ShipDesign Name = "Foo 2" Description = "Bar" Hull = "Foo" Graphic = "Baz"
+ShipDesign Name = "Foo 2" Description = "Bar" Hull = "Foo" Graphic = "Baz" Model
+ShipDesign Name = "Foo 2" Description = "Bar" Hull = "Foo" Graphic = "Baz" Model =

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -941,19 +941,19 @@ std::string ShipDesign::Dump() const {
     if (!m_name_desc_in_stringtable)
         retval += DumpIndent() + "NoStringtableLookup\n";
     retval += DumpIndent() + "hull = \"" + m_hull + "\"\n";
-    retval += DumpIndent() + "parts = ";
-    if (m_parts.empty()) {
-        retval += "[]\n";
-    } else if (m_parts.size() == 1) {
-        retval += "\"" + *m_parts.begin() + "\"\n";
-    } else {
-        retval += "[\n";
-        ++g_indent;
-        for (std::vector<std::string>::const_iterator it = m_parts.begin(); it != m_parts.end(); ++it) {
-            retval += DumpIndent() + "\"" + *it + "\"\n";
+    if (!m_parts.empty()) {
+        retval += DumpIndent() + "parts = ";
+        if (m_parts.size() == 1) {
+            retval += "\"" + *m_parts.begin() + "\"\n";
+        } else {
+            retval += "[\n";
+            ++g_indent;
+            for (std::vector<std::string>::const_iterator it = m_parts.begin(); it != m_parts.end(); ++it) {
+                retval += DumpIndent() + "\"" + *it + "\"\n";
+            }
+            --g_indent;
+            retval += DumpIndent() + "]\n";
         }
-        --g_indent;
-        retval += DumpIndent() + "]\n";
     }
     if (!m_icon.empty())
         retval += DumpIndent() + "icon = \"" + m_icon + "\"\n";


### PR DESCRIPTION
- making shipparts optional for the parser so it accepts shipdesigns
  containing a shiphull that does not have any slots and so no parts
- storing custom shipdesigns will only write out shipparts if present
