### PR TITLE
Fix issue 1199 sitrep list lacks scroll bar for last item.

### DIFF
--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -544,7 +544,9 @@ protected:
     Row&            ColHeaders();                   ///< returns the row containing the headings for the columns, if any.  If undefined, the returned heading Row will have size() 0. non-const for derivers
     //@}
 
-    void            AdjustScrolls(bool adjust_for_resize);  ///< creates, destroys, or resizes scrolls to reflect size of data in listbox
+    /** creates, destroys, or resizes scrolls to reflect size of data in listbox. \p force_scroll
+        forces the scroll bar to be added.*/
+    void            AdjustScrolls(bool adjust_for_resize, const std::pair<bool, bool>& force_scrolls = {false, false});
 
     void DropsAcceptable(DropsAcceptableIter first, DropsAcceptableIter last,
                          const Pt& pt, Flags<ModKey> mod_keys) const override;
@@ -573,7 +575,8 @@ private:
     /** Return the client size excluding the scroll bar sizes.*/
     Pt ClientSizeExcludingScrolls() const;
     /** Return a pair of dimensions of the scollable area if vscroll and/or hscroll is required.*/
-    std::pair<boost::optional<X>, boost::optional<Y>> CheckScrollsRequired() const;
+    std::pair<boost::optional<X>, boost::optional<Y>>
+        CheckIfScrollsRequired(const std::pair<bool, bool>& force_scrolls= {false, false}) const;
     /** Add vscroll and/or hscroll if \p required_total_extents x or y dimension exists. Return a
         pair of bools indicating if added or removed vscroll or hscroll.*/
     std::pair<bool, bool> AddOrRemoveScrolls(const std::pair<boost::optional<X>, boost::optional<Y>>& required_total_extents);

--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -572,14 +572,29 @@ private:
     /** Restore cached selected, clicked and last browsed rows.*/
     void RestoreCachedSelections(const SelectionCache& cache);
 
-    /** Return the client size excluding the scroll bar sizes.*/
+    /** Return the client size excluding the scroll bar sizes, in order to determine if scroll bars
+        are needed. This is a private function that is a component of AdjustScrolls.*/
     Pt ClientSizeExcludingScrolls() const;
-    /** Return a pair of dimensions of the scollable area if vscroll and/or hscroll is required.*/
+
+    /** Return a pair of optional X and/or Y dimensions of the scollable area iff vscroll and/or
+        hscroll are required. If scrollbars are needed, the scrollable extent will be larger than the
+        client size.  If a scrollbar is not required in some dimension return boost::none
+        for that dimension. \p maybe_client_size might contain a precalculated client size.
+
+        This is a private function that is a component of AdjustScrolls. */
     std::pair<boost::optional<X>, boost::optional<Y>>
-        CheckIfScrollsRequired(const std::pair<bool, bool>& force_scrolls= {false, false}) const;
-    /** Add vscroll and/or hscroll if \p required_total_extents x or y dimension exists. Return a
-        pair of bools indicating if added or removed vscroll or hscroll.*/
-    std::pair<bool, bool> AddOrRemoveScrolls(const std::pair<boost::optional<X>, boost::optional<Y>>& required_total_extents);
+        CheckIfScrollsRequired(const std::pair<bool, bool>& force_scrolls = {false, false},
+                               const boost::optional<Pt>& maybe_client_size = boost::none) const;
+
+    /** Add vscroll and/or hscroll if \p required_total_extents the x andor y dimension exists. The
+        value of \p required_total_extents is the full x and y dimensions of the underlying ListBox
+        requiring the scrollbar as calculated in CheckIfScrollsRequired.  Return a pair of bools
+        indicating if vscroll and/or hscroll was added and/or removed.  \p maybe_client_size might
+        contain a precalculated client size as calculated in ClientSizeExcludingScrolls.
+
+        This is a private function that is a component of AdjustScrolls. */
+    std::pair<bool, bool> AddOrRemoveScrolls(const std::pair<boost::optional<X>, boost::optional<Y>>& required_total_extents,
+                                             const boost::optional<Pt>& maybe_client_size = boost::none);
 
     std::list<Row*> m_rows;             ///< line item data
 

--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -569,6 +569,14 @@ private:
     /** Restore cached selected, clicked and last browsed rows.*/
     void RestoreCachedSelections(const SelectionCache& cache);
 
+    /** Return the client size excluding the scroll bar sizes.*/
+    Pt ClientSizeExcludingScrolls() const;
+    /** Return a pair of dimensions of the scollable area if vscroll and/or hscroll is required.*/
+    std::pair<boost::optional<X>, boost::optional<Y>> CheckScrollsRequired() const;
+    /** Add vscroll and/or hscroll if \p required_total_extents x or y dimension exists. Return a
+        pair of bools indicating if added or removed vscroll or hscroll.*/
+    std::pair<bool, bool> AddOrRemoveScrolls(const std::pair<boost::optional<X>, boost::optional<Y>>& required_total_extents);
+
     std::list<Row*> m_rows;             ///< line item data
 
     Scroll*         m_vscroll;          ///< vertical scroll bar on right

--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -552,8 +552,9 @@ protected:
 
 private:
     /** Show only rows that are within the visible list box area and hide all others.  If
-        \p do_prerender is true then prerender the visible rows.*/
-    void            ShowVisibleRows(bool do_prerender);
+        \p do_prerender is true then prerender the visible rows.  Return true if prerender
+        resulted in any visible row changing size. */
+    bool            ShowVisibleRows(bool do_prerender);
     void            ConnectSignals();
     void            ValidateStyle();                                        ///< reconciles inconsistencies in the style flags
     void            VScrolled(int tab_low, int tab_high, int low, int high);///< signals from the vertical scroll bar are caught here

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -2138,7 +2138,7 @@ Pt ListBox::ClientSizeExcludingScrolls() const
     return cl_sz;
 }
 
