### PR TITLE
Fix NSIS installer continuing install before uninstall completes

### DIFF
--- a/Installer/FreeOrion_Install_Script.nsi.in
+++ b/Installer/FreeOrion_Install_Script.nsi.in
@@ -148,7 +148,9 @@ Function .onInit
 
   uninst_onInit:
   ClearErrors
-  Exec "$$R0"
+  InitPluginsDir
+  CopyFiles "$$R0" "$$pluginsdir"
+  ExecWait '$$pluginsdir\Uninstall.exe _?=$$INSTDIR'
 
   fin_onInit:
 


### PR DESCRIPTION
This is an attempt to fix an issue with the NSIS installer, brought up on the forum here:

http://freeorion.org/forum/viewtopic.php?f=28&t=10402

~~The problem is, the fix proposed in this PR doesn't work completely satisfactorily, as it causes the previous version of FO not being uninstalled completely, the `FreeOrion` folder in the Windows programs directory and the `uninstall.exe` within don't get deleted (all the other contents of `FreeOrion` do though).~~

~~That might not be a big issue with the "uninstall before install" feature this PR tries to fix, as FO gets installed again, most likely into the same location so the left over folder and the `uninstall.exe` will get overwritten anyway. But e.g. in case the user decides to install to a different location, these bits of the old installation would be left behind.~~

~~Which probably is still better than the issue described in the forum thread above, but I didn't want to make assumptions, so I'm putting this up here for review. And maybe someone has a better solution.~~

The approach implemented by this PR has been suggested by @dbenage-cx in the thread linked above, it has one small issue though mentioned by @dbenage-cx there (referring to the filename of the uninstall executable):

> The issue with this approach is separating the filename from the directory name, as the previous versions stored the one value.

Considering that the filename of the uninstall executable hasn't been changed ever, I consider this issue negligible.
