### PR TITLE
Change asteroid building requirements.

### DIFF
--- a/default/scripting/buildings/NEUTRONIUM_FORGE.focs.txt
+++ b/default/scripting/buildings/NEUTRONIUM_FORGE.focs.txt
@@ -6,6 +6,7 @@ BuildingType
     tags = "ORBITAL"
     location = And [
         Planet
+        OwnedBy empire = Source.Owner
         Not Contains Building name = "BLD_NEUTRONIUM_FORGE"
         Contains And [
             Building name = "BLD_SHIPYARD_BASE"
@@ -17,7 +18,6 @@ BuildingType
                 Building name = "BLD_NEUTRONIUM_EXTRACTOR"
                 Building name = "BLD_NEUTRONIUM_SYNTH"
             ]
-        OwnedBy empire = Source.Owner
         ]
         TargetPopulation low = 1
     ]

--- a/default/scripting/buildings/shipyards/ASTEROID.focs.txt
+++ b/default/scripting/buildings/shipyards/ASTEROID.focs.txt
@@ -9,10 +9,12 @@ BuildingType
         Planet type = Asteroids
         OwnedBy empire = Source.Owner
 
-        /* TODO: Check that one, seems to be weird */
-        Not Contains And [
-            Building name = "BLD_SHIPYARD_AST"
-            OwnedBy empire = Source.Owner
+        ContainedBy And [
+            System 
+            Contains And [
+                Building name = "BLD_SHIPYARD_BASE"
+                OwnedBy empire = Source.Owner
+            ]
         ]
     ]
     EnqueueLocation = [[ENQUEUE_BUILD_ONE_PER_PLANET]]

--- a/default/scripting/buildings/shipyards/ASTEROID_REF.focs.txt
+++ b/default/scripting/buildings/shipyards/ASTEROID_REF.focs.txt
@@ -8,17 +8,6 @@ BuildingType
         Not Contains Building name = "BLD_SHIPYARD_AST_REF"
         Planet type = Asteroids
         OwnedBy empire = Source.Owner
-        Or  [
-            Contains And [
-                Building name = "BLD_SHIPYARD_AST"
-                OwnedBy empire = Source.Owner
-                ]
-            Enqueued type = Building name = "BLD_SHIPYARD_AST"
-            ]
-        Not Contains And [
-            Building name = "BLD_SHIPYARD_AST_REF"
-            OwnedBy empire = Source.Owner
-        ]
     ]
     EnqueueLocation = [[ENQUEUE_BUILD_ONE_PER_PLANET]]
     icon = "icons/building/shipyard-6.png"

--- a/default/scripting/ship_hulls/asteroid/SH_AGREGATE_ASTEROID.disabled
+++ b/default/scripting/ship_hulls/asteroid/SH_AGREGATE_ASTEROID.disabled
@@ -48,6 +48,20 @@ Hull
                 OwnedBy empire = Source.Owner
             ]
         ]
+        ResourceSupplyConnected empire = Source.Owner condition = And [
+             Building name = "BLD_SHIPYARD_AST"
+             Or [
+                 OwnedBy empire = Source.Owner
+                 OwnedBy affiliation = AllyOf empire = Source.Owner
+             ]
+        ]
+        ResourceSupplyConnected empire = Source.Owner condition = And [
+             Building name = "BLD_SHIPYARD_AST_REF"
+             Or [
+                 OwnedBy empire = Source.Owner
+                 OwnedBy affiliation = AllyOf empire = Source.Owner
+             ]
+        ]
     ]
     effectsgroups = [
         EffectsGroup

--- a/default/scripting/ship_hulls/asteroid/SH_ASTEROID.focs.txt
+++ b/default/scripting/ship_hulls/asteroid/SH_ASTEROID.focs.txt
@@ -29,6 +29,13 @@ Hull
                 OwnedBy empire = Source.Owner
             ]
         ]
+        ResourceSupplyConnected empire = Source.Owner condition = And [
+             Building name = "BLD_SHIPYARD_AST"
+             Or [
+                 OwnedBy empire = Source.Owner
+                 OwnedBy affiliation = AllyOf empire = Source.Owner
+             ]
+        ]
     ]
     effectsgroups = [
         [[AVERAGE_BASE_FUEL_REGEN]]

--- a/default/scripting/ship_hulls/asteroid/SH_CAMOUFLAGE_ASTEROID.focs.txt
+++ b/default/scripting/ship_hulls/asteroid/SH_CAMOUFLAGE_ASTEROID.focs.txt
@@ -26,6 +26,13 @@ Hull
                 OwnedBy empire = Source.Owner
             ]
         ]
+        ResourceSupplyConnected empire = Source.Owner condition = And [
+             Building name = "BLD_SHIPYARD_AST"
+             Or [
+                 OwnedBy empire = Source.Owner
+                 OwnedBy affiliation = AllyOf empire = Source.Owner
+             ]
+        ]
     ]
     effectsgroups = [
         EffectsGroup

--- a/default/scripting/ship_hulls/asteroid/SH_CRYSTALLIZED_ASTEROID.focs.txt
+++ b/default/scripting/ship_hulls/asteroid/SH_CRYSTALLIZED_ASTEROID.focs.txt
@@ -35,6 +35,20 @@ Hull
                 OwnedBy empire = Source.Owner
             ]
         ]
