### PR TITLE
Append planet ordinal on creation

### DIFF
--- a/default/python/universe_generation/starsystems.py
+++ b/default/python/universe_generation/starsystems.py
@@ -54,16 +54,21 @@ def name_planets(system):
     """
     planet_number = 1
     # iterate over all planets in the system
-    for planet in fo.sys_get_planets(system):
+    for planet in fo.sys_get_planets_by_orbit(system):
+        if planet == fo.invalid_object():
+            continue
+        planet_type = fo.planet_get_type(planet)
+        name = fo.user_string("NEW_PLANET_NAME")
+        name = name.replace("%1%", fo.get_name(system))
         # use different naming methods for "normal" planets and asteroid belts
-        if fo.planet_get_type(planet) == fo.planetType.asteroids:
-            # get localized text from stringtable
-            name = fo.user_string("PL_ASTEROID_BELT_OF_SYSTEM")
-            # %1% parameter in the localized string is the system name
-            name = name.replace("%1%", fo.get_name(system))
+        if planet_type == fo.planetType.asteroids:
+            # get defined orbit suffix
+            name = name.replace("%2%", fo.planet_get_orbital_suffix(planet))
         else:
             # set name to system name + planet number as roman number...
-            name = fo.get_name(system) + " " + fo.roman_number(planet_number)
+            # TODO This has the potential of duplicate names
+            #   if a new planet is created in this system later
+            name = name.replace("%2%", fo.roman_number(planet_number))
             # ...and increase planet number
             planet_number += 1
         # do the actual renaming

--- a/default/scripting/fields/fields.macros
+++ b/default/scripting/fields/fields.macros
@@ -99,19 +99,19 @@ EFFECT_CREATE_PLANET
 '''CreatePlanet
     type = OneOf(Barren, Desert, Inferno, Ocean, Radiated, Swamp, Terran, Toxic, Tundra)
     planetsize = OneOf(tiny, small, medium, large)
-    name = UserString("NEW_PLANET_NAME") % Target.Name
+    name = UserString("NEW_PLANET_NAME") % Target.Name % Target.OrbitalSuffix
 '''
 
 EFFECT_CREATE_ASTEROID
 '''CreatePlanet
     type = asteroids
     planetsize = asteroids
-    name = UserString("NEW_ASTEROIDS_NAME") % Target.Name % Source.Name
+    name = UserString("NEW_ASTEROIDS_NAME") % Target.Name % Source.Name % Target.OrbitalSuffix
 '''
 
 EFFECT_CREATE_GASGIANT
 '''CreatePlanet
     type = GasGiant
     planetsize = GasGiant
-    name = UserString("NEW_PLANET_NAME") % Target.Name
+    name = UserString("NEW_PLANET_NAME") % Target.Name % Target.OrbitalSuffix
 '''

--- a/default/scripting/fields/fields.macros
+++ b/default/scripting/fields/fields.macros
@@ -106,7 +106,7 @@ EFFECT_CREATE_ASTEROID
 '''CreatePlanet
     type = asteroids
     planetsize = asteroids
-    name = UserString("NEW_ASTEROIDS_NAME") % Target.Name % Source.Name % Target.OrbitalSuffix
+    name = UserString("NEW_PLANET_NAME") % Target.Name % Target.OrbitalSuffix
 '''
 
 EFFECT_CREATE_GASGIANT

--- a/default/stringtables/de.txt
+++ b/default/stringtables/de.txt
@@ -190,17 +190,15 @@ Bomberflotte %1%
 NEW_BATTLE_FLEET_NAME
 Kriegsflotte %1%
 
-# Name for a newly created asteroid belt.
-# %1% name of the system this asteroid belt is created in.
-# %2% orbit number where this asteroid belt is created on.
-NEW_ASTEROIDS_NAME
-Überreste von %1% %2%
-
-# Name for a newly created planet. When creating a new planet it is assumed this
-# planet is the first one within the system.
-# %1% name of the system this planet is created in.
+# This string remains as a non-compile mechanisim to override the default name of new planets.
+# This string remains as a non-compile mechanisim to override the default name of new planets.
+# Planet suffix is a roman number, except for asteriods which are unique (see NEW_ASTEROID_SUFFIX_ORBIT_I)
+# During universe generaton, the roman number is ordinal with other non-asteroids, in order of orbit
+# For all other instances, the roman number is the orbital position of the planet
+# %1% represents the system name
+# %2% represents the planet suffix
 #NEW_PLANET_NAME
-#%1% I
+#%1% %2%
 
 EMPTY_SPACE
 Tiefe des Alls

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -191,15 +191,17 @@ Bomber Fleet %1%
 NEW_BATTLE_FLEET_NAME
 Battle Fleet %1%
 
-# Name for a newly created asteroid belt.
-# %1% name of the system this asteroid belt is created in.
-# %2% orbit number where this asteroid belt is created on.
-NEW_ASTEROIDS_NAME
-%1% %2% %3%
-
+# This string remains as a non-compile mechanisim to override the default name of new planets.
+# Planet suffix is a roman number, except for asteriods which are unique (see NEW_ASTEROID_SUFFIX_ORBIT_I)
+# During universe generaton, the roman number is ordinal with other non-asteroids, in order of orbit
+# For all other instances, the roman number is the orbital position of the planet
+# %1% represents the system name
+# %2% represents the planet suffix
 NEW_PLANET_NAME
 %1% %2%
 
+# Asteroid suffixes are appended to the default name when a new asteroid is created.
+# Each orbit position is able to have a unique suffix.
 NEW_ASTEROID_SUFFIX_ORBIT_I
 [[PL_ASTEROID_BELT]]
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -195,13 +195,31 @@ Battle Fleet %1%
 # %1% name of the system this asteroid belt is created in.
 # %2% orbit number where this asteroid belt is created on.
 NEW_ASTEROIDS_NAME
-%1% %2% remnants
+%1% %2% %3%
 
-# Name for a newly created planet. When creating a new planet it is assumed this
-# planet is the first one within the system.
-# %1% name of the system this planet is created in.
 NEW_PLANET_NAME
-%1% I
+%1% %2%
+
+NEW_ASTEROID_SUFFIX_ORBIT_I
+[[PL_ASTEROID_BELT]]
+
+NEW_ASTEROID_SUFFIX_ORBIT_II
+[[PL_ASTEROID_BELT]]
+
+NEW_ASTEROID_SUFFIX_ORBIT_III
+[[PL_ASTEROID_BELT]]
+
+NEW_ASTEROID_SUFFIX_ORBIT_IV
+[[PL_ASTEROID_BELT]]
+
+NEW_ASTEROID_SUFFIX_ORBIT_V
+[[PL_ASTEROID_BELT]]
+
+NEW_ASTEROID_SUFFIX_ORBIT_VI
+[[PL_ASTEROID_BELT]]
+
+NEW_ASTEROID_SUFFIX_ORBIT_VII
+[[PL_ASTEROID_BELT]]
 
 EMPTY_SPACE
 Deep Space

--- a/default/stringtables/fr.txt
+++ b/default/stringtables/fr.txt
@@ -191,17 +191,15 @@ Flotte Bombardement %1%
 NEW_BATTLE_FLEET_NAME
 Flotte Combat %1%
 
-# Name for a newly created asteroid belt.
-# %1% name of the system this asteroid belt is created in.
-# %2% orbit number where this asteroid belt is created on.
-NEW_ASTEROIDS_NAME
-Rémanent %2% %1%
-
-# Name for a newly created planet. When creating a new planet it is assumed this
-# planet is the first one within the system.
-# %1% name of the system this planet is created in.
+# This string remains as a non-compile mechanisim to override the default name of new planets.
+# This string remains as a non-compile mechanisim to override the default name of new planets.
+# Planet suffix is a roman number, except for asteriods which are unique (see NEW_ASTEROID_SUFFIX_ORBIT_I)
+# During universe generaton, the roman number is ordinal with other non-asteroids, in order of orbit
+# For all other instances, the roman number is the orbital position of the planet
+# %1% represents the system name
+# %2% represents the planet suffix
 #NEW_PLANET_NAME
-#%1% I
+#%1% %2%
 
 EMPTY_SPACE
 Espace Interstellaire

--- a/parse/StringValueRefParser.cpp
+++ b/parse/StringValueRefParser.cpp
@@ -81,6 +81,7 @@ namespace { struct string_parser_rules {
                 |    tok.BuildingType_
                 |    tok.Focus_
                 |    tok.PreferredFocus_
+                |    tok.OrbitalSuffix_
                 ;
 
             constant

--- a/parse/Tokens.h
+++ b/parse/Tokens.h
@@ -259,6 +259,7 @@
     (Orange)                                    \
     (Orbit)                                     \
     (OrderedBombardedBy)                        \
+    (OrbitalSuffix)                             \
     (OriginalType)                              \
     (OutpostsOwned)                             \
     (OwnedBy)                                   \

--- a/python/server/ServerWrapper.cpp
+++ b/python/server/ServerWrapper.cpp
@@ -994,6 +994,20 @@ namespace {
         return py_planets;
     }
 
+    list SystemGetPlanetsByOrbit(int system_id) {
+        list py_planets;
+        TemporaryPtr<System> cur_system = GetSystem(system_id);
+        if (!cur_system) {
+            ErrorLogger() << "SystemGetPlanetsByOrbit : Couldn't get system with ID " << system_id;
+            return py_planets;
+        }
+        const std::vector<int>& orbits = cur_system->PlanetIDsByOrbit();
+        for (std::vector<int>::const_iterator it = orbits.begin();
+             it != orbits.end(); ++it)
+        { py_planets.append(*it); }
+        return py_planets;
+    }
+
     list SystemGetFleets(int system_id) {
         list py_fleets;
         TemporaryPtr<System> system = GetSystem(system_id);
@@ -1205,6 +1219,16 @@ namespace {
 
         return planet->Colonize(empire_id, species, population);
     }
+
+    object PlanetOrbitalSuffix(int planet_id) {
+        TemporaryPtr<Planet> planet = GetPlanet(planet_id);
+        if (!planet) {
+            ErrorLogger() << "PlanetOrbitalSuffix: couldn't get planet with ID:" << planet_id;
+            return object("");
+        }
+
+        return object(planet->OrbitalSuffix());
+    }
 }
 
 namespace FreeOrionPython {
@@ -1305,6 +1329,7 @@ namespace FreeOrionPython {
         def("sys_orbit_occupied",                   SystemOrbitOccupied);
         def("sys_orbit_of_planet",                  SystemOrbitOfPlanet);
         def("sys_get_planets",                      SystemGetPlanets);
+        def("sys_get_planets_by_orbit",             SystemGetPlanetsByOrbit);
         def("sys_get_fleets",                       SystemGetFleets);
         def("sys_get_starlanes",                    SystemGetStarlanes);
         def("sys_add_starlane",                     SystemAddStarlane);
@@ -1321,5 +1346,6 @@ namespace FreeOrionPython {
         def("planet_available_foci",                PlanetAvailableFoci);
         def("planet_make_outpost",                  PlanetMakeOutpost);
         def("planet_make_colony",                   PlanetMakeColony);
+        def("planet_get_orbital_suffix",            PlanetOrbitalSuffix);
     }
 }

--- a/universe/Effect.cpp
+++ b/universe/Effect.cpp
@@ -1410,8 +1410,9 @@ void CreatePlanet::Execute(const ScriptingContext& context) const {
         if (ValueRef::ConstantExpr(m_name) && UserStringExists(name_str))
             name_str = UserString(name_str);
     } else {
-        name_str = str(FlexibleFormat(UserString("NEW_PLANET_NAME")) % system->Name());
+        name_str = str(FlexibleFormat(UserString("NEW_PLANET_NAME")) % system->Name() % planet->OrbitalSuffix());
     }
+
     planet->Rename(name_str);
 
     // apply after-creation effects

--- a/universe/Planet.cpp
+++ b/universe/Planet.cpp
@@ -871,3 +871,29 @@ void Planet::ClampMeters() {
     UniverseObject::GetMeter(METER_REBEL_TROOPS)->ClampCurrentToRange();
     UniverseObject::GetMeter(METER_DETECTION)->ClampCurrentToRange();
 }
+
+const std::string Planet::OrbitalSuffix() const {
+    TemporaryPtr<const System> system_ptr = GetSystem(this->SystemID());
+    int orbit = system_ptr->OrbitOfPlanet(this->ID());
+    if (m_size == SZ_ASTEROIDS) {  // asteroids are named according to orbit position
+        while (!UserStringExists("NEW_ASTEROID_SUFFIX_ORBIT_" + RomanNumber(orbit + 1))) {
+            --orbit;
+            if (orbit < 0) {
+                orbit = system_ptr->NumPlanets();
+                break;
+            }
+        }
+        return UserString("NEW_ASTEROID_SUFFIX_ORBIT_" + RomanNumber(orbit + 1));
+    } else {
+        if (orbit < 0) {
+            orbit = 0;
+            const std::set<int>& system_planet_ids = system_ptr->PlanetIDs();
+            for (std::set<int>::const_iterator it = system_planet_ids.begin(); it != system_planet_ids.end(); ++it) {
+                if (TemporaryPtr<const Planet> it_planet = GetPlanet(*it))
+                    if (it_planet->Size() != SZ_ASTEROIDS)
+                        ++orbit;
+            }
+        }
+        return RomanNumber(orbit + 1);
+    }
+}

--- a/universe/Planet.h
+++ b/universe/Planet.h
@@ -133,6 +133,7 @@ public:
     virtual float               NextTurnCurrentMeterValue(MeterType type) const;
 
     const std::string&          SurfaceTexture() const          { return m_surface_texture; }
+    const std::string           OrbitalSuffix() const;              ///< Returns the ordered naming suffix for this planet
     //@}
 
     /** \name Mutators */ //@{

--- a/universe/System.h
+++ b/universe/System.h
@@ -40,6 +40,7 @@ public:
     StarType                NextYoungerStarType() const;
 
     int                     Orbits() const                  { return m_orbits.size(); } ///< returns the number of orbits in this system
+    int                     NumPlanets() const              { return m_planets.size(); }    ///< returns number of planets in this system
 
     int                     NumStarlanes() const;                       ///< returns the number of starlanes from this system to other systems
     int                     NumWormholes() const;                       ///< returns the number of wormholes from this system to other systems

--- a/universe/System.h
+++ b/universe/System.h
@@ -60,6 +60,7 @@ public:
 
     virtual bool            Contains(int object_id) const;                                  ///< returns true if object with id \a object_id is in this System
     virtual bool            ContainedBy(int object_id) const{ return false; }               ///< returns true if there is an object with id \a object_id that contains this UniverseObject
+    const std::vector<int>& PlanetIDsByOrbit() const { return m_orbits; }                   ///< returns planets ids in this system, indexed by orbit
 
     int                     PlanetInOrbit(int orbit) const;             ///< returns the ID of the planet in the specified \a orbit, or INVALID_OBJECT_ID if there is no planet in that orbit or it is an invalid orbit
     int                     OrbitOfPlanet(int object_id) const;         ///< returns the orbit ID in which the planet with \a object_id is located, or -1 the specified ID is not a planet in an orbit of this system

--- a/universe/ValueRef.cpp
+++ b/universe/ValueRef.cpp
@@ -1013,6 +1013,17 @@ std::string Variable<std::string>::Eval(const ScriptingContext& context) const
         if (!empire)
             return "";
         return empire->TopPriorityEnqueuedTech();
+    } else if (property_name == "OrbitalSuffix") {
+        if (TemporaryPtr<const Planet> planet = boost::dynamic_pointer_cast<const Planet>(object)) {
+            return planet->OrbitalSuffix();
+        } else if (TemporaryPtr<const System> system_ptr = boost::dynamic_pointer_cast<const System>(object)) {
+            if (TemporaryPtr<const Planet> planet = boost::dynamic_pointer_cast<const Planet>(GetPlanet(*system_ptr->PlanetIDs().rbegin())))
+                return planet->OrbitalSuffix();
+            else
+                return RomanNumber(system_ptr->PlanetIDs().size());
+        }
+        ErrorLogger() << "OrbitalSuffix requested for non-planet or system object: " << "(" << object->ID() << ")" << object->Name();
+        return "";
     }
 
     ErrorLogger() << "Variable<std::string>::Eval unrecognized object property: " << TraceReference(m_property_name, m_ref_type, context);


### PR DESCRIPTION
PR is to address new planet names having a fixed ordinal (outside of universe generation), escalated by #641

Default behaviour when no name is specified will now append a roman number for the orbit position.
Asteroids are named according to their position within the system.

Universe generation is changed to utilize orbital position naming.

OribtalSuffix is added for FOCS, returning the same value for the suffix as the default/no name behaviour.
