### PR TITLE
Fix bug839 meter growth tooltip incorrect

### DIFF
--- a/UI/MeterBrowseWnd.cpp
+++ b/UI/MeterBrowseWnd.cpp
@@ -380,13 +380,12 @@ void MeterBrowseWnd::UpdateEffectLabelsAndValues(GG::Y& top) {
             text += UserString("TT_INHERENT");
             break;
 
-        case ECT_UNKNOWN_CAUSE: {
+        case ECT_UNKNOWN_CAUSE:
         default:
             const std::string& label_template = (info_it->custom_label.empty()
                 ? UserString("TT_UNKNOWN")
                 : UserString(info_it->custom_label));
             text += label_template;
-        }
         }
 
         GG::Label* label = new CUILabel(text, GG::FORMAT_RIGHT);

--- a/UI/MeterBrowseWnd.cpp
+++ b/UI/MeterBrowseWnd.cpp
@@ -243,21 +243,12 @@ namespace DualMeter {
                 for (std::vector<Effect::AccountingInfo>::const_iterator info_it = info_vec.begin();
                      info_it != info_vec.end(); ++info_it)
                 {
-                    switch (info_it->cause_type) {
-                    case ECT_TECH:
-                    case ECT_BUILDING:
-                    case ECT_FIELD:
-                    case ECT_SPECIAL:
-                    case ECT_SPECIES:
-                    case ECT_SHIP_HULL:
-                    case ECT_SHIP_PART:
-                    case ECT_INHERENT:
-                        projected += info_it->meter_change;
-                        break;
-                    case ECT_UNKNOWN_CAUSE:
-                    default:
-                        ; // Don't add unknown effects.
+                    if ((info_it->cause_type == ECT_UNKNOWN_CAUSE)
+                        || (info_it->cause_type == INVALID_EFFECTS_GROUP_CAUSE_TYPE))
+                    {
+                        continue;
                     }
+                    projected += info_it->meter_change;
                 }
             }
         }
@@ -273,7 +264,7 @@ namespace DualMeter {
             projected = target;
         }
 
-        // Also clamp With no target
+        // Clamp when there is no target.
         if (!target_meter)
             projected = current;
 
@@ -320,7 +311,6 @@ void MeterBrowseWnd::UpdateSummary() {
 
         // unpaired meter total for breakdown summary
         breakdown_total = boost::get<0>(current_projected_target);
-        // breakdown_total = obj->InitialMeterValue(m_primary_meter_type);
         breakdown_meter_name = MeterToUserString(m_primary_meter_type);
     }
 

--- a/UI/MeterBrowseWnd.h
+++ b/UI/MeterBrowseWnd.h
@@ -5,7 +5,17 @@
 #include <GG/BrowseInfoWnd.h>
 
 #include "../universe/Enums.h"
+#include <boost/tuple/tuple.hpp>
 
+class UniverseObject;
+
+namespace DualMeter {
+
+    /** Return the triplet of {Current, Projected, Target} meter value for the pair of meters \p
+        actual_meter_type and \p target_meter_type associated with \p obj. */
+    boost::tuple<float, float, float> CurrentProjectedTarget(
+        const UniverseObject& obj, const MeterType& actual_meter_type, const MeterType& target_meter_type);
+}
 
 /** Gives details about what effects contribute to a meter's maximum value (Effect Accounting) and
   * shows the current turn's current meter value and the predicted current meter value for next turn. */

--- a/UI/MultiMeterStatusBar.cpp
+++ b/UI/MultiMeterStatusBar.cpp
@@ -1,4 +1,5 @@
 #include "MultiMeterStatusBar.h"
+#include "MeterBrowseWnd.h"
 
 #include <GG/ClrConstants.h>
 #include <GG/DrawUtil.h>
@@ -201,23 +202,14 @@ void MultiMeterStatusBar::Update() {
         const Meter* actual_meter = obj->GetMeter(meter_types_pair.first);
         const Meter* target_max_meter = obj->GetMeter(meter_types_pair.second);
 
+        boost::tuple<float, float, float> current_projected_target = DualMeter::CurrentProjectedTarget(
+            *obj, meter_types_pair.first, meter_types_pair.second);
+
         if (actual_meter || target_max_meter) {
             ++num_bars;
-            if (actual_meter) {
-                m_initial_values.push_back(actual_meter->Initial());
-                if (target_max_meter)
-                    m_projected_values.push_back(obj->NextTurnCurrentMeterValue(meter_types_pair.first));
-                else
-                    m_projected_values.push_back(actual_meter->Initial());
-            } else {
-                m_initial_values.push_back(Meter::INVALID_VALUE);
-                m_projected_values.push_back(Meter::INVALID_VALUE);
-            }
-            if (target_max_meter) {
-                m_target_max_values.push_back(target_max_meter->Current());
-            } else {
-                m_target_max_values.push_back(Meter::INVALID_VALUE);
-            }
+            m_initial_values.push_back(boost::get<0>(current_projected_target));
+            m_projected_values.push_back(boost::get<1>(current_projected_target));
+            m_target_max_values.push_back(boost::get<2>(current_projected_target));
             m_bar_colours.push_back(MeterColor(meter_types_pair.first));
         }
     }


### PR DESCRIPTION
This PR fixes issue #839.

It does this by creating `DualMeter::CurrentProjectedTarget()` to calculate the correct projected meter estimates.  It then uses these estimates in the `MeterBrowseWnd` and `MultiMeterStatusBar`. 

I tested it with Force Energy Structures and the Megalith.
