### PR TITLE
Utilize an accessible function for combat rounds

### DIFF
--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -291,7 +291,7 @@ void CombatInfo::ForceAtLeastBasicVisibility(int attacker_id, int target_id)
 namespace {
     // Each combat "bout" all attackers attack one target with each available
     // weapon, and launch fighters from each bay (if any are available)
-    static const int NUM_COMBAT_BOUTS = 3;  // TODO: make into a configurable game rule
+    const int NUM_COMBAT_BOUTS = GetUniverse().GetNumCombatRounds();
 
     struct PartAttackInfo {
         PartAttackInfo(ShipPartClass part_class_, const std::string& part_name_, float part_attack_) :

--- a/universe/Ship.cpp
+++ b/universe/Ship.cpp
@@ -517,16 +517,23 @@ namespace {
         if (!include_fighters || fighter_damage <= 0.0f || available_fighters <= 0 || fighter_launch_capacity <= 0)
             return retval;
 
-        // assuming 3 combat "bouts"
         int fighter_shots = std::min(available_fighters, fighter_launch_capacity);  // how many fighters launched in bout 1
         available_fighters -= fighter_shots;
-        fighter_shots *= 2;                                                         // first-bout-launched fighters attack in bouts 2 and 3
-        fighter_shots += std::min(available_fighters, fighter_launch_capacity);     // second-bout-launched fighters attack only in bout 3
+        int launched_fighters = fighter_shots;
+        int num_bouts = GetUniverse().GetNumCombatRounds();
+        int remaining_bouts = num_bouts - 2;  // no attack for first round, second round already added
+        while (remaining_bouts > 0) {
+            int fighters_launched_this_bout = std::min(available_fighters, fighter_launch_capacity);
+            available_fighters -= fighters_launched_this_bout;
+            launched_fighters += fighters_launched_this_bout;
+            fighter_shots += launched_fighters;
+            --remaining_bouts;
+        }
 
         // how much damage does a fighter shot do?
         fighter_damage = std::max(0.0f, fighter_damage);
 
-        retval.push_back(fighter_damage * fighter_shots / 3.0f);    // divide by 3 because fighter calculation is for a full combat, but direct firefor one attack
+        retval.push_back(fighter_damage * fighter_shots / num_bouts);    // divide by bouts because fighter calculation is for a full combat, but direct firefor one attack
 
         return retval;
     }

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -695,16 +695,23 @@ float ShipDesign::AdjustedAttack(float shield) const {
         }
     }
 
-    // assuming 3 combat "bouts"
     int fighter_shots = std::min(available_fighters, fighter_launch_capacity);  // how many fighters launched in bout 1
     available_fighters -= fighter_shots;
-    fighter_shots *= 2;                                                         // first-bout-launched fighters attack in bouts 2 and 3
-    fighter_shots += std::min(available_fighters, fighter_launch_capacity);     // second-bout-launched fighters attack only in bout 3
+    int launched_fighters = fighter_shots;
+    int num_bouts = GetUniverse().GetNumCombatRounds();
+    int remaining_bouts = num_bouts - 2;  // no attack for first round, second round already added
+    while (remaining_bouts > 0) {
+        int fighters_launched_this_bout = std::min(available_fighters, fighter_launch_capacity);
+        available_fighters -= fighters_launched_this_bout;
+        launched_fighters += fighters_launched_this_bout;
+        fighter_shots += launched_fighters;
+        --remaining_bouts;
+    }
 
     // how much damage does a fighter shot do?
     fighter_damage = std::max(0.0f, fighter_damage);
 
-    return direct_attack + fighter_shots*fighter_damage/3.0f;   // divide by 3 because fighter calculation is for a full combat, but direct firefor one attack
+    return direct_attack + fighter_shots*fighter_damage/num_bouts;   // divide by bouts because fighter calculation is for a full combat, but direct firefor one attack
 }
 
 std::vector<std::string> ShipDesign::Parts(ShipSlotType slot_type) const {

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -1098,6 +1098,9 @@ int Universe::NearestSystemTo(double x, double y) const {
     return min_dist2_sys_id;
 }
 
+const int Universe::GetNumCombatRounds() const
+{ return 3; }
+
 int Universe::GenerateObjectID() {
     if (m_last_allocated_object_id + 1 < MAX_ID)
         return ++m_last_allocated_object_id;

--- a/universe/Universe.h
+++ b/universe/Universe.h
@@ -237,6 +237,11 @@ public:
     const std::map<std::string, std::map<int, std::map<int, double> > >&
                                             GetStatRecords() const { return m_stat_records; }
 
+    /** Number of combat rounds
+     * TODO make into a configurable game rule
+     */
+    const int                               GetNumCombatRounds() const;
+
     mutable UniverseObjectDeleteSignalType UniverseObjectDeleteSignal; ///< the state changed signal object for this UniverseObject
     //@}
 


### PR DESCRIPTION
Moves the definition for number of combat rounds to Universe::GetNumCombatRounds()

Implements this function in fighter calculations within Ship and ShipDesign