### PR TITLE
Fix bugs where TELEPATHIC_DETECTION downgrades visibilty of planets.

### DIFF
--- a/default/scripting/species/common/telepathic.macros
+++ b/default/scripting/species/common/telepathic.macros
@@ -4,9 +4,11 @@ TELEPATHIC_DETECTION
             scope = And [
                 PopulationCenter
                 Not Population high = 0
-                WithinStarlaneJumps jumps = @1@ condition = Source
                 Not VisibleToEmpire empire = Source.Owner
+                Not OwnedBy empire = Source.Owner
+                WithinStarlaneJumps jumps = @1@ condition = Source
             ]
-            activation = OwnedBy affiliation = AnyEmpire
+            // Activate the turn after source creation to allow regular vision to prevail
+            activation = Turn low = Source.CreationTurn + 1
             effects = SetVisibility visibility = Basic empire = Source.Owner
 '''

--- a/default/scripting/species/common/telepathic.macros
+++ b/default/scripting/species/common/telepathic.macros
@@ -3,12 +3,12 @@ TELEPATHIC_DETECTION
             description = "TELEPATHIC_DETECTION"
             scope = And [
                 PopulationCenter
-                Not Population high = 0
                 Not VisibleToEmpire empire = Source.Owner
+                Not Source
                 Not OwnedBy empire = Source.Owner
+                Not Population high = 0
                 WithinStarlaneJumps jumps = @1@ condition = Source
             ]
-            // Activate the turn after source creation to allow regular vision to prevail
-            activation = Turn low = Source.CreationTurn + 1
+            activation = OwnedBy affiliation = AnyEmpire
             effects = SetVisibility visibility = Basic empire = Source.Owner
 '''


### PR DESCRIPTION
TELEPATHIC_DETECTION had two bugs.

First it hid the species with telepathic detection's own capital planet
on the first turn.

Secondly, it prevented normal visibility rules from applying on the
first turn.

This fixes the problem by not applying to its own planets and by
delaying telepathic detection by one turn.
