### PR TITLE
Bugfix in ShipdesignAI

### DIFF
--- a/default/python/AI/ShipDesignAI.py
+++ b/default/python/AI/ShipDesignAI.py
@@ -548,7 +548,7 @@ class ShipDesignCache(object):
         print "Caching buildable ship parts per planet..."
         for pid in inhabited_planets:
             local_testhulls = [hull for hull in self.testhulls
-                               if hull in self.hulls_for_planets[pid][:number_of_testhulls]]
+                               if hull in self.hulls_for_planets[pid]]
             this_planet = universe.getPlanet(pid)
             if verbose:
                 print "Testhulls for %s are %s" % (this_planet, local_testhulls)


### PR DESCRIPTION
Fixes a bug where the AI would sometimes think it can't build parts at a
planet despite it actually being able to.

Basically happened whenever a buildable hull exists as testdesign but is not considered as local testhull.
