### PR TITLE
Improve GG::Font::DetermineLines()

### DIFF
--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -272,7 +272,7 @@ public:
 
     /** \brief TextAndElementsAssembler is used to assemble a matched pair of text and a vector of
         TextElement, without incurring the computational cost of parsing the text with
-        ComputeTextElements().
+        ExpensiveParseFromTextToTextElements().
 
         The pair of string and vector returned by Text() and Elements() are consistent with each
         other and can be used with the fast constructor or the fast SetText variant of TextControl.
@@ -571,8 +571,9 @@ public:
         string \p text to be consistent even if the \p new_text is longer/shorter than the original
         TEXT type TextElement.
 
-        This does not recompute the text_elements. It is faster than ComputeTextElements on a new
-        string. It will not find white space in the inserted text.
+        This does not recompute the text_elements. It is faster than
+        ExpensiveParseFromTextToTextElements on a new string. It will not find white space in the
+        inserted text.
 
         \p text and \p text_elements are assumed to be consistent with each other and both will be
         changed to remain consistent.

--- a/GG/GG/TextControl.h
+++ b/GG/GG/TextControl.h
@@ -95,6 +95,16 @@ public:
     //@}
     virtual ~TextControl();
 
+    /** Assignment operator.
+
+        Text Control requires an assignment operator because m_text_elements contains pointers
+        to m_text which need to be bound with Bind() to the m_text in this TextControl.
+
+        Using the assignment operator is faster than using SetText() with text from another
+        TextControl because it avoids the XML parse overhead.
+    */
+    TextControl& operator=(const TextControl& that);
+
     /** \name Accessors */ ///@{
     virtual Pt        MinUsableSize() const;
 

