### PR TITLE
Add fleetwnd near to system title

### DIFF
--- a/GG/GG/PtRect.h
+++ b/GG/GG/PtRect.h
@@ -30,6 +30,7 @@
 
 #include <GG/Base.h>
 #include <GG/StrongTypedef.h>
+#include <boost/functional/hash.hpp>
 
 
 namespace GG {
@@ -147,6 +148,23 @@ GG_API inline Rect operator+(const Pt& pt, const Rect& rect) { return rect + pt;
 GG_API inline Rect operator-(const Pt& pt, const Rect& rect) { return rect - pt; } ///< returns \a rect shifted by subtracting \a pt from each corner
 
 GG_API std::ostream& operator<<(std::ostream& os, const Rect& rect); ///< Rect stream-output operator for debug output
+
+    // Hash functions
+    // Replace with C++11 equilvalent when converted to C++11
+    GG_API inline std::size_t hash_value(X const& x) { return boost::hash<int>()(Value(x)); }
+    GG_API inline std::size_t hash_value(Y const& y) { return boost::hash<int>()(Value(y)); }
+    GG_API inline std::size_t hash_value(Pt const& pt) {
+        std::size_t seed(0);
+        boost::hash_combine(seed, pt.x);
+        boost::hash_combine(seed, pt.y);
+        return seed;
+    }
+    GG_API inline std::size_t hash_value(Rect const& r) {
+        std::size_t seed(0);
+        boost::hash_combine(seed, r.ul);
+        boost::hash_combine(seed, r.lr);
+        return seed;
+    }
 
 } // namepace GG
 

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -3017,7 +3017,7 @@ void FleetWnd::SetStatIconValues() {
     {
         TemporaryPtr<const Fleet> fleet = *fleet_it;
 
-        if ( !(m_empire_id == ALL_EMPIRES || fleet->OwnedBy(m_empire_id)) )
+        if ( !(((m_empire_id == ALL_EMPIRES) && (fleet->Unowned())) || fleet->OwnedBy(m_empire_id)) )
             continue;
 
         std::vector<TemporaryPtr<const Ship> > ships = Objects().FindObjects<const Ship>(fleet->ShipIDs());
@@ -3112,7 +3112,7 @@ void FleetWnd::Refresh() {
                 this_client_stale_object_info.find(fleet_id) != this_client_stale_object_info.end())
             { continue; }
 
-            if (m_empire_id == ALL_EMPIRES || fleet->OwnedBy(m_empire_id)) {
+            if ( ((m_empire_id == ALL_EMPIRES) && (fleet->Unowned())) || fleet->OwnedBy(m_empire_id) ) {
                 m_fleet_ids.insert(fleet_id);
                 AddFleet(fleet_id);
             }

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -2850,6 +2850,11 @@ FleetWnd::FleetWnd(const std::vector<int>& fleet_ids, bool order_issuing_enabled
     m_fleet_detail_panel(0),
     m_stat_icons()
 {
+    if (!fleet_ids.empty()) {
+        if (TemporaryPtr<const Fleet> fleet = GetFleet(*fleet_ids.begin()))
+            m_empire_id = fleet->Owner();
+    }
+
     for (std::vector<int>::const_iterator it = fleet_ids.begin(); it != fleet_ids.end(); ++it)
         m_fleet_ids.insert(*it);
     Init(selected_fleet_id);

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -536,29 +536,6 @@ FleetWnd* FleetUIManager::NewFleetWnd(const std::vector<int>& fleet_ids,
     return retval;
 }
 
-FleetWnd* FleetUIManager::NewFleetWnd(int system_id, int empire_id,
-                                      int selected_fleet_id/* = INVALID_OBJECT_ID*/,
-                                      GG::Flags<GG::WndFlag> flags/* = GG::INTERACTIVE | GG::DRAGABLE | GG::ONTOP | CLOSABLE | GG::RESIZABLE*/)
-{
-    std::string config_name = "";
-    if (!GetOptionsDB().Get<bool>("UI.multiple-fleet-windows")) {
-        CloseAll();
-        // Only write to OptionsDB if in single fleet window mode.
-        config_name = FLEET_WND_NAME;
-    }
-    FleetWnd* retval = new FleetWnd(system_id, empire_id, m_order_issuing_enabled, selected_fleet_id, flags, config_name);
-
-    m_fleet_wnds.insert(retval);
-    GG::Connect(retval->ClosingSignal,              &FleetUIManager::FleetWndClosing,           this);
-    GG::Connect(retval->ClickedSignal,              &FleetUIManager::FleetWndClicked,           this);
-    GG::Connect(retval->FleetRightClickedSignal,    FleetRightClickedSignal);
-    GG::Connect(retval->ShipRightClickedSignal,     ShipRightClickedSignal);
-
-    GG::GUI::GetGUI()->Register(retval);
-
-    return retval;
-}
-
 void FleetUIManager::CullEmptyWnds() {
     // scan through FleetWnds, deleting those that have no fleets
     for (std::set<FleetWnd*>::iterator it = m_fleet_wnds.begin(); it != m_fleet_wnds.end(); ) {
@@ -2842,7 +2819,7 @@ FleetWnd::FleetWnd(const std::vector<int>& fleet_ids, bool order_issuing_enabled
          int selected_fleet_id/* = INVALID_OBJECT_ID*/,
          GG::Flags<GG::WndFlag> flags/* = INTERACTIVE | DRAGABLE | ONTOP | CLOSABLE | RESIZABLE*/,
          const std::string& config_name) :
-    MapWndPopup("", flags, config_name),
+    MapWndPopup("", flags | GG::RESIZABLE, config_name),
     m_fleet_ids(),
     m_empire_id(ALL_EMPIRES),
     m_system_id(INVALID_OBJECT_ID),
@@ -2861,21 +2838,6 @@ FleetWnd::FleetWnd(const std::vector<int>& fleet_ids, bool order_issuing_enabled
         m_fleet_ids.insert(*it);
     Init(selected_fleet_id);
 }
-
-FleetWnd::FleetWnd(int system_id, int empire_id, bool order_issuing_enabled,
-         int selected_fleet_id/* = INVALID_OBJECT_ID*/,
-         GG::Flags<GG::WndFlag> flags/* = INTERACTIVE | DRAGABLE | ONTOP | CLOSABLE | RESIZABLE*/,
-         const std::string& config_name) :
-    MapWndPopup("", flags | GG::RESIZABLE, config_name),
-    m_fleet_ids(),
-    m_empire_id(empire_id),
-    m_system_id(system_id),
-    m_order_issuing_enabled(order_issuing_enabled),
-    m_fleets_lb(0),
-    m_new_fleet_drop_target(0),
-    m_fleet_detail_panel(0),
-    m_stat_icons()
-{ Init(selected_fleet_id); }
 
 FleetWnd::~FleetWnd() {
     ClientUI::GetClientUI()->GetMapWnd()->ClearProjectedFleetMovementLines();

--- a/UI/FleetWnd.h
+++ b/UI/FleetWnd.h
@@ -45,10 +45,6 @@ public:
                                 int selected_fleet_id = INVALID_OBJECT_ID,
                                 GG::Flags<GG::WndFlag> flags = GG::INTERACTIVE | GG::DRAGABLE | GG::ONTOP | CLOSABLE | GG::RESIZABLE);
 
-    FleetWnd*       NewFleetWnd(int system_id, int empire_id,
-                                int selected_fleet_id = INVALID_OBJECT_ID,
-                                GG::Flags<GG::WndFlag> flags = GG::INTERACTIVE | GG::DRAGABLE | GG::ONTOP | CLOSABLE | GG::RESIZABLE);
-
     void            CullEmptyWnds();
     void            SetActiveFleetWnd(FleetWnd* fleet_wnd);
     bool            CloseAll();
@@ -135,11 +131,6 @@ protected:
 private:
     /** \name Structors */ //@{
     FleetWnd(const std::vector<int>& fleet_ids, bool order_issuing_enabled,
-             int selected_fleet_id = INVALID_OBJECT_ID,
-             GG::Flags<GG::WndFlag> flags = GG::INTERACTIVE | GG::DRAGABLE | GG::ONTOP | CLOSABLE | GG::RESIZABLE,
-             const std::string& config_name = "");
-
-    FleetWnd(int system_id, int empire_id, bool order_issuing_enabled,
              int selected_fleet_id = INVALID_OBJECT_ID,
              GG::Flags<GG::WndFlag> flags = GG::INTERACTIVE | GG::DRAGABLE | GG::ONTOP | CLOSABLE | GG::RESIZABLE,
              const std::string& config_name = "");

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -4001,24 +4001,15 @@ void MapWnd::SelectFleet(TemporaryPtr<Fleet> fleet) {
 
     // if there isn't a FleetWnd for this fleet open, need to open one
     if (!fleet_wnd) {
-        //std::cout << "SelectFleet couldn't find fleetwnd for fleet " << std::endl;
-        TemporaryPtr<System> system = GetSystem(fleet->SystemID());
-
-        // create fleetwnd to show fleet to be selected (actual selection occurs below).
-        if (system) {
-            fleet_wnd = manager.NewFleetWnd(system->ID(), fleet->Owner());
-        } else {
-            // get all (moving) fleets represented by fleet button for this fleet
-            boost::unordered_map<int, FleetButton*>::iterator it = m_fleet_buttons.find(fleet->ID());
-            if (it == m_fleet_buttons.end()) {
-                ErrorLogger() << "Couldn't find a FleetButton for fleet in MapWnd::SelectFleet";
-                return;
-            }
-            const std::vector<int>& wnd_fleet_ids = it->second->Fleets();
-            // create new fleetwnd in which to show selected fleet
-            fleet_wnd = manager.NewFleetWnd(wnd_fleet_ids);
+        // get all (moving) fleets represented by fleet button for this fleet
+        boost::unordered_map<int, FleetButton*>::iterator it = m_fleet_buttons.find(fleet->ID());
+        if (it == m_fleet_buttons.end()) {
+            ErrorLogger() << "Couldn't find a FleetButton for fleet in MapWnd::SelectFleet";
+            return;
         }
-
+        const std::vector<int>& wnd_fleet_ids = it->second->Fleets();
+        // create new fleetwnd in which to show selected fleet
+        fleet_wnd = manager.NewFleetWnd(wnd_fleet_ids);
 
         // opened a new FleetWnd, so play sound
         FleetButton::PlayFleetButtonOpenSound();

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -3101,6 +3101,11 @@ FW_NEW_FLEET_LABEL
 FW_EMPIRE_FLEETS_AT_SYSTEM
 %1% Fleets At %2%
 
+# %1% empire, which owns the fleets.
+# %2% system where those fleets hold.
+FW_EMPIRE_FLEETS_NEAR_SYSTEM
+%1% Fleets Near %2%
+
 # Fleet window title
 # %1% empire, which owns the fleets.
 FW_EMPIRE_FLEETS
@@ -3114,6 +3119,11 @@ No Fleet
 # %1% system where those fleets hold.
 FW_GENERIC_FLEETS_AT_SYSTEM
 Fleets At %1%
+
+# Fleet window title
+# %1% system where those fleets hold.
+FW_GENERIC_FLEETS_NEAR_SYSTEM
+Fleets Near %1%
 
 # Fleet window title
 FW_GENERIC_FLEETS


### PR DESCRIPTION
This implements #786 'Label Fleets Window as "near System X"'.

Most of the work was fixing the ability to correctly track the location of fleet in the fleet window and their owners.  The commit message of the fourth commit explains the relevant logic and I have copied it below.

Add a FleetWnd title that indicates near system X exposes the following
subtle bug in FleetWnd.  When a FleetWnd is created for a travelling
fleet and the fleet arrives at a system the FleetWnd still displays the
fleet and still thinks that it is travelling.

This commit fixes the bug by changing the tracking behavior to the
following.

Are all fleets in one location?  Use that location.

Otherwise, are all selected fleets in one location?  Use that location
and remove fleets not at that location.

Otherwise, is the current location a system?  Use that location and add
appropriate fleets at that system.

Otherwise remove all fleets as all fleets have gone in separate
directions.
