### PR TITLE
make species attribute description uniform

### DIFF
--- a/default/stringtables/de.txt
+++ b/default/stringtables/de.txt
@@ -6827,7 +6827,7 @@ NO_INDUSTRY
 −−−	Keine [[encyclopedia INDUSTRY_TITLE]]
 
 BAD_INDUSTRY
-−	Schlechte [[encyclopedia INDUSTRY_TITLE]]: -50%
+−	Schlechte [[encyclopedia INDUSTRY_TITLE]]: 75%
 
 AVERAGE_INDUSTRY
 '''	Mittelmässige [[encyclopedia INDUSTRY_TITLE]]: 100%'''
@@ -6836,16 +6836,16 @@ GOOD_INDUSTRY
 +	Gute [[encyclopedia INDUSTRY_TITLE]]: 150%
 
 GREAT_INDUSTRY
-++	Große [[encyclopedia INDUSTRY_TITLE]]: 200%
+++	Hervorragende [[encyclopedia INDUSTRY_TITLE]]: 200%
 
 ULTIMATE_INDUSTRY
-+++	Perfekte [[encyclopedia INDUSTRY_TITLE]]: 400%
++++	Perfekte [[encyclopedia INDUSTRY_TITLE]]: 300%
 
 NO_RESEARCH
 −−−	Keine [[encyclopedia RESEARCH_TITLE]]
 
 BAD_RESEARCH
-−	Schlechte [[encyclopedia RESEARCH_TITLE]]: -50%
+−	Schlechte [[encyclopedia RESEARCH_TITLE]]: 75%
 
 AVERAGE_RESEARCH
 '''	Mittelmässige [[encyclopedia RESEARCH_TITLE]]: 100%'''
@@ -6854,16 +6854,16 @@ GOOD_RESEARCH
 +	Gute [[encyclopedia RESEARCH_TITLE]]: 150%
 
 GREAT_RESEARCH
-++	Große [[encyclopedia RESEARCH_TITLE]]: 200%
+++	Hervorragende [[encyclopedia RESEARCH_TITLE]]: 200%
 
 ULTIMATE_RESEARCH
-+++	Perfekte [[encyclopedia RESEARCH_TITLE]]: 400%
++++	Perfekte [[encyclopedia RESEARCH_TITLE]]: 300%
 
 NO_DEFENSE_TROOPS
 −−−	Keine Boden[[encyclopedia TROOP_TITLE]]
 
 BAD_DEFENSE_TROOPS
-−	Schlechte Boden[[encyclopedia TROOP_TITLE]]: -50%
+−	Schlechte Boden[[encyclopedia TROOP_TITLE]]: 50%
 
 AVERAGE_DEFENSE_TROOPS
 '''	Mittelmäßige Boden[[encyclopedia TROOP_TITLE]]: 100%'''
@@ -6872,7 +6872,7 @@ GOOD_DEFENSE_TROOPS
 +	Gute Boden[[encyclopedia TROOP_TITLE]]: 150%.
 
 GREAT_DEFENSE_TROOPS
-++	Große Boden[[encyclopedia TROOP_TITLE]]: 200%.
+++	Hervorragende Boden[[encyclopedia TROOP_TITLE]]: 200%.
 
 ULTIMATE_DEFENSE_TROOPS
 +++	Perfekte Boden[[encyclopedia TROOP_TITLE]]: 300%.
@@ -6884,34 +6884,34 @@ GOOD_DETECTION
 +	Gute [[encyclopedia DETECTION_RANGE_TITLE]]: +25 Bonus.
 
 GREAT_DETECTION
-++	Große [[encyclopedia DETECTION_RANGE_TITLE]]: +50 Bonus.
+++	Hervorragende [[encyclopedia DETECTION_RANGE_TITLE]]: +50 Bonus.
 
 ULTIMATE_DETECTION
 +++	Perfekte [[encyclopedia DETECTION_RANGE_TITLE]]: +100 Bonus.
 
 BAD_STEALTH
-−	Schlechte [[encyclopedia STEALTH_TITLE]]: −15 Malus.
+−	Schlechte [[encyclopedia STEALTH_TITLE]]: −20 Malus.
 
 AVERAGE_STEALTH
 '''	Mittelmäßige [[encyclopedia STEALTH_TITLE]].'''
 
 GOOD_STEALTH
-+	Gute [[encyclopedia STEALTH_TITLE]]: +15 Bonus.
++	Gute [[encyclopedia STEALTH_TITLE]]: +20 Bonus.
 
 GREAT_STEALTH
-++	Grosse [[encyclopedia STEALTH_TITLE]]: +40 Bonus.
+++	Hervorragende [[encyclopedia STEALTH_TITLE]]: +40 Bonus.
 
 ULTIMATE_STEALTH
 +++	Perfekte [[encyclopedia STEALTH_TITLE]]: +60 Bonus.
 
 BAD_POPULATION
-−	Arme Bevölkerung 75%
+−	Niedrige Bevölkerung 75%
 
 AVERAGE_POPULATION
