### PR TITLE
Windows Wide Path Fixes

### DIFF
--- a/GG/GG/GUI.h
+++ b/GG/GG/GUI.h
@@ -313,7 +313,7 @@ public:
     boost::shared_ptr<Font>    GetFont(const boost::shared_ptr<Font>& font, unsigned int pts);
 
     /** Removes the desired font from the managed pool; since shared_ptr's are
-        used, the font may be deleted much later */
+        used, the font may be deleted much later. */
     void                       FreeFont(const std::string& font_filename, unsigned int pts);
 
     /** Adds an already-constructed texture to the managed pool \warning
@@ -321,9 +321,24 @@ public:
         do that. */
     boost::shared_ptr<Texture> StoreTexture(Texture* texture, const std::string& texture_name);
 
-    boost::shared_ptr<Texture> StoreTexture(const boost::shared_ptr<Texture> &texture, const std::string& texture_name); ///< adds an already-constructed texture to the managed pool
-    boost::shared_ptr<Texture> GetTexture(const std::string& name, bool mipmap = false); ///< loads the requested texture from file \a name; mipmap textures are generated if \a mipmap is true
-    void                       FreeTexture(const std::string& name); ///< removes the desired texture from the managed pool; since shared_ptr's are used, the texture may be deleted much later
+    /** Adds an already-constructed texture to the managed pool. */
+    boost::shared_ptr<Texture> StoreTexture(const boost::shared_ptr<Texture> &texture, const std::string& texture_name);
+
+    /** Loads the requested texture from file \a name; mipmap textures are
+      * generated if \a mipmap is true. */
+    boost::shared_ptr<Texture> GetTexture(const std::string& name, bool mipmap = false);
+
+    /** Loads the requested texture from file \a name; mipmap textures are
+      * generated if \a mipmap is true. */
+    boost::shared_ptr<Texture> GetTexture(const boost::filesystem::path& path, bool mipmap = false);
+
+    /** Removes the desired texture from the managed pool; since shared_ptr's
+      * are used, the texture may be deleted much later. */
+    void                       FreeTexture(const std::string& name);
+
+    /** Removes the desired texture from the managed pool; since shared_ptr's
+      * are used, the texture may be deleted much later. */
+    void                       FreeTexture(const boost::filesystem::path& path);
 
     void SetStyleFactory(const boost::shared_ptr<StyleFactory>& factory); ///< sets the currently-installed style factory
 

--- a/GG/GG/RichText/ImageBlock.h
+++ b/GG/GG/RichText/ImageBlock.h
@@ -7,8 +7,6 @@
 
 namespace GG
 {
-
-
 /**
 * @brief A Block control containing an image.
 *
@@ -28,27 +26,25 @@ public:
      */
     static const std::string IMAGE_TAG;
 
-
     /**
      * @brief Construct image block.
      *
      * @param image_path The path to the image.
      */
-    ImageBlock ( const std::string& image_path, X x, Y y, X w, GG::Flags< GG::WndFlag > flags );
+    ImageBlock(const std::string& image_path, X x, Y y, X w, GG::Flags<GG::WndFlag> flags);
 
     //! Implement from BlockControl sets the maximum width, returns the actual size based on that.
-    virtual Pt SetMaxWidth ( X width );
+    virtual Pt SetMaxWidth(X width);
 
     virtual void Render();
 
     //! Set the root path from which to look for images with the factory.
-    static bool SetImagePath (
-        RichText::IBlockControlFactory* factory, //!< The factory to set the path for. Should be an image block factory.
-        const std::string& path ); //!< The base path to look for images from.
+    static bool SetImagePath(RichText::IBlockControlFactory* factory,  //!< The factory to set the path for. Should be an image block factory.
+                             const std::string& path);                 //!< The base path to look for images from.
 
     //! Set the root path from which to look for images with the factory.
-    static bool SetDefaultImagePath (
-        const std::string& path ); //!< The base path to look for images from.
+    static bool SetDefaultImagePath(const std::string& path); //!< The base path to look for images from.
+
 private:
     StaticGraphic* m_graphic; //! The StaticGraphic used to render the image.
 };

