### PR TITLE
Partial fix of bug #1093 sidepanel flicker.

### DIFF
--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -385,6 +385,7 @@ DropDownList::iterator DropDownList::Insert(Row* row, iterator it, bool signal/*
     row->SetDragDropDataType("");
     DropDownList::iterator ret = LB()->Insert(row, it, signal);
     Resize(Size());
+    RequirePreRender();
     return ret;
 }
 
@@ -393,6 +394,7 @@ DropDownList::iterator DropDownList::Insert(Row* row, bool signal/* = true*/)
     row->SetDragDropDataType("");
     DropDownList::iterator ret = LB()->Insert(row, signal);
     Resize(Size());
+    RequirePreRender();
     return ret;
 }
 
@@ -403,6 +405,7 @@ void DropDownList::Insert(const std::vector<Row*>& rows, iterator it, bool signa
     { (*rows_it)->SetDragDropDataType(""); }
     LB()->Insert(rows, it, signal);
     Resize(Size());
+    RequirePreRender();
 }
 
 void DropDownList::Insert(const std::vector<Row*>& rows, bool signal/* = true*/)
@@ -412,6 +415,7 @@ void DropDownList::Insert(const std::vector<Row*>& rows, bool signal/* = true*/)
     { (*rows_it)->SetDragDropDataType(""); }
     LB()->Insert(rows, signal);
     Resize(Size());
+    RequirePreRender();
 }
 
 DropDownList::Row* DropDownList::Erase(iterator it, bool signal/* = false*/)

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -370,9 +370,7 @@ void DropDownList::RenderDisplayedRow()
             GUI::GetGUI()->PreRenderWindow(LB());
             LB()->Hide();
         }
-
         current_item->Show();
-        GUI::GetGUI()->PreRenderWindow(current_item);
     }
 
     // Vertically center the selected row in the box.
@@ -380,11 +378,14 @@ void DropDownList::RenderDisplayedRow()
                        Top() + Height() / 2 - (current_item->Top() + current_item->Height() / 2));
     current_item->OffsetMove(offset);
 
+    GUI::GetGUI()->PreRenderWindow(current_item);
+
     BeginClipping();
     GUI::GetGUI()->RenderWindow(current_item);
     EndClipping();
 
     current_item->OffsetMove(-offset);
+
     if (!sel_visible)
         current_item->Hide();
 }

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -108,6 +108,11 @@ ModalListPicker::ModalListPicker(Clr color, const Wnd* relative_to_wnd) :
 
     if (INSTRUMENT_ALL_SIGNALS)
         Connect(SelChangedSignal, ModalListPickerSelChangedEcho(*this));
+
+    if (m_relative_to_wnd)
+        m_lb_wnd->MoveTo(Pt(m_relative_to_wnd->Left(), m_relative_to_wnd->Bottom()));
+
+    m_lb_wnd->Hide();
 }
 
 void ModalListPicker::LClick(const Pt& pt, Flags<ModKey> mod_keys)
@@ -117,6 +122,7 @@ void ModalListPicker::ModalInit()
 {
     if (m_relative_to_wnd)
         m_lb_wnd->MoveTo(Pt(m_relative_to_wnd->Left(), m_relative_to_wnd->Bottom()));
+
     Show();
 }
 

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -154,7 +154,11 @@ DropDownList::DropDownList(size_t num_shown_elements, Clr color) :
     if (INSTRUMENT_ALL_SIGNALS)
         Connect(SelChangedSignal, DropDownListSelChangedEcho(*this));
 
+    // InitBuffer here prevents a crash if DropDownList is constructed in
+    // the prerender phase.
     InitBuffer();