--- a/GG/GG/TextControl.h
+++ b/GG/GG/TextControl.h
@@ -78,8 +78,8 @@ public:
     /** Fast constructor.
 
      This constructor requires a \p str and \text_elements that are consistent with each other.
-     Font::ComputeTextElements() will not be called on \p str.  Hence this constructor is much
-     faster than the first constructor.*/
+     Font::ExpensiveParseFromTextToTextElements() will not be called on \p str.  Hence this
+     constructor is much faster than the first constructor.*/
     TextControl(X x, Y y, X w, Y h, const std::string& str,
                 const std::vector<boost::shared_ptr<Font::TextElement> >&text_elements,
                 const boost::shared_ptr<Font>& font,

--- a/GG/GG/TextControl.h
+++ b/GG/GG/TextControl.h
@@ -198,11 +198,16 @@ public:
         the newly rendered text occupies. */
     virtual void SetText(const std::string& str);
 
-    /** Sets the text displayed in this control to \a str \p text_elements
-        pair.  This is faster than SetText without \p text_elements. May resize
-        the window.  If the control was constructed with FORMAT_NOWRAP, calls
-        to this function cause the window to be resized to whatever space the
-        newly rendered text occupies. */
+    /** Sets the text displayed in this control to the \p str \p text_elements
+        pair.  This is faster than SetText without \p text_elements.
+
+        This may resize the window.  If the control was constructed with FORMAT_NOWRAP, calls to
+        this function cause the window to be resized to whatever space the newly rendered text
+        occupies.
+
+        If the \p str and \p text_elements are inconsistent and \p str is shorter than expected
+        from examining \p text_elements then it will return without changing the TextControl.
+    */
     virtual void SetText(const std::string& str,
                          const std::vector<boost::shared_ptr<Font::TextElement> >&text_elements);
 

--- a/GG/GG/TextControl.h
+++ b/GG/GG/TextControl.h
@@ -316,6 +316,10 @@ private:
     void RefreshCache();
     void PurgeCache();
 
+    /** Recompute line data, code points, text extent and minusable size cache when
+        m_text_elements changes.*/
+    void RecomputeLineData();
+
     std::string                 m_text;
     Flags<TextFormat>           m_format;      ///< the formatting used to display the text (vertical and horizontal alignment, etc.)
     Clr                         m_text_color;  ///< the color of the text itself (may differ from GG::Control::m_color)

--- a/GG/GG/TextControl.h
+++ b/GG/GG/TextControl.h
@@ -74,7 +74,12 @@ public:
     TextControl(X x, Y y, X w, Y h, const std::string& str, const boost::shared_ptr<Font>& font,
                 Clr color = CLR_BLACK, Flags<TextFormat> format = FORMAT_NONE,
                 Flags<WndFlag> flags = NO_WND_FLAGS);
-    /** Fast constructor.*/
+
+    /** Fast constructor.
+
+     This constructor requires a \p str and \text_elements that are consistent with each other.
+     Font::ComputeTextElements() will not be called on \p str.  Hence this constructor is much
+     faster than the first constructor.*/
     TextControl(X x, Y y, X w, Y h, const std::string& str,
                 const std::vector<boost::shared_ptr<Font::TextElement> >&text_elements,
                 const boost::shared_ptr<Font>& font,

--- a/GG/GG/TextControl.h
+++ b/GG/GG/TextControl.h
@@ -74,6 +74,12 @@ public:
     TextControl(X x, Y y, X w, Y h, const std::string& str, const boost::shared_ptr<Font>& font,
                 Clr color = CLR_BLACK, Flags<TextFormat> format = FORMAT_NONE,
                 Flags<WndFlag> flags = NO_WND_FLAGS);
+    /** Fast constructor.*/
+    TextControl(X x, Y y, X w, Y h, const std::string& str,
+                const std::vector<boost::shared_ptr<Font::TextElement> >&text_elements,
+                const boost::shared_ptr<Font>& font,
+                Clr color = CLR_BLACK, Flags<TextFormat> format = FORMAT_NONE,
+                Flags<WndFlag> flags = NO_WND_FLAGS);
     //@}
     virtual ~TextControl();
 

--- a/GG/GG/TextControl.h
+++ b/GG/GG/TextControl.h
@@ -80,6 +80,18 @@ public:
                 const boost::shared_ptr<Font>& font,
                 Clr color = CLR_BLACK, Flags<TextFormat> format = FORMAT_NONE,
                 Flags<WndFlag> flags = NO_WND_FLAGS);
+
+    /** Copy constructor.
+
+        Text Control requires a copy-constructor because m_text_elements contains pointers
+        to m_text which need to be bound with Bind() to the m_text in the new TextControl.
+
+        Using the copy constructor is faster than constructing a TextControl with text from another
+        TextControl because it avoids the XML parse overhead.
+
+        Since Control does not have a way to access Flags the copy using default flags.
+    */
+    explicit TextControl(const TextControl& that);
     //@}
     virtual ~TextControl();
 

--- a/GG/src/TextControl.cpp
+++ b/GG/src/TextControl.cpp
@@ -336,7 +336,6 @@ void TextControl::SizeMove(const Pt& ul, const Pt& lr)
         Pt text_sz = m_font->TextExtent(m_line_data);
         m_text_ul = Pt();
         m_text_lr = text_sz;
-        AdjustMinimumSize();
         PurgeCache();
     }
     RecomputeTextBounds();

--- a/GG/src/TextControl.cpp
+++ b/GG/src/TextControl.cpp
@@ -55,6 +55,26 @@ TextControl::TextControl(X x, Y y, X w, Y h, const std::string& str, const boost
     SetText(str);
 }
 
