### PR TITLE
Some fixes for CMake-generated MSVC project.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,10 @@ if (WIN32)
         set (CMAKE_STATIC_LIBRARY_PREFIX "lib")
         set (CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /NODEFAULTLIB:LIBCMT")
         set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /NODEFAULTLIB:LIBCMT")
+        add_definitions(
+            -DUNICODE
+            -D_UNICODE
+        )
     endif ()
 elseif (APPLE)
     add_definitions(-DFREEORION_MACOSX)

--- a/GG/CMakeLists.txt
+++ b/GG/CMakeLists.txt
@@ -58,6 +58,10 @@ if (MSVC)
     set (CMAKE_STATIC_LIBRARY_PREFIX "lib")
     set (CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /NODEFAULTLIB:LIBCMT")
     set (CMAKE_STATIC_LINKER_FLAGS "${CMAKE_STATIC_LINKER_FLAGS} /NODEFAULTLIB:LIBCMT")
+    add_definitions(
+        -DUNICODE
+        -D_UNICODE
+    )
 endif ()
 
 include_directories(

--- a/client/human/CMakeLists.txt
+++ b/client/human/CMakeLists.txt
@@ -8,6 +8,7 @@ find_package(SDL2 REQUIRED)
 find_package(OpenAL REQUIRED)
 find_package(Ogg REQUIRED)
 find_package(Vorbis REQUIRED)
+find_package(PNG REQUIRED)
 
 include_directories(
     SYSTEM
@@ -16,6 +17,7 @@ include_directories(
     ${SDL2_INCLUDE_DIR}
     ${OGG_INCLUDE_DIR}
     ${VORBIS_INCLUDE_DIR}
+    ${PNG_INCLUDE_DIR}
 )
 
 add_definitions(-DFREEORION_BUILD_HUMAN)
@@ -170,6 +172,7 @@ set(freeorion_LINK_LIBS
     ${SDL2_LIBRARY}
     ${OGG_LIBRARY}
     ${VORBIS_LIBRARIES}
+    ${PNG_LIBRARIES}
     ${ZLIB_LIBRARY}
     ${Boost_LOCALE_LIBRARY}
     ${CMAKE_THREAD_LIBS_INIT}

--- a/parse/DoubleComplexValueRefParser.cpp
+++ b/parse/DoubleComplexValueRefParser.cpp
@@ -48,7 +48,7 @@ namespace parse {
 
             species_empire_opinion
                 = (
-                    (  tok.SpeciesOpinion_ [ _a = construct<std::string>("SpeciesEmpireOpinion") ]
+                    (  tok.SpeciesOpinion_ [ _a = construct<std::string>(std::string("SpeciesEmpireOpinion")) ]
                        >  parse::label(Species_token) >  string_value_ref [ _d = _1 ]
                     )
                   >> parse::label(Empire_token)  >  simple_int [ _b = _1 ]
@@ -57,7 +57,7 @@ namespace parse {
 
             species_species_opinion
                 = (
-                    (   tok.SpeciesOpinion_ [ _a = construct<std::string>("SpeciesSpeciesOpinion") ]
+                    (   tok.SpeciesOpinion_ [ _a = construct<std::string>(std::string("SpeciesSpeciesOpinion")) ]
                       >  parse::label(Species_token) >  string_value_ref [ _d = _1 ]
                     )
                   >> parse::label(Species_token) >  string_value_ref [ _e = _1 ]

--- a/parse/StringValueRefParser.cpp
+++ b/parse/StringValueRefParser.cpp
@@ -93,7 +93,7 @@ namespace { struct string_parser_rules {
                     |   tok.ThisTech_
                     |   tok.ThisSpecies_
                     |   tok.ThisSpecial_
-                   ) [ _val = new_<ValueRef::Constant<std::string> >("CurrentContent") ]
+                   ) [ _val = new_<ValueRef::Constant<std::string> >(std::string("CurrentContent")) ]
                 ;
 
             free_variable

--- a/util/Process.cpp
+++ b/util/Process.cpp
@@ -29,7 +29,7 @@ public:
 private:
     bool                m_free;
 #if defined(FREEORION_WIN32)
-    STARTUPINFO          m_startup_info;
+    STARTUPINFOW         m_startup_info;
     PROCESS_INFORMATION  m_process_info;
 #elif defined(FREEORION_LINUX) || defined(FREEORION_MACOSX)
     pid_t                m_process_id;


### PR DESCRIPTION
1. Use unicode version of WinAPI functions. I got error with STARTUPINFOA.
2. Add dependency from libpng to human client project.