### PR TITLE
Improve performance of WithinStarlaneJumps.

### DIFF
--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -6606,9 +6606,9 @@ void WithinStarlaneJumps::Eval(const ScriptingContext& parent_context,
         ObjectSet subcondition_matches;
         m_condition->Eval(local_context, subcondition_matches);
         int jump_limit = m_jumps->Eval(local_context);
-        ObjectSet &from_set( search_domain == Condition::MATCHES ? matches : non_matches);
+        ObjectSet &from_set(search_domain == Condition::MATCHES ? matches : non_matches);
 
-        GetUniverse().GetPathfinder()->WithinJumpsOfOthers(jump_limit, matches, non_matches, from_set, subcondition_matches);
+        std::tie(matches, non_matches) = GetPathfinder()->WithinJumpsOfOthers(jump_limit, from_set, subcondition_matches);
 
     } else {
         // re-evaluate contained objects for each candidate object
@@ -6659,11 +6659,15 @@ bool WithinStarlaneJumps::Match(const ScriptingContext& local_context) const {
     if (jump_limit < 0)
         return false;
 
-    ObjectSet near;
-    ObjectSet one;
-    one.push_back(candidate);
-    GetUniverse().GetPathfinder()->WithinJumpsOfOthers(jump_limit, near, one, one, subcondition_matches);
-    return !near.empty();
+    ObjectSet candidate_set;
+    candidate_set.push_back(candidate);
+
+    // candidate objects within jumps of subcondition_matches objects
+    ObjectSet near_objs;
+
+    std::tie(near_objs, std::ignore) =
+        GetPathfinder()->WithinJumpsOfOthers(jump_limit, candidate_set, subcondition_matches);
+    return !near_objs.empty();
 }
 
 void WithinStarlaneJumps::SetTopLevelContent(const std::string& content_name) {

--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -6659,8 +6659,7 @@ bool WithinStarlaneJumps::Match(const ScriptingContext& local_context) const {
     if (jump_limit < 0)
         return false;
 
-    ObjectSet candidate_set;
-    candidate_set.push_back(candidate);
+    ObjectSet candidate_set{candidate};
 
     // candidate objects within jumps of subcondition_matches objects
     ObjectSet near_objs;

--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -6591,36 +6591,6 @@ bool WithinStarlaneJumps::operator==(const ConditionBase& rhs) const {
     return true;
 }
 
-namespace {
-    struct WithinStarlaneJumpsSimpleMatch {
-        WithinStarlaneJumpsSimpleMatch(const ObjectSet& from_objects, int jump_limit) :
-            m_from_objects(from_objects),
-            m_jump_limit(jump_limit)
-        {}
-
-        bool operator()(std::shared_ptr<const UniverseObject> candidate) const {
-            if (!candidate)
-                return false;
-            if (m_from_objects.empty())
-                return false;
-            if (m_jump_limit < 0)
-                return false;
-
-            // is candidate object close enough to any subcondition matches?
-            for (std::shared_ptr<const UniverseObject> obj : m_from_objects) {
-                int jumps = GetPathfinder()->JumpDistanceBetweenObjects(obj->ID(), candidate->ID());
-                if (jumps != -1 && jumps <= m_jump_limit)
-                    return true;
-            }
-
-            return false;
-        }
-
-        const ObjectSet& m_from_objects;
-        int m_jump_limit;
-    };
-}
-
 void WithinStarlaneJumps::Eval(const ScriptingContext& parent_context,
                                ObjectSet& matches, ObjectSet& non_matches,
                                SearchDomain search_domain/* = NON_MATCHES*/) const
@@ -6636,8 +6606,10 @@ void WithinStarlaneJumps::Eval(const ScriptingContext& parent_context,
         ObjectSet subcondition_matches;
         m_condition->Eval(local_context, subcondition_matches);
         int jump_limit = m_jumps->Eval(local_context);
+        ObjectSet &from_set( search_domain == Condition::MATCHES ? matches : non_matches);
 
-        EvalImpl(matches, non_matches, search_domain, WithinStarlaneJumpsSimpleMatch(subcondition_matches, jump_limit));
+        GetUniverse().GetPathfinder()->WithinJumps(jump_limit, matches, non_matches, from_set, subcondition_matches);
+
     } else {
         // re-evaluate contained objects for each candidate object
         ConditionBase::Eval(parent_context, matches, non_matches, search_domain);
@@ -6680,9 +6652,18 @@ bool WithinStarlaneJumps::Match(const ScriptingContext& local_context) const {
     // get subcondition matches
     ObjectSet subcondition_matches;
     m_condition->Eval(local_context, subcondition_matches);
-    int jump_limit = m_jumps->Eval(local_context);
+    if (subcondition_matches.empty())
+        return false;
 
-    return WithinStarlaneJumpsSimpleMatch(subcondition_matches, jump_limit)(candidate);
+    int jump_limit = m_jumps->Eval(local_context);
+    if (jump_limit < 0)
+        return false;
+
+    ObjectSet near;
+    ObjectSet one;
+    one.push_back(candidate);
+    GetUniverse().GetPathfinder()->WithinJumps(jump_limit, near, one, one, subcondition_matches);
+    return !near.empty();
 }
 
 void WithinStarlaneJumps::SetTopLevelContent(const std::string& content_name) {

--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -6608,7 +6608,7 @@ void WithinStarlaneJumps::Eval(const ScriptingContext& parent_context,
         int jump_limit = m_jumps->Eval(local_context);
         ObjectSet &from_set( search_domain == Condition::MATCHES ? matches : non_matches);
 
-        GetUniverse().GetPathfinder()->WithinJumps(jump_limit, matches, non_matches, from_set, subcondition_matches);
+        GetUniverse().GetPathfinder()->WithinJumpsOfOthers(jump_limit, matches, non_matches, from_set, subcondition_matches);
 
     } else {
         // re-evaluate contained objects for each candidate object
@@ -6662,7 +6662,7 @@ bool WithinStarlaneJumps::Match(const ScriptingContext& local_context) const {
     ObjectSet near;
     ObjectSet one;
     one.push_back(candidate);
-    GetUniverse().GetPathfinder()->WithinJumps(jump_limit, near, one, one, subcondition_matches);
+    GetUniverse().GetPathfinder()->WithinJumpsOfOthers(jump_limit, near, one, one, subcondition_matches);
     return !near.empty();
 }
 

--- a/universe/Pathfinder.cpp
+++ b/universe/Pathfinder.cpp
@@ -744,7 +744,7 @@ namespace {
 /** JumpDistanceSys2Visitor determines the distance between \p _sys_id1 and the
     GeneralizedLocation that it is visiting.*/
 struct JumpDistanceSys2Visitor : public boost::static_visitor<int> {
-    JumpDistanceSys2Visitor(Pathfinder::PathfinderImpl const & _pf, int _sys_id1) :
+    JumpDistanceSys2Visitor(const Pathfinder::PathfinderImpl& _pf, int _sys_id1) :
         pf(_pf), sys_id1(_sys_id1) {}
 
     /** Return the maximum distance if this end is nowhere.  */
@@ -755,7 +755,7 @@ struct JumpDistanceSys2Visitor : public boost::static_visitor<int> {
         short sjumps = -1;
         try {
             sjumps = pf.JumpDistanceBetweenSystems(sys_id1, sys_id2);
-        } catch (std::out_of_range const &) {
+        } catch (const std::out_of_range&) {
             ErrorLogger() << "JumpsBetweenObjects caught out of range exception sys_id1 = "
                           << sys_id1 << " sys_id2 = " << sys_id2;
             return INT_MAX;
@@ -783,7 +783,7 @@ struct JumpDistanceSys2Visitor : public boost::static_visitor<int> {
         int jumps = std::min(jumps1, jumps2);
         return jumps;
    }
-    Pathfinder::PathfinderImpl const & pf;
+    const Pathfinder::PathfinderImpl& pf;
     int sys_id1;
 };
 
@@ -791,8 +791,8 @@ struct JumpDistanceSys2Visitor : public boost::static_visitor<int> {
     JumpDistanceSysVisitor2 to determines the distance between \p _sys_id2 and
     the GeneralizedLocation that it is visiting.*/
 struct JumpDistanceSys1Visitor : public boost::static_visitor<int> {
-    JumpDistanceSys1Visitor(Pathfinder::PathfinderImpl const & _pf,
-                            GeneralizedLocationType const &_sys2_ids) :
+    JumpDistanceSys1Visitor(const Pathfinder::PathfinderImpl& _pf,
+                            const GeneralizedLocationType&_sys2_ids) :
         pf(_pf), sys2_ids(_sys2_ids) {}
 
     /** Return the maximum distance if the first object is nowhere.*/
@@ -1007,9 +1007,9 @@ std::multimap<double, int> Pathfinder::PathfinderImpl::ImmediateNeighbors(int sy
 /** Examine a single universe object and determine if it is within jumps
     of any object in others.*/
 struct WithinJumpsOfOthersObjectVisitor : public boost::static_visitor<bool> {
-    WithinJumpsOfOthersObjectVisitor(Pathfinder::PathfinderImpl const & _pf,
+    WithinJumpsOfOthersObjectVisitor(const Pathfinder::PathfinderImpl& _pf,
                                      int _jumps,
-                                     std::vector<std::shared_ptr<const UniverseObject>> const & _others
+                                     const std::vector<std::shared_ptr<const UniverseObject>>& _others
                                     ) :
         pf(_pf), jumps(_jumps), others(_others) {}
 
@@ -1022,9 +1022,9 @@ struct WithinJumpsOfOthersObjectVisitor : public boost::static_visitor<bool> {
         return pf.WithinJumpsOfOthers(jumps, prev_next.first, others)
             || pf.WithinJumpsOfOthers(jumps, prev_next.second, others);
     }
-    Pathfinder::PathfinderImpl const & pf;
+    const Pathfinder::PathfinderImpl& pf;
     int jumps;
-    std::vector<std::shared_ptr<const UniverseObject>> const & others;
+    const std::vector<std::shared_ptr<const UniverseObject>>& others;
 };
 
 /** Examine a single other in the cache to see if any of its locations
@@ -1155,7 +1155,7 @@ int Pathfinder::PathfinderImpl::NearestSystemTo(double x, double y) const {
 
     std::vector<std::shared_ptr<System>> systems = Objects().FindObjects<System>();
 
-    for (auto const &system : systems)
+    for (auto const& system : systems)
     {
         double xs = system->X();
         double ys = system->Y();
@@ -1211,7 +1211,7 @@ void Pathfinder::PathfinderImpl::InitializeSystemGraph(const std::vector<int> sy
         //std::shared_ptr<const System> & system1 = systems[system1_index];
 
         // add edges and edge weights
-        for (auto const & lane_dest : system1->StarlanesWormholes()) {
+        for (auto const& lane_dest : system1->StarlanesWormholes()) {
             // get id in universe of system at other end of lane
             const int lane_dest_id = lane_dest.first;
             // skip null lanes and only add edges in one direction, to avoid
@@ -1278,7 +1278,7 @@ void Pathfinder::PathfinderImpl::UpdateEmpireVisibilityFilteredSystemGraphs(int 
 
     if (for_empire_id == ALL_EMPIRES) {
         // all empires get their own, accurately filtered graph
-        for (auto const &empire : Empires()) {
+        for (auto const& empire : Empires()) {
             int empire_id = empire.first;
             GraphImpl::EdgeVisibilityFilter filter(&m_graph_impl->system_graph, empire_id);
             auto filtered_graph_ptr = std::make_shared<GraphImpl::EmpireViewSystemGraph>(m_graph_impl->system_graph, filter);
@@ -1290,7 +1290,7 @@ void Pathfinder::PathfinderImpl::UpdateEmpireVisibilityFilteredSystemGraphs(int 
         GraphImpl::EdgeVisibilityFilter filter(&m_graph_impl->system_graph, for_empire_id);
         auto filtered_graph_ptr = std::make_shared<GraphImpl::EmpireViewSystemGraph>(m_graph_impl->system_graph, filter);
 
-        for (auto const &empire : Empires()) {
+        for (auto const& empire : Empires()) {
             int empire_id = empire.first;
             m_graph_impl->empire_system_graph_views[empire_id] = filtered_graph_ptr;
         }

--- a/universe/Pathfinder.cpp
+++ b/universe/Pathfinder.cpp
@@ -262,8 +262,7 @@ namespace SystemPathing {
               m_level_complete(false)
         {}
 
-        void initialize_vertex(const Vertex& v, const Graph& g)
-        {}
+        void initialize_vertex(const Vertex& v, const Graph& g) {}
 
         void discover_vertex(const Vertex& v, const Graph& g) {
             m_predecessors[static_cast<int>(v)] = m_source;
@@ -621,8 +620,8 @@ Pathfinder::Pathfinder() :
     pimpl(new PathfinderImpl)
 {}
 
-Pathfinder::~Pathfinder() {
-}
+Pathfinder::~Pathfinder()
+{}
 
 namespace {
     std::shared_ptr<const Fleet> FleetFromObject(std::shared_ptr<const UniverseObject> obj) {
@@ -753,7 +752,8 @@ namespace {
     GeneralizedLocation that it is visiting.*/
 struct JumpDistanceSys2Visitor : public boost::static_visitor<int> {
     JumpDistanceSys2Visitor(const Pathfinder::PathfinderImpl& _pf, int _sys_id1) :
-        pf(_pf), sys_id1(_sys_id1) {}
+        pf(_pf), sys_id1(_sys_id1)
+    {}
 
     /** Return the maximum distance if this end is nowhere.  */
     int operator()(std::nullptr_t) const { return INT_MAX; }
@@ -801,7 +801,8 @@ struct JumpDistanceSys2Visitor : public boost::static_visitor<int> {
 struct JumpDistanceSys1Visitor : public boost::static_visitor<int> {
     JumpDistanceSys1Visitor(const Pathfinder::PathfinderImpl& _pf,
                             const GeneralizedLocationType&_sys2_ids) :
-        pf(_pf), sys2_ids(_sys2_ids) {}
+        pf(_pf), sys2_ids(_sys2_ids)
+    {}
 
     /** Return the maximum distance if the first object is nowhere.*/
     int operator()(std::nullptr_t) const { return INT_MAX; }
@@ -1017,9 +1018,9 @@ std::multimap<double, int> Pathfinder::PathfinderImpl::ImmediateNeighbors(int sy
 struct WithinJumpsOfOthersObjectVisitor : public boost::static_visitor<bool> {
     WithinJumpsOfOthersObjectVisitor(const Pathfinder::PathfinderImpl& _pf,
                                      int _jumps,
-                                     const std::vector<std::shared_ptr<const UniverseObject>>& _others
-                                    ) :
-        pf(_pf), jumps(_jumps), others(_others) {}
+                                     const std::vector<std::shared_ptr<const UniverseObject>>& _others) :
+        pf(_pf), jumps(_jumps), others(_others)
+    {}
 
     bool operator()(std::nullptr_t) const { return false; }
     bool operator()(int sys_id) const {
@@ -1040,8 +1041,7 @@ struct WithinJumpsOfOthersObjectVisitor : public boost::static_visitor<bool> {
 struct WithinJumpsOfOthersOtherVisitor : public boost::static_visitor<bool> {
     WithinJumpsOfOthersOtherVisitor(const Pathfinder::PathfinderImpl& _pf,
                                     int _jumps,
-                                    const distance_matrix_storage<short>::row_ref _row
-                                   ) :
+                                    const distance_matrix_storage<short>::row_ref _row) :
         pf(_pf), jumps(_jumps), row(_row)
     {}
 

--- a/universe/Pathfinder.cpp
+++ b/universe/Pathfinder.cpp
@@ -64,9 +64,9 @@ namespace {
         }
 
         /**N x N table of hop distances in row column form.*/
-        std::vector< std::vector<T> > m_data;
+        std::vector< std::vector<T>> m_data;
         /**Per row mutexes.*/
-        std::vector< std::shared_ptr<boost::shared_mutex> > m_row_mutexes;
+        std::vector< std::shared_ptr<boost::shared_mutex>> m_row_mutexes;
         /**Table mutex*/
         boost::shared_mutex m_mutex;
     };
@@ -475,7 +475,7 @@ namespace {
     /////////////////////////////////////////////
     struct GraphImpl {
         typedef boost::property<vertex_system_id_t, int,
-                                boost::property<boost::vertex_index_t, int> >   vertex_property_t;  ///< a system graph property map type
+                                boost::property<boost::vertex_index_t, int>>   vertex_property_t;  ///< a system graph property map type
         typedef boost::property<boost::edge_weight_t, double>                   edge_property_t;    ///< a system graph property map type
 
         // declare main graph types, including properties declared above
@@ -530,7 +530,7 @@ namespace {
             int                     m_empire_id;
         };
         typedef boost::filtered_graph<SystemGraph, EdgeVisibilityFilter> EmpireViewSystemGraph;
-        typedef std::map<int, std::shared_ptr<EmpireViewSystemGraph> > EmpireViewSystemGraphMap;
+        typedef std::map<int, std::shared_ptr<EmpireViewSystemGraph>> EmpireViewSystemGraphMap;
 
         // declare property map types for properties declared above
         typedef boost::property_map<SystemGraph, vertex_system_id_t>::const_type        ConstSystemIDPropertyMap;
@@ -576,15 +576,15 @@ class Pathfinder::PathfinderImpl {
 
     void WithinJumpsOfOthers(
         int jumps,
-        std::vector<std::shared_ptr<const UniverseObject> > & near,
-        std::vector<std::shared_ptr<const UniverseObject> > & far,
-        std::vector<std::shared_ptr<const UniverseObject> > & candidates,
-        std::vector<std::shared_ptr<const UniverseObject> > const & others) const;
+        std::vector<std::shared_ptr<const UniverseObject>> & near,
+        std::vector<std::shared_ptr<const UniverseObject>> & far,
+        std::vector<std::shared_ptr<const UniverseObject>> & candidates,
+        std::vector<std::shared_ptr<const UniverseObject>> const & others) const;
 
     /**Return true if \p system_id is within \p jumps of any of \p others*/
     bool WithinJumpsOfOthers(
         int jumps, int system_id,
-        std::vector<std::shared_ptr<const UniverseObject> > const & others) const;
+        std::vector<std::shared_ptr<const UniverseObject>> const & others) const;
 
     /** If any of \p others are within \p jumps of \p ii return true in \p answer.
 
@@ -592,7 +592,7 @@ class Pathfinder::PathfinderImpl {
      */
     void WithinJumpsOfOthersCacheHit(
         bool* const answer, int jumps,
-        std::vector<std::shared_ptr<const UniverseObject> > const & others,
+        std::vector<std::shared_ptr<const UniverseObject>> const & others,
         size_t ii, const distance_matrix_storage<short>::row_ref row) const;
 
     int NearestSystemTo(double x, double y) const;
@@ -680,7 +680,7 @@ short Pathfinder::PathfinderImpl::JumpDistanceBetweenSystems(int system1_id, int
         return 0;
 
     try {
-        distance_matrix_cache< distance_matrix_storage<short> > cache(m_system_jumps);
+        distance_matrix_cache< distance_matrix_storage<short>> cache(m_system_jumps);
 
         size_t system1_index = m_system_id_to_graph_index.at(system1_id);
         size_t system2_index = m_system_id_to_graph_index.at(system2_id);
@@ -720,7 +720,7 @@ namespace {
     // A constant to indate a UniverseObject is nowhere.
     typedef void (*NowhereType)();
     void Nowhere() {}
-    typedef boost::variant<NowhereType, int, std::pair<int, int > > ObjectSystemIDType;
+    typedef boost::variant<NowhereType, int, std::pair<int, int >> ObjectSystemIDType;
 
     /** Return the location of \p obj.*/
     ObjectSystemIDType ObjectSystemID(std::shared_ptr<const UniverseObject> obj) {
@@ -1020,7 +1020,7 @@ std::multimap<double, int> Pathfinder::PathfinderImpl::ImmediateNeighbors(int sy
 struct WithinJumpsOfOthersObjectVisitor : public boost::static_visitor<bool> {
     WithinJumpsOfOthersObjectVisitor(Pathfinder::PathfinderImpl const & _pf,
                                      int _jumps,
-                                     std::vector<std::shared_ptr<const UniverseObject> > const & _others
+                                     std::vector<std::shared_ptr<const UniverseObject>> const & _others
                                     ) :
         pf(_pf), jumps(_jumps), others(_others) {}
 
@@ -1035,7 +1035,7 @@ struct WithinJumpsOfOthersObjectVisitor : public boost::static_visitor<bool> {
     }
     Pathfinder::PathfinderImpl const & pf;
     int jumps;
-    std::vector<std::shared_ptr<const UniverseObject> > const & others;
+    std::vector<std::shared_ptr<const UniverseObject>> const & others;
 };
 
 /** Examine a single other in the cache to see if any of its locations
@@ -1076,7 +1076,7 @@ struct WithinJumpsOfOthersOtherVisitor : public boost::static_visitor<bool> {
 void Pathfinder::PathfinderImpl::WithinJumpsOfOthersCacheHit(
     bool* const answer, // answer constant pointer to a non-constant bool
     int jumps,
-    const std::vector<std::shared_ptr<const UniverseObject> >& others,
+    const std::vector<std::shared_ptr<const UniverseObject>>& others,
     size_t ii, const distance_matrix_storage<short>::row_ref row) const
 {
     // Check if any of the others are within jumps of candidate, by looping
@@ -1095,26 +1095,26 @@ void Pathfinder::PathfinderImpl::WithinJumpsOfOthersCacheHit(
 
 void Pathfinder::WithinJumpsOfOthers(
     int jumps,
-    std::vector<std::shared_ptr<const UniverseObject> >& near,
-    std::vector<std::shared_ptr<const UniverseObject> >& far,
-    std::vector<std::shared_ptr<const UniverseObject> >& candidates,
-    const std::vector<std::shared_ptr<const UniverseObject> >& others) const
+    std::vector<std::shared_ptr<const UniverseObject>>& near,
+    std::vector<std::shared_ptr<const UniverseObject>>& far,
+    std::vector<std::shared_ptr<const UniverseObject>>& candidates,
+    const std::vector<std::shared_ptr<const UniverseObject>>& others) const
 {
     pimpl->WithinJumpsOfOthers(jumps, near, far, candidates, others);
 }
 
 void Pathfinder::PathfinderImpl::WithinJumpsOfOthers(
     int jumps,
-    std::vector<std::shared_ptr<const UniverseObject> >& near,
-    std::vector<std::shared_ptr<const UniverseObject> >& far,
-    std::vector<std::shared_ptr<const UniverseObject> >& candidates_,
-    const std::vector<std::shared_ptr<const UniverseObject> >& others) const
+    std::vector<std::shared_ptr<const UniverseObject>>& near,
+    std::vector<std::shared_ptr<const UniverseObject>>& far,
+    std::vector<std::shared_ptr<const UniverseObject>>& candidates_,
+    const std::vector<std::shared_ptr<const UniverseObject>>& others) const
 {
     // Examine each candidate and transfer those within jumps of the
     // others into near.
     // near or far may be the same as candidates.
     WithinJumpsOfOthersObjectVisitor visitor(*this, jumps, others);
-    std::vector<std::shared_ptr<const UniverseObject> > candidates;
+    std::vector<std::shared_ptr<const UniverseObject>> candidates;
     candidates.swap(candidates_);
     size_t size = candidates.size();
     near.reserve(near.size() + size);
@@ -1133,7 +1133,7 @@ void Pathfinder::PathfinderImpl::WithinJumpsOfOthers(
 
 bool Pathfinder::PathfinderImpl::WithinJumpsOfOthers(
     int jumps, int system_id,
-    const std::vector<std::shared_ptr<const UniverseObject> >& others) const
+    const std::vector<std::shared_ptr<const UniverseObject>>& others) const
 {
     if (others.empty())
         return false;
@@ -1148,7 +1148,7 @@ bool Pathfinder::PathfinderImpl::WithinJumpsOfOthers(
 
     // Examine the cache to see if \p system_id is within \p jumps of \p others
     bool within_jumps(false);
-    distance_matrix_cache< distance_matrix_storage<short> > cache(m_system_jumps);
+    distance_matrix_cache< distance_matrix_storage<short>> cache(m_system_jumps);
     cache.examine_row(system_index,
                       boost::bind(&Pathfinder::PathfinderImpl::HandleCacheMiss, this, _1, _2),
                       boost::bind(&Pathfinder::PathfinderImpl::WithinJumpsOfOthersCacheHit, this,
@@ -1165,7 +1165,7 @@ int Pathfinder::PathfinderImpl::NearestSystemTo(double x, double y) const {
     double min_dist2 = DBL_MAX;
     int min_dist2_sys_id = INVALID_OBJECT_ID;
 
-    std::vector<std::shared_ptr<System> > systems = Objects().FindObjects<System>();
+    std::vector<std::shared_ptr<System>> systems = Objects().FindObjects<System>();
 
     for (auto const &system : systems)
     {

--- a/universe/Pathfinder.cpp
+++ b/universe/Pathfinder.cpp
@@ -586,9 +586,12 @@ class Pathfinder::PathfinderImpl {
         int jumps, int system_id,
         std::vector<std::shared_ptr<const UniverseObject> > const & others) const;
 
-    /** If any of \p others are within \p jumps of \p ii return true in \p answer.*/
+    /** If any of \p others are within \p jumps of \p ii return true in \p answer.
+
+        \p answer is a constant pointer to a non-constant bool so that boost::bind
+     */
     void WithinJumpsOfOthersCacheHit(
-        bool * const answer, int jumps,
+        bool* const answer, int jumps,
         std::vector<std::shared_ptr<const UniverseObject> > const & others,
         size_t ii, const distance_matrix_storage<short>::row_ref row) const;
 
@@ -1016,9 +1019,9 @@ std::multimap<double, int> Pathfinder::PathfinderImpl::ImmediateNeighbors(int sy
     of any object in others.*/
 struct WithinJumpsOfOthersObjectVisitor : public boost::static_visitor<bool> {
     WithinJumpsOfOthersObjectVisitor(Pathfinder::PathfinderImpl const & _pf,
-                             int _jumps,
-                             std::vector<std::shared_ptr<const UniverseObject> > const & _others
-                            ) :
+                                     int _jumps,
+                                     std::vector<std::shared_ptr<const UniverseObject> > const & _others
+                                    ) :
         pf(_pf), jumps(_jumps), others(_others) {}
 
     bool operator()(NowhereType) const { return false; }
@@ -1039,9 +1042,9 @@ struct WithinJumpsOfOthersObjectVisitor : public boost::static_visitor<bool> {
     are within jumps*/
 struct WithinJumpsOfOthersOtherVisitor : public boost::static_visitor<bool> {
     WithinJumpsOfOthersOtherVisitor(Pathfinder::PathfinderImpl const & _pf,
-                            int _jumps,
-                            const distance_matrix_storage<short>::row_ref _row
-                            ) :
+                                    int _jumps,
+                                    const distance_matrix_storage<short>::row_ref _row
+                                   ) :
         pf(_pf), jumps(_jumps), row(_row) {}
 
     bool single_result(int other_id) const {
@@ -1071,11 +1074,11 @@ struct WithinJumpsOfOthersOtherVisitor : public boost::static_visitor<bool> {
 
 
 void Pathfinder::PathfinderImpl::WithinJumpsOfOthersCacheHit(
-    bool * const answer,
+    bool* const answer, // answer constant pointer to a non-constant bool
     int jumps,
-    std::vector<std::shared_ptr<const UniverseObject> > const & others,
-    size_t ii, const distance_matrix_storage<short>::row_ref row) const {
-
+    const std::vector<std::shared_ptr<const UniverseObject> >& others,
+    size_t ii, const distance_matrix_storage<short>::row_ref row) const
+{
     // Check if any of the others are within jumps of candidate, by looping
     // through all of the others and applying the WithinJumpsOfOthersOtherVisitor.
     *answer = false;
@@ -1092,20 +1095,21 @@ void Pathfinder::PathfinderImpl::WithinJumpsOfOthersCacheHit(
 
 void Pathfinder::WithinJumpsOfOthers(
     int jumps,
-    std::vector<std::shared_ptr<const UniverseObject> > & near,
-    std::vector<std::shared_ptr<const UniverseObject> > & far,
-    std::vector<std::shared_ptr<const UniverseObject> > & candidates,
-    std::vector<std::shared_ptr<const UniverseObject> > const & others) const {
+    std::vector<std::shared_ptr<const UniverseObject> >& near,
+    std::vector<std::shared_ptr<const UniverseObject> >& far,
+    std::vector<std::shared_ptr<const UniverseObject> >& candidates,
+    const std::vector<std::shared_ptr<const UniverseObject> >& others) const
+{
     pimpl->WithinJumpsOfOthers(jumps, near, far, candidates, others);
 }
 
 void Pathfinder::PathfinderImpl::WithinJumpsOfOthers(
     int jumps,
-    std::vector<std::shared_ptr<const UniverseObject> > & near,
-    std::vector<std::shared_ptr<const UniverseObject> > & far,
-    std::vector<std::shared_ptr<const UniverseObject> > & candidates_,
-    std::vector<std::shared_ptr<const UniverseObject> > const & others) const {
-
+    std::vector<std::shared_ptr<const UniverseObject> >& near,
+    std::vector<std::shared_ptr<const UniverseObject> >& far,
+    std::vector<std::shared_ptr<const UniverseObject> >& candidates_,
+    const std::vector<std::shared_ptr<const UniverseObject> >& others) const
+{
     // Examine each candidate and transfer those within jumps of the
     // others into near.
     // near or far may be the same as candidates.
@@ -1129,8 +1133,8 @@ void Pathfinder::PathfinderImpl::WithinJumpsOfOthers(
 
 bool Pathfinder::PathfinderImpl::WithinJumpsOfOthers(
     int jumps, int system_id,
-    std::vector<std::shared_ptr<const UniverseObject> > const & others) const {
-
+    const std::vector<std::shared_ptr<const UniverseObject> >& others) const
+{
     if (others.empty())
         return false;
 

--- a/universe/Pathfinder.cpp
+++ b/universe/Pathfinder.cpp
@@ -1081,10 +1081,9 @@ void Pathfinder::PathfinderImpl::WithinJumpsOfOthersCacheHit(
     // through all of the others and applying the WithinJumpsOfOthersOtherVisitor.
     answer = false;
     for (const auto& other : others) {
-        WithinJumpsOfOthersOtherVisitor visitor(*this, jumps, row);
-        GeneralizedLocationType other_systems = GeneralizedLocation(other);
-        bool other_within_jumps = boost::apply_visitor(visitor, other_systems);
-        if (other_within_jumps) {
+        WithinJumpsOfOthersOtherVisitor check_if_location_is_within_jumps(*this, jumps, row);
+        GeneralizedLocationType location = GeneralizedLocation(other);
+        if (boost::apply_visitor(check_if_location_is_within_jumps, location)) {
             answer = true;
             return;
         }

--- a/universe/Pathfinder.cpp
+++ b/universe/Pathfinder.cpp
@@ -576,21 +576,21 @@ class Pathfinder::PathfinderImpl {
 
     void WithinJumpsOfOthers(
         int jumps,
-        std::vector<std::shared_ptr<const UniverseObject>> & near,
-        std::vector<std::shared_ptr<const UniverseObject>> & far,
-        std::vector<std::shared_ptr<const UniverseObject>> & candidates,
-        std::vector<std::shared_ptr<const UniverseObject>> const & others) const;
+        std::vector<std::shared_ptr<const UniverseObject>>& near,
+        std::vector<std::shared_ptr<const UniverseObject>>& far,
+        std::vector<std::shared_ptr<const UniverseObject>>& candidates,
+        const std::vector<std::shared_ptr<const UniverseObject>>& others) const;
 
     /**Return true if \p system_id is within \p jumps of any of \p others*/
     bool WithinJumpsOfOthers(
         int jumps, int system_id,
-        std::vector<std::shared_ptr<const UniverseObject>> const & others) const;
+        const std::vector<std::shared_ptr<const UniverseObject>>& others) const;
 
     /** If any of \p others are within \p jumps of \p ii return true in \p answer.
      */
     void WithinJumpsOfOthersCacheHit(
         bool& answer, int jumps,
-        std::vector<std::shared_ptr<const UniverseObject>> const & others,
+        const std::vector<std::shared_ptr<const UniverseObject>>& others,
         size_t ii, const distance_matrix_storage<short>::row_ref row) const;
 
     int NearestSystemTo(double x, double y) const;
@@ -834,8 +834,8 @@ struct JumpDistanceSys1Visitor : public boost::static_visitor<int> {
         int jumps = std::min(jumps1, jumps2);
         return jumps;
     }
-    Pathfinder::PathfinderImpl const & pf;
-    GeneralizedLocationType const & sys2_ids;
+    const Pathfinder::PathfinderImpl& pf;
+    const GeneralizedLocationType& sys2_ids;
 };
 
 int Pathfinder::JumpDistanceBetweenObjects(int object1_id, int object2_id) const {
@@ -1039,11 +1039,12 @@ struct WithinJumpsOfOthersObjectVisitor : public boost::static_visitor<bool> {
 /** Examine a single other in the cache to see if any of its locations
     are within jumps*/
 struct WithinJumpsOfOthersOtherVisitor : public boost::static_visitor<bool> {
-    WithinJumpsOfOthersOtherVisitor(Pathfinder::PathfinderImpl const & _pf,
+    WithinJumpsOfOthersOtherVisitor(const Pathfinder::PathfinderImpl& _pf,
                                     int _jumps,
                                     const distance_matrix_storage<short>::row_ref _row
                                    ) :
-        pf(_pf), jumps(_jumps), row(_row) {}
+        pf(_pf), jumps(_jumps), row(_row)
+    {}
 
     bool single_result(int other_id) const {
         int index;
@@ -1065,7 +1066,7 @@ struct WithinJumpsOfOthersOtherVisitor : public boost::static_visitor<bool> {
         return single_result(prev_next.first)
             || single_result(prev_next.second);
     }
-    Pathfinder::PathfinderImpl const & pf;
+    const Pathfinder::PathfinderImpl& pf;
     int jumps;
     const distance_matrix_storage<short>::row_ref row;
 };
@@ -1145,7 +1146,7 @@ bool Pathfinder::PathfinderImpl::WithinJumpsOfOthers(
 
     // Examine the cache to see if \p system_id is within \p jumps of \p others
     bool within_jumps(false);
-    distance_matrix_cache< distance_matrix_storage<short>> cache(m_system_jumps);
+    distance_matrix_cache<distance_matrix_storage<short>> cache(m_system_jumps);
     cache.examine_row(system_index,
                       boost::bind(&Pathfinder::PathfinderImpl::HandleCacheMiss, this, _1, _2),
                       boost::bind(&Pathfinder::PathfinderImpl::WithinJumpsOfOthersCacheHit, this,

--- a/universe/Pathfinder.cpp
+++ b/universe/Pathfinder.cpp
@@ -1051,15 +1051,14 @@ void Pathfinder::PathfinderImpl::WithinJumpsOfOthersCacheHit(
     std::vector<std::shared_ptr<const UniverseObject> > const & others,
     size_t ii, const distance_matrix_storage<short>::row_ref row) const {
 
-    // Check if any of the others are within jumps of candidate
+    // Check if any of the others are within jumps of candidate, by looping
+    // through all of the others and applying the WithinJumpsOfOthersOtherVisitor.
     *answer = false;
-    for (std::vector<std::shared_ptr<const UniverseObject> >::const_iterator other = others.begin();
-         other != others.end(); ++other) {
-
+    for (const auto& other : others) {
         WithinJumpsOfOthersOtherVisitor visitor(*this, jumps, row);
-        ObjectSystemIDType other_systems = ObjectSystemID(*other);
+        ObjectSystemIDType other_systems = ObjectSystemID(other);
         bool other_within_jumps = boost::apply_visitor(visitor, other_systems);
-        if (other_within_jumps){
+        if (other_within_jumps) {
             *answer = true;
             return;
         }
@@ -1092,15 +1091,14 @@ void Pathfinder::PathfinderImpl::WithinJumpsOfOthers(
     near.reserve(near.size() + size);
     far.reserve(near.size() + size);
 
-    for (std::vector<std::shared_ptr<const UniverseObject> >::iterator candidate = candidates.begin();
-         candidate != candidates.end(); ++candidate) {
-        ObjectSystemIDType candidate_systems = ObjectSystemID(*candidate);
+    for (const auto& candidate : candidates) {
+        ObjectSystemIDType candidate_systems = ObjectSystemID(candidate);
         bool is_near = boost::apply_visitor(visitor, candidate_systems);
 
         if (is_near)
-            near.push_back(*candidate);
+            near.push_back(candidate);
         else
-            far.push_back(*candidate);
+            far.push_back(candidate);
     }
 }
 

--- a/universe/Pathfinder.cpp
+++ b/universe/Pathfinder.cpp
@@ -780,7 +780,7 @@ struct JumpDistanceSys2Visitor : public boost::static_visitor<int> {
         try {
             if (prev_sys_id != INVALID_OBJECT_ID)
                 sjumps1 = pf.JumpDistanceBetweenSystems(sys_id1, prev_sys_id);
-            if (next_sys_id!= INVALID_OBJECT_ID)
+            if (next_sys_id != INVALID_OBJECT_ID)
                 sjumps2 = pf.JumpDistanceBetweenSystems(sys_id1, next_sys_id);
         } catch (...) {
             ErrorLogger() << "JumpsBetweenObjects caught exception when calling JumpDistanceBetweenSystems";
@@ -838,9 +838,8 @@ struct JumpDistanceSys1Visitor : public boost::static_visitor<int> {
     const GeneralizedLocationType& sys2_ids;
 };
 
-int Pathfinder::JumpDistanceBetweenObjects(int object1_id, int object2_id) const {
-    return pimpl->JumpDistanceBetweenObjects(object1_id, object2_id);
-}
+int Pathfinder::JumpDistanceBetweenObjects(int object1_id, int object2_id) const
+{ return pimpl->JumpDistanceBetweenObjects(object1_id, object2_id); }
 
 int Pathfinder::PathfinderImpl::JumpDistanceBetweenObjects(int object1_id, int object2_id) const {
     GeneralizedLocationType obj1 = GeneralizedLocation(object1_id);
@@ -1072,8 +1071,7 @@ struct WithinJumpsOfOthersOtherVisitor : public boost::static_visitor<bool> {
 
 
 void Pathfinder::PathfinderImpl::WithinJumpsOfOthersCacheHit(
-    bool& answer,
-    int jumps,
+    bool& answer, int jumps,
     const std::vector<std::shared_ptr<const UniverseObject>>& others,
     size_t ii, const distance_matrix_storage<short>::row_ref row) const
 {
@@ -1105,9 +1103,8 @@ Pathfinder::PathfinderImpl::WithinJumpsOfOthers(
     const std::vector<std::shared_ptr<const UniverseObject>>& candidates,
     const std::vector<std::shared_ptr<const UniverseObject>>& stationary) const
 {
-    // Examine each candidate and transfer those within jumps of the
-    // others into near.
-    // near or far may be the same as candidates.
+    // Examine each candidate and copy those within jumps of the
+    // others into near and the rest into far.
     WithinJumpsOfOthersObjectVisitor visitor(*this, jumps, stationary);
     std::vector<std::shared_ptr<const UniverseObject>> near, far;
     size_t size = candidates.size();

--- a/universe/Pathfinder.cpp
+++ b/universe/Pathfinder.cpp
@@ -102,6 +102,11 @@ namespace {
 
         public:
 
+        // Note: The signatures for the cache miss handler and the cache hit handler have a void
+        // return type, because this code can not anticipate all expected return types.  In order
+        // to return a result function the calling code will need to bind the return parameter to
+        // the function so that the function still has the required signature.
+
         /// Cache miss handler
         typedef boost::function<void (size_t &/*ii*/, Row /*row*/)> cache_miss_handler;
 
@@ -586,6 +591,9 @@ class Pathfinder::PathfinderImpl {
         const std::vector<std::shared_ptr<const UniverseObject>>& others) const;
 
     /** If any of \p others are within \p jumps of \p ii return true in \p answer.
+
+        The return value must be in a parameter so that after being bound to \p answer and \p jumps
+        the function signature is that required by the cache_hit_handler type.
      */
     void WithinJumpsOfOthersCacheHit(
         bool& answer, int jumps,

--- a/universe/Pathfinder.cpp
+++ b/universe/Pathfinder.cpp
@@ -1124,7 +1124,7 @@ Pathfinder::PathfinderImpl::WithinJumpsOfOthers(
             far.push_back(candidate);
     }
 
-    return std::make_pair(near, far);
+    return {near, far};
 }
 
 bool Pathfinder::PathfinderImpl::WithinJumpsOfOthers(

--- a/universe/Pathfinder.h
+++ b/universe/Pathfinder.h
@@ -108,7 +108,7 @@ public:
     /** Returns the \p near and \p far objects from the \p candidates that are
         within \p jumps of the \p others.
         The \p candidates are modified and transfered to the \near vector.*/
-    void WithinJumps(
+    void WithinJumpsOfOthers(
         int jumps,
         std::vector<std::shared_ptr<const UniverseObject> > & near,
         std::vector<std::shared_ptr<const UniverseObject> > & far,

--- a/universe/Pathfinder.h
+++ b/universe/Pathfinder.h
@@ -101,6 +101,8 @@ public:
       * \a empire_id == ALL_EMPIRES.
       * \throw std::out_of_range This function will throw if the  system
       * ID is out of range. */
+    //TODO empire_id is never set to anything other than self, which in
+    //the AI's is the same as ALL_EMPIRES
     std::multimap<double, int>              ImmediateNeighbors(int system_id, int empire_id = ALL_EMPIRES) const;
 
     /** Returns the id of the System object that is closest to the specified

--- a/universe/Pathfinder.h
+++ b/universe/Pathfinder.h
@@ -110,10 +110,10 @@ public:
         The \p candidates are modified and transfered to the \near vector.*/
     void WithinJumpsOfOthers(
         int jumps,
-        std::vector<std::shared_ptr<const UniverseObject> > & near,
-        std::vector<std::shared_ptr<const UniverseObject> > & far,
-        std::vector<std::shared_ptr<const UniverseObject> > & candidates,
-        std::vector<std::shared_ptr<const UniverseObject> > const & others) const;
+        std::vector<std::shared_ptr<const UniverseObject>>& near,
+        std::vector<std::shared_ptr<const UniverseObject>>& far,
+        std::vector<std::shared_ptr<const UniverseObject>>& candidates,
+        const std::vector<std::shared_ptr<const UniverseObject>>& others) const;
 
     /** Returns the id of the System object that is closest to the specified
       * (\a x, \a y) location on the map, by direct-line distance. */

--- a/universe/Pathfinder.h
+++ b/universe/Pathfinder.h
@@ -135,7 +135,7 @@ public:
     //@}
 
     class PathfinderImpl;
-    std::unique_ptr<PathfinderImpl> const pimpl;
+    const std::unique_ptr<PathfinderImpl> pimpl;
 
     /* friend class boost::serialization::access; */
     /* template <class Archive> */

--- a/universe/Pathfinder.h
+++ b/universe/Pathfinder.h
@@ -105,15 +105,13 @@ public:
     //the AI's is the same as ALL_EMPIRES
     std::multimap<double, int>              ImmediateNeighbors(int system_id, int empire_id = ALL_EMPIRES) const;
 
-    /** Returns the \p near and \p far objects from the \p candidates that are
-        within \p jumps of the \p others.
-        The \p candidates are modified and transfered to the \near vector.*/
-    void WithinJumpsOfOthers(
-        int jumps,
-        std::vector<std::shared_ptr<const UniverseObject>>& near,
-        std::vector<std::shared_ptr<const UniverseObject>>& far,
-        std::vector<std::shared_ptr<const UniverseObject>>& candidates,
-        const std::vector<std::shared_ptr<const UniverseObject>>& others) const;
+    /** Returns the partition (near, far) of the \p candidate objects into two sets, those that are within \p
+        jumps of the \p stationary objects and that are not.*/
+    std::pair<std::vector<std::shared_ptr<const UniverseObject>>, std::vector<std::shared_ptr<const UniverseObject>>>
+        WithinJumpsOfOthers(
+            int jumps,
+            const std::vector<std::shared_ptr<const UniverseObject>>& candidates,
+            const std::vector<std::shared_ptr<const UniverseObject>>& stationary) const;
 
     /** Returns the id of the System object that is closest to the specified
       * (\a x, \a y) location on the map, by direct-line distance. */

--- a/universe/Pathfinder.h
+++ b/universe/Pathfinder.h
@@ -126,7 +126,6 @@ public:
 
     //@}
 
-private:
     class PathfinderImpl;
     std::unique_ptr<PathfinderImpl> const pimpl;
 

--- a/universe/Pathfinder.h
+++ b/universe/Pathfinder.h
@@ -135,11 +135,8 @@ public:
     //@}
 
     class PathfinderImpl;
+private:
     const std::unique_ptr<PathfinderImpl> pimpl;
-
-    /* friend class boost::serialization::access; */
-    /* template <class Archive> */
-    /* void serialize(Archive& ar, const unsigned int version); */
 };
 
 #endif // _Pathfinder_h_

--- a/universe/Pathfinder.h
+++ b/universe/Pathfinder.h
@@ -105,6 +105,16 @@ public:
     //the AI's is the same as ALL_EMPIRES
     std::multimap<double, int>              ImmediateNeighbors(int system_id, int empire_id = ALL_EMPIRES) const;
 
+    /** Returns the \p near and \p far objects from the \p candidates that are
+        within \p jumps of the \p others.
+        The \p candidates are modified and transfered to the \near vector.*/
+    void WithinJumps(
+        int jumps,
+        std::vector<std::shared_ptr<const UniverseObject> > & near,
+        std::vector<std::shared_ptr<const UniverseObject> > & far,
+        std::vector<std::shared_ptr<const UniverseObject> > & candidates,
+        std::vector<std::shared_ptr<const UniverseObject> > const & others) const;
+
     /** Returns the id of the System object that is closest to the specified
       * (\a x, \a y) location on the map, by direct-line distance. */
     int                                     NearestSystemTo(double x, double y) const;


### PR DESCRIPTION
The WithinStarlaneJumps condition determines if objects are within j jumps of a candidate object.  It currently does that by determining the jump distance between the candidate and each object in the set.  This potentially involves a cache miss for every system associated with an object in the set.

This PR modifies the Pathfinder to allow a single cache hit to return the distances from one system to all others in a single cache hit and a single pathfind.

There are two significant changes.
- It creates `examine_row()` which allows a single `distance_cache_matrix` hit to return the entire row.  A single cache hit will determine the distance from any one system to every other system.
- It abstracts object location into `ObjectSystemIDType` which is a boost::variant encompassing 3 concepts of location: nowhere, one system and in transit.  It then uses variant visitors to determine the distances between these abstracted locations.

The `WithinJumpsOfOthers()` uses the abstracted location, the visitors and the ability to examine an entire row to compute its result quickly.

