### PR TITLE
Categorize pedia articles for ship hulls

### DIFF
--- a/default/scripting/encyclopedia/ENC_SHIP_HULL.focs.txt
+++ b/default/scripting/encyclopedia/ENC_SHIP_HULL.focs.txt
@@ -1,0 +1,6 @@
+Article
+    name = "ENC_SHIP_HULL"
+    category = "ENC_SHIP_HULL"
+    short_description = "ENC_SHIP_HULL"
+    description = "ENC_SHIP_HULL_DESC"
+    icon = "icons/ship_hulls/generic_hull.png"

--- a/default/scripting/encyclopedia/ship_hull/HULL_LINE_ASTEROIDS.focs.txt
+++ b/default/scripting/encyclopedia/ship_hull/HULL_LINE_ASTEROIDS.focs.txt
@@ -1,0 +1,6 @@
+Article
+    name = "HULL_LINE_ASTEROIDS"
+    category = "ENC_SHIP_HULL"
+    short_description = "HULL_LINE_ASTEROIDS"
+    description = "HULL_LINE_ASTEROIDS_DESC"
+    icon = "icons/ship_hulls/asteroid_hull_small.png"

--- a/default/scripting/encyclopedia/ship_hull/HULL_LINE_ENERGY.focs.txt
+++ b/default/scripting/encyclopedia/ship_hull/HULL_LINE_ENERGY.focs.txt
@@ -1,0 +1,6 @@
+Article
+    name = "HULL_LINE_ENERGY"
+    category = "ENC_SHIP_HULL"
+    short_description = "HULL_LINE_ENERGY"
+    description = "HULL_LINE_ENERGY_DESC"
+    icon = "icons/ship_hulls/energy_frigate_hull_small.png"

--- a/default/scripting/encyclopedia/ship_hull/HULL_LINE_GENERIC.focs.txt
+++ b/default/scripting/encyclopedia/ship_hull/HULL_LINE_GENERIC.focs.txt
@@ -1,0 +1,6 @@
+Article
+    name = "HULL_LINE_GENERIC"
+    category = "ENC_SHIP_HULL"
+    short_description = "HULL_LINE_GENERIC"
+    description = "HULL_LINE_GENERIC_DESC"
+    icon = "icons/ship_hulls/generic_hull.png"

--- a/default/scripting/encyclopedia/ship_hull/HULL_LINE_ORGANIC.focs.txt
+++ b/default/scripting/encyclopedia/ship_hull/HULL_LINE_ORGANIC.focs.txt
@@ -1,0 +1,6 @@
+Article
+    name = "HULL_LINE_ORGANIC"
+    category = "ENC_SHIP_HULL"
+    short_description = "HULL_LINE_ORGANIC"
+    description = "HULL_LINE_ORGANIC_DESC"
+    icon = "icons/ship_hulls/organic_hull_small.png"

--- a/default/scripting/encyclopedia/ship_hull/HULL_LINE_ROBOTIC.focs.txt
+++ b/default/scripting/encyclopedia/ship_hull/HULL_LINE_ROBOTIC.focs.txt
@@ -1,0 +1,6 @@
+Article
+    name = "HULL_LINE_ROBOTIC"
+    category = "ENC_SHIP_HULL"
+    short_description = "HULL_LINE_ROBOTIC"
+    description = "HULL_LINE_ROBOTIC_DESC"
+    icon = "icons/ship_hulls/robotic_hull_small.png"

--- a/default/scripting/encyclopedia/ship_hull/HULL_MONSTER.focs.txt
+++ b/default/scripting/encyclopedia/ship_hull/HULL_MONSTER.focs.txt
@@ -1,0 +1,6 @@
+Article
+    name = "HULL_MONSTER"
+    category = "ENC_SHIP_HULL"
+    short_description = "HULL_MONSTER"
+    description = "HULL_MONSTER_DESC"
+    icon = "icons/monsters/kraken-3.png"

--- a/default/scripting/encyclopedia/ship_hull/monster/HULL_MONSTER_GUARD.focs.txt
+++ b/default/scripting/encyclopedia/ship_hull/monster/HULL_MONSTER_GUARD.focs.txt
@@ -1,0 +1,6 @@
+Article
+    name = "HULL_MONSTER_GUARD"
+    category = "HULL_MONSTER"
+    short_description = "HULL_MONSTER_GUARD"
+    description = "HULL_MONSTER_GUARD_DESC"
+    icon = "icons/monsters/sentry.png"

--- a/default/scripting/encyclopedia/ship_hull/monster/HULL_MONSTER_JUGGERNAUT.focs.txt
+++ b/default/scripting/encyclopedia/ship_hull/monster/HULL_MONSTER_JUGGERNAUT.focs.txt
@@ -1,0 +1,6 @@
+Article
+    name = "HULL_MONSTER_JUGGERNAUT"
+    category = "HULL_MONSTER"
+    short_description = "HULL_MONSTER_JUGGERNAUT"
+    description = "HULL_MONSTER_JUGGERNAUT_DESC"
+    icon = "icons/monsters/juggernaut-3.png"

--- a/default/scripting/encyclopedia/ship_hull/monster/HULL_MONSTER_KRAKEN.focs.txt
+++ b/default/scripting/encyclopedia/ship_hull/monster/HULL_MONSTER_KRAKEN.focs.txt
@@ -1,0 +1,6 @@
+Article
+    name = "HULL_MONSTER_KRAKEN"
+    category = "HULL_MONSTER"
+    short_description = "HULL_MONSTER_KRAKEN"
+    description = "HULL_MONSTER_KRAKEN_DESC"
+    icon = "icons/monsters/kraken-3.png"

