### PR TITLE
fine-tuning the scanline shader

### DIFF
--- a/UI/CUIControls.cpp
+++ b/UI/CUIControls.cpp
@@ -2232,12 +2232,14 @@ namespace {
     ScanlineRenderer scanline_shader;
 }
 
-ScanlineControl::ScanlineControl(GG::X x, GG::Y y, GG::X w, GG::Y h, bool square /*= false*/) :
+ScanlineControl::ScanlineControl(GG::X x, GG::Y y, GG::X w, GG::Y h, bool square, GG::Clr clr):
     Control(x, y, w, h, GG::NO_WND_FLAGS),
-    m_square(square)
+    m_square(square),
+    m_color(clr)
 {}
 
 void ScanlineControl::Render() {
+    scanline_shader.SetColor(m_color);
     if (m_square)
         scanline_shader.RenderRectangle(UpperLeft(), LowerRight());
     else

--- a/UI/CUIControls.h
+++ b/UI/CUIControls.h
@@ -658,10 +658,15 @@ private:
 /** Renders scanlines over its area. */
 class ScanlineControl : public GG::Control {
 public:
-    ScanlineControl(GG::X x, GG::Y y, GG::X w, GG::Y h, bool square = false);
+    ScanlineControl(GG::X x, GG::Y y, GG::X w, GG::Y h, bool square = false, GG::Clr clr = GG::CLR_BLACK);
+
+    /** Changes the color used to draw the scanlines. */
+    void SetColor(GG::Clr clr) { m_color = clr; };
     virtual void Render();
+
 private:
     bool m_square;
+    GG::Clr m_color;
 };
 
 /** Consistently rendered popup menu */

--- a/UI/CUIDrawUtil.cpp
+++ b/UI/CUIDrawUtil.cpp
@@ -390,7 +390,7 @@ class ScanlineRenderer::ScanlineRendererImpl {
 public:
     ScanlineRendererImpl() :
         m_scanline_shader(), m_failed_init(false)
-    {}
+    { m_color = GG::CLR_BLACK; }
 
     void StartUsing() {
         if (m_failed_init)
@@ -413,6 +413,11 @@ public:
         float fog_scanline_spacing = static_cast<float>(GetOptionsDB().Get<double>("UI.system-fog-of-war-spacing"));
         m_scanline_shader->Use();
         m_scanline_shader->Bind("scanline_spacing", fog_scanline_spacing);
+        m_scanline_shader->Bind("line_color", m_color.r * (1.f / 255.f), m_color.g * (1.f / 255.f), m_color.b * (1.f / 255.f), m_color.a * (1.f / 255.f));
+    }
+
+    void SetColor(GG::Clr clr) {
+        m_color = clr;
     }
 
     void StopUsing()
@@ -432,6 +437,7 @@ public:
 
     boost::shared_ptr<ShaderProgram> m_scanline_shader;
     bool m_failed_init;
+    GG::Clr m_color;
 };
 
 
@@ -451,6 +457,9 @@ void ScanlineRenderer::RenderRectangle(const GG::Pt& ul, const GG::Pt& lr)
 
 void ScanlineRenderer::StartUsing()
 { pimpl->StartUsing(); }
+
+void ScanlineRenderer::SetColor(GG::Clr clr)
+{ pimpl->SetColor(clr); }
 
 void ScanlineRenderer::StopUsing()
 { pimpl->StopUsing(); }

--- a/UI/CUIDrawUtil.h
+++ b/UI/CUIDrawUtil.h
@@ -108,6 +108,9 @@ public:
     /** Draw scanlines in the square area bounded by \p ul and \p lr.*/
     void RenderRectangle(const GG::Pt& ul, const GG::Pt& lr);
 
+    /** Changes the color used to draw the scanlines. Set color before calling StartUsing()*/
+    void SetColor(GG::Clr clr);
+
     /** Start using ScanlineRenderer to draw arbitrary shapes with the scanline
         shader program.*/
     void StartUsing();

--- a/UI/FleetButton.cpp
+++ b/UI/FleetButton.cpp
@@ -251,8 +251,9 @@ void FleetButton::Init(const std::vector<int>& fleet_IDs, SizeType size_type) {
         }
     }
 
