### PR TITLE
Python unit tests

### DIFF
--- a/default/python/AI/freeorion_tools.py
+++ b/default/python/AI/freeorion_tools.py
@@ -3,7 +3,6 @@ import re
 import sys
 
 import freeOrionAIInterface as fo  # pylint: disable=import-error
-import FreeOrionAI as foAI
 from functools import wraps
 from traceback import format_exc
 
@@ -159,6 +158,9 @@ def cache_by_turn(function):
     is keyed by the original function name.  Wraps only functions without arguments.
     Cache result is stored in savegame, will crash with picle error if result contains any boost object.
     """
+    # avoid circular import
+    import FreeOrionAI as foAI
+
     @wraps(function)
     def wrapper():
         if foAI.foAIstate is None:

--- a/default/python/common/print_utils.py
+++ b/default/python/common/print_utils.py
@@ -191,34 +191,3 @@ class Table(object):
             for header in legend:
                 result.append(('*%-*s %s' % (name_width, header.name[:-1], header.description)))
         return '\n'.join(x.encode('utf-8') for x in result)
-
-
-# Tests
-if __name__ == '__main__':
-    t = Table(
-        [Text('name', align='<', description='Name for first column'),
-         Float('value', description='VValue'),
-         Sequence('zzz'),
-         Sequence('zzzzzzzzzzzzzzzzzz'),
-         ],
-        table_name='Wooho')
-    t.add_row(['hello', 144444, 'abcffff', 'a'])
-    t.add_row([u'Plato aa\u03b2 III', 21, 'de', 'a'])
-    t.add_row([u'Plato \u03b2 III', 21, 'de', 'a'])
-    t.add_row(['Plato B III', 21, 'd', 'a'])
-    t.add_row(['Plato Bddddd III', 21, 'd', 'a'])
-    t.add_row(['Plato III', 21, 'd', 'a'])
-    t.print_table()
-
-    print
-    print '=' * 5, 'Columns', '=' * 5
-    print_in_columns(['a', 'b', 'c', 'd'], 2)
-
-    t2 = Table([Text('name', align='<', description='Name for first column'),
-                Float('value', description='VValue'),
-                Sequence('zzz'),
-                Sequence('zzzzzzzzzzzzzzzzzz'),
-                ],
-               table_name='Wooho'
-               )
-    t2.print_table()

--- a/default/python/tests/AI/test_parse_ai_tag_grade.py
+++ b/default/python/tests/AI/test_parse_ai_tag_grade.py
@@ -1,0 +1,10 @@
+from freeorion_tools import get_ai_tag_grade
+
+
+def test_parse_weapon_tag_positive():
+    assert 'GREAT' == get_ai_tag_grade(['AI_TAG_GREAT_WEAPONS'], 'WEAPONS')
+
+
+def test_parse_weapon_tag_negative():
+    assert '' == get_ai_tag_grade(['AI_TAG_WEAPONS'], 'WEAPONS')
+

--- a/default/python/tests/README.md
+++ b/default/python/tests/README.md
@@ -1,0 +1,17 @@
+# Test runner
+
+This test are supposed to be run outside the game engine.
+
+## Requirements
+ - install [pytest](http://pytest.org/latest/getting-started.html)
+
+## Run test
+ - open console (`cmd` or `PowerShell` for win)
+ - change dir to `freeorion\default\python\tests`
+ - execute  `run_tests.py` with python
+   - `python run_tests.py` for windows
+   - `./run_tests.py` for linux and mac
+
+ `run_tests.py` accepts same commandline arguments as pytest. I prefer to add `-v --tb long`
+ 
+ `run_tests.py` adds required directories to python path and runs pytest.  

--- a/default/python/tests/common/test_print_utils.py
+++ b/default/python/tests/common/test_print_utils.py
@@ -1,0 +1,68 @@
+# coding=utf-8
+'''
+
+
+===== Columns =====
+
+
+
+Process finished with exit code 0
+'''
+
+from common.print_utils import print_in_columns, Table, Text, Float, Sequence
+
+EXPECTED_COLUMNS = '''a   c
+b   d
+'''
+
+EXPECTED_SIMPLE_TABLE = '''Wooho
+============================================================================
+| name*            | value*     | zzz                 | zzzzzzzzzzzzzzzzzz |
+============================================================================
+| hello            |  144444.00 | a, b, c, f, f, f, f |                  a |
+| Plato aaβ III    |      21.00 |                d, e |                  a |
+| Plato β III      |      21.00 |                d, e |                  a |
+| Plato B III      |      21.00 |                   d |                  a |
+| Plato Bddddd III |      21.00 |                   d |                  a |
+| Plato III        |      21.00 |                   d |                  a |
+----------------------------------------------------------------------------
+*name   Name for first column
+*value  VValue'''
+
+EXPECTED_EMPTY_TABLE = '''Wooho
+=============================================
+| name* | value* | zzz | zzzzzzzzzzzzzzzzzz |
+=============================================
+---------------------------------------------
+*name   Name for first column
+*value  VValue'''
+
+
+# https://pytest.org/latest/capture.html#accessing-captured-output-from-a-test-function
+def test_print_in_columns(capfd):
+    print_in_columns(['a', 'b', 'c', 'd'], 2)
+    out, err = capfd.readouterr()
+    assert out == EXPECTED_COLUMNS
+
+
+def test_simple_table():
+    t = Table(
+        [Text('name', align='<', description='Name for first column'), Float('value', description='VValue'),
+         Sequence('zzz'), Sequence('zzzzzzzzzzzzzzzzzz')],
+        table_name='Wooho')
+    t.add_row(['hello', 144444, 'abcffff', 'a'])
+    t.add_row([u'Plato aa\u03b2 III', 21, 'de', 'a'])
+    t.add_row([u'Plato \u03b2 III', 21, 'de', 'a'])
+    t.add_row(['Plato B III', 21, 'd', 'a'])
+    t.add_row(['Plato Bddddd III', 21, 'd', 'a'])
+    t.add_row(['Plato III', 21, 'd', 'a'])
+    assert t.get_table() == EXPECTED_SIMPLE_TABLE
+
+
+def test_empty_table():
+    empty = Table(
+        [Text('name', align='<', description='Name for first column'), Float('value', description='VValue'),
+         Sequence('zzz'), Sequence('zzzzzzzzzzzzzzzzzz')],
+        table_name='Wooho'
+    )
+    assert empty.get_table() == EXPECTED_EMPTY_TABLE

--- a/default/python/tests/run_tests.py
+++ b/default/python/tests/run_tests.py
@@ -1,0 +1,14 @@
+#!/usr/bin/env python2.7
+
+import os
+import sys
+import pytest
+
+this_dir = os.path.dirname(__file__)
+
+# add path to AI
+sys.path.append(os.path.join(this_dir, '..', '..', 'AI/'))
+# path to freeOrionAIInterface mock
+sys.path.append(os.path.join(this_dir, '..', '..', 'AI/', 'freeorion_debug', 'ide_tools', 'result'))
+
+pytest.main(sys.argv[1:])

--- a/default/python/tests/run_tests.py
+++ b/default/python/tests/run_tests.py
@@ -10,5 +10,7 @@ this_dir = os.path.dirname(__file__)
 sys.path.append(os.path.join(this_dir, '..', '..', 'python', 'AI/'))
 # path to freeOrionAIInterface mock
 sys.path.append(os.path.join(this_dir, '..', '..', 'python', 'AI/', 'freeorion_debug', 'ide_tools', 'result'))
+# add path to common tools
+sys.path.append(os.path.join(this_dir, '..', '..', 'python'))
 
 pytest.main(sys.argv[1:])

--- a/default/python/tests/run_tests.py
+++ b/default/python/tests/run_tests.py
@@ -7,8 +7,8 @@ import pytest
 this_dir = os.path.dirname(__file__)
 
 # add path to AI
-sys.path.append(os.path.join(this_dir, '..', '..', 'AI/'))
+sys.path.append(os.path.join(this_dir, '..', '..', 'python', 'AI/'))
 # path to freeOrionAIInterface mock
-sys.path.append(os.path.join(this_dir, '..', '..', 'AI/', 'freeorion_debug', 'ide_tools', 'result'))
+sys.path.append(os.path.join(this_dir, '..', '..', 'python', 'AI/', 'freeorion_debug', 'ide_tools', 'result'))
 
 pytest.main(sys.argv[1:])


### PR DESCRIPTION
This is implementation of infrastructure for `offline` tests for out python code (AI, universe generation, turn events). 

I took changes introduced by @LGM-Doyle in  #677 and make them windows friendly. 

Testing code that required c++ interface is still possible with use of [mock](https://pypi.python.org/pypi/mock) or other libraries.

I expect that this feature will be used by small number of python developers. But if person want to write tests for his code, we should not throw this test away.  

Tested on win7x64
