### PR TITLE
Fix crashes in ModalListPicker in the multiplayer lobby.

### DIFF
--- a/GG/GG/DropDownList.h
+++ b/GG/GG/DropDownList.h
@@ -237,7 +237,7 @@ protected:
 private:
     const ListBox*  LB() const;
 
-    std::unique_ptr<ModalListPicker> const m_modal_picker;
+    const std::shared_ptr<ModalListPicker> m_modal_picker;
 };
 
 } // namespace GG


### PR DESCRIPTION
If the parent of a ModalListPicker that is dropped down and in a modal
event loop is destroyed, then signaling or returning from the Run() and
accessing any members of the parent results in a segfault.

It is not possible to throw an exception and unroll the modal event pump
cleanly.

This commit uses a pair of shared_ptrs to the ModalListPicker instance
to determine if the parent has been destroyed before signaling or
returning from Run().

This PR works for this specific case #1336.

It does not fix the underlying problem that the modal event pump is not thread safe.  There may be other paths lurking to expose this flaw.