### PR TITLE
add tech turn and RP requirement to tech panel (2)

### DIFF
--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -3102,6 +3102,9 @@ Navigation
 TECH_TOTAL_COST_STR
 %1% RP and %2% Turns
 
+TECH_TOTAL_COST_ALT_STR
+%1% RP / %2% Turns
+
 TECH_TURN_COST_STR
 +%1% / %2% RP
 


### PR DESCRIPTION
adds tech RP and turn cost to the lower right of tech panels, for unresearched techs.
also adjusts tech panel width, and distance between the panels

![tech_tree](https://cloud.githubusercontent.com/assets/12985960/17085712/1382fdf8-51df-11e6-8843-8889ee561e8a.jpg)
