### PR TITLE
Add pedia links into beginner game hints

### DIFF
--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -3921,11 +3921,11 @@ Outposts are unmanned stations, which can be founded in places too hostile for a
 FOCUS_TITLE
 Planetary Focus
 FOCUS_TEXT
-'''Each planet has a focus setting, dictating what the inhabitants will put more effort toward, such as production or research. Not all areas of focus are always available. They may be restricted because the species can not focus on that area, the technology is not yet known, or other factors such as the availability of a special.
+'''Each planet has a focus setting, dictating what the inhabitants will put more effort toward, such as [[encyclopedia INDUSTRY_TITLE]] or [[encyclopedia RESEARCH_TITLE]]. Not all areas of focus are always available. They may be restricted because the species can not focus on that area, the technology is not yet known, or other factors such as the availability of a [[encyclopedia ENC_SPECIAL]].
 
 The focus of a planet may grant it bonuses or enable effects. A small penalty applies when changing a planets focus, which will diminish over time.
 
-A planet will default to the inhabiting species' preferred focus if it has one, otherwise it will default to production.'''
+A planet will default to the inhabiting species' preferred focus if it has one, otherwise it will default to [[encyclopedia INDUSTRY_TITLE]].'''
 
 GROWTH_FOCUS_TITLE
 Growth Focus
@@ -5065,7 +5065,7 @@ RANDOM_BEGINNER_HINT
 Hint #%rawtext%
 
 BEGINNER_HINT_01
-1: At the beginning of the game, constructing more scouts may help in exploring the region around your homeworld.
+1: At the beginning of the game, constructing more [[predefinedshipdesign SD_SCOUT]]s may help in exploring the region around your homeworld.
 
 BEGINNER_HINT_02
 2: Each species has its own planet preference. If you can conquer a planet with a different species, you can colonize other planets with them as well, allowing you to secure a system faster. Keep in mind that not all species can colonize and that some can not build ships.
@@ -5077,34 +5077,34 @@ BEGINNER_HINT_04
 4: Systems that are connected by thick lines are [[encyclopedia SUPPLY_TITLE]] line linked and they share [[encyclopedia INDUSTRY_TITLE]] Production Points (PP).
 
 BEGINNER_HINT_05
-5: All systems share [[encyclopedia RESEARCH_TITLE]] Points (RP) that they generate even if they are not connected by supply lines. When not connected to a supply line, setting the [[encyclopedia FOCUS_TITLE]] to research might be more efficient for a planet than other settings.
+5: All systems share [[encyclopedia RESEARCH_TITLE]] Points (RP) that they generate even if they are not connected by [[encyclopedia SUPPLY_TITLE]] lines. When not connected to a supply line, setting the [[encyclopedia FOCUS_TITLE]] to research might be more efficient for a planet than other settings.
 
 BEGINNER_HINT_06
 6: [[encyclopedia SUPPLY_TITLE]] lines can be used to refill the [[encyclopedia FUEL_TITLE]] supply of ships.
 
 BEGINNER_HINT_07
-7: Some buildings, like the [[buildingtype BLD_INDUSTRY_CENTER]], will have an effect on each planet that has a supply line connection to it. Others, like [[buildingtype BLD_GAS_GIANT_GEN]], only affect the system that they are built in. Check the 'Pedia to learn about the functions of different buildings.
+7: Some buildings, like the [[buildingtype BLD_INDUSTRY_CENTER]], will have an effect on each planet that has a [[encyclopedia SUPPLY_TITLE]] line connection to it. Others, like [[buildingtype BLD_GAS_GIANT_GEN]], only affect the system that they are built in. Check the [[encyclopedia ENC_BUILDING_TYPE]] Pedia section to learn about the functions of different buildings.
 
 BEGINNER_HINT_08
-8: An Outpost ship can setup an outpost on any unclaimed visible planet or asteroid that it can reach, unless there are hostile ships in that system.
+8: An [[predefinedshipdesign SD_OUTPOST_SHIP]] can setup an [[encyclopedia OUTPOSTS_TITLE]] on any unclaimed visible planet or asteroid that it can reach, unless there are hostile ships in that system.
 
 BEGINNER_HINT_09
