### PR TITLE
Restrict shipyard to ship building species

### DIFF
--- a/default/scripting/buildings/shipyards/BASE.focs.txt
+++ b/default/scripting/buildings/shipyards/BASE.focs.txt
@@ -10,7 +10,10 @@ BuildingType
         Not Contains Building name = "BLD_SHIPYARD_BASE"
         OwnedBy empire = Source.Owner
     ]
-    EnqueueLocation = [[ENQUEUE_BUILD_ONE_PER_PLANET]]
+    EnqueueLocation = And [
+        [[ENQUEUE_BUILD_ONE_PER_PLANET]]
+        CanProduceShips
+    ]
     effectsgroups =
         EffectsGroup
             scope = And [ 


### PR DESCRIPTION
Fixes #612 

Only allow species that can build ships to construct a base shipyard.
