### PR TITLE
Refactor the GraphImpl portion of Universe into Pathfinder.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,6 +232,7 @@ set (freeorioncommon_HEADER
     universe/System.h
     universe/Tech.h
     universe/Universe.h
+    universe/Pathfinder.h
     universe/UniverseObject.h
     universe/ValueRef.h
     universe/ValueRefFwd.h
@@ -294,6 +295,7 @@ set (freeorioncommon_SOURCE
     universe/System.cpp
     universe/Tech.cpp
     universe/Universe.cpp
+    universe/Pathfinder.cpp
     universe/UniverseObject.cpp
     universe/ValueRef.cpp
     util/AppInterface.cpp

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -3673,7 +3673,7 @@ namespace {
         if (!fleet)
             return "";
 
-        int nearest_system_id(GetUniverse().GetPathfinder()->NearestSystemTo(fleet->X(), fleet->Y()));
+        int nearest_system_id(GetPathfinder()->NearestSystemTo(fleet->X(), fleet->Y()));
         if (std::shared_ptr<const System> system = GetSystem(nearest_system_id)) {
             const std::string& sys_name = system->ApparentName(client_empire_id);
             return sys_name;

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -19,6 +19,7 @@
 #include "../universe/ShipDesign.h"
 #include "../universe/System.h"
 #include "../universe/Enums.h"
+#include "../universe/Pathfinder.h"
 #include "../network/Message.h"
 #include "../Empire/Empire.h"
 
@@ -3672,7 +3673,7 @@ namespace {
         if (!fleet)
             return "";
 
-        int nearest_system_id(GetUniverse().NearestSystemTo(fleet->X(), fleet->Y()));
+        int nearest_system_id(GetUniverse().GetPathfinder()->NearestSystemTo(fleet->X(), fleet->Y()));
         if (std::shared_ptr<const System> system = GetSystem(nearest_system_id)) {
             const std::string& sys_name = system->ApparentName(client_empire_id);
             return sys_name;

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -4840,7 +4840,7 @@ void MapWnd::PlotFleetMovement(int system_id, bool execute_move, bool append) {
             start_system = fleet->NextSystemID();
 
         // get path to destination...
-        std::list<int> route = GetUniverse().GetPathfinder()->ShortestPath(start_system, system_id, empire_id).first;
+        std::list<int> route = GetPathfinder()->ShortestPath(start_system, system_id, empire_id).first;
         if (append && !fleet->TravelRoute().empty()) {
             std::list<int> old_route(fleet->TravelRoute());
             old_route.erase(--old_route.end()); //end of old is begin of new
@@ -6477,7 +6477,7 @@ void MapWnd::DispatchFleetsExploring() {
                 if (systems_order_sent.find(system_supply.first) != systems_order_sent.end())
                     continue; //someone already went there this turn
 
-                std::pair<std::list<int>, double> pair = GetUniverse().GetPathfinder()->ShortestPath(fleet->SystemID(), system_supply.first, empire_id);
+                std::pair<std::list<int>, double> pair = GetPathfinder()->ShortestPath(fleet->SystemID(), system_supply.first, empire_id);
 
                 //we check for the fuel.
                 bool is_doable_for_fuel = true;

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -42,6 +42,7 @@
 #include "../universe/Species.h"
 #include "../universe/System.h"
 #include "../universe/Field.h"
+#include "../universe/Pathfinder.h"
 #include "../universe/Universe.h"
 #include "../universe/UniverseObject.h"
 #include "../Empire/Empire.h"
@@ -4839,7 +4840,7 @@ void MapWnd::PlotFleetMovement(int system_id, bool execute_move, bool append) {
             start_system = fleet->NextSystemID();
 
         // get path to destination...
-        std::list<int> route = GetUniverse().ShortestPath(start_system, system_id, empire_id).first;
+        std::list<int> route = GetUniverse().GetPathfinder()->ShortestPath(start_system, system_id, empire_id).first;
         if (append && !fleet->TravelRoute().empty()) {
             std::list<int> old_route(fleet->TravelRoute());
             old_route.erase(--old_route.end()); //end of old is begin of new
@@ -6476,7 +6477,7 @@ void MapWnd::DispatchFleetsExploring() {
                 if (systems_order_sent.find(system_supply.first) != systems_order_sent.end())
                     continue; //someone already went there this turn
 
-                std::pair<std::list<int>, double> pair = GetUniverse().ShortestPath(fleet->SystemID(), system_supply.first, empire_id);
+                std::pair<std::list<int>, double> pair = GetUniverse().GetPathfinder()->ShortestPath(fleet->SystemID(), system_supply.first, empire_id);
 
                 //we check for the fuel.
                 bool is_doable_for_fuel = true;

--- a/Xcode/FreeOrion.xcodeproj/project.pbxproj
+++ b/Xcode/FreeOrion.xcodeproj/project.pbxproj
@@ -323,6 +323,7 @@
 		9E632AED13AD24D1003D1874 /* libboost_regex.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EEEEA7513ACB91A0085B1A0 /* libboost_regex.a */; };
 		CE0ED5F91BCFE16E00375001 /* AIWrapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE0ED5F71BCFE16E00375001 /* AIWrapper.cpp */; };
 		CE13B48F1C8CB0CF0085A4DC /* CommonParamsParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE13B48E1C8CB0CF0085A4DC /* CommonParamsParser.cpp */; };
+		CE2BAD8F1E3E43E40085A4DC /* Pathfinder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE2BAD8D1E3E43E40085A4DC /* Pathfinder.cpp */; };
 		CE2C454D1C65036F0085A4DC /* ResourceBrowseWnd.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE2C454B1C65036F0085A4DC /* ResourceBrowseWnd.cpp */; };
 		CE2C454E1C6503990085A4DC /* libz.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 822E325B19BEED6C00A7B707 /* libz.a */; };
 		CE3102B61DBFD0730085A4DC /* DeferredLayout.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE3102B51DBFD0730085A4DC /* DeferredLayout.cpp */; };
@@ -1088,6 +1089,8 @@
 		CE0ED5F81BCFE16E00375001 /* AIWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIWrapper.h; sourceTree = "<group>"; };
 		CE13B48D1C8CB0CF0085A4DC /* CommonParams.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CommonParams.h; sourceTree = "<group>"; };
 		CE13B48E1C8CB0CF0085A4DC /* CommonParamsParser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CommonParamsParser.cpp; sourceTree = "<group>"; };
+		CE2BAD8D1E3E43E40085A4DC /* Pathfinder.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Pathfinder.cpp; sourceTree = "<group>"; };
+		CE2BAD8E1E3E43E40085A4DC /* Pathfinder.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Pathfinder.h; sourceTree = "<group>"; };
 		CE2C454B1C65036F0085A4DC /* ResourceBrowseWnd.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ResourceBrowseWnd.cpp; sourceTree = "<group>"; };
 		CE2C454C1C65036F0085A4DC /* ResourceBrowseWnd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ResourceBrowseWnd.h; sourceTree = "<group>"; };
 		CE3102B41DBFD05B0085A4DC /* DeferredLayout.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DeferredLayout.h; sourceTree = "<group>"; };
@@ -1831,6 +1834,8 @@
 				471D5CF80A98A3F900DA9C21 /* Meter.h */,
 				82592EF3147E387100B840A5 /* ObjectMap.cpp */,
 				82592EF4147E387100B840A5 /* ObjectMap.h */,
+				CE2BAD8D1E3E43E40085A4DC /* Pathfinder.cpp */,
+				CE2BAD8E1E3E43E40085A4DC /* Pathfinder.h */,
 				471D5CFC0A98A3F900DA9C21 /* Planet.cpp */,
 				471D5CFD0A98A3F900DA9C21 /* Planet.h */,
 				471D5CFE0A98A3F900DA9C21 /* PopCenter.cpp */,
@@ -2594,6 +2599,7 @@
 				47103BF40CF04E5900A7DF2B /* Order.cpp in Sources */,
 				47103BF50CF04E5900A7DF2B /* OrderSet.cpp in Sources */,
 				47103BF60CF04E5900A7DF2B /* Random.cpp in Sources */,
+				CE2BAD8F1E3E43E40085A4DC /* Pathfinder.cpp in Sources */,
 				47103BF70CF04E5900A7DF2B /* SitRepEntry.cpp in Sources */,
 				47103BF80CF04E5900A7DF2B /* VarText.cpp in Sources */,
 				47103BF90CF04E5900A7DF2B /* XMLDoc.cpp in Sources */,

--- a/msvc2013/Common/Common.vcxproj
+++ b/msvc2013/Common/Common.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -184,6 +184,7 @@
     <ClInclude Include="..\..\universe\System.h" />
     <ClInclude Include="..\..\universe\Tech.h" />
     <ClInclude Include="..\..\universe\Universe.h" />
+    <ClInclude Include="..\..\universe\Pathfinder.h" />
     <ClInclude Include="..\..\universe\UniverseObject.h" />
     <ClInclude Include="..\..\universe\ValueRef.h" />
     <ClInclude Include="..\..\universe\ValueRefFwd.h" />
@@ -245,6 +246,7 @@
     <ClCompile Include="..\..\universe\System.cpp" />
     <ClCompile Include="..\..\universe\Tech.cpp" />
     <ClCompile Include="..\..\universe\Universe.cpp" />
+    <ClCompile Include="..\..\universe\Pathfinder.cpp" />
     <ClCompile Include="..\..\universe\UniverseObject.cpp" />
     <ClCompile Include="..\..\universe\ValueRef.cpp" />
     <ClCompile Include="..\..\util\AppInterface.cpp" />

--- a/msvc2015/Common/Common.vcxproj
+++ b/msvc2015/Common/Common.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -184,6 +184,7 @@
     <ClInclude Include="..\..\universe\System.h" />
     <ClInclude Include="..\..\universe\Tech.h" />
     <ClInclude Include="..\..\universe\Universe.h" />
+    <ClInclude Include="..\..\universe\Pathfinder.h" />
     <ClInclude Include="..\..\universe\UniverseObject.h" />
     <ClInclude Include="..\..\universe\ValueRef.h" />
     <ClInclude Include="..\..\universe\ValueRefFwd.h" />
@@ -245,6 +246,7 @@
     <ClCompile Include="..\..\universe\System.cpp" />
     <ClCompile Include="..\..\universe\Tech.cpp" />
     <ClCompile Include="..\..\universe\Universe.cpp" />
+    <ClCompile Include="..\..\universe\Pathfinder.cpp" />
     <ClCompile Include="..\..\universe\UniverseObject.cpp" />
     <ClCompile Include="..\..\universe\ValueRef.cpp" />
     <ClCompile Include="..\..\util\AppInterface.cpp" />

--- a/msvc2015/Common/Common.vcxproj.filters
+++ b/msvc2015/Common/Common.vcxproj.filters
@@ -223,6 +223,9 @@
     <ClInclude Include="..\..\Empire\Supply.h">
       <Filter>Header Files\Empire</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\universe\Pathfinder.h">
+      <Filter>Header Files\universe</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\network\MessageQueue.cpp">
@@ -398,6 +401,9 @@
     </ClCompile>
     <ClCompile Include="..\..\Empire\Supply.cpp">
       <Filter>Source Files\Empire</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\universe\Pathfinder.cpp">
+      <Filter>Source Files\universe</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/python/UniverseWrapper.cpp
+++ b/python/UniverseWrapper.cpp
@@ -1,3 +1,4 @@
+#include "../universe/Pathfinder.h"
 #include "../universe/Universe.h"
 #include "../universe/UniverseObject.h"
 #include "../universe/Fleet.h"
@@ -100,19 +101,19 @@ namespace {
 
     double                  LinearDistance(const Universe& universe, int system1_id, int system2_id) {
         double retval = 9999999.9;  // arbitrary large value
-        retval = universe.LinearDistance(system1_id, system2_id);
+        retval = universe.GetPathfinder()->LinearDistance(system1_id, system2_id);
         return retval;
     }
     boost::function<double(const Universe&, int, int)> LinearDistanceFunc =                     &LinearDistance;
 
     int                     JumpDistanceBetweenSystems(const Universe& universe, int system1_id, int system2_id) {
-        return universe.JumpDistanceBetweenSystems(system1_id, system2_id);
+        return universe.GetPathfinder()->JumpDistanceBetweenSystems(system1_id, system2_id);
     }
     boost::function<int(const Universe&, int, int)> JumpDistanceFunc =                          &JumpDistanceBetweenSystems;
 
     std::vector<int>        ShortestPath(const Universe& universe, int start_sys, int end_sys, int empire_id) {
         std::vector<int> retval;
-        std::pair<std::list<int>, int> path = universe.ShortestPath(start_sys, end_sys, empire_id);
+        std::pair<std::list<int>, int> path = universe.GetPathfinder()->ShortestPath(start_sys, end_sys, empire_id);
         std::copy(path.first.begin(), path.first.end(), std::back_inserter(retval));
         return retval;
     }
@@ -120,7 +121,7 @@ namespace {
 
     std::vector<int>        LeastJumpsPath(const Universe& universe, int start_sys, int end_sys, int empire_id) {
         std::vector<int> retval;
-        std::pair<std::list<int>, int> path = universe.LeastJumpsPath(start_sys, end_sys, empire_id);
+        std::pair<std::list<int>, int> path = universe.GetPathfinder()->LeastJumpsPath(start_sys, end_sys, empire_id);
         std::copy(path.first.begin(), path.first.end(), std::back_inserter(retval));
         return retval;
     }
@@ -128,15 +129,20 @@ namespace {
 
     bool                    SystemsConnectedP(const Universe& universe, int system1_id, int system2_id, int empire_id=ALL_EMPIRES) {
         //DebugLogger() << "SystemsConnected!(" << system1_id << ", " << system2_id << ")";
-        bool retval = universe.SystemsConnected(system1_id, system2_id, empire_id);
+        bool retval = universe.GetPathfinder()->SystemsConnected(system1_id, system2_id, empire_id);
         //DebugLogger() << "SystemsConnected! retval: " << retval;
         return retval;
     }
     boost::function<bool(const Universe&, int, int, int)> SystemsConnectedFunc =                &SystemsConnectedP;
 
+    bool                    SystemHasVisibleStarlanesP(const Universe& universe, int system_id, int empire_id = ALL_EMPIRES) {
+        return universe.GetPathfinder()->SystemHasVisibleStarlanes(system_id, empire_id);
+    }
+    boost::function<bool(const Universe&, int, int)> SystemHasVisibleStarlanesFunc =            &SystemHasVisibleStarlanesP;
+
     std::vector<int>        ImmediateNeighborsP(const Universe& universe, int system1_id, int empire_id = ALL_EMPIRES) {
         std::vector<int> retval;
-        for (const std::multimap<double, int>::value_type& entry : universe.ImmediateNeighbors(system1_id, empire_id))
+        for (const std::multimap<double, int>::value_type& entry : universe.GetPathfinder()->ImmediateNeighbors(system1_id, empire_id))
         { retval.push_back(entry.second); }
         return retval;
     }
@@ -144,7 +150,7 @@ namespace {
 
     std::map<int,double>    SystemNeighborsMapP(const Universe& universe, int system1_id, int empire_id = ALL_EMPIRES) {
         std::map<int,double> retval;
-        for (const std::multimap<double, int>::value_type& entry : universe.ImmediateNeighbors(system1_id, empire_id))
+        for (const std::multimap<double, int>::value_type& entry : universe.GetPathfinder()->ImmediateNeighbors(system1_id, empire_id))
         { retval[entry.second] = entry.first; }
         return retval;
     }
@@ -307,7 +313,11 @@ namespace FreeOrionPython {
             .def("destroyedObjectIDs",          make_function(&Universe::EmpireKnownDestroyedObjectIDs,
                                                                                     return_value_policy<return_by_value>()))
 
-            .def("systemHasStarlane",           &Universe::SystemHasVisibleStarlanes)
+            .def("systemHasStarlane",           make_function(
+                                                    SystemHasVisibleStarlanesFunc,
+                                                    return_value_policy<return_by_value>(),
+                                                    boost::mpl::vector<bool, const Universe&, int, int>()
+                                                ))
 
             .def("updateMeterEstimates",        &UpdateMetersWrapper)
 

--- a/python/server/ServerWrapper.cpp
+++ b/python/server/ServerWrapper.cpp
@@ -609,10 +609,10 @@ namespace {
     { GetUniverse().SetUniverseWidth(width); }
 
     double LinearDistance(int system1_id, int system2_id)
-    { return GetUniverse().GetPathfinder()->LinearDistance(system1_id, system2_id); }
+    { return GetPathfinder()->LinearDistance(system1_id, system2_id); }
 
     int JumpDistanceBetweenSystems(int system1_id, int system2_id)
-    { return GetUniverse().GetPathfinder()->JumpDistanceBetweenSystems(system1_id, system2_id); }
+    { return GetPathfinder()->JumpDistanceBetweenSystems(system1_id, system2_id); }
 
     list GetAllObjects() {
         list py_all_objects;

--- a/python/server/ServerWrapper.cpp
+++ b/python/server/ServerWrapper.cpp
@@ -11,6 +11,7 @@
 #include "../../universe/Ship.h"
 #include "../../universe/Field.h"
 #include "../../universe/Tech.h"
+#include "../../universe/Pathfinder.h"
 #include "../../universe/Universe.h"
 #include "../../universe/UniverseGenerator.h"
 #include "../../universe/Enums.h"
@@ -608,10 +609,10 @@ namespace {
     { GetUniverse().SetUniverseWidth(width); }
 
     double LinearDistance(int system1_id, int system2_id)
-    { return GetUniverse().LinearDistance(system1_id, system2_id); }
+    { return GetUniverse().GetPathfinder()->LinearDistance(system1_id, system2_id); }
 
     int JumpDistanceBetweenSystems(int system1_id, int system2_id)
-    { return GetUniverse().JumpDistanceBetweenSystems(system1_id, system2_id); }
+    { return GetUniverse().GetPathfinder()->JumpDistanceBetweenSystems(system1_id, system2_id); }
 
     list GetAllObjects() {
         list py_all_objects;

--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -4,6 +4,7 @@
 #include "../util/Random.h"
 #include "../util/i18n.h"
 #include "UniverseObject.h"
+#include "Pathfinder.h"
 #include "Universe.h"
 #include "Building.h"
 #include "Fleet.h"
@@ -6607,7 +6608,7 @@ namespace {
 
             // is candidate object close enough to any subcondition matches?
             for (std::shared_ptr<const UniverseObject> obj : m_from_objects) {
-                int jumps = GetUniverse().JumpDistanceBetweenObjects(obj->ID(), candidate->ID());
+                int jumps = GetUniverse().GetPathfinder()->JumpDistanceBetweenObjects(obj->ID(), candidate->ID());
                 if (jumps != -1 && jumps <= m_jump_limit)
                     return true;
             }

--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -6608,7 +6608,7 @@ namespace {
 
             // is candidate object close enough to any subcondition matches?
             for (std::shared_ptr<const UniverseObject> obj : m_from_objects) {
-                int jumps = GetUniverse().GetPathfinder()->JumpDistanceBetweenObjects(obj->ID(), candidate->ID());
+                int jumps = GetPathfinder()->JumpDistanceBetweenObjects(obj->ID(), candidate->ID());
                 if (jumps != -1 && jumps <= m_jump_limit)
                     return true;
             }

--- a/universe/Effect.cpp
+++ b/universe/Effect.cpp
@@ -129,7 +129,7 @@ namespace {
 
         int dest_system = fleet->FinalDestinationID();
 
-        std::pair<std::list<int>, double> route_pair = GetUniverse().GetPathfinder()->ShortestPath(start_system, dest_system, fleet->Owner());
+        std::pair<std::list<int>, double> route_pair = GetPathfinder()->ShortestPath(start_system, dest_system, fleet->Owner());
 
         // if shortest path is empty, the route may be impossible or trivial, so just set route to move fleet
         // to the next system that it was just set to move to anyway.

--- a/universe/Effect.cpp
+++ b/universe/Effect.cpp
@@ -10,6 +10,7 @@
 #include "../Empire/Empire.h"
 #include "ValueRef.h"
 #include "Condition.h"
+#include "Pathfinder.h"
 #include "Universe.h"
 #include "UniverseObject.h"
 #include "Building.h"
@@ -128,7 +129,7 @@ namespace {
 
         int dest_system = fleet->FinalDestinationID();
 
-        std::pair<std::list<int>, double> route_pair = GetUniverse().ShortestPath(start_system, dest_system, fleet->Owner());
+        std::pair<std::list<int>, double> route_pair = GetUniverse().GetPathfinder()->ShortestPath(start_system, dest_system, fleet->Owner());
 
         // if shortest path is empty, the route may be impossible or trivial, so just set route to move fleet
         // to the next system that it was just set to move to anyway.
@@ -2664,7 +2665,7 @@ void SetDestination::Execute(const ScriptingContext& context) const {
         return;
 
     // find shortest path for fleet's owner
-    std::pair<std::list<int>, double> short_path = universe.ShortestPath(start_system_id, destination_system_id, target_fleet->Owner());
+    std::pair<std::list<int>, double> short_path = universe.GetPathfinder()->ShortestPath(start_system_id, destination_system_id, target_fleet->Owner());
     const std::list<int>& route_list = short_path.first;
 
     // reject empty move paths (no path exists).

--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -26,7 +26,7 @@ namespace {
     const double FLEET_MOVEMENT_EPSILON = 0.1;  // how close a fleet needs to be to a system to have arrived in the system
 
     bool SystemHasNoVisibleStarlanes(int system_id, int empire_id)
-    { return !GetUniverse().GetPathfinder()->SystemHasVisibleStarlanes(system_id, empire_id); }
+    { return !GetPathfinder()->SystemHasVisibleStarlanes(system_id, empire_id); }
 
     template<typename IT>
     double PathLength (const IT& begin, const IT& end) {
@@ -154,7 +154,7 @@ void Fleet::Copy(std::shared_ptr<const UniverseObject> copied_object, int empire
                 ShortenRouteToEndAtSystem(travel_route, moving_to);
                 if (!travel_route.empty() && travel_route.front() != 0 && travel_route.size() != copied_fleet_route.size()) {
                     try {
-                        travel_distance -= GetUniverse().GetPathfinder()->ShortestPath(travel_route.back(),
+                        travel_distance -= GetPathfinder()->ShortestPath(travel_route.back(),
                                                                       copied_fleet_route.back()).second;
                     } catch (...) {
                         DebugLogger() << "Fleet::Copy couldn't find route to system(s):"
@@ -1047,7 +1047,7 @@ void Fleet::CalculateRouteTo(int target_system_id) {
 
         std::pair<std::list<int>, double> path;
         try {
-            path = GetUniverse().GetPathfinder()->ShortestPath(m_prev_system, target_system_id, this->Owner());
+            path = GetPathfinder()->ShortestPath(m_prev_system, target_system_id, this->Owner());
         } catch (...) {
             DebugLogger() << "Fleet::CalculateRoute couldn't find route to system(s):"
                           << " fleet's previous: " << m_prev_system << " or moving to: " << target_system_id;
@@ -1087,7 +1087,7 @@ void Fleet::CalculateRouteTo(int target_system_id) {
     if (this->CanChangeDirectionEnRoute()) {
         std::pair<std::list<int>, double> path1;
         try {
-            path1 = GetUniverse().GetPathfinder()->ShortestPath(m_next_system, dest_system_id, this->Owner());
+            path1 = GetPathfinder()->ShortestPath(m_next_system, dest_system_id, this->Owner());
         } catch (...) {
             DebugLogger() << "Fleet::CalculateRoute couldn't find route to system(s):"
                           << " fleet's next: " << m_next_system << " or destination: " << dest_system_id;
@@ -1108,7 +1108,7 @@ void Fleet::CalculateRouteTo(int target_system_id) {
 
         std::pair<std::list<int>, double> path2;
         try {
-            path2 = GetUniverse().GetPathfinder()->ShortestPath(m_prev_system, dest_system_id, this->Owner());
+            path2 = GetPathfinder()->ShortestPath(m_prev_system, dest_system_id, this->Owner());
         } catch (...) {
             DebugLogger() << "Fleet::CalculateRoute couldn't find route to system(s):"
                           << " fleet's previous: " << m_prev_system << " or destination: " << dest_system_id;
@@ -1138,7 +1138,7 @@ void Fleet::CalculateRouteTo(int target_system_id) {
         // Cannot change direction. Must go to the end of the current starlane
         std::pair<std::list<int>, double> path;
         try {
-            path = GetUniverse().GetPathfinder()->ShortestPath(m_next_system, dest_system_id, this->Owner());
+            path = GetPathfinder()->ShortestPath(m_next_system, dest_system_id, this->Owner());
         } catch (...) {
             DebugLogger() << "Fleet::CalculateRoute couldn't find route to system(s):"
                           << " fleet's next: " << m_next_system << " or destination: " << dest_system_id;

--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -4,6 +4,7 @@
 #include "ShipDesign.h"
 #include "Ship.h"
 #include "System.h"
+#include "Pathfinder.h"
 #include "Universe.h"
 #include "Enums.h"
 #include "../util/i18n.h"
@@ -25,7 +26,7 @@ namespace {
     const double FLEET_MOVEMENT_EPSILON = 0.1;  // how close a fleet needs to be to a system to have arrived in the system
 
     bool SystemHasNoVisibleStarlanes(int system_id, int empire_id)
-    { return !GetUniverse().SystemHasVisibleStarlanes(system_id, empire_id); }
+    { return !GetUniverse().GetPathfinder()->SystemHasVisibleStarlanes(system_id, empire_id); }
 
     template<typename IT>
     double PathLength (const IT& begin, const IT& end) {
@@ -153,7 +154,7 @@ void Fleet::Copy(std::shared_ptr<const UniverseObject> copied_object, int empire
                 ShortenRouteToEndAtSystem(travel_route, moving_to);
                 if (!travel_route.empty() && travel_route.front() != 0 && travel_route.size() != copied_fleet_route.size()) {
                     try {
-                        travel_distance -= GetUniverse().ShortestPath(travel_route.back(),
+                        travel_distance -= GetUniverse().GetPathfinder()->ShortestPath(travel_route.back(),
                                                                       copied_fleet_route.back()).second;
                     } catch (...) {
                         DebugLogger() << "Fleet::Copy couldn't find route to system(s):"
@@ -1046,7 +1047,7 @@ void Fleet::CalculateRouteTo(int target_system_id) {
 
         std::pair<std::list<int>, double> path;
         try {
-            path = GetUniverse().ShortestPath(m_prev_system, target_system_id, this->Owner());
+            path = GetUniverse().GetPathfinder()->ShortestPath(m_prev_system, target_system_id, this->Owner());
         } catch (...) {
             DebugLogger() << "Fleet::CalculateRoute couldn't find route to system(s):"
                           << " fleet's previous: " << m_prev_system << " or moving to: " << target_system_id;
@@ -1086,7 +1087,7 @@ void Fleet::CalculateRouteTo(int target_system_id) {
     if (this->CanChangeDirectionEnRoute()) {
         std::pair<std::list<int>, double> path1;
         try {
-            path1 = GetUniverse().ShortestPath(m_next_system, dest_system_id, this->Owner());
+            path1 = GetUniverse().GetPathfinder()->ShortestPath(m_next_system, dest_system_id, this->Owner());
         } catch (...) {
             DebugLogger() << "Fleet::CalculateRoute couldn't find route to system(s):"
                           << " fleet's next: " << m_next_system << " or destination: " << dest_system_id;
@@ -1107,7 +1108,7 @@ void Fleet::CalculateRouteTo(int target_system_id) {
 
         std::pair<std::list<int>, double> path2;
         try {
-            path2 = GetUniverse().ShortestPath(m_prev_system, dest_system_id, this->Owner());
+            path2 = GetUniverse().GetPathfinder()->ShortestPath(m_prev_system, dest_system_id, this->Owner());
         } catch (...) {
             DebugLogger() << "Fleet::CalculateRoute couldn't find route to system(s):"
                           << " fleet's previous: " << m_prev_system << " or destination: " << dest_system_id;
@@ -1137,7 +1138,7 @@ void Fleet::CalculateRouteTo(int target_system_id) {
         // Cannot change direction. Must go to the end of the current starlane
         std::pair<std::list<int>, double> path;
         try {
-            path = GetUniverse().ShortestPath(m_next_system, dest_system_id, this->Owner());
+            path = GetUniverse().GetPathfinder()->ShortestPath(m_next_system, dest_system_id, this->Owner());
         } catch (...) {
             DebugLogger() << "Fleet::CalculateRoute couldn't find route to system(s):"
                           << " fleet's next: " << m_next_system << " or destination: " << dest_system_id;

--- a/universe/Pathfinder.cpp
+++ b/universe/Pathfinder.cpp
@@ -475,7 +475,7 @@ namespace {
 
         struct EdgeVisibilityFilter     {
             EdgeVisibilityFilter() :
-                m_graph(0),
+                m_graph(nullptr),
                 m_empire_id(ALL_EMPIRES)
             {}
 

--- a/universe/Pathfinder.cpp
+++ b/universe/Pathfinder.cpp
@@ -501,7 +501,7 @@ namespace {
                 int sys_id_2 = sys_id_property_map[sys_graph_index_2];
 
                 // look up lane between systems
-                TemporaryPtr<const System> system1 = GetEmpireKnownSystem(sys_id_1, m_empire_id);
+                boost::shared_ptr<const System> system1 = GetEmpireKnownSystem(sys_id_1, m_empire_id);
                 if (!system1) {
                     ErrorLogger() << "EdgeDescriptor::operator() couldn't find system with id " << sys_id_1;
                     return false;
@@ -572,10 +572,10 @@ Pathfinder::~Pathfinder() {
 }
 
 namespace {
-    TemporaryPtr<const Fleet> FleetFromObject(TemporaryPtr<const UniverseObject> obj) {
-        TemporaryPtr<const Fleet> retval = boost::dynamic_pointer_cast<const Fleet>(obj);
+    boost::shared_ptr<const Fleet> FleetFromObject(boost::shared_ptr<const UniverseObject> obj) {
+        boost::shared_ptr<const Fleet> retval = boost::dynamic_pointer_cast<const Fleet>(obj);
         if (!retval) {
-            if (TemporaryPtr<const Ship> ship = boost::dynamic_pointer_cast<const Ship>(obj))
+            if (boost::shared_ptr<const Ship> ship = boost::dynamic_pointer_cast<const Ship>(obj))
                 retval = GetFleet(ship->FleetID());
         }
         return retval;
@@ -587,12 +587,12 @@ double Pathfinder::LinearDistance(int system1_id, int system2_id) const {
 }
 
 double Pathfinder::PathfinderImpl::LinearDistance(int system1_id, int system2_id) const {
-    TemporaryPtr<const System> system1 = GetSystem(system1_id);
+    boost::shared_ptr<const System> system1 = GetSystem(system1_id);
     if (!system1) {
         ErrorLogger() << "Universe::LinearDistance passed invalid system id: " << system1_id;
         throw std::out_of_range("system1_id invalid");
     }
-    TemporaryPtr<const System> system2 = GetSystem(system2_id);
+    boost::shared_ptr<const System> system2 = GetSystem(system2_id);
     if (!system2) {
         ErrorLogger() << "Universe::LinearDistance passed invalid system id: " << system2_id;
         throw std::out_of_range("system2_id invalid");
@@ -656,16 +656,16 @@ int Pathfinder::JumpDistanceBetweenObjects(int object1_id, int object2_id) const
 }
 
 int Pathfinder::PathfinderImpl::JumpDistanceBetweenObjects(int object1_id, int object2_id) const {
-    TemporaryPtr<const UniverseObject> obj1 = GetUniverseObject(object1_id);
+    boost::shared_ptr<const UniverseObject> obj1 = GetUniverseObject(object1_id);
     if (!obj1)
         return INT_MAX;
 
-    TemporaryPtr<const UniverseObject> obj2 = GetUniverseObject(object2_id);
+    boost::shared_ptr<const UniverseObject> obj2 = GetUniverseObject(object2_id);
     if (!obj2)
         return INT_MAX;
 
-    TemporaryPtr<const System> system_one = GetSystem(obj1->SystemID());
-    TemporaryPtr<const System> system_two = GetSystem(obj2->SystemID());
+    boost::shared_ptr<const System> system_one = GetSystem(obj1->SystemID());
+    boost::shared_ptr<const System> system_two = GetSystem(obj2->SystemID());
 
     if (system_one && system_two) {
         // both condition-matching object and candidate are / in systems.
@@ -685,7 +685,7 @@ int Pathfinder::PathfinderImpl::JumpDistanceBetweenObjects(int object1_id, int o
         // just object one is / in a system.
         // TODO generalize Object to report multiple systems for things
         // like fleets in transit
-        if (TemporaryPtr<const Fleet> fleet = FleetFromObject(obj2)) {
+        if (boost::shared_ptr<const Fleet> fleet = FleetFromObject(obj2)) {
             // other object is a fleet that is between systems
             // need to check shortest path from systems on either side of starlane fleet is on
             short jumps1 = -1, jumps2 = -1;
@@ -708,7 +708,7 @@ int Pathfinder::PathfinderImpl::JumpDistanceBetweenObjects(int object1_id, int o
 
     } else if (system_two) {
         // just object two is a system.
-        if (TemporaryPtr<const Fleet> fleet = FleetFromObject(obj1)) {
+        if (boost::shared_ptr<const Fleet> fleet = FleetFromObject(obj1)) {
             // other object is a fleet that is between systems
             // need to check shortest path from systems on either side of starlane fleet is on
             short jumps1 = -1, jumps2 = -1;
@@ -731,8 +731,8 @@ int Pathfinder::PathfinderImpl::JumpDistanceBetweenObjects(int object1_id, int o
     } else {
         // neither object is / in a system
 
-        TemporaryPtr<const Fleet> fleet_one = FleetFromObject(obj1);
-        TemporaryPtr<const Fleet> fleet_two = FleetFromObject(obj2);
+        boost::shared_ptr<const Fleet> fleet_one = FleetFromObject(obj1);
+        boost::shared_ptr<const Fleet> fleet_two = FleetFromObject(obj2);
 
         if (fleet_one && fleet_two) {
             // both objects are / in a fleet.
@@ -812,25 +812,25 @@ double Pathfinder::PathfinderImpl::ShortestPathDistance(int object1_id, int obje
     // If one or both objects are (in) a fleet between systems, use the destination system
     // and add the distance from the fleet to the destination system, essentially calculating
     // the distance travelled until both could be in the same system.
-    TemporaryPtr<const UniverseObject> obj1 = GetUniverseObject(object1_id);
+    boost::shared_ptr<const UniverseObject> obj1 = GetUniverseObject(object1_id);
     if (!obj1)
         return -1;
 
-    TemporaryPtr<const UniverseObject> obj2 = GetUniverseObject(object2_id);
+    boost::shared_ptr<const UniverseObject> obj2 = GetUniverseObject(object2_id);
     if (!obj2)
         return -1;
 
-    TemporaryPtr<const System> system_one = GetSystem(obj1->SystemID());
-    TemporaryPtr<const System> system_two = GetSystem(obj2->SystemID());
+    boost::shared_ptr<const System> system_one = GetSystem(obj1->SystemID());
+    boost::shared_ptr<const System> system_two = GetSystem(obj2->SystemID());
     std::pair< std::list< int >, double > path_len_pair;
     double dist1(0.0), dist2(0.0);
-    TemporaryPtr<const Fleet> fleet;
+    boost::shared_ptr<const Fleet> fleet;
 
     if (!system_one) {
         fleet = FleetFromObject(obj1);
         if (!fleet)
             return -1;
-        if (TemporaryPtr<const System> next_sys = GetSystem(fleet->NextSystemID())) {
+        if (boost::shared_ptr<const System> next_sys = GetSystem(fleet->NextSystemID())) {
             system_one = next_sys;
             dist1 = std::sqrt(pow((next_sys->X() - fleet->X()), 2) + pow((next_sys->Y() - fleet->Y()), 2));
         }
@@ -840,7 +840,7 @@ double Pathfinder::PathfinderImpl::ShortestPathDistance(int object1_id, int obje
         fleet = FleetFromObject(obj2);
         if (!fleet)
             return -1;
-        if (TemporaryPtr<const System> next_sys = GetSystem(fleet->NextSystemID())) {
+        if (boost::shared_ptr<const System> next_sys = GetSystem(fleet->NextSystemID())) {
             system_two = next_sys;
             dist2 = std::sqrt(pow((next_sys->X() - fleet->X()), 2) + pow((next_sys->Y() - fleet->Y()), 2));
         }
@@ -910,7 +910,7 @@ bool Pathfinder::SystemHasVisibleStarlanes(int system_id, int empire_id) const {
 }
 
 bool Pathfinder::PathfinderImpl::SystemHasVisibleStarlanes(int system_id, int empire_id) const {
-    if (TemporaryPtr<const System> system = GetEmpireKnownSystem(system_id, empire_id))
+    if (boost::shared_ptr<const System> system = GetEmpireKnownSystem(system_id, empire_id))
         if (!system->StarlanesWormholes().empty())
             return true;
     return false;
@@ -939,7 +939,7 @@ int Pathfinder::PathfinderImpl::NearestSystemTo(double x, double y) const {
     double min_dist2 = DBL_MAX;
     int min_dist2_sys_id = INVALID_OBJECT_ID;
 
-    std::vector<TemporaryPtr<System> > systems = Objects().FindObjects<System>();
+    std::vector<boost::shared_ptr<System> > systems = Objects().FindObjects<System>();
 
     for (auto const &system : systems)
     {
@@ -990,8 +990,8 @@ void Pathfinder::PathfinderImpl::InitializeSystemGraph(const std::vector<int> sy
     // add edges for all starlanes
     for (size_t system1_index = 0; system1_index < system_ids.size(); ++system1_index) {
         int system1_id = system_ids[system1_index];
-        TemporaryPtr<const System> system1 = GetEmpireKnownSystem(system1_id, for_empire_id);
-        //TemporaryPtr<const System> & system1 = systems[system1_index];
+        boost::shared_ptr<const System> system1 = GetEmpireKnownSystem(system1_id, for_empire_id);
+        //boost::shared_ptr<const System> & system1 = systems[system1_index];
 
         // add edges and edge weights
         for (auto const & lane_dest : system1->StarlanesWormholes()) {

--- a/universe/Pathfinder.cpp
+++ b/universe/Pathfinder.cpp
@@ -58,7 +58,7 @@ namespace {
             m_data.resize(a_size);
             m_row_mutexes.resize(a_size);
             for (auto &row_mutex : m_row_mutexes)
-                row_mutex = std::shared_ptr<boost::shared_mutex>(new boost::shared_mutex());
+                row_mutex = std::make_shared<boost::shared_mutex>();
         }
 
         /**N x N table of hop distances in row column form.*/
@@ -962,7 +962,7 @@ void Pathfinder::InitializeSystemGraph(const std::vector<int> system_ids, int fo
 
 void Pathfinder::PathfinderImpl::InitializeSystemGraph(const std::vector<int> system_ids, int for_empire_id) {
     typedef boost::graph_traits<GraphImpl::SystemGraph>::edge_descriptor EdgeDescriptor;
-    std::shared_ptr<GraphImpl> new_graph_impl(new GraphImpl());
+    auto new_graph_impl{std::make_shared<GraphImpl>()};
     // std::vector<int> system_ids = ::EmpireKnownObjects(for_empire_id).FindObjectIDs<System>();
     // NOTE: this initialization of graph_changed prevents testing for edges between nonexistant vertices
     bool graph_changed = system_ids.size() != boost::num_vertices(m_graph_impl->system_graph);
@@ -1056,16 +1056,14 @@ void Pathfinder::PathfinderImpl::UpdateEmpireVisibilityFilteredSystemGraphs(int 
         for (auto const &empire : Empires()) {
             int empire_id = empire.first;
             GraphImpl::EdgeVisibilityFilter filter(&m_graph_impl->system_graph, empire_id);
-            std::shared_ptr<GraphImpl::EmpireViewSystemGraph> filtered_graph_ptr(
-                new GraphImpl::EmpireViewSystemGraph(m_graph_impl->system_graph, filter));
+            auto filtered_graph_ptr{std::make_shared<GraphImpl::EmpireViewSystemGraph>(m_graph_impl->system_graph, filter)};
             m_graph_impl->empire_system_graph_views[empire_id] = filtered_graph_ptr;
         }
 
     } else {
         // all empires share a single filtered graph, filtered by the for_empire_id
         GraphImpl::EdgeVisibilityFilter filter(&m_graph_impl->system_graph, for_empire_id);
-        std::shared_ptr<GraphImpl::EmpireViewSystemGraph> filtered_graph_ptr(
-            new GraphImpl::EmpireViewSystemGraph(m_graph_impl->system_graph, filter));
+        auto filtered_graph_ptr{std::make_shared<GraphImpl::EmpireViewSystemGraph>(m_graph_impl->system_graph, filter)};
 
         for (auto const &empire : Empires()) {
             int empire_id = empire.first;

--- a/universe/Pathfinder.cpp
+++ b/universe/Pathfinder.cpp
@@ -962,7 +962,7 @@ void Pathfinder::InitializeSystemGraph(const std::vector<int> system_ids, int fo
 
 void Pathfinder::PathfinderImpl::InitializeSystemGraph(const std::vector<int> system_ids, int for_empire_id) {
     typedef boost::graph_traits<GraphImpl::SystemGraph>::edge_descriptor EdgeDescriptor;
-    auto new_graph_impl{std::make_shared<GraphImpl>()};
+    auto new_graph_impl = std::make_shared<GraphImpl>();
     // std::vector<int> system_ids = ::EmpireKnownObjects(for_empire_id).FindObjectIDs<System>();
     // NOTE: this initialization of graph_changed prevents testing for edges between nonexistant vertices
     bool graph_changed = system_ids.size() != boost::num_vertices(m_graph_impl->system_graph);
@@ -1056,14 +1056,14 @@ void Pathfinder::PathfinderImpl::UpdateEmpireVisibilityFilteredSystemGraphs(int 
         for (auto const &empire : Empires()) {
             int empire_id = empire.first;
             GraphImpl::EdgeVisibilityFilter filter(&m_graph_impl->system_graph, empire_id);
-            auto filtered_graph_ptr{std::make_shared<GraphImpl::EmpireViewSystemGraph>(m_graph_impl->system_graph, filter)};
+            auto filtered_graph_ptr = std::make_shared<GraphImpl::EmpireViewSystemGraph>(m_graph_impl->system_graph, filter);
             m_graph_impl->empire_system_graph_views[empire_id] = filtered_graph_ptr;
         }
 
     } else {
         // all empires share a single filtered graph, filtered by the for_empire_id
         GraphImpl::EdgeVisibilityFilter filter(&m_graph_impl->system_graph, for_empire_id);
-        auto filtered_graph_ptr{std::make_shared<GraphImpl::EmpireViewSystemGraph>(m_graph_impl->system_graph, filter)};
+        auto filtered_graph_ptr = std::make_shared<GraphImpl::EmpireViewSystemGraph>(m_graph_impl->system_graph, filter);
 
         for (auto const &empire : Empires()) {
             int empire_id = empire.first;

--- a/universe/Pathfinder.cpp
+++ b/universe/Pathfinder.cpp
@@ -1,0 +1,836 @@
+#include "Pathfinder.h"
+
+#include "../util/OptionsDB.h"
+#include "../util/i18n.h"
+#include "../util/Logger.h"
+#include "../util/Random.h"
+#include "../util/RunQueue.h"
+#include "../util/ScopedTimer.h"
+#include "../parse/Parse.h"
+#include "../Empire/Empire.h"
+#include "../Empire/EmpireManager.h"
+#include "Building.h"
+#include "Fleet.h"
+#include "Planet.h"
+#include "Ship.h"
+#include "ShipDesign.h"
+#include "System.h"
+#include "Field.h"
+#include "UniverseObject.h"
+#include "Predicates.h"
+#include "Special.h"
+#include "Species.h"
+#include "Condition.h"
+#include "ValueRef.h"
+#include "Universe.h"
+
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/split.hpp>
+#include <boost/filesystem/fstream.hpp>
+#include <boost/graph/adjacency_list.hpp>
+#include <boost/graph/breadth_first_search.hpp>
+#include <boost/graph/dijkstra_shortest_paths.hpp>
+#include <boost/graph/filtered_graph.hpp>
+#include <boost/noncopyable.hpp>
+#include <boost/optional/optional.hpp>
+#include <boost/property_map/property_map.hpp>
+#include <boost/smart_ptr/shared_ptr.hpp>
+#include <boost/thread/condition_variable.hpp>
+#include <boost/thread/locks.hpp>
+#include <boost/thread/shared_mutex.hpp>
+#include <boost/timer.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <list>
+#include <stdexcept>
+
+namespace {
+    const double    WORMHOLE_TRAVEL_DISTANCE = 0.1;         // the effective distance for ships travelling along a wormhole, for determining how much of their speed is consumed by the jump
+}
+
+namespace SystemPathing {
+    /** Used to short-circuit the use of BFS (breadth-first search) or
+      * Dijkstra's algorithm for pathfinding when it finds the desired
+      * destination system. */
+    struct PathFindingShortCircuitingVisitor : public boost::base_visitor<PathFindingShortCircuitingVisitor>
+    {
+        typedef boost::on_finish_vertex event_filter;
+
+        struct FoundDestination {}; // exception type thrown when destination is found
+
+        PathFindingShortCircuitingVisitor(int dest_system) : destination_system(dest_system) {}
+        template <class Vertex, class Graph>
+        void operator()(Vertex u, Graph& g)
+        {
+            if (static_cast<int>(u) == destination_system)
+                throw FoundDestination();
+        }
+        const int destination_system;
+    };
+
+    /** Complete BFS visitor implementing:
+      *  - predecessor recording
+      *  - short-circuit exit on found match
+      *  - maximum search depth
+      */
+    template <class Graph, class Edge, class Vertex> class BFSVisitorImpl
+    {
+    public:
+        class FoundDestination {};
+        class ReachedDepthLimit {};
+
+    private:
+        Vertex m_marker;
+        Vertex m_stop;
+        Vertex m_source;
+        Vertex * m_predecessors;
+        int m_levels_remaining;
+        bool m_level_complete;
+
+    public:
+        BFSVisitorImpl(const Vertex& start, const Vertex& stop, Vertex predecessors[], int max_depth)
+            : m_marker(start),
+              m_stop(stop),
+              m_source(start),
+              m_predecessors(predecessors),
+              m_levels_remaining(max_depth),
+              m_level_complete(false)
+        {}
+
+        void initialize_vertex(const Vertex& v, const Graph& g)
+        {}
+
+        void discover_vertex(const Vertex& v, const Graph& g) {
+            m_predecessors[static_cast<int>(v)] = m_source;
+
+            if (v == m_stop)
+                throw FoundDestination();
+
+            if (m_level_complete) {
+                m_marker = v;
+                m_level_complete = false;
+            }
+        }
+
+        void examine_vertex(const Vertex& v, const Graph& g) {
+            if (v == m_marker) {
+                if (!m_levels_remaining)
+                    throw ReachedDepthLimit();
+                m_levels_remaining--;
+                m_level_complete = true;
+            }
+
+            m_source = v; // avoid re-calculating source from edge
+        }
+
+        void examine_edge(const Edge& e, const Graph& g) {}
+        void tree_edge(const Edge& e, const Graph& g) {}    // wait till target is calculated
+
+
+        void non_tree_edge(const Edge& e, const Graph& g) {}
+        void gray_target(const Edge& e, const Graph& g) {}
+        void black_target(const Edge& e, const Graph& g) {}
+        void finish_vertex(const Vertex& e, const Graph& g) {}
+    };
+
+    ////////////////////////////////////////////////////////////////
+    // templated implementations of Universe graph search methods //
+    ////////////////////////////////////////////////////////////////
+    struct vertex_system_id_t {typedef boost::vertex_property_tag kind;}; ///< a system graph property map type
+
+    /** Returns the path between vertices \a system1_id and \a system2_id of
+      * \a graph that travels the shorest distance on starlanes, and the path
+      * length.  If system1_id is the same vertex as system2_id, the path has
+      * just that system in it, and the path lenth is 0.  If there is no path
+      * between the two vertices, then the list is empty and the path length
+      * is -1.0 */
+    template <class Graph>
+    std::pair<std::list<int>, double> ShortestPathImpl(const Graph& graph, int system1_id, int system2_id,
+                                                       double linear_distance, const boost::unordered_map<int, size_t>& id_to_graph_index)
+    {
+        typedef typename boost::property_map<Graph, vertex_system_id_t>::const_type     ConstSystemIDPropertyMap;
+        typedef typename boost::property_map<Graph, boost::vertex_index_t>::const_type  ConstIndexPropertyMap;
+        typedef typename boost::property_map<Graph, boost::edge_weight_t>::const_type   ConstEdgeWeightPropertyMap;
+
+        std::pair<std::list<int>, double> retval(std::list<int>(), -1.0);
+
+        ConstSystemIDPropertyMap sys_id_property_map = boost::get(vertex_system_id_t(), graph);
+
+        // convert system IDs to graph indices.  try/catch for invalid input system ids.
+        size_t system1_index, system2_index;
+        try {
+            system1_index = id_to_graph_index.at(system1_id);
+            system2_index = id_to_graph_index.at(system2_id);
+        } catch (...) {
+            return retval;
+        }
+
+        // early exit if systems are the same
+        if (system1_id == system2_id) {
+            retval.first.push_back(system2_id);
+            retval.second = 0.0;    // no jumps needed -> 0 distance
+            return retval;
+        }
+
+        /* initializing all vertices' predecessors to themselves prevents endless loops when back traversing the tree in the case where
+           one of the end systems is system 0, because systems that are not connected to the root system (system2) are not visited
+           by the search, and so their predecessors are left unchanged.  Default initialization of the vector may be 0 or undefined
+           which could lead to out of bounds errors, or endless loops if a system's default predecessor is 0 (debug mode), and 0's
+           predecessor is that system */
+        std::vector<int> predecessors(boost::num_vertices(graph));
+        std::vector<double> distances(boost::num_vertices(graph));
+        for (unsigned int i = 0; i < boost::num_vertices(graph); ++i) {
+            predecessors[i] = i;
+            distances[i] = -1.0;
+        }
+
+
+        ConstIndexPropertyMap index_map = boost::get(boost::vertex_index, graph);
+        ConstEdgeWeightPropertyMap edge_weight_map = boost::get(boost::edge_weight, graph);
+
+
+        // do the actual path finding using verbose boost magic...
+        try {
+            boost::dijkstra_shortest_paths(graph, system1_index, &predecessors[0], &distances[0], edge_weight_map, index_map,
+                                           std::less<double>(), std::plus<double>(), std::numeric_limits<int>::max(), 0,
+                                           boost::make_dijkstra_visitor(PathFindingShortCircuitingVisitor(system2_index)));
+        } catch (const PathFindingShortCircuitingVisitor::FoundDestination&) {
+            // catching this just means that the destination was found, and so the algorithm was exited early, via exception
+        }
+
+
+        int current_system = system2_index;
+        while (predecessors[current_system] != current_system) {
+            retval.first.push_front(sys_id_property_map[current_system]);
+            current_system = predecessors[current_system];
+        }
+        retval.second = distances[system2_index];
+
+        if (retval.first.empty()) {
+            // there is no path between the specified nodes
+            retval.second = -1.0;
+            return retval;
+        } else {
+            // add start system to path, as it wasn't added by traversing predecessors array
+            retval.first.push_front(sys_id_property_map[system1_index]);
+        }
+
+        return retval;
+    }
+
+    /** Returns the path between vertices \a system1_id and \a system2_id of
+      * \a graph that takes the fewest number of jumps (edge traversals), and
+      * the number of jumps this path takes.  If system1_id is the same vertex
+      * as system2_id, the path has just that system in it, and the path lenth
+      * is 0.  If there is no path between the two vertices, then the list is
+      * empty and the path length is -1 */
+    template <class Graph>
+    std::pair<std::list<int>, int> LeastJumpsPathImpl(const Graph& graph, int system1_id, int system2_id,
+                                                      const boost::unordered_map<int, size_t>& id_to_graph_index,
+                                                      int max_jumps = INT_MAX)
+    {
+        typedef typename boost::property_map<Graph, vertex_system_id_t>::const_type ConstSystemIDPropertyMap;
+
+        ConstSystemIDPropertyMap sys_id_property_map = boost::get(vertex_system_id_t(), graph);
+        std::pair<std::list<int>, int> retval;
+
+        size_t system1_index = id_to_graph_index.at(system1_id);
+        size_t system2_index = id_to_graph_index.at(system2_id);
+
+        // early exit if systems are the same
+        if (system1_id == system2_id) {
+            retval.first.push_back(system2_id);
+            retval.second = 0;  // no jumps needed
+            return retval;
+        }
+
+        /* initializing all vertices' predecessors to themselves prevents endless loops when back traversing the tree in the case where
+           one of the end systems is system 0, because systems that are not connected to the root system (system2) are not visited
+           by the search, and so their predecessors are left unchanged.  Default initialization of the vector may be 0 or undefined
+           which could lead to out of bounds errors, or endless loops if a system's default predecessor is 0, (debug mode) and 0's
+           predecessor is that system */
+        std::vector<int> predecessors(boost::num_vertices(graph));
+        for (unsigned int i = 0; i < boost::num_vertices(graph); ++i)
+            predecessors[i] = i;
+
+
+        // do the actual path finding using verbose boost magic...
+        typedef BFSVisitorImpl<Graph, typename boost::graph_traits<Graph>::edge_descriptor, int> BFSVisitor;
+        try {
+            boost::queue<int> buf;
+            std::vector<int> colors(boost::num_vertices(graph));
+
+            BFSVisitor bfsVisitor(system1_index, system2_index, &predecessors[0], max_jumps);
+            boost::breadth_first_search(graph, system1_index, buf, bfsVisitor, &colors[0]);
+        } catch (const typename BFSVisitor::ReachedDepthLimit&) {
+            // catching this means the algorithm explored the neighborhood until max_jumps and didn't find anything
+            return std::make_pair(std::list<int>(), -1);
+        } catch (const typename BFSVisitor::FoundDestination&) {
+            // catching this just means that the destination was found, and so the algorithm was exited early, via exception
+        }
+
+
+        int current_system = system2_index;
+        while (predecessors[current_system] != current_system) {
+            retval.first.push_front(sys_id_property_map[current_system]);
+            current_system = predecessors[current_system];
+        }
+        retval.second = retval.first.size() - 1;    // number of jumps is number of systems in path minus one for the starting system
+
+        if (retval.first.empty()) {
+            // there is no path between the specified nodes
+            retval.second = -1;
+        } else {
+            // add start system to path, as it wasn't added by traversing predecessors array
+            retval.first.push_front(sys_id_property_map[system1_index]);
+        }
+
+        return retval;
+    }
+
+    template <class Graph>
+    std::multimap<double, int> ImmediateNeighborsImpl(const Graph& graph, int system_id,
+                                                      const boost::unordered_map<int, size_t>& id_to_graph_index)
+    {
+        typedef typename Graph::out_edge_iterator OutEdgeIterator;
+        typedef typename boost::property_map<Graph, vertex_system_id_t>::const_type ConstSystemIDPropertyMap;
+        typedef typename boost::property_map<Graph, boost::edge_weight_t>::const_type ConstEdgeWeightPropertyMap;
+
+        std::multimap<double, int> retval;
+        ConstEdgeWeightPropertyMap edge_weight_map = boost::get(boost::edge_weight, graph);
+        ConstSystemIDPropertyMap sys_id_property_map = boost::get(vertex_system_id_t(), graph);
+        std::pair<OutEdgeIterator, OutEdgeIterator> edges = boost::out_edges(id_to_graph_index.at(system_id), graph);
+        for (OutEdgeIterator it = edges.first; it != edges.second; ++it)
+        { retval.insert(std::make_pair(edge_weight_map[*it], sys_id_property_map[boost::target(*it, graph)])); }
+        return retval;
+    }
+}
+using namespace SystemPathing;  // to keep GCC 4.2 on OSX happy
+
+extern const int ALL_EMPIRES;
+
+namespace {
+
+    /// minimal public interface for distance caches
+    template <class T> struct distance_matrix_storage {
+        typedef T value_type;
+        typedef std::vector<T>& row_ref;
+
+        distance_matrix_storage() {};
+        distance_matrix_storage(const distance_matrix_storage<T>& src)
+        { resize(src.m_data.size()); };
+
+        size_t size()
+        { return m_data.size(); }
+
+        void resize(size_t a_size) {
+            const size_t old_size = size();
+
+            m_data.clear();
+            m_data.resize(a_size);
+            m_row_mutexes.resize(a_size);
+            for (size_t i = old_size; i < a_size; ++i)
+                m_row_mutexes[i] = boost::shared_ptr<boost::shared_mutex>(new boost::shared_mutex());
+        }
+
+        std::vector< std::vector<T> > m_data;
+        std::vector< boost::shared_ptr<boost::shared_mutex> > m_row_mutexes;
+        boost::shared_mutex m_mutex;
+    };
+
+    /////////////////////////////////////////////
+    // struct GraphImpl
+    /////////////////////////////////////////////
+    struct GraphImpl {
+        typedef boost::property<vertex_system_id_t, int,
+                                boost::property<boost::vertex_index_t, int> >   vertex_property_t;  ///< a system graph property map type
+        typedef boost::property<boost::edge_weight_t, double>                   edge_property_t;    ///< a system graph property map type
+
+        // declare main graph types, including properties declared above
+        // could add boost::disallow_parallel_edge_tag GraphProperty but it doesn't
+        // work for vecS vector-based lists and parallel edges can be avoided while
+        // creating the graph by filtering the edges to be added
+        typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS,
+                                      vertex_property_t, edge_property_t> SystemGraph;
+
+        struct EdgeVisibilityFilter     {
+            EdgeVisibilityFilter() :
+                m_graph(0),
+                m_empire_id(ALL_EMPIRES)
+            {}
+
+            EdgeVisibilityFilter(const SystemGraph* graph, int empire_id) :
+                m_graph(graph),
+                m_empire_id(empire_id)
+            {
+                if (!graph)
+                    ErrorLogger() << "EdgeVisibilityFilter passed null graph pointer";
+            }
+
+            template <typename EdgeDescriptor>
+            bool operator()(const EdgeDescriptor& edge) const
+            {
+                if (!m_graph)
+                    return false;
+
+                // get system ids from graph indices
+                ConstSystemIDPropertyMap sys_id_property_map = boost::get(vertex_system_id_t(), *m_graph); // for reverse-lookup System universe ID from graph index
+                int sys_graph_index_1 = boost::source(edge, *m_graph);
+                int sys_id_1 = sys_id_property_map[sys_graph_index_1];
+                int sys_graph_index_2 = boost::target(edge, *m_graph);
+                int sys_id_2 = sys_id_property_map[sys_graph_index_2];
+
+                // look up lane between systems
+                TemporaryPtr<const System> system1 = GetEmpireKnownSystem(sys_id_1, m_empire_id);
+                if (!system1) {
+                    ErrorLogger() << "EdgeDescriptor::operator() couldn't find system with id " << sys_id_1;
+                    return false;
+                }
+                if (system1->HasStarlaneTo(sys_id_2))
+                    return true;
+
+                // lane not found
+                return false;
+            }
+
+            private:
+            const SystemGraph*      m_graph;
+            int                     m_empire_id;
+        };
+        typedef boost::filtered_graph<SystemGraph, EdgeVisibilityFilter> EmpireViewSystemGraph;
+        typedef std::map<int, boost::shared_ptr<EmpireViewSystemGraph> > EmpireViewSystemGraphMap;
+
+        // declare property map types for properties declared above
+        typedef boost::property_map<SystemGraph, vertex_system_id_t>::const_type        ConstSystemIDPropertyMap;
+        typedef boost::property_map<SystemGraph, vertex_system_id_t>::type              SystemIDPropertyMap;
+        typedef boost::property_map<SystemGraph, boost::vertex_index_t>::const_type     ConstIndexPropertyMap;
+        typedef boost::property_map<SystemGraph, boost::vertex_index_t>::type           IndexPropertyMap;
+        typedef boost::property_map<SystemGraph, boost::edge_weight_t>::const_type      ConstEdgeWeightPropertyMap;
+        typedef boost::property_map<SystemGraph, boost::edge_weight_t>::type            EdgeWeightPropertyMap;
+
+        SystemGraph                 system_graph;                 ///< a graph in which the systems are vertices and the starlanes are edges
+        EmpireViewSystemGraphMap    empire_system_graph_views;    ///< a map of empire IDs to the views of the system graph by those empires
+    };
+}
+
+/////////////////////////////////////////////
+// class PathfinderImpl
+/////////////////////////////////////////////
+class Pathfinder::PathfinderImpl {
+    public:
+
+    PathfinderImpl(): m_graph_impl(new GraphImpl) {}
+
+    double LinearDistance(int object1_id, int object2_id) const;
+    short JumpDistanceBetweenSystems(int system1_id, int system2_id) const;
+    //TODO smokeun int                     JumpDistanceBetweenObjects(int object1_id, int object2_id) const;
+    std::pair<std::list<int>, double> ShortestPath(int system1_id, int system2_id, int empire_id = ALL_EMPIRES) const;
+    //TODO smokeun double                  ShortestPathDistance(int object1_id, int object2_id) const;
+    std::pair<std::list<int>, int> LeastJumpsPath(
+        int system1_id, int system2_id, int empire_id = ALL_EMPIRES, int max_jumps = INT_MAX) const;
+    bool SystemsConnected(int system1_id, int system2_id, int empire_id = ALL_EMPIRES) const;
+    bool SystemHasVisibleStarlanes(int system_id, int empire_id = ALL_EMPIRES) const;
+    std::multimap<double, int> ImmediateNeighbors(int system_id, int empire_id = ALL_EMPIRES) const;
+    int NearestSystemTo(double x, double y) const;
+    void InitializeSystemGraph(const std::vector<int> system_ids, int for_empire_id = ALL_EMPIRES);
+    void UpdateEmpireVisibilityFilteredSystemGraphs(int for_empire_id = ALL_EMPIRES);
+
+
+    mutable distance_matrix_storage<short>  m_system_jumps;             ///< indexed by system graph index (not system id), caches the smallest number of jumps to travel between all the systems
+    boost::shared_ptr<GraphImpl>            m_graph_impl;               ///< a graph in which the systems are vertices and the starlanes are edges
+    boost::unordered_map<int, size_t>       m_system_id_to_graph_index;
+};
+
+/////////////////////////////////////////////
+// class Pathfinder
+/////////////////////////////////////////////
+Pathfinder::Pathfinder() :
+    pimpl(new PathfinderImpl)
+{}
+
+Pathfinder::~Pathfinder() {
+}
+
+namespace {
+    // wrapper around Pathfinder::distance_matrix_storage
+    // implementing functionality outside the public header
+    // the cache assumes the matrix to be symmetric
+    template <class Storage, class T = typename Storage::value_type, class Row = typename Storage::row_ref>
+    class distance_matrix_cache {
+    public:
+        distance_matrix_cache(Storage& the_storage) : m_storage(the_storage) {}
+        size_t size() {
+            boost::shared_lock<boost::shared_mutex> guard(m_storage.m_mutex);
+            return m_storage.size();
+        }
+        void resize(size_t a_size) {
+            boost::unique_lock<boost::shared_mutex> guard(m_storage.m_mutex);
+            m_storage.resize(a_size);
+        }
+
+        class row_lock {
+        private:
+            boost::shared_lock<boost::shared_mutex> m_lock;
+            boost::unique_lock<boost::shared_mutex> m_row_lock;
+
+            void swap(boost::shared_lock<boost::shared_mutex>& guard, boost::unique_lock<boost::shared_mutex>& row_guard) {
+                m_lock.swap(guard);
+                m_row_lock.swap(row_guard);
+            }
+            friend class distance_matrix_cache<Storage, T, Row>;
+
+        public:
+            row_lock() {};
+            void swap(row_lock& other) {
+                m_lock.swap(other.m_lock);
+                m_row_lock.swap(other.m_row_lock);
+            }
+            void unlock() {
+                m_row_lock.unlock();
+                m_lock.unlock();
+            }
+        };
+
+    public:
+        /** try to retrieve an element, lock the whole row on cache miss
+          * if \a lock already holds a lock, it will be unlocked after locking the row.
+          */
+        boost::optional<T> get_or_lock_row(size_t row_index, size_t column_index, row_lock& lock) const {
+            boost::shared_lock<boost::shared_mutex> guard(m_storage.m_mutex);
+
+            if (row_index < m_storage.size() && column_index < m_storage.size()) {
+                {
+                    boost::shared_lock<boost::shared_mutex> row_guard(*m_storage.m_row_mutexes[row_index]);
+                    Row row_data = m_storage.m_data[row_index];
+
+                    if (column_index < row_data.size())
+                        return row_data[column_index];
+                }
+                {
+                    boost::shared_lock<boost::shared_mutex> column_guard(*m_storage.m_row_mutexes[column_index]);
+                    Row column_data = m_storage.m_data[column_index];
+
+                    if (row_index < column_data.size())
+                        return column_data[row_index];
+                }
+                {
+                    boost::unique_lock<boost::shared_mutex> row_guard(*m_storage.m_row_mutexes[row_index]);
+                    Row row_data = m_storage.m_data[row_index];
+
+                    if (column_index < row_data.size()) {
+                        return row_data[column_index];
+                    } else {
+                        lock.swap(guard, row_guard);
+
+                        return boost::optional<T>();
+                    }
+                }
+            } else {
+                ErrorLogger() << "distance_matrix_cache::get_or_lock_row passed invalid node indices: " << row_index << "," << column_index << " matrix size: " << m_storage.size();
+                if (row_index < m_storage.size())
+                    throw std::out_of_range("column_index invalid");
+                else
+                    throw std::out_of_range("row_index invalid");
+            }
+
+            return boost::optional<T>(); // unreachable
+        }
+
+        /** replace the contents of a row with \a new_data.
+          * precondition: \a lock must hold a lock to the specified row.
+          */
+        void swap_and_unlock_row(size_t row_index, Row new_data, row_lock& lock) {
+            if (row_index < m_storage.size()) {
+                Row row_data = m_storage.m_data[row_index];
+
+                row_data.swap(new_data);
+            } else {
+                ErrorLogger() << "distance_matrix_cache::swap_and_unlock_row passed invalid node index: " << row_index << " matrix size: " << m_storage.size();
+                throw std::out_of_range("row_index invalid");
+            }
+
+            lock.unlock(); // only unlock on success
+        }
+    private:
+        Storage& m_storage;
+    };
+}
+
+
+double Pathfinder::LinearDistance(int system1_id, int system2_id) const {
+    return pimpl->LinearDistance(system1_id, system2_id);
+}
+
+double Pathfinder::PathfinderImpl::LinearDistance(int system1_id, int system2_id) const {
+    TemporaryPtr<const System> system1 = GetSystem(system1_id);
+    if (!system1) {
+        ErrorLogger() << "Universe::LinearDistance passed invalid system id: " << system1_id;
+        throw std::out_of_range("system1_id invalid");
+    }
+    TemporaryPtr<const System> system2 = GetSystem(system2_id);
+    if (!system2) {
+        ErrorLogger() << "Universe::LinearDistance passed invalid system id: " << system2_id;
+        throw std::out_of_range("system2_id invalid");
+    }
+    double x_dist = system2->X() - system1->X();
+    double y_dist = system2->Y() - system1->Y();
+    return std::sqrt(x_dist*x_dist + y_dist*y_dist);
+}
+
+short Pathfinder::JumpDistanceBetweenSystems(int system1_id, int system2_id) const {
+    return pimpl->JumpDistanceBetweenSystems(system1_id, system2_id);
+}
+
+short Pathfinder::PathfinderImpl::JumpDistanceBetweenSystems(int system1_id, int system2_id) const {
+    if (system1_id == system2_id)
+        return 0;
+
+    try {
+        distance_matrix_cache< distance_matrix_storage<short> > cache(m_system_jumps);
+        distance_matrix_cache< distance_matrix_storage<short> >::row_lock cache_guard;
+        size_t system1_index = m_system_id_to_graph_index.at(system1_id);
+        size_t system2_index = m_system_id_to_graph_index.at(system2_id);
+        size_t smaller_index = (std::min)(system1_index, system2_index);
+        size_t other_index   = (std::max)(system1_index, system2_index);
+        boost::optional<short> maybe_jumps = cache.get_or_lock_row(smaller_index, other_index, cache_guard); // prefer filling the smaller row/column for increased cache locality
+        short jumps;
+
+        if (maybe_jumps) {
+            // cache hit, any locks are already released
+            // get_value_or() in order to silence potentially-uninitialized warning
+            jumps = maybe_jumps.get_value_or(SHRT_MAX);
+        } else {
+            // cache miss, still holding a lock in cache_guard
+            // we are keeping the row locked during computation so other
+            // threads waiting for the same row will see a cache hit
+            typedef boost::iterator_property_map<std::vector<short>::iterator, boost::identity_property_map> DistancePropertyMap;
+
+            std::vector<short> private_distance_buffer(m_system_jumps.size(), SHRT_MAX);
+            DistancePropertyMap distance_property_map(private_distance_buffer.begin());
+            boost::distance_recorder<DistancePropertyMap, boost::on_tree_edge> distance_recorder(distance_property_map);
+
+            // FIXME: dont compute m_system_jumps[i][j] again as m_system_jumps[j][i]
+            private_distance_buffer[smaller_index] = 0;
+            boost::breadth_first_search(m_graph_impl->system_graph, smaller_index, boost::visitor(boost::make_bfs_visitor(distance_recorder)));
+            jumps = private_distance_buffer[other_index];
+            cache.swap_and_unlock_row(smaller_index, private_distance_buffer, cache_guard);
+        }
+        if (jumps == SHRT_MAX)  // value returned for no valid path
+            return -1;
+
+        return jumps;
+    } catch (const std::out_of_range&) {
+        ErrorLogger() << "PathfinderImpl::JumpDistanceBetweenSystems passed invalid system id(s): "
+                               << system1_id << " & " << system2_id;
+        throw;
+    }
+}
+
+std::pair<std::list<int>, double> Pathfinder::ShortestPath(int system1_id, int system2_id, int empire_id/* = ALL_EMPIRES*/) const {
+    return pimpl->ShortestPath(system1_id, system2_id, empire_id);
+}
+
+std::pair<std::list<int>, double> Pathfinder::PathfinderImpl::ShortestPath(int system1_id, int system2_id, int empire_id/* = ALL_EMPIRES*/) const {
+    if (empire_id == ALL_EMPIRES) {
+        // find path on full / complete system graph
+        try {
+            double linear_distance = LinearDistance(system1_id, system2_id);
+            return ShortestPathImpl(m_graph_impl->system_graph, system1_id, system2_id,
+                                    linear_distance, m_system_id_to_graph_index);
+        } catch (const std::out_of_range&) {
+            ErrorLogger() << "PathfinderImpl::ShortestPath passed invalid system id(s): "
+                                   << system1_id << " & " << system2_id;
+            throw;
+        }
+    }
+
+    // find path on single empire's view of system graph
+    GraphImpl::EmpireViewSystemGraphMap::const_iterator graph_it =
+        m_graph_impl->empire_system_graph_views.find(empire_id);
+    if (graph_it == m_graph_impl->empire_system_graph_views.end()) {
+        ErrorLogger() << "PathfinderImpl::ShortestPath passed unknown empire id: " << empire_id;
+        throw std::out_of_range("PathfinderImpl::ShortestPath passed unknown empire id");
+    }
+    try {
+        double linear_distance = LinearDistance(system1_id, system2_id);
+        return ShortestPathImpl(*graph_it->second, system1_id, system2_id,
+                                linear_distance, m_system_id_to_graph_index);
+    } catch (const std::out_of_range&) {
+        ErrorLogger() << "PathfinderImpl::ShortestPath passed invalid system id(s): "
+                      << system1_id << " & " << system2_id;
+        throw;
+    }
+}
+
+std::pair<std::list<int>, int> Pathfinder::LeastJumpsPath(
+    int system1_id, int system2_id, int empire_id/* = ALL_EMPIRES*/, int max_jumps/* = INT_MAX*/) const {
+    return pimpl->LeastJumpsPath(system1_id, system2_id, empire_id, max_jumps);
+}
+
+std::pair<std::list<int>, int> Pathfinder::PathfinderImpl::LeastJumpsPath(
+    int system1_id, int system2_id, int empire_id/* = ALL_EMPIRES*/, int max_jumps/* = INT_MAX*/) const
+{
+    if (empire_id == ALL_EMPIRES) {
+        // find path on full / complete system graph
+        try {
+            return LeastJumpsPathImpl(m_graph_impl->system_graph, system1_id, system2_id,
+                                      m_system_id_to_graph_index, max_jumps);
+        } catch (const std::out_of_range&) {
+            ErrorLogger() << "PathfinderImpl::LeastJumpsPath passed invalid system id(s): "
+                                   << system1_id << " & " << system2_id;
+            throw;
+        }
+    }
+
+    // find path on single empire's view of system graph
+    GraphImpl::EmpireViewSystemGraphMap::const_iterator graph_it =
+        m_graph_impl->empire_system_graph_views.find(empire_id);
+    if (graph_it == m_graph_impl->empire_system_graph_views.end()) {
+        ErrorLogger() << "PathfinderImpl::LeastJumpsPath passed unknown empire id: " << empire_id;
+        throw std::out_of_range("PathfinderImpl::LeastJumpsPath passed unknown empire id");
+    }
+    try {
+        return LeastJumpsPathImpl(*graph_it->second, system1_id, system2_id,
+                                  m_system_id_to_graph_index, max_jumps);
+    } catch (const std::out_of_range&) {
+        ErrorLogger() << "PathfinderImpl::LeastJumpsPath passed invalid system id(s): "
+                               << system1_id << " & " << system2_id;
+        throw;
+    }
+}
+
+std::multimap<double, int> Pathfinder::ImmediateNeighbors(int system_id, int empire_id/* = ALL_EMPIRES*/) const {
+    return pimpl->ImmediateNeighbors(system_id, empire_id);
+}
+
+std::multimap<double, int> Pathfinder::PathfinderImpl::ImmediateNeighbors(int system_id, int empire_id/* = ALL_EMPIRES*/) const {
+    if (empire_id == ALL_EMPIRES) {
+        return ImmediateNeighborsImpl(m_graph_impl->system_graph, system_id, m_system_id_to_graph_index);
+    } else {
+        GraphImpl::EmpireViewSystemGraphMap::const_iterator graph_it = m_graph_impl->empire_system_graph_views.find(empire_id);
+        if (graph_it != m_graph_impl->empire_system_graph_views.end())
+            return ImmediateNeighborsImpl(*graph_it->second, system_id, m_system_id_to_graph_index);
+    }
+    return std::multimap<double, int>();
+}
+
+void Pathfinder::InitializeSystemGraph(const std::vector<int> system_ids, int for_empire_id) {
+    return pimpl->InitializeSystemGraph(system_ids, for_empire_id);
+}
+
+void Pathfinder::PathfinderImpl::InitializeSystemGraph(const std::vector<int> system_ids, int for_empire_id) {
+    typedef boost::graph_traits<GraphImpl::SystemGraph>::edge_descriptor EdgeDescriptor;
+    boost::shared_ptr<GraphImpl> new_graph_impl(new GraphImpl());
+    // std::vector<int> system_ids = ::EmpireKnownObjects(for_empire_id).FindObjectIDs<System>();
+    // NOTE: this initialization of graph_changed prevents testing for edges between nonexistant vertices
+    bool graph_changed = system_ids.size() != boost::num_vertices(m_graph_impl->system_graph);
+    //DebugLogger() << "InitializeSystemGraph(" << for_empire_id << ") system_ids: (" << system_ids.size() << ")";
+    //for (std::vector<int>::const_iterator it = system_ids.begin(); it != system_ids.end(); ++it)
+    //    DebugLogger() << " ... " << *it;
+
+    GraphImpl::SystemIDPropertyMap sys_id_property_map =
+        boost::get(vertex_system_id_t(), new_graph_impl->system_graph);
+
+    GraphImpl::EdgeWeightPropertyMap edge_weight_map =
+        boost::get(boost::edge_weight, new_graph_impl->system_graph);
+
+    // add vertices to graph for all systems
+    for (size_t system_index = 0; system_index < system_ids.size(); ++system_index) {
+        // add a vertex to the graph for this system, and assign it the system's universe ID as a property
+        boost::add_vertex(new_graph_impl->system_graph);
+        int system_id = system_ids[system_index];
+        sys_id_property_map[system_index] = system_id;
+        // add record of index in new_graph_impl->system_graph of this system
+        m_system_id_to_graph_index[system_id] = system_index;
+    }
+
+    // add edges for all starlanes
+    for (size_t system1_index = 0; system1_index < system_ids.size(); ++system1_index) {
+        int system1_id = system_ids[system1_index];
+        TemporaryPtr<const System> system1 = GetEmpireKnownSystem(system1_id, for_empire_id);
+        //TemporaryPtr<const System> & system1 = systems[system1_index];
+
+        // add edges and edge weights
+        for (std::map<int, bool>::const_iterator it = system1->StarlanesWormholes().begin();
+             it != system1->StarlanesWormholes().end(); ++it)
+        {
+            // get id in universe of system at other end of lane
+            const int lane_dest_id = it->first;
+            // skip null lanes and only add edges in one direction, to avoid
+            // duplicating edges ( since this is an undirected graph, A->B
+            // duplicates B->A )
+            if (lane_dest_id >= system1_id)
+                continue;
+
+            // get new_graph_impl->system_graph index for this system
+            boost::unordered_map<int, size_t>::iterator reverse_lookup_map_it = m_system_id_to_graph_index.find(lane_dest_id);
+            if (reverse_lookup_map_it == m_system_id_to_graph_index.end())
+                continue;   // couldn't find destination system id in vertex lookup map; don't add to graph
+            size_t lane_dest_graph_index = reverse_lookup_map_it->second;
+
+            std::pair<EdgeDescriptor, bool> add_edge_result =
+                boost::add_edge(system1_index, lane_dest_graph_index, new_graph_impl->system_graph);
+
+            if (add_edge_result.second) {   // if this is a non-duplicate starlane or wormhole
+                if (it->second) {               // if this is a wormhole
+                    edge_weight_map[add_edge_result.first] = WORMHOLE_TRAVEL_DISTANCE;
+                } else {                        // if this is a starlane
+                    edge_weight_map[add_edge_result.first] = LinearDistance(system1_id, lane_dest_id);
+                }
+                graph_changed = graph_changed || !boost::edge(system1_index, lane_dest_graph_index, m_graph_impl->system_graph).second;
+            }
+        }
+    }
+
+    // if all previous edges still exist in the new graph, and the number of vertices and edges hasn't changed,
+    // then no vertices or edges can have been added either, so it is still the same graph
+    graph_changed = graph_changed || boost::num_edges(new_graph_impl->system_graph) != boost::num_edges(m_graph_impl->system_graph);
+
+    if (graph_changed) {
+        new_graph_impl.swap(m_graph_impl);
+        // clear jumps distance cache
+        // NOTE: re-filling the cache is O(#vertices * (#vertices + #edges)) in the worst case!
+        m_system_jumps.resize(system_ids.size());
+    }
+    UpdateEmpireVisibilityFilteredSystemGraphs(for_empire_id);
+}
+
+void Pathfinder::UpdateEmpireVisibilityFilteredSystemGraphs(int for_empire_id) {
+    return pimpl->UpdateEmpireVisibilityFilteredSystemGraphs(for_empire_id);
+}
+
+void Pathfinder::PathfinderImpl::UpdateEmpireVisibilityFilteredSystemGraphs(int for_empire_id) {
+    m_graph_impl->empire_system_graph_views.clear();
+
+    // if building system graph views for all empires, then each empire's graph
+    // should accurately filter for that empire's visibility.  if building
+    // graphs for one empire, that empire won't know what systems other empires
+    // have visibility of, so instead, have all empires' filtered graphs be
+    // equal to the empire for which filtering is being done.  this way, on the
+    // clients, enemy fleets can have move paths even though the client doesn't
+    // know what systems those empires know about (so can't make an accurate
+    // filtered graph for other empires)
+
+    if (for_empire_id == ALL_EMPIRES) {
+        // all empires get their own, accurately filtered graph
+        for (EmpireManager::const_iterator it = Empires().begin(); it != Empires().end(); ++it) {
+            int empire_id = it->first;
+            GraphImpl::EdgeVisibilityFilter filter(&m_graph_impl->system_graph, empire_id);
+            boost::shared_ptr<GraphImpl::EmpireViewSystemGraph> filtered_graph_ptr(
+                new GraphImpl::EmpireViewSystemGraph(m_graph_impl->system_graph, filter));
+            m_graph_impl->empire_system_graph_views[empire_id] = filtered_graph_ptr;
+        }
+
+    } else {
+        // all empires share a single filtered graph, filtered by the for_empire_id
+        GraphImpl::EdgeVisibilityFilter filter(&m_graph_impl->system_graph, for_empire_id);
+        boost::shared_ptr<GraphImpl::EmpireViewSystemGraph> filtered_graph_ptr(
+            new GraphImpl::EmpireViewSystemGraph(m_graph_impl->system_graph, filter));
+
+        for (EmpireManager::const_iterator it = Empires().begin(); it != Empires().end(); ++it) {
+            int empire_id = it->first;
+            m_graph_impl->empire_system_graph_views[empire_id] = filtered_graph_ptr;
+        }
+    }
+}

--- a/universe/Pathfinder.cpp
+++ b/universe/Pathfinder.cpp
@@ -1,48 +1,24 @@
 #include "Pathfinder.h"
 
-#include "../util/OptionsDB.h"
-#include "../util/i18n.h"
 #include "../util/Logger.h"
-#include "../util/Random.h"
-#include "../util/RunQueue.h"
 #include "../util/ScopedTimer.h"
-#include "../parse/Parse.h"
-#include "../Empire/Empire.h"
 #include "../Empire/EmpireManager.h"
-#include "Building.h"
 #include "Fleet.h"
-#include "Planet.h"
 #include "Ship.h"
-#include "ShipDesign.h"
 #include "System.h"
-#include "Field.h"
 #include "UniverseObject.h"
-#include "Predicates.h"
-#include "Special.h"
-#include "Species.h"
-#include "Condition.h"
 #include "ValueRef.h"
 #include "Universe.h"
 
-#include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/split.hpp>
-#include <boost/filesystem/fstream.hpp>
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/breadth_first_search.hpp>
 #include <boost/graph/dijkstra_shortest_paths.hpp>
 #include <boost/graph/filtered_graph.hpp>
-#include <boost/noncopyable.hpp>
-#include <boost/optional/optional.hpp>
-#include <boost/property_map/property_map.hpp>
 #include <boost/smart_ptr/shared_ptr.hpp>
-#include <boost/thread/condition_variable.hpp>
 #include <boost/thread/locks.hpp>
 #include <boost/thread/shared_mutex.hpp>
-#include <boost/timer.hpp>
 
 #include <algorithm>
-#include <cmath>
-#include <list>
 #include <stdexcept>
 
 namespace {

--- a/universe/Pathfinder.h
+++ b/universe/Pathfinder.h
@@ -6,7 +6,6 @@
 #include "UniverseObject.h"
 
 #include <boost/unordered_map.hpp>
-#include <boost/scoped_ptr.hpp>
 
 #include <vector>
 #include <map>
@@ -139,8 +138,7 @@ public:
 
 private:
     class PathfinderImpl;
-    /* TODO make unique_ptr C++11 */
-    boost::scoped_ptr<PathfinderImpl> const pimpl;
+    std::unique_ptr<PathfinderImpl> const pimpl;
 
     /* friend class boost::serialization::access; */
     /* template <class Archive> */

--- a/universe/Pathfinder.h
+++ b/universe/Pathfinder.h
@@ -37,8 +37,8 @@ public:
     typedef boost::shared_ptr<const Pathfinder> ConstPtr;
 
     /** \name Structors */ //@{
-    Pathfinder();                                     ///< default ctor
-    virtual ~Pathfinder();                            ///< dtor
+    Pathfinder();
+    virtual ~Pathfinder();
     //@}
 
     /** \name Accessors */ //@{

--- a/universe/Pathfinder.h
+++ b/universe/Pathfinder.h
@@ -1,8 +1,6 @@
 #ifndef _Pathfinder_h_
 #define _Pathfinder_h_
 
-#include "Enums.h"
-#include "ObjectMap.h"
 #include "UniverseObject.h"
 
 #include <boost/unordered_map.hpp>
@@ -16,16 +14,6 @@
 #  undef GetObject
 #  undef GetObjectA
 #endif
-
-struct UniverseObjectVisitor;
-class XMLElement;
-class System;
-
-class Empire;
-struct UniverseObjectVisitor;
-class XMLElement;
-class ShipDesign;
-class System;
 
 /** The Pathfinder  class contains the locations of systems, the
   * starlanes and functions to determine pathing and trip duration

--- a/universe/Pathfinder.h
+++ b/universe/Pathfinder.h
@@ -42,6 +42,8 @@ class System;
 class FO_COMMON_API Pathfinder {
 public:
 
+    typedef boost::shared_ptr<const Pathfinder> ConstPtr;
+
     /** \name Structors */ //@{
     Pathfinder();                                     ///< default ctor
     virtual ~Pathfinder();                            ///< dtor
@@ -64,7 +66,7 @@ public:
       * for cases where one or the other are fleets / ships on starlanes between
       * systems. Returns INT_MAX when no path exists, or either object does not
       * exist. */
-    //TODO smokeun int                     JumpDistanceBetweenObjects(int object1_id, int object2_id) const;
+    int                     JumpDistanceBetweenObjects(int object1_id, int object2_id) const;
 
     /** Returns the sequence of systems, including \a system1_id and
       * \a system2_id, that defines the shortest path from \a system1 to
@@ -82,7 +84,7 @@ public:
       * for cases where one or the other are fleets / ships on starlanes between
       * systems. Returns -1 when no path exists, or either object does not
       * exist. */
-    //TODO smokeun double                  ShortestPathDistance(int object1_id, int object2_id) const;
+    double                  ShortestPathDistance(int object1_id, int object2_id) const;
 
     /** Returns the sequence of systems, including \a system1 and \a system2,
       * that defines the path with the fewest jumps from \a system1 to

--- a/universe/Pathfinder.h
+++ b/universe/Pathfinder.h
@@ -1,0 +1,156 @@
+#ifndef _Pathfinder_h_
+#define _Pathfinder_h_
+
+
+#include "Enums.h"
+#include "ObjectMap.h"
+#include "TemporaryPtr.h"
+#include "UniverseObject.h"
+
+#include <boost/signals2/signal.hpp>
+#include <boost/unordered_map.hpp>
+#include <boost/numeric/ublas/symmetric.hpp>
+#include <boost/serialization/access.hpp>
+#include <boost/thread/shared_mutex.hpp>
+#include <boost/scoped_ptr.hpp>
+
+#include <vector>
+#include <list>
+#include <map>
+#include <string>
+#include <set>
+
+#ifdef FREEORION_WIN32
+// because the linker gets confused about Win32 API functions...
+#  undef GetObject
+#  undef GetObjectA
+#endif
+
+struct UniverseObjectVisitor;
+class XMLElement;
+class System;
+
+class Empire;
+struct UniverseObjectVisitor;
+class XMLElement;
+class ShipDesign;
+class System;
+
+/** The Pathfinder  class contains the locations of systems, the
+  * starlanes and functions to determine pathing and trip duration
+  * around the Universe. */
+class FO_COMMON_API Pathfinder {
+public:
+
+    /** \name Structors */ //@{
+    Pathfinder();                                     ///< default ctor
+    virtual ~Pathfinder();                            ///< dtor
+    //@}
+
+    /** \name Accessors */ //@{
+
+    /** Returns the straight-line distance between the objects with the given
+      * IDs. \throw std::out_of_range This function will throw if either object
+      * ID is out of range. */
+    double                  LinearDistance(int object1_id, int object2_id) const;
+
+    /** Returns the number of starlane jumps between the systems with the given
+      * IDs. If there is no path between the systems, -1 is returned.
+      * \throw std::out_of_range This function will throw if either system
+      * ID is not a valid system id. */
+    short                   JumpDistanceBetweenSystems(int system1_id, int system2_id) const;
+
+    /** Returns the number of starlane jumps between any two objects, accounting
+      * for cases where one or the other are fleets / ships on starlanes between
+      * systems. Returns INT_MAX when no path exists, or either object does not
+      * exist. */
+    //TODO smokeun int                     JumpDistanceBetweenObjects(int object1_id, int object2_id) const;
+
+    /** Returns the sequence of systems, including \a system1_id and
+      * \a system2_id, that defines the shortest path from \a system1 to
+      * \a system2, and the distance travelled to get there.  If no such path
+      * exists, the list will be empty.  Note that the path returned may be via
+      * one or more starlane, or may be "offroad".  The path is calculated
+      * using the visibility for empire \a empire_id, or without regard to
+      * visibility if \a empire_id == ALL_EMPIRES.
+      * \throw std::out_of_range This function will throw if either system ID
+      * is out of range, or if the empire ID is not known. */
+    std::pair<std::list<int>, double>
+                            ShortestPath(int system1_id, int system2_id, int empire_id = ALL_EMPIRES) const;
+
+    /** Returns the shortest starlane path distance between any two objects, accounting
+      * for cases where one or the other are fleets / ships on starlanes between
+      * systems. Returns -1 when no path exists, or either object does not
+      * exist. */
+    //TODO smokeun double                  ShortestPathDistance(int object1_id, int object2_id) const;
+
+    /** Returns the sequence of systems, including \a system1 and \a system2,
+      * that defines the path with the fewest jumps from \a system1 to
+      * \a system2, and the number of jumps to get there.  If no such path
+      * exists, the list will be empty.  The path is calculated using the
+      * visibility for empire \a empire_id, or without regard to visibility if
+      * \a empire_id == ALL_EMPIRES.  \throw std::out_of_range This function
+      * will throw if either system ID is out of range or if the empire ID is
+      * not known. */
+    std::pair<std::list<int>, int>
+                            LeastJumpsPath(int system1_id, int system2_id, int empire_id = ALL_EMPIRES,
+                                           int max_jumps = INT_MAX) const;
+
+    /** Returns whether there is a path known to empire \a empire_id between
+      * system \a system1 and system \a system2.  The path is calculated using
+      * the visibility for empire \a empire_id, or without regard to visibility
+      * if \a empire_id == ALL_EMPIRES.  \throw std::out_of_range This function
+      * will throw if either system ID is out of range or if the empire ID is
+      * not known. */
+    bool                    SystemsConnected(int system1_id, int system2_id, int empire_id = ALL_EMPIRES) const;
+
+    /** Returns true iff \a system is reachable from another system (i.e. it
+      * has at least one known starlane to it).   This does not guarantee that
+      * the system is reachable from any specific other system, as two separate
+      * groups of locally but not globally interconnected systems may exist.
+      * The starlanes considered depend on their visibility for empire
+      * \a empire_id, or without regard to visibility if
+      * \a empire_id == ALL_EMPIRES. */
+    bool                    SystemHasVisibleStarlanes(int system_id, int empire_id = ALL_EMPIRES) const;
+
+    /** Returns the systems that are one starlane hop away from system
+      * \a system.  The returned systems are indexed by distance from
+      * \a system.  The neighborhood is calculated using the visibility
+      * for empire \a empire_id, or without regard to visibility if
+      * \a empire_id == ALL_EMPIRES.
+      * \throw std::out_of_range This function will throw if the  system
+      * ID is out of range. */
+    std::multimap<double, int>              ImmediateNeighbors(int system_id, int empire_id = ALL_EMPIRES) const;
+
+    /** Returns the id of the System object that is closest to the specified
+      * (\a x, \a y) location on the map, by direct-line distance. */
+    int                                     NearestSystemTo(double x, double y) const;
+
+    //@}
+
+    /** \name Mutators */ //@{
+
+    /** Fills pathfinding data structure and determines least jumps distances
+      * between systems for the empire with id \a for_empire_id or uses the
+      * main / true / visible objects if \a for_empire_id is ALL_EMPIRES*/
+    void            InitializeSystemGraph(const std::vector<int> system_ids, int for_empire_id = ALL_EMPIRES);
+
+    /** Regenerates per-empire system view graphs by filtering the complete
+      * system graph based on empire visibility.  Does not regenerate the base
+      * graph to account for actual system-starlane connectivity changes. */
+    void            UpdateEmpireVisibilityFilteredSystemGraphs(int for_empire_id = ALL_EMPIRES);
+
+
+    //@}
+
+private:
+    class PathfinderImpl;
+    /* TODO make unique_ptr C++11 */
+    boost::scoped_ptr<PathfinderImpl> const pimpl;
+
+    /* friend class boost::serialization::access; */
+    /* template <class Archive> */
+    /* void serialize(Archive& ar, const unsigned int version); */
+};
+
+#endif // _Pathfinder_h_

--- a/universe/Pathfinder.h
+++ b/universe/Pathfinder.h
@@ -33,7 +33,7 @@ class System;
 class FO_COMMON_API Pathfinder {
 public:
 
-    typedef boost::shared_ptr<const Pathfinder> ConstPtr;
+    typedef std::shared_ptr<const Pathfinder> ConstPtr;
 
     /** \name Structors */ //@{
     Pathfinder();

--- a/universe/Pathfinder.h
+++ b/universe/Pathfinder.h
@@ -1,23 +1,15 @@
 #ifndef _Pathfinder_h_
 #define _Pathfinder_h_
 
-
 #include "Enums.h"
 #include "ObjectMap.h"
-#include "TemporaryPtr.h"
 #include "UniverseObject.h"
 
-#include <boost/signals2/signal.hpp>
 #include <boost/unordered_map.hpp>
-#include <boost/numeric/ublas/symmetric.hpp>
-#include <boost/serialization/access.hpp>
-#include <boost/thread/shared_mutex.hpp>
 #include <boost/scoped_ptr.hpp>
 
 #include <vector>
-#include <list>
 #include <map>
-#include <string>
 #include <set>
 
 #ifdef FREEORION_WIN32

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -24,6 +24,7 @@
 #include "Condition.h"
 #include "ValueRef.h"
 #include "Enums.h"
+#include "Pathfinder.h"
 
 #include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
@@ -83,344 +84,10 @@ namespace boost {
     template <class Key, class Value> const Value& get(const constant_property<Key, Value>& pmap, const Key&) { return pmap.m_value; }
 }
 
-namespace SystemPathing {
-    /** Used to short-circuit the use of BFS (breadth-first search) or
-      * Dijkstra's algorithm for pathfinding when it finds the desired
-      * destination system. */
-    struct PathFindingShortCircuitingVisitor : public boost::base_visitor<PathFindingShortCircuitingVisitor>
-    {
-        typedef boost::on_finish_vertex event_filter;
-
-        struct FoundDestination {}; // exception type thrown when destination is found
-
-        PathFindingShortCircuitingVisitor(int dest_system) : destination_system(dest_system) {}
-        template <class Vertex, class Graph>
-        void operator()(Vertex u, Graph& g)
-        {
-            if (static_cast<int>(u) == destination_system)
-                throw FoundDestination();
-        }
-        const int destination_system;
-    };
-
-    /** Complete BFS visitor implementing:
-      *  - predecessor recording
-      *  - short-circuit exit on found match
-      *  - maximum search depth 
-      */
-    template <class Graph, class Edge, class Vertex> class BFSVisitorImpl
-    {
-    public:
-        class FoundDestination {}; 
-        class ReachedDepthLimit {};
-
-    private:
-        Vertex m_marker;
-        Vertex m_stop;
-        Vertex m_source;
-        Vertex * m_predecessors;
-        int m_levels_remaining;
-        bool m_level_complete;
-
-    public:
-        BFSVisitorImpl(const Vertex& start, const Vertex& stop, Vertex predecessors[], int max_depth)
-            : m_marker(start),
-              m_stop(stop),
-              m_source(start),
-              m_predecessors(predecessors),
-              m_levels_remaining(max_depth),
-              m_level_complete(false)
-        {}
-
-        void initialize_vertex(const Vertex& v, const Graph& g)
-        {}
-
-        void discover_vertex(const Vertex& v, const Graph& g) {
-            m_predecessors[static_cast<int>(v)] = m_source;
-
-            if (v == m_stop)
-                throw FoundDestination();
-
-            if (m_level_complete) {
-                m_marker = v;
-                m_level_complete = false;
-            }
-        }
-
-        void examine_vertex(const Vertex& v, const Graph& g) {
-            if (v == m_marker) {
-                if (!m_levels_remaining)
-                    throw ReachedDepthLimit();
-                m_levels_remaining--;
-                m_level_complete = true;
-            }
-            
-            m_source = v; // avoid re-calculating source from edge
-        }
-
-        void examine_edge(const Edge& e, const Graph& g) {}
-        void tree_edge(const Edge& e, const Graph& g) {}    // wait till target is calculated
-
-
-        void non_tree_edge(const Edge& e, const Graph& g) {}
-        void gray_target(const Edge& e, const Graph& g) {}
-        void black_target(const Edge& e, const Graph& g) {}
-        void finish_vertex(const Vertex& e, const Graph& g) {}
-    };
-
-    ////////////////////////////////////////////////////////////////
-    // templated implementations of Universe graph search methods //
-    ////////////////////////////////////////////////////////////////
-    struct vertex_system_id_t {typedef boost::vertex_property_tag kind;}; ///< a system graph property map type
-
-    /** Returns the path between vertices \a system1_id and \a system2_id of
-      * \a graph that travels the shorest distance on starlanes, and the path
-      * length.  If system1_id is the same vertex as system2_id, the path has
-      * just that system in it, and the path lenth is 0.  If there is no path
-      * between the two vertices, then the list is empty and the path length
-      * is -1.0 */
-    template <class Graph>
-    std::pair<std::list<int>, double> ShortestPathImpl(const Graph& graph, int system1_id, int system2_id,
-                                                       double linear_distance, const boost::unordered_map<int, size_t>& id_to_graph_index)
-    {
-        typedef typename boost::property_map<Graph, vertex_system_id_t>::const_type     ConstSystemIDPropertyMap;
-        typedef typename boost::property_map<Graph, boost::vertex_index_t>::const_type  ConstIndexPropertyMap;
-        typedef typename boost::property_map<Graph, boost::edge_weight_t>::const_type   ConstEdgeWeightPropertyMap;
-
-        std::pair<std::list<int>, double> retval(std::list<int>(), -1.0);
-
-        ConstSystemIDPropertyMap sys_id_property_map = boost::get(vertex_system_id_t(), graph);
-
-        // convert system IDs to graph indices.  try/catch for invalid input system ids.
-        size_t system1_index, system2_index;
-        try {
-            system1_index = id_to_graph_index.at(system1_id);
-            system2_index = id_to_graph_index.at(system2_id);
-        } catch (...) {
-            return retval;
-        }
-
-        // early exit if systems are the same
-        if (system1_id == system2_id) {
-            retval.first.push_back(system2_id);
-            retval.second = 0.0;    // no jumps needed -> 0 distance
-            return retval;
-        }
-
-        /* initializing all vertices' predecessors to themselves prevents endless loops when back traversing the tree in the case where
-           one of the end systems is system 0, because systems that are not connected to the root system (system2) are not visited
-           by the search, and so their predecessors are left unchanged.  Default initialization of the vector may be 0 or undefined
-           which could lead to out of bounds errors, or endless loops if a system's default predecessor is 0 (debug mode), and 0's
-           predecessor is that system */
-        std::vector<int> predecessors(boost::num_vertices(graph));
-        std::vector<double> distances(boost::num_vertices(graph));
-        for (unsigned int i = 0; i < boost::num_vertices(graph); ++i) {
-            predecessors[i] = i;
-            distances[i] = -1.0;
-        }
-
-
-        ConstIndexPropertyMap index_map = boost::get(boost::vertex_index, graph);
-        ConstEdgeWeightPropertyMap edge_weight_map = boost::get(boost::edge_weight, graph);
-
-
-        // do the actual path finding using verbose boost magic...
-        try {
-            boost::dijkstra_shortest_paths(graph, system1_index, &predecessors[0], &distances[0], edge_weight_map, index_map, 
-                                           std::less<double>(), std::plus<double>(), std::numeric_limits<int>::max(), 0, 
-                                           boost::make_dijkstra_visitor(PathFindingShortCircuitingVisitor(system2_index)));
-        } catch (const PathFindingShortCircuitingVisitor::FoundDestination&) {
-            // catching this just means that the destination was found, and so the algorithm was exited early, via exception
-        }
-
-
-        int current_system = system2_index;
-        while (predecessors[current_system] != current_system) {
-            retval.first.push_front(sys_id_property_map[current_system]);
-            current_system = predecessors[current_system];
-        }
-        retval.second = distances[system2_index];
-
-        if (retval.first.empty()) {
-            // there is no path between the specified nodes
-            retval.second = -1.0;
-            return retval;
-        } else {
-            // add start system to path, as it wasn't added by traversing predecessors array
-            retval.first.push_front(sys_id_property_map[system1_index]);
-        }
-
-        return retval;
-    }
-
-    /** Returns the path between vertices \a system1_id and \a system2_id of
-      * \a graph that takes the fewest number of jumps (edge traversals), and
-      * the number of jumps this path takes.  If system1_id is the same vertex
-      * as system2_id, the path has just that system in it, and the path lenth
-      * is 0.  If there is no path between the two vertices, then the list is
-      * empty and the path length is -1 */
-    template <class Graph>
-    std::pair<std::list<int>, int> LeastJumpsPathImpl(const Graph& graph, int system1_id, int system2_id,
-                                                      const boost::unordered_map<int, size_t>& id_to_graph_index,
-                                                      int max_jumps = INT_MAX)
-    {
-        typedef typename boost::property_map<Graph, vertex_system_id_t>::const_type ConstSystemIDPropertyMap;
-
-        ConstSystemIDPropertyMap sys_id_property_map = boost::get(vertex_system_id_t(), graph);
-        std::pair<std::list<int>, int> retval;
-
-        size_t system1_index = id_to_graph_index.at(system1_id);
-        size_t system2_index = id_to_graph_index.at(system2_id);
-
-        // early exit if systems are the same
-        if (system1_id == system2_id) {
-            retval.first.push_back(system2_id);
-            retval.second = 0;  // no jumps needed
-            return retval;
-        }
-
-        /* initializing all vertices' predecessors to themselves prevents endless loops when back traversing the tree in the case where
-           one of the end systems is system 0, because systems that are not connected to the root system (system2) are not visited
-           by the search, and so their predecessors are left unchanged.  Default initialization of the vector may be 0 or undefined
-           which could lead to out of bounds errors, or endless loops if a system's default predecessor is 0, (debug mode) and 0's
-           predecessor is that system */
-        std::vector<int> predecessors(boost::num_vertices(graph));
-        for (unsigned int i = 0; i < boost::num_vertices(graph); ++i)
-            predecessors[i] = i;
-
-
-        // do the actual path finding using verbose boost magic...
-        typedef BFSVisitorImpl<Graph, typename boost::graph_traits<Graph>::edge_descriptor, int> BFSVisitor;
-        try {
-            boost::queue<int> buf;
-            std::vector<int> colors(boost::num_vertices(graph));
-
-            BFSVisitor bfsVisitor(system1_index, system2_index, &predecessors[0], max_jumps);
-            boost::breadth_first_search(graph, system1_index, buf, bfsVisitor, &colors[0]);
-        } catch (const typename BFSVisitor::ReachedDepthLimit&) {
-            // catching this means the algorithm explored the neighborhood until max_jumps and didn't find anything
-            return std::make_pair(std::list<int>(), -1);
-        } catch (const typename BFSVisitor::FoundDestination&) {
-            // catching this just means that the destination was found, and so the algorithm was exited early, via exception
-        }
-
-
-        int current_system = system2_index;
-        while (predecessors[current_system] != current_system) {
-            retval.first.push_front(sys_id_property_map[current_system]);
-            current_system = predecessors[current_system];
-        }
-        retval.second = retval.first.size() - 1;    // number of jumps is number of systems in path minus one for the starting system
-
-        if (retval.first.empty()) {
-            // there is no path between the specified nodes
-            retval.second = -1;
-        } else {
-            // add start system to path, as it wasn't added by traversing predecessors array
-            retval.first.push_front(sys_id_property_map[system1_index]);
-        }
-
-        return retval;
-    }
-
-    template <class Graph>
-    std::multimap<double, int> ImmediateNeighborsImpl(const Graph& graph, int system_id,
-                                                      const boost::unordered_map<int, size_t>& id_to_graph_index)
-    {
-        typedef typename Graph::out_edge_iterator OutEdgeIterator;
-        typedef typename boost::property_map<Graph, vertex_system_id_t>::const_type ConstSystemIDPropertyMap;
-        typedef typename boost::property_map<Graph, boost::edge_weight_t>::const_type ConstEdgeWeightPropertyMap;
-
-        std::multimap<double, int> retval;
-        ConstEdgeWeightPropertyMap edge_weight_map = boost::get(boost::edge_weight, graph);
-        ConstSystemIDPropertyMap sys_id_property_map = boost::get(vertex_system_id_t(), graph);
-        std::pair<OutEdgeIterator, OutEdgeIterator> edges = boost::out_edges(id_to_graph_index.at(system_id), graph);
-        for (OutEdgeIterator it = edges.first; it != edges.second; ++it)
-        { retval.insert(std::make_pair(edge_weight_map[*it], sys_id_property_map[boost::target(*it, graph)])); }
-        return retval;
-    }
-}
-using namespace SystemPathing;  // to keep GCC 4.2 on OSX happy
 
 extern const int ALL_EMPIRES            = -1;
 // TODO: implement a robust, thread-safe solution for creating multiple client-local temporary objects with unique IDs that will never conflict with each other or the server.
 extern const int MAX_ID                 = 2000000000;
-
-
-/////////////////////////////////////////////
-// struct Universe::GraphImpl
-/////////////////////////////////////////////
-struct Universe::GraphImpl {
-    typedef boost::property<vertex_system_id_t, int,
-                            boost::property<boost::vertex_index_t, int> >   vertex_property_t;  ///< a system graph property map type
-    typedef boost::property<boost::edge_weight_t, double>                   edge_property_t;    ///< a system graph property map type
-
-    // declare main graph types, including properties declared above
-    // could add boost::disallow_parallel_edge_tag GraphProperty but it doesn't
-    // work for vecS vector-based lists and parallel edges can be avoided while
-    // creating the graph by filtering the edges to be added
-    typedef boost::adjacency_list<boost::vecS, boost::vecS, boost::undirectedS,
-                                  vertex_property_t, edge_property_t> SystemGraph;
-
-    struct EdgeVisibilityFilter     {
-        EdgeVisibilityFilter() :
-            m_graph(nullptr),
-            m_empire_id(ALL_EMPIRES)
-        {}
-
-        EdgeVisibilityFilter(const SystemGraph* graph, int empire_id) :
-            m_graph(graph),
-            m_empire_id(empire_id)
-        {
-            if (!graph)
-                ErrorLogger() << "EdgeVisibilityFilter passed null graph pointer";
-        }
-
-        template <typename EdgeDescriptor>
-        bool operator()(const EdgeDescriptor& edge) const
-        {
-            if (!m_graph)
-                return false;
-
-            // get system ids from graph indices
-            ConstSystemIDPropertyMap sys_id_property_map = boost::get(vertex_system_id_t(), *m_graph); // for reverse-lookup System universe ID from graph index
-            int sys_graph_index_1 = boost::source(edge, *m_graph);
-            int sys_id_1 = sys_id_property_map[sys_graph_index_1];
-            int sys_graph_index_2 = boost::target(edge, *m_graph);
-            int sys_id_2 = sys_id_property_map[sys_graph_index_2];
-
-            // look up lane between systems
-            std::shared_ptr<const System> system1 = GetEmpireKnownSystem(sys_id_1, m_empire_id);
-            if (!system1) {
-                ErrorLogger() << "EdgeDescriptor::operator() couldn't find system with id " << sys_id_1;
-                return false;
-            }
-            if (system1->HasStarlaneTo(sys_id_2))
-                return true;
-
-            // lane not found
-            return false;
-        }
-
-    private:
-        const SystemGraph*      m_graph;
-        int                     m_empire_id;
-    };
-    typedef boost::filtered_graph<SystemGraph, EdgeVisibilityFilter> EmpireViewSystemGraph;
-    typedef std::map<int, std::shared_ptr<EmpireViewSystemGraph>> EmpireViewSystemGraphMap;
-
-    // declare property map types for properties declared above
-    typedef boost::property_map<SystemGraph, vertex_system_id_t>::const_type        ConstSystemIDPropertyMap;
-    typedef boost::property_map<SystemGraph, vertex_system_id_t>::type              SystemIDPropertyMap;
-    typedef boost::property_map<SystemGraph, boost::vertex_index_t>::const_type     ConstIndexPropertyMap;
-    typedef boost::property_map<SystemGraph, boost::vertex_index_t>::type           IndexPropertyMap;
-    typedef boost::property_map<SystemGraph, boost::edge_weight_t>::const_type      ConstEdgeWeightPropertyMap;
-    typedef boost::property_map<SystemGraph, boost::edge_weight_t>::type            EdgeWeightPropertyMap;
-
-    SystemGraph                 system_graph;                 ///< a graph in which the systems are vertices and the starlanes are edges
-    EmpireViewSystemGraphMap    empire_system_graph_views;    ///< a map of empire IDs to the views of the system graph by those empires
-};
-
 
 namespace EmpireStatistics {
     const std::map<std::string, ValueRef::ValueRefBase<double>*>& GetEmpireStats() {
@@ -441,7 +108,7 @@ namespace EmpireStatistics {
 // class Universe
 /////////////////////////////////////////////
 Universe::Universe() :
-    m_graph_impl(new GraphImpl),
+    m_pathfinder(new Pathfinder),
     m_last_allocated_object_id(-1), // this is conicidentally equal to INVALID_OBJECT_ID as of this writing, but the reason for this to be -1 is so that the first object has id 0, and all object ids are non-negative
     m_last_allocated_design_id(-1), // same, but for ShipDesign::INVALID_DESIGN_ID
     m_universe_width(1000.0),
@@ -473,7 +140,6 @@ void Universe::Clear() {
 
     m_empire_object_visible_specials.clear();
 
-    m_system_id_to_graph_index.clear();
     m_effect_accounting_map.clear();
     m_effect_discrepancy_map.clear();
 
@@ -656,234 +322,21 @@ std::set<std::string> Universe::GetObjectVisibleSpecialsByEmpire(int object_id, 
     }
 }
 
-namespace {
-    // wrapper around Universe::distance_matrix_storage 
-    // implementing functionality outside the public header
-    // the cache assumes the matrix to be symmetric
-    template <class Storage, class T = typename Storage::value_type, class Row = typename Storage::row_ref>
-    class distance_matrix_cache {
-    public:
-        distance_matrix_cache(Storage& the_storage) : m_storage(the_storage) {}
-        size_t size() {
-            boost::shared_lock<boost::shared_mutex> guard(m_storage.m_mutex); 
-            return m_storage.size();
-        }
-        void resize(size_t a_size) {
-            boost::unique_lock<boost::shared_mutex> guard(m_storage.m_mutex); 
-            m_storage.resize(a_size);
-        }
-
-        class row_lock {
-        private:
-            boost::shared_lock<boost::shared_mutex> m_lock;
-            boost::unique_lock<boost::shared_mutex> m_row_lock;
-
-            void swap(boost::shared_lock<boost::shared_mutex>& guard, boost::unique_lock<boost::shared_mutex>& row_guard) {
-                m_lock.swap(guard);
-                m_row_lock.swap(row_guard);
-            }
-            friend class distance_matrix_cache<Storage, T, Row>;
-
-        public:
-            row_lock() {};
-            void swap(row_lock& other) {
-                m_lock.swap(other.m_lock);
-                m_row_lock.swap(other.m_row_lock);
-            }
-            void unlock() {
-                m_row_lock.unlock();
-                m_lock.unlock();
-            }
-        };
-
-    public:
-        /** try to retrieve an element, lock the whole row on cache miss
-          * if \a lock already holds a lock, it will be unlocked after locking the row.
-          */
-        boost::optional<T> get_or_lock_row(size_t row_index, size_t column_index, row_lock& lock) const {
-            boost::shared_lock<boost::shared_mutex> guard(m_storage.m_mutex);
-
-            if (row_index < m_storage.size() && column_index < m_storage.size()) {
-                {
-                    boost::shared_lock<boost::shared_mutex> row_guard(*m_storage.m_row_mutexes[row_index]);
-                    Row row_data = m_storage.m_data[row_index];  
-
-                    if (column_index < row_data.size())
-                        return row_data[column_index];
-                }
-                {
-                    boost::shared_lock<boost::shared_mutex> column_guard(*m_storage.m_row_mutexes[column_index]);
-                    Row column_data = m_storage.m_data[column_index];  
-
-                    if (row_index < column_data.size())
-                        return column_data[row_index];
-                }
-                {
-                    boost::unique_lock<boost::shared_mutex> row_guard(*m_storage.m_row_mutexes[row_index]);
-                    Row row_data = m_storage.m_data[row_index];  
-
-                    if (column_index < row_data.size()) {
-                        return row_data[column_index];
-                    } else {
-                        lock.swap(guard, row_guard);
-
-                        return boost::optional<T>();
-                    }
-                }
-            } else {
-                ErrorLogger() << "distance_matrix_cache::get_or_lock_row passed invalid node indices: " << row_index << "," << column_index << " matrix size: " << m_storage.size();
-                if (row_index < m_storage.size())
-                    throw std::out_of_range("column_index invalid");
-                else
-                    throw std::out_of_range("row_index invalid");
-            }
-
-            return boost::optional<T>(); // unreachable
-        }
-
-        /** replace the contents of a row with \a new_data. 
-          * precondition: \a lock must hold a lock to the specified row.
-          */
-        void swap_and_unlock_row(size_t row_index, Row new_data, row_lock& lock) {
-            if (row_index < m_storage.size()) {
-                Row row_data = m_storage.m_data[row_index];  
-
-                row_data.swap(new_data);
-            } else {
-                ErrorLogger() << "distance_matrix_cache::swap_and_unlock_row passed invalid node index: " << row_index << " matrix size: " << m_storage.size();
-                throw std::out_of_range("row_index invalid");
-            }
-
-            lock.unlock(); // only unlock on success
-        }
-    private:
-        Storage& m_storage;
-    };
-}
-
 double Universe::LinearDistance(int system1_id, int system2_id) const {
-    std::shared_ptr<const System> system1 = GetSystem(system1_id);
-    if (!system1) {
-        ErrorLogger() << "Universe::LinearDistance passed invalid system id: " << system1_id;
-        throw std::out_of_range("system1_id invalid");
-    }
-    std::shared_ptr<const System> system2 = GetSystem(system2_id);
-    if (!system2) {
-        ErrorLogger() << "Universe::LinearDistance passed invalid system id: " << system2_id;
-        throw std::out_of_range("system2_id invalid");
-    }
-    double x_dist = system2->X() - system1->X();
-    double y_dist = system2->Y() - system1->Y();
-    return std::sqrt(x_dist*x_dist + y_dist*y_dist);
+    return m_pathfinder->LinearDistance(system1_id, system2_id);
 }
 
 short Universe::JumpDistanceBetweenSystems(int system1_id, int system2_id) const {
-    if (system1_id == system2_id)
-        return 0;
-
-    try {
-        distance_matrix_cache< distance_matrix_storage<short> > cache(m_system_jumps);
-        distance_matrix_cache< distance_matrix_storage<short> >::row_lock cache_guard;
-        size_t system1_index = m_system_id_to_graph_index.at(system1_id);
-        size_t system2_index = m_system_id_to_graph_index.at(system2_id);
-        size_t smaller_index = (std::min)(system1_index, system2_index);
-        size_t other_index   = (std::max)(system1_index, system2_index);
-        boost::optional<short> maybe_jumps = cache.get_or_lock_row(smaller_index, other_index, cache_guard); // prefer filling the smaller row/column for increased cache locality
-        short jumps;
-
-        if (maybe_jumps) {
-            // cache hit, any locks are already released
-            // get_value_or() in order to silence potentially-uninitialized warning
-            jumps = maybe_jumps.get_value_or(SHRT_MAX);
-        } else {
-            // cache miss, still holding a lock in cache_guard
-            // we are keeping the row locked during computation so other 
-            // threads waiting for the same row will see a cache hit
-            typedef boost::iterator_property_map<std::vector<short>::iterator, boost::identity_property_map> DistancePropertyMap;
-
-            std::vector<short> private_distance_buffer(m_system_jumps.size(), SHRT_MAX);
-            DistancePropertyMap distance_property_map(private_distance_buffer.begin());
-            boost::distance_recorder<DistancePropertyMap, boost::on_tree_edge> distance_recorder(distance_property_map);
-
-            // FIXME: dont compute m_system_jumps[i][j] again as m_system_jumps[j][i]
-            private_distance_buffer[smaller_index] = 0;
-            boost::breadth_first_search(m_graph_impl->system_graph, smaller_index, boost::visitor(boost::make_bfs_visitor(distance_recorder)));
-            jumps = private_distance_buffer[other_index];
-            cache.swap_and_unlock_row(smaller_index, private_distance_buffer, cache_guard);
-        }
-        if (jumps == SHRT_MAX)  // value returned for no valid path
-            return -1;
-
-        return jumps;
-    } catch (const std::out_of_range&) {
-        ErrorLogger() << "Universe::JumpDistanceBetweenSystems passed invalid system id(s): "
-                               << system1_id << " & " << system2_id;
-        throw;
-    }
+    return m_pathfinder->JumpDistanceBetweenSystems(system1_id, system2_id);
 }
 
 std::pair<std::list<int>, double> Universe::ShortestPath(int system1_id, int system2_id, int empire_id/* = ALL_EMPIRES*/) const {
-    if (empire_id == ALL_EMPIRES) {
-        // find path on full / complete system graph
-        try {
-            double linear_distance = LinearDistance(system1_id, system2_id);
-            return ShortestPathImpl(m_graph_impl->system_graph, system1_id, system2_id,
-                                    linear_distance, m_system_id_to_graph_index);
-        } catch (const std::out_of_range&) {
-            ErrorLogger() << "Universe::ShortestPath passed invalid system id(s): "
-                                   << system1_id << " & " << system2_id;
-            throw;
-        }
-    }
-
-    // find path on single empire's view of system graph
-    GraphImpl::EmpireViewSystemGraphMap::const_iterator graph_it =
-        m_graph_impl->empire_system_graph_views.find(empire_id);
-    if (graph_it == m_graph_impl->empire_system_graph_views.end()) {
-        ErrorLogger() << "Universe::ShortestPath passed unknown empire id: " << empire_id;
-        throw std::out_of_range("Universe::ShortestPath passed unknown empire id");
-    }
-    try {
-        double linear_distance = LinearDistance(system1_id, system2_id);
-        return ShortestPathImpl(*graph_it->second, system1_id, system2_id,
-                                linear_distance, m_system_id_to_graph_index);
-    } catch (const std::out_of_range&) {
-        ErrorLogger() << "Universe::ShortestPath passed invalid system id(s): "
-                      << system1_id << " & " << system2_id;
-        throw;
-    }
+    return m_pathfinder->ShortestPath(system1_id, system2_id, empire_id);
 }
 
 std::pair<std::list<int>, int> Universe::LeastJumpsPath(int system1_id, int system2_id, int empire_id/* = ALL_EMPIRES*/,
-                                                        int max_jumps/* = INT_MAX*/) const
-{
-    if (empire_id == ALL_EMPIRES) {
-        // find path on full / complete system graph
-        try {
-            return LeastJumpsPathImpl(m_graph_impl->system_graph, system1_id, system2_id,
-                                      m_system_id_to_graph_index, max_jumps);
-        } catch (const std::out_of_range&) {
-            ErrorLogger() << "Universe::LeastJumpsPath passed invalid system id(s): "
-                                   << system1_id << " & " << system2_id;
-            throw;
-        }
-    }
-
-    // find path on single empire's view of system graph
-    GraphImpl::EmpireViewSystemGraphMap::const_iterator graph_it =
-        m_graph_impl->empire_system_graph_views.find(empire_id);
-    if (graph_it == m_graph_impl->empire_system_graph_views.end()) {
-        ErrorLogger() << "Universe::LeastJumpsPath passed unknown empire id: " << empire_id;
-        throw std::out_of_range("Universe::LeastJumpsPath passed unknown empire id");
-    }
-    try {
-        return LeastJumpsPathImpl(*graph_it->second, system1_id, system2_id,
-                                  m_system_id_to_graph_index, max_jumps);
-    } catch (const std::out_of_range&) {
-        ErrorLogger() << "Universe::LeastJumpsPath passed invalid system id(s): "
-                               << system1_id << " & " << system2_id;
-        throw;
-    }
+                                                        int max_jumps/* = INT_MAX*/) const {
+    return m_pathfinder->LeastJumpsPath(system1_id, system2_id, empire_id, max_jumps);
 }
 
 namespace {
@@ -1071,14 +524,7 @@ bool Universe::SystemHasVisibleStarlanes(int system_id, int empire_id) const {
 }
 
 std::multimap<double, int> Universe::ImmediateNeighbors(int system_id, int empire_id/* = ALL_EMPIRES*/) const {
-    if (empire_id == ALL_EMPIRES) {
-        return ImmediateNeighborsImpl(m_graph_impl->system_graph, system_id, m_system_id_to_graph_index);
-    } else {
-        GraphImpl::EmpireViewSystemGraphMap::const_iterator graph_it = m_graph_impl->empire_system_graph_views.find(empire_id);
-        if (graph_it != m_graph_impl->empire_system_graph_views.end())
-            return ImmediateNeighborsImpl(*graph_it->second, system_id, m_system_id_to_graph_index);
-    }
-    return std::multimap<double, int>();
+    return m_pathfinder->ImmediateNeighbors(system_id, empire_id);
 }
 
 int Universe::NearestSystemTo(double x, double y) const {
@@ -3514,112 +2960,18 @@ void Universe::EffectDestroy(int object_id, int source_object_id) {
 }
 
 void Universe::InitializeSystemGraph(int for_empire_id) {
-    typedef boost::graph_traits<GraphImpl::SystemGraph>::edge_descriptor EdgeDescriptor;
-    auto new_graph_impl = std::make_shared<GraphImpl>();
     std::vector<int> system_ids = ::EmpireKnownObjects(for_empire_id).FindObjectIDs<System>();
-    // NOTE: this initialization of graph_changed prevents testing for edges between nonexistant vertices
-    bool graph_changed = system_ids.size() != boost::num_vertices(m_graph_impl->system_graph);
-    //DebugLogger() << "InitializeSystemGraph(" << for_empire_id << ") system_ids: (" << system_ids.size() << ")";
-    //for (int id : system_ids)
-    //    DebugLogger() << " ... " << id;
-
-    GraphImpl::SystemIDPropertyMap sys_id_property_map =
-        boost::get(vertex_system_id_t(), new_graph_impl->system_graph);
-
-    GraphImpl::EdgeWeightPropertyMap edge_weight_map =
-        boost::get(boost::edge_weight, new_graph_impl->system_graph);
-
-    // add vertices to graph for all systems
-    for (size_t system_index = 0; system_index < system_ids.size(); ++system_index) {
-        // add a vertex to the graph for this system, and assign it the system's universe ID as a property
-        boost::add_vertex(new_graph_impl->system_graph);
-        int system_id = system_ids[system_index];
-        sys_id_property_map[system_index] = system_id;
-        // add record of index in new_graph_impl->system_graph of this system
-        m_system_id_to_graph_index[system_id] = system_index;
-    }
-
-    // add edges for all starlanes
+    std::vector<TemporaryPtr<const System> > systems;
     for (size_t system1_index = 0; system1_index < system_ids.size(); ++system1_index) {
         int system1_id = system_ids[system1_index];
-        std::shared_ptr<const System> system1 = GetEmpireKnownSystem(system1_id, for_empire_id);
-
-        // add edges and edge weights
-        for (const std::map<int, bool>::value_type& entry : system1->StarlanesWormholes()) {
-            // get id in universe of system at other end of lane
-            const int lane_dest_id = entry.first;
-            // skip null lanes and only add edges in one direction, to avoid
-            // duplicating edges ( since this is an undirected graph, A->B
-            // duplicates B->A )
-            if (lane_dest_id >= system1_id)
-                continue;
-
-            // get new_graph_impl->system_graph index for this system
-            boost::unordered_map<int, size_t>::iterator reverse_lookup_map_it = m_system_id_to_graph_index.find(lane_dest_id);
-            if (reverse_lookup_map_it == m_system_id_to_graph_index.end())
-                continue;   // couldn't find destination system id in vertex lookup map; don't add to graph
-            size_t lane_dest_graph_index = reverse_lookup_map_it->second;
-
-            std::pair<EdgeDescriptor, bool> add_edge_result =
-                boost::add_edge(system1_index, lane_dest_graph_index, new_graph_impl->system_graph);
-
-            if (add_edge_result.second) {   // if this is a non-duplicate starlane or wormhole
-                if (entry.second) {               // if this is a wormhole
-                    edge_weight_map[add_edge_result.first] = WORMHOLE_TRAVEL_DISTANCE;
-                } else {                        // if this is a starlane
-                    edge_weight_map[add_edge_result.first] = LinearDistance(system1_id, lane_dest_id);
-                }
-                graph_changed = graph_changed || !boost::edge(system1_index, lane_dest_graph_index, m_graph_impl->system_graph).second;
-            }
-        }
+        systems.push_back(GetEmpireKnownSystem(system1_id, for_empire_id));
     }
 
-    // if all previous edges still exist in the new graph, and the number of vertices and edges hasn't changed, 
-    // then no vertices or edges can have been added either, so it is still the same graph
-    graph_changed = graph_changed || boost::num_edges(new_graph_impl->system_graph) != boost::num_edges(m_graph_impl->system_graph);
-
-    if (graph_changed) {
-        new_graph_impl.swap(m_graph_impl);
-        // clear jumps distance cache
-        // NOTE: re-filling the cache is O(#vertices * (#vertices + #edges)) in the worst case!
-        m_system_jumps.resize(system_ids.size());
-    }
-    UpdateEmpireVisibilityFilteredSystemGraphs(for_empire_id);
+    m_pathfinder->InitializeSystemGraph(system_ids, for_empire_id);
 }
 
-void Universe::UpdateEmpireVisibilityFilteredSystemGraphs(int for_empire_id) {
-    m_graph_impl->empire_system_graph_views.clear();
-
-    // if building system graph views for all empires, then each empire's graph
-    // should accurately filter for that empire's visibility.  if building
-    // graphs for one empire, that empire won't know what systems other empires
-    // have visibility of, so instead, have all empires' filtered graphs be
-    // equal to the empire for which filtering is being done.  this way, on the
-    // clients, enemy fleets can have move paths even though the client doesn't
-    // know what systems those empires know about (so can't make an accurate
-    // filtered graph for other empires)
-
-    if (for_empire_id == ALL_EMPIRES) {
-        // all empires get their own, accurately filtered graph
-        for (std::map<int, Empire*>::value_type& empire_entry : Empires()) {
-            int empire_id = empire_entry.first;
-            GraphImpl::EdgeVisibilityFilter filter(&m_graph_impl->system_graph, empire_id);
-            std::shared_ptr<GraphImpl::EmpireViewSystemGraph> filtered_graph_ptr(
-                new GraphImpl::EmpireViewSystemGraph(m_graph_impl->system_graph, filter));
-            m_graph_impl->empire_system_graph_views[empire_id] = filtered_graph_ptr;
-        }
-
-    } else {
-        // all empires share a single filtered graph, filtered by the for_empire_id
-        GraphImpl::EdgeVisibilityFilter filter(&m_graph_impl->system_graph, for_empire_id);
-        std::shared_ptr<GraphImpl::EmpireViewSystemGraph> filtered_graph_ptr(
-            new GraphImpl::EmpireViewSystemGraph(m_graph_impl->system_graph, filter));
-
-        for (std::map<int, Empire*>::value_type& empire_entry : Empires()) {
-            int empire_id = empire_entry.first;
-            m_graph_impl->empire_system_graph_views[empire_id] = filtered_graph_ptr;
-        }
-    }
+void Universe::UpdateEmpireVisibilityFilteredSystemGraphs(int empire_id) {
+    m_pathfinder->UpdateEmpireVisibilityFilteredSystemGraphs(empire_id);
 }
 
 int& Universe::EncodingEmpire()

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -26,25 +26,8 @@
 #include "Enums.h"
 #include "Pathfinder.h"
 
-#include <boost/algorithm/string/classification.hpp>
-#include <boost/algorithm/string/split.hpp>
-#include <boost/filesystem/fstream.hpp>
-#include <boost/graph/adjacency_list.hpp>
-#include <boost/graph/breadth_first_search.hpp>
-#include <boost/graph/dijkstra_shortest_paths.hpp>
-#include <boost/graph/filtered_graph.hpp>
-#include <boost/noncopyable.hpp>
-#include <boost/optional/optional.hpp>
 #include <boost/property_map/property_map.hpp>
-#include <boost/thread/condition_variable.hpp>
-#include <boost/thread/locks.hpp>
-#include <boost/thread/shared_mutex.hpp>
 #include <boost/timer.hpp>
-
-#include <algorithm>
-#include <cmath>
-#include <list>
-#include <stdexcept>
 
 
 #if defined(_MSC_VER)

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -322,47 +322,6 @@ std::set<std::string> Universe::GetObjectVisibleSpecialsByEmpire(int object_id, 
     }
 }
 
-double Universe::LinearDistance(int system1_id, int system2_id) const {
-    return m_pathfinder->LinearDistance(system1_id, system2_id);
-}
-
-short Universe::JumpDistanceBetweenSystems(int system1_id, int system2_id) const {
-    return m_pathfinder->JumpDistanceBetweenSystems(system1_id, system2_id);
-}
-
-std::pair<std::list<int>, double> Universe::ShortestPath(int system1_id, int system2_id, int empire_id/* = ALL_EMPIRES*/) const {
-    return m_pathfinder->ShortestPath(system1_id, system2_id, empire_id);
-}
-
-double Universe::ShortestPathDistance(int object1_id, int object2_id) const {
-    return m_pathfinder->ShortestPathDistance(object1_id,  object2_id);
-}
-
-std::pair<std::list<int>, int> Universe::LeastJumpsPath(int system1_id, int system2_id, int empire_id/* = ALL_EMPIRES*/,
-                                                        int max_jumps/* = INT_MAX*/) const {
-    return m_pathfinder->LeastJumpsPath(system1_id, system2_id, empire_id, max_jumps);
-}
-
-int Universe::JumpDistanceBetweenObjects(int object1_id, int object2_id) const {
-    return m_pathfinder->JumpDistanceBetweenObjects(object1_id, object2_id);
-}
-
-bool Universe::SystemsConnected(int system1_id, int system2_id, int empire_id) const {
-    return m_pathfinder->SystemsConnected(system1_id, system2_id, empire_id);
-}
-
-bool Universe::SystemHasVisibleStarlanes(int system_id, int empire_id) const {
-    return m_pathfinder->SystemHasVisibleStarlanes(system_id, empire_id);
-}
-
-std::multimap<double, int> Universe::ImmediateNeighbors(int system_id, int empire_id/* = ALL_EMPIRES*/) const {
-    return m_pathfinder->ImmediateNeighbors(system_id, empire_id);
-}
-
-int Universe::NearestSystemTo(double x, double y) const {
-    return m_pathfinder->NearestSystemTo(x, y);
-}
-
 const int Universe::GetNumCombatRounds() const
 { return 3; }
 
@@ -2788,6 +2747,8 @@ void Universe::InitializeSystemGraph(int for_empire_id) {
     m_pathfinder->InitializeSystemGraph(system_ids, for_empire_id);
 }
 
+//TODO Universe::UpdateEmpireVisibilityFilteredSystemGraphs is never
+//used.  Decide if the functionality permanently belongs in Pathfinder
 void Universe::UpdateEmpireVisibilityFilteredSystemGraphs(int empire_id) {
     m_pathfinder->UpdateEmpireVisibilityFilteredSystemGraphs(empire_id);
 }

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -2738,7 +2738,7 @@ void Universe::EffectDestroy(int object_id, int source_object_id) {
 
 void Universe::InitializeSystemGraph(int for_empire_id) {
     std::vector<int> system_ids = ::EmpireKnownObjects(for_empire_id).FindObjectIDs<System>();
-    std::vector<boost::shared_ptr<const System> > systems;
+    std::vector<std::shared_ptr<const System> > systems;
     for (size_t system1_index = 0; system1_index < system_ids.size(); ++system1_index) {
         int system1_id = system_ids[system1_index];
         systems.push_back(GetEmpireKnownSystem(system1_id, for_empire_id));

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -2738,7 +2738,7 @@ void Universe::EffectDestroy(int object_id, int source_object_id) {
 
 void Universe::InitializeSystemGraph(int for_empire_id) {
     std::vector<int> system_ids = ::EmpireKnownObjects(for_empire_id).FindObjectIDs<System>();
-    std::vector<TemporaryPtr<const System> > systems;
+    std::vector<boost::shared_ptr<const System> > systems;
     for (size_t system1_index = 0; system1_index < system_ids.size(); ++system1_index) {
         int system1_id = system_ids[system1_index];
         systems.push_back(GetEmpireKnownSystem(system1_id, for_empire_id));

--- a/universe/Universe.h
+++ b/universe/Universe.h
@@ -156,83 +156,8 @@ public:
       * that the empire with id \a empire_id can see this turn. */
     std::set<std::string>   GetObjectVisibleSpecialsByEmpire(int object_id, int empire_id) const;
 
-    /** Returns the straight-line distance between the objects with the given
-      * IDs. \throw std::out_of_range This function will throw if either object
-      * ID is out of range. */
-    double                  LinearDistance(int object1_id, int object2_id) const;
-
-    /** Returns the number of starlane jumps between the systems with the given
-      * IDs. If there is no path between the systems, -1 is returned.
-      * \throw std::out_of_range This function will throw if either system
-      * ID is not a valid system id. */
-    short                   JumpDistanceBetweenSystems(int system1_id, int system2_id) const;
-
-    /** Returns the number of starlane jumps between any two objects, accounting
-      * for cases where one or the other are fleets / ships on starlanes between
-      * systems. Returns INT_MAX when no path exists, or either object does not
-      * exist. */
-    int                     JumpDistanceBetweenObjects(int object1_id, int object2_id) const;
-
-
-    /** Returns the sequence of systems, including \a system1_id and
-      * \a system2_id, that defines the shortest path from \a system1 to
-      * \a system2, and the distance travelled to get there.  If no such path
-      * exists, the list will be empty.  Note that the path returned may be via
-      * one or more starlane, or may be "offroad".  The path is calculated
-      * using the visibility for empire \a empire_id, or without regard to
-      * visibility if \a empire_id == ALL_EMPIRES.
-      * \throw std::out_of_range This function will throw if either system ID
-      * is out of range, or if the empire ID is not known. */
-    std::pair<std::list<int>, double>
-                            ShortestPath(int system1_id, int system2_id, int empire_id = ALL_EMPIRES) const;
-
-    /** Returns the shortest starlane path distance between any two objects, accounting
-      * for cases where one or the other are fleets / ships on starlanes between
-      * systems. Returns -1 when no path exists, or either object does not
-      * exist. */
-    double                  ShortestPathDistance(int object1_id, int object2_id) const;
-
-    /** Returns the sequence of systems, including \a system1 and \a system2,
-      * that defines the path with the fewest jumps from \a system1 to
-      * \a system2, and the number of jumps to get there.  If no such path
-      * exists, the list will be empty.  The path is calculated using the
-      * visibility for empire \a empire_id, or without regard to visibility if
-      * \a empire_id == ALL_EMPIRES.  \throw std::out_of_range This function
-      * will throw if either system ID is out of range or if the empire ID is
-      * not known. */
-    std::pair<std::list<int>, int>
-                            LeastJumpsPath(int system1_id, int system2_id, int empire_id = ALL_EMPIRES,
-                                           int max_jumps = INT_MAX) const;
-
-    /** Returns whether there is a path known to empire \a empire_id between
-      * system \a system1 and system \a system2.  The path is calculated using
-      * the visibility for empire \a empire_id, or without regard to visibility
-      * if \a empire_id == ALL_EMPIRES.  \throw std::out_of_range This function
-      * will throw if either system ID is out of range or if the empire ID is
-      * not known. */
-    bool                    SystemsConnected(int system1_id, int system2_id, int empire_id = ALL_EMPIRES) const;
-
-    /** Returns true iff \a system is reachable from another system (i.e. it
-      * has at least one known starlane to it).   This does not guarantee that
-      * the system is reachable from any specific other system, as two separate
-      * groups of locally but not globally interconnected systems may exist.
-      * The starlanes considered depend on their visibility for empire
-      * \a empire_id, or without regard to visibility if
-      * \a empire_id == ALL_EMPIRES. */
-    bool                    SystemHasVisibleStarlanes(int system_id, int empire_id = ALL_EMPIRES) const;
-
-    /** Returns the systems that are one starlane hop away from system
-      * \a system.  The returned systems are indexed by distance from
-      * \a system.  The neighborhood is calculated using the visibility
-      * for empire \a empire_id, or without regard to visibility if
-      * \a empire_id == ALL_EMPIRES.
-      * \throw std::out_of_range This function will throw if the  system
-      * ID is out of range. */
-    std::multimap<double, int>              ImmediateNeighbors(int system_id, int empire_id = ALL_EMPIRES) const;
-
-    /** Returns the id of the System object that is closest to the specified
-      * (\a x, \a y) location on the map, by direct-line distance. */
-    int                                     NearestSystemTo(double x, double y) const;
+    /** Return the Pathfinder */
+    boost::shared_ptr<const Pathfinder> GetPathfinder() const {return m_pathfinder;}
 
     /** Returns map, indexed by object id, to map, indexed by MeterType,
       * to vector of EffectAccountInfo for the meter, in order effects

--- a/universe/Universe.h
+++ b/universe/Universe.h
@@ -157,7 +157,7 @@ public:
     std::set<std::string>   GetObjectVisibleSpecialsByEmpire(int object_id, int empire_id) const;
 
     /** Return the Pathfinder */
-    boost::shared_ptr<const Pathfinder> GetPathfinder() const {return m_pathfinder;}
+    std::shared_ptr<const Pathfinder> GetPathfinder() const {return m_pathfinder;}
 
     /** Returns map, indexed by object id, to map, indexed by MeterType,
       * to vector of EffectAccountInfo for the meter, in order effects
@@ -390,7 +390,7 @@ public:
 private:
     /* Pathfinder setup for the viewing empire
      */
-    boost::shared_ptr<Pathfinder> const m_pathfinder;
+    std::shared_ptr<Pathfinder> const m_pathfinder;
 
     /** Inserts object \a obj into the universe; returns a std::shared_ptr
       * to the inserted object. */

--- a/universe/UniverseObject.cpp
+++ b/universe/UniverseObject.cpp
@@ -326,8 +326,12 @@ void UniverseObject::MoveTo(std::shared_ptr<UniverseObject> object) {
 }
 
 void UniverseObject::MoveTo(double x, double y) {
-    if (x < 0.0 || GetUniverse().UniverseWidth() < x || y < 0.0 || GetUniverse().UniverseWidth() < y)
-        DebugLogger() << "UniverseObject::MoveTo : Placing object \"" + m_name + "\" off the map area.";
+    if ((x < 0.0 || GetUniverse().UniverseWidth() < x || y < 0.0 || GetUniverse().UniverseWidth() < y)
+        && (x != INVALID_POSITION || y != INVALID_POSITION))
+    {
+        DebugLogger() << "UniverseObject::MoveTo : Placing object \"" << m_name << "\" ("
+                      << m_id << ") outside the map area at (" << x << ", " << y << ").";
+    }
 
     if (m_x == x && m_y == y)
         return;

--- a/universe/UniverseObject.cpp
+++ b/universe/UniverseObject.cpp
@@ -6,6 +6,7 @@
 #include "Meter.h"
 #include "System.h"
 #include "Special.h"
+#include "Pathfinder.h"
 #include "Universe.h"
 #include "Predicates.h"
 #include "Enums.h"
@@ -196,7 +197,7 @@ std::string UniverseObject::Dump() const {
             os << "  at: " << sys_name;
     } else {
         os << "  at: (" << this->X() << ", " << this->Y() << ")";
-        int near_id = GetUniverse().NearestSystemTo(this->X(), this->Y());
+        int near_id = GetUniverse().GetPathfinder()->NearestSystemTo(this->X(), this->Y());
         std::shared_ptr<const System> system = GetSystem(near_id);
         if (system) {
             const std::string& sys_name = system->Name();

--- a/universe/UniverseObject.cpp
+++ b/universe/UniverseObject.cpp
@@ -197,7 +197,7 @@ std::string UniverseObject::Dump() const {
             os << "  at: " << sys_name;
     } else {
         os << "  at: (" << this->X() << ", " << this->Y() << ")";
-        int near_id = GetUniverse().GetPathfinder()->NearestSystemTo(this->X(), this->Y());
+        int near_id = GetPathfinder()->NearestSystemTo(this->X(), this->Y());
         std::shared_ptr<const System> system = GetSystem(near_id);
         if (system) {
             const std::string& sys_name = system->Name();

--- a/universe/ValueRef.cpp
+++ b/universe/ValueRef.cpp
@@ -9,6 +9,7 @@
 #include "Species.h"
 #include "System.h"
 #include "Field.h"
+#include "Pathfinder.h"
 #include "Universe.h"
 #include "UniverseObject.h"
 #include "Condition.h"
@@ -858,7 +859,7 @@ int Variable<int>::Eval(const ScriptingContext& context) const
         if (object->SystemID() != INVALID_OBJECT_ID)
             return object->SystemID();
 
-        return GetUniverse().NearestSystemTo(object->X(), object->Y());
+        return GetUniverse().GetPathfinder()->NearestSystemTo(object->X(), object->Y());
 
     } else if (property_name == "NumShips") {
         if (std::shared_ptr<const Fleet> fleet = std::dynamic_pointer_cast<const Fleet>(object))
@@ -1608,7 +1609,7 @@ int ComplexVariable<int>::Eval(const ScriptingContext& context) const
         if (m_int_ref2)
             object2_id = m_int_ref2->Eval(context);
 
-        int retval = GetUniverse().JumpDistanceBetweenObjects(object1_id, object2_id);
+        int retval = GetUniverse().GetPathfinder()->JumpDistanceBetweenObjects(object1_id, object2_id);
         if (retval == INT_MAX)
             return -1;
         return retval;
@@ -1629,7 +1630,7 @@ int ComplexVariable<int>::Eval(const ScriptingContext& context) const
         //    empire_id = m_int_ref3->Eval(context);
 
 
-        int retval = GetUniverse().JumpDistanceBetweenObjects(object1_id, object2_id/*, empire_id*/);
+        int retval = GetUniverse().GetPathfinder()->JumpDistanceBetweenObjects(object1_id, object2_id/*, empire_id*/);
         if (retval == INT_MAX)
             return -1;
         return retval;
@@ -1786,7 +1787,7 @@ double ComplexVariable<double>::Eval(const ScriptingContext& context) const
         if (m_int_ref2)
             object2_id = m_int_ref2->Eval(context);
 
-        return GetUniverse().ShortestPathDistance(object1_id, object2_id);
+        return GetUniverse().GetPathfinder()->ShortestPathDistance(object1_id, object2_id);
 
     }
     else if (variable_name == "SpeciesEmpireOpinion") {

--- a/universe/ValueRef.cpp
+++ b/universe/ValueRef.cpp
@@ -859,7 +859,7 @@ int Variable<int>::Eval(const ScriptingContext& context) const
         if (object->SystemID() != INVALID_OBJECT_ID)
             return object->SystemID();
 
-        return GetUniverse().GetPathfinder()->NearestSystemTo(object->X(), object->Y());
+        return GetPathfinder()->NearestSystemTo(object->X(), object->Y());
 
     } else if (property_name == "NumShips") {
         if (std::shared_ptr<const Fleet> fleet = std::dynamic_pointer_cast<const Fleet>(object))
@@ -1609,7 +1609,7 @@ int ComplexVariable<int>::Eval(const ScriptingContext& context) const
         if (m_int_ref2)
             object2_id = m_int_ref2->Eval(context);
 
-        int retval = GetUniverse().GetPathfinder()->JumpDistanceBetweenObjects(object1_id, object2_id);
+        int retval = GetPathfinder()->JumpDistanceBetweenObjects(object1_id, object2_id);
         if (retval == INT_MAX)
             return -1;
         return retval;
@@ -1630,7 +1630,7 @@ int ComplexVariable<int>::Eval(const ScriptingContext& context) const
         //    empire_id = m_int_ref3->Eval(context);
 
 
-        int retval = GetUniverse().GetPathfinder()->JumpDistanceBetweenObjects(object1_id, object2_id/*, empire_id*/);
+        int retval = GetPathfinder()->JumpDistanceBetweenObjects(object1_id, object2_id/*, empire_id*/);
         if (retval == INT_MAX)
             return -1;
         return retval;
@@ -1787,7 +1787,7 @@ double ComplexVariable<double>::Eval(const ScriptingContext& context) const
         if (m_int_ref2)
             object2_id = m_int_ref2->Eval(context);
 
-        return GetUniverse().GetPathfinder()->ShortestPathDistance(object1_id, object2_id);
+        return GetPathfinder()->ShortestPathDistance(object1_id, object2_id);
 
     }
     else if (variable_name == "SpeciesEmpireOpinion") {

--- a/util/AppInterface.h
+++ b/util/AppInterface.h
@@ -98,6 +98,10 @@ inline SupplyManager& GetSupplyManager()
 inline Universe& GetUniverse()
 { return IApp::GetApp()->GetUniverse(); }
 
+/** Accessor for the App's universe object */
+inline std::shared_ptr<const Pathfinder> GetPathfinder()
+{ return IApp::GetApp()->GetUniverse().GetPathfinder(); }
+
 /** Accessor for all (on server) or all known (on client) objects ObjectMap */
 inline ObjectMap& Objects()
 { return IApp::GetApp()->GetUniverse().Objects(); }

--- a/util/Order.cpp
+++ b/util/Order.cpp
@@ -10,6 +10,7 @@
 #include "../universe/Ship.h"
 #include "../universe/ShipDesign.h"
 #include "../universe/System.h"
+#include "../universe/Pathfinder.h"
 #include "../universe/Universe.h"
 #include "../universe/UniverseObject.h"
 #include "../universe/Enums.h"
@@ -277,7 +278,7 @@ FleetMoveOrder::FleetMoveOrder(int empire, int fleet_id, int start_system_id, in
         return;
     }
 
-    std::pair<std::list<int>, double> short_path = GetUniverse().ShortestPath(m_start_system, m_dest_system, empire);
+    std::pair<std::list<int>, double> short_path = GetUniverse().GetPathfinder()->ShortestPath(m_start_system, m_dest_system, empire);
 
     m_route.clear();
     std::copy(short_path.first.begin(), short_path.first.end(), std::back_inserter(m_route));

--- a/util/Order.cpp
+++ b/util/Order.cpp
@@ -278,7 +278,7 @@ FleetMoveOrder::FleetMoveOrder(int empire, int fleet_id, int start_system_id, in
         return;
     }
 
-    std::pair<std::list<int>, double> short_path = GetUniverse().GetPathfinder()->ShortestPath(m_start_system, m_dest_system, empire);
+    std::pair<std::list<int>, double> short_path = GetPathfinder()->ShortestPath(m_start_system, m_dest_system, empire);
 
     m_route.clear();
     std::copy(short_path.first.begin(), short_path.first.end(), std::back_inserter(m_route));


### PR DESCRIPTION
Separate the functionality encompassed by the graph of starlanes, and pathfinding into its own class.

The benefits will include the following.

Better code partitioning and a smaller Universe class.

Faster partial compile times since Pathfinder is a pimpl implementation.

The ability to optimize the pathfinding functions, in the immediate future the neighborhood region finding functions, which is currently prevented because the distance_matrix_storage and the implementation
of the distance cache are on the different sides of the public private
divide of Universe.h and Universe.cpp. 