+TextControl::TextControl(X x, Y y, X w, Y h, const std::string& str,
+                         const std::vector<boost::shared_ptr<Font::TextElement> >& text_elements,
+                         const boost::shared_ptr<Font>& font,
+                         Clr color /*= CLR_BLACK*/, Flags<TextFormat> format /*= FORMAT_NONE*/,
+                         Flags<WndFlag> flags /*= NO_WND_FLAGS*/) :
+    Control(x, y, w, h, flags),
+    m_format(format),
+    m_text_color(color),
+    m_clip_text(false),
+    m_set_min_size(false),
+    m_code_points(0),
+    m_font(font),
+    m_render_cache(0),
+    m_cached_minusable_size_width(X0),
+    m_cached_minusable_size(Pt())
+{
+    ValidateFormat();
+    SetText(str, text_elements);
+}
+
 TextControl::~TextControl()
 {
     delete m_render_cache;

--- a/GG/src/TextControl.cpp
+++ b/GG/src/TextControl.cpp
@@ -61,10 +61,12 @@ TextControl::TextControl(X x, Y y, X w, Y h, const std::string& str,
                          Clr color /*= CLR_BLACK*/, Flags<TextFormat> format /*= FORMAT_NONE*/,
                          Flags<WndFlag> flags /*= NO_WND_FLAGS*/) :
     Control(x, y, w, h, flags),
+    m_text(),
     m_format(format),
     m_text_color(color),
     m_clip_text(false),
     m_set_min_size(false),
+    m_text_elements(),
     m_code_points(0),
     m_font(font),
     m_render_cache(0),
@@ -260,6 +262,17 @@ void TextControl::SetText(const std::string& str,
 {
     if (!utf8::is_valid(str.begin(), str.end()))
         return;
+
+    std::size_t expected_length(0);
+    for (std::vector<boost::shared_ptr<Font::TextElement> >::const_iterator it = text_elements.begin();
+         it != text_elements.end(); ++it)
+    {
+        expected_length +=(*it)->text.size();
+    }
+
+    if (expected_length > str.size())
+        return;
+
     m_text = str;
 
     m_text_elements = text_elements;

--- a/GG/src/TextControl.cpp
+++ b/GG/src/TextControl.cpp
@@ -160,11 +160,11 @@ std::string TextControl::Text(CPSize from, CPSize to) const
 
     //std::cout << "low: " << low << "  high: " << high << std::endl << std::flush;
 
-    std::pair<std::size_t, CPSize> low_pos = LinePositionOf(low, GetLineData());
-    std::pair<std::size_t, CPSize> high_pos = LinePositionOf(high, GetLineData());
+    std::pair<std::size_t, CPSize> low_pos = LinePositionOf(low, m_line_data);
+    std::pair<std::size_t, CPSize> high_pos = LinePositionOf(high, m_line_data);
 
-    StrSize low_string_idx = StringIndexOf(low_pos.first, low_pos.second, GetLineData());
-    StrSize high_string_idx = StringIndexOf(high_pos.first, high_pos.second, GetLineData());
+    StrSize low_string_idx = StringIndexOf(low_pos.first, low_pos.second, m_line_data);
+    StrSize high_string_idx = StringIndexOf(high_pos.first, high_pos.second, m_line_data);
 
     std::string::const_iterator low_it = m_text.begin() + Value(low_string_idx);
     std::string::const_iterator high_it = m_text.begin() + Value(high_string_idx);

--- a/GG/src/TextControl.cpp
+++ b/GG/src/TextControl.cpp
@@ -287,7 +287,6 @@ void TextControl::RecomputeLineData() {
     Pt text_sz = m_font->TextExtent(m_line_data);
     m_text_ul = Pt();
     m_text_lr = text_sz;
-    AdjustMinimumSize();
     PurgeCache();
     if (m_format & FORMAT_NOWRAP) {
         Resize(text_sz);

--- a/GG/src/TextControl.cpp
+++ b/GG/src/TextControl.cpp
@@ -102,6 +102,29 @@ TextControl::~TextControl()
     m_render_cache = 0;
 }
 
+TextControl& TextControl::operator=(const TextControl& that)
+{
+    m_text = that.m_text;
+    m_format = that.m_format;
+    m_text_color = that.m_text_color;
+    m_clip_text = that.m_clip_text;
+    m_set_min_size = that.m_set_min_size;
+    m_text_elements = that.m_text_elements;
+    m_code_points = that.m_code_points;
+    m_font = that.m_font;
+    m_render_cache = that.m_render_cache;
+    m_cached_minusable_size_width = that.m_cached_minusable_size_width;
+    m_cached_minusable_size = that.m_cached_minusable_size;
+
+    for (std::vector<boost::shared_ptr<Font::TextElement> >::iterator it = m_text_elements.begin();
+         it != m_text_elements.end(); ++it)
+    {
+        (*it)->Bind(m_text);
+    }
+
+    return *this;
+}
+
 Pt TextControl::MinUsableSize() const
 { return m_text_lr - m_text_ul; }
 

--- a/GG/src/TextControl.cpp
+++ b/GG/src/TextControl.cpp
@@ -251,21 +251,8 @@ void TextControl::SetText(const std::string& str)
     if (!m_font)
         return;
 
-    m_code_points = CPSize(utf8::distance(str.begin(), str.end()));
     m_text_elements = m_font->ExpensiveParseFromTextToTextElements(m_text, m_format);
-    m_line_data = m_font->DetermineLines(m_text, m_format, ClientSize().x, m_text_elements);
-    Pt text_sz = m_font->TextExtent(m_line_data);
-    m_text_ul = Pt();
-    m_text_lr = text_sz;
-    AdjustMinimumSize();
-    PurgeCache();
-    if (m_format & FORMAT_NOWRAP) {
-        Resize(text_sz);
-    } else {
-        RecomputeTextBounds();
-    }
-
-    m_cached_minusable_size_width = X0;
+    RecomputeLineData();
 }
 
 void TextControl::SetText(const std::string& str,
@@ -275,8 +262,6 @@ void TextControl::SetText(const std::string& str,
         return;
     m_text = str;
 
-    m_code_points = CPSize(utf8::distance(str.begin(), str.end()));
-
     m_text_elements = text_elements;
     for (std::vector<boost::shared_ptr<Font::TextElement> >::iterator it = m_text_elements.begin();
          it != m_text_elements.end(); ++it)
@@ -284,26 +269,18 @@ void TextControl::SetText(const std::string& str,
         (*it)->Bind(m_text);
     }
 
-    if (!m_font)
-        return;
-
-    m_line_data = m_font->DetermineLines(m_text, m_format, ClientSize().x, m_text_elements);
-    Pt text_sz = m_font->TextExtent(m_line_data);
-    m_text_ul = Pt();
-    m_text_lr = text_sz;
-    AdjustMinimumSize();
-    PurgeCache();
-    if (m_format & FORMAT_NOWRAP) {
-        Resize(text_sz);
-    } else {
-        RecomputeTextBounds();
-    }
-
-    m_cached_minusable_size_width = X0;
+    RecomputeLineData();
 }
 
 void TextControl::ChangeTemplatedText(const std::string& new_text, size_t targ_offset) {
     m_font->ChangeTemplatedText(m_text, m_text_elements, new_text, targ_offset);
+    RecomputeLineData();
+}
+
+void TextControl::RecomputeLineData() {
+    if (!m_font)
+        return;
+
     m_code_points = CPSize(utf8::distance(m_text.begin(), m_text.end()));
 
     m_line_data = m_font->DetermineLines(m_text, m_format, ClientSize().x, m_text_elements);

--- a/GG/src/TextControl.cpp
+++ b/GG/src/TextControl.cpp
@@ -75,6 +75,27 @@ TextControl::TextControl(X x, Y y, X w, Y h, const std::string& str,
     SetText(str, text_elements);
 }
 
+TextControl::TextControl(const TextControl& that) :
+    Control(that.Left(), that.Top(), that.Width(), that.Height()),
+    m_text(that.m_text),
+    m_format(that.m_format),
+    m_text_color(that.m_text_color),
+    m_clip_text(that.m_clip_text),
+    m_set_min_size(that.m_set_min_size),
+    m_text_elements(that.m_text_elements),
+    m_code_points(that.m_code_points),
+    m_font(that.m_font),
+    m_render_cache(that.m_render_cache),
+    m_cached_minusable_size_width(that.m_cached_minusable_size_width),
+    m_cached_minusable_size(that.m_cached_minusable_size)
+{
+    for (std::vector<boost::shared_ptr<Font::TextElement> >::iterator it = m_text_elements.begin();
+         it != m_text_elements.end(); ++it)
+    {
+        (*it)->Bind(m_text);
+    }
+}
+
 TextControl::~TextControl()
 {
     delete m_render_cache;


### PR DESCRIPTION
This PR is a collection of improvements to `GG::Font` to improve its
performance.

Previously `Font::DetermineLines()` consumed 25% of the processing time when
the UI was stalling freeorion.  Within `DetermineLines()` most of the time was
spent parsing the XML strings into TextElements used by Font to break the
string into known style tags, unknown style tags and text. 

The PR breaks out the XML to TextElements computation into
`ComputeTextElements()`.  It then removes gotcha variants of
`DetermineLines()` so that Font can be used efficiently.  It short-circuits
logic for common operations like parsing an empty string.

Repeated use of `ComputeTextElements()` in tight loops is still a
performance hazard. I was unable to improve the usage of `boost::xpressive`
as much as I had hoped.