--- a/default/scripting/encyclopedia/ship_hull/monster/HULL_MONSTER_KRILL.focs.txt
+++ b/default/scripting/encyclopedia/ship_hull/monster/HULL_MONSTER_KRILL.focs.txt
@@ -1,0 +1,6 @@
+Article
+    name = "HULL_MONSTER_KRILL"
+    category = "HULL_MONSTER"
+    short_description = "HULL_MONSTER_KRILL"
+    description = "HULL_MONSTER_KRILL_DESC"
+    icon = "icons/monsters/krill-3.png"

--- a/default/scripting/encyclopedia/ship_hull/monster/HULL_MONSTER_SNOWFLAKE.focs.txt
+++ b/default/scripting/encyclopedia/ship_hull/monster/HULL_MONSTER_SNOWFLAKE.focs.txt
@@ -1,0 +1,6 @@
+Article
+    name = "HULL_MONSTER_SNOWFLAKE"
+    category = "HULL_MONSTER"
+    short_description = "HULL_MONSTER_SNOWFLAKE"
+    description = "HULL_MONSTER_SNOWFLAKE_DESC"
+    icon = "icons/monsters/snowflake-3.png"

--- a/default/scripting/encyclopedia/ship_hull/monster/HULL_MONSTER_TREE.focs.txt
+++ b/default/scripting/encyclopedia/ship_hull/monster/HULL_MONSTER_TREE.focs.txt
@@ -1,0 +1,6 @@
+Article
+    name = "HULL_MONSTER_TREE"
+    category = "HULL_MONSTER"
+    short_description = "HULL_MONSTER_TREE"
+    description = "HULL_MONSTER_TREE_DESC"
+    icon = "icons/monsters/tree.png"

--- a/default/scripting/ship_hulls/Basic.focs.txt
+++ b/default/scripting/ship_hulls/Basic.focs.txt
@@ -10,6 +10,7 @@ Hull
     ]
     buildCost = 10.0 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildTime = 2
+    tags = [ "PEDIA_HULL_LINE_GENERIC" ]
     location = Contains And [
         Building name = "BLD_SHIPYARD_BASE"
         OwnedBy empire = Source.Owner
@@ -38,6 +39,7 @@ Hull
     ]
     buildCost = 20 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildTime = 2
+    tags = [ "PEDIA_HULL_LINE_GENERIC" ]
     location = Contains And [
         Building name = "BLD_SHIPYARD_BASE"
         OwnedBy empire = Source.Owner
@@ -67,6 +69,7 @@ Hull
     ]
     buildCost = 30 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildTime = 2
+    tags = [ "PEDIA_HULL_LINE_GENERIC" ]
     location = Contains And [
         Building name = "BLD_SHIPYARD_BASE"
         OwnedBy empire = Source.Owner

--- a/default/scripting/ship_hulls/SH_COLONY_BASE.focs.txt
+++ b/default/scripting/ship_hulls/SH_COLONY_BASE.focs.txt
@@ -8,6 +8,7 @@ Hull
     slots = Slot type = Internal position = (0.50, 0.50)
     buildCost = 1
     buildTime = 3
+    tags = [ "PEDIA_HULL_LINE_GENERIC" ]
     location = OwnedBy empire = Source.Owner
     effectsgroups =
         [[REGULAR_HULL_DETECTION]]

--- a/default/scripting/ship_hulls/asteroid/SH_AGREGATE_ASTEROID.disabled
+++ b/default/scripting/ship_hulls/asteroid/SH_AGREGATE_ASTEROID.disabled
@@ -28,7 +28,7 @@ Hull
     ]
     buildCost = 60.0 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildTime = 3
