### PR TITLE
Remove debug print

### DIFF
--- a/util/Directories.cpp
+++ b/util/Directories.cpp
@@ -448,7 +448,7 @@ const fs::path GetSaveDir() {
     if (options_save_dir.empty())
         options_save_dir = GetOptionsDB().GetDefault<std::string>("save-dir");
     //std::cout << "GetSaveDir dir: " << options_save_dir << " << valid UTF-8: " << utf8::is_valid(options_save_dir.begin(), options_save_dir.end()) << std::endl;
-    DebugLogger() << "GetSaveDir dir: " << options_save_dir << " << valid UTF-8: " << utf8::is_valid(options_save_dir.begin(), options_save_dir.end());
+    //DebugLogger() << "GetSaveDir dir: " << options_save_dir << " << valid UTF-8: " << utf8::is_valid(options_save_dir.begin(), options_save_dir.end());
     return FilenameToPath(options_save_dir);
 }
 


### PR DESCRIPTION
Every time I run game on windows,  black window with annoying message appears.

I don't know if we change logging level for release. If yes, then just close this PR.  Or may be it should be changed to print message only for not valid names?

PS. Game icon is blank,  it is not always blank, and this happens for a long time, should I create an issue separate issue for that?

PPS. I don't sure about tags.  May be add theirs descriptions to `guidelines for contributing`

![debug_at_start](https://cloud.githubusercontent.com/assets/171597/18223172/4bd7734e-71b7-11e6-8a38-e94a1cf354f3.png)
