### PR TITLE
Use PopCenter::Reset for zero pop planets with a species

### DIFF
--- a/universe/Planet.cpp
+++ b/universe/Planet.cpp
@@ -867,7 +867,7 @@ void Planet::PopGrowthProductionResearchPhase() {
                 species_it->second++;
         }
         // remove species
-        SetSpecies("");
+        PopCenter::Reset();
     }
 
     if (!just_conquered) {


### PR DESCRIPTION
Removing a species during `PopGrowthProductionResearchPhase` does not reset the PopCenter meters.  After this code triggers, `METER_TARGET_POPULATION` is sometimes set to a value other than 0.  The following turn, the meters update to their correct values.

I did not find a source for this new meter value, as it is inconsistent I believe may be undefined behavior from unset values.  With one instance, reloading the same save file 2 turns beforehand would sometimes show the planet with 0, 2, or 10 max pop.

The Planet Suitability Report would report an "incorrect" population, since the planet is reporting a higher max pop than it should have for that turn.

Fixes #979 
