### PR TITLE
Fix cpp api python filter

### DIFF
--- a/doc/Doxyfile.in
+++ b/doc/Doxyfile.in
@@ -126,7 +126,7 @@ EXAMPLE_PATTERNS       =
 EXAMPLE_RECURSIVE      = NO
 IMAGE_PATH             =
 INPUT_FILTER           =
-FILTER_PATTERNS        = "*.py=\"@PYTHON_EXECUTABLE@ @FreeOrion_SOURCE_DIR@/doc/tag_filter.py\""
+FILTER_PATTERNS        = "*.py=\"@PYTHON_EXECUTABLE@\" \"@FreeOrion_SOURCE_DIR@/doc/tag_filter.py\""
 FILTER_SOURCE_FILES    = NO
 FILTER_SOURCE_PATTERNS =
 USE_MDFILE_AS_MAINPAGE =


### PR DESCRIPTION
Workaround for the multiple no file found warnings:
 `sh: @PYTHON_EXECUTABLE@ @FreeOrion_SOURCE_DIR@/doc/tag_filter.py: No such file or directory
`

Related #1254 