### PR TITLE
Fix bug1086 resizing side panel causes crash

### DIFF
--- a/UI/AccordionPanel.cpp
+++ b/UI/AccordionPanel.cpp
@@ -96,6 +96,9 @@ void AccordionPanel::SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
 }
 
 void AccordionPanel::SetCollapsed(bool collapsed) {
+    if (collapsed == m_collapsed)
+        return;
+
     boost::filesystem::path button_texture_dir = ClientUI::ArtDir() / "icons" / "buttons";
 
     m_collapsed = collapsed;

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -607,7 +607,7 @@ private:
 
     GG::Scroll*                 m_vscroll; ///< the vertical scroll (for viewing all the planet panes)
 
-    bool                        m_ignore_recurisve_resize;
+    bool                        m_ignore_recursive_resize;
 };
 
 class RotatingPlanetControl : public GG::Control {
@@ -2266,7 +2266,7 @@ SidePanel::PlanetPanelContainer::PlanetPanelContainer() :
     m_planet_panels(),
     m_selected_planet_id(INVALID_OBJECT_ID),
     m_vscroll(new CUIScroll(GG::VERTICAL)),
-    m_ignore_recurisve_resize(false)
+    m_ignore_recursive_resize(false)
 {
     SetName("PlanetPanelContainer");
     SetChildClippingMode(ClipToClient);
@@ -2386,10 +2386,10 @@ void SidePanel::PlanetPanelContainer::SetPlanets(const std::vector<int>& planet_
 }
 
 void SidePanel::PlanetPanelContainer::DoPanelsLayout() {
-    if (m_ignore_recurisve_resize)
+    if (m_ignore_recursive_resize)
         return;
 
-    GG::ScopedAssign<bool> prevent_inifinite_recursion(m_ignore_recurisve_resize, true);
+    GG::ScopedAssign<bool> prevent_inifinite_recursion(m_ignore_recursive_resize, true);
 
     GG::Y y = GG::Y0;
     GG::X x = GG::X0;

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -606,6 +606,8 @@ private:
                                 m_valid_selection_predicate;
 
     GG::Scroll*                 m_vscroll; ///< the vertical scroll (for viewing all the planet panes)
+
+    bool                        m_ignore_recurisve_resize;
 };
 
 class RotatingPlanetControl : public GG::Control {
@@ -2263,7 +2265,8 @@ SidePanel::PlanetPanelContainer::PlanetPanelContainer() :
     Wnd(GG::X0, GG::Y0, GG::X1, GG::Y1, GG::INTERACTIVE),
     m_planet_panels(),
     m_selected_planet_id(INVALID_OBJECT_ID),
-    m_vscroll(new CUIScroll(GG::VERTICAL))
+    m_vscroll(new CUIScroll(GG::VERTICAL)),
+    m_ignore_recurisve_resize(false)
 {
     SetName("PlanetPanelContainer");
     SetChildClippingMode(ClipToClient);
@@ -2383,6 +2386,11 @@ void SidePanel::PlanetPanelContainer::SetPlanets(const std::vector<int>& planet_
 }
 
 void SidePanel::PlanetPanelContainer::DoPanelsLayout() {
+    if (m_ignore_recurisve_resize)
+        return;
+
+    GG::ScopedAssign<bool> prevent_inifinite_recursion(m_ignore_recurisve_resize, true);
+
     GG::Y y = GG::Y0;
     GG::X x = GG::X0;
 

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -845,6 +845,7 @@ SidePanel::PlanetPanel::PlanetPanel(GG::X w, int planet_id, StarType star_type) 
     GG::Connect(m_focus_drop->SelChangedSignal,     &SidePanel::PlanetPanel::FocusDropListSelectionChanged,  this);
     GG::Connect(this->FocusChangedSignal,           &SidePanel::PlanetPanel::SetFocus, this);
     m_focus_drop->MoveTo(GG::Pt(GG::X1, GG::Y1));   // force auto-resize so height is correct for subsequent layout stuff
+    m_focus_drop->Resize(GG::Pt(MeterIconSize().x*4, MeterIconSize().y*3/2 + 4));
     m_focus_drop->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
     m_focus_drop->SetStyle(GG::LIST_NOSORT | GG::LIST_SINGLESEL);
 


### PR DESCRIPTION
This PR fixes issue #1086, by preventing the stack overflow.

This section is copied from the third commit.

```Several infinitely recursive loops passing through
SidePanel::PlanetPanelContainer::DoPanelsLayout() were possible.

In one PlanetPanelContainer::DoPanelsLayout() would call
PlanetPanel::DoLayout(), which would signal ResizedSignal(), which would
call DoPanelsLayout() in an infinite loop.

A second loop passed through AccordionPanel::SetCollapsed(), which even
when the collapsed state was unchanged still signaled with the
ExpandCollapseSignal().
```

The third commit is possibly the only commit necessary to stop SidePanel having a stack overflow.

The second commit prevents AccordionPanel from doing unnecessary work and potentially causing other unnecessary work.

The first commit is required since currently SidePanel expects the unnecessary signal from AccordionPanel before it correctly sizes the focus drop down icons.