### PR TITLE
Move various weapon stat-based effects into techs

### DIFF
--- a/default/scripting/ship_parts/Weapons.focs.txt
+++ b/default/scripting/ship_parts/Weapons.focs.txt
@@ -3,6 +3,7 @@ Part
     description = "SR_WEAPON_1_1_DESC"
     class = ShortRange
     damage = 3
+    NoDefaultCapacityEffect
     mountableSlotTypes = External
     buildcost = 20 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildtime = 1

--- a/default/scripting/ship_parts/Weapons.focs.txt
+++ b/default/scripting/ship_parts/Weapons.focs.txt
@@ -5,11 +5,11 @@ Part
     damage = 3
     NoDefaultCapacityEffect
     mountableSlotTypes = External
-    buildcost = 20 * [[FLEET_UPKEEP_MULTIPLICATOR(SR_WEAPON_1_1)]]
+    buildcost = 20 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildtime = 1
     location = OwnedBy empire = Source.Owner
     effectsgroups =
-        [[WEAPON_BASE_UNOWNED_EFFECTS]]
+        [[WEAPON_BASE_UNOWNED_EFFECTS(SR_WEAPON_1_1)]]
     icon = "icons/ship_parts/mass-driver.png"
 
 Part
@@ -20,11 +20,11 @@ Part
     shots = 3
     NoDefaultCapacityEffect
     mountableSlotTypes = External
-    buildcost = 1 * [[FLEET_UPKEEP_MULTIPLICATOR(SR_WEAPON_0_1)]]
+    buildcost = 1 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildtime = 1
     location = OwnedBy empire = Source.Owner
     effectsgroups =
-        [[WEAPON_BASE_UNOWNED_EFFECTS]]
+        [[WEAPON_BASE_UNOWNED_EFFECTS(SR_WEAPON_0_1)]]
     icon = "icons/ship_parts/flak.png"
 
 Part
@@ -34,11 +34,11 @@ Part
     damage = 5
     NoDefaultCapacityEffect
     mountableSlotTypes = External
-    buildcost = 30 * [[FLEET_UPKEEP_MULTIPLICATOR(SR_WEAPON_2_1)]]
+    buildcost = 30 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildtime = 2
     location = OwnedBy empire = Source.Owner
     effectsgroups =
-        [[WEAPON_BASE_UNOWNED_EFFECTS]]
+        [[WEAPON_BASE_UNOWNED_EFFECTS(SR_WEAPON_2_1)]]
     icon = "icons/ship_parts/laser.png"
 
 Part
@@ -48,11 +48,11 @@ Part
     damage = 9
     NoDefaultCapacityEffect
     mountableSlotTypes = External
-    buildcost = 40 * [[FLEET_UPKEEP_MULTIPLICATOR(SR_WEAPON_3_1)]]
+    buildcost = 40 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildtime = 3
     location = OwnedBy empire = Source.Owner
     effectsgroups =
-        [[WEAPON_BASE_UNOWNED_EFFECTS]]
+        [[WEAPON_BASE_UNOWNED_EFFECTS(SR_WEAPON_3_1)]]
     icon = "icons/ship_parts/plasma.png"
 
 Part
@@ -62,11 +62,11 @@ Part
     damage = 15
     NoDefaultCapacityEffect
     mountableSlotTypes = External
-    buildcost = 60 * [[FLEET_UPKEEP_MULTIPLICATOR(SR_WEAPON_4_1)]]
+    buildcost = 60 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildtime = 4
     location = OwnedBy empire = Source.Owner
     effectsgroups =
-        [[WEAPON_BASE_UNOWNED_EFFECTS]]
+        [[WEAPON_BASE_UNOWNED_EFFECTS(SR_WEAPON_4_1)]]
     icon = "icons/ship_parts/death-ray.png"
 
 Part

--- a/default/scripting/ship_parts/Weapons.focs.txt
+++ b/default/scripting/ship_parts/Weapons.focs.txt
@@ -5,9 +5,11 @@ Part
     damage = 3
     NoDefaultCapacityEffect
     mountableSlotTypes = External
