### PR TITLE
Fix bug #841 ship scanlines below ship.

### DIFF
--- a/UI/BuildingsPanel.h
+++ b/UI/BuildingsPanel.h
@@ -2,6 +2,7 @@
 #define _BuildingsPanel_h_
 
 #include "AccordionPanel.h"
+#include "CUIDrawUtil.h"
 
 class BuildingIndicator;
 class MultiTurnProgressBar;
@@ -83,7 +84,7 @@ public:
 private:
     void            DoLayout();
 
-    static boost::shared_ptr<ShaderProgram> s_scanline_shader;
+    static ScanlineRenderer s_scanline_shader;
 
     GG::StaticGraphic*          m_graphic;
     GG::StaticGraphic*          m_scrap_indicator;  ///< shown to indicate building was ordered scrapped

--- a/UI/CUIControls.cpp
+++ b/UI/CUIControls.cpp
@@ -2178,3 +2178,23 @@ void CUIToggleRepresenter::Render(const GG::StateButton& button) const {
     glColor(icon_clr);
     render_checked ? m_checked_icon->OrthoBlit(icon_ul, icon_lr) : m_unchecked_icon->OrthoBlit(icon_ul, icon_lr);
 }
+
+////////////////////////////////////////////////
+// ScanlineControl
+////////////////////////////////////////////////
+
+namespace {
+    ScanlineRenderer scanline_shader;
+}
+
+ScanlineControl::ScanlineControl(GG::X x, GG::Y y, GG::X w, GG::Y h, bool square /*= false*/) :
+    Control(x, y, w, h, GG::NO_WND_FLAGS),
+    m_square(square)
+{}
+
+void ScanlineControl::Render() {
+    if (m_square)
+        scanline_shader.RenderRectangle(UpperLeft(), LowerRight());
+    else
+        scanline_shader.RenderCircle(UpperLeft(), LowerRight());
+}

--- a/UI/CUIControls.h
+++ b/UI/CUIControls.h
@@ -624,4 +624,13 @@ private:
     GG::Clr                             m_checked_color;
 };
 
+/** Renders scanlines over its area. */
+class ScanlineControl : public GG::Control {
+public:
+    ScanlineControl(GG::X x, GG::Y y, GG::X w, GG::Y h, bool square = false);
+    virtual void Render();
+private:
+    bool m_square;
+};
+
 #endif // _CUIControls_h_

