### PR TITLE
Send status message at start of saving a game

### DIFF
--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -591,6 +591,7 @@ WaitingForTurnData::~WaitingForTurnData()
 boost::statechart::result WaitingForTurnData::react(const SaveGameDataRequest& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) WaitingForTurnData.SaveGameDataRequest";
     DebugLogger() << "Sending Save Game Data to Server";
+    Client().GetClientUI()->GetMessageWnd()->HandleGameStatusUpdate(UserString("SERVER_SAVE_INITIATE_ACK") + "\n");
     Client().HandleSaveGameDataRequest();
     return discard_event();
 }
@@ -694,6 +695,7 @@ PlayingTurn::~PlayingTurn()
 boost::statechart::result PlayingTurn::react(const SaveGameDataRequest& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) PlayingTurn.SaveGameDataRequest";
     DebugLogger() << "Sending Save Game Data to Server";
+    Client().GetClientUI()->GetMessageWnd()->HandleGameStatusUpdate(UserString("SERVER_SAVE_INITIATE_ACK") + "\n");
     Client().HandleSaveGameDataRequest();
     return discard_event();
 }

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -902,6 +902,9 @@ The server has sent an end-game message. Buh-bye.
 PLAYER_DISCONNECTED
 Player %1% no longer has a connection to the server.
 
+SERVER_SAVE_INITIATE_ACK
+Saving...
+
 SERVER_SAVE_COMPLETE
 Saved %2% bytes to file: %1%
 


### PR DESCRIPTION
Fixes #766 

Sends a message to clients to indicate the start of a game save.

Separated changes between host only and all players into second commit, in the event sending only to host is preferred.
