### PR TITLE
Fix multimonitor persistence

### DIFF
--- a/GG/GG/SDL/SDLGUI.h
+++ b/GG/GG/SDL/SDLGUI.h
@@ -122,7 +122,15 @@ public:
     // \override
     virtual Pt      GetDefaultResolution (int display_id);
     static  Pt      GetDefaultResolutionStatic(int display_id);
+    static int      NumVideoDisplaysStatic();
     virtual bool    FramebuffersAvailable() const;
+
+    /** Returns the largest possible width if all displays are aligned horizontally.
+        Ideally it reports actual desktop width using all displays.*/
+    static int MaximumPossibleWidth();
+    /** Returns the largest possible height if all displays are aligned vertically.
+        Ideally it reports the actual desktop height using all displays.*/
+    static int MaximumPossibleHeight();
 protected:
     void SetAppSize(const GG::Pt& size);
 
@@ -144,6 +152,11 @@ protected:
     virtual void    Run();
 
     void            ResetFramebuffer(); ///< Resizes or deletes the framebuffer for fake fullscreen.
+
+    /** Given is_width = true (false) it returns the largest possible window
+        width (height) if all displays are aligned horizontally (vertically).
+        Ideally it returns the actual width (height) of a multi-monitor display.*/
+    static int MaximumPossibleDimension(bool is_width = true);
 
 private:
     void            RelayTextInput (const SDL_TextInputEvent& text, Pt mouse_pos);

--- a/GG/GG/SDL/SDLGUI.h
+++ b/GG/GG/SDL/SDLGUI.h
@@ -147,6 +147,8 @@ protected:
 
 private:
     void            RelayTextInput (const SDL_TextInputEvent& text, Pt mouse_pos);
+    // Bare minimum SDL video initialization to allow queries to display sizes etc.
+    static void     SDLMinimalInit();
 
     X         m_app_width;      ///< application width and height (defaults to 1024 x 768)
     Y         m_app_height;

--- a/GG/src/SDL/SDLGUI.cpp
+++ b/GG/src/SDL/SDLGUI.cpp
@@ -907,10 +907,14 @@ Pt SDLGUI::GetDefaultResolutionStatic(int display_id)
         }
     }
 
-    SDL_DisplayMode mode;
-    SDL_GetDesktopDisplayMode(display_id, &mode);
-    Pt resolution(X(mode.w), Y(mode.h));
-    return resolution;
+    if (display_id >=0 && display_id < SDL_GetNumVideoDisplays()) {
+        SDL_DisplayMode mode;
+        SDL_GetDesktopDisplayMode(display_id, &mode);
+        Pt resolution(X(mode.w), Y(mode.h));
+        return resolution;
+    } else {
+        return Pt(X0, Y0);
+    }
 }
 
 void SDLGUI::RelayTextInput(const SDL_TextInputEvent& text, GG::Pt mouse_pos)

