### PR TITLE
Rewrite get_fleet_orders_from_system_targets

### DIFF
--- a/default/python/AI/AIFleetMission.py
+++ b/default/python/AI/AIFleetMission.py
@@ -471,8 +471,8 @@ class AIFleetMission(object):
 
         # for some targets fleet has to visit systems and therefore fleet visit them
         if self.target:
-            system_targets_required_to_visit = [self.target.get_system()]
-            orders_to_visit_systems = MoveUtilsAI.get_fleet_orders_from_system_targets(self.fleet, system_targets_required_to_visit)
+            system_to_visit = self.target.get_system()
+            orders_to_visit_systems = MoveUtilsAI.create_move_orders_to_system(self.fleet, system_to_visit)
             # TODO: if fleet doesn't have enough fuel to get to final target, consider resetting Mission
             for fleet_order in orders_to_visit_systems:
                 self.orders.append(fleet_order)


### PR DESCRIPTION
- Function is renamed to create_move_orders_to_system
- Function now is usable only for a single target (never was called for multiple targets before)
- Simplified code logic