### PR TITLE
Refactor get_fleets_for_mission

### DIFF
--- a/default/python/AI/AIFleetMission.py
+++ b/default/python/AI/AIFleetMission.py
@@ -289,12 +289,11 @@ class AIFleetMission(object):
         self.clear_target()  # TODO: clear from foAIstate
         self.clear_fleet_orders()
         troops_needed = max(0, target_troops - FleetUtilsAI.count_troops_in_fleet(fleet_id))
-        found_stats = {}
         min_stats = {'rating': 0, 'troopCapacity': troops_needed}
         target_stats = {'rating': 10, 'troopCapacity': troops_needed}
         found_fleets = []
         # TODO check if next statement does not mutate any global states and can be removed
-        _ = FleetUtilsAI.get_fleets_for_mission(1, target_stats, min_stats, found_stats, "",
+        _ = FleetUtilsAI.get_fleets_for_mission(1, target_stats, min_stats, {}, "",
                                                 systems_to_check=[fleet.systemID], systems_checked=[],
                                                 fleet_pool_set=set(new_fleets), fleet_list=found_fleets)
         for fid in found_fleets:

--- a/default/python/AI/AIFleetMission.py
+++ b/default/python/AI/AIFleetMission.py
@@ -296,8 +296,7 @@ class AIFleetMission(object):
         # TODO check if next statement does not mutate any global states and can be removed
         _ = FleetUtilsAI.get_fleets_for_mission(1, target_stats, min_stats, found_stats, "",
                                                 systems_to_check=[fleet.systemID], systems_checked=[],
-                                                fleet_pool_set=set(new_fleets), fleet_list=found_fleets,
-                                                verbose=False)
+                                                fleet_pool_set=set(new_fleets), fleet_list=found_fleets)
         for fid in found_fleets:
             FleetUtilsAI.merge_fleet_a_into_b(fid, fleet_id)
         target = Planet(target_id)

--- a/default/python/AI/AIFleetMission.py
+++ b/default/python/AI/AIFleetMission.py
@@ -293,8 +293,7 @@ class AIFleetMission(object):
         target_stats = {'rating': 10, 'troopCapacity': troops_needed}
         found_fleets = []
         # TODO check if next statement does not mutate any global states and can be removed
