### PR TITLE
Enable production queue additions from object wnd

### DIFF
--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -2655,6 +2655,12 @@ Latest known [[encyclopedia STEALTH_TITLE]] is out of date. Actual stealth excee
 MENUITEM_SET_FOCUS
 Set focus
 
+MENUITEM_ENQUEUE_BUILDING
+Queue Building
+
+MENUITEM_ENQUEUE_SHIPDESIGN
+Queue Ship
+
 ## Resources Panel ##########
 
 RP_FOCUS_TOOLTIP


### PR DESCRIPTION
Adds right click contexts for planets in the object window, adding ship designs or buildings to the production queue.
