### PR TITLE
FOCS support for part based fleet upkeep

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -3385,6 +3385,23 @@ void Empire::UpdateOwnedObjectCounters() {
         m_ship_designs_owned[ship->DesignID()]++;
     }
 
+    // update ship part counts
+    m_ship_part_types_owned.clear();
+    m_ship_part_class_owned.clear();
+    for (const std::map<int, int>::value_type& design_count : m_ship_designs_owned) {
+        const ShipDesign* design = GetShipDesign(design_count.first);
+        if (!design)
+            continue;
+
+        // update count of PartTypes
+        for (const std::map<std::string, int>::value_type& part_type : design->PartTypeCount())
+            m_ship_part_types_owned[part_type.first] += part_type.second * design_count.second;
+
+        // update count of ShipPartClasses
+        for (const std::map<ShipPartClass, int>::value_type& part_class : design->PartClassCount())
+            m_ship_part_class_owned[part_class.first] += part_class.second * design_count.second;
+    }
+
     // colonies of each species, and unspecified outposts
     m_species_colonies_owned.clear();
     m_outposts_owned = 0;
@@ -3424,6 +3441,16 @@ int Empire::TotalShipsOwned() const {
     for (const std::map<int, int>::value_type& entry : m_ship_designs_owned)
     { counter += entry.second; }
     return counter;
+}
+
+int Empire::TotalShipPartsOwned() const {
+    // sum counts of all ship parts owned by this empire
+    int retval = 0;
+
+    for (const std::map<ShipPartClass, int>::value_type& part_class : m_ship_part_class_owned)
+        retval += part_class.second;
+
+    return retval;
 }
 
 int Empire::TotalBuildingsOwned() const {

--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -567,10 +567,13 @@ public:
     void                        UpdateOwnedObjectCounters();
 
     int                         TotalShipsOwned() const;
+    int                         TotalShipPartsOwned() const;    ///< Total number of parts for all owned ships in this empire
     int                         TotalBuildingsOwned() const;
 
     std::map<std::string, int>& SpeciesShipsOwned()     { return m_species_ships_owned; }
     std::map<int, int>&         ShipDesignsOwned()      { return m_ship_designs_owned; }
+    std::map<std::string, int>&       ShipPartTypesOwned()        { return m_ship_part_types_owned; }
+    std::map<ShipPartClass, int>&     ShipPartClassOwned()        { return m_ship_part_class_owned; }
     std::map<std::string, int>& SpeciesColoniesOwned()  { return m_species_colonies_owned; }
     int&                        OutpostsOwned()         { return m_outposts_owned; }
     std::map<std::string, int>& BuildingTypesOwned()    { return m_building_types_owned; }
@@ -643,6 +646,8 @@ private:
 
     std::map<std::string, int>      m_species_ships_owned;      ///< how many ships of each species does this empire currently own?
     std::map<int, int>              m_ship_designs_owned;       ///< how many ships of each design does this empire currently own?
+    std::map<std::string, int>      m_ship_part_types_owned;    ///< how many ship parts are currently owned, indexed by PartType
+    std::map<ShipPartClass, int>    m_ship_part_class_owned;    ///< how many ship parts are currently owned, indexed by ShipPartClass
     std::map<std::string, int>      m_species_colonies_owned;   ///< how many colonies of each species does this empire currently own?
     int                             m_outposts_owned;           ///< how many uncolonized outposts does this empire currently own?
     std::map<std::string, int>      m_building_types_owned;     ///< how many buildings does this empire currently own?

--- a/parse/IntComplexValueRefParser.cpp
+++ b/parse/IntComplexValueRefParser.cpp
@@ -102,6 +102,18 @@ namespace parse {
                     ) [ _val = new_<ValueRef::ComplexVariable<int> >(_a, _b, _c, _f, _d, _e) ]
                 ;
 
+            ship_parts_owned
+                =   (
+                            tok.ShipPartsOwned_ [ _a = construct<std::string>(_1) ]
+                        >-( parse::label(Empire_token)          > int_value_ref [ _b = _1 ] )
+                        >-(     ( parse::label(Name_token)      > string_value_ref [ _d = _1 ] )
+                            |   ( parse::label(Class_token)     >>
+                                  parse::enum_parser<ShipPartClass>() [ _c = new_<ValueRef::Constant<int>>(_1) ]
+                                )
+                          )
+                    ) [ _val = new_<ValueRef::ComplexVariable<int>>(_a, _b, _c, _f, _d, _e) ]
+                ;
+
             ship_designs_destroyed
                 =   (
                             tok.ShipDesignsDestroyed_ [ _a = construct<std::string>(_1) ]
@@ -238,6 +250,7 @@ namespace parse {
                 |   outposts_owned
                 |   parts_in_ship_design
                 |   part_class_in_ship_design
+                |   ship_parts_owned
                 |   ship_designs_destroyed
                 |   ship_designs_lost
                 |   ship_designs_owned
@@ -265,6 +278,7 @@ namespace parse {
             outposts_owned.name("OutpostsOwned");
             parts_in_ship_design.name("PartsInShipDesign");
             part_class_in_ship_design.name("PartClassInShipDesign");
+            ship_parts_owned.name("ShipPartsOwned");
             ship_designs_destroyed.name("ShipDesignsDestroyed");
             ship_designs_lost.name("ShipDesignsLost");
             ship_designs_owned.name("ShipDesignsOwned");
@@ -292,6 +306,7 @@ namespace parse {
             debug(outposts_owned);
             debug(parts_in_ship_design);
             debug(part_class_in_ship_design);
+            debug(ship_parts_owned);
             debug(ship_designs_destroyed);
             debug(ship_designs_lost);
             debug(ship_designs_owned);
@@ -321,6 +336,7 @@ namespace parse {
         complex_variable_rule<int>::type    outposts_owned;
         complex_variable_rule<int>::type    parts_in_ship_design;
         complex_variable_rule<int>::type    part_class_in_ship_design;
+        complex_variable_rule<int>::type    ship_parts_owned;
         complex_variable_rule<int>::type    ship_designs_destroyed;
         complex_variable_rule<int>::type    ship_designs_lost;
         complex_variable_rule<int>::type    ship_designs_owned;

--- a/parse/Tokens.h
+++ b/parse/Tokens.h
@@ -403,6 +403,7 @@
     (ShipHull)                                  \
     (ShipPart)                                  \
     (ShipPartMeter)                             \
+    (ShipPartsOwned)                            \
     (Ships)                                     \
     (Short_Description)                         \
     (ShortestPath)                              \

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -906,7 +906,9 @@ void ShipDesign::BuildStatCaches() {
         if (!part->Producible())
             m_producible = false;
 
-        switch (part->Class()) {
+        ShipPartClass part_class = part->Class();
+
+        switch (part_class) {
         case PC_DIRECT_WEAPON:
             m_is_armed = true;
             break;
@@ -956,6 +958,10 @@ void ShipDesign::BuildStatCaches() {
         default:
             break;
         }
+
+        m_num_part_types[part_name]++;
+        if (part_class > INVALID_SHIP_PART_CLASS && part_class < NUM_SHIP_PART_CLASSES)
+            m_num_part_classes[part_class]++;
     }
 }
 

--- a/universe/ShipDesign.h
+++ b/universe/ShipDesign.h
@@ -526,6 +526,12 @@ public:
     const std::string&              Model() const           { return m_3D_model; }  ///< returns filename of 3D model that represents ships of design
     bool                            LookupInStringtable() const { return m_name_desc_in_stringtable; }
 
+    /** returns number of parts in this ship design, indexed by PartType name */
+    const std::map<std::string, int>&     PartTypeCount() const { return m_num_part_types; }
+
+    /** returns number of parts in this ship design, indexed by ShipPartClass */
+    const std::map<ShipPartClass, int>&   PartClassCount() const { return m_num_part_classes; }
+
     std::string                     Dump() const;                                   ///< returns a data file format representation of this object
 
     friend bool operator ==(const ShipDesign& first, const ShipDesign& second);
@@ -586,6 +592,8 @@ private:
     float   m_industry_generation;
     float   m_trade_generation;
     bool    m_is_production_location;
+    std::map<std::string, int>      m_num_part_types;
+    std::map<ShipPartClass, int>    m_num_part_classes;
 
     bool    m_producible;
 

--- a/util/SerializeEmpire.cpp
+++ b/util/SerializeEmpire.cpp
@@ -128,6 +128,8 @@ void Empire::serialize(Archive& ar, const unsigned int version)
 
             & BOOST_SERIALIZATION_NVP(m_species_ships_owned)
             & BOOST_SERIALIZATION_NVP(m_ship_designs_owned)
+            & BOOST_SERIALIZATION_NVP(m_ship_part_types_owned)
+            & BOOST_SERIALIZATION_NVP(m_ship_part_class_owned)
             & BOOST_SERIALIZATION_NVP(m_species_colonies_owned)
             & BOOST_SERIALIZATION_NVP(m_outposts_owned)
             & BOOST_SERIALIZATION_NVP(m_building_types_owned)


### PR DESCRIPTION
~~PR is intended for testing of fleet upkeep utilizing number of currently owned parts.
Initial change from 1% per ship to 0.2% per part.
While there are various threads discussing changes to upkeep, the most recent revolves around [Influence & Happiness](http://www.freeorion.org/forum/viewtopic.php?f=5&t=9998)~~

Changed to only add support for such a change.