### PR TITLE
Correct ctor selection for delegated ctor - MultiIconValueIndicator

### DIFF
--- a/UI/MultiIconValueIndicator.cpp
+++ b/UI/MultiIconValueIndicator.cpp
@@ -28,7 +28,7 @@ MultiIconValueIndicator::MultiIconValueIndicator(GG::X w) :
 
 MultiIconValueIndicator::MultiIconValueIndicator(GG::X w, int object_id,
                                                  const std::vector<std::pair<MeterType, MeterType>>& meter_types) :
-    MultiIconValueIndicator(w, {{object_id}}, meter_types)
+    MultiIconValueIndicator(w, std::vector<int>{object_id}, meter_types)
 {}
 
 MultiIconValueIndicator::MultiIconValueIndicator(GG::X w, const std::vector<int>& object_ids,


### PR DESCRIPTION
Apple LLVM 6.1.0 fails to build with 1 error, 1 warning:
```
/Users/travis/build/freeorion/freeorion/UI/MultiIconValueIndicator.cpp:31:33: warning: too many braces around scalar initializer

/Users/travis/build/freeorion/freeorion/UI/MultiIconValueIndicator.cpp:31:5: error: constructor for 'MultiIconValueIndicator' creates a delegation cycle [-Wdelegating-ctor-cycles]
```

~~GCC 6.3.1 has a similar error and warning:~~
(Apparently, I can no longer reproduce despite `make clean && ccache -- clear`)

PR is a proposed solution to correct constructor selection of delegated constructor.

Needs testing at least for `MSVC`

 (created as branch on master to verify travis now builds)