### PR TITLE
Ai tweaks for sparse galaxy

### DIFF
--- a/default/python/AI/AIDependencies.py
+++ b/default/python/AI/AIDependencies.py
@@ -103,6 +103,14 @@ SPECIES_INDUSTRY_MODIFIER = {'NO': 0.0, 'BAD': 0.75, 'GOOD': 1.5, 'GREAT': 2.0, 
 SPECIES_POPULATION_MODIFIER = {'BAD': 0.75, 'GOOD': 1.25}
 SPECIES_SUPPLY_MODIFIER = {'BAD': 0, 'AVERAGE': 1, 'GREAT': 2, 'ULTIMATE': 3}
 
+# <editor-fold desc="XenoResurrectionSpecies">
+EXTINCT_SPECIES = [
+    "BANFORO",
+    "KILANDOW",
+    "MISIORLA"
+]
+# </editor-fold>
+
 # <editor-fold desc="Piloting traits">
 # TODO (Morlic): Consider using only 1 dict with tuple for (Capacity, SecondaryStat) effects
 PILOT_DAMAGE_MODIFIER_DICT = {

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -917,10 +917,8 @@ def evaluate_planet(planet_id, mission_type, spec_name, empire, detail=None):
             ast_val = 0
             if tech_is_complete("PRO_MICROGRAV_MAN"):
                 per_ast = 5
-            elif fo.currentTurn() > 40:
-                per_ast = 2.5
             else:
-                per_ast = 0.1
+                per_ast = 3
             if system:
                 for pid in system.planetIDs:
                     other_planet = universe.getPlanet(pid)

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -214,6 +214,9 @@ def survey_universe():
         active_growth_specials.clear()
         if tech_is_complete(TechsListsAI.EXOBOT_TECH_NAME):
             empire_colonizers["SP_EXOBOT"] = []  # get it into colonizer list even if no colony yet
+        for spec_name in AIDependencies.EXTINCT_SPECIES:
+            if empire.buildingTypeAvailable("BLD_COL_"+spec_name):
+                empire_colonizers["SP_"+spec_name] = []  # get it into colonizer list even if no colony yet
         AIstate.popCtrIDs[:] = []
         AIstate.popCtrSystemIDs[:] = []
         AIstate.outpostIDs[:] = []

--- a/default/python/AI/PriorityAI.py
+++ b/default/python/AI/PriorityAI.py
@@ -234,7 +234,7 @@ def _calculate_colonisation_priority():
     colony_cost = AIDependencies.COLONY_POD_COST * (1 + AIDependencies.COLONY_POD_UPKEEP * num_colonies)
     turns_to_build = 8  # TODO: check for susp anim pods, build time 10
     mil_prio = foAI.foAIstate.get_priority(PriorityType.PRODUCTION_MILITARY)
-    allotted_portion = ([[[0.6, 0.8], [0.3, 0.4]], [[0.8, 0.9], [0.3, 0.4]]][galaxy_is_sparse]
+    allotted_portion = ([[[0.6, 0.8], [0.3, 0.4]], [[0.8, 0.9], [0.4, 0.6]]][galaxy_is_sparse]
                        [any(enemies_sighted)][fo.empireID() % 2])
     # if ( foAI.foAIstate.get_priority(AIPriorityType.PRIORITY_PRODUCTION_COLONISATION)
     # > 2 * foAI.foAIstate.get_priority(AIPriorityType.PRIORITY_PRODUCTION_MILITARY)):

--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -1074,6 +1074,20 @@ def generate_production_orders():
                 else:
                     print "Error failed enqueueing %s at planet %d (%s) , with result %d" % (building_name, pid, planet.name, res)
 
+    building_name = "BLD_XENORESURRECTION_LAB"
+    queued_xeno_lab_locs = [element.locationID for element in production_queue if element.name==building_name]
+    for pid in list(AIstate.popCtrIDs)+list(AIstate.outpostIDs):
+        if pid in queued_xeno_lab_locs or not empire.canBuild(fo.buildType.building, building_name, pid):
+            continue
+        res = fo.issueEnqueueBuildingProductionOrder(building_name, pid)
+        print "Enqueueing %s at planet %d (%s) , with result %d"%(building_name, pid, planet.name, res)
+        if res:
+            res = fo.issueRequeueProductionOrder(production_queue.size-1, 2)  # move to near front
+            print "Requeueing %s to front of build queue, with result %d"%(building_name, res)
+            break
+        else:
+            print "Error failed enqueueing %s at planet %d (%s) , with result %d"%(building_name, pid, planet.name, res)
+
     queued_clny_bld_locs = [element.locationID for element in production_queue if element.name.startswith('BLD_COL_')]
     colony_bldg_entries = ([entry for entry in foAI.foAIstate.colonisablePlanetIDs.items() if entry[1][0] > 60 and
                            entry[0] not in queued_clny_bld_locs and entry[0] in ColonisationAI.empire_outpost_ids]

--- a/default/python/AI/TechsListsAI.py
+++ b/default/python/AI/TechsListsAI.py
@@ -191,6 +191,31 @@ class TechGroup1SparseB(TechGroup1):
             "SHP_SPACE_FLUX_DRIVE"
         )
 
+class TechGroup1SparseC(TechGroup1):
+    def __init__(self):
+        super(TechGroup1SparseC, self).__init__()
+        self.enqueue(
+            self.economy,
+            self.economy,
+            "SHP_ORG_HULL",
+            "PRO_NANOTECH_PROD",
+            "GRO_GENETIC_ENG",
+            "PRO_SENTIENT_AUTOMATION",
+            "GRO_GENETIC_MED",
+            "GRO_SYMBIOTIC_BIO",
+            "PRO_MICROGRAV_MAN",
+            "PRO_EXOBOTS",
+            "GRO_XENO_GENETICS",
+            "SHP_ASTEROID_HULLS",
+            "PRO_FUSION_GEN",
+            "SHP_WEAPON_2_1",
+            "SHP_ZORTRIUM_PLATE",
+            "SHP_SPACE_FLUX_DRIVE",
+            "LRN_FORCE_FIELD",
+            "PRO_ORBITAL_GEN",
+            "SPY_DETECT_2",
+        )
+
 
 class TechGroup2(TechGroup):
     def __init__(self):
@@ -579,6 +604,7 @@ def test_tech_integrity():
         TechGroup1b,
         TechGroup1SparseA,
         TechGroup1SparseB,
+        TechGroup1SparseC,
         TechGroup2,
         TechGroup2A,
         TechGroup2B,
@@ -631,13 +657,13 @@ def sparse_galaxy_techs(index):
         result += TechGroup4().get_techs()
         result += TechGroup5().get_techs()  #
     elif index == 3:
-        result = TechGroup1SparseB().get_techs()  # early org_hull
+        result = TechGroup1SparseC().get_techs()  # early org_hull
         result += TechGroup2SparseB().get_techs()
         result += TechGroup3A().get_techs()
         result += TechGroup4().get_techs()
         result += TechGroup5().get_techs()  #
     elif index == 4:
-        result = TechGroup1SparseB().get_techs()  # early _lrn_artif_minds
+        result = TechGroup1SparseC().get_techs()  # early _lrn_artif_minds
         result += TechGroup2SparseB().get_techs()
         result += TechGroup3B().get_techs()  # faster plasma weaps
         result += TechGroup4().get_techs()


### PR DESCRIPTION
Hi guys, long time no see.  I have a little Christmas contribution that I think could help liven up the holidays-- some relatively modest AI tweaks that nonetheless seem to make it a fair bit more competitive, especially in the specific setups this is directed to, which are ones where the monster density is no greater than Low, and where there are at least 40 systems per empire (or 35 if the shape is elliptical).   I prefer to run this at 400 systems and 6 AIs.  

Also, independent of the sparsity, this enables the AI to use the XenoResurrection Lab and the associated extinct species.

I am still getting up to speed on some of the AI changes during my absence, so CJ et al., just let me know if you'd prefer I change the way I tweaked the techs here.