### PR TITLE
Gate ai trooper movement

### DIFF
--- a/default/python/AI/AIFleetMission.py
+++ b/default/python/AI/AIFleetMission.py
@@ -8,7 +8,7 @@ import MoveUtilsAI
 import MilitaryAI
 import InvasionAI
 import CombatRatingsAI
-from universe_object import System, Fleet, Planet
+from universe_object import UniverseObject, System, Fleet, Planet
 from EnumsAI import MissionType
 from AIDependencies import INVALID_ID
 
@@ -50,6 +50,7 @@ COMPATIBLE_ROLES_MAP = {
 class AIFleetMission(object):
     """
     Stores information about AI mission. Every mission has fleetID and AI targets depending upon AI fleet mission type.
+    :type target: UniverseObject | None
     """
 
     def __init__(self, fleet_id):

--- a/default/python/AI/AIstate.py
+++ b/default/python/AI/AIstate.py
@@ -519,7 +519,10 @@ class AIstate(object):
         return threat, max_threat, myrating, threat_fleets
 
     def get_fleet_mission(self, fleet_id):
-        """Returns AIFleetMission with fleetID."""
+        """
+        Returns AIFleetMission with fleetID.
+        :rtype: AIFleetMission.AIFleetMission
+        """
         if fleet_id in self.__aiMissionsByFleetID:
             return self.__aiMissionsByFleetID[fleet_id]
         else:

--- a/default/python/AI/universe_object.py
+++ b/default/python/AI/universe_object.py
@@ -3,7 +3,10 @@ import freeOrionAIInterface as fo  # pylint: disable=import-error
 from AIDependencies import INVALID_ID
 
 class UniverseObject(object):
-    """Stores information about AI target - its id and type."""
+    """
+    Stores information about AI target - its id and type.
+    :type id: int
+    """
 
     def __init__(self, target_id):
         self.id = target_id
@@ -21,7 +24,7 @@ class UniverseObject(object):
 
     def get_object(self):
         """
-        Returns UniverseObject or None.
+        Returns fo.universeObject or None.
         """
         return None
 
@@ -29,7 +32,10 @@ class UniverseObject(object):
         return self.id is not None and self.id >= 0
 
     def get_system(self):
-        """Returns all system AITargets required to visit in this object."""
+        """
+        Returns the system that contains this object, or None.
+        :rtype: System | None
+        """
         raise NotImplementedError()
 
 
@@ -37,11 +43,18 @@ class Planet(UniverseObject):
     object_name = 'planet'
 
     def get_system(self):
+        """
+        Returns the system that contains this object, or None.
+        :rtype: System | None
+        """
         universe = fo.getUniverse()
         planet = universe.getPlanet(self.id)
         return System(planet.systemID)
 
     def get_object(self):
+        """
+        :rtype fo.planet:
+        """
         return fo.getUniverse().getPlanet(self.id)
 
 
@@ -49,6 +62,10 @@ class System(UniverseObject):
     object_name = 'system'
 
     def get_system(self):
+        """
+        Returns this object.
+        :rtype: System
+        """
         return self
 
     def get_object(self):
@@ -59,7 +76,10 @@ class Fleet(UniverseObject):
     object_name = 'fleet'
 
     def get_system(self):
-        """Get current fleet location or target system if currently on starlane."""
+        """
+        Get current fleet location or target system if currently on starlane.
+        :rtype: System | None
+        """
         universe = fo.getUniverse()
         fleet = universe.getFleet(self.id)
         system_id = fleet.nextSystemID


### PR DESCRIPTION
Adds additional checks on the movement of AI trooper fleets based on the last known status of the invasion target; helps address concerns raised in #1012 and #1013.  
```Python
            # Don't advance outside of our fleet-supply zone unless the target either has no shields at all or there
            # is already a military fleet assigned to secure the target, and don't take final jump unless the planet is
            # (to the AI's knowledge) down to zero shields.
```

These changes are compatible-with / supplementary-to  (but not really dependent on) the invasion-related military secure mission proposals in #1309 

The first commit here is some related type hinting that I had added while working on this, it is not actually needed here and could be left for a more exhaustive pass at adding more type hinting