### PR TITLE
Force the usage of boost::phoenix v3 in older boost versions.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,6 +157,10 @@ add_subdirectory(GG)
 set(CMAKE_INSTALL_LIBDIR ${_ORIG_CMAKE_INSTALL_LIBDIR})
 unset(_ORIG_CMAKE_INSTALL_LIBDIR)
 
+add_definitions(
+    -DBOOST_SPIRIT_USE_PHOENIX_V3
+)
+
 if(${Boost_VERSION} EQUAL "106100")
     # with boost 1.61 some boost::optional internals were changed. However
     # boost::spirit relies on some API the old implementation provided.  This

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,9 +157,14 @@ add_subdirectory(GG)
 set(CMAKE_INSTALL_LIBDIR ${_ORIG_CMAKE_INSTALL_LIBDIR})
 unset(_ORIG_CMAKE_INSTALL_LIBDIR)
 
-add_definitions(
-    -DBOOST_SPIRIT_USE_PHOENIX_V3
-)
+if(${Boost_VERSION} LESS "105600")
+    # Starting with boost 1.56 boost::spirit uses boost::phoenix v3 exclusively.
+    # Before that version there spirit provides an translation layer, which can
+    # be enabled by defining BOOST_SPIRIT_USE_PHOENIX_V3.
+    add_definitions(
+        -DBOOST_SPIRIT_USE_PHOENIX_V3
+    )
+endif()
 
 if(${Boost_VERSION} EQUAL "106100")
     # with boost 1.61 some boost::optional internals were changed. However

