### PR TITLE
Revise naming method for new planets

### DIFF
--- a/default/python/universe_generation/starsystems.py
+++ b/default/python/universe_generation/starsystems.py
@@ -52,21 +52,12 @@ def name_planets(system):
     unless it's an asteroid belt, in that case name is system
     name + 'asteroid belt' (localized).
     """
-    planet_number = 1
     # iterate over all planets in the system
+    sys_name = fo.get_name(system)
     for planet in fo.sys_get_planets(system):
-        # use different naming methods for "normal" planets and asteroid belts
-        if fo.planet_get_type(planet) == fo.planetType.asteroids:
-            # get localized text from stringtable
-            name = fo.user_string("PL_ASTEROID_BELT_OF_SYSTEM")
-            # %1% parameter in the localized string is the system name
-            name = name.replace("%1%", fo.get_name(system))
-        else:
-            # set name to system name + planet number as roman number...
-            name = fo.get_name(system) + " " + fo.roman_number(planet_number)
-            # ...and increase planet number
-            planet_number += 1
-        # do the actual renaming
+        name = fo.user_string("NEW_PLANET_NAME")
+        name = name.replace("%1%", sys_name)
+        name = name.replace("%2%", fo.planet_cardinal_suffix(planet))
         fo.set_name(planet, name)
 
 

--- a/default/scripting/fields/fields.macros
+++ b/default/scripting/fields/fields.macros
@@ -99,19 +99,16 @@ EFFECT_CREATE_PLANET
 '''CreatePlanet
     type = OneOf(Barren, Desert, Inferno, Ocean, Radiated, Swamp, Terran, Toxic, Tundra)
     planetsize = OneOf(tiny, small, medium, large)
-    name = UserString("NEW_PLANET_NAME") % Target.Name
 '''
 
 EFFECT_CREATE_ASTEROID
 '''CreatePlanet
     type = asteroids
     planetsize = asteroids
-    name = UserString("NEW_ASTEROIDS_NAME") % Target.Name % Source.Name
 '''
 
 EFFECT_CREATE_GASGIANT
 '''CreatePlanet
     type = GasGiant
     planetsize = GasGiant
-    name = UserString("NEW_PLANET_NAME") % Target.Name
 '''

--- a/default/stringtables/de.txt
+++ b/default/stringtables/de.txt
@@ -170,17 +170,22 @@ Bomberflotte %1%
 NEW_BATTLE_FLEET_NAME
 Kriegsflotte %1%
 
-# Name for a newly created asteroid belt.
-# %1% name of the system this asteroid belt is created in.
-# %2% orbit number where this asteroid belt is created on.
-NEW_ASTEROIDS_NAME
-Überreste von %1% %2%
-
-# Name for a newly created planet. When creating a new planet it is assumed this
-# planet is the first one within the system.
+# Name for a newly created planet.
+# Suffix bears some explanation:
+#  - Planets are grouped for asteroids and non-asteroids.
+#  - Suffix is a roman numeral, with additional rules for asteroids.
+#  - The roman numeral is a rank for proximity to the center of the system,
+#      in relation to other planets in the same group.
+#  - For asteroids, the suffix starts with a localized NEW_ASTEROIDS_SUFFIX.
+#      If any other asteroids are in the system, the roman numeral is appended.
 # %1% name of the system this planet is created in.
-#NEW_PLANET_NAME
-#%1% I
+# %2% suffix for this planet
+# NEW_PLANET_NAME
+# %1% %2%
+
+# The label pre-pended to a new asteroids naming suffix
+# NEW_ASTEROIDS_SUFFIX
+# [[PT_ASTEROIDS]]
 
 EMPTY_SPACE
 Tiefe des Alls

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -165,17 +165,22 @@ Bomber Fleet %1%
 NEW_BATTLE_FLEET_NAME
 Battle Fleet %1%
 
-# Name for a newly created asteroid belt.
-# %1% name of the system this asteroid belt is created in.
-# %2% orbit number where this asteroid belt is created on.
-NEW_ASTEROIDS_NAME
-%1% %2% remnants
-
-# Name for a newly created planet. When creating a new planet it is assumed this
-# planet is the first one within the system.
+# Name for a newly created planet.
+# Suffix bears some explanation:
+#  - Planets are grouped for asteroids and non-asteroids.
+#  - Suffix is a roman numeral, with additional rules for asteroids.
+#  - The roman numeral is a rank for proximity to the center of the system,
+#      in relation to other planets in the same group.
+#  - For asteroids, the suffix starts with a localized NEW_ASTEROIDS_SUFFIX.
+#      If any other asteroids are in the system, the roman numeral is appended.
 # %1% name of the system this planet is created in.
+# %2% suffix for this planet
 NEW_PLANET_NAME
-%1% I
+%1% %2%
+
+# The label pre-pended to a new asteroids naming suffix
+NEW_ASTEROIDS_SUFFIX
+[[PT_ASTEROIDS]]
 
 EMPTY_SPACE
 Deep Space

--- a/default/stringtables/fr.txt
+++ b/default/stringtables/fr.txt
@@ -191,17 +191,22 @@ Flotte Bombardement %1%
 NEW_BATTLE_FLEET_NAME
 Flotte Combat %1%
 
-# Name for a newly created asteroid belt.
-# %1% name of the system this asteroid belt is created in.
-# %2% orbit number where this asteroid belt is created on.
-NEW_ASTEROIDS_NAME
-Rémanent %2% %1%
-
-# Name for a newly created planet. When creating a new planet it is assumed this
-# planet is the first one within the system.
+# Name for a newly created planet.
+# Suffix bears some explanation:
+#  - Planets are grouped for asteroids and non-asteroids.
+#  - Suffix is a roman numeral, with additional rules for asteroids.
+#  - The roman numeral is a rank for proximity to the center of the system,
+#      in relation to other planets in the same group.
+#  - For asteroids, the suffix starts with a localized NEW_ASTEROIDS_SUFFIX.
+#      If any other asteroids are in the system, the roman numeral is appended.
 # %1% name of the system this planet is created in.
-#NEW_PLANET_NAME
-#%1% I
+# %2% suffix for this planet
+# NEW_PLANET_NAME
+# %1% %2%
+
+# The label pre-pended to a new asteroids naming suffix
+# NEW_ASTEROIDS_SUFFIX
+# [[PT_ASTEROIDS]]
 
 EMPTY_SPACE
 Espace Interstellaire

--- a/python/server/ServerWrapper.cpp
+++ b/python/server/ServerWrapper.cpp
@@ -1205,6 +1205,16 @@ namespace {
 
         return planet->Colonize(empire_id, species, population);
     }
+
+    object PlanetCardinalSuffix(int planet_id) {
+        TemporaryPtr<Planet> planet = GetPlanet(planet_id);
+        if (!planet) {
+            ErrorLogger() << "PlanetCardinalSuffix: couldn't get planet with ID:" << planet_id;
+            return object(UserString("ERROR"));
+        }
+
+        return object(planet->CardinalSuffix());
+    }
 }
 
 namespace FreeOrionPython {
@@ -1321,5 +1331,6 @@ namespace FreeOrionPython {
         def("planet_available_foci",                PlanetAvailableFoci);
         def("planet_make_outpost",                  PlanetMakeOutpost);
         def("planet_make_colony",                   PlanetMakeColony);
+        def("planet_cardinal_suffix",               PlanetCardinalSuffix);
     }
 }

--- a/universe/Effect.cpp
+++ b/universe/Effect.cpp
@@ -1410,7 +1410,7 @@ void CreatePlanet::Execute(const ScriptingContext& context) const {
         if (ValueRef::ConstantExpr(m_name) && UserStringExists(name_str))
             name_str = UserString(name_str);
     } else {
-        name_str = str(FlexibleFormat(UserString("NEW_PLANET_NAME")) % system->Name());
+        name_str = str(FlexibleFormat(UserString("NEW_PLANET_NAME")) % system->Name() % planet->CardinalSuffix());
     }
     planet->Rename(name_str);
 

--- a/universe/Planet.h
+++ b/universe/Planet.h
@@ -133,6 +133,7 @@ public:
     virtual float               NextTurnCurrentMeterValue(MeterType type) const;
 
     const std::string&          SurfaceTexture() const          { return m_surface_texture; }
+    std::string                 CardinalSuffix() const;     ///< returns a roman number representing this planets orbit in relation to other planets
     //@}
 
     /** \name Mutators */ //@{

--- a/universe/System.h
+++ b/universe/System.h
@@ -56,6 +56,7 @@ public:
     const std::set<int>&    FleetIDs() const                { return m_fleets; }
     const std::set<int>&    ShipIDs() const                 { return m_ships; }
     const std::set<int>&    FieldIDs() const                { return m_fields; }
+    const std::vector<int>& PlanetIDsByOrbit() const        { return m_orbits; }
 
     virtual bool            Contains(int object_id) const;                                  ///< returns true if object with id \a object_id is in this System
     virtual bool            ContainedBy(int object_id) const{ return false; }               ///< returns true if there is an object with id \a object_id that contains this UniverseObject


### PR DESCRIPTION
This PR is to address planet naming in a manner suitable for release (supersedes #761).

Names planets based on their proximity to the center of the system, in relation to other planets in their group.
Groups are defined as a) asteroid type planets and b) all others.

A couple of notable issues:
-  The first asteroid planet created by a nebula will not have a roman numeral, even with other asteroids in the system. (minor issue for release)
-  Creation of planets outside of the current default order (lowest free orbit) may cause duplicate or un-ordered names for future planets. (not a conflict for anything targeted for 0.4.6)
-  `CardinalSuffix` is fixed to group between asteroids and non-asteroids.  Allowing dynamic sets of PlanetTypes to group by is deferred for post-release.
