### PR TITLE
Improve GG::ListBox and derived classes.

### DIFF
--- a/GG/GG/DropDownList.h
+++ b/GG/GG/DropDownList.h
@@ -110,6 +110,10 @@ public:
     virtual Pt      ClientUpperLeft() const;
     virtual Pt      ClientLowerRight() const;
 
+    /** Return the width of the displayed row.  Override this function if the displayed row is a
+        different width than the drop down rows.*/
+    virtual GG::X  DisplayedRowWidth() const;
+
     mutable SelChangedSignalType SelChangedSignal; ///< the selection change signal object for this DropDownList
     //@}
 

--- a/GG/GG/DropDownList.h
+++ b/GG/GG/DropDownList.h
@@ -178,6 +178,9 @@ public:
     void            SetColAlignment(std::size_t n, Alignment align); ///< sets the alignment of column \a n to \a align; not range-checked
     void            SetRowAlignment(iterator it, Alignment align);   ///< sets the alignment of the Row at row index \a n to \a align; not range-checked
 
+    /** Sets the stretch of column \a n to \a stretch; not range-checked */
+    void            SetColStretch(std::size_t n, double stretch);
+
     /** Sets whether to normalize rows when inserted (true) or leave them as
       * they are. */
     void            NormalizeRowsOnInsert(bool enable = true);

--- a/GG/GG/DropDownList.h
+++ b/GG/GG/DropDownList.h
@@ -118,6 +118,7 @@ public:
     //@}
 
     /** \name Mutators */ ///@{
+    virtual void    PreRender();
     virtual void    Render();
     virtual void    SizeMove(const Pt& ul, const Pt& lr); ///< resizes the control, ensuring the proper height is maintained based on the list's row height
     virtual void    SetColor(Clr c);

--- a/GG/GG/DropDownList.h
+++ b/GG/GG/DropDownList.h
@@ -170,8 +170,17 @@ public:
         to an empty ListBox */
     void            UnLockColWidths();
 
+    /** Set ListBox to stop managing column widths and alignment.  The number of columns must be
+        set with SetColWidth(), but widths of individual rows columns or the header will not be
+        managed by ListBox. */
+    void            ManuallyManageColProps();
+
     void            SetColAlignment(std::size_t n, Alignment align); ///< sets the alignment of column \a n to \a align; not range-checked
     void            SetRowAlignment(iterator it, Alignment align);   ///< sets the alignment of the Row at row index \a n to \a align; not range-checked
+
+    /** Sets whether to normalize rows when inserted (true) or leave them as
+      * they are. */
+    void            NormalizeRowsOnInsert(bool enable = true);
     //@}
 
 protected:

--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -34,8 +34,8 @@
 #include <GG/Control.h>
 #include <GG/Timer.h>
 
+#include <boost/shared_ptr.hpp>
 #include <set>
-
 
 namespace GG {
 
@@ -516,6 +516,12 @@ private:
     void            NormalizeRow(Row* row);                                 ///< adjusts a Row so that it has the same number of cells as other rows, and that each cell has the correct width and alignment
     iterator        FirstRowShownWhenBottomIs(iterator bottom_row, Y client_height); ///< Returns the first row shown when the last row shown is \a bottom_row
     std::size_t     FirstColShownWhenRightIs(std::size_t right_col, X client_width); ///< Returns the index of the first column shown when the last column shown is \a right_col
+
+    struct SelectionCache;
+    /** Cache the selected, clicked and last browsed rows.*/
+    boost::shared_ptr<SelectionCache> CacheSelections();
+    /** Restore cached selected, clicked and last browsed rows.*/
+    void RestoreCachedSelections(const SelectionCache& cache);
 
     std::list<Row*> m_rows;             ///< line item data
 

--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -85,8 +85,8 @@ extern GG_API const ListBoxStyle LIST_BROWSEUPDATES;  ///< Causes a signal to be
     SetColWidth(), and lock the column widths with LockColWidths(). To create a
     ListBox and manually control the column widths and alignment use
     ManuallyManageColProps() and set the number of columns with SetNumCols().
-    Use DefineColWidth() and DefineColAlignments() to set widths and
-    alignments from an exemplar row.
+    Use DefineColWidths(), DefineColAlignments() and
+    DefineColStretches() to set widths and alignments from an exemplar row.
 
     <br>Note that Rows are stored by pointer.  If you want to move a Row from
     one ListBox to another, use GetRow() and Insert().
@@ -181,6 +181,7 @@ public:
         void         ClearColAlignments(); ///< Clear the horizontal alignments of the cells in this Row
         void         SetColWidths(const std::vector<X>& widths); ///< sets all the widths of the cells of this Row; not range checked
         void         ClearColWidths(); ///< Clear the minimum widths of the cells of this Row.
+        void         SetColStretches(const std::vector<double>& stretches); ///< Set all column stretches.
         void         SetMargin(unsigned int margin); ///< sets the amount of space left between the contents of adjacent cells, in pixels
         //@}
 
@@ -193,6 +194,7 @@ public:
         Alignment              m_row_alignment;  ///< row alignment; one of ALIGN_TOP, ALIGN_VCENTER, or ALIGN_BOTTOM
         std::vector<Alignment> m_col_alignments; ///< column alignments; each is one of ALIGN_TOP, ALIGN_VCENTER, or ALIGN_BOTTOM
         std::vector<X>         m_col_widths;     ///< column widths
+        std::vector<double>    m_col_stretches;  ///< the stretch factor of each column
         unsigned int           m_margin;         ///< the amount of space left between the contents of adjacent cells, in pixels
 
         bool                   m_ignore_adjust_layout;
@@ -290,6 +292,7 @@ public:
 
     X               ColWidth(std::size_t n) const;     ///< returns the width of column \a n in pixels; not range-checked
     Alignment       ColAlignment(std::size_t n) const; ///< returns the alignment of column \a n; must be ALIGN_LEFT, ALIGN_CENTER, or ALIGN_RIGHT; not range-checked
+    double          ColStretch(std::size_t n) const;   ///< Return the stretch factor of column \a n.
     Alignment       RowAlignment(iterator it) const;   ///< returns the alignment of row \a it; must be ALIGN_TOP, ALIGN_VCENTER, or ALIGN_BOTTOM; not range-checked
 
     /** Returns the set of data types allowed to be dropped over this ListBox
@@ -413,6 +416,9 @@ public:
     /** Sets the alignment of column \a n to \a align; not range-checked */
     void            SetColAlignment(std::size_t n, Alignment align);
 
+    /** Sets the stretch of column \a n to \a stretch; not range-checked */
+    void            SetColStretch(std::size_t n, double stretch);
+
     /** Sets the alignment of row \a it to \a align; not range-checked */
     void            SetRowAlignment(iterator it, Alignment align);
 
@@ -425,6 +431,9 @@ public:
 
     /** Sets the column alignments from an exemplar \p row.*/
     void            DefineColAlignments(const Row& row);
+
+    /** Sets the column alignments from an exemplar \p row.*/
+    void            DefineColStretches(const Row& row);
 
     /** Sets whether to add padding at the end of the scrolls when the ListBox is
      *  bigger than the client area, so that any row can be scrolled all the way to
@@ -564,6 +573,8 @@ private:
     std::vector<X>  m_col_widths;       ///< the width of each of the columns goes here
     std::vector<Alignment>
                     m_col_alignments;   ///< the horizontal alignment of each of the columns goes here
+    std::vector<double>
+                    m_col_stretches;    ///< the stretch factor of each column
     unsigned int    m_cell_margin;      ///< the amount of space left between each edge of the cell and its contents, in pixels
 
     Clr             m_int_color;        ///< color painted into the client area of the control

--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -83,8 +83,8 @@ extern GG_API const ListBoxStyle LIST_BROWSEUPDATES;  ///< Causes a signal to be
     number of columns.  To create a ListBox with user-defined widths, use the
     ctor designed for that, or call SetNumCols(), set individual widths with
     SetColWidth(), and lock the column widths with LockColWidths(). To create a
-    ListBox and manually control the column widths use
-    ManuallyManageColWidths() and set the number of columns with SetNumCols().
+    ListBox and manually control the column widths and alignment use
+    ManuallyManageColProps() and set the number of columns with SetNumCols().
 
     <br>Note that Rows are stored by pointer.  If you want to move a Row from
     one ListBox to another, use GetRow() and Insert().
@@ -176,6 +176,7 @@ public:
         void         SetColAlignment(std::size_t n, Alignment align); ///< sets the horizontal alignment of the Control in the \a nth cell of this Row; not range checked
         void         SetColWidth(std::size_t n, X width); ///< sets the width of the \a nth cell of this Row; not range checked
         void         SetColAlignments(const std::vector<Alignment>& aligns); ///< sets the horizontal alignment of all the Controls in this Row; not range checked
+        void         ClearColAlignments(); ///< Clear the horizontal alignments of the cells in this Row
         void         SetColWidths(const std::vector<X>& widths); ///< sets all the widths of the cells of this Row; not range checked
         void         ClearColWidths(); ///< Clear the minimum widths of the cells of this Row.
         void         SetMargin(unsigned int margin); ///< sets the amount of space left between the contents of adjacent cells, in pixels
@@ -277,8 +278,8 @@ public:
     /** Returns true iff column widths are fixed \see LockColWidths() */
     bool            KeepColWidths() const;
 
-    /** Return true if column width are not managed by ListBox. */
-    bool            ManuallyManagingColWidths() const;
+    /** Return true if column width and alignment are not managed by ListBox. */
+    bool            ManuallyManagingColProps() const;
 
     /** Returns the index of the column used to sort rows, when sorting is
         enabled.  \note The sort column is not range checked when it is set by
@@ -402,10 +403,10 @@ public:
         an empty ListBox */
     void            UnLockColWidths();
 
-    /** Set ListBox to stop managing column widths.  The number of columns can be set with
-        SetColWidth(), but widths of individual rows columns or the header will not be managed by
-        ListBox.*/
-    void            ManuallyManageColWidths();
+    /** Set ListBox to stop managing column widths and alignment.  The number of columns must be
+        set with SetColWidth(), but widths of individual rows columns or the header will not be
+        managed by ListBox. */
+    void            ManuallyManageColProps();
 
     /** Sets the alignment of column \a n to \a align; not range-checked */
     void            SetColAlignment(std::size_t n, Alignment align);
@@ -552,8 +553,9 @@ private:
 
     iterator        m_first_row_shown;  ///< index of row at top of visible area (always begin() for non-empty ListBox with LIST_NOSCROLL set)
     std::size_t     m_first_col_shown;  ///< like above, but index of column at left
+    std::size_t     m_num_cols;         ///< the number of columns
     std::vector<X>  m_col_widths;       ///< the width of each of the columns goes here
-    std::vector<Alignment> 
+    std::vector<Alignment>
                     m_col_alignments;   ///< the horizontal alignment of each of the columns goes here
     unsigned int    m_cell_margin;      ///< the amount of space left between each edge of the cell and its contents, in pixels
 
@@ -580,7 +582,7 @@ private:
     Timer           m_auto_scroll_timer;
 
     bool            m_normalize_rows_on_insert;
-    bool            m_manage_column_widths;
+    bool            m_manage_column_props;
 
     bool            m_add_padding_at_end;
 

--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -516,7 +516,6 @@ protected:
     void            Insert(const std::vector<Row*>& rows, iterator it, bool dropped, bool signal);  ///< insertion sorts into list, or inserts into an unsorted list before \a it; returns insertion point
     Row*            Erase(iterator it, bool removing_duplicate, bool signal); ///< erases the row at index \a idx, handling it as a duplicate removal (such as for drag-and-drops within a single ListBox) if indicated
     void            BringCaretIntoView();           ///< makes sure caret is visible when scrolling occurs due to keystrokes etc.
-    void            RecreateScrolls();              ///< recreates the vertical and horizontal scrolls as needed.
     void            ResetAutoScrollVars();          ///< resets all variables related to auto-scroll to their initial values
     void            Resort();                       ///< performs a full resort of all rows, using the current sort functor.
     Row&            ColHeaders();                   ///< returns the row containing the headings for the columns, if any.  If undefined, the returned heading Row will have size() 0. non-const for derivers

--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -335,6 +335,7 @@ public:
     virtual void    StartingChildDragDrop(const Wnd* wnd, const GG::Pt& offset);
     virtual void    AcceptDrops(const Pt& pt, const std::vector<Wnd*>& wnds, Flags<ModKey> mod_keys);
     virtual void    ChildrenDraggedAway(const std::vector<Wnd*>& wnds, const Wnd* destination);
+    virtual void    PreRender();
     virtual void    Render();
 
     virtual void    SizeMove(const Pt& ul, const Pt& lr);  ///< resizes the control, then resizes the scrollbars as needed
@@ -572,6 +573,7 @@ private:
     iterator        m_rclick_row;       ///< the row most recently right-clicked
     iterator        m_last_row_browsed; ///< the last row sent out as having been browsed (used to prevent duplicate browse signals)
 
+    GG::Pt          m_first_row_offset; ///< scrolled offset of the first row.
     iterator        m_first_row_shown;  ///< index of row at top of visible area (always begin() for non-empty ListBox with LIST_NOSCROLL set)
     std::size_t     m_first_col_shown;  ///< like above, but index of column at left
     std::size_t     m_num_cols;         ///< the number of columns

--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -35,6 +35,8 @@
 #include <GG/Timer.h>
 
 #include <boost/shared_ptr.hpp>
+#include <boost/unordered_set.hpp>
+
 #include <set>
 
 namespace GG {
@@ -210,7 +212,12 @@ public:
         bool operator()(const iterator& lhs, const iterator& rhs) const;
     };
 
-    typedef std::set<iterator, RowPtrIteratorLess> SelectionSet;
+    struct IteratorHash : std::unary_function<iterator, std::size_t> {
+        std::size_t operator()(const iterator& it) const
+        { return boost::hash<const Row*>()(*it); }
+    };
+
+    typedef boost::unordered_set<iterator, IteratorHash> SelectionSet;
 
     /** \name Signal Types */ ///@{
     /** emitted when the list box is cleared */

--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -130,18 +130,6 @@ public:
         time. */
     struct GG_API Row : public Control
     {
-        /** Allows multiple mutators on a Row to be called, with only one call
-            to the sometimes-expensive Row::AdjustLayout made at the end.
-            Declare a DeferAdjustLayout on the stack before calling Row
-            mutators, and at the end of scope, when the DeferAdjustLayout is
-            destructed, Row::AdjustLayout is called. */
-        struct DeferAdjustLayout
-        {
-            DeferAdjustLayout(Row* row);
-            ~DeferAdjustLayout();
-            Row* const m_row;
-        };
-
         /** the type of key used to sort rows */
         typedef std::string SortKeyType;
 
@@ -191,7 +179,6 @@ public:
 
         boost::signals2::signal<void(const Pt&, GG::Flags<GG::ModKey>)> RightClickedSignal;
     protected:
-        void AdjustLayout();
         virtual void           RClick(const Pt& pt, GG::Flags<GG::ModKey> mod);
 
         std::vector<Control*>  m_cells;          ///< the Controls in this Row (each may be null)

--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -180,7 +180,7 @@ public:
 
         boost::signals2::signal<void(const Pt&, GG::Flags<GG::ModKey>)> RightClickedSignal;
     protected:
-        void AdjustLayout(bool adjust_for_push_back = false);
+        void AdjustLayout();
         virtual void           RClick(const Pt& pt, GG::Flags<GG::ModKey> mod);
 
         std::vector<Control*>  m_cells;          ///< the Controls in this Row (each may be null)

--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -85,6 +85,8 @@ extern GG_API const ListBoxStyle LIST_BROWSEUPDATES;  ///< Causes a signal to be
     SetColWidth(), and lock the column widths with LockColWidths(). To create a
     ListBox and manually control the column widths and alignment use
     ManuallyManageColProps() and set the number of columns with SetNumCols().
+    Use DefineColWidth() and DefineColAlignments() to set widths and
+    alignments from an exemplar row.
 
     <br>Note that Rows are stored by pointer.  If you want to move a Row from
     one ListBox to another, use GetRow() and Insert().
@@ -418,6 +420,12 @@ public:
       * they are. */
     void            NormalizeRowsOnInsert(bool enable = true);
 
+    /** Sets the column widths from an exemplar \p row.*/
+    void            DefineColWidths(const Row& row);
+
+    /** Sets the column alignments from an exemplar \p row.*/
+    void            DefineColAlignments(const Row& row);
+
     /** Sets whether to add padding at the end of the scrolls when the ListBox is
      *  bigger than the client area, so that any row can be scrolled all the way to
      *  the top (true), or only use as much space as it needs. */
@@ -502,7 +510,6 @@ protected:
     virtual bool    EventFilter(Wnd* w, const WndEvent& event);
 
     /** Define the number of columns, the column widths and alignment from \p row.*/
-    void            DefineColumnsAndAlignment(const Row& row);
     iterator        Insert(Row* row, iterator it, bool dropped, bool signal);                       ///< insertion sorts into list, or inserts into an unsorted list before \a it; returns insertion point
     void            Insert(const std::vector<Row*>& rows, iterator it, bool dropped, bool signal);  ///< insertion sorts into list, or inserts into an unsorted list before \a it; returns insertion point
     Row*            Erase(iterator it, bool removing_duplicate, bool signal); ///< erases the row at index \a idx, handling it as a duplicate removal (such as for drag-and-drops within a single ListBox) if indicated

--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -489,6 +489,8 @@ protected:
 
     virtual bool    EventFilter(Wnd* w, const WndEvent& event);
 
+    /** Define the number of columns, the column widths and alignment from \p row.*/
+    void            DefineColumnsAndAlignment(const Row& row);
     iterator        Insert(Row* row, iterator it, bool dropped, bool signal);                       ///< insertion sorts into list, or inserts into an unsorted list before \a it; returns insertion point
     void            Insert(const std::vector<Row*>& rows, iterator it, bool dropped, bool signal);  ///< insertion sorts into list, or inserts into an unsorted list before \a it; returns insertion point
     Row*            Erase(iterator it, bool removing_duplicate, bool signal); ///< erases the row at index \a idx, handling it as a duplicate removal (such as for drag-and-drops within a single ListBox) if indicated

--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -163,6 +163,8 @@ public:
         Alignment    ColAlignment(std::size_t n) const; ///< returns the horizontal alignment of the Control in the \a nth cell of this Row; not range checked
         X            ColWidth(std::size_t n) const;     ///< returns the width of the \a nth cell of this Row; not range checked
         unsigned int Margin() const;                    ///< returns the amount of space left between the contents of adjacent cells, in pixels
+        /** Return true if the row is normalized.  Used by ListBox to track normalization.*/
+        bool         IsNormalized() const;
         //@}
 
         /** \name Mutators */ ///@{
@@ -183,6 +185,8 @@ public:
         void         ClearColWidths(); ///< Clear the minimum widths of the cells of this Row.
         void         SetColStretches(const std::vector<double>& stretches); ///< Set all column stretches.
         void         SetMargin(unsigned int margin); ///< sets the amount of space left between the contents of adjacent cells, in pixels
+        /** Set normalized.  Used by ListBox to track normalization.*/
+        void         SetNormalized(bool normalized);
         //@}
 
         boost::signals2::signal<void(const Pt&, GG::Flags<GG::ModKey>)> RightClickedSignal;
@@ -198,6 +202,7 @@ public:
         unsigned int           m_margin;         ///< the amount of space left between the contents of adjacent cells, in pixels
 
         bool                   m_ignore_adjust_layout;
+        bool                   m_is_normalized;
 
         friend struct DeferAdjustLayout;
     };

--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -82,7 +82,9 @@ extern GG_API const ListBoxStyle LIST_BROWSEUPDATES;  ///< Causes a signal to be
     LockColWidths() to prevent empty ListBoxes from taking on a new row's
     number of columns.  To create a ListBox with user-defined widths, use the
     ctor designed for that, or call SetNumCols(), set individual widths with
-    SetColWidth(), and lock the column widths with LockColWidths().
+    SetColWidth(), and lock the column widths with LockColWidths(). To create a
+    ListBox and manually control the column widths use
+    ManuallyManageColWidths() and set the number of columns with SetNumCols().
 
     <br>Note that Rows are stored by pointer.  If you want to move a Row from
     one ListBox to another, use GetRow() and Insert().
@@ -175,6 +177,7 @@ public:
         void         SetColWidth(std::size_t n, X width); ///< sets the width of the \a nth cell of this Row; not range checked
         void         SetColAlignments(const std::vector<Alignment>& aligns); ///< sets the horizontal alignment of all the Controls in this Row; not range checked
         void         SetColWidths(const std::vector<X>& widths); ///< sets all the widths of the cells of this Row; not range checked
+        void         ClearColWidths(); ///< Clear the minimum widths of the cells of this Row.
         void         SetMargin(unsigned int margin); ///< sets the amount of space left between the contents of adjacent cells, in pixels
         //@}
 
@@ -273,6 +276,9 @@ public:
 
     /** Returns true iff column widths are fixed \see LockColWidths() */
     bool            KeepColWidths() const;
+
+    /** Return true if column width are not managed by ListBox. */
+    bool            ManuallyManagingColWidths() const;
 
     /** Returns the index of the column used to sort rows, when sorting is
         enabled.  \note The sort column is not range checked when it is set by
@@ -395,6 +401,11 @@ public:
     /** Allows the number of columns to be determined by the first row added to
         an empty ListBox */
     void            UnLockColWidths();
+
+    /** Set ListBox to stop managing column widths.  The number of columns can be set with
+        SetColWidth(), but widths of individual rows columns or the header will not be managed by
+        ListBox.*/
+    void            ManuallyManageColWidths();
 
     /** Sets the alignment of column \a n to \a align; not range-checked */
     void            SetColAlignment(std::size_t n, Alignment align);
@@ -569,6 +580,7 @@ private:
     Timer           m_auto_scroll_timer;
 
     bool            m_normalize_rows_on_insert;
+    bool            m_manage_column_widths;
 
     bool            m_add_padding_at_end;
 

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -263,6 +263,22 @@ void DropDownList::InitBuffer()
     m_buffer.createServerBuffer();
 }
 
