### PR TITLE
Require systems with non black hole stars to have a satellite.

### DIFF
--- a/default/python/universe_generation/planets.py
+++ b/default/python/universe_generation/planets.py
@@ -34,11 +34,11 @@ def base_chance_of_planet(planet_density, galaxy_shape, star_type, orbit, planet
             + tables.ORBIT_MOD_TO_PLANET_SIZE_DIST[orbit][planet_size]
             + tables.GALAXY_SHAPE_MOD_TO_PLANET_SIZE_DIST[galaxy_shape][planet_size])
 
+
 def can_have_planets(star_type, orbits, planet_density, galaxy_shape):
     """
     Return True if a system can have any planets.
     """
-
     for orbit in orbits:
         base_chance_none = base_chance_of_planet(planet_density, galaxy_shape, star_type, orbit, fo.planetSize.noWorld)
         base_chance_any  = max([base_chance_of_planet(planet_density, galaxy_shape, star_type, orbit, size)
@@ -53,7 +53,6 @@ def calc_planet_size(star_type, orbit, planet_density, galaxy_shape):
     """
     Calculate planet size for a potential new planet based on planet density setup option, star type and orbit number.
     """
-
     # try to pick a planet size by making a series of "rolls" (1-100)
     # for each planet size, and take the highest modified roll
     planet_size = fo.planetSize.unknown
@@ -88,7 +87,6 @@ def calc_planet_type(star_type, orbit, planet_size):
 
     TODO: take into account star type and orbit number for determining planet type.
     """
-
     # check specified planet size to determine if we want a planet at all
     if planet_size in planet_sizes:
         # if yes, determine planet type based on planet size...
@@ -106,7 +104,6 @@ def generate_a_planet(system, star_type, orbit, planet_density, galaxy_shape):
     """
     Place a planet in an orbit of a system. Return True on success
     """
-
     planet_size = calc_planet_size(star_type, orbit, planet_density, galaxy_shape)
     if planet_size not in planet_sizes:
         return False

--- a/default/python/universe_generation/planets.py
+++ b/default/python/universe_generation/planets.py
@@ -28,6 +28,27 @@ planet_types_real = (fo.planetType.swamp,  fo.planetType.radiated,  fo.planetTyp
                      fo.planetType.ocean)
 
 
+def base_chance_of_planet(planet_density, galaxy_shape, star_type, orbit, planet_size):
+    return (tables.DENSITY_MOD_TO_PLANET_SIZE_DIST[planet_density][planet_size]
+            + tables.STAR_TYPE_MOD_TO_PLANET_SIZE_DIST[star_type][planet_size]
+            + tables.ORBIT_MOD_TO_PLANET_SIZE_DIST[orbit][planet_size]
+            + tables.GALAXY_SHAPE_MOD_TO_PLANET_SIZE_DIST[galaxy_shape][planet_size])
+
+def can_have_planets(star_type, orbits, planet_density, galaxy_shape):
+    """
+    Return True if a system can have any planets.
+    """
+
+    for orbit in orbits:
+        base_chance_none = base_chance_of_planet(planet_density, galaxy_shape, star_type, orbit, fo.planetSize.noWorld)
+        base_chance_any  = max([base_chance_of_planet(planet_density, galaxy_shape, star_type, orbit, size)
+                                for size in planet_sizes])
+
+        if base_chance_any > base_chance_none - 100:
+            return True
+    return False
+
+
 def calc_planet_size(star_type, orbit, planet_density, galaxy_shape):
     """
     Calculate planet size for a potential new planet based on planet density setup option, star type and orbit number.
@@ -38,15 +59,12 @@ def calc_planet_size(star_type, orbit, planet_density, galaxy_shape):
     planet_size = fo.planetSize.unknown
     try:
         max_roll = 0
-        for candidate in planet_sizes_all:
-            roll = random.randint(1, 100) \
-                + tables.DENSITY_MOD_TO_PLANET_SIZE_DIST[planet_density][candidate] \
-                + tables.STAR_TYPE_MOD_TO_PLANET_SIZE_DIST[star_type][candidate] \
-                + tables.ORBIT_MOD_TO_PLANET_SIZE_DIST[orbit][candidate] \
-                + tables.GALAXY_SHAPE_MOD_TO_PLANET_SIZE_DIST[galaxy_shape][candidate]
+        for size in planet_sizes_all:
+            roll = (random.randint(1, 100)
+                    + base_chance_of_planet(planet_density, galaxy_shape, star_type, orbit, size))
             if max_roll < roll:
                 max_roll = roll
-                planet_size = candidate
+                planet_size = size
     except:
         # in case of an error play it safe and set planet size to invalid
         planet_size = fo.planetSize.unknown
@@ -82,3 +100,22 @@ def calc_planet_type(star_type, orbit, planet_size):
             return random.choice(planet_types_real)
     else:
         return fo.planetType.unknown
+
+
+def generate_a_planet(system, star_type, orbit, planet_density, galaxy_shape):
+    """
+    Place a planet in an orbit of a system. Return True on success
+    """
+
+    planet_size = calc_planet_size(star_type, orbit, planet_density, galaxy_shape)
+    if planet_size not in planet_sizes:
+        return False
+    # ok, we want a planet, determine planet type and generate the planet
+    planet_type = calc_planet_type(star_type, orbit, planet_size)
+    if planet_type == fo.planetType.unknown:
+        return False
+    if fo.create_planet(planet_size, planet_type, system, orbit, "") == fo.invalid_object():
+        # create planet failed, report an error
+        util.report_error("Python generate_systems: create planet in system %d failed" % system)
+        return False
+    return True

--- a/default/python/universe_generation/universe_tables.py
+++ b/default/python/universe_generation/universe_tables.py
@@ -60,6 +60,9 @@ DENSITY_MOD_TO_PLANET_SIZE_DIST = {
 
 # Given the star type that was already chosen, what will the bonus be for this
 # size of planet?
+# Note: A positive value for none, will mean a chance of empty systems
+# of that type in game.  All star types with a zero or less chance for
+# none will be forced to have at least one satellite.
 STAR_TYPE_MOD_TO_PLANET_SIZE_DIST = {
 #                           none  tiny  small  medium  large  huge  asteroids  gas giant
     fo.starType.blue:      (  0,    0,     0,      0,    -5,  -10,         0,         0),


### PR DESCRIPTION
@MatGB suggested this change.  

Once he suggested it I started to notice how much time I was spending clicking on systems with stars, because I couldn't remember if they had planets or not.

@MatGB may want to rebalance it to have fewer stars, since they all now have at least one planet/asteroids.

I still allowed black holes to have no planets.  I think that they are rare and that flavor-wise the absence of planets works.
