### PR TITLE
Restructure mine damage effectgroups

### DIFF
--- a/default/scripting/specials/FORTRESS.focs.txt
+++ b/default/scripting/specials/FORTRESS.focs.txt
@@ -33,82 +33,7 @@ Special
                 SetShield value = Value + min(5.0, max(Value, 0.25*Target.Construction))
                 SetDefense value = Value + 1
             ]
-
-        // Mines Start
-        EffectsGroup
-            scope = And [
-                Ship
-                ContainedBy And [
-                    System 
-                    Contains And [
-                        Source
-                        Not OwnerHasTech name = "DEF_SYST_DEF_MINE_2"
-                    ]
-                ]
-                (RootCandidate.Owner != Source.Owner)  // particularly to exclude an unowned Fotress with unowned monsters
-                Or [
-                    OwnedBy affiliation = EnemyOf empire = Source.Owner
-                    Unowned
-                ]
-            ]
-            effects = SetStructure value = Value - 3
-
-        EffectsGroup
-            scope = And [
-                Fleet
-                ContainedBy And [
-                    System 
-                    Contains And [
-                        Source
-                        Not OwnerHasTech name = "DEF_SYST_DEF_MINE_2"
-                    ]
-                ]
-                (RootCandidate.Owner != Source.Owner)  // particularly to exclude an unowned Fotress with unowned monsters
-                OwnedBy affiliation = EnemyOf empire = Source.Owner
-            ]
-            effects = [
-                GenerateSitRepMessage
-                    message = "EFFECT_MINES"
-                    icon = "icons/sitrep/combat_damage.png"
-                    parameters = [
-                        tag = "empire" data = Target.Owner
-                        tag = "fleet" data = Target.ID
-                        tag = "rawtext" data = "3"
-                        tag = "system" data = Target.SystemID
-                    ]
-                    empire = Target.Owner
-            ]
-
-        EffectsGroup
-            scope = And [
-                Ship
-                ContainedBy And [
-                    System 
-                    Contains And [
-                        Source
-                        Not OwnerHasTech name = "DEF_SYST_DEF_MINE_2"
-                    ]
-                ]
-                (RootCandidate.Owner != Source.Owner)  // particularly to exclude an unowned Fotress with unowned monsters
-                Or [
-                    OwnedBy affiliation = EnemyOf empire = Source.Owner
-                    Unowned
-                ]
-                Structure high = 3
-            ]
-            effects = [
-                GenerateSitRepMessage
-                    message = "EFFECT_MINES_SHIP_DESTROYED"
-                    icon = "icons/sitrep/combat_destroyed.png"
-                    parameters = [
-                        tag = "empire" data = Target.Owner
-                        tag = "ship" data = Target.ID
-                        tag = "system" data = Target.SystemID
-                    ]
-                    empire = Target.Owner
-                Destroy
-            ]
-        // Mines End
+        [[EG_SYSTEM_MINES(3, LATE_PRIORITY)]]
 
         EffectsGroup
             scope = Source
@@ -140,3 +65,7 @@ Special
             effects = CreateShip designname = "SM_GUARD_2"
         ]
         graphic = "icons/specials_huge/fortress.png"
+
+#include "/scripting/techs/defense/mines.macros"
+
+#include "/scripting/common/priorities.macros"

