### PR TITLE
Add dismiss sensor ghost

### DIFF
--- a/UI/BuildingsPanel.cpp
+++ b/UI/BuildingsPanel.cpp
@@ -456,7 +456,7 @@ void BuildingIndicator::RClick(const GG::Pt& pt, GG::Flags<GG::ModKey> mod_keys)
             std::map<int, int> pending_scrap_orders = PendingScrapOrders();
             std::map<int, int>::const_iterator it = pending_scrap_orders.find(building->ID());
             if (it != pending_scrap_orders.end()) {
-                HumanClientApp::GetApp()->Orders().RecindOrder(it->second);
+                HumanClientApp::GetApp()->Orders().RescindOrder(it->second);
             break;
             }
         }

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -3584,14 +3584,8 @@ void FleetWnd::FleetRightClicked(GG::ListBox::iterator it, const GG::Pt& pt, con
             GetUniverse().ForgetKnownObject(ALL_EMPIRES, fleet->ID());
 
             // Force a redraw
-
-            // Just signaling StateChanged doesn't work because MapWnd
-            // only resets/deletes paths to non-existent objects on the
-            // turn updates and not when handling StateChanged.
-            // fleet->StateChangedSignal();
-
-            //So brute force.
-            ClientUI::GetClientUI()->GetMapWnd()->MidTurnUpdate();
+            this->Refresh();
+            ClientUI::GetClientUI()->GetMapWnd()->RemoveFleet(fleet->ID());
 
             break;
         }

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -2683,7 +2683,7 @@ void FleetDetailPanel::ShipRightClicked(GG::ListBox::iterator it, const GG::Pt& 
             std::map<int, int> pending_scrap_orders = PendingScrapOrders();
             std::map<int, int>::const_iterator it = pending_scrap_orders.find(ship->ID());
             if (it != pending_scrap_orders.end())
-                HumanClientApp::GetApp()->Orders().RecindOrder(it->second);
+                HumanClientApp::GetApp()->Orders().RescindOrder(it->second);
             break;
         }
 
