### PR TITLE
Fix drop down list key scrolling

### DIFF
--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -285,7 +285,7 @@ boost::optional<DropDownList::iterator> ModalListPicker::KeyPressCommon(
         }
         break;
     case GGK_PAGEUP: // page up key (not numpad key)
-        if (LB()->NumRows() && CurrentItem() != LB()->end()) {
+        if (!LB()->Empty() && CurrentItem() != LB()->end()) {
             std::size_t i = std::max(1ul, m_num_shown_rows - 1u);
             DropDownList::iterator it = CurrentItem();
             while (i && it != LB()->begin()) {
@@ -297,7 +297,7 @@ boost::optional<DropDownList::iterator> ModalListPicker::KeyPressCommon(
         }
         break;
     case GGK_PAGEDOWN: // page down key (not numpad key)
-        if (LB()->NumRows()) {
+        if (!LB()->Empty()) {
             std::size_t i = std::max(1ul, m_num_shown_rows - 1u);
             DropDownList::iterator it = CurrentItem();
             while (i && it != --LB()->end()) {
@@ -309,14 +309,14 @@ boost::optional<DropDownList::iterator> ModalListPicker::KeyPressCommon(
         }
         break;
     case GGK_HOME: // home key (not numpad)
-        if (LB()->NumRows()) {
+        if (!LB()->Empty()) {
             DropDownList::iterator it(LB()->begin());
             LB()->BringRowIntoView(it);
             return it;
         }
         break;
     case GGK_END: // end key (not numpad)
-        if (LB()->NumRows() && !LB()->Empty()) {
+        if (!LB()->Empty()) {
             DropDownList::iterator it(--LB()->end());
             LB()->BringRowIntoView(it);
             return it;

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -271,42 +271,56 @@ boost::optional<DropDownList::iterator> ModalListPicker::KeyPressCommon(
 {
     switch (key) {
     case GGK_UP: // arrow-up (not numpad arrow)
-        if (CurrentItem() != LB()->end() && CurrentItem() != LB()->begin())
-            return boost::prior(CurrentItem());
+        if (CurrentItem() != LB()->end() && CurrentItem() != LB()->begin()) {
+            DropDownList::iterator prev_it(boost::prior(CurrentItem()));
+            LB()->BringRowIntoView(prev_it);
+            return prev_it;
+        }
         break;
     case GGK_DOWN: // arrow-down (not numpad arrow)
-        if (CurrentItem() != LB()->end() && CurrentItem() != --LB()->end())
-            return boost::next(CurrentItem());
+        if (CurrentItem() != LB()->end() && CurrentItem() != --LB()->end()) {
+            DropDownList::iterator next_it(boost::next(CurrentItem()));
+            LB()->BringRowIntoView(next_it);
+            return next_it;
+        }
         break;
     case GGK_PAGEUP: // page up key (not numpad key)
         if (LB()->NumRows() && CurrentItem() != LB()->end()) {
-            std::size_t i = 10;
+            std::size_t i = std::max(1ul, m_num_shown_rows - 1u);
             DropDownList::iterator it = CurrentItem();
             while (i && it != LB()->begin()) {
                 --it;
                 --i;
             }
+            LB()->BringRowIntoView(it);
             return it;
         }
         break;
     case GGK_PAGEDOWN: // page down key (not numpad key)
         if (LB()->NumRows()) {
-            std::size_t i = 10;
+            std::size_t i = std::max(1ul, m_num_shown_rows - 1u);
             DropDownList::iterator it = CurrentItem();
             while (i && it != --LB()->end()) {
                 ++it;
-                ++i;
+                --i;
             }
+            LB()->BringRowIntoView(it);
             return it;
         }
         break;
     case GGK_HOME: // home key (not numpad)
-        if (LB()->NumRows())
-            return LB()->begin();
+        if (LB()->NumRows()) {
+            DropDownList::iterator it(LB()->begin());
+            LB()->BringRowIntoView(it);
+            return it;
+        }
         break;
     case GGK_END: // end key (not numpad)
-        if (LB()->NumRows() && !LB()->Empty())
-            return --LB()->end();
+        if (LB()->NumRows() && !LB()->Empty()) {
+            DropDownList::iterator it(--LB()->end());
+            LB()->BringRowIntoView(it);
+            return it;
+        }
         break;
     case GGK_RETURN:
     case GGK_KP_ENTER:

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -150,7 +150,7 @@ namespace {
 ModalListPicker::ModalListPicker(Clr color, const Wnd* relative_to_wnd, size_t num_rows) :
     Control(X0, Y0, GUI::GetGUI()->AppWidth(), GUI::GetGUI()->AppHeight(), INTERACTIVE | MODAL),
     m_lb_wnd(GetStyleFactory()->NewDropDownListListBox(color, color)),
-    m_num_shown_rows(num_rows),
+    m_num_shown_rows(std::max<std::size_t>(1, num_rows)),
     m_relative_to_wnd(relative_to_wnd),
     m_dropped(false),
     m_resized_connection()

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -270,6 +270,25 @@ void ModalListPicker::CorrectListSize() {
 boost::optional<DropDownList::iterator> ModalListPicker::KeyPressCommon(
     Key key, boost::uint32_t key_code_point, Flags<ModKey> mod_keys)
 {
+    bool numlock_on = mod_keys & MOD_KEY_NUM;
+    if (!numlock_on) {
+        // convert keypad keys into corresponding non-number keys
+        switch (key) {
+        case GGK_KP0:       key = GGK_INSERT;   break;
+        case GGK_KP1:       key = GGK_END;      break;
+        case GGK_KP2:       key = GGK_DOWN;     break;
+        case GGK_KP3:       key = GGK_PAGEDOWN; break;
+        case GGK_KP4:       key = GGK_LEFT;     break;
+        case GGK_KP5:                           break;
+        case GGK_KP6:       key = GGK_RIGHT;    break;
+        case GGK_KP7:       key = GGK_HOME;     break;
+        case GGK_KP8:       key = GGK_UP;       break;
+        case GGK_KP9:       key = GGK_PAGEUP;   break;
+        case GGK_KP_PERIOD: key = GGK_DELETE;   break;
+        default:                                break;
+        }
+    }
+
     switch (key) {
     case GGK_UP: // arrow-up (not numpad arrow)
         if (CurrentItem() != LB()->end() && CurrentItem() != LB()->begin()) {

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -181,7 +181,24 @@ bool ModalListPicker::Run() {
 void ModalListPicker::ModalInit()
 {
     m_dropped = true;
-    m_lb_wnd->BringRowIntoView(CurrentItem());
+
+    // Try to center the current item unless within half the number of
+    // shown rows from the top or bottom
+    if (CurrentItem() != m_lb_wnd->end() && !m_lb_wnd->Empty()) {
+        std::size_t current_ii(std::distance(m_lb_wnd->begin(), CurrentItem()));
+        std::size_t half_shown((m_num_shown_rows / 2));
+        std::size_t even_extra_one((m_num_shown_rows % 2 == 0) ? 1 : 0);
+
+        m_lb_wnd->SetFirstRowShown(m_lb_wnd->begin());
+        if (current_ii >= (m_lb_wnd->NumRows() - 1 - half_shown)) {
+            m_lb_wnd->BringRowIntoView(--m_lb_wnd->end());
+        } else if (current_ii >= half_shown) {
+            m_lb_wnd->SetFirstRowShown(
+                boost::next(m_lb_wnd->begin(),
+                            current_ii - half_shown + even_extra_one));
+        }
+    }
+
     m_lb_wnd->Hide(); // to enable CorrectListSize() to work
     CorrectListSize();
     m_resized_connection = Connect(GG::GUI::GetGUI()->WindowResizedSignal,

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -181,6 +181,7 @@ bool ModalListPicker::Run() {
 void ModalListPicker::ModalInit()
 {
     m_dropped = true;
+    m_lb_wnd->BringRowIntoView(CurrentItem());
     m_lb_wnd->Hide(); // to enable CorrectListSize() to work
     CorrectListSize();
     m_resized_connection = Connect(GG::GUI::GetGUI()->WindowResizedSignal,

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -306,7 +306,7 @@ boost::optional<DropDownList::iterator> ModalListPicker::KeyPressCommon(
         break;
     case GGK_PAGEUP: // page up key (not numpad key)
         if (!LB()->Empty() && CurrentItem() != LB()->end()) {
-            std::size_t i = std::max(1ul, m_num_shown_rows - 1u);
+            std::size_t i = std::max<std::size_t>(1, m_num_shown_rows - 1);
             DropDownList::iterator it = CurrentItem();
             while (i && it != LB()->begin()) {
                 --it;
@@ -318,7 +318,7 @@ boost::optional<DropDownList::iterator> ModalListPicker::KeyPressCommon(
         break;
     case GGK_PAGEDOWN: // page down key (not numpad key)
         if (!LB()->Empty()) {
-            std::size_t i = std::max(1ul, m_num_shown_rows - 1u);
+            std::size_t i = std::max<std::size_t>(1, m_num_shown_rows - 1);
             DropDownList::iterator it = CurrentItem();
             while (i && it != --LB()->end()) {
                 ++it;

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -1153,11 +1153,13 @@ void ListBox::BringRowIntoView(iterator it)
             it_found = true;
         }
 
-        if (first_row_found && !last_row_found)
-            last_row_y_offset = y_offset;
-
-        if ((y_offset - first_row_y_offset) >= ClientHeight())
+        if (first_row_found && !last_row_found
+            && ((y_offset - first_row_y_offset) >= ClientHeight()))
+        {
             last_row_found = true;
+            if (it2 != m_rows.begin())
+                last_row_y_offset = y_offset - (*boost::prior(it2))->Height();
+        }
 
         y_offset += (*it2)->Height();
         ++it2;
@@ -1166,15 +1168,13 @@ void ListBox::BringRowIntoView(iterator it)
     if (!it_found)
         return;
 
-    RequirePreRender();
-
     if (y_offset <= ClientHeight())
         SetFirstRowShown(begin());
 
     // Shift the view if 'it' is outside of [first_row .. last_row]
     if (it_y_offset < first_row_y_offset)
         SetFirstRowShown(it);
-    else if (it_y_offset > last_row_y_offset)
+    else if (it_y_offset >= last_row_y_offset)
         SetFirstRowShown(FirstRowShownWhenBottomIs(it, ClientHeight()));
 }
 
@@ -2389,7 +2389,7 @@ void ListBox::NormalizeRow(Row* row)
 
 ListBox::iterator ListBox::FirstRowShownWhenBottomIs(iterator bottom_row, Y client_height)
 {
-    Y available_space = client_height;
+    Y available_space = client_height - (*bottom_row)->Height();
     iterator it = bottom_row;
     while (it != m_rows.begin() && (*boost::prior(it))->Height() <= available_space) {
         available_space -= (*--it)->Height();

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -2794,8 +2794,6 @@ SidePanel::SidePanel(const std::string& config_name) :
     Sound::TempUISoundDisabler sound_disabler;
 
     m_system_name = new SystemNameDropDownList(6);
-    m_system_name->SetColor(GG::CLR_ZERO);
-    m_system_name->SetInteriorColor(GG::FloatClr(0.0, 0.0, 0.0, 0.5));
     m_system_name->SetStyle(GG::LIST_NOSORT | GG::LIST_SINGLESEL);
     m_system_name->DisableDropArrow();
     m_system_name->SetInteriorColor(GG::Clr(0, 0, 0, 200));

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -723,8 +723,8 @@ namespace {
 
     class SystemRow : public GG::ListBox::Row {
     public:
-        SystemRow(int system_id) :
-            GG::ListBox::Row(GG::X1, GG::Y(SystemNameFontSize()), "SystemRow"),
+        SystemRow(int system_id, GG::Y h) :
+            GG::ListBox::Row(GG::X1, h, "SystemRow"),
             m_system_id(system_id)
         {
             SetName("SystemRow");
@@ -3060,6 +3060,9 @@ void SidePanel::RefreshSystemNames() {
             sorted_systems.insert(std::make_pair(sys_it->Name(), sys_it->ID()));
     }
 
+    boost::shared_ptr<GG::Font> system_name_font(ClientUI::GetBoldFont(SystemNameFontSize()));
+    GG::Y system_name_height(system_name_font->Lineskip() + 4);
+
     // Make a vector of sorted rows and insert them in a single operation.
     std::vector<GG::DropDownList::Row*> rows;
     rows.reserve(sorted_systems.size());
@@ -3067,8 +3070,7 @@ void SidePanel::RefreshSystemNames() {
          sys_it != sorted_systems.end(); ++sys_it)
     {
         int sys_id = sys_it->second;
-        SystemRow* sysrow = new SystemRow(sys_id);
-        rows.push_back(sysrow);
+        rows.push_back(new SystemRow(sys_id, system_name_height));
     }
     m_system_name->Insert(rows, false);
 


### PR DESCRIPTION
The PR fixes and enhances the drop down list key handling.

The bugs described are evident in long drop down lists like the `SystemName` list in the `SidePanel`.

The PR:
- makes sure that the drop down list tracks the selected item.
- changes to pageup/pagedown stride from 10 to (drop down list size - 1) which is a page.
- fixes some fence post errors in `ListBox::BringIntoView()`