### PR TITLE
In Font.cpp create TextAndElementsAssembler.

### DIFF
--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -247,20 +247,18 @@ public:
         mutable X cached_width;
     };
 
-    /** \brief Used to encapsulate a text and tokens together to be rendered
-        using GG::Font.
-
-        TextElements allows a matched pair of XML string and vector of TextElement to be directly
-        constructed while avoiding the computationally costly ComputeTextElements() function.
+    /** \brief TextAndElementsAssembler is used to assemble a matched pair of text and a vector of
+        TextElement, without incurring the computational cost of parsing the text with
+        ComputeTextElements().
 
         The pair of string and vector returned by Text() and Elements() are consistent with each
-        other and can be used with the fast constructor for TextControl.
+        other and can be used with the fast constructor or the fast SetText variant of TextControl.
     */
-    class GG_API TextElements
+    class GG_API TextAndElementsAssembler
     {
     public:
-        TextElements(const Font& font);
-        ~TextElements();
+        TextAndElementsAssembler(const Font& font);
+        ~TextAndElementsAssembler();
 
         /** Return the constructed text.*/
         const std::string& Text();
@@ -268,24 +266,24 @@ public:
         const std::vector<boost::shared_ptr<TextElement> >& Elements();
 
         /** Add an open tag iff it exists as a recognized tag.*/
-        TextElements& AddOpenTag(const std::string& tag);
+        TextAndElementsAssembler& AddOpenTag(const std::string& tag);
         /** Add an open tag iff it exists as a recognized tag.*/
-        TextElements& AddOpenTag(const std::string& tag, const std::vector<std::string>& params);
+        TextAndElementsAssembler& AddOpenTag(const std::string& tag, const std::vector<std::string>& params);
         /** Add a close tag iff it exists as a recognized tag.*/
-        TextElements& AddCloseTag(const std::string& tag);
+        TextAndElementsAssembler& AddCloseTag(const std::string& tag);
         /** Add a text element.  Any whitespace in this text element will be non-breaking.*/
-        TextElements& AddText(const std::string& text);
+        TextAndElementsAssembler& AddText(const std::string& text);
         /** Add a white space element.*/
-        TextElements& AddWhitespace(const std::string& whitespace);
+        TextAndElementsAssembler& AddWhitespace(const std::string& whitespace);
         /** Add a new line element.*/
-        TextElements& AddNewline();
+        TextAndElementsAssembler& AddNewline();
 
         /** Add an open Clr tag.*/
-        TextElements& AddOpenTag(const Clr& color);
+        TextAndElementsAssembler& AddOpenTag(const Clr& color);
 
     private:
-        class TextElementsImpl;
-        boost::scoped_ptr<TextElementsImpl> const pimpl;
+        class TextAndElementsAssemblerImpl;
+        boost::scoped_ptr<TextAndElementsAssemblerImpl> const pimpl;
     };
 
     /** \brief The type of TextElement that represents a text formatting

--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -147,6 +147,9 @@ public:
             pair.second. */
         Substring(const std::string& str_, const IterPair& pair);
 
+        /** Rebind to a different string.*/
+        void Bind(const std::string& str_);
+
         /** Returns an iterator to the beginning of the substring. */
         std::string::const_iterator begin() const;
 
@@ -206,6 +209,9 @@ public:
 
         virtual ~TextElement(); ///< Virtual dtor.
 
+        /** Rebind to a different string.*/
+        virtual void Bind(const std::string& whole_text);
+
         /** Returns the TextElementType of the element. */
         virtual TextElementType Type() const;
 
@@ -241,6 +247,9 @@ public:
         /** Ctor.  \a close indicates that the tag is a close-tag
             (e.g. "</rgba>"). */
         FormattingTag(bool close);
+
+        /** Rebind to a different string.*/
+        virtual void Bind(const std::string& whole_text);
 
         virtual TextElementType Type() const;
 

--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -247,6 +247,40 @@ public:
         mutable X cached_width;
     };
 
