### PR TITLE
Add aggregation to common python timer.

### DIFF
--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -12,10 +12,10 @@ import TechsListsAI
 import MilitaryAI
 from turn_state import state
 from EnumsAI import MissionType, FocusType, EmpireProductionTypes, ShipRoleType, PriorityType
-from freeorion_tools import dict_from_map, tech_is_complete, get_ai_tag_grade, cache_by_turn, Timer
+from freeorion_tools import dict_from_map, tech_is_complete, get_ai_tag_grade, cache_by_turn, FOTimer
 from AIDependencies import INVALID_ID, POP_CONST_MOD_MAP, POP_SIZE_MOD_MAP
 
-colonization_timer = Timer('getColonyFleets()')
+colonization_timer = FOTimer('getColonyFleets()')
 
 
 empire_colonizers = {}

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -550,11 +550,7 @@ def get_colony_fleets():
     # export outposts for other AI modules
     foAI.foAIstate.colonisableOutpostIDs.clear()
     foAI.foAIstate.colonisableOutpostIDs.update(sorted_outposts)
-    colonization_timer.stop_and_print()
-    # colonization_timer is file scope in order to capture times from different functions
-    # in this file, but it produces output each turn.  It needs to be cleared
-    # once per turn so that the aggregate times only reflect this turn.
-    colonization_timer.clear_data()
+    colonization_timer.stop_print_and_clear()
 
 
 def assign_colonisation_values(planet_ids, mission_type, species, empire, detail=None,

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -12,10 +12,10 @@ import TechsListsAI
 import MilitaryAI
 from turn_state import state
 from EnumsAI import MissionType, FocusType, EmpireProductionTypes, ShipRoleType, PriorityType
-from freeorion_tools import dict_from_map, tech_is_complete, get_ai_tag_grade, cache_by_turn, FOTimer
+from freeorion_tools import dict_from_map, tech_is_complete, get_ai_tag_grade, cache_by_turn, AITimer
 from AIDependencies import INVALID_ID, POP_CONST_MOD_MAP, POP_SIZE_MOD_MAP
 
-colonization_timer = FOTimer('getColonyFleets()')
+colonization_timer = AITimer('getColonyFleets()')
 
 
 empire_colonizers = {}

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -551,6 +551,10 @@ def get_colony_fleets():
     foAI.foAIstate.colonisableOutpostIDs.clear()
     foAI.foAIstate.colonisableOutpostIDs.update(sorted_outposts)
     colonization_timer.end()
+    # colonization_timer is file scope in order to capture times from different functions
+    # in this file, but it produces output each turn.  It needs to be cleared
+    # once per turn so that the aggregate times only reflect this turn.
+    colonization_timer.clear_data()
 
 
 def assign_colonisation_values(planet_ids, mission_type, species, empire, detail=None,

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -550,7 +550,7 @@ def get_colony_fleets():
     # export outposts for other AI modules
     foAI.foAIstate.colonisableOutpostIDs.clear()
     foAI.foAIstate.colonisableOutpostIDs.update(sorted_outposts)
-    colonization_timer.end()
+    colonization_timer.stop_and_print()
     # colonization_timer is file scope in order to capture times from different functions
     # in this file, but it produces output each turn.  It needs to be cleared
     # once per turn so that the aggregate times only reflect this turn.

--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -249,8 +249,9 @@ def generateOrders():  # pylint: disable=invalid-name
             main_timer.stop()
         except Exception as e:
             print_error(e, location=action.__name__)
-    main_timer.end()
-    turn_timer.end()
+    main_timer.stop_and_print()
+    turn_timer.stop_and_print()
+
     # Turn timer is file scope in order to capture times from different functions
     # in this file, but it produces output each turn.  It needs to be cleared
     # once per turn so that the aggregate times only reflect this turn.

--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -28,13 +28,13 @@ import ResearchAI
 import ResourcesAI
 import TechsListsAI
 from AIDependencies import INVALID_ID
-from freeorion_tools import UserStringList, chat_on_error, print_error, UserString, handle_debug_chat, Timer, init_handlers
+from freeorion_tools import UserStringList, chat_on_error, print_error, UserString, handle_debug_chat, FOTimer, init_handlers
 from common.listeners import listener
 from character.character_module import Aggression
 from character.character_strings_module import get_trait_name_aggression, possible_capitals
 
-main_timer = Timer('timer', write_log=True)
-turn_timer = Timer('bucket', write_log=True)
+main_timer = FOTimer('timer', write_log=True)
+turn_timer = FOTimer('bucket', write_log=True)
 
 using_statprof = False
 try:

--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -251,6 +251,7 @@ def generateOrders():  # pylint: disable=invalid-name
             print_error(e, location=action.__name__)
     main_timer.end()
     turn_timer.end()
+    turn_timer.clear()
     turn_timer.start("Server_Processing")
 
     try:

--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -249,13 +249,8 @@ def generateOrders():  # pylint: disable=invalid-name
             main_timer.stop()
         except Exception as e:
             print_error(e, location=action.__name__)
-    main_timer.stop_and_print()
-    turn_timer.stop_and_print()
-
-    # Turn timer is file scope in order to capture times from different functions
-    # in this file, but it produces output each turn.  It needs to be cleared
-    # once per turn so that the aggregate times only reflect this turn.
-    turn_timer.clear_data()
+    main_timer.stop_print_and_clear()
+    turn_timer.stop_print_and_clear()
     turn_timer.start("Server_Processing")
 
     try:

--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -28,13 +28,13 @@ import ResearchAI
 import ResourcesAI
 import TechsListsAI
 from AIDependencies import INVALID_ID
-from freeorion_tools import UserStringList, chat_on_error, print_error, UserString, handle_debug_chat, FOTimer, init_handlers
+from freeorion_tools import UserStringList, chat_on_error, print_error, UserString, handle_debug_chat, AITimer, init_handlers
 from common.listeners import listener
 from character.character_module import Aggression
 from character.character_strings_module import get_trait_name_aggression, possible_capitals
 
-main_timer = FOTimer('timer', write_log=True)
-turn_timer = FOTimer('bucket', write_log=True)
+main_timer = AITimer('timer', write_log=True)
+turn_timer = AITimer('bucket', write_log=True)
 
 using_statprof = False
 try:

--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -251,7 +251,10 @@ def generateOrders():  # pylint: disable=invalid-name
             print_error(e, location=action.__name__)
     main_timer.end()
     turn_timer.end()
-    turn_timer.clear()
+    # Turn timer is file scope in order to capture times from different functions
+    # in this file, but it produces output each turn.  It needs to be cleared
+    # once per turn so that the aggregate times only reflect this turn.
+    turn_timer.clear_data()
     turn_timer.start("Server_Processing")
 
     try:

--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -16,10 +16,10 @@ import ColonisationAI
 import MilitaryAI
 from EnumsAI import MissionType, PriorityType
 import CombatRatingsAI
-from freeorion_tools import tech_is_complete, FOTimer
+from freeorion_tools import tech_is_complete, AITimer
 from AIDependencies import INVALID_ID
 
-invasion_timer = FOTimer('get_invasion_fleets()', write_log=False)
+invasion_timer = AITimer('get_invasion_fleets()', write_log=False)
 
 
 def get_invasion_fleets():

--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -167,7 +167,7 @@ def get_invasion_fleets():
     # export invasion targeted systems for other AI modules
     AIstate.invasionTargetedSystemIDs = list(all_invasion_targeted_system_ids)
     invasion_timer.stop(section_name="evaluating %d target planets" % (len(evaluated_planet_ids)))
-    invasion_timer.end()
+    invasion_timer.stop_and_print()
     # invasion_timer is file scope in order to capture times from different functions
     # in this file, but it produces output each turn.  It needs to be cleared
     # once per turn so that the aggregate times only reflect this turn.

--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -167,11 +167,7 @@ def get_invasion_fleets():
     # export invasion targeted systems for other AI modules
     AIstate.invasionTargetedSystemIDs = list(all_invasion_targeted_system_ids)
     invasion_timer.stop(section_name="evaluating %d target planets" % (len(evaluated_planet_ids)))
-    invasion_timer.stop_and_print()
-    # invasion_timer is file scope in order to capture times from different functions
-    # in this file, but it produces output each turn.  It needs to be cleared
-    # once per turn so that the aggregate times only reflect this turn.
-    invasion_timer.clear_data()
+    invasion_timer.stop_print_and_clear()
 
 
 def get_invasion_targeted_planet_ids(planet_ids, mission_type):

--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -16,10 +16,10 @@ import ColonisationAI
 import MilitaryAI
 from EnumsAI import MissionType, PriorityType
 import CombatRatingsAI
-from freeorion_tools import tech_is_complete, Timer
+from freeorion_tools import tech_is_complete, FOTimer
 from AIDependencies import INVALID_ID
 
-invasion_timer = Timer('get_invasion_fleets()', write_log=False)
+invasion_timer = FOTimer('get_invasion_fleets()', write_log=False)
 
 
 def get_invasion_fleets():

--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -168,6 +168,10 @@ def get_invasion_fleets():
     AIstate.invasionTargetedSystemIDs = list(all_invasion_targeted_system_ids)
     invasion_timer.stop(section_name="evaluating %d target planets" % (len(evaluated_planet_ids)))
     invasion_timer.end()
+    # invasion_timer is file scope in order to capture times from different functions
+    # in this file, but it produces output each turn.  It needs to be cleared
+    # once per turn so that the aggregate times only reflect this turn.
+    invasion_timer.clear_data()
 
 
 def get_invasion_targeted_planet_ids(planet_ids, mission_type):

--- a/default/python/AI/PriorityAI.py
+++ b/default/python/AI/PriorityAI.py
@@ -76,6 +76,10 @@ def calculate_priorities():
     foAI.foAIstate.set_priority(PriorityType.RESEARCH_SHIPS, _calculate_ships_priority())
     foAI.foAIstate.set_priority(PriorityType.RESEARCH_DEFENSE, 0)
     prioritiees_timer.end()
+    # priorities_timer is file scope in order to capture times from different functions
+    # in this file, but it produces output each turn.  It needs to be cleared
+    # once per turn so that the aggregate times only reflect this turn.
+    prioritiees_timer.clear_data()
 
 
 def _calculate_industry_priority():  # currently only used to print status

--- a/default/python/AI/PriorityAI.py
+++ b/default/python/AI/PriorityAI.py
@@ -75,11 +75,7 @@ def calculate_priorities():
     foAI.foAIstate.set_priority(PriorityType.RESEARCH_ECONOMICS, 0)
     foAI.foAIstate.set_priority(PriorityType.RESEARCH_SHIPS, _calculate_ships_priority())
     foAI.foAIstate.set_priority(PriorityType.RESEARCH_DEFENSE, 0)
-    prioritiees_timer.stop_and_print()
-    # priorities_timer is file scope in order to capture times from different functions
-    # in this file, but it produces output each turn.  It needs to be cleared
-    # once per turn so that the aggregate times only reflect this turn.
-    prioritiees_timer.clear_data()
+    prioritiees_timer.stop_print_and_clear()
 
 
 def _calculate_industry_priority():  # currently only used to print status

--- a/default/python/AI/PriorityAI.py
+++ b/default/python/AI/PriorityAI.py
@@ -14,10 +14,10 @@ import ResearchAI
 import AIDependencies
 from turn_state import state
 from EnumsAI import PriorityType, MissionType, EmpireProductionTypes, get_priority_production_types, ShipRoleType
-from freeorion_tools import Timer, tech_is_complete
+from freeorion_tools import FOTimer, tech_is_complete
 from AIDependencies import INVALID_ID
 
-prioritiees_timer = Timer('calculate_priorities()')
+prioritiees_timer = FOTimer('calculate_priorities()')
 
 allottedInvasionTargets = 0
 allottedColonyTargets = 0

--- a/default/python/AI/PriorityAI.py
+++ b/default/python/AI/PriorityAI.py
@@ -75,7 +75,7 @@ def calculate_priorities():
     foAI.foAIstate.set_priority(PriorityType.RESEARCH_ECONOMICS, 0)
     foAI.foAIstate.set_priority(PriorityType.RESEARCH_SHIPS, _calculate_ships_priority())
     foAI.foAIstate.set_priority(PriorityType.RESEARCH_DEFENSE, 0)
-    prioritiees_timer.end()
+    prioritiees_timer.stop_and_print()
     # priorities_timer is file scope in order to capture times from different functions
     # in this file, but it produces output each turn.  It needs to be cleared
     # once per turn so that the aggregate times only reflect this turn.

--- a/default/python/AI/PriorityAI.py
+++ b/default/python/AI/PriorityAI.py
@@ -14,10 +14,10 @@ import ResearchAI
 import AIDependencies
 from turn_state import state
 from EnumsAI import PriorityType, MissionType, EmpireProductionTypes, get_priority_production_types, ShipRoleType
-from freeorion_tools import FOTimer, tech_is_complete
+from freeorion_tools import AITimer, tech_is_complete
 from AIDependencies import INVALID_ID
 
-prioritiees_timer = FOTimer('calculate_priorities()')
+prioritiees_timer = AITimer('calculate_priorities()')
 
 allottedInvasionTargets = 0
 allottedColonyTargets = 0

--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -16,7 +16,7 @@ from turn_state import state
 
 from EnumsAI import (PriorityType, EmpireProductionTypes, MissionType, get_priority_production_types,
                      FocusType, ShipRoleType, ShipDesignTypes)
-from freeorion_tools import dict_from_map, ppstring, chat_human, tech_is_complete, print_error, FOTimer
+from freeorion_tools import dict_from_map, ppstring, chat_human, tech_is_complete, print_error, AITimer
 from common.print_utils import Table, Sequence, Text
 from AIDependencies import INVALID_ID
 
@@ -30,7 +30,7 @@ _CHAT_DEBUG = False
 
 def find_best_designs_this_turn():
     """Calculate the best designs for each ship class available at this turn."""
-    design_timer = FOTimer('ShipDesigner')
+    design_timer = AITimer('ShipDesigner')
     design_timer.start('Updating cache for new turn')
     ShipDesignAI.Cache.update_for_new_turn()
     _design_cache.clear()

--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -60,7 +60,7 @@ def find_best_designs_this_turn():
     if fo.currentTurn() % 10 == 0:
         design_timer.start('Printing')
         ShipDesignAI.Cache.print_best_designs()
-    design_timer.end()
+    design_timer.stop_and_print()
 
 
 def get_design_cost(design, pid):  # TODO: Use new framework

--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -60,7 +60,7 @@ def find_best_designs_this_turn():
     if fo.currentTurn() % 10 == 0:
         design_timer.start('Printing')
         ShipDesignAI.Cache.print_best_designs()
-    design_timer.stop_and_print()
+    design_timer.stop_print_and_clear()
 
 
 def get_design_cost(design, pid):  # TODO: Use new framework

--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -16,7 +16,7 @@ from turn_state import state
 
 from EnumsAI import (PriorityType, EmpireProductionTypes, MissionType, get_priority_production_types,
                      FocusType, ShipRoleType, ShipDesignTypes)
-from freeorion_tools import dict_from_map, ppstring, chat_human, tech_is_complete, print_error, Timer
+from freeorion_tools import dict_from_map, ppstring, chat_human, tech_is_complete, print_error, FOTimer
 from common.print_utils import Table, Sequence, Text
 from AIDependencies import INVALID_ID
 
@@ -30,7 +30,7 @@ _CHAT_DEBUG = False
 
 def find_best_designs_this_turn():
     """Calculate the best designs for each ship class available at this turn."""
-    design_timer = Timer('ShipDesigner')
+    design_timer = FOTimer('ShipDesigner')
     design_timer.start('Updating cache for new turn')
     ShipDesignAI.Cache.update_for_new_turn()
     _design_cache.clear()

--- a/default/python/AI/ResourcesAI.py
+++ b/default/python/AI/ResourcesAI.py
@@ -628,11 +628,7 @@ def set_planet_resource_foci():
 
         reporter.print_table(priority_ratio)
 
-        resource_timer.stop_and_print()
-        # resource_timer is file scope in order to capture times from different functions
-        # in this file, but it produces output each turn.  It needs to be cleared
-        # once per turn so that the aggregate times only reflect this turn.
-        resource_timer.clear_data()
+        resource_timer.stop_print_and_clear()
 
     Reporter.print_resource_ai_footer()
 

--- a/default/python/AI/ResourcesAI.py
+++ b/default/python/AI/ResourcesAI.py
@@ -628,7 +628,7 @@ def set_planet_resource_foci():
 
         reporter.print_table(priority_ratio)
 
-        resource_timer.end()
+        resource_timer.stop_and_print()
         # resource_timer is file scope in order to capture times from different functions
         # in this file, but it produces output each turn.  It needs to be cleared
         # once per turn so that the aggregate times only reflect this turn.

--- a/default/python/AI/ResourcesAI.py
+++ b/default/python/AI/ResourcesAI.py
@@ -18,9 +18,9 @@ import random
 import ColonisationAI
 import AIDependencies
 import CombatRatingsAI
-from freeorion_tools import tech_is_complete, Timer
+from freeorion_tools import tech_is_complete, FOTimer
 
-resource_timer = Timer('timer_bucket')
+resource_timer = FOTimer('timer_bucket')
 
 # Local Constants
 INDUSTRY = FocusType.FOCUS_INDUSTRY

--- a/default/python/AI/ResourcesAI.py
+++ b/default/python/AI/ResourcesAI.py
@@ -629,6 +629,10 @@ def set_planet_resource_foci():
         reporter.print_table(priority_ratio)
 
         resource_timer.end()
+        # resource_timer is file scope in order to capture times from different functions
+        # in this file, but it produces output each turn.  It needs to be cleared
+        # once per turn so that the aggregate times only reflect this turn.
+        resource_timer.clear_data()
 
     Reporter.print_resource_ai_footer()
 

--- a/default/python/AI/ResourcesAI.py
+++ b/default/python/AI/ResourcesAI.py
@@ -18,9 +18,9 @@ import random
 import ColonisationAI
 import AIDependencies
 import CombatRatingsAI
-from freeorion_tools import tech_is_complete, FOTimer
+from freeorion_tools import tech_is_complete, AITimer
 
-resource_timer = FOTimer('timer_bucket')
+resource_timer = AITimer('timer_bucket')
 
 # Local Constants
 INDUSTRY = FocusType.FOCUS_INDUSTRY

--- a/default/python/AI/freeorion_tools/__init__.py
+++ b/default/python/AI/freeorion_tools/__init__.py
@@ -1,5 +1,5 @@
 from _freeorion_tools import *
 from extend_freeorion_AI_interface import patch_interface
 from interactive_shell import handle_debug_chat
-from timers import Timer
+from timers import FOTimer
 from handlers import init_handlers

--- a/default/python/AI/freeorion_tools/__init__.py
+++ b/default/python/AI/freeorion_tools/__init__.py
@@ -1,5 +1,5 @@
 from _freeorion_tools import *
 from extend_freeorion_AI_interface import patch_interface
 from interactive_shell import handle_debug_chat
-from timers import FOTimer
+from timers import AITimer
 from handlers import init_handlers

--- a/default/python/AI/freeorion_tools/timers.py
+++ b/default/python/AI/freeorion_tools/timers.py
@@ -44,6 +44,15 @@ class DummyTimer(object):
     def end(self):
         pass
 
+    def clear(self):
+        pass
+
+    def print_flat(self):
+        pass
+
+    def print_aggregate(self):
+        pass
+
 
 class FOLogTimer(Timer):
     """A Timer with a FO AI engine dependent extension that logs timer results to a file each turn.

--- a/default/python/AI/freeorion_tools/timers.py
+++ b/default/python/AI/freeorion_tools/timers.py
@@ -72,6 +72,7 @@ class AILogTimer(Timer):
         Timer.__init__(self, timer_name)
         self.headers = None
         self.write_log = write_log
+        self.log_name = None
 
     def _write(self, text):
         if not _get_timers_dir():

--- a/default/python/AI/freeorion_tools/timers.py
+++ b/default/python/AI/freeorion_tools/timers.py
@@ -41,7 +41,7 @@ class DummyTimer(object):
     def start(self, *args, **kwargs):
         pass
 
-    def end(self):
+    def stop_and_print(self):
         pass
 
     def clear_data(self):
@@ -80,12 +80,12 @@ class AILogTimer(Timer):
             f.write(text)
             f.write('\n')
 
-    def end(self):
+    def stop_and_print(self):
         """
-        Stop timer, output result, clear checks.
+        Stop timer, output result.
         If dumping to file, if headers are not match to prev, new header line will be added.
         """
-        Timer.end(self)
+        Timer.stop_and_print(self)
 
         if self.write_log and DUMP_TO_FILE:
             turn = fo.currentTurn()

--- a/default/python/AI/freeorion_tools/timers.py
+++ b/default/python/AI/freeorion_tools/timers.py
@@ -56,6 +56,9 @@ class DummyTimer(object):
     def print_aggregate(self):
         pass
 
+    def print_statistics(self):
+        pass
+
 
 class AILogTimer(Timer):
     """A Timer with a FO AI engine dependent extension that logs timer results to a file each turn.

--- a/default/python/AI/freeorion_tools/timers.py
+++ b/default/python/AI/freeorion_tools/timers.py
@@ -54,7 +54,7 @@ class DummyTimer(object):
         pass
 
 
-class FOLogTimer(Timer):
+class AILogTimer(Timer):
     """A Timer with a FO AI engine dependent extension that logs timer results to a file each turn.
     """
     def __init__(self, timer_name, write_log=False):
@@ -100,4 +100,4 @@ class FOLogTimer(Timer):
             self._write(''.join(row))
         self.timers = []  # clear times
 
-FOTimer = FOLogTimer if USE_TIMERS else DummyTimer
+AITimer = AILogTimer if USE_TIMERS else DummyTimer

--- a/default/python/AI/freeorion_tools/timers.py
+++ b/default/python/AI/freeorion_tools/timers.py
@@ -44,7 +44,7 @@ class DummyTimer(object):
     def end(self):
         pass
 
-    def clear(self):
+    def clear_data(self):
         pass
 
     def print_flat(self):
@@ -98,6 +98,5 @@ class AILogTimer(Timer):
             for header, val in zip(self.headers, [turn] + [x[1] for x in self.timers]):
                 row.append('%*s ' % (len(header) - 2, int(val)))
             self._write(''.join(row))
-        self.timers = []  # clear times
 
 AITimer = AILogTimer if USE_TIMERS else DummyTimer

--- a/default/python/AI/freeorion_tools/timers.py
+++ b/default/python/AI/freeorion_tools/timers.py
@@ -44,6 +44,9 @@ class DummyTimer(object):
     def stop_and_print(self):
         pass
 
+    def stop_print_and_clear(self):
+        pass
+
     def clear_data(self):
         pass
 
@@ -80,9 +83,9 @@ class AILogTimer(Timer):
             f.write(text)
             f.write('\n')
 
-    def stop_and_print(self):
+    def stop_print_and_clear(self):
         """
-        Stop timer, output result.
+        Stop timer, output result, and clear timers.
         If dumping to file, if headers are not match to prev, new header line will be added.
         """
         Timer.stop_and_print(self)

--- a/default/python/common/timers.py
+++ b/default/python/common/timers.py
@@ -73,13 +73,12 @@ class Timer(object):
 
         self._print_timer_table(time_table)
 
-    def end(self, dont_print=False):
+    def stop_and_print(self):
         """
-        Stop timer, output flat result if dont_print is False.
+        Stop timer, output flat result.
         """
         self.stop()
-        if not dont_print:
-            self.print_flat()
+        self.print_flat()
 
     def clear_data(self):
         """

--- a/default/python/common/timers.py
+++ b/default/python/common/timers.py
@@ -11,7 +11,6 @@ class Timer(object):
         self.end_time = None
         self.section_name = None
         self.timers = []
-        self.log_name = None
 
     def stop(self, section_name=''):
         """

--- a/default/python/common/timers.py
+++ b/default/python/common/timers.py
@@ -1,0 +1,50 @@
+from time import time
+
+
+class Timer(object):
+    def __init__(self, timer_name):
+        """
+        Creates timer. Timer name is name that will be in logs.
+
+        """
+        self.timer_name = timer_name
+        self.start_time = None
+        self.section_name = None
+        self.timers = []
+        self.log_name = None
+
+    def stop(self, section_name=''):
+        """
+        Stop timer if running. Specify section_name if want to override its name.
+        """
+        if self.start_time:
+            self.end_time = time()
+            section_name = section_name or self.section_name
+            self.timers.append((section_name, (self.end_time - self.start_time) * 1000.0))
+        self.start_time = None
+        self.section_name = None
+
+    def start(self, section_name):
+        """
+        Stop prev timer if present and starts new.
+        """
+        self.stop()
+        self.section_name = section_name
+        self.start_time = time()
+
+    def end(self):
+        """
+        Stop timer, output result, clear checks.
+        """
+        self.stop()
+        if not self.timers:
+            return
+        max_header = max(len(x[0]) for x in self.timers)
+        line_max_size = max_header + 14
+        print
+        print ('Timing for %s:' % self.timer_name)
+        print '=' * line_max_size
+        for name, val in self.timers:
+            print "%-*s %8d msec" % (max_header, name, val)
+        print '-' * line_max_size
+        print ("Total: %8d msec" % sum(x[1] for x in self.timers)).rjust(line_max_size)

--- a/default/python/common/timers.py
+++ b/default/python/common/timers.py
@@ -33,11 +33,10 @@ class Timer(object):
         self.section_name = section_name
         self.start_time = time()
 
-    def end(self):
+    def _print_timer_table(self, time_table):
         """
-        Stop timer, output result, clear checks.
+        Print a header and a footer and fill it with the timing results from time_table
         """
-        self.stop()
         if not self.timers:
             return
         max_header = max(len(x[0]) for x in self.timers)
@@ -45,7 +44,44 @@ class Timer(object):
         print
         print 'Timing for %s:' % self.timer_name
         print '=' * line_max_size
-        for name, val in self.timers:
+
+        for name, val in time_table:
             print "%-*s %8d msec" % (max_header, name, val)
+
         print '-' * line_max_size
         print ("Total: %8d msec" % sum(x[1] for x in self.timers)).rjust(line_max_size)
+
+    def print_flat(self):
+        """
+        Output result.
+        """
+        self._print_timer_table(self.timers)
+
+    def print_aggregate(self):
+        """
+        Print aggregated results for each section.
+        """
+        accumulated_times = {}
+        ordered_names = []
+        for name, val in self.timers:
+            if name not in accumulated_times:
+                ordered_names.append(name)
+                accumulated_times[name] = 0
+            accumulated_times[name] += val
+        time_table = [(name, accumulated_times[name]) for name in ordered_names]
+
+        self._print_timer_table(time_table)
+
+    def end(self, dont_print=False):
+        """
+        Stop timer, output flat result if dont_print is False.
+        """
+        self.stop()
+        if not dont_print:
+            self.print_flat()
+
+    def clear(self):
+        """
+        Clear timers
+        """
+        self.timers = []

--- a/default/python/common/timers.py
+++ b/default/python/common/timers.py
@@ -9,6 +9,7 @@ class Timer(object):
         """
         self.timer_name = timer_name
         self.start_time = None
+        self.end_time = None
         self.section_name = None
         self.timers = []
         self.log_name = None
@@ -42,7 +43,7 @@ class Timer(object):
         max_header = max(len(x[0]) for x in self.timers)
         line_max_size = max_header + 14
         print
-        print ('Timing for %s:' % self.timer_name)
+        print 'Timing for %s:' % self.timer_name
         print '=' * line_max_size
         for name, val in self.timers:
             print "%-*s %8d msec" % (max_header, name, val)

--- a/default/python/common/timers.py
+++ b/default/python/common/timers.py
@@ -74,6 +74,45 @@ class Timer(object):
 
         self._print_timer_table(time_table)
 
+    def print_statistics(self):
+        """
+        Print number of times, average, std, and max statistics for each section.
+        """
+        # TODO: If conversion to python 3 happens, use statistics.pstdev() to compute statistics.
+        number_samples = {}
+        means = {}
+        stds = {}
+        maxes = {}
+        ordered_names = []
+        for name, val in self.timers:
+            if name not in ordered_names:
+                ordered_names.append(name)
+                means[name] = 0
+                stds[name] = 0
+                number_samples[name] = 0
+                maxes[name] = val
+            means[name] += val
+            number_samples[name] += 1
+            maxes[name] = max(val, maxes[name])
+        for name in ordered_names:
+            means[name] = means[name] / number_samples[name]
+        for name, val in self.timers:
+            stds[name] += (val - means[name]) ** 2.0
+        for name in ordered_names:
+            stds[name] = (stds[name] / number_samples[name]) ** 0.5
+
+        max_header = max(len(x) for x in ordered_names)
+        line_max_size = max_header + 70
+        print
+        print 'Timing statistics for %s:' % self.timer_name
+        print '=' * line_max_size
+
+        for name in ordered_names:
+            print (("{:<{name_width}} num: {:>6d}, mean: {:>6.2f} msec, std: {:>6.2f} msec, max: {:>6.2f} msec").
+                   format(name, number_samples[name], means[name], stds[name], maxes[name], name_width=max_header))
+
+        print '=' * line_max_size
+
     def stop_and_print(self):
         """
         Stop timer, output flat result.

--- a/default/python/common/timers.py
+++ b/default/python/common/timers.py
@@ -38,9 +38,10 @@ class Timer(object):
         """
         # TODO: Convert to use table code from here /python/common/print_utils.py#L116
 
-        if not self.timers:
+        if not time_table:
+            print "NOT Time Table"
             return
-        max_header = max(len(x[0]) for x in self.timers)
+        max_header = max(len(x[0]) for x in time_table)
         line_max_size = max_header + 14
         print
         print 'Timing for %s:' % self.timer_name
@@ -50,7 +51,7 @@ class Timer(object):
             print "%-*s %8d msec" % (max_header, name, val)
 
         print '-' * line_max_size
-        print ("Total: %8d msec" % sum(x[1] for x in self.timers)).rjust(line_max_size)
+        print ("Total: %8d msec" % sum(x[1] for x in time_table)).rjust(line_max_size)
 
     def print_flat(self):
         """

--- a/default/python/common/timers.py
+++ b/default/python/common/timers.py
@@ -36,6 +36,8 @@ class Timer(object):
         """
         Print a header and a footer and fill it with the timing results from time_table.
         """
+        # TODO: Convert to use table code from here /python/common/print_utils.py#L116
+
         if not self.timers:
             return
         max_header = max(len(x[0]) for x in self.timers)

--- a/default/python/common/timers.py
+++ b/default/python/common/timers.py
@@ -5,7 +5,6 @@ class Timer(object):
     def __init__(self, timer_name):
         """
         Creates timer. Timer name is name that will be in logs.
-
         """
         self.timer_name = timer_name
         self.start_time = None
@@ -35,7 +34,7 @@ class Timer(object):
 
     def _print_timer_table(self, time_table):
         """
-        Print a header and a footer and fill it with the timing results from time_table
+        Print a header and a footer and fill it with the timing results from time_table.
         """
         if not self.timers:
             return
@@ -82,6 +81,6 @@ class Timer(object):
 
     def clear(self):
         """
-        Clear timers
+        Clear timers.
         """
         self.timers = []

--- a/default/python/common/timers.py
+++ b/default/python/common/timers.py
@@ -81,8 +81,8 @@ class Timer(object):
         if not dont_print:
             self.print_flat()
 
-    def clear(self):
+    def clear_data(self):
         """
-        Clear timers.
+        Clear timer data.
         """
         self.timers = []


### PR DESCRIPTION
This PR moves the portions of the AI timer that are not dependent on the `freeOrionAIInterface` into the python common code.  It then adds aggregation to the timer.  Aggregation means adding up the times of recursive sections of code and printing the sum with `print_aggregate()`.  

The original style of printing is available with `print_flat()`.  Calling `end()` still defaults to `print_flat()`.  

This addition to the `Timer` helped in profiling the universe generation code.