### PR TITLE
Add fighter related info to ship design articles

### DIFF
--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -1982,7 +1982,7 @@ namespace {
         return (FlexibleFormat(UserString("ENC_SHIP_DESIGN_DESCRIPTION_STATS_STR"))
             % species
             % attack
-            % ship->CurrentPartClassMeterValue(METER_MAX_SECONDARY_STAT, PC_DIRECT_WEAPON)
+            % ship->SumCurrentPartMeterValuesForPartClass(METER_MAX_SECONDARY_STAT, PC_DIRECT_WEAPON)
             % structure
             % shield
             % ship->CurrentMeterValue(METER_DETECTION)
@@ -1993,7 +1993,7 @@ namespace {
             % ship->TroopCapacity()
             % ship->FighterMax()
             % (attack - ship->TotalWeaponsDamage(0.0f, false))
-            % ship->CurrentPartClassMeterValue(METER_MAX_CAPACITY, PC_FIGHTER_BAY)
+            % ship->SumCurrentPartMeterValuesForPartClass(METER_MAX_CAPACITY, PC_FIGHTER_BAY)
             % strength
             % (strength / cost)
             % typical_shot

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -1980,28 +1980,26 @@ namespace {
         float typical_shot = *std::max_element(enemy_shots.begin(), enemy_shots.end());
         float typical_strength = std::pow(ship->TotalWeaponsDamage(enemy_DR) * structure * typical_shot / std::max(typical_shot - shield, 0.001f), 0.6f);
         return (FlexibleFormat(UserString("ENC_SHIP_DESIGN_DESCRIPTION_STATS_STR"))
-            % ""
-            % ""
-            % ""
-            % ""
-            % ""
-            % ""
-            % ""
-            % ship->CurrentMeterValue(METER_MAX_STRUCTURE)
-            % ship->CurrentMeterValue(METER_MAX_SHIELD)
+            % species
+            % attack
+            % ship->CurrentPartClassMeterValue(METER_MAX_SECONDARY_STAT, PC_DIRECT_WEAPON)
+            % structure
+            % shield
             % ship->CurrentMeterValue(METER_DETECTION)
             % ship->CurrentMeterValue(METER_STEALTH)
-            % ship->CurrentMeterValue(METER_SPEED)
             % ship->CurrentMeterValue(METER_SPEED)
             % ship->CurrentMeterValue(METER_MAX_FUEL)
             % design->ColonyCapacity()
             % ship->TroopCapacity()
-            % attack
-            % species
-            % strength % (strength / cost)
+            % ship->FighterMax()
+            % (attack - ship->TotalWeaponsDamage(0.0f, false))
+            % ship->CurrentPartClassMeterValue(METER_MAX_CAPACITY, PC_FIGHTER_BAY)
+            % strength
+            % (strength / cost)
             % typical_shot
             % enemy_DR
-            % typical_strength % (typical_strength / cost)).str();
+            % typical_strength
+            % (typical_strength / cost)).str();
     }
 
     void RefreshDetailPanelShipDesignTag(   const std::string& item_type, const std::string& item_name,

--- a/default/scripting/encyclopedia/ship_parts/PC_FIGHTER_BAY.focs.txt
+++ b/default/scripting/encyclopedia/ship_parts/PC_FIGHTER_BAY.focs.txt
@@ -1,0 +1,6 @@
+Article
+    name = "PC_FIGHTER_BAY"
+    category = "CATEGORY_GAME_CONCEPTS"
+    short_description = "PC_FIGHTER_BAY"
+    description = "PC_FIGHTER_BAY_DESC"
+    icon = "icons/ship_parts/fighters-1.png"

--- a/default/scripting/encyclopedia/ship_parts/PC_FIGHTER_HANGAR.focs.txt
+++ b/default/scripting/encyclopedia/ship_parts/PC_FIGHTER_HANGAR.focs.txt
@@ -1,0 +1,6 @@
+Article
+    name = "PC_FIGHTER_HANGAR"
+    category = "CATEGORY_GAME_CONCEPTS"
+    short_description = "PC_FIGHTER_HANGAR"
+    description = "PC_FIGHTER_HANGAR_DESC"
+    icon = "icons/ship_parts/fighter05.png"

--- a/default/stringtables/de.txt
+++ b/default/stringtables/de.txt
@@ -2839,41 +2839,6 @@ FP
 ENC_COST_AND_TURNS_STR
 %1% %2% und %3% Rnd
 
-# FIXME
-# Displays the ship design properties inside a Pedia article in detail.
-# %1% description.
-# %2% hull name.
-# %3% list of builtin parts.
-# %4% number of builtin weapon parts.
-# %5% number of builtin rocket parts.
-# %6% number of builtin fighter bays.
-# %7% number of builtin point defense weapon bays.
-# %8% amount of structure points.
-# %9% amount of shield points.
-# %10% amount of detection points.
-# %11% amount of stealth points.
-# %12% battle speed.
-# %13% starlane speed.
-# %14% fuel capacity.
-# %15% number of settlers.
-# %16% number of troops.
-# %17% total damage done by weapons.
-# %18% species that mans the ship.
-ENC_SHIP_DESIGN_DESCRIPTION_STR
-'''%1%
-
-Rumpf: %2%
-Teile: %3%
-
-Gesamter Angriffsschaden: %17%    [[metertype METER_STRUCTURE]]: %8%    [[metertype METER_SHIELD]]: %9%
-[[metertype METER_SPEED]]: %13%    [[metertype METER_FUEL]] Fassungsvermögen: %14%
-[[metertype METER_DETECTION]]: %10%    [[metertype METER_STEALTH]]: %11%
-Besiedlungsvermögen: %15%    Truppen: %16%
-
-Erwartete Kampfstärke (ohne Schilde): %19$.f (%20$.2f pro PP)
-Gegenüber erwarteten gegnerischen Waffen und Schilden: %21$.f (%22$.2f pro PP)
-'''
-
 ENC_UNLOCKED_BY
 '''<u>Durch Technologie freigeschaltet:</u>
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -3950,18 +3950,45 @@ Parts: %3%
 
 '''
 
-# FIXME
-# will need dummy vals 1-8 and 12 for numbering to remain compatible with original ENC_SHIP_DESIGN_DESCRIPTION_STR
+# Detailed ship design information for a given species
+# %1% species for this design
+# %2% total damage from all weapon types
+# %3% weapon shots per round
+# %4% structure
+# %5% shield
+# %6% detection range
+# %7% stealth
+# %8% starlane speed
+# %9% fuel
+# %10% population
+# %11% troops
+# %12% fighters
+# %13% total damage per round of fighters
+# %14% launch bay capacity
+# %15% average attack strength
+# %16% average attack strength/pp
+# %17% mock enemy attack strength
+# %18% mock enemy shields
+# %19% mock average attack strength
+# %20% mock average attack strength/pp
 ENC_SHIP_DESIGN_DESCRIPTION_STATS_STR
 '''
-For species: %18%
-Total [[encyclopedia DAMAGE_TITLE]]: %17%    [[metertype METER_STRUCTURE]]: %8%    [[metertype METER_SHIELD]]: %9%
-[[metertype METER_SPEED]]: %13%    [[metertype METER_FUEL]] Capacity: %14%
-[[metertype METER_DETECTION]]: %10%    [[metertype METER_STEALTH]]: %11%
-Colonization Capacity: %15%    [[metertype METER_TROOPS]]: %16%
-Estimated combat strength (ignoring shields):  %19$.f   (%20$.2f per PP)
-Against enemy attack %21$.1f and shields %22$.1f:       %23$.f   (%24$.2f per PP)
+For [[encyclopedia ENC_SPECIES]]: %1%
+Total [[encyclopedia DAMAGE_TITLE]]: %2%    [[PC_DIRECT_WEAPON]] Shots: %3%
+[[metertype METER_STRUCTURE]]: %4%    [[metertype METER_SHIELD]]: %5%
+[[metertype METER_DETECTION]]: %6%    [[metertype METER_STEALTH]]: %7%
+[[metertype METER_SPEED]]: %8%    [[metertype METER_FUEL]] [[METER_CAPACITY]]: %9%
+Colonization [[METER_CAPACITY]]: %10%    [[metertype METER_TROOPS]]: %11%
+[[OBJ_FIGHTER]] [[encyclopedia DAMAGE_TITLE]]: %13%    [[ENC_SDD_HANGAR]]: %12%    [[ENC_SDD_BAY]]: %14%
+Estimated combat strength (ignoring shields):  %15$.f   (%16$.2f per PP)
+Against enemy attack %17$.1f and shields %18$.1f:       %19$.f   (%20$.2f per PP)
 '''
+
+ENC_SDD_HANGAR
+<encyclopedia PC_FIGHTER_HANGAR>[[SHIP_FIGHTER_HANGAR_SUMMARY]]</encyclopedia>
+
+ENC_SDD_BAY
+<encyclopedia PC_FIGHTER_BAY>[[SHIP_FIGHTER_BAY_SUMMARY]]</encyclopedia>
 
 ENC_UNLOCKED_BY
 '''<u>Unlocked By Techs:</u>

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -3938,41 +3938,6 @@ ENC_AUTO_TIME_COST_VARIABLE_DETAIL_STR
 '''
 At location %1%, the cost and time are %2% %3% over %4% turns.'''
 
-# FIXME
-# Displays the ship design properties inside a Pedia article in detail.
-# %1% description.
-# %2% hull name.
-# %3% list of builtin parts.
-# %4% number of builtin weapon parts.
-# %5% number of builtin rocket parts.
-# %6% number of builtin fighter bays.
-# %7% number of builtin point defense weapon bays.
-# %8% amount of structure points.
-# %9% amount of shield points.
-# %10% amount of detection points.
-# %11% amount of stealth points.
-# %12% battle speed.
-# %13% starlane speed.
-# %14% fuel capacity.
-# %15% number of settlers.
-# %16% number of troops.
-# %17% total damage done by weapons.
-# %18% species that mans the ship.
-ENC_SHIP_DESIGN_DESCRIPTION_STR
-'''%1%
-
-Hull: %2%
-Parts: %3%
-
-Total [[encyclopedia DAMAGE_TITLE]]: %17%    [[metertype METER_STRUCTURE]]: %8%    [[metertype METER_SHIELD]]: %9%
-[[metertype METER_SPEED]]: %13%    [[metertype METER_FUEL]] Capacity: %14%
-[[metertype METER_DETECTION]]: %10%    [[metertype METER_STEALTH]]: %11%
-Colonization Capacity: %15%    [[metertype METER_TROOPS]]: %16%
-
-Estimated combat strength (ignoring shields): %19$.f (%20$.2f per PP)
-Against likely enemy weapons and shields: %21$.f (%22$.2f per PP)
-'''
-
 # Displays a ship design inside the Pedia with the basic informations.
 # %1% description.
 # %2% hull name.

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -3980,15 +3980,15 @@ Total [[encyclopedia DAMAGE_TITLE]]: %2%    [[PC_DIRECT_WEAPON]] Shots: %3%
 [[metertype METER_SPEED]]: %8%    [[metertype METER_FUEL]] [[METER_CAPACITY]]: %9%
 Colonization [[METER_CAPACITY]]: %10%    [[metertype METER_TROOPS]]: %11%
 [[OBJ_FIGHTER]] [[encyclopedia DAMAGE_TITLE]]: %13%    [[ENC_SDD_HANGAR]]: %12%    [[ENC_SDD_BAY]]: %14%
-Estimated combat strength (ignoring shields):  %15$.f   (%16$.2f per PP)
-Against enemy attack %17$.1f and shields %18$.1f:       %19$.f   (%20$.2f per PP)
+Estimated combat strength   (<i>ignoring shields</i>):  %15$.f   (%16$.2f per PP)
+            (<i>enemy with attack %17$.1f and shields %18$.1f</i>):  %19$.f   (%20$.2f per PP)
 '''
 
 ENC_SDD_HANGAR
-<encyclopedia PC_FIGHTER_HANGAR>[[SHIP_FIGHTER_HANGAR_SUMMARY]]</encyclopedia>
+[[encyclopedia PC_FIGHTER_HANGAR]] [[METER_CAPACITY]]
 
 ENC_SDD_BAY
-<encyclopedia PC_FIGHTER_BAY>[[SHIP_FIGHTER_BAY_SUMMARY]]</encyclopedia>
+[[encyclopedia PC_FIGHTER_BAY]] [[METER_CAPACITY]]
 
 ENC_UNLOCKED_BY
 '''<u>Unlocked By Techs:</u>
@@ -7639,10 +7639,10 @@ Hangar
 
 PC_FIGHTER_HANGAR_DESC
 '''Hangars are the storage, maintenance, and resupply areas for fighters.
-Since each hangar is built in support of other hangars on the ship, a ship is limited to one specific hangar type.
+A ship can not have more than one type of hangar.
 
-After combat, fighters need to return to a hangar for repairs, fuel, and rearmament.
-Any fighter that is unable to dock at a hangar will likely be lost to the cold realities of space.
+After combat, fighters return to a hangar for repairs, fuel, and rearmament.
+If a carrier is destroyed in combat, any of its fighters that survive the battle will be unable to dock after combat, and will also be lost.
 '''
 
 # Ship part classes
@@ -7651,7 +7651,7 @@ Launch Bay
 
 PC_FIGHTER_BAY_DESC
 '''Launch bays are the access point for fighters to enter or exit a ship.
-Each launch bay allows a certain number of fighters to launch each combat round.
+Each launch bay allows a number of fighters to launch each combat round.
 '''
 
 # Ship part classes

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -7637,9 +7637,22 @@ Direct Weapon
 PC_FIGHTER_HANGAR
 Hangar
 
+PC_FIGHTER_HANGAR_DESC
+'''Hangars are the storage, maintenance, and resupply areas for fighters.
+Since each hangar is built in support of other hangars on the ship, a ship is limited to one specific hangar type.
+
+After combat, fighters need to return to a hangar for repairs, fuel, and rearmament.
+Any fighter that is unable to dock at a hangar will likely be lost to the cold realities of space.
+'''
+
 # Ship part classes
 PC_FIGHTER_BAY
 Launch Bay
+
+PC_FIGHTER_BAY_DESC
+'''Launch bays are the access point for fighters to enter or exit a ship.
+Each launch bay allows a certain number of fighters to launch each combat round.
+'''
 
 # Ship part classes
 PC_SHIELD

--- a/default/stringtables/es.txt
+++ b/default/stringtables/es.txt
@@ -1603,43 +1603,6 @@ Sistema
 ENC_COST_AND_TURNS_STR
 %3% Turnos %1% %2%/T
 
-# FIXME
-# Displays the ship design properties inside a Pedia article in detail.
-# %1% description.
-# %2% hull name.
-# %3% list of builtin parts.
-# %4% number of builtin weapon parts.
-# %5% number of builtin rocket parts.
-# %6% number of builtin fighter bays.
-# %7% number of builtin point defense weapon bays.
-# %8% amount of structure points.
-# %9% amount of shield points.
-# %10% amount of detection points.
-# %11% amount of stealth points.
-# %12% battle speed.
-# %13% starlane speed.
-# %14% fuel capacity.
-# %15% number of settlers.
-# %16% number of troops.
-# %17% total damage done by weapons.
-# %18% species that mans the ship.
-ENC_SHIP_DESIGN_DESCRIPTION_STR
-'''%1%
-
-Partes de Fuego Directo: %2%
-Partes de Misil: %3%
-Bahias de Cazas: %4%
-Partes de Punto de Defensa: %5%
-Estructura: %6%
-Escudos: %7%
-Fuerza de Detección: %8%
-Velocidad de Batalla: %9%
-Velocidad de Línea Estelar: %10%
-Capacidad de Combustible: %11%
-Capacidad de Colonización: %12%
-Ocultación: %13%
-'''
-
 
 ##
 ## Combat report

--- a/default/stringtables/fi.txt
+++ b/default/stringtables/fi.txt
@@ -1396,43 +1396,6 @@ TP
 ENC_COST_AND_TURNS_STR
 %3% Turns @ %1% %2% / Turn
 
-# FIXME
-# Displays the ship design properties inside a Pedia article in detail.
-# %1% description.
-# %2% hull name.
-# %3% list of builtin parts.
-# %4% number of builtin weapon parts.
-# %5% number of builtin rocket parts.
-# %6% number of builtin fighter bays.
-# %7% number of builtin point defense weapon bays.
-# %8% amount of structure points.
-# %9% amount of shield points.
-# %10% amount of detection points.
-# %11% amount of stealth points.
-# %12% battle speed.
-# %13% starlane speed.
-# %14% fuel capacity.
-# %15% number of settlers.
-# %16% number of troops.
-# %17% total damage done by weapons.
-# %18% species that mans the ship.
-ENC_SHIP_DESIGN_DESCRIPTION_STR
-'''%1%
-
-Suoratuliosat: %2%
-Ohjusosat: %3%
-Hävittäjähangaarit: %4%
-Lähipuolustusosat: %5%
-Runko: %6%
-Suojat: %7%
-Havainnointi: %8%
-Taistelunopeus: %9%
-Tähtilinjanopeus: %10%
-Polttoainekapasiteetti: %11%
-Kolonisaatiokapasiteetti: %12%
-Häivetaso: %13%
-'''
-
 
 ##
 ## Combat report

--- a/default/stringtables/fr.txt
+++ b/default/stringtables/fr.txt
@@ -4102,41 +4102,6 @@ ENC_AUTO_TIME_COST_VARIABLE_DETAIL_STR
 '''
 Sur %1%, le coût et le temps sont de %2% %3% sur %4% tours.'''
 
-# FIXME
-# Displays the ship design properties inside a Pedia article in detail.
-# %1% description.
-# %2% hull name.
-# %3% list of builtin parts.
-# %4% number of builtin weapon parts.
-# %5% number of builtin rocket parts.
-# %6% number of builtin fighter bays.
-# %7% number of builtin point defense weapon bays.
-# %8% amount of structure points.
-# %9% amount of shield points.
-# %10% amount of detection points.
-# %11% amount of stealth points.
-# %12% battle speed.
-# %13% starlane speed.
-# %14% fuel capacity.
-# %15% number of settlers.
-# %16% number of troops.
-# %17% total damage done by weapons.
-# %18% species that mans the ship.
-ENC_SHIP_DESIGN_DESCRIPTION_STR
-'''%1%
-
-Coque : %2%
-Équipement : %3%
-
-Total [[encyclopedia DAMAGE_TITLE]] : %17%    [[metertype METER_STRUCTURE]] : %8%    [[metertype METER_SHIELD]] : %9%
-[[metertype METER_SPEED]] : %13%    Capacité [[metertype METER_FUEL]] : %14%
-[[metertype METER_DETECTION]] : %10%    [[metertype METER_STEALTH]] : %11%
-Colons à bord : %15%    [[metertype METER_TROOPS]] à bord : %16%
-
-Estimation force de combat (sans boucliers): %19$.f (%20$.2f par PP)
-Contre la plupart des armes et boucliers ennemis: %21$.f (%22$.2f par PP)
-'''
-
 # Displays a ship design inside the Pedia with the basic informations.
 # %1% description.
 # %2% hull name.

--- a/default/stringtables/fr.txt
+++ b/default/stringtables/fr.txt
@@ -4114,17 +4114,38 @@ Coque: %2%
 
 '''
 
-# FIXME
-# will need dummy vals 1-8 and 12 for numbering to remain compatible with original ENC_SHIP_DESIGN_DESCRIPTION_STR
+# Detailed ship design information for a given species
+# %1% species for this design
+# %2% total damage from all weapon types
+# %3% weapon shots per round
+# %4% structure
+# %5% shield
+# %6% detection range
+# %7% stealth
+# %8% starlane speed
+# %9% fuel
+# %10% population
+# %11% troops
+# %12% fighters
+# %13% total damage per round of fighters
+# %14% launch bay capacity
+# %15% average attack strength
+# %16% average attack strength/pp
+# %17% mock enemy attack strength
+# %18% mock enemy shields
+# %19% mock average attack strength
+# %20% mock average attack strength/pp
 ENC_SHIP_DESIGN_DESCRIPTION_STATS_STR
 '''
-Pour espèce : %18%
-Total [[encyclopedia DAMAGE_TITLE]] : %17%    [[metertype METER_STRUCTURE]] : %8%    [[metertype METER_SHIELD]] : %9%
-[[metertype METER_SPEED]] : %13%    Capacité [[metertype METER_FUEL]] : %14%
-[[metertype METER_DETECTION]] : %10%    [[metertype METER_STEALTH]] : %11%
-Colons à bord : %15%    [[metertype METER_TROOPS]] à bord : %16%
-Estimation force de combat (sans boucliers) :  %19$.f   (%20$.2f par PP)
-Contre les dommages %21$.1f et boucliers %22$.1f ennemis :  %23$.f   (%24$.2f par PP)
+Pour [[encyclopedia ENC_SPECIES]]: %1%
+Total [[encyclopedia DAMAGE_TITLE]] : %2%    [[PC_DIRECT_WEAPON]] Coups: %3%
+[[metertype METER_STRUCTURE]] : %4%    [[metertype METER_SHIELD]] : %5%
+[[metertype METER_DETECTION]] : %6%    [[metertype METER_STEALTH]] : %7%
+[[metertype METER_SPEED]] : %8%    Capacité [[metertype METER_FUEL]] : %9%
+Colons à bord : %10%    [[metertype METER_TROOPS]] à bord : %11%
+[[OBJ_FIGHTER]] [[encyclopedia DAMAGE_TITLE]]: %13%    [[ENC_SDD_HANGAR]]: %12%    [[ENC_SDD_BAY]]: %14%
+Estimation force de combat (sans boucliers) :  %15$.f   (%16$.2f par PP)
+Contre les dommages %17$.1f et boucliers %18$.1f ennemis :  %19$.f   (%20$.2f par PP)
 '''
 
 ENC_UNLOCKED_BY

--- a/default/stringtables/it.txt
+++ b/default/stringtables/it.txt
@@ -2015,43 +2015,6 @@ PR
 ENC_COST_AND_TURNS_STR
 %1% %2% e %3% Turni
 
-# FIXME
-# Displays the ship design properties inside a Pedia article in detail.
-# %1% description.
-# %2% hull name.
-# %3% list of builtin parts.
-# %4% number of builtin weapon parts.
-# %5% number of builtin rocket parts.
-# %6% number of builtin fighter bays.
-# %7% number of builtin point defense weapon bays.
-# %8% amount of structure points.
-# %9% amount of shield points.
-# %10% amount of detection points.
-# %11% amount of stealth points.
-# %12% battle speed.
-# %13% starlane speed.
-# %14% fuel capacity.
-# %15% number of settlers.
-# %16% number of troops.
-# %17% total damage done by weapons.
-# %18% species that mans the ship.
-ENC_SHIP_DESIGN_DESCRIPTION_STR
-'''%1%
-
-Scafo: %2%
-Parti: %3%
-
-Totale Danni Attacco: %17%
-Strutture: %8%
-[[metertype METER_SHIELD]]: %9%
-[[metertype METER_DETECTION]]: %10%
-[[metertype METER_STEALTH]]: %11%
-Capacità Carburante: %14%
-Capacità Colonizzazione: %15%
-Truppe: %16%
-Velocità Stellare: %13%
-'''
-
 ENC_UNLOCKED_BY
 '''<u>Sbloccato dalle Tecnologie:</u>
 

--- a/default/stringtables/ru.txt
+++ b/default/stringtables/ru.txt
@@ -2499,17 +2499,38 @@ ENC_SHIP_DESIGN_DESCRIPTION_BASE_STR
 
 '''
 
-# FIXME
-# will need dummy vals 1-8 and 12 for numbering to remain compatible with original ENC_SHIP_DESIGN_DESCRIPTION_STR
+# Detailed ship design information for a given species
+# %1% species for this design
+# %2% total damage from all weapon types
+# %3% weapon shots per round
+# %4% structure
+# %5% shield
+# %6% detection range
+# %7% stealth
+# %8% starlane speed
+# %9% fuel
+# %10% population
+# %11% troops
+# %12% fighters
+# %13% total damage per round of fighters
+# %14% launch bay capacity
+# %15% average attack strength
+# %16% average attack strength/pp
+# %17% mock enemy attack strength
+# %18% mock enemy shields
+# %19% mock average attack strength
+# %20% mock average attack strength/pp
 ENC_SHIP_DESIGN_DESCRIPTION_STATS_STR
 '''
-Для расы: %18%
-Общий урон: %17%    [[metertype METER_STRUCTURE]]: %8%    [[metertype METER_SHIELD]]: %9%
-[[metertype METER_SPEED]]: %13%    [[metertype METER_FUEL]]: %14%
-[[metertype METER_DETECTION]]: %10%    [[metertype METER_STEALTH]]: %11%
-Численность колонии: %15%    [[metertype METER_TROOPS]]: %16%
-Расчетная боевая мощь (игнорируя щиты):  %19$.f   (%20$.2f за PP)
-Против вражеской атаки %21$.1f и щитов %22$.1f:       %23$.f   (%24$.2f за PP)
+Для расы: %1%
+Общий урон: %2%    [[PC_DIRECT_WEAPON]] Shots: %3%
+[[metertype METER_STRUCTURE]]: %4%    [[metertype METER_SHIELD]]: %5%
+[[metertype METER_DETECTION]]: %6%    [[metertype METER_STEALTH]]: %7%
+[[metertype METER_SPEED]]: %8%    [[metertype METER_FUEL]] [[METER_CAPACITY]]: %9%
+Численность колонии: %10%    [[metertype METER_TROOPS]]: %11%
+[[OBJ_FIGHTER]] [[encyclopedia DAMAGE_TITLE]]: %13%    [[ENC_SDD_HANGAR]]: %12%    [[ENC_SDD_BAY]]: %14%
+Расчетная боевая мощь (игнорируя щиты):  %15$.f   (%16$.2f за PP)
+Против вражеской атаки %17$.1f и щитов %18$.1f:       %19$.f   (%20$.2f за PP)
 '''
 
 ENC_UNLOCKED_BY

--- a/default/stringtables/ru.txt
+++ b/default/stringtables/ru.txt
@@ -2487,43 +2487,6 @@ ENC_RP
 ENC_COST_AND_TURNS_STR
 %3% ходов @ %1% %2% / ход
 
-# FIXME
-# Displays the ship design properties inside a Pedia article in detail.
-# %1% description.
-# %2% hull name.
-# %3% list of builtin parts.
-# %4% number of builtin weapon parts.
-# %5% number of builtin rocket parts.
-# %6% number of builtin fighter bays.
-# %7% number of builtin point defense weapon bays.
-# %8% amount of structure points.
-# %9% amount of shield points.
-# %10% amount of detection points.
-# %11% amount of stealth points.
-# %12% battle speed.
-# %13% starlane speed.
-# %14% fuel capacity.
-# %15% number of settlers.
-# %16% number of troops.
-# %17% total damage done by weapons.
-# %18% species that mans the ship.
-ENC_SHIP_DESIGN_DESCRIPTION_STR
-'''%1%
-
-Корпус: %2%
-Части: %3%
-
-Общий урон: %17%
-Структура: %8%
-[[metertype METER_SHIELD]]: %9%
-[[metertype METER_DETECTION]]: %10%
-[[metertype METER_STEALTH]]: %11%
-Топливо: %14%
-Модуль поселенцев: %15%
-Десант: %16%
-Скорость перелетов: %13%
-'''
-
 # Displays a ship design inside the Pedia with the basic informations.
 # %1% description.
 # %2% hull name.

--- a/universe/Ship.cpp
+++ b/universe/Ship.cpp
@@ -431,7 +431,7 @@ float Ship::InitialPartMeterValue(MeterType type, const std::string& part_name) 
     return 0.0f;
 }
 
-float Ship::CurrentPartClassMeterValue(MeterType type, ShipPartClass part_class) const {
+float Ship::SumCurrentPartMeterValuesForPartClass(MeterType type, ShipPartClass part_class) const {
     float retval = 0.0f;
 
     const ShipDesign* design = GetShipDesign(m_design_id);

--- a/universe/Ship.cpp
+++ b/universe/Ship.cpp
@@ -431,6 +431,37 @@ float Ship::InitialPartMeterValue(MeterType type, const std::string& part_name) 
     return 0.0f;
 }
 
+float Ship::CurrentPartClassMeterValue(MeterType type, ShipPartClass part_class) const {
+    float retval = 0.0f;
+
+    const ShipDesign* design = GetShipDesign(m_design_id);
+    if (!design)
+        return retval;
+
+    const std::vector<std::string>& parts = design->Parts();
+    if (parts.empty())
+        return retval;
+
+    std::map<std::string, int> part_counts;
+    for (const std::string& part : parts)
+        part_counts[part]++;
+
+    for (const PartMeterMap::value_type& part_meter : m_part_meters) {
+        if (part_meter.first.first != type)
+            continue;
+        const std::string& part_name = part_meter.first.second;
+        if (part_counts[part_name] < 1)
+            continue;
+        const PartType* part_type = GetPartType(part_name);
+        if (!part_type)
+            continue;
+        if (part_class == part_type->Class())
+            retval += part_meter.second.Current() * part_counts[part_name];
+    }
+
+    return retval;
+}
+
 float Ship::FighterCount() const {
     float retval = 0.0f;
     for (const PartMeterMap::value_type& entry : m_part_meters) {

--- a/universe/Ship.h
+++ b/universe/Ship.h
@@ -61,8 +61,8 @@ public:
     float                       CurrentPartMeterValue(MeterType type, const std::string& part_name) const;  ///< returns current value of the specified part meter \a type for the specified part name
     float                       InitialPartMeterValue(MeterType type, const std::string& part_name) const;  ///< returns this turn's initial value for the speicified part meter \a type for the specified part name
 
-    /** Returns sum of current value for MeterType @p type of all parts with ShipPartClass @p part_class */
-    float                       CurrentPartClassMeterValue(MeterType type, ShipPartClass part_class) const;
+    /** Returns sum of current value for part meter @p type of all parts with ShipPartClass @p part_class */
+    float                       SumCurrentPartMeterValuesForPartClass(MeterType type, ShipPartClass part_class) const;
 
     float                       TotalWeaponsDamage(float shield_DR = 0.0f, bool include_fighters = true) const; ///< versus an enemy with a given shields DR
     float                       FighterCount() const;

--- a/universe/Ship.h
+++ b/universe/Ship.h
@@ -61,6 +61,9 @@ public:
     float                       CurrentPartMeterValue(MeterType type, const std::string& part_name) const;  ///< returns current value of the specified part meter \a type for the specified part name
     float                       InitialPartMeterValue(MeterType type, const std::string& part_name) const;  ///< returns this turn's initial value for the speicified part meter \a type for the specified part name
 
+    /** Returns sum of current value for MeterType @p type of all parts with ShipPartClass @p part_class */
+    float                       CurrentPartClassMeterValue(MeterType type, ShipPartClass part_class) const;
+
     float                       TotalWeaponsDamage(float shield_DR = 0.0f, bool include_fighters = true) const; ///< versus an enemy with a given shields DR
     float                       FighterCount() const;
     float                       FighterMax() const;


### PR DESCRIPTION
Suggested by UrshMost in [forum](http://www.freeorion.org/forum/viewtopic.php?f=28&t=10339#p86772).

Adds fighter damage, capacity and launch capacity to pedia article of ship designs.
In lieu of specific info for flak cannons, adds a total number of weapon shots fired (per round).