### PR TITLE
Move ship design redundancy settings from UserString

### DIFF
--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -639,10 +639,6 @@ void PartsListBox::CullSuperfluousParts(std::vector<const PartType* >& this_grou
 {
     /// This is not merely a check for obsolescence; see PartsListBox::Populate for more info
 
-    static std::list<std::string> redundancy_exclusion_list;
-    if (redundancy_exclusion_list.empty())
-        UserStringList("FUNCTIONAL_SHIP_PART_REDUNDANCY_SKIP_LIST", redundancy_exclusion_list);
-
     for (std::vector<const PartType* >::iterator part_it = this_group.begin();
          part_it != this_group.end(); ++part_it)
     {

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -617,8 +617,10 @@ bool PartALocationSubsumesPartB(const PartType* check_part, const PartType* ref_
         return map_it->second;
 
     bool result = true;
-    if (check_part->Name() == "SH_MULTISPEC" || ref_part->Name() == "SH_MULTISPEC")
-        result = false;
+
+    if (check_part->Tags().count(TAG_SKIP_REDUNDANT_FILTER) > 0 ||
+        ref_part->Tags().count(TAG_SKIP_REDUNDANT_FILTER) > 0)
+    { result = false; }
 
     const Condition::ConditionBase* check_part_loc = check_part->Location();
     const Condition::ConditionBase* ref_part_loc = ref_part->Location();

--- a/UI/DesignWnd.h
+++ b/UI/DesignWnd.h
@@ -3,6 +3,9 @@
 
 #include <GG/Wnd.h>
 
+/** @content_tag{CTRL_SKIP_REDUNDANT_FILTER} Never hide this part during redundant part filtering **/
+const std::string TAG_SKIP_REDUNDANT_FILTER = "CTRL_SKIP_REDUNDANT_FILTER";
+
 class EncyclopediaDetailPanel;
 
 /** Lets the player design ships */

--- a/default/customizations/common_user_customizations.txt
+++ b/default/customizations/common_user_customizations.txt
@@ -4,25 +4,6 @@
 # To minimize potential conflict with stringtable tags, all keys here should begin with "FUNCTIONAL_"
 
 
-## DesignWnd Redundant Part Filtering
-## Default settings will deem a first part redundant to a second only if the second is all of (i) more powerful,
-## (ii) no more expensive, (iii) takes no longer to build, and (iv) has no Location restrictions not also required
-## by the first part (note that the checking on this point is currently over-conservative).
-## Adjusting the Max Cost Ratio above 1.0 allows the filtering to consider a superior part which might cost a bit
-## more, but whose Capacity/Cost ratio is at least equal to the Min Bargain Ratio.  For example, with the current content
-## as of the time of this writing, setting the Max Cost Ratio to 2.1 and leaving the Min Bargain Ratio at 1.0 woould cause
-## Zortrium armor to suppress Standard armor, and for Advanced Ground Troop Pods to suppress Standard Troop Pods.  Then
-## also increasing the Max Time Ratio to 1.4 or higher would cause N-Dimensional Engines to suppress Improved Engine Couplings.
-## Dropping the Max Cost Ratio below 2.0, or increasing the Min Bargain Ratio above 1.0, would prevent the redundancy filtering
-## for troop Pods.  If the Min Bargain Ratio were no higher than about 1.2 and the Max Cost Ratio at least about 1.4, then
-## some of the armor redundancy filtering would still occur.
- 
-## Some parts have special Effects and so may be preferred to be excluded from the redundancy
-## checks, which do not consider such Effects.  Parts on this list will be excluded from Redundancy checks.
-## The SH_MULTISPEC shield part is one such part; it as a strong stealth Effect, but unless excluded
-## here the Black Shield can suppress it as redundant.
-
-
 ## FUNCTIONAL_SITREP_PRIORITY_ORDER is an ordered, whitespace separated list, prioritizing
 ## these sitreps to be presented in the SitrepPanel in the order set below.
 ## Sitreps not specified below will appear in the SitrepPanel following those below.

--- a/default/customizations/common_user_customizations.txt
+++ b/default/customizations/common_user_customizations.txt
@@ -16,18 +16,7 @@
 ## Dropping the Max Cost Ratio below 2.0, or increasing the Min Bargain Ratio above 1.0, would prevent the redundancy filtering
 ## for troop Pods.  If the Min Bargain Ratio were no higher than about 1.2 and the Max Cost Ratio at least about 1.4, then
 ## some of the armor redundancy filtering would still occur.
-## Both settings have a minimum value of 1.0
  
-FUNCTIONAL_MAX_COST_RATIO
-1.0
-
-FUNCTIONAL_MIN_BARGAIN_RATIO
-1.0
-
-FUNCTIONAL_MAX_TIME_RATIO
-1.0
-
-
 ## Some parts have special Effects and so may be preferred to be excluded from the redundancy
 ## checks, which do not consider such Effects.  Parts on this list will be excluded from Redundancy checks.
 ## The SH_MULTISPEC shield part is one such part; it as a strong stealth Effect, but unless excluded

--- a/default/customizations/common_user_customizations.txt
+++ b/default/customizations/common_user_customizations.txt
@@ -22,10 +22,6 @@
 ## The SH_MULTISPEC shield part is one such part; it as a strong stealth Effect, but unless excluded
 ## here the Black Shield can suppress it as redundant.
 
-FUNCTIONAL_SHIP_PART_REDUNDANCY_SKIP_LIST
-'''SH_MULTISPEC
-'''
-
 
 ## FUNCTIONAL_SITREP_PRIORITY_ORDER is an ordered, whitespace separated list, prioritizing
 ## these sitreps to be presented in the SitrepPanel in the order set below.

--- a/default/scripting/ship_parts/Shields.focs.txt
+++ b/default/scripting/ship_parts/Shields.focs.txt
@@ -54,6 +54,7 @@ Part
     mountableSlotTypes = Internal
     buildcost = 100 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildtime = 8
+    tags = "CTRL_SKIP_REDUNDANT_FILTER"
     location = OwnedBy empire = Source.Owner
     effectsgroups = [
         [[SHIELD_STACKING]]     //Make sure to add new shields to SUM_SHIELD_CAPACITY and BEST_SHIELD_EFFECT

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1743,6 +1743,14 @@ Network port to use for server discovery.
 OPTIONS_DB_NETWORK_MESSAGE_PORT
 Network port to use for client-server messaging.
 
+OPTIONS_DB_UI_DESIGN_PART_FILTER_MIN_BARGAIN
+Minimum bargain ratio for filtering redundant ship parts in the design window.
+
+OPTIONS_DB_UI_DESIGN_PART_FILTER_MAX_COST
+Maximum cost ratio for filtering redundant ship parts in the design window.
+
+OPTIONS_DB_UI_DESIGN_PART_FILTER_MAX_TIME
+Maximum time ratio for filtering redundant ship parts in the design window.
 
 ##
 ## File dialog

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1743,6 +1743,48 @@ Network port to use for server discovery.
 OPTIONS_DB_NETWORK_MESSAGE_PORT
 Network port to use for client-server messaging.
 
+OPTIONS_DB_UI_DESIGN_PART_FILTER_DESC
+'''DesignWnd Redundant Part Filtering
+
+Deems a first part redundant to a second only if the second is all of:
+
+(i) more powerful
+
+(ii) no more expensive
+
+(iii) takes no longer to build
+
+(iv) has no Location restrictions not also required by the first part
+
+(note that the checking on this last point is currently over-conservative).
+
+Adjusting the Max Cost Ratio above 1.0 allows the filtering to consider a
+superior part which might cost a bit more, but whose Capacity/Cost ratio is at
+least equal to the Min Bargain Ratio.
+
+For example, with the current content as of the time of this writing, setting
+the Max Cost Ratio to 2.1 and leaving the Min Bargain Ratio at 1.0 would cause
+Zortrium armor to suppress Standard armor, and for Advanced Ground Troop Pods
+to suppress Standard Troop Pods.
+
+Then also increasing the Max Time Ratio to 1.4 or higher would cause
+N-Dimensional Engines to suppress Improved Engine Couplings.
+
+Dropping the Max Cost Ratio below 2.0, or increasing the Min Bargain Ratio
+above 1.0, would prevent the redundancy filtering for troop Pods.
+
+If the Min Bargain Ratio were no higher than about 1.2 and the Max Cost Ratio
+at least about 1.4, then some of the armor redundancy filtering would still
+occur.
+ 
+Some parts have special Effects and so may be preferred to be excluded from the
+redundancy checks, which do not consider such Effects.
+
+Parts on this list will be excluded from Redundancy checks.
+
+The SH_MULTISPEC shield part is one such part; it has a strong stealth Effect,
+but unless excluded the Black Shield can suppress it as redundant.'''
+
 OPTIONS_DB_UI_DESIGN_PART_FILTER_MIN_BARGAIN
 Minimum bargain ratio for filtering redundant ship parts in the design window.
 


### PR DESCRIPTION
PR relocates settings used with the `Redundant` parts filter within ship design.

Moves the bargain, cost, and time ratios to OptionsDB.

Removes skip list in favor of definition tags.

Partial proposal towards #907
