### PR TITLE
Xenophobic bugfixes

### DIFF
--- a/default/scripting/species/common/xenophobic.macros
+++ b/default/scripting/species/common/xenophobic.macros
@@ -1,9 +1,12 @@
 XENOPHOBIC_SELF
-'''     EffectsGroup
+'''
+        // Give the concentration camp tech at game start
+        EffectsGroup
             scope = Source
             activation = Turn high = 0
             effects = GiveEmpireTech name = "CON_CONC_CAMP"
 
+        // Give malus to industry, research and happiness for other species nearby
         EffectsGroup
             scope = Source
             activation = And [
@@ -40,6 +43,7 @@ XENOPHOBIC_SELF
                 )
             ]
 
+        // Give a pop malus for self-sustaining xenophobic species based on the number of nearby planets with other species
         EffectsGroup
             scope = Source
             activation = And [
@@ -74,7 +78,7 @@ Count condition = And [
 
 // single argument should be the name of the species capitalized
 XENOPHOBIC_OTHER
-'''     EffectsGroup
+'''     EffectsGroup 
             scope = And [
                 PopulationCenter
                 OwnedBy empire = Source.Owner

--- a/default/scripting/species/common/xenophobic.macros
+++ b/default/scripting/species/common/xenophobic.macros
@@ -49,10 +49,17 @@ XENOPHOBIC_SELF
             stackinggroup = "XENOPHOBIC_POP_SELF"
             accountinglabel = "XENOPHOBIC_LABEL_SELF"
             priority = [[LATE_PRIORITY]]
-            effects = SetTargetPopulation value = max(Value * (0.6 + (0.4 * (0.8 ^ 
-                Count condition = And [
+            effects = SetTargetPopulation value = Value - min(
+                    max(Value, 0) * 0.4 * (1 - 0.8^[[XENOPHOBIC_SELFSUSTAINING_QUALIFYING_PLANET_COUNT]]),
+                    3 * Target.SizeAsDouble  // Cap malus at the self-sustaining bonus
+                )
+'''
+
+XENOPHOBIC_SELFSUSTAINING_QUALIFYING_PLANET_COUNT
+'''
+Count condition = And [
                     PopulationCenter
-                    Not OR [ 
+                    Not OR [
                         Species name = Source.Species
                         Species name = "SP_EXOBOT"
                     ]
@@ -63,8 +70,6 @@ XENOPHOBIC_SELF
                               condition = ExploredByEmpire
                                           empire = Source.Owner
                 ]
-                ) ) ), (Value - 3 * Target.SizeAsDouble)) // Sets the pop malus dependent on the number of other species nearby up to a max of the self sustaining bonus
-
 '''
 
 // single argument should be the name of the species capitalized

--- a/default/scripting/species/common/xenophobic.macros
+++ b/default/scripting/species/common/xenophobic.macros
@@ -31,15 +31,16 @@ XENOPHOBIC_SELF
                 SetTargetResearch value = Value * 0.9
                 SetTargetHappiness value = Value - (
                     Count condition = And [
-                    PopulationCenter
-                    WithinStarlaneJumps jumps = 5 condition = Source
-                    OwnedBy empire = Source.Owner
-                    Not OR [ 
-                        Species name = Source.Species
-                        Species name = "SP_EXOBOT"
+                        PopulationCenter
+                        OwnedBy empire = Source.Owner
+                        Not OR [ 
+                            Species name = Source.Species
+                            Species name = "SP_EXOBOT"
+                        ]
+                        Not Population high = 0
+                        Not Contains Building name = "BLD_CONC_CAMP"
+                        WithinStarlaneJumps jumps = 5 condition = Source
                     ]
-                    Not Population high = 0
-                ]
                 )
             ]
 


### PR DESCRIPTION
The PR covers two fixes related to the xenophobic frenzy:
#### 1. Fixes issue #924

Bug was existing as population malus was proportional to current population. So negative populations received a "negative malus", i.e. a bonus.
Note that the formula is not changed but merely recasted to an actually readable form:

> Previous form of the formula: `Max(A,B)`
> with `B = Value - 3*size =: Value - b`,
> with `A = Value * (0.6 + (0.4 * (0.8 ^ n)))`
> 
> A is easily recasted to
> 
> ```
> A  =  Value *  [ (1-0.4) + 0.4 * 0.8^n] 
>    =  Value * (1 - 0.4 * (1 - 0.8^n))
>    =  Value - Value * 0.4*(1-0.8^n)
>    =: Value - a
> ```
> 
> It is then easy to see that `Max(A, B)` is equivalent to `Value - Min(a, b)`, i.e. what is used in the new code.
#### 2. Fixes Happiness malus:

Activation for the condition ignores planets with Concentration Camps. However, planets with concentration camps where still counted for the calculation of the happiness malus.
