### PR TITLE
Improve universe generation performance.

### DIFF
--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -997,7 +997,7 @@ void HumanClientApp::HandleTurnUpdate()
 { UpdateCombatLogManager(); }
 
 void HumanClientApp::UpdateCombatLogManager() {
-    boost::optional<std::vector<int>> incomplete_ids { GetCombatLogManager().IncompleteLogIDs() };
+    boost::optional<std::vector<int>> incomplete_ids = GetCombatLogManager().IncompleteLogIDs();
     if (incomplete_ids)
         m_networking.SendMessage(RequestCombatLogsMessage(PlayerID(), *incomplete_ids));
 }

--- a/default/python/interface_mock/result/freeorion.py
+++ b/default/python/interface_mock/result/freeorion.py
@@ -425,13 +425,15 @@ class MonsterFleetPlan(object):
         """
         return int()
 
-    def location(self, number):
+    def locations(self, item_list):
         """
-        :param number:
-        :type number: int
-        :rtype: bool
+        :param string:
+        :type string: str
+        :param item_list:
+        :type item_list: list
+        :rtype: list
         """
-        return bool()
+        return list()
 
     def name(self):
         """
@@ -3516,15 +3518,15 @@ def special_has_location(string):
     return bool()
 
 
-def special_location(string, number):
+def special_locations(string, item_list):
     """
     :param string:
     :type string: str
-    :param number:
-    :type number: int
-    :rtype: bool
+    :param item_list:
+    :type item_list: list
+    :rtype: list
     """
-    return bool()
+    return list()
 
 
 def special_spawn_limit(string):

--- a/default/python/universe_generation/empires.py
+++ b/default/python/universe_generation/empires.py
@@ -94,19 +94,19 @@ class HomeSystemFinder(object):
 
     def find_home_systems_for_min_jump_distance(self, systems_pool, min_jumps):
         """
-        Return a good list of home systems
+        Return a good list of home systems or an empty list if there are fewer than num_home_systems in the pool.
 
-        Return a list of home systems which are at least the specified minimum number of jumps apart,
-        and with a good system merit picked randomly from the specified pool.
+        A good list of home systems are at least the specified minimum number of jumps apart,
+        with the best minimum system merit of all such lists picked randomly from the ''systems_pool''.
 
-        Return an empty list if there are fewer than num_home_systems in the pool.
+        Algorithm:
+        Make several attempts to find systems that match the condition
+        of being at least min_jumps apart.
+        Use the minimum merit of the best num_home_system systems found
+        as the merit of the current best set of systems.
+        On each attempt use the merit of the current best set of home
+        systems to truncate the pool of candidates.
         """
-        # Make several attempts to find systems that match the condition
-        # of being at least min_jumps apart
-        # Use the minimum merit of the best num_home_system systems found
-        # as the merit of the current best set of systems.
-        # On each attempt use the merit of the current best set of home
-        # systems to truncate the pool of candidates.
 
         # precalculate the system merits
         for system in systems_pool:

--- a/default/python/universe_generation/empires.py
+++ b/default/python/universe_generation/empires.py
@@ -87,10 +87,11 @@ def min_planets_in_vicinity_limit(num_systems):
 
 class HomeSystemFinder(object):
     """Finds a set of home systems with a least ''num_home_systems'' systems."""
-    def __init__(self, _num_home_systems):
+    def __init__(self, _len_systems, _num_home_systems):
         # cache of sytem merits
         self.system_merit = {}
         self.num_home_systems = _num_home_systems
+        self.len_systems = _len_systems
 
     def find_home_systems_for_min_jump_distance(self, systems_pool, min_jumps):
         """
@@ -129,7 +130,7 @@ class HomeSystemFinder(object):
         # (999, 39) and (199, 19) the following was observered.  The distribution of candidate
         # length is a normal random variable with standard deviation approximately equal to
 
-        expected_len_candidate_std = (len(systems_pool) ** (1.0/3)) / 10.0 * 1.5
+        expected_len_candidate_std = (self.len_systems ** (1.0/2.0)) * 0.03
 
         # So if the mean of the length of the candidates is with 1/2 std of the target
         # num_home_systems then there is a 90% expectation of hitting the goal within 6 tries.
@@ -199,7 +200,7 @@ class HomeSystemFinder(object):
         return best_candidate
 
 
-def find_home_systems(num_home_systems, pool_list, jump_distance, min_jump_distance):
+def find_home_systems(len_systems, num_home_systems, pool_list, jump_distance, min_jump_distance):
     """
     Tries to find a specified number of home systems which are as far apart from each other as possible.
     Starts with the specified jump distance and reduces that limit until enough systems can be found or the
@@ -209,7 +210,7 @@ def find_home_systems(num_home_systems, pool_list, jump_distance, min_jump_dista
     of the pool for logging purposes as second element.
     """
 
-    finder = HomeSystemFinder(num_home_systems)
+    finder = HomeSystemFinder(len_systems, num_home_systems)
     # try to find home systems, decrease the min jumps until enough systems can be found, or the jump distance drops
     # below the specified minimum jump distance (which means failure)
     while jump_distance >= min_jump_distance:
@@ -384,7 +385,7 @@ def compile_home_system_list(num_home_systems, systems, gsd):
         # specify 0 as number of requested home systems to pick as much systems as possible
         (pool_matching_sys_limit, "pool of systems that meet at least the min systems limit"),
     ]
-    home_systems = find_home_systems(num_home_systems, pool_list, min_jumps, HS_MIN_DISTANCE_PRIORITY_LIMIT)
+    home_systems = find_home_systems(len(systems), num_home_systems, pool_list, min_jumps, HS_MIN_DISTANCE_PRIORITY_LIMIT)
 
     # check if the first attempt delivered a list with enough home systems
     # if not, we make our second attempt, this time disregarding the filtered pools and using all systems, starting
@@ -392,7 +393,7 @@ def compile_home_system_list(num_home_systems, systems, gsd):
     # systems as possible
     if len(home_systems) < num_home_systems:
         print "Second attempt: trying to pick home systems from all systems"
-        home_systems = find_home_systems(num_home_systems, [(systems, "complete pool")], min_jumps, 1)
+        home_systems = find_home_systems(len(systems), num_home_systems, [(systems, "complete pool")], min_jumps, 1)
 
     # check if the selection process delivered a list with enough home systems
     # if not, our galaxy obviously is too crowded, report an error and return an empty list

--- a/default/python/universe_generation/empires.py
+++ b/default/python/universe_generation/empires.py
@@ -3,7 +3,7 @@ import random
 
 import freeorion as fo
 
-from galaxy import get_systems_within_jumps
+from galaxy_topology import get_systems_within_jumps
 from starsystems import star_types_real, pick_star_type
 from planets import calc_planet_size, calc_planet_type, planet_sizes_real, planet_types_real
 from names import get_name_list, random_name

--- a/default/python/universe_generation/empires.py
+++ b/default/python/universe_generation/empires.py
@@ -87,11 +87,10 @@ def min_planets_in_vicinity_limit(num_systems):
 
 class HomeSystemFinder(object):
     """Finds a set of home systems with a least ''num_home_systems'' systems."""
-    def __init__(self, _len_systems, _num_home_systems):
+    def __init__(self, _num_home_systems):
         # cache of sytem merits
         self.system_merit = {}
         self.num_home_systems = _num_home_systems
-        self.len_systems = _len_systems
 
     def find_home_systems_for_min_jump_distance(self, systems_pool, min_jumps):
         """
@@ -130,13 +129,13 @@ class HomeSystemFinder(object):
         # (999, 39) and (199, 19) the following was observered.  The distribution of candidate
         # length is a normal random variable with standard deviation approximately equal to
 
-        # expected_len_candidate_std = (self.len_systems ** (1.0/2.0)) * 0.03
+        # expected_len_candidate_std = (len(systems) ** (1.0/2.0)) * 0.03
 
         # which is about 1 for 1000 systems.  It is likely that anylen(candidate) is within 1
         # standard deviation of the expected len(candidate)
 
-        # If we are within the miss_threshold of the target then try up to num_complete_misses more times.
-        miss_threshold = 3
+        # If we are within the MISS_THRESHOLD of the target then try up to num_complete_misses more times.
+        MISS_THRESHOLD = 3
         num_complete_misses_remaining = 4
 
         # Cap the number of attempts to the smaller of the number of systems in the pool, or 100
@@ -166,7 +165,7 @@ class HomeSystemFinder(object):
                 local_pool -= set(get_systems_within_jumps(member, min_jumps))
 
             # Count complete misses when number of candidates is not close to the target.
-            if len(candidate) < (self.num_home_systems - miss_threshold):
+            if len(candidate) < (self.num_home_systems - MISS_THRESHOLD):
                 num_complete_misses_remaining -= 1
 
             if len(candidate) < self.num_home_systems:
@@ -193,7 +192,7 @@ class HomeSystemFinder(object):
         return best_candidate
 
 
-def find_home_systems(len_systems, num_home_systems, pool_list, jump_distance, min_jump_distance):
+def find_home_systems(num_home_systems, pool_list, jump_distance, min_jump_distance):
     """
     Tries to find a specified number of home systems which are as far apart from each other as possible.
     Starts with the specified jump distance and reduces that limit until enough systems can be found or the
@@ -203,7 +202,7 @@ def find_home_systems(len_systems, num_home_systems, pool_list, jump_distance, m
     of the pool for logging purposes as second element.
     """
 
-    finder = HomeSystemFinder(len_systems, num_home_systems)
+    finder = HomeSystemFinder(num_home_systems)
     # try to find home systems, decrease the min jumps until enough systems can be found, or the jump distance drops
     # below the specified minimum jump distance (which means failure)
     while jump_distance >= min_jump_distance:
@@ -378,7 +377,7 @@ def compile_home_system_list(num_home_systems, systems, gsd):
         # specify 0 as number of requested home systems to pick as much systems as possible
         (pool_matching_sys_limit, "pool of systems that meet at least the min systems limit"),
     ]
-    home_systems = find_home_systems(len(systems), num_home_systems, pool_list, min_jumps, HS_MIN_DISTANCE_PRIORITY_LIMIT)
+    home_systems = find_home_systems(num_home_systems, pool_list, min_jumps, HS_MIN_DISTANCE_PRIORITY_LIMIT)
 
     # check if the first attempt delivered a list with enough home systems
     # if not, we make our second attempt, this time disregarding the filtered pools and using all systems, starting
@@ -386,7 +385,7 @@ def compile_home_system_list(num_home_systems, systems, gsd):
     # systems as possible
     if len(home_systems) < num_home_systems:
         print "Second attempt: trying to pick home systems from all systems"
