### PR TITLE
Move initialization of app window options out of static initialization

### DIFF
--- a/GG/GG/SDL/SDLGUI.h
+++ b/GG/GG/SDL/SDLGUI.h
@@ -160,7 +160,8 @@ protected:
 
 private:
     void            RelayTextInput (const SDL_TextInputEvent& text, Pt mouse_pos);
-    // Bare minimum SDL video initialization to allow queries to display sizes etc.
+    /** Bare minimum SDL video initialization to allow queries to display sizes etc.
+        If called during static initialization, it will cause OSX to crash on exit. */
     static void     SDLMinimalInit();
 
     X         m_app_width;      ///< application width and height (defaults to 1024 x 768)

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -115,21 +115,6 @@ namespace {
     const int MIN_WIDTH = 800;
     const int MIN_HEIGHT = 600;
 
-    void AddOptionsAfterGUIInitialization(OptionsDB& db) {
-        const int max_width_plus_one = HumanClientApp::MaximumPossibleWidth() + 1;
-        const int max_height_plus_one = HumanClientApp::MaximumPossibleHeight() + 1;
-
-        db.Add("app-width",             UserStringNop("OPTIONS_DB_APP_WIDTH"),             DEFAULT_WIDTH,       RangedValidator<int>(MIN_WIDTH, max_width_plus_one));
-        db.Add("app-height",            UserStringNop("OPTIONS_DB_APP_HEIGHT"),            DEFAULT_HEIGHT,      RangedValidator<int>(MIN_HEIGHT, max_height_plus_one));
-        db.Add("app-width-windowed",    UserStringNop("OPTIONS_DB_APP_WIDTH_WINDOWED"),    DEFAULT_WIDTH,       RangedValidator<int>(MIN_WIDTH, max_width_plus_one));
-        db.Add("app-height-windowed",   UserStringNop("OPTIONS_DB_APP_HEIGHT_WINDOWED"),   DEFAULT_HEIGHT,      RangedValidator<int>(MIN_HEIGHT, max_height_plus_one));
-        db.Add("app-left-windowed",     UserStringNop("OPTIONS_DB_APP_LEFT_WINDOWED"),     DEFAULT_LEFT,        OrValidator<int>( RangedValidator<int>(-max_width_plus_one, max_width_plus_one), DiscreteValidator<int>(DEFAULT_LEFT) ));
-        db.Add("app-top-windowed",      UserStringNop("OPTIONS_DB_APP_TOP_WINDOWED"),      DEFAULT_TOP,         RangedValidator<int>(-max_height_plus_one, max_height_plus_one));
-
-    }
-
-    bool temp_bool2 = RegisterOptions(&AddOptionsAfterGUIInitialization);
-
     /* Sets the value of options that need language-dependent default values.*/
     void SetStringtableDependentOptionDefaults() {
         if (GetOptionsDB().Get<std::string>("GameSetup.empire-name").empty())
@@ -185,6 +170,18 @@ namespace {
             GetOptionsDB().Set<bool>("UI.system-fog-of-war",            false);
         }
     }
+}
+
+void HumanClientApp::AddWindowSizeOptionsAfterMainStart(OptionsDB& db) {
+    const int max_width_plus_one = HumanClientApp::MaximumPossibleWidth() + 1;
+    const int max_height_plus_one = HumanClientApp::MaximumPossibleHeight() + 1;
+
+    db.Add("app-width",             UserStringNop("OPTIONS_DB_APP_WIDTH"),             DEFAULT_WIDTH,       RangedValidator<int>(MIN_WIDTH, max_width_plus_one));
+    db.Add("app-height",            UserStringNop("OPTIONS_DB_APP_HEIGHT"),            DEFAULT_HEIGHT,      RangedValidator<int>(MIN_HEIGHT, max_height_plus_one));
+    db.Add("app-width-windowed",    UserStringNop("OPTIONS_DB_APP_WIDTH_WINDOWED"),    DEFAULT_WIDTH,       RangedValidator<int>(MIN_WIDTH, max_width_plus_one));
+    db.Add("app-height-windowed",   UserStringNop("OPTIONS_DB_APP_HEIGHT_WINDOWED"),   DEFAULT_HEIGHT,      RangedValidator<int>(MIN_HEIGHT, max_height_plus_one));
+    db.Add("app-left-windowed",     UserStringNop("OPTIONS_DB_APP_LEFT_WINDOWED"),     DEFAULT_LEFT,        OrValidator<int>( RangedValidator<int>(-max_width_plus_one, max_width_plus_one), DiscreteValidator<int>(DEFAULT_LEFT) ));
+    db.Add("app-top-windowed",      UserStringNop("OPTIONS_DB_APP_TOP_WINDOWED"),      DEFAULT_TOP,         RangedValidator<int>(-max_height_plus_one, max_height_plus_one));
 }
 
 HumanClientApp::HumanClientApp(int width, int height, bool calculate_fps, const std::string& name,

--- a/client/human/HumanClientApp.h
+++ b/client/human/HumanClientApp.h
@@ -4,6 +4,7 @@
 #include "../ClientApp.h"
 #include "../../util/Process.h"
 #include "../../UI/ClientUI.h"
+#include "../../util/OptionsDB.h"
 
 #include <GG/SDL/SDLGUI.h>
 
@@ -83,6 +84,9 @@ public:
 
     static HumanClientApp*      GetApp();               ///< returns HumanClientApp pointer to the single instance of the app
 
+    /** Adds window dimension options to OptionsDB after the start of main, but before HumanClientApp constructor.
+        OSX will not tolerate static initialization of SDL, to check screen size. */
+    static void AddWindowSizeOptionsAfterMainStart(OptionsDB& db);
 protected:
     virtual void Initialize();
 

--- a/client/human/chmain.cpp
+++ b/client/human/chmain.cpp
@@ -210,6 +210,8 @@ int mainConfigOptionsSetup(const std::vector<std::string>& args) {
 
 int mainSetupAndRun() {
     try {
+        RegisterOptions(&HumanClientApp::AddWindowSizeOptionsAfterMainStart);
+
         int colour_depth = GetOptionsDB().Get<int>("color-depth");
         bool fullscreen = GetOptionsDB().Get<bool>("fullscreen");
         bool fake_mode_change = GetOptionsDB().Get<bool>("fake-mode-change");


### PR DESCRIPTION
This is an attempt to address bug #564.

I can not test it as I'm running linux.  It may not help. Please allow Vezzra to test it.

Starting with PR #519 OSX crashes on exit.  PR #519 initialized SDL during the static initialization.  Prior to PR #519 initialization happened in the HumanClientApp constructor.  The initialization was moved in order to detect the screen sizes before the HumanClientApp was constructed. 

I've moved the initialization out of static initialization and into main().

Note, technically SDL requires that the main() function be replaced with SDL_main().  Freeorion was not using SDL_main() before PR #519 and is still not using SDL_main(), so I do not think that absence of SDL_main() is directly causing the new OSX crash.  However, adding SDL_main() might fix it because then all initialization will be as SDL expects.  I'm trying this fix first, because it is simpler and closest to the way things were.
