### PR TITLE
Add user doc for George communal vision

### DIFF
--- a/default/scripting/species/SP_GEORGE.focs.txt
+++ b/default/scripting/species/SP_GEORGE.focs.txt
@@ -32,17 +32,7 @@ Species
         [[LARGE_PLANET]]
         [[BROAD_EP]]
 
-        EffectsGroup
-            scope = And [
-                Planet
-                Species name = "SP_GEORGE"
-                Not OwnedBy empire = Source.Owner   // would be redundant to re-assign visbility to own planets
-            ]
-            activation = And [
-                Planet
-                Not Unowned
-            ]
-            effects = SetVisibility visibility = Full empire = Source.Owner
+        [[COMMUNAL_VISION(SP_GEORGE)]]
     ]
 
     [[TUNDRA_BROAD_EP]]

--- a/default/scripting/species/common/detection.macros
+++ b/default/scripting/species/common/detection.macros
@@ -30,3 +30,19 @@ ULTIMATE_DETECTION
             scope = Source
             effects = SetDetection value = Value + 100
 '''
+
+# param 1: species
+COMMUNAL_VISION
+'''        EffectsGroup
+            description = "COMMUNAL_VISION_DESC"
+            scope = And [
+                Planet
+                Species name = "@1@"
+                Not OwnedBy empire = Source.Owner   // would be redundant to re-assign visbility to own planets
+            ]
+            activation = And [
+                Planet
+                Not Unowned
+            ]
+            effects = SetVisibility visibility = Full empire = Source.Owner
+'''

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -6143,6 +6143,7 @@ SP_GEORGE_DESC
 
 Description:
 The units that make up George look like 2.5 meter long, 0.5 meter tall centipedes except with a far smoother skin and a cluster of about 6 tentacle/antennae at the front for manipulation. The units can't act or even think on their own. The mind of George is the sum of all the units communicating telepathically, over any distance.
+Due to their telepathic abilities, George share a communal vision with all other George in the universe, regardless of empire affiliation.
 '''
 
 SP_CRAY
@@ -12373,6 +12374,9 @@ LIGHT_SENSITIVE_DESC
 
 TELEPATHIC_DETECTION_DESC
 +	Telepathic Detection: can sense nearby populated planets.
+
+COMMUNAL_VISION_DESC
+	Communal Vision: shares visibility within the same species.
 
 
 ##

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -4486,7 +4486,9 @@ Detection Range
 DETECTION_RANGE_TEXT
 '''The Detection Range represents the distance in uu that sensors can reach. An empire can only see objects that have a [[encyclopedia STEALTH_TITLE]] value lower than or equal to its [[encyclopedia DETECTION_TITLE]] and are within Detection Range of a controlled space ship or planet.
 
-Space ships and planets have a Detection Range meter. There is the option to display Detection Range circles (in uu) in the Galaxy Map section of the Options menu.  To facilitate predictions of what would be within a Detection Range, there are also options to display a standard 'Map Scale Line' as well as a 'Map Scale Circle' centered on the currently selected system and indicating the same distance as the Map Scale Line.  They are both responsive to the the map zoom level and can be toggled via hotkeys.'''
+Space ships and planets have a Detection Range meter. There is the option to display Detection Range circles (in uu) in the Galaxy Map section of the Options menu.  To facilitate predictions of what would be within a Detection Range, there are also options to display a standard 'Map Scale Line' as well as a 'Map Scale Circle' centered on the currently selected system and indicating the same distance as the Map Scale Line.  They are both responsive to the the map zoom level and can be toggled via hotkeys.
+
+Some objects or abilities may allow vision of certain areas outside of this range.  Some examples are from species abilities of [[species SP_TRITH]] or [[species SP_GEORGE]], or from the effects from a [[buildingtype BLD_SCRYING_SPHERE]].'''
 
 TROOP_TITLE
 Troops


### PR DESCRIPTION
George were granted communal vision in commit 7cbe2822
Currently no pedia entry mentions this feature, leading to the appearance of faulty behavior e.g. [forum post](http://www.freeorion.org/forum/viewtopic.php?f=28&t=10315)

PR adds some descriptive entries to the George and the Detection Range articles to help mitigate confusion such features may cause.