-        home_systems = find_home_systems(len(systems), num_home_systems, [(systems, "complete pool")], min_jumps, 1)
+        home_systems = find_home_systems(num_home_systems, [(systems, "complete pool")], min_jumps, 1)
 
     # check if the selection process delivered a list with enough home systems
     # if not, our galaxy obviously is too crowded, report an error and return an empty list

--- a/default/python/universe_generation/empires.py
+++ b/default/python/universe_generation/empires.py
@@ -135,6 +135,11 @@ class HomeSystemFinder(object):
             local_pool = {s for (m, s) in all_merit_system}
 
             if len(local_pool) < self.num_home_systems:
+                if len(best_candidate) < self.num_home_systems:
+                    print ("Failing in find_home_systems_for_min_jump_distance because "
+                           "current_merit_lower_bound = {} trims local pool to {} systems "
+                           "which is less than num_home_systems {}.".format(
+                               current_merit_lower_bound, len(local_pool), self.num_home_systems))
                 break
 
             attempts = min(attempts - 1, len(local_pool))

--- a/default/python/universe_generation/empires.py
+++ b/default/python/universe_generation/empires.py
@@ -119,7 +119,6 @@ class HomeSystemFinder(object):
         # can be achieved.
         all_merit_system = sorted([(self.system_merit[s], s)
                                    for s in systems_pool], reverse=True)
-        (best_case_merit_lower_bound, _) = all_merit_system[self.num_home_systems - 1]
         current_merit_lower_bound = 0
 
         best_candidate = []
@@ -171,10 +170,6 @@ class HomeSystemFinder(object):
 
             # Quit if the lowest merit planet meets the minimum threshold
             if merit >= min_planets_in_vicinity_limit(get_systems_within_jumps(system, HS_VICINITY_RANGE)):
-                break
-
-            # quit if it isn't possible to improve the current accepted list
-            if merit >= best_case_merit_lower_bound:
                 break
 
             # If we have a better candidate, set the new lower bound one higher to try for a better candidate.

--- a/default/python/universe_generation/empires.py
+++ b/default/python/universe_generation/empires.py
@@ -156,7 +156,8 @@ class HomeSystemFinder(object):
             # quit if it isn't possible to improve the current accepted list
             if merit >= best_case_merit_lower_bound:
                 break
-            attempts -= 1
+
+            attempts = min(attempts - 1, len(local_pool))
         return best_candidate
 
 

--- a/default/python/universe_generation/empires.py
+++ b/default/python/universe_generation/empires.py
@@ -1,5 +1,6 @@
 import os.path
 import random
+import statistics
 
 import freeorion as fo
 
@@ -12,7 +13,6 @@ from options import (HS_ACCEPTABLE_PLANET_TYPES, HS_MIN_PLANETS_IN_VICINITY_TOTA
                      HS_VICINITY_RANGE, HS_MIN_SYSTEMS_IN_VICINITY, HS_ACCEPTABLE_PLANET_SIZES)
 
 from util import load_string_list, report_error
-import statistics
 
 
 def get_empire_name_generator():
@@ -321,7 +321,8 @@ def compile_home_system_list(num_home_systems, systems, gsd):
             pool_matching_sys_limit.append(system)
             if count_planets_in_systems(systems_in_vicinity) >= min_planets_in_vicinity_limit(len(systems_in_vicinity)):
                 pool_matching_sys_and_planet_limit.append(system)
-    print len(pool_matching_sys_and_planet_limit), "systems meet the min systems and planets in the near vicinity limit"
+    print (len(pool_matching_sys_and_planet_limit),
+           "systems meet the min systems and planets in the near vicinity limit")
     print len(pool_matching_sys_limit), "systems meet the min systems in the near vicinity limit"
 
     # now try to pick the requested number of home systems

--- a/default/python/universe_generation/empires.py
+++ b/default/python/universe_generation/empires.py
@@ -157,11 +157,9 @@ class HomeSystemFinder(object):
             # Calculate the merit of the current attempt.  If it is the best so far
             # keep it and update the merit_threshold
             merit_system = sorted([(self.system_merit[s], s)
-                                   for s in candidate])[:self.num_home_systems]
-            merit = merit_system[-1]
-            if merit > current_merit_lower_bound:
-                current_merit_lower_bound = merit
-                best_candidate = [s for (_, s) in merit_system]
+                                   for s in candidate], reverse=True)[:self.num_home_systems]
+
+            (merit, system) = merit_system[-1]
 
             # quit if it isn't possible to improve the current accepted list
             if merit >= best_case_merit_lower_bound:

--- a/default/python/universe_generation/empires.py
+++ b/default/python/universe_generation/empires.py
@@ -168,16 +168,15 @@ class HomeSystemFinder(object):
 
             (merit, system) = merit_system[-1]
 
-            # Quit if the lowest merit planet meets the minimum threshold
-            if merit >= min_planets_in_vicinity_limit(get_systems_within_jumps(system, HS_VICINITY_RANGE)):
-                break
-
             # If we have a better candidate, set the new lower bound and try for a better candidate.
             if merit >= current_merit_lower_bound:
                 print ("Home system merit lower bound improved from {} to "
                        "{}".format(current_merit_lower_bound, merit))
                 current_merit_lower_bound = merit
                 best_candidate = [s for (_, s) in merit_system]
+                # Quit sucessfully if the lowest merit planet meets the minimum threshold
+                if merit >= min_planets_in_vicinity_limit(get_systems_within_jumps(system, HS_VICINITY_RANGE)):
+                    break
 
         return best_candidate
 

--- a/default/python/universe_generation/empires.py
+++ b/default/python/universe_generation/empires.py
@@ -1,6 +1,5 @@
 import os.path
 import random
-import statistics
 
 import freeorion as fo
 
@@ -13,6 +12,7 @@ from options import (HS_ACCEPTABLE_PLANET_TYPES, HS_MIN_PLANETS_IN_VICINITY_TOTA
                      HS_VICINITY_RANGE, HS_MIN_SYSTEMS_IN_VICINITY, HS_ACCEPTABLE_PLANET_SIZES)
 
 from util import load_string_list, report_error
+import statistics
 
 
 def get_empire_name_generator():

--- a/default/python/universe_generation/empires.py
+++ b/default/python/universe_generation/empires.py
@@ -185,7 +185,7 @@ class HomeSystemFinder(object):
             (merit, system) = merit_system[-1]
 
             # If we have a better candidate, set the new lower bound and try for a better candidate.
-            if merit >= current_merit_lower_bound:
+            if merit > current_merit_lower_bound:
                 print ("Home system set merit lower bound improved from {} to "
                        "{}".format(current_merit_lower_bound, merit))
                 current_merit_lower_bound = merit

--- a/default/python/universe_generation/empires.py
+++ b/default/python/universe_generation/empires.py
@@ -152,7 +152,7 @@ class HomeSystemFinder(object):
             local_pool = {s for (m, s) in all_merit_system}
 
             if len(local_pool) < self.num_home_systems:
