### PR TITLE
Improve font determine lines streamline use of Font::TextExtent()

### DIFF
--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -567,9 +567,6 @@ private:
 
     typedef boost::unordered_map<boost::uint32_t, Glyph> GlyphMap;
 
-    std::vector<LineData> DetermineLinesImpl(const std::string& text, Flags<TextFormat>& format, X box_width,
-                                             const std::vector<boost::shared_ptr<TextElement> >& text_elements) const;
-
     FT_Error          GetFace(FT_Face& face);
     FT_Error          GetFace(const std::vector<unsigned char>& file_contents, FT_Face& face);
     void              CheckFace(FT_Face font, FT_Error error);

--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -492,7 +492,7 @@ public:
                                            const std::vector<boost::shared_ptr<TextElement> >& text_elements) const;
 
     /** Returns the maximum dimensions of the text in x and y. */
-    Pt   TextExtent(const std::string& text, const std::vector<LineData>& line_data) const;
+    Pt   TextExtent(const std::vector<LineData>& line_data) const;
     //@}
 
     /** Adds \a tag to the list of embedded tags that Font should not print

--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -476,10 +476,9 @@ public:
     std::vector<boost::shared_ptr<Font::TextElement> > ExpensiveParseFromTextToTextElements(const std::string& text,
                                                                                             const Flags<TextFormat>& format) const;
 
-    /** DetermineLines() calculates the \p line_data resulting from adding the necessary line
+    /** DetermineLines() returns the \p line_data resulting from adding the necessary line
         breaks, to  the \p text formatted with \p format and parsed into \p text_elements, to fit
-        the \p text into a box of width \p box_width. It returns the text extent of that \p
-        line_data.
+        the \p text into a box of width \p box_width.
 
         It accounts for alignment, wrapping and justification of the \p text.
 
@@ -489,9 +488,8 @@ public:
         behavior.  \p text_elements contains internal pointers to the \p text to which it is
         bound.  Compatible means the exact same \p text object, not the same text content.
         */
-    Pt   DetermineLines(const std::string& text, Flags<TextFormat>& format, X box_width,
-                        const std::vector<boost::shared_ptr<TextElement> >& text_elements,
-                        std::vector<LineData>& line_data) const;
+    std::vector<LineData>   DetermineLines(const std::string& text, Flags<TextFormat>& format, X box_width,
+                                           const std::vector<boost::shared_ptr<TextElement> >& text_elements) const;
 
     /** Returns the maximum dimensions of the text in x and y. */
     Pt   TextExtent(const std::string& text, const std::vector<LineData>& line_data) const;
@@ -569,11 +567,8 @@ private:
 
     typedef boost::unordered_map<boost::uint32_t, Glyph> GlyphMap;
 
-    Pt DetermineLinesImpl(const std::string& text,
-                          Flags<TextFormat>& format,
-                          X box_width,
-                          std::vector<LineData>& line_data,
-                          const std::vector<boost::shared_ptr<TextElement> >& text_elements) const;
+    std::vector<LineData> DetermineLinesImpl(const std::string& text, Flags<TextFormat>& format, X box_width,
+                                             const std::vector<boost::shared_ptr<TextElement> >& text_elements) const;
 
     FT_Error          GetFace(FT_Face& face);
     FT_Error          GetFace(const std::vector<unsigned char>& file_contents, FT_Face& face);

--- a/GG/src/BrowseInfoWnd.cpp
+++ b/GG/src/BrowseInfoWnd.cpp
@@ -135,7 +135,7 @@ void TextBoxBrowseInfoWnd::SetText(const std::string& str)
     Flags<TextFormat> fmt = GetTextFormat();
     std::vector<boost::shared_ptr<Font::TextElement> > text_elements = m_font->ExpensiveParseFromTextToTextElements(str, fmt);
     std::vector<Font::LineData> lines = m_font->DetermineLines(str, fmt, m_preferred_width - X(margins), text_elements);
-    Pt extent = m_font->TextExtent(str, lines);
+    Pt extent = m_font->TextExtent(lines);
     SetMinSize(extent + Pt(X(margins), Y(margins)));
     m_text_control->SetText(str);
     Resize(extent + Pt(X(margins), Y0));

