### PR TITLE
Added human client backtrace to CMakefile

### DIFF
--- a/client/human/CMakeLists.txt
+++ b/client/human/CMakeLists.txt
@@ -21,6 +21,12 @@ if(WIN32)
     find_package(GLEW REQUIRED)
 endif()
 
+if (CMAKE_BUILD_TYPE STREQUAL "Debug")
+  add_definitions(
+    -DENABLE_CRASH_BACKTRACE
+    )
+endif()
+
 include_directories(
     ${OPENGL_INCLUDE_DIR}
     ${GLEW_INCLUDE_DIRS}
@@ -224,4 +230,3 @@ install(
     DESTINATION share/freeorion
     COMPONENT COMPONENT_FREEORION
 )
-

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -185,6 +185,7 @@ HumanClientApp::HumanClientApp(int width, int height, bool calculate_fps, const 
 {
 #ifdef ENABLE_CRASH_BACKTRACE
     signal(SIGSEGV, SigHandler);
+    DebugLogger() << "Human Client Crash Backtrace enabled. ";
 #endif
 #ifdef FREEORION_MACOSX
     SDL_SetHint(SDL_HINT_MAC_CTRL_CLICK_EMULATE_RIGHT_CLICK, "1");


### PR DESCRIPTION
This added the crash backtrace that was already in the code to the CMakeLists.txt so that it is included in debug builds.