--- a/GG/GG/RichText/ImageBlock.h
+++ b/GG/GG/RichText/ImageBlock.h
@@ -5,6 +5,8 @@
 #include <GG/RichText/RichText.h>
 #include <GG/StaticGraphic.h>
 
+#include <boost/filesystem/path.hpp>
+
 namespace GG
 {
 /**
@@ -31,7 +33,7 @@ public:
      *
      * @param image_path The path to the image.
      */
-    ImageBlock(const std::string& image_path, X x, Y y, X w, GG::Flags<GG::WndFlag> flags);
+    ImageBlock(const boost::filesystem::path& path, X x, Y y, X w, GG::Flags<GG::WndFlag> flags);
 
     //! Implement from BlockControl sets the maximum width, returns the actual size based on that.
     virtual Pt SetMaxWidth(X width);
@@ -39,11 +41,11 @@ public:
     virtual void Render();
 
     //! Set the root path from which to look for images with the factory.
-    static bool SetImagePath(RichText::IBlockControlFactory* factory,  //!< The factory to set the path for. Should be an image block factory.
-                             const std::string& path);                 //!< The base path to look for images from.
+    static bool SetImagePath(RichText::IBlockControlFactory* factory,   //!< The factory to set the path for. Should be an image block factory.
+                             const boost::filesystem::path& path);      //!< The base path to look for images from.
 
     //! Set the root path from which to look for images with the factory.
-    static bool SetDefaultImagePath(const std::string& path); //!< The base path to look for images from.
+    static bool SetDefaultImagePath(const boost::filesystem::path& path); //!< The base path to look for images from.
 
 private:
     StaticGraphic* m_graphic; //! The StaticGraphic used to render the image.

--- a/GG/src/GIL/extension/io/png_dynamic_io.hpp
+++ b/GG/src/GIL/extension/io/png_dynamic_io.hpp
@@ -120,6 +120,30 @@ inline void png_read_image(const std::string& filename,any_image<Images>& im) {
 }
 
 /// \ingroup PNG_IO
+/// \brief reads a PNG image into a run-time instantiated image
+template <typename Images>
+inline void png_read_image(FILE* file,any_image<Images>& im) {
+    detail::png_reader_dynamic m(file);
+    m.read_image(im);
+}
+
+/// \ingroup PNG_IO
+/// \brief reads a PNG image into a run-time instantiated image
+template <typename Images>
+inline void png_read_image(const boost::filesystem::path& path,any_image<Images>& im) {
+#if defined (_WIN32)
+    boost::filesystem::path::string_type path_native = path.native();
+    FILE* file = _wfopen(path_native.c_str(), L"rb");
+    detail::png_reader_dynamic m(file);
+    m.read_image(im);
+    fclose(file);
+#else
+    std::string filename = path.generic_string());
+    png_read_image(filename.c_str(),im);
+#endif
+}
+
+/// \ingroup PNG_IO
 /// \brief Saves the currently instantiated view to a png file specified by the given png image file name.
 /// Throws std::ios_base::failure if the currently instantiated view type is not supported for writing by the I/O extension 
 /// or if it fails to create the file.

--- a/GG/src/GIL/extension/io/png_dynamic_io.hpp
+++ b/GG/src/GIL/extension/io/png_dynamic_io.hpp
@@ -138,7 +138,7 @@ inline void png_read_image(const boost::filesystem::path& path,any_image<Images>
     m.read_image(im);
     fclose(file);
 #else
-    std::string filename = path.generic_string());
+    std::string filename = path.generic_string();
     png_read_image(filename.c_str(),im);
 #endif
 }

--- a/GG/src/GIL/extension/io/png_io.hpp
+++ b/GG/src/GIL/extension/io/png_io.hpp
@@ -193,7 +193,7 @@ inline void png_read_and_convert_image(const boost::filesystem::path& path,Image
     gil::png_read_and_convert_image(file,im);
     fclose(file);
 #else
-    std::string filename = path.generic_string());
+    std::string filename = path.generic_string();
     png_read_and_convert_image(filename.c_str(),im);
 #endif
 }