--- a/GG/src/BrowseInfoWnd.cpp
+++ b/GG/src/BrowseInfoWnd.cpp
@@ -132,10 +132,10 @@ void TextBoxBrowseInfoWnd::SetText(const std::string& str)
 {
     unsigned int margins = 2 * TextMargin();
 
-    std::vector<Font::LineData> lines;
     Flags<TextFormat> fmt = GetTextFormat();
     std::vector<boost::shared_ptr<Font::TextElement> > text_elements = m_font->ExpensiveParseFromTextToTextElements(str, fmt);
-    Pt extent = m_font->DetermineLines(str, fmt, m_preferred_width - X(margins), text_elements, lines);
+    std::vector<Font::LineData> lines = m_font->DetermineLines(str, fmt, m_preferred_width - X(margins), text_elements);
+    Pt extent = m_font->TextExtent(str, lines);
     SetMinSize(extent + Pt(X(margins), Y(margins)));
     m_text_control->SetText(str);
     Resize(extent + Pt(X(margins), Y0));

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -1067,12 +1067,6 @@ void Font::ProcessTagsBefore(const std::vector<LineData>& line_data, RenderState
     }
 }
 
-std::vector<Font::LineData> Font::DetermineLines(const std::string& text, Flags<TextFormat>& format, X box_width,
-                                                 const std::vector<boost::shared_ptr<TextElement> >& text_elements) const
-{
-    return DetermineLinesImpl(text, format, box_width, text_elements);
-}
-
 std::string Font::StripTags(const std::string& text, bool strip_unpaired_tags)
 {
     using namespace boost::xpressive;
@@ -1336,8 +1330,8 @@ std::vector<boost::shared_ptr<Font::TextElement> > Font::ExpensiveParseFromTextT
     return text_elements;
 }
 
-std::vector<Font::LineData> Font::DetermineLinesImpl(const std::string& text, Flags<TextFormat>& format, X box_width,
-                                                     const std::vector<boost::shared_ptr<TextElement> >& text_elements) const
+std::vector<Font::LineData> Font::DetermineLines(const std::string& text, Flags<TextFormat>& format, X box_width,
+                                                 const std::vector<boost::shared_ptr<TextElement> >& text_elements) const
 {
     ValidateFormat(format);
 

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -1067,11 +1067,10 @@ void Font::ProcessTagsBefore(const std::vector<LineData>& line_data, RenderState
     }
 }
 
-Pt Font::DetermineLines(const std::string& text, Flags<TextFormat>& format, X box_width,
-                        const std::vector<boost::shared_ptr<TextElement> >& text_elements,
-                        std::vector<LineData>& line_data) const
+std::vector<Font::LineData> Font::DetermineLines(const std::string& text, Flags<TextFormat>& format, X box_width,
+                                                 const std::vector<boost::shared_ptr<TextElement> >& text_elements) const
 {
-    return DetermineLinesImpl(text, format, box_width, line_data, text_elements);
+    return DetermineLinesImpl(text, format, box_width, text_elements);
 }
 
 std::string Font::StripTags(const std::string& text, bool strip_unpaired_tags)
@@ -1337,11 +1336,8 @@ std::vector<boost::shared_ptr<Font::TextElement> > Font::ExpensiveParseFromTextT
     return text_elements;
 }
 