+    /** \brief Used to encapsulate a text and tokens together to be rendered
+        using GG::Font. */
+    class GG_API TextElements
+    {
+    public:
+        TextElements(const Font& font);
+        ~TextElements();
+
+        /** Return the constructed text.*/
+        const std::string& Text();
+        /** Return the constructed TextElements.*/
+        const std::vector<boost::shared_ptr<TextElement> >& Elements();
+
+        /** Add an open tag iff it exists as a recognized tag.*/
+        TextElements& AddOpenTag(const std::string& tag);
+        /** Add an open tag iff it exists as a recognized tag.*/
+        TextElements& AddOpenTag(const std::string& tag, const std::vector<std::string>& params);
+        /** Add a close tag iff it exists as a recognized tag.*/
+        TextElements& AddCloseTag(const std::string& tag);
+        /** Add a text element.  Any whitespace in this text element will be non-breaking.*/
+        TextElements& AddText(const std::string& text);
+        /** Add a white space element.*/
+        TextElements& AddWhitespace(const std::string& whitespace);
+        /** Add a new line element.*/
+        TextElements& AddNewline();
+
+        /** Add an open Clr tag.*/
+        TextElements& AddOpenTag(const Clr& color);
+
+    private:
+        class TextElementsImpl;
+        boost::scoped_ptr<TextElementsImpl> const pimpl;
+    };
+
     /** \brief The type of TextElement that represents a text formatting
         tag. */
     struct GG_API FormattingTag : TextElement

--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -491,6 +491,13 @@ public:
     std::vector<boost::shared_ptr<Font::TextElement> > ExpensiveParseFromTextToTextElements(const std::string& text,
                                                                                             const Flags<TextFormat>& format) const;
 
+    /** Fill \p text_elements with the font widths of characters from \p text starting from \p
+        start. */
+    void FillTemplatedText(
+        const std::string& text,
+        std::vector<boost::shared_ptr<TextElement> >& text_elements,
+        std::vector<boost::shared_ptr<TextElement> >::iterator starting_from) const;
+
     /** DetermineLines() returns the \p line_data resulting from adding the necessary line
         breaks, to  the \p text formatted with \p format and parsed into \p text_elements, to fit
         the \p text into a box of width \p box_width.

--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -147,7 +147,7 @@ public:
             pair.second. */
         Substring(const std::string& str_, const IterPair& pair);
 
-        /** Rebind to a different string.*/
+        /** Rebind to \p str_, by changing the pointer str to point to \p str_.*/
         void Bind(const std::string& str_);
 
         /** Returns an iterator to the beginning of the substring. */
@@ -209,7 +209,12 @@ public:
 
         virtual ~TextElement(); ///< Virtual dtor.
 
-        /** Rebind to a different string.*/
+        /** Rebind to \p whole_text, by binding the SubString data member text to \p whole_text.
+
+            Binding to a new \p whole_text is very fast compared to re-parsing the entire \p
+            whole_text and allows TextElements of TextElementType TEXT to be changed quickly if it
+            is known that the parse would be the same.
+         */
         virtual void Bind(const std::string& whole_text);
 
         /** Returns the TextElementType of the element. */
@@ -248,7 +253,8 @@ public:
             (e.g. "</rgba>"). */
         FormattingTag(bool close);
 
-        /** Rebind to a different string.*/
+        /** Rebind to \p whole_text by binding both the base class and the data member tag_name
+            to \p whole_text. */
         virtual void Bind(const std::string& whole_text);
 
         virtual TextElementType Type() const;

--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -231,6 +231,8 @@ public:
             element represents. */
         CPSize CodePointSize() const;
 
+        virtual bool operator==(const TextElement &rhs) const;
+
         /** The text from the original string represented by the element. */
         Substring text;
 
@@ -258,6 +260,8 @@ public:
         virtual void Bind(const std::string& whole_text);
 
         virtual TextElementType Type() const;
+
+        virtual bool operator==(const TextElement &rhs) const;
 
         /** The parameter strings within the tag, e.g. "0", "0", "0", and "255"
             for the tag "<rgba 0 0 0 255>". */

--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -493,10 +493,9 @@ public:
 
     /** Fill \p text_elements with the font widths of characters from \p text starting from \p
         start. */
