### PR TITLE
More Design Window fixes

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -2640,6 +2640,8 @@ void Empire::AddShipDesign(int ship_design_id, int next_design_id) {
      * valid, so this just adds this design's id to those that this empire will
      * retain as one of it's ship designs, which are those displayed in the GUI
      * list of available designs for human players, and */
+    if (ship_design_id == next_design_id)
+        return;
     const ShipDesign* ship_design = GetUniverse().GetShipDesign(ship_design_id);
     if (ship_design) {  // don't check if design is producible; adding a ship design is useful for more than just producing it
         // design is valid, so just add the id to empire's set of ids that it knows about

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -1217,6 +1217,7 @@ public:
 
     void                            ShowAvailability(bool available, bool refresh_list = true);
     void                            HideAvailability(bool available, bool refresh_list = true);
+    virtual void                    EnableOrderIssuing(bool enable = true);
     //@}
 
     mutable boost::signals2::signal<void (int)>                 DesignSelectedSignal;
@@ -1310,6 +1311,7 @@ private:
     bool                        m_showing_completed_designs;
     bool                        m_showing_saved_designs;
     bool                        m_showing_monsters;
+    bool                        m_enabled;          ///<active player (true) or observer (false)
 
     std::set<std::string>       m_hulls_in_list;
     std::set<std::string>       m_saved_desgins_in_list;
@@ -1451,7 +1453,8 @@ BasesListBox::BasesListBox() :
     m_showing_empty_hulls(false),
     m_showing_completed_designs(false),
     m_showing_saved_designs(false),
-    m_showing_monsters(false)
+    m_showing_monsters(false),
+    m_enabled(false)
 {
     InitRowSizes();
     SetStyle(GG::LIST_NOSEL);
@@ -1995,7 +1998,7 @@ void BasesListBox::ShowCompletedDesigns(bool refresh_list) {
     m_showing_completed_designs = true;
     m_showing_saved_designs = false;
     m_showing_monsters = false;
-    EnableOrderIssuing(true);
+    EnableOrderIssuing(m_enabled);
     if (refresh_list)
         Populate();
 }
@@ -2052,6 +2055,12 @@ void BasesListBox::HideAvailability(bool available, bool refresh_list) {
     }
 }
 
+void BasesListBox::EnableOrderIssuing(bool enable/* = true*/)
+{
+    m_enabled = enable;
+    QueueListBox::EnableOrderIssuing(m_enabled && m_showing_completed_designs);
+}
+
 
 //////////////////////////////////////////////////
 // DesignWnd::BaseSelector                      //
@@ -2069,6 +2078,7 @@ public:
     void            SetEmpireShown(int empire_id, bool refresh_list);
     void            ShowAvailability(bool available, bool refresh_list);
     void            HideAvailability(bool available, bool refresh_list);
+    void            EnableOrderIssuing(bool enable/* = true*/);
     //@}
 
     mutable boost::signals2::signal<void (int)>                 DesignSelectedSignal;
@@ -2215,6 +2225,17 @@ void DesignWnd::BaseSelector::ToggleAvailability(bool available, bool refresh_li
         else
             ShowAvailability(false, refresh_list);
     }
+}
+
+void DesignWnd::BaseSelector::EnableOrderIssuing(bool enable/* = true*/) {
+    if(m_hulls_list)
+        m_hulls_list->EnableOrderIssuing(enable);
+    if(m_designs_list)
+        m_designs_list->EnableOrderIssuing(enable);
+    if(m_saved_designs_list)
+        m_saved_designs_list->EnableOrderIssuing(enable);
+    if(m_monsters_list)
+        m_monsters_list->EnableOrderIssuing(enable);
 }
 
 void DesignWnd::BaseSelector::DoLayout() {
@@ -3499,4 +3520,6 @@ void DesignWnd::ReplaceDesign() {
 }
 
 void DesignWnd::EnableOrderIssuing(bool enable/* = true*/)
-{}
+{
+    m_base_selector->EnableOrderIssuing(enable);
+}

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -1489,7 +1489,7 @@ void BasesListBox::ChildrenDraggedAway(const std::vector<GG::Wnd*>& wnds, const 
 
     Row* original_row = boost::polymorphic_downcast<Row*>(*wnds.begin());
     iterator insertion_point = std::find(begin(), end(), original_row);
-    if(insertion_point != end())
+    if (insertion_point != end())
         ++insertion_point;
 
     // replace dragged-away control with new copy
@@ -1541,11 +1541,11 @@ void BasesListBox::QueueItemMoved(GG::ListBox::Row* row, std::size_t position) {
     BasesListBox::CompletedDesignListBoxRow* control =
         boost::polymorphic_downcast<BasesListBox::CompletedDesignListBoxRow*>(row);
     Empire* empire = GetEmpire(m_empire_id_shown);
-    if (control != NULL && empire != NULL) {
+    if (control && empire) {
         int design_id = control->DesignID();
 
         iterator insert_before_row = begin();
-        for(std::size_t ii = 0; ii < position; ++ii)
+        for (std::size_t ii = 0; ii < position; ++ii)
             insert_before_row++;
         const BasesListBox::CompletedDesignListBoxRow* insert_before_control =
             boost::polymorphic_downcast<const BasesListBox::CompletedDesignListBoxRow*>(*insert_before_row);
@@ -2018,8 +2018,7 @@ void BasesListBox::HideAvailability(bool available, bool refresh_list) {
     }
 }
 
-void BasesListBox::EnableOrderIssuing(bool enable/* = true*/)
-{
+void BasesListBox::EnableOrderIssuing(bool enable/* = true*/) {
     m_enabled = enable;
     QueueListBox::EnableOrderIssuing(m_enabled && m_showing_completed_designs);
 }
@@ -2191,7 +2190,7 @@ void DesignWnd::BaseSelector::ToggleAvailability(bool available, bool refresh_li
 }
 
 void DesignWnd::BaseSelector::EnableOrderIssuing(bool enable/* = true*/) {
-    if(m_hulls_list)
+    if (m_hulls_list)
         m_hulls_list->EnableOrderIssuing(enable);
     if(m_designs_list)
         m_designs_list->EnableOrderIssuing(enable);
@@ -3482,7 +3481,6 @@ void DesignWnd::ReplaceDesign() {
     DebugLogger() << "Replaced design #" << replaced_id << " with #" << new_design_id ;
 }
 
-void DesignWnd::EnableOrderIssuing(bool enable/* = true*/)
-{
+void DesignWnd::EnableOrderIssuing(bool enable/* = true*/) {
     m_base_selector->EnableOrderIssuing(enable);
 }

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -2978,7 +2978,7 @@ void DesignWnd::MainPanel::SetDesign(const ShipDesign* ship_design) {
     }
 
     m_complete_design_id = ship_design->ID();
-    m_replaced_design_id = ship_design->ID();
+    m_replaced_design_id = ship_design->IsMonster() ? ShipDesign::INVALID_DESIGN_ID : ship_design->ID();
 
     m_design_name->SetText(ship_design->Name());
     m_design_description->SetText(ship_design->Description());
@@ -2998,6 +2998,7 @@ void DesignWnd::MainPanel::SetDesign(int design_id)
 void DesignWnd::MainPanel::SetDesignComponents(const std::string& hull,
                                                const std::vector<std::string>& parts)
 {
+    m_replaced_design_id = ShipDesign::INVALID_DESIGN_ID;
     SetHull(hull);
     SetParts(parts);
 }
@@ -3007,8 +3008,7 @@ void DesignWnd::MainPanel::SetDesignComponents(const std::string& hull,
                                                const std::string& name,
                                                const std::string& desc)
 {
-    SetHull(hull);
-    SetParts(parts);
+    SetDesignComponents(hull, parts);
     m_design_name->SetText(name);
     m_design_description->SetText(desc);
 }

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -1541,20 +1541,19 @@ void BasesListBox::QueueItemMoved(GG::ListBox::Row* row, std::size_t position) {
     BasesListBox::CompletedDesignListBoxRow* control =
         boost::polymorphic_downcast<BasesListBox::CompletedDesignListBoxRow*>(row);
     Empire* empire = GetEmpire(m_empire_id_shown);
-    if (control && empire) {
+    if (control && empire && position <= NumRows()) {
         int design_id = control->DesignID();
 
         iterator insert_before_row = begin();
-        for (std::size_t ii = 0; ii < position; ++ii)
-            insert_before_row++;
-        const BasesListBox::CompletedDesignListBoxRow* insert_before_control =
-            boost::polymorphic_downcast<const BasesListBox::CompletedDesignListBoxRow*>(*insert_before_row);
-        int insert_before_id = (insert_before_row == end() || !insert_before_control)
-            ? ShipDesign::INVALID_DESIGN_ID : insert_before_control->DesignID();
+        std::advance(insert_before_row, position);
 
-        DebugLogger() << "Accepted Drop of id " << design_id << " before " << insert_before_id;
+        const BasesListBox::CompletedDesignListBoxRow* insert_before_control = (insert_before_row == end()) ? NULL :
+            boost::polymorphic_downcast<const BasesListBox::CompletedDesignListBoxRow*>(*insert_before_row);
+        int insert_before_id = insert_before_control
+            ? insert_before_control->DesignID() : ShipDesign::INVALID_DESIGN_ID;
 
         if (design_id != insert_before_id)
+            //insert_before_row may be end() to insert as last item
             Insert(control, insert_before_row);
         control->Resize(ListRowSize());
         HumanClientApp::GetApp()->Orders()
@@ -2192,11 +2191,11 @@ void DesignWnd::BaseSelector::ToggleAvailability(bool available, bool refresh_li
 void DesignWnd::BaseSelector::EnableOrderIssuing(bool enable/* = true*/) {
     if (m_hulls_list)
         m_hulls_list->EnableOrderIssuing(enable);
-    if(m_designs_list)
+    if (m_designs_list)
         m_designs_list->EnableOrderIssuing(enable);
-    if(m_saved_designs_list)
+    if (m_saved_designs_list)
         m_saved_designs_list->EnableOrderIssuing(enable);
-    if(m_monsters_list)
+    if (m_monsters_list)
         m_monsters_list->EnableOrderIssuing(enable);
 }
 
@@ -3481,6 +3480,5 @@ void DesignWnd::ReplaceDesign() {
     DebugLogger() << "Replaced design #" << replaced_id << " with #" << new_design_id ;
 }
 
-void DesignWnd::EnableOrderIssuing(bool enable/* = true*/) {
-    m_base_selector->EnableOrderIssuing(enable);
-}
+void DesignWnd::EnableOrderIssuing(bool enable/* = true*/)
+{ m_base_selector->EnableOrderIssuing(enable); }

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -1458,8 +1458,6 @@ BasesListBox::BasesListBox() :
 
     GG::Connect(DoubleClickedSignal,    &BasesListBox::BaseDoubleClicked,   this);
     GG::Connect(LeftClickedSignal,      &BasesListBox::BaseLeftClicked,     this);
-
-    EnableOrderIssuing(true);
 }
 
 const std::pair<bool, bool>& BasesListBox::GetAvailabilitiesShown() const
@@ -1987,6 +1985,7 @@ void BasesListBox::ShowEmptyHulls(bool refresh_list) {
     m_showing_completed_designs = false;
     m_showing_saved_designs = false;
     m_showing_monsters = false;
+    EnableOrderIssuing(false);
     if (refresh_list)
         Populate();
 }
@@ -1996,6 +1995,7 @@ void BasesListBox::ShowCompletedDesigns(bool refresh_list) {
     m_showing_completed_designs = true;
     m_showing_saved_designs = false;
     m_showing_monsters = false;
+    EnableOrderIssuing(true);
     if (refresh_list)
         Populate();
 }
@@ -2005,6 +2005,7 @@ void BasesListBox::ShowSavedDesigns(bool refresh_list) {
     m_showing_completed_designs = false;
     m_showing_saved_designs = true;
     m_showing_monsters = false;
+    EnableOrderIssuing(false);
     if (refresh_list)
         Populate();
 }
@@ -2014,6 +2015,7 @@ void BasesListBox::ShowMonsters(bool refresh_list) {
     m_showing_completed_designs = false;
     m_showing_saved_designs = false;
     m_showing_monsters = true;
+    EnableOrderIssuing(false);
     if (refresh_list)
         Populate();
 }

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -3206,7 +3206,7 @@ void DesignWnd::MainPanel::DesignChanged() {
 }
 
 void DesignWnd::MainPanel::DesignNameChanged() {
-    if (m_disabled_by_name || (!IsDesignNameValid() && !m_confirm_button->Disabled()) || IsDesignNameValid())
+    if (m_disabled_by_name || (!IsDesignNameValid() && !m_confirm_button->Disabled()))
         DesignChangedSignal();
     else if (GetOptionsDB().Get<bool>("UI.design-pedia-dynamic"))
         DesignNameChangedSignal();

--- a/UI/QueueListBox.cpp
+++ b/UI/QueueListBox.cpp
@@ -129,7 +129,8 @@ void QueueListBox::AcceptDrops(const GG::Pt& pt, const std::vector<GG::Wnd*>& wn
     GG::ListBox::Row* row = boost::polymorphic_downcast<GG::ListBox::Row*>(wnd);
     if (AllowedDropTypes().find(drop_type) == AllowedDropTypes().end() ||
         !row ||
-        std::find(begin(), end(), row) == end()) {
+        std::find(begin(), end(), row) == end())
+    {
         delete wnd;
         return;
     }

--- a/util/Order.cpp
+++ b/util/Order.cpp
@@ -1146,14 +1146,16 @@ void ShipDesignOrder::ExecuteImpl() const {
 
     } else if (m_move_design) {
         //Move an existing design from its current location to just before the after_design
-          if (!empire->ShipDesignKept(m_design_id)) {
+        if (!empire->ShipDesignKept(m_design_id)) {
             ErrorLogger() << "Tried to move a ShipDesign that the empire wasn't remembering";
             return;
         }
+        if (m_design_id == m_design_id_after)
+            return;
+
         empire->RemoveShipDesign(m_design_id);
         empire->AddShipDesign(m_design_id, m_design_id_after);
         DebugLogger() << "Move Ship Design " << m_design_id << " to before " << m_design_id_after;
-
     } else {
         // player is ordering empire to retain a particular design, so that is can
         // be used to construct ships by that empire.


### PR DESCRIPTION
This patch is a series of fixes to bugs in the design window.  Some are related to the new replace design feature, while others pre-date that feature.  The bugs fixed are:
1. The drop indicator was active for the hulls and monster lists.  It should not be.
2. EnableOrderIssuing was not hooked up to prevent observers from changing the order of an empire's designs.
3. Dropping any hulls/designs/monsters on the workbench moved that design to the end of the list temporarily.
4. DesignNameValidity was being called too often and slowing the interface.
5. When re-ordering designs, dropping a design on itself was temporarily moving it to the end of the list.
6. Not a bug.  I upgraded error checking on QueueListBox and used its functionality more fully in BasesListBox.
7. Selecting a hull/monster was not disabling the replace button.