-std::pair<boost::optional<X>, boost::optional<Y>> ListBox::CheckScrollsRequired() const
+std::pair<boost::optional<X>, boost::optional<Y>> ListBox::CheckIfScrollsRequired(const std::pair<bool, bool>& force_scrolls) const
 {
     // this client area calculation disregards the thickness of scrolls
     Pt cl_sz = (LowerRight() - Pt(X(BORDER_THICK), Y(BORDER_THICK))) -
@@ -2153,11 +2153,13 @@ std::pair<boost::optional<X>, boost::optional<Y>> ListBox::CheckScrollsRequired(
         total_y_extent += row->Height();
 
     bool vertical_needed =
+        force_scrolls.second ||
         m_first_row_shown != m_rows.begin() ||
         (m_rows.size() && (cl_sz.y < total_y_extent ||
                            (cl_sz.y < total_y_extent - SCROLL_WIDTH &&
                             cl_sz.x < total_x_extent - SCROLL_WIDTH)));
     bool horizontal_needed =
+        force_scrolls.first ||
         m_first_col_shown ||
         (m_rows.size() && (cl_sz.x < total_x_extent ||
                            (cl_sz.x < total_x_extent - SCROLL_WIDTH &&
@@ -2268,9 +2270,9 @@ std::pair<bool, bool> ListBox::AddOrRemoveScrolls(
     return {hscroll_added_or_removed, vscroll_added_or_removed};
 }
 
-void ListBox::AdjustScrolls(bool adjust_for_resize)
+void ListBox::AdjustScrolls(bool adjust_for_resize, const std::pair<bool, bool>& force_scrolls)
 {
-    const auto required_total_extents = CheckScrollsRequired();
+    const auto required_total_extents = CheckIfScrollsRequired(force_scrolls);
 
     bool vscroll_added_or_removed;
     std::tie(std::ignore,  vscroll_added_or_removed) = AddOrRemoveScrolls(required_total_extents);

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -858,22 +858,20 @@ void ListBox::PreRender()
     // stable then force the scrollbar to be added if either cycle had a scroll bar.
 
     // Perform a cycle of adjust scrolls and prerendering rows and return if sizes changed.
-    auto check_adjust_scroll_size_change =
-        [this](std::pair<bool, bool> force_scrolls = {false, false})
-        {
-            // This adjust scrolls may add or remove scrolls
-            AdjustScrolls(true);
+    auto check_adjust_scroll_size_change = [this](std::pair<bool, bool> force_scrolls = {false, false}) {
+        // This adjust scrolls may add or remove scrolls
+        AdjustScrolls(true);
 
-            bool visible_row_size_change = ShowVisibleRows(true);
+        bool visible_row_size_change = ShowVisibleRows(true);
 
-            bool header_size_change = false;
-            if (!m_header_row->empty()) {
-                auto old_size = m_header_row->Size();
-                GUI::PreRenderWindow(m_header_row);
-                header_size_change |= (old_size != m_header_row->Size());
-            }
-            return visible_row_size_change | header_size_change;
-        };
+        bool header_size_change = false;
+        if (!m_header_row->empty()) {
+            auto old_size = m_header_row->Size();
+            GUI::PreRenderWindow(m_header_row);
+            header_size_change |= (old_size != m_header_row->Size());
+        }
+        return visible_row_size_change | header_size_change;
+    };
 
     // Try adjusting scroll twice and then force the scrolls on.
     if (check_adjust_scroll_size_change()) {

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -859,8 +859,7 @@ void ListBox::PreRender()
 
     // Perform a cycle of adjust scrolls and prerendering rows and return if sizes changed.
     auto check_adjust_scroll_size_change =
-        [this]
-        (std::pair<bool, bool> force_scrolls = {false, false})
+        [this](std::pair<bool, bool> force_scrolls = {false, false})
         {
             // This adjust scrolls may add or remove scrolls
             AdjustScrolls(true);

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -946,8 +946,9 @@ void ListBox::SizeMove(const Pt& ul, const Pt& lr)
         RequirePreRender();
 }
 
-void ListBox::ShowVisibleRows(bool do_prerender)
+bool ListBox::ShowVisibleRows(bool do_prerender)
 {
+    bool a_row_size_changed = false;
     // Ensure that data in occluded cells is not rendered
     // and that any re-layout during prerender is immediate.
     Y visible_height(BORDER_THICK);
@@ -961,8 +962,11 @@ void ListBox::ShowVisibleRows(bool do_prerender)
             (*it)->Hide();
         } else {
             (*it)->Show();
-            if (do_prerender)
+            if (do_prerender) {
+                auto old_size = (*it)->Size();
                 GUI::PreRenderWindow(*it);
+                a_row_size_changed |= (old_size != (*it)->Size());
+            }
 
             visible_height += (*it)->Height();
             if (visible_height >= max_visible_height)
@@ -970,6 +974,7 @@ void ListBox::ShowVisibleRows(bool do_prerender)
         }
     }
 
+    return a_row_size_changed;
 }
 
 void ListBox::Show(bool show_children /* = true*/)


### PR DESCRIPTION
This PR fixes issue #1199.

The problem was that the sitrep rows change their height in their prerender after the decision to add/remove the vertical scroll bar is made, because it changes the size of the client area.  

In general this problem could be unstable. Every change to the scroll bars changes the client area, which changes the row sizes which changes the scroll bar requirements, closing the feedback loop.

The solution, I've employed is to try twice and then force the scroll bar to be added.
