### PR TITLE
Remove gotchas variants of `Font::DetermineLines()`.

### DIFF
--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -448,7 +448,7 @@ public:
 
     /** Wrapper around PreRenderText that provides dummy values for line start and end values.*/
     void PreRenderText(const Pt& ul, const Pt& lr, const std::string& text, Flags<TextFormat>& format,
-                       RenderCache& cache, const std::vector<LineData>* line_data = 0,
+                       RenderCache& cache, const std::vector<LineData>& line_data,
                        RenderState* render_state = 0) const;
 
     /** Fill the \p cache with glyphs corresponding to the passed in \p text and \p line_data.*/
@@ -474,7 +474,7 @@ public:
         call it repeatedly on a known text.
     */
     std::vector<boost::shared_ptr<Font::TextElement> > ExpensiveParseFromTextToTextElements(const std::string& text,
-                                                                                            const Flags<TextFormat>& format = FORMAT_NONE) const;
+                                                                                            const Flags<TextFormat>& format) const;
 
     /** Returns the maximum dimensions of the string in x and y, and populates
         \a line_data. */

--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -477,20 +477,7 @@ public:
                                                                                             const Flags<TextFormat>& format) const;
 
     /** Returns the maximum dimensions of the string in x and y, and populates
-        \a line_data. */
-    Pt   DetermineLines(const std::string& text, Flags<TextFormat>& format, X box_width,
-                        std::vector<LineData>& line_data) const;
-
-    /** Returns the maximum dimensions of the string in x and y, and populates
-        \a line_data and \a text_elements.  Note that \a text_elements must be
-        empty. */
-    Pt   DetermineLines(const std::string& text, Flags<TextFormat>& format, X box_width,
-                        std::vector<LineData>& line_data,
-                        std::vector<boost::shared_ptr<TextElement> >& text_elements) const;
-
-    /** Returns the maximum dimensions of the string in x and y, and populates
-        \a line_data.  The contents of \a text_elements will be used, and the
-        equivalent work done by DetermineLines() will be skipped.  Supplying a
+        \a line_data.  The contents of \a text_elements will be used.  Supplying a
         \a text and a \a text_elements that are incompatible will result in
         undefined behavior. */
     Pt   DetermineLines(const std::string& text, Flags<TextFormat>& format, X box_width,
@@ -577,7 +564,7 @@ private:
                           Flags<TextFormat>& format,
                           X box_width,
                           std::vector<LineData>& line_data,
-                          std::vector<boost::shared_ptr<TextElement> >* text_elements_ptr) const;
+                          const std::vector<boost::shared_ptr<TextElement> >& text_elements) const;
 
     FT_Error          GetFace(FT_Face& face);
     FT_Error          GetFace(const std::vector<unsigned char>& file_contents, FT_Face& face);

--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -476,10 +476,19 @@ public:
     std::vector<boost::shared_ptr<Font::TextElement> > ExpensiveParseFromTextToTextElements(const std::string& text,
                                                                                             const Flags<TextFormat>& format) const;
 
-    /** Returns the maximum dimensions of the string in x and y, and populates
-        \a line_data.  The contents of \a text_elements will be used.  Supplying a
-        \a text and a \a text_elements that are incompatible will result in
-        undefined behavior. */
+    /** DetermineLines() calculates the \p line_data resulting from adding the necessary line
+        breaks, to  the \p text formatted with \p format and parsed into \p text_elements, to fit
+        the \p text into a box of width \p box_width. It returns the text extent of that \p
+        line_data.
+
+        It accounts for alignment, wrapping and justification of the \p text.
+
+        A \p box_width of X0 will add a line break at every whitespace element in \p text_elements.
+
+        Supplying a \p text and \p text_elements that are incompatible will result in undefined
+        behavior.  \p text_elements contains internal pointers to the \p text to which it is
+        bound.  Compatible means the exact same \p text object, not the same text content.
+        */
     Pt   DetermineLines(const std::string& text, Flags<TextFormat>& format, X box_width,
                         const std::vector<boost::shared_ptr<TextElement> >& text_elements,
                         std::vector<LineData>& line_data) const;

--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -474,7 +474,7 @@ public:
         call it repeatedly on a known text.
     */
     std::vector<boost::shared_ptr<Font::TextElement> > ExpensiveParseFromTextToTextElements(const std::string& text,
-                                                                                            const Flags<TextFormat>& format) const;
+                                                                                            const Flags<TextFormat>& format = FORMAT_NONE) const;
 
     /** Returns the maximum dimensions of the string in x and y, and populates
         \a line_data. */

--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -465,6 +465,16 @@ public:
     void ProcessTagsBefore(const std::vector<LineData>& line_data, RenderState& render_state,
                            std::size_t begin_line, CPSize begin_char) const;
 
