### PR TITLE
Prevent unowned planet mines from affecting unowned guard ships

### DIFF
--- a/default/scripting/ship_hulls/monster/SH_GUARD_0_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_GUARD_0_BODY.focs.txt
@@ -13,6 +13,7 @@ Hull
     buildCost = 1
     buildTime = 2
     Unproducible
+    tags = "UNOWNED_FRIENDLY"
     location = All
     effectsgroups = [
         [[UNOWNED_OWNED_VISION_BONUS(WEAK,10,10)]]

--- a/default/scripting/ship_hulls/monster/SH_GUARD_1_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_GUARD_1_BODY.focs.txt
@@ -13,6 +13,7 @@ Hull
     buildCost = 1
     buildTime = 2
     Unproducible
+    tags = "UNOWNED_FRIENDLY"
     location = All
     effectsgroups = [
         [[UNOWNED_OWNED_VISION_BONUS(POOR,20,20)]]

--- a/default/scripting/ship_hulls/monster/SH_GUARD_3_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_GUARD_3_BODY.focs.txt
@@ -18,6 +18,7 @@ Hull
     buildCost = 1
     buildTime = 2
     Unproducible
+    tags = "UNOWNED_FRIENDLY"
     location = All
     effectsgroups = [
         [[UNOWNED_OWNED_VISION_BONUS(GOOD,50,50)]]

--- a/default/scripting/ship_hulls/monster/SH_GUARD_MONSTER_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_GUARD_MONSTER_BODY.focs.txt
@@ -15,6 +15,7 @@ Hull
     buildCost = 1
     buildTime = 2
     Unproducible
+    tags = "UNOWNED_FRIENDLY"
     location = All
     effectsgroups = [
         [[UNOWNED_OWNED_VISION_BONUS(MODERATE,40,30)]]

--- a/default/scripting/techs/defense/mines.macros
+++ b/default/scripting/techs/defense/mines.macros
@@ -13,7 +13,7 @@
 //   SYS_DEF_MINES_1
 
 EG_SYSTEM_MINES
-'''        // damage ship; sitreps issued below
+'''        // Empire owned planet, damage enemy ship; sitreps issued below
         EffectsGroup
             scope = And [
                 Ship
@@ -22,15 +22,36 @@ EG_SYSTEM_MINES
                     OwnedBy affiliation = EnemyOf empire = Source.Owner
                     Unowned
                 ]
-                Not OwnedBy empire = Source.Owner
                 Structure low = @1@ + 0.0001
             ]
+            activation = Not Unowned
             stackinggroup = "DEF_MINES_DAMAGE_STACK"
             priority = @2@
             effects = [
                 SetStructure value = Value - @1@
             ]
-        // destroy ship; sitreps issued below
+        // Unowned planet, damage non-friendly ship; sitreps issued below
+        EffectsGroup
+            scope = And [
+                Ship
+            [[SYSTEM_MINES_SCOPE(@3@)]]
+            Or [
+                Not Unowned
+                And [
+                    Unowned
+                    Not HasTag name = "UNOWNED_FRIENDLY"
+                    ]
+                ]
+                Structure low = @1@ + 0.0001
+            ]
+            activation = Unowned
+            stackinggroup = "DEF_MINES_DAMAGE_STACK"
+            priority = @2@
+            effects = [
+                SetStructure value = Value - @1@
+            ]
+
+        // Empire owned planet, destroy enemy ship; sitreps issued below
         EffectsGroup
             scope = And [
                 Ship
@@ -39,14 +60,37 @@ EG_SYSTEM_MINES
                     OwnedBy affiliation = EnemyOf empire = Source.Owner
                     Unowned
                 ]
-                Not OwnedBy empire = Source.Owner
                 Structure high = @1@
             ]
+            activation = Not Unowned
             stackinggroup = "DEF_MINES_DAMAGE_STACK"
             priority = @2@
             effects = [
                 Destroy
             ]
+        // Unowned planet, destroy non-friendly ship; sitreps issued below
+        EffectsGroup
+            scope = And [
+                Ship
+                [[SYSTEM_MINES_SCOPE(@3@)]]
+            Or [
+                Not Unowned
+                And [
+                    Unowned
+                    Not HasTag name = "UNOWNED_FRIENDLY"
+                    ]
+                ]
+                Structure low = @1@ + 0.0001
+            ]
+            activation = Unowned
+            stackinggroup = "DEF_MINES_DAMAGE_STACK"
+            priority = @2@
+            effects = [
+                Destroy
+            ]
+
+        // Sitreps
+
         // Planet owner sitrep - visible enemy fleet damaged
         EffectsGroup
             scope = And [


### PR DESCRIPTION
Fixes #873 

The following ship designs are not damaged from unowned planet mines:
-  SM_GUARD_0  -  Maintenance Ship
-  SM_GUARD_1  -  Sentry
-  SM_GUARD_2  -  Sentinel
-  SM_ACIREMA_GUARD  -  Acirema Guard Ship
-  SM_GUARD_3  -  Warden
