### PR TITLE
Implement request #986 rename systems.

### DIFF
--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -753,7 +753,64 @@ namespace {
         int m_system_id;
         bool m_initialized;
     };
+}
+/** A class to display all of the system names*/
+class SidePanel::SystemNameDropDownList : public CUIDropDownList {
+    public:
+    SystemNameDropDownList(size_t num_shown_elements) :
+        CUIDropDownList(num_shown_elements),
+        m_order_issuing_enabled(true)
+    { }
 
+    /** Enable/disable the ability to give orders that modify the system name.*/
+    void EnableOrderIssuing(bool enable = true)
+    { m_order_issuing_enabled = enable; }
+
+    virtual void RClick(const GG::Pt& pt, GG::Flags<GG::ModKey> mod_keys) {
+        if (CurrentItem() == end())
+            return;
+
+        SystemRow* system_row(dynamic_cast<SystemRow*>(*CurrentItem()));
+        if (!system_row)
+            return;
+
+        TemporaryPtr<const System> system(GetSystem(system_row->SystemID()));
+        if (!system)
+            return;
+
+        GG::MenuItem menu_contents;
+        if (m_order_issuing_enabled && system->OwnedBy(HumanClientApp::GetApp()->EmpireID()))
+            menu_contents.next_level.push_back(GG::MenuItem(UserString("SP_RENAME_SYSTEM"), 1, false, false));
+
+        GG::PopupMenu popup(pt.x, pt.y, ClientUI::GetFont(), menu_contents, ClientUI::TextColor(),
+                            ClientUI::WndOuterBorderColor(), ClientUI::WndColor(), ClientUI::EditHiliteColor());
+
+        if (popup.Run()) {
+            switch (popup.MenuID()) {
+            case 1: // rename system
+                {
+                    const std::string& old_name(system->Name());
+                    CUIEditWnd edit_wnd(GG::X(350), UserString("SP_ENTER_NEW_SYSTEM_NAME"), old_name);
+                    edit_wnd.Run();
+                    const std::string& new_name(edit_wnd.Result());
+                    if (m_order_issuing_enabled && !new_name.empty() && new_name != old_name) {
+                        HumanClientApp::GetApp()->Orders().IssueOrder(
+                            OrderPtr(new RenameOrder(HumanClientApp::GetApp()->EmpireID(), system->ID(), new_name)));
+                        if (SidePanel* side_panel = dynamic_cast<SidePanel*>(Parent()))
+                            side_panel->Refresh();
+                    }
+                }
+                break;
+            default:
+                break;
+            }
+        }
+    }
+
+    bool m_order_issuing_enabled;
+};
+
+namespace {
     const std::vector<boost::shared_ptr<GG::Texture> >& GetAsteroidTextures() {
         static std::vector<boost::shared_ptr<GG::Texture> > retval;
         if (retval.empty()) {
@@ -2713,7 +2770,7 @@ SidePanel::SidePanel(const std::string& config_name) :
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "rightarrowclicked.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "rightarrowmouseover.png")));
 
-    m_system_name = new CUIDropDownList(6);
+    m_system_name = new SystemNameDropDownList(6);
     m_system_name->SetColor(GG::CLR_ZERO);
     m_system_name->SetInteriorColor(GG::FloatClr(0.0, 0.0, 0.0, 0.5));
     m_star_type_text = new GG::TextControl(GG::X0, GG::Y0, GG::X1, GG::Y1, "", ClientUI::GetFont(), ClientUI::TextColor());
@@ -3255,6 +3312,7 @@ void SidePanel::SetSystem(int system_id) {
 void SidePanel::EnableSelection(bool enable/* = true*/)
 { m_selection_enabled = enable; }
 
-void SidePanel::EnableOrderIssuing(bool enable/* = true*/)
-{ m_planet_panel_container->EnableOrderIssuing(enable); }
-
+void SidePanel::EnableOrderIssuing(bool enable/* = true*/) {
+    m_system_name->EnableOrderIssuing(enable);
+    m_planet_panel_container->EnableOrderIssuing(enable);
+}

--- a/UI/SidePanel.h
+++ b/UI/SidePanel.h
@@ -124,7 +124,8 @@ private:
     static void         FleetsRemoved(const std::vector<TemporaryPtr<Fleet> >& fleets);     ///< responds to removal fleets from system during a turn.  may update colonize buttons
     static void         FleetStateChanged();            ///< responds to fleet state changes during a turn, which may include issueing or cancelling move orders.  may update colonize buttons
 
-    CUIDropDownList*            m_system_name;
+    class SystemNameDropDownList;
+    SystemNameDropDownList*     m_system_name;
     GG::TextControl*            m_star_type_text;
     GG::Button*                 m_button_prev;
     GG::Button*                 m_button_next;

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -3015,6 +3015,12 @@ Unknown
 TT_SPECIES_POPULATION
 %1% [[METER_POPULATION]]
 
+SP_RENAME_SYSTEM
+Rename System
+
+SP_ENTER_NEW_SYSTEM_NAME
+Enter new system name
+
 SP_RENAME_PLANET
 Rename Planet
 

--- a/universe/System.cpp
+++ b/universe/System.cpp
@@ -320,6 +320,23 @@ bool System::HasWormholeTo(int id) const {
     return (it == m_starlanes_wormholes.end() ? false : it->second == true);
 }
 
+int  System::Owner() const {
+    // Check if all of the owners are the same empire.
+    int first_owner_found(ALL_EMPIRES);
+    for (std::set<int>::const_iterator it = m_planets.begin(); it != m_planets.end(); ++it) {
+        if (TemporaryPtr<const Planet> planet = GetPlanet(*it)) {
+            const int owner(planet->Owner());
+            if (owner == ALL_EMPIRES)
+                continue;
+            if (first_owner_found == ALL_EMPIRES)
+                first_owner_found = owner;
+            if (first_owner_found != owner)
+                return ALL_EMPIRES;
+        }
+    }
+    return first_owner_found;
+}
+
 const std::set<int>& System::ContainedObjectIDs() const
 { return m_objects; }
 

--- a/universe/System.h
+++ b/universe/System.h
@@ -48,6 +48,10 @@ public:
 
     virtual int             SystemID() const                { return this->ID(); }
 
+    /** Systems are unowned unless at least one planet is owned by an empire and no other empire
+        owns any planets in the system.*/
+    int                     Owner() const;
+
     virtual const std::set<int>&    ContainedObjectIDs() const;                     ///< returns ids of objects in this system
 
     const std::set<int>&    ObjectIDs() const               { return m_objects; }

--- a/universe/UniverseObject.cpp
+++ b/universe/UniverseObject.cpp
@@ -290,10 +290,10 @@ void UniverseObject::AddMeter(MeterType meter_type) {
 }
 
 bool UniverseObject::Unowned() const
-{ return m_owner_empire_id == ALL_EMPIRES; }
+{ return Owner() == ALL_EMPIRES; }
 
 bool UniverseObject::OwnedBy(int empire) const
-{ return empire != ALL_EMPIRES && empire == m_owner_empire_id; }
+{ return empire != ALL_EMPIRES && empire == Owner(); }
 
 Visibility UniverseObject::GetVisibility(int empire_id) const
 { return GetUniverse().GetObjectVisibilityByEmpire(this->ID(), empire_id); }

--- a/universe/UniverseObject.h
+++ b/universe/UniverseObject.h
@@ -60,7 +60,7 @@ public:
     virtual double              X() const;                          ///< the X-coordinate of this object
     virtual double              Y() const;                          ///< the Y-coordinate of this object
 
-    int                         Owner() const;                      ///< returns the ID of the empire that owns this object, or ALL_EMPIRES if there is no owner
+    virtual int                 Owner() const;                      ///< returns the ID of the empire that owns this object, or ALL_EMPIRES if there is no owner
     bool                        Unowned() const;                    ///< returns true iff there are no owners of this object
     bool                        OwnedBy(int empire) const;          ///< returns true iff the empire with id \a empire owns this object; unowned objects always return false;
 

--- a/util/Order.cpp
+++ b/util/Order.cpp
@@ -87,7 +87,9 @@ void RenameOrder::ExecuteImpl() const {
 
     // verify that empire specified in order owns specified object
     if (!obj->OwnedBy(EmpireID())) {
-        ErrorLogger() << "Empire specified in rename order does not own specified object.";
+        ErrorLogger() << "Empire (" << EmpireID()
+                      << ") specified in rename order does not own specified object which is owned by "
+                      << obj->Owner() << ".";
         return;
     }
 


### PR DESCRIPTION
This PR add the ability to rename systems as per request #986.

It follows #993.  After #993 is merged it is only 4 commits.

It add a context menu element to the SidePanel system name to rename the system if the system is owned by the player.

This PR changes the game mechanic of system ownership.  Previously systems could not be owned.  This PR changes system ownership.   An empire owns a system if is owns at least one planet in a system and no other empire owns any planets.  A system is unowned if no empire owns any planets or multiple empires own planets.
