### PR TITLE
Add GG::Wnd::PreRender() to do layout once per frame.

### DIFF
--- a/GG/GG/GUI.h
+++ b/GG/GG/GUI.h
@@ -376,6 +376,7 @@ public:
     //@}
 
     static GUI*  GetGUI();                  ///< allows any GG code access to GUI framework by calling GUI::GetGUI()
+    static void  PreRenderWindow(Wnd* wnd); ///< PreRender \p wnd's children and the \p wnd.
     static void  RenderWindow(Wnd* wnd);    ///< renders a window (if it is visible) and all its visible descendents recursively
     virtual void RenderDragDropWnds();      ///< renders Wnds currently being drag-dropped
 
@@ -417,6 +418,8 @@ protected:
 
     /** \name Mutators */ ///@{
     void           ProcessBrowseInfo();    ///< determines the current browse info mode, if any
+    /** Allow all windows in the z-list to update data before rendering. */
+    virtual void   PreRender();
     virtual void   RenderBegin() = 0;      ///< clears the backbuffer, etc.
     virtual void   Render();               ///< renders the windows in the z-list
     virtual void   RenderEnd() = 0;        ///< swaps buffers, etc.

--- a/GG/GG/GUI.h
+++ b/GG/GG/GUI.h
@@ -376,7 +376,11 @@ public:
     //@}
 
     static GUI*  GetGUI();                  ///< allows any GG code access to GUI framework by calling GUI::GetGUI()
-    static void  PreRenderWindow(Wnd* wnd); ///< PreRender \p wnd's children and the \p wnd.
+
+    /** If \p wnd is visible recursively call PreRenderWindow() on all \p wnd's children and then
+        call \p wnd->PreRender().  The order guarantees that when wnd->PreRender() is called all
+        of \p wnd's children have already been prerendered.*/
+    static void  PreRenderWindow(Wnd* wnd);
     static void  RenderWindow(Wnd* wnd);    ///< renders a window (if it is visible) and all its visible descendents recursively
     virtual void RenderDragDropWnds();      ///< renders Wnds currently being drag-dropped
 

--- a/GG/GG/Wnd.h
+++ b/GG/GG/Wnd.h
@@ -194,6 +194,14 @@ extern GG_API const WndFlag NO_WND_FLAGS;
     current.  Note the use of the phrase "client-area children".  This refers
     to children entirely within the client area of the window.
 
+    <h3>Timing</h3>
+
+    <br>Each render interval the following things happen in this order: events
+    are handled PreRender() and then Render() are called. PreRender() and
+    Render() are only called if the window is visible. Data used to render the
+    window may change multiple times between calls to Render().  PreRender()
+    allows Wnd to perform any expensive updates only once per render interval.
+
     <h3>Browse Info</h3>
 
     <br>Browse info is a non-interactive informational window that pops up
@@ -582,6 +590,13 @@ public:
     /** Sets the margin that should exist between the windows in the layout.
         If no layout exists for the window, this has no effect. */
     void SetLayoutCellMargin(unsigned int margin);
+
+    /** Update Wnd prior to Render().
+        PreRender() is called once each render interval before Render().  This
+        allows the Wnd to consolidate multiple expensive pre rendering data
+        updates into a single update.  PreRender() of child windows will be
+        called before this PreRender(). */
+    virtual void PreRender();
 
     /** Draws this Wnd.  Note that Wnds being dragged for a drag-and-drop
         operation are rendered twice -- once in-place as normal, once in the

--- a/GG/GG/Wnd.h
+++ b/GG/GG/Wnd.h
@@ -218,6 +218,13 @@ extern GG_API const WndFlag NO_WND_FLAGS;
     Core parts of GG will continue to immediately update layout until
     peripheral parts are updated to expect deferred updates.
 
+    The default implementation of PreRender() only clears the flag set by RequirePreRender().
+    For a class to defer its layout to the prerender phase it needs to override PreRender() and
+    implement its layout changes in PreRender().
+
+    Legacy GG did not have a prerender phase and all layout changes were immediate.  Any Wnd class
+    that does not override PreRender() will update layout immediately when executing mutating functions.
+
     <h3>Browse Info</h3>
 
     <br>Browse info is a non-interactive informational window that pops up
@@ -611,13 +618,18 @@ public:
     void SetLayoutCellMargin(unsigned int margin);
 
     /** Update Wnd prior to Render().
+
         PreRender() is called before Render() if RequirePreRender() was called.
-        The default PreRender() resets RequirePreRender.  Wnd::PreRender should
-        be called in any overrides to reset RequirePreRender().
-        PreRender() of child windows will be called before this PreRender(). */
+        The default PreRender() resets the flag from RequirePreRender().
+        Wnd::PreRender() should be called in any overrides to reset
+        RequirePreRender().
+
+        In the GUI processing loop the PreRender() of child windows whose
+        RequirePreRender() flag is set will have been called before their
+        parent PreRender(). */
     virtual void PreRender();
 
-    /** Require that layout be updated before the next Render(). */
+    /** Require that PreRender() be called to update layout before the next Render(). */
     virtual void RequirePreRender();
 
     /** Draws this Wnd.  Note that Wnds being dragged for a drag-and-drop

--- a/GG/GG/Wnd.h
+++ b/GG/GG/Wnd.h
@@ -618,7 +618,7 @@ public:
     virtual void PreRender();
 
     /** Require that layout be updated before the next Render(). */
