### PR TITLE
Fractional progress

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -1175,7 +1175,7 @@ void ProductionQueue::Update() {
             max_turns *= 2;  // double the turns for simulations, because of uncertainties around frontloading
 
             max_turns = std::min(max_turns, int(DP_TURNS - first_turn_pp_available + 1));
-            //DebugLogger() << "     max turns simulated: "<< max_turns << "first turn pp avail: "<<(first_turn_pp_available-1);
+            //DebugLogger() << "     max turns simulated: "<< max_turns << "first turn pp avail: " << (first_turn_pp_available-1);
 
             float allocation;
             float element_this_turn_limit;

--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -1187,7 +1187,7 @@ void ProductionQueue::Update() {
                 // total cost remaining to complete the last item in the queue element (eg. the element has all but
                 // the last item complete already) and by the total pp available in this element's production location's
                 // resource sharing group
-                //DebugLogger()  << "     turn: "<<j<<"; max_pp_needed: "<< additional_pp_to_complete_element <<"; per turn limit: " << element_per_turn_limit<<"; pp stil avail: "<<pp_still_available[first_turn_pp_available+j-1];
+                //DebugLogger()  << "     turn: " << j << "; max_pp_needed: " << additional_pp_to_complete_element << "; per turn limit: " << element_per_turn_limit << "; pp stil avail: " << pp_still_available[first_turn_pp_available+j-1];
                 element_this_turn_limit = CalculateProductionPerTurnLimit(element, item_cost, build_turns);
                 allocation = std::max(0.0f, std::min(element_this_turn_limit, pp_still_available[first_turn_pp_available+j-1]));
                 element.progress += allocation / std::max(EPSILON, total_item_cost);    // add turn's allocation

--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -1513,7 +1513,13 @@ const ResearchQueue& Empire::GetResearchQueue() const
 
 float Empire::ResearchProgress(const std::string& name) const {
     std::map<std::string, float>::const_iterator it = m_research_progress.find(name);
-    return (it == m_research_progress.end()) ? 0.0 : it->second;
+    if (it == m_research_progress.end())
+        return 0.0f;
+    const Tech* tech = GetTech(it->first);
+    if (!tech)
+        return 0.0f;
+    float tech_cost = tech->ResearchCost(m_id);
+    return it->second * tech_cost;
 }
 
 const std::set<std::string>& Empire::AvailableTechs() const
@@ -1723,8 +1729,15 @@ bool Empire::ShipHullAvailable(const std::string& name) const
 const ProductionQueue& Empire::GetProductionQueue() const
 { return m_production_queue; }
 
-float Empire::ProductionStatus(int i) const
-{ return (0 <= i && i < static_cast<int>(m_production_queue.size())) ? m_production_queue[i].progress : -1.0; }
+float Empire::ProductionStatus(int i) const {
+    if (0 > i || i >= static_cast<int>(m_production_queue.size()))
+        return -1.0f;
+    float item_progress = m_production_queue[i].progress;
+    float item_cost;
+    int item_time;
+    boost::tie(item_cost, item_time) = this->ProductionCostAndTime(m_production_queue[i]);
+    return item_progress * item_cost;
+}
 
 std::pair<float, int> Empire::ProductionCostAndTime(const ProductionQueue::Element& element) const
 { return ProductionCostAndTime(element.item, element.location); }

--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -155,6 +155,8 @@ struct FO_COMMON_API ProductionQueue {
         std::map<std::string, std::map<int, float> >    CompletionSpecialConsumption(int location_id) const;// for each special name, what object ids have those special capacities reduced by what amount
         std::map<MeterType, std::map<int, float> >      CompletionMeterConsumption(int location_id) const;  // for each meter type, what object ids have those meters reduced by what amount
 
+        std::string Dump() const;
+
         BuildType   build_type;
         // only one of these may be valid, depending on BuildType
         std::string name;
@@ -187,6 +189,8 @@ struct FO_COMMON_API ProductionQueue {
         int             turns_left_to_completion;
         int             rally_point_id;
         bool            paused;
+
+        std::string Dump() const;
 
     private:
         friend class boost::serialization::access;

--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -180,7 +180,7 @@ struct FO_COMMON_API ProductionQueue {
         int             remaining;                  ///< how many left to produce
         int             location;                   ///< the ID of the UniverseObject at which this item is being produced
         float           allocated_pp;               ///< PP allocated to this ProductionQueue Element by Empire production update
-        float           progress;                   ///< PP that has been spent on this production element (will increase by allocation during next turn processing)
+        float           progress;                   ///< fraction of this item that is complete.
         float           progress_memory;            ///< updated by server turn processing; aides in allowing blocksize changes to be undone in same turn w/o progress loss
         int             blocksize_memory;           ///< used along with progress_memory
         int             turns_left_to_next_item;

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -338,15 +338,17 @@ namespace {
             if (empire)
                 boost::tie(total_cost, minimum_turns) = empire->ProductionCostAndTime(elem);
             total_cost *= elem.blocksize;
+
             float per_turn_cost = total_cost / std::max(1, minimum_turns);
-            float progress = empire ? empire->ProductionStatus(queue_index) : 0.0f;
-            if (progress == -1.0f)
-                progress = 0.0f;
+
+            float pp_accumulated = empire ? empire->ProductionStatus(queue_index) : 0.0f; // returns as PP
+            if (pp_accumulated == -1.0f)
+                pp_accumulated = 0.0f;
 
             panel = new QueueProductionItemPanel(GG::X0, GG::Y0, ClientWidth() - MARGIN - MARGIN,
                                                  elem, elem.allocated_pp, total_cost, minimum_turns, elem.remaining,
-                                                 static_cast<int>(progress / std::max(1e-6f, per_turn_cost)),
-                                                 std::fmod(progress, per_turn_cost) / std::max(1e-6f, per_turn_cost));
+                                                 static_cast<int>(pp_accumulated / std::max(1e-6f, per_turn_cost)),
+                                                 std::fmod(pp_accumulated, per_turn_cost) / std::max(1e-6f, per_turn_cost));
             push_back(panel);
 
             // Since this is only called during PreRender force panel to PreRender()

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -296,7 +296,7 @@ namespace {
 
         // %1% / %2%  +  %3% / %4% PP/turn
         main_text += boost::io::str(FlexibleFormat(UserString("PRODUCTION_WND_PROGRESS"))
-                        % DoubleToString(progress, 3, false)
+                        % DoubleToString(progress*100.0f, 3, false)
                         % DoubleToString(total_cost, 3, false)
                         % DoubleToString(allocation, 3, false)
                         % DoubleToString(max_allocation, 3, false)) + "\n";

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -3600,7 +3600,7 @@ PRODUCTION_QUEUE_REPETITIONS
 # %3% production points used per turn.
 # %4% production points available per turn.
 PRODUCTION_WND_PROGRESS
-'''%1% / %2% PP
+'''%1%%% complete
 + %3% / %4% target PP/turn'''
 
 # %1% location where the item is produced.


### PR DESCRIPTION
Changes storing of progress on production items to a fraction of completion rather than accumulated PP. This should result in better handling of situations where costs change after partial completion, such as preventing extra pp per turn being accumulated while at high cost, then quicker-than-intended completion after the cost is reduced while accumulated PP are retained.