-                if len(best_candidate) < self.num_home_systems:
+                if not best_candidate:
                     print ("Failing in find_home_systems_for_min_jump_distance because "
                            "current_merit_lower_bound = {} trims local pool to {} systems "
                            "which is less than num_home_systems {}.".format(

--- a/default/python/universe_generation/empires.py
+++ b/default/python/universe_generation/empires.py
@@ -134,6 +134,8 @@ class HomeSystemFinder(object):
             if len(local_pool) < self.num_home_systems:
                 break
 
+            attempts = min(attempts - 1, len(local_pool))
+
             while local_pool:
                 member = random.choice(list(local_pool))
                 candidate.append(member)
@@ -157,7 +159,6 @@ class HomeSystemFinder(object):
             if merit >= best_case_merit_lower_bound:
                 break
 
-            attempts = min(attempts - 1, len(local_pool))
         return best_candidate
 
 

--- a/default/python/universe_generation/empires.py
+++ b/default/python/universe_generation/empires.py
@@ -172,11 +172,11 @@ class HomeSystemFinder(object):
             if merit >= min_planets_in_vicinity_limit(get_systems_within_jumps(system, HS_VICINITY_RANGE)):
                 break
 
-            # If we have a better candidate, set the new lower bound one higher to try for a better candidate.
+            # If we have a better candidate, set the new lower bound and try for a better candidate.
             if merit >= current_merit_lower_bound:
                 print ("Home system merit lower bound improved from {} to "
-                       "{}".format(current_merit_lower_bound, merit + 1))
-                current_merit_lower_bound = merit + 1
+                       "{}".format(current_merit_lower_bound, merit))
+                current_merit_lower_bound = merit
                 best_candidate = [s for (_, s) in merit_system]
 
         return best_candidate

--- a/default/python/universe_generation/empires.py
+++ b/default/python/universe_generation/empires.py
@@ -113,7 +113,7 @@ class HomeSystemFinder(object):
             if system not in self.system_merit:
                 self.system_merit[system] = calculate_home_system_merit(system)
 
-        # The list of merits and systems reverse sorted by merit.
+        # The list of merits and systems sorted in descending order by merit.
         all_merit_system = sorted([(self.system_merit[s], s)
                                    for s in systems_pool], reverse=True)
 

--- a/default/python/universe_generation/empires.py
+++ b/default/python/universe_generation/empires.py
@@ -103,8 +103,8 @@ class HomeSystemFinder(object):
         Make several attempts to find systems that match the condition
         of being at least min_jumps apart.
         Use the minimum merit of the best num_home_system systems found
-        as the merit of the current best set of systems.
-        On each attempt use the merit of the current best set of home
+        to compare the candidate with the current best set of systems.
+        On each attempt use the minimum merit of the current best set of home
         systems to truncate the pool of candidates.
         """
 
@@ -113,18 +113,12 @@ class HomeSystemFinder(object):
             if system not in self.system_merit:
                 self.system_merit[system] = calculate_home_system_merit(system)
 
-        # In the list of systems reverse sorted by merit, if the first
-        # num_home_systems are all min_jumps apart, then the merit of the
-        # num_home_systems nth system is the best_case_merit_lower_bound that
-        # can be achieved.
+        # The list of merits and systems reverse sorted by merit.
         all_merit_system = sorted([(self.system_merit[s], s)
                                    for s in systems_pool], reverse=True)
+
         current_merit_lower_bound = 0
-
         best_candidate = []
-
-        # cap the number of attempts to the smaller of the number of systems in the pool, or 100
-        attempts = min(100, len(systems_pool))
 
         # Cap the number of attempts when the found number of systems is less than the target
         # num_home_systems because this indicates that the min_jumps is too large and/or the
@@ -145,6 +139,9 @@ class HomeSystemFinder(object):
             len(systems_pool), expected_len_candidate_std, lowest_continuable_mean_len_of_candidates))
 
         lens_of_failed_candidates = []
+
+        # Cap the number of attempts to the smaller of the number of systems in the pool, or 100
+        attempts = min(100, len(systems_pool))
 
         while attempts:
             # use a local pool of all candidate systems better than the worst threshold merit
@@ -189,13 +186,13 @@ class HomeSystemFinder(object):
 
             # If we have a better candidate, set the new lower bound and try for a better candidate.
             if merit >= current_merit_lower_bound:
-                print ("Home system merit lower bound improved from {} to "
+                print ("Home system set merit lower bound improved from {} to "
                        "{}".format(current_merit_lower_bound, merit))
                 current_merit_lower_bound = merit
                 best_candidate = [s for (_, s) in merit_system]
                 lens_of_failed_candidates = []
 
-                # Quit sucessfully if the lowest merit planet meets the minimum threshold
+                # Quit sucessfully if the lowest merit system meets the minimum threshold
                 if merit >= min_planets_in_vicinity_limit(get_systems_within_jumps(system, HS_VICINITY_RANGE)):
                     break
 

--- a/default/python/universe_generation/empires.py
+++ b/default/python/universe_generation/empires.py
@@ -113,10 +113,13 @@ class HomeSystemFinder(object):
             if system not in self.system_merit:
                 self.system_merit[system] = calculate_home_system_merit(system)
 
-        # In the list of systems sorted by merit, if the first num_home_systems are all min_jumps
-        # apart, then the merit of the num_home_systems nth system is the
-        # best_case_merit_lower_bound that can be achieved.
-        best_case_merit_lower_bound = sorted(self.system_merit.values())[self.num_home_systems - 1]
+        # In the list of systems reverse sorted by merit, if the first
+        # num_home_systems are all min_jumps apart, then the merit of the
+        # num_home_systems nth system is the best_case_merit_lower_bound that
+        # can be achieved.
+        all_merit_system = sorted([(self.system_merit[s], s)
+                                   for s in systems_pool], reverse=True)
+        (best_case_merit_lower_bound, _) = all_merit_system[self.num_home_systems - 1]
         current_merit_lower_bound = 0
 
         best_candidate = []
@@ -124,13 +127,13 @@ class HomeSystemFinder(object):
         # cap the number of attempts to the smaller of the number of systems in the pool, or 100
         attempts = min(100, len(systems_pool))
 
-        # Copy systems_pool to avoid aliasing of the caller's systems_pool variable
-        local_pool = set(systems_pool)
 
         while attempts:
             candidate = []
             # use a local pool of all candidate systems better than the worst threshold merit
-            local_pool = {s for s in local_pool if self.system_merit[s] > current_merit_lower_bound}
+            all_merit_system = [(m, s) for (m, s) in all_merit_system if m > current_merit_lower_bound]
+            local_pool = {s for (m, s) in all_merit_system}
+
             if len(local_pool) < self.num_home_systems:
                 break
 

--- a/default/python/universe_generation/galaxy.py
+++ b/default/python/universe_generation/galaxy.py
@@ -379,27 +379,6 @@ def calc_universe_width(shape, size):
     return width
 
 
-def get_systems_within_jumps(origin_system, jumps):
-    """
-    Returns all systems within jumps jumps of system origin_system (including origin_system).
-    If jumps is 0, return list that only contains system origin_system.
-    If jumps is negative, return empty list.
-    """
-    if jumps < 0:
-        return []
-    matching_systems = [origin_system]
-    next_origin_systems = [origin_system]
-    while jumps > 0:
-        origin_systems = list(next_origin_systems)
-        next_origin_systems = []
-        for system in origin_systems:
-            neighbor_systems = [s for s in fo.sys_get_starlanes(system) if s not in matching_systems]
-            next_origin_systems.extend(neighbor_systems)
-            matching_systems.extend(neighbor_systems)
-        jumps -= 1
-    return matching_systems
-
-
 def spiral_galaxy_calc_positions(positions, adjacency_grid, arms, size, width):
     """
     Calculate positions for the spiral galaxy shapes.

--- a/default/python/universe_generation/galaxy.py
+++ b/default/python/universe_generation/galaxy.py
@@ -286,7 +286,8 @@ def stitching_positions(p1, p2):
     Returns a list of positions between p1 and p2 between MIN_SYSTEM_SEPARATION and MAX_STARLANE_LENGTH apart
     """
     if 2 * universe_tables.MIN_SYSTEM_SEPARATION >= universe_tables.MAX_STARLANE_LENGTH:
-        util.report_error("MAX_STARLANE_LENGTH must be twice MIN_SYSTEM_SEPARATION to allow extra positions to be added to enforce MAX_STARLANE_LENGTH")
+        util.report_error("MAX_STARLANE_LENGTH must be twice MIN_SYSTEM_SEPARATION to "
+                          "allow extra positions to be added to enforce MAX_STARLANE_LENGTH")
         return []
 
     max_dist = universe_tables.MAX_STARLANE_LENGTH
@@ -297,7 +298,7 @@ def stitching_positions(p1, p2):
 
     # Pick a random point in an 2:1 ratio ellipse and then rotate and slide it in between p1 and p2
     p1_p2_theta = acos((p2[0] - p1[0]) / p1_p2_dist)
-    p1_p2_scale = (p1_p2_dist - 2*min_dist) / 2
+    p1_p2_scale = (p1_p2_dist - 2 * min_dist) / 2
     p1_p2_translation = ((p1[0] + p2[0]) / 2, (p1[1] + p2[1]) / 2)
 
     radius_0space = uniform(0.0, 1.0)

--- a/default/python/universe_generation/galaxy.py
+++ b/default/python/universe_generation/galaxy.py
@@ -298,7 +298,7 @@ def stitching_positions(p1, p2):
 
     # Pick a random point in an 2:1 ratio ellipse and then rotate and slide it in between p1 and p2
     p1_p2_theta = acos((p2[0] - p1[0]) / p1_p2_dist)
-    p1_p2_scale = (p1_p2_dist - 2 * min_dist) / 2
+    p1_p2_scale = (p1_p2_dist - 2*min_dist) / 2
     p1_p2_translation = ((p1[0] + p2[0]) / 2, (p1[1] + p2[1]) / 2)
 
     radius_0space = uniform(0.0, 1.0)

--- a/default/python/universe_generation/galaxy_topology.py
+++ b/default/python/universe_generation/galaxy_topology.py
@@ -4,7 +4,7 @@ import freeorion as fo
 def get_systems_within_jumps(origin_system, jumps):
     """
     Returns all systems within jumps jumps of system origin_system (including origin_system).
-    If jumps is 0, return list that only contains system origin_system.
+    If jumps is 0, return list that only contains origin_system.
     If jumps is negative, return empty list.
     """
     # TODO use a priority queue or at least sets

--- a/default/python/universe_generation/galaxy_topology.py
+++ b/default/python/universe_generation/galaxy_topology.py
@@ -1,0 +1,24 @@
+import freeorion as fo
+
+
+def get_systems_within_jumps(origin_system, jumps):
+    """
+    Returns all systems within jumps jumps of system origin_system (including origin_system).
+    If jumps is 0, return list that only contains system origin_system.
+    If jumps is negative, return empty list.
+    """
+    # TODO use a priority queue or at least sets
+    # TODO move to C++ and use boost::graph
+    if jumps < 0:
+        return []
+    matching_systems = [origin_system]
+    next_origin_systems = [origin_system]
+    while jumps > 0:
+        origin_systems = list(next_origin_systems)
+        next_origin_systems = []
+        for system in origin_systems:
+            neighbor_systems = [s for s in fo.sys_get_starlanes(system) if s not in matching_systems]
+            next_origin_systems.extend(neighbor_systems)
+            matching_systems.extend(neighbor_systems)
+        jumps -= 1
+    return matching_systems

--- a/default/python/universe_generation/monsters.py
+++ b/default/python/universe_generation/monsters.py
@@ -144,18 +144,16 @@ def generate_monsters(monster_freq, systems):
     # required to prevent their placement from disjoining the map
     starlane_altering_monsters = StarlaneAlteringMonsters(systems)
 
+    # collect info for tracked monster nest valid locations
+    planets = [p for s in systems for p in fo.sys_get_planets(s)]
+    for nest in tracked_nest_valid_locations:
+        tracked_nest_valid_locations[nest] = len(fo.special_locations(nest, planets))
+
     # for each system in the list that has been passed to this function, find a monster fleet that can be spawned at
     # the system and which hasn't already been added too many times, then attempt to add that monster fleet by
     # testing the spawn rate chance
     random.shuffle(systems)
     for system in systems:
-        # collect info for tracked monster nest valid locations
-        for planet in fo.sys_get_planets(system):
-            for nest in tracked_nest_valid_locations:
-                # print "\t tracked monster check planet: %d size: %s for nest: %20s  | result: %s"
-                # % (planet, fo.planet_get_size(planet), nest, fo.special_location(nest, planet))
-                if fo.special_location(nest, planet):
-                    tracked_nest_valid_locations[nest] += 1
 
         # collect info for tracked monster valid locations
         for fp in tracked_plan_valid_locations:

--- a/default/python/universe_generation/monsters.py
+++ b/default/python/universe_generation/monsters.py
@@ -1,11 +1,12 @@
 import random
 import itertools
+import statistics
 import freeorion as fo
 from util import MapGenerationError, report_error
 from galaxy_topology import get_systems_within_jumps
-import statistics
 import universe_tables
 from galaxy import DisjointSets
+
 
 
 class StarlaneAlteringMonsters(object):
@@ -131,7 +132,8 @@ def generate_monsters(monster_freq, _systems, home_systems):
     systems = [s for s in _systems if s not in empire_exclusions]
 
     # Fleet plans that include ships capable of altering starlanes.
-    ## @content_tag{CAN_ALTER_STARLANES} universe_generator special handling for fleets containing a hull design with this tag.
+    # @content_tag{CAN_ALTER_STARLANES} universe_generator special handling for
+    # fleets containing a hull design with this tag.
     fleet_can_alter_starlanes = {fp for fp in fleet_plans
                                  if any([universe.getGenericShipDesign(design).hull_type.hasTag("CAN_ALTER_STARLANES")
                                          for design in fp.ship_designs()])}
@@ -144,7 +146,8 @@ def generate_monsters(monster_freq, _systems, home_systems):
         print "/ spawn limit", fleet_plan.spawn_limit(),
         print "/ effective chance", basic_chance * fleet_plan.spawn_rate(),
         fp_location_cache[fleet_plan] = set(fleet_plan.locations(systems))
-        print "/ can be spawned at", len([x == True for x in fp_location_cache[fleet_plan]]), "of", len(systems), "systems"
+        print ("/ can be spawned at", len([x is True for x in fp_location_cache[fleet_plan]]),
+               "of", len(systems), "systems")
         if fleet_plan.name() in nest_name_map.values():
             statistics.tracked_monsters_chance[fleet_plan.name()] = basic_chance * fleet_plan.spawn_rate()
 
@@ -203,8 +206,8 @@ def generate_monsters(monster_freq, _systems, home_systems):
             # decrement counter for this monster fleet
             spawn_limits[fleet_plan] -= 1
 
-        except MapGenerationError as e:
-            report_error(str(e))
+        except MapGenerationError as err:
+            report_error(str(err))
             continue
 
     print "Actual # monster fleets placed: %d; Total Placement Expectation: %.1f" % (actual_tally, expectation_tally)

--- a/default/python/universe_generation/monsters.py
+++ b/default/python/universe_generation/monsters.py
@@ -130,17 +130,13 @@ def generate_monsters(monster_freq, systems):
 
     # dump a list of all monster fleets meeting these conditions and their properties to the log
     print "Monster fleets available for generation at game start:"
+    fp_location_cache = {}
     for fleet_plan in fleet_plans:
         print "...", fleet_plan.name(), ": spawn rate", fleet_plan.spawn_rate(),
         print "/ spawn limit", fleet_plan.spawn_limit(),
         print "/ effective chance", basic_chance * fleet_plan.spawn_rate(),
-
-        if len(systems) < 100:
-            # Note: The WithinStarlaneJumps condition in fp.location()
-            # is the most time costly function in universe generation
-            print "/ can be spawned at", len([s for s in systems if fleet_plan.location(s)]), "systems"
-        else:
-            print  # to terminate the print line
+        fp_location_cache[fleet_plan] = set(fleet_plan.locations(systems))
+        print "/ can be spawned at", len([x == True for x in fp_location_cache[fleet_plan]]), "of", len(systems), "systems"
         if fleet_plan.name() in nest_name_map.values():
             statistics.tracked_monsters_chance[fleet_plan.name()] = basic_chance * fleet_plan.spawn_rate()
 
@@ -162,15 +158,13 @@ def generate_monsters(monster_freq, systems):
 
         # collect info for tracked monster valid locations
         for fp in tracked_plan_valid_locations:
-            if fp.location(system):
+            if system in fp_location_cache[fp]:
                 tracked_plan_valid_locations[fp] += 1
 
         # filter out all monster fleets whose location condition allows this system and whose counter hasn't reached 0.
-        # Note: The WithinStarlaneJumps condition in fp.location() is
-        # the most time costly function in universe generation.
         suitable_fleet_plans = [fp for fp in fleet_plans
-                                if spawn_limits[fp]
-                                and fp.location(system)
+                                if system in fp_location_cache[fp]
+                                and spawn_limits[fp]
                                 and (fp not in fleet_can_alter_starlanes
                                      or starlane_altering_monsters.can_place_at(system, fp))]
         # if there are no suitable monster fleets for this system, continue with the next

--- a/default/python/universe_generation/monsters.py
+++ b/default/python/universe_generation/monsters.py
@@ -147,6 +147,7 @@ def generate_monsters(monster_freq, systems):
     # for each system in the list that has been passed to this function, find a monster fleet that can be spawned at
     # the system and which hasn't already been added too many times, then attempt to add that monster fleet by
     # testing the spawn rate chance
+    random.shuffle(systems)
     for system in systems:
         # collect info for tracked monster nest valid locations
         for planet in fo.sys_get_planets(system):

--- a/default/python/universe_generation/monsters.py
+++ b/default/python/universe_generation/monsters.py
@@ -1,6 +1,8 @@
 import random
+import itertools
 import freeorion as fo
 from util import MapGenerationError, report_error
+from galaxy_topology import get_systems_within_jumps
 import statistics
 import universe_tables
 from galaxy import DisjointSets
@@ -81,7 +83,7 @@ def populate_monster_fleet(fleet_plan, system):
     print "Spawn", fleet_plan.name(), "at", fo.get_name(system)
 
 
-def generate_monsters(monster_freq, systems):
+def generate_monsters(monster_freq, _systems, home_systems):
     """
     Adds space monsters to systems.
     """
@@ -122,6 +124,12 @@ def generate_monsters(monster_freq, systems):
 
     universe = fo.get_universe()
 
+    EMPIRE_TO_MONSTER_MIN_DIST = 2
+    empire_exclusions = set(list(itertools.chain.from_iterable(
+        [get_systems_within_jumps(e, EMPIRE_TO_MONSTER_MIN_DIST)
+         for e in home_systems])))
+    systems = [s for s in _systems if s not in empire_exclusions]
+
     # Fleet plans that include ships capable of altering starlanes.
     ## @content_tag{CAN_ALTER_STARLANES} universe_generator special handling for fleets containing a hull design with this tag.
     fleet_can_alter_starlanes = {fp for fp in fleet_plans
@@ -154,7 +162,6 @@ def generate_monsters(monster_freq, systems):
     # testing the spawn rate chance
     random.shuffle(systems)
     for system in systems:
-
         # collect info for tracked monster valid locations
         for fp in tracked_plan_valid_locations:
             if system in fp_location_cache[fp]:

--- a/default/python/universe_generation/monsters.py
+++ b/default/python/universe_generation/monsters.py
@@ -1,12 +1,9 @@
 import random
-import itertools
 import freeorion as fo
 from util import MapGenerationError, report_error
-from galaxy_topology import get_systems_within_jumps
 import statistics
 import universe_tables
 from galaxy import DisjointSets
-
 
 
 class StarlaneAlteringMonsters(object):
@@ -84,7 +81,7 @@ def populate_monster_fleet(fleet_plan, system):
     print "Spawn", fleet_plan.name(), "at", fo.get_name(system)
 
 
-def generate_monsters(monster_freq, _systems, home_systems):
+def generate_monsters(monster_freq, systems):
     """
     Adds space monsters to systems.
     """
@@ -123,12 +120,6 @@ def generate_monsters(monster_freq, _systems, home_systems):
         return
 
     universe = fo.get_universe()
-
-    EMPIRE_TO_MONSTER_MIN_DIST = 2
-    empire_exclusions = set(itertools.chain.from_iterable(
-        get_systems_within_jumps(e, EMPIRE_TO_MONSTER_MIN_DIST)
-        for e in home_systems))
-    systems = [s for s in _systems if s not in empire_exclusions]
 
     # Fleet plans that include ships capable of altering starlanes.
     # @content_tag{CAN_ALTER_STARLANES} universe_generator special handling for fleets containing a hull design with this tag.

--- a/default/python/universe_generation/monsters.py
+++ b/default/python/universe_generation/monsters.py
@@ -131,8 +131,7 @@ def generate_monsters(monster_freq, _systems, home_systems):
     systems = [s for s in _systems if s not in empire_exclusions]
 
     # Fleet plans that include ships capable of altering starlanes.
-    # @content_tag{CAN_ALTER_STARLANES} universe_generator special handling for
-    # fleets containing a hull design with this tag.
+    # @content_tag{CAN_ALTER_STARLANES} universe_generator special handling for fleets containing a hull design with this tag.
     fleet_can_alter_starlanes = {fp for fp in fleet_plans
                                  if any([universe.getGenericShipDesign(design).hull_type.hasTag("CAN_ALTER_STARLANES")
                                          for design in fp.ship_designs()])}

--- a/default/python/universe_generation/monsters.py
+++ b/default/python/universe_generation/monsters.py
@@ -118,7 +118,6 @@ def generate_monsters(monster_freq, _systems, home_systems):
     tracked_plan_tries = {name: 0 for name in nest_name_map.values()}
     tracked_plan_counts = {name: 0 for name in nest_name_map.values()}
     tracked_plan_valid_locations = {fp: 0 for fp in fleet_plans if fp.name() in tracked_plan_counts}
-    tracked_nest_valid_locations = {nest: 0 for nest in nest_name_map}
 
     if not fleet_plans:
         return
@@ -126,9 +125,9 @@ def generate_monsters(monster_freq, _systems, home_systems):
     universe = fo.get_universe()
 
     EMPIRE_TO_MONSTER_MIN_DIST = 2
-    empire_exclusions = set(list(itertools.chain.from_iterable(
-        [get_systems_within_jumps(e, EMPIRE_TO_MONSTER_MIN_DIST)
-         for e in home_systems])))
+    empire_exclusions = set(itertools.chain.from_iterable(
+        get_systems_within_jumps(e, EMPIRE_TO_MONSTER_MIN_DIST)
+        for e in home_systems))
     systems = [s for s in _systems if s not in empire_exclusions]
 
     # Fleet plans that include ships capable of altering starlanes.
@@ -146,7 +145,7 @@ def generate_monsters(monster_freq, _systems, home_systems):
         print "/ spawn limit", fleet_plan.spawn_limit(),
         print "/ effective chance", basic_chance * fleet_plan.spawn_rate(),
         fp_location_cache[fleet_plan] = set(fleet_plan.locations(systems))
-        print ("/ can be spawned at", len([x is True for x in fp_location_cache[fleet_plan]]),
+        print ("/ can be spawned at", len(fp_location_cache[fleet_plan]),
                "of", len(systems), "systems")
         if fleet_plan.name() in nest_name_map.values():
             statistics.tracked_monsters_chance[fleet_plan.name()] = basic_chance * fleet_plan.spawn_rate()
@@ -157,8 +156,8 @@ def generate_monsters(monster_freq, _systems, home_systems):
 
     # collect info for tracked monster nest valid locations
     planets = [p for s in systems for p in fo.sys_get_planets(s)]
-    for nest in tracked_nest_valid_locations:
-        tracked_nest_valid_locations[nest] = len(fo.special_locations(nest, planets))
+    tracked_nest_valid_locations = {nest: len(fo.special_locations(nest, planets))
+                                    for nest in nest_name_map}
 
     # for each system in the list that has been passed to this function, find a monster fleet that can be spawned at
     # the system and which hasn't already been added too many times, then attempt to add that monster fleet by

--- a/default/python/universe_generation/monsters.py
+++ b/default/python/universe_generation/monsters.py
@@ -1,9 +1,9 @@
 import random
 import itertools
-import statistics
 import freeorion as fo
 from util import MapGenerationError, report_error
 from galaxy_topology import get_systems_within_jumps
+import statistics
 import universe_tables
 from galaxy import DisjointSets
 

--- a/default/python/universe_generation/natives.py
+++ b/default/python/universe_generation/natives.py
@@ -1,10 +1,10 @@
 import random
 import itertools
+import statistics
 
 import freeorion as fo
 
 import planets
-import statistics
 import universe_tables
 from galaxy_topology import get_systems_within_jumps
 

--- a/default/python/universe_generation/natives.py
+++ b/default/python/universe_generation/natives.py
@@ -28,9 +28,9 @@ def generate_natives(native_freq, systems, empire_home_systems):
     # select only planets sufficiently far away from player home systems
     # list of planets safe for natives
     EMPIRE_TO_NATIVE_MIN_DIST = 2
-    empire_exclusions = set(list(itertools.chain.from_iterable(
-        [get_systems_within_jumps(e, EMPIRE_TO_NATIVE_MIN_DIST)
-         for e in empire_home_systems])))
+    empire_exclusions = set(itertools.chain.from_iterable(
+        get_systems_within_jumps(e, EMPIRE_TO_NATIVE_MIN_DIST)
+        for e in empire_home_systems))
     native_safe_planets = set(itertools.chain.from_iterable(
         [fo.sys_get_planets(s) for s in systems if s not in empire_exclusions]))
 

--- a/default/python/universe_generation/natives.py
+++ b/default/python/universe_generation/natives.py
@@ -1,10 +1,10 @@
 import random
 import itertools
-import statistics
 
 import freeorion as fo
 
 import planets
+import statistics
 import universe_tables
 from galaxy_topology import get_systems_within_jumps
 

--- a/default/python/universe_generation/specials.py
+++ b/default/python/universe_generation/specials.py
@@ -1,8 +1,8 @@
 import random
 from collections import defaultdict
-import statistics
 
 import freeorion as fo
+import statistics
 import universe_tables
 from galaxy_topology import get_systems_within_jumps
 

--- a/default/python/universe_generation/specials.py
+++ b/default/python/universe_generation/specials.py
@@ -26,11 +26,17 @@ def calculate_number_of_specials_to_place(objs):
 
 
 def place_special(specials, obj):
-    """ Place a single special."""
+    """
+    Place at most a single special.
+    Return the number of specials placed.
+    """
     # Calculate the conditional probabilities that each special is
     # placed here given that a special will be placed here.
     probs = [fo.special_spawn_rate(sp) for sp in specials]
-    total_prob = sum(probs)
+    total_prob = float(sum(probs))
+    if total_prob == 0:
+        # This shouldn't happen since special_spawn_rate > 0.0 is checked in distribute_specials()
+        return 0
     thresholds = [x / total_prob for x in probs]
 
     chance = random.random()
@@ -43,7 +49,8 @@ def place_special(specials, obj):
         fo.add_special(obj, special)
         print "Special", special, "added to", fo.get_name(obj)
 
-        break
+        return 1
+    return 0
 
 
 # TODO Bug:  distribute_specials forward checks that a special can be
@@ -144,8 +151,7 @@ def distribute_specials(specials_freq, universe_objects):
                 statistics.specials_repeat_dist[0] += 1
                 continue
 
-            place_special(local_specials, obj)
-            track_num_placed[obj] += 1
+            track_num_placed[obj] += place_special(local_specials, obj)
 
     for num_placed in track_num_placed.values():
         statistics.specials_repeat_dist[num_placed] += 1

--- a/default/python/universe_generation/specials.py
+++ b/default/python/universe_generation/specials.py
@@ -18,7 +18,7 @@ REPEAT_RATE = {1: 0.08, 2: 0.05, 3: 0.01, 4: 0.00}
 
 
 def calculate_number_of_specials_to_place(objs):
-    """Return a list of number placed at each obj"""
+    """Return a list of number of specials to be placed at each obj"""
     return [1 if random.random() > REPEAT_RATE[1] else
             2 if random.random() > REPEAT_RATE[2] else
             3 if random.random() > REPEAT_RATE[3] else 4
@@ -106,7 +106,7 @@ def distribute_specials(specials_freq, universe_objects):
         for (obj, system, specials_count) in obj_tuple_needing_specials:
             systems_needing_specials[system].add((obj, system, specials_count))
 
-        print " Placing in {} locations remaining.".format(str(len(systems_needing_specials)))
+        print " Placing in {} locations remaining.".format(len(systems_needing_specials))
 
         # Find a list of candidates all spaced GALAXY_DECORRECLATION_DISTANCE apart
         candidates = []

--- a/default/python/universe_generation/specials.py
+++ b/default/python/universe_generation/specials.py
@@ -1,13 +1,14 @@
 import random
 from collections import defaultdict
+import statistics
 
 import freeorion as fo
-import statistics
 import universe_tables
 from timers import Timer
 from galaxy_topology import get_systems_within_jumps
 
 REPEAT_RATE = {1: 0.08, 2: 0.05, 3: 0.01, 4: 0.00}
+
 
 def calc_num_placed(objs):
     """Return a list of number placed at each obj"""
@@ -26,7 +27,7 @@ def place_special_fast(specials, obj, specials_timer, per_special_timer):
     # placed here given that a special will be placed here.
     probs = [fo.special_spawn_rate(sp) for sp in specials]
     total_prob = sum(probs)
-    thresholds = [x/total_prob for x in probs]
+    thresholds = [x / total_prob for x in probs]
 
     chance = random.random()
     for threshold, special in zip(thresholds, specials):
@@ -89,7 +90,7 @@ def distribute_specials(specials_freq, universe_objects):
 
     print("Base chance for specials is {}. Placing specials on {} of {} ({:1.4f})objects"
           .format(base_chance, len(objects_needing_specials), len(universe_objects),
-                  float(len(objects_needing_specials))/len(universe_objects)))
+                  float(len(objects_needing_specials)) / len(universe_objects)))
 
     specials_timer.start("Associate with Systems")
     obj_tuple_needing_specials = set(zip(objects_needing_specials,
@@ -124,7 +125,7 @@ def distribute_specials(specials_freq, universe_objects):
             candidates.append(member[0])
             obj_tuple_needing_specials.remove(member)
             if member[2] > 1:
-                obj_tuple_needing_specials.add((member[0], member[1], member[2]-1))
+                obj_tuple_needing_specials.add((member[0], member[1], member[2] - 1))
 
             specials_timer.start("Trim close")
             # remove all neighbors from the local pool

--- a/default/python/universe_generation/specials.py
+++ b/default/python/universe_generation/specials.py
@@ -113,8 +113,8 @@ def distribute_specials(specials_freq, universe_objects):
     i_cache = 0
     while obj_tuple_needing_specials:
         systems_needing_specials = defaultdict(set)
-        for (obj, sys, n) in obj_tuple_needing_specials:
-            systems_needing_specials[sys].add((obj, sys, n))
+        for (obj, system, specials_count) in obj_tuple_needing_specials:
+            systems_needing_specials[system].add((obj, system, specials_count))
 
         print " Placing in {} locations remaining.".format(str(len(systems_needing_specials)))
 
@@ -125,15 +125,15 @@ def distribute_specials(specials_freq, universe_objects):
             specials_timer.start("Randos")
             random_sys = random.choice(systems_needing_specials.values())
             member = random.choice(list(random_sys))
-            (obj, sys, n) = member
+            obj, system, specials_count = member
             candidates.append(obj)
             obj_tuple_needing_specials.remove(member)
-            if n > 1:
-                obj_tuple_needing_specials.add((obj, sys, n - 1))
+            if specials_count > 1:
+                obj_tuple_needing_specials.add((obj, system, specials_count - 1))
 
             specials_timer.start("Trim close")
             # remove all neighbors from the local pool
-            for neighbor in get_systems_within_jumps(sys, GALAXY_DECOUPLING_DISTANCE):
+            for neighbor in get_systems_within_jumps(system, GALAXY_DECOUPLING_DISTANCE):
                 if neighbor in systems_needing_specials:
                     systems_needing_specials.pop(neighbor)
 

--- a/default/python/universe_generation/specials.py
+++ b/default/python/universe_generation/specials.py
@@ -26,6 +26,7 @@ def distribute_specials(specials_freq, universe_objects):
         print "...", special, ": spawn rate", fo.special_spawn_rate(special),\
               "/ spawn limit", fo.special_spawn_limit(special)
 
+    random.shuffle(universe_objects)
     # attempt to apply a special to each universe object in the list that has been passed to this function
     # by finding a special that can be applied to it and hasn't been added too many times, and then attempt
     # to add that special by testing its spawn rate

--- a/default/python/universe_generation/specials.py
+++ b/default/python/universe_generation/specials.py
@@ -1,18 +1,70 @@
 import random
+from collections import defaultdict
+
 import freeorion as fo
 import statistics
 import universe_tables
+from timers import Timer
+from galaxy_topology import get_systems_within_jumps
+
+REPEAT_RATE = {1: 0.08, 2: 0.05, 3: 0.01, 4: 0.00}
+
+def calc_num_placed(objs):
+    """Return a list of number placed at each obj"""
+    return [1 if random.random() > REPEAT_RATE[1] else
+            2 if random.random() > REPEAT_RATE[2] else
+            3 if random.random() > REPEAT_RATE[3] else 1
+            for __ in objs]
 
 
+def place_special_fast(specials, obj, specials_timer, per_special_timer):
+    """ Place at least single special.
+    Return the number of specials placed.
+    """
+    num_placed = 0
+    # Calculate the conditional probabilities that each special is
+    # placed here given that a special will be placed here.
+    probs = [fo.special_spawn_rate(sp) for sp in specials]
+    total_prob = sum(probs)
+    thresholds = [x/total_prob for x in probs]
+
+    chance = random.random()
+    for threshold, special in zip(thresholds, specials):
+        if chance > threshold:
+            chance -= threshold
+            continue
+
+        per_special_timer.start(special + "_place")
+        specials_timer.start("Place Special")
+        # All prerequisites and the test have been met, now add this special to this universe object.
+        fo.add_special(obj, special)
+        num_placed += 1
+        print "Special", special, "added to", fo.get_name(obj)
+
+        break
+
+    per_special_timer.start("None")
+    return num_placed
+
+
+# TODO Bug:  distribute_specials forward checks that a special can be
+# placed, but it doesn't recursively check all previously placed
+# specials against the new special.
 def distribute_specials(specials_freq, universe_objects):
     """
     Adds start-of-game specials to universe objects.
     """
+    specials_timer = Timer('place_specials_bucket')
+    specials_timer.start("Basic Chance")
+    per_special_timer = Timer('per_special_bucket')
+    per_special_timer.start("None")
 
     # get basic chance for occurrence of specials from the universe tables
-    basic_chance = universe_tables.SPECIALS_FREQUENCY[specials_freq]
-    if basic_chance <= 0:
+    base_chance = universe_tables.SPECIALS_FREQUENCY[specials_freq]
+    if base_chance <= 0:
         return
+
+    specials_timer.start("List Specials")
 
     # get a list with all specials that have a spawn rate and limit both > 0 and a location condition defined
     # (no location condition means a special shouldn't get added at game start)
@@ -20,58 +72,107 @@ def distribute_specials(specials_freq, universe_objects):
                 fo.special_spawn_limit(sp) > 0 and fo.special_has_location(sp)]
     if not specials:
         return
+
+    specials_timer.start("Print Spawn Rate")
+
     # dump a list of all specials meeting that conditions and their properties to the log
     print "Specials available for distribution at game start:"
     for special in specials:
-        print "...", special, ": spawn rate", fo.special_spawn_rate(special),\
-              "/ spawn limit", fo.special_spawn_limit(special)
+        print("... {:30}: spawn rate {:2.3f} / spawn limit {}".
+              format(special, fo.special_spawn_rate(special), fo.special_spawn_limit(special)))
 
-    random.shuffle(universe_objects)
-    # attempt to apply a special to each universe object in the list that has been passed to this function
-    # by finding a special that can be applied to it and hasn't been added too many times, and then attempt
-    # to add that special by testing its spawn rate
-    repeat_rate = {1: 0.08, 2: 0.05, 3: 0.01, 4: 0.00}
-    for univ_obj in universe_objects:
-        # for this universe object, find a suitable special
-        # start by shuffling our specials list, so each time the specials are considered in a new random order
-        random.shuffle(specials)
-        num_here = 0
+    specials_timer.start("Filter By Base Chance")
+    objects_needing_specials = [obj for obj in universe_objects if random.random() < base_chance]
 
-        # then, consider each special until one has been found or we run out of specials
-        # (the latter case means that no special is added to this universe object)
+    specials_timer.start("Compile num_placed statistics")
+    track_num_placed = {obj: 0 for obj in universe_objects}
+
+    print("Base chance for specials is {}. Placing specials on {} of {} ({:1.4f})objects"
+          .format(base_chance, len(objects_needing_specials), len(universe_objects),
+                  float(len(objects_needing_specials))/len(universe_objects)))
+
+    specials_timer.start("Associate with Systems")
+    obj_tuple_needing_specials = set(zip(objects_needing_specials,
+                                         fo.objs_get_systems(objects_needing_specials),
+                                         calc_num_placed(objects_needing_specials)))
+
+    # Equal to the largest distance in WithinStarlaneJumps conditions
+    # GALAXY_DECOUPLING_DISTANCE is used as follows.  For any two or more objects
+    # at least GALAXY_DECOUPLING_DISTANCE appart you only need to check
+    # fo.special_locations once and then you can place as many specials as possible,
+    # subject to number restrictions.
+    #
+    # Organize the objects into sets where all objects are spaced GALAXY_DECOUPLING_DISTANCE
+    # appart.  Place a special on each one.  Repeat until you run out of specials or objects.
+    GALAXY_DECOUPLING_DISTANCE = 6
+
+    i_cache = 0
+    while obj_tuple_needing_specials:
+        systems_needing_specials = defaultdict(set)
+        for (obj, sys, n) in obj_tuple_needing_specials:
+            systems_needing_specials[sys].add((obj, sys, n))
+
+        print " Placing in " + str(len(systems_needing_specials)) + " locations remaining"
+
+        # Find a list of candidates all spaced GALAXY_DECORRECLATION_DISTANCE apart
+        specials_timer.start("Compose spaced list")
+        candidates = []
+        while systems_needing_specials:
+            specials_timer.start("Randos")
+            random_sys = random.choice(systems_needing_specials.values())
+            member = random.choice(list(random_sys))
+            candidates.append(member[0])
+            obj_tuple_needing_specials.remove(member)
+            if member[2] > 1:
+                obj_tuple_needing_specials.add((member[0], member[1], member[2]-1))
+
+            specials_timer.start("Trim close")
+            # remove all neighbors from the local pool
+            for neighbor in get_systems_within_jumps(member[1], GALAXY_DECOUPLING_DISTANCE):
+                if neighbor in systems_needing_specials:
+                    systems_needing_specials.pop(neighbor)
+
+        i_cache += 1
+        specials_timer.start("Cache Locations " + str(i_cache))
+        print("Caching specials_locations() at {} of {} remaining locations.".
+              format(str(len(candidates)), str(len(obj_tuple_needing_specials) + len(candidates))))
+        # Get the locations at which each special can be placed
+        locations_cache = {}
         for special in specials:
+            per_special_timer.start(special + "_cache")
+            # The fo.special_locations in the following line consumes most of the time in this
+            # function.  Decreasing GALAXY_DECOUPLING_DISTANCE will speed up the whole
+            # function by reducing the number of times this needs to be called.
+            locations_cache[special] = set(fo.special_locations(special, candidates))
+
+        per_special_timer.start("None")
+
+        # Attempt to apply a special to each candidate
+        # by finding a special that can be applied to it and hasn't been added too many times
+        for obj in candidates:
+
+            specials_timer.start("Check max limit per special")
             # check if the spawn limit for this special has already been reached (that is, if this special
             # has already been added the maximal allowed number of times)
-            if statistics.specials_summary[special] >= fo.special_spawn_limit(special):
-                # if yes, consider next special
+            specials = [s for s in specials if statistics.specials_summary[s] < fo.special_spawn_limit(s)]
+            if not specials:
+                break
+
+            specials_timer.start("Check no local specials")
+            # Find which specials can be placed at this one location
+            local_specials = [sp for sp in specials if obj in locations_cache[sp]]
+            if not local_specials:
+                statistics.specials_repeat_dist[0] += 1
                 continue
 
-            # check if this universe object matches the location condition for this special
-            # (meaning, if this special can be added to this universe object at all)
-            if not fo.special_location(special, univ_obj):
-                # if not, consider next special
-                continue
+            num_placed = place_special_fast(local_specials, obj, specials_timer, per_special_timer)
+            track_num_placed[obj] += num_placed
 
-            # we have found a special that meets all prerequisites
-            # now do the test if we want to add the selected special to this universe object by making a roll against
-            # the basic probability multiplied by the spawn rate of the special
-            if random.random() > basic_chance * fo.special_spawn_rate(special):
-                # no, test failed, break out of the specials loop and continue with the next universe object
-                statistics.specials_repeat_dist[num_here] += 1
-                break
-            num_here += 1
+    specials_timer.start("Compile num_placed statistics")
+    for num_placed in track_num_placed.values():
+        statistics.specials_repeat_dist[num_placed] += 1
 
-            # all prerequisites and the test have been met, now add this special to this universe object
-            fo.add_special(univ_obj, special)
-            # increase the statistic counter for this special, so we can keep track of how often it has already
-            # been added (needed for the spawn limit test above, and to dump some statistics to the log later)
-            statistics.specials_summary[special] += 1
-            print "Special", special, "added to", fo.get_name(univ_obj)
-
-            # stop attempting to add specials here?  give a small chance to try more than one special
-            if random.random() > repeat_rate.get(num_here, 0.0):
-                # sorry, no, break out of the specials loop and continue with the next universe object
-                statistics.specials_repeat_dist[num_here] += 1
-                break
-        else:
-                statistics.specials_repeat_dist[num_here] += 1
+    specials_timer.stop()
+    specials_timer.print_aggregate()
+    per_special_timer.stop()
+    per_special_timer.print_aggregate()

--- a/default/python/universe_generation/specials.py
+++ b/default/python/universe_generation/specials.py
@@ -108,7 +108,7 @@ def distribute_specials(specials_freq, universe_objects):
 
         print " Placing in {} locations remaining.".format(len(systems_needing_specials))
 
-        # Find a list of candidates all spaced GALAXY_DECORRECLATION_DISTANCE apart
+        # Find a list of candidates all spaced GALAXY_DECOUPLING_DISTANCE apart
         candidates = []
         while systems_needing_specials:
             random_sys = random.choice(systems_needing_specials.values())

--- a/default/python/universe_generation/specials.py
+++ b/default/python/universe_generation/specials.py
@@ -27,10 +27,7 @@ def calculate_number_of_specials_to_place(objs):
 
 
 def place_special(specials, obj, specials_timer, per_special_timer):
-    """ Place at most a single special.
-    Return the number of specials placed.
-    """
-    num_placed = 0
+    """ Place a single special."""
     # Calculate the conditional probabilities that each special is
     # placed here given that a special will be placed here.
     probs = [fo.special_spawn_rate(sp) for sp in specials]
@@ -47,13 +44,11 @@ def place_special(specials, obj, specials_timer, per_special_timer):
         specials_timer.start("Place Special")
         # All prerequisites and the test have been met, now add this special to this universe object.
         fo.add_special(obj, special)
-        num_placed += 1
         print "Special", special, "added to", fo.get_name(obj)
 
         break
 
     per_special_timer.start("None")
-    return num_placed
 
 
 # TODO Bug:  distribute_specials forward checks that a special can be
@@ -175,8 +170,8 @@ def distribute_specials(specials_freq, universe_objects):
                 statistics.specials_repeat_dist[0] += 1
                 continue
 
-            num_placed = place_special(local_specials, obj, specials_timer, per_special_timer)
-            track_num_placed[obj] += num_placed
+            place_special(local_specials, obj, specials_timer, per_special_timer)
+            track_num_placed[obj] += 1
 
     specials_timer.start("Compile num_placed statistics")
     for num_placed in track_num_placed.values():

--- a/default/python/universe_generation/specials.py
+++ b/default/python/universe_generation/specials.py
@@ -22,7 +22,7 @@ def calculate_number_of_specials_to_place(objs):
     return [1 if random.random() > REPEAT_RATE[1] else
             2 if random.random() > REPEAT_RATE[2] else
             3 if random.random() > REPEAT_RATE[3] else 4
-            for __ in objs]
+            for _ in objs]
 
 
 def place_special(specials, obj):
@@ -45,7 +45,6 @@ def place_special(specials, obj):
             chance -= threshold
             continue
 
-        # All prerequisites and the test have been met, now add this special to this universe object.
         fo.add_special(obj, special)
         print "Special", special, "added to", fo.get_name(obj)
 
@@ -100,7 +99,6 @@ def distribute_specials(specials_freq, universe_objects):
     # appart.  Place a special on each one.  Repeat until you run out of specials or objects.
     GALAXY_DECOUPLING_DISTANCE = 6
 
-    i_cache = 0
     while obj_tuple_needing_specials:
         systems_needing_specials = defaultdict(set)
         for (obj, system, specials_count) in obj_tuple_needing_specials:
@@ -124,7 +122,6 @@ def distribute_specials(specials_freq, universe_objects):
                 if neighbor in systems_needing_specials:
                     systems_needing_specials.pop(neighbor)
 
-        i_cache += 1
         print("Caching specials_locations() at {} of {} remaining locations.".
               format(str(len(candidates)), str(len(obj_tuple_needing_specials) + len(candidates))))
         # Get the locations at which each special can be placed
@@ -151,6 +148,7 @@ def distribute_specials(specials_freq, universe_objects):
                 statistics.specials_repeat_dist[0] += 1
                 continue
 
+            # All prerequisites and the test have been met, now add this special to this universe object.
             track_num_placed[obj] += place_special(local_specials, obj)
 
     for num_placed in track_num_placed.values():

--- a/default/python/universe_generation/specials.py
+++ b/default/python/universe_generation/specials.py
@@ -22,12 +22,12 @@ def calc_num_placed(objs):
     """Return a list of number placed at each obj"""
     return [1 if random.random() > REPEAT_RATE[1] else
             2 if random.random() > REPEAT_RATE[2] else
-            3 if random.random() > REPEAT_RATE[3] else 1
+            3 if random.random() > REPEAT_RATE[3] else 4
             for __ in objs]
 
 
-def place_special_fast(specials, obj, specials_timer, per_special_timer):
-    """ Place at least single special.
+def place_special(specials, obj, specials_timer, per_special_timer):
+    """ Place at most a single special.
     Return the number of specials placed.
     """
     num_placed = 0
@@ -121,7 +121,7 @@ def distribute_specials(specials_freq, universe_objects):
         for (obj, sys, n) in obj_tuple_needing_specials:
             systems_needing_specials[sys].add((obj, sys, n))
 
-        print " Placing in " + str(len(systems_needing_specials)) + " locations remaining"
+        print " Placing in {} locations remaining.".format(str(len(systems_needing_specials)))
 
         # Find a list of candidates all spaced GALAXY_DECORRECLATION_DISTANCE apart
         specials_timer.start("Compose spaced list")
@@ -130,14 +130,15 @@ def distribute_specials(specials_freq, universe_objects):
             specials_timer.start("Randos")
             random_sys = random.choice(systems_needing_specials.values())
             member = random.choice(list(random_sys))
-            candidates.append(member[0])
+            (obj, sys, n) = member
+            candidates.append(obj)
             obj_tuple_needing_specials.remove(member)
-            if member[2] > 1:
-                obj_tuple_needing_specials.add((member[0], member[1], member[2] - 1))
+            if n > 1:
+                obj_tuple_needing_specials.add((obj, sys, n - 1))
 
             specials_timer.start("Trim close")
             # remove all neighbors from the local pool
-            for neighbor in get_systems_within_jumps(member[1], GALAXY_DECOUPLING_DISTANCE):
+            for neighbor in get_systems_within_jumps(sys, GALAXY_DECOUPLING_DISTANCE):
                 if neighbor in systems_needing_specials:
                     systems_needing_specials.pop(neighbor)
 
@@ -174,7 +175,7 @@ def distribute_specials(specials_freq, universe_objects):
                 statistics.specials_repeat_dist[0] += 1
                 continue
 
-            num_placed = place_special_fast(local_specials, obj, specials_timer, per_special_timer)
+            num_placed = place_special(local_specials, obj, specials_timer, per_special_timer)
             track_num_placed[obj] += num_placed
 
     specials_timer.start("Compile num_placed statistics")

--- a/default/python/universe_generation/specials.py
+++ b/default/python/universe_generation/specials.py
@@ -7,6 +7,14 @@ import universe_tables
 from timers import Timer
 from galaxy_topology import get_systems_within_jumps
 
+# REPEAT_RATE along with calc_num_placed determines if there are multiple specials in a single
+# location.  There can only be at most 4 specials in a single location.
+# The probabilites break down as follows:
+# Count  Probability
+# one    (1 - REPEAT_RATE[0])
+# two    REPEAT_RATE[0] * (1 - REPEAT_RATE[1])
+# three  REPEAT_RATE[0] * REPEAT_RATE[1] *(1 - REPEAT_RATE[2])
+# four   REPEAT_RATE[0] * REPEAT_RATE[1] * REPEAT_RATE[2]
 REPEAT_RATE = {1: 0.08, 2: 0.05, 3: 0.01, 4: 0.00}
 
 

--- a/default/python/universe_generation/specials.py
+++ b/default/python/universe_generation/specials.py
@@ -7,8 +7,8 @@ import universe_tables
 from timers import Timer
 from galaxy_topology import get_systems_within_jumps
 
-# REPEAT_RATE along with calc_num_placed determines if there are multiple specials in a single
-# location.  There can only be at most 4 specials in a single location.
+# REPEAT_RATE along with calculate_number_of_specials_to_place determines if there are multiple
+# specials in a single location.  There can only be at most 4 specials in a single location.
 # The probabilites break down as follows:
 # Count  Probability
 # one    (1 - REPEAT_RATE[0])
@@ -18,7 +18,7 @@ from galaxy_topology import get_systems_within_jumps
 REPEAT_RATE = {1: 0.08, 2: 0.05, 3: 0.01, 4: 0.00}
 
 
-def calc_num_placed(objs):
+def calculate_number_of_specials_to_place(objs):
     """Return a list of number placed at each obj"""
     return [1 if random.random() > REPEAT_RATE[1] else
             2 if random.random() > REPEAT_RATE[2] else
@@ -103,7 +103,7 @@ def distribute_specials(specials_freq, universe_objects):
     specials_timer.start("Associate with Systems")
     obj_tuple_needing_specials = set(zip(objects_needing_specials,
                                          fo.objs_get_systems(objects_needing_specials),
-                                         calc_num_placed(objects_needing_specials)))
+                                         calculate_number_of_specials_to_place(objects_needing_specials)))
 
     # Equal to the largest distance in WithinStarlaneJumps conditions
     # GALAXY_DECOUPLING_DISTANCE is used as follows.  For any two or more objects