+    /**Populate \p text_elements with TextElements parsed from \p
+       text. \p ignore_tags determines if all KnownTags() are ignored.
+
+       This function is costly even on one character texts. Do not call it from tight loops.  Do
+       not call it from within Render().  Do not call it repeatedly on a known text.
+    */
+    void ExpensiveParseFromTextToTextElements(const std::string& text,
+                                              bool ignore_tags,
+                                              std::vector<boost::shared_ptr<TextElement> >& text_elements) const;
+
     /** Returns the maximum dimensions of the string in x and y, and populates
         \a line_data. */
     Pt   DetermineLines(const std::string& text, Flags<TextFormat>& format, X box_width,
@@ -567,12 +577,6 @@ private:
     };
 
     typedef boost::unordered_map<boost::uint32_t, Glyph> GlyphMap;
-
-    /**Populate \p text_elements with TextElements parsed from \p
-       text. \p ignore_tags determines if all KnownTags() are ignored.*/
-    void FillTextElements(const std::string& text,
-                          bool ignore_tags,
-                          std::vector<boost::shared_ptr<TextElement> >& text_elements) const;
 
     Pt DetermineLinesImpl(const std::string& text,
                           Flags<TextFormat>& format,

--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -472,7 +472,7 @@ public:
        not call it from within Render().  Do not call it repeatedly on a known text.
     */
     void ExpensiveParseFromTextToTextElements(const std::string& text,
-                                              bool ignore_tags,
+                                              const Flags<TextFormat>& format,
                                               std::vector<boost::shared_ptr<TextElement> >& text_elements) const;
 
     /** Returns the maximum dimensions of the string in x and y, and populates

--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -435,7 +435,7 @@ public:
 
     /** Formatted text rendering. */
     void RenderText(const Pt& pt1, const Pt& pt2, const std::string& text, Flags<TextFormat>& format,
-                    const std::vector<LineData>* line_data = 0, RenderState* render_state = 0) const;
+                    const std::vector<LineData>& line_data, RenderState* render_state = 0) const;
 
     /** Formatted text rendering over a subset of lines and code points.  The
         glyphs rendered are in the range [CodePointIndexOf(<i>begin_line</i>,

--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -465,15 +465,16 @@ public:
     void ProcessTagsBefore(const std::vector<LineData>& line_data, RenderState& render_state,
                            std::size_t begin_line, CPSize begin_char) const;
 
-    /**Populate \p text_elements with TextElements parsed from \p
-       text. \p ignore_tags determines if all KnownTags() are ignored.
+    /** Return a vector of TextElements parsed from \p text, using the
+        FORMAT_IGNORETAGS bit in \p format to determine if all KnownTags()
+        are ignored.
 
-       This function is costly even on one character texts. Do not call it from tight loops.  Do
-       not call it from within Render().  Do not call it repeatedly on a known text.
+        This function is costly even on single character texts. Do not call
+        it from tight loops.  Do not call it from within Render().  Do not
+        call it repeatedly on a known text.
     */
-    void ExpensiveParseFromTextToTextElements(const std::string& text,
-                                              const Flags<TextFormat>& format,
-                                              std::vector<boost::shared_ptr<TextElement> >& text_elements) const;
+    std::vector<boost::shared_ptr<Font::TextElement> > ExpensiveParseFromTextToTextElements(const std::string& text,
+                                                                                            const Flags<TextFormat>& format) const;
 
     /** Returns the maximum dimensions of the string in x and y, and populates
         \a line_data. */

--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -497,12 +497,6 @@ public:
                         const std::vector<boost::shared_ptr<TextElement> >& text_elements,
                         std::vector<LineData>& line_data) const;
 
-    /** Returns the maximum dimensions of the string in x and y.  Provided as
-        a convenience; it just calls DetermineLines with the given
-        parameters. */
-    Pt   TextExtent(const std::string& text, Flags<TextFormat> format = FORMAT_NONE,
-                    X box_width = X0) const;
-
     /** Returns the maximum dimensions of the text in x and y. */
     Pt   TextExtent(const std::string& text, const std::vector<LineData>& line_data) const;
     //@}