--- a/GG/src/SDL/SDLGUI.cpp
+++ b/GG/src/SDL/SDLGUI.cpp
@@ -895,21 +895,21 @@ std::vector<std::string> SDLGUI::GetSupportedResolutions() const
 void SDLGUI::SDLMinimalInit()
 {
     if (!SDL_WasInit(SDL_INIT_VIDEO)) {
-        if(SDL_Init(SDL_INIT_VIDEO) < 0) {
+        if (SDL_Init(SDL_INIT_VIDEO) < 0) {
             std::cerr << "SDL initialization failed: " << SDL_GetError() << std::endl;
             throw std::runtime_error("Failed to initialize SDL");
         }
     }
 }
 
-Pt SDLGUI::GetDefaultResolution (int display_id)
+Pt SDLGUI::GetDefaultResolution(int display_id)
 { return GetDefaultResolutionStatic(display_id); }
 
 Pt SDLGUI::GetDefaultResolutionStatic(int display_id)
 {
     SDLMinimalInit();
 
-    if (display_id >=0 && display_id < SDL_GetNumVideoDisplays()) {
+    if (display_id >= 0 && display_id < SDL_GetNumVideoDisplays()) {
         SDL_DisplayMode mode;
         SDL_GetDesktopDisplayMode(display_id, &mode);
         Pt resolution(X(mode.w), Y(mode.h));
@@ -929,9 +929,9 @@ int SDLGUI::MaximumPossibleDimension(bool is_width) {
     int dim = 0;
 
     int num_displays = NumVideoDisplaysStatic();
-    for (int idisplay = 0; idisplay < num_displays; ++idisplay) {
+    for (int i_display = 0; i_display < num_displays; ++i_display) {
         SDL_Rect r;
-        if (SDL_GetDisplayBounds(idisplay, &r) == 0) {
+        if (SDL_GetDisplayBounds(i_display, &r) == 0) {
             dim += is_width ? r.w : r.h;
         }
     }

--- a/GG/src/SDL/SDLGUI.cpp
+++ b/GG/src/SDL/SDLGUI.cpp
@@ -619,11 +619,7 @@ void SDLGUI::SDLInit()
 {
     InitializeKeyMap(m_key_map);
 
-    int sdl_status = SDL_Init(SDL_INIT_VIDEO);
-    if(sdl_status < 0) {
-        std::cerr << "Failed to initialize sdl. SDL_Init returned: " << sdl_status << std::endl;
-        Exit(1);
-    }
+    SDLMinimalInit();
 
     SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
     SDL_GL_SetAttribute(SDL_GL_STENCIL_SIZE, 2);
@@ -875,6 +871,8 @@ std::vector<std::string> SDLGUI::GetSupportedResolutions() const
 {
     std::vector<std::string> mode_vec;
 
+    SDLMinimalInit();
+
     unsigned valid_mode_count = SDL_GetNumDisplayModes(m_display_id);
 
     /* Check if our resolution is restricted */
@@ -894,18 +892,22 @@ std::vector<std::string> SDLGUI::GetSupportedResolutions() const
     return mode_vec;
 }
 
-Pt SDLGUI::GetDefaultResolution (int display_id)
-{ return GetDefaultResolutionStatic(display_id); }
-
-Pt SDLGUI::GetDefaultResolutionStatic(int display_id)
+void SDLGUI::SDLMinimalInit()
 {
-    // Must initialize sdl here to be able to query the default screen resolution
     if (!SDL_WasInit(SDL_INIT_VIDEO)) {
         if(SDL_Init(SDL_INIT_VIDEO) < 0) {
             std::cerr << "SDL initialization failed: " << SDL_GetError() << std::endl;
             throw std::runtime_error("Failed to initialize SDL");
         }
     }
+}
+
+Pt SDLGUI::GetDefaultResolution (int display_id)
+{ return GetDefaultResolutionStatic(display_id); }
+
+Pt SDLGUI::GetDefaultResolutionStatic(int display_id)
+{
+    SDLMinimalInit();
 
     if (display_id >=0 && display_id < SDL_GetNumVideoDisplays()) {
         SDL_DisplayMode mode;

--- a/GG/src/SDL/SDLGUI.cpp
+++ b/GG/src/SDL/SDLGUI.cpp
@@ -919,6 +919,32 @@ Pt SDLGUI::GetDefaultResolutionStatic(int display_id)
     }
 }
 
+int SDLGUI::NumVideoDisplaysStatic()
+{
+    SDLMinimalInit();
+    return SDL_GetNumVideoDisplays();
+}
+
+int SDLGUI::MaximumPossibleDimension(bool is_width) {
+    int dim = 0;
+
+    int num_displays = NumVideoDisplaysStatic();
+    for (int idisplay = 0; idisplay < num_displays; ++idisplay) {
+        SDL_Rect r;
+        if (SDL_GetDisplayBounds(idisplay, &r) == 0) {
+            dim += is_width ? r.w : r.h;
+        }
+    }
+    return dim;
+}
+
+int SDLGUI::MaximumPossibleWidth()
+{ return MaximumPossibleDimension(true); }
+
+int SDLGUI::MaximumPossibleHeight()
+{ return MaximumPossibleDimension(false); }
+
+
 void SDLGUI::RelayTextInput(const SDL_TextInputEvent& text, GG::Pt mouse_pos)
 {
     const char *current = text.text;

--- a/UI/CUIWnd.cpp
+++ b/UI/CUIWnd.cpp
@@ -250,8 +250,8 @@ void CUIWnd::SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
             // Keep this CUIWnd entirely inside the application window.
             available_size = GG::Pt(app->AppWidth(), app->AppHeight());
         } else {
-            available_size = GG::Pt( GG::X(HumanClientApp::MaximumPossibleWidth()),
-                                     GG::Y(HumanClientApp::MaximumPossibleHeight()));
+            available_size = GG::Pt(GG::X(HumanClientApp::MaximumPossibleWidth()),
+                                    GG::Y(HumanClientApp::MaximumPossibleHeight()));
             ErrorLogger() << "CUIWnd::SizeMove() could not get app instance!";
         }
 

--- a/UI/CUIWnd.cpp
+++ b/UI/CUIWnd.cpp
@@ -241,8 +241,8 @@ void CUIWnd::ValidatePosition()
 void CUIWnd::SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
     GG::Pt old_sz = Size();
     if (m_config_save) {    // can write position/size to OptionsDB
-        GG::Pt available_size(GG::X(2048), GG::Y(2048));    // arbitrary large values in case available_size can't be set below
 
+        GG::Pt available_size;
         if (const GG::Wnd* parent = Parent()) {
             // Keep this CUIWnd entirely inside its parent.
             available_size = parent->ClientSize();
@@ -250,6 +250,8 @@ void CUIWnd::SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
             // Keep this CUIWnd entirely inside the application window.
             available_size = GG::Pt(app->AppWidth(), app->AppHeight());
         } else {
+            available_size = GG::Pt( GG::X(HumanClientApp::MaximumPossibleWidth()),
+                                     GG::Y(HumanClientApp::MaximumPossibleHeight()));
             ErrorLogger() << "CUIWnd::SizeMove() could not get app instance!";
         }
 

--- a/UI/CUIWnd.cpp
+++ b/UI/CUIWnd.cpp
@@ -752,17 +752,20 @@ const std::string CUIWnd::AddWindowOptions(const std::string& config_name,
             new_name = config_name;
         }
     } else if (!config_name.empty()) {
+        const int max_width_plus_one = HumanClientApp::MaximumPossibleWidth() + 1;
+        const int max_height_plus_one = HumanClientApp::MaximumPossibleHeight() + 1;
+
         db.Add<bool>("UI.windows."+config_name+".initialized",      UserStringNop("OPTIONS_DB_UI_WINDOWS_EXISTS"),          false,      Validator<bool>(),              false);
 
-        db.Add<int> ("UI.windows."+config_name+".left",             UserStringNop("OPTIONS_DB_UI_WINDOWS_LEFT"),            left,       OrValidator<int>(RangedValidator<int>(0, 2560), DiscreteValidator<int>(INVALID_POS)));
-        db.Add<int> ("UI.windows."+config_name+".top",              UserStringNop("OPTIONS_DB_UI_WINDOWS_TOP"),             top,        OrValidator<int>(RangedValidator<int>(0, 1600), DiscreteValidator<int>(INVALID_POS)));
-        db.Add<int> ("UI.windows."+config_name+".left-windowed",    UserStringNop("OPTIONS_DB_UI_WINDOWS_LEFT_WINDOWED"),   left,       OrValidator<int>(RangedValidator<int>(0, 2560), DiscreteValidator<int>(INVALID_POS)));
-        db.Add<int> ("UI.windows."+config_name+".top-windowed",     UserStringNop("OPTIONS_DB_UI_WINDOWS_TOP_WINDOWED"),    top,        OrValidator<int>(RangedValidator<int>(0, 1600), DiscreteValidator<int>(INVALID_POS)));
+        db.Add<int> ("UI.windows."+config_name+".left",             UserStringNop("OPTIONS_DB_UI_WINDOWS_LEFT"),            left,       OrValidator<int>(RangedValidator<int>(0, max_width_plus_one), DiscreteValidator<int>(INVALID_POS)));
+        db.Add<int> ("UI.windows."+config_name+".top",              UserStringNop("OPTIONS_DB_UI_WINDOWS_TOP"),             top,        OrValidator<int>(RangedValidator<int>(0, max_height_plus_one), DiscreteValidator<int>(INVALID_POS)));
+        db.Add<int> ("UI.windows."+config_name+".left-windowed",    UserStringNop("OPTIONS_DB_UI_WINDOWS_LEFT_WINDOWED"),   left,       OrValidator<int>(RangedValidator<int>(0, max_width_plus_one), DiscreteValidator<int>(INVALID_POS)));
+        db.Add<int> ("UI.windows."+config_name+".top-windowed",     UserStringNop("OPTIONS_DB_UI_WINDOWS_TOP_WINDOWED"),    top,        OrValidator<int>(RangedValidator<int>(0, max_height_plus_one), DiscreteValidator<int>(INVALID_POS)));
 
-        db.Add<int> ("UI.windows."+config_name+".width",            UserStringNop("OPTIONS_DB_UI_WINDOWS_WIDTH"),           width,      RangedValidator<int>(0, 2560));
-        db.Add<int> ("UI.windows."+config_name+".height",           UserStringNop("OPTIONS_DB_UI_WINDOWS_HEIGHT"),          height,     RangedValidator<int>(0, 1600));
-        db.Add<int> ("UI.windows."+config_name+".width-windowed",   UserStringNop("OPTIONS_DB_UI_WINDOWS_WIDTH_WINDOWED"),  width,      RangedValidator<int>(0, 2560));
-        db.Add<int> ("UI.windows."+config_name+".height-windowed",  UserStringNop("OPTIONS_DB_UI_WINDOWS_HEIGHT_WINDOWED"), height,     RangedValidator<int>(0, 1600));
+        db.Add<int> ("UI.windows."+config_name+".width",            UserStringNop("OPTIONS_DB_UI_WINDOWS_WIDTH"),           width,      RangedValidator<int>(0, max_width_plus_one));
+        db.Add<int> ("UI.windows."+config_name+".height",           UserStringNop("OPTIONS_DB_UI_WINDOWS_HEIGHT"),          height,     RangedValidator<int>(0, max_height_plus_one));
+        db.Add<int> ("UI.windows."+config_name+".width-windowed",   UserStringNop("OPTIONS_DB_UI_WINDOWS_WIDTH_WINDOWED"),  width,      RangedValidator<int>(0, max_width_plus_one));
+        db.Add<int> ("UI.windows."+config_name+".height-windowed",  UserStringNop("OPTIONS_DB_UI_WINDOWS_HEIGHT_WINDOWED"), height,     RangedValidator<int>(0, max_height_plus_one));
 
         db.Add<bool>("UI.windows."+config_name+".visible",          UserStringNop("OPTIONS_DB_UI_WINDOWS_VISIBLE"),         visible,    Validator<bool>());
         db.Add<bool>("UI.windows."+config_name+".pinned",           UserStringNop("OPTIONS_DB_UI_WINDOWS_PINNED"),          pinned,     Validator<bool>());

--- a/UI/CUIWnd.h
+++ b/UI/CUIWnd.h
@@ -141,6 +141,7 @@ public:
 
     //! \name Statics //@{
     static void     InvalidateUnusedOptions();          //!< removes unregistered and registered-but-unused window options from the OptionsDB so that new windows fall back to their default properties.
+
     //@}
 
 protected:

--- a/UI/TechTreeWnd.cpp
+++ b/UI/TechTreeWnd.cpp
@@ -284,7 +284,6 @@ TechTreeWnd::TechTreeControls::TechTreeControls(const std::string& config_name) 
 
     SetChildClippingMode(ClipToClient);
     DoButtonLayout();
-    Resize(GG::Pt(Width(), MinSize().y));
 }
 
 void TechTreeWnd::TechTreeControls::DoButtonLayout() {
@@ -1829,8 +1828,6 @@ void TechTreeWnd::InitializeWindows() {
     const GG::Pt controls_wh(m_layout_panel->Width() - ClientUI::ScrollWidth(), GG::Y0);
 
     m_enc_detail_panel->InitSizeMove(pedia_ul,  pedia_ul + pedia_wh);
-    // Size to new width so it recalculates its own height.
-    m_tech_tree_controls->Resize(GG::Pt(controls_wh.x, m_tech_tree_controls->Height()));
     m_tech_tree_controls->InitSizeMove(controls_ul,  controls_ul + controls_wh);
 }
 

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -108,7 +108,7 @@ namespace {
     /** These options can only be validated after the graphics system (SDL) is initialized,
         so that display size can be detected
      */
-    const int DEFAULT_WIDTH = 1025;
+    const int DEFAULT_WIDTH = 1024;
     const int DEFAULT_HEIGHT = 768;
     const int DEFAULT_LEFT = static_cast<int>(SDL_WINDOWPOS_CENTERED);
     const int DEFAULT_TOP = 50;
@@ -119,12 +119,12 @@ namespace {
         const int max_width_plus_one = HumanClientApp::MaximumPossibleWidth() + 1;
         const int max_height_plus_one = HumanClientApp::MaximumPossibleHeight() + 1;
 
-        db.Add("app-width",             UserStringNop("OPTIONS_DB_APP_WIDTH"),             DEFAULT_WIDTH,   RangedValidator<int>(MIN_WIDTH, max_width_plus_one));
-        db.Add("app-height",            UserStringNop("OPTIONS_DB_APP_HEIGHT"),            DEFAULT_HEIGHT,    RangedValidator<int>(MIN_HEIGHT, max_height_plus_one));
-        db.Add("app-width-windowed",    UserStringNop("OPTIONS_DB_APP_WIDTH_WINDOWED"),    DEFAULT_WIDTH,   RangedValidator<int>(MIN_WIDTH, max_width_plus_one));
-        db.Add("app-height-windowed",   UserStringNop("OPTIONS_DB_APP_HEIGHT_WINDOWED"),   DEFAULT_HEIGHT,    RangedValidator<int>(MIN_HEIGHT, max_height_plus_one));
-        db.Add("app-left-windowed",     UserStringNop("OPTIONS_DB_APP_LEFT_WINDOWED"),     DEFAULT_LEFT, OrValidator<int>( RangedValidator<int>(-max_width_plus_one, max_width_plus_one), DiscreteValidator<int>(DEFAULT_LEFT) ));
-        db.Add("app-top-windowed",      UserStringNop("OPTIONS_DB_APP_TOP_WINDOWED"),      DEFAULT_TOP,     RangedValidator<int>(-max_height_plus_one, max_height_plus_one));
+        db.Add("app-width",             UserStringNop("OPTIONS_DB_APP_WIDTH"),             DEFAULT_WIDTH,       RangedValidator<int>(MIN_WIDTH, max_width_plus_one));
+        db.Add("app-height",            UserStringNop("OPTIONS_DB_APP_HEIGHT"),            DEFAULT_HEIGHT,      RangedValidator<int>(MIN_HEIGHT, max_height_plus_one));
+        db.Add("app-width-windowed",    UserStringNop("OPTIONS_DB_APP_WIDTH_WINDOWED"),    DEFAULT_WIDTH,       RangedValidator<int>(MIN_WIDTH, max_width_plus_one));
+        db.Add("app-height-windowed",   UserStringNop("OPTIONS_DB_APP_HEIGHT_WINDOWED"),   DEFAULT_HEIGHT,      RangedValidator<int>(MIN_HEIGHT, max_height_plus_one));
+        db.Add("app-left-windowed",     UserStringNop("OPTIONS_DB_APP_LEFT_WINDOWED"),     DEFAULT_LEFT,        OrValidator<int>( RangedValidator<int>(-max_width_plus_one, max_width_plus_one), DiscreteValidator<int>(DEFAULT_LEFT) ));
+        db.Add("app-top-windowed",      UserStringNop("OPTIONS_DB_APP_TOP_WINDOWED"),      DEFAULT_TOP,         RangedValidator<int>(-max_height_plus_one, max_height_plus_one));
 
     }
 

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -121,7 +121,6 @@ namespace {
 
         db.Add("app-width",             UserStringNop("OPTIONS_DB_APP_WIDTH"),             DEFAULT_WIDTH,   RangedValidator<int>(MIN_WIDTH, max_width_plus_one));
         db.Add("app-height",            UserStringNop("OPTIONS_DB_APP_HEIGHT"),            DEFAULT_HEIGHT,    RangedValidator<int>(MIN_HEIGHT, max_height_plus_one));
-
         db.Add("app-width-windowed",    UserStringNop("OPTIONS_DB_APP_WIDTH_WINDOWED"),    DEFAULT_WIDTH,   RangedValidator<int>(MIN_WIDTH, max_width_plus_one));
         db.Add("app-height-windowed",   UserStringNop("OPTIONS_DB_APP_HEIGHT_WINDOWED"),   DEFAULT_HEIGHT,    RangedValidator<int>(MIN_HEIGHT, max_height_plus_one));
         db.Add("app-left-windowed",     UserStringNop("OPTIONS_DB_APP_LEFT_WINDOWED"),     DEFAULT_LEFT, OrValidator<int>( RangedValidator<int>(-max_width_plus_one, max_width_plus_one), DiscreteValidator<int>(DEFAULT_LEFT) ));

--- a/client/human/chmain.cpp
+++ b/client/human/chmain.cpp
@@ -233,7 +233,8 @@ int mainSetupAndRun() {
 #endif
 
         parse::init();
-        HumanClientApp app(width_height.first, width_height.second, true, "FreeOrion " + FreeOrionVersionString(),
+
+        HumanClientApp app(width, height, true, "FreeOrion " + FreeOrionVersionString(),
                            left, top, fullscreen, fake_mode_change);
 
         if (GetOptionsDB().Get<bool>("quickstart")) {


### PR DESCRIPTION
This patch further improves the multi-monitor presentation.  It allows for persistence of
window sizes, when presenting freeorion in one big window across multiple monitors.  

Previously, window sizes were not persisting because the validation  of config.xml sizes was using a maximum size from a single monitor.  

This patch adds the ability for SDLGUI to report a maximum possible width/height if
all available monitors are lined up either horizontally/vertically.  That size is used for the validation.  Hence,
no possible valid window sizes are rejected.

The patch does not adjust the initial sizes chosen for windows, which are still not great for multi-monitor presentation.
