### PR TITLE
Fix bug524 wait for ai crash

### DIFF
--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -116,13 +116,16 @@ void AIClientApp::ConnectToServer() {
 void AIClientApp::StartPythonAI() {
     PythonAI* python_ai = new PythonAI();
     if (!(python_ai->Initialize())) {
-        const std::string err_msg = "AIClientApp::AIClientApp : Failed to initialize Python AI.  Exiting Soon.";
-        ErrorLogger() << err_msg;
+        //Note: At this point in the initialization the AI has not been associated with a PlayerConnection
+        //so the server will no know the AI's PlayerName.
+        std::stringstream err_msg;
+        err_msg << "AIClientApp::AIClientApp: Failed to initialize Python AI for " << PlayerName() << ".  Exiting Soon.";
+        ErrorLogger() << err_msg.str();
         Networking().SendMessage(
             ErrorMessage(str(FlexibleFormat(UserString("ERROR_PYTHON_AI_CRASHED")) % PlayerName()) , true));
         boost::this_thread::sleep_for(boost::chrono::seconds(2));
         Networking().DisconnectFromServer();
-        throw std::runtime_error(err_msg);
+        throw std::runtime_error(err_msg.str());
     }
     m_AI = python_ai;
 

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -70,7 +70,6 @@ const AIBase* AIClientApp::GetAI()
 { return m_AI; }
 
 void AIClientApp::Run() {
-
     ConnectToServer();
 
     StartPythonAI();

--- a/client/AI/AIClientApp.h
+++ b/client/AI/AIClientApp.h
@@ -31,7 +31,10 @@ public:
 
 private:
     void                Run();          ///< initializes app state, then executes main event handler/render loop (PollAndRender())
+    void                ConnectToServer();
+    void                StartPythonAI();
     void                HandleMessage(const Message& msg);
+
 
     AIBase*             m_AI;           ///< implementation of AI logic
     std::string         m_player_name;

--- a/client/AI/camain.cpp
+++ b/client/AI/camain.cpp
@@ -51,8 +51,6 @@ int wmain(int argc, wchar_t* argv[], wchar_t* envp[]) {
 
         AIClientApp g_app(args);
 
-        DebugLogger() << "AIClientApp and logging initialized.  Running app.";
-
         g_app();
 
     } catch (const std::invalid_argument& e) {

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -476,10 +476,12 @@ boost::statechart::result PlayingGame::react(const Error& msg) {
     // MessageBox blocks and can allow other events to transit<> to a new state
     // which makes this transit fatal.
     boost::statechart::result retval = fatal ? transit<IntroMenu>() : discard_event();
-    ClientUI::MessageBox(UserString(problem), true);
+    ClientUI::MessageBox(UserString(problem), false);
 
     if (fatal) {
         Client().EndGame(true);
+        Client().GetClientUI()->GetMessageWnd()->Hide();
+        Client().GetClientUI()->GetPlayerListWnd()->Hide();
         Client().Remove(Client().GetClientUI()->GetMapWnd());
         Client().GetClientUI()->GetMapWnd()->RemoveWindows();
         Client().Networking().SetHostPlayerID(Networking::INVALID_PLAYER_ID);

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -889,6 +889,10 @@ Universe generation completed with errors. See log files for detailed error mess
 SERVER_TURN_EVENTS_ERRORS
 Python scripted turn events executed with errors. See log files for detailed error messages. Game can continue, but gameplay will probably be impaired.
 
+ERROR_PYTHON_AI_CRASHED
+Python AI for %1% crashed.
+
+
 ######################################
 # Command Line and OptionsDB Options #
 ######################################

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -318,6 +318,7 @@ int ServerApp::GetNewDesignID()
 
 void ServerApp::Run() {
     DebugLogger() << "FreeOrion server waiting for network events";
+    std::cout << "FreeOrion server waiting for network events" << std::endl;
     while (1) {
         if (m_io_service.run_one())
             m_networking.HandleNextEvent();

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -318,7 +318,6 @@ int ServerApp::GetNewDesignID()
 
 void ServerApp::Run() {
     DebugLogger() << "FreeOrion server waiting for network events";
-    std::cout << "FreeOrion server waiting for network events" << std::endl;
     while (1) {
         if (m_io_service.run_one())
             m_networking.HandleNextEvent();
@@ -437,6 +436,7 @@ void ServerApp::HandleNonPlayerMessage(const Message& msg, PlayerConnectionPtr p
     case Message::HOST_SP_GAME: m_fsm->process_event(HostSPGame(msg, player_connection));   break;
     case Message::HOST_MP_GAME: m_fsm->process_event(HostMPGame(msg, player_connection));   break;
     case Message::JOIN_GAME:    m_fsm->process_event(JoinGame(msg, player_connection));     break;
+    case Message::ERROR_MSG:    m_fsm->process_event(Error(msg, player_connection));        break;
     case Message::DEBUG:        break;
     default:
         if ((m_networking.size() == 1) && (player_connection->IsLocalConnection()) && (msg.Type() == Message::SHUT_DOWN_SERVER)) {

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -1337,11 +1337,6 @@ sc::result WaitingForTurnEnd::react(const CheckTurnEndConditions& c) {
     return discard_event();
 }
 
-sc::result WaitingForTurnEnd::react(const Error& msg) {
-    HandleErrorMessage(msg, Server());
-    return discard_event();
-}
-
 
 ////////////////////////////////////////////////////////////
 // WaitingForTurnEndIdle
@@ -1371,11 +1366,6 @@ sc::result WaitingForTurnEndIdle::react(const SaveGameRequest& msg) {
     context<WaitingForTurnEnd>().m_save_filename = message.Text();  // store requested save file name in Base state context so that sibling state can retreive it
 
     return transit<WaitingForSaveData>();
-}
-
-sc::result WaitingForTurnEndIdle::react(const Error& msg) {
-    HandleErrorMessage(msg, Server());
-    return discard_event();
 }
 
 
@@ -1490,11 +1480,6 @@ sc::result WaitingForSaveData::react(const ClientSaveData& msg) {
     return discard_event();
 }
 
-sc::result WaitingForSaveData::react(const Error& msg) {
-    HandleErrorMessage(msg, Server());
-    return discard_event();
-}
-
 
 ////////////////////////////////////////////////////////////
 // ProcessingTurn
@@ -1546,10 +1531,5 @@ sc::result ProcessingTurn::react(const ProcessTurn& u) {
 
 sc::result ProcessingTurn::react(const CheckTurnEndConditions& c) {
     if (TRACE_EXECUTION) DebugLogger() << "(ServerFSM) ProcessingTurn.CheckTurnEndConditions";
-    return discard_event();
-}
-
-sc::result ProcessingTurn::react(const Error& msg) {
-    HandleErrorMessage(msg, Server());
     return discard_event();
 }

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -141,6 +141,7 @@ namespace {
     }
 
 
+    /** Note:  This Exits on fatal errors and does not return.*/
     void HandleErrorMessage(const Error& msg, ServerApp &server) {
         std::string problem;
         bool fatal;
@@ -149,7 +150,9 @@ namespace {
         std::stringstream ss;
 
         ss << "Server received from player "
-           << msg.m_player_connection << (fatal?"a fatal":"an")
+           << msg.m_player_connection->PlayerName() << "("
+           << msg.m_player_connection->PlayerID() << ")"
+           << (fatal?" a fatal":" an")
            << " error message: " << problem;
 
         if (fatal) {

--- a/server/ServerFSM.h
+++ b/server/ServerFSM.h
@@ -66,7 +66,8 @@ struct MessageEventBase {
     (RequestDesignID)                       \
     (PlayerChat)                            \
     (Diplomacy)                             \
-    (ModeratorAct)
+    (ModeratorAct)                          \
+    (Error)
 
 
 #define DECLARE_MESSAGE_EVENT(r, data, name)                                    \
@@ -124,7 +125,8 @@ private:
 struct Idle : sc::state<Idle, ServerFSM> {
     typedef boost::mpl::list<
         sc::custom_reaction<HostMPGame>,
-        sc::custom_reaction<HostSPGame>
+        sc::custom_reaction<HostSPGame>,
+        sc::custom_reaction<Error>
     > reactions;
 
     Idle(my_context c);
@@ -132,6 +134,7 @@ struct Idle : sc::state<Idle, ServerFSM> {
 
     sc::result react(const HostMPGame& msg);
     sc::result react(const HostSPGame& msg);
+    sc::result react(const Error& msg);
 
     SERVER_ACCESSOR
 };
@@ -146,7 +149,8 @@ struct MPLobby : sc::state<MPLobby, ServerFSM> {
         sc::custom_reaction<LobbyChat>,
         sc::custom_reaction<StartMPGame>,
         sc::custom_reaction<HostMPGame>,
-        sc::custom_reaction<HostSPGame>
+        sc::custom_reaction<HostSPGame>,
+        sc::custom_reaction<Error>
     > reactions;
 
     MPLobby(my_context c);
@@ -159,6 +163,7 @@ struct MPLobby : sc::state<MPLobby, ServerFSM> {
     sc::result react(const StartMPGame& msg);
     sc::result react(const HostMPGame& msg);
     sc::result react(const HostSPGame& msg);
+    sc::result react(const Error& msg);
 
     boost::shared_ptr<MultiplayerLobbyData> m_lobby_data;
     std::vector<PlayerSaveGameData>         m_player_save_game_data;
@@ -175,7 +180,8 @@ struct WaitingForSPGameJoiners : sc::state<WaitingForSPGameJoiners, ServerFSM> {
         sc::in_state_reaction<Disconnection, ServerFSM, &ServerFSM::HandleNonLobbyDisconnection>,
         sc::custom_reaction<JoinGame>,
         sc::custom_reaction<CheckStartConditions>,
-        sc::custom_reaction<LoadSaveFileFailed>
+        sc::custom_reaction<LoadSaveFileFailed>,
+        sc::custom_reaction<Error>
     > reactions;
 
     WaitingForSPGameJoiners(my_context c);
@@ -186,6 +192,7 @@ struct WaitingForSPGameJoiners : sc::state<WaitingForSPGameJoiners, ServerFSM> {
     // in SP games, save data is loaded when setting up AI clients, in order to
     // know which / how many to set up.  Loading might fail.
     sc::result react(const LoadSaveFileFailed& u);
+    sc::result react(const Error& msg);
 
     boost::shared_ptr<SinglePlayerSetupData> m_single_player_setup_data;
     std::vector<PlayerSaveGameData>          m_player_save_game_data;
@@ -203,7 +210,8 @@ struct WaitingForMPGameJoiners : sc::state<WaitingForMPGameJoiners, ServerFSM> {
     typedef boost::mpl::list<
         sc::in_state_reaction<Disconnection, ServerFSM, &ServerFSM::HandleNonLobbyDisconnection>,
         sc::custom_reaction<JoinGame>,
-        sc::custom_reaction<CheckStartConditions>
+        sc::custom_reaction<CheckStartConditions>,
+        sc::custom_reaction<Error>
     > reactions;
 
     WaitingForMPGameJoiners(my_context c);
@@ -214,6 +222,7 @@ struct WaitingForMPGameJoiners : sc::state<WaitingForMPGameJoiners, ServerFSM> {
     // unlike in SP game setup, no save file data needs to be loaded in this
     // state, as all the relevant info about AIs is provided by the lobby data.
     // as such, no file load error handling reaction is needed in this state.
+    sc::result react(const Error& msg);
 
     boost::shared_ptr<MultiplayerLobbyData> m_lobby_data;
     std::vector<PlayerSaveGameData>         m_player_save_game_data;
@@ -232,7 +241,8 @@ struct PlayingGame : sc::state<PlayingGame, ServerFSM, WaitingForTurnEnd> {
         sc::in_state_reaction<Disconnection, ServerFSM, &ServerFSM::HandleNonLobbyDisconnection>,
         sc::custom_reaction<PlayerChat>,
         sc::custom_reaction<Diplomacy>,
-        sc::custom_reaction<ModeratorAct>
+        sc::custom_reaction<ModeratorAct>,
+        sc::custom_reaction<Error>
     > reactions;
 
     PlayingGame(my_context c);
@@ -241,6 +251,7 @@ struct PlayingGame : sc::state<PlayingGame, ServerFSM, WaitingForTurnEnd> {
     sc::result react(const PlayerChat& msg);
     sc::result react(const Diplomacy& msg);
     sc::result react(const ModeratorAct& msg);
+    sc::result react(const Error& msg);
 
     SERVER_ACCESSOR
 };
@@ -254,7 +265,8 @@ struct WaitingForTurnEnd : sc::state<WaitingForTurnEnd, PlayingGame, WaitingForT
         sc::custom_reaction<TurnOrders>,
         sc::custom_reaction<RequestObjectID>,
         sc::custom_reaction<RequestDesignID>,
-        sc::custom_reaction<CheckTurnEndConditions>
+        sc::custom_reaction<CheckTurnEndConditions>,
+        sc::custom_reaction<Error>
     > reactions;
 
     WaitingForTurnEnd(my_context c);
@@ -264,6 +276,7 @@ struct WaitingForTurnEnd : sc::state<WaitingForTurnEnd, PlayingGame, WaitingForT
     sc::result react(const RequestObjectID& msg);
     sc::result react(const RequestDesignID& msg);
     sc::result react(const CheckTurnEndConditions& c);
+    sc::result react(const Error& msg);
 
     std::string m_save_filename;
 
@@ -274,13 +287,15 @@ struct WaitingForTurnEnd : sc::state<WaitingForTurnEnd, PlayingGame, WaitingForT
 /** The default substate of WaitingForTurnEnd. */
 struct WaitingForTurnEndIdle : sc::state<WaitingForTurnEndIdle, WaitingForTurnEnd> {
     typedef boost::mpl::list<
-        sc::custom_reaction<SaveGameRequest>
+        sc::custom_reaction<SaveGameRequest>,
+        sc::custom_reaction<Error>
     > reactions;
 
     WaitingForTurnEndIdle(my_context c);
     ~WaitingForTurnEndIdle();
 
     sc::result react(const SaveGameRequest& msg);
+    sc::result react(const Error& msg);
 
     SERVER_ACCESSOR
 };
@@ -295,13 +310,15 @@ struct WaitingForSaveData : sc::state<WaitingForSaveData, WaitingForTurnEnd> {
         sc::deferral<SaveGameRequest>,
         sc::deferral<TurnOrders>,
         sc::deferral<PlayerChat>,
-        sc::deferral<Diplomacy>
+        sc::deferral<Diplomacy>,
+        sc::custom_reaction<Error>
     > reactions;
 
     WaitingForSaveData(my_context c);
     ~WaitingForSaveData();
 
     sc::result react(const ClientSaveData& msg);
+    sc::result react(const Error& msg);
 
     std::set<int>                   m_needed_reponses;
     std::set<int>                   m_players_responded;
@@ -322,7 +339,8 @@ struct ProcessingTurn : sc::state<ProcessingTurn, PlayingGame> {
         sc::deferral<SaveGameRequest>,
         sc::deferral<TurnOrders>,
         sc::deferral<Diplomacy>,
-        sc::custom_reaction<CheckTurnEndConditions>
+        sc::custom_reaction<CheckTurnEndConditions>,
+        sc::custom_reaction<Error>
     > reactions;
 
     ProcessingTurn(my_context c);
@@ -330,6 +348,7 @@ struct ProcessingTurn : sc::state<ProcessingTurn, PlayingGame> {
 
     sc::result react(const ProcessTurn& u);
     sc::result react(const CheckTurnEndConditions& c);
+    sc::result react(const Error& msg);
 
     SERVER_ACCESSOR
 };

--- a/server/ServerFSM.h
+++ b/server/ServerFSM.h
@@ -265,8 +265,7 @@ struct WaitingForTurnEnd : sc::state<WaitingForTurnEnd, PlayingGame, WaitingForT
         sc::custom_reaction<TurnOrders>,
         sc::custom_reaction<RequestObjectID>,
         sc::custom_reaction<RequestDesignID>,
-        sc::custom_reaction<CheckTurnEndConditions>,
-        sc::custom_reaction<Error>
+        sc::custom_reaction<CheckTurnEndConditions>
     > reactions;
 
     WaitingForTurnEnd(my_context c);
@@ -276,7 +275,6 @@ struct WaitingForTurnEnd : sc::state<WaitingForTurnEnd, PlayingGame, WaitingForT
     sc::result react(const RequestObjectID& msg);
     sc::result react(const RequestDesignID& msg);
     sc::result react(const CheckTurnEndConditions& c);
-    sc::result react(const Error& msg);
 
     std::string m_save_filename;
 
@@ -287,15 +285,13 @@ struct WaitingForTurnEnd : sc::state<WaitingForTurnEnd, PlayingGame, WaitingForT
 /** The default substate of WaitingForTurnEnd. */
 struct WaitingForTurnEndIdle : sc::state<WaitingForTurnEndIdle, WaitingForTurnEnd> {
     typedef boost::mpl::list<
-        sc::custom_reaction<SaveGameRequest>,
-        sc::custom_reaction<Error>
+        sc::custom_reaction<SaveGameRequest>
     > reactions;
 
     WaitingForTurnEndIdle(my_context c);
     ~WaitingForTurnEndIdle();
 
     sc::result react(const SaveGameRequest& msg);
-    sc::result react(const Error& msg);
 
     SERVER_ACCESSOR
 };
@@ -310,15 +306,13 @@ struct WaitingForSaveData : sc::state<WaitingForSaveData, WaitingForTurnEnd> {
         sc::deferral<SaveGameRequest>,
         sc::deferral<TurnOrders>,
         sc::deferral<PlayerChat>,
-        sc::deferral<Diplomacy>,
-        sc::custom_reaction<Error>
+        sc::deferral<Diplomacy>
     > reactions;
 
     WaitingForSaveData(my_context c);
     ~WaitingForSaveData();
 
     sc::result react(const ClientSaveData& msg);
-    sc::result react(const Error& msg);
 
     std::set<int>                   m_needed_reponses;
     std::set<int>                   m_players_responded;
@@ -339,8 +333,7 @@ struct ProcessingTurn : sc::state<ProcessingTurn, PlayingGame> {
         sc::deferral<SaveGameRequest>,
         sc::deferral<TurnOrders>,
         sc::deferral<Diplomacy>,
-        sc::custom_reaction<CheckTurnEndConditions>,
-        sc::custom_reaction<Error>
+        sc::custom_reaction<CheckTurnEndConditions>
     > reactions;
 
     ProcessingTurn(my_context c);
@@ -348,7 +341,6 @@ struct ProcessingTurn : sc::state<ProcessingTurn, PlayingGame> {
 
     sc::result react(const ProcessTurn& u);
     sc::result react(const CheckTurnEndConditions& c);
-    sc::result react(const Error& msg);
 
     SERVER_ACCESSOR
 };


### PR DESCRIPTION
I think this fixes #524 and #534. 

It produces the MessageBox saying "ERROR: Python AI for AI_1 crashed."  as request by @Morlic-fo when I used the python code provided by @Cjkjvfnby during initialization of the AI.