-    void FillTemplatedText(
-        const std::string& text,
-        std::vector<boost::shared_ptr<TextElement> >& text_elements,
-        std::vector<boost::shared_ptr<TextElement> >::iterator starting_from) const;
+    void FillTemplatedText(const std::string& text,
+                           std::vector<boost::shared_ptr<TextElement> >& text_elements,
+                           std::vector<boost::shared_ptr<TextElement> >::iterator starting_from) const;
 
     /** DetermineLines() returns the \p line_data resulting from adding the necessary line
         breaks, to  the \p text formatted with \p format and parsed into \p text_elements, to fit

--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -248,7 +248,14 @@ public:
     };
 
     /** \brief Used to encapsulate a text and tokens together to be rendered
-        using GG::Font. */
+        using GG::Font.
+
+        TextElements allows a matched pair of XML string and vector of TextElement to be directly
+        constructed while avoiding the computationally costly ComputeTextElements() function.
+
+        The pair of string and vector returned by Text() and Elements() are consistent with each
+        other and can be used with the fast constructor for TextControl.
+    */
     class GG_API TextElements
     {
     public:

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -523,6 +523,12 @@ CPSize Font::TextElement::CodePointSize() const
 { return CPSize(widths.size()); }
 
 
+bool Font::TextElement::operator==(const TextElement &rhs) const
+{
+    return (text == rhs.text && widths == rhs.widths
+            && whitespace == rhs.whitespace && newline == rhs.newline);
+}
+
 ///////////////////////////////////////
 // class GG::Font::FormattingTag
 ///////////////////////////////////////
@@ -550,6 +556,15 @@ void Font::FormattingTag::Bind(const std::string& whole_text)
 Font::FormattingTag::TextElementType Font::FormattingTag::Type() const
 { return close_tag ? CLOSE_TAG : OPEN_TAG; }
 
+bool Font::FormattingTag::operator==(const TextElement &rhs) const
+{
+    Font::FormattingTag const* ft = dynamic_cast<Font::FormattingTag const*>(&rhs);
+    return (ft
+            && Font::TextElement::operator==(rhs)
+            && params == ft->params
+            && tag_name == ft->tag_name
+            && close_tag == ft->close_tag);
+}
 
 ///////////////////////////////////////
 // class GG::Font::LineData

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -361,6 +361,12 @@ Font::Substring::Substring(const std::string& str_, const IterPair& pair) :
     second = std::distance(str->begin(), pair.second);
 }
 
+void Font::Substring::Bind(const std::string& str_)
+{
+    assert(std::distance(str_.begin(), str_.end()) >= second);
+    str = &str_;
+}
+
 std::string::const_iterator Font::Substring::begin() const
 { return boost::next(str->begin(), first); }
 
@@ -497,6 +503,9 @@ Font::TextElement::TextElement(bool ws, bool nl) :
 Font::TextElement::~TextElement()
 {}
 
+void Font::TextElement::Bind(const std::string& whole_text)
+{ text.Bind(whole_text); }
+
 Font::TextElement::TextElementType Font::TextElement::Type() const
 { return newline ? NEWLINE : (whitespace ? WHITESPACE : TEXT); }
 
@@ -526,6 +535,17 @@ Font::FormattingTag::FormattingTag(bool close) :
     TextElement(false, false),
     close_tag(close)
 {}
