### PR TITLE
Fix bugs 1137 1138 drop down list mousewheel inconsistencies.

### DIFF
--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -732,7 +732,7 @@ void DropDownList::KeyPress(Key key, boost::uint32_t key_code_point, Flags<ModKe
 void DropDownList::MouseWheel(const Pt& pt, int move, Flags<ModKey> mod_keys)
 {
     if (!Disabled()) {
-        m_modal_picker->SignalChanged(m_modal_picker->Select(m_modal_picker->MouseWheelCommon(pt, move, mod_keys)));
+        m_modal_picker->SignalChanged(m_modal_picker->Select(m_modal_picker->MouseWheelCommon(pt, -move, mod_keys)));
     } else {
         Control::MouseWheel(pt, move, mod_keys);
     }

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -350,6 +350,8 @@ void ModalListPicker::KeyPress(Key key, boost::uint32_t key_code_point, Flags<Mo
 
 void ModalListPicker::MouseWheel(const Pt& pt, int move, Flags<ModKey> mod_keys)
 {
+    if (!LB()->InWindow(pt))
+        return;
     SignalChanged(Select(MouseWheelCommon(pt, move, mod_keys)));
 }
 


### PR DESCRIPTION
This PR addresses issues #1137 and #1138, with the behavior of the mousewheel when using the DropDownList.

It prevents scrolling the dropped drop down list when the pointer is outside of the list box.

It corrects the direction of the scrolling in the anchor area so that it matches the direction when the pointer in within the dropped list.