-        _ = FleetUtilsAI.get_fleets_for_mission(target_stats, min_stats, {},
-                                                starting_system=fleet.systemID,
+        _ = FleetUtilsAI.get_fleets_for_mission(target_stats, min_stats, {}, starting_system=fleet.systemID,
                                                 fleet_pool_set=set(new_fleets), fleet_list=found_fleets)
         for fid in found_fleets:
             FleetUtilsAI.merge_fleet_a_into_b(fid, fleet_id)

--- a/default/python/AI/AIFleetMission.py
+++ b/default/python/AI/AIFleetMission.py
@@ -293,7 +293,7 @@ class AIFleetMission(object):
         target_stats = {'rating': 10, 'troopCapacity': troops_needed}
         found_fleets = []
         # TODO check if next statement does not mutate any global states and can be removed
-        _ = FleetUtilsAI.get_fleets_for_mission(1, target_stats, min_stats, {},
+        _ = FleetUtilsAI.get_fleets_for_mission(target_stats, min_stats, {},
                                                 starting_system=fleet.systemID,
                                                 fleet_pool_set=set(new_fleets), fleet_list=found_fleets)
         for fid in found_fleets:

--- a/default/python/AI/AIFleetMission.py
+++ b/default/python/AI/AIFleetMission.py
@@ -294,7 +294,7 @@ class AIFleetMission(object):
         found_fleets = []
         # TODO check if next statement does not mutate any global states and can be removed
         _ = FleetUtilsAI.get_fleets_for_mission(1, target_stats, min_stats, {},
-                                                systems_to_check=[fleet.systemID], systems_checked=[],
+                                                starting_system=fleet.systemID, systems_checked=[],
                                                 fleet_pool_set=set(new_fleets), fleet_list=found_fleets)
         for fid in found_fleets:
             FleetUtilsAI.merge_fleet_a_into_b(fid, fleet_id)

--- a/default/python/AI/AIFleetMission.py
+++ b/default/python/AI/AIFleetMission.py
@@ -293,7 +293,7 @@ class AIFleetMission(object):
         target_stats = {'rating': 10, 'troopCapacity': troops_needed}
         found_fleets = []
         # TODO check if next statement does not mutate any global states and can be removed
-        _ = FleetUtilsAI.get_fleets_for_mission(1, target_stats, min_stats, {}, "",
+        _ = FleetUtilsAI.get_fleets_for_mission(1, target_stats, min_stats, {},
                                                 systems_to_check=[fleet.systemID], systems_checked=[],
                                                 fleet_pool_set=set(new_fleets), fleet_list=found_fleets)
         for fid in found_fleets:

--- a/default/python/AI/AIFleetMission.py
+++ b/default/python/AI/AIFleetMission.py
@@ -294,7 +294,7 @@ class AIFleetMission(object):
         found_fleets = []
         # TODO check if next statement does not mutate any global states and can be removed
         _ = FleetUtilsAI.get_fleets_for_mission(1, target_stats, min_stats, {},
-                                                starting_system=fleet.systemID, systems_checked=[],
+                                                starting_system=fleet.systemID,
                                                 fleet_pool_set=set(new_fleets), fleet_list=found_fleets)
         for fid in found_fleets:
             FleetUtilsAI.merge_fleet_a_into_b(fid, fleet_id)

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -1345,7 +1345,7 @@ def send_colony_ships(colony_fleet_ids, evaluated_planets, mission_type):
         try:
             this_fleet_list = FleetUtilsAI.get_fleets_for_mission(nships=1, target_stats={}, min_stats={}, cur_stats={},
                                                                   starting_system=sys_id,
-                                                                  systems_checked=[], species=this_spec,
+                                                                  species=this_spec,
                                                                   fleet_pool_set=fleet_pool, fleet_list=found_fleets)
         except:
             continue

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -1344,8 +1344,8 @@ def send_colony_ships(colony_fleet_ids, evaluated_planets, mission_type):
         found_fleets = []
         try:
             this_fleet_list = FleetUtilsAI.get_fleets_for_mission(nships=1, target_stats={}, min_stats={}, cur_stats={},
-                                                                  species=this_spec, systems_to_check=[sys_id],
-                                                                  systems_checked=[],
+                                                                  starting_system=sys_id,
+                                                                  systems_checked=[], species=this_spec,
                                                                   fleet_pool_set=fleet_pool, fleet_list=found_fleets)
         except:
             continue

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -1343,7 +1343,7 @@ def send_colony_ships(colony_fleet_ids, evaluated_planets, mission_type):
         this_spec = target[1][1]
         found_fleets = []
         try:
-            this_fleet_list = FleetUtilsAI.get_fleets_for_mission(nships=1, target_stats={}, min_stats={}, cur_stats={},
+            this_fleet_list = FleetUtilsAI.get_fleets_for_mission(target_stats={}, min_stats={}, cur_stats={},
                                                                   starting_system=sys_id,
                                                                   species=this_spec,
                                                                   fleet_pool_set=fleet_pool, fleet_list=found_fleets)

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -1346,8 +1346,7 @@ def send_colony_ships(colony_fleet_ids, evaluated_planets, mission_type):
             this_fleet_list = FleetUtilsAI.get_fleets_for_mission(nships=1, target_stats={}, min_stats={}, cur_stats={},
                                                                   species=this_spec, systems_to_check=[sys_id],
                                                                   systems_checked=[],
-                                                                  fleet_pool_set=fleet_pool, fleet_list=found_fleets,
-                                                                  verbose=False)
+                                                                  fleet_pool_set=fleet_pool, fleet_list=found_fleets)
         except:
             continue
         if not this_fleet_list:

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -1344,8 +1344,7 @@ def send_colony_ships(colony_fleet_ids, evaluated_planets, mission_type):
         found_fleets = []
         try:
             this_fleet_list = FleetUtilsAI.get_fleets_for_mission(target_stats={}, min_stats={}, cur_stats={},
-                                                                  starting_system=sys_id,
-                                                                  species=this_spec,
+                                                                  starting_system=sys_id, species=this_spec,
                                                                   fleet_pool_set=fleet_pool, fleet_list=found_fleets)
         except:
             continue

--- a/default/python/AI/ExplorationAI.py
+++ b/default/python/AI/ExplorationAI.py
@@ -82,7 +82,7 @@ def assign_scouts_to_explore_systems():
             print "Skipping exploration of system %d due to Big Monster, threat %d" % (this_sys_id, foAI.foAIstate.systemStatus[this_sys_id]['monsterThreat'])
             continue
         this_fleet_list = FleetUtilsAI.get_fleets_for_mission(nships=1, target_stats={}, min_stats={}, cur_stats={},
-                                                              systems_to_check=[this_sys_id],
+                                                              starting_system=this_sys_id,
                                                               systems_checked=[], fleet_pool_set=available_scouts,
                                                               fleet_list=[])
         if not this_fleet_list:

--- a/default/python/AI/ExplorationAI.py
+++ b/default/python/AI/ExplorationAI.py
@@ -85,7 +85,7 @@ def assign_scouts_to_explore_systems():
         this_fleet_list = FleetUtilsAI.get_fleets_for_mission(nships=1, target_stats={}, min_stats={}, cur_stats={},
                                                               species="", systems_to_check=[this_sys_id],
                                                               systems_checked=[], fleet_pool_set=available_scouts,
-                                                              fleet_list=found_fleets, verbose=False)
+                                                              fleet_list=found_fleets)
         if not this_fleet_list:
             print "Seem to have run out of scouts while trying to cover sys_id %d" % this_sys_id
             break  # must have ran out of scouts

--- a/default/python/AI/ExplorationAI.py
+++ b/default/python/AI/ExplorationAI.py
@@ -82,7 +82,7 @@ def assign_scouts_to_explore_systems():
             print "Skipping exploration of system %d due to Big Monster, threat %d" % (this_sys_id, foAI.foAIstate.systemStatus[this_sys_id]['monsterThreat'])
             continue
         this_fleet_list = FleetUtilsAI.get_fleets_for_mission(nships=1, target_stats={}, min_stats={}, cur_stats={},
-                                                              species="", systems_to_check=[this_sys_id],
+                                                              systems_to_check=[this_sys_id],
                                                               systems_checked=[], fleet_pool_set=available_scouts,
                                                               fleet_list=[])
         if not this_fleet_list:

--- a/default/python/AI/ExplorationAI.py
+++ b/default/python/AI/ExplorationAI.py
@@ -81,7 +81,7 @@ def assign_scouts_to_explore_systems():
         if (sys_status.setdefault('monsterThreat', 0) > 2000 * foAI.foAIstate.aggression) or (fo.currentTurn() < 20 and foAI.foAIstate.systemStatus[this_sys_id]['monsterThreat'] > 200):
             print "Skipping exploration of system %d due to Big Monster, threat %d" % (this_sys_id, foAI.foAIstate.systemStatus[this_sys_id]['monsterThreat'])
             continue
-        this_fleet_list = FleetUtilsAI.get_fleets_for_mission(nships=1, target_stats={}, min_stats={}, cur_stats={},
+        this_fleet_list = FleetUtilsAI.get_fleets_for_mission(target_stats={}, min_stats={}, cur_stats={},
                                                               starting_system=this_sys_id, fleet_pool_set=available_scouts,
                                                               fleet_list=[])
         if not this_fleet_list:

--- a/default/python/AI/ExplorationAI.py
+++ b/default/python/AI/ExplorationAI.py
@@ -81,11 +81,10 @@ def assign_scouts_to_explore_systems():
         if (sys_status.setdefault('monsterThreat', 0) > 2000 * foAI.foAIstate.aggression) or (fo.currentTurn() < 20 and foAI.foAIstate.systemStatus[this_sys_id]['monsterThreat'] > 200):
             print "Skipping exploration of system %d due to Big Monster, threat %d" % (this_sys_id, foAI.foAIstate.systemStatus[this_sys_id]['monsterThreat'])
             continue
-        found_fleets = []
         this_fleet_list = FleetUtilsAI.get_fleets_for_mission(nships=1, target_stats={}, min_stats={}, cur_stats={},
                                                               species="", systems_to_check=[this_sys_id],
                                                               systems_checked=[], fleet_pool_set=available_scouts,
-                                                              fleet_list=found_fleets)
+                                                              fleet_list=[])
         if not this_fleet_list:
             print "Seem to have run out of scouts while trying to cover sys_id %d" % this_sys_id
             break  # must have ran out of scouts

--- a/default/python/AI/ExplorationAI.py
+++ b/default/python/AI/ExplorationAI.py
@@ -82,8 +82,7 @@ def assign_scouts_to_explore_systems():
             print "Skipping exploration of system %d due to Big Monster, threat %d" % (this_sys_id, foAI.foAIstate.systemStatus[this_sys_id]['monsterThreat'])
             continue
         this_fleet_list = FleetUtilsAI.get_fleets_for_mission(nships=1, target_stats={}, min_stats={}, cur_stats={},
-                                                              starting_system=this_sys_id,
-                                                              systems_checked=[], fleet_pool_set=available_scouts,
+                                                              starting_system=this_sys_id, fleet_pool_set=available_scouts,
                                                               fleet_list=[])
         if not this_fleet_list:
             print "Seem to have run out of scouts while trying to cover sys_id %d" % this_sys_id

--- a/default/python/AI/FleetUtilsAI.py
+++ b/default/python/AI/FleetUtilsAI.py
@@ -69,7 +69,7 @@ def get_targeted_planet_ids(planet_ids, mission_type):
 
 
 def get_fleets_for_mission(target_stats, min_stats, cur_stats, starting_system,
-                           fleet_pool_set, fleet_list, species="", take_any=False):
+                           fleet_pool_set, fleet_list, species=""):
     """
     Implements breadth-first search through systems
     mutates cur_stats with running status, systems_to_check and systems_checked as systems are checked,
@@ -137,8 +137,7 @@ def get_fleets_for_mission(target_stats, min_stats, cur_stats, starting_system,
             )):
                 systems_to_check.append(neighbor_id)
     # we ran out of systems or fleets to check but did not meet requirements yet.
-    if take_any or (stats_meet_reqs(cur_stats, min_stats)
-                    and any(universe.getFleet(fid).shipIDs for fid in fleet_list)):
+    if stats_meet_reqs(cur_stats, min_stats) and any(universe.getFleet(fid).shipIDs for fid in fleet_list):
         return fleet_list
     else:
         return []

--- a/default/python/AI/FleetUtilsAI.py
+++ b/default/python/AI/FleetUtilsAI.py
@@ -68,7 +68,8 @@ def get_targeted_planet_ids(planet_ids, mission_type):
     return targeted_planets
 
 
-# TODO: as used, cur_stats is  just another return value
+# TODO: Avoid mutable arguments and use return values instead
+# TODO: Use Dijkstra's algorithm instead of BFS to consider starlane length
 def get_fleets_for_mission(target_stats, min_stats, cur_stats, starting_system,
                            fleet_pool_set, fleet_list, species=""):
     """Get fleets for a mission.
@@ -112,7 +113,7 @@ def get_fleets_for_mission(target_stats, min_stats, cur_stats, starting_system,
         while fleets_here:
             fleet_id = fleets_here.pop(0)
             fleet = universe.getFleet(fleet_id)
-            if not fleet:
+            if not fleet:  # TODO should be checked before passed to the function
                 fleet_pool_set.remove(fleet_id)
                 continue
             # try splitting fleet

--- a/default/python/AI/FleetUtilsAI.py
+++ b/default/python/AI/FleetUtilsAI.py
@@ -69,8 +69,7 @@ def get_targeted_planet_ids(planet_ids, mission_type):
 
 
 def get_fleets_for_mission(nships, target_stats, min_stats, cur_stats, species, systems_to_check, systems_checked,
-                           fleet_pool_set, fleet_list, take_any=False, extend_search=True,
-                           verbose=False, depth=0):
+                           fleet_pool_set, fleet_list, take_any=False, extend_search=True):
     """
     Implements breadth-first search through systems
     mutates cur_stats with running status, systems_to_check and systems_checked as systems are checked,

--- a/default/python/AI/FleetUtilsAI.py
+++ b/default/python/AI/FleetUtilsAI.py
@@ -68,8 +68,8 @@ def get_targeted_planet_ids(planet_ids, mission_type):
     return targeted_planets
 
 
-def get_fleets_for_mission(nships, target_stats, min_stats, cur_stats, species, systems_to_check, systems_checked,
-                           fleet_pool_set, fleet_list, take_any=False, extend_search=True):
+def get_fleets_for_mission(nships, target_stats, min_stats, cur_stats, systems_to_check, systems_checked,
+                           fleet_pool_set, fleet_list, species="", take_any=False, extend_search=True):
     """
     Implements breadth-first search through systems
     mutates cur_stats with running status, systems_to_check and systems_checked as systems are checked,

--- a/default/python/AI/FleetUtilsAI.py
+++ b/default/python/AI/FleetUtilsAI.py
@@ -68,7 +68,7 @@ def get_targeted_planet_ids(planet_ids, mission_type):
     return targeted_planets
 
 
-def get_fleets_for_mission(nships, target_stats, min_stats, cur_stats, starting_system,
+def get_fleets_for_mission(target_stats, min_stats, cur_stats, starting_system,
                            fleet_pool_set, fleet_list, species="", take_any=False, extend_search=True):
     """
     Implements breadth-first search through systems
@@ -139,7 +139,7 @@ def get_fleets_for_mission(nships, target_stats, min_stats, cur_stats, starting_
                     systems_to_check.append(neighbor_id)
     # we ran out of systems or fleets to check but did not meet requirements yet.
     if take_any or (stats_meet_reqs(cur_stats, min_stats)
-                    and sum(len(universe.getFleet(fid).shipIDs) for fid in fleet_list) >= nships):
+                    and any(universe.getFleet(fid).shipIDs for fid in fleet_list)):
         return fleet_list
     else:
         return []

--- a/default/python/AI/FleetUtilsAI.py
+++ b/default/python/AI/FleetUtilsAI.py
@@ -142,7 +142,7 @@ def get_fleets_for_mission(target_stats, min_stats, cur_stats, starting_system,
             if 'troopCapacity' in target_stats:
                 cur_stats['troopCapacity'] = cur_stats.get('troopCapacity', 0) + troop_capacity
             # if we already meet the requirements, we can stop looking for more ships
-            if (sum(len(universe.getFleet(fid).shipIDs) for fid in fleet_list) >= nships) \
+            if (sum(len(universe.getFleet(fid).shipIDs) for fid in fleet_list) >= 1) \
                     and stats_meet_reqs(cur_stats, target_stats):
                 return fleet_list
 

--- a/default/python/AI/FleetUtilsAI.py
+++ b/default/python/AI/FleetUtilsAI.py
@@ -68,7 +68,7 @@ def get_targeted_planet_ids(planet_ids, mission_type):
     return targeted_planets
 
 
-def get_fleets_for_mission(nships, target_stats, min_stats, cur_stats, starting_system, systems_checked,
+def get_fleets_for_mission(nships, target_stats, min_stats, cur_stats, starting_system,
                            fleet_pool_set, fleet_list, species="", take_any=False, extend_search=True):
     """
     Implements breadth-first search through systems
@@ -82,6 +82,7 @@ def get_fleets_for_mission(nships, target_stats, min_stats, cur_stats, starting_
     universe = fo.getUniverse()
     colonization_roles = (ShipRoleType.CIVILIAN_COLONISATION, ShipRoleType.BASE_COLONISATION)
     systems_to_check = [starting_system]
+    systems_checked = []
     # loop over systems in a breadth-first-search trying to find nearby suitable ships in fleet_pool_set
     while systems_to_check and fleet_pool_set:
         this_system_id = systems_to_check.pop(0)

--- a/default/python/AI/FleetUtilsAI.py
+++ b/default/python/AI/FleetUtilsAI.py
@@ -68,7 +68,7 @@ def get_targeted_planet_ids(planet_ids, mission_type):
     return targeted_planets
 
 
-def get_fleets_for_mission(nships, target_stats, min_stats, cur_stats, systems_to_check, systems_checked,
+def get_fleets_for_mission(nships, target_stats, min_stats, cur_stats, starting_system, systems_checked,
                            fleet_pool_set, fleet_list, species="", take_any=False, extend_search=True):
     """
     Implements breadth-first search through systems
@@ -81,7 +81,7 @@ def get_fleets_for_mission(nships, target_stats, min_stats, cur_stats, systems_t
     """
     universe = fo.getUniverse()
     colonization_roles = (ShipRoleType.CIVILIAN_COLONISATION, ShipRoleType.BASE_COLONISATION)
-
+    systems_to_check = [starting_system]
     # loop over systems in a breadth-first-search trying to find nearby suitable ships in fleet_pool_set
     while systems_to_check and fleet_pool_set:
         this_system_id = systems_to_check.pop(0)

--- a/default/python/AI/FleetUtilsAI.py
+++ b/default/python/AI/FleetUtilsAI.py
@@ -89,9 +89,9 @@ def get_fleets_for_mission(target_stats, min_stats, cur_stats, starting_system,
     :type cur_stats: dict
     :param starting_system: system_id where breadth-first-search is centered
     :type starting_system: int
-    :param fleet_pool_set: fleets allowed to be selected
+    :param fleet_pool_set: (**mutated**) fleets allowed to be selected. Split fleed_ids are added, used ones removed.
     :type: fleet_pool_set: set[int]
-    :param fleet_list: fleets that are selected for the mission.
+    :param fleet_list: (**mutated**) fleets that are selected for the mission. Gets filled during the call.
     :type fleet_list: list[int]
     :param species: species for colonization mission
     :type species: str

--- a/default/python/AI/FleetUtilsAI.py
+++ b/default/python/AI/FleetUtilsAI.py
@@ -69,7 +69,7 @@ def get_targeted_planet_ids(planet_ids, mission_type):
 
 
 def get_fleets_for_mission(target_stats, min_stats, cur_stats, starting_system,
-                           fleet_pool_set, fleet_list, species="", take_any=False, extend_search=True):
+                           fleet_pool_set, fleet_list, species="", take_any=False):
     """
     Implements breadth-first search through systems
     mutates cur_stats with running status, systems_to_check and systems_checked as systems are checked,
@@ -128,15 +128,14 @@ def get_fleets_for_mission(target_stats, min_stats, cur_stats, starting_system,
                 return fleet_list
 
         # finished system without meeting requirements. Add neighboring systems to search queue.
-        if extend_search:
-            for neighbor_id in [el.key() for el in
-                                universe.getSystemNeighborsMap(this_system_id, fo.empireID())]:
-                if all((
-                            neighbor_id not in systems_checked,
-                            neighbor_id not in systems_to_check,
-                            neighbor_id in foAI.foAIstate.exploredSystemIDs
-                )):
-                    systems_to_check.append(neighbor_id)
+        for neighbor_id in [el.key() for el in
+                            universe.getSystemNeighborsMap(this_system_id, fo.empireID())]:
+            if all((
+                        neighbor_id not in systems_checked,
+                        neighbor_id not in systems_to_check,
+                        neighbor_id in foAI.foAIstate.exploredSystemIDs
+            )):
+                systems_to_check.append(neighbor_id)
     # we ran out of systems or fleets to check but did not meet requirements yet.
     if take_any or (stats_meet_reqs(cur_stats, min_stats)
                     and any(universe.getFleet(fid).shipIDs for fid in fleet_list)):

--- a/default/python/AI/FleetUtilsAI.py
+++ b/default/python/AI/FleetUtilsAI.py
@@ -68,16 +68,35 @@ def get_targeted_planet_ids(planet_ids, mission_type):
     return targeted_planets
 
 
+# TODO: as used, cur_stats is  just another return value
 def get_fleets_for_mission(target_stats, min_stats, cur_stats, starting_system,
                            fleet_pool_set, fleet_list, species=""):
-    """
-    Implements breadth-first search through systems
-    mutates cur_stats with running status, systems_to_check and systems_checked as systems are checked,
-    fleet_pool_set as fleets are checked also mutates fleet_list as running list of selected fleets;
-    this list will be returned as the function return value if the target statsare met or if upon exhausting
-    systems_to_check both take_any is true and the min stats are met.
+    """Get fleets for a mission.
+
+    Implements breadth-first search through systems starting at the **starting_sytem**.
+    In each system, local fleets are checked if they are in the allowed **fleet_pool_set** and suitable for the mission.
+    If so, they are added to the **fleet_list** and **cur_stats** is updated with the currently selected fleet summary.
+    The search continues until the requirements defined in **target_stats** are met or there are no more systems/fleets.
+    In that case, if the **min_stats** are covered, the **fleet_list** is returned anyway.
     Otherwise, an empty list is returned by the function, in which case the caller can make an evaluation of
     an emergency use of the found fleets in fleet_list; if not to be used they should be added back to the main pool.
+
+    :param target_stats: stats the fleet should ideally meet
+    :type target_stats: dict
+    :param min_stats: minimum stats the final fleet must meet to be accepted
+    :type min_stats: dict
+    :param cur_stats: (**mutated**) stat summary of selected fleet
+    :type cur_stats: dict
+    :param starting_system: system_id where breadth-first-search is centered
+    :type starting_system: int
+    :param fleet_pool_set: fleets allowed to be selected
+    :type: fleet_pool_set: set[int]
+    :param fleet_list: fleets that are selected for the mission.
+    :type fleet_list: list[int]
+    :param species: species for colonization mission
+    :type species: str
+    :return: List of selected fleet_ids or empty list if couldn't meet minimum requirements.
+    :rtype: list[int]
     """
     universe = fo.getUniverse()
     colonization_roles = (ShipRoleType.CIVILIAN_COLONISATION, ShipRoleType.BASE_COLONISATION)

--- a/default/python/AI/FleetUtilsAI.py
+++ b/default/python/AI/FleetUtilsAI.py
@@ -100,12 +100,12 @@ def get_fleets_for_mission(target_stats, min_stats, cur_stats, starting_system,
     """
     universe = fo.getUniverse()
     colonization_roles = (ShipRoleType.CIVILIAN_COLONISATION, ShipRoleType.BASE_COLONISATION)
-    systems_to_check = [starting_system]
-    systems_checked = []
+    systems_enqueued = [starting_system]
+    systems_visited = []
     # loop over systems in a breadth-first-search trying to find nearby suitable ships in fleet_pool_set
-    while systems_to_check and fleet_pool_set:
-        this_system_id = systems_to_check.pop(0)
-        systems_checked.append(this_system_id)
+    while systems_enqueued and fleet_pool_set:
+        this_system_id = systems_enqueued.pop(0)
+        systems_visited.append(this_system_id)
         accessible_fleets = foAI.foAIstate.systemStatus.get(this_system_id, {}).get('myFleetsAccessible', [])
         fleets_here = [fid for fid in accessible_fleets if fid in fleet_pool_set]
         # loop over all fleets in the system, split them if possible and select suitable ships
@@ -150,11 +150,11 @@ def get_fleets_for_mission(target_stats, min_stats, cur_stats, starting_system,
         for neighbor_id in [el.key() for el in
                             universe.getSystemNeighborsMap(this_system_id, fo.empireID())]:
             if all((
-                        neighbor_id not in systems_checked,
-                        neighbor_id not in systems_to_check,
-                        neighbor_id in foAI.foAIstate.exploredSystemIDs
+                    neighbor_id not in systems_visited,
+                    neighbor_id not in systems_enqueued,
+                    neighbor_id in foAI.foAIstate.exploredSystemIDs
             )):
-                systems_to_check.append(neighbor_id)
+                systems_enqueued.append(neighbor_id)
     # we ran out of systems or fleets to check but did not meet requirements yet.
     if stats_meet_reqs(cur_stats, min_stats) and any(universe.getFleet(fid).shipIDs for fid in fleet_list):
         return fleet_list

--- a/default/python/AI/FleetUtilsAI.py
+++ b/default/python/AI/FleetUtilsAI.py
@@ -86,7 +86,7 @@ def get_fleets_for_mission(target_stats, min_stats, cur_stats, starting_system,
     :type target_stats: dict
     :param min_stats: minimum stats the final fleet must meet to be accepted
     :type min_stats: dict
-    :param cur_stats: (**mutated**) stat summary of selected fleet
+    :param cur_stats: (**mutated**) stat summary of selected fleets
     :type cur_stats: dict
     :param starting_system: system_id where breadth-first-search is centered
     :type starting_system: int

--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -401,8 +401,8 @@ def send_invasion_fleets(fleet_ids, evaluated_planets, mission_type):
         min_stats = {'rating': 0, 'troopCapacity': ptroops}
         target_stats = {'rating': 10, 'troopCapacity': ptroops+1}
         these_fleets = FleetUtilsAI.get_fleets_for_mission(target_stats, min_stats, found_stats,
-                                                           starting_system=sys_id,
-                                                           fleet_pool_set=invasion_fleet_pool, fleet_list=found_fleets)
+                                                           starting_system=sys_id, fleet_pool_set=invasion_fleet_pool,
+                                                           fleet_list=found_fleets)
         if not these_fleets:
             if not FleetUtilsAI.stats_meet_reqs(found_stats, min_stats):
                 print "Insufficient invasion troop allocation for system %d ( %s ) -- requested %s , found %s" % (
@@ -468,8 +468,8 @@ def assign_invasion_fleets_to_invade():
             target_stats = {'rating': 10, 'troopCapacity': troops_needed}
 
             FleetUtilsAI.get_fleets_for_mission(target_stats, min_stats, found_stats,
-                                                starting_system=sys_id,
-                                                fleet_pool_set=local_base_troops, fleet_list=found_fleets)
+                                                starting_system=sys_id, fleet_pool_set=local_base_troops,
+                                                fleet_list=found_fleets)
             for fid2 in found_fleets:
                 FleetUtilsAI.merge_fleet_a_into_b(fid2, fid)
                 available_troopbase_fleet_ids.discard(fid2)

--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -402,8 +402,7 @@ def send_invasion_fleets(fleet_ids, evaluated_planets, mission_type):
         target_stats = {'rating': 10, 'troopCapacity': ptroops+1}
         these_fleets = FleetUtilsAI.get_fleets_for_mission(1, target_stats, min_stats, found_stats, "",
                                                            systems_to_check=[sys_id], systems_checked=[],
-                                                           fleet_pool_set=invasion_fleet_pool, fleet_list=found_fleets,
-                                                           verbose=False)
+                                                           fleet_pool_set=invasion_fleet_pool, fleet_list=found_fleets)
         if not these_fleets:
             if not FleetUtilsAI.stats_meet_reqs(found_stats, min_stats):
                 print "Insufficient invasion troop allocation for system %d ( %s ) -- requested %s , found %s" % (
@@ -470,8 +469,7 @@ def assign_invasion_fleets_to_invade():
 
             FleetUtilsAI.get_fleets_for_mission(1, target_stats, min_stats, found_stats, "",
                                                 systems_to_check=[sys_id], systems_checked=[],
-                                                fleet_pool_set=local_base_troops, fleet_list=found_fleets,
-                                                verbose=False)
+                                                fleet_pool_set=local_base_troops, fleet_list=found_fleets)
             for fid2 in found_fleets:
                 FleetUtilsAI.merge_fleet_a_into_b(fid2, fid)
                 available_troopbase_fleet_ids.discard(fid2)

--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -400,7 +400,7 @@ def send_invasion_fleets(fleet_ids, evaluated_planets, mission_type):
         found_stats = {}
         min_stats = {'rating': 0, 'troopCapacity': ptroops}
         target_stats = {'rating': 10, 'troopCapacity': ptroops+1}
-        these_fleets = FleetUtilsAI.get_fleets_for_mission(1, target_stats, min_stats, found_stats,
+        these_fleets = FleetUtilsAI.get_fleets_for_mission(target_stats, min_stats, found_stats,
                                                            starting_system=sys_id,
                                                            fleet_pool_set=invasion_fleet_pool, fleet_list=found_fleets)
         if not these_fleets:
@@ -467,7 +467,7 @@ def assign_invasion_fleets_to_invade():
             min_stats = {'rating': 0, 'troopCapacity': troops_needed}
             target_stats = {'rating': 10, 'troopCapacity': troops_needed}
 
-            FleetUtilsAI.get_fleets_for_mission(1, target_stats, min_stats, found_stats,
+            FleetUtilsAI.get_fleets_for_mission(target_stats, min_stats, found_stats,
                                                 starting_system=sys_id,
                                                 fleet_pool_set=local_base_troops, fleet_list=found_fleets)
             for fid2 in found_fleets:

--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -400,7 +400,7 @@ def send_invasion_fleets(fleet_ids, evaluated_planets, mission_type):
         found_stats = {}
         min_stats = {'rating': 0, 'troopCapacity': ptroops}
         target_stats = {'rating': 10, 'troopCapacity': ptroops+1}
-        these_fleets = FleetUtilsAI.get_fleets_for_mission(1, target_stats, min_stats, found_stats, "",
+        these_fleets = FleetUtilsAI.get_fleets_for_mission(1, target_stats, min_stats, found_stats,
                                                            systems_to_check=[sys_id], systems_checked=[],
                                                            fleet_pool_set=invasion_fleet_pool, fleet_list=found_fleets)
         if not these_fleets:
@@ -467,7 +467,7 @@ def assign_invasion_fleets_to_invade():
             min_stats = {'rating': 0, 'troopCapacity': troops_needed}
             target_stats = {'rating': 10, 'troopCapacity': troops_needed}
 
-            FleetUtilsAI.get_fleets_for_mission(1, target_stats, min_stats, found_stats, "",
+            FleetUtilsAI.get_fleets_for_mission(1, target_stats, min_stats, found_stats,
                                                 systems_to_check=[sys_id], systems_checked=[],
                                                 fleet_pool_set=local_base_troops, fleet_list=found_fleets)
             for fid2 in found_fleets:

--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -401,7 +401,7 @@ def send_invasion_fleets(fleet_ids, evaluated_planets, mission_type):
         min_stats = {'rating': 0, 'troopCapacity': ptroops}
         target_stats = {'rating': 10, 'troopCapacity': ptroops+1}
         these_fleets = FleetUtilsAI.get_fleets_for_mission(1, target_stats, min_stats, found_stats,
-                                                           starting_system=sys_id, systems_checked=[],
+                                                           starting_system=sys_id,
                                                            fleet_pool_set=invasion_fleet_pool, fleet_list=found_fleets)
         if not these_fleets:
             if not FleetUtilsAI.stats_meet_reqs(found_stats, min_stats):
@@ -468,7 +468,7 @@ def assign_invasion_fleets_to_invade():
             target_stats = {'rating': 10, 'troopCapacity': troops_needed}
 
             FleetUtilsAI.get_fleets_for_mission(1, target_stats, min_stats, found_stats,
-                                                starting_system=sys_id, systems_checked=[],
+                                                starting_system=sys_id,
                                                 fleet_pool_set=local_base_troops, fleet_list=found_fleets)
             for fid2 in found_fleets:
                 FleetUtilsAI.merge_fleet_a_into_b(fid2, fid)

--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -401,7 +401,7 @@ def send_invasion_fleets(fleet_ids, evaluated_planets, mission_type):
         min_stats = {'rating': 0, 'troopCapacity': ptroops}
         target_stats = {'rating': 10, 'troopCapacity': ptroops+1}
         these_fleets = FleetUtilsAI.get_fleets_for_mission(1, target_stats, min_stats, found_stats,
-                                                           systems_to_check=[sys_id], systems_checked=[],
+                                                           starting_system=sys_id, systems_checked=[],
                                                            fleet_pool_set=invasion_fleet_pool, fleet_list=found_fleets)
         if not these_fleets:
             if not FleetUtilsAI.stats_meet_reqs(found_stats, min_stats):
@@ -468,7 +468,7 @@ def assign_invasion_fleets_to_invade():
             target_stats = {'rating': 10, 'troopCapacity': troops_needed}
 
             FleetUtilsAI.get_fleets_for_mission(1, target_stats, min_stats, found_stats,
-                                                systems_to_check=[sys_id], systems_checked=[],
+                                                starting_system=sys_id, systems_checked=[],
                                                 fleet_pool_set=local_base_troops, fleet_list=found_fleets)
             for fid2 in found_fleets:
                 FleetUtilsAI.merge_fleet_a_into_b(fid2, fid)

--- a/default/python/AI/MilitaryAI.py
+++ b/default/python/AI/MilitaryAI.py
@@ -738,7 +738,7 @@ def assign_military_fleets_to_systems(use_fleet_id_list=None, allocations=None, 
         found_fleets = []
         found_stats = {}
         try:
-            these_fleets = FleetUtilsAI.get_fleets_for_mission(1, {'rating': alloc}, {'rating': minalloc}, found_stats, starting_system=sys_id, systems_checked=[],
+            these_fleets = FleetUtilsAI.get_fleets_for_mission(1, {'rating': alloc}, {'rating': minalloc}, found_stats, starting_system=sys_id,
                                                                fleet_pool_set=avail_mil_fleet_ids, fleet_list=found_fleets)
         except:
             continue

--- a/default/python/AI/MilitaryAI.py
+++ b/default/python/AI/MilitaryAI.py
@@ -738,7 +738,7 @@ def assign_military_fleets_to_systems(use_fleet_id_list=None, allocations=None, 
         found_fleets = []
         found_stats = {}
         try:
-            these_fleets = FleetUtilsAI.get_fleets_for_mission(1, {'rating': alloc}, {'rating': minalloc}, found_stats, "", systems_to_check=[sys_id], systems_checked=[],
+            these_fleets = FleetUtilsAI.get_fleets_for_mission(1, {'rating': alloc}, {'rating': minalloc}, found_stats, systems_to_check=[sys_id], systems_checked=[],
                                                                fleet_pool_set=avail_mil_fleet_ids, fleet_list=found_fleets)
         except:
             continue

--- a/default/python/AI/MilitaryAI.py
+++ b/default/python/AI/MilitaryAI.py
@@ -738,7 +738,7 @@ def assign_military_fleets_to_systems(use_fleet_id_list=None, allocations=None, 
         found_fleets = []
         found_stats = {}
         try:
-            these_fleets = FleetUtilsAI.get_fleets_for_mission(1, {'rating': alloc}, {'rating': minalloc}, found_stats, starting_system=sys_id,
+            these_fleets = FleetUtilsAI.get_fleets_for_mission({'rating': alloc}, {'rating': minalloc}, found_stats, starting_system=sys_id,
                                                                fleet_pool_set=avail_mil_fleet_ids, fleet_list=found_fleets)
         except:
             continue

--- a/default/python/AI/MilitaryAI.py
+++ b/default/python/AI/MilitaryAI.py
@@ -737,11 +737,9 @@ def assign_military_fleets_to_systems(use_fleet_id_list=None, allocations=None, 
             break
         found_fleets = []
         found_stats = {}
-        try:
-            these_fleets = FleetUtilsAI.get_fleets_for_mission({'rating': alloc}, {'rating': minalloc}, found_stats, starting_system=sys_id,
-                                                               fleet_pool_set=avail_mil_fleet_ids, fleet_list=found_fleets)
-        except:
-            continue
+        these_fleets = FleetUtilsAI.get_fleets_for_mission({'rating': alloc}, {'rating': minalloc}, found_stats,
+                                                           starting_system=sys_id, fleet_pool_set=avail_mil_fleet_ids,
+                                                           fleet_list=found_fleets)
         if not these_fleets:
             if not found_fleets or not (FleetUtilsAI.stats_meet_reqs(found_stats, {'rating': minalloc}) or takeAny):
                 if doing_main:

--- a/default/python/AI/MilitaryAI.py
+++ b/default/python/AI/MilitaryAI.py
@@ -739,7 +739,7 @@ def assign_military_fleets_to_systems(use_fleet_id_list=None, allocations=None, 
         found_stats = {}
         try:
             these_fleets = FleetUtilsAI.get_fleets_for_mission(1, {'rating': alloc}, {'rating': minalloc}, found_stats, "", systems_to_check=[sys_id], systems_checked=[],
-                                                               fleet_pool_set=avail_mil_fleet_ids, fleet_list=found_fleets, verbose=False)
+                                                               fleet_pool_set=avail_mil_fleet_ids, fleet_list=found_fleets)
         except:
             continue
         if not these_fleets:

--- a/default/python/AI/MilitaryAI.py
+++ b/default/python/AI/MilitaryAI.py
@@ -738,7 +738,7 @@ def assign_military_fleets_to_systems(use_fleet_id_list=None, allocations=None, 
         found_fleets = []
         found_stats = {}
         try:
-            these_fleets = FleetUtilsAI.get_fleets_for_mission(1, {'rating': alloc}, {'rating': minalloc}, found_stats, systems_to_check=[sys_id], systems_checked=[],
+            these_fleets = FleetUtilsAI.get_fleets_for_mission(1, {'rating': alloc}, {'rating': minalloc}, found_stats, starting_system=sys_id, systems_checked=[],
                                                                fleet_pool_set=avail_mil_fleet_ids, fleet_list=found_fleets)
         except:
             continue


### PR DESCRIPTION
Previous implementation was some weird iterative-recursion-hybrid. It is now a purely iterative implementation of the same algorithm.

Various arguments were not used or always called the same way. I removed that unused functionality for an overall much simpler and more readable function. If needed in the future, the functionality may be trivially reimplemented. 

The PR is opened to fighter branch rather than master to avoid conflicts as the function is changed in Fighter branch. Probably will be needed for next set of fighter-related AI updates and I prefer working with a clean codebase...
