### PR TITLE
Fix combat log accordion bad initial reflow.

### DIFF
--- a/UI/CombatReport/CombatLogWnd.cpp
+++ b/UI/CombatReport/CombatLogWnd.cpp
@@ -1,5 +1,6 @@
 #include "CombatLogWnd.h"
 
+#include <GG/GUI.h>
 #include <GG/DeferredLayout.h>
 #include <GG/Scroll.h>
 #include <GG/ScrollPanel.h>
@@ -465,5 +466,21 @@ void CombatLogWnd::HandleMadeVisible()
 void CombatLogWnd::PreRender()
 {
     GG::Wnd::PreRender();
+
+    /* Workaround
+
+     Problem: CombatLogWnd is incorrectly initialized with a width of 30 which causes the combat
+     accordion windows to incorrectly size themselves as if the title text were 30 wide.
+
+    This fix forces the combat accordion window to correctly resize itself.
+
+    TODO: Fix intial size of CombatReport from (30,15) to its actual first displayed size.*/
+    GG::Pt size = Size();
+    Resize(size + GG::Pt(2*pimpl->m_font->SpaceWidth(), GG::Y0));
+    GG::GUI::PreRenderWindow(this);
+    Resize(size);
+    GG::GUI::PreRenderWindow(this);
+    /* End workaround. */
+
     WndChangedSignal();
 }

--- a/UI/CombatReport/CombatLogWnd.cpp
+++ b/UI/CombatReport/CombatLogWnd.cpp
@@ -463,8 +463,7 @@ GG::Pt CombatLogWnd::MinUsableSize() const
 void CombatLogWnd::HandleMadeVisible()
 { return pimpl->HandleWndChanged(); }
 
-void CombatLogWnd::PreRender()
-{
+void CombatLogWnd::PreRender() {
     GG::Wnd::PreRender();
 
     /* Workaround

--- a/UI/CombatReport/CombatLogWnd.cpp
+++ b/UI/CombatReport/CombatLogWnd.cpp
@@ -143,6 +143,7 @@ namespace {
         SetLayout(new GG::DeferredLayout(UpperLeft().x, UpperLeft().y, Width(), Height(), 1, 1));
         GetLayout()->Add(title, 0, 0, 1, 1);
         SetCollapsed(true);
+        RequirePreRender();
     }
 
     CombatLogAccordionPanel::~CombatLogAccordionPanel() {
@@ -185,12 +186,8 @@ GG::Pt CombatLogWnd::CombatLogWndImpl::MinUsableSize() const {
     return GG::Pt(m_font->SpaceWidth()*20, m_font->Lineskip()*10);
 }
 
-void CombatLogWnd::CombatLogWndImpl::HandleWndChanged() {
-    GG::Pt size = m_wnd.Size();
-    m_wnd.Resize(size + GG::Pt(2*m_font->SpaceWidth(), GG::Y0));
-    m_wnd.Resize(size);
-    m_wnd.WndChangedSignal();
-}
+void CombatLogWnd::CombatLogWndImpl::HandleWndChanged()
+{ m_wnd.RequirePreRender(); }
 
 
 namespace {
@@ -464,3 +461,9 @@ GG::Pt CombatLogWnd::MinUsableSize() const
 
 void CombatLogWnd::HandleMadeVisible()
 { return pimpl->HandleWndChanged(); }
+
+void CombatLogWnd::PreRender()
+{
+    GG::Wnd::PreRender();
+    WndChangedSignal();
+}

--- a/UI/CombatReport/CombatLogWnd.h
+++ b/UI/CombatReport/CombatLogWnd.h
@@ -20,6 +20,7 @@ public:
     void SetFont(boost::shared_ptr<GG::Font> font);
     /// Set which log to show
     void SetLog(int log_id);
+    virtual void PreRender();
     //@}
 
     ///link clicked signals: first string is the link type, second string is the specific item clicked


### PR DESCRIPTION
PR #1076 re-exposed the problem with the initial text reflow of the combat accordion window title.

I have used the same workaround as before #1076 added `DeferredLayout`, but moved it into the `PreRender()` function.  

If I find a proper fix, while fixing the other combat log problems with fighters I will replace this code, but this PR is an improvement on #1076.
