### PR TITLE
[python] Cleanup game scripts

### DIFF
--- a/default/python/AI/AIDependencies.py
+++ b/default/python/AI/AIDependencies.py
@@ -77,21 +77,21 @@ INVALID_ID = -1
 # boni that scale with planet size
 POP_SIZE_MOD_MAP = {
     # "Effect": [uninhab, hostile, poor, adequate, good]
-    "environment_bonus": [0, -4, -2, 0, 3],
-    "GRO_SUBTER_HAB": [0, 1, 1, 1, 1],
+    "environment_bonus": [0,-4,-2, 0, 3],
+    "GRO_SUBTER_HAB":    [0, 1, 1, 1, 1],
     "GRO_SYMBIOTIC_BIO": [0, 0, 1, 1, 1],
     "GRO_XENO_GENETICS": [0, 1, 2, 2, 0],
-    "GRO_XENO_HYBRID": [0, 2, 1, 0, 0],
-    "GRO_CYBORG": [0, 2, 0, 0, 0],
-    "CON_NDIM_STRUC": [0, 2, 2, 2, 2],
-    "CON_ORBITAL_HAB": [0, 1, 1, 1, 1],
+    "GRO_XENO_HYBRID":   [0, 2, 1, 0, 0],
+    "GRO_CYBORG":        [0, 2, 0, 0, 0],
+    "CON_NDIM_STRUC":    [0, 2, 2, 2, 2],
+    "CON_ORBITAL_HAB":   [0, 1, 1, 1, 1],
 }
 
 # flat boni not dependent on size
 POP_CONST_MOD_MAP = {
     # "Source": [uninhab, hostile, poor, adequate, good]
-    "GRO_PLANET_ECOL": [0, 0, 0, 1, 1],
-    "GRO_SYMBIOTIC_BIO": [0, 0, 0, -1, -1],
+    "GRO_PLANET_ECOL":   [0, 0, 0, 1, 1],
+    "GRO_SYMBIOTIC_BIO": [0, 0, 0,-1,-1],
 }
 # </editor-fold>
 
@@ -115,37 +115,37 @@ EXTINCT_SPECIES = [
 # TODO (Morlic): Consider using only 1 dict with tuple for (Capacity, SecondaryStat) effects
 PILOT_DAMAGE_MODIFIER_DICT = {
     # TRAIT:    {weapon_name: effect, weapon_name2: effect2,...}
-    "NO": {},
-    "BAD": {"SR_WEAPON_1_1": -1, "SR_WEAPON_2_1": -2, "SR_WEAPON_3_1": -3, "SR_WEAPON_4_1": -5},
-    "GOOD": {"SR_WEAPON_1_1": 1, "SR_WEAPON_2_1": 2, "SR_WEAPON_3_1": 3, "SR_WEAPON_4_1": 5},
-    "GREAT": {"SR_WEAPON_1_1": 2, "SR_WEAPON_2_1": 4, "SR_WEAPON_3_1": 6, "SR_WEAPON_4_1": 10},
-    "ULTIMATE": {"SR_WEAPON_1_1": 3, "SR_WEAPON_2_1": 6, "SR_WEAPON_3_1": 9, "SR_WEAPON_4_1": 15, "SR_WEAPON_0_1": 1},
+    "NO":       {},
+    "BAD":      {"SR_WEAPON_1_1": -1, "SR_WEAPON_2_1": -2, "SR_WEAPON_3_1": -3, "SR_WEAPON_4_1": -5},
+    "GOOD":     {"SR_WEAPON_1_1":  1, "SR_WEAPON_2_1":  2, "SR_WEAPON_3_1":  3, "SR_WEAPON_4_1": 5},
+    "GREAT":    {"SR_WEAPON_1_1":  2, "SR_WEAPON_2_1":  4, "SR_WEAPON_3_1":  6, "SR_WEAPON_4_1": 10},
+    "ULTIMATE": {"SR_WEAPON_1_1":  3, "SR_WEAPON_2_1":  6, "SR_WEAPON_3_1":  9, "SR_WEAPON_4_1": 15, "SR_WEAPON_0_1": 1},
 }
 
 PILOT_ROF_MODIFIER_DICT = {
     # TRAIT:    {weapon_name: effect, weapon_name2: effect2,...}
-    "NO": {},
-    "BAD": {"SR_WEAPON_0_1": -1},
-    "GOOD": {"SR_WEAPON_0_1": 1},
-    "GREAT": {"SR_WEAPON_0_1": 2},
+    "NO":       {},
+    "BAD":      {"SR_WEAPON_0_1": -1},
+    "GOOD":     {"SR_WEAPON_0_1": 1},
+    "GREAT":    {"SR_WEAPON_0_1": 2},
     "ULTIMATE": {"SR_WEAPON_0_1": 3},
 }
 
 PILOT_FIGHTERDAMAGE_MODIFIER_DICT = {
     # TRAIT:    {hangar_name: effect, hangar_name2: effect2,...}
-    "NO": {},
-    "BAD": {"FT_HANGAR_1": -1, "FT_HANGAR_2": -2, "FT_HANGAR_3": -3, "FT_HANGAR_4": -4},
-    "GOOD": {"FT_HANGAR_1": 1, "FT_HANGAR_2": 2, "FT_HANGAR_3": 3, "FT_HANGAR_4": 4},
-    "GREAT": {"FT_HANGAR_1": 2, "FT_HANGAR_2": 4, "FT_HANGAR_3": 6, "FT_HANGAR_4": 8},
-    "ULTIMATE": {"FT_HANGAR_1": 3, "FT_HANGAR_2": 6, "FT_HANGAR_3": 9, "FT_HANGAR_4": 12},
+    "NO":       {},
+    "BAD":      {"FT_HANGAR_1": -1, "FT_HANGAR_2": -2, "FT_HANGAR_3": -3, "FT_HANGAR_4": -4},
+    "GOOD":     {"FT_HANGAR_1":  1, "FT_HANGAR_2":  2, "FT_HANGAR_3":  3, "FT_HANGAR_4": 4},
+    "GREAT":    {"FT_HANGAR_1":  2, "FT_HANGAR_2":  4, "FT_HANGAR_3":  6, "FT_HANGAR_4": 8},
+    "ULTIMATE": {"FT_HANGAR_1":  3, "FT_HANGAR_2":  6, "FT_HANGAR_3":  9, "FT_HANGAR_4": 12},
 }
 
 PILOT_FIGHTER_CAPACITY_MODIFIER_DICT = {
     # TRAIT:    {hangar_name: effect, hangar_name2: effect2,...}
-    "NO": {},
-    "BAD": {},
-    "GOOD": {},
-    "GREAT": {},
+    "NO":       {},
+    "BAD":      {},
+    "GOOD":     {},
+    "GREAT":    {},
     "ULTIMATE": {},
 }
 # </editor-fold>

--- a/default/python/AI/AIDependencies.py
+++ b/default/python/AI/AIDependencies.py
@@ -77,21 +77,21 @@ INVALID_ID = -1
 # boni that scale with planet size
 POP_SIZE_MOD_MAP = {
     # "Effect": [uninhab, hostile, poor, adequate, good]
-    "environment_bonus": [0,-4,-2, 0, 3],
-    "GRO_SUBTER_HAB":    [0, 1, 1, 1, 1],
+    "environment_bonus": [0, -4, -2, 0, 3],
+    "GRO_SUBTER_HAB": [0, 1, 1, 1, 1],
     "GRO_SYMBIOTIC_BIO": [0, 0, 1, 1, 1],
     "GRO_XENO_GENETICS": [0, 1, 2, 2, 0],
-    "GRO_XENO_HYBRID":   [0, 2, 1, 0, 0],
-    "GRO_CYBORG":        [0, 2, 0, 0, 0],
-    "CON_NDIM_STRUC":    [0, 2, 2, 2, 2],
-    "CON_ORBITAL_HAB":   [0, 1, 1, 1, 1],
+    "GRO_XENO_HYBRID": [0, 2, 1, 0, 0],
+    "GRO_CYBORG": [0, 2, 0, 0, 0],
+    "CON_NDIM_STRUC": [0, 2, 2, 2, 2],
+    "CON_ORBITAL_HAB": [0, 1, 1, 1, 1],
 }
 
 # flat boni not dependent on size
 POP_CONST_MOD_MAP = {
     # "Source": [uninhab, hostile, poor, adequate, good]
-    "GRO_PLANET_ECOL":   [0, 0, 0, 1, 1],
-    "GRO_SYMBIOTIC_BIO": [0, 0, 0,-1,-1],
+    "GRO_PLANET_ECOL": [0, 0, 0, 1, 1],
+    "GRO_SYMBIOTIC_BIO": [0, 0, 0, -1, -1],
 }
 # </editor-fold>
 
@@ -115,37 +115,37 @@ EXTINCT_SPECIES = [
 # TODO (Morlic): Consider using only 1 dict with tuple for (Capacity, SecondaryStat) effects
 PILOT_DAMAGE_MODIFIER_DICT = {
     # TRAIT:    {weapon_name: effect, weapon_name2: effect2,...}
-    "NO":       {},
-    "BAD":      {"SR_WEAPON_1_1": -1, "SR_WEAPON_2_1": -2, "SR_WEAPON_3_1": -3, "SR_WEAPON_4_1": -5},
-    "GOOD":     {"SR_WEAPON_1_1":  1, "SR_WEAPON_2_1":  2, "SR_WEAPON_3_1":  3, "SR_WEAPON_4_1": 5},
-    "GREAT":    {"SR_WEAPON_1_1":  2, "SR_WEAPON_2_1":  4, "SR_WEAPON_3_1":  6, "SR_WEAPON_4_1": 10},
-    "ULTIMATE": {"SR_WEAPON_1_1":  3, "SR_WEAPON_2_1":  6, "SR_WEAPON_3_1":  9, "SR_WEAPON_4_1": 15, "SR_WEAPON_0_1": 1},
+    "NO": {},
+    "BAD": {"SR_WEAPON_1_1": -1, "SR_WEAPON_2_1": -2, "SR_WEAPON_3_1": -3, "SR_WEAPON_4_1": -5},
+    "GOOD": {"SR_WEAPON_1_1": 1, "SR_WEAPON_2_1": 2, "SR_WEAPON_3_1": 3, "SR_WEAPON_4_1": 5},
+    "GREAT": {"SR_WEAPON_1_1": 2, "SR_WEAPON_2_1": 4, "SR_WEAPON_3_1": 6, "SR_WEAPON_4_1": 10},
+    "ULTIMATE": {"SR_WEAPON_1_1": 3, "SR_WEAPON_2_1": 6, "SR_WEAPON_3_1": 9, "SR_WEAPON_4_1": 15, "SR_WEAPON_0_1": 1},
 }
 
 PILOT_ROF_MODIFIER_DICT = {
     # TRAIT:    {weapon_name: effect, weapon_name2: effect2,...}
-    "NO":       {},
-    "BAD":      {"SR_WEAPON_0_1": -1},
-    "GOOD":     {"SR_WEAPON_0_1": 1},
-    "GREAT":    {"SR_WEAPON_0_1": 2},
+    "NO": {},
+    "BAD": {"SR_WEAPON_0_1": -1},
+    "GOOD": {"SR_WEAPON_0_1": 1},
+    "GREAT": {"SR_WEAPON_0_1": 2},
     "ULTIMATE": {"SR_WEAPON_0_1": 3},
 }
 
 PILOT_FIGHTERDAMAGE_MODIFIER_DICT = {
     # TRAIT:    {hangar_name: effect, hangar_name2: effect2,...}
-    "NO":       {},
-    "BAD":      {"FT_HANGAR_1": -1, "FT_HANGAR_2": -2, "FT_HANGAR_3": -3, "FT_HANGAR_4": -4},
-    "GOOD":     {"FT_HANGAR_1":  1, "FT_HANGAR_2":  2, "FT_HANGAR_3":  3, "FT_HANGAR_4": 4},
-    "GREAT":    {"FT_HANGAR_1":  2, "FT_HANGAR_2":  4, "FT_HANGAR_3":  6, "FT_HANGAR_4": 8},
-    "ULTIMATE": {"FT_HANGAR_1":  3, "FT_HANGAR_2":  6, "FT_HANGAR_3":  9, "FT_HANGAR_4": 12},
+    "NO": {},
+    "BAD": {"FT_HANGAR_1": -1, "FT_HANGAR_2": -2, "FT_HANGAR_3": -3, "FT_HANGAR_4": -4},
+    "GOOD": {"FT_HANGAR_1": 1, "FT_HANGAR_2": 2, "FT_HANGAR_3": 3, "FT_HANGAR_4": 4},
+    "GREAT": {"FT_HANGAR_1": 2, "FT_HANGAR_2": 4, "FT_HANGAR_3": 6, "FT_HANGAR_4": 8},
+    "ULTIMATE": {"FT_HANGAR_1": 3, "FT_HANGAR_2": 6, "FT_HANGAR_3": 9, "FT_HANGAR_4": 12},
 }
 
 PILOT_FIGHTER_CAPACITY_MODIFIER_DICT = {
     # TRAIT:    {hangar_name: effect, hangar_name2: effect2,...}
-    "NO":       {},
-    "BAD":      {},
-    "GOOD":     {},
-    "GREAT":    {},
+    "NO": {},
+    "BAD": {},
+    "GOOD": {},
+    "GREAT": {},
     "ULTIMATE": {},
 }
 # </editor-fold>
@@ -793,5 +793,3 @@ PART_EFFECTS = {
 # </editor-fold>
 
 # </editor-fold>
-
-

--- a/default/python/AI/AIFleetMission.py
+++ b/default/python/AI/AIFleetMission.py
@@ -340,10 +340,8 @@ class AIFleetMission(object):
                     this_system_id = fleet_order.target.id
                     this_status = foAI.foAIstate.systemStatus.setdefault(this_system_id, {})
                     if this_status.get('monsterThreat', 0) > fo.currentTurn() * MilitaryAI.cur_best_mil_ship_rating() / 4.0:
-                        if (self.type not in (MissionType.MILITARY,
-                                              MissionType.SECURE) or
-                            fleet_order != self.orders[-1]  # if this move order is not this mil fleet's final destination, and blocked by Big Monster, release and hope for more effective reassignment
-                            ):
+                        # if this move order is not this mil fleet's final destination, and blocked by Big Monster, release and hope for more effective reassignment
+                        if self.type not in (MissionType.MILITARY, MissionType.SECURE) or fleet_order != self.orders[-1]:
                             print "Aborting mission due to being blocked by Big Monster at system %d, threat %d" % (this_system_id, foAI.foAIstate.systemStatus[this_system_id]['monsterThreat'])
                             print "Full set of orders were:"
                             for this_order in self.orders:
@@ -463,8 +461,9 @@ class AIFleetMission(object):
                 if repair_fleet_order and repair_fleet_order.is_valid():
                     self.orders.append(repair_fleet_order)
             cur_fighter_capacity, max_fighter_capacity = FleetUtilsAI.get_fighter_capacity_of_fleet(fleet_id)
-            if (fleet.fuel < fleet.maxFuel or cur_fighter_capacity < max_fighter_capacity
-                    and self.get_location_target().id not in fleet_supplyable_system_ids):
+            if (fleet.fuel < fleet.maxFuel or
+                    cur_fighter_capacity < max_fighter_capacity and
+                    self.get_location_target().id not in fleet_supplyable_system_ids):
                 resupply_fleet_order = MoveUtilsAI.get_resupply_fleet_order(self.fleet, self.get_location_target())
                 if resupply_fleet_order.is_valid():
                     self.orders.append(resupply_fleet_order)

--- a/default/python/AI/AIstate.py
+++ b/default/python/AI/AIstate.py
@@ -460,7 +460,7 @@ class AIstate(object):
                 sys_status['myFleetRating'] = my_ratings_list and CombatRatingsAI.combine_ratings_list(my_ratings_list) or 0
                 sys_status['all_local_defenses'] = CombatRatingsAI.combine_ratings(sys_status['myFleetRating'], sys_status['mydefenses']['overall'])
             sys_status['neighbors'] = set(dict_from_map(universe.getSystemNeighborsMap(sys_id, self.empireID)))
-            
+
         for sys_id in system_id_list:
             sys_status = self.systemStatus[sys_id]
             neighbors = sys_status.get('neighbors', set())
@@ -475,7 +475,7 @@ class AIstate(object):
                     setb.update(self.systemStatus.get(sys2id, {}).get('neighbors', set()))
             jump2ring = jumps2 - neighbors - {sys_id}
             jump3ring = jumps3 - jumps2 - neighbors - {sys_id}
-            jump4ring = jumps4 - jumps3  - jumps2 - neighbors - {sys_id}
+            jump4ring = jumps4 - jumps3 - jumps2 - neighbors - {sys_id}
             sys_status['2jump_ring'] = jump2ring
             sys_status['3jump_ring'] = jump3ring
             sys_status['4jump_ring'] = jump4ring
@@ -687,7 +687,7 @@ class AIstate(object):
                 # Not at all sure how this came about, but was throwing off threat assessments
             if fleet_id not in ok_fleets:  # or fleet.empty:
                 if (fleet and self.__fleetRoleByID.get(fleet_id, -1) != -1 and fleet_id not in destroyed_object_ids and
-                                [ship_id for ship_id in fleet.shipIDs if ship_id not in destroyed_object_ids]):
+                        [ship_id for ship_id in fleet.shipIDs if ship_id not in destroyed_object_ids]):
                     if not just_resumed:
                         fleetsLostBySystem.setdefault(old_sys_id, []).append(max(old_rating, MilitaryAI.MinThreat))
                 if fleet_id in self.__fleetRoleByID:

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -1,3 +1,5 @@
+from operator import itemgetter
+
 import freeOrionAIInterface as fo  # pylint: disable=import-error
 from common.print_utils import Table, Text, Sequence, Bool
 import sys
@@ -639,7 +641,7 @@ def get_base_outpost_defense_value():
     # for now, just combing these for rough composite factor
     # since outposts have no infrastructure (until late game at least), many of these have less weight
     # than for colonies
-    result = 3 * (0.1 + net_count) * (1 + regen_count/3.0) * (1 + garrison_count/6.0) * (1 + shield_count/3.0)
+    result = 3 * (0.1 + net_count) * (1 + regen_count / 3.0) * (1 + garrison_count / 6.0) * (1 + shield_count / 3.0)
 
     return result
 
@@ -770,11 +772,11 @@ def evaluate_planet(planet_id, mission_type, spec_name, empire, detail=None):
     cur_best_mil_ship_rating = max(MilitaryAI.cur_best_mil_ship_rating(), 0.001)
     fleet_threat_ratio = (sys_status.get('fleetThreat', 0) - myrating) / float(cur_best_mil_ship_rating)
     monster_threat_ratio = sys_status.get('monsterThreat', 0) / float(cur_best_mil_ship_rating)
-    neighbor_threat_ratio = ((sys_status.get('neighborThreat', 0)) / float(cur_best_mil_ship_rating)) + \
-                            min(0, fleet_threat_ratio)  # last portion gives credit for inner extra defenses
+    neighbor_threat_ratio = (sys_status.get('neighborThreat', 0) / float(cur_best_mil_ship_rating) +
+                             min(0, fleet_threat_ratio))  # last portion gives credit for inner extra defenses
     myrating = sys_status.get('my_neighbor_rating', 0)
     jump2_threat_ratio = ((max(0, sys_status.get('jump2_threat', 0) - myrating) / float(cur_best_mil_ship_rating)) +
-                         min(0, neighbor_threat_ratio))  # last portion gives credit for inner extra defenses
+                          min(0, neighbor_threat_ratio))  # last portion gives credit for inner extra defenses
 
     thrt_factor = 1.0
     ship_limit = 2 * (2 ** (fo.currentTurn() / 40.0))
@@ -913,7 +915,7 @@ def evaluate_planet(planet_id, mission_type, spec_name, empire, detail=None):
                 detail.append("%s %.1f" % (special, fort_val))
             elif special == "HONEYCOMB_SPECIAL":
                 honey_val = 0.3 * (AIDependencies.HONEYCOMB_IND_MULTIPLIER * AIDependencies.INDUSTRY_PER_POP *
-                                 empire_status['industrialists'] * discount_multiplier)
+                                   empire_status['industrialists'] * discount_multiplier)
                 retval += honey_val
                 detail.append("%s %.1f" % (special, honey_val))
         if planet.size == fo.planetSize.asteroids:
@@ -1353,7 +1355,9 @@ def _print_empire_species_roster():
     species_table = Table(header, table_name="Empire species roster Turn %d" % fo.currentTurn())
     for species_name, planet_ids in state.get_empire_planets_by_species().items():
         species_tags = fo.getSpecies(species_name).tags
-        grade_symbol = lambda x: grade_map.get(get_ai_tag_grade(species_tags, x).upper(), "o")
+
+        def grade_symbol(x):
+            return grade_map.get(get_ai_tag_grade(species_tags, x).upper(), "o")
         is_colonizer = species_name in empire_colonizers
         number_of_shipyards = len(empire_ship_builders.get(species_name, []))
         this_row = [species_name, planet_ids, is_colonizer, number_of_shipyards]
@@ -1384,10 +1388,12 @@ def __print_candidate_table(candidates, mission):
     universe = fo.getUniverse()
     if mission == 'Colonization':
         col1 = Text('(Score, Species)')
-        col1_value = lambda x: (x[0], x[1])
+
+        def col1_value(x):
+            return x[0], x[1]
     elif mission == 'Outposts':
         col1 = Text('Score')
-        col1_value = lambda x: x[0]
+        col1_value = itemgetter(0)
     else:
         print >> sys.stderr, "__print_candidate_table(%s, %s): Invalid mission type" % (candidates, mission)
         return

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -641,7 +641,7 @@ def get_base_outpost_defense_value():
     # for now, just combing these for rough composite factor
     # since outposts have no infrastructure (until late game at least), many of these have less weight
     # than for colonies
-    result = 3 * (0.1 + net_count) * (1 + regen_count / 3.0) * (1 + garrison_count / 6.0) * (1 + shield_count / 3.0)
+    result = 3 * (0.1 + net_count) * (1 + regen_count/3.0) * (1 + garrison_count/6.0) * (1 + shield_count/3.0)
 
     return result
 

--- a/default/python/AI/CombatRatingsAI.py
+++ b/default/python/AI/CombatRatingsAI.py
@@ -9,6 +9,7 @@ from freeorion_tools import get_ai_tag_grade, dict_to_tuple, tuple_to_dict, cach
 from ShipDesignAI import get_part_type
 from AIDependencies import INVALID_ID
 