--- a/GG/src/BrowseInfoWnd.cpp
+++ b/GG/src/BrowseInfoWnd.cpp
@@ -131,7 +131,11 @@ unsigned int TextBoxBrowseInfoWnd::TextMargin() const
 void TextBoxBrowseInfoWnd::SetText(const std::string& str)
 {
     unsigned int margins = 2 * TextMargin();
-    Pt extent = m_font->TextExtent(str, GetTextFormat(), m_preferred_width - X(margins));
+
+    std::vector<Font::LineData> lines;
+    std::vector<boost::shared_ptr<Font::TextElement> > text_elements = m_font->ExpensiveParseFromTextToTextElements(str, GetTextFormat());
+    Flags<TextFormat> fmt = GetTextFormat();
+    Pt extent = m_font->DetermineLines(str, fmt, m_preferred_width - X(margins), text_elements, lines);
     SetMinSize(extent + Pt(X(margins), Y(margins)));
     m_text_control->SetText(str);
     Resize(extent + Pt(X(margins), Y0));

--- a/GG/src/BrowseInfoWnd.cpp
+++ b/GG/src/BrowseInfoWnd.cpp
@@ -133,8 +133,8 @@ void TextBoxBrowseInfoWnd::SetText(const std::string& str)
     unsigned int margins = 2 * TextMargin();
 
     std::vector<Font::LineData> lines;
-    std::vector<boost::shared_ptr<Font::TextElement> > text_elements = m_font->ExpensiveParseFromTextToTextElements(str, GetTextFormat());
     Flags<TextFormat> fmt = GetTextFormat();
+    std::vector<boost::shared_ptr<Font::TextElement> > text_elements = m_font->ExpensiveParseFromTextToTextElements(str, fmt);
     Pt extent = m_font->DetermineLines(str, fmt, m_preferred_width - X(margins), text_elements, lines);
     SetMinSize(extent + Pt(X(margins), Y(margins)));
     m_text_control->SetText(str);

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -1136,12 +1136,6 @@ std::string Font::StripTags(const std::string& text, bool strip_unpaired_tags)
     return retval.str();
 }
 
-Pt Font::TextExtent(const std::string& text, Flags<TextFormat> format/* = FORMAT_NONE*/, X box_width/* = X0*/) const
-{
-    std::vector<LineData> lines;
-    return DetermineLines(text, format, box_width ? box_width : X(1 << 15), lines);
-}
-
 Pt Font::TextExtent(const std::string& text, const std::vector<LineData>& line_data) const
 {
     Pt retval;

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -965,21 +965,14 @@ void Font::RenderText(const Pt& ul, const Pt& lr, const std::string& text, Flags
 }
 
 void Font::PreRenderText(const Pt& ul, const Pt& lr, const std::string& text, Flags<TextFormat>& format, RenderCache& cache,
-                         const std::vector<LineData>* line_data/* = 0*/, RenderState* render_state/* = 0*/) const
+                         const std::vector<LineData>& line_data, RenderState* render_state/* = 0*/) const
  {
     RenderState state;
     if (!render_state)
         render_state = &state;
 
-    // get breakdown of how text is divided into lines
-    std::vector<LineData> lines;
-    if (!line_data) {
-        DetermineLines(text, format, lr.x - ul.x, lines);
-        line_data = &lines;
-    }
-
-    PreRenderText(ul, lr, text, format, *line_data, *render_state,
-                  0, CP0, line_data->size(), line_data->empty() ? CP0 : CPSize(line_data->back().char_data.size()), cache);
+    PreRenderText(ul, lr, text, format, line_data, *render_state,
+                  0, CP0, line_data.size(), line_data.empty() ? CP0 : CPSize(line_data.back().char_data.size()), cache);
 }
 
 void Font::PreRenderText(const Pt& ul, const Pt& lr, const std::string& text, Flags<TextFormat>& format,

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -1253,7 +1253,7 @@ namespace DebugOutput {
     }
 }
 
