### PR TITLE
Allow pedia article for category

### DIFF
--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -245,7 +245,7 @@ namespace {
                 // Do not add sub-categories
                 const EncyclopediaArticle& article = GetPediaArticle(it->first);
                 // No article found or specifically a top-level category
-                if (!(article.category.empty() || article.category == "ENC_INDEX"))
+                if (!article.category.empty() && article.category != "ENC_INDEX")
                     continue;
 
                 sorted_entries_list.insert(std::make_pair(UserString(it->first),
@@ -1216,7 +1216,7 @@ namespace {
                 detailed_description = UserString(article_it->description);
 
                 const std::string& article_cat = article_it->category;
-                if (!(article_cat == "ENC_INDEX" || article_cat.empty()))
+                if (article_cat != "ENC_INDEX" && !article_cat.empty())
                     general_type = UserString(article_cat);
 
                 const std::string& article_brief = article_it->short_description;

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -143,7 +143,7 @@ namespace {
     /** Find Encyclopedia article with given name
      * @param[in] name name entry of the article
      */
-    EncyclopediaArticle GetPediaArticle(const std::string& name) {
+    const EncyclopediaArticle& GetPediaArticle(const std::string& name) {
         const std::map<std::string, std::vector<EncyclopediaArticle> >& articles = GetEncyclopedia().articles;
         for (std::map<std::string, std::vector<EncyclopediaArticle> >::const_iterator category_it = articles.begin();
              category_it != articles.end(); ++category_it)
@@ -156,7 +156,7 @@ namespace {
                 }
             }
         }
-        return EncyclopediaArticle("", "", "", "", "");
+        return GetEncyclopedia().empty_article;
     }
 
     /** Returns map from (Human-readable and thus sorted article category) to

--- a/default/scripting/encyclopedia/metabolisms/CATEGORY_METABOLISMS.focs.txt
+++ b/default/scripting/encyclopedia/metabolisms/CATEGORY_METABOLISMS.focs.txt
@@ -1,0 +1,6 @@
+Article
+    name = "METABOLISM_TITLE"
+    category = "CATEGORY_GAME_CONCEPTS"
+    short_description = "SPECIES_ARTICLE_SHORT_DESC"
+    description = "METABOLISM_TEXT"
+    icon = "icons/species/human.png"

--- a/default/scripting/encyclopedia/metabolisms/LITHIC_SPECIES.focs.txt
+++ b/default/scripting/encyclopedia/metabolisms/LITHIC_SPECIES.focs.txt
@@ -1,6 +1,6 @@
 Article
     name = "LITHIC_SPECIES_TITLE"
-    category = "CATEGORY_GAME_CONCEPTS"
+    category = "METABOLISM_TITLE"
     short_description = "SPECIES_ARTICLE_SHORT_DESC"
     description = "LITHIC_SPECIES_TEXT"
     icon = "icons/species/egassem.png"

--- a/default/scripting/encyclopedia/metabolisms/ORGANIC_SPECIES.focs.txt
+++ b/default/scripting/encyclopedia/metabolisms/ORGANIC_SPECIES.focs.txt
@@ -1,6 +1,6 @@
 Article
     name = "ORGANIC_SPECIES_TITLE"
-    category = "CATEGORY_GAME_CONCEPTS"
+    category = "METABOLISM_TITLE"
     short_description = "SPECIES_ARTICLE_SHORT_DESC"
     description = "ORGANIC_SPECIES_TEXT"
     icon = "icons/species/human.png"

--- a/default/scripting/encyclopedia/metabolisms/PHOTOTROPHIC_SPECIES.focs.txt
+++ b/default/scripting/encyclopedia/metabolisms/PHOTOTROPHIC_SPECIES.focs.txt
@@ -1,6 +1,6 @@
 Article
     name = "PHOTOTROPHIC_SPECIES_TITLE"
-    category = "CATEGORY_GAME_CONCEPTS"
+    category = "METABOLISM_TITLE"
     short_description = "SPECIES_ARTICLE_SHORT_DESC"
     description = "PHOTOTROPHIC_SPECIES_TEXT"
     icon = "icons/species/flora-07.png"

--- a/default/scripting/encyclopedia/metabolisms/ROBOTIC_SPECIES.focs.txt
+++ b/default/scripting/encyclopedia/metabolisms/ROBOTIC_SPECIES.focs.txt
@@ -1,6 +1,6 @@
 Article
     name = "ROBOTIC_SPECIES_TITLE"
-    category = "CATEGORY_GAME_CONCEPTS"
+    category = "METABOLISM_TITLE"
     short_description = "SPECIES_ARTICLE_SHORT_DESC"
     description = "ROBOTIC_SPECIES_TEXT"
     icon = "icons/species/robotic-01.png"

--- a/default/scripting/encyclopedia/metabolisms/SEL_SUSTAINING_SPECIES.focs.txt
+++ b/default/scripting/encyclopedia/metabolisms/SEL_SUSTAINING_SPECIES.focs.txt
@@ -1,6 +1,6 @@
 Article
     name = "SELF_SUSTAINING_SPECIES_TITLE"
-    category = "CATEGORY_GAME_CONCEPTS"
+    category = "METABOLISM_TITLE"
     short_description = "SPECIES_ARTICLE_SHORT_DESC"
     description = "SELF_SUSTAINING_SPECIES_TEXT"
     icon = "icons/species/acirema.png"

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -4223,6 +4223,11 @@ ENC_COMBAT_PLATFORM_NO_DAMAGE_MANY_EVENTS
 ENC_METER_TYPE
 Meter Type
 
+ENC_CATEGORY_HEADER
+'''
+<center>Articles in this category</center>
+<center>---</center>'''
+
 
 ##
 ## Combat report
@@ -4876,6 +4881,12 @@ Interstellar Fields
 
 FIELDS_TEXT
 There are several [[encyclopedia ENC_FIELD_TYPE]]s.  They each have a distinctive, somewhat diffuse, appearance.  Right-clicking on them in the [[encyclopedia MAP_WINDOW_ARTICLE_TITLE]] brings up a small popup menu identifying their type and providing an option to look up their details.
+
+METABOLISM_TITLE
+Metabolism
+
+METABOLISM_TEXT
+'''The metabolism of species in the galaxy fall into one of the types listed here.'''
 
 
 ##

--- a/universe/Encyclopedia.cpp
+++ b/universe/Encyclopedia.cpp
@@ -11,7 +11,8 @@ const Encyclopedia& GetEncyclopedia() {
 }
 
 Encyclopedia::Encyclopedia() :
-    articles()
+    articles(),
+    empty_article()
 {
     try {
         parse::encyclopedia_articles(*this);

--- a/universe/Encyclopedia.h
+++ b/universe/Encyclopedia.h
@@ -8,6 +8,14 @@
 #include "../util/Export.h"
 
 struct FO_COMMON_API EncyclopediaArticle {
+    /** Default ctor */
+    EncyclopediaArticle() :
+        name(""),
+        category(""),
+        short_description(""),
+        description(""),
+        icon("")
+    {}
     EncyclopediaArticle(const std::string& name_, const std::string& category_,
                         const std::string& short_description_, const std::string& description_,
                         const std::string& icon_) :
@@ -27,6 +35,7 @@ struct FO_COMMON_API EncyclopediaArticle {
 struct FO_COMMON_API Encyclopedia {
     Encyclopedia();
     std::map<std::string, std::vector<EncyclopediaArticle> >   articles;
+    const EncyclopediaArticle                                  empty_article;
 };
 
 FO_COMMON_API const Encyclopedia& GetEncyclopedia();


### PR DESCRIPTION
Proposal to resolve #976 

Implements subcategories by allowing a category to be defined as another article.
This also allows any category to contain some descriptive entry prior to listing the contents.

To provide a merge-able test case, the different metabolism articles are moved into a sub-category.