### PR TITLE
Fix use after free error.

### DIFF
--- a/network/ServerNetworking.h
+++ b/network/ServerNetworking.h
@@ -167,7 +167,7 @@ public:
     //@}
 
     /** \name Accessors */ //@{
-    /** Returns true iff EstablishPlayer() has been called on this
+    /** Returns true if EstablishPlayer() successfully has been called on this
         connection. */
     bool EstablishedPlayer() const;
 


### PR DESCRIPTION
Fix use-after-free error. Shutdown socket before closing and use shared pointer to prevent free while handlers are active.