--- a/default/python/universe_generation/specials.py
+++ b/default/python/universe_generation/specials.py
@@ -4,7 +4,6 @@ import statistics
 
 import freeorion as fo
 import universe_tables
-from timers import Timer
 from galaxy_topology import get_systems_within_jumps
 
 # REPEAT_RATE along with calculate_number_of_specials_to_place determines if there are multiple
@@ -26,7 +25,7 @@ def calculate_number_of_specials_to_place(objs):
             for __ in objs]
 
 
-def place_special(specials, obj, specials_timer, per_special_timer):
+def place_special(specials, obj):
     """ Place a single special."""
     # Calculate the conditional probabilities that each special is
     # placed here given that a special will be placed here.
@@ -40,15 +39,11 @@ def place_special(specials, obj, specials_timer, per_special_timer):
             chance -= threshold
             continue
 
-        per_special_timer.start(special + "_place")
-        specials_timer.start("Place Special")
         # All prerequisites and the test have been met, now add this special to this universe object.
         fo.add_special(obj, special)
         print "Special", special, "added to", fo.get_name(obj)
 
         break
-
-    per_special_timer.start("None")
 
 
 # TODO Bug:  distribute_specials forward checks that a special can be
@@ -58,17 +53,10 @@ def distribute_specials(specials_freq, universe_objects):
     """
     Adds start-of-game specials to universe objects.
     """
