### PR TITLE
AI - Tweak Colonisation

### DIFF
--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -1000,8 +1000,10 @@ def evaluate_planet(planet_id, mission_type, spec_name, empire, detail=None):
             ast_val = 0
             if tech_is_complete("PRO_MICROGRAV_MAN"):
                 per_ast = 5
-            else:
+            elif fo.currentTurn() > 40:
                 per_ast = 2.5
+            else:
+                per_ast = 0.1
             if system:
                 for pid in system.planetIDs:
                     other_planet = universe.getPlanet(pid)
@@ -1020,9 +1022,9 @@ def evaluate_planet(planet_id, mission_type, spec_name, empire, detail=None):
             if tech_is_complete("SHP_ASTEROID_HULLS"):
                 per_ast = 20
             elif tech_is_complete("CON_ORBITAL_CON"):
-                per_ast = 10
-            else:
                 per_ast = 5
+            else:
+                per_ast = 0.1
             if system:
                 for pid in system.planetIDs:
                     other_planet = universe.getPlanet(pid)

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -1096,11 +1096,11 @@ def evaluate_planet(planet_id, mission_type, spec_name, empire, detail=None):
 
         if sys_supply <= 0:
             if sys_supply + planet_supply >= 0:
-                supply_val = 100 * (planet_supply - max(-3, sys_supply))
+                supply_val = 40 * (planet_supply - max(-3, sys_supply))
             else:
                 supply_val = 200 * (planet_supply + sys_supply)  # a penalty
         elif planet_supply > sys_supply == 1:  # TODO: check min neighbor supply
-            supply_val = 50 * (planet_supply - sys_supply)
+            supply_val = 20 * (planet_supply - sys_supply)
         detail.append("sys_supply: %d, planet_supply: %d, supply_val: %.0f" % (sys_supply, planet_supply, supply_val))
 
         # if AITags != "":


### PR DESCRIPTION
- Reduce supply weights: The AI used to weight supply value of a planet very strongly. This led to weird decision-making by choosing smaller planets over a perfectly fine and accessible larger planet. Hopefully, the new weights lead to more reasonable decision-making in this regard.
- Slightly reduce early-game rating of asteroids (before relevant techs are researched).
