### PR TITLE
Fix bug925 resource sidepanel cutoff

### DIFF
--- a/UI/ResourcePanel.cpp
+++ b/UI/ResourcePanel.cpp
@@ -43,8 +43,6 @@ ResourcePanel::ResourcePanel(GG::X w, int object_id) :
     if (!res)
         throw std::invalid_argument("Attempted to construct a ResourcePanel with an UniverseObject that is not a ResourceCenter");
 
-    SetChildClippingMode(ClipToClientAndWindowSeparately);
-
     GG::Connect(m_expand_button->LeftClickedSignal, &ResourcePanel::ExpandCollapseButtonPressed, this);
 
     // small meter indicators - for use when panel is collapsed


### PR DESCRIPTION
Fix for #925.

This PR does two things:
- It fixes the child clipping of the resource sidepanel panel.
- It allows the MultiMeterStatusBar to rescale to handle values larger than 100.0, by increasing the range of the MultiMeterStatusBar in increments of 100.0.  It still draws the grey lines every 20 units to show the scale.

@TheSilentOne1, I was not sure if you wanted this fixed or you wanted to fix it yourself.  I chose to fix it, since I added the offending line of code incorrectly clipping the resource Client.
