### PR TITLE
Fix Wnd::DetachChild(wnd) to null m_layout, if wnd equals m_layout.

### DIFF
--- a/GG/src/Wnd.cpp
+++ b/GG/src/Wnd.cpp
@@ -590,6 +590,8 @@ void Wnd::DetachChild(Wnd* wnd)
         return;
     m_children.erase(it);
     wnd->SetParent(0);
+    if (wnd == m_layout)
+        m_layout = 0;
     if (Layout* this_as_layout = dynamic_cast<Layout*>(this)) {
         this_as_layout->Remove(wnd);
         wnd->m_containing_layout = 0;
@@ -855,7 +857,6 @@ Layout* Wnd::DetachLayout()
 {
     Layout* retval = m_layout;
     DetachChild(m_layout);
-    m_layout = 0;
     return retval;
 }
 


### PR DESCRIPTION
DetachChild(wnd) does not set m_layout to null if the child, wnd, is the
m_layout. Consequently, calling DetachChildren() will eventually cause a
crash because GetLayout() returns m_layout whose Parent() is null.

This commit fixes that bug.

I exposed this bug with new code that I am working on.  I do not think it is critical that it be included in the 0.4.6 candidate, but you may be of a different mind.
