### PR TITLE
Fix obstructed system supply calculation.

### DIFF
--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -387,6 +387,9 @@ void SupplyManager::Update() {
 
                 //DebugLogger() << "... removed empire " << empire_id << " system " << sys_id << " supply.";
 
+                // Remove from unobstructed systems
+                empire_supply_unobstructed_systems[empire_id].erase(sys_id);
+
                 std::set<std::pair<int, int> >& lane_traversals = m_supply_starlane_traversals[empire_id];
                 std::set<std::pair<int, int> > lane_traversals_initial = lane_traversals;
                 std::set<std::pair<int, int> >& obstructed_traversals = m_supply_starlane_obstructed_traversals[empire_id];


### PR DESCRIPTION
This PR fixes issue #883.

Remove system from the set of unobstructed systems when two or more
empires have equal supply to the system.

Previously, only the starlanes were marked obstructed allowing another
system from a different starlane at a lower supply value to supply the
system.
