### PR TITLE
Add DropDownList keypress while list is dropped.

### DIFF
--- a/GG/GG/DropDownList.h
+++ b/GG/GG/DropDownList.h
@@ -64,6 +64,9 @@ public:
     /** emitted when a new item is selected; will be end() when no item is
       * selected */
     typedef boost::signals2::signal<void (iterator)>   SelChangedSignalType;
+
+    /** Signal \a true when drop down opens and false when it closes.*/
+    typedef boost::signals2::signal<void (bool)>       DropDownOpenedSignalType;
     //@}
 
     /** \name Structors */ ///@{
@@ -116,6 +119,8 @@ public:
     virtual GG::X  DisplayedRowWidth() const;
 
     mutable SelChangedSignalType SelChangedSignal; ///< the selection change signal object for this DropDownList
+
+    DropDownOpenedSignalType DropDownOpenedSignal;
     //@}
 
     /** \name Mutators */ ///@{

--- a/GG/GG/DropDownList.h
+++ b/GG/GG/DropDownList.h
@@ -212,7 +212,6 @@ protected:
     //@}
 
 private:
-    void            SelectImpl(iterator it, bool signal);
     const ListBox*  LB() const;
 
     ModalListPicker*    m_modal_picker;

--- a/GG/GG/DropDownList.h
+++ b/GG/GG/DropDownList.h
@@ -91,6 +91,7 @@ public:
     Clr             InteriorColor() const;          ///< returns the color painted into the client area of the control
 
     Y               DropHeight() const; ///< returns the height of the drop-down list
+    bool            Dropped() const;                ///< Return true if the drop down list is open.
 
     /** Returns the style flags of the list \see GG::ListBoxStyle */
     Flags<ListBoxStyle> Style() const;

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -510,7 +510,9 @@ void DropDownList::LClick(const Pt& pt, Flags<ModKey> mod_keys)
     }
     LB()->m_first_col_shown = 0;
 
+    DropDownOpenedSignal(true);
     m_modal_picker->Run();
+    DropDownOpenedSignal(false);
 }
 
 void DropDownList::KeyPress(Key key, boost::uint32_t key_code_point, Flags<ModKey> mod_keys)

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -60,7 +60,8 @@ public:
 
     DropDownList::iterator CurrentItem();
 
-    /** Select \p it  in m_lb_wnd is not none and return the new selected or none if no change.*/
+    /** If \p it is not none then select \p it in the LB().  Return the newly selected iterator or none if
+        the selection did not change.*/
     boost::optional<DropDownList::iterator> Select(boost::optional<DropDownList::iterator> it);
 
     /** Call SelChangedSignal if \p it is not none. */

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -220,6 +220,12 @@ boost::optional<DropDownList::iterator> ModalListPicker::KeyPressCommon(
         if (LB()->NumRows() && !LB()->Empty())
             return --LB()->end();
         break;
+    case GGK_RETURN:
+    case GGK_KP_ENTER:
+    case GGK_ESCAPE:
+        EndRun();
+        return boost::none;
+        break;
     default:
         return boost::none;
     }

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -42,6 +42,8 @@ public:
 
     ModalListPicker(Clr color, const Wnd* relative_to_wnd);
 
+    virtual bool   Run();
+    bool           Dropped() const;
     virtual void LClick(const Pt& pt, Flags<ModKey> mod_keys);
     virtual void ModalInit();
 
@@ -60,6 +62,7 @@ private:
 
     ListBox*    m_lb_wnd;
     const Wnd*  m_relative_to_wnd;
