### PR TITLE
Add some support for freedesktop XDG Base Directory Specification

### DIFF
--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -116,7 +116,7 @@ namespace {
 
     const std::string DESIGN_FILENAME_EXTENSION = ".txt";
     const std::string UNABLE_TO_OPEN_FILE = "Unable to open file";
-    boost::filesystem::path SavedDesignsDir() { return GetUserDir() / "shipdesigns"; }
+    boost::filesystem::path SavedDesignsDir() { return GetUserDataDir() / "shipdesigns"; }
 
     class SavedDesignsManager {
     public:

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -609,7 +609,7 @@ OptionsWnd::OptionsWnd():
     // Directories tab
     current_page = CreatePage(UserString("OPTIONS_PAGE_DIRECTORIES"));
     DirectoryOption(current_page, 0, "resource-dir", UserString("OPTIONS_FOLDER_SETTINGS"), GetRootDataDir());  // GetRootDataDir() returns the default browse path when modifying this directory option.  the actual default directory (before modifying) is gotten from the specified option name "resource-dir"
-    DirectoryOption(current_page, 0, "save-dir",     UserString("OPTIONS_FOLDER_SAVE"),     GetUserDir());
+    DirectoryOption(current_page, 0, "save-dir",     UserString("OPTIONS_FOLDER_SAVE"),     GetUserDataDir());
     m_tabs->SetCurrentWnd(0);
 
     // Misc

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -37,7 +37,7 @@ AIClientApp::AIClientApp(const std::vector<std::string>& args) :
     // read command line args
 
     m_player_name = args.at(1);
-    const std::string AICLIENT_LOG_FILENAME((GetUserDir() / (m_player_name + ".log")).string());
+    const std::string AICLIENT_LOG_FILENAME((GetUserDataDir() / (m_player_name + ".log")).string());
     if (args.size() >=3) {
         m_max_aggression = boost::lexical_cast<int>(args.at(2));
     }

--- a/client/AI/camain.cpp
+++ b/client/AI/camain.cpp
@@ -30,6 +30,8 @@ int wmain(int argc, wchar_t* argv[], wchar_t* envp[]) {
 #endif
 
     try {
+        // TODO Code combining config, persistent_config and commandline args is copy-pasted
+        // slightly differently in chmain, dmain and camain.  Make it into a single function.
         XMLDoc doc;
         {
             boost::filesystem::ifstream ifs(GetConfigPath());

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -203,7 +203,7 @@ HumanClientApp::HumanClientApp(int width, int height, bool calculate_fps, const 
 #endif
     m_fsm = new HumanClientFSM(*this);
 
-    const std::string HUMAN_CLIENT_LOG_FILENAME((GetUserDir() / "freeorion.log").string());
+    const std::string HUMAN_CLIENT_LOG_FILENAME((GetUserDataDir() / "freeorion.log").string());
 
     InitLogger(HUMAN_CLIENT_LOG_FILENAME, "Client");
 

--- a/client/human/chmain.cpp
+++ b/client/human/chmain.cpp
@@ -114,6 +114,9 @@ int mainConfigOptionsSetup(const std::vector<std::string>& args) {
         Hotkey::AddOptions(GetOptionsDB());
 
 
+        // TODO Code combining config, persistent_config and commandline args is copy-pasted
+        // slightly differently in chmain, dmain and camain.  Make it into a single function.
+
         // read config.xml and set options entries from it, if present
         {
             XMLDoc doc;
@@ -147,6 +150,7 @@ int mainConfigOptionsSetup(const std::vector<std::string>& args) {
         // override previously-saved and default options with command line parameters and flags
         GetOptionsDB().SetFromCommandLine(args);
 
+        CompleteXDGMigration();
 
         // Handle the case where the resource-dir does not exist anymore
         // gracefully by resetting it to the standard path into the

--- a/default/AI/FreeOrionAI.py
+++ b/default/AI/FreeOrionAI.py
@@ -60,7 +60,7 @@ def initFreeOrionAI():  # pylint: disable=invalid-name
     """Called by client when Python AI starts, before any game new game starts or saved game is resumed."""
     ai_config = fo.getAIConfigStr()
     print "Initialized FreeOrion Python AI with ai_config string '%s'" % ai_config
-    user_dir = fo.getUserDir()
+    user_dir = fo.getUserDataDir()
     print "Path to folder for user specific data: %s" % user_dir
     print(sys.path)
 

--- a/default/AI/charting/charts.py
+++ b/default/AI/charting/charts.py
@@ -20,7 +20,7 @@ import sys
 from glob import glob
 import traceback
 
-dataDir = os.environ.get('HOME', "") + "/.freeorion"
+dataDir = (os.environ.get('HOME', "") + "/.freeorion" ) if os.name != 'posix' else (os.environ.get('XDG_DATA_HOME', os.environ.get('HOME', "") + "/.local/share") + "/freeorion") 
 graphDir = dataDir
 
 fileRoot = "game1"

--- a/default/AI/freeorion_debug/ide_tools/parse_docs.py
+++ b/default/AI/freeorion_debug/ide_tools/parse_docs.py
@@ -200,14 +200,14 @@ if __name__ == '__main__':
     # example1 = """__delitem__( (IntBoolMap)arg1, (object)arg2) -> None"""
     example1 = """getEmpire() -> empire\n\ngetEmpire((int)star_name, (int)arg2, (int)arg3) -> empire"""
 
-    # example1 = ("""getUserDir() -> str :\n
-    #     Returns path to directory where FreeOrion stores user specific data (config files, saves, etc.).
+    # example1 = ("""getUserDataDir() -> str :\n
+    #     Returns path to directory where FreeOrion stores user specific data (saves, etc.).
     #
-    #     getUserDir((int)args1) -> str :\n
+    #     getUserDataDir((int)args1) -> str :\n
     #         Unicorns.
     #     """)
     #
-    # example1 = """getUserDir() -> str :\n    Returns path to directory where FreeOrion stores user specific data (config files, saves, etc.)."""
+    # example1 = """getUserDataDir() -> str :\n    Returns path to directory where FreeOrion stores user specific data (config files, saves, etc.)."""
 
     info = Docs(example1, 1)
     print "=" * 100

--- a/default/AI/freeorion_debug/ide_tools/result/freeOrionAIInterface.py
+++ b/default/AI/freeorion_debug/ide_tools/result/freeOrionAIInterface.py
@@ -3242,9 +3242,9 @@ def getUniverse():
     return universe()
 
 
-def getUserDir():
+def getUserDataDir():
     """
-    Returns path to directory where FreeOrion stores user specific data (config files, saves, etc.).
+    Returns path to directory where FreeOrion stores user specific data (saves, etc.).
 
     :rtype: str
     """

--- a/python/AI/AIWrapper.cpp
+++ b/python/AI/AIWrapper.cpp
@@ -83,8 +83,11 @@ namespace {
         return ret_list;
     }
 
-    boost::python::str GetUserDirWrapper()
-    { return boost::python::str(PathString(GetUserDir())); }
+    boost::python::str GetUserConfigDirWrapper()
+    { return boost::python::str(PathString(GetUserConfigDir())); }
+
+    boost::python::str GetUserDataDirWrapper()
+    { return boost::python::str(PathString(GetUserDataDir())); }
 
 }
 
@@ -135,7 +138,8 @@ namespace FreeOrionPython {
 
         def("getAIConfigStr",           AIInterface::GetAIConfigStr,    return_value_policy<return_by_value>());
         def("getAIDir",                 AIInterface::GetAIDir,          return_value_policy<return_by_value>());
-        def("getUserDir",               GetUserDirWrapper,              /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific data (config files, saves, etc.).");
+        def("getUserConfigDir",         GetUserConfigDirWrapper,        /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific configuration.");
+        def("getUserDataDir",           GetUserDataDirWrapper,          /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific data (saves, etc.).");
 
         def("initMeterEstimatesDiscrepancies",      AIInterface::InitMeterEstimatesAndDiscrepancies);
         def("updateMeterEstimates",                 AIInterface::UpdateMeterEstimates);

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -139,7 +139,7 @@ ServerApp::ServerApp() :
     m_current_turn(INVALID_GAME_TURN),
     m_single_player_game(false)
 {
-    const std::string SERVER_LOG_FILENAME((GetUserDir() / "freeoriond.log").string());
+    const std::string SERVER_LOG_FILENAME((GetUserDataDir() / "freeoriond.log").string());
 
     InitLogger(SERVER_LOG_FILENAME, "Server");
 

--- a/server/dmain.cpp
+++ b/server/dmain.cpp
@@ -33,6 +33,9 @@ int wmain(int argc, wchar_t* argv[], wchar_t* envp[]) {
     try {
         GetOptionsDB().AddFlag('h', "help", "Print this help message.");
 
+        // TODO Code combining config, persistent_config and commandline args is copy-pasted
+        // slightly differently in chmain, dmain and camain.  Make it into a single function.
+
         // read config.xml and set options entries from it, if present
         XMLDoc doc;
         {

--- a/util/Directories.cpp
+++ b/util/Directories.cpp
@@ -100,7 +100,13 @@ void InitDirs(const std::string& argv0) {
     g_initialized = true;
 }
 
-const fs::path GetUserDir() {
+const fs::path GetUserConfigDir() {
+    if (!g_initialized)
+        InitDirs("");
+    return s_user_dir;
+}
+
+const fs::path GetUserDataDir() {
     if (!g_initialized)
         InitDirs("");
     return s_user_dir;
@@ -143,7 +149,12 @@ void InitDirs(const std::string& argv0) {
 
     br_init(0);
 
-    fs::path p = GetUserDir();
+    fs::path cp = GetUserConfigDir();
+    if (!exists(cp)) {
+        fs::create_directories(cp);
+    }
+
+    fs::path p = GetUserDataDir();
     if (!exists(p)) {
         fs::create_directories(p);
     }
@@ -158,8 +169,17 @@ void InitDirs(const std::string& argv0) {
     g_initialized = true;
 }
 
-const fs::path GetUserDir() {
-    static fs::path p = fs::path(getenv("HOME")) / ".freeorion";
+const fs::path GetUserConfigDir() {
+    static fs::path p = getenv("XDG_CONFIG_HOME")
+        ? fs::path(getenv("XDG_CONFIG_HOME")) / "freeorion"
+        : fs::path(getenv("HOME")) / ".config" / "freeorion";
+    return p;
+}
+
+const fs::path GetUserDataDir() {
+    static fs::path p = getenv("XDG_DATA_HOME")
+        ? fs::path(getenv("XDG_DATA_HOME")) / "freeorion"
+        : fs::path(getenv("HOME")) / ".local" / "share" / "freeorion";
     return p;
 }
 
@@ -241,7 +261,7 @@ void InitDirs(const std::string& argv0) {
     if (g_initialized)
         return;
 
-    fs::path local_dir = GetUserDir();
+    fs::path local_dir = GetUserConfigDir();
     if (!exists(local_dir))
         fs::create_directories(local_dir);
 
@@ -254,7 +274,12 @@ void InitDirs(const std::string& argv0) {
     g_initialized = true;
 }
 
-const fs::path GetUserDir() {
+const fs::path GetUserConfigDir() {
+    static fs::path p = fs::path(std::wstring(_wgetenv(L"APPDATA"))) / "FreeOrion";
+    return p;
+}
+
+const fs::path GetUserDataDir() {
     static fs::path p = fs::path(std::wstring(_wgetenv(L"APPDATA"))) / "FreeOrion";
     return p;
 }
@@ -299,12 +324,12 @@ const fs::path GetResourceDir() {
 }
 
 const fs::path GetConfigPath() {
-    static const fs::path p = GetUserDir() / "config.xml";
+    static const fs::path p = GetUserConfigDir() / "config.xml";
     return p;
 }
 
 const fs::path GetPersistentConfigPath() {
-    static const fs::path p = GetUserDir() / "persistent_config.xml";
+    static const fs::path p = GetUserConfigDir() / "persistent_config.xml";
     return p;
 }
 

--- a/util/Directories.h
+++ b/util/Directories.h
@@ -11,14 +11,26 @@
   * directories if they do not yet exist. */
 FO_COMMON_API void InitDirs(const std::string& argv0);
 
-/** Returns the directory where FreeOrion should store user specific data, like
-  * the configuration file and savegames.  Under Unix, this would be
-  * <tt>~/.freeorion</tt>, under Windows, this might be something along the
-  * lines of <tt>C:\\Documents and Settings\\Username\\FreeOrion</tt>
+/** Returns the directory where FreeOrion should store user specific
+  * configuration data , like the configuration file.  Under Unix, this
+  * would be <tt>$XDG_CONFIG_HOME/freeorion</tt>, under Windows, this
+  * might be something along the lines of
+  * <tt>C:\\Documents and Settings\\Username\\FreeOrion</tt>
   * or even <tt>\\\\Gandalf\\Users\\Frodo\\Settings\\FreeOrion</tt>.
   * \note <ul><li> If the directory does not exist, it will be created.
-  * <li>This directory is the only one that can be considered writable!</ul> */
-FO_COMMON_API const boost::filesystem::path GetUserDir();
+  * Under Windows and OSX it is the same as the GetUserDataDir()
+  * <li>This directory can be considered writable!</ul> */
+FO_COMMON_API const boost::filesystem::path GetUserConfigDir();
+
+/** Returns the directory where FreeOrion should store user specific data,
+  * like the savegames.  Under Unix, this would be
+  * <tt>$XDG_DATA_HOME/freeorion</tt>, under Windows, this might be something
+  * along the lines of <tt>C:\\Documents and Settings\\Username\\FreeOrion</tt>
+  * or even <tt>\\\\Gandalf\\Users\\Frodo\\Settings\\FreeOrion</tt>.
+  * \note <ul><li> If the directory does not exist, it will be created.
+  * Under Windows and OSX it is the same as the GetUserConfigDir()
+  * <li>This directory can be considered writable!</ul> */
+FO_COMMON_API const boost::filesystem::path GetUserDataDir();
 
 /** Converts UTF-8 string into a path, doing any required wide-character
   * conversions as determined by the operating system / filesystem. */

--- a/util/Directories.h
+++ b/util/Directories.h
@@ -9,6 +9,12 @@
 /** This function must be called before any Get*Dir function is called. It
   * stores the current working directory as well as creating local
   * directories if they do not yet exist. */
+FO_COMMON_API void CompleteXDGMigration();
+
+/** This function completes the migration of directories to the XDG
+  * specified location by updating the save-dir option to the new location
+  * after the option is loaded from XML files.  It only updates the option
+  * if it is set to the old default option. */
 FO_COMMON_API void InitDirs(const std::string& argv0);
 
 /** Returns the directory where FreeOrion should store user specific

--- a/util/MultiplayerCommon.cpp
+++ b/util/MultiplayerCommon.cpp
@@ -30,7 +30,7 @@ namespace {
     // command-line options
     void AddOptions(OptionsDB& db) {
         db.Add<std::string>("resource-dir",         UserStringNop("OPTIONS_DB_RESOURCE_DIR"),          PathString(GetRootDataDir() / "default"));
-        db.Add<std::string>('S', "save-dir",        UserStringNop("OPTIONS_DB_SAVE_DIR"),              PathString(GetUserDir() / "save"));
+        db.Add<std::string>('S', "save-dir",        UserStringNop("OPTIONS_DB_SAVE_DIR"),              PathString(GetUserDataDir() / "save"));
         db.Add<std::string>("log-level",            UserStringNop("OPTIONS_DB_LOG_LEVEL"),             "DEBUG");
         db.Add<std::string>("stringtable-filename", UserStringNop("OPTIONS_DB_STRINGTABLE_FILENAME"),  PathString(GetRootDataDir() / "default" / "stringtables" / "en.txt"));
         db.Add("binary-serialization",              UserStringNop("OPTIONS_DB_BINARY_SERIALIZATION"),  false);


### PR DESCRIPTION
The XDG Base Directory Specification is at
https://specifications.freedesktop.org/basedir-spec/basedir-spec-
latest.html

It requires that configuration files be stored in
$XDG_CONFIG_HOME/freeorion which defaults to
$HOME/.local/share/freeorion

It requires that user app data be stored in
$XDG_DATA_HOME/freeorion which defaults to
$HOME/.config/freeorion

This commit splits GetUserDir() into GetUserConfigDir() and
GetUserDataDir().  On linux and BSD they return the correct XDG
directories.  On Windows and OSX they return the same directory
as GetUserDir() before this commit.

This commit does not support XDG_DATA_DIRS, XDG_CONFIG_DIRS,
XDG_CACHE_HOME or XDG_RUNTIME_DIRS.

This does not break saves/configs, but if you do not move them to the new location 
or set the save dir to your old location you will not see them.
