### PR TITLE
Fix gg handles drag drop enter event inconsistently

### DIFF
--- a/GG/src/GUI.cpp
+++ b/GG/src/GUI.cpp
@@ -405,22 +405,21 @@ void GUIImpl::HandleMouseDrag(unsigned int mouse_button, const Pt& pos, int curr
 
             if (m_curr_wnd_under_cursor && m_prev_wnd_under_cursor == m_curr_wnd_under_cursor) {
                 // Wnd under cursor has remained the same for the last two updates
-                if (m_curr_drag_drop_here_wnd) {
+                if (m_curr_drag_drop_here_wnd && m_curr_drag_drop_here_wnd == m_curr_wnd_under_cursor) {
                     // Wnd being dragged over is still being dragged over...
-                    if (m_curr_wnd_under_cursor != m_curr_drag_drop_here_wnd) {
-                        m_curr_wnd_under_cursor = 0;
-                        std::cerr << "HandleMouseDrag: m_curr_wnd_under_cursor inconsistent with m_curr_drag_drop_here_wnd" << std::endl << std::flush;
-                        return;
-                    }
                     WndEvent event(WndEvent::DragDropHere, pos, m_drag_drop_wnds, m_mod_keys);
                     m_curr_wnd_under_cursor->HandleEvent(event);
                     m_drag_drop_wnds_acceptable = event.GetAcceptableDropWnds();
 
                 } else {
-                    // Wnd being dragged over is new; give it an Enter message
-                    WndEvent event(WndEvent::DragDropEnter, pos, m_drag_drop_wnds, m_mod_keys);
+                    // pass drag-drop event to check if the various dragged Wnds are acceptable to drop
+                    WndEvent event(WndEvent::CheckDrops, pos, m_drag_drop_wnds, m_mod_keys);
                     m_curr_wnd_under_cursor->HandleEvent(event);
                     m_drag_drop_wnds_acceptable = event.GetAcceptableDropWnds();
+
+                    // Wnd being dragged over is new; give it an Enter message
+                    WndEvent enter_event(WndEvent::DragDropEnter, pos, m_drag_drop_wnds, m_mod_keys);
+                    m_curr_wnd_under_cursor->HandleEvent(enter_event);
                     m_curr_drag_drop_here_wnd = m_curr_wnd_under_cursor;
                 }
             }
@@ -1766,6 +1765,10 @@ Wnd* GUI::CheckedGetWindowUnder(const Pt& pt, Flags<ModKey> mod_keys)
         w->HandleEvent(event);
         s_impl->m_drag_drop_wnds_acceptable[dragged_wnd] = false;
         s_impl->m_drag_drop_wnds_acceptable = event.GetAcceptableDropWnds();
+
+        // Wnd being dragged over is new; give it an Enter message
+        WndEvent enter_event(WndEvent::DragDropEnter, pt, dragged_wnd, mod_keys);
+        w->HandleEvent(enter_event);
         s_impl->m_curr_drag_drop_here_wnd = w;
 
     } else if (registered_drag_drop) {
@@ -1773,6 +1776,10 @@ Wnd* GUI::CheckedGetWindowUnder(const Pt& pt, Flags<ModKey> mod_keys)
         WndEvent event(WndEvent::CheckDrops, pt, s_impl->m_drag_drop_wnds, mod_keys);
         w->HandleEvent(event);
         s_impl->m_drag_drop_wnds_acceptable = event.GetAcceptableDropWnds();
+
+        // Wnd being dragged over is new; give it an Enter message
+        WndEvent enter_event(WndEvent::DragDropEnter, pt, s_impl->m_drag_drop_wnds, mod_keys);
+        w->HandleEvent(enter_event);
         s_impl->m_curr_drag_drop_here_wnd = w;
 
     } else {

--- a/GG/src/Wnd.cpp
+++ b/GG/src/Wnd.cpp
@@ -35,6 +35,7 @@
 #include <boost/multi_index/member.hpp>
 #include <boost/multi_index/ordered_index.hpp>
 
+
 using namespace GG;
 
 namespace {
@@ -1014,7 +1015,7 @@ void Wnd::MouseWheel(const Pt& pt, int move, Flags<ModKey> mod_keys)
 { if (!Interactive()) ForwardEventToParent(); }
 
 void Wnd::DragDropEnter(const Pt& pt, std::map<const Wnd*, bool>& drop_wnds_acceptable, Flags<ModKey> mod_keys)
-{ this->DragDropHere(pt, drop_wnds_acceptable, mod_keys); }
+{ if (!Interactive()) ForwardEventToParent(); }
 
 void Wnd::DragDropHere(const Pt& pt, std::map<const Wnd*, bool>& drop_wnds_acceptable, Flags<ModKey> mod_keys)
 {


### PR DESCRIPTION
GG used `DragDropEnter` and `CheckDrops` events inter-changeably and
inconsistently.

`ChecksDrops` should be used to check if drops are acceptable.

`DragDropEnter` should be used to inform windows of drag drop entry.

In `HandleMouseDrag()` `DragDropEnter` was used to check if drops are
acceptable.

In `CheckedGetWindowUnder()` the drag drop here window was being updated
without first causing the `DragDropEnter` event.

This commit make all three locations where the drag drop here window is
updated first use `CheckDrops` to capture drop acceptability and then
inform the window with `DragDrop` Enter.

This PR will cause new `DragDropEnter` events that were not being generated before the patch.

It can be cherry-picked to version 0.4.6. with or without PR #954 as you see fit.