-void Font::FillTextElements(const std::string& text,
+void Font::ExpensiveParseFromTextToTextElements(const std::string& text,
                             bool ignore_tags,
                             std::vector<boost::shared_ptr<TextElement> >& text_elements) const
 {
@@ -1385,7 +1385,7 @@ Pt Font::DetermineLinesImpl(const std::string& text,
         text_elements_ptr ? *text_elements_ptr : local_text_elements;
 
     bool ignore_tags = format & FORMAT_IGNORETAGS;
-    FillTextElements(text, ignore_tags, text_elements);
+    ExpensiveParseFromTextToTextElements(text, ignore_tags, text_elements);
 
     RenderState render_state;
     int tab_width = 8; // default tab width

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -1311,9 +1311,9 @@ std::vector<boost::shared_ptr<Font::TextElement> > Font::ExpensiveParseFromTextT
                     for (smatch::nested_results_type::const_iterator nested_it =
                              ++(*it).nested_results().begin();
                          nested_it != (*it).nested_results().end();
-                         ++nested_it) {
-                        element->params.push_back(
-                            Substring(text, (*nested_it)[0]));
+                         ++nested_it)
+                    {
+                        element->params.push_back(Substring(text, (*nested_it)[0]));
                     }
                 }
                 element->tag_name = Substring(text, (*it)[tag_name_tag]);

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -937,21 +937,14 @@ X Font::RenderText(const Pt& pt_, const std::string& text) const
 }
 
 void Font::RenderText(const Pt& ul, const Pt& lr, const std::string& text, Flags<TextFormat>& format,
-                      const std::vector<LineData>* line_data/* = 0*/, RenderState* render_state/* = 0*/) const
-                      {
+                      const std::vector<LineData>& line_data, RenderState* render_state/* = 0*/) const
+{
     RenderState state;
     if (!render_state)
         render_state = &state;
 
-    // get breakdown of how text is divided into lines
-    std::vector<LineData> lines;
-    if (!line_data) {
-        DetermineLines(text, format, lr.x - ul.x, lines);
-        line_data = &lines;
-    }
-
-    RenderText(ul, lr, text, format, *line_data, *render_state,
-               0, CP0, line_data->size(), CPSize(line_data->back().char_data.size()));
+    RenderText(ul, lr, text, format, line_data, *render_state,
+               0, CP0, line_data.size(), CPSize(line_data.back().char_data.size()));
 }
 
 void Font::RenderText(const Pt& ul, const Pt& lr, const std::string& text, Flags<TextFormat>& format,

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -1254,7 +1254,7 @@ namespace DebugOutput {
 }
 
 void Font::ExpensiveParseFromTextToTextElements(const std::string& text,
-                            bool ignore_tags,
+                            const Flags<TextFormat>& format,
                             std::vector<boost::shared_ptr<TextElement> >& text_elements) const
 {
     if (text_elements.empty()) {
@@ -1262,6 +1262,8 @@ void Font::ExpensiveParseFromTextToTextElements(const std::string& text,
 
         if (text.empty())
             return;
+
+        bool ignore_tags = format & FORMAT_IGNORETAGS;
 
         // Fetch and use the regular expression from the TagHandler which parses all the known XML tags.
         sregex& regex = StaticTagHandler().Regex(text, ignore_tags);
@@ -1384,8 +1386,7 @@ Pt Font::DetermineLinesImpl(const std::string& text,
     std::vector<boost::shared_ptr<TextElement> >& text_elements =
         text_elements_ptr ? *text_elements_ptr : local_text_elements;
 
-    bool ignore_tags = format & FORMAT_IGNORETAGS;
-    ExpensiveParseFromTextToTextElements(text, ignore_tags, text_elements);
+    ExpensiveParseFromTextToTextElements(text, format, text_elements);
 
     RenderState render_state;
     int tab_width = 8; // default tab width

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -1068,27 +1068,10 @@ void Font::ProcessTagsBefore(const std::vector<LineData>& line_data, RenderState
 }
 
 Pt Font::DetermineLines(const std::string& text, Flags<TextFormat>& format, X box_width,
-                        std::vector<LineData>& line_data) const
-{ return DetermineLinesImpl(text, format, box_width, line_data, 0); }
-
-Pt Font::DetermineLines(const std::string& text, Flags<TextFormat>& format, X box_width,
-                        std::vector<LineData>& line_data,
-                        std::vector<boost::shared_ptr<TextElement> >& text_elements) const
-{
-    assert(text_elements.empty());
-    return DetermineLinesImpl(text, format, box_width, line_data, &text_elements);
-}
-
-Pt Font::DetermineLines(const std::string& text, Flags<TextFormat>& format, X box_width,
                         const std::vector<boost::shared_ptr<TextElement> >& text_elements,
                         std::vector<LineData>& line_data) const
 {
-    assert(!text_elements.empty());
-    return DetermineLinesImpl(text,
-                              format,
-                              box_width,
-                              line_data,
-                              const_cast<std::vector<boost::shared_ptr<TextElement> >*>(&text_elements));
+    return DetermineLinesImpl(text, format, box_width, line_data, text_elements);
 }
 
 std::string Font::StripTags(const std::string& text, bool strip_unpaired_tags)
@@ -1358,11 +1341,9 @@ Pt Font::DetermineLinesImpl(const std::string& text,
                             Flags<TextFormat>& format,
                             X box_width,
                             std::vector<LineData>& line_data,
-                            std::vector<boost::shared_ptr<TextElement> >* text_elements_ptr) const
+                            const std::vector<boost::shared_ptr<TextElement> >& text_elements) const
 {
     ValidateFormat(format);
-
-    std::vector<boost::shared_ptr<TextElement> > text_elements = ExpensiveParseFromTextToTextElements(text, format);
 
     RenderState render_state;
     int tab_width = 8; // default tab width

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -1319,14 +1319,14 @@ std::vector<boost::shared_ptr<Font::TextElement> > Font::ExpensiveParseFromTextT
                 element->tag_name = Substring(text, (*it)[tag_name_tag]);
                 text_elements.push_back(element);
 
-                // Close XML tag
+            // Close XML tag
             } else if ((*it)[close_bracket_tag].matched) {
                 boost::shared_ptr<Font::FormattingTag> element(new Font::FormattingTag(true));
                 element->text = Substring(text, (*it)[0]);
                 element->tag_name = Substring(text, (*it)[tag_name_tag]);
                 text_elements.push_back(element);
 
-                // Whitespace element
+            // Whitespace element
             } else if ((*it)[whitespace_tag].matched) {
                 boost::shared_ptr<Font::TextElement> element(new Font::TextElement(true, false));
                 element->text = Substring(text, (*it)[whitespace_tag]);
@@ -1336,11 +1336,12 @@ std::vector<boost::shared_ptr<Font::TextElement> > Font::ExpensiveParseFromTextT
                 // newline TextElement.
                 char last_char = *boost::prior(element->text.end());
                 if (last_char == '\n' || last_char == '\f' || last_char == '\r') {
-                    // Basic text element.
                     boost::shared_ptr<Font::TextElement> element(new Font::TextElement(false, true));
                     text_elements.push_back(element);
                 }
             }
+
+        // Basic text element.
         } else {
             boost::shared_ptr<Font::TextElement> element(new Font::TextElement(false, false));
             element->text = combined_text;

--- a/GG/src/Menu.cpp
+++ b/GG/src/Menu.cpp
@@ -465,7 +465,9 @@ void PopupMenu::Render()
             }
             std::vector<Font::LineData> lines;
             Flags<TextFormat> fmt = FORMAT_LEFT | FORMAT_TOP;
-            Pt menu_sz = m_font->DetermineLines(str, fmt, X0, lines); // get dimensions of text in menu
+            std::vector<boost::shared_ptr<Font::TextElement> > text_elements
+                = m_font->ExpensiveParseFromTextToTextElements(str, fmt);
+            Pt menu_sz = m_font->DetermineLines(str, fmt, X0, text_elements, lines); // get dimensions of text in menu
             menu_sz.x += 2 * HORIZONTAL_MARGIN;
             if (needs_indicator)
                 menu_sz.x += CHECK_WIDTH + 2 * HORIZONTAL_MARGIN; // make room for the little arrow

--- a/GG/src/Menu.cpp
+++ b/GG/src/Menu.cpp
@@ -519,7 +519,13 @@ void PopupMenu::Render()
                 glColor3ub(clr.r, clr.g, clr.b);
 
                 if (!menu.next_level[j].separator) {
-                    m_font->RenderText(line_rect.ul, line_rect.lr, menu.next_level[j].label, fmt);
+                    // TODO cache line data v expensive calculation
+                    std::vector<Font::LineData> lines;
+                    std::vector<boost::shared_ptr<Font::TextElement> > text_elements
+                        = m_font->ExpensiveParseFromTextToTextElements(menu.next_level[j].label, fmt);
+                    Pt menu_sz = m_font->DetermineLines(menu.next_level[j].label, fmt, X0, text_elements, lines);
+
+                    m_font->RenderText(line_rect.ul, line_rect.lr, menu.next_level[j].label, fmt, lines);
 
                 } else {
                     Line(line_rect.ul.x + HORIZONTAL_MARGIN, line_rect.ul.y + INDICATOR_HEIGHT/2 + INDICATOR_VERTICAL_MARGIN,

--- a/GG/src/MultiEdit.cpp
+++ b/GG/src/MultiEdit.cpp
@@ -303,7 +303,9 @@ void MultiEdit::SetText(const std::string& str)
             TextControl::SetText(str);
         } else {
             std::vector<Font::LineData> lines;
-            GetFont()->DetermineLines(str, format, cl_sz.x, lines);
+            std::vector<boost::shared_ptr<Font::TextElement> > text_elements
+                = GetFont()->ExpensiveParseFromTextToTextElements(str, format);
+            Pt extent = GetFont()->DetermineLines(str, format, cl_sz.x, text_elements, lines);
             if (m_max_lines_history < lines.size()) {
                 std::size_t first_line = 0;
                 std::size_t last_line = m_max_lines_history - 1;

--- a/GG/src/TextControl.cpp
+++ b/GG/src/TextControl.cpp
@@ -162,7 +162,7 @@ void TextControl::RefreshCache() {
     PurgeCache();
     m_render_cache = new Font::RenderCache();
     if (m_font)
-        m_font->PreRenderText(Pt(X0, Y0), Size(), m_text, m_format, *m_render_cache, &m_line_data);
+        m_font->PreRenderText(Pt(X0, Y0), Size(), m_text, m_format, *m_render_cache, m_line_data);
 }
 
 void TextControl::PurgeCache()

--- a/GG/src/TextControl.cpp
+++ b/GG/src/TextControl.cpp
@@ -73,7 +73,7 @@ Pt TextControl::MinUsableSize(X width) const
 
     std::vector<Font::LineData> dummy_line_data;
     Flags<TextFormat> dummy_format(m_format);
-    m_cached_minusable_size = m_font->DetermineLines(m_text, dummy_format, width, dummy_line_data)
+    m_cached_minusable_size = m_font->DetermineLines(m_text, dummy_format, width, m_text_elements, dummy_line_data)
         + (ClientUpperLeft() - UpperLeft()) + (LowerRight() - ClientLowerRight());
     m_cached_minusable_size_width = width;
     return m_cached_minusable_size;
@@ -183,9 +183,9 @@ void TextControl::SetText(const std::string& str)
         return;
 
     m_code_points = CPSize(utf8::distance(str.begin(), str.end()));
-    m_text_elements.clear();
+    m_text_elements = m_font->ExpensiveParseFromTextToTextElements(m_text, m_format);
     Pt text_sz =
-        m_font->DetermineLines(m_text, m_format, ClientSize().x, m_line_data, m_text_elements);
+        m_font->DetermineLines(m_text, m_format, ClientSize().x, m_text_elements, m_line_data);
     m_text_ul = Pt();
     m_text_lr = text_sz;
     AdjustMinimumSize();
@@ -233,13 +233,9 @@ void TextControl::SizeMove(const Pt& ul, const Pt& lr)
 
     if (redo_determine_lines) {
         Pt text_sz;
-        if (m_text_elements.empty()) {
-            text_sz =
-                m_font->DetermineLines(m_text, m_format, client_width, m_line_data, m_text_elements);
-        } else {
-            text_sz =
-                m_font->DetermineLines(m_text, m_format, client_width, m_text_elements, m_line_data);
-        }
+        if (m_text_elements.empty())
+            m_text_elements = m_font->ExpensiveParseFromTextToTextElements(m_text, m_format);
+        text_sz = m_font->DetermineLines(m_text, m_format, client_width, m_text_elements, m_line_data);
         m_text_ul = Pt();
         m_text_lr = text_sz;
         AdjustMinimumSize();

--- a/GG/src/dialogs/FileDlg.cpp
+++ b/GG/src/dialogs/FileDlg.cpp
@@ -265,8 +265,8 @@ void FileDlg::DoLayout()
 
     // determine the space needed to display both text labels in the chosen font; use this to expand the edit as far as
     // possible
-    X labels_width = std::max(m_font->TextExtent(m_files_label->Text()).x, 
-                              m_font->TextExtent(m_file_types_label->Text()).x) + H_SPACING;
+    X labels_width = std::max((m_files_label->MinUsableSize()).x,
+                              (m_file_types_label->MinUsableSize()).x) + H_SPACING;
 
     m_files_label->MoveTo(Pt(X0, Height() - (button_height + V_SPACING) * 2));
     m_files_label->Resize(Pt(labels_width - H_SPACING / 2, button_height));
@@ -657,7 +657,8 @@ void FileDlg::UpdateDirectoryText()
 #else
     std::string str = s_working_dir.string();
 #endif
-    while (m_font->TextExtent(str).x > Width() - 2 * H_SPACING) {
+    m_curr_dir_text->SetText(str);
+    while (m_curr_dir_text->Width() > Width() - 2 * H_SPACING) {
         std::string::size_type slash_idx = str.find('/', 1);
         std::string::size_type backslash_idx = str.find('\\', 1);
         if (slash_idx != std::string::npos) {
@@ -669,8 +670,8 @@ void FileDlg::UpdateDirectoryText()
         } else {
             break;
         }
+        m_curr_dir_text->SetText(str);
     }
-    *m_curr_dir_text << str;
     DoLayout();
 }
 

--- a/UI/CombatReport/GraphicalSummary.cpp
+++ b/UI/CombatReport/GraphicalSummary.cpp
@@ -586,8 +586,13 @@ public:
         GG::Pt pos(GG::X(0), GG::Y(0));
         for (std::vector<ToggleData*>::iterator it = m_toggles.begin(); it != m_toggles.end(); ++it) {
             ToggleData& toggle = **it;
-            toggle.button->Resize(GG::Pt(cui_font->TextExtent(toggle.button->Text(), GG::FORMAT_LEFT).x + OPTION_BUTTON_PADDING,
-                                         OPTION_BUTTON_HEIGHT));
+            if (!toggle.button->Children().empty()) {
+                //Assume first child of the button is the label
+                if (const GG::TextControl* label = dynamic_cast<GG::TextControl const*>(toggle.button->Children().front())) {
+                    toggle.button->Resize(GG::Pt(label->MinUsableSize().x
+                                                 + OPTION_BUTTON_PADDING, OPTION_BUTTON_HEIGHT));
+                }
+            }
             toggle.button->MoveTo(pos);
             pos.x += toggle.button->Width() + OPTION_BUTTON_PADDING;
         }

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -2439,7 +2439,12 @@ namespace {
             std::string species_name = *it;
 
             std::string species_name_column1 = str(FlexibleFormat(UserString("ENC_SPECIES_PLANET_TYPE_SUITABILITY_COLUMN1")) % UserString(species_name)); 
-            max_species_name_column1_width = std::max(font->TextExtent(species_name_column1).x, max_species_name_column1_width);
+            std::vector<GG::Font::LineData> lines;
+            GG::Flags<GG::TextFormat> format = GG::FORMAT_NONE;
+            std::vector<boost::shared_ptr<GG::Font::TextElement> > text_elements =
+                font->ExpensiveParseFromTextToTextElements(species_name_column1, format);
+            GG::Pt extent = font->DetermineLines(species_name_column1, format, GG::X(1 << 15), text_elements, lines);
+            max_species_name_column1_width = std::max(extent.x, max_species_name_column1_width);
 
             // Setting the planet's species allows all of it meters to reflect
             // species (and empire) properties, such as environment type
@@ -2478,8 +2483,16 @@ namespace {
             std::string user_species_name = UserString(it->second.first);
             std::string species_name_column1 = str(FlexibleFormat(UserString("ENC_SPECIES_PLANET_TYPE_SUITABILITY_COLUMN1")) % LinkTaggedText(VarText::SPECIES_TAG, it->second.first));
 
-            while (font->TextExtent(species_name_column1).x < max_species_name_column1_width)
-            { species_name_column1 += "\t"; }
+            std::vector<GG::Font::LineData> lines;
+            GG::Flags<GG::TextFormat> format = GG::FORMAT_NONE;
+            std::vector<boost::shared_ptr<GG::Font::TextElement> > text_elements =
+                font->ExpensiveParseFromTextToTextElements(species_name_column1, format);
+            GG::Pt extent = font->DetermineLines(species_name_column1, format, GG::X(1 << 15), text_elements, lines);
+            while (extent.x < max_species_name_column1_width) {
+                species_name_column1 += "\t";
+                text_elements = font->ExpensiveParseFromTextToTextElements(species_name_column1, format);
+                extent = font->DetermineLines(species_name_column1, format, GG::X(1 << 15), text_elements, lines);
+            }
 
             if (it->first > 0) {
                 if (!positive_header_placed) {

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -2341,7 +2341,7 @@ namespace {
                                             boost::shared_ptr<GG::Texture>& other_texture, int& turns,
                                             float& cost, std::string& cost_units, std::string& general_type,
                                             std::string& specific_type, std::string& detailed_description,
-                                            GG::Clr& color)
+                                            GG::Clr& color, GG::X width)
     {
         general_type = UserString("SP_PLANET_SUITABILITY");
 
@@ -2443,7 +2443,7 @@ namespace {
             GG::Flags<GG::TextFormat> format = GG::FORMAT_NONE;
             std::vector<boost::shared_ptr<GG::Font::TextElement> > text_elements =
                 font->ExpensiveParseFromTextToTextElements(species_name_column1, format);
-            GG::Pt extent = font->DetermineLines(species_name_column1, format, GG::X(1 << 15), text_elements, lines);
+            GG::Pt extent = font->DetermineLines(species_name_column1, format, width, text_elements, lines);
             max_species_name_column1_width = std::max(extent.x, max_species_name_column1_width);
 
             // Setting the planet's species allows all of it meters to reflect
@@ -2487,11 +2487,11 @@ namespace {
             GG::Flags<GG::TextFormat> format = GG::FORMAT_NONE;
             std::vector<boost::shared_ptr<GG::Font::TextElement> > text_elements =
                 font->ExpensiveParseFromTextToTextElements(species_name_column1, format);
-            GG::Pt extent = font->DetermineLines(species_name_column1, format, GG::X(1 << 15), text_elements, lines);
+            GG::Pt extent = font->DetermineLines(species_name_column1, format, width, text_elements, lines);
             while (extent.x < max_species_name_column1_width) {
                 species_name_column1 += "\t";
                 text_elements = font->ExpensiveParseFromTextToTextElements(species_name_column1, format);
-                extent = font->DetermineLines(species_name_column1, format, GG::X(1 << 15), text_elements, lines);
+                extent = font->DetermineLines(species_name_column1, format, width, text_elements, lines);
             }
 
             if (it->first > 0) {
@@ -2551,7 +2551,8 @@ namespace {
                                             boost::shared_ptr<GG::Texture>& other_texture, int& turns,
                                             float& cost, std::string& cost_units, std::string& general_type,
                                             std::string& specific_type, std::string& detailed_description,
-                                            GG::Clr& color, boost::weak_ptr<const ShipDesign>& incomplete_design)
+                                            GG::Clr& color, boost::weak_ptr<const ShipDesign>& incomplete_design,
+                                            GG::X width)
     {
         if (item_type == TextLinker::ENCYCLOPEDIA_TAG) {
             RefreshDetailPanelPediaTag(         item_type, item_name,
@@ -2609,7 +2610,7 @@ namespace {
         } else if (item_type == PLANET_SUITABILITY_REPORT) {
             RefreshDetailPanelSuitabilityTag(   item_type, item_name,
                                                 name, texture, other_texture, turns, cost, cost_units,
-                                                general_type, specific_type, detailed_description, color);
+                                                general_type, specific_type, detailed_description, color, width);
         } else if (item_type == TEXT_SEARCH_RESULTS) {
             RefreshDetailPanelSearchResultsTag( item_type, item_name,
                                                 name, texture, other_texture, turns, cost, cost_units,
@@ -2651,7 +2652,7 @@ void EncyclopediaDetailPanel::Refresh() {
     GetRefreshDetailPanelInfo(m_items_it->first, m_items_it->second,
                               name, texture, other_texture, turns, cost, cost_units,
                               general_type, specific_type, detailed_description, color,
-                              m_incomplete_design);
+                              m_incomplete_design, ClientWidth());
 
     if (m_items_it->first == TextLinker::GRAPH_TAG) {
         const std::string& graph_id = m_items_it->second;

--- a/UI/IntroScreen.cpp
+++ b/UI/IntroScreen.cpp
@@ -132,8 +132,12 @@ void CreditsWnd::DrawCredits(GG::X x1, GG::Y y1, GG::X x2, GG::Y y2, int transpa
                         credit += person.Attribute("task");
                         credit += "</rgba>";
                     }
-                    m_font->RenderText(GG::Pt(x1, y1 + offset), GG::Pt(x2, y2), credit, format, 0);
-                    offset += m_font->TextExtent(credit, format).y + 2;
+                    std::vector<GG::Font::LineData> lines;
+                    std::vector<boost::shared_ptr<GG::Font::TextElement> > text_elements =
+                        m_font->ExpensiveParseFromTextToTextElements(credit, format);
+                    m_font->DetermineLines(credit, format, x2 - x1, text_elements, lines);
+                    m_font->RenderText(GG::Pt(x1, y1 + offset), GG::Pt(x2, y2), credit, format, &lines);
+                    offset += m_font->TextExtent(credit, lines).y + 2;
                 }
             }
             offset += m_font->Lineskip() + 2;

--- a/UI/IntroScreen.cpp
+++ b/UI/IntroScreen.cpp
@@ -136,7 +136,7 @@ void CreditsWnd::DrawCredits(GG::X x1, GG::Y y1, GG::X x2, GG::Y y2, int transpa
                     std::vector<boost::shared_ptr<GG::Font::TextElement> > text_elements =
                         m_font->ExpensiveParseFromTextToTextElements(credit, format);
                     m_font->DetermineLines(credit, format, x2 - x1, text_elements, lines);
-                    m_font->RenderText(GG::Pt(x1, y1 + offset), GG::Pt(x2, y2), credit, format, &lines);
+                    m_font->RenderText(GG::Pt(x1, y1 + offset), GG::Pt(x2, y2), credit, format, lines);
                     offset += m_font->TextExtent(credit, lines).y + 2;
                 }
             }

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -2042,7 +2042,11 @@ void MapWnd::RenderMovementLineETAIndicators(const MapWnd::MovementLineData& mov
         // render ETA number in white with black shadows
         std::string text = "<s>" + boost::lexical_cast<std::string>(vert.eta) + "</s>";
         glColor(GG::CLR_WHITE);
-        font->RenderText(ul, lr, text, flags);
+        // TODO cache the text_elements
+        std::vector<GG::Font::LineData> lines;
+        std::vector<boost::shared_ptr<GG::Font::TextElement> > text_elements = font->ExpensiveParseFromTextToTextElements(text, flags);
+        font->DetermineLines(text, flags, lr.x - ul.x, text_elements, lines);
+        font->RenderText(ul, lr, text, flags, lines);
     }
     glPopMatrix();
 }


### PR DESCRIPTION
This PR follows #1035

This removes the gotcha variant of Font::DetermineLines that repeatedly create and discard the computationally expensive TextElement vector.