--- a/default/scripting/techs/defense/Defense.focs.txt
+++ b/default/scripting/techs/defense/Defense.focs.txt
@@ -28,77 +28,7 @@ Tech
     researchturns = 4
     prerequisites = "DEF_DEFENSE_NET_1"
     effectsgroups = [
-        EffectsGroup
-            scope = And [
-                Ship
-                ContainedBy And [
-                    System 
-                    Contains And [
-                        Planet
-                        OwnedBy empire = Source.Owner
-                        Not HasSpecial name = "FORTRESS_SPECIAL"
-                    ]
-                ]
-                Or [
-                    OwnedBy affiliation = EnemyOf empire = Source.Owner
-                    Unowned
-                ]
-            ]
-            activation = Not OwnerHasTech name = "DEF_SYST_DEF_MINE_2"
-            effects = SetStructure value = Value - 2
-        EffectsGroup
-            scope = And [
-                Fleet
-                ContainedBy And [
-                    System 
-                    Contains And [
-                        Planet
-                        OwnedBy empire = Source.Owner
-                        Not HasSpecial name = "FORTRESS_SPECIAL"
-                    ]
-                ]
-                OwnedBy affiliation = EnemyOf empire = Source.Owner
-            ]
-            activation = Not OwnerHasTech name = "DEF_SYST_DEF_MINE_2"
-            effects = [
-                GenerateSitRepMessage
-                    message = "EFFECT_MINES"
-                    icon = "icons/sitrep/combat_damage.png"
-                    parameters = [
-                        tag = "empire" data = Target.Owner
-                        tag = "fleet" data = Target.ID
-                        tag = "rawtext" data = "2"
-                        tag = "system" data = Target.SystemID
-                    ]
-                    empire = Target.Owner
-            ]
-        EffectsGroup
-            scope = And [
-                Ship
-                ContainedBy And [
-                    System 
-                    Contains And [
-                        Planet
-                        OwnedBy empire = Source.Owner
-                        Not HasSpecial name = "FORTRESS_SPECIAL"
-                    ]
-                ]
-                OwnedBy affiliation = EnemyOf empire = Source.Owner
-                Structure high = 2
-            ]
-            activation = Not OwnerHasTech name = "DEF_SYST_DEF_MINE_2"
-            effects = [
-                GenerateSitRepMessage
-                    message = "EFFECT_MINES_SHIP_DESTROYED"
-                    icon = "icons/sitrep/combat_destroyed.png"
-                    parameters = [
-                        tag = "empire" data = Target.Owner
-                        tag = "ship" data = Target.ID
-                        tag = "system" data = Target.SystemID
-                    ]
-                    empire = Target.Owner
-                Destroy
-            ]
+        [[EG_SYSTEM_MINES(2,VERY_LATE_PRIORITY)]]
     ]
     graphic = "icons/tech/system_defense_mines.png"
 
@@ -111,74 +41,7 @@ Tech
     researchturns = 6
     prerequisites = "DEF_SYST_DEF_MINE_1"
     effectsgroups = [
-        EffectsGroup
-            scope = And [
-                Ship
-                ContainedBy And [
-                    System 
-                    Contains And [
-                        Planet
-                        OwnedBy empire = Source.Owner
-                    ]
-                ]
-                Or [
-                    OwnedBy affiliation = EnemyOf empire = Source.Owner
-                    Unowned
-                ]
-            ]
-            activation = Not OwnerHasTech name = "DEF_SYST_DEF_MINE_3"
-            effects = SetStructure value = Value - 6
-        EffectsGroup
-            scope = And [
-                Fleet
-                ContainedBy And [
-                    System 
-                    Contains And [
-                        Planet
-                        OwnedBy empire = Source.Owner
-                    ]
-                ]
-                OwnedBy affiliation = EnemyOf empire = Source.Owner
-            ]
-            activation = Not OwnerHasTech name = "DEF_SYST_DEF_MINE_3"
-            effects = [
-                GenerateSitRepMessage
-                    message = "EFFECT_MINES"
-                    icon = "icons/sitrep/combat_damage.png"
-                    parameters = [
-                        tag = "empire" data = Target.Owner
-                        tag = "fleet" data = Target.ID
-                        tag = "rawtext" data = "6"
-                        tag = "system" data = Target.SystemID
-                    ]
-                    empire = Target.Owner
-            ]
-        EffectsGroup
-            scope = And [
-                Ship
-                ContainedBy And [
-                    System 
-                    Contains And [
-                        Planet
-                        OwnedBy empire = Source.Owner
-                    ]
-                ]
-                OwnedBy affiliation = EnemyOf empire = Source.Owner
-                Structure high = 6
-            ]
-            activation = Not OwnerHasTech name = "DEF_SYST_DEF_MINE_3"
-            effects = [
-                GenerateSitRepMessage
-                    message = "EFFECT_MINES_SHIP_DESTROYED"
-                    icon = "icons/sitrep/combat_destroyed.png"
-                    parameters = [
-                        tag = "empire" data = Target.Owner
-                        tag = "ship" data = Target.ID
-                        tag = "system" data = Target.SystemID
-                    ]
-                    empire = Target.Owner
-                Destroy
-            ]
+        [[EG_SYSTEM_MINES(6,DEFAULT_PRIORITY)]]
     ]
     graphic = "icons/tech/system_defense_mines.png"
 
