### PR TITLE
Refactor ResourcesAI.py

### DIFF
--- a/default/AI/AIstate.py
+++ b/default/AI/AIstate.py
@@ -933,7 +933,6 @@ class AIstate(object):
             return
 
     def session_start_cleanup(self):
-        ResourcesAI.newTargets.clear()
         self.newlySplitFleets = {}
         for fleetID in FleetUtilsAI.get_empire_fleet_ids():
             self.get_fleet_role(fleetID)

--- a/default/AI/ResourcesAI.py
+++ b/default/AI/ResourcesAI.py
@@ -11,10 +11,7 @@ from freeorion_tools import tech_is_complete
 
 resource_timer = Timer('timer_bucket')
 
-newTargets = {}
-currentFocus = {}
-currentOutput = {}
-planetMap = {}
+#Local Constants
 IFocus = FocusType.FOCUS_INDUSTRY
 RFocus = FocusType.FOCUS_RESEARCH
 MFocus = FocusType.FOCUS_MINING  # not currently used in content
@@ -29,17 +26,22 @@ limitAssessments = False
 
 lastFociCheck = [0]
 
+new_targets = {}
+current_focus = {}
+current_output = {}
+planet_map = {}
+
 
 def _fill_data_dicts(planet_ids):
     universe = fo.getUniverse()
-    newTargets.clear()
-    currentFocus.clear()
-    currentOutput.clear()
-    planets = [(pid, planetMap[pid]) for pid in planet_ids]
+    new_targets.clear()
+    current_focus.clear()
+    current_output.clear()
+    planets = [(pid, planet_map[pid]) for pid in planet_ids]
     for pid, planet in planets:
-        currentFocus[pid] = planet.focus
-        currentOutput.setdefault(pid, {})[IFocus] = planet.currentMeterValue(fo.meterType.industry)
-        currentOutput[pid][RFocus] = planet.currentMeterValue(fo.meterType.research)
+        current_focus[pid] = planet.focus
+        current_output.setdefault(pid, {})[IFocus] = planet.currentMeterValue(fo.meterType.industry)
+        current_output[pid][RFocus] = planet.currentMeterValue(fo.meterType.research)
         if IFocus in planet.availableFoci and planet.focus != IFocus:
             fo.issueChangeFocusOrder(pid, IFocus)  # may not be able to take, but try
     universe.updateMeterEstimates(planet_ids)
@@ -47,13 +49,13 @@ def _fill_data_dicts(planet_ids):
         itarget = planet.currentMeterValue(fo.meterType.targetIndustry)
         rtarget = planet.currentMeterValue(fo.meterType.targetResearch)
         if planet.focus == IFocus:
-            newTargets.setdefault(pid, {})[IFocus] = (itarget, rtarget)
-            newTargets.setdefault(pid, {})[GFocus] = [0, rtarget]
+            new_targets.setdefault(pid, {})[IFocus] = (itarget, rtarget)
+            new_targets.setdefault(pid, {})[GFocus] = [0, rtarget]
         else:
-            newTargets.setdefault(pid, {})[IFocus] = (0, 0)
-            newTargets.setdefault(pid, {})[GFocus] = [0, 0]
-        # if currentFocus[pid] == MFocus:
-        # newTargets[pid][MFocus] = (mtarget, rtarget)
+            new_targets.setdefault(pid, {})[IFocus] = (0, 0)
+            new_targets.setdefault(pid, {})[GFocus] = [0, 0]
+        # if current_focus[pid] == MFocus:
+        # new_targets[pid][MFocus] = (mtarget, rtarget)
         if RFocus in planet.availableFoci and planet.focus != RFocus:
             fo.issueChangeFocusOrder(pid, RFocus)  # may not be able to take, but try
     universe.updateMeterEstimates(planet_ids)
@@ -62,22 +64,22 @@ def _fill_data_dicts(planet_ids):
         itarget = planet.currentMeterValue(fo.meterType.targetIndustry)
         rtarget = planet.currentMeterValue(fo.meterType.targetResearch)
         if planet.focus == RFocus:
-            newTargets.setdefault(pid, {})[RFocus] = (itarget, rtarget)
-            newTargets[pid][GFocus][0] = itarget
+            new_targets.setdefault(pid, {})[RFocus] = (itarget, rtarget)
+            new_targets[pid][GFocus][0] = itarget
         else:
-            newTargets.setdefault(pid, {})[RFocus] = (0, 0)
-            newTargets[pid][GFocus][0] = 0
-        if can_focus and currentFocus[pid] != planet.focus:
-            fo.issueChangeFocusOrder(pid, currentFocus[pid])  # put it back to what it was
+            new_targets.setdefault(pid, {})[RFocus] = (0, 0)
+            new_targets[pid][GFocus][0] = 0
+        if can_focus and current_focus[pid] != planet.focus:
+            fo.issueChangeFocusOrder(pid, current_focus[pid])  # put it back to what it was
     universe.updateMeterEstimates(planet_ids)
     # Protection focus will give the same off-focus Industry and Research targets as Growth Focus
     for pid, planet in planets:
-        newTargets[pid][PFocus] = newTargets[pid][GFocus]
+        new_targets[pid][PFocus] = new_targets[pid][GFocus]
 
 
 def get_resource_target_totals(empirePlanetIDs):
-    pp = sum(x.currentMeterValue(fo.meterType.targetIndustry) for x in planetMap.values())
-    rp = sum(x.currentMeterValue(fo.meterType.targetResearch) for x in planetMap.values())
+    pp = sum(x.currentMeterValue(fo.meterType.targetIndustry) for x in planet_map.values())
+    rp = sum(x.currentMeterValue(fo.meterType.targetResearch) for x in planet_map.values())
     _fill_data_dicts(empirePlanetIDs)
     return pp, rp
 
@@ -134,34 +136,34 @@ def weighted_sum_output(outputs):
 
 def assess_protection_focus(pid):
     """Return True if planet should use Protection Focus"""
-    this_planet = planetMap[pid]
+    this_planet = planet_map[pid]
     sys_status = foAI.foAIstate.systemStatus.get(this_planet.systemID, {})
     threat_from_supply = (0.25 * foAI.foAIstate.empire_standard_enemy_rating *
                           min(2, len(sys_status.get('enemies_nearly_supplied', []))))
     print "Planet %s has regional+supply threat of %.1f" % ('P_%d<%s>' % (pid, this_planet.name), threat_from_supply)
     regional_threat = sys_status.get('regional_threat', 0) + threat_from_supply
     if not regional_threat:  # no need for protection
-        if currentFocus[pid] == PFocus:
+        if current_focus[pid] == PFocus:
             print "Advising dropping Protection Focus at %s due to no regional threat" % this_planet
         return False
-    cur_prod_val = weighted_sum_output([currentOutput[pid][IFocus], currentOutput[pid][RFocus]])
-    target_prod_val = max(map(weighted_sum_output, [newTargets[pid][IFocus], newTargets[pid][RFocus]]))
-    prot_prod_val = weighted_sum_output(newTargets[pid][PFocus])
+    cur_prod_val = weighted_sum_output([current_output[pid][IFocus], current_output[pid][RFocus]])
+    target_prod_val = max(map(weighted_sum_output, [new_targets[pid][IFocus], new_targets[pid][RFocus]]))
+    prot_prod_val = weighted_sum_output(new_targets[pid][PFocus])
     local_production_diff = 0.8 * cur_prod_val + 0.2 * target_prod_val - prot_prod_val
     fleet_threat = sys_status.get('fleetThreat', 0)
     # TODO: relax the below rejection once the overall determination of PFocus is better tuned
     if not fleet_threat and local_production_diff > 8:
-        if currentFocus[pid] == PFocus:
+        if current_focus[pid] == PFocus:
             print "Advising dropping Protection Focus at %s due to excessive productivity loss" % this_planet
         return False
     local_p_defenses = sys_status.get('mydefenses', {}).get('overall', 0)
     # TODO have adjusted_p_defenses take other in-system planets into account
-    adjusted_p_defenses = local_p_defenses * (1.0 if currentFocus[pid] != PFocus else 0.5)
+    adjusted_p_defenses = local_p_defenses * (1.0 if current_focus[pid] != PFocus else 0.5)
     local_fleet_rating = sys_status.get('myFleetRating', 0)
     combined_local_defenses = sys_status.get('all_local_defenses', 0)
     my_neighbor_rating = sys_status.get('my_neighbor_rating', 0)
     neighbor_threat = sys_status.get('neighborThreat', 0)
-    safety_factor = 1.2 if currentFocus[pid] == PFocus else 0.5
+    safety_factor = 1.2 if current_focus[pid] == PFocus else 0.5
     cur_shield = this_planet.currentMeterValue(fo.meterType.shield)
     max_shield = this_planet.currentMeterValue(fo.meterType.maxShield)
     cur_troops = this_planet.currentMeterValue(fo.meterType.troops)
