### PR TITLE
Allow industry on outposts (pop center change)

### DIFF
--- a/universe/PopCenter.cpp
+++ b/universe/PopCenter.cpp
@@ -123,6 +123,10 @@ void PopCenter::PopCenterPopGrowthProductionResearchPhase() {
 
     //if (cur_pop > 0.0)
     //    DebugLogger() << "Planet Pop: " << cur_pop << " growth: " << pop_growth;
+	if (SpeciesName().empty()) {
+		// don't do anything for outposts
+		return;
+	}
 
     if (new_pop >= MINIMUM_POP_CENTER_POPULATION) {
         GetMeter(METER_POPULATION)->SetCurrent(new_pop);


### PR DESCRIPTION
Before, all population centers with close to zero population were
depopulated and in turn got the industry reset to zero.
As a outpost is a population center with zero population, it was not
possible to have industry at an outpost. 

I need this functionality right now because I scripted a branch for supply ships which do not work on outposts without this. I was told to create this PR
Discussion about this and supply ships in the forums at 
http://www.freeorion.org/forum/viewtopic.php?f=15&t=10152&p=86319#p86319

To be able to build at supply line disconnected outposts, the code now
looks if there is a species on the planet. If it is not, it is considered
an outpost and the industry does not get set to zero.
