### PR TITLE
Improve FleetWnd split fleet

### DIFF
--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -3491,6 +3491,7 @@ void FleetWnd::FleetRightClicked(GG::ListBox::iterator it, const GG::Pt& pt, con
         }
 
         case 4: {   // split
+            ScopedTimer split_fleet_timer("FleetWnd::SplitFleet", true);
             // remove first ship from set, so it stays in its existing fleet
             std::set<int>::iterator it = ship_ids_set.begin();
             ship_ids_set.erase(it);

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -4060,13 +4060,6 @@ void MapWnd::RemoveFleet(int fleet_id) {
     RefreshFleetButtons();
 }
 
-void MapWnd::SetFleetMovementLine(const FleetButton* fleet_button) {
-    assert(fleet_button);
-    // each fleet represented by button could have different move path
-    for (std::vector<int>::const_iterator it = fleet_button->Fleets().begin(); it != fleet_button->Fleets().end(); ++it)
-        SetFleetMovementLine(*it);
-}
-
 void MapWnd::SetFleetMovementLine(int fleet_id) {
     if (fleet_id == INVALID_OBJECT_ID)
         return;

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -286,11 +286,6 @@ namespace {
         GetOptionsDB().Set(option_name, !initially_enabled);
         return !initially_enabled;
     }
-
-
-    double last_render_output = 0.0;
-    double num_render = 0.0;
-    double num_update = 0.0;
 }
 
 
@@ -1415,15 +1410,6 @@ void MapWnd::Render() {
         return; // as of this writing, the design screen has a fully opaque background
     if (m_research_wnd->Visible())
         return;
-
-    num_render += 1.0;
-    if ((GG::GUI::GetGUI()->Ticks() - last_render_output) > 1000.0){
-        last_render_output = GG::GUI::GetGUI()->Ticks();
-        double up_per_render = num_update / num_render;
-        DebugLogger() << "Updates per render " << up_per_render << "(" << num_update <<"/"<<num_render<<")";
-        num_update = 0;
-        num_render = 0;
-    }
 
     DeferredRefreshFleetButtons();
 
@@ -4402,7 +4388,6 @@ void MapWnd::DeferredRefreshFleetButtons() {
         return;
     m_deferred_refresh_fleet_buttons = false;
 
-    num_update += 1.0;
     ScopedTimer timer("RefreshFleetButtons()", true);
 
     // determine fleets that need buttons so that fleets at the same location can

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -4389,6 +4389,36 @@ namespace {
                 && fleet->SystemID() == INVALID_OBJECT_ID);
     }
 
+    /** TEST DELETE below*/
+    template <typename K>
+    void test_map_equivalence(
+        boost::unordered_map<std::pair<K, int>, std::vector<int> > & new_map,
+        std::map<K, std::map<int, std::vector<TemporaryPtr<const Fleet> > > > &ref_map,
+        std::string const & errmsg) {
+        boost::unordered_map<std::pair<K, int>, std::vector<int> > converted_map;
+        for (typename std::map<K, std::map<int, std::vector<TemporaryPtr<const Fleet> > > >::const_iterator it = ref_map.begin();
+             it != ref_map.end(); ++it) {
+            for (std::map<int, std::vector<TemporaryPtr<const Fleet> > >::const_iterator jt = it->second.begin();
+                 jt != it->second.end(); ++jt) {
+                for (std::vector<TemporaryPtr<const Fleet> >::const_iterator kt = jt->second.begin();
+                     kt != jt->second.end(); ++kt) {
+                    converted_map[std::make_pair(it->first, jt->first)].push_back((*kt)->ID());
+                    if (new_map.count(std::make_pair(it->first, jt->first)) == 0 )
+                        ErrorLogger() << " missing system, empire or loc,empire key "
+                                      << "(sys,owner,fleet) = (" << (*kt)->SystemID() <<", "
+                                      <<jt->first<<", "<<(*kt)->Name()<<" ("<<(*kt)->ID()<<")";
+                }
+            }
+        }
+        if (new_map != converted_map) {
+            ErrorLogger() << "new_map != converted_map "<< errmsg
+                          << " ref size " << ref_map.size() << " new size " << new_map.size();
+        } else {
+            DebugLogger() << "new_map and old match for " << errmsg;
+        }
+    }
+    /** TEST DELETE above*/
+
 }
 
 void MapWnd::RefreshFleetButtons()
@@ -4576,6 +4606,13 @@ void MapWnd::DeferredRefreshFleetButtons() {
             }
         }
 
+    }{ScopedTimer timer("RefreshFleetButtons() P234 check all", true);
+    /** TEST DELETE below*/
+
+        test_map_equivalence(departing_fleets_new, departing_fleets, "departing_fleets");
+        test_map_equivalence(stationary_fleets_new, stationary_fleets, "stationary_fleets");
+        test_map_equivalence(moving_fleets_new, moving_fleets, "moving_fleets");
+    /** TEST_DELETE above*/
 
     }{ScopedTimer timer("RefreshFleetButtons() P4 clearing", true);
     // clear old fleet buttons

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -4445,24 +4445,7 @@ void MapWnd::DeferredRefreshFleetButtons() {
         }
 
     }{ScopedTimer timer("RefreshFleetButtons() P4 clearing", true);
-    // clear old fleet buttons
-    m_fleet_buttons.clear();            // duplicates pointers in following containers
-
-    for (std::map<int, std::set<FleetButton*> >::iterator it = m_stationary_fleet_buttons.begin(); it != m_stationary_fleet_buttons.end(); ++it)
-        for (std::set<FleetButton*>::iterator set_it = it->second.begin(); set_it != it->second.end(); ++set_it)
-            delete *set_it;
-    m_stationary_fleet_buttons.clear();
-
-    for (std::map<int, std::set<FleetButton*> >::iterator it = m_departing_fleet_buttons.begin(); it != m_departing_fleet_buttons.end(); ++it)
-        for (std::set<FleetButton*>::iterator set_it = it->second.begin(); set_it != it->second.end(); ++set_it)
-            delete *set_it;
-    m_departing_fleet_buttons.clear();
-
-    for (std::map<std::pair<double, double>, std::set<FleetButton*> >::iterator it = m_moving_fleet_buttons.begin(); it != m_moving_fleet_buttons.end(); ++it)
-        for (std::set<FleetButton*>::iterator set_it = it->second.begin(); set_it != it->second.end(); ++set_it)
-            delete *set_it;
-    m_moving_fleet_buttons.clear();
-
+        DeleteFleetButtons();
     }
     // create new fleet buttons for fleets...
     const FleetButton::SizeType FLEETBUTTON_SIZE = FleetButtonSizeType();
@@ -4518,6 +4501,28 @@ void MapWnd::CreateFleetButtonsOfType (
         GG::Connect(fb->LeftClickedSignal,  boost::bind(&MapWnd::FleetButtonLeftClicked,    this, fb));
         GG::Connect(fb->RightClickedSignal, boost::bind(&MapWnd::FleetButtonRightClicked,   this, fb));
     }
