### PR TITLE
Add pierced description for combat log

### DIFF
--- a/combat/CombatEvents.cpp
+++ b/combat/CombatEvents.cpp
@@ -646,11 +646,18 @@ std::string WeaponFireEvent::CombatLogDescription(int viewing_empire_id) const {
 std::string WeaponFireEvent::CombatLogDetails(int viewing_empire_id) const {
     const std::string& template_str = UserString("ENC_COMBAT_ATTACK_DETAILS");
 
-    return str(FlexibleFormat(template_str)
-               % ShipPartLink(weapon_name)
-               % power
-               % shield
-               % damage);
+    if (shield >= 0)
+        return str(FlexibleFormat(template_str)
+                   % ShipPartLink(weapon_name)
+                   % power
+                   % shield
+                   % damage);
+    else
+        return str(FlexibleFormat(template_str)
+                   % ShipPartLink(weapon_name)
+                   % power
+                   % UserString("ENC_COMBAT_SHIELD_PIERCED")
+                   % damage);
 }
 
 boost::optional<int> WeaponFireEvent::PrincipalFaction(int viewing_empire_id) const {

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -4109,6 +4109,9 @@ ENC_COMBAT_ATTACK_STR
 ENC_COMBAT_ATTACK_DETAILS
 Weapon: %1%  Strength: %2%  Shields: %3%  Damage: %4%
 
+ENC_COMBAT_SHIELD_PIERCED
+pierced
+
 # %1% link to the attacking unit or empire.
 # %2% name of the unit attacked.
 ENC_COMBAT_ATTACK_SIMPLE_STR


### PR DESCRIPTION
This PR changes the combat log description for fighter attacks so that the shield strength is reported as `pierced`.  This makes the fighter shield piercing ability more visible/discoverable.