+
+void Font::FormattingTag::Bind(const std::string& whole_text)
+{
+    TextElement::Bind(whole_text);
+    tag_name.Bind(whole_text);
+    for (std::vector<Substring>::iterator it = params.begin();
+         it != params.end(); ++it)
+    {
+        it->Bind(whole_text);
+    }
+}
 
 Font::FormattingTag::TextElementType Font::FormattingTag::Type() const
 { return close_tag ? CLOSE_TAG : OPEN_TAG; }

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -1345,12 +1345,17 @@ void Font::FillTemplatedText(
     std::vector<boost::shared_ptr<Font::TextElement> >& text_elements,
     std::vector<boost::shared_ptr<Font::TextElement> >::iterator start) const
 {
+    // For each TextElement in text_elements starting from start.
     std::vector<boost::shared_ptr<Font::TextElement> >::iterator& te_it = start;
     for (; te_it != text_elements.end(); ++te_it) {
         boost::shared_ptr<TextElement> elem = (*te_it);
+
+        // For each character in the TextElement.
         std::string::const_iterator it = elem->text.begin();
         std::string::const_iterator end_it = elem->text.end();
         while (it != end_it) {
+
+            // Find and set the width of the character glyph.
             elem->widths.push_back(X0);
             boost::uint32_t c = utf8::next(it, end_it);
             if (c != WIDE_NEWLINE) {

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -492,7 +492,7 @@ namespace {
         provided to callers without the overhead of recompiling the
         regular expression.*/
     class CompiledRegex {
-        public:
+    public:
         CompiledRegex(const boost::unordered_set<std::string>& known_tags, bool strip_unpaired_tags) :
             m_text(0), m_known_tags(&known_tags), m_ignore_tags(false), m_tag_stack(),
             m_EVERYTHING()
@@ -561,7 +561,7 @@ namespace {
             return m_EVERYTHING;
         }
 
-        private:
+    private:
 
         bool MatchesKnownTag(const boost::xpressive::ssub_match& sub) {
             return m_ignore_tags ? false : m_known_tags->count(sub.str()) != 0;
@@ -588,28 +588,34 @@ namespace {
         xpr::sregex m_EVERYTHING;
     };
 
+    /** TagHandler stores a set of all known tags and provides pre-compiled regexs for those tags.
+
+     Known tags are tags that will be parsed into TextElement OPEN_TAG or CLOSE_TAG. */
     class TagHandler {
-        public:
+    public:
         TagHandler() :
             m_known_tags(),
             m_regex_w_tags(m_known_tags, false),
             m_regex_w_tags_skipping_unmatched(m_known_tags, true)
         {}
 
+        /** Add a tag to the set of known tags.*/
         void Insert(const std::string& tag) {
             m_known_tags.insert(tag);
         }
 
+        /** Remove a tag from the set of known tags.*/
         void Erase(const std::string& tag) {
             m_known_tags.erase(tag);
         }
 
+        /** Remove all tags from the set of known tags.*/
         void Clear() {
             m_known_tags.clear();
         }
 
         // Return a regex bound to \p text using the currently known
-        // tags possible \p ignore_tags and/or \p strip_unpaired_tags
+        // tags.  If required \p ignore_tags and/or \p strip_unpaired_tags.
         xpr::sregex & Regex(const std::string& text, bool ignore_tags, bool strip_unpaired_tags = false) {
             if (!strip_unpaired_tags)
                 return m_regex_w_tags.BindRegexToText(text, ignore_tags);
@@ -617,7 +623,7 @@ namespace {
                 return m_regex_w_tags_skipping_unmatched.BindRegexToText(text, ignore_tags);
         }
 
-        private:
+    private:
         // set of tags known to the handler
         boost::unordered_set<std::string> m_known_tags;
 

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -494,7 +494,10 @@ namespace {
     class CompiledRegex {
     public:
         CompiledRegex(const boost::unordered_set<std::string>& known_tags, bool strip_unpaired_tags) :
-            m_text(0), m_known_tags(&known_tags), m_ignore_tags(false), m_tag_stack(),
+            m_text(0),
+            m_known_tags(&known_tags),
+            m_ignore_tags(false),
+            m_tag_stack(),
             m_EVERYTHING()
         {
             // Synonyms for s1 thru s5 sub matches
@@ -600,27 +603,24 @@ namespace {
         {}
 
         /** Add a tag to the set of known tags.*/
-        void Insert(const std::string& tag) {
-            m_known_tags.insert(tag);
-        }
+        void Insert(const std::string& tag)
+        { m_known_tags.insert(tag); }
 
         /** Remove a tag from the set of known tags.*/
-        void Erase(const std::string& tag) {
-            m_known_tags.erase(tag);
-        }
+        void Erase(const std::string& tag)
+        { m_known_tags.erase(tag); }
 
         /** Remove all tags from the set of known tags.*/
-        void Clear() {
-            m_known_tags.clear();
-        }
+        void Clear()
+        { m_known_tags.clear(); }
 
-        bool IsKnown(const std::string &tag) {
-            return m_known_tags.find(tag) != m_known_tags.end();
-        }
+        bool IsKnown(const std::string &tag) const
+        { return m_known_tags.find(tag) != m_known_tags.end(); }
 
         // Return a regex bound to \p text using the currently known
         // tags.  If required \p ignore_tags and/or \p strip_unpaired_tags.
-        xpr::sregex & Regex(const std::string& text, bool ignore_tags, bool strip_unpaired_tags = false) {
+        xpr::sregex& Regex(const std::string& text, bool ignore_tags, bool strip_unpaired_tags = false)
+        {
             if (!strip_unpaired_tags)
                 return m_regex_w_tags.BindRegexToText(text, ignore_tags);
             else
@@ -647,7 +647,8 @@ namespace {
     }
 
     // Registers the default action and known tags.
-    int RegisterDefaultTags() {
+    int RegisterDefaultTags()
+    {
         StaticTagHandler().Insert("i");
         StaticTagHandler().Insert("s");
         StaticTagHandler().Insert("u");
@@ -753,7 +754,10 @@ class Font::TextAndElementsAssembler::TextAndElementsAssemblerImpl
 {
 public:
     TextAndElementsAssemblerImpl(const Font& font) :
-        m_font(font), m_text(), m_text_elements(), m_are_widths_calculated(false)
+        m_font(font),
+        m_text(),
+        m_text_elements(),
+        m_are_widths_calculated(false)
     {}
 
     /** Return the constructed text.*/
@@ -777,6 +781,7 @@ public:
 
         m_are_widths_calculated = false;
 
+        // Create the opening part of an open tag, like this: "<tag"
         boost::shared_ptr<Font::FormattingTag> element(new Font::FormattingTag(false));
         size_t tag_begin = m_text.size();
         size_t tag_name_begin = m_text.append("<").size();
@@ -785,6 +790,7 @@ public:
                                       boost::next(m_text.begin(), tag_name_begin),
                                       boost::next(m_text.begin(), tag_name_end));
 
+        // If there are params add them, like this: "<tag param1 param2"
         if (params) {
             for (std::vector<std::string>::const_iterator it = params->begin();
                  it != params->end(); ++it)
@@ -798,6 +804,8 @@ public:
                                                     boost::next(m_text.begin(), param_end)));
             }
         }
+
+        // Create the close part of an open tag to complete the tag, like this:"<tag param1 param2>"
         size_t tag_end = m_text.append(">").size();
         element->text = Substring(m_text,
                                   boost::next(m_text.begin(), tag_begin),
@@ -814,6 +822,7 @@ public:
 
         m_are_widths_calculated = false;
 
+        // Create a close tag that looks like this: "</tag>"
         boost::shared_ptr<Font::FormattingTag> element(new Font::FormattingTag(true));
         size_t tag_begin = m_text.size();
         size_t tag_name_begin = m_text.append("</").size();
@@ -857,7 +866,7 @@ public:
         m_text_elements.push_back(element);
     }
 
-    /** Add a white space element.*/
+    /** Add a newline element.*/
     void AddNewline()
     {
         m_are_widths_calculated = false;
@@ -867,7 +876,8 @@ public:
     }
 
     /** Add open color tag.*/
-    void AddOpenTag(const Clr& color) {
+    void AddOpenTag(const Clr& color)
+    {
         std::vector<std::string> params;
         params.push_back(boost::lexical_cast<std::string>(static_cast<int>(color.r)));
         params.push_back(boost::lexical_cast<std::string>(static_cast<int>(color.g)));
@@ -888,47 +898,56 @@ private:
 Font::TextAndElementsAssembler::TextAndElementsAssembler(const Font& font) :
     pimpl(new TextAndElementsAssemblerImpl(font))
 {}
+
 // Required because Impl is defined here
 Font::TextAndElementsAssembler::~TextAndElementsAssembler()
 {}
+
 const std::string& Font::TextAndElementsAssembler::Text()
 { return pimpl->Text(); }
 
 const std::vector<boost::shared_ptr<Font::TextElement> >& Font::TextAndElementsAssembler::Elements()
 { return pimpl->Elements(); }
 
-Font::TextAndElementsAssembler& Font::TextAndElementsAssembler::AddOpenTag(const std::string& tag) {
+Font::TextAndElementsAssembler& Font::TextAndElementsAssembler::AddOpenTag(const std::string& tag)
+{
     pimpl->AddOpenTag(tag);
     return *this;
 }
 
 Font::TextAndElementsAssembler& Font::TextAndElementsAssembler::AddOpenTag(
-    const std::string& tag, const std::vector<std::string>& params) {
+    const std::string& tag, const std::vector<std::string>& params)
+{
     pimpl->AddOpenTag(tag, &params);
     return *this;
 }
 
-Font::TextAndElementsAssembler& Font::TextAndElementsAssembler::AddCloseTag(const std::string& tag) {
+Font::TextAndElementsAssembler& Font::TextAndElementsAssembler::AddCloseTag(const std::string& tag)
+{
     pimpl->AddCloseTag(tag);
     return *this;
 }
 
-Font::TextAndElementsAssembler& Font::TextAndElementsAssembler::AddText(const std::string& text) {
+Font::TextAndElementsAssembler& Font::TextAndElementsAssembler::AddText(const std::string& text)
+{
     pimpl->AddText(text);
     return *this;
 }
 
-Font::TextAndElementsAssembler& Font::TextAndElementsAssembler::AddWhitespace(const std::string& whitespace) {
+Font::TextAndElementsAssembler& Font::TextAndElementsAssembler::AddWhitespace(const std::string& whitespace)
+{
     pimpl->AddWhitespace(whitespace);
     return *this;
 }
 
-Font::TextAndElementsAssembler& Font::TextAndElementsAssembler::AddNewline() {
+Font::TextAndElementsAssembler& Font::TextAndElementsAssembler::AddNewline()
+{
     pimpl->AddNewline();
     return *this;
 }
 
-Font::TextAndElementsAssembler& Font::TextAndElementsAssembler::AddOpenTag(const Clr& color) {
+Font::TextAndElementsAssembler& Font::TextAndElementsAssembler::AddOpenTag(const Clr& color)
+{
     pimpl->AddOpenTag(color);
     return *this;
 }

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -761,7 +761,7 @@ public:
     {}
 
     /** Return the constructed text.*/
-    const std::string& Text()
+    const std::string& Text() const
     { return m_text; }
 
     /** Return the constructed TextElements.*/

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -747,12 +747,12 @@ bool Font::FormattingTag::operator==(const TextElement &rhs) const
 }
 
 ///////////////////////////////////////
-// class GG::Font::TextElements
+// class GG::Font::TextAndElementsAssembler
 ///////////////////////////////////////
-class Font::TextElements::TextElementsImpl
+class Font::TextAndElementsAssembler::TextAndElementsAssemblerImpl
 {
 public:
-    TextElementsImpl(const Font& font) :
+    TextAndElementsAssemblerImpl(const Font& font) :
         m_font(font), m_text(), m_text_elements(), m_are_widths_calculated(false)
     {}
 
@@ -885,42 +885,50 @@ private:
 };
 
 
-Font::TextElements::TextElements(const Font& font) :
-    pimpl(new TextElementsImpl(font))
+Font::TextAndElementsAssembler::TextAndElementsAssembler(const Font& font) :
+    pimpl(new TextAndElementsAssemblerImpl(font))
 {}
 // Required because Impl is defined here
-Font::TextElements::~TextElements()
+Font::TextAndElementsAssembler::~TextAndElementsAssembler()
 {}
-const std::string& Font::TextElements::Text()
+const std::string& Font::TextAndElementsAssembler::Text()
 { return pimpl->Text(); }
-const std::vector<boost::shared_ptr<Font::TextElement> >& Font::TextElements::Elements()
+
+const std::vector<boost::shared_ptr<Font::TextElement> >& Font::TextAndElementsAssembler::Elements()
 { return pimpl->Elements(); }
-Font::TextElements& Font::TextElements::AddOpenTag(const std::string& tag) {
+
+Font::TextAndElementsAssembler& Font::TextAndElementsAssembler::AddOpenTag(const std::string& tag) {
     pimpl->AddOpenTag(tag);
     return *this;
 }
-Font::TextElements& Font::TextElements::AddOpenTag(
+
+Font::TextAndElementsAssembler& Font::TextAndElementsAssembler::AddOpenTag(
     const std::string& tag, const std::vector<std::string>& params) {
     pimpl->AddOpenTag(tag, &params);
     return *this;
 }
-Font::TextElements& Font::TextElements::AddCloseTag(const std::string& tag) {
+
+Font::TextAndElementsAssembler& Font::TextAndElementsAssembler::AddCloseTag(const std::string& tag) {
     pimpl->AddCloseTag(tag);
     return *this;
 }
-Font::TextElements& Font::TextElements::AddText(const std::string& text) {
+
+Font::TextAndElementsAssembler& Font::TextAndElementsAssembler::AddText(const std::string& text) {
     pimpl->AddText(text);
     return *this;
 }
-Font::TextElements& Font::TextElements::AddWhitespace(const std::string& whitespace) {
+
+Font::TextAndElementsAssembler& Font::TextAndElementsAssembler::AddWhitespace(const std::string& whitespace) {
     pimpl->AddWhitespace(whitespace);
     return *this;
 }
-Font::TextElements& Font::TextElements::AddNewline() {
+
+Font::TextAndElementsAssembler& Font::TextAndElementsAssembler::AddNewline() {
     pimpl->AddNewline();
     return *this;
 }
-Font::TextElements& Font::TextElements::AddOpenTag(const Clr& color) {
+
+Font::TextAndElementsAssembler& Font::TextAndElementsAssembler::AddOpenTag(const Clr& color) {
     pimpl->AddOpenTag(color);
     return *this;
 }

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -1331,25 +1331,36 @@ std::vector<boost::shared_ptr<Font::TextElement> > Font::ExpensiveParseFromTextT
     }
 
     // fill in the widths of code points in each TextElement
-    for (std::size_t i = 0; i < text_elements.size(); ++i) {
-        std::string::const_iterator it = text_elements[i]->text.begin();
-        std::string::const_iterator end_it = text_elements[i]->text.end();
-        while (it != end_it) {
-            text_elements[i]->widths.push_back(X0);
-            boost::uint32_t c = utf8::next(it, end_it);
-            if (c != WIDE_NEWLINE) {
-                GlyphMap::const_iterator it = m_glyphs.find(c);
-                // use a space when an unrendered glyph is requested (the
-                // space chararacter is always renderable)
-                text_elements[i]->widths.back() = (it != m_glyphs.end()) ? it->second.advance : m_space_width;
-            }
-        }
-    }
+    FillTemplatedText(text, text_elements, text_elements.begin());
 
 #if DEBUG_DETERMINELINES
     DebugOutput::PrintParseResults(text_elements);
 #endif
     return text_elements;
+}
+
+
+void Font::FillTemplatedText(
+    const std::string& text,
+    std::vector<boost::shared_ptr<Font::TextElement> >& text_elements,
+    std::vector<boost::shared_ptr<Font::TextElement> >::iterator start) const
+{
+    std::vector<boost::shared_ptr<Font::TextElement> >::iterator& te_it = start;
+    for (; te_it != text_elements.end(); ++te_it) {
+        boost::shared_ptr<TextElement> elem = (*te_it);
+        std::string::const_iterator it = elem->text.begin();
+        std::string::const_iterator end_it = elem->text.end();
+        while (it != end_it) {
+            elem->widths.push_back(X0);
+            boost::uint32_t c = utf8::next(it, end_it);
+            if (c != WIDE_NEWLINE) {
+                GlyphMap::const_iterator it = m_glyphs.find(c);
+                // use a space when an unrendered glyph is requested (the
+                // space chararacter is always renderable)
+                elem->widths.back() = (it != m_glyphs.end()) ? it->second.advance : m_space_width;
+            }
+        }
+    }
 }
 
 std::vector<Font::LineData> Font::DetermineLines(const std::string& text, Flags<TextFormat>& format, X box_width,


### PR DESCRIPTION
This PR follows #1038.

TextAndElementsAssembler allows the creation of a matched pair of text and vector of `TextElement` efficiently.
