### PR TITLE
Add support for github contribution file, issue template and pull request template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,75 @@
+<!--
+Please fill in a a meaningful and concise issue title in the title field above.
+It helps us to classify the issue even  before reading the body and handling the
+issue a bit better.  Prefix the title with labels you find approciate to
+describe the issue like "[Bug]" in case of a bug, "[Feature]" for a feature
+request.
+
+Examples:
+  * Great: "[Bug] Unable to select fleet in galaxy map"
+  * Good: "[Bug] Unable to click fleet"
+  * Not really okay: "Issue with fleets"
+  * Horrible: "HELP!!!"
+-->
+
+
+### Environment
+<!--
+You don't need to provide the information in section when they are not useful in
+the context of this issue.  For example feature requests may not need a
+FreeOrion version, but maybe depend on the operating system you use.  When in
+doubt provide all information you have available.
+
+You can find the FreeOrion version number in the lower right corner of the game
+main screen.
+
+When stating the operating system also note the version of the operating system
+so, `Windows 8 Pro` instead of `Windows` or `Mac OSX Mountain Lion` instead of
+`OSX`.
+-->
+
+* **FreeOrion Version**:
+* **Operating System**:
+* **Graphic card used**:
+* **Fetched as**
+  * [ ] Binary release
+  * [ ] Compiled from source
+
+
+### Description
+<!--
+Add a meaningful description of the bug you encountered or of the feature you
+want to request.
+
+If a screenshot or image helps to describe the issue content feel free to create
+one.
+
+Also attach the log files the game creates.  The log files The log files can be
+found on
+* Windows: %APPDATA%\FreeOrion
+* MacOSX: ~/Library/"Application Support"/FreeOrion
+* Linux: ${XDG_DATA_HOME:-~/.local/share}/freeorion
+-->
+
+
+### Expected Result
+<!--
+If this issue is not a bug you can remove this section.
+
+When you enter an issue please add a description of what behaviour you would
+expect from the game instead of the issue.
+-->
+
+
+#### Steps to reproduce
+<!--
+If this issue is not a bug you can remove this section.
+
+If the error only manifests itself after doing a certain number of actions
+please add a list of steps to reproduce the bug.  If the error only occurs in
+a certain game state please be sure to add a save game to the issue.
+-->
+* First step.
+* Second step.
+* Another step.
+* Issue occurs.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# How to contribute to FreeOrion
+
+As an open source project FreeOrion both relies on contributions from long time
+developers and one time contributors.  This guide should help you to create
+contributions that can be easily integrated into the FreeOrion project.
+
+
+## I found an error in the game or I want to file a bug report
+
+So you stumbled on a reproducible error in FreeOrion?  You can report it in
+[FreeOrion Issues].  Please check before reporting the error if
+someone else has already posted it.  When creating a new issue you will see a
+template of required data.  Please fill in the template with all the information
+that you know.
+
+After reporting the error a developer will take over the report and maybe ask
+you for further guidance and feedback, so please stay responsive.
+
+
+## I want to contribute code
+
+We gladly accept any useful addition to the project.  However before you start
+developing something please inform the developers about your endeavours to avoid
+duplicate work.  If you're trying to fix a reported bug please state that you're
+working on the bug.  If you want to implement a new feature get in touch with
+the developers via the [FreeOrion Forum] to check if the feature complies with
+our idea of the game.
+
+To start contributing first clone [FreeOrion Git] repository.  After that create
+a branch with a concise name, if the branch implements an issue call it
+`fix-<Issue Number>`.  To publish your contribution create a [Pull Request] and
+wait for feedback from the developers.
+
+To ensure your PR won't be rejected please make sure that:
+
+* The code changes match the [Code Standards].  For Python code we follow
+  [PEP 8].
+* The commits of the PR are atomic.  This means that one commit should only
+  contain a single logical and indivisible change.  If you need to describe the
+  change inside the commit with a list or any other enumeration you're already
+  doing it wrong.  Don't lump together functional changes and code style
+  changes.  When style changes are needed put them into a separate commit.
+* The [Commit Messages] follow the rules for a great Git commit message.
+* The PR **IS** concise on the topic it addresses.  If you want to address
+  different topics create different branches and PRs for them.  If the
+  topics/PRs relate to each other document so in the PR message.
+* The PR **DOES NOT** contain any merge commits from any other branch.  If you
+  want to update your branch to a more recent master use the `git rebase`
+  command.
+
+[FreeOrion Git]: https://github.com/freeorion/freeorion.git
+[FreeOrion Issues]: https://github.com/freeorion/freeorion/issues
+[FreeOrion Forum]: http://www.freeorion.org/forum/
+[Code Standards]: http://www.freeorion.org/index.php/Code_Standards
+[Pull Request]: https://help.github.com/articles/proposing-changes-to-a-project-with-pull-requests/
+[Commit Messages]: http://chris.beams.io/posts/git-commit/
+[PEP 8]: https://www.python.org/dev/peps/pep-0008/

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ FreeOrion, an open-source game inspired by Master of Orion, is a turn-based game
 
 ## How to contribute
 
-http://freeorion.org/index.php/How_to_Help
+For more details please see our [Contribution Guidelines](CONTRIBUTING.md).
+
 
 ## License
 


### PR DESCRIPTION
GitHub added support for [Contributing Guidelines](https://github.com/blog/1184-contributing-guidelines) and [PR/Issue Templates](https://github.com/blog/2111-issue-and-pull-request-templates) some time ago.  As the file names already indicate these files allow GitHub users to add project contribution guidelines and templates for issues and pull requests.  I think that adding some well written documentation files could save us some time for reoccurring problems like:
- Users report bugs without the necessary context (version, os, log files, …).
- Pull requests violating some guideline, making it necessary to point this out.

_Doesn't these files overlap with the [How to Help](http://www.freeorion.org/index.php/How_to_Help) and related pages?_

They totally do.  However maintaining (some revised) content of those pages inside the repository:
1. Makes it easier to version of the guidelines associated with the code version, something that doesn't work well with the wiki in my opinion.
2. Allows us to use the GitHub integration.
3. Keeps the information close to the place where contributors look first, the README.md file inside the source and the GitHub project page.