+
 def get_empire_standard_fighter():
     """Get the current empire standard fighter stats, i.e. the most common shiptype within the empire.
 
@@ -182,15 +183,15 @@ class ShipCombatStats(object):
             e_attacks, e_structure, e_shields = enemy_stats.get_basic_stats()
             if e_attacks:
                 e_num_attacks = sum(n for n in e_attacks.values())
-                e_total_attack = sum(n*dmg for dmg, n in e_attacks.iteritems())
+                e_total_attack = sum(n * dmg for dmg, n in e_attacks.iteritems())
                 e_avg_attack = e_total_attack / e_num_attacks
-                e_net_attack = sum(n*max(dmg - my_shields, .001) for dmg, n in e_attacks.iteritems())
-                e_net_attack = max(e_net_attack, .1*e_total_attack)
+                e_net_attack = sum(n * max(dmg - my_shields, .001) for dmg, n in e_attacks.iteritems())
+                e_net_attack = max(e_net_attack, .1 * e_total_attack)
                 shield_factor = e_total_attack / e_net_attack
                 my_structure *= max(1, shield_factor)
-            my_total_attack = sum(n*max(dmg - e_shields, .001) for dmg, n in my_attacks.iteritems())
+            my_total_attack = sum(n * max(dmg - e_shields, .001) for dmg, n in my_attacks.iteritems())
         else:
-            my_total_attack = sum(n*dmg for dmg, n in my_attacks.iteritems())
+            my_total_attack = sum(n * dmg for dmg, n in my_attacks.iteritems())
             my_structure += my_shields
 
         # consider fighter attacks
@@ -203,7 +204,7 @@ class ShipCombatStats(object):
         my_total_attack += fighter_damage_per_bout
 
         # consider fighter protection factor
-        fighters_shot_down = (1-survival_rate**2) * launched_1st_bout + (1-survival_rate) * launched_2nd_bout
+        fighters_shot_down = (1 - survival_rate**2) * launched_1st_bout + (1-survival_rate) * launched_2nd_bout
         damage_prevented = fighters_shot_down * e_avg_attack
         my_structure += damage_prevented
         return my_total_attack * my_structure

--- a/default/python/AI/DiplomaticCorp.py
+++ b/default/python/AI/DiplomaticCorp.py
@@ -113,8 +113,8 @@ class DiplomaticCorp(object):
 class BeginnerDiplomaticCorp(DiplomaticCorp):
     pass
 
+
 class ManiacalDiplomaticCorp(DiplomaticCorp):
     def __init__(self):
         DiplomaticCorp.__init__(self)
         self.be_chatty = False
-

--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -56,6 +56,7 @@ class AIStateMock(AIstate.AIstate):
     def __init__(self):
         pass
 
+
 # AIstate
 foAIstate = AIStateMock()
 diplomatic_corp = None
@@ -96,6 +97,7 @@ def startNewGame(aggression_input=fo.aggression.aggressive):  # pylint: disable=
     global diplomatic_corp
     diplomatic_corp = diplomatic_corp_configs.get(aggression_trait.key, DiplomaticCorp.DiplomaticCorp)()
     TechsListsAI.test_tech_integrity()
+
 
 @chat_on_error
 def resumeLoadedGame(saved_state_string):  # pylint: disable=invalid-name

--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -366,7 +366,7 @@ def evaluate_invasion_planet(planet_id, empire, secure_fleet_missions, verbose=T
     if not tech_is_complete("SHP_ORG_HULL"):
         troop_cost = math.ceil(planned_troops/6.0) * (40 * (1 + foAI.foAIstate.shipCount*AIDependencies.SHIP_UPKEEP))
     else:
-        troop_cost = math.ceil(planned_troops / 6.0) * (20 * (1 + foAI.foAIstate.shipCount*AIDependencies.SHIP_UPKEEP))
+        troop_cost = math.ceil(planned_troops/6.0) * (20 * (1 + foAI.foAIstate.shipCount*AIDependencies.SHIP_UPKEEP))
     planet_score = retaliation_risk_factor(planet.owner) * threat_factor * max(0, pop_val + supply_val + bld_tally + enemy_val - 0.8*troop_cost)
     if clear_path:
         planet_score *= 1.5

--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -359,15 +359,15 @@ def evaluate_invasion_planet(planet_id, empire, secure_fleet_missions, verbose=T
         else:
             supply_val *= 0.2
 
-    threat_factor = min(1, 0.2*MilitaryAI.totMilRating/(sys_total_threat+0.001))**2  # devalue invasions that would require too much military force
+    threat_factor = min(1, 0.2 * MilitaryAI.totMilRating / (sys_total_threat + 0.001))**2  # devalue invasions that would require too much military force
     build_time = 4
 
-    planned_troops = troops if system_secured else min(troops+max_jumps+build_time, max_troops)
+    planned_troops = troops if system_secured else min(troops + max_jumps + build_time, max_troops)
     if not tech_is_complete("SHP_ORG_HULL"):
-        troop_cost = math.ceil(planned_troops/6.0) * (40*(1+foAI.foAIstate.shipCount * AIDependencies.SHIP_UPKEEP))
+        troop_cost = math.ceil(planned_troops/6.0) * (40 * (1 + foAI.foAIstate.shipCount*AIDependencies.SHIP_UPKEEP))
     else:
-        troop_cost = math.ceil(planned_troops/6.0) * (20*(1+foAI.foAIstate.shipCount * AIDependencies.SHIP_UPKEEP))
-    planet_score = retaliation_risk_factor(planet.owner) * threat_factor * max(0, pop_val+supply_val+bld_tally+enemy_val-0.8*troop_cost)
+        troop_cost = math.ceil(planned_troops / 6.0) * (20 * (1 + foAI.foAIstate.shipCount*AIDependencies.SHIP_UPKEEP))
+    planet_score = retaliation_risk_factor(planet.owner) * threat_factor * max(0, pop_val + supply_val + bld_tally + enemy_val - 0.8*troop_cost)
     if clear_path:
         planet_score *= 1.5
     if verbose:
@@ -399,7 +399,7 @@ def send_invasion_fleets(fleet_ids, evaluated_planets, mission_type):
         found_fleets = []
         found_stats = {}
         min_stats = {'rating': 0, 'troopCapacity': ptroops}
-        target_stats = {'rating': 10, 'troopCapacity': ptroops+1}
+        target_stats = {'rating': 10, 'troopCapacity': ptroops + 1}
         these_fleets = FleetUtilsAI.get_fleets_for_mission(target_stats, min_stats, found_stats,
                                                            starting_system=sys_id, fleet_pool_set=invasion_fleet_pool,
                                                            fleet_list=found_fleets)

--- a/default/python/AI/MilitaryAI.py
+++ b/default/python/AI/MilitaryAI.py
@@ -534,7 +534,7 @@ def get_military_fleets(mil_fleets_ids=None, try_reset=True, thisround="Main"):
         ot_sys_alloc = 0
         ot_sys_threat = [(o_s_id, safety_factor * combine_ratings(systems_status.get(o_s_id, {}).get('fleetThreat', 0), systems_status.get(o_s_id, {}).get('monsterThreat', 0) + systems_status.get(o_s_id, {}).get('planetThreat', 0))) for o_s_id in explo_target_ids]
         totot_sys_threat = sum([thrt for sid, thrt in ot_sys_threat])
-        tot_cur_alloc = sum([0.8 * already_assigned_rating[sid] for sid, thrt in ot_sys_threat])
+        tot_cur_alloc = sum(0.8 * already_assigned_rating[sid] for sid, thrt in ot_sys_threat)
         # intentionally after tallies, but perhaps should be before
         # this supply threat calc intentionally uses a lower multiplier 0.25
         ot_sys_threat = [(sys_id, sys_threat + enemy_sup_factor[sys_id] * 0.25 * enemy_rating) for sys_id, sys_threat in ot_sys_threat]
@@ -577,7 +577,7 @@ def get_military_fleets(mil_fleets_ids=None, try_reset=True, thisround="Main"):
         ot_sys_alloc = 0
         ot_sys_threat = [(o_s_id, threat_bias + safety_factor*combine_ratings(systems_status.get(o_s_id, {}).get('fleetThreat', 0), systems_status.get(o_s_id, {}).get('monsterThreat', 0) + systems_status.get(o_s_id, {}).get('planetThreat', 0))) for o_s_id in border_targets]
         totot_sys_threat = sum([thrt for sid, thrt in ot_sys_threat])
-        tot_cur_alloc = sum([0.8 * already_assigned_rating[sid] for sid, thrt in ot_sys_threat])
+        tot_cur_alloc = sum(0.8 * already_assigned_rating[sid] for sid, thrt in ot_sys_threat)
         # do not add enemy supply threat here
         for sid, thrt in ot_sys_threat:
             cur_alloc = already_assigned_rating[sid]

--- a/default/python/AI/MilitaryAI.py
+++ b/default/python/AI/MilitaryAI.py
@@ -216,7 +216,7 @@ def get_military_fleets(mil_fleets_ids=None, try_reset=True, thisround="Main"):
     # --------Capital Threat ----------
     if capital_sys_id is not None:
         capital_sys_status = systems_status[capital_sys_id]
-        capital_threat = safety_factor*(2 * threat_bias + combine_ratings_list([capital_sys_status[thrt_key] for thrt_key in ['totalThreat', 'neighborThreat']]))
+        capital_threat = safety_factor * (2*threat_bias + combine_ratings_list([capital_sys_status[thrt_key] for thrt_key in ['totalThreat', 'neighborThreat']]))
         capital_threat += max(0, enemy_sup_factor[sys_id]*enemy_rating - capital_sys_status.get('my_neighbor_rating', 0))
         local_support = combine_ratings(already_assigned_rating[capital_sys_id], capital_sys_status['my_neighbor_rating'])
         base_needed_rating = rating_needed(capital_sys_status['regional_threat'], local_support)
@@ -225,7 +225,7 @@ def get_military_fleets(mil_fleets_ids=None, try_reset=True, thisround="Main"):
                         rating_needed(2 * capital_threat, already_assigned_rating[capital_sys_id]))
         new_alloc = 0
         if try_reset:
-            if needed_rating > 0.5*avail_mil_rating:
+            if needed_rating > 0.5 * avail_mil_rating:
                 try_again(all_military_fleet_ids)
                 return
         if needed_rating > 0:
@@ -255,8 +255,7 @@ def get_military_fleets(mil_fleets_ids=None, try_reset=True, thisround="Main"):
     new_alloc = 0
     if empire_occupied_system_ids:
         oc_sys_tot_threat_v1 = [(o_s_id, threat_bias + safety_factor*combine_ratings_list(
-                                [systems_status.get(o_s_id, {}).get(thrt_key, 0) for thrt_key in ['totalThreat', 'neighborThreat']]))
-                                                                                            for o_s_id in empire_occupied_system_ids]
+                                [systems_status.get(o_s_id, {}).get(thrt_key, 0) for thrt_key in ['totalThreat', 'neighborThreat']])) for o_s_id in empire_occupied_system_ids]
         tot_oc_sys_threat = sum([thrt for _, thrt in oc_sys_tot_threat_v1])
         tot_cur_alloc = sum([already_assigned_rating[sid] for sid, _ in oc_sys_tot_threat_v1])
         # intentionally after tallies, but perhaps should be before
@@ -277,7 +276,7 @@ def get_military_fleets(mil_fleets_ids=None, try_reset=True, thisround="Main"):
         for sid, thrt in oc_sys_tot_threat:
             cur_alloc = already_assigned_rating[sid]
             needed_rating = rating_needed(1.3 * thrt, cur_alloc)
-            max_alloc = rating_needed(2*thrt, cur_alloc)
+            max_alloc = rating_needed(2 * thrt, cur_alloc)
             if (needed_rating > 0.8 * remaining_mil_rating) and try_reset:
                 try_again(all_military_fleet_ids)
                 return
@@ -311,17 +310,16 @@ def get_military_fleets(mil_fleets_ids=None, try_reset=True, thisround="Main"):
     if other_targeted_system_ids:
         ot_sys_alloc = 0
         ot_sys_threat = [(o_s_id, threat_bias + safety_factor * combine_ratings_list([
-                                systems_status.get(o_s_id, {}).get('totalThreat', 0),
-                                0.75 * systems_status.get(o_s_id, {}).get('neighborThreat', 0),
-                                0.5 * systems_status.get(o_s_id, {}).get('jump2_threat', 0)]))
-                         for o_s_id in other_targeted_system_ids]
+            systems_status.get(o_s_id, {}).get('totalThreat', 0),
+            0.75 * systems_status.get(o_s_id, {}).get('neighborThreat', 0),
+            0.5 * systems_status.get(o_s_id, {}).get('jump2_threat', 0)])) for o_s_id in other_targeted_system_ids]
         totot_sys_threat = sum([thrt for sid, thrt in ot_sys_threat])
         tot_cur_alloc = sum([already_assigned_rating[sid] for sid, thrt in ot_sys_threat])
         # intentionally after tallies, but perhaps should be before
         ot_sys_threat = [(sys_id, sys_threat + enemy_sup_factor[sys_id] * 0.5 * enemy_rating) for sys_id, sys_threat in ot_sys_threat]
         for sid, thrt in ot_sys_threat:
             cur_alloc = already_assigned_rating[sid]
-            needed_rating = rating_needed(1.4*thrt, cur_alloc)
+            needed_rating = rating_needed(1.4 * thrt, cur_alloc)
             this_alloc = 0
             # only record more allocation for this invasion if we already started or have enough rating available
             take_any = already_assigned_rating[sid] > 0
@@ -355,10 +353,9 @@ def get_military_fleets(mil_fleets_ids=None, try_reset=True, thisround="Main"):
     if other_targeted_system_ids:
         ot_sys_alloc = 0
         ot_sys_threat = [(o_s_id, threat_bias + safety_factor*combine_ratings_list([
-                                systems_status.get(o_s_id, {}).get('totalThreat', 0),
-                                0.75*systems_status.get(o_s_id, {}).get('neighborThreat', 0),
-                                0.5*systems_status.get(o_s_id, {}).get('jump2_threat', 0)]))
-                         for o_s_id in other_targeted_system_ids]
+            systems_status.get(o_s_id, {}).get('totalThreat', 0),
+            0.75 * systems_status.get(o_s_id, {}).get('neighborThreat', 0),
+            0.5 * systems_status.get(o_s_id, {}).get('jump2_threat', 0)])) for o_s_id in other_targeted_system_ids]
         totot_sys_threat = sum([thrt for sid, thrt in ot_sys_threat])
         tot_cur_alloc = sum([already_assigned_rating[sid] for sid, thrt in ot_sys_threat])
         # intentionally after tallies, but perhaps should be before
@@ -393,11 +390,10 @@ def get_military_fleets(mil_fleets_ids=None, try_reset=True, thisround="Main"):
             print "-----------------"
     if other_targeted_system_ids:
         ot_sys_alloc = 0
-        ot_sys_threat = [(o_s_id, threat_bias + safety_factor*combine_ratings_list([
-                                systems_status.get(o_s_id, {}).get('totalThreat', 0),
-                                0.75*systems_status.get(o_s_id, {}).get('neighborThreat', 0),
-                                0.5*systems_status.get(o_s_id, {}).get('jump2_threat', 0)]))
-                         for o_s_id in other_targeted_system_ids]
+        ot_sys_threat = [(o_s_id, threat_bias + safety_factor * combine_ratings_list([
+            systems_status.get(o_s_id, {}).get('totalThreat', 0),
+            0.75 * systems_status.get(o_s_id, {}).get('neighborThreat', 0),
+            0.5 * systems_status.get(o_s_id, {}).get('jump2_threat', 0)])) for o_s_id in other_targeted_system_ids]
         totot_sys_threat = sum([thrt for sid, thrt in ot_sys_threat])
         # intentionally after tallies, but perhaps should be before
         ot_sys_threat = [(sys_id, sys_threat + enemy_sup_factor[sys_id] * 0.5 * enemy_rating) for sys_id, sys_threat in ot_sys_threat]
@@ -412,7 +408,7 @@ def get_military_fleets(mil_fleets_ids=None, try_reset=True, thisround="Main"):
             if needed_rating > 0 and (remaining_mil_rating > needed_rating or take_any):
                 this_alloc = max(0, min(needed_rating, remaining_mil_rating))
                 new_alloc += this_alloc
-                max_alloc = rating_needed(3*thrt, cur_alloc)
+                max_alloc = rating_needed(3 * thrt, cur_alloc)
                 allocations.append((sid, this_alloc, take_any, max_alloc))
                 allocation_groups.setdefault('otherTargets', []).append((sid, this_alloc, take_any, max_alloc))
                 remaining_mil_rating -= this_alloc
@@ -446,10 +442,9 @@ def get_military_fleets(mil_fleets_ids=None, try_reset=True, thisround="Main"):
     if other_targeted_system_ids:
         ot_sys_alloc = 0
         ot_sys_threat = [(o_s_id, threat_bias + safety_factor*combine_ratings_list([
-                                systems_status.get(o_s_id, {}).get('totalThreat', 0),
-                                0.75*systems_status.get(o_s_id, {}).get('neighborThreat', 0),
-                                0.5*systems_status.get(o_s_id, {}).get('jump2_threat', 0)]))
-                         for o_s_id in other_targeted_system_ids]
+            systems_status.get(o_s_id, {}).get('totalThreat', 0),
+            0.75 * systems_status.get(o_s_id, {}).get('neighborThreat', 0),
+            0.5 * systems_status.get(o_s_id, {}).get('jump2_threat', 0)])) for o_s_id in other_targeted_system_ids]
         totot_sys_threat = sum([thrt for sid, thrt in ot_sys_threat])
         tot_cur_alloc = sum([already_assigned_rating[sid] for sid, thrt in ot_sys_threat])
         # intentionally after tallies, but perhaps should be before
@@ -458,7 +453,7 @@ def get_military_fleets(mil_fleets_ids=None, try_reset=True, thisround="Main"):
         new_alloc = 0
         for sid, thrt in ot_sys_threat:
             cur_alloc = already_assigned_rating[sid]
-            needed_rating = rating_needed(1.4*thrt, cur_alloc)
+            needed_rating = rating_needed(1.4 * thrt, cur_alloc)
             this_alloc = 0
             # only record more allocation for this invasion if we already started or have enough rating available
             take_any = already_assigned_rating[sid] > 0
@@ -537,9 +532,9 @@ def get_military_fleets(mil_fleets_ids=None, try_reset=True, thisround="Main"):
     new_alloc = 0
     if explo_target_ids:
         ot_sys_alloc = 0
-        ot_sys_threat = [(o_s_id, safety_factor*combine_ratings(systems_status.get(o_s_id, {}).get('fleetThreat', 0), systems_status.get(o_s_id, {}).get('monsterThreat', 0) + systems_status.get(o_s_id, {}).get('planetThreat', 0))) for o_s_id in explo_target_ids]
+        ot_sys_threat = [(o_s_id, safety_factor * combine_ratings(systems_status.get(o_s_id, {}).get('fleetThreat', 0), systems_status.get(o_s_id, {}).get('monsterThreat', 0) + systems_status.get(o_s_id, {}).get('planetThreat', 0))) for o_s_id in explo_target_ids]
         totot_sys_threat = sum([thrt for sid, thrt in ot_sys_threat])
-        tot_cur_alloc = sum([0.8*already_assigned_rating[sid] for sid, thrt in ot_sys_threat])
+        tot_cur_alloc = sum([0.8 * already_assigned_rating[sid] for sid, thrt in ot_sys_threat])
         # intentionally after tallies, but perhaps should be before
         # this supply threat calc intentionally uses a lower multiplier 0.25
         ot_sys_threat = [(sys_id, sys_threat + enemy_sup_factor[sys_id] * 0.25 * enemy_rating) for sys_id, sys_threat in ot_sys_threat]
@@ -570,7 +565,7 @@ def get_military_fleets(mil_fleets_ids=None, try_reset=True, thisround="Main"):
     accessible_system_ids = [sys_id for sys_id in visible_system_ids if universe.systemsConnected(sys_id, home_system_id, empire_id)]
     current_mil_systems = [sid for sid, alloc, take_any, multiplier in allocations if alloc > 0]
     border_targets1 = [sid for sid in accessible_system_ids if sid not in current_mil_systems]
-    border_targets = [sid for sid in border_targets1 if (threat_bias + systems_status.get(sid, {}).get('fleetThreat', 0) + systems_status.get(sid, {}).get('planetThreat', 0) > 0.8*already_assigned_rating[sid])]
+    border_targets = [sid for sid in border_targets1 if (threat_bias + systems_status.get(sid, {}).get('fleetThreat', 0) + systems_status.get(sid, {}).get('planetThreat', 0) > 0.8 * already_assigned_rating[sid])]
     if "Main" in thisround:
         if _verbose_mil_reporting:
             print
@@ -582,7 +577,7 @@ def get_military_fleets(mil_fleets_ids=None, try_reset=True, thisround="Main"):
         ot_sys_alloc = 0
         ot_sys_threat = [(o_s_id, threat_bias + safety_factor*combine_ratings(systems_status.get(o_s_id, {}).get('fleetThreat', 0), systems_status.get(o_s_id, {}).get('monsterThreat', 0) + systems_status.get(o_s_id, {}).get('planetThreat', 0))) for o_s_id in border_targets]
         totot_sys_threat = sum([thrt for sid, thrt in ot_sys_threat])
-        tot_cur_alloc = sum([0.8*already_assigned_rating[sid] for sid, thrt in ot_sys_threat])
+        tot_cur_alloc = sum([0.8 * already_assigned_rating[sid] for sid, thrt in ot_sys_threat])
         # do not add enemy supply threat here
         for sid, thrt in ot_sys_threat:
             cur_alloc = already_assigned_rating[sid]
@@ -593,7 +588,7 @@ def get_military_fleets(mil_fleets_ids=None, try_reset=True, thisround="Main"):
             if needed_rating > 0 and (remaining_mil_rating > needed_rating or take_any):
                 this_alloc = max(0, min(needed_rating, remaining_mil_rating))
                 new_alloc += this_alloc
-                max_alloc = safety_factor*2*max(systems_status.get(sid, {}).get('totalThreat', 0), systems_status.get(sid, {}).get('neighborThreat', 0))
+                max_alloc = safety_factor * 2 * max(systems_status.get(sid, {}).get('totalThreat', 0), systems_status.get(sid, {}).get('neighborThreat', 0))
                 allocations.append((sid, this_alloc, take_any, max_alloc))
                 allocation_groups.setdefault('accessibleTargets', []).append((sid, this_alloc, take_any, max_alloc))
                 remaining_mil_rating -= this_alloc
@@ -725,7 +720,7 @@ def assign_military_fleets_to_systems(use_fleet_id_list=None, allocations=None, 
         these_allocations = allocations
 
     # send_for_repair(mil_needing_repair_ids) #currently, let get taken care of by AIFleetMission.generate_fleet_orders()
-    
+
     # get systems to defend
 
     avail_mil_fleet_ids = set(avail_mil_fleet_ids)
@@ -785,4 +780,3 @@ def assign_military_fleets_to_systems(use_fleet_id_list=None, allocations=None, 
             allocations = get_military_fleets(mil_fleets_ids=avail_mil_fleet_ids, try_reset=False, thisround=thisround)
         if allocations:
             assign_military_fleets_to_systems(use_fleet_id_list=avail_mil_fleet_ids, allocations=allocations, round=round)
-

--- a/default/python/AI/MoveUtilsAI.py
+++ b/default/python/AI/MoveUtilsAI.py
@@ -26,8 +26,8 @@ def create_move_orders_to_system(fleet, target):
     # TODO: add priority
     starting_system = fleet.get_system()  # current fleet location or current target system if on starlane
     # if the mission does not end at the targeted system, make sure we can actually return to supply after moving.
-    ensure_return = target.id not in set(AIstate.colonyTargetedSystemIDs + AIstate.outpostTargetedSystemIDs
-                                         + AIstate.invasionTargetedSystemIDs + AIstate.blockadeTargetedSystemIDs)
+    ensure_return = target.id not in set(AIstate.colonyTargetedSystemIDs + AIstate.outpostTargetedSystemIDs +
+                                         AIstate.invasionTargetedSystemIDs + AIstate.blockadeTargetedSystemIDs)
     system_targets = can_travel_to_system(fleet.id, starting_system, target, ensure_return=ensure_return)
     result = [fleet_orders.OrderMove(fleet, system) for system in system_targets]
     if not result and starting_system.id != target.id:
@@ -84,10 +84,10 @@ def can_travel_to_system(fleet_id, from_system_target, to_system_target, ensure_
         elif target_sys_id in ColonisationAI.annexable_ring3 and foAI.foAIstate.character.may_travel_beyond_supply(3):
             print "target in Ring 2, has enough aggression"
     if (not unsupplied_stops or not ensure_return or
-        target_sys_id in fleet_supplyable_system_ids and len(unsupplied_stops) <= fuel
-        or target_sys_id in ColonisationAI.annexable_ring1 and len(unsupplied_stops) < fuel
-        or target_sys_id in ColonisationAI.annexable_ring2 and foAI.foAIstate.character.may_travel_beyond_supply(2) and len(unsupplied_stops) < fuel - 1
-        or target_sys_id in ColonisationAI.annexable_ring3 and foAI.foAIstate.character.may_travel_beyond_supply(3) and len(unsupplied_stops) < fuel - 2):
+        target_sys_id in fleet_supplyable_system_ids and len(unsupplied_stops) <= fuel or
+            target_sys_id in ColonisationAI.annexable_ring1 and len(unsupplied_stops) < fuel or
+            target_sys_id in ColonisationAI.annexable_ring2 and foAI.foAIstate.character.may_travel_beyond_supply(2) and len(unsupplied_stops) < fuel - 1 or
+            target_sys_id in ColonisationAI.annexable_ring3 and foAI.foAIstate.character.may_travel_beyond_supply(3) and len(unsupplied_stops) < fuel - 2):
         return [universe_object.System(sid) for sid in short_path]
     else:
         # print " getting path from 'can_travel_to_system_and_return_to_resupply' ",
@@ -97,7 +97,7 @@ def can_travel_to_system(fleet_id, from_system_target, to_system_target, ensure_
 def can_travel_to_system_and_return_to_resupply(fleet_id, from_system_target, to_system_target):
     """
     Filter systems where fleet can travel from starting system. # TODO rename function