--- a/GG/src/GIL/extension/io/png_io.hpp
+++ b/GG/src/GIL/extension/io/png_io.hpp
@@ -176,6 +176,29 @@ inline void png_read_and_convert_image(const std::string& filename,Image& im) {
 }
 
 /// \ingroup PNG_IO
+/// \brief Allocates a new image whose dimensions are determined by the given png image file, loads and color-converts the pixels into it.
+template <typename Image>
+inline void png_read_and_convert_image(FILE* file,Image& im) {
+    detail::png_reader_color_convert<default_color_converter> m(file, default_color_converter());
+    m.read_image(im);
+}
+
+/// \ingroup PNG_IO
+/// \brief Allocates a new image whose dimensions are determined by the given png image file path, loads and color-converts the pixels into it.
+template <typename Image>
+inline void png_read_and_convert_image(const boost::filesystem::path& path,Image& im) {
+#if defined (_WIN32)
+    boost::filesystem::path::string_type path_native = path.native();
+    FILE* file = _wfopen(path_native.c_str(), L"rb");
+    gil::png_read_and_convert_image(file,im);
+    fclose(file);
+#else
+    std::string filename = path.generic_string());
+    png_read_and_convert_image(filename.c_str(),im);
+#endif
+}
+
+/// \ingroup PNG_IO
 /// \brief Determines whether the given view type is supported for writing
 template <typename View>
 struct png_write_support {

--- a/GG/src/GIL/extension/io/png_io_private.hpp
+++ b/GG/src/GIL/extension/io/png_io_private.hpp
@@ -281,6 +281,8 @@ public:
     png_reader_color_convert(FILE* file          ) : png_reader(file) {}
     png_reader_color_convert(const char* filename,CC cc_in) : png_reader(filename),_cc(cc_in) {}
     png_reader_color_convert(const char* filename) : png_reader(filename) {}
+    png_reader_color_convert(const boost::filesystem::path& path) : png_reader(path) {}
+
     template <typename View>
     void apply(const View& view) {
         png_uint_32 width, height;

--- a/GG/src/GUI.cpp
+++ b/GG/src/GUI.cpp
@@ -1335,11 +1335,11 @@ boost::shared_ptr<Texture> GUI::StoreTexture(Texture* texture, const std::string
 boost::shared_ptr<Texture> GUI::StoreTexture(const boost::shared_ptr<Texture>& texture, const std::string& texture_name)
 { return GetTextureManager().StoreTexture(texture, texture_name); }
 
-boost::shared_ptr<Texture> GUI::GetTexture(const std::string& name, bool mipmap/* = false*/)
-{ return GetTextureManager().GetTexture(name, mipmap); }
+boost::shared_ptr<Texture> GUI::GetTexture(const boost::filesystem::path& path, bool mipmap/* = false*/)
+{ return GetTextureManager().GetTexture(path, mipmap); }
 
-void GUI::FreeTexture(const std::string& name)
-{ GetTextureManager().FreeTexture(name); }
+void GUI::FreeTexture(const boost::filesystem::path& path)
+{ GetTextureManager().FreeTexture(path); }
 
 void GUI::SetStyleFactory(const boost::shared_ptr<StyleFactory>& factory)
 {

--- a/GG/src/GUI.cpp
+++ b/GG/src/GUI.cpp
@@ -1490,7 +1490,7 @@ void GUI::RenderWindow(Wnd* wnd)
             if (clip)
                 wnd->BeginClipping();
             for (std::list<Wnd*>::iterator it = wnd->m_children.begin(); it != wnd->m_children.end(); ++it) {
-                if ((*it)->Visible())
+                if ((*it) && (*it)->Visible())
                     RenderWindow(*it);
             }
             if (clip)
@@ -1504,7 +1504,7 @@ void GUI::RenderWindow(Wnd* wnd)
             if (children_copy.begin() != client_child_begin) {
                 wnd->BeginNonclientClipping();
                 for (std::vector<Wnd*>::iterator it = children_copy.begin(); it != client_child_begin; ++it) {
-                    if ((*it)->Visible())
+                    if ((*it) && (*it)->Visible())
                         RenderWindow(*it);
                 }
                 wnd->EndNonclientClipping();
@@ -1513,7 +1513,7 @@ void GUI::RenderWindow(Wnd* wnd)
             if (client_child_begin != children_copy.end()) {
                 wnd->BeginClipping();
                 for (std::vector<Wnd*>::iterator it = client_child_begin; it != children_copy.end(); ++it) {
-                    if ((*it)->Visible())
+                    if ((*it) && (*it)->Visible())
                         RenderWindow(*it);
                 }
                 wnd->EndClipping();

--- a/GG/src/RichText/ImageBlock.cpp
+++ b/GG/src/RichText/ImageBlock.cpp
@@ -21,8 +21,7 @@ namespace GG {
     {
         try {
             boost::shared_ptr<Texture> texture = GetTextureManager().GetTexture(image_path);
-            m_graphic = new StaticGraphic(texture,
-                                          GRAPHIC_PROPSCALE | GRAPHIC_SHRINKFIT | GRAPHIC_CENTER);
+            m_graphic = new StaticGraphic(texture, GRAPHIC_PROPSCALE | GRAPHIC_SHRINKFIT | GRAPHIC_CENTER);
             AttachChild(m_graphic);
         } catch (GG::Texture::BadFile&) {
             // No can do inside GiGi.
@@ -74,7 +73,9 @@ namespace GG {
     // A factory for creating image blocks from tags.
     class ImageBlockFactory : public RichText::IBlockControlFactory {
     public:
-        ImageBlockFactory() : m_root_path(".") {}
+        ImageBlockFactory() :
+            m_root_path(".")
+        {}
 
         //! Create a Text block from a plain text tag.
         virtual BlockControl* CreateFromTag(const std::string& tag,
@@ -92,7 +93,8 @@ namespace GG {
         }
 
         // Sets the root of image search path.
-        void SetRootPath(const std::string& path) { m_root_path = FileDlg::StringToPath(path); }
+        void SetRootPath(const std::string& path)
+        { m_root_path = FileDlg::StringToPath(path); }
 
     private:
         boost::filesystem::path m_root_path;
@@ -115,17 +117,12 @@ namespace GG {
     };
 
     // Register image block as the image tag handler.
-    static int dummy =
-        RichText::RegisterDefaultBlock(ImageBlock::IMAGE_TAG, new ImageBlockFactory());
+    static int dummy = RichText::RegisterDefaultBlock(ImageBlock::IMAGE_TAG, new ImageBlockFactory());
 
     //! Set the root path from which to look for images with the factory.
-    bool ImageBlock::SetImagePath(
-        RichText::IBlockControlFactory* factory, //!< The factory to set the
-        //! path for. Should be an image
-        //! block factory.
-        const std::string& path)
-    { //!< The base path to look for images from.
-
+    bool ImageBlock::SetImagePath(RichText::IBlockControlFactory* factory,
+                                  const std::string& path)
+    {
         // Try to convert the factory to an image factory.
         ImageBlockFactory* image_factory = dynamic_cast<ImageBlockFactory*>(factory);
 

--- a/GG/src/RichText/RichText.cpp
+++ b/GG/src/RichText/RichText.cpp
@@ -230,10 +230,11 @@ namespace GG {
                 // Extract the parameters from params_string to the tag_params map.
                 ExtractParameters(tag.tag_params, params);
 
-                BlockControl* block = FactoryMap()[tag.tag]->CreateFromTag(
-                    tag.tag, params, tag.content, m_font, m_color, m_format);
-                m_owner->AttachChild(block);
-                m_blocks.push_back(block);
+                BlockControl* block = FactoryMap()[tag.tag]->CreateFromTag(tag.tag, params, tag.content, m_font, m_color, m_format);
+                if (block) {
+                    m_owner->AttachChild(block);
+                    m_blocks.push_back(block);
+                }
             }
 
             DoLayout();

--- a/GG/src/Texture.cpp
+++ b/GG/src/Texture.cpp
@@ -705,8 +705,9 @@ boost::shared_ptr<Texture> TextureManager::StoreTexture(const boost::shared_ptr<
 
 boost::shared_ptr<Texture> TextureManager::GetTexture(const boost::filesystem::path& path, bool mipmap/* = false*/)
 {
-    std::map<std::string, boost::shared_ptr<Texture> >::iterator it = m_textures.find(path.string());
+    std::map<std::string, boost::shared_ptr<Texture> >::iterator it = m_textures.find(path.generic_string());
     if (it == m_textures.end()) { // if no such texture was found, attempt to load it now, using name as the filename
+        //std::cout << "TextureManager::GetTexture storing new texture under name: " << path.generic_string();
         return (m_textures[path.generic_string()] = LoadTexture(path, mipmap));
     } else { // otherwise, just return the texture we found
         return it->second;

--- a/GG/src/Texture.cpp
+++ b/GG/src/Texture.cpp
@@ -276,7 +276,7 @@ void Texture::Load(const boost::filesystem::path& path, bool mipmap/* = false*/)
     std::string filename;
     utf8::utf16to8(path_native.begin(), path_native.end(), std::back_inserter(filename));
 #else
-    std::string filename = path.generic_string());
+    std::string filename = path.generic_string();
 #endif
 
 

--- a/GG/src/dialogs/FileDlg.cpp
+++ b/GG/src/dialogs/FileDlg.cpp
@@ -227,7 +227,6 @@ const boost::filesystem::path FileDlg::StringToPath(const std::string& str) {
 #endif
 }
 
-
 void FileDlg::CreateChildren(bool multi)
 {
     if (m_save)

--- a/GG/src/dialogs/FileDlg.cpp
+++ b/GG/src/dialogs/FileDlg.cpp
@@ -219,7 +219,7 @@ const fs::path& FileDlg::WorkingDirectory()
 const boost::filesystem::path FileDlg::StringToPath(const std::string& str) {
 #if defined(_WIN32)
     // convert UTF-8 path string to UTF-16
-    boost::filesystem::path::string_type str_native;
+    fs::path::string_type str_native;
     utf8::utf8to16(str.begin(), str.end(), std::back_inserter(str_native));
     return fs::path(str_native);
 #else

--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -48,7 +48,7 @@
 const Tech* GetTech(const std::string& name);
 
 bool TextureFileNameCompare(const boost::shared_ptr<GG::Texture> t1, const boost::shared_ptr<GG::Texture> t2)
-{ return t1 && t2 && t1->Filename() < t2->Filename(); }
+{ return t1 && t2 && t1->Path() < t2->Path(); }
 
 namespace fs = boost::filesystem;
 
@@ -926,9 +926,9 @@ void ClientUI::MessageBox(const std::string& message, bool play_alert_sound/* = 
 boost::shared_ptr<GG::Texture> ClientUI::GetTexture(const boost::filesystem::path& path, bool mipmap/* = false*/) {
     boost::shared_ptr<GG::Texture> retval;
     try {
-        retval = HumanClientApp::GetApp()->GetTexture(path.string(), mipmap);
+        retval = HumanClientApp::GetApp()->GetTexture(path, mipmap);
     } catch(...) {
-        retval = HumanClientApp::GetApp()->GetTexture((ClientUI::ArtDir() / "misc" / "missing.png").string(), mipmap);
+        retval = HumanClientApp::GetApp()->GetTexture(ClientUI::ArtDir() / "misc" / "missing.png", mipmap);
     }
 #ifdef FREEORION_MACOSX
     if (!mipmap)

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -1804,6 +1804,11 @@ namespace {
     GG::GL2DVertexBuffer dot_vertices_buffer;
     GG::GLTexCoordBuffer dot_star_texture_coords;
     const unsigned int BUFFER_CAPACITY(512);    // should be long enough for most plausible fleet move lines
+
+    boost::shared_ptr<GG::Texture> MoveLineDotTexture() {
+        boost::shared_ptr<GG::Texture> retval = ClientUI::GetTexture(ClientUI::ArtDir() / "misc" / "move_line_dot.png");
+        return retval;
+    }
 }
 
 void MapWnd::RenderFleetMovementLines() {
@@ -1817,7 +1822,7 @@ void MapWnd::RenderFleetMovementLines() {
     float move_line_animation_shift = static_cast<int>(ticks * rate) % dot_spacing;
 
     // texture for dots
-    boost::shared_ptr<GG::Texture> move_line_dot_texture = ClientUI::GetTexture(ClientUI::ArtDir() / "misc" / "move_line_dot.png");
+    boost::shared_ptr<GG::Texture> move_line_dot_texture = MoveLineDotTexture();
     float dot_size = Value(move_line_dot_texture->DefaultWidth());
     //std::cout << "dot size: " << dot_size << std::endl;
 

--- a/UI/PlayerListWnd.cpp
+++ b/UI/PlayerListWnd.cpp
@@ -20,23 +20,74 @@
 namespace {
     const int           DATA_PANEL_BORDER = 1;
 
-    boost::shared_ptr<GG::Texture> AIIcon()         { return ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "ai.png"); }
-    boost::shared_ptr<GG::Texture> HumanIcon()      { return ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "human.png"); }
-    boost::shared_ptr<GG::Texture> ObserverIcon()   { return ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "observer.png"); }
-    boost::shared_ptr<GG::Texture> ModeratorIcon()  { return ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "moderator.png"); }
-    boost::shared_ptr<GG::Texture> HostIcon()       { return ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "host.png"); }
-    boost::shared_ptr<GG::Texture> PlayingIcon()    { return ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "playing.png"); }
-    boost::shared_ptr<GG::Texture> WaitingIcon()    { return ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "waiting.png"); }
-    boost::shared_ptr<GG::Texture> CombatIcon()     { return ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "combat.png"); }
-    boost::shared_ptr<GG::Texture> WarIcon()        { return ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "war.png"); }
-    boost::shared_ptr<GG::Texture> PeaceIcon()      { return ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "peace.png"); }
-    boost::shared_ptr<GG::Texture> UnknownIcon()    { return ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "unknown.png"); }
-    boost::shared_ptr<GG::Texture> ShipIcon()       { return ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "sitrep" / "fleet_arrived.png"); }
-    boost::shared_ptr<GG::Texture> ProductionIcon() { return ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "meter" / "industry.png"); }
-    boost::shared_ptr<GG::Texture> ResearchIcon()   { return ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "meter" / "research.png"); }
-    boost::shared_ptr<GG::Texture> DetectionIcon()  { return ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "meter" / "detection.png"); }
-    boost::shared_ptr<GG::Texture> WonIcon()        { return ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "sitrep" / "victory.png"); }
-    boost::shared_ptr<GG::Texture> LostIcon()       { return ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "sitrep" / "empire_eliminated.png"); }
+    boost::shared_ptr<GG::Texture> AIIcon() {
+        static boost::shared_ptr<GG::Texture> retval = ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "ai.png");
+        return retval;
+    }
+    boost::shared_ptr<GG::Texture> HumanIcon() {
+        static boost::shared_ptr<GG::Texture> retval = ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "human.png");
+        return retval;
+    }
+    boost::shared_ptr<GG::Texture> ObserverIcon() {
+        static boost::shared_ptr<GG::Texture> retval = ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "observer.png");
+        return retval;
+    }
+    boost::shared_ptr<GG::Texture> ModeratorIcon() {
+        static boost::shared_ptr<GG::Texture> retval = ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "moderator.png");
+        return retval;
+    }
+    boost::shared_ptr<GG::Texture> HostIcon() {
+        static boost::shared_ptr<GG::Texture> retval = ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "host.png");
+        return retval;
+    }
+    boost::shared_ptr<GG::Texture> PlayingIcon() {
+        static boost::shared_ptr<GG::Texture> retval = ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "playing.png");
+        return retval;
+    }
+    boost::shared_ptr<GG::Texture> WaitingIcon() {
+        static boost::shared_ptr<GG::Texture> retval = ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "waiting.png");
+        return retval;
+    }
+    boost::shared_ptr<GG::Texture> CombatIcon() {
+        static boost::shared_ptr<GG::Texture> retval = ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "combat.png");
+        return retval;
+    }
+    boost::shared_ptr<GG::Texture> WarIcon() {
+        static boost::shared_ptr<GG::Texture> retval = ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "war.png");
+        return retval;
+    }
+    boost::shared_ptr<GG::Texture> PeaceIcon() {
+        static boost::shared_ptr<GG::Texture> retval = ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "peace.png");
+        return retval;
+    }
+    boost::shared_ptr<GG::Texture> UnknownIcon() {
+        static boost::shared_ptr<GG::Texture> retval = ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "unknown.png");
+        return retval;
+    }
+    boost::shared_ptr<GG::Texture> ShipIcon() {
+        static boost::shared_ptr<GG::Texture> retval = ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "sitrep" / "fleet_arrived.png");
+        return retval;
+    }
+    boost::shared_ptr<GG::Texture> ProductionIcon() {
+        static boost::shared_ptr<GG::Texture> retval = ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "meter" / "industry.png");
+        return retval;
+    }
+    boost::shared_ptr<GG::Texture> ResearchIcon() {
+        static boost::shared_ptr<GG::Texture> retval = ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "meter" / "research.png");
+        return retval;
+    }
+    boost::shared_ptr<GG::Texture> DetectionIcon() {
+        static boost::shared_ptr<GG::Texture> retval = ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "meter" / "detection.png");
+        return retval;
+    }
+    boost::shared_ptr<GG::Texture> WonIcon() {
+        static boost::shared_ptr<GG::Texture> retval = ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "sitrep" / "victory.png");
+        return retval;
+    }
+    boost::shared_ptr<GG::Texture> LostIcon() {
+        static boost::shared_ptr<GG::Texture> retval = ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "sitrep" / "empire_eliminated.png");
+        return retval;
+    }
 
 
     ////////////////////////////////////////////////

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -40,8 +40,8 @@ namespace {
 
     const std::string SAVE_FILE_WND_NAME = "save-load";
 
-    const GG::X PROMT_WIDTH ( 200 );
-    const GG::Y PROMPT_HEIGHT ( 75 );
+    const GG::X PROMT_WIDTH(200);
+    const GG::Y PROMPT_HEIGHT(75);
 
     const double DEFAULT_STRETCH = 1.0;
 
@@ -143,9 +143,6 @@ namespace {
         }
         return false;
     }