+        ResourceSupplyConnected empire = Source.Owner condition = And [
+             Building name = "BLD_SHIPYARD_AST"
+             Or [
+                 OwnedBy empire = Source.Owner
+                 OwnedBy affiliation = AllyOf empire = Source.Owner
+             ]
+        ]
+        ResourceSupplyConnected empire = Source.Owner condition = And [
+             Building name = "BLD_SHIPYARD_AST_REF"
+             Or [
+                 OwnedBy empire = Source.Owner
+                 OwnedBy affiliation = AllyOf empire = Source.Owner
+             ]
+        ]
     ]
     effectsgroups = [
         [[AVERAGE_BASE_FUEL_REGEN]]

--- a/default/scripting/ship_hulls/asteroid/SH_HEAVY_ASTEROID.focs.txt
+++ b/default/scripting/ship_hulls/asteroid/SH_HEAVY_ASTEROID.focs.txt
@@ -31,6 +31,13 @@ Hull
                 OwnedBy empire = Source.Owner
             ]
         ]
+        ResourceSupplyConnected empire = Source.Owner condition = And [
+             Building name = "BLD_SHIPYARD_AST"
+             Or [
+                 OwnedBy empire = Source.Owner
+                 OwnedBy affiliation = AllyOf empire = Source.Owner
+             ]
+        ]
     ]
     effectsgroups = [
         [[AVERAGE_BASE_FUEL_REGEN]]

--- a/default/scripting/ship_hulls/asteroid/SH_MINIASTEROID_SWARM.focs.txt
+++ b/default/scripting/ship_hulls/asteroid/SH_MINIASTEROID_SWARM.focs.txt
@@ -31,6 +31,20 @@ Hull
                 OwnedBy empire = Source.Owner
             ]
         ]
+        ResourceSupplyConnected empire = Source.Owner condition = And [
+             Building name = "BLD_SHIPYARD_AST"
+             Or [
+                 OwnedBy empire = Source.Owner
+                 OwnedBy affiliation = AllyOf empire = Source.Owner
+             ]
+        ]
+        ResourceSupplyConnected empire = Source.Owner condition = And [
+             Building name = "BLD_SHIPYARD_AST_REF"
+             Or [
+                 OwnedBy empire = Source.Owner
+                 OwnedBy affiliation = AllyOf empire = Source.Owner
+             ]
+        ]
     ]
     effectsgroups = [
         [[ASTEROID_FIELD_STEALTH_BONUS]]

--- a/default/scripting/ship_hulls/asteroid/SH_SCATTERED_ASTEROID.focs.txt
+++ b/default/scripting/ship_hulls/asteroid/SH_SCATTERED_ASTEROID.focs.txt
@@ -49,6 +49,20 @@ Hull
                 OwnedBy empire = Source.Owner
             ]
         ]
+        ResourceSupplyConnected empire = Source.Owner condition = And [
+             Building name = "BLD_SHIPYARD_AST"
+             Or [
+                 OwnedBy empire = Source.Owner
+                 OwnedBy affiliation = AllyOf empire = Source.Owner
+             ]
+        ]
+        ResourceSupplyConnected empire = Source.Owner condition = And [
+             Building name = "BLD_SHIPYARD_AST_REF"
+             Or [
+                 OwnedBy empire = Source.Owner
+                 OwnedBy affiliation = AllyOf empire = Source.Owner
+             ]
+        ]
     ]
     effectsgroups = [
         EffectsGroup

--- a/default/scripting/ship_hulls/asteroid/SH_SMALL_ASTEROID.focs.txt
+++ b/default/scripting/ship_hulls/asteroid/SH_SMALL_ASTEROID.focs.txt
@@ -24,6 +24,13 @@ Hull
                 OwnedBy empire = Source.Owner
             ]
         ]
+        ResourceSupplyConnected empire = Source.Owner condition = And [
+             Building name = "BLD_SHIPYARD_AST"
+             Or [
+                 OwnedBy empire = Source.Owner
+                 OwnedBy affiliation = AllyOf empire = Source.Owner
+             ]
+        ]
     ]
     effectsgroups = [
         [[AVERAGE_BASE_FUEL_REGEN]]

--- a/default/scripting/ship_hulls/asteroid/SH_SMALL_CAMOUFLAGE_ASTEROID.focs.txt
+++ b/default/scripting/ship_hulls/asteroid/SH_SMALL_CAMOUFLAGE_ASTEROID.focs.txt
@@ -24,6 +24,13 @@ Hull
                 OwnedBy empire = Source.Owner
             ]
         ]