-'''	Mittelmäßige Bevölkerung'''
+'''	Normale Bevölkerung'''
 
 GOOD_POPULATION
-+	Gesunde Bevölkerung 125%
++	Hohe Bevölkerung 125%
 
 
 ##
@@ -6924,19 +6924,19 @@ STANDARD_CONSTRUCTION_LABEL
 
 # %1% FIXME
 GOOD_ENVIRONMENT_LABEL
-%1% Gute Umgebung
+%1% Gute Umweltbedingungen
 
 # %1% FIXME
 ADEQUATE_ENVIRONMENT_LABEL
-%1% Passende Umgebung
+%1% Ausreichende Umweltbedingungen
 
 # %1% FIXME
 POOR_ENVIRONMENT_LABEL
-%1% Arme Umgebung
+%1% Schlechte Umweltbedingungen
 
 # %1% FIXME
 HOSTILE_ENVIRONMENT_LABEL
-%1% Feindliche Umgebung
+%1% Feindliche Umweltbedingungen
 
 HOMEWORLD_LABEL
 Heimatwelt

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -12700,7 +12700,7 @@ NO_INDUSTRY
 −−−	No [[encyclopedia INDUSTRY_TITLE]]
 
 BAD_INDUSTRY
-−	Bad [[encyclopedia INDUSTRY_TITLE]]: -25%
+−	Bad [[encyclopedia INDUSTRY_TITLE]]: 75%
 
 AVERAGE_INDUSTRY
 '''	Average [[encyclopedia INDUSTRY_TITLE]]: 100%'''
@@ -12718,7 +12718,7 @@ NO_RESEARCH
 −−−	No [[encyclopedia RESEARCH_TITLE]]
 
 BAD_RESEARCH
-−	Bad [[encyclopedia RESEARCH_TITLE]]: -25%
+−	Bad [[encyclopedia RESEARCH_TITLE]]: 75%
 
 AVERAGE_RESEARCH
 '''	Average [[encyclopedia RESEARCH_TITLE]]: 100%'''
@@ -12736,7 +12736,7 @@ NO_DEFENSE_TROOPS
 −−−	No Defensive Ground [[encyclopedia TROOP_TITLE]]
 
 BAD_DEFENSE_TROOPS
-−	Bad Defensive Ground [[encyclopedia TROOP_TITLE]]: -50%
+−	Bad Defensive Ground [[encyclopedia TROOP_TITLE]]: 50%
 
 AVERAGE_DEFENSE_TROOPS
 '''	Average Defensive Ground [[encyclopedia TROOP_TITLE]]: 100%'''
@@ -12754,7 +12754,7 @@ NO_OFFENSE_TROOPS
 −−−	No Offensive Ground [[encyclopedia TROOP_TITLE]]
 
 BAD_OFFENSE_TROOPS
-−	Bad Offensive Ground [[encyclopedia TROOP_TITLE]]: -50%
+−	Bad Offensive Ground [[encyclopedia TROOP_TITLE]]: 50%
 
 AVERAGE_OFFENSE_TROOPS
 '''	Average Offensive Ground [[encyclopedia TROOP_TITLE]]: 100%'''

--- a/default/stringtables/fr.txt
+++ b/default/stringtables/fr.txt
@@ -12683,7 +12683,7 @@ NO_INDUSTRY
 −−−	Pas d'[[encyclopedia INDUSTRY_TITLE]]
 
 BAD_INDUSTRY
-−	Mauvais en [[encyclopedia INDUSTRY_TITLE]] : -25%
+−	Mauvais en [[encyclopedia INDUSTRY_TITLE]] : 75%
 
 AVERAGE_INDUSTRY
 '''	Normal en [[encyclopedia INDUSTRY_TITLE]] : 100%'''
@@ -12701,7 +12701,7 @@ NO_RESEARCH
 −−−	Pas de [[encyclopedia RESEARCH_TITLE]]
 
 BAD_RESEARCH
-−	Mauvais en [[encyclopedia RESEARCH_TITLE]] : -25%
+−	Mauvais en [[encyclopedia RESEARCH_TITLE]] : 75%
 
 AVERAGE_RESEARCH
 '''	Normal en [[encyclopedia RESEARCH_TITLE]] : 100%'''
@@ -12719,7 +12719,7 @@ NO_DEFENSE_TROOPS
 −−−	Pas d'[[encyclopedia TROOP_TITLE]] défensive
 
 BAD_DEFENSE_TROOPS
-−	Mauvais en [[encyclopedia TROOP_TITLE]] défensive : -50%
+−	Mauvais en [[encyclopedia TROOP_TITLE]] défensive : 50%
 
 AVERAGE_DEFENSE_TROOPS
 '''	Normal en [[encyclopedia TROOP_TITLE]] défensive : 100%'''
@@ -12737,7 +12737,7 @@ NO_OFFENSE_TROOPS
 −−−	Pas d'[[encyclopedia TROOP_TITLE]] offensive
 
 BAD_OFFENSE_TROOPS
