### PR TITLE
Fix production wnd does not track sidepanel.

### DIFF
--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -1006,8 +1006,8 @@ BuildDesignatorWnd::BuildDesignatorWnd(GG::X w, GG::Y h) :
     GG::Connect(m_build_selector->ShowPediaSignal,        &BuildDesignatorWnd::ShowPedia,          this);
     GG::Connect(m_build_selector->RequestBuildItemSignal, &BuildDesignatorWnd::BuildItemRequested, this);
 
-    GG::Connect(m_side_panel->PlanetSelectedSignal, PlanetSelectedSignal);
-    GG::Connect(m_side_panel->SystemSelectedSignal, SystemSelectedSignal);
+    GG::Connect(SidePanel::PlanetSelectedSignal, PlanetSelectedSignal);
+    GG::Connect(SidePanel::SystemSelectedSignal, SystemSelectedSignal);
 
     // connect build type button clicks to update display
     GG::Connect(m_build_selector->m_build_type_buttons[BT_BUILDING]->CheckedSignal, boost::bind(&BuildDesignatorWnd::ToggleType, this, BT_BUILDING, true));

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -4832,6 +4832,7 @@ void MapWnd::PlanetDoubleClicked(int planet_id) {
             ToggleProduction();
         CenterOnObject(planet->SystemID());
         m_production_wnd->SelectSystem(planet->SystemID());
+        m_production_wnd->SelectPlanet(planet_id);
     }
 }
 

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -2473,7 +2473,6 @@ void SidePanel::PlanetPanelContainer::ScrollTo(int pos) {
 void SidePanel::PlanetPanelContainer::Clear() {
     m_planet_panels.clear();
     m_selected_planet_id = INVALID_OBJECT_ID;
-    PlanetSelectedSignal(m_selected_planet_id);
     DetachChild(m_vscroll);
     DeleteChildren();
     AttachChild(m_vscroll);

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -3332,6 +3332,13 @@ void SidePanel::SelectPlanetImpl(int planet_id) {
 void SidePanel::SetSystem(int system_id) {
     if (s_system_id == system_id)
         return;
+
+    TemporaryPtr<const System> system = GetSystem(system_id);
+    if (!system) {
+        s_system_id = INVALID_OBJECT_ID;
+        return;
+    }
+
     s_system_id = system_id;
 
     if (GetSystem(s_system_id))

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -2900,9 +2900,6 @@ void SidePanel::PreRender() {
     // save initial scroll position so it can be restored after repopulating the planet panel container
     const int initial_scroll_pos = m_planet_panel_container->ScrollPosition();
 
-    // save initial selected planet so it can be restored
-    const int initial_selected_planet_id = m_planet_panel_container->SelectedPlanetID();
-
     // Needs refresh updates all data related to all SizePanels, including system list etc.
     if (s_needs_refresh)
         RefreshInPreRender();
@@ -2916,13 +2913,12 @@ void SidePanel::PreRender() {
     // On a resize only DoLayout should be called.
     DoLayout();
 
-    if (s_needs_refresh || s_needs_update) {
-        // restore planet panel container scroll position from before clearing
+    // restore planet panel container scroll position from before clearing
+    if (s_needs_refresh || s_needs_update)
         m_planet_panel_container->ScrollTo(initial_scroll_pos);
 
-        // restore planet selection
-        m_planet_panel_container->SelectPlanet(initial_selected_planet_id);
-    }
+    // restore planet selection
+    m_planet_panel_container->SelectPlanet(s_planet_id);
 
     s_needs_refresh = false;
     s_needs_update  = false;

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -3259,12 +3259,8 @@ void SidePanel::FleetStateChanged()
 int SidePanel::SystemID()
 { return s_system_id; }
 
-int SidePanel::SelectedPlanetID() const {
-    if (m_planet_panel_container)
-        return m_planet_panel_container->SelectedPlanetID();
-    else
-        return INVALID_OBJECT_ID;
-}
+int SidePanel::SelectedPlanetID() const
+{ return (m_selection_enabled ? s_planet_id : INVALID_OBJECT_ID); }
 
 bool SidePanel::PlanetSelectable(int planet_id) const {
     if (!m_selection_enabled)

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -3310,14 +3310,9 @@ void SidePanel::SelectPlanet(int planet_id) {
     s_planet_id = planet_id;
 
     for (std::set<SidePanel*>::iterator it = s_side_panels.begin(); it != s_side_panels.end(); ++it)
-        (*it)->SelectPlanetImpl(planet_id);
+        (*it)->RequirePreRender();
 
     PlanetSelectedSignal(s_planet_id);
-}
-
-void SidePanel::SelectPlanetImpl(int planet_id) {
-    //std::cout << "SidePanel::SelectPlanetImpl(" << planet_id << ")" << std::endl;
-    m_planet_panel_container->SelectPlanet(planet_id);
 }
 
 void SidePanel::SetSystem(int system_id) {

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -588,7 +588,7 @@ public:
     //@}
 
     /** emitted when an enabled planet panel is clicked by the user */
-    mutable boost::signals2::signal<void (int)> PlanetSelectedSignal;
+    mutable boost::signals2::signal<void (int)> PlanetClickedSignal;
 
     /** emitted when a planet panel is left-double-clicked*/
     mutable boost::signals2::signal<void (int)> PlanetLeftDoubleClickedSignal;
@@ -601,7 +601,6 @@ public:
 private:
     void            DisableNonSelectionCandidates();    //!< disables planet panels that aren't selection candidates
 
-    void            PlanetLeftClicked(int planet_id);   //!< responds to user clicking a planet panel.  emits PlanetSelectedSignal
     void            DoPanelsLayout();                   //!< repositions PlanetPanels, without moving top panel.  Panels below may shift if ones above them have resized.
     void            DoLayout();
 
@@ -2510,7 +2509,7 @@ void SidePanel::PlanetPanelContainer::SetPlanets(const std::vector<int>& planet_
         PlanetPanel* planet_panel = new PlanetPanel(Width() - m_vscroll->Width(), it->second, star_type);
         AttachChild(planet_panel);
         m_planet_panels.push_back(planet_panel);
-        GG::Connect(m_planet_panels.back()->LeftClickedSignal,          &SidePanel::PlanetPanelContainer::PlanetLeftClicked,   this);
+        GG::Connect(m_planet_panels.back()->LeftClickedSignal,          PlanetClickedSignal);
         GG::Connect(m_planet_panels.back()->LeftDoubleClickedSignal,    PlanetLeftDoubleClickedSignal);
         GG::Connect(m_planet_panels.back()->RightClickedSignal,         PlanetRightClickedSignal);
         GG::Connect(m_planet_panels.back()->BuildingRightClickedSignal, BuildingRightClickedSignal);
@@ -2673,11 +2672,6 @@ void SidePanel::PlanetPanelContainer::DisableNonSelectionCandidates() {
     }
 }
 
-void SidePanel::PlanetPanelContainer::PlanetLeftClicked(int planet_id) {
-    //DebugLogger() << "SidePanel::PlanetPanelContainer::PlanetLeftClicked(" << planet_id << ")";
-    PlanetSelectedSignal(planet_id);
-}
-
 void SidePanel::PlanetPanelContainer::VScroll(int pos_top, int pos_bottom, int range_min, int range_max) {
     if (pos_bottom > range_max) {
         // prevent scrolling beyond allowed max
@@ -2783,7 +2777,7 @@ SidePanel::SidePanel(const std::string& config_name) :
     GG::Connect(m_system_name->SelChangedSignal,                         &SidePanel::SystemSelectionChanged, this);
     GG::Connect(m_button_prev->LeftClickedSignal,                        &SidePanel::PrevButtonClicked,      this);
     GG::Connect(m_button_next->LeftClickedSignal,                        &SidePanel::NextButtonClicked,      this);
-    GG::Connect(m_planet_panel_container->PlanetSelectedSignal,          &SidePanel::PlanetSelectedSlot,     this);
+    GG::Connect(m_planet_panel_container->PlanetClickedSignal,           &SidePanel::PlanetClickedSlot,      this);
     GG::Connect(m_planet_panel_container->PlanetLeftDoubleClickedSignal, PlanetDoubleClickedSignal);
     GG::Connect(m_planet_panel_container->PlanetRightClickedSignal,      PlanetRightClickedSignal);
     GG::Connect(m_planet_panel_container->BuildingRightClickedSignal,    BuildingRightClickedSignal);
@@ -3222,7 +3216,7 @@ void SidePanel::NextButtonClicked() {
     SystemSelectionChanged(m_system_name->CurrentItem());
 }
 
-void SidePanel::PlanetSelectedSlot(int planet_id) {
+void SidePanel::PlanetClickedSlot(int planet_id) {
     if (m_selection_enabled)
         SelectPlanet(planet_id);
 }

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -2783,7 +2783,7 @@ SidePanel::SidePanel(const std::string& config_name) :
     GG::Connect(m_system_name->SelChangedSignal,                         &SidePanel::SystemSelectionChanged, this);
     GG::Connect(m_button_prev->LeftClickedSignal,                        &SidePanel::PrevButtonClicked,      this);
     GG::Connect(m_button_next->LeftClickedSignal,                        &SidePanel::NextButtonClicked,      this);
-    GG::Connect(m_planet_panel_container->PlanetSelectedSignal,          &SidePanel::PlanetSelected,         this);
+    GG::Connect(m_planet_panel_container->PlanetSelectedSignal,          &SidePanel::PlanetSelectedSlot,     this);
     GG::Connect(m_planet_panel_container->PlanetLeftDoubleClickedSignal, PlanetDoubleClickedSignal);
     GG::Connect(m_planet_panel_container->PlanetRightClickedSignal,      PlanetRightClickedSignal);
     GG::Connect(m_planet_panel_container->BuildingRightClickedSignal,    BuildingRightClickedSignal);
@@ -3222,10 +3222,9 @@ void SidePanel::NextButtonClicked() {
     SystemSelectionChanged(m_system_name->CurrentItem());
 }
 
-void SidePanel::PlanetSelected(int planet_id) {
-    //std::cout << "SidePanel::PlanetSelected(" << planet_id << ")" << std::endl;
-    if (SelectedPlanetID() != planet_id)
-        PlanetSelectedSignal(planet_id);
+void SidePanel::PlanetSelectedSlot(int planet_id) {
+    if (m_selection_enabled)
+        SelectPlanet(planet_id);
 }
 
 void SidePanel::FleetsInserted(const std::vector<TemporaryPtr<Fleet> >& fleets) {

--- a/UI/SidePanel.h
+++ b/UI/SidePanel.h
@@ -142,6 +142,9 @@ private:
 
     static int                  s_system_id;
 
+    /** The id of the currently-selected planet, or INVALID_OBJECT_ID if no planet is selected. */
+    static int                  s_planet_id;
+
     static std::set<SidePanel*> s_side_panels;
 
     static std::set<boost::signals2::connection>      s_system_connections;

--- a/UI/SidePanel.h
+++ b/UI/SidePanel.h
@@ -112,7 +112,6 @@ private:
     void                RefreshInPreRender();
 
     void                RefreshImpl();                  ///< fully refreshes contents.  to be used when objects are created, destroyed or added to system
-    void                SelectPlanetImpl(int planet_id);///< sets selected planet in this sidepanel
 
     void                SystemSelectionChanged(GG::DropDownList::iterator it);  ///< responds to user selecting a system in the droplist.  may emit SystemSelectedSignal
 

--- a/UI/SidePanel.h
+++ b/UI/SidePanel.h
@@ -40,7 +40,7 @@ public:
 
     /** Returns whether this SidePanel contains an object with the indicated
       * \a object_id that can be selected within the SidePanel. */
-    bool                PlanetSelectable(int id) const;
+    bool                PlanetSelectable(int planet_id) const;
     //@}
 
     /** \name Mutators */ //@{

--- a/UI/SidePanel.h
+++ b/UI/SidePanel.h
@@ -118,7 +118,7 @@ private:
 
     void                PrevButtonClicked();            ///< responds to user clicking next system button
     void                NextButtonClicked();            ///< responts to user clicking previous system button
-    void                PlanetSelected(int planet_id);  ///< responds to user selection of a planet by emitting PlanetSelectedSignal
+    void                PlanetSelectedSlot(int planet_id);  ///< responds to user selection of a planet by emitting PlanetSelectedSignal
 
     static void         FleetsInserted(const std::vector<TemporaryPtr<Fleet> >& fleets);    ///< responds to insertion fleets into system during a turn.  may update colonize buttons
     static void         FleetsRemoved(const std::vector<TemporaryPtr<Fleet> >& fleets);     ///< responds to removal fleets from system during a turn.  may update colonize buttons

--- a/UI/SidePanel.h
+++ b/UI/SidePanel.h
@@ -117,7 +117,8 @@ private:
 
     void                PrevButtonClicked();            ///< responds to user clicking next system button
     void                NextButtonClicked();            ///< responts to user clicking previous system button
-    void                PlanetSelectedSlot(int planet_id);  ///< responds to user selection of a planet by emitting PlanetSelectedSignal
+    /** Respond to the user clicking a planet by selecting it if selection is enabled.*/
+    void                PlanetClickedSlot(int planet_id);
 
     static void         FleetsInserted(const std::vector<TemporaryPtr<Fleet> >& fleets);    ///< responds to insertion fleets into system during a turn.  may update colonize buttons
     static void         FleetsRemoved(const std::vector<TemporaryPtr<Fleet> >& fleets);     ///< responds to removal fleets from system during a turn.  may update colonize buttons


### PR DESCRIPTION
This PR fixes the bug where the ProductionWnd's selected planet no longer persistently tracks the system selected in the SidePanel.  The bug was introduced by changes to add PreRender() to the SidePanel.

Previously, selection and storage of the selected planet id was handled by the PlanetContainerPanel inside the SidePanel that was linked to the production window.  

Adding PreRender() changed the timing of events, so that when the Production window was informed that the system had changed and polled the PlanetContainerPanel it was still showing the old system, which the Production window then used to determine which planet's BuildDesignator to display. 

This PR promotes selection of the planet id and storage of the value to the static functions and variables that tie together the two SidePanels.  This is at a higher level of the hierarchy, outside of the PreRender() functions. 