-    
+
     :param fleet_id:
     :type fleet_id: int
     :param from_system_target:
@@ -177,9 +177,9 @@ def get_best_drydock_system_id(start_system_id, fleet_id):
             continue
         for pid in pids:
             planet = universe.getPlanet(pid)
-            if (planet
-                  and planet.currentMeterValue(fo.meterType.happiness) >= DRYDOCK_HAPPINESS_THRESHOLD
-                  and planet.currentMeterValue(fo.meterType.targetHappiness) >= DRYDOCK_HAPPINESS_THRESHOLD):
+            if (planet and
+                    planet.currentMeterValue(fo.meterType.happiness) >= DRYDOCK_HAPPINESS_THRESHOLD and
+                    planet.currentMeterValue(fo.meterType.targetHappiness) >= DRYDOCK_HAPPINESS_THRESHOLD):
                 drydock_system_ids.add(sys_id)
                 break
 

--- a/default/python/AI/PlanetUtilsAI.py
+++ b/default/python/AI/PlanetUtilsAI.py
@@ -4,6 +4,7 @@ import ColonisationAI
 from freeorion_tools import print_error
 from AIDependencies import INVALID_ID
 
+
 def safe_name(univ_object):
     return (univ_object and univ_object.name) or "?"
 
@@ -109,8 +110,8 @@ def get_owned_planets_by_empire(planet_ids):
     for pid in planet_ids:
         planet = universe.getPlanet(pid)
         # even if our universe says we own it, if we can't see it we must have lost it
-        if (planet and not planet.unowned and planet.ownedBy(empire_id)
-                and universe.getVisibility(pid, empire_id) >= fo.visibility.partial):
+        if (planet and not planet.unowned and planet.ownedBy(empire_id) and
+                universe.getVisibility(pid, empire_id) >= fo.visibility.partial):
             result.append(pid)
     return result
 

--- a/default/python/AI/PriorityAI.py
+++ b/default/python/AI/PriorityAI.py
@@ -116,7 +116,7 @@ def _calculate_research_priority():
     mgrav_prod_tech = AIDependencies.PRO_MICROGRAV_MAN
     got_mgrav_prod = tech_is_complete(mgrav_prod_tech)
     # got_solar_gen = tech_is_complete(AIDependencies.PRO_SOL_ORB_GEN)
-    
+
     milestone_techs = ["PRO_SENTIENT_AUTOMATION", "LRN_DISTRIB_THOUGHT", "LRN_QUANT_NET", "SHP_WEAPON_2_4", "SHP_WEAPON_3_2", "SHP_WEAPON_4_2"]
     milestones_done = [mstone for mstone in milestone_techs if tech_is_complete(mstone)]
     print "Research Milestones accomplished at turn %d: %s" % (current_turn, milestones_done)
@@ -166,7 +166,7 @@ def _calculate_research_priority():
             research_priority *= 0.5
         else:
             research_priority *= 0.8
-                
+
     if ((tech_is_complete("SHP_WEAPON_2_4") or
          tech_is_complete("SHP_WEAPON_4_1")) and
             tech_is_complete(AIDependencies.PROD_AUTO_NAME)):
@@ -179,7 +179,7 @@ def _calculate_research_priority():
     print "Research Production (current/target) : ( %.1f / %.1f )" % (total_rp, target_rp)
     print "Priority for Research: %d (new target ~ %d RP)" % (research_priority, total_pp * research_priority / industry_priority)
 
-    if len(enemies_sighted) < (2 + current_turn/20.0):  # TODO: adjust for colonisation priority
+    if len(enemies_sighted) < (2 + current_turn / 20.0):  # TODO: adjust for colonisation priority
         research_priority *= 1.2
     if (current_turn > 20) and (len(recent_enemies) > 3):
         research_priority *= 0.8
@@ -231,8 +231,7 @@ def _calculate_colonisation_priority():
     colony_cost = AIDependencies.COLONY_POD_COST * (1 + AIDependencies.COLONY_POD_UPKEEP * num_colonies)
     turns_to_build = 8  # TODO: check for susp anim pods, build time 10
     mil_prio = foAI.foAIstate.get_priority(PriorityType.PRODUCTION_MILITARY)
-    allotted_portion = ([[[0.6, 0.8], [0.3, 0.4]], [[0.8, 0.9], [0.4, 0.6]]][galaxy_is_sparse]
-                       [any(enemies_sighted)])
+    allotted_portion = ([[[0.6, 0.8], [0.3, 0.4]], [[0.8, 0.9], [0.4, 0.6]]][galaxy_is_sparse][any(enemies_sighted)])
     allotted_portion = foAI.foAIstate.character.preferred_colonization_portion(allotted_portion)
     # if ( foAI.foAIstate.get_priority(AIPriorityType.PRIORITY_PRODUCTION_COLONISATION)
     # > 2 * foAI.foAIstate.get_priority(AIPriorityType.PRIORITY_PRODUCTION_MILITARY)):
@@ -252,8 +251,7 @@ def _calculate_colonisation_priority():
 
     if num_colonies > colony_growth_barrier:
         return 0.0
-    num_colonisable_planet_ids = len([pid for (pid, (score, _)) in foAI.foAIstate.colonisablePlanetIDs.items()
-                                   if score > 60][:allottedColonyTargets + 2])
+    num_colonisable_planet_ids = len([pid for (pid, (score, _)) in foAI.foAIstate.colonisablePlanetIDs.items() if score > 60][:allottedColonyTargets + 2])
     if num_colonisable_planet_ids == 0:
         return 1
 
@@ -321,11 +319,11 @@ def _calculate_outpost_priority():
 
 def _calculate_invasion_priority():
     """Calculates the demand for troop ships by opponent planets."""
-    
+
     global allottedInvasionTargets
     if not foAI.foAIstate.character.may_invade():
         return 0
-    
+
     empire = fo.getEmpire()
     enemies_sighted = foAI.foAIstate.misc.get('enemies_sighted', {})
     multiplier = 1
@@ -333,7 +331,7 @@ def _calculate_invasion_priority():
     colony_growth_barrier = foAI.foAIstate.character.max_number_colonies()
     if num_colonies > colony_growth_barrier:
         return 0.0
-    
+
     if len(foAI.foAIstate.colonisablePlanetIDs) > 0:
         best_colony_score = max(2, foAI.foAIstate.colonisablePlanetIDs.items()[0][1][0])
     else:
@@ -385,7 +383,7 @@ def _calculate_invasion_priority():
             invasion_priority *= 1.5
     if not enemies_sighted:
         invasion_priority *= 1.5
-        
+
     if invasion_priority < 0:
         return 0
 
@@ -400,7 +398,7 @@ def _calculate_military_priority():
     capital_id = PlanetUtilsAI.get_capital()
     if capital_id is None or capital_id == INVALID_ID:
         return 0  # no capitol (not even a capitol-in-the-making), means can't produce any ships
-        
+
     have_l1_weaps = (tech_is_complete("SHP_WEAPON_1_4") or
                      (tech_is_complete("SHP_WEAPON_1_3") and tech_is_complete("SHP_MIL_ROBO_CONT")) or
                      tech_is_complete("SHP_WEAPON_2_1") or
@@ -408,7 +406,7 @@ def _calculate_military_priority():
     have_l2_weaps = (tech_is_complete("SHP_WEAPON_2_3") or
                      tech_is_complete("SHP_WEAPON_4_1"))
     enemies_sighted = foAI.foAIstate.misc.get('enemies_sighted', {})
-        
+
     allotted_invasion_targets = 1 + int(fo.currentTurn()/25)
     target_planet_ids = [pid for pid, pscore, trp in AIstate.invasionTargets[:allotted_invasion_targets]] + [pid for pid, pscore in foAI.foAIstate.colonisablePlanetIDs.items()[:allottedColonyTargets]] + [pid for pid, pscore in foAI.foAIstate.colonisableOutpostIDs.items()[:allottedColonyTargets]]
 
@@ -458,7 +456,7 @@ def _calculate_military_priority():
     fmt_string = "Calculating Military Priority:  min(t,40) + max(0,75 * ships_needed) \n\t  Priority: %d  \t ships_needed: %d \t defense_ships_needed: %d \t curShipRating: %.0f \t l1_weaps: %s \t enemies_sighted: %s"
     print fmt_string % (military_priority, ships_needed, defense_ships_needed, cur_ship_rating, have_l1_weaps, enemies_sighted)
     print "Source of milship demand: ", ships_needed_allocation
-    
+
     military_priority *= foAI.foAIstate.character.military_priority_scaling()
     return max(military_priority, 0)
 

--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -306,7 +306,7 @@ def generate_production_orders():
                         cost, time = empire.productionCostAndTime(production_queue[production_queue.size - 1])
                         building_expense += cost / time
 
-            if (total_pp > 40 or ((current_turn > 40) and (ColonisationAI.empire_status.get('industrialists', 0) >= 20))) and ("BLD_INDUSTRY_CENTER" in possible_building_types) and ("BLD_INDUSTRY_CENTER" not in (capital_buildings+queued_building_names)) and (building_expense < building_ratio*total_pp):
+            if (total_pp > 40 or ((current_turn > 40) and (ColonisationAI.empire_status.get('industrialists', 0) >= 20))) and ("BLD_INDUSTRY_CENTER" in possible_building_types) and ("BLD_INDUSTRY_CENTER" not in (capital_buildings + queued_building_names)) and (building_expense < building_ratio * total_pp):
                 res = fo.issueEnqueueBuildingProductionOrder("BLD_INDUSTRY_CENTER", homeworld.id)
                 print "Enqueueing BLD_INDUSTRY_CENTER, with result %d" % res
                 if res:
@@ -398,7 +398,7 @@ def generate_production_orders():
                         if num_needed > 1:
                             fo.issueChangeProductionQuantityOrder(production_queue.size - 1, 1, num_needed)
                         cost, time = empire.productionCostAndTime(production_queue[production_queue.size - 1])
-                        defense_allocation += production_queue[production_queue.size - 1].blocksize * cost/time
+                        defense_allocation += production_queue[production_queue.size - 1].blocksize * cost / time
                         fo.issueRequeueProductionOrder(production_queue.size - 1, 0)  # move to front
                         break
 
@@ -596,7 +596,7 @@ def generate_production_orders():
                             else:
                                 builder_loc_choices.append(sys_id)
                                 need_yard[sys_id] = pid
-                yard_locs.extend((colonizer_loc_choices+builder_loc_choices)[:1])  # add at most one of these non top pilot locs
+                yard_locs.extend((colonizer_loc_choices + builder_loc_choices)[:1])  # add at most one of these non top pilot locs
             new_yard_count = len(queued_building_locs)
             for sys_id in yard_locs:  # build at most 2 new asteroid yards at a time
                 if new_yard_count >= 2:
@@ -764,7 +764,7 @@ def generate_production_orders():
                     print "problem queueing %s at planet %s" % (building_name, planet_used)
 
     building_name = "BLD_BLACK_HOLE_POW_GEN"
-    if empire.buildingTypeAvailable(building_name) and  foAI.foAIstate.character.may_build_building(building_name):
+    if empire.buildingTypeAvailable(building_name) and foAI.foAIstate.character.may_build_building(building_name):
         already_got_one = False
         for pid in list(AIstate.popCtrIDs) + list(AIstate.outpostIDs):
             planet = universe.getPlanet(pid)
@@ -915,7 +915,7 @@ def generate_production_orders():
         c_pop = planet.currentMeterValue(fo.meterType.population)
         t_ind = planet.currentMeterValue(fo.meterType.targetIndustry)
         c_ind = planet.currentMeterValue(fo.meterType.industry)
-        pop_disqualified = (c_pop <= 32) or (c_pop < 0.9*t_pop)
+        pop_disqualified = (c_pop <= 32) or (c_pop < 0.9 * t_pop)
         built_camp = False
         this_spec = planet.speciesName
         safety_margin_met = ((this_spec in ColonisationAI.empire_colonizers and (len(state.get_empire_planets_with_species(this_spec)) + len(colony_ship_map.get(this_spec, [])) >= 2)) or (c_pop >= 50))
@@ -1056,7 +1056,7 @@ def generate_production_orders():
 
     building_name = "BLD_XENORESURRECTION_LAB"
     queued_xeno_lab_locs = [element.locationID for element in production_queue if element.name == building_name]
-    for pid in list(AIstate.popCtrIDs)+list(AIstate.outpostIDs):
+    for pid in list(AIstate.popCtrIDs) + list(AIstate.outpostIDs):
         if pid in queued_xeno_lab_locs or not empire.canBuild(fo.buildType.building, building_name, pid):
             continue
         res = fo.issueEnqueueBuildingProductionOrder(building_name, pid)
@@ -1177,13 +1177,13 @@ def generate_production_orders():
             loc = random.choice(build_choices)
             prod_time = best_design.productionTime(empire.empireID, loc)
             prod_cost = best_design.productionCost(empire.empireID, loc)
-            troopers_needed = max(0, int(min(0.99 + (current_turn/20.0 - total_available_troops)/max(2, prod_time - 1), total_military_ships/3 - total_troop_ships)))
+            troopers_needed = max(0, int(min(0.99 + (current_turn/20.0 - total_available_troops) / max(2, prod_time - 1), total_military_ships/3 - total_troop_ships)))
             ship_number = troopers_needed
             per_turn_cost = (float(prod_cost) / prod_time)
-            if troopers_needed > 0 and total_pp > 3*per_turn_cost*queued_troop_ships and foAI.foAIstate.character.may_produce_troops():
+            if troopers_needed > 0 and total_pp > 3 * per_turn_cost * queued_troop_ships and foAI.foAIstate.character.may_produce_troops():
                 retval = fo.issueEnqueueShipProductionOrder(best_design_id, loc)
                 if retval != 0:
-                    print "forcing %d new ship(s) to production queue: %s; per turn production cost %.1f" % (ship_number, best_design.name, ship_number*per_turn_cost)
+                    print "forcing %d new ship(s) to production queue: %s; per turn production cost %.1f" % (ship_number, best_design.name, ship_number * per_turn_cost)
                     print
                     if ship_number > 1:
                         fo.issueChangeProductionQuantityOrder(production_queue.size - 1, 1, ship_number)
@@ -1268,7 +1268,7 @@ def generate_production_orders():
             species_map.setdefault(this_spec, []).append(loc)
         colony_build_choices = []
         for pid, (score, this_spec) in foAI.foAIstate.colonisablePlanetIDs.items():
-            colony_build_choices.extend(int(math.ceil(score))*[pid2 for pid2 in species_map.get(this_spec, []) if pid2 in planet_set])
+            colony_build_choices.extend(int(math.ceil(score)) * [pid2 for pid2 in species_map.get(this_spec, []) if pid2 in planet_set])
 
         local_priorities = {}
         local_priorities.update(filtered_priorities)
@@ -1469,7 +1469,7 @@ def _print_production_queue(after_turn=False):
             element.name,
             universe.getPlanet(element.locationID),
             "%dx %d" % (element.remaining, element.blocksize),
-            "%.1f / %.1f" %(element.progress, cost),
+            "%.1f / %.1f" % (element.progress, cost),
             "%.1f" % element.allocation,
             "%d" % element.turnsLeft,
         ])

