### PR TITLE
Fix bug python system exit not an error

### DIFF
--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -128,6 +128,10 @@ void AIClientApp::StartPythonAI() {
         Networking().DisconnectFromServer();
         throw std::runtime_error(err_msg.str());
     }
+
+    if (m_AI)
+        delete m_AI;
+
     m_AI = python_ai;
 
 }

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -44,11 +44,14 @@ AIClientApp::AIClientApp(const std::vector<std::string>& args) :
     }
 
     InitLogger(AICLIENT_LOG_FILENAME, "AI");
-    DebugLogger() << PlayerName() + " logger initialized.";
+    DebugLogger() << PlayerName() + " ai client initialized.";
 }
 
 AIClientApp::~AIClientApp() {
-    DebugLogger() << "Shutting down " + PlayerName() + " logger...";
+    if (Networking().Connected())
+        Networking().DisconnectFromServer();
+
+    DebugLogger() << "Shutting down " + PlayerName() + " ai client.";
 }
 
 void AIClientApp::operator()()
@@ -71,23 +74,39 @@ const AIBase* AIClientApp::GetAI()
 void AIClientApp::Run() {
     ConnectToServer();
 
-    StartPythonAI();
+    try {
+        StartPythonAI();
 
-    // join game
-    Networking().SendMessage(JoinGameMessage(PlayerName(), Networking::CLIENT_TYPE_AI_PLAYER));
+        // join game
+        Networking().SendMessage(JoinGameMessage(PlayerName(), Networking::CLIENT_TYPE_AI_PLAYER));
 
-    // respond to messages until disconnected
-    while (1) {
-        if (!Networking().Connected())
-            break;
-        if (Networking().MessageAvailable()) {
-            Message msg;
-            Networking().GetMessage(msg);
-            HandleMessage(msg);
-        } else {
-            boost::this_thread::sleep_for(boost::chrono::milliseconds(250));
+        // respond to messages until disconnected
+        while (1) {
+            try {
+
+                if (!Networking().Connected())
+                    break;
+                if (Networking().MessageAvailable()) {
+                    Message msg;
+                    Networking().GetMessage(msg);
+                    HandleMessage(msg);
+                } else {
+                    boost::this_thread::sleep_for(boost::chrono::milliseconds(250));
+                }
+
+            } catch (boost::python::error_already_set) {
+                /* If the python interpreter is still running then keep
+                   going, otherwise exit.*/
+                m_AI->HandleErrorAlreadySet();
+                if (m_AI->IsPythonRunning())
+                    throw;
+            }
         }
+    } catch (boost::python::error_already_set) {
+        HandlePythonAICrash();
     }
+
+    Networking().DisconnectFromServer();
 }
 
 void AIClientApp::ConnectToServer() {
@@ -114,19 +133,24 @@ void AIClientApp::ConnectToServer() {
 
 void AIClientApp::StartPythonAI() {
     m_AI.reset(new PythonAI());
-    if (!m_AI.get()->Initialize()) {
-        //Note: At this point in the initialization the AI has not been associated with a PlayerConnection
-        //so the server will no know the AI's PlayerName.
-        std::stringstream err_msg;
-        err_msg << "AIClientApp::AIClientApp: Failed to initialize Python AI for " << PlayerName() << ".  Exiting Soon.";
-        ErrorLogger() << err_msg.str();
-        Networking().SendMessage(
-            ErrorMessage(str(FlexibleFormat(UserString("ERROR_PYTHON_AI_CRASHED")) % PlayerName()) , true));
-        boost::this_thread::sleep_for(boost::chrono::seconds(2));
-        Networking().DisconnectFromServer();
-        throw std::runtime_error(err_msg.str());
+    if (!(m_AI.get())->Initialize()) {
+        HandlePythonAICrash();
+        throw std::runtime_error("PythonAI failed to initialize.");
     }
 }
+
+void AIClientApp::HandlePythonAICrash() {
+    // Note: If python crashed during initialization then the AI has not
+    // been associated with a PlayerConnection so the server will not
+    // know the AI's PlayerName.
+    std::stringstream err_msg;
+    err_msg << "AIClientApp failed due to error in python AI code for " << PlayerName() << ".  Exiting Soon.";
+    ErrorLogger() << err_msg.str() << " id = " << PlayerID();
+    Networking().SendMessage(
+        ErrorMessage(PlayerID(), str(FlexibleFormat(UserString("ERROR_PYTHON_AI_CRASHED")) % PlayerName()) , true));
+    boost::this_thread::sleep_for(boost::chrono::milliseconds(500));
+}
+
 
 void AIClientApp::HandleMessage(const Message& msg) {
     //DebugLogger() << "AIClientApp::HandleMessage " << msg.Type();

--- a/client/AI/AIClientApp.h
+++ b/client/AI/AIClientApp.h
@@ -35,6 +35,7 @@ private:
     void                Run();          ///< initializes app state, then executes main event handler/render loop (PollAndRender())
     void                ConnectToServer();
     void                StartPythonAI();
+    void                HandlePythonAICrash();
     void                HandleMessage(const Message& msg);
 
 

--- a/client/AI/AIClientApp.h
+++ b/client/AI/AIClientApp.h
@@ -3,8 +3,10 @@
 
 #include "../ClientApp.h"
 #include <vector>
+#include <boost/scoped_ptr.hpp>
 
 class AIBase;
+class PythonAI;
 
 /** the application framework for an AI player FreeOrion client.*/
 class AIClientApp : public ClientApp {
@@ -36,8 +38,7 @@ private:
     void                HandleMessage(const Message& msg);
 
 
-    AIBase*             m_AI;           ///< implementation of AI logic
-                                        ///TODO:Use smart pointer
+    boost::scoped_ptr<PythonAI> m_AI;     ///< implementation of AI logic
     std::string         m_player_name;
     int                 m_max_aggression;
 };

--- a/client/AI/AIClientApp.h
+++ b/client/AI/AIClientApp.h
@@ -37,6 +37,7 @@ private:
 
 
     AIBase*             m_AI;           ///< implementation of AI logic
+                                        ///TODO:Use smart pointer
     std::string         m_player_name;
     int                 m_max_aggression;
 };

--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -5,7 +5,6 @@ import sys
 import random
 
 from common import configure_logging
-configure_logging.redirect_logging_to_freeorion_logger()
 
 # IMPORTANT! this import also execute python code to update freeOrionAIInterface interface,
 # removing this import will brake AI in unexpected way.

--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -4,6 +4,9 @@ import pickle  # Python object serialization library
 import sys
 import random
 
+from common import configure_logging
+configure_logging.redirect_logging_to_freeorion_logger()
+
 # IMPORTANT! this import also execute python code to update freeOrionAIInterface interface,
 # removing this import will brake AI in unexpected way.
 

--- a/default/python/common/configure_logging.py
+++ b/default/python/common/configure_logging.py
@@ -1,0 +1,26 @@
+import sys
+import logging
+import freeorion_logger
+
+
+class dbgLogger(object):
+    """A stream-like object to redirect stdout to C++ process"""
+    @staticmethod
+    def write(msg):
+        freeorion_logger.log(msg)
+
+
+class errLogger(object):
+    """A stream-like object to redirect stderr to C++ process"""
+    @staticmethod
+    def write(msg):
+        freeorion_logger.error(msg)
+
+
+def redirect_logging_to_freeorion_logger():
+    """Redirect stdout, stderr and the logging.logger to hosting process' freeorion_logger"""
+
+    sys.stdout = dbgLogger()
+    sys.stderr = errLogger()
+    print 'Python stdout and stderr redirected'
+

--- a/default/python/common/configure_logging.py
+++ b/default/python/common/configure_logging.py
@@ -1,16 +1,15 @@
 import sys
-import logging
 import freeorion_logger
 
 
-class dbgLogger(object):
+class DbgLogger(object):
     """A stream-like object to redirect stdout to C++ process"""
     @staticmethod
     def write(msg):
         freeorion_logger.log(msg)
 
 
-class errLogger(object):
+class ErrLogger(object):
     """A stream-like object to redirect stderr to C++ process"""
     @staticmethod
     def write(msg):
@@ -20,7 +19,8 @@ class errLogger(object):
 def redirect_logging_to_freeorion_logger():
     """Redirect stdout, stderr and the logging.logger to hosting process' freeorion_logger"""
 
-    sys.stdout = dbgLogger()
-    sys.stderr = errLogger()
+    sys.stdout = DbgLogger()
+    sys.stderr = ErrLogger()
     print 'Python stdout and stderr redirected'
 
+redirect_logging_to_freeorion_logger()

--- a/default/python/universe_generation/universe_generator.py
+++ b/default/python/universe_generation/universe_generator.py
@@ -1,5 +1,8 @@
 import random
 
+from common import configure_logging
+configure_logging.redirect_logging_to_freeorion_logger()
+
 import freeorion as fo
 
 from starnames import name_star_systems

--- a/default/python/universe_generation/universe_generator.py
+++ b/default/python/universe_generation/universe_generator.py
@@ -1,7 +1,6 @@
 import random
 
 from common import configure_logging
-configure_logging.redirect_logging_to_freeorion_logger()
 
 import freeorion as fo
 

--- a/python/AI/AIFramework.cpp
+++ b/python/AI/AIFramework.cpp
@@ -128,14 +128,8 @@ bool PythonAI::InitModules() {
         return false;
     }
 
-    try {
-        // import universe generator script file
-        m_python_module_ai = import("FreeOrionAI");
-    }
-    catch (error_already_set err) {
-        ErrorLogger() << "Unable to import AI script.";
-        throw;
-    }
+    // import universe generator script file
+    m_python_module_ai = import("FreeOrionAI");
 
     DebugLogger() << "AI Python modules successfully initialized!";
     return true;
@@ -164,67 +158,43 @@ void PythonAI::GenerateOrders() {
 }
 
 void PythonAI::HandleChatMessage(int sender_id, const std::string& msg) {
-    try {
-        // call Python function that responds or ignores a chat message
-        object handleChatMessagePythonFunction = m_python_module_ai.attr("handleChatMessage");
-        handleChatMessagePythonFunction(sender_id, msg);
-    } catch (error_already_set err) {
-        PyErr_Print();
-    }
+    // call Python function that responds or ignores a chat message
+    object handleChatMessagePythonFunction = m_python_module_ai.attr("handleChatMessage");
+    handleChatMessagePythonFunction(sender_id, msg);
 }
 
 void PythonAI::HandleDiplomaticMessage(const DiplomaticMessage& msg) {
-    try {
-        // call Python function to inform of diplomatic message change
-        object handleDiplomaticMessagePythonFunction = m_python_module_ai.attr("handleDiplomaticMessage");
-        handleDiplomaticMessagePythonFunction(msg);
-    } catch (error_already_set err) {
-        PyErr_Print();
-    }
+    // call Python function to inform of diplomatic message change
+    object handleDiplomaticMessagePythonFunction = m_python_module_ai.attr("handleDiplomaticMessage");
+    handleDiplomaticMessagePythonFunction(msg);
 }
 
 void PythonAI::HandleDiplomaticStatusUpdate(const DiplomaticStatusUpdateInfo& u) {
-    try {
-        // call Python function to inform of diplomatic status update
-        object handleDiplomaticStatusUpdatePythonFunction = m_python_module_ai.attr("handleDiplomaticStatusUpdate");
-        handleDiplomaticStatusUpdatePythonFunction(u);
-    } catch (error_already_set err) {
-        PyErr_Print();
-    }
+    // call Python function to inform of diplomatic status update
+    object handleDiplomaticStatusUpdatePythonFunction = m_python_module_ai.attr("handleDiplomaticStatusUpdate");
+    handleDiplomaticStatusUpdatePythonFunction(u);
 }
 
 void PythonAI::StartNewGame() {
     FreeOrionPython::ClearStaticSaveStateString();
-    try {
-        // call Python function that sets up the AI to be able to generate orders for a new game
-        object startNewGamePythonFunction = m_python_module_ai.attr("startNewGame");
-        startNewGamePythonFunction(m_aggression);
-    } catch (error_already_set err) {
-        PyErr_Print();
-    }
+    // call Python function that sets up the AI to be able to generate orders for a new game
+    object startNewGamePythonFunction = m_python_module_ai.attr("startNewGame");
+    startNewGamePythonFunction(m_aggression);
 }
 
 void PythonAI::ResumeLoadedGame(const std::string& save_state_string) {
     //DebugLogger() << "PythonAI::ResumeLoadedGame(" << save_state_string << ")";
     FreeOrionPython::SetStaticSaveStateString(save_state_string);
-    try {
-        // call Python function that deals with the new state string sent by the server
-        object resumeLoadedGamePythonFunction = m_python_module_ai.attr("resumeLoadedGame");
-        resumeLoadedGamePythonFunction(FreeOrionPython::GetStaticSaveStateString());
-    } catch (error_already_set err) {
-        PyErr_Print();
-    }
+    // call Python function that deals with the new state string sent by the server
+    object resumeLoadedGamePythonFunction = m_python_module_ai.attr("resumeLoadedGame");
+    resumeLoadedGamePythonFunction(FreeOrionPython::GetStaticSaveStateString());
 }
 
 const std::string& PythonAI::GetSaveStateString() {
-    try {
-        // call Python function that serializes AI state for storage in save file and sets s_save_state_string
-        // to contain that string
-        object prepareForSavePythonFunction = m_python_module_ai.attr("prepareForSave");
-        prepareForSavePythonFunction();
-    } catch (error_already_set err) {
-        PyErr_Print();
-    }
+    // call Python function that serializes AI state for storage in save file and sets s_save_state_string
+    // to contain that string
+    object prepareForSavePythonFunction = m_python_module_ai.attr("prepareForSave");
+    prepareForSavePythonFunction();
     //DebugLogger() << "PythonAI::GetSaveStateString() returning: " << s_save_state_string;
     return FreeOrionPython::GetStaticSaveStateString();
 }

--- a/python/AI/AIFramework.cpp
+++ b/python/AI/AIFramework.cpp
@@ -123,10 +123,7 @@ bool PythonAI::InitModules() {
         ErrorLogger() << "Can't find folder containing AI scripts";
         return false;
     }
-    if (!AddToSysPath(ai_path)) {
-        ErrorLogger() << "Can't add folder containing AI scripts to sys.path";
-        return false;
-    }
+    AddToSysPath(ai_path);
 
     // import universe generator script file
     m_python_module_ai = import("FreeOrionAI");

--- a/python/AI/AIFramework.cpp
+++ b/python/AI/AIFramework.cpp
@@ -97,12 +97,7 @@ BOOST_PYTHON_MODULE(freeOrionAIInterface)
 //////////////////////
 bool PythonAI::Initialize() {
     if (PythonBase::Initialize()) {
-        try {
-            BuildingTypeManager& temp = GetBuildingTypeManager();  // Ensure buildings are initialized
-        } catch (error_already_set err) {
-            PyErr_Print();
-            return false;
-        }
+        BuildingTypeManager& temp = GetBuildingTypeManager();  // Ensure buildings are initialized
         return true;
     }
     else
@@ -138,9 +133,8 @@ bool PythonAI::InitModules() {
         m_python_module_ai = import("FreeOrionAI");
     }
     catch (error_already_set err) {
-        ErrorLogger() << "Unable to import AI script";
-        PyErr_Print();
-        return false;
+        ErrorLogger() << "Unable to import AI script.";
+        throw;
     }
 
     DebugLogger() << "AI Python modules successfully initialized!";

--- a/python/AI/AIFramework.cpp
+++ b/python/AI/AIFramework.cpp
@@ -153,10 +153,12 @@ void PythonAI::GenerateOrders() {
         //DebugLogger() << "PythonAI::GenerateOrders : generating orders";
         generateOrdersPythonFunction();
     } catch (error_already_set err) {
-        PyErr_Print();
-        //DebugLogger() << "PythonAI::GenerateOrders : python error caught and printed";
+        HandleErrorAlreadySet();
+        if (IsPythonRunning())
+            throw;
+
+        ErrorLogger() << "PythonAI::GenerateOrders : Python error caught.  Partial orders sent to server";
         AIInterface::DoneTurn();
-        //DebugLogger() << "PythonAI::GenerateOrders : done with error";
     }
     DebugLogger() << "PythonAI::GenerateOrders order generating time: " << (order_timer.elapsed() * 1000.0);
 }

--- a/python/CommonFramework.cpp
+++ b/python/CommonFramework.cpp
@@ -22,7 +22,6 @@ BOOST_PYTHON_MODULE(freeorion_logger) {
 }
 
 PythonBase::PythonBase() :
-    m_python_interpreter_initialized(false),
 #if defined(FREEORION_MACOSX)
     m_home_dir(""),
     m_program_name(""),
@@ -54,7 +53,6 @@ bool PythonBase::Initialize()
 #endif
         // initializes Python interpreter, allowing Python functions to be called from C++
         Py_Initialize();
-        m_python_interpreter_initialized = true;
         DebugLogger() << "Python initialized";
         DebugLogger() << "Python version: " << Py_GetVersion();
         DebugLogger() << "Python prefix: " << Py_GetPrefix();
@@ -101,10 +99,8 @@ bool PythonBase::Initialize()
 }
 
 void PythonBase::Finalize() {
-    if (m_python_interpreter_initialized) {
+    if (Py_IsInitialized())
         Py_Finalize();
-        m_python_interpreter_initialized = false;
-    }
     DebugLogger() << "Cleaned up FreeOrion Python interface";
 }
 

--- a/python/CommonFramework.cpp
+++ b/python/CommonFramework.cpp
@@ -138,21 +138,17 @@ bool PythonBase::ExecScript(const std::string script) {
     return true;
 }
 
-bool PythonBase::SetCurrentDir(const std::string dir) {
+void PythonBase::SetCurrentDir(const std::string dir) {
     std::string script = "import os\n"
     "os.chdir(r'" + dir + "')\n"
     "print 'Python current directory set to', os.getcwd()";
-    if (!ExecScript(script)) {
-        ErrorLogger() << "Unable to set Python current directory";
-        return false;
-    }
-    return true;
+    exec(script.c_str(), m_namespace, m_namespace);
 }
 
 void PythonBase::AddToSysPath(const std::string dir) {
-    std::string command = "import sys\n"
+    std::string script = "import sys\n"
         "sys.path.append(r'" + dir + "')";
-    exec(command.c_str(), m_namespace, m_namespace);
+    exec(script.c_str(), m_namespace, m_namespace);
 }
 
 void PythonBase::SetErrorModule(object& module)

--- a/python/CommonFramework.cpp
+++ b/python/CommonFramework.cpp
@@ -65,7 +65,7 @@ bool PythonBase::Initialize()
 
     DebugLogger() << "Initializing C++ interfaces for Python";
 
-    systemExit = import("exceptions").attr("SystemExit");
+    m_system_exit = import("exceptions").attr("SystemExit");
     try {
         // get main namespace, needed to run other interpreted code
         object py_main = import("__main__");
@@ -108,7 +108,7 @@ void PythonBase::HandleErrorAlreadySet() {
     }
 
     // Matches system exit
-    if (PyErr_ExceptionMatches(systemExit.ptr()))
+    if (PyErr_ExceptionMatches(m_system_exit.ptr()))
     {
         Finalize();
         ErrorLogger() << "Python interpreter exited with SystemExit(), sys.exit(), exit, quit or some other alias.";
@@ -125,10 +125,6 @@ void PythonBase::Finalize() {
         Py_Finalize();
         DebugLogger() << "Cleaned up FreeOrion Python interface";
     }
-}
-
-void PythonBase::ExecScript(const std::string script) {
-    exec(script.c_str(), m_namespace, m_namespace);
 }
 
 void PythonBase::SetCurrentDir(const std::string dir) {

--- a/python/CommonFramework.cpp
+++ b/python/CommonFramework.cpp
@@ -30,6 +30,10 @@ PythonBase::PythonBase() :
     m_python_module_error(NULL)
 {}
 
+PythonBase::~PythonBase() {
+    Finalize();
+}
+
 bool PythonBase::Initialize()
 {
     DebugLogger() << "Initializing FreeOrion Python interface";

--- a/python/CommonFramework.cpp
+++ b/python/CommonFramework.cpp
@@ -127,15 +127,8 @@ void PythonBase::Finalize() {
     }
 }
 
-bool PythonBase::ExecScript(const std::string script) {
-    try {
-        object ignored = exec(script.c_str(), m_namespace, m_namespace);
-    }
-    catch (error_already_set err) {
-        PyErr_Print();
-        return false;
-    }
-    return true;
+void PythonBase::ExecScript(const std::string script) {
+    exec(script.c_str(), m_namespace, m_namespace);
 }
 
 void PythonBase::SetCurrentDir(const std::string dir) {

--- a/python/CommonFramework.cpp
+++ b/python/CommonFramework.cpp
@@ -176,7 +176,7 @@ std::vector<std::string> PythonBase::ErrorReport() {
         list py_err_list;
         try { py_err_list = extract<list>(f()); }
         catch (error_already_set err) {
-            PyErr_Print();
+            HandleErrorAlreadySet();
             return err_list;
         }
 

--- a/python/CommonFramework.cpp
+++ b/python/CommonFramework.cpp
@@ -99,9 +99,10 @@ bool PythonBase::Initialize()
 }
 
 void PythonBase::Finalize() {
-    if (Py_IsInitialized())
+    if (Py_IsInitialized()) {
         Py_Finalize();
-    DebugLogger() << "Cleaned up FreeOrion Python interface";
+        DebugLogger() << "Cleaned up FreeOrion Python interface";
+    }
 }
 
 bool PythonBase::ExecScript(const std::string script) {

--- a/python/CommonFramework.cpp
+++ b/python/CommonFramework.cpp
@@ -72,8 +72,7 @@ bool PythonBase::Initialize()
         m_namespace = extract<dict>(py_main.attr("__dict__"));
 
         // add the directory containing common Python modules used by all Python scripts to Python sys.path
-        if (!AddToSysPath(GetPythonCommonDir()))
-            return false;
+        AddToSysPath(GetPythonCommonDir());
 
         // allow the "freeorion_logger" C++ module to be imported within Python code
         try {
@@ -150,14 +149,10 @@ bool PythonBase::SetCurrentDir(const std::string dir) {
     return true;
 }
 
-bool PythonBase::AddToSysPath(const std::string dir) {
+void PythonBase::AddToSysPath(const std::string dir) {
     std::string command = "import sys\n"
         "sys.path.append(r'" + dir + "')";
-    if (!ExecScript(command)) {
-        ErrorLogger() << "Unable to add " << dir << " to sys.path";
-        return false;
-    }
-    return true;
+    exec(command.c_str(), m_namespace, m_namespace);
 }
 
 void PythonBase::SetErrorModule(object& module)

--- a/python/CommonFramework.h
+++ b/python/CommonFramework.h
@@ -40,7 +40,6 @@ public:
     bool         Initialize();                         // initializes and runs the Python interpreter, prepares the Python environment
     void         Finalize();                           // stops Python interpreter and releases its resources
     virtual bool InitModules() = 0;                    // initializes Python modules, must be implemented by derived classes
-    void         ExecScript(const std::string script); // executes a Python script or throws error_already_set
     void         SetCurrentDir(const std::string dir); // sets Python current work directory or throws error_already_set
     void         AddToSysPath(const std::string dir);  // adds directory to Python sys.path or throws error_already_set
     void         SetErrorModule(boost::python::object& module); // sets Python module that contains error report function defined on the Python side
@@ -49,7 +48,7 @@ public:
 private:
     // A copy of the systemExit exception to compare with returned
     // exceptions.  It can't be created in the exception handler.
-    boost::python::object systemExit;
+    boost::python::object m_system_exit;
 
     // some helper objects needed to initialize and run the Python interface
 #if defined(FREEORION_MACOSX) || defined(FREEORION_WIN32)

--- a/python/CommonFramework.h
+++ b/python/CommonFramework.h
@@ -29,7 +29,6 @@ public:
 
 private:
     // some helper objects needed to initialize and run the Python interface
-    bool                  m_python_interpreter_initialized;
 #if defined(FREEORION_MACOSX) || defined(FREEORION_WIN32)
     char                  m_home_dir[1024];
     char                  m_program_name[1024];

--- a/python/CommonFramework.h
+++ b/python/CommonFramework.h
@@ -18,6 +18,25 @@ public:
     virtual ~PythonBase();
     //@}
 
+    /**
+       Handles boost::python::error_already_set.
+       If the error is SystemExit the python interpreter is finalized
+       and no longer available.
+
+       Call PyErr_Print() if the exception is an error.
+
+       HandleErrorAlreadySet is idempotent, calling it mutliple times
+       won't crash or hang the process.
+     */
+    void         HandleErrorAlreadySet();
+    /**
+       IsPythonRunning returns true is the python interpreter is
+       initialized.  It is typically called after
+       HandleErrorAlreadySet() to determine if the error caused the
+       interpreter to shutdown.
+     */
+    bool         IsPythonRunning();
+
     bool         Initialize();                         // initializes and runs the Python interpreter, prepares the Python environment
     void         Finalize();                           // stops Python interpreter and releases its resources
     virtual bool InitModules() = 0;                    // initializes Python modules, must be implemented by derived classes
@@ -28,6 +47,10 @@ public:
     std::vector<std::string> ErrorReport();            // wraps call to error report function defined on the Python side
 
 private:
+    // A copy of the systemExit exception to compare with returned
+    // exceptions.  It can't be created in the exception handler.
+    boost::python::object systemExit;
+
     // some helper objects needed to initialize and run the Python interface
 #if defined(FREEORION_MACOSX) || defined(FREEORION_WIN32)
     char                  m_home_dir[1024];

--- a/python/CommonFramework.h
+++ b/python/CommonFramework.h
@@ -42,7 +42,7 @@ public:
     virtual bool InitModules() = 0;                    // initializes Python modules, must be implemented by derived classes
     bool         ExecScript(const std::string script); // executes a Python script
     bool         SetCurrentDir(const std::string dir); // sets Python current work directory
-    bool         AddToSysPath(const std::string dir);  // adds directory to Python sys.patch
+    void         AddToSysPath(const std::string dir);  // adds directory to Python sys.path or throws error_already_set
     void         SetErrorModule(boost::python::object& module); // sets Python module that contains error report function defined on the Python side
     std::vector<std::string> ErrorReport();            // wraps call to error report function defined on the Python side
 

--- a/python/CommonFramework.h
+++ b/python/CommonFramework.h
@@ -41,7 +41,7 @@ public:
     void         Finalize();                           // stops Python interpreter and releases its resources
     virtual bool InitModules() = 0;                    // initializes Python modules, must be implemented by derived classes
     bool         ExecScript(const std::string script); // executes a Python script
-    bool         SetCurrentDir(const std::string dir); // sets Python current work directory
+    void         SetCurrentDir(const std::string dir); // sets Python current work directory or throws error_already_set
     void         AddToSysPath(const std::string dir);  // adds directory to Python sys.path or throws error_already_set
     void         SetErrorModule(boost::python::object& module); // sets Python module that contains error report function defined on the Python side
     std::vector<std::string> ErrorReport();            // wraps call to error report function defined on the Python side

--- a/python/CommonFramework.h
+++ b/python/CommonFramework.h
@@ -40,7 +40,7 @@ public:
     bool         Initialize();                         // initializes and runs the Python interpreter, prepares the Python environment
     void         Finalize();                           // stops Python interpreter and releases its resources
     virtual bool InitModules() = 0;                    // initializes Python modules, must be implemented by derived classes
-    bool         ExecScript(const std::string script); // executes a Python script
+    void         ExecScript(const std::string script); // executes a Python script or throws error_already_set
     void         SetCurrentDir(const std::string dir); // sets Python current work directory or throws error_already_set
     void         AddToSysPath(const std::string dir);  // adds directory to Python sys.path or throws error_already_set
     void         SetErrorModule(boost::python::object& module); // sets Python module that contains error report function defined on the Python side

--- a/python/CommonFramework.h
+++ b/python/CommonFramework.h
@@ -15,6 +15,7 @@ class PythonBase {
 public:
     /** \name ctor */ //@{
     PythonBase();
+    virtual ~PythonBase();
     //@}
 
     bool         Initialize();                         // initializes and runs the Python interpreter, prepares the Python environment

--- a/python/server/ServerFramework.cpp
+++ b/python/server/ServerFramework.cpp
@@ -73,10 +73,7 @@ bool PythonServer::InitModules() {
         ErrorLogger() << "Can't find folder containing universe generation scripts";
         return false;
     }
-    if (!AddToSysPath(GetPythonUniverseGeneratorDir())) {
-        ErrorLogger() << "Can't add folder containing universe generation scripts to sys.path";
-        return false;
-    }
+    AddToSysPath(GetPythonUniverseGeneratorDir());
 
     // import universe generator script file
     m_python_module_universe_generator = import("universe_generator");
@@ -88,10 +85,7 @@ bool PythonServer::InitModules() {
         ErrorLogger() << "Can't find folder containing turn events scripts";
         return false;
     }
-    if (!AddToSysPath(GetPythonTurnEventsDir())) {
-        ErrorLogger() << "Can't add folder containing turn events scripts to sys.path";
-        return false;
-    }
+    AddToSysPath(GetPythonTurnEventsDir());
 
     // import universe generator script file
     m_python_module_turn_events = import("turn_events");

--- a/python/server/ServerFramework.cpp
+++ b/python/server/ServerFramework.cpp
@@ -78,15 +78,8 @@ bool PythonServer::InitModules() {
         return false;
     }
 
-    try {
-        // import universe generator script file
-        m_python_module_universe_generator = import("universe_generator");
-    }
-    catch (error_already_set err) {
-        ErrorLogger() << "Unable to import universe generator script";
-        PyErr_Print();
-        return false;
-    }
+    // import universe generator script file
+    m_python_module_universe_generator = import("universe_generator");
 
     // Confirm existence of the directory containing the turn event Python
     // scripts and add it to Pythons sys.path to make sure Python will find
@@ -100,15 +93,8 @@ bool PythonServer::InitModules() {
         return false;
     }
 
-    try {
-        // import universe generator script file
-        m_python_module_turn_events = import("turn_events");
-    }
-    catch (error_already_set err) {
-        ErrorLogger() << "Unable to import turn events script";
-        PyErr_Print();
-        return false;
-    }
+    // import universe generator script file
+    m_python_module_turn_events = import("turn_events");
 
     DebugLogger() << "Server Python modules successfully initialized!";
     return true;
@@ -135,7 +121,7 @@ bool PythonServer::CreateUniverse(std::map<int, PlayerSetupData>& player_setup_d
     try { success = f(py_player_setup_data); }
     catch (error_already_set err) {
         success = false;
-        PyErr_Print();
+        HandleErrorAlreadySet();
     }
     return success;
 }
@@ -150,7 +136,7 @@ bool PythonServer::ExecuteTurnEvents() {
     try { success = f(); }
     catch (error_already_set err) {
         success = false;
-        PyErr_Print();
+        HandleErrorAlreadySet();
     }
     return success;
 }

--- a/python/server/ServerFramework.cpp
+++ b/python/server/ServerFramework.cpp
@@ -112,27 +112,16 @@ bool PythonServer::CreateUniverse(std::map<int, PlayerSetupData>& player_setup_d
         return false;
     }
 
-    try { success = f(py_player_setup_data); }
-    catch (error_already_set err) {
-        success = false;
-        HandleErrorAlreadySet();
-    }
-    return success;
+    return f(py_player_setup_data);
 }
 
 bool PythonServer::ExecuteTurnEvents() {
-    bool success;
     object f = m_python_module_turn_events.attr("execute_turn_events");
     if (!f) {
         ErrorLogger() << "Unable to call Python function execute_turn_events ";
         return false;
     }
-    try { success = f(); }
-    catch (error_already_set err) {
-        success = false;
-        HandleErrorAlreadySet();
-    }
-    return success;
+    return f();
 }
 
 const std::string GetPythonUniverseGeneratorDir()

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1308,7 +1308,7 @@ void ServerApp::ExecuteScriptedTurnEvents() {
         success = false;
         m_python_server.HandleErrorAlreadySet();
         if (!m_python_server.IsPythonRunning()) {
-            ErrorLogger() << "Python interpreter is no longer running.  Attemting to restart.";
+            ErrorLogger() << "Python interpreter is no longer running.  Attempting to restart.";
             if (m_python_server.Initialize()) {
                 ErrorLogger() << "Python interpreter successfully restarted.";
             } else {

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -150,7 +150,11 @@ ServerApp::ServerApp() :
     GG::Connect(Empires().DiplomaticStatusChangedSignal,  &ServerApp::HandleDiplomaticStatusChange, this);
     GG::Connect(Empires().DiplomaticMessageChangedSignal, &ServerApp::HandleDiplomaticMessageChange,this);
 
-    m_python_server.Initialize();
+    if (!m_python_server.Initialize()) {
+        // TODO: This should throw since the python interpreter is an
+        // essentially resource that can't be acquired.  This is unrecoverable.
+        ErrorLogger() << "Server's python interpreter failed to initialize.";
+    }
 
     m_signals.async_wait(boost::bind(&ServerApp::SignalHandler, this, _1, _2));
 }


### PR DESCRIPTION
This PR addresses issue #524.

It makes handling of python exceptions more consistent, by handling them in a single function and allowing the exceptions to propagate to the level where they can be handled completely.

It creates HandleErrorAlreadySet() which differentiates between exception which are errors and SystemExit types of python exceptions, which are not errors and indicate that the python interpreter has shutdown.  

The errors are printed out with PyErr_Print() and in cases outside of the initialization, the execution loop continues after the error is logged.

All cases of SystemExit exceptions and python errors during initialization are fatal and cause the freeorion server to exit.

The only cases that I know of that can still cause the freeorion server to hang are using the python os module to merge threads that have not been forked, or to cause an exit via terminate.  I don't know how to prevent these.
