### PR TITLE
Kobuntura should prefer the industry focus

### DIFF
--- a/default/scripting/species/SP_KOBUNTURA.focs.txt
+++ b/default/scripting/species/SP_KOBUNTURA.focs.txt
@@ -15,7 +15,7 @@ Species
         [[HAS_ADVANCED_FOCI]]
     ]
 
-    preferredfocus = "FOCUS_RESEARCH"
+    preferredfocus = "FOCUS_INDUSTRY"
 
     effectsgroups = [
         [[GREAT_INDUSTRY]]


### PR DESCRIPTION
as they are better at industry, as such this avoids a dumb
micromanagement of switching the focus after colonization