### PR TITLE
Do not show tree in TechTreeWnd Constructor when game is not started.

### DIFF
--- a/UI/ResearchWnd.cpp
+++ b/UI/ResearchWnd.cpp
@@ -343,7 +343,7 @@ private:
 //////////////////////////////////////////////////
 // ResearchWnd                                  //
 //////////////////////////////////////////////////
-ResearchWnd::ResearchWnd(GG::X w, GG::Y h) :
+ResearchWnd::ResearchWnd(GG::X w, GG::Y h, bool initially_hidden /*= true*/) :
     GG::Wnd(GG::X0, GG::Y0, w, h, GG::INTERACTIVE | GG::ONTOP),
     m_research_info_panel(0),
     m_queue_wnd(0),
@@ -357,7 +357,7 @@ ResearchWnd::ResearchWnd(GG::X w, GG::Y h) :
     m_research_info_panel = new ProductionInfoPanel(UserString("RESEARCH_WND_TITLE"), UserString("RESEARCH_INFO_RP"),
                                                     GG::X0, GG::Y0, GG::X(queue_width), GG::Y(100), "research.InfoPanel");
     m_queue_wnd = new ResearchQueueWnd(GG::X0, GG::Y(100), queue_width, GG::Y(ClientSize().y - 100));
-    m_tech_tree_wnd = new TechTreeWnd(tech_tree_wnd_size.x, tech_tree_wnd_size.y);
+    m_tech_tree_wnd = new TechTreeWnd(tech_tree_wnd_size.x, tech_tree_wnd_size.y, initially_hidden);
 
     GG::Connect(m_queue_wnd->GetQueueListBox()->QueueItemMovedSignal,   &ResearchWnd::QueueItemMoved,               this);
     GG::Connect(m_queue_wnd->GetQueueListBox()->QueueItemDeletedSignal, &ResearchWnd::DeleteQueueItem,              this);

--- a/UI/ResearchWnd.h
+++ b/UI/ResearchWnd.h
@@ -13,7 +13,7 @@ class ResearchQueueWnd;
 class ResearchWnd : public GG::Wnd {
 public:
     /** \name Structors */ //@{
-    ResearchWnd(GG::X w, GG::Y h);
+    ResearchWnd(GG::X w, GG::Y h, bool initially_hidden = true);
     ~ResearchWnd();
     //@}
 

--- a/UI/TechTreeWnd.cpp
+++ b/UI/TechTreeWnd.cpp
@@ -1903,7 +1903,7 @@ void TechTreeWnd::TechListBox::TechDoubleClicked(GG::ListBox::iterator it, const
 //////////////////////////////////////////////////
 // TechTreeWnd                                  //
 //////////////////////////////////////////////////
-TechTreeWnd::TechTreeWnd(GG::X w, GG::Y h) :
+TechTreeWnd::TechTreeWnd(GG::X w, GG::Y h, bool initially_hidden /*= true*/) :
     GG::Wnd(GG::X0, GG::Y0, w, h, GG::INTERACTIVE),
     m_tech_tree_controls(0),
     m_enc_detail_panel(0),
@@ -1959,11 +1959,16 @@ TechTreeWnd::TechTreeWnd(GG::X w, GG::Y h) :
     // connect view type selector
     GG::Connect(m_tech_tree_controls->m_view_type_button->CheckedSignal, &TechTreeWnd::ToggleViewType, this);
 
-    ShowAllCategories();
-    ShowStatus(TS_RESEARCHABLE);
-    ShowStatus(TS_HAS_RESEARCHED_PREREQ);
-    ShowStatus(TS_COMPLETE);
-    // leave unresearchable hidden by default
+    //TechTreeWnd in typically constructed before theUI client has
+    //accesss to the technologies so showing these categories takes a
+    //long time and generates errors, but is never seen by the user.
+    if (!initially_hidden) {
+        ShowAllCategories();
+        ShowStatus(TS_RESEARCHABLE);
+        ShowStatus(TS_HAS_RESEARCHED_PREREQ);
+        ShowStatus(TS_COMPLETE);
+        // leave unresearchable hidden by default
+    }
 
     ShowTreeView();
 }

--- a/UI/TechTreeWnd.h
+++ b/UI/TechTreeWnd.h
@@ -20,7 +20,10 @@ public:
     typedef boost::signals2::signal<void (const std::vector<std::string>&, int)>    QueueAddTechsSignalType;
 
     /** \name Structors */ //@{
-    TechTreeWnd(GG::X w, GG::Y h);
+    /** TechTreeWnd contructor is usually called before client has
+        access to techs.  Attempting to show the tech tree takes a long
+        time and generates errors.*/
+    TechTreeWnd(GG::X w, GG::Y h, bool initially_hidden = true);
     ~TechTreeWnd();
     //@}
 


### PR DESCRIPTION
This PR speeds up game startup.

When the ClientUI is initialized (before game creation) the TechTreeWnd
in created and immediately hidden.  Because the game has not been
created yet this generates several errors and takes a long time.  

The errors are the same ones that were recently removed by [ Tweaked research cost and time functions to prevent unnecessary debug…](https://github.com/freeorion/freeorion/commit/da2db7eb1a19a9b926ff35fb7bd6afaa9ef69e3f), which reminded me I had this sitting around.  I was afraid if I didn't see the errors every time I checked the logs, I'd forget about this commit.

The speed up still applies.  

This commit defaults the TechTreeWnd constructor to not show the tree.

