### PR TITLE
Industrious outposts minimal

### DIFF
--- a/default/scripting/buildings/AUTO_HISTORY_ANALYSER.focs.txt
+++ b/default/scripting/buildings/AUTO_HISTORY_ANALYSER.focs.txt
@@ -16,6 +16,7 @@ BuildingType
             scope = And [
                 Object id = Source.PlanetID
                 Planet
+                NOT Population high = 0
                 OwnedBy empire = Source.Owner
             ]
             priority = [[VERY_LATE_PRIORITY]]

--- a/default/scripting/buildings/CULTURE_ARCHIVES.focs.txt
+++ b/default/scripting/buildings/CULTURE_ARCHIVES.focs.txt
@@ -10,6 +10,7 @@ BuildingType
             scope = And [
                 Object id = Source.PlanetID
                 Planet
+                NOT Population high = 0
                 OwnedBy empire = Source.Owner
             ]
             priority = [[VERY_LATE_PRIORITY]]

--- a/default/scripting/buildings/CULTURE_LIBRARY.focs.txt
+++ b/default/scripting/buildings/CULTURE_LIBRARY.focs.txt
@@ -10,6 +10,7 @@ BuildingType
             scope = And [
                 Object id = Source.PlanetID
                 Planet
+                NOT Population high = 0
             ]
             priority = [[LATE_PRIORITY]]
             effects = SetTargetResearch value = Value + 5

--- a/default/scripting/specials/ECCENTRIC_ORBIT.focs.txt
+++ b/default/scripting/specials/ECCENTRIC_ORBIT.focs.txt
@@ -12,6 +12,7 @@ Special
     effectsgroups =
         EffectsGroup
             scope = Source
+            activation = NOT Population high = 0
             priority = [[LATE_PRIORITY]]
             effects = [
                 SetTargetResearch value = Value + 3

--- a/default/scripting/specials/PHILOSOPHER.focs.txt
+++ b/default/scripting/specials/PHILOSOPHER.focs.txt
@@ -35,6 +35,7 @@ Special
         EffectsGroup
             scope = And [
                 Planet
+                NOT Population high = 0
 //                Focus type = "FOCUS_RESEARCH" // Does not require focus
                 InSystem id = Source.SystemID
             ]

--- a/default/scripting/techs/learning/DISTRIB_THOUGHT.focs.txt
+++ b/default/scripting/techs/learning/DISTRIB_THOUGHT.focs.txt
@@ -11,6 +11,7 @@ Tech
             scope = And [
                 ProductionCenter
                 OwnedBy empire = Source.Owner
+                NOT Population high = 0
                 // Focus type = "FOCUS_RESEARCH"  //Does not require research Focus
             ]
             priority = [[EARLY_PRIORITY]]

--- a/default/scripting/techs/production/MICRO_MANUF.focs.txt
+++ b/default/scripting/techs/production/MICRO_MANUF.focs.txt
@@ -11,6 +11,7 @@ Tech
             scope = And [
                 ProductionCenter
                 OwnedBy empire = Source.Owner
+                NOT Population high = 0
                 ContainedBy And [
                     System 
                     Contains And [

--- a/universe/PopCenter.cpp
+++ b/universe/PopCenter.cpp
@@ -117,6 +117,11 @@ void PopCenter::PopCenterResetTargetMaxUnpairedMeters() {
 }
 
 void PopCenter::PopCenterPopGrowthProductionResearchPhase() {
+	if (m_species_name.empty()) {
+		// No changes to population or happiness
+		return;
+	}
+
     float cur_pop = CurrentMeterValue(METER_POPULATION);
     float pop_growth = NextTurnPopGrowth(); // may be negative
     float new_pop = cur_pop + pop_growth;

--- a/universe/PopCenter.cpp
+++ b/universe/PopCenter.cpp
@@ -117,10 +117,10 @@ void PopCenter::PopCenterResetTargetMaxUnpairedMeters() {
 }
 
 void PopCenter::PopCenterPopGrowthProductionResearchPhase() {
-	if (m_species_name.empty()) {
-		// No changes to population or happiness
-		return;
-	}
+    if (m_species_name.empty()) {
+        // No changes to population or happiness
+        return;
+    }
 
     float cur_pop = CurrentMeterValue(METER_POPULATION);
     float pop_growth = NextTurnPopGrowth(); // may be negative


### PR DESCRIPTION
This is a minimalistic/KISS implementation for enabling production on outposts again.

What it does:
* Add a minimal population condition for all effects which add a fixed amount to research or production regardless 
* Stop depopulating planets which are already depopulated (i.e. have no species)
 
All other effects are not important, because of one of the following reason
* effect uses a FOCUS condition
* effect already has a condition which checks if there is population (e.g. minimum population, species, if there is a good environment...)
* effect adds some multiple of population (so zero pop means zero effect)
* building is cultural archives, cultural library, automated history analyzer which probably should be destroyed on depopulation (ATM cultural archives and automated history analyzer are not)
* effect changes supply (which is the same for outposts and colonies)

I checked for research, industry and happiness effects.


