### PR TITLE
Adjust invasion and colonization priority for non-standard species

### DIFF
--- a/default/python/AI/AIDependencies.py
+++ b/default/python/AI/AIDependencies.py
@@ -586,6 +586,9 @@ PILOT_FIGHTER_CAPACITY_MODIFIER_DICT = {
 # </editor-fold>
 
 # <editor-fold desc="Extraordinary Species Rules">
+# tag used if species self-destructs on conquest
+TAG_DESTROYED_ON_CONQUEST = "DESTROYED_ON_CONQUEST"
+
 # some species have a fixed population
 SPECIES_FIXED_POPULATION = {
     # species_name: fixed_population_size

--- a/default/python/AI/AIDependencies.py
+++ b/default/python/AI/AIDependencies.py
@@ -96,62 +96,6 @@ POP_CONST_MOD_MAP = {
 # </editor-fold>
 
 
-# <editor-fold desc="Species">
-# Species modifiers
-SPECIES_RESEARCH_MODIFIER = {'NO': 0.0, 'BAD': 0.75, 'GOOD': 1.5, 'GREAT': 2.0, 'ULTIMATE': 3.0}
-SPECIES_INDUSTRY_MODIFIER = {'NO': 0.0, 'BAD': 0.75, 'GOOD': 1.5, 'GREAT': 2.0, 'ULTIMATE': 3.0}
-SPECIES_POPULATION_MODIFIER = {'BAD': 0.75, 'GOOD': 1.25}
-SPECIES_SUPPLY_MODIFIER = {'BAD': 0, 'AVERAGE': 1, 'GREAT': 2, 'ULTIMATE': 3}
-
-# <editor-fold desc="XenoResurrectionSpecies">
-EXTINCT_SPECIES = [
-    "BANFORO",
-    "KILANDOW",
-    "MISIORLA"
-]
-# </editor-fold>
-
-# <editor-fold desc="Piloting traits">
-# TODO (Morlic): Consider using only 1 dict with tuple for (Capacity, SecondaryStat) effects
-PILOT_DAMAGE_MODIFIER_DICT = {
-    # TRAIT:    {weapon_name: effect, weapon_name2: effect2,...}
-    "NO":       {},
-    "BAD":      {"SR_WEAPON_1_1": -1, "SR_WEAPON_2_1": -2, "SR_WEAPON_3_1": -3, "SR_WEAPON_4_1": -5},
-    "GOOD":     {"SR_WEAPON_1_1":  1, "SR_WEAPON_2_1":  2, "SR_WEAPON_3_1":  3, "SR_WEAPON_4_1": 5},
-    "GREAT":    {"SR_WEAPON_1_1":  2, "SR_WEAPON_2_1":  4, "SR_WEAPON_3_1":  6, "SR_WEAPON_4_1": 10},
-    "ULTIMATE": {"SR_WEAPON_1_1":  3, "SR_WEAPON_2_1":  6, "SR_WEAPON_3_1":  9, "SR_WEAPON_4_1": 15, "SR_WEAPON_0_1": 1},
-}
-
-PILOT_ROF_MODIFIER_DICT = {
-    # TRAIT:    {weapon_name: effect, weapon_name2: effect2,...}
-    "NO":       {},
-    "BAD":      {"SR_WEAPON_0_1": -1},
-    "GOOD":     {"SR_WEAPON_0_1": 1},
-    "GREAT":    {"SR_WEAPON_0_1": 2},
-    "ULTIMATE": {"SR_WEAPON_0_1": 3},
-}
-
-PILOT_FIGHTERDAMAGE_MODIFIER_DICT = {
-    # TRAIT:    {hangar_name: effect, hangar_name2: effect2,...}
-    "NO":       {},
-    "BAD":      {"FT_HANGAR_1": -1, "FT_HANGAR_2": -2, "FT_HANGAR_3": -3, "FT_HANGAR_4": -4},
-    "GOOD":     {"FT_HANGAR_1":  1, "FT_HANGAR_2":  2, "FT_HANGAR_3":  3, "FT_HANGAR_4": 4},
-    "GREAT":    {"FT_HANGAR_1":  2, "FT_HANGAR_2":  4, "FT_HANGAR_3":  6, "FT_HANGAR_4": 8},
-    "ULTIMATE": {"FT_HANGAR_1":  3, "FT_HANGAR_2":  6, "FT_HANGAR_3":  9, "FT_HANGAR_4": 12},
-}
-
-PILOT_FIGHTER_CAPACITY_MODIFIER_DICT = {
-    # TRAIT:    {hangar_name: effect, hangar_name2: effect2,...}
-    "NO":       {},
-    "BAD":      {},
-    "GOOD":     {},
-    "GREAT":    {},
-    "ULTIMATE": {},
-}
-# </editor-fold>
-# </editor-fold>
-
-
 # <editor-fold desc="Specials">
 # <editor-fold desc="Growth Focus specials">
 # stores growth special per metabolism
@@ -260,6 +204,9 @@ GRO_XENO_GENETICS = "GRO_XENO_GENETICS"
 GRO_GENOME_BANK = "GRO_GENETIC_MED"
 
 CON_CONC_CAMP = "CON_CONC_CAMP"
+
+SPY_STEALTH_1 = "SPY_STEALTH_1"
+SPY_STEALTH_2 = "SPY_STEALTH_2"
 # </editor-fold>
 
 
@@ -576,6 +523,80 @@ SHIP_TECHS_REQUIRING_BLACK_HOLE = (
     "SHP_SOLAR_CONT",
 )
 
+# </editor-fold>
+
+# </editor-fold>
+
+
+# <editor-fold desc="Species">
+# species names
+SP_LAMBALALAM = "SP_LEMBALALAM"
+
+# Species modifiers
+SPECIES_RESEARCH_MODIFIER = {'NO': 0.0, 'BAD': 0.75, 'GOOD': 1.5, 'GREAT': 2.0, 'ULTIMATE': 3.0}
+SPECIES_INDUSTRY_MODIFIER = {'NO': 0.0, 'BAD': 0.75, 'GOOD': 1.5, 'GREAT': 2.0, 'ULTIMATE': 3.0}
+SPECIES_POPULATION_MODIFIER = {'BAD': 0.75, 'GOOD': 1.25}
+SPECIES_SUPPLY_MODIFIER = {'BAD': 0, 'AVERAGE': 1, 'GREAT': 2, 'ULTIMATE': 3}
+
+# <editor-fold desc="XenoResurrectionSpecies">
+EXTINCT_SPECIES = [
+    "BANFORO",
+    "KILANDOW",
+    "MISIORLA"
+]
+# </editor-fold>
+
+# <editor-fold desc="Piloting traits">
+# TODO (Morlic): Consider using only 1 dict with tuple for (Capacity, SecondaryStat) effects
+PILOT_DAMAGE_MODIFIER_DICT = {
+    # TRAIT:    {weapon_name: effect, weapon_name2: effect2,...}
+    "NO":       {},
+    "BAD":      {"SR_WEAPON_1_1": -1, "SR_WEAPON_2_1": -2, "SR_WEAPON_3_1": -3, "SR_WEAPON_4_1": -5},
+    "GOOD":     {"SR_WEAPON_1_1":  1, "SR_WEAPON_2_1":  2, "SR_WEAPON_3_1":  3, "SR_WEAPON_4_1": 5},
+    "GREAT":    {"SR_WEAPON_1_1":  2, "SR_WEAPON_2_1":  4, "SR_WEAPON_3_1":  6, "SR_WEAPON_4_1": 10},
+    "ULTIMATE": {"SR_WEAPON_1_1":  3, "SR_WEAPON_2_1":  6, "SR_WEAPON_3_1":  9, "SR_WEAPON_4_1": 15, "SR_WEAPON_0_1": 1},
+}
+
+PILOT_ROF_MODIFIER_DICT = {
+    # TRAIT:    {weapon_name: effect, weapon_name2: effect2,...}
+    "NO":       {},
+    "BAD":      {"SR_WEAPON_0_1": -1},
+    "GOOD":     {"SR_WEAPON_0_1": 1},
+    "GREAT":    {"SR_WEAPON_0_1": 2},
+    "ULTIMATE": {"SR_WEAPON_0_1": 3},
+}
+
+PILOT_FIGHTERDAMAGE_MODIFIER_DICT = {
+    # TRAIT:    {hangar_name: effect, hangar_name2: effect2,...}
+    "NO":       {},
+    "BAD":      {"FT_HANGAR_1": -1, "FT_HANGAR_2": -2, "FT_HANGAR_3": -3, "FT_HANGAR_4": -4},
+    "GOOD":     {"FT_HANGAR_1":  1, "FT_HANGAR_2":  2, "FT_HANGAR_3":  3, "FT_HANGAR_4": 4},
+    "GREAT":    {"FT_HANGAR_1":  2, "FT_HANGAR_2":  4, "FT_HANGAR_3":  6, "FT_HANGAR_4": 8},
+    "ULTIMATE": {"FT_HANGAR_1":  3, "FT_HANGAR_2":  6, "FT_HANGAR_3":  9, "FT_HANGAR_4": 12},
+}
+
+PILOT_FIGHTER_CAPACITY_MODIFIER_DICT = {
+    # TRAIT:    {hangar_name: effect, hangar_name2: effect2,...}
+    "NO":       {},
+    "BAD":      {},
+    "GOOD":     {},
+    "GREAT":    {},
+    "ULTIMATE": {},
+}
+# </editor-fold>
+
+# <editor-fold desc="Extraordinary Species Rules">
+# some species have a fixed population
+SPECIES_FIXED_POPULATION = {
+    # species_name: fixed_population_size
+    SP_LAMBALALAM: 5.0,
+}
+
+# techs that are unlocked if conquering a planet of a species
+SPECIES_TECH_UNLOCKS = {
+    # species: [tech1, tech2, ...]
+    SP_LAMBALALAM: [GRO_LIFE_CYCLE, SPY_STEALTH_1, SPY_STEALTH_2]
+}
 # </editor-fold>
 
 # </editor-fold>

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -1104,23 +1104,27 @@ def evaluate_planet(planet_id, mission_type, spec_name, empire, detail=None):
         if planet_id in species.homeworlds:  # TODO: check for homeworld growth focus
             pop_size_mod += 2
 
-        max_pop_size = pop_const_mod + planet_size * pop_size_mod * pop_tag_mod
-        detail.append(
-            "baseMaxPop %d + size*psm %d * %d * %.2f = %d" % (pop_const_mod, planet_size, pop_size_mod, pop_tag_mod, max_pop_size))
+        if planet.speciesName not in AIDependencies.SPECIES_FIXED_POPULATION:
+            max_pop_size = pop_const_mod + planet_size * pop_size_mod * pop_tag_mod
+            detail.append("baseMaxPop %d + size*psm %d * %d * %.2f = %d" % (
+                           pop_const_mod, planet_size, pop_size_mod, pop_tag_mod, max_pop_size))
 
-        for _special in set(planet.specials).intersection(AIDependencies.POP_FIXED_MOD_SPECIALS):
-            this_mod = sum(AIDependencies.POP_FIXED_MOD_SPECIALS[_special].get(int(psize), 0)
-                           for psize in [-1, planet.size])
-            detail.append("%s (maxPop%+.1f)" % (_special, this_mod))
-            max_pop_size += this_mod
+            for _special in set(planet.specials).intersection(AIDependencies.POP_FIXED_MOD_SPECIALS):
+                this_mod = sum(AIDependencies.POP_FIXED_MOD_SPECIALS[_special].get(int(psize), 0)
+                               for psize in [-1, planet.size])
+                detail.append("%s (maxPop%+.1f)" % (_special, this_mod))
+                max_pop_size += this_mod
 
-        for _special in set(planet.specials).intersection(AIDependencies.POP_PROPORTIONAL_MOD_SPECIALS):
-            this_mod = planet.size * sum(AIDependencies.POP_PROPORTIONAL_MOD_SPECIALS[_special].get(int(psize), 0)
-                                         for psize in [-1, planet.size])
-            detail.append("%s (maxPop%+.1f)" % (_special, this_mod))
-            max_pop_size += this_mod
+            for _special in set(planet.specials).intersection(AIDependencies.POP_PROPORTIONAL_MOD_SPECIALS):
+                this_mod = planet.size * sum(AIDependencies.POP_PROPORTIONAL_MOD_SPECIALS[_special].get(int(psize), 0)
+                                             for psize in [-1, planet.size])
+                detail.append("%s (maxPop%+.1f)" % (_special, this_mod))
+                max_pop_size += this_mod
 
-        detail.append("maxPop %.1f" % max_pop_size)
+            detail.append("maxPop %.1f" % max_pop_size)
+        else:
+            max_pop_size = AIDependencies.SPECIES_FIXED_POPULATION[planet.speciesName]
+            detail.append("Fixed max population of %.2f" % max_pop_size)
 
         for special in ["MINERALS_SPECIAL", "CRYSTALS_SPECIAL", "ELERIUM_SPECIAL"]:
             if special in planet_specials:

--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -284,6 +284,12 @@ def evaluate_invasion_planet(planet_id, empire, secure_fleet_missions, verbose=T
         bld_tally += bval
         detail.append("%s: %d" % (bldType, bval))
 
+    tech_tally = 0
+    for unlocked_tech in AIDependencies.SPECIES_TECH_UNLOCKS.get(species_name, []):
+        if not tech_is_complete(unlocked_tech):
+            rp_cost = fo.getTech(unlocked_tech).researchCost(empire_id)
+            tech_tally += rp_cost * 10
+
     p_sys_id = planet.systemID
     capitol_id = PlanetUtilsAI.get_capital()
     least_jumps_path = []
@@ -367,7 +373,8 @@ def evaluate_invasion_planet(planet_id, empire, secure_fleet_missions, verbose=T
         troop_cost = math.ceil(planned_troops/6.0) * (40*(1+foAI.foAIstate.shipCount * AIDependencies.SHIP_UPKEEP))
     else:
         troop_cost = math.ceil(planned_troops/6.0) * (20*(1+foAI.foAIstate.shipCount * AIDependencies.SHIP_UPKEEP))
-    planet_score = retaliation_risk_factor(planet.owner) * threat_factor * max(0, pop_val+supply_val+bld_tally+enemy_val-0.8*troop_cost)
+    base_score = pop_val + supply_val + bld_tally + tech_tally + enemy_val - 0.8*troop_cost
+    planet_score = retaliation_risk_factor(planet.owner) * threat_factor * max(0, base_score)
     if clear_path:
         planet_score *= 1.5
     if verbose:

--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -290,7 +290,8 @@ def evaluate_invasion_planet(planet_id, empire, secure_fleet_missions, verbose=T
     for unlocked_tech in AIDependencies.SPECIES_TECH_UNLOCKS.get(species_name, []):
         if not tech_is_complete(unlocked_tech):
             rp_cost = fo.getTech(unlocked_tech).researchCost(empire_id)
-            tech_tally += rp_cost * 10
+            tech_tally += rp_cost * 4
+            detail.append("%s: %d" % (unlocked_tech, rp_cost * 4))
 
     p_sys_id = planet.systemID
     capitol_id = PlanetUtilsAI.get_capital()

--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -272,9 +272,11 @@ def evaluate_invasion_planet(planet_id, empire, secure_fleet_missions, verbose=T
 
     species_name = planet.speciesName
     species = fo.getSpecies(species_name)
-    if not species:  # this call iterates over this Empire's available species with which it could colonize after an invasion
+    if not species or AIDependencies.TAG_DESTROYED_ON_CONQUEST in species.tags:
+        # this call iterates over this Empire's available species with which it could colonize after an invasion
         planet_eval = ColonisationAI.assign_colonisation_values([planet_id], MissionType.INVASION, None, empire, detail)
-        pop_val = max(0.75 * planet_eval.get(planet_id, [0])[0], ColonisationAI.evaluate_planet(planet_id, MissionType.OUTPOST, None, empire, detail))
+        pop_val = max(0.75 * planet_eval.get(planet_id, [0])[0],
+                      ColonisationAI.evaluate_planet(planet_id, MissionType.OUTPOST, None, empire, detail))
     else:
         pop_val = ColonisationAI.evaluate_planet(planet_id, MissionType.INVASION, species_name, empire, detail)
 


### PR DESCRIPTION
The PR

- handles fixed size populations when assigning colonization values
- increases invasion priority if a tech will be unlocked by conquering the planet
- implements the relevant settings for Lembala'Lam species.
- adjusts invasion priority if a species is destroyed on conquest (e.g. Ancient Guardians)

Resolves #1012
Resolves #1058
