### PR TITLE
Make planet stealth techs effect only owned planet not all system planets

### DIFF
--- a/default/scripting/techs/spy/STEALTH_1.focs.txt
+++ b/default/scripting/techs/spy/STEALTH_1.focs.txt
@@ -10,10 +10,7 @@ Tech
         EffectsGroup
             scope = And [
                 OwnedBy empire = Source.Owner
-                Or [
-                    Planet
-                    System
-                ]
+                Planet
             ]
             activation = And [
                 Not OwnerHasTech name = "SPY_STEALTH_2"

--- a/default/scripting/techs/spy/STEALTH_2.focs.txt
+++ b/default/scripting/techs/spy/STEALTH_2.focs.txt
@@ -10,10 +10,7 @@ Tech
         EffectsGroup
             scope = And [
                 OwnedBy empire = Source.Owner
-                Or [
-                    Planet
-                    System
-                ]
+                Planet
             ]
             activation = And [
                 Not OwnerHasTech name = "SPY_STEALTH_3"

--- a/default/scripting/techs/spy/STEALTH_3.focs.txt
+++ b/default/scripting/techs/spy/STEALTH_3.focs.txt
@@ -10,10 +10,7 @@ Tech
         EffectsGroup
             scope = And [
                 OwnedBy empire = Source.Owner
-                Or [
-                    Planet
-                    System
-                ]
+                Planet
             ]
             activation = Not OwnerHasTech name = "SPY_STEALTH_4"
             effects = [

--- a/default/scripting/techs/spy/STEALTH_4.focs.txt
+++ b/default/scripting/techs/spy/STEALTH_4.focs.txt
@@ -14,10 +14,7 @@ Tech
         EffectsGroup
             scope = And [
                 OwnedBy empire = Source.Owner
-                Or [
-                    Planet
-                    System
-                ]
+                Planet
             ]
             effects = [
                 AddSpecial name = "VOID_SLAVE_SPECIAL"


### PR DESCRIPTION
Recent changes to allow system renaming allow systems to be owned if only a single empire owns
planets in a system.

The current version of the planetary stealth techs applies to all
planets in a system if the system is owned by the empire.  This means
that uncolonized planets in a system with colonies/outposts controlled
by a single empire pick up the stealth boost.

This commit reduces the scope of the effect to only the owned planet.

I was not sure what the original intent of the `Or` clause with system and planet was in the original code.

I also looked through all uses of `OwndedBy` in the scripting and did not see other examples of this problem.