### PR TITLE
Refactor: Replace GetUniverseObject with specific Get*

### DIFF
--- a/UI/MultiIconValueIndicator.cpp
+++ b/UI/MultiIconValueIndicator.cpp
@@ -49,9 +49,8 @@ MultiIconValueIndicator::MultiIconValueIndicator(GG::X w, const std::vector<int>
         // special case for population meter for an indicator showing only a
         // single popcenter: icon is species icon, rather than generic pop icon
         if (PRIMARY_METER_TYPE == METER_POPULATION && m_object_ids.size() == 1) {
-            if (std::shared_ptr<const UniverseObject> obj = GetUniverseObject(*m_object_ids.begin()))
-                if (std::shared_ptr<const PopCenter> pc = std::dynamic_pointer_cast<const PopCenter>(obj))
-                    texture = ClientUI::SpeciesIcon(pc->SpeciesName());
+	    if (std::shared_ptr<const PopCenter> pc = GetPopCenter(*m_object_ids.begin()))
+		texture = ClientUI::SpeciesIcon(pc->SpeciesName());
         }
 
         m_icons.push_back(new StatisticIcon(texture, 0.0, 3, false,
@@ -145,16 +144,13 @@ bool MultiIconValueIndicator::EventFilter(GG::Wnd* w, const GG::WndEvent& event)
     GG::MenuItem menu_contents;
     std::string species_name;
 
-    std::shared_ptr<const UniverseObject> obj = GetUniverseObject(*m_object_ids.begin());
-    if (meter_type == METER_POPULATION && obj && m_object_ids.size() == 1) {
-        std::shared_ptr<const PopCenter> pc = std::dynamic_pointer_cast<const PopCenter>(obj);
-        if (pc) {
-            species_name = pc->SpeciesName();
-            if (!species_name.empty()) {
-                std::string species_label = boost::io::str(FlexibleFormat(UserString("ENC_LOOKUP")) % UserString(species_name));
-                menu_contents.next_level.push_back(GG::MenuItem(species_label, 1, false, false));
-            }
-        }
+    std::shared_ptr<const PopCenter> pc = GetPopCenter(*m_object_ids.begin());
+    if (meter_type == METER_POPULATION && pc && m_object_ids.size() == 1) {
+	species_name = pc->SpeciesName();
+	if (!species_name.empty()) {
+	    std::string species_label = boost::io::str(FlexibleFormat(UserString("ENC_LOOKUP")) % UserString(species_name));
+	    menu_contents.next_level.push_back(GG::MenuItem(species_label, 1, false, false));
+	}
     }
 
     if (!meter_title.empty()) {

--- a/UI/PopulationPanel.cpp
+++ b/UI/PopulationPanel.cpp
@@ -240,14 +240,9 @@ void PopulationPanel::DoLayout() {
 }
 
 std::shared_ptr<const PopCenter> PopulationPanel::GetPopCenter() const {
-    std::shared_ptr<const UniverseObject> obj = GetUniverseObject(m_popcenter_id);
-    if (!obj) {
-        ErrorLogger() << "PopulationPanel tried to get an object with an invalid m_popcenter_id";
-        return nullptr;
-    }
-    std::shared_ptr<const PopCenter> pop = std::dynamic_pointer_cast<const PopCenter>(obj);
+    std::shared_ptr<const PopCenter> pop = ::GetPopCenter(m_popcenter_id);
     if (!pop) {
-        ErrorLogger() << "PopulationPanel failed casting an object pointer to a PopCenter pointer";
+        ErrorLogger() << "PopulationPanel tried to get an object with an invalid m_popcenter_id";
         return nullptr;
     }
     return pop;

--- a/UI/ResourcePanel.cpp
+++ b/UI/ResourcePanel.cpp
@@ -255,14 +255,9 @@ void ResourcePanel::DoLayout() {
 }
 
 std::shared_ptr<const ResourceCenter> ResourcePanel::GetResCenter() const {
-    std::shared_ptr<const UniverseObject> obj = GetUniverseObject(m_rescenter_id);
-    if (!obj) {
-        ErrorLogger() << "ResourcePanel tried to get an object with an invalid m_rescenter_id";
-        return nullptr;
-    }
-    std::shared_ptr<const ResourceCenter> res = std::dynamic_pointer_cast<const ResourceCenter>(obj);
+    std::shared_ptr<const ResourceCenter> res = GetResourceCenter(m_rescenter_id);
     if (!res) {
-        ErrorLogger() << "ResourcePanel failed casting an object pointer to a ResourceCenter pointer";
+        ErrorLogger() << "ResourcePanel tried to get an object with an invalid m_rescenter_id";
         return nullptr;
     }
     return res;

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -2387,12 +2387,7 @@ void SidePanel::PlanetPanel::FocusDropListSelectionChangedSlot(GG::DropDownList:
         return;
     }
 
-    std::shared_ptr<const UniverseObject> obj = GetUniverseObject(m_planet_id);
-    if (!obj) {
-        ErrorLogger() << "PlanetPanel::FocusDropListSelectionChanged couldn't get object with id " << m_planet_id;
-        return;
-    }
-    std::shared_ptr<const ResourceCenter> res = std::dynamic_pointer_cast<const ResourceCenter>(obj);
+    std::shared_ptr<const ResourceCenter> res = GetResourceCenter(m_planet_id);
     if (!res) {
         ErrorLogger() << "PlanetPanel::FocusDropListSelectionChanged couldn't convert object with id " << m_planet_id << " to a ResourceCenter";
         return;

--- a/python/EmpireWrapper.cpp
+++ b/python/EmpireWrapper.cpp
@@ -168,8 +168,7 @@ namespace {
         for (const std::map<std::set<int>, float>::value_type& objects_pp : prodQueue.AvailablePP(industry_pool)) {
             std::set<int> planetSet;
             for (int object_id : objects_pp.first) {
-                std::shared_ptr<UniverseObject> location = GetUniverseObject(object_id);
-                if (/* std::shared_ptr<const Planet> planet = */ std::dynamic_pointer_cast<const Planet>(location))
+                if (/* std::shared_ptr<const Planet> planet = */ GetPlanet(object_id))
                     planetSet.insert(object_id);
             }
             if (!planetSet.empty())
@@ -186,8 +185,7 @@ namespace {
         for (const std::map<std::set<int>, float>::value_type& objects_pp : objectsWithAllocatedPP) {
             std::set<int> planetSet;
             for (int object_id : objects_pp.first) {
-                std::shared_ptr<UniverseObject> location = GetUniverseObject(object_id);
-                if (/* std::shared_ptr<const Planet> planet = */ std::dynamic_pointer_cast<const Planet>(location))
+                if (/* std::shared_ptr<const Planet> planet = */ GetPlanet(object_id))
                     planetSet.insert(object_id);
             }
             if (!planetSet.empty())
@@ -205,8 +203,7 @@ namespace {
         for (const std::set<int>&  objects : objectsWithWastedPP) {
                  std::set<int> planetSet;
                  for (int object_id : objects) {
-                     std::shared_ptr<UniverseObject> location = GetUniverseObject(object_id);
-                     if (/* std::shared_ptr<const Planet> planet = */ std::dynamic_pointer_cast<const Planet>(location))
+                     if (/* std::shared_ptr<const Planet> planet = */ GetPlanet(object_id))
                          planetSet.insert(object_id);
                  }
                  if (!planetSet.empty())


### PR DESCRIPTION
Issue: #1243

Refactored instances where an object gotten with GetUniverseObject
was immediately cast into a more specific type to directly fetch
the more specific type.