### PR TITLE
Acquire scoped mutex locks before accessing PRNG generator.

### DIFF
--- a/util/Random.cpp
+++ b/util/Random.cpp
@@ -1,31 +1,44 @@
 #include "Random.h"
 
 #include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/thread/mutex.hpp>
 
 namespace {
     GeneratorType gen; // the one random number generator driving the distributions below
+
+    static boost::mutex s_prng_mutex;
 }
 
 void Seed(unsigned int seed) {
+    boost::mutex::scoped_lock lock(s_prng_mutex);
     gen.seed(static_cast<boost::mt19937::result_type>(seed));
 }
 
 void ClockSeed() {
+    boost::mutex::scoped_lock lock(s_prng_mutex);
     boost::posix_time::time_duration diff = boost::posix_time::microsec_clock::local_time().time_of_day();
     gen.seed(static_cast<boost::mt19937::result_type>(diff.total_milliseconds()));
 }
 
-SmallIntDistType SmallIntDist(int min, int max)
-{ return SmallIntDistType(gen, boost::uniform_smallint<>(min, max)); }
+SmallIntDistType SmallIntDist(int min, int max) {
+    boost::mutex::scoped_lock lock(s_prng_mutex);
+    return SmallIntDistType(gen, boost::uniform_smallint<>(min, max));
+}
 
-IntDistType IntDist(int min, int max)
-{ return IntDistType(gen, boost::uniform_int<>(min, max)); }
+IntDistType IntDist(int min, int max) {
+    boost::mutex::scoped_lock lock(s_prng_mutex);
+    return IntDistType(gen, boost::uniform_int<>(min, max));
+}
 
-DoubleDistType DoubleDist(double min, double max)
-{ return DoubleDistType(gen, boost::uniform_real<>(min, max)); }
+DoubleDistType DoubleDist(double min, double max) {
+    boost::mutex::scoped_lock lock(s_prng_mutex);
+    return DoubleDistType(gen, boost::uniform_real<>(min, max));
+}
 
-GaussianDistType GaussianDist(double mean, double sigma)
-{ return GaussianDistType(gen, boost::normal_distribution<>(mean, sigma)); }
+GaussianDistType GaussianDist(double mean, double sigma) {
+    boost::mutex::scoped_lock lock(s_prng_mutex);
+    return GaussianDistType(gen, boost::normal_distribution<>(mean, sigma));
+}
 
 int RandSmallInt(int min, int max)
 { return (min == max ? min : SmallIntDist(min,max)()); }


### PR DESCRIPTION
Hopefully makes accessing the random functions thread safe.

Related to:
https://github.com/freeorion/freeorion/issues/1230
https://github.com/freeorion/freeorion/pull/1241