+        ResourceSupplyConnected empire = Source.Owner condition = And [
+             Building name = "BLD_SHIPYARD_AST"
+             Or [
+                 OwnedBy empire = Source.Owner
+                 OwnedBy affiliation = AllyOf empire = Source.Owner
+             ]
+        ]
     ]
     effectsgroups = [
         [[AVERAGE_BASE_FUEL_REGEN]]

--- a/default/scripting/ship_parts/Armor.focs.txt
+++ b/default/scripting/ship_parts/Armor.focs.txt
@@ -93,7 +93,7 @@ Part
     location = And [
         OwnedBy empire = Source.Owner
         Contains Building name = "BLD_NEUTRONIUM_FORGE"
-        Number low = 1 high = 999 condition = And [
+        ResourceSupplyConnected empire = Source.Owner condition = And [
             OwnedBy empire = Source.Owner
             Or [
                 Building name = "BLD_NEUTRONIUM_EXTRACTOR"

--- a/default/scripting/ship_parts/Armor.focs.txt
+++ b/default/scripting/ship_parts/Armor.focs.txt
@@ -51,7 +51,7 @@ Part
     buildcost = 6 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildtime = 2
     location = And [
-        Number low = 1 high = 999 condition = And [
+        ResourceSupplyConnected empire = Source.Owner condition = And [
             Building name = "BLD_SHIPYARD_AST_REF"
             Or [
                 OwnedBy empire = Source.Owner
@@ -71,7 +71,7 @@ Part
     buildcost = 8 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildtime = 3
     location = And [
-        Number low = 1 high = 999 condition = And [
+        ResourceSupplyConnected empire = Source.Owner condition = And [
             Building name = "BLD_SHIPYARD_AST_REF"
             Or [
                 OwnedBy empire = Source.Owner

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -10697,7 +10697,7 @@ BLD_SHIPYARD_AST
 Asteroid Processor
 
 BLD_SHIPYARD_AST_DESC
-'''This building is required for the production of all asteroid hulls and all further asteroid processor upgrades. This building can only be built on an asteroid belt, which also can be an [[encyclopedia OUTPOSTS_TITLE]].
+'''This building is required for the production of all asteroid hulls and for further asteroid processor upgrades. This building can only be built at an [[encyclopedia OUTPOSTS_TITLE]], on an asteroid belt, in a system with a [[buildingtype BLD_SHIPYARD_BASE]].
 
 A massive processing plant dedicated to the purpose of hollowing out asteroids and preparing them to be used as ships' hulls. Asteroids thus prepared are sent to a [[buildingtype BLD_SHIPYARD_BASE]] in the same system, where they are turned into the final hull.'''
 
@@ -10705,9 +10705,9 @@ BLD_SHIPYARD_AST_REF
 Asteroid Reformation Processor
 
 BLD_SHIPYARD_AST_REF_DESC
-'''This is an upgrade to the [[buildingtype BLD_SHIPYARD_AST]] and allows production of [[shiphull SH_MINIASTEROID_SWARM]]s, [[shiphull SH_SCATTERED_ASTEROID]]s, and [[shiphull SH_CRYSTALLIZED_ASTEROID]]s. In addition, this processor upgrade allows any shipyard in the empire or an ally's empire to produce ships with the [[shippart AR_ROCK_PLATE]] and [[shippart AR_CRYSTAL_PLATE]] ship parts.
+'''This building can be built on its own or as an upgrade to the [[buildingtype BLD_SHIPYARD_AST]].   On its own, this processor allows any shipyard in the empire or an ally's empire to produce ships with the [[shippart AR_ROCK_PLATE]] and [[shippart AR_CRYSTAL_PLATE]] ship parts.  As an upgrade to the [[buildingtype BLD_SHIPYARD_AST]], it allows production of [[shiphull SH_MINIASTEROID_SWARM]]s, [[shiphull SH_SCATTERED_ASTEROID]]s, and [[shiphull SH_CRYSTALLIZED_ASTEROID]]s. 
 
-An extensive facility dedicated to fusing, shattering, deconstructing and rebuilding preexisting asteroids to form ship's parts and prepare them to be used as hulls.'''
+An extensive facility dedicated to fusing, shattering, deconstructing and rebuilding preexisting asteroids to form ship's parts and prepare them to be used as advanced hulls.'''
 
 BLD_SHIPYARD_ORG_ORB_INC
 Orbital Incubator


### PR DESCRIPTION
This PR makes two changes to the requirements for the asteroid buildings:
- requires that the asteroid shipyard be build in a system with an empire owned shipyard.
- allows the asteroid reformation processor to be build on any asteroid belt, without an asteroid shipyard.

It more clearly delineates the usage of the two buildings.

I never realized that the asteroid reformation processor, created armor parts that you could use anywhere it was supply connected.  I knew that it was an extension to the asteroid shipyard and assumed that it needed to be in the same system as the shipyard using the parts.

With this PR the asteroid shipyard is tied to a basic shipyard, like the other hull lines shipyard extensions.

The asteroid processor clearly creates a freespace resource that can be used anywhere.