@@ -191,72 +54,12 @@ Tech
     researchturns = 8
     prerequisites = "DEF_SYST_DEF_MINE_2"
     effectsgroups = [
-        EffectsGroup
-            scope = And [
-                Ship
-                ContainedBy And [
-                    System 
-                    Contains And [
-                        Planet
-                        OwnedBy empire = Source.Owner
-                    ]
-                ]
-                Or [
-                    OwnedBy affiliation = EnemyOf empire = Source.Owner
-                    Unowned
-                ]
-            ]
-            effects = SetStructure value = Value - 14
-        EffectsGroup
-            scope = And [
-                Fleet
-                ContainedBy And [
-                    System 
-                    Contains And [
-                        Planet
-                        OwnedBy empire = Source.Owner
-                    ]
-                ]
-                OwnedBy affiliation = EnemyOf empire = Source.Owner
-            ]
-            effects = [
-                GenerateSitRepMessage
-                    message = "EFFECT_MINES"
-                    icon = "icons/sitrep/combat_damage.png"
-                    parameters = [
-                        tag = "empire" data = Target.Owner
-                        tag = "fleet" data = Target.ID
-                        tag = "rawtext" data = "14"
-                        tag = "system" data = Target.SystemID
-                    ]
-                    empire = Target.Owner
-            ]
-        EffectsGroup
-            scope = And [
-                Ship
-                ContainedBy And [
-                    System 
-                    Contains And [
-                        Planet
-                        OwnedBy empire = Source.Owner
-                    ]
-                ]
-                OwnedBy affiliation = EnemyOf empire = Source.Owner
-                Structure high = 14
-            ]
-            effects = [
-                GenerateSitRepMessage
-                    message = "EFFECT_MINES_SHIP_DESTROYED"
-                    icon = "icons/sitrep/combat_destroyed.png"
-                    parameters = [
-                        tag = "empire" data = Target.Owner
-                        tag = "ship" data = Target.ID
-                        tag = "system" data = Target.SystemID
-                    ]
-                    empire = Target.Owner
-                Destroy
-            ]
+        [[EG_SYSTEM_MINES(14,EARLY_PRIORITY)]]
     ]
     graphic = "icons/tech/system_defense_mines.png"
+
+#include "mines.macros"
+
+#include "/scripting/common/priorities.macros"
 
 #include "/scripting/common/base_prod.macros"