-
-    bool IsValidUTF8(const std::string& in)
-    { return utf8::is_valid(in.begin(), in.end()); }
 }
 
 /** Describes how a column should be set up in the dialog */

--- a/UI/Sound.cpp
+++ b/UI/Sound.cpp
@@ -1,6 +1,7 @@
 #include "Sound.h"
 #include "../util/Logger.h"
 #include "../util/OptionsDB.h"
+#include "../util/Directories.h"
 
 #ifdef FREEORION_MACOSX
 # include <OpenAL/alc.h>
@@ -156,27 +157,22 @@ Sound::Sound() :
     InitOpenAL(NUM_SOURCES, m_sources, m_music_buffers);
 }
 
-Sound::~Sound()
-{
-    if (alcGetCurrentContext() != 0)
-    {
+Sound::~Sound() {
+    if (alcGetCurrentContext() != 0) {
         alDeleteSources(NUM_SOURCES, m_sources); // Automatically stops currently playing sources
 
         alDeleteBuffers(2, m_music_buffers);
-        for( std::map<std::string, ALuint>::iterator itr = m_buffers.begin(); itr != m_buffers.end(); ++itr )
+        for (std::map<std::string, ALuint>::iterator itr = m_buffers.begin(); itr != m_buffers.end(); ++itr)
             alDeleteBuffers(1, &itr->second );
     }
-
-
     ShutdownOpenAL();
 }
 
-void Sound::PlayMusic(const boost::filesystem::path& path, int loops /* = 0*/)
-{
+void Sound::PlayMusic(const boost::filesystem::path& path, int loops /* = 0*/) {
     ALenum m_openal_error;
-    std::string filename = path.string();
-    FILE *m_f = 0;
-    vorbis_info *vorbis_info;
+    std::string filename = PathString(path);
+    FILE* m_f = 0;
+    vorbis_info* vorbis_info;
     m_music_loops = 0;
 
 #ifdef FREEORION_WIN32
@@ -269,7 +265,7 @@ void Sound::PlaySound(const boost::filesystem::path& path, bool is_ui_sound/* = 
     if (!GetOptionsDB().Get<bool>("UI.sound.enabled") || (is_ui_sound && UISoundsTemporarilyDisabled()))
         return;
 
-    std::string filename = path.string();
+    std::string filename = PathString(path);
     ALuint current_buffer;
     ALenum source_state;
     ALsizei ogg_freq;
@@ -369,7 +365,7 @@ void Sound::PlaySound(const boost::filesystem::path& path, bool is_ui_sound/* = 
 
 void Sound::FreeSound(const boost::filesystem::path& path) {
     ALenum m_openal_error;
-    std::string filename = path.string();
+    std::string filename = PathString(path);
     std::map<std::string, ALuint>::iterator it = m_buffers.find(filename);
 
     if (it != m_buffers.end()) {

--- a/util/Directories.cpp
+++ b/util/Directories.cpp
@@ -68,7 +68,7 @@ void InitDirs(const std::string& argv0) {
             exit(-1);
         }
     }
-    
+
     bundle_path = fs::path(bundle_dir);
 
     // search bundle_path for a directory named "FreeOrion.app", exiting if not found, else constructing a path to application bundle contents
@@ -82,7 +82,7 @@ void InitDirs(const std::string& argv0) {
         }
         app_path /= "FreeOrion.app/Contents";
     }
-    
+
     s_root_data_dir =   app_path / "Resources";
     s_user_dir      =   fs::path(getenv("HOME")) / "Library" / "Application Support" / "FreeOrion";
     s_bin_dir       =   app_path / "Executables";
@@ -288,11 +288,14 @@ const fs::path GetResourceDir() {
     // use default location
     std::string options_resource_dir = GetOptionsDB().Get<std::string>("resource-dir");
     fs::path dir = FilenameToPath(options_resource_dir);
-
-    if (options_resource_dir.empty() || !fs::is_directory(dir) || !fs::exists(dir))
-        return FilenameToPath(GetOptionsDB().GetDefault<std::string>("resource-dir"));
-    else
+    if (fs::exists(dir) && fs::is_directory(dir))
         return dir;
+
+    dir = GetOptionsDB().GetDefault<std::string>("resource-dir");
+    if (!fs::is_directory(dir) || !fs::exists(dir))
+        dir = FilenameToPath(GetOptionsDB().GetDefault<std::string>("resource-dir"));
+
+    return dir;
 }
 
 const fs::path GetConfigPath() {
@@ -399,3 +402,6 @@ std::vector<fs::path> ListDir(const fs::path& path) {
 
     return retval;
 }
+
+bool IsValidUTF8(const std::string& in)
+{ return utf8::is_valid(in.begin(), in.end()); }

--- a/util/Directories.h
+++ b/util/Directories.h
@@ -20,6 +20,8 @@ FO_COMMON_API void InitDirs(const std::string& argv0);
   * <li>This directory is the only one that can be considered writable!</ul> */
 FO_COMMON_API const boost::filesystem::path GetUserDir();
 
+/** Converts UTF-8 string into a path, doing any required wide-character
+  * conversions as determined by the operating system / filesystem. */
 FO_COMMON_API const boost::filesystem::path FilenameToPath(const std::string& path_str);
 
 /** Returns the directory that contains all game content files, such as string
@@ -69,5 +71,9 @@ FO_COMMON_API boost::filesystem::path RelativePath(const boost::filesystem::path
 
 /** Returns a vector of files within \a path including a recursive search though sub-dirs */
 FO_COMMON_API std::vector<boost::filesystem::path> ListDir(const boost::filesystem::path& path);
+
+/** Returns true iff the string \a in is valid UTF-8. */
+FO_COMMON_API bool IsValidUTF8(const std::string& in);
+
 
 #endif


### PR DESCRIPTION
Currently, setting the resource directory to a path with non-ascii characters will cause errors in path resolution on Windows. This attempts to fix it, hopefully in a way that doesn't break anything else. Some testing reports from others (Windows or non-Windows) would be useful.
