### PR TITLE
Improve combat log with deferred layout.

### DIFF
--- a/UI/CombatReport/CombatLogWnd.cpp
+++ b/UI/CombatReport/CombatLogWnd.cpp
@@ -140,7 +140,7 @@ namespace {
 
         SetBorderMargin(BORDER_MARGIN);
 
-        SetLayout(new GG::Layout(UpperLeft().x, UpperLeft().y, Width(), Height(), 1, 1));
+        SetLayout(new GG::DeferredLayout(UpperLeft().x, UpperLeft().y, Width(), Height(), 1, 1));
         GetLayout()->Add(title, 0, 0, 1, 1);
         SetCollapsed(true);
     }

--- a/UI/CombatReport/CombatLogWnd.cpp
+++ b/UI/CombatReport/CombatLogWnd.cpp
@@ -1,6 +1,6 @@
 #include "CombatLogWnd.h"
 
-#include <GG/Layout.h>
+#include <GG/DeferredLayout.h>
 #include <GG/Scroll.h>
 #include <GG/ScrollPanel.h>
 
@@ -386,7 +386,7 @@ void CombatLogWnd::CombatLogWndImpl::SetLog(int log_id) {
     }
 
     m_wnd.DeleteChildren();
-    GG::Layout* layout = new GG::Layout(m_wnd.UpperLeft().x, m_wnd.UpperLeft().y
+    GG::Layout* layout = new GG::DeferredLayout(m_wnd.UpperLeft().x, m_wnd.UpperLeft().y
                                         , m_wnd.Width(), m_wnd.Height()
                                         , 1, 1 ///< numrows, numcols
                                         , 0, 0 ///< wnd margin, cell margin


### PR DESCRIPTION
This PR addresses some of the issues in #1073.  

For my combat window with fighters test case it improved layout time from 12 seconds to 1 second.

It does not fix any of the `Uknown` labels that should be known, or any other issues with the combat log.

It depends on the newly merged into master `DeferredLayout` class, so the Fighter branch will need to be rebased to master to see the improvements from this PR.