+void DropDownList::PreRender()
+{
+
+    // reset size of displayed drop list based on number of shown rows set.
+    // assumes that all rows have the same height.
+    // adds some magic padding for now to prevent the scroll bars showing up.
+    Pt drop_down_size(ClientWidth(), ClientHeight());
+    if (LB()->NumRows() > 0)
+        drop_down_size.y = LB()->GetRow(0).Height() * std::min<int>(m_num_shown_elements, LB()->NumRows()) + 4;
+
+    LB()->Resize(drop_down_size);
+
+    if (LB()->Visible())
+        GUI::GetGUI()->PreRenderWindow(LB());
+}
+
 void DropDownList::Render()
 {
     // draw beveled-down rectangle around client area
@@ -352,17 +368,11 @@ void DropDownList::SizeMove(const Pt& ul, const Pt& lr)
     // adjust size to keep correct height based on row height, etc.
     GG::Pt sz = Size();
     Wnd::SizeMove(ul, lr);
-    Pt drop_down_size(ClientWidth(), ClientHeight());
 
-    // reset size of displayed drop list based on number of shown rows set.
-    // assumes that all rows have the same height.
-    // adds some magic padding for now to prevent the scroll bars showing up.
-    if (LB()->NumRows() > 0)
-        drop_down_size.y = LB()->GetRow(0).Height() * std::min<int>(m_num_shown_elements, LB()->NumRows()) + 4;
-    LB()->SizeMove(Pt(X0, Height()), Pt(X0, Height()) + drop_down_size);
-
-    if (sz != Size())
+    if (sz != Size()) {
         InitBuffer();
+        RequirePreRender();
+    }
 }
 
 void DropDownList::SetColor(Clr c)

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -351,7 +351,9 @@ void DropDownList::RenderDisplayedRow()
         GUI::GetGUI()->PreRenderWindow(current_item);
     }
 
-    Pt offset = ClientUpperLeft() - current_item->UpperLeft();
+    // Vertically center the selected row in the box.
+    Pt offset = GG::Pt(ClientUpperLeft().x - current_item->ClientUpperLeft().x,
+                       Top() + Height() / 2 - (current_item->Top() + current_item->Height() / 2));
     current_item->OffsetMove(offset);
 
     BeginClipping();

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -308,6 +308,9 @@ void DropDownList::Render()
     RenderDisplayedRow();
 }
 
+GG::X DropDownList::DisplayedRowWidth() const
+{ return ClientWidth(); }
+
 void DropDownList::RenderDisplayedRow()
 {
     // Draw the ListBox::Row of currently displayed item, if any.

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -320,6 +320,8 @@ void DropDownList::RenderDisplayedRow()
     if (!visible)
         current_item->Show();
     BeginClipping();
+    // The following prerender is necessary because Show() is called after the prerender phase of GG.
+    GUI::GetGUI()->PreRenderWindow(current_item);
     GUI::GetGUI()->RenderWindow(current_item);
     EndClipping();
     current_item->OffsetMove(-offset);
@@ -431,11 +433,18 @@ void DropDownList::LockColWidths()
 void DropDownList::UnLockColWidths()
 { LB()->UnLockColWidths(); }
 
+void DropDownList::ManuallyManageColProps()
+{ LB()->ManuallyManageColProps(); }
+
 void DropDownList::SetColAlignment(std::size_t n, Alignment align) 
 { LB()->SetColAlignment(n, align); }
 
+
 void DropDownList::SetRowAlignment(iterator it, Alignment align) 
 { LB()->SetRowAlignment(it, align); }
+
+void DropDownList::NormalizeRowsOnInsert(bool enable /*= true*/)
+{ LB()->NormalizeRowsOnInsert(enable); }
 
 void DropDownList::LClick(const Pt& pt, Flags<ModKey> mod_keys)
 {

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -454,9 +454,11 @@ void DropDownList::ManuallyManageColProps()
 void DropDownList::SetColAlignment(std::size_t n, Alignment align) 
 { LB()->SetColAlignment(n, align); }
 
-
-void DropDownList::SetRowAlignment(iterator it, Alignment align) 
+void DropDownList::SetRowAlignment(iterator it, Alignment align)
 { LB()->SetRowAlignment(it, align); }
+
+void DropDownList::SetColStretch(std::size_t n, double stretch)
+{ LB()->SetColStretch(n, stretch); }
 
 void DropDownList::NormalizeRowsOnInsert(bool enable /*= true*/)
 { LB()->NormalizeRowsOnInsert(enable); }

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -317,6 +317,8 @@ void DropDownList::RenderDisplayedRow()
     if (CurrentItem() == LB()->end())
         return;
 
+    /** The following code possibly renders the selected row twice.  Once in the selected area and
+        also in the drop down list if it is visible.*/
     Row* current_item = *CurrentItem();
     bool sel_visible = current_item->Visible();
     bool lb_visible = LB()->Visible();
@@ -330,8 +332,6 @@ void DropDownList::RenderDisplayedRow()
         }
 
         current_item->Show();
-        const GG::Pt row_size(LB()->ClientWidth(), (*LB()->FirstRowShown())->Size().y);
-        current_item->Resize(row_size);
         GUI::GetGUI()->PreRenderWindow(current_item);
     }
 

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -860,8 +860,7 @@ void ListBox::PreRender()
             (*it)->Hide();
         else {
             (*it)->Show();
-            if ((*it)->PreRenderRequired())
-                (*it)->PreRender();
+            GUI::PreRenderWindow((*it));
         }
 
         if (it == last_visible_row)
@@ -869,10 +868,7 @@ void ListBox::PreRender()
     }
 
     if (!m_header_row->empty())
