### PR TITLE
Reduce number of initial scouts from 8 to 5

### DIFF
--- a/default/python/AI/PriorityAI.py
+++ b/default/python/AI/PriorityAI.py
@@ -22,7 +22,6 @@ prioritiees_timer = AITimer('calculate_priorities()')
 allottedInvasionTargets = 0
 allottedColonyTargets = 0
 allotted_outpost_targets = 0
-scoutsNeeded = 0
 unmetThreat = 0
 
 
@@ -188,7 +187,6 @@ def _calculate_research_priority():
 
 def _calculate_exploration_priority():
     """Calculates the demand for scouts by unexplored systems."""
-    global scoutsNeeded
     empire = fo.getEmpire()
     num_unexplored_systems = len(ExplorationAI.borderUnexploredSystemIDs)  # len(foAI.foAIstate.get_explorable_systems(ExplorableSystemType.UNEXPLORED))
     num_scouts = sum([foAI.foAIstate.fleetStatus.get(fid, {}).get('nships', 0) for fid in FleetUtilsAI.get_empire_fleet_ids_by_role(
@@ -208,8 +206,9 @@ def _calculate_exploration_priority():
     # need_cap_B is to help regulate investment into scouting while the empire is small.
     # These caps could perhaps instead be tied more directly to military priority and
     # total empire production.
-    scoutsNeeded = max(0, min(4 + int(mil_ships / 5), 4 + int(fo.currentTurn() / 50), 2 + num_unexplored_systems**0.5) - num_scouts - queued_scout_ships)
-    exploration_priority = int(40 * scoutsNeeded)
+    desired_number_of_scouts = int(min(4 + mil_ships/5, 4 + fo.currentTurn()/50.0, 2 + num_unexplored_systems**0.5))
+    scouts_needed = max(0, desired_number_of_scouts - (num_scouts + queued_scout_ships))
+    exploration_priority = int(40 * scouts_needed)
 
     print
     print "Number of Scouts: %s" % num_scouts

--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -215,16 +215,12 @@ def generate_production_orders():
                 continue
             claimed_stars.setdefault(t_sys.starType, []).append(sys_id)
 
-    if (current_turn in [1, 4]) and ((production_queue.totalSpent < total_pp) or (len(production_queue) <= 3)):
-        best_design_id, best_design, build_choices = get_best_ship_info(PriorityType.PRODUCTION_EXPLORATION)
-        if len(AIstate.opponentPlanetIDs) == 0:
-            init_scouts = 3
-        else:
-            init_scouts = 0
-        if best_design_id:
-            for scout_count in range(init_scouts):
+    if current_turn == 1 and len(AIstate.opponentPlanetIDs) == 0:
+        best_design_id, _, build_choices = get_best_ship_info(PriorityType.PRODUCTION_EXPLORATION)
+        if best_design_id is not None:
+            for _ in range(3):
                 fo.issueEnqueueShipProductionOrder(best_design_id, build_choices[0])
-        fo.updateProductionQueue()
+            fo.updateProductionQueue()
 
     building_expense = 0.0
     building_ratio = foAI.foAIstate.character.preferred_building_ratio([0.4, 0.35, 0.30])


### PR DESCRIPTION
2 starting scouts and 3 more enqueued on first turn should be enough.

Building another 3 on turn 4 delays more important stuff and adds significant fleet upkeep.