### PR TITLE
Add sectioned scoped timer

### DIFF
--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -2319,16 +2319,19 @@ void MapWnd::EnableOrderIssuing(bool enable/* = true*/) {
 void MapWnd::InitTurn() {
     int turn_number = CurrentTurn();
     DebugLogger() << "Initializing turn " << turn_number;
-    ScopedTimer init_timer("MapWnd::InitTurn", true);
+    SectionedScopedTimer timer("MapWnd::InitTurn", boost::chrono::milliseconds(1));
+    timer.EnterSection("init");
 
     //DebugLogger() << GetSupplyManager().Dump();
 
     Universe& universe = GetUniverse();
     const ObjectMap& objects = Objects();
 
+    timer.EnterSection("system graph");
     // FIXME: this is actually only needed when there was no mid-turn update
     universe.InitializeSystemGraph(HumanClientApp::GetApp()->EmpireID());
 
+    timer.EnterSection("meter estimates");
     // update effect accounting and meter estimates
     universe.InitMeterEstimatesAndDiscrepancies();
 
@@ -2343,9 +2346,11 @@ void MapWnd::InitTurn() {
 
     GetUniverse().ApplyAppearanceEffects();
 
+    timer.EnterSection("rendering");
     // set up system icons, starlanes, galaxy gas rendering
     InitTurnRendering();
 
+    timer.EnterSection("fleet signals");
     // connect system fleet add and remove signals
     std::vector<TemporaryPtr<const System> > systems = objects.FindObjects<System>();
     for (std::vector<TemporaryPtr<const System> >::const_iterator it = systems.begin(); it != systems.end(); ++it) {
@@ -2365,6 +2370,7 @@ void MapWnd::InitTurn() {
     MoveChildUp(m_btn_turn);
 
 
+    timer.EnterSection("sitreps");
     // are there any sitreps to show?
     bool show_intro_sitreps = CurrentTurn() == 1 && GetOptionsDB().Get<Aggression>("GameSetup.ai-aggression") <= TYPICAL;
     DebugLogger() << "showing intro sitreps : " << show_intro_sitreps;
@@ -2418,25 +2424,21 @@ void MapWnd::InitTurn() {
     RefreshSliders();
 
 
-    boost::timer timer;
+    timer.EnterSection("update resource pools");
     for (EmpireManager::iterator it = Empires().begin(); it != Empires().end(); ++it)
         it->second->UpdateResourcePools();
-    DebugLogger() << "MapWnd::InitTurn updating resource pools time: " << (timer.elapsed() * 1000.0);
 
 
-    timer.restart();
+    timer.EnterSection("refresh research");
     m_research_wnd->Refresh();
-    DebugLogger() << "MapWnd::InitTurn research wnd refresh time: " << (timer.elapsed() * 1000.0);
 
 
-    timer.restart();
+    timer.EnterSection("refresh sidepanel");
     SidePanel::Refresh();       // recreate contents of all SidePanels.  ensures previous turn's objects and signals are disposed of
-    DebugLogger() << "MapWnd::InitTurn sidepanel refresh time: " << (timer.elapsed() * 1000.0);
 
 
-    timer.restart();
+    timer.EnterSection("refresh production wnd");
     m_production_wnd->Refresh();
-    DebugLogger() << "MapWnd::InitTurn m_production_wnd refresh time: " << (timer.elapsed() * 1000.0);
 
 
     if (turn_number == 1 && this_client_empire) {
@@ -2452,20 +2454,19 @@ void MapWnd::InitTurn() {
         CenterOnMapCoord(0.0, 0.0);
     }
 
-    timer.restart();
+    timer.EnterSection("refresh indicators");
     RefreshIndustryResourceIndicator();
     RefreshResearchResourceIndicator();
     RefreshTradeResourceIndicator();
     RefreshFleetResourceIndicator();
     RefreshPopulationIndicator();
     RefreshDetectionIndicator();
-    DebugLogger() << "MapWnd::InitTurn indicators refresh time: " << (timer.elapsed() * 1000.0);
 
-    timer.restart();
+    timer.EnterSection("dispatch exploring");
     FleetUIManager::GetFleetUIManager().RefreshAll();
     DispatchFleetsExploring();
-    DebugLogger() << "MapWnd::InitTurn fleet UI refresh and exploring dispatch time: " << (timer.elapsed() * 1000.0);
 
+    timer.EnterSection("enable observers");
     HumanClientApp* app = HumanClientApp::GetApp();
     if (app->GetClientType() == Networking::CLIENT_TYPE_HUMAN_MODERATOR) {
         // this client is a moderator

--- a/util/ScopedTimer.cpp
+++ b/util/ScopedTimer.cpp
@@ -7,14 +7,14 @@
 
 class ScopedTimer::ScopedTimerImpl {
 public:
-    ScopedTimerImpl(const std::string& timed_name, bool always_output) :
+    ScopedTimerImpl(const std::string& timed_name, bool enable_output) :
         m_start(boost::chrono::high_resolution_clock::now()),
         m_name(timed_name),
-        m_always_output(always_output)
+        m_enable_output(enable_output)
     {}
     ~ScopedTimerImpl() {
         boost::chrono::nanoseconds duration = boost::chrono::high_resolution_clock::now() - m_start;
-        if (duration >= boost::chrono::milliseconds(1) && ( m_always_output || GetOptionsDB().Get<bool>("verbose-logging")))
+        if (duration >= boost::chrono::milliseconds(1) && (m_enable_output || GetOptionsDB().Get<bool>("verbose-logging")))
             if (duration >= boost::chrono::milliseconds(10))
                 DebugLogger() << m_name << " time: "
                               << boost::chrono::symbol_format
@@ -30,11 +30,11 @@ public:
     }
     boost::chrono::high_resolution_clock::time_point m_start;
     std::string                                      m_name;
-    bool                                             m_always_output;
+    bool                                             m_enable_output;
 };
 
-ScopedTimer::ScopedTimer(const std::string& timed_name, bool always_output) :
-    pimpl(new ScopedTimerImpl(timed_name, always_output))
+ScopedTimer::ScopedTimer(const std::string& timed_name, bool enable_output) :
+    pimpl(new ScopedTimerImpl(timed_name, enable_output))
 {}
 
 // ~ScopedTimer is required because Impl is defined here.

--- a/util/ScopedTimer.cpp
+++ b/util/ScopedTimer.cpp
@@ -33,7 +33,7 @@ public:
         return (duration >= m_threshold && (m_enable_output || GetOptionsDB().Get<bool>("verbose-logging")));
     }
 
-    void FormatDuration(std::stringstream &ss, const boost::chrono::nanoseconds & duration) {
+    void FormatDuration(std::stringstream& ss, const boost::chrono::nanoseconds & duration) {
         ss << boost::chrono::symbol_format << std::setw(8) << std::right;
         if (duration >= boost::chrono::milliseconds(10))
             ss << boost::chrono::duration_cast<boost::chrono::milliseconds>(duration);
@@ -70,8 +70,8 @@ class SectionedScopedTimer::SectionedScopedTimerImpl : public ScopedTimer::Scope
     struct Sections {
         Sections(const boost::chrono::high_resolution_clock::time_point &now,
                  const boost::chrono::nanoseconds& time_from_start) :
-            m_table(), m_section_start(now), m_curr(), m_section_names() {
-
+            m_table(), m_section_start(now), m_curr(), m_section_names()
+        {
             // Create a dummy "" section so that m_curr is always a valid iterator.
             std::pair<SectionTable::iterator, bool> curr = m_table.insert(std::make_pair("", time_from_start));
             m_curr = curr.first;
@@ -79,8 +79,8 @@ class SectionedScopedTimer::SectionedScopedTimerImpl : public ScopedTimer::Scope
 
         /** Add time to the current section and then setup the new section. */
         void Accumulate(const boost::chrono::high_resolution_clock::time_point &now,
-                        const std::string & section_name) {
-
+                        const std::string & section_name)
+        {
             if (m_curr->first == section_name)
                 return;
 
@@ -118,7 +118,7 @@ class SectionedScopedTimer::SectionedScopedTimerImpl : public ScopedTimer::Scope
 
 public:
     SectionedScopedTimerImpl(const std::string& timed_name, bool enable_output,
-                    boost::chrono::microseconds threshold) :
+                             boost::chrono::microseconds threshold) :
         ScopedTimerImpl(timed_name, enable_output, threshold)
     {}
 
@@ -146,13 +146,14 @@ public:
         // Find the longest name to right align the times.
         size_t longest_section_name(0);
         for (std::vector<std::string>::const_iterator it = m_sections->m_section_names.begin();
-             it != m_sections->m_section_names.end(); ++it) {
+             it != m_sections->m_section_names.end(); ++it)
+        {
             longest_section_name = std::max(longest_section_name, it->size());
         }
 
         for (std::vector<std::string>::const_iterator it = m_sections->m_section_names.begin();
-             it != m_sections->m_section_names.end(); ++it) {
-
+             it != m_sections->m_section_names.end(); ++it)
+       {
             Sections::SectionTable::const_iterator jt = m_sections->m_table.find(*it);
             if (jt == m_sections->m_table.end()) {
                 ErrorLogger() << "Missing section " << *it << " in section table.";

--- a/util/ScopedTimer.cpp
+++ b/util/ScopedTimer.cpp
@@ -4,6 +4,9 @@
 #include "Logger.h"
 
 #include <boost/chrono/io/duration_io.hpp>
+#include <boost/unordered_map.hpp>
+
+#include <iomanip>
 
 class ScopedTimer::ScopedTimerImpl {
 public:
@@ -17,20 +20,29 @@ public:
 
     ~ScopedTimerImpl() {
         boost::chrono::nanoseconds duration = boost::chrono::high_resolution_clock::now() - m_start;
-        if (duration >= m_threshold && (m_enable_output || GetOptionsDB().Get<bool>("verbose-logging")))
-            if (duration >= boost::chrono::milliseconds(10))
-                DebugLogger() << m_name << " time: "
-                              << boost::chrono::symbol_format
-                              << boost::chrono::duration_cast<boost::chrono::milliseconds>(duration);
-            else if (duration >= boost::chrono::microseconds(10))
-                DebugLogger() << m_name << " time: "
-                              << boost::chrono::symbol_format
-                              << boost::chrono::duration_cast<boost::chrono::microseconds>(duration);
-            else
-                DebugLogger() << m_name << " time: "
-                              << boost::chrono::symbol_format
-                              << boost::chrono::duration_cast<boost::chrono::nanoseconds>(duration);
+        if (!ShouldOutput(duration))
+            return;
+
+        std::stringstream ss;
+        ss << m_name << " time: ";
+        FormatDuration(ss, duration);
+        DebugLogger() << ss.str();
     }
+
+    bool ShouldOutput(const boost::chrono::nanoseconds & duration) {
+        return (duration >= m_threshold && (m_enable_output || GetOptionsDB().Get<bool>("verbose-logging")));
+    }
+
+    void FormatDuration(std::stringstream &ss, const boost::chrono::nanoseconds & duration) {
+        ss << boost::chrono::symbol_format << std::setw(8) << std::right;
+        if (duration >= boost::chrono::milliseconds(10))
+            ss << boost::chrono::duration_cast<boost::chrono::milliseconds>(duration);
+        else if (duration >= boost::chrono::microseconds(10))
+            ss << boost::chrono::duration_cast<boost::chrono::microseconds>(duration);
+        else
+            ss << boost::chrono::duration_cast<boost::chrono::nanoseconds>(duration);
+    }
+
     boost::chrono::high_resolution_clock::time_point m_start;
     std::string                                      m_name;
     bool                                             m_enable_output;
@@ -49,3 +61,165 @@ ScopedTimer::ScopedTimer(const std::string& timed_name, boost::chrono::microseco
 // ~ScopedTimer is required because Impl is defined here.
 ScopedTimer::~ScopedTimer()
 {}
+
+
+
+class SectionedScopedTimer::SectionedScopedTimerImpl : public ScopedTimer::ScopedTimerImpl {
+
+    /** Sections store a time and a duration for each section of the elapsed time report.*/
+    struct Sections {
+        Sections(const boost::chrono::high_resolution_clock::time_point &now,
+                 const boost::chrono::nanoseconds& time_from_start) :
+            m_table(), m_section_start(now), m_curr(), m_section_names() {
+
+            // Create a dummy "" section so that m_curr is always a valid iterator.
+            std::pair<SectionTable::iterator, bool> curr = m_table.insert(std::make_pair("", time_from_start));
+            m_curr = curr.first;
+        }
+
+        /** Add time to the current section and then setup the new section. */
+        void Accumulate(const boost::chrono::high_resolution_clock::time_point &now,
+                        const std::string & section_name) {
+
+            if (m_curr->first == section_name)
+                return;
+
+            m_curr->second += (now - m_section_start);
+
+            m_section_start = now;
+
+            // Create a new section if needed and update m_curr.
+            std::pair<SectionTable::iterator, bool> maybe_new = m_table.insert(
+                std::make_pair(section_name,
+                               boost::chrono::high_resolution_clock::duration::zero()));
+            m_curr = maybe_new.first;
+
+            // Insert succeed, so grab the new section name.
+            if (maybe_new.second)
+                m_section_names.push_back(section_name);
+
+        }
+
+        //Table of section durations
+        typedef boost::unordered_map<std::string, boost::chrono::nanoseconds> SectionTable;
+        SectionTable m_table;
+
+        // Currently running section start time and iterator
+        boost::chrono::high_resolution_clock::time_point m_section_start;
+
+        // m_curr always points to the section currently accumulating
+        // time or to the dummy "" blank section.
+        SectionTable::iterator m_curr;
+
+        // Names of the sections in order or creation.
+        std::vector<std::string> m_section_names;
+
+    };
+
+public:
+    SectionedScopedTimerImpl(const std::string& timed_name, bool enable_output,
+                    boost::chrono::microseconds threshold) :
+        ScopedTimerImpl(timed_name, enable_output, threshold)
+    {}
+
+    /** The destructor will print the table of accumulated times. */
+    ~SectionedScopedTimerImpl() {
+        boost::chrono::nanoseconds duration = boost::chrono::high_resolution_clock::now() - m_start;
+
+        if (!ShouldOutput(duration))
+            return;
+
+        // No table so use basic ScopedTimer output.
+        if (!m_sections) {
+            std::stringstream ss;
+            ss << m_name << " time: ";
+            ScopedTimerImpl::FormatDuration(ss, duration);
+            DebugLogger() << ss.str();
+            return;
+        }
+
+        //Stop the final section.
+        EnterSection("");
+
+        //Print the section times followed by the total time elapsed.
+
+        // Find the longest name to right align the times.
+        size_t longest_section_name(0);
+        for (std::vector<std::string>::const_iterator it = m_sections->m_section_names.begin();
+             it != m_sections->m_section_names.end(); ++it) {
+            longest_section_name = std::max(longest_section_name, it->size());
+        }
+
+        for (std::vector<std::string>::const_iterator it = m_sections->m_section_names.begin();
+             it != m_sections->m_section_names.end(); ++it) {
+
+            Sections::SectionTable::const_iterator jt = m_sections->m_table.find(*it);
+            if (jt == m_sections->m_table.end()) {
+                ErrorLogger() << "Missing section " << *it << " in section table.";
+                continue;
+            }
+
+            if (!ShouldOutput(jt->second))
+                continue;
+
+            // Create a header with padding, so all times align.
+            std::stringstream header, tail;
+            FormatDuration(tail, jt->second);
+            header << m_name << " - "
+                   << std::setw(longest_section_name) << std::left << *it
+                   << std::right << " time: "
+                   << tail.str();
+            DebugLogger() << header.str();
+        }
+
+        // Create a header with padding, so all times align.
+        std::stringstream header, tail;
+        FormatDuration(tail, duration);
+        header << m_name
+               << std::setw(longest_section_name + 3 + 7)
+               << std::right << " time: "
+               << tail.str();
+        DebugLogger() << header.str();
+
+        // Prevent the base class from outputting a duplicate total time.
+        m_enable_output = false;
+    }
+
+    void EnterSection(const std::string& section_name) {
+        boost::chrono::high_resolution_clock::time_point now(boost::chrono::high_resolution_clock::now());
+
+        // One time initialization.
+        if (!m_sections)
+            CreateSections(now);
+
+        m_sections->Accumulate(now, section_name);
+    }
+
+    /** CreateSections allow m_sections to only be initialized if it is used.*/
+    Sections* CreateSections(const boost::chrono::high_resolution_clock::time_point &now) {
+        m_sections.reset(new Sections(now, now - m_start));
+        return m_sections.get();
+    }
+
+    // Pointer to table of sections.
+    // Sections are only allocated when the first section is created, to minimize overhead of a
+    // section-less timer.
+    boost::scoped_ptr<Sections> m_sections;
+
+};
+
+SectionedScopedTimer::SectionedScopedTimer(const std::string& timed_name, bool enable_output,
+                         boost::chrono::microseconds threshold) :
+    pimpl(new SectionedScopedTimerImpl(timed_name, enable_output, threshold))
+{}
+
+SectionedScopedTimer::SectionedScopedTimer(const std::string& timed_name, boost::chrono::microseconds threshold) :
+    pimpl(new SectionedScopedTimerImpl(timed_name, true, threshold))
+{}
+
+// ~SectionedScopedTimer is required because Impl is defined here.
+SectionedScopedTimer::~SectionedScopedTimer()
+{}
+
+void SectionedScopedTimer::EnterSection(const std::string& section_name)
+{ pimpl->EnterSection(section_name);}

--- a/util/ScopedTimer.cpp
+++ b/util/ScopedTimer.cpp
@@ -7,14 +7,17 @@
 
 class ScopedTimer::ScopedTimerImpl {
 public:
-    ScopedTimerImpl(const std::string& timed_name, bool enable_output) :
+    ScopedTimerImpl(const std::string& timed_name, bool enable_output,
+                    boost::chrono::microseconds threshold) :
         m_start(boost::chrono::high_resolution_clock::now()),
         m_name(timed_name),
-        m_enable_output(enable_output)
+        m_enable_output(enable_output),
+        m_threshold(threshold)
     {}
+
     ~ScopedTimerImpl() {
         boost::chrono::nanoseconds duration = boost::chrono::high_resolution_clock::now() - m_start;
-        if (duration >= boost::chrono::milliseconds(1) && (m_enable_output || GetOptionsDB().Get<bool>("verbose-logging")))
+        if (duration >= m_threshold && (m_enable_output || GetOptionsDB().Get<bool>("verbose-logging")))
             if (duration >= boost::chrono::milliseconds(10))
                 DebugLogger() << m_name << " time: "
                               << boost::chrono::symbol_format
@@ -31,12 +34,18 @@ public:
     boost::chrono::high_resolution_clock::time_point m_start;
     std::string                                      m_name;
     bool                                             m_enable_output;
+    boost::chrono::microseconds                      m_threshold;
 };
 
-ScopedTimer::ScopedTimer(const std::string& timed_name, bool enable_output) :
-    pimpl(new ScopedTimerImpl(timed_name, enable_output))
+ScopedTimer::ScopedTimer(const std::string& timed_name, bool enable_output,
+                         boost::chrono::microseconds threshold) :
+    pimpl(new ScopedTimerImpl(timed_name, enable_output, threshold))
+{}
+
+ScopedTimer::ScopedTimer(const std::string& timed_name, boost::chrono::microseconds threshold) :
+    pimpl(new ScopedTimerImpl(timed_name, true, threshold))
 {}
 
 // ~ScopedTimer is required because Impl is defined here.
 ScopedTimer::~ScopedTimer()
-{ }
+{}

--- a/util/ScopedTimer.h
+++ b/util/ScopedTimer.h
@@ -9,8 +9,8 @@
 #include <boost/chrono/chrono.hpp>
 #include <boost/scoped_ptr.hpp>
 
-/** Wrapper for boost::timer that outputs time during which this object
-    existed.  Created in the scope of a function, and passed the appropriate
+/** Outputs time during which this object existed.
+    Created in the scope of a function, and passed the appropriate
     name, it will output to DebugLogger() the time elapsed while
     the function was executing.
 
@@ -24,10 +24,84 @@ public:
                 boost::chrono::microseconds threshold = boost::chrono::milliseconds(1));
     ScopedTimer(const std::string& timed_name, boost::chrono::microseconds threshold);
     ~ScopedTimer();
-private:
+
     class ScopedTimerImpl;
+private:
     // TODO use C++11 unique_ptr
     boost::scoped_ptr<ScopedTimerImpl> const pimpl;
+};
+
+/** Similar to ScopedTimer SectionedScopedTimer times the duration of its own existence.  It also
+    allows the creation of sub section timers.  Timers are created by calling EnterSection(name).
+
+    Only one sub-section timer is active at any time.
+
+    Timers can be re-entered, which is effective to profile looping structures.
+
+    Any name is valid except an empty string.  Calling EnterSection("") will stop the currently
+    running sub section timer.  The total time will still keep running.
+
+    When SectionedScopedTimer goes out of scope it will print a table of its elapsed time and the
+    sub sections.
+
+    It only prints times if the time is greater than the threshold.  Each section is only printed
+    if its time is greater than the threshold.  The whole table is only printed if the total time
+    is greater than the threshold.
+
+    The tables of times will look like the following:
+
+    Title - Section  time: xxxx ms
+    Title - Section2 time: xxxx ms
+    Title            time: xxxx ms
+
+    The following is a usage example.  It shows how to create timer with a section before a loop,
+    two sections in a loop, a section after a loop and a section that will not be timed.
+
+    Usage:
+
+    void function_to_profile () {
+
+        SectionedScopedTimer timer("Title", boost::chrono::milliseconds(1));
+        timer.EnterSection("initial section");
+
+        profiled_code();
+
+        for() {
+            timer.EnterSection("for loop 1 section");
+
+            more_code();
+
+            timer.EnterSection("for loop 2 section");
+
+            even_more_code();
+        }
+
+        timer.EnterSection(""); // don't time this section
+
+        untimed_code();
+
+        timer.EnterSection("final section");
+
+        final_timed_code()
+    }
+
+*/
+class FO_COMMON_API SectionedScopedTimer {
+public:
+    SectionedScopedTimer(const std::string& timed_name, bool enable_output = false,
+                         boost::chrono::microseconds threshold = boost::chrono::milliseconds(1));
+    SectionedScopedTimer(const std::string& timed_name, boost::chrono::microseconds threshold);
+    ~SectionedScopedTimer();
+
+    /** Start recording times for \p section_name.
+     This can be called multiple times to add more time to a previously created section.  Use this
+     feature to profile separate parts of loop strucures. */
+    void EnterSection(const std::string& section_name);
+
+private:
+    class SectionedScopedTimerImpl;
+    // TODO use C++11 unique_ptr
+    boost::scoped_ptr<SectionedScopedTimerImpl> const pimpl;
 };
 
 #endif // _MultiplayerCommon_h_

--- a/util/ScopedTimer.h
+++ b/util/ScopedTimer.h
@@ -5,17 +5,26 @@
 
 #include "Export.h"
 
+// TODO change boost to std when C++11 is adopted.
+#include <boost/chrono/chrono.hpp>
+#include <boost/scoped_ptr.hpp>
+
 /** Wrapper for boost::timer that outputs time during which this object
-  * existed.  Created in the scope of a function, and passed the appropriate
-  * name, it will output to DebugLogger() the time elapsed while
-  * the function was executing. */
+    existed.  Created in the scope of a function, and passed the appropriate
+    name, it will output to DebugLogger() the time elapsed while
+    the function was executing.
+
+    If \p always_output is false it never outputs.
+*/
+
 class FO_COMMON_API ScopedTimer {
 public:
     ScopedTimer(const std::string& timed_name, bool always_output = false);
     ~ScopedTimer();
 private:
     class ScopedTimerImpl;
-    ScopedTimerImpl*    m_impl;
+    // TODO use C++11 unique_ptr
+    boost::scoped_ptr<ScopedTimerImpl> const pimpl;
 };
 
 #endif // _MultiplayerCommon_h_

--- a/util/ScopedTimer.h
+++ b/util/ScopedTimer.h
@@ -14,13 +14,15 @@
     name, it will output to DebugLogger() the time elapsed while
     the function was executing.
 
-    If \p enable_output is true and duration is greater than 1 ms threshold
-    then print output.
+    If \p enable_output is true and duration is greater than threshold then
+    print output.
 */
 
 class FO_COMMON_API ScopedTimer {
 public:
-    ScopedTimer(const std::string& timed_name, bool enable_output = false);
+    ScopedTimer(const std::string& timed_name, bool enable_output = false,
+                boost::chrono::microseconds threshold = boost::chrono::milliseconds(1));
+    ScopedTimer(const std::string& timed_name, boost::chrono::microseconds threshold);
     ~ScopedTimer();
 private:
     class ScopedTimerImpl;

--- a/util/ScopedTimer.h
+++ b/util/ScopedTimer.h
@@ -14,12 +14,13 @@
     name, it will output to DebugLogger() the time elapsed while
     the function was executing.
 
-    If \p always_output is false it never outputs.
+    If \p enable_output is true and duration is greater than 1 ms threshold
+    then print output.
 */
 
 class FO_COMMON_API ScopedTimer {
 public:
-    ScopedTimer(const std::string& timed_name, bool always_output = false);
+    ScopedTimer(const std::string& timed_name, bool enable_output = false);
     ~ScopedTimer();
 private:
     class ScopedTimerImpl;


### PR DESCRIPTION
This PR does three things: 
- makes the time threshold for display of `ScopedTimer` a parameter of the constructor
- adds `SectionedScopedTimer` as a `ScopedTimer` with separately timed sub-sections.
- uses `SectionedScopedTimer` in `MapWnd::InitTurn()` as an example.

`SectionedScopedTimer` is a `ScopedTimer` with an additional member function`EnterSection(<section name>)`, which creates/re-enters a separately timed sub section, with an arbitrary name.

When `SectionedScopedTimer` goes out of scope and is destroyed it prints a table of times.  The table includes its total time and the time of any subsections that exceed the threshold parameter.

An example table looks like this:

```
         Title - Section  time: xxxx ms
         Title - Section2 time: xxxx ms
         Title            time: xxxx ms
```

SectionedScopedTimer was the profiling tool that I used while working on the split fleet timing PR #863.  I stripped it out of that PR to submit here separately.  
