### PR TITLE
PreRender specials panel after changes during prerender.

### DIFF
--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -1069,6 +1069,11 @@ void SidePanel::PlanetPanel::DoLayout() {
 
     Resize(GG::Pt(Width(), std::max(y, min_height)));
 
+    // DoLayout() is only called during prerender so prerender the specials panel
+    // in case it has pending changes.
+    if (m_specials_panel)
+        GG::GUI::PreRenderWindow(m_specials_panel);
+
     ResizedSignal();
 }
 


### PR DESCRIPTION
This fixes the last flickering item that I saw in the sidepanel, for issue #1093.

Changing the specials panel during prerender causes changes to be
scheduled for layout in the next prerender, which appears as a visible
glitch.

This commit forces a prerender of the specials panel at the end of 
PlanetPanel::DoLayout() which is only called during the prerender phase.
