### PR TITLE
Remove secondary file check of savegames

### DIFF
--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -774,9 +774,6 @@ void SaveFileDialog::Confirm() {
             ErrorLogger() << "SaveFileDialog::Confirm: Invalid status for file: " << Result();
             return;
         }
-    } else if (!fs::is_regular_file(chosen_full_path)) {
-        ErrorLogger() << "SaveFileDialog::Confirm: problem with result: " << Result();
-        return;
     }
 
     CloseClicked();


### PR DESCRIPTION
Fixes #693

User is still kept from loading a non-existing file, as CheckChoiceValidity() does not enable the OK button.
