### PR TITLE
Fix gg list child dragged away

### DIFF
--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -686,9 +686,7 @@ void ListBox::ChildrenDraggedAway(const std::vector<Wnd*>& wnds, const Wnd* dest
 
         m_selections = new_selections;
 
-        if (m_selections.empty()) {
-            ClearedSignal();
-        } else if (m_selections.size() != initially_selected_rows.size()) {
+        if (m_selections.size() != initially_selected_rows.size()) {
             SelChangedSignal(m_selections);
         }
     }


### PR DESCRIPTION
This is a bug fix.  

In the GG::List::ChildrenDraggedAway code if the last selected row is dragged away the old code erroneously signaled that the entire list was cleared.  This patch removes that signalling.  It only signals that the selected set was cleared.
