### PR TITLE
Add EmpireMeterValue to FOCS for retrieving a value

### DIFF
--- a/parse/DoubleComplexValueRefParser.cpp
+++ b/parse/DoubleComplexValueRefParser.cpp
@@ -26,6 +26,13 @@ namespace parse {
                   )     [ _val = new_<ValueRef::ComplexVariable<double> >(_a, _b, _c, _f, _d, _e) ]
                 ;
 
+            empire_meter_value
+                = (     tok.EmpireMeterValue_ [ _a = construct<std::string>(_1)]
+                     >  parse::label(Empire_token)  >  simple_int[ _b = _1]
+                     >  parse::label(Meter_token) > tok.string[ _d = new_<ValueRef::Constant<std::string> >(_1)]
+                  )     [_val = new_<ValueRef::ComplexVariable<double> >(_a, _b, _c, _f, _d, _e)]
+                ;
+
              direct_distance
                 = (     tok.DirectDistanceBetween_ [ _a = construct<std::string>(_1) ]
                      >  parse::label(Object_token) > simple_int [ _b = _1 ]
@@ -66,6 +73,7 @@ namespace parse {
 
             start
                 %=  part_capacity
+                |   empire_meter_value
                 |   direct_distance
                 |   shortest_path
                 |   species_empire_opinion
@@ -73,6 +81,7 @@ namespace parse {
                 ;
 
             part_capacity.name("PartCapacity");
+            empire_meter_value.name("EmpireMeterValue");
             direct_distance.name("DirectDistanceBetween");
             shortest_path.name("ShortestPathBetween");
             species_empire_opinion.name("SpeciesOpinion (of empire)");
@@ -84,6 +93,7 @@ namespace parse {
         }
 
         complex_variable_rule<double>::type part_capacity;
+        complex_variable_rule<double>::type empire_meter_value;
         complex_variable_rule<double>::type direct_distance;
         complex_variable_rule<double>::type shortest_path;
         complex_variable_rule<double>::type species_empire_opinion;

--- a/parse/Tokens.h
+++ b/parse/Tokens.h
@@ -102,6 +102,7 @@
     (Else)                                      \
     (Empire)                                    \
     (EmpireMeter)                               \
+    (EmpireMeterValue)                          \
     (EmpireShipsDestroyed)                      \
     (Endpoint)                                  \
     (EnemyOf)                                   \

--- a/universe/ValueRef.cpp
+++ b/universe/ValueRef.cpp
@@ -1763,7 +1763,7 @@ double ComplexVariable<double>::Eval(const ScriptingContext& context) const
             empire_id = m_int_ref1->Eval(context);
         Empire* empire = GetEmpire(empire_id);
         if (!empire)
-            return -1.0;
+            return 0.0;
 
         std::string empire_meter_name;
         if (m_string_ref1)

--- a/universe/ValueRef.cpp
+++ b/universe/ValueRef.cpp
@@ -1757,6 +1757,22 @@ double ComplexVariable<double>::Eval(const ScriptingContext& context) const
         return part_type->Capacity();
 
     }
+    else if (variable_name == "EmpireMeterValue") {
+        int empire_id = ALL_EMPIRES;
+        if (m_int_ref1)
+            empire_id = m_int_ref1->Eval(context);
+        Empire* empire = GetEmpire(empire_id);
+        if (!empire)
+            return -1.0;
+
+        std::string empire_meter_name;
+        if (m_string_ref1)
+            empire_meter_name = m_string_ref1->Eval(context);
+        Meter * meter = empire->GetMeter(empire_meter_name);
+        if (!meter)
+            return 0.0;
+        return meter->Current();
+    }
     else if (variable_name == "DirectDistanceBetween") {
         int object1_id = INVALID_OBJECT_ID;
         if (m_int_ref1)

--- a/universe/ValueRef.cpp
+++ b/universe/ValueRef.cpp
@@ -1768,7 +1768,7 @@ double ComplexVariable<double>::Eval(const ScriptingContext& context) const
         std::string empire_meter_name;
         if (m_string_ref1)
             empire_meter_name = m_string_ref1->Eval(context);
-        Meter * meter = empire->GetMeter(empire_meter_name);
+        Meter* meter = empire->GetMeter(empire_meter_name);
         if (!meter)
             return 0.0;
         return meter->Current();


### PR DESCRIPTION
A generic way to get the value of an empire meter in FOCS. This is necessary for meters existing only in FOCS and helpful when in the process of introducing new meters.

Use like this:
EmpireMeterValue empire = Source.Owner meter = "METER_DETECTION_STRENGTH"

Be careful that the value only represents the meter value in the instant
when this gets called. E.g. other effects might change it afterwards.

Implementation Note:
Maybe the token should be EmpireMeter instead of EmpireMeterValue.