### PR TITLE
Convert GG::EventPump time logging to boost::chrono.

### DIFF
--- a/GG/GG/EventPump.h
+++ b/GG/GG/EventPump.h
@@ -33,6 +33,9 @@
 
 #include <GG/GUI.h>
 
+// TODO change boost to std when C++11 is adopted.
+#include <boost/chrono/chrono.hpp>
+
 
 namespace GG {
 
@@ -44,9 +47,9 @@ struct GG_API EventPumpState
 {
     EventPumpState(); ///< Default ctor.
 
-    unsigned int last_FPS_time;    ///< The last time an FPS calculation was done.
-    unsigned int last_frame_time;  ///< The time of the last frame rendered.
-    unsigned int most_recent_time; ///< The time recorded on the previous iteration of the event pump loop.
+    boost::chrono::high_resolution_clock::time_point last_FPS_time;    ///< The last time an FPS calculation was done.
+    boost::chrono::high_resolution_clock::time_point last_frame_time;  ///< The time of the last frame rendered.
+    boost::chrono::high_resolution_clock::time_point most_recent_time; ///< The time recorded on the previous iteration of the event pump loop.
     std::size_t  frames;           ///< The number of frames rendered since \a last_frame_time.
 };
 

--- a/GG/GG/GUI.h
+++ b/GG/GG/GUI.h
@@ -32,6 +32,9 @@
 #include <GG/Font.h>
 #include <GG/WndEvent.h>
 
+// TODO change boost to std when C++11 is adopted.
+#include <boost/chrono/chrono.hpp>
+
 
 namespace boost { namespace archive {
     class xml_oarchive;
@@ -240,6 +243,9 @@ public:
     void            ClearEventState();
 
     void            SetFocusWnd(Wnd* wnd);          ///< sets the input focus window to \a wnd
+    /** Suspend the GUI thread for \p us microseconds.  Singlethreaded GUI subclasses may do
+        nothing here, or may pause for \p us microseconds. */
+    virtual void    Wait(boost::chrono::microseconds us);
     virtual void    Wait(unsigned int ms);          ///< suspends the GUI thread for \a ms milliseconds.  Singlethreaded GUI subclasses may do nothing here, or may pause for \a ms milliseconds.
     void            Register(Wnd* wnd);             ///< adds \a wnd into the z-list.  Registering a null pointer or registering the same window multiple times is a no-op.
     void            RegisterModal(Wnd* wnd);        ///< adds \a wnd onto the modal windows "stack"

--- a/GG/src/EventPump.cpp
+++ b/GG/src/EventPump.cpp
@@ -30,9 +30,9 @@
 using namespace GG;
 
 EventPumpState::EventPumpState() :
-    last_FPS_time(0),
-    last_frame_time(0),
-    most_recent_time(0),
+    last_FPS_time(boost::chrono::high_resolution_clock::now()),
+    last_frame_time(boost::chrono::high_resolution_clock::now()),
+    most_recent_time(boost::chrono::high_resolution_clock::now()),
     frames(0)
 {}
 
@@ -40,28 +40,33 @@ EventPumpState::EventPumpState() :
 void EventPumpBase::LoopBody(GUI* gui, EventPumpState& state, bool do_non_rendering, bool do_rendering)
 {
     if (do_non_rendering) {
-        int time = gui->Ticks();
+        boost::chrono::high_resolution_clock::time_point time = boost::chrono::high_resolution_clock::now();
 
         // send an idle message, so that the gui has timely updates for triggering browse info windows, etc.
         gui->HandleGGEvent(GUI::IDLE, GGK_UNKNOWN, 0, gui->ModKeys(), gui->MousePosition(), Pt());
 
         // govern FPS speed if needed
         if (double max_FPS = gui->MaxFPS()) {
-            double min_ms_per_frame = 1000.0 / max_FPS;
-            double ms_to_wait = min_ms_per_frame - (time - state.last_frame_time);
-            if (0.0 < ms_to_wait) {
-                gui->Wait(static_cast<unsigned int>(ms_to_wait));
-                time = gui->Ticks();
+            boost::chrono::microseconds min_us_per_frame = boost::chrono::duration_cast<boost::chrono::microseconds>(
+            boost::chrono::duration<double>(1.0 / (max_FPS + 1)));
+            boost::chrono::microseconds us_elapsed = boost::chrono::duration_cast<boost::chrono::microseconds>(
+                time - state.last_frame_time);
+            boost::chrono::microseconds us_to_wait = (min_us_per_frame - us_elapsed);
+            if (boost::chrono::microseconds(0) < us_to_wait) {
+                gui->Wait(us_to_wait);
+                time = boost::chrono::high_resolution_clock::now();
             }
         }
         state.last_frame_time = time;
 
         // track FPS if needed
-        gui->SetDeltaT(time - state.most_recent_time);
+        gui->SetDeltaT(boost::chrono::duration_cast<boost::chrono::microseconds>(time - state.most_recent_time).count());
         if (gui->FPSEnabled()) {
             ++state.frames;
-            if (1000 < time - state.last_FPS_time) { // calculate FPS at most once a second
-                gui->SetFPS(state.frames / ((time - state.last_FPS_time) / 1000.0));
+            if (boost::chrono::seconds(1) < time - state.last_FPS_time) { // calculate FPS at most once a second
+                double time_since_last_FPS = boost::chrono::duration_cast<boost::chrono::microseconds>(
+                    time - state.last_FPS_time).count() / 1000000.0;
+                gui->SetFPS(state.frames / time_since_last_FPS);
                 state.last_FPS_time = time;
                 state.frames = 0;
             }

--- a/GG/src/GUI.cpp
+++ b/GG/src/GUI.cpp
@@ -1197,6 +1197,9 @@ bool GUI::SetNextFocusWndInCycle()
 void GUI::Wait(unsigned int ms)
 { boost::this_thread::sleep_for(boost::chrono::milliseconds(ms)); }
 
+void GUI::Wait(boost::chrono::microseconds us)
+{ boost::this_thread::sleep_for(us); }
+
 void GUI::Register(Wnd* wnd)
 { if (wnd) s_impl->m_zlist.Add(wnd); }
 


### PR DESCRIPTION
This commit makes time tracking more consistent in GG.

boost::chrono is syntactically the same as std::chrono from the C++11
standard.

GG::GUI::Wait already uses boost::this_thread::sleep_for in
boost::chrono units.