--- a/default/python/AI/ResearchAI.py
+++ b/default/python/AI/ResearchAI.py
@@ -31,6 +31,7 @@ class Choices(object):
         self.extra_asteroid_hull = rng.random() < 0.05
         self.extra_energy_hull = rng.random() < 0.05
 
+
 empire_stars = {}
 research_reqs = {}
 choices = Choices()
@@ -418,7 +419,7 @@ def generate_research_orders():
         return
     else:
         print 'New research approach is used'
-    
+
     # initializing priority functions here within generate_research_orders() to avoid import race
     if not priority_funcs:
         init()
@@ -604,8 +605,7 @@ def get_research_queue_techs():
 
 
 def exclude_tech(tech_name):
-    return ((not foAI.foAIstate.character.may_research_tech(tech_name))
-            or tech_name in TechsListsAI.unusable_techs())
+    return not foAI.foAIstate.character.may_research_tech(tech_name) or tech_name in TechsListsAI.unusable_techs()
 
 
 def generate_classic_research_orders():
@@ -625,7 +625,7 @@ def generate_classic_research_orders():
     for tline in tlines:
         print "%25s %25s %25s" % tline
     print
-    
+
     #
     # report techs currently at head of research queue
     #
@@ -712,8 +712,8 @@ def generate_classic_research_orders():
             research_queue_list = get_research_queue_techs()
             def_techs = TechsListsAI.defense_techs_1()
             for def_tech in def_techs:
-                if (foAI.foAIstate.character.may_research_tech_classic(def_tech)
-                    and def_tech not in research_queue_list[:5] and not tech_is_complete(def_tech)):
+                if (foAI.foAIstate.character.may_research_tech_classic(def_tech) and
+                        def_tech not in research_queue_list[:5] and not tech_is_complete(def_tech)):
                     res = fo.issueEnqueueTechOrder(def_tech, min(3, len(research_queue_list)))
                     print "Empire is very defensive, so attempted to fast-track %s, got result %d" % (def_tech, res)
         if False:  # with current stats of Conc Camps, disabling this fast-track
@@ -725,8 +725,8 @@ def generate_classic_research_orders():
             if "SHP_DEFLECTOR_SHIELD" in research_queue_list and foAI.foAIstate.character.may_research_tech_classic("SHP_DEFLECTOR_SHIELD"):
                 insert_idx = min(insert_idx, research_queue_list.index("SHP_DEFLECTOR_SHIELD"))
             for cc_tech in ["CON_ARCH_PSYCH", "CON_CONC_CAMP"]:
-                if (cc_tech not in research_queue_list[:insert_idx + 1] and not tech_is_complete(cc_tech)
-                    and foAI.foAIstate.character.may_research_tech_classic(cc_tech)):
+                if (cc_tech not in research_queue_list[:insert_idx+1] and not tech_is_complete(cc_tech) and
+                        foAI.foAIstate.character.may_research_tech_classic(cc_tech)):
                     res = fo.issueEnqueueTechOrder(cc_tech, insert_idx)
                     msg = "Empire is very aggressive, so attempted to fast-track %s, got result %d" % (cc_tech, res)
                     if report_adjustments:
@@ -854,8 +854,8 @@ def generate_classic_research_orders():
     #
     # check to accelerate xeno_arch
     if True:  # just to help with cold-folding /  organization
-        if (state.have_ruins and not tech_is_complete("LRN_XENOARCH")
-            and foAI.foAIstate.character.may_research_tech_classic("LRN_XENOARCH")):
+        if (state.have_ruins and not tech_is_complete("LRN_XENOARCH") and
+                foAI.foAIstate.character.may_research_tech_classic("LRN_XENOARCH")):
             if artif_minds in research_queue_list:
                 insert_idx = 7 + research_queue_list.index(artif_minds)
             elif "GRO_SYMBIOTIC_BIO" in research_queue_list:
@@ -961,8 +961,8 @@ def generate_classic_research_orders():
             if most_adequate == 0:
                 insert_idx = num_techs_accelerated
                 for xg_tech in ["GRO_XENO_GENETICS", "GRO_GENETIC_ENG"]:
-                    if (xg_tech not in research_queue_list[:1+num_techs_accelerated] and not tech_is_complete(xg_tech)
-                        and foAI.foAIstate.character.may_research_tech_classic(xg_tech)):
+                    if (xg_tech not in research_queue_list[:1+num_techs_accelerated] and not tech_is_complete(xg_tech) and
+                            foAI.foAIstate.character.may_research_tech_classic(xg_tech)):
                         res = fo.issueEnqueueTechOrder(xg_tech, insert_idx)
                         num_techs_accelerated += 1
                         msg = "Empire has poor colonizers, so attempted to fast-track %s, got result %d" % (xg_tech, res)
@@ -983,8 +983,8 @@ def generate_classic_research_orders():
             if empire.population() > ([300, 100][got_telepathy]):
                 insert_idx = num_techs_accelerated
                 for dt_ech in ["LRN_PHYS_BRAIN", "LRN_TRANSLING_THT", "LRN_PSIONICS", "LRN_DISTRIB_THOUGHT"]:
-                    if (dt_ech not in research_queue_list[:insert_idx + 2] and not tech_is_complete(dt_ech)
-                        and foAI.foAIstate.character.may_research_tech_classic(dt_ech)):
+                    if (dt_ech not in research_queue_list[:insert_idx+2] and not tech_is_complete(dt_ech) and
+                            foAI.foAIstate.character.may_research_tech_classic(dt_ech)):
                         res = fo.issueEnqueueTechOrder(dt_ech, insert_idx)
                         num_techs_accelerated += 1
                         insert_idx += 1

--- a/default/python/AI/ResourcesAI.py
+++ b/default/python/AI/ResourcesAI.py
@@ -82,10 +82,8 @@ class PlanetFocusManager(object):
         Return success or failure
         """
         info = self.raw_planet_info.get(pid)
-        success = bool(info is not None and
-                       (info.current_focus == focus
-                        or (focus in info.planet.availableFoci
-                            and fo.issueChangeFocusOrder(pid, focus))))
+        success = bool(info is not None and (
+            info.current_focus == focus or focus in info.planet.availableFoci and fo.issueChangeFocusOrder(pid, focus)))
         if success:
             if update and info.current_focus != focus:
                 universe = fo.getUniverse()
@@ -439,11 +437,8 @@ def set_planet_production_and_research_specials(focus_manager):
             if focus_manager.bake_future_focus(pid, INDUSTRY):
                 print "%s focus of planet %s (%d) (with Honeycomb) at Industry Focus" % (["set", "left"][info.current_focus == INDUSTRY], planet.name, pid)
                 continue
-        if ((([bld.buildingTypeName for bld in map(universe.getBuilding, planet.buildingIDs) if bld.buildingTypeName in
-               ["BLD_CONC_CAMP", "BLD_CONC_CAMP_REMNANT"]])
-             or ([ccspec for ccspec in planet.specials if ccspec in
-                  ["CONC_CAMP_MASTER_SPECIAL", "CONC_CAMP_SLAVE_SPECIAL"]]))
-                and INDUSTRY in planet.availableFoci):
+        if ((([bld.buildingTypeName for bld in map(universe.getBuilding, planet.buildingIDs) if bld.buildingTypeName in ["BLD_CONC_CAMP", "BLD_CONC_CAMP_REMNANT"]]) or
+                ([ccspec for ccspec in planet.specials if ccspec in ["CONC_CAMP_MASTER_SPECIAL", "CONC_CAMP_SLAVE_SPECIAL"]])) and INDUSTRY in planet.availableFoci):
             if focus_manager.bake_future_focus(pid, INDUSTRY):
                 print "%s focus of planet %s (%d) (with Concentration Camps/Remnants) at Industry Focus" % (["set", "left"][info.current_focus == INDUSTRY], planet.name, pid)
                 continue
@@ -562,10 +557,10 @@ def set_planet_industry_and_research_foci(focus_manager, priority_ratio):
         # if focus_manager.current_focus[pid] == MFocus:
         # ii = max( ii, focus_manager.possible_output[MFocus][0] )
         if ((ratio > 2.0 and target_pp < 15 and got_algo) or
-            (ratio > 2.5 and target_pp < 25 and ii > 5 and got_algo) or
-            (ratio > 3.0 and target_pp < 40 and ii > 5 and got_algo) or
-            (ratio > 4.0 and target_pp < 100 and ii > 10) or
-            ((target_rp + rr - tr) / max(0.001, target_pp - ii + ri) > 2 * priority_ratio)):  # we already have algo elegance and more RP would be too expensive, or overkill
+                (ratio > 2.5 and target_pp < 25 and ii > 5 and got_algo) or
+                (ratio > 3.0 and target_pp < 40 and ii > 5 and got_algo) or
+                (ratio > 4.0 and target_pp < 100 and ii > 10) or
+                ((target_rp + rr - tr) / max(0.001, target_pp - ii + ri) > 2 * priority_ratio)):  # we already have algo elegance and more RP would be too expensive, or overkill
             if not printed_header:
                 printed_header = True
                 print "Rejecting further Research Focus choices as too expensive:"

--- a/default/python/AI/ShipDesignAI.py
+++ b/default/python/AI/ShipDesignAI.py
@@ -221,22 +221,22 @@ class ShipDesignCache(object):
             print classname
             cache_name = print_dict[classname]
             for consider_fleet in cache_name:
-                print 4*" ", consider_fleet
+                print 4 * " ", consider_fleet
                 cache_upkeep = cache_name[consider_fleet]
                 for req_tuple in cache_upkeep:
-                    print 8*" ", req_tuple
+                    print 8 * " ", req_tuple
                     cache_reqs = cache_upkeep[req_tuple]
                     for tech_tuple in cache_reqs:
-                        print 12*" ", tech_tuple, " # relevant tech upgrades"
+                        print 12 * " ", tech_tuple, " # relevant tech upgrades"
                         cache_techs = cache_reqs[tech_tuple]
                         for species_tuple in cache_techs:
-                            print 16*" ", species_tuple, " # relevant species stats"
+                            print 16 * " ", species_tuple, " # relevant species stats"
                             cache_species = cache_techs[species_tuple]
                             for av_parts in cache_species:
-                                print 20*" ", av_parts
+                                print 20 * " ", av_parts
                                 cache_parts = cache_species[av_parts]
                                 for hullname in sorted(cache_parts, reverse=True, key=lambda x: cache_parts[x][0]):
-                                    print 24*" ", hullname, ":",
+                                    print 24 * " ", hullname, ":",
                                     print cache_parts[hullname]
         self.last_printed = copy.deepcopy(self.best_designs)
 
@@ -450,9 +450,9 @@ class ShipDesignCache(object):
                             else:
                                 a = old_part
                                 b = new_part
-                            if (self.production_cost[pid][a.name] <= self.production_cost[pid][b.name]
-                                    and {x for x in a.mountableSlotTypes} >= {x for x in b.mountableSlotTypes}
-                                    and self.production_time[pid][a.name] <= self.production_time[pid][b.name]):
+                            if (self.production_cost[pid][a.name] <= self.production_cost[pid][b.name] and
+                                    {x for x in a.mountableSlotTypes} >= {x for x in b.mountableSlotTypes} and
+                                    self.production_time[pid][a.name] <= self.production_time[pid][b.name]):
                                 self.strictly_worse_parts[a.name].append(b.name)
                                 print "Part %s is strictly worse than part %s" % (b.name, a.name)
                     break
@@ -645,9 +645,9 @@ class AdditionalSpecifications(object):
             n = 0
             d = 0
             for dmg, count in enemy_attack_stats.iteritems():
-                d += dmg*count
+                d += dmg * count
                 n += count
-            self.avg_enemy_weapon_strength = d/n
+            self.avg_enemy_weapon_strength = d / n
 
         print enemy_attack_stats, self.max_enemy_weapon_strength
 
@@ -976,8 +976,8 @@ class ShipDesigner(object):
                 elif token == AIDependencies.FUEL_PER_TURN:
                     self.fuel_per_turn = max(self.fuel_per_turn + value, self.fuel)
                 elif token == AIDependencies.STEALTH_MODIFIER:
-                    if not (AIDependencies.NO_EFFECT_WITH_CLOAKS in tokendict.get(AIDependencies.STACKING_RULES, [])
-                            and self._partclass_in_design(STEALTH)):
+                    if not (AIDependencies.NO_EFFECT_WITH_CLOAKS in tokendict.get(AIDependencies.STACKING_RULES, []) and
+                            self._partclass_in_design(STEALTH)):
                         self.stealth += value
                 # STACKING_RULES configures NO_EFFECT_WITH_CLOAKS -> ignore
                 elif token == AIDependencies.STACKING_RULES:
@@ -1232,8 +1232,7 @@ class ShipDesigner(object):
             # TODO: Check for redundance of weapons with new tech upgrade system
             # TODO: Check for redundance of hangars
             # TODO Remember to use secondaryStat as well for weapons/hangars
-            check_for_redundance = (ARMOUR | ENGINES | FUEL | SHIELDS
-                                    | STEALTH | DETECTION | TROOPS | FIGHTER_BAY) & self.useful_part_classes
+            check_for_redundance = (ARMOUR | ENGINES | FUEL | SHIELDS | STEALTH | DETECTION | TROOPS | FIGHTER_BAY) & self.useful_part_classes
             for slottype in part_dict:
                 partclass_dict = defaultdict(list)
                 for tup in part_dict[slottype]:
@@ -1253,9 +1252,9 @@ class ShipDesigner(object):
                         cost_a = local_cost_cache.get(a.name, a.productionCost(empire_id, self.pid))
                         for b in shipPartsPerClass:
                             cost_b = local_cost_cache.get(b.name, b.productionCost(empire_id, self.pid))
-                            if (b is not a
-                                    and (b.capacity/cost_b - a.capacity/cost_a) > -1e-6
-                                    and b.capacity >= a.capacity):
+                            if (b is not a and
+                                    b.capacity / cost_b - a.capacity / cost_a > -1e-6 and
+                                    b.capacity >= a.capacity):
                                 if verbose:
                                     print "removing %s because %s is better." % (a.name, b.name)
                                 part_dict[slottype].remove((a.name, a))
@@ -1281,7 +1280,7 @@ class ShipDesigner(object):
         :param num_slots: number of slots to fill
         :return: list of int: the number of parts used in the design (indexed in order as in available_parts)
         """
