### PR TITLE
Impose limits on population-dependent research and production bonuses.

### DIFF
--- a/default/scripting/techs/learning/ALGO_ELEGANCE.focs.txt
+++ b/default/scripting/techs/learning/ALGO_ELEGANCE.focs.txt
@@ -13,7 +13,7 @@ Tech
                 Focus type = "FOCUS_RESEARCH"
             ]
             priority = [[EARLY_PRIORITY]]
-            effects = SetTargetResearch value = Value + Target.Population * 0.5 * [[RESEARCH_PER_POP]]
+            effects = SetTargetResearch value = Value + Max(6, Target.Population * 0.5 * [[RESEARCH_PER_POP]])
     ]
     graphic = "icons/tech/algorithmic_elegance.png"
 

--- a/default/scripting/techs/learning/ARTIF_MINDS.focs.txt
+++ b/default/scripting/techs/learning/ARTIF_MINDS.focs.txt
@@ -14,7 +14,7 @@ Tech
                 NOT TargetPopulation low = 0 high = 0
             ]
             priority = [[VERY_LATE_PRIORITY]]
-            effects = SetTargetResearch value = Value + 10 * [[RESEARCH_PER_POP]]
+            effects = SetTargetResearch value = Value + max(8, 10 * [[RESEARCH_PER_POP]])
     ]
     graphic = "icons/tech/basic_autolabs.png"
 

--- a/default/scripting/techs/learning/DISTRIB_THOUGHT.focs.txt
+++ b/default/scripting/techs/learning/DISTRIB_THOUGHT.focs.txt
@@ -15,7 +15,7 @@ Tech
                 // Focus type = "FOCUS_RESEARCH"  //Does not require research Focus
             ]
             priority = [[EARLY_PRIORITY]]
-            effects = SetTargetResearch value = Value + Target.Population * 0.5 * [[RESEARCH_PER_POP]]
+            effects = SetTargetResearch value = Value + Max(12, Target.Population * 0.5 * [[RESEARCH_PER_POP]])
     ]
     graphic = "icons/tech/distributed_thought.png"
 

--- a/default/scripting/techs/learning/QUANT_NET.focs.txt
+++ b/default/scripting/techs/learning/QUANT_NET.focs.txt
@@ -14,7 +14,7 @@ Tech
                 Focus type = "FOCUS_RESEARCH"
             ]
             priority = [[LATE_PRIORITY]]
-            effects = SetTargetResearch value = Value + Target.Population * 2.5 * [[RESEARCH_PER_POP]]
+            effects = SetTargetResearch value = Value + Max(12, Target.Population * 2.5 * [[RESEARCH_PER_POP]])
     ]
     graphic = "icons/tech/quantum_networking.png"
 

--- a/default/scripting/techs/learning/STELLAR_TOMOGRAPHY.focs.txt
+++ b/default/scripting/techs/learning/STELLAR_TOMOGRAPHY.focs.txt
@@ -15,7 +15,7 @@ Tech
                 Focus type = "FOCUS_RESEARCH"
             ]
             priority = [[LATE_PRIORITY]]
-            effects = SetTargetResearch value = Value + Target.Population * 5 * [[RESEARCH_PER_POP]]
+            effects = SetTargetResearch value = Value + Max(24, Target.Population * 5 * [[RESEARCH_PER_POP]])
 
         EffectsGroup
             scope = And [
@@ -25,7 +25,7 @@ Tech
                 Focus type = "FOCUS_RESEARCH"
             ]
             priority = [[LATE_PRIORITY]]
-            effects = SetTargetResearch value = Value + Target.Population * 3.75 * [[RESEARCH_PER_POP]]
+            effects = SetTargetResearch value = Value + Max(18, Target.Population * 3.75 * [[RESEARCH_PER_POP]])
 
         EffectsGroup
             scope = And [
@@ -35,7 +35,7 @@ Tech
                 Focus type = "FOCUS_RESEARCH"
             ]
             priority = [[LATE_PRIORITY]]
-            effects = SetTargetResearch value = Value + Target.Population * 2.5 * [[RESEARCH_PER_POP]]
+            effects = SetTargetResearch value = Value + Max(12, Target.Population * 2.5 * [[RESEARCH_PER_POP]])
 
         EffectsGroup
             scope = And [
@@ -45,7 +45,7 @@ Tech
                 Focus type = "FOCUS_RESEARCH"
             ]
             priority = [[LATE_PRIORITY]]
-            effects = SetTargetResearch value = Value + Target.Population * 1 * [[RESEARCH_PER_POP]]
+            effects = SetTargetResearch value = Value + Max(5, Target.Population * 1 * [[RESEARCH_PER_POP]])
     ]
     graphic = "icons/tech/stellar_tomography.png"
 

--- a/default/scripting/techs/production/FUSION_GEN.focs.txt
+++ b/default/scripting/techs/production/FUSION_GEN.focs.txt
@@ -14,7 +14,7 @@ Tech
                 Focus type = "FOCUS_INDUSTRY"
             ]
             priority = [[EARLY_PRIORITY]]
-            effects = SetTargetIndustry value = Value + Target.Population * 1.0 * [[INDUSTRY_PER_POP]]
+            effects = SetTargetIndustry value = Value + max(6, Target.Population * 1.0 * [[INDUSTRY_PER_POP]])
     ]
     graphic = "icons/tech/fusion_generation.png"
 

--- a/default/scripting/techs/production/ROBOTIC_PROD.focs.txt
+++ b/default/scripting/techs/production/ROBOTIC_PROD.focs.txt
@@ -13,7 +13,7 @@ Tech
                 Focus type = "FOCUS_INDUSTRY"
             ]
             priority = [[LATE_PRIORITY]]
-            effects = SetTargetIndustry value = Value + Target.Population * 0.5 * [[INDUSTRY_PER_POP]]
+            effects = SetTargetIndustry value = Value + max(6, Target.Population * 0.5 * [[INDUSTRY_PER_POP]])
         ]
     graphic = "icons/tech/robotic_production.png"
 


### PR DESCRIPTION
Imposes limits on the size of meter increases from various techs that have population-dependent bonuses. This means that bonuses grow with population, but only up to a point. This should reduce the range of output levels over the course of a game, and reduce the benefit of having high population planets.

The actual limits here are somewhat arbitrary and require balance consideration (along with the entire concept).