### PR TITLE
Change low planet density

### DIFF
--- a/default/python/universe_generation/universe_tables.py
+++ b/default/python/universe_generation/universe_tables.py
@@ -53,7 +53,7 @@ UNIVERSE_AGE_MOD_TO_STAR_TYPE_DIST = {
 # This checks what you chose for galaxy planet density:
 DENSITY_MOD_TO_PLANET_SIZE_DIST = {
 #                                none  tiny  small  medium  large  huge  asteroids  gas giant
-    fo.galaxySetupOption.low:   ( 77,    0,     0,      0,    -5,  -10,         0,         0),
+    fo.galaxySetupOption.low:   ( 85,    0,     0,      0,    -5,  -10,         0,         0),
     fo.galaxySetupOption.medium:( 70,    0,     0,      0,    -5,  -10,         0,         0),
     fo.galaxySetupOption.high:  ( 50,    0,     0,      0,    -5,  -10,         0,         0),
 }


### PR DESCRIPTION
This changes the percentage change of systems with no planet in a slot to 85% from 77% for the low density case.  The medium density case is 70%.  The previous low density case was 77%.  In play, I couldn't perceive the difference between 70% and 77%.  Perhaps even 90% is playable and fun.

I will post this to the website for comments as it is a game play change.
