### PR TITLE
Allow SitRep rclick menu from majority of SitRep row

### DIFF
--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -178,8 +178,10 @@ public:
         void         SetMargin(unsigned int margin); ///< sets the amount of space left between the contents of adjacent cells, in pixels
         //@}
 
+        boost::signals2::signal<void(const Pt&, GG::Flags<GG::ModKey>)> RightClickedSignal;
     protected:
         void AdjustLayout(bool adjust_for_push_back = false);
+        virtual void           RClick(const Pt& pt, GG::Flags<GG::ModKey> mod);
 
         std::vector<Control*>  m_cells;          ///< the Controls in this Row (each may be null)
         Alignment              m_row_alignment;  ///< row alignment; one of ALIGN_TOP, ALIGN_VCENTER, or ALIGN_BOTTOM
@@ -499,9 +501,9 @@ protected:
 
     void            AdjustScrolls(bool adjust_for_resize);  ///< creates, destroys, or resizes scrolls to reflect size of data in listbox
 
-protected:
     virtual void    DropsAcceptable(DropsAcceptableIter first, DropsAcceptableIter last,
                                     const Pt& pt, Flags<ModKey> mod_keys) const;
+    void            HandleRowRightClicked(const Pt& pt, Flags<ModKey> mod);
 
 private:
     void            ConnectSignals();

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -388,6 +388,10 @@ void ListBox::Row::AdjustLayout(bool adjust_for_push_back/* = false*/)
     }
 }
 
+void ListBox::Row::RClick(const Pt& pt, GG::Flags<GG::ModKey> mod) {
+     RightClickedSignal(pt, mod);
+}
+
 
 ////////////////////////////////////////////////
 // GG::ListBox::RowPtrIteratorLess
@@ -482,6 +486,14 @@ void ListBox::DropsAcceptable(DropsAcceptableIter first, DropsAcceptableIter las
                 it->second = true;
             } catch (const DontAcceptDrop&) {}
         }
+    }
+}
+
+void ListBox::HandleRowRightClicked(const Pt& pt, GG::Flags<GG::ModKey> mod) {
+    iterator row_it = RowUnderPt(pt);
+    if (row_it != m_rows.end()) {
+        m_rclick_row = row_it;
+        RightClickedSignal(row_it, pt, mod);
     }
 }
 
@@ -1652,6 +1664,7 @@ ListBox::iterator ListBox::Insert(Row* row, iterator it, bool dropped, bool sign
     if (signal)
         AfterInsertSignal(it);
 
+    Connect(row->RightClickedSignal, &ListBox::HandleRowRightClicked, this);
     return retval;
 }
 

--- a/UI/SitRepPanel.cpp
+++ b/UI/SitRepPanel.cpp
@@ -619,6 +619,7 @@ void SitRepPanel::DismissalMenu(GG::ListBox::iterator it, const GG::Pt& pt, cons
     }
     menu_contents.next_level.push_back(GG::MenuItem(UserString("SITREP_SNOOZE_CLEAR_ALL"),        4, false, false));
     menu_contents.next_level.push_back(GG::MenuItem(UserString("SITREP_SNOOZE_CLEAR_INDEFINITE"), 5, false, false));
+    menu_contents.next_level.push_back(GG::MenuItem("  " + UserString("HOTKEY_COPY"),                   10, false, false));
 
     GG::PopupMenu popup(pt.x, pt.y, ClientUI::GetFont(), menu_contents, ClientUI::TextColor(),
                         ClientUI::WndInnerBorderColor(), ClientUI::WndColor(), ClientUI::EditHiliteColor());
@@ -646,6 +647,12 @@ void SitRepPanel::DismissalMenu(GG::ListBox::iterator it, const GG::Pt& pt, cons
     }
     case 5: { //
         permanently_snoozed_sitreps.clear();
+        break;
+    }
+    case 10: { // Copy text of sitrep
+        if (sitrep_text.empty())
+            break;
+        GG::GUI::GetGUI()->SetClipboardText(GG::Font::StripTags(sitrep_text));
         break;
     }
 


### PR DESCRIPTION
Allows user to right click on most of a row to select from the context menu.
LinkText retains the original menu to either copy or open the link.
