### PR TITLE
Autoselection of ships for bombard

### DIFF
--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -1037,7 +1037,7 @@ namespace {
             ship->OwnedBy(empire_id) &&
             ship->GetVisibility(empire_id) >= VIS_PARTIAL_VISIBILITY &&
             ship->OrderedScrapped() == false &&
-            fleet->FinalDestinationID() == INVALID_OBJECT_ID )
+            fleet->FinalDestinationID() == INVALID_OBJECT_ID)
         { return true; }
         return false;
     }
@@ -1048,9 +1048,9 @@ namespace {
         TemporaryPtr<Fleet> fleet = GetFleet(ship->FleetID());
         if (!fleet)
             return false;
-        if ( IsAvailable(ship, system_id, empire_id) &&
+        if (IsAvailable(ship, system_id, empire_id) &&
             ship->CanColonize() &&
-            ship->OrderedColonizePlanet() == INVALID_OBJECT_ID )
+            ship->OrderedColonizePlanet() == INVALID_OBJECT_ID)
         { return true; }
         return false;
     };
@@ -1063,7 +1063,7 @@ namespace {
             return false;
         if (IsAvailable(ship, system_id, empire_id) &&
             ship->HasTroops() &&
-            ship->OrderedInvadePlanet() == INVALID_OBJECT_ID )
+            ship->OrderedInvadePlanet() == INVALID_OBJECT_ID)
         { return true; }
         return false;
     };
@@ -1076,7 +1076,7 @@ namespace {
             return false;
         if (IsAvailable(ship, system_id, empire_id) &&
             ship->CanBombard() &&
-            ship->OrderedBombardPlanet() == INVALID_OBJECT_ID )
+            ship->OrderedBombardPlanet() == INVALID_OBJECT_ID)
         { return true; }
         return false;
     };
@@ -1095,12 +1095,9 @@ namespace {
                 retval.push_back(*tag_it);
                 break;
             } else if ((tag_it->length() > TAG_BOMBARD_PREFIX.length()) &&
-                (tag_it->substr(0, TAG_BOMBARD_PREFIX.length()) == TAG_BOMBARD_PREFIX))
-            {
-                retval.push_back(tag_it->substr(TAG_BOMBARD_PREFIX.length()));
-            }
+                       (tag_it->substr(0, TAG_BOMBARD_PREFIX.length()) == TAG_BOMBARD_PREFIX))
+            { retval.push_back(tag_it->substr(TAG_BOMBARD_PREFIX.length())); }
         }
-
         return retval;
     }
 
@@ -1386,7 +1383,6 @@ std::set<TemporaryPtr<const Ship> > AutomaticallyChosenBombardShips(int target_p
                 break;
             }
         }
-
     }
 
     return retval;

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -1081,7 +1081,8 @@ namespace {
         return false;
     };
 
