### PR TITLE
AI config file rename and relocation

### DIFF
--- a/default/AI/freeorion_debug/option_tools.py
+++ b/default/AI/freeorion_debug/option_tools.py
@@ -2,11 +2,12 @@ import os
 from ConfigParser import SafeConfigParser
 from collections import OrderedDict as odict
 import platform
+import sys
 
 try:
     import freeOrionAIInterface as fo  # pylint: disable=import-error
 except ImportError:
-    print ("Executing outside of FreeOrion.")
+    sys.stderr.write("Executing outside of FreeOrion.")
 
 
 AI_SUB_DIR = 'AI'
@@ -61,7 +62,7 @@ def _parse_options():
         try:
             config = _create_default_config_file(default_file)
         except IOError:
-            print ("AI Config: default file is not present and not writable at location %s\n" % default_file)
+            sys.stderr.write("AI Config: default file is not present and not writable at location %s\n" % default_file)
             config = _create_default_config_file(os.path.join(fo.getUserDir(), CONFIG_DEFAULT_FILE))
 
     option_file = _get_option_file()
@@ -72,10 +73,10 @@ def _parse_options():
     if option_file:
         config_files = [option_file]
         configs_read = config.read(config_files)
-        print ("AI Config read config file(s): %s" % configs_read)
+        print "AI Config read config file(s): %s" % configs_read
         if len(configs_read) != len(config_files):
-            print ("AI Config Error; could NOT read config file(s): %s"
-                   % list(set(config_files).difference(configs_read)))
+            sys.stderr.write("AI Config Error; could NOT read config file(s): %s"
+                             % list(set(config_files).difference(configs_read)))
     for section in config.sections():
         sectioned_options.setdefault(section, odict())
         for k, v in config.items(section):
@@ -98,7 +99,7 @@ def _get_default_file_path():
         if os.path.isdir(fo.getUserDir()) and not os.path.isdir(CONFIG_DEFAULT_DIR):
             os.makedirs(CONFIG_DEFAULT_DIR)
     except OSError:
-        print ("AI Config Error: could not create path %s" % CONFIG_DEFAULT_DIR)
+        sys.stderr.write("AI Config Error: could not create path %s" % CONFIG_DEFAULT_DIR)
         return fo.getUserDir()
 
     return CONFIG_DEFAULT_DIR
@@ -137,9 +138,6 @@ def _create_default_config_file(path):
     if path:
         with open(path, 'w') as configfile:
             config.write(configfile)
-        print ("default config is dumped to %s" % path)
+        print "default config is dumped to %s" % path
     return config
 
-
-if __name__ == '__main__':
-    _create_default_config_file(_get_option_file())

--- a/default/AI/freeorion_debug/option_tools.py
+++ b/default/AI/freeorion_debug/option_tools.py
@@ -7,7 +7,7 @@ import sys
 try:
     import freeOrionAIInterface as fo  # pylint: disable=import-error
 except ImportError:
-    sys.stderr.write("Executing outside of FreeOrion.")
+    sys.stderr.write("Executing outside of FreeOrion.\n")
 
 
 AI_SUB_DIR = 'AI'
@@ -75,7 +75,7 @@ def _parse_options():
         configs_read = config.read(config_files)
         print "AI Config read config file(s): %s" % configs_read
         if len(configs_read) != len(config_files):
