### PR TITLE
FOCS: Adjust mine damage macro for limited scope

### DIFF
--- a/default/scripting/specials/FORTRESS.focs.txt
+++ b/default/scripting/specials/FORTRESS.focs.txt
@@ -33,7 +33,7 @@ Special
                 SetShield value = Value + min(5.0, max(Value, 0.25*Target.Construction))
                 SetDefense value = Value + 1
             ]
-        [[EG_SYSTEM_MINES(3, LATE_PRIORITY)]]
+        [[EG_SYSTEM_MINES(3,LATE_PRIORITY,SOURCE)]]
 
         EffectsGroup
             scope = Source

--- a/default/scripting/techs/defense/Defense.focs.txt
+++ b/default/scripting/techs/defense/Defense.focs.txt
@@ -28,7 +28,7 @@ Tech
     researchturns = 4
     prerequisites = "DEF_DEFENSE_NET_1"
     effectsgroups = [
-        [[EG_SYSTEM_MINES(2,VERY_LATE_PRIORITY)]]
+        [[EG_SYSTEM_MINES(2,VERY_LATE_PRIORITY,EMPIRE)]]
     ]
     graphic = "icons/tech/system_defense_mines.png"
 
@@ -41,7 +41,7 @@ Tech
     researchturns = 6
     prerequisites = "DEF_SYST_DEF_MINE_1"
     effectsgroups = [
-        [[EG_SYSTEM_MINES(6,DEFAULT_PRIORITY)]]
+        [[EG_SYSTEM_MINES(6,DEFAULT_PRIORITY,EMPIRE)]]
     ]
     graphic = "icons/tech/system_defense_mines.png"
 
@@ -54,7 +54,7 @@ Tech
     researchturns = 8
     prerequisites = "DEF_SYST_DEF_MINE_2"
     effectsgroups = [
-        [[EG_SYSTEM_MINES(14,EARLY_PRIORITY)]]
+        [[EG_SYSTEM_MINES(14,EARLY_PRIORITY,EMPIRE)]]
     ]
     graphic = "icons/tech/system_defense_mines.png"
 

--- a/default/scripting/techs/defense/mines.macros
+++ b/default/scripting/techs/defense/mines.macros
@@ -1,26 +1,19 @@
+//#debug_macros "mines_macro.log"
 // EffectsGroups for System Defense Mines
 // arg1 total damage
 // arg2 priority
