### PR TITLE
Prevent monster maturation during combat

### DIFF
--- a/default/scripting/ship_hulls/monster/SH_FLOATER.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_FLOATER.focs.txt
@@ -31,6 +31,7 @@ Hull
                 ]
             ]
             activation = And [
+                Turn low = Source.LastTurnActiveInBattle + 1
                 InSystem
                 Random probability = 0.1
             ]

--- a/default/scripting/ship_hulls/monster/SH_JUGGERNAUT_1_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_JUGGERNAUT_1_BODY.focs.txt
@@ -52,7 +52,7 @@ Hull
                 ]
             ]
             activation = And [
-                Turn low = 30
+                Turn low = max(30, Source.LastTurnActiveInBattle + 1)
                 Random probability = Source.Age*0.01 - 0.1
             ]
             effects = [

--- a/default/scripting/ship_hulls/monster/SH_JUGGERNAUT_2_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_JUGGERNAUT_2_BODY.focs.txt
@@ -28,7 +28,7 @@ Hull
                 ]
             ]
             activation = And [
-                Turn low = 60
+                Turn low = max(60, Source.LastTurnActiveInBattle + 1)
                 Random probability = Source.Age*0.01 - 0.1
             ]
             effects = [

--- a/default/scripting/ship_hulls/monster/SH_KRAKEN_1_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_KRAKEN_1_BODY.focs.txt
@@ -50,7 +50,7 @@ Hull
                 ]
             ]
             activation = And [
-                Turn low = 30
+                Turn low = max(30, Source.LastTurnActiveInBattle + 1)
                 //triple the chance of maturing when in a system with Krill
                 Random probability = (Source.Age*0.01 - 0.1) * 3^(If condition = ContainedBy Contains OR [
                     Design name = "SM_KRILL_1"

--- a/default/scripting/ship_hulls/monster/SH_KRAKEN_2_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_KRAKEN_2_BODY.focs.txt
@@ -28,7 +28,7 @@ Hull
                 ]
             ]
             activation = And [
-                Turn low = 60
+                Turn low = max(60, Source.LastTurnActiveInBattle + 1)
                 //triple the chance of maturing when in a system with Krill
                 Random probability = (Source.Age*0.01 - 0.1) * 3^(If condition = ContainedBy Contains OR [
                     Design name = "SM_KRILL_1"

--- a/default/scripting/ship_hulls/monster/SH_KRILL_1_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_KRILL_1_BODY.focs.txt
@@ -25,7 +25,7 @@ Hull
                 ]
             ]
             activation = And [
-                Turn low = 30
+                Turn low = max(30, Source.LastTurnActiveInBattle + 1)
                 InSystem
             ]
             stackinggroup = "KRILL_1_ACTION_STACK"
@@ -45,7 +45,7 @@ Hull
                 ]
             ]
             activation = And [
-                Turn low = 30
+                Turn low = max(30, Source.LastTurnActiveInBattle + 1)
                 InSystem
             ]
             effects = Destroy
@@ -59,7 +59,7 @@ Hull
                 ]
             ]
             activation = And [
-                Turn low = 30
+                Turn low = max(30, Source.LastTurnActiveInBattle + 1)
                 Random probability = 0.1
                 InSystem
             ]

--- a/default/scripting/ship_hulls/monster/SH_KRILL_2_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_KRILL_2_BODY.focs.txt
@@ -25,7 +25,7 @@ Hull
                 ]
             ]
             activation = And [
-                Turn low = 60
+                Turn low = max(60, Source.LastTurnActiveInBattle + 1)
                 InSystem
             ]
             stackinggroup = "KRILL_2_ACTION_STACK"
@@ -55,7 +55,7 @@ Hull
                 ]
             ]
             activation = And [
-                Turn low = 60
+                Turn low = max(60, Source.LastTurnActiveInBattle + 1)
                 InSystem
             ]
            effects = Destroy
@@ -69,7 +69,7 @@ Hull
                 ]
             ]
             activation = And [
-                Turn low = 60
+                Turn low = max(60, Source.LastTurnActiveInBattle + 1)
                 Random probability = 0.15
                 InSystem
             ]

--- a/default/scripting/ship_hulls/monster/SH_KRILL_3_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_KRILL_3_BODY.focs.txt
@@ -27,7 +27,7 @@ Hull
                 ]
             ]
             activation = And [
-                Turn low = 90
+                Turn low = max(90, Source.LastTurnActiveInBattle + 1)
                 InSystem
             ]
             stackinggroup = "KRILL_3_ACTION_STACK"
@@ -57,7 +57,7 @@ Hull
                 ]
             ]
             activation = And [
-                Turn low = 90
+                Turn low = max(90, Source.LastTurnActiveInBattle + 1)
                 InSystem
             ]
             effects = Destroy
@@ -71,7 +71,7 @@ Hull
                 ]
             ]
             activation = And [
-                Turn low = 90
+                Turn low = max(90, Source.LastTurnActiveInBattle + 1)
                 Random probability = 0.08
                 InSystem
             ]

--- a/default/scripting/ship_hulls/monster/SH_SNOWFLAKE_1_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_SNOWFLAKE_1_BODY.focs.txt
@@ -53,7 +53,7 @@ Hull
                 ]
             ]
             activation = And [
-                Turn low = 30
+                Turn low = max(30, Source.LastTurnActiveInBattle + 1)
                 Random probability = Source.Age*0.01 - 0.1
             ]
             accountinglabel = "SNOWFLAKE_GROWTH_LABEL"

--- a/default/scripting/ship_hulls/monster/SH_SNOWFLAKE_2_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_SNOWFLAKE_2_BODY.focs.txt
@@ -28,7 +28,7 @@ Hull
                 ]
             ]
             activation = And [
-                Turn low = 60
+                Turn low = max(60, Source.LastTurnActiveInBattle + 1)
                 Random probability = Source.Age*0.01 - 0.1
             ]
             effects = [


### PR DESCRIPTION
Addresses the bug portion of #949, preventing monsters from "maturing" during combat.