### PR TITLE
Allow Process() to return immediately.  linux only.

### DIFF
--- a/util/Process.cpp
+++ b/util/Process.cpp
@@ -206,8 +206,7 @@ Process::Impl::Impl(const std::string& cmd, const std::vector<std::string>& argv
         break;
     }
 
-    default: // original process side of fork (execution continues after a set-up wait)
-        sleep(1); // wait a second to let the child process set up
+    default:
         break;
     }
 }

--- a/util/Process.h
+++ b/util/Process.h
@@ -49,7 +49,9 @@ public:
         name. The first token on the command line must be the name of the executable of the process to be created.  Example: 
         cmd: "/usr/bin/cvs", argv: "cvs update -C project_file.cpp". Of course, each arg should be in its own string within 
         argv, and argv strings containing spaces must be enclosed in quotes.  \throw std::runtime_error Throws 
-        std::runtime_error if the process cannot be successfully created.*/
+        std::runtime_error if the process cannot be successfully created.
+
+        Process returns immediately.*/
     Process(const std::string& cmd, const std::vector<std::string>& argv);
     //@}
 


### PR DESCRIPTION
Removes sleep(1) from the original side of the fork() in linux.

In all cases where Process() is actually used the human client or the
server contacts the child process asynchronously via networking.

sleep(1) did not guarantee the new process was fully initialized.  It
also imposed a 1 second per AI startup penalty.