### PR TITLE
Move shipyard building list from UserString to definition tag

### DIFF
--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -1376,9 +1376,7 @@ void SidePanel::PlanetPanel::Refresh() {
             continue;
         if (known_destroyed_object_ids.find(*building_it) != known_destroyed_object_ids.end())
             continue;
-        std::list<std::string> shipyards_list;
-        UserStringList("FUNCTIONAL_SHIPYARD_BUILDING_LIST", shipyards_list);
-        if (std::find(shipyards_list.begin(), shipyards_list.end(), building->BuildingTypeName()) != shipyards_list.end()) {
+        if (building->HasTag(TAG_SHIPYARD)) {
             has_shipyard = true;
             break;
         }

--- a/UI/SystemIcon.cpp
+++ b/UI/SystemIcon.cpp
@@ -167,9 +167,7 @@ OwnerColoredSystemName::OwnerColoredSystemName(int system_id, int font_size, boo
                 if (known_destroyed_object_ids.find(building_id) != known_destroyed_object_ids.end())
                     continue;
 
-                std::list<std::string> shipyards_list;
-                UserStringList("FUNCTIONAL_SHIPYARD_BUILDING_LIST", shipyards_list);
-                if (std::find(shipyards_list.begin(), shipyards_list.end(), building->BuildingTypeName()) != shipyards_list.end()) {
+                if (building->HasTag(TAG_SHIPYARD)) {
                     has_shipyard = true;
                     break;
                 }

--- a/UI/SystemIcon.h
+++ b/UI/SystemIcon.h
@@ -4,6 +4,14 @@
 #include <GG/GGFwd.h>
 #include <GG/Control.h>
 
+/** @content_tag{CTRL_SHIPYARD} Building is to be treated as a shipyard when formatting containing objects
+ * 
+ * For objects containing a building with this tag:
+ * * Planets have an underlined name in the sidepanel
+ * * Systems have their name underlined on the map and sidepanel
+ */
+const std::string TAG_SHIPYARD = "CTRL_SHIPYARD";
+
 class FleetButton;
 class RotatingGraphic;
 

--- a/default/content_specific_parameters.txt
+++ b/default/content_specific_parameters.txt
@@ -31,10 +31,3 @@ ROBOTIC
 SELF_SUSTAINING
 TELEPATHIC'''
 ##STYLISH  // add to tag order list if ever this tag is given a function
-
-
-## FUNCTIONAL_SHIPYARD_BUILDING_LIST specifies those buildings which the MapWnd should recognize as shipyards
-## Since currently the BLD_SHIPYARD_BASE is required for all more advanced shipyards to be functional,
-## so it is the only one currently listed.
-FUNCTIONAL_SHIPYARD_BUILDING_LIST
-'''BLD_SHIPYARD_BASE'''

--- a/default/scripting/buildings/shipyards/BASE.focs.txt
+++ b/default/scripting/buildings/shipyards/BASE.focs.txt
@@ -3,7 +3,7 @@ BuildingType
     description = "BLD_SHIPYARD_BASE_DESC"
     buildcost = 10
     buildtime = 4
-    tags = "ORBITAL"
+    tags = [ "ORBITAL" "CTRL_SHIPYARD" ]
     location = And [
         Planet
         TargetPopulation low = 1


### PR DESCRIPTION
Removes the UserString defined list in favor of `CTRL_UNDERLINE` definition tag.

Partial proposal towards #907
