### PR TITLE
Improve combat log differential serialization

### DIFF
--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -751,7 +751,7 @@ bool ClientUI::ZoomToField(int id) {
 }
 
 bool ClientUI::ZoomToCombatLog(int id) {
-    if (GetCombatLogManager().LogAvailable(id)) {
+    if (GetCombatLogManager().GetLog(id)) {
         GetMapWnd()->ShowCombatLog(id);
         return true;
     }

--- a/UI/CombatReport/GraphicalSummary.cpp
+++ b/UI/CombatReport/GraphicalSummary.cpp
@@ -707,11 +707,11 @@ void GraphicalSummaryWnd::HandleButtonChanged() {
 
 void GraphicalSummaryWnd::MakeSummaries(int log_id) {
     m_summaries.clear();
-    if (!CombatLogAvailable(log_id)) {
+    boost::optional<const CombatLog&> log = GetCombatLog(log_id);
+    if (!log) {
         ErrorLogger() << "CombatReportWnd::CombatReportPrivate::MakeSummaries: Could not find log: " << log_id;
     } else {
-        const CombatLog& log = GetCombatLog(log_id);
-        for (int object_id : log.object_ids) {
+        for (int object_id : log->object_ids) {
             if (object_id < 0)
                 continue;   // fighters and invalid objects
             TemporaryPtr<UniverseObject> object = GetUniverseObject(object_id);
@@ -724,8 +724,8 @@ void GraphicalSummaryWnd::MakeSummaries(int log_id) {
             if (m_summaries.find(owner_id) == m_summaries.end())
                 m_summaries[owner_id] = CombatSummary(owner_id);
 
-            std::map<int, CombatParticipantState>::const_iterator map_it = log.participant_states.find(object_id);
-            if (map_it != log.participant_states.end()) {
+            std::map<int, CombatParticipantState>::const_iterator map_it = log->participant_states.find(object_id);
+            if (map_it != log->participant_states.end()) {
                 m_summaries[owner_id].AddUnit(object_id, map_it->second);
             } else {
                 ErrorLogger() << "Participant state missing from log. Object id: " << object_id << " log id: " << log_id;

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -242,12 +242,12 @@ void AIClientApp::HandleMessage(const Message& msg) {
             std::string save_state_string;
             m_player_status.clear();
 
-            ExtractMessageData(msg,                     single_player_game,     m_empire_id,
-                               m_current_turn,          m_empires,              m_universe,
-                               GetSpeciesManager(),     GetCombatLogManager(),  GetSupplyManager(),
-                               m_player_info,           m_orders,               loaded_game_data,
-                               ui_data_available,       ui_data,                state_string_available,
-                               save_state_string,       m_galaxy_setup_data);
+            ExtractGameStartMessageData(msg,                     single_player_game,     m_empire_id,
+                                        m_current_turn,          m_empires,              m_universe,
+                                        GetSpeciesManager(),     GetCombatLogManager(),  GetSupplyManager(),
+                                        m_player_info,           m_orders,               loaded_game_data,
+                                        ui_data_available,       ui_data,                state_string_available,
+                                        save_state_string,       m_galaxy_setup_data);
 
             DebugLogger() << "Extracted GameStart message for turn: " << m_current_turn << " with empire: " << m_empire_id;
 
@@ -332,9 +332,9 @@ void AIClientApp::HandleMessage(const Message& msg) {
     case Message::TURN_UPDATE: {
         if (msg.SendingPlayer() == Networking::INVALID_PLAYER_ID) {
             //DebugLogger() << "AIClientApp::HandleMessage : extracting turn update message data";
-            ExtractMessageData(msg,                     m_empire_id,        m_current_turn,
-                               m_empires,               m_universe,         GetSpeciesManager(),
-                               GetCombatLogManager(),   GetSupplyManager(), m_player_info);
+            ExtractTurnUpdateMessageData(msg,                     m_empire_id,        m_current_turn,
+                                         m_empires,               m_universe,         GetSpeciesManager(),
+                                         GetCombatLogManager(),   GetSupplyManager(), m_player_info);
             //DebugLogger() << "AIClientApp::HandleMessage : generating orders";
             GetUniverse().InitializeSystemGraph(m_empire_id);
             m_AI->GenerateOrders();
@@ -345,7 +345,7 @@ void AIClientApp::HandleMessage(const Message& msg) {
 
     case Message::TURN_PARTIAL_UPDATE:
         if (msg.SendingPlayer() == Networking::INVALID_PLAYER_ID)
-            ExtractMessageData(msg, m_empire_id, m_universe);
+            ExtractTurnPartialUpdateMessageData(msg, m_empire_id, m_universe);
         break;
 
     case Message::TURN_PROGRESS:
@@ -364,14 +364,14 @@ void AIClientApp::HandleMessage(const Message& msg) {
 
     case Message::DIPLOMACY: {
         DiplomaticMessage diplo_message;
-        ExtractMessageData(msg, diplo_message);
+        ExtractDiplomacyMessageData(msg, diplo_message);
         m_AI->HandleDiplomaticMessage(diplo_message);
         break;
     }
 
     case Message::DIPLOMATIC_STATUS: {
         DiplomaticStatusUpdateInfo diplo_update;
-        ExtractMessageData(msg, diplo_update);
+        ExtractDiplomaticStatusMessageData(msg, diplo_update);
         m_AI->HandleDiplomaticStatusUpdate(diplo_update);
         break;
     }

--- a/client/ClientApp.h
+++ b/client/ClientApp.h
@@ -206,6 +206,10 @@ public:
      */
     void SetCurrentTurn(int turn);
 
+    /** @brief Handle the turn update.
+     */
+    virtual void HandleTurnUpdate() {}
+
     /** @brief Set whether the current game is a single player game or not
      *
      * @param single_player Set true if the game is a single player game,

--- a/client/ClientFSMEvents.h
+++ b/client/ClientFSMEvents.h
@@ -21,6 +21,7 @@ struct MessageEventBase
 
 // Define Boost.Preprocessor list of all Message events
 #define MESSAGE_EVENTS                         \
+    (DispatchCombatLogs)                       \
     (Error)                                    \
     (HostMPGame)                               \
     (HostSPGame)                               \

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -893,7 +893,6 @@ void HumanClientApp::UpdateCombatLogs(const Message& msg){
     {
         GetCombatLogManager().CompleteLog(it->first, it->second);
     }
-
 }
 
 void HumanClientApp::HandleWindowMove(GG::X w, GG::Y h) {
@@ -999,9 +998,8 @@ void HumanClientApp::HandleTurnUpdate()
 { UpdateCombatLogManager(); }
 
 void HumanClientApp::UpdateCombatLogManager() {
-    boost::optional<std::vector<int> > incompleteIDs(GetCombatLogManager().IncompleteLogIDs());
-    if (incompleteIDs)
-        m_networking.SendMessage(RequestCombatLogsMessage(PlayerID(), *incompleteIDs));
+    if (auto incomplete_ids {GetCombatLogManager().IncompleteLogIDs()})
+        m_networking.SendMessage(RequestCombatLogsMessage(PlayerID(), *incomplete_ids));
 }
 
 namespace {

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -977,6 +977,11 @@ void HumanClientApp::StartGame() {
 
 void HumanClientApp::HandleTurnUpdate() {
 
+    if (GetCombatLogManager().HasIncompleteLogs() && m_networking.Connected()) {
+        m_networking.SendMessage(
+            RequestCombatLogsMessage(EmpireID(),
+                                     GetCombatLogManager().IncompleteLogIDs()));
+    }
 }
 
 namespace {

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -865,6 +865,8 @@ void HumanClientApp::HandleMessage(Message& msg) {
     case Message::DIPLOMACY:                m_fsm->process_event(Diplomacy(msg));               break;
     case Message::DIPLOMATIC_STATUS:        m_fsm->process_event(DiplomaticStatusUpdate(msg));  break;
     case Message::END_GAME:                 m_fsm->process_event(::EndGame(msg));               break;
+
+    case Message::DISPATCH_COMBAT_LOGS:     m_fsm->process_event(DispatchCombatLogs(msg));       break;
     default:
         ErrorLogger() << "HumanClientApp::HandleMessage : Received an unknown message type \"" << msg.Type() << "\".";
     }
@@ -876,6 +878,22 @@ void HumanClientApp::HandleSaveGameDataRequest() {
     SaveGameUIData ui_data;
     m_ui->GetSaveGameUIData(ui_data);
     m_networking.SendMessage(ClientSaveDataMessage(PlayerID(), Orders(), ui_data));
+}
+
+void HumanClientApp::UpdateCombatLogs(const Message& msg){
+    DebugLogger() << "HCL Update Combat Logs";
+
+    // Unpack the combat logs from the message
+    std::vector<std::pair<int, CombatLog> > logs;
+    ExtractDispatchCombatLogsMessageData(msg, logs);
+
+    // Update the combat log manager with the completed logs.
+    for (std::vector<std::pair<int, CombatLog> >::const_iterator it = logs.begin();
+         it != logs.end(); ++it)
+    {
+        GetCombatLogManager().CompleteLog(it->first, it->second);
+    }
+
 }
 
 void HumanClientApp::HandleWindowMove(GG::X w, GG::Y h) {

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -712,7 +712,7 @@ void HumanClientApp::RequestSavePreviews(const std::string& directory, PreviewIn
     Message response;
     m_networking.SendSynchronousMessage(RequestSavePreviewsMessage(PlayerID(), generic_directory), response);
     if (response.Type() == Message::DISPATCH_SAVE_PREVIEWS){
-        ExtractMessageData(response, previews);
+        ExtractDispatchSavePreviewsMessageData(response, previews);
         DebugLogger() << "HumanClientApp::RequestSavePreviews Got " << previews.previews.size() << " previews.";
     }else{
         ErrorLogger() << "HumanClientApp::RequestSavePreviews: Wrong response type from server: " << response.Type();

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -991,12 +991,17 @@ void HumanClientApp::StartGame() {
 
     if (MapWnd* map_wnd = ClientUI::GetClientUI()->GetMapWnd())
         map_wnd->ResetEmpireShown();
+
+    UpdateCombatLogManager();
 }
 
-void HumanClientApp::HandleTurnUpdate() {
+void HumanClientApp::HandleTurnUpdate()
+{ UpdateCombatLogManager(); }
+
+void HumanClientApp::UpdateCombatLogManager() {
     boost::optional<std::vector<int> > incompleteIDs(GetCombatLogManager().IncompleteLogIDs());
     if (incompleteIDs)
-        m_networking.SendMessage(RequestCombatLogsMessage(EmpireID(), *incompleteIDs));
+        m_networking.SendMessage(RequestCombatLogsMessage(PlayerID(), *incompleteIDs));
 }
 
 namespace {

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -976,12 +976,9 @@ void HumanClientApp::StartGame() {
 }
 
 void HumanClientApp::HandleTurnUpdate() {
-
-    if (GetCombatLogManager().HasIncompleteLogs() && m_networking.Connected()) {
-        m_networking.SendMessage(
-            RequestCombatLogsMessage(EmpireID(),
-                                     GetCombatLogManager().IncompleteLogIDs()));
-    }
+    boost::optional<std::vector<int> > incompleteIDs(GetCombatLogManager().IncompleteLogIDs());
+    if (incompleteIDs)
+        m_networking.SendMessage(RequestCombatLogsMessage(EmpireID(), *incompleteIDs));
 }
 
 namespace {

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -975,6 +975,10 @@ void HumanClientApp::StartGame() {
         map_wnd->ResetEmpireShown();
 }
 
+void HumanClientApp::HandleTurnUpdate() {
+
+}
+
 namespace {
     void RemoveOldestFiles(int files_limit, boost::filesystem::path& p) {
         using namespace boost::filesystem;

--- a/client/human/HumanClientApp.h
+++ b/client/human/HumanClientApp.h
@@ -53,6 +53,10 @@ public:
     void                CancelMultiplayerGameFromLobby();               ///< cancels out of multiplayer game
     void                SaveGame(const std::string& filename);          ///< saves the current game; blocks until all save-related network traffic is resolved.
     void                StartGame();
+    /** Handle the turn update, by requesting complete combat log information.
+     */
+    void HandleTurnUpdate();
+
     void                EndGame(bool suppress_FSM_reset = false);       ///< kills the server (if appropriate) and ends the current game, leaving the application in its start state
     void                LoadSinglePlayerGame(std::string filename = "");///< loads a single player game chosen by the user; returns true if a game was loaded, and false if the operation was cancelled
     void                RequestSavePreviews(const std::string& directory, PreviewInformation& previews); ///< Requests the savegame previews for choosing one.

--- a/client/human/HumanClientApp.h
+++ b/client/human/HumanClientApp.h
@@ -53,9 +53,14 @@ public:
     void                CancelMultiplayerGameFromLobby();               ///< cancels out of multiplayer game
     void                SaveGame(const std::string& filename);          ///< saves the current game; blocks until all save-related network traffic is resolved.
     void                StartGame();
-    /** Handle the turn update, by requesting complete combat log information.
+
+    /** Handle background events that need starting when the turn updates.
      */
-    void HandleTurnUpdate();
+    void                HandleTurnUpdate();
+    /** Check if the CombatLogManager has incomplete logs that need fetching and start fetching
+        them from the server.
+     */
+    void                UpdateCombatLogManager();
 
     void                EndGame(bool suppress_FSM_reset = false);       ///< kills the server (if appropriate) and ends the current game, leaving the application in its start state
     void                LoadSinglePlayerGame(std::string filename = "");///< loads a single player game chosen by the user; returns true if a game was loaded, and false if the operation was cancelled

--- a/client/human/HumanClientApp.h
+++ b/client/human/HumanClientApp.h
@@ -75,6 +75,7 @@ public:
     virtual void        StartTurn();
 
     void                HandleSaveGameDataRequest();
+    void                UpdateCombatLogs(const Message& msg);
 
     void                OpenURL(const std::string& url);
     //@}

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -111,7 +111,7 @@ boost::statechart::result WaitingForSPHostAck::react(const Error& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) WaitingForSPHostAck.Error";
     std::string problem;
     bool fatal;
-    ExtractMessageData(msg.m_message, problem, fatal);
+    ExtractErrorMessageData(msg.m_message, problem, fatal);
 
     ErrorLogger() << "WaitingForSPHostAck::react(const Error& msg) error: " << problem;
 
@@ -155,7 +155,7 @@ boost::statechart::result WaitingForMPHostAck::react(const Error& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) WaitingForMPHostAck.Error";
     std::string problem;
     bool fatal;
-    ExtractMessageData(msg.m_message, problem, fatal);
+    ExtractErrorMessageData(msg.m_message, problem, fatal);
 
     ErrorLogger() << "WaitingForMPHostAck::react(const Error& msg) error: " << problem;
 
@@ -198,7 +198,7 @@ boost::statechart::result WaitingForMPJoinAck::react(const Error& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) WaitingForMPJoinAck.Error";
     std::string problem;
     bool fatal;
-    ExtractMessageData(msg.m_message, problem, fatal);
+    ExtractErrorMessageData(msg.m_message, problem, fatal);
 
     ErrorLogger() << "WaitingForMPJoinAck::react(const Error& msg) error: " << problem;
 
@@ -266,7 +266,7 @@ boost::statechart::result MPLobby::react(const HostID& msg) {
 boost::statechart::result MPLobby::react(const LobbyUpdate& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) MPLobby.LobbyUpdate";
     MultiplayerLobbyData lobby_data;
-    ExtractMessageData(msg.m_message, lobby_data);
+    ExtractLobbyUpdateMessageData(msg.m_message, lobby_data);
     Client().GetClientUI()->GetMultiPlayerLobbyWnd()->LobbyUpdate(lobby_data);
     return discard_event();
 }
@@ -310,7 +310,7 @@ boost::statechart::result MPLobby::react(const Error& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) MPLobby.Error";
     std::string problem;
     bool fatal;
-    ExtractMessageData(msg.m_message, problem, fatal);
+    ExtractErrorMessageData(msg.m_message, problem, fatal);
 
     ErrorLogger() << "MPLobby::react(const Error& msg) error: " << problem;
 
@@ -390,7 +390,7 @@ boost::statechart::result PlayingGame::react(const PlayerStatus& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) PlayingGame.PlayerStatus";
     int about_player_id;
     Message::PlayerStatus status;
-    ExtractMessageData(msg.m_message, about_player_id, status);
+    ExtractPlayerStatusMessageData(msg.m_message, about_player_id, status);
 
     Client().SetPlayerStatus(about_player_id, status);
     Client().GetClientUI()->GetMessageWnd()->HandlePlayerStatusUpdate(status, about_player_id);
@@ -404,7 +404,7 @@ boost::statechart::result PlayingGame::react(const Diplomacy& d) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) PlayingGame.Diplomacy";
 
     DiplomaticMessage diplo_message;
-    ExtractMessageData(d.m_message, diplo_message);
+    ExtractDiplomacyMessageData(d.m_message, diplo_message);
     Empires().SetDiplomaticMessage(diplo_message);
 
     return discard_event();
@@ -414,7 +414,7 @@ boost::statechart::result PlayingGame::react(const DiplomaticStatusUpdate& u) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) PlayingGame.DiplomaticStatusUpdate";
 
     DiplomaticStatusUpdateInfo diplo_update;
-    ExtractMessageData(u.m_message, diplo_update);
+    ExtractDiplomaticStatusMessageData(u.m_message, diplo_update);
     Empires().SetDiplomaticStatus(diplo_update.empire1_id, diplo_update.empire2_id, diplo_update.diplo_status);
 
     return discard_event();
@@ -424,7 +424,7 @@ boost::statechart::result PlayingGame::react(const EndGame& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) PlayingGame.EndGame";
     Message::EndGameReason reason;
     std::string reason_player_name;
-    ExtractMessageData(msg.m_message, reason, reason_player_name);
+    ExtractEndGameMessageData(msg.m_message, reason, reason_player_name);
     std::string reason_message;
     bool error = false;
     switch (reason) {
@@ -457,7 +457,7 @@ boost::statechart::result PlayingGame::react(const Error& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) PlayingGame.Error";
     std::string problem;
     bool fatal;
-    ExtractMessageData(msg.m_message, problem, fatal);
+    ExtractErrorMessageData(msg.m_message, problem, fatal);
 
     ErrorLogger() << "PlayingGame::react(const Error& msg) error: "
                   << problem << "\nProblem is" <<(fatal ? "":"non-")<<" fatal";
@@ -482,7 +482,7 @@ boost::statechart::result PlayingGame::react(const TurnProgress& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) PlayingGame.TurnProgress";
 
     Message::TurnProgressPhase phase_id;
-    ExtractMessageData(msg.m_message, phase_id);
+    ExtractTurnProgressMessageData(msg.m_message, phase_id);
     Client().GetClientUI()->GetMessageWnd()->HandleTurnPhaseUpdate(phase_id);
 
     return discard_event();
@@ -491,7 +491,7 @@ boost::statechart::result PlayingGame::react(const TurnProgress& msg) {
 boost::statechart::result PlayingGame::react(const TurnPartialUpdate& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) PlayingGame.TurnPartialUpdate";
 
-    ExtractMessageData(msg.m_message,   Client().EmpireID(),    GetUniverse());
+    ExtractTurnPartialUpdateMessageData(msg.m_message,   Client().EmpireID(),    GetUniverse());
 
     Client().GetClientUI()->GetMapWnd()->MidTurnUpdate();
 
@@ -530,12 +530,12 @@ boost::statechart::result WaitingForGameStart::react(const GameStart& msg) {
     int current_turn = INVALID_GAME_TURN;
     Client().PlayerStatus().clear();
 
-    ExtractMessageData(msg.m_message,       single_player_game,             empire_id,
-                       current_turn,        Empires(),                      GetUniverse(),
-                       GetSpeciesManager(), GetCombatLogManager(),          GetSupplyManager(),
-                       Client().Players(),  orders,                         loaded_game_data,
-                       ui_data_available,   ui_data,                        save_state_string_available,
-                       save_state_string,   Client().GetGalaxySetupData());
+    ExtractGameStartMessageData(msg.m_message,       single_player_game,             empire_id,
+                                current_turn,        Empires(),                      GetUniverse(),
+                                GetSpeciesManager(), GetCombatLogManager(),          GetSupplyManager(),
+                                Client().Players(),  orders,                         loaded_game_data,
+                                ui_data_available,   ui_data,                        save_state_string_available,
+                                save_state_string,   Client().GetGalaxySetupData());
 
     DebugLogger() << "Extracted GameStart message for turn: " << current_turn << " with empire: " << empire_id;
 
@@ -584,7 +584,7 @@ boost::statechart::result WaitingForTurnData::react(const SaveGameComplete& msg)
 
     std::string save_filename;
     int bytes_written;
-    ExtractMessageData(msg.m_message, save_filename, bytes_written);
+    ExtractServerSaveGameCompleteMessageData(msg.m_message, save_filename, bytes_written);
 
 
     Client().GetClientUI()->GetMessageWnd()->HandleGameStatusUpdate(
@@ -600,9 +600,9 @@ boost::statechart::result WaitingForTurnData::react(const TurnUpdate& msg) {
     int current_turn = INVALID_GAME_TURN;
 
     try {
-        ExtractMessageData(msg.m_message,           Client().EmpireID(),    current_turn,
-                           Empires(),               GetUniverse(),          GetSpeciesManager(),
-                           GetCombatLogManager(),   GetSupplyManager(),     Client().Players());
+        ExtractTurnUpdateMessageData(msg.m_message,           Client().EmpireID(),    current_turn,
+                                     Empires(),               GetUniverse(),          GetSpeciesManager(),
+                                     GetCombatLogManager(),   GetSupplyManager(),     Client().Players());
     } catch (...) {
         Client().GetClientUI()->GetMessageWnd()->HandleLogMessage(UserString("ERROR_PROCESSING_SERVER_MESSAGE") + "\n");
         return discard_event();
@@ -690,7 +690,7 @@ boost::statechart::result PlayingTurn::react(const SaveGameComplete& msg) {
 
     std::string save_filename;
     int bytes_written;
-    ExtractMessageData(msg.m_message, save_filename, bytes_written);
+    ExtractServerSaveGameCompleteMessageData(msg.m_message, save_filename, bytes_written);
 
 
     Client().GetClientUI()->GetMessageWnd()->HandleGameStatusUpdate(
@@ -726,7 +726,7 @@ boost::statechart::result PlayingTurn::react(const PlayerStatus& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) PlayingTurn.PlayerStatus";
     int about_player_id;
     Message::PlayerStatus status;
-    ExtractMessageData(msg.m_message, about_player_id, status);
+    ExtractPlayerStatusMessageData(msg.m_message, about_player_id, status);
 
     Client().SetPlayerStatus(about_player_id, status);
     Client().GetClientUI()->GetMessageWnd()->HandlePlayerStatusUpdate(status, about_player_id);

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -621,6 +621,12 @@ boost::statechart::result WaitingForTurnData::react(const TurnUpdate& msg) {
     return transit<PlayingTurn>();
 }
 
+boost::statechart::result WaitingForTurnData::react(const DispatchCombatLogs& msg) {
+    DebugLogger() << "(PlayerFSM) WaitingForTurnData::DispatchCombatLogs message received";
+    Client().UpdateCombatLogs(msg.m_message);
+    return discard_event();
+}
+
 
 ////////////////////////////////////////////////////////////
 // PlayingTurn
@@ -764,3 +770,8 @@ boost::statechart::result PlayingTurn::react(const PlayerStatus& msg) {
     return discard_event();
 }
 
+boost::statechart::result PlayingTurn::react(const DispatchCombatLogs& msg) {
+    DebugLogger() << "(PlayerFSM) PlayingGame::DispatchCombatLogs message received";
+    Client().UpdateCombatLogs(msg.m_message);
+    return discard_event();
+}

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -616,6 +616,8 @@ boost::statechart::result WaitingForTurnData::react(const TurnUpdate& msg) {
     if (Client().Networking().PlayerIsHost(Client().PlayerID()))
         Client().Autosave();
 
+    Client().HandleTurnUpdate();
+
     return transit<PlayingTurn>();
 }
 

--- a/client/human/HumanClientFSM.h
+++ b/client/human/HumanClientFSM.h
@@ -265,7 +265,8 @@ struct WaitingForTurnData : boost::statechart::state<WaitingForTurnData, Playing
     typedef boost::mpl::list<
         boost::statechart::custom_reaction<SaveGameDataRequest>,
         boost::statechart::custom_reaction<SaveGameComplete>,
-        boost::statechart::custom_reaction<TurnUpdate>
+        boost::statechart::custom_reaction<TurnUpdate>,
+        boost::statechart::custom_reaction<DispatchCombatLogs>
     > reactions;
 
     WaitingForTurnData(my_context ctx);
@@ -274,6 +275,7 @@ struct WaitingForTurnData : boost::statechart::state<WaitingForTurnData, Playing
     boost::statechart::result react(const SaveGameDataRequest& d);
     boost::statechart::result react(const SaveGameComplete& d);
     boost::statechart::result react(const TurnUpdate& msg);
+    boost::statechart::result react(const DispatchCombatLogs& msg);
 
     CLIENT_ACCESSOR
 };
@@ -289,7 +291,8 @@ struct PlayingTurn : boost::statechart::state<PlayingTurn, PlayingGame> {
         boost::statechart::custom_reaction<AdvanceTurn>,
         boost::statechart::custom_reaction<TurnUpdate>,
         boost::statechart::custom_reaction<TurnEnded>,
-        boost::statechart::custom_reaction<PlayerStatus>
+        boost::statechart::custom_reaction<PlayerStatus>,
+        boost::statechart::custom_reaction<DispatchCombatLogs>
     > reactions;
 
     PlayingTurn(my_context ctx);
@@ -301,6 +304,7 @@ struct PlayingTurn : boost::statechart::state<PlayingTurn, PlayingGame> {
     boost::statechart::result react(const TurnUpdate& msg);
     boost::statechart::result react(const TurnEnded& d);
     boost::statechart::result react(const PlayerStatus& msg);
+    boost::statechart::result react(const DispatchCombatLogs& msg);
 
     CLIENT_ACCESSOR
 };

--- a/combat/CombatLogManager.cpp
+++ b/combat/CombatLogManager.cpp
@@ -157,15 +157,11 @@ CombatLogManager::CombatLogManager() :
     m_latest_log_id(-1)
 {}
 
-bool CombatLogManager::LogAvailable(int log_id) const
-{ return m_logs.begin() != m_logs.end(); }
-
-const CombatLog& CombatLogManager::GetLog(int log_id) const {
+boost::optional<const CombatLog&> CombatLogManager::GetLog(int log_id) const {
     std::map<int, CombatLog>::const_iterator it = m_logs.find(log_id);
     if (it != m_logs.end())
         return it->second;
-    static CombatLog EMPTY_LOG;
-    return EMPTY_LOG;
+    return boost::none;
 }
 
 int CombatLogManager::AddLog(const CombatLog& log) {
@@ -210,8 +206,5 @@ CombatLogManager& CombatLogManager::GetCombatLogManager() {
 CombatLogManager& GetCombatLogManager()
 { return CombatLogManager::GetCombatLogManager(); }
 
-const CombatLog& GetCombatLog(int log_id)
+boost::optional<const CombatLog&> GetCombatLog(int log_id)
 { return GetCombatLogManager().GetLog(log_id); }
-
-bool CombatLogAvailable(int log_id)
-{ return GetCombatLogManager().LogAvailable(log_id); }

--- a/combat/CombatLogManager.cpp
+++ b/combat/CombatLogManager.cpp
@@ -199,6 +199,18 @@ void CombatLogManager::GetLogsToSerialize(std::map<int, CombatLog>& logs, int en
 void CombatLogManager::SetLog(int log_id, const CombatLog& log)
 { m_logs[log_id] = log; }
 
+
+bool CombatLogManager::HasIncompleteLogs() const
+{
+    return true;
+}
+
+std::vector<int> CombatLogManager::IncompleteLogIDs() const
+{
+    return std::vector<int>(1,19);
+}
+
+
 CombatLogManager& CombatLogManager::GetCombatLogManager() {
     static CombatLogManager manager;
     return manager;

--- a/combat/CombatLogManager.cpp
+++ b/combat/CombatLogManager.cpp
@@ -200,6 +200,37 @@ CombatLogManager& CombatLogManager::GetCombatLogManager() {
     return manager;
 }
 
+template <class Archive>
+void CombatLogManager::serialize(Archive& ar, const unsigned int version)
+{
+    std::map<int, CombatLog> logs;
+
+    if (Archive::is_saving::value) {
+        GetLogsToSerialize(logs, GetUniverse().EncodingEmpire());
+    }
+
+    ar  & BOOST_SERIALIZATION_NVP(logs)
+        & BOOST_SERIALIZATION_NVP(m_latest_log_id);
+
+    if (Archive::is_loading::value) {
+        // copy new logs, but don't erase old ones
+        for (auto& log : logs)
+            this->SetLog(log.first, log.second);
+    }
+}
+
+template
+void CombatLogManager::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive& ar, const unsigned int version);
+
+template
+void CombatLogManager::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive& ar, const unsigned int version);
+
+template
+void CombatLogManager::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive& ar, const unsigned int version);
+
+template
+void CombatLogManager::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive& ar, const unsigned int version);
+
 ///////////////////////////////////////////////////////////
 // Free Functions                                        //
 ///////////////////////////////////////////////////////////

--- a/combat/CombatLogManager.cpp
+++ b/combat/CombatLogManager.cpp
@@ -241,10 +241,21 @@ void CombatLogManager::CombatLogManagerImpl::GetLogsToSerialize(
 void CombatLogManager::CombatLogManagerImpl::SetLog(int log_id, const CombatLog& log)
 { m_logs[log_id] = log; }
 
-
 boost::optional<std::vector<int> > CombatLogManager::CombatLogManagerImpl::IncompleteLogIDs() const
 {
-    return std::vector<int>(1,19);
+    if (m_incomplete_logs.empty())
+        return boost::none;
+
+    // Set the log ids in reverse order so that if the server only has time to
+    // send one log it is the most recent combat log, which is the one most
+    // likely of interest to the player.
+    std::vector<int> ids;
+    for (std::set<int>::reverse_iterator rit = m_incomplete_logs.rbegin();
+         rit != m_incomplete_logs.rend(); ++rit)
+    {
+        ids.push_back(*rit);
+    }
+    return ids;
 }
 
 template <class Archive>

--- a/combat/CombatLogManager.cpp
+++ b/combat/CombatLogManager.cpp
@@ -157,15 +157,6 @@ CombatLogManager::CombatLogManager() :
     m_latest_log_id(-1)
 {}
 
-std::map<int, CombatLog>::const_iterator CombatLogManager::begin() const
-{ return m_logs.begin(); }
-
-std::map<int, CombatLog>::const_iterator CombatLogManager::end() const
-{ return m_logs.end(); }
-
-std::map<int, CombatLog>::const_iterator CombatLogManager::find(int log_id) const
-{ return m_logs.find(log_id); }
-
 bool CombatLogManager::LogAvailable(int log_id) const
 { return m_logs.begin() != m_logs.end(); }
 
@@ -182,9 +173,6 @@ int CombatLogManager::AddLog(const CombatLog& log) {
     m_logs[new_log_id] = log;
     return new_log_id;
 }
-
-void CombatLogManager::RemoveLog(int log_id)
-{ m_logs.erase(log_id); }
 
 void CombatLogManager::Clear()
 { m_logs.clear(); }

--- a/combat/CombatLogManager.cpp
+++ b/combat/CombatLogManager.cpp
@@ -163,11 +163,8 @@ class CombatLogManager::CombatLogManagerImpl
     /** Return the requested combat log or boost::none.*/
     boost::optional<const CombatLog&>  GetLog(int log_id) const;
 
-    /** Return true if there are partial logs.*/
-    bool HasIncompleteLogs() const;
-
-    /** Return the ids of all incomplete logs.*/
-    std::vector<int> IncompleteLogIDs() const;
+    /** Return the ids of all incomplete logs or none.*/
+    boost::optional<std::vector<int> > IncompleteLogIDs() const;
     //@}
 
     /** \name Mutators */ //@{
@@ -219,12 +216,7 @@ void CombatLogManager::CombatLogManagerImpl::SetLog(int log_id, const CombatLog&
 { m_logs[log_id] = log; }
 
 
-bool CombatLogManager::CombatLogManagerImpl::HasIncompleteLogs() const
-{
-    return true;
-}
-
-std::vector<int> CombatLogManager::CombatLogManagerImpl::IncompleteLogIDs() const
+boost::optional<std::vector<int> > CombatLogManager::CombatLogManagerImpl::IncompleteLogIDs() const
 {
     return std::vector<int>(1,19);
 }
@@ -268,10 +260,7 @@ int CombatLogManager::AddLog(const CombatLog& log)
 void CombatLogManager::Clear()
 { return pimpl->Clear(); }
 
-bool CombatLogManager::HasIncompleteLogs() const
-{ return pimpl->HasIncompleteLogs(); }
-
-std::vector<int> CombatLogManager::IncompleteLogIDs() const
+boost::optional<std::vector<int> > CombatLogManager::IncompleteLogIDs() const
 { return pimpl->IncompleteLogIDs(); }
 
 CombatLogManager& CombatLogManager::GetCombatLogManager() {

--- a/combat/CombatLogManager.h
+++ b/combat/CombatLogManager.h
@@ -49,11 +49,8 @@ public:
     /** Return the requested combat log or boost::none.*/
     boost::optional<const CombatLog&>  GetLog(int log_id) const;
 
-    /** Return true if there are partial logs.*/
-    bool HasIncompleteLogs() const;
-
-    /** Return the ids of all incomplete logs.*/
-    std::vector<int> IncompleteLogIDs() const;
+    /** Return the ids of all incomplete logs or boost::none if they are all complete.*/
+    boost::optional<std::vector<int> > IncompleteLogIDs() const;
     //@}
 
     /** \name Mutators */ //@{

--- a/combat/CombatLogManager.h
+++ b/combat/CombatLogManager.h
@@ -5,6 +5,8 @@
 
 #include "../util/Export.h"
 
+#include <boost/optional/optional.hpp>
+
 // A snapshot of the state of a participant of the combat
 // at it's end
 struct FO_COMMON_API CombatParticipantState {
@@ -43,8 +45,8 @@ BOOST_CLASS_VERSION ( CombatLog, 1 );
 class FO_COMMON_API CombatLogManager {
 public:
     /** \name Accessors */ //@{
-    bool              LogAvailable(int log_id) const; // returns whether a log with the indicated id is available
-    const CombatLog&  GetLog(int log_id) const;       // returns requested combat log, or an empty default log if no log with the requested id exists
+    /** Return the requested combat log or boost::none.*/
+    boost::optional<const CombatLog&>  GetLog(int log_id) const;
 
     /** Return true if there are partial logs.*/
     bool HasIncompleteLogs() const;
@@ -79,10 +81,7 @@ FO_COMMON_API CombatLogManager&   GetCombatLogManager();
 
 /** Returns the CombatLog with the indicated id, or an empty log if there
   * is no avaiable log with that id. */
-FO_COMMON_API const CombatLog&    GetCombatLog(int log_id);
-
-/** Returns true if a CombatLog with the indicated id is available. */
-FO_COMMON_API bool                CombatLogAvailable(int log_id);
+FO_COMMON_API boost::optional<const CombatLog&> GetCombatLog(int log_id);
 
 template <class Archive>
 void CombatLogManager::serialize(Archive& ar, const unsigned int version)

--- a/combat/CombatLogManager.h
+++ b/combat/CombatLogManager.h
@@ -48,6 +48,12 @@ public:
     std::map<int, CombatLog>::const_iterator    find(int log_id) const;
     bool                                        LogAvailable(int log_id) const; // returns whether a log with the indicated id is available
     const CombatLog&                            GetLog(int log_id) const;       // returns requested combat log, or an empty default log if no log with the requested id exists
+
+    /** Return true if there are partial logs.*/
+    bool HasIncompleteLogs() const;
+
+    /** Return the ids of all incomplete logs.*/
+    std::vector<int> IncompleteLogIDs() const;
     //@}
 
     /** \name Mutators */ //@{

--- a/combat/CombatLogManager.h
+++ b/combat/CombatLogManager.h
@@ -43,11 +43,8 @@ BOOST_CLASS_VERSION ( CombatLog, 1 );
 class FO_COMMON_API CombatLogManager {
 public:
     /** \name Accessors */ //@{
-    std::map<int, CombatLog>::const_iterator    begin() const;
-    std::map<int, CombatLog>::const_iterator    end() const;
-    std::map<int, CombatLog>::const_iterator    find(int log_id) const;
-    bool                                        LogAvailable(int log_id) const; // returns whether a log with the indicated id is available
-    const CombatLog&                            GetLog(int log_id) const;       // returns requested combat log, or an empty default log if no log with the requested id exists
+    bool              LogAvailable(int log_id) const; // returns whether a log with the indicated id is available
+    const CombatLog&  GetLog(int log_id) const;       // returns requested combat log, or an empty default log if no log with the requested id exists
 
     /** Return true if there are partial logs.*/
     bool HasIncompleteLogs() const;
@@ -58,7 +55,6 @@ public:
 
     /** \name Mutators */ //@{
     int     AddLog(const CombatLog& log);   // adds log, returns unique log id
-    void    RemoveLog(int log_id);
     void    Clear();
     //@}
 

--- a/combat/CombatLogManager.h
+++ b/combat/CombatLogManager.h
@@ -6,6 +6,7 @@
 #include "../util/Export.h"
 
 #include <boost/optional/optional.hpp>
+#include <boost/scoped_ptr.hpp>
 
 // A snapshot of the state of a participant of the combat
 // at it's end
@@ -64,12 +65,11 @@ public:
 
 private:
     CombatLogManager();
+    ~CombatLogManager();
 
-    void GetLogsToSerialize(std::map<int, CombatLog>& logs, int encoding_empire) const;
-    void SetLog(int log_id, const CombatLog& log);
-
-    std::map<int, CombatLog>    m_logs;
-    int                         m_latest_log_id;
+    class CombatLogManagerImpl;
+    // TODO use C++11 unique_ptr
+    boost::scoped_ptr<CombatLogManagerImpl> const pimpl;
 
     friend class boost::serialization::access;
     template <class Archive>

--- a/combat/CombatLogManager.h
+++ b/combat/CombatLogManager.h
@@ -54,7 +54,10 @@ public:
     //@}
 
     /** \name Mutators */ //@{
-    int     AddLog(const CombatLog& log);   // adds log, returns unique log id
+    int     AddNewLog(const CombatLog& log);   // adds log, returns unique log id
+    /** Replace incomplete log with \p id with \p log. An incomplete log is a partially downloaded
+        log where only the log id is known.*/
+    void    CompleteLog(int id, const CombatLog& log);
     void    Clear();
     //@}
 

--- a/combat/CombatLogManager.h
+++ b/combat/CombatLogManager.h
@@ -83,24 +83,4 @@ FO_COMMON_API CombatLogManager&   GetCombatLogManager();
   * is no avaiable log with that id. */
 FO_COMMON_API boost::optional<const CombatLog&> GetCombatLog(int log_id);
 
-template <class Archive>
-void CombatLogManager::serialize(Archive& ar, const unsigned int version)
-{
-    std::map<int, CombatLog> logs;
-
-    if (Archive::is_saving::value) {
-        GetLogsToSerialize(logs, GetUniverse().EncodingEmpire());
-    }
-
-    ar  & BOOST_SERIALIZATION_NVP(logs)
-        & BOOST_SERIALIZATION_NVP(m_latest_log_id);
-
-    if (Archive::is_loading::value) {
-        // copy new logs, but don't erase old ones
-        for (std::map<int, CombatLog>::value_type& log : logs)
-            this->SetLog(log.first, log.second);
-    }
-}
-
-
 #endif // _CombatLogManager_h_

--- a/combat/CombatLogManager.h
+++ b/combat/CombatLogManager.h
@@ -55,10 +55,15 @@ public:
 
     /** \name Mutators */ //@{
     int     AddNewLog(const CombatLog& log);   // adds log, returns unique log id
-    /** Replace incomplete log with \p id with \p log. An incomplete log is a partially downloaded
-        log where only the log id is known.*/
+    /** Replace incomplete log with \p id with \p log. An incomplete log is a
+        partially downloaded log where only the log id is known.*/
     void    CompleteLog(int id, const CombatLog& log);
     void    Clear();
+
+    /** Serialize log headers so that the receiving LogManager can then request
+        complete logs in the background.*/
+    template <class Archive>
+    void SerializeIncompleteLogs(Archive& ar, const unsigned int version);
     //@}
 
     static CombatLogManager& GetCombatLogManager();

--- a/network/Message.cpp
+++ b/network/Message.cpp
@@ -1077,8 +1077,8 @@ FO_COMMON_API void ExtractRequestCombatLogsMessageData(const Message& msg, std::
     }
 }
 
-FO_COMMON_API void ExtractDispathCombatLogsMessageData(
-    const Message& msg, std::vector<std::pair<int, const CombatLog&> >& logs)
+FO_COMMON_API void ExtractDispatchCombatLogsMessageData(
+    const Message& msg, std::vector<std::pair<int, CombatLog> >& logs)
 {
     try {
         std::istringstream is(msg.Text());

--- a/network/Message.cpp
+++ b/network/Message.cpp
@@ -986,22 +986,6 @@ void ExtractMessageData(const Message& msg, Moderator::ModeratorAction*& mod_act
     }
 }
 
-void ExtractMessageData(const Message& msg, int& empire_id, std::string& empire_name) {
-    try {
-        std::istringstream is(msg.Text());
-        freeorion_xml_iarchive ia(is);
-        ia >> BOOST_SERIALIZATION_NVP(empire_id)
-           >> BOOST_SERIALIZATION_NVP(empire_name);
-
-    } catch (const std::exception& err) {
-        ErrorLogger() << "ExtractMessageData(const Message& msg, int empire_id, std::string& "
-                      << "empire_name) failed!  Message:\n"
-                      << msg.Text() << "\n"
-                      << "Error: " << err.what();
-        throw err;
-    }
-}
-
 void ExtractMessageData(const Message& msg, DiplomaticMessage& diplo_message) {
     try {
         std::istringstream is(msg.Text());

--- a/network/Message.cpp
+++ b/network/Message.cpp
@@ -611,6 +611,17 @@ Message DispatchSavePreviewsMessage(int receiver, const PreviewInformation& prev
     return Message(Message::DISPATCH_SAVE_PREVIEWS, Networking::INVALID_PLAYER_ID, receiver, os.str(), true);
 }
 
+Message RequestCombatLogsMessage(int sender, const std::vector<int>& ids) {
+    std::ostringstream os;
+    freeorion_xml_oarchive oa(os);
+    oa << BOOST_SERIALIZATION_NVP(ids);
+    return Message(Message::REQUEST_COMBAT_LOGS, sender, Networking::INVALID_PLAYER_ID, os.str());
+}
+
+Message DispatchCombatLogsMessage(int receiver) {
+    return Message(Message::DISPATCH_COMBAT_LOGS, Networking::INVALID_PLAYER_ID, receiver, "fake logs", true);
+}
+
 ////////////////////////////////////////////////
 // Multiplayer Lobby Message named ctors
 ////////////////////////////////////////////////
@@ -1044,6 +1055,19 @@ FO_COMMON_API void ExtractServerSaveGameCompleteMessageData(const Message& msg, 
 
     } catch(const std::exception& err) {
         ErrorLogger() << "ExtractServerSaveGameCompleteServerSaveGameCompleteMessageData(const Message& msg, std::string& save_filename, int& bytes_written) failed!  Message:\n"
+                      << msg.Text() << "\n"
+                      << "Error: " << err.what();
+        throw err;
+    }
+}
+
+FO_COMMON_API void ExtractRequestCombatLogsMessageData(const Message& msg, std::vector<int>& ids) {
+    try {
+        std::istringstream is(msg.Text());
+        freeorion_xml_iarchive ia(is);
+        ia >> BOOST_SERIALIZATION_NVP(ids);
+    } catch(const std::exception& err) {
+        ErrorLogger() << "ExtractRequestCombatLogMessageData(const Message& msg, std::vector<int>& ids) failed!  Message:\n"
                       << msg.Text() << "\n"
                       << "Error: " << err.what();
         throw err;

--- a/network/Message.cpp
+++ b/network/Message.cpp
@@ -645,14 +645,14 @@ Message StartMPGameMessage(int player_id)
 ////////////////////////////////////////////////
 // Message data extractors
 ////////////////////////////////////////////////
-void ExtractMessageData(const Message& msg, std::string& problem, bool& fatal) {
+void ExtractErrorMessageData(const Message& msg, std::string& problem, bool& fatal) {
     try {
         std::istringstream is(msg.Text());
         freeorion_xml_iarchive ia(is);
         ia >> BOOST_SERIALIZATION_NVP(problem)
            >> BOOST_SERIALIZATION_NVP(fatal);
     } catch (const std::exception& err) {
-        ErrorLogger() << "ExtractMessageData(const Message& msg, std::string& problem, bool& fatal) failed!  Message:\n"
+        ErrorLogger() << "ExtractErrorMessageData(const Message& msg, std::string& problem, bool& fatal) failed!  Message:\n"
                       << msg.Text() << "\n"
                       << "Error: " << err.what();
         problem = UserStringNop("SERVER_MESSAGE_NOT_UNDERSTOOD");
@@ -660,7 +660,7 @@ void ExtractMessageData(const Message& msg, std::string& problem, bool& fatal) {
     }
 }
 
-void ExtractMessageData(const Message& msg, std::string& host_player_name, std::string& client_version_string) {
+void ExtractHostMPGameMessageData(const Message& msg, std::string& host_player_name, std::string& client_version_string) {
     try {
         std::istringstream is(msg.Text());
         freeorion_xml_iarchive ia(is);
@@ -668,28 +668,28 @@ void ExtractMessageData(const Message& msg, std::string& host_player_name, std::
            >> BOOST_SERIALIZATION_NVP(client_version_string);
 
     } catch (const std::exception& err) {
-        ErrorLogger() << "ExtractMessageData(const Message& msg, std::string& host_player_name, std::string& client_version_string) failed!  Message:\n"
+        ErrorLogger() << "ExtractHostMPGameMessageData(const Message& msg, std::string& host_player_name, std::string& client_version_string) failed!  Message:\n"
                       << msg.Text() << "\n"
                       << "Error: " << err.what();
         throw err;
     }
 }
 
-void ExtractMessageData(const Message& msg, MultiplayerLobbyData& lobby_data) {
+void ExtractLobbyUpdateMessageData(const Message& msg, MultiplayerLobbyData& lobby_data) {
     try {
         std::istringstream is(msg.Text());
         freeorion_xml_iarchive ia(is);
         ia >> BOOST_SERIALIZATION_NVP(lobby_data);
 
     } catch (const std::exception& err) {
-        ErrorLogger() << "ExtractMessageData(const Message& msg, MultiplayerLobbyData& lobby_data) failed!  Message:\n"
+        ErrorLogger() << "ExtractLobbyUpdateMessageData(const Message& msg, MultiplayerLobbyData& lobby_data) failed!  Message:\n"
                       << msg.Text() << "\n"
                       << "Error: " << err.what();
         throw err;
     }
 }
 
-void ExtractMessageData(const Message& msg, bool& single_player_game, int& empire_id, int& current_turn,
+void ExtractGameStartMessageData(const Message& msg, bool& single_player_game, int& empire_id, int& current_turn,
                         EmpireManager& empires, Universe& universe, SpeciesManager& species, CombatLogManager& combat_logs,
                         SupplyManager& supply,
                         std::map<int, PlayerInfo>& players, OrderSet& orders, bool& loaded_game_data, bool& ui_data_available,
@@ -709,7 +709,7 @@ void ExtractMessageData(const Message& msg, bool& single_player_game, int& empir
 
             boost::timer deserialize_timer;
             ia >> BOOST_SERIALIZATION_NVP(empires);
-            DebugLogger() << "ExtractMessage empire deserialization time " << (deserialize_timer.elapsed() * 1000.0);
+            DebugLogger() << "ExtractGameStartMessage empire deserialization time " << (deserialize_timer.elapsed() * 1000.0);
 
             ia >> BOOST_SERIALIZATION_NVP(species)
                >> BOOST_SERIALIZATION_NVP(combat_logs)
@@ -717,7 +717,7 @@ void ExtractMessageData(const Message& msg, bool& single_player_game, int& empir
 
             deserialize_timer.restart();
             Deserialize(ia, universe);
-            DebugLogger() << "ExtractMessage universe deserialization time " << (deserialize_timer.elapsed() * 1000.0);
+            DebugLogger() << "ExtractGameStartMessage universe deserialization time " << (deserialize_timer.elapsed() * 1000.0);
 
 
             ia >> BOOST_SERIALIZATION_NVP(players)
@@ -748,7 +748,7 @@ void ExtractMessageData(const Message& msg, bool& single_player_game, int& empir
 
             boost::timer deserialize_timer;
             ia >> BOOST_SERIALIZATION_NVP(empires);
-            DebugLogger() << "ExtractMessage empire deserialization time " << (deserialize_timer.elapsed() * 1000.0);
+            DebugLogger() << "ExtractGameStartMessage empire deserialization time " << (deserialize_timer.elapsed() * 1000.0);
 
             ia >> BOOST_SERIALIZATION_NVP(species)
                >> BOOST_SERIALIZATION_NVP(combat_logs)
@@ -756,7 +756,7 @@ void ExtractMessageData(const Message& msg, bool& single_player_game, int& empir
 
             deserialize_timer.restart();
             Deserialize(ia, universe);
-            DebugLogger() << "ExtractMessage universe deserialization time " << (deserialize_timer.elapsed() * 1000.0);
+            DebugLogger() << "ExtractGameStartMessage universe deserialization time " << (deserialize_timer.elapsed() * 1000.0);
 
 
             ia >> BOOST_SERIALIZATION_NVP(players)
@@ -777,16 +777,16 @@ void ExtractMessageData(const Message& msg, bool& single_player_game, int& empir
         }
 
     } catch (const std::exception& err) {
-        ErrorLogger() << "ExtractMessageData(...) failed!  Message probably long, so not outputting to log.\n"
+        ErrorLogger() << "ExtractGameStartMessageData(...) failed!  Message probably long, so not outputting to log.\n"
                       << "Error: " << err.what();
         throw err;
     }
 }
 
-void ExtractMessageData(const Message& msg, std::string& player_name, Networking::ClientType& client_type,
+void ExtractJoinGameMessageData(const Message& msg, std::string& player_name, Networking::ClientType& client_type,
                         std::string& version_string)
 {
-    DebugLogger() << "ExtractMessageData() from " << player_name << " client type " << client_type;
+    DebugLogger() << "ExtractJoinGameMessageData() from " << player_name << " client type " << client_type;
     try {
         std::istringstream is(msg.Text());
         freeorion_xml_iarchive ia(is);
@@ -795,7 +795,7 @@ void ExtractMessageData(const Message& msg, std::string& player_name, Networking
            >> BOOST_SERIALIZATION_NVP(version_string);
 
     } catch (const std::exception& err) {
-        ErrorLogger() << "ExtractMessageData(const Message& msg, std::string& player_name, "
+        ErrorLogger() << "ExtractJoinGameMessageData(const Message& msg, std::string& player_name, "
                       << "Networking::ClientType client_type, std::string& version_string) failed!  Message:\n"
                       << msg.Text() << "\n"
                       << "Error: " << err.what();
@@ -803,21 +803,21 @@ void ExtractMessageData(const Message& msg, std::string& player_name, Networking
     }
 }
 
-void ExtractMessageData(const Message& msg, OrderSet& orders) {
+void ExtractTurnOrdersMessageData(const Message& msg, OrderSet& orders) {
     try {
         std::istringstream is(msg.Text());
         freeorion_xml_iarchive ia(is);
         Deserialize(ia, orders);
 
     } catch (const std::exception& err) {
-        ErrorLogger() << "ExtractMessageData(const Message& msg, OrderSet& orders) failed!  Message:\n"
+        ErrorLogger() << "ExtractTurnOrdersMessageData(const Message& msg, OrderSet& orders) failed!  Message:\n"
                       << msg.Text() << "\n"
                       << "Error: " << err.what();
         throw err;
     }
 }
 
-void ExtractMessageData(const Message& msg, int empire_id, int& current_turn, EmpireManager& empires, Universe& universe,
+void ExtractTurnUpdateMessageData(const Message& msg, int empire_id, int& current_turn, EmpireManager& empires, Universe& universe,
                         SpeciesManager& species, CombatLogManager& combat_logs, SupplyManager& supply,
                         std::map<int, PlayerInfo>& players)
 {
@@ -852,13 +852,13 @@ void ExtractMessageData(const Message& msg, int empire_id, int& current_turn, Em
         }
 
     } catch (const std::exception& err) {
-        ErrorLogger() << "ExtractMessageData(...) failed!  Message probably long, so not outputting to log.\n"
+        ErrorLogger() << "ExtractTurnUpdateMessageData(...) failed!  Message probably long, so not outputting to log.\n"
                       << "Error: " << err.what();
         throw err;
     }
 }
 
-void ExtractMessageData(const Message& msg, int empire_id, Universe& universe) {
+void ExtractTurnPartialUpdateMessageData(const Message& msg, int empire_id, Universe& universe) {
     try {
         ScopedTimer timer("Mid Turn Update Unpacking", true);
 
@@ -878,14 +878,15 @@ void ExtractMessageData(const Message& msg, int empire_id, Universe& universe) {
         }
 
     } catch (const std::exception& err) {
-        ErrorLogger() << "ExtractMessageData(...) failed!  Message probably long, so not outputting to log.\n"
+        ErrorLogger() << "ExtracturnPartialUpdateMessageData(...) failed!  Message probably long, so not outputting to log.\n"
                       << "Error: " << err.what();
         throw err;
     }
 }
 
-void ExtractMessageData(const Message& msg, OrderSet& orders, bool& ui_data_available, SaveGameUIData& ui_data,
-                        bool& save_state_string_available, std::string& save_state_string)
+void ExtractClientSaveDataMessageData(const Message& msg, OrderSet& orders, bool& ui_data_available,
+                                      SaveGameUIData& ui_data, bool& save_state_string_available,
+                                      std::string& save_state_string)
 {
     try {
         std::istringstream is(msg.Text());
@@ -906,27 +907,27 @@ void ExtractMessageData(const Message& msg, OrderSet& orders, bool& ui_data_avai
         }
 
     } catch (const std::exception& err) {
-        ErrorLogger() << "ExtractMessageData(...) failed!  Message probably long, so not outputting to log.\n"
+        ErrorLogger() << "ExtractClientSaveDataMessageData(...) failed!  Message probably long, so not outputting to log.\n"
                       << "Error: " << err.what();
         throw err;
     }
 }
 
-void ExtractMessageData(const Message& msg, Message::TurnProgressPhase& phase_id) {
+void ExtractTurnProgressMessageData(const Message& msg, Message::TurnProgressPhase& phase_id) {
     try {
         std::istringstream is(msg.Text());
         freeorion_xml_iarchive ia(is);
         ia >> BOOST_SERIALIZATION_NVP(phase_id);
 
     } catch (const std::exception& err) {
-        ErrorLogger() << "ExtractMessageData(const Message& msg, Message::TurnProgressPhase& phase_id) failed!  Message:\n"
+        ErrorLogger() << "ExtractTurnProgressMessageData(const Message& msg, Message::TurnProgressPhase& phase_id) failed!  Message:\n"
                       << msg.Text() << "\n"
                       << "Error: " << err.what();
         throw err;
     }
 }
 
-void ExtractMessageData(const Message& msg, int& about_player_id, Message::PlayerStatus& status) {
+void ExtractPlayerStatusMessageData(const Message& msg, int& about_player_id, Message::PlayerStatus& status) {
     try {
         std::istringstream is(msg.Text());
         freeorion_xml_iarchive ia(is);
@@ -934,14 +935,14 @@ void ExtractMessageData(const Message& msg, int& about_player_id, Message::Playe
            >> BOOST_SERIALIZATION_NVP(status);
  
     } catch (const std::exception& err) {
-        ErrorLogger() << "ExtractMessageData(const Message& msg, int& about_player_id, Message::PlayerStatus&) failed!  Message:\n"
+        ErrorLogger() << "ExtractPlayerStatusMessageData(const Message& msg, int& about_player_id, Message::PlayerStatus&) failed!  Message:\n"
                       << msg.Text() << "\n"
                       << "Error: " << err.what();
         throw err;
     }
 }
 
-void ExtractMessageData(const Message& msg, SinglePlayerSetupData& setup_data, std::string& client_version_string) {
+void ExtractHostSPGameMessageData(const Message& msg, SinglePlayerSetupData& setup_data, std::string& client_version_string) {
     try {
         std::istringstream is(msg.Text());
         freeorion_xml_iarchive ia(is);
@@ -949,14 +950,14 @@ void ExtractMessageData(const Message& msg, SinglePlayerSetupData& setup_data, s
            >> BOOST_SERIALIZATION_NVP(client_version_string);
 
     } catch (const std::exception& err) {
-        ErrorLogger() << "ExtractMessageData(const Message& msg, SinglePlayerSetupData& setup_data, std::string& client_version_string) failed!  Message:\n"
+        ErrorLogger() << "ExtractHostSPGameMessageData(const Message& msg, SinglePlayerSetupData& setup_data, std::string& client_version_string) failed!  Message:\n"
                       << msg.Text() << "\n"
                       << "Error: " << err.what();
         throw err;
     }
 }
 
-void ExtractMessageData(const Message& msg, Message::EndGameReason& reason, std::string& reason_player_name) {
+void ExtractEndGameMessageData(const Message& msg, Message::EndGameReason& reason, std::string& reason_player_name) {
     try {
         std::istringstream is(msg.Text());
         freeorion_xml_iarchive ia(is);
@@ -964,7 +965,7 @@ void ExtractMessageData(const Message& msg, Message::EndGameReason& reason, std:
            >> BOOST_SERIALIZATION_NVP(reason_player_name);
 
     } catch (const std::exception& err) {
-        ErrorLogger() << "ExtractMessageData(const Message& msg, Message::EndGameReason& reason, "
+        ErrorLogger() << "ExtractEndGameMessageData(const Message& msg, Message::EndGameReason& reason, "
                       << "std::string& reason_player_name) failed!  Message:\n"
                       << msg.Text() << "\n"
                       << "Error: " << err.what();
@@ -972,28 +973,28 @@ void ExtractMessageData(const Message& msg, Message::EndGameReason& reason, std:
     }
 }
 
-void ExtractMessageData(const Message& msg, Moderator::ModeratorAction*& mod_action) {
+void ExtractModeratorActionMessageData(const Message& msg, Moderator::ModeratorAction*& mod_action) {
     try {
         std::istringstream is(msg.Text());
         freeorion_xml_iarchive ia(is);
         ia >> BOOST_SERIALIZATION_NVP(mod_action);
 
     } catch (const std::exception& err) {
-        ErrorLogger() << "ExtractMessageData(const Message& msg, Moderator::ModeratorAction& mod_act) "
+        ErrorLogger() << "ExtractModeratorActionMessageData(const Message& msg, Moderator::ModeratorAction& mod_act) "
                       << "failed!  Message:\n"
                       << msg.Text() << "\n"
                       << "Error: " << err.what();
     }
 }
 
-void ExtractMessageData(const Message& msg, DiplomaticMessage& diplo_message) {
+void ExtractDiplomacyMessageData(const Message& msg, DiplomaticMessage& diplo_message) {
     try {
         std::istringstream is(msg.Text());
         freeorion_xml_iarchive ia(is);
         ia >> BOOST_SERIALIZATION_NVP(diplo_message);
 
     } catch (const std::exception& err) {
-        ErrorLogger() << "ExtractMessageData(const Message& msg, DiplomaticMessage& "
+        ErrorLogger() << "ExtractDiplomacyMessageData(const Message& msg, DiplomaticMessage& "
                       << "diplo_message) failed!  Message:\n"
                       << msg.Text() << "\n"
                       << "Error: " << err.what();
@@ -1001,7 +1002,7 @@ void ExtractMessageData(const Message& msg, DiplomaticMessage& diplo_message) {
     }
 }
 
-void ExtractMessageData(const Message& msg, DiplomaticStatusUpdateInfo& diplo_update) {
+void ExtractDiplomaticStatusMessageData(const Message& msg, DiplomaticStatusUpdateInfo& diplo_update) {
     try {
         std::istringstream is(msg.Text());
         freeorion_xml_iarchive ia(is);
@@ -1010,31 +1011,31 @@ void ExtractMessageData(const Message& msg, DiplomaticStatusUpdateInfo& diplo_up
            >> BOOST_SERIALIZATION_NVP(diplo_update.diplo_status);
 
     } catch (const std::exception& err) {
-        ErrorLogger() << "ExtractMessageData(const Message& msg, DiplomaticStatusUpdate& diplo_update) failed!  Message:\n"
+        ErrorLogger() << "ExtractDiplomaticStatusMessageData(const Message& msg, DiplomaticStatusUpdate& diplo_update) failed!  Message:\n"
                       << msg.Text() << "\n"
                       << "Error: " << err.what();
         throw err;
     }
 }
 
-void ExtractMessageData(const Message& msg, std::string& directory)
+void ExtractRequestSavePreviewsMessageData(const Message& msg, std::string& directory)
 { directory = msg.Text(); }
 
-void ExtractMessageData(const Message& msg, PreviewInformation& previews) {
+void ExtractDispatchSavePreviewsMessageData(const Message& msg, PreviewInformation& previews) {
     try {
         std::istringstream is(msg.Text());
         freeorion_xml_iarchive ia(is);
         ia >> BOOST_SERIALIZATION_NVP(previews);
 
     } catch(const std::exception& err) {
-        ErrorLogger() << "ExtractMessageData(const Message& msg, PreviewInformation& previews) failed!  Message:\n"
+        ErrorLogger() << "ExtractDispatchSavePreviewsMessageData(const Message& msg, PreviewInformation& previews) failed!  Message:\n"
                       << msg.Text() << "\n"
                       << "Error: " << err.what();
         throw err;
     }
 }
 
-FO_COMMON_API void ExtractMessageData(const Message& msg, std::string& save_filename, int& bytes_written) {
+FO_COMMON_API void ExtractServerSaveGameCompleteMessageData(const Message& msg, std::string& save_filename, int& bytes_written) {
     try {
         std::istringstream is(msg.Text());
         freeorion_xml_iarchive ia(is);
@@ -1042,7 +1043,7 @@ FO_COMMON_API void ExtractMessageData(const Message& msg, std::string& save_file
            >> BOOST_SERIALIZATION_NVP(bytes_written);
 
     } catch(const std::exception& err) {
-        ErrorLogger() << "ExtractMessageData(const Message& msg, std::string& save_filename, int& bytes_written) failed!  Message:\n"
+        ErrorLogger() << "ExtractServerSaveGameCompleteServerSaveGameCompleteMessageData(const Message& msg, std::string& save_filename, int& bytes_written) failed!  Message:\n"
                       << msg.Text() << "\n"
                       << "Error: " << err.what();
         throw err;

--- a/network/Message.cpp
+++ b/network/Message.cpp
@@ -618,8 +618,11 @@ Message RequestCombatLogsMessage(int sender, const std::vector<int>& ids) {
     return Message(Message::REQUEST_COMBAT_LOGS, sender, Networking::INVALID_PLAYER_ID, os.str());
 }
 
-Message DispatchCombatLogsMessage(int receiver) {
-    return Message(Message::DISPATCH_COMBAT_LOGS, Networking::INVALID_PLAYER_ID, receiver, "fake logs", true);
+Message DispatchCombatLogsMessage(int receiver, const std::vector<std::pair<int, const CombatLog&> >& logs) {
+    std::ostringstream os;
+    freeorion_xml_oarchive oa(os);
+    oa << BOOST_SERIALIZATION_NVP(logs);
+    return Message(Message::DISPATCH_COMBAT_LOGS, Networking::INVALID_PLAYER_ID, receiver, os.str(), true);
 }
 
 ////////////////////////////////////////////////
@@ -1072,4 +1075,20 @@ FO_COMMON_API void ExtractRequestCombatLogsMessageData(const Message& msg, std::
                       << "Error: " << err.what();
         throw err;
     }
+}
+
+FO_COMMON_API void ExtractDispathCombatLogsMessageData(
+    const Message& msg, std::vector<std::pair<int, const CombatLog&> >& logs)
+{
+    try {
+        std::istringstream is(msg.Text());
+        freeorion_xml_iarchive ia(is);
+        ia >> BOOST_SERIALIZATION_NVP(logs);
+    } catch(const std::exception& err) {
+        ErrorLogger() << "ExtractDispatchCombatLogMessageData(const Message& msg, std::vector<std::pair<int, const CombatLog&> >& logs) failed!  Message:\n"
+                      << msg.Text() << "\n"
+                      << "Error: " << err.what();
+        throw err;
+    }
+
 }

--- a/network/Message.cpp
+++ b/network/Message.cpp
@@ -221,7 +221,7 @@ Message HostIDMessage(int host_player_id) {
 Message GameStartMessage(int player_id, bool single_player_game, int empire_id,
                          int current_turn, const EmpireManager& empires,
                          const Universe& universe, const SpeciesManager& species,
-                         const CombatLogManager& combat_logs, const SupplyManager& supply,
+                         CombatLogManager& combat_logs, const SupplyManager& supply,
                          const std::map<int, PlayerInfo>& players,
                          const GalaxySetupData& galaxy_setup_data,
                          bool use_binary_serialization)
@@ -235,9 +235,9 @@ Message GameStartMessage(int player_id, bool single_player_game, int empire_id,
                << BOOST_SERIALIZATION_NVP(current_turn);
             GetUniverse().EncodingEmpire() = empire_id;
             oa << BOOST_SERIALIZATION_NVP(empires)
-               << BOOST_SERIALIZATION_NVP(species)
-               << BOOST_SERIALIZATION_NVP(combat_logs)
-               << BOOST_SERIALIZATION_NVP(supply);
+               << BOOST_SERIALIZATION_NVP(species);
+            combat_logs.SerializeIncompleteLogs(oa, 1);
+            oa << BOOST_SERIALIZATION_NVP(supply);
             Serialize(oa, universe);
             bool loaded_game_data = false;
             oa << BOOST_SERIALIZATION_NVP(players)
@@ -250,9 +250,9 @@ Message GameStartMessage(int player_id, bool single_player_game, int empire_id,
                << BOOST_SERIALIZATION_NVP(current_turn);
             GetUniverse().EncodingEmpire() = empire_id;
             oa << BOOST_SERIALIZATION_NVP(empires)
-               << BOOST_SERIALIZATION_NVP(species)
-               << BOOST_SERIALIZATION_NVP(combat_logs)
-               << BOOST_SERIALIZATION_NVP(supply);
+               << BOOST_SERIALIZATION_NVP(species);
+            combat_logs.SerializeIncompleteLogs(oa, 1);
+            oa << BOOST_SERIALIZATION_NVP(supply);
             Serialize(oa, universe);
             bool loaded_game_data = false;
             oa << BOOST_SERIALIZATION_NVP(players)
@@ -266,7 +266,7 @@ Message GameStartMessage(int player_id, bool single_player_game, int empire_id,
 Message GameStartMessage(int player_id, bool single_player_game, int empire_id,
                          int current_turn, const EmpireManager& empires,
                          const Universe& universe, const SpeciesManager& species,
-                         const CombatLogManager& combat_logs, const SupplyManager& supply,
+                         CombatLogManager& combat_logs, const SupplyManager& supply,
                          const std::map<int, PlayerInfo>& players,
                          const OrderSet& orders, const SaveGameUIData* ui_data,
                          const GalaxySetupData& galaxy_setup_data,
@@ -281,9 +281,9 @@ Message GameStartMessage(int player_id, bool single_player_game, int empire_id,
                << BOOST_SERIALIZATION_NVP(current_turn);
             GetUniverse().EncodingEmpire() = empire_id;
             oa << BOOST_SERIALIZATION_NVP(empires)
-               << BOOST_SERIALIZATION_NVP(species)
-               << BOOST_SERIALIZATION_NVP(combat_logs)
-               << BOOST_SERIALIZATION_NVP(supply);
+               << BOOST_SERIALIZATION_NVP(species);
+            combat_logs.SerializeIncompleteLogs(oa, 1);
+            oa << BOOST_SERIALIZATION_NVP(supply);
             Serialize(oa, universe);
             bool loaded_game_data = true;
             oa << BOOST_SERIALIZATION_NVP(players)
@@ -303,9 +303,9 @@ Message GameStartMessage(int player_id, bool single_player_game, int empire_id,
                << BOOST_SERIALIZATION_NVP(current_turn);
             GetUniverse().EncodingEmpire() = empire_id;
             oa << BOOST_SERIALIZATION_NVP(empires)
-               << BOOST_SERIALIZATION_NVP(species)
-               << BOOST_SERIALIZATION_NVP(combat_logs)
-               << BOOST_SERIALIZATION_NVP(supply);
+               << BOOST_SERIALIZATION_NVP(species);
+            combat_logs.SerializeIncompleteLogs(oa, 1);
+            oa << BOOST_SERIALIZATION_NVP(supply);
             Serialize(oa, universe);
             bool loaded_game_data = true;
             oa << BOOST_SERIALIZATION_NVP(players)
@@ -326,7 +326,7 @@ Message GameStartMessage(int player_id, bool single_player_game, int empire_id,
 Message GameStartMessage(int player_id, bool single_player_game, int empire_id,
                          int current_turn, const EmpireManager& empires,
                          const Universe& universe, const SpeciesManager& species,
-                         const CombatLogManager& combat_logs, const SupplyManager& supply,
+                         CombatLogManager& combat_logs, const SupplyManager& supply,
                          const std::map<int, PlayerInfo>& players,
                          const OrderSet& orders, const std::string* save_state_string,
                          const GalaxySetupData& galaxy_setup_data,
@@ -341,9 +341,9 @@ Message GameStartMessage(int player_id, bool single_player_game, int empire_id,
                << BOOST_SERIALIZATION_NVP(current_turn);
             GetUniverse().EncodingEmpire() = empire_id;
             oa << BOOST_SERIALIZATION_NVP(empires)
-               << BOOST_SERIALIZATION_NVP(species)
-               << BOOST_SERIALIZATION_NVP(combat_logs)
-               << BOOST_SERIALIZATION_NVP(supply);
+               << BOOST_SERIALIZATION_NVP(species);
+            combat_logs.SerializeIncompleteLogs(oa, 1);
+            oa << BOOST_SERIALIZATION_NVP(supply);
             Serialize(oa, universe);
             bool loaded_game_data = true;
             oa << BOOST_SERIALIZATION_NVP(players)
@@ -363,9 +363,9 @@ Message GameStartMessage(int player_id, bool single_player_game, int empire_id,
                << BOOST_SERIALIZATION_NVP(current_turn);
             GetUniverse().EncodingEmpire() = empire_id;
             oa << BOOST_SERIALIZATION_NVP(empires)
-               << BOOST_SERIALIZATION_NVP(species)
-               << BOOST_SERIALIZATION_NVP(combat_logs)
-               << BOOST_SERIALIZATION_NVP(supply);
+               << BOOST_SERIALIZATION_NVP(species);
+            combat_logs.SerializeIncompleteLogs(oa, 1);
+            oa << BOOST_SERIALIZATION_NVP(supply);
             Serialize(oa, universe);
             bool loaded_game_data = true;
             oa << BOOST_SERIALIZATION_NVP(players)
@@ -422,7 +422,7 @@ Message PlayerStatusMessage(int player_id, int about_player_id, Message::PlayerS
 
 Message TurnUpdateMessage(int player_id, int empire_id, int current_turn,
                           const EmpireManager& empires, const Universe& universe,
-                          const SpeciesManager& species, const CombatLogManager& combat_logs,
+                          const SpeciesManager& species, CombatLogManager& combat_logs,
                           const SupplyManager& supply,
                           const std::map<int, PlayerInfo>& players,
                           bool use_binary_serialization)
@@ -432,11 +432,11 @@ Message TurnUpdateMessage(int player_id, int empire_id, int current_turn,
         if (use_binary_serialization) {
             freeorion_bin_oarchive oa(os);
             GetUniverse().EncodingEmpire() = empire_id;
-            oa << BOOST_SERIALIZATION_NVP(current_turn)
-               << BOOST_SERIALIZATION_NVP(empires)
-               << BOOST_SERIALIZATION_NVP(species)
-               << BOOST_SERIALIZATION_NVP(combat_logs)
-               << BOOST_SERIALIZATION_NVP(supply);
+            oa << BOOST_SERIALIZATION_NVP(current_turn);
+            oa << BOOST_SERIALIZATION_NVP(empires);
+            oa << BOOST_SERIALIZATION_NVP(species);
+            combat_logs.SerializeIncompleteLogs(oa, 1);
+            oa << BOOST_SERIALIZATION_NVP(supply);
             Serialize(oa, universe);
             oa << BOOST_SERIALIZATION_NVP(players);
         } else {
@@ -444,9 +444,9 @@ Message TurnUpdateMessage(int player_id, int empire_id, int current_turn,
             GetUniverse().EncodingEmpire() = empire_id;
             oa << BOOST_SERIALIZATION_NVP(current_turn)
                << BOOST_SERIALIZATION_NVP(empires)
-               << BOOST_SERIALIZATION_NVP(species)
-               << BOOST_SERIALIZATION_NVP(combat_logs)
-               << BOOST_SERIALIZATION_NVP(supply);
+               << BOOST_SERIALIZATION_NVP(species);
+            combat_logs.SerializeIncompleteLogs(oa, 1);
+            oa << BOOST_SERIALIZATION_NVP(supply);
             Serialize(oa, universe);
             oa << BOOST_SERIALIZATION_NVP(players);
         }
@@ -618,7 +618,7 @@ Message RequestCombatLogsMessage(int sender, const std::vector<int>& ids) {
     return Message(Message::REQUEST_COMBAT_LOGS, sender, Networking::INVALID_PLAYER_ID, os.str());
 }
 
-Message DispatchCombatLogsMessage(int receiver, const std::vector<std::pair<int, const CombatLog&> >& logs) {
+Message DispatchCombatLogsMessage(int receiver, const std::vector<std::pair<int, const CombatLog> >& logs) {
     std::ostringstream os;
     freeorion_xml_oarchive oa(os);
     oa << BOOST_SERIALIZATION_NVP(logs);
@@ -725,9 +725,9 @@ void ExtractGameStartMessageData(const Message& msg, bool& single_player_game, i
             ia >> BOOST_SERIALIZATION_NVP(empires);
             DebugLogger() << "ExtractGameStartMessage empire deserialization time " << (deserialize_timer.elapsed() * 1000.0);
 
-            ia >> BOOST_SERIALIZATION_NVP(species)
-               >> BOOST_SERIALIZATION_NVP(combat_logs)
-               >> BOOST_SERIALIZATION_NVP(supply);
+            ia >> BOOST_SERIALIZATION_NVP(species);
+            combat_logs.SerializeIncompleteLogs(ia, 1);
+            ia >> BOOST_SERIALIZATION_NVP(supply);
 
             deserialize_timer.restart();
             Deserialize(ia, universe);
@@ -764,9 +764,9 @@ void ExtractGameStartMessageData(const Message& msg, bool& single_player_game, i
             ia >> BOOST_SERIALIZATION_NVP(empires);
             DebugLogger() << "ExtractGameStartMessage empire deserialization time " << (deserialize_timer.elapsed() * 1000.0);
 
-            ia >> BOOST_SERIALIZATION_NVP(species)
-               >> BOOST_SERIALIZATION_NVP(combat_logs)
-               >> BOOST_SERIALIZATION_NVP(supply);
+            ia >> BOOST_SERIALIZATION_NVP(species);
+            combat_logs.SerializeIncompleteLogs(ia, 1);
+            ia >> BOOST_SERIALIZATION_NVP(supply);
 
             deserialize_timer.restart();
             Deserialize(ia, universe);
@@ -831,9 +831,9 @@ void ExtractTurnOrdersMessageData(const Message& msg, OrderSet& orders) {
     }
 }
 
-void ExtractTurnUpdateMessageData(const Message& msg, int empire_id, int& current_turn, EmpireManager& empires, Universe& universe,
-                        SpeciesManager& species, CombatLogManager& combat_logs, SupplyManager& supply,
-                        std::map<int, PlayerInfo>& players)
+void ExtractTurnUpdateMessageData(const Message& msg, int empire_id, int& current_turn, EmpireManager& empires,
+                                  Universe& universe, SpeciesManager& species, CombatLogManager& combat_logs,
+                                  SupplyManager& supply, std::map<int, PlayerInfo>& players)
 {
     try {
         ScopedTimer timer("Turn Update Unpacking", true);
@@ -845,9 +845,9 @@ void ExtractTurnUpdateMessageData(const Message& msg, int empire_id, int& curren
             GetUniverse().EncodingEmpire() = empire_id;
             ia >> BOOST_SERIALIZATION_NVP(current_turn)
                >> BOOST_SERIALIZATION_NVP(empires)
-               >> BOOST_SERIALIZATION_NVP(species)
-               >> BOOST_SERIALIZATION_NVP(combat_logs)
-               >> BOOST_SERIALIZATION_NVP(supply);
+               >> BOOST_SERIALIZATION_NVP(species);
+            combat_logs.SerializeIncompleteLogs(ia, 1);
+            ia >> BOOST_SERIALIZATION_NVP(supply);
             Deserialize(ia, universe);
             ia >> BOOST_SERIALIZATION_NVP(players);
 
@@ -858,9 +858,9 @@ void ExtractTurnUpdateMessageData(const Message& msg, int empire_id, int& curren
             GetUniverse().EncodingEmpire() = empire_id;
             ia >> BOOST_SERIALIZATION_NVP(current_turn)
                >> BOOST_SERIALIZATION_NVP(empires)
-               >> BOOST_SERIALIZATION_NVP(species)
-               >> BOOST_SERIALIZATION_NVP(combat_logs)
-               >> BOOST_SERIALIZATION_NVP(supply);
+               >> BOOST_SERIALIZATION_NVP(species);
+            combat_logs.SerializeIncompleteLogs(ia, 1);
+            ia >> BOOST_SERIALIZATION_NVP(supply);
             Deserialize(ia, universe);
             ia >> BOOST_SERIALIZATION_NVP(players);
         }

--- a/network/Message.h
+++ b/network/Message.h
@@ -407,6 +407,6 @@ FO_COMMON_API void ExtractServerSaveGameCompleteMessageData(const Message& msg, 
 
 FO_COMMON_API void ExtractRequestCombatLogsMessageData(const Message& msg, std::vector<int>& ids);
 
-FO_COMMON_API void ExtractDispathCombatLogsMessageData(const Message& msg, std::vector<std::pair<int, const CombatLog&> >& logs);
+FO_COMMON_API void ExtractDispatchCombatLogsMessageData(const Message& msg, std::vector<std::pair<int, CombatLog> >& logs);
 
 #endif // _Message_h_

--- a/network/Message.h
+++ b/network/Message.h
@@ -191,7 +191,7 @@ FO_COMMON_API Message HostIDMessage(int host_player_id);
 /** creates a GAME_START message.  Contains the initial game state visible to player \a player_id.*/
 FO_COMMON_API Message GameStartMessage(int player_id, bool single_player_game, int empire_id, int current_turn,
                                        const EmpireManager& empires, const Universe& universe,
-                                       const SpeciesManager& species, const CombatLogManager& combat_logs,
+                                       const SpeciesManager& species, CombatLogManager& combat_logs,
                                        const SupplyManager& supply, const std::map<int, PlayerInfo>& players,
                                        const GalaxySetupData& galaxy_setup_data, bool use_binary_serialization);
 
@@ -199,7 +199,7 @@ FO_COMMON_API Message GameStartMessage(int player_id, bool single_player_game, i
   * player \a player_id.  Also includes data loaded from a saved game. */
 FO_COMMON_API Message GameStartMessage(int player_id, bool single_player_game, int empire_id, int current_turn,
                                        const EmpireManager& empires, const Universe& universe,
-                                       const SpeciesManager& species, const CombatLogManager& combat_logs,
+                                       const SpeciesManager& species, CombatLogManager& combat_logs,
                                        const SupplyManager& supply,
                                        const std::map<int, PlayerInfo>& players, const OrderSet& orders,
                                        const SaveGameUIData* ui_data,
@@ -209,7 +209,7 @@ FO_COMMON_API Message GameStartMessage(int player_id, bool single_player_game, i
   * player \a player_id.  Also includes state string loaded from a saved game. */
 FO_COMMON_API Message GameStartMessage(int player_id, bool single_player_game, int empire_id, int current_turn,
                                        const EmpireManager& empires, const Universe& universe,
-                                       const SpeciesManager& species, const CombatLogManager& combat_logs,
+                                       const SpeciesManager& species, CombatLogManager& combat_logs,
                                        const SupplyManager& supply,
                                        const std::map<int, PlayerInfo>& players, const OrderSet& orders,
                                        const std::string* save_state_string,
@@ -239,7 +239,7 @@ FO_COMMON_API Message PlayerStatusMessage(int player_id, int about_player_id, Me
 /** creates a TURN_UPDATE message. */
 FO_COMMON_API Message TurnUpdateMessage(int player_id, int empire_id, int current_turn,
                                         const EmpireManager& empires, const Universe& universe,
-                                        const SpeciesManager& species, const CombatLogManager& combat_logs,
+                                        const SpeciesManager& species, CombatLogManager& combat_logs,
                                         const SupplyManager& supply,
                                         const std::map<int, PlayerInfo>& players, bool use_binary_serialization);
 
@@ -321,7 +321,7 @@ FO_COMMON_API Message DispatchSavePreviewsMessage(int receiver, const PreviewInf
 FO_COMMON_API Message RequestCombatLogsMessage(int sender, const std::vector<int>& ids);
 
 /** returns combat logs to the client */
-FO_COMMON_API Message DispatchCombatLogsMessage(int receiver, const std::vector<std::pair<int, const CombatLog&> >& logs);
+FO_COMMON_API Message DispatchCombatLogsMessage(int receiver, const std::vector<std::pair<int, const CombatLog> >& logs);
 
 ////////////////////////////////////////////////
 // Multiplayer Lobby Message named ctors

--- a/network/Message.h
+++ b/network/Message.h
@@ -383,7 +383,6 @@ FO_COMMON_API void ExtractMessageData(const Message& msg, Message::EndGameReason
 
 FO_COMMON_API void ExtractMessageData(const Message& msg, Moderator::ModeratorAction*& action);
 
-FO_COMMON_API void ExtractMessageData(const Message& msg, int& empire_id, std::string& empire_name);
 
 FO_COMMON_API void ExtractMessageData(const Message& msg, DiplomaticMessage& diplo_message);
 

--- a/network/Message.h
+++ b/network/Message.h
@@ -254,7 +254,7 @@ FO_COMMON_API Message ClientSaveDataMessage(int sender, const OrderSet& orders, 
 Message ClientSaveDataMessage(int sender, const OrderSet& orders);
 
 /** creates an REQUEST_NEW_OBJECT_ID message. This message is a synchronous
-    message, when sent it will wait for a reply form the server */
+    message, when sent it will wait for a reply from the server */
 FO_COMMON_API Message RequestNewObjectIDMessage(int sender);
 
 /** creates an DISPATCH_NEW_OBJECT_ID  message.  This message is sent to a
@@ -262,7 +262,7 @@ FO_COMMON_API Message RequestNewObjectIDMessage(int sender);
 FO_COMMON_API Message DispatchObjectIDMessage(int player_id, int new_id);
 
 /** creates an REQUEST_NEW_DESIGN_ID message. This message is a synchronous
-    message, when sent it will wait for a reply form the server */
+    message, when sent it will wait for a reply from the server */
 FO_COMMON_API Message RequestNewDesignIDMessage(int sender);
 
 /** creates an DISPATCH_NEW_DESIGN_ID  message.  This message is sent to a

--- a/network/Message.h
+++ b/network/Message.h
@@ -18,6 +18,7 @@
 class EmpireManager;
 class SupplyManager;
 class SpeciesManager;
+class CombatLog;
 class CombatLogManager;
 class Message;
 struct MultiplayerLobbyData;
@@ -320,7 +321,7 @@ FO_COMMON_API Message DispatchSavePreviewsMessage(int receiver, const PreviewInf
 FO_COMMON_API Message RequestCombatLogsMessage(int sender, const std::vector<int>& ids);
 
 /** returns combat logs to the client */
-FO_COMMON_API Message DispatchCombatLogsMessage(int receiver);
+FO_COMMON_API Message DispatchCombatLogsMessage(int receiver, const std::vector<std::pair<int, const CombatLog&> >& logs);
 
 ////////////////////////////////////////////////
 // Multiplayer Lobby Message named ctors
@@ -405,5 +406,7 @@ FO_COMMON_API void ExtractDispatchSavePreviewsMessageData(const Message& msg, Pr
 FO_COMMON_API void ExtractServerSaveGameCompleteMessageData(const Message& msg, std::string& save_filename, int& bytes_written);
 
 FO_COMMON_API void ExtractRequestCombatLogsMessageData(const Message& msg, std::vector<int>& ids);
+
+FO_COMMON_API void ExtractDispathCombatLogsMessageData(const Message& msg, std::vector<std::pair<int, const CombatLog&> >& logs);
 
 #endif // _Message_h_

--- a/network/Message.h
+++ b/network/Message.h
@@ -85,7 +85,9 @@ public:
         MODERATOR_ACTION,       ///< sent by client to server when a moderator edits the universe
         SHUT_DOWN_SERVER,       ///< sent by host client to server to kill the server process
         REQUEST_SAVE_PREVIEWS,  ///< sent by client to request previews of available savegames
-        DISPATCH_SAVE_PREVIEWS  ///< sent by host to client to provide the savegame previews
+        DISPATCH_SAVE_PREVIEWS,  ///< sent by host to client to provide the savegame previews
+        REQUEST_COMBAT_LOGS,  ///< sent by client to request combat logs
+        DISPATCH_COMBAT_LOGS  ///< sent by host to client to provide combat logs
     )
 
     GG_CLASS_ENUM(TurnProgressPhase,
@@ -314,6 +316,12 @@ FO_COMMON_API Message RequestSavePreviewsMessage(int sender, std::string directo
 /** returns the savegame previews to the client */
 FO_COMMON_API Message DispatchSavePreviewsMessage(int receiver, const PreviewInformation& preview);
 
+/** requests combat logs from server */
+FO_COMMON_API Message RequestCombatLogsMessage(int sender, const std::vector<int>& ids);
+
+/** returns combat logs to the client */
+FO_COMMON_API Message DispatchCombatLogsMessage(int receiver);
+
 ////////////////////////////////////////////////
 // Multiplayer Lobby Message named ctors
 ////////////////////////////////////////////////
@@ -395,5 +403,7 @@ FO_COMMON_API void ExtractRequestSavePreviewsMessageData(const Message& msg, std
 FO_COMMON_API void ExtractDispatchSavePreviewsMessageData(const Message& msg, PreviewInformation& previews);
 
 FO_COMMON_API void ExtractServerSaveGameCompleteMessageData(const Message& msg, std::string& save_filename, int& bytes_written);
+
+FO_COMMON_API void ExtractRequestCombatLogsMessageData(const Message& msg, std::vector<int>& ids);
 
 #endif // _Message_h_

--- a/network/Message.h
+++ b/network/Message.h
@@ -343,55 +343,57 @@ FO_COMMON_API Message StartMPGameMessage(int player_id);
 // Message data extractors
 ////////////////////////////////////////////////
 
-FO_COMMON_API void ExtractMessageData(const Message& msg, std::string& problem, bool& fatal);
+FO_COMMON_API void ExtractErrorMessageData(const Message& msg, std::string& problem, bool& fatal);
 
-FO_COMMON_API void ExtractMessageData(const Message& msg, std::string& host_player_name, std::string& client_version_string);
+FO_COMMON_API void ExtractHostMPGameMessageData(const Message& msg, std::string& host_player_name,
+                                                std::string& client_version_string);
 
-FO_COMMON_API void ExtractMessageData(const Message& msg, MultiplayerLobbyData& lobby_data);
+FO_COMMON_API void ExtractLobbyUpdateMessageData(const Message& msg, MultiplayerLobbyData& lobby_data);
 
-FO_COMMON_API void ExtractMessageData(const Message& msg, bool& single_player_game, int& empire_id,
-                                      int& current_turn, EmpireManager& empires, Universe& universe,
-                                      SpeciesManager& species, CombatLogManager& combat_logs,
-                                      SupplyManager& supply,
-                                      std::map<int, PlayerInfo>& players, OrderSet& orders,
-                                      bool& loaded_game_data, bool& ui_data_available,
-                                      SaveGameUIData& ui_data, bool& save_state_string_available,
-                                      std::string& save_state_string, GalaxySetupData& galaxy_setup_data);
+FO_COMMON_API void ExtractGameStartMessageData(const Message& msg, bool& single_player_game, int& empire_id,
+                                               int& current_turn, EmpireManager& empires, Universe& universe,
+                                               SpeciesManager& species, CombatLogManager& combat_logs,
+                                               SupplyManager& supply,
+                                               std::map<int, PlayerInfo>& players, OrderSet& orders,
+                                               bool& loaded_game_data, bool& ui_data_available,
+                                               SaveGameUIData& ui_data, bool& save_state_string_available,
+                                               std::string& save_state_string, GalaxySetupData& galaxy_setup_data);
 
-FO_COMMON_API void ExtractMessageData(const Message& msg, std::string& player_name, Networking::ClientType& client_type,
-                                      std::string& version_string);
+FO_COMMON_API void ExtractJoinGameMessageData(const Message& msg, std::string& player_name,
+                                              Networking::ClientType& client_type,
+                                              std::string& version_string);
 
-FO_COMMON_API void ExtractMessageData(const Message& msg, OrderSet& orders);
+FO_COMMON_API void ExtractTurnOrdersMessageData(const Message& msg, OrderSet& orders);
 
-FO_COMMON_API void ExtractMessageData(const Message& msg, int empire_id, int& current_turn, EmpireManager& empires,
-                                      Universe& universe, SpeciesManager& species, CombatLogManager& combat_logs,
-                                      SupplyManager& supply, std::map<int, PlayerInfo>& players);
+FO_COMMON_API void ExtractTurnUpdateMessageData(const Message& msg, int empire_id, int& current_turn, EmpireManager& empires,
+                                                Universe& universe, SpeciesManager& species, CombatLogManager& combat_logs,
+                                                SupplyManager& supply, std::map<int, PlayerInfo>& players);
 
-FO_COMMON_API void ExtractMessageData(const Message& msg, int empire_id, Universe& universe);
+FO_COMMON_API void ExtractTurnPartialUpdateMessageData(const Message& msg, int empire_id, Universe& universe);
 
-FO_COMMON_API void ExtractMessageData(const Message& msg, OrderSet& orders, bool& ui_data_available,
-                                      SaveGameUIData& ui_data, bool& save_state_string_available,
-                                      std::string& save_state_string);
+FO_COMMON_API void ExtractClientSaveDataMessageData(const Message& msg, OrderSet& orders,
+                                                    bool& ui_data_available, SaveGameUIData& ui_data,
+                                                    bool& save_state_string_available,
+                                                    std::string& save_state_string);
 
-FO_COMMON_API void ExtractMessageData(const Message& msg, Message::TurnProgressPhase& phase_id);
+FO_COMMON_API void ExtractTurnProgressMessageData(const Message& msg, Message::TurnProgressPhase& phase_id);
 
-FO_COMMON_API void ExtractMessageData(const Message& msg, int& about_player_id, Message::PlayerStatus& status);
+FO_COMMON_API void ExtractPlayerStatusMessageData(const Message& msg, int& about_player_id, Message::PlayerStatus& status);
 
-FO_COMMON_API void ExtractMessageData(const Message& msg, SinglePlayerSetupData& setup_data, std::string& client_version_string);
+FO_COMMON_API void ExtractHostSPGameMessageData(const Message& msg, SinglePlayerSetupData& setup_data, std::string& client_version_string);
 
-FO_COMMON_API void ExtractMessageData(const Message& msg, Message::EndGameReason& reason, std::string& reason_player_name);
+FO_COMMON_API void ExtractEndGameMessageData(const Message& msg, Message::EndGameReason& reason, std::string& reason_player_name);
 
-FO_COMMON_API void ExtractMessageData(const Message& msg, Moderator::ModeratorAction*& action);
+FO_COMMON_API void ExtractModeratorActionMessageData(const Message& msg, Moderator::ModeratorAction*& action);
 
+FO_COMMON_API void ExtractDiplomacyMessageData(const Message& msg, DiplomaticMessage& diplo_message);
 
-FO_COMMON_API void ExtractMessageData(const Message& msg, DiplomaticMessage& diplo_message);
+FO_COMMON_API void ExtractDiplomaticStatusMessageData(const Message& msg, DiplomaticStatusUpdateInfo& diplo_update);
 
-FO_COMMON_API void ExtractMessageData(const Message& msg, DiplomaticStatusUpdateInfo& diplo_update);
+FO_COMMON_API void ExtractRequestSavePreviewsMessageData(const Message& msg, std::string& directory);
 
-FO_COMMON_API void ExtractMessageData(const Message& msg, std::string& directory);
+FO_COMMON_API void ExtractDispatchSavePreviewsMessageData(const Message& msg, PreviewInformation& previews);
 
-FO_COMMON_API void ExtractMessageData(const Message& msg, PreviewInformation& previews);
-
-FO_COMMON_API void ExtractMessageData(const Message& msg, std::string& save_filename, int& bytes_written);
+FO_COMMON_API void ExtractServerSaveGameCompleteMessageData(const Message& msg, std::string& save_filename, int& bytes_written);
 
 #endif // _Message_h_

--- a/network/ServerNetworking.cpp
+++ b/network/ServerNetworking.cpp
@@ -194,6 +194,7 @@ namespace {
         case Message::MODERATOR_ACTION:         return "Moderator Action";
         case Message::SHUT_DOWN_SERVER:         return "Shut Down Server";
         case Message::REQUEST_SAVE_PREVIEWS:    return "Request save previews";
+        case Message::REQUEST_COMBAT_LOGS:      return "Request combat logs";
         default:                                return "Unknown Type";
         };
     }

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -803,7 +803,7 @@ void ServerApp::UpdateSavePreviews(const Message& msg, PlayerConnectionPtr playe
     DebugLogger() << "ServerApp::UpdateSavePreviews: ServerApp UpdateSavePreviews";
 
     std::string directory_name;
-    ExtractMessageData(msg, directory_name);
+    ExtractRequestSavePreviewsMessageData(msg, directory_name);
 
     DebugLogger() << "ServerApp::UpdateSavePreviews: Got preview request for directory: " << directory_name;
 

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -833,7 +833,7 @@ void ServerApp::UpdateCombatLogs(const Message& msg, PlayerConnectionPtr player_
     ExtractRequestCombatLogsMessageData(msg, ids);
 
     // Compose a vector of the requested ids and logs
-    std::vector<std::pair<int, const CombatLog&> > logs;
+    std::vector<std::pair<int, const CombatLog> > logs;
     for (std::vector<int>::iterator it = ids.begin(); it != ids.end(); ++it) {
         boost::optional<const CombatLog&> log = GetCombatLogManager().GetLog(*it);
         if (!log) {
@@ -844,6 +844,8 @@ void ServerApp::UpdateCombatLogs(const Message& msg, PlayerConnectionPtr player_
     }
 
     // Return them to the client
+    DebugLogger() << "UpdateCombatLogs returning " << logs.size()
+                  << " logs to player " << player_connection->PlayerID();
     player_connection->SendMessage(DispatchCombatLogsMessage(player_connection->PlayerID(), logs));
 }
 

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -406,6 +406,7 @@ void ServerApp::HandleMessage(const Message& msg, PlayerConnectionPtr player_con
     case Message::SHUT_DOWN_SERVER:         HandleShutdownMessage(msg, player_connection);  break;
 
     case Message::REQUEST_SAVE_PREVIEWS:    UpdateSavePreviews(msg, player_connection); break;
+    case Message::REQUEST_COMBAT_LOGS:      UpdateCombatLogs(msg, player_connection); break;
 
     default:
         ErrorLogger() << "ServerApp::HandleMessage : Received an unknown message type \"" << msg.Type() << "\".  Terminating connection.";
@@ -825,6 +826,15 @@ void ServerApp::UpdateSavePreviews(const Message& msg, PlayerConnectionPtr playe
     DebugLogger() << "ServerApp::UpdateSavePreviews: Sending " << preview_information.previews.size() << " previews in response.";
     player_connection->SendMessage(DispatchSavePreviewsMessage(player_connection->PlayerID(), preview_information));
     DebugLogger() << "ServerApp::UpdateSavePreviews: Previews sent.";
+}
+
+void ServerApp::UpdateCombatLogs(const Message& msg, PlayerConnectionPtr player_connection){
+    DebugLogger() << "ServerApp::UpdateCombatLogs() entered";
+
+    std::vector<int> ids;
+    ExtractRequestCombatLogsMessageData(msg, ids);
+
+    DebugLogger() << "ServerApp::UpdateCombatLogs() ids requested  first one is " << ids[0];
 }
 
 namespace {

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1831,7 +1831,7 @@ namespace {
 
         for (const CombatInfo& combat_info : combats) {
             // add combat log entry
-            int log_id = log_manager.AddLog(CombatLog(combat_info));
+            int log_id = log_manager.AddNewLog(CombatLog(combat_info));
 
             // basic "combat occured" sitreps
             const std::set<int>& empire_ids = combat_info.empire_ids;

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -406,7 +406,7 @@ void ServerApp::HandleMessage(const Message& msg, PlayerConnectionPtr player_con
     case Message::SHUT_DOWN_SERVER:         HandleShutdownMessage(msg, player_connection);  break;
 
     case Message::REQUEST_SAVE_PREVIEWS:    UpdateSavePreviews(msg, player_connection); break;
-    case Message::REQUEST_COMBAT_LOGS:      UpdateCombatLogs(msg, player_connection); break;
+    case Message::REQUEST_COMBAT_LOGS:      m_fsm->process_event(RequestCombatLogs(msg, player_connection));break;
 
     default:
         ErrorLogger() << "ServerApp::HandleMessage : Received an unknown message type \"" << msg.Type() << "\".  Terminating connection.";

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -171,6 +171,9 @@ public:
 
     void UpdateSavePreviews(const Message& msg, PlayerConnectionPtr player_connection);
 
+    /** Send the requested combat logs to the client.*/
+    void UpdateCombatLogs(const Message& msg, PlayerConnectionPtr player_connection);
+
     static ServerApp*           GetApp();         ///< returns a ClientApp pointer to the singleton instance of the app
     Universe&                   GetUniverse();    ///< returns server's copy of Universe
     EmpireManager&              Empires();        ///< returns the server's copy of the Empires

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -139,7 +139,7 @@ namespace {
     void HandleErrorMessage(const Error& msg, ServerApp &server) {
         std::string problem;
         bool fatal;
-        ExtractMessageData(msg.m_message, problem, fatal);
+        ExtractErrorMessageData(msg.m_message, problem, fatal);
 
         std::stringstream ss;
 
@@ -259,7 +259,7 @@ sc::result Idle::react(const HostMPGame& msg) {
 
     std::string host_player_name;
     std::string client_version_string;
-    ExtractMessageData(message, host_player_name, client_version_string);
+    ExtractHostMPGameMessageData(message, host_player_name, client_version_string);
 
     // validate host name (was found and wasn't empty)
     if (host_player_name.empty()) {
@@ -291,7 +291,7 @@ sc::result Idle::react(const HostSPGame& msg) {
 
     boost::shared_ptr<SinglePlayerSetupData> single_player_setup_data(new SinglePlayerSetupData);
     std::string client_version_string;
-    ExtractMessageData(message, *single_player_setup_data, client_version_string);
+    ExtractHostSPGameMessageData(message, *single_player_setup_data, client_version_string);
 
 
     // get host player's name from setup data or saved file
@@ -450,7 +450,7 @@ sc::result MPLobby::react(const JoinGame& msg) {
     std::string player_name;
     Networking::ClientType client_type;
     std::string client_version_string;
-    ExtractMessageData(message, player_name, client_type, client_version_string);
+    ExtractJoinGameMessageData(message, player_name, client_type, client_version_string);
     // TODO: check if player name is unique.  If not, modify it slightly to be unique.
 
     // assign unique player ID to newly connected player
@@ -490,7 +490,7 @@ sc::result MPLobby::react(const LobbyUpdate& msg) {
     const Message& message = msg.m_message;
 
     MultiplayerLobbyData incoming_lobby_data;
-    ExtractMessageData(message, incoming_lobby_data);
+    ExtractLobbyUpdateMessageData(message, incoming_lobby_data);
 
     // check if new lobby data changed player setup data.  if so, need to echo
     // back to sender with updated lobby details.
@@ -893,7 +893,7 @@ sc::result WaitingForSPGameJoiners::react(const JoinGame& msg) {
     std::string player_name("Default_Player_Name_in_WaitingForSPGameJoiners::react(const JoinGame& msg)");
     Networking::ClientType client_type(Networking::INVALID_CLIENT_TYPE);
     std::string client_version_string;
-    ExtractMessageData(message, player_name, client_type, client_version_string);
+    ExtractJoinGameMessageData(message, player_name, client_type, client_version_string);
 
     int player_id = server.m_networking.NewPlayerID();
 
@@ -1023,7 +1023,7 @@ sc::result WaitingForMPGameJoiners::react(const JoinGame& msg) {
     std::string player_name("Default_Player_Name_in_WaitingForMPGameJoiners::react(const JoinGame& msg)");
     Networking::ClientType client_type(Networking::INVALID_CLIENT_TYPE);
     std::string client_version_string;
-    ExtractMessageData(message, player_name, client_type, client_version_string);
+    ExtractJoinGameMessageData(message, player_name, client_type, client_version_string);
 
     int player_id = server.m_networking.NewPlayerID();
 
@@ -1125,7 +1125,7 @@ sc::result PlayingGame::react(const Diplomacy& msg) {
     const Message& message = msg.m_message;
 
     DiplomaticMessage diplo_message;
-    ExtractMessageData(message, diplo_message);
+    ExtractDiplomacyMessageData(message, diplo_message);
     Empires().HandleDiplomaticMessage(diplo_message);
 
     return discard_event();
@@ -1146,7 +1146,7 @@ sc::result PlayingGame::react(const ModeratorAct& msg) {
     }
 
     Moderator::ModeratorAction* action = 0;
-    ExtractMessageData(message, action);
+    ExtractModeratorActionMessageData(message, action);
 
     DebugLogger() << "PlayingGame::react(ModeratorAct): " << (action ? action->Dump() : "(null)");
 
@@ -1190,7 +1190,7 @@ sc::result WaitingForTurnEnd::react(const TurnOrders& msg) {
     const Message& message = msg.m_message;
 
     OrderSet* order_set = new OrderSet;
-    ExtractMessageData(message, *order_set);
+    ExtractTurnOrdersMessageData(message, *order_set);
 
     assert(message.SendingPlayer() == msg.m_player_connection->PlayerID());
 
@@ -1388,7 +1388,7 @@ sc::result WaitingForSaveData::react(const ClientSaveData& msg) {
     bool save_state_string_available = false;
 
     try {
-        ExtractMessageData(message, received_orders, ui_data_available, *ui_data, save_state_string_available, save_state_string);
+        ExtractClientSaveDataMessageData(message, received_orders, ui_data_available, *ui_data, save_state_string_available, save_state_string);
     } catch (const std::exception& e) {
         DebugLogger() << "WaitingForSaveData::react(const ClientSaveData& msg) received invalid save data from player " << player_connection->PlayerName();
         player_connection->SendMessage(ErrorMessage(UserStringNop("INVALID_CLIENT_SAVE_DATA_RECEIVED"), false));

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -1166,6 +1166,12 @@ sc::result PlayingGame::react(const ModeratorAct& msg) {
     return discard_event();
 }
 
+sc::result PlayingGame::react(const RequestCombatLogs& msg) {
+    DebugLogger() << "(ServerFSM) PlayingGame::RequestCombatLogs message received";
+    Server().UpdateCombatLogs(msg.m_message, msg.m_player_connection);
+    return discard_event();
+}
+
 sc::result PlayingGame::react(const Error& msg) {
     HandleErrorMessage(msg, Server());
     return discard_event();

--- a/server/ServerFSM.h
+++ b/server/ServerFSM.h
@@ -64,6 +64,7 @@ struct MessageEventBase {
     (ClientSaveData)                        \
     (RequestObjectID)                       \
     (RequestDesignID)                       \
+    (RequestCombatLogs)                     \
     (PlayerChat)                            \
     (Diplomacy)                             \
     (ModeratorAct)                          \
@@ -242,6 +243,7 @@ struct PlayingGame : sc::state<PlayingGame, ServerFSM, WaitingForTurnEnd> {
         sc::custom_reaction<PlayerChat>,
         sc::custom_reaction<Diplomacy>,
         sc::custom_reaction<ModeratorAct>,
+        sc::custom_reaction<RequestCombatLogs>,
         sc::custom_reaction<Error>
     > reactions;
 
@@ -251,6 +253,7 @@ struct PlayingGame : sc::state<PlayingGame, ServerFSM, WaitingForTurnEnd> {
     sc::result react(const PlayerChat& msg);
     sc::result react(const Diplomacy& msg);
     sc::result react(const ModeratorAct& msg);
+    sc::result react(const RequestCombatLogs& msg);
     sc::result react(const Error& msg);
 
     SERVER_ACCESSOR


### PR DESCRIPTION
Currently, every turn update the server sends all combat logs since turn 1 to every player, human and AI.  The AIs never use the combat reports.  

Profiling on my machine showed that the time spent sending the logs was about 0.8 ms per log, per player, per turn.  If the game goes long enough parsing and sending the logs becomes the biggest time component of processing the turn.

This PR changes the implementation so that each turn all players are informed of the number of available combats logs and then only the human clients request any combat logs that they do not already have.  This means that during a game each combat log is only downloaded once per human client.
