### PR TITLE
Fix drop down list doesn't track anchor on app resize.

### DIFF
--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -184,7 +184,7 @@ void ModalListPicker::ModalInit()
     m_lb_wnd->Hide(); // to enable CorrectListSize() to work
     CorrectListSize();
     m_resized_connection = Connect(GG::GUI::GetGUI()->WindowResizedSignal,
-                                     boost::bind(&ModalListPicker::WindowResizedSlot, this, _1, _2));
+                                   boost::bind(&ModalListPicker::WindowResizedSlot, this, _1, _2));
     Show();
 }
 


### PR DESCRIPTION
The drop down list and its anchor are in different event pumps.  If the
entire app is resized the drop down list may not track the anchor.

This commit closes the drop down list if the app is resized.

This PR fixes #1139.