### PR TITLE
Fix bug #1183 in DropDownList pre-scroll to last selected item is incorrect.

### DIFF
--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -560,7 +560,7 @@ private:
     void            HScrolled(int tab_low, int tab_high, int low, int high);///< signals from the horizontal scroll bar are caught here
     void            ClickAtRow(iterator it, Flags<ModKey> mod_keys);        ///< handles to a mouse-click or spacebar-click on \a it, modified by \a keys
     void            NormalizeRow(Row* row);                                 ///< adjusts a Row so that it has the same number of cells as other rows, and that each cell has the correct width and alignment
-    iterator        FirstRowShownWhenBottomIs(iterator bottom_row, Y client_height); ///< Returns the first row shown when the last row shown is \a bottom_row
+    iterator        FirstRowShownWhenBottomIs(iterator bottom_row); ///< Returns the first row shown when the last row shown is \a bottom_row
     std::size_t     FirstColShownWhenRightIs(std::size_t right_col, X client_width); ///< Returns the index of the first column shown when the last column shown is \a right_col
 
     struct SelectionCache;

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -110,7 +110,7 @@ private:
     void WindowResizedSlot(X x, Y y);
 
     /** Used by CorrectListSize() to determine the list height from the current first shown row. */
-    void DetermineListHeight(Pt drop_down_size);
+    Pt DetermineListHeight(const Pt& drop_down_size);
 
     ListBox*            m_lb_wnd;
     const size_t        m_num_shown_rows;
@@ -261,7 +261,9 @@ void ModalListPicker::SignalChanged(boost::optional<DropDownList::iterator> it)
         SelChangedSignal(*it);
 }
 
