### PR TITLE
Add python logger support to AI

### DIFF
--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -232,6 +232,7 @@ HumanClientApp::HumanClientApp(int width, int height, bool calculate_fps, const 
     RegisterLoggerWithOptionsDB("effects");
     RegisterLoggerWithOptionsDB("FSM");
     RegisterLoggerWithOptionsDB("network");
+    RegisterLoggerWithOptionsDB("python");
 
     InfoLogger() << FreeOrionVersionString();
 

--- a/default/python/AI/AIDependencies.py
+++ b/default/python/AI/AIDependencies.py
@@ -20,6 +20,8 @@ Example usage:
     my_industry = AIDependencies.INDUSTRY_PER_POP * my_population
 """
 import freeOrionAIInterface as fo  # interface used to interact with FreeOrion AI client  # pylint: disable=import-error
+from common.configure_logging import convenience_function_references_for_logger
+(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
 
 # Note re common dictionary lookup structure, "PlanetSize-Dependent-Lookup":
 # Many dictionaries herein (a prime example being the building_supply dictionary) have a primary key (such as

--- a/default/python/AI/AIFleetMission.py
+++ b/default/python/AI/AIFleetMission.py
@@ -14,6 +14,9 @@ from universe_object import UniverseObject, System, Fleet, Planet
 from EnumsAI import MissionType
 from AIDependencies import INVALID_ID
 
+from common.configure_logging import convenience_function_references_for_logger
+(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
+
 ORDERS_FOR_MISSION = {
     MissionType.EXPLORATION: OrderMove,
     MissionType.OUTPOST: OrderOutpost,

--- a/default/python/AI/AIstate.py
+++ b/default/python/AI/AIstate.py
@@ -14,7 +14,7 @@ from EnumsAI import MissionType, ShipRoleType
 import CombatRatingsAI
 import MilitaryAI
 import PlanetUtilsAI
-from freeorion_tools import dict_from_map, print_error
+from freeorion_tools import dict_from_map
 from universe_object import System
 from AIDependencies import INVALID_ID
 from character.character_module import create_character, Aggression
@@ -52,7 +52,7 @@ class ConversionError(Exception):
     Automatically logs and chats to the host if raised.
     """
     def __init__(self, msg=""):
-        print_error(msg)
+        error(msg, exc_info=True)
 
 
 def convert_to_version(state, version):

--- a/default/python/AI/AIstate.py
+++ b/default/python/AI/AIstate.py
@@ -19,6 +19,9 @@ from universe_object import System
 from AIDependencies import INVALID_ID
 from character.character_module import create_character, Aggression
 
+from common.configure_logging import convenience_function_references_for_logger
+(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
+
 
 # moving ALL or NEARLY ALL 'global' variables into AIState object rather than module
 # in general, leaving items as a module attribute if they are recalculated each turn without reference to prior values

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -13,7 +13,7 @@ import TechsListsAI
 import MilitaryAI
 from turn_state import state
 from EnumsAI import MissionType, FocusType, EmpireProductionTypes, ShipRoleType, PriorityType
-from freeorion_tools import dict_from_map, tech_is_complete, get_ai_tag_grade, cache_by_turn, AITimer, print_error
+from freeorion_tools import dict_from_map, tech_is_complete, get_ai_tag_grade, cache_by_turn, AITimer
 from AIDependencies import (INVALID_ID, POP_CONST_MOD_MAP, POP_SIZE_MOD_MAP_MODIFIED_BY_SPECIES,
                             POP_SIZE_MOD_MAP_NOT_MODIFIED_BY_SPECIES)
 
@@ -1352,7 +1352,7 @@ def send_colony_ships(colony_fleet_ids, evaluated_planets, mission_type):
                                                                   starting_system=sys_id, species=this_spec,
                                                                   fleet_pool_set=fleet_pool, fleet_list=found_fleets)
         except Exception as e:
-            print_error(e)
+            error(e, exc_info=True)
             continue
         if not this_fleet_list:
             fleet_pool.update(found_fleets)  # just to be safe

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -17,6 +17,9 @@ from freeorion_tools import dict_from_map, tech_is_complete, get_ai_tag_grade, c
 from AIDependencies import (INVALID_ID, POP_CONST_MOD_MAP, POP_SIZE_MOD_MAP_MODIFIED_BY_SPECIES,
                             POP_SIZE_MOD_MAP_NOT_MODIFIED_BY_SPECIES)
 
+from common.configure_logging import convenience_function_references_for_logger
+(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
+
 colonization_timer = AITimer('getColonyFleets()')
 
 

--- a/default/python/AI/CombatRatingsAI.py
+++ b/default/python/AI/CombatRatingsAI.py
@@ -8,6 +8,8 @@ from freeorion_tools import get_ai_tag_grade, dict_to_tuple, tuple_to_dict, cach
 from ShipDesignAI import get_part_type
 from AIDependencies import INVALID_ID
 
+from common.configure_logging import convenience_function_references_for_logger
+(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
 
 def get_empire_standard_fighter():
     """Get the current empire standard fighter stats, i.e. the most common shiptype within the empire.

--- a/default/python/AI/DiplomaticCorp.py
+++ b/default/python/AI/DiplomaticCorp.py
@@ -7,6 +7,9 @@ from character.character_module import Aggression
 from character.character_strings_module import possible_greetings
 from freeorion_tools import UserStringList, chat_on_error
 
+from common.configure_logging import convenience_function_references_for_logger
+(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
+
 
 def handle_pregame_chat(sender_player_id, message_txt):
     if fo.playerIsAI(sender_player_id):

--- a/default/python/AI/ExplorationAI.py
+++ b/default/python/AI/ExplorationAI.py
@@ -5,7 +5,7 @@ from EnumsAI import MissionType
 import universe_object
 import MoveUtilsAI
 import PlanetUtilsAI
-from freeorion_tools import dict_from_map, print_error
+from freeorion_tools import dict_from_map
 from AIDependencies import INVALID_ID
 
 from common.configure_logging import convenience_function_references_for_logger
@@ -58,7 +58,7 @@ def assign_scouts_to_explore_systems():
     if INVALID_ID in check_list:  # shouldn't normally happen, unless due to bug elsewhere
         for sys_list, name in [(foAI.foAIstate.needsEmergencyExploration, "foAI.foAIstate.needsEmergencyExploration"), (needs_vis, "needs_vis"), (explore_list, "explore_list")]:
             if INVALID_ID in sys_list:
-                print_error("INVALID_ID found in " + name)
+                error("INVALID_ID found in " + name, exc_info=True)
     needs_coverage = [sys_id for sys_id in check_list if sys_id not in already_covered and sys_id != INVALID_ID]  # emergency coverage can be due to invasion detection trouble, etc.
     print "Needs coverage: %s" % needs_coverage
 

--- a/default/python/AI/ExplorationAI.py
+++ b/default/python/AI/ExplorationAI.py
@@ -8,6 +8,9 @@ import PlanetUtilsAI
 from freeorion_tools import dict_from_map, print_error
 from AIDependencies import INVALID_ID
 
+from common.configure_logging import convenience_function_references_for_logger
+(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
+
 
 TARGET_POP = 'targetPop'
 TROOPS = 'troops'

--- a/default/python/AI/FleetUtilsAI.py
+++ b/default/python/AI/FleetUtilsAI.py
@@ -9,6 +9,8 @@ from universe_object import Planet
 from ShipDesignAI import get_part_type
 from AIDependencies import INVALID_ID
 import AIDependencies
+from common.configure_logging import convenience_function_references_for_logger
+(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
 __designStats = {}
 
 

--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -5,7 +5,6 @@ import sys
 import random
 
 from common import configure_logging
-configure_logging.redirect_logging_to_freeorion_logger(__name__)
 
 import logging
 logger = logging.getLogger(__name__)

--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -49,8 +49,8 @@ except ImportError:
 
 
 user_dir = fo.getUserDataDir()
-print "Path to folder for user specific data: %s" % user_dir
-print 'Python paths', sys.path
+logger.debug("Path to folder for user specific data: %s" % user_dir)
+logger.debug('Python paths %s' % sys.path)
 
 
 # Mock to have proper inspection and autocomplete for this variable
@@ -74,29 +74,29 @@ def startNewGame(aggression_input=fo.aggression.aggressive):  # pylint: disable=
         return
 
     if empire.eliminated:
-        print "This empire has been eliminated. Ignoring new game start message."
+        logger.info("This empire has been eliminated. Ignoring new game start message.")
         return
 
     turn_timer.start("Server Processing")
 
     # initialize AIstate
     global foAIstate
-    print "Initializing foAIstate..."
+    logger.debug("Initializing foAIstate...")
     foAIstate = AIstate.AIstate(aggression_input)
     aggression_trait = foAIstate.character.get_trait(Aggression)
-    print "New game started, AI Aggression level %d (%s)" % (
-        aggression_trait.key, get_trait_name_aggression(foAIstate.character))
+    logger.debug("New game started, AI Aggression level %d (%s)" % (
+        aggression_trait.key, get_trait_name_aggression(foAIstate.character)))
     foAIstate.session_start_cleanup()
-    print "Initialization of foAIstate complete!"
-    print "Trying to rename our homeworld..."
+    logger.debug("Initialization of foAIstate complete!")
+    logger.debug("Trying to rename our homeworld...")
     planet_id = PlanetUtilsAI.get_capital()
     universe = fo.getUniverse()
     if planet_id is not None and planet_id != INVALID_ID:
         planet = universe.getPlanet(planet_id)
         new_name = " ".join([random.choice(possible_capitals(foAIstate.character)).strip(), planet.name])
-        print "    Renaming to %s..." % new_name
+        logger.debug("    Renaming to %s..." % new_name)
         res = fo.issueRenameOrder(planet_id, new_name)
-        print "    Result: %d; Planet is now named %s" % (res, planet.name)
+        logger.debug("    Result: %d; Planet is now named %s" % (res, planet.name))
 
     diplomatic_corp_configs = {fo.aggression.beginner: DiplomaticCorp.BeginnerDiplomaticCorp,
                                fo.aggression.maniacal: DiplomaticCorp.ManiacalDiplomaticCorp}
@@ -120,7 +120,7 @@ def resumeLoadedGame(saved_state_string):  # pylint: disable=invalid-name
     global foAIstate
     print "Resuming loaded game"
     if not saved_state_string:
-        print_error("AI given empty state-string to resume from; this is expected if the AI is assigned to an empire "
+        logger.error("AI given empty state-string to resume from; this is expected if the AI is assigned to an empire "
                     "previously run by a human, but is otherwise an error. AI will be set to Aggressive.")
         foAIstate = AIstate.AIstate(fo.aggression.aggressive)
         foAIstate.session_start_cleanup()
@@ -133,7 +133,7 @@ def resumeLoadedGame(saved_state_string):  # pylint: disable=invalid-name
             # assigning new state
             foAIstate = AIstate.AIstate(fo.aggression.aggressive)
             foAIstate.session_start_cleanup()
-            print_error("Fail to load aiState from saved game: %s" % e)
+            logger.error("Fail to load aiState from saved game: %s", e)
 
     aggression_trait = foAIstate.character.get_trait(Aggression)
     diplomatic_corp_configs = {fo.aggression.beginner: DiplomaticCorp.BeginnerDiplomaticCorp,
@@ -154,10 +154,10 @@ def prepareForSave():  # pylint: disable=invalid-name
         return
 
     if empire.eliminated:
-        print "This empire has been eliminated. Save info request"
+        logger.info("This empire has been eliminated. Save info request")
         return
 
-    print "Preparing for game save by serializing state"
+    logger.info("Preparing for game save by serializing state")
 
     # serialize (convert to string) global state dictionary and send to AI client to be stored in save file
     try:
@@ -165,7 +165,7 @@ def prepareForSave():  # pylint: disable=invalid-name
         print "foAIstate pickled to string, about to send to server"
         fo.setSaveStateString(dump_string)
     except:
-        print_error("foAIstate unable to pickle save-state string; the save file should be playable but the AI may have a different aggression.", trace=True)
+        logger.error("foAIstate unable to pickle save-state string; the save file should be playable but the AI may have a different aggression.", exc_info=True)
 
 
 @chat_on_error
@@ -178,10 +178,10 @@ def handleChatMessage(sender_id, message_text):  # pylint: disable=invalid-name
         return
 
     if empire.eliminated:
-        print "This empire has been eliminated. Ignoring chat message"
+        logger.debug("This empire has been eliminated. Ignoring chat message")
         return
 
-    # print "Received chat message from " + str(senderID) + " that says: " + messageText + " - ignoring it"
+    # logger.debug("Received chat message from " + str(senderID) + " that says: " + messageText + " - ignoring it")
     # perhaps it is a debugging interaction
     if handle_debug_chat(sender_id, message_text):
         return
@@ -201,7 +201,7 @@ def handleDiplomaticMessage(message):  # pylint: disable=invalid-name
         return
 
     if empire.eliminated:
-        print "This empire has been eliminated. Ignoring diplomatic message"
+        logger.debug("This empire has been eliminated. Ignoring diplomatic message")
         return
 
     diplomatic_corp.handle_diplomatic_message(message)
@@ -217,7 +217,7 @@ def handleDiplomaticStatusUpdate(status_update):  # pylint: disable=invalid-name
         return
 
     if empire.eliminated:
-        print "This empire has been eliminated. Ignoring diplomatic status update"
+        logger.debug("This empire has been eliminated. Ignoring diplomatic status update")
         return
 
     diplomatic_corp.handle_diplomatic_status_update(status_update)
@@ -252,7 +252,7 @@ def generateOrders():  # pylint: disable=invalid-name
         return
 
     if empire.eliminated:
-        print "This empire has been eliminated. Aborting order generation"
+        logger.debug("This empire has been eliminated. Aborting order generation")
         try:
             # early abort if already eliminated. no need to do meter calculations
             # on last-seen gamestate if nothing can be ordered anyway...
@@ -262,16 +262,16 @@ def generateOrders():  # pylint: disable=invalid-name
         return
 
     # This code block is required for correct AI work.
-    print "Meter / Resource Pool updating..."
+    logger.info("Meter / Resource Pool updating...")
     fo.initMeterEstimatesDiscrepancies()
     fo.updateMeterEstimates(False)
     fo.updateResourcePools()
 
     turn = fo.currentTurn()
     turn_uid = foAIstate.set_turn_uid()
-    print "\n\n\n", "=" * 20,
-    print "Starting turn %s (%s) of game: %s" % (turn, turn_uid, foAIstate.uid),
-    print "=" * 20, "\n"
+    logger.debug("\n\n\n" + "=" * 20)
+    logger.debug("Starting turn %s (%s) of game: %s" % (turn, turn_uid, foAIstate.uid))
+    logger.debug("=" * 20 + "\n")
 
     turn_timer.start("AI planning")
     # set the random seed (based on galaxy seed, empire name and current turn)
@@ -313,7 +313,7 @@ def generateOrders():  # pylint: disable=invalid-name
 
     foAIstate.refresh()  # checks exploration border & clears roles/missions of missing fleets & updates fleet locs & threats
     foAIstate.report_system_threats()
-    print("Calling AI Modules")
+    logger.debug("Calling AI Modules")
     # call AI modules
     action_list = [ColonisationAI.survey_universe,
                    ProductionAI.find_best_designs_this_turn,

--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -4,8 +4,11 @@ import pickle  # Python object serialization library
 import sys
 import random
 
-from common.configure_logging import redirect_logging_to_freeorion_logger
-redirect_logging_to_freeorion_logger()
+from common import configure_logging
+configure_logging.redirect_logging_to_freeorion_logger(__name__)
+
+import logging
+logger = logging.getLogger(__name__)
 
 import freeOrionAIInterface as fo  # interface used to interact with FreeOrion AI client  # pylint: disable=import-error
 

--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -9,8 +9,7 @@ from common.configure_logging import redirect_logging_to_freeorion_logger, conve
 
 import freeOrionAIInterface as fo  # interface used to interact with FreeOrion AI client  # pylint: disable=import-error
 
-log_level = logging.DEBUG if fo.getOptionsDBOptionBool("verbose-logging") else logging.INFO
-redirect_logging_to_freeorion_logger(log_level)
+redirect_logging_to_freeorion_logger()
 (debug, info, warn, error, fatal) = convenience_function_references_for_logger()
 
 from common.option_tools import parse_config

--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -5,7 +5,7 @@ import sys
 import random
 
 from common.configure_logging import convenience_function_references_for_logger
-(debug, info, warning, error, fatal) = convenience_function_references_for_logger()
+(debug, info, warn, error, fatal) = convenience_function_references_for_logger()
 import logging
 logger = logging.getLogger(__name__)
 

--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -3,13 +3,15 @@ these methods in turn activate other portions of the python AI code."""
 import pickle  # Python object serialization library
 import sys
 import random
-
-from common.configure_logging import convenience_function_references_for_logger
-(debug, info, warn, error, fatal) = convenience_function_references_for_logger()
 import logging
-logger = logging.getLogger(__name__)
+
+from common.configure_logging import redirect_logging_to_freeorion_logger, convenience_function_references_for_logger
 
 import freeOrionAIInterface as fo  # interface used to interact with FreeOrion AI client  # pylint: disable=import-error
+
+log_level = logging.DEBUG if fo.getOptionsDBOptionBool("verbose-logging") else logging.INFO
+redirect_logging_to_freeorion_logger(log_level)
+(debug, info, warn, error, fatal) = convenience_function_references_for_logger()
 
 from common.option_tools import parse_config
 parse_config(fo.getOptionsDBOptionStr("ai-config"), fo.getUserConfigDir())

--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -31,7 +31,7 @@ import ResearchAI
 import ResourcesAI
 import TechsListsAI
 from AIDependencies import INVALID_ID
-from freeorion_tools import chat_on_error, print_error, handle_debug_chat, AITimer, init_handlers
+from freeorion_tools import chat_on_error, handle_debug_chat, AITimer, init_handlers
 from common.listeners import listener
 from character.character_module import Aggression
 from character.character_strings_module import get_trait_name_aggression, possible_capitals
@@ -248,7 +248,7 @@ def generateOrders():  # pylint: disable=invalid-name
             # not invalidate doneTurn()
             fo.doneTurn()
         except Exception as e:
-            print_error(e)
+            error(e, exc_info=True)
         return
 
     if empire.eliminated:
@@ -258,7 +258,7 @@ def generateOrders():  # pylint: disable=invalid-name
             # on last-seen gamestate if nothing can be ordered anyway...
             fo.doneTurn()
         except Exception as e:
-            print_error(e)
+            error(e, exc_info=True)
         return
 
     # This code block is required for correct AI work.
@@ -335,7 +335,7 @@ def generateOrders():  # pylint: disable=invalid-name
             action()
             main_timer.stop()
         except Exception as e:
-            print_error(e, location=action.__name__)
+            error(e, exc_info=True)
     main_timer.stop_print_and_clear()
     turn_timer.stop_print_and_clear()
     turn_timer.start("Server_Processing")
@@ -343,7 +343,7 @@ def generateOrders():  # pylint: disable=invalid-name
     try:
         fo.doneTurn()
     except Exception as e:
-        print_error(e)  # TODO move it to cycle above
+        error(e, exc_info=True)  # TODO move it to cycle above
 
     if using_statprof:
         try:

--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -19,6 +19,9 @@ import CombatRatingsAI
 from freeorion_tools import tech_is_complete, AITimer
 from AIDependencies import INVALID_ID
 
+from common.configure_logging import convenience_function_references_for_logger
+(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
+
 MAX_BASE_TROOPERS_GOOD_INVADERS = 20
 MAX_BASE_TROOPERS_POOR_INVADERS = 10
 _TROOPS_SAFETY_MARGIN = 1  # try to send this amount of additional troops to account for uncertainties in calculation

--- a/default/python/AI/MilitaryAI.py
+++ b/default/python/AI/MilitaryAI.py
@@ -12,6 +12,8 @@ import ProductionAI
 import CombatRatingsAI
 from freeorion_tools import ppstring, cache_by_turn
 from AIDependencies import INVALID_ID
+from common.configure_logging import convenience_function_references_for_logger
+(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
 
 MinThreat = 10  # the minimum threat level that will be ascribed to an unknown threat capable of killing scouts
 _military_allocations = []

--- a/default/python/AI/MoveUtilsAI.py
+++ b/default/python/AI/MoveUtilsAI.py
@@ -11,6 +11,8 @@ import PlanetUtilsAI
 from freeorion_tools import ppstring
 from AIDependencies import INVALID_ID, DRYDOCK_HAPPINESS_THRESHOLD
 
+from common.configure_logging import convenience_function_references_for_logger
+(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
 
 def create_move_orders_to_system(fleet, target):
     """

--- a/default/python/AI/PlanetUtilsAI.py
+++ b/default/python/AI/PlanetUtilsAI.py
@@ -6,6 +6,10 @@ from freeorion_tools import print_error
 from AIDependencies import INVALID_ID
 
 
+from common.configure_logging import convenience_function_references_for_logger
+(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
+
+
 def safe_name(univ_object):
     return (univ_object and univ_object.name) or "?"
 

--- a/default/python/AI/PlanetUtilsAI.py
+++ b/default/python/AI/PlanetUtilsAI.py
@@ -2,7 +2,6 @@ import sys
 
 import freeOrionAIInterface as fo  # pylint: disable=import-error
 import ColonisationAI
-from freeorion_tools import print_error
 from AIDependencies import INVALID_ID
 
 
@@ -72,7 +71,7 @@ def get_capital():
             if population_id_pairs:
                 return max(population_id_pairs)[-1]
     except Exception as e:
-        print_error(e)
+        error(e, exc_info=True)
     return INVALID_ID  # shouldn't ever reach here
 
 

--- a/default/python/AI/PriorityAI.py
+++ b/default/python/AI/PriorityAI.py
@@ -16,6 +16,8 @@ from turn_state import state
 from EnumsAI import PriorityType, MissionType, EmpireProductionTypes, get_priority_production_types, ShipRoleType
 from freeorion_tools import AITimer, tech_is_complete
 from AIDependencies import INVALID_ID
+from common.configure_logging import convenience_function_references_for_logger
+(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
 
 prioritiees_timer = AITimer('calculate_priorities()')
 

--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -23,6 +23,9 @@ from freeorion_tools import dict_from_map, ppstring, chat_human, tech_is_complet
 from common.print_utils import Table, Sequence, Text
 from AIDependencies import INVALID_ID
 
+from common.configure_logging import convenience_function_references_for_logger
+(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
+
 _best_military_design_rating_cache = {}  # indexed by turn, values are rating of the military design of the turn
 _design_cost_cache = {0: {(-1, -1): 0}}  # outer dict indexed by cur_turn (currently only one turn kept); inner dict indexed by (design_id, pid)
 

--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -19,7 +19,7 @@ from turn_state import state
 
 from EnumsAI import (PriorityType, EmpireProductionTypes, MissionType, get_priority_production_types,
                      FocusType, ShipRoleType)
-from freeorion_tools import dict_from_map, ppstring, chat_human, tech_is_complete, print_error, AITimer
+from freeorion_tools import dict_from_map, ppstring, chat_human, tech_is_complete, AITimer
 from common.print_utils import Table, Sequence, Text
 from AIDependencies import INVALID_ID
 
@@ -870,7 +870,7 @@ def generate_production_orders():
                     try:
                         distance_map[sys_id] = universe.jumpDistance(homeworld.systemID, sys_id)
                     except Exception as e:
-                        print_error(e, location="ProductionAI.generateProductionOrders")
+                        error(e, exc_info=True)
                 print ([INVALID_ID] + sorted([(dist, sys_id) for sys_id, dist in distance_map.items()]))
                 use_sys = ([(-1, INVALID_ID)] + sorted([(dist, sys_id) for sys_id, dist in distance_map.items()]))[:2][-1][-1]  # kinda messy, but ensures a value
             if use_sys != INVALID_ID:

--- a/default/python/AI/ResearchAI.py
+++ b/default/python/AI/ResearchAI.py
@@ -16,6 +16,9 @@ from turn_state import state
 from freeorion_tools import tech_is_complete, get_ai_tag_grade, chat_human
 from common.print_utils import print_in_columns
 
+from common.configure_logging import convenience_function_references_for_logger
+(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
+
 inProgressTechs = {}
 
 

--- a/default/python/AI/ResourcesAI.py
+++ b/default/python/AI/ResourcesAI.py
@@ -21,6 +21,8 @@ import AIDependencies
 import CombatRatingsAI
 from common.print_utils import Table, Text, Float
 from freeorion_tools import tech_is_complete, AITimer
+from common.configure_logging import convenience_function_references_for_logger
+(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
 
 resource_timer = AITimer('timer_bucket')
 

--- a/default/python/AI/ShipDesignAI.py
+++ b/default/python/AI/ShipDesignAI.py
@@ -57,6 +57,9 @@ import FleetUtilsAI
 from AIDependencies import INVALID_ID
 from freeorion_tools import print_error, UserString, tech_is_complete
 
+from common.configure_logging import convenience_function_references_for_logger
+(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
+
 # Define meta classes for the ship parts  TODO storing as set may not be needed anymore
 ARMOUR = frozenset({fo.shipPartClass.armour})
 SHIELDS = frozenset({fo.shipPartClass.shields})

--- a/default/python/AI/ShipDesignAI.py
+++ b/default/python/AI/ShipDesignAI.py
@@ -55,7 +55,7 @@ import AIstate
 import CombatRatingsAI
 import FleetUtilsAI
 from AIDependencies import INVALID_ID
-from freeorion_tools import print_error, UserString, tech_is_complete
+from freeorion_tools import UserString, tech_is_complete
 
 from common.configure_logging import convenience_function_references_for_logger
 (debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
@@ -360,7 +360,7 @@ class ShipDesignCache(object):
                     print "    Expected: %s, got: %s. Cache was repaired." % (partname, cached_name)
         except Exception as e:
             self.part_by_partname.clear()
-            print_error(e)
+            error(e, exc_info=True)
 
         corrupted = []
         # create a copy of the dict-keys so we can alter the dict
@@ -793,6 +793,7 @@ class ShipDesigner(object):
 
         :returns: float - rating
         """
+        error("WARNING: Rating function not overloaded for class %s!" % self.__class__.__name__)
         raise NotImplementedError
 
     def _set_stats_to_default(self):
@@ -1192,8 +1193,8 @@ class ShipDesigner(object):
                     best_design_list.append((best_rating_for_planet, pid, design_id,
                                              self.production_cost, copy.deepcopy(self.design_stats)))
                 else:
-                    print_error("The best design for %s on planet %d could not be added."
-                                % (self.__class__.__name__, pid))
+                    error("The best design for %s on planet %d could not be added."
+                          % (self.__class__.__name__, pid))
             elif verbose:
                 print "Could not find a suitable design of type %s for planet %s." % (self.__class__.__name__, planet)
         sorted_design_list = sorted(best_design_list, key=lambda x: x[0], reverse=True)
@@ -2337,10 +2338,9 @@ def _get_tech_bonus(upgrade_dict, part_name):
     except KeyError:
         if part_name not in _raised_warnings:
             _raised_warnings.add(part_name)
-            print_error(("WARNING: Encountered unknown part (%s): "
-                         "The AI can play on but its damage estimates may be incorrect leading to worse decision-making. "
-                         "Please update AIDependencies.py") % part_name,
-                        location="ShipDesignAI._get_tech_bonus()", trace=True)
+            error(("WARNING: Encountered unknown part (%s): "
+                   "The AI can play on but its damage estimates may be incorrect leading to worse decision-making. "
+                   "Please update AIDependencies.py") % part_name, exc_info=True)
         return 0
     total_tech_bonus = 0
     for tech, bonus in upgrades:

--- a/default/python/AI/TechsListsAI.py
+++ b/default/python/AI/TechsListsAI.py
@@ -5,7 +5,6 @@ researched next.
 """
 import sys
 
-from freeorion_tools import print_error
 import freeOrionAIInterface as fo  # pylint: disable=import-error
 
 from common.configure_logging import convenience_function_references_for_logger
@@ -649,10 +648,10 @@ def test_tech_integrity():
         techs = this_group.get_techs()
         for tech in techs:
             if not fo.getTech(tech):
-                print_error("In %s: Tech %s seems not to exist!" % (group.__name__, tech))
+                error("In %s: Tech %s seems not to exist!" % (group.__name__, tech))
                 error_occured = True
         for err in this_group.get_errors():
-            print_error(err, location=group.__name__)
+            error(e, exc_info=True)
             error_occured = True
         if not error_occured:
             print "Seems to be OK!"

--- a/default/python/AI/TechsListsAI.py
+++ b/default/python/AI/TechsListsAI.py
@@ -8,6 +8,9 @@ import sys
 from freeorion_tools import print_error
 import freeOrionAIInterface as fo  # pylint: disable=import-error
 
+from common.configure_logging import convenience_function_references_for_logger
+(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
+
 EXOBOT_TECH_NAME = "PRO_EXOBOTS"
 
 

--- a/default/python/AI/character/character_module.py
+++ b/default/python/AI/character/character_module.py
@@ -91,6 +91,8 @@ import math
 import random
 
 import freeOrionAIInterface as fo  # pylint: disable=import-error
+from common.configure_logging import convenience_function_references_for_logger
+(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
 
 
 class Trait(object):

--- a/default/python/AI/character/character_strings_module.py
+++ b/default/python/AI/character/character_strings_module.py
@@ -24,6 +24,8 @@ possible_capitals(Character([Aggression(0)])) returns ['Royal', 'Imperial'].
 
 import character as character_package
 import freeOrionAIInterface as fo  # pylint: disable=import-error
+from common.configure_logging import convenience_function_references_for_logger
+(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
 
 
 class _CharacterTableFunction(object):

--- a/default/python/AI/fleet_orders.py
+++ b/default/python/AI/fleet_orders.py
@@ -12,6 +12,10 @@ import CombatRatingsAI
 from freeorion_tools import print_error
 from universe_object import Fleet, System, Planet
 from AIDependencies import INVALID_ID
+
+from common.configure_logging import convenience_function_references_for_logger
+(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
+
 dumpTurn = 0
 
 

--- a/default/python/AI/fleet_orders.py
+++ b/default/python/AI/fleet_orders.py
@@ -9,7 +9,6 @@ import MilitaryAI
 import MoveUtilsAI
 import PlanetUtilsAI
 import CombatRatingsAI
-from freeorion_tools import print_error
 from universe_object import Fleet, System, Planet
 from AIDependencies import INVALID_ID
 
@@ -82,10 +81,10 @@ class AIFleetOrder(object):
         :type target: universe_object.UniverseObject
         """
         if not isinstance(fleet, Fleet):
-            print_error("Order required fleet got %s" % type(fleet))
+            error("Order required fleet got %s" % type(fleet))
 
         if not isinstance(target, self.TARGET_TYPE):
-            print_error("Target is not allowed, got %s expect %s" % (type(target), self.TARGET_TYPE))
+            error("Target is not allowed, got %s expect %s" % (type(target), self.TARGET_TYPE))
 
         self.fleet = fleet
         self.target = target

--- a/default/python/AI/turn_state.py
+++ b/default/python/AI/turn_state.py
@@ -1,6 +1,8 @@
 from collections import namedtuple
 
 import freeOrionAIInterface as fo
+from common.configure_logging import convenience_function_references_for_logger
+(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
 
 PlanetInfo = namedtuple('PlanetInfo', ['pid', 'species_name', 'owner', 'system_id'])
 

--- a/default/python/AI/universe_object.py
+++ b/default/python/AI/universe_object.py
@@ -3,6 +3,8 @@ import sys
 import freeOrionAIInterface as fo  # pylint: disable=import-error
 from AIDependencies import INVALID_ID
 
+from common.configure_logging import convenience_function_references_for_logger
+(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
 
 class UniverseObject(object):
     """

--- a/default/python/common/configure_logging.py
+++ b/default/python/common/configure_logging.py
@@ -1,5 +1,4 @@
-"""
-configure_logging redirects print and the logger to use the freeorion server.
+"""configure_logging redirects print and the logger to use the freeorion server.
 
 Output redirected to the freeorion server prints in the appropriate log:
 freeorion.log freeoriond.log or AI_<N>.log.
@@ -71,7 +70,13 @@ INFO    - used to report game state and progress.
 DEBUG   - used for low-level implementation or calculation details.
           For example the calculations when rating a fleet.
 
-For more information see https://docs.python.org/2/howto/logging.html
+For more information about the python standard library logger see
+https://docs.python.org/2/howto/logging.html
+
+The function convenience_function_references_for_logger(name) returns the
+specific logging functions from the logger ''name'' which can be bound to
+convenient local functions, to avoid calling name.error() to produce an error
+log.
 
 """
 import sys
@@ -145,10 +150,10 @@ def _create_narrow_handler(level):
     return h
 
 
-def _redirect_logging_to_freeorion_logger():
+def redirect_logging_to_freeorion_logger():
     """Redirect stdout, stderr and the logging.logger to hosting process' freeorion_logger."""
 
-    if not hasattr(_redirect_logging_to_freeorion_logger, "only_redirect_once"):
+    if not hasattr(redirect_logging_to_freeorion_logger, "only_redirect_once"):
         sys.stdout = _stdoutLikeStream()
         sys.stderr = _stderrLikeStream()
         print 'Python stdout and stderr are redirected to ai process.'
@@ -164,6 +169,12 @@ def _redirect_logging_to_freeorion_logger():
         logger.setLevel(logging.DEBUG)
         logger.info("Root logger is redirected to ai process.")
 
-        _redirect_logging_to_freeorion_logger.only_redirect_once = True
+        redirect_logging_to_freeorion_logger.only_redirect_once = True
 
-_redirect_logging_to_freeorion_logger()
+redirect_logging_to_freeorion_logger()
+
+
+def convenience_function_references_for_logger(name=""):
+    """Return a tuple (debug, info, warning, error, fatal) of the ''name'' logger's convenience functions."""
+    logger = logging.getLogger(name)
+    return (logger.debug, logger.info, logger.warning, logger.error, logger.critical)

--- a/default/python/common/configure_logging.py
+++ b/default/python/common/configure_logging.py
@@ -47,21 +47,21 @@ import freeorion_logger  # pylint: disable=import-error
 
 
 class _stdoutLikeStream(object):
-    """A stream-like object to redirect stdout to C++ process"""
+    """A stream-like object to redirect stdout to C++ process."""
     @staticmethod
     def write(msg):
         freeorion_logger.debug(msg)
 
 
 class _stderrLikeStream(object):
-    """A stream-like object to redirect stdout to C++ process"""
+    """A stream-like object to redirect stdout to C++ process."""
     @staticmethod
     def write(msg):
         freeorion_logger.error(msg)
 
 
 class _streamlikeLogger(object):
-    """A stream-like object to redirect stdout to C++ process for logger"""
+    """A stream-like object to redirect stdout to C++ process for logger."""
     def __init__(self, level):
         self.logger = {
             logging.DEBUG: freeorion_logger.debug,
@@ -77,7 +77,7 @@ class _streamlikeLogger(object):
 
 
 class _SingleLevelFilter(logging.Filter):
-    """This filter selects for only one log level"""
+    """This filter selects for only one log level."""
     def __init__(self, _level):
         super(_SingleLevelFilter, self).__init__()
         self.level = _level
@@ -91,7 +91,7 @@ _error_formatter = logging.Formatter('Module %(module)s, File %(filename)s,  Fun
 
 def _create_narrow_handler(level):
     """Create a handler for logger that forwards a single level of log
-    to the appropriate stream in the C++ app"""
+    to the appropriate stream in the C++ app."""
     h = logging.StreamHandler(_streamlikeLogger(level))
     h.addFilter(_SingleLevelFilter(level))
     h.setLevel(level)
@@ -101,7 +101,7 @@ def _create_narrow_handler(level):
 
 
 def _redirect_logging_to_freeorion_logger():
-    """Redirect stdout, stderr and the logging.logger to hosting process' freeorion_logger"""
+    """Redirect stdout, stderr and the logging.logger to hosting process' freeorion_logger."""
 
     if not hasattr(_redirect_logging_to_freeorion_logger, "only_redirect_once"):
         sys.stdout = _stdoutLikeStream()

--- a/default/python/common/configure_logging.py
+++ b/default/python/common/configure_logging.py
@@ -1,3 +1,46 @@
+"""
+configure_logging redirects print and the logger to use the freeorion server.
+
+Output redirected to the freeorion server prints in the appropriate log:
+freeorion.log freeoriond.log or AI_<N>.log.
+
+logging messages of levels warning and above are decorated with module name, file name, function name and line number.
+
+Usage:
+
+import logging
+import utils.configure_logging
+< Use python logging or print and have it re-directed >
+
+Notes on using the standard python logger:
+The python standard library is composed of two basic parts: loggers and handlers.
+Loggers generate the log and associate a whole bunch of level, timing, file, function and
+other information with the log.  Handlers do somthing like stream to file, console or email.
+
+* The simplest is to use the root logger.
+logging.debug(msg)
+logging.info(msg)
+logging.warn(msg)
+logging.error(msg)
+logging.fatal(msg)
+
+* Loggers can have arbitrary hierarchical names,
+  created globally when you call getLogger() from anywhere.
+logging.getLogger("toplevel.2ndlevel")
+
+* Loggers can be filtered by log level.  For example turn off logging below warning level.
+  This is hierarchical.  The following turns off logging below warning level
+  for name.subname and also name.subname.subsubname.
+logging.getLogger(name.subname).setLevel(logging.WARN)
+
+* Logger formats string using the old format style.
+  It only formats the string if that level of debugging is enabled.
+logging("A formatted %s contained the number nine %d", "string", 9)
+
+
+For more information see https://docs.python.org/2/howto/logging.html
+
+"""
 import sys
 import logging
 import freeorion_logger  # pylint: disable=import-error

--- a/default/python/common/configure_logging.py
+++ b/default/python/common/configure_logging.py
@@ -175,6 +175,6 @@ redirect_logging_to_freeorion_logger()
 
 
 def convenience_function_references_for_logger(name=""):
-    """Return a tuple (debug, info, warning, error, fatal) of the ''name'' logger's convenience functions."""
+    """Return a tuple (debug, info, warn, error, fatal) of the ''name'' logger's convenience functions."""
     logger = logging.getLogger(name)
     return (logger.debug, logger.info, logger.warning, logger.error, logger.critical)

--- a/default/python/common/configure_logging.py
+++ b/default/python/common/configure_logging.py
@@ -81,7 +81,35 @@ log.
 """
 import sys
 import logging
-import freeorion_logger  # FreeOrion logger interface pylint: disable=import-error
+
+try:
+    import freeorion_logger  # FreeOrion logger interface pylint: disable=import-error
+except ImportError as e:
+
+    # Create an alternative logger for use in testing when the server is unavailable
+    class _FreeOrionLoggerForTest(object):
+        """A stub freeorion_logger for testing"""
+        @staticmethod
+        def debug(msg):
+            print msg
+
+        @staticmethod
+        def info(msg):
+            print msg
+
+        @staticmethod
+        def warn(msg):
+            print msg
+
+        @staticmethod
+        def error(msg):
+            print >> sys.stderr, msg
+
+        @staticmethod
+        def fatal(msg):
+            print >> sys.stderr, msg
+
+    freeorion_logger = _FreeOrionLoggerForTest()
 
 
 class _stdoutLikeStream(object):

--- a/default/python/common/configure_logging.py
+++ b/default/python/common/configure_logging.py
@@ -43,12 +43,17 @@ class _SingleLevelFilter(logging.Filter):
         return record.levelno == self.level
 
 
+_error_formatter = logging.Formatter('Module %(module)s, File %(filename)s,  Function %(funcName)s():%(lineno)d  - %(message)s')
+
+
 def _create_narrow_handler(level):
     """Create a handler for logger that forwards a single level of log
     to the appropriate stream in the C++ app"""
     h = logging.StreamHandler(_streamlikeLogger(level))
     h.addFilter(_SingleLevelFilter(level))
     h.setLevel(level)
+    if level > logging.INFO:
+        h.setFormatter(_error_formatter)
     return h
 
 

--- a/default/python/common/configure_logging.py
+++ b/default/python/common/configure_logging.py
@@ -161,9 +161,9 @@ class _Formatter(logging.Formatter):
     def format(self, record):
         """Select the correct log format and call logging.Formatter.format()"""
         if record.name == 'root':
-            self._fmt = '%(filename)s:%(funcName)s():%(lineno)d  - %(message)s'
+            self._fmt = 'python : %(filename)s:%(funcName)s():%(lineno)d  - %(message)s'
         else:
-            self._fmt = '%(name)s %(filename)s:%(funcName)s():%(lineno)d  - %(message)s'
+            self._fmt = '%(name)s : %(filename)s:%(funcName)s():%(lineno)d  - %(message)s'
 
         return super(_Formatter, self).format(record)
 

--- a/default/python/common/configure_logging.py
+++ b/default/python/common/configure_logging.py
@@ -81,7 +81,7 @@ log.
 """
 import sys
 import logging
-import freeorion_logger  # pylint: disable=import-error
+import freeorion_logger  # FreeOrion logger interface pylint: disable=import-error
 
 
 class _stdoutLikeStream(object):
@@ -150,7 +150,7 @@ def _create_narrow_handler(level):
     return h
 
 
-def redirect_logging_to_freeorion_logger():
+def redirect_logging_to_freeorion_logger(initial_log_level=logging.DEBUG):
     """Redirect stdout, stderr and the logging.logger to hosting process' freeorion_logger."""
 
     if not hasattr(redirect_logging_to_freeorion_logger, "only_redirect_once"):
@@ -166,12 +166,11 @@ def redirect_logging_to_freeorion_logger():
         logger.addHandler(_create_narrow_handler(logging.FATAL))
         logger.addHandler(_create_narrow_handler(logging.NOTSET))
 
-        logger.setLevel(logging.DEBUG)
-        logger.info("Root logger is redirected to ai process.")
+        logger.setLevel(initial_log_level)
+        logger.info("The python logger is initialized with a log level of %s",
+                    logging.getLevelName(logger.getEffectiveLevel()))
 
         redirect_logging_to_freeorion_logger.only_redirect_once = True
-
-redirect_logging_to_freeorion_logger()
 
 
 def convenience_function_references_for_logger(name=""):

--- a/default/python/common/configure_logging.py
+++ b/default/python/common/configure_logging.py
@@ -1,12 +1,13 @@
 import sys
-import freeorion_logger
+import logging
+import freeorion_logger  # pylint: disable=import-error
 
 
 class DbgLogger(object):
     """A stream-like object to redirect stdout to C++ process."""
     @staticmethod
     def write(msg):
-        freeorion_logger.log(msg)
+        freeorion_logger.debug(msg)
 
 
 class ErrLogger(object):
@@ -16,10 +17,55 @@ class ErrLogger(object):
         freeorion_logger.error(msg)
 
 
-def redirect_logging_to_freeorion_logger():
-    """Redirect stdout, stderr and the logging.logger to hosting process' freeorion_logger."""
+class StreamlikeLogger(object):
+    """A stream-like object to redirect stdout to C++ process for logger"""
+    def __init__(self, level):
+        self.logger = {
+            logging.DEBUG: freeorion_logger.debug,
+            logging.INFO: freeorion_logger.info,
+            logging.WARNING: freeorion_logger.warn,
+            logging.ERROR: freeorion_logger.error,
+            logging.CRITICAL: freeorion_logger.fatal,
+            logging.NOTSET: freeorion_logger.debug
+        }[level]
+
+    def write(self, msg):
+        self.logger(msg)
+
+
+class SingleLevelFilter(logging.Filter):
+    """This filter selects for only one log level"""
+    def __init__(self, _level):
+        super(SingleLevelFilter, self).__init__()
+        self.level = _level
+
+    def filter(self, record):
+        return record.levelno == self.level
+
+
+def create_narrow_handler(level):
+    """Create a handler for logger that forwards a single level of log
+    to the appropriate stream in the C++ app"""
+    h = logging.StreamHandler(StreamlikeLogger(level))
+    h.addFilter(SingleLevelFilter(level))
+    h.setLevel(level)
+    return h
+
+
+def redirect_logging_to_freeorion_logger(name):
+    """Redirect stdout, stderr and the logging.logger to hosting process' freeorion_logger"""
+
     sys.stdout = DbgLogger()
     sys.stderr = ErrLogger()
     print 'Python stdout and stderr redirected'
 
+    logger = logging.getLogger(name)
+    logger.addHandler(create_narrow_handler(logging.DEBUG))
+    logger.addHandler(create_narrow_handler(logging.INFO))
+    logger.addHandler(create_narrow_handler(logging.WARNING))
+    logger.addHandler(create_narrow_handler(logging.ERROR))
+    logger.addHandler(create_narrow_handler(logging.CRITICAL))
+    logger.addHandler(create_narrow_handler(logging.NOTSET))
 
+    logger.setLevel(logging.DEBUG)
+    logger.info("logger('{}') is redirected to ai process.".format(name))

--- a/default/python/universe_generation/universe_generator.py
+++ b/default/python/universe_generation/universe_generator.py
@@ -1,7 +1,7 @@
 import random
 
-from common.configure_logging import redirect_logging_to_freeorion_logger
-redirect_logging_to_freeorion_logger()
+from common import configure_logging
+configure_logging.redirect_logging_to_freeorion_logger(__name__)
 
 import freeorion as fo
 

--- a/default/python/universe_generation/universe_generator.py
+++ b/default/python/universe_generation/universe_generator.py
@@ -16,7 +16,7 @@ from util import int_hash, seed_rng, report_error, error_list
 from universe_tables import MAX_JUMPS_BETWEEN_SYSTEMS, MAX_STARLANE_LENGTH
 import universe_statistics
 
-(debug, info, warning, error, fatal) = convenience_function_references_for_logger()
+(debug, info, warn, error, fatal) = convenience_function_references_for_logger()
 
 
 class PyGalaxySetupData:

--- a/default/python/universe_generation/universe_generator.py
+++ b/default/python/universe_generation/universe_generator.py
@@ -1,7 +1,6 @@
 import random
 
 from common import configure_logging
-configure_logging.redirect_logging_to_freeorion_logger(__name__)
 
 import freeorion as fo
 

--- a/default/python/universe_generation/universe_generator.py
+++ b/default/python/universe_generation/universe_generator.py
@@ -1,6 +1,6 @@
 import random
 
-from common.configure_logging import convenience_function_references_for_logger
+from common.configure_logging import redirect_logging_to_freeorion_logger, convenience_function_references_for_logger
 
 import freeorion as fo
 
@@ -16,6 +16,7 @@ from util import int_hash, seed_rng, report_error, error_list
 from universe_tables import MAX_JUMPS_BETWEEN_SYSTEMS, MAX_STARLANE_LENGTH
 import universe_statistics
 
+redirect_logging_to_freeorion_logger()
 (debug, info, warn, error, fatal) = convenience_function_references_for_logger()
 
 

--- a/default/python/universe_generation/universe_generator.py
+++ b/default/python/universe_generation/universe_generator.py
@@ -1,6 +1,6 @@
 import random
 
-from common import configure_logging
+from common.configure_logging import convenience_function_references_for_logger
 
 import freeorion as fo
 
@@ -15,6 +15,8 @@ from specials import distribute_specials
 from util import int_hash, seed_rng, report_error, error_list
 from universe_tables import MAX_JUMPS_BETWEEN_SYSTEMS, MAX_STARLANE_LENGTH
 import universe_statistics
+
+(debug, info, warning, error, fatal) = convenience_function_references_for_logger()
 
 
 class PyGalaxySetupData:

--- a/python/LoggingWrapper.cpp
+++ b/python/LoggingWrapper.cpp
@@ -45,7 +45,8 @@ namespace {
 
     // info logger
     void PythonLoggerCoreInfo(const std::string &s) {
-        InfoLogger() << s;
+        // The extra space aligns info messages with debug messages.
+            InfoLogger() << " " << s;
     }
     void PythonLoggerInfo(const std::string & text) {
         static std::stringstream log_stream("");

--- a/python/LoggingWrapper.cpp
+++ b/python/LoggingWrapper.cpp
@@ -9,49 +9,84 @@ namespace {
     // Expose interface for redirecting standard output and error to FreeOrion
     // logging.  Can be imported before loading the main FreeOrion AI interface
     // library.
-    static const int MAX_SINGLE_CHUNK_TEXT_SIZE = 4096;
+    static const std::size_t MAX_SINGLE_CHUNK_TEXT_SIZE = 4096;
 
-    // stdout logger
-    static std::string log_buffer("");
-    void LogText(const char* text) {
-        // Python sends text as several null-terminated array of char which need to be
-        // concatenated before they are output to the logger.  There's probably a better
-        // way to do this, but I don't know what it is, and this seems reasonably safe...
-        if (!text) return;
-        for (int i = 0; i < MAX_SINGLE_CHUNK_TEXT_SIZE; ++i) {
-            if (text[i] == '\0') break;
-            if (text[i] == '\n' || i == MAX_SINGLE_CHUNK_TEXT_SIZE - 1) {
-                DebugLogger() << log_buffer;
-                log_buffer = "";
-            } else {
-                log_buffer += text[i];
-            }
+    // Python sends text as several null-terminated array of char which need to be
+    // concatenated before they are output to the logger.  There's probably a better
+    // way to do this, but I don't know what it is, and this seems reasonably safe...
+    void send_to_log(std::stringstream & ss, const std::string & input, void  (*logger) (const std::string &)) {
+        if (input.empty()) return;
+        ss <<  ((input.size() < MAX_SINGLE_CHUNK_TEXT_SIZE) ? input : input.substr(0, MAX_SINGLE_CHUNK_TEXT_SIZE));
+        std::string line;
+        std::getline(ss, line);
+        while (ss.good()) {
+            logger(line);
+            std::getline(ss, line);
+        }
+
+        if (ss.eof()) {
+            ss.clear();
+            ss << line;
+        } else if (ss.bad() || ss.fail()) {
+            ErrorLogger() << "Logger stream from python experienced an error " << ss.rdstate();
+            ss.clear();
         }
     }
 
-    // stderr logger
-    static std::string error_buffer("");
-    void ErrorText(const char* text) {
-        // Python sends text as several null-terminated array of char which need to be
-        // concatenated before they are output to the logger.  There's probably a better
-        // way to do this, but I don't know what it is, and this seems reasonably safe...
-       if (!text) return;
-        for (int i = 0; i < MAX_SINGLE_CHUNK_TEXT_SIZE; ++i) {
-            if (text[i] == '\0') break;
-            if (text[i] == '\n' || i == MAX_SINGLE_CHUNK_TEXT_SIZE - 1) {
-                BOOST_LOG_TRIVIAL(error) << error_buffer;
-                error_buffer = "";
-            } else {
-                error_buffer += text[i];
-            }
-        }
+
+    // debug/stdout logger
+    void PythonLoggerCoreDebug(const std::string &s) {
+        DebugLogger() << s;
+    }
+    void PythonLoggerDebug(const std::string & text) {
+        static std::stringstream log_stream("");
+        send_to_log(log_stream, text, &PythonLoggerCoreDebug);
+    }
+
+    // info logger
+    void PythonLoggerCoreInfo(const std::string &s) {
+        BOOST_LOG_TRIVIAL(info) << s;
+    }
+    void PythonLoggerInfo(const std::string & text) {
+        static std::stringstream log_stream("");
+        send_to_log(log_stream, text, &PythonLoggerCoreInfo);
+    }
+
+    // warn logger
+    void PythonLoggerCoreWarn(const std::string &s) {
+        BOOST_LOG_TRIVIAL(warning) << s;
+    }
+    void PythonLoggerWarn(const std::string & text) {
+        static std::stringstream log_stream("");
+        send_to_log(log_stream, text, &PythonLoggerCoreWarn);
+    }
+
+    // error logger
+    void PythonLoggerCoreError(const std::string &s) {
+        BOOST_LOG_TRIVIAL(error) << s;
+    }
+    void PythonLoggerError(const std::string & text) {
+        static std::stringstream log_stream("");
+        send_to_log(log_stream, text, &PythonLoggerCoreError);
+    }
+
+    // critical logger
+    void PythonLoggerCoreFatal(const std::string &s) {
+        BOOST_LOG_TRIVIAL(fatal) << s;
+    }
+    void PythonLoggerFatal(const std::string & text) {
+        static std::stringstream log_stream("");
+        send_to_log(log_stream, text, &PythonLoggerCoreFatal);
     }
 }
 
 namespace FreeOrionPython {
     using boost::python::def;
     void WrapLogger() {
-        def("log",      LogText);
-        def("error",    ErrorText);
+        def("debug", PythonLoggerDebug);
+        def("info", PythonLoggerInfo);
+        def("warn", PythonLoggerWarn);
+        def("error", PythonLoggerError);
+        def("fatal", PythonLoggerFatal);
     }
 }

--- a/python/LoggingWrapper.cpp
+++ b/python/LoggingWrapper.cpp
@@ -42,8 +42,6 @@ namespace {
             expr::stream
             << expr::format_date_time<boost::posix_time::ptime>("TimeStamp", "%H:%M:%S.%f")
             << " [" << log_severity << "] "
-            << channel_name
-            << " : "
             << expr::message
         );
 

--- a/python/LoggingWrapper.cpp
+++ b/python/LoggingWrapper.cpp
@@ -45,7 +45,7 @@ namespace {
 
     // info logger
     void PythonLoggerCoreInfo(const std::string &s) {
-        BOOST_LOG_TRIVIAL(info) << s;
+        InfoLogger() << s;
     }
     void PythonLoggerInfo(const std::string & text) {
         static std::stringstream log_stream("");
@@ -54,7 +54,7 @@ namespace {
 
     // warn logger
     void PythonLoggerCoreWarn(const std::string &s) {
-        BOOST_LOG_TRIVIAL(warning) << s;
+        WarnLogger() << s;
     }
     void PythonLoggerWarn(const std::string & text) {
         static std::stringstream log_stream("");
@@ -63,7 +63,7 @@ namespace {
 
     // error logger
     void PythonLoggerCoreError(const std::string &s) {
-        BOOST_LOG_TRIVIAL(error) << s;
+        ErrorLogger() << s;
     }
     void PythonLoggerError(const std::string & text) {
         static std::stringstream log_stream("");
@@ -72,7 +72,7 @@ namespace {
 
     // critical logger
     void PythonLoggerCoreFatal(const std::string &s) {
-        BOOST_LOG_TRIVIAL(fatal) << s;
+        ErrorLogger() << s;
     }
     void PythonLoggerFatal(const std::string & text) {
         static std::stringstream log_stream("");

--- a/util/Logger.cpp
+++ b/util/Logger.cpp
@@ -114,15 +114,6 @@ std::unordered_map<std::string, LogLevel> ValidNameToLogLevel() {
     return retval;
 }
 
-// Provide a LogLevel stream out formatter for streaming logs
-template<typename CharT, typename TraitsT>
-std::basic_ostream<CharT, TraitsT>& operator<<(
-    std::basic_ostream<CharT, TraitsT>& os, const LogLevel& level)
-{
-    os << log_level_names[static_cast<std::size_t>(level)];
-    return os;
-}
-
 // Provide a LogLevel input formatter for filtering
 template<typename CharT, typename TraitsT>
 inline std::basic_istream<CharT, TraitsT >& operator>>(

--- a/util/Logger.h
+++ b/util/Logger.h
@@ -4,6 +4,8 @@
 #include <boost/log/sources/severity_channel_logger.hpp>
 #include <boost/log/expressions/keyword.hpp>
 #include <boost/log/utility/manipulators/add_value.hpp>
+#include <boost/log/sinks/sync_frontend.hpp>
+#include <boost/log/sinks/text_file_backend.hpp>
 #include <boost/log/sources/global_logger_storage.hpp>
 #include <boost/signals2/signal.hpp>
 
@@ -304,6 +306,15 @@ BOOST_LOG_ATTRIBUTE_KEYWORD(log_src_linenum, "SrcLinenum", int);
 
 /** Sets the \p threshold of \p source.  \p source == "" is the default logger.*/
 FO_COMMON_API void SetLoggerThreshold(const std::string& source, LogLevel threshold);
+
+/** Apply \p configure_front_end to a new FileSinkFrontEnd for \p channel_name.  During static
+    initialization if the backend does not yet exist, then \p configure_front_end will be
+    stored until the backend is created.*/
+using LoggerTextFileSinkFrontend = boost::log::sinks::synchronous_sink<boost::log::sinks::text_file_backend>;
+using LoggerFileSinkFrontEndConfigurer = std::function<void(LoggerTextFileSinkFrontend& sink_frontend)>;
+FO_COMMON_API void ApplyConfigurationToFileSinkFrontEnd(
+    const std::string& channel_name,
+    const LoggerFileSinkFrontEndConfigurer& configure_front_end);
 
 extern int g_indent;
 

--- a/util/Logger.h
+++ b/util/Logger.h
@@ -153,6 +153,15 @@ constexpr LogLevel default_log_level_threshold = LogLevel::debug;
 FO_COMMON_API std::string to_string(const LogLevel level);
 FO_COMMON_API LogLevel to_LogLevel(const std::string& name);
 
+// Provide a LogLevel stream out formatter for streaming logs
+template<typename CharT, typename TraitsT>
+std::basic_ostream<CharT, TraitsT>& operator<<(
+    std::basic_ostream<CharT, TraitsT>& os, const LogLevel& level)
+{
+    os << to_string(level);
+    return os;
+}
+
 std::unordered_map<std::string, LogLevel> ValidNameToLogLevel();
 
 // Prefix \p name to create a global logger name less likely to collide.


### PR DESCRIPTION
This adds support for the standard python logging.logger, by redirecting its output to an appropriate stream of the freeorion log files.

There are comments in the code base that print statements need to be removed or turned off for the release build.  The python logger supports debug levels and hierarchically named loggers.  Both of these features will be useful with detailed control of logging.  It doesn't help if the cost is in computing the logged data.

While refactoring to add this feature I removed some previously hard-coded python from CommonFramework.cpp.

I also moved initFreeOrionAI() into FreeOrion.py which might address issue #606 :"Import AI code only after freeOrionAIInterface is ready"