-−	Mauvais en [[encyclopedia TROOP_TITLE]] offensive : -50%
+−	Mauvais en [[encyclopedia TROOP_TITLE]] offensive : 50%
 
 AVERAGE_OFFENSE_TROOPS
 '''	Normal en [[encyclopedia TROOP_TITLE]] offensive : 100%'''

--- a/default/stringtables/ru.txt
+++ b/default/stringtables/ru.txt
@@ -7841,7 +7841,7 @@ NO_INDUSTRY
 ---	Нет [[encyclopedia INDUSTRY_TITLE]]
 
 BAD_INDUSTRY
--	Плохая [[encyclopedia INDUSTRY_TITLE]]: -50%
+-	Плохая [[encyclopedia INDUSTRY_TITLE]]: 75%
 
 AVERAGE_INDUSTRY
 '''	Средняя [[encyclopedia INDUSTRY_TITLE]]: 100%'''
@@ -7853,13 +7853,13 @@ GREAT_INDUSTRY
 ++	Превосходная [[encyclopedia INDUSTRY_TITLE]]: 200%
 
 ULTIMATE_INDUSTRY
-+++	Беспрецедентная [[encyclopedia INDUSTRY_TITLE]]: 400%
++++	Беспрецедентная [[encyclopedia INDUSTRY_TITLE]]: 300%
 
 NO_RESEARCH
 ---	Нет [[encyclopedia RESEARCH_TITLE]]
 
 BAD_RESEARCH
--	Плохая [[encyclopedia RESEARCH_TITLE]]: -50%
+-	Плохая [[encyclopedia RESEARCH_TITLE]]: 75%
 
 AVERAGE_RESEARCH
 '''	Средняя [[encyclopedia RESEARCH_TITLE]]: 100%'''
@@ -7871,25 +7871,25 @@ GREAT_RESEARCH
 ++	Превосходная [[encyclopedia RESEARCH_TITLE]]: 200%
 
 ULTIMATE_RESEARCH
-+++	Беспрецедентная [[encyclopedia RESEARCH_TITLE]]: 400%
++++	Беспрецедентная [[encyclopedia RESEARCH_TITLE]]: 300%
 
 NO_DEFENSE_TROOPS
 ---	Беззащитные [[encyclopedia TROOP_TITLE]]
 
 BAD_DEFENSE_TROOPS
--	Плохие защитные [[encyclopedia TROOP_TITLE]]: -50%.
+-	Плохие защитные [[encyclopedia TROOP_TITLE]]: 50%
 
 AVERAGE_DEFENSE_TROOPS
-'''	Средние защитные [[encyclopedia TROOP_TITLE]]:-100%.'''
+'''	Средние защитные [[encyclopedia TROOP_TITLE]]: 100%.'''
 
 GOOD_DEFENSE_TROOPS
-+	Хорошие защитные [[encyclopedia TROOP_TITLE]]: 150%.
++	Хорошие защитные [[encyclopedia TROOP_TITLE]]: 150%
 
 GREAT_DEFENSE_TROOPS
-++	Превосходные защитные [[encyclopedia TROOP_TITLE]]: 200%.
+++	Превосходные защитные [[encyclopedia TROOP_TITLE]]: 200%
 
 ULTIMATE_DEFENSE_TROOPS
-+++	Беспрецедентные защитные [[encyclopedia TROOP_TITLE]]: 300%.
++++	Беспрецедентные защитные [[encyclopedia TROOP_TITLE]]: 300%
 
 BAD_DETECTION
 -	Плохое [[encyclopedia DETECTION_RANGE_TITLE]]: -20 малус.
@@ -7904,13 +7904,13 @@ ULTIMATE_DETECTION
 +++	Беспрецедентное обнаружение: +100 бонус.
 
 BAD_STEALTH
--	Плохая [[encyclopedia STEALTH_TITLE]]: -15 малус.
+-	Плохая [[encyclopedia STEALTH_TITLE]]: -20 малус.
 
 AVERAGE_STEALTH
 '''	Средняя [[encyclopedia STEALTH_TITLE]].'''
 
 GOOD_STEALTH
-+	Хорошая [[encyclopedia STEALTH_TITLE]]: +15 бонус.
++	Хорошая [[encyclopedia STEALTH_TITLE]]: +20 бонус.
 
 GREAT_STEALTH
 ++	Превосходная [[encyclopedia STEALTH_TITLE]]: +40 бонус.


### PR DESCRIPTION
![species desc](https://cloud.githubusercontent.com/assets/12985960/18027117/e84a92cc-6c5a-11e6-972f-6cbfa8d26bd2.jpg)
PR changes en, de, fr, ru stringtable so numbers range from 50-300%, switch -25% to 75% and -50% to 50%. Also some minor tweaks to de stringtable. Fixed some spec. attrib. numbers (industry -50% to 75%, etc.) for de and ru stringtable.