-    specials_timer = Timer('place_specials_bucket')
-    specials_timer.start("Basic Chance")
-    per_special_timer = Timer('per_special_bucket')
-    per_special_timer.start("None")
-
     # get basic chance for occurrence of specials from the universe tables
     base_chance = universe_tables.SPECIALS_FREQUENCY[specials_freq]
     if base_chance <= 0:
         return
-
-    specials_timer.start("List Specials")
 
     # get a list with all specials that have a spawn rate and limit both > 0 and a location condition defined
     # (no location condition means a special shouldn't get added at game start)
@@ -77,25 +65,20 @@ def distribute_specials(specials_freq, universe_objects):
     if not specials:
         return
 
-    specials_timer.start("Print Spawn Rate")
-
     # dump a list of all specials meeting that conditions and their properties to the log
     print "Specials available for distribution at game start:"
     for special in specials:
         print("... {:30}: spawn rate {:2.3f} / spawn limit {}".
               format(special, fo.special_spawn_rate(special), fo.special_spawn_limit(special)))
 
-    specials_timer.start("Filter By Base Chance")
     objects_needing_specials = [obj for obj in universe_objects if random.random() < base_chance]
 
-    specials_timer.start("Compile num_placed statistics")
     track_num_placed = {obj: 0 for obj in universe_objects}
 
     print("Base chance for specials is {}. Placing specials on {} of {} ({:1.4f})objects"
           .format(base_chance, len(objects_needing_specials), len(universe_objects),
                   float(len(objects_needing_specials)) / len(universe_objects)))
 