-    buildcost = 20 * [[FLEET_UPKEEP_MULTIPLICATOR]]
+    buildcost = 20 * [[FLEET_UPKEEP_MULTIPLICATOR(SR_WEAPON_1_1)]]
     buildtime = 1
     location = OwnedBy empire = Source.Owner
+    effectsgroups =
+        [[WEAPON_BASE_UNOWNED_EFFECTS]]
     icon = "icons/ship_parts/mass-driver.png"
 
 Part
@@ -16,10 +18,13 @@ Part
     class = ShortRange
     damage = 1
     shots = 3
+    NoDefaultCapacityEffect
     mountableSlotTypes = External
-    buildcost = 1 * [[FLEET_UPKEEP_MULTIPLICATOR]]
+    buildcost = 1 * [[FLEET_UPKEEP_MULTIPLICATOR(SR_WEAPON_0_1)]]
     buildtime = 1
     location = OwnedBy empire = Source.Owner
+    effectsgroups =
+        [[WEAPON_BASE_UNOWNED_EFFECTS]]
     icon = "icons/ship_parts/flak.png"
 
 Part
@@ -27,10 +32,13 @@ Part
     description = "SR_WEAPON_2_1_DESC"
     class = ShortRange
     damage = 5
+    NoDefaultCapacityEffect
     mountableSlotTypes = External
-    buildcost = 30 * [[FLEET_UPKEEP_MULTIPLICATOR]]
+    buildcost = 30 * [[FLEET_UPKEEP_MULTIPLICATOR(SR_WEAPON_2_1)]]
     buildtime = 2
     location = OwnedBy empire = Source.Owner
+    effectsgroups =
+        [[WEAPON_BASE_UNOWNED_EFFECTS]]
     icon = "icons/ship_parts/laser.png"
 
 Part
@@ -38,10 +46,13 @@ Part
     description = "SR_WEAPON_3_1_DESC"
     class = ShortRange
     damage = 9
+    NoDefaultCapacityEffect
     mountableSlotTypes = External
-    buildcost = 40 * [[FLEET_UPKEEP_MULTIPLICATOR]]
+    buildcost = 40 * [[FLEET_UPKEEP_MULTIPLICATOR(SR_WEAPON_3_1)]]
     buildtime = 3
     location = OwnedBy empire = Source.Owner
+    effectsgroups =
+        [[WEAPON_BASE_UNOWNED_EFFECTS]]
     icon = "icons/ship_parts/plasma.png"
 
 Part
@@ -49,10 +60,13 @@ Part
     description = "SR_WEAPON_4_1_DESC"
     class = ShortRange
     damage = 15
+    NoDefaultCapacityEffect
     mountableSlotTypes = External
-    buildcost = 60 * [[FLEET_UPKEEP_MULTIPLICATOR]]
+    buildcost = 60 * [[FLEET_UPKEEP_MULTIPLICATOR(SR_WEAPON_4_1)]]
     buildtime = 4
     location = OwnedBy empire = Source.Owner
+    effectsgroups =
+        [[WEAPON_BASE_UNOWNED_EFFECTS]]
     icon = "icons/ship_parts/death-ray.png"
 
 Part
@@ -111,3 +125,14 @@ Part
     icon = "icons/ship_parts/snowflake_laser.png"
 
 #include "/scripting/common/upkeep.macros"
+
+WEAPON_BASE_UNOWNED_EFFECTS
+'''        EffectsGroup
+            scope = Source
+            activation = Unowned    // if owned by a player, gets weapon meters set by effects in relevant techs
+            accountinglabel = "@1@"
+            effects = [
+                SetMaxCapacity partname = "@1@" value = Value + PartCapacity name = "@1@"
+                SetMaxSecondaryStat partname = "@1@" value = Value + PartSecondaryStat name = "@1@"
+            ]
+'''

--- a/default/scripting/techs/ships/Weapons.focs.txt
+++ b/default/scripting/techs/ships/Weapons.focs.txt
@@ -11,6 +11,19 @@ Tech
         Item type = ShipPart name = "GT_TROOP_POD"
         Item type = ShipPart name = "SR_WEAPON_0_1"
     ]