-        return len(available_parts)*[0] + [num_slots]  # corresponds to an entirely empty design
+        return len(available_parts) * [0] + [num_slots]  # corresponds to an entirely empty design
 
     def _combinatorial_filling(self, available_parts):
         """Fill the design using a combinatorial approach.
@@ -1668,7 +1667,10 @@ class MilitaryShipDesigner(WarShipDesigner):
         parts = [get_part_type(part) for part in available_parts]
         weapons = [part for part in parts if part.partClass in WEAPONS]
         armours = [part for part in parts if part.partClass in ARMOUR]
-        cap = lambda x: x.capacity
+
+        def cap(x):
+            return x.capacity
+
         if weapons:
             weapon_part = max(weapons, key=self._calculate_weapon_strength)
             weapon = weapon_part.name
@@ -1685,17 +1687,17 @@ class MilitaryShipDesigner(WarShipDesigner):
                 ch = Cache.production_cost[self.pid].get(self.hull.name,
                                                          self.hull.productionCost(fo.empireID(), self.pid))
                 if ca == cw:
-                    n = (s+h/a)/2
+                    n = (s + h/a) / 2
                 else:
                     p1 = a*s*ca + a*ch
-                    p2 = math.sqrt(a * (ca*s + ch) * (a*s*cw+a*ch+h*cw-h*ca))
-                    p3 = a*(ca-cw)
-                    n = max((p1+p2)/p3, (p1-p2)/p3)
+                    p2 = math.sqrt(a * (ca*s + ch) * (a*s*cw + a*ch + h*cw - h*ca))
+                    p3 = a * (ca-cw)
+                    n = max((p1+p2) / p3, (p1-p2) / p3)
                 n = int(round(n))
                 n = max(n, 1)
                 n = min(n, s)
                 # print "estimated weapon slots for %s: %d" % (self.hull.name, n)
-                ret_val[idxarmour] = s-n
+                ret_val[idxarmour] = s - n
                 ret_val[idxweapon] = n
             else:
                 ret_val[idxweapon] = num_slots
@@ -1709,7 +1711,7 @@ class MilitaryShipDesigner(WarShipDesigner):
 
     def _calc_rating_for_name(self):
         self.update_stats(ignore_species=True)
-        return self.structure*self._total_dmg()*(1+self.shields/10)
+        return self.structure * self._total_dmg() * (1 + self.shields/10)
 
 
 class CarrierShipDesigner(WarShipDesigner):
@@ -1799,7 +1801,7 @@ class CarrierShipDesigner(WarShipDesigner):
         return best_rating, best_partlist
 
     def _calc_rating_for_name(self):
-        base_rating = self.structure*self._total_dmg()*(1+self.shields/10)
+        base_rating = self.structure * self._total_dmg() * (1 + self.shields/10)
         fighter_rating = self.fighter_capacity * self.fighter_launch_rate * (.1+self.fighter_damage)
         return base_rating + fighter_rating
 
@@ -1825,14 +1827,15 @@ class TroopShipDesignerBaseClass(ShipDesigner):
         if self.troops == 0:
             return INVALID_DESIGN_RATING
         else:
-            return self.troops/self._adjusted_production_cost()
+            return self.troops / self._adjusted_production_cost()
 
     def _starting_guess(self, available_parts, num_slots):
         # fill completely with biggest troop pods. If none are available for this slot type, leave empty.
         troop_pods = [get_part_type(part) for part in available_parts if get_part_type(part).partClass in TROOPS]
-        ret_val = (len(available_parts)+1)*[0]
+        ret_val = (len(available_parts)+1) * [0]
         if troop_pods:
-            cap = lambda x: x.capacity
+            def cap(x):
+                return x.capacity
             biggest_troop_pod = max(troop_pods, key=cap).name
             try:  # we could use an if-check here but since we usually have troop pods for the slot, try is faster
                 idx = available_parts.index(biggest_troop_pod)
@@ -1909,11 +1912,11 @@ class ColonisationShipDesignerBaseClass(ShipDesigner):
     def _rating_function(self):
         if self.colonisation <= 0:  # -1 indicates no pod, 0 indicates outpost
             return INVALID_DESIGN_RATING
-        return self.colonisation*(1+0.002*(self.speed-75))/self.production_cost
+        return self.colonisation * (1 + 0.002*(self.speed - 75)) / self.production_cost
 
     def _starting_guess(self, available_parts, num_slots):
         # we want to use one and only one of the best colo pods
-        ret_val = (len(available_parts)+1)*[0]
+        ret_val = (len(available_parts)+1) * [0]
         if num_slots == 0:
             return ret_val
         parts = [get_part_type(part) for part in available_parts]
@@ -1973,7 +1976,7 @@ class OrbitalColonisationShipDesigner(ColonisationShipDesignerBaseClass):
     def _rating_function(self):
         if self.colonisation <= 0:  # -1 indicates no pod, 0 indicates outpost
             return INVALID_DESIGN_RATING
-        return self.colonisation/self.production_cost
+        return self.colonisation / self.production_cost
 
 
 class OutpostShipDesignerBaseClass(ShipDesigner):
@@ -1997,7 +2000,7 @@ class OutpostShipDesignerBaseClass(ShipDesigner):
     def _rating_function(self):
         if self.colonisation != 0:
             return INVALID_DESIGN_RATING
-        return (1+0.002*(self.speed-75))/self.production_cost
+        return (1 + 0.002*(self.speed - 75)) / self.production_cost
 
     def _class_specific_filter(self, partname_dict):
         # filter all colo pods
@@ -2009,7 +2012,7 @@ class OutpostShipDesignerBaseClass(ShipDesigner):
 
     def _starting_guess(self, available_parts, num_slots):
         # use one outpost pod as starting guess
-        ret_val = (len(available_parts)+1)*[0]
+        ret_val = (len(available_parts)+1) * [0]
         if num_slots == 0:
             return ret_val
         parts = [get_part_type(part) for part in available_parts]
@@ -2046,7 +2049,7 @@ class OrbitalOutpostShipDesigner(OutpostShipDesignerBaseClass):
     def _rating_function(self):
         if self.colonisation != 0:
             return INVALID_DESIGN_RATING
-        return 1/self.production_cost
+        return 1 / self.production_cost
 
 
 class StandardOutpostShipDesigner(OutpostShipDesignerBaseClass):
@@ -2088,7 +2091,7 @@ class OrbitalDefenseShipDesigner(ShipDesigner):
         if self.speed > 10:
             return INVALID_DESIGN_RATING
         total_dmg = self._total_dmg_vs_shields()
-        return (1+total_dmg*self.structure)/self._adjusted_production_cost()
+        return (1 + total_dmg*self.structure) / self._adjusted_production_cost()
 
     def _calc_rating_for_name(self):
         self.update_stats(ignore_species=True)
@@ -2150,7 +2153,7 @@ class KrillSpawnerShipDesigner(ShipDesigner):
 
     def _starting_guess(self, available_parts, num_slots):
         # starting guess is a design completely empty except for the krill spawner part.
-        ret_val = (len(available_parts)+1)*[0]
+        ret_val = (len(available_parts)+1) * [0]
         if num_slots == 0:
             return ret_val
         if AIDependencies.PART_KRILL_SPAWNER not in available_parts:
@@ -2165,7 +2168,7 @@ class KrillSpawnerShipDesigner(ShipDesigner):
 def _create_ship_design(design_name, hull_name, part_names, model="fighter",
                         description="", icon="", name_desc_in_string_table=False,
                         verbose=False):
-    """This is basically a wrapper around fo.issueCreateShipDesignOrder to 
+    """This is basically a wrapper around fo.issueCreateShipDesignOrder to
     also update the cache.
 
     :param design_name: the name of the design
@@ -2320,7 +2323,7 @@ def recursive_dict_diff(dict_new, dict_old, dict_diff, diff_level_threshold=0):
     --> diff = {1:2, 2:{3:4}}
 
     :type dict_new: dict
-    :type dict  _old: dict
+    :type dict_old: dict
     :param dict_diff: Difference between dict_old and dict_new, modified and filled within this function
     :type dict_diff: dict
     :param diff_level_threshold: Depth to next diff up to which non-diff entries are stored in dict_diff
@@ -2330,7 +2333,7 @@ def recursive_dict_diff(dict_new, dict_old, dict_diff, diff_level_threshold=0):
     NO_DIFF = 9999
     min_diff_level = NO_DIFF
     for key, value in dict_new.iteritems():
-        if not key in dict_old:
+        if key not in dict_old:
             dict_diff[key] = copy.deepcopy(value)
             min_diff_level = 0
         elif isinstance(value, dict):
@@ -2338,7 +2341,7 @@ def recursive_dict_diff(dict_new, dict_old, dict_diff, diff_level_threshold=0):
             min_diff_level = min(min_diff_level, this_diff_level)
             if this_diff_level > NO_DIFF and min_diff_level > diff_level_threshold:
                 del dict_diff[key]
-        elif not key in dict_old or value != dict_old[key]:
+        elif key not in dict_old or value != dict_old[key]:
                 dict_diff[key] = copy.deepcopy(value)
                 min_diff_level = 0
     return min_diff_level

--- a/default/python/AI/TechsListsAI.py
+++ b/default/python/AI/TechsListsAI.py
@@ -49,8 +49,7 @@ class TechGroup(object):
 
     def _add_remaining(self):
         """Add all remaining techs in the tech group to self._tech_queue if not already contained."""
-        all_needed_techs = set(self.economy + self.weapon + self.armor
-                               + self.misc + self.defense + self.hull)
+        all_needed_techs = set(self.economy + self.weapon + self.armor + self.misc + self.defense + self.hull)
         remaining_techs = list(all_needed_techs - set(self._tech_queue))
         self._tech_queue.extend(remaining_techs)
 
@@ -190,6 +189,7 @@ class TechGroup1SparseB(TechGroup1):
             "SHP_ZORTRIUM_PLATE",
             "SHP_SPACE_FLUX_DRIVE"
         )
+
 
 class TechGroup1SparseC(TechGroup1):
     def __init__(self):

--- a/default/python/AI/character/character_module.py
+++ b/default/python/AI/character/character_module.py
@@ -150,7 +150,7 @@ class Trait(object):
         """Return True if permitted to explore system with the given monster threat."""
         return True
 
-    def may_surge_industry(self, totalPP, totalRP):  # pylint: disable=no-self-use,unused-argument
+    def may_surge_industry(self, total_pp, total_rp):  # pylint: disable=no-self-use,unused-argument
         """Return True if permitted to surge industry as used in PriorityAI.py"""
         return True
 
@@ -316,8 +316,8 @@ class Aggression(Trait):
         return 2 + ((0.5 + self.aggression) ** 2) * fo.currentTurn() / 50.0
 
     def may_invade(self):
-        return (self.aggression > fo.aggression.turtle
-                and not (self.aggression == fo.aggression.beginner and fo.currentTurn() < 150))
+        return (self.aggression > fo.aggression.turtle and
+                not (self.aggression == fo.aggression.beginner and fo.currentTurn() < 150))
 
     def may_invade_with_bases(self):
         return self.aggression > fo.aggression.typical
@@ -410,8 +410,7 @@ class Aggression(Trait):
                                            "LRN_TRANSCEND": fo.aggression.typical}
 
     def may_research_tech_classic(self, tech):
-        return (type(self).TECH_LOWER_THRESHOLD_CLASSIC_STATIC.get(tech, fo.aggression.beginner)
-                <= self.aggression <=
+        return (type(self).TECH_LOWER_THRESHOLD_CLASSIC_STATIC.get(tech, fo.aggression.beginner) <= self.aggression <=
                 type(self).TECH_UPPER_THRESHOLD_CLASSIC_STATIC.get(tech, fo.aggression.maniacal))
 
     def attitude_to_empire(self, other_empire_id, diplomatic_logs):
@@ -497,9 +496,8 @@ class EmpireIDTrait(Trait):
         return self._modulo_two_choice(alternatives)
 
     def may_travel_beyond_supply(self, distance):
-        return (distance < 2
-                or distance <= 2 and self.aggression >= fo.aggression.typical
-                or self.aggression >= fo.aggression.aggressive)
+        return (distance < 2 or distance <= 2 and self.aggression >= fo.aggression.typical or
+                self.aggression >= fo.aggression.aggressive)
 
     # TODO remove this function as soon as old style research is gone
     # It defeats the orthogonality goal of character components for little gain
@@ -543,6 +541,7 @@ def _make_single_function_combiner(funcnamei, f_combo):
         return f_combo([getattr(x, funcnamei)(*args, **kwargs) for x in self.traits])
     return func
 
+
 # Create combiners for traits that all must be true
 for funcname in ["may_explore_system", "may_surge_industry", "may_maximize_research", "may_invade",
                  "may-invade_with_bases", "may_build_building", "may_produce_troops",
@@ -573,8 +572,10 @@ def average_not_none(llin):
         return 0
     return sum(ll) / float(len(ll))
 
+
 for funcname in ["attitude_to_empire"]:
     setattr(Character, funcname, _make_single_function_combiner(funcname, average_not_none))
+
 
 # Create combiners for traits that use the geometic mean of all not None results
 def geometric_mean_not_none(llin):
@@ -587,8 +588,10 @@ def geometric_mean_not_none(llin):
         return 1
     return math.exp(sum(map(math.log, ll)) / float(len(ll)))
 
+
 for funcname in ["warship_adjusted_production_cost_exponent"]:
     setattr(Character, funcname, _make_single_function_combiner(funcname, geometric_mean_not_none))
+
 
 def _make_most_preferred_combiner(funcnamei):
     """Make a combiner that runs the preference function for each trait and
@@ -603,6 +606,7 @@ def _make_most_preferred_combiner(funcnamei):
         return Counter.most_common(Counter(prefs), 1)[0][0]
     return _most_preferred
 
+
 # Create combiners for traits deal with preference
 for funcname in ["preferred_research_cutoff", "preferred_colonization_portion",
                  "preferred_outpost_portion", "preferred_building_ratio", "preferred_discount_multiplier"]:
@@ -616,9 +620,9 @@ def create_character(aggression=fo.aggression.maniacal, empire_id=0):
 
     # Check the optionsDB for the trait bypass values and create
     # the character.
-    NO_VALUE = -1
-    bypassed_aggression = get_trait_bypass_value("aggression", aggression, NO_VALUE)
-    bypassed_empire_id = get_trait_bypass_value("empire-id", empire_id, NO_VALUE)
+    no_value = -1
+    bypassed_aggression = get_trait_bypass_value("aggression", aggression, no_value)
+    bypassed_empire_id = get_trait_bypass_value("empire-id", empire_id, no_value)
 
     return Character([Aggression(bypassed_aggression), EmpireIDTrait(bypassed_empire_id, bypassed_aggression)])
 

--- a/default/python/AI/fleet_orders.py
+++ b/default/python/AI/fleet_orders.py
@@ -472,4 +472,3 @@ class OrderRepair(AIFleetOrder):
                 if system_id in foAI.foAIstate.needsEmergencyExploration:
                     del foAI.foAIstate.needsEmergencyExploration[foAI.foAIstate.needsEmergencyExploration.index(system_id)]
             self.order_issued = True
-

--- a/default/python/AI/freeorion_tools/_freeorion_tools.py
+++ b/default/python/AI/freeorion_tools/_freeorion_tools.py
@@ -71,9 +71,9 @@ def tech_is_complete(tech):
 def ppstring(foo):
     """
     Returns a string version of lists, dicts, sets, such that entries with special characters will be
-    printed in legible string format rather than as hex escape characters, i.e., 
+    printed in legible string format rather than as hex escape characters, i.e.,
     ['Asimov α'] rather than ['Asimov \xce\xb1']."""
-    
+
     if isinstance(foo, list):
         return "[" + ",".join(map(ppstring, foo)) + "]"
     elif isinstance(foo, dict):

--- a/default/python/AI/freeorion_tools/charts_handler.py
+++ b/default/python/AI/freeorion_tools/charts_handler.py
@@ -7,6 +7,7 @@ from PlanetUtilsAI import get_capital
 from ResearchAI import get_research_index
 from character.character_strings_module import get_trait_name_aggression
 
+
 def charting_text():
     import FreeOrionAI as foAI  # avoid circular imports
     universe = fo.getUniverse()

--- a/default/python/AI/freeorion_tools/handlers.py
+++ b/default/python/AI/freeorion_tools/handlers.py
@@ -34,5 +34,3 @@ def init_handlers(config_str, search_dir):
             print_exc()
             exit(1)
         register_pre_handler('generateOrders', charting_text)
-
-

--- a/default/python/AI/universe_object.py
+++ b/default/python/AI/universe_object.py
@@ -2,6 +2,7 @@ import sys
 import freeOrionAIInterface as fo  # pylint: disable=import-error
 from AIDependencies import INVALID_ID
 
+
 class UniverseObject(object):
     """Stores information about AI target - its id and type."""
 

--- a/default/python/common/charting/charts.py
+++ b/default/python/common/charting/charts.py
@@ -37,6 +37,7 @@ def show_only_some(x, pos):
     else:
         return ''
 
