### PR TITLE
Fix bug wasted production lines

### DIFF
--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -3165,8 +3165,11 @@ void MapWnd::InitStarlaneRenderingBuffers() {
             std::map<std::set<int>, float>::const_iterator allocated_it = allocated_pp.find(it->first);
             if (allocated_it == allocated_pp.end() || (group_pp > allocated_it->second + 0.05)) {
                 boost::unordered_map<std::set<int>, boost::shared_ptr<std::set<int> > >::iterator group_core_it = res_group_cores.find(it->first);
-                if (group_core_it != res_group_cores.end())
-                    under_alloc_res_grp_core_members = group_core_it->second;
+                if (group_core_it != res_group_cores.end()) {
+                    if (!under_alloc_res_grp_core_members)
+                        under_alloc_res_grp_core_members = boost::make_shared<std::set<int> >();
+                    under_alloc_res_grp_core_members->insert(group_core_it->second->begin(), group_core_it->second->end());
+                }
             }
         }
     }

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -3063,9 +3063,9 @@ void MapWnd::InitStarlaneRenderingBuffers() {
     // map keyed by ResourcePool to the set of systems considered the core of the corresponding ResGroup
     boost::unordered_map<std::set<int>, boost::shared_ptr<std::set<int> > > res_group_cores;
 
-    std::set<int>                           res_group_core_members;
+    boost::unordered_set<int>                           res_group_core_members;
     boost::unordered_map<int, boost::shared_ptr<std::set<int> > >   member_to_core;
-    boost::shared_ptr<std::set<int> >       under_alloc_res_grp_core_members;
+    boost::shared_ptr<boost::unordered_set<int> >       under_alloc_res_grp_core_members;
 
     if (this_client_empire) {
         const ProductionQueue& queue = this_client_empire->GetProductionQueue();
@@ -3167,7 +3167,7 @@ void MapWnd::InitStarlaneRenderingBuffers() {
                 boost::unordered_map<std::set<int>, boost::shared_ptr<std::set<int> > >::iterator group_core_it = res_group_cores.find(it->first);
                 if (group_core_it != res_group_cores.end()) {
                     if (!under_alloc_res_grp_core_members)
-                        under_alloc_res_grp_core_members = boost::make_shared<std::set<int> >();
+                        under_alloc_res_grp_core_members = boost::make_shared<boost::unordered_set<int> >();
                     under_alloc_res_grp_core_members->insert(group_core_it->second->begin(), group_core_it->second->end());
                 }
             }


### PR DESCRIPTION
This fixes the bug reported in [the forum](http://freeorion.org/forum/viewtopic.php?f=25&t=10187&sid=92b29d0b7f669d2efda5257aed72352a), by AndrewW.

@geoffthemedio pointed out it was caused by my PR #797.

The problem was that I was no longer accumulating the set of all systems with wasted production, only keeping the last set examined.

This PR restores the correct behavior of accumulating all systems with wasted production.
