### PR TITLE
Production pedia: Fix non-stringtable name lookups

### DIFF
--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -972,7 +972,10 @@ void BuildDesignatorWnd::BuildSelector::BuildItemRightClicked(GG::ListBox::itera
         menu_contents.next_level.push_back(GG::MenuItem(UserString("PRODUCTION_DETAIL_ADD_TO_TOP_OF_QUEUE"),   2, false, false));
     }
 
-    std::string popup_label = boost::io::str(FlexibleFormat(UserString("ENC_LOOKUP")) % UserString(item_name));
+    if (UserStringExists(item_name))
+        item_name = UserString(item_name);
+
+    std::string popup_label = boost::io::str(FlexibleFormat(UserString("ENC_LOOKUP")) % item_name);
     menu_contents.next_level.push_back(GG::MenuItem(popup_label, 3, false, false));
 
     GG::PopupMenu popup(pt.x, pt.y, ClientUI::GetFont(), menu_contents, ClientUI::TextColor(),

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -633,7 +633,10 @@ namespace {
             if (build_type == BT_SHIP)
                 item_name = GetShipDesign(queue_row->m_build.item.design_id)->Name(false);
 
-            std::string popup_label = boost::io::str(FlexibleFormat(UserString("ENC_LOOKUP")) % UserString(item_name));
+            if (UserStringExists(item_name))
+                item_name = UserString(item_name);
+
+            std::string popup_label = boost::io::str(FlexibleFormat(UserString("ENC_LOOKUP")) % item_name);
             menu_contents.next_level.push_back(GG::MenuItem(popup_label, 5, false, false));
 
             GG::PopupMenu popup(pt.x, pt.y, ClientUI::GetFont(), menu_contents, ClientUI::TextColor(),


### PR DESCRIPTION
Custom ship design names show "ERROR:..." for right click context pedia lookup.

PR uses the raw name entry when there is no stringtable reference.
