### PR TITLE
Replaced boost::thread::sleep with boost::thread::sleep_for

### DIFF
--- a/GG/src/GUI.cpp
+++ b/GG/src/GUI.cpp
@@ -1123,7 +1123,7 @@ bool GUI::SetNextFocusWndInCycle()
 }
 
 void GUI::Wait(unsigned int ms)
-{ boost::this_thread::sleep(boost::posix_time::milliseconds(ms)); }
+{ boost::this_thread::sleep_for(boost::chrono::milliseconds(ms)); }
 
 void GUI::Register(Wnd* wnd)
 { if (wnd) s_impl->m_zlist.Add(wnd); }

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -106,7 +106,7 @@ void AIClientApp::Run() {
             Networking().GetMessage(msg);
             HandleMessage(msg);
         } else {
-            boost::this_thread::sleep(boost::posix_time::milliseconds(250));
+            boost::this_thread::sleep_for(boost::chrono::milliseconds(250));
         }
     }
 }

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -508,7 +508,7 @@ void HumanClientApp::NewSinglePlayerGame(bool quickstart) {
         if (m_networking.Connected()) {
             DebugLogger() << "HumanClientApp::NewSinglePlayerGame Sending server shutdown message.";
             m_networking.SendMessage(ShutdownServerMessage(m_networking.PlayerID()));
-            boost::this_thread::sleep(boost::posix_time::seconds(1));
+            boost::this_thread::sleep_for(boost::chrono::seconds(1));
             m_networking.DisconnectFromServer();
             if (!m_networking.Connected())
                 DebugLogger() << "HumanClientApp::NewSinglePlayerGame Disconnected from server.";
@@ -611,7 +611,7 @@ void HumanClientApp::LoadSinglePlayerGame(std::string filename/* = ""*/) {
     if (m_game_started) {
         EndGame();
         // delay to make sure old game is fully cleaned up before attempting to start a new one
-        boost::this_thread::sleep(boost::posix_time::seconds(3));
+        boost::this_thread::sleep_for(boost::chrono::seconds(3));
     } else {
         DebugLogger() << "HumanClientApp::LoadSinglePlayerGame() not already in a game, so don't need to end it";
     }
@@ -1088,7 +1088,7 @@ void HumanClientApp::EndGame(bool suppress_FSM_reset) {
     if (m_networking.Connected()) {
         DebugLogger() << "HumanClientApp::EndGame Sending server shutdown message.";
         m_networking.SendMessage(ShutdownServerMessage(m_networking.PlayerID()));
-        boost::this_thread::sleep(boost::posix_time::seconds(1));
+        boost::this_thread::sleep_for(boost::chrono::seconds(1));
         m_networking.DisconnectFromServer();
         if (!m_networking.Connected())
             DebugLogger() << "HumanClientApp::EndGame Disconnected from server.";

--- a/client/human/chmain.cpp
+++ b/client/human/chmain.cpp
@@ -189,15 +189,15 @@ int mainConfigOptionsSetup(const std::vector<std::string>& args) {
 
     } catch (const std::invalid_argument& e) {
         std::cerr << "main() caught exception(std::invalid_argument): " << e.what() << std::endl;
-        boost::this_thread::sleep(boost::posix_time::seconds(3));
+        boost::this_thread::sleep_for(boost::chrono::seconds(3));
         return 1;
     } catch (const std::runtime_error& e) {
         std::cerr << "main() caught exception(std::runtime_error): " << e.what() << std::endl;
-        boost::this_thread::sleep(boost::posix_time::seconds(3));
+        boost::this_thread::sleep_for(boost::chrono::seconds(3));
         return 1;
     } catch (const std::exception& e) {
         std::cerr << "main() caught exception(std::exception): " << e.what() << std::endl;
-        boost::this_thread::sleep(boost::posix_time::seconds(3));
+        boost::this_thread::sleep_for(boost::chrono::seconds(3));
         return 1;
     } catch (...) {
         std::cerr << "main() caught unknown exception." << std::endl;

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -239,7 +239,7 @@ void ClientNetworking::DisconnectFromServer() {
     if (Connected())
         m_io_service.post(boost::bind(&ClientNetworking::DisconnectFromServerImpl, this));
     // HACK! wait a bit for the disconnect to occur
-    boost::this_thread::sleep(boost::posix_time::seconds(1));
+    boost::this_thread::sleep_for(boost::chrono::seconds(1));
 }
 
 void ClientNetworking::SetPlayerID(int player_id) {

--- a/network/ServerNetworking.cpp
+++ b/network/ServerNetworking.cpp
@@ -243,7 +243,7 @@ void PlayerConnection::HandleMessageHeaderRead(boost::system::error_code error,
         if (m_new_connection) {
             // wait half a second if the first data read is an error; we
             // probably just need more setup time
-            boost::this_thread::sleep(boost::posix_time::milliseconds(500));
+            boost::this_thread::sleep_for(boost::chrono::milliseconds(500));
         } else {
             if (error == boost::asio::error::eof ||
                 error == boost::asio::error::connection_reset) {

--- a/server/SaveLoad.cpp
+++ b/server/SaveLoad.cpp
@@ -232,7 +232,7 @@ void LoadGame(const std::string& filename, ServerSaveGameData& server_save_game_
               EmpireManager& empire_manager, SpeciesManager& species_manager,
               CombatLogManager& combat_log_manager, GalaxySetupData& galaxy_setup_data)
 {
-    //boost::this_thread::sleep(boost::posix_time::seconds(1));
+    //boost::this_thread::sleep_for(boost::chrono::seconds(1));
 
     ScopedTimer timer("LoadGame: " + filename, true);
 

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -349,7 +349,7 @@ void ServerApp::CleanupAIs() {
     if (ai_connection_lingering) {
         // time for AIs to react?
         DebugLogger() << "ServerApp::CleanupAIs() waiting 1 second for AI processes to clean up...";
-        boost::this_thread::sleep(boost::posix_time::seconds(1));
+        boost::this_thread::sleep_for(boost::chrono::seconds(1));
     }
 
     DebugLogger() << "ServerApp::CleanupAIs() killing " << m_ai_client_processes.size() << " AI clients.";

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -214,7 +214,7 @@ void ServerFSM::HandleNonLobbyDisconnection(const Disconnection& d) {
     if (m_server.m_networking.empty() || m_server.m_ai_client_processes.size() == m_server.m_networking.NumEstablishedPlayers()) {
         DebugLogger() << "ServerFSM::HandleNonLobbyDisconnection : All human players disconnected; server terminating.";
         // HACK! Pause for a bit to let the player disconnected and end game messages propogate.
-        boost::this_thread::sleep(boost::posix_time::seconds(2));
+        boost::this_thread::sleep_for(boost::chrono::seconds(2));
         m_server.Exit(1);
     }
 }


### PR DESCRIPTION
boost::thread::sleep was DEPRECATED in boost version 1.50 June 2012

At some point boost::thread::sleep will be dropped and replaced with boost::thread::sleep_for
and boost::thread::sleep_until. 
