### PR TITLE
Split Log Files!

### DIFF
--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -78,12 +78,11 @@ AIClientApp::AIClientApp(const std::vector<std::string>& args) :
     // read command line args
 
     m_player_name = args.at(1);
-    const std::string AICLIENT_LOG_FILENAME((GetUserDataDir() / (m_player_name + ".log")).string());
     if (args.size() >=3) {
         m_max_aggression = boost::lexical_cast<int>(args.at(2));
     }
 
-    InitLogger(AICLIENT_LOG_FILENAME, "AI");
+    InitLogger(m_player_name);
     DebugLogger() << PlayerName() + " ai client initialized.";
 }
 

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -202,9 +202,8 @@ HumanClientApp::HumanClientApp(int width, int height, bool calculate_fps, const 
 #endif
     m_fsm.reset(new HumanClientFSM(*this));
 
-    const std::string HUMAN_CLIENT_LOG_FILENAME((GetUserDataDir() / "freeorion.log").string());
-
-    InitLogger(HUMAN_CLIENT_LOG_FILENAME, "Client");
+    // TODO Add an increment here to support multiple human clients (hotseat)
+    InitLogger("HumanClient");
 
     try {
         InfoLogger() << "GL Version String: " << GetGLVersionString();

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1432,6 +1432,12 @@ Sets the root directory for the game resource files (game content and data files
 OPTIONS_DB_LOG_LEVEL
 Sets the level at or above which log messages will be output (levels in order of increasing verbosity: FATAL, ERROR, WARN, INFO, DEBUG, TRACE)
 
+OPTIONS_DB_LOG_DIR
+Directory to store log files.
+
+OPTIONS_DB_LOG_ROTATE_SIZE
+Approximate maximum size (in MegaBytes) for log files.
+
 OPTIONS_DB_STRINGTABLE_FILENAME
 Sets the language-specific string table filename.
 

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -138,9 +138,7 @@ ServerApp::ServerApp() :
     m_current_turn(INVALID_GAME_TURN),
     m_single_player_game(false)
 {
-    const std::string SERVER_LOG_FILENAME((GetUserDataDir() / "freeoriond.log").string());
-
-    InitLogger(SERVER_LOG_FILENAME, "Server");
+    InitLogger("Server");
 
     LogDependencyVersions();
 

--- a/util/Logger.h
+++ b/util/Logger.h
@@ -8,9 +8,11 @@
 #include "Export.h"
 
 
-/** Initializes the logging system. Log to the given file.
- * If the file already exists it will be deleted. */
-FO_COMMON_API void InitLogger(const std::string& logFile, const std::string& pattern);
+/** Initializes the logging system.
+ * 
+ * @param[in] process_name name for this log, used in file and directory naming
+ */
+FO_COMMON_API void InitLogger(const std::string& process_name);
 
 /** Accessors for the App's logger */
 FO_COMMON_API void SetLoggerPriority(int priority);

--- a/util/Logger.h
+++ b/util/Logger.h
@@ -38,7 +38,7 @@ BOOST_LOG_ATTRIBUTE_KEYWORD(log_src_linenum, "SrcLinenum", int);
     FO_LOGGER(info)
 
 #define WarnLogger()\
-    FO_LOGGER(warn)
+    FO_LOGGER(warning)
 
 #define ErrorLogger()\
     FO_LOGGER(error)

--- a/util/MultiplayerCommon.cpp
+++ b/util/MultiplayerCommon.cpp
@@ -33,6 +33,12 @@ namespace {
         db.Add<std::string>("resource-dir",         UserStringNop("OPTIONS_DB_RESOURCE_DIR"),          PathString(GetRootDataDir() / "default"));
         db.Add<std::string>('S', "save-dir",        UserStringNop("OPTIONS_DB_SAVE_DIR"),              PathString(GetUserDataDir() / "save"));
         db.Add<std::string>("log-level",            UserStringNop("OPTIONS_DB_LOG_LEVEL"),             "DEBUG");
+        db.Add<std::string>( "logging.directory",
+                             UserStringNop("OPTIONS_DB_LOG_DIR"),
+                             PathString(GetUserDataDir() / "logs"));
+        db.Add<unsigned int>("logging.rotate-mb",
+                             UserStringNop("OPTIONS_DB_LOG_ROTATE_SIZE"),
+                             25, RangedValidator<unsigned int>(1, 1000));
         db.Add<std::string>("stringtable-filename", UserStringNop("OPTIONS_DB_STRINGTABLE_FILENAME"),  PathString(GetRootDataDir() / "default" / "stringtables" / "en.txt"));
         db.Add("binary-serialization",              UserStringNop("OPTIONS_DB_BINARY_SERIALIZATION"),  false);
 


### PR DESCRIPTION
PR provides configurable rotation and archiving of log files.

When logs are initialized, any existing logs are move to the archive directory.
These archived files are appended with a timestamp to retain a unique name.
Timestamp matches the last write time (e.g. `AI_1-1486641524.log`)
If there are more files for a process than the config setting allows, old files are removed.

During a game, log files are written to a process specific file with a `.tmp` extension.
Once the rotation limit is reached it is appended to a process specific `.log` file.
(e.g. `logs\AI_1.tmp` and `logs\AI_1.log`)

Current logs and archived logs are in separate directories to ease the burden of sending logs.
With this layout a user could compress the `log` folder for upload elsewhere.

One removal was of the process name from each log line.  This is simple to add back if needed.
freeorion and freeoriond were given more user friendly names of Client and Server.

In a worse case, if the temporary files are not cleaned up by the collector (e.g. terminated client), the archived files may have duplicate info appended to the end.

Resolves #1276

For testing recommend: `--log-level TRACE --logging.rotate-mb 1 --logging.archive-max-files 2`