### PR TITLE
Change not auto fleet scouts and cols

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -3171,7 +3171,7 @@ void Empire::CheckProductionProgress() {
                 }
 
                 // rename fleet, given its id and the ship that is in it
-                fleet->Rename(Fleet::GenerateFleetName(ship_ids, fleet->ID()));
+                fleet->Rename(fleet->GenerateFleetName());
                 fleet->SetAggressive(fleet->HasArmedShips());
 
                 if (rally_point_id != INVALID_OBJECT_ID) {

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -231,8 +231,8 @@ namespace {
                 }
             }
 
-            // generate new fleet name
-            std::string fleet_name = Fleet::GenerateFleetName(ship_ids, new_fleet_id);
+            // Request a generated fleet name
+            std::string fleet_name = "";
 
             // add entry to order data
             order_fleet_names.push_back(fleet_name);

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -148,6 +148,24 @@ Fleet %1%
 NEW_FLEET_NAME_NO_NUMBER
 Fleet
 
+NEW_MONSTER_FLEET_NAME
+Herd %1%
+
+NEW_COLONY_FLEET_NAME
+Colony Fleet %1%
+
+NEW_RECON_FLEET_NAME
+Recon Fleet %1%
+
+NEW_TROOP_FLEET_NAME
+Troop Fleet %1%
+
+NEW_BOMBARD_FLEET_NAME
+Bomber Fleet %1%
+
+NEW_BATTLE_FLEET_NAME
+Battle Fleet %1%
+
 # new asteroids or new planet names...
 # used to generate name for effect-created planets, when no name = (string) is specified.
 # When specifying an object name for these effects, if the specified string matches a

--- a/universe/Effect.cpp
+++ b/universe/Effect.cpp
@@ -78,8 +78,7 @@ namespace {
 
         std::vector<int> ship_ids;
         ship_ids.push_back(ship->ID());
-        std::string fleet_name = Fleet::GenerateFleetName(ship_ids, fleet->ID());
-        fleet->Rename(fleet_name);
+        fleet->Rename(fleet->GenerateFleetName());
         fleet->GetMeter(METER_STEALTH)->SetCurrent(Meter::LARGE_VALUE);
 
         fleet->AddShip(ship->ID());

--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -1397,6 +1397,94 @@ std::string Fleet::GenerateFleetName() {
     if (ID() == INVALID_OBJECT_ID)
         return UserString("NEW_FLEET_NAME_NO_NUMBER");
 
+    std::vector<TemporaryPtr<const Ship> > ships;
+    for (std::set<int>::iterator it = m_ships.begin(); it != m_ships.end(); ++it) {
+        if (TemporaryPtr<const Ship> ship = GetShip(*it)) {
+            ships.push_back(ship);
+        }
+    }
+
+    std::vector< TemporaryPtr<const Ship> >::iterator it = ships.begin();
+
+    // TODO C++11 replace all of these loops with std::all_of
+    bool all_monster(true);
+    while (it != ships.end()) {
+        if(!(*it)->IsMonster()) {
+            all_monster = false;
+            break;
+        }
+        ++it;
+    }
+
+    if (all_monster)
+        return boost::io::str(FlexibleFormat(UserString("NEW_MONSTER_FLEET_NAME")) % boost::lexical_cast<std::string>(ID()));
+
+    bool all_colony(true);
+    it = ships.begin();
+    while (it != ships.end()) {
+        if(!(*it)->CanColonize()) {
+            all_colony = false;
+            break;
+        }
+        ++it;
+    }
+
+    if (all_colony)
+        return boost::io::str(FlexibleFormat(UserString("NEW_COLONY_FLEET_NAME")) % boost::lexical_cast<std::string>(ID()));
+
+    bool all_non_coms(true);
+    it = ships.begin();
+    while (it != ships.end()) {
+        if((*it)->IsArmed() || (*it)->CanHaveTroops() || (*it)->CanBombard()) {
+            all_non_coms = false;
+            break;
+        }
+        ++it;
+    }
+
+    if (all_non_coms)
+        return boost::io::str(FlexibleFormat(UserString("NEW_RECON_FLEET_NAME")) % boost::lexical_cast<std::string>(ID()));
+
+    bool all_troop(true);
+    it = ships.begin();
+    while (it != ships.end()) {
+        if(!(*it)->CanHaveTroops()) {
+            all_troop = false;
+            break;
+        }
+        ++it;
+    }
+
+    if (all_troop)
+        return boost::io::str(FlexibleFormat(UserString("NEW_TROOP_FLEET_NAME")) % boost::lexical_cast<std::string>(ID()));
+
+    bool all_bombard(true);
+    it = ships.begin();
+    while (it != ships.end()) {
+        if(!(*it)->CanBombard()) {
+            all_bombard = false;
+            break;
+        }
+        ++it;
+    }
+
+    if (all_bombard)
+        return boost::io::str(FlexibleFormat(UserString("NEW_BOMBARD_FLEET_NAME")) % boost::lexical_cast<std::string>(ID()));
+
+    bool mixed_combat(true);
+    it = ships.begin();
+    while (it != ships.end()) {
+        if(!((*it)->IsArmed() || (*it)->CanHaveTroops() || (*it)->CanBombard())) {
+            mixed_combat = false;
+            break;
+        }
+        ++it;
+    }
+
+    if (mixed_combat)
+        return boost::io::str(FlexibleFormat(UserString("NEW_BATTLE_FLEET_NAME")) % boost::lexical_cast<std::string>(ID()));
+
+
     return boost::io::str(FlexibleFormat(UserString("NEW_FLEET_NAME")) % boost::lexical_cast<std::string>(ID()));
 }
 

--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -1404,12 +1404,12 @@ std::string Fleet::GenerateFleetName() {
         }
     }
 