+}
+
+void MapWnd::DeleteFleetButtons() {
+    m_fleet_buttons.clear();            // duplicates pointers in following containers
+
+    for (std::map<int, std::set<FleetButton*> >::iterator it = m_stationary_fleet_buttons.begin();
+         it != m_stationary_fleet_buttons.end(); ++it)
+        for (std::set<FleetButton*>::iterator set_it = it->second.begin(); set_it != it->second.end(); ++set_it)
+            delete *set_it;
+    m_stationary_fleet_buttons.clear();
+
+    for (std::map<int, std::set<FleetButton*> >::iterator it = m_departing_fleet_buttons.begin();
+         it != m_departing_fleet_buttons.end(); ++it)
+        for (std::set<FleetButton*>::iterator set_it = it->second.begin(); set_it != it->second.end(); ++set_it)
+            delete *set_it;
+    m_departing_fleet_buttons.clear();
+
+    for (std::map<std::pair<double, double>, std::set<FleetButton*> >::iterator it = m_moving_fleet_buttons.begin();
+         it != m_moving_fleet_buttons.end(); ++it)
+        for (std::set<FleetButton*>::iterator set_it = it->second.begin(); set_it != it->second.end(); ++set_it)
+            delete *set_it;
+    m_moving_fleet_buttons.clear();
 }
 
 void MapWnd::RemoveFleetsStateChangedSignal(const std::vector<TemporaryPtr<Fleet> >& fleets) {
@@ -5328,29 +5333,7 @@ void MapWnd::Sanitize() {
 
     m_starlane_endpoints.clear();
 
-    for (std::map<int, std::set<FleetButton*> >::iterator it = m_stationary_fleet_buttons.begin(); it != m_stationary_fleet_buttons.end(); ++it) {
-        std::set<FleetButton*>& set = it->second;
-        for (std::set<FleetButton*>::iterator set_it = set.begin(); set_it != set.end(); ++set_it)
-            delete *set_it;
-        set.clear();
-    }
-    m_stationary_fleet_buttons.clear();
-
-    for (std::map<int, std::set<FleetButton*> >::iterator it = m_departing_fleet_buttons.begin(); it != m_departing_fleet_buttons.end(); ++it) {
-        std::set<FleetButton*>& set = it->second;
-        for (std::set<FleetButton*>::iterator set_it = set.begin(); set_it != set.end(); ++set_it)
-            delete *set_it;
-        set.clear();
-    }
-    m_departing_fleet_buttons.clear();
-
-    for (std::map<std::pair<double, double>, std::set<FleetButton*> >::iterator pos_it = m_moving_fleet_buttons.begin();
-         pos_it != m_moving_fleet_buttons.end(); ++pos_it)
-        for (std::set<FleetButton*>::iterator set_it = pos_it->second.begin(); set_it != pos_it->second.end(); ++set_it)
-            delete *set_it;
-    m_moving_fleet_buttons.clear();
-
-    m_fleet_buttons.clear();    // contains duplicate pointers of those in moving, departing and stationary set / maps, so don't need to delete again
+    DeleteFleetButtons();
 
     for (boost::unordered_map<int, boost::signals2::connection>::iterator it = m_fleet_state_change_signals.begin(); it != m_fleet_state_change_signals.end(); ++it)
         it->second.disconnect();

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -1425,6 +1425,8 @@ void MapWnd::Render() {
         num_render = 0;
     }
 
+    DeferredRefreshFleetButtons();
+
     glMatrixMode(GL_MODELVIEW);
     glPushMatrix();
     glLoadIdentity();
@@ -4338,7 +4340,15 @@ std::pair<double, double> MapWnd::MovingFleetMapPositionOnLane(TemporaryPtr<cons
     return ScreenPosOnStarane(fleet->X(), fleet->Y(), lane.first, lane.second, screen_lane_endpoints);
 }
 
-void MapWnd::RefreshFleetButtons() {
+void MapWnd::RefreshFleetButtons()
+{ m_deferred_refresh_fleet_buttons = true; }
+
+void MapWnd::DeferredRefreshFleetButtons() {
+
+    if (!m_deferred_refresh_fleet_buttons)
+        return;
+    m_deferred_refresh_fleet_buttons = false;
+
     num_update += 1.0;
     ScopedTimer timer("RefreshFleetButtons()", true);
 

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -4388,37 +4388,6 @@ namespace {
         return (fleet->FinalDestinationID() != INVALID_OBJECT_ID
                 && fleet->SystemID() == INVALID_OBJECT_ID);
     }
-
-    /** TEST DELETE below*/
-    template <typename K>
-    void test_map_equivalence(
-        boost::unordered_map<std::pair<K, int>, std::vector<int> > & new_map,
-        std::map<K, std::map<int, std::vector<TemporaryPtr<const Fleet> > > > &ref_map,
-        std::string const & errmsg) {
-        boost::unordered_map<std::pair<K, int>, std::vector<int> > converted_map;
-        for (typename std::map<K, std::map<int, std::vector<TemporaryPtr<const Fleet> > > >::const_iterator it = ref_map.begin();
-             it != ref_map.end(); ++it) {
-            for (std::map<int, std::vector<TemporaryPtr<const Fleet> > >::const_iterator jt = it->second.begin();
-                 jt != it->second.end(); ++jt) {
-                for (std::vector<TemporaryPtr<const Fleet> >::const_iterator kt = jt->second.begin();
-                     kt != jt->second.end(); ++kt) {
-                    converted_map[std::make_pair(it->first, jt->first)].push_back((*kt)->ID());
-                    if (new_map.count(std::make_pair(it->first, jt->first)) == 0 )
-                        ErrorLogger() << " missing system, empire or loc,empire key "
-                                      << "(sys,owner,fleet) = (" << (*kt)->SystemID() <<", "
-                                      <<jt->first<<", "<<(*kt)->Name()<<" ("<<(*kt)->ID()<<")";
-                }
-            }
-        }
-        if (new_map != converted_map) {
-            ErrorLogger() << "new_map != converted_map "<< errmsg
-                          << " ref size " << ref_map.size() << " new size " << new_map.size();
-        } else {
-            DebugLogger() << "new_map and old match for " << errmsg;
-        }
-    }
-    /** TEST DELETE above*/
-
 }
 
 void MapWnd::RefreshFleetButtons()
@@ -4605,14 +4574,6 @@ void MapWnd::DeferredRefreshFleetButtons() {
                 ErrorLogger() << "Fleet "<< fleet->Name() << " is not stationary, departing from a system or in transit.";
             }
         }
-
-    }{ScopedTimer timer("RefreshFleetButtons() P234 check all", true);
-    /** TEST DELETE below*/
-
-        test_map_equivalence(departing_fleets_new, departing_fleets, "departing_fleets");
-        test_map_equivalence(stationary_fleets_new, stationary_fleets, "stationary_fleets");
-        test_map_equivalence(moving_fleets_new, moving_fleets, "moving_fleets");
-    /** TEST_DELETE above*/
 
     }{ScopedTimer timer("RefreshFleetButtons() P4 clearing", true);
     // clear old fleet buttons

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -4273,7 +4273,8 @@ void MapWnd::DoFleetButtonsLayout() {
 
     // position moving fleet buttons
     for (boost::unordered_map<std::pair<double, double>, boost::unordered_set<FleetButton*> >::iterator pos_it = m_moving_fleet_buttons.begin();
-         pos_it != m_moving_fleet_buttons.end(); ++pos_it) {
+         pos_it != m_moving_fleet_buttons.end(); ++pos_it)
+    {
         for (boost::unordered_set<FleetButton*>::iterator it = pos_it->second.begin(); it != pos_it->second.end(); ++it) {
             FleetButton* fb = *it;
 
@@ -4331,7 +4332,7 @@ namespace {
     TemporaryPtr<const Fleet> IsQualifiedFleet(const TemporaryPtr<const UniverseObject>& obj,
                                                int empire_id,
                                                const std::set<int>& known_destroyed_objects,
-                                               const std::set<int>& stale_object_info){
+                                               const std::set<int>& stale_object_info) {
         int object_id = obj->ID();
         TemporaryPtr<const Fleet> fleet = boost::dynamic_pointer_cast<const Fleet>(obj);
 
@@ -4339,16 +4340,18 @@ namespace {
             && !fleet->Empty()
             && (known_destroyed_objects.count(object_id) == 0)
             && (stale_object_info.count(object_id) == 0))
+        {
             return fleet;
+        }
         return TemporaryPtr<const Fleet>();
     }
 
     /** If the \p fleet has orders and is departing from a valid system, return the system*/
     TemporaryPtr<const System> IsDepartingFromSystem(const TemporaryPtr<const Fleet>& fleet) {
-
         if (fleet->FinalDestinationID() != INVALID_OBJECT_ID
             && !fleet->TravelRoute().empty()
-            && fleet->SystemID() != INVALID_OBJECT_ID) {
+            && fleet->SystemID() != INVALID_OBJECT_ID)
+        {
             TemporaryPtr<const System> system = GetSystem(fleet->SystemID());
             if (system)
                 return system;
@@ -4362,7 +4365,8 @@ namespace {
     TemporaryPtr<const System> IsStationaryInSystem(const TemporaryPtr<const Fleet>& fleet) {
         if ((fleet->FinalDestinationID() == INVALID_OBJECT_ID
              || fleet->TravelRoute().empty())
-            && fleet->SystemID() != INVALID_OBJECT_ID) {
+            && fleet->SystemID() != INVALID_OBJECT_ID)
+        {
             TemporaryPtr<const System> system = GetSystem(fleet->SystemID());
             if (system)
                 return system;
@@ -4402,7 +4406,8 @@ void MapWnd::DeferredRefreshFleetButtons() {
     LocationXEmpireToFleetsMap moving_fleets;
 
     for (std::map<int, TemporaryPtr<UniverseObject> >::const_iterator candidate_it = Objects().ExistingFleetsBegin();
-         candidate_it != Objects().ExistingFleetsEnd(); ++candidate_it) {
+         candidate_it != Objects().ExistingFleetsEnd(); ++candidate_it)
+    {
         TemporaryPtr<const Fleet> fleet = IsQualifiedFleet(
             candidate_it->second, client_empire_id,
             this_client_known_destroyed_objects, this_client_stale_object_info);
@@ -4450,7 +4455,8 @@ template <typename K>
 void MapWnd::CreateFleetButtonsOfType (
     boost::unordered_map<K, boost::unordered_set<FleetButton*> >& type_fleet_buttons,
     const boost::unordered_map<std::pair<K, int>, std::vector<int> > &fleets_map,
-    const FleetButton::SizeType & fleet_button_size) {
+    const FleetButton::SizeType & fleet_button_size)
+{
     for (typename boost::unordered_map<std::pair<K, int>, std::vector<int> >::const_iterator fleets_it = fleets_map.begin();
          fleets_it != fleets_map.end(); ++fleets_it)
     {
@@ -4482,20 +4488,26 @@ void MapWnd::DeleteFleetButtons() {
 
     for (boost::unordered_map<int, boost::unordered_set<FleetButton*> >::iterator it = m_stationary_fleet_buttons.begin();
          it != m_stationary_fleet_buttons.end(); ++it)
+    {
         for (boost::unordered_set<FleetButton*>::iterator set_it = it->second.begin(); set_it != it->second.end(); ++set_it)
             delete *set_it;
+    }
     m_stationary_fleet_buttons.clear();
 
     for (boost::unordered_map<int, boost::unordered_set<FleetButton*> >::iterator it = m_departing_fleet_buttons.begin();
          it != m_departing_fleet_buttons.end(); ++it)
+    {
         for (boost::unordered_set<FleetButton*>::iterator set_it = it->second.begin(); set_it != it->second.end(); ++set_it)
             delete *set_it;
+    }
     m_departing_fleet_buttons.clear();
 
     for (boost::unordered_map<std::pair<double, double>, boost::unordered_set<FleetButton*> >::iterator
-             it = m_moving_fleet_buttons.begin(); it != m_moving_fleet_buttons.end(); ++it)
+         it = m_moving_fleet_buttons.begin(); it != m_moving_fleet_buttons.end(); ++it)
+    {
         for (boost::unordered_set<FleetButton*>::iterator set_it = it->second.begin(); set_it != it->second.end(); ++set_it)
             delete *set_it;
+    }
     m_moving_fleet_buttons.clear();
 }
 
@@ -5191,17 +5203,19 @@ void MapWnd::RefreshFleetButtonSelectionIndicators() {
             (*button_it)->SetSelected(false);
     }
 
-    for (boost::unordered_map<int, boost::unordered_set<FleetButton*> >::iterator it = m_departing_fleet_buttons.begin(); it != m_departing_fleet_buttons.end(); ++it) {
+    for (boost::unordered_map<int, boost::unordered_set<FleetButton*> >::iterator it = m_departing_fleet_buttons.begin();
+         it != m_departing_fleet_buttons.end(); ++it)
+    {
         boost::unordered_set<FleetButton*>& set = it->second;
         for (boost::unordered_set<FleetButton*>::iterator button_it = set.begin(); button_it != set.end(); ++button_it)
             (*button_it)->SetSelected(false);
     }
 
     for (boost::unordered_map<std::pair<double, double>, boost::unordered_set<FleetButton*> >::iterator pos_it = m_moving_fleet_buttons.begin();
-         pos_it != m_moving_fleet_buttons.end(); ++pos_it) {
-        for (boost::unordered_set<FleetButton*>::iterator it = pos_it->second.begin(); it != pos_it->second.end(); ++it) {
+         pos_it != m_moving_fleet_buttons.end(); ++pos_it)
+    {
+        for (boost::unordered_set<FleetButton*>::iterator it = pos_it->second.begin(); it != pos_it->second.end(); ++it)
             (*it)->SetSelected(false);
-        }
     }
 
     // add new selection indicators

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -286,6 +286,11 @@ namespace {
         GetOptionsDB().Set(option_name, !initially_enabled);
         return !initially_enabled;
     }
+
+
+    double last_render_output = 0.0;
+    double num_render = 0.0;
+    double num_update = 0.0;
 }
 
 
@@ -1410,6 +1415,15 @@ void MapWnd::Render() {
         return; // as of this writing, the design screen has a fully opaque background
     if (m_research_wnd->Visible())
         return;
+
+    num_render += 1.0;
+    if ((GG::GUI::GetGUI()->Ticks() - last_render_output) > 1000.0){
+        last_render_output = GG::GUI::GetGUI()->Ticks();
+        double up_per_render = num_update / num_render;
+        DebugLogger() << "Updates per render " << up_per_render << "(" << num_update <<"/"<<num_render<<")";
+        num_update = 0;
+        num_render = 0;
+    }
 
     glMatrixMode(GL_MODELVIEW);
     glPushMatrix();
@@ -4325,7 +4339,8 @@ std::pair<double, double> MapWnd::MovingFleetMapPositionOnLane(TemporaryPtr<cons
 }
 
 void MapWnd::RefreshFleetButtons() {
-    ScopedTimer timer("RefreshFleetButtons()");
+    num_update += 1.0;
+    ScopedTimer timer("RefreshFleetButtons()", true);
     // determine fleets that need buttons so that fleets at the same location can
     // be grouped by empire owner and buttons created
     const ObjectMap& objects = GetUniverse().Objects();

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -1657,7 +1657,7 @@ void MapWnd::RenderSystemOverlays() {
     glColor4f(1.0f, 1.0f, 1.0f, 1.0f);
     glPushMatrix();
     glLoadIdentity();
-    for (std::map<int, SystemIcon*>::const_iterator it = m_system_icons.begin();
+    for (boost::unordered_map<int, SystemIcon*>::const_iterator it = m_system_icons.begin();
          it != m_system_icons.end(); ++it)
     { it->second->RenderOverlay(ZoomFactor()); }
     glPopMatrix();
@@ -1729,7 +1729,7 @@ void MapWnd::RenderSystems() {
         glLineWidth(1.5f);
         glColor(GetOptionsDB().Get<StreamableColor>("UI.unowned-starlane-colour").ToClr());
 
-        for (std::map<int, SystemIcon*>::const_iterator it = m_system_icons.begin();
+        for (boost::unordered_map<int, SystemIcon*>::const_iterator it = m_system_icons.begin();
              it != m_system_icons.end(); ++it)
         {
             const SystemIcon* icon = it->second;
@@ -2551,7 +2551,7 @@ void MapWnd::InitTurnRendering() {
     const ObjectMap& objects = Objects();
 
     // remove old system icons
-    for (std::map<int, SystemIcon*>::iterator it = m_system_icons.begin(); it != m_system_icons.end(); ++it)
+    for (boost::unordered_map<int, SystemIcon*>::iterator it = m_system_icons.begin(); it != m_system_icons.end(); ++it)
         DeleteChild(it->second);
     m_system_icons.clear();
 
@@ -2661,7 +2661,7 @@ void MapWnd::InitSystemRenderingBuffers() {
     }
 
 
-    for (std::map<int, SystemIcon*>::const_iterator it = m_system_icons.begin(); it != m_system_icons.end(); ++it) {
+    for (boost::unordered_map<int, SystemIcon*>::const_iterator it = m_system_icons.begin(); it != m_system_icons.end(); ++it) {
         const SystemIcon* icon = it->second;
         int system_id = it->first;
         TemporaryPtr<const System> system = GetSystem(system_id);
@@ -3189,7 +3189,7 @@ void MapWnd::InitStarlaneRenderingBuffers() {
     // calculate in-universe apparent starlane endpoints and create buffers for starlane rendering
     m_starlane_endpoints.clear();
 
-    for (std::map<int, SystemIcon*>::const_iterator it = m_system_icons.begin(); it != m_system_icons.end(); ++it) {
+    for (boost::unordered_map<int, SystemIcon*>::const_iterator it = m_system_icons.begin(); it != m_system_icons.end(); ++it) {
         int system_id = it->first;
 
         // skip systems that don't actually exist
@@ -3718,13 +3718,13 @@ void MapWnd::RestoreFromSaveData(const SaveGameUIData& data) {
 }
 
 void MapWnd::ShowSystemNames() {
-    for (std::map<int, SystemIcon*>::iterator it = m_system_icons.begin(); it != m_system_icons.end(); ++it) {
+    for (boost::unordered_map<int, SystemIcon*>::iterator it = m_system_icons.begin(); it != m_system_icons.end(); ++it) {
         it->second->ShowName();
     }
 }
 
 void MapWnd::HideSystemNames() {
-    for (std::map<int, SystemIcon*>::iterator it = m_system_icons.begin(); it != m_system_icons.end(); ++it) {
+    for (boost::unordered_map<int, SystemIcon*>::iterator it = m_system_icons.begin(); it != m_system_icons.end(); ++it) {
         it->second->HideName();
     }
 }
@@ -3903,7 +3903,7 @@ void MapWnd::SelectSystem(int system_id) {
     if (SidePanel::SystemID() != system_id) {
         // remove map selection indicator from previously selected system
         if (SidePanel::SystemID() != INVALID_OBJECT_ID) {
-            std::map<int, SystemIcon*>::iterator it = m_system_icons.find(SidePanel::SystemID());
+            boost::unordered_map<int, SystemIcon*>::iterator it = m_system_icons.find(SidePanel::SystemID());
             if (it != m_system_icons.end())
                 it->second->SetSelected(false);
         }
@@ -3916,7 +3916,7 @@ void MapWnd::SelectSystem(int system_id) {
 
         // place map selection indicator on newly selected system
         if (SidePanel::SystemID() != INVALID_OBJECT_ID) {
-            std::map<int, SystemIcon*>::iterator it = m_system_icons.find(SidePanel::SystemID());
+            boost::unordered_map<int, SystemIcon*>::iterator it = m_system_icons.find(SidePanel::SystemID());
             if (it != m_system_icons.end())
                 it->second->SetSelected(true);
         }
@@ -4189,7 +4189,7 @@ bool MapWnd::EventFilter(GG::Wnd* w, const GG::WndEvent& event) {
 void MapWnd::DoSystemIconsLayout() {
     // position and resize system icons and gaseous substance
     const int SYSTEM_ICON_SIZE = SystemIconSize();
-    for (std::map<int, SystemIcon*>::iterator it = m_system_icons.begin(); it != m_system_icons.end(); ++it) {
+    for (boost::unordered_map<int, SystemIcon*>::iterator it = m_system_icons.begin(); it != m_system_icons.end(); ++it) {
         TemporaryPtr<const System> system = GetSystem(it->first);
         if (!system) {
             ErrorLogger() << "MapWnd::DoSystemIconsLayout couldn't get system with id " << it->first;
@@ -4238,7 +4238,7 @@ void MapWnd::DoFleetButtonsLayout() {
                        GG::Y(static_cast<int>(system->Y()*ZoomFactor() - SYSTEM_ICON_SIZE / 2.0)));
 
         // get system icon itself.  can't use the system icon's UpperLeft to position fleet button due to weirdness that results that I don't want to figure out
-        std::map<int, SystemIcon*>::const_iterator sys_it = m_system_icons.find(system->ID());
+        boost::unordered_map<int, SystemIcon*>::const_iterator sys_it = m_system_icons.find(system->ID());
         if (sys_it == m_system_icons.end()) {
             ErrorLogger() << "couldn't find system icon for fleet button in DoFleetButtonsLayout";
             continue;
@@ -4268,7 +4268,7 @@ void MapWnd::DoFleetButtonsLayout() {
                        GG::Y(static_cast<int>(system->Y()*ZoomFactor() - SYSTEM_ICON_SIZE / 2.0)));
 
         // get system icon itself.  can't use the system icon's UpperLeft to position fleet button due to weirdness that results that I don't want to figure out
-        std::map<int, SystemIcon*>::const_iterator sys_it = m_system_icons.find(system->ID());
+        boost::unordered_map<int, SystemIcon*>::const_iterator sys_it = m_system_icons.find(system->ID());
         if (sys_it == m_system_icons.end()) {
             ErrorLogger() << "couldn't find system icon for fleet button in DoFleetButtonsLayout";
             continue;
@@ -5480,7 +5480,7 @@ void MapWnd::Sanitize() {
 
     m_projected_fleet_lines.clear();
 
-    for (std::map<int, SystemIcon*>::iterator it = m_system_icons.begin(); it != m_system_icons.end(); ++it)
+    for (boost::unordered_map<int, SystemIcon*>::iterator it = m_system_icons.begin(); it != m_system_icons.end(); ++it)
         delete it->second;
     m_system_icons.clear();
 

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -4639,7 +4639,7 @@ void MapWnd::DeferredRefreshFleetButtons() {
 
     // create movement lines (after positioning buttons, so lines will originate from button location)
     for (std::map<int, FleetButton*>::iterator it = m_fleet_buttons.begin(); it != m_fleet_buttons.end(); ++it)
-        SetFleetMovementLine(it->second);
+        SetFleetMovementLine(it->first);
     }
 }
 

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -4027,7 +4027,7 @@ void MapWnd::SelectFleet(TemporaryPtr<Fleet> fleet) {
             fleet_wnd = manager.NewFleetWnd(system->ID(), fleet->Owner());
         } else {
             // get all (moving) fleets represented by fleet button for this fleet
-            std::map<int, FleetButton*>::iterator it = m_fleet_buttons.find(fleet->ID());
+            boost::unordered_map<int, FleetButton*>::iterator it = m_fleet_buttons.find(fleet->ID());
             if (it == m_fleet_buttons.end()) {
                 ErrorLogger() << "Couldn't find a FleetButton for fleet in MapWnd::SelectFleet";
                 return;
@@ -4226,7 +4226,7 @@ void MapWnd::DoFleetButtonsLayout() {
     const int SYSTEM_ICON_SIZE = SystemIconSize();
 
     // position departing fleet buttons
-    for (std::map<int, std::set<FleetButton*> >::iterator it = m_departing_fleet_buttons.begin(); it != m_departing_fleet_buttons.end(); ++it) {
+    for (boost::unordered_map<int, boost::unordered_set<FleetButton*> >::iterator it = m_departing_fleet_buttons.begin(); it != m_departing_fleet_buttons.end(); ++it) {
         // calculate system icon position
         TemporaryPtr<const System> system = GetSystem(it->first);
         if (!system) {
@@ -4247,8 +4247,8 @@ void MapWnd::DoFleetButtonsLayout() {
 
         // place all buttons
         int n = 1;
-        std::set<FleetButton*>& buttons = it->second;
-        for (std::set<FleetButton*>::iterator button_it = buttons.begin(); button_it != buttons.end(); ++button_it) {
+        boost::unordered_set<FleetButton*>& buttons = it->second;
+        for (boost::unordered_set<FleetButton*>::iterator button_it = buttons.begin(); button_it != buttons.end(); ++button_it) {
             GG::Pt ul = system_icon->NthFleetButtonUpperLeft(n, true);
             ++n;
             (*button_it)->MoveTo(ul + icon_ul);
@@ -4256,7 +4256,7 @@ void MapWnd::DoFleetButtonsLayout() {
     }
 
     // position stationary fleet buttons
-    for (std::map<int, std::set<FleetButton*> >::iterator it = m_stationary_fleet_buttons.begin(); it != m_stationary_fleet_buttons.end(); ++it) {
+    for (boost::unordered_map<int, boost::unordered_set<FleetButton*> >::iterator it = m_stationary_fleet_buttons.begin(); it != m_stationary_fleet_buttons.end(); ++it) {
         // calculate system icon position
         TemporaryPtr<const System> system = GetSystem(it->first);
         if (!system) {
@@ -4277,8 +4277,8 @@ void MapWnd::DoFleetButtonsLayout() {
 
         // place all buttons
         int n = 1;
-        std::set<FleetButton*>& buttons = it->second;
-        for (std::set<FleetButton*>::iterator button_it = buttons.begin(); button_it != buttons.end(); ++button_it) {
+        boost::unordered_set<FleetButton*>& buttons = it->second;
+        for (boost::unordered_set<FleetButton*>::iterator button_it = buttons.begin(); button_it != buttons.end(); ++button_it) {
             GG::Pt ul = system_icon->NthFleetButtonUpperLeft(n, false);
             ++n;
             (*button_it)->MoveTo(ul + icon_ul);
@@ -4286,9 +4286,9 @@ void MapWnd::DoFleetButtonsLayout() {
     }
 
     // position moving fleet buttons
-    for (std::map<std::pair<double, double>, std::set<FleetButton*> >::iterator pos_it = m_moving_fleet_buttons.begin();
+    for (boost::unordered_map<std::pair<double, double>, boost::unordered_set<FleetButton*> >::iterator pos_it = m_moving_fleet_buttons.begin();
          pos_it != m_moving_fleet_buttons.end(); ++pos_it) {
-        for (std::set<FleetButton*>::iterator it = pos_it->second.begin(); it != pos_it->second.end(); ++it) {
+        for (boost::unordered_set<FleetButton*>::iterator it = pos_it->second.begin(); it != pos_it->second.end(); ++it) {
             FleetButton* fb = *it;
 
             const GG::Pt FLEET_BUTTON_SIZE = fb->Size();
@@ -4467,14 +4467,14 @@ void MapWnd::DeferredRefreshFleetButtons() {
 
 
     // create movement lines (after positioning buttons, so lines will originate from button location)
-    for (std::map<int, FleetButton*>::iterator it = m_fleet_buttons.begin(); it != m_fleet_buttons.end(); ++it)
+    for (boost::unordered_map<int, FleetButton*>::iterator it = m_fleet_buttons.begin(); it != m_fleet_buttons.end(); ++it)
         SetFleetMovementLine(it->first);
     }
 }
 
 template <typename K>
 void MapWnd::CreateFleetButtonsOfType (
-    std::map<K, std::set<FleetButton*> >& type_fleet_buttons,
+    boost::unordered_map<K, boost::unordered_set<FleetButton*> >& type_fleet_buttons,
     const boost::unordered_map<std::pair<K, int>, std::vector<int> > &fleets_map,
     const FleetButton::SizeType & fleet_button_size) {
     for (typename boost::unordered_map<std::pair<K, int>, std::vector<int> >::const_iterator fleets_it = fleets_map.begin();
@@ -4506,21 +4506,21 @@ void MapWnd::CreateFleetButtonsOfType (
 void MapWnd::DeleteFleetButtons() {
     m_fleet_buttons.clear();            // duplicates pointers in following containers
 
-    for (std::map<int, std::set<FleetButton*> >::iterator it = m_stationary_fleet_buttons.begin();
+    for (boost::unordered_map<int, boost::unordered_set<FleetButton*> >::iterator it = m_stationary_fleet_buttons.begin();
          it != m_stationary_fleet_buttons.end(); ++it)
-        for (std::set<FleetButton*>::iterator set_it = it->second.begin(); set_it != it->second.end(); ++set_it)
+        for (boost::unordered_set<FleetButton*>::iterator set_it = it->second.begin(); set_it != it->second.end(); ++set_it)
             delete *set_it;
     m_stationary_fleet_buttons.clear();
 
-    for (std::map<int, std::set<FleetButton*> >::iterator it = m_departing_fleet_buttons.begin();
+    for (boost::unordered_map<int, boost::unordered_set<FleetButton*> >::iterator it = m_departing_fleet_buttons.begin();
          it != m_departing_fleet_buttons.end(); ++it)
-        for (std::set<FleetButton*>::iterator set_it = it->second.begin(); set_it != it->second.end(); ++set_it)
+        for (boost::unordered_set<FleetButton*>::iterator set_it = it->second.begin(); set_it != it->second.end(); ++set_it)
             delete *set_it;
     m_departing_fleet_buttons.clear();
 
-    for (std::map<std::pair<double, double>, std::set<FleetButton*> >::iterator it = m_moving_fleet_buttons.begin();
-         it != m_moving_fleet_buttons.end(); ++it)
-        for (std::set<FleetButton*>::iterator set_it = it->second.begin(); set_it != it->second.end(); ++set_it)
+    for (boost::unordered_map<std::pair<double, double>, boost::unordered_set<FleetButton*> >::iterator
+             it = m_moving_fleet_buttons.begin(); it != m_moving_fleet_buttons.end(); ++it)
+        for (boost::unordered_set<FleetButton*>::iterator set_it = it->second.begin(); set_it != it->second.end(); ++set_it)
             delete *set_it;
     m_moving_fleet_buttons.clear();
 }
@@ -5211,21 +5211,21 @@ void MapWnd::RefreshFleetButtonSelectionIndicators() {
     //std::cout << "MapWnd::RefreshFleetButtonSelectionIndicators()" << std::endl;
 
     // clear old selection indicators
-    for (std::map<int, std::set<FleetButton*> >::iterator it = m_stationary_fleet_buttons.begin(); it != m_stationary_fleet_buttons.end(); ++it) {
-        std::set<FleetButton*>& set = it->second;
-        for (std::set<FleetButton*>::iterator button_it = set.begin(); button_it != set.end(); ++button_it)
+    for (boost::unordered_map<int, boost::unordered_set<FleetButton*> >::iterator it = m_stationary_fleet_buttons.begin(); it != m_stationary_fleet_buttons.end(); ++it) {
+        boost::unordered_set<FleetButton*>& set = it->second;
+        for (boost::unordered_set<FleetButton*>::iterator button_it = set.begin(); button_it != set.end(); ++button_it)
             (*button_it)->SetSelected(false);
     }
 
-    for (std::map<int, std::set<FleetButton*> >::iterator it = m_departing_fleet_buttons.begin(); it != m_departing_fleet_buttons.end(); ++it) {
-        std::set<FleetButton*>& set = it->second;
-        for (std::set<FleetButton*>::iterator button_it = set.begin(); button_it != set.end(); ++button_it)
+    for (boost::unordered_map<int, boost::unordered_set<FleetButton*> >::iterator it = m_departing_fleet_buttons.begin(); it != m_departing_fleet_buttons.end(); ++it) {
+        boost::unordered_set<FleetButton*>& set = it->second;
+        for (boost::unordered_set<FleetButton*>::iterator button_it = set.begin(); button_it != set.end(); ++button_it)
             (*button_it)->SetSelected(false);
     }
 
-    for (std::map<std::pair<double, double>, std::set<FleetButton*> >::iterator pos_it = m_moving_fleet_buttons.begin();
+    for (boost::unordered_map<std::pair<double, double>, boost::unordered_set<FleetButton*> >::iterator pos_it = m_moving_fleet_buttons.begin();
          pos_it != m_moving_fleet_buttons.end(); ++pos_it) {
-        for (std::set<FleetButton*>::iterator it = pos_it->second.begin(); it != pos_it->second.end(); ++it) {
+        for (boost::unordered_set<FleetButton*>::iterator it = pos_it->second.begin(); it != pos_it->second.end(); ++it) {
             (*it)->SetSelected(false);
         }
     }
@@ -5233,7 +5233,7 @@ void MapWnd::RefreshFleetButtonSelectionIndicators() {
     // add new selection indicators
     for (std::set<int>::const_iterator it = m_selected_fleet_ids.begin(); it != m_selected_fleet_ids.end(); ++it) {
         int fleet_id = *it;
-        std::map<int, FleetButton*>::iterator button_it = m_fleet_buttons.find(fleet_id);
+        boost::unordered_map<int, FleetButton*>::iterator button_it = m_fleet_buttons.find(fleet_id);
         if (button_it != m_fleet_buttons.end())
             button_it->second->SetSelected(true);
     }

--- a/UI/MapWnd.h
+++ b/UI/MapWnd.h
@@ -11,6 +11,9 @@
 #include "../universe/Fleet.h"
 #include "FleetButton.h"
 
+#include <boost/unordered_set.hpp>
+#include <boost/unordered_map.hpp>
+
 class FleetWnd;
 class MapWndPopup;
 class DesignWnd;
@@ -232,7 +235,7 @@ private:
         type_fleet_buttons and record the fleet buttons in \p m_fleet_buttons.*/
     template <typename K>
     void            CreateFleetButtonsOfType(
-        std::map<K, std::set<FleetButton*> >& type_fleet_buttons,
+        boost::unordered_map<K, boost::unordered_set<FleetButton*> >& type_fleet_buttons,
         const boost::unordered_map<std::pair<K, int>, std::vector<int> > &fleets_map,
         const FleetButton::SizeType& fleet_button_size);
 
@@ -427,10 +430,10 @@ private:
 
     std::map<std::pair<int, int>, LaneEndpoints>    m_starlane_endpoints;                   //!< map from starlane start and end system IDs (stored in pair in increasing order) to the universe coordiates at which to draw the starlane ends
 
-    std::map<int, std::set<FleetButton*> >          m_stationary_fleet_buttons;             //!< icons representing fleets at a system that are not departing, indexed by system
-    std::map<int, std::set<FleetButton*> >          m_departing_fleet_buttons;              //!< icons representing fleets at a system that are departing, indexed by system
-    std::map<std::pair<double, double>,  std::set<FleetButton*> > m_moving_fleet_buttons;   //!< icons representing fleets not at a system
-    std::map<int, FleetButton*>                     m_fleet_buttons;                        //!< fleet icons, index by fleet
+    boost::unordered_map<int, boost::unordered_set<FleetButton*> >          m_stationary_fleet_buttons;             //!< icons representing fleets at a system that are not departing, indexed by system
+    boost::unordered_map<int, boost::unordered_set<FleetButton*> >          m_departing_fleet_buttons;              //!< icons representing fleets at a system that are departing, indexed by system
+    boost::unordered_map<std::pair<double, double>,  boost::unordered_set<FleetButton*> > m_moving_fleet_buttons;   //!< icons representing fleets not at a system
+    boost::unordered_map<int, FleetButton*>                     m_fleet_buttons;                        //!< fleet icons, index by fleet
 
     boost::unordered_map<int, boost::signals2::connection>               m_fleet_state_change_signals;
     boost::unordered_map<int, std::vector<boost::signals2::connection> > m_system_fleet_insert_remove_signals;

--- a/UI/MapWnd.h
+++ b/UI/MapWnd.h
@@ -426,13 +426,8 @@ private:
 
     std::map<int, std::set<FleetButton*> >          m_stationary_fleet_buttons;             //!< icons representing fleets at a system that are not departing, indexed by system
     std::map<int, std::set<FleetButton*> >          m_departing_fleet_buttons;              //!< icons representing fleets at a system that are departing, indexed by system
-    std::set<FleetButton*>                          m_moving_fleet_buttons;                 //!< icons representing fleets not at a system
+    std::map<std::pair<double, double>,  std::set<FleetButton*> > m_moving_fleet_buttons;   //!< icons representing fleets not at a system
     std::map<int, FleetButton*>                     m_fleet_buttons;                        //!< fleet icons, index by fleet
-
-    std::map<int, std::set<FleetButton*> >          m_stationary_fleet_buttons_new;             //!< icons representing fleets at a system that are not departing, indexed by system
-    std::map<int, std::set<FleetButton*> >          m_departing_fleet_buttons_new;              //!< icons representing fleets at a system that are departing, indexed by system
-    std::map<std::pair<double, double>,  std::set<FleetButton*> > m_moving_fleet_buttons_new;                 //!< icons representing fleets not at a system
-    std::map<int, FleetButton*>                     m_fleet_buttons_new;                        //!< fleet icons, index by fleet
 
     boost::unordered_map<int, boost::signals2::connection>               m_fleet_state_change_signals;
     boost::unordered_map<int, std::vector<boost::signals2::connection> > m_system_fleet_insert_remove_signals;

--- a/UI/MapWnd.h
+++ b/UI/MapWnd.h
@@ -227,6 +227,15 @@ private:
     void            RefreshFleetButtons();
     /**  Removes old / existing and create new fleet buttons. Only called once per render interval.*/
     void            DeferredRefreshFleetButtons();
+
+    /** Use the vectors of fleet ids from \p fleets_map to create fleet buttons in \p
+        type_fleet_buttons and record the fleet buttons in \p m_fleet_buttons.*/
+    template <typename K>
+    void            CreateFleetButtonsOfType(
+        std::map<K, std::set<FleetButton*> >& type_fleet_buttons,
+        const boost::unordered_map<std::pair<K, int>, std::vector<int> > &fleets_map,
+        const FleetButton::SizeType& fleet_button_size);
+
     void            RefreshFleetButtonSelectionIndicators();    //!< marks (only) selected fleets' buttons as selected
 
     /** Connect all \p fleets StateChangedSignal to RefreshFleetButtons. */
@@ -419,6 +428,11 @@ private:
     std::map<int, std::set<FleetButton*> >          m_departing_fleet_buttons;              //!< icons representing fleets at a system that are departing, indexed by system
     std::set<FleetButton*>                          m_moving_fleet_buttons;                 //!< icons representing fleets not at a system
     std::map<int, FleetButton*>                     m_fleet_buttons;                        //!< fleet icons, index by fleet
+
+    std::map<int, std::set<FleetButton*> >          m_stationary_fleet_buttons_new;             //!< icons representing fleets at a system that are not departing, indexed by system
+    std::map<int, std::set<FleetButton*> >          m_departing_fleet_buttons_new;              //!< icons representing fleets at a system that are departing, indexed by system
+    std::map<std::pair<double, double>,  std::set<FleetButton*> > m_moving_fleet_buttons_new;                 //!< icons representing fleets not at a system
+    std::map<int, FleetButton*>                     m_fleet_buttons_new;                        //!< fleet icons, index by fleet
 
     boost::unordered_map<int, boost::signals2::connection>               m_fleet_state_change_signals;
     boost::unordered_map<int, std::vector<boost::signals2::connection> > m_system_fleet_insert_remove_signals;

--- a/UI/MapWnd.h
+++ b/UI/MapWnd.h
@@ -224,7 +224,10 @@ private:
     bool            PanX(GG::X x = GG::X(50));
     bool            PanY(GG::Y y = GG::Y(50));
 
-    void            RefreshFleetButtons();                      //!< removes old / existing and creates new fleet buttons
+    /** Mark all fleet buttons for a refresh. */
+    void            RefreshFleetButtons();
+    /**  Removes old / existing and create new fleet buttons. Only called once per render interval.*/
+    void            DeferredRefreshFleetButtons();
     void            RefreshFleetButtonSelectionIndicators();    //!< marks (only) selected fleets' buttons as selected
     void            FleetsAddedOrRemoved(const std::vector<TemporaryPtr<Fleet> >& fleets);
 
@@ -473,6 +476,9 @@ private:
     GG::Slider<double>*         m_zoom_slider;      //!< allows user to set zoom level
 
     std::set<int>               m_fleets_exploring;
+
+    /// indicates that refresh fleet button work should be done before rendering.
+    bool                        m_deferred_refresh_fleet_buttons;
 
     friend struct IntroMenu;
     friend struct WaitingForGameStart;

--- a/UI/MapWnd.h
+++ b/UI/MapWnd.h
@@ -402,7 +402,7 @@ private:
 
     double                      m_zoom_steps_in;    //!< number of zoom steps in.  each 1.0 step increases display scaling by the same zoom step factor
     SidePanel*                  m_side_panel;       //!< planet view panel on the side of the main map
-    std::map<int, SystemIcon*>  m_system_icons;     //!< system icons in the main map, indexed by system id
+    boost::unordered_map<int, SystemIcon*>  m_system_icons;     //!< system icons in the main map, indexed by system id
     std::map<int, FieldIcon*>   m_field_icons;      //!< field icons in the main map, indexed by field id
     SitRepPanel*                m_sitrep_panel;     //!< sitrep panel
     ResearchWnd*                m_research_wnd;     //!< research screen

--- a/UI/MapWnd.h
+++ b/UI/MapWnd.h
@@ -228,7 +228,16 @@ private:
     /**  Removes old / existing and create new fleet buttons. Only called once per render interval.*/
     void            DeferredRefreshFleetButtons();
     void            RefreshFleetButtonSelectionIndicators();    //!< marks (only) selected fleets' buttons as selected
-    void            FleetsAddedOrRemoved(const std::vector<TemporaryPtr<Fleet> >& fleets);
+
+    /** Connect all \p fleets StateChangedSignal to RefreshFleetButtons. */
+    void            AddFleetsStateChangedSignal(const std::vector<TemporaryPtr<Fleet> >& fleets);
+    /** Disconnect all \p fleets StateChangedSignal from RefreshFleetButtons. */
+    void            RemoveFleetsStateChangedSignal(const std::vector<TemporaryPtr<Fleet> >& fleets);
+    /** Handle FleetsInsertedSignal by connecting signals and refreshing fleet buttons. */
+    void            FleetsInsertedSignalHandler(const std::vector<TemporaryPtr<Fleet> >& fleets);
+    /** Handle FleetsRemovedSignal by disconnecting signals and refreshing fleet buttons. */
+    void            FleetsRemovedSignalHandler(const std::vector<TemporaryPtr<Fleet> >& fleets);
+
 
     void            DoFleetButtonsLayout();                     //!< does layout of fleet buttons
     std::pair<double, double>   MovingFleetMapPositionOnLane(TemporaryPtr<const Fleet> fleet) const; //!< returns position on map where a moving fleet should be displayed.  This is different from the fleet's actual universe position due to the squishing of fleets moving along a lane into the space between the system circles at the ends of the lane
@@ -411,8 +420,8 @@ private:
     std::set<FleetButton*>                          m_moving_fleet_buttons;                 //!< icons representing fleets not at a system
     std::map<int, FleetButton*>                     m_fleet_buttons;                        //!< fleet icons, index by fleet
 
-    std::map<int, boost::signals2::connection>               m_fleet_state_change_signals;
-    std::map<int, std::vector<boost::signals2::connection> > m_system_fleet_insert_remove_signals;
+    boost::unordered_map<int, boost::signals2::connection>               m_fleet_state_change_signals;
+    boost::unordered_map<int, std::vector<boost::signals2::connection> > m_system_fleet_insert_remove_signals;
 
     std::map<int, MovementLineData>                 m_fleet_lines;                          //!< lines used for moving fleets in the main map
     std::map<int, MovementLineData>                 m_projected_fleet_lines;                //!< lines that show the projected path of the active fleet in the FleetWnd

--- a/UI/MapWnd.h
+++ b/UI/MapWnd.h
@@ -236,6 +236,9 @@ private:
         const boost::unordered_map<std::pair<K, int>, std::vector<int> > &fleets_map,
         const FleetButton::SizeType& fleet_button_size);
 
+    /** Delete all fleet buttons.*/
+    void            DeleteFleetButtons();
+
     void            RefreshFleetButtonSelectionIndicators();    //!< marks (only) selected fleets' buttons as selected
 
     /** Connect all \p fleets StateChangedSignal to RefreshFleetButtons. */

--- a/UI/MapWnd.h
+++ b/UI/MapWnd.h
@@ -156,7 +156,6 @@ public:
     void            ReselectLastFleet();                                    //!< re-selects the most recent selected fleet, if a valid one exists
 
     void            RemoveFleet(int fleet_id); //!< removes specified fleet.
-    void            SetFleetMovementLine(const FleetButton* fleet_button);  //!< creates fleet movement lines for all fleets in the given FleetButton to indicate where (and whether) they are moving.  Move lines originate from the FleetButton.
     void            SetFleetMovementLine(int fleet_id);                     //!< creates fleet movement line for a single fleet.  Move lines originate from the fleet's button location.
 
     /* creates specially-coloured projected fleet movement line for specified

--- a/universe/TemporaryPtr.h
+++ b/universe/TemporaryPtr.h
@@ -6,6 +6,7 @@
 #include <boost/serialization/access.hpp>
 #include <boost/smart_ptr/shared_ptr.hpp>
 #include <boost/smart_ptr/weak_ptr.hpp>
+#include <boost/functional/hash.hpp>
 
 template <class T> class EnableTemporaryFromThis;
 template <class T> class TemporaryPtr;
@@ -121,6 +122,16 @@ private:
 template <class Y>
 std::ostream& operator<<(std::ostream& o, const TemporaryPtr<Y>& p)
 { return (o << ""); }
+
+// Replace with a C++11 hash function.
+namespace boost {
+    template<typename Y>
+        struct hash<TemporaryPtr<const Y> > {
+        inline size_t operator() (const TemporaryPtr<const Y>& y) const {
+            return boost::hash<const Y*>()(y.get());
+        }
+    };
+}
 
 #include "TemporaryPtr.tcc"
 


### PR DESCRIPTION
This PR improves the run time of `FleetWnd`split fleet.  

It will also improve update times for any maps which contain fleets.  

It does not change any game rules, or UI elements.  I think it is suitable for inclusion in 0.4.6.

On my test example merging all the fleets in a fleet button with many fleets and then splitting them.  The splitting took 19 seconds before this PR and 3 seconds after.  

You can compare the results yourself with any save with a large fleet. The PR is save compatible.  

The first commit https://github.com/freeorion/freeorion/commit/efa00c3441b7d24286baaf9df1e052bc0dd8bea4 contains the `FleetWnd::SplitFleet` `ScopedTimer` for split fleet.  If you checkout https://github.com/freeorion/freeorion/commit/efa00c3441b7d24286baaf9df1e052bc0dd8bea4 and split a big fleet, the time will be in the `freeorion.log` as `FleetWnd::SplitFleet time: xxxx.xx`.  You can compare the results with the whole PR.  The changes are large enough to be noticeable without the timer.

The PR makes several changes in `MapWnd` that cumulatively produce the improvement.
- it creates separate handlers for fleet insert and remove events.
- it defers all work from multiple fleet insert/remove events during a single render interval to a single function `DeferredRefreshFleetButtons()` run only if needed at the start of `Render()`
- it removes some redundancy in fleet movement line drawing.
- it only examines fleets instead of all objects when considering fleets to draw.
- it uses unordered sets and maps for unordered sets and maps of fleet related objects.

It makes some code quality changes, by reducing repeated code.