+
 doPlotTypes = ["PP + 2RP"] + ["PP"] + ["RP"] + ["RP_Ratio"]  # +[ "ShipCount"]
 
 
@@ -80,6 +81,7 @@ def parse_file(file_name, ai=True):
                 if "Empire Ship Count:" in line:
                     data['ShipCount'].append(int(line.split("Empire Ship Count:")[1]))
         return data, details
+
 
 allData = {}
 species = {}

--- a/default/python/common/configure_logging.py
+++ b/default/python/common/configure_logging.py
@@ -21,5 +21,3 @@ def redirect_logging_to_freeorion_logger():
     sys.stdout = DbgLogger()
     sys.stderr = ErrLogger()
     print 'Python stdout and stderr redirected'
-
-

--- a/default/python/common/option_tools.py
+++ b/default/python/common/option_tools.py
@@ -1,7 +1,7 @@
 import os
 import sys
 from ConfigParser import SafeConfigParser
-from collections import OrderedDict as odict
+from collections import OrderedDict
 
 AI_SUB_DIR = 'AI'
 DEFAULT_SUB_DIR = os.path.join(AI_SUB_DIR, 'default')
@@ -15,8 +15,8 @@ TIMERS_DUMP_FOLDER = 'timers_dump_folder'
 HANDLERS = 'handlers'
 
 
-flat_options = odict()
-sectioned_options = odict()
+flat_options = OrderedDict()
+sectioned_options = OrderedDict()
 
 
 def _get_option_file(config_dir):
@@ -30,15 +30,15 @@ def _get_option_file(config_dir):
 
 
 def _get_default_file_path(config_dir):
-    CONFIG_DEFAULT_DIR = os.path.join(config_dir, DEFAULT_SUB_DIR)
+    config_default_dir = os.path.join(config_dir, DEFAULT_SUB_DIR)
 
     try:
-        if os.path.isdir(config_dir) and not os.path.isdir(CONFIG_DEFAULT_DIR):
-            os.makedirs(CONFIG_DEFAULT_DIR)
+        if os.path.isdir(config_dir) and not os.path.isdir(config_default_dir):
+            os.makedirs(config_default_dir)
     except OSError:
-        sys.stderr.write("AI Config Error: could not create path %s\n" % CONFIG_DEFAULT_DIR)
+        sys.stderr.write("AI Config Error: could not create path %s\n" % config_default_dir)
         return config_dir
-    return CONFIG_DEFAULT_DIR
+    return config_default_dir
 
 
 def _get_preset_default_ai_options():
