### PR TITLE
Fix tech tree arcs null pointer reference and memory leak

### DIFF
--- a/UI/TechTreeArcs.cpp
+++ b/UI/TechTreeArcs.cpp
@@ -160,10 +160,7 @@ TechTreeArcs::TechTreeArcs(const TechTreeLayout& layout, const std::set<std::str
 {}
 
 TechTreeArcs::~TechTreeArcs() {
-    if (m_impl != 0) {
-        delete m_impl;
-    }
-    m_impl = 0;
+    Reset();
 }
 
 void TechTreeArcs::Render(double scale) {
@@ -171,13 +168,13 @@ void TechTreeArcs::Render(double scale) {
         m_impl->Render(scale);
 }
 
-void TechTreeArcs::Reset()
-{ m_impl = 0; }
+void TechTreeArcs::Reset() {
+    if (m_impl)
+        delete m_impl;
+    m_impl = 0;
+}
 
 void TechTreeArcs::Reset(const TechTreeLayout& layout, const std::set< std::string >& techs_to_show) {
-    if (m_impl != 0) {
-        delete m_impl;
-        m_impl = 0;
-    }
+    Reset();
     m_impl = new TechTreeArcsImplementation(layout, techs_to_show);
 }

--- a/UI/TechTreeArcs.cpp
+++ b/UI/TechTreeArcs.cpp
@@ -166,8 +166,10 @@ TechTreeArcs::~TechTreeArcs() {
     m_impl = 0;
 }
 
-void TechTreeArcs::Render(double scale)
-{ m_impl->Render(scale); }
+void TechTreeArcs::Render(double scale) {
+    if (m_impl)
+        m_impl->Render(scale);
+}
 
 void TechTreeArcs::Reset()
 { m_impl = 0; }
@@ -179,5 +181,3 @@ void TechTreeArcs::Reset(const TechTreeLayout& layout, const std::set< std::stri
     }
     m_impl = new TechTreeArcsImplementation(layout, techs_to_show);
 }
-
-


### PR DESCRIPTION
This pull request fixes two errors:
- a null pointer reference in TechTreeArcs::Render
  when m_impl has not been allocated. 
- a memory leak in Reset() where m_impl is zeroed without first unallocating memory.
