### PR TITLE
Add blank line in pedia planet details between cyclical environments …

### DIFF
--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -1732,8 +1732,8 @@ namespace {
             {
                 detailed_description += UserString(boost::lexical_cast<std::string>(pt_env_it->first)) + " : " +
                                         UserString(boost::lexical_cast<std::string>(pt_env_it->second)) + "\n";
-                //add blank line between cyclical environments and asteroids and gas giants
-                if(pt_env_it->first == PT_OCEAN){
+                // add blank line between cyclical environments and asteroids and gas giants
+                if (pt_env_it->first == PT_OCEAN) {
                     detailed_description += "\n";
                 }
             }

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -1732,6 +1732,10 @@ namespace {
             {
                 detailed_description += UserString(boost::lexical_cast<std::string>(pt_env_it->first)) + " : " +
                                         UserString(boost::lexical_cast<std::string>(pt_env_it->second)) + "\n";
+                //add blank line between cyclical environments and asteroids and gas giants
+                if(pt_env_it->first == PT_OCEAN){
+                    detailed_description += "\n";
+                }
             }
         } else {
             detailed_description += "\n";


### PR DESCRIPTION
…and asteroids and gas giants.

I mentioned this in one of my posts to the website.  In the pedia planet page for a species environmental
preferences, this patch adds a blank line between the ocean environment and asteroids.  It will make
it easier to visually pick out the cycle of species environmental preferences.