--- a/UI/CUIDrawUtil.cpp
+++ b/UI/CUIDrawUtil.cpp
@@ -393,13 +393,10 @@ public:
     {}
 
     void StartUsing() {
-        if (m_failed_init || (!GetOptionsDB().Get<bool>("UI.system-fog-of-war")))
+        if (m_failed_init)
             return;
 
         if (!m_scanline_shader) {
-            if (m_failed_init)
-                return;
-
             boost::filesystem::path shader_path = GetRootDataDir() / "default" / "shaders" / "scanlines.frag";
             std::string shader_text;
             ReadFile(shader_path, shader_text);

--- a/UI/CUIDrawUtil.h
+++ b/UI/CUIDrawUtil.h
@@ -4,6 +4,7 @@
 #include <GG/Clr.h>
 #include <GG/PtRect.h>
 #include <GG/GLClientAndServerBuffer.h>
+#include <boost/scoped_ptr.hpp>
 
 /** adjusts the intensity of the color up or down by \a amount units per color
   * channel; leaves alpha unchanged if \a jointly_capped is true then, if the
@@ -88,6 +89,38 @@ void PartlyRoundedRect(const GG::Pt& ul, const GG::Pt& lr, int radius, bool ur_r
   * parameters. */
 void BufferStorePartlyRoundedRectVertices(GG::GL2DVertexBuffer& buffer, const GG::Pt& ul, const GG::Pt& lr,
                                           int radius, bool ur_round, bool ul_round, bool ll_round, bool lr_round);
+
+/** ScanlineRenderer renders scanlines in circular/square/arbitrary areas.
+    It loads the scanline shader on first use.
+    There is only expected to by one ScanlineRenderer per compilation unit so
+    that the shader is compiled once.
+
+    Bracketing OpenGL primitives with StartUsing() and StopUsing() will render
+    scanlines in that arbitrary area.*/
+class ScanlineRenderer {
+public:
+    ScanlineRenderer();
+    ~ScanlineRenderer();
+
+    /** Draw scanlines in the circular area bounded by \p ul and \p lr.*/
+    void RenderCircle(const GG::Pt& ul, const GG::Pt& lr);
+
+    /** Draw scanlines in the square area bounded by \p ul and \p lr.*/
+    void RenderRectangle(const GG::Pt& ul, const GG::Pt& lr);
+
+    /** Start using ScanlineRenderer to draw arbitrary shapes with the scanline
+        shader program.*/
+    void StartUsing();
+
+    /** Stop using ScanlineRenderer to draw arbitrary shapes with the scanline
+        shader program.*/
+    void StopUsing();
+
+private:
+    class ScanlineRendererImpl;
+    // TODO use C++11 unique_ptr
+    boost::scoped_ptr<ScanlineRendererImpl> const pimpl;
+};
 
 #endif // _CUIDrawUtil_h_
 

--- a/UI/FleetButton.cpp
+++ b/UI/FleetButton.cpp
@@ -166,8 +166,10 @@ FleetButton::~FleetButton() {
     DetachChild(m_selection_indicator);
     delete m_selection_indicator;
 
-    DetachChild(m_scanline_control);
-    delete m_scanline_control;
+    if (m_scanline_control) {
+        DetachChild(m_scanline_control);
+        delete m_scanline_control;
+    }
 }
 
 void FleetButton::Init(const std::vector<int>& fleet_IDs, SizeType size_type) {
@@ -310,9 +312,6 @@ void FleetButton::Init(const std::vector<int>& fleet_IDs, SizeType size_type) {
 
     LayoutIcons();
 
-    // Create scanline renderer control
-    m_scanline_control = new ScanlineControl(GG::X0, GG::Y0, Width(), Height());
-
     // Scanlines for not currently-visible objects?
     int empire_id = HumanClientApp::GetApp()->EmpireID();
     if (empire_id == ALL_EMPIRES || !GetOptionsDB().Get<bool>("UI.system-fog-of-war"))
@@ -325,6 +324,9 @@ void FleetButton::Init(const std::vector<int>& fleet_IDs, SizeType size_type) {
             break;
         }
     }
+
+    // Create scanline renderer control
+    m_scanline_control = new ScanlineControl(GG::X0, GG::Y0, Width(), Height());
 
     if (!at_least_one_fleet_visible)
         AttachChild(m_scanline_control);

--- a/UI/FleetButton.h
+++ b/UI/FleetButton.h
@@ -6,6 +6,7 @@
 class Fleet;
 template <class T> class TemporaryPtr;
 class RotatingGraphic;
+class ScanlineControl;
 
 /** represents one or more fleets of an empire at a location on the map. */
 class FleetButton : public GG::Button {
@@ -53,6 +54,7 @@ private:
     std::vector<int>                m_fleets;   ///< the fleets represented by this button
     std::vector<RotatingGraphic*>   m_icons;
     RotatingGraphic*                m_selection_indicator;
+    ScanlineControl*                m_scanline_control;
     bool                            m_selected; ///< should this button render itself specially to show that it is selected?
 };
 

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -807,8 +807,10 @@ void ShipDataPanel::SetShipIcon() {
     delete m_bombard_indicator;
     m_bombard_indicator = 0;
 
-    delete m_scanline_control;
-    m_scanline_control = 0;
+    if (m_scanline_control) {
+        delete m_scanline_control;
+        m_scanline_control = 0;
+    }
 
     TemporaryPtr<const Ship> ship = GetShip(m_ship_id);
     if (!ship)
@@ -850,7 +852,9 @@ void ShipDataPanel::SetShipIcon() {
         AttachChild(m_bombard_indicator);
     }
     int client_empire_id = HumanClientApp::GetApp()->EmpireID();
-    if (ship->GetVisibility(client_empire_id) < VIS_BASIC_VISIBILITY) {
+    if ((ship->GetVisibility(client_empire_id) < VIS_BASIC_VISIBILITY)
+        && GetOptionsDB().Get<bool>("UI.system-fog-of-war"))
+    {
         m_scanline_control = new ScanlineControl(GG::X0, GG::Y0, m_ship_icon->Width(), m_ship_icon->Height(), true);
         AttachChild(m_scanline_control);
     }
@@ -1517,8 +1521,10 @@ void FleetDataPanel::AggressionToggleButtonPressed() {
 void FleetDataPanel::Refresh() {
     delete m_fleet_icon;
     m_fleet_icon = 0;
-    delete m_scanline_control;
-    m_scanline_control = 0;
+    if (m_scanline_control) {
+        delete m_scanline_control;
+        m_scanline_control = 0;
+    }
     delete m_gift_indicator;
     m_gift_indicator = 0;
 
@@ -1569,7 +1575,9 @@ void FleetDataPanel::Refresh() {
             AttachChild(m_gift_indicator);
         }
 
-        if (fleet->GetVisibility(client_empire_id) < VIS_BASIC_VISIBILITY) {
+        if ((fleet->GetVisibility(client_empire_id) < VIS_BASIC_VISIBILITY)
+            && GetOptionsDB().Get<bool>("UI.system-fog-of-war"))
+        {
             m_scanline_control = new ScanlineControl(GG::X0, GG::Y0, DATA_PANEL_ICON_SPACE.x, ClientHeight(), true);
             AttachChild(m_scanline_control);
         }

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -1563,8 +1563,9 @@ void MapWnd::RenderFields() {
     }
 
     // if any, render scanlines over not-visible fields
-    if (!m_field_scanline_circles.empty() &&
-        HumanClientApp::GetApp()->EmpireID() != ALL_EMPIRES)
+    if (!m_field_scanline_circles.empty()
+        && HumanClientApp::GetApp()->EmpireID() != ALL_EMPIRES
+        && GetOptionsDB().Get<bool>("UI.system-fog-of-war"))
     {
         glDisableClientState(GL_TEXTURE_COORD_ARRAY);
         m_field_scanline_circles.activate();
@@ -1696,10 +1697,8 @@ void MapWnd::RenderSystems() {
     float fog_scanline_spacing = 4.0f;
     Universe& universe = GetUniverse();
 
-    if (empire_id != ALL_EMPIRES && GetOptionsDB().Get<bool>("UI.system-fog-of-war")) {
+    if (empire_id != ALL_EMPIRES && GetOptionsDB().Get<bool>("UI.system-fog-of-war"))
         fog_scanlines = true;
-        fog_scanline_spacing = static_cast<float>(GetOptionsDB().Get<double>("UI.system-fog-of-war-spacing"));
-    }
 
     RenderScaleCircle();
 

--- a/UI/MapWnd.h
+++ b/UI/MapWnd.h
@@ -471,7 +471,7 @@ private:
     GG::GL3DVertexBuffer                m_starfield_verts;
     GG::GLRGBAColorBuffer               m_starfield_colours;
 
-    boost::shared_ptr<ShaderProgram>    m_scanline_shader;
+    ScanlineRenderer                    m_scanline_shader;
 
     GG::Pt                      m_drag_offset;      //!< distance the cursor is from the upper-left corner of the window during a drag ((-1, -1) if no drag is occurring)
     bool                        m_dragged;          //!< tracks whether or not a drag occurs during a left button down sequence of events

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -639,7 +639,7 @@ public:
         }
 
         // render fog of war over planet if it's not visible to this client's player
-        if (m_visibility <= VIS_BASIC_VISIBILITY)
+        if ((m_visibility <= VIS_BASIC_VISIBILITY) && GetOptionsDB().Get<bool>("UI.system-fog-of-war"))
             s_scanline_shader.RenderCircle(ul, lr);
     }
 

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -616,13 +616,6 @@ public:
         m_initial_rotation(fmod(planet_id / 7.352535, 1.0)),    // arbitrary scale number applied to id to give consistent by varied angles
         m_star_type(star_type)
     {
-        if (!s_scanline_shader && GetOptionsDB().Get<bool>("UI.system-fog-of-war")) {
-            boost::filesystem::path shader_path = GetRootDataDir() / "default" / "shaders" / "scanlines.frag";
-            std::string shader_text;
-            ReadFile(shader_path, shader_text);
-            s_scanline_shader = boost::shared_ptr<ShaderProgram>(
-                ShaderProgram::shaderProgramFactory("", shader_text));
-        }
         Refresh();
     }
 
@@ -646,16 +639,8 @@ public:
         }
 
         // render fog of war over planet if it's not visible to this client's player
-        if (s_scanline_shader &&
-            m_visibility <= VIS_BASIC_VISIBILITY &&
-            GetOptionsDB().Get<bool>("UI.system-fog-of-war"))
-        {
-            float fog_scanline_spacing = static_cast<float>(GetOptionsDB().Get<double>("UI.system-fog-of-war-spacing"));
-            s_scanline_shader->Use();
-            s_scanline_shader->Bind("scanline_spacing", fog_scanline_spacing);
-            CircleArc(ul, lr, 0.0, TWO_PI, true);
-            s_scanline_shader->stopUse();
-        }
+        if (m_visibility <= VIS_BASIC_VISIBILITY)
+            s_scanline_shader.RenderCircle(ul, lr);
     }
 
     void Refresh() {
@@ -714,9 +699,10 @@ private:
     double                          m_initial_rotation;
     StarType                        m_star_type;
 
-    static boost::shared_ptr<ShaderProgram> s_scanline_shader;
+    static ScanlineRenderer         s_scanline_shader;
 };
-boost::shared_ptr<ShaderProgram> RotatingPlanetControl::s_scanline_shader = boost::shared_ptr<ShaderProgram>();
+
+ScanlineRenderer RotatingPlanetControl::s_scanline_shader;
 
 
 namespace {


### PR DESCRIPTION
This fixes issue #841.

It generalizes existing code into a `ScanlineRenderer` and a `ScanlineControl`.  It uses the `ScanlineRenderer` in the `ScanlineControl` to render the scanlines on top of the ship icon.
