### PR TITLE
Add use the MapZoom hotkey to zoom research window techtree

### DIFF
--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -6086,10 +6086,10 @@ namespace {
     /// On when the MapWnd window is visible and not covered
     //  by one of the full screen covering windows
     class VisibleMapWndCondition : public HotkeyCondition {
-        protected:
+    protected:
         const MapWnd& target;
 
-        public:
+    public:
         VisibleMapWndCondition(const MapWnd& tg) : target(tg) {}
         virtual bool IsActive() const {
             return target.Visible() && !target.InResearchViewMode() && !target.InDesignViewMode();

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -1377,6 +1377,12 @@ void MapWnd::GetSaveGameUIData(SaveGameUIData& data) const {
 bool MapWnd::InProductionViewMode() const
 { return m_in_production_view_mode; }
 
+bool MapWnd::InResearchViewMode() const
+{ return m_research_wnd->Visible(); }
+
+bool MapWnd::InDesignViewMode() const
+{ return m_design_wnd->Visible(); }
+
 ModeratorActionSetting MapWnd::GetModeratorActionSetting() const
 { return m_moderator_wnd->SelectedAction(); }
 
@@ -6075,6 +6081,22 @@ bool MapWnd::ZoomToSystemWithWastedPP() {
     return false;
 }
 
+namespace {
+
+    /// On when the MapWnd window is visible and not covered
+    //  by one of the full screen covering windows
+    class VisibleMapWndCondition : public HotkeyCondition {
+        protected:
+        const MapWnd& target;
+
+        public:
+        VisibleMapWndCondition(const MapWnd& tg) : target(tg) {}
+        virtual bool IsActive() const {
+            return target.Visible() && !target.InResearchViewMode() && !target.InDesignViewMode();
+        };
+    };
+}
+
 void MapWnd::ConnectKeyboardAcceleratorSignals() {
     HotkeyManager* hkm = HotkeyManager::GetManager();
 
@@ -6087,13 +6109,13 @@ void MapWnd::ConnectKeyboardAcceleratorSignals() {
     hkm->Connect(this, &MapWnd::ToggleDesign,           "map.design",           new VisibleWindowCondition(this));
     hkm->Connect(this, &MapWnd::ToggleObjects,          "map.objects",          new VisibleWindowCondition(this));
     hkm->Connect(this, &MapWnd::ShowMenu,               "map.menu",             new VisibleWindowCondition(this));
-    hkm->Connect(this, &MapWnd::KeyboardZoomIn,         "map.zoom_in",          new VisibleWindowCondition(this));
-    hkm->Connect(this, &MapWnd::KeyboardZoomIn,         "map.zoom_in_alt",      new VisibleWindowCondition(this));
-    hkm->Connect(this, &MapWnd::KeyboardZoomOut,        "map.zoom_out",         new VisibleWindowCondition(this));
-    hkm->Connect(this, &MapWnd::KeyboardZoomOut,        "map.zoom_out_alt",     new VisibleWindowCondition(this));
-    hkm->Connect(this, &MapWnd::ZoomToHomeSystem,       "map.zoom_home_system", new VisibleWindowCondition(this));
-    hkm->Connect(this, &MapWnd::ZoomToPrevOwnedSystem,  "map.zoom_prev_system", new VisibleWindowCondition(this));
-    hkm->Connect(this, &MapWnd::ZoomToNextOwnedSystem,  "map.zoom_next_system", new VisibleWindowCondition(this));
+    hkm->Connect(this, &MapWnd::KeyboardZoomIn,         "map.zoom_in",          new VisibleMapWndCondition(*this));
+    hkm->Connect(this, &MapWnd::KeyboardZoomIn,         "map.zoom_in_alt",      new VisibleMapWndCondition(*this));
+    hkm->Connect(this, &MapWnd::KeyboardZoomOut,        "map.zoom_out",         new VisibleMapWndCondition(*this));
+    hkm->Connect(this, &MapWnd::KeyboardZoomOut,        "map.zoom_out_alt",     new VisibleMapWndCondition(*this));
+    hkm->Connect(this, &MapWnd::ZoomToHomeSystem,       "map.zoom_home_system", new VisibleMapWndCondition(*this));
+    hkm->Connect(this, &MapWnd::ZoomToPrevOwnedSystem,  "map.zoom_prev_system", new VisibleMapWndCondition(*this));
+    hkm->Connect(this, &MapWnd::ZoomToNextOwnedSystem,  "map.zoom_next_system", new VisibleMapWndCondition(*this));
 
     // the list of windows for which the fleet shortcuts are blacklisted.
     std::list<GG::Wnd*> bl;

--- a/UI/MapWnd.h
+++ b/UI/MapWnd.h
@@ -70,6 +70,16 @@ public:
       * production screen */
     bool                        InProductionViewMode() const;
 
+    /** returns true iff this MapWnd is visible and usable for interaction, but
+      * the allowed interactions are restricted to those appropriate to the
+      * research screen */
+    bool                        InResearchViewMode() const;
+
+    /** returns true iff this MapWnd is visible and usable for interaction, but
+      * the allowed interactions are restricted to those appropriate to the
+      * design screen */
+    bool                        InDesignViewMode() const;
+
     /** returns the currently set moderator action in this MapWnd's
       * ModeratorActionsWnd. */
     ModeratorActionSetting      GetModeratorActionSetting() const;

--- a/UI/MapWnd.h
+++ b/UI/MapWnd.h
@@ -65,19 +65,22 @@ public:
       * save-and-load cycle */
     void                        GetSaveGameUIData(SaveGameUIData& data) const;
 
-    /** returns true iff this MapWnd is visible and usable for interaction, but
-      * the allowed interactions are restricted to those appropriate to the
-      * production screen */
+    /** returns true if MapWnd is visible and usable behind a production window.
+     * MapWnd interactions are restricted to those appropriate to the production window */
     bool                        InProductionViewMode() const;
 
-    /** returns true iff this MapWnd is visible and usable for interaction, but
-      * the allowed interactions are restricted to those appropriate to the
-      * research screen */
+    /** returns true if MapWnd is visible and usable behind a research window.
+     * MapWnd interactions are restricted to those appropriate to the research window.
+     * Currently, there are no interactions with the MapWnd while the research window
+     * is visible because although the MapWnd is visible the research window is opaque
+     * and on top.*/
     bool                        InResearchViewMode() const;
 
-    /** returns true iff this MapWnd is visible and usable for interaction, but
-      * the allowed interactions are restricted to those appropriate to the
-      * design screen */
+    /** returns true if MapWnd is visible and usable behind a design window.
+     * MapWnd interactions are restricted to those appropriate to the design window
+     * Currently, there are no interactions with the MapWnd while the design window
+     * is visible because although the MapWnd is visible the design window is opaque
+     * and on top.*/
     bool                        InDesignViewMode() const;
 
     /** returns the currently set moderator action in this MapWnd's

--- a/UI/TechTreeWnd.cpp
+++ b/UI/TechTreeWnd.cpp
@@ -18,6 +18,7 @@
 #include "../Empire/Empire.h"
 #include "TechTreeLayout.h"
 #include "TechTreeArcs.h"
+#include "Hotkeys.h"
 
 #include <GG/GUI.h>
 #include <GG/DrawUtil.h>
@@ -567,6 +568,9 @@ private:
     void TreeZoomedSlot(int move);
     void TreeZoomInClicked();
     void TreeZoomOutClicked();
+    bool TreeZoomInKeyboard();
+    bool TreeZoomOutKeyboard();
+    void ConnectKeyboardAcceleratorSignals();
 
     double                  m_scale;
     std::set<std::string>   m_categories_shown;
@@ -1053,6 +1057,7 @@ TechTreeWnd::LayoutPanel::LayoutPanel(GG::X w, GG::Y h) :
     GG::Connect(m_zoom_in_button->LeftClickedSignal,    &TechTreeWnd::LayoutPanel::TreeZoomInClicked,   this);
     GG::Connect(m_zoom_out_button->LeftClickedSignal,   &TechTreeWnd::LayoutPanel::TreeZoomOutClicked,  this);
 
+    ConnectKeyboardAcceleratorSignals();
 
     // show all categories...
     m_categories_shown.clear();
@@ -1065,6 +1070,17 @@ TechTreeWnd::LayoutPanel::LayoutPanel(GG::X w, GG::Y h) :
     //m_tech_statuses_shown.insert(TS_UNRESEARCHABLE);
     m_tech_statuses_shown.insert(TS_RESEARCHABLE);
     m_tech_statuses_shown.insert(TS_COMPLETE);
+}
+
+void TechTreeWnd::LayoutPanel::ConnectKeyboardAcceleratorSignals() {
+    HotkeyManager* hkm = HotkeyManager::GetManager();
+
+    hkm->Connect(this, &TechTreeWnd::LayoutPanel::TreeZoomInKeyboard,         "map.zoom_in",          new VisibleWindowCondition(this));
+    hkm->Connect(this, &TechTreeWnd::LayoutPanel::TreeZoomInKeyboard,         "map.zoom_in_alt",      new VisibleWindowCondition(this));
+    hkm->Connect(this, &TechTreeWnd::LayoutPanel::TreeZoomOutKeyboard,        "map.zoom_out",         new VisibleWindowCondition(this));
+    hkm->Connect(this, &TechTreeWnd::LayoutPanel::TreeZoomOutKeyboard,        "map.zoom_out_alt",     new VisibleWindowCondition(this));
+
+    hkm->RebuildShortcuts();
 }
 
 GG::Pt TechTreeWnd::LayoutPanel::ClientLowerRight() const
@@ -1448,6 +1464,16 @@ void TechTreeWnd::LayoutPanel::TreeZoomInClicked()
 void TechTreeWnd::LayoutPanel::TreeZoomOutClicked()
 { TreeZoomedSlot(-1); }
 
+// The bool return value is to re-use the MapWnd::KeyboardZoomIn hotkey
+bool TechTreeWnd::LayoutPanel::TreeZoomInKeyboard() {
+    TreeZoomedSlot(1);
+    return true;
+}
+
+bool TechTreeWnd::LayoutPanel::TreeZoomOutKeyboard() {
+    TreeZoomedSlot(-1);
+    return true;
+}
 
 //////////////////////////////////////////////////
 // TechTreeWnd::TechListBox                     //


### PR DESCRIPTION
1. Disable the map zoom hotkey when research or design window is
   visible.
2. Enable the map zoom hot key to zoom the research window tech tree.
