### PR TITLE
Refactor Font::DetermineLines.

### DIFF
--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -108,6 +108,7 @@ GG_API std::string RgbaTag(const Clr& c);
     <br>The supported tags are:
     - \verbatim<i></i> \endverbatim                 Italics
     - \verbatim<u></u> \endverbatim                 Underline
+    - \verbatim<s></s> \endverbatim                 Shadow
     - \verbatim<rgba r g b a></rgba> \endverbatim   Color. Sets current rendering color to that specified by parameters.  Parameters may be either floating point values in the range [0.0, 1.0], or integer values in the range [0, 255].  All parameters must be in one format or the other.  The \</rgba> tag restores the previously set \<rgba> color, or restores the default color used to render the text when there are no other \<rgba> tags in effect.  Example tag: \<rgba 0.4 0.5 0.6 0.7>.
     - \verbatim<left></left> \endverbatim           Left-justified text.
     - \verbatim<center></center> \endverbatim       Centered text.

--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -564,9 +564,10 @@ private:
 
     typedef boost::unordered_map<boost::uint32_t, Glyph> GlyphMap;
 
-    /** Parse XML in text and add glyphs to text_elements. */
+    /**Populate \p text_elements with TextElements parsed from \p
+       text. \p ignore_tags determines if all KnownTags() are ignored.*/
     void FillTextElements(const std::string& text,
-                          Flags<TextFormat>& format,
+                          bool ignore_tags,
                           std::vector<boost::shared_ptr<TextElement> >& text_elements) const;
 
     Pt DetermineLinesImpl(const std::string& text,

--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -445,15 +445,18 @@ public:
                     std::size_t begin_line, CPSize begin_char,
                     std::size_t end_line, CPSize end_char) const;
 
+    /** Wrapper around PreRenderText that provides dummy values for line start and end values.*/
     void PreRenderText(const Pt& ul, const Pt& lr, const std::string& text, Flags<TextFormat>& format,
                        RenderCache& cache, const std::vector<LineData>* line_data = 0,
                        RenderState* render_state = 0) const;
 
+    /** Fill the \p cache with glyphs corresponding to the passed in \p text and \p line_data.*/
     void PreRenderText(const Pt& pt1, const Pt& pt2, const std::string& text,
                        Flags<TextFormat>& format, const std::vector<LineData>& line_data,
                        RenderState& render_state, std::size_t begin_line, CPSize begin_char,
                        std::size_t end_line, CPSize end_char, RenderCache& cache) const;
 