-    tags = [ "ASTEROID_HULL" ]
+    tags = [ "ASTEROID_HULL" "PEDIA_HULL_LINE_ASTEROIDS" ]
     location = And [
         Contains And [
             Building name = "BLD_SHIPYARD_BASE"

--- a/default/scripting/ship_hulls/asteroid/SH_ASTEROID.focs.txt
+++ b/default/scripting/ship_hulls/asteroid/SH_ASTEROID.focs.txt
@@ -15,7 +15,7 @@ Hull
     ]
     buildCost = 20.0 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildTime = 2
-    tags = [ "ASTEROID_HULL" ]
+    tags = [ "ASTEROID_HULL" "PEDIA_HULL_LINE_ASTEROIDS" ]
     location = And [
         Planet
         Contains And [

--- a/default/scripting/ship_hulls/asteroid/SH_CAMOUFLAGE_ASTEROID.focs.txt
+++ b/default/scripting/ship_hulls/asteroid/SH_CAMOUFLAGE_ASTEROID.focs.txt
@@ -13,7 +13,7 @@ Hull
     ]
     buildCost = 16.0 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildTime = 2
-    tags = [ "ASTEROID_HULL" ]
+    tags = [ "ASTEROID_HULL" "PEDIA_HULL_LINE_ASTEROIDS" ]
     location = And [
         Contains And [
             Building name = "BLD_SHIPYARD_BASE"

--- a/default/scripting/ship_hulls/asteroid/SH_CRYSTALLIZED_ASTEROID.focs.txt
+++ b/default/scripting/ship_hulls/asteroid/SH_CRYSTALLIZED_ASTEROID.focs.txt
@@ -15,7 +15,7 @@ Hull
     ]
     buildCost = 20.0 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildTime = 3
-    tags = [ "ASTEROID_HULL" ]
+    tags = [ "ASTEROID_HULL" "PEDIA_HULL_LINE_ASTEROIDS" ]
     location = And [
         Contains And [
             Building name = "BLD_SHIPYARD_BASE"

--- a/default/scripting/ship_hulls/asteroid/SH_HEAVY_ASTEROID.focs.txt
+++ b/default/scripting/ship_hulls/asteroid/SH_HEAVY_ASTEROID.focs.txt
@@ -18,7 +18,7 @@ Hull
     ]
     buildCost = 40.0 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildTime = 3
-    tags = [ "ASTEROID_HULL" ]
+    tags = [ "ASTEROID_HULL" "PEDIA_HULL_LINE_ASTEROIDS" ]
     location = And [
         Contains And [
             Building name = "BLD_SHIPYARD_BASE"

--- a/default/scripting/ship_hulls/asteroid/SH_MINIASTEROID_SWARM.focs.txt
+++ b/default/scripting/ship_hulls/asteroid/SH_MINIASTEROID_SWARM.focs.txt
@@ -11,7 +11,7 @@ Hull
     ]
     buildCost = 10.0 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildTime = 3
-    tags = [ "ASTEROID_HULL" ]
+    tags = [ "ASTEROID_HULL" "PEDIA_HULL_LINE_ASTEROIDS" ]
     location = And [
         Contains And [
             Building name = "BLD_SHIPYARD_BASE"

--- a/default/scripting/ship_hulls/asteroid/SH_SCATTERED_ASTEROID.focs.txt
+++ b/default/scripting/ship_hulls/asteroid/SH_SCATTERED_ASTEROID.focs.txt
@@ -29,7 +29,7 @@ Hull
     ]
     buildCost = 120.0 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildTime = 8
-    tags = [ "ASTEROID_HULL" ]
+    tags = [ "ASTEROID_HULL" "PEDIA_HULL_LINE_ASTEROIDS" ]
     location = And [
         Contains And [
             Building name = "BLD_SHIPYARD_BASE"

--- a/default/scripting/ship_hulls/asteroid/SH_SMALL_ASTEROID.focs.txt
+++ b/default/scripting/ship_hulls/asteroid/SH_SMALL_ASTEROID.focs.txt
@@ -11,7 +11,7 @@ Hull
     ]
     buildCost = 6.0 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildTime = 2
-    tags = [ "ASTEROID_HULL" ]
+    tags = [ "ASTEROID_HULL" "PEDIA_HULL_LINE_ASTEROIDS" ]
     location = And [
         Contains And [
             Building name = "BLD_SHIPYARD_BASE"

--- a/default/scripting/ship_hulls/asteroid/SH_SMALL_CAMOUFLAGE_ASTEROID.focs.txt
+++ b/default/scripting/ship_hulls/asteroid/SH_SMALL_CAMOUFLAGE_ASTEROID.focs.txt
@@ -11,7 +11,7 @@ Hull
     ]
     buildCost = 9.0 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildTime = 2
-    tags = [ "ASTEROID_HULL" ]
+    tags = [ "ASTEROID_HULL" "PEDIA_HULL_LINE_ASTEROIDS" ]
     location = And [
         Contains And [
             Building name = "BLD_SHIPYARD_BASE"

--- a/default/scripting/ship_hulls/energy/SH_COMPRESSED_ENERGY.focs.txt
+++ b/default/scripting/ship_hulls/energy/SH_COMPRESSED_ENERGY.focs.txt
@@ -8,7 +8,7 @@ Hull
     slots = Slot type = External position = (0.65, 0.40)
     buildCost = 5 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildTime = 2
-    tags = [ "ENERGY_HULL" ]
+    tags = [ "ENERGY_HULL" "PEDIA_HULL_LINE_ENERGY" ]
     location = And [
         Contains And [
             Building name = "BLD_SHIPYARD_ENRG_COMP"

--- a/default/scripting/ship_hulls/energy/SH_ENERGY_FRIGATE.focs.txt
+++ b/default/scripting/ship_hulls/energy/SH_ENERGY_FRIGATE.focs.txt
@@ -14,6 +14,7 @@ Hull
     ]
     buildCost = 40 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildTime = 3
+    tags = [ "PEDIA_HULL_LINE_ENERGY" ]
     location = And [
         Contains And [
             Building name = "BLD_SHIPYARD_ENRG_COMP"

--- a/default/scripting/ship_hulls/energy/SH_FRACTAL_ENERGY.focs.txt
+++ b/default/scripting/ship_hulls/energy/SH_FRACTAL_ENERGY.focs.txt
@@ -23,7 +23,7 @@ Hull
     ]
     buildCost = 80.0 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildTime = 7
-    tags = [ "ENERGY_HULL" ]
+    tags = [ "ENERGY_HULL" "PEDIA_HULL_LINE_ENERGY" ]
     location = And [
         Contains And [
             Building name = "BLD_SHIPYARD_ENRG_COMP"

--- a/default/scripting/ship_hulls/energy/SH_QUANTUM_ENERGY.focs.txt
+++ b/default/scripting/ship_hulls/energy/SH_QUANTUM_ENERGY.focs.txt
@@ -19,7 +19,7 @@ Hull
     ]
     buildCost = 60 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildTime = 5
-    tags = [ "ENERGY_HULL" ]
+    tags = [ "ENERGY_HULL" "PEDIA_HULL_LINE_ENERGY" ]
     location = And [
         Contains And [
             Building name = "BLD_SHIPYARD_ENRG_COMP"

--- a/default/scripting/ship_hulls/energy/SH_SOLAR.focs.txt
+++ b/default/scripting/ship_hulls/energy/SH_SOLAR.focs.txt
@@ -36,7 +36,7 @@ Hull
     ]
     buildCost = 120.0 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildTime = 10
-    tags = [ "ENERGY_HULL" ]
+    tags = [ "ENERGY_HULL" "PEDIA_HULL_LINE_ENERGY" ]
     location = And [
         Contains And [
             Building name = "BLD_SHIPYARD_ENRG_COMP"

--- a/default/scripting/ship_hulls/monster/SH_BLACK_KRAKEN_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_BLACK_KRAKEN_BODY.focs.txt
@@ -15,6 +15,7 @@ Hull
     buildcost = 1
     buildtime = 1
     Unproducible
+    tags = [ "PEDIA_HULL_MONSTER_KRAKEN" ]
     location = All
     effectsgroups = [
         [[HUNT_BUILDINGS]]

--- a/default/scripting/ship_hulls/monster/SH_BLOATED_JUGGERNAUT_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_BLOATED_JUGGERNAUT_BODY.focs.txt
@@ -17,6 +17,7 @@ Hull
     buildcost = 1
     buildtime = 1
     Unproducible
+    tags = [ "PEDIA_HULL_MONSTER_JUGGERNAUT" ]
     location = All
     effectsgroups = [
         [[HUNT_BUILDINGS]]

--- a/default/scripting/ship_hulls/monster/SH_COSMIC_DRAGON_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_COSMIC_DRAGON_BODY.focs.txt
@@ -14,6 +14,7 @@ Hull
     buildcost = 1
     buildtime = 1
     Unproducible
+    tags = [ "PEDIA_HULL_MONSTER" ]
     location = All
     effectsgroups = [
         [[HUNT_PLANETS]]

--- a/default/scripting/ship_hulls/monster/SH_DAMPENING_CLOUD_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_DAMPENING_CLOUD_BODY.focs.txt
@@ -11,6 +11,7 @@ Hull
     buildcost = 1
     buildtime = 1
     Unproducible
+    tags = [ "PEDIA_HULL_MONSTER" ]
     location = All
     effectsgroups = [
         [[INFINITE_FUEL]]

--- a/default/scripting/ship_hulls/monster/SH_DRONE_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_DRONE_BODY.focs.txt
@@ -13,6 +13,7 @@ Hull
     buildCost = 1
     buildTime = 2
     Unproducible
+    tags = [ "PEDIA_HULL_MONSTER_GUARD" ]
     location = All
     effectsgroups = [
         [[MONSTER_MOVE_ALWAYS]]

--- a/default/scripting/ship_hulls/monster/SH_EXP_OUTPOST_HULL.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_EXP_OUTPOST_HULL.focs.txt
@@ -12,7 +12,7 @@ Hull
     buildcost = 1
     buildtime = 1
     Unproducible
-    tags = [ "CAN_ALTER_STARLANES" ]
+    tags = [ "CAN_ALTER_STARLANES" "PEDIA_HULL_MONSTER_GUARD" ]
     location = All
     effectsgroups = [
         EffectsGroup

--- a/default/scripting/ship_hulls/monster/SH_FLOATER.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_FLOATER.focs.txt
@@ -13,6 +13,7 @@ Hull
     buildCost = 1
     buildTime = 2
     Unproducible
+    tags = [ "PEDIA_HULL_MONSTER_TREE" ]
     location = All
     effectsgroups = [
         [[MONSTER_MOVE_ALWAYS]]
@@ -23,7 +24,7 @@ Hull
             scope = And [
                 Object id = Source.SystemID
                 System
-                Star type = [Blue White Yellow Orange Red]                
+                Star type = [Blue White Yellow Orange Red]
                 Not Number low = 2 condition = And [
                     Ship
                     Monster

--- a/default/scripting/ship_hulls/monster/SH_GUARD_0_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_GUARD_0_BODY.focs.txt
@@ -13,7 +13,7 @@ Hull
     buildCost = 1
     buildTime = 2
     Unproducible
-    tags = "UNOWNED_FRIENDLY"
+    tags = [ "UNOWNED_FRIENDLY" "PEDIA_HULL_MONSTER_GUARD" ]
     location = All
     effectsgroups = [
         [[UNOWNED_OWNED_VISION_BONUS(WEAK,10,10)]]

--- a/default/scripting/ship_hulls/monster/SH_GUARD_1_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_GUARD_1_BODY.focs.txt
@@ -13,7 +13,7 @@ Hull
     buildCost = 1
     buildTime = 2
     Unproducible
-    tags = "UNOWNED_FRIENDLY"
+    tags = [ "UNOWNED_FRIENDLY" "PEDIA_HULL_MONSTER_GUARD" ]
     location = All
     effectsgroups = [
         [[UNOWNED_OWNED_VISION_BONUS(POOR,20,20)]]

--- a/default/scripting/ship_hulls/monster/SH_GUARD_3_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_GUARD_3_BODY.focs.txt
@@ -18,7 +18,7 @@ Hull
     buildCost = 1
     buildTime = 2
     Unproducible
-    tags = "UNOWNED_FRIENDLY"
+    tags = [ "UNOWNED_FRIENDLY" "PEDIA_HULL_MONSTER_GUARD" ]
     location = All
     effectsgroups = [
         [[UNOWNED_OWNED_VISION_BONUS(GOOD,50,50)]]

--- a/default/scripting/ship_hulls/monster/SH_GUARD_MONSTER_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_GUARD_MONSTER_BODY.focs.txt
@@ -15,7 +15,7 @@ Hull
     buildCost = 1
     buildTime = 2
     Unproducible
-    tags = "UNOWNED_FRIENDLY"
+    tags = [ "UNOWNED_FRIENDLY" "PEDIA_HULL_MONSTER_GUARD" ]
     location = All
     effectsgroups = [
         [[UNOWNED_OWNED_VISION_BONUS(MODERATE,40,30)]]

--- a/default/scripting/ship_hulls/monster/SH_IMMOBILE_FACTOR.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_IMMOBILE_FACTOR.focs.txt
@@ -13,6 +13,7 @@ Hull
     buildCost = 1
     buildTime = 1
     Unproducible
+    tags = [ "PEDIA_HULL_MONSTER_GUARD" ]
     location = All
     effectsgroups = [
         [[UNOWNED_OWNED_VISION_BONUS(WEAK,10,10)]]

--- a/default/scripting/ship_hulls/monster/SH_JUGGERNAUT_1_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_JUGGERNAUT_1_BODY.focs.txt
@@ -14,6 +14,7 @@ Hull
     buildCost = 1
     buildTime = 1
     Unproducible
+    tags = [ "PEDIA_HULL_MONSTER_JUGGERNAUT" ]
     location = All
     effectsgroups = [
        EffectsGroup    // remove self and recreate on first turn, so that it starts with age 0

--- a/default/scripting/ship_hulls/monster/SH_JUGGERNAUT_2_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_JUGGERNAUT_2_BODY.focs.txt
@@ -14,6 +14,7 @@ Hull
     buildCost = 1
     buildTime = 1
     Unproducible
+    tags = [ "PEDIA_HULL_MONSTER_JUGGERNAUT" ]
     location = All
     effectsgroups = [
         [[MONSTER_MOVE_ALWAYS]]

--- a/default/scripting/ship_hulls/monster/SH_JUGGERNAUT_3_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_JUGGERNAUT_3_BODY.focs.txt
@@ -14,11 +14,11 @@ Hull
     buildCost = 1
     buildTime = 1
     Unproducible
+    tags = [ "PEDIA_HULL_MONSTER_JUGGERNAUT" ]
     location = All
     effectsgroups = [
         [[MONSTER_MOVE_ALWAYS]]
         [[INFINITE_FUEL]]
-        
          EffectsGroup
             scope = Source
             activation = Source
@@ -26,7 +26,6 @@ Hull
                 SetMaxCapacity partname = "SR_JAWS" value = Value + min(Source.Age*0.2, 8)
                 SetCapacity partname = "SR_JAWS" value = Value + min(Source.Age*0.2, 8)
             ]
-        
         [[EXCELLENT_VISION]]
     ]
     icon = ""

--- a/default/scripting/ship_hulls/monster/SH_KRAKEN_1_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_KRAKEN_1_BODY.focs.txt
@@ -12,6 +12,7 @@ Hull
     buildCost = 1
     buildTime = 1
     Unproducible
+    tags = [ "PEDIA_HULL_MONSTER_KRAKEN" ]
     location = All
     effectsgroups = [
         EffectsGroup    // remove self and recreate on first turn, so that it starts with age 0
@@ -22,7 +23,7 @@ Hull
                 Destroy
             ]
 
-        EffectsGroup     
+        EffectsGroup
             scope = NumberOf number = 2 condition = And [
                 Planet
                 Planet type = GasGiant

--- a/default/scripting/ship_hulls/monster/SH_KRAKEN_2_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_KRAKEN_2_BODY.focs.txt
@@ -14,6 +14,7 @@ Hull
     buildCost = 1
     buildTime = 1
     Unproducible
+    tags = [ "PEDIA_HULL_MONSTER_KRAKEN" ]
     location = All
     effectsgroups = [
         [[MONSTER_MOVE_ALWAYS]]

--- a/default/scripting/ship_hulls/monster/SH_KRAKEN_3_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_KRAKEN_3_BODY.focs.txt
@@ -14,11 +14,11 @@ Hull
     buildCost = 1
     buildTime = 1
     Unproducible
+    tags = [ "PEDIA_HULL_MONSTER_KRAKEN" ]
     location = All
     effectsgroups = [
         [[MONSTER_MOVE_ALWAYS]]
         [[INFINITE_FUEL]]
-        
          EffectsGroup
             scope = Source
             activation = Source
@@ -26,7 +26,6 @@ Hull
                 SetMaxCapacity partname = "SR_TENTACLE" value = Value + min(Source.Age*0.3, 15)
                 SetCapacity partname = "SR_TENTACLE" value = Value + min(Source.Age*0.3, 15)
             ]
-        
         [[GOOD_VISION]]
     ]
     icon = ""

--- a/default/scripting/ship_hulls/monster/SH_KRILL_1_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_KRILL_1_BODY.focs.txt
@@ -11,6 +11,7 @@ Hull
     buildCost = 1
     buildTime = 1
     Unproducible
+    tags = [ "PEDIA_HULL_MONSTER_KRILL" ]
     location = All
     effectsgroups = [
 

--- a/default/scripting/ship_hulls/monster/SH_KRILL_2_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_KRILL_2_BODY.focs.txt
@@ -12,6 +12,7 @@ Hull
     buildCost = 1
     buildTime = 1
     Unproducible
+    tags = [ "PEDIA_HULL_MONSTER_KRILL" ]
     location = All
     effectsgroups = [
         EffectsGroup

--- a/default/scripting/ship_hulls/monster/SH_KRILL_3_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_KRILL_3_BODY.focs.txt
@@ -14,6 +14,7 @@ Hull
     buildCost = 1
     buildTime = 1
     Unproducible
+    tags = [ "PEDIA_HULL_MONSTER_KRILL" ]
     location = All
     effectsgroups = [
         EffectsGroup

--- a/default/scripting/ship_hulls/monster/SH_KRILL_4_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_KRILL_4_BODY.focs.txt
@@ -15,6 +15,7 @@ Hull
     buildCost = 1
     buildTime = 1
     Unproducible
+    tags = [ "PEDIA_HULL_MONSTER_KRILL" ]
     location = All
     effectsgroups = [
         EffectsGroup

--- a/default/scripting/ship_hulls/monster/SH_NEBULOUS.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_NEBULOUS.focs.txt
@@ -12,6 +12,7 @@ Hull
     buildcost = 1
     buildtime = 1
     Unproducible
+    tags = [ "PEDIA_HULL_MONSTER" ]
     location = All
     effectsgroups = [
         [[INFINITE_FUEL]]

--- a/default/scripting/ship_hulls/monster/SH_PSIONIC_SNOWFLAKE_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_PSIONIC_SNOWFLAKE_BODY.focs.txt
@@ -14,6 +14,7 @@ Hull
     buildCost = 1
     buildTime = 1
     Unproducible
+    tags = [ "PEDIA_HULL_MONSTER_SNOWFLAKE" ]
     location = All
     effectsgroups = [
         [[HUNT_SHIPS]]

--- a/default/scripting/ship_hulls/monster/SH_SNOWFLAKE_1_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_SNOWFLAKE_1_BODY.focs.txt
@@ -14,6 +14,7 @@ Hull
     buildCost = 1
     buildTime = 1
     Unproducible
+    tags = [ "PEDIA_HULL_MONSTER_SNOWFLAKE" ]
     location = All
     effectsgroups = [
         EffectsGroup    // remove self and recreate on first turn, so that it starts with age 0

--- a/default/scripting/ship_hulls/monster/SH_SNOWFLAKE_2_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_SNOWFLAKE_2_BODY.focs.txt
@@ -14,6 +14,7 @@ Hull
     buildCost = 1
     buildTime = 1
     Unproducible
+    tags = [ "PEDIA_HULL_MONSTER_SNOWFLAKE" ]
     location = All
     effectsgroups = [
         [[MONSTER_MOVE_ALWAYS]]

--- a/default/scripting/ship_hulls/monster/SH_SNOWFLAKE_3_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_SNOWFLAKE_3_BODY.focs.txt
@@ -14,11 +14,11 @@ Hull
     buildCost = 1
     buildTime = 1
     Unproducible
+    tags = [ "PEDIA_HULL_MONSTER_SNOWFLAKE" ]
     location = All
     effectsgroups = [
         [[MONSTER_MOVE_ALWAYS]]
         [[INFINITE_FUEL]]
-        
         EffectsGroup
             scope = Source
             activation = Source
@@ -26,7 +26,6 @@ Hull
                 SetMaxCapacity partname = "SR_ICE_BEAM" value = Value + min(Source.Age*0.3, 18)
                 SetCapacity partname = "SR_ICE_BEAM" value = Value + min(Source.Age*0.3, 18)
             ]
-        
         [[EXCELLENT_VISION]]
     ]
     icon = ""

--- a/default/scripting/ship_hulls/monster/SH_STRONG_MONSTER_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_STRONG_MONSTER_BODY.focs.txt
@@ -15,7 +15,7 @@ Hull
     buildCost = 1
     buildTime = 2
     Unproducible
-
+    tags = [ "PEDIA_HULL_MONSTER" ]
     location = All
     effectsgroups = [
         [[MONSTER_MOVE_ALWAYS]]

--- a/default/scripting/ship_hulls/monster/SH_TREE_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_TREE_BODY.focs.txt
@@ -9,6 +9,7 @@ Hull
     buildCost = 1
     buildTime = 2
     Unproducible
+    tags = [ "PEDIA_HULL_MONSTER_TREE" ]
     location = All
     effectsgroups = [
         [[MODERATE_VISION]]

--- a/default/scripting/ship_hulls/monster/SH_WHITE_KRAKEN_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_WHITE_KRAKEN_BODY.focs.txt
@@ -15,6 +15,7 @@ Hull
     buildcost = 1
     buildtime = 1
     Unproducible
+    tags = [ "PEDIA_HULL_MONSTER_KRAKEN" ]
     location = All
     effectsgroups = [
         [[GOOD_VISION]]

--- a/default/scripting/ship_hulls/organic/SH_BIOADAPTIVE.focs.txt
+++ b/default/scripting/ship_hulls/organic/SH_BIOADAPTIVE.focs.txt
@@ -15,7 +15,7 @@ Hull
     ]
     buildCost = 21 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildTime = 6
-    tags = [ "ORGANIC_HULL" ]
+    tags = [ "ORGANIC_HULL" "PEDIA_HULL_LINE_ORGANIC" ]
     location = And [
         Contains And [
             Building name = "BLD_SHIPYARD_ORG_CELL_GRO_CHAMB"

--- a/default/scripting/ship_hulls/organic/SH_ENDOMORPHIC.focs.txt
+++ b/default/scripting/ship_hulls/organic/SH_ENDOMORPHIC.focs.txt
@@ -15,7 +15,7 @@ Hull
     ]
     buildCost = 23 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildTime = 5
-    tags = [ "ORGANIC_HULL" ]
+    tags = [ "ORGANIC_HULL" "PEDIA_HULL_LINE_ORGANIC" ]
     location = And [
         Contains And [
             Building name = "BLD_SHIPYARD_ORG_XENO_FAC"

--- a/default/scripting/ship_hulls/organic/SH_ENDOSYMBIOTIC.focs.txt
+++ b/default/scripting/ship_hulls/organic/SH_ENDOSYMBIOTIC.focs.txt
@@ -16,7 +16,7 @@ Hull
     ]
     buildCost = 25 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildTime = 6
-    tags = [ "ORGANIC_HULL" ]
+    tags = [ "ORGANIC_HULL" "PEDIA_HULL_LINE_ORGANIC" ]
     location = And [
         Contains And [
             Building name = "BLD_SHIPYARD_ORG_CELL_GRO_CHAMB"

--- a/default/scripting/ship_hulls/organic/SH_ORGANIC.focs.txt
+++ b/default/scripting/ship_hulls/organic/SH_ORGANIC.focs.txt
@@ -13,7 +13,7 @@ Hull
     ]
     buildCost = 14 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildTime = 3
-    tags = [ "ORGANIC_HULL" ]
+    tags = [ "ORGANIC_HULL" "PEDIA_HULL_LINE_ORGANIC" ]
     location = And [
         Contains And [
             Building name = "BLD_SHIPYARD_ORG_ORB_INC"

--- a/default/scripting/ship_hulls/organic/SH_PROTOPLASMIC.focs.txt
+++ b/default/scripting/ship_hulls/organic/SH_PROTOPLASMIC.focs.txt
@@ -14,7 +14,7 @@ Hull
     ]
     buildCost = 15 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildTime = 5
-    tags = [ "ORGANIC_HULL" ]
+    tags = [ "ORGANIC_HULL" "PEDIA_HULL_LINE_ORGANIC" ]
     location = And [
         Contains And [
             Building name = "BLD_SHIPYARD_ORG_CELL_GRO_CHAMB"

--- a/default/scripting/ship_hulls/organic/SH_RAVENOUS.focs.txt
+++ b/default/scripting/ship_hulls/organic/SH_RAVENOUS.focs.txt
@@ -7,16 +7,16 @@ Hull
     structure = 5
     slots = [
         Slot type = External position = (0.20, 0.15)
-        Slot type = External position = (0.40, 0.15)        
+        Slot type = External position = (0.40, 0.15)
         Slot type = Internal position = (0.45, 0.50)
-        Slot type = Internal position = (0.55, 0.50)        
-        Slot type = External position = (0.80, 0.55)        
+        Slot type = Internal position = (0.55, 0.50)
+        Slot type = External position = (0.80, 0.55)
         Slot type = External position = (0.20, 0.75)
         Slot type = External position = (0.40, 0.75)
     ]
     buildCost = 25 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildTime = 6
-    tags = [ "ORGANIC_HULL" ]
+    tags = [ "ORGANIC_HULL" "PEDIA_HULL_LINE_ORGANIC" ]
     location = And [
         Contains And [
             Building name = "BLD_SHIPYARD_ORG_XENO_FAC"

--- a/default/scripting/ship_hulls/organic/SH_SENTIENT.focs.txt
+++ b/default/scripting/ship_hulls/organic/SH_SENTIENT.focs.txt
@@ -19,7 +19,7 @@ Hull
     ]
     buildCost = 60 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildTime = 8
-    tags = [ "ORGANIC_HULL" ]
+    tags = [ "ORGANIC_HULL" "PEDIA_HULL_LINE_ORGANIC" ]
     location = And [
         Contains And [
             Building name = "BLD_SHIPYARD_ORG_XENO_FAC"

--- a/default/scripting/ship_hulls/organic/SH_STATIC_MULTICELLULAR.focs.txt
+++ b/default/scripting/ship_hulls/organic/SH_STATIC_MULTICELLULAR.focs.txt
@@ -14,7 +14,7 @@ Hull
     ]
     buildCost = 18 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildTime = 4
-    tags = [ "ORGANIC_HULL" ]
+    tags = [ "ORGANIC_HULL" "PEDIA_HULL_LINE_ORGANIC" ]
     location = And [
        // Contains And [
         //    Building name = "BLD_SHIPYARD_ORG_XENO_FAC"

--- a/default/scripting/ship_hulls/organic/SH_SYMBIOTIC.focs.txt
+++ b/default/scripting/ship_hulls/organic/SH_SYMBIOTIC.focs.txt
@@ -13,7 +13,7 @@ Hull
     ]
     buildCost = 12 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildTime = 4
-    tags = [ "ORGANIC_HULL" ]
+    tags = [ "ORGANIC_HULL" "PEDIA_HULL_LINE_ORGANIC" ]
     location = And [
 //        Contains And [
 //            Building name = "BLD_SHIPYARD_ORG_CELL_GRO_CHAMB"

--- a/default/scripting/ship_hulls/robotic/SH_LOGITICS_FACILITATOR.focs.txt
+++ b/default/scripting/ship_hulls/robotic/SH_LOGITICS_FACILITATOR.focs.txt
@@ -19,7 +19,7 @@ Hull
     ]
     buildCost = 100 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildTime = 8
-    tags = [ "ROBOTIC_HULL" ]
+    tags = [ "ROBOTIC_HULL" "PEDIA_HULL_LINE_ROBOTIC" ]
     location = And [
         Contains And [
             Building name = "BLD_SHIPYARD_CON_ADV_ENGINE"

--- a/default/scripting/ship_hulls/robotic/SH_NANOROBOTIC.focs.txt
+++ b/default/scripting/ship_hulls/robotic/SH_NANOROBOTIC.focs.txt
@@ -16,7 +16,7 @@ Hull
     ]
     buildCost = 50 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildTime = 2
-    tags = [ "ROBOTIC_HULL" ]
+    tags = [ "ROBOTIC_HULL" "PEDIA_HULL_LINE_ROBOTIC" ]
     location = And [
         Contains And [
             Building name = "BLD_SHIPYARD_CON_NANOROBO"

--- a/default/scripting/ship_hulls/robotic/SH_ROBOTIC.focs.txt
+++ b/default/scripting/ship_hulls/robotic/SH_ROBOTIC.focs.txt
@@ -14,7 +14,7 @@ Hull
     ]
     buildCost = 40 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildTime = 2
-    tags = [ "ROBOTIC_HULL" ]
+    tags = [ "ROBOTIC_HULL" "PEDIA_HULL_LINE_ROBOTIC" ]
     location = And [
         Contains And [
             Building name = "BLD_SHIPYARD_BASE"

--- a/default/scripting/ship_hulls/robotic/SH_SELF_GRAVITATING.focs.txt
+++ b/default/scripting/ship_hulls/robotic/SH_SELF_GRAVITATING.focs.txt
@@ -18,7 +18,7 @@ Hull
     ]
     buildCost = 60 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildTime = 2
-    tags = [ "ROBOTIC_HULL" ]
+    tags = [ "ROBOTIC_HULL" "PEDIA_HULL_LINE_ROBOTIC" ]
     location = And [
         Contains And [
             Building name = "BLD_SHIPYARD_CON_GEOINT"

--- a/default/scripting/ship_hulls/robotic/SH_SPATIAL_FLUX.focs.txt
+++ b/default/scripting/ship_hulls/robotic/SH_SPATIAL_FLUX.focs.txt
@@ -11,6 +11,7 @@ Hull
     ]
     buildCost = 11 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildTime = 2
+    tags = [ "PEDIA_HULL_LINE_ROBOTIC" ]
     location = And [
         Contains And [
             Building name = "BLD_SHIPYARD_BASE"
@@ -28,7 +29,6 @@ Hull
             activation = Not Stationary
             accountinglabel = "SPATIAL_FLUX_MALUS"
             effects = SetStealth value = Value - 30
-            
         EffectsGroup
             scope = Source
             activation = Not Aggressive

--- a/default/scripting/ship_hulls/robotic/SH_TITANIC.focs.txt
+++ b/default/scripting/ship_hulls/robotic/SH_TITANIC.focs.txt
@@ -29,7 +29,7 @@ Hull
     ]
     buildCost = 160 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildTime = 5
-    tags = [ "ROBOTIC_HULL" ]
+    tags = [ "ROBOTIC_HULL" "PEDIA_HULL_LINE_ROBOTIC" ]
     location = And [
         Contains And [
             Building name = "BLD_SHIPYARD_CON_GEOINT"

--- a/default/scripting/ship_hulls/robotic/SH_TRANSSPATIAL.focs.txt
+++ b/default/scripting/ship_hulls/robotic/SH_TRANSSPATIAL.focs.txt
@@ -11,6 +11,7 @@ Hull
         ]
     buildCost = 10 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildTime = 3
+    tags = [ "PEDIA_HULL_LINE_ROBOTIC" ]
     location = And [
         Contains And [
             Building name = "BLD_SHIPYARD_CON_ADV_ENGINE"

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -3795,6 +3795,9 @@ Ship Part
 ENC_SHIP_HULL
 Ship Hull
 
+ENC_SHIP_HULL_DESC
+Ship Hulls
+
 ENC_TECH
 Technologies
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -7874,6 +7874,80 @@ Partial
 VIS_FULL_VISIBILITY
 Full
 
+# Ship hull categories
+
+HULL_LINE_GENERIC
+Hull Line: Generic
+
+HULL_LINE_GENERIC_DESC
+Generic line of ship hulls with no specialty
+
+HULL_LINE_ASTEROIDS
+Hull Line: [[PT_ASTEROIDS]]
+
+HULL_LINE_ASTEROIDS_DESC
+Line of hulls modelled from and utilizing [[PT_ASTEROIDS]].
+
+HULL_LINE_ENERGY
+Hull Line: Energy
+
+HULL_LINE_ENERGY_DESC
+Line of hulls designed from, or utilizing, a high energy density.
+
+HULL_LINE_ORGANIC
+Hull Line: Organic
+
+HULL_LINE_ORGANIC_DESC
+Line of hulls composed of organic materials.
+
+HULL_LINE_ROBOTIC
+Hull Line: Robotic
+
+HULL_LINE_ROBOTIC_DESC
+Line of hulls with a heavy emphasis on artificial intelligence and automation.
+
+HULL_MONSTER
+Monster Bodies
+
+HULL_MONSTER_DESC
+Bodies used in monster designs
+
+HULL_MONSTER_GUARD
+Guardian Bodies
+
+HULL_MONSTER_GUARD_DESC
+Bodies used in guardian class monster designs
+
+HULL_MONSTER_JUGGERNAUT
+Juggernaut Bodies
+
+HULL_MONSTER_JUGGERNAUT_DESC
+Bodies used in juggernaut monster designs
+
+HULL_MONSTER_KRAKEN
+Kraken Bodies
+
+HULL_MONSTER_KRAKEN_DESC
+Bodies used in kraken monster designs
+
+HULL_MONSTER_KRILL
+Krill Bodies
+
+HULL_MONSTER_KRILL_DESC
+Bodies used in krill monster designs
+
+HULL_MONSTER_SNOWFLAKE
+Snowflake Bodies
+
+HULL_MONSTER_SNOWFLAKE_DESC
+Bodies used in snowflake monster designs
+
+HULL_MONSTER_TREE
+Tree Bodies
+
+HULL_MONSTER_TREE_DESC
+Bodies used in tree monster designs
+
 
 ##
 ## FOCS value references, effects & condition descriptions


### PR DESCRIPTION
Differences with [forum thread](http://www.freeorion.org/forum/viewtopic.php?f=6&t=10343):
* Monster hulls have sub categories (e.g. all krill hulls)
* Guardian hulls moved into a monster hull sub-category
* No Special hull category (since there is just one hull)
* Basic hulls category relabeled as Generic

Only brief explanations of each category were added.