@@ -3523,7 +3523,7 @@ void FleetWnd::FleetRightClicked(GG::ListBox::iterator it, const GG::Pt& pt, con
                 for (OrderSet::const_iterator it = orders.begin(); it != orders.end(); ++it) {
                     if (boost::shared_ptr<ScrapOrder> order = boost::dynamic_pointer_cast<ScrapOrder>(it->second)) {
                         if (order->ObjectID() == ship_id) {
-                            HumanClientApp::GetApp()->Orders().RecindOrder(it->first);
+                            HumanClientApp::GetApp()->Orders().RescindOrder(it->first);
                             // could break here, but won't to ensure there are no problems with doubled orders
                         }
                     }
@@ -3550,7 +3550,7 @@ void FleetWnd::FleetRightClicked(GG::ListBox::iterator it, const GG::Pt& pt, con
                     boost::dynamic_pointer_cast<GiveObjectToEmpireOrder>(it->second))
                 {
                     if (order->ObjectID() == fleet->ID()) {
-                        HumanClientApp::GetApp()->Orders().RecindOrder(it->first);
+                        HumanClientApp::GetApp()->Orders().RescindOrder(it->first);
                         // could break here, but won't to ensure there are no problems with doubled orders
                     }
                 }

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -3435,13 +3435,14 @@ void FleetWnd::FleetRightClicked(GG::ListBox::iterator it, const GG::Pt& pt, con
     }
 
 
-    //Allow dismissal of stale visibility information
+    // Allow dismissal of stale visibility information
     if (!fleet->OwnedBy(client_empire_id)){
         Universe::VisibilityTurnMap visibility_turn_map =
             GetUniverse().GetObjectVisibilityTurnMapByEmpire(fleet->ID(), client_empire_id);
         Universe::VisibilityTurnMap::const_iterator last_turn_visible_it = visibility_turn_map.find(VIS_BASIC_VISIBILITY);
         if (last_turn_visible_it != visibility_turn_map.end()
-            && last_turn_visible_it->second < CurrentTurn()) {
+            && last_turn_visible_it->second < CurrentTurn())
+        {
             menu_contents.next_level.push_back(GG::MenuItem(UserString("FW_ORDER_DISMISS_SENSOR_GHOST"),   13, false, false));
         }
    }
@@ -3571,11 +3572,15 @@ void FleetWnd::FleetRightClicked(GG::ListBox::iterator it, const GG::Pt& pt, con
 
         case 13: { // Remove visibility information for this fleet from
                    // the empire's visibility table.
-            //server info for future effect
+            // Server changes for permanent effect
+            // Tell the server to change what the empire wants to know
+            // in future so that the server doesn't keep resending this
+            // fleet information.
             HumanClientApp::GetApp()->Orders().IssueOrder(
                 OrderPtr(new ForgetOrder(client_empire_id, fleet->ID()))
             );
-            //local info for immediate effect
+            // Client changes for immediate effect
+            // Force the client to change immediately.
             GetUniverse().ForgetKnownObject(ALL_EMPIRES, fleet->ID());
 
             // Force a redraw

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -3555,6 +3555,7 @@ void FleetWnd::FleetRightClicked(GG::ListBox::iterator it, const GG::Pt& pt, con
                     }
                 }
             }
+            break;
         }
 
         default: { // check for menu item indicating give to other empire order

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -3817,8 +3817,8 @@ void MapWnd::SelectFleet(TemporaryPtr<Fleet> fleet) {
 }
 
 void MapWnd::RemoveFleet(int fleet_id) {
-    RemoveFleetMovementLine(fleet_id);
-    RemoveProjectedFleetMovementLine(fleet_id);
+    m_fleet_lines.erase(fleet_id);
+    m_projected_fleet_lines.erase(fleet_id);
     m_selected_fleet_ids.erase(fleet_id);
     RefreshFleetButtons();
 }
@@ -3934,18 +3934,6 @@ void MapWnd::SetProjectedFleetMovementLines(const std::vector<int>& fleet_ids,
 {
     for (std::vector<int>::const_iterator it = fleet_ids.begin(); it != fleet_ids.end(); ++it)
         SetProjectedFleetMovementLine(*it, travel_route);
-}
-
-void MapWnd::RemoveProjectedFleetMovementLine(int fleet_id) {
-    std::map<int, MovementLineData>::iterator it = m_projected_fleet_lines.find(fleet_id);
-    if (it != m_projected_fleet_lines.end())
-        m_projected_fleet_lines.erase(it);
-}
-
-void MapWnd::RemoveFleetMovementLine(int fleet_id) {
-    std::map<int, MovementLineData>::iterator it = m_fleet_lines.find(fleet_id);
-    if (it != m_fleet_lines.end())
-        m_fleet_lines.erase(it);
 }
 
 void MapWnd::ClearProjectedFleetMovementLines()
@@ -4792,7 +4780,7 @@ void MapWnd::PlotFleetMovement(int system_id, bool execute_move, bool append) {
 
         // plot empty move pathes if destination is not a known system
         if (system_id == INVALID_OBJECT_ID) {
-            RemoveProjectedFleetMovementLine(fleet_id);
+            m_projected_fleet_lines.erase(fleet_id);
             continue;
         }
 

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -3816,6 +3816,13 @@ void MapWnd::SelectFleet(TemporaryPtr<Fleet> fleet) {
     fleet_wnd->SelectFleet(fleet->ID());
 }
 
+void MapWnd::RemoveFleet(int fleet_id) {
+    RemoveFleetMovementLine(fleet_id);
+    RemoveProjectedFleetMovementLine(fleet_id);
+    m_selected_fleet_ids.erase(fleet_id);
+    RefreshFleetButtons();
+}
+
 void MapWnd::SetFleetMovementLine(const FleetButton* fleet_button) {
     assert(fleet_button);
     // each fleet represented by button could have different move path
@@ -3933,6 +3940,12 @@ void MapWnd::RemoveProjectedFleetMovementLine(int fleet_id) {
     std::map<int, MovementLineData>::iterator it = m_projected_fleet_lines.find(fleet_id);
     if (it != m_projected_fleet_lines.end())
         m_projected_fleet_lines.erase(it);
+}
+
+void MapWnd::RemoveFleetMovementLine(int fleet_id) {
+    std::map<int, MovementLineData>::iterator it = m_fleet_lines.find(fleet_id);
+    if (it != m_fleet_lines.end())
+        m_fleet_lines.erase(it);
 }
 
 void MapWnd::ClearProjectedFleetMovementLines()
@@ -5070,15 +5083,8 @@ void MapWnd::UniverseObjectDeleted(TemporaryPtr<const UniverseObject> obj) {
         DebugLogger() << "MapWnd::UniverseObjectDeleted: " << obj->ID();
     else
         DebugLogger() << "MapWnd::UniverseObjectDeleted: NO OBJECT";
-    if (TemporaryPtr<const Fleet> fleet = boost::dynamic_pointer_cast<const Fleet>(obj)) {
-        std::map<int, MovementLineData>::iterator it1 = m_fleet_lines.find(fleet->ID());
-        if (it1 != m_fleet_lines.end())
-            m_fleet_lines.erase(it1);
-
-        std::map<int, MovementLineData>::iterator it2 = m_projected_fleet_lines.find(fleet->ID());
-        if (it2 != m_projected_fleet_lines.end())
-            m_projected_fleet_lines.erase(it2);
-    }
+    if (TemporaryPtr<const Fleet> fleet = boost::dynamic_pointer_cast<const Fleet>(obj))
+        RemoveFleet(fleet->ID());
 }
 
 void MapWnd::RegisterPopup(MapWndPopup* popup) {

--- a/UI/MapWnd.h
+++ b/UI/MapWnd.h
@@ -156,7 +156,6 @@ public:
     void            ReselectLastFleet();                                    //!< re-selects the most recent selected fleet, if a valid one exists
 
     void            RemoveFleet(int fleet_id); //!< removes specified fleet.
-    void            RemoveFleetMovementLine(int fleet_id); //!< removes fleet movement line for specified fleet.
     void            SetFleetMovementLine(const FleetButton* fleet_button);  //!< creates fleet movement lines for all fleets in the given FleetButton to indicate where (and whether) they are moving.  Move lines originate from the FleetButton.
     void            SetFleetMovementLine(int fleet_id);                     //!< creates fleet movement line for a single fleet.  Move lines originate from the fleet's button location.
 
@@ -168,7 +167,7 @@ public:
      * fleets following the specified route.  Move lines originates from the
      * fleets' button locations. */
     void            SetProjectedFleetMovementLines(const std::vector<int>& fleet_ids, const std::list<int>& travel_route);
-    void            RemoveProjectedFleetMovementLine(int fleet_id); //!< removes projected fleet movement line for specified fleet.
+
     void            ClearProjectedFleetMovementLines();             //!< removes all projected fleet movement lines
 
     void            ResetEmpireShown();                             //!< auto-resets the shown empire in any contained Wnds, to the current client's empire (if any)

--- a/UI/MapWnd.h
+++ b/UI/MapWnd.h
@@ -155,6 +155,8 @@ public:
     void            SelectFleet(TemporaryPtr<Fleet> fleet);                              //!< programatically selects fleets
     void            ReselectLastFleet();                                    //!< re-selects the most recent selected fleet, if a valid one exists
 
+    void            RemoveFleet(int fleet_id); //!< removes specified fleet.
+    void            RemoveFleetMovementLine(int fleet_id); //!< removes fleet movement line for specified fleet.
     void            SetFleetMovementLine(const FleetButton* fleet_button);  //!< creates fleet movement lines for all fleets in the given FleetButton to indicate where (and whether) they are moving.  Move lines originate from the FleetButton.
     void            SetFleetMovementLine(int fleet_id);                     //!< creates fleet movement line for a single fleet.  Move lines originate from the fleet's button location.
 

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -1916,7 +1916,7 @@ void SidePanel::PlanetPanel::RClick(const GG::Pt& pt, GG::Flags<GG::ModKey> mod_
                     boost::dynamic_pointer_cast<GiveObjectToEmpireOrder>(it->second))
                 {
                     if (order->ObjectID() == planet->ID()) {
-                        HumanClientApp::GetApp()->Orders().RecindOrder(it->first);
+                        HumanClientApp::GetApp()->Orders().RescindOrder(it->first);
                         // could break here, but won't to ensure there are no problems with doubled orders
                     }
                 }
@@ -2038,7 +2038,7 @@ namespace {
             for (OrderSet::const_iterator it = orders.begin(); it != orders.end(); ++it) {
                 if (boost::shared_ptr<ColonizeOrder> order = boost::dynamic_pointer_cast<ColonizeOrder>(it->second)) {
                     if (order->ShipID() == ship->ID()) {
-                        HumanClientApp::GetApp()->Orders().RecindOrder(it->first);
+                        HumanClientApp::GetApp()->Orders().RescindOrder(it->first);
                         // could break here, but won't to ensure there are no problems with doubled orders
                     }
                 }
@@ -2050,7 +2050,7 @@ namespace {
             for (OrderSet::const_iterator it = orders.begin(); it != orders.end(); ++it) {
                if (boost::shared_ptr<InvadeOrder> order = boost::dynamic_pointer_cast<InvadeOrder>(it->second)) {
                     if (order->ShipID() == ship->ID()) {
-                        HumanClientApp::GetApp()->Orders().RecindOrder(it->first);
+                        HumanClientApp::GetApp()->Orders().RescindOrder(it->first);
                         // could break here, but won't to ensure there are no problems with doubled orders
                     }
                 }
@@ -2062,7 +2062,7 @@ namespace {
             for (OrderSet::const_iterator it = orders.begin(); it != orders.end(); ++it) {
                 if (boost::shared_ptr<ScrapOrder> order = boost::dynamic_pointer_cast<ScrapOrder>(it->second)) {
                     if (order->ObjectID() == ship->ID()) {
-                        HumanClientApp::GetApp()->Orders().RecindOrder(it->first);
+                        HumanClientApp::GetApp()->Orders().RescindOrder(it->first);
                         // could break here, but won't to ensure there are no problems with doubled orders
                     }
                 }
@@ -2074,7 +2074,7 @@ namespace {
             for (OrderSet::const_iterator it = orders.begin(); it != orders.end(); ++it) {
                if (boost::shared_ptr<BombardOrder> order = boost::dynamic_pointer_cast<BombardOrder>(it->second)) {
                     if (order->ShipID() == ship->ID()) {
-                        HumanClientApp::GetApp()->Orders().RecindOrder(it->first);
+                        HumanClientApp::GetApp()->Orders().RescindOrder(it->first);
                         // could break here, but won't to ensure there are no problems with doubled orders
                     }
                 }
@@ -2100,7 +2100,7 @@ void SidePanel::PlanetPanel::ClickColonize() {
 
     if (it != pending_colonization_orders.end()) {
         // cancel previous colonization order for planet
-        HumanClientApp::GetApp()->Orders().RecindOrder(it->second);
+        HumanClientApp::GetApp()->Orders().RescindOrder(it->second);
 
     } else {
         // find colony ship and order it to colonize
@@ -2146,7 +2146,7 @@ void SidePanel::PlanetPanel::ClickInvade() {
         // cancel previous invasion orders for this planet
         for (std::set<int>::const_iterator o_it = planet_invade_orders.begin();
              o_it != planet_invade_orders.end(); ++o_it)
-        { HumanClientApp::GetApp()->Orders().RecindOrder(*o_it); }
+        { HumanClientApp::GetApp()->Orders().RescindOrder(*o_it); }
 
     } else {
         // order selected invasion ships to invade planet
@@ -2194,7 +2194,7 @@ void SidePanel::PlanetPanel::ClickBombard() {
         // cancel previous bombard orders for this planet
         for (std::set<int>::const_iterator o_it = planet_bombard_orders.begin();
              o_it != planet_bombard_orders.end(); ++o_it)
-        { HumanClientApp::GetApp()->Orders().RecindOrder(*o_it); }
+        { HumanClientApp::GetApp()->Orders().RescindOrder(*o_it); }
 
     } else {
         // order selected bombard ships to bombard planet

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -2996,6 +2996,10 @@ Split This Design Ships From Fleet
 FW_SPLIT_SHIPS_ALL_DESIGNS
 Split Ships Into Fleets For Each Design
 
+# Remove old visibility information from the client empire's saved information
+FW_ORDER_DISMISS_SENSOR_GHOST
+Dismiss Sensor Ghost
+
 ORDER_SHIP_SCRAP
 Scrap Ship
 

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -2515,7 +2515,7 @@ void Universe::ForgetKnownObject(int empire_id, int object_id) {
         return;
 
     TemporaryPtr<UniverseObject> obj = objects.Object(object_id);
-    if(!obj) {
+    if (!obj) {
         ErrorLogger() << "ForgetKnownObject empire: " << empire_id
                       << " bad object id: " << object_id;
         return;

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -2536,6 +2536,17 @@ void Universe::ForgetKnownObject(int empire_id, int object_id) {
             ForgetKnownObject(empire_id, child->ID());
     }
 
+    if (int container_id = obj->ContainerObjectID() != INVALID_OBJECT_ID) {
+        if (TemporaryPtr<UniverseObject> container = objects.Object(container_id)) {
+            if (TemporaryPtr<System> system = boost::dynamic_pointer_cast<System>(container))
+                system->Remove(object_id);
+            else if (TemporaryPtr<Planet> planet = boost::dynamic_pointer_cast<Planet>(container))
+                planet->RemoveBuilding(object_id);
+            else if (TemporaryPtr<Fleet> fleet = boost::dynamic_pointer_cast<Fleet>(container))
+                fleet->RemoveShip(object_id);
+        }
+    }
+
     objects.Remove(object_id);
 }
 

--- a/universe/Universe.h
+++ b/universe/Universe.h
@@ -318,6 +318,10 @@ public:
     /** Applies empire-object visibilities set by effects. */
     void            ApplyEffectDerivedVisibilities();
 
+    /** If an \p empire_id can't currently see \p object_id, then remove
+     * \p object_id' object from the object map and the set of known objects. */
+    void            ForgetKnownObject(int empire_id, int object_id);
+
     /** Sets visibility for indicated \a empire_id of object with \a object_id
       * a vis */
     void            SetEmpireObjectVisibility(int empire_id, int object_id, Visibility vis);

--- a/util/Order.cpp
+++ b/util/Order.cpp
@@ -1304,3 +1304,35 @@ bool GiveObjectToEmpireOrder::UndoImpl() const {
     }
     return false;
 }
+
+////////////////////////////////////////////////
+// ForgetOrder
+////////////////////////////////////////////////
+ForgetOrder::ForgetOrder() :
+    Order(),
+    m_object_id(INVALID_OBJECT_ID)
+{}
+
+ForgetOrder::ForgetOrder(int empire, int object_id) :
+    Order(empire),
+    m_object_id(object_id)
+{}
+
+void ForgetOrder::ExecuteImpl() const {
+    ValidateEmpireID();
+    int empire_id = EmpireID();
+    TemporaryPtr<Fleet> fleet = GetFleet(m_object_id);
+    if (!fleet)
+        return;
+    if (fleet->OwnedBy(empire_id)) {
+        ErrorLogger() << "ForgetOrder::ExecuteImpl empire: " << empire_id
+                      << " on fleet: " << fleet->ID()
+                      << ". Trying to forget visibility of own fleet.";
+        return;
+    }
+
+    DebugLogger() << "ForgetOrder::ExecuteImpl empire: " << empire_id
+                  << " on fleet: " << fleet->ID();
+
+    GetUniverse().ForgetKnownObject(empire_id, fleet->ID());
+}

--- a/util/Order.cpp
+++ b/util/Order.cpp
@@ -1321,18 +1321,9 @@ ForgetOrder::ForgetOrder(int empire, int object_id) :
 void ForgetOrder::ExecuteImpl() const {
     ValidateEmpireID();
     int empire_id = EmpireID();
-    TemporaryPtr<UniverseObject> obj = GetUniverse().Objects().Object(m_object_id);
-    if (!obj)
-        return;
-    if (obj->OwnedBy(empire_id)) {
-        ErrorLogger() << "ForgetOrder::ExecuteImpl empire: " << empire_id
-                      << " for object: " << obj->ID()
-                      << ". Trying to forget visibility of own object.";
-        return;
-    }
 
     DebugLogger() << "ForgetOrder::ExecuteImpl empire: " << empire_id
-                  << " for object: " << obj->ID();
+                  << " for object: " << m_object_id;
 
-    GetUniverse().ForgetKnownObject(empire_id, obj->ID());
+    GetUniverse().ForgetKnownObject(empire_id, m_object_id);
 }

--- a/util/Order.cpp
+++ b/util/Order.cpp
@@ -1321,18 +1321,18 @@ ForgetOrder::ForgetOrder(int empire, int object_id) :
 void ForgetOrder::ExecuteImpl() const {
     ValidateEmpireID();
     int empire_id = EmpireID();
-    TemporaryPtr<Fleet> fleet = GetFleet(m_object_id);
-    if (!fleet)
+    TemporaryPtr<UniverseObject> obj = GetUniverse().Objects().Object(m_object_id);
+    if (!obj)
         return;
-    if (fleet->OwnedBy(empire_id)) {
+    if (obj->OwnedBy(empire_id)) {
         ErrorLogger() << "ForgetOrder::ExecuteImpl empire: " << empire_id
-                      << " on fleet: " << fleet->ID()
-                      << ". Trying to forget visibility of own fleet.";
+                      << " for object: " << obj->ID()
+                      << ". Trying to forget visibility of own object.";
         return;
     }
 
     DebugLogger() << "ForgetOrder::ExecuteImpl empire: " << empire_id
-                  << " on fleet: " << fleet->ID();
+                  << " for object: " << obj->ID();
 
-    GetUniverse().ForgetKnownObject(empire_id, fleet->ID());
+    GetUniverse().ForgetKnownObject(empire_id, obj->ID());
 }

--- a/util/Order.h
+++ b/util/Order.h
@@ -675,6 +675,39 @@ private:
     void serialize(Archive& ar, const unsigned int version);
 };
 
+/////////////////////////////////////////////////////
+// ForgetOrder
+/////////////////////////////////////////////////////
+/** ForgetOrder removes the object from the empire's known objects. */
+class FO_COMMON_API ForgetOrder : public Order {
+public:
+    /** \name Structors */ //@{
+    ForgetOrder();
+    ForgetOrder(int empire, int object_id);
+    //@}
+
+    /** \name Accessors */ //@{
+    int             ObjectID() const { return m_object_id; }///< returns ID of object selected in this order
+    //@}
+
+private:
+    /**
+     *  Preconditions:
+     *     - m_object_id must be the ID of an object not owned by issuing empire
+     *
+     *  Postconditions:
+     *     - the object is removed from the table of known objects.
+     */
+    virtual void    ExecuteImpl() const;
+
+    int m_object_id;
+
+    friend class boost::serialization::access;
+    template <class Archive>
+    void serialize(Archive& ar, const unsigned int version);
+};
+
+
 // Note: *::serialize() implemented in SerializeOrderSet.cpp.
 
 #endif // _Order_h_

--- a/util/OrderSet.cpp
+++ b/util/OrderSet.cpp
@@ -30,7 +30,7 @@ void OrderSet::ApplyOrders() {
         it->second->Execute();
 }
 
-bool OrderSet::RecindOrder(int order) {
+bool OrderSet::RescindOrder(int order) {
     bool retval = false;
     OrderMap::iterator it = m_orders.find(order);
     if (it != m_orders.end()) {

--- a/util/OrderSet.h
+++ b/util/OrderSet.h
@@ -59,7 +59,7 @@ public:
         client-side during game loading. */
     void           ApplyOrders();
 
-    bool           RecindOrder(int order);    ///< removes the order from the OrderSet; returns true on success, false if there was no such order or the order is non-recindable
+    bool           RescindOrder(int order);    ///< removes the order from the OrderSet; returns true on success, false if there was no such order or the order is non-rescindable
     void           Reset(); ///< clears all orders; should be called at the beginning of a new turn
     //@}
 

--- a/util/SerializeOrderSet.cpp
+++ b/util/SerializeOrderSet.cpp
@@ -28,6 +28,7 @@ BOOST_CLASS_EXPORT(ShipDesignOrder)
 BOOST_CLASS_EXPORT(ScrapOrder)
 BOOST_CLASS_EXPORT(AggressiveOrder)
 BOOST_CLASS_EXPORT(GiveObjectToEmpireOrder)
+BOOST_CLASS_EXPORT(ForgetOrder)
 
 
 template <class Archive>
@@ -185,6 +186,13 @@ void GiveObjectToEmpireOrder::serialize(Archive& ar, const unsigned int version)
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Order)
         & BOOST_SERIALIZATION_NVP(m_object_id)
         & BOOST_SERIALIZATION_NVP(m_recipient_empire_id);
+}
+
+template <class Archive>
+void ForgetOrder::serialize(Archive& ar, const unsigned int version)
+{
+    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Order)
+        & BOOST_SERIALIZATION_NVP(m_object_id);
 }
 
 template <class Archive>


### PR DESCRIPTION
The UI displays known objects that have been detected in previous turns as partially greyed out.

Sometimes these fleets disappear/merge/die outside of the view of the player empire.  Then the ghost fleets are displayed in their last known state forever, even though the player is fairly certain that the fleet no longer exists and is very certain that they want the detected fleet removed from the display.

This PR adds a context menu option "Dismiss Sensor Ghost" to ghost fleets.  The option removes the fleet from the table of known objects. If the fleet is detected again it is re-added to the table of known objects as normal.

This issue has been brought up multiple times before now, most recently by Starionx and @MatGB  in [the forum](http://freeorion.org/forum/viewtopic.php?f=28&t=10148&sid=ef956232905082d5a4b97150b6a278aa&start=15).