-    specials_timer.start("Associate with Systems")
     obj_tuple_needing_specials = set(zip(objects_needing_specials,
                                          fo.objs_get_systems(objects_needing_specials),
                                          calculate_number_of_specials_to_place(objects_needing_specials)))
@@ -119,10 +102,8 @@ def distribute_specials(specials_freq, universe_objects):
         print " Placing in {} locations remaining.".format(str(len(systems_needing_specials)))
 
         # Find a list of candidates all spaced GALAXY_DECORRECLATION_DISTANCE apart
-        specials_timer.start("Compose spaced list")
         candidates = []
         while systems_needing_specials:
-            specials_timer.start("Randos")
             random_sys = random.choice(systems_needing_specials.values())
             member = random.choice(list(random_sys))
             obj, system, specials_count = member
@@ -131,53 +112,40 @@ def distribute_specials(specials_freq, universe_objects):
             if specials_count > 1:
                 obj_tuple_needing_specials.add((obj, system, specials_count - 1))
 
-            specials_timer.start("Trim close")
             # remove all neighbors from the local pool
             for neighbor in get_systems_within_jumps(system, GALAXY_DECOUPLING_DISTANCE):
                 if neighbor in systems_needing_specials:
                     systems_needing_specials.pop(neighbor)
 
         i_cache += 1
