### PR TITLE
In SidePanel confine planet rename context menu item inside planet name.

### DIFF
--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -1851,8 +1851,11 @@ void SidePanel::PlanetPanel::RClick(const GG::Pt& pt, GG::Flags<GG::ModKey> mod_
     }
 
     GG::MenuItem menu_contents;
-    if (planet->OwnedBy(HumanClientApp::GetApp()->EmpireID()) && m_order_issuing_enabled )
+    if (planet->OwnedBy(HumanClientApp::GetApp()->EmpireID()) && m_order_issuing_enabled
+        && m_planet_name->InClient(pt))
+    {
         menu_contents.next_level.push_back(GG::MenuItem(UserString("SP_RENAME_PLANET"), 1, false, false));
+    }
 
     menu_contents.next_level.push_back(GG::MenuItem(UserString("SP_PLANET_SUITABILITY"), 2, false, false));
 


### PR DESCRIPTION
The SidePanel has a context menu item to rename the planet if it is
owned by the player.  Change the condition so that it only appears when
the cursor is over the planet name.
