### PR TITLE
use old boost::optional implementation for newer boost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,7 +166,7 @@ if(${Boost_VERSION} LESS "105600")
     )
 endif()
 
-if(${Boost_VERSION} EQUAL "106100")
+if(${Boost_VERSION} EQUAL "106100" OR ${Boost_VERSION} GREATER "106100")
     # with boost 1.61 some boost::optional internals were changed. However
     # boost::spirit relies on some API the old implementation provided.  This
     # define enables the usage of the old boost::optional implementation.


### PR DESCRIPTION
fixes #777; see also 70c19e312ae86919bd77b39d45fa35dc4b66d458
