### PR TITLE
Provide std::string in phoenix expressions

### DIFF
--- a/parse/DoubleComplexValueRefParser.cpp
+++ b/parse/DoubleComplexValueRefParser.cpp
@@ -1,6 +1,9 @@
 #include "ValueRefParserImpl.h"
 
 namespace parse {
+    const std::string TOK_SPECIES_EMPIRE_OPINION{"SpeciesEmpireOpinion"};
+    const std::string TOK_SPECIES_SPECIES_OPINION{"SpeciesSpeciesOpinion"};
+
     struct double_complex_parser_rules {
         double_complex_parser_rules() {
             qi::_1_type _1;
@@ -55,7 +58,7 @@ namespace parse {
 
             species_empire_opinion
                 = (
-                    (  tok.SpeciesOpinion_ [ _a = construct<std::string>("SpeciesEmpireOpinion") ]
+                    (  tok.SpeciesOpinion_ [ _a = construct<std::string>(TOK_SPECIES_EMPIRE_OPINION) ]
                        >  parse::label(Species_token) >  string_value_ref [ _d = _1 ]
                     )
                   >> parse::label(Empire_token)  >  simple_int [ _b = _1 ]
@@ -64,7 +67,7 @@ namespace parse {
 
             species_species_opinion
                 = (
-                    (   tok.SpeciesOpinion_ [ _a = construct<std::string>("SpeciesSpeciesOpinion") ]
+                    (   tok.SpeciesOpinion_ [ _a = construct<std::string>(TOK_SPECIES_SPECIES_OPINION) ]
                       >  parse::label(Species_token) >  string_value_ref [ _d = _1 ]
                     )
                   >> parse::label(Species_token) >  string_value_ref [ _e = _1 ]

--- a/parse/StringValueRefParser.cpp
+++ b/parse/StringValueRefParser.cpp
@@ -67,7 +67,10 @@ void initialize_nonnumeric_expression_parsers<std::string>(
         ;
 }
 
-namespace { struct string_parser_rules {
+namespace {
+    const std::string TOK_CURRENT_CONTENT{"CurrentContent"};
+
+    struct string_parser_rules {
         string_parser_rules() {
             qi::_1_type _1;
             qi::_val_type _val;
@@ -93,7 +96,7 @@ namespace { struct string_parser_rules {
                     |   tok.ThisTech_
                     |   tok.ThisSpecies_
                     |   tok.ThisSpecial_
-                   ) [ _val = new_<ValueRef::Constant<std::string> >("CurrentContent") ]
+                   ) [ _val = new_<ValueRef::Constant<std::string> >(TOK_CURRENT_CONTENT) ]
                 ;
 
             free_variable


### PR DESCRIPTION
With boost 1.63, phoenix uses variadic expressions (which may be disabled by defining `BOOST_PHOENIX_NO_VARIADIC_EXPRESSION`).
These expressions do not implicitly convert `char *` to `std::string`

An alternate previous fix by @o01eg was [here](https://github.com/freeorion/freeorion/pull/1202/commits/12112351b2084eef49f7eab07ff4e95bdae45f6e).

Fixes #1267 