### PR TITLE
Massively increased build costs of Transformer

### DIFF
--- a/default/scripting/buildings/TRANSFORMER.focs.txt
+++ b/default/scripting/buildings/TRANSFORMER.focs.txt
@@ -1,7 +1,7 @@
 BuildingType
     name = "BLD_TRANSFORMER"
     description = "BLD_TRANSFORMER_DESC"
-    buildcost = 100
+    buildcost = 600
     buildtime = 8
     location = AND [
         Not Contains Building name = "BLD_TRANSFORMER"


### PR DESCRIPTION
Fixes the long standing and repeatedly criticized issue that the build costs of the Transformer building are far too low, sometimes only a fraction of one of the buildings it can emulate (stargates being the example being frequently brought up). Raised the build costs from 100 to 800.