### PR TITLE
Move species collection to state

### DIFF
--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -387,10 +387,10 @@ def survey_universe():
         table_name="Empire species roster"
     )
 
-    for spec_name, planets in state.get_species_planets().items():
+    for spec_name, planet_ids in state.get_empire_planets_by_species().items():
         this_spec = fo.getSpecies(spec_name)
         species_table.add_row(
-            (spec_name, planets, spec_name in empire_colonizers,
+            (spec_name, planet_ids, spec_name in empire_colonizers,
              len(empire_ship_builders.get(spec_name, [])), list(this_spec.tags))
         )
     species_table.print_table()
@@ -501,7 +501,7 @@ def get_colony_fleets():
         if not planet:
             continue
         sys_id = planet.systemID
-        for pid2 in state.get_empire_species_systems().get(sys_id, []):
+        for pid2 in state.get_empire_inhabited_planets_by_system().get(sys_id, []):
             planet2 = universe.getPlanet(pid2)
             if not (planet2 and planet2.speciesName in empire_colonizers):
                 continue

--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -1,4 +1,5 @@
 import sys
+from turn_state import state
 
 import freeOrionAIInterface as fo  # pylint: disable=import-error
 import FreeOrionAI as foAI
@@ -100,7 +101,7 @@ def get_invasion_fleets():
             planet_partial_vis_turn = universe.getVisibilityTurnsMap(pid, empire_id).get(fo.visibility.partial, -9999)
             if planet_partial_vis_turn < sys_partial_vis_turn:
                 continue
-            for pid2 in ColonisationAI.empire_species_systems.get(sys_id, {}).get('pids', []):
+            for pid2 in state.get_empire_species_systems().get(sys_id, []):
                 if available_pp.get(pid2, 0) < 2:  # TODO: improve troop base PP sufficiency determination
                     break
                 planet2 = universe.getPlanet(pid2)

--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -101,7 +101,7 @@ def get_invasion_fleets():
             planet_partial_vis_turn = universe.getVisibilityTurnsMap(pid, empire_id).get(fo.visibility.partial, -9999)
             if planet_partial_vis_turn < sys_partial_vis_turn:
                 continue
-            for pid2 in state.get_empire_species_systems().get(sys_id, []):
+            for pid2 in state.get_empire_inhabited_planets_by_system().get(sys_id, []):
                 if available_pp.get(pid2, 0) < 2:  # TODO: improve troop base PP sufficiency determination
                     break
                 planet2 = universe.getPlanet(pid2)

--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -379,7 +379,7 @@ def generate_production_orders():
                 queued_defenses[sys_id] = queued_defenses.get(sys_id, 0) + element.blocksize*element.remaining
                 defense_allocation += element.allocation
         print "Queued Defenses:", [(ppstring(PlanetUtilsAI.sys_name_ids([sys_id])), num) for sys_id, num in queued_defenses.items()]
-        for sys_id in ColonisationAI.empire_species_systems:
+        for sys_id, pids in state.get_empire_species_systems().items():
             if foAI.foAIstate.systemStatus.get(sys_id, {}).get('fleetThreat', 1) > 0:
                 continue  # don't build orbital shields if enemy fleet present
             if defense_allocation > max_defense_portion * total_pp:
@@ -390,11 +390,11 @@ def generate_production_orders():
                 if foAI.foAIstate.get_fleet_role(fid) == MissionType.ORBITAL_DEFENSE:
                     print "Found %d existing Orbital Defenses in %s :" % (foAI.foAIstate.fleetStatus.get(fid, {}).get('nships', 0), ppstring(PlanetUtilsAI.sys_name_ids([sys_id])))
                     sys_orbital_defenses[sys_id] += foAI.foAIstate.fleetStatus.get(fid, {}).get('nships', 0)
-            for pid in ColonisationAI.empire_species_systems.get(sys_id, {}).get('pids', []):
+            for pid in pids:
                 sys_orbital_defenses[sys_id] += queued_defenses.get(pid, 0)
             if sys_orbital_defenses[sys_id] < target_orbitals:
                 num_needed = target_orbitals - sys_orbital_defenses[sys_id]
-                for pid in ColonisationAI.empire_species_systems.get(sys_id, {}).get('pids', []):
+                for pid in pids:
                     best_design_id, col_design, build_choices = get_best_ship_info(PriorityType.PRODUCTION_ORBITAL_DEFENSE, pid)
                     if not best_design_id:
                         print "no orbital defenses can be built at ", ppstring(PlanetUtilsAI.planet_name_ids([pid]))
@@ -413,14 +413,16 @@ def generate_production_orders():
     queued_shipyard_locs = [element.locationID for element in production_queue if (element.name == "BLD_SHIPYARD_BASE")]
     system_colonies = {}
     colony_systems = {}
+    empire_species = state.get_species_planets()
+    systems_with_species = state.get_empire_species_systems()
     for spec_name in ColonisationAI.empire_colonizers:
-        if (len(ColonisationAI.empire_colonizers[spec_name]) == 0) and (spec_name in ColonisationAI.empire_species):  # not enough current shipyards for this species#TODO: also allow orbital incubators and/or asteroid ships
-            for pid in ColonisationAI.empire_species.get(spec_name, []):  # SP_EXOBOT may not actually have a colony yet but be in empireColonizers
+        if (len(ColonisationAI.empire_colonizers[spec_name]) == 0) and (spec_name in empire_species):  # not enough current shipyards for this species#TODO: also allow orbital incubators and/or asteroid ships
+            for pid in state.get_planets_for_species(spec_name):  # SP_EXOBOT may not actually have a colony yet but be in empireColonizers
                 if pid in queued_shipyard_locs:
                     break  # won't try building more than one shipyard at once, per colonizer
             else:  # no queued shipyards, get planets with target pop >=3, and queue a shipyard on the one with biggest current pop
-                planets = zip(map(universe.getPlanet, ColonisationAI.empire_species[spec_name]), ColonisationAI.empire_species[spec_name])
-                pops = sorted([(planet.currentMeterValue(fo.meterType.population), pid) for planet, pid in planets if (planet and planet.currentMeterValue(fo.meterType.targetPopulation) >= 3.0)])
+                planets = map(universe.getPlanet, state.get_planets_for_species(spec_name))
+                pops = sorted([(planet.currentMeterValue(fo.meterType.population), planet.id) for planet in planets if (planet and planet.currentMeterValue(fo.meterType.targetPopulation) >= 3.0)])
                 pids = [pid for pop, pid in pops if building_type.canBeProduced(empire.empireID, pid)]
                 if pids:
                     build_loc = pids[-1]
@@ -429,14 +431,14 @@ def generate_production_orders():
                     if res:
                         queued_shipyard_locs.append(build_loc)
                         break  # only start at most one new shipyard per species per turn
-        for pid in ColonisationAI.empire_species.get(spec_name, []):
+        for pid in state.get_planets_for_species(spec_name):
             planet = universe.getPlanet(pid)
             if planet:
                 system_colonies.setdefault(planet.systemID, {}).setdefault('pids', []).append(pid)
                 colony_systems[pid] = planet.systemID
 
     acirema_systems = {}
-    for pid in ColonisationAI.empire_species.get("SP_ACIREMA", []):
+    for pid in state.get_planets_for_species("SP_ACIREMA"):
         acirema_systems.setdefault(universe.getPlanet(pid).systemID, []).append(pid)
         if (pid in queued_shipyard_locs) or not building_type.canBeProduced(empire.empireID, pid):
             continue  # but not 'break' because we want to build shipyards at *every* Acirema planet
@@ -557,7 +559,7 @@ def generate_production_orders():
                 planet = universe.getPlanet(pid)
                 this_spec = planet.speciesName
                 sys_id = planet.systemID
-                if planet.size == fo.planetSize.asteroids and sys_id in ColonisationAI.empire_species_systems:
+                if planet.size == fo.planetSize.asteroids and sys_id in systems_with_species:
                     asteroid_systems.setdefault(sys_id, []).append(pid)
                     if (pid in queued_building_locs) or (building_name in [universe.getBuilding(bldg).buildingTypeName for bldg in planet.buildingIDs]):
                         asteroid_yards[sys_id] = pid  # shouldn't ever overwrite another, but ok if it did
@@ -637,7 +639,7 @@ def generate_production_orders():
         for pid in list(AIstate.popCtrIDs) + list(AIstate.outpostIDs):  # TODO: check to ensure that a resource center exists in system, or GGG would be wasted
             if pid not in queued_building_locs and building_type.canBeProduced(empire.empireID, pid):  # TODO: verify that canBeProduced() checks for preexistence of a barring building
                 planet = universe.getPlanet(pid)
-                if planet.systemID in ColonisationAI.empire_species_systems:
+                if planet.systemID in systems_with_species:
                     gg_list = []
                     can_use_gg = False
                     system = universe.getSystem(planet.systemID)
@@ -923,7 +925,7 @@ def generate_production_orders():
         pop_disqualified = (c_pop <= 32) or (c_pop < 0.9*t_pop)
         built_camp = False
         this_spec = planet.speciesName
-        safety_margin_met = ((this_spec in ColonisationAI.empire_colonizers and (len(ColonisationAI.empire_species.get(this_spec, []) + colony_ship_map.get(this_spec, [])) >= 2)) or (c_pop >= 50))
+        safety_margin_met = ((this_spec in ColonisationAI.empire_colonizers and (len(state.get_planets_for_species(this_spec) + colony_ship_map.get(this_spec, [])) >= 2)) or (c_pop >= 50))
         if pop_disqualified or not safety_margin_met:  # check even if not aggressive, etc, just in case acquired planet with a ConcCamp on it
             if can_build_camp:
                 if pop_disqualified:
@@ -931,7 +933,7 @@ def generate_production_orders():
                         print "Conc Camp disqualified at %s due to low pop: current %.1f target: %.1f" % (planet.name, c_pop, t_pop)
                 else:
                     if verbose_camp:
-                        print "Conc Camp disqualified at %s due to safety margin; species %s, colonizing planets %s, with %d colony ships" % (planet.name, planet.speciesName, ColonisationAI.empire_species.get(planet.speciesName, []), len(colony_ship_map.get(planet.speciesName, [])))
+                        print "Conc Camp disqualified at %s due to safety margin; species %s, colonizing planets %s, with %d colony ships" % (planet.name, planet.speciesName, state.get_planets_for_species(planet.speciesName), len(colony_ship_map.get(planet.speciesName, [])))
             for bldg in planet.buildingIDs:
                 if universe.getBuilding(bldg).buildingTypeName == building_name:
                     res = fo.issueScrapOrder(bldg)
@@ -1029,8 +1031,7 @@ def generate_production_orders():
             
         max_dock_builds = int(0.8 + empire.productionPoints/120.0)
         print "Considering building %s, found current and queued systems %s" % (building_name, ppstring(PlanetUtilsAI.sys_name_ids(cur_drydoc_sys.union(queued_sys))))
-        for sys_id, pids_dict in ColonisationAI.empire_species_systems.items():  # TODO: sort/prioritize in some fashion
-            pids = pids_dict.get('pids', [])
+        for sys_id, pids in state.get_empire_species_systems().items():  # TODO: sort/prioritize in some fashion
             local_top_pilots = dict(top_pilot_systems.get(sys_id, []))
             local_drydocks = ColonisationAI.empire_dry_docks.get(sys_id, [])
             if len(queued_locs) >= max_dock_builds:

--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -925,7 +925,7 @@ def generate_production_orders():
         pop_disqualified = (c_pop <= 32) or (c_pop < 0.9*t_pop)
         built_camp = False
         this_spec = planet.speciesName
-        safety_margin_met = ((this_spec in ColonisationAI.empire_colonizers and (len(state.get_planets_for_species(this_spec) + colony_ship_map.get(this_spec, [])) >= 2)) or (c_pop >= 50))
+        safety_margin_met = ((this_spec in ColonisationAI.empire_colonizers and (len(state.get_planets_for_species(this_spec)) + len(colony_ship_map.get(this_spec, [])) >= 2)) or (c_pop >= 50))
         if pop_disqualified or not safety_margin_met:  # check even if not aggressive, etc, just in case acquired planet with a ConcCamp on it
             if can_build_camp:
                 if pop_disqualified:

--- a/default/python/AI/ResearchAI.py
+++ b/default/python/AI/ResearchAI.py
@@ -961,7 +961,7 @@ def generate_classic_research_orders():
     if True:  # just to help with cold-folding / organization
         if not tech_is_complete("LRN_DISTRIB_THOUGHT"):
             got_telepathy = False
-            for specName in state.get_species_planets():
+            for specName in state.get_empire_planets_by_species():
                 this_spec = fo.getSpecies(specName)
                 if this_spec and ("TELEPATHIC" in list(this_spec.tags)):
                     got_telepathy = True

--- a/default/python/AI/ResearchAI.py
+++ b/default/python/AI/ResearchAI.py
@@ -961,7 +961,7 @@ def generate_classic_research_orders():
     if True:  # just to help with cold-folding / organization
         if not tech_is_complete("LRN_DISTRIB_THOUGHT"):
             got_telepathy = False
-            for specName in ColonisationAI.empire_species:
+            for specName in state.get_species_planets():
                 this_spec = fo.getSpecies(specName)
                 if this_spec and ("TELEPATHIC" in list(this_spec.tags)):
                     got_telepathy = True

--- a/default/python/AI/turn_state.py
+++ b/default/python/AI/turn_state.py
@@ -42,7 +42,7 @@ class State(object):
             planet = universe.getPlanet(pid)
             self.__planet_info[pid] = PlanetInfo(pid, planet.speciesName, planet.owner, planet.systemID)
 
-    def get_empire_species_systems(self):
+    def get_empire_inhabited_planets_by_system(self):
         """
         Return dict from system id to planet ids of empire with species.
 
@@ -50,9 +50,9 @@ class State(object):
         """
         # TODO: as currently used, is duplicative with combo of foAI.foAIstate.popCtrSystemIDs and foAI.foAIstate.colonizedSystems
         empire_id = fo.empireID()
-        planets_with_species = (x for x in self.__planet_info.itervalues() if x.owner == empire_id and x.species_name)
+        empire_planets_with_species = (x for x in self.__planet_info.itervalues() if x.owner == empire_id and x.species_name)
         result = {}
-        for x in planets_with_species:
+        for x in empire_planets_with_species:
             result.setdefault(x.system_id, []).append(x.pid)
         return result
 
@@ -65,19 +65,19 @@ class State(object):
         empire_id = fo.empireID()
         return frozenset(x.pid for x in self.__planet_info.itervalues() if x.owner == empire_id and x.species_name)
 
-    def get_planets_for_species(self, species):
+    def get_empire_planets_with_species(self, species_name):
         """
         Return list of empire planet ids with species.
 
-        :param species: species name
-        :type species: str
+        :param species_name: species name
+        :type species_name: str
         :rtype: tuple[int]
         """
-        if not species:
+        if not species_name:
             return []
-        return tuple(self.get_species_planets().get(species, []))
+        return tuple(self.get_empire_planets_by_species().get(species_name, []))
 
-    def get_species_planets(self):
+    def get_empire_planets_by_species(self):
         """
         Return dict for empire from species to list of planet ids.
 

--- a/default/python/AI/turn_state.py
+++ b/default/python/AI/turn_state.py
@@ -60,12 +60,13 @@ class State(object):
         """
         Return list of empire planet ids with species.
 
-        :rtype: set[int]
+        :param species: species name
+        :type species: str
+        :rtype: tuple[int]
         """
         if not species:
             return []
-        empire_id = fo.empireID()
-        return tuple(x.pid for x in self.__planets.itervalues() if x.owner == empire_id and x.species == species)
+        return tuple(self.get_species_planets().get(species, []))
 
     def get_species_planets(self):
         """

--- a/default/python/AI/turn_state.py
+++ b/default/python/AI/turn_state.py
@@ -31,6 +31,12 @@ class State(object):
         Must be called at each turn (before first use) to update inner state.
         """
         self.__init__()
+        self.__update_planets()
+
+    def __update_planets(self):
+        """
+        Update information about planets.
+        """
         universe = fo.getUniverse()
         for pid in universe.planetIDs:
             planet = universe.getPlanet(pid)

--- a/default/python/AI/turn_state.py
+++ b/default/python/AI/turn_state.py
@@ -58,7 +58,7 @@ class State(object):
 
     def get_inhabited_planets(self):
         """
-        Return set of empire planet ids with species.
+        Return frozenset of empire planet ids with species.
 
         :rtype: frozenset[int]
         """
@@ -67,14 +67,14 @@ class State(object):
 
     def get_empire_planets_with_species(self, species_name):
         """
-        Return list of empire planet ids with species.
+        Return tuple of empire planet ids with species.
 
         :param species_name: species name
         :type species_name: str
         :rtype: tuple[int]
         """
         if not species_name:
-            return []
+            return ()
         return tuple(self.get_empire_planets_by_species().get(species_name, []))
 
     def get_empire_planets_by_species(self):

--- a/default/python/AI/turn_state.py
+++ b/default/python/AI/turn_state.py
@@ -51,7 +51,7 @@ class State(object):
         """
         Return set of empire planet ids with species.
 
-        :rtype: set[int]
+        :rtype: frozenset[int]
         """
         empire_id = fo.empireID()
         return frozenset(x.pid for x in self.__planets.itervalues() if x.owner == empire_id and x.species)

--- a/default/python/AI/turn_state.py
+++ b/default/python/AI/turn_state.py
@@ -27,6 +27,9 @@ class State(object):
         self.__planet_info = {}  # map from planet_id to PlanetInfo
 
     def update(self):
+        """
+        Must be called at each turn (before first use) to update inner state.
+        """
         self.__init__()
         universe = fo.getUniverse()
         for pid in universe.planetIDs:

--- a/default/python/AI/turn_state.py
+++ b/default/python/AI/turn_state.py
@@ -8,7 +8,7 @@ class State(object):
     """
     This class represent state for current turn.
     It contains variables that renewed each turn.
-    Before each turn `clean` method should be called at the beginning of each turn.
+    Before each turn `update` method should be called at the beginning of each turn.
 
     Each variable should have a getter that returns value or deepcopy of value if it is immutable
     and one or couple setters (if need to change inner collections in collection).

--- a/default/python/AI/turn_state.py
+++ b/default/python/AI/turn_state.py
@@ -24,14 +24,14 @@ class State(object):
         self.__have_computronium = False
         self.__best_pilot_rating = 1e-8
         self.__medium_pilot_rating = 1e-8
-        self.__planets = {}
+        self.__planet_info = {}  # map from planet_id to PlanetInfo
 
     def update(self):
         self.__init__()
         universe = fo.getUniverse()
         for pid in universe.planetIDs:
             planet = universe.getPlanet(pid)
-            self.__planets[pid] = PlanetInfo(pid, planet.speciesName, planet.owner, planet.systemID)
+            self.__planet_info[pid] = PlanetInfo(pid, planet.speciesName, planet.owner, planet.systemID)
 
     def get_empire_species_systems(self):
         """
@@ -41,7 +41,7 @@ class State(object):
         """
         # TODO: as currently used, is duplicative with combo of foAI.foAIstate.popCtrSystemIDs and foAI.foAIstate.colonizedSystems
         empire_id = fo.empireID()
-        planets_with_species = (x for x in self.__planets.itervalues() if x.owner == empire_id and x.species_name)
+        planets_with_species = (x for x in self.__planet_info.itervalues() if x.owner == empire_id and x.species_name)
         result = {}
         for x in planets_with_species:
             result.setdefault(x.system_id, []).append(x.pid)
@@ -54,7 +54,7 @@ class State(object):
         :rtype: frozenset[int]
         """
         empire_id = fo.empireID()
-        return frozenset(x.pid for x in self.__planets.itervalues() if x.owner == empire_id and x.species_name)
+        return frozenset(x.pid for x in self.__planet_info.itervalues() if x.owner == empire_id and x.species_name)
 
     def get_planets_for_species(self, species):
         """
@@ -76,7 +76,7 @@ class State(object):
         """
         empire_id = fo.empireID()
         result = {}
-        for x in (x for x in self.__planets.itervalues() if x.owner == empire_id and x.species_name):
+        for x in (x for x in self.__planet_info.itervalues() if x.owner == empire_id and x.species_name):
             result.setdefault(x.species_name, []).append(x.pid)
         return result
 

--- a/default/python/AI/turn_state.py
+++ b/default/python/AI/turn_state.py
@@ -51,21 +51,21 @@ class State(object):
         """
         Return set of empire planet ids with species.
 
-        :rtype: set
+        :rtype: set[int]
         """
         empire_id = fo.empireID()
-        return {x.pid for x in self.__planets.itervalues() if x.owner == empire_id and x.species}
+        return frozenset(x.pid for x in self.__planets.itervalues() if x.owner == empire_id and x.species)
 
     def get_planets_for_species(self, species):
         """
         Return list of empire planet ids with species.
 
-        :rtype: list[int]
+        :rtype: set[int]
         """
         if not species:
             return []
         empire_id = fo.empireID()
-        return [x.pid for x in self.__planets.itervalues() if x.owner == empire_id and x.species == species]
+        return tuple(x.pid for x in self.__planets.itervalues() if x.owner == empire_id and x.species == species)
 
     def get_species_planets(self):
         """

--- a/default/python/AI/turn_state.py
+++ b/default/python/AI/turn_state.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
 import freeOrionAIInterface as fo
 
-PlanetInfo = namedtuple('PlanetInfo', ['pid', 'species', 'owner', 'system_id'])
+PlanetInfo = namedtuple('PlanetInfo', ['pid', 'species_name ', 'owner', 'system_id'])
 
 
 class State(object):
@@ -41,7 +41,7 @@ class State(object):
         """
         # TODO: as currently used, is duplicative with combo of foAI.foAIstate.popCtrSystemIDs and foAI.foAIstate.colonizedSystems
         empire_id = fo.empireID()
-        planets_with_species = (x for x in self.__planets.itervalues() if x.owner == empire_id and x.species)
+        planets_with_species = (x for x in self.__planets.itervalues() if x.owner == empire_id and x.species_name)
         result = {}
         for x in planets_with_species:
             result.setdefault(x.system_id, []).append(x.pid)
@@ -54,7 +54,7 @@ class State(object):
         :rtype: frozenset[int]
         """
         empire_id = fo.empireID()
-        return frozenset(x.pid for x in self.__planets.itervalues() if x.owner == empire_id and x.species)
+        return frozenset(x.pid for x in self.__planets.itervalues() if x.owner == empire_id and x.species_name)
 
     def get_planets_for_species(self, species):
         """
@@ -76,8 +76,8 @@ class State(object):
         """
         empire_id = fo.empireID()
         result = {}
-        for x in (x for x in self.__planets.itervalues() if x.owner == empire_id and x.species):
-            result.setdefault(x.species, []).append(x.pid)
+        for x in (x for x in self.__planets.itervalues() if x.owner == empire_id and x.species_name):
+            result.setdefault(x.species_name, []).append(x.pid)
         return result
 
     @property


### PR DESCRIPTION
Replace some module level variables to methods in state.
- `empire_species` -> Splited for two methods:
  - `state.get_species_planets()`
  - `state.get_planets_for_species(species_name)`
- `empire_species_by_planet` - > `state.planets_with_species()`
- `empire_species_systems` -> `state.get_empire_species_systems`,
  structure changed: `{sid: {'pids': [pid, ...]}}` - > `{sid: [pid, ...]}`
