### PR TITLE
Add ListBox::Show() to only show rows within the visible box.

### DIFF
--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -335,7 +335,7 @@ public:
 
     /** Show the  list box.  If \p show_children is true then show the rows that are within the
         boundaries of the list box.*/
-    virtual void Show(bool show_children = true);
+    virtual void    Show(bool show_children = true);
 
     virtual void    Disable(bool b = true);
     virtual void    SetColor(Clr c);

--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -538,6 +538,9 @@ protected:
     void            HandleRowRightClicked(const Pt& pt, Flags<ModKey> mod);
 
 private:
+    /** Show only rows that are within the visible list box area and hide all others.  If
+        \p do_prerender is true then prerender the visible rows.*/
+    void            ShowVisibleRows(bool do_prerender);
     void            ConnectSignals();
     void            ValidateStyle();                                        ///< reconciles inconsistencies in the style flags
     void            VScrolled(int tab_low, int tab_high, int low, int high);///< signals from the vertical scroll bar are caught here

--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -333,6 +333,10 @@ public:
 
     virtual void    SizeMove(const Pt& ul, const Pt& lr);  ///< resizes the control, then resizes the scrollbars as needed
 
+    /** Show the  list box.  If \p show_children is true then show the rows that are within the
+        boundaries of the list box.*/
+    virtual void Show(bool show_children = true);
+
     virtual void    Disable(bool b = true);
     virtual void    SetColor(Clr c);
 

--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -146,7 +146,6 @@ public:
         std::size_t         size() const;                       ///< returns the number of Controls in this Row
         bool                empty() const;                      ///< returns true iff there are 0 Controls in this Row
 
