### PR TITLE
Add combat log details

### DIFF
--- a/GG/GG/Edit.h
+++ b/GG/GG/Edit.h
@@ -79,6 +79,9 @@ public:
     virtual Pt ClientUpperLeft() const;
     virtual Pt ClientLowerRight() const;
 
+    /** Returns the minimum usable size if the text were reflowed into a \a width box.*/
+    virtual Pt MinUsableSize(X width) const;
+
     /** Returns the current position of the cursor (first selected character
         to one past the last selected one). */
     const std::pair<CPSize, CPSize>& CursorPosn() const;

--- a/GG/GG/ScrollPanel.h
+++ b/GG/GG/ScrollPanel.h
@@ -32,6 +32,11 @@ public:
 
     //! Sets the background color of the panel.
     void SetBackgroundColor(const Clr& color);
+
+    //! Returns the scroll bar.
+    const Scroll * GetScroll() const
+    { return m_vscroll;}
+
 protected:
     virtual void MouseWheel(const Pt& pt, int move, GG::Flags< GG::ModKey > mod_keys);
 

--- a/GG/GG/TabWnd.h
+++ b/GG/GG/TabWnd.h
@@ -46,7 +46,7 @@ public:
     /** Emitted when the currently-selected Wnd has changed; the new selected
         Wnd's index in the group is provided (this may be NO_WND if no Wnd is
         currently selected). */
-    typedef boost::signals2::signal<void (std::size_t)> WndChangedSignalType;
+    typedef boost::signals2::signal<void (std::size_t)> TabChangedSignalType;
     //@}
 
     /** \name Structors */ ///@{
@@ -120,7 +120,7 @@ public:
     /** Emitted when the currently-selected Wnd has changed; the new selected
         Wnd's index in the group is provided (this may be NO_WND if no Wnd is
         currently selected). */
-    typedef boost::signals2::signal<void (std::size_t)> WndChangedSignalType;
+    typedef boost::signals2::signal<void (std::size_t)> TabChangedSignalType;
     //@}
 
     /** \name Structors */ ///@{
@@ -168,7 +168,7 @@ public:
     void            SetCurrentWnd(std::size_t index);
     //@}
 
-    mutable WndChangedSignalType WndChangedSignal; ///< The Wnd change signal object for this TabWnd
+    mutable TabChangedSignalType TabChangedSignal; ///< The Wnd change signal object for this TabWnd
 
     /** The invalid Wnd position index that there is no currently-selected
         Wnd. */

--- a/GG/GG/TextControl.h
+++ b/GG/GG/TextControl.h
@@ -80,6 +80,9 @@ public:
     /** \name Accessors */ ///@{
     virtual Pt        MinUsableSize() const;
 
+    /** Returns the minimum usable size if the text were reflowed into a \a width box.*/
+    virtual Pt        MinUsableSize(X width) const;
+
     /** Returns the text displayed in this control. */
     const std::string& Text() const;
 
@@ -258,6 +261,9 @@ private:
     Pt                          m_text_ul;     ///< stored relative to the control's UpperLeft()
     Pt                          m_text_lr;     ///< stored relative to the control's UpperLeft()
     Font::RenderCache*          m_render_cache;///< Cache much of text rendering.
+
+    mutable X                   m_cached_minusable_size_width;
+    mutable Pt                  m_cached_minusable_size;
 };
 
 typedef TextControl Label;

--- a/GG/GG/TextControl.h
+++ b/GG/GG/TextControl.h
@@ -106,7 +106,7 @@ public:
         MinSize(), if any has been set.  Note that this operates independently
         of fit-to-text behavior, which sets the window size, not its minimum
         size. */
-    bool              SetMinSize() const;
+    bool              IsResetMinSize() const;
 
     /** Sets the value of \a t to the interpreted value of the control's text.
         If the control's text can be interpreted as an object of type T by
@@ -185,7 +185,7 @@ public:
 
     /** Enables/disables setting the minimum size of the window to be the text
         size. */
-    void         SetMinSize(bool b);
+    void         SetResetMinSize(bool b);
 
     /** Sets the value of the control's text to the stringified version of t.
         If t can be converted to a string representation by a

--- a/GG/src/Edit.cpp
+++ b/GG/src/Edit.cpp
@@ -83,6 +83,9 @@ Edit::Edit(const std::string& str, const boost::shared_ptr<Font>& font, Clr colo
 Pt Edit::MinUsableSize() const
 { return Pt(X(4 * PIXEL_MARGIN), HeightFromFont(GetFont(), PIXEL_MARGIN)); }
 
+Pt Edit::MinUsableSize(X width) const
+{ return MinUsableSize(); }
+
 Pt Edit::ClientUpperLeft() const
 { return UpperLeft() + Pt(X(PIXEL_MARGIN), Y(PIXEL_MARGIN)); }
 

--- a/GG/src/Layout.cpp
+++ b/GG/src/Layout.cpp
@@ -703,7 +703,11 @@ void Layout::ValidateAlignment(Flags<Alignment>& alignment)
 }
 
 void Layout::RedoLayout()
-{ Resize(Size()); }
+{
+    //Bug:  This does nothing if the size has not changed.  Fixing it to
+    //use Layout::SizeMove breaks all text boxes.
+    Resize(Size());
+}
 
 void Layout::ChildSizeOrMinSizeOrMaxSizeChanged()
 {

--- a/GG/src/Layout.cpp
+++ b/GG/src/Layout.cpp
@@ -335,8 +335,6 @@ void Layout::SizeMove(const Pt& ul, const Pt& lr)
         if (const_cast<const Wnd*>(parent)->GetLayout() == this) {
             Pt new_parent_min_size = MinSize() + parent->Size() - parent->ClientSize();
             Pt parent_min_size = parent->MinSize();
-            new_parent_min_size.x = std::max(parent_min_size.x, new_parent_min_size.x);
-            new_parent_min_size.y = std::max(parent_min_size.y, new_parent_min_size.y);
             ScopedAssign<bool> assignment(m_ignore_parent_resize, true);
             parent->SetMinSize(Pt(new_parent_min_size.x, new_parent_min_size.y));
         }

--- a/GG/src/Layout.cpp
+++ b/GG/src/Layout.cpp
@@ -242,8 +242,10 @@ void Layout::SizeMove(const Pt& ul, const Pt& lr)
         // only height-for-width Wnd type, doesn't get vertically squashed
         // down to 0-height cells.  Note that they can still get horizontally
         // squashed.
-        if (dynamic_cast<TextControl*>(it->first))
-            min_space_needed.y = std::max(min_space_needed.y, min_usable_size.y);
+        if (TextControl *text_control = dynamic_cast<TextControl*>(it->first)) {
+            min_space_needed.y = (text_control->MinUsableSize(Width()) + margin).y;
+            min_usable_size.y = min_space_needed.y;
+        }
 
         // adjust row minimums
         double total_stretch = 0.0;

--- a/GG/src/Layout.cpp
+++ b/GG/src/Layout.cpp
@@ -289,18 +289,27 @@ void Layout::SizeMove(const Pt& ul, const Pt& lr)
     // determine final effective minimums, preserving stretch ratios
     double greatest_min_over_stretch_ratio = 0.0;
     double greatest_usable_min_over_stretch_ratio = 0.0;
+    bool is_zero_total_stretch = true;
     for (std::size_t i = 0; i < m_row_params.size(); ++i) {
         if (m_row_params[i].stretch) {
+            is_zero_total_stretch = false;
             greatest_min_over_stretch_ratio = std::max(greatest_min_over_stretch_ratio, m_row_params[i].effective_min / m_row_params[i].stretch);
             greatest_usable_min_over_stretch_ratio = std::max(greatest_usable_min_over_stretch_ratio, row_effective_min_usable_sizes[i] / m_row_params[i].stretch);
         }
     }
     for (std::size_t i = 0; i < m_row_params.size(); ++i) {
-        m_row_params[i].effective_min = std::max(m_row_params[i].effective_min, static_cast<unsigned int>(m_row_params[i].stretch * greatest_min_over_stretch_ratio));
-        row_effective_min_usable_sizes[i] = std::max(row_effective_min_usable_sizes[i], static_cast<unsigned int>(m_row_params[i].stretch * greatest_usable_min_over_stretch_ratio));
+        if (is_zero_total_stretch || m_row_params[i].stretch) {
+            m_row_params[i].effective_min = std::max(
+                m_row_params[i].effective_min,
+                static_cast<unsigned int>(m_row_params[i].stretch * greatest_min_over_stretch_ratio));
+            row_effective_min_usable_sizes[i] = std::max(
+                row_effective_min_usable_sizes[i],
+                static_cast<unsigned int>(m_row_params[i].stretch * greatest_usable_min_over_stretch_ratio));
+        }
     }
     greatest_min_over_stretch_ratio = 0.0;
     greatest_usable_min_over_stretch_ratio = 0.0;
+    is_zero_total_stretch = true;
     for (std::size_t i = 0; i < m_column_params.size(); ++i) {
         if (m_column_params[i].stretch) {
             greatest_min_over_stretch_ratio = std::max(greatest_min_over_stretch_ratio, m_column_params[i].effective_min / m_column_params[i].stretch);
@@ -308,10 +317,17 @@ void Layout::SizeMove(const Pt& ul, const Pt& lr)
         }
     }
     for (std::size_t i = 0; i < m_column_params.size(); ++i) {
-        m_column_params[i].effective_min = std::max(m_column_params[i].effective_min, static_cast<unsigned int>(m_column_params[i].stretch * greatest_min_over_stretch_ratio));
-        column_effective_min_usable_sizes[i] = std::max(column_effective_min_usable_sizes[i], static_cast<unsigned int>(m_column_params[i].stretch * greatest_usable_min_over_stretch_ratio));
+        if (is_zero_total_stretch || m_column_params[i].stretch) {
+            m_column_params[i].effective_min = std::max(
+                m_column_params[i].effective_min,
+                static_cast<unsigned int>(m_column_params[i].stretch * greatest_min_over_stretch_ratio));
+            column_effective_min_usable_sizes[i] = std::max(
+                column_effective_min_usable_sizes[i],
+                static_cast<unsigned int>(m_column_params[i].stretch * greatest_usable_min_over_stretch_ratio));
+        }
     }
 
+    //TODO Determine min usable size before stretching to fit space requested
     m_min_usable_size.x = X(2 * m_border_margin);
     for (std::size_t i = 0; i < column_effective_min_usable_sizes.size(); ++i) {
         m_min_usable_size.x += static_cast<int>(column_effective_min_usable_sizes[i]);

--- a/GG/src/TabWnd.cpp
+++ b/GG/src/TabWnd.cpp
@@ -135,10 +135,24 @@ void OverlayWnd::SetCurrentWnd(std::size_t index)
     Wnd* old_current_wnd = CurrentWnd();
     m_current_wnd_index = index;
     Wnd* current_wnd = CurrentWnd();
+    assert(current_wnd);
     if (current_wnd != old_current_wnd) {
+        GG::Pt ul = old_current_wnd ? old_current_wnd->UpperLeft() : current_wnd->UpperLeft();
+        GG::Pt lr = old_current_wnd ? old_current_wnd->LowerRight() : current_wnd->LowerRight();
+        current_wnd->SizeMove(ul, lr);
+
         Layout* layout = GetLayout();
         layout->Remove(old_current_wnd);
         layout->Add(current_wnd, 0, 0);
+
+        if (old_current_wnd)
+            old_current_wnd->SizeMove(ul, lr);
+
+        // Toggle the size to force layout to relayout even though size
+        // has not changed.
+        SizeMove(UpperLeft(), LowerRight() - GG::Pt(GG::X(1), GG::Y(1)));
+        SizeMove(UpperLeft(), LowerRight() + GG::Pt(GG::X(1), GG::Y(1)));
+
     }
 }
 

--- a/GG/src/TabWnd.cpp
+++ b/GG/src/TabWnd.cpp
@@ -177,7 +177,7 @@ TabWnd::TabWnd(X x, Y y, X w, Y h, const boost::shared_ptr<Font>& font, Clr colo
     Connect(m_tab_bar->TabChangedSignal, boost::bind(&TabWnd::TabChanged, this, _1, true));
 
     if (INSTRUMENT_ALL_SIGNALS)
-        Connect(WndChangedSignal, TabChangedEcho("TabWnd::WndChangedSignal"));
+        Connect(TabChangedSignal, TabChangedEcho("TabWnd::TabChangedSignal"));
 }
 
 Pt TabWnd::MinUsableSize() const
@@ -254,7 +254,7 @@ void TabWnd::TabChanged(std::size_t index, bool signal)
     assert(index < m_named_wnds.size());
     m_overlay->SetCurrentWnd(index);
     if (signal)
-        WndChangedSignal(index);
+        TabChangedSignal(index);
 }
 
 

--- a/GG/src/TextControl.cpp
+++ b/GG/src/TextControl.cpp
@@ -195,6 +195,9 @@ void TextControl::SetText(const std::string& str)
     } else {
         RecomputeTextBounds();
     }
+
+    m_cached_minusable_size_width = X0;
+
 }
 
 const boost::shared_ptr<Font>& TextControl::GetFont() const

--- a/GG/src/TextControl.cpp
+++ b/GG/src/TextControl.cpp
@@ -103,7 +103,7 @@ Clr TextControl::TextColor() const
 bool TextControl::ClipText() const
 { return m_clip_text; }
 
-bool TextControl::SetMinSize() const
+bool TextControl::IsResetMinSize() const
 { return m_set_min_size; }
 
 TextControl::operator const std::string&() const
@@ -253,7 +253,7 @@ void TextControl::SetColor(Clr c)
 void TextControl::ClipText(bool b)
 { m_clip_text = b; }
 
-void TextControl::SetMinSize(bool b)
+void TextControl::SetResetMinSize(bool b)
 {
     m_set_min_size = b;
     AdjustMinimumSize();

--- a/GG/src/TextControl.cpp
+++ b/GG/src/TextControl.cpp
@@ -47,7 +47,9 @@ TextControl::TextControl(X x, Y y, X w, Y h, const std::string& str, const boost
     m_set_min_size(false),
     m_code_points(0),
     m_font(font),
-    m_render_cache(0)
+    m_render_cache(0),
+    m_cached_minusable_size_width(X0),
+    m_cached_minusable_size(Pt())
 {
     ValidateFormat();
     SetText(str);
@@ -61,6 +63,21 @@ TextControl::~TextControl()
 
 Pt TextControl::MinUsableSize() const
 { return m_text_lr - m_text_ul; }
+
+Pt TextControl::MinUsableSize(X width) const
+{
+    X min_delta = m_font->SpaceWidth();
+    X abs_delta_w = X(std::abs(Value(m_cached_minusable_size_width - width)));
+    if ( m_cached_minusable_size_width != X0 &&  abs_delta_w < min_delta)
+        return m_cached_minusable_size;
+
+    std::vector<Font::LineData> dummy_line_data;
+    Flags<TextFormat> dummy_format(m_format);
+    m_cached_minusable_size = m_font->DetermineLines(m_text, dummy_format, width, dummy_line_data)
+        + (ClientUpperLeft() - UpperLeft()) + (LowerRight() - ClientLowerRight());
+    m_cached_minusable_size_width = width;
+    return m_cached_minusable_size;
+}
 
 const std::string& TextControl::Text() const
 { return m_text; }
@@ -379,4 +396,5 @@ void TextControl::RecomputeTextBounds()
     else if (m_format & FORMAT_CENTER)
         m_text_ul.x = (Size().x - text_sz.x) / 2.0;
     m_text_lr = m_text_ul + text_sz;
+    AdjustMinimumSize();
 }

--- a/GG/src/Wnd.cpp
+++ b/GG/src/Wnd.cpp
@@ -329,7 +329,7 @@ Pt Wnd::MaxSize() const
 { return m_max_size; }
 
 Pt Wnd::MinUsableSize() const
-{ return Size(); }
+{ return m_layout ? m_layout->MinUsableSize() : Size(); }
 
 Pt Wnd::ClientUpperLeft() const
 { return UpperLeft(); }

--- a/GG/src/dialogs/ThreeButtonDlg.cpp
+++ b/GG/src/dialogs/ThreeButtonDlg.cpp
@@ -144,7 +144,7 @@ void ThreeButtonDlg::Init(const std::string& msg, const boost::shared_ptr<Font>&
     TextControl* message_text = style->NewTextControl(msg, font, m_text_color,
                                                       FORMAT_CENTER | FORMAT_VCENTER | FORMAT_WORDBREAK);
     message_text->Resize(Pt(ClientWidth() - 2 * SPACING, Height()));
-    message_text->SetMinSize(true);
+    message_text->SetResetMinSize(true);
     layout->Add(message_text, 0, 0);
     layout->SetRowStretch(0, 1);
     layout->SetMinimumRowHeight(1, BUTTON_HEIGHT);

--- a/UI/AccordionPanel.cpp
+++ b/UI/AccordionPanel.cpp
@@ -3,10 +3,11 @@
 #include "ClientUI.h"
 #include "CUIControls.h"
 
-AccordionPanel::AccordionPanel(GG::X w, GG::Y h) :
+AccordionPanel::AccordionPanel(GG::X w, GG::Y h, bool is_button_on_left /*= false*/) :
     GG::Control(GG::X0, GG::Y0, w, h, GG::INTERACTIVE),
     m_expand_button(0),
     m_collapsed(true),
