### PR TITLE
Closable pedia for research window

### DIFF
--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -5492,6 +5492,11 @@ void MapWnd::ShowPedia() {
         return;
     }
 
+    if (m_research_wnd->Visible()) {
+        m_research_wnd->TogglePedia();
+        return;
+    }
+
     ClearProjectedFleetMovementLines();
 
     // hide other "competing" windows
@@ -5555,6 +5560,10 @@ void MapWnd::ShowResearch() {
     // show the research window
     m_research_wnd->Show();
     GG::GUI::GetGUI()->MoveUp(m_research_wnd);
+
+    // hide pedia again if it is supposed to be hidden persistently
+    if (GetOptionsDB().Get<bool>("UI.windows.research.pedia.persistently-hidden"))
+        m_research_wnd->HidePedia();
 
     // indicate selection on button
     m_btn_research->SetUnpressedGraphic(GG::SubTexture(ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "buttons" / "research_mouseover.png")));

--- a/UI/ResearchWnd.cpp
+++ b/UI/ResearchWnd.cpp
@@ -343,6 +343,19 @@ void ResearchWnd::ShowTech(const std::string& tech_name) {
     m_tech_tree_wnd->SelectTech(tech_name);
 }
 
+void ResearchWnd::ShowPedia()
+{ m_tech_tree_wnd->ShowPedia(); }
+
+void ResearchWnd::HidePedia()
+{ m_tech_tree_wnd->HidePedia(); }
+
+void ResearchWnd::TogglePedia()
+{ m_tech_tree_wnd->TogglePedia(); }
+
+bool ResearchWnd::PediaVisible()
+{ return m_tech_tree_wnd->PediaVisible(); }
+
+
 void ResearchWnd::QueueItemMoved(GG::ListBox::Row* row, std::size_t position) {
     if (QueueRow* queue_row = boost::polymorphic_downcast<QueueRow*>(row)) {
         int empire_id = HumanClientApp::GetApp()->EmpireID();

--- a/UI/ResearchWnd.h
+++ b/UI/ResearchWnd.h
@@ -19,6 +19,7 @@ public:
 
     /** \name Accessors */ //@{
     int     ShownEmpireID() const;
+    bool    PediaVisible();
     //@}
 
     /** \name Mutators */ //@{
@@ -36,6 +37,10 @@ public:
     void    ShowTech(const std::string& tech_name);
     void    QueueItemMoved(GG::ListBox::Row* row, std::size_t position);
     void    Sanitize();
+
+    void    ShowPedia();
+    void    HidePedia();
+    void    TogglePedia();
 
     /** Enables, or disables if \a enable is false, issuing orders via this ResearchWnd. */
     void    EnableOrderIssuing(bool enable = true);

--- a/UI/TechTreeWnd.h
+++ b/UI/TechTreeWnd.h
@@ -28,6 +28,7 @@ public:
     double                  Scale() const;
     std::set<std::string>   GetCategoriesShown() const;
     std::set<TechStatus>    GetTechStatusesShown() const;
+    bool                    PediaVisible();
     //@}
 
     //! \name Mutators //@{
@@ -53,6 +54,10 @@ public:
     void            CenterOnTech(const std::string& tech_name);
     void            SetEncyclopediaTech(const std::string& tech_name);
     void            SelectTech(const std::string& tech_name);
+
+    void            ShowPedia();
+    void            HidePedia();
+    void            TogglePedia();
     //@}
 
     mutable TechSignalType          TechBrowsedSignal;

--- a/UI/TechTreeWnd.h
+++ b/UI/TechTreeWnd.h
@@ -76,6 +76,7 @@ private:
                                  const GG::Flags<GG::ModKey>& modkeys);
     void    TechDoubleClickedSlot(const std::string& tech_name,
                                   const GG::Flags<GG::ModKey>& modkeys);
+    void    TechPediaDisplaySlot(const std::string& tech_name);
 
     void    InitializeWindows();
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1508,6 +1508,9 @@ Hidden sitrep templates
 OPTIONS_DB_PRODUCTION_PEDIA_HIDDEN
 True if the player has manually closed the production window's pedia.
 
+OPTIONS_DB_RESEARCH_PEDIA_HIDDEN
+True if the player has manually closed the research window's pedia.
+
 OPTIONS_DB_UI_SAVE_DIALOG_TOOLTIP_DELAY
 Tooltip delay for save dialog
 


### PR DESCRIPTION
Allows pedia window in research screen to be toggled opened/closed.

Menu pedia button behavior consistent with production window.
