### PR TITLE
Define LinkDecorator destructor as virtual

### DIFF
--- a/UI/LinkText.h
+++ b/UI/LinkText.h
@@ -10,6 +10,7 @@ class LinkDecorator {
 public:
     /** \name Structors */ //@{
     LinkDecorator() {};
+    virtual ~LinkDecorator() {};
     //@}
 
     /// Gets called for each link of the type this decorator is assigned to.


### PR DESCRIPTION
Fixes compile warning with GGC 6 + boost 1.61:

```
[85%] Building CXX object client/human/CMakeFiles/freeorion.dir/__/__/UI/LinkText.cpp.o
In file included from /opt/projects/boost/include/boost/checked_delete.hpp:15:0,
             from /opt/projects/boost/include/boost/smart_ptr/shared_ptr.hpp:26,
             from /opt/projects/boost/include/boost/shared_ptr.hpp:17,
             from /opt/projects/boost/include/boost/signals2/signal.hpp:21,
             from /opt/projects/freeorion/GG/GG/Base.h:39,
             from /opt/projects/freeorion/GG/GG/Wnd.h:32,
             from /opt/projects/freeorion/GG/GG/Control.h:32,
             from /opt/projects/freeorion/GG/GG/TextControl.h:33,
             from /opt/projects/freeorion/UI/LinkText.h:4,
             from /opt/projects/freeorion/UI/LinkText.cpp:1:
/opt/projects/boost/include/boost/core/checked_delete.hpp: In instantiation of ‘void boost::checked_delete(T*) [with T = LinkDecorator]’:
/opt/projects/boost/include/boost/smart_ptr/detail/shared_count.hpp:141:34:   required from ‘boost::detail::shared_count::shared_count(Y*) [with Y = LinkDecorator]’
/opt/projects/boost/include/boost/smart_ptr/shared_ptr.hpp:284:20:   required from ‘void boost::detail::sp_pointer_construct(boost::shared_ptr<X>*, Y*, boost::detail::shared_count&) [with T = LinkDecorator; Y = LinkDecorator]’
/opt/projects/boost/include/boost/smart_ptr/shared_ptr.hpp:362:44:   required from ‘boost::shared_ptr<T>::shared_ptr(Y*) [with Y = LinkDecorator; T = LinkDecorator]’
/opt/projects/freeorion/UI/LinkText.cpp:222:73:   required from here
/opt/projects/boost/include/boost/core/checked_delete.hpp:34:5: warning: deleting object of polymorphic class type ‘LinkDecorator’ which has non-virtual destructor might cause undefined behavior [-Wdelete-non-virtual-dtor]
     delete x;
     ^~~~~~
```