+    m_is_left(is_button_on_left),
     m_interior_color(ClientUI::WndColor())
 {
     boost::filesystem::path button_texture_dir = ClientUI::ArtDir() / "icons" / "buttons";
@@ -38,8 +39,11 @@ void AccordionPanel::InitBuffer() {
     m_border_buffer.createServerBuffer();
 }
 
+GG::Pt AccordionPanel::ClientUpperLeft() const
+{ return UpperLeft() + GG::Pt((m_is_left ? GG::X(EXPAND_BUTTON_SIZE) : GG::X0), GG::Y0); }
+
 GG::Pt AccordionPanel::ClientLowerRight() const
-{ return LowerRight() - GG::Pt(GG::X(EXPAND_BUTTON_SIZE), GG::Y0); }
+{ return LowerRight() - GG::Pt((m_is_left ? GG::X0 : GG::X(EXPAND_BUTTON_SIZE)), GG::Y0); }
 
 void AccordionPanel::SetInteriorColor(GG::Clr c)
 { m_interior_color = c; }
@@ -104,7 +108,7 @@ bool AccordionPanel::IsCollapsed() const {
 }
 
 void AccordionPanel::DoLayout() {
-    GG::Pt expand_button_ul(Width() - EXPAND_BUTTON_SIZE, GG::Y0);
+    GG::Pt expand_button_ul(m_is_left ? GG::X(-EXPAND_BUTTON_SIZE) : (Width() - EXPAND_BUTTON_SIZE), GG::Y0);
     GG::Pt expand_button_lr = expand_button_ul + GG::Pt(GG::X(EXPAND_BUTTON_SIZE), GG::Y(EXPAND_BUTTON_SIZE));
     m_expand_button->SizeMove(expand_button_ul, expand_button_lr);
 }

--- a/UI/AccordionPanel.cpp
+++ b/UI/AccordionPanel.cpp
@@ -8,7 +8,8 @@ AccordionPanel::AccordionPanel(GG::X w, GG::Y h, bool is_button_on_left /*= fals
     m_expand_button(0),
     m_collapsed(true),
     m_is_left(is_button_on_left),
-    m_interior_color(ClientUI::WndColor())
+    m_interior_color(ClientUI::WndColor()),
+    m_border_margin(0)
 {
     boost::filesystem::path button_texture_dir = ClientUI::ArtDir() / "icons" / "buttons";
 
@@ -40,13 +41,16 @@ void AccordionPanel::InitBuffer() {
 }
 
 GG::Pt AccordionPanel::ClientUpperLeft() const
-{ return UpperLeft() + GG::Pt((m_is_left ? GG::X(EXPAND_BUTTON_SIZE) : GG::X0), GG::Y0); }
+{ return UpperLeft() + GG::Pt((m_is_left ? GG::X(EXPAND_BUTTON_SIZE + m_border_margin) : GG::X0), GG::Y0); }
 
 GG::Pt AccordionPanel::ClientLowerRight() const
-{ return LowerRight() - GG::Pt((m_is_left ? GG::X0 : GG::X(EXPAND_BUTTON_SIZE)), GG::Y0); }
+{ return LowerRight() - GG::Pt((m_is_left ? GG::X0 : GG::X(EXPAND_BUTTON_SIZE + m_border_margin)), GG::Y0); }
 
 void AccordionPanel::SetInteriorColor(GG::Clr c)
 { m_interior_color = c; }
+
+void AccordionPanel::SetBorderMargin(unsigned int margin)
+{ m_border_margin = margin; }
 
 void AccordionPanel::Render() {
     if (Height() < 1 || Width() < 1)
@@ -108,7 +112,8 @@ bool AccordionPanel::IsCollapsed() const {
 }
 
 void AccordionPanel::DoLayout() {
-    GG::Pt expand_button_ul(m_is_left ? GG::X(-EXPAND_BUTTON_SIZE) : (Width() - EXPAND_BUTTON_SIZE), GG::Y0);
+    GG::Pt expand_button_ul(m_is_left ? GG::X(-(EXPAND_BUTTON_SIZE + m_border_margin))
+                            : (Width() + GG::X(-(EXPAND_BUTTON_SIZE + m_border_margin))), GG::Y0);
     GG::Pt expand_button_lr = expand_button_ul + GG::Pt(GG::X(EXPAND_BUTTON_SIZE), GG::Y(EXPAND_BUTTON_SIZE));
     m_expand_button->SizeMove(expand_button_ul, expand_button_lr);
 }

--- a/UI/AccordionPanel.cpp
+++ b/UI/AccordionPanel.cpp
@@ -3,9 +3,11 @@
 #include "ClientUI.h"
 #include "CUIControls.h"
 
-AccordionPanel::AccordionPanel(GG::X w) :
-    GG::Wnd(GG::X0, GG::Y0, w, GG::Y(ClientUI::Pts()*2), GG::INTERACTIVE),
-    m_expand_button(0)
+AccordionPanel::AccordionPanel(GG::X w, GG::Y h) :
+    GG::Control(GG::X0, GG::Y0, w, h, GG::INTERACTIVE),
+    m_expand_button(0),
+    m_collapsed(true),
+    m_interior_color(ClientUI::WndColor())
 {
     boost::filesystem::path button_texture_dir = ClientUI::ArtDir() / "icons" / "buttons";
 
@@ -13,7 +15,8 @@ AccordionPanel::AccordionPanel(GG::X w) :
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "downarrownormal.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "downarrowclicked.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "downarrowmouseover.png")));
-    m_expand_button->SetMinSize(GG::Pt(GG::X(16), GG::Y(16)));
+    m_expand_button->SetMinSize(GG::Pt(GG::X(EXPAND_BUTTON_SIZE), GG::Y(EXPAND_BUTTON_SIZE)));
+    m_expand_button->NonClientChild(true);
 
     AttachChild(m_expand_button);
 
@@ -35,6 +38,12 @@ void AccordionPanel::InitBuffer() {
     m_border_buffer.createServerBuffer();
 }
 
+GG::Pt AccordionPanel::ClientLowerRight() const
+{ return LowerRight() - GG::Pt(GG::X(EXPAND_BUTTON_SIZE), GG::Y0); }
+
+void AccordionPanel::SetInteriorColor(GG::Clr c)
+{ m_interior_color = c; }
+
 void AccordionPanel::Render() {
     if (Height() < 1 || Width() < 1)
         return;
@@ -49,7 +58,7 @@ void AccordionPanel::Render() {
     glEnableClientState(GL_VERTEX_ARRAY);
 
     m_border_buffer.activate();
-    glColor(ClientUI::WndColor());
+    glColor(m_interior_color);
     glDrawArrays(GL_TRIANGLE_FAN,   0, m_border_buffer.size() - 1);
     glColor(ClientUI::WndOuterBorderColor());
     glDrawArrays(GL_LINE_STRIP,     0, m_border_buffer.size());
@@ -76,6 +85,7 @@ void AccordionPanel::SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
 void AccordionPanel::SetCollapsed(bool collapsed) {
     boost::filesystem::path button_texture_dir = ClientUI::ArtDir() / "icons" / "buttons";
 
+    m_collapsed = collapsed;
     if (!collapsed) {
         m_expand_button->SetUnpressedGraphic(GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "uparrownormal.png"   )));
         m_expand_button->SetPressedGraphic  (GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "uparrowclicked.png"  )));
@@ -89,8 +99,12 @@ void AccordionPanel::SetCollapsed(bool collapsed) {
     ExpandCollapseSignal();
 }
 
+bool AccordionPanel::IsCollapsed() const {
+    return m_collapsed;
+}
+
 void AccordionPanel::DoLayout() {
-    GG::Pt expand_button_ul(Width() - 16, GG::Y0);
-    GG::Pt expand_button_lr = expand_button_ul + GG::Pt(GG::X(16), GG::Y(16));
+    GG::Pt expand_button_ul(Width() - EXPAND_BUTTON_SIZE, GG::Y0);
+    GG::Pt expand_button_lr = expand_button_ul + GG::Pt(GG::X(EXPAND_BUTTON_SIZE), GG::Y(EXPAND_BUTTON_SIZE));
     m_expand_button->SizeMove(expand_button_ul, expand_button_lr);
 }

--- a/UI/AccordionPanel.h
+++ b/UI/AccordionPanel.h
@@ -11,10 +11,11 @@ public:
     static const int EXPAND_BUTTON_SIZE = 16;
 
     /** \name Structors */ //@{
-    AccordionPanel(GG::X w, GG::Y h);
+    AccordionPanel(GG::X w, GG::Y h, bool is_button_on_left = false);
     virtual ~AccordionPanel();
     //@}
 
+    virtual GG::Pt ClientUpperLeft() const;
     virtual GG::Pt ClientLowerRight() const;
 
     /** \name Mutators */ //@{
@@ -37,8 +38,9 @@ protected:
     virtual void    DoLayout();
     virtual void    InitBuffer();
 
-    GG::Button*             m_expand_button;    ///< at top right of panel, toggles the panel open/closed to show details or minimal summary
+    GG::Button*             m_expand_button;    ///< at top right/left of panel, toggles the panel open/closed to show details or minimal summary
     bool                    m_collapsed;
+    bool                    m_is_left; ///< Is expand button on the left?
 
     GG::Clr                 m_interior_color;
 };

--- a/UI/AccordionPanel.h
+++ b/UI/AccordionPanel.h
@@ -28,7 +28,8 @@ public:
 
     //@}
 
-    mutable boost::signals2::signal<void ()> ExpandCollapseSignal;
+    typedef boost::signals2::signal<void ()> ExpandCollapseSignalType;
+    mutable ExpandCollapseSignalType ExpandCollapseSignal;
 
 protected:
     GG::GL2DVertexBuffer    m_border_buffer;

--- a/UI/AccordionPanel.h
+++ b/UI/AccordionPanel.h
@@ -4,18 +4,27 @@
 #include <GG/GGFwd.h>
 #include <GG/Wnd.h>
 #include <GG/GLClientAndServerBuffer.h>
+#include "GG/Control.h"
 
-class AccordionPanel : public GG::Wnd {
+class AccordionPanel : public GG::Control {
 public:
+    static const int EXPAND_BUTTON_SIZE = 16;
+
     /** \name Structors */ //@{
-    AccordionPanel(GG::X w);
+    AccordionPanel(GG::X w, GG::Y h);
     virtual ~AccordionPanel();
     //@}
+
+    virtual GG::Pt ClientLowerRight() const;
 
     /** \name Mutators */ //@{
     virtual void Render();
     virtual void MouseWheel(const GG::Pt& pt, int move, GG::Flags<GG::ModKey> mod_keys);
     virtual void SizeMove(const GG::Pt& ul, const GG::Pt& lr);
+
+    /** Sets the interior color of the box. */
+    void SetInteriorColor(GG::Clr c);
+
     //@}
 
     mutable boost::signals2::signal<void ()> ExpandCollapseSignal;
@@ -24,10 +33,14 @@ protected:
     GG::GL2DVertexBuffer    m_border_buffer;
 
     void            SetCollapsed(bool collapsed);
+    bool            IsCollapsed() const;
     virtual void    DoLayout();
     virtual void    InitBuffer();
 
     GG::Button*             m_expand_button;    ///< at top right of panel, toggles the panel open/closed to show details or minimal summary
+    bool                    m_collapsed;
+
+    GG::Clr                 m_interior_color;
 };
 
 #endif

--- a/UI/AccordionPanel.h
+++ b/UI/AccordionPanel.h
@@ -26,6 +26,10 @@ public:
     /** Sets the interior color of the box. */
     void SetInteriorColor(GG::Clr c);
 
+    /** Set the number of pixels between the expansion symbol and the
+        client area. */
+    void SetBorderMargin(unsigned int margin);
+
     //@}
 
     typedef boost::signals2::signal<void ()> ExpandCollapseSignalType;
@@ -44,6 +48,9 @@ protected:
     bool                    m_is_left; ///< Is expand button on the left?
 
     GG::Clr                 m_interior_color;
+
+    /// The number of pixels between the expansion button and the client area.
+    unsigned int            m_border_margin;
 };
 
 #endif

--- a/UI/BuildingsPanel.cpp
+++ b/UI/BuildingsPanel.cpp
@@ -50,7 +50,7 @@ namespace {
 }
 
 BuildingsPanel::BuildingsPanel(GG::X w, int columns, int planet_id) :
-    AccordionPanel(w),
+    AccordionPanel(w, GG::Y(ClientUI::Pts()*2)),
     m_planet_id(planet_id),
     m_columns(columns),
     m_building_indicators()

--- a/UI/CombatReport/CombatLogWnd.cpp
+++ b/UI/CombatReport/CombatLogWnd.cpp
@@ -45,7 +45,9 @@ namespace {
         for (std::map<int,int>::const_iterator it = count_per_empire.begin(); it != count_per_empire.end(); ) {
             std::string owner_string = UserString("NEUTRAL");
             if (const Empire* owner = GetEmpire(it->first))
-                owner_string = GG::RgbaTag(owner->Color()) + owner->Name() + "</rgba>";
+                owner_string = GG::RgbaTag(owner->Color()) + "<" + VarText::EMPIRE_ID_TAG + " "
+                    + boost::lexical_cast<std::string>(owner->EmpireID()) + ">" + owner->Name()
+                    + "</" + VarText::EMPIRE_ID_TAG + ">" + "</rgba>";
             ss << owner_string << ": " << it->second;
             ++it;
             if (it != count_per_empire.end())
@@ -214,6 +216,8 @@ LinkText * CombatLogWnd::DecorateLinkText(std::string const & text) {
 
     links->SetDecorator(VarText::SHIP_ID_TAG, new ColorByOwner());
     links->SetDecorator(VarText::PLANET_ID_TAG, new ColorByOwner());
+    links->SetDecorator(VarText::SYSTEM_ID_TAG, new ColorByOwner());
+    links->SetDecorator(VarText::EMPIRE_ID_TAG, new ColorByOwner());
 
     GG::Connect(links->LinkClickedSignal,       &CombatLogWnd::HandleLinkClick,          this);
     GG::Connect(links->LinkDoubleClickedSignal, &CombatLogWnd::HandleLinkDoubleClick,    this);

--- a/UI/CombatReport/CombatLogWnd.cpp
+++ b/UI/CombatReport/CombatLogWnd.cpp
@@ -1,5 +1,6 @@
 #include "CombatLogWnd.h"
 
+#include <GG/Layout.h>
 #include "../LinkText.h"
 
 #include "../../client/human/HumanClientApp.h"
@@ -10,6 +11,7 @@
 #include "../../util/i18n.h"
 #include "../../util/Logger.h"
 #include "../../universe/UniverseObject.h"
+#include "../AccordionPanel.h"
 #include "../../Empire/Empire.h"
 
 namespace {
@@ -92,48 +94,79 @@ namespace {
     }
 }
 
-
-CombatLogWnd::CombatLogWnd() :
-    CUILinkTextMultiEdit("", GG::MULTI_WORDBREAK | GG::MULTI_READ_ONLY)
+CombatLogWnd::CombatLogWnd(GG::X w, GG::Y h) :
+    GG::Wnd(GG::X0, GG::Y0, w, h, GG::NO_WND_FLAGS),
+    m_text_format_flags(GG::FORMAT_WORDBREAK| GG::FORMAT_LEFT | GG::FORMAT_TOP)
 {
-    SetDecorator(VarText::SHIP_ID_TAG, new ColorByOwner());
-    SetDecorator(VarText::PLANET_ID_TAG, new ColorByOwner());
+    SetName("CombatLogWnd");
+}
+
+void CombatLogWnd::HandleLinkClick(const std::string& link_type, const std::string& data)
+{ LinkClickedSignal(link_type, data); }
+void CombatLogWnd::HandleLinkDoubleClick(const std::string& link_type, const std::string& data)
+{ LinkDoubleClickedSignal(link_type, data); }
+void CombatLogWnd::HandleLinkRightClick(const std::string& link_type, const std::string& data)
+{ LinkRightClickedSignal(link_type, data); }
+
+
+LinkText * CombatLogWnd::DecorateLinkText(std::string const & text) {
+    LinkText * links = new LinkText(GG::X0, GG::Y0, text, ClientUI::GetFont(), GG::CLR_WHITE);
+
+    links->SetTextFormat(m_text_format_flags);
+
+    links->SetDecorator(VarText::SHIP_ID_TAG, new ColorByOwner());
+    links->SetDecorator(VarText::PLANET_ID_TAG, new ColorByOwner());
+
+    GG::Connect(links->LinkClickedSignal,       &CombatLogWnd::HandleLinkClick,          this);
+    GG::Connect(links->LinkDoubleClickedSignal, &CombatLogWnd::HandleLinkDoubleClick,    this);
+    GG::Connect(links->LinkRightClickedSignal,  &CombatLogWnd::HandleLinkDoubleClick,    this);
+
+    return links;
+}
+
+void CombatLogWnd::AddRow(GG::Wnd * wnd) {
+    if( GG::Layout * layout = GetLayout())
+        layout->Add(wnd, layout->Rows(), 0);
 }
 
 void CombatLogWnd::SetLog(int log_id) {
-    std::stringstream detailed_description;
-    bool available = CombatLogAvailable(log_id);
-    if (!available) {
-        ErrorLogger() << "EncyclopediaDetailPanel::Refresh couldn't find combat log with id: " << log_id;
+    if (!CombatLogAvailable(log_id)) {
+        ErrorLogger() << "Couldn't find combat log with id: " << log_id;
         return;
     }
+
+    DeleteChildren();
+    GG::Layout* layout = new GG::Layout(UpperLeft().x, UpperLeft().y, Width(), Height()
+                                        , 1, 1 ///< numrows, numcols
+                                        , 0, 0 ///< wnd margin, cell margin
+                                       );
+    SetLayout(layout);
+
     const CombatLog& log = GetCombatLog(log_id);
     int client_empire_id = HumanClientApp::GetApp()->EmpireID();
 
     DebugLogger() << "Setting log with " << log.combat_events.size() << " events";
 
-    std::string name = UserString("ENC_COMBAT_LOG");
-    boost::shared_ptr<GG::Texture> texture = ClientUI::GetTexture(ClientUI::ArtDir() / "/icons/sitrep/combat.png", true);
-    std::string general_type = UserString("ENC_COMBAT_LOG");
-
     TemporaryPtr<const System> system = GetSystem(log.system_id);
     const std::string& sys_name = (system ? system->PublicName(client_empire_id) : UserString("ERROR"));
 
-    detailed_description << str(FlexibleFormat(UserString("ENC_COMBAT_LOG_DESCRIPTION_STR"))
+    AddRow(DecorateLinkText(str(FlexibleFormat(UserString("ENC_COMBAT_LOG_DESCRIPTION_STR"))
                                 % LinkTaggedIDText(VarText::SYSTEM_ID_TAG, log.system_id, sys_name)
-                                % log.turn) + "\n";
-
-    detailed_description <<"\n"+ UserString("COMBAT_INITIAL_FORCES") + "\n" + CountsToText(CountByOwner(log.object_ids))+"\n";
+                                % log.turn) + "\n"
+                           ));
+    AddRow(DecorateLinkText(UserString("COMBAT_INITIAL_FORCES")));
+    AddRow(DecorateLinkText(CountsToText(CountByOwner(log.object_ids))));
 
     for (std::vector<CombatEventPtr>::const_iterator it = log.combat_events.begin();
-         it != log.combat_events.end(); ++it)
-    {
+         it != log.combat_events.end(); ++it) {
         DebugLogger() << "event debug info: " << it->get()->DebugString();
 
         if (const BoutBeginEvent* bout_begin = dynamic_cast<BoutBeginEvent*>(it->get())) {
-            detailed_description << str(FlexibleFormat(UserString("ENC_ROUND_BEGIN")) % bout_begin->bout) + "\n";
+            AddRow(DecorateLinkText(str(FlexibleFormat(UserString("ENC_ROUND_BEGIN")) % bout_begin->bout)));
 
         } else if (const AttackEvent* attack = dynamic_cast<AttackEvent*>(it->get())) {
+            std::stringstream event_title;
+            std::stringstream event_detail;
             std::string attacker_link;
             if (attack->attacker_id >= 0)   // ship
                 attacker_link = PublicNameLink(client_empire_id, attack->attacker_id, UserString("ENC_COMBAT_UNKNOWN_OBJECT"));
@@ -144,12 +177,15 @@ void CombatLogWnd::SetLog(int log_id) {
 
             const std::string& template_str = UserString("ENC_COMBAT_ATTACK_STR");
 
-            detailed_description << str(FlexibleFormat(template_str)
+            AddRow(DecorateLinkText(str(FlexibleFormat(template_str)
                                         % attacker_link
                                         % target_link
                                         % attack->damage
                                         % attack->bout
-                                        % attack->round) + "\n";
+                                        % attack->round)));
+
+            DebugLogger() << " Attack Event is " << event_title.str();
+
 
         } else if (const IncapacitationEvent* incapacitation = dynamic_cast<IncapacitationEvent*>(it->get())) {
             TemporaryPtr<const UniverseObject> object = GetUniverseObject(incapacitation->object_id);
@@ -177,7 +213,7 @@ void CombatLogWnd::SetLog(int log_id) {
             if (const Empire* owner = GetEmpire(owner_id))
                 owner_string += owner->Name() + " ";
 
-            detailed_description << str(FlexibleFormat(template_str) % owner_string % object_str) + "\n";
+            AddRow(DecorateLinkText(str(FlexibleFormat(template_str) % owner_string % object_str)));
 
         } else if (const FighterLaunchEvent* launch = dynamic_cast<FighterLaunchEvent*>(it->get())) {
             std::string launched_from_link = PublicNameLink(client_empire_id, launch->launched_from_id, UserString("ENC_COMBAT_UNKNOWN_OBJECT"));
@@ -188,13 +224,12 @@ void CombatLogWnd::SetLog(int log_id) {
                                                 UserString("ENC_COMBAT_LAUNCH_STR") :
                                                 UserString("ENC_COMBAT_RECOVER_STR"));
 
-            detailed_description << str(FlexibleFormat(template_str)
+            AddRow(DecorateLinkText(str(FlexibleFormat(template_str)
                                         % launched_from_link
                                         % empire_coloured_fighter
                                         % std::abs(launch->number_launched)
                                         % attack->bout
-                                        % attack->round) + "\n";
-
+                                        % attack->round)));
         } else if (const FighterAttackedEvent* fighter_attack = dynamic_cast<FighterAttackedEvent*>(it->get())) {
             std::string attacked_by;
             if (fighter_attack->attacked_by_object_id >= 0) // attacked by ship or planet
@@ -205,15 +240,37 @@ void CombatLogWnd::SetLog(int log_id) {
 
             const std::string& template_str = UserString("ENC_COMBAT_ATTACK_SIMPLE_STR");
 
-            detailed_description << str(FlexibleFormat(template_str)
+            AddRow(DecorateLinkText(str(FlexibleFormat(template_str)
                                         % attacked_by
                                         % empire_coloured_attacked_fighter
                                         % attack->bout
-                                        % attack->round) + "\n";
+                                        % attack->round)));
         }
     }
 
-    detailed_description << "\n" + UserString("COMBAT_SUMMARY_DESTROYED") + "\n" + CountsToText(CountByOwner(log.destroyed_object_ids));
+    std::stringstream summary_text;
+    summary_text << "\n" + UserString("COMBAT_SUMMARY_DESTROYED")
+        + "\n" + CountsToText(CountByOwner(log.destroyed_object_ids));
 
-    SetText(detailed_description.str());
+    AddRow(DecorateLinkText(summary_text.str()));
+
+    //Add a dummy row that the layout manager can use to add space.
+    AddRow(DecorateLinkText(""));
+    layout->SetRowStretch(layout->Rows() - 1, 1);
+
+}
+
+GG::Pt CombatLogWnd::ClientUpperLeft() const
+{ return UpperLeft() + GG::Pt(GG::X(MARGIN), GG::Y(MARGIN)); }
+
+GG::Pt CombatLogWnd::ClientLowerRight() const
+{ return LowerRight() - GG::Pt(GG::X(MARGIN), GG::Y(MARGIN)); }
+
+void CombatLogWnd::Render() {
+    GG::Clr interior_color =  ClientUI::CtrlColor();
+    GG::Clr border_color = ClientUI::CtrlBorderColor();
+
+    GG::Pt ul = UpperLeft(), lr = LowerRight();
+
+    FlatRectangle(ul, lr, interior_color, border_color, 1);
 }

--- a/UI/CombatReport/CombatLogWnd.cpp
+++ b/UI/CombatReport/CombatLogWnd.cpp
@@ -83,6 +83,9 @@ namespace {
         LinkText * title;
         std::vector<GG::Wnd *> details;
 
+        //distance between expansion symbol and text
+        static const unsigned int BORDER_MARGIN = 5;
+
     };
 
     CombatLogAccordionPanel::CombatLogAccordionPanel(
@@ -98,6 +101,8 @@ namespace {
 
         GG::Connect(m_expand_button->LeftClickedSignal, &CombatLogAccordionPanel::ToggleExpansion, this);
         GG::Connect(this->ExpandCollapseSignal, &CombatLogWnd::HandleWndChanged, &log);
+
+        SetBorderMargin(BORDER_MARGIN);
 
         SetLayout(new GG::Layout(UpperLeft().x, UpperLeft().y, Width(), Height(), 1, 1));
         GetLayout()->Add(title, 0, 0, 1, 1);

--- a/UI/CombatReport/CombatLogWnd.cpp
+++ b/UI/CombatReport/CombatLogWnd.cpp
@@ -355,9 +355,7 @@ std::vector<GG::Wnd *> CombatLogWnd::CombatLogWndImpl::MakeCombatLogPanel(
         return new_logs;
     }
 
-    //Note:: detail string is parsed again in the AccordionPanel
-    std::string details = event->CombatLogDetails(viewing_empire_id);
-    if (!event->FlattenSubEvents() && !details.empty()) {
+    if (!event->FlattenSubEvents() && !event->AreDetailsEmpty(viewing_empire_id)) {
         new_logs.push_back(new CombatLogAccordionPanel(w, *this, viewing_empire_id, event));
         return new_logs;
     }
@@ -366,6 +364,7 @@ std::vector<GG::Wnd *> CombatLogWnd::CombatLogWndImpl::MakeCombatLogPanel(
     if (!(event->FlattenSubEvents() && title.empty()))
         new_logs.push_back(DecorateLinkText(title));
 
+    std::string details = event->CombatLogDetails(viewing_empire_id);
     PopulateWithFlatLogs(w, viewing_empire_id, new_logs, event, details);
 
     return new_logs;

--- a/UI/CombatReport/CombatLogWnd.cpp
+++ b/UI/CombatReport/CombatLogWnd.cpp
@@ -230,6 +230,10 @@ void CombatLogWnd::SetLog(int log_id) {
     //Add a dummy row that the layout manager can use to add space.
     AddRow(DecorateLinkText(""));
     layout->SetRowStretch(layout->Rows() - 1, 1);
+
+    if (Parent()) {
+        SizeMove(Parent()->ClientUpperLeft(), Parent()->ClientLowerRight());
+    }
 }
 
 GG::Pt CombatLogWnd::ClientUpperLeft() const

--- a/UI/CombatReport/CombatLogWnd.cpp
+++ b/UI/CombatReport/CombatLogWnd.cpp
@@ -366,3 +366,6 @@ GG::Pt CombatLogWnd::ClientLowerRight() const
 
 GG::Pt CombatLogWnd::MinUsableSize() const
 { return pimpl->MinUsableSize(); }
+
+void CombatLogWnd::HandleMadeVisible()
+{ return pimpl->HandleWndChanged(); }

--- a/UI/CombatReport/CombatLogWnd.cpp
+++ b/UI/CombatReport/CombatLogWnd.cpp
@@ -14,11 +14,16 @@
 #include "../AccordionPanel.h"
 #include "../../Empire/Empire.h"
 
+
 namespace {
+    typedef boost::shared_ptr<LinkText> LinkTextPtr;
+
     const std::string EMPTY_STRING;
 
-    std::map<int, int> CountByOwner(const std::set<int>& objects) {
+    std::map<int, int> CountByOwner(const std::set<int>& owners, const std::set<int>& objects) {
         std::map<int, int> objects_per_owner;
+        for (std::set<int>::const_iterator it = owners.begin(); it != owners.end(); ++it)
+            objects_per_owner[*it] = 0;
         for (std::set<int>::const_iterator it = objects.begin(); it != objects.end(); ++it) {
             TemporaryPtr<const UniverseObject> object = Objects().Object(*it);
             if (object && (
@@ -48,11 +53,105 @@ namespace {
         }
         return ss.str();
     }
+
+    //Returns either a simple LinkText for a simple log or a CombatLogAccordionPanel for a complex log
+    GG::Wnd * MakeCombatLogPanel(
+        GG::X w, CombatLogWnd &log, int viewing_empire_id, ConstCombatEventPtr event);
+
+    /// A Single section in the CombatLog showing general outline of a ship's combat
+    /// and expanding into specifics.
+    class CombatLogAccordionPanel : public AccordionPanel {
+        public:
+        CombatLogAccordionPanel(GG::X w, CombatLogWnd &log_, int viewing_empire_id_, ConstCombatEventPtr event_);
+        ~CombatLogAccordionPanel();
+        private:
+        /** toggles panel expanded or collapsed */
+        void ToggleExpansion();
+
+        CombatLogWnd & log;
+        int viewing_empire_id;
+        ConstCombatEventPtr event;
+        LinkText * title;
+        std::vector<GG::Wnd *> details;
+
+    };
+
+    CombatLogAccordionPanel::CombatLogAccordionPanel(
+        GG::X w, CombatLogWnd &log_, int viewing_empire_id_, ConstCombatEventPtr event_) :
+        AccordionPanel(w, GG::Y(ClientUI::Pts())),
+        log(log_),
+        viewing_empire_id(viewing_empire_id_),
+        event(event_),
+        title(log.DecorateLinkText(event->CombatLogDescription(viewing_empire_id))),
+        details()
+    {
+        AccordionPanel::SetInteriorColor(ClientUI::CtrlColor());
+
+        GG::Connect(m_expand_button->LeftClickedSignal, &CombatLogAccordionPanel::ToggleExpansion, this);
+
+        SetLayout(new GG::Layout(UpperLeft().x, UpperLeft().y, Width(), Height(), 1, 1));
+        GetLayout()->Add(title, 0, 0, 1, 1);
+        SetCollapsed(true);
+    }
+
+    CombatLogAccordionPanel::~CombatLogAccordionPanel() {
+        if (!IsCollapsed() && !details.empty()) {
+            for (std::vector<GG::Wnd *>::iterator it = details.begin(); it != details.end(); ++it) {
+                delete *it;
+            }
+        }
+    }
+
+    void CombatLogAccordionPanel::ToggleExpansion() {
+        DebugLogger() << "Expand/Collapse of detailed combat log.";
+        bool new_collapsed = !IsCollapsed();
+        if (new_collapsed) {
+            for (std::vector<GG::Wnd *>::iterator it = details.begin(); it != details.end(); ++it) {
+                GetLayout()->Remove(*it);
+            }
+        } else {
+            if (details.empty()) {
+                std::string detail_text = event->CombatLogDetails(viewing_empire_id);
+                if (!detail_text.empty()){
+                    details.push_back(log.DecorateLinkText(detail_text));
+                }
+                if (!event->AreSubEventsEmpty(viewing_empire_id)) {
+                    std::vector<ConstCombatEventPtr> sub_events = event->SubEvents(viewing_empire_id);
+                    for (std::vector<ConstCombatEventPtr>::iterator sub_event_it = sub_events.begin();
+                         sub_event_it != sub_events.end(); ++sub_event_it) {
+                        details.push_back(MakeCombatLogPanel(Width(), log, viewing_empire_id, *sub_event_it));
+                    }
+                }
+            }
+
+            for (std::vector<GG::Wnd *>::iterator it = details.begin(); it != details.end(); ++it) {
+                GetLayout()->Add(*it, GetLayout()->Rows(), 0);
+            }
+        }
+        SetCollapsed(new_collapsed);
+    }
+
+    //Returns either a simple LinkText for a simple log or a CombatLogAccordionPanel for a complex log
+    GG::Wnd * MakeCombatLogPanel(
+        GG::X w, CombatLogWnd &log, int viewing_empire_id, ConstCombatEventPtr event) {
+        if (!event->AreSubEventsEmpty(viewing_empire_id)) {
+            return new CombatLogAccordionPanel(w, log, viewing_empire_id, event);
+        }
+
+        //Note:: detail string is parsed again in the AccordionPanel
+        std::string details = event->CombatLogDetails(viewing_empire_id);
+        if (!details.empty() ) {
+            return new CombatLogAccordionPanel(w, log, viewing_empire_id, event);
+        }
+
+        return log.DecorateLinkText(event->CombatLogDescription(viewing_empire_id));
+    }
 }
 
 CombatLogWnd::CombatLogWnd(GG::X w, GG::Y h) :
     GG::Wnd(GG::X0, GG::Y0, w, h, GG::NO_WND_FLAGS),
-    m_text_format_flags(GG::FORMAT_WORDBREAK| GG::FORMAT_LEFT | GG::FORMAT_TOP)
+    m_text_format_flags(GG::FORMAT_WORDBREAK| GG::FORMAT_LEFT | GG::FORMAT_TOP),
+    m_font(ClientUI::GetFont())
 {
     SetName("CombatLogWnd");
 }
@@ -66,7 +165,7 @@ void CombatLogWnd::HandleLinkRightClick(const std::string& link_type, const std:
 
 
 LinkText * CombatLogWnd::DecorateLinkText(std::string const & text) {
-    LinkText * links = new LinkText(GG::X0, GG::Y0, text, ClientUI::GetFont(), GG::CLR_WHITE);
+    LinkText * links = new LinkText(GG::X0, GG::Y0, text, m_font, GG::CLR_WHITE);
 
     links->SetTextFormat(m_text_format_flags);
 
@@ -84,6 +183,9 @@ void CombatLogWnd::AddRow(GG::Wnd * wnd) {
     if( GG::Layout * layout = GetLayout())
         layout->Add(wnd, layout->Rows(), 0);
 }
+
+void CombatLogWnd::SetFont(boost::shared_ptr<GG::Font> font)
+{ m_font = font; }
 
 void CombatLogWnd::SetLog(int log_id) {
     if (!CombatLogAvailable(log_id)) {
@@ -111,20 +213,19 @@ void CombatLogWnd::SetLog(int log_id) {
                                 % log.turn) + "\n"
                            ));
     AddRow(DecorateLinkText(UserString("COMBAT_INITIAL_FORCES")));
-    AddRow(DecorateLinkText(CountsToText(CountByOwner(log.object_ids))));
+    AddRow(DecorateLinkText(CountsToText(CountByOwner(log.empire_ids, log.object_ids))));
+
+    std::stringstream summary_text;
+    summary_text << std::endl << UserString("COMBAT_SUMMARY_DESTROYED")
+                 << std::endl << CountsToText(CountByOwner(log.empire_ids, log.destroyed_object_ids));
+    AddRow(DecorateLinkText(summary_text.str()));
 
     for (std::vector<CombatEventPtr>::const_iterator it = log.combat_events.begin();
          it != log.combat_events.end(); ++it) {
         DebugLogger() << "event debug info: " << it->get()->DebugString();
 
-        AddRow(DecorateLinkText(it->get()->CombatLogDescription(client_empire_id)));
+        AddRow(MakeCombatLogPanel(m_font->SpaceWidth()*10, *this, client_empire_id, *it));
     }
-
-    std::stringstream summary_text;
-    summary_text << "\n" + UserString("COMBAT_SUMMARY_DESTROYED")
-        + "\n" + CountsToText(CountByOwner(log.destroyed_object_ids));
-
-    AddRow(DecorateLinkText(summary_text.str()));
 
     //Add a dummy row that the layout manager can use to add space.
     AddRow(DecorateLinkText(""));

--- a/UI/CombatReport/CombatLogWnd.cpp
+++ b/UI/CombatReport/CombatLogWnd.cpp
@@ -311,7 +311,6 @@ LinkText * CombatLogWnd::CombatLogWndImpl::DecorateLinkText(std::string const & 
     links->SetDecorator(VarText::SYSTEM_ID_TAG, new ColorByOwner());
     links->SetDecorator(VarText::EMPIRE_ID_TAG, new ColorByOwner());
 
-
     links->LinkClickedSignal.connect(m_wnd.LinkClickedSignal);
     links->LinkDoubleClickedSignal.connect(m_wnd.LinkDoubleClickedSignal);
     links->LinkRightClickedSignal.connect(m_wnd.LinkRightClickedSignal);

--- a/UI/CombatReport/CombatLogWnd.cpp
+++ b/UI/CombatReport/CombatLogWnd.cpp
@@ -33,10 +33,7 @@ public:
     void AddRow(GG::Wnd * wnd);
     //@}
 
-    /**These handlers just echo the signals from contained log objects to the above signals*/
-    void HandleLinkClick(const std::string& link_type, const std::string& data);
-    void HandleLinkDoubleClick(const std::string& link_type, const std::string& data);
-    void HandleLinkRightClick(const std::string& link_type, const std::string& data);
+    /** When windows changes forces a re-layout */
     void HandleWndChanged();
 
     /** DecorateLinkText creates a CUILinkTextMultiEdit using \a text and attaches it to handlers
@@ -188,13 +185,6 @@ GG::Pt CombatLogWnd::CombatLogWndImpl::MinUsableSize() const {
     return GG::Pt(m_font->SpaceWidth()*20, m_font->Lineskip()*10);
 }
 
-void CombatLogWnd::CombatLogWndImpl::HandleLinkClick(const std::string& link_type, const std::string& data)
-{ m_wnd.LinkClickedSignal(link_type, data); }
-void CombatLogWnd::CombatLogWndImpl::HandleLinkDoubleClick(const std::string& link_type, const std::string& data)
-{ m_wnd.LinkDoubleClickedSignal(link_type, data); }
-void CombatLogWnd::CombatLogWndImpl::HandleLinkRightClick(const std::string& link_type, const std::string& data)
-{ m_wnd.LinkRightClickedSignal(link_type, data); }
-
 void CombatLogWnd::CombatLogWndImpl::HandleWndChanged() {
     GG::Pt size = m_wnd.Size();
     m_wnd.Resize(size + GG::Pt(2*m_font->SpaceWidth(), GG::Y0));
@@ -321,9 +311,10 @@ LinkText * CombatLogWnd::CombatLogWndImpl::DecorateLinkText(std::string const & 
     links->SetDecorator(VarText::SYSTEM_ID_TAG, new ColorByOwner());
     links->SetDecorator(VarText::EMPIRE_ID_TAG, new ColorByOwner());
 
-    GG::Connect(links->LinkClickedSignal,       &CombatLogWnd::CombatLogWndImpl::HandleLinkClick,          this);
-    GG::Connect(links->LinkDoubleClickedSignal, &CombatLogWnd::CombatLogWndImpl::HandleLinkDoubleClick,    this);
-    GG::Connect(links->LinkRightClickedSignal,  &CombatLogWnd::CombatLogWndImpl::HandleLinkDoubleClick,    this);
+
+    links->LinkClickedSignal.connect(m_wnd.LinkClickedSignal);
+    links->LinkDoubleClickedSignal.connect(m_wnd.LinkDoubleClickedSignal);
+    links->LinkRightClickedSignal.connect(m_wnd.LinkRightClickedSignal);
     GG::Connect(links->ChangedSignal,           &CombatLogWnd::CombatLogWndImpl::HandleWndChanged,         this);
 
     return links;

--- a/UI/CombatReport/CombatLogWnd.cpp
+++ b/UI/CombatReport/CombatLogWnd.cpp
@@ -48,50 +48,6 @@ namespace {
         }
         return ss.str();
     }
-
-    const std::string& LinkTag(UniverseObjectType obj_type) {
-        switch (obj_type) {
-        case OBJ_SHIP:
-            return VarText::SHIP_ID_TAG;
-            break;
-        case OBJ_FLEET:
-            return VarText::FLEET_ID_TAG;
-            break;
-        case OBJ_PLANET:
-            return VarText::PLANET_ID_TAG;
-            break;
-        case OBJ_BUILDING:
-            return VarText::BUILDING_ID_TAG;
-            break;
-        case OBJ_SYSTEM:
-            return VarText::SYSTEM_ID_TAG;
-            break;
-        case OBJ_FIELD:
-        default:
-            return EMPTY_STRING;
-        }
-    }
-
-    /// Creates a link tag of the appropriate type for object_id,
-    /// with the content being the public name from the point of view of client_empire_id.
-    /// Returns not_found if object_id is not found.
-    std::string PublicNameLink(int client_empire_id, int object_id, const std::string& not_found) {
-        TemporaryPtr<const UniverseObject> object = GetUniverseObject(object_id);
-        if (object) {
-            const std::string& name = object->PublicName(client_empire_id);
-            const std::string& tag = LinkTag(object->ObjectType());
-            return LinkTaggedIDText(tag, object_id, name);
-        } else {
-            return not_found;
-        }
-    }
-
-    std::string EmpireColourWrappedText(int empire_id, const std::string& text) {
-        const Empire* empire = GetEmpire(empire_id);
-        if (!empire)
-            return text;
-        return GG::RgbaTag(empire->Color()) + text + "</rgba>";
-    }
 }
 
 CombatLogWnd::CombatLogWnd(GG::X w, GG::Y h) :
@@ -161,91 +117,7 @@ void CombatLogWnd::SetLog(int log_id) {
          it != log.combat_events.end(); ++it) {
         DebugLogger() << "event debug info: " << it->get()->DebugString();
 
-        if (const BoutBeginEvent* bout_begin = dynamic_cast<BoutBeginEvent*>(it->get())) {
-            AddRow(DecorateLinkText(str(FlexibleFormat(UserString("ENC_ROUND_BEGIN")) % bout_begin->bout)));
-
-        } else if (const AttackEvent* attack = dynamic_cast<AttackEvent*>(it->get())) {
-            std::stringstream event_title;
-            std::stringstream event_detail;
-            std::string attacker_link;
-            if (attack->attacker_id >= 0)   // ship
-                attacker_link = PublicNameLink(client_empire_id, attack->attacker_id, UserString("ENC_COMBAT_UNKNOWN_OBJECT"));
-            else                            // fighter
-                attacker_link = EmpireColourWrappedText(attack->attacker_owner_id, UserString("OBJ_FIGHTER"));
-
-            std::string target_link = PublicNameLink(client_empire_id, attack->target_id, UserString("ENC_COMBAT_UNKNOWN_OBJECT"));
-
-            const std::string& template_str = UserString("ENC_COMBAT_ATTACK_STR");
-
-            AddRow(DecorateLinkText(str(FlexibleFormat(template_str)
-                                        % attacker_link
-                                        % target_link
-                                        % attack->damage
-                                        % attack->bout
-                                        % attack->round)));
-
-            DebugLogger() << " Attack Event is " << event_title.str();
-
-
-        } else if (const IncapacitationEvent* incapacitation = dynamic_cast<IncapacitationEvent*>(it->get())) {
-            TemporaryPtr<const UniverseObject> object = GetUniverseObject(incapacitation->object_id);
-            std::string template_str, object_str;
-            int owner_id = incapacitation->object_owner_id;
-
-            if (!object && incapacitation->object_id < 0) {
-                template_str = UserString("ENC_COMBAT_FIGHTER_INCAPACITATED_STR");
-                object_str = UserString("OBJ_FIGHTER");
-
-            } else if (!object) {
-                template_str = UserString("ENC_COMBAT_UNKNOWN_DESTROYED_STR");
-                object_str = UserString("ENC_COMBAT_UNKNOWN_OBJECT");
-
-            } else if (object->ObjectType() == OBJ_PLANET) {
-                template_str = UserString("ENC_COMBAT_PLANET_INCAPACITATED_STR");
-                object_str = PublicNameLink(client_empire_id, incapacitation->object_id, UserString("ENC_COMBAT_UNKNOWN_OBJECT"));
-
-            } else {    // ships or other to-be-determined objects...
-                template_str = UserString("ENC_COMBAT_DESTROYED_STR");
-                object_str = PublicNameLink(client_empire_id, incapacitation->object_id, UserString("ENC_COMBAT_UNKNOWN_OBJECT"));
-            }
-
-            std::string owner_string = " ";
-            if (const Empire* owner = GetEmpire(owner_id))
-                owner_string += owner->Name() + " ";
-
-            AddRow(DecorateLinkText(str(FlexibleFormat(template_str) % owner_string % object_str)));
-
-        } else if (const FighterLaunchEvent* launch = dynamic_cast<FighterLaunchEvent*>(it->get())) {
-            std::string launched_from_link = PublicNameLink(client_empire_id, launch->launched_from_id, UserString("ENC_COMBAT_UNKNOWN_OBJECT"));
-            std::string empire_coloured_fighter = EmpireColourWrappedText(launch->fighter_owner_empire_id, UserString("OBJ_FIGHTER"));
-
-            // launching negative fighters indicates recovery of them by the ship
-            const std::string& template_str = (launch->number_launched >= 0 ?
-                                                UserString("ENC_COMBAT_LAUNCH_STR") :
-                                                UserString("ENC_COMBAT_RECOVER_STR"));
-
-            AddRow(DecorateLinkText(str(FlexibleFormat(template_str)
-                                        % launched_from_link
-                                        % empire_coloured_fighter
-                                        % std::abs(launch->number_launched)
-                                        % attack->bout
-                                        % attack->round)));
-        } else if (const FighterAttackedEvent* fighter_attack = dynamic_cast<FighterAttackedEvent*>(it->get())) {
-            std::string attacked_by;
-            if (fighter_attack->attacked_by_object_id >= 0) // attacked by ship or planet
-                attacked_by = PublicNameLink(client_empire_id, fighter_attack->attacked_by_object_id, UserString("ENC_COMBAT_UNKNOWN_OBJECT"));
-            else                                            // attacked by fighter
-                attacked_by = EmpireColourWrappedText(fighter_attack->attacker_owner_empire_id, UserString("OBJ_FIGHTER"));
-            std::string empire_coloured_attacked_fighter = EmpireColourWrappedText(fighter_attack->attacked_owner_id, UserString("OBJ_FIGHTER"));
-
-            const std::string& template_str = UserString("ENC_COMBAT_ATTACK_SIMPLE_STR");
-
-            AddRow(DecorateLinkText(str(FlexibleFormat(template_str)
-                                        % attacked_by
-                                        % empire_coloured_attacked_fighter
-                                        % attack->bout
-                                        % attack->round)));
-        }
+        AddRow(DecorateLinkText(it->get()->CombatLogDescription(client_empire_id)));
     }
 
     std::stringstream summary_text;

--- a/UI/CombatReport/CombatLogWnd.cpp
+++ b/UI/CombatReport/CombatLogWnd.cpp
@@ -78,7 +78,7 @@ namespace {
 
     CombatLogAccordionPanel::CombatLogAccordionPanel(
         GG::X w, CombatLogWnd &log_, int viewing_empire_id_, ConstCombatEventPtr event_) :
-        AccordionPanel(w, GG::Y(ClientUI::Pts())),
+        AccordionPanel(w, GG::Y(ClientUI::Pts()), true),
         log(log_),
         viewing_empire_id(viewing_empire_id_),
         event(event_),

--- a/UI/CombatReport/CombatLogWnd.cpp
+++ b/UI/CombatReport/CombatLogWnd.cpp
@@ -230,7 +230,6 @@ void CombatLogWnd::SetLog(int log_id) {
     //Add a dummy row that the layout manager can use to add space.
     AddRow(DecorateLinkText(""));
     layout->SetRowStretch(layout->Rows() - 1, 1);
-
 }
 
 GG::Pt CombatLogWnd::ClientUpperLeft() const
@@ -239,11 +238,6 @@ GG::Pt CombatLogWnd::ClientUpperLeft() const
 GG::Pt CombatLogWnd::ClientLowerRight() const
 { return LowerRight() - GG::Pt(GG::X(MARGIN), GG::Y(MARGIN)); }
 
-void CombatLogWnd::Render() {
-    GG::Clr interior_color =  ClientUI::CtrlColor();
-    GG::Clr border_color = ClientUI::CtrlBorderColor();
-
-    GG::Pt ul = UpperLeft(), lr = LowerRight();
-
-    FlatRectangle(ul, lr, interior_color, border_color, 1);
+GG::Pt CombatLogWnd::MinUsableSize() const {
+    return GG::Pt(m_font->SpaceWidth()*20, m_font->Lineskip()*10);
 }

--- a/UI/CombatReport/CombatLogWnd.h
+++ b/UI/CombatReport/CombatLogWnd.h
@@ -2,11 +2,13 @@
 #define COMBATLOGWND_H
 
 #include "../CUIControls.h"
+#include <boost/scoped_ptr.hpp>
 
 /// Display a log of combat events with expandable log sections with more details of a combat event
 class CombatLogWnd : public GG::Wnd {
 public:
     CombatLogWnd(GG::X w, GG::Y h);
+    virtual ~CombatLogWnd();
 
     /** \name Accessors */ ///@{
     virtual GG::Pt ClientUpperLeft() const;
@@ -26,26 +28,14 @@ public:
     mutable boost::signals2::signal<void (const std::string&, const std::string&)> LinkRightClickedSignal;
     mutable boost::signals2::signal<void ()> WndChangedSignal;
 
-    /**These handlers just echo the signals from contained log objects to the above signals*/
-    void HandleLinkClick(const std::string& link_type, const std::string& data);
-    void HandleLinkDoubleClick(const std::string& link_type, const std::string& data);
-    void HandleLinkRightClick(const std::string& link_type, const std::string& data);
-    void HandleWndChanged();
-
-    /** DecorateLinkText creates a CUILinkTextMultiEdit using \a text and attaches it to handlers
-        \a and_flags are anded to the default flags. */
-    LinkText * DecorateLinkText(std::string const & text);
-
+    class CombatLogWndImpl;
 private:
-    /** Add a row at the end of the combat report*/
-    void AddRow(GG::Wnd * wnd);
+    //TODO C++11 unique_ptr
+    friend CombatLogWndImpl;
+    const boost::scoped_ptr<CombatLogWndImpl> pimpl;
 
     /// The number of pixels to leave between the text and the frame.
     static const int MARGIN = 5;
-
-    ///default flags for a text link log segment
-    GG::Flags<GG::TextFormat> m_text_format_flags;
-    boost::shared_ptr<GG::Font> m_font;
 
     };
 

--- a/UI/CombatReport/CombatLogWnd.h
+++ b/UI/CombatReport/CombatLogWnd.h
@@ -28,6 +28,9 @@ public:
     mutable boost::signals2::signal<void (const std::string&, const std::string&)> LinkRightClickedSignal;
     mutable boost::signals2::signal<void ()> WndChangedSignal;
 
+    /* The window may have becomem visible.*/
+    void HandleMadeVisible();
+
     class CombatLogWndImpl;
 private:
     //TODO C++11 unique_ptr

--- a/UI/CombatReport/CombatLogWnd.h
+++ b/UI/CombatReport/CombatLogWnd.h
@@ -3,13 +3,49 @@
 
 #include "../CUIControls.h"
 
-/// Displays a textual log of combat events
-class CombatLogWnd : public CUILinkTextMultiEdit {
+/// Display a log of combat events with expandable log sections with more details of a combat event
+class CombatLogWnd : public GG::Wnd {
 public:
-    CombatLogWnd();
+    CombatLogWnd(GG::X w, GG::Y h);
 
+
+    /** \name Accessors */ ///@{
+    virtual GG::Pt ClientUpperLeft() const;
+    virtual GG::Pt ClientLowerRight() const;
+    //@}
+
+    /** \name Mutators */ //@{
+    void SetFont(boost::shared_ptr<GG::Font> font);
     /// Set which log to show
     void SetLog(int log_id);
-};
+
+    void Render();
+    //@}
+
+    ///link clicked signals: first string is the link type, second string is the specific item clicked
+    mutable boost::signals2::signal<void (const std::string&, const std::string&)> LinkClickedSignal;
+    mutable boost::signals2::signal<void (const std::string&, const std::string&)> LinkDoubleClickedSignal;
+    mutable boost::signals2::signal<void (const std::string&, const std::string&)> LinkRightClickedSignal;
+
+    /**These handlers just echo the signals from contained CUILinkTextMultiEdit objects to the above signals*/
+    void HandleLinkClick(const std::string& link_type, const std::string& data);
+    void HandleLinkDoubleClick(const std::string& link_type, const std::string& data);
+    void HandleLinkRightClick(const std::string& link_type, const std::string& data);
+
+private:
+    /** DecorateLinkText creates a CUILinkTextMultiEdit using \a text and attaches it to handlers
+        \a and_flags are anded to the default flags. */
+    LinkText * DecorateLinkText(std::string const & text);
+
+    /** Add a row at the end of the combat report*/
+    void AddRow(GG::Wnd * wnd);
+
+    /// The number of pixels to leave between the text and the frame.
+    static const int MARGIN = 5;
+
+    ///default flags for a text link log segment
+    GG::Flags<GG::TextFormat> m_text_format_flags;
+    boost::shared_ptr<GG::Font> m_font;
+    };
 
 #endif // COMBATLOGWND_H

--- a/UI/CombatReport/CombatLogWnd.h
+++ b/UI/CombatReport/CombatLogWnd.h
@@ -24,11 +24,13 @@ public:
     mutable boost::signals2::signal<void (const std::string&, const std::string&)> LinkClickedSignal;
     mutable boost::signals2::signal<void (const std::string&, const std::string&)> LinkDoubleClickedSignal;
     mutable boost::signals2::signal<void (const std::string&, const std::string&)> LinkRightClickedSignal;
+    mutable boost::signals2::signal<void ()> WndChangedSignal;
 
-    /**These handlers just echo the signals from contained CUILinkTextMultiEdit objects to the above signals*/
+    /**These handlers just echo the signals from contained log objects to the above signals*/
     void HandleLinkClick(const std::string& link_type, const std::string& data);
     void HandleLinkDoubleClick(const std::string& link_type, const std::string& data);
     void HandleLinkRightClick(const std::string& link_type, const std::string& data);
+    void HandleWndChanged();
 
     /** DecorateLinkText creates a CUILinkTextMultiEdit using \a text and attaches it to handlers
         \a and_flags are anded to the default flags. */

--- a/UI/CombatReport/CombatLogWnd.h
+++ b/UI/CombatReport/CombatLogWnd.h
@@ -11,14 +11,13 @@ public:
     /** \name Accessors */ ///@{
     virtual GG::Pt ClientUpperLeft() const;
     virtual GG::Pt ClientLowerRight() const;
+    virtual GG::Pt MinUsableSize() const;
     //@}
 
     /** \name Mutators */ //@{
     void SetFont(boost::shared_ptr<GG::Font> font);
     /// Set which log to show
     void SetLog(int log_id);
-
-    void Render();
     //@}
 
     ///link clicked signals: first string is the link type, second string is the specific item clicked

--- a/UI/CombatReport/CombatLogWnd.h
+++ b/UI/CombatReport/CombatLogWnd.h
@@ -8,7 +8,6 @@ class CombatLogWnd : public GG::Wnd {
 public:
     CombatLogWnd(GG::X w, GG::Y h);
 
-
     /** \name Accessors */ ///@{
     virtual GG::Pt ClientUpperLeft() const;
     virtual GG::Pt ClientLowerRight() const;
@@ -32,11 +31,11 @@ public:
     void HandleLinkDoubleClick(const std::string& link_type, const std::string& data);
     void HandleLinkRightClick(const std::string& link_type, const std::string& data);
 
-private:
     /** DecorateLinkText creates a CUILinkTextMultiEdit using \a text and attaches it to handlers
         \a and_flags are anded to the default flags. */
     LinkText * DecorateLinkText(std::string const & text);
 
+private:
     /** Add a row at the end of the combat report*/
     void AddRow(GG::Wnd * wnd);
 
@@ -46,6 +45,7 @@ private:
     ///default flags for a text link log segment
     GG::Flags<GG::TextFormat> m_text_format_flags;
     boost::shared_ptr<GG::Font> m_font;
+
     };
 
 #endif // COMBATLOGWND_H

--- a/UI/CombatReport/CombatReportData.h
+++ b/UI/CombatReport/CombatReportData.h
@@ -7,7 +7,7 @@
 
 #include <vector>
 
-struct AttackEvent;
+struct WeaponFireEvent;
 struct CombatParticipantState;
 class Empire;
 class UniverseObject;
@@ -16,8 +16,9 @@ class UniverseObject;
 struct ParticipantSummary {
     int                         object_id;
     int                         empire_id;
-    std::vector<AttackEvent*>   attacks;
-    std::vector<AttackEvent*>   attacks_against;
+    // These appear to be never used
+    /* std::vector<WeaponFireEvent*>   attacks; */
+    /* std::vector<WeaponFireEvent*>   attacks_against; */
     float                       current_health;
     float                       max_health;
 

--- a/UI/CombatReport/CombatReportWnd.cpp
+++ b/UI/CombatReport/CombatReportWnd.cpp
@@ -23,6 +23,8 @@ public:
         m_log(new CombatLogWnd(m_wnd.ClientWidth(), m_wnd.ClientHeight())),
         m_min_size(GG::X0, GG::Y0)
     {
+        m_log->SetFont(ClientUI::GetFont());
+
         m_tabs->AddWnd(m_graphical, UserString("COMBAT_SUMMARY"));
         m_tabs->AddWnd(m_log, UserString("COMBAT_LOG"));
         m_wnd.AttachChild(m_tabs);
@@ -44,6 +46,7 @@ public:
 
     void SetLog(int log_id) {
         m_graphical->SetLog(log_id);
+        m_log->SetFont(ClientUI::GetFont());
         m_log->SetLog(log_id);
     }
 

--- a/UI/CombatReport/CombatReportWnd.cpp
+++ b/UI/CombatReport/CombatReportWnd.cpp
@@ -20,11 +20,9 @@ public:
         m_tabs(new GG::TabWnd(GG::X0, GG::Y0, GG::X1, GG::Y1, ClientUI::GetFont(),
                               ClientUI::CtrlColor(), ClientUI::TextColor())),
         m_graphical(new GraphicalSummaryWnd()),
-        m_log(new CombatLogWnd()),
+        m_log(new CombatLogWnd(m_wnd.ClientWidth(), m_wnd.ClientHeight())),
         m_min_size(GG::X0, GG::Y0)
     {
-        m_log->SetFont(ClientUI::GetFont());
-
         m_tabs->AddWnd(m_graphical, UserString("COMBAT_SUMMARY"));
         m_tabs->AddWnd(m_log, UserString("COMBAT_LOG"));
         m_wnd.AttachChild(m_tabs);
@@ -46,7 +44,6 @@ public:
 
     void SetLog(int log_id) {
         m_graphical->SetLog(log_id);
-        m_log->SetFont(ClientUI::GetFont());
         m_log->SetLog(log_id);
     }
 

--- a/UI/CombatReport/CombatReportWnd.cpp
+++ b/UI/CombatReport/CombatReportWnd.cpp
@@ -159,8 +159,10 @@ private:
             m_min_size += graphical_wnd->MinUsableSize();
         } else {
             // The log uses the GG::Layout which incorrectly reports
-            // the current size as the minimum size.
-            m_min_size += m_log_scroller->MinUsableSize();
+            // the current size as the minimum size. So use an arbitrary
+            // minimum size of 20 characters by 1 line height
+            // m_min_size += m_log_scroller->MinUsableSize();
+            m_min_size += GG::Pt(ClientUI::GetFont()->SpaceWidth()*20, ClientUI::GetFont()->Height());
         }
 
         std::list<GG::Wnd*>::const_iterator layout_begin =
@@ -186,6 +188,8 @@ private:
     void HandleWindowChanged() {
         // Use the minimum size of the newly selected window.
         UpdateMinSize();
+
+        DoLayout();
     }
 };
 

--- a/UI/CombatReport/CombatReportWnd.cpp
+++ b/UI/CombatReport/CombatReportWnd.cpp
@@ -48,9 +48,10 @@ public:
 
     void SetLog(int log_id) {
         m_graphical->SetLog(log_id);
+
         m_log->SetFont(ClientUI::GetFont());
-        m_log->SetLog(log_id);
         m_log_scroller->ScrollTo(GG::Y0);
+        m_log->SetLog(log_id);
     }
 
     void DoLayout() {
@@ -63,9 +64,6 @@ public:
         if (GraphicalSummaryWnd* graphical_wnd =
                dynamic_cast<GraphicalSummaryWnd*>(m_tabs->CurrentWnd())) {
             graphical_wnd->DoLayout();
-        } else {
-            //try to force a re-layout to prevent initial sizing error when switching tabs
-            m_log_scroller->SizeMove(m_tabs->ClientUpperLeft(), m_tabs->ClientLowerRight());
         }
     }
 

--- a/UI/CombatReport/CombatReportWnd.cpp
+++ b/UI/CombatReport/CombatReportWnd.cpp
@@ -50,6 +50,7 @@ public:
         m_graphical->SetLog(log_id);
         m_log->SetFont(ClientUI::GetFont());
         m_log->SetLog(log_id);
+        m_log_scroller->ScrollTo(GG::Y0);
     }
 
     void DoLayout() {

--- a/UI/CombatReport/CombatReportWnd.cpp
+++ b/UI/CombatReport/CombatReportWnd.cpp
@@ -161,7 +161,7 @@ private:
         } else {
             // The log uses the GG::Layout which incorrectly reports
             // the current size as the minimum size.
-            m_min_size += m_log->MinUsableSize();
+            m_min_size += m_log_scroller->MinUsableSize();
         }
 
         std::list<GG::Wnd*>::const_iterator layout_begin =

--- a/UI/CombatReport/CombatReportWnd.cpp
+++ b/UI/CombatReport/CombatReportWnd.cpp
@@ -39,7 +39,7 @@ public:
 
         // Catch the window-changed signal from the tab bar so that layout
         // updates can be performed for the newly-selected window.
-        GG::Connect(m_tabs->WndChangedSignal, boost::bind(&CombatReportPrivate::HandleWindowChanged, this));
+        GG::Connect(m_tabs->TabChangedSignal, &CombatReportPrivate::HandleTabChanged, this);
 
         // This can be called whether m_graphical is the selected window or
         // not, but it will still only use the min size of the selected window.
@@ -191,6 +191,13 @@ private:
         UpdateMinSize();
 
         DoLayout();
+    }
+
+    void HandleTabChanged(size_t tabnum) {
+        if (tabnum == 1)
+            m_log->HandleMadeVisible();
+
+        HandleWindowChanged();
     }
 };
 

--- a/UI/CombatReport/CombatReportWnd.cpp
+++ b/UI/CombatReport/CombatReportWnd.cpp
@@ -22,7 +22,7 @@ public:
                               ClientUI::CtrlColor(), ClientUI::TextColor())),
         m_graphical(new GraphicalSummaryWnd()),
         m_log(new CombatLogWnd(m_wnd.ClientWidth(), m_wnd.ClientHeight())),
-        m_log_scroller(new GG::ScrollPanel(GG::X(0), GG::Y(0), m_wnd.ClientWidth(), m_wnd.ClientHeight(), m_log)),
+        m_log_scroller(new GG::ScrollPanel(GG::X(0), GG::Y(0), m_tabs->ClientWidth(), m_tabs->ClientHeight(), m_log)),
         m_min_size(GG::X0, GG::Y0)
     {
         m_log->SetFont(ClientUI::GetFont());
@@ -35,16 +35,15 @@ public:
         GG::Connect(m_log->LinkClickedSignal,       &CombatReportPrivate::HandleLinkClick,          this);
         GG::Connect(m_log->LinkDoubleClickedSignal, &CombatReportPrivate::HandleLinkDoubleClick,    this);
         GG::Connect(m_log->LinkRightClickedSignal,  &CombatReportPrivate::HandleLinkDoubleClick,    this);
+        GG::Connect(m_log->WndChangedSignal,        &CombatReportPrivate::HandleWindowChanged,      this);
 
         // Catch the window-changed signal from the tab bar so that layout
         // updates can be performed for the newly-selected window.
-        GG::Connect(m_tabs->WndChangedSignal,
-                    boost::bind(&CombatReportPrivate::HandleTabChanged, this));
+        GG::Connect(m_tabs->WndChangedSignal, boost::bind(&CombatReportPrivate::HandleWindowChanged, this));
 
         // This can be called whether m_graphical is the selected window or
         // not, but it will still only use the min size of the selected window.
-        GG::Connect(m_graphical->MinSizeChangedSignal,
-                    boost::bind(&CombatReportPrivate::UpdateMinSize, this));
+        GG::Connect(m_graphical->MinSizeChangedSignal, &CombatReportPrivate::UpdateMinSize, this);
     }
 
     void SetLog(int log_id) {
@@ -184,12 +183,9 @@ private:
         }
     }
 
-    void HandleTabChanged() {
+    void HandleWindowChanged() {
         // Use the minimum size of the newly selected window.
         UpdateMinSize();
-
-        // Make sure that the newly selected window gets an update.
-        DoLayout();
     }
 };
 

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -2086,7 +2086,7 @@ DesignWnd::BaseSelector::BaseSelector(const std::string& config_name) :
                 boost::bind(&DesignWnd::BaseSelector::ToggleAvailability, this, false, true));
 
     m_tabs = new GG::TabWnd(GG::X(5), GG::Y(2), GG::X(10), GG::Y(10), ClientUI::GetFont(), ClientUI::WndColor(), ClientUI::TextColor());
-    GG::Connect(m_tabs->WndChangedSignal,                       &DesignWnd::BaseSelector::WndSelected,      this);
+    GG::Connect(m_tabs->TabChangedSignal,                       &DesignWnd::BaseSelector::WndSelected,      this);
     AttachChild(m_tabs);
 
     m_hulls_list = new BasesListBox();

--- a/UI/IconTextBrowseWnd.cpp
+++ b/UI/IconTextBrowseWnd.cpp
@@ -36,7 +36,7 @@ IconTextBrowseWnd::IconTextBrowseWnd(const boost::shared_ptr<GG::Texture> textur
     m_main_text = new CUILabel(main_text, GG::FORMAT_LEFT | GG::FORMAT_TOP | GG::FORMAT_WORDBREAK);
     m_main_text->MoveTo(GG::Pt(m_icon->Width() + GG::X(EDGE_PAD), ROW_HEIGHT));
     m_main_text->Resize(GG::Pt(ICON_BROWSE_TEXT_WIDTH, ICON_BROWSE_ICON_HEIGHT));
-    m_main_text->SetMinSize(true);
+    m_main_text->SetResetMinSize(true);
     m_main_text->Resize(m_main_text->MinSize());
 
     AttachChild(m_title_text);

--- a/UI/MilitaryPanel.cpp
+++ b/UI/MilitaryPanel.cpp
@@ -25,7 +25,7 @@ namespace {
 }
 
 MilitaryPanel::MilitaryPanel(GG::X w, int planet_id) :
-    AccordionPanel(w),
+    AccordionPanel(w, GG::Y(ClientUI::Pts()*2)),
     m_planet_id(planet_id),
     m_meter_stats(),
     m_multi_icon_value_indicator(0),

--- a/UI/PopulationPanel.cpp
+++ b/UI/PopulationPanel.cpp
@@ -26,7 +26,7 @@ namespace {
 }
 
 PopulationPanel::PopulationPanel(GG::X w, int object_id) :
-    AccordionPanel(w),
+    AccordionPanel(w, GG::Y(ClientUI::Pts()*2)),
     m_popcenter_id(object_id),
     m_meter_stats(),
     m_multi_icon_value_indicator(0),

--- a/UI/ResourcePanel.cpp
+++ b/UI/ResourcePanel.cpp
@@ -31,7 +31,7 @@ namespace {
 }
 
 ResourcePanel::ResourcePanel(GG::X w, int object_id) :
-    AccordionPanel(w),
+    AccordionPanel(w, GG::Y(ClientUI::Pts()*2)),
     m_rescenter_id(object_id),
     m_meter_stats(),
     m_multi_icon_value_indicator(0),

--- a/UI/ResourcePanel.cpp
+++ b/UI/ResourcePanel.cpp
@@ -43,7 +43,7 @@ ResourcePanel::ResourcePanel(GG::X w, int object_id) :
     if (!res)
         throw std::invalid_argument("Attempted to construct a ResourcePanel with an UniverseObject that is not a ResourceCenter");
 
-    SetChildClippingMode(ClipToClient);
+    SetChildClippingMode(ClipToClientAndWindowSeparately);
 
     GG::Connect(m_expand_button->LeftClickedSignal, &ResourcePanel::ExpandCollapseButtonPressed, this);
 

--- a/UI/TextBrowseWnd.cpp
+++ b/UI/TextBrowseWnd.cpp
@@ -28,7 +28,7 @@ TextBrowseWnd::TextBrowseWnd(const std::string& title_text, const std::string& m
     m_main_text = new CUILabel(main_text, GG::FORMAT_LEFT | GG::FORMAT_TOP | GG::FORMAT_WORDBREAK);
     m_main_text->MoveTo(GG::Pt(GG::X(EDGE_PAD) + m_offset.x, ROW_HEIGHT + m_offset.y));
     m_main_text->Resize(GG::Pt(w, ICON_BROWSE_ICON_HEIGHT));
-    m_main_text->SetMinSize(true);
+    m_main_text->SetResetMinSize(true);
     m_main_text->Resize(m_main_text->MinSize());
 
     AttachChild(m_main_text);

--- a/combat/CombatEvent.cpp
+++ b/combat/CombatEvent.cpp
@@ -6,11 +6,18 @@
 
 #include "../util/Serialize.ipp"
 #include "../util/Serialize.h"
-#include "../universe/Universe.h"
+#include "../util/Logger.h"
 
 #include <sstream>
 
 CombatEvent::CombatEvent() {}
+
+boost::optional<int> CombatEvent::PrincipalFaction(int viewing_empire_id) const {
+    ErrorLogger() << "A combat logger expected this event to be "
+        "associated with a faction: "<< this->DebugString();
+
+    return boost::optional<int>();
+}
 
 template<typename Archive>
 void CombatEvent::serialize(Archive& ar, const unsigned int version) {}

--- a/combat/CombatEvent.h
+++ b/combat/CombatEvent.h
@@ -26,7 +26,7 @@ struct FO_COMMON_API CombatEvent {
 
     /** Generate the combat log details.
         Describe how it happened in enough detail to avoid a trip to the Pedia. */
-    virtual std::string CombatLogDetails(int empire_id) const
+    virtual std::string CombatLogDetails(int viewing_empire_id) const
     { return std::string(""); }
 
     /** If the combat event is composed of smaller events then return a vector of the sub events,

--- a/combat/CombatEvent.h
+++ b/combat/CombatEvent.h
@@ -4,8 +4,14 @@
 #include <boost/shared_ptr.hpp>
 #include <boost/serialization/access.hpp>
 #include <boost/serialization/export.hpp>
+#include <vector>
 
 #include "../util/Export.h"
+
+// Should be unique_ptr, but we don't have c++11
+struct CombatEvent;
+typedef boost::shared_ptr<CombatEvent> CombatEventPtr;
+typedef boost::shared_ptr<const CombatEvent> ConstCombatEventPtr;
 
 /// An abstract base class for combat events
 struct FO_COMMON_API CombatEvent {
@@ -18,6 +24,16 @@ struct FO_COMMON_API CombatEvent {
         Describe the result of a combat event (i.e. what happened). */
     virtual std::string CombatLogDescription(int viewing_empire_id) const = 0;
 
+    /** Generate the combat log details.
+        Describe how it happened in enough detail to avoid a trip to the Pedia. */
+    virtual std::string CombatLogDetails(int empire_id) const
+    { return std::string(""); }
+
+    /** If the combat event is composed of smaller events then return a vector of the sub events,
+        otherwise returns an empty vector.
+    */
+    virtual std::vector<ConstCombatEventPtr> SubEvents(int viewing_empire_id) const
+    { return std::vector<ConstCombatEventPtr>(); }
 
 private:
     friend class boost::serialization::access;
@@ -26,8 +42,5 @@ private:
 };
 
 BOOST_CLASS_EXPORT_KEY(CombatEvent)
-
-// Should be unique_ptr, but we don't have c++11
-typedef boost::shared_ptr<CombatEvent> CombatEventPtr;
 
 #endif // COMBATEVENT_H

--- a/combat/CombatEvent.h
+++ b/combat/CombatEvent.h
@@ -35,6 +35,11 @@ struct FO_COMMON_API CombatEvent {
     virtual std::vector<ConstCombatEventPtr> SubEvents(int viewing_empire_id) const
     { return std::vector<ConstCombatEventPtr>(); }
 
+    /** Return true if there are no sub events;
+    */
+    virtual bool AreSubEventsEmpty(int viewing_empire_id) const
+    { return true; }
+
 private:
     friend class boost::serialization::access;
     template <class Archive>

--- a/combat/CombatEvent.h
+++ b/combat/CombatEvent.h
@@ -15,6 +15,15 @@ typedef boost::shared_ptr<CombatEvent> CombatEventPtr;
 typedef boost::shared_ptr<const CombatEvent> ConstCombatEventPtr;
 
 /// An abstract base class for combat events
+/**
+Combat events are created during combat processing to act as a log of
+combat events.
+
+Many combat events are created, but few are examined by players.
+The constructors must be fast.  They should not do any string processing
+in the contructor. The descriptions can be expanded on request.
+
+*/
 struct FO_COMMON_API CombatEvent {
     CombatEvent();
 
@@ -35,6 +44,11 @@ struct FO_COMMON_API CombatEvent {
     */
     virtual std::vector<ConstCombatEventPtr> SubEvents(int viewing_empire_id) const
     { return std::vector<ConstCombatEventPtr>(); }
+
+    /** Return true if there are no details;
+    */
+    virtual bool AreDetailsEmpty(int viewing_empire_id) const
+    { return true; }
 
     /** Return true if there are no sub events;
     */

--- a/combat/CombatEvent.h
+++ b/combat/CombatEvent.h
@@ -4,6 +4,7 @@
 #include <boost/shared_ptr.hpp>
 #include <boost/serialization/access.hpp>
 #include <boost/serialization/export.hpp>
+#include <boost/optional/optional.hpp>
 #include <vector>
 
 #include "../util/Export.h"
@@ -39,6 +40,20 @@ struct FO_COMMON_API CombatEvent {
     */
     virtual bool AreSubEventsEmpty(int viewing_empire_id) const
     { return true; }
+
+    /** Return true if sub events are to be flattened on display;
+    */
+    virtual bool FlattenSubEvents() const
+    { return false; }
+
+    /** Return principal faction.
+
+        PrincipalFaction is used by UnorderedEvents to sort the display
+        of events by Facton.  The principal faction should be the
+        faction most active in the event (i.e. the attacker in a WeaponEvent).
+        It is from the perspective of the \p viewing_empire_id. Some events
+        like BoutBegin are not associated with any faction.*/
+    virtual boost::optional<int> PrincipalFaction(int viewing_empire_id) const;
 
 private:
     friend class boost::serialization::access;

--- a/combat/CombatEvent.h
+++ b/combat/CombatEvent.h
@@ -14,6 +14,11 @@ struct FO_COMMON_API CombatEvent {
     virtual ~CombatEvent() {}
     virtual std::string DebugString() const = 0;
 
+    /** Generate the combat log description.
+        Describe the result of a combat event (i.e. what happened). */
+    virtual std::string CombatLogDescription(int viewing_empire_id) const = 0;
+
+
 private:
     friend class boost::serialization::access;
     template <class Archive>

--- a/combat/CombatEvents.cpp
+++ b/combat/CombatEvents.cpp
@@ -288,21 +288,30 @@ InitialStealthEvent::InitialStealthEvent(const StealthInvisbleMap &x) :
 std::string InitialStealthEvent::DebugString() const {
     std::stringstream ss;
     ss << "InitialStealthEvent: ";
-    for (StealthInvisbleMap::const_iterator attack_empire = target_empire_id_to_invisble_obj_id.begin();
-         attack_empire != target_empire_id_to_invisble_obj_id.end(); ++attack_empire) {
-        ss << " Attacking Empire: " << EmpireLink(attack_empire->first) << "\n";
-        for (std::map<int, std::set<std::pair<int, Visibility> > >::const_iterator
-                 target_empire = attack_empire->second.begin();
-             target_empire != attack_empire->second.end(); ++target_empire) {
-            ss << " Target Empire: " << EmpireLink(target_empire->first) << " Targets: ";
+    if (target_empire_id_to_invisble_obj_id.size() > 4) {
+        ss << target_empire_id_to_invisble_obj_id.size() << " events.";
+    } else {
+        for (StealthInvisbleMap::const_iterator attack_empire = target_empire_id_to_invisble_obj_id.begin();
+             attack_empire != target_empire_id_to_invisble_obj_id.end(); ++attack_empire) {
+            ss << " Attacking Empire: " << EmpireLink(attack_empire->first) << "\n";
+            for (std::map<int, std::set<std::pair<int, Visibility> > >::const_iterator
+                     target_empire = attack_empire->second.begin();
+                 target_empire != attack_empire->second.end(); ++target_empire) {
+                ss << " Target Empire: " << EmpireLink(target_empire->first) << " Targets: ";
 
-            for (std::set<std::pair<int, Visibility> >::const_iterator attacker_it = target_empire->second.begin();
-                 attacker_it != target_empire->second.end(); ++attacker_it) {
-                ss << FighterOrPublicNameLink(ALL_EMPIRES, attacker_it->first, target_empire->first);
+                if (target_empire->second.size() > 4) {
+                    ss << target_empire->second.size() << " attackers.";
+                } else {
+                    for (std::set<std::pair<int, Visibility> >::const_iterator attacker_it = target_empire->second.begin();
+                         attacker_it != target_empire->second.end(); ++attacker_it) {
+                        ss << FighterOrPublicNameLink(ALL_EMPIRES, attacker_it->first, target_empire->first);
+                    }
+                }
+                ss << "\n";
             }
-            ss << "\n";
         }
     }
+
     return ss.str();
 }
 
@@ -457,13 +466,21 @@ void StealthChangeEvent::AddEvent(int attacker_id_, int target_id_, int attacker
 std::string StealthChangeEvent::DebugString() const {
     std::stringstream ss;
     ss << "StealthChangeEvent";
-    for (std::map<int, std::vector<StealthChangeEventDetailPtr> >::const_iterator target_it = events.begin();
-         target_it != events.end(); ++target_it) {
-        ss << "Target Empire: " << EmpireLink(target_it->first) << "\n";
+    if (events.size() > 4) {
+        ss << events.size() << " empires.";
+    } else {
+        for (std::map<int, std::vector<StealthChangeEventDetailPtr> >::const_iterator target_it = events.begin();
+             target_it != events.end(); ++target_it) {
+            ss << "Target Empire: " << EmpireLink(target_it->first) << "\n";
 
-        for (std::vector<StealthChangeEventDetailPtr>::const_iterator event_it = target_it->second.begin();
-             event_it != target_it->second.end(); ++event_it){
-            ss << (*event_it)->DebugString();
+            if (target_it->second.size() > 4) {
+                ss << target_it->second.size() << " events.";
+            } else {
+                for (std::vector<StealthChangeEventDetailPtr>::const_iterator event_it = target_it->second.begin();
+                     event_it != target_it->second.end(); ++event_it){
+                    ss << (*event_it)->DebugString();
+                }
+            }
         }
     }
     return ss.str();

--- a/combat/CombatEvents.cpp
+++ b/combat/CombatEvents.cpp
@@ -584,28 +584,31 @@ WeaponFireEvent::WeaponFireEvent() :
     round(-1),
     attacker_id(INVALID_OBJECT_ID),
     target_id(INVALID_OBJECT_ID),
+    weapon_name(),
     power(0.0f),
     shield(0.0f),
     damage(0.0f),
     attacker_owner_id(ALL_EMPIRES)
 {}
 
-WeaponFireEvent::WeaponFireEvent(int bout_, int round_, int attacker_id_, int target_id_
-                                 , float power_, float shield_, float damage_, int attacker_owner_id_) :
+WeaponFireEvent::WeaponFireEvent(
+    int bout_, int round_, int attacker_id_, int target_id_, const std::string &weapon_name_
+    , float power_, float shield_, float damage_, int attacker_owner_id_) :
     bout(bout_),
     round(round_),
     attacker_id(attacker_id_),
     target_id( target_id_),
+    weapon_name(weapon_name_),
     power(power_),
     shield(shield_),
     damage(damage_),
     attacker_owner_id(attacker_owner_id_)
-{}
+{ }
 
 std::string WeaponFireEvent::DebugString() const {
     std::stringstream ss;
     ss << "rnd: " << round << " : "
-       << attacker_id << " -> " << target_id << " : "
+       << attacker_id << " -> " << target_id << " : " << weapon_name << " "
        << power << " - " << shield << " = " << damage << "   attacker owner: " << attacker_owner_id;
     return ss.str();
 }
@@ -628,6 +631,7 @@ std::string WeaponFireEvent::CombatLogDetails(int viewing_empire_id) const {
     const std::string& template_str = UserString("ENC_COMBAT_ATTACK_DETAILS");
 
     return str(FlexibleFormat(template_str)
+               % UserString(weapon_name)
                % power
                % shield
                % damage);
@@ -645,6 +649,7 @@ void WeaponFireEvent::serialize(Archive& ar, const unsigned int version) {
        & BOOST_SERIALIZATION_NVP(round)
        & BOOST_SERIALIZATION_NVP(attacker_id)
        & BOOST_SERIALIZATION_NVP(target_id)
+       & BOOST_SERIALIZATION_NVP(weapon_name)
        & BOOST_SERIALIZATION_NVP(power)
        & BOOST_SERIALIZATION_NVP(shield)
        & BOOST_SERIALIZATION_NVP(damage)
@@ -905,10 +910,12 @@ WeaponsPlatformEvent::WeaponsPlatformEvent(int bout_, int attacker_id_, int atta
     events()
 {}
 
-void WeaponsPlatformEvent::AddEvent(int round_, int target_id_, float power_, float shield_, float damage_) {
+void WeaponsPlatformEvent::AddEvent(
+    int round_, int target_id_, std::string const & weapon_name_,
+    float power_, float shield_, float damage_) {
     events[target_id_].push_back(
         boost::make_shared<WeaponFireEvent>(
-            bout, round_, attacker_id, target_id_, power_, shield_, damage_, attacker_owner_id));
+            bout, round_, attacker_id, target_id_, weapon_name_, power_, shield_, damage_, attacker_owner_id));
 }
 
 std::string WeaponsPlatformEvent::DebugString() const {

--- a/combat/CombatEvents.cpp
+++ b/combat/CombatEvents.cpp
@@ -414,7 +414,7 @@ void StealthChangeEvent::StealthChangeEventDetail::serialize<freeorion_xml_iarch
 //////////////////////////////////////////
 ///////// Attack Event////////////////////
 //////////////////////////////////////////
-AttackEvent::AttackEvent() :
+WeaponFireEvent::WeaponFireEvent() :
     bout(-1),
     round(-1),
     attacker_id(INVALID_OBJECT_ID),
@@ -423,7 +423,7 @@ AttackEvent::AttackEvent() :
     attacker_owner_id(ALL_EMPIRES)
 {}
 
-AttackEvent::AttackEvent(int bout_, int round_, int attacker_id_, int target_id_, float damage_, int attacker_owner_id_) :
+WeaponFireEvent::WeaponFireEvent(int bout_, int round_, int attacker_id_, int target_id_, float damage_, int attacker_owner_id_) :
     bout(bout_),
     round(round_),
     attacker_id(attacker_id_),
@@ -432,7 +432,7 @@ AttackEvent::AttackEvent(int bout_, int round_, int attacker_id_, int target_id_
     attacker_owner_id(attacker_owner_id_)
 {}
 
-std::string AttackEvent::DebugString() const {
+std::string WeaponFireEvent::DebugString() const {
     std::stringstream ss;
     ss << "rnd: " << round << " : "
        << attacker_id << " -> " << target_id << " : "
@@ -440,7 +440,7 @@ std::string AttackEvent::DebugString() const {
     return ss.str();
 }
 
-std::string AttackEvent::CombatLogDescription(int viewing_empire_id) const {
+std::string WeaponFireEvent::CombatLogDescription(int viewing_empire_id) const {
     std::string attacker_link = FighterOrPublicNameLink(viewing_empire_id, attacker_id, attacker_owner_id);
     std::string target_link = PublicNameLink(viewing_empire_id, target_id);
 
@@ -455,7 +455,7 @@ std::string AttackEvent::CombatLogDescription(int viewing_empire_id) const {
 }
 
 template <class Archive>
-void AttackEvent::serialize(Archive& ar, const unsigned int version) {
+void WeaponFireEvent::serialize(Archive& ar, const unsigned int version) {
     ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(CombatEvent);
     ar & BOOST_SERIALIZATION_NVP(bout)
        & BOOST_SERIALIZATION_NVP(round)
@@ -470,20 +470,20 @@ void AttackEvent::serialize(Archive& ar, const unsigned int version) {
     }
 }
 
-BOOST_CLASS_VERSION(AttackEvent, 4)
-BOOST_CLASS_EXPORT(AttackEvent)
+BOOST_CLASS_VERSION(WeaponFireEvent, 4)
+BOOST_CLASS_EXPORT(WeaponFireEvent)
 
 template
-void AttackEvent::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive& ar, const unsigned int version);
+void WeaponFireEvent::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive& ar, const unsigned int version);
 
 template
-void AttackEvent::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive& ar, const unsigned int version);
+void WeaponFireEvent::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive& ar, const unsigned int version);
 
 template
-void AttackEvent::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive& ar, const unsigned int version);
+void WeaponFireEvent::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive& ar, const unsigned int version);
 
 template
-void AttackEvent::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive& ar, const unsigned int version);
+void WeaponFireEvent::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive& ar, const unsigned int version);
 
 //////////////////////////////////////////
 ///////// IncapacitationEvent/////////////

--- a/combat/CombatEvents.cpp
+++ b/combat/CombatEvents.cpp
@@ -82,7 +82,17 @@ namespace {
         const std::string name = (empire = GetEmpire(empire_id)) ? empire->Name() : UserString("ENC_COMBAT_UNKNOWN_OBJECT");
 
         const std::string& tag = VarText::EMPIRE_ID_TAG;
-        return "<" + tag + " " + boost::lexical_cast<std::string>(empire_id) + ">" + name + "</" + tag + ">";
+        std::string empire_wrapped = "<" + tag + " " + boost::lexical_cast<std::string>(empire_id) + ">" + name + "</" + tag + ">";
+        //TODO refactor this to somewhere that links with the UI code.
+        GG::Clr c = ((empire = GetEmpire(empire_id)) ? empire->Color() : GG::Clr(80,255,128,255));
+        std::stringstream color_wrapped;
+        color_wrapped << "<rgba "
+                      << static_cast<int>(c.r) << " "
+                      << static_cast<int>(c.g) << " "
+                      << static_cast<int>(c.b) << " "
+                      << static_cast<int>(c.a) << ">"
+                      << empire_wrapped << "</rgba>";
+        return color_wrapped.str();
     }
 }
 

--- a/combat/CombatEvents.cpp
+++ b/combat/CombatEvents.cpp
@@ -8,6 +8,67 @@
 
 #include <sstream>
 
+#include "../util/i18n.h"
+#include "../util/VarText.h"
+#include "../UI/LinkText.h"
+#include "../Empire/Empire.h"
+#include "../client/human/HumanClientApp.h"
+
+namespace {
+    const std::string EMPTY_STRING("");
+    const std::string& LinkTag(UniverseObjectType obj_type) {
+        switch (obj_type) {
+        case OBJ_SHIP:
+            return VarText::SHIP_ID_TAG;
+        case OBJ_FLEET:
+            return VarText::FLEET_ID_TAG;
+        case OBJ_PLANET:
+            return VarText::PLANET_ID_TAG;
+        case OBJ_BUILDING:
+            return VarText::BUILDING_ID_TAG;
+        case OBJ_SYSTEM:
+            return VarText::SYSTEM_ID_TAG;
+        case OBJ_FIELD:
+        default:
+            return EMPTY_STRING;
+        }
+    }
+
+    /// Creates a link tag of the appropriate type for object_id,
+    /// with the content being the public name from the point of view of empire_id.
+    /// Returns not_found if object_id is not found.
+    std::string PublicNameLink(int empire_id, int object_id, const std::string& not_found) {
+        TemporaryPtr<const UniverseObject> object = GetUniverseObject(object_id);
+        if (object) {
+            const std::string& name = object->PublicName(empire_id);
+            const std::string& tag = LinkTag(object->ObjectType());
+            return "<" + tag + " " + boost::lexical_cast<std::string>(object_id) + ">" + name + "</" + tag + ">";
+        } else {
+            return not_found;
+        }
+    }
+
+
+    //Copied pasted from Font.cpp due to Font not being linked into AI and server code
+    std::string RgbaTagCopy(const GG::Clr& c, std::string const & text) {
+        std::stringstream stream;
+        stream << "<rgba "
+               << static_cast<int>(c.r) << " "
+               << static_cast<int>(c.g) << " "
+               << static_cast<int>(c.b) << " "
+               << static_cast<int>(c.a)
+               << ">" << text << "</rgba>";
+        return stream.str();
+    }
+
+    std::string EmpireColourWrappedText(int empire_id, const std::string& text) {
+        const Empire* empire = GetEmpire(empire_id);
+        if (!empire)
+            return text;
+        return RgbaTagCopy(empire->Color(), text);
+    }
+
+}
 
 //////////////////////////////////////////
 ///////// BoutBeginEvent//////////////////
@@ -24,6 +85,10 @@ std::string BoutBeginEvent::DebugString() const {
     std::stringstream ss;
     ss << "Bout " << bout << " begins.";
     return ss.str();
+}
+
+std::string BoutBeginEvent::CombatLogDescription(int viewing_empire_id) const {
+    return str(FlexibleFormat(UserString("ENC_ROUND_BEGIN")) % bout);
 }
 
 template <class Archive>
@@ -73,6 +138,25 @@ std::string AttackEvent::DebugString() const {
        << attacker_id << " -> " << target_id << " : "
        << damage << "   attacker owner: " << attacker_owner_id;
     return ss.str();
+}
+
+std::string AttackEvent::CombatLogDescription(int viewing_empire_id) const {
+    std::string attacker_link;
+    if (attacker_id >= 0)   // ship
+        attacker_link = PublicNameLink(viewing_empire_id, attacker_id, UserString("ENC_COMBAT_UNKNOWN_OBJECT"));
+    else                            // fighter
+        attacker_link = EmpireColourWrappedText(attacker_owner_id, UserString("OBJ_FIGHTER"));
+
+    std::string target_link = PublicNameLink(viewing_empire_id, target_id, UserString("ENC_COMBAT_UNKNOWN_OBJECT"));
+
+    const std::string& template_str = UserString("ENC_COMBAT_ATTACK_STR");
+
+    return str(FlexibleFormat(template_str)
+               % attacker_link
+               % target_link
+               % damage
+               % bout
+               % round);
 }
 
 template <class Archive>
@@ -127,6 +211,37 @@ std::string IncapacitationEvent::DebugString() const {
     return ss.str();
 }
 
+
+std::string IncapacitationEvent::CombatLogDescription(int viewing_empire_id) const {
+    TemporaryPtr<const UniverseObject> object = GetUniverseObject(object_id);
+    std::string template_str, object_str;
+    int owner_id = object_owner_id;
+
+    if (!object && object_id < 0) {
+        template_str = UserString("ENC_COMBAT_FIGHTER_INCAPACITATED_STR");
+        object_str = UserString("OBJ_FIGHTER");
+
+    } else if (!object) {
+        template_str = UserString("ENC_COMBAT_UNKNOWN_DESTROYED_STR");
+        object_str = UserString("ENC_COMBAT_UNKNOWN_OBJECT");
+
+    } else if (object->ObjectType() == OBJ_PLANET) {
+        template_str = UserString("ENC_COMBAT_PLANET_INCAPACITATED_STR");
+        object_str = PublicNameLink(viewing_empire_id, object_id, UserString("ENC_COMBAT_UNKNOWN_OBJECT"));
+
+    } else {    // ships or other to-be-determined objects...
+        template_str = UserString("ENC_COMBAT_DESTROYED_STR");
+        object_str = PublicNameLink(viewing_empire_id, object_id, UserString("ENC_COMBAT_UNKNOWN_OBJECT"));
+    }
+
+    std::string owner_string = " ";
+    if (const Empire* owner = GetEmpire(owner_id))
+        owner_string += owner->Name() + " ";
+
+    return str(FlexibleFormat(template_str) % owner_string % object_str);
+}
+
+
 template <class Archive>
 void IncapacitationEvent::serialize (Archive& ar, const unsigned int version) {
     ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(CombatEvent);
@@ -178,6 +293,20 @@ std::string FighterAttackedEvent::DebugString() const {
     return ss.str();
 }
 
+std::string FighterAttackedEvent::CombatLogDescription(int viewing_empire_id) const {
+    std::string attacked_by;
+    if (attacked_by_object_id >= 0) // attacked by ship or planet
+        attacked_by = PublicNameLink(viewing_empire_id, attacked_by_object_id, UserString("ENC_COMBAT_UNKNOWN_OBJECT"));
+    else                                            // attacked by fighter
+        attacked_by = EmpireColourWrappedText(attacker_owner_empire_id, UserString("OBJ_FIGHTER"));
+    std::string empire_coloured_attacked_fighter = EmpireColourWrappedText(attacked_owner_id, UserString("OBJ_FIGHTER"));
+
+    const std::string& template_str = UserString("ENC_COMBAT_ATTACK_SIMPLE_STR");
+
+    return str(FlexibleFormat(template_str)
+                                % attacked_by
+                                % empire_coloured_attacked_fighter);
+}
 template <class Archive>
 void FighterAttackedEvent::serialize (Archive& ar, const unsigned int version) {
     ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(CombatEvent);
@@ -226,6 +355,21 @@ std::string FighterLaunchEvent::DebugString() const {
        << " fighter(s) of empire " << fighter_owner_empire_id
        << " at bout " << bout;
     return ss.str();
+}
+
+std::string FighterLaunchEvent::CombatLogDescription(int viewing_empire_id) const {
+    std::string launched_from_link = PublicNameLink(viewing_empire_id, launched_from_id, UserString("ENC_COMBAT_UNKNOWN_OBJECT"));
+    std::string empire_coloured_fighter = EmpireColourWrappedText(fighter_owner_empire_id, UserString("OBJ_FIGHTER"));
+
+    // launching negative fighters indicates recovery of them by the ship
+    const std::string& template_str = (number_launched >= 0 ?
+                                       UserString("ENC_COMBAT_LAUNCH_STR") :
+                                       UserString("ENC_COMBAT_RECOVER_STR"));
+
+   return str(FlexibleFormat(template_str)
+              % launched_from_link
+              % empire_coloured_fighter
+              % std::abs(number_launched));
 }
 
 template <class Archive>

--- a/combat/CombatEvents.cpp
+++ b/combat/CombatEvents.cpp
@@ -775,7 +775,9 @@ std::string WeaponsPlatformEvent::CombatLogDescription(int viewing_empire_id) co
         std::vector<std::string> target_links;
         for (std::map<int, double>::iterator target_it = damaged.begin();
              target_it != damaged.end(); ++target_it) {
-            target_links.push_back( PublicNameLink(viewing_empire_id, target_it->first));
+            target_links.push_back(
+                str(FlexibleFormat(UserString("ENC_COMBAT_PLATFORM_TARGET_AND_DAMAGE"))
+                    % PublicNameLink(viewing_empire_id, target_it->first) % target_it->second));
         }
 
         desc += FlexibleFormatList(attacker_link, target_links

--- a/combat/CombatEvents.cpp
+++ b/combat/CombatEvents.cpp
@@ -352,6 +352,9 @@ std::string StealthChangeEvent::CombatLogDescription(int viewing_empire_id) cons
     return desc;
 }
 
+bool StealthChangeEvent::AreSubEventsEmpty(int viewing_empire_id) const {
+    return events.empty();
+}
 std::vector<ConstCombatEventPtr> StealthChangeEvent::SubEvents(int viewing_empire_id) const {
     std::vector<ConstCombatEventPtr> all_events;
     for (std::map<int, std::vector<StealthChangeEventDetailPtr> >::const_iterator target_it = events.begin();
@@ -768,6 +771,10 @@ std::string WeaponsPlatformEvent::CombatLogDescription(int viewing_empire_id) co
                                    , UserString("ENC_COMBAT_PLATFORM_NO_DAMAGE_1_EVENTS")).str();
     }
     return desc;
+}
+
+bool WeaponsPlatformEvent::AreSubEventsEmpty(int viewing_empire_id) const {
+    return events.empty();
 }
 
 std::vector<ConstCombatEventPtr> WeaponsPlatformEvent::SubEvents(int viewing_empire_id) const {

--- a/combat/CombatEvents.h
+++ b/combat/CombatEvents.h
@@ -179,7 +179,7 @@ struct FO_COMMON_API WeaponFireEvent : public CombatEvent {
     typedef boost::shared_ptr<const WeaponFireEvent> ConstWeaponFireEventPtr;
 
     WeaponFireEvent();
-    WeaponFireEvent(int bout, int round, int attacker_id, int target_id
+    WeaponFireEvent(int bout, int round, int attacker_id, int target_id, const std::string &weapon_name
                     , float power_, float shield_, float damage_, int attacker_owner_id_);
 
     virtual ~WeaponFireEvent() {}
@@ -195,6 +195,7 @@ struct FO_COMMON_API WeaponFireEvent : public CombatEvent {
     int     round;
     int     attacker_id;
     int     target_id;
+    std::string weapon_name;
     float   power;
     float   shield;
     float   damage;
@@ -285,7 +286,8 @@ struct FO_COMMON_API WeaponsPlatformEvent : public CombatEvent {
 
     virtual ~WeaponsPlatformEvent() {}
 
-    void AddEvent(int round, int target_id, float power_, float shield_, float damage_);
+    void AddEvent(int round, int target_id, std::string const & weapon_name_,
+                  float power_, float shield_, float damage_);
 
     virtual std::string DebugString() const;
     virtual std::string CombatLogDescription(int viewing_empire_id) const;

--- a/combat/CombatEvents.h
+++ b/combat/CombatEvents.h
@@ -20,6 +20,7 @@ struct FO_COMMON_API BoutBeginEvent : public CombatEvent {
     virtual ~BoutBeginEvent() {}
 
     virtual std::string DebugString() const;
+    virtual std::string CombatLogDescription(int viewing_empire_id) const;
 
     int bout;
 
@@ -37,6 +38,7 @@ struct FO_COMMON_API AttackEvent : public CombatEvent {
     virtual ~AttackEvent() {}
 
     virtual std::string DebugString() const;
+    virtual std::string CombatLogDescription(int viewing_empire_id) const;
 
     int     bout;
     int     round;
@@ -59,6 +61,7 @@ struct FO_COMMON_API IncapacitationEvent : public CombatEvent {
     virtual ~IncapacitationEvent() {}
 
     virtual std::string DebugString() const;
+    virtual std::string CombatLogDescription(int viewing_empire_id) const;
 
     int bout;
     int object_id;
@@ -77,6 +80,7 @@ struct FO_COMMON_API FighterAttackedEvent : public CombatEvent {
     virtual ~FighterAttackedEvent() {}
 
     virtual std::string DebugString() const;
+    virtual std::string CombatLogDescription(int viewing_empire_id) const;
 
     int bout;
     int round;
@@ -97,6 +101,7 @@ struct FO_COMMON_API FighterLaunchEvent : public CombatEvent {
     virtual ~FighterLaunchEvent() {}
 
     virtual std::string DebugString() const;
+    virtual std::string CombatLogDescription(int viewing_empire_id) const;
 
     int bout;
     int fighter_owner_empire_id;    // may be ALL_EMPIRE if fighter was owned by no empire

--- a/combat/CombatEvents.h
+++ b/combat/CombatEvents.h
@@ -57,6 +57,50 @@ private:
     void serialize(Archive& ar, const unsigned int version);
 };
 
+/**StealthChangeEvent describes changes in the visibility of objects during combat.
+ At this time always decloaking.*/
+struct FO_COMMON_API StealthChangeEvent : public CombatEvent {
+    StealthChangeEvent();
+    StealthChangeEvent(int bout);
+
+    virtual ~StealthChangeEvent() {}
+
+    void AddEvent(int attacker_id_, int target_id_, int attacker_empire_, int target_empire_, Visibility new_visibility_);
+
+    virtual std::string DebugString() const;
+    virtual std::string CombatLogDescription(int viewing_empire_id) const;
+    virtual std::vector<ConstCombatEventPtr> SubEvents(int viewing_empire_id) const;
+
+    struct StealthChangeEventDetail;
+    typedef boost::shared_ptr<StealthChangeEventDetail> StealthChangeEventDetailPtr;
+    typedef boost::shared_ptr<const StealthChangeEventDetail> ConstStealthChangeEventDetailPtr;
+    struct StealthChangeEventDetail : public CombatEvent {
+        int attacker_id;
+        int target_id;
+        int attacker_empire_id;
+        int target_empire_id;
+        Visibility visibility;
+        StealthChangeEventDetail();
+        StealthChangeEventDetail(int attacker_id_, int target_id_, int attacker_empire_, int target_empire_, Visibility new_visibility_);
+
+        virtual std::string DebugString() const;
+        virtual std::string CombatLogDescription(int viewing_empire_id) const;
+
+        friend class boost::serialization::access;
+        template <class Archive>
+        void serialize(Archive& ar, const unsigned int version);
+    };
+
+private:
+    int     bout;
+
+    std::map<int, std::vector<StealthChangeEventDetailPtr> > events;
+
+    friend class boost::serialization::access;
+    template <class Archive>
+    void serialize(Archive& ar, const unsigned int version);
+};
+
 /// An event that describes a single attack by one object or fighter against another object or fighter
 struct FO_COMMON_API AttackEvent : public CombatEvent {
     AttackEvent();

--- a/combat/CombatEvents.h
+++ b/combat/CombatEvents.h
@@ -1,11 +1,13 @@
 #ifndef COMBATEVENTS_H
 #define COMBATEVENTS_H
 
+#include <set>
 #include <boost/shared_ptr.hpp>
 #include <boost/serialization/access.hpp>
 #include <boost/serialization/export.hpp>
 
 #include "../util/Export.h"
+#include "../universe/Enums.h"
 
 #include "CombatEvent.h"
 
@@ -25,6 +27,31 @@ struct FO_COMMON_API BoutBeginEvent : public CombatEvent {
     int bout;
 
 private:
+    friend class boost::serialization::access;
+    template <class Archive>
+    void serialize(Archive& ar, const unsigned int version);
+};
+
+/** InitialStealthEvent describes the initially stealthy combatants.
+    Note:  Because it is initialized with the unfiltered stealth information it
+    contains information not availble to all empires. */
+struct FO_COMMON_API InitialStealthEvent : public CombatEvent {
+
+    /// a map of attacker empire id -> defender empire id -> set of (attacker ids, visibility)
+    typedef std::map<int, std::map< int, std::set< std::pair<int, Visibility> > > > StealthInvisbleMap;
+
+    InitialStealthEvent();
+    InitialStealthEvent(const StealthInvisbleMap &);
+
+    virtual ~InitialStealthEvent() {}
+
+    virtual std::string DebugString() const;
+    virtual std::string CombatLogDescription(int viewing_empire_id) const;
+
+private:
+
+    StealthInvisbleMap target_empire_id_to_invisble_obj_id;
+
     friend class boost::serialization::access;
     template <class Archive>
     void serialize(Archive& ar, const unsigned int version);

--- a/combat/CombatEvents.h
+++ b/combat/CombatEvents.h
@@ -70,6 +70,7 @@ struct FO_COMMON_API StealthChangeEvent : public CombatEvent {
     virtual std::string DebugString() const;
     virtual std::string CombatLogDescription(int viewing_empire_id) const;
     virtual std::vector<ConstCombatEventPtr> SubEvents(int viewing_empire_id) const;
+    virtual bool AreSubEventsEmpty(int viewing_empire_id) const;
 
     struct StealthChangeEventDetail;
     typedef boost::shared_ptr<StealthChangeEventDetail> StealthChangeEventDetailPtr;
@@ -204,6 +205,7 @@ struct FO_COMMON_API WeaponsPlatformEvent : public CombatEvent {
     virtual std::string DebugString() const;
     virtual std::string CombatLogDescription(int viewing_empire_id) const;
     virtual std::vector<ConstCombatEventPtr> SubEvents(int viewing_empire_id) const;
+    virtual bool AreSubEventsEmpty(int viewing_empire_id) const;
 
     int bout;
     int attacker_id;

--- a/combat/CombatEvents.h
+++ b/combat/CombatEvents.h
@@ -102,11 +102,11 @@ private:
 };
 
 /// An event that describes a single attack by one object or fighter against another object or fighter
-struct FO_COMMON_API AttackEvent : public CombatEvent {
-    AttackEvent();
-    AttackEvent(int bout, int round, int attacker_id, int target_id, float damage_, int attacker_owner_id_);
+struct FO_COMMON_API WeaponFireEvent : public CombatEvent {
+    WeaponFireEvent();
+    WeaponFireEvent(int bout, int round, int attacker_id, int target_id, float damage_, int attacker_owner_id_);
 
-    virtual ~AttackEvent() {}
+    virtual ~WeaponFireEvent() {}
 
     virtual std::string DebugString() const;
     virtual std::string CombatLogDescription(int viewing_empire_id) const;

--- a/combat/CombatEvents.h
+++ b/combat/CombatEvents.h
@@ -103,6 +103,9 @@ private:
 
 /// An event that describes a single attack by one object or fighter against another object or fighter
 struct FO_COMMON_API WeaponFireEvent : public CombatEvent {
+    typedef boost::shared_ptr<WeaponFireEvent> WeaponFireEventPtr;
+    typedef boost::shared_ptr<const WeaponFireEvent> ConstWeaponFireEventPtr;
+
     WeaponFireEvent();
     WeaponFireEvent(int bout, int round, int attacker_id, int target_id, float damage_, int attacker_owner_id_);
 
@@ -180,6 +183,35 @@ struct FO_COMMON_API FighterLaunchEvent : public CombatEvent {
     int number_launched;
 
 private:
+    friend class boost::serialization::access;
+    template <class Archive>
+    void serialize(Archive& ar, const unsigned int version);
+};
+
+/** WeaponsPlatformEvent describes a ship or planet with zero or more weapons firing its weapons in combat.
+   It may have some WeaponFire sub-events.*/
+struct FO_COMMON_API WeaponsPlatformEvent : public CombatEvent {
+    typedef boost::shared_ptr<WeaponsPlatformEvent> WeaponsPlatformEventPtr;
+    typedef boost::shared_ptr<const WeaponsPlatformEvent> ConstWeaponsPlatformEventPtr;
+
+    WeaponsPlatformEvent();
+    WeaponsPlatformEvent(int bout, int attacker_id, int attacker_owner_id_);
+
+    virtual ~WeaponsPlatformEvent() {}
+
+    void AddEvent(int round, int target_id, float damage_);
+
+    virtual std::string DebugString() const;
+    virtual std::string CombatLogDescription(int viewing_empire_id) const;
+    virtual std::vector<ConstCombatEventPtr> SubEvents(int viewing_empire_id) const;
+
+    int bout;
+    int attacker_id;
+    int attacker_owner_id;
+
+private:
+    std::map<int, std::vector<WeaponFireEvent::WeaponFireEventPtr> > events;
+
     friend class boost::serialization::access;
     template <class Archive>
     void serialize(Archive& ar, const unsigned int version);

--- a/combat/CombatEvents.h
+++ b/combat/CombatEvents.h
@@ -108,17 +108,21 @@ struct FO_COMMON_API WeaponFireEvent : public CombatEvent {
     typedef boost::shared_ptr<const WeaponFireEvent> ConstWeaponFireEventPtr;
 
     WeaponFireEvent();
-    WeaponFireEvent(int bout, int round, int attacker_id, int target_id, float damage_, int attacker_owner_id_);
+    WeaponFireEvent(int bout, int round, int attacker_id, int target_id
+                    , float power_, float shield_, float damage_, int attacker_owner_id_);
 
     virtual ~WeaponFireEvent() {}
 
     virtual std::string DebugString() const;
     virtual std::string CombatLogDescription(int viewing_empire_id) const;
+    virtual std::string CombatLogDetails(int viewing_empire_id) const;
 
     int     bout;
     int     round;
     int     attacker_id;
     int     target_id;
+    float   power;
+    float   shield;
     float   damage;
     int     attacker_owner_id;
 
@@ -200,7 +204,7 @@ struct FO_COMMON_API WeaponsPlatformEvent : public CombatEvent {
 
     virtual ~WeaponsPlatformEvent() {}
 
-    void AddEvent(int round, int target_id, float damage_);
+    void AddEvent(int round, int target_id, float power_, float shield_, float damage_);
 
     virtual std::string DebugString() const;
     virtual std::string CombatLogDescription(int viewing_empire_id) const;

--- a/combat/CombatEvents.h
+++ b/combat/CombatEvents.h
@@ -187,6 +187,8 @@ struct FO_COMMON_API WeaponFireEvent : public CombatEvent {
     virtual std::string DebugString() const;
     virtual std::string CombatLogDescription(int viewing_empire_id) const;
     virtual std::string CombatLogDetails(int viewing_empire_id) const;
+    virtual bool AreDetailsEmpty(int viewing_empire_id) const
+    { return false; }
     virtual boost::optional<int> PrincipalFaction(int viewing_empire_id) const;
 
     int     bout;

--- a/combat/CombatLogManager.cpp
+++ b/combat/CombatLogManager.cpp
@@ -121,6 +121,8 @@ void CombatLog::serialize(Archive& ar, const unsigned int version)
     ar.template register_type<IncapacitationEvent>();
     ar.template register_type<BoutBeginEvent>();
     ar.template register_type<InitialStealthEvent>();
+    ar.template register_type<StealthChangeEvent>();
+
     ar  & BOOST_SERIALIZATION_NVP(turn)
     & BOOST_SERIALIZATION_NVP(system_id)
     & BOOST_SERIALIZATION_NVP(empire_ids)

--- a/combat/CombatLogManager.cpp
+++ b/combat/CombatLogManager.cpp
@@ -117,7 +117,7 @@ void CombatLog::serialize(Archive& ar, const unsigned int version)
     // pointers to their base class.
     // Therefore we need to manually register their types
     // in the archive.
-    ar.template register_type<AttackEvent>();
+    ar.template register_type<WeaponFireEvent>();
     ar.template register_type<IncapacitationEvent>();
     ar.template register_type<BoutBeginEvent>();
     ar.template register_type<InitialStealthEvent>();

--- a/combat/CombatLogManager.cpp
+++ b/combat/CombatLogManager.cpp
@@ -122,6 +122,7 @@ void CombatLog::serialize(Archive& ar, const unsigned int version)
     ar.template register_type<BoutBeginEvent>();
     ar.template register_type<InitialStealthEvent>();
     ar.template register_type<StealthChangeEvent>();
+    ar.template register_type<WeaponsPlatformEvent>();
 
     ar  & BOOST_SERIALIZATION_NVP(turn)
     & BOOST_SERIALIZATION_NVP(system_id)

--- a/combat/CombatLogManager.cpp
+++ b/combat/CombatLogManager.cpp
@@ -120,7 +120,7 @@ void CombatLog::serialize(Archive& ar, const unsigned int version)
     ar.template register_type<AttackEvent>();
     ar.template register_type<IncapacitationEvent>();
     ar.template register_type<BoutBeginEvent>();
-    
+    ar.template register_type<InitialStealthEvent>();
     ar  & BOOST_SERIALIZATION_NVP(turn)
     & BOOST_SERIALIZATION_NVP(system_id)
     & BOOST_SERIALIZATION_NVP(empire_ids)

--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -346,7 +346,7 @@ namespace {
                 DebugLogger() << "COMBAT: Ship " << attacker->Name() << " (" << attacker->ID() << ") does " << damage << " damage to Ship " << target->Name() << " (" << target->ID() << ")";
         }
 
-        combat_info.combat_events.push_back(boost::make_shared<AttackEvent>(bout, round, attacker->ID(), target->ID(), damage, attacker->Owner()));
+        combat_info.combat_events.push_back(boost::make_shared<WeaponFireEvent>(bout, round, attacker->ID(), target->ID(), damage, attacker->Owner()));
 
         attacker->SetLastTurnActiveInCombat(CurrentTurn());
         target->SetLastTurnActiveInCombat(CurrentTurn());
@@ -419,7 +419,7 @@ namespace {
                 DebugLogger() << "COMBAT: Ship " << attacker->Name() << " (" << attacker->ID() << ") does " << construction_damage << " instrastructure damage to Planet " << target->Name() << " (" << target->ID() << ")";
         }
 
-        combat_info.combat_events.push_back(boost::make_shared<AttackEvent>(bout, round, attacker->ID(), target->ID(), damage, attacker->Owner()));
+        combat_info.combat_events.push_back(boost::make_shared<WeaponFireEvent>(bout, round, attacker->ID(), target->ID(), damage, attacker->Owner()));
         attacker->SetLastTurnActiveInCombat(CurrentTurn());
         target->SetLastTurnAttackedByShip(CurrentTurn());
     }
@@ -472,7 +472,7 @@ namespace {
                 DebugLogger() << "COMBAT: Planet " << attacker->Name() << " (" << attacker->ID() << ") does " << damage << " damage to Ship " << target->Name() << " (" << target->ID() << ")";
         }
 
-        combat_info.combat_events.push_back(boost::make_shared<AttackEvent>(bout, round, attacker->ID(), target->ID(), damage, attacker->Owner()));
+        combat_info.combat_events.push_back(boost::make_shared<WeaponFireEvent>(bout, round, attacker->ID(), target->ID(), damage, attacker->Owner()));
         target->SetLastTurnActiveInCombat(CurrentTurn());
     }
 
@@ -528,7 +528,7 @@ namespace {
                 DebugLogger() << "COMBAT: Fighter of empire " << attacker->Owner() << " (" << attacker->ID() << ") does " << damage << " damage to Ship " << target->Name() << " (" << target->ID() << ")";
         }
 
-        combat_info.combat_events.push_back(boost::make_shared<AttackEvent>(bout, round, attacker->ID(), target->ID(), damage, attacker->Owner()));
+        combat_info.combat_events.push_back(boost::make_shared<WeaponFireEvent>(bout, round, attacker->ID(), target->ID(), damage, attacker->Owner()));
         target->SetLastTurnActiveInCombat(CurrentTurn());
     }
 
@@ -1641,7 +1641,7 @@ namespace {
             // of visibility the attacker can be counter-attacked in subsequent rounds if it
             // was not already attackable
             CombatEventPtr this_event = combat_info.combat_events[event_index];
-            if (boost::shared_ptr<AttackEvent> this_attack = boost::dynamic_pointer_cast<AttackEvent>(this_event)) {
+            if (boost::shared_ptr<WeaponFireEvent> this_attack = boost::dynamic_pointer_cast<WeaponFireEvent>(this_event)) {
                 combat_info.ForceAtLeastBasicVisibility(this_attack->attacker_id, this_attack->target_id);
                 int target_empire = combat_info.objects.Object(this_attack->target_id)->Owner();
                 std::set<int>::iterator attacker_targettable_it

--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -1613,7 +1613,7 @@ namespace {
             WeaponsPlatformEvent::WeaponsPlatformEventPtr platform_event
                 = boost::make_shared<WeaponsPlatformEvent>(bout, attacker_id, attacker->Owner());
             ShootAllWeapons(attacker, weapons, combat_state, bout, round++, platform_event);
-            if (!platform_event->SubEvents(attacker->Owner()).empty())
+            if (!platform_event->AreSubEventsEmpty(attacker->Owner()))
                 combat_info.combat_events.push_back(platform_event);
         }
 
@@ -1689,7 +1689,8 @@ namespace {
                 }
             }
         }
-        combat_info.combat_events.push_back(stealth_change_event);
+        if (!stealth_change_event->AreSubEventsEmpty(ALL_EMPIRES))
+            combat_info.combat_events.push_back(stealth_change_event);
 
         /// Remove all who died in the bout
         combat_state.CullTheDead(bout);

--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -1565,10 +1565,10 @@ namespace {
             }
 
         } else if (attack_planet) {     // treat planet defenses as direct fire weapon
-            weapons.push_back(PartAttackInfo(PC_DIRECT_WEAPON, "", attack_planet->CurrentMeterValue(METER_DEFENSE)));
+            weapons.push_back(PartAttackInfo(PC_DIRECT_WEAPON, "DEF_DEFENSE", attack_planet->CurrentMeterValue(METER_DEFENSE)));
 
         } else if (attack_fighter) {    // treat fighter damage as direct fire weapon
-            weapons.push_back(PartAttackInfo(PC_DIRECT_WEAPON, "", attack_fighter->Damage()));
+            weapons.push_back(PartAttackInfo(PC_DIRECT_WEAPON, "FT_WEAPON_1", attack_fighter->Damage()));
         }
         return weapons;
     }

--- a/combat/CombatSystem.h
+++ b/combat/CombatSystem.h
@@ -4,6 +4,7 @@
 #include "../universe/Universe.h"
 #include "../util/AppInterface.h"
 #include "CombatEvent.h"
+#include "CombatEvents.h"
 
 #include <boost/serialization/version.hpp>
 

--- a/combat/CombatSystem.h
+++ b/combat/CombatSystem.h
@@ -23,6 +23,11 @@ public:
     /** \name Mutators */ //@{
     //void                        Clear();            ///< cleans up contents
     TemporaryPtr<System>        GetSystem();        ///< returns System object in this CombatInfo's objects if one exists with id system_id
+
+    /**Reveal stealthed attacker to their target's empires.
+       Returns true and new visibility if update changed visibility.*/
+    std::pair<bool, Visibility> UpdateObjectVisibility(int attacker_id, int target_id);
+
     //@}
 
     int                                 turn;                       ///< main game turn
@@ -45,6 +50,8 @@ private:
     void    GetDestroyedObjectKnowersToSerialize(std::map<int, std::set<int> >&         filtered_destroyed_object_knowers,  int encoding_empire) const;
     void    GetEmpireObjectVisibilityToSerialize(Universe::EmpireObjectVisibilityMap&   filtered_empire_object_visibility,  int encoding_empire) const;
     void    GetCombatEventsToSerialize(          std::vector<CombatEventPtr>&           filtered_combat_events,             int encoding_empire) const;
+
+    void InitializeObjectVisibility();
 
     friend class boost::serialization::access;
     template<class Archive>

--- a/combat/CombatSystem.h
+++ b/combat/CombatSystem.h
@@ -25,9 +25,8 @@ public:
     //void                        Clear();            ///< cleans up contents
     TemporaryPtr<System>        GetSystem();        ///< returns System object in this CombatInfo's objects if one exists with id system_id
 
-    /**Reveal stealthed attacker to their target's empires.
-       Returns true and new visibility if update changed visibility.*/
-    std::pair<bool, Visibility> UpdateObjectVisibility(int attacker_id, int target_id);
+    /** Reveal stealthed attacker to their target's empires. */
+    void ForceAtLeastBasicVisibility(int attacker_id, int target_id);
 
     //@}
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -56,6 +56,10 @@ Yes
 NO
 No
 
+# ELLIPSIS is used as a placeholder for unexpanded content in the combat log window.
+ELLIPSIS
+...
+
 EMPIRE
 Empire
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -3868,6 +3868,17 @@ The%1%ship %2% was destroyed
 ENC_COMBAT_INITIAL_STEALTH_LIST
 %2% empire can not target:
 
+# %1 attacker %2 defender %3 empire
+ENC_COMBAT_STEALTH_DECLOAK_ATTACK
+%1% decloaks while attacking %2%.
+
+ENC_COMBAT_STEALTH_DECLOAK_ATTACK_1_EVENTS
+%2% empire can now target,
+
+ENC_COMBAT_STEALTH_DECLOAK_ATTACK_MANY_EVENTS
+%2% empire can now target:
+
+
 ###########################################
 # Combat Report #
 ###########################################

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -3878,6 +3878,18 @@ ENC_COMBAT_STEALTH_DECLOAK_ATTACK_1_EVENTS
 ENC_COMBAT_STEALTH_DECLOAK_ATTACK_MANY_EVENTS
 %2% empire can now target:
 
+ENC_COMBAT_PLATFORM_DAMAGE_1_EVENTS
+%2% damages the
+
+ENC_COMBAT_PLATFORM_DAMAGE_MANY_EVENTS
+%2% damages %1% targets:
+
+ENC_COMBAT_PLATFORM_NO_DAMAGE_1_EVENTS
+%2% could not damage the
+
+ENC_COMBAT_PLATFORM_NO_DAMAGE_MANY_EVENTS
+%2% could not damage %1% targets:
+
 
 ###########################################
 # Combat Report #

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -3837,6 +3837,9 @@ Combat at %1% on turn %2%:
 ENC_COMBAT_ATTACK_STR
 %1% attacks %2% and does %3% damage
 
+ENC_COMBAT_ATTACK_DETAILS
+Attack strength: %1%  Shield strength: %2%  Final damage: %3%
+
 ENC_COMBAT_ATTACK_SIMPLE_STR
 %1% attacks %2%
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -3865,6 +3865,9 @@ The%1%planet %2% was incapacitated
 ENC_COMBAT_DESTROYED_STR
 The%1%ship %2% was destroyed
 
+ENC_COMBAT_INITIAL_STEALTH_LIST
+%2% empire can not target:
+
 ###########################################
 # Combat Report #
 ###########################################

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -8724,6 +8724,9 @@ Interstellar Lighthouse
 SPY_LIGHTHOUSE_DESC
 By using a complex pattern of EM pulses and particle streams to reveal the location of objects in a system, it is possible for even very stealthy objects to be illuminated and detected with moderate detection equipment.
 
+DEF_DEFENSE
+Planetary Defense
+
 DEF_DEFENSE_NET_1
 Planetary Defense Network 1
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -207,6 +207,63 @@ Unowned
 NOWHERE
 Cannot be produced
 
+################################## 
+# FORMAT_LIST items are for lists of the form
+# FORMAT_LIST_HEADER FORMAT_LIST_x_ITEMS
+# i.e.
+# There is none.
+# There is only: banana
+# There are: apple and banana
+##################################
+
+FORMAT_LIST_DEFAULT_PLURAL_HEADER
+There are:
+
+FORMAT_LIST_DEFAULT_SINGLE_HEADER
+There is one:
+
+FORMAT_LIST_DEFAULT_EMPTY_HEADER
+There is none.
+
+FORMAT_LIST_DEFAULT_DUAL_HEADER
+There are:
+
+FORMAT_LIST_0_ITEMS
+%1%
+
+FORMAT_LIST_1_ITEMS
+%1% %2%.
+
+FORMAT_LIST_2_ITEMS
+%1% %2% and %3%.
+
+FORMAT_LIST_3_ITEMS
+%1% %2%, %3% and %4%.
+
+FORMAT_LIST_4_ITEMS
+%1% %2%, %3%, %4% and %5%.
+
+FORMAT_LIST_5_ITEMS
+%1% %2%, %3%, %4%, %5% and %6%.
+
+FORMAT_LIST_6_ITEMS
+%1% %2%, %3%, %4%, %5%, %6% and %7%.
+
+FORMAT_LIST_7_ITEMS
+%1% %2%, %3%, %4%, %5%, %6%, %7% and %8%.
+
+FORMAT_LIST_8_ITEMS
+%1% %2%, %3%, %4%, %5%, %6%, %7%, %8% and %9%.
+
+FORMAT_LIST_9_ITEMS
+%1% %2%, %3%, %4%, %5%, %6%, %7%, %8%, %9% and %10%.
+
+FORMAT_LIST_10_ITEMS
+%1% %2%, %3%, %4%, %5%, %6%, %7%, %8%, %9%, %10% and %11%.
+
+FORMAT_LIST_MANY_ITEMS
+%1% %2%, %3%, %4%, %5%, %6%, %7%, %8%, %9%, %10%, %11% ...
+
 ###########################
 # Predefined Ship Designs #
 ###########################

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -3842,7 +3842,7 @@ ENC_COMBAT_ATTACK_STR
 %1% attacks %2% and does %3% damage
 
 ENC_COMBAT_ATTACK_DETAILS
-Attack strength: %1%  Shield strength: %2%  Damage: %3%
+Weapon: %1%  Strength: %2%  Shields: %3%  Damage: %4%
 
 ENC_COMBAT_ATTACK_SIMPLE_STR
 %1% attacks %2%

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -211,7 +211,7 @@ Cannot be produced
 # FORMAT_LIST items are for lists of the form
 # FORMAT_LIST_HEADER FORMAT_LIST_x_ITEMS
 # i.e.
-# There is none.
+# There are none.
 # There is only: banana
 # There are: apple and banana
 ##################################
@@ -223,7 +223,7 @@ FORMAT_LIST_DEFAULT_SINGLE_HEADER
 There is one:
 
 FORMAT_LIST_DEFAULT_EMPTY_HEADER
-There is none.
+There are none.
 
 FORMAT_LIST_DEFAULT_DUAL_HEADER
 There are:
@@ -3838,7 +3838,7 @@ ENC_COMBAT_ATTACK_STR
 %1% attacks %2% and does %3% damage
 
 ENC_COMBAT_ATTACK_DETAILS
-Attack strength: %1%  Shield strength: %2%  Final damage: %3%
+Attack strength: %1%  Shield strength: %2%  Damage: %3%
 
 ENC_COMBAT_ATTACK_SIMPLE_STR
 %1% attacks %2%
@@ -3873,22 +3873,26 @@ ENC_COMBAT_INITIAL_STEALTH_LIST
 
 # %1 attacker %2 defender %3 empire
 ENC_COMBAT_STEALTH_DECLOAK_ATTACK
-%1% decloaks while attacking %2%.
+%2% detects %1% during attack.
 
 ENC_COMBAT_STEALTH_DECLOAK_ATTACK_1_EVENTS
-%2% empire can now target,
+%2% detects
 
 ENC_COMBAT_STEALTH_DECLOAK_ATTACK_MANY_EVENTS
-%2% empire can now target:
+%2% detects:
 
 ENC_COMBAT_PLATFORM_DAMAGE_1_EVENTS
-%2% damages the
+%2% damages
 
 ENC_COMBAT_PLATFORM_DAMAGE_MANY_EVENTS
 %2% damages %1% targets:
 
+# %1 defender %2 damage
+ENC_COMBAT_PLATFORM_TARGET_AND_DAMAGE
+%1% for %2% damage
+
 ENC_COMBAT_PLATFORM_NO_DAMAGE_1_EVENTS
-%2% could not damage the
+%2% could not damage
 
 ENC_COMBAT_PLATFORM_NO_DAMAGE_MANY_EVENTS
 %2% could not damage %1% targets:

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1973,11 +1973,11 @@ namespace {
             for (std::vector<CombatEventPtr>::const_iterator it = attacks.begin();
                  it != attacks.end(); ++it)
             {
-                const AttackEvent* maybe_attack = dynamic_cast<AttackEvent*>(it->get());
+                const WeaponFireEvent* maybe_attack = dynamic_cast<WeaponFireEvent*>(it->get());
                 if(!maybe_attack){
                     continue;
                 }
-                const AttackEvent& attack = *maybe_attack;
+                const WeaponFireEvent& attack = *maybe_attack;
                 // Check that the thing that was hurt died
                 if (combat_info.destroyed_object_ids.find(attack.target_id) == combat_info.destroyed_object_ids.end())
                     continue;

--- a/util/i18n.cpp
+++ b/util/i18n.cpp
@@ -263,3 +263,4 @@ int EffectiveSign(double val) {
     else
         return 0;
 }
+

--- a/util/i18n.h
+++ b/util/i18n.h
@@ -53,12 +53,12 @@ FO_COMMON_API int EffectiveSign(double val);
 
 template<typename HeaderContainer, typename ListContainer>
 FO_COMMON_API boost::format FlexibleFormatList(
-    const HeaderContainer& header_words
-    , const ListContainer& words
-    , const std::string& plural_header_template
-    , const std::string& single_header_template
-    , const std::string& empty_header_template
-    , const std::string& dual_header_template )
+    const HeaderContainer& header_words,
+    const ListContainer& words,
+    const std::string& plural_header_template,
+    const std::string& single_header_template,
+    const std::string& empty_header_template,
+    const std::string& dual_header_template )
 {
     std::string header_template;
     switch (words.size()) {
@@ -81,7 +81,7 @@ FO_COMMON_API boost::format FlexibleFormatList(
         header_fmt % *it;
     }
 
-    std::string template_str = words.size()<=10
+    std::string template_str = words.size() <= 10
         ? UserString("FORMAT_LIST_" + boost::lexical_cast<std::string>(words.size()) + "_ITEMS")
         : UserString("FORMAT_LIST_MANY_ITEMS");
 
@@ -96,11 +96,11 @@ FO_COMMON_API boost::format FlexibleFormatList(
 
 template<typename Container>
 FO_COMMON_API boost::format FlexibleFormatList(const Container& words) {
-    return FlexibleFormatList(std::vector<std::string>(), words
-                              , UserString("FORMAT_LIST_DEFAULT_PLURAL_HEADER")
-                              , UserString("FORMAT_LIST_DEFAULT_SINGLE_HEADER")
-                              , UserString("FORMAT_LIST_DEFAULT_EMPTY_HEADER")
-                              , UserString("FORMAT_LIST_DEFAULT_DUAL_HEADER"));
+    return FlexibleFormatList(std::vector<std::string>(), words,
+                              UserString("FORMAT_LIST_DEFAULT_PLURAL_HEADER"),
+                              UserString("FORMAT_LIST_DEFAULT_SINGLE_HEADER"),
+                              UserString("FORMAT_LIST_DEFAULT_EMPTY_HEADER"),
+                              UserString("FORMAT_LIST_DEFAULT_DUAL_HEADER"));
 }
 
 template<typename Container>


### PR DESCRIPTION
This PR adds expandable details to the combat log.  The point is to make the specific rules governing combat available immediately in the combat log, in particular the interaction of shields and stealth.  It creates a framework for other events and writing the combat log in a more narrative structure.

Please comment on this idea and/or the implementation.

The motivation is in questions from beginners (like myself) on the forum.  Two often repeated questions are: Why was my massive fleet with mass drivers unable to damage the enemy?; Why did my stealth fleet suddenly get wiped out in round 2? The answer is usually read the manual.  This tries to provide the answer right where the player is already looking.

I've posted two partially expanded combat logs on the [http://freeorion.org/forum/viewtopic.php?f=6&t=10058](forum), showing shields preventing damage and a ship being destroyed in round 2 after it has been decloaked.  Note that damage is grouped by attacker.

In the shield case the details show attack strength, shield strength and final damage implying that 9 strength - 3 shield = 6 damage.

In the cloaking case, the details show which (friendly) planets and ships are cloaked at the start of combat and which ones decloaked and why.  It does not list enemy cloaked ships or planets.

To implement this, I have pushed the XML generation into the CombatEvent, which must generate a CombatLogDescription() and may generate CombatLogDetails() and SubEvents() if appropriate.  This better localizes the code for each type of event.  The combat log itself only checks each log and displays it as plain text or in an accordion window.

CombatSystem was changed in order to include the new events. ObjectAttackableBy[Monsters/Empire] was refactored to create ObjectUntargettableBy[Monsters/Empire] to create the initial stealth event.

Some code other than the CombatLog, CombatSystem and the events was changed.

The TextControl and Layout were changed so that TextControl can report a minusable size based on a proposed width and the Layout can then use that value.

AccordionPanel was changed to be more general: report a client area, settable interior color, report state of collapse.
