### PR TITLE
Fix Head on a spike special

### DIFF
--- a/default/scripting/specials/HEAD_ON_A_SPIKE.focs.txt
+++ b/default/scripting/specials/HEAD_ON_A_SPIKE.focs.txt
@@ -18,14 +18,14 @@ Special
                 OwnedBy affiliation = AnyEmpire
                 WithinDistance distance = 100 condition = Source
             ]
-        stackinggroup = "HEAD_ON_A_SPIKE_SPECIAL_EFFECT"
-        effects = [
-            SetMaxShield value = Value - 1
-            SetMaxStructure value = Value -1 
-            SetMaxDamage partname = "SR_WEAPON_1_1" value = Value - 1
-            SetMaxDamage partname = "SR_WEAPON_2_1" value = Value - 1
-            SetMaxDamage partname = "SR_WEAPON_3_1" value = Value - 1
-            SetMaxDamage partname = "SR_WEAPON_4_1" value = Value - 1
-        ]
+            stackinggroup = "HEAD_ON_A_SPIKE_SPECIAL_EFFECT"
+            effects = [
+                SetMaxShield value = Value - 1
+                SetMaxStructure value = Value - 1 
+                SetMaxDamage partname = "SR_WEAPON_1_1" value = Value - 1
+                SetMaxDamage partname = "SR_WEAPON_2_1" value = Value - 1
+                SetMaxDamage partname = "SR_WEAPON_3_1" value = Value - 1
+                SetMaxDamage partname = "SR_WEAPON_4_1" value = Value - 1
+            ]
     ]
     graphic = "icons/sitrep/empire_eliminated.png"

--- a/default/scripting/specials/HEAD_ON_A_SPIKE.focs.txt
+++ b/default/scripting/specials/HEAD_ON_A_SPIKE.focs.txt
@@ -22,22 +22,10 @@ Special
         effects = [
             SetMaxShield value = Value - 1
             SetMaxStructure value = Value -1 
-            SetDamage partname = "SR_WEAPON_1_1" value = Value - 1
-            SetDamage partname = "SR_WEAPON_1_2" value = Value - 1
-            SetDamage partname = "SR_WEAPON_1_3" value = Value - 1
-            SetDamage partname = "SR_WEAPON_1_4" value = Value - 1
-            SetDamage partname = "SR_WEAPON_2_1" value = Value - 1
-            SetDamage partname = "SR_WEAPON_2_2" value = Value - 1
-            SetDamage partname = "SR_WEAPON_2_3" value = Value - 1
-            SetDamage partname = "SR_WEAPON_2_4" value = Value - 1
-            SetDamage partname = "SR_WEAPON_3_1" value = Value - 1
-            SetDamage partname = "SR_WEAPON_3_2" value = Value - 1
-            SetDamage partname = "SR_WEAPON_3_3" value = Value - 1
-            SetDamage partname = "SR_WEAPON_3_4" value = Value - 1
-            SetDamage partname = "SR_WEAPON_4_1" value = Value - 1
-            SetDamage partname = "SR_WEAPON_4_2" value = Value - 1
-            SetDamage partname = "SR_WEAPON_4_3" value = Value - 1
-            SetDamage partname = "SR_WEAPON_4_4" value = Value - 1
+            SetMaxDamage partname = "SR_WEAPON_1_1" value = Value - 1
+            SetMaxDamage partname = "SR_WEAPON_2_1" value = Value - 1
+            SetMaxDamage partname = "SR_WEAPON_3_1" value = Value - 1
+            SetMaxDamage partname = "SR_WEAPON_4_1" value = Value - 1
         ]
     ]
     graphic = "icons/sitrep/empire_eliminated.png"


### PR DESCRIPTION
Fixes an issue described in this [forum post](http://freeorion.org/forum/viewtopic.php?f=28&t=10354&p=86863#p86863). 

Ever since the weapon upgrade rework, the special would now reduce the *current* weapon capacity by 1 **per turn** whereas the initial intention (IIRC) was to reduce the maximum damage of the weapons by 1.