--- a/parse/BuildingsParser.cpp
+++ b/parse/BuildingsParser.cpp
@@ -22,13 +22,7 @@ namespace std {
 
 namespace {
     struct insert_ {
-#if BOOST_VERSION < 105600
-        template <typename Arg1, typename Arg2> // Phoenix v2
-        struct result
-        { typedef void type; };
-#else
         typedef void result_type;
-#endif
 
         void operator()(std::map<std::string, BuildingType*>& building_types, BuildingType* building_type) const {
             if (!building_types.insert(std::make_pair(building_type->Name(), building_type)).second) {

--- a/parse/EncyclopediaParser.cpp
+++ b/parse/EncyclopediaParser.cpp
@@ -17,13 +17,7 @@ namespace std {
 
 namespace {
     struct insert_ {
-#if BOOST_VERSION < 105600
-        template <typename Arg1, typename Arg2> // Phoenix v2
-        struct result
-        { typedef void type; };
-#else
         typedef void result_type;
-#endif
 
         void operator()(Encyclopedia& enc, const EncyclopediaArticle& article) const
         { enc.articles[article.category].push_back(article); }

--- a/parse/FieldsParser.cpp
+++ b/parse/FieldsParser.cpp
@@ -20,13 +20,7 @@ namespace std {
 
 namespace {
     struct insert_ {
-#if BOOST_VERSION < 105600
-        template <typename Arg1, typename Arg2> // Phoenix v2
-        struct result
-        { typedef void type; };
-#else
         typedef void result_type;
-#endif
 
         void operator()(std::map<std::string, FieldType*>& fields, FieldType* field_type) const {
             if (!fields.insert(std::make_pair(field_type->Name(), field_type)).second) {

--- a/parse/KeymapParser.cpp
+++ b/parse/KeymapParser.cpp
@@ -20,13 +20,7 @@ namespace {
     typedef std::map<std::string, Keymap>   NamedKeymaps;
 
     struct insert_key_pair_ {
-#if BOOST_VERSION < 105600
-        template <typename Arg1, typename Arg2> // Phoenix v2
-        struct result
-        { typedef void type; };
-#else
         typedef void result_type;
-#endif
 
         void operator()(Keymap& keymap, const Keymap::value_type& key_id_pair) const {
             keymap[key_id_pair.first] = key_id_pair.second;
@@ -36,13 +30,7 @@ namespace {
     const boost::phoenix::function<insert_key_pair_> insert_key_pair;
 
     struct insert_key_map_ {
-#if BOOST_VERSION < 105600
-        template <typename Arg1, typename Arg2> // Phoenix v2
-        struct result
-        { typedef void type; };
-#else
         typedef void result_type;
-#endif
 
         void operator()(NamedKeymaps& named_keymaps, const NamedKeymaps::value_type& name_keymap) const {
             named_keymaps[name_keymap.first] = name_keymap.second;

--- a/parse/Lexer.cpp
+++ b/parse/Lexer.cpp
@@ -10,13 +10,7 @@
 
 namespace {
     struct strip_quotes_ {
-#if BOOST_VERSION < 105600
-        template <typename Arg1, typename Arg2> // Phoenix v2
-        struct result
-        { typedef std::string type; };
-#else
         typedef std::string result_type;
-#endif
 
         std::string operator()(const parse::text_iterator& start, const parse::text_iterator& end) const {
             std::string::const_iterator start_ = start;

--- a/parse/MonsterFleetPlansParser.cpp
+++ b/parse/MonsterFleetPlansParser.cpp
@@ -22,13 +22,7 @@ namespace std {
 
 namespace {
     struct new_monster_fleet_plan_ {
-#if BOOST_VERSION < 105600
-        template <typename Arg1, typename Arg2, typename Arg3, typename Arg4, typename Arg5> // Phoenix v2
-        struct result
-        { typedef MonsterFleetPlan* type; };
-#else
         typedef MonsterFleetPlan* result_type;
-#endif
 
         MonsterFleetPlan* operator()(const std::string& fleet_name, const std::vector<std::string>& ship_design_names,
                                      double spawn_rate, int spawn_limit, Condition::ConditionBase* location) const

--- a/parse/ReportParseError.h
+++ b/parse/ReportParseError.h
@@ -43,13 +43,7 @@ namespace parse {
     }
 
     struct report_error_ {
-#if BOOST_VERSION < 105600
-        template <typename Arg1, typename Arg2, typename Arg3, typename Arg4> // Phoenix v2
-        struct result
-        { typedef void type; };
-#else
         typedef void result_type;
-#endif
 
         template <typename Arg1, typename Arg2, typename Arg3, typename Arg4>
         void operator()(Arg1 first, Arg2, Arg3 it, Arg4 rule_name) const

--- a/parse/ShipDesignsParser.cpp
+++ b/parse/ShipDesignsParser.cpp
@@ -18,13 +18,7 @@ namespace std {
 
 namespace {
     struct insert_ {
-#if BOOST_VERSION < 105600
-        template <typename Arg1, typename Arg2> // Phoenix v2
-        struct result
-        { typedef void type; };
-#else
         typedef void result_type;
-#endif
 
         void operator()(std::map<std::string, ShipDesign*>& designs, ShipDesign* design) const {
             if (!designs.insert(std::make_pair(design->Name(false), design)).second) {

--- a/parse/ShipHullsParser.cpp
+++ b/parse/ShipHullsParser.cpp
@@ -30,13 +30,7 @@ namespace std {
 
 namespace {
     struct insert_hull_ {
-#if BOOST_VERSION < 105600
-        template <typename Arg1, typename Arg2> // Phoenix v2
-        struct result
-        { typedef void type; };
-#else
         typedef void result_type;
-#endif
 
         void operator()(std::map<std::string, HullType*>& hulls, HullType* hull) const {
             if (!hulls.insert(std::make_pair(hull->Name(), hull)).second) {

--- a/parse/ShipPartsParser.cpp
+++ b/parse/ShipPartsParser.cpp
@@ -27,13 +27,7 @@ namespace std {
 
 namespace {
     struct insert_part_type_ {
-#if BOOST_VERSION < 105600
-        template <typename Arg1, typename Arg2> // Phoenix v2
-        struct result
-        { typedef void type; };
-#else
         typedef void result_type;
-#endif
 
         void operator()(std::map<std::string, PartType*>& part_types, PartType* part_type) const {
             if (!part_types.insert(std::make_pair(part_type->Name(), part_type)).second) {

--- a/parse/SpecialsParser.cpp
+++ b/parse/SpecialsParser.cpp
@@ -21,13 +21,7 @@ namespace std {
 
 namespace {
     struct insert_ {
-#if BOOST_VERSION < 105600
-        template <typename Arg1, typename Arg2> // Phoenix v2
-        struct result
-        { typedef void type; };
-#else
         typedef void result_type;
-#endif
 
         void operator()(std::map<std::string, Special*>& specials, Special* special) const {
             if (!specials.insert(std::make_pair(special->Name(), special)).second) {

--- a/parse/SpeciesParser.cpp
+++ b/parse/SpeciesParser.cpp
@@ -24,13 +24,7 @@ namespace std {
 
 namespace {
     struct insert_species_ {
-#if BOOST_VERSION < 105600
-        template <typename Arg1, typename Arg2> // Phoenix v2
-        struct result
-        { typedef void type; };
-#else
         typedef void result_type;
-#endif
 
         void operator()(std::map<std::string, Species*>& species, Species* specie) const {
             if (!species.insert(std::make_pair(specie->Name(), specie)).second) {

--- a/parse/TechsParser.cpp
+++ b/parse/TechsParser.cpp
@@ -25,13 +25,7 @@ namespace {
     std::map<std::string, TechCategory*>* g_categories = 0;
 
     struct insert_tech_ {
-#if BOOST_VERSION < 105600
-        template <typename Arg1, typename Arg2> // Phoenix v2
-        struct result
-        { typedef void type; };
-#else
         typedef void result_type;
-#endif
 
         void operator()(TechManager::TechContainer& techs, Tech* tech) const {
             g_categories_seen->insert(tech->Category());
@@ -49,13 +43,7 @@ namespace {
     const boost::phoenix::function<insert_tech_> insert_tech;
 
     struct insert_category_ {
-#if BOOST_VERSION < 105600
-        template <typename Arg1, typename Arg2> // Phoenix v2
-        struct result
-        { typedef void type; };
-#else
         typedef void result_type;
-#endif
 
         void operator()(std::map<std::string, TechCategory*>& categories, TechCategory* category) const {
             if (!categories.insert(std::make_pair(category->name, category)).second) {

--- a/test/parse/lexer_test_rules.cpp
+++ b/test/parse/lexer_test_rules.cpp
@@ -2,13 +2,7 @@
 
 struct quote_
 {
-#if BOOST_VERSION < 105600
-    template <typename Arg>
-    struct result
-    { typedef std::string type; };
-#else
     typedef std::string result_type;
-#endif
 
     std::string operator()(const std::string& arg1) const
         { return '"' + arg1 + '"'; }
@@ -17,13 +11,7 @@ const boost::phoenix::function<quote_> quote;
 
 struct remove_
 {
-#if BOOST_VERSION < 105600
-    template <typename Arg> // Phoenix v2
-    struct result
-    { typedef void type; };
-#else
     typedef void result_type;
-#endif
 
     void operator()(const char* const& arg1) const
         { lexer_test_rules::unchecked_tokens.erase(arg1); }


### PR DESCRIPTION
As reported in this [thread](http://www.freeorion.org/forum/viewtopic.php?f=24&t=10276) and in commit c00f6f94c67504b1f761de1ad0ccb55270386c16 the added line and file logger attributes pull in a boost::log header, which in turn uses boost::phoenix v3.  The current compiler code however uses boost::spirit::phoenix v2 or v3 depending on the boost version.  This may cause a type collision between those two phoenix versions (thanks to @Hacklin for pointing this out).

To avoid this issue I defined  `BOOST_SPIRIT_USE_PHOENIX_V3` in the CMakeLists.txt for boost versions older than 1.56 (thanks to @dbenage-cx for researching this) and I removed some boost version conditional code, which defines the return type for rules.  This branch now compiles properly with recent boost version and with older boost version (tested on debian stable with boost 1.55).

@Hacklin: Could you please test if this fixes your problem?
