### PR TITLE
Remove binding of SaveFileDialog::UpdatePreviewList to FocusChangedSignal.

### DIFF
--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -665,7 +665,6 @@ void SaveFileDialog::Init() {
     GG::Connect(m_file_list->DoubleClickedSignal,               &SaveFileDialog::DoubleClickRow,    this);
     GG::Connect(m_name_edit->EditedSignal,                      &SaveFileDialog::FileNameEdited,    this);
     GG::Connect(m_current_dir_edit->EditedSignal,               &SaveFileDialog::DirectoryEdited,   this);
-    GG::Connect(GG::GUI::GetGUI()->FocusChangedSignal,          boost::bind(&SaveFileDialog::UpdatePreviewList, this));
 
     if (!m_load_only) {
         m_name_edit->SetText(std::string("save-") + FilenameTimestamp() + m_extension);


### PR DESCRIPTION
This might contribute to long loading times, since it will reload all of
the data in the SaveFileDialog if focus changes.

This would contributes to long loading times in #855, if the user shifted focus away from freeorion while waiting.