-        specials_timer.start("Cache Locations " + str(i_cache))
         print("Caching specials_locations() at {} of {} remaining locations.".
               format(str(len(candidates)), str(len(obj_tuple_needing_specials) + len(candidates))))
         # Get the locations at which each special can be placed
         locations_cache = {}
         for special in specials:
-            per_special_timer.start(special + "_cache")
             # The fo.special_locations in the following line consumes most of the time in this
             # function.  Decreasing GALAXY_DECOUPLING_DISTANCE will speed up the whole
             # function by reducing the number of times this needs to be called.
             locations_cache[special] = set(fo.special_locations(special, candidates))
 
-        per_special_timer.start("None")
-
         # Attempt to apply a special to each candidate
         # by finding a special that can be applied to it and hasn't been added too many times
         for obj in candidates:
 
-            specials_timer.start("Check max limit per special")
             # check if the spawn limit for this special has already been reached (that is, if this special
             # has already been added the maximal allowed number of times)
             specials = [s for s in specials if statistics.specials_summary[s] < fo.special_spawn_limit(s)]
             if not specials:
                 break
 
-            specials_timer.start("Check no local specials")
             # Find which specials can be placed at this one location
             local_specials = [sp for sp in specials if obj in locations_cache[sp]]
             if not local_specials:
                 statistics.specials_repeat_dist[0] += 1
                 continue
 
