### PR TITLE
Give Trith new Telepathic Detection species trait

### DIFF
--- a/default/scripting/species/SP_TRITH.focs.txt
+++ b/default/scripting/species/SP_TRITH.focs.txt
@@ -27,12 +27,12 @@ Species
         [[AVERAGE_SUPPLY]]
         [[AVERAGE_DEFENSE_TROOPS]]
 
-        [[GREAT_DETECTION]]
+        [[GOOD_DETECTION]]
         [[GOOD_STEALTH]]
 
         [[XENOPHOBIC_SELF]]
-
         [[XENOPHOBIC_OTHER(TRITH)]]
+        [[TELEPATHIC_DETECTION(5)]]
 
         // not for description
         [[AVERAGE_PLANETARY_SHIELDS]]

--- a/default/scripting/species/common/telepathic.macros
+++ b/default/scripting/species/common/telepathic.macros
@@ -1,0 +1,12 @@
+TELEPATHIC_DETECTION
+'''     EffectsGroup
+            description = "TELEPATHIC_DETECTION"
+            scope = And [
+                PopulationCenter
+                Not Population high = 0
+                WithinStarlaneJumps jumps = @1@ condition = Source
+                Not VisibleToEmpire empire = Source.Owner
+            ]
+            activation = OwnedBy affiliation = AnyEmpire
+            effects = SetVisibility visibility = Basic empire = Source.Owner
+'''

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -11237,6 +11237,11 @@ GREAT_ASTEROID_INDUSTRY
 
 LIGHT_SENSITIVE
 −	Light Sensitive: Population is reduced in systems with blue and to a lesser extend white stars.
+
+TELEPATHIC_DETECTION
++	Telepathic Detection: can sense nearby populated planets.
+
+
 #############################################################
 ####          A C C O U N T I N G    L A B E L S         ####
 #############################################################


### PR DESCRIPTION
Added new "Telepathic Detection" species trait which grants partial visibility of populated planets within a certain number of jumps of a ship or planet of the species with this trait and added the new trait to species Trith. Removed the Great Detection species trait from Trith for balance reasons.
