### PR TITLE
Reduce AI polling interval from 250ms to 10ms to increase responsiveness.

### DIFF
--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -134,7 +134,7 @@ void AIClientApp::Run() {
                     Networking().GetMessage(msg);
                     HandleMessage(msg);
                 } else {
-                    boost::this_thread::sleep_for(boost::chrono::milliseconds(250));
+                    boost::this_thread::sleep_for(boost::chrono::milliseconds(10));
                 }
 
             } catch (boost::python::error_already_set) {


### PR DESCRIPTION
1/4 second is too long.  The AI will never appear responsive to callbacks.  I chose 10ms as long from a processor perspective, but slightly shorter than a video refresh interval.