### PR TITLE
Fix bug #1109 drop down list modal event pump race.

### DIFF
--- a/GG/GG/DeferredLayout.h
+++ b/GG/GG/DeferredLayout.h
@@ -41,7 +41,7 @@ protected:
 private:
     Pt   m_ul_prerender;
     Pt   m_lr_prerender;
-    bool m_stop_deferred_resize_recursion;
+    bool m_make_resize_immediate_during_prerender;
 };
 
 } // namespace GG

--- a/GG/GG/DeferredLayout.h
+++ b/GG/GG/DeferredLayout.h
@@ -29,8 +29,6 @@ public:
     /** \name Mutators */ ///@{
     virtual void SizeMove(const Pt& ul, const Pt& lr);
     virtual void PreRender();
-    virtual void SetMinSize(const Pt& sz);
-    virtual void SetMaxSize(const Pt& sz);
     //@}
 
 protected:

--- a/GG/GG/DropDownList.h
+++ b/GG/GG/DropDownList.h
@@ -120,7 +120,10 @@ public:
         different width than the drop down rows.*/
     virtual GG::X  DisplayedRowWidth() const;
 
-    mutable SelChangedSignalType SelChangedSignal; ///< the selection change signal object for this DropDownList
+    /** The selection change signal while not running the modal drop down box.
+        This will also signal an event when the drop list closes if the selection changed.
+     */
+    mutable SelChangedSignalType SelChangedSignal;
 
     DropDownOpenedSignalType DropDownOpenedSignal;
     //@}

--- a/GG/GG/DropDownList.h
+++ b/GG/GG/DropDownList.h
@@ -218,7 +218,6 @@ private:
 
     // TODO use C++11 unique_ptr
     boost::scoped_ptr<ModalListPicker> const    m_modal_picker;
-    size_t              m_num_shown_elements;
 };
 
 } // namespace GG

--- a/GG/GG/DropDownList.h
+++ b/GG/GG/DropDownList.h
@@ -34,6 +34,8 @@
 #include <GG/ListBox.h>
 #include <GG/GLClientAndServerBuffer.h>
 
+#include <boost/scoped_ptr.hpp>
+
 class ModalListPicker;
 
 namespace GG {
@@ -214,7 +216,8 @@ protected:
 private:
     const ListBox*  LB() const;
 
-    ModalListPicker*    m_modal_picker;
+    // TODO use C++11 unique_ptr
+    boost::scoped_ptr<ModalListPicker> const    m_modal_picker;
     size_t              m_num_shown_elements;
 };
 