+    effectsgroups =
+        EffectsGroup
+            scope = And [
+                Ship
+                OwnedBy empire = Source.Owner
+                DesignHasPart  name = "SR_WEAPON_1_1"
+            ]
+            accountinglabel = "SR_WEAPON_1_1"
+            effects = [
+                SetMaxCapacity partname = "SR_WEAPON_1_1" value = Value + 5
+                SetMaxSecondaryStat partname = "SR_WEAPON_1_1" value = Value + 1
+            ]
+
     graphic = "icons/tech/planetary_colonialism.png"
 
 Tech

--- a/default/scripting/techs/ships/Weapons.focs.txt
+++ b/default/scripting/techs/ships/Weapons.focs.txt
@@ -12,17 +12,7 @@ Tech
         Item type = ShipPart name = "SR_WEAPON_0_1"
     ]
     effectsgroups =
-        EffectsGroup
-            scope = And [
-                Ship
-                OwnedBy empire = Source.Owner
-                DesignHasPart  name = "SR_WEAPON_1_1"
-            ]
-            accountinglabel = "SR_WEAPON_1_1"
-            effects = [
-                SetMaxCapacity partname = "SR_WEAPON_1_1" value = Value + 5
-                SetMaxSecondaryStat partname = "SR_WEAPON_1_1" value = Value + 1
-            ]
+        [[WEAPON_BASE_EFFECTS(SR_WEAPON_1_1)]]
 
     graphic = "icons/tech/planetary_colonialism.png"
 
@@ -47,14 +37,7 @@ Tech
     tags = [ "PEDIA_SR_WEAPON_TECHS" ]
     prerequisites = "SHP_ROOT_AGGRESSION"
     effectsgroups =
-        EffectsGroup
-            scope = And [
-                Ship
-                OwnedBy empire = Source.Owner
-                DesignHasPart  name = "SR_WEAPON_1_1"
-            ]
-            accountinglabel = "SR_WEAPON_1_2"
-            effects = SetMaxCapacity partname = "SR_WEAPON_1_1" value = Value + 1
+        [[WEAPON_UPGRADE_CAPACITY_EFFECTS(SR_WEAPON_1_1, 1)]]
     graphic = "icons/ship_parts/mass-driver-2.png"
 
 Tech
@@ -67,14 +50,7 @@ Tech
     tags = [ "PEDIA_SR_WEAPON_TECHS" ]
     prerequisites = "SHP_WEAPON_1_2"
     effectsgroups =
-        EffectsGroup
-            scope = And [
-                Ship
-                OwnedBy empire = Source.Owner
-                DesignHasPart name = "SR_WEAPON_1_1"
-            ]
-            accountinglabel = "SR_WEAPON_1_3_DESC"
-            effects = SetMaxCapacity partname = "SR_WEAPON_1_1" value = Value + 1
+        [[WEAPON_UPGRADE_CAPACITY_EFFECTS(SR_WEAPON_1_1, 1)]]
     graphic = "icons/ship_parts/mass-driver-3.png"
 
 Tech
@@ -87,14 +63,7 @@ Tech
     tags = [ "PEDIA_SR_WEAPON_TECHS" ]
     prerequisites = "SHP_WEAPON_1_3"
     effectsgroups =
-        EffectsGroup
-            scope = And [
-                Ship
-                OwnedBy empire = Source.Owner
-                DesignHasPart  name = "SR_WEAPON_1_1"
-            ]
-            accountinglabel = "SR_WEAPON_1_4"
-            effects = SetMaxCapacity partname = "SR_WEAPON_1_1" value = Value + 1
+        [[WEAPON_UPGRADE_CAPACITY_EFFECTS(SR_WEAPON_1_1, 1)]]
     graphic = "icons/ship_parts/mass-driver-4.png"
 
 Tech
@@ -107,6 +76,8 @@ Tech
     tags = [ "PEDIA_SR_WEAPON_TECHS" ]
     prerequisites = "SHP_ROOT_AGGRESSION"
     unlock = Item type = ShipPart name = "SR_WEAPON_2_1"
+    effectsgroups =
+        [[WEAPON_BASE_EFFECTS(SR_WEAPON_2_1)]]
     graphic = "icons/ship_parts/laser-1.png"
 
 Tech
