### PR TITLE
Galaxy setup and Resource browse wnd upscale

### DIFF
--- a/UI/CensusBrowseWnd.cpp
+++ b/UI/CensusBrowseWnd.cpp
@@ -24,7 +24,7 @@ namespace {
     const GG::Y     ICON_BROWSE_ICON_HEIGHT(64);
 
     const GG::X BrowseTextWidth() {
-        return GG::X(200.0f * (std::max(static_cast<float>(ClientUI::Pts()), 12.0f) / 12.0f));
+        return GG::X(FontBasedUpscale(200));
     }
 }
 

--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -1004,6 +1004,15 @@ ClientUI::TexturesAndDist ClientUI::PrefixedTexturesAndDist(const boost::filesys
     return prefixed_textures_it->second;
 }
 
+int FontBasedUpscale(int x) {
+    int retval(x);
+    int font_pts = ClientUI::Pts();
+    if (font_pts > 12) {
+        retval *= static_cast<float>(font_pts) / 12.0f;
+    }
+    return retval;
+}
+
 StreamableColor::StreamableColor() :
     r(0),
     g(0),

--- a/UI/ClientUI.h
+++ b/UI/ClientUI.h
@@ -240,4 +240,7 @@ struct StreamableColor {
 std::ostream& operator<<(std::ostream& os, const StreamableColor& clr);
 std::istream& operator>>(std::istream& is, StreamableColor& clr);
 
+/** Increases the given value when font size is larger than 12 */
+int FontBasedUpscale(int x);
+
 #endif // _ClientUI_h_

--- a/UI/GalaxySetupWnd.cpp
+++ b/UI/GalaxySetupWnd.cpp
@@ -23,7 +23,9 @@ namespace {
     const GG::Y CONTROL_HEIGHT(30);
     const GG::Y PANEL_CONTROL_SPACING(33);
     const GG::Y GAL_SETUP_PANEL_HT(PANEL_CONTROL_SPACING * 10);
-    const GG::X GAL_SETUP_WND_WD(645);
+    const GG::X GalSetupWndWidth() {
+        return GG::X(345 + FontBasedUpscale(300));
+    }
     const GG::Y GAL_SETUP_WND_HT(29 + (PANEL_CONTROL_SPACING * 6) + GAL_SETUP_PANEL_HT);
     const GG::Pt PREVIEW_SZ(GG::X(248), GG::Y(186));
     const bool ALLOW_NO_STARLANES = false;
@@ -53,7 +55,9 @@ namespace {
 ////////////////////////////////////////////////
 // GalaxySetupPanel
 ////////////////////////////////////////////////
-const GG::X GalaxySetupPanel::DEFAULT_WIDTH(305);
+const GG::X GalaxySetupPanel::DefaultWidth() {
+    return GG::X(FontBasedUpscale(305));
+}
 
 GalaxySetupPanel::GalaxySetupPanel(GG::X w, GG::Y h) :
     GG::Control(GG::X0, GG::Y0, w, h, GG::NO_WND_FLAGS),
@@ -499,7 +503,7 @@ GalaxySetupWnd::GalaxySetupWnd() :
 
     m_galaxy_setup_panel = new GalaxySetupPanel();
 
-    const GG::X LABELS_WIDTH = (GalaxySetupPanel::DEFAULT_WIDTH - 5) / 2;
+    const GG::X LABELS_WIDTH = (GalaxySetupPanel::DefaultWidth() - 5) / 2;
 
     // player name
     m_player_name_label = new CUILabel(UserString("GSETUP_PLAYER_NAME"), GG::FORMAT_RIGHT, GG::INTERACTIVE);
@@ -626,16 +630,16 @@ void GalaxySetupWnd::SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
 }
 
 GG::Rect GalaxySetupWnd::CalculatePosition() const {
-    GG::Pt new_ul((HumanClientApp::GetApp()->AppWidth() - GAL_SETUP_WND_WD) / 2,
+    GG::Pt new_ul((HumanClientApp::GetApp()->AppWidth() - GalSetupWndWidth()) / 2,
                   (HumanClientApp::GetApp()->AppHeight() - GAL_SETUP_WND_HT) / 2);
-    GG::Pt new_sz(GAL_SETUP_WND_WD, GAL_SETUP_WND_HT);
+    GG::Pt new_sz(GalSetupWndWidth(), GAL_SETUP_WND_HT);
     return GG::Rect(new_ul, new_ul + new_sz);
 }
 
 void GalaxySetupWnd::DoLayout() {
     m_galaxy_setup_panel->MoveTo(GG::Pt(GG::X0, GG::Y(4)));
 
-    const GG::X LABELS_WIDTH = (GalaxySetupPanel::DEFAULT_WIDTH - 5) / 2;
+    const GG::X LABELS_WIDTH = (GalaxySetupPanel::DefaultWidth() - 5) / 2;
 
     GG::Pt row_advance(GG::X0, PANEL_CONTROL_SPACING);
     GG::Pt label_ul(CONTROL_MARGIN, GAL_SETUP_PANEL_HT + (PANEL_CONTROL_SPACING - CONTROL_HEIGHT) / 2 + 4);

--- a/UI/GalaxySetupWnd.h
+++ b/UI/GalaxySetupWnd.h
@@ -6,6 +6,7 @@
 #include <GG/ListBox.h>
 
 #include "../universe/Universe.h"
+#include "ClientUI.h"
 #include "CUIWnd.h"
 
 class EmpireColorSelector;
@@ -15,10 +16,10 @@ struct GalaxySetupData;
 /** Encapsulates the galaxy setup options so that they may be reused in the GalaxySetupWnd and the MultiPlayerLobbyWnd. */
 class GalaxySetupPanel : public GG::Control {
 public:
-    static const GG::X DEFAULT_WIDTH;
+    static const GG::X DefaultWidth();
 
     /** \name Structors*/ //!@{
-    GalaxySetupPanel(GG::X w = GG::X(305), GG::Y h = GG::Y(330));
+    GalaxySetupPanel(GG::X w = GG::X(FontBasedUpscale(305)), GG::Y h = GG::Y(330));
     //!@}
 
     /** \name Accessors*/ //!@{
@@ -32,7 +33,7 @@ public:
     GalaxySetupOption               GetMonsterFrequency() const;    //!< Returns the frequency of space monsters
     GalaxySetupOption               GetNativeFrequency() const;     //!< Returns the frequency of natives
     Aggression                      GetAIAggression() const;        //!< Returns the  maximum AI aggression level 
-    
+
     boost::shared_ptr<GG::Texture>  PreviewImage() const;           //!< Returns the current preview image texture
 
     /** the settings changed signal object for this GalaxySetupPanel */

--- a/UI/ResourceBrowseWnd.cpp
+++ b/UI/ResourceBrowseWnd.cpp
@@ -5,14 +5,16 @@
 
 namespace {
     const int       EDGE_PAD(3);
-    const GG::X     BROWSE_TEXT_WIDTH(200);
+    const GG::X BrowseTextWidth() {
+        return GG::X(FontBasedUpscale(200));
+    }
     const GG::Y     ICON_BROWSE_ICON_HEIGHT(64);
 }
 
 
 ResourceBrowseWnd::ResourceBrowseWnd(const std::string& title_text, const std::string& unit_label,
                                      float used, float output, float target_output) :
-    GG::BrowseInfoWnd(GG::X0, GG::Y0, BROWSE_TEXT_WIDTH, GG::Y1),
+    GG::BrowseInfoWnd(GG::X0, GG::Y0, BrowseTextWidth(), GG::Y1),
     m_title_text(0),
     m_used_points_label(0),
     m_used_points(0),
@@ -32,7 +34,7 @@ ResourceBrowseWnd::ResourceBrowseWnd(const std::string& title_text, const std::s
 
     m_title_text = new CUILabel(title_text, GG::FORMAT_CENTER);
     m_title_text->MoveTo(GG::Pt(top_left.x + EDGE_PAD, top_left.y));
-    m_title_text->Resize(GG::Pt(BROWSE_TEXT_WIDTH - 2*EDGE_PAD, ROW_HEIGHT));
+    m_title_text->Resize(GG::Pt(BrowseTextWidth() - 2*EDGE_PAD, ROW_HEIGHT));
     m_title_text->SetFont(ClientUI::GetBoldFont());
     top_left.y += m_title_text->Height() + EDGE_PAD;
 
@@ -46,7 +48,7 @@ ResourceBrowseWnd::ResourceBrowseWnd(const std::string& title_text, const std::s
     const GG::X VALUE_TEXT_WIDTH = Width() - 4 - CENTERLINE_GAP - LABEL_TEXT_WIDTH;
     const GG::X LEFT_TEXT_X(0);
     const GG::X RIGHT_TEXT_X = LEFT_TEXT_X + LABEL_TEXT_WIDTH + 8 + CENTERLINE_GAP;
-    const GG::X P_LABEL_X = RIGHT_TEXT_X + 40;
+    const GG::X P_LABEL_X = RIGHT_TEXT_X + FontBasedUpscale(40);
 
     std::pair<int, int> m_center_gap(Value(LABEL_TEXT_WIDTH + 2), Value(LABEL_TEXT_WIDTH + 2 + CENTERLINE_GAP));
 
@@ -100,7 +102,7 @@ ResourceBrowseWnd::ResourceBrowseWnd(const std::string& title_text, const std::s
     top_left.y += m_target_points_label->Height();
 
     // background / border rendering prep
-    Resize(GG::Pt(BROWSE_TEXT_WIDTH, top_left.y + EDGE_PAD - m_offset.y));
+    Resize(GG::Pt(BrowseTextWidth(), top_left.y + EDGE_PAD - m_offset.y));
 
     InitBuffer();
 }


### PR DESCRIPTION
Adjust window width and spacing for galaxy setup and resource browse windows, when font size is larger than 12pt.

Addresses issue https://github.com/freeorion/freeorion/issues/533