-        if (GG::Layout* lay = m_header_row->GetLayout()) {
-            if(lay->PreRenderRequired())
-                lay->PreRender();
-        }
+        GUI::PreRenderWindow(m_header_row);
 }
 void ListBox::Render()
 {
@@ -1884,6 +1880,8 @@ ListBox::iterator ListBox::Insert(Row* row, iterator it, bool dropped, bool sign
             Erase(original_dropped_position, true, false);
     }
 
+    row->Hide();
+
     if (signal)
         AfterInsertSignal(it);
 
@@ -1915,6 +1913,7 @@ void ListBox::Insert(const std::vector<Row*>& rows, iterator it, bool dropped, b
     {
         Row* row = *row_it;
         row->InstallEventFilter(this);
+        row->Hide();
     }
 
     // add row at requested location (or default end position)

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -205,7 +205,8 @@ ListBox::Row::Row() :
     Control(X0, Y0, DEFAULT_ROW_WIDTH, DEFAULT_ROW_HEIGHT),
     m_row_alignment(ALIGN_VCENTER),
     m_margin(2),
-    m_ignore_adjust_layout(false)
+    m_ignore_adjust_layout(false),
+    m_is_normalized(false)
 {}
 
 ListBox::Row::Row(X w, Y h, const std::string& drag_drop_data_type,
@@ -213,7 +214,8 @@ ListBox::Row::Row(X w, Y h, const std::string& drag_drop_data_type,
     Control(X0, Y0, w, h),
     m_row_alignment(align),
     m_margin(margin),
-    m_ignore_adjust_layout(false)
+    m_ignore_adjust_layout(false),
+    m_is_normalized(false)
 { SetDragDropDataType(drag_drop_data_type); }
 
 ListBox::Row::~Row()
@@ -253,6 +255,9 @@ X ListBox::Row::ColWidth(std::size_t n) const
 
 unsigned int ListBox::Row::Margin() const
 { return m_margin; }
+
+bool ListBox::Row::IsNormalized() const
+{ return m_is_normalized; }
 
 void ListBox::Row::Render()
 {}
@@ -396,6 +401,9 @@ void ListBox::Row::SetMargin(unsigned int margin)
     m_margin = margin;
     AdjustLayout();
 }
+
+void ListBox::Row::SetNormalized(bool normalized)
+{ m_is_normalized = normalized; }
 
 void ListBox::Row::AdjustLayout()
 {

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -26,18 +26,13 @@
 
 #include <GG/GUI.h>
 #include <GG/DrawUtil.h>
-#include <GG/Layout.h>
 #include <GG/DeferredLayout.h>
 #include <GG/Scroll.h>
-#include <GG/StaticGraphic.h>
 #include <GG/StyleFactory.h>
 #include <GG/TextControl.h>
-#include <GG/WndEvent.h>
 
 #include <boost/cast.hpp>
-#include <boost/assign/list_of.hpp>
 
-#include <cmath>
 #include <numeric>
 
 

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -1994,14 +1994,6 @@ ListBox::Row* ListBox::Erase(iterator it, bool removing_duplicate, bool signal)
 void ListBox::BringCaretIntoView()
 { BringRowIntoView(m_caret); }
 
-void ListBox::RecreateScrolls()
-{
-    delete m_vscroll;
-    delete m_hscroll;
-    m_vscroll = m_hscroll = 0;
-    RequirePreRender();
-}
-
 void ListBox::ResetAutoScrollVars()
 {
     m_auto_scrolling_up = false;

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -1461,11 +1461,13 @@ void ListBox::KeyPress(Key key, boost::uint32_t key_code_point, Flags<ModKey> mo
                 if (m_style & LIST_NOSEL) {
                     if (m_caret != m_rows.end())
                         delete Erase(m_caret, false, true);
-                } else {    // todo: check if erase invalidates iterators in m_selections and makes this loop problematic
-                    for (SelectionSet::iterator it = m_selections.begin(); it != m_selections.end(); ++it) {
+                } else {
+                    std::vector<iterator> prev_selections;
+                    std::copy(m_selections.begin(), m_selections.end(), prev_selections.begin());
+                    m_selections.clear();
+                    for (std::vector<iterator>::iterator it = prev_selections.begin(); it != prev_selections.end(); ++it) {
                         delete Erase(*it, false, true);
                     }
-                    m_selections.clear();
                 }
             } else {
                 // Pass delete on if we ignored it

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -219,9 +219,14 @@ ListBox::Row::Row(X w, Y h, const std::string& drag_drop_data_type,
 ListBox::Row::~Row()
 {}
 
-std::string ListBox::Row::SortKey(std::size_t column) const
+std::string ListBox::Row::SortKey(std::size_t col) const
 {
-    const TextControl* text_control = dynamic_cast<const TextControl*>(at(column));
+    if (col >= m_cells.size()) {
+        std::cout << "ListBox::Row::SortKey out of range column = " << col << " > num cols = " << m_cells.size();
+        return "";
+    }
+
+    const TextControl* text_control = dynamic_cast<const TextControl*>(at(col));
     return text_control ? text_control->Text() : "";
 }
 

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -1624,27 +1624,15 @@ bool ListBox::EventFilter(Wnd* w, const WndEvent& event)
     return true;
 }
 
-void ListBox::DefineColumnsAndAlignment(const Row& row)
+void ListBox::DefineColWidths(const Row& row)
 {
-    if (!m_manage_column_props)
-        return;
-
     const GG::X WIDTH = ClientSize().x - SCROLL_WIDTH;
 
-    m_num_cols = row.size();
     m_col_widths.resize(row.size());
-    m_col_alignments.resize(row.size());
     GG::X total_width = GG::X0;
     for (std::size_t i = 0; i < row.size(); ++i) {
         // use the column width from the Row
         total_width += row.ColWidth(i);
-
-        // use the column alignment from the Row, if it has been set;
-        // otherwise, use the one dictated by the ListBoxStyle flags
-        Alignment a = row.ColAlignment(i);
-        if (a == ALIGN_NONE)
-            a = AlignmentFromStyle(m_style);
-        m_col_alignments[i] = a;
     }
 
     const GG::X_d SCALE_FACTOR = 1.0 * WIDTH / total_width;
@@ -1654,9 +1642,19 @@ void ListBox::DefineColumnsAndAlignment(const Row& row)
         total_scaled_width += (m_col_widths[i] = row.ColWidth(i) * SCALE_FACTOR);
     }
     m_col_widths.back() += total_scaled_width - WIDTH;
+}
 
-    if (!m_header_row->empty() && m_normalize_rows_on_insert)
-        NormalizeRow(m_header_row);
+void ListBox::DefineColAlignments(const Row& row)
+{
+    m_col_alignments.resize(row.size());
+    for (std::size_t i = 0; i < row.size(); ++i) {
+        // use the column alignment from the Row, if it has been set;
+        // otherwise, use the one dictated by the ListBoxStyle flags
+        Alignment a = row.ColAlignment(i);
+        if (a == ALIGN_NONE)
+            a = AlignmentFromStyle(m_style);
+        m_col_alignments[i] = a;
+    }
 }
 
 ListBox::iterator ListBox::Insert(Row* row, iterator it, bool dropped, bool signal)
@@ -1671,8 +1669,10 @@ ListBox::iterator ListBox::Insert(Row* row, iterator it, bool dropped, bool sign
 
     // The first row inserted into an empty list box defines the number of
     // columns, and initializes the column widths and alignments.
-    if (m_rows.empty() && (m_col_widths.empty() || !m_keep_col_widths))
-        DefineColumnsAndAlignment(*row);
+    if (m_rows.empty() && (m_col_widths.empty() || !m_keep_col_widths)) {
+        DefineColWidths(*row);
+        DefineColAlignments(*row);
+    }
 
     row->InstallEventFilter(this);
     if (m_normalize_rows_on_insert)
@@ -1746,8 +1746,10 @@ void ListBox::Insert(const std::vector<Row*>& rows, iterator it, bool dropped, b
 
     // The first row inserted into an empty list box defines the number of
     // columns, and initializes the column widths and alignments.
-    if (m_col_widths.empty() || !m_keep_col_widths)
-        DefineColumnsAndAlignment(*(*rows.begin()));
+    if (m_col_widths.empty() || !m_keep_col_widths) {
+        DefineColWidths(*(*m_rows.begin()));
+        DefineColAlignments(*(*m_rows.begin()));
+    }
 
     // housekeeping of rows...
     for (std::vector<Row*>::const_iterator row_it = rows.begin();
@@ -2247,15 +2249,10 @@ void ListBox::NormalizeRow(Row* row)
     assert(m_num_cols);
     Row::DeferAdjustLayout defer_adjust_layout(row);
     row->SetMargin(m_cell_margin);
-    if (m_manage_column_props) {
-        row->resize(m_num_cols);
-        row->SetColWidths(m_col_widths);
-        row->SetColAlignments(m_col_alignments);
-        row->Resize(Pt(std::accumulate(m_col_widths.begin(), m_col_widths.end(), X0), row->Height()));
-    } else {
-        row->ClearColWidths();
-        row->ClearColAlignments();
-    }
+    row->resize(m_num_cols);
+    row->SetColWidths(m_col_widths);
+    row->SetColAlignments(m_col_alignments);
+    row->Resize(Pt(ClientWidth(), row->Height()));
 }
 
 ListBox::iterator ListBox::FirstRowShownWhenBottomIs(iterator bottom_row, Y client_height)

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -949,21 +949,6 @@ void ListBox::Render()
         GUI::GetGUI()->RenderWindow(m_vscroll);
     if (m_hscroll)
         GUI::GetGUI()->RenderWindow(m_hscroll);
-
-    // ensure that data in occluded cells is not rendered
-    bool hide = true;
-    for (iterator it = m_rows.begin(); it != m_rows.end(); ++it) {
-        if (it == m_first_row_shown)
-            hide = false;
-
-        if (hide)
-            (*it)->Hide();
-        else
-            (*it)->Show();
-
-        if (it == last_visible_row)
-            hide = true;
-    }
 }
 
 void ListBox::SizeMove(const Pt& ul, const Pt& lr)

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -1123,21 +1123,24 @@ void ListBox::SetNumCols(std::size_t n)
 {
     assert(n);
     m_num_cols = n;
-    if (m_col_widths.size()) {
-        m_col_widths.resize(n);
-        m_col_alignments.resize(n);
-    } else {
-        m_col_widths.resize(n, ClientSize().x / static_cast<int>(n));
-        m_col_widths.back() += ClientSize().x % static_cast<int>(n);
-        Alignment alignment = ALIGN_NONE;
-        if (m_style & LIST_LEFT)
-            alignment = ALIGN_LEFT;
-        if (m_style & LIST_CENTER)
-            alignment = ALIGN_CENTER;
-        if (m_style & LIST_RIGHT)
-            alignment = ALIGN_RIGHT;
-        m_col_alignments.resize(n, alignment);
+    if (m_manage_column_props) {
+        if (m_col_widths.size()) {
+            m_col_widths.resize(n);
+            m_col_alignments.resize(n, ALIGN_NONE);
+        } else {
+            m_col_widths.resize(n, ClientSize().x / static_cast<int>(n));
+            m_col_widths.back() += ClientSize().x % static_cast<int>(n);
+            Alignment alignment = ALIGN_NONE;
+            if (m_style & LIST_LEFT)
+                alignment = ALIGN_LEFT;
+            if (m_style & LIST_CENTER)
+                alignment = ALIGN_CENTER;
+            if (m_style & LIST_RIGHT)
+                alignment = ALIGN_RIGHT;
+            m_col_alignments.resize(n, alignment);
+        }
     }
+
     if (n <= m_sort_col)
         m_sort_col = 0;
     for (iterator it = m_rows.begin(); it != m_rows.end(); ++it) {
@@ -1148,9 +1151,11 @@ void ListBox::SetNumCols(std::size_t n)
 
 void ListBox::SetColWidth(std::size_t n, X w)
 {
-    if (m_num_cols < n + 1) {
+    if (m_num_cols < n + 1)
         m_num_cols = n + 1;
-    }
+    if (m_col_widths.size() < n + 1)
+        m_col_widths.resize(n + 1);
+
     m_col_widths[n] = w;
     for (iterator it = m_rows.begin(); it != m_rows.end(); ++it) {
         (*it)->SetColWidth(n, w);
@@ -1161,9 +1166,9 @@ void ListBox::SetColWidth(std::size_t n, X w)
 void ListBox::SetSortCol(std::size_t n)
 {
     bool needs_resort = m_sort_col != n && !(m_style & LIST_NOSORT);
-    if (m_num_cols < n + 1) {
+    if (m_num_cols < n + 1)
         m_num_cols = n + 1;
-    }
+
     m_sort_col = n;
     if (needs_resort)
         Resort();
@@ -1193,6 +1198,11 @@ void ListBox::ManuallyManageColProps()
 
 void ListBox::SetColAlignment(std::size_t n, Alignment align)
 {
+    if (m_num_cols < n + 1)
+        m_num_cols = n + 1;
+    if (m_col_alignments.size() < n + 1)
+        m_col_alignments.resize(n + 1);
+
     m_col_alignments[n] = align;
     for (iterator it = m_rows.begin(); it != m_rows.end(); ++it) {
         (*it)->SetColAlignment(n, align);

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -1168,15 +1168,15 @@ void ListBox::SetFirstRowShown(iterator it)
     if (it != m_rows.end()) {
         RequirePreRender();
         m_first_row_shown = it;
+
+        AdjustScrolls(false);
+
         if (m_vscroll) {
             Y acc(0);
             for (iterator it2 = m_rows.begin(); it2 != m_first_row_shown; ++it2)
                 acc += (*it2)->Height();
             m_vscroll->ScrollTo(Value(acc));
             SignalScroll(*m_vscroll, true);
-        } else {
-            std::size_t row_num = std::distance(m_rows.begin(), m_first_row_shown);
-            VScrolled(row_num, 0, 0, 0);
         }
     }
 }

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -839,7 +839,8 @@ void ListBox::PreRender()
 
     // Ensure that data in occluded cells is not rendered
     // and that any re-layout during prerender is immediate.
-    iterator last_visible_row = LastVisibleRow();
+    Y visible_height(0);
+    Y max_visible_height = ClientSize().y;
     bool hide = true;
     for (iterator it = m_rows.begin(); it != m_rows.end(); ++it) {
         if (it == m_first_row_shown)
@@ -850,10 +851,11 @@ void ListBox::PreRender()
         } else {
             (*it)->Show();
             GUI::PreRenderWindow(*it);
-        }
 
-        if (it == last_visible_row)
-            hide = true;
+            visible_height += (*it)->Height();
+            if (visible_height >= max_visible_height)
+                hide = true;
+        }
     }
 
     if (!m_header_row->empty())

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -1832,6 +1832,9 @@ void ListBox::DefineColStretches(const Row& row)
 
 ListBox::iterator ListBox::Insert(Row* row, iterator it, bool dropped, bool signal)
 {
+    if(!row)
+        return m_rows.end();
+
     // Track the originating row in case this is an intra-ListBox
     // drag-and-drop.
     iterator original_dropped_position = m_rows.end();

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -2221,6 +2221,7 @@ void ListBox::AdjustScrolls(bool adjust_for_resize)
         }
     } else if (!m_hscroll && horizontal_needed) { // if scroll doesn't exist but is needed
         m_hscroll = style->NewListBoxHScroll(m_color, CLR_SHADOW);
+        m_hscroll->NonClientChild(true);
         m_hscroll->MoveTo(Pt(X0, cl_sz.y - SCROLL_WIDTH));
         m_hscroll->Resize(Pt(cl_sz.x - (vertical_needed ? SCROLL_WIDTH : 0), Y(SCROLL_WIDTH)));
 

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -948,8 +948,6 @@ void ListBox::SizeMove(const Pt& ul, const Pt& lr)
 
     const GG::Pt old_size = Size();
     Wnd::SizeMove(ul, lr);
-    if (!m_header_row->empty())
-        NormalizeRow(m_header_row);
     AdjustScrolls(true);
     if (old_size != Size())
         RequirePreRender();
@@ -1234,13 +1232,14 @@ void ListBox::SetColHeaders(Row* r)
         if (m_manage_column_props && m_rows.empty() && m_col_widths.empty()) {
             m_num_cols = m_header_row->size();
             m_col_widths.resize(m_header_row->size(),
-                                (ClientSize().x - SCROLL_WIDTH) / static_cast<int>(m_header_row->size()));
-            // put the remainder in the last column, so the total width == ClientSize().x - SCROLL_WIDTH
-            m_col_widths.back() += (ClientSize().x - SCROLL_WIDTH) % static_cast<int>(m_header_row->size());
+                                ClientWidth() / static_cast<int>(m_header_row->size()));
+            // put the remainder in the last column, so the total width == ClientWidth()
+            m_col_widths.back() += ClientWidth() % static_cast<int>(m_header_row->size());
             m_col_alignments.resize(m_header_row->size(), AlignmentFromStyle(m_style));
             m_col_stretches.resize(m_header_row->size(), 0.0);
         }
-        NormalizeRow(m_header_row);
+        if (m_normalize_rows_on_insert)
+            NormalizeRow(m_header_row);
         m_header_row->MoveTo(Pt(X0, -m_header_row->Height()));
         AttachChild(m_header_row);
     } else {

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -931,21 +931,6 @@ void ListBox::Render()
 
 void ListBox::SizeMove(const Pt& ul, const Pt& lr)
 {
-    // TODO: fix incomplete/wrong resizing of widths.  This current call to NormalizeRow appears to force the header 
-    // columns to fit the previous widths rather than adapting them all to the new width akin to what is done when the
-    // first rown is inserted with Insert().  The places where I believe this failure makes noticeable problems are
-    // with the multiplayer galaxy setup panel and with the SitRep panel.  In the former, a post-creation SizeMove
-    // making it more narrow was causing the dropdowns to get unneeded and blocking horizonal scrollbars.  Extra 
-    // debugging logging had shown that when the galaxy panel dropdowns (listbox's) were made more narrow, their
-    // column width was left unchanged, convincing ListBox that it now needed a horizontal scrollbar.  The workaround
-    // for that being put into place in this same commit is to have that panel simply be made the desired size to begin
-    // with rather than later being resized.  I believe the same failure leads to a different symptom with the 
-    // SitRepPanel.  There it has no horizontal scroll and instead uses wraparaound, but when resized the SitRep panel
-    // is forced delete and remake those (listbox) Rows whose wraparound status would be changed by the new width.  I
-    // believe this makes it's resizing behavior noticeably jerky-- the jerkiness had been far worse until recently
-    // because it was simply recreating all rows rather than only those really impacted by the change in width.
-    // My initial experiments to resolve this here have failed; hence this long comment.
-
     const GG::Pt old_size = Size();
     Wnd::SizeMove(ul, lr);
     AdjustScrolls(true);

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -2060,6 +2060,7 @@ void ListBox::Resort()
     RestoreCachedSelections(*cached_selections);
 
     m_first_row_shown = m_rows.empty() ? m_rows.end() : m_rows.begin();
+    SetFirstRowShown(m_first_row_shown);
 }
 
 ListBox::Row& ListBox::ColHeaders()

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -1143,13 +1143,13 @@ void ListBox::BringRowIntoView(iterator it)
             it_found = true;
         }
 
-        if (first_row_found && !last_row_found) {
+        if (first_row_found && !last_row_found)
             last_row_y_offset = y_offset;
-            if (y_offset >= ClientHeight()) {
-                last_row_found = true;
-            }
-            y_offset += (*it2)->Height();
-        }
+
+        if ((y_offset - first_row_y_offset) >= ClientHeight())
+            last_row_found = true;
+
+        y_offset += (*it2)->Height();
         ++it2;
     }
 

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -886,12 +886,6 @@ void ListBox::Render()
     BeginClipping();
 
     // draw selection hiliting
-
-    // Note that inside the for loop below, prev_sel is guaranteed to be valid
-    // (i.e. != m_rows.end()), since a non-empty m_selections implies a
-    // non-empty m_rows, and a non-empty m_rows implies a valid
-    // m_first_row_shown.
-    iterator prev_sel = m_first_row_shown;
     Y top(0);
     Y bottom = (*m_first_row_shown)->Height();
     for (SelectionSet::iterator sel_it = m_selections.begin(); sel_it != m_selections.end(); ++sel_it) {
@@ -899,21 +893,10 @@ void ListBox::Render()
         if (RowAboveOrIsRow(m_first_row_shown, curr_sel, m_rows.end()) &&
             RowAboveOrIsRow(curr_sel, last_visible_row, m_rows.end()))
         {
-            // No need to look for the current selection's top, if it is the
-            // same as the bottom of the last iteration.
-            if (boost::next(prev_sel) == curr_sel) {
-                top = bottom;
-            } else {
-                for (iterator it = prev_sel; it != curr_sel; ++it) {
-                    top += (*it)->Height();
-                }
-            }
-            bottom = top + (*curr_sel)->Height();
-            if (cl_lr.y < bottom)
-                bottom = cl_lr.y;
+            top = std::max((*curr_sel)->Top(), cl_ul.y);
+            bottom = std::min(top + (*curr_sel)->Height(), cl_lr.y);
             FlatRectangle(Pt(cl_ul.x, cl_ul.y + top), Pt(cl_lr.x, cl_ul.y + bottom),
                           hilite_color_to_use, CLR_ZERO, 0);
-            prev_sel = curr_sel;
         }
     }
 

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -811,10 +811,8 @@ void ListBox::PreRender()
             (*it)->Hide();
         else {
             (*it)->Show();
-            if (GG::Layout* lay = (*it)->GetLayout()) {
-                if(lay->PreRenderRequired())
-                    lay->PreRender();
-            }
+            if ((*it)->PreRenderRequired())
+                (*it)->PreRender();
         }
 
         if (it == last_visible_row)

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -27,6 +27,7 @@
 #include <GG/GUI.h>
 #include <GG/DrawUtil.h>
 #include <GG/Layout.h>
+#include <GG/DeferredLayout.h>
 #include <GG/Scroll.h>
 #include <GG/StaticGraphic.h>
 #include <GG/StyleFactory.h>
@@ -379,7 +380,7 @@ void ListBox::Row::AdjustLayout()
     if (!nonempty_cell_found)
         return;
 
-    SetLayout(new Layout(X0, Y0, Width(), Height(), 1, m_cells.size(), m_margin, m_margin));
+    SetLayout(new DeferredLayout(X0, Y0, Width(), Height(), 1, m_cells.size(), m_margin, m_margin));
     Layout* layout = GetLayout();
     for (std::size_t i = 0; i < m_cells.size(); ++i) {
         layout->SetMinimumColumnWidth(i, m_col_widths[i]);

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -2147,7 +2147,6 @@ void ListBox::AdjustScrolls(bool adjust_for_resize)
                            (cl_sz.x < total_x_extent - SCROLL_WIDTH &&
                             cl_sz.y < total_y_extent - SCROLL_WIDTH)));
 
-
     if (m_add_padding_at_end) {
         // This probably looks a little odd. We only want to show scrolls if they
         // are needed, that is if the data shown exceed the bounds of the client
@@ -2165,7 +2164,6 @@ void ListBox::AdjustScrolls(bool adjust_for_resize)
     boost::shared_ptr<StyleFactory> style = GetStyleFactory();
 
     bool vscroll_added_or_removed(false);
-
 
     // Remove unecessary vscroll
     if (m_vscroll && !vertical_needed) {

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -897,7 +897,7 @@ void ListBox::Render()
         {
             top = std::max((*curr_sel)->Top(), cl_ul.y);
             bottom = std::min(top + (*curr_sel)->Height(), cl_lr.y);
-            FlatRectangle(Pt(cl_ul.x, cl_ul.y + top), Pt(cl_lr.x, cl_ul.y + bottom),
+            FlatRectangle(Pt(cl_ul.x, top), Pt(cl_lr.x, bottom),
                           hilite_color_to_use, CLR_ZERO, 0);
         }
     }

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -360,7 +360,7 @@ void ListBox::Row::SetMargin(unsigned int margin)
     AdjustLayout();
 }
 
-void ListBox::Row::AdjustLayout(bool adjust_for_push_back/* = false*/)
+void ListBox::Row::AdjustLayout()
 {
     if (m_ignore_adjust_layout)
         return;

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -1012,8 +1012,6 @@ void ListBox::Clear()
     DetachChild(m_header_row);
     DeleteChildren();
     AttachChild(m_header_row);
-    m_vscroll = 0;
-    m_hscroll = 0;
     m_first_row_offset = Pt(X0, Y0);
     m_first_row_shown = m_rows.end();
     m_first_col_shown = 0;
@@ -1030,7 +1028,10 @@ void ListBox::Clear()
             m_num_cols = 1;
     }
 
-    AdjustScrolls(false);
+    DeleteChild(m_vscroll);
+    m_vscroll = 0;
+    DeleteChild(m_hscroll);
+    m_hscroll = 0;
 
     if (m_iterator_being_erased)
         *m_iterator_being_erased = m_rows.end();

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -2388,9 +2388,7 @@ void ListBox::NormalizeRow(Row* row)
 
 ListBox::iterator ListBox::FirstRowShownWhenBottomIs(iterator bottom_row, Y client_height)
 {
-    if (bottom_row == m_rows.end())
-        return m_rows.begin();
-    Y available_space = client_height - (*bottom_row)->Height();
+    Y available_space = client_height;
     iterator it = bottom_row;
     while (it != m_rows.begin() && (*boost::prior(it))->Height() <= available_space) {
         available_space -= (*--it)->Height();

--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -869,7 +869,7 @@ void BuildDesignatorWnd::BuildSelector::PopulateList() {
     }
 
     if (new_first_row_it != m_buildable_items->end()) {
-        m_buildable_items->SetFirstRowShown(new_first_row_it);
+        m_buildable_items->BringRowIntoView(new_first_row_it);
     } else {
         if (!m_buildable_items->Empty())
             m_buildable_items->BringRowIntoView(--m_buildable_items->end());

--- a/UI/BuildingsPanel.cpp
+++ b/UI/BuildingsPanel.cpp
@@ -267,7 +267,7 @@ BuildingIndicator::BuildingIndicator(GG::X w, int building_id) :
     m_order_issuing_enabled(true)
 {
     if (TemporaryPtr<const Building> building = GetBuilding(m_building_id))
-        GG::Connect(building->StateChangedSignal,   &BuildingIndicator::Refresh,     this);
+        GG::Connect(building->StateChangedSignal,   &BuildingIndicator::RequirePreRender,     this);
     Refresh();
 }
 
@@ -295,7 +295,7 @@ BuildingIndicator::BuildingIndicator(GG::X w, const std::string& building_type,
                                               ClientUI::TechWndProgressBarColor(), GG::LightColor(ClientUI::ResearchableTechFillColor()));
     AttachChild(m_progress_bar);
 
-    Refresh();
+    RequirePreRender();
 }
 
 void BuildingIndicator::Render() {
@@ -336,6 +336,11 @@ void BuildingIndicator::Render() {
     glEnable(GL_TEXTURE_2D);
 
     s_scanline_shader.StopUsing();
+}
+
+void BuildingIndicator::PreRender() {
+    GG::Wnd::PreRender();
+    Refresh();
 }
 
 void BuildingIndicator::Refresh() {

--- a/UI/BuildingsPanel.cpp
+++ b/UI/BuildingsPanel.cpp
@@ -67,11 +67,11 @@ BuildingsPanel::BuildingsPanel(GG::X w, int columns, int planet_id) :
     if (planet) {
         if (const Empire* empire = GetEmpire(planet->Owner())) {
             const ProductionQueue& queue = empire->GetProductionQueue();
-            GG::Connect(queue.ProductionQueueChangedSignal, &BuildingsPanel::Refresh, this);
+            GG::Connect(queue.ProductionQueueChangedSignal, &BuildingsPanel::RequirePreRender, this);
         }
     }
 
-    Refresh();
+    RequirePreRender();
 }
 
 BuildingsPanel::~BuildingsPanel() {
@@ -165,7 +165,16 @@ void BuildingsPanel::Update() {
     }
 }
 
+void BuildingsPanel::PreRender() {
+    AccordionPanel::PreRender();
+    RefreshImpl();
+}
+
 void BuildingsPanel::Refresh() {
+    RequirePreRender();
+}
+
+void BuildingsPanel::RefreshImpl() {
     Update();
     DoLayout();
 }

--- a/UI/BuildingsPanel.h
+++ b/UI/BuildingsPanel.h
@@ -21,13 +21,13 @@ public:
     //@}
 
     /** \name Mutators */ //@{
-    /** expands or collapses panel to show details or just summary info */
-    void ExpandCollapse(bool expanded);
+    virtual void PreRender();
 
-    /** updates indicators with values of associated object.  Does not do layout and resizing. */
-    void Update();
     /** updates, redoes layout, resizes indicator */
     void Refresh();
+
+    /** expands or collapses panel to show details or just summary info */
+    void ExpandCollapse(bool expanded);
 
     /** Enables, or disables if \a enable is false, issuing orders via this panel. */
     void EnableOrderIssuing(bool enable = true);
@@ -37,6 +37,10 @@ public:
 
 protected:
     /** \name Mutators */ //@{
+    /** updates indicators with values of associated object.  Does not do layout and resizing. */
+    void Update();
+    void RefreshImpl();
+
     /** resizes panel and positions widgets */
     virtual void DoLayout();
     //@}

--- a/UI/BuildingsPanel.h
+++ b/UI/BuildingsPanel.h
@@ -68,8 +68,8 @@ public:
                       double turns_completed, double total_turns, double total_cost, double turn_spending);
 
     /** \name Mutators */ //@{
+    virtual void PreRender();
     virtual void    Render();
-    void            Refresh();
 
     virtual void    SizeMove(const GG::Pt& ul, const GG::Pt& lr);
     virtual void    MouseWheel(const GG::Pt& pt, int move, GG::Flags<GG::ModKey> mod_keys);
@@ -82,6 +82,7 @@ public:
     mutable boost::signals2::signal<void (int)> RightClickedSignal;
 
 private:
+    void            Refresh();
     void            DoLayout();
 
     static ScanlineRenderer s_scanline_shader;

--- a/UI/CUIControls.cpp
+++ b/UI/CUIControls.cpp
@@ -822,6 +822,14 @@ void CUIDropDownList::Render() {
     RenderDisplayedRow();
 }
 
+GG::Pt CUIDropDownList::ClientLowerRight() const {
+    GG::Pt sz = Size();
+    int margin = 3;
+    int triangle_width = Value(sz.y - 4 * margin);
+    int outline_width = triangle_width + 3 * margin;
+    return DropDownList::LowerRight() - GG::Pt((m_render_drop_arrow ? GG::X(outline_width) : GG::X0), GG::Y0);
+}
+
 void CUIDropDownList::LClick(const GG::Pt& pt, GG::Flags<GG::ModKey> mod_keys) {
     if (!Disabled())
         PlayDropDownListOpenSound();

--- a/UI/CUIControls.cpp
+++ b/UI/CUIControls.cpp
@@ -717,7 +717,6 @@ void CUIScroll::SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
 CUIListBox::CUIListBox(void):
     ListBox(ClientUI::CtrlBorderColor(), ClientUI::CtrlColor())
 {
-    RecreateScrolls();
     GG::Connect(SelChangedSignal,   &PlayListSelectSound,   -1);
     GG::Connect(DroppedSignal,      &PlayItemDropSound,     -1);
 }

--- a/UI/CUIControls.cpp
+++ b/UI/CUIControls.cpp
@@ -822,13 +822,15 @@ void CUIDropDownList::Render() {
     RenderDisplayedRow();
 }
 
-GG::Pt CUIDropDownList::ClientLowerRight() const {
+GG::X CUIDropDownList::DisplayedRowWidth() const
+{
     GG::Pt sz = Size();
     int margin = 3;
     int triangle_width = Value(sz.y - 4 * margin);
     int outline_width = triangle_width + 3 * margin;
-    return DropDownList::LowerRight() - GG::Pt((m_render_drop_arrow ? GG::X(outline_width) : GG::X0), GG::Y0);
+    return GG::X(DropDownList::Width() - (m_render_drop_arrow ? GG::X(outline_width + 2 * margin) : GG::X0));
 }
+
 
 void CUIDropDownList::LClick(const GG::Pt& pt, GG::Flags<GG::ModKey> mod_keys) {
     if (!Disabled())

--- a/UI/CUIControls.cpp
+++ b/UI/CUIControls.cpp
@@ -13,6 +13,7 @@
 #include "TextBrowseWnd.h"
 
 #include <GG/GUI.h>
+#include <GG/Layout.h>
 #include <GG/DrawUtil.h>
 #include <GG/dialogs/ColorDlg.h>
 
@@ -1427,9 +1428,11 @@ namespace {
             GG::Label* species_name = new CUILabel(UserString(species->Name()), GG::FORMAT_LEFT);
             species_name->Resize(GG::Pt(Width() - GG::X(Value(h)), h));
             push_back(species_name);
-            GG::X first_col_width(Value(h) - 10);
+            GG::X first_col_width(Value(h) - 2);
             SetColWidth(0, first_col_width);
             SetColWidth(1, w - first_col_width);
+            GetLayout()->SetColumnStretch(0, 0.0);
+            GetLayout()->SetColumnStretch(1, 1.0);
             SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
             SetBrowseInfoWnd(boost::shared_ptr<GG::BrowseInfoWnd>(
                 new IconTextBrowseWnd(ClientUI::SpeciesIcon(species->Name()),
@@ -1444,6 +1447,10 @@ namespace {
 SpeciesSelector::SpeciesSelector(GG::X w, GG::Y h) :
     CUIDropDownList(6)
 {
+    ManuallyManageColProps();
+    NormalizeRowsOnInsert(false);
+    SetNumCols(2);
+
     Resize(GG::Pt(w, h - 8));
     const SpeciesManager& sm = GetSpeciesManager();
     for (SpeciesManager::playable_iterator it = sm.playable_begin(); it != sm.playable_end(); ++it)

--- a/UI/CUIControls.h
+++ b/UI/CUIControls.h
@@ -265,7 +265,8 @@ public:
     explicit CUIDropDownList(size_t num_shown_elements); ///< basic ctor
     //@}
 
-    virtual GG::Pt ClientLowerRight() const;
+    /** Return the width of the displayed row which excludes the DropArrow. */
+    virtual GG::X  DisplayedRowWidth() const;
 
     /** \name Mutators */ //@{
     virtual void    Render();

--- a/UI/CUIControls.h
+++ b/UI/CUIControls.h
@@ -265,6 +265,8 @@ public:
     explicit CUIDropDownList(size_t num_shown_elements); ///< basic ctor
     //@}
 
+    virtual GG::Pt ClientLowerRight() const;
+
     /** \name Mutators */ //@{
     virtual void    Render();
     virtual void    LClick(const GG::Pt& pt, GG::Flags<GG::ModKey> mod_keys);

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -492,7 +492,11 @@ PartsListBox::PartsListBox(void) :
     m_availabilities_shown(std::make_pair(false, false)),
     m_show_superfluous_parts(true),
     m_previous_num_columns(-1)
-{ SetStyle(GG::LIST_NOSEL); }
+{
+    ManuallyManageColProps();
+    NormalizeRowsOnInsert(false);
+    SetStyle(GG::LIST_NOSEL);
+}
 
 const std::set<ShipPartClass>& PartsListBox::GetClassesShown() const
 { return m_part_classes_shown; }
@@ -1622,9 +1626,8 @@ GG::Pt BasesListBox::ListRowSize()
 void BasesListBox::InitRowSizes() {
     // preinitialize listbox/row column widths, because what
     // ListBox::Insert does on default is not suitable for this case
-    SetNumCols(1);
-    SetColWidth(0, GG::X0);
-    LockColWidths();
+    ManuallyManageColProps();
+    NormalizeRowsOnInsert(false);
 }
 
 void BasesListBox::PopulateWithEmptyHulls() {

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -535,7 +535,8 @@ EncyclopediaDetailPanel::EncyclopediaDetailPanel(GG::Flags<GG::WndFlag> flags, c
     m_description_panel(0),
     m_icon(0),
     m_search_edit(0),
-    m_graph(0)
+    m_graph(0),
+    m_needs_refresh(false)
 {
     const int PTS = ClientUI::Pts();
     const int NAME_PTS = PTS*3/2;
@@ -616,11 +617,6 @@ EncyclopediaDetailPanel::EncyclopediaDetailPanel(GG::Flags<GG::WndFlag> flags, c
 EncyclopediaDetailPanel::~EncyclopediaDetailPanel() {
     if (m_graph && m_graph->Parent() != this)
     delete m_graph;
-}
-
-void EncyclopediaDetailPanel::PreRender() {
-    GG::Wnd::PreRender();
-    DoLayout();
 }
 
 void EncyclopediaDetailPanel::DoLayout() {
@@ -2635,6 +2631,22 @@ namespace {
 }
 
 void EncyclopediaDetailPanel::Refresh() {
+    m_needs_refresh = true;
+    RequirePreRender();
+}
+
+void EncyclopediaDetailPanel::PreRender() {
+    CUIWnd::PreRender();
+
+    if (m_needs_refresh) {
+        m_needs_refresh = false;
+        RefreshImpl();
+    }
+
+    DoLayout();
+}
+
+void EncyclopediaDetailPanel::RefreshImpl() {
     if (m_icon) {
         DeleteChild(m_icon);
         m_icon = 0;
@@ -2740,8 +2752,6 @@ void EncyclopediaDetailPanel::Refresh() {
 
     if (!detailed_description.empty())
         m_description_box->SetText(detailed_description);
-
-    DoLayout();
 
     m_description_panel->ScrollTo(GG::Y0);
 }

--- a/UI/EncyclopediaDetailPanel.h
+++ b/UI/EncyclopediaDetailPanel.h
@@ -87,6 +87,7 @@ protected:
 
 private:
     void            DoLayout();
+    void            RefreshImpl();
 
     virtual void    CloseClicked();
 
@@ -111,6 +112,7 @@ private:
     GG::Edit*           m_search_edit;      // box to type to search
 
     GraphControl*       m_graph;
+    bool                m_needs_refresh;    ///< Indicates that data is stale.
 };
 
 

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -2978,6 +2978,11 @@ void FleetWnd::Init(int selected_fleet_id) {
     DoLayout();
 }
 
+void FleetWnd::PreRender() {
+    MapWndPopup::PreRender();
+    Refresh();
+}
+
 GG::Rect FleetWnd::CalculatePosition() const {
     GG::Pt ul(GG::X(5), GG::GUI::GetGUI()->AppHeight() - FLEET_WND_HEIGHT - 5);
     GG::Pt wh(FLEET_WND_WIDTH, FLEET_WND_HEIGHT);
@@ -3707,7 +3712,7 @@ void FleetWnd::FleetRightClicked(GG::ListBox::iterator it, const GG::Pt& pt, con
             GetUniverse().ForgetKnownObject(ALL_EMPIRES, fleet->ID());
 
             // Force a redraw
-            this->Refresh();
+            RequirePreRender();
             ClientUI::GetClientUI()->GetMapWnd()->RemoveFleet(fleet->ID());
 
             break;
@@ -3828,7 +3833,7 @@ void FleetWnd::SystemChangedSlot() {
         return;
     }
 
-    Refresh();
+    RequirePreRender();
 }
 
 void FleetWnd::EnableOrderIssuing(bool enable/* = true*/) {

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -2299,11 +2299,8 @@ private:
     }
 
     void            InitRowSizes() {
-        // preinitialize listbox/row column widths, because what
-        // ListBox::Insert does on default is not suitable for this case
         SetNumCols(1);
-        SetColWidth(0, GG::X0);
-        LockColWidths();
+        ManuallyManageColProps();
     }
 
     iterator    m_highlighted_row_it;
@@ -2337,11 +2334,8 @@ public:
 
         // repopulate list with ships in current fleet
 
-        // preinitialize listbox/row column widths, because what
-        // ListBox::Insert does on default is not suitable for this case
         SetNumCols(1);
-        SetColWidth(0, GG::X0);
-        LockColWidths();
+        ManuallyManageColProps();
 
         int this_client_empire_id = HumanClientApp::GetApp()->EmpireID();
         const std::set<int>& this_client_known_destroyed_objects =

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -2283,7 +2283,12 @@ private:
             return;
         }
 
-
+        // Do not un-highlight a row from the selection set since rows in the selection set and the
+        // drop target use the same graphical highlight effect.
+        if (Selected(m_highlighted_row_it)) {
+            m_highlighted_row_it = end();
+            return;
+        }
 
         GG::ListBox::Row* selected_row = *m_highlighted_row_it;
         if (!selected_row) {

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -1714,8 +1714,6 @@ void FleetDataPanel::DoLayout() {
 void FleetDataPanel::Init() {
     m_initialized = true;
 
-    SectionedScopedTimer timer("FleetDataPanel::Init", boost::chrono::microseconds(30));
-    timer.EnterSection("init");
     m_fleet_name_text = new CUILabel("", GG::FORMAT_LEFT);
     AttachChild(m_fleet_name_text);
     m_fleet_destination_text = new CUILabel("", GG::FORMAT_RIGHT);
@@ -1730,7 +1728,6 @@ void FleetDataPanel::Init() {
         GG::Connect(m_aggression_toggle->LeftClickedSignal, &FleetDataPanel::AggressionToggleButtonPressed, this);
 
     } else if (TemporaryPtr<const Fleet> fleet = GetFleet(m_fleet_id)) {
-        timer.EnterSection("icon setup");
         int tooltip_delay = GetOptionsDB().Get<int>("UI.tooltip-delay");
 
         // stat icon for fleet count
@@ -1742,7 +1739,6 @@ void FleetDataPanel::Init() {
         icon->InstallEventFilter(this);
         AttachChild(icon);
 
-        timer.EnterSection("armed");
         if (fleet->HasArmedShips()) {
             // stat icon for fleet damage
             icon = new StatisticIcon(DamageIcon(), 0, 0, false,
@@ -1809,7 +1805,6 @@ void FleetDataPanel::Init() {
             AttachChild(icon);
         }
 
-        timer.EnterSection("structure");
         // stat icon for fleet structure
         icon = new StatisticIcon(ClientUI::MeterIcon(METER_STRUCTURE), 0, 0, false,
                                  GG::X0, GG::Y0, StatIconSize().x, StatIconSize().y);
@@ -1819,7 +1814,6 @@ void FleetDataPanel::Init() {
         icon->InstallEventFilter(this);
         AttachChild(icon);
 
-        timer.EnterSection("shields");
         // stat icon for fleet shields
         icon = new StatisticIcon(ClientUI::MeterIcon(METER_SHIELD), 0, 0, false,
                                  GG::X0, GG::Y0, StatIconSize().x, StatIconSize().y);
@@ -1829,7 +1823,6 @@ void FleetDataPanel::Init() {
         icon->InstallEventFilter(this);
         AttachChild(icon);
 
-        timer.EnterSection("fuel");
         // stat icon for fleet fuel
         icon = new StatisticIcon(ClientUI::MeterIcon(METER_FUEL), 0, 0, false,
                                  GG::X0, GG::Y0, StatIconSize().x, StatIconSize().y);
@@ -1839,7 +1832,6 @@ void FleetDataPanel::Init() {
         icon->InstallEventFilter(this);
         AttachChild(icon);
 
-        timer.EnterSection("speed");
         // stat icon for fleet speed
         icon = new StatisticIcon(SpeedIcon(), 0, 0, false,
                                  GG::X0, GG::Y0, StatIconSize().x, StatIconSize().y);
@@ -1849,11 +1841,8 @@ void FleetDataPanel::Init() {
         icon->InstallEventFilter(this);
         AttachChild(icon);
 
-
-        timer.EnterSection("connect");
         m_fleet_connection = GG::Connect(fleet->StateChangedSignal, &FleetDataPanel::RequirePreRender, this);
 
-        timer.EnterSection("aggro");
         int client_empire_id = HumanClientApp::GetApp()->EmpireID();
         if (fleet->OwnedBy(client_empire_id) || fleet->GetVisibility(client_empire_id) >= VIS_FULL_VISIBILITY) {
             m_aggression_toggle = new CUIButton(

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -3802,8 +3802,6 @@ void FleetWnd::ShipSelectionChanged(const GG::ListBox::SelectionSet& rows)
 { SelectedShipsChangedSignal(); }
 
 void FleetWnd::UniverseObjectDeleted(TemporaryPtr<const UniverseObject> obj) {
-    DebugLogger() << "FleetWnd::UniverseObjectDeleted";
-
     // check if deleted object was a fleet.  if not, abort.
     TemporaryPtr<const Fleet> deleted_fleet = boost::dynamic_pointer_cast<const Fleet>(obj);
     if (!deleted_fleet)
@@ -3823,7 +3821,6 @@ void FleetWnd::UniverseObjectDeleted(TemporaryPtr<const UniverseObject> obj) {
             break;
         }
     }
-    DebugLogger() << "FleetWnd::UniverseObjectDeleted done";
 }
 
 void FleetWnd::SystemChangedSlot() {

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -1106,6 +1106,7 @@ public:
     bool                Selected() const;
     NewFleetAggression  GetNewFleetAggression() const;
 
+    virtual void        PreRender();
     virtual void        Render();
     virtual void        DragDropHere(const GG::Pt& pt, std::map<const GG::Wnd*, bool>& drop_wnds_acceptable,
                                      GG::Flags<GG::ModKey> mod_keys);
@@ -1165,6 +1166,7 @@ FleetDataPanel::FleetDataPanel(GG::X w, GG::Y h, int fleet_id) :
     m_stat_icons(),
     m_selected(false)
 {
+    RequirePreRender();
     SetChildClippingMode(ClipToClient);
     m_fleet_name_text = new CUILabel("", GG::FORMAT_LEFT);
     AttachChild(m_fleet_name_text);
@@ -1283,8 +1285,7 @@ FleetDataPanel::FleetDataPanel(GG::X w, GG::Y h, int fleet_id) :
         icon->InstallEventFilter(this);
         AttachChild(icon);
 
-
-        m_fleet_connection = GG::Connect(fleet->StateChangedSignal, &FleetDataPanel::Refresh, this);
+        m_fleet_connection = GG::Connect(fleet->StateChangedSignal, &FleetDataPanel::RequirePreRender, this);
 
         int client_empire_id = HumanClientApp::GetApp()->EmpireID();
         if (fleet->OwnedBy(client_empire_id) || fleet->GetVisibility(client_empire_id) >= VIS_FULL_VISIBILITY) {
@@ -1296,8 +1297,6 @@ FleetDataPanel::FleetDataPanel(GG::X w, GG::Y h, int fleet_id) :
             GG::Connect(m_aggression_toggle->LeftClickedSignal, &FleetDataPanel::AggressionToggleButtonPressed, this);
         }
     }
-
-    Refresh();
 }
 
 FleetDataPanel::FleetDataPanel(GG::X w, GG::Y h, int system_id, bool new_fleet_drop_target) :
@@ -1315,6 +1314,7 @@ FleetDataPanel::FleetDataPanel(GG::X w, GG::Y h, int system_id, bool new_fleet_d
     m_stat_icons(),
     m_selected(false)
 {
+    RequirePreRender();
     SetChildClippingMode(ClipToClient);
     m_fleet_name_text = new CUILabel("", GG::FORMAT_LEFT);
     AttachChild(m_fleet_name_text);
@@ -1326,8 +1326,6 @@ FleetDataPanel::FleetDataPanel(GG::X w, GG::Y h, int system_id, bool new_fleet_d
         GG::SubTexture(FleetAggressiveMouseoverIcon()));
     AttachChild(m_aggression_toggle);
     GG::Connect(m_aggression_toggle->LeftClickedSignal, &FleetDataPanel::AggressionToggleButtonPressed, this);
-
-    Refresh();
 }
 
 GG::Pt FleetDataPanel::ClientUpperLeft() const
@@ -1341,6 +1339,11 @@ bool FleetDataPanel::Selected() const
 
 NewFleetAggression FleetDataPanel::GetNewFleetAggression() const
 { return m_new_fleet_aggression; }
+
+void FleetDataPanel::PreRender() {
+    GG::Wnd::PreRender();
+    Refresh();
+}
 
 void FleetDataPanel::Render() {
     // main background position and colour

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -2636,16 +2636,9 @@ std::set<int> FleetDetailPanel::SelectedShipIDs() const {
             continue;
         }
         GG::ListBox::Row* row = **sel_it;
-        ShipRow* ship_row = 0;
-        try {   // casing rows here sometimes causes RTTI exceptions.  not sure why, but need to avoid crash.
-            if ((ship_row = dynamic_cast<ShipRow*>(row))) {
-                if (ship_row->ShipID() != INVALID_OBJECT_ID)
-                    retval.insert(ship_row->ShipID());
-                //std::cout << " ship row for ship: " << ship_row->ShipID() << " is selected" << std::endl << std::flush;
-            }
-        } catch (...) {
-            continue;
-        }
+        ShipRow* ship_row = dynamic_cast<ShipRow*>(row);
+        if (ship_row && (ship_row->ShipID() != INVALID_OBJECT_ID))
+            retval.insert(ship_row->ShipID());
     }
     return retval;
 }

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -2162,12 +2162,6 @@ public:
         //std::cout << "FleetsListBox::DragDropLeave done" << std::endl << std::flush;
     }
 
-    void            Refresh() {
-        const GG::Pt row_size = ListRowSize();
-        for (GG::ListBox::iterator it = begin(); it != end(); ++it)
-            (*it)->Resize(row_size);
-    }
-
     virtual void    SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
         const GG::Pt old_size = Size();
         CUIListBox::SizeMove(ul, lr);
@@ -3797,7 +3791,6 @@ void FleetWnd::CreateNewFleetFromDrops(const std::vector<int>& ship_ids) {
     m_fleet_detail_panel->SetSelectedShips(std::set<int>());
 
     CreateNewFleetFromShips(ship_ids, aggression);
-    m_fleets_lb->Refresh();
 }
 
 void FleetWnd::ShipSelectionChanged(const GG::ListBox::SelectionSet& rows)

--- a/UI/FleetWnd.h
+++ b/UI/FleetWnd.h
@@ -109,11 +109,11 @@ public:
     //@}
 
     //! \name Mutators //@{
+    virtual void            PreRender();
     void                    SelectFleet(int fleet_id);                          ///< deselects any selected fleets, and selects the indicated fleet, bringing it into the fleet detail window
     void                    SetSelectedFleets(const std::set<int>& fleet_ids);  ///< deselects any selected fleets, and selects the fleets with the indicated ids
     void                    SetSelectedShips(const std::set<int>& ship_ids);    ///< deselected any selected ships, and selects the ships with the indicated ids if they are in the selected fleet.
     virtual void            SizeMove(const GG::Pt& ul, const GG::Pt& lr);
-    void                    Refresh();                          ///< regenerates contents
 
     /** Enables, or disables if \a enable is false, issuing orders via this FleetWnd. */
     void                    EnableOrderIssuing(bool enable = true);
@@ -146,6 +146,7 @@ private:
     //@}
 
     void            Init(int selected_fleet_id);
+    void            Refresh();                          ///< regenerates contents
     void            RefreshStateChangedSignals();
 
     void            AddFleet(int fleet_id);     ///< adds a new fleet row to this FleetWnd's ListBox of FleetRows and updates internal fleets bookkeeping

--- a/UI/LinkText.cpp
+++ b/UI/LinkText.cpp
@@ -18,38 +18,6 @@ namespace {
 
     // closing format tag
     static const std::string LINK_FORMAT_CLOSE = "</rgba>";
-
-    static bool link_tags_registered = false;
-    void RegisterLinkTags() {
-        if (link_tags_registered)
-            return;
-        link_tags_registered = true;
-
-        // need to register the tags that link text uses so GG::Font will know how to (not) render them
-        GG::Font::RegisterKnownTag(VarText::PLANET_ID_TAG);
-        GG::Font::RegisterKnownTag(VarText::SYSTEM_ID_TAG);
-        GG::Font::RegisterKnownTag(VarText::SHIP_ID_TAG);
-        GG::Font::RegisterKnownTag(VarText::FLEET_ID_TAG);
-        GG::Font::RegisterKnownTag(VarText::BUILDING_ID_TAG);
-        GG::Font::RegisterKnownTag(VarText::FIELD_ID_TAG);
-
-        GG::Font::RegisterKnownTag(VarText::COMBAT_ID_TAG);
-
-        GG::Font::RegisterKnownTag(VarText::EMPIRE_ID_TAG);
-        GG::Font::RegisterKnownTag(VarText::DESIGN_ID_TAG);
-        GG::Font::RegisterKnownTag(VarText::PREDEFINED_DESIGN_TAG);
-
-        GG::Font::RegisterKnownTag(VarText::TECH_TAG);
-        GG::Font::RegisterKnownTag(VarText::BUILDING_TYPE_TAG);
-        GG::Font::RegisterKnownTag(VarText::SPECIAL_TAG);
-        GG::Font::RegisterKnownTag(VarText::SHIP_HULL_TAG);
-        GG::Font::RegisterKnownTag(VarText::SHIP_PART_TAG);
-        GG::Font::RegisterKnownTag(VarText::SPECIES_TAG);
-        GG::Font::RegisterKnownTag(VarText::FIELD_TYPE_TAG);
-
-        GG::Font::RegisterKnownTag(TextLinker::ENCYCLOPEDIA_TAG);
-        GG::Font::RegisterKnownTag(TextLinker::GRAPH_TAG);
-    }
 }
 
 ///////////////////////////////////////
@@ -535,3 +503,38 @@ std::string LinkTaggedIDText(const std::string& tag, int id, const std::string& 
 
 std::string LinkTaggedPresetText(const std::string& tag, const std::string& stringtable_entry, const std::string& display_text)
 { return "<" + tag + " " + stringtable_entry + ">" + display_text + "</" + tag + ">"; }
+
+namespace {
+    static bool link_tags_registered = false;
+}
+
+void RegisterLinkTags() {
+    if (link_tags_registered)
+        return;
+    link_tags_registered = true;
+
+    // need to register the tags that link text uses so GG::Font will know how to (not) render them
+    GG::Font::RegisterKnownTag(VarText::PLANET_ID_TAG);
+    GG::Font::RegisterKnownTag(VarText::SYSTEM_ID_TAG);
+    GG::Font::RegisterKnownTag(VarText::SHIP_ID_TAG);
+    GG::Font::RegisterKnownTag(VarText::FLEET_ID_TAG);
+    GG::Font::RegisterKnownTag(VarText::BUILDING_ID_TAG);
+    GG::Font::RegisterKnownTag(VarText::FIELD_ID_TAG);
+
+    GG::Font::RegisterKnownTag(VarText::COMBAT_ID_TAG);
+
+    GG::Font::RegisterKnownTag(VarText::EMPIRE_ID_TAG);
+    GG::Font::RegisterKnownTag(VarText::DESIGN_ID_TAG);
+    GG::Font::RegisterKnownTag(VarText::PREDEFINED_DESIGN_TAG);
+
+    GG::Font::RegisterKnownTag(VarText::TECH_TAG);
+    GG::Font::RegisterKnownTag(VarText::BUILDING_TYPE_TAG);
+    GG::Font::RegisterKnownTag(VarText::SPECIAL_TAG);
+    GG::Font::RegisterKnownTag(VarText::SHIP_HULL_TAG);
+    GG::Font::RegisterKnownTag(VarText::SHIP_PART_TAG);
+    GG::Font::RegisterKnownTag(VarText::SPECIES_TAG);
+    GG::Font::RegisterKnownTag(VarText::FIELD_TYPE_TAG);
+
+    GG::Font::RegisterKnownTag(TextLinker::ENCYCLOPEDIA_TAG);
+    GG::Font::RegisterKnownTag(TextLinker::GRAPH_TAG);
+}

--- a/UI/LinkText.h
+++ b/UI/LinkText.h
@@ -171,4 +171,10 @@ std::string LinkTaggedIDText(const std::string& tag, int id, const std::string& 
 
 /// Helper for generating a link string with preset display text (not to be looked up in stringtable)
 std::string LinkTaggedPresetText(const std::string& tag, const std::string& stringtable_entry, const std::string& display_text);
+
+/// Free function to register link tags that TextLinker knows of.  This allows GG::Font to remove
+/// them so that they will not be rendered.  Must be called at least once before text with embedded
+/// XML tags is handled by GG::Font
+void RegisterLinkTags();
+
 #endif // _LinkText_h_

--- a/UI/MultiplayerLobbyWnd.cpp
+++ b/UI/MultiplayerLobbyWnd.cpp
@@ -103,6 +103,9 @@ namespace {
             CUIDropDownList(6)
         {
             SetStyle(GG::LIST_NOSORT);
+            ManuallyManageColProps();
+            NormalizeRowsOnInsert(false);
+            SetNumCols(1);
             GG::Y type_row_height(std::max(GG::Y1, h - 8));
             Resize(GG::Pt(w, type_row_height));
 
@@ -419,6 +422,9 @@ MultiPlayerLobbyWnd::MultiPlayerLobbyWnd() :
 
     m_players_lb = new CUIListBox();
     m_players_lb->SetStyle(GG::LIST_NOSORT | GG::LIST_NOSEL);
+    m_players_lb->ManuallyManageColProps();
+    m_players_lb->NormalizeRowsOnInsert(true);
+    m_players_lb->SetNumCols(5);
 
     m_start_game_bn = new CUIButton(UserString("START_GAME_BN"));
     m_cancel_bn = new CUIButton(UserString("CANCEL"));

--- a/UI/MultiplayerLobbyWnd.cpp
+++ b/UI/MultiplayerLobbyWnd.cpp
@@ -67,8 +67,8 @@ namespace {
             {
                 push_back(new CUILabel(UserString("NO_PLAYER")));
             }
-            TypeRow(Networking::ClientType type_, bool show_add_drop = false) :
-                GG::DropDownList::Row(GG::X1, GG::Y1, "PlayerTypeSelectorRow"),
+            TypeRow(GG::X w, GG::Y h, Networking::ClientType type_, bool show_add_drop = false) :
+                GG::DropDownList::Row(w, h, "PlayerTypeSelectorRow"),
                 type(type_)
             {
                 switch (type) {
@@ -102,17 +102,19 @@ namespace {
         TypeSelector(GG::X w, GG::Y h, Networking::ClientType client_type, bool disabled) :
             CUIDropDownList(6)
         {
-            Resize(GG::Pt(w, std::max(GG::Y1, h - 8)));
             SetStyle(GG::LIST_NOSORT);
+            GG::Y type_row_height(std::max(GG::Y1, h - 8));
+            Resize(GG::Pt(w, type_row_height));
+
             if (client_type == Networking::CLIENT_TYPE_AI_PLAYER) {
                 if (disabled) {
                     // For AI players on non-hosts, have "AI" shown (disabled)
-                    Insert(new TypeRow(Networking::CLIENT_TYPE_AI_PLAYER));      // static "AI" display
+                    Insert(new TypeRow(w, type_row_height, Networking::CLIENT_TYPE_AI_PLAYER));      // static "AI" display
                     Select(0);
                 } else {
                     // For AI players on host, have "AI" shown on droplist, with "Drop" shown as alternate selection to remove the AI
-                    Insert(new TypeRow(Networking::CLIENT_TYPE_AI_PLAYER));      // "AI" display
-                    Insert(new TypeRow(Networking::INVALID_CLIENT_TYPE, true));  // "Drop" option
+                    Insert(new TypeRow(w, type_row_height, Networking::CLIENT_TYPE_AI_PLAYER));      // "AI" display
+                    Insert(new TypeRow(w, type_row_height, Networking::INVALID_CLIENT_TYPE, true));  // "Drop" option
                     Select(0);
                 }
             } else if (client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER ||
@@ -121,14 +123,14 @@ namespace {
             {
                 if (disabled) {
                     // For human players on other players non-host, have "AI" or "Observer" indicator (disabled)
-                    Insert(new TypeRow(client_type));
+                    Insert(new TypeRow(w, type_row_height, client_type));
                     Select(0);
                 } else {
                     // For human players on host, have "Player", "Observer", and "Drop" options.  TODO: have "Ban" option.
-                    Insert(new TypeRow(Networking::CLIENT_TYPE_HUMAN_PLAYER));   // "Human" display / option
-                    Insert(new TypeRow(Networking::CLIENT_TYPE_HUMAN_OBSERVER)); // "Observer" display / option
-                    Insert(new TypeRow(Networking::CLIENT_TYPE_HUMAN_MODERATOR));// "Moderator" display / option
-                    Insert(new TypeRow(Networking::INVALID_CLIENT_TYPE, true));  // "Drop" option
+                    Insert(new TypeRow(w, type_row_height, Networking::CLIENT_TYPE_HUMAN_PLAYER));   // "Human" display / option
+                    Insert(new TypeRow(w, type_row_height, Networking::CLIENT_TYPE_HUMAN_OBSERVER)); // "Observer" display / option
+                    Insert(new TypeRow(w, type_row_height, Networking::CLIENT_TYPE_HUMAN_MODERATOR));// "Moderator" display / option
+                    Insert(new TypeRow(w, type_row_height, Networking::INVALID_CLIENT_TYPE, true));  // "Drop" option
 
                     if (client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER)
                         Select(0);
@@ -142,12 +144,12 @@ namespace {
             } else {
                 if (disabled) {
                     // For empty row on non-host, should probably have no row... could also put "None" (disabled)
-                    Insert(new TypeRow(Networking::INVALID_CLIENT_TYPE));
+                    Insert(new TypeRow(w, type_row_height, Networking::INVALID_CLIENT_TYPE));
                     Select(0);
                 } else {
                     // For empty row on host, have "None" and "Add AI" options on droplist
-                    Insert(new TypeRow(Networking::INVALID_CLIENT_TYPE));        // "None" display
-                    Insert(new TypeRow(Networking::CLIENT_TYPE_AI_PLAYER, true));// "Add AI" option
+                    Insert(new TypeRow(w, type_row_height, Networking::INVALID_CLIENT_TYPE));        // "None" display
+                    Insert(new TypeRow(w, type_row_height, Networking::CLIENT_TYPE_AI_PLAYER, true));// "Add AI" option
 
                     Select(0);
                 }

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -2532,6 +2532,7 @@ void ObjectListWnd::ObjectRightClicked(GG::ListBox::iterator it, const GG::Pt& p
                 std::map<int, int>::iterator it = avail_designs.begin();
                 std::advance(it, id - MENUITEM_SET_SHIP_BASE - 1);
                 int ship_design = it->first;
+                bool needs_queue_update(false);
                 const GG::ListBox::SelectionSet sel = m_list_box->Selections();
                 for (GG::ListBox::SelectionSet::const_iterator it = sel.begin(); it != sel.end(); ++it) {
                     ObjectRow *row = dynamic_cast<ObjectRow *>(**it);
@@ -2542,12 +2543,15 @@ void ObjectListWnd::ObjectRightClicked(GG::ListBox::iterator it, const GG::Pt& p
                         continue;
                     ProductionQueue::ProductionItem ship_item(BT_SHIP, ship_design);
                     app->Orders().IssueOrder(OrderPtr(new ProductionQueueOrder(app->EmpireID(), ship_item, 1, row->ObjectID())));
-                    cur_empire->UpdateProductionQueue();
+                    needs_queue_update = true;
                 }
+                if (needs_queue_update)
+                    cur_empire->UpdateProductionQueue();
             } else if (id > MENUITEM_SET_BUILDING_BASE && id <= bld_menuitem_id) {
                 std::map<std::string, int>::iterator it = avail_blds.begin();
                 std::advance(it, id - MENUITEM_SET_BUILDING_BASE - 1);
                 std::string bld = it->first;
+                bool needs_queue_update(false);
                 const GG::ListBox::SelectionSet sel = m_list_box->Selections();
                 for (GG::ListBox::SelectionSet::const_iterator it = sel.begin(); it != sel.end(); ++it) {
                     ObjectRow *row = dynamic_cast<ObjectRow *>(**it);
@@ -2562,8 +2566,10 @@ void ObjectListWnd::ObjectRightClicked(GG::ListBox::iterator it, const GG::Pt& p
                     }
                     ProductionQueue::ProductionItem bld_item(BT_BUILDING, bld);
                     app->Orders().IssueOrder(OrderPtr(new ProductionQueueOrder(app->EmpireID(), bld_item, 1, row->ObjectID())));
-                    cur_empire->UpdateProductionQueue();
+                    needs_queue_update = true;
                 }
+                if (needs_queue_update)
+                    cur_empire->UpdateProductionQueue();
             }
 
             std::set<int> sel_ids = SelectedObjectIDs();

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -1761,9 +1761,9 @@ public:
     {
         // preinitialize listbox/row column widths, because what
         // ListBox::Insert does on default is not suitable for this case
+        ManuallyManageColProps();
         SetNumCols(1);
-        SetColWidth(0, GG::X0);
-        LockColWidths();
+        NormalizeRowsOnInsert(false);
         SetSortCmp(CustomRowCmp());
 
         SetVScrollWheelIncrement(Value(ListRowHeight())*4);

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -17,6 +17,7 @@
 #include "../universe/ShipDesign.h"
 
 #include <GG/DrawUtil.h>
+#include <GG/Layout.h>
 #include <GG/StaticGraphic.h>
 
 #include <boost/cast.hpp>
@@ -195,7 +196,8 @@ namespace {
     //////////////////////////////////////////////////
     class QueueProductionItemPanel : public GG::Control {
     public:
-        QueueProductionItemPanel(GG::X w, const ProductionQueue::Element& build, double turn_cost, double total_cost,
+        QueueProductionItemPanel(GG::X x, GG::Y y, GG::X w,
+                                 const ProductionQueue::Element& build, double turn_cost, double total_cost,
                                  int turns, int number, int turns_completed, double partially_complete_turn);
 
         virtual void    PreRender();
@@ -336,7 +338,7 @@ namespace {
             elem(elem)
         {
             RequirePreRender();
-            Resize(GG::Pt(w - 2 * MARGIN, QueueProductionItemPanel::DefaultHeight()));
+            Resize(GG::Pt(w, QueueProductionItemPanel::DefaultHeight()));
         }
 
         void Init() {
@@ -351,10 +353,11 @@ namespace {
             if (progress == -1.0f)
                 progress = 0.0f;
 
-            panel = new QueueProductionItemPanel(Width() - MARGIN - MARGIN, elem,
-                                                 elem.allocated_pp, total_cost, minimum_turns, elem.remaining,
-                                                 static_cast<int>(progress / std::max(1e-6f, per_turn_cost)),
-                                                 std::fmod(progress, per_turn_cost) / std::max(1e-6f, per_turn_cost));
+            panel = new QueueProductionItemPanel(GG::X(GetLayout()->BorderMargin()), GG::Y(GetLayout()->BorderMargin()),
+                                                   Width() - MARGIN - MARGIN - GG::X(2 * GetLayout()->BorderMargin()),
+                                                   elem, elem.allocated_pp, total_cost, minimum_turns, elem.remaining,
+                                                   static_cast<int>(progress / std::max(1e-6f, per_turn_cost)),
+                                                   std::fmod(progress, per_turn_cost) / std::max(1e-6f, per_turn_cost));
             push_back(panel);
 
             SetDragDropDataType(BuildDesignatorWnd::PRODUCTION_ITEM_DROP_TYPE);
@@ -372,8 +375,9 @@ namespace {
             if (!panel)
                 Init();
 
-            panel->Resize(Size() - GG::Pt((X_MARGIN + X_MARGIN), GG::Y0));
-            GG::ListBox::Row::Resize(panel->Size() + GG::Pt((X_MARGIN + X_MARGIN), GG::Y0));
+            GG::Pt border(GG::X(2 * GetLayout()->BorderMargin()), GG::Y(2 * GetLayout()->BorderMargin()));
+            panel->Resize(Size() - border);
+            GG::ListBox::Row::Resize(panel->Size() + border);
         }
 
         virtual void SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
@@ -409,10 +413,10 @@ namespace {
     //////////////////////////////////////////////////
     // QueueProductionItemPanel implementation
     //////////////////////////////////////////////////
-    QueueProductionItemPanel::QueueProductionItemPanel(GG::X w, const ProductionQueue::Element& build,
+    QueueProductionItemPanel::QueueProductionItemPanel(GG::X x, GG::Y y, GG::X w, const ProductionQueue::Element& build,
                                                        double turn_spending, double total_cost, int turns, int number,
                                                        int turns_completed, double partially_complete_turn) :
-        GG::Control(GG::X0, GG::Y0, w, GG::Y(10), GG::NO_WND_FLAGS),
+        GG::Control(x, y, w, GG::Y(10), GG::NO_WND_FLAGS),
         elem(build),
         m_name_text(0),
         m_location_text(0),

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -405,6 +405,7 @@ namespace {
         m_turns_completed(turns_completed),
         m_partially_complete_turn(partially_complete_turn)
     {
+        SetChildClippingMode(ClipToClient);
         GG::Clr clr = m_in_progress
             ? GG::LightColor(ClientUI::ResearchableTechTextAndBorderColor())
             : ClientUI::ResearchableTechTextAndBorderColor();

--- a/UI/QueueListBox.cpp
+++ b/UI/QueueListBox.cpp
@@ -66,7 +66,7 @@ QueueListBox::QueueListBox(const std::string& drop_type_str, const std::string& 
 }
 
 GG::X QueueListBox::RowWidth() const
-{ return Width() - 5; }
+{ return ClientWidth(); }
 
 void QueueListBox::KeyPress(GG::Key key, boost::uint32_t key_code_point, GG::Flags<GG::ModKey> mod_keys)
 {
@@ -139,6 +139,16 @@ void QueueListBox::Render() {
             lr.x = panel->Right();
         }
         GG::FlatRectangle(GG::Pt(ul.x, ul.y - 1), GG::Pt(lr.x, ul.y), GG::CLR_ZERO, GG::CLR_WHITE, 1);
+    }
+}
+
+void QueueListBox::SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
+    const GG::Pt old_size = Size();
+    CUIListBox::SizeMove(ul, lr);
+    if (old_size != Size() && !Empty()) {
+        const GG::Pt row_size(RowWidth(), (*begin())->Height());
+        for (GG::ListBox::iterator it = begin(); it != end(); ++it)
+            (*it)->Resize(row_size);
     }
 }
 

--- a/UI/QueueListBox.cpp
+++ b/UI/QueueListBox.cpp
@@ -58,30 +58,15 @@ QueueListBox::QueueListBox(const std::string& drop_type_str, const std::string& 
     GG::Connect(ClearedSignal,                      &QueueListBox::ShowPromptSlot,              this);
     GG::Connect(GG::ListBox::RightClickedSignal,    &QueueListBox::ItemRightClicked,            this);
 
-    // preinitialize listbox/row column widths, because what
-    // ListBox::Insert does on default is not suitable for this case
     SetNumCols(1);
-    SetColWidth(0, GG::X0);
-    LockColWidths();
+    ManuallyManageColProps();
     NormalizeRowsOnInsert(false);
 
     ShowPromptSlot();
 }
 
 GG::X QueueListBox::RowWidth() const
-{ return Width() - ClientUI::ScrollWidth() - 5; }
-
-void QueueListBox::SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
-    const GG::Pt old_size = Size();
-    CUIListBox::SizeMove(ul, lr);
-
-    if (old_size != Size()) {
-        for (GG::ListBox::iterator it = begin(); it != end(); ++it) {
-            GG::Pt old_row_sz = (*it)->Size();
-            (*it)->Resize(GG::Pt(Width() - ClientUI::ScrollWidth() - 5, old_row_sz.y));
-        }
-    }
-}
+{ return Width() - 5; }
 
 void QueueListBox::KeyPress(GG::Key key, boost::uint32_t key_code_point, GG::Flags<GG::ModKey> mod_keys)
 {

--- a/UI/QueueListBox.h
+++ b/UI/QueueListBox.h
@@ -12,8 +12,6 @@ public:
 
     GG::X           RowWidth() const;
 
-    virtual void    SizeMove(const GG::Pt& ul, const GG::Pt& lr);
-
     virtual void    AcceptDrops(const GG::Pt& pt, const std::vector<GG::Wnd*>& wnds, GG::Flags<GG::ModKey> mod_keys);
     virtual void    DragDropHere(const GG::Pt& pt, std::map<const GG::Wnd*, bool>& drop_wnds_acceptable,
                                  GG::Flags<GG::ModKey> mod_keys);

--- a/UI/QueueListBox.h
+++ b/UI/QueueListBox.h
@@ -24,6 +24,7 @@ public:
     void            Clear();
 
     virtual void    Render();
+    virtual void    SizeMove(const GG::Pt& ul, const GG::Pt& lr);
 
     boost::signals2::signal<void (GG::ListBox::Row*, std::size_t)>  QueueItemMovedSignal;
     boost::signals2::signal<void (GG::ListBox::iterator)>           QueueItemDeletedSignal;

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -423,10 +423,8 @@ public:
     {
         m_columns = SaveFileColumn::GetColumns();
         m_visible_columns = FilterColumns();
+        ManuallyManageColProps();
         SetNumCols(m_visible_columns.size());
-        for (unsigned int i = 0; i < m_visible_columns.size(); ++i)
-        { SetColWidth(i, GG::X1); }
-        LockColWidths();
         SetColHeaders(new SaveFileRow(m_visible_columns));
         SetSortCmp(&SaveFileListBox::DirectoryAwareCmp);
         SetVScrollWheelIncrement(WHEEL_INCREMENT);

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -449,7 +449,7 @@ public:
         for (unsigned int i = 0; i < m_visible_columns->size(); ++i) {
             const SaveFileColumn& column = (*m_visible_columns)[i];
             SetColStretch(i, column.Stretch());
-            SetColWidth(i, column.FixedWidth());
+            SetColWidth(i, column.FixedWidth(ClientWidth()));
         }
 
         SetSortCmp(&SaveFileListBox::DirectoryAwareCmp);

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -377,7 +377,7 @@ public:
         SaveFileRow(columns, directory) {
         SetMargin(ROW_MARGIN);
 
-        push_back(new CUILabel(PATH_DELIM_BEGIN + directory + PATH_DELIM_END, GG::FORMAT_NOWRAP));
+        push_back(new CUILabel(PATH_DELIM_BEGIN + directory + PATH_DELIM_END, GG::FORMAT_NOWRAP | GG::FORMAT_LEFT));
         GetLayout()->SetColumnStretch(0, 1.0);
     }
 
@@ -393,6 +393,7 @@ public:
             sum += column.FixedWidth(ClientWidth());
         }
         layout->SetMinimumColumnWidth (0, sum);
+        layout->SetColumnStretch(0, 1.0);
     }
 };
 

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -324,6 +324,7 @@ public:
         m_initialized(false)
     {
         SetName("SaveFileRow for \""+filename+"\"");
+        SetChildClippingMode(ClipToClient);
         RequirePreRender();
     }
 

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -435,12 +435,23 @@ class SaveFileListBox : public CUIListBox {
 public:
     SaveFileListBox() :
         CUIListBox ()
-    {
+    { }
+
+    void Init() {
         m_columns = SaveFileColumn::GetColumns();
         m_visible_columns = FilterColumns(m_columns);
         ManuallyManageColProps();
+        NormalizeRowsOnInsert(false);
         SetNumCols(m_visible_columns->size());
-        SetColHeaders(new SaveFileHeaderRow(m_visible_columns));
+
+        SaveFileHeaderRow* header_row = new SaveFileHeaderRow(m_visible_columns);
+        SetColHeaders(header_row);
+        for (unsigned int i = 0; i < m_visible_columns->size(); ++i) {
+            const SaveFileColumn& column = (*m_visible_columns)[i];
+            SetColStretch(i, column.Stretch());
+            SetColWidth(i, column.FixedWidth());
+        }
+
         SetSortCmp(&SaveFileListBox::DirectoryAwareCmp);
         SetVScrollWheelIncrement(WHEEL_INCREMENT);
     }
@@ -900,6 +911,7 @@ void SaveFileDialog::UpdatePreviewList() {
     DebugLogger() << "SaveFileDialog::UpdatePreviewList";
 
     m_file_list->Clear();
+    m_file_list->Init();
 
     // If no browsing, no reloading
     if (!m_server_previews) {

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -493,11 +493,14 @@ public:
     /// @param [in] previews The preview data
     void LoadSaveGamePreviews(const std::vector<FullPreview>& previews) {
         int tooltip_delay = GetOptionsDB().Get<int>("UI.save-file-dialog.tooltip-delay");
+
+        std::vector<Row*> rows;
         for (vector<FullPreview>::const_iterator it = previews.begin(); it != previews.end(); ++it) {
-            SaveFileRow* row = new SaveFileFileRow(*it, m_visible_columns, m_columns, tooltip_delay);
-            Insert(row);
-            row->AdjustColumns();
+            rows.push_back(new SaveFileFileRow(*it, m_visible_columns, m_columns, tooltip_delay));
         }
+
+        // Insert rows enmasse to avoid per insertion vector sort costs.
+        Insert(rows, false);
     }
 
     void LoadDirectories(const fs::path& path) {

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -579,25 +579,9 @@ private:
     /// b) be sorted alphabetically
     /// This custom comparer achieves these goals.
     static bool DirectoryAwareCmp(const Row& row1, const Row& row2, int column_int) {
-        unsigned column = 0;
-        if (column_int >= 0) {
-            column = column_int;
-        }
-        std::string key1;
-        std::string key2;
-        // If column is other than the first one,
-        // use the first one for columns that don't have that many,
-        // since they should be directories.
-        if (row1.size() < column) {
-            key1 = row1.SortKey(column);
-        } else {
-            key1 = row1.SortKey(0);
-        }
-        if (row2.size() < column) {
-            key2 = row2.SortKey(column);
-        } else {
-            key2 = row2.SortKey(0);
-        }
+        std::string key1(row1.SortKey(0));
+        std::string key2(row2.SortKey(0));
+
         const bool row1_is_directory = dynamic_cast<const SaveFileDirectoryRow*>(&row1);
         const bool row2_is_directory = dynamic_cast<const SaveFileDirectoryRow*>(&row2);
         if (!row1_is_directory && !row2_is_directory) {
@@ -605,10 +589,8 @@ private:
         } else if ( row1_is_directory && row2_is_directory ) {
             // Directories always return directory name as sort key
             return key1.compare(key2) >= 0;
-        } else if ( row1_is_directory && !row2_is_directory ){
-            return false;
         } else {
-            return true;
+            return ( !row1_is_directory && row2_is_directory );
         }
     }
 };

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -102,8 +102,9 @@ namespace {
             ClientUI::GetFont()->ExpensiveParseFromTextToTextElements(string, fmt);
         std::vector<GG::Font::LineData> lines = ClientUI::GetFont()->DetermineLines(string, fmt, width, text_elements);
         GG::Pt extent = ClientUI::GetFont()->TextExtent(lines);
-        GG::Label* text = new CUILabel(string, GG::FORMAT_WORDBREAK | GG::FORMAT_LEFT);
-        text->Resize(GG::Pt(extent.x, extent.y));
+        GG::Label* text = new CUILabel(string, text_elements,
+                                       GG::FORMAT_WORDBREAK | GG::FORMAT_LEFT, GG::NO_WND_FLAGS,
+                                       GG::X0, GG::Y0, extent.x, extent.y);
         text->ClipText(true);
         text->SetChildClippingMode(GG::Wnd::ClipToClient);
         return text;
@@ -181,8 +182,9 @@ public:
         GG::Label* retval = 0;
 
         if (column.m_fixed) {
-            retval = new CUILabel(value, format_flags);
-            retval->Resize(GG::Pt(column.FixedWidth(), ClientUI::GetFont()->Height()));
+            retval = new CUILabel(value, format_flags, GG::NO_WND_FLAGS,
+                                  GG::X0, GG::Y0,
+                                  column.FixedWidth(), ClientUI::GetFont()->Height());
         } else {
             retval = CreateResizingText(value, max_width);
         }

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -344,7 +344,7 @@ public:
         GG::Layout* layout = GetLayout();
         if (!layout)
             return;
-        for (unsigned int i = 0; i < m_columns->size(); ++i){
+        for (unsigned int i = 0; i < m_columns->size(); ++i) {
             const SaveFileColumn& column = (*m_columns)[i];
             layout->SetColumnStretch ( i, column.Stretch() );
             layout->SetMinimumColumnWidth ( i, column.FixedWidth(ClientWidth()) ); // Considers header
@@ -377,23 +377,35 @@ public:
         SaveFileRow(columns, directory) {
         SetMargin(ROW_MARGIN);
 
-        push_back(new CUILabel(PATH_DELIM_BEGIN + directory + PATH_DELIM_END, GG::FORMAT_NOWRAP | GG::FORMAT_LEFT));
-        GetLayout()->SetColumnStretch(0, 1.0);
+        for (unsigned int i = 0; i < m_columns->size(); ++i) {
+            if (i==0) {
+                CUILabel* label = new CUILabel(PATH_DELIM_BEGIN + directory + PATH_DELIM_END,
+                                               GG::FORMAT_NOWRAP | GG::FORMAT_LEFT);
+                label->Resize(GG::Pt(DirectoryNameSize(), ClientUI::GetFont()->Height()));
+                push_back(label);
+            } else {
+                // Dummy columns
+                CUILabel* label = new CUILabel("", GG::FORMAT_NOWRAP);
+                label->Resize(GG::Pt(GG::X0, ClientUI::GetFont()->Height()));
+                push_back(label);
+            }
+        }
+
+        AdjustColumns();
     }
 
-
-    virtual void AdjustColumns() {
+    GG::X DirectoryNameSize() {
         GG::Layout* layout = GetLayout();
         if (!layout)
-            return;
+            return ClientUI::GetFont()->SpaceWidth() * 10;
+
         // Give the directory label at least all the room that the other columns demand anyway
         GG::X sum(0);
         for (unsigned int i = 0; i < m_columns->size(); ++i) {
             const SaveFileColumn& column = (*m_columns)[i];
             sum += column.FixedWidth(ClientWidth());
         }
-        layout->SetMinimumColumnWidth (0, sum);
-        layout->SetColumnStretch(0, 1.0);
+        return sum;
     }
 };
 

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -445,26 +445,6 @@ public:
         SetVScrollWheelIncrement(WHEEL_INCREMENT);
     }
 
-    virtual void SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
-        const GG::Pt old_size = Size();
-        CUIListBox::SizeMove(ul, lr);
-        if (old_size != Size())
-            RefreshRowSizes();
-    }
-
-    void RefreshRowSizes() {
-        ResetColHeaders();
-        const GG::Pt row_size = ListRowSize();
-        ColHeaders().Resize(row_size);
-        dynamic_cast<SaveFileRow*>(&ColHeaders())->AdjustColumns();
-        for (GG::ListBox::iterator it = begin(); it != end(); ++it) {
-            SaveFileRow* row = dynamic_cast<SaveFileRow*>(*it);
-            if (row)
-                row->AdjustColumns();
-            (*it)->Resize(row_size);
-        }
-    }
-
     void ResetColHeaders() {
         RemoveColHeaders();
         SetColHeaders(new SaveFileHeaderRow(m_visible_columns));
@@ -951,8 +931,6 @@ void SaveFileDialog::UpdatePreviewList() {
         }
     }
 
-    // Forces the width to recompute
-    m_file_list->RefreshRowSizes();
     // HACK: Sometimes the first row is not drawn without this
     m_file_list->BringRowIntoView(m_file_list->begin());
 

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -387,8 +387,10 @@ public:
     }
 
     void AdjustColumns(const std::vector<SaveFileColumn>& columns) {
+        GG::Layout* layout = GetLayout();
+        if (!layout)
+            return;
         if (Type() != DIRECTORY) {
-            GG::Layout* layout = GetLayout();
             for (unsigned int i = 0; i < columns.size(); ++i){
                 const SaveFileColumn& column = columns[i];
                 layout->SetColumnStretch ( i, column.Stretch() );
@@ -396,7 +398,6 @@ public:
             }
         } else {
             // Give the directory label at least all the room that the other columns demand anyway
-            GG::Layout* layout = GetLayout();
             GG::X sum(0);
             for (unsigned int i = 0; i < columns.size(); ++i) {
                 const SaveFileColumn& column = columns[i];

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -906,10 +906,6 @@ void SaveFileDialog::UpdatePreviewList() {
 
     m_file_list->Clear();
 
-    // Needed because there is a bug in ListBox, where the headers
-    // never resize to less wide
-    m_file_list->ResetColHeaders();
-
     // If no browsing, no reloading
     if (!m_server_previews) {
         m_file_list->LoadSaveGamePreviews(FilenameToPath(GetDirPath()), m_extension);

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -876,6 +876,10 @@ SidePanel::PlanetPanel::PlanetPanel(GG::X w, int planet_id, StarType star_type) 
     m_focus_drop->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
     m_focus_drop->SetStyle(GG::LIST_NOSORT | GG::LIST_SINGLESEL);
     m_focus_drop->ManuallyManageColProps();
+    m_focus_drop->SetNumCols(2);
+    m_focus_drop->SetColWidth(0, m_focus_drop->DisplayedRowWidth());
+    m_focus_drop->SetColStretch(0, 0.0);
+    m_focus_drop->SetColStretch(1, 1.0);
 
 
     // meter panels

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -873,10 +873,9 @@ SidePanel::PlanetPanel::PlanetPanel(GG::X w, int planet_id, StarType star_type) 
     AttachChild(m_focus_drop);
     GG::Connect(m_focus_drop->SelChangedSignal,     &SidePanel::PlanetPanel::FocusDropListSelectionChanged,  this);
     GG::Connect(this->FocusChangedSignal,           &SidePanel::PlanetPanel::SetFocus, this);
-    m_focus_drop->MoveTo(GG::Pt(GG::X1, GG::Y1));   // force auto-resize so height is correct for subsequent layout stuff
-    m_focus_drop->Resize(GG::Pt(MeterIconSize().x*4, MeterIconSize().y*3/2 + 4));
     m_focus_drop->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
     m_focus_drop->SetStyle(GG::LIST_NOSORT | GG::LIST_SINGLESEL);
+    m_focus_drop->ManuallyManageColProps();
 
 
     // meter panels
@@ -1734,7 +1733,7 @@ void SidePanel::PlanetPanel::Refresh() {
             GG::StaticGraphic* graphic = new GG::StaticGraphic(texture, GG::GRAPHIC_FITGRAPHIC | GG::GRAPHIC_PROPSCALE);
             graphic->Resize(GG::Pt(MeterIconSize().x*3/2, MeterIconSize().y*3/2));
             GG::DropDownList::Row* row = new GG::DropDownList::Row(graphic->Width(), graphic->Height(), "FOCUS");
-            row->push_back(dynamic_cast<GG::Control*>(graphic));
+            row->push_back(graphic);
             rows.push_back(row);
         }
         m_focus_drop->Insert(rows, false);

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -2696,11 +2696,9 @@ SidePanel::SidePanel(const std::string& config_name) :
     Sound::TempUISoundDisabler sound_disabler;
 
     m_system_name->DisableDropArrow();
-    m_system_name->SetStyle(GG::LIST_CENTER);
     m_system_name->SetInteriorColor(GG::Clr(0, 0, 0, 200));
+    m_system_name->ManuallyManageColProps();
     m_system_name->SetNumCols(1);
-    m_system_name->SetColWidth(0, GG::X0);
-    m_system_name->LockColWidths();
     AttachChild(m_system_name);
 
     AttachChild(m_star_type_text);

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -36,6 +36,7 @@
 #include "../util/ScopedTimer.h"
 #include "../client/human/HumanClientApp.h"
 
+#include <GG/Layout.h>
 #include <GG/DrawUtil.h>
 #include <GG/StaticGraphic.h>
 #include <GG/DynamicGraphic.h>
@@ -721,15 +722,36 @@ namespace {
     public:
         SystemRow(int system_id) :
             GG::ListBox::Row(),
-            m_system_id(system_id)
+            m_system_id(system_id),
+            m_initialized(false)
         {
+            RequirePreRender();
             SetDragDropDataType("SystemRow");
-            push_back(new OwnerColoredSystemName(m_system_id, SystemNameFontSize(), false));
+        }
+
+        virtual void Init() {
+            m_initialized = true;
+            OwnerColoredSystemName *name(new OwnerColoredSystemName(m_system_id, SystemNameFontSize(), false));
+            push_back(name);
+            GG::ListBox::Row::Resize(name->Size());
+            GetLayout()->SetChildAlignment(name, GG::ALIGN_VCENTER | GG::ALIGN_CENTER);
+            GetLayout()->PreRender();
+        }
+
+        virtual void PreRender() {
+            if (!m_initialized)
+                Init();
+            GG::ListBox::Row::PreRender();
         }
 
         int SystemID() const { return m_system_id; }
+
+        virtual SortKeyType SortKey(std::size_t column) const
+        { return GetSystem(m_system_id)->Name(); }
+
     private:
         int m_system_id;
+        bool m_initialized;
     };
 
     const std::vector<boost::shared_ptr<GG::Texture> >& GetAsteroidTextures() {

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -3114,11 +3114,6 @@ void SidePanel::DoLayout() {
     lr = ul + GG::Pt(ClientWidth() - GG::X(MaxPlanetDiameter()), name_height);
     m_system_name->SizeMove(ul, lr);
 
-    // system name droplist rows
-    const GG::X row_width(m_system_name->Width() - ClientUI::ScrollWidth() - 5);
-    for (GG::ListBox::iterator it = m_system_name->begin(); it != m_system_name->end(); ++it)
-        (*it)->Resize(GG::Pt(row_width, (*it)->Height()));
-
     // star type text
     ul = GG::Pt(GG::X(MaxPlanetDiameter()) + 2*EDGE_PAD, name_height + EDGE_PAD*4);
     lr = GG::Pt(ClientWidth() - 1, ul.y + m_star_type_text->Height());

--- a/UI/SitRepPanel.cpp
+++ b/UI/SitRepPanel.cpp
@@ -12,6 +12,7 @@
 #include "../universe/ShipDesign.h"
 
 #include <GG/DrawUtil.h>
+#include <GG/Layout.h>
 
 #include <boost/lexical_cast.hpp>
 
@@ -240,7 +241,7 @@ namespace {
         }
 
         virtual void        SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
-            if (ul != UpperLeft() || (lr.x - ul.x) != Width())
+            if (ul != ClientUpperLeft() || (lr.x - ul.x) != Width())
                 DoLayout(ul, lr.x - ul.x);
         }
 
@@ -339,8 +340,9 @@ namespace {
                 Init();
 
             // Resize to fit panel after text reflows
-            m_panel->Resize(Size());
-            GG::ListBox::Row::Resize(m_panel->Size());
+            GG::Pt border(GG::X(2 * GetLayout()->BorderMargin()), GG::Y(2 * GetLayout()->BorderMargin()));
+            m_panel->Resize(Size() - border);
+            GG::ListBox::Row::Resize(m_panel->Size() + border);
         }
 
         virtual void        SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
@@ -350,7 +352,9 @@ namespace {
         }
 
         void            Init() {
-            m_panel = new SitRepDataPanel(GG::X0, GG::Y0, ClientWidth(), ClientHeight(), m_sitrep);
+            m_panel = new SitRepDataPanel(GG::X(GetLayout()->BorderMargin()), GG::Y(GetLayout()->BorderMargin()),
+                                          ClientWidth() - GG::X(2 * GetLayout()->BorderMargin()),
+                                          ClientHeight() - GG::Y(2 * GetLayout()->BorderMargin()), m_sitrep);
             push_back(m_panel);
             GG::Connect(m_panel->RightClickedSignal, &SitRepRow::RClick, this);
         }

--- a/UI/SitRepPanel.cpp
+++ b/UI/SitRepPanel.cpp
@@ -17,8 +17,10 @@
 
 
 namespace {
-    GG::X ICON_RIGHT_MARGIN(3);
-    GG::Y ITEM_VERTICAL_PADDING(2);
+    const int sitrep_row_margin(1);
+    const int sitrep_edge_to_outline_spacing(2);
+    const int sitrep_edge_to_content_spacing(sitrep_edge_to_outline_spacing + 1 + 2);
+    const int sitrep_spacing(2);
 
     /** Adds options related to SitRepPanel to Options DB. */
     void AddOptions(OptionsDB& db) {
@@ -28,8 +30,8 @@ namespace {
     }
     bool temp_bool = RegisterOptions(&AddOptions);
 
-    GG::X GetIconSize()
-    { return GG::X(GetOptionsDB().Get<int>("UI.sitrep-icon-size")); }
+    int GetIconSize()
+    { return GetOptionsDB().Get<int>("UI.sitrep-icon-size"); }
 
     std::map<std::string, std::string> label_display_map;
     std::map<int, std::set<std::string> > snoozed_sitreps;
@@ -218,42 +220,28 @@ namespace {
     //////////////////////////////////
     class SitRepDataPanel : public GG::Control {
     public:
-        SitRepDataPanel(GG::X w, GG::Y h, const SitRepEntry& sitrep) :
-            Control(GG::X0, GG::Y0, w, h, GG::NO_WND_FLAGS),
+        SitRepDataPanel(GG::X left, GG::Y top, GG::X w, GG::Y h, const SitRepEntry& sitrep) :
+            Control(left, top, w, h, GG::NO_WND_FLAGS),
             m_initialized(false),
             m_sitrep_entry(sitrep),
             m_icon(0),
             m_link_text(0)
         {
             SetChildClippingMode(ClipToClient);
+            Init();
+            DoLayout(GG::Pt(left, top), w);
         }
 
         virtual void        Render() {
-            if (!m_initialized)
-                Init();
             GG::Clr background_clr = this->Disabled() ? ClientUI::WndColor() : ClientUI::CtrlColor();
-            GG::FlatRectangle(UpperLeft(), LowerRight() - GG::Pt(GG::X0, GG::Y(2)), background_clr, ClientUI::WndOuterBorderColor(), 1u);
+            GG::Pt spacer = GG::Pt(GG::X(sitrep_edge_to_outline_spacing), GG::Y(sitrep_edge_to_outline_spacing));
+            GG::FlatRectangle(UpperLeft() + spacer, LowerRight() - spacer,
+                              background_clr, ClientUI::WndOuterBorderColor(), 1u);
         }
 
         virtual void        SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
-            Init();
-            const GG::Pt old_size = Size();
-            GG::Control::SizeMove(ul, lr);
-            if (old_size != Size()) {
-                DoLayout();
-            }
-            if (m_link_text) {
-                // establish sitrep panel's size; use icon or text size for panel height, whichever is larger
-                // DoLayout reflowed the text.
-                int text_size = Value((m_link_text->TextLowerRight() - m_link_text->TextUpperLeft()).y);
-                int icon_size = Value(GetIconSize());
-                int max_panel_size = std::max(text_size, icon_size);
-                max_panel_size += Value(2*ITEM_VERTICAL_PADDING);
-
-                GG::Pt panel_size = GG::Pt(GG::X(lr.x - ul.x), GG::Y(max_panel_size));
-                GG::Control::SizeMove(ul, ul + panel_size);
-                DoLayout();
-            }
+            if (ul != UpperLeft() || (lr.x - ul.x) != Width())
+                DoLayout(ul, lr.x - ul.x);
         }
 
         const SitRepEntry&  GetSitRepEntry() const { return m_sitrep_entry; }
@@ -264,36 +252,51 @@ namespace {
         void            RClick(const GG::Pt& pt, GG::Flags<GG::ModKey> mod) { RightClickedSignal(pt, mod); }
 
     private:
-        void            DoLayout() {
-            if (!m_initialized)
-                return;
-            GG::Y ICON_HEIGHT(Value(GetIconSize()));
+        void            DoLayout(const GG::Pt& ul, const GG::X& width) {
+            // Resize the text
+            GG::Pt spacer = GG::Pt(GG::X(sitrep_edge_to_content_spacing), GG::Y(sitrep_edge_to_content_spacing));
+            GG::X icon_left(ul.x + spacer.x);
+            int icon_dim = GetIconSize();
+            GG::X text_left(icon_left + GG::X(icon_dim) + sitrep_spacing);
+            GG::X text_width(width - text_left - spacer.x);
+            m_link_text->SizeMove(GG::Pt(text_left, GG::Y0), GG::Pt(text_left, GG::Y0) + GG::Pt(text_width, GG::Y1));
 
-            GG::X left(GG::X0);
-            GG::Y bottom(ClientHeight() - ITEM_VERTICAL_PADDING);
+            // Choose height so that text always fits
+            GG::Y text_height = m_link_text->MinUsableSize().y;
+            GG::Y panel_height = std::max(text_height, GG::Y(icon_dim)) + 2 * spacer.y;
 
-            m_icon->SizeMove(GG::Pt(left, bottom/2 - ICON_HEIGHT/2), GG::Pt(left + GetIconSize(), bottom/2 + ICON_HEIGHT/2));
-            left += GetIconSize() + ICON_RIGHT_MARGIN;
+            // Move the elements into place.
+            GG::Y icon_top(ul.y + panel_height/2 - GG::Y(icon_dim)/2);
+            m_icon->MoveTo(GG::Pt(icon_left, icon_top));
 
-            m_link_text->SizeMove(GG::Pt(left, GG::Y0), GG::Pt(ClientWidth() - 3, bottom));
+            GG::Y text_top(ul.y + panel_height/2 - GG::Y(text_height)/2);
+            GG::Pt text_ul(text_left, text_top);
+            m_link_text->SizeMove(text_ul, text_ul + m_link_text->MinUsableSize());
+
+            //Resize control to fit
+            GG::Pt new_size = GG::Pt(width, panel_height);
+            GG::Control::SizeMove(ul, ul + new_size);
         }
 
         void            Init() {
-            if (m_initialized)
-                return;
             m_initialized = true;
 
+            int icon_dim = GetIconSize();
             std::string icon_texture = (m_sitrep_entry.GetIcon().empty() ?
                 "/icons/sitrep/generic.png" : m_sitrep_entry.GetIcon());
             boost::shared_ptr<GG::Texture> icon = ClientUI::GetTexture(
                 ClientUI::ArtDir() / icon_texture, true);
             m_icon = new GG::StaticGraphic(icon, GG::GRAPHIC_FITGRAPHIC | GG::GRAPHIC_PROPSCALE);
             AttachChild(m_icon);
+            m_icon->Resize(GG::Pt(GG::X(icon_dim), GG::Y(icon_dim)));
 
-            m_link_text = new SitRepLinkText(GG::X0, GG::Y0, GG::X1, m_sitrep_entry.GetText() + " ", 
+            GG::Pt spacer = GG::Pt(GG::X(sitrep_edge_to_content_spacing), GG::Y(sitrep_edge_to_content_spacing));
+            GG::X icon_left(spacer.x);
+            GG::X text_left(icon_left + GG::X(icon_dim) + sitrep_spacing);
+            GG::X text_width(ClientWidth() - text_left - spacer.x);
+            m_link_text = new SitRepLinkText(GG::X0, GG::Y0, text_width, m_sitrep_entry.GetText() + " ",
                                              ClientUI::GetFont(),
-                                             GG::FORMAT_LEFT | GG::FORMAT_VCENTER | GG::FORMAT_WORDBREAK,
-                                             ClientUI::TextColor());
+                                             GG::FORMAT_LEFT | GG::FORMAT_VCENTER | GG::FORMAT_WORDBREAK, ClientUI::TextColor());
             m_link_text->SetDecorator(VarText::EMPIRE_ID_TAG, new ColorEmpire());
             AttachChild(m_link_text);
 
@@ -301,13 +304,11 @@ namespace {
             GG::Connect(m_link_text->LinkDoubleClickedSignal, &HandleLinkClick);
             GG::Connect(m_link_text->LinkRightClickedSignal,  &HandleLinkClick);
             GG::Connect(m_link_text->RightClickedSignal,      &SitRepDataPanel::RClick,     this);
-
-            DoLayout();
         }
 
         bool                m_initialized;
 
-        SitRepEntry         m_sitrep_entry;
+        const SitRepEntry&  m_sitrep_entry;
         GG::StaticGraphic*  m_icon;
         SitRepLinkText*     m_link_text;
     };
@@ -320,30 +321,45 @@ namespace {
     public:
         SitRepRow(GG::X w, GG::Y h, const SitRepEntry& sitrep) :
             GG::ListBox::Row(w, h, ""),
-            m_panel(0)
+            m_panel(0),
+            m_sitrep(sitrep)
         {
             SetName("SitRepRow");
+            SetMargin(sitrep_row_margin);
             SetChildClippingMode(ClipToClient);
-            m_panel = new SitRepDataPanel(w, h, sitrep);
-            push_back(m_panel);
-            GG::Connect(m_panel->RightClickedSignal, &SitRepRow::RClick, this);
+            SetMinSize(GG::Pt(GG::X(2 * GetIconSize() + 2 * sitrep_edge_to_content_spacing),
+                              GG::Y(std::max(GetIconSize(), ClientUI::Pts() * 2) + 2 * sitrep_edge_to_content_spacing)));
+            RequirePreRender();
         }
 
-        void SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
-            const GG::Pt old_size = Size();
-            GG::Pt new_size = lr - ul;
-            new_size.x -= 9; // Avoid allowing the scrollbar to hide the very rightmost pixels.
-            if (!empty() && m_panel && old_size != new_size) {
-                m_panel->Resize(new_size);
-                new_size = m_panel->Size();
-            }
-            GG::ListBox::Row::SizeMove(ul, ul + new_size);
+        virtual void        PreRender() {
+            GG::ListBox::Row::PreRender();
+
+            if (!m_panel)
+                Init();
+
+            // Resize to fit panel after text reflows
+            m_panel->Resize(Size());
+            GG::ListBox::Row::Resize(m_panel->Size());
+        }
+
+        virtual void        SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
+            if (!m_panel || (Size() != (lr - ul)))
+                RequirePreRender();
+            GG::ListBox::Row::SizeMove(ul, lr);
+        }
+
+        void            Init() {
+            m_panel = new SitRepDataPanel(GG::X0, GG::Y0, ClientWidth(), ClientHeight(), m_sitrep);
+            push_back(m_panel);
+            GG::Connect(m_panel->RightClickedSignal, &SitRepRow::RClick, this);
         }
 
         const SitRepEntry&  GetSitRepEntry() const { return m_panel->GetSitRepEntry(); }
 
     private:
         SitRepDataPanel*    m_panel;
+        const SitRepEntry   m_sitrep;
     };
 }
 
@@ -365,6 +381,8 @@ SitRepPanel::SitRepPanel(const std::string& config_name) :
     m_sitreps_lb = new CUIListBox();
     m_sitreps_lb->SetStyle(GG::LIST_NOSORT | GG::LIST_NOSEL);
     m_sitreps_lb->SetVScrollWheelIncrement(ClientUI::Pts()*4.5);
+    m_sitreps_lb->ManuallyManageColProps();
+    m_sitreps_lb->NormalizeRowsOnInsert(false);
     AttachChild(m_sitreps_lb);
 
     m_prev_turn_button = new CUIButton(UserString("BACK"));
@@ -715,6 +733,10 @@ void SitRepPanel::Update() {
 
     std::size_t first_visible_row = std::distance(m_sitreps_lb->begin(), m_sitreps_lb->FirstRowShown());
     m_sitreps_lb->Clear();
+    m_sitreps_lb->SetStyle(GG::LIST_NOSORT | GG::LIST_NOSEL);
+    m_sitreps_lb->SetVScrollWheelIncrement(ClientUI::Pts()*4.5);
+    m_sitreps_lb->ManuallyManageColProps();
+    m_sitreps_lb->NormalizeRowsOnInsert(false);
 
     // Get back to sane default
     if (m_showing_turn == INVALID_GAME_TURN)
@@ -763,7 +785,7 @@ void SitRepPanel::Update() {
     { orderedSitreps.push_back(*sitrep_it); }
 
     // create UI rows for all sitrps
-    GG::X width = m_sitreps_lb->Width() - ClientUI::ScrollWidth();
+    GG::X width = m_sitreps_lb->ClientWidth();
     for (std::vector<SitRepEntry>::iterator sitrep_it = orderedSitreps.begin();
          sitrep_it != orderedSitreps.end(); ++sitrep_it)
     { m_sitreps_lb->Insert(new SitRepRow(width, GG::Y(ClientUI::Pts()*2), *sitrep_it)); }

--- a/UI/SitRepPanel.cpp
+++ b/UI/SitRepPanel.cpp
@@ -454,10 +454,8 @@ void SitRepPanel::SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
     if (old_size != GG::Wnd::Size()) {
         DoLayout();
         Update();
-        if (!m_sitreps_lb->Empty()) {
-            m_sitreps_lb->BringRowIntoView(--m_sitreps_lb->end());
-            m_sitreps_lb->BringRowIntoView(boost::next(m_sitreps_lb->begin(), first_visible_queue_row));
-        }
+        if (!m_sitreps_lb->Empty())
+            m_sitreps_lb->SetFirstRowShown(boost::next(m_sitreps_lb->begin(), first_visible_queue_row));
     }
 }
 

--- a/UI/SystemIcon.cpp
+++ b/UI/SystemIcon.cpp
@@ -214,13 +214,27 @@ OwnerColoredSystemName::OwnerColoredSystemName(int system_id, int font_size, boo
         text_color = ClientUI::TextColor();
     }
 
-    GG::Control* text = new GG::TextControl(GG::X0, GG::Y0, GG::X1, GG::Y1, "<s>" + wrapped_system_name + "</s>", font, text_color);
+    GG::TextControl* text = new GG::TextControl(
+        GG::X0, GG::Y0, GG::X1, GG::Y1, "<s>" + wrapped_system_name + "</s>", font, text_color);
     AttachChild(text);
-    Resize(GG::Pt(text->Width(), text->Height()));
+    GG::Pt text_size(text->TextLowerRight() - text->TextUpperLeft());
+    text->SizeMove(GG::Pt(GG::X0, GG::Y0), text_size);
+    SizeMove(UpperLeft(), UpperLeft() + text_size);
 }
 
 void OwnerColoredSystemName::Render()
 {}
+
+void OwnerColoredSystemName::SizeMove(const GG::Pt& ul, const GG::Pt& lr)
+{
+    GG::Control::SizeMove(ul, lr);
+
+    // Center text
+    if (!Children().empty())
+        if (GG::TextControl* text = dynamic_cast<GG::TextControl*>(*Children().begin())) {
+            text->MoveTo(GG::Pt((Width() - text->Width()) / 2, (Height() - text->Height()) / 2));
+        }
+}
 
 ////////////////////////////////////////////////
 // SystemIcon
@@ -683,8 +697,8 @@ void SystemIcon::HideName() {
 
 void SystemIcon::PositionSystemName() {
     if (m_colored_name) {
-        GG::X name_left = ( Width()  - m_colored_name->Width()           )/2;
-        GG::Y name_top =  ( Height() + GG::Y(EnclosingCircleDiameter()*2))/2;
+        GG::X name_left = ( Width()  - m_colored_name->Width()                                      )/2;
+        GG::Y name_top =  ( Height() + GG::Y(EnclosingCircleDiameter()*2) - m_colored_name->Height())/2;
         m_colored_name->MoveTo(GG::Pt(name_left, name_top));
     }
 }

--- a/UI/SystemIcon.h
+++ b/UI/SystemIcon.h
@@ -24,6 +24,7 @@ class OwnerColoredSystemName : public GG::Control {
 public:
     OwnerColoredSystemName(int system_id, int font_size, bool blank_unexplored_and_none);
     virtual void Render();
+    virtual void SizeMove(const GG::Pt& ul, const GG::Pt& lr);
 };
 
 /** A control that allows interaction with a star system.  This class allows

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -304,6 +304,9 @@ HumanClientApp::HumanClientApp(int width, int height, bool calculate_fps, const 
     if (inform_user_sound_failed)
         ClientUI::MessageBox(UserString("ERROR_SOUND_INITIALIZATION_FAILED"), false);
 
+    // Register LinkText tags with GG::Font
+    RegisterLinkTags();
+
     m_fsm->initiate();
 }
 


### PR DESCRIPTION
This PR improves the performance of `ListBox` based classes.

It refactors `ListBox` so that it will not layout rows that are not
visible.  It does this by adding `PreRender()` to both the `ListBox::Row`
and `ListBox` itself.  To use this functionality fully any classes derived
from `ListBox::Row` must do their initialization in their `PreRender()`.  

Additionally, the `ClientSize()` now correctly accounts for the scroll
bars.

This functionality replaces `ListBox::Row::AdjustLayout()`, which was a
toned down version of `PreRender()` that operated with some lexical scope
to suppress re-layout.  This cause of unpredictability when using
`ListBox::Row` because some operations where immediate and others not.

`ListBox` based classes are upgraded/fixed to work with the new functionality.