@@ -119,14 +90,7 @@ Tech
     tags = [ "PEDIA_SR_WEAPON_TECHS" ]
     prerequisites = "SHP_WEAPON_2_1"
     effectsgroups =
-        EffectsGroup
-            scope = And [
-                Ship
-                OwnedBy empire = Source.Owner
-                DesignHasPart  name = "SR_WEAPON_2_1"
-            ]
-            accountinglabel = "SR_WEAPON_2_2"
-            effects = SetMaxCapacity partname = "SR_WEAPON_2_1" value = Value + 2
+        [[WEAPON_UPGRADE_CAPACITY_EFFECTS(SR_WEAPON_2_1, 2)]]
     graphic = "icons/ship_parts/laser-2.png"
 
 Tech
@@ -139,14 +103,7 @@ Tech
     tags = [ "PEDIA_SR_WEAPON_TECHS" ]
     prerequisites = "SHP_WEAPON_2_2"
     effectsgroups =
-        EffectsGroup
-            scope = And [
-                Ship
-                OwnedBy empire = Source.Owner
-                DesignHasPart  name = "SR_WEAPON_2_1"
-            ]
-            accountinglabel = "SR_WEAPON_2_3"
-            effects = SetMaxCapacity partname = "SR_WEAPON_2_1" value = Value + 2
+        [[WEAPON_UPGRADE_CAPACITY_EFFECTS(SR_WEAPON_2_1, 2)]]
     graphic = "icons/ship_parts/laser-3.png"
 
 Tech
@@ -159,14 +116,7 @@ Tech
     tags = [ "PEDIA_SR_WEAPON_TECHS" ]
     prerequisites = "SHP_WEAPON_2_3"
     effectsgroups =
-        EffectsGroup
-            scope = And [
-                Ship
-                OwnedBy empire = Source.Owner
-                DesignHasPart  name = "SR_WEAPON_2_1"
-            ]
-            accountinglabel = "SR_WEAPON_2_4"
-            effects = SetMaxCapacity partname = "SR_WEAPON_2_1" value = Value + 2
+        [[WEAPON_UPGRADE_CAPACITY_EFFECTS(SR_WEAPON_2_1, 2)]]
     graphic = "icons/ship_parts/laser-4.png"
 
 Tech
@@ -179,6 +129,8 @@ Tech
     tags = [ "PEDIA_SR_WEAPON_TECHS" ]
     prerequisites = "SHP_WEAPON_2_1"
     unlock = Item type = ShipPart name = "SR_WEAPON_3_1"
+    effectsgroups =
+        [[WEAPON_BASE_EFFECTS(SR_WEAPON_3_1)]]
     graphic = "icons/ship_parts/plasma-1.png"
 
 Tech
@@ -191,14 +143,7 @@ Tech
     tags = [ "PEDIA_SR_WEAPON_TECHS" ]
     prerequisites = "SHP_WEAPON_3_1"
     effectsgroups =
-        EffectsGroup
-            scope = And [
-                Ship
-                OwnedBy empire = Source.Owner
-                DesignHasPart  name = "SR_WEAPON_3_1"
-            ]
-            accountinglabel = "SR_WEAPON_3_2"
-            effects = SetMaxCapacity partname = "SR_WEAPON_3_1" value = Value + 3
+        [[WEAPON_UPGRADE_CAPACITY_EFFECTS(SR_WEAPON_3_1, 3)]]
     graphic = "icons/ship_parts/plasma-2.png"
 
 Tech
@@ -211,14 +156,7 @@ Tech
     tags = [ "PEDIA_SR_WEAPON_TECHS" ]
     prerequisites = "SHP_WEAPON_3_2"
     effectsgroups =
-        EffectsGroup
-            scope = And [
-                Ship
-                OwnedBy empire = Source.Owner
-                DesignHasPart  name = "SR_WEAPON_3_1"
-            ]
-            accountinglabel = "SR_WEAPON_3_3"
-            effects = SetMaxCapacity partname = "SR_WEAPON_3_1" value = Value + 3
+        [[WEAPON_UPGRADE_CAPACITY_EFFECTS(SR_WEAPON_3_1, 3)]]
     graphic = "icons/ship_parts/plasma-3.png"
 
 Tech
