### PR TITLE
Use drydock at system planet with highest happiness

### DIFF
--- a/default/scripting/buildings/shipyards/ORBITAL_DRYDOCK.focs.txt
+++ b/default/scripting/buildings/shipyards/ORBITAL_DRYDOCK.focs.txt
@@ -34,7 +34,7 @@ BuildingType
             activation = And [
                 Source
                 ContainedBy And [
-                    Planet
+                    [[PLANET_OWNED_DRYDOCK_HIGHEST_HAPPINESS]]
                     Population high = 0
                 ]
             ]
@@ -64,7 +64,10 @@ BuildingType
                 Turn low = LocalCandidate.ArrivedOnTurn + 1
                 (Source.Planet.Happiness >= [[CONST_ORB_DRYDOCK_MIN_HAPPY]])
             ]
-            activation = Turn low = Source.System.LastTurnBattleHere + 1
+            activation = And [
+                ContainedBy [[PLANET_OWNED_DRYDOCK_HIGHEST_HAPPINESS]]
+                Turn low = Source.System.LastTurnBattleHere + 1
+            ]
             stackinggroup = "SHIP_REPAIR"
             priority = 80  // not macroed to prevent unwanted changes
             effects = [
@@ -91,7 +94,10 @@ BuildingType
                 Turn low = LocalCandidate.ArrivedOnTurn + 1
                 (Source.Planet.Happiness >= [[CONST_ORB_DRYDOCK_MIN_HAPPY]])
             ]
-            activation = Turn low = Source.System.LastTurnBattleHere + 1
+            activation = And [
+                ContainedBy [[PLANET_OWNED_DRYDOCK_HIGHEST_HAPPINESS]]
+                Turn low = Source.System.LastTurnBattleHere + 1
+            ]
             stackinggroup = "SHIP_REPAIR"
             priority = 80  // not macroed to prevent unwanted changes
             effects = [
@@ -117,7 +123,10 @@ BuildingType
                 Turn low = LocalCandidate.ArrivedOnTurn + 1
                 (Source.Planet.Happiness < [[CONST_ORB_DRYDOCK_MIN_HAPPY]])
             ]
-            activation = Turn low = Source.System.LastTurnBattleHere + 1
+            activation = And [
+                ContainedBy [[PLANET_OWNED_DRYDOCK_HIGHEST_HAPPINESS]]
+                Turn low = Source.System.LastTurnBattleHere + 1
+            ]
             stackinggroup = "SHIP_REPAIR"
             priority = 120  // not macroed to prevent unwanted changes
             effects = [
@@ -164,6 +173,17 @@ ORB_DRYDOCK_REPAIR_RATE
 // arg1 target max structure
 ORB_DRYDOCK_REPAIR_VAL
 '''[[ORB_DRYDOCK_HAPPY_RATE]] * [[ORB_DRYDOCK_REPAIR_RATE(@1@)]]'''
+
++// Planet in system with highest happiness that is owned and has a drydock
+PLANET_OWNED_DRYDOCK_HIGHEST_HAPPINESS
+'''MaximumNumberOf Number = 1 SortKey = LocalCandidate.Happiness Condition = And [
+    Planet
+    InSystem id = Source.SystemID
+    OwnedBy empire = Source.Owner
+    Contains
+        Building name = "BLD_SHIPYARD_ORBITAL_DRYDOCK"
+]
+'''
 
 #include "/scripting/common/enqueue.macros"
 


### PR DESCRIPTION
Limits effect activation to the system planet (with a drydock) that has the highest happiness.

Fixes #1122 