### PR TITLE
Fix bugs #1106 and 1107, WeaponFireEvent doesn't work with boost::shared_ptr.

### DIFF
--- a/combat/CombatEvents.cpp
+++ b/combat/CombatEvents.cpp
@@ -608,19 +608,20 @@ WeaponFireEvent::WeaponFireEvent() :
 {}
 
 WeaponFireEvent::WeaponFireEvent(
-    int bout_, int round_, int attacker_id_, int target_id_, const std::string &weapon_name_,
-    float power_, float shield_, float damage_, int attacker_owner_id_, int target_owner_id_) :
+    int bout_, int round_, int attacker_id_, int target_id_, const std::string& weapon_name_,
+    const boost::tuple<float, float, float>& power_shield_damage,
+    int attacker_owner_id_, int target_owner_id_) :
     bout(bout_),
     round(round_),
     attacker_id(attacker_id_),
     target_id( target_id_),
     weapon_name(weapon_name_),
-    power(power_),
-    shield(shield_),
-    damage(damage_),
+    power(),
+    shield(),
+    damage(),
     attacker_owner_id(attacker_owner_id_),
     target_owner_id(target_owner_id_)
-{ }
+{ boost::tie(power, shield, damage) = power_shield_damage; }
 
 std::string WeaponFireEvent::DebugString() const {
     std::stringstream ss;
@@ -940,7 +941,8 @@ void WeaponsPlatformEvent::AddEvent(
     float power_, float shield_, float damage_) {
     events[target_id_].push_back(
         boost::make_shared<WeaponFireEvent>(
-            bout, round_, attacker_id, target_id_, weapon_name_, power_, shield_, damage_,
+            bout, round_, attacker_id, target_id_, weapon_name_,
+            boost::tie(power_, shield_, damage_),
             attacker_owner_id, target_owner_id_));
 }
 

--- a/combat/CombatEvents.h
+++ b/combat/CombatEvents.h
@@ -2,6 +2,7 @@
 #define COMBATEVENTS_H
 
 #include <set>
+#include <boost/tuple/tuple.hpp>
 #include <boost/shared_ptr.hpp>
 #include <boost/serialization/access.hpp>
 #include <boost/serialization/export.hpp>
@@ -185,9 +186,13 @@ struct FO_COMMON_API WeaponFireEvent : public CombatEvent {
         weapon_name of \p power against \p shield doing \p damage.
 
         If \p shield is negative that implies the weapon is shield piercing.
+
+        The use of tuple in the constructor is to keep the number of parameters below 10 which
+        is the maximum that some compilers that emulate variadic templates support.
      */
     WeaponFireEvent(int bout, int round, int attacker_id, int target_id, const std::string &weapon_name,
-                    float power_, float shield_, float damage_, int attacker_owner_id_, int target_owner_id_);
+                    const boost::tuple<float, float, float> &power_shield_damage,
+                    int attacker_owner_id_, int target_owner_id_);
 
     virtual ~WeaponFireEvent() {}
 

--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -547,8 +547,10 @@ namespace {
                 DebugLogger() << "COMBAT: Fighter of empire " << attacker->Owner() << " (" << attacker->ID() << ") does " << damage << " damage to Ship " << target->Name() << " (" << target->ID() << ")";
         }
 
+        float pierced_shield_value(-1.0);
         CombatEventPtr attack_event = boost::make_shared<WeaponFireEvent>(
-            bout, round, attacker->ID(), target->ID(), weapon.part_type_name, power, -1.0f, damage,
+            bout, round, attacker->ID(), target->ID(), weapon.part_type_name,
+            boost::tie(power, pierced_shield_value, damage),
             attacker->Owner(), target->Owner());
         attacks_event->AddEvent(attack_event);
         target->SetLastTurnActiveInCombat(CurrentTurn());


### PR DESCRIPTION
The WeaponFireEvent constructor has 10 parameters.
    
boost::make_shared<T> uses templates with variadic parameters to create
the shared pointer with T constructor.
    
Some compilers only emulate variadic templates and consequently don't
support boost::make_shared<T> with constructors with more than 9
parameters.
    
This commit uses boost::tuple to reduce the number of parameters in the
WeaponFireEvent constructor below 10.

This hopefully fixes issues #1106 and #1107.

I apologize for breaking the build.