### PR TITLE
Fix global-buffer-overflow error.

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -771,7 +771,7 @@ std::string ProductionQueue::ProductionItem::Dump() const {
     if (!name.empty())
         retval += "name: " + name;
     if (design_id != ShipDesign::INVALID_DESIGN_ID)
-        retval += "id: " + design_id;
+        retval += "id: " + boost::lexical_cast<std::string>(design_id);
     return retval;
 }
 


### PR DESCRIPTION
Make AddressSanitizer happy.
```
==5832==ERROR: AddressSanitizer: global-buffer-overflow on address 0x7f602f2e2925 at pc 0x7f602e81ce91 bp 0x7ffcdd76f600 sp 0x7ffcdd76f5f0
READ of size 1 at 0x7f602f2e2925 thread T0
    #0 0x7f602e81ce90 in std::char_traits<char>::length(char const*) /usr/lib/gcc/x86_64-pc-linux-gnu/4.9.4/include/g++-v4/bits/char_traits.h:263
    #1 0x7f602e81ce90 in std::string::append(char const*) /usr/lib/gcc/x86_64-pc-linux-gnu/4.9.4/include/g++-v4/bits/basic_string.h:1025
    #2 0x7f602e81ce90 in std::string::operator+=(char const*) /usr/lib/gcc/x86_64-pc-linux-gnu/4.9.4/include/g++-v4/bits/basic_string.h:958
    #3 0x7f602e81ce90 in ProductionQueue::ProductionItem::Dump() const /mnt/another/srcs/GIT/freeorion/Empire/Empire.cpp:774
0x7f602f2e2925 is located 0 bytes to the right of global variable '*.LC128' from '/mnt/another/srcs/GIT/freeorion/Empire/Empire.cpp' (0x7f602f2e2920) of size 5
  '*.LC128' is ascii string 'id: '
0x7f602f2e2925 is located 59 bytes to the left of global variable '*.LC129' from '/mnt/another/srcs/GIT/freeorion/Empire/Empire.cpp' (0x7f602f2e2960) of size 27
  '*.LC129' is ascii string 'ProductionQueue::Element ('
SUMMARY: AddressSanitizer: global-buffer-overflow /usr/lib/gcc/x86_64-pc-linux-gnu/4.9.4/include/g++-v4/bits/char_traits.h:263 std::char_traits<char>::length(char const*)
```