+    /** Render the glyphs from the \p cache.*/
     void RenderCachedText(RenderCache& cache) const;
 
     /** Sets \a render_state as if all the text before (<i>begin_line</i>,

--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -564,6 +564,11 @@ private:
 
     typedef boost::unordered_map<boost::uint32_t, Glyph> GlyphMap;
 
+    /** Parse XML in text and add glyphs to text_elements. */
+    void FillTextElements(const std::string& text,
+                          Flags<TextFormat>& format,
+                          std::vector<boost::shared_ptr<TextElement> >& text_elements) const;
+
     Pt DetermineLinesImpl(const std::string& text,
                           Flags<TextFormat>& format,
                           X box_width,

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -1098,13 +1098,12 @@ void Font::ThrowBadGlyph(const std::string& format_str, boost::uint32_t c)
 }
 
 void Font::FillTextElements(const std::string& text,
-                            Flags<TextFormat>& format,
+                            bool ignore_tags,
                             std::vector<boost::shared_ptr<TextElement> >& text_elements) const {
     if (text_elements.empty()) {
         using namespace boost::xpressive;
 
         std::stack<Substring> tag_stack;
-        bool ignore_tags = format & FORMAT_IGNORETAGS;
         MatchesKnownTag matches_known_tag(KnownTags(), ignore_tags);
         MatchesTopOfStack matches_tag_stack(tag_stack, ignore_tags);
 
@@ -1260,7 +1259,8 @@ Pt Font::DetermineLinesImpl(const std::string& text,
     std::vector<boost::shared_ptr<TextElement> >& text_elements =
         text_elements_ptr ? *text_elements_ptr : local_text_elements;
 
-    FillTextElements(text, format, text_elements);
+    bool ignore_tags = format & FORMAT_IGNORETAGS;
+    FillTextElements(text, ignore_tags, text_elements);
 
     RenderState render_state;
     int tab_width = 8; // default tab width

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -240,6 +240,21 @@ namespace {
     };
     const boost::xpressive::function<PushSubmatchOntoStack>::type Push = {{}};
 
+    struct PushSubmatchOntoStackP
+    {
+        typedef void result_type;
+        void operator()(const std::string* str,
+                        std::stack<Font::Substring>& tag_stack,
+                        bool& ignore_tags,
+                        const boost::xpressive::ssub_match& sub) const
+        {
+            tag_stack.push(Font::Substring(*str, sub));
+            if (tag_stack.top() == PRE_TAG)
+                ignore_tags = true;
+        }
+    };
+    const boost::xpressive::function<PushSubmatchOntoStackP>::type PushP = {{}};
+
     bool operator==(const Font::Substring& lhs, const boost::xpressive::ssub_match& rhs)
     {
         return lhs.size() == static_cast<std::size_t>(rhs.length()) &&

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -1097,25 +1097,9 @@ void Font::ThrowBadGlyph(const std::string& format_str, boost::uint32_t c)
     throw BadGlyph(boost::io::str(boost::format(format_str) % boost::io::str(format % c)));
 }
 
-Pt Font::DetermineLinesImpl(const std::string& text,
+void Font::FillTextElements(const std::string& text,
                             Flags<TextFormat>& format,
-                            X box_width,
-                            std::vector<LineData>& line_data,
-                            std::vector<boost::shared_ptr<TextElement> >* text_elements_ptr) const
-{
-    ValidateFormat(format);
-
-#if DEBUG_DETERMINELINES
-    std::cout << "Font::DetermineLines(text=\"" << text << "\" (@ "
-              << static_cast<const void*>(&*text.begin()) << ") format="
-              << format << " box_width=" << box_width << ")" << std::endl;
-#endif
-
-    std::vector<boost::shared_ptr<TextElement> > local_text_elements;
-
-    std::vector<boost::shared_ptr<TextElement> >& text_elements =
-        text_elements_ptr ? *text_elements_ptr : local_text_elements;
-
+                            std::vector<boost::shared_ptr<TextElement> >& text_elements) const {
     if (text_elements.empty()) {
         using namespace boost::xpressive;
 
@@ -1255,6 +1239,28 @@ Pt Font::DetermineLinesImpl(const std::string& text,
         std::cout << std::endl;
 #endif
     }
+}
+
+Pt Font::DetermineLinesImpl(const std::string& text,
+                            Flags<TextFormat>& format,
+                            X box_width,
+                            std::vector<LineData>& line_data,
+                            std::vector<boost::shared_ptr<TextElement> >* text_elements_ptr) const
+{
+    ValidateFormat(format);
+
+#if DEBUG_DETERMINELINES
+    std::cout << "Font::DetermineLines(text=\"" << text << "\" (@ "
+              << static_cast<const void*>(&*text.begin()) << ") format="
+              << format << " box_width=" << box_width << ")" << std::endl;
+#endif
+
+    std::vector<boost::shared_ptr<TextElement> > local_text_elements;
+
+    std::vector<boost::shared_ptr<TextElement> >& text_elements =
+        text_elements_ptr ? *text_elements_ptr : local_text_elements;
+
+    FillTextElements(text, format, text_elements);
 
     RenderState render_state;
     int tab_width = 8; // default tab width

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -718,19 +718,22 @@ namespace {
             mark_tag whitespace_tag(4);
             mark_tag text_tag(5);
 
-            //   [<]+?   -+ 'non-greedy'   ~not   set[|] 'set', _s space
-            // anythin but space or <
+            // The comments before each regex are intended to clarify the mapping from xpressive
+            // notation to the more typical regex notation.  If you read xpressive or don't read
+            // regex then ignore them.
+
+            // -+ 'non-greedy',   ~ 'not',   set[|] 'set',    _s 'space' = 'anything but space or <'
             const sregex TAG_PARAM =
                 -+~set[_s | '<'];
 
-            //+_w one or more greed word chars, () group no capture, [] semantic
+            //+_w one or more greed word chars,  () group no capture,  [] semantic operation
             const sregex OPEN_TAG_NAME =
                 (+_w)[check(boost::bind(&CompiledRegex::MatchesKnownTag, this, _1))];
             // (+_w) one or more greedy word check matches stack
             const sregex CLOSE_TAG_NAME =
                 (+_w)[check(boost::bind(&CompiledRegex::MatchesTopOfStack, this, _1))];
-            // *blank zero or more greedy whitespace, >> followed by , _ln newline,
-            // (set = 'a', 'b') [ab], +blank one or more greedy blank
+            // *blank  'zero or more greedy whitespace',   >> 'followed by',    _ln 'newline',
+            // (set = 'a', 'b') is '[ab]',    +blank 'one or more greedy blank'
             const sregex WHITESPACE =
                 (*blank >> (_ln | (set = '\n', '\r', '\f'))) | +blank;
 
@@ -741,9 +744,9 @@ namespace {
             if (!strip_unpaired_tags) {
                 m_EVERYTHING =
                     ('<' >> (tag_name_tag = OPEN_TAG_NAME) // < followed by TAG_NAME
-                     >> repeat<0, 9>(+blank >> TAG_PARAM)  //repeat 0 to 9  single blank followed
-                                                           //by TAG_PARAM
-                     >> (open_bracket_tag.proto_base() = '>'))  //s1. close tag and push
+                     >> repeat<0, 9>(+blank >> TAG_PARAM)  // repeat 0 to 9 a single blank followed
+                                                           // by TAG_PARAM
+                     >> (open_bracket_tag.proto_base() = '>'))  // s1. close tag and push operation
                     [PushP(ref(m_text), ref(m_tag_stack), ref(m_ignore_tags), tag_name_tag)] |
                     ("</" >> (tag_name_tag = CLOSE_TAG_NAME) >> (close_bracket_tag.proto_base() = '>')) |
                     (whitespace_tag = WHITESPACE) |

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -67,6 +67,10 @@ namespace {
     const boost::uint32_t WIDE_FF = '\f';
     const boost::uint32_t WIDE_TAB = '\t';
 
+    const std::string ITALIC_TAG = "i";
+    const std::string SHADOW_TAG = "s";
+    const std::string UNDERLINE_TAG = "u";
+    const std::string RGBA_TAG = "rgba";
     const std::string ALIGN_LEFT_TAG = "left";
     const std::string ALIGN_CENTER_TAG = "center";
     const std::string ALIGN_RIGHT_TAG = "right";
@@ -853,10 +857,10 @@ namespace {
 
     // Registers the default action and known tags.
     int RegisterDefaultTags() {
-        StaticTagHandler().Insert("i");
-        StaticTagHandler().Insert("s");
-        StaticTagHandler().Insert("u");
-        StaticTagHandler().Insert("rgba");
+        StaticTagHandler().Insert(ITALIC_TAG);
+        StaticTagHandler().Insert(SHADOW_TAG);
+        StaticTagHandler().Insert(UNDERLINE_TAG);
+        StaticTagHandler().Insert(RGBA_TAG);
         StaticTagHandler().Insert(ALIGN_LEFT_TAG);
         StaticTagHandler().Insert(ALIGN_CENTER_TAG);
         StaticTagHandler().Insert(ALIGN_RIGHT_TAG);
@@ -1927,7 +1931,7 @@ X Font::StoreGlyph(const Pt& pt, const Glyph& glyph, const Font::RenderState* re
 void Font::HandleTag(const boost::shared_ptr<FormattingTag>& tag, double* orig_color,
                      RenderState& render_state) const
 {
-    if (tag->tag_name == "i") {
+    if (tag->tag_name == ITALIC_TAG) {
         if (tag->close_tag) {
             if (render_state.use_italics) {
                 --render_state.use_italics;
@@ -1935,7 +1939,7 @@ void Font::HandleTag(const boost::shared_ptr<FormattingTag>& tag, double* orig_c
         } else {
             ++render_state.use_italics;
         }
-    } else if (tag->tag_name == "u") {
+    } else if (tag->tag_name == UNDERLINE_TAG) {
         if (tag->close_tag) {
             if (render_state.draw_underline) {
                 --render_state.draw_underline;
@@ -1943,7 +1947,7 @@ void Font::HandleTag(const boost::shared_ptr<FormattingTag>& tag, double* orig_c
         } else {
             ++render_state.draw_underline;
         }
-    } else if (tag->tag_name == "s") {
+    } else if (tag->tag_name == SHADOW_TAG) {
         if (tag->close_tag) {
             if (render_state.use_shadow) {
                 --render_state.use_shadow;
@@ -1951,7 +1955,7 @@ void Font::HandleTag(const boost::shared_ptr<FormattingTag>& tag, double* orig_c
         } else {
             ++render_state.use_shadow;
         }
-    } else if (tag->tag_name == "rgba") {
+    } else if (tag->tag_name == RGBA_TAG) {
         if (tag->close_tag) {
             // Popping is ok also for an empty color stack.
             render_state.PopColor();

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -711,7 +711,6 @@ namespace {
         CompiledRegex(const std::set<std::string>& known_tags, bool strip_unpaired_tags) :
             m_text(0), m_known_tags(&known_tags), m_ignore_tags(false), m_tag_stack(),
             m_EVERYTHING() {
-
             // Synonyms for s1 thru s5 sub matches
             mark_tag tag_name_tag(1);
             mark_tag open_bracket_tag(2);
@@ -800,7 +799,9 @@ namespace {
 
     class TagHandler {
         public:
-        TagHandler() : m_known_tags()
+        TagHandler() : m_known_tags(),
+                       m_regex_w_tags(m_known_tags, false),
+                       m_regex_w_tags_skipping_unmatched(m_known_tags, true)
         {}
 
         void Insert(const std::string& tag) {
@@ -817,10 +818,24 @@ namespace {
 
         const std::set<std::string>& KnownTags()
         { return m_known_tags; }
+        // Return a regex bound to \p text using the currently known
+        // tags possible \p ignore_tags and/or \p strip_unpaired_tags
+        sregex & Regex(const std::string& text, bool ignore_tags, bool strip_unpaired_tags = false) {
+            if (!strip_unpaired_tags)
+                return m_regex_w_tags.BindRegexToText(text, ignore_tags);
+            else
+                return m_regex_w_tags_skipping_unmatched.BindRegexToText(text, ignore_tags);
+        }
 
         private:
         // set of tags known to the handler
         std::set<std::string> m_known_tags;
+
+        // Compiled regular expression including tag stack
+        CompiledRegex m_regex_w_tags;
+
+        // Compiled regular expression using tags but skipping unmatched tags.
+        CompiledRegex m_regex_w_tags_skipping_unmatched;
     };
 
 


### PR DESCRIPTION
This PR refactors Font::DetermineLines.
It creates FillTextElements to do the intensive processing of DetermineLines.
It moves all of the boost::xpressive regex creation into CompiledRegex, to reduce repetition in the code.
