### PR TITLE
Refactor planet orbital assignment

### DIFF
--- a/universe/System.cpp
+++ b/universe/System.cpp
@@ -110,7 +110,9 @@ void System::Copy(TemporaryPtr<const UniverseObject> copied_object, int empire_i
         this->m_objects = copied_system->VisibleContainedObjectIDs(empire_id);
 
         // only copy orbit info for visible planets
+        size_t orbits_size = m_orbits.size();
         m_orbits.clear();
+        m_orbits.assign(orbits_size, INVALID_OBJECT_ID);
         for (int o = 0; o < static_cast<int>(copied_system->m_orbits.size()); ++o) {
             int planet_id = copied_system->m_orbits[o];
             if (m_objects.find(planet_id) != m_objects.end())

--- a/universe/System.cpp
+++ b/universe/System.cpp
@@ -349,7 +349,7 @@ void System::Insert(TemporaryPtr<UniverseObject> obj, int orbit/* = -1*/) {
         if (orbit == -1) {
             bool already_in_orbit = false;
             for (int o = 0; o < static_cast<int>(m_orbits.size()); ++o) {
-                if (m_orbits[o] = obj->ID()) {
+                if (m_orbits[o] == obj->ID()) {
                     already_in_orbit = true;
                     break;
                 }

--- a/universe/System.cpp
+++ b/universe/System.cpp
@@ -380,8 +380,21 @@ void System::Insert(TemporaryPtr<UniverseObject> obj, int orbit/* = -1*/) {
                 }
                 // put object into desired orbit
                 m_orbits[orbit] = obj->ID();
+            } else {  // Log as an error, if no current orbit attempt to assign to a free orbit
+                ErrorLogger() << "System::Insert() Planet " << obj->ID()
+                              << " requested orbit " << orbit
+                              << " in system " << ID()
+                              << ", which is occupied by" << m_orbits[orbit];
+                const std::set<int>& free_orbits = FreeOrbits();
+                if (free_orbits.size() > 0 && OrbitOfPlanet(obj->ID()) == -1) {
+                    int new_orbit = *(free_orbits.begin());
+                    m_orbits[new_orbit] = obj->ID();
+                    DebugLogger() << "System::Insert() Planet " << obj->ID()
+                                  << " assigned to orbit " << new_orbit;
+                }
             }
         }
+        //TODO If planet not assigned to an orbit, reject insertion of planet, provide feedback to caller
     }
     // if not a planet, don't need to put into an orbit
 


### PR DESCRIPTION
Fixes issue with orbits not persisting after planet creation.
As part of the PR, new planets are assigned a random free orbit, consistent with universe generation.
Planets created with a specific orbit are only assigned a random free orbit if the requested orbit is occupied.
If the system has no free orbits for a new planet, it is not added to system.

The ordering of planets in the side panel is by orbit position, since they currently return `-1`, the perceived order is due to the ID.
Planets from universe generation are named in order of creation, without regard to orbit position.
As this PR corrects the orbit reported, planets will seem to be in the wrong order.  PR #761 corrects the naming.