--- a/GG/GG/DropDownList.h
+++ b/GG/GG/DropDownList.h
@@ -52,7 +52,16 @@ namespace GG {
     DropDownList.  Though you can still set the alignment, etc. of individual
     rows, as in ListBox, the currently-selected row will have the same
     alignment, etc. when displayed in the control in its unopened state.  Note
-    that this may look quite ugly. */
+    that this may look quite ugly.
+
+    On selection DropDownList emits one of two signals, SelChangedSignal or
+    SelChangedWhileDroppedSignal.  SelChangedWhileDroppedSignal is emitted
+    when the selection changes while running a ModalEventPump to display the
+    drop down list and handle its events.
+
+    SelChangedSignal will also be emitted when the drop down list closes if
+    the selected item changed.
+*/
 class GG_API DropDownList : public Control
 {
 public:
@@ -124,6 +133,8 @@ public:
         This will also signal an event when the drop list closes if the selection changed.
      */
     mutable SelChangedSignalType SelChangedSignal;
+    /** The selection change signal while running the modal drop down box.*/
+    mutable SelChangedSignalType SelChangedWhileDroppedSignal;
 
     DropDownOpenedSignalType DropDownOpenedSignal;
     //@}

--- a/GG/GG/Wnd.h
+++ b/GG/GG/Wnd.h
@@ -649,7 +649,7 @@ public:
     virtual bool Run();
 
     /** Ends the current execution of Run(), if any. */
-    void EndRun();
+    virtual void EndRun();
 
     /** Sets the time cutoff (in milliseconds) for a browse info mode.  If \a
         mode is not less than the current number of modes, extra modes will be

--- a/GG/src/DeferredLayout.cpp
+++ b/GG/src/DeferredLayout.cpp
@@ -62,27 +62,3 @@ void DeferredLayout::PreRender()
 
 void DeferredLayout::RedoLayout()
 { RequirePreRender(); }
-
-void DeferredLayout::SetMinSize(const Pt& sz)
-{
-    Pt old_ul_prerender = m_ul_prerender;
-    Pt old_lr_prerender = m_lr_prerender;
-
-    Layout::SetMinSize(sz);
-
-    m_ul_prerender = old_ul_prerender;
-    m_lr_prerender = old_lr_prerender;
-    ClampRectWithMinAndMaxSize(m_ul_prerender, m_lr_prerender);
-}
-
-void DeferredLayout::SetMaxSize(const Pt& sz)
-{
-    Pt old_ul_prerender = m_ul_prerender;
-    Pt old_lr_prerender = m_lr_prerender;
-
-    Layout::SetMaxSize(sz);
-
-    m_ul_prerender = old_ul_prerender;
-    m_lr_prerender = old_lr_prerender;
-    ClampRectWithMinAndMaxSize(m_ul_prerender, m_lr_prerender);
-}

--- a/GG/src/DeferredLayout.cpp
+++ b/GG/src/DeferredLayout.cpp
@@ -38,10 +38,12 @@ void DeferredLayout::SizeMove(const Pt& ul, const Pt& lr)
     if (m_stop_deferred_resize_recursion)
         return;
 
-    RequirePreRender();
+    if ((ul != RelativeUpperLeft()) || (lr != RelativeLowerRight())) {
+        RequirePreRender();
 
-    m_ul_prerender = ul;
-    m_lr_prerender = lr;
+        m_ul_prerender = ul;
+        m_lr_prerender = lr;
+    }
 
     // Note: m_upperleft and m_lowerright will be updated when DoLayout() is called in PreRender().
 }

--- a/GG/src/DeferredLayout.cpp
+++ b/GG/src/DeferredLayout.cpp
@@ -30,13 +30,16 @@ DeferredLayout::DeferredLayout(X x, Y y, X w, Y h, std::size_t rows, std::size_t
     Layout(x, y, w, h, rows, columns, border_margin, cell_margin),
     m_ul_prerender(Pt(x, y)),
     m_lr_prerender(Pt(x + w, y + h)),
-    m_stop_deferred_resize_recursion(false)
+    m_make_resize_immediate_during_prerender(false)
 {}
 
 void DeferredLayout::SizeMove(const Pt& ul, const Pt& lr)
 {
-    if (m_stop_deferred_resize_recursion)
+    if (m_make_resize_immediate_during_prerender) {
+        if (ul != m_ul_prerender || lr != m_lr_prerender)
+            DoLayout(ul, lr);
         return;
+    }
 
     if ((ul != RelativeUpperLeft()) || (lr != RelativeLowerRight())) {
         RequirePreRender();
@@ -51,7 +54,7 @@ void DeferredLayout::SizeMove(const Pt& ul, const Pt& lr)
 void DeferredLayout::PreRender()
 {
     Layout::PreRender();
-    ScopedAssign<bool> assignment(m_stop_deferred_resize_recursion, true);
+    ScopedAssign<bool> assignment(m_make_resize_immediate_during_prerender, true);
     DoLayout(m_ul_prerender, m_lr_prerender);
     m_ul_prerender = RelativeUpperLeft();
     m_lr_prerender = RelativeLowerRight();

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -545,16 +545,17 @@ void DropDownList::RenderDisplayedRow()
     Row* current_item = *CurrentItem();
     bool sel_visible = current_item->Visible();
     bool lb_visible = LB()->Visible();
-    if (!sel_visible) {
-        // The following is necessary because neither LB() nor the selected row may be visible and
-        // prerendered.
-        if (!lb_visible) {
-            LB()->Show();
-            GUI::GetGUI()->PreRenderWindow(LB());
-            LB()->Hide();
-        }
+
+    // The following is necessary because neither LB() nor the selected row may be visible and
+    // prerendered.
+    if (!lb_visible)
+        LB()->Show();
+    GUI::GetGUI()->PreRenderWindow(LB());
+    if (!lb_visible)
+        LB()->Hide();
+
+    if (!sel_visible)
         current_item->Show();
-    }
 
     // Vertically center the selected row in the box.
     Pt offset = GG::Pt(ClientUpperLeft().x - current_item->ClientUpperLeft().x,

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -322,8 +322,6 @@ DropDownList::DropDownList(size_t num_shown_elements, Clr color) :
 DropDownList::~DropDownList() {
     if (m_modal_picker)
         m_modal_picker->EndRun();
-    DetachChild(m_modal_picker);
-    delete m_modal_picker;
 
     m_buffer.clear();
 }

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -634,6 +634,7 @@ void DropDownList::Clear()
 {
     m_modal_picker->EndRun();
     LB()->Clear();
+    RequirePreRender();
 }
 
 DropDownList::iterator DropDownList::begin()

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -44,6 +44,7 @@ public:
     ModalListPicker(Clr color, const Wnd* relative_to_wnd, size_t m_num_shown_rows);
 
     virtual bool   Run();
+    virtual void   EndRun();
     bool           Dropped() const;
     virtual void   Render() {};
 
@@ -157,11 +158,22 @@ ModalListPicker::ModalListPicker(Clr color, const Wnd* relative_to_wnd, size_t n
 
 
 bool ModalListPicker::Run() {
-    m_dropped = true;
-    CorrectListSize();
     bool retval = Wnd::Run();
     m_dropped = false;
     return retval;
+}
+
+void ModalListPicker::ModalInit()
+{
+    m_dropped = true;
+    m_lb_wnd->Hide(); // to enable CorrectListSize() to work
+    CorrectListSize();
+    Show();
+}
+
+void ModalListPicker::EndRun() {
+    Wnd::EndRun();
+    m_lb_wnd->Hide();
 }
 
 bool ModalListPicker::Dropped() const
@@ -306,14 +318,6 @@ boost::optional<DropDownList::iterator> ModalListPicker::MouseWheelCommon(
 
 void ModalListPicker::LClick(const Pt& pt, Flags<ModKey> mod_keys)
 { EndRun(); }
-
-void ModalListPicker::ModalInit()
-{
-    if (m_relative_to_wnd)
-        m_lb_wnd->MoveTo(Pt(m_relative_to_wnd->Left(), m_relative_to_wnd->Bottom()));
-
-    Show();
-}
 
 void ModalListPicker::LBSelChangedSlot(const ListBox::SelectionSet& rows)
 {

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -158,8 +158,11 @@ ModalListPicker::ModalListPicker(Clr color, const Wnd* relative_to_wnd, size_t n
 
 
 bool ModalListPicker::Run() {
+    DropDownList::iterator old_current_item = CurrentItem();
     bool retval = Wnd::Run();
     m_dropped = false;
+    if (old_current_item != CurrentItem())
+        SignalChanged(CurrentItem());
     return retval;
 }
 

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -2817,7 +2817,8 @@ SidePanel::SidePanel(const std::string& config_name) :
     m_system_resource_summary = new MultiIconValueIndicator(Width() - EDGE_PAD*2);
     AttachChild(m_system_resource_summary);
 
-    GG::Connect(m_system_name->SelChangedSignal,                         &SidePanel::SystemSelectionChanged, this);
+    GG::Connect(m_system_name->SelChangedSignal,                         &SidePanel::SystemSelectionChangedSlot,    this);
+    GG::Connect(m_system_name->SelChangedWhileDroppedSignal,             &SidePanel::SystemSelectionChangedSlot,    this);
     GG::Connect(m_button_prev->LeftClickedSignal,                        &SidePanel::PrevButtonClicked,      this);
     GG::Connect(m_button_next->LeftClickedSignal,                        &SidePanel::NextButtonClicked,      this);
     GG::Connect(m_planet_panel_container->PlanetSelectedSignal,          &SidePanel::PlanetSelected,         this);
@@ -3237,7 +3238,10 @@ void SidePanel::SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
         RequirePreRender();
 }
 
-void SidePanel::SystemSelectionChanged(GG::DropDownList::iterator it) {
+void SidePanel::SystemSelectionChangedSlot(GG::DropDownList::iterator it) {
+    /** This handles cases when the list is dropped and not dropped in the
+        same way. Refresh should not update the list of systems if the list
+        is open. */
     int system_id = INVALID_OBJECT_ID;
     if (it != m_system_name->end())
         system_id = boost::polymorphic_downcast<const SystemRow*>(*it)->SystemID();
@@ -3251,7 +3255,7 @@ void SidePanel::PrevButtonClicked() {
     if (selected == m_system_name->begin())
         selected = m_system_name->end();
     m_system_name->Select(--selected);
-    SystemSelectionChanged(m_system_name->CurrentItem());
+    SystemSelectionChangedSlot(m_system_name->CurrentItem());
 }
 
 void SidePanel::NextButtonClicked() {
@@ -3260,7 +3264,7 @@ void SidePanel::NextButtonClicked() {
     if (++selected == m_system_name->end())
         selected = m_system_name->begin();
     m_system_name->Select(selected);
-    SystemSelectionChanged(m_system_name->CurrentItem());
+    SystemSelectionChangedSlot(m_system_name->CurrentItem());
 }
 
 void SidePanel::PlanetSelected(int planet_id) {

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -726,39 +726,25 @@ namespace {
     public:
         SystemRow(int system_id) :
             GG::ListBox::Row(GG::X1, GG::Y(SystemNameFontSize()), "SystemRow"),
-            m_system_id(system_id),
-            m_initialized(false)
-        { RequirePreRender(); }
-
-        virtual void Init() {
-            m_initialized = true;
-            OwnerColoredSystemName *name(new OwnerColoredSystemName(m_system_id, SystemNameFontSize(), false));
-            push_back(name);
-
-            SetColAlignment(0, GG::ALIGN_CENTER);
+            m_system_id(system_id)
+        {
+            SetName("SystemRow");
+            RequirePreRender();
         }
 
-        virtual void PreRender() {
-            if (!m_initialized)
-                Init();
-
-            // Lock the row to the size of its drop box.
-            if (Parent())
-                SetColWidth(0, Parent()->ClientWidth());
+        void Init() {
+            OwnerColoredSystemName *name(new OwnerColoredSystemName(m_system_id, SystemNameFontSize(), false));
+            push_back(name);
+            SetColAlignment(0, GG::ALIGN_CENTER);
             GetLayout()->PreRender();
         }
 
-        /** Lock the system row size to the size of the drop down list box. This makes sure that
-            the row is the correct width with the name centered  when the dropdown list steals the
-            selected row for rendering.*/
-        virtual void SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
-            GG::Pt adjusted_lr(GG::X(Parent() ? ul.x + Parent()->ClientWidth() : lr.x), lr.y);
-            GG::Pt target_size(adjusted_lr - ul);
-            if ((ul == RelativeUpperLeft()) && (adjusted_lr == RelativeLowerRight()))
-                return;
+        virtual void PreRender() {
+            // If there is no control add it.
+            if (!size())
+                Init();
 
-            GG::Wnd::SizeMove(ul, adjusted_lr);
-            RequirePreRender();
+            GG::ListBox::Row::PreRender();
         }
 
         int SystemID() const { return m_system_id; }
@@ -768,7 +754,6 @@ namespace {
 
     private:
         int m_system_id;
-        bool m_initialized;
     };
 }
 /** A class to display all of the system names*/

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -2390,11 +2390,6 @@ void SidePanel::PlanetPanel::FocusDropListOpened(bool is_open) {
 }
 
 void SidePanel::PlanetPanel::FocusDropListSelectionChangedSlot(GG::DropDownList::iterator selected) {
-    // Do not update the sidepanel while the focus drop is open.  Otherwise scrolling with the key
-    // press does not work because every up/down arrow press deletes and recreates the m_focus_drop.
-    if (m_focus_drop->Dropped())
-        return;
-
     // all this funciton needs to do is emit FocusChangedSignal.  The code
     // preceeding that determines which focus was selected from the iterator
     // parameter, does some safety checks, and disables UI sounds

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -521,7 +521,7 @@ private:
     void                    ClickInvade();                      ///< called if invade button is pressed
     void                    ClickBombard();                     ///< called if bombard button is pressed
 
-    void                    FocusDropListSelectionChanged(GG::DropDownList::iterator selected); ///< called when droplist selection changes, emits FocusChangedSignal
+    void                    FocusDropListSelectionChangedSlot(GG::DropDownList::iterator selected); ///< called when droplist selection changes, emits FocusChangedSignal
     /** Called when focus drop list opens/closes to inform that it now \p is_open. */
     void                    FocusDropListOpened(bool is_open);
 
@@ -930,9 +930,9 @@ SidePanel::PlanetPanel::PlanetPanel(GG::X w, int planet_id, StarType star_type) 
     // focus-selection droplist
     m_focus_drop = new CUIDropDownList(6);
     AttachChild(m_focus_drop);
-    GG::Connect(m_focus_drop->DropDownOpenedSignal, &SidePanel::PlanetPanel::FocusDropListOpened,  this);
-    GG::Connect(m_focus_drop->SelChangedSignal,     &SidePanel::PlanetPanel::FocusDropListSelectionChanged,  this);
-    GG::Connect(this->FocusChangedSignal,           &SidePanel::PlanetPanel::SetFocus, this);
+    GG::Connect(m_focus_drop->DropDownOpenedSignal,             &SidePanel::PlanetPanel::FocusDropListOpened,  this);
+    GG::Connect(m_focus_drop->SelChangedSignal,                 &SidePanel::PlanetPanel::FocusDropListSelectionChangedSlot,  this);
+    GG::Connect(this->FocusChangedSignal,                       &SidePanel::PlanetPanel::SetFocus, this);
     m_focus_drop->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
     m_focus_drop->SetStyle(GG::LIST_NOSORT | GG::LIST_SINGLESEL);
     m_focus_drop->ManuallyManageColProps();
@@ -2386,10 +2386,10 @@ void SidePanel::PlanetPanel::FocusDropListOpened(bool is_open) {
     if (is_open)
         return;
 
-    FocusDropListSelectionChanged(m_focus_drop->CurrentItem());
+    FocusDropListSelectionChangedSlot(m_focus_drop->CurrentItem());
 }
 
-void SidePanel::PlanetPanel::FocusDropListSelectionChanged(GG::DropDownList::iterator selected) {
+void SidePanel::PlanetPanel::FocusDropListSelectionChangedSlot(GG::DropDownList::iterator selected) {
     // Do not update the sidepanel while the focus drop is open.  Otherwise scrolling with the key
     // press does not work because every up/down arrow press deletes and recreates the m_focus_drop.
     if (m_focus_drop->Dropped())

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -2817,6 +2817,7 @@ SidePanel::SidePanel(const std::string& config_name) :
     m_system_resource_summary = new MultiIconValueIndicator(Width() - EDGE_PAD*2);
     AttachChild(m_system_resource_summary);
 
+    GG::Connect(m_system_name->DropDownOpenedSignal,                     &SidePanel::SystemNameDropListOpenedSlot,  this);
     GG::Connect(m_system_name->SelChangedSignal,                         &SidePanel::SystemSelectionChangedSlot,    this);
     GG::Connect(m_system_name->SelChangedWhileDroppedSignal,             &SidePanel::SystemSelectionChangedSlot,    this);
     GG::Connect(m_button_prev->LeftClickedSignal,                        &SidePanel::PrevButtonClicked,      this);
@@ -3249,6 +3250,13 @@ void SidePanel::SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
 
     if (old_size != GG::Wnd::Size())
         RequirePreRender();
+}
+
+void SidePanel::SystemNameDropListOpenedSlot(bool is_open) {
+    // Refresh the system names when the drop list closes.
+    if (is_open)
+        return;
+    RefreshSystemNames();
 }
 
 void SidePanel::SystemSelectionChangedSlot(GG::DropDownList::iterator it) {

--- a/UI/SidePanel.h
+++ b/UI/SidePanel.h
@@ -114,6 +114,8 @@ private:
     void                RefreshImpl();                  ///< fully refreshes contents.  to be used when objects are created, destroyed or added to system
     void                SelectPlanetImpl(int planet_id);///< sets selected planet in this sidepanel
 
+    /**  Insert all known systems into the SystemName drop down list.*/
+    void                RefreshSystemNames();
     /**  Handle the user selecting a system in the droplist while the list is closed, using keys.
          It may emit SystemSelectedSignal. */
     void                SystemSelectionChangedSlot(GG::DropDownList::iterator it);

--- a/UI/SidePanel.h
+++ b/UI/SidePanel.h
@@ -114,7 +114,9 @@ private:
     void                RefreshImpl();                  ///< fully refreshes contents.  to be used when objects are created, destroyed or added to system
     void                SelectPlanetImpl(int planet_id);///< sets selected planet in this sidepanel
 
-    void                SystemSelectionChanged(GG::DropDownList::iterator it);  ///< responds to user selecting a system in the droplist.  may emit SystemSelectedSignal
+    /**  Handle the user selecting a system in the droplist while the list is closed, using keys.
+         It may emit SystemSelectedSignal. */
+    void                SystemSelectionChangedSlot(GG::DropDownList::iterator it);
 
     void                PrevButtonClicked();            ///< responds to user clicking next system button
     void                NextButtonClicked();            ///< responts to user clicking previous system button

--- a/UI/SidePanel.h
+++ b/UI/SidePanel.h
@@ -116,6 +116,9 @@ private:
 
     /**  Insert all known systems into the SystemName drop down list.*/
     void                RefreshSystemNames();
+    /**  Refresh the system name list when it closes, in case the known systems changed while it
+         was open. */
+    void                SystemNameDropListOpenedSlot(bool is_open);
     /**  Handle the user selecting a system in the droplist while the list is closed, using keys.
          It may emit SystemSelectedSignal. */
     void                SystemSelectionChangedSlot(GG::DropDownList::iterator it);


### PR DESCRIPTION
tl;dr; A race condition between the EventPump and the ModalEventPump in the DropDownList code was fixed by adding a separate signal SelChangedWhileDroppedSignal.

This fixes issue #1109.

****The problem****

+ DropDownList uses a ModalEventPump to display the drop down list in ModalListPicker, while at the same time moving and restoring the selected row each Render() phase to render it in the drop down list anchor location.  
+ SidePanel::SystemRow displays a centered system name.  
+ SidePanel deletes and re-creates all of the rows immediately when SystemRow indicates a change in the selected row.  
+ The DropDownList and the DropDownList::ModalListPicker are both running PreRender on the same SystemRow in different EventPumps.  

A race condition happens which sometimes results in the SystemRow::Init() function running twice.  This creates an inconsistent SystemRow, which eventually leads to the crash.

Triggering this bug does not require the SidePanel to be touched in anyway.  It might require the SidePanel to have been visible at least once, but  I did not check this condition.

****The evidence****

I captured the stack inside of the SystemRow::Init() function showing that it had a) run unnecessarily a second time when m_intialized was already true and b) that it added a spurious control with a min width in Layout of 32767 !!!.  SystemRow while valiantly keeping the System name centered aliases the spurious min width with certain widths of SidePanels to create either ever larger magnitude positive/negative (m_ul_prerender, m_lr_prerender) pairs.  These are the large values that Geoff noticed that look uninitialized.  This is also what I assume was causing the crash to be very machine specific.

****A solution****

1. Remove the clamping of SystemRow to the parent size that was interacting badly with the DropDownList double render of the selected row.
2. Prevent the DropDownWnd correcting the size of the drop down box while the drop down box is visible.  This should prevent both DropDownList::PreRender() and ModalListPicker::PreRender() from racing to prerender the list box.
3. Make EndRun() virtual so that ModalListPicker can hide its list as part of its teardown within the ModalEventPump.
4. Split SelChangedSignal in to SelChangedWhileDroppedSignal and SelChangedSignal so that consumers can handle them appropriately.  I considered passing a parameter `is_dropped`, but chose two signals to emphasize that the SelChangedWhileDropped version is handled in the ModalEventPump and not the normal event pump.  The user could also use a single handler and detect status with Dropped().
5. Change the original SelChangedSignal to emit a final SelChanged when the drop down closes so that old code does not miss any selection changes events.
6. Changed the SidePanel code to separate the re-generation of the SystemRow so that it doesn't happen while the modal list is open.  

****Not perfect****

It introduces (at the least) the following quirk/bug.  If the system name drop down list is open and the names of known systems changes this will not be reflected in the systems in the list until the list is closed and re-opened.  A solution to that is to refactor DropDownList to not use  ModalEventPump.
