### PR TITLE
Add TechTreeWnd::Show() to fix bug with deferred tech parsing in TechTreeWnd

### DIFF
--- a/UI/TechTreeWnd.cpp
+++ b/UI/TechTreeWnd.cpp
@@ -1908,7 +1908,8 @@ TechTreeWnd::TechTreeWnd(GG::X w, GG::Y h, bool initially_hidden /*= true*/) :
     m_tech_tree_controls(0),
     m_enc_detail_panel(0),
     m_layout_panel(0),
-    m_tech_list(0)
+    m_tech_list(0),
+    m_initially_hide_tree(initially_hidden)
 {
     Sound::TempUISoundDisabler sound_disabler;
 
@@ -1959,10 +1960,10 @@ TechTreeWnd::TechTreeWnd(GG::X w, GG::Y h, bool initially_hidden /*= true*/) :
     // connect view type selector
     GG::Connect(m_tech_tree_controls->m_view_type_button->CheckedSignal, &TechTreeWnd::ToggleViewType, this);
 
-    //TechTreeWnd in typically constructed before theUI client has
+    //TechTreeWnd in typically constructed before the UI client has
     //accesss to the technologies so showing these categories takes a
     //long time and generates errors, but is never seen by the user.
-    if (!initially_hidden) {
+    if (!m_initially_hide_tree) {
         ShowAllCategories();
         ShowStatus(TS_RESEARCHABLE);
         ShowStatus(TS_HAS_RESEARCHED_PREREQ);
@@ -2024,6 +2025,22 @@ void TechTreeWnd::InitializeWindows() {
 
     m_enc_detail_panel->InitSizeMove(pedia_ul,  pedia_ul + pedia_wh);
     m_tech_tree_controls->InitSizeMove(controls_ul,  controls_ul + controls_wh);
+}
+
+void TechTreeWnd::Show(bool children) {
+    GG::Wnd::Show(children);
+
+    // When Show() is called for TechTree the ClientUI should now have
+    // access to the technologies so that parsing does not generate
+    // errors.
+    if (m_initially_hide_tree) {
+        m_initially_hide_tree = false;
+        ShowAllCategories();
+        ShowStatus(TS_RESEARCHABLE);
+        ShowStatus(TS_HAS_RESEARCHED_PREREQ);
+        ShowStatus(TS_COMPLETE);
+        // leave unresearchable hidden by default
+    }
 }
 
 void TechTreeWnd::ShowCategory(const std::string& category) {

--- a/UI/TechTreeWnd.cpp
+++ b/UI/TechTreeWnd.cpp
@@ -1909,7 +1909,7 @@ TechTreeWnd::TechTreeWnd(GG::X w, GG::Y h, bool initially_hidden /*= true*/) :
     m_enc_detail_panel(0),
     m_layout_panel(0),
     m_tech_list(0),
-    m_initially_hide_tree(initially_hidden)
+    m_init_flag(initially_hidden)
 {
     Sound::TempUISoundDisabler sound_disabler;
 
@@ -1963,7 +1963,7 @@ TechTreeWnd::TechTreeWnd(GG::X w, GG::Y h, bool initially_hidden /*= true*/) :
     //TechTreeWnd in typically constructed before the UI client has
     //accesss to the technologies so showing these categories takes a
     //long time and generates errors, but is never seen by the user.
-    if (!m_initially_hide_tree) {
+    if (!m_init_flag) {
         ShowAllCategories();
         ShowStatus(TS_RESEARCHABLE);
         ShowStatus(TS_HAS_RESEARCHED_PREREQ);
@@ -2033,8 +2033,8 @@ void TechTreeWnd::Show(bool children) {
     // When Show() is called for TechTree the ClientUI should now have
     // access to the technologies so that parsing does not generate
     // errors.
-    if (m_initially_hide_tree) {
-        m_initially_hide_tree = false;
+    if (m_init_flag) {
+        m_init_flag = false;
         ShowAllCategories();
         ShowStatus(TS_RESEARCHABLE);
         ShowStatus(TS_HAS_RESEARCHED_PREREQ);

--- a/UI/TechTreeWnd.h
+++ b/UI/TechTreeWnd.h
@@ -41,6 +41,7 @@ public:
     void            Reset();
     void            SetScale(double scale);
 
+    virtual void    Show(bool children = true);
     void            ShowCategory(const std::string& category);
     void            ShowAllCategories();
     void            HideCategory(const std::string& category);
@@ -87,6 +88,7 @@ private:
     EncyclopediaDetailPanel*    m_enc_detail_panel;
     LayoutPanel*                m_layout_panel;
     TechListBox*                m_tech_list;
+    bool                        m_initially_hide_tree;
 };
 
 #endif // _TechTreeWnd_h_

--- a/UI/TechTreeWnd.h
+++ b/UI/TechTreeWnd.h
@@ -22,7 +22,9 @@ public:
     /** \name Structors */ //@{
     /** TechTreeWnd contructor is usually called before client has
         access to techs.  Attempting to show the tech tree takes a long
-        time and generates errors.*/
+        time and generates errors.  If \p initially_hidden is true then the
+        tech categories are not parsed until the first time Show() is
+        called, speeding up the constructor and preventing spurious errors.*/
     TechTreeWnd(GG::X w, GG::Y h, bool initially_hidden = true);
     ~TechTreeWnd();
     //@}
@@ -88,7 +90,11 @@ private:
     EncyclopediaDetailPanel*    m_enc_detail_panel;
     LayoutPanel*                m_layout_panel;
     TechListBox*                m_tech_list;
-    bool                        m_initially_hide_tree;
+
+    /// If m_init_flag is true tech categories are not parsed until the
+    /// first time Show() is called.  TechTreeWnd is constructed before the
+    /// tech categories are available to be parsed.
+    bool                        m_init_flag;
 };
 
 #endif // _TechTreeWnd_h_


### PR DESCRIPTION
The TechTreeWnd parsing was deferred until the client could access the
technologies, but was never intentionally activated.

This commit creates a Show() function that checks if the parsing was
deferred and parses the techs the first time that show is called.

@dbenage-cx pointed this bug with #1103 out in issue #1117.