### PR TITLE
Adjust z-order when toggling Pedia in Research and Production screens

### DIFF
--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -1287,6 +1287,8 @@ void BuildDesignatorWnd::ShowFieldTypeInEncyclopedia(const std::string& field_ty
 { m_enc_detail_panel->SetFieldType(field_type_name); }
 
 void BuildDesignatorWnd::ShowPedia() {
+    MoveChildUp(m_enc_detail_panel);
+    MoveChildUp(m_build_selector);
     m_enc_detail_panel->Refresh();
     m_enc_detail_panel->Show();
 
@@ -1295,6 +1297,7 @@ void BuildDesignatorWnd::ShowPedia() {
 }
 
 void BuildDesignatorWnd::HidePedia() {
+    MoveChildDown(m_enc_detail_panel);
     m_enc_detail_panel->Hide();
 
     OptionsDB& db = GetOptionsDB();

--- a/UI/TechTreeWnd.cpp
+++ b/UI/TechTreeWnd.cpp
@@ -1981,6 +1981,8 @@ void TechTreeWnd::ShowTreeView() {
     MoveChildDown(m_layout_panel);
     DetachChild(m_tech_list);
     MoveChildUp(m_tech_tree_controls);
+    if (!PediaVisible())
+        MoveChildDown(m_enc_detail_panel);
 }
 
 void TechTreeWnd::ShowListView() {
@@ -1989,6 +1991,8 @@ void TechTreeWnd::ShowListView() {
     MoveChildDown(m_tech_list);
     DetachChild(m_layout_panel);
     MoveChildUp(m_tech_tree_controls);
+    if (!PediaVisible())
+        MoveChildDown(m_enc_detail_panel);
 }
 
 void TechTreeWnd::SetScale(double scale)
@@ -2014,6 +2018,10 @@ void TechTreeWnd::SelectTech(const std::string& tech_name)
 { m_layout_panel->ShowTech(tech_name); }
 
 void TechTreeWnd::ShowPedia() {
+    if (!PediaVisible()) {
+        MoveChildUp(m_enc_detail_panel);
+        MoveChildUp(m_tech_tree_controls);
+    }
     m_enc_detail_panel->Refresh();
     m_enc_detail_panel->Show();
 
@@ -2022,6 +2030,7 @@ void TechTreeWnd::ShowPedia() {
 }
 
 void TechTreeWnd::HidePedia() {
+    MoveChildDown(m_enc_detail_panel);
     m_enc_detail_panel->Hide();
 
     OptionsDB& db = GetOptionsDB();


### PR DESCRIPTION
Workaround for #652

Specifically reorders for research and production screens.
