### PR TITLE
Make sure num_segments is at least 1

### DIFF
--- a/UI/MultiMeterStatusBar.cpp
+++ b/UI/MultiMeterStatusBar.cpp
@@ -128,6 +128,8 @@ void MultiMeterStatusBar::Render() {
     // lines for 20, 40, 60, 80 etc.
     int num_segments = num_full_increments * 5;
     GG::GL2DVertexBuffer bar_verts;
+    if (num_segments == 0)
+        num_segments = 1;
     bar_verts.reserve(num_segments - 1);
     for (int ii_div_line = 1; ii_div_line <= (num_segments -1); ++ii_div_line) {
         bar_verts.store(BAR_LEFT + ii_div_line*BAR_MAX_LENGTH/num_segments, TOP);


### PR DESCRIPTION
After computing the possible range for the meter, make sure num_segments is 1 before passing it into the reserve method.

This patch fixes this particular crash, but I'm not sure if it's the best place to fix it. I didn't fix it inside `GG/GLClientAndServerBuffer.cpp` since it felt like as far as `GLClientAndServerBufferBase` is concerned, it *should* assume the parameter passed to `reserve` is unsigned.

fixes #1272