### PR TITLE
Improve sound system initialization.

### DIFF
--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -1121,8 +1121,7 @@ void OptionsWnd::DoneClicked()
     m_done = true;
 }
 
-void OptionsWnd::SoundOptionsFeedback::SoundEffectsEnableClicked(bool checked)
-{
+void OptionsWnd::SoundOptionsFeedback::SoundEffectsEnableClicked(bool checked) {
     if (checked) {
         try {
             Sound::GetSound().Enable();
@@ -1138,8 +1137,7 @@ void OptionsWnd::SoundOptionsFeedback::SoundEffectsEnableClicked(bool checked)
     }
 }
 
-void OptionsWnd::SoundOptionsFeedback::MusicClicked(bool checked)
-{
+void OptionsWnd::SoundOptionsFeedback::MusicClicked(bool checked) {
     if (checked) {
         try {
             Sound::GetSound().Enable();
@@ -1156,24 +1154,22 @@ void OptionsWnd::SoundOptionsFeedback::MusicClicked(bool checked)
     }
 }
 
-void OptionsWnd::SoundOptionsFeedback::MusicVolumeSlid(int pos, int low, int high) const
-{
+void OptionsWnd::SoundOptionsFeedback::MusicVolumeSlid(int pos, int low, int high) const {
     GetOptionsDB().Set("UI.sound.music-volume", pos);
     Sound::GetSound().SetMusicVolume(pos);
 }
 
-void OptionsWnd::SoundOptionsFeedback::UISoundsVolumeSlid(int pos, int low, int high) const
-{
+void OptionsWnd::SoundOptionsFeedback::UISoundsVolumeSlid(int pos, int low, int high) const {
     GetOptionsDB().Set("UI.sound.volume", pos);
     Sound::GetSound().SetUISoundsVolume(pos);
     Sound::GetSound().PlaySound(GetOptionsDB().Get<std::string>("UI.sound.button-click"), true);
 }
 
 void OptionsWnd::SoundOptionsFeedback::SetMusicButton(GG::StateButton* button)
-{ m_music_button = button;}
+{ m_music_button = button; }
 
 void OptionsWnd::SoundOptionsFeedback::SetEffectsButton(GG::StateButton* button)
-{ m_effects_button = button;}
+{ m_effects_button = button; }
 
 void OptionsWnd::SoundOptionsFeedback::SoundInitializationFailure(std::runtime_error const &e) {
     if (std::string(e.what()) != "ERROR_SOUND_INITIALIZATION_FAILED")

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -875,7 +875,7 @@ void OptionsWnd::VolumeOption(GG::ListBox* page, int indentation_level, const st
     button->SetBrowseText(UserString(GetOptionsDB().GetDescription(toggle_option_name)));
     slider->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
     slider->SetBrowseText(UserString(GetOptionsDB().GetDescription(volume_option_name)));
-    GG::Connect(button->CheckedSignal, SetOptionFunctor<bool>(toggle_option_name));
+    GG::Connect(button->CheckedSignal, &OptionsWnd::SoundEffectsEnableClicked, this);
     GG::Connect(slider->SlidAndStoppedSignal, volume_slider_handler, this);
 }
 
@@ -1118,14 +1118,29 @@ void OptionsWnd::DoneClicked()
     m_done = true;
 }
 
+void OptionsWnd::SoundEffectsEnableClicked(bool checked) const
+{
+    if (checked) {
+        GetOptionsDB().Set("UI.sound.enabled", true);
+        Sound::GetSound().Enable(true);
+    } else {
+        GetOptionsDB().Set("UI.sound.enabled", false);
+        if (!GetOptionsDB().Get<bool>("UI.sound.music-enabled"))
+            Sound::GetSound().Enable(false);
+    }
+}
+
 void OptionsWnd::MusicClicked(bool checked)
 {
     if (checked) {
         GetOptionsDB().Set("UI.sound.music-enabled", true);
+        Sound::GetSound().Enable(true);
         Sound::GetSound().PlayMusic(GetOptionsDB().Get<std::string>("UI.sound.bg-music"), -1);
     } else {
         GetOptionsDB().Set("UI.sound.music-enabled", false);
         Sound::GetSound().StopMusic();
+        if (!GetOptionsDB().Get<bool>("UI.sound.enabled"))
+            Sound::GetSound().Enable(false);
     }
 }
 

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -1127,7 +1127,7 @@ void OptionsWnd::SoundOptionsFeedback::SoundEffectsEnableClicked(bool checked) {
             Sound::GetSound().Enable();
             GetOptionsDB().Set("UI.sound.enabled", true);
             Sound::GetSound().PlaySound(GetOptionsDB().Get<std::string>("UI.sound.button-click"), true);
-        } catch (std::runtime_error const &e) {
+        } catch (Sound::InitializationFailureException const &e) {
             SoundInitializationFailure(e);
         }
     } else {
@@ -1143,7 +1143,7 @@ void OptionsWnd::SoundOptionsFeedback::MusicClicked(bool checked) {
             Sound::GetSound().Enable();
             GetOptionsDB().Set("UI.sound.music-enabled", true);
             Sound::GetSound().PlayMusic(GetOptionsDB().Get<std::string>("UI.sound.bg-music"), -1);
-        } catch (std::runtime_error const &e) {
+        } catch (Sound::InitializationFailureException const &e) {
             SoundInitializationFailure(e);
         }
     } else {
@@ -1171,10 +1171,7 @@ void OptionsWnd::SoundOptionsFeedback::SetMusicButton(GG::StateButton* button)
 void OptionsWnd::SoundOptionsFeedback::SetEffectsButton(GG::StateButton* button)
 { m_effects_button = button; }
 
-void OptionsWnd::SoundOptionsFeedback::SoundInitializationFailure(std::runtime_error const &e) {
-    if (std::string(e.what()) != "ERROR_SOUND_INITIALIZATION_FAILED")
-        throw;
-
+void OptionsWnd::SoundOptionsFeedback::SoundInitializationFailure(Sound::InitializationFailureException const &e) {
     GetOptionsDB().Set("UI.sound.enabled", false);
     GetOptionsDB().Set("UI.sound.music-enabled", false);
     if (m_effects_button)

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -1123,6 +1123,7 @@ void OptionsWnd::SoundEffectsEnableClicked(bool checked) const
     if (checked) {
         GetOptionsDB().Set("UI.sound.enabled", true);
         Sound::GetSound().Enable(true);
+        Sound::GetSound().PlaySound(GetOptionsDB().Get<std::string>("UI.sound.button-click"), true);
     } else {
         GetOptionsDB().Set("UI.sound.enabled", false);
         if (!GetOptionsDB().Get<bool>("UI.sound.music-enabled"))

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -403,8 +403,8 @@ OptionsWnd::OptionsWnd():
     // Audio settings tab
     current_page = CreatePage(UserString("OPTIONS_PAGE_AUDIO"));
     CreateSectionHeader(current_page, 0, UserString("OPTIONS_VOLUME_AND_MUSIC"));
-    MusicVolumeOption(current_page, 0);
-    VolumeOption(current_page, 0, "UI.sound.enabled", "UI.sound.volume", UserString("OPTIONS_UI_SOUNDS"), &OptionsWnd::UISoundsVolumeSlid, UI_sound_enabled);
+    MusicVolumeOption(current_page, 0, m_sound_feedback);
+    VolumeOption(current_page, 0, "UI.sound.enabled", "UI.sound.volume", UserString("OPTIONS_UI_SOUNDS"), UI_sound_enabled, m_sound_feedback);
     FileOption(current_page, 0, "UI.sound.bg-music", UserString("OPTIONS_BACKGROUND_MUSIC"), ClientUI::SoundDir(),
                std::make_pair(UserString("OPTIONS_MUSIC_FILE"), "*" + MUSIC_FILE_SUFFIX),
                ValidMusicFile);
@@ -831,7 +831,7 @@ GG::Spin<double>* OptionsWnd::DoubleOption(GG::ListBox* page, int indentation_le
     return spin;
 }
 
-void OptionsWnd::MusicVolumeOption(GG::ListBox* page, int indentation_level) {
+void OptionsWnd::MusicVolumeOption(GG::ListBox* page, int indentation_level, SoundOptionsFeedback &fb) {
     GG::ListBox::Row* row = new GG::ListBox::Row();
     GG::StateButton* button = new CUIStateButton(UserString("OPTIONS_MUSIC"), GG::FORMAT_LEFT, boost::make_shared<CUICheckBoxRepresenter>());
     button->Resize(button->MinUsableSize());
@@ -850,12 +850,14 @@ void OptionsWnd::MusicVolumeOption(GG::ListBox* page, int indentation_level) {
     button->SetBrowseText(UserString(GetOptionsDB().GetDescription("UI.sound.music-enabled")));
     slider->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
     slider->SetBrowseText(UserString(GetOptionsDB().GetDescription("UI.sound.music-volume")));
-    GG::Connect(button->CheckedSignal, &OptionsWnd::MusicClicked, this);
-    GG::Connect(slider->SlidSignal, &OptionsWnd::MusicVolumeSlid, this);
+    fb.SetMusicButton(button);
+    GG::Connect(button->CheckedSignal, &OptionsWnd::SoundOptionsFeedback::MusicClicked, &fb);
+    GG::Connect(slider->SlidSignal, &OptionsWnd::SoundOptionsFeedback::MusicVolumeSlid, &fb);
 }
 
-void OptionsWnd::VolumeOption(GG::ListBox* page, int indentation_level, const std::string& toggle_option_name, const std::string& volume_option_name, const std::string& text,
-                              VolumeSliderHandler volume_slider_handler, bool toggle_value)
+void OptionsWnd::VolumeOption(GG::ListBox* page, int indentation_level, const std::string& toggle_option_name,
+                              const std::string& volume_option_name, const std::string& text,
+                              bool toggle_value, SoundOptionsFeedback &fb)
 {
     GG::ListBox::Row* row = new GG::ListBox::Row();
     GG::StateButton* button = new CUIStateButton(text, GG::FORMAT_LEFT, boost::make_shared<CUICheckBoxRepresenter>());
@@ -875,8 +877,9 @@ void OptionsWnd::VolumeOption(GG::ListBox* page, int indentation_level, const st
     button->SetBrowseText(UserString(GetOptionsDB().GetDescription(toggle_option_name)));
     slider->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
     slider->SetBrowseText(UserString(GetOptionsDB().GetDescription(volume_option_name)));
-    GG::Connect(button->CheckedSignal, &OptionsWnd::SoundEffectsEnableClicked, this);
-    GG::Connect(slider->SlidAndStoppedSignal, volume_slider_handler, this);
+    fb.SetEffectsButton(button);
+    GG::Connect(button->CheckedSignal,        &OptionsWnd::SoundOptionsFeedback::SoundEffectsEnableClicked, &fb);
+    GG::Connect(slider->SlidAndStoppedSignal, &OptionsWnd::SoundOptionsFeedback::UISoundsVolumeSlid, &fb);
 }
 
 void OptionsWnd::FileOptionImpl(GG::ListBox* page, int indentation_level, const std::string& option_name, const std::string& text, const fs::path& path,
@@ -1118,42 +1121,69 @@ void OptionsWnd::DoneClicked()
     m_done = true;
 }
 
-void OptionsWnd::SoundEffectsEnableClicked(bool checked) const
+void OptionsWnd::SoundOptionsFeedback::SoundEffectsEnableClicked(bool checked)
 {
     if (checked) {
-        GetOptionsDB().Set("UI.sound.enabled", true);
-        Sound::GetSound().Enable(true);
-        Sound::GetSound().PlaySound(GetOptionsDB().Get<std::string>("UI.sound.button-click"), true);
+        try {
+            Sound::GetSound().Enable();
+            GetOptionsDB().Set("UI.sound.enabled", true);
+            Sound::GetSound().PlaySound(GetOptionsDB().Get<std::string>("UI.sound.button-click"), true);
+        } catch (std::runtime_error const &e) {
+            SoundInitializationFailure(e);
+        }
     } else {
         GetOptionsDB().Set("UI.sound.enabled", false);
         if (!GetOptionsDB().Get<bool>("UI.sound.music-enabled"))
-            Sound::GetSound().Enable(false);
+            Sound::GetSound().Disable();
     }
 }
 
-void OptionsWnd::MusicClicked(bool checked)
+void OptionsWnd::SoundOptionsFeedback::MusicClicked(bool checked)
 {
     if (checked) {
-        GetOptionsDB().Set("UI.sound.music-enabled", true);
-        Sound::GetSound().Enable(true);
-        Sound::GetSound().PlayMusic(GetOptionsDB().Get<std::string>("UI.sound.bg-music"), -1);
+        try {
+            Sound::GetSound().Enable();
+            GetOptionsDB().Set("UI.sound.music-enabled", true);
+            Sound::GetSound().PlayMusic(GetOptionsDB().Get<std::string>("UI.sound.bg-music"), -1);
+        } catch (std::runtime_error const &e) {
+            SoundInitializationFailure(e);
+        }
     } else {
         GetOptionsDB().Set("UI.sound.music-enabled", false);
         Sound::GetSound().StopMusic();
         if (!GetOptionsDB().Get<bool>("UI.sound.enabled"))
-            Sound::GetSound().Enable(false);
+            Sound::GetSound().Disable();
     }
 }
 
-void OptionsWnd::MusicVolumeSlid(int pos, int low, int high)
+void OptionsWnd::SoundOptionsFeedback::MusicVolumeSlid(int pos, int low, int high) const
 {
     GetOptionsDB().Set("UI.sound.music-volume", pos);
     Sound::GetSound().SetMusicVolume(pos);
 }
 
-void OptionsWnd::UISoundsVolumeSlid(int pos, int low, int high)
+void OptionsWnd::SoundOptionsFeedback::UISoundsVolumeSlid(int pos, int low, int high) const
 {
     GetOptionsDB().Set("UI.sound.volume", pos);
     Sound::GetSound().SetUISoundsVolume(pos);
     Sound::GetSound().PlaySound(GetOptionsDB().Get<std::string>("UI.sound.button-click"), true);
+}
+
+void OptionsWnd::SoundOptionsFeedback::SetMusicButton(GG::StateButton* button)
+{ m_music_button = button;}
+
+void OptionsWnd::SoundOptionsFeedback::SetEffectsButton(GG::StateButton* button)
+{ m_effects_button = button;}
+
+void OptionsWnd::SoundOptionsFeedback::SoundInitializationFailure(std::runtime_error const &e) {
+    if (std::string(e.what()) != "ERROR_SOUND_INITIALIZATION_FAILED")
+        throw;
+
+    GetOptionsDB().Set("UI.sound.enabled", false);
+    GetOptionsDB().Set("UI.sound.music-enabled", false);
+    if (m_effects_button)
+        m_effects_button->SetCheck(false);
+    if (m_music_button)
+        m_music_button->SetCheck(false);
+    ClientUI::MessageBox(UserString(e.what()), false);
 }

--- a/UI/OptionsWnd.h
+++ b/UI/OptionsWnd.h
@@ -55,6 +55,7 @@ private:
     void                ResolutionOption(GG::ListBox* page, int indentation_level);
 
     void                DoneClicked();
+    void                SoundEffectsEnableClicked(bool checked) const;
     void                MusicClicked(bool checked);
     void                MusicVolumeSlid(int pos, int low, int high);
     void                UISoundsVolumeSlid(int pos, int low, int high);

--- a/UI/OptionsWnd.h
+++ b/UI/OptionsWnd.h
@@ -7,6 +7,7 @@
 #include <GG/GGFwd.h>
 
 #include "CUIWnd.h"
+#include "Sound.h"
 
 
 //! This is a dialog box that allows the user to control certain basic game parameters, such as sound and music
@@ -58,7 +59,7 @@ private:
         /** Handles a sound initialization failure by setting sound
             effects and music enable check boxes to disabled and
             informing the player with a popup message box.*/
-        void SoundInitializationFailure(std::runtime_error const &e);
+        void SoundInitializationFailure(Sound::InitializationFailureException const &e);
 
     private:
         GG::StateButton* m_effects_button;

--- a/UI/OptionsWnd.h
+++ b/UI/OptionsWnd.h
@@ -31,6 +31,8 @@ protected:
 
 private:
 
+    /**SoundOptionsFeedback enables immediate player feedback when
+       sound options are changed.*/
     class SoundOptionsFeedback {
     public:
         SoundOptionsFeedback() :
@@ -38,13 +40,24 @@ private:
             m_music_button(0)
         {}
 
+        /** Stores a pointer to  the sound effects check box.*/
         void SetEffectsButton(GG::StateButton * const button);
+        /** Stores pointer to music enable check box.*/
         void SetMusicButton(GG::StateButton * const button);
 
+        /**Enables/disables sound effects when the sound effects check
+           box is clicked.*/
         void SoundEffectsEnableClicked(bool checked);
+        /**Enables/disables background music when the music check
+           box is clicked.*/
         void MusicClicked(bool checked);
+        /** Adjusts the music volume.*/
         void MusicVolumeSlid(int pos, int low, int high) const;
+        /** Adjusts the effects volume.*/
         void UISoundsVolumeSlid(int pos, int low, int high) const;
+        /** Handles a sound initialization failure by setting sound
+            effects and music enable check boxes to disabled and
+            informing the player with a popup message box.*/
         void SoundInitializationFailure(std::runtime_error const &e);
 
     private:

--- a/UI/OptionsWnd.h
+++ b/UI/OptionsWnd.h
@@ -30,7 +30,27 @@ protected:
     virtual GG::Rect CalculatePosition() const;
 
 private:
-    typedef void (OptionsWnd::* VolumeSliderHandler)(int, int, int);
+
+    class SoundOptionsFeedback {
+    public:
+        SoundOptionsFeedback() :
+            m_effects_button(0),
+            m_music_button(0)
+        {}
+
+        void SetEffectsButton(GG::StateButton * const button);
+        void SetMusicButton(GG::StateButton * const button);
+
+        void SoundEffectsEnableClicked(bool checked);
+        void MusicClicked(bool checked);
+        void MusicVolumeSlid(int pos, int low, int high) const;
+        void UISoundsVolumeSlid(int pos, int low, int high) const;
+        void SoundInitializationFailure(std::runtime_error const &e);
+
+    private:
+        GG::StateButton* m_effects_button;
+        GG::StateButton* m_music_button;
+    };
 
     void                DoLayout();
 
@@ -41,9 +61,10 @@ private:
     GG::Spin<int>*      IntOption(GG::ListBox* page, int indentation_level, const std::string& option_name, const std::string& text);
     GG::Spin<double>*   DoubleOption(GG::ListBox* page, int indentation_level, const std::string& option_name, const std::string& text);
     void                HotkeyOption(GG::ListBox* page, int indentation_level, const std::string& hotkey_name);
-    void                MusicVolumeOption(GG::ListBox* page, int indentation_level);
-    void                VolumeOption(GG::ListBox* page, int indentation_level, const std::string& toggle_option_name, const std::string& volume_option_name, const std::string& text,
-                                     VolumeSliderHandler volume_slider_handler, bool toggle_value);
+    void                MusicVolumeOption(GG::ListBox* page, int indentation_level, SoundOptionsFeedback &fb);
+    void                VolumeOption(GG::ListBox* page, int indentation_level, const std::string& toggle_option_name,
+                                     const std::string& volume_option_name, const std::string& text, bool toggle_value,
+                                     SoundOptionsFeedback &fb);
     void                FileOptionImpl(GG::ListBox* page, int indentation_level, const std::string& option_name, const std::string& text, const boost::filesystem::path& path, const std::vector<std::pair<std::string, std::string> >& filters, StringValidator string_validator, bool directory, bool relative_path);
     void                FileOption(GG::ListBox* page, int indentation_level, const std::string& option_name, const std::string& text, const boost::filesystem::path& path, StringValidator string_validator = 0);
     void                FileOption(GG::ListBox* page, int indentation_level, const std::string& option_name, const std::string& text, const boost::filesystem::path& path, const std::pair<std::string, std::string>& filter, StringValidator string_validator = 0);
@@ -55,13 +76,13 @@ private:
     void                ResolutionOption(GG::ListBox* page, int indentation_level);
 
     void                DoneClicked();
-    void                SoundEffectsEnableClicked(bool checked) const;
-    void                MusicClicked(bool checked);
-    void                MusicVolumeSlid(int pos, int low, int high);
-    void                UISoundsVolumeSlid(int pos, int low, int high);
 
     GG::TabWnd* m_tabs;
     GG::Button* m_done_button;
+
+    // Enable and disable the sound when audio options are changed.
+    SoundOptionsFeedback m_sound_feedback;
+
 };
 
 #endif // _OptionsWnd_h_

--- a/UI/OptionsWnd.h
+++ b/UI/OptionsWnd.h
@@ -40,10 +40,10 @@ private:
             m_music_button(0)
         {}
 
-        /** Stores a pointer to  the sound effects check box.*/
-        void SetEffectsButton(GG::StateButton * const button);
+        /** Stores a pointer to the sound effects check box.*/
+        void SetEffectsButton(GG::StateButton* const button);
         /** Stores pointer to music enable check box.*/
-        void SetMusicButton(GG::StateButton * const button);
+        void SetMusicButton(GG::StateButton* const button);
 
         /**Enables/disables sound effects when the sound effects check
            box is clicked.*/

--- a/UI/Sound.cpp
+++ b/UI/Sound.cpp
@@ -272,7 +272,7 @@ void Sound::SoundImpl::InitOpenAL() {
     device = alcOpenDevice(0);    /* currently only select the default output device - usually a NULL-terminated
                                    * string desctribing a device can be passed here (of type ALchar*) */
     if (device == 0) {
-        ErrorLogger() << "Unable to initialise OpenAL device: " << alGetString(alGetError()) << "\n";
+        ErrorLogger() << "Unable to initialise default OpenAL device.";
         m_initialized = false;
         return;
     }

--- a/UI/Sound.cpp
+++ b/UI/Sound.cpp
@@ -3,6 +3,8 @@
 #include "../util/OptionsDB.h"
 #include "../util/Directories.h"
 
+#include <boost/scoped_array.hpp>
+
 #ifdef FREEORION_MACOSX
 # include <OpenAL/alc.h>
 #else
@@ -95,7 +97,7 @@ namespace {
         ALenum m_openal_error;
         int endian = 0; /// 0 for little-endian (x86), 1 for big-endian (ppc)
         int bitStream,bytes,bytes_new;
-        char* array = new char[buffer_size];
+        boost::scoped_array<char> array(new char[buffer_size]);
         bytes = 0;
 
         if (alcGetCurrentContext() != 0) {
@@ -114,19 +116,16 @@ namespace {
                 }
             } while ((buffer_size - bytes) > 4096);
             if (bytes > 0) {
-                alBufferData(bufferName, ogg_format, array, static_cast < ALsizei > (bytes), ogg_freq);
+                alBufferData(bufferName, ogg_format, array.get(), static_cast < ALsizei > (bytes), ogg_freq);
                 m_openal_error = alGetError();
                 if (m_openal_error != AL_NONE)
                     ErrorLogger() << "RefillBuffer: OpenAL ERROR: " << alGetString(m_openal_error);
             } else {
                 ov_clear(ogg_file); // the app might think we still have something to play.
-                delete [] array;
                 return 1;
             }
-            delete [] array;
             return 0;
         }
-        delete [] array;
         return 1;
     }
 }

--- a/UI/Sound.cpp
+++ b/UI/Sound.cpp
@@ -452,11 +452,9 @@ void Sound::SoundImpl::StopMusic() {
     if (!m_initialized)
         return;
 
-    if (alcGetCurrentContext() != 0)
-    {
+    if (alcGetCurrentContext() != 0) {
         alSourceStop(m_sources[0]);
-        if (m_music_name.size() > 0)
-        {
+        if (m_music_name.size() > 0) {
             m_music_name.clear();  // do this to avoid music being re-started by other functions
             ov_clear(&m_ogg_file); // and unload the file for good measure. the file itself is closed now, don't re-close it again
         }
@@ -491,16 +489,14 @@ void Sound::SoundImpl::PlaySound(const boost::filesystem::path& path, bool is_ui
     };
 #endif
 
-    if (alcGetCurrentContext() != 0)
-    {
+    if (alcGetCurrentContext() != 0) {
         /* First check if the sound data of the file we want to play is already buffered somewhere */
         std::map<std::string, ALuint>::iterator it = m_buffers.find(filename);
         if (it != m_buffers.end()) {
             current_buffer = it->second;
             found_buffer = true;
         } else {
-            if ((file = fopen(filename.c_str(), "rb")) != 0) // make sure we CAN open it
-            {
+            if ((file = fopen(filename.c_str(), "rb")) != 0) { // make sure we CAN open it
                 OggVorbis_File ogg_file;
                 vorbis_info *vorbis_info;
                 ALenum ogg_format;

--- a/UI/Sound.cpp
+++ b/UI/Sound.cpp
@@ -94,7 +94,7 @@ namespace {
     int _fseek64_wrap(FILE *f, ogg_int64_t off, int whence) {
         if (!f)
             return -1;
-        return fseek(f,off,whence);
+        return fseek(f, off, whence);
     }
 #endif
 
@@ -103,7 +103,7 @@ namespace {
     {
         ALenum m_openal_error;
         int endian = 0; /// 0 for little-endian (x86), 1 for big-endian (ppc)
-        int bitStream,bytes,bytes_new;
+        int bitStream, bytes, bytes_new;
         boost::scoped_array<char> array(new char[buffer_size]);
         bytes = 0;
 
@@ -116,7 +116,7 @@ namespace {
                     if (loops != 0) {   // enter here if we need to play the same file again
                         if (loops > 0)
                             loops--;
-                        ov_time_seek(ogg_file,0.0); // rewind to beginning
+                        ov_time_seek(ogg_file, 0.0); // rewind to beginning
                     }
                     else
                         break;
@@ -287,9 +287,9 @@ void Sound::SoundImpl::InitOpenAL() {
         return;
     }
 
-    alListenerf(AL_GAIN,1.0);
+    alListenerf(AL_GAIN, 1.0);
     error_code = alGetError();
-    if(error_code != AL_NO_ERROR) {
+    if (error_code != AL_NO_ERROR) {
         ErrorLogger() << "Unable to create OpenAL listener: " << alGetString(error_code) << "\n" << "Disabling OpenAL sound system!\n";
         alcMakeContextCurrent(0);
         alcDestroyContext(context);
@@ -300,7 +300,7 @@ void Sound::SoundImpl::InitOpenAL() {
 
     alGenSources(NUM_SOURCES, m_sources);
     error_code = alGetError();
-    if(error_code != AL_NO_ERROR) {
+    if (error_code != AL_NO_ERROR) {
         ErrorLogger() << "Unable to create OpenAL sources: " << alGetString(error_code) << "\n" << "Disabling OpenAL sound system!\n";
         alcMakeContextCurrent(0);
         alcDestroyContext(context);
@@ -416,10 +416,10 @@ void Sound::SoundImpl::PlayMusic(const boost::filesystem::path& path, int loops 
                 /* fill up the buffers and queue them up for the first time */
                 if (!RefillBuffer(&m_ogg_file, m_ogg_format, m_ogg_freq, m_music_buffers[0], BUFFER_SIZE, m_music_loops))
                 {
-                    alSourceQueueBuffers(m_sources[0],1,&m_music_buffers[0]); // queue up the buffer if we manage to fill it
+                    alSourceQueueBuffers(m_sources[0], 1, &m_music_buffers[0]); // queue up the buffer if we manage to fill it
                     if (!RefillBuffer(&m_ogg_file, m_ogg_format, m_ogg_freq, m_music_buffers[1], BUFFER_SIZE, m_music_loops))
                     {
-                        alSourceQueueBuffers(m_sources[0],1,&m_music_buffers[1]);
+                        alSourceQueueBuffers(m_sources[0], 1, &m_music_buffers[1]);
                         m_music_name = filename; // yup, we're playing something that takes up more than 2 buffers
                     }
                     else
@@ -448,8 +448,7 @@ void Sound::SoundImpl::PlayMusic(const boost::filesystem::path& path, int loops 
         ErrorLogger() << "PlayMusic: OpenAL ERROR: " << alGetString(m_openal_error);
 }
 
-void Sound::SoundImpl::StopMusic()
-{
+void Sound::SoundImpl::StopMusic() {
     if (!m_initialized)
         return;
 
@@ -465,8 +464,7 @@ void Sound::SoundImpl::StopMusic()
     }
 }
 
-void Sound::SoundImpl::PlaySound(const boost::filesystem::path& path, bool is_ui_sound/* = false*/)
-{
+void Sound::SoundImpl::PlaySound(const boost::filesystem::path& path, bool is_ui_sound/* = false*/) {
     if (!m_initialized || !GetOptionsDB().Get<bool>("UI.sound.enabled") || (is_ui_sound && UISoundsTemporarilyDisabled()))
         return;
 
@@ -549,7 +547,7 @@ void Sound::SoundImpl::PlaySound(const boost::filesystem::path& path, bool is_ui
         if (found_buffer) {
             /* Now that we have the buffer, we need to find a source to send it to */
             for (m_i = 1; m_i < NUM_SOURCES; ++m_i) {   // as we're playing sounds we start at 1. 0 is reserved for music
-                alGetSourcei(m_sources[m_i],AL_SOURCE_STATE,&source_state);
+                alGetSourcei(m_sources[m_i], AL_SOURCE_STATE, &source_state);
                 if ((source_state != AL_PLAYING) && (source_state != AL_PAUSED)) {
                     found_source = true;
                     alSourcei(m_sources[m_i], AL_BUFFER, current_buffer);
@@ -620,7 +618,7 @@ void Sound::SoundImpl::SetMusicVolume(int vol) {
     GetOptionsDB().Set<int>("UI.sound.music-volume", vol);
     if (alcGetCurrentContext() != 0)
     {
-        alSourcef(m_sources[0],AL_GAIN, ((ALfloat) vol)/255.0);
+        alSourcef(m_sources[0], AL_GAIN, ((ALfloat) vol)/255.0);
         /* it is highly unlikely that we'll get an error here but better safe than sorry */
         m_openal_error = alGetError();
         if (m_openal_error != AL_NONE)
@@ -639,7 +637,7 @@ void Sound::SoundImpl::SetUISoundsVolume(int vol) {
     GetOptionsDB().Set<int>("UI.sound.volume", vol);
     if (alcGetCurrentContext() != 0) {
         for (int it = 1; it < NUM_SOURCES; ++it)
-            alSourcef(m_sources[it],AL_GAIN, ((ALfloat) vol)/255.0);
+            alSourcef(m_sources[it], AL_GAIN, ((ALfloat) vol)/255.0);
         /* it is highly unlikely that we'll get an error here but better safe than sorry */
         m_openal_error = alGetError();
         if (m_openal_error != AL_NONE)
@@ -655,7 +653,7 @@ void Sound::SoundImpl::DoFrame() {
     int      num_buffers_processed;
 
     if ((alcGetCurrentContext() != 0) && (m_music_name.size() > 0)) {
-        alGetSourcei(m_sources[0],AL_BUFFERS_PROCESSED,&num_buffers_processed);
+        alGetSourcei(m_sources[0], AL_BUFFERS_PROCESSED, &num_buffers_processed);
         while (num_buffers_processed > 0) {
             ALuint buffer_name_yay;
             alSourceUnqueueBuffers (m_sources[0], 1, &buffer_name_yay);
@@ -664,7 +662,7 @@ void Sound::SoundImpl::DoFrame() {
                 m_music_name.clear();  // m_music_name.clear() must always be called before ov_clear. Otherwise
                 break; /// this happens if RefillBuffer returns 1, meaning it encountered EOF and the file shouldn't be repeated
             }
-            alSourceQueueBuffers(m_sources[0],1,&buffer_name_yay);
+            alSourceQueueBuffers(m_sources[0], 1, &buffer_name_yay);
             num_buffers_processed--;
         }
         alGetSourcei(m_sources[0], AL_SOURCE_STATE, &state);

--- a/UI/Sound.cpp
+++ b/UI/Sound.cpp
@@ -250,52 +250,51 @@ void Sound::SoundImpl::InitOpenAL() {
         ErrorLogger() << "Unable to initialise OpenAL device: " << alGetString(alGetError()) << "\n";
         m_initialized = false;
         return;
-    } else {
-        m_context = alcCreateContext(m_device, 0);   // instead of 0 we can pass a ALCint* pointing to a set of
-        // attributes (ALC_FREQUENCY, ALC_REFRESH and ALC_SYNC)
-
-        if ((m_context != 0) && (alcMakeContextCurrent(m_context) == AL_TRUE)) {
-            alListenerf(AL_GAIN,1.0);
-            alGetError(); // clear possible previous errors (just to be certain)
-            alGenSources(NUM_SOURCES, m_sources);
-            error_code = alGetError();
-            if(error_code != AL_NO_ERROR) {
-                ErrorLogger() << "Unable to create OpenAL sources: " << alGetString(error_code) << "\n" << "Disabling OpenAL sound system!\n";
-                alcMakeContextCurrent(0);
-                alcDestroyContext(m_context);
-                m_initialized = false;
-                return;
-            } else {
-                alGetError();
-                alGenBuffers(NUM_MUSIC_BUFFERS, m_music_buffers);
-                error_code = alGetError();
-                if (error_code != AL_NO_ERROR) {
-                    ErrorLogger() << "Unable to create OpenAL buffers: " << alGetString(error_code) << "\n" << "Disabling OpenAL sound system!\n";
-                    alDeleteBuffers(NUM_MUSIC_BUFFERS, m_music_buffers);
-                    alcMakeContextCurrent(0);
-                    alcDestroyContext(m_context);
-                    m_initialized = false;
-                    return;
-                } else {
-                    for (int i = 0; i < NUM_SOURCES; ++i) {
-                        alSourcei(m_sources[i], AL_SOURCE_RELATIVE, AL_TRUE);
-                    }
-                    DebugLogger() << "OpenAL initialized. Version "
-                                  << alGetString(AL_VERSION)
-                                  << "Renderer "
-                                  << alGetString(AL_RENDERER)
-                                  << "Vendor "
-                                  << alGetString(AL_VENDOR) << "\n"
-                                  << "Extensions: "
-                                  << alGetString(AL_EXTENSIONS) << "\n";
-                }
-            }
-        } else {
-            ErrorLogger() << "Unable to create OpenAL context : " << alGetString(alGetError()) << "\n";
-            m_initialized = false;
-            return;
-        }
     }
+
+    m_context = alcCreateContext(m_device, 0);   // instead of 0 we can pass a ALCint* pointing to a set of
+    // attributes (ALC_FREQUENCY, ALC_REFRESH and ALC_SYNC)
+
+    if (!((m_context != 0) && (alcMakeContextCurrent(m_context) == AL_TRUE))) {
+        ErrorLogger() << "Unable to create OpenAL context : " << alGetString(alGetError()) << "\n";
+        m_initialized = false;
+        return;
+    }
+
+    alListenerf(AL_GAIN,1.0);
+    alGetError(); // clear possible previous errors (just to be certain)
+    alGenSources(NUM_SOURCES, m_sources);
+    error_code = alGetError();
+    if(error_code != AL_NO_ERROR) {
+        ErrorLogger() << "Unable to create OpenAL sources: " << alGetString(error_code) << "\n" << "Disabling OpenAL sound system!\n";
+        alcMakeContextCurrent(0);
+        alcDestroyContext(m_context);
+        m_initialized = false;
+        return;
+    }
+
+    alGenBuffers(NUM_MUSIC_BUFFERS, m_music_buffers);
+    error_code = alGetError();
+    if (error_code != AL_NO_ERROR) {
+        ErrorLogger() << "Unable to create OpenAL buffers: " << alGetString(error_code) << "\n" << "Disabling OpenAL sound system!\n";
+        alDeleteBuffers(NUM_MUSIC_BUFFERS, m_music_buffers);
+        alcMakeContextCurrent(0);
+        alcDestroyContext(m_context);
+        m_initialized = false;
+        return;
+    }
+
+    for (int i = 0; i < NUM_SOURCES; ++i) {
+        alSourcei(m_sources[i], AL_SOURCE_RELATIVE, AL_TRUE);
+    }
+    DebugLogger() << "OpenAL initialized. Version "
+                  << alGetString(AL_VERSION)
+                  << " Renderer "
+                  << alGetString(AL_RENDERER)
+                  << " Vendor "
+                  << alGetString(AL_VENDOR) << "\n"
+                  << " Extensions: "
+                  << alGetString(AL_EXTENSIONS) << "\n";
     m_initialized = true;
 }
 

--- a/UI/Sound.cpp
+++ b/UI/Sound.cpp
@@ -23,7 +23,7 @@ public:
     SoundImpl();  ///< ctor.
     ~SoundImpl(); ///< dotr.
 
-    /** Enables the sound system.  Throws runtime_error on failure. */
+    /** Enables the sound system.  Throws Sound::InitializationFailureException on failure. */
     void Enable();
 
     /** Disable the sound system. */
@@ -215,9 +215,10 @@ Sound::SoundImpl::SoundImpl() :
 
     try {
         Enable();
-    } catch (std::runtime_error const & e) {
-        if (std::string(e.what()) != "ERROR_SOUND_INITIALIZATION_FAILED")
-            throw;
+    } catch (InitializationFailureException const&) {
+        // Bury the exception because the GetSound() singleton may cause
+        // the sound system to initialize at unpredictable times when
+        // the user can't be usefully informed of the failure.
     }
 }
 
@@ -239,7 +240,7 @@ void Sound::SoundImpl::Enable() {
         ErrorLogger() "Unable to initialize audio.  Sound effects and music are disabled.";
         // TODO: Let InitOpenAL throw the OpenAL error message which
         // might be more useful.
-        throw std::runtime_error("ERROR_SOUND_INITIALIZATION_FAILED");
+        throw InitializationFailureException("ERROR_SOUND_INITIALIZATION_FAILED");
     }
 
     DebugLogger() << "Audio " << (m_initialized ? "enabled." : "disabled.");

--- a/UI/Sound.cpp
+++ b/UI/Sound.cpp
@@ -224,13 +224,6 @@ void Sound::SoundImpl::Enable(bool enable) {
 
         StopMusic();
 
-        if (alcGetCurrentContext() != 0) {
-            alDeleteSources(NUM_SOURCES, m_sources); // Automatically stops currently playing sources
-
-            alDeleteBuffers(NUM_MUSIC_BUFFERS, m_music_buffers);
-            for (std::map<std::string, ALuint>::iterator itr = m_buffers.begin(); itr != m_buffers.end(); ++itr)
-                alDeleteBuffers(1, &itr->second );
-        }
         ShutdownOpenAL();
 
         m_initialized = false;
@@ -307,6 +300,14 @@ void Sound::SoundImpl::InitOpenAL() {
 }
 
 void Sound::SoundImpl::ShutdownOpenAL() {
+
+    if (alcGetCurrentContext() != 0) {
+        alDeleteSources(NUM_SOURCES, m_sources); // Automatically stops currently playing sources
+
+        alDeleteBuffers(NUM_MUSIC_BUFFERS, m_music_buffers);
+        for (std::map<std::string, ALuint>::iterator itr = m_buffers.begin(); itr != m_buffers.end(); ++itr)
+            alDeleteBuffers(1, &itr->second );
+    }
 
     ALCcontext* context = alcGetCurrentContext();
     if (context != 0) {

--- a/UI/Sound.cpp
+++ b/UI/Sound.cpp
@@ -16,7 +16,7 @@ namespace {
     const int BUFFER_SIZE = 409600; // The size of the buffer we read music data into.
 
     /// Initialize OpenAl and return true on success.
-    bool InitOpenAL(int num_sources, ALuint *sources, ALuint *music_buffers) {
+    bool InitOpenAL(int num_sources, ALuint *sources, int num_music_buffers, ALuint *music_buffers) {
         ALCcontext *m_context;
         ALCdevice *m_device;
         ALenum error_code;
@@ -42,11 +42,11 @@ namespace {
                     return false;
                 } else {
                     alGetError();
-                    alGenBuffers(2, music_buffers);
+                    alGenBuffers(num_music_buffers, music_buffers);
                     error_code = alGetError();
                     if (error_code != AL_NO_ERROR) {
                         ErrorLogger() << "Unable to create OpenAL buffers: " << alGetString(error_code) << "\n" << "Disabling OpenAL sound system!\n";
-                        alDeleteBuffers(2, music_buffers);
+                        alDeleteBuffers(num_music_buffers, music_buffers);
                         alcMakeContextCurrent(0);
                         alcDestroyContext(m_context);
                         return false;
@@ -175,7 +175,7 @@ void Sound::Enable(bool enable) {
         return;
 
     if (enable) {
-        m_initialized = InitOpenAL(NUM_SOURCES, m_sources, m_music_buffers);
+        m_initialized = InitOpenAL(NUM_SOURCES, m_sources, NUM_MUSIC_BUFFERS, m_music_buffers);
     } else {
 
         StopMusic();
@@ -183,7 +183,7 @@ void Sound::Enable(bool enable) {
         if (alcGetCurrentContext() != 0) {
             alDeleteSources(NUM_SOURCES, m_sources); // Automatically stops currently playing sources
 
-            alDeleteBuffers(2, m_music_buffers);
+            alDeleteBuffers(NUM_MUSIC_BUFFERS, m_music_buffers);
             for (std::map<std::string, ALuint>::iterator itr = m_buffers.begin(); itr != m_buffers.end(); ++itr)
                 alDeleteBuffers(1, &itr->second );
         }

--- a/UI/Sound.h
+++ b/UI/Sound.h
@@ -19,7 +19,7 @@ public:
         ~TempUISoundDisabler();
     };
 
-    /** Returns the singleton instance of Sound. */
+    /** Returns the singleton instance of Sound.*/
     static Sound& GetSound();
 
     /** Plays a music file.  The file will be played in an infinitve loop if \a loop is < 0, and it will be played \a
@@ -47,8 +47,11 @@ public:
     /** Does the work that must be done by the sound system once per frame. */
     void DoFrame();
 
-    /** Enables(disables) the sound system if enable is true(false).. */
-    void Enable(bool enable);
+    /** Enables the sound system.  Throws runtime_error on failure. */
+    void Enable();
+
+    /** Disable the sound system. */
+    void Disable();
 
 private:
     class SoundImpl;

--- a/UI/Sound.h
+++ b/UI/Sound.h
@@ -19,6 +19,11 @@ public:
         ~TempUISoundDisabler();
     };
 
+    class InitializationFailureException : public std::runtime_error {
+    public:
+        explicit InitializationFailureException(const std::string& s) : std::runtime_error(s) {}
+    };
+
     /** Returns the singleton instance of Sound.*/
     static Sound& GetSound();
 

--- a/UI/Sound.h
+++ b/UI/Sound.h
@@ -56,6 +56,9 @@ public:
     /** Does the work that must be done by the sound system once per frame. */
     void DoFrame();
 
+    /** Enables(disables) the sound system if enable is true(false).. */
+    void Enable(bool enable);
+
 private:
     Sound();  ///< ctor.
     ~Sound(); ///< dotr.
@@ -73,6 +76,10 @@ private:
     ALenum                            m_ogg_format;           ///< mono or stereo
     ALsizei                           m_ogg_freq;             ///< sampling frequency
     unsigned int                      m_temporary_disable_count; ///< Count of the number of times sound was disabled. Sound is enabled when this is zero.
+    /** m_initialized indicates if the sound system has been initialized.
+        The system will not be initialized if both sound effects and
+        music are disabled or if initialization failed. */
+    bool                              m_initialized;
 };
 
 #endif // _Sound_h_

--- a/UI/Sound.h
+++ b/UI/Sound.h
@@ -66,12 +66,13 @@ private:
     bool UISoundsTemporarilyDisabled() const;
 
     static const int NUM_SOURCES = 16; // The number of sources for OpenAL to create. Should be 2 or more.
+    static const int NUM_MUSIC_BUFFERS = 2; // The number of music buffers.
 
     ALuint                            m_sources[NUM_SOURCES]; ///< OpenAL sound sources. The first one is used for music
     int                               m_music_loops;          ///< the number of loops of the current music to play (< 0 for loop forever)
     std::string                       m_music_name;           ///< the name of the currently-playing music file
     std::map<std::string, ALuint>     m_buffers;              ///< the currently-cached (and possibly playing) sounds, if any; keyed on filename
-    ALuint                            m_music_buffers[2];     ///< two additional buffers for music. statically defined as they'll be changed many times.
+    ALuint                            m_music_buffers[NUM_MUSIC_BUFFERS];     ///< two additional buffers for music. statically defined as they'll be changed many times.
     OggVorbis_File                    m_ogg_file;             ///< the currently open ogg file
     ALenum                            m_ogg_format;           ///< mono or stereo
     ALsizei                           m_ogg_freq;             ///< sampling frequency

--- a/UI/Sound.h
+++ b/UI/Sound.h
@@ -1,17 +1,8 @@
 #ifndef _Sound_h_
 #define _Sound_h_
 
-#ifdef FREEORION_MACOSX
-# include <OpenAL/al.h>
-#else
-# include <AL/al.h>
-#endif
-
-#include <vorbis/vorbisfile.h>
-
 #include <boost/filesystem/path.hpp>
-
-#include <map>
+#include <boost/scoped_ptr.hpp>
 
 
 class Sound
@@ -60,27 +51,12 @@ public:
     void Enable(bool enable);
 
 private:
+    class SoundImpl;
+    // TODO use C++11 unique_ptr
+    boost::scoped_ptr<SoundImpl> const pimpl;
     Sound();  ///< ctor.
     ~Sound(); ///< dotr.
 
-    bool UISoundsTemporarilyDisabled() const;
-
-    static const int NUM_SOURCES = 16; // The number of sources for OpenAL to create. Should be 2 or more.
-    static const int NUM_MUSIC_BUFFERS = 2; // The number of music buffers.
-
-    ALuint                            m_sources[NUM_SOURCES]; ///< OpenAL sound sources. The first one is used for music
-    int                               m_music_loops;          ///< the number of loops of the current music to play (< 0 for loop forever)
-    std::string                       m_music_name;           ///< the name of the currently-playing music file
-    std::map<std::string, ALuint>     m_buffers;              ///< the currently-cached (and possibly playing) sounds, if any; keyed on filename
-    ALuint                            m_music_buffers[NUM_MUSIC_BUFFERS];     ///< two additional buffers for music. statically defined as they'll be changed many times.
-    OggVorbis_File                    m_ogg_file;             ///< the currently open ogg file
-    ALenum                            m_ogg_format;           ///< mono or stereo
-    ALsizei                           m_ogg_freq;             ///< sampling frequency
-    unsigned int                      m_temporary_disable_count; ///< Count of the number of times sound was disabled. Sound is enabled when this is zero.
-    /** m_initialized indicates if the sound system has been initialized.
-        The system will not be initialized if both sound effects and
-        music are disabled or if initialization failed. */
-    bool                              m_initialized;
 };
 
 #endif // _Sound_h_

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -220,13 +220,26 @@ HumanClientApp::HumanClientApp(int width, int height, bool calculate_fps, const 
 
     SetMinDragTime(0);
 
+    bool inform_user_sound_failed(false);
+    try {
+        if (GetOptionsDB().Get<bool>("UI.sound.enabled") || GetOptionsDB().Get<bool>("UI.sound.music-enabled"))
+            Sound::GetSound().Enable();
+
+        if ((GetOptionsDB().Get<bool>("UI.sound.music-enabled")))
+            Sound::GetSound().PlayMusic(GetOptionsDB().Get<std::string>("UI.sound.bg-music"), -1);
+
+        Sound::GetSound().SetMusicVolume(GetOptionsDB().Get<int>("UI.sound.music-volume"));
+        Sound::GetSound().SetUISoundsVolume(GetOptionsDB().Get<int>("UI.sound.volume"));
+    } catch (std::runtime_error const & e) {
+        if (std::string(e.what()) != "ERROR_SOUND_INITIALIZATION_FAILED")
+            throw;
+        inform_user_sound_failed = true;
+    }
+
     m_ui = boost::shared_ptr<ClientUI>(new ClientUI());
 
-    if ((GetOptionsDB().Get<bool>("UI.sound.music-enabled")))
-        Sound::GetSound().PlayMusic(GetOptionsDB().Get<std::string>("UI.sound.bg-music"), -1);
-
-    Sound::GetSound().SetMusicVolume(GetOptionsDB().Get<int>("UI.sound.music-volume"));
-    Sound::GetSound().SetUISoundsVolume(GetOptionsDB().Get<int>("UI.sound.volume"));
+    if (inform_user_sound_failed)
+        ClientUI::MessageBox(UserString("ERROR_SOUND_INITIALIZATION_FAILED"), false);
 
     EnableFPS();
     UpdateFPSLimit();

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -238,9 +238,6 @@ HumanClientApp::HumanClientApp(int width, int height, bool calculate_fps, const 
 
     m_ui = boost::shared_ptr<ClientUI>(new ClientUI());
 
-    if (inform_user_sound_failed)
-        ClientUI::MessageBox(UserString("ERROR_SOUND_INITIALIZATION_FAILED"), false);
-
     EnableFPS();
     UpdateFPSLimit();
     GG::Connect(GetOptionsDB().OptionChangedSignal("show-fps"), &HumanClientApp::UpdateFPSLimit, this);
@@ -304,6 +301,11 @@ HumanClientApp::HumanClientApp(int width, int height, bool calculate_fps, const 
     if (fake_mode_change && !FramebuffersAvailable()) {
         ErrorLogger() << "Requested fake mode changes, but the framebuffer opengl extension is not available. Ignoring.";
     }
+
+    // Placed after mouse initialization.
+    if (inform_user_sound_failed)
+        ClientUI::MessageBox(UserString("ERROR_SOUND_INITIALIZATION_FAILED"), false);
+
     m_fsm->initiate();
 }
 

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -230,9 +230,7 @@ HumanClientApp::HumanClientApp(int width, int height, bool calculate_fps, const 
 
         Sound::GetSound().SetMusicVolume(GetOptionsDB().Get<int>("UI.sound.music-volume"));
         Sound::GetSound().SetUISoundsVolume(GetOptionsDB().Get<int>("UI.sound.volume"));
-    } catch (std::runtime_error const & e) {
-        if (std::string(e.what()) != "ERROR_SOUND_INITIALIZATION_FAILED")
-            throw;
+    } catch (Sound::InitializationFailureException const &) {
         inform_user_sound_failed = true;
     }
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -211,6 +211,15 @@ Unowned
 NOWHERE
 Cannot be produced
 
+#############################################################
+####               M A J O R   E R R O R S               ####
+#############################################################
+
+ERROR_SOUND_INITIALIZATION_FAILED
+'''OpenAL audio system initialization failed.
+Check log files for more detailed messages.
+'''
+
 ################################## 
 # FORMAT_LIST items are for lists of the form
 # FORMAT_LIST_HEADER FORMAT_LIST_x_ITEMS


### PR DESCRIPTION
This is an attempt address the issues in #705.

I was not able to duplicate the problem.  However, I simulated the problem by crashing the OpenAL initialization at various points.  

Part of the problem may be that the OpenAL system is initialized even when sound is disabled.  This PR fixes that problem.

Parts of the OpenAL initialization were not checked for errors.  This PR fixes that problem.

Parts of the OpenAL system leaked during failed initialization.  This PR fixes that problem.

This PR adds popups on UI initialization and in the options window if sound system initialization fails.

It also prevents enabling either music or sound effects in the options window if the sound system can't be initialized.

I'm very ambivalent about the popup during initialization. Since there will be no sound the user will know that something is broken and probably check the logs without prompting.  I'd be happy to remove this popup, I only added it to be symmetrical with the popup in the Options window.

The popup in the Options window is the only way to inform the user why the sound effects and music check boxes aren't responding.

If the user in [the forum link](http://freeorion.org/forum/viewtopic.php?f=25&t=9736) is still crashing on startup before they can get to the options screen and disable the audio, then manual changing their config.xml or persistent_config.xml  to include the following will disable audio:

``` xml
<?xml version="1.0"?>
<XMLDoc>
  <UI>
    <sound>
      <enabled>0</enabled>
      <music-enabled>0</music-enabled>
    </sound>
  </UI>
</XMLDoc>
```

Please use the following as the merge message.

---------------------------- Snip here -----------------------------------------------------------
Improve sound system initialization.
1. Prevent initializing OpenAL when both music and sound effects are disabled.
2. Check all OpenAL errors during initialization and fail of any error.
3. Release all OpenAL constructs on failed initialization or disabling of sound system.
4. Inform user with a MessageBox of sound system intialization failure at startup and in Options window.
5. Prevent OptionsWnd from enabling music or sound effects check box when sound system fails to initialize.
6. Add a click noise to sound effects enabling check box.

------------------------------------Snip here --------------------------------------------------------