-            sys.stderr.write("AI Config Error; could NOT read config file(s): %s"
+            sys.stderr.write("AI Config Error; could NOT read config file(s): %s\n"
                              % list(set(config_files).difference(configs_read)))
     for section in config.sections():
         sectioned_options.setdefault(section, odict())
@@ -99,7 +99,7 @@ def _get_default_file_path():
         if os.path.isdir(fo.getUserConfigDir()) and not os.path.isdir(CONFIG_DEFAULT_DIR):
             os.makedirs(CONFIG_DEFAULT_DIR)
     except OSError:
-        sys.stderr.write("AI Config Error: could not create path %s" % CONFIG_DEFAULT_DIR)
+        sys.stderr.write("AI Config Error: could not create path %s\n" % CONFIG_DEFAULT_DIR)
         return fo.getUserConfigDir()
 
     return CONFIG_DEFAULT_DIR

--- a/default/AI/freeorion_debug/option_tools.py
+++ b/default/AI/freeorion_debug/option_tools.py
@@ -6,10 +6,13 @@ import platform
 try:
     import freeOrionAIInterface as fo  # pylint: disable=import-error
 except ImportError:
-    print "Executing outside of FreeOrion."
+    print ("Executing outside of FreeOrion.")
 
 
-DEFAULT_CONFIG_FILE = 'default_config.ini'
+AI_SUB_DIR = 'AI'
+DEFAULT_SUB_DIR = os.path.join(AI_SUB_DIR, 'default')
+CONFIG_DEFAULT_DIR = os.path.join(fo.getUserDir(), DEFAULT_SUB_DIR)
+CONFIG_DEFAULT_FILE = 'config.ini'
 
 # CONFIG KEYS
 TIMER_SECTION = 'Timers'
@@ -29,9 +32,9 @@ def check_bool(option):
 def get_option_dict():
     """
     Return options for AI
-    :return: ordered dict of options 
+    :return: ordered dict of options
     """
-    
+
     if not flat_options:
         _parse_options()
     return flat_options
@@ -42,7 +45,7 @@ def get_sectioned_option_dict():
     Return options for AI
     :return: ordered dict of ordered dicts of options
     """
-    
+
     if not sectioned_options:
         _parse_options()
     return sectioned_options
@@ -50,30 +53,29 @@ def get_sectioned_option_dict():
 
 def _parse_options():
     # get defaults; check if don't already exist and can write
-    default_file = _get_default_file_path()
+    default_file = _get_option_file()
     if os.path.exists(default_file):
         config = SafeConfigParser()
         config.read([default_file])
     else:
-        if platform.system() != "Linux":
-            default_file = ""
         try:
             config = _create_default_config_file(default_file)
         except IOError:
-            print "AI Config: default file is not present and not writable at location %s" % default_file
-            config = _create_default_config_file("")
+            print ("AI Config: default file is not present and not writable at location %s\n" % default_file)
+            config = _create_default_config_file(os.path.join(fo.getUserDir(), CONFIG_DEFAULT_FILE))
 
-    option_path = _get_option_file_path()
+    option_file = _get_option_file()
     # if not os.path.exists(option_path):
     #    raise Exception('Error, option path "%s" does not exists.' % option_path)
 
     # read the defaults and then the specified config path
-    if option_path:
-        config_files = [option_path]
+    if option_file:
+        config_files = [option_file]
         configs_read = config.read(config_files)
-        print "AI Config read config file(s): %s" % configs_read
+        print ("AI Config read config file(s): %s" % configs_read)
         if len(configs_read) != len(config_files):
-            print "AI Config Error; could NOT read config file(s): %s" % list(set(config_files).difference(configs_read))
+            print ("AI Config Error; could NOT read config file(s): %s"
+                   % list(set(config_files).difference(configs_read)))
     for section in config.sections():
         sectioned_options.setdefault(section, odict())
         for k, v in config.items(section):
@@ -81,10 +83,10 @@ def _parse_options():
             sectioned_options[section][k] = v
 
 
-def _get_option_file_path():
+def _get_option_file():
     # hack to allow lunch this code separately to dump default config
-    ai_path = fo.getAIDir()
-    option_file = fo.getAIConfigStr()
+    ai_path = _get_default_file_path()
+    option_file = CONFIG_DEFAULT_FILE
     if ai_path and option_file:
         return os.path.join(ai_path, option_file)
     else:
@@ -92,8 +94,14 @@ def _get_option_file_path():
 
 
 def _get_default_file_path():
-    # TODO: determine more robust treatment in case ResourceDir is not writable by user
-    return os.path.join(fo.getAIDir() or ".", DEFAULT_CONFIG_FILE)
+    try:
+        if os.path.isdir(fo.getUserDir()) and not os.path.isdir(CONFIG_DEFAULT_DIR):
+            os.makedirs(CONFIG_DEFAULT_DIR)
+    except OSError:
+        print ("AI Config Error: could not create path %s" % CONFIG_DEFAULT_DIR)
+        return fo.getUserDir()
+
+    return CONFIG_DEFAULT_DIR
 
 
 def _get_preset_default_ai_options():
@@ -129,9 +137,9 @@ def _create_default_config_file(path):
     if path:
         with open(path, 'w') as configfile:
             config.write(configfile)
-        print "default config is dumped to %s" % path
+        print ("default config is dumped to %s" % path)
     return config
 
 
 if __name__ == '__main__':
-    _create_default_config_file(_get_default_file_path())
+    _create_default_config_file(_get_option_file())

--- a/default/AI/freeorion_debug/option_tools.py
+++ b/default/AI/freeorion_debug/option_tools.py
@@ -12,7 +12,7 @@ except ImportError:
 
 AI_SUB_DIR = 'AI'
 DEFAULT_SUB_DIR = os.path.join(AI_SUB_DIR, 'default')
-CONFIG_DEFAULT_DIR = os.path.join(fo.getUserDir(), DEFAULT_SUB_DIR)
+CONFIG_DEFAULT_DIR = os.path.join(fo.getUserConfigDir(), DEFAULT_SUB_DIR)
 CONFIG_DEFAULT_FILE = 'config.ini'
 
 # CONFIG KEYS
@@ -63,7 +63,7 @@ def _parse_options():
             config = _create_default_config_file(default_file)
         except IOError:
             sys.stderr.write("AI Config: default file is not present and not writable at location %s\n" % default_file)
-            config = _create_default_config_file(os.path.join(fo.getUserDir(), CONFIG_DEFAULT_FILE))
+            config = _create_default_config_file(os.path.join(fo.getUserConfigDir(), CONFIG_DEFAULT_FILE))
 
     option_file = _get_option_file()
     # if not os.path.exists(option_path):
@@ -96,11 +96,11 @@ def _get_option_file():
 
 def _get_default_file_path():
     try:
-        if os.path.isdir(fo.getUserDir()) and not os.path.isdir(CONFIG_DEFAULT_DIR):
+        if os.path.isdir(fo.getUserConfigDir()) and not os.path.isdir(CONFIG_DEFAULT_DIR):
             os.makedirs(CONFIG_DEFAULT_DIR)
     except OSError:
         sys.stderr.write("AI Config Error: could not create path %s" % CONFIG_DEFAULT_DIR)
-        return fo.getUserDir()
+        return fo.getUserConfigDir()
 
     return CONFIG_DEFAULT_DIR
 

--- a/default/AI/freeorion_debug/timers.py
+++ b/default/AI/freeorion_debug/timers.py
@@ -1,7 +1,7 @@
 import os
 import freeOrionAIInterface as fo
 from time import time
-from option_tools import get_option_dict, check_bool, _get_default_file_path
+from option_tools import get_option_dict, check_bool, DEFAULT_SUB_DIR
 from option_tools import TIMERS_TO_FILE, TIMERS_USE_TIMERS, TIMERS_DUMP_FOLDER
 import sys
 
@@ -10,7 +10,7 @@ options = get_option_dict()
 
 USE_TIMERS = check_bool(options[TIMERS_USE_TIMERS])
 DUMP_TO_FILE = check_bool(options[TIMERS_TO_FILE])
-TIMERS_DIR = os.path.join(_get_default_file_path(), options[TIMERS_DUMP_FOLDER])
+TIMERS_DIR = os.path.join(fo.getUserDataDir(), DEFAULT_SUB_DIR, options[TIMERS_DUMP_FOLDER])
 
 
 def make_header(*args):
@@ -19,7 +19,7 @@ def make_header(*args):
 
 def _get_timers_dir():
     try:
-        if os.path.isdir(fo.getUserDir()) and not os.path.isdir(TIMERS_DIR):
+        if os.path.isdir(fo.getUserDataDir()) and not os.path.isdir(TIMERS_DIR):
             os.makedirs(TIMERS_DIR)
     except OSError:
         sys.stderr.write("AI Config Error: could not create path %s" % TIMERS_DIR)

--- a/default/AI/freeorion_debug/timers.py
+++ b/default/AI/freeorion_debug/timers.py
@@ -3,6 +3,7 @@ import freeOrionAIInterface as fo
 from time import time
 from option_tools import get_option_dict, check_bool, _get_default_file_path
 from option_tools import TIMERS_TO_FILE, TIMERS_USE_TIMERS, TIMERS_DUMP_FOLDER
+import sys
 
 # setup module
 options = get_option_dict()
@@ -21,8 +22,8 @@ def _get_timers_dir():
         if os.path.isdir(fo.getUserDir()) and not os.path.isdir(TIMERS_DIR):
             os.makedirs(TIMERS_DIR)
     except OSError:
-        print ("AI Config Error: could not create path %s" % TIMERS_DIR)
-        return fo.getUserDir()
+        sys.stderr.write("AI Config Error: could not create path %s" % TIMERS_DIR)
+        return False
 
     return TIMERS_DIR
 
@@ -79,6 +80,8 @@ class LogTimer(object):
         self.start_time = time()
 
     def _write(self, text):
+        if not _get_timers_dir():
+            return
         if not self.log_name:
             empaire_id = fo.getEmpire().empireID - 1
             self.log_name = os.path.join(_get_timers_dir(), '%s-%02d.txt' % (self.timer_name, empaire_id))
@@ -101,11 +104,11 @@ class LogTimer(object):
         max_header = max(len(x[0]) for x in self.timers)
         line_max_size = max_header + 14
         print
-        print ('Timing for %s:' % self.timer_name)
-        print ('=' * line_max_size)
+        print 'Timing for %s:' % self.timer_name
+        print '=' * line_max_size
         for name, val in self.timers:
-            print ("%-*s %8d msec" % (max_header, name, val))
-        print ('-' * line_max_size)
+            print "%-*s %8d msec" % (max_header, name, val)
+        print '-' * line_max_size
         print ("Total: %8d msec" % sum(x[1] for x in self.timers)).rjust(line_max_size)
 
         if self.write_log and DUMP_TO_FILE:

--- a/default/AI/freeorion_debug/timers.py
+++ b/default/AI/freeorion_debug/timers.py
@@ -22,7 +22,7 @@ def _get_timers_dir():
         if os.path.isdir(fo.getUserDataDir()) and not os.path.isdir(TIMERS_DIR):
             os.makedirs(TIMERS_DIR)
     except OSError:
-        sys.stderr.write("AI Config Error: could not create path %s" % TIMERS_DIR)
+        sys.stderr.write("AI Config Error: could not create path %s\n" % TIMERS_DIR)
         return False
 
     return TIMERS_DIR

--- a/default/AI/freeorion_debug/timers.py
+++ b/default/AI/freeorion_debug/timers.py
@@ -104,7 +104,7 @@ class LogTimer(object):
         max_header = max(len(x[0]) for x in self.timers)
         line_max_size = max_header + 14
         print
-        print 'Timing for %s:' % self.timer_name
+        print ('Timing for %s:' % self.timer_name)
         print '=' * line_max_size
         for name, val in self.timers:
             print "%-*s %8d msec" % (max_header, name, val)


### PR DESCRIPTION
Issue #462 

Rename default AI config file to `config.ini`
Relocate file to `UserConfigDir() / "AI" / "default"`, create AI/default if not existing.

Relocate optional timer logs to `UserDataDir() / "AI' / "default"` directory, creating config specified sub-dir if needed.