+// arg3 scope of systems effected: SOURCE, EMPIRE
 EG_SYSTEM_MINES
 '''        // damage ship; sitreps issued below
         EffectsGroup
             scope = And [
                 Ship
-                ContainedBy And [
-                    System 
-                    Contains Or [
-                        Source
-                        And [
-                            Planet
-                            OwnedBy empire = Source.Owner
-                        ]
-                    ]
-                ]
+                [[SYSTEM_MINES_SCOPE(@3@)]]
                 Or [
                     OwnedBy affiliation = EnemyOf empire = Source.Owner
                     Unowned
                 ]
-                (RootCandidate.Owner != Source.Owner)
+                Not OwnedBy empire = Source.Owner
                 Structure low = @1@ + 0.0001
             ]
             stackinggroup = "DEF_MINES_DAMAGE_STACK"
@@ -32,21 +25,12 @@ EG_SYSTEM_MINES
         EffectsGroup
             scope = And [
                 Ship
-                ContainedBy And [
-                    System 
-                    Contains Or [
-                        Source
-                        And [
-                            Planet
-                            OwnedBy empire = Source.Owner
-                        ]
-                    ]
-                ]
+                [[SYSTEM_MINES_SCOPE(@3@)]]
                 Or [
                     OwnedBy affiliation = EnemyOf empire = Source.Owner
                     Unowned
                 ]
-                (RootCandidate.Owner != Source.Owner)
+                Not OwnedBy empire = Source.Owner
                 Structure high = @1@
             ]
             stackinggroup = "DEF_MINES_DAMAGE_STACK"
@@ -58,16 +42,7 @@ EG_SYSTEM_MINES
         EffectsGroup
             scope = And [
                 Fleet
-                ContainedBy And [
-                    System
-                    Contains Or [
-                        Source
-                        And [
-                            Planet
-                            OwnedBy empire = Source.Owner
-                        ]
-                    ]
-                ]
+                [[SYSTEM_MINES_SCOPE(@3@)]]
                 OwnedBy affiliation = EnemyOf empire = Source.Owner
                 VisibleToEmpire empire = Source.Owner
             ]
@@ -89,16 +64,7 @@ EG_SYSTEM_MINES
         EffectsGroup
             scope = And [
                 Ship
-                ContainedBy And [
-                    System
-                    Contains Or [
-                        Source
-                        And [
-                            Planet
-                            OwnedBy empire = Source.Owner
-                        ]
-                    ]
-                ]
+                [[SYSTEM_MINES_SCOPE(@3@)]]
                 Unowned
                 VisibleToEmpire empire = Source.Owner
                 Structure low = @1@ + 0.0001
@@ -122,16 +88,7 @@ EG_SYSTEM_MINES
         EffectsGroup
             scope = And [
                 Ship
-                ContainedBy And [
-                    System
-                    Contains Or [
-                        Source
-                        And [
-                            Planet
-                            OwnedBy empire = Source.Owner
-                        ]
-                    ]
-                ]
+                [[SYSTEM_MINES_SCOPE(@3@)]]
                 Unowned
                 VisibleToEmpire empire = Source.Owner
                 Structure high = @1@
@@ -154,16 +111,7 @@ EG_SYSTEM_MINES
         EffectsGroup
             scope = And [
                 Ship
-                ContainedBy And [
-                    System
-                    Contains Or [
-                        Source
-                        And [
-                            Planet
-                            OwnedBy empire = Source.Owner
-                        ]
-                    ]
-                ]
+                [[SYSTEM_MINES_SCOPE(@3@)]]
                 OwnedBy affiliation = EnemyOf empire = Source.Owner
                 Structure high = @1@
                 VisibleToEmpire empire = Source.Owner
@@ -185,16 +133,7 @@ EG_SYSTEM_MINES
         EffectsGroup
             scope = And [
                 Ship
-                ContainedBy And [
-                    System
-                    Contains Or [
-                        Source
-                        And [
-                            Planet
-                            OwnedBy empire = Source.Owner
-                        ]
-                    ]
-                ]
+                [[SYSTEM_MINES_SCOPE(@3@)]]
                 Or [
                     OwnedBy affiliation = EnemyOf empire = Source.Owner
                     Unowned
@@ -216,16 +155,7 @@ EG_SYSTEM_MINES
         EffectsGroup
             scope = And [
                 Fleet
-                ContainedBy And [
-                    System 
-                    Contains Or [
-                        Source
-                        And [
-                            Planet
-                            OwnedBy empire = Source.Owner
-                        ]
-                    ]
-                ]
+                [[SYSTEM_MINES_SCOPE(@3@)]]
                 OwnedBy affiliation = EnemyOf empire = Source.Owner
             ]
             stackinggroup = "DEF_MINES_SITREP_FLEET_STACK"
@@ -245,16 +175,7 @@ EG_SYSTEM_MINES
         EffectsGroup
             scope = And [
                 Ship
-                ContainedBy And [
-                    System 
-                    Contains Or [
-                        Source
-                        And [
-                            Planet
-                            OwnedBy empire = Source.Owner
-                        ]
-                    ]
-                ]
+                [[SYSTEM_MINES_SCOPE(@3@)]]
                 OwnedBy affiliation = EnemyOf empire = Source.Owner
                 Structure high = @1@
             ]
@@ -271,3 +192,18 @@ EG_SYSTEM_MINES
                     empire = Target.Owner
             ]
 '''
+
+SYSTEM_MINES_SCOPE
+'''[[SYSTEM_MINES_SCOPE_@1@]]'''
+
+SYSTEM_MINES_SCOPE_SOURCE
+'''InSystem id = Source.SystemID'''
+
+SYSTEM_MINES_SCOPE_EMPIRE
+'''ContainedBy And [
+                    System 
+                    Contains And [
+                        Planet
+                        OwnedBy empire = Source.Owner
+                    ]
+                ]'''


### PR DESCRIPTION
Fixes #703 

Mine damage from an owned fortress was applied to all empire systems.
