### PR TITLE
Make ListBox::Show show the header with other non-row children.

### DIFF
--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -987,12 +987,14 @@ void ListBox::Show(bool show_children /* = true*/)
     if (!show_children)
         return;
 
-    // Deal with non row children normally
+    // Deal with the header row and non row children normally
     for (std::list<Wnd*>::const_iterator it = Children().begin();
          it != Children().end(); ++it)
     {
-        if (!dynamic_cast<Row*>(*it))
-            (*it)->Show(show_children);
+        const Row* row(dynamic_cast<Row*>(*it));
+        bool is_regular_row(row && row != m_header_row);
+        if (!is_regular_row)
+            (*it)->Show(true);
     }
 
     // Show rows that will be visible when rendered but don't prerender them.


### PR DESCRIPTION
`ListBox::Show(true)` was not detecting and showing the header row when requested.  The header must always be shown when the children of the `ListBox` are to be shown.

This commit/PR fixes that.

It should fix #1161.