@@ -47,17 +47,19 @@ def _get_preset_default_ai_options():
     each sub-dict corresponds to a config file section
     :return:
     """
-    return odict([
-        (TIMER_SECTION, odict([
-            (TIMERS_USE_TIMERS, False),
-            (TIMERS_TO_FILE, False),
-            (TIMERS_DUMP_FOLDER, 'timers')
-        ])
-         ),
-        ('main', odict([
-            (HANDLERS, '')
-        ])
-         )  # module names in handler directory, joined by space
+    return OrderedDict([
+        (
+            TIMER_SECTION, OrderedDict([
+                (TIMERS_USE_TIMERS, False),
+                (TIMERS_TO_FILE, False),
+                (TIMERS_DUMP_FOLDER, 'timers')
+            ])
+        ),
+        (
+            'main', OrderedDict([
+                (HANDLERS, '')
+            ])
+        )  # module names in handler directory, joined by space
     ])
 
 
@@ -120,7 +122,7 @@ def parse_config(option_string, config_dir):
             sys.stderr.write("AI Config Error; could NOT read config file(s): %s\n"
                              % list(set(config_files).difference(configs_read)))
     for section in config.sections():
-        sectioned_options.setdefault(section, odict())
+        sectioned_options.setdefault(section, OrderedDict())
         for k, v in config.items(section):
             flat_options[k] = v
             sectioned_options[section][k] = v

--- a/default/python/common/timers.py
+++ b/default/python/common/timers.py
@@ -105,11 +105,9 @@ class Timer(object):
         print
         print 'Timing statistics for %s:' % self.timer_name
         print '=' * line_max_size
-
         for name in ordered_names:
             print (("{:<{name_width}} num: {:>6d}, mean: {:>6.2f} msec, std: {:>6.2f} msec, max: {:>6.2f} msec").
                    format(name, number_samples[name], means[name], stds[name], maxes[name], name_width=max_header))
-
         print '=' * line_max_size
 
     def stop_and_print(self):

--- a/default/python/handlers/inspect_freeOrionAIInterface.py
+++ b/default/python/handlers/inspect_freeOrionAIInterface.py
@@ -71,6 +71,7 @@ def inspect_ai_interface():
     )
     exit(1)  # exit game to main menu no need to play anymore.
 
+
 from common.listeners import register_pre_handler
 
 register_pre_handler('generateOrders', inspect_ai_interface)

--- a/default/python/turn_events/turn_events.py
+++ b/default/python/turn_events/turn_events.py
@@ -38,7 +38,7 @@ def execute_turn_events():
     # monster freq ranges from 1/30 (= one monster per 30 systems) to 1/3 (= one monster per 3 systems)
     # (example: low monsters and 150 Systems results in 150 / 30 * 0.01 = 0.05)
     if monster_freq > 0 and random() < len(systems) * monster_freq * 0.01:
-        #only spawn Krill at the moment, other monsters can follow in the future
+        # only spawn Krill at the moment, other monsters can follow in the future
         if random() < 1:
             monster_type = "SM_KRILL_1"
         else:

--- a/default/python/universe_generation/monsters.py
+++ b/default/python/universe_generation/monsters.py
@@ -160,11 +160,8 @@ def generate_monsters(monster_freq, systems):
                 tracked_plan_valid_locations[fp] += 1
 
         # filter out all monster fleets whose location condition allows this system and whose counter hasn't reached 0.
-        suitable_fleet_plans = [fp for fp in fleet_plans
-                                if system in fp_location_cache[fp]
-                                and spawn_limits[fp]
-                                and (fp not in fleet_can_alter_starlanes
-                                     or starlane_altering_monsters.can_place_at(system, fp))]
+        suitable_fleet_plans = [fp for fp in fleet_plans if system in fp_location_cache[fp] and spawn_limits[fp] and
+                                (fp not in fleet_can_alter_starlanes or starlane_altering_monsters.can_place_at(system, fp))]
         # if there are no suitable monster fleets for this system, continue with the next
         if not suitable_fleet_plans:
             continue

--- a/default/python/universe_generation/options.py
+++ b/default/python/universe_generation/options.py
@@ -2,9 +2,9 @@ import freeorion as fo
 from planets import planet_types_real, planet_sizes_real
 
 
-###############################
-## STAR GROUP NAMING OPTIONS ##
-###############################
+#############################
+# STAR GROUP NAMING OPTIONS #
+#############################
 
 # if star_groups_use_chars is true use entries from the stringtable entry STAR_GROUP_CHARS (single characters),
 # otherwise use words like 'Alpha' from the stringtable entry STAR_GROUP_WORDS.
@@ -22,9 +22,9 @@ TARGET_INDIV_RATIO_LARGE = 0.3  # in large galaxies, 30% of the star systems get
 NAMING_LARGE_GALAXY_SIZE = 200  # a galaxy with 200+ star systems is considered as large, below that value as small
 
 
-###################################
-## HOME SYSTEM SELECTION OPTIONS ##
-###################################
+#################################
+# HOME SYSTEM SELECTION OPTIONS #
+#################################
 
 # These options are needed in the home system selection/placement process. They determine the minimum number of
 # systems and planets that a home system must have in its near vicinity, define the extend of this "near vicinity", etc.

--- a/default/python/universe_generation/planets.py
+++ b/default/python/universe_generation/planets.py
@@ -29,10 +29,12 @@ planet_types_real = (fo.planetType.swamp, fo.planetType.radiated, fo.planetType.
 
 
 def base_chance_of_planet(planet_density, galaxy_shape, star_type, orbit, planet_size):
-    return (tables.DENSITY_MOD_TO_PLANET_SIZE_DIST[planet_density][planet_size]
-            + tables.STAR_TYPE_MOD_TO_PLANET_SIZE_DIST[star_type][planet_size]
-            + tables.ORBIT_MOD_TO_PLANET_SIZE_DIST[orbit][planet_size]
-            + tables.GALAXY_SHAPE_MOD_TO_PLANET_SIZE_DIST[galaxy_shape][planet_size])
+    return sum((
+        tables.DENSITY_MOD_TO_PLANET_SIZE_DIST[planet_density][planet_size],
+        tables.STAR_TYPE_MOD_TO_PLANET_SIZE_DIST[star_type][planet_size],
+        tables.ORBIT_MOD_TO_PLANET_SIZE_DIST[orbit][planet_size],
+        tables.GALAXY_SHAPE_MOD_TO_PLANET_SIZE_DIST[galaxy_shape][planet_size]
+    ))
 
 
 def can_have_planets(star_type, orbits, planet_density, galaxy_shape):
@@ -59,8 +61,7 @@ def calc_planet_size(star_type, orbit, planet_density, galaxy_shape):
     try:
         max_roll = 0
         for size in planet_sizes_all:
-            roll = (random.randint(1, 100)
-                    + base_chance_of_planet(planet_density, galaxy_shape, star_type, orbit, size))
+            roll = (random.randint(1, 100) + base_chance_of_planet(planet_density, galaxy_shape, star_type, orbit, size))
             if max_roll < roll:
                 max_roll = roll
                 planet_size = size

--- a/default/python/universe_generation/starnames.py
+++ b/default/python/universe_generation/starnames.py
@@ -53,7 +53,7 @@ def cluster_stars(positions, num_star_groups):
     """
     Returns a list, same size as positions argument, containing indices from 0 to num_star_groups.
     """
-    
+
     if num_star_groups > len(positions):
         return [[pos] for pos in positions]
     centers = [[pos[0], pos[1]] for pos in random.sample(positions, num_star_groups)]

--- a/default/python/universe_generation/universe_tables.py
+++ b/default/python/universe_generation/universe_tables.py
@@ -1,6 +1,5 @@
 import freeorion as fo
 
-
 #################################
 # Galaxy Generation Data Tables #
 #################################
@@ -35,13 +34,13 @@ BASE_STAR_TYPE_DIST = {
 # a table, the entry in the "Young" row and "blue" column is the bonus for blue
 # stars if you chose a Young galaxy.
 UNIVERSE_AGE_MOD_TO_STAR_TYPE_DIST = {
-#                                blue  white  yellow  orange  red  neutron  blackHole  noStar
-#                        Young:
-    fo.galaxySetupOption.low:   ( 10,    20,      0,      0,   0,       0,         0,     60),
-#                        Mature:
-    fo.galaxySetupOption.medium:( -5,     0,     10,     20,   0,      10,        10,     40),
-#                        Ancient:
-    fo.galaxySetupOption.high:  (-20,   -10,      0,     10,  20,      20,        20,     20),
+    #                                blue  white  yellow  orange  red  neutron  blackHole  noStar
+    #                        Young:
+    fo.galaxySetupOption.low: (10, 20, 0, 0, 0, 0, 0, 60),
+    #                        Mature:
+    fo.galaxySetupOption.medium: (-5, 0, 10, 20, 0, 10, 10, 40),
+    #                        Ancient:
+    fo.galaxySetupOption.high: (-20, -10, 0, 10, 20, 20, 20, 20),
 }
 
 # These following tables are as above, but for planet sizes rather than star
@@ -52,10 +51,10 @@ UNIVERSE_AGE_MOD_TO_STAR_TYPE_DIST = {
 #
 # This checks what you chose for galaxy planet density:
 DENSITY_MOD_TO_PLANET_SIZE_DIST = {
-#                                none  tiny  small  medium  large  huge  asteroids  gas giant
-    fo.galaxySetupOption.low:   ( 85,    0,     0,      0,    -5,  -10,         0,         0),
-    fo.galaxySetupOption.medium:( 70,    0,     0,      0,    -5,  -10,         0,         0),
-    fo.galaxySetupOption.high:  ( 50,    0,     0,      0,    -5,  -10,         0,         0),
+    #                                none  tiny  small  medium  large  huge  asteroids  gas giant
+    fo.galaxySetupOption.low: (85, 0, 0, 0, -5, -10, 0, 0),
+    fo.galaxySetupOption.medium: (70, 0, 0, 0, -5, -10, 0, 0),
+    fo.galaxySetupOption.high: (50, 0, 0, 0, -5, -10, 0, 0),
 }
 
 # Given the star type that was already chosen, what will the bonus be for this
@@ -64,73 +63,73 @@ DENSITY_MOD_TO_PLANET_SIZE_DIST = {
 # of that type in game.  All star types with a zero or less chance for
 # none will be forced to have at least one satellite.
 STAR_TYPE_MOD_TO_PLANET_SIZE_DIST = {
-#                           none  tiny  small  medium  large  huge  asteroids  gas giant
-    fo.starType.blue:      (  0,    0,     0,      0,    -5,  -10,         0,         0),
-    fo.starType.white:     (  0,    0,     0,      0,    -5,  -10,         0,         0),
-    fo.starType.yellow:    (  0,    0,     0,      0,    -5,  -10,         0,         0),
-    fo.starType.orange:    (  0,    0,     0,      0,    -5,  -10,         0,         0),
-    fo.starType.red:       (  0,    0,     0,      0,    -5,  -10,         0,         0),
-    fo.starType.neutron:   (  5,    0,     0,      0,    -5,  -10,        20,         0),
-    fo.starType.blackHole: ( 30,    0,     0,     -5,   -10,  -15,        10,        -5),
-    fo.starType.noStar:    ( 80,    0,     0,      0,   -10,  -15,         0,        10),
+    #                           none  tiny  small  medium  large  huge  asteroids  gas giant
+    fo.starType.blue: (0, 0, 0, 0, -5, -10, 0, 0),
+    fo.starType.white: (0, 0, 0, 0, -5, -10, 0, 0),
+    fo.starType.yellow: (0, 0, 0, 0, -5, -10, 0, 0),
+    fo.starType.orange: (0, 0, 0, 0, -5, -10, 0, 0),
+    fo.starType.red: (0, 0, 0, 0, -5, -10, 0, 0),
+    fo.starType.neutron: (5, 0, 0, 0, -5, -10, 20, 0),
+    fo.starType.blackHole: (30, 0, 0, -5, -10, -15, 10, -5),
+    fo.starType.noStar: (80, 0, 0, 0, -10, -15, 0, 10),
 }
 
 # In this one, the given is the orbit number of the planet. So the first row
 # corresponds to the planet closest to the star, the second is the next one,
 # and so on.
 ORBIT_MOD_TO_PLANET_SIZE_DIST = (
-#    none  tiny  small  medium  large  huge  asteroids  gas giant
-    ( 10,    0,    20,     10,     0,    0,         0,       -80),
-    (  5,    0,    15,     20,     5,    0,         0,       -70),
-    (  0,    0,    10,     30,    10,    5,         0,       -60),
-    (  0,    0,    10,     30,    10,    5,        10,       -30),
-    (  0,    0,    10,     20,    15,   10,        25,         0),
-    (  0,    0,     5,      5,    20,   15,        10,        30),
-    (  0,    0,     5,      5,    15,   10,         5,        30),
-    (  0,    0,    10,      5,    10,    5,         5,        30),
-    (  5,    0,    10,      5,     5,    5,         5,        30),
-    ( 10,    0,    10,      0,     0,    0,         5,        10),
+    #    none  tiny  small  medium  large  huge  asteroids  gas giant
+    (10, 0, 20, 10, 0, 0, 0, -80),
+    (5, 0, 15, 20, 5, 0, 0, -70),
+    (0, 0, 10, 30, 10, 5, 0, -60),
+    (0, 0, 10, 30, 10, 5, 10, -30),
+    (0, 0, 10, 20, 15, 10, 25, 0),
+    (0, 0, 5, 5, 20, 15, 10, 30),
+    (0, 0, 5, 5, 15, 10, 5, 30),
+    (0, 0, 10, 5, 10, 5, 5, 30),
+    (5, 0, 10, 5, 5, 5, 5, 30),
+    (10, 0, 10, 0, 0, 0, 5, 10),
 )
 
 # Bonus to the planet size based on the shape of the galaxy.
 GALAXY_SHAPE_MOD_TO_PLANET_SIZE_DIST = {
-#                                none  tiny  small  medium  large  huge  asteroids  gas giant
-    fo.galaxyShape.spiral2:    (   0,    0,     0,      0,     0,    0,         0,         0),
-    fo.galaxyShape.spiral3:    (   0,    0,     0,      0,     0,    0,         0,         0),
-    fo.galaxyShape.spiral4:    (   0,    0,     0,      0,     0,    0,         0,         0),
-    fo.galaxyShape.cluster:    (   0,    0,     0,      0,     0,    0,         0,         0),
-    fo.galaxyShape.elliptical: (   0,    0,     0,      0,     0,    0,         0,         0),
-    fo.galaxyShape.disc:       (   0,    0,     0,      0,     0,    0,         0,         0),
-    fo.galaxyShape.box:        (   0,    0,     0,      0,     0,    0,         0,         0),
-    fo.galaxyShape.irregular:  (   0,    0,     0,      0,     0,    0,         0,         0),
-    fo.galaxyShape.ring:       (   0,    0,     0,      0,     0,    0,         0,         0),
+    #                                none  tiny  small  medium  large  huge  asteroids  gas giant
+    fo.galaxyShape.spiral2: (0, 0, 0, 0, 0, 0, 0, 0),
+    fo.galaxyShape.spiral3: (0, 0, 0, 0, 0, 0, 0, 0),
+    fo.galaxyShape.spiral4: (0, 0, 0, 0, 0, 0, 0, 0),
+    fo.galaxyShape.cluster: (0, 0, 0, 0, 0, 0, 0, 0),
+    fo.galaxyShape.elliptical: (0, 0, 0, 0, 0, 0, 0, 0),
+    fo.galaxyShape.disc: (0, 0, 0, 0, 0, 0, 0, 0),
+    fo.galaxyShape.box: (0, 0, 0, 0, 0, 0, 0, 0),
+    fo.galaxyShape.irregular: (0, 0, 0, 0, 0, 0, 0, 0),
+    fo.galaxyShape.ring: (0, 0, 0, 0, 0, 0, 0, 0),
 }
 
 # Whenever any special might be placed, the following probability is the chance
 # that it actually will be (after other factors are considered).
 SPECIALS_FREQUENCY = {
-    fo.galaxySetupOption.none:    0,
-    fo.galaxySetupOption.low:    .1,
+    fo.galaxySetupOption.none: 0,
+    fo.galaxySetupOption.low: .1,
     fo.galaxySetupOption.medium: .3,
-    fo.galaxySetupOption.high:   .8,
+    fo.galaxySetupOption.high: .8,
 }
 
 # Whenever a monster might be placed, the following probability is the chance
 # that it actually will be (after other factors are considered).
 MONSTER_FREQUENCY = {
-    fo.galaxySetupOption.none:   0,
-    fo.galaxySetupOption.low:    0.033,
+    fo.galaxySetupOption.none: 0,
+    fo.galaxySetupOption.low: 0.033,
     fo.galaxySetupOption.medium: 0.125,
-    fo.galaxySetupOption.high:   0.333,
+    fo.galaxySetupOption.high: 0.333,
 }
 
 # Whenever natives might be placed on a planet, the following probability is
 # the chance that they actually will be (after other factors are considered).
 NATIVE_FREQUENCY = {
-    fo.galaxySetupOption.none:   0,
-    fo.galaxySetupOption.low:    0.083,
+    fo.galaxySetupOption.none: 0,
+    fo.galaxySetupOption.low: 0.083,
     fo.galaxySetupOption.medium: 0.143,
-    fo.galaxySetupOption.high:   0.200,
+    fo.galaxySetupOption.high: 0.200,
 }
 
 # This is the maximum size of the shortest path via starlane that the generator
@@ -138,9 +137,9 @@ NATIVE_FREQUENCY = {
 # map will end up with more starlanes to create enough connections between adjacent
 # systems.
 MAX_JUMPS_BETWEEN_SYSTEMS = {
-    fo.galaxySetupOption.low:    8,
+    fo.galaxySetupOption.low: 8,
     fo.galaxySetupOption.medium: 3,
-    fo.galaxySetupOption.high:   1,
+    fo.galaxySetupOption.high: 1,
 }
 
 # The maximum length of any starlane the galaxy generator can create (in uu).

--- a/default/python/universe_generation/universe_tables.py
+++ b/default/python/universe_generation/universe_tables.py
@@ -1,5 +1,6 @@
 import freeorion as fo
 
+
 #################################
 # Galaxy Generation Data Tables #
 #################################
@@ -34,13 +35,13 @@ BASE_STAR_TYPE_DIST = {
 # a table, the entry in the "Young" row and "blue" column is the bonus for blue
 # stars if you chose a Young galaxy.
 UNIVERSE_AGE_MOD_TO_STAR_TYPE_DIST = {
-    #                                blue  white  yellow  orange  red  neutron  blackHole  noStar
-    #                        Young:
-    fo.galaxySetupOption.low: (10, 20, 0, 0, 0, 0, 0, 60),
-    #                        Mature:
-    fo.galaxySetupOption.medium: (-5, 0, 10, 20, 0, 10, 10, 40),
-    #                        Ancient:
-    fo.galaxySetupOption.high: (-20, -10, 0, 10, 20, 20, 20, 20),
+#                                blue  white  yellow  orange  red  neutron  blackHole  noStar
+#                        Young:
+    fo.galaxySetupOption.low:   ( 10,    20,      0,      0,   0,       0,         0,     60),
+#                        Mature:
+    fo.galaxySetupOption.medium:( -5,     0,     10,     20,   0,      10,        10,     40),
+#                        Ancient:
+    fo.galaxySetupOption.high:  (-20,   -10,      0,     10,  20,      20,        20,     20),
 }
 
 # These following tables are as above, but for planet sizes rather than star
@@ -51,10 +52,10 @@ UNIVERSE_AGE_MOD_TO_STAR_TYPE_DIST = {
 #
 # This checks what you chose for galaxy planet density:
 DENSITY_MOD_TO_PLANET_SIZE_DIST = {
-    #                                none  tiny  small  medium  large  huge  asteroids  gas giant
-    fo.galaxySetupOption.low: (85, 0, 0, 0, -5, -10, 0, 0),
-    fo.galaxySetupOption.medium: (70, 0, 0, 0, -5, -10, 0, 0),
-    fo.galaxySetupOption.high: (50, 0, 0, 0, -5, -10, 0, 0),
+#                                none  tiny  small  medium  large  huge  asteroids  gas giant
+    fo.galaxySetupOption.low:   ( 85,    0,     0,      0,    -5,  -10,         0,         0),
+    fo.galaxySetupOption.medium:( 70,    0,     0,      0,    -5,  -10,         0,         0),
+    fo.galaxySetupOption.high:  ( 50,    0,     0,      0,    -5,  -10,         0,         0),
 }
 
 # Given the star type that was already chosen, what will the bonus be for this
@@ -63,73 +64,73 @@ DENSITY_MOD_TO_PLANET_SIZE_DIST = {
 # of that type in game.  All star types with a zero or less chance for
 # none will be forced to have at least one satellite.
 STAR_TYPE_MOD_TO_PLANET_SIZE_DIST = {
-    #                           none  tiny  small  medium  large  huge  asteroids  gas giant
-    fo.starType.blue: (0, 0, 0, 0, -5, -10, 0, 0),
-    fo.starType.white: (0, 0, 0, 0, -5, -10, 0, 0),
-    fo.starType.yellow: (0, 0, 0, 0, -5, -10, 0, 0),
-    fo.starType.orange: (0, 0, 0, 0, -5, -10, 0, 0),
-    fo.starType.red: (0, 0, 0, 0, -5, -10, 0, 0),
-    fo.starType.neutron: (5, 0, 0, 0, -5, -10, 20, 0),
-    fo.starType.blackHole: (30, 0, 0, -5, -10, -15, 10, -5),
-    fo.starType.noStar: (80, 0, 0, 0, -10, -15, 0, 10),
+#                           none  tiny  small  medium  large  huge  asteroids  gas giant
+    fo.starType.blue:      (  0,    0,     0,      0,    -5,  -10,         0,         0),
+    fo.starType.white:     (  0,    0,     0,      0,    -5,  -10,         0,         0),
+    fo.starType.yellow:    (  0,    0,     0,      0,    -5,  -10,         0,         0),
+    fo.starType.orange:    (  0,    0,     0,      0,    -5,  -10,         0,         0),
+    fo.starType.red:       (  0,    0,     0,      0,    -5,  -10,         0,         0),
+    fo.starType.neutron:   (  5,    0,     0,      0,    -5,  -10,        20,         0),
+    fo.starType.blackHole: ( 30,    0,     0,     -5,   -10,  -15,        10,        -5),
+    fo.starType.noStar:    ( 80,    0,     0,      0,   -10,  -15,         0,        10),
 }
 
 # In this one, the given is the orbit number of the planet. So the first row
 # corresponds to the planet closest to the star, the second is the next one,
 # and so on.
 ORBIT_MOD_TO_PLANET_SIZE_DIST = (
-    #    none  tiny  small  medium  large  huge  asteroids  gas giant
-    (10, 0, 20, 10, 0, 0, 0, -80),
-    (5, 0, 15, 20, 5, 0, 0, -70),
-    (0, 0, 10, 30, 10, 5, 0, -60),
-    (0, 0, 10, 30, 10, 5, 10, -30),
-    (0, 0, 10, 20, 15, 10, 25, 0),
-    (0, 0, 5, 5, 20, 15, 10, 30),
-    (0, 0, 5, 5, 15, 10, 5, 30),
-    (0, 0, 10, 5, 10, 5, 5, 30),
-    (5, 0, 10, 5, 5, 5, 5, 30),
-    (10, 0, 10, 0, 0, 0, 5, 10),
+#    none  tiny  small  medium  large  huge  asteroids  gas giant
+    ( 10,    0,    20,     10,     0,    0,         0,       -80),
+    (  5,    0,    15,     20,     5,    0,         0,       -70),
+    (  0,    0,    10,     30,    10,    5,         0,       -60),
+    (  0,    0,    10,     30,    10,    5,        10,       -30),
+    (  0,    0,    10,     20,    15,   10,        25,         0),
+    (  0,    0,     5,      5,    20,   15,        10,        30),
+    (  0,    0,     5,      5,    15,   10,         5,        30),
+    (  0,    0,    10,      5,    10,    5,         5,        30),
+    (  5,    0,    10,      5,     5,    5,         5,        30),
+    ( 10,    0,    10,      0,     0,    0,         5,        10),
 )
 
 # Bonus to the planet size based on the shape of the galaxy.
 GALAXY_SHAPE_MOD_TO_PLANET_SIZE_DIST = {
-    #                                none  tiny  small  medium  large  huge  asteroids  gas giant
-    fo.galaxyShape.spiral2: (0, 0, 0, 0, 0, 0, 0, 0),
-    fo.galaxyShape.spiral3: (0, 0, 0, 0, 0, 0, 0, 0),
-    fo.galaxyShape.spiral4: (0, 0, 0, 0, 0, 0, 0, 0),
-    fo.galaxyShape.cluster: (0, 0, 0, 0, 0, 0, 0, 0),
-    fo.galaxyShape.elliptical: (0, 0, 0, 0, 0, 0, 0, 0),
-    fo.galaxyShape.disc: (0, 0, 0, 0, 0, 0, 0, 0),
-    fo.galaxyShape.box: (0, 0, 0, 0, 0, 0, 0, 0),
-    fo.galaxyShape.irregular: (0, 0, 0, 0, 0, 0, 0, 0),
-    fo.galaxyShape.ring: (0, 0, 0, 0, 0, 0, 0, 0),
+#                                none  tiny  small  medium  large  huge  asteroids  gas giant
+    fo.galaxyShape.spiral2:    (   0,    0,     0,      0,     0,    0,         0,         0),
+    fo.galaxyShape.spiral3:    (   0,    0,     0,      0,     0,    0,         0,         0),
+    fo.galaxyShape.spiral4:    (   0,    0,     0,      0,     0,    0,         0,         0),
+    fo.galaxyShape.cluster:    (   0,    0,     0,      0,     0,    0,         0,         0),
+    fo.galaxyShape.elliptical: (   0,    0,     0,      0,     0,    0,         0,         0),
+    fo.galaxyShape.disc:       (   0,    0,     0,      0,     0,    0,         0,         0),
+    fo.galaxyShape.box:        (   0,    0,     0,      0,     0,    0,         0,         0),
+    fo.galaxyShape.irregular:  (   0,    0,     0,      0,     0,    0,         0,         0),
+    fo.galaxyShape.ring:       (   0,    0,     0,      0,     0,    0,         0,         0),
 }
 
 # Whenever any special might be placed, the following probability is the chance
 # that it actually will be (after other factors are considered).
 SPECIALS_FREQUENCY = {
-    fo.galaxySetupOption.none: 0,
-    fo.galaxySetupOption.low: .1,
+    fo.galaxySetupOption.none:    0,
+    fo.galaxySetupOption.low:    .1,
     fo.galaxySetupOption.medium: .3,
-    fo.galaxySetupOption.high: .8,
+    fo.galaxySetupOption.high:   .8,
 }
 
 # Whenever a monster might be placed, the following probability is the chance
 # that it actually will be (after other factors are considered).
 MONSTER_FREQUENCY = {
-    fo.galaxySetupOption.none: 0,
-    fo.galaxySetupOption.low: 0.033,
+    fo.galaxySetupOption.none:   0,
+    fo.galaxySetupOption.low:    0.033,
     fo.galaxySetupOption.medium: 0.125,
-    fo.galaxySetupOption.high: 0.333,
+    fo.galaxySetupOption.high:   0.333,
 }
 
 # Whenever natives might be placed on a planet, the following probability is
 # the chance that they actually will be (after other factors are considered).
 NATIVE_FREQUENCY = {
-    fo.galaxySetupOption.none: 0,
-    fo.galaxySetupOption.low: 0.083,
+    fo.galaxySetupOption.none:   0,
+    fo.galaxySetupOption.low:    0.083,
     fo.galaxySetupOption.medium: 0.143,
-    fo.galaxySetupOption.high: 0.200,
+    fo.galaxySetupOption.high:   0.200,
 }
 
 # This is the maximum size of the shortest path via starlane that the generator
@@ -137,9 +138,9 @@ NATIVE_FREQUENCY = {
 # map will end up with more starlanes to create enough connections between adjacent
 # systems.
 MAX_JUMPS_BETWEEN_SYSTEMS = {
-    fo.galaxySetupOption.low: 8,
+    fo.galaxySetupOption.low:    8,
     fo.galaxySetupOption.medium: 3,
-    fo.galaxySetupOption.high: 1,
+    fo.galaxySetupOption.high:   1,
 }
 
 # The maximum length of any starlane the galaxy generator can create (in uu).


### PR DESCRIPTION
This is massive style cleanup for python code.  It is preparation for #1296

I use [pycodestyle](https://pypi.python.org/pypi/pycodestyle) for checks:  

`pycodestyle . --ignore=E501,E402,E226,E722`

- `E226 missing whitespace around arithmetic operator`(asymmetrical number of  whitespaces around operators, this is freeorion code style, approved by @Dilvish-fo, also it is in default ignore list of tool)
- `E402 module level import not at top of file`  will fix later, I expect conflicts with logging branch
- `E501 line too long (87 > 79 characters)` too many of them
- `E722 do not use bare except'`  will fix this in different branch

Result:
- one false-positive item (`E305 expected 2 blank lines after class or function definition, found 1`)
