### PR TITLE
Move profiling to separate function

### DIFF
--- a/default/AI/ProductionAI.py
+++ b/default/AI/ProductionAI.py
@@ -11,10 +11,6 @@ import PriorityAI
 import ColonisationAI
 import MilitaryAI
 import ShipDesignAI
-from time import clock
-import cProfile
-import pstats
-import StringIO
 
 from EnumsAI import (PriorityType, EmpireProductionTypes, MissionType, get_priority_production_types,
                      FocusType, ShipRoleType, ShipDesignTypes)
@@ -41,9 +37,6 @@ _CHAT_DEBUG = False
 
 def find_best_designs_this_turn():
     """Calculate the best designs for each ship class available at this turn."""
-    pr = cProfile.Profile()
-    pr.enable()
-    start = clock()
     ShipDesignAI.Cache.update_for_new_turn()
     design_cache.clear()
     design_cache[PriorityType.PRODUCTION_MILITARY] = ShipDesignAI.MilitaryShipDesigner().optimize_design()
@@ -56,15 +49,6 @@ def find_best_designs_this_turn():
     design_cache[PriorityType.PRODUCTION_ORBITAL_DEFENSE] = ShipDesignAI.OrbitalDefenseShipDesigner().optimize_design()
     design_cache[PriorityType.PRODUCTION_EXPLORATION] = ShipDesignAI.ScoutShipDesigner().optimize_design()
     ShipDesignAI.KrillSpawnerShipDesigner().optimize_design()  # just designing it, building+mission not supported yet
-    pr.disable()
-    print "DEBUG INFORMATION: The design evaluations took %f s" % (clock() - start)
-    print "-----"
-    s = StringIO.StringIO()
-    sort_by = 'cumulative'
-    ps = pstats.Stats(pr, stream=s).sort_stats(sort_by)
-    ps.print_stats()
-    print s.getvalue()
-    print "-----"
     if fo.currentTurn() % 10 == 0:
         ShipDesignAI.Cache.print_best_designs()
 

--- a/default/AI/freeorion_debug/profiling.py
+++ b/default/AI/freeorion_debug/profiling.py
@@ -1,0 +1,45 @@
+import cProfile
+import os
+import pstats
+import time
+import freeOrionAIInterface as fo
+import StringIO
+import FreeOrionAI as foAI
+
+
+def profile(sort_by='cumulative'):
+    """
+    Profile function decorator.
+
+    Each function execution will add new entry to file.
+
+    Result stored in user directory in profile catalog. See lne in logs for exact position.
+    """
+
+    def argument_wrapper(function):
+        def wrapper(*args, **kwargs):
+            base_path = os.path.join(fo.getUserDataDir(), 'profiling')
+            path = os.path.join(base_path, foAI.foAIstate.uid)
+
+            pr = cProfile.Profile()
+            pr.enable()
+            start = time.clock()
+            result = function(*args, **kwargs)
+            end = time.clock()
+            pr.disable()
+            print "Profile %s tooks %f s, saved to %s" % (function.__name__, end - start, path)
+            s = StringIO.StringIO()
+            ps = pstats.Stats(pr, stream=s).strip_dirs().sort_stats(sort_by)
+            ps.print_stats()
+
+            if not os.path.exists(base_path):
+                os.makedirs(base_path)
+            with open(path, 'a') as f:
+                f.write(s.getvalue())
+                f.write('\n')
+
+            return result
+
+        return wrapper
+
+    return argument_wrapper


### PR DESCRIPTION
- extract profile to separate function
- disable it for find_best_designs_this_turn

Here is possible usecase:
- add decorator to `generateOrders`
- play game on same settings couple of times
- change something
- play couple of times
- run script:
  
  ``` python
  import os
  import re
  import matplotlib.pyplot as plt
  
  base = 'c:/Users/sa/AppData/Roaming/FreeOrion/profiling/'
  
  call_regexpr = re.compile('(\d+) function calls \(\d+ primitive calls\) in ([0-9.]+) seconds')
  
  
  def extract_time(path):
  times = []
  with open(path) as f:
      for line in f:
          if 'function calls' in line:
              times.append(call_regexpr.search(line).groups())
  return times
  
  
  def show_time_graph():
  all_times = []
  for name in os.listdir(base):
      all_times.append(extract_time(os.path.join(base, name)))
  
  for i, t in enumerate(all_times):
      plt.plot([float(x[1]) for x in t])
  
  plt.show()
  
  
  show_time_graph()
  ```

Result I got:
![test](https://cloud.githubusercontent.com/assets/171597/15557665/3c9bb2f6-22dd-11e6-95e2-7e35142d6d1b.png)

I did not find any bottleneck that can be fixed easily.
