### PR TITLE
Update AI default research order

### DIFF
--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -26,6 +26,7 @@ import PriorityAI
 import ProductionAI
 import ResearchAI
 import ResourcesAI
+import TechsListsAI
 from freeorion_tools import UserStringList, chat_on_error, print_error, UserString, handle_debug_chat, Timer, init_handlers
 from common.listeners import listener
 
@@ -103,6 +104,7 @@ def startNewGame(aggression=fo.aggression.aggressive):  # pylint: disable=invali
                                fo.aggression.maniacal: DiplomaticCorp.ManiacalDiplomaticCorp}
     global diplomatic_corp
     diplomatic_corp = diplomatic_corp_configs.get(aggression, DiplomaticCorp.DiplomaticCorp)()
+    TechsListsAI.test_tech_integrity()
 
 
 @chat_on_error
@@ -126,6 +128,7 @@ def resumeLoadedGame(saved_state_string):  # pylint: disable=invalid-name
                                fo.aggression.maniacal: DiplomaticCorp.ManiacalDiplomaticCorp}
     global diplomatic_corp
     diplomatic_corp = diplomatic_corp_configs.get(foAIstate.aggression, DiplomaticCorp.DiplomaticCorp)()
+    TechsListsAI.test_tech_integrity()
 
 
 @chat_on_error


### PR DESCRIPTION
So, this is the first pass of the research order (mostly early/midgame stuff, lategame mostly untouched) dealing with issue #633. 
Testing and feedback is requested:
- Any new error messages popping up?
- Does the AI seemingly forget some important techs or research them too late? How is the Active Radar timing now?
- Does the AI resource output / expansion improve compared to previous version?
- General feeling of difficulty compared to previous version, e.g. military timeline of the AI, difficulty to conquer the AI's planets, timing windows etc.

As far as I am concerned, this may be merged to master for easier testing once @Cjkjvfnby reviewed the code eventhough the tech order is still WIP. Should be unproblematic to revert if "major" issues are revealed that can't be hotfixed "in time" for release.
## Updated research order
### AI pursues economic techs slightly more greedy now:
- AI always starts the game with the "holy quadruple" of Planetary Ecology, Subterranean Habitation, Algorithmic Elegance and Nascent Artificial Intelligence
- Adaptive Automation and Exobots are researched much earlier
- AI should no longer research Orbital Generation, Microgravity Industry or Asteroid Hulls prematurely
- AI will research various growth techs slightly earlier
- Delayed Industrial Center slightly in favor of other PP boosts

The AI may be weaker against early attacks. Didn't use to make a challenge when rushed properly anyway. The changes are intended to let the AI to keep economically up with the human player for a longer time.
### Removed unused techs:
- AI will no longer research hull types it doesn't use due to its ShipDesign algorithm anyway.
- AI will no longer research stealth techs (which came too late to be of any use anyway and aren't used in current generation ship designs)
- AI will no longer "prematurely" research theory techs
### MISC research priority:
- Delay weapon upgrade techs slightly after the initial weapon is researched to allow building of ships before the tech upgrade (e.g. may squeeze some economic tech in between Laser 2 and 3)
- Active Radar is researched earlier now
## Rewrite tech groups as classes
- added functionality to avoid missing important techs are forgotten in specific (sub-)tech groups.
- add test function to check for invalid techs/research groups
- Delayed Force-Field-Harmonics slightly