@@ -172,18 +174,18 @@ def assess_protection_focus(pid):
     use_protection = True
     reason = ""
     if (fleet_threat and  # i.e., an enemy is sitting on us
-              (currentFocus[pid] != PFocus or  # too late to start protection TODO: but maybe regen worth it
+              (current_focus[pid] != PFocus or  # too late to start protection TODO: but maybe regen worth it
               # protection forcus only useful here if it maintains an elevated level
               all([AIDependencies.PROT_FOCUS_MULTIPLIER * a <= b for a, b in def_meter_pairs]))):
         use_protection = False
         reason = "A"
-    elif ((currentFocus[pid] != PFocus and cur_shield < max_shield - 2 and
+    elif ((current_focus[pid] != PFocus and cur_shield < max_shield - 2 and
                not tech_is_complete(AIDependencies.PLANET_BARRIER_I_TECH)) and
               (cur_defense < max_defense - 2 and not tech_is_complete(AIDependencies.DEFENSE_REGEN_1_TECH)) and
               (cur_troops < max_troops - 2)):
         use_protection = False
         reason = "B1"
-    elif ((currentFocus[pid] == PFocus and cur_shield*AIDependencies.PROT_FOCUS_MULTIPLIER < max_shield-2 and
+    elif ((current_focus[pid] == PFocus and cur_shield*AIDependencies.PROT_FOCUS_MULTIPLIER < max_shield-2 and
                not tech_is_complete(AIDependencies.PLANET_BARRIER_I_TECH)) and
               (cur_defense*AIDependencies.PROT_FOCUS_MULTIPLIER < max_defense-2 and
                    not tech_is_complete(AIDependencies.DEFENSE_REGEN_1_TECH)) and
@@ -200,7 +202,7 @@ def assess_protection_focus(pid):
         use_protection = False
         reason = "E"
     elif (safety_factor * regional_threat <= combined_local_defenses and
-              (currentFocus[pid] != PFocus or
+              (current_focus[pid] != PFocus or
               (0.5 * safety_factor * regional_threat <= local_fleet_rating and
                    fleet_threat == 0 and neighbor_threat < combined_local_defenses and
                    local_production_diff > 5))):
@@ -212,7 +214,7 @@ def assess_protection_focus(pid):
           local_production_diff > 5):
         use_protection = False
         reason = "G"
-    if use_protection or currentFocus[pid] == PFocus:
+    if use_protection or current_focus[pid] == PFocus:
         print ("Advising %sProtection Focus (reason %s) for planet %s, with local_prod_diff of %.1f, comb. local"
                " defenses %.1f, local fleet rating %.1f and regional threat %.1f, threat sources: %s") % (
             ["dropping ", ""][use_protection], reason, this_planet, local_production_diff, combined_local_defenses,
@@ -228,7 +230,7 @@ def use_planet_growth_specials(empirePlanetIDs, newFoci):
             for special in [aspec for aspec in AIDependencies.metabolismBoostMap.get(metab, []) if aspec in ColonisationAI.available_growth_specials]:
                 rankedPlanets = []
                 for pid in ColonisationAI.available_growth_specials[special]:
-                    planet = planetMap[pid]
+                    planet = planet_map[pid]
                     cur_focus = planet.focus
                     pop = planet.currentMeterValue(fo.meterType.population)
                     if (pop > metabIncPop - 2 * planet.size) or (GFocus not in planet.availableFoci):  # not enough benefit to lose local production, or can't put growth focus here
@@ -254,10 +256,10 @@ def use_planet_growth_specials(empirePlanetIDs, newFoci):
                         newFoci[spPID] = GFocus
                         if spPID in empirePlanetIDs:
                             del empirePlanetIDs[empirePlanetIDs.index(spPID)]
-                            print "%s focus of planet %s (%d) at Growth Focus" % (["set", "left"][cur_focus == GFocus], planetMap[spPID].name, spPID)
+                            print "%s focus of planet %s (%d) at Growth Focus" % (["set", "left"][cur_focus == GFocus], planet_map[spPID].name, spPID)
                         break
                     else:
-                        print "failed setting focus of planet %s (%d) at Growth Focus; focus left at %s" % (planetMap[spPID].name, spPID, planetMap[spPID].focus)
+                        print "failed setting focus of planet %s (%d) at Growth Focus; focus left at %s" % (planet_map[spPID].name, spPID, planet_map[spPID].focus)
 
 
 def use_planet_production_and_research_specials(empirePlanetIDs, newFoci):
@@ -265,7 +267,7 @@ def use_planet_production_and_research_specials(empirePlanetIDs, newFoci):
     universe = fo.getUniverse()
     already_have_comp_moon = False
     for pid in empirePlanetIDs:
-        planet = planetMap[pid]
+        planet = planet_map[pid]
         if "COMPUTRONIUM_SPECIAL" in planet.specials and RFocus in planet.availableFoci and not already_have_comp_moon:
             curFocus = planet.focus
             newFoci[pid] = RFocus
@@ -276,7 +278,7 @@ def use_planet_production_and_research_specials(empirePlanetIDs, newFoci):
                     universe.updateMeterEstimates(empirePlanetIDs)
             if curFocus == RFocus or result == 1:
                 already_have_comp_moon = True
-                print "%s focus of planet %s (%d) (with Computronium Moon) at Research Focus" % (["set", "left"][curFocus == RFocus], planetMap[pid].name, pid)
+                print "%s focus of planet %s (%d) (with Computronium Moon) at Research Focus" % (["set", "left"][curFocus == RFocus], planet_map[pid].name, pid)
                 if pid in empirePlanetIDs:
                     del empirePlanetIDs[empirePlanetIDs.index(pid)]
                 continue
@@ -289,7 +291,7 @@ def use_planet_production_and_research_specials(empirePlanetIDs, newFoci):
                 if result == 1:
                     universe.updateMeterEstimates(empirePlanetIDs)
             if curFocus == IFocus or result == 1:
-                print "%s focus of planet %s (%d) (with Honeycomb) at Industry Focus" % (["set", "left"][curFocus == IFocus], planetMap[pid].name, pid)
+                print "%s focus of planet %s (%d) (with Honeycomb) at Industry Focus" % (["set", "left"][curFocus == IFocus], planet_map[pid].name, pid)
                 if pid in empirePlanetIDs:
                     del empirePlanetIDs[empirePlanetIDs.index(pid)]
                 continue
@@ -304,14 +306,14 @@ def use_planet_production_and_research_specials(empirePlanetIDs, newFoci):
                 result = fo.issueChangeFocusOrder(pid, IFocus)
                 if result == 1:
                     print ("Tried setting %s for Concentration Camp planet %s (%d) with species %s and current focus %s, got result %d and focus %s" %
-                           (newFoci[pid], planet.name, pid, planet.speciesName, curFocus, result, planetMap[pid].focus))
+                           (newFoci[pid], planet.name, pid, planet.speciesName, curFocus, result, planet_map[pid].focus))
                     universe.updateMeterEstimates(empirePlanetIDs)
-                if (result != 1) or planetMap[pid].focus != IFocus:
+                if (result != 1) or planet_map[pid].focus != IFocus:
                     newplanet = universe.getPlanet(pid)
                     print ("Error: Failed setting %s for Concentration Camp planet %s (%d) with species %s and current focus %s, but new planet copy shows %s" %
-                           (newFoci[pid], planetMap[pid].name, pid, planetMap[pid].speciesName, planetMap[pid].focus, newplanet.focus))
+                           (newFoci[pid], planet_map[pid].name, pid, planet_map[pid].speciesName, planet_map[pid].focus, newplanet.focus))
             if curFocus == IFocus or result == 1:
-                print "%s focus of planet %s (%d) (with Concentration Camps/Remnants) at Industry Focus" % (["set", "left"][curFocus == IFocus], planetMap[pid].name, pid)
+                print "%s focus of planet %s (%d) (with Concentration Camps/Remnants) at Industry Focus" % (["set", "left"][curFocus == IFocus], planet_map[pid].name, pid)
                 if pid in empirePlanetIDs:
                     del empirePlanetIDs[empirePlanetIDs.index(pid)]
                 continue
@@ -321,7 +323,7 @@ def set_planet_protection_foci(empirePlanetIDs, newFoci):
     '''Assess and set protection foci'''
     universe = fo.getUniverse()
     for pid in empirePlanetIDs:
-        planet = planetMap[pid]
+        planet = planet_map[pid]
         if PFocus in planet.availableFoci and assess_protection_focus(pid):
             curFocus = planet.focus
             newFoci[pid] = PFocus
@@ -365,10 +367,10 @@ def set_planet_industry_and_research_foci(empirePlanetIDs, newFoci, priorityRati
 
     #Handle presets
     for pid in preset_ids:
-        nPP, nRP = newTargets.get(pid, {}).get(planetMap[pid].focus, [0, 0])
+        nPP, nRP = new_targets.get(pid, {}).get(planet_map[pid].focus, [0, 0])
         curTargetPP += nPP
         curTargetRP += nRP
-        iPP, iRP = newTargets.get(pid, {}).get(IFocus, [0, 0])
+        iPP, iRP = new_targets.get(pid, {}).get(IFocus, [0, 0])
         ctPP0 += iPP
         ctRP0 += iRP
 
@@ -376,7 +378,7 @@ def set_planet_industry_and_research_foci(empirePlanetIDs, newFoci, priorityRati
 
     # tally max Industry
     for pid in list(id_set):
-        iPP, iRP = newTargets.get(pid, {}).get(IFocus, [0, 0])
+        iPP, iRP = new_targets.get(pid, {}).get(IFocus, [0, 0])
         ctPP0 += iPP
         ctRP0 += iRP
 
@@ -385,13 +387,13 @@ def set_planet_industry_and_research_foci(empirePlanetIDs, newFoci, priorityRati
 
     for adj_round in [2, 3, 4]:
         for pid in list(id_set):
-            II, IR = newTargets[pid][IFocus]
-            RI, RR = newTargets[pid][RFocus]
-            CI, CR = currentOutput[pid][IFocus], currentOutput[pid][RFocus]
-            research_penalty = (currentFocus[pid] != RFocus)
+            II, IR = new_targets[pid][IFocus]
+            RI, RR = new_targets[pid][RFocus]
+            CI, CR = current_output[pid][IFocus], current_output[pid][RFocus]
+            research_penalty = (current_focus[pid] != RFocus)
             # calculate factor F at which II + F * IR == RI + F * RR =====> F = ( II-RI ) / (RR-IR)
             thisFactor = (II - RI) / max(0.01, RR - IR)  # don't let denominator be zero for planets where focus doesn't change RP
-            planet = planetMap[pid]
+            planet = planet_map[pid]
             if adj_round == 2:  # take research at planets with very cheap research
                 if (maxi_ratio < priorityRatio) and (curTargetRP < priorityRatio * ctPP0) and (thisFactor <= 1.0):
                     curTargetPP += RI
@@ -430,10 +432,10 @@ def set_planet_industry_and_research_foci(empirePlanetIDs, newFoci, priorityRati
                     break
             else:  # RP not super cheap & we have enough, stop taking it
                 break
-        II, IR = newTargets[pid][IFocus]
-        RI, RR = newTargets[pid][RFocus]
-        # if currentFocus[pid] == MFocus:
-        # II = max( II, newTargets[pid][MFocus][0] )
+        II, IR = new_targets[pid][IFocus]
+        RI, RR = new_targets[pid][RFocus]
+        # if current_focus[pid] == MFocus:
+        # II = max( II, new_targets[pid][MFocus][0] )
         if (not do_research and (
                (ratio > 2.0 and curTargetPP < 15 and gotAlgo) or
                (ratio > 2.5 and curTargetPP < 25 and II > 5 and gotAlgo) or
@@ -444,13 +446,13 @@ def set_planet_industry_and_research_foci(empirePlanetIDs, newFoci, priorityRati
                 printedHeader = True
                 print "Rejecting further Research Focus choices as too expensive:"
                 print "%34s|%20s|%15s |%15s|%15s |%15s |%15s" % ("                      Planet ", " current RP/PP ", " current target RP/PP ", "current Focus ", "  rejectedFocus ", " rejected target RP/PP ", "rejected RP-PP EQF")
-            oldFocus = currentFocus[pid]
-            cPP, cRP = currentOutput[pid][IFocus], currentOutput[pid][RFocus]
-            otPP, otRP = newTargets[pid].get(oldFocus, (0, 0))
-            ntPP, ntRP = newTargets[pid].get(RFocus, (0, 0))
-            print "pID (%3d) %22s | c: %5.1f / %5.1f | cT: %5.1f / %5.1f |  cF: %8s | nF: %8s | cT: %5.1f / %5.1f | %.2f" % (pid, planetMap[pid].name, cRP, cPP, otRP, otPP, fociMap.get(oldFocus, 'unknown'), fociMap[RFocus], ntRP, ntPP, ratio)
+            oldFocus = current_focus[pid]
+            cPP, cRP = current_output[pid][IFocus], current_output[pid][RFocus]
+            otPP, otRP = new_targets[pid].get(oldFocus, (0, 0))
+            ntPP, ntRP = new_targets[pid].get(RFocus, (0, 0))
+            print "pID (%3d) %22s | c: %5.1f / %5.1f | cT: %5.1f / %5.1f |  cF: %8s | nF: %8s | cT: %5.1f / %5.1f | %.2f" % (pid, planet_map[pid].name, cRP, cPP, otRP, otPP, fociMap.get(oldFocus, 'unknown'), fociMap[RFocus], ntRP, ntPP, ratio)
             continue  # RP is getting too expensive, but might be willing to still allocate from a planet with less PP to lose
-        # if planetMap[pid].currentMeterValue(fo.meterType.targetPopulation) >0: #only set to research if pop won't die out
+        # if planet_map[pid].currentMeterValue(fo.meterType.targetPopulation) >0: #only set to research if pop won't die out
         newFoci[pid] = RFocus
         curTargetRP += (RR - IR)
         curTargetPP -= (II - RI)
@@ -485,8 +487,8 @@ def set_planet_resource_foci():
         # shuffle(generalPlanetIDs)
         resource_timer.start("Targets")
         planets = map(universe.getPlanet, empirePlanetIDs)
-        planetMap.clear()
-        planetMap.update(zip(empirePlanetIDs, planets))
+        planet_map.clear()
+        planet_map.update(zip(empirePlanetIDs, planets))
 
         newFoci = {}
 
@@ -494,32 +496,32 @@ def set_planet_resource_foci():
 
         use_planet_production_and_research_specials(empirePlanetIDs, newFoci)
 
-        # pp, rp = get_resource_target_totals(empirePlanetIDs, planetMap)
-        pp, rp = get_resource_target_totals(planetMap.keys())
+        # pp, rp = get_resource_target_totals(empirePlanetIDs, planet_map)
+        pp, rp = get_resource_target_totals(planet_map.keys())
 
         set_planet_protection_foci(empirePlanetIDs, newFoci)
 
         set_planet_happiness_foci()
 
-        preset_ids = set(planetMap.keys()) - set(empirePlanetIDs)
+        preset_ids = set(planet_map.keys()) - set(empirePlanetIDs)
         ctPP0, ctRP0, curTargetPP, curTargetRP = set_planet_industry_and_research_foci(empirePlanetIDs, newFoci, priorityRatio, preset_ids)
 
         totalChanged = 0 
         for id_set in empirePlanetIDs, preset_ids:
             for pid in id_set:
-                canFocus = planetMap[pid].currentMeterValue(fo.meterType.targetPopulation) > 0
-                oldFocus = currentFocus[pid]
+                canFocus = planet_map[pid].currentMeterValue(fo.meterType.targetPopulation) > 0
+                oldFocus = current_focus[pid]
                 newFocus = newFoci.get(pid, IFocus)
-                cPP, cRP = currentOutput[pid][IFocus], currentOutput[pid][RFocus]
-                otPP, otRP = newTargets[pid].get(oldFocus, (0, 0))
+                cPP, cRP = current_output[pid][IFocus], current_output[pid][RFocus]
+                otPP, otRP = new_targets[pid].get(oldFocus, (0, 0))
                 ntPP, ntRP = otPP, otRP
                 if (canFocus
                     and newFocus != oldFocus
-                    and newFocus in planetMap[pid].availableFoci
-                    and newFocus != planetMap[pid].focus):
-                    if (fo.issueChangeFocusOrder(pid, newFocus) != 1):
+                    and newFocus in planet_map[pid].availableFoci
+                    and newFocus != planet_map[pid].focus):
+                    if fo.issueChangeFocusOrder(pid, newFocus) != 1:
                         newFoci[pid] = oldFocus
-                        print "Trouble changing focus of planet %s (%d) to %s" % (planetMap[pid].name, pid, newFocus)
+                        print "Trouble changing focus of planet %s (%d) to %s" % (planet_map[pid].name, pid, newFocus)
 
         print "============================"
         print "Planet Focus Assignments to achieve target RP/PP ratio of %.2f from current ratio of %.2f ( %.1f / %.1f )" % (priorityRatio, rp / (pp + 0.0001), rp, pp)
@@ -529,13 +531,13 @@ def set_planet_resource_foci():
         totalChanged = 0
         for id_set in empirePlanetIDs, preset_ids:
             for pid in id_set:
-                canFocus = planetMap[pid].currentMeterValue(fo.meterType.targetPopulation) > 0
-                oldFocus = currentFocus[pid]
+                canFocus = planet_map[pid].currentMeterValue(fo.meterType.targetPopulation) > 0
+                oldFocus = current_focus[pid]
                 newFocus = newFoci.get(pid, IFocus)
-                cPP, cRP = currentOutput[pid][IFocus], currentOutput[pid][RFocus]
-                otPP, otRP = newTargets[pid].get(oldFocus, (0, 0))
-                ntPP, ntRP = newTargets[pid].get(newFocus, (0, 0))
-                print "pID (%3d) %22s | c: %5.1f / %5.1f | cT: %5.1f / %5.1f |  cF: %8s | nF: %8s | cT: %5.1f / %5.1f " % (pid, planetMap[pid].name, cRP, cPP, otRP, otPP, fociMap.get(oldFocus, 'unknown'), fociMap[newFocus], ntRP, ntPP)
+                cPP, cRP = current_output[pid][IFocus], current_output[pid][RFocus]
+                otPP, otRP = new_targets[pid].get(oldFocus, (0, 0))
+                ntPP, ntRP = new_targets[pid].get(newFocus, (0, 0))
+                print "pID (%3d) %22s | c: %5.1f / %5.1f | cT: %5.1f / %5.1f |  cF: %8s | nF: %8s | cT: %5.1f / %5.1f " % (pid, planet_map[pid].name, cRP, cPP, otRP, otPP, fociMap.get(oldFocus, 'unknown'), fociMap[newFocus], ntRP, ntPP)
             print "-------------------------------------"
         print "-------------------------------------"
         print "Final Ratio Target (turn %4d) RP/PP : %.2f ( %.1f / %.1f ) after %d Focus changes" % (fo.currentTurn(), curTargetRP / (curTargetPP + 0.0001), curTargetRP, curTargetPP, totalChanged)

--- a/default/AI/ResourcesAI.py
+++ b/default/AI/ResourcesAI.py
@@ -555,8 +555,7 @@ def set_planet_industry_and_research_foci(focus_manager, priorityRatio):
     printedHeader = False
     gotAlgo = tech_is_complete("LRN_ALGO_ELEGANCE")
     for ratio, pid, pinfo in ratios:
-        do_research = False  # (focus_manager.new_foci[pid]==RFocus)
-        if (priorityRatio < (curTargetRP / (curTargetPP + 0.0001))) and not do_research:  # we have enough RP
+        if priorityRatio < (curTargetRP / (curTargetPP + 0.0001)):  # we have enough RP
             if ratio < 1.1 and foAI.foAIstate.aggression > fo.aggression.cautious:  # but wait, RP is still super cheap relative to PP, maybe will take more RP
                 if priorityRatio < 1.5 * (curTargetRP / (curTargetPP + 0.0001)):  # yeah, really a glut of RP, stop taking RP
                     break
@@ -566,12 +565,11 @@ def set_planet_industry_and_research_foci(focus_manager, priorityRatio):
         RI, RR = pinfo.possible_output[RFocus]
         # if focus_manager.current_focus[pid] == MFocus:
         # II = max( II, focus_manager.possible_output[MFocus][0] )
-        if (not do_research and (
-                (ratio > 2.0 and curTargetPP < 15 and gotAlgo) or
-                (ratio > 2.5 and curTargetPP < 25 and II > 5 and gotAlgo) or
-                (ratio > 3.0 and curTargetPP < 40 and II > 5 and gotAlgo) or
-                (ratio > 4.0 and curTargetPP < 100 and II > 10) or
-                ((curTargetRP + RR - IR) / max(0.001, curTargetPP - II + RI) > 2 * priorityRatio))):  # we already have algo elegance and more RP would be too expensive, or overkill
+        if ((ratio > 2.0 and curTargetPP < 15 and gotAlgo) or
+            (ratio > 2.5 and curTargetPP < 25 and II > 5 and gotAlgo) or
+            (ratio > 3.0 and curTargetPP < 40 and II > 5 and gotAlgo) or
+            (ratio > 4.0 and curTargetPP < 100 and II > 10) or
+            ((curTargetRP + RR - IR) / max(0.001, curTargetPP - II + RI) > 2 * priorityRatio)):  # we already have algo elegance and more RP would be too expensive, or overkill
             if not printedHeader:
                 printedHeader = True
                 print "Rejecting further Research Focus choices as too expensive:"

--- a/default/AI/ResourcesAI.py
+++ b/default/AI/ResourcesAI.py
@@ -53,12 +53,6 @@ class PlanetFocusInfo(object):
         self.possible_output[self.current_focus] = (itarget, rtarget)
         self.future_focus = self.current_focus
 
-    def can_change_focus(self):
-        """Can the planet change focus?  Is it's population non zero?"""
-        # It uses the target population versus current population to avoid situations
-        # where an unsustainable population is dying?
-        return self.planet.currentMeterValue(fo.meterType.targetPopulation) > 0
-
 
 class PlanetFocusManager(object):
     """PlanetFocusManager tracks all of the empire's planets, what their current and future focus will be."""
@@ -76,7 +70,7 @@ class PlanetFocusManager(object):
         self.baked_planet_info = {}
 
         for pid, pinfo in self.raw_planet_info.items():
-            if not pinfo.can_change_focus():
+            if not pinfo.planet.availableFoci:
                 self.baked_planet_info[pid] = self.raw_planet_info.pop(pid)
 
     def bake_future_focus(self, pid, focus, update=True):
@@ -142,7 +136,7 @@ class PlanetFocusManager(object):
             else:
                 pinfo.possible_output[RFocus] = (0, 0)
                 pinfo.possible_output[GFocus] = (0, pinfo.possible_output[GFocus])
-            if pinfo.can_change_focus() and pinfo.current_focus != planet.focus:
+            if pinfo.planet.availableFoci and pinfo.current_focus != planet.focus:
                 fo.issueChangeFocusOrder(pid, pinfo.current_focus)  # put it back to what it was
 
         universe.updateMeterEstimates(unbaked_pids)

--- a/default/AI/ResourcesAI.py
+++ b/default/AI/ResourcesAI.py
@@ -360,8 +360,10 @@ def set_planet_industry_and_research_foci(empirePlanetIDs, newFoci, priorityRati
     curTargetRP = 0.001
     resource_timer.start("Loop")  # loop
     has_force = tech_is_complete("CON_FRC_ENRG_STRC")
-    preset_ids = set(planetMap.keys()) - set(empirePlanetIDs)
+    #cumulative all industry focus
     ctPP0, ctRP0 = 0, 0
+
+    #Handle presets
     for pid in preset_ids:
         nPP, nRP = newTargets.get(pid, {}).get(planetMap[pid].focus, [0, 0])
         curTargetPP += nPP
@@ -371,14 +373,18 @@ def set_planet_industry_and_research_foci(empirePlanetIDs, newFoci, priorityRati
         ctRP0 += iRP
 
     id_set = set(empirePlanetIDs)
-    for adj_round in [1, 2, 3, 4]:
-        maxi_ratio = ctRP0 / max(0.01, ctPP0)  # should only change between rounds 1 and 2
+
+    # tally max Industry
+    for pid in list(id_set):
+        iPP, iRP = newTargets.get(pid, {}).get(IFocus, [0, 0])
+        ctPP0 += iPP
+        ctRP0 += iRP
+
+    #smallest possible ratio of research to industry with an all industry focus
+    maxi_ratio = ctRP0 / max(0.01, ctPP0)
+
+    for adj_round in [2, 3, 4]:
         for pid in list(id_set):
-            if adj_round == 1:  # tally max Industry
-                iPP, iRP = newTargets.get(pid, {}).get(IFocus, [0, 0])
-                ctPP0 += iPP
-                ctRP0 += iRP
-                continue
             II, IR = newTargets[pid][IFocus]
             RI, RR = newTargets[pid][RFocus]
             CI, CR = currentOutput[pid][IFocus], currentOutput[pid][RFocus]

--- a/default/AI/ResourcesAI.py
+++ b/default/AI/ResourcesAI.py
@@ -384,7 +384,7 @@ def assess_protection_focus(pid, pinfo):
     return use_protection
 
 
-def use_planet_growth_specials(focus_manager):
+def set_planet_growth_specials(focus_manager):
     """set resource foci of planets with potentially useful growth factors. Remove planets from list of candidates."""
     if useGrowth:
         # TODO: also consider potential future benefit re currently unpopulated planets
@@ -410,7 +410,7 @@ def use_planet_growth_specials(focus_manager):
                     continue
                 rankedPlanets.sort()
                 print "Considering Growth Focus choice for special %s; possible planet pop, id pairs are %s" % (metab, rankedPlanets)
-                for spSize, spPID, cur_focus in rankedPlanets:  # index 0 should be able to set focus, but just in case...
+                for _spPop, spPID, cur_focus in rankedPlanets:  # index 0 should be able to set focus, but just in case...
                     planet = focus_manager.all_planet_info[spPID].planet
                     if focus_manager.bake_future_focus(spPID, GFocus):
                         print "%s focus of planet %s (%d) at Growth Focus" % (["set", "left"][cur_focus == GFocus], planet.name, spPID)
@@ -419,11 +419,16 @@ def use_planet_growth_specials(focus_manager):
                         print "failed setting focus of planet %s (%d) at Growth Focus; focus left at %s" % (planet.name, spPID, planet.focus)
 
 
-def use_planet_production_and_research_specials(focus_manager):
-    """Use production and research specials as appropriate.  Remove planets from list of candidates."""
+def set_planet_production_and_research_specials(focus_manager):
+    """Set production and research specials.
+    Sets production/research specials for known (COMPUTRONIUM, HONEYCOMB and CONC_CAMP)
+    production/research specials.
+    Remove planets from list of candidates using bake_future_focus."""
     # TODO remove reliance on rules knowledge.  Just scan for specials with production
     # and research bonuses and use what you find. Perhaps maintain a list
     # of know types of specials
+    # TODO use "best" COMPUTRON planet instead of first found, where "best" means least industry loss,
+    # least threatened, no foci change penalty etc.
     universe = fo.getUniverse()
     already_have_comp_moon = False
     for pid, pinfo in focus_manager.raw_planet_info.items():
@@ -443,9 +448,6 @@ def use_planet_production_and_research_specials(focus_manager):
                   ["CONC_CAMP_MASTER_SPECIAL", "CONC_CAMP_SLAVE_SPECIAL"]] != []))
                 and IFocus in planet.availableFoci):
             if focus_manager.bake_future_focus(pid, IFocus):
-                if pinfo.current_focus != IFocus:
-                    print ("Tried setting %s for Concentration Camp planet %s (%d) with species %s and current focus %s, got result %d and focus %s" %
-                           (pinfo.future_focus, planet.name, pid, planet.speciesName, pinfo.current_focus, True, planet.focus))
                 print "%s focus of planet %s (%d) (with Concentration Camps/Remnants) at Industry Focus" % (["set", "left"][pinfo.current_focus == IFocus], planet.name, pid)
                 continue
             else:
@@ -476,6 +478,7 @@ def set_planet_protection_foci(focus_manager):
 def set_planet_happiness_foci(focus_manager):
     """Assess and set planet focus to preferred focus depending on happiness"""
     # TODO Assess need to set planet to preferred focus to improve happiness
+    pass
 
 
 def set_planet_industry_and_research_foci(focus_manager, priorityRatio):
@@ -609,8 +612,8 @@ def set_planet_resource_foci():
         reporter = Reporter(focus_manager)
         reporter.capture_section_info("Unfocusable")
 
-        use_planet_growth_specials(focus_manager)
-        use_planet_production_and_research_specials(focus_manager)
+        set_planet_growth_specials(focus_manager)
+        set_planet_production_and_research_specials(focus_manager)
         reporter.capture_section_info("Specials")
 
         focus_manager.calculate_planet_infos(focus_manager.raw_planet_info.keys())

--- a/default/AI/ResourcesAI.py
+++ b/default/AI/ResourcesAI.py
@@ -51,6 +51,12 @@ class PlanetFocusInfo(object):
         self.possible_output[self.current_focus] = (itarget, rtarget)
         self.future_focus = self.current_focus
 
+    def can_change_focus(self):
+        """Can the planet change focus?  Is it's population non zero?"""
+        #TODO Could this be changed to current population instead of target population?
+        #It uses the target population to avoid situations where an unsustainable population is dying?
+        return self.planet.currentMeterValue(fo.meterType.targetPopulation) > 0
+
 
 class PlanetFocusManager(object):
     """PlanetFocusManager tracks all of the empire's planets, what their current and future focus will be."""
@@ -73,8 +79,7 @@ class PlanetFocusManager(object):
         self.baked_planet_info = dict()
 
         for pid, pinfo in self.raw_planet_info.items():
-            focusable = pinfo.planet.currentMeterValue(fo.meterType.targetPopulation) > 0
-            if not focusable:
+            if not pinfo.can_change_focus():
                 self.baked_planet_info[pid] = self.raw_planet_info.pop(pid)
 
 
@@ -129,7 +134,6 @@ class PlanetFocusManager(object):
 
         universe.updateMeterEstimates(unbaked_pids)
         for pid, pinfo, planet in planet_infos:
-            can_focus = planet.currentMeterValue(fo.meterType.targetPopulation) > 0
             itarget = planet.currentMeterValue(fo.meterType.targetIndustry)
             rtarget = planet.currentMeterValue(fo.meterType.targetResearch)
             if planet.focus == RFocus:
@@ -138,7 +142,7 @@ class PlanetFocusManager(object):
             else:
                 pinfo.possible_output[RFocus] = (0, 0)
                 pinfo.possible_output[GFocus] = (0, pinfo.possible_output[GFocus])
-            if can_focus and pinfo.current_focus != planet.focus:
+            if pinfo.can_change_focus() and pinfo.current_focus != planet.focus:
                 fo.issueChangeFocusOrder(pid, pinfo.current_focus)  # put it back to what it was
 
         universe.updateMeterEstimates(unbaked_pids)

--- a/default/AI/ResourcesAI.py
+++ b/default/AI/ResourcesAI.py
@@ -26,62 +26,83 @@ limitAssessments = False
 
 lastFociCheck = [0]
 
-new_targets = {}
-current_focus = {}
-current_output = {}
-planet_map = {}
+class PlanetFocusManager(object):
+    """PlanetFocusManager tracks all of the empire's planets, what their current and future focus will be."""
+
+    def __init__(self):
+        self.new_targets = {}
+        self.current_focus = {}
+        self.current_output = {}
+
+        universe = fo.getUniverse()
+
+        resource_timer.start("getPlanets")
+        self.planet_ids = list(PlanetUtilsAI.get_owned_planets_by_empire(universe.planetIDs))
+
+        # resource_timer.start("Shuffle")
+        # shuffle(generalPlanetIDs)
+
+        resource_timer.start("Targets")
+        self.planet_map = {}
+        planets = map(universe.getPlanet, self.planet_ids)
+        self.planet_map.update(zip(self.planet_ids, planets))
+
+        self.new_foci = {}
+
+    def fill_data_dicts(self):
+        #TODO rename this something less generic
+        """ Calculates current_focus, current_output and new_targets.
+
+        Measures the current_focus, current_outputs of each planet.
+        Calculates for each possible focus the target output of each planet.
+        """
+        universe = fo.getUniverse()
+        self.new_targets.clear()
+        self.current_focus.clear()
+        self.current_output.clear()
+        planets = [(pid, self.planet_map[pid]) for pid in self.planet_ids]
+        for pid, planet in planets:
+            self.current_focus[pid] = planet.focus
+            self.current_output.setdefault(pid, {})[IFocus] = planet.currentMeterValue(fo.meterType.industry)
+            self.current_output[pid][RFocus] = planet.currentMeterValue(fo.meterType.research)
+            if IFocus in planet.availableFoci and planet.focus != IFocus:
+                fo.issueChangeFocusOrder(pid, IFocus)  # may not be able to take, but try
+        universe.updateMeterEstimates(self.planet_ids)
+        for pid, planet in planets:
+            itarget = planet.currentMeterValue(fo.meterType.targetIndustry)
+            rtarget = planet.currentMeterValue(fo.meterType.targetResearch)
+            if planet.focus == IFocus:
+                self.new_targets.setdefault(pid, {})[IFocus] = (itarget, rtarget)
+                self.new_targets.setdefault(pid, {})[GFocus] = [0, rtarget]
+            else:
+                self.new_targets.setdefault(pid, {})[IFocus] = (0, 0)
+                self.new_targets.setdefault(pid, {})[GFocus] = [0, 0]
+            # if self.current_focus[pid] == MFocus:
+            # self.new_targets[pid][MFocus] = (mtarget, rtarget)
+            if RFocus in planet.availableFoci and planet.focus != RFocus:
+                fo.issueChangeFocusOrder(pid, RFocus)  # may not be able to take, but try
+        universe.updateMeterEstimates(self.planet_ids)
+        for pid, planet in planets:
+            can_focus = planet.currentMeterValue(fo.meterType.targetPopulation) > 0
+            itarget = planet.currentMeterValue(fo.meterType.targetIndustry)
+            rtarget = planet.currentMeterValue(fo.meterType.targetResearch)
+            if planet.focus == RFocus:
+                self.new_targets.setdefault(pid, {})[RFocus] = (itarget, rtarget)
+                self.new_targets[pid][GFocus][0] = itarget
+            else:
+                self.new_targets.setdefault(pid, {})[RFocus] = (0, 0)
+                self.new_targets[pid][GFocus][0] = 0
+            if can_focus and self.current_focus[pid] != planet.focus:
+                fo.issueChangeFocusOrder(pid, self.current_focus[pid])  # put it back to what it was
+        universe.updateMeterEstimates(self.planet_ids)
+        # Protection focus will give the same off-focus Industry and Research targets as Growth Focus
+        for pid, planet in planets:
+            self.new_targets[pid][PFocus] = self.new_targets[pid][GFocus]
 
 
-def _fill_data_dicts(planet_ids):
-    universe = fo.getUniverse()
-    new_targets.clear()
-    current_focus.clear()
-    current_output.clear()
-    planets = [(pid, planet_map[pid]) for pid in planet_ids]
-    for pid, planet in planets:
-        current_focus[pid] = planet.focus
-        current_output.setdefault(pid, {})[IFocus] = planet.currentMeterValue(fo.meterType.industry)
-        current_output[pid][RFocus] = planet.currentMeterValue(fo.meterType.research)
-        if IFocus in planet.availableFoci and planet.focus != IFocus:
-            fo.issueChangeFocusOrder(pid, IFocus)  # may not be able to take, but try
-    universe.updateMeterEstimates(planet_ids)
-    for pid, planet in planets:
-        itarget = planet.currentMeterValue(fo.meterType.targetIndustry)
-        rtarget = planet.currentMeterValue(fo.meterType.targetResearch)
-        if planet.focus == IFocus:
-            new_targets.setdefault(pid, {})[IFocus] = (itarget, rtarget)
-            new_targets.setdefault(pid, {})[GFocus] = [0, rtarget]
-        else:
-            new_targets.setdefault(pid, {})[IFocus] = (0, 0)
-            new_targets.setdefault(pid, {})[GFocus] = [0, 0]
-        # if current_focus[pid] == MFocus:
-        # new_targets[pid][MFocus] = (mtarget, rtarget)
-        if RFocus in planet.availableFoci and planet.focus != RFocus:
-            fo.issueChangeFocusOrder(pid, RFocus)  # may not be able to take, but try
-    universe.updateMeterEstimates(planet_ids)
-    for pid, planet in planets:
-        can_focus = planet.currentMeterValue(fo.meterType.targetPopulation) > 0
-        itarget = planet.currentMeterValue(fo.meterType.targetIndustry)
-        rtarget = planet.currentMeterValue(fo.meterType.targetResearch)
-        if planet.focus == RFocus:
-            new_targets.setdefault(pid, {})[RFocus] = (itarget, rtarget)
-            new_targets[pid][GFocus][0] = itarget
-        else:
-            new_targets.setdefault(pid, {})[RFocus] = (0, 0)
-            new_targets[pid][GFocus][0] = 0
-        if can_focus and current_focus[pid] != planet.focus:
-            fo.issueChangeFocusOrder(pid, current_focus[pid])  # put it back to what it was
-    universe.updateMeterEstimates(planet_ids)
-    # Protection focus will give the same off-focus Industry and Research targets as Growth Focus
-    for pid, planet in planets:
-        new_targets[pid][PFocus] = new_targets[pid][GFocus]
-
-
-def get_resource_target_totals(empirePlanetIDs):
-    pp = sum(x.currentMeterValue(fo.meterType.targetIndustry) for x in planet_map.values())
-    rp = sum(x.currentMeterValue(fo.meterType.targetResearch) for x in planet_map.values())
-    _fill_data_dicts(empirePlanetIDs)
-    return pp, rp
+def get_resource_target_totals(focus_manager):
+    #TODO bury this
+    focus_manager.fill_data_dicts()
 
 
 def print_resources_priority():
@@ -134,36 +155,37 @@ def weighted_sum_output(outputs):
     return outputs[0] + RESEARCH_WEIGHTING * outputs[1]
 
 
-def assess_protection_focus(pid):
+def assess_protection_focus(focus_manager, pid):
+    #TODO change to pass in a single planet with focus' production object
     """Return True if planet should use Protection Focus"""
-    this_planet = planet_map[pid]
+    this_planet = focus_manager.planet_map[pid]
     sys_status = foAI.foAIstate.systemStatus.get(this_planet.systemID, {})
     threat_from_supply = (0.25 * foAI.foAIstate.empire_standard_enemy_rating *
                           min(2, len(sys_status.get('enemies_nearly_supplied', []))))
     print "Planet %s has regional+supply threat of %.1f" % ('P_%d<%s>' % (pid, this_planet.name), threat_from_supply)
     regional_threat = sys_status.get('regional_threat', 0) + threat_from_supply
     if not regional_threat:  # no need for protection
-        if current_focus[pid] == PFocus:
+        if focus_manager.current_focus[pid] == PFocus:
             print "Advising dropping Protection Focus at %s due to no regional threat" % this_planet
         return False
-    cur_prod_val = weighted_sum_output([current_output[pid][IFocus], current_output[pid][RFocus]])
-    target_prod_val = max(map(weighted_sum_output, [new_targets[pid][IFocus], new_targets[pid][RFocus]]))
-    prot_prod_val = weighted_sum_output(new_targets[pid][PFocus])
+    cur_prod_val = weighted_sum_output([focus_manager.current_output[pid][IFocus], focus_manager.current_output[pid][RFocus]])
+    target_prod_val = max(map(weighted_sum_output, [focus_manager.new_targets[pid][IFocus], focus_manager.new_targets[pid][RFocus]]))
+    prot_prod_val = weighted_sum_output(focus_manager.new_targets[pid][PFocus])
     local_production_diff = 0.8 * cur_prod_val + 0.2 * target_prod_val - prot_prod_val
     fleet_threat = sys_status.get('fleetThreat', 0)
     # TODO: relax the below rejection once the overall determination of PFocus is better tuned
     if not fleet_threat and local_production_diff > 8:
-        if current_focus[pid] == PFocus:
+        if focus_manager.current_focus[pid] == PFocus:
             print "Advising dropping Protection Focus at %s due to excessive productivity loss" % this_planet
         return False
     local_p_defenses = sys_status.get('mydefenses', {}).get('overall', 0)
     # TODO have adjusted_p_defenses take other in-system planets into account
-    adjusted_p_defenses = local_p_defenses * (1.0 if current_focus[pid] != PFocus else 0.5)
+    adjusted_p_defenses = local_p_defenses * (1.0 if focus_manager.current_focus[pid] != PFocus else 0.5)
     local_fleet_rating = sys_status.get('myFleetRating', 0)
     combined_local_defenses = sys_status.get('all_local_defenses', 0)
     my_neighbor_rating = sys_status.get('my_neighbor_rating', 0)
     neighbor_threat = sys_status.get('neighborThreat', 0)
-    safety_factor = 1.2 if current_focus[pid] == PFocus else 0.5
+    safety_factor = 1.2 if focus_manager.current_focus[pid] == PFocus else 0.5
     cur_shield = this_planet.currentMeterValue(fo.meterType.shield)
     max_shield = this_planet.currentMeterValue(fo.meterType.maxShield)
     cur_troops = this_planet.currentMeterValue(fo.meterType.troops)
@@ -174,18 +196,18 @@ def assess_protection_focus(pid):
     use_protection = True
     reason = ""
     if (fleet_threat and  # i.e., an enemy is sitting on us
-              (current_focus[pid] != PFocus or  # too late to start protection TODO: but maybe regen worth it
+              (focus_manager.current_focus[pid] != PFocus or  # too late to start protection TODO: but maybe regen worth it
               # protection forcus only useful here if it maintains an elevated level
               all([AIDependencies.PROT_FOCUS_MULTIPLIER * a <= b for a, b in def_meter_pairs]))):
         use_protection = False
         reason = "A"
-    elif ((current_focus[pid] != PFocus and cur_shield < max_shield - 2 and
+    elif ((focus_manager.current_focus[pid] != PFocus and cur_shield < max_shield - 2 and
                not tech_is_complete(AIDependencies.PLANET_BARRIER_I_TECH)) and
               (cur_defense < max_defense - 2 and not tech_is_complete(AIDependencies.DEFENSE_REGEN_1_TECH)) and
               (cur_troops < max_troops - 2)):
         use_protection = False
         reason = "B1"
-    elif ((current_focus[pid] == PFocus and cur_shield*AIDependencies.PROT_FOCUS_MULTIPLIER < max_shield-2 and
+    elif ((focus_manager.current_focus[pid] == PFocus and cur_shield*AIDependencies.PROT_FOCUS_MULTIPLIER < max_shield-2 and
                not tech_is_complete(AIDependencies.PLANET_BARRIER_I_TECH)) and
               (cur_defense*AIDependencies.PROT_FOCUS_MULTIPLIER < max_defense-2 and
                    not tech_is_complete(AIDependencies.DEFENSE_REGEN_1_TECH)) and
@@ -202,7 +224,7 @@ def assess_protection_focus(pid):
         use_protection = False
         reason = "E"
     elif (safety_factor * regional_threat <= combined_local_defenses and
-              (current_focus[pid] != PFocus or
+              (focus_manager.current_focus[pid] != PFocus or
               (0.5 * safety_factor * regional_threat <= local_fleet_rating and
                    fleet_threat == 0 and neighbor_threat < combined_local_defenses and
                    local_production_diff > 5))):
@@ -214,7 +236,7 @@ def assess_protection_focus(pid):
           local_production_diff > 5):
         use_protection = False
         reason = "G"
-    if use_protection or current_focus[pid] == PFocus:
+    if use_protection or focus_manager.current_focus[pid] == PFocus:
         print ("Advising %sProtection Focus (reason %s) for planet %s, with local_prod_diff of %.1f, comb. local"
                " defenses %.1f, local fleet rating %.1f and regional threat %.1f, threat sources: %s") % (
             ["dropping ", ""][use_protection], reason, this_planet, local_production_diff, combined_local_defenses,
@@ -222,7 +244,7 @@ def assess_protection_focus(pid):
     return use_protection
 
 
-def use_planet_growth_specials(empirePlanetIDs, newFoci):
+def use_planet_growth_specials(focus_manager):
     '''set resource foci of planets with potentially useful growth factors. Remove planets from list of candidates.'''
     if useGrowth:
         # TODO: also consider potential future benefit re currently unpopulated planets
@@ -230,7 +252,7 @@ def use_planet_growth_specials(empirePlanetIDs, newFoci):
             for special in [aspec for aspec in AIDependencies.metabolismBoostMap.get(metab, []) if aspec in ColonisationAI.available_growth_specials]:
                 rankedPlanets = []
                 for pid in ColonisationAI.available_growth_specials[special]:
-                    planet = planet_map[pid]
+                    planet = focus_manager.planet_map[pid]
                     cur_focus = planet.focus
                     pop = planet.currentMeterValue(fo.meterType.population)
                     if (pop > metabIncPop - 2 * planet.size) or (GFocus not in planet.availableFoci):  # not enough benefit to lose local production, or can't put growth focus here
@@ -253,104 +275,104 @@ def use_planet_growth_specials(empirePlanetIDs, newFoci):
                     if cur_focus != GFocus:
                         result = fo.issueChangeFocusOrder(spPID, GFocus)
                     if result == 1:
-                        newFoci[spPID] = GFocus
-                        if spPID in empirePlanetIDs:
-                            del empirePlanetIDs[empirePlanetIDs.index(spPID)]
-                            print "%s focus of planet %s (%d) at Growth Focus" % (["set", "left"][cur_focus == GFocus], planet_map[spPID].name, spPID)
+                        focus_manager.new_foci[spPID] = GFocus
+                        if spPID in focus_manager.planet_ids:
+                            del focus_manager.planet_ids[focus_manager.planet_ids.index(spPID)]
+                            print "%s focus of planet %s (%d) at Growth Focus" % (["set", "left"][cur_focus == GFocus], focus_manager.planet_map[spPID].name, spPID)
                         break
                     else:
-                        print "failed setting focus of planet %s (%d) at Growth Focus; focus left at %s" % (planet_map[spPID].name, spPID, planet_map[spPID].focus)
+                        print "failed setting focus of planet %s (%d) at Growth Focus; focus left at %s" % (focus_manager.planet_map[spPID].name, spPID, focus_manager.planet_map[spPID].focus)
 
 
-def use_planet_production_and_research_specials(empirePlanetIDs, newFoci):
+def use_planet_production_and_research_specials(focus_manager):
     '''Use production and research specials as appropriate.  Remove planets from list of candidates.'''
     universe = fo.getUniverse()
     already_have_comp_moon = False
-    for pid in empirePlanetIDs:
-        planet = planet_map[pid]
+    for pid in focus_manager.planet_ids:
+        planet = focus_manager.planet_map[pid]
         if "COMPUTRONIUM_SPECIAL" in planet.specials and RFocus in planet.availableFoci and not already_have_comp_moon:
             curFocus = planet.focus
-            newFoci[pid] = RFocus
+            focus_manager.new_foci[pid] = RFocus
             result = 0
             if curFocus != RFocus:
                 result = fo.issueChangeFocusOrder(pid, RFocus)
                 if result == 1:
-                    universe.updateMeterEstimates(empirePlanetIDs)
+                    universe.updateMeterEstimates(focus_manager.planet_ids)
             if curFocus == RFocus or result == 1:
                 already_have_comp_moon = True
-                print "%s focus of planet %s (%d) (with Computronium Moon) at Research Focus" % (["set", "left"][curFocus == RFocus], planet_map[pid].name, pid)
-                if pid in empirePlanetIDs:
-                    del empirePlanetIDs[empirePlanetIDs.index(pid)]
+                print "%s focus of planet %s (%d) (with Computronium Moon) at Research Focus" % (["set", "left"][curFocus == RFocus], focus_manager.planet_map[pid].name, pid)
+                if pid in focus_manager.planet_ids:
+                    del focus_manager.planet_ids[focus_manager.planet_ids.index(pid)]
                 continue
         if "HONEYCOMB_SPECIAL" in planet.specials and IFocus in planet.availableFoci:
             curFocus = planet.focus
-            newFoci[pid] = IFocus
+            focus_manager.new_foci[pid] = IFocus
             result = 0
             if curFocus != IFocus:
                 result = fo.issueChangeFocusOrder(pid, IFocus)
                 if result == 1:
-                    universe.updateMeterEstimates(empirePlanetIDs)
+                    universe.updateMeterEstimates(focus_manager.planet_ids)
             if curFocus == IFocus or result == 1:
-                print "%s focus of planet %s (%d) (with Honeycomb) at Industry Focus" % (["set", "left"][curFocus == IFocus], planet_map[pid].name, pid)
-                if pid in empirePlanetIDs:
-                    del empirePlanetIDs[empirePlanetIDs.index(pid)]
+                print "%s focus of planet %s (%d) (with Honeycomb) at Industry Focus" % (["set", "left"][curFocus == IFocus], focus_manager.planet_map[pid].name, pid)
+                if pid in focus_manager.planet_ids:
+                    del focus_manager.planet_ids[focus_manager.planet_ids.index(pid)]
                 continue
         if ((([bld.buildingTypeName for bld in map(universe.getObject, planet.buildingIDs) if bld.buildingTypeName in
                 ["BLD_CONC_CAMP", "BLD_CONC_CAMP_REMNANT"]] != []) or
                          ([ccspec for ccspec in planet.specials if ccspec in ["CONC_CAMP_MASTER_SPECIAL", "CONC_CAMP_SLAVE_SPECIAL"]] != []))
                 and IFocus in planet.availableFoci):
             curFocus = planet.focus
-            newFoci[pid] = IFocus
+            focus_manager.new_foci[pid] = IFocus
             result = 0
             if curFocus != IFocus:
                 result = fo.issueChangeFocusOrder(pid, IFocus)
                 if result == 1:
                     print ("Tried setting %s for Concentration Camp planet %s (%d) with species %s and current focus %s, got result %d and focus %s" %
-                           (newFoci[pid], planet.name, pid, planet.speciesName, curFocus, result, planet_map[pid].focus))
-                    universe.updateMeterEstimates(empirePlanetIDs)
-                if (result != 1) or planet_map[pid].focus != IFocus:
+                           (focus_manager.new_foci[pid], planet.name, pid, planet.speciesName, curFocus, result, focus_manager.planet_map[pid].focus))
+                    universe.updateMeterEstimates(focus_manager.planet_ids)
+                if (result != 1) or focus_manager.planet_map[pid].focus != IFocus:
                     newplanet = universe.getPlanet(pid)
                     print ("Error: Failed setting %s for Concentration Camp planet %s (%d) with species %s and current focus %s, but new planet copy shows %s" %
-                           (newFoci[pid], planet_map[pid].name, pid, planet_map[pid].speciesName, planet_map[pid].focus, newplanet.focus))
+                           (focus_manager.new_foci[pid], focus_manager.planet_map[pid].name, pid, focus_manager.planet_map[pid].speciesName, focus_manager.planet_map[pid].focus, newplanet.focus))
             if curFocus == IFocus or result == 1:
-                print "%s focus of planet %s (%d) (with Concentration Camps/Remnants) at Industry Focus" % (["set", "left"][curFocus == IFocus], planet_map[pid].name, pid)
-                if pid in empirePlanetIDs:
-                    del empirePlanetIDs[empirePlanetIDs.index(pid)]
+                print "%s focus of planet %s (%d) (with Concentration Camps/Remnants) at Industry Focus" % (["set", "left"][curFocus == IFocus], focus_manager.planet_map[pid].name, pid)
+                if pid in focus_manager.planet_ids:
+                    del focus_manager.planet_ids[focus_manager.planet_ids.index(pid)]
                 continue
 
 
-def set_planet_protection_foci(empirePlanetIDs, newFoci):
+def set_planet_protection_foci(focus_manager):
     '''Assess and set protection foci'''
     universe = fo.getUniverse()
-    for pid in empirePlanetIDs:
-        planet = planet_map[pid]
-        if PFocus in planet.availableFoci and assess_protection_focus(pid):
+    for pid in focus_manager.planet_ids:
+        planet = focus_manager.planet_map[pid]
+        if PFocus in planet.availableFoci and assess_protection_focus(focus_manager, pid):
             curFocus = planet.focus
-            newFoci[pid] = PFocus
+            focus_manager.new_foci[pid] = PFocus
             result = 0
             if curFocus != PFocus:
                 result = fo.issueChangeFocusOrder(pid, PFocus)
                 if result == 1:
                     print ("Tried setting %s for planet %s (%d) with species %s and current focus %s, got result %d and focus %s" %
-                           (newFoci[pid], planet.name, pid, planet.speciesName, curFocus, result, planet.focus))
-                    universe.updateMeterEstimates(empirePlanetIDs)
+                           (focus_manager.new_foci[pid], planet.name, pid, planet.speciesName, curFocus, result, planet.focus))
+                    universe.updateMeterEstimates(focus_manager.planet_ids)
                 if (result != 1) or planet.focus != PFocus:
                     newplanet = universe.getPlanet(pid)
                     print ("Error: Failed setting %s for planet %s (%d) with species %s and current focus %s, but new planet copy shows %s" %
-                           (newFoci[pid], planet.name, pid, planet.speciesName, planet.focus, newplanet.focus))
+                           (focus_manager.new_foci[pid], planet.name, pid, planet.speciesName, planet.focus, newplanet.focus))
             if curFocus == PFocus or result == 1:
                 print "%s focus of planet %s (%d) at Protection(Defense) Focus" % (["set", "left"][curFocus == PFocus], planet.name, pid)
-                if pid in empirePlanetIDs:
-                    del empirePlanetIDs[empirePlanetIDs.index(pid)]
+                if pid in focus_manager.planet_ids:
+                    del focus_manager.planet_ids[focus_manager.planet_ids.index(pid)]
                 continue
 
 
-def set_planet_happiness_foci():
+def set_planet_happiness_foci(focus_manager):
     """Assess and set planet focus to preferred focus depending on happiness"""
     #TODO Assess need to set planet to preferred focus to improve happiness
 
 
-def set_planet_industry_and_research_foci(empirePlanetIDs, newFoci, priorityRatio, preset_ids):
+def set_planet_industry_and_research_foci(focus_manager, priorityRatio, preset_ids):
     """Adjust planet's industry versus research focus while targetting the given ratio and avoiding penalties from changing focus"""
     print "\n-----------------------------------------"
     print "Making Planet Focus Change Determinations\n"
@@ -367,18 +389,18 @@ def set_planet_industry_and_research_foci(empirePlanetIDs, newFoci, priorityRati
 
     #Handle presets
     for pid in preset_ids:
-        nPP, nRP = new_targets.get(pid, {}).get(planet_map[pid].focus, [0, 0])
+        nPP, nRP = focus_manager.new_targets.get(pid, {}).get(focus_manager.planet_map[pid].focus, [0, 0])
         curTargetPP += nPP
         curTargetRP += nRP
-        iPP, iRP = new_targets.get(pid, {}).get(IFocus, [0, 0])
+        iPP, iRP = focus_manager.new_targets.get(pid, {}).get(IFocus, [0, 0])
         ctPP0 += iPP
         ctRP0 += iRP
 
-    id_set = set(empirePlanetIDs)
+    id_set = set(focus_manager.planet_ids)
 
     # tally max Industry
     for pid in list(id_set):
-        iPP, iRP = new_targets.get(pid, {}).get(IFocus, [0, 0])
+        iPP, iRP = focus_manager.new_targets.get(pid, {}).get(IFocus, [0, 0])
         ctPP0 += iPP
         ctRP0 += iRP
 
@@ -387,18 +409,18 @@ def set_planet_industry_and_research_foci(empirePlanetIDs, newFoci, priorityRati
 
     for adj_round in [2, 3, 4]:
         for pid in list(id_set):
-            II, IR = new_targets[pid][IFocus]
-            RI, RR = new_targets[pid][RFocus]
-            CI, CR = current_output[pid][IFocus], current_output[pid][RFocus]
-            research_penalty = (current_focus[pid] != RFocus)
+            II, IR = focus_manager.new_targets[pid][IFocus]
+            RI, RR = focus_manager.new_targets[pid][RFocus]
+            CI, CR = focus_manager.current_output[pid][IFocus], focus_manager.current_output[pid][RFocus]
+            research_penalty = (focus_manager.current_focus[pid] != RFocus)
             # calculate factor F at which II + F * IR == RI + F * RR =====> F = ( II-RI ) / (RR-IR)
             thisFactor = (II - RI) / max(0.01, RR - IR)  # don't let denominator be zero for planets where focus doesn't change RP
-            planet = planet_map[pid]
+            planet = focus_manager.planet_map[pid]
             if adj_round == 2:  # take research at planets with very cheap research
                 if (maxi_ratio < priorityRatio) and (curTargetRP < priorityRatio * ctPP0) and (thisFactor <= 1.0):
                     curTargetPP += RI
                     curTargetRP += RR
-                    newFoci[pid] = RFocus
+                    focus_manager.new_foci[pid] = RFocus
                     id_set.discard(pid)
                 continue
             if adj_round == 3:  # take research at planets where can do reasonable balance
@@ -412,30 +434,30 @@ def set_planet_industry_and_research_foci(empirePlanetIDs, newFoci, priorityRati
                 if (CI > II + 8) or (((RR > II) or ((RR - CR) >= 1 + 2 * research_penalty)) and ((RR - IR) >= 3) and ((CR - IR) >= 0.7 * ((II - CI) * (1 + 0.1 * research_penalty)))):
                     curTargetPP += CI - 1 - research_penalty
                     curTargetRP += CR + 1
-                    newFoci[pid] = RFocus
+                    focus_manager.new_foci[pid] = RFocus
                     id_set.discard(pid)
                 continue
             # adj_round == 4 assume default IFocus
             curTargetPP += II  # icurTargets initially calculated by Industry focus, which will be our default focus
             curTargetRP += IR
-            newFoci[pid] = IFocus
+            focus_manager.new_foci[pid] = IFocus
             ratios.append((thisFactor, pid))
 
     ratios.sort()
     printedHeader = False
     gotAlgo = tech_is_complete("LRN_ALGO_ELEGANCE")
     for ratio, pid in ratios:
-        do_research = False  # (newFoci[pid]==RFocus)
+        do_research = False  # (focus_manager.new_foci[pid]==RFocus)
         if (priorityRatio < (curTargetRP / (curTargetPP + 0.0001))) and not do_research:  # we have enough RP
             if ratio < 1.1 and foAI.foAIstate.aggression > fo.aggression.cautious:  # but wait, RP is still super cheap relative to PP, maybe will take more RP
                 if priorityRatio < 1.5 * (curTargetRP / (curTargetPP + 0.0001)):  # yeah, really a glut of RP, stop taking RP
                     break
             else:  # RP not super cheap & we have enough, stop taking it
                 break
-        II, IR = new_targets[pid][IFocus]
-        RI, RR = new_targets[pid][RFocus]
-        # if current_focus[pid] == MFocus:
-        # II = max( II, new_targets[pid][MFocus][0] )
+        II, IR = focus_manager.new_targets[pid][IFocus]
+        RI, RR = focus_manager.new_targets[pid][RFocus]
+        # if focus_manager.current_focus[pid] == MFocus:
+        # II = max( II, focus_manager.new_targets[pid][MFocus][0] )
         if (not do_research and (
                (ratio > 2.0 and curTargetPP < 15 and gotAlgo) or
                (ratio > 2.5 and curTargetPP < 25 and II > 5 and gotAlgo) or
@@ -446,14 +468,14 @@ def set_planet_industry_and_research_foci(empirePlanetIDs, newFoci, priorityRati
                 printedHeader = True
                 print "Rejecting further Research Focus choices as too expensive:"
                 print "%34s|%20s|%15s |%15s|%15s |%15s |%15s" % ("                      Planet ", " current RP/PP ", " current target RP/PP ", "current Focus ", "  rejectedFocus ", " rejected target RP/PP ", "rejected RP-PP EQF")
-            oldFocus = current_focus[pid]
-            cPP, cRP = current_output[pid][IFocus], current_output[pid][RFocus]
-            otPP, otRP = new_targets[pid].get(oldFocus, (0, 0))
-            ntPP, ntRP = new_targets[pid].get(RFocus, (0, 0))
-            print "pID (%3d) %22s | c: %5.1f / %5.1f | cT: %5.1f / %5.1f |  cF: %8s | nF: %8s | cT: %5.1f / %5.1f | %.2f" % (pid, planet_map[pid].name, cRP, cPP, otRP, otPP, fociMap.get(oldFocus, 'unknown'), fociMap[RFocus], ntRP, ntPP, ratio)
+            oldFocus = focus_manager.current_focus[pid]
+            cPP, cRP = focus_manager.current_output[pid][IFocus], focus_manager.current_output[pid][RFocus]
+            otPP, otRP = focus_manager.new_targets[pid].get(oldFocus, (0, 0))
+            ntPP, ntRP = focus_manager.new_targets[pid].get(RFocus, (0, 0))
+            print "pID (%3d) %22s | c: %5.1f / %5.1f | cT: %5.1f / %5.1f |  cF: %8s | nF: %8s | cT: %5.1f / %5.1f | %.2f" % (pid, focus_manager.planet_map[pid].name, cRP, cPP, otRP, otPP, fociMap.get(oldFocus, 'unknown'), fociMap[RFocus], ntRP, ntPP, ratio)
             continue  # RP is getting too expensive, but might be willing to still allocate from a planet with less PP to lose
-        # if planet_map[pid].currentMeterValue(fo.meterType.targetPopulation) >0: #only set to research if pop won't die out
-        newFoci[pid] = RFocus
+        # if focus_manager.planet_map[pid].currentMeterValue(fo.meterType.targetPopulation) >0: #only set to research if pop won't die out
+        focus_manager.new_foci[pid] = RFocus
         curTargetRP += (RR - IR)
         curTargetPP -= (II - RI)
 
@@ -465,7 +487,6 @@ def set_planet_resource_foci():
 
     print "\n============================"
     print "Collecting info to assess Planet Focus Changes\n"
-    universe = fo.getUniverse()
     empire = fo.getEmpire()
     currentTurn = fo.currentTurn()
     # set the random seed (based on galaxy seed, empire ID and current turn)
@@ -473,8 +494,6 @@ def set_planet_resource_foci():
     freq = min(3, (max(5, currentTurn - 80)) / 4.0) ** (1.0 / 3)
     if not (limitAssessments and (abs(currentTurn - lastFociCheck[0]) < 1.5 * freq) and (random.random() < 1.0 / freq)):
         lastFociCheck[0] = currentTurn
-        resource_timer.start("getPlanets")
-        empirePlanetIDs = list(PlanetUtilsAI.get_owned_planets_by_empire(universe.planetIDs))
         resource_timer.start("Filter")
         resource_timer.start("Priority")
         # TODO: take into acct splintering of resource groups
@@ -483,45 +502,41 @@ def set_planet_resource_foci():
         ppPrio = foAI.foAIstate.get_priority(PriorityType.RESOURCE_PRODUCTION)
         rpPrio = foAI.foAIstate.get_priority(PriorityType.RESOURCE_RESEARCH)
         priorityRatio = float(rpPrio) / (ppPrio + 0.0001)
-        resource_timer.start("Shuffle")
-        # shuffle(generalPlanetIDs)
-        resource_timer.start("Targets")
-        planets = map(universe.getPlanet, empirePlanetIDs)
-        planet_map.clear()
-        planet_map.update(zip(empirePlanetIDs, planets))
 
-        newFoci = {}
+        focus_manager = PlanetFocusManager()
 
-        use_planet_growth_specials(empirePlanetIDs, newFoci)
+        use_planet_growth_specials(focus_manager)
 
-        use_planet_production_and_research_specials(empirePlanetIDs, newFoci)
+        use_planet_production_and_research_specials(focus_manager)
 
-        # pp, rp = get_resource_target_totals(empirePlanetIDs, planet_map)
-        pp, rp = get_resource_target_totals(planet_map.keys())
+        get_resource_target_totals(focus_manager)
 
-        set_planet_protection_foci(empirePlanetIDs, newFoci)
+        pp = sum(x.currentMeterValue(fo.meterType.targetIndustry) for x in focus_manager.planet_map.values())
+        rp = sum(x.currentMeterValue(fo.meterType.targetResearch) for x in focus_manager.planet_map.values())
 
-        set_planet_happiness_foci()
+        set_planet_protection_foci(focus_manager)
 
-        preset_ids = set(planet_map.keys()) - set(empirePlanetIDs)
-        ctPP0, ctRP0, curTargetPP, curTargetRP = set_planet_industry_and_research_foci(empirePlanetIDs, newFoci, priorityRatio, preset_ids)
+        set_planet_happiness_foci(focus_manager)
 
-        totalChanged = 0 
-        for id_set in empirePlanetIDs, preset_ids:
+        preset_ids = set(focus_manager.planet_map.keys()) - set(focus_manager.planet_ids)
+        ctPP0, ctRP0, curTargetPP, curTargetRP = set_planet_industry_and_research_foci(focus_manager, priorityRatio, preset_ids)
+
+        totalChanged = 0
+        for id_set in focus_manager.planet_ids, preset_ids:
             for pid in id_set:
-                canFocus = planet_map[pid].currentMeterValue(fo.meterType.targetPopulation) > 0
-                oldFocus = current_focus[pid]
-                newFocus = newFoci.get(pid, IFocus)
-                cPP, cRP = current_output[pid][IFocus], current_output[pid][RFocus]
-                otPP, otRP = new_targets[pid].get(oldFocus, (0, 0))
+                canFocus = focus_manager.planet_map[pid].currentMeterValue(fo.meterType.targetPopulation) > 0
+                oldFocus = focus_manager.current_focus[pid]
+                newFocus = focus_manager.new_foci.get(pid, IFocus)
+                cPP, cRP = focus_manager.current_output[pid][IFocus], focus_manager.current_output[pid][RFocus]
+                otPP, otRP = focus_manager.new_targets[pid].get(oldFocus, (0, 0))
                 ntPP, ntRP = otPP, otRP
                 if (canFocus
                     and newFocus != oldFocus
-                    and newFocus in planet_map[pid].availableFoci
-                    and newFocus != planet_map[pid].focus):
+                    and newFocus in focus_manager.planet_map[pid].availableFoci
+                    and newFocus != focus_manager.planet_map[pid].focus):
                     if fo.issueChangeFocusOrder(pid, newFocus) != 1:
-                        newFoci[pid] = oldFocus
-                        print "Trouble changing focus of planet %s (%d) to %s" % (planet_map[pid].name, pid, newFocus)
+                        focus_manager.new_foci[pid] = oldFocus
+                        print "Trouble changing focus of planet %s (%d) to %s" % (focus_manager.planet_map[pid].name, pid, newFocus)
 
         print "============================"
         print "Planet Focus Assignments to achieve target RP/PP ratio of %.2f from current ratio of %.2f ( %.1f / %.1f )" % (priorityRatio, rp / (pp + 0.0001), rp, pp)
@@ -529,15 +544,15 @@ def set_planet_resource_foci():
         print "-------------------------------------"
         print "%34s|%20s|%15s |%15s|%15s |%15s " % ("                      Planet ", " current RP/PP ", " current target RP/PP ", "current Focus ", "  newFocus ", " new target RP/PP ")
         totalChanged = 0
-        for id_set in empirePlanetIDs, preset_ids:
+        for id_set in focus_manager.planet_ids, preset_ids:
             for pid in id_set:
-                canFocus = planet_map[pid].currentMeterValue(fo.meterType.targetPopulation) > 0
-                oldFocus = current_focus[pid]
-                newFocus = newFoci.get(pid, IFocus)
-                cPP, cRP = current_output[pid][IFocus], current_output[pid][RFocus]
-                otPP, otRP = new_targets[pid].get(oldFocus, (0, 0))
-                ntPP, ntRP = new_targets[pid].get(newFocus, (0, 0))
-                print "pID (%3d) %22s | c: %5.1f / %5.1f | cT: %5.1f / %5.1f |  cF: %8s | nF: %8s | cT: %5.1f / %5.1f " % (pid, planet_map[pid].name, cRP, cPP, otRP, otPP, fociMap.get(oldFocus, 'unknown'), fociMap[newFocus], ntRP, ntPP)
+                canFocus = focus_manager.planet_map[pid].currentMeterValue(fo.meterType.targetPopulation) > 0
+                oldFocus = focus_manager.current_focus[pid]
+                newFocus = focus_manager.new_foci.get(pid, IFocus)
+                cPP, cRP = focus_manager.current_output[pid][IFocus], focus_manager.current_output[pid][RFocus]
+                otPP, otRP = focus_manager.new_targets[pid].get(oldFocus, (0, 0))
+                ntPP, ntRP = focus_manager.new_targets[pid].get(newFocus, (0, 0))
+                print "pID (%3d) %22s | c: %5.1f / %5.1f | cT: %5.1f / %5.1f |  cF: %8s | nF: %8s | cT: %5.1f / %5.1f " % (pid, focus_manager.planet_map[pid].name, cRP, cPP, otRP, otPP, fociMap.get(oldFocus, 'unknown'), fociMap[newFocus], ntRP, ntPP)
             print "-------------------------------------"
         print "-------------------------------------"
         print "Final Ratio Target (turn %4d) RP/PP : %.2f ( %.1f / %.1f ) after %d Focus changes" % (fo.currentTurn(), curTargetRP / (curTargetPP + 0.0001), curTargetRP, curTargetPP, totalChanged)

--- a/default/AI/ResourcesAI.py
+++ b/default/AI/ResourcesAI.py
@@ -444,12 +444,12 @@ def set_planet_industry_and_research_foci(empirePlanetIDs, newFoci, priorityRati
                 printedHeader = True
                 print "Rejecting further Research Focus choices as too expensive:"
                 print "%34s|%20s|%15s |%15s|%15s |%15s |%15s" % ("                      Planet ", " current RP/PP ", " current target RP/PP ", "current Focus ", "  rejectedFocus ", " rejected target RP/PP ", "rejected RP-PP EQF")
-                oldFocus = currentFocus[pid]
-                cPP, cRP = currentOutput[pid][IFocus], currentOutput[pid][RFocus]
-                otPP, otRP = newTargets[pid].get(oldFocus, (0, 0))
-                ntPP, ntRP = newTargets[pid].get(RFocus, (0, 0))
-                print "pID (%3d) %22s | c: %5.1f / %5.1f | cT: %5.1f / %5.1f |  cF: %8s | nF: %8s | cT: %5.1f / %5.1f | %.2f" % (pid, planetMap[pid].name, cRP, cPP, otRP, otPP, fociMap.get(oldFocus, 'unknown'), fociMap[RFocus], ntRP, ntPP, ratio)
-                continue  # RP is getting too expensive, but might be willing to still allocate from a planet with less PP to lose
+            oldFocus = currentFocus[pid]
+            cPP, cRP = currentOutput[pid][IFocus], currentOutput[pid][RFocus]
+            otPP, otRP = newTargets[pid].get(oldFocus, (0, 0))
+            ntPP, ntRP = newTargets[pid].get(RFocus, (0, 0))
+            print "pID (%3d) %22s | c: %5.1f / %5.1f | cT: %5.1f / %5.1f |  cF: %8s | nF: %8s | cT: %5.1f / %5.1f | %.2f" % (pid, planetMap[pid].name, cRP, cPP, otRP, otPP, fociMap.get(oldFocus, 'unknown'), fociMap[RFocus], ntRP, ntPP, ratio)
+            continue  # RP is getting too expensive, but might be willing to still allocate from a planet with less PP to lose
         # if planetMap[pid].currentMeterValue(fo.meterType.targetPopulation) >0: #only set to research if pop won't die out
         newFoci[pid] = RFocus
         curTargetRP += (RR - IR)

--- a/default/AI/ResourcesAI.py
+++ b/default/AI/ResourcesAI.py
@@ -7,8 +7,8 @@ and finally the targetted ratio of research/production. Each decision on a plane
 transfers the planet from the raw list to the baked list, until all planets
 have their future focus decided.
 """
-#Note: The algorithm is not stable with respect to pid order.  i.e. Two empire with
-#      exactly the same colonies, but different pids may make different choices.
+# Note: The algorithm is not stable with respect to pid order.  i.e. Two empire with
+#       exactly the same colonies, but different pids may make different choices.
 
 import freeOrionAIInterface as fo  # pylint: disable=import-error
 import FreeOrionAI as foAI
@@ -23,7 +23,7 @@ from freeorion_tools import tech_is_complete
 
 resource_timer = Timer('timer_bucket')
 
-#Local Constants
+# Local Constants
 IFocus = FocusType.FOCUS_INDUSTRY
 RFocus = FocusType.FOCUS_RESEARCH
 MFocus = FocusType.FOCUS_MINING  # not currently used in content
@@ -31,7 +31,7 @@ GFocus = FocusType.FOCUS_GROWTH
 PFocus = FocusType.FOCUS_PROTECTION
 fociMap = {IFocus: "Industry", RFocus: "Research", MFocus: "Mining", GFocus: "Growth", PFocus: "Defense"}
 
-#TODO use the priorityRatio to weight
+# TODO use the priorityRatio to weight
 RESEARCH_WEIGHTING = 2.0
 
 useGrowth = True
@@ -45,8 +45,8 @@ class PlanetFocusInfo(object):
     def __init__(self, planet):
         self.planet = planet
         self.current_focus = planet.focus
-        self.current_output = (planet.currentMeterValue(fo.meterType.industry)
-                               , planet.currentMeterValue(fo.meterType.research))
+        self.current_output = (planet.currentMeterValue(fo.meterType.industry),
+                               planet.currentMeterValue(fo.meterType.research))
         self.possible_output = {}
         itarget = planet.currentMeterValue(fo.meterType.targetIndustry)
         rtarget = planet.currentMeterValue(fo.meterType.targetResearch)
@@ -55,8 +55,8 @@ class PlanetFocusInfo(object):
 
     def can_change_focus(self):
         """Can the planet change focus?  Is it's population non zero?"""
-        #TODO Could this be changed to current population instead of target population?
-        #It uses the target population to avoid situations where an unsustainable population is dying?
+        # It uses the target population versus current population to avoid situations
+        # where an unsustainable population is dying?
         return self.planet.currentMeterValue(fo.meterType.targetPopulation) > 0
 
 
@@ -111,7 +111,7 @@ class PlanetFocusManager(object):
         It excludes baked planets from consideration.
         Note: The results will not be strictly correct if any planets have global effects
         """
-        #TODO this function depends on the specific rule that off-focus meter value are always the minimum value
+        # TODO this function depends on the specific rule that off-focus meter value are always the minimum value
         universe = fo.getUniverse()
         unbaked_pids = [pid for pid in pids if not pid in self.baked_planet_info]
         planet_infos = [(pid, self.all_planet_info[pid], self.all_planet_info[pid].planet) for pid in unbaked_pids]
@@ -177,8 +177,8 @@ class Reporter(object):
     @staticmethod
     def print_table_header():
         print "==================================="
-        print Reporter.table_format % ("Planet", "current RP/PP", "old target RP/PP"
-                                       , "current Focus", "newFocus", "new target RP/PP")
+        print Reporter.table_format % ("Planet", "current RP/PP", "old target RP/PP",
+                                       "current Focus", "newFocus", "new target RP/PP")
 
     def print_table_footer(self, priorityRatio):
         current_industry_target = 0
@@ -207,18 +207,18 @@ class Reporter(object):
 
         print "-----------------------------------"
         print "Planet Focus Assignments to achieve target RP/PP ratio of %.2f from current ratio of %.2f ( %.1f / %.1f )" \
-            % (priorityRatio, current_research_target / (current_industry_target + 0.0001)
-               , current_research_target, current_industry_target)
+            % (priorityRatio, current_research_target / (current_industry_target + 0.0001),
+               current_research_target, current_industry_target)
         print "Max Industry assignments would result in target RP/PP ratio of %.2f ( %.1f / %.1f )" \
-            % (all_industry_research_target / (all_industry_industry_target + 0.0001)
-               , all_industry_research_target, all_industry_industry_target)
+            % (all_industry_research_target / (all_industry_industry_target + 0.0001),
+               all_industry_research_target, all_industry_industry_target)
         print "Max Research assignments would result in target RP/PP ratio of %.2f ( %.1f / %.1f )" \
-            % (all_research_research_target / (all_research_industry_target + 0.0001)
-               , all_research_research_target, all_research_industry_target)
+            % (all_research_research_target / (all_research_industry_target + 0.0001),
+               all_research_research_target, all_research_industry_target)
         print "-----------------------------------"
         print "Final Ratio Target (turn %4d) RP/PP : %.2f ( %.1f / %.1f ) after %d Focus changes" \
-            % (fo.currentTurn(), current_research_target / (current_industry_target + 0.0001)
-               , current_research_target, current_industry_target, total_changed)
+            % (fo.currentTurn(), current_research_target / (current_industry_target + 0.0001),
+               current_research_target, current_industry_target, total_changed)
 
     def print_table(self, priorityRatio):
         """Prints a table of all of the captured sections of assignments"""
@@ -276,7 +276,7 @@ class Reporter(object):
         # what is the focus of available resource centers?
         print
         warnings = {}
-        #TODO combine this with previous table to reduce report duplication?
+        # TODO combine this with previous table to reduce report duplication?
         print "Planet Resources Foci:"
         for planetID in empirePlanetIDs:
             planet = universe.getPlanet(planetID)
@@ -427,8 +427,8 @@ def use_planet_growth_specials(focus_manager):
 
 def use_planet_production_and_research_specials(focus_manager):
     """Use production and research specials as appropriate.  Remove planets from list of candidates."""
-    #TODO remove reliance on rules knowledge.  Just scan for specials with production
-    #and research bonuses and use what you find. Perhaps maintain a list
+    # TODO remove reliance on rules knowledge.  Just scan for specials with production
+    # and research bonuses and use what you find. Perhaps maintain a list
     # of know types of specials
     universe = fo.getUniverse()
     already_have_comp_moon = False
@@ -481,7 +481,7 @@ def set_planet_protection_foci(focus_manager):
 
 def set_planet_happiness_foci(focus_manager):
     """Assess and set planet focus to preferred focus depending on happiness"""
-    #TODO Assess need to set planet to preferred focus to improve happiness
+    # TODO Assess need to set planet to preferred focus to improve happiness
 
 
 def set_planet_industry_and_research_foci(focus_manager, priorityRatio):
@@ -496,10 +496,10 @@ def set_planet_industry_and_research_foci(focus_manager, priorityRatio):
     curTargetRP = 0.001
     resource_timer.start("Loop")  # loop
     has_force = tech_is_complete("CON_FRC_ENRG_STRC")
-    #cumulative all industry focus
+    # cumulative all industry focus
     ctPP0, ctRP0 = 0, 0
 
-    #Handle presets which only have possible output for preset focus
+    # Handle presets which only have possible output for preset focus
     for pid, pinfo in focus_manager.baked_planet_info.items():
         nPP, nRP = pinfo.possible_output[pinfo.future_focus]
         curTargetPP += nPP
@@ -515,7 +515,7 @@ def set_planet_industry_and_research_foci(focus_manager, priorityRatio):
         if RFocus not in pinfo.planet.availableFoci:
             focus_manager.bake_future_focus(pid, pinfo.current_focus, False)
 
-    #smallest possible ratio of research to industry with an all industry focus
+    # smallest possible ratio of research to industry with an all industry focus
     maxi_ratio = ctRP0 / max(0.01, ctPP0)
 
     for adj_round in [2, 3, 4]:
@@ -587,7 +587,7 @@ def set_planet_industry_and_research_foci(focus_manager, priorityRatio):
         curTargetRP += (RR - IR)
         curTargetPP -= (II - RI)
 
-    #Any planet in the ratios list and still raw is set to industry
+    # Any planet in the ratios list and still raw is set to industry
     for ratio, pid, pinfo in ratios:
         if pid in focus_manager.raw_planet_info:
             focus_manager.bake_future_focus(pid, IFocus, False)

--- a/default/AI/ResourcesAI.py
+++ b/default/AI/ResourcesAI.py
@@ -352,8 +352,8 @@ def assess_protection_focus(pid, pinfo):
     if use_protection or pinfo.current_focus == PFocus:
         print ("Advising %sProtection Focus (reason %s) for planet %s, with local_prod_diff of %.1f, comb. local"
                " defenses %.1f, local fleet rating %.1f and regional threat %.1f, threat sources: %s") % (
-            ["dropping ", ""][use_protection], reason, this_planet, local_production_diff, combined_local_defenses,
-            local_fleet_rating, regional_threat, sys_status['regional_fleet_threats'])
+                   ["dropping ", ""][use_protection], reason, this_planet, local_production_diff, combined_local_defenses,
+                   local_fleet_rating, regional_threat, sys_status['regional_fleet_threats'])
     return use_protection
 
 
@@ -414,8 +414,7 @@ def use_planet_production_and_research_specials(focus_manager):
                ["BLD_CONC_CAMP", "BLD_CONC_CAMP_REMNANT"]] != [])
              or ([ccspec for ccspec in planet.specials if ccspec in
                   ["CONC_CAMP_MASTER_SPECIAL", "CONC_CAMP_SLAVE_SPECIAL"]] != []))
-            and IFocus in planet.availableFoci):
-
+                and IFocus in planet.availableFoci):
             if focus_manager.bake_future_focus(pid, IFocus):
                 if pinfo.current_focus != IFocus:
                     print ("Tried setting %s for Concentration Camp planet %s (%d) with species %s and current focus %s, got result %d and focus %s" %
@@ -535,11 +534,11 @@ def set_planet_industry_and_research_foci(focus_manager, priorityRatio):
         # if focus_manager.current_focus[pid] == MFocus:
         # II = max( II, focus_manager.possible_output[MFocus][0] )
         if (not do_research and (
-               (ratio > 2.0 and curTargetPP < 15 and gotAlgo) or
-               (ratio > 2.5 and curTargetPP < 25 and II > 5 and gotAlgo) or
-               (ratio > 3.0 and curTargetPP < 40 and II > 5 and gotAlgo) or
-               (ratio > 4.0 and curTargetPP < 100 and II > 10) or
-               ((curTargetRP + RR - IR) / max(0.001, curTargetPP - II + RI) > 2 * priorityRatio))):  # we already have algo elegance and more RP would be too expensive, or overkill
+                (ratio > 2.0 and curTargetPP < 15 and gotAlgo) or
+                (ratio > 2.5 and curTargetPP < 25 and II > 5 and gotAlgo) or
+                (ratio > 3.0 and curTargetPP < 40 and II > 5 and gotAlgo) or
+                (ratio > 4.0 and curTargetPP < 100 and II > 10) or
+                ((curTargetRP + RR - IR) / max(0.001, curTargetPP - II + RI) > 2 * priorityRatio))):  # we already have algo elegance and more RP would be too expensive, or overkill
             if not printedHeader:
                 printedHeader = True
                 print "Rejecting further Research Focus choices as too expensive:"

--- a/default/AI/ResourcesAI.py
+++ b/default/AI/ResourcesAI.py
@@ -504,6 +504,23 @@ def set_planet_resource_foci():
         preset_ids = set(planetMap.keys()) - set(empirePlanetIDs)
         ctPP0, ctRP0, curTargetPP, curTargetRP = set_planet_industry_and_research_foci(empirePlanetIDs, newFoci, priorityRatio, preset_ids)
 
+        totalChanged = 0 
+        for id_set in empirePlanetIDs, preset_ids:
+            for pid in id_set:
+                canFocus = planetMap[pid].currentMeterValue(fo.meterType.targetPopulation) > 0
+                oldFocus = currentFocus[pid]
+                newFocus = newFoci.get(pid, IFocus)
+                cPP, cRP = currentOutput[pid][IFocus], currentOutput[pid][RFocus]
+                otPP, otRP = newTargets[pid].get(oldFocus, (0, 0))
+                ntPP, ntRP = otPP, otRP
+                if (canFocus
+                    and newFocus != oldFocus
+                    and newFocus in planetMap[pid].availableFoci
+                    and newFocus != planetMap[pid].focus):
+                    if (fo.issueChangeFocusOrder(pid, newFocus) != 1):
+                        newFoci[pid] = oldFocus
+                        print "Trouble changing focus of planet %s (%d) to %s" % (planetMap[pid].name, pid, newFocus)
+
         print "============================"
         print "Planet Focus Assignments to achieve target RP/PP ratio of %.2f from current ratio of %.2f ( %.1f / %.1f )" % (priorityRatio, rp / (pp + 0.0001), rp, pp)
         print "Max Industry assignments would result in target RP/PP ratio of %.2f ( %.1f / %.1f )" % (ctRP0 / (ctPP0 + 0.0001), ctRP0, ctPP0)
@@ -517,15 +534,7 @@ def set_planet_resource_foci():
                 newFocus = newFoci.get(pid, IFocus)
                 cPP, cRP = currentOutput[pid][IFocus], currentOutput[pid][RFocus]
                 otPP, otRP = newTargets[pid].get(oldFocus, (0, 0))
-                ntPP, ntRP = otPP, otRP
-                if newFocus != oldFocus and newFocus in planetMap[pid].availableFoci:  # planetMap[pid].focus
-                    totalChanged += 1
-                    if newFocus != planetMap[pid].focus:
-                        result = fo.issueChangeFocusOrder(pid, newFocus)
-                        if result == 1:
-                            ntPP, ntRP = newTargets[pid].get(newFocus, (0, 0))
-                        else:
-                            print "Trouble changing focus of planet %s (%d) to %s" % (planetMap[pid].name, pid, newFocus)
+                ntPP, ntRP = newTargets[pid].get(newFocus, (0, 0))
                 print "pID (%3d) %22s | c: %5.1f / %5.1f | cT: %5.1f / %5.1f |  cF: %8s | nF: %8s | cT: %5.1f / %5.1f " % (pid, planetMap[pid].name, cRP, cPP, otRP, otPP, fociMap.get(oldFocus, 'unknown'), fociMap[newFocus], ntRP, ntPP)
             print "-------------------------------------"
         print "-------------------------------------"

--- a/default/AI/ResourcesAI.py
+++ b/default/AI/ResourcesAI.py
@@ -43,9 +43,8 @@ class PlanetFocusInfo(object):
     def __init__(self, planet):
         self.planet = planet
         self.current_focus = planet.focus
-        self.current_output = {}
-        self.current_output[IFocus] = planet.currentMeterValue(fo.meterType.industry)
-        self.current_output[RFocus] = planet.currentMeterValue(fo.meterType.research)
+        self.current_output = (planet.currentMeterValue(fo.meterType.industry)
+                               , planet.currentMeterValue(fo.meterType.research))
         self.possible_output = {}
         itarget = planet.currentMeterValue(fo.meterType.targetIndustry)
         rtarget = planet.currentMeterValue(fo.meterType.targetResearch)
@@ -227,7 +226,7 @@ class Reporter(object):
                 pinfo = self.focus_manager.baked_planet_info[pid]
                 oldFocus = pinfo.current_focus
                 newFocus = pinfo.future_focus
-                cPP, cRP = pinfo.current_output[IFocus], pinfo.current_output[RFocus]
+                cPP, cRP = pinfo.current_output
                 otPP, otRP = pinfo.possible_output.get(oldFocus, (0, 0))
                 ntPP, ntRP = pinfo.possible_output[newFocus]
                 print (Reporter.table_format %
@@ -312,7 +311,7 @@ def assess_protection_focus(pid, pinfo):
         if pinfo.current_focus == PFocus:
             print "Advising dropping Protection Focus at %s due to no regional threat" % this_planet
         return False
-    cur_prod_val = weighted_sum_output([pinfo.current_output[IFocus], pinfo.current_output[RFocus]])
+    cur_prod_val = weighted_sum_output(pinfo.current_output)
     target_prod_val = max(map(weighted_sum_output, [pinfo.possible_output[IFocus], pinfo.possible_output[RFocus]]))
     prot_prod_val = weighted_sum_output(pinfo.possible_output[PFocus])
     local_production_diff = 0.8 * cur_prod_val + 0.2 * target_prod_val - prot_prod_val
@@ -520,7 +519,7 @@ def set_planet_industry_and_research_foci(focus_manager, priorityRatio):
         for pid, pinfo in focus_manager.raw_planet_info.items():
             II, IR = pinfo.possible_output[IFocus]
             RI, RR = pinfo.possible_output[RFocus]
-            CI, CR = pinfo.current_output[IFocus], pinfo.current_output[RFocus]
+            CI, CR = pinfo.current_output
             research_penalty = (pinfo.current_focus != RFocus)
             # calculate factor F at which II + F * IR == RI + F * RR =====> F = ( II-RI ) / (RR-IR)
             thisFactor = (II - RI) / max(0.01, RR - IR)  # don't let denominator be zero for planets where focus doesn't change RP
@@ -575,7 +574,7 @@ def set_planet_industry_and_research_foci(focus_manager, priorityRatio):
                 print "Rejecting further Research Focus choices as too expensive:"
                 print "%34s|%20s|%15s |%15s|%15s |%15s |%15s" % ("                      Planet ", " current RP/PP ", " current target RP/PP ", "current Focus ", "  rejectedFocus ", " rejected target RP/PP ", "rejected RP-PP EQF")
             oldFocus = pinfo.current_focus
-            cPP, cRP = pinfo.current_output[IFocus], pinfo.current_output[RFocus]
+            cPP, cRP = pinfo.current_output
             otPP, otRP = pinfo.possible_output[oldFocus]
             ntPP, ntRP = pinfo.possible_output[RFocus]
             print "pID (%3d) %22s | c: %5.1f / %5.1f | cT: %5.1f / %5.1f |  cF: %8s | nF: %8s | cT: %5.1f / %5.1f | %.2f" % (pid, pinfo.planet.name, cRP, cPP, otRP, otPP, fociMap.get(oldFocus, 'unknown'), fociMap[RFocus], ntRP, ntPP, ratio)

--- a/default/AI/ResourcesAI.py
+++ b/default/AI/ResourcesAI.py
@@ -20,6 +20,7 @@ RFocus = FocusType.FOCUS_RESEARCH
 MFocus = FocusType.FOCUS_MINING  # not currently used in content
 GFocus = FocusType.FOCUS_GROWTH
 PFocus = FocusType.FOCUS_PROTECTION
+fociMap = {IFocus: "Industry", RFocus: "Research", MFocus: "Mining", GFocus: "Growth", PFocus: "Defense"}
 
 RESEARCH_WEIGHTING = 2.0
 
@@ -219,9 +220,240 @@ def assess_protection_focus(pid):
     return use_protection
 
 
+def use_planet_growth_specials(empirePlanetIDs, newFoci):
+    '''set resource foci of planets with potentially useful growth factors. Remove planets from list of candidates.'''
+    if useGrowth:
+        # TODO: also consider potential future benefit re currently unpopulated planets
+        for metab, metabIncPop in ColonisationAI.empire_metabolisms.items():
+            for special in [aspec for aspec in AIDependencies.metabolismBoostMap.get(metab, []) if aspec in ColonisationAI.available_growth_specials]:
+                rankedPlanets = []
+                for pid in ColonisationAI.available_growth_specials[special]:
+                    planet = planetMap[pid]
+                    cur_focus = planet.focus
+                    pop = planet.currentMeterValue(fo.meterType.population)
+                    if (pop > metabIncPop - 2 * planet.size) or (GFocus not in planet.availableFoci):  # not enough benefit to lose local production, or can't put growth focus here
+                        continue
+                    for special2 in ["COMPUTRONIUM_SPECIAL"]:
+                        if special2 in planet.specials:
+                            break
+                    else:  # didn't have any specials that would override interest in growth special
+                        print "Considering Growth Focus for %s (%d) with special %s; planet has pop %.1f and %s metabolism incremental pop is %.1f" % (
+                            planet.name, pid, special, pop, metab, metabIncPop)
+                        if cur_focus == GFocus:
+                            pop -= 4  # discourage changing current focus to minimize focus-changing penalties
+                            rankedPlanets.append((pop, pid, cur_focus))
+                if not rankedPlanets:
+                    continue
+                rankedPlanets.sort()
+                print "Considering Growth Focus choice for special %s; possible planet pop, id pairs are %s" % (metab, rankedPlanets)
+                for spSize, spPID, cur_focus in rankedPlanets:  # index 0 should be able to set focus, but just in case...
+                    result = 1
+                    if cur_focus != GFocus:
+                        result = fo.issueChangeFocusOrder(spPID, GFocus)
+                    if result == 1:
+                        newFoci[spPID] = GFocus
+                        if spPID in empirePlanetIDs:
+                            del empirePlanetIDs[empirePlanetIDs.index(spPID)]
+                            print "%s focus of planet %s (%d) at Growth Focus" % (["set", "left"][cur_focus == GFocus], planetMap[spPID].name, spPID)
+                        break
+                    else:
+                        print "failed setting focus of planet %s (%d) at Growth Focus; focus left at %s" % (planetMap[spPID].name, spPID, planetMap[spPID].focus)
+
+
+def use_planet_production_and_research_specials(empirePlanetIDs, newFoci):
+    '''Use production and research specials as appropriate.  Remove planets from list of candidates.'''
+    universe = fo.getUniverse()
+    already_have_comp_moon = False
+    for pid in empirePlanetIDs:
+        planet = planetMap[pid]
+        if "COMPUTRONIUM_SPECIAL" in planet.specials and RFocus in planet.availableFoci and not already_have_comp_moon:
+            curFocus = planet.focus
+            newFoci[pid] = RFocus
+            result = 0
+            if curFocus != RFocus:
+                result = fo.issueChangeFocusOrder(pid, RFocus)
+                if result == 1:
+                    universe.updateMeterEstimates(empirePlanetIDs)
+            if curFocus == RFocus or result == 1:
+                already_have_comp_moon = True
+                print "%s focus of planet %s (%d) (with Computronium Moon) at Research Focus" % (["set", "left"][curFocus == RFocus], planetMap[pid].name, pid)
+                if pid in empirePlanetIDs:
+                    del empirePlanetIDs[empirePlanetIDs.index(pid)]
+                continue
+        if "HONEYCOMB_SPECIAL" in planet.specials and IFocus in planet.availableFoci:
+            curFocus = planet.focus
+            newFoci[pid] = IFocus
+            result = 0
+            if curFocus != IFocus:
+                result = fo.issueChangeFocusOrder(pid, IFocus)
+                if result == 1:
+                    universe.updateMeterEstimates(empirePlanetIDs)
+            if curFocus == IFocus or result == 1:
+                print "%s focus of planet %s (%d) (with Honeycomb) at Industry Focus" % (["set", "left"][curFocus == IFocus], planetMap[pid].name, pid)
+                if pid in empirePlanetIDs:
+                    del empirePlanetIDs[empirePlanetIDs.index(pid)]
+                continue
+        if ((([bld.buildingTypeName for bld in map(universe.getObject, planet.buildingIDs) if bld.buildingTypeName in
+                ["BLD_CONC_CAMP", "BLD_CONC_CAMP_REMNANT"]] != []) or
+                         ([ccspec for ccspec in planet.specials if ccspec in ["CONC_CAMP_MASTER_SPECIAL", "CONC_CAMP_SLAVE_SPECIAL"]] != []))
+                and IFocus in planet.availableFoci):
+            curFocus = planet.focus
+            newFoci[pid] = IFocus
+            result = 0
+            if curFocus != IFocus:
+                result = fo.issueChangeFocusOrder(pid, IFocus)
+                if result == 1:
+                    print ("Tried setting %s for Concentration Camp planet %s (%d) with species %s and current focus %s, got result %d and focus %s" %
+                           (newFoci[pid], planet.name, pid, planet.speciesName, curFocus, result, planetMap[pid].focus))
+                    universe.updateMeterEstimates(empirePlanetIDs)
+                if (result != 1) or planetMap[pid].focus != IFocus:
+                    newplanet = universe.getPlanet(pid)
+                    print ("Error: Failed setting %s for Concentration Camp planet %s (%d) with species %s and current focus %s, but new planet copy shows %s" %
+                           (newFoci[pid], planetMap[pid].name, pid, planetMap[pid].speciesName, planetMap[pid].focus, newplanet.focus))
+            if curFocus == IFocus or result == 1:
+                print "%s focus of planet %s (%d) (with Concentration Camps/Remnants) at Industry Focus" % (["set", "left"][curFocus == IFocus], planetMap[pid].name, pid)
+                if pid in empirePlanetIDs:
+                    del empirePlanetIDs[empirePlanetIDs.index(pid)]
+                continue
+
+
+def set_planet_protection_foci(empirePlanetIDs, newFoci):
+    '''Assess and set protection foci'''
+    universe = fo.getUniverse()
+    for pid in empirePlanetIDs:
+        planet = planetMap[pid]
+        if PFocus in planet.availableFoci and assess_protection_focus(pid):
+            curFocus = planet.focus
+            newFoci[pid] = PFocus
+            result = 0
+            if curFocus != PFocus:
+                result = fo.issueChangeFocusOrder(pid, PFocus)
+                if result == 1:
+                    print ("Tried setting %s for planet %s (%d) with species %s and current focus %s, got result %d and focus %s" %
+                           (newFoci[pid], planet.name, pid, planet.speciesName, curFocus, result, planet.focus))
+                    universe.updateMeterEstimates(empirePlanetIDs)
+                if (result != 1) or planet.focus != PFocus:
+                    newplanet = universe.getPlanet(pid)
+                    print ("Error: Failed setting %s for planet %s (%d) with species %s and current focus %s, but new planet copy shows %s" %
+                           (newFoci[pid], planet.name, pid, planet.speciesName, planet.focus, newplanet.focus))
+            if curFocus == PFocus or result == 1:
+                print "%s focus of planet %s (%d) at Protection(Defense) Focus" % (["set", "left"][curFocus == PFocus], planet.name, pid)
+                if pid in empirePlanetIDs:
+                    del empirePlanetIDs[empirePlanetIDs.index(pid)]
+                continue
+
+
+def set_planet_happiness_foci():
+    """Assess and set planet focus to preferred focus depending on happiness"""
+    #TODO Assess need to set planet to preferred focus to improve happiness
+
+
+def set_planet_industry_and_research_foci(empirePlanetIDs, newFoci, priorityRatio, preset_ids):
+    """Adjust planet's industry versus research focus while targetting the given ratio and avoiding penalties from changing focus"""
+    print "\n-----------------------------------------"
+    print "Making Planet Focus Change Determinations\n"
+
+    ratios = []
+    # for each planet, calculate RP:PP value ratio at which industry/Mining focus and research focus would have the same total value, & sort by that
+    # include a bias to slightly discourage changing foci
+    curTargetPP = 0.001
+    curTargetRP = 0.001
+    resource_timer.start("Loop")  # loop
+    has_force = tech_is_complete("CON_FRC_ENRG_STRC")
+    preset_ids = set(planetMap.keys()) - set(empirePlanetIDs)
+    ctPP0, ctRP0 = 0, 0
+    for pid in preset_ids:
+        nPP, nRP = newTargets.get(pid, {}).get(planetMap[pid].focus, [0, 0])
+        curTargetPP += nPP
+        curTargetRP += nRP
+        iPP, iRP = newTargets.get(pid, {}).get(IFocus, [0, 0])
+        ctPP0 += iPP
+        ctRP0 += iRP
+
+    id_set = set(empirePlanetIDs)
+    for adj_round in [1, 2, 3, 4]:
+        maxi_ratio = ctRP0 / max(0.01, ctPP0)  # should only change between rounds 1 and 2
+        for pid in list(id_set):
+            if adj_round == 1:  # tally max Industry
+                iPP, iRP = newTargets.get(pid, {}).get(IFocus, [0, 0])
+                ctPP0 += iPP
+                ctRP0 += iRP
+                continue
+            II, IR = newTargets[pid][IFocus]
+            RI, RR = newTargets[pid][RFocus]
+            CI, CR = currentOutput[pid][IFocus], currentOutput[pid][RFocus]
+            research_penalty = (currentFocus[pid] != RFocus)
+            # calculate factor F at which II + F * IR == RI + F * RR =====> F = ( II-RI ) / (RR-IR)
+            thisFactor = (II - RI) / max(0.01, RR - IR)  # don't let denominator be zero for planets where focus doesn't change RP
+            planet = planetMap[pid]
+            if adj_round == 2:  # take research at planets with very cheap research
+                if (maxi_ratio < priorityRatio) and (curTargetRP < priorityRatio * ctPP0) and (thisFactor <= 1.0):
+                    curTargetPP += RI
+                    curTargetRP += RR
+                    newFoci[pid] = RFocus
+                    id_set.discard(pid)
+                continue
+            if adj_round == 3:  # take research at planets where can do reasonable balance
+                if has_force or (foAI.foAIstate.aggression < fo.aggression.aggressive) or (curTargetRP >= priorityRatio * ctPP0):
+                    continue
+                pop = planet.currentMeterValue(fo.meterType.population)
+                t_pop = planet.currentMeterValue(fo.meterType.targetPopulation)
+                # if AI is aggressive+, and this planet in range where temporary Research focus can get an additional RP at cost of 1 PP, and still need some RP, then do it
+                if pop < t_pop - 5:
+                    continue
+                if (CI > II + 8) or (((RR > II) or ((RR - CR) >= 1 + 2 * research_penalty)) and ((RR - IR) >= 3) and ((CR - IR) >= 0.7 * ((II - CI) * (1 + 0.1 * research_penalty)))):
+                    curTargetPP += CI - 1 - research_penalty
+                    curTargetRP += CR + 1
+                    newFoci[pid] = RFocus
+                    id_set.discard(pid)
+                continue
+            # adj_round == 4 assume default IFocus
+            curTargetPP += II  # icurTargets initially calculated by Industry focus, which will be our default focus
+            curTargetRP += IR
+            newFoci[pid] = IFocus
+            ratios.append((thisFactor, pid))
+
+    ratios.sort()
+    printedHeader = False
+    gotAlgo = tech_is_complete("LRN_ALGO_ELEGANCE")
+    for ratio, pid in ratios:
+        do_research = False  # (newFoci[pid]==RFocus)
+        if (priorityRatio < (curTargetRP / (curTargetPP + 0.0001))) and not do_research:  # we have enough RP
+            if ratio < 1.1 and foAI.foAIstate.aggression > fo.aggression.cautious:  # but wait, RP is still super cheap relative to PP, maybe will take more RP
+                if priorityRatio < 1.5 * (curTargetRP / (curTargetPP + 0.0001)):  # yeah, really a glut of RP, stop taking RP
+                    break
+            else:  # RP not super cheap & we have enough, stop taking it
+                break
+        II, IR = newTargets[pid][IFocus]
+        RI, RR = newTargets[pid][RFocus]
+        # if currentFocus[pid] == MFocus:
+        # II = max( II, newTargets[pid][MFocus][0] )
+        if (not do_research and (
+               (ratio > 2.0 and curTargetPP < 15 and gotAlgo) or
+               (ratio > 2.5 and curTargetPP < 25 and II > 5 and gotAlgo) or
+               (ratio > 3.0 and curTargetPP < 40 and II > 5 and gotAlgo) or
+               (ratio > 4.0 and curTargetPP < 100 and II > 10) or
+               ((curTargetRP + RR - IR) / max(0.001, curTargetPP - II + RI) > 2 * priorityRatio))):  # we already have algo elegance and more RP would be too expensive, or overkill
+            if not printedHeader:
+                printedHeader = True
+                print "Rejecting further Research Focus choices as too expensive:"
+                print "%34s|%20s|%15s |%15s|%15s |%15s |%15s" % ("                      Planet ", " current RP/PP ", " current target RP/PP ", "current Focus ", "  rejectedFocus ", " rejected target RP/PP ", "rejected RP-PP EQF")
+                oldFocus = currentFocus[pid]
+                cPP, cRP = currentOutput[pid][IFocus], currentOutput[pid][RFocus]
+                otPP, otRP = newTargets[pid].get(oldFocus, (0, 0))
+                ntPP, ntRP = newTargets[pid].get(RFocus, (0, 0))
+                print "pID (%3d) %22s | c: %5.1f / %5.1f | cT: %5.1f / %5.1f |  cF: %8s | nF: %8s | cT: %5.1f / %5.1f | %.2f" % (pid, planetMap[pid].name, cRP, cPP, otRP, otPP, fociMap.get(oldFocus, 'unknown'), fociMap[RFocus], ntRP, ntPP, ratio)
+                continue  # RP is getting too expensive, but might be willing to still allocate from a planet with less PP to lose
+        # if planetMap[pid].currentMeterValue(fo.meterType.targetPopulation) >0: #only set to research if pop won't die out
+        newFoci[pid] = RFocus
+        curTargetRP += (RR - IR)
+        curTargetPP -= (II - RI)
+
+    return ctPP0, ctRP0, curTargetPP, curTargetRP
+
+
 def set_planet_resource_foci():
     """set resource focus of planets """
-    newFoci = {}
 
     print "\n============================"
     print "Collecting info to assess Planet Focus Changes\n"
@@ -229,7 +461,7 @@ def set_planet_resource_foci():
     empire = fo.getEmpire()
     currentTurn = fo.currentTurn()
     # set the random seed (based on galaxy seed, empire ID and current turn)
-    # for game-reload consistency 
+    # for game-reload consistency
     freq = min(3, (max(5, currentTurn - 80)) / 4.0) ** (1.0 / 3)
     if not (limitAssessments and (abs(currentTurn - lastFociCheck[0]) < 1.5 * freq) and (random.random() < 1.0 / freq)):
         lastFociCheck[0] = currentTurn
@@ -249,218 +481,23 @@ def set_planet_resource_foci():
         planets = map(universe.getPlanet, empirePlanetIDs)
         planetMap.clear()
         planetMap.update(zip(empirePlanetIDs, planets))
-        if useGrowth:
-            # TODO: also consider potential future benefit re currently unpopulated planets
-            for metab, metabIncPop in ColonisationAI.empire_metabolisms.items():
-                for special in [aspec for aspec in AIDependencies.metabolismBoostMap.get(metab, []) if aspec in ColonisationAI.available_growth_specials]:
-                    rankedPlanets = []
-                    for pid in ColonisationAI.available_growth_specials[special]:
-                        planet = planetMap[pid]
-                        cur_focus = planet.focus
-                        pop = planet.currentMeterValue(fo.meterType.population)
-                        if (pop > metabIncPop - 2 * planet.size) or (GFocus not in planet.availableFoci):  # not enough benefit to lose local production, or can't put growth focus here
-                            continue
-                        for special2 in ["COMPUTRONIUM_SPECIAL"]:
-                            if special2 in planet.specials:
-                                break
-                        else:  # didn't have any specials that would override interest in growth special
-                            print "Considering Growth Focus for %s (%d) with special %s; planet has pop %.1f and %s metabolism incremental pop is %.1f" % (
-                                planet.name, pid, special, pop, metab, metabIncPop)
-                            if cur_focus == GFocus:
-                                pop -= 4  # discourage changing current focus to minimize focus-changing penalties
-                            rankedPlanets.append((pop, pid, cur_focus))
-                    if not rankedPlanets:
-                        continue
-                    rankedPlanets.sort()
-                    print "Considering Growth Focus choice for special %s; possible planet pop, id pairs are %s" % (metab, rankedPlanets)
-                    for spSize, spPID, cur_focus in rankedPlanets:  # index 0 should be able to set focus, but just in case...
-                        result = 1
-                        if cur_focus != GFocus:
-                            result = fo.issueChangeFocusOrder(spPID, GFocus)
-                        if result == 1:
-                            newFoci[spPID] = GFocus
-                            if spPID in empirePlanetIDs:
-                                del empirePlanetIDs[empirePlanetIDs.index(spPID)]
-                            print "%s focus of planet %s (%d) at Growth Focus" % (["set", "left"][cur_focus == GFocus], planetMap[spPID].name, spPID)
-                            break
-                        else:
-                            print "failed setting focus of planet %s (%d) at Growth Focus; focus left at %s" % (planetMap[spPID].name, spPID, planetMap[spPID].focus)
-        already_have_comp_moon = False
-        for pid in empirePlanetIDs:
-            planet = planetMap[pid]
-            if "COMPUTRONIUM_SPECIAL" in planet.specials and RFocus in planet.availableFoci and not already_have_comp_moon:
-                curFocus = planet.focus
-                newFoci[pid] = RFocus
-                result = 0
-                if curFocus != RFocus:
-                    result = fo.issueChangeFocusOrder(pid, RFocus)
-                    if result == 1:
-                        universe.updateMeterEstimates(empirePlanetIDs)
-                if curFocus == RFocus or result == 1:
-                    already_have_comp_moon = True
-                    print "%s focus of planet %s (%d) (with Computronium Moon) at Research Focus" % (["set", "left"][curFocus == RFocus], planetMap[pid].name, pid)
-                    if pid in empirePlanetIDs:
-                        del empirePlanetIDs[empirePlanetIDs.index(pid)]
-                    continue
-            if "HONEYCOMB_SPECIAL" in planet.specials and IFocus in planet.availableFoci:
-                curFocus = planet.focus
-                newFoci[pid] = IFocus
-                result = 0
-                if curFocus != IFocus:
-                    result = fo.issueChangeFocusOrder(pid, IFocus)
-                    if result == 1:
-                        universe.updateMeterEstimates(empirePlanetIDs)
-                if curFocus == IFocus or result == 1:
-                    print "%s focus of planet %s (%d) (with Honeycomb) at Industry Focus" % (["set", "left"][curFocus == IFocus], planetMap[pid].name, pid)
-                    if pid in empirePlanetIDs:
-                        del empirePlanetIDs[empirePlanetIDs.index(pid)]
-                    continue
-            if ((([bld.buildingTypeName for bld in map(universe.getObject, planet.buildingIDs) if bld.buildingTypeName in
-                    ["BLD_CONC_CAMP", "BLD_CONC_CAMP_REMNANT"]] != []) or
-                             ([ccspec for ccspec in planet.specials if ccspec in ["CONC_CAMP_MASTER_SPECIAL", "CONC_CAMP_SLAVE_SPECIAL"]] != []))
-                    and IFocus in planet.availableFoci):
-                curFocus = planet.focus
-                newFoci[pid] = IFocus
-                result = 0
-                if curFocus != IFocus:
-                    result = fo.issueChangeFocusOrder(pid, IFocus)
-                    if result == 1:
-                        print ("Tried setting %s for Concentration Camp planet %s (%d) with species %s and current focus %s, got result %d and focus %s" %
-                               (newFoci[pid], planet.name, pid, planet.speciesName, curFocus, result, planetMap[pid].focus))
-                        universe.updateMeterEstimates(empirePlanetIDs)
-                    if (result != 1) or planetMap[pid].focus != IFocus:
-                        newplanet = universe.getPlanet(pid)
-                        print ("Error: Failed setting %s for Concentration Camp planet %s (%d) with species %s and current focus %s, but new planet copy shows %s" %
-                               (newFoci[pid], planetMap[pid].name, pid, planetMap[pid].speciesName, planetMap[pid].focus, newplanet.focus))
-                if curFocus == IFocus or result == 1:
-                    print "%s focus of planet %s (%d) (with Concentration Camps/Remnants) at Industry Focus" % (["set", "left"][curFocus == IFocus], planetMap[pid].name, pid)
-                    if pid in empirePlanetIDs:
-                        del empirePlanetIDs[empirePlanetIDs.index(pid)]
-                    continue
+
+        newFoci = {}
+
+        use_planet_growth_specials(empirePlanetIDs, newFoci)
+
+        use_planet_production_and_research_specials(empirePlanetIDs, newFoci)
+
         # pp, rp = get_resource_target_totals(empirePlanetIDs, planetMap)
         pp, rp = get_resource_target_totals(planetMap.keys())
 
-        for pid in empirePlanetIDs:
-            planet = planetMap[pid]
-            if PFocus in planet.availableFoci and assess_protection_focus(pid):
-                curFocus = planet.focus
-                newFoci[pid] = PFocus
-                result = 0
-                if curFocus != PFocus:
-                    result = fo.issueChangeFocusOrder(pid, PFocus)
-                    if result == 1:
-                        print ("Tried setting %s for planet %s (%d) with species %s and current focus %s, got result %d and focus %s" %
-                               (newFoci[pid], planet.name, pid, planet.speciesName, curFocus, result, planet.focus))
-                        universe.updateMeterEstimates(empirePlanetIDs)
-                    if (result != 1) or planet.focus != PFocus:
-                        newplanet = universe.getPlanet(pid)
-                        print ("Error: Failed setting %s for planet %s (%d) with species %s and current focus %s, but new planet copy shows %s" %
-                               (newFoci[pid], planet.name, pid, planet.speciesName, planet.focus, newplanet.focus))
-                if curFocus == PFocus or result == 1:
-                    print "%s focus of planet %s (%d) at Protection(Defense) Focus" % (["set", "left"][curFocus == PFocus], planet.name, pid)
-                    if pid in empirePlanetIDs:
-                        del empirePlanetIDs[empirePlanetIDs.index(pid)]
-                    continue
+        set_planet_protection_foci(empirePlanetIDs, newFoci)
 
-        print "\n-----------------------------------------"
-        print "Making Planet Focus Change Determinations\n"
+        set_planet_happiness_foci()
 
-        ratios = []
-        # for each planet, calculate RP:PP value ratio at which industry/Mining focus and research focus would have the same total value, & sort by that
-        # include a bias to slightly discourage changing foci
-        curTargetPP = 0.001
-        curTargetRP = 0.001
-        resource_timer.start("Loop")  # loop
-        has_force = tech_is_complete("CON_FRC_ENRG_STRC")
         preset_ids = set(planetMap.keys()) - set(empirePlanetIDs)
-        ctPP0, ctRP0 = 0, 0
-        for pid in preset_ids:
-            nPP, nRP = newTargets.get(pid, {}).get(planetMap[pid].focus, [0, 0])
-            curTargetPP += nPP
-            curTargetRP += nRP
-            iPP, iRP = newTargets.get(pid, {}).get(IFocus, [0, 0])
-            ctPP0 += iPP
-            ctRP0 += iRP
+        ctPP0, ctRP0, curTargetPP, curTargetRP = set_planet_industry_and_research_foci(empirePlanetIDs, newFoci, priorityRatio, preset_ids)
 
-        id_set = set(empirePlanetIDs)
-        for adj_round in [1, 2, 3, 4]:
-            maxi_ratio = ctRP0 / max(0.01, ctPP0)  # should only change between rounds 1 and 2
-            for pid in list(id_set):
-                if adj_round == 1:  # tally max Industry
-                    iPP, iRP = newTargets.get(pid, {}).get(IFocus, [0, 0])
-                    ctPP0 += iPP
-                    ctRP0 += iRP
-                    continue
-                II, IR = newTargets[pid][IFocus]
-                RI, RR = newTargets[pid][RFocus]
-                CI, CR = currentOutput[pid][IFocus], currentOutput[pid][RFocus]
-                research_penalty = (currentFocus[pid] != RFocus)
-                # calculate factor F at which II + F * IR == RI + F * RR =====> F = ( II-RI ) / (RR-IR)
-                thisFactor = (II - RI) / max(0.01, RR - IR)  # don't let denominator be zero for planets where focus doesn't change RP
-                planet = planetMap[pid]
-                if adj_round == 2:  # take research at planets with very cheap research
-                    if (maxi_ratio < priorityRatio) and (curTargetRP < priorityRatio * ctPP0) and (thisFactor <= 1.0):
-                        curTargetPP += RI
-                        curTargetRP += RR
-                        newFoci[pid] = RFocus
-                        id_set.discard(pid)
-                    continue
-                if adj_round == 3:  # take research at planets where can do reasonable balance
-                    if has_force or (foAI.foAIstate.aggression < fo.aggression.aggressive) or (curTargetRP >= priorityRatio * ctPP0):
-                        continue
-                    pop = planet.currentMeterValue(fo.meterType.population)
-                    t_pop = planet.currentMeterValue(fo.meterType.targetPopulation)
-                    # if AI is aggressive+, and this planet in range where temporary Research focus can get an additional RP at cost of 1 PP, and still need some RP, then do it
-                    if pop < t_pop - 5:
-                        continue
-                    if (CI > II + 8) or (((RR > II) or ((RR - CR) >= 1 + 2 * research_penalty)) and ((RR - IR) >= 3) and ((CR - IR) >= 0.7 * ((II - CI) * (1 + 0.1 * research_penalty)))):
-                        curTargetPP += CI - 1 - research_penalty
-                        curTargetRP += CR + 1
-                        newFoci[pid] = RFocus
-                        id_set.discard(pid)
-                    continue
-                # adj_round == 4 assume default IFocus
-                curTargetPP += II  # icurTargets initially calculated by Industry focus, which will be our default focus
-                curTargetRP += IR
-                newFoci[pid] = IFocus
-                ratios.append((thisFactor, pid))
-
-        ratios.sort()
-        printedHeader = False
-        fociMap = {IFocus: "Industry", RFocus: "Research", MFocus: "Mining", GFocus: "Growth", PFocus: "Defense"}
-        gotAlgo = tech_is_complete("LRN_ALGO_ELEGANCE")
-        for ratio, pid in ratios:
-            do_research = False  # (newFoci[pid]==RFocus)
-            if (priorityRatio < (curTargetRP / (curTargetPP + 0.0001))) and not do_research:  # we have enough RP
-                if ratio < 1.1 and foAI.foAIstate.aggression > fo.aggression.cautious:  # but wait, RP is still super cheap relative to PP, maybe will take more RP
-                    if priorityRatio < 1.5 * (curTargetRP / (curTargetPP + 0.0001)):  # yeah, really a glut of RP, stop taking RP
-                        break
-                else:  # RP not super cheap & we have enough, stop taking it
-                    break
-            II, IR = newTargets[pid][IFocus]
-            RI, RR = newTargets[pid][RFocus]
-            # if currentFocus[pid] == MFocus:
-            # II = max( II, newTargets[pid][MFocus][0] )
-            if (not do_research and (
-                   (ratio > 2.0 and curTargetPP < 15 and gotAlgo) or
-                   (ratio > 2.5 and curTargetPP < 25 and II > 5 and gotAlgo) or
-                   (ratio > 3.0 and curTargetPP < 40 and II > 5 and gotAlgo) or
-                   (ratio > 4.0 and curTargetPP < 100 and II > 10) or
-                   ((curTargetRP + RR - IR) / max(0.001, curTargetPP - II + RI) > 2 * priorityRatio))):  # we already have algo elegance and more RP would be too expensive, or overkill
-                if not printedHeader:
-                    printedHeader = True
-                    print "Rejecting further Research Focus choices as too expensive:"
-                    print "%34s|%20s|%15s |%15s|%15s |%15s |%15s" % ("                      Planet ", " current RP/PP ", " current target RP/PP ", "current Focus ", "  rejectedFocus ", " rejected target RP/PP ", "rejected RP-PP EQF")
-                    oldFocus = currentFocus[pid]
-                    cPP, cRP = currentOutput[pid][IFocus], currentOutput[pid][RFocus]
-                    otPP, otRP = newTargets[pid].get(oldFocus, (0, 0))
-                    ntPP, ntRP = newTargets[pid].get(RFocus, (0, 0))
-                    print "pID (%3d) %22s | c: %5.1f / %5.1f | cT: %5.1f / %5.1f |  cF: %8s | nF: %8s | cT: %5.1f / %5.1f | %.2f" % (pid, planetMap[pid].name, cRP, cPP, otRP, otPP, fociMap.get(oldFocus, 'unknown'), fociMap[RFocus], ntRP, ntPP, ratio)
-                    continue  # RP is getting too expensive, but might be willing to still allocate from a planet with less PP to lose
-            # if planetMap[pid].currentMeterValue(fo.meterType.targetPopulation) >0: #only set to research if pop won't die out
-            newFoci[pid] = RFocus
-            curTargetRP += (RR - IR)
-            curTargetPP -= (II - RI)
         print "============================"
         print "Planet Focus Assignments to achieve target RP/PP ratio of %.2f from current ratio of %.2f ( %.1f / %.1f )" % (priorityRatio, rp / (pp + 0.0001), rp, pp)
         print "Max Industry assignments would result in target RP/PP ratio of %.2f ( %.1f / %.1f )" % (ctRP0 / (ctPP0 + 0.0001), ctRP0, ctPP0)


### PR DESCRIPTION
This PR is a major refactor of ResourcesAI.py. 

I was trying to determine why the AI appears to be precessing around a threshold when toggling between research and industry focus every third turn.  It turns out adj_round 3 intentionally trades 3 industry points for 1 research point when targeting low a research/industry ratio.

The PR fixes one small bug preventing more than one high industry planet from being prevented from switching to research and otherwise doesn't intentionally change any logic.

The refactor is mostly of three parts.
1.   Rewrote set_planet_resource_foci into a function that calls 5 sub-functions: use_planet_growth_specials, use_planet_production_and_research_specials, set_planet_protection_foci, set_planet_happiness_foci (,a placeholder) and set_planet_industry_and_research_foci.  They all do the obvious duty in the same manner as before.  They do not access any non-local variables other than fo, the freeorion global.
2.  Replaced the file scope variables new_targets, current_focus, current_output  and planet_map with a focus_manager.  The focus_manager includes planet info for each planet encompassing the previous variables.  focus_manager manages all updating or changes of state of the focus setting.  Most significantly focus_manager uses bake_future_focus to change a planet's status from raw to baked as its focus is set.  Previously, the behavior was implicit and if a planet was set, but not removed from the list it would be overwritten later.  All setting happens in this one function as opposed to throughout the file.
3.  Moved all reporting into a Reporter object.  The reporter.capture_section_info is called after each stage of the set_planet_resource_foci to capture the information to make table sections: Unfocusable, Specials, Protection, Happiness and Typical.

I think the refactored code is clearer to read.
The code is more local in scope and hence easier to modify in future. 