+    bool m_dropped;  ///< Is the drop down list open.
 };
 
 namespace {
@@ -100,7 +103,8 @@ namespace {
 ModalListPicker::ModalListPicker(Clr color, const Wnd* relative_to_wnd) :
     Wnd(X0, Y0, GUI::GetGUI()->AppWidth(), GUI::GetGUI()->AppHeight(), INTERACTIVE | MODAL),
     m_lb_wnd(GetStyleFactory()->NewDropDownListListBox(color, color)),
-    m_relative_to_wnd(relative_to_wnd)
+    m_relative_to_wnd(relative_to_wnd),
+    m_dropped(false)
 {
     Connect(m_lb_wnd->SelChangedSignal,     &ModalListPicker::LBSelChangedSlot, this);
     Connect(m_lb_wnd->LeftClickedSignal,    &ModalListPicker::LBLeftClickSlot,  this);
@@ -109,6 +113,17 @@ ModalListPicker::ModalListPicker(Clr color, const Wnd* relative_to_wnd) :
     if (INSTRUMENT_ALL_SIGNALS)
         Connect(SelChangedSignal, ModalListPickerSelChangedEcho(*this));
 }
+
+
+bool ModalListPicker::Run() {
+    m_dropped = true;
+    bool retval = Wnd::Run();
+    m_dropped = false;
+    return retval;
+}
+
+bool ModalListPicker::Dropped() const
+{ return m_dropped; }
 
 void ModalListPicker::LClick(const Pt& pt, Flags<ModKey> mod_keys)
 { EndRun(); }
@@ -203,6 +218,9 @@ bool DropDownList::Selected(std::size_t n) const
 
 Clr DropDownList::InteriorColor() const
 { return LB()->InteriorColor(); }
+
+bool DropDownList::Dropped() const
+{ return m_modal_picker->Dropped(); }
 
 Y DropDownList::DropHeight() const
 { return LB()->Height(); }

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -111,7 +111,7 @@ ModalListPicker::ModalListPicker(Clr color, const Wnd* relative_to_wnd) :
 }
 
 void ModalListPicker::LClick(const Pt& pt, Flags<ModKey> mod_keys)
-{ m_done = true; }
+{ EndRun(); }
 
 void ModalListPicker::ModalInit()
 {
@@ -129,13 +129,13 @@ void ModalListPicker::LBSelChangedSlot(const ListBox::SelectionSet& rows)
         ListBox::iterator sel_it = *rows.begin();
         SelChangedSignal(sel_it);
     }
-    m_done = true;
+    EndRun();
 }
 
 void ModalListPicker::LBLeftClickSlot(ListBox::iterator it, const GG::Pt& pt, const GG::Flags<GG::ModKey>& modkeys)
 {
     Hide();
-    m_done = true;
+    EndRun();
 }
 
 

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -521,6 +521,8 @@ private:
     void                    ClickBombard();                     ///< called if bombard button is pressed
 
     void                    FocusDropListSelectionChanged(GG::DropDownList::iterator selected); ///< called when droplist selection changes, emits FocusChangedSignal
+    /** Called when focus drop list opens/closes to inform that it now \p is_open. */
+    void                    FocusDropListOpened(bool is_open);
 
     int                     m_planet_id;                ///< id for the planet with is represented by this planet panel
     GG::TextControl*        m_planet_name;              ///< planet name
@@ -871,6 +873,7 @@ SidePanel::PlanetPanel::PlanetPanel(GG::X w, int planet_id, StarType star_type) 
     // focus-selection droplist
     m_focus_drop = new CUIDropDownList(6);
     AttachChild(m_focus_drop);
+    GG::Connect(m_focus_drop->DropDownOpenedSignal, &SidePanel::PlanetPanel::FocusDropListOpened,  this);
     GG::Connect(m_focus_drop->SelChangedSignal,     &SidePanel::PlanetPanel::FocusDropListSelectionChanged,  this);
     GG::Connect(this->FocusChangedSignal,           &SidePanel::PlanetPanel::SetFocus, this);
     m_focus_drop->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
@@ -2319,7 +2322,20 @@ void SidePanel::PlanetPanel::ClickBombard() {
     }
 }
 
+void SidePanel::PlanetPanel::FocusDropListOpened(bool is_open) {
+    // Update when the focus drop closes.
+    if (is_open)
+        return;
+
+    FocusDropListSelectionChanged(m_focus_drop->CurrentItem());
+}
+
 void SidePanel::PlanetPanel::FocusDropListSelectionChanged(GG::DropDownList::iterator selected) {
+    // Do not update the sidepanel while the focus drop is open.  Otherwise scrolling with the key
+    // press does not work because every up/down arrow press deletes and recreates the m_focus_drop.
+    if (m_focus_drop->Dropped())
+        return;
+
     // all this funciton needs to do is emit FocusChangedSignal.  The code
     // preceeding that determines which focus was selected from the iterator
     // parameter, does some safety checks, and disables UI sounds


### PR DESCRIPTION
This PR partially addresses issue #969 "Focus dropdown list box gets clipped when it doesn't fit in the window", by refactoring DropDownList to allow key presses to work while the drop down list is open.  It was the easiest of the suggestions that @Vezzra made to make work.

It refactors behavior that was already present when the drop down was closed, and moves it into the drop down so that it can also run when the drop down is both closed and open.