-9: Colony ships take longer to build than outpost ships, but they can settle planets outside of your supply range.
+9: [[predefinedshipdesign SD_COLONY_SHIP]]s take longer to build than [[predefinedshipdesign SD_OUTPOST_SHIP]]s, but they can settle planets outside of your [[encyclopedia SUPPLY_TITLE]] range.
 
 BEGINNER_HINT_10
-10: With a system selected, right click on a planets picture in the system side panel to access the Planet Suitability report. This will tell you what species from your empire will be able to successfully settle that planet. Numbers in green show the maximum population that the planet could achieve if colonized by that species, red numbers indicate that the species would die out if they attempted to colonize.
+10: With a system selected in the [[encyclopedia MAP_WINDOW_ARTICLE_TITLE]], right click on a planets picture in the system side panel to access the Planet Suitability report. This will tell you what species from your empire will be able to successfully settle that planet. Numbers in green show the maximum population that the planet could achieve if colonized by that species, red numbers indicate that the species would die out if they attempted to colonize.
 
 BEGINNER_HINT_11
 11: Maximum populations that planets can achieve can be boosted by researching various growth techs. Rare specials can also increase the maximum population for species with certain metabolisms, see [[encyclopedia GROWTH_FOCUS_TITLE]] for more info on these specials.
 
 BEGINNER_HINT_12
-12: Be on the lookout for planets with specials, they usually indicate some special resource on that planet that may benefit your entire empire if utilized properly. Right click on a special's icon to access its 'Pedia entry and find out more!
+12: Be on the lookout for planets with [[encyclopedia ENC_SPECIAL]]s, they usually indicate some special resource on that planet that may benefit your entire empire if utilized properly. Right click on a special's icon to access its 'Pedia entry and find out more!
 
 BEGINNER_HINT_13
 13: Only [[species SP_EXOBOT]] can settle asteroid belts. If you find a lot of asteroids belts nearby you might want to research how to build them sooner rather than later!
 
 BEGINNER_HINT_14
-14: Research [[encyclopedia SUPPLY_TITLE]] improvements to increase the distance from your systems that your supply lines reach.
+14: Research [[encyclopedia SUPPLY_TITLE]] improvements, like the [[tech CON_ORBITAL_CON]], to increase the distance from your systems that your supply lines reach.
 
 BEGINNER_HINT_15
 15: Most species start out with a [[encyclopedia HAPPINESS_TITLE]] of 1 when you capture their planet, and this will normally increase by 1 per turn. Look out for [[encyclopedia XENOPHOBIC_SPECIES_TITLE]] species though! They don't like being near other species and this will effect the happiness and other values of both them and the other nearby species.
@@ -5119,7 +5119,7 @@ BEGINNER_HINT_18
 18: [[encyclopedia FOCUS_TITLE]] - pay attention to the focus setting of new planets that are added to your empire, either from settling them or from conquering them. This setting controls if the planet focuses on industrial production or on research or on defense. Later in the game, more focus options may unlock as new technologies are researched, and different species may have different focus options available.
 
 BEGINNER_HINT_19
-19: A colony can be established on an outpost by constructing a colony building or by using a colony ship. Most colony buildings require a supply connection to a planet with at least 5 happiness, and 3 population. When a species is unlocked, such as when researching [[tech PRO_EXOBOTS]], this requirement for their colony building does not apply.
+19: A colony can be established on an [[encyclopedia OUTPOSTS_TITLE]] by constructing a colony building or by using a [[predefinedshipdesign SD_COLONY_SHIP]]. Most colony buildings require a [[encyclopedia SUPPLY_TITLE]] connection to a planet with at least 5 [[encyclopedia HAPPINESS_TITLE]], and 3 population. When a species is unlocked, such as when researching [[tech PRO_EXOBOTS]], this requirement for their colony building does not apply.
 
 #############################################################
 ####                    S P E C I E S                    ####


### PR DESCRIPTION
- Replace "production" by "industry" when needed, as the related Focus is "Industry Focus"
- Add pedia links to the basic Scout, Colony Ship and Outpost Ship articles, as they are the only ones available by default for a beginner.
