### PR TITLE
Add design window replace blueprint

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -2107,7 +2107,7 @@ const std::map<int, std::set<int> > Empire::VisibleStarlanes() const {
 }
 
 Empire::ShipDesignItr Empire::ShipDesignBegin() const
-{return m_ship_designs_ordered.begin(); }
+{ return m_ship_designs_ordered.begin(); }
 
 Empire::ShipDesignItr Empire::ShipDesignEnd() const
 { return m_ship_designs_ordered.end(); }

--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -2542,11 +2542,8 @@ int Empire::AddShipDesign(ShipDesign* ship_design) {
         if (ship_design == it->second) {
             // ship design is already present in universe.  just need to add it to the empire's set of ship designs
             int ship_design_id = it->first;
-            if (m_ship_designs.find(ship_design_id) == m_ship_designs.end()) {
-                m_ship_designs_ordered.insert(m_ship_designs_ordered.end(), ship_design_id);
-                m_ship_designs.insert(ship_design_id);
-            }
-            return it->first;
+            AddShipDesign(ship_design_id);
+            return ship_design_id;
         }
     }
 
@@ -2565,13 +2562,7 @@ int Empire::AddShipDesign(ShipDesign* ship_design) {
         return INVALID_OBJECT_ID;
     }
 
-    if (GetOptionsDB().Get<bool>("verbose-logging"))
-        DebugLogger() << "AddShipDesign::  "<<ship_design->Name()<< " ("<<new_design_id<<") to empire #"<<EmpireID();
-
-    m_ship_designs_ordered.insert(m_ship_designs_ordered.end(), new_design_id);
-    m_ship_designs.insert(new_design_id);
-
-    ShipDesignsChangedSignal();
+    AddShipDesign(new_design_id);
 
     return new_design_id;
 }

--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -5,6 +5,7 @@
 #include "ResourcePool.h"
 #include "../util/Export.h"
 #include "../universe/Meter.h"
+#include "../universe/ShipDesign.h"
 
 #include <GG/Clr.h>
 
@@ -444,7 +445,9 @@ public:
     void        AddPartType(const std::string& name);       ///< Inserts the given ship PartType into the Empire's list of available BuldingTypes.
     void        AddHullType(const std::string& name);       ///< Inserts the given ship HullType into the Empire's list of available BuldingTypes.
     void        AddExploredSystem(int ID);                  ///< Inserts the given ID into the Empire's list of explored systems.
-    void        AddShipDesign(int ship_design_id);          ///< inserts given design id into the empire's set of designs
+
+    /** inserts given design id into the empire's set of designs in front of next design */
+    void        AddShipDesign(int ship_design_id, int next_design_id = ShipDesign::INVALID_DESIGN_ID);
     int         AddShipDesign(ShipDesign* ship_design);     ///< inserts given ShipDesign into the Universe, adds the design's id to the Empire's set of ids, and returns the new design's id, which is INVALID_OBJECT_ID on failure.  If successful, universe takes ownership of passed ShipDesign.
 
     std::string NewShipName();                              ///< generates a random ship name, appending II, III, etc., to it if it has been used before by this empire

--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -279,7 +279,7 @@ public:
     typedef std::set<std::string>::const_iterator       TechItr;
     typedef std::set<std::string>::const_iterator       BuildingTypeItr;
     typedef std::set<int>::const_iterator               SystemIDItr;
-    typedef std::set<int>::const_iterator               ShipDesignItr;
+    typedef std::list<int>::const_iterator              ShipDesignItr;
     typedef std::vector<SitRepEntry>::const_iterator    SitRepItr;
     //@}
 
@@ -611,7 +611,8 @@ private:
     std::set<std::string>           m_available_part_types;     ///< list of acquired ship PartType.  These are string names referencing PartType objects
     std::set<std::string>           m_available_hull_types;     ///< list of acquired ship HullType.  These are string names referencing HullType objects
     std::set<int>                   m_explored_systems;         ///< systems you've explored
-    std::set<int>                   m_ship_designs;             ///< The Empire's ship designs, indexed by design id
+    std::set<int>                   m_ship_designs;             ///< The Empire's ship designs sorted by id
+    std::list<int>                  m_ship_designs_ordered;     ///<The Empire's ship designs in preferred order
 
     std::vector<SitRepEntry>        m_sitrep_entries;           ///< The Empire's sitrep entries
 

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -2709,7 +2709,7 @@ DesignWnd::MainPanel::MainPanel(const std::string& config_name) :
     m_design_name = new CUIEdit(UserString("DESIGN_NAME_DEFAULT"));
     m_design_description_label = new CUILabel(UserString("DESIGN_WND_DESIGN_DESCRIPTION"), GG::FORMAT_RIGHT, GG::INTERACTIVE);
     m_design_description = new CUIEdit(UserString("DESIGN_DESCRIPTION_DEFAULT"));
-    m_replace_button = new CUIButton(UserString("DESIGN_WND_REPLACE"));
+    m_replace_button = new CUIButton(UserString("DESIGN_WND_UPDATE"));
     m_confirm_button = new CUIButton(UserString("DESIGN_WND_ADD"));
     m_clear_button = new CUIButton(UserString("DESIGN_WND_CLEAR"));
 
@@ -3134,7 +3134,7 @@ void DesignWnd::MainPanel::DesignChanged() {
 
     if (!m_hull) {
         m_replace_button->SetBrowseInfoWnd(boost::shared_ptr<GG::BrowseInfoWnd>(
-            new TextBrowseWnd(UserString("DESIGN_INVALID"), UserString("DESIGN_REPLACE_INVALID_NO_CANDIDATE"))));
+            new TextBrowseWnd(UserString("DESIGN_INVALID"), UserString("DESIGN_UPDATE_INVALID_NO_CANDIDATE"))));
 
         m_confirm_button->SetBrowseInfoWnd(boost::shared_ptr<GG::BrowseInfoWnd>(
             new TextBrowseWnd(UserString("DESIGN_INVALID"), UserString("DESIGN_INV_NO_HULL"))));
@@ -3172,8 +3172,8 @@ void DesignWnd::MainPanel::DesignChanged() {
             const std::string& replace_name = replace_ship_design->Name();
 
             m_replace_button->SetBrowseInfoWnd(boost::shared_ptr<GG::BrowseInfoWnd>(
-                new TextBrowseWnd(UserString("DESIGN_WND_REPLACE"),
-                boost::io::str(FlexibleFormat(UserString("DESIGN_WND_REPLACE_DETAIL")) % replace_name))));
+                new TextBrowseWnd(UserString("DESIGN_WND_UPDATE"),
+                boost::io::str(FlexibleFormat(UserString("DESIGN_WND_UPDATE_DETAIL")) % replace_name))));
             m_replace_button->Disable(false);
         }
         m_confirm_button->Disable(false);

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -1579,8 +1579,8 @@ void BasesListBox::AcceptDrops(const GG::Pt& pt, const std::vector<GG::Wnd*>& wn
 
             DebugLogger()<<"Accepted Drop of id "<<design_id<<" before "<< insert_before_id;
 
-            empire->RemoveShipDesign(design_id);
-            empire->AddShipDesign(design_id, insert_before_id);
+            HumanClientApp::GetApp()->Orders()
+                .IssueOrder(OrderPtr(new ShipDesignOrder(m_empire_id_shown, design_id, insert_before_id)));
         }
     }
 

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -1204,7 +1204,7 @@ public:
     /** \name Mutators */ //@{
     virtual void                    SizeMove(const GG::Pt& ul, const GG::Pt& lr);
     virtual void                    ChildrenDraggedAway(const std::vector<GG::Wnd*>& wnds, const GG::Wnd* destination);
-    virtual void    AcceptDrops(const GG::Pt& pt, const std::vector<GG::Wnd*>& wnds, GG::Flags<GG::ModKey> mod_keys);
+    virtual void                    AcceptDrops(const GG::Pt& pt, const std::vector<GG::Wnd*>& wnds, GG::Flags<GG::ModKey> mod_keys);
 
     void                            SetEmpireShown(int empire_id, bool refresh_list = true);
 