-            place_special(local_specials, obj, specials_timer, per_special_timer)
+            place_special(local_specials, obj)
             track_num_placed[obj] += 1
 
-    specials_timer.start("Compile num_placed statistics")
     for num_placed in track_num_placed.values():
         statistics.specials_repeat_dist[num_placed] += 1
-
-    specials_timer.stop()
-    specials_timer.print_aggregate()
-    per_special_timer.stop()
-    per_special_timer.print_aggregate()

--- a/default/python/universe_generation/universe_generator.py
+++ b/default/python/universe_generation/universe_generator.py
@@ -1,5 +1,4 @@
 import random
-import statistics
 
 from common import configure_logging
 
@@ -15,6 +14,7 @@ from monsters import generate_monsters
 from specials import distribute_specials
 from util import int_hash, seed_rng, report_error, error_list
 from universe_tables import MAX_JUMPS_BETWEEN_SYSTEMS, MAX_STARLANE_LENGTH
+import statistics
 
 
 class PyGalaxySetupData:

--- a/default/python/universe_generation/universe_generator.py
+++ b/default/python/universe_generation/universe_generator.py
@@ -134,7 +134,7 @@ def create_universe(psd_map):
 
     print "Generating Space Monsters"
     seed_rng(seed_pool.pop())
-    generate_monsters(gsd.monster_frequency, systems)
+    generate_monsters(gsd.monster_frequency, systems, home_systems)
 
     print "Distributing Starting Specials"
     seed_rng(seed_pool.pop())

--- a/default/python/universe_generation/universe_generator.py
+++ b/default/python/universe_generation/universe_generator.py
@@ -1,4 +1,5 @@
 import random
+import statistics
 
 from common import configure_logging
 
@@ -14,7 +15,6 @@ from monsters import generate_monsters
 from specials import distribute_specials
 from util import int_hash, seed_rng, report_error, error_list
 from universe_tables import MAX_JUMPS_BETWEEN_SYSTEMS, MAX_STARLANE_LENGTH
-import statistics
 
 
 class PyGalaxySetupData:

--- a/default/python/universe_generation/universe_generator.py
+++ b/default/python/universe_generation/universe_generator.py
@@ -134,7 +134,7 @@ def create_universe(psd_map):
 
     print "Generating Space Monsters"
     seed_rng(seed_pool.pop())
-    generate_monsters(gsd.monster_frequency, systems, home_systems)
+    generate_monsters(gsd.monster_frequency, systems)
 
     print "Distributing Starting Specials"
     seed_rng(seed_pool.pop())

--- a/default/scripting/specials/HONEYCOMB.focs.txt
+++ b/default/scripting/specials/HONEYCOMB.focs.txt
@@ -7,13 +7,6 @@ Special
     location = And [
         Planet
         Not Planet type = Asteroids
-        Not WithinStarlaneJumps jumps = 5 condition = And [
-            System
-            Contains And [
-                Planet
-                OwnedBy affiliation = AnyEmpire
-            ]
-        ]
         Not WithinStarlaneJumps jumps = 2 condition = And [
             System
             Contains And [
@@ -22,6 +15,13 @@ Special
                     Species
                     HasSpecial
                 ]
+            ]
+        ]
+        Not WithinStarlaneJumps jumps = 5 condition = And [
+            System
+            Contains And [
+                Planet
+                OwnedBy affiliation = AnyEmpire
             ]
         ]
     ]

--- a/python/server/ServerWrapper.cpp
+++ b/python/server/ServerWrapper.cpp
@@ -214,8 +214,7 @@ namespace {
 
         Condition::ObjectSet objs;
         boost::python::stl_input_iterator<int> end;
-        for (boost::python::stl_input_iterator<int> id(obj_ids);
-             id != end; ++id) {
+        for (boost::python::stl_input_iterator<int> id(obj_ids); id != end; ++id) {
             if (std::shared_ptr<const UniverseObject> obj = GetUniverseObject(*id))
                 objs.push_back(obj);
             else
@@ -235,8 +234,8 @@ namespace {
         else
             permitted_objs = objs;
 
-        for (auto id : permitted_objs) {
-            permitted_ids.append(id->ID());
+        for (auto &obj : permitted_objs) {
+            permitted_ids.append(obj->ID());
         }
 
         return permitted_ids;
@@ -950,7 +949,7 @@ namespace {
         boost::python::stl_input_iterator<int> end;
         for (boost::python::stl_input_iterator<int> id(obj_ids);
              id != end; ++id) {
-            if (TemporaryPtr<const UniverseObject> obj = GetUniverseObject(*id)) {
+            if (std::shared_ptr<const UniverseObject> obj = GetUniverseObject(*id)) {
                 py_systems.append(obj->SystemID());
             } else {
                 ErrorLogger() << "Passed an invalid universe object id " << *id;

--- a/python/server/ServerWrapper.cpp
+++ b/python/server/ServerWrapper.cpp
@@ -944,6 +944,22 @@ namespace {
         return field->ID();
     }
 
+    // Wrappers for Object class member functions
+    list ObjectsGetSystems(list obj_ids) {
+        list py_systems;
+        boost::python::stl_input_iterator<int> end;
+        for (boost::python::stl_input_iterator<int> id(obj_ids);
+             id != end; ++id) {
+            if (TemporaryPtr<const UniverseObject> obj = GetUniverseObject(*id)) {
+                py_systems.append(obj->SystemID());
+            } else {
+                ErrorLogger() << "Passed an invalid universe object id " << *id;
+                py_systems.append(INVALID_OBJECT_ID);
+            }
+        }
+        return py_systems;
+    }
+
     // Wrappers for System class member functions
     StarType SystemGetStarType(int system_id) {
         std::shared_ptr<System> system = GetSystem(system_id);
@@ -1330,6 +1346,8 @@ namespace FreeOrionPython {
         def("create_monster",                       CreateMonster);
         def("create_field",                         CreateField);
         def("create_field_in_system",               CreateFieldInSystem);
+
+        def("objs_get_systems",                     ObjectsGetSystems);
 
         def("sys_get_star_type",                    SystemGetStarType);
         def("sys_set_star_type",                    SystemSetStarType);

--- a/python/server/ServerWrapper.cpp
+++ b/python/server/ServerWrapper.cpp
@@ -260,27 +260,6 @@ namespace {
         return special->SpawnLimit();
     }
 
-    bool SpecialLocation(const std::string special_name, int object_id) {
-        // get special and check if it exists
-        const Special* special = GetSpecial(special_name);
-        if (!special) {
-            ErrorLogger() << "SpecialLocation: couldn't get special " << special_name;
-            return false;
-        }
-
-        // get the universe object to test and check if it exists
-        std::shared_ptr<UniverseObject> obj = GetUniverseObject(object_id);
-        if (!obj) {
-            ErrorLogger() << "SpecialLocation: Couldn't get object with ID " << object_id;
-            return false;
-        }
-
-        // get special location condition and evaluate it with the specified universe object
-        // if no location condition has been defined, no object matches
-        const Condition::ConditionBase* location_test = special->Location();
-        return (location_test && location_test->Eval(obj));
-    }
-
     list SpecialLocations(const std::string special_name, list object_ids) {
         // get special and check if it exists
         const Special* special = GetSpecial(special_name);
@@ -1303,7 +1282,6 @@ namespace FreeOrionPython {
 
         def("special_spawn_rate",                   SpecialSpawnRate);
         def("special_spawn_limit",                  SpecialSpawnLimit);
-        def("special_location",                     SpecialLocation);
         def("special_locations",                    SpecialLocations);
         def("special_has_location",                 SpecialHasLocation);
         def("get_all_specials",                     GetAllSpecials);

--- a/python/server/ServerWrapper.cpp
+++ b/python/server/ServerWrapper.cpp
@@ -944,7 +944,7 @@ namespace {
         return field->ID();
     }
 
-    // Wrappers for Object class member functions
+    // Return a list of system ids of universe objects with @p obj_ids.
     list ObjectsGetSystems(list obj_ids) {
         list py_systems;
         boost::python::stl_input_iterator<int> end;


### PR DESCRIPTION
This PR along with #1214 provide a performance improvement to universe generation.

The performance improvement on a galaxy with 999 systems and 39 AIs is from 83 seconds to to 21 seconds.

39 seconds of that improvement is from #1214, which is linux only, but I don't think that windows machines are experiencing that slowdown.

This PR makes the improvements by making the following changes in the universe generation python code along with supporting changes in the C++ code:  
- It vectorizes `locations()` and `special_locations()`.  By searching all locations at the same time, it reduces round trip time between python and C++ and does all of the `WithinStarLaneJumps` calculations in parallel.
- It aggressively trims the candidate list for home systems.
- It rearranges the HONEYCOMB condition to do the expensive clause last.
- It uses known home systems to remove systems from consideration for monsters and natives.

While doing this two bugs were found, but only one was fixed.

In monsters and specials the systems were not randomized.  In galaxy topologies were system number is strongly correlated with location the monsters and specials ended up bunched in one area of the galaxy.  This is fixed in this PR.

In `specials.py` specials check their own clause against all existing specials before placement, but they do not recursively check all existing specials clauses against themselves.  Since, some special's clauses are written in a reciprocal way this is not a problem for all specials.  I could not think of a computationally efficient way to fix this so I made a TODO note and did not fix it. 