-void ModalListPicker::DetermineListHeight(Pt drop_down_size) {
+Pt ModalListPicker::DetermineListHeight(const Pt& _drop_down_size) {
+    auto drop_down_size = _drop_down_size;
+
     // Determine the expected height
     auto border_thick = 2 * GG::Y(ListBox::BORDER_THICK);
     auto num_rows = std::min<int>(m_num_shown_rows, LB()->NumRows());
@@ -281,6 +283,8 @@ void ModalListPicker::DetermineListHeight(Pt drop_down_size) {
     if (!LB()->Selections().empty())
         LB()->BringRowIntoView(*(LB()->Selections().begin()));
     GUI::GetGUI()->PreRenderWindow(LB());
+
+    return drop_down_size;
 }
 
 void ModalListPicker::CorrectListSize() {
@@ -319,7 +323,7 @@ void ModalListPicker::CorrectListSize() {
         // (width, prerender etc.) would mean this code could be reduced to
         // check height and resize list just once.
 
-        DetermineListHeight(drop_down_size);
+        drop_down_size = DetermineListHeight(drop_down_size);
         DetermineListHeight(drop_down_size);
 
         LB()->Hide();

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -294,13 +294,15 @@ void ModalListPicker::CorrectListSize() {
         // (width, prerender etc.) would mean this code could be reduced to
         // check height and resize list just once.
 
-        drop_down_size.y = (*LB()->FirstRowShown())->Height() * std::min<int>(m_num_shown_rows, LB()->NumRows()) + 4;
+        drop_down_size.y = (*LB()->FirstRowShown())->Height() * std::min<int>(m_num_shown_rows, LB()->NumRows())
+            + 4 * GG::Y(ListBox::BORDER_THICK);
         LB()->Resize(drop_down_size);
         if (!LB()->Selections().empty())
             LB()->BringRowIntoView(*(LB()->Selections().begin()));
         GUI::GetGUI()->PreRenderWindow(LB());
 
-        drop_down_size.y = (*LB()->FirstRowShown())->Height() * std::min<int>(m_num_shown_rows, LB()->NumRows()) + 4;
+        drop_down_size.y = (*LB()->FirstRowShown())->Height() * std::min<int>(m_num_shown_rows, LB()->NumRows())
+            + 4 * GG::Y(ListBox::BORDER_THICK);
         LB()->Resize(drop_down_size);
         if (!LB()->Selections().empty())
             LB()->BringRowIntoView(*(LB()->Selections().begin()));

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -902,7 +902,7 @@ void ListBox::Render()
             RowAboveOrIsRow(curr_sel, last_visible_row, m_rows.end()))
         {
             top = std::max((*curr_sel)->Top(), cl_ul.y);
-            bottom = std::min(top + (*curr_sel)->Height(), cl_lr.y);
+            bottom = std::min((*curr_sel)->Top() + (*curr_sel)->Height(), cl_lr.y);
             FlatRectangle(Pt(cl_ul.x, top), Pt(cl_lr.x, bottom),
                           hilite_color_to_use, CLR_ZERO, 0);
         }

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -1209,7 +1209,7 @@ void ListBox::BringRowIntoView(iterator it)
     if (it_y_offset < first_row_y_offset)
         SetFirstRowShown(it);
     else if (it_y_offset >= last_row_y_offset)
-        SetFirstRowShown(FirstRowShownWhenBottomIs(it, ClientHeight()));
+        SetFirstRowShown(FirstRowShownWhenBottomIs(it));
 }
 
 void ListBox::SetFirstRowShown(iterator it)
@@ -2425,9 +2425,9 @@ void ListBox::NormalizeRow(Row* row)
     GUI::PreRenderWindow(row);
 }
 
-ListBox::iterator ListBox::FirstRowShownWhenBottomIs(iterator bottom_row, Y client_height)
+ListBox::iterator ListBox::FirstRowShownWhenBottomIs(iterator bottom_row)
 {
-    Y available_space = client_height - (*bottom_row)->Height() - GG::Y(2*BORDER_THICK);
+    Y available_space = ClientHeight() - (*bottom_row)->Height();
     iterator it = bottom_row;
     while (it != m_rows.begin() && (*std::prev(it))->Height() <= available_space) {
         available_space -= (*--it)->Height();

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -1173,6 +1173,7 @@ void ListBox::BringRowIntoView(iterator it)
 
     Y y_offset(BORDER_THICK), it_y_offset(BORDER_THICK);
     Y first_row_y_offset(BORDER_THICK), last_row_y_offset(BORDER_THICK);
+    iterator it_end_row = --m_rows.end();
     iterator it2 = m_rows.begin();
     while ((it2 != m_rows.end()) && (!first_row_found || !last_row_found || !it_found)) {
         if (it2 == m_first_row_shown) {
@@ -1186,7 +1187,8 @@ void ListBox::BringRowIntoView(iterator it)
         }
 
         if (first_row_found && !last_row_found
-            && ((y_offset - first_row_y_offset) >= ClientHeight()))
+            && (((y_offset - first_row_y_offset + GG::Y(2 * BORDER_THICK)) >= ClientHeight())
+                || it2 == it_end_row))
         {
             last_row_found = true;
             if (it2 != m_rows.begin())
@@ -1200,7 +1202,7 @@ void ListBox::BringRowIntoView(iterator it)
     if (!it_found)
         return;
 
-    if (y_offset <= ClientHeight())
+    if (y_offset + GG::Y(BORDER_THICK) <= ClientHeight())
         SetFirstRowShown(begin());
 
     // Shift the view if 'it' is outside of [first_row .. last_row]
@@ -2425,7 +2427,7 @@ void ListBox::NormalizeRow(Row* row)
 
 ListBox::iterator ListBox::FirstRowShownWhenBottomIs(iterator bottom_row, Y client_height)
 {
-    Y available_space = client_height - (*bottom_row)->Height();
+    Y available_space = client_height - (*bottom_row)->Height() - GG::Y(2*BORDER_THICK);
     iterator it = bottom_row;
     while (it != m_rows.begin() && (*std::prev(it))->Height() <= available_space) {
         available_space -= (*--it)->Height();

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -1169,12 +1169,20 @@ void ListBox::BringRowIntoView(iterator target)
         return;
 
     // Find the y offsets of the first and last shown rows and target.
-    bool first_row_found(false), last_row_found(false), target_found(false);
+    auto first_row_found(false);
+    auto last_row_found(false);
+    auto target_found(false);
 
-    Y y_offset_top(Y0), y_offset_bot(Y0), target_y_offset(Y0);
-    Y first_row_y_offset(Y0), last_row_y_offset(Y0);
-    iterator final_row = --m_rows.end();
-    iterator it = m_rows.begin();
+    auto y_offset_top(Y0);
+    auto y_offset_bot(Y0);
+    auto target_y_offset(Y0);
+
+    auto first_row_y_offset(Y0);
+    auto last_row_y_offset(Y0);
+
+    auto final_row = --m_rows.end();
+    auto it = m_rows.begin();
+
     while ((it != m_rows.end()) && (!first_row_found || !last_row_found || !target_found)) {
         y_offset_bot += (*it)->Height();
 

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -1218,12 +1218,13 @@ void ListBox::SetFirstRowShown(iterator it)
         return;
 
     RequirePreRender();
-    m_first_row_shown = it;
 
     AdjustScrolls(false);
 
-    if (!m_vscroll)
+    if (!m_vscroll && m_first_row_shown == m_rows.begin())
         return;
+
+    m_first_row_shown = m_vscroll ? it : m_rows.begin();
 
     Y acc(0);
     for (iterator it2 = m_rows.begin(); it2 != m_first_row_shown; ++it2)


### PR DESCRIPTION
There were several contributing problems all related to the BORDER_SIZE.
1. In the DropDownList::CorrectListSize() it was not accounting for the
borders of the list.
2. In ListBox BringRowIntoView() and FirstRowShownWhenBottomIs() both
were not accounting for the BORDER_SIZE.