### PR TITLE
Fix bug in SidePanel::DoPanelsLayout.

### DIFF
--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -2583,7 +2583,7 @@ void SidePanel::PlanetPanelContainer::DoPanelsLayout() {
 
     // Determine if scroll bar is required for height or expected because it is already present.
     GG::Y available_height = Height();
-    GG::Y initially_used_height = GG::Y(0);
+    GG::Y initially_used_height = GG::Y0;
     for (std::vector<PlanetPanel*>::iterator it = m_planet_panels.begin(); it != m_planet_panels.end(); ++it) {
         initially_used_height += (*it)->Height() + EDGE_PAD;
     }


### PR DESCRIPTION
DoPanelsLayout is unstable when a PlanetPanel that is narrowed for the
scroll bar is also shorter.  This results in the layout flickering
between a SidePanel with vscroll and without.

PlanetPanels with expanded buildings can be shorter with the scroll bar
because it might resize the building icons to be smaller when the scroll
bar is added.

This commit just keeps the layout with the scroll bar even if adding the
scroll makes the panels short enough to not require the scroll bar.