### PR TITLE
Add right click context to hide/show SitRep templates

### DIFF
--- a/UI/SitRepPanel.cpp
+++ b/UI/SitRepPanel.cpp
@@ -599,36 +599,49 @@ void SitRepPanel::IgnoreSitRep(GG::ListBox::iterator it, const GG::Pt& pt, const
 
 void SitRepPanel::DismissalMenu(GG::ListBox::iterator it, const GG::Pt& pt, const GG::Flags<GG::ModKey>& mod) {
 
-    GG::MenuItem menu_contents;
+    GG::MenuItem menu_contents, submenu_ignore, submenu_block, separator_item;
     std::string sitrep_text, sitrep_template;
+    separator_item.separator = true;
     int start_turn = 0;
     SitRepRow* sitrep_row(0);
     if (it != m_sitreps_lb->end()) 
         sitrep_row = dynamic_cast<SitRepRow*>(*it);
+    submenu_ignore.label = UserString("SITREP_IGNORE_MENU");
     if (sitrep_row) {
         const SitRepEntry& sitrep_entry = sitrep_row->GetSitRepEntry();
         sitrep_text = sitrep_entry.GetText();
         start_turn = sitrep_entry.GetTurn();
         if (start_turn > 0) {
-            menu_contents.next_level.push_back(GG::MenuItem(UserString("SITREP_SNOOZE_5_TURNS"),      1, false, false));
-            menu_contents.next_level.push_back(GG::MenuItem(UserString("SITREP_SNOOZE_10_TURNS"),     2, false, false));
-            menu_contents.next_level.push_back(GG::MenuItem(UserString("SITREP_SNOOZE_INDEFINITE"),   3, false, false));
+            submenu_ignore.next_level.push_back(GG::MenuItem(UserString("SITREP_SNOOZE_5_TURNS"),      1, false, false));
+            submenu_ignore.next_level.push_back(GG::MenuItem(UserString("SITREP_SNOOZE_10_TURNS"),     2, false, false));
+            submenu_ignore.next_level.push_back(GG::MenuItem(UserString("SITREP_SNOOZE_INDEFINITE"),   3, false, false));
+            submenu_ignore.next_level.push_back(separator_item);
         }
+    }
+    submenu_ignore.next_level.push_back(GG::MenuItem(UserString("SITREP_SNOOZE_CLEAR_ALL"),            4, false, false));
+    submenu_ignore.next_level.push_back(GG::MenuItem(UserString("SITREP_SNOOZE_CLEAR_INDEFINITE"),     5, false, false));
+    menu_contents.next_level.push_back(submenu_ignore);
+
+    submenu_block.label = UserString("SITREP_BLOCK_MENU");
+    if (sitrep_row) {
+        const SitRepEntry& sitrep_entry = sitrep_row->GetSitRepEntry();
         sitrep_template = sitrep_entry.GetLabelString();
         std::string sitrep_label = sitrep_entry.GetStringtableLookupFlag() ? UserString(sitrep_template) : sitrep_template;
 
         if (!sitrep_label.empty() && !sitrep_template.empty()) {
-            menu_contents.next_level.push_back(GG::MenuItem(str(FlexibleFormat(UserString("SITREP_HIDE_TEMPLATE"))
-                                                                               % sitrep_label),       4, false, false));
+            submenu_block.next_level.push_back(GG::MenuItem(str(FlexibleFormat(UserString("SITREP_HIDE_TEMPLATE"))
+                                                                               % sitrep_label),        7, false, false));
         }
     }
-    if (m_hidden_sitrep_templates.size() > 0)
-        menu_contents.next_level.push_back(GG::MenuItem(UserString("SITREP_SHOWALL_TEMPLATES"),       5, false, false));
+    if (m_hidden_sitrep_templates.size() > 0) {
+        if (sitrep_row)
+            submenu_block.next_level.push_back(separator_item);
+        submenu_block.next_level.push_back(GG::MenuItem(UserString("SITREP_SHOWALL_TEMPLATES"),        8, false, false));
+    }
+    menu_contents.next_level.push_back(submenu_block);
 
-    menu_contents.next_level.push_back(GG::MenuItem(UserString("SITREP_SNOOZE_CLEAR_ALL"),            6, false, false));
-    menu_contents.next_level.push_back(GG::MenuItem(UserString("SITREP_SNOOZE_CLEAR_INDEFINITE"),     7, false, false));
-    menu_contents.next_level.push_back(GG::MenuItem("? - " + UserString("SITREP_IGNORE_BLOCK_TITLE"), 8, false, false));
-    menu_contents.next_level.push_back(GG::MenuItem("  " + UserString("HOTKEY_COPY"),                10, false, false));
+    menu_contents.next_level.push_back(GG::MenuItem("? - " + UserString("SITREP_IGNORE_BLOCK_TITLE"),  9, false, false));
+    menu_contents.next_level.push_back(GG::MenuItem("  " + UserString("HOTKEY_COPY"),                 10, false, false));
 
     CUIPopupMenu popup(pt.x, pt.y, menu_contents);
     if (!popup.Run())
@@ -650,26 +663,26 @@ void SitRepPanel::DismissalMenu(GG::ListBox::iterator it, const GG::Pt& pt, cons
         permanently_snoozed_sitreps.insert(sitrep_text);
         break;
     }
-    case 4: { // Add template for the row entry to hidden templates
+    case 4: { //
+        snoozed_sitreps.clear();
+    }
+    case 5: { //
+        permanently_snoozed_sitreps.clear();
+        break;
+    }
+    case 7: { // Add template for the row entry to hidden templates
         m_hidden_sitrep_templates.insert(sitrep_template);
         SetHiddenSitRepTemplateStringsInOptions(m_hidden_sitrep_templates);
         Update();
         break;
     }
-    case 5: { // Show all hidden templates
+    case 8: { // Show all hidden templates
         m_hidden_sitrep_templates.clear();
         SetHiddenSitRepTemplateStringsInOptions(m_hidden_sitrep_templates);
         Update();
         break;
     }
-    case 6: { //
-        snoozed_sitreps.clear();
-    }
-    case 7: { //
-        permanently_snoozed_sitreps.clear();
-        break;
-    }
-    case 8: { // Display help article
+    case 9: { // Display help article
         ClientUI::GetClientUI()->ZoomToEncyclopediaEntry("SITREP_IGNORE_BLOCK_TITLE");
         break;
     }

--- a/UI/SitRepPanel.cpp
+++ b/UI/SitRepPanel.cpp
@@ -601,47 +601,57 @@ void SitRepPanel::DismissalMenu(GG::ListBox::iterator it, const GG::Pt& pt, cons
 
     GG::MenuItem menu_contents, submenu_ignore, submenu_block, separator_item;
     std::string sitrep_text, sitrep_template;
+    std::string entry_margin("  ");
     separator_item.separator = true;
     int start_turn = 0;
     SitRepRow* sitrep_row(0);
     if (it != m_sitreps_lb->end()) 
         sitrep_row = dynamic_cast<SitRepRow*>(*it);
-    submenu_ignore.label = UserString("SITREP_IGNORE_MENU");
+    submenu_ignore.label = entry_margin + UserString("SITREP_IGNORE_MENU");
     if (sitrep_row) {
         const SitRepEntry& sitrep_entry = sitrep_row->GetSitRepEntry();
         sitrep_text = sitrep_entry.GetText();
         start_turn = sitrep_entry.GetTurn();
         if (start_turn > 0) {
-            submenu_ignore.next_level.push_back(GG::MenuItem(UserString("SITREP_SNOOZE_5_TURNS"),      1, false, false));
-            submenu_ignore.next_level.push_back(GG::MenuItem(UserString("SITREP_SNOOZE_10_TURNS"),     2, false, false));
-            submenu_ignore.next_level.push_back(GG::MenuItem(UserString("SITREP_SNOOZE_INDEFINITE"),   3, false, false));
+            submenu_ignore.next_level.push_back(GG::MenuItem(entry_margin + UserString("SITREP_SNOOZE_5_TURNS"),      1,
+                                                             false, false));
+            submenu_ignore.next_level.push_back(GG::MenuItem(entry_margin + UserString("SITREP_SNOOZE_10_TURNS"),     2,
+                                                             false, false));
+            submenu_ignore.next_level.push_back(GG::MenuItem(entry_margin + UserString("SITREP_SNOOZE_INDEFINITE"),   3,
+                                                             false, false));
             submenu_ignore.next_level.push_back(separator_item);
         }
     }
-    submenu_ignore.next_level.push_back(GG::MenuItem(UserString("SITREP_SNOOZE_CLEAR_ALL"),            4, false, false));
-    submenu_ignore.next_level.push_back(GG::MenuItem(UserString("SITREP_SNOOZE_CLEAR_INDEFINITE"),     5, false, false));
+    submenu_ignore.next_level.push_back(GG::MenuItem(entry_margin + UserString("SITREP_SNOOZE_CLEAR_ALL"),            4,
+                                                     false, false));
+    submenu_ignore.next_level.push_back(GG::MenuItem(entry_margin + UserString("SITREP_SNOOZE_CLEAR_INDEFINITE"),     5,
+                                                     false, false));
     menu_contents.next_level.push_back(submenu_ignore);
 
-    submenu_block.label = UserString("SITREP_BLOCK_MENU");
+    submenu_block.label = entry_margin + UserString("SITREP_BLOCK_MENU");
     if (sitrep_row) {
         const SitRepEntry& sitrep_entry = sitrep_row->GetSitRepEntry();
         sitrep_template = sitrep_entry.GetLabelString();
         std::string sitrep_label = sitrep_entry.GetStringtableLookupFlag() ? UserString(sitrep_template) : sitrep_template;
 
         if (!sitrep_label.empty() && !sitrep_template.empty()) {
-            submenu_block.next_level.push_back(GG::MenuItem(str(FlexibleFormat(UserString("SITREP_HIDE_TEMPLATE"))
-                                                                               % sitrep_label),        7, false, false));
+            submenu_block.next_level.push_back(GG::MenuItem(entry_margin + str(FlexibleFormat(UserString("SITREP_HIDE_TEMPLATE"))
+                                                                               % sitrep_label),                       7,
+                                                            false, false));
         }
     }
     if (m_hidden_sitrep_templates.size() > 0) {
         if (sitrep_row)
             submenu_block.next_level.push_back(separator_item);
-        submenu_block.next_level.push_back(GG::MenuItem(UserString("SITREP_SHOWALL_TEMPLATES"),        8, false, false));
+        submenu_block.next_level.push_back(GG::MenuItem(entry_margin + UserString("SITREP_SHOWALL_TEMPLATES"),        8,
+                                                        false, false));
     }
     menu_contents.next_level.push_back(submenu_block);
 
-    menu_contents.next_level.push_back(GG::MenuItem("? - " + UserString("SITREP_IGNORE_BLOCK_TITLE"),  9, false, false));
-    menu_contents.next_level.push_back(GG::MenuItem("  " + UserString("HOTKEY_COPY"),                 10, false, false));
+    menu_contents.next_level.push_back(GG::MenuItem("? - " + UserString("SITREP_IGNORE_BLOCK_TITLE"),                 9,
+                                                    false, false));
+    menu_contents.next_level.push_back(GG::MenuItem(entry_margin + UserString("HOTKEY_COPY"),                        10,
+                                                    false, false));
 
     CUIPopupMenu popup(pt.x, pt.y, menu_contents);
     if (!popup.Run())

--- a/UI/SitRepPanel.cpp
+++ b/UI/SitRepPanel.cpp
@@ -648,9 +648,10 @@ void SitRepPanel::DismissalMenu(GG::ListBox::iterator it, const GG::Pt& pt, cons
     }
     menu_contents.next_level.push_back(submenu_block);
 
-    menu_contents.next_level.push_back(GG::MenuItem("? - " + UserString("SITREP_IGNORE_BLOCK_TITLE"),                 9,
+    menu_contents.next_level.push_back(GG::MenuItem(entry_margin + UserString("HOTKEY_COPY"),                         9,
                                                     false, false));
-    menu_contents.next_level.push_back(GG::MenuItem(entry_margin + UserString("HOTKEY_COPY"),                        10,
+    menu_contents.next_level.push_back(GG::MenuItem(entry_margin + UserString("POPUP_MENU_PEDIA_PREFIX") +
+                                                    UserString("SITREP_IGNORE_BLOCK_TITLE"),                         10,
                                                     false, false));
 
     CUIPopupMenu popup(pt.x, pt.y, menu_contents);
@@ -692,14 +693,14 @@ void SitRepPanel::DismissalMenu(GG::ListBox::iterator it, const GG::Pt& pt, cons
         Update();
         break;
     }
-    case 9: { // Display help article
-        ClientUI::GetClientUI()->ZoomToEncyclopediaEntry("SITREP_IGNORE_BLOCK_TITLE");
-        break;
-    }
-    case 10: { // Copy text of sitrep
+    case 9: { // Copy text of sitrep
         if (sitrep_text.empty())
             break;
         GG::GUI::GetGUI()->SetClipboardText(GG::Font::StripTags(sitrep_text));
+        break;
+    }
+    case 10: { // Display help article
+        ClientUI::GetClientUI()->ZoomToEncyclopediaEntry("SITREP_IGNORE_BLOCK_TITLE");
         break;
     }
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -239,6 +239,9 @@ Unowned
 NOWHERE
 Cannot be produced
 
+# Prefix to use for menu items that will open a pedia entry
+POPUP_MENU_PEDIA_PREFIX
+'''Help: '''
 
 ##
 ## Major errors

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -5071,32 +5071,32 @@ FILTERS
 Filters
 
 SITREP_IGNORE_MENU
-'''  Ignore'''
+Ignore
 
 SITREP_BLOCK_MENU
-'''  Block'''
+Block
 
 SITREP_SNOOZE_5_TURNS
-'''  For 5 turns, ignore this SitRep'''
+For 5 turns, ignore this SitRep
 
 SITREP_SNOOZE_10_TURNS
-'''  For 10 turns, ignore this SitRep'''
+For 10 turns, ignore this SitRep
 
 SITREP_SNOOZE_INDEFINITE
-'''  Completely ignore this SitRep'''
+Completely ignore this SitRep
 
 SITREP_SNOOZE_CLEAR_INDEFINITE
-'''  Show completely ignored SitReps'''
+Show completely ignored SitReps
 
 SITREP_SNOOZE_CLEAR_ALL
-'''  Show all ignored SitReps'''
+Show all ignored SitReps
 
 # %1% localized name of SitRep template
 SITREP_HIDE_TEMPLATE
-'''  Block all %1% SitReps'''
+Block all %1% SitReps
 
 SITREP_SHOWALL_TEMPLATES
-'''  Show all blocked SitReps'''
+Show all blocked SitReps
 
 SITREP_WELCOME
 [[encyclopedia GREETINGS_GUIDE_TITLE]] [[GREETINGS_GUIDE_REFERENCE]]

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -5085,6 +5085,13 @@ SITREP_SNOOZE_CLEAR_INDEFINITE
 SITREP_SNOOZE_CLEAR_ALL
 '''  Show all ignored SitReps'''
 
+# %1% localized name of SitRep template
+SITREP_HIDE_TEMPLATE
+'''  Block all %1% SitReps'''
+
+SITREP_SHOWALL_TEMPLATES
+'''  Show all blocked SitReps'''
+
 SITREP_WELCOME
 [[encyclopedia GREETINGS_GUIDE_TITLE]] [[GREETINGS_GUIDE_REFERENCE]]
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -5070,6 +5070,12 @@ Situation Report - Turn %1%
 FILTERS
 Filters
 
+SITREP_IGNORE_MENU
+'''  Ignore'''
+
+SITREP_BLOCK_MENU
+'''  Block'''
+
 SITREP_SNOOZE_5_TURNS
 '''  For 5 turns, ignore this SitRep'''
 


### PR DESCRIPTION
Adds right click context for each SitRep row for:
- hiding SitReps of the same template type
- showing all hidden SitReps when at least one is hidden

Resolves #889 
