### PR TITLE
Improve combat log for fighters.

### DIFF
--- a/UI/CombatReport/CombatLogWnd.cpp
+++ b/UI/CombatReport/CombatLogWnd.cpp
@@ -386,11 +386,11 @@ void CombatLogWnd::CombatLogWndImpl::SetLog(int log_id) {
                            GetOptionsDB().Get<bool>("verbose-combat-logging");
 
     m_wnd.DeleteChildren();
-    GG::Layout* layout = new GG::DeferredLayout(m_wnd.UpperLeft().x, m_wnd.UpperLeft().y
-                                        , m_wnd.Width(), m_wnd.Height()
-                                        , 1, 1 ///< numrows, numcols
-                                        , 0, 0 ///< wnd margin, cell margin
-                                       );
+    GG::Layout* layout = new GG::DeferredLayout(m_wnd.UpperLeft().x, m_wnd.UpperLeft().y,
+                                                m_wnd.Width(), m_wnd.Height(),
+                                                1, 1, ///< numrows, numcols
+                                                0, 0 ///< wnd margin, cell margin
+                                               );
     m_wnd.SetLayout(layout);
 
     int client_empire_id = HumanClientApp::GetApp()->EmpireID();

--- a/UI/CombatReport/CombatLogWnd.cpp
+++ b/UI/CombatReport/CombatLogWnd.cpp
@@ -156,7 +156,6 @@ namespace {
     }
 
     void CombatLogAccordionPanel::ToggleExpansion() {
-        DebugLogger() << "Expand/Collapse of detailed combat log.";
         bool new_collapsed = !IsCollapsed();
         if (new_collapsed) {
             for (GG::Wnd* wnd : details) {
@@ -381,6 +380,9 @@ void CombatLogWnd::CombatLogWndImpl::SetLog(int log_id) {
         return;
     }
 
+    bool verbose_logging = GetOptionsDB().Get<bool>("verbose-logging") ||
+                           GetOptionsDB().Get<bool>("verbose-combat-logging");
+
     m_wnd.DeleteChildren();
     GG::Layout* layout = new GG::DeferredLayout(m_wnd.UpperLeft().x, m_wnd.UpperLeft().y
                                         , m_wnd.Width(), m_wnd.Height()
@@ -392,7 +394,8 @@ void CombatLogWnd::CombatLogWndImpl::SetLog(int log_id) {
     int client_empire_id = HumanClientApp::GetApp()->EmpireID();
 
     // Write Header text
-    DebugLogger() << "Setting log with " << log->combat_events.size() << " events";
+    if (verbose_logging)
+        DebugLogger() << "Showing combat log #" << log_id << " with " << log->combat_events.size() << " events";
 
     TemporaryPtr<const System> system = GetSystem(log->system_id);
     const std::string& sys_name = (system ? system->PublicName(client_empire_id) : UserString("ERROR"));
@@ -411,7 +414,8 @@ void CombatLogWnd::CombatLogWndImpl::SetLog(int log_id) {
 
     // Write Logs
     for (CombatEventPtr event : log->combat_events) {
-        DebugLogger() << "event debug info: " << event->DebugString();
+        if (verbose_logging)
+            DebugLogger() << "event debug info: " << event->DebugString();
 
         for (GG::Wnd* wnd : MakeCombatLogPanel(m_font->SpaceWidth()*10, client_empire_id, event)) {
             AddRow(wnd);

--- a/UI/CombatReport/CombatLogWnd.cpp
+++ b/UI/CombatReport/CombatLogWnd.cpp
@@ -89,11 +89,13 @@ namespace {
     std::string CountsToText(const std::map<int, int>& count_per_empire, const std::string& delimiter = ", ") {
         std::stringstream ss;
         for (std::map<int,int>::const_iterator it = count_per_empire.begin(); it != count_per_empire.end(); ) {
-            std::string owner_string = UserString("NEUTRAL");
+            std::string owner_string;
             if (const Empire* owner = GetEmpire(it->first))
                 owner_string = GG::RgbaTag(owner->Color()) + "<" + VarText::EMPIRE_ID_TAG + " "
                     + boost::lexical_cast<std::string>(owner->EmpireID()) + ">" + owner->Name()
                     + "</" + VarText::EMPIRE_ID_TAG + ">" + "</rgba>";
+            else
+                owner_string = GG::RgbaTag(ClientUI::DefaultLinkColor()) + UserString("NEUTRAL")  + "</rgba>";
             ss << owner_string << ": " << it->second;
             ++it;
             if (it != count_per_empire.end())

--- a/combat/CombatEvents.cpp
+++ b/combat/CombatEvents.cpp
@@ -729,7 +729,9 @@ std::string IncapacitationEvent::CombatLogDescription(int viewing_empire_id) con
     if (const Empire* owner = GetEmpire(owner_id))
         owner_string += owner->Name() + " ";
 
-    return str(FlexibleFormat(template_str) % owner_string % object_str);
+    std::string object_link = FighterOrPublicNameLink(viewing_empire_id, object_id, object_owner_id);
+
+    return str(FlexibleFormat(template_str) % owner_string % object_link);
 }
 
 boost::optional<int> IncapacitationEvent::PrincipalFaction(int viewing_empire_id) const {

--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -1554,8 +1554,6 @@ namespace {
         // get any chance to attack during this combat
         if (bout <= GetUniverse().GetNumCombatRounds() - 1) {
             FighterLaunchesEventPtr launches_event = boost::make_shared<FighterLaunchesEvent>();
-            combat_info.combat_events.push_back(launches_event);
-
             for (int attacker_id : shuffled_attackers) {
                 TemporaryPtr<UniverseObject> attacker = combat_info.objects.Object(attacker_id);
 
@@ -1576,6 +1574,11 @@ namespace {
 
                 if (verbose_logging)
                     DebugLogger() << "Attacker: " << attacker->Name();
+            }
+
+            if (!launches_event->AreSubEventsEmpty(ALL_EMPIRES)) {
+                CombatEventPtr launches_event_cast = boost::static_pointer_cast<CombatEvent, AttacksEvent>(launches_event);
+                bout_event->AddEvent(launches_event_cast);
             }
         }
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -4100,17 +4100,17 @@ ENC_COMBAT_UNKNOWN_DESTROYED_STR
 # %1% name of the empire which owns the attacked unit.
 # %2% name of the attacked fighter.
 ENC_COMBAT_FIGHTER_INCAPACITATED_STR
-A%1%fighter was destroyed
+A %2% was destroyed
 
 # %1% name of the empire which owns the attacked unit.
 # %2% name of the attacked planet.
 ENC_COMBAT_PLANET_INCAPACITATED_STR
-The%1%planet %2% was incapacitated
+The planet %2% was incapacitated
 
 # %1% name of the empire which owns the attacked unit.
 # %2% name of the attacked unit.
 ENC_COMBAT_DESTROYED_STR
-The%1%ship %2% was destroyed
+The ship %2% was destroyed
 
 # %1% unused
 # %2% name of empire


### PR DESCRIPTION
This PR makes 4 small changes to the combat log window:
- moves the launch events into the bout event before the destroy events.  This was requested in http://freeorion.org/forum/viewtopic.php?f=28&t=10339.
- restricts debug logging to when verbose logging is requested
- makes the NEUTRAL empire name the same color as its links
- changes the destroyed object report to indicate empire with color instead of explicitly by name.  This is more in line with the other types of logs.