### PR TITLE
Fix combat log to not report targeted fighters as Unknown objects.

### DIFF
--- a/combat/CombatEvents.h
+++ b/combat/CombatEvents.h
@@ -179,8 +179,15 @@ struct FO_COMMON_API WeaponFireEvent : public CombatEvent {
     typedef boost::shared_ptr<const WeaponFireEvent> ConstWeaponFireEventPtr;
 
     WeaponFireEvent();
-    WeaponFireEvent(int bout, int round, int attacker_id, int target_id, const std::string &weapon_name
-                    , float power_, float shield_, float damage_, int attacker_owner_id_);
+
+    /** WeaponFireEvent encodes a single attack in \p bout, \p round by \p
+        attacker_id owned by \p attacker_owner_id on \p target_id with \p
+        weapon_name of \p power against \p shield doing \p damage.
+
+        If \p shield is negative that implies the weapon is shield piercing.
+     */
+    WeaponFireEvent(int bout, int round, int attacker_id, int target_id, const std::string &weapon_name,
+                    float power_, float shield_, float damage_, int attacker_owner_id_, int target_owner_id_);
 
     virtual ~WeaponFireEvent() {}
 
@@ -200,6 +207,7 @@ struct FO_COMMON_API WeaponFireEvent : public CombatEvent {
     float   shield;
     float   damage;
     int     attacker_owner_id;
+    int     target_owner_id;
 
 private:
     friend class boost::serialization::access;
@@ -286,7 +294,7 @@ struct FO_COMMON_API WeaponsPlatformEvent : public CombatEvent {
 
     virtual ~WeaponsPlatformEvent() {}
 
-    void AddEvent(int round, int target_id, std::string const & weapon_name_,
+    void AddEvent(int round, int target_id, int target_owner_id_, std::string const & weapon_name_,
                   float power_, float shield_, float damage_);
 
     virtual std::string DebugString() const;

--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -351,7 +351,7 @@ namespace {
                 DebugLogger() << "COMBAT: Ship " << attacker->Name() << " (" << attacker->ID() << ") does " << damage << " damage to Ship " << target->Name() << " (" << target->ID() << ")";
         }
 
-        combat_event->AddEvent(round, target->ID(), weapon.part_type_name, power, shield, damage);
+        combat_event->AddEvent(round, target->ID(), target->Owner(), weapon.part_type_name, power, shield, damage);
 
         attacker->SetLastTurnActiveInCombat(CurrentTurn());
         target->SetLastTurnActiveInCombat(CurrentTurn());
@@ -428,7 +428,7 @@ namespace {
 
         //TODO report the planet damage details more clearly
         float total_damage = shield_damage + defense_damage + construction_damage;
-        combat_event->AddEvent(round, target->ID(), weapon.part_type_name, power, 0.0f, total_damage);
+        combat_event->AddEvent(round, target->ID(), target->Owner(), weapon.part_type_name, power, 0.0f, total_damage);
 
         attacker->SetLastTurnActiveInCombat(CurrentTurn());
         target->SetLastTurnAttackedByShip(CurrentTurn());
@@ -445,10 +445,7 @@ namespace {
             // any damage is enough to kill any fighter
             target->SetDestroyed();
         }
-        combat_event->AddEvent(round, target->ID(), weapon.part_type_name, power, 0.0f, 1.0f);
-        CombatEventPtr attack_event = boost::make_shared<FighterAttackedEvent>(
-            bout, round, attacker->ID(), attacker->Owner(), target->Owner());
-        attacks_event->AddEvent(attack_event);
+        combat_event->AddEvent(round, target->ID(), target->Owner(), weapon.part_type_name, power, 0.0f, 1.0f);
         attacker->SetLastTurnActiveInCombat(CurrentTurn());
     }
 
@@ -490,7 +487,7 @@ namespace {
                 DebugLogger() << "COMBAT: Planet " << attacker->Name() << " (" << attacker->ID() << ") does " << damage << " damage to Ship " << target->Name() << " (" << target->ID() << ")";
         }
 
-        combat_event->AddEvent(round, target->ID(), weapon.part_type_name, power, shield, damage);
+        combat_event->AddEvent(round, target->ID(), target->Owner(), weapon.part_type_name, power, shield, damage);
 
         target->SetLastTurnActiveInCombat(CurrentTurn());
     }
@@ -512,10 +509,7 @@ namespace {
             target->SetDestroyed();
         }
 
-        combat_event->AddEvent(round, target->ID(), weapon.part_type_name, power, 0.0f, 1.0f);
-        CombatEventPtr attack_event = boost::make_shared<FighterAttackedEvent>(
-            bout, round, attacker->ID(), attacker->Owner(), target->Owner());
-        attacks_event->AddEvent(attack_event);
+        combat_event->AddEvent(round, target->ID(), target->Owner(), weapon.part_type_name, power, 0.0f, 1.0f);
     }
 
     void AttackFighterShip(TemporaryPtr<Fighter> attacker, const PartAttackInfo& weapon, TemporaryPtr<Ship> target,
@@ -554,7 +548,8 @@ namespace {
         }
 
         CombatEventPtr attack_event = boost::make_shared<WeaponFireEvent>(
-            bout, round, attacker->ID(), target->ID(), weapon.part_type_name, power, shield, damage, attacker->Owner());
+            bout, round, attacker->ID(), target->ID(), weapon.part_type_name, power, -1.0f, damage,
+            attacker->Owner(), target->Owner());
         attacks_event->AddEvent(attack_event);
         target->SetLastTurnActiveInCombat(CurrentTurn());
     }


### PR DESCRIPTION
Fighters were being reported as unknown because they have a temporary
negative ID.  They are the only objects with temporary IDs.

This commit adds the empire associated with targeted objects to the data
stored in a weapon fire event so that temporary ids are reported as
Fighter and not Unknown.

This is part of ongoing fixes/improvments related to the Fighters branch, #1073 and #587. 