### PR TITLE
Fix bug #1330 ~ServerApp() is never called.

### DIFF
--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -99,7 +99,9 @@ void AIClientApp::operator()()
 
 void AIClientApp::Exit(int code) {
     DebugLogger() << "Initiating Exit (code " << code << " - " << (code ? "error" : "normal") << " termination)";
-    exit(code);
+    if (code)
+        exit(code);
+    throw NormalExitException();
 }
 
 int AIClientApp::EffectsProcessingThreads() const
@@ -142,6 +144,8 @@ void AIClientApp::Run() {
                     throw;
             }
         }
+    } catch (const NormalExitException&) {
+        // intentionally empty.
     } catch (boost::python::error_already_set) {
         HandlePythonAICrash();
     }

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -91,7 +91,7 @@ AIClientApp::~AIClientApp() {
     if (Networking().Connected())
         Networking().DisconnectFromServer();
 
-    DebugLogger() << "Shutting down " + PlayerName() + " ai client.";
+    DebugLogger() << "Shut down " + PlayerName() + " ai client.";
 }
 
 void AIClientApp::operator()()

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -170,7 +170,10 @@ void ServerApp::operator()()
 
 void ServerApp::SignalHandler(const boost::system::error_code& error, int signal_number) {
     if (!error)
-        Exit(1);
+        throw NormalExitException();
+
+    ErrorLogger() << "Exiting due to OS error (" << error.value() << ") " << error.message();
+    Exit(1);
 }
 
 void ServerApp::Exit(int code) {

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -433,7 +433,7 @@ void ServerApp::HandleShutdownMessage(const Message& msg, PlayerConnectionPtr pl
         return;
     }
     DebugLogger() << "ServerApp::HandleShutdownMessage shutting down";
-    Exit(1);
+    Exit(0);
 }
 
 void ServerApp::HandleNonPlayerMessage(const Message& msg, PlayerConnectionPtr player_connection) {
@@ -447,7 +447,7 @@ void ServerApp::HandleNonPlayerMessage(const Message& msg, PlayerConnectionPtr p
         if ((m_networking.size() == 1) && (player_connection->IsLocalConnection()) && (msg.Type() == Message::SHUT_DOWN_SERVER)) {
             DebugLogger() << "ServerApp::HandleNonPlayerMessage received Message::SHUT_DOWN_SERVER from the sole "
                                    << "connected player, who is local and so the request is being honored; server shutting down.";
-                                   Exit(1);
+                                   Exit(0);
         } else {
             ErrorLogger() << "ServerApp::HandleNonPlayerMessage : Received an invalid message type \""
                                             << msg.Type() << "\" for a non-player Message.  Terminating connection.";

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -74,10 +74,6 @@ namespace {
             }
         }
     }
-
-    // NormalExitException is used to break out of the run loop, without called terminate and
-    // failing to unroll the stack.
-    class NormalExitException {};
 };
 
 ////////////////////////////////////////////////

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -155,7 +155,7 @@ ServerApp::ServerApp() :
 
     if (!m_python_server.Initialize()) {
         ErrorLogger() << "Server's python interpreter failed to initialize.";
-        Exit(1);
+        Exit(0);
     }
 
     m_signals.async_wait(boost::bind(&ServerApp::SignalHandler, this, _1, _2));
@@ -1275,7 +1275,7 @@ void ServerApp::GenerateUniverse(std::map<int, PlayerSetupData>& player_setup_da
         m_python_server.HandleErrorAlreadySet();
         if (!m_python_server.IsPythonRunning()) {
             ErrorLogger() << "Python interpreter is no longer running.  Exiting.";
-            Exit(1);
+            Exit(0);
         }
     }
 
@@ -1328,7 +1328,7 @@ void ServerApp::ExecuteScriptedTurnEvents() {
                 ErrorLogger() << "Python interpreter successfully restarted.";
             } else {
                 ErrorLogger() << "Python interpreter failed to restart.  Exiting.";
-                Exit(1);
+                Exit(0);
             }
         }
     }

--- a/util/AppInterface.h
+++ b/util/AppInterface.h
@@ -77,6 +77,10 @@ protected:
 
     static IApp* s_app; ///< a IApp pointer to the singleton instance of the app
 
+    // NormalExitException is used to break out of the run loop, without calling
+    // terminate and failing to unroll the stack.
+    class NormalExitException {};
+
 private:
     const IApp& operator=(const IApp&); // disabled
     IApp(const IApp&); // disabled


### PR DESCRIPTION
This PR fixes [#1330 ~ServerApp never called](https://github.com/freeorion/freeorion/issues/1330).

The problem was that the ServerApp (and the AIClient) were calling `Exit(1)` which called `exit(1)` in the normal shutdown of the server via a user message.  This in turn throws an exception, which because it is at the top level calls `terminate()` which the C++ standard require to exit the application without unrolling the stack.  Hence `~ServerApp()` is never called.

The solution is to catch the normal exit conditions.  So I added `NormalExitException` to the `AppInterface` to be thrown and caught during normal operation.

The human client is immune to this problem, because it already uses a similar construction within the SDLGUI code. 

I expanded the meaning of normal exit to include crashed python environment.  This condition is adequately reported in the log files, there is no information in any stacktrace and preventing the application from exiting cleanly is unwarranted. 