-        virtual Control*    operator[](std::size_t n) const;    ///< returns the Control in the \a nth cell of this Row; not range checked
         virtual Control*    at(std::size_t n) const;            ///< returns the Control in the \a nth cell of this Row \throw std::range_error throws when size() <= \a n
 
         Alignment    RowAlignment() const;              ///< returns the vertical alignment of this Row

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -271,13 +271,19 @@ void ModalListPicker::CorrectListSize() {
         LB()->Show();
 
         // Resize the rows, once to pick up the correct height and a second
-        // time to use the height to size the drop down list
+        // time to use the height to size the drop down list.
+        // Only prerender the list box to avoid prerendering rows that the list box will
+        // subsequently scroll off screen.
         drop_down_size.y = (*LB()->FirstRowShown())->Height() * std::min<int>(m_num_shown_rows, LB()->NumRows()) + 4;
         LB()->Resize(drop_down_size);
+        if (!LB()->Selections().empty())
+            LB()->BringRowIntoView(*(LB()->Selections().begin()));
         GUI::GetGUI()->PreRenderWindow(LB());
 
         drop_down_size.y = (*LB()->FirstRowShown())->Height() * std::min<int>(m_num_shown_rows, LB()->NumRows()) + 4;
         LB()->Resize(drop_down_size);
+        if (!LB()->Selections().empty())
+            LB()->BringRowIntoView(*(LB()->Selections().begin()));
         GUI::GetGUI()->PreRenderWindow(LB());
 
         LB()->Hide();

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -270,10 +270,22 @@ void ModalListPicker::CorrectListSize() {
     } else {
         LB()->Show();
 
-        // Resize the rows, once to pick up the correct height and a second
-        // time to use the height to size the drop down list.
-        // Only prerender the list box to avoid prerendering rows that the list box will
-        // subsequently scroll off screen.
+        // The purpose of this code is to produce a drop down list that
+        // will be exactly m_num_shown_rows high and make sure that the
+        // selected row is prerendered in the same way when the drop down
+        // list is open or closed.
+
+        // The list needs to be resized twice.  The first resize with an
+        // estimated row height will add any list box chrome, like scroll
+        // bars to the list and may change the height of the row.  The
+        // second resize uses the corrected row height to finalize the drop
+        // down list size.
+
+        // Note:  Placing a tighter constraint on valid DropDownList rows
+        // of always returning the same fixed height regardless of status
+        // (width, prerender etc.) would mean this code could be reduced to
+        // check height and resize list just once.
+
         drop_down_size.y = (*LB()->FirstRowShown())->Height() * std::min<int>(m_num_shown_rows, LB()->NumRows()) + 4;
         LB()->Resize(drop_down_size);
         if (!LB()->Selections().empty())

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -363,7 +363,7 @@ void ListBox::Row::SetCell(std::size_t n, Control* c)
 
 Control* ListBox::Row::RemoveCell(std::size_t n)
 {
-    if (m_cells.size() < (n+1))
+    if (m_cells.size() <= n)
         return 0;
     Layout* layout = GetLayout();
     Control* retval = m_cells[n];

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -239,9 +239,6 @@ std::size_t ListBox::Row::size() const
 bool ListBox::Row::empty() const
 { return m_cells.empty(); }
 
-Control* ListBox::Row::operator[](std::size_t n) const
-{ return m_cells[n]; }
-
 Control* ListBox::Row::at(std::size_t n) const
 { return m_cells.at(n); }
 

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -363,6 +363,8 @@ void ListBox::Row::SetCell(std::size_t n, Control* c)
 
 Control* ListBox::Row::RemoveCell(std::size_t n)
 {
+    if (m_cells.size() < (n+1))
+        return 0;
     Layout* layout = GetLayout();
     Control* retval = m_cells[n];
     layout->Remove(retval);

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -858,6 +858,11 @@ void ListBox::PreRender()
     // Reset require prerender after call to adjust scrolls
     Control::PreRender();
 
+    // Resize rows to fit client area.
+    X row_width(std::max(ClientWidth(), X(1)));
+    for (iterator it = m_rows.begin(); it != m_rows.end(); ++it)
+        (*it)->Resize(Pt(row_width, (*it)->Height()));
+
     // Ensure that data in occluded cells is not rendered
     // and that any re-layout during prerender is immediate.
     Y visible_height(BORDER_THICK);

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -961,6 +961,43 @@ void ListBox::SizeMove(const Pt& ul, const Pt& lr)
         RequirePreRender();
 }
 
+void ListBox::Show(bool show_children /* = true*/)
+{
+    Control::Show(false);
+
+    if (!show_children)
+        return;
+
+    // Deal with non row children normally
+    for (std::list<Wnd*>::const_iterator it = Children().begin();
+         it != Children().end(); ++it)
+    {
+        if (!dynamic_cast<Row*>(*it))
+            (*it)->Show(show_children);
+    }
+
+    // Show rows that will be visible when rendered
+    Y visible_height(BORDER_THICK);
+    Y max_visible_height = ClientSize().y;
+    bool hide = true;
+    for (iterator it = m_rows.begin(); it != m_rows.end(); ++it) {
+        if (it == m_first_row_shown)
+            hide = false;
+
+        if (hide) {
+            (*it)->Hide();
+        } else {
+            (*it)->Show();
+
+            visible_height += (*it)->Height();
+            if (visible_height >= max_visible_height)
+                hide = true;
+        }
+    }
+
+    RequirePreRender();
+}
+
 void ListBox::Disable(bool b/* = true*/)
 {
     Control::Disable(b);

--- a/GG/src/dialogs/FileDlg.cpp
+++ b/GG/src/dialogs/FileDlg.cpp
@@ -452,7 +452,7 @@ void FileDlg::FileSetChanged(const ListBox::SelectionSet& files)
     std::string all_files;
     bool dir_selected = false;
     for (ListBox::SelectionSet::const_iterator it = files.begin(); it != files.end(); ++it) {
-        std::string filename = boost::polymorphic_downcast<TextControl*>((***it)[0])->Text();
+        std::string filename = !(***it).empty() ? boost::polymorphic_downcast<TextControl*>((***it).at(0))->Text() : "";
         if (filename[0] != '[') {
             if (!all_files.empty())
                 all_files += " ";
@@ -690,7 +690,7 @@ void FileDlg::OpenDirectory()
         return;
 
     std::string directory;
-    directory = boost::polymorphic_downcast<TextControl*>((***sels.begin())[0])->Text();
+    directory = !(***sels.begin()).empty() ? boost::polymorphic_downcast<TextControl*>((***sels.begin()).at(0))->Text() : "";
 
     if (directory.size() < 2 || directory[0] != '[')
         return;

--- a/UI/CUIControls.cpp
+++ b/UI/CUIControls.cpp
@@ -1552,12 +1552,12 @@ EmpireColorSelector::EmpireColorSelector(GG::Y h) :
 }
 
 GG::Clr EmpireColorSelector::CurrentColor() const
-{ return (**CurrentItem())[0]->Color(); }
+{ return !(**CurrentItem()).empty() ? (**CurrentItem()).at(0)->Color() : GG::CLR_RED; }
 
 void EmpireColorSelector::SelectColor(const GG::Clr& clr) {
     for (iterator list_it = begin(); list_it != end(); ++list_it) {
         const GG::ListBox::Row* row = *list_it;
-        if (row && !row->empty() && (*row)[0]->Color() == clr) {
+        if (row && !row->empty() && row->at(0)->Color() == clr) {
             Select(list_it);
             return;
         }
@@ -1568,7 +1568,7 @@ void EmpireColorSelector::SelectColor(const GG::Clr& clr) {
 void EmpireColorSelector::SelectionChanged(GG::DropDownList::iterator it) {
     const GG::ListBox::Row* row = *it;
     if (row && !row->empty())
-        ColorChangedSignal((*row)[0]->Color());
+        ColorChangedSignal(!row->empty() ? row->at(0)->Color() : GG::CLR_RED);
     else
         ErrorLogger() << "EmpireColorSelector::SelectionChanged had trouble getting colour from row!";
 }

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -1872,9 +1872,9 @@ void BasesListBox::BaseRightClicked(GG::ListBox::iterator it, const GG::Pt& pt, 
                 if (result != "" && result != design->Name()) {
                     HumanClientApp::GetApp()->Orders().IssueOrder(
                         OrderPtr(new ShipDesignOrder(client_empire_id, design_id, result)));
-                    ShipDesignPanel* design_panel = dynamic_cast<ShipDesignPanel*>(
-                        !design_row->empty() ? design_row->at(0) : 0);
-                    design_panel->Update();
+                    if (!design_row->empty())
+                        if (ShipDesignPanel* design_panel = dynamic_cast<ShipDesignPanel*>(design_row->at(0)))
+                            design_panel->Update();
                 }
                 break;
             }

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -458,7 +458,7 @@ void PartsListBox::PartsListBoxRow::ChildrenDraggedAway(const std::vector<GG::Wn
     // find control in row
     unsigned int i = -1;
     for (i = 0; i < size(); ++i) {
-        dragged_control = (*this)[i];
+        dragged_control = !empty() ? at(i) : 0;
         if (dragged_control == control)
             break;
         else
@@ -1872,7 +1872,8 @@ void BasesListBox::BaseRightClicked(GG::ListBox::iterator it, const GG::Pt& pt, 
                 if (result != "" && result != design->Name()) {
                     HumanClientApp::GetApp()->Orders().IssueOrder(
                         OrderPtr(new ShipDesignOrder(client_empire_id, design_id, result)));
-                    ShipDesignPanel* design_panel = dynamic_cast<ShipDesignPanel*>((*design_row)[0]);
+                    ShipDesignPanel* design_panel = dynamic_cast<ShipDesignPanel*>(
+                        !design_row->empty() ? design_row->at(0) : 0);
                     design_panel->Update();
                 }
                 break;

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -2072,7 +2072,7 @@ public:
         assert(drop_target_row);
         assert(!drop_target_row->empty());
 
-        GG::Control* control = (*drop_target_row)[0];
+        GG::Control* control = !drop_target_row->empty() ? drop_target_row->at(0) : 0;
         assert(control);
 
         FleetDataPanel* drop_target_data_panel = boost::polymorphic_downcast<FleetDataPanel*>(control);
@@ -2228,7 +2228,7 @@ private:
         GG::ListBox::Row* selected_row = *row_it;
         assert(selected_row);
         assert(!selected_row->empty());
-        GG::Control* control = (*selected_row)[0];
+        GG::Control* control = !selected_row->empty() ? selected_row->at(0) : 0;
         FleetDataPanel* data_panel = boost::polymorphic_downcast<FleetDataPanel*>(control);
         assert(data_panel);
 
@@ -2279,7 +2279,7 @@ private:
             return;
         }
 
-        GG::Control* control = (*selected_row)[0];
+        GG::Control* control = !selected_row->empty() ? selected_row->at(0) : 0;;
         if (!control) {
             ErrorLogger() << "FleetsListBox::ClearHighlighting : null control in selected row!";
             return;
@@ -2658,7 +2658,7 @@ void FleetDetailPanel::UniverseObjectDeleted(TemporaryPtr<const UniverseObject> 
 void FleetDetailPanel::ShipSelectionChanged(const GG::ListBox::SelectionSet& rows) {
     for (GG::ListBox::iterator it = m_ships_lb->begin(); it != m_ships_lb->end(); ++it) {
         try {
-            ShipDataPanel* ship_panel = boost::polymorphic_downcast<ShipDataPanel*>((**it)[0]);
+            ShipDataPanel* ship_panel = boost::polymorphic_downcast<ShipDataPanel*>(!(**it).empty() ? (**it).at(0) : 0);
             ship_panel->Select(rows.find(it) != rows.end());
         } catch (const std::exception& e) {
             ErrorLogger() << "FleetDetailPanel::ShipSelectionChanged caught exception: " << e.what();
@@ -3413,8 +3413,8 @@ void FleetWnd::FleetSelectionChanged(const GG::ListBox::SelectionSet& rows) {
 
     for (GG::ListBox::iterator it = m_fleets_lb->begin(); it != m_fleets_lb->end(); ++it) {
         try {
-            FleetDataPanel* fleet_panel = boost::polymorphic_downcast<FleetDataPanel*>((**it)[0]);
-            fleet_panel->Select(rows.find(it) != rows.end());
+            if (FleetDataPanel* fleet_panel = boost::polymorphic_downcast<FleetDataPanel*>(!(**it).empty() ? (**it).at(0) : 0))
+                fleet_panel->Select(rows.find(it) != rows.end());
         } catch (const std::exception& e) {
             ErrorLogger() << "FleetWnd::FleetSelectionChanged caught exception: " << e.what();
             continue;

--- a/UI/MultiplayerLobbyWnd.cpp
+++ b/UI/MultiplayerLobbyWnd.cpp
@@ -332,7 +332,7 @@ namespace {
             m_color_selector->SelectColor(m_player_data.m_empire_color);
 
             // set previous player name indication
-            if (size() >=5)
+            if (size() >= 5)
                 boost::polymorphic_downcast<GG::Label*>(at(4))->SetText(it->second.m_player_name);
 
             DataChangedSignal();

--- a/UI/MultiplayerLobbyWnd.cpp
+++ b/UI/MultiplayerLobbyWnd.cpp
@@ -332,7 +332,8 @@ namespace {
             m_color_selector->SelectColor(m_player_data.m_empire_color);
 
             // set previous player name indication
-            boost::polymorphic_downcast<GG::Label*>(operator[](4))->SetText(it->second.m_player_name);
+            if (size() >=5)
+                boost::polymorphic_downcast<GG::Label*>(at(4))->SetText(it->second.m_player_name);
 
             DataChangedSignal();
         }

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -2352,7 +2352,7 @@ void ObjectListWnd::ObjectSelectionChanged(const GG::ListBox::SelectionSet& rows
             ErrorLogger() << "ObjectListWnd::ObjectSelectionChanged got empty row";
             continue;
         }
-        GG::Control* control = (*row)[0];
+        GG::Control* control = !row->empty() ? row->at(0) : 0;
         if (!control) {
             ErrorLogger() << "ObjectListWnd::ObjectSelectionChanged couldn't get control from row";
             continue;

--- a/UI/PlayerListWnd.cpp
+++ b/UI/PlayerListWnd.cpp
@@ -673,7 +673,7 @@ void PlayerListWnd::PlayerSelectionChanged(const GG::ListBox::SelectionSet& rows
             ErrorLogger() << "PlayerListWnd::PlayerSelectionChanged got empty row";
             continue;
         }
-        GG::Control* control = (*row)[0];
+        GG::Control* control = !row->empty() ? row->at(0) : 0;
         if (!control) {
             ErrorLogger() << "PlayerListWnd::PlayerSelectionChanged couldn't get control from row";
             continue;

--- a/UI/QueueListBox.cpp
+++ b/UI/QueueListBox.cpp
@@ -134,7 +134,7 @@ void QueueListBox::Render() {
         if (m_drop_point == end())
             ul.y = lr.y;
         if (!row->empty()) {
-            GG::Control* panel = (*row)[0];
+            GG::Control* panel =  row->at(0);
             ul.x = panel->Left();
             lr.x = panel->Right();
         }

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -925,7 +925,7 @@ void SaveFileDialog::UpdateDirectory(const std::string& newdir) {
 void SaveFileDialog::DirectoryDropdownSelect(GG::DropDownList::iterator selection) {
     GG::DropDownList::Row& row = **selection;
     if (row.size() > 0) {
-        GG::Label* control = dynamic_cast<GG::Label*>(row[0]);
+        GG::Label* control = dynamic_cast<GG::Label*>(row.at(0));
         if (control) {
             UpdateDirectory(control->Text());
         }

--- a/UI/ServerConnectWnd.cpp
+++ b/UI/ServerConnectWnd.cpp
@@ -197,10 +197,9 @@ void ServerConnectWnd::OkClicked()
         m_result.second = "HOST GAME SELECTED";
     } else {
         m_result.second = *m_IP_address_edit;
-        if (m_result.second == "") {
+        if (m_result.second == "" && !(***m_servers_lb->Selections().begin()).empty()) {
             m_result.second =
-                boost::polymorphic_downcast<GG::Label*>(
-                    (***m_servers_lb->Selections().begin())[0])->Text();
+                boost::polymorphic_downcast<GG::Label*>((***m_servers_lb->Selections().begin()).at(0))->Text() ;
         }
     }
     CUIWnd::CloseClicked();

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -740,7 +740,7 @@ namespace {
 
         virtual void PreRender() {
             // If there is no control add it.
-            if (!size())
+            if (GetLayout()->Children().empty())
                 Init();
 
             GG::ListBox::Row::PreRender();
@@ -2798,6 +2798,7 @@ SidePanel::SidePanel(const std::string& config_name) :
     m_system_name->DisableDropArrow();
     m_system_name->SetInteriorColor(GG::Clr(0, 0, 0, 200));
     m_system_name->ManuallyManageColProps();
+    m_system_name->NormalizeRowsOnInsert(false);
     m_system_name->SetNumCols(1);
     AttachChild(m_system_name);
 

--- a/UI/TechTreeWnd.cpp
+++ b/UI/TechTreeWnd.cpp
@@ -1680,11 +1680,11 @@ void TechTreeWnd::TechListBox::TechRow::Update() {
         return;
 
     std::string cost_str = boost::lexical_cast<std::string>(static_cast<int>(this_row_tech->ResearchCost(HumanClientApp::GetApp()->EmpireID()) + 0.5));
-    if (GG::TextControl* tc = dynamic_cast<GG::TextControl*>(!empty() ? at(2) : 0))
+    if (GG::TextControl* tc = dynamic_cast<GG::TextControl*>((size() >= 3) ? at(2) : 0))
         tc->SetText(cost_str);
 
     std::string time_str = boost::lexical_cast<std::string>(this_row_tech->ResearchTime(HumanClientApp::GetApp()->EmpireID()));
-    if (GG::TextControl* tc = dynamic_cast<GG::TextControl*>(!empty() ? at(3) : 0))
+    if (GG::TextControl* tc = dynamic_cast<GG::TextControl*>((size() >= 4) ? at(3) : 0))
         tc->SetText(time_str);
 }
 

--- a/UI/TechTreeWnd.cpp
+++ b/UI/TechTreeWnd.cpp
@@ -1680,11 +1680,11 @@ void TechTreeWnd::TechListBox::TechRow::Update() {
         return;
 
     std::string cost_str = boost::lexical_cast<std::string>(static_cast<int>(this_row_tech->ResearchCost(HumanClientApp::GetApp()->EmpireID()) + 0.5));
-    if (GG::TextControl* tc = dynamic_cast<GG::TextControl*>((*this)[2]))
+    if (GG::TextControl* tc = dynamic_cast<GG::TextControl*>(!empty() ? at(2) : 0))
         tc->SetText(cost_str);
 
     std::string time_str = boost::lexical_cast<std::string>(this_row_tech->ResearchTime(HumanClientApp::GetApp()->EmpireID()));
-    if (GG::TextControl* tc = dynamic_cast<GG::TextControl*>((*this)[3]))
+    if (GG::TextControl* tc = dynamic_cast<GG::TextControl*>(!empty() ? at(3) : 0))
         tc->SetText(time_str);
 }
 


### PR DESCRIPTION
This PR further speeds up and cleans up the SidePanel SystemName drop down list.

It adds `ListBox::Show(bool children)`, which unlike the default `Show()` does not show all of its children.  It only shows those rows which would be visible if the list rendered.  This means that the `PreRender()` of rows that would not be in the drop down are not called.  It still calls all of the `PreRender()` functions of the invisible items in the dropped portion of the list even when it is not dropped, so it is not optimal.

This speeds up re-generation of the SidePanel even when the SystemName is not expanded.  From profiling on a 1000 system map this improves the re-load of the SystemName caused by the Super-Testers revealing all of the systems from 400ms to 1.8ms.  In a regular game this cost is paid every time the SidePanel updates the SystemName contributing to late game sluggishness.

Making this change exposed a bug where `ListBox::Row::operator[]` creates dangling null Control* pointers, which causes problems (i.e. crashing), so that operator is removed in this PR.