@@ -1499,10 +1499,10 @@ void BasesListBox::ChildrenDraggedAway(const std::vector<GG::Wnd*>& wnds, const 
         int design_id = design_row->DesignID();
 
         ListBox::iterator point;
-        for (point = begin(); point != end(); ++point) {
+        for ( point = begin(); point != end(); ++point ) {
             const BasesListBox::CompletedDesignListBoxRow* irow =
                 boost::polymorphic_downcast<const BasesListBox::CompletedDesignListBoxRow*>(*point);
-            if(irow && irow->DesignID() == design_id){
+            if( irow && irow->DesignID() == design_id ) {
                 ++point;
                 break;
             }
@@ -1589,7 +1589,7 @@ void BasesListBox::AcceptDrops(const GG::Pt& pt, const std::vector<GG::Wnd*>& wn
             int insert_before_id = (insert_before_row == end() || !insert_before_control)
                 ? ShipDesign::INVALID_DESIGN_ID : insert_before_control->DesignID();
 
-            DebugLogger()<<"Accepted Drop of id "<<design_id<<" before "<< insert_before_id;
+            DebugLogger() << "Accepted Drop of id " << design_id << " before " << insert_before_id;
 
             HumanClientApp::GetApp()->Orders().IssueOrder(OrderPtr(new ShipDesignOrder(m_empire_id_shown, design_id, insert_before_id)));
         }
@@ -1844,9 +1844,8 @@ void BasesListBox::BaseLeftClicked(GG::ListBox::iterator it, const GG::Pt& pt, c
     }
 }
 
-void BasesListBox::ItemRightClickedImpl(GG::ListBox::iterator it, const GG::Pt& pt, const GG::Flags<GG::ModKey>& modkeys) {
-    BaseRightClicked(it, pt, modkeys);
-}
+void BasesListBox::ItemRightClickedImpl(GG::ListBox::iterator it, const GG::Pt& pt, const GG::Flags<GG::ModKey>& modkeys)
+{ BaseRightClicked(it, pt, modkeys); }
 
 void BasesListBox::BaseRightClicked(GG::ListBox::iterator it, const GG::Pt& pt, const GG::Flags<GG::ModKey>& modkeys) {
     // determine type of row that was clicked, and emit appropriate signal
@@ -2761,9 +2760,8 @@ bool DesignWnd::MainPanel::IsDesignNameValid() const {
     return !m_design_name->Text().empty();
 }
 
-const std::string DesignWnd::MainPanel::ValidatedDesignName() const {
-    return (IsDesignNameValid()) ? m_design_name->Text() : UserString("DESIGN_NAME_DEFAULT");
-}
+const std::string DesignWnd::MainPanel::ValidatedDesignName() const
+{ return (IsDesignNameValid()) ? m_design_name->Text() : UserString("DESIGN_NAME_DEFAULT"); }
 
 const std::string& DesignWnd::MainPanel::DesignDescription() const
 { return m_design_description->Text(); }

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -1287,9 +1287,9 @@ public:
     };
 
 protected:
-    void ItemRightClickedImpl(GG::ListBox::iterator it, const GG::Pt& pt, const GG::Flags<GG::ModKey>& modkeys);
-    virtual void                    DropsAcceptable(DropsAcceptableIter first, DropsAcceptableIter last,
-                                                    const GG::Pt& pt, GG::Flags<GG::ModKey> mod_keys) const;
+    virtual void ItemRightClickedImpl(GG::ListBox::iterator it, const GG::Pt& pt, const GG::Flags<GG::ModKey>& modkeys);
+    virtual void DropsAcceptable(DropsAcceptableIter first, DropsAcceptableIter last,
+                                 const GG::Pt& pt, GG::Flags<GG::ModKey> mod_keys) const;
 
 private:
     void    BaseDoubleClicked(GG::ListBox::iterator it, const GG::Pt& pt, const GG::Flags<GG::ModKey>& modkeys);
@@ -1458,7 +1458,6 @@ BasesListBox::BasesListBox() :
 
     GG::Connect(DoubleClickedSignal,    &BasesListBox::BaseDoubleClicked,   this);
     GG::Connect(LeftClickedSignal,      &BasesListBox::BaseLeftClicked,     this);
-    GG::Connect(RightClickedSignal,     &BasesListBox::BaseRightClicked,    this);
 
     EnableOrderIssuing(true);
 }
@@ -1541,6 +1540,7 @@ void BasesListBox::ChildrenDraggedAway(const std::vector<GG::Wnd*>& wnds, const 
 
     // remove dragged-away row from this ListBox
     CUIListBox::ChildrenDraggedAway(wnds, destination);
+    DetachChild(wnds.front());
 
 }
 

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -1284,10 +1284,10 @@ public:
     };
 
 protected:
-    virtual void                    DropsAcceptable(DropsAcceptableIter first
-                                                    , DropsAcceptableIter last
-                                                    , const GG::Pt& pt
-                                                    , GG::Flags<GG::ModKey> mod_keys) const;
+    virtual void                    DropsAcceptable(DropsAcceptableIter first,
+                                                    DropsAcceptableIter last,
+                                                    const GG::Pt& pt,
+                                                    GG::Flags<GG::ModKey> mod_keys) const;
 private:
     void    BaseDoubleClicked(GG::ListBox::iterator it, const GG::Pt& pt, const GG::Flags<GG::ModKey>& modkeys);
     void    BaseLeftClicked(GG::ListBox::iterator it, const GG::Pt& pt, const GG::Flags<GG::ModKey>& modkeys);
@@ -1489,10 +1489,10 @@ void BasesListBox::ChildrenDraggedAway(const std::vector<GG::Wnd*>& wnds, const 
         int design_id = design_row->DesignID();
 
         ListBox::iterator point;
-        for(point = begin(); point != end(); ++point){
+        for (point = begin(); point != end(); ++point) {
             const BasesListBox::CompletedDesignListBoxRow* irow =
                 boost::polymorphic_downcast<const BasesListBox::CompletedDesignListBoxRow*>(*point);
-            if(irow->DesignID() == design_id){
+            if(irow && irow->DesignID() == design_id){
                 ++point;
                 break;
             }
@@ -1500,7 +1500,7 @@ void BasesListBox::ChildrenDraggedAway(const std::vector<GG::Wnd*>& wnds, const 
 
         CompletedDesignListBoxRow* row = new CompletedDesignListBoxRow(row_size.x, row_size.y,
                                                                        design_id);
-        Insert(row,point);
+        Insert(row, point);
         row->Resize(row_size);
 
     } else if (wnd->DragDropDataType() == HULL_PARTS_ROW_DROP_TYPE_STRING) {
@@ -1535,7 +1535,7 @@ void BasesListBox::ChildrenDraggedAway(const std::vector<GG::Wnd*>& wnds, const 
 
 
 void BasesListBox::DropsAcceptable(DropsAcceptableIter first, DropsAcceptableIter last,
-                                    const GG::Pt& pt, GG::Flags<GG::ModKey> mod_keys) const
+                                   const GG::Pt& pt, GG::Flags<GG::ModKey> mod_keys) const
 {
     for (DropsAcceptableIter it = first; it != last; ++it)
         it->second = false;
@@ -1545,9 +1545,10 @@ void BasesListBox::DropsAcceptable(DropsAcceptableIter first, DropsAcceptableIte
         return;
     }
 
-    if(m_showing_completed_designs && first->first->DragDropDataType() == COMPLETE_DESIGN_ROW_DROP_STRING)
+    if (m_showing_completed_designs && first->first->DragDropDataType() == COMPLETE_DESIGN_ROW_DROP_STRING)
         first->second = true;
 }
+
 void BasesListBox::AcceptDrops(const GG::Pt& pt, const std::vector<GG::Wnd*>& wnds, GG::Flags<GG::ModKey> mod_keys) {
     if (wnds.empty()) return;
 
@@ -1579,8 +1580,7 @@ void BasesListBox::AcceptDrops(const GG::Pt& pt, const std::vector<GG::Wnd*>& wn
 
             DebugLogger()<<"Accepted Drop of id "<<design_id<<" before "<< insert_before_id;
 
-            HumanClientApp::GetApp()->Orders()
-                .IssueOrder(OrderPtr(new ShipDesignOrder(m_empire_id_shown, design_id, insert_before_id)));
+            HumanClientApp::GetApp()->Orders().IssueOrder(OrderPtr(new ShipDesignOrder(m_empire_id_shown, design_id, insert_before_id)));
         }
     }
 

--- a/UI/DesignWnd.h
+++ b/UI/DesignWnd.h
@@ -39,6 +39,8 @@ private:
     class MainPanel;        // shows image of hull, slots and parts, design name and description entry boxes, confirm button
 
     void    AddDesign();    ///< adds current design to those stored by this empire, allowing ships of this design to be produced
+    int AddDesignCore(); ///< Adds the current design to those stored by the empire and returns the new_id or INVALID_DESIGN_ID on failure
+    void    ReplaceDesign();///< replace selected completed design with the current design in the stored designs of this empire
 
     void    InitializeWindows();
 

--- a/UI/DesignWnd.h
+++ b/UI/DesignWnd.h
@@ -39,7 +39,7 @@ private:
     class MainPanel;        // shows image of hull, slots and parts, design name and description entry boxes, confirm button
 
     void    AddDesign();    ///< adds current design to those stored by this empire, allowing ships of this design to be produced
-    int AddDesignCore(); ///< Adds the current design to those stored by the empire and returns the new_id or INVALID_DESIGN_ID on failure
+    int     AddDesignCore();///< Adds the current design to those stored by the empire and returns the new_id or INVALID_DESIGN_ID on failure
     void    ReplaceDesign();///< replace selected completed design with the current design in the stored designs of this empire
 
     void    InitializeWindows();

--- a/UI/QueueListBox.cpp
+++ b/UI/QueueListBox.cpp
@@ -47,7 +47,7 @@ QueueListBox::QueueListBox(const std::string& drop_type_str, const std::string& 
     m_drop_point(end()),
     m_show_drop_point(false),
     m_order_issuing_enabled(true),
-    m_showing_prompt(true),
+    m_showing_prompt(false),
     m_prompt_str(prompt_str)
 {
     AllowDropType(drop_type_str);
@@ -64,7 +64,7 @@ QueueListBox::QueueListBox(const std::string& drop_type_str, const std::string& 
     LockColWidths();
     NormalizeRowsOnInsert(false);
 
-    Insert(new PromptRow(RowWidth(), m_prompt_str));
+    ShowPromptSlot();
 }
 
 GG::X QueueListBox::RowWidth() const
@@ -231,8 +231,6 @@ void QueueListBox::ShowPromptSlot() {
 
 void QueueListBox::ShowPromptConditionallySlot(iterator it) {
     if (begin() == end()) {
-        Insert(new PromptRow(Width() - 4, m_prompt_str), begin(), false, false);
-        m_showing_prompt = true;
+        ShowPromptSlot();
     }
 }
-

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -746,7 +746,7 @@ An unmanned armed ship built by the Acirema, standing guard over the system.
 SM_EXP_OUTPOST
 Experiment Zero
 SM_EXP_OUTPOST_DESC
-'''An ancient creation of the Experimentors that reduces [[encyclopedia SHIELDS_TITLE]] and [[encyclopedia DAMAGE_TITLE]]. 
+'''An ancient creation of the Experimentors that reduces [[encyclopedia SHIELDS_TITLE]] and [[encyclopedia DAMAGE_TITLE]].
 
 Experiment Zero was sent to this galaxy to guard the outpost of the Experimentors with its unique abilities. While it does not attack ships directly, it fills the whole system with quadrillions of diminutive units, hampering enemy shields and weapons to the point that all but the very best equipment will be ineffective.'''
 
@@ -3272,7 +3272,7 @@ DESIGN_INVALID
 Invalid Design
 
 DESIGN_INV_MODERATOR
-Moderators and observers cannot create new ship designs.
+Moderators and observers cannot create or modify ship designs.
 
 DESIGN_INV_NO_HULL
 Begin a ship design by selecting its hull.
@@ -3286,6 +3286,23 @@ Duplicates Existing Design
 DESIGN_KNOWN_DETAIL
 This design is a duplicate of "%1%".
 
+DESIGN_OBSOLETE
+Obsolete Design
+
+DESIGN_WND_ADD
+Add New Design
+
+DESIGN_WND_REPLACE
+Replace Old Design
+
+DESIGN_WND_REPLACE_DETAIL
+Replace "%1%"
+
+DESIGN_REPLACE_INVALID_NO_CANDIDATE
+Choose an existing design to replace
+
+
+
 ################
 ## Statistics ##
 ################
@@ -3294,7 +3311,7 @@ Ship Count
 
 MILITARY_STRENGTH_STAT
 Rough Estimate of Total Military Strength
-    
+
 PP_OUTPUT
 Production Output
 
@@ -3599,7 +3616,7 @@ ENC_AUTO_TIME_COST_VARIABLE_STR
 
 <u>Time and Cost</u>
 
-Either one or both of time and cost to %1% this item varies by location.  
+Either one or both of time and cost to %1% this item varies by location.
 In the expressions describing these, the term Source will generally refer to the respective empire's Capital, and the term Target will generally refer to the location under consideration.
 '''
 
@@ -4082,22 +4099,22 @@ AI_LEVELS_TEXT
 AIs rename their capital planet on turn 1, adding a prefix. Once you discover their home system you can determine their personality.
 The current prefixes are:
 
-Beginner: 
+Beginner:
 [[AI_CAPITOL_NAMES_BEGINNER]]
 
-Turtle: 
+Turtle:
 [[AI_CAPITOL_NAMES_TURTLE]]
 
-Cautious: 
+Cautious:
 [[AI_CAPITOL_NAMES_CAUTIOUS]]
 
-Moderate: 
+Moderate:
 [[AI_CAPITOL_NAMES_TYPICAL]]
 
-Aggressive: 
+Aggressive:
 [[AI_CAPITOL_NAMES_AGGRESSIVE]]
 
-Maniacal: 
+Maniacal:
 [[AI_CAPITOL_NAMES_MANIACAL]]'''
 
 STRUCTURE_TITLE
@@ -4135,7 +4152,7 @@ To order a selected fleet to move to another system, right-click on the destinat
 
 Fleets can contain any number of ships and can be divided and merged with other fleets in the same system.
 
-Each fleet has the option to hide (Eye symbol) or be aggressive (Fist symbol).   
+Each fleet has the option to hide (Eye symbol) or be aggressive (Fist symbol).
 
 Right-click on a fleet in the fleet window to access additional options like switching to auto-exploration, renaming or scrapping the fleet.'''
 
@@ -5377,7 +5394,7 @@ Social Structure:
 Egassem society is essentially feudalistic, with each Egassem individual being one 'fiefdom'. The fact that Egassem are typically long-lived (effectively ageless) means that they are highly conservative and highly concerned with wealth.
 
 Homeworld:
-A world wracked with tidal and geological heating, as well as the more conventional solar radiation. Large 'oceans' of liquid rock cover most of the surface. 
+A world wracked with tidal and geological heating, as well as the more conventional solar radiation. Large 'oceans' of liquid rock cover most of the surface.
 '''
 
 SP_SSLITH
@@ -5584,7 +5601,7 @@ The wide ranging, delicate fungi-nets are too large and integrated into the soil
 SP_ABADDONI
 Abaddoni
 SP_ABADDONI_GAMEPLAY_DESC
-'''A race of cave dwelling generally decent folk living in permanent slavery to an overprotective computer they created. 
+'''A race of cave dwelling generally decent folk living in permanent slavery to an overprotective computer they created.
 Prefers Inferno planets.
 [[encyclopedia LITHIC_SPECIES_TITLE]]
 '''
@@ -5681,7 +5698,7 @@ The Furthest are furry, 1.5 m tall creatures. Radially symmetric, they have thre
 Name:
 The Furthest believe that sapience is measured by the distance that a being can separate itself from danger. Thus the name "Furthest" describes their species as the most advanced of beings.
 
-Personality: 
+Personality:
 The Furthest report that their homeworld was once full of the deadliest predators imaginable. They survived by developing caution to the utmost level. Indeed staying alert for threats, and hiding  are the core of their psychology and culture. The Furthest homeworld currently contains no carnivore they can't crush underfoot.
 
 Reason for Staying:
@@ -7068,16 +7085,16 @@ DESC_SPECIES_NOT
 
 DESC_ENQUEUED
 ''' where empire %1% has between %2% and %3% things on the production queue'''
- 
+
 DESC_ENQUEUED_NOT
 ''' where empire %1% does not have between %2% and %3% things on the production queue'''
- 
+
 DESC_ENQUEUED_BUILDING
 ''' where empire %1% has between %2% and %3% %4% buildings on the production queue'''
- 
+
 DESC_ENQUEUED_BUILDING_NOT
 ''' where empire %1% does not have between %2% and %3% %4% buildings on the production queue'''
- 
+
 DESC_ENQUEUED_DESIGN
 ''' where empire %1% has between %2% and %3% %4% ships on the production queue'''
 
@@ -7233,7 +7250,7 @@ DESC_CAN_PRODUCE_SHIPS
 
 DESC_CAN_PRODUCE_SHIPS_NOT
 ''' without a species that can produce ships'''
- 
+
 DESC_SUPPLY_CONNECTED_FLEET
 ''' that is in a system where the %1% empire can provide fleet supply'''
 
@@ -8701,7 +8718,7 @@ SPY_STEALTH_4
 Planetary Phasing Cloak
 
 SPY_STEALTH_4_DESC
-'''Unlocks the [[shippart ST_CLOAK_4]] ship part and gives all planets and outposts in the empire the [[special VOID_SLAVE_SPECIAL]] special which increases the [[encyclopedia STEALTH_TITLE]] of all planets and buildings by 80. 
+'''Unlocks the [[shippart ST_CLOAK_4]] ship part and gives all planets and outposts in the empire the [[special VOID_SLAVE_SPECIAL]] special which increases the [[encyclopedia STEALTH_TITLE]] of all planets and buildings by 80.
 
 Even the most carefully concealed ship emits radiation in the form of force carrier particles. By modulating the wave forms of these particles, it is possible to synchronize them with the background radiation, hampering even very advanced attempts to detect the ship.'''
 
@@ -8714,7 +8731,7 @@ SPY_CUSTOM_ADVISORIES_DESC
 Many of the SitReps are determined automatically, but additional custom SitReps can be specified by editing the file default/customizations/custom_sitreps.txt
 (Note: in a multiplayer game, the content files of the Server are the ones which determine what SitReps are sent to empires.)
 More particulars on the FreeOrion scripting language, such as for these custom SitReps, can be found at our wiki:  http://www.freeorion.org/index.php/Free_Orion_Content_Script_(FOCS)
-There are four preset (possibly translated) labels for use with custom sitreps, so that they get placement at the top of the SitRep window.  More information on how to use the labels can be found on the wiki, and in the custom_sitreps.txt. 
+There are four preset (possibly translated) labels for use with custom sitreps, so that they get placement at the top of the SitRep window.  More information on how to use the labels can be found on the wiki, and in the custom_sitreps.txt.
 These four labels are
 "[[CUSTOM_1]]"
 "[[CUSTOM_2]]"
@@ -8945,7 +8962,7 @@ Chaos Wave
 
 SHP_CHAOS_WAVE_DESC
 Unlocks the [[shippart SP_CHAOS_WAVE]] ship part, which allows ships to greatly reduce the population of enemy planets.
- 
+
 SPY_PLANET_STEALTH_MOD
 Planet Stealth Modifier
 
@@ -9316,7 +9333,7 @@ BLD_CONC_CAMP
 Concentration Camps
 
 BLD_CONC_CAMP_DESC
-'''Decreases the planet's population at a rate of 3 per turn, increases target [[encyclopedia INDUSTRY_TITLE]] by 5 times the planet's population and sets the target [[encyclopedia HAPPINESS_TITLE]] to 0. 
+'''Decreases the planet's population at a rate of 3 per turn, increases target [[encyclopedia INDUSTRY_TITLE]] by 5 times the planet's population and sets the target [[encyclopedia HAPPINESS_TITLE]] to 0.
 
 Ridding a planet of an undesirable species allows the introduction of a more suited species. By creating a planet-wide network of concentration camps designed to work the citizens to death, this goal can be achieved quickly and efficiently. This building can be built on an [[encyclopedia OUTPOSTS_TITLE]].'''
 
@@ -9330,7 +9347,7 @@ BLD_BLACK_HOLE_POW_GEN
 Black Hole Power Generator
 
 BLD_BLACK_HOLE_POW_GEN_DESC
-'''Increases [[encyclopedia INDUSTRY_TITLE]] on all [[encyclopedia SUPPLY_TITLE]] line connected planets with the Industry focus by 1.2 per Population. 
+'''Increases [[encyclopedia INDUSTRY_TITLE]] on all [[encyclopedia SUPPLY_TITLE]] line connected planets with the Industry focus by 1.2 per Population.
 [[NO_STACK_SUPPLY_CONNECTION_TEXT]]
 
 This building can be built at an [[encyclopedia OUTPOSTS_TITLE]], but must be in a black hole system.'''
@@ -9873,7 +9890,7 @@ FU_N_DIMENSIONAL_ENGINE_MATRIX
 N-Dimensional Engine Matrix
 
 FU_N_DIMENSIONAL_ENGINE_MATRIX_DESC
-'''Increases [[encyclopedia STARLANE_SPEED_TITLE]] by 20. 
+'''Increases [[encyclopedia STARLANE_SPEED_TITLE]] by 20.
 
 N-Dimensional subspace research resulted in a more efficient engine matrix.'''
 
@@ -10074,8 +10091,8 @@ GT_TROOP_POD
 Ground Troop Pod
 
 GT_TROOP_POD_DESC
-'''Carries 2 units of ground [[encyclopedia TROOP_TITLE]] and equipment that can be deployed onto a planet. 
-  * The troops can only be used for one invasion.  
+'''Carries 2 units of ground [[encyclopedia TROOP_TITLE]] and equipment that can be deployed onto a planet.
+  * The troops can only be used for one invasion.
   * The ships carrying troops during an invasion come in for a fast hard landing and are unusable afterwards.'''
 
 GT_TROOP_POD_2
@@ -10083,7 +10100,7 @@ Advanced Ground Troop Pod
 
 GT_TROOP_POD_2_DESC
 '''Carries 4 units of cybernetically advanced ground [[encyclopedia TROOP_TITLE]] and equipment that can be deployed onto a planet.
-  * The troops can only be used for one invasion.  
+  * The troops can only be used for one invasion.
   * The ships carrying troops during an invasion come in for a fast hard landing and are unusable afterwards.'''
 
 SP_DISTORTION_MODULATOR
@@ -10222,7 +10239,7 @@ Robotic Hull
 SH_ROBOTIC_DESC
 '''This hull is completely automated and functions under the principals of [[tech SHP_MIL_ROBO_CONT]]. It has four external slots and one internal slot, and repairs 2 points of [[encyclopedia STRUCTURE_TITLE]] each turn.
 
-[[encyclopedia STEALTH_TITLE]] is low, [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is average. 
+[[encyclopedia STEALTH_TITLE]] is low, [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is average.
 
 In addition to a [[buildingtype BLD_SHIPYARD_BASE]], an [[buildingtype BLD_SHIPYARD_ORBITAL_DRYDOCK]] is required at the planet where it is constructed.'''
 
@@ -10230,7 +10247,7 @@ SH_SPATIAL_FLUX
 Spatial Flux Hull
 
 SH_SPATIAL_FLUX_DESC
-'''This tiny hull is capable of decent speed over long distances due to the power of the [[tech SHP_SPACE_FLUX_DRIVE]]. It has only two external slots however, and its max [[encyclopedia STRUCTURE_TITLE]] is low. 
+'''This tiny hull is capable of decent speed over long distances due to the power of the [[tech SHP_SPACE_FLUX_DRIVE]]. It has only two external slots however, and its max [[encyclopedia STRUCTURE_TITLE]] is low.
 
 [[encyclopedia STEALTH_TITLE]] is moderate, but it receives a large [[encyclopedia STEALTH_TITLE]] penalty for movement both in combat and on the galaxy map. [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is average.
 
@@ -10250,7 +10267,7 @@ SH_NANOROBOTIC
 Nano-Robotic Hull
 
 SH_NANOROBOTIC_DESC
-'''This automated hull is large and repairs damage to itself using millions of nano-robots. It has six external slots and one internal slot, and restores [[encyclopedia STRUCTURE_TITLE]] completely between combats. 
+'''This automated hull is large and repairs damage to itself using millions of nano-robots. It has six external slots and one internal slot, and restores [[encyclopedia STRUCTURE_TITLE]] completely between combats.
 
 [[encyclopedia STEALTH_TITLE]] and is low, [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is average.
 
@@ -10290,9 +10307,9 @@ SH_ASTEROID
 Asteroid Hull
 
 SH_ASTEROID_DESC
-'''This hull is constructed from an average-sized asteroid and it is fairly inexpensive to build. A bit roomier than the [[shiphull SH_STANDARD]], it has four external slots and two internal slots. 
+'''This hull is constructed from an average-sized asteroid and it is fairly inexpensive to build. A bit roomier than the [[shiphull SH_STANDARD]], it has four external slots and two internal slots.
 
-[[encyclopedia STEALTH_TITLE]] is low but the hull gets a large bonus on the galaxy map when it is in a system with an asteroid belt, and in combat when it is hiding in an asteroid belt. [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low.  
+[[encyclopedia STEALTH_TITLE]] is low but the hull gets a large bonus on the galaxy map when it is in a system with an asteroid belt, and in combat when it is hiding in an asteroid belt. [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low.
 
 Requires a [[buildingtype BLD_SHIPYARD_BASE]] and an asteroid belt with an [[buildingtype BLD_SHIPYARD_AST]] present in the system where it is produced.'''
 
@@ -10300,9 +10317,9 @@ SH_SMALL_ASTEROID
 Small Asteroid Hull
 
 SH_SMALL_ASTEROID_DESC
-'''This hull is constructed from a very small asteroid. It has only a single external slot and a single internal slot. 
+'''This hull is constructed from a very small asteroid. It has only a single external slot and a single internal slot.
 
-[[encyclopedia STEALTH_TITLE]] is low but the hull gets a large bonus on the galaxy map when it is in a system with an asteroid belt, and in combat when it is hiding in an asteroid belt. [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low. 
+[[encyclopedia STEALTH_TITLE]] is low but the hull gets a large bonus on the galaxy map when it is in a system with an asteroid belt, and in combat when it is hiding in an asteroid belt. [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low.
 
 Requires a [[buildingtype BLD_SHIPYARD_BASE]] and an asteroid belt with an [[buildingtype BLD_SHIPYARD_AST]] present in the system where it is produced.'''
 
@@ -10310,9 +10327,9 @@ SH_HEAVY_ASTEROID
 Heavy Asteroid Hull
 
 SH_HEAVY_ASTEROID_DESC
-'''This hull is constructed from a gigantic asteroid, and has six external slots and three internal slots. 
+'''This hull is constructed from a gigantic asteroid, and has six external slots and three internal slots.
 
-[[encyclopedia STEALTH_TITLE]] is low but the hull gets a large bonus on the galaxy map when it is in a system with an asteroid belt, and in combat when it is hiding in an asteroid belt. [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low. 
+[[encyclopedia STEALTH_TITLE]] is low but the hull gets a large bonus on the galaxy map when it is in a system with an asteroid belt, and in combat when it is hiding in an asteroid belt. [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low.
 
 Requires a [[buildingtype BLD_SHIPYARD_BASE]] and an asteroid belt with an [[buildingtype BLD_SHIPYARD_AST]] present in the system where it is produced.'''
 
@@ -10320,9 +10337,9 @@ SH_CAMOUFLAGE_ASTEROID
 Camouflage Asteroid Hull
 
 SH_CAMOUFLAGE_ASTEROID_DESC
-'''This hull is designed to look exactly like a real asteroid. It has four internal slots, but no external slots. 
+'''This hull is designed to look exactly like a real asteroid. It has four internal slots, but no external slots.
 
-[[encyclopedia STEALTH_TITLE]] is moderate and the hull gets a large bonus on the galaxy map when it is in a system with an asteroid belt, and in combat when it is hiding in an asteroid belt. [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low. 
+[[encyclopedia STEALTH_TITLE]] is moderate and the hull gets a large bonus on the galaxy map when it is in a system with an asteroid belt, and in combat when it is hiding in an asteroid belt. [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low.
 
 Requires a [[buildingtype BLD_SHIPYARD_BASE]] and an asteroid belt with an [[buildingtype BLD_SHIPYARD_AST]] present in the system where it is produced.'''
 
@@ -10330,9 +10347,9 @@ SH_SMALL_CAMOUFLAGE_ASTEROID
 Small Camouflage Asteroid Hull
 
 SH_SMALL_CAMOUFLAGE_ASTEROID_DESC
-'''This camouflage asteroid hull is able to make use of camouflage asteroid parts on its exterior, although it must be made much smaller to compensate and avoid losing its [[encyclopedia STEALTH_TITLE]] bonus. It has a single external slot and a single internal slot. 
+'''This camouflage asteroid hull is able to make use of camouflage asteroid parts on its exterior, although it must be made much smaller to compensate and avoid losing its [[encyclopedia STEALTH_TITLE]] bonus. It has a single external slot and a single internal slot.
 
-[[encyclopedia STEALTH_TITLE]] is high and the hull gets a bonus on the galaxy map when it is in a system with an asteroid belt, and in combat when it is hiding in an asteroid belt. [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low. 
+[[encyclopedia STEALTH_TITLE]] is high and the hull gets a bonus on the galaxy map when it is in a system with an asteroid belt, and in combat when it is hiding in an asteroid belt. [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low.
 
 Requires a [[buildingtype BLD_SHIPYARD_BASE]] and an asteroid belt with an [[buildingtype BLD_SHIPYARD_AST]] present in the system where it is produced.'''
 
@@ -10342,7 +10359,7 @@ Aggregate Asteroid Hull
 SH_AGREGATE_ASTEROID_DESC
 '''This massive hull is formed by combining several large asteroids. It has fifteen external slots and four internal slots.
 
-[[encyclopedia STEALTH_TITLE]] is low but the hull gets a large bonus on the galaxy map when it is in a system with an asteroid belt, and in combat when it is hiding in an asteroid belt. [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low. 
+[[encyclopedia STEALTH_TITLE]] is low but the hull gets a large bonus on the galaxy map when it is in a system with an asteroid belt, and in combat when it is hiding in an asteroid belt. [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low.
 
 Requires a [[buildingtype BLD_SHIPYARD_BASE]], and an asteroid belt with an [[buildingtype BLD_SHIPYARD_AST]] and an [[buildingtype BLD_SHIPYARD_AST_REF]] present in the system where it is produced.'''
 
@@ -10350,9 +10367,9 @@ SH_MINIASTEROID_SWARM
 Mini-Asteroid Swarm
 
 SH_MINIASTEROID_SWARM_DESC
-'''This hull is constructed from a small asteroid, much of which has been broken off to form numerous tiny asteroids, which are controlled by the main hull. These asteroids protect the main ship, giving a bonus to [[encyclopedia SHIELDS_TITLE]]. This hull has two external slots, but no internal slots. [[encyclopedia STRUCTURE_TITLE]] is very low. 
+'''This hull is constructed from a small asteroid, much of which has been broken off to form numerous tiny asteroids, which are controlled by the main hull. These asteroids protect the main ship, giving a bonus to [[encyclopedia SHIELDS_TITLE]]. This hull has two external slots, but no internal slots. [[encyclopedia STRUCTURE_TITLE]] is very low.
 
-[[encyclopedia STEALTH_TITLE]] is low but the hull gets a large bonus on the galaxy map when it is in a system with an asteroid belt, and in combat when it is hiding in an asteroid belt. [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low. 
+[[encyclopedia STEALTH_TITLE]] is low but the hull gets a large bonus on the galaxy map when it is in a system with an asteroid belt, and in combat when it is hiding in an asteroid belt. [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low.
 
 Requires a [[buildingtype BLD_SHIPYARD_BASE]], and an asteroid belt with an [[buildingtype BLD_SHIPYARD_AST]] and an [[buildingtype BLD_SHIPYARD_AST_REF]] present in the system where it is produced.'''
 
@@ -10360,9 +10377,9 @@ SH_SCATTERED_ASTEROID
 Scattered Asteroid Hull
 
 SH_SCATTERED_ASTEROID_DESC
-'''This flagship is constructed from several large asteroids, some of which have been combined to form the main hull, and some of which have been broken apart to form numerous tiny asteroids, which are controlled by the main hull. These asteroids protect not only the main ship, but every accompanying friendly ship, giving a bonus to [[encyclopedia SHIELDS_TITLE]] for all owned ships and allies' ships in the vicinity. This hull has fifteen external slots and four internal slots. [[encyclopedia STRUCTURE_TITLE]] is high. 
+'''This flagship is constructed from several large asteroids, some of which have been combined to form the main hull, and some of which have been broken apart to form numerous tiny asteroids, which are controlled by the main hull. These asteroids protect not only the main ship, but every accompanying friendly ship, giving a bonus to [[encyclopedia SHIELDS_TITLE]] for all owned ships and allies' ships in the vicinity. This hull has fifteen external slots and four internal slots. [[encyclopedia STRUCTURE_TITLE]] is high.
 
-[[encyclopedia STEALTH_TITLE]] is low but the hull gets a large bonus on the galaxy map when it is in a system with an asteroid belt, and in combat when it is hiding in an asteroid belt. [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low. 
+[[encyclopedia STEALTH_TITLE]] is low but the hull gets a large bonus on the galaxy map when it is in a system with an asteroid belt, and in combat when it is hiding in an asteroid belt. [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low.
 
 Requires a [[buildingtype BLD_SHIPYARD_BASE]], and an asteroid belt with an [[buildingtype BLD_SHIPYARD_AST]] and an [[buildingtype BLD_SHIPYARD_AST_REF]] present in the system where it is produced.'''
 
@@ -10370,9 +10387,9 @@ SH_CRYSTALLIZED_ASTEROID
 Crystallized Asteroid Hull
 
 SH_CRYSTALLIZED_ASTEROID_DESC
-'''This sturdy hull is made from a average-sized asteroid, hardened by advanced crystallization techniques. Like the regular [[shiphull SH_ASTEROID]], it has four external slots and two internal slots. [[encyclopedia STRUCTURE_TITLE]] is extremely high. 
+'''This sturdy hull is made from a average-sized asteroid, hardened by advanced crystallization techniques. Like the regular [[shiphull SH_ASTEROID]], it has four external slots and two internal slots. [[encyclopedia STRUCTURE_TITLE]] is extremely high.
 
-[[encyclopedia STEALTH_TITLE]] is low but the hull gets a large bonus on the galaxy map when it is in a system with an asteroid belt, and in combat when it is hiding in an asteroid belt. [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low. 
+[[encyclopedia STEALTH_TITLE]] is low but the hull gets a large bonus on the galaxy map when it is in a system with an asteroid belt, and in combat when it is hiding in an asteroid belt. [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low.
 
 Requires a [[buildingtype BLD_SHIPYARD_BASE]], and an asteroid belt with an [[buildingtype BLD_SHIPYARD_AST]] and an [[buildingtype BLD_SHIPYARD_AST_REF]] present in the system where it is produced.'''
 
@@ -10380,10 +10397,10 @@ SH_ORGANIC
 Organic Hull
 
 SH_ORGANIC_DESC
-'''A living hull with three external slots and one internal slot. 
+'''A living hull with three external slots and one internal slot.
 Organic Growth: starts with 5 [[encyclopedia STRUCTURE_TITLE]], but grows an additional 5 structure over 25 turns.
 
-[[encyclopedia STEALTH_TITLE]] is moderate, [[encyclopedia DETECTION_RANGE_TITLE]] is poor and [[encyclopedia STARLANE_SPEED_TITLE]] is good. 
+[[encyclopedia STEALTH_TITLE]] is moderate, [[encyclopedia DETECTION_RANGE_TITLE]] is poor and [[encyclopedia STARLANE_SPEED_TITLE]] is good.
 
 Cheap and versatile hull able to carry out many fleet roles but likely to become obsolete as technology develops. Low detection makes it poorly suited in a scouting role but it can make a capable warship. Living hull regenerates [[encyclopedia STRUCTURE_TITLE]] and [[encyclopedia FUEL_TITLE]] between combats.
 
@@ -10395,7 +10412,7 @@ Static Multicellular Hull
 SH_STATIC_MULTICELLULAR_DESC
 '''Despite being organic, this hull is non-living, being produced via multi-cellular casting. The versatility of the interior and the lack of necessity for internal organs increases its capacity, but without living systems, it cannot replenish health or energy. It has three external slots and two internal slots.
 
-[[encyclopedia STEALTH_TITLE]] is low, [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is high.  
+[[encyclopedia STEALTH_TITLE]] is low, [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is high.
 
 Cheap and versatile hull able to fill many fleet roles without excelling at any. This hull regenerates neither [[encyclopedia STRUCTURE_TITLE]] nor [[encyclopedia FUEL_TITLE]] between combats.
 
@@ -10405,12 +10422,12 @@ SH_ENDOMORPHIC
 Endomorphic Hull
 
 SH_ENDOMORPHIC_DESC
-'''A half living hull with four external slots and two internal slots. 
+'''A half living hull with four external slots and two internal slots.
 Organic Growth: starts with 5 [[encyclopedia STRUCTURE_TITLE]], but grows an additional 15 structure over 30 turns.
 
-[[encyclopedia STEALTH_TITLE]] is low, [[encyclopedia DETECTION_RANGE_TITLE]] is good and [[encyclopedia STARLANE_SPEED_TITLE]] is high. 
+[[encyclopedia STEALTH_TITLE]] is low, [[encyclopedia DETECTION_RANGE_TITLE]] is good and [[encyclopedia STARLANE_SPEED_TITLE]] is high.
 
-Potentially a capable warship. 
+Potentially a capable warship.
 
 This hull regenerates neither [[encyclopedia STRUCTURE_TITLE]] nor [[encyclopedia FUEL_TITLE]] between combats.
 
@@ -10423,7 +10440,7 @@ SH_SYMBIOTIC_DESC
 '''A living hull with two internal and two external slots. Exists in a symbiotic relationship with its crew, increasing its [[encyclopedia STEALTH_TITLE]] and speed.
 Organic Growth: starts with 10 [[encyclopedia STRUCTURE_TITLE]], but grows an additional 10 structure over 50 turns.
 
-[[encyclopedia STEALTH_TITLE]] is moderate, [[encyclopedia DETECTION_RANGE_TITLE]] is good and [[encyclopedia STARLANE_SPEED_TITLE]] is high. 
+[[encyclopedia STEALTH_TITLE]] is moderate, [[encyclopedia DETECTION_RANGE_TITLE]] is good and [[encyclopedia STARLANE_SPEED_TITLE]] is high.
 
 Less external slots makes this hull unsuited for a frontline combat role, but the internal slots, detection range and stealth give it potential as a scout or commerce raider.
 
@@ -10435,10 +10452,10 @@ SH_PROTOPLASMIC
 Protoplasmic Hull
 
 SH_PROTOPLASMIC_DESC
-'''A living hull with three internal slots and two external slots. 
+'''A living hull with three internal slots and two external slots.
 Organic Growth: starts with 5 [[encyclopedia STRUCTURE_TITLE]], gains an additional 25 over 50 turns.
 
-[[encyclopedia STEALTH_TITLE]] is high, [[encyclopedia DETECTION_RANGE_TITLE]] is good and [[encyclopedia STARLANE_SPEED_TITLE]] is high. 
+[[encyclopedia STEALTH_TITLE]] is high, [[encyclopedia DETECTION_RANGE_TITLE]] is good and [[encyclopedia STARLANE_SPEED_TITLE]] is high.
 
 Less external slots makes this hull unsuited for a frontline combat role, but the internal slots, detection range and stealth give it potential as a scout or commerce raider.
 
@@ -10449,11 +10466,11 @@ Endosymbiotic Hull
 
 SH_ENDOSYMBIOTIC_DESC
 '''This living mono-cellular hull exists in a symbiotic relationship with its crew, suspending them in its cytoplasm and using them as organelles.
-It has four external slots and three internal slots. 
+It has four external slots and three internal slots.
 
 The base hull is born with 5 [[encyclopedia STRUCTURE_TITLE]], but grows an additional 15 structure over 30 turns.
 
-[[encyclopedia STEALTH_TITLE]] is good, [[encyclopedia DETECTION_RANGE_TITLE]] is high and [[encyclopedia STARLANE_SPEED_TITLE]] is high. 
+[[encyclopedia STEALTH_TITLE]] is good, [[encyclopedia DETECTION_RANGE_TITLE]] is high and [[encyclopedia STARLANE_SPEED_TITLE]] is high.
 
 Living hull regenerates [[encyclopedia STRUCTURE_TITLE]] and [[encyclopedia FUEL_TITLE]] between combats. Potentially a powerful warship, commerce raider or armed scout.
 
@@ -10468,7 +10485,7 @@ SH_RAVENOUS_DESC
 
 Organic Growth: starts with 5 [[encyclopedia STRUCTURE_TITLE]], grows an additional 20 structure over 40 turns.
 
-[[encyclopedia STEALTH_TITLE]] is low, [[encyclopedia DETECTION_RANGE_TITLE]] is excellent and [[encyclopedia STARLANE_SPEED_TITLE]] is high. 
+[[encyclopedia STEALTH_TITLE]] is low, [[encyclopedia DETECTION_RANGE_TITLE]] is excellent and [[encyclopedia STARLANE_SPEED_TITLE]] is high.
 
 Potentially a powerful and fast warship.
 
@@ -10481,10 +10498,10 @@ SH_BIOADAPTIVE
 Bio-Adaptive Hull
 
 SH_BIOADAPTIVE_DESC
-'''A living hull with mind and body in unison, master of healing and endurance. It has three external slots and three internal slots. 
+'''A living hull with mind and body in unison, master of healing and endurance. It has three external slots and three internal slots.
 Organic Growth: starts with 15 [[encyclopedia STRUCTURE_TITLE]], grows an additional 25 structure over 50 turns.
 
-[[encyclopedia STEALTH_TITLE]] is high, [[encyclopedia DETECTION_RANGE_TITLE]] is excellent and [[encyclopedia STARLANE_SPEED_TITLE]] is high. 
+[[encyclopedia STEALTH_TITLE]] is high, [[encyclopedia DETECTION_RANGE_TITLE]] is excellent and [[encyclopedia STARLANE_SPEED_TITLE]] is high.
 
 Potentially a powerful and fast commerce raider or scout.
 
@@ -10497,10 +10514,10 @@ SH_SENTIENT
 Sentient Hull
 
 SH_SENTIENT_DESC
-'''This self-aware organic flagship with powerful analytical abilities and a tremendous memory capacity, which allow it to direct friendly vessels and provide them with useful information and subtle tactical cues in combat, giving a [[encyclopedia STEALTH_TITLE]] and [[encyclopedia DETECTION_RANGE_TITLE]] bonus to all accompanying friendly ships. It has six external slots, three internal slots, and a core slot. 
+'''This self-aware organic flagship with powerful analytical abilities and a tremendous memory capacity, which allow it to direct friendly vessels and provide them with useful information and subtle tactical cues in combat, giving a [[encyclopedia STEALTH_TITLE]] and [[encyclopedia DETECTION_RANGE_TITLE]] bonus to all accompanying friendly ships. It has six external slots, three internal slots, and a core slot.
 Organic Growth: Starts with 12 [[encyclopedia STRUCTURE_TITLE]], grows an additional 45 over 45 turns.
 
-[[encyclopedia STEALTH_TITLE]] is good, [[encyclopedia DETECTION_RANGE_TITLE]] is good and [[encyclopedia STARLANE_SPEED_TITLE]] is high. 
+[[encyclopedia STEALTH_TITLE]] is good, [[encyclopedia DETECTION_RANGE_TITLE]] is good and [[encyclopedia STARLANE_SPEED_TITLE]] is high.
 
 This hull regenerates [[encyclopedia STRUCTURE_TITLE]] and [[encyclopedia FUEL_TITLE]] between combats.
 
@@ -10510,18 +10527,18 @@ SH_COMPRESSED_ENERGY
 Compressed Energy Hull
 
 SH_COMPRESSED_ENERGY_DESC
-'''This fast hull is comprised entirely of compressed energy and has a single external slot. 
+'''This fast hull is comprised entirely of compressed energy and has a single external slot.
 
-Structure is low, [[encyclopedia STEALTH_TITLE]] is good, [[encyclopedia DETECTION_RANGE_TITLE]] is normal and [[encyclopedia STARLANE_SPEED_TITLE]] is very high. 
+Structure is low, [[encyclopedia STEALTH_TITLE]] is good, [[encyclopedia DETECTION_RANGE_TITLE]] is normal and [[encyclopedia STARLANE_SPEED_TITLE]] is very high.
 
 This hull requires a great deal of energy to construct and can only be built at a system with a star of type White, Blue or Black Hole and requires a [[buildingtype BLD_SHIPYARD_BASE]] and an [[buildingtype BLD_SHIPYARD_ENRG_COMP]] at the planet where it is formed.'''
 
 SH_ENERGY_FRIGATE
 Energy Frigate
 SH_ENERGY_FRIGATE_DESC
-'''This fast hull combines compressed energy and warship technology to create a fast but fragile attack ship. 
+'''This fast hull combines compressed energy and warship technology to create a fast but fragile attack ship.
 
-[[encyclopedia STRUCTURE_TITLE]] and [[encyclopedia STEALTH_TITLE]] are low, [[encyclopedia DETECTION_RANGE_TITLE]] is normal and [[encyclopedia STARLANE_SPEED_TITLE]] is very high. 
+[[encyclopedia STRUCTURE_TITLE]] and [[encyclopedia STEALTH_TITLE]] are low, [[encyclopedia DETECTION_RANGE_TITLE]] is normal and [[encyclopedia STARLANE_SPEED_TITLE]] is very high.
 
 This hull requires a great deal of energy to construct and can only be built at a system with a star of type White, Blue or Black Hole and requires a [[buildingtype BLD_SHIPYARD_BASE]] and an [[buildingtype BLD_SHIPYARD_ENRG_COMP]] at the planet where it is formed.'''
 
@@ -10529,9 +10546,9 @@ SH_FRACTAL_ENERGY
 Fractal Energy Hull
 
 SH_FRACTAL_ENERGY_DESC
-'''This hull, while small, has a fractal surface which allows many more parts to be mounted than would be possible on a smoother hull. It has fourteen external slots, but no internal slots. 
+'''This hull, while small, has a fractal surface which allows many more parts to be mounted than would be possible on a smoother hull. It has fourteen external slots, but no internal slots.
 
-[[encyclopedia STRUCTURE_TITLE]] is moderate, [[encyclopedia STEALTH_TITLE]] is very low, [[encyclopedia DETECTION_RANGE_TITLE]] is normal and [[encyclopedia STARLANE_SPEED_TITLE]] is very high.  
+[[encyclopedia STRUCTURE_TITLE]] is moderate, [[encyclopedia STEALTH_TITLE]] is very low, [[encyclopedia DETECTION_RANGE_TITLE]] is normal and [[encyclopedia STARLANE_SPEED_TITLE]] is very high.
 
 This hull requires a very great deal of energy to construct—it can only be built at a system with a star of type Blue or Black Hole and requires a [[buildingtype BLD_SHIPYARD_BASE]], and an [[buildingtype BLD_SHIPYARD_ENRG_COMP]] at the planet where it is formed.'''
 
@@ -10539,9 +10556,9 @@ SH_QUANTUM_ENERGY
 Quantum Energy Hull
 
 SH_QUANTUM_ENERGY_DESC
-'''This hull magnifies quantum energy fluctuations to increase its own power. It has seven external slots and three internal slots. 
+'''This hull magnifies quantum energy fluctuations to increase its own power. It has seven external slots and three internal slots.
 
-[[encyclopedia STRUCTURE_TITLE]] is moderate, [[encyclopedia STEALTH_TITLE]] is very low, [[encyclopedia DETECTION_RANGE_TITLE]] is normal and [[encyclopedia STARLANE_SPEED_TITLE]] is very high.  
+[[encyclopedia STRUCTURE_TITLE]] is moderate, [[encyclopedia STEALTH_TITLE]] is very low, [[encyclopedia DETECTION_RANGE_TITLE]] is normal and [[encyclopedia STARLANE_SPEED_TITLE]] is very high.
 
 This hull requires a very great deal of energy to construct—it can only be built at a system with a star of type Blue or Black Hole and requires a [[buildingtype BLD_SHIPYARD_BASE]], and an [[buildingtype BLD_SHIPYARD_ENRG_COMP]] at the planet where it is formed.'''
 
@@ -10551,7 +10568,7 @@ Solar Hull
 SH_SOLAR_DESC
 '''This mighty flagship is essentially a miniature sun, and as such is a great source of both [[encyclopedia FUEL_TITLE]] and visibility. All accompanying friendly ships completely recover fuel between combat, and all enemy ships in the vicinity receive a penalty to [[encyclopedia STEALTH_TITLE]]. This hull has eighteen external slots, eight internal slots and a core slot—a far greater internal capacity than any other hull.
 
-[[encyclopedia STRUCTURE_TITLE]] is extremely high, [[encyclopedia STEALTH_TITLE]] is very low, [[encyclopedia DETECTION_RANGE_TITLE]] is normal and [[encyclopedia STARLANE_SPEED_TITLE]] is very high. However, this ship has the ability to enter a star and hide, giving it perfect [[encyclopedia STEALTH_TITLE]] on the galaxy map when it is in a system with a star of type other than Black Hole or Neutron, and in combat, when it is hiding inside such a star. 
+[[encyclopedia STRUCTURE_TITLE]] is extremely high, [[encyclopedia STEALTH_TITLE]] is very low, [[encyclopedia DETECTION_RANGE_TITLE]] is normal and [[encyclopedia STARLANE_SPEED_TITLE]] is very high. However, this ship has the ability to enter a star and hide, giving it perfect [[encyclopedia STEALTH_TITLE]] on the galaxy map when it is in a system with a star of type other than Black Hole or Neutron, and in combat, when it is hiding inside such a star.
 
 This ship requires a tremendous amount of energy to construct and must harness energy from particle-antiparticle collisions on the event horizon of a Black Hole in its formation. It requires a [[buildingtype BLD_SHIPYARD_BASE]], an [[buildingtype BLD_SHIPYARD_ENRG_COMP]] and a [[buildingtype BLD_SHIPYARD_ENRG_SOLAR]] at the planet where it is built.'''
 
@@ -10560,7 +10577,7 @@ Basic Small Hull
 SH_BASIC_SMALL_DESC
 '''A small, basic interstellar hull. It has only one external slot but can make an extra jump compared to other basic hulls.
 
-[[encyclopedia STEALTH_TITLE]] is low, [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is average. 
+[[encyclopedia STEALTH_TITLE]] is low, [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is average.
 
 Requires a [[buildingtype BLD_SHIPYARD_BASE]] at the planet where it is constructed.'''
 
@@ -10569,7 +10586,7 @@ Basic Medium Hull
 SH_BASIC_MEDIUM_DESC
 '''A medium-sized, basic interstellar hull, with two external slots and one internal slot.
 
-[[encyclopedia STEALTH_TITLE]] is low, [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low. 
+[[encyclopedia STEALTH_TITLE]] is low, [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low.
 
 Requires a [[buildingtype BLD_SHIPYARD_BASE]] at the planet where it is constructed.'''
 
@@ -10579,7 +10596,7 @@ Basic Large Hull
 SH_STANDARD_DESC
 '''A large, basic interstellar hull, with three external slots and one internal slot.
 
-[[encyclopedia STEALTH_TITLE]] is low, [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low. 
+[[encyclopedia STEALTH_TITLE]] is low, [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low.
 
 Requires a [[buildingtype BLD_SHIPYARD_BASE]] at the planet where it is constructed.'''
 
@@ -10757,9 +10774,9 @@ GROWTH_SPECIAL_POPULATION_LITHIC_INCREASE
 [[encyclopedia LITHIC_SPECIES_TITLE]] [[GROWTH_SPECIAL_POPULATION_INCREASE]] [[LITHIC_SPECIES_TITLE]].
 
 GROWTH_SPECIAL_POPULATION_INCREASE
-'''species inhabiting this planet will have the maximum population boosted by planet size (Tiny: +1, Small: +2, Medium: +3, Large: +4, Huge: +5) regardless of planetary environmment. 
+'''species inhabiting this planet will have the maximum population boosted by planet size (Tiny: +1, Small: +2, Medium: +3, Large: +4, Huge: +5) regardless of planetary environmment.
 
-If this planet is set to the [[encyclopedia GROWTH_FOCUS_TITLE]], the bonus is applied to all [[encyclopedia SUPPLY_TITLE]] connected worlds inhabited by species with''' 
+If this planet is set to the [[encyclopedia GROWTH_FOCUS_TITLE]], the bonus is applied to all [[encyclopedia SUPPLY_TITLE]] connected worlds inhabited by species with'''
 
 GROWTH_SPECIAL_INDUSTRY_BOOST
 If this planet is set to the Industry Focus, target [[encyclopedia INDUSTRY_TITLE]] is increased by 0.2 per Population.
@@ -11307,7 +11324,7 @@ Krill Spawner
 
 ### End of AI Shipdesign Name Lists
 
-### AI Diplomacy Strings and Lists 
+### AI Diplomacy Strings and Lists
 ### Translator Note: for AI Keys ending with "LIST", each line of the provided value should be an independent entry; each entry must be a single line.
 ### For such lists, you may provide more or fewer entries than are provided in en.txt, unless otherwise indicated in a comment for that key
 
@@ -11444,7 +11461,7 @@ Sending you to your ancestors is our sacred duty!
 # NOTE TO TRANSLATORS:
 # The following lists group the AI turn 1 greetings by AI agression level.
 # These are functional lists that must not be translated!
- 
+
 AI_FIRST_TURN_GREETING_LIST_BEGINNER
 '''AI_FIRST_TURN_GREETING_MSG101
 AI_FIRST_TURN_GREETING_MSG102
@@ -12145,7 +12162,7 @@ Helevorn
 Helix
 Helliconia
 Helos
-Helotrix 
+Helotrix
 Hematopf
 Henderson
 Henge
@@ -14922,4 +14939,3 @@ MONSTER_NAMES
 #include "../global_settings.txt"
 #include "../content_specific_parameters.txt"
 #include "../customizations/common_user_customizations.txt"
-

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -3301,6 +3301,9 @@ Replace "%1%"
 DESIGN_REPLACE_INVALID_NO_CANDIDATE
 Choose an existing design to replace
 
+ADD_FIRST_DESIGN_DESIGN_QUEUE_PROMPT
+Select a hull, add parts and then click "Add New Design" to create an available design.
+
 
 
 ################

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -3292,11 +3292,20 @@ Obsolete Design
 DESIGN_WND_ADD
 Add New Design
 
+DESIGN_WND_ADD_DETAIL
+'''Add new design called
+"%1%"
+to finished designs.'''
+
 DESIGN_WND_UPDATE
 Update Old Design
 
 DESIGN_WND_UPDATE_DETAIL
-Update "%1%"
+'''Replace old design
+"%1%"
+with new design
+"%2%"
+in finished designs.'''
 
 DESIGN_UPDATE_INVALID_NO_CANDIDATE
 Choose an existing design to update.

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -3292,14 +3292,14 @@ Obsolete Design
 DESIGN_WND_ADD
 Add New Design
 
-DESIGN_WND_REPLACE
-Replace Old Design
+DESIGN_WND_UPDATE
+Update Old Design
 
-DESIGN_WND_REPLACE_DETAIL
-Replace "%1%"
+DESIGN_WND_UPDATE_DETAIL
+Update "%1%"
 
-DESIGN_REPLACE_INVALID_NO_CANDIDATE
-Choose an existing design to replace
+DESIGN_UPDATE_INVALID_NO_CANDIDATE
+Choose an existing design to update.
 
 ADD_FIRST_DESIGN_DESIGN_QUEUE_PROMPT
 Select a hull, add parts and then click "Add New Design" to create an available design.

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -746,7 +746,7 @@ An unmanned armed ship built by the Acirema, standing guard over the system.
 SM_EXP_OUTPOST
 Experiment Zero
 SM_EXP_OUTPOST_DESC
-'''An ancient creation of the Experimentors that reduces [[encyclopedia SHIELDS_TITLE]] and [[encyclopedia DAMAGE_TITLE]].
+'''An ancient creation of the Experimentors that reduces [[encyclopedia SHIELDS_TITLE]] and [[encyclopedia DAMAGE_TITLE]]. 
 
 Experiment Zero was sent to this galaxy to guard the outpost of the Experimentors with its unique abilities. While it does not attack ships directly, it fills the whole system with quadrillions of diminutive units, hampering enemy shields and weapons to the point that all but the very best equipment will be ineffective.'''
 
@@ -3304,8 +3304,6 @@ Choose an existing design to replace
 ADD_FIRST_DESIGN_DESIGN_QUEUE_PROMPT
 Select a hull, add parts and then click "Add New Design" to create an available design.
 
-
-
 ################
 ## Statistics ##
 ################
@@ -3314,7 +3312,7 @@ Ship Count
 
 MILITARY_STRENGTH_STAT
 Rough Estimate of Total Military Strength
-
+    
 PP_OUTPUT
 Production Output
 
@@ -3619,7 +3617,7 @@ ENC_AUTO_TIME_COST_VARIABLE_STR
 
 <u>Time and Cost</u>
 
-Either one or both of time and cost to %1% this item varies by location.
+Either one or both of time and cost to %1% this item varies by location.  
 In the expressions describing these, the term Source will generally refer to the respective empire's Capital, and the term Target will generally refer to the location under consideration.
 '''
 
@@ -4102,22 +4100,22 @@ AI_LEVELS_TEXT
 AIs rename their capital planet on turn 1, adding a prefix. Once you discover their home system you can determine their personality.
 The current prefixes are:
 
-Beginner:
+Beginner: 
 [[AI_CAPITOL_NAMES_BEGINNER]]
 
-Turtle:
+Turtle: 
 [[AI_CAPITOL_NAMES_TURTLE]]
 
-Cautious:
+Cautious: 
 [[AI_CAPITOL_NAMES_CAUTIOUS]]
 
-Moderate:
+Moderate: 
 [[AI_CAPITOL_NAMES_TYPICAL]]
 
-Aggressive:
+Aggressive: 
 [[AI_CAPITOL_NAMES_AGGRESSIVE]]
 
-Maniacal:
+Maniacal: 
 [[AI_CAPITOL_NAMES_MANIACAL]]'''
 
 STRUCTURE_TITLE
@@ -4155,7 +4153,7 @@ To order a selected fleet to move to another system, right-click on the destinat
 
 Fleets can contain any number of ships and can be divided and merged with other fleets in the same system.
 
-Each fleet has the option to hide (Eye symbol) or be aggressive (Fist symbol).
+Each fleet has the option to hide (Eye symbol) or be aggressive (Fist symbol).   
 
 Right-click on a fleet in the fleet window to access additional options like switching to auto-exploration, renaming or scrapping the fleet.'''
 
@@ -5397,7 +5395,7 @@ Social Structure:
 Egassem society is essentially feudalistic, with each Egassem individual being one 'fiefdom'. The fact that Egassem are typically long-lived (effectively ageless) means that they are highly conservative and highly concerned with wealth.
 
 Homeworld:
-A world wracked with tidal and geological heating, as well as the more conventional solar radiation. Large 'oceans' of liquid rock cover most of the surface.
+A world wracked with tidal and geological heating, as well as the more conventional solar radiation. Large 'oceans' of liquid rock cover most of the surface. 
 '''
 
 SP_SSLITH
@@ -5604,7 +5602,7 @@ The wide ranging, delicate fungi-nets are too large and integrated into the soil
 SP_ABADDONI
 Abaddoni
 SP_ABADDONI_GAMEPLAY_DESC
-'''A race of cave dwelling generally decent folk living in permanent slavery to an overprotective computer they created.
+'''A race of cave dwelling generally decent folk living in permanent slavery to an overprotective computer they created. 
 Prefers Inferno planets.
 [[encyclopedia LITHIC_SPECIES_TITLE]]
 '''
@@ -5701,7 +5699,7 @@ The Furthest are furry, 1.5 m tall creatures. Radially symmetric, they have thre
 Name:
 The Furthest believe that sapience is measured by the distance that a being can separate itself from danger. Thus the name "Furthest" describes their species as the most advanced of beings.
 
-Personality:
+Personality: 
 The Furthest report that their homeworld was once full of the deadliest predators imaginable. They survived by developing caution to the utmost level. Indeed staying alert for threats, and hiding  are the core of their psychology and culture. The Furthest homeworld currently contains no carnivore they can't crush underfoot.
 
 Reason for Staying:
@@ -7088,16 +7086,16 @@ DESC_SPECIES_NOT
 
 DESC_ENQUEUED
 ''' where empire %1% has between %2% and %3% things on the production queue'''
-
+ 
 DESC_ENQUEUED_NOT
 ''' where empire %1% does not have between %2% and %3% things on the production queue'''
-
+ 
 DESC_ENQUEUED_BUILDING
 ''' where empire %1% has between %2% and %3% %4% buildings on the production queue'''
-
+ 
 DESC_ENQUEUED_BUILDING_NOT
 ''' where empire %1% does not have between %2% and %3% %4% buildings on the production queue'''
-
+ 
 DESC_ENQUEUED_DESIGN
 ''' where empire %1% has between %2% and %3% %4% ships on the production queue'''
 
@@ -7253,7 +7251,7 @@ DESC_CAN_PRODUCE_SHIPS
 
 DESC_CAN_PRODUCE_SHIPS_NOT
 ''' without a species that can produce ships'''
-
+ 
 DESC_SUPPLY_CONNECTED_FLEET
 ''' that is in a system where the %1% empire can provide fleet supply'''
 
@@ -8721,7 +8719,7 @@ SPY_STEALTH_4
 Planetary Phasing Cloak
 
 SPY_STEALTH_4_DESC
-'''Unlocks the [[shippart ST_CLOAK_4]] ship part and gives all planets and outposts in the empire the [[special VOID_SLAVE_SPECIAL]] special which increases the [[encyclopedia STEALTH_TITLE]] of all planets and buildings by 80.
+'''Unlocks the [[shippart ST_CLOAK_4]] ship part and gives all planets and outposts in the empire the [[special VOID_SLAVE_SPECIAL]] special which increases the [[encyclopedia STEALTH_TITLE]] of all planets and buildings by 80. 
 
 Even the most carefully concealed ship emits radiation in the form of force carrier particles. By modulating the wave forms of these particles, it is possible to synchronize them with the background radiation, hampering even very advanced attempts to detect the ship.'''
 
@@ -8734,7 +8732,7 @@ SPY_CUSTOM_ADVISORIES_DESC
 Many of the SitReps are determined automatically, but additional custom SitReps can be specified by editing the file default/customizations/custom_sitreps.txt
 (Note: in a multiplayer game, the content files of the Server are the ones which determine what SitReps are sent to empires.)
 More particulars on the FreeOrion scripting language, such as for these custom SitReps, can be found at our wiki:  http://www.freeorion.org/index.php/Free_Orion_Content_Script_(FOCS)
-There are four preset (possibly translated) labels for use with custom sitreps, so that they get placement at the top of the SitRep window.  More information on how to use the labels can be found on the wiki, and in the custom_sitreps.txt.
+There are four preset (possibly translated) labels for use with custom sitreps, so that they get placement at the top of the SitRep window.  More information on how to use the labels can be found on the wiki, and in the custom_sitreps.txt. 
 These four labels are
 "[[CUSTOM_1]]"
 "[[CUSTOM_2]]"
@@ -8965,7 +8963,7 @@ Chaos Wave
 
 SHP_CHAOS_WAVE_DESC
 Unlocks the [[shippart SP_CHAOS_WAVE]] ship part, which allows ships to greatly reduce the population of enemy planets.
-
+ 
 SPY_PLANET_STEALTH_MOD
 Planet Stealth Modifier
 
@@ -9336,7 +9334,7 @@ BLD_CONC_CAMP
 Concentration Camps
 
 BLD_CONC_CAMP_DESC
-'''Decreases the planet's population at a rate of 3 per turn, increases target [[encyclopedia INDUSTRY_TITLE]] by 5 times the planet's population and sets the target [[encyclopedia HAPPINESS_TITLE]] to 0.
+'''Decreases the planet's population at a rate of 3 per turn, increases target [[encyclopedia INDUSTRY_TITLE]] by 5 times the planet's population and sets the target [[encyclopedia HAPPINESS_TITLE]] to 0. 
 
 Ridding a planet of an undesirable species allows the introduction of a more suited species. By creating a planet-wide network of concentration camps designed to work the citizens to death, this goal can be achieved quickly and efficiently. This building can be built on an [[encyclopedia OUTPOSTS_TITLE]].'''
 
@@ -9350,7 +9348,7 @@ BLD_BLACK_HOLE_POW_GEN
 Black Hole Power Generator
 
 BLD_BLACK_HOLE_POW_GEN_DESC
-'''Increases [[encyclopedia INDUSTRY_TITLE]] on all [[encyclopedia SUPPLY_TITLE]] line connected planets with the Industry focus by 1.2 per Population.
+'''Increases [[encyclopedia INDUSTRY_TITLE]] on all [[encyclopedia SUPPLY_TITLE]] line connected planets with the Industry focus by 1.2 per Population. 
 [[NO_STACK_SUPPLY_CONNECTION_TEXT]]
 
 This building can be built at an [[encyclopedia OUTPOSTS_TITLE]], but must be in a black hole system.'''
@@ -9893,7 +9891,7 @@ FU_N_DIMENSIONAL_ENGINE_MATRIX
 N-Dimensional Engine Matrix
 
 FU_N_DIMENSIONAL_ENGINE_MATRIX_DESC
-'''Increases [[encyclopedia STARLANE_SPEED_TITLE]] by 20.
+'''Increases [[encyclopedia STARLANE_SPEED_TITLE]] by 20. 
 
 N-Dimensional subspace research resulted in a more efficient engine matrix.'''
 
@@ -10094,8 +10092,8 @@ GT_TROOP_POD
 Ground Troop Pod
 
 GT_TROOP_POD_DESC
-'''Carries 2 units of ground [[encyclopedia TROOP_TITLE]] and equipment that can be deployed onto a planet.
-  * The troops can only be used for one invasion.
+'''Carries 2 units of ground [[encyclopedia TROOP_TITLE]] and equipment that can be deployed onto a planet. 
+  * The troops can only be used for one invasion.  
   * The ships carrying troops during an invasion come in for a fast hard landing and are unusable afterwards.'''
 
 GT_TROOP_POD_2
@@ -10103,7 +10101,7 @@ Advanced Ground Troop Pod
 
 GT_TROOP_POD_2_DESC
 '''Carries 4 units of cybernetically advanced ground [[encyclopedia TROOP_TITLE]] and equipment that can be deployed onto a planet.
-  * The troops can only be used for one invasion.
+  * The troops can only be used for one invasion.  
   * The ships carrying troops during an invasion come in for a fast hard landing and are unusable afterwards.'''
 
 SP_DISTORTION_MODULATOR
@@ -10242,7 +10240,7 @@ Robotic Hull
 SH_ROBOTIC_DESC
 '''This hull is completely automated and functions under the principals of [[tech SHP_MIL_ROBO_CONT]]. It has four external slots and one internal slot, and repairs 2 points of [[encyclopedia STRUCTURE_TITLE]] each turn.
 
-[[encyclopedia STEALTH_TITLE]] is low, [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is average.
+[[encyclopedia STEALTH_TITLE]] is low, [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is average. 
 
 In addition to a [[buildingtype BLD_SHIPYARD_BASE]], an [[buildingtype BLD_SHIPYARD_ORBITAL_DRYDOCK]] is required at the planet where it is constructed.'''
 
@@ -10250,7 +10248,7 @@ SH_SPATIAL_FLUX
 Spatial Flux Hull
 
 SH_SPATIAL_FLUX_DESC
-'''This tiny hull is capable of decent speed over long distances due to the power of the [[tech SHP_SPACE_FLUX_DRIVE]]. It has only two external slots however, and its max [[encyclopedia STRUCTURE_TITLE]] is low.
+'''This tiny hull is capable of decent speed over long distances due to the power of the [[tech SHP_SPACE_FLUX_DRIVE]]. It has only two external slots however, and its max [[encyclopedia STRUCTURE_TITLE]] is low. 
 
 [[encyclopedia STEALTH_TITLE]] is moderate, but it receives a large [[encyclopedia STEALTH_TITLE]] penalty for movement both in combat and on the galaxy map. [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is average.
 
@@ -10270,7 +10268,7 @@ SH_NANOROBOTIC
 Nano-Robotic Hull
 
 SH_NANOROBOTIC_DESC
-'''This automated hull is large and repairs damage to itself using millions of nano-robots. It has six external slots and one internal slot, and restores [[encyclopedia STRUCTURE_TITLE]] completely between combats.
+'''This automated hull is large and repairs damage to itself using millions of nano-robots. It has six external slots and one internal slot, and restores [[encyclopedia STRUCTURE_TITLE]] completely between combats. 
 
 [[encyclopedia STEALTH_TITLE]] and is low, [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is average.
 
@@ -10310,9 +10308,9 @@ SH_ASTEROID
 Asteroid Hull
 
 SH_ASTEROID_DESC
-'''This hull is constructed from an average-sized asteroid and it is fairly inexpensive to build. A bit roomier than the [[shiphull SH_STANDARD]], it has four external slots and two internal slots.
+'''This hull is constructed from an average-sized asteroid and it is fairly inexpensive to build. A bit roomier than the [[shiphull SH_STANDARD]], it has four external slots and two internal slots. 
 
-[[encyclopedia STEALTH_TITLE]] is low but the hull gets a large bonus on the galaxy map when it is in a system with an asteroid belt, and in combat when it is hiding in an asteroid belt. [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low.
+[[encyclopedia STEALTH_TITLE]] is low but the hull gets a large bonus on the galaxy map when it is in a system with an asteroid belt, and in combat when it is hiding in an asteroid belt. [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low.  
 
 Requires a [[buildingtype BLD_SHIPYARD_BASE]] and an asteroid belt with an [[buildingtype BLD_SHIPYARD_AST]] present in the system where it is produced.'''
 
@@ -10320,9 +10318,9 @@ SH_SMALL_ASTEROID
 Small Asteroid Hull
 
 SH_SMALL_ASTEROID_DESC
-'''This hull is constructed from a very small asteroid. It has only a single external slot and a single internal slot.
+'''This hull is constructed from a very small asteroid. It has only a single external slot and a single internal slot. 
 
-[[encyclopedia STEALTH_TITLE]] is low but the hull gets a large bonus on the galaxy map when it is in a system with an asteroid belt, and in combat when it is hiding in an asteroid belt. [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low.
+[[encyclopedia STEALTH_TITLE]] is low but the hull gets a large bonus on the galaxy map when it is in a system with an asteroid belt, and in combat when it is hiding in an asteroid belt. [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low. 
 
 Requires a [[buildingtype BLD_SHIPYARD_BASE]] and an asteroid belt with an [[buildingtype BLD_SHIPYARD_AST]] present in the system where it is produced.'''
 
@@ -10330,9 +10328,9 @@ SH_HEAVY_ASTEROID
 Heavy Asteroid Hull
 
 SH_HEAVY_ASTEROID_DESC
-'''This hull is constructed from a gigantic asteroid, and has six external slots and three internal slots.
+'''This hull is constructed from a gigantic asteroid, and has six external slots and three internal slots. 
 
-[[encyclopedia STEALTH_TITLE]] is low but the hull gets a large bonus on the galaxy map when it is in a system with an asteroid belt, and in combat when it is hiding in an asteroid belt. [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low.
+[[encyclopedia STEALTH_TITLE]] is low but the hull gets a large bonus on the galaxy map when it is in a system with an asteroid belt, and in combat when it is hiding in an asteroid belt. [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low. 
 
 Requires a [[buildingtype BLD_SHIPYARD_BASE]] and an asteroid belt with an [[buildingtype BLD_SHIPYARD_AST]] present in the system where it is produced.'''
 
@@ -10340,9 +10338,9 @@ SH_CAMOUFLAGE_ASTEROID
 Camouflage Asteroid Hull
 
 SH_CAMOUFLAGE_ASTEROID_DESC
-'''This hull is designed to look exactly like a real asteroid. It has four internal slots, but no external slots.
+'''This hull is designed to look exactly like a real asteroid. It has four internal slots, but no external slots. 
 
-[[encyclopedia STEALTH_TITLE]] is moderate and the hull gets a large bonus on the galaxy map when it is in a system with an asteroid belt, and in combat when it is hiding in an asteroid belt. [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low.
+[[encyclopedia STEALTH_TITLE]] is moderate and the hull gets a large bonus on the galaxy map when it is in a system with an asteroid belt, and in combat when it is hiding in an asteroid belt. [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low. 
 
 Requires a [[buildingtype BLD_SHIPYARD_BASE]] and an asteroid belt with an [[buildingtype BLD_SHIPYARD_AST]] present in the system where it is produced.'''
 
@@ -10350,9 +10348,9 @@ SH_SMALL_CAMOUFLAGE_ASTEROID
 Small Camouflage Asteroid Hull
 
 SH_SMALL_CAMOUFLAGE_ASTEROID_DESC
-'''This camouflage asteroid hull is able to make use of camouflage asteroid parts on its exterior, although it must be made much smaller to compensate and avoid losing its [[encyclopedia STEALTH_TITLE]] bonus. It has a single external slot and a single internal slot.
+'''This camouflage asteroid hull is able to make use of camouflage asteroid parts on its exterior, although it must be made much smaller to compensate and avoid losing its [[encyclopedia STEALTH_TITLE]] bonus. It has a single external slot and a single internal slot. 
 
-[[encyclopedia STEALTH_TITLE]] is high and the hull gets a bonus on the galaxy map when it is in a system with an asteroid belt, and in combat when it is hiding in an asteroid belt. [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low.
+[[encyclopedia STEALTH_TITLE]] is high and the hull gets a bonus on the galaxy map when it is in a system with an asteroid belt, and in combat when it is hiding in an asteroid belt. [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low. 
 
 Requires a [[buildingtype BLD_SHIPYARD_BASE]] and an asteroid belt with an [[buildingtype BLD_SHIPYARD_AST]] present in the system where it is produced.'''
 
@@ -10362,7 +10360,7 @@ Aggregate Asteroid Hull
 SH_AGREGATE_ASTEROID_DESC
 '''This massive hull is formed by combining several large asteroids. It has fifteen external slots and four internal slots.
 
-[[encyclopedia STEALTH_TITLE]] is low but the hull gets a large bonus on the galaxy map when it is in a system with an asteroid belt, and in combat when it is hiding in an asteroid belt. [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low.
+[[encyclopedia STEALTH_TITLE]] is low but the hull gets a large bonus on the galaxy map when it is in a system with an asteroid belt, and in combat when it is hiding in an asteroid belt. [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low. 
 
 Requires a [[buildingtype BLD_SHIPYARD_BASE]], and an asteroid belt with an [[buildingtype BLD_SHIPYARD_AST]] and an [[buildingtype BLD_SHIPYARD_AST_REF]] present in the system where it is produced.'''
 
@@ -10370,9 +10368,9 @@ SH_MINIASTEROID_SWARM
 Mini-Asteroid Swarm
 
 SH_MINIASTEROID_SWARM_DESC
-'''This hull is constructed from a small asteroid, much of which has been broken off to form numerous tiny asteroids, which are controlled by the main hull. These asteroids protect the main ship, giving a bonus to [[encyclopedia SHIELDS_TITLE]]. This hull has two external slots, but no internal slots. [[encyclopedia STRUCTURE_TITLE]] is very low.
+'''This hull is constructed from a small asteroid, much of which has been broken off to form numerous tiny asteroids, which are controlled by the main hull. These asteroids protect the main ship, giving a bonus to [[encyclopedia SHIELDS_TITLE]]. This hull has two external slots, but no internal slots. [[encyclopedia STRUCTURE_TITLE]] is very low. 
 
-[[encyclopedia STEALTH_TITLE]] is low but the hull gets a large bonus on the galaxy map when it is in a system with an asteroid belt, and in combat when it is hiding in an asteroid belt. [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low.
+[[encyclopedia STEALTH_TITLE]] is low but the hull gets a large bonus on the galaxy map when it is in a system with an asteroid belt, and in combat when it is hiding in an asteroid belt. [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low. 
 
 Requires a [[buildingtype BLD_SHIPYARD_BASE]], and an asteroid belt with an [[buildingtype BLD_SHIPYARD_AST]] and an [[buildingtype BLD_SHIPYARD_AST_REF]] present in the system where it is produced.'''
 
@@ -10380,9 +10378,9 @@ SH_SCATTERED_ASTEROID
 Scattered Asteroid Hull
 
 SH_SCATTERED_ASTEROID_DESC
-'''This flagship is constructed from several large asteroids, some of which have been combined to form the main hull, and some of which have been broken apart to form numerous tiny asteroids, which are controlled by the main hull. These asteroids protect not only the main ship, but every accompanying friendly ship, giving a bonus to [[encyclopedia SHIELDS_TITLE]] for all owned ships and allies' ships in the vicinity. This hull has fifteen external slots and four internal slots. [[encyclopedia STRUCTURE_TITLE]] is high.
+'''This flagship is constructed from several large asteroids, some of which have been combined to form the main hull, and some of which have been broken apart to form numerous tiny asteroids, which are controlled by the main hull. These asteroids protect not only the main ship, but every accompanying friendly ship, giving a bonus to [[encyclopedia SHIELDS_TITLE]] for all owned ships and allies' ships in the vicinity. This hull has fifteen external slots and four internal slots. [[encyclopedia STRUCTURE_TITLE]] is high. 
 
-[[encyclopedia STEALTH_TITLE]] is low but the hull gets a large bonus on the galaxy map when it is in a system with an asteroid belt, and in combat when it is hiding in an asteroid belt. [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low.
+[[encyclopedia STEALTH_TITLE]] is low but the hull gets a large bonus on the galaxy map when it is in a system with an asteroid belt, and in combat when it is hiding in an asteroid belt. [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low. 
 
 Requires a [[buildingtype BLD_SHIPYARD_BASE]], and an asteroid belt with an [[buildingtype BLD_SHIPYARD_AST]] and an [[buildingtype BLD_SHIPYARD_AST_REF]] present in the system where it is produced.'''
 
@@ -10390,9 +10388,9 @@ SH_CRYSTALLIZED_ASTEROID
 Crystallized Asteroid Hull
 
 SH_CRYSTALLIZED_ASTEROID_DESC
-'''This sturdy hull is made from a average-sized asteroid, hardened by advanced crystallization techniques. Like the regular [[shiphull SH_ASTEROID]], it has four external slots and two internal slots. [[encyclopedia STRUCTURE_TITLE]] is extremely high.
+'''This sturdy hull is made from a average-sized asteroid, hardened by advanced crystallization techniques. Like the regular [[shiphull SH_ASTEROID]], it has four external slots and two internal slots. [[encyclopedia STRUCTURE_TITLE]] is extremely high. 
 
-[[encyclopedia STEALTH_TITLE]] is low but the hull gets a large bonus on the galaxy map when it is in a system with an asteroid belt, and in combat when it is hiding in an asteroid belt. [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low.
+[[encyclopedia STEALTH_TITLE]] is low but the hull gets a large bonus on the galaxy map when it is in a system with an asteroid belt, and in combat when it is hiding in an asteroid belt. [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low. 
 
 Requires a [[buildingtype BLD_SHIPYARD_BASE]], and an asteroid belt with an [[buildingtype BLD_SHIPYARD_AST]] and an [[buildingtype BLD_SHIPYARD_AST_REF]] present in the system where it is produced.'''
 
@@ -10400,10 +10398,10 @@ SH_ORGANIC
 Organic Hull
 
 SH_ORGANIC_DESC
-'''A living hull with three external slots and one internal slot.
+'''A living hull with three external slots and one internal slot. 
 Organic Growth: starts with 5 [[encyclopedia STRUCTURE_TITLE]], but grows an additional 5 structure over 25 turns.
 
-[[encyclopedia STEALTH_TITLE]] is moderate, [[encyclopedia DETECTION_RANGE_TITLE]] is poor and [[encyclopedia STARLANE_SPEED_TITLE]] is good.
+[[encyclopedia STEALTH_TITLE]] is moderate, [[encyclopedia DETECTION_RANGE_TITLE]] is poor and [[encyclopedia STARLANE_SPEED_TITLE]] is good. 
 
 Cheap and versatile hull able to carry out many fleet roles but likely to become obsolete as technology develops. Low detection makes it poorly suited in a scouting role but it can make a capable warship. Living hull regenerates [[encyclopedia STRUCTURE_TITLE]] and [[encyclopedia FUEL_TITLE]] between combats.
 
@@ -10415,7 +10413,7 @@ Static Multicellular Hull
 SH_STATIC_MULTICELLULAR_DESC
 '''Despite being organic, this hull is non-living, being produced via multi-cellular casting. The versatility of the interior and the lack of necessity for internal organs increases its capacity, but without living systems, it cannot replenish health or energy. It has three external slots and two internal slots.
 
-[[encyclopedia STEALTH_TITLE]] is low, [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is high.
+[[encyclopedia STEALTH_TITLE]] is low, [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is high.  
 
 Cheap and versatile hull able to fill many fleet roles without excelling at any. This hull regenerates neither [[encyclopedia STRUCTURE_TITLE]] nor [[encyclopedia FUEL_TITLE]] between combats.
 
@@ -10425,12 +10423,12 @@ SH_ENDOMORPHIC
 Endomorphic Hull
 
 SH_ENDOMORPHIC_DESC
-'''A half living hull with four external slots and two internal slots.
+'''A half living hull with four external slots and two internal slots. 
 Organic Growth: starts with 5 [[encyclopedia STRUCTURE_TITLE]], but grows an additional 15 structure over 30 turns.
 
-[[encyclopedia STEALTH_TITLE]] is low, [[encyclopedia DETECTION_RANGE_TITLE]] is good and [[encyclopedia STARLANE_SPEED_TITLE]] is high.
+[[encyclopedia STEALTH_TITLE]] is low, [[encyclopedia DETECTION_RANGE_TITLE]] is good and [[encyclopedia STARLANE_SPEED_TITLE]] is high. 
 
-Potentially a capable warship.
+Potentially a capable warship. 
 
 This hull regenerates neither [[encyclopedia STRUCTURE_TITLE]] nor [[encyclopedia FUEL_TITLE]] between combats.
 
@@ -10443,7 +10441,7 @@ SH_SYMBIOTIC_DESC
 '''A living hull with two internal and two external slots. Exists in a symbiotic relationship with its crew, increasing its [[encyclopedia STEALTH_TITLE]] and speed.
 Organic Growth: starts with 10 [[encyclopedia STRUCTURE_TITLE]], but grows an additional 10 structure over 50 turns.
 
-[[encyclopedia STEALTH_TITLE]] is moderate, [[encyclopedia DETECTION_RANGE_TITLE]] is good and [[encyclopedia STARLANE_SPEED_TITLE]] is high.
+[[encyclopedia STEALTH_TITLE]] is moderate, [[encyclopedia DETECTION_RANGE_TITLE]] is good and [[encyclopedia STARLANE_SPEED_TITLE]] is high. 
 
 Less external slots makes this hull unsuited for a frontline combat role, but the internal slots, detection range and stealth give it potential as a scout or commerce raider.
 
@@ -10455,10 +10453,10 @@ SH_PROTOPLASMIC
 Protoplasmic Hull
 
 SH_PROTOPLASMIC_DESC
-'''A living hull with three internal slots and two external slots.
+'''A living hull with three internal slots and two external slots. 
 Organic Growth: starts with 5 [[encyclopedia STRUCTURE_TITLE]], gains an additional 25 over 50 turns.
 
-[[encyclopedia STEALTH_TITLE]] is high, [[encyclopedia DETECTION_RANGE_TITLE]] is good and [[encyclopedia STARLANE_SPEED_TITLE]] is high.
+[[encyclopedia STEALTH_TITLE]] is high, [[encyclopedia DETECTION_RANGE_TITLE]] is good and [[encyclopedia STARLANE_SPEED_TITLE]] is high. 
 
 Less external slots makes this hull unsuited for a frontline combat role, but the internal slots, detection range and stealth give it potential as a scout or commerce raider.
 
@@ -10469,11 +10467,11 @@ Endosymbiotic Hull
 
 SH_ENDOSYMBIOTIC_DESC
 '''This living mono-cellular hull exists in a symbiotic relationship with its crew, suspending them in its cytoplasm and using them as organelles.
-It has four external slots and three internal slots.
+It has four external slots and three internal slots. 
 
 The base hull is born with 5 [[encyclopedia STRUCTURE_TITLE]], but grows an additional 15 structure over 30 turns.
 
-[[encyclopedia STEALTH_TITLE]] is good, [[encyclopedia DETECTION_RANGE_TITLE]] is high and [[encyclopedia STARLANE_SPEED_TITLE]] is high.
+[[encyclopedia STEALTH_TITLE]] is good, [[encyclopedia DETECTION_RANGE_TITLE]] is high and [[encyclopedia STARLANE_SPEED_TITLE]] is high. 
 
 Living hull regenerates [[encyclopedia STRUCTURE_TITLE]] and [[encyclopedia FUEL_TITLE]] between combats. Potentially a powerful warship, commerce raider or armed scout.
 
@@ -10488,7 +10486,7 @@ SH_RAVENOUS_DESC
 
 Organic Growth: starts with 5 [[encyclopedia STRUCTURE_TITLE]], grows an additional 20 structure over 40 turns.
 
-[[encyclopedia STEALTH_TITLE]] is low, [[encyclopedia DETECTION_RANGE_TITLE]] is excellent and [[encyclopedia STARLANE_SPEED_TITLE]] is high.
+[[encyclopedia STEALTH_TITLE]] is low, [[encyclopedia DETECTION_RANGE_TITLE]] is excellent and [[encyclopedia STARLANE_SPEED_TITLE]] is high. 
 
 Potentially a powerful and fast warship.
 
@@ -10501,10 +10499,10 @@ SH_BIOADAPTIVE
 Bio-Adaptive Hull
 
 SH_BIOADAPTIVE_DESC
-'''A living hull with mind and body in unison, master of healing and endurance. It has three external slots and three internal slots.
+'''A living hull with mind and body in unison, master of healing and endurance. It has three external slots and three internal slots. 
 Organic Growth: starts with 15 [[encyclopedia STRUCTURE_TITLE]], grows an additional 25 structure over 50 turns.
 
-[[encyclopedia STEALTH_TITLE]] is high, [[encyclopedia DETECTION_RANGE_TITLE]] is excellent and [[encyclopedia STARLANE_SPEED_TITLE]] is high.
+[[encyclopedia STEALTH_TITLE]] is high, [[encyclopedia DETECTION_RANGE_TITLE]] is excellent and [[encyclopedia STARLANE_SPEED_TITLE]] is high. 
 
 Potentially a powerful and fast commerce raider or scout.
 
@@ -10517,10 +10515,10 @@ SH_SENTIENT
 Sentient Hull
 
 SH_SENTIENT_DESC
-'''This self-aware organic flagship with powerful analytical abilities and a tremendous memory capacity, which allow it to direct friendly vessels and provide them with useful information and subtle tactical cues in combat, giving a [[encyclopedia STEALTH_TITLE]] and [[encyclopedia DETECTION_RANGE_TITLE]] bonus to all accompanying friendly ships. It has six external slots, three internal slots, and a core slot.
+'''This self-aware organic flagship with powerful analytical abilities and a tremendous memory capacity, which allow it to direct friendly vessels and provide them with useful information and subtle tactical cues in combat, giving a [[encyclopedia STEALTH_TITLE]] and [[encyclopedia DETECTION_RANGE_TITLE]] bonus to all accompanying friendly ships. It has six external slots, three internal slots, and a core slot. 
 Organic Growth: Starts with 12 [[encyclopedia STRUCTURE_TITLE]], grows an additional 45 over 45 turns.
 
-[[encyclopedia STEALTH_TITLE]] is good, [[encyclopedia DETECTION_RANGE_TITLE]] is good and [[encyclopedia STARLANE_SPEED_TITLE]] is high.
+[[encyclopedia STEALTH_TITLE]] is good, [[encyclopedia DETECTION_RANGE_TITLE]] is good and [[encyclopedia STARLANE_SPEED_TITLE]] is high. 
 
 This hull regenerates [[encyclopedia STRUCTURE_TITLE]] and [[encyclopedia FUEL_TITLE]] between combats.
 
@@ -10530,18 +10528,18 @@ SH_COMPRESSED_ENERGY
 Compressed Energy Hull
 
 SH_COMPRESSED_ENERGY_DESC
-'''This fast hull is comprised entirely of compressed energy and has a single external slot.
+'''This fast hull is comprised entirely of compressed energy and has a single external slot. 
 
-Structure is low, [[encyclopedia STEALTH_TITLE]] is good, [[encyclopedia DETECTION_RANGE_TITLE]] is normal and [[encyclopedia STARLANE_SPEED_TITLE]] is very high.
+Structure is low, [[encyclopedia STEALTH_TITLE]] is good, [[encyclopedia DETECTION_RANGE_TITLE]] is normal and [[encyclopedia STARLANE_SPEED_TITLE]] is very high. 
 
 This hull requires a great deal of energy to construct and can only be built at a system with a star of type White, Blue or Black Hole and requires a [[buildingtype BLD_SHIPYARD_BASE]] and an [[buildingtype BLD_SHIPYARD_ENRG_COMP]] at the planet where it is formed.'''
 
 SH_ENERGY_FRIGATE
 Energy Frigate
 SH_ENERGY_FRIGATE_DESC
-'''This fast hull combines compressed energy and warship technology to create a fast but fragile attack ship.
+'''This fast hull combines compressed energy and warship technology to create a fast but fragile attack ship. 
 
-[[encyclopedia STRUCTURE_TITLE]] and [[encyclopedia STEALTH_TITLE]] are low, [[encyclopedia DETECTION_RANGE_TITLE]] is normal and [[encyclopedia STARLANE_SPEED_TITLE]] is very high.
+[[encyclopedia STRUCTURE_TITLE]] and [[encyclopedia STEALTH_TITLE]] are low, [[encyclopedia DETECTION_RANGE_TITLE]] is normal and [[encyclopedia STARLANE_SPEED_TITLE]] is very high. 
 
 This hull requires a great deal of energy to construct and can only be built at a system with a star of type White, Blue or Black Hole and requires a [[buildingtype BLD_SHIPYARD_BASE]] and an [[buildingtype BLD_SHIPYARD_ENRG_COMP]] at the planet where it is formed.'''
 
@@ -10549,9 +10547,9 @@ SH_FRACTAL_ENERGY
 Fractal Energy Hull
 
 SH_FRACTAL_ENERGY_DESC
-'''This hull, while small, has a fractal surface which allows many more parts to be mounted than would be possible on a smoother hull. It has fourteen external slots, but no internal slots.
+'''This hull, while small, has a fractal surface which allows many more parts to be mounted than would be possible on a smoother hull. It has fourteen external slots, but no internal slots. 
 
-[[encyclopedia STRUCTURE_TITLE]] is moderate, [[encyclopedia STEALTH_TITLE]] is very low, [[encyclopedia DETECTION_RANGE_TITLE]] is normal and [[encyclopedia STARLANE_SPEED_TITLE]] is very high.
+[[encyclopedia STRUCTURE_TITLE]] is moderate, [[encyclopedia STEALTH_TITLE]] is very low, [[encyclopedia DETECTION_RANGE_TITLE]] is normal and [[encyclopedia STARLANE_SPEED_TITLE]] is very high.  
 
 This hull requires a very great deal of energy to construct—it can only be built at a system with a star of type Blue or Black Hole and requires a [[buildingtype BLD_SHIPYARD_BASE]], and an [[buildingtype BLD_SHIPYARD_ENRG_COMP]] at the planet where it is formed.'''
 
@@ -10559,9 +10557,9 @@ SH_QUANTUM_ENERGY
 Quantum Energy Hull
 
 SH_QUANTUM_ENERGY_DESC
-'''This hull magnifies quantum energy fluctuations to increase its own power. It has seven external slots and three internal slots.
+'''This hull magnifies quantum energy fluctuations to increase its own power. It has seven external slots and three internal slots. 
 
-[[encyclopedia STRUCTURE_TITLE]] is moderate, [[encyclopedia STEALTH_TITLE]] is very low, [[encyclopedia DETECTION_RANGE_TITLE]] is normal and [[encyclopedia STARLANE_SPEED_TITLE]] is very high.
+[[encyclopedia STRUCTURE_TITLE]] is moderate, [[encyclopedia STEALTH_TITLE]] is very low, [[encyclopedia DETECTION_RANGE_TITLE]] is normal and [[encyclopedia STARLANE_SPEED_TITLE]] is very high.  
 
 This hull requires a very great deal of energy to construct—it can only be built at a system with a star of type Blue or Black Hole and requires a [[buildingtype BLD_SHIPYARD_BASE]], and an [[buildingtype BLD_SHIPYARD_ENRG_COMP]] at the planet where it is formed.'''
 
@@ -10571,7 +10569,7 @@ Solar Hull
 SH_SOLAR_DESC
 '''This mighty flagship is essentially a miniature sun, and as such is a great source of both [[encyclopedia FUEL_TITLE]] and visibility. All accompanying friendly ships completely recover fuel between combat, and all enemy ships in the vicinity receive a penalty to [[encyclopedia STEALTH_TITLE]]. This hull has eighteen external slots, eight internal slots and a core slot—a far greater internal capacity than any other hull.
 
-[[encyclopedia STRUCTURE_TITLE]] is extremely high, [[encyclopedia STEALTH_TITLE]] is very low, [[encyclopedia DETECTION_RANGE_TITLE]] is normal and [[encyclopedia STARLANE_SPEED_TITLE]] is very high. However, this ship has the ability to enter a star and hide, giving it perfect [[encyclopedia STEALTH_TITLE]] on the galaxy map when it is in a system with a star of type other than Black Hole or Neutron, and in combat, when it is hiding inside such a star.
+[[encyclopedia STRUCTURE_TITLE]] is extremely high, [[encyclopedia STEALTH_TITLE]] is very low, [[encyclopedia DETECTION_RANGE_TITLE]] is normal and [[encyclopedia STARLANE_SPEED_TITLE]] is very high. However, this ship has the ability to enter a star and hide, giving it perfect [[encyclopedia STEALTH_TITLE]] on the galaxy map when it is in a system with a star of type other than Black Hole or Neutron, and in combat, when it is hiding inside such a star. 
 
 This ship requires a tremendous amount of energy to construct and must harness energy from particle-antiparticle collisions on the event horizon of a Black Hole in its formation. It requires a [[buildingtype BLD_SHIPYARD_BASE]], an [[buildingtype BLD_SHIPYARD_ENRG_COMP]] and a [[buildingtype BLD_SHIPYARD_ENRG_SOLAR]] at the planet where it is built.'''
 
@@ -10580,7 +10578,7 @@ Basic Small Hull
 SH_BASIC_SMALL_DESC
 '''A small, basic interstellar hull. It has only one external slot but can make an extra jump compared to other basic hulls.
 
-[[encyclopedia STEALTH_TITLE]] is low, [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is average.
+[[encyclopedia STEALTH_TITLE]] is low, [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is average. 
 
 Requires a [[buildingtype BLD_SHIPYARD_BASE]] at the planet where it is constructed.'''
 
@@ -10589,7 +10587,7 @@ Basic Medium Hull
 SH_BASIC_MEDIUM_DESC
 '''A medium-sized, basic interstellar hull, with two external slots and one internal slot.
 
-[[encyclopedia STEALTH_TITLE]] is low, [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low.
+[[encyclopedia STEALTH_TITLE]] is low, [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low. 
 
 Requires a [[buildingtype BLD_SHIPYARD_BASE]] at the planet where it is constructed.'''
 
@@ -10599,7 +10597,7 @@ Basic Large Hull
 SH_STANDARD_DESC
 '''A large, basic interstellar hull, with three external slots and one internal slot.
 
-[[encyclopedia STEALTH_TITLE]] is low, [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low.
+[[encyclopedia STEALTH_TITLE]] is low, [[encyclopedia DETECTION_RANGE_TITLE]] is average and [[encyclopedia STARLANE_SPEED_TITLE]] is low. 
 
 Requires a [[buildingtype BLD_SHIPYARD_BASE]] at the planet where it is constructed.'''
 
@@ -10777,9 +10775,9 @@ GROWTH_SPECIAL_POPULATION_LITHIC_INCREASE
 [[encyclopedia LITHIC_SPECIES_TITLE]] [[GROWTH_SPECIAL_POPULATION_INCREASE]] [[LITHIC_SPECIES_TITLE]].
 
 GROWTH_SPECIAL_POPULATION_INCREASE
-'''species inhabiting this planet will have the maximum population boosted by planet size (Tiny: +1, Small: +2, Medium: +3, Large: +4, Huge: +5) regardless of planetary environmment.
+'''species inhabiting this planet will have the maximum population boosted by planet size (Tiny: +1, Small: +2, Medium: +3, Large: +4, Huge: +5) regardless of planetary environmment. 
 
-If this planet is set to the [[encyclopedia GROWTH_FOCUS_TITLE]], the bonus is applied to all [[encyclopedia SUPPLY_TITLE]] connected worlds inhabited by species with'''
+If this planet is set to the [[encyclopedia GROWTH_FOCUS_TITLE]], the bonus is applied to all [[encyclopedia SUPPLY_TITLE]] connected worlds inhabited by species with''' 
 
 GROWTH_SPECIAL_INDUSTRY_BOOST
 If this planet is set to the Industry Focus, target [[encyclopedia INDUSTRY_TITLE]] is increased by 0.2 per Population.
@@ -11327,7 +11325,7 @@ Krill Spawner
 
 ### End of AI Shipdesign Name Lists
 
-### AI Diplomacy Strings and Lists
+### AI Diplomacy Strings and Lists 
 ### Translator Note: for AI Keys ending with "LIST", each line of the provided value should be an independent entry; each entry must be a single line.
 ### For such lists, you may provide more or fewer entries than are provided in en.txt, unless otherwise indicated in a comment for that key
 
@@ -11464,7 +11462,7 @@ Sending you to your ancestors is our sacred duty!
 # NOTE TO TRANSLATORS:
 # The following lists group the AI turn 1 greetings by AI agression level.
 # These are functional lists that must not be translated!
-
+ 
 AI_FIRST_TURN_GREETING_LIST_BEGINNER
 '''AI_FIRST_TURN_GREETING_MSG101
 AI_FIRST_TURN_GREETING_MSG102
@@ -12165,7 +12163,7 @@ Helevorn
 Helix
 Helliconia
 Helos
-Helotrix
+Helotrix 
 Hematopf
 Henderson
 Henge
@@ -14942,3 +14940,4 @@ MONSTER_NAMES
 #include "../global_settings.txt"
 #include "../content_specific_parameters.txt"
 #include "../customizations/common_user_customizations.txt"
+

--- a/util/Order.cpp
+++ b/util/Order.cpp
@@ -1152,7 +1152,7 @@ void ShipDesignOrder::ExecuteImpl() const {
         }
         empire->RemoveShipDesign(m_design_id);
         empire->AddShipDesign(m_design_id, m_design_id_after);
-        DebugLogger()<<"Move Ship Design "<<m_design_id << " to before "<<m_design_id_after;
+        DebugLogger() << "Move Ship Design " << m_design_id << " to before " << m_design_id_after;
 
     } else {
         // player is ordering empire to retain a particular design, so that is can

--- a/util/Order.h
+++ b/util/Order.h
@@ -88,7 +88,7 @@ public:
 
 private:
     /**
-     * Preconditions of execute: 
+     * Preconditions of execute:
      *    - the designated planet must exist, be owned by the issuing empire
      *
      *  Postconditions:
@@ -109,7 +109,7 @@ private:
 /////////////////////////////////////////////////////
 // NewFleetOrder
 /////////////////////////////////////////////////////
-/** the Order subclass that represents forming a new fleet. 
+/** the Order subclass that represents forming a new fleet.
     Only one of system or position will be used to place the new fleet.*/
 class FO_COMMON_API NewFleetOrder : public Order {
 public:
@@ -179,7 +179,7 @@ private:
      *    - m_fleet is a valid id of a fleet owned by the order-giving empire
      *    - if the fleet is located in a system, m_start_system is the id of that system
      *    - if the fleet is not located in a system, m_start_system is the id of the system the fleet is moving to
-     *    - 
+     *    -
      *
      *  Postconditions:
      *    - TODO: WRITE THIS
@@ -409,7 +409,7 @@ public:
 
 private:
     /**
-     * Preconditions of execute: 
+     * Preconditions of execute:
      *    - the designated planet must exist, be owned by the issuing empire
      *
      *  Postconditions:
@@ -506,7 +506,9 @@ private:
   * The 3-arg ctor taking a ShipDesign argument creates a new shipdesign in the
   * universe's catalog of shipdesigns with the passed new design id, and adds
   * this design to the \a empire's set of remembered designs.  The new design
-  * must be marked as designed by this \a empire.*/
+  * must be marked as designed by this \a empire.
+  * The 3-arg ctor (int,int,int) moves a design_id_to_move to before design_id_after
+  */
 class FO_COMMON_API ShipDesignOrder : public Order {
 public:
     /** \name Structors */ //@{
@@ -515,6 +517,7 @@ public:
     ShipDesignOrder(int empire, int design_id_to_erase, bool dummy);
     ShipDesignOrder(int empire, int new_design_id, const ShipDesign& ship_design);
     ShipDesignOrder(int empire, int existing_design_id, const std::string& new_name = "", const std::string& new_description = "");
+    ShipDesignOrder(int empire, int design_id_to_move, int design_id_after);
     //@}
 
 private:
@@ -542,6 +545,7 @@ private:
     bool                        m_update_name_or_description;
     bool                        m_delete_design_from_empire;
     bool                        m_create_new_design;
+    bool                        m_move_design;
 
     // details of design to create
     std::string                 m_name;
@@ -553,6 +557,7 @@ private:
     std::string                 m_icon;
     std::string                 m_3D_model;
     bool                        m_name_desc_in_stringtable;
+    int                         m_design_id_after;             //<location after the inserted design
     // end details of design to create
 
     friend class boost::serialization::access;

--- a/util/SerializeEmpire.cpp
+++ b/util/SerializeEmpire.cpp
@@ -116,6 +116,7 @@ void Empire::serialize(Archive& ar, const unsigned int version)
         m_id == GetUniverse().EncodingEmpire())
     {
         ar  & BOOST_SERIALIZATION_NVP(m_ship_designs)
+            & BOOST_SERIALIZATION_NVP(m_ship_designs_ordered)
             & BOOST_SERIALIZATION_NVP(m_sitrep_entries)
             & BOOST_SERIALIZATION_NVP(m_resource_pools)
             & BOOST_SERIALIZATION_NVP(m_population_pool)

--- a/util/SerializeOrderSet.cpp
+++ b/util/SerializeOrderSet.cpp
@@ -150,6 +150,7 @@ void ShipDesignOrder::serialize(Archive& ar, const unsigned int version)
     ar  & BOOST_SERIALIZATION_NVP(m_design_id);
     ar  & BOOST_SERIALIZATION_NVP(m_delete_design_from_empire);
     ar  & BOOST_SERIALIZATION_NVP(m_create_new_design);
+    ar  & BOOST_SERIALIZATION_NVP(m_move_design);
     ar  & BOOST_SERIALIZATION_NVP(m_update_name_or_description);
     ar  & BOOST_SERIALIZATION_NVP(m_name);
     ar  & BOOST_SERIALIZATION_NVP(m_description);
@@ -160,6 +161,7 @@ void ShipDesignOrder::serialize(Archive& ar, const unsigned int version)
     ar  & BOOST_SERIALIZATION_NVP(m_icon);
     ar  & BOOST_SERIALIZATION_NVP(m_3D_model);
     ar  & BOOST_SERIALIZATION_NVP(m_name_desc_in_stringtable);
+    ar  & BOOST_SERIALIZATION_NVP(m_design_id_after);
 }
 
 template <class Archive>
@@ -196,4 +198,3 @@ void Deserialize(Archive& ia, OrderSet& order_set)
 { ia >> BOOST_SERIALIZATION_NVP(order_set); }
 template void Deserialize<freeorion_bin_iarchive>(freeorion_bin_iarchive& ia, OrderSet& order_set);
 template void Deserialize<freeorion_xml_iarchive>(freeorion_xml_iarchive& ia, OrderSet& order_set);
-


### PR DESCRIPTION
This patch adds new features to the Design Window.

It adds the ability sort completed designs and have the order be persistent and usable in the Production Window.

It adds a button that replaces a current completed design with the new/upgraded design, called "Replace Old Design"

It changes the confirm button text to "Add New Design"  

It changes the delete design wording to "Obsolete", as it doesn't delete anything.

P.S I tried to register for the website, to provide my new user experience and discuss changes.  I think there is a delay or it didn't like my temporary email addresses.
