### PR TITLE
Fix bug513 bug597 resetting sitrep

### DIFF
--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -987,7 +987,7 @@ void ListBox::BringRowIntoView(iterator it)
     if (m_vscroll) {
         Y acc(0);
         for (iterator it2 = m_rows.begin(); it2 != m_first_row_shown; ++it2)
-            acc += (*it)->Height();
+            acc += (*it2)->Height();
         m_vscroll->ScrollTo(Value(acc));
         SignalScroll(*m_vscroll, true);
     }
@@ -1000,7 +1000,7 @@ void ListBox::SetFirstRowShown(iterator it)
         if (m_vscroll) {
             Y acc(0);
             for (iterator it2 = m_rows.begin(); it2 != m_first_row_shown; ++it2)
-                acc += (*it)->Height();
+                acc += (*it2)->Height();
             m_vscroll->ScrollTo(Value(acc));
             SignalScroll(*m_vscroll, true);
         } else {

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -5365,9 +5365,6 @@ void MapWnd::ShowSitRep() {
     HideProduction();
     HideDesign();
 
-    // update sitrep window
-    m_sitrep_panel->Update();
-
     // show the sitrep window
     m_sitrep_panel->Show();
     GG::GUI::GetGUI()->MoveUp(m_sitrep_panel);


### PR DESCRIPTION
This PR fixes bug #513 and bug #597, which both deal with the sitrep window resetting when either the MapWnd closes the production window or when the filtering of sitreps is changed.

It also fixes two un-reported bugs in GG::List SetFirstRowShown and BringRowIntoView where it was using the height of the target row in place of the height of each individual rows when re-positioning the rows.  This fix was necessary for the fix of the resetting of the sitrep window with changing filtering.

The fix for the map window is simply to not update when toggling the sitrep window.

The fix for the resetting with filtering is two steps.
1. always restore sitrep->list positioning on each update. 
2. Only change which sitrep is displayed in ShowSitRepsForTurn(), which also sets the sitrep window to display the first row.
