### PR TITLE
Fix scope logic for damage control on moving ships

### DIFF
--- a/default/scripting/ship_hulls/robotic/SH_NANOROBOTIC.focs.txt
+++ b/default/scripting/ship_hulls/robotic/SH_NANOROBOTIC.focs.txt
@@ -36,9 +36,15 @@ Hull
         EffectsGroup
             scope = And [
                 Source
-                Turn low = LocalCandidate.System.LastTurnBattleHere + 1
-                Structure high = LocalCandidate.MaxStructure - 0.001
+                Or [
+                    Not InSystem
+                    And [
+                        InSystem
+                        Turn low = LocalCandidate.System.LastTurnBattleHere + 1
+                    ]
                 ]
+                Structure high = LocalCandidate.MaxStructure - 0.001
+            ]
             activation = Turn low = Source.CreationTurn + 1
             effects = SetStructure value = Value + Value
 

--- a/default/scripting/ship_hulls/robotic/SH_ROBOTIC.focs.txt
+++ b/default/scripting/ship_hulls/robotic/SH_ROBOTIC.focs.txt
@@ -30,9 +30,15 @@ Hull
         EffectsGroup
             scope = And [
                 Source
-                Turn low = LocalCandidate.System.LastTurnBattleHere + 1
-                Structure high = LocalCandidate.MaxStructure - 0.001
+                Or [
+                    Not InSystem
+                    And [
+                        InSystem
+                        Turn low = LocalCandidate.System.LastTurnBattleHere + 1
+                    ]
                 ]
+                Structure high = LocalCandidate.MaxStructure - 0.001
+            ]
             activation = Source
             effects = SetStructure value = Value + 2
 

--- a/default/scripting/techs/ships/DamageControl.focs.txt
+++ b/default/scripting/techs/ships/DamageControl.focs.txt
@@ -28,7 +28,13 @@ Tech
             scope = And [
                 Ship
                 OwnedBy empire = Source.Owner
-                Turn low = LocalCandidate.System.LastTurnBattleHere + 1
+                Or [
+                    Not InSystem
+                    And [
+                        InSystem
+                        Turn low = LocalCandidate.System.LastTurnBattleHere + 1
+                    ]
+                ]
                 Structure high = LocalCandidate.MaxStructure - 0.001
             ]
             effects = SetStructure value = Value + 1


### PR DESCRIPTION
Skip battlecheck for ships in motion.

```
[error] Client : ValueRef.cpp:79 : FollowReference : Unable to get system for object
[error] Client : ValueRef.cpp:753 : Variable<int>::Eval unable to follow reference: LocalCandidate.System.LastTurnBattleHere :  | Local Candidate: Ship 1538 (  )  |  System (-1):  |  LastTurnBattleHere  | 
[error] Client : ValueRef.cpp:755 : source: Planet 63 ( Minerva I )
```