-    // Create scanline renderer control
-    m_scanline_control = new ScanlineControl(GG::X0, GG::Y0, Width(), Height());
+    // Create scanline renderer control, use opposite color of fleet btn
+    GG::Clr opposite_clr(255 - Color().r, 255 - Color().g, 255 - Color().b, 64);
+    m_scanline_control = new ScanlineControl(GG::X0, GG::Y0, Width(), Height(), false, opposite_clr);
 
     if (!at_least_one_fleet_visible)
         AttachChild(m_scanline_control);

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -1521,7 +1521,6 @@ void FleetDataPanel::Refresh() {
         if ((fleet->GetVisibility(client_empire_id) < VIS_BASIC_VISIBILITY)
             && GetOptionsDB().Get<bool>("UI.system-fog-of-war"))
         {
-            // TODO: load fleetwnd scanline color from optionsDB
             m_scanline_control = new ScanlineControl(GG::X0, GG::Y0, DataPanelIconSpace().x, ClientHeight(), true,
                                                      GetOptionsDB().Get<StreamableColor>("UI.fleet-wnd-scanline-clr").ToClr());
             AttachChild(m_scanline_control);

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -440,7 +440,9 @@ namespace {
     }
 
     void AddOptions(OptionsDB& db) {
-        db.Add("UI.fleet-wnd-aggression",   UserStringNop("OPTIONS_DB_FLEET_WND_AGGRESSION"),   INVALID_FLEET_AGGRESSION,   Validator<NewFleetAggression>());
+        db.Add("UI.fleet-wnd-aggression",   UserStringNop("OPTIONS_DB_FLEET_WND_AGGRESSION"),       INVALID_FLEET_AGGRESSION,                   Validator<NewFleetAggression>());
+        db.Add("UI.fleet-wnd-scanline-clr", UserStringNop("OPTIONS_DB_UI_FLEET_WND_SCANLINE_CLR"),  StreamableColor(GG::Clr(24, 24, 24, 192)),  Validator<StreamableColor>());
+        
     }
     bool temp_bool = RegisterOptions(&AddOptions);
 
@@ -851,7 +853,8 @@ void ShipDataPanel::SetShipIcon() {
     if ((ship->GetVisibility(client_empire_id) < VIS_BASIC_VISIBILITY)
         && GetOptionsDB().Get<bool>("UI.system-fog-of-war"))
     {
-        m_scanline_control = new ScanlineControl(GG::X0, GG::Y0, m_ship_icon->Width(), m_ship_icon->Height(), true);
+        m_scanline_control = new ScanlineControl(GG::X0, GG::Y0, m_ship_icon->Width(), m_ship_icon->Height(), true,
+                                                 GetOptionsDB().Get<StreamableColor>("UI.fleet-wnd-scanline-clr").ToClr());
         AttachChild(m_scanline_control);
     }
 }
@@ -1518,7 +1521,9 @@ void FleetDataPanel::Refresh() {
         if ((fleet->GetVisibility(client_empire_id) < VIS_BASIC_VISIBILITY)
             && GetOptionsDB().Get<bool>("UI.system-fog-of-war"))
         {
-            m_scanline_control = new ScanlineControl(GG::X0, GG::Y0, DataPanelIconSpace().x, ClientHeight(), true);
+            // TODO: load fleetwnd scanline color from optionsDB
+            m_scanline_control = new ScanlineControl(GG::X0, GG::Y0, DataPanelIconSpace().x, ClientHeight(), true,
+                                                     GetOptionsDB().Get<StreamableColor>("UI.fleet-wnd-scanline-clr").ToClr());
             AttachChild(m_scanline_control);
         }
 

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -125,6 +125,8 @@ namespace {
 
         db.Add("UI.system-fog-of-war",              UserStringNop("OPTIONS_DB_UI_SYSTEM_FOG"),                      true,       Validator<bool>());
         db.Add("UI.system-fog-of-war-spacing",      UserStringNop("OPTIONS_DB_UI_SYSTEM_FOG_SPACING"),              4.0,        RangedStepValidator<double>(0.25, 1.5, 8.0));
+        db.Add("UI.system-fog-of-war-clr",          UserStringNop("OPTIONS_DB_UI_SYSTEM_FOG_CLR"),                  StreamableColor(GG::Clr(36, 36, 36, 192)),      Validator<StreamableColor>());
+        db.Add("UI.field-fog-of-war-clr",           UserStringNop("OPTIONS_DB_UI_FIELD_FOG_CLR"),                   StreamableColor(GG::Clr(0, 0, 0, 64)),          Validator<StreamableColor>());
 
         db.Add("UI.system-icon-size",               UserStringNop("OPTIONS_DB_UI_SYSTEM_ICON_SIZE"),                14,         RangedValidator<int>(8, 50));
 
@@ -1585,6 +1587,7 @@ void MapWnd::RenderFields() {
         glBindTexture(GL_TEXTURE_2D, 0);
         //glPolygonMode(GL_FRONT_AND_BACK, GL_LINE);
 
+        m_scanline_shader.SetColor(GetOptionsDB().Get<StreamableColor>("UI.field-fog-of-war-clr").ToClr()); 
         m_scanline_shader.StartUsing();
 
         glDrawArrays(GL_TRIANGLES, 0, m_field_scanline_circles.size());
@@ -1743,6 +1746,7 @@ void MapWnd::RenderSystems() {
             if (fog_scanlines
                 && (universe.GetObjectVisibilityByEmpire(it->first, empire_id) <= VIS_BASIC_VISIBILITY))
             {
+                m_scanline_shader.SetColor(GetOptionsDB().Get<StreamableColor>("UI.system-fog-of-war-clr").ToClr());
                 m_scanline_shader.RenderCircle(circle_ul, circle_lr);
             }
 

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -401,9 +401,10 @@ namespace {
 
     /** Adds options related to sidepanel to Options DB. */
     void        AddOptions(OptionsDB& db) {
-        db.Add("UI.sidepanel-planet-max-diameter",  UserStringNop("OPTIONS_DB_UI_SIDEPANEL_PLANET_MAX_DIAMETER"),  128,    RangedValidator<int>(16, 512));
-        db.Add("UI.sidepanel-planet-min-diameter",  UserStringNop("OPTIONS_DB_UI_SIDEPANEL_PLANET_MIN_DIAMETER"),  24,     RangedValidator<int>(8,  128));
-        db.Add("UI.sidepanel-planet-shown",         UserStringNop("OPTIONS_DB_UI_SIDEPANEL_PLANET_SHOWN"),         true,   Validator<bool>());
+        db.Add("UI.sidepanel-planet-max-diameter",   UserStringNop("OPTIONS_DB_UI_SIDEPANEL_PLANET_MAX_DIAMETER"),  128,    RangedValidator<int>(16, 512));
+        db.Add("UI.sidepanel-planet-min-diameter",   UserStringNop("OPTIONS_DB_UI_SIDEPANEL_PLANET_MIN_DIAMETER"),  24,     RangedValidator<int>(8,  128));
+        db.Add("UI.sidepanel-planet-shown",          UserStringNop("OPTIONS_DB_UI_SIDEPANEL_PLANET_SHOWN"),         true,   Validator<bool>());
+        db.Add("UI.sidepanel-planet-fog-of-war-clr", UserStringNop("OPTIONS_DB_UI_PLANET_FOG_CLR"),                 StreamableColor(GG::Clr(0, 0, 0, 128)), Validator<StreamableColor>());
     }
     bool temp_bool = RegisterOptions(&AddOptions);
 
@@ -650,8 +651,10 @@ public:
         }
 
         // render fog of war over planet if it's not visible to this client's player
-        if ((m_visibility <= VIS_BASIC_VISIBILITY) && GetOptionsDB().Get<bool>("UI.system-fog-of-war"))
+        if ((m_visibility <= VIS_BASIC_VISIBILITY) && GetOptionsDB().Get<bool>("UI.system-fog-of-war")) {
+            s_scanline_shader.SetColor(GetOptionsDB().Get<StreamableColor>("UI.sidepanel-planet-fog-of-war-clr").ToClr());
             s_scanline_shader.RenderCircle(ul, lr);
+        }
     }
 
     void Refresh() {

--- a/default/shaders/scanlines.frag
+++ b/default/shaders/scanlines.frag
@@ -1,12 +1,12 @@
 
 // GLSL fragment shader that draws horizontal scanlines
 uniform float   scanline_spacing;                       // distance between repetitions of pattern
+uniform vec4    line_color;                             // color of darkened lines
 
-const vec4      half_gray = vec4(0.0, 0.0, 0.0, 0.5);   // darkened pixels
 const vec4      transparent = vec4(1.0, 1.0, 1.0, 0.0); // undarkened pixels
 
 void main() {
     gl_FragColor = transparent;
     if (mod(gl_FragCoord.y, scanline_spacing) >= (scanline_spacing / 2.0))
-        gl_FragColor = half_gray;
+        gl_FragColor = line_color;
 }

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1401,6 +1401,15 @@ Toggles whether to render fog of war scan-line shading over system icons.
 OPTIONS_DB_UI_SYSTEM_FOG_SPACING
 Sets spacing (in pixels) between fog of war scan-lines.
 
+OPTIONS_DB_UI_SYSTEM_FOG_CLR
+Sets the color of the scan-line shading over system icons.
+
+OPTIONS_DB_UI_FIELD_FOG_CLR
+Sets the color of the scan-line shading over field icons.
+
+OPTIONS_DB_UI_PLANET_FOG_CLR
+Sets the color of the scan-line shading over planet graphics on the sidepanel.
+
 OPTIONS_DB_UI_SYSTEM_CIRCLES
 Toggles whether to draw circles around systems.
 
@@ -1424,6 +1433,9 @@ Sets minimum zoom level at which tiny fleet icons are shown on the galaxy map. A
 
 OPTIONS_DB_UI_FLEET_SELECTION_INDICATOR_SIZE
 Sets size of fleet selection indicator, relative to fleet icon size.
+
+OPTIONS_DB_UI_FLEET_WND_SCANLINE_CLR
+Sets the color of the scan-line shading over ship/fleet graphics on the fleet window.
 
 OPTIONS_DB_SHOW_FLEET_ETA
 Show fleet ETA (for moving fleets) in Fleet Window


### PR DESCRIPTION
In reference to https://github.com/freeorion/freeorion/issues/1148:
This pull request improves the use of the scanline shader (sls) throughout the game by allowing to assign a color to it. Currently, the sls is used for the fleet and ship data panel on the fleet window, planets on the sidepanel, as well as fleet buttons, systems and fields on the map screen. For the sls of fleet buttons, the complementary color of the fleet buttons is used, which helps a lot with the sensor ghost issue referenced above. All the other uses of the sls have been fine-tuned.

As always, I'm especially grateful for advice regarding the C++ code.

![sls-test](https://cloud.githubusercontent.com/assets/12985960/20891056/7e388ad0-bb09-11e6-8c46-55e5a73004fb.jpg)