-Pt Font::DetermineLinesImpl(const std::string& text,
-                            Flags<TextFormat>& format,
-                            X box_width,
-                            std::vector<LineData>& line_data,
-                            const std::vector<boost::shared_ptr<TextElement> >& text_elements) const
+std::vector<Font::LineData> Font::DetermineLinesImpl(const std::string& text, Flags<TextFormat>& format, X box_width,
+                                                     const std::vector<boost::shared_ptr<TextElement> >& text_elements) const
 {
     ValidateFormat(format);
 
@@ -1358,7 +1354,7 @@ Pt Font::DetermineLinesImpl(const std::string& text,
         orig_just = ALIGN_RIGHT;
     bool last_line_of_curr_just = false; // is this the last line of the current justification? (for instance when a </right> tag is encountered)
 
-    line_data.clear();
+    std::vector<Font::LineData> line_data;
     line_data.push_back(LineData());
     line_data.back().justification = orig_just;
 
@@ -1539,7 +1535,7 @@ Pt Font::DetermineLinesImpl(const std::string& text,
     DebugOutput::PrintLineBreakdown(text, format, box_width, line_data);
 #endif
 
-    return TextExtent(text, line_data);
+    return line_data;
 }
 
 FT_Error Font::GetFace(FT_Face& face)

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -1098,14 +1098,16 @@ std::string Font::StripTags(const std::string& text, bool strip_unpaired_tags)
     return retval.str();
 }
 
-Pt Font::TextExtent(const std::string& text, const std::vector<LineData>& line_data) const
+Pt Font::TextExtent(const std::vector<LineData>& line_data) const
 {
     Pt retval;
     for (std::size_t i = 0; i < line_data.size(); ++i) {
         if (retval.x < line_data[i].Width())
             retval.x = line_data[i].Width();
     }
-    retval.y = text.empty() ? Y0 : (static_cast<int>(line_data.size()) - 1) * m_lineskip + m_height;
+    bool is_empty = line_data.empty()
+        || (line_data.size() == 1 && line_data.front().Empty());
+    retval.y = is_empty ? Y0 : (static_cast<int>(line_data.size()) - 1) * m_lineskip + m_height;
     return retval;
 }
 
@@ -1348,6 +1350,7 @@ std::vector<Font::LineData> Font::DetermineLines(const std::string& text, Flags<
         orig_just = ALIGN_RIGHT;
     bool last_line_of_curr_just = false; // is this the last line of the current justification? (for instance when a </right> tag is encountered)
 
+    // TODO check if possible to return empty line_data for empty text;
     std::vector<Font::LineData> line_data;
     line_data.push_back(LineData());
     line_data.back().justification = orig_just;

--- a/GG/src/Menu.cpp
+++ b/GG/src/Menu.cpp
@@ -463,11 +463,11 @@ void PopupMenu::Render()
                 if (menu.next_level[j].next_level.size() || menu.next_level[j].checked)
                     needs_indicator = true;
             }
-            std::vector<Font::LineData> lines;
             Flags<TextFormat> fmt = FORMAT_LEFT | FORMAT_TOP;
             std::vector<boost::shared_ptr<Font::TextElement> > text_elements
                 = m_font->ExpensiveParseFromTextToTextElements(str, fmt);
-            Pt menu_sz = m_font->DetermineLines(str, fmt, X0, text_elements, lines); // get dimensions of text in menu
+            std::vector<Font::LineData> lines = m_font->DetermineLines(str, fmt, X0, text_elements);
+            Pt menu_sz = m_font->TextExtent(str, lines); // get dimensions of text in menu
             menu_sz.x += 2 * HORIZONTAL_MARGIN;
             if (needs_indicator)
                 menu_sz.x += CHECK_WIDTH + 2 * HORIZONTAL_MARGIN; // make room for the little arrow
@@ -522,10 +522,10 @@ void PopupMenu::Render()
 
                 if (!menu.next_level[j].separator) {
                     // TODO cache line data v expensive calculation
-                    std::vector<Font::LineData> lines;
                     std::vector<boost::shared_ptr<Font::TextElement> > text_elements
                         = m_font->ExpensiveParseFromTextToTextElements(menu.next_level[j].label, fmt);
-                    Pt menu_sz = m_font->DetermineLines(menu.next_level[j].label, fmt, X0, text_elements, lines);
+                    std::vector<Font::LineData> lines =
+                        m_font->DetermineLines(menu.next_level[j].label, fmt, X0, text_elements);
 
                     m_font->RenderText(line_rect.ul, line_rect.lr, menu.next_level[j].label, fmt, lines);
 

--- a/GG/src/Menu.cpp
+++ b/GG/src/Menu.cpp
@@ -522,8 +522,8 @@ void PopupMenu::Render()
 
                 if (!menu.next_level[j].separator) {
                     // TODO cache line data v expensive calculation
-                    std::vector<boost::shared_ptr<Font::TextElement> > text_elements
-                        = m_font->ExpensiveParseFromTextToTextElements(menu.next_level[j].label, fmt);
+                    std::vector<boost::shared_ptr<Font::TextElement> > text_elements =
+                        m_font->ExpensiveParseFromTextToTextElements(menu.next_level[j].label, fmt);
                     std::vector<Font::LineData> lines =
                         m_font->DetermineLines(menu.next_level[j].label, fmt, X0, text_elements);
 

--- a/GG/src/Menu.cpp
+++ b/GG/src/Menu.cpp
@@ -467,7 +467,7 @@ void PopupMenu::Render()
             std::vector<boost::shared_ptr<Font::TextElement> > text_elements
                 = m_font->ExpensiveParseFromTextToTextElements(str, fmt);
             std::vector<Font::LineData> lines = m_font->DetermineLines(str, fmt, X0, text_elements);
-            Pt menu_sz = m_font->TextExtent(str, lines); // get dimensions of text in menu
+            Pt menu_sz = m_font->TextExtent(lines); // get dimensions of text in menu
             menu_sz.x += 2 * HORIZONTAL_MARGIN;
             if (needs_indicator)
                 menu_sz.x += CHECK_WIDTH + 2 * HORIZONTAL_MARGIN; // make room for the little arrow

--- a/GG/src/MultiEdit.cpp
+++ b/GG/src/MultiEdit.cpp
@@ -358,7 +358,7 @@ void MultiEdit::SetText(const std::string& str)
         CPSize cursor_pos = CharIndexOf(m_cursor_end.first, m_cursor_end.second);
         this->m_cursor_pos = std::make_pair(cursor_pos, cursor_pos);
 
-        m_contents_sz = GetFont()->TextExtent(Text(), GetLineData());
+        m_contents_sz = GetFont()->TextExtent(GetLineData());
 
         AdjustScrolls();
         AdjustView();

--- a/GG/src/MultiEdit.cpp
+++ b/GG/src/MultiEdit.cpp
@@ -302,10 +302,9 @@ void MultiEdit::SetText(const std::string& str)
         if (m_max_lines_history == ALL_LINES) {
             TextControl::SetText(str);
         } else {
-            std::vector<Font::LineData> lines;
             std::vector<boost::shared_ptr<Font::TextElement> > text_elements
                 = GetFont()->ExpensiveParseFromTextToTextElements(str, format);
-            Pt extent = GetFont()->DetermineLines(str, format, cl_sz.x, text_elements, lines);
+            std::vector<Font::LineData> lines = GetFont()->DetermineLines(str, format, cl_sz.x, text_elements);
             if (m_max_lines_history < lines.size()) {
                 std::size_t first_line = 0;
                 std::size_t last_line = m_max_lines_history - 1;

--- a/GG/src/TextControl.cpp
+++ b/GG/src/TextControl.cpp
@@ -71,9 +71,10 @@ Pt TextControl::MinUsableSize(X width) const
     if ( m_cached_minusable_size_width != X0 &&  abs_delta_w < min_delta)
         return m_cached_minusable_size;
 
-    std::vector<Font::LineData> dummy_line_data;
     Flags<TextFormat> dummy_format(m_format);
-    m_cached_minusable_size = m_font->DetermineLines(m_text, dummy_format, width, m_text_elements, dummy_line_data)
+    std::vector<Font::LineData> dummy_line_data =
+        m_font->DetermineLines(m_text, dummy_format, width, m_text_elements);
+    m_cached_minusable_size = m_font->TextExtent(m_text, dummy_line_data)
         + (ClientUpperLeft() - UpperLeft()) + (LowerRight() - ClientLowerRight());
     m_cached_minusable_size_width = width;
     return m_cached_minusable_size;
@@ -184,8 +185,8 @@ void TextControl::SetText(const std::string& str)
 
     m_code_points = CPSize(utf8::distance(str.begin(), str.end()));
     m_text_elements = m_font->ExpensiveParseFromTextToTextElements(m_text, m_format);
-    Pt text_sz =
-        m_font->DetermineLines(m_text, m_format, ClientSize().x, m_text_elements, m_line_data);
+    m_line_data = m_font->DetermineLines(m_text, m_format, ClientSize().x, m_text_elements);
+    Pt text_sz = m_font->TextExtent(m_text, m_line_data);
     m_text_ul = Pt();
     m_text_lr = text_sz;
     AdjustMinimumSize();
@@ -232,10 +233,10 @@ void TextControl::SizeMove(const Pt& ul, const Pt& lr)
     }
 
     if (redo_determine_lines) {
-        Pt text_sz;
         if (m_text_elements.empty())
             m_text_elements = m_font->ExpensiveParseFromTextToTextElements(m_text, m_format);
-        text_sz = m_font->DetermineLines(m_text, m_format, client_width, m_text_elements, m_line_data);
+        m_line_data = m_font->DetermineLines(m_text, m_format, client_width, m_text_elements);
+        Pt text_sz = m_font->TextExtent(m_text, m_line_data);
         m_text_ul = Pt();
         m_text_lr = text_sz;
         AdjustMinimumSize();

--- a/GG/src/TextControl.cpp
+++ b/GG/src/TextControl.cpp
@@ -78,7 +78,7 @@ Pt TextControl::MinUsableSize(X width) const
     Flags<TextFormat> dummy_format(m_format);
     std::vector<Font::LineData> dummy_line_data =
         m_font->DetermineLines(m_text, dummy_format, width, m_text_elements);
-    m_cached_minusable_size = m_font->TextExtent(m_text, dummy_line_data)
+    m_cached_minusable_size = m_font->TextExtent(dummy_line_data)
         + (ClientUpperLeft() - UpperLeft()) + (LowerRight() - ClientLowerRight());
     m_cached_minusable_size_width = width;
     return m_cached_minusable_size;
@@ -190,7 +190,7 @@ void TextControl::SetText(const std::string& str)
     m_code_points = CPSize(utf8::distance(str.begin(), str.end()));
     m_text_elements = m_font->ExpensiveParseFromTextToTextElements(m_text, m_format);
     m_line_data = m_font->DetermineLines(m_text, m_format, ClientSize().x, m_text_elements);
-    Pt text_sz = m_font->TextExtent(m_text, m_line_data);
+    Pt text_sz = m_font->TextExtent(m_line_data);
     m_text_ul = Pt();
     m_text_lr = text_sz;
     AdjustMinimumSize();
@@ -240,7 +240,7 @@ void TextControl::SizeMove(const Pt& ul, const Pt& lr)
         if (m_text_elements.empty())
             m_text_elements = m_font->ExpensiveParseFromTextToTextElements(m_text, m_format);
         m_line_data = m_font->DetermineLines(m_text, m_format, client_width, m_text_elements);
-        Pt text_sz = m_font->TextExtent(m_text, m_line_data);
+        Pt text_sz = m_font->TextExtent(m_line_data);
         m_text_ul = Pt();
         m_text_lr = text_sz;
         AdjustMinimumSize();

--- a/GG/src/TextControl.cpp
+++ b/GG/src/TextControl.cpp
@@ -66,11 +66,15 @@ Pt TextControl::MinUsableSize() const
 
 Pt TextControl::MinUsableSize(X width) const
 {
+    // If the requested width is within one space width of the cached width
+    // don't recalculate the size
     X min_delta = m_font->SpaceWidth();
     X abs_delta_w = X(std::abs(Value(m_cached_minusable_size_width - width)));
-    if ( m_cached_minusable_size_width != X0 &&  abs_delta_w < min_delta)
+    if (m_cached_minusable_size_width != X0 &&  abs_delta_w < min_delta)
         return m_cached_minusable_size;
 
+    // Calculate and cache the minimum usable size when m_cached_minusable_size is equal to width.
+    // Create dummy line data with line breaks added so that lines are not wider than width.
     Flags<TextFormat> dummy_format(m_format);
     std::vector<Font::LineData> dummy_line_data =
         m_font->DetermineLines(m_text, dummy_format, width, m_text_elements);

--- a/UI/CombatReport/GraphicalSummary.cpp
+++ b/UI/CombatReport/GraphicalSummary.cpp
@@ -588,9 +588,11 @@ public:
             ToggleData& toggle = **it;
             if (!toggle.button->Children().empty()) {
                 //Assume first child of the button is the label
-                if (const GG::TextControl* label = dynamic_cast<GG::TextControl const*>(toggle.button->Children().front())) {
-                    toggle.button->Resize(GG::Pt(label->MinUsableSize().x
-                                                 + OPTION_BUTTON_PADDING, OPTION_BUTTON_HEIGHT));
+                if (const GG::TextControl* label = dynamic_cast<GG::TextControl const*>(toggle.button->Children().front()))
+                {
+                    toggle.button->Resize(
+                        GG::Pt(label->MinUsableSize().x + OPTION_BUTTON_PADDING,
+                               OPTION_BUTTON_HEIGHT));
                 }
             }
             toggle.button->MoveTo(pos);

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -2439,11 +2439,12 @@ namespace {
             std::string species_name = *it;
 
             std::string species_name_column1 = str(FlexibleFormat(UserString("ENC_SPECIES_PLANET_TYPE_SUITABILITY_COLUMN1")) % UserString(species_name)); 
-            std::vector<GG::Font::LineData> lines;
             GG::Flags<GG::TextFormat> format = GG::FORMAT_NONE;
             std::vector<boost::shared_ptr<GG::Font::TextElement> > text_elements =
                 font->ExpensiveParseFromTextToTextElements(species_name_column1, format);
-            GG::Pt extent = font->DetermineLines(species_name_column1, format, width, text_elements, lines);
+            std::vector<GG::Font::LineData> lines = font->DetermineLines(
+                species_name_column1, format, GG::X(1 << 15), text_elements);
+            GG::Pt extent = font->TextExtent(species_name_column1, lines);
             max_species_name_column1_width = std::max(extent.x, max_species_name_column1_width);
 
             // Setting the planet's species allows all of it meters to reflect
@@ -2483,15 +2484,17 @@ namespace {
             std::string user_species_name = UserString(it->second.first);
             std::string species_name_column1 = str(FlexibleFormat(UserString("ENC_SPECIES_PLANET_TYPE_SUITABILITY_COLUMN1")) % LinkTaggedText(VarText::SPECIES_TAG, it->second.first));
 
-            std::vector<GG::Font::LineData> lines;
             GG::Flags<GG::TextFormat> format = GG::FORMAT_NONE;
             std::vector<boost::shared_ptr<GG::Font::TextElement> > text_elements =
                 font->ExpensiveParseFromTextToTextElements(species_name_column1, format);
-            GG::Pt extent = font->DetermineLines(species_name_column1, format, width, text_elements, lines);
+            std::vector<GG::Font::LineData> lines = font->DetermineLines(
+                species_name_column1, format, GG::X(1 << 15), text_elements);
+            GG::Pt extent = font->TextExtent(species_name_column1, lines);
             while (extent.x < max_species_name_column1_width) {
                 species_name_column1 += "\t";
                 text_elements = font->ExpensiveParseFromTextToTextElements(species_name_column1, format);
-                extent = font->DetermineLines(species_name_column1, format, width, text_elements, lines);
+                lines = font->DetermineLines(species_name_column1, format, GG::X(1 << 15), text_elements);
+                extent = font->TextExtent(species_name_column1, lines);
             }
 
             if (it->first > 0) {

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -2444,7 +2444,7 @@ namespace {
                 font->ExpensiveParseFromTextToTextElements(species_name_column1, format);
             std::vector<GG::Font::LineData> lines = font->DetermineLines(
                 species_name_column1, format, GG::X(1 << 15), text_elements);
-            GG::Pt extent = font->TextExtent(species_name_column1, lines);
+            GG::Pt extent = font->TextExtent(lines);
             max_species_name_column1_width = std::max(extent.x, max_species_name_column1_width);
 
             // Setting the planet's species allows all of it meters to reflect
@@ -2489,12 +2489,12 @@ namespace {
                 font->ExpensiveParseFromTextToTextElements(species_name_column1, format);
             std::vector<GG::Font::LineData> lines = font->DetermineLines(
                 species_name_column1, format, GG::X(1 << 15), text_elements);
-            GG::Pt extent = font->TextExtent(species_name_column1, lines);
+            GG::Pt extent = font->TextExtent(lines);
             while (extent.x < max_species_name_column1_width) {
                 species_name_column1 += "\t";
                 text_elements = font->ExpensiveParseFromTextToTextElements(species_name_column1, format);
                 lines = font->DetermineLines(species_name_column1, format, GG::X(1 << 15), text_elements);
-                extent = font->TextExtent(species_name_column1, lines);
+                extent = font->TextExtent(lines);
             }
 
             if (it->first > 0) {

--- a/UI/IntroScreen.cpp
+++ b/UI/IntroScreen.cpp
@@ -132,10 +132,10 @@ void CreditsWnd::DrawCredits(GG::X x1, GG::Y y1, GG::X x2, GG::Y y2, int transpa
                         credit += person.Attribute("task");
                         credit += "</rgba>";
                     }
-                    std::vector<GG::Font::LineData> lines;
                     std::vector<boost::shared_ptr<GG::Font::TextElement> > text_elements =
                         m_font->ExpensiveParseFromTextToTextElements(credit, format);
-                    m_font->DetermineLines(credit, format, x2 - x1, text_elements, lines);
+                    std::vector<GG::Font::LineData> lines =
+                        m_font->DetermineLines(credit, format, x2 - x1, text_elements);
                     m_font->RenderText(GG::Pt(x1, y1 + offset), GG::Pt(x2, y2), credit, format, lines);
                     offset += m_font->TextExtent(credit, lines).y + 2;
                 }

--- a/UI/IntroScreen.cpp
+++ b/UI/IntroScreen.cpp
@@ -137,7 +137,7 @@ void CreditsWnd::DrawCredits(GG::X x1, GG::Y y1, GG::X x2, GG::Y y2, int transpa
                     std::vector<GG::Font::LineData> lines =
                         m_font->DetermineLines(credit, format, x2 - x1, text_elements);
                     m_font->RenderText(GG::Pt(x1, y1 + offset), GG::Pt(x2, y2), credit, format, lines);
-                    offset += m_font->TextExtent(credit, lines).y + 2;
+                    offset += m_font->TextExtent(lines).y + 2;
                 }
             }
             offset += m_font->Lineskip() + 2;

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -2046,9 +2046,9 @@ void MapWnd::RenderMovementLineETAIndicators(const MapWnd::MovementLineData& mov
         std::string text = "<s>" + boost::lexical_cast<std::string>(vert.eta) + "</s>";
         glColor(GG::CLR_WHITE);
         // TODO cache the text_elements
-        std::vector<GG::Font::LineData> lines;
         std::vector<boost::shared_ptr<GG::Font::TextElement> > text_elements = font->ExpensiveParseFromTextToTextElements(text, flags);
-        font->DetermineLines(text, flags, lr.x - ul.x, text_elements, lines);
+        std::vector<GG::Font::LineData> lines =
+            font->DetermineLines(text, flags, lr.x - ul.x, text_elements);
         font->RenderText(ul, lr, text, flags, lines);
     }
     glPopMatrix();

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -100,7 +100,7 @@ namespace {
         std::vector<boost::shared_ptr<GG::Font::TextElement> > text_elements =
             ClientUI::GetFont()->ExpensiveParseFromTextToTextElements(string, fmt);
         std::vector<GG::Font::LineData> lines = ClientUI::GetFont()->DetermineLines(string, fmt, width, text_elements);
-        GG::Pt extent = ClientUI::GetFont()->TextExtent(string, lines);
+        GG::Pt extent = ClientUI::GetFont()->TextExtent(lines);
         GG::Label* text = new CUILabel(string, GG::FORMAT_WORDBREAK | GG::FORMAT_LEFT);
         text->Resize(GG::Pt(extent.x, extent.y));
         text->ClipText(true);
@@ -203,11 +203,11 @@ public:
         std::vector<boost::shared_ptr<GG::Font::TextElement> > text_elements =
             font->ExpensiveParseFromTextToTextElements(m_wide_as, fmt);
         lines = font->DetermineLines(m_wide_as, fmt, max_width, text_elements);
-        GG::Pt extent1 = font->TextExtent(m_wide_as, lines);
+        GG::Pt extent1 = font->TextExtent(lines);
 
         text_elements = font->ExpensiveParseFromTextToTextElements(Title(), fmt);
         lines = font->DetermineLines(Title(), fmt, max_width, text_elements);
-        GG::Pt extent2 = font->TextExtent(Title(), lines);
+        GG::Pt extent2 = font->TextExtent(lines);
 
         return std::max(extent1.x, extent2.x) + GG::X(SAVE_FILE_CELL_MARGIN);
     }
@@ -657,7 +657,7 @@ void SaveFileDialog::Init() {
             font->ExpensiveParseFromTextToTextElements(SERVER_LABEL+SERVER_LABEL+SERVER_LABEL, fmt);
         std::vector<GG::Font::LineData> lines = font->DetermineLines(
             SERVER_LABEL+SERVER_LABEL+SERVER_LABEL, fmt, ClientWidth(), text_elements);
-        GG::X drop_width = font->TextExtent(SERVER_LABEL+SERVER_LABEL+SERVER_LABEL, lines).x;
+        GG::X drop_width = font->TextExtent(lines).x;
         m_layout->SetMinimumColumnWidth(2, std::max(m_confirm_btn->MinUsableSize().x + 2*SAVE_FILE_BUTTON_MARGIN, drop_width/2));
         m_layout->SetMinimumColumnWidth(3, std::max(cancel_btn->MinUsableSize().x + SAVE_FILE_BUTTON_MARGIN, drop_width / 2));
 
@@ -677,16 +677,16 @@ void SaveFileDialog::Init() {
         font->ExpensiveParseFromTextToTextElements(cancel_btn->Text(), fmt);
     std::vector<GG::Font::LineData> lines = ClientUI::GetFont()->DetermineLines(
         cancel_btn->Text(), fmt, GG::X(1 << 15), text_elements);
-    GG::Pt extent = ClientUI::GetFont()->TextExtent(cancel_btn->Text(), lines);
+    GG::Pt extent = ClientUI::GetFont()->TextExtent(lines);
     m_layout->SetMinimumRowHeight(3, extent.y);
 
     text_elements = font->ExpensiveParseFromTextToTextElements(filename_label->Text(), fmt);
     lines = font->DetermineLines(filename_label->Text(), fmt, ClientWidth(), text_elements);
-    GG::Pt extent1 = font->TextExtent(filename_label->Text(), lines);
+    GG::Pt extent1 = font->TextExtent(lines);
 
     text_elements = font->ExpensiveParseFromTextToTextElements(directory_label->Text(), fmt);
     lines = font->DetermineLines(directory_label->Text(), fmt, ClientWidth(), text_elements);
-    GG::Pt extent2 = font->TextExtent(directory_label->Text(), lines);
+    GG::Pt extent2 = font->TextExtent(lines);
 
     m_layout->SetMinimumColumnWidth(0, std::max(extent1.x, extent2.x));
     m_layout->SetColumnStretch(1, 1.0);

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -96,11 +96,11 @@ namespace {
     {
         // Calculate the extent manually to ensure the control stretches to full
         // width when possible.  Otherwise it would always word break.
-        std::vector<GG::Font::LineData> lines;
         GG::Flags<GG::TextFormat> fmt = GG::FORMAT_NONE;
         std::vector<boost::shared_ptr<GG::Font::TextElement> > text_elements =
             ClientUI::GetFont()->ExpensiveParseFromTextToTextElements(string, fmt);
-        GG::Pt extent = ClientUI::GetFont()->DetermineLines(string, fmt, width, text_elements, lines);
+        std::vector<GG::Font::LineData> lines = ClientUI::GetFont()->DetermineLines(string, fmt, width, text_elements);
+        GG::Pt extent = ClientUI::GetFont()->TextExtent(string, lines);
         GG::Label* text = new CUILabel(string, GG::FORMAT_WORDBREAK | GG::FORMAT_LEFT);
         text->Resize(GG::Pt(extent.x, extent.y));
         text->ClipText(true);
@@ -202,10 +202,12 @@ public:
         //TODO cache this resulting extent
         std::vector<boost::shared_ptr<GG::Font::TextElement> > text_elements =
             font->ExpensiveParseFromTextToTextElements(m_wide_as, fmt);
-        GG::Pt extent1 = font->DetermineLines(m_wide_as, fmt, max_width, text_elements, lines);
+        lines = font->DetermineLines(m_wide_as, fmt, max_width, text_elements);
+        GG::Pt extent1 = font->TextExtent(m_wide_as, lines);
 
         text_elements = font->ExpensiveParseFromTextToTextElements(Title(), fmt);
-        GG::Pt extent2 = font->DetermineLines(Title(), fmt, max_width, text_elements, lines);
+        lines = font->DetermineLines(Title(), fmt, max_width, text_elements);
+        GG::Pt extent2 = font->TextExtent(Title(), lines);
 
         return std::max(extent1.x, extent2.x) + GG::X(SAVE_FILE_CELL_MARGIN);
     }
@@ -650,12 +652,12 @@ void SaveFileDialog::Init() {
         m_remote_dir_dropdown = new CUIDropDownList(6);
         m_layout->Add(m_current_dir_edit, 0, 1, 1, 1);
         m_layout->Add(m_remote_dir_dropdown, 0, 2 , 1, 2);
-        std::vector<GG::Font::LineData> lines;
         GG::Flags<GG::TextFormat> fmt = GG::FORMAT_NONE;
         std::vector<boost::shared_ptr<GG::Font::TextElement> > text_elements =
             font->ExpensiveParseFromTextToTextElements(SERVER_LABEL+SERVER_LABEL+SERVER_LABEL, fmt);
-        GG::X drop_width = font->DetermineLines(SERVER_LABEL+SERVER_LABEL+SERVER_LABEL,
-                                                fmt, ClientWidth(), text_elements, lines).x;
+        std::vector<GG::Font::LineData> lines = font->DetermineLines(
+            SERVER_LABEL+SERVER_LABEL+SERVER_LABEL, fmt, ClientWidth(), text_elements);
+        GG::X drop_width = font->TextExtent(SERVER_LABEL+SERVER_LABEL+SERVER_LABEL, lines).x;
         m_layout->SetMinimumColumnWidth(2, std::max(m_confirm_btn->MinUsableSize().x + 2*SAVE_FILE_BUTTON_MARGIN, drop_width/2));
         m_layout->SetMinimumColumnWidth(3, std::max(cancel_btn->MinUsableSize().x + SAVE_FILE_BUTTON_MARGIN, drop_width / 2));
 
@@ -670,18 +672,21 @@ void SaveFileDialog::Init() {
 
     m_layout->SetMinimumRowHeight(0, m_current_dir_edit->MinUsableSize().y);
     m_layout->SetRowStretch      (1, 1.0 );
-    std::vector<GG::Font::LineData> lines;
     GG::Flags<GG::TextFormat> fmt = GG::FORMAT_NONE;
     std::vector<boost::shared_ptr<GG::Font::TextElement> > text_elements =
         font->ExpensiveParseFromTextToTextElements(cancel_btn->Text(), fmt);
-    GG::Pt extent = ClientUI::GetFont()->DetermineLines(cancel_btn->Text(), fmt, ClientWidth(), text_elements, lines);
+    std::vector<GG::Font::LineData> lines = ClientUI::GetFont()->DetermineLines(
+        cancel_btn->Text(), fmt, GG::X(1 << 15), text_elements);
+    GG::Pt extent = ClientUI::GetFont()->TextExtent(cancel_btn->Text(), lines);
     m_layout->SetMinimumRowHeight(3, extent.y);
 
     text_elements = font->ExpensiveParseFromTextToTextElements(filename_label->Text(), fmt);
-    GG::Pt extent1 = font->DetermineLines(filename_label->Text(), fmt, ClientWidth(), text_elements, lines);
+    lines = font->DetermineLines(filename_label->Text(), fmt, ClientWidth(), text_elements);
+    GG::Pt extent1 = font->TextExtent(filename_label->Text(), lines);
 
     text_elements = font->ExpensiveParseFromTextToTextElements(directory_label->Text(), fmt);
-    GG::Pt extent2 = font->DetermineLines(directory_label->Text(), fmt, ClientWidth(), text_elements, lines);
+    lines = font->DetermineLines(directory_label->Text(), fmt, ClientWidth(), text_elements);
+    GG::Pt extent2 = font->TextExtent(directory_label->Text(), lines);
 
     m_layout->SetMinimumColumnWidth(0, std::max(extent1.x, extent2.x));
     m_layout->SetColumnStretch(1, 1.0);


### PR DESCRIPTION
This follow PR #1036.
