### PR TITLE
Fix experimentor placement potentially disjoining the map

### DIFF
--- a/default/python/universe_generation/monsters.py
+++ b/default/python/universe_generation/monsters.py
@@ -4,6 +4,70 @@ import freeorion as fo
 import util
 import statistics
 import universe_tables
+from galaxy import DisjointSets
+
+
+monsters_that_alter_starlanes = {"SM_EXP_OUTPOST"}
+
+
+class MapAlteringMonsters(object):
+    def __init__(self, systems):
+        self.systems = systems
+        self.placed = []
+        self.removed_lanes = set()
+        self.starlanes = [(s1, s2) for s1 in systems for s2 in fo.sys_get_starlanes(s1) if s1 < s2]
+
+    def matches(self, plan):
+        return plan.name() in monsters_that_alter_starlanes
+
+    def can_place_at(self, system, plan):
+        # Check if the map altering monster fleet ''plan'' can be placed at ''system''
+        # without disjoining the galaxy map.
+        # Compute the disjoint set of the galaxy without the starlanes
+        # from the proposed system.  Return False if there will be more
+        # connected regions than the number of placed experimentor
+        # outposts plus one, otherwise True.
+        local_lanes = {(min(system, s), max(system, s)) for s in fo.sys_get_starlanes(system)}
+
+        dsets = DisjointSets()
+        for s3 in self.systems:
+            dsets.add(s3)
+
+        for lane in self.starlanes:
+            if lane in self.removed_lanes or lane in local_lanes:
+                continue
+            dsets.link(lane[0], lane[1])
+
+        num_contiguous_regions = len(dsets.complete_sets())
+        expected_num_contiguous_regions = (len(self.placed) + 2)
+
+        if num_contiguous_regions > expected_num_contiguous_regions:
+            return False
+
+        if num_contiguous_regions < expected_num_contiguous_regions:
+            util.report_error("Number of contiguos regions %d is below the expected number "
+                              "of contiguous regions %d when placing %d monster %s that can "
+                              "break starlanes."
+                              % (num_contiguous_regions, expected_num_contiguous_regions,
+                                 len(self.placed) + 1, plan.name()))
+            return False
+
+        return True
+
+    def place(self, system, plan):
+        # create map altering monster fleet ''plan'' at ''system''.
+        local_lanes = {(min(system, s), max(system, s)) for s in fo.sys_get_starlanes(system)}
+
+        try:
+            populate_monster_fleet(plan, system)
+            if system not in self.placed:
+                self.placed.append(system)
+            self.removed_lanes |= local_lanes
+
+        except RuntimeError as e:
+            util.report_error(str(e))
+
+
 def populate_monster_fleet(fleet_plan, system):
     """
     Create a monster fleet in ''system'' according to ''fleet_plan''
@@ -26,7 +90,6 @@ def populate_monster_fleet(fleet_plan, system):
             raise RuntimeError(errstr)
 
     print "Spawn", fleet_plan.name(), "at", fo.get_name(system)
-
 
 
 def generate_monsters(monster_freq, systems):
@@ -80,6 +143,10 @@ def generate_monsters(monster_freq, systems):
         if fleet_plan.name() in nest_name_map.values():
             statistics.tracked_monsters_chance[fleet_plan.name()] = basic_chance * fleet_plan.spawn_rate()
 
+    # initialize a manager for monsters that can alter the map
+    # required to prevent their placement from disjoining the map
+    map_altering_monsters = MapAlteringMonsters(systems)
+
     # for each system in the list that has been passed to this function, find a monster fleet that can be spawned at
     # the system and which hasn't already been added too many times, then attempt to add that monster fleet by
     # testing the spawn rate chance
@@ -98,7 +165,11 @@ def generate_monsters(monster_freq, systems):
 
         # filter out all monster fleets whose location condition allows this system and whose counter hasn't reached 0.
         # Note: The WithinStarlaneJumps condition in fp.location() is the most time costly function in universe generation.
-        suitable_fleet_plans = [fp for fp in fleet_plans if spawn_limits[fp] and fp.location(system)]
+        suitable_fleet_plans = [fp for fp in fleet_plans
+                                if spawn_limits[fp]
+                                and fp.location(system)
+                                and (not map_altering_monsters.matches(fp)
+                                     or map_altering_monsters.can_place_at(system, fp))]
         # if there are no suitable monster fleets for this system, continue with the next
         if not suitable_fleet_plans:
             continue
@@ -120,12 +191,15 @@ def generate_monsters(monster_freq, systems):
         # all prerequisites and the test have been met, now spawn this monster fleet in this system
         # create monster fleet
         try:
-            populate_monster_fleet(fleet_plan, system)
+            if map_altering_monsters.matches(fleet_plan):
+                map_altering_monsters.place(system, fleet_plan)
+            else:
+                populate_monster_fleet(fleet_plan, system)
             # decrement counter for this monster fleet
             spawn_limits[fleet_plan] -= 1
 
         except RuntimeError as e:
-            print >> sys.stderr, str(e)
+            util.report_error(str(e))
             continue
 
     print "Actual # monster fleets placed: %d; Total Placement Expectation: %.1f" % (actual_tally, expectation_tally)


### PR DESCRIPTION
This is an alternative implementation of @LGM-Doyle's PR #834, where I try to stick closer to the behaviour of the original code. **_ATTENTION**_: This PR is **_not**_ intended to be merged. Its purpose is only for review and demonstration.
#834 strictly splits the placing of the experimentor monster fleet off the placement of all the other monster fleets, which has several issues:
- The spawn limit parameter gets handled differently for the experimentors.
- It requires some code to make sure the experimentor monster fleet gets filtered out of the complete monster fleet list in the section where all the "normal" monsters get placed, and some code to pick the experimentor monster fleet from this list in the function that deals only with experimentor placement.
- The way it's implemented breaks if someone changes the experimentor spawn limit, or scripts another starlane changing space monster and thinks adding that to the list of `monsters_that_alter_starlanes` is sufficient for things to work correctly.

So I took @LGM-Doyle's code, rearranged it and adjusted a few things so that the `generate_monsters` function once again handles all the monsters, experimentors included, and do the special handling of the experimentors within that function.

@LGM-Doyle, what do you think?