-    virtual void        RequirePreRender();
+    virtual void RequirePreRender();
 
     /** Draws this Wnd.  Note that Wnds being dragged for a drag-and-drop
         operation are rendered twice -- once in-place as normal, once in the

--- a/GG/src/EventPump.cpp
+++ b/GG/src/EventPump.cpp
@@ -71,6 +71,7 @@ void EventPumpBase::LoopBody(GUI* gui, EventPumpState& state, bool do_non_render
 
     if (do_rendering) {
         // do one iteration of the render loop
+        gui->PreRender();
         gui->RenderBegin();
         gui->Render();
         gui->RenderEnd();

--- a/GG/src/GUI.cpp
+++ b/GG/src/GUI.cpp
@@ -1558,7 +1558,9 @@ void GUI::PreRenderWindow(Wnd* wnd)
     for (std::list<Wnd*>::iterator it = wnd->m_children.begin(); it != wnd->m_children.end(); ++it) {
         PreRenderWindow(*it);
     }
-    wnd->PreRender();
+
+    if (wnd->PreRenderRequired())
+        wnd->PreRender();
 }
 
 void GUI::RenderWindow(Wnd* wnd)

--- a/GG/src/Wnd.cpp
+++ b/GG/src/Wnd.cpp
@@ -872,6 +872,8 @@ void Wnd::SetLayoutCellMargin(unsigned int margin)
         m_layout->SetCellMargin(margin);
 }
 
+void Wnd::PreRender() {}
+
 void Wnd::Render() {}
 
 bool Wnd::Run()

--- a/GG/src/Wnd.cpp
+++ b/GG/src/Wnd.cpp
@@ -264,7 +264,7 @@ bool Wnd::Visible() const
 { return m_visible; }
 
 bool Wnd::PreRenderRequired() const
-{ return m_needs_prerender; }
+{ return m_needs_prerender || (m_layout && m_layout->m_needs_prerender); }
 
 const std::string& Wnd::Name() const
 { return m_name; }
@@ -876,7 +876,11 @@ void Wnd::SetLayoutCellMargin(unsigned int margin)
 }
 
 void Wnd::PreRender()
-{ m_needs_prerender = false; }
+{
+    m_needs_prerender = false;
+    if (m_layout && m_layout->m_needs_prerender)
+        m_layout->PreRender();
+}
 
 void Wnd::RequirePreRender()
 { m_needs_prerender = true; }

--- a/GG/src/Wnd.cpp
+++ b/GG/src/Wnd.cpp
@@ -263,6 +263,9 @@ bool Wnd::NonClientChild() const
 bool Wnd::Visible() const
 { return m_visible; }
 
+bool Wnd::PreRenderRequired() const
+{ return m_needs_prerender; }
+
 const std::string& Wnd::Name() const
 { return m_name; }
 
@@ -872,7 +875,11 @@ void Wnd::SetLayoutCellMargin(unsigned int margin)
         m_layout->SetCellMargin(margin);
 }
 
-void Wnd::PreRender() {}
+void Wnd::PreRender()
+{ m_needs_prerender = false; }
+
+void Wnd::RequirePreRender()
+{ m_needs_prerender = true; }
 
 void Wnd::Render() {}
 

--- a/UI/TechTreeWnd.cpp
+++ b/UI/TechTreeWnd.cpp
@@ -605,8 +605,6 @@ public:
 
     virtual bool    InWindow(const GG::Pt& pt) const;
 
-    /** Require that layout and format be updated before the next Render()*/
-    virtual void    RequirePreRender();
     /** Update layout and format only if required.*/
     virtual void    PreRender();
     virtual void    Render();
@@ -656,7 +654,6 @@ private:
     bool                            m_selected;
     int                             m_eta;
     bool                            m_enqueued;
-    bool                            m_needs_prerender;
 };
 
 TechTreeWnd::LayoutPanel::TechPanel::TechPanel(const std::string& tech_name, const LayoutPanel* panel) :
@@ -713,13 +710,8 @@ bool TechTreeWnd::LayoutPanel::TechPanel::InWindow(const GG::Pt& pt) const {
     return GG::Pt(GG::X0, GG::Y0) <= p && p < GG::Pt(TechPanelWidth(), TechPanelHeight());
 }
 
-void TechTreeWnd::LayoutPanel::TechPanel::RequirePreRender()
-{ m_needs_prerender = true; }
-
 void TechTreeWnd::LayoutPanel::TechPanel::PreRender() {
-    if (!m_needs_prerender)
-        return;
-    m_needs_prerender = false;
+    GG::Wnd::PreRender();
 
     const int PAD = 8;
     GG::X text_left(GG::X(Value(TechPanelHeight())) + PAD);
@@ -769,7 +761,6 @@ void TechTreeWnd::LayoutPanel::TechPanel::PreRender() {
 }
 
 void TechTreeWnd::LayoutPanel::TechPanel::Render() {
-    PreRender();
     const int PAD = 8;
     GG::X text_left(GG::X(Value(TechPanelHeight())) + PAD);
     GG::Y text_top(0);


### PR DESCRIPTION
Adding `Wnd::PreRender()` to the event loop before `Render()` formalizes the
method of consolidating all layout changes once per video frame.

Consolidating change provides performance improvements from a single layout
per frame. It may also fix bugs where multiple UI events are triggered by a
single user action and early changes modify the layout, causing
subsequently processed actions to hit different or removed UI elements
resulting in unexpected behavior.

`PreRender()` is only run on visible windows that have requested a prerender
with `RequirePrender()`.

`PreRender()` processes children first so that parents can check child sizes
while in `PreRender()` and get the correct size, not the size from the last 
rendered frame.
