### PR TITLE
Random species selection during setup

### DIFF
--- a/UI/CUIControls.cpp
+++ b/UI/CUIControls.cpp
@@ -1434,25 +1434,35 @@ namespace {
         {
             if (!species)
                 return;
-            GG::Wnd::SetName(species->Name());
-            GG::StaticGraphic* icon = new GG::StaticGraphic(
-                ClientUI::SpeciesIcon(species->Name()), GG::GRAPHIC_FITGRAPHIC| GG::GRAPHIC_PROPSCALE);
-            icon->Resize(GG::Pt(GG::X(Value(h - 5)), h - 5));
+            const std::string& species_name = species->Name();
+            Init(species_name, UserString(species_name), species->GameplayDescription(), w, h,
+                 ClientUI::SpeciesIcon(species_name));
+        };
+
+        SpeciesRow(const std::string& species_name, const std::string& localized_name, const std::string& species_desc,
+            GG::X w, GG::Y h, boost::shared_ptr<GG::Texture> species_icon) :
+            GG::ListBox::Row(w, h, "", GG::ALIGN_VCENTER, 0)
+        { Init(species_name, localized_name, species_desc, w, h, species_icon); };
+
+    private:
+        void Init(const std::string& species_name, const std::string& localized_name, const std::string& species_desc,
+                  GG::X width, GG::Y height, boost::shared_ptr<GG::Texture> species_icon) {
+            GG::Wnd::SetName(species_name);
+            GG::StaticGraphic* icon = new GG::StaticGraphic(species_icon, GG::GRAPHIC_FITGRAPHIC| GG::GRAPHIC_PROPSCALE);
+            icon->Resize(GG::Pt(GG::X(Value(height - 5)), height - 5));
             push_back(icon);
-            GG::Label* species_name = new CUILabel(UserString(species->Name()), GG::FORMAT_LEFT | GG::FORMAT_VCENTER);
-            push_back(species_name);
-            GG::X first_col_width(Value(h));
+            GG::Label* species_label = new CUILabel(localized_name, GG::FORMAT_LEFT | GG::FORMAT_VCENTER);
+            push_back(species_label);
+            GG::X first_col_width(Value(height));
             SetColWidth(0, first_col_width);
-            SetColWidth(1, w - first_col_width);
+            SetColWidth(1, width - first_col_width);
             GetLayout()->SetColumnStretch(0, 0.0);
             GetLayout()->SetColumnStretch(1, 1.0);
-            SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
-            SetBrowseInfoWnd(boost::shared_ptr<GG::BrowseInfoWnd>(
-                new IconTextBrowseWnd(ClientUI::SpeciesIcon(species->Name()),
-                                      UserString(species->Name()),
-                                      species->GameplayDescription())
-                                     )
-                            );
+            if (!species_desc.empty()) {
+                SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
+                SetBrowseInfoWnd(boost::shared_ptr<GG::BrowseInfoWnd>(new IconTextBrowseWnd(species_icon, localized_name,
+                                                                                            species_desc)));
+            }
         }
     };
 }
@@ -1469,8 +1479,12 @@ SpeciesSelector::SpeciesSelector(GG::X w, GG::Y h) :
     const SpeciesManager& sm = GetSpeciesManager();
     for (SpeciesManager::playable_iterator it = sm.playable_begin(); it != sm.playable_end(); ++it)
         Insert(new SpeciesRow(it->second, w, h - 4));
-    if (!this->Empty())
+    if (!this->Empty()) {
+        // Add an option for random selection
+        Insert(new SpeciesRow("RANDOM", UserString("GSETUP_RANDOM"), UserString("GSETUP_SPECIES_RANDOM_DESC"), w, h - 4,
+                              ClientUI::GetTexture("default/data/art/icons/unknown.png")));
         Select(this->begin());
+    }
     GG::Connect(SelChangedSignal, &SpeciesSelector::SelectionChanged, this);
 }
 

--- a/UI/CUIControls.cpp
+++ b/UI/CUIControls.cpp
@@ -1440,13 +1440,14 @@ namespace {
         };
 
         SpeciesRow(const std::string& species_name, const std::string& localized_name, const std::string& species_desc,
-            GG::X w, GG::Y h, boost::shared_ptr<GG::Texture> species_icon) :
+                   GG::X w, GG::Y h, boost::shared_ptr<GG::Texture> species_icon) :
             GG::ListBox::Row(w, h, "", GG::ALIGN_VCENTER, 0)
         { Init(species_name, localized_name, species_desc, w, h, species_icon); };
 
     private:
         void Init(const std::string& species_name, const std::string& localized_name, const std::string& species_desc,
-                  GG::X width, GG::Y height, boost::shared_ptr<GG::Texture> species_icon) {
+                  GG::X width, GG::Y height, boost::shared_ptr<GG::Texture> species_icon)
+        {
             GG::Wnd::SetName(species_name);
             GG::StaticGraphic* icon = new GG::StaticGraphic(species_icon, GG::GRAPHIC_FITGRAPHIC| GG::GRAPHIC_PROPSCALE);
             icon->Resize(GG::Pt(GG::X(Value(height - 5)), height - 5));

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -505,13 +505,15 @@ void HumanClientApp::NewSinglePlayerGame(bool quickstart) {
         if (human_player_setup_data.m_starting_species_name == "1")
             human_player_setup_data.m_starting_species_name = "SP_HUMAN";   // kludge / bug workaround for bug with options storage and retreival.  Empty-string options are stored, but read in as "true" boolean, and converted to string equal to "1"
 
-        if (!GetSpecies(human_player_setup_data.m_starting_species_name)) {
+        if (human_player_setup_data.m_starting_species_name != "RANDOM" &&
+            !GetSpecies(human_player_setup_data.m_starting_species_name))
+        {
             const SpeciesManager& sm = GetSpeciesManager();
             if (sm.NumPlayableSpecies() < 1)
                 human_player_setup_data.m_starting_species_name.clear();
             else
                 human_player_setup_data.m_starting_species_name = sm.playable_begin()->first;
-            }
+        }
 
         human_player_setup_data.m_save_game_empire_id = ALL_EMPIRES; // not used for new games
         human_player_setup_data.m_client_type = Networking::CLIENT_TYPE_HUMAN_PLAYER;

--- a/default/python/universe_generation/empires.py
+++ b/default/python/universe_generation/empires.py
@@ -381,8 +381,8 @@ def setup_empire(empire, empire_name, home_system, starting_species, player_name
     print "Empire name for player", player_name, "is", empire_name
 
     # check starting species, if no one is given, pick one randomly
-    if not starting_species:
-        print "No starting species set for player", player_name, ", picking one randomly"
+    if starting_species == "RANDOM" or not starting_species:
+        print "Picking random starting species for player", player_name
         starting_species = next(starting_species_pool)
     print "Starting species for player", player_name, "is", starting_species
     statistics.empire_species[starting_species] += 1

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -2064,6 +2064,9 @@ Aggressive
 GSETUP_MANIACAL
 Maniacal
 
+# Random species selection description
+GSETUP_SPECIES_RANDOM_DESC
+Picks a random selection from the available playable species.
 
 ##
 ## About dialog


### PR DESCRIPTION
Provides option in both Multi-player and Single player setups for random species selection.

Resolves #799 