-    /** Parse content tags for a Ship, returning tags that potentially match with those of a Planet.
+    /** Content tags that note if a Ship should be auto-selected for bombarding a Planet.
+     *  These tags are determined from the TAG_BOMBARD_PREFIX tags of @a ship and potentially match those of a Planet.
      *  If the Ship contains the content tag defined in TAG_BOMBARD_ALWAYS, only that tag will be returned.
      */
     std::vector<std::string> BombardTagsForShip(TemporaryPtr<const Ship> ship) {
@@ -1344,8 +1345,8 @@ std::set<TemporaryPtr<const Ship> > AutomaticallyChosenInvasionShips(int target_
     return retval;
 }
 
-/** Returns valid Ship%s capable of bombarding a given planet.
- * @param target_planet_id ID of planet to potentially bombard
+/** Returns valid Ship%s capable of bombarding a given Planet.
+ * @param target_planet_id ID of Planet to potentially bombard
  */
 std::set<TemporaryPtr<const Ship> > AutomaticallyChosenBombardShips(int target_planet_id) {
     std::set<TemporaryPtr<const Ship> > retval;
@@ -1362,7 +1363,7 @@ std::set<TemporaryPtr<const Ship> > AutomaticallyChosenBombardShips(int target_p
     if (!system)
         return retval;
 
-    //Can't bombard owned-by-self planets; early exit
+    // Can't bombard owned-by-self planets; early exit
     if (target_planet->OwnedBy(empire_id))
         return retval;
 

--- a/default/scripting/ship_parts/SP_BIOTERM.focs.txt
+++ b/default/scripting/ship_parts/SP_BIOTERM.focs.txt
@@ -2,9 +2,11 @@ Part
     name = "SP_BIOTERM"
     description = "SP_BIOTERM_DESC"
     class = Bombard
+    capacity = 1.0
     mountableSlotTypes = External
     buildcost = 5 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildtime = 3
+    tags = [ "CTRL_BOMBARD_ORGANIC" ]
     location = All
     effectsgroups = [
         EffectsGroup    // players can order terminators used on enemies

--- a/default/scripting/ship_parts/SP_CHAOS_WAVE.focs.txt
+++ b/default/scripting/ship_parts/SP_CHAOS_WAVE.focs.txt
@@ -2,9 +2,11 @@ Part
     name = "SP_CHAOS_WAVE"
     description = "SP_CHAOS_WAVE_DESC"
     class = Bombard
+    capacity = 2.0
     mountableSlotTypes = External
     buildcost = 10 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildtime = 5
+    tags = [ "CTRL_ALWAYS_BOMBARD" ]
     location = All
     effectsgroups = [
         EffectsGroup    // players can order chaos wave used on enemies

--- a/default/scripting/ship_parts/SP_DARK_RAY.focs.txt
+++ b/default/scripting/ship_parts/SP_DARK_RAY.focs.txt
@@ -2,9 +2,11 @@ Part
     name = "SP_DARK_RAY"
     description = "SP_DARK_RAY_DESC"
     class = Bombard
+    capacity = 0.5
     mountableSlotTypes = External
     buildcost = 5 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildtime = 3
+    tags = [ "CTRL_BOMBARD_PHOTOTROPHIC" ]
     location = All
     effectsgroups = [
         EffectsGroup    // players can order dark ray used on enemies

--- a/default/scripting/ship_parts/SP_DEATH_SPORE.focs.txt
+++ b/default/scripting/ship_parts/SP_DEATH_SPORE.focs.txt
@@ -2,9 +2,11 @@ Part
     name = "SP_DEATH_SPORE"
     description = "SP_DEATH_SPORE_DESC"
     class = Bombard
+    capacity = 0.5
     mountableSlotTypes = External
     buildcost = 5 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildtime = 3
+    tags = [ "CTRL_BOMBARD_ORGANIC" ]
     location = All
     effectsgroups = [
         EffectsGroup    // players can order death spores used on enemies

--- a/default/scripting/ship_parts/SP_EMO.focs.txt
+++ b/default/scripting/ship_parts/SP_EMO.focs.txt
@@ -2,9 +2,11 @@ Part
     name = "SP_EMO"
     description = "SP_EMO_DESC"
     class = Bombard
+    capacity = 1.0
     mountableSlotTypes = External
     buildcost = 5 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildtime = 3
+    tags = [ "CTRL_BOMBARD_ROBOTIC" ]
     location = All
     effectsgroups = [
         EffectsGroup    // players can order EMO used on enemies

--- a/default/scripting/ship_parts/SP_EMP.focs.txt
+++ b/default/scripting/ship_parts/SP_EMP.focs.txt
@@ -2,9 +2,11 @@ Part
     name = "SP_EMP"
     description = "SP_EMP_DESC"
     class = Bombard
+    capacity = 0.5
     mountableSlotTypes = External
     buildcost = 5 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildtime = 3
+    tags = [ "CTRL_BOMBARD_ROBOTIC" ]
     location = All
     effectsgroups = [
         EffectsGroup    // players can order EMP used on enemies

--- a/default/scripting/ship_parts/SP_GRV.focs.txt
+++ b/default/scripting/ship_parts/SP_GRV.focs.txt
@@ -2,9 +2,11 @@ Part
     name = "SP_GRV"
     description = "SP_GRV_DESC"
     class = Bombard
+    capacity = 1.0
     mountableSlotTypes = External
     buildcost = 5 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildtime = 3
+    tags = [ "CTRL_BOMBARD_LITHIC" ]
     location = All
     effectsgroups = [
         EffectsGroup    // players can order graviton pulse used on enemies

--- a/default/scripting/ship_parts/SP_SONIC.focs.txt
+++ b/default/scripting/ship_parts/SP_SONIC.focs.txt
@@ -2,9 +2,11 @@ Part
     name = "SP_SONIC"
     description = "SP_SONIC_DESC"
     class = Bombard
+    capacity = 0.5
     mountableSlotTypes = External
     buildcost = 5 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildtime = 3
+    tags = [ "CTRL_BOMBARD_LITHIC" ]
     location = All
     effectsgroups = [
         EffectsGroup    // players can order sonic shockwave used on enemies

--- a/default/scripting/ship_parts/SP_VOID_SHADOW.focs.txt
+++ b/default/scripting/ship_parts/SP_VOID_SHADOW.focs.txt
@@ -2,9 +2,11 @@ Part
     name = "SP_VOID_SHADOW"
     description = "SP_VOID_SHADOW_DESC"
     class = Bombard
+    capacity = 1.0
     mountableSlotTypes = External
     buildcost = 5 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildtime = 3
+    tags = [ "CTRL_BOMBARD_PHOTOTROPHIC" ]
     location = All
     effectsgroups = [
         EffectsGroup    // players can order void shadow used on enemies


### PR DESCRIPTION
Addresses automatic selection of ships, utilizing content tags as an additional selection criteria.
Adds population reduction amounts as the capacity of bombard parts for UI display and potential AI use.

This PR does not enable bombarding to continue until canceled, as I was unable to resolve the cancel button not functioning (`Planet::IsAboutToBeBombarded` is true, despite my attempts).

Related to #672, 