--- a/default/scripting/techs/defense/mines.macros
+++ b/default/scripting/techs/defense/mines.macros
@@ -1,0 +1,246 @@
+// EffectsGroups for System Defense Mines
+// arg1 total damage
+// arg2 priority
+EG_SYSTEM_MINES
+'''        // damage ship; sitreps issued below
+        EffectsGroup
+            scope = And [
+                Ship
+                ContainedBy And [
+                    System 
+                    Contains And [
+                        Planet
+                        OwnedBy empire = Source.Owner
+                    ]
+                ]
+                Or [
+                    OwnedBy affiliation = EnemyOf empire = Source.Owner
+                    Unowned
+                ]
+                (RootCandidate.Owner != Source.Owner)
+                Structure low = @1@ + 0.0001
+            ]
+            stackinggroup = "DEF_MINES_DAMAGE_STACK"
+            priority = [[@2@]]
+            effects = [
+                SetStructure value = Value - @1@
+            ]
+        // destroy ship; sitreps issued below
+        EffectsGroup
+            scope = And [
+                Ship
+                ContainedBy And [
+                    System 
+                    Contains And [
+                        Planet
+                        OwnedBy empire = Source.Owner
+                    ]
+                ]
+                Or [
+                    OwnedBy affiliation = EnemyOf empire = Source.Owner
+                    Unowned
+                ]
+                (RootCandidate.Owner != Source.Owner)
+                Structure high = @1@
+            ]
+            stackinggroup = "DEF_MINES_DAMAGE_STACK"
+            priority = [[@2@]]
+            effects = [
+                Destroy
+            ]
+        // Planet owner sitrep - visible enemy fleet damaged
+        EffectsGroup
+            scope = And [
+                Fleet
+                ContainedBy And [
+                    System
+                    Contains And [
+                        Planet
+                        OwnedBy empire = Source.Owner
+                    ]
+                ]
+                OwnedBy affiliation = EnemyOf empire = Source.Owner
+                VisibleToEmpire empire = Source.Owner
+            ]
+            stackinggroup = "DEF_MINES_SITREP_PLANET_VISIBLE_ENEMY_STACK"
+            priority = [[@2@]]
+            effects = [
+                GenerateSitRepMessage
+                    message = "EFFECT_MINES"
+                    icon = "icons/sitrep/combat_damage.png"
+                    parameters = [
+                        tag = "empire" data = Target.Owner
+                        tag = "fleet" data = Target.ID
+                        tag = "rawtext" data = "@1@"
+                        tag = "system" data = Target.SystemID
+                    ]
+                    empire = Source.Owner
+            ]
+        // Planet owner sitrep - visible unowned ship damaged
+        EffectsGroup
+            scope = And [
+                Ship
+                ContainedBy And [
+                    System
+                    Contains And [
+                        Planet
+                        OwnedBy empire = Source.Owner
+                    ]
+                ]
+                Unowned
+                VisibleToEmpire empire = Source.Owner
+                Structure low = @1@ + 0.0001
+            ]
+            stackinggroup = "DEF_MINES_SITREP_PLANET_VISIBLE_UNOWNED_STACK"
+            priority = [[@2@]]
+            effects = [
+                GenerateSitRepMessage
+                    message = "EFFECT_MINES_SINGLE_SHIP"
+                    label = "EFFECT_MINES_LABEL"
+                    icon = "icons/sitrep/combat_damage.png"
+                    parameters = [
+                        tag = "ship" data = Target.ID
+                        tag = "shipdesign" data = Target.DesignID
+                        tag = "rawtext" data = "@1@"
+                        tag = "system" data = Target.SystemID
+                    ]
+                    empire = Source.Owner
+            ]
+        // Planet owner sitrep - visible unowned ship destroyed
+        EffectsGroup
+            scope = And [
+                Ship
+                ContainedBy And [
+                    System
+                    Contains And [
+                        Planet
+                        OwnedBy empire = Source.Owner
+                    ]
+                ]
+                Unowned
+                VisibleToEmpire empire = Source.Owner
+                Structure high = @1@
+            ]
+            stackinggroup = "DEF_MINES_SITREP_PLANET_VISIBLE_UNOWNED_STACK"
+            priority = [[@2@]]
+            effects = [
+                GenerateSitRepMessage
+                    message = "EFFECT_MINES_UNOWNED_DESTROYED"
+                    label = "EFFECT_MINES_SHIP_DESTROYED_LABEL"
+                    icon = "icons/sitrep/combat_damage.png"
+                    parameters = [
+                        tag = "ship" data = Target.ID
+                        tag = "shipdesign" data = Target.DesignID
+                        tag = "system" data = Target.SystemID
+                    ]
+                    empire = Source.Owner
+            ]
+        // Planet owner sitrep - visible enemy ship destroyed
+        EffectsGroup
+            scope = And [
+                Ship
+                ContainedBy And [
+                    System
+                    Contains And [
+                        Planet
+                        OwnedBy empire = Source.Owner
+                    ]
+                ]
+                OwnedBy affiliation = EnemyOf empire = Source.Owner
+                Structure high = @1@
+                VisibleToEmpire empire = Source.Owner
+            ]
+            stackinggroup = "DEF_MINES_SITREP_PLANET_VISIBLE_ENEMY_STACK"
+            priority = [[@2@]]
+            effects = [
+                GenerateSitRepMessage
+                    message = "EFFECT_MINES_SHIP_DESTROYED"
+                    icon = "icons/sitrep/combat_destroyed.png"
+                    parameters = [
+                        tag = "empire" data = Target.Owner
+                        tag = "ship" data = Target.ID
+                        tag = "system" data = Target.SystemID
+                    ]
+                    empire = Source.Owner
+            ]
+        // Planet owner sitrep - non-visible ship damaged or destroyed
+        EffectsGroup
+            scope = And [
+                Ship
+                ContainedBy And [
+                    System
+                    Contains And [
+                        Planet
+                        OwnedBy empire = Source.Owner
+                    ]
+                ]
+                Or [
+                    OwnedBy affiliation = EnemyOf empire = Source.Owner
+                    Unowned
+                ]
+                Not VisibleToEmpire empire = Source.Owner
+            ]
+            stackinggroup = "DEF_MINES_SITREP_PLANET_INVISIBLE_STACK"
+            priority = [[@2@]]
+            effects = [
+                GenerateSitRepMessage
+                    message = "EFFECT_MINES_UNKNOWN"
+                    icon = "icons/sitrep/combat_damage.png"
+                    parameters = [
+                        tag = "system" data = Target.SystemID
+                    ]
+                    empire = Source.Owner
+            ]
+        // Fleet owner sitrep - damaged fleet
+        EffectsGroup
+            scope = And [
+                Fleet
+                ContainedBy And [
+                    System 
+                    Contains And [
+                        Planet
+                        OwnedBy empire = Source.Owner
+                    ]
+                ]
+                OwnedBy affiliation = EnemyOf empire = Source.Owner
+            ]
+            stackinggroup = "DEF_MINES_SITREP_FLEET_STACK"
+            effects = [
+                GenerateSitRepMessage
+                    message = "EFFECT_MINES"
+                    icon = "icons/sitrep/combat_damage.png"
+                    parameters = [
+                        tag = "empire" data = Target.Owner
+                        tag = "fleet" data = Target.ID
+                        tag = "rawtext" data = "@1@"
+                        tag = "system" data = Target.SystemID
+                    ]
+                    empire = Target.Owner
+            ]
+        // Ship owner sitrep - destroyed ship
+        EffectsGroup
+            scope = And [
+                Ship
+                ContainedBy And [
+                    System 
+                    Contains And [
+                        Planet
+                        OwnedBy empire = Source.Owner
+                    ]
+                ]
+                OwnedBy affiliation = EnemyOf empire = Source.Owner
+                Structure high = @1@
+            ]
+            stackinggroup = "DEF_MINES_SITREP_SHIP_STACK"
+            effects = [
+                GenerateSitRepMessage
+                    message = "EFFECT_MINES_SHIP_DESTROYED"
+                    icon = "icons/sitrep/combat_destroyed.png"
+                    parameters = [
+                        tag = "empire" data = Target.Owner
+                        tag = "ship" data = Target.ID
+                        tag = "system" data = Target.SystemID
+                    ]
+                    empire = Target.Owner
+            ]
+'''

