### PR TITLE
left-click on map to close fleet wnd

### DIFF
--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -531,7 +531,7 @@ namespace {
         // UI behavior
         db.Add("UI.tooltip-delay",              UserStringNop("OPTIONS_DB_UI_TOOLTIP_DELAY"),              500,        RangedValidator<int>(0, 3000));
         db.Add("UI.multiple-fleet-windows",     UserStringNop("OPTIONS_DB_UI_MULTIPLE_FLEET_WINDOWS"),     false);
-        db.Add("UI.window-quickclose",          UserStringNop("OPTIONS_DB_UI_WINDOW_QUICKCLOSE"),          false);
+        db.Add("UI.window-quickclose",          UserStringNop("OPTIONS_DB_UI_WINDOW_QUICKCLOSE"),          true);
         db.Add("UI.auto-reposition-windows",    UserStringNop("OPTIONS_DB_UI_AUTO_REPOSITION_WINDOWS"),    true);
 
         // UI behavior, hidden options

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -579,7 +579,7 @@ bool FleetUIManager::CloseAll() {
     std::vector<FleetWnd*> vec(m_fleet_wnds.begin(), m_fleet_wnds.end());
 
     for (std::size_t i = 0; i < vec.size(); ++i)
-        delete vec[i];
+        vec[i]->CloseClicked();
 
     m_active_fleet_wnd = 0;
 

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -2187,9 +2187,10 @@ void MapWnd::LButtonUp(const GG::Pt &pt, GG::Flags<GG::ModKey> mod_keys) {
 void MapWnd::LClick(const GG::Pt &pt, GG::Flags<GG::ModKey> mod_keys) {
     m_drag_offset = GG::Pt(-GG::X1, -GG::Y1);
     FleetUIManager& manager = FleetUIManager::GetFleetUIManager();
+    bool quick_close_wnds = GetOptionsDB().Get<bool>("UI.window-quickclose");
 
     // if a fleet window is visible, hide it and deselect fleet; if not, hide sidepanel
-    if (!m_dragged && !m_in_production_view_mode && manager.ActiveFleetWnd()) {
+    if (!m_dragged && !m_in_production_view_mode && manager.ActiveFleetWnd() && quick_close_wnds) {
         manager.CloseAll(); }
     else if (!m_dragged && !m_in_production_view_mode) {
         SelectSystem(INVALID_OBJECT_ID);
@@ -2208,21 +2209,6 @@ void MapWnd::RClick(const GG::Pt& pt, GG::Flags<GG::ModKey> mod_keys) {
             StarType star_type = m_moderator_wnd->SelectedStarType();
             net.SendMessage(ModeratorActionMessage(HumanClientApp::GetApp()->PlayerID(),
                 Moderator::CreateSystem(u_pos.first, u_pos.second, star_type)));
-            return;
-        }
-    }
-
-
-    // Attempt to close open fleet windows (if any are open and this is
-    // allowed), then attempt to close the SidePanel (if open);
-    // if these fail, go ahead with the context-sensitive popup menu. Note
-    // that this enforces a one-close-per-click policy.
-    if (GetOptionsDB().Get<bool>("UI.window-quickclose")) {
-        if (FleetUIManager::GetFleetUIManager().CloseAll())
-            return;
-
-        if (m_side_panel->Visible()) {
-            m_side_panel->Hide();
             return;
         }
     }
@@ -4145,23 +4131,6 @@ void MapWnd::SetProjectedFleetMovementLines(const std::vector<int>& fleet_ids,
 
 void MapWnd::ClearProjectedFleetMovementLines()
 { m_projected_fleet_lines.clear(); }
-
-bool MapWnd::EventFilter(GG::Wnd* w, const GG::WndEvent& event) {
-    if (event.Type() == GG::WndEvent::RClick && FleetUIManager::GetFleetUIManager().empty()) {
-        // Attempt to close the SidePanel (if open); if this fails, just let Wnd w handle it.
-        // Note that this enforces a one-close-per-click policy.
-
-        if (GetOptionsDB().Get<bool>("UI.window-quickclose")) {
-            if (m_side_panel->Visible()) {
-                m_side_panel->Hide();
-                DetachChild(m_side_panel);
-                return true;
-            }
-        }
-    }
-
-    return false;
-}
 
 void MapWnd::DoSystemIconsLayout() {
     // position and resize system icons and gaseous substance

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -2189,7 +2189,8 @@ void MapWnd::LClick(const GG::Pt &pt, GG::Flags<GG::ModKey> mod_keys) {
     FleetUIManager& manager = FleetUIManager::GetFleetUIManager();
 
     // if a fleet window is visible, hide it and deselect fleet; if not, hide sidepanel
-    if (manager.ActiveFleetWnd()) { manager.CloseAll(); }
+    if (!m_dragged && !m_in_production_view_mode && manager.ActiveFleetWnd()) {
+        manager.CloseAll(); }
     else if (!m_dragged && !m_in_production_view_mode) {
         SelectSystem(INVALID_OBJECT_ID);
         m_side_panel->Hide();

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -2186,7 +2186,11 @@ void MapWnd::LButtonUp(const GG::Pt &pt, GG::Flags<GG::ModKey> mod_keys) {
 
 void MapWnd::LClick(const GG::Pt &pt, GG::Flags<GG::ModKey> mod_keys) {
     m_drag_offset = GG::Pt(-GG::X1, -GG::Y1);
-    if (!m_dragged && !m_in_production_view_mode) {
+    FleetUIManager& manager = FleetUIManager::GetFleetUIManager();
+
+    // if a fleet window is visible, hide it and deselect fleet; if not, hide sidepanel
+    if (manager.ActiveFleetWnd()) { manager.CloseAll(); }
+    else if (!m_dragged && !m_in_production_view_mode) {
         SelectSystem(INVALID_OBJECT_ID);
         m_side_panel->Hide();
     }

--- a/UI/MapWnd.h
+++ b/UI/MapWnd.h
@@ -184,8 +184,6 @@ public:
     bool            IsFleetExploring(const int fleet_id);
     void            DispatchFleetsExploring();                      //!< called at each turn begin and when a fleet start/stop exploring to redispatch everyone.
 
-protected:
-    virtual bool    EventFilter(GG::Wnd* w, const GG::WndEvent& event);
 
 private:
     void            RefreshTradeResourceIndicator();

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1,4 +1,4 @@
-﻿English
+English
 
 # This is the English String Table file for FreeOrion
 #

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1,4 +1,4 @@
-English
+﻿English
 
 # This is the English String Table file for FreeOrion
 #
@@ -1446,7 +1446,7 @@ OPTIONS_DB_UI_MULTIPLE_FLEET_WINDOWS
 If true, clicks on multiple fleet buttons will open multiple fleet windows at the same time. Otherwise, opening a fleet window will close any currently-open fleet window.
 
 OPTIONS_DB_UI_WINDOW_QUICKCLOSE
-Close open windows such as fleet windows and the system-view side panel when you right-click on the main map.
+Close open fleet window(s) when you left-click on the main map.
 
 OPTIONS_DB_UI_AUTO_REPOSITION_WINDOWS
 Toggles whether to automatically reposition windows when the application size changes.
@@ -2183,7 +2183,7 @@ OPTIONS_MULTIPLE_FLEET_WNDS
 Multiple fleet windows
 
 OPTIONS_QUICK_CLOSE_WNDS
-Quick-close windows
+Quick-close fleet window(s)
 
 OPTIONS_SHOW_SIDEPANEL_PLANETS
 Show side panel planets


### PR DESCRIPTION
Left-clicking the map screen will close the fleet window if it is open. If no fleet window is open, it will close the sidepanel. (If you play with multiple fleet window enabled, all fleet windows will close.)
