### PR TITLE
match default width of map screen and production screen sidepanels

### DIFF
--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -1170,7 +1170,7 @@ void BuildDesignatorWnd::Update() {
 void BuildDesignatorWnd::InitializeWindows() {
     GG::X queue_width(GetOptionsDB().Get<int>("UI.queue-width"));
 
-    const GG::X SIDEPANEL_WIDTH = GG::X(512);
+    const GG::X SIDEPANEL_WIDTH(GetOptionsDB().Get<int>("UI.sidepanel-width"));
     const GG::Y PANEL_HEIGHT    = GG::Y(240);
 
     const GG::Pt pedia_ul(queue_width, GG::Y0);

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -144,6 +144,7 @@ namespace {
 
         db.Add("UI.hide-map-panels",                UserStringNop("OPTIONS_DB_UI_HIDE_MAP_PANELS"),                 false,      Validator<bool>());
 
+        db.Add("UI.sidepanel-width",                UserStringNop("OPTIONS_DB_UI_SIDEPANEL_WIDTH"),                 512,        Validator<int>());
 
         // Register hotkey names/default values for the context "map".
         Hotkey::AddHotkey("map.return_to_map",        UserStringNop("HOTKEY_MAP_RETURN_TO_MAP"),        GG::GGK_ESCAPE);
@@ -1311,9 +1312,11 @@ void MapWnd::DoLayout() {
 }
 
 void MapWnd::InitializeWindows() {
+    const GG::X SIDEPANEL_WIDTH(GetOptionsDB().Get<int>("UI.sidepanel-width"));
+
     // system-view side panel
-    const GG::Pt sidepanel_ul(AppWidth() - GG::X(450), m_toolbar->Bottom());
-    const GG::Pt sidepanel_wh(GG::X(450), AppHeight() - m_toolbar->Height());
+    const GG::Pt sidepanel_ul(AppWidth() - SIDEPANEL_WIDTH, m_toolbar->Bottom());
+    const GG::Pt sidepanel_wh(SIDEPANEL_WIDTH, AppHeight() - m_toolbar->Height());
 
     // situation report window
     const GG::Pt sitrep_ul(SCALE_LINE_MAX_WIDTH + LAYOUT_MARGIN, m_toolbar->Bottom());

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1,4 +1,4 @@
-English
+﻿English
 
 #This is the English String Table file for FreeOrion
 #Translate this file to other languages.
@@ -1031,6 +1031,9 @@ Toggles whether to show a right-click popup menu on the galaxy map.
 
 OPTIONS_DB_UI_HIDE_MAP_PANELS
 Toggles whether the sitrep, pedia etc. panels are temporarily hidden when opening the production window and reopened when closing the production window.
+
+OPTIONS_DB_UI_SIDEPANEL_WIDTH
+Default width for the map and production screen's sidepanel
 
 OPTIONS_DB_STARLANE_THICKNESS
 Sets how wide to render starlanes in pixels.

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1,4 +1,4 @@
-﻿English
+English
 
 #This is the English String Table file for FreeOrion
 #Translate this file to other languages.


### PR DESCRIPTION
(to 512). store value in options-db