@@ -231,14 +169,7 @@ Tech
     tags = [ "PEDIA_SR_WEAPON_TECHS" ]
     prerequisites = "SHP_WEAPON_3_3"
     effectsgroups =
-        EffectsGroup
-            scope = And [
-                Ship
-                OwnedBy empire = Source.Owner
-                DesignHasPart  name = "SR_WEAPON_3_1"
-            ]
-            accountinglabel = "SR_WEAPON_3_4"
-            effects = SetMaxCapacity partname = "SR_WEAPON_3_1" value = Value + 3
+        [[WEAPON_UPGRADE_CAPACITY_EFFECTS(SR_WEAPON_3_1, 3)]]
     graphic = "icons/ship_parts/plasma-4.png"
 
 Tech
@@ -251,6 +182,8 @@ Tech
     tags = [ "PEDIA_SR_WEAPON_TECHS" ]
     prerequisites = "SHP_WEAPON_3_1"
     unlock = Item type = ShipPart name = "SR_WEAPON_4_1"
+    effectsgroups =
+        [[WEAPON_BASE_EFFECTS(SR_WEAPON_4_1)]]
     graphic = "icons/ship_parts/death-ray-1.png"
 
 Tech
@@ -263,14 +196,7 @@ Tech
     tags = [ "PEDIA_SR_WEAPON_TECHS" ]
     prerequisites = "SHP_WEAPON_4_1"
     effectsgroups =
-        EffectsGroup
-            scope = And [
-                Ship
-                OwnedBy empire = Source.Owner
-                DesignHasPart  name = "SR_WEAPON_4_1"
-            ]
-            accountinglabel = "SR_WEAPON_4_2"
-            effects = SetMaxCapacity partname = "SR_WEAPON_4_1" value = Value + 5
+        [[WEAPON_UPGRADE_CAPACITY_EFFECTS(SR_WEAPON_4_1, 5)]]
     graphic = "icons/ship_parts/death-ray-2.png"
 
 Tech
@@ -351,3 +277,29 @@ Tech
     unlock = Item type = ShipPart name = "SP_KRILL_SPAWNER"
 
 #include "/scripting/common/base_prod.macros"
+
+WEAPON_BASE_EFFECTS
+'''        EffectsGroup
+            scope = And [
+                Ship
+                OwnedBy empire = Source.Owner
+                DesignHasPart  name = "@1@"
+            ]
+            accountinglabel = "@1@"
+            effects = [
+                SetMaxCapacity partname = "@1@" value = Value + PartCapacity name = "@1@"
+                SetMaxSecondaryStat partname = "@1@" value = Value + PartSecondaryStat name = "@1@"
+            ]
+'''
+
+WEAPON_UPGRADE_CAPACITY_EFFECTS
+'''
+        EffectsGroup
+            scope = And [
+                Ship
+                OwnedBy empire = Source.Owner
+                DesignHasPart  name = "@1@"
+            ]
+            accountinglabel = "@1@"
+            effects = SetMaxCapacity partname = "@1@" value = Value + @2@
+'''

--- a/universe/ValueRef.cpp
+++ b/universe/ValueRef.cpp
@@ -1841,6 +1841,18 @@ double ComplexVariable<double>::Eval(const ScriptingContext& context) const
         return part_type->Capacity();
 
     }
+    else if (variable_name == "PartSecondaryStat") {
+        std::string part_type_name;
+        if (m_string_ref1)
+            part_type_name = m_string_ref1->Eval(context);
+
+        const PartType* part_type = GetPartType(part_type_name);
+        if (!part_type)
+            return 0.0;
+
+        return part_type->SecondaryStat();
+
+    }
     else if (variable_name == "EmpireMeterValue") {
         int empire_id = ALL_EMPIRES;
         if (m_int_ref1)


### PR DESCRIPTION
Should have similar effect processing optimization results as moving species effects.

Updated to work for various weapons and upgrades, and handle case of unowned ships.

The idea is that instead of processing this effect as a separate single-target effectsgroup for each ship with the part, it can be processed once per empire.