+
+    RequirePreRender();
 }
 
 DropDownList::~DropDownList() {
@@ -267,6 +271,8 @@ void DropDownList::PreRender()
 {
     GG::Control::PreRender();
 
+    InitBuffer();
+
     // reset size of displayed drop list based on number of shown rows set.
     // assumes that all rows have the same height.
     // adds some magic padding for now to prevent the scroll bars showing up.
@@ -373,7 +379,6 @@ void DropDownList::SizeMove(const Pt& ul, const Pt& lr)
     Wnd::SizeMove(ul, lr);
 
     if (sz != Size()) {
-        InitBuffer();
         RequirePreRender();
     }
 }

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -276,14 +276,31 @@ void DropDownList::PreRender()
     // reset size of displayed drop list based on number of shown rows set.
     // assumes that all rows have the same height.
     // adds some magic padding for now to prevent the scroll bars showing up.
+
+    bool lb_visible = LB()->Visible();
+    if (!lb_visible)
+        LB()->Show();
+
+    LB()->MoveTo(Pt(Left(), Bottom()));
+
     Pt drop_down_size(ClientWidth(), ClientHeight());
-    if (LB()->NumRows() > 0)
-        drop_down_size.y = LB()->GetRow(0).Height() * std::min<int>(m_num_shown_elements, LB()->NumRows()) + 4;
 
-    LB()->Resize(drop_down_size);
-
-    if (LB()->Visible())
+    if (LB()->Empty()) {
+        LB()->Resize(drop_down_size);
+    } else {
+        // Resize the rows, once to pick up the correct height and a second
+        // time to use the height to size the drop down list
+        drop_down_size.y = (*LB()->FirstRowShown())->Height() * std::min<int>(m_num_shown_elements, LB()->NumRows()) + 4;
+        LB()->Resize(drop_down_size);
         GUI::GetGUI()->PreRenderWindow(LB());
+
+        drop_down_size.y = (*LB()->FirstRowShown())->Height() * std::min<int>(m_num_shown_elements, LB()->NumRows()) + 4;
+        LB()->Resize(drop_down_size);
+        GUI::GetGUI()->PreRenderWindow(LB());
+    }
+
+    if (!lb_visible)
+        LB()->Hide();
 }
 
 void DropDownList::Render()

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -265,6 +265,7 @@ void DropDownList::InitBuffer()
 
 void DropDownList::PreRender()
 {
+    GG::Control::PreRender();
 
     // reset size of displayed drop list based on number of shown rows set.
     // assumes that all rows have the same height.

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -392,12 +392,13 @@ void DropDownList::RenderDisplayedRow()
 void DropDownList::SizeMove(const Pt& ul, const Pt& lr)
 {
     // adjust size to keep correct height based on row height, etc.
-    GG::Pt sz = Size();
+    GG::Pt old_ul = RelativeUpperLeft();
+    GG::Pt old_lr = RelativeLowerRight();
+
     Wnd::SizeMove(ul, lr);
 
-    if (sz != Size()) {
+    if ((old_ul != RelativeUpperLeft()) || (old_lr != RelativeLowerRight()))
         RequirePreRender();
-    }
 }
 
 void DropDownList::SetColor(Clr c)

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -2969,33 +2969,30 @@ void SidePanel::RefreshImpl() {
 
 
     // populate droplist of system names
+    std::map<std::string, int> system_map; //alphabetize Systems here
+    for (ObjectMap::const_iterator<System> sys_it = Objects().const_begin<System>();
+         sys_it != Objects().const_end<System>(); ++sys_it)
     {
-        ScopedTimer droplist_population_timer("SidePanel::RefreshImpl droplist population", true);
-        std::map<std::string, int> system_map; //alphabetize Systems here
-        for (ObjectMap::const_iterator<System> sys_it = Objects().const_begin<System>();
-             sys_it != Objects().const_end<System>(); ++sys_it)
-        {
-            if (!sys_it->Name().empty() || sys_it->ID() == s_system_id) // skip rows for systems that aren't known to this client, except the selected system
-                system_map.insert(std::make_pair(sys_it->Name(), sys_it->ID()));
-        }
-        std::vector<GG::DropDownList::Row*> rows;
-        rows.reserve(system_map.size());
-        for (std::map< std::string, int>::iterator sys_it = system_map.begin(); sys_it != system_map.end(); ++sys_it)
-        {
-            int sys_id = sys_it->second;
-            rows.push_back(new SystemRow(sys_id));
-        }
-        m_system_name->Insert(rows, false);
+        if (!sys_it->Name().empty() || sys_it->ID() == s_system_id) // skip rows for systems that aren't known to this client, except the selected system
+            system_map.insert(std::make_pair(sys_it->Name(), sys_it->ID()));
+    }
+    std::vector<GG::DropDownList::Row*> rows;
+    rows.reserve(system_map.size());
+    for (std::map< std::string, int>::iterator sys_it = system_map.begin(); sys_it != system_map.end(); ++sys_it)
+    {
+        int sys_id = sys_it->second;
+        rows.push_back(new SystemRow(sys_id));
+    }
+    m_system_name->Insert(rows, false);
 
-        // select in the list the currently-selected system
-        for (GG::DropDownList::iterator it = m_system_name->begin();
-             it != m_system_name->end(); ++it)
-        {
-            if (const SystemRow* row = dynamic_cast<const SystemRow*>(*it)) {
-                if (s_system_id == row->SystemID()) {
-                    m_system_name->Select(it);
-                    break;
-                }
+    // select in the list the currently-selected system
+    for (GG::DropDownList::iterator it = m_system_name->begin();
+         it != m_system_name->end(); ++it)
+    {
+        if (const SystemRow* row = dynamic_cast<const SystemRow*>(*it)) {
+            if (s_system_id == row->SystemID()) {
+                m_system_name->Select(it);
+                break;
             }
         }
     }

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -2034,7 +2034,7 @@ void SidePanel::PlanetPanel::MouseWheel(const GG::Pt& pt, int move, GG::Flags<GG
 { ForwardEventToParent(); }
 
 void SidePanel::PlanetPanel::PreRender() {
-    GG::Wnd::PreRender();
+    GG::Control::PreRender();
     DoLayout();
 }
 
@@ -2846,7 +2846,7 @@ void SidePanel::InitBuffers() {
 }
 
 void SidePanel::PreRender() {
-    GG::Wnd::PreRender();
+    CUIWnd::PreRender();
 
     // Needs refresh updates all data related to all SizePanels, including system list etc.
     if (s_needs_refresh) {

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -2498,7 +2498,7 @@ void SidePanel::PlanetPanelContainer::SetPlanets(const std::vector<int>& planet_
         GG::Connect(m_planet_panels.back()->LeftDoubleClickedSignal,    PlanetLeftDoubleClickedSignal);
         GG::Connect(m_planet_panels.back()->RightClickedSignal,         PlanetRightClickedSignal);
         GG::Connect(m_planet_panels.back()->BuildingRightClickedSignal, BuildingRightClickedSignal);
-        GG::Connect(m_planet_panels.back()->ResizedSignal,              &SidePanel::PlanetPanelContainer::DoPanelsLayout,       this);
+        GG::Connect(m_planet_panels.back()->ResizedSignal,              &SidePanel::PlanetPanelContainer::RequirePreRender,       this);
     }
 
     // disable non-selectable planet panels
@@ -2509,6 +2509,8 @@ void SidePanel::PlanetPanelContainer::SetPlanets(const std::vector<int>& planet_
     RefreshAllPlanetPanels();
 
     SelectPlanet(initial_selected_planet_panel);
+
+    RequirePreRender();
 }
 
 void SidePanel::PlanetPanelContainer::DoPanelsLayout() {
@@ -2660,7 +2662,7 @@ void SidePanel::PlanetPanelContainer::VScroll(int pos_top, int pos_bottom, int r
         pos_top -= extra;
     }
 
-    DoPanelsLayout();
+    RequirePreRender();
 }
 
 void SidePanel::PlanetPanelContainer::RefreshAllPlanetPanels() {
@@ -2669,7 +2671,7 @@ void SidePanel::PlanetPanelContainer::RefreshAllPlanetPanels() {
 }
 
 void SidePanel::PlanetPanelContainer::ShowScrollbar()
-{ DoPanelsLayout(); }
+{ RequirePreRender(); }
 
 void SidePanel::PlanetPanelContainer::HideScrollbar()
 { DetachChild(m_vscroll); }
@@ -2680,7 +2682,7 @@ void SidePanel::PlanetPanelContainer::SizeMove(const GG::Pt& ul, const GG::Pt& l
     GG::Wnd::SizeMove(ul, lr);
 
     if (old_size != GG::Wnd::Size())
-        DoLayout();
+        RequirePreRender();
 }
 
 void SidePanel::PlanetPanelContainer::EnableOrderIssuing(bool enable/* = true*/) {

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -572,6 +572,7 @@ public:
     void            SetValidSelectionPredicate(const boost::shared_ptr<UniverseObjectVisitor> &visitor);
     void            ScrollTo(int pos);
 
+    virtual void    PreRender();
     void            RefreshAllPlanetPanels();           //!< updates data displayed in info panels and redoes layout
 
     virtual void    ShowScrollbar();
@@ -2564,6 +2565,11 @@ void SidePanel::PlanetPanelContainer::DoPanelsLayout() {
     unsigned int page_size = Value(available_height);
     int scroll_max = Value(used_height);
     m_vscroll->SizeScroll(0, scroll_max, line_size, page_size);
+}
+
+void SidePanel::PlanetPanelContainer::PreRender() {
+    GG::Wnd::PreRender();
+    DoLayout();
 }
 
 void SidePanel::PlanetPanelContainer::DoLayout() {

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -2775,6 +2775,8 @@ SidePanel::SidePanel(const std::string& config_name) :
     SetMinSize(GG::Pt(GG::X(MaxPlanetDiameter() + BORDER_LEFT + BORDER_RIGHT + 120),
                       PLANET_PANEL_TOP + GG::Y(MaxPlanetDiameter())));
 
+    s_needs_refresh = true;
+    s_needs_update  = true;
     RequirePreRender();
     Hide();
 

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -899,19 +899,19 @@ SidePanel::PlanetPanel::PlanetPanel(GG::X w, int planet_id, StarType star_type) 
     // meter panels
     m_population_panel = new PopulationPanel(panel_width, m_planet_id);
     AttachChild(m_population_panel);
-    GG::Connect(m_population_panel->ExpandCollapseSignal,       &SidePanel::PlanetPanel::DoLayout, this);
+    GG::Connect(m_population_panel->ExpandCollapseSignal,       &SidePanel::PlanetPanel::RequirePreRender, this);
 
     m_resource_panel = new ResourcePanel(panel_width, m_planet_id);
     AttachChild(m_resource_panel);
-    GG::Connect(m_resource_panel->ExpandCollapseSignal,         &SidePanel::PlanetPanel::DoLayout, this);
+    GG::Connect(m_resource_panel->ExpandCollapseSignal,         &SidePanel::PlanetPanel::RequirePreRender, this);
 
     m_military_panel = new MilitaryPanel(panel_width, m_planet_id);
     AttachChild(m_military_panel);
-    GG::Connect(m_military_panel->ExpandCollapseSignal,         &SidePanel::PlanetPanel::DoLayout, this);
+    GG::Connect(m_military_panel->ExpandCollapseSignal,         &SidePanel::PlanetPanel::RequirePreRender, this);
 
     m_buildings_panel = new BuildingsPanel(panel_width, 4, m_planet_id);
     AttachChild(m_buildings_panel);
-    GG::Connect(m_buildings_panel->ExpandCollapseSignal,        &SidePanel::PlanetPanel::DoLayout, this);
+    GG::Connect(m_buildings_panel->ExpandCollapseSignal,        &SidePanel::PlanetPanel::RequirePreRender, this);
     GG::Connect(m_buildings_panel->BuildingRightClickedSignal,  BuildingRightClickedSignal);
 
     m_specials_panel = new SpecialsPanel(panel_width, m_planet_id);
@@ -934,6 +934,8 @@ SidePanel::PlanetPanel::PlanetPanel(GG::X w, int planet_id, StarType star_type) 
     SetChildClippingMode(ClipToWindow);
 
     Refresh();
+
+    RequirePreRender();
 }
 
 SidePanel::PlanetPanel::~PlanetPanel() {
@@ -1469,7 +1471,7 @@ void SidePanel::PlanetPanel::Refresh() {
         DetachChild(m_specials_panel);
         delete m_specials_panel;        m_specials_panel = 0;
 
-        DoLayout();
+        RequirePreRender();
         return;
     }
 
@@ -2395,7 +2397,7 @@ SidePanel::PlanetPanelContainer::PlanetPanelContainer() :
     SetName("PlanetPanelContainer");
     SetChildClippingMode(ClipToClient);
     GG::Connect(m_vscroll->ScrolledSignal, &SidePanel::PlanetPanelContainer::VScroll, this);
-    DoLayout();
+    RequirePreRender();
 }
 
 SidePanel::PlanetPanelContainer::~PlanetPanelContainer()

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -3150,6 +3150,14 @@ void SidePanel::DoLayout() {
     lr = GG::Pt(ClientWidth() - 1, ClientHeight() - GG::Y(INNER_BORDER_ANGLE_OFFSET));
     m_planet_panel_container->SizeMove(ul, lr);
 
+    // Force system name, system summary and planet panel container to prerender
+    // immediately.  All three may have had data that affects layout, change
+    // after the PreRender() phase started, so they will not have been pre-rendered.  The
+    // SidePanel layout and rendering is slow enough that this appears as a visible glitch.
+    GG::GUI::PreRenderWindow(m_system_name);
+    GG::GUI::PreRenderWindow(m_system_resource_summary);
+    GG::GUI::PreRenderWindow(m_planet_panel_container);
+
     // hide scrollbar if there is no planets in the system
     TemporaryPtr<const System> system = GetSystem(s_system_id);
     if (system) {

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -2879,6 +2879,12 @@ void SidePanel::InitBuffers() {
 void SidePanel::PreRender() {
     CUIWnd::PreRender();
 
+    // save initial scroll position so it can be restored after repopulating the planet panel container
+    const int initial_scroll_pos = m_planet_panel_container->ScrollPosition();
+
+    // save initial selected planet so it can be restored
+    const int initial_selected_planet_id = m_planet_panel_container->SelectedPlanetID();
+
     // Needs refresh updates all data related to all SizePanels, including system list etc.
     if (s_needs_refresh)
         RefreshInPreRender();
@@ -2891,6 +2897,15 @@ void SidePanel::PreRender() {
 
     // On a resize only DoLayout should be called.
     DoLayout();
+
+    if (s_needs_refresh || s_needs_update) {
+        // restore planet panel container scroll position from before clearing
+        m_planet_panel_container->ScrollTo(initial_scroll_pos);
+
+        // restore planet selection
+        m_planet_panel_container->SelectPlanet(initial_selected_planet_id);
+    }
+
     s_needs_refresh = false;
     s_needs_update  = false;
 }
@@ -2969,13 +2984,6 @@ void SidePanel::RefreshInPreRender() {
 void SidePanel::RefreshImpl() {
     ScopedTimer sidepanel_refresh_impl_timer("SidePanel::RefreshImpl", true);
     Sound::TempUISoundDisabler sound_disabler;
-
-    // save initial scroll position so it can be restored after repopulating the planet panel container
-    const int initial_scroll_pos = m_planet_panel_container->ScrollPosition();
-
-    // save initial selected planet so it can be restored
-    const int initial_selected_planet_id = m_planet_panel_container->SelectedPlanetID();
-
 
     // clear out current contents
     m_planet_panel_container->Clear();
@@ -3106,14 +3114,6 @@ void SidePanel::RefreshImpl() {
         AttachChild(m_system_resource_summary);
         m_system_resource_summary->Update();
     }
-
-    DoLayout();
-
-    // restore planet panel container scroll position from before clearing
-    m_planet_panel_container->ScrollTo(initial_scroll_pos);
-
-    // restore planet selection
-    m_planet_panel_container->SelectPlanet(initial_selected_planet_id);
 }
 
 void SidePanel::DoLayout() {

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -2880,26 +2880,19 @@ void SidePanel::PreRender() {
     CUIWnd::PreRender();
 
     // Needs refresh updates all data related to all SizePanels, including system list etc.
-    if (s_needs_refresh) {
-        s_needs_refresh = false;
-        s_needs_update = false;
-
-        // Note: RefreshInPreRender() also calls DoLayout(), but it also stores and restores the
-        // scroll bar and planet selection.
+    if (s_needs_refresh)
         RefreshInPreRender();
-        return;
-    }
 
     // Update updates the data for each planet tab in all SidePanels
     if (s_needs_update) {
-        s_needs_update = false;
-
         for (std::set<SidePanel*>::iterator it = s_side_panels.begin(); it != s_side_panels.end(); ++it)
             (*it)->UpdateImpl();
     }
 
     // On a resize only DoLayout should be called.
     DoLayout();
+    s_needs_refresh = false;
+    s_needs_update  = false;
 }
 
 void SidePanel::Update() {

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -36,6 +36,7 @@
 #include "../util/ScopedTimer.h"
 #include "../client/human/HumanClientApp.h"
 
+#include <GG/GUI.h>
 #include <GG/Layout.h>
 #include <GG/DrawUtil.h>
 #include <GG/StaticGraphic.h>
@@ -2552,7 +2553,14 @@ void SidePanel::PlanetPanelContainer::DoPanelsLayout() {
         GG::Pt panel_ul(x, y);
         GG::Pt panel_lr(Width() - scroll_width, y + PANEL_HEIGHT);
         panel->SizeMove(panel_ul, panel_lr);
-        y += PANEL_HEIGHT + EDGE_PAD;
+
+        // Force planet panel container to render.  Since planet panel rendering
+        // is slow its absence is visible as a glitch.
+        GG::GUI::PreRenderWindow(panel);
+        y += panel->Height() + EDGE_PAD;
+
+        if (panel->Height() != PANEL_HEIGHT)
+            ErrorLogger() << "Panel height is " << panel->Height() << " not " << PANEL_HEIGHT << " as expected";
     }
 
     // hide scrollbar if all panels are visible and fit into the available height


### PR DESCRIPTION
This PR mostly fixes issue #1093 of sidepanel flicker during updates.

The flicker was caused by the side panel, system name, system resource indicator, planet panel container and accordion panels all having `PreRender()` function that update during the prerender phase.  However, the sidepanel re-creates or triggers data updates of the layouts of its child panels during its `PreRender()`.  These children then update their layout during the **next** prerender phase.  Since the sidepanel layout is slow, 10s of ms on my machine this delay is very visible.

This PR fixes the problem by calling `GG::GUI::PreRenderWindow()` on the system name, system resource indicator and the planet panel container after those children are modified so that they immediately execute their `PreRender()` functions.

I did not fix the glitch with the accordion panels, because it looks like a larger fix that will spill over into the combat log, so I will work on it separately.