### PR TITLE
Improve fleet tooltip for fighters

### DIFF
--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -538,6 +538,7 @@ namespace {
 
         // UI behavior
         db.Add("UI.tooltip-delay",              UserStringNop("OPTIONS_DB_UI_TOOLTIP_DELAY"),              500,        RangedValidator<int>(0, 3000));
+        db.Add("UI.tooltip.extended-delay",     UserStringNop("OPTIONS_DB_UI_TOOLTIP_LONG_DELAY"),         5000,       RangedValidator<int>(0, 30000));
         db.Add("UI.multiple-fleet-windows",     UserStringNop("OPTIONS_DB_UI_MULTIPLE_FLEET_WINDOWS"),     false);
         db.Add("UI.window-quickclose",          UserStringNop("OPTIONS_DB_UI_WINDOW_QUICKCLOSE"),          true);
         db.Add("UI.auto-reposition-windows",    UserStringNop("OPTIONS_DB_UI_AUTO_REPOSITION_WINDOWS"),    true);

--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -538,7 +538,7 @@ namespace {
 
         // UI behavior
         db.Add("UI.tooltip-delay",              UserStringNop("OPTIONS_DB_UI_TOOLTIP_DELAY"),              500,        RangedValidator<int>(0, 3000));
-        db.Add("UI.tooltip.extended-delay",     UserStringNop("OPTIONS_DB_UI_TOOLTIP_LONG_DELAY"),         5000,       RangedValidator<int>(0, 30000));
+        db.Add("UI.tooltip.extended-delay",     UserStringNop("OPTIONS_DB_UI_TOOLTIP_LONG_DELAY"),         3500,       RangedValidator<int>(0, 30000));
         db.Add("UI.multiple-fleet-windows",     UserStringNop("OPTIONS_DB_UI_MULTIPLE_FLEET_WINDOWS"),     false);
         db.Add("UI.window-quickclose",          UserStringNop("OPTIONS_DB_UI_WINDOW_QUICKCLOSE"),          true);
         db.Add("UI.auto-reposition-windows",    UserStringNop("OPTIONS_DB_UI_AUTO_REPOSITION_WINDOWS"),    true);

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -925,10 +925,13 @@ void ShipDataPanel::Refresh() {
             it->second->SetBrowseInfoWnd(browse_wnd);
 
         } else if (it->first == METER_SECONDARY_STAT) {
-            boost::shared_ptr<GG::BrowseInfoWnd> browse_wnd(new IconTextBrowseWnd(
-                FightersIcon(), UserString("SHIP_FIGHTERS_TITLE"),
-                UserString("SHIP_FIGHTERS_STAT")));
+            boost::shared_ptr<GG::BrowseInfoWnd> browse_wnd(new ShipFightersBrowseWnd(
+                m_ship_id, it->first));
             it->second->SetBrowseInfoWnd(browse_wnd);
+            boost::shared_ptr<GG::BrowseInfoWnd> detailed_wnd(new ShipFightersBrowseWnd(
+                m_ship_id, it->first, true));
+            it->second->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip.extended-delay"), 1);
+            it->second->SetBrowseInfoWnd(detailed_wnd, 1);
 
         } else if (it->first == METER_POPULATION) {
             boost::shared_ptr<GG::BrowseInfoWnd> browse_wnd(new IconTextBrowseWnd(

--- a/UI/MeterBrowseWnd.cpp
+++ b/UI/MeterBrowseWnd.cpp
@@ -834,8 +834,7 @@ void ShipFightersBrowseWnd::UpdateEffectLabelsAndValues(GG::Y& top) {
 
     if (!m_show_all_bouts) {
         // Show damage for first wave (2nd combat round)
-        std::pair<int, float> first_wave = FightersDamageForBout(bay_total_capacity, hangar_current_fighters,
-                                                                    fighter_damage, 2);
+        std::pair<int, float> first_wave = FightersDamageForBout(bay_total_capacity, hangar_current_fighters, fighter_damage, 2);
         std::string launch_text = ColourWrappedtext(boost::lexical_cast<std::string>(first_wave.first), HIGHLIGHT_COLOR);
         std::string damage_label_text = boost::io::str(FlexibleFormat(UserString("TT_FIGHTER_DAMAGE"))
                                                        % launch_text % fighter_damage_text);
@@ -895,10 +894,10 @@ void ShipFightersBrowseWnd::UpdateEffectLabelsAndValues(GG::Y& top) {
 
         // Damage summary labels
         float total_dmg = FightersDamageForBout(bay_total_capacity, hangar_current_fighters, fighter_damage).second;
-        std::string detail_avg_text = boost::io::str(FlexibleFormat(UserString("SHIP_FIGHTERS_DAMAGE_AVERAGE"))
-            % ColourWrappedtext(DoubleToString(total_dmg / NUM_COMBAT_BOUTS, 3, false), DAMAGE_COLOR));
-        std::string detail_value_text = boost::io::str(FlexibleFormat(UserString("SHIP_FIGHTERS_DAMAGE_TOTAL"))
-            % ColourWrappedtext(DoubleToString(total_dmg, 3, false), DAMAGE_COLOR));
+        std::string avg_val =  ColourWrappedtext(DoubleToString(total_dmg / NUM_COMBAT_BOUTS, 3, false), DAMAGE_COLOR);
+        std::string detail_avg_text = boost::io::str(FlexibleFormat(UserString("SHIP_FIGHTERS_DAMAGE_AVERAGE")) % avg_val);
+        std::string total_val = ColourWrappedtext(DoubleToString(total_dmg, 3, false), DAMAGE_COLOR);
+        std::string detail_value_text = boost::io::str(FlexibleFormat(UserString("SHIP_FIGHTERS_DAMAGE_TOTAL")) % total_val);
 
         GG::Label* detail_summary_avg = new CUILabel(detail_avg_text, GG::FORMAT_RIGHT);
         detail_summary_avg->MoveTo(GG::Pt(GG::X0, top));

--- a/UI/MeterBrowseWnd.cpp
+++ b/UI/MeterBrowseWnd.cpp
@@ -19,6 +19,7 @@
 
 #include <boost/optional.hpp>
 #include <boost/tuple/tuple.hpp>
+#include <boost/math/special_functions/round.hpp>
 
 namespace {
     /** Returns text wrapped in GG RGBA tags for specified colour */
@@ -43,6 +44,10 @@ namespace {
 
     GG::X MeterBrowseValueWidth()
     { return GG::X(4*ClientUI::Pts()); }
+
+    GG::X FighterBrowseLabelWidth()
+    { return GG::X(10*ClientUI::Pts()); }
+
 }
 
 MeterBrowseWnd::MeterBrowseWnd(int object_id, MeterType primary_meter_type, MeterType secondary_meter_type/* = INVALID_METER_TYPE*/) :
@@ -579,5 +584,361 @@ void ShipDamageBrowseWnd::UpdateEffectLabelsAndValues(GG::Y& top) {
         m_effect_labels_and_values.push_back(std::make_pair(label, value));
 
         top += m_row_height;
+    }
+
+}
+
+namespace {
+    class ShipFightersBrowseRow : public GG::ListBox::Row {
+    public:
+        ShipFightersBrowseRow(const std::string& label, double value, double base_value = 0.0f) :
+                GG::ListBox::Row(FighterBrowseLabelWidth() + MeterBrowseValueWidth(), GG::Y1, "")
+        {
+            CUILabel* label_control = new CUILabel(label, GG::FORMAT_RIGHT);
+            push_back(label_control);
+            label_control->Resize(GG::Pt(FighterBrowseLabelWidth(), GG::Y(ClientUI::Pts()*3/2)));
+
+            std::string value_text;
+            if (base_value > 0.0f) {
+                std::string base_value_text = ColourWrappedtext(boost::lexical_cast<std::string>(base_value),
+                                                                ClientUI::StatIncrColor());
+                value_text = boost::io::str(FlexibleFormat(UserString("TT_N_OF_N"))
+                                            % boost::lexical_cast<std::string>(value) % base_value_text);
+            } else {
+                value_text = ColourWrappedtext(boost::lexical_cast<std::string>(value), ClientUI::StatIncrColor());
+            }
+            CUILabel* value_control = new CUILabel(value_text);
+            push_back(value_control);
+            value_control->Resize(GG::Pt(MeterBrowseValueWidth(), GG::Y(ClientUI::Pts()*3/2)));
+
+            Resize(GG::Pt(label_control->Width() + value_control->Width(),
+                          std::max(label_control->Height(), value_control->Height())));
+        }
+    };
+}
+
+ShipFightersBrowseWnd::ShipFightersBrowseWnd(int object_id, MeterType primary_meter_type, bool show_all_bouts /* = false*/) :
+    MeterBrowseWnd(object_id, primary_meter_type),
+    m_bay_list(0),
+    m_hangar_list(0),
+    m_show_all_bouts(show_all_bouts)
+{}
+
+void ShipFightersBrowseWnd::Initialize() {
+    m_row_height = GG::Y(ClientUI::Pts()*3/2);
+    const GG::X LABEL_WIDTH = FighterBrowseLabelWidth();
+    const GG::X VALUE_WIDTH = MeterBrowseValueWidth();
+    const GG::X TOTAL_WIDTH = ((LABEL_WIDTH + VALUE_WIDTH) * 2) + (EDGE_PAD * 3);
+    const GG::Clr BG_COLOR = ClientUI::WndColor();
+
+    // get objects and meters to verify that they exist
+    TemporaryPtr<const UniverseObject> ship = GetShip(m_object_id);
+    if (!ship) {
+        ErrorLogger() << "Couldn't get ship with id " << m_object_id;
+        return;
+    }
+    GG::Y top = GG::Y0;
+
+    // create controls and do layout
+    m_meter_title = new CUILabel("", GG::FORMAT_RIGHT);
+    m_meter_title->MoveTo(GG::Pt(GG::X0, top));
+    m_meter_title->Resize(GG::Pt(TOTAL_WIDTH, m_row_height));
+    m_meter_title->SetFont(ClientUI::GetBoldFont());
+    AttachChild(m_meter_title);
+
+    top += m_row_height;
+
+    m_bay_list = new CUIListBox();
+    m_bay_list->SetColor(BG_COLOR);
+    m_bay_list->SetInteriorColor(BG_COLOR);
+    m_bay_list->ManuallyManageColProps();
+    m_bay_list->SetNumCols(2);
+    m_bay_list->SetColWidth(0, LABEL_WIDTH - EDGE_PAD);
+    m_bay_list->SetColWidth(1, VALUE_WIDTH - EDGE_PAD);
+    m_bay_list->MoveTo(GG::Pt(GG::X0, top));
+    AttachChild(m_bay_list);
+
+    m_hangar_list = new CUIListBox();
+    m_hangar_list->SetColor(BG_COLOR);
+    m_hangar_list->SetInteriorColor(BG_COLOR);
+    m_hangar_list->ManuallyManageColProps();
+    m_hangar_list->SetNumCols(2);
+    m_hangar_list->SetColWidth(0, LABEL_WIDTH - EDGE_PAD);
+    m_hangar_list->SetColWidth(1, VALUE_WIDTH - EDGE_PAD);
+    m_hangar_list->MoveTo(GG::Pt(LABEL_WIDTH + VALUE_WIDTH + EDGE_PAD, top));
+    AttachChild(m_hangar_list);
+
+    UpdateSummary();
+
+    UpdateEffectLabelsAndValues(top);
+
+    Resize(GG::Pt(TOTAL_WIDTH + EDGE_PAD, top + EDGE_PAD));
+
+    m_initialized = true;
+}
+
+void ShipFightersBrowseWnd::UpdateImpl(std::size_t mode, const Wnd* target) {
+    if (!m_initialized)
+        Initialize();
+}
+
+void ShipFightersBrowseWnd::UpdateSummary() {
+    TemporaryPtr<const Ship> ship = GetShip(m_object_id);
+    if (!ship)
+        return;
+
+    // unpaired meter total for breakdown summary
+    float breakdown_total = ship->FighterCount();
+    std::string breakdown_meter_name = UserString("SHIP_FIGHTERS_TITLE");
+
+
+    // set accounting breakdown total / summary
+    if (m_meter_title)
+        m_meter_title->SetText(boost::io::str(FlexibleFormat(UserString("TT_BREAKDOWN_SUMMARY")) %
+                                              breakdown_meter_name %
+                                              DoubleToString(breakdown_total, 3, false)));
+}
+
+namespace {
+    /** Number of fighters that participated for @p bout and total damage inflicted
+     *  If @p bout is less than 1 (or unassigned), total damage is summed for all rounds
+     */
+    std::pair<int, float> FightersDamageForBout(int total_bay_capacity, int current_docked_fighters,
+                                                float fighter_damage, int bout = -1)
+    {
+        int last_bout = bout < 1 ? ShipFightersBrowseWnd::NUM_COMBAT_BOUTS : bout;
+        std::pair<int, float> retval = { 0, 0.0f };
+        int fighters_next_bout = 0;
+        int remaining_docked_fighters = current_docked_fighters;
+
+        for (int i = 1; i <= last_bout; ++i) {
+            retval.first += fighters_next_bout;
+            if (bout == last_bout)
+                retval.second = retval.first * fighter_damage;
+            else 
+                retval.second += retval.first * fighter_damage;
+
+            // launch fighters
+            fighters_next_bout = std::min(total_bay_capacity, remaining_docked_fighters);
+            remaining_docked_fighters -= fighters_next_bout;
+        }
+
+        return retval;
+    }
+}
+
+void ShipFightersBrowseWnd::UpdateEffectLabelsAndValues(GG::Y& top) {
+    // clear existing labels
+    for (unsigned int i = 0; i < m_effect_labels_and_values.size(); ++i) {
+        DeleteChild(m_effect_labels_and_values[i].first);
+        DeleteChild(m_effect_labels_and_values[i].second);
+    }
+    m_effect_labels_and_values.clear();
+    m_bay_list->DeleteChildren();
+    m_hangar_list->DeleteChildren();
+
+    // early return if no valid ship, ship design, or no parts in the design
+    TemporaryPtr<const Ship> ship = GetShip(m_object_id);
+    if (!ship) {
+        ErrorLogger() << "Couldn't get ship with id " << m_object_id;
+        return;
+    }
+    const ShipDesign* design = GetShipDesign(ship->DesignID());
+    if (!design)
+        return;
+    const std::vector<std::string>& parts = design->Parts();
+    if (parts.empty())
+        return;
+
+    const GG::Clr DAMAGE_COLOR = GG::CLR_ORANGE;
+    const GG::Clr HIGHLIGHT_COLOR = GG::CLR_YELLOW;
+    const GG::X LABEL_WIDTH = FighterBrowseLabelWidth();
+    const GG::X VALUE_WIDTH = MeterBrowseValueWidth();
+    const GG::X ROW_WIDTH = LABEL_WIDTH + EDGE_PAD + VALUE_WIDTH;
+
+    float fighter_damage = 0.0f;
+    std::pair<std::string, int> hangar_part;  // name, count
+    std::multimap<std::string, int> bay_parts;  // name, capacity
+    int hangar_current_fighters = 0;
+    int hangar_total_capacity = 0;
+    int bay_total_capacity = 0;
+
+    // populate values from hangars and bays
+    for (std::string part_name : parts) {
+        const PartType* part = GetPartType(part_name);
+        if (!part)
+            continue;
+        ShipPartClass part_class = part->Class();
+
+        if (part_class == PC_FIGHTER_BAY) {
+            float current_capacity = ship->CurrentPartMeterValue(METER_CAPACITY, part_name);
+            // store the current part and capacity, increase total bay capacity
+            bay_parts.insert(std::make_pair(part_name, current_capacity));
+            bay_total_capacity += current_capacity;
+            // TODO Account for METER_MAX_CAPACITY if this control is expanded for more detail
+
+        } else if (part_class == PC_FIGHTER_HANGAR) {
+            if (hangar_part.first.empty()) {
+                hangar_part.first = part_name;
+            } else if (hangar_part.first != part_name) {
+                ErrorLogger() << "Ship " << ship->ID() << "contains different hangar parts: "
+                              << hangar_part.first << ", " << part_name;
+            }
+            // set the current and total fighter capacity
+            hangar_current_fighters = ship->CurrentPartMeterValue(METER_CAPACITY, part_name);
+            hangar_total_capacity = ship->CurrentPartMeterValue(METER_MAX_CAPACITY, part_name);
+            fighter_damage = ship->CurrentPartMeterValue(METER_SECONDARY_STAT, part_name);
+            // hangars share the same ship meter, increase the count for later processing
+            hangar_part.second++;
+        }
+    }
+
+    //  no fighters, early return
+    if (hangar_part.second <= 0)
+        return;
+
+    // Add list summary labels
+    std::string bay_value_text = boost::lexical_cast<std::string>(bay_total_capacity);
+    std::string hangar_current_text = boost::lexical_cast<std::string>(hangar_current_fighters);
+
+    // highlight the lower value if not showing all bouts
+    if (!m_show_all_bouts) {
+        if (hangar_current_fighters <= bay_total_capacity)
+            hangar_current_text = ColourWrappedtext(hangar_current_text, HIGHLIGHT_COLOR);
+        else
+            bay_value_text = ColourWrappedtext(bay_value_text, HIGHLIGHT_COLOR);
+    }
+
+    std::string hangar_total_text = boost::lexical_cast<std::string>(hangar_total_capacity);
+    std::string hangar_value_text = boost::io::str(FlexibleFormat(UserString("TT_N_OF_N"))
+                                                   % hangar_current_text % hangar_total_text);
+
+    GG::Label* bay_summary = new CUILabel(boost::io::str(FlexibleFormat(UserString("TT_BREAKDOWN_SUMMARY"))
+                                                         % UserString("SHIP_FIGHTER_BAY_SUMMARY") % bay_value_text));
+    bay_summary->SetFont(ClientUI::GetBoldFont());
+    bay_summary->MoveTo(GG::Pt(GG::X0, top));
+    bay_summary->Resize(GG::Pt(LABEL_WIDTH + VALUE_WIDTH, m_row_height));
+    AttachChild(bay_summary);
+
+    GG::Label* hangar_summary = new CUILabel(boost::io::str(FlexibleFormat(UserString("TT_BREAKDOWN_SUMMARY"))
+                                                            % UserString("SHIP_FIGHTER_HANGAR_SUMMARY") % hangar_value_text));
+    hangar_summary->SetFont(ClientUI::GetBoldFont());
+    hangar_summary->MoveTo(GG::Pt(ROW_WIDTH, top));
+    hangar_summary->Resize(GG::Pt(LABEL_WIDTH + VALUE_WIDTH, m_row_height));
+    AttachChild(hangar_summary);
+    m_effect_labels_and_values.push_back(std::make_pair(bay_summary, hangar_summary));
+
+    top += m_row_height;
+
+    std::string fighter_damage_text = ColourWrappedtext(DoubleToString(fighter_damage, 3, false), DAMAGE_COLOR);
+
+    if (!m_show_all_bouts) {
+        // Show damage for first wave (2nd combat round)
+        std::pair<int, float> first_wave = FightersDamageForBout(bay_total_capacity, hangar_current_fighters,
+                                                                    fighter_damage, 2);
+        std::string launch_text = ColourWrappedtext(boost::lexical_cast<std::string>(first_wave.first), HIGHLIGHT_COLOR);
+        std::string damage_label_text = boost::io::str(FlexibleFormat(UserString("TT_FIGHTER_DAMAGE"))
+                                                       % launch_text % fighter_damage_text);
+        GG::Label* damage_label = new CUILabel(damage_label_text, GG::FORMAT_RIGHT);
+        damage_label->MoveTo(GG::Pt(GG::X0, top));
+        damage_label->Resize(GG::Pt(LABEL_WIDTH * 2 + EDGE_PAD, m_row_height));
+        AttachChild(damage_label);
+
+        std::string damage_value_text = DoubleToString(first_wave.second, 3, false);
+        GG::Label* damage_value = new CUILabel(ColourWrappedtext(damage_value_text, DAMAGE_COLOR));
+        damage_value->MoveTo(GG::Pt(LABEL_WIDTH * 2, top));
+        damage_value->Resize(GG::Pt(VALUE_WIDTH * 2, m_row_height));
+        damage_value->SetFont(ClientUI::GetBoldFont());
+        AttachChild(damage_value);
+        m_effect_labels_and_values.push_back(std::make_pair(damage_label, damage_value));
+
+        top += m_row_height;
+    } else {
+        // add labels for bay parts
+        for (std::multimap<std::string, int>::value_type& bay_part : bay_parts) {
+            const std::string& part_name = UserString(bay_part.first);
+            int fighter_total = bay_part.second;
+            m_bay_list->Insert(new ShipFightersBrowseRow(part_name, fighter_total));
+        }
+
+        // add a label for each hangar part, distributing the total fighters equally
+        int unaccounted_current_fighters = hangar_current_fighters;
+        int unaccounted_total_fighters = hangar_total_capacity;
+        const std::string& hangar_name = UserString(hangar_part.first);
+        for (int i = 0; i < hangar_part.second; ++i) {
+            int max_fighters = std::min(unaccounted_total_fighters, hangar_total_capacity / hangar_part.second);
+            // top heavy when current fighters do not distribute equally
+            int cur_fighters = std::min(unaccounted_current_fighters, std::min(max_fighters,
+                boost::math::iround(static_cast<float>(hangar_current_fighters) / hangar_part.second)));
+            unaccounted_current_fighters -= cur_fighters;
+            unaccounted_total_fighters -= max_fighters;
+            m_hangar_list->Insert(new ShipFightersBrowseRow(hangar_name, cur_fighters, max_fighters));
+        }
+        // validate that all fighters were accounted for
+        if (unaccounted_current_fighters != 0 || unaccounted_total_fighters != 0) {
+            DebugLogger() << "Display of number of fighters mismatched.  Current: "
+                          << unaccounted_current_fighters << "/" << hangar_current_fighters
+                          << " Total: " << unaccounted_total_fighters << "/" << hangar_total_capacity
+                          << "  For ship " << ship->ID() << " with design: \n" << design->Dump();
+        }
+
+        int max_rows = static_cast<int>(std::max(m_bay_list->NumRows(), m_hangar_list->NumRows()));
+        int list_vpad = max_rows > 0 ? 10 : 0;
+        const GG::Y LIST_HEIGHT = (m_row_height * max_rows) + list_vpad;
+
+        m_bay_list->MoveTo(GG::Pt(GG::X0, top));
+        m_bay_list->Resize(GG::Pt(ROW_WIDTH, LIST_HEIGHT));
+        m_hangar_list->MoveTo(GG::Pt(ROW_WIDTH + EDGE_PAD, top));
+        m_hangar_list->Resize(GG::Pt(ROW_WIDTH, LIST_HEIGHT));
+
+        top += LIST_HEIGHT;
+
+        // Damage summary labels
+        float total_dmg = FightersDamageForBout(bay_total_capacity, hangar_current_fighters, fighter_damage).second;
+        std::string detail_avg_text = boost::io::str(FlexibleFormat(UserString("SHIP_FIGHTERS_DAMAGE_AVERAGE"))
+            % ColourWrappedtext(DoubleToString(total_dmg / NUM_COMBAT_BOUTS, 3, false), DAMAGE_COLOR));
+        std::string detail_value_text = boost::io::str(FlexibleFormat(UserString("SHIP_FIGHTERS_DAMAGE_TOTAL"))
+            % ColourWrappedtext(DoubleToString(total_dmg, 3, false), DAMAGE_COLOR));
+
+        GG::Label* detail_summary_avg = new CUILabel(detail_avg_text, GG::FORMAT_RIGHT);
+        detail_summary_avg->MoveTo(GG::Pt(GG::X0, top));
+        detail_summary_avg->Resize(GG::Pt(LABEL_WIDTH + VALUE_WIDTH, m_row_height));
+        AttachChild(detail_summary_avg);
+
+        GG::Label* detail_summary_total = new CUILabel(detail_value_text, GG::FORMAT_RIGHT);
+        detail_summary_total->MoveTo(GG::Pt(ROW_WIDTH, top));
+        detail_summary_total->Resize(GG::Pt(LABEL_WIDTH + VALUE_WIDTH, m_row_height));
+        detail_summary_total->SetFont(ClientUI::GetBoldFont());
+        AttachChild(detail_summary_total);
+        m_effect_labels_and_values.push_back(std::make_pair(detail_summary_avg, detail_summary_total));
+
+        top += m_row_height;
+
+        // Damage labels for each combat round
+        for (int i = 2; i <= NUM_COMBAT_BOUTS; ++i) {
+            std::pair<int, float> current_bout = FightersDamageForBout(bay_total_capacity, hangar_current_fighters,
+                                                                       fighter_damage, i);
+            std::string launch_text = boost::lexical_cast<std::string>(current_bout.first);
+            std::string damage_label_text = boost::io::str(FlexibleFormat(UserString("TT_FIGHTER_DAMAGE"))
+                                                           % launch_text % fighter_damage_text);
+            std::string bout_text = boost::io::str(FlexibleFormat(UserString("TT_COMBAT_ROUND"))
+                                                   % boost::lexical_cast<std::string>(i));
+            damage_label_text = boost::io::str(FlexibleFormat(UserString("TT_BREAKDOWN_SUMMARY"))
+                                               % bout_text % damage_label_text);
+
+            GG::Label* bout_label = new CUILabel(damage_label_text, GG::FORMAT_RIGHT);
+            bout_label->MoveTo(GG::Pt(GG::X0, top));
+            bout_label->Resize(GG::Pt(LABEL_WIDTH * 2 + EDGE_PAD, m_row_height));
+            AttachChild(bout_label);
+
+            std::string bout_value_text = DoubleToString(current_bout.second, 3, false);
+            GG::Label* bout_value = new CUILabel(ColourWrappedtext(bout_value_text, DAMAGE_COLOR));
+            bout_value->MoveTo(GG::Pt(LABEL_WIDTH * 2, top));
+            bout_value->Resize(GG::Pt(VALUE_WIDTH * 2, m_row_height));
+            AttachChild(bout_value);
+            m_effect_labels_and_values.push_back(std::make_pair(bout_label, bout_value));
+
+            top += m_row_height;
+        }
     }
 }

--- a/UI/MeterBrowseWnd.cpp
+++ b/UI/MeterBrowseWnd.cpp
@@ -605,7 +605,7 @@ namespace {
          * @param [in] base_value optional; If greater than 0.0f: the value label is formatted to "value of base_value"
          */
         ShipFightersBrowseRow(const std::string& label, int qty, double value, double base_value = 0.0f) :
-                GG::ListBox::Row(FighterBrowseListWidth(), MeterBrowseRowHeight(), "")
+            GG::ListBox::Row(FighterBrowseListWidth(), MeterBrowseRowHeight(), "")
         {
             const GG::Clr QTY_COLOR = GG::CLR_GRAY;
 

--- a/UI/MeterBrowseWnd.cpp
+++ b/UI/MeterBrowseWnd.cpp
@@ -521,7 +521,7 @@ void ShipDamageBrowseWnd::UpdateSummary() {
         return;
 
     // unpaired meter total for breakdown summary
-    float breakdown_total = ship->TotalWeaponsDamage();
+    float breakdown_total = ship->TotalWeaponsDamage(0.0f, false);
     std::string breakdown_meter_name = UserString("SHIP_DAMAGE_STAT_TITLE");
 
 

--- a/UI/MeterBrowseWnd.cpp
+++ b/UI/MeterBrowseWnd.cpp
@@ -733,7 +733,7 @@ namespace {
     std::pair<int, float> FightersDamageForBout(int total_bay_capacity, int current_docked_fighters,
                                                 float fighter_damage, int bout = -1)
     {
-        int last_bout = bout < 1 ? ShipFightersBrowseWnd::NUM_COMBAT_BOUTS : bout;
+        int last_bout = bout < 1 ? GetUniverse().GetNumCombatRounds() : bout;
         std::pair<int, float> retval = { 0, 0.0f };
         int fighters_next_bout = 0;
         int remaining_docked_fighters = current_docked_fighters;
@@ -922,6 +922,7 @@ void ShipFightersBrowseWnd::UpdateEffectLabelsAndValues(GG::Y& top) {
         // Damage summary labels
         // TODO Add list of effects on hangar(fighter) damage
 
+        const int NUM_COMBAT_BOUTS = GetUniverse().GetNumCombatRounds();
         float total_dmg = FightersDamageForBout(bay_total_capacity, hangar_current_fighters, fighter_damage).second;
         std::string avg_val =  ColourWrappedtext(DoubleToString(total_dmg / NUM_COMBAT_BOUTS, 3, false), DAMAGE_COLOR);
         std::string detail_avg_text = boost::io::str(FlexibleFormat(UserString("SHIP_FIGHTERS_DAMAGE_AVERAGE")) % avg_val);

--- a/UI/MeterBrowseWnd.h
+++ b/UI/MeterBrowseWnd.h
@@ -70,4 +70,22 @@ private:
 
 };
 
+class ShipFightersBrowseWnd : public MeterBrowseWnd {
+public:
+    ShipFightersBrowseWnd(int object_id, MeterType primary_meter_type, bool show_all_bouts = false);
+    static const int NUM_COMBAT_BOUTS = 3;
+
+private:
+    void            Initialize();
+
+    virtual void    UpdateImpl(std::size_t mode, const Wnd* target);
+    void            UpdateSummary();
+    void            UpdateEffectLabelsAndValues(GG::Y& top);
+
+    GG::ListBox*    m_bay_list;
+    GG::ListBox*    m_hangar_list;
+    bool            m_show_all_bouts;
+
+};
+
 #endif

--- a/UI/MeterBrowseWnd.h
+++ b/UI/MeterBrowseWnd.h
@@ -73,7 +73,6 @@ private:
 class ShipFightersBrowseWnd : public MeterBrowseWnd {
 public:
     ShipFightersBrowseWnd(int object_id, MeterType primary_meter_type, bool show_all_bouts = false);
-    static const int NUM_COMBAT_BOUTS = 3;
 
 private:
     void            Initialize();

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1452,6 +1452,9 @@ Sets size of system icons below which the fixed-size tiny icons will be shown.
 OPTIONS_DB_UI_TOOLTIP_DELAY
 Sets UI tooltip pop-up delay, in ms.
 
+OPTIONS_DB_UI_TOOLTIP_LONG_DELAY
+Sets UI tooltip pop-up delay for alternate pop-ups, in ms.
+
 OPTIONS_DB_UI_ENC_SEARCH_ARTICLE
 When searching the pedia, check for matches in article contents.
 
@@ -3021,6 +3024,21 @@ Species <i>%2%</i>
 TT_FIELD
 <i>%2%</i>
 
+# %1% number of fighters
+# %2% damage per fighter
+TT_FIGHTER_DAMAGE
+%1% Fighters * %2% Damage
+
+# Represent a value out of a possible total value
+# %1% number
+# %2% number
+TT_N_OF_N
+%1% of %2%
+
+# %1% combat round
+TT_COMBAT_ROUND
+Round %1%
+
 TT_UNKNOWN
 Unknown
 
@@ -3193,6 +3211,20 @@ Total troop capacity of this ship.
 
 SHIP_FIGHTERS_TITLE
 Fighters
+
+SHIP_FIGHTER_BAY_SUMMARY
+Launch Capacity
+
+SHIP_FIGHTER_HANGAR_SUMMARY
+Current Fighters
+
+# %1% average damage
+SHIP_FIGHTERS_DAMAGE_AVERAGE
+Average per Round: %1%
+
+# %1% total damage
+SHIP_FIGHTERS_DAMAGE_TOTAL
+Total Damage: %1%
 
 SHIP_FIGHTERS_STAT
 Total fighters in this ship.

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -3024,10 +3024,13 @@ Species <i>%2%</i>
 TT_FIELD
 <i>%2%</i>
 
+TT_FIGHTER_LAUNCH
+Launching
+
 # %1% number of fighters
 # %2% damage per fighter
 TT_FIGHTER_DAMAGE
-%1% Fighters * %2% Damage
+%1% Attacking * %2% Damage
 
 # Represent a value out of a possible total value
 # %1% number
@@ -3037,7 +3040,7 @@ TT_N_OF_N
 
 # %1% combat round
 TT_COMBAT_ROUND
-Round %1%
+Round %1%:
 
 TT_UNKNOWN
 Unknown
@@ -3218,13 +3221,8 @@ Launch Capacity
 SHIP_FIGHTER_HANGAR_SUMMARY
 Current Fighters
 
-# %1% average damage
-SHIP_FIGHTERS_DAMAGE_AVERAGE
-Average per Round: %1%
-
-# %1% total damage
 SHIP_FIGHTERS_DAMAGE_TOTAL
-Total Damage: %1%
+Total Damage
 
 SHIP_FIGHTERS_STAT
 Total fighters in this ship.


### PR DESCRIPTION
Provides two tooltip modes for a ships fighter icon in fleet window.
The first tooltip displays after the normal delay, with a summary view.
The second replaces the first after a longer delay, with a more detailed accounting.

[Forum discussion](http://www.freeorion.org/forum/viewtopic.php?f=6&t=10342)