### PR TITLE
Document `util/XMLDoc.h` and trim file includes.

### DIFF
--- a/UI/IntroScreen.cpp
+++ b/UI/IntroScreen.cpp
@@ -13,6 +13,7 @@
 #include "../util/OptionsDB.h"
 #include "../util/Serialize.h"
 #include "../util/Version.h"
+#include "../util/XMLDoc.h"
 
 #include <GG/GUI.h>
 #include <GG/DrawUtil.h>

--- a/client/AI/camain.cpp
+++ b/client/AI/camain.cpp
@@ -4,6 +4,7 @@
 #include "../../util/OptionsDB.h"
 #include "../../util/Directories.h"
 #include "../../util/Logger.h"
+#include "../../util/XMLDoc.h"
 
 #include <GG/utf8/checked.h>
 

--- a/util/MultiplayerCommon.cpp
+++ b/util/MultiplayerCommon.cpp
@@ -5,6 +5,7 @@
 #include "Logger.h"
 #include "OptionsDB.h"
 #include "Random.h"
+#include "XMLDoc.h"
 #include "../universe/Fleet.h"
 #include "../universe/Planet.h"
 #include "../universe/System.h"

--- a/util/OptionsDB.cpp
+++ b/util/OptionsDB.cpp
@@ -11,6 +11,7 @@
 #include <string>
 
 #include <boost/spirit/include/classic.hpp>
+#include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/erase.hpp>
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/filesystem/fstream.hpp>

--- a/util/OptionsDB.cpp
+++ b/util/OptionsDB.cpp
@@ -3,6 +3,7 @@
 #include "i18n.h"
 #include "Logger.h"
 #include "OptionValidators.h"
+#include "XMLDoc.h"
 
 #include "util/Directories.h"
 