--- a/default/scripting/techs/defense/mines.macros
+++ b/default/scripting/techs/defense/mines.macros
@@ -8,9 +8,12 @@ EG_SYSTEM_MINES
                 Ship
                 ContainedBy And [
                     System 
-                    Contains And [
-                        Planet
-                        OwnedBy empire = Source.Owner
+                    Contains Or [
+                        Source
+                        And [
+                            Planet
+                            OwnedBy empire = Source.Owner
+                        ]
                     ]
                 ]
                 Or [
@@ -31,9 +34,12 @@ EG_SYSTEM_MINES
                 Ship
                 ContainedBy And [
                     System 
-                    Contains And [
-                        Planet
-                        OwnedBy empire = Source.Owner
+                    Contains Or [
+                        Source
+                        And [
+                            Planet
+                            OwnedBy empire = Source.Owner
+                        ]
                     ]
                 ]
                 Or [
@@ -54,9 +60,12 @@ EG_SYSTEM_MINES
                 Fleet
                 ContainedBy And [
                     System
-                    Contains And [
-                        Planet
-                        OwnedBy empire = Source.Owner
+                    Contains Or [
+                        Source
+                        And [
+                            Planet
+                            OwnedBy empire = Source.Owner
+                        ]
                     ]
                 ]
                 OwnedBy affiliation = EnemyOf empire = Source.Owner
@@ -82,9 +91,12 @@ EG_SYSTEM_MINES
                 Ship
                 ContainedBy And [
                     System
-                    Contains And [
-                        Planet
-                        OwnedBy empire = Source.Owner
+                    Contains Or [
+                        Source
+                        And [
+                            Planet
+                            OwnedBy empire = Source.Owner
+                        ]
                     ]
                 ]
                 Unowned
@@ -112,9 +124,12 @@ EG_SYSTEM_MINES
                 Ship
                 ContainedBy And [
                     System
-                    Contains And [
-                        Planet
-                        OwnedBy empire = Source.Owner
+                    Contains Or [
+                        Source
+                        And [
+                            Planet
+                            OwnedBy empire = Source.Owner
+                        ]
                     ]
                 ]
                 Unowned
@@ -141,9 +156,12 @@ EG_SYSTEM_MINES
                 Ship
                 ContainedBy And [
                     System
-                    Contains And [
-                        Planet
-                        OwnedBy empire = Source.Owner
+                    Contains Or [
+                        Source
+                        And [
+                            Planet
+                            OwnedBy empire = Source.Owner
+                        ]
                     ]
                 ]
                 OwnedBy affiliation = EnemyOf empire = Source.Owner
@@ -169,9 +187,12 @@ EG_SYSTEM_MINES
                 Ship
                 ContainedBy And [
                     System
-                    Contains And [
-                        Planet
-                        OwnedBy empire = Source.Owner
+                    Contains Or [
+                        Source
+                        And [
+                            Planet
+                            OwnedBy empire = Source.Owner
+                        ]
                     ]
                 ]
                 Or [
@@ -197,9 +218,12 @@ EG_SYSTEM_MINES
                 Fleet
                 ContainedBy And [
                     System 
-                    Contains And [
-                        Planet
-                        OwnedBy empire = Source.Owner
+                    Contains Or [
+                        Source
+                        And [
+                            Planet
+                            OwnedBy empire = Source.Owner
+                        ]
                     ]
                 ]
                 OwnedBy affiliation = EnemyOf empire = Source.Owner
@@ -223,9 +247,12 @@ EG_SYSTEM_MINES
                 Ship
                 ContainedBy And [
                     System 
-                    Contains And [
-                        Planet
-                        OwnedBy empire = Source.Owner
+                    Contains Or [
+                        Source
+                        And [
+                            Planet
+                            OwnedBy empire = Source.Owner
+                        ]
                     ]
                 ]
                 OwnedBy affiliation = EnemyOf empire = Source.Owner

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -5038,13 +5038,22 @@ Psychogenic Domination
 
 EFFECT_MINES
 At %system%: Mines caused %rawtext% damage to the %empire% fleet %fleet%.
+EFFECT_MINES_SINGLE_SHIP
+At %system%: Mines caused %rawtext% damage to %ship%, a %shipdesign%.
 EFFECT_MINES_LABEL
 System Mines
 
 EFFECT_MINES_SHIP_DESTROYED
 At %system%: mines destroyed the %empire% ship %ship%.
+EFFECT_MINES_UNOWNED_DESTROYED
+At %system%: mines destroyed the ship %ship%, a %shipdesign%.
 EFFECT_MINES_SHIP_DESTROYED_LABEL
 System Mines Destroyed Ship
+
+EFFECT_MINES_UNKNOWN
+At %system%: An unknown object has triggered your mines.
+EFFECT_MINES_UNKNOWN_LABEL
+System Mines Unknown Ship
 
 EFFECT_FLEET_MOVED_TOWARDS
 At %planet%: [[tech LRN_SPATIAL_DISTORT_GEN]] moved %fleet% back towards %system%. They were initially %rawtext% uu apart.


### PR DESCRIPTION
Fixes #360 & #538 
Ensure sitreps are generated for both planet and ship owner when mines damage or destroy a ship.

A message is generated for the planet owner for invisible ship damage, but only to note that something set them off.