-    std::vector< TemporaryPtr<const Ship> >::iterator it = ships.begin();
+    std::vector<TemporaryPtr<const Ship> >::iterator it = ships.begin();
 
     // TODO C++11 replace all of these loops with std::all_of
     bool all_monster(true);
     while (it != ships.end()) {
-        if(!(*it)->IsMonster()) {
+        if (!(*it)->IsMonster()) {
             all_monster = false;
             break;
         }
@@ -1422,7 +1422,7 @@ std::string Fleet::GenerateFleetName() {
     bool all_colony(true);
     it = ships.begin();
     while (it != ships.end()) {
-        if(!(*it)->CanColonize()) {
+        if (!(*it)->CanColonize()) {
             all_colony = false;
             break;
         }
@@ -1435,7 +1435,7 @@ std::string Fleet::GenerateFleetName() {
     bool all_non_coms(true);
     it = ships.begin();
     while (it != ships.end()) {
-        if((*it)->IsArmed() || (*it)->CanHaveTroops() || (*it)->CanBombard()) {
+        if ((*it)->IsArmed() || (*it)->CanHaveTroops() || (*it)->CanBombard()) {
             all_non_coms = false;
             break;
         }
@@ -1448,7 +1448,7 @@ std::string Fleet::GenerateFleetName() {
     bool all_troop(true);
     it = ships.begin();
     while (it != ships.end()) {
-        if(!(*it)->CanHaveTroops()) {
+        if (!(*it)->CanHaveTroops()) {
             all_troop = false;
             break;
         }
@@ -1461,7 +1461,7 @@ std::string Fleet::GenerateFleetName() {
     bool all_bombard(true);
     it = ships.begin();
     while (it != ships.end()) {
-        if(!(*it)->CanBombard()) {
+        if (!(*it)->CanBombard()) {
             all_bombard = false;
             break;
         }
@@ -1474,7 +1474,7 @@ std::string Fleet::GenerateFleetName() {
     bool mixed_combat(true);
     it = ships.begin();
     while (it != ships.end()) {
-        if(!((*it)->IsArmed() || (*it)->CanHaveTroops() || (*it)->CanBombard())) {
+        if (!((*it)->IsArmed() || (*it)->CanHaveTroops() || (*it)->CanBombard())) {
             mixed_combat = false;
             break;
         }

--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -1391,13 +1391,13 @@ void Fleet::ShortenRouteToEndAtSystem(std::list<int>& travel_route, int last_sys
         travel_route.push_back(*m_travel_route.begin());
 }
 
-std::string Fleet::GenerateFleetName(const std::vector<int>& ship_ids, int new_fleet_id) {
+std::string Fleet::GenerateFleetName() {
     // TODO: Change returned name based on passed ship designs.  eg. return "colony fleet" if
     // ships are colony ships, or "battle fleet" if ships are armed.
-    if (new_fleet_id == INVALID_OBJECT_ID)
+    if (ID() == INVALID_OBJECT_ID)
         return UserString("NEW_FLEET_NAME_NO_NUMBER");
 
-    return boost::io::str(FlexibleFormat(UserString("NEW_FLEET_NAME")) % boost::lexical_cast<std::string>(new_fleet_id));
+    return boost::io::str(FlexibleFormat(UserString("NEW_FLEET_NAME")) % boost::lexical_cast<std::string>(ID()));
 }
 
 void Fleet::SetGiveToEmpire(int empire_id) {

--- a/universe/Fleet.h
+++ b/universe/Fleet.h
@@ -122,8 +122,8 @@ public:
     virtual void            ResetTargetMaxUnpairedMeters();
     //@}
 
-    /* returns a name for a fleet based on the specified \a ship_ids */
-    static std::string      GenerateFleetName(const std::vector<int>& ship_ids, int new_fleet_id = INVALID_OBJECT_ID);
+    /* returns a name for a fleet based on its ships*/
+    std::string      GenerateFleetName();
 
     static const int            ETA_NEVER;                                  ///< returned by ETA when fleet can't reach destination due to lack of route or inability to move
     static const int            ETA_UNKNOWN;                                ///< returned when ETA can't be determined

--- a/universe/Ship.cpp
+++ b/universe/Ship.cpp
@@ -337,6 +337,11 @@ float Ship::TroopCapacity() const {
     return retval;
 }
 
+bool Ship::CanHaveTroops() const {
+    const ShipDesign* design = Design();
+    return design ? design->HasTroops() : false;
+}
+
 const std::string& Ship::PublicName(int empire_id) const {
     // Disclose real ship name only to fleet owners. Rationale: a player who
     // doesn't know the design for a particular ship can easily guess it if the

--- a/universe/Ship.h
+++ b/universe/Ship.h
@@ -37,6 +37,7 @@ public:
     bool                        IsArmed() const;
     bool                        CanColonize() const;
     bool                        HasTroops() const;
+    bool                        CanHaveTroops() const;
     bool                        CanBombard() const;
     const std::string&          SpeciesName() const         { return m_species_name; }
     float                       Speed() const;

--- a/util/Order.cpp
+++ b/util/Order.cpp
@@ -163,11 +163,11 @@ void NewFleetOrder::ExecuteImpl() const {
 
     GetUniverse().InhibitUniverseObjectSignals(true);
     std::vector<TemporaryPtr<Fleet> > created_fleets;
-    created_fleets.reserve(m_fleet_names.size());
+    created_fleets.reserve(m_ship_id_groups.size());
 
 
     // create fleet for each group of ships
-    for (int i = 0; i < static_cast<int>(m_fleet_names.size()); ++i) {
+    for (int i = 0; i < static_cast<int>(m_ship_id_groups.size()); ++i) {
         const std::string&      fleet_name =    m_fleet_names[i];
         int                     fleet_id =      m_fleet_ids[i];
         const std::vector<int>& ship_ids =      m_ship_id_groups[i];
@@ -227,6 +227,9 @@ void NewFleetOrder::ExecuteImpl() const {
             ship->SetFleetID(fleet->ID());
         }
         fleet->AddShips(validated_ships_ids);
+
+        if (fleet_name.empty())
+            fleet->Rename(fleet->GenerateFleetName());
 
         created_fleets.push_back(fleet);
     }


### PR DESCRIPTION
Please use the following as the merge message.

---------------------snip --------------------------------------
1. Names fleets based on their function: Colony, Recon, Troop, Bomber, Combat and Herd.
2. Prevent non-combat fleets from automatically merging.  Colony and Recon ships are immediately useful for sending to new planets.