@@ -149,7 +150,9 @@ void OptionsDB::Commit()
         return;
     boost::filesystem::ofstream ofs(GetConfigPath());
     if (ofs) {
-        GetOptionsDB().GetXML().WriteDoc(ofs);
+        XMLDoc doc;
+        GetOptionsDB().GetXML(doc);
+        doc.WriteDoc(ofs);
         m_dirty = false;
     } else {
         std::cerr << UserString("UNABLE_TO_WRITE_CONFIG_XML") << std::endl;
@@ -257,8 +260,8 @@ void OptionsDB::GetUsage(std::ostream& os, const std::string& command_line/* = "
     }
 }
 
-XMLDoc OptionsDB::GetXML() const {
-    XMLDoc doc;
+void OptionsDB::GetXML(XMLDoc& doc) const {
+    doc = XMLDoc();
 
     std::vector<XMLElement*> elem_stack;
     elem_stack.push_back(&doc.root_node);
@@ -304,8 +307,6 @@ XMLDoc OptionsDB::GetXML() const {
         elem_stack.back()->AppendChild(temp);
         elem_stack.push_back(&elem_stack.back()->Child(temp.Tag()));
     }
-
-    return doc;
 }
 
 OptionsDB::OptionChangedSignalType& OptionsDB::OptionChangedSignal(const std::string& option) {

--- a/util/OptionsDB.h
+++ b/util/OptionsDB.h
@@ -4,7 +4,6 @@
 #include "Export.h"
 #include "Logger.h"
 #include "OptionValidators.h"
-#include "XMLDoc.h"
 
 #include <boost/any.hpp>
 #include <boost/signals2/signal.hpp>
@@ -13,6 +12,8 @@
 
 
 class OptionsDB;
+class XMLDoc;
+class XMLElement;
 
 /////////////////////////////////////////////
 // Free Functions
@@ -171,8 +172,12 @@ public:
     /** writes a usage message to \a os */
     void        GetUsage(std::ostream& os, const std::string& command_line = "") const;
 
-    /** returns the contents of the DB as an XMLDoc. */
-    XMLDoc      GetXML() const;
+    /** @brief  Saves the contents of the options DB to the @p doc XMLDoc.
+     *
+     * @param[in,out] doc  The document this OptionsDB should be written to.
+     *      This resets the given @p doc.
+     */
+    void GetXML(XMLDoc& doc) const;
 
     /** find all registered Options that begin with \a prefix and store them in
       * \a ret. */

--- a/util/XMLDoc.cpp
+++ b/util/XMLDoc.cpp
@@ -91,9 +91,9 @@ namespace {
 ////////////////////////////////////////////////
 // XMLElement
 ////////////////////////////////////////////////
-XMLElement::XMLElement(const std::string& t, bool r) :
-    m_tag(t),
-    m_root(r)
+XMLElement::XMLElement(const std::string& tag, bool root) :
+    m_tag(tag),
+    m_root(root)
 {}
 
 const std::string& XMLElement::Tag() const
@@ -108,17 +108,17 @@ int XMLElement::NumChildren() const
 int XMLElement::NumAttributes() const
 { return m_attributes.size(); }
 
-bool XMLElement::ContainsChild(const std::string& child) const
-{ return ChildIndex(child) != -1; }
+bool XMLElement::ContainsChild(const std::string& tag) const
+{ return ChildIndex(tag) != -1; }
 
-bool XMLElement::ContainsAttribute(const std::string& attrib) const
-{ return m_attributes.find(attrib) != m_attributes.end(); }
+bool XMLElement::ContainsAttribute(const std::string& key) const
+{ return m_attributes.find(key) != m_attributes.end(); }
 
-int XMLElement::ChildIndex(const std::string& child) const
+int XMLElement::ChildIndex(const std::string& key) const
 {
     int retval = -1;
     for (unsigned int i = 0; i < m_children.size(); ++i) {
-        if (m_children[i].m_tag == child) {
+        if (m_children[i].m_tag == key) {
             retval = i;
             break;
         }
@@ -126,19 +126,19 @@ int XMLElement::ChildIndex(const std::string& child) const
     return retval;
 }
 
-const XMLElement& XMLElement::Child(unsigned int idx) const
-{ return m_children.at(idx); }
+const XMLElement& XMLElement::Child(unsigned int index) const
+{ return m_children.at(index); }
 
-const XMLElement& XMLElement::Child(const std::string& child) const
+const XMLElement& XMLElement::Child(const std::string& tag) const
 {
     unsigned int i = 0;
     for (; i < m_children.size(); ++i) {
-        if (m_children[i].m_tag == child)
+        if (m_children[i].m_tag == tag)
             break;
     }
 
     if (i == m_children.size())
-        throw NoSuchChild("XMLElement::Child(): The XMLElement \"" + Tag() + "\" contains no child \"" + child + "\".");
+        throw NoSuchChild("XMLElement::Child(): The XMLElement \"" + Tag() + "\" contains no child \"" + tag + "\".");
 
     return m_children[i];
 }
@@ -151,10 +151,10 @@ const XMLElement& XMLElement::LastChild() const
     return m_children.back();
 }
 
-const std::string& XMLElement::Attribute(const std::string& attrib) const
+const std::string& XMLElement::Attribute(const std::string& key) const
 {
     static const std::string empty_str("");
-    std::map<std::string, std::string>::const_iterator it = m_attributes.find(attrib);
+    std::map<std::string, std::string>::const_iterator it = m_attributes.find(key);
     if (it != m_attributes.end())
         return it->second;
     else
@@ -214,19 +214,19 @@ XMLElement::const_attr_iterator XMLElement::attr_begin() const
 XMLElement::const_attr_iterator XMLElement::attr_end() const
 { return m_attributes.end(); }
 
-XMLElement& XMLElement::Child(unsigned int idx)
-{ return m_children.at(idx); }
+XMLElement& XMLElement::Child(unsigned int index)
+{ return m_children.at(index); }
 
-XMLElement& XMLElement::Child(const std::string& child)
+XMLElement& XMLElement::Child(const std::string& tag)
 {
     unsigned int i = 0;
     for (; i < m_children.size(); ++i) {
-        if (m_children[i].m_tag == child)
+        if (m_children[i].m_tag == tag)
             break;
     }
 
     if (i == m_children.size())
-        throw NoSuchChild("XMLElement::Child(): The XMLElement \"" + Tag() + "\" contains no child \"" + child + "\".");
+        throw NoSuchChild("XMLElement::Child(): The XMLElement \"" + Tag() + "\" contains no child \"" + tag + "\".");
 
     return m_children[i];
 }
@@ -239,8 +239,8 @@ XMLElement& XMLElement::LastChild()
     return m_children.back();
 }
 
-void XMLElement::SetAttribute(const std::string& attrib, const std::string& val)
-{ m_attributes[attrib] = val; }
+void XMLElement::SetAttribute(const std::string& key, const std::string& value)
+{ m_attributes[key] = value; }
 
 void XMLElement::SetTag(const std::string& tag)
 { m_tag = tag; }
@@ -248,42 +248,42 @@ void XMLElement::SetTag(const std::string& tag)
 void XMLElement::SetText(const std::string& text)
 { m_text = text; }
 
-void XMLElement::RemoveAttribute(const std::string& attrib)
-{ m_attributes.erase(attrib); }
+void XMLElement::RemoveAttribute(const std::string& key)
+{ m_attributes.erase(key); }
 
 void XMLElement::RemoveAttributes()
 { m_attributes.clear(); }
 
-void XMLElement::AppendChild(const XMLElement& e)
-{ m_children.push_back(e); }
+void XMLElement::AppendChild(const XMLElement& child)
+{ m_children.push_back(child); }
 
-void XMLElement::AppendChild(const std::string& child)
-{ m_children.push_back(XMLElement(child)); }
+void XMLElement::AppendChild(const std::string& tag)
+{ m_children.push_back(XMLElement(tag)); }
 
-void XMLElement::AddChildBefore(const XMLElement& e, unsigned int idx)
+void XMLElement::AddChildBefore(const XMLElement& child, unsigned int index)
 {
-    if (m_children.size() <= idx)
-        throw NoSuchIndex("XMLElement::AddChildBefore(): Index " + boost::lexical_cast<std::string>(idx) + " is out of range for XMLElement \"" + Tag() + "\".");
+    if (m_children.size() <= index)
+        throw NoSuchIndex("XMLElement::AddChildBefore(): Index " + boost::lexical_cast<std::string>(index) + " is out of range for XMLElement \"" + Tag() + "\".");
 
-    m_children.insert(m_children.begin() + idx, e);
+    m_children.insert(m_children.begin() + index, child);
 }
 
-void XMLElement::RemoveChild(unsigned int idx)
+void XMLElement::RemoveChild(unsigned int index)
 {
-    if (m_children.size() <= idx)
-        throw NoSuchIndex("XMLElement::RemoveChild(): Index " + boost::lexical_cast<std::string>(idx) + " is out of range for XMLElement \"" + Tag() + "\".");
+    if (m_children.size() <= index)
+        throw NoSuchIndex("XMLElement::RemoveChild(): Index " + boost::lexical_cast<std::string>(index) + " is out of range for XMLElement \"" + Tag() + "\".");
 
-    m_children.erase(m_children.begin() + idx);
+    m_children.erase(m_children.begin() + index);
 }
 
-void XMLElement::RemoveChild(const std::string& child)
+void XMLElement::RemoveChild(const std::string& tag)
 {
-    int idx = ChildIndex(child);
+    int index = ChildIndex(tag);
 
-    if (idx == -1)
-        throw NoSuchChild("XMLElement::RemoveChild(): The XMLElement \"" + Tag() + "\" contains no child \"" + child + "\".");
+    if (index == -1)
+        throw NoSuchChild("XMLElement::RemoveChild(): The XMLElement \"" + Tag() + "\" contains no child \"" + tag + "\".");
 
-    m_children.erase(m_children.begin() + idx);
+    m_children.erase(m_children.begin() + index);
 }
 
 void XMLElement::RemoveChildren()

--- a/util/XMLDoc.cpp
+++ b/util/XMLDoc.cpp
@@ -56,6 +56,7 @@
 
 #include "XMLDoc.h"
 
+#include <boost/lexical_cast.hpp>
 #include <boost/spirit/include/classic.hpp>
 
 #include <stdexcept>

--- a/util/XMLDoc.h
+++ b/util/XMLDoc.h
@@ -38,79 +38,78 @@
 
 /** @brief  Represents a simplified XML markup element.
  *
- * An XMLElement represent represents a XML element from the opening tag
- * \<tag-name\>, including its attributes to the corresponding closing tag
- * \</tag-name\>.  This may or may not include a text data section \b OR child
- * XML elements.
+ * An XMLElement represents a XML element from the opening tag * \<tag-name\>,
+ * including its attributes to the corresponding closing tag \</tag-name\>.
+ * This may or may not include a text data section @b OR child XML elements.
  *
- * For take the "burns" example:
-   \code{.xml}
+ * Using the "burns" example:
+   @code{.xml}
    <burns>Say <quote>Goodnight</quote> Gracie.</burns>
-   \endcode
+   @endcode
  *
  * may not work as expected.  The resulting XMLElement \<burns\> node will
  * contain both the "Say " and the " Gracie." text fragment.  Or represented
  * differently:
  *
-   \code{.js}
+   @code{.js}
    burns.Text() == "Say  Gracie."
-   \endcode
+   @endcode
  *
  * However, if used to represent data structures like the example struct foo:
  *
-   \code{.cpp}
+   @code{.cpp}
    struct foo
    {
       int ref_ct;
       double data;
    };
-   \endcode
+   @endcode
  *
  * the current implementation creates a XML representation similar to:
  *
-   \code{.xml}
+   @code{.xml}
    <bar>
      <foo>
        <ref_ct>13<ref_ct/>
        <data>0.364951<data/>
      </foo>
    </bar>
-   \endcode
+   @endcode
  *
  * Further, while the "burns" example is standard XML, an XMLElement optionally
  * accepts its single text string in quotes, and strips off trailing white
  * space, in direct contrary to the XML standard.  So "burns" from above is
  * equivalent to:
-   \code{.xml}
+   @code{.xml}
    <burns>"Say  Gracie."<quote>Goodnight</quote></burns>
-   \endcode
+   @endcode
  * or:
-   \code{.xml}
+   @code{.xml}
    <burns>Say  Gracie.<quote>Goodnight</quote></burns>
-   \endcode
+   @endcode
  * or:
-   \code{.xml}
+   @code{.xml}
    <burns>"Say  Gracie."
      <quote>Goodnight</quote>
    </burns>
-   \endcode
+   @endcode
  * or:
-    \code{.xml}
-    <burns>Say  Gracie.
-      <quote>Goodnight</quote>
-    </burns>
-    \endcode
+   @code{.xml}
+   <burns>Say  Gracie.
+     <quote>Goodnight</quote>
+   </burns>
+   @endcode
  *
  * Each of these examples yields to
-   \code{.js}
+   @code{.js}
    burns.Text() == "Say  Gracie."
-   \endcode
+   @endcode
  *
  * When an XMLElement is saved, its text is saved within a CDATA section.  Any
  * string can be put inside one of these quoted text fields, even text that
  * includes an arbitrary number of quotes.  So any std::string or c-string can
  * be assigned to an element.  However, when hand-editing an XML file containing
- * such text strings, need to be a bit careful.  The closing quote must be the
+ * such text strings, one needs to be careful.  The closing quote must be the
  * last thing other than white space.  Adding more than one quoted text string
  * to the XML element, with each string separated by other elements, will result
  * in a single concatenated string, as illustrated above.
@@ -307,7 +306,7 @@ public:
     /** @brief  Returns the last XMLElement child of this XMLElement.
      *
      * @return  A reference to the last XMLElement child.
-     * \throw XMLElement:NoSuchIndex  When there are no child XMLElement%s.
+     * @throw XMLElement:NoSuchIndex  When there are no child XMLElement%s.
      */
     const XMLElement& LastChild() const;
 
@@ -324,10 +323,10 @@ public:
      *      stream @p os with indentation level @p indent when @p whitespace
      *      is set.
      *
-     * @param [in] os  The output stream this document should be written to.
-     * @param [in] indent  The indentation level this element should be
+     * @param[in] os  The output stream this document should be written to.
+     * @param[in] indent  The indentation level this element should be
      *      indented.
-     * @param [in] whitespace  If set to true the child XMLElement%s are
+     * @param[in] whitespace  If set to true the child XMLElement%s are
      *      indented and newline separated.
      * @return  The given @p os output stream.
      */
@@ -336,9 +335,9 @@ public:
     /** @brief  Return this XMLElement XML formatted as string with indentation
      * level @p indent when @p whitespace is set.
      *
-     * @param [in] indent  The indentation level this element should be
+     * @param[in] indent  The indentation level this element should be
      *      indented.
-     * @param [in] whitespace  If set to true the child XMLElement%s are
+     * @param[in] whitespace  If set to true the child XMLElement%s are
      *      indented and newline separated.
      * @return  A string containing the XML formatted representation of this
      *      XMLElement.
@@ -528,8 +527,8 @@ public:
 
     /** @brief  Construct a document from the given input stream @p is.
      *
-     * @param[in] is  An input stream that provides an XML markup document when
-     *      reading.
+     * @param[in] is  An input stream that provides an XML markup document once
+     *      read.
      *
      * @bug  @p is isn't actually read but ignored and an empty (and maybe
      *      invalid) document is created.  Use XMLDoc::ReadDoc(std::istream&)
@@ -542,8 +541,8 @@ public:
     /** @brief  Write the contents of the XMLDoc into the given output stream
      *      @p os with optional @p indent.
      *
-     * @param [in] os  The output stream this document should be written to.
-     * @param [in] indent  If set to true the XML elements are indented and
+     * @param[in] os  The output stream this document should be written to.
+     * @param[in] indent  If set to true the XML elements are indented and
      *      newline separated.
      * @return  The given @p os output stream.
      */
@@ -554,8 +553,8 @@ public:
     /** @brief  Clears the current content of this XMLDoc instance and read a
      *      new document from the given input stream @p is.
      *
-     * @param[in] is  An input stream that provides an XML markup document when
-     *      reading.
+     * @param[in] is  An input stream that provides an XML markup document once
+     *      read.
      * @return  The given @p is input stream.
      */
     std::istream& ReadDoc(std::istream& is);

--- a/util/XMLDoc.h
+++ b/util/XMLDoc.h
@@ -40,259 +40,564 @@
 
 #include "Export.h"
 
-/** \file
- *
- * Contains free functions and classes to modify, read and write XML files.
+/** @file
+ * @brief  Declares free functions and classes to modify, read and write simple
+ *      XML files.
  */
 
-/** encapsulates an XML element (from a <> tag to a </> tag).  XMLElement is a simplified XML element, 
-    consisting only of a tag, a single text string, attributes and child elements.  It is designed to represent 
-    C++ objects to allow them to easily be saved to/loaded from disk and serialized to be sent over a network 
-    connection. It is *not* designed to represent documents. So this:
-    \verbatim
-      <burns>Say <quote>Goodnight</quote> Gracie.</burns> 
-    \endverbatim
-    may not work as you might think. You will end up with both the "Say " and the " Gracie." together.  
-    So burns.Text() == "Say  Gracie.". If, however, you wanted to represent an object bar of class foo:
-    \verbatim
-      class foo
-      {
-         int ref_ct;
-         double data;
-      };
-    \endverbatim
-    you might do something like this: 
-    \verbatim
-      <bar>
-         <foo>
-            <ref_ct>13<ref_ct/>
-            <data>0.364951<data/>
-         </foo>
-      </bar>
-    \endverbatim
-    Further, while that example is standard XML, an XMLElement optionally accepts its single text string in quotes, 
-    and strips off trailing whitespace, in direct contrary to the XML standard.  
-    So "burns" from above is equivalent to:
-    \verbatim
-      <burns>"Say  Gracie."<quote>Goodnight</quote></burns> 
-    \endverbatim
-    or:
-    \verbatim
-      <burns>Say  Gracie.<quote>Goodnight</quote></burns> 
-    \endverbatim
-    or:
-    \verbatim
-      <burns>"Say  Gracie."
-         <quote>Goodnight</quote>
-      </burns> 
-    \endverbatim
-    or:
-    \verbatim
-      <burns>Say  Gracie.
-         <quote>Goodnight</quote>
-      </burns> 
-    \endverbatim
-    Each of these yields a burns.Text() of "Say  Gracie.".  When an XMLElement is saved, its text is saved within a CDATA section.
-    Any string can be put inside one of these quoted text fields, even text that includes an arbitrary number of quotes.  So you 
-    can assign any std::string or c-string to an element.  However, when hand-editing an XML file containing such text strings, you
-    need to be a bit careful.  The closing quote must be the last thing other than whitespace.  Adding 
-    more than one quoted text string to the XML element, with each string separated by other elements, will result in a 
-    single concatenated string, as illustrated above.
-    This is not the most time- or space-efficient way to organize object data, but it may just be one of the simplest 
-    and most easily read. */
+/** @brief  Represents a simplified XML markup element.
+ *
+ * An XMLElement represent represents a XML element from the opening tag
+ * \<tag-name\>, including its attributes to the corresponding closing tag
+ * \</tag-name\>.  This may or may not include a text data section \b OR child
+ * XML elements.
+ *
+ * For take the "burns" example:
+   \code{.xml}
+   <burns>Say <quote>Goodnight</quote> Gracie.</burns>
+   \endcode
+ *
+ * may not work as expected.  The resulting XMLElement \<burns\> node will
+ * contain both the "Say " and the " Gracie." text fragment.  Or represented
+ * differently:
+ *
+   \code{.js}
+   burns.Text() == "Say  Gracie."
+   \endcode
+ *
+ * However, if used to represent data structures like the example struct foo:
+ *
+   \code{.cpp}
+   struct foo
+   {
+      int ref_ct;
+      double data;
+   };
+   \endcode
+ *
+ * the current implementation creates a XML representation similar to:
+ *
+   \code{.xml}
+   <bar>
+     <foo>
+       <ref_ct>13<ref_ct/>
+       <data>0.364951<data/>
+     </foo>
+   </bar>
+   \endcode
+ *
+ * Further, while the "burns" example is standard XML, an XMLElement optionally
+ * accepts its single text string in quotes, and strips off trailing white
+ * space, in direct contrary to the XML standard.  So "burns" from above is
+ * equivalent to:
+   \code{.xml}
+   <burns>"Say  Gracie."<quote>Goodnight</quote></burns>
+   \endcode
+ * or:
+   \code{.xml}
+   <burns>Say  Gracie.<quote>Goodnight</quote></burns>
+   \endcode
+ * or:
+   \code{.xml}
+   <burns>"Say  Gracie."
+     <quote>Goodnight</quote>
+   </burns>
+   \endcode
+ * or:
+    \code{.xml}
+    <burns>Say  Gracie.
+      <quote>Goodnight</quote>
+    </burns>
+    \endcode
+ *
+ * Each of these examples yields to
+   \code{.js}
+   burns.Text() == "Say  Gracie."
+   \endcode
+ *
+ * When an XMLElement is saved, its text is saved within a CDATA section.  Any
+ * string can be put inside one of these quoted text fields, even text that
+ * includes an arbitrary number of quotes.  So any std::string or c-string can
+ * be assigned to an element.  However, when hand-editing an XML file containing
+ * such text strings, need to be a bit careful.  The closing quote must be the
+ * last thing other than white space.  Adding more than one quoted text string
+ * to the XML element, with each string separated by other elements, will result
+ * in a single concatenated string, as illustrated above.
+ *
+ * This is not the most time- or space-efficient way to organize object data,
+ * but it may just be one of the simplest and most easily read.
+ */
 class FO_COMMON_API XMLElement
 {
 public:
-    typedef std::vector<XMLElement>::iterator                  child_iterator;
-    typedef std::vector<XMLElement>::const_iterator            const_child_iterator;
-    typedef std::map<std::string, std::string>::iterator       attr_iterator;
-    typedef std::map<std::string, std::string>::const_iterator const_attr_iterator;
-
-    /** \name Structors */ //@{
-    XMLElement() : m_root(false) {} ///< default ctor
-    XMLElement(const std::string& tag) : m_tag(tag), m_text(""), m_root(false) {}  ///< ctor that constructs an XMLElement with a tag-name \a tag
-    XMLElement(const std::string& tag, const std::string& text) : m_tag(tag), m_text(text), m_root(false) {}  ///< ctor that constructs an XMLElement with a tag-name \a tag and text \a text
-    XMLElement(const std::string& tag, const XMLElement& body) : m_tag(tag), m_children(std::vector<XMLElement>(1, body)), m_root(false) {}  ///< ctor that constructs an XMLElement with a tag-name \a tag and a single child \a body
-    //@}
-
-    /** \name Accessors */ //@{
-    const std::string& Tag() const;                          ///< returns the tag-name of the XMLElement
-    const std::string& Text() const;                         ///< returns the text of this XMLElement
-    int NumChildren() const;                                 ///< returns the number of children in the XMLElement
-    int NumAttributes() const;                               ///< returns the number of attributes in the XMLElement
-    bool ContainsChild(const std::string& child) const;      ///< returns true if the element contains a child called \a name
-    bool ContainsAttribute(const std::string& attrib) const; ///< returns true if the element contains an attribute called \a name
-    int  ChildIndex(const std::string& child) const;         ///< returns the index of the child called \a name, or -1 if not found
-
-    /**  returns the child in the \a idx-th position of the child list of the XMLElement.  \throw
-         XMLElement::NoSuchIndex An out of range index will cause an exception. */
-    const XMLElement& Child(unsigned int idx) const;
-
-    /**  returns the child in child list of the XMLElement that has the tag-name \a str.  \throw
-         XMLElement::NoSuchChild An exception is thrown if no child named \a child exists. */   
-    const XMLElement& Child(const std::string& child) const;
-
-    /**  returns the last child in child list of the XMLElement.  \throw XMLElement:NoSuchIndex Calling this on an
-         empty element will cause an exception. */   
-    const XMLElement& LastChild() const;
-
-    /** returns the value of the attribute with name \a key, or "" if no such named attribute is found */
-    const std::string& Attribute(const std::string& attrib) const;
-
-    /** writes the XMLElement to an output stream; returns the stream */
-    std::ostream& WriteElement(std::ostream& os, int indent = 0, bool whitespace = true) const;
-    std::string WriteElement(int indent = 0, bool whitespace = true) const;
-
-    const_child_iterator child_begin() const; ///< const_iterator to the first child in the XMLElement
-    const_child_iterator child_end() const;   ///< const_iterator to the last + 1 child in the XMLElement
-    const_attr_iterator  attr_begin() const;  ///< const_iterator to the first attribute in the XMLElement
-    const_attr_iterator  attr_end() const;    ///< const_iterator to the last + 1 attribute in the XMLElement
-    //@}
-
-    /** \name Mutators */ //@{
-    /**  returns the child in the \a idx-th position of the child list of the XMLElement.  \throw
-         XMLElement:NoSuchIndex An out of range index will cause an exception. */
-    XMLElement& Child(unsigned int idx);
-
-    /**  returns the child in child list of the XMLElement that has the tag-name \a child.  \throw
-         XMLElement::NoSuchChild An exception is thrown if no child named \a child exists. */   
-    XMLElement& Child(const std::string& child);
-
-    /**  returns the last child in child list of the XMLElement.  \throw XMLElement:NoSuchIndex Calling this on an
-         empty element will cause an exception. */   
-    XMLElement& LastChild();
-
-    /** sets (and possibly overwrites) an attribute \a attrib, with the value \a val. */
-    void SetAttribute(const std::string& attrib, const std::string& val);
-
-    /** sets the tag to \a tag */
-    void SetTag(const std::string& tag);
-
-    /** sets the text to \a text */
-    void SetText(const std::string& text);
-
-    /** removes attribute \a attrib from the XMLElement*/
-    void RemoveAttribute(const std::string& attrib);
-
-    /** removes all attributes from the XMLElement*/
-    void RemoveAttributes();
-
-    /** adds child XMLElement \a e to the end of the child list of the XMLElement */
-    void AppendChild(const XMLElement& e);
-
-    /** creates an empty XMLElement with tag-name \a child, and adds it to the end of the child list of the
-        XMLElement */
-    void AppendChild(const std::string& child);
-
-    /** adds a child \a e in the \a idx-th position of the child list of the XMLElement. \throw
-         XMLElement::NoSuchIndex An out of range index will cause an exception. */
-    void AddChildBefore(const XMLElement& e, unsigned int idx);
-
-    /** removes the child in the \a idx-th position of the child list of the XMLElement.  \throw
-         XMLElement::NoSuchIndex An out of range index will cause an exception. */
-    void RemoveChild(unsigned int idx);
-
-    /** removes the child called \a child from the XMLElement.  \throw XMLElement:NoSuchChild An exception is thrown
-        if no child named \a child exists. */
-    void RemoveChild(const std::string& child);
-
-    /** removes all children from the XMLElement*/
-    void RemoveChildren();
-
-    child_iterator child_begin();     ///< iterator to the first child in the XMLElement
-    child_iterator child_end();       ///< iterator to the last + 1 child in the XMLElement
-    attr_iterator  attr_begin();   ///< iterator to the first attribute in the XMLElement
-    attr_iterator  attr_end();     ///< iterator to the last + 1 attribute in the XMLElement
-    //@}
-
-    /** \name Exceptions */ //@{
-    /** The base class for XMLElement exceptions. */
+    /** \name  Exceptions */ //@{
+    /** @brief  The base class for XMLElement based exceptions. */
     class Exception : public GG::ExceptionBase
     {
     public:
-        Exception () throw() : ExceptionBase() {}
-        Exception (const std::string& msg) throw() : ExceptionBase(msg) {}
-        virtual const char* type() const throw() = 0;
+        /** @brief  Create a new exception with the given @p message. */
+        Exception (const std::string& message) :
+            ExceptionBase(message)
+        {}
     };
 
-    /** Thrown when a request for a named child element cannot be fulfilled. */
+    /** @brief  Thrown when a request for a tag-name named  child element cannot
+     *      be fulfilled.
+     */
     class NoSuchChild : public Exception
     {
     public:
-        NoSuchChild () throw() : Exception () {}
-        NoSuchChild (const std::string& msg) throw() : Exception (msg) {}
+        /** @copydoc Exception::Exception(const std::string&) */
+        NoSuchChild (const std::string& message) :
+            Exception (message)
+        {}
+
         virtual const char* type() const throw()
-            {return "XMLElement::NoSuchChild" ;}
+        { return "XMLElement::NoSuchChild"; }
     };
 
-    /** Thrown when a request for an indexed child element cannot be fulfilled. */
+    /** @brief  Thrown when a request for an indexed child element cannot be
+     *      fulfilled.
+     */
     class NoSuchIndex : public Exception
     {
     public:
-        NoSuchIndex () throw() : Exception () {}
-        NoSuchIndex (const std::string& msg) throw() : Exception (msg) {}
+        /** @copydoc Exception::Exception(const std::string&) */
+        NoSuchIndex (const std::string& message) :
+            Exception (message)
+        {}
+
         virtual const char* type() const throw()
-            {return "XMLElement::NoSuchIndex" ;}
+        { return "XMLElement::NoSuchIndex"; }
     };
     //@}
 
+    /** @name  Iterators */ //@{
+    //@{
+    /** @brief Iterator to iterate over child XMLElement%s. */
+    typedef std::vector<XMLElement>::iterator       child_iterator;
+    typedef std::vector<XMLElement>::const_iterator const_child_iterator;
+    //@}
+    //@{
+    /** @brief Iterator to iterate over a XMLElement attributes. */
+    typedef std::map<std::string, std::string>::iterator       attr_iterator;
+    typedef std::map<std::string, std::string>::const_iterator const_attr_iterator;
+    //@}
+    //@}
+
+    /** @name  Structors */ //@{
+    /** @brief  Creates a new XMLElement with an empty tag-name assigned.
+     *
+     * Create a new XMLElement with no tag-name, text, attribute or child nodes
+     * set.  Also the new instance isn't marked as root node.
+     */
+    XMLElement() : m_root(false)
+    {}
+
+
+    /** @brief  Creates a new XMLElement with the given @p tag tag-name.
+     *
+     * Create a new XMLElement with the given @p tag tag-name but no text,
+     * attribute or child nodes set.  Also the new instance isn't marked as root
+     * node.
+     *
+     * @param[in] tag  The tag name of this XML element.
+     */
+    XMLElement(const std::string& tag) :
+        m_tag(tag),
+        m_text(""),
+        m_root(false)
+    {}
+
+    /** @brief  Creates a new XMLElement with the given @p tag tag-name and
+     *      @p text content.
+     *
+     * Create a new XMLElement with the given @p tag tag-name and @p text
+     * content, but no attribute or child nodes set.  Also the new instance
+     * isn't marked as root node.
+     *
+     * @param[in] tag  The tag name of this XML element.
+     * @param[in] text  The text assigned to this XML element.
+     */
+    XMLElement(const std::string& tag, const std::string& text) :
+        m_tag(tag),
+        m_text(text),
+        m_root(false)
+    {}
+
+    /** @brief  Creates a new XMLElement with the given @p tag tag-name and
+     *      @p body a single child element.
+     *
+     * @param[in] tag  The tag name of this XML element.
+     * @param[in] body  The child XML element assigned as body to this XML
+     *      element.
+     */
+    XMLElement(const std::string& tag, const XMLElement& body) :
+        m_tag(tag),
+        m_children(std::vector<XMLElement>(1, body)), m_root(false)
+    {}
+    //@}
+
+    /** @name  Accessors */ //@{
+    /** @brief  Returns the the tag-name of this XMLElement.
+     *
+     * @return  The tag-name of this XMLElement.  Can be an empty string.
+     */
+    const std::string& Tag() const;
+
+    /** @brief  Returns the text body of this XMLElement.
+     *
+     * @return  The text content of this XMLElement.  Can be an empty string.
+     */
+    const std::string& Text() const;
+
+    /** @brief  Returns the number of child nodes inside this XMLElement.
+     *
+     * @return  The number of child XMLElement%s contained by this this
+     *      XMLElement.  Is always positive.
+     */
+    int NumChildren() const;
+
+    /** @brief  Returns the number of attributes attached to this XMLElement.
+     *
+     * @return  The number of attributes attached to this XMLElement.  Is always
+     *      positive.
+     */
+    int NumAttributes() const;
+
+    /** @brief  Returns if this XMLElement contains a child with @p tag as
+     *      tag-name.
+     *
+     * @param[in] tag  The tag-name of the searched child XMLElement.
+     * @return  True if there is at least one child with a @p tag tag-name,
+     *      false if not.
+     */
+    bool ContainsChild(const std::string& tag) const;
+
+    /** @brief  Returns if this XMLElement contains an attribute with the
+     *      attribute key @p key.
+     *
+     * @param[in] key  The attribute key of the searched attribute.
+     * @return  True if there is an attribute with a @p key, false if not.
+     */
+    bool ContainsAttribute(const std::string& key) const;
+
+    /** @brief  Returns the index of the first child XMLElement with @p tag as
+     *      tag-name or -1 if none found.
+     *
+     * @param[in] tag  The tag-name of the searched child XMLElement.
+     * @return  The index of the first found child XMLElement with @p tag as
+     *      tag-name or -1 of no such child XMLElement can be found.
+     */
+    int ChildIndex(const std::string& tag) const;
+
+    /** @brief  Returns the XMLElement child at the @p index%ed position of the
+     *      child list of this XMLElement.
+     *
+     * @param[in] index  The index of the child XMLElement requested. The passed
+     *      value must be between 0 and NumChildren() - 1.
+     * @return  A reference to the XMLElement child at the @p index%ed position
+     *      of this XMLElement child list.
+     * @throw XMLElement::NoSuchIndex  When @p index is out of range in this
+     *      XMLElement child list.
+     */
+    const XMLElement& Child(unsigned int index) const;
+
+    /** @brief  Returns the first XMLElement child that has @p tag as tag-name.
+     *
+     * @param[in] tag  The tag-name of the child XMLElement requested.
+     * @return  A reference to the first XMLElement child which has the tag-name
+     *      @p tag.
+     * @throw XMLElement::NoSuchChild  When no child with a tag-name @p tag
+     *      exists.
+     */
+    const XMLElement& Child(const std::string& tag) const;
+
+    /** @brief  Returns the last XMLElement child of this XMLElement.
+     *
+     * @return  A reference to the last XMLElement child.
+     * \throw XMLElement:NoSuchIndex  When there are no child XMLElement%s.
+     */
+    const XMLElement& LastChild() const;
+
+    /** @brief  Returns the value of the attribute with name @p key or an empty
+     *      string if there is no with attribute with this key.
+     *
+     * @param[in] key  The attribute key of the searched attribute.
+     * @return  The value of the attribute with the @p key or an empty string if
+     *      there is no such attribute.
+     */
+    const std::string& Attribute(const std::string& key) const;
+
+    /** @brief  Write this XMLElement XML formatted into the given output
+     *      stream @p os with indentation level @p indent when @p whitespace
+     *      is set.
+     *
+     * @param [in] os  The output stream this document should be written to.
+     * @param [in] indent  The indentation level this element should be
+     *      indented.
+     * @param [in] whitespace  If set to true the child XMLElement%s are
+     *      indented and newline separated.
+     * @return  The given @p os output stream.
+     */
+    std::ostream& WriteElement(std::ostream& os, int indent = 0, bool whitespace = true) const;
+
+    /** @brief  Return this XMLElement XML formatted as string with indentation
+     * level @p indent when @p whitespace is set.
+     *
+     * @param [in] indent  The indentation level this element should be
+     *      indented.
+     * @param [in] whitespace  If set to true the child XMLElement%s are
+     *      indented and newline separated.
+     * @return  A string containing the XML formatted representation of this
+     *      XMLElement.
+     */
+    std::string WriteElement(int indent = 0, bool whitespace = true) const;
+
+    /** @brief  Return an iterator to the first child in this XMLElement. */
+    const_child_iterator child_begin() const;
+
+    /** @brief  Return an iterator to the one beyond last child in this
+     * XMLElement.
+     */
+    const_child_iterator child_end() const;
+
+    /** @brief  Return an iterator to the first attribute in this XMLElement. */
+    const_attr_iterator attr_begin() const;
+
+    /** @brief  Return an iterator to the one beyond last attribute in this
+     * XMLElement.
+     */
+    const_attr_iterator attr_end() const;
+    //@}
+
+    /** @name  Mutators */ //@{
+    /** @copydoc XMLElement::Child(unsigned int) const */
+    XMLElement& Child(unsigned int index);
+
+    /** @copydoc XMLElement::Child(const std::string&) const */
+    XMLElement& Child(const std::string& tag);
+
+    /** @copydoc XMLElement::LastChild() const */
+    XMLElement& LastChild();
+
+    /** @brief  Sets the @p value of the attribute @p key in this XMLElement.
+     *
+     * When the attribute @p key already has a value set it will be overwritten
+     * with the new @p value.
+     *
+     * @param[in] key  The key of the attribute to set.
+     * @param[in] value  The new value the attribute should be set to.
+     */
+    void SetAttribute(const std::string& key, const std::string& value);
+
+    /** @brief  Sets the tag-name of this XMLElement to @p tag.
+     *
+     * @param[in] tag  The new tag-name this XMLElement should have.
+     */
+    void SetTag(const std::string& tag);
+
+    /** @brief  Sets the text content of this XMLEement to @p text.
+     *
+     * @param[in] text  The new text content this XMLElement should have.
+     */
+    void SetText(const std::string& text);
+
+    /** @brief  Removes the attribute with @p key from this XMLElement.
+     *
+     * @param[in] key  The key of the attribute to be deleted.  If no such
+     *      attribute exist no action is taken.
+     */
+    void RemoveAttribute(const std::string& key);
+
+    /** @brief  Removes all attributes from this XMLElement. */
+    void RemoveAttributes();
+
+    /** @brief  Adds a given child XMLElement @p child to the end of the child
+     *      list of this XMLElement.
+     *
+     * @param[in] child  The XMLElement to be appended to the child list.
+     */
+    void AppendChild(const XMLElement& child);
+
+    /** @brief  Creates an new empty XMLElement with the tag-name @p tag and
+     *      appends it to the child list of this XMLElement.
+     *
+     * @param[in] tag  The tag of the created XMLElement.
+     */
+    void AppendChild(const std::string& tag);
+
+    /** @brief  Adds a given child XMLElement @p child before the child element
+     *      at the @p index%ed position in the child list of this XMLElement.
+     *
+     * @param[in] child  The XMLElement to be inserted into the child list.
+     * @param[in] index  The index of the child XMLElement where the @p child
+     *      put be in front of. The passed value must be between 0 and
+     *      NumChildren() - 1.
+     * @throw XMLElement::NoSuchIndex  When @p index is out of range in this
+     *      XMLElement child list.
+     */
+    void AddChildBefore(const XMLElement& child, unsigned int index);
+
+    /** @brief  Removes the XMLElement child at the @p index%ed position of the
+     *      child list of this XMLElement.
+     *
+     * @param[in] index  The index of the child XMLElement that should be
+     *      removed.  The passed value must be between 0 and NumChildren() - 1.
+     * @throw XMLElement::NoSuchIndex  When @p index is out of range in this
+     *      XMLElement child list.
+     */
+    void RemoveChild(unsigned int index);
+
+    /** @brief  Removes the XMLElement child with the tag-name @p tag from this
+     *      XMLElement.
+     *
+     * @param[in] tag  The tag-name of the child XMLElement to be deleted.
+     * @throw XMLElement::NoSuchChild  When no child with a tag-name @p tag
+     *      exists.
+     */
+    void RemoveChild(const std::string& tag);
+
+    /** @brief Removes all children from this XMLElement. */
+    void RemoveChildren();
+
+    /** @copydoc XMLElement::child_begin() const */
+    child_iterator child_begin();
+
+    /** @copydoc XMLElement::child_end() const */
+    child_iterator child_end();
+
+    /** @copydoc XMLElement::attr_begin() const */
+    attr_iterator attr_begin();
+
+    /** @copydoc XMLElement::attr_end() const */
+    attr_iterator attr_end();
+    //@}
+
 private:
-    /** ctor that constructs an XMLElement from a tag-name \a t and a bool \a r indicating whether it is the root
-        XMLElement in an XMLDoc document*/
-    XMLElement(const std::string& t, bool r);
+    /** @name  Structors */ //@{
+    /** @brief  Creates a new XMLElement with the given @p tag tag-name and
+     *      marked as root node, if @p root is set.
+     *
+     * @param[in] tag  The tag name of this XML element.
+     * @param[in] root  When true this XMLElement should be interpreted as root
+     *      node in a XMLElement tree.
+     *
+     * @note Called by friend XMLDoc.
+     */
+    XMLElement(const std::string& tag, bool root);
+    //@}
 
-    std::string                        m_tag;        ///< the tag-name of the XMLElement
-    std::string                        m_text;       ///< the text of this XMLElement
-    std::map<std::string, std::string> m_attributes; ///< the attributes of the XMLElement, stored as key-value pairs
-    std::vector<XMLElement>            m_children;   ///< the XMLElement children of this XMLElement
+    /** @brief  Stores the tag-name associated to this XMLElement.
+     *
+     * @bug  Currently this can contain an empty string but I doubt it will
+     *      be useful as it will cause invalid XML documents serializations.
+     */
+    std::string m_tag;
 
-    bool                               m_root;       ///< true if this XMLElement is the root element of an XMLDoc document
+    /** @brief  Stores the text content associated to this XMLElement. */
+    std::string m_text;
 
-    /** allows XMLDoc to create root XMLElements and call the non-const overload of LastChild() */
+    /** @brief  Stores the attributes associated to this XMLElement by key name
+     *      mapping.
+     */
+    std::map<std::string, std::string> m_attributes;
+
+    /** @brief  Stores a list of the child XMLElement%s associated to this
+     *      XMLElement.
+     *
+     * This list can be empty when this XMLElement has no associated child
+     * elements.
+     */
+    std::vector<XMLElement> m_children;
+
+    /** @brief  Set to true if this XMLElement is the root element of an XMLDoc
+     *      document.
+     */
+    bool m_root;
+
     friend class XMLDoc;
 };
 
-/** \deprecated All the GG XML classes are deprecated and will be removed upon the next major release.
-    encapsulates an entire XML document.  Each XMLDoc is assumed to take up an entire file, and to contain an arbitrary
-    number of XMLElements within its root_node member. */
+/** @brief  Represents a document formatted with XML markup.
+ *
+ * Each XMLDoc instance is assumed to represent a complete document.  It
+ * contains a tree of nested XMLElement%s, starting from the always existing
+ * root XMLElement node.
+ */
 class FO_COMMON_API XMLDoc
 {
 public:
-    /** \name Structors */ //@{
-    /** ctor that constructs an empty XML document with a root node with tag-name \a root_tag */
+    /** @name  Structors */ //@{
+    /** @brief  Create an empty document with the given tag-name @p root_tag.
+     *
+     * @param[in] root_tag  The tag-name of the created root XMLElement.
+     */
     XMLDoc(const std::string& root_tag = "XMLDoc");
 
-    /** ctor that constructs an XML document from an input stream \a is */
+    /** @brief  Construct a document from the given input stream @p is.
+     *
+     * @param[in] is  An input stream that provides an XML markup document when
+     *      reading.
+     *
+     * @bug  @p is isn't actually read but ignored and an empty (and maybe
+     *      invalid) document is created.  Use XMLDoc::ReadDoc(std::istream&)
+     *      instead.
+     */
     XMLDoc(const std::istream& is);
     //@}
 
-    /** \name Accessors */ //@{
-    /** writes the XMLDoc to an output stream; returns the stream.  If \a whitespace is false, the document is written
-        without whitespace (one long line with no spaces between XMLElements).  Otherwise, the document is formatted in
-        a more standard human-readable form. */
-    std::ostream& WriteDoc(std::ostream& os, bool whitespace = true) const;
+    /** @name  Accessors */ //@{
+    /** @brief  Write the contents of the XMLDoc into the given output stream
+     *      @p os with optional @p indent.
+     *
+     * @param [in] os  The output stream this document should be written to.
+     * @param [in] indent  If set to true the XML elements are indented and
+     *      newline separated.
+     * @return  The given @p os output stream.
+     */
+    std::ostream& WriteDoc(std::ostream& os, bool indent = true) const;
     //@}
 
-    /** \name Mutators */ //@{
-    /** destroys the current contents of the XMLDoc, and replaces them with the contents of the document in the input
-        stream \a is; returns the stream*/
+    /** @name  Mutators */ //@{
+    /** @brief  Clears the current content of this XMLDoc instance and read a
+     *      new document from the given input stream @p is.
+     *
+     * @param[in] is  An input stream that provides an XML markup document when
+     *      reading.
+     * @return  The given @p is input stream.
+     */
     std::istream& ReadDoc(std::istream& is);
 
-    /** destroys the current contents of the XMLDoc, and replaces them with the contents of the document in the input
-        string \a s */
+    /** @brief  Clears the current content of this XMLDoc instance and read a
+     *      new document from the given string @p s.
+     *
+     * @param[in] s  An string containing an XML markup document.
+     */
     void ReadDoc(const std::string& s);
     //@}
 
-    XMLElement root_node;  ///< the single XMLElement in the document, under which all other XMLElement are children
+    /** @brief  The root element that contains the parsed document, which is
+     *      represented by XMLElement%s.
+     */
+    XMLElement root_node;
 
 private:
-    struct RuleDefiner {RuleDefiner();};  ///< used to create XML parsing rules at static initialization time
+    /** @brief  Creates the XML parsing rules at static initialization time. */
+    struct RuleDefiner { RuleDefiner(); };
     static RuleDefiner s_rule_definer;
 
-    /** holds the XMLDoc to which the code should add elements */
+    /** @brief  Holds the XMLDoc to which the XML parser should add parsed
+     *      elements.
+     *
+     * @todo  No need to hold a static instance here, pass the document into
+     *      the parser as additional attribute.  This also avoids potential
+     *      problems in multithreaded setups.
+     */
     static XMLDoc* s_curr_parsing_doc;
 
-    /** maintains the current environment for reading XMLElements (the current enclosing XMLElement) */
+    /** @brief  Holds the current environment for reading XMLElement%s (the
+     *      current enclosing XMLElement%s). */
     static std::vector<XMLElement*> s_element_stack;
 
     static XMLElement s_temp_elem;
@@ -309,4 +614,3 @@ private:
 };
 
 #endif // _XMLDoc_h_
-

--- a/util/XMLDoc.h
+++ b/util/XMLDoc.h
@@ -24,19 +24,10 @@
    Zach Laine
    whatwasthataddress@hotmail.com */
 
-#ifndef _GG_Enum_h_
-#include <GG/Enum.h>
-#endif
-
-#ifndef _GG_Exception_h_
-#include <GG/Exception.h>
-#endif
-
-#include <boost/lexical_cast.hpp>
-
 #include <map>
 #include <string>
 #include <vector>
+#include <GG/Exception.h>
 
 #include "Export.h"
 


### PR DESCRIPTION
This PR updates the in-code documentation of `util/XMLDoc.h` by using Doxygen keywords, adding remarks, bug notes and todo notes and being more verbose in general.  Types, attributes or functions that were not documented are left out intentional.

I already applied a pass of aspell correction.

Also this PR cuts down the includes from files that were included by `util/XMLDoc.h` and files that included `util/XMLDoc.h` to reduce useless inclusion dependencies, which force up the compile time.  This required a minimal API change of `OptionsDB`.
