### PR TITLE
Fix bug referencing NULL validator in OptionsDB.

### DIFF
--- a/util/OptionsDB.cpp
+++ b/util/OptionsDB.cpp
@@ -93,8 +93,18 @@ OptionsDB::Option::Option(char short_name_, const std::string& name_, const boos
 }
 
 bool OptionsDB::Option::SetFromString(const std::string& str) {
-    boost::any value_ = flag ? boost::lexical_cast<bool>(str) : validator->Validate(str);
-    bool changed =  validator->String(value) != validator->String(value_);
+    bool changed = false;
+    boost::any value_;
+
+    if (!flag) {
+        value_ = validator->Validate(str);
+        changed = validator->String(value) != validator->String(value_);
+    } else {
+        value_ = boost::lexical_cast<bool>(str);
+        changed = (boost::lexical_cast<std::string>(boost::any_cast<bool>(value))
+                   != boost::lexical_cast<std::string>(boost::any_cast<bool>(value_)));
+    }
+
     if (changed) {
         value = value_;
         (*option_changed_sig_ptr)();

--- a/util/OptionsDB.h
+++ b/util/OptionsDB.h
@@ -353,7 +353,16 @@ template <typename T>
 bool OptionsDB::Option::SetFromValue(const T& value_) {
     if (value.type() != typeid(T))
         throw boost::bad_any_cast();
-    bool changed = validator->String(value) != validator->String(value_);
+
+    bool changed = false;
+
+    if (!flag) {
+        changed =  validator->String(value) != validator->String(value_);
+    } else {
+        changed = (boost::lexical_cast<std::string>(boost::any_cast<bool>(value))
+                   != boost::lexical_cast<std::string>(boost::any_cast<bool>(value_)));
+    }
+
     if (changed) {
         value = value_;
         (*option_changed_sig_ptr)();


### PR DESCRIPTION
flag options have no validator.  Old code referenced the non-existent
validator.
