### PR TITLE
Add stealth and detection to supply resolution.

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -2005,29 +2005,6 @@ namespace
     }
 }
 
-void Empire::UpdateSystemToStealthAndSupplyRange() {
-
-    m_system_to_stealth_supply.clear();
-
-    // as of this writing, only planets can generate supply propagation
-    for (int object_id : ExistingObjectsKnownToEmpire<Planet>(EmpireID())) {
-        std::shared_ptr<const Planet> planet = GetPlanet(object_id);
-        std::shared_ptr<const UniverseObject> obj = planet;
-        // Check is it an owned planet with a valid id and a supply meter.
-        if (!planet
-            || !planet->OwnedBy(EmpireID())
-            || (planet->SystemID() == INVALID_OBJECT_ID)
-            || !obj->GetMeter(METER_SUPPLY))
-        { continue; }
-
-        // TODO: Why is this NextTurn Supply?
-        float supply_range = obj->NextTurnCurrentMeterValue(METER_SUPPLY);
-        float stealth = obj->GetMeter(METER_STEALTH) ? obj->CurrentMeterValue(METER_STEALTH) : 0;
-
-        m_system_to_stealth_supply[planet->SystemID()].insert(std::make_pair(stealth, supply_range));
-    }
-}
-
 void Empire::UpdateSystemSupplyRanges(const std::set<int>& known_objects) {
     //std::cout << "Empire::UpdateSystemSupplyRanges() for empire " << this->Name() << std::endl;
     m_supply_system_ranges.clear();
@@ -2368,9 +2345,6 @@ void Empire::UpdateAvailableLanes() {
     }
     m_pending_system_exit_lanes.clear(); // TODO: consider: not really necessary, & may be more efficient to not clear.
 }
-
-const std::unordered_map<int, std::set<std::pair<float, float>>>& Empire::SystemToStealthAndSupplyRange() const
-{ return m_system_to_stealth_supply; }
 
 const std::unordered_map<int, float>& Empire::SystemSupplyRanges() const
 { return m_supply_system_ranges; }

--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -3496,12 +3496,12 @@ void Empire::InitResourcePools() {
     m_resource_pools[RE_INDUSTRY]->SetConnectedSupplyGroups(GetSupplyManager().ResourceSupplyGroups(m_id));
 
     // set non-blockadeable resource pools to share resources between all systems
-    std::set<std::set<int> > sets_set;
-    std::set<int> all_systems_set;
+    std::vector<std::unordered_set<int>> sets_set;
+    std::unordered_set<int> all_systems_set;
     for (const std::map<int, std::shared_ptr<UniverseObject>>::value_type& entry : Objects().ExistingSystems()) {
         all_systems_set.insert(entry.first);
     }
-    sets_set.insert(all_systems_set);
+    sets_set.push_back(all_systems_set);
     m_resource_pools[RE_RESEARCH]->SetConnectedSupplyGroups(sets_set);
     m_resource_pools[RE_TRADE]->SetConnectedSupplyGroups(sets_set);
 

--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -2127,13 +2127,6 @@ void Empire::UpdateSupplyUnobstructedSystems(const std::set<int>& known_systems)
     // get all fleets, or just those visible to this client's empire
     const std::set<int>& known_destroyed_objects = GetUniverse().EmpireKnownDestroyedObjectIDs(this->EmpireID());
 
-    // get empire supply ranges
-    std::map<int, std::map<int, float> > empire_system_supply_ranges;
-    for (const std::map<int, Empire*>::value_type& entry : Empires()) {
-        const Empire* empire = entry.second;
-        empire_system_supply_ranges[entry.first] = empire->SystemSupplyRanges();
-    }
-
     // find systems that contain fleets that can either maintain supply or block supply.
     // to affect supply in either manner, a fleet must be armed & aggressive, & must be not
     // trying to depart the systme.  Qualifying enemy fleets will blockade if no friendly fleets

--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -1982,12 +1982,13 @@ void Empire::Win(const std::string& reason) {
 
 namespace
 {
+    template <typename T>
     std::vector<int> ExistingObjectsKnownToEmpire(int id) {
         const Universe& universe = GetUniverse();
         const ObjectMap& empire_known_objects = EmpireKnownObjects(id);
 
         // get ids of objects partially or better visible to this empire.
-        auto known_objects_vec = empire_known_objects.FindObjectIDs();
+        auto known_objects_vec = empire_known_objects.FindObjectIDs<T>();
         const auto& known_destroyed_objects = universe.EmpireKnownDestroyedObjectIDs(id);
 
         std::vector<int> known_objects;
@@ -2005,7 +2006,7 @@ void Empire::UpdateSystemToStealthAndSupplyRange() {
     m_system_to_stealth_supply.clear();
 
     // as of this writing, only planets can generate supply propagation
-    for (int object_id : ExistingObjectsKnownToEmpire(EmpireID())) {
+    for (int object_id : ExistingObjectsKnownToEmpire<Planet>(EmpireID())) {
         std::shared_ptr<const Planet> planet = GetPlanet(object_id);
         std::shared_ptr<const UniverseObject> obj = planet;
         // Check is it an owned planet with a valid id and a supply meter.

--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -2244,6 +2244,9 @@ void Empire::UpdateAvailableLanes() {
     m_pending_system_exit_lanes.clear(); // TODO: consider: not really necessary, & may be more efficient to not clear.
 }
 
+const std::unordered_map<int, std::set<std::pair<float, float>>>& Empire::SystemToStealthAndSupplyRange() const
+{ return m_system_to_stealth_supply; }
+
 const std::map<int, float>& Empire::SystemSupplyRanges() const
 { return m_supply_system_ranges; }
 

--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -2051,7 +2051,7 @@ void Empire::UpdateSystemSupplyRanges(const std::set<int>& known_objects) {
             float supply_range = obj->NextTurnCurrentMeterValue(METER_SUPPLY);
 
             // if this object can provide more supply range than the best previously checked object in this system, record its range as the new best for the system
-            std::map<int, float>::iterator system_it = m_supply_system_ranges.find(system_id);  // try to find a previous entry for this system's supply range
+            const auto& system_it = m_supply_system_ranges.find(system_id);  // try to find a previous entry for this system's supply range
             if (system_it == m_supply_system_ranges.end() || supply_range > system_it->second) {// if there is no previous entry, or the previous entry is shorter than the new one, add or replace the entry
                 //std::cout << " ... object " << obj->Name() << " has resource supply range: " << resource_supply_range << std::endl;
                 m_supply_system_ranges[system_id] = supply_range;
@@ -2368,7 +2368,7 @@ void Empire::UpdateAvailableLanes() {
 const std::unordered_map<int, std::set<std::pair<float, float>>>& Empire::SystemToStealthAndSupplyRange() const
 { return m_system_to_stealth_supply; }
 
-const std::map<int, float>& Empire::SystemSupplyRanges() const
+const std::unordered_map<int, float>& Empire::SystemSupplyRanges() const
 { return m_supply_system_ranges; }
 
 const std::set<int>& Empire::SupplyUnobstructedSystems() const

--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -11,6 +11,7 @@
 
 #include <deque>
 #include <string>
+#include <unordered_set>
 #include <unordered_map>
 
 struct ItemSpec;
@@ -396,6 +397,9 @@ public:
       * propagate supply. */
     const std::map<int, float>&             SystemSupplyRanges() const;
 
+    /** Returns the systems in which this empire is blockading supply.*/
+    const std::unordered_set<int>& SupplyBlockadedSystems() const;
+
     /** Return a map from system id to an ordered set of pairs of stealth and supply range.*/
     const std::unordered_map<int, std::set<std::pair<float, float>>>& SystemToStealthAndSupplyRange() const;
 
@@ -513,6 +517,8 @@ public:
     void        UpdateSystemSupplyRanges(const std::set<int>& known_objects);
     /** Calculates ranges that systems can send fleet and resource supplies. */
     void        UpdateSystemSupplyRanges();
+    /** Calculates the systems in which this empire is blockading supply. */
+    void        UpdateSupplyBlockadedSystems();
     /** Calculates stealth and range that systems can send fleet and resource supplies. */
     void        UpdateSystemToStealthAndSupplyRange();
     /** Calculates systems that can propagate supply (fleet or resource) using
@@ -701,6 +707,9 @@ private:
     // cached calculation results, returned by reference
     std::map<int, float>            m_supply_system_ranges;         ///< number of starlane jumps away from each system (by id) supply can be conveyed.  This is the number due to a system's contents conveying supply and is computed and set by UpdateSystemSupplyRanges
     std::set<int>                   m_supply_unobstructed_systems;  ///< ids of system that don't block supply from flowing
+
+    /** System id where this empire is blockading/protecting supply.*/
+    std::unordered_set<int>         m_systems_with_empire_owned_blockading_fleets;
 
     /** A map from system id to a set of supply stealth and range.*/
     std::unordered_map<int, std::set<std::pair<float, float>>> m_system_to_stealth_supply;

--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -224,15 +224,15 @@ struct FO_COMMON_API ProductionQueue {
 
     /** Returns map from sets of object ids that can share resources to amount
       * of PP available in those groups of objects */
-    std::map<std::set<int>, float> AvailablePP(const std::shared_ptr<ResourcePool>& industry_pool) const;
+    std::map<ResourcePool::key_type, float> AvailablePP(const std::shared_ptr<ResourcePool>& industry_pool) const;
 
     /** Returns map from sets of object ids that can share resources to amount
       * of PP allocated to production queue elements that have build locations
       * in systems in the group. */
-    const std::map<std::set<int>, float>&  AllocatedPP() const;
+    const std::map<ResourcePool::key_type, float>&  AllocatedPP() const;
 
     /** Returns sets of object ids that have more available than allocated PP */
-    std::set<std::set<int>> ObjectsWithWastedPP(const std::shared_ptr<ResourcePool>& industry_pool) const;
+    std::set<ResourcePool::key_type> ObjectsWithWastedPP(const std::shared_ptr<ResourcePool>& industry_pool) const;
 
 
     // STL container-like interface
@@ -277,7 +277,7 @@ struct FO_COMMON_API ProductionQueue {
 private:
     QueueType                       m_queue;
     int                             m_projects_in_progress;
-    std::map<std::set<int>, float>  m_object_group_allocated_pp;
+    std::map<ResourcePool::key_type, float>  m_object_group_allocated_pp;
     int                             m_empire_id;
 
     friend class boost::serialization::access;

--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -400,9 +400,6 @@ public:
     /** Returns the systems in which this empire is blockading supply.*/
     const std::unordered_set<int>& SupplyBlockadedSystems() const;
 
-    /** Return a map from system id to an ordered set of pairs of stealth and supply range.*/
-    const std::unordered_map<int, std::set<std::pair<float, float>>>& SystemToStealthAndSupplyRange() const;
-
     /** Returns set of system ids that are able to propagate supply from one
       * system to the next, or at which supply can be delivered to fleets if
       * supply can reach the system from elsewhere, or in which planets can
@@ -519,8 +516,6 @@ public:
     void        UpdateSystemSupplyRanges();
     /** Calculates the systems in which this empire is blockading supply. */
     void        UpdateSupplyBlockadedSystems();
-    /** Calculates stealth and range that systems can send fleet and resource supplies. */
-    void        UpdateSystemToStealthAndSupplyRange();
     /** Calculates systems that can propagate supply (fleet or resource) using
       * the specified set of \a known_systems */
     void        UpdateSupplyUnobstructedSystems(const std::set<int>& known_systems);
@@ -710,9 +705,6 @@ private:
 
     /** System id where this empire is blockading/protecting supply.*/
     std::unordered_set<int>         m_systems_with_empire_owned_blockading_fleets;
-
-    /** A map from system id to a set of supply stealth and range.*/
-    std::unordered_map<int, std::set<std::pair<float, float>>> m_system_to_stealth_supply;
 
     std::map<int, std::set<int> >   m_available_system_exit_lanes;  ///< for each system known to this empire, the set of available/non-blockaded exit lanes for fleet travel
     std::map<int, std::set<int> >   m_pending_system_exit_lanes;    ///< pending updates to m_available_system_exit_lanes

--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -396,6 +396,9 @@ public:
       * propagate supply. */
     const std::map<int, float>&             SystemSupplyRanges() const;
 
+    /** Return a map from system id to an ordered set of pairs of stealth and supply range.*/
+    const std::unordered_map<int, std::set<std::pair<float, float>>>& SystemToStealthAndSupplyRange() const;
+
     /** Returns set of system ids that are able to propagate supply from one
       * system to the next, or at which supply can be delivered to fleets if
       * supply can reach the system from elsewhere, or in which planets can

--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -395,7 +395,7 @@ public:
 
     /** Returns distance in jumps away from each system that this empire can
       * propagate supply. */
-    const std::map<int, float>&             SystemSupplyRanges() const;
+    const std::unordered_map<int, float>&             SystemSupplyRanges() const;
 
     /** Returns the systems in which this empire is blockading supply.*/
     const std::unordered_set<int>& SupplyBlockadedSystems() const;
@@ -705,7 +705,7 @@ private:
     std::map<std::string, int>      m_building_types_scrapped;  ///< how many buildings of each type has this empire scrapped?
 
     // cached calculation results, returned by reference
-    std::map<int, float>            m_supply_system_ranges;         ///< number of starlane jumps away from each system (by id) supply can be conveyed.  This is the number due to a system's contents conveying supply and is computed and set by UpdateSystemSupplyRanges
+    std::unordered_map<int, float>            m_supply_system_ranges;         ///< number of starlane jumps away from each system (by id) supply can be conveyed.  This is the number due to a system's contents conveying supply and is computed and set by UpdateSystemSupplyRanges
     std::set<int>                   m_supply_unobstructed_systems;  ///< ids of system that don't block supply from flowing
 
     /** System id where this empire is blockading/protecting supply.*/

--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -11,6 +11,7 @@
 
 #include <deque>
 #include <string>
+#include <unordered_map>
 
 struct ItemSpec;
 class ShipDesign;
@@ -509,6 +510,8 @@ public:
     void        UpdateSystemSupplyRanges(const std::set<int>& known_objects);
     /** Calculates ranges that systems can send fleet and resource supplies. */
     void        UpdateSystemSupplyRanges();
+    /** Calculates stealth and range that systems can send fleet and resource supplies. */
+    void        UpdateSystemToStealthAndSupplyRange();
     /** Calculates systems that can propagate supply (fleet or resource) using
       * the specified set of \a known_systems */
     void        UpdateSupplyUnobstructedSystems(const std::set<int>& known_systems);
@@ -695,6 +698,10 @@ private:
     // cached calculation results, returned by reference
     std::map<int, float>            m_supply_system_ranges;         ///< number of starlane jumps away from each system (by id) supply can be conveyed.  This is the number due to a system's contents conveying supply and is computed and set by UpdateSystemSupplyRanges
     std::set<int>                   m_supply_unobstructed_systems;  ///< ids of system that don't block supply from flowing
+
+    /** A map from system id to a set of supply stealth and range.*/
+    std::unordered_map<int, std::set<std::pair<float, float>>> m_system_to_stealth_supply;
+
     std::map<int, std::set<int> >   m_available_system_exit_lanes;  ///< for each system known to this empire, the set of available/non-blockaded exit lanes for fleet travel
     std::map<int, std::set<int> >   m_pending_system_exit_lanes;    ///< pending updates to m_available_system_exit_lanes
 

--- a/Empire/ResourcePool.cpp
+++ b/Empire/ResourcePool.cpp
@@ -135,8 +135,21 @@ std::string ResourcePool::Dump() const {
 void ResourcePool::SetObjects(const std::vector<int>& object_ids)
 { m_object_ids = object_ids; }
 
-void ResourcePool::SetConnectedSupplyGroups(const std::set<std::set<int> >& connected_system_groups)
-{ m_connected_system_groups = connected_system_groups; }
+void ResourcePool::SetConnectedSupplyGroups(const std::vector<std::unordered_set<int>>& connected_system_groups)
+{
+    // TODO Using unordered sets of unordered sets is inefficient since the hash function must be
+    // order N.  Refactor this to have the external container be a vector, which can be iterated to
+    // find the object of interest.  For now transform the set.
+    // m_connected_system_groups = connected_system_groups;
+
+    m_connected_system_groups.clear();
+    for (auto& unordered_set : connected_system_groups) {
+        std::set<int> sorted;
+        for (auto x : unordered_set)
+            sorted.insert(x);
+        m_connected_system_groups.insert(sorted);
+    }
+}
 
 void ResourcePool::SetStockpileObject(int stockpile_object_id)
 { m_stockpile_object_id = stockpile_object_id; }
@@ -175,7 +188,7 @@ void ResourcePool::Update() {
 
         // is object's system in a system group?
         std::set<int> object_system_group;
-        for (const std::set<int>& sys_group : m_connected_system_groups) {
+        for (const auto& sys_group : m_connected_system_groups) {
             if (sys_group.find(object_system_id) != sys_group.end()) {
                 object_system_group = sys_group;
                 break;

--- a/Empire/ResourcePool.cpp
+++ b/Empire/ResourcePool.cpp
@@ -34,16 +34,16 @@ float ResourcePool::Stockpile() const
 
 float ResourcePool::Output() const {
     float retval = 0.0f;
-    for (const std::map<std::set<int>, float>::value_type& entry : m_connected_object_groups_resource_output)
+    for (const auto& entry : m_connected_object_groups_resource_output)
     { retval += entry.second; }
     return retval;
 }
 
 float ResourcePool::GroupOutput(int object_id) const {
     // find group containing specified object
-    for (const std::map<std::set<int>, float>::value_type& entry : m_connected_object_groups_resource_output)
+    for (const auto& entry : m_connected_object_groups_resource_output)
     {
-        const std::set<int>& group = entry.first;
+        const auto& group = *entry.first;
         if (group.find(object_id) != group.end())
             return entry.second;
     }
@@ -56,15 +56,15 @@ float ResourcePool::GroupOutput(int object_id) const {
 
 float ResourcePool::TargetOutput() const {
     float retval = 0.0f;
-    for (const std::map<std::set<int>, float>::value_type& entry : m_connected_object_groups_resource_target_output)
+    for (const auto& entry : m_connected_object_groups_resource_target_output)
     { retval += entry.second; }
     return retval;
 }
 
 float ResourcePool::GroupTargetOutput(int object_id) const {
     // find group containing specified object
-    for (const std::map<std::set<int>, float>::value_type& entry : m_connected_object_groups_resource_target_output) {
-        const std::set<int>& group = entry.first;
+    for (const auto& entry : m_connected_object_groups_resource_target_output) {
+        const auto& group = *entry.first;
         if (group.find(object_id) != group.end())
             return entry.second;
     }
@@ -76,20 +76,20 @@ float ResourcePool::GroupTargetOutput(int object_id) const {
 
 float ResourcePool::TotalAvailable() const {
     float retval = m_stockpile;
-    for (const std::map<std::set<int>, float>::value_type& entry : m_connected_object_groups_resource_output)
+    for (const auto& entry : m_connected_object_groups_resource_output)
     { retval += entry.second; }
     return retval;
 }
 
-std::map<std::set<int>, float> ResourcePool::Available() const {
-    std::map<std::set<int>, float> retval = m_connected_object_groups_resource_output;
+std::map<ResourcePool::key_type, float> ResourcePool::Available() const {
+    auto retval = m_connected_object_groups_resource_output;
 
     if (INVALID_OBJECT_ID == m_stockpile_object_id)
         return retval;  // early exit for no stockpile
 
     // find group that contains the stockpile, and add the stockpile to that group's production to give its availability
-    for (std::map<std::set<int>, float>::value_type& entry : retval) {
-        const std::set<int>& group = entry.first;
+    for (auto& entry : retval) {
+        const auto& group = *entry.first;
         if (group.find(m_stockpile_object_id) != group.end()) {
             entry.second += m_stockpile;
             break;  // assuming stockpile is on only one group
@@ -106,8 +106,8 @@ float ResourcePool::GroupAvailable(int object_id) const {
         return GroupOutput(object_id);
 
     // need to find if stockpile object is in the requested object's group
-    for (const std::map<std::set<int>, float>::value_type& entry : m_connected_object_groups_resource_output) {
-        const std::set<int>& group = entry.first;
+    for (const auto& entry : m_connected_object_groups_resource_output) {
+        const auto& group = *entry.first;
         if (group.find(object_id) != group.end()) {
             // found group for requested object.  is stockpile also in this group?
             if (group.find(m_stockpile_object_id) != group.end())
@@ -135,20 +135,11 @@ std::string ResourcePool::Dump() const {
 void ResourcePool::SetObjects(const std::vector<int>& object_ids)
 { m_object_ids = object_ids; }
 
-void ResourcePool::SetConnectedSupplyGroups(const std::vector<std::unordered_set<int>>& connected_system_groups)
+void ResourcePool::SetConnectedSupplyGroups(const std::vector<ResourcePool::key_type>& connected_system_groups)
 {
-    // TODO Using unordered sets of unordered sets is inefficient since the hash function must be
-    // order N.  Refactor this to have the external container be a vector, which can be iterated to
-    // find the object of interest.  For now transform the set.
-    // m_connected_system_groups = connected_system_groups;
-
     m_connected_system_groups.clear();
-    for (auto& unordered_set : connected_system_groups) {
-        std::set<int> sorted;
-        for (auto x : unordered_set)
-            sorted.insert(x);
-        m_connected_system_groups.insert(sorted);
-    }
+    for (auto& set : connected_system_groups)
+        m_connected_system_groups.insert(set);
 }
 
 void ResourcePool::SetStockpileObject(int stockpile_object_id)
@@ -172,7 +163,8 @@ void ResourcePool::Update() {
 
     // temporary storage: indexed by group of systems, which objects
     // are located in that system group?
-    std::map<std::set<int>, std::set<std::shared_ptr<const UniverseObject>>> system_groups_to_object_groups;
+    std::map<key_type,
+             std::set<std::shared_ptr<const UniverseObject>>> system_groups_to_object_groups;
 
 
     // for every object, find if a connected system group contains the object's
@@ -187,9 +179,9 @@ void ResourcePool::Update() {
             continue;
 
         // is object's system in a system group?
-        std::set<int> object_system_group;
+        key_type object_system_group;
         for (const auto& sys_group : m_connected_system_groups) {
-            if (sys_group.find(object_system_id) != sys_group.end()) {
+            if (sys_group->find(object_system_id) != sys_group->end()) {
                 object_system_group = sys_group;
                 break;
             }
@@ -199,14 +191,15 @@ void ResourcePool::Update() {
         // own entry in m_connected_object_groups_resource_output and m_connected_object_groups_resource_target_output
         // this will allow the object to use its own locally produced
         // resource when, for instance, distributing pp
-        if (object_system_group.empty()) {
-            object_system_group.insert(object_id);  // just use this already-available set to store the object id, even though it is not likely actually a system
+        if (!object_system_group) {
+            auto single_item_group = std::make_shared<std::unordered_set<int>>();
+            single_item_group->insert(object_id);  // just use this set to store the object id, even though it is not likely actually a system
 
             float obj_output = obj->GetMeter(meter_type) ? obj->CurrentMeterValue(meter_type) : 0.0f;
-            m_connected_object_groups_resource_output[object_system_group] = obj_output;
+            m_connected_object_groups_resource_output[single_item_group] = obj_output;
 
             float obj_target_output = obj->GetMeter(target_meter_type) ? obj->CurrentMeterValue(target_meter_type) : 0.0f;
-            m_connected_object_groups_resource_target_output[object_system_group] = obj_target_output;
+            m_connected_object_groups_resource_target_output[single_item_group] = obj_target_output;
             continue;
         }
 
@@ -217,9 +210,9 @@ void ResourcePool::Update() {
 
     // sum the resource production for object groups, and store the total
     // group production, indexed by group of object ids
-    for (std::map<std::set<int>, std::set<std::shared_ptr<const UniverseObject>>>::value_type& entry : system_groups_to_object_groups) {
+    for (auto& entry : system_groups_to_object_groups) {
         const std::set<std::shared_ptr<const UniverseObject>>& object_group = entry.second;
-        std::set<int> object_group_ids;
+        auto object_group_ids = std::make_shared<std::unordered_set<int>>();
         float total_group_output = 0.0f;
         float total_group_target_output = 0.0f;
         for (std::shared_ptr<const UniverseObject> obj : object_group) {
@@ -227,7 +220,7 @@ void ResourcePool::Update() {
                 total_group_output += obj->CurrentMeterValue(meter_type);
             if (obj->GetMeter(target_meter_type))
                 total_group_target_output += obj->CurrentMeterValue(target_meter_type);
-            object_group_ids.insert(obj->ID());
+            object_group_ids->insert(obj->ID());
         }
         m_connected_object_groups_resource_output[object_group_ids] = total_group_output;
         m_connected_object_groups_resource_target_output[object_group_ids] = total_group_target_output;

--- a/Empire/ResourcePool.h
+++ b/Empire/ResourcePool.h
@@ -9,6 +9,7 @@
 
 #include <vector>
 #include <set>
+#include <unordered_set>
 
 class ResourceCenter;
 class PopCenter;
@@ -49,7 +50,7 @@ public:
     void        SetObjects(const std::vector<int>& object_ids);
     /** specifies which sets systems can share resources.  any two sets should
       * have no common systems. */
-    void        SetConnectedSupplyGroups(const std::set<std::set<int> >& connected_system_groups);
+    void        SetConnectedSupplyGroups(const std::vector<std::unordered_set<int>>& connected_system_groups);
 
    /** specifies which object has access to the resource stockpile.  Objects in
      * a supply group with the object that can access the stockpile can store
@@ -66,7 +67,7 @@ private:
     ResourcePool(); ///< default ctor needed for serialization
 
     std::vector<int>                        m_object_ids;                                       ///< IDs of objects to consider in this pool
-    std::set<std::set<int> >                m_connected_system_groups;                          ///< sets of systems between and in which objects can share this pool's resource
+    std::set<std::set<int>>                m_connected_system_groups;                          ///< sets of systems between and in which objects can share this pool's resource
     std::map<std::set<int>, float>          m_connected_object_groups_resource_output;          ///< cached map from connected group of objects that can share resources, to how much resource is output by ResourceCenters in the group.  regenerated during update from other state information.
     std::map<std::set<int>, float>          m_connected_object_groups_resource_target_output;   ///< cached map from connected group of objects that can share resources, to how much resource would, if all meters equaled their target meters, be output by ResourceCenters in the group.  regenerated during update from other state information.
     int                                     m_stockpile_object_id;                              ///< object id where stockpile for this pool is located

--- a/Empire/ResourcePool.h
+++ b/Empire/ResourcePool.h
@@ -22,7 +22,7 @@ class FO_COMMON_API ResourcePool {
 public:
     // Resource pool uses pointers to shared const int sets as key to it sets and maps.
     // Using the set itself as the key is slow, because both set comparison and hasing are O(N).
-    using key_type = std::shared_ptr<const std::unordered_set<int>>;
+    using key_type = std::shared_ptr<std::unordered_set<int>>;
 
     /** \name Structors */ //@{
     ResourcePool(ResourceType type);

--- a/Empire/ResourcePool.h
+++ b/Empire/ResourcePool.h
@@ -20,6 +20,10 @@ class Empire;
   * of a particular resource (eg. research, industry). */
 class FO_COMMON_API ResourcePool {
 public:
+    // Resource pool uses pointers to shared const int sets as key to it sets and maps.
+    // Using the set itself as the key is slow, because both set comparison and hasing are O(N).
+    using key_type = std::shared_ptr<const std::unordered_set<int>>;
+
     /** \name Structors */ //@{
     ResourcePool(ResourceType type);
     //@}
@@ -36,7 +40,7 @@ public:
     float                           GroupTargetOutput(int object_id) const;
 
     float                           TotalAvailable() const;                 ///< returns amount of resource immediately available = production + stockpile from all ResourceCenters, ignoring limitations of connections between centers
-    std::map<std::set<int>, float>  Available() const;                      ///< returns the sets of groups of objects that can share resources, and the amount of this pool's resource that each group has available
+    std::map<key_type, float>  Available() const;                      ///< returns the sets of groups of objects that can share resources, and the amount of this pool's resource that each group has available
     float                           GroupAvailable(int object_id) const;    ///< returns amount of resource available in resource sharing group that contains the object with id \a object_id
 
     std::string                     Dump() const;
@@ -50,7 +54,7 @@ public:
     void        SetObjects(const std::vector<int>& object_ids);
     /** specifies which sets systems can share resources.  any two sets should
       * have no common systems. */
-    void        SetConnectedSupplyGroups(const std::vector<std::unordered_set<int>>& connected_system_groups);
+    void        SetConnectedSupplyGroups(const std::vector<key_type>& connected_system_groups);
 
    /** specifies which object has access to the resource stockpile.  Objects in
      * a supply group with the object that can access the stockpile can store
@@ -67,9 +71,9 @@ private:
     ResourcePool(); ///< default ctor needed for serialization
 
     std::vector<int>                        m_object_ids;                                       ///< IDs of objects to consider in this pool
-    std::set<std::set<int>>                m_connected_system_groups;                          ///< sets of systems between and in which objects can share this pool's resource
-    std::map<std::set<int>, float>          m_connected_object_groups_resource_output;          ///< cached map from connected group of objects that can share resources, to how much resource is output by ResourceCenters in the group.  regenerated during update from other state information.
-    std::map<std::set<int>, float>          m_connected_object_groups_resource_target_output;   ///< cached map from connected group of objects that can share resources, to how much resource would, if all meters equaled their target meters, be output by ResourceCenters in the group.  regenerated during update from other state information.
+    std::set<key_type>                 m_connected_system_groups;                          ///< sets of systems between and in which objects can share this pool's resource
+    std::map<key_type, float>          m_connected_object_groups_resource_output;          ///< cached map from connected group of objects that can share resources, to how much resource is output by ResourceCenters in the group.  regenerated during update from other state information.
+    std::map<key_type, float>          m_connected_object_groups_resource_target_output;   ///< cached map from connected group of objects that can share resources, to how much resource would, if all meters equaled their target meters, be output by ResourceCenters in the group.  regenerated during update from other state information.
     int                                     m_stockpile_object_id;                              ///< object id where stockpile for this pool is located
     float                                   m_stockpile;                                        ///< current stockpiled amount of resource
     ResourceType                            m_type;                                             ///< what kind of resource does this pool hold?
@@ -121,7 +125,9 @@ void ResourcePool::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_object_ids)
         & BOOST_SERIALIZATION_NVP(m_stockpile)
         & BOOST_SERIALIZATION_NVP(m_stockpile_object_id)
-        & BOOST_SERIALIZATION_NVP(m_connected_system_groups);
+        & BOOST_SERIALIZATION_NVP(m_connected_system_groups)
+        & BOOST_SERIALIZATION_NVP(m_connected_object_groups_resource_output)
+        & BOOST_SERIALIZATION_NVP(m_connected_object_groups_resource_target_output);
 }
 
 template <class Archive>

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -73,8 +73,8 @@ public:
 
     /** Returns set of sets of systems that can share industry (systems in
       * separate groups are blockaded or otherwise separated). */
-    const std::unordered_map<int, std::vector<std::shared_ptr<const std::unordered_set<int>>>>& ResourceSupplyGroups() const;
-    const std::vector<std::shared_ptr<const std::unordered_set<int>>>&                          ResourceSupplyGroups(int empire_id) const;
+    const std::unordered_map<int, std::vector<std::shared_ptr<std::unordered_set<int>>>>& ResourceSupplyGroups() const;
+    const std::vector<std::shared_ptr<std::unordered_set<int>>>&                          ResourceSupplyGroups(int empire_id) const;
 
     /** Returns the range from each system that the empire with id \a empire_id
       * can propagate supply.*/
@@ -136,7 +136,7 @@ private:
     /** sets of system ids that are connected by supply lines and are able to
         share resources between systems or between objects in systems. indexed
         by empire id. */
-    std::unordered_map<int, std::vector<std::shared_ptr<const std::unordered_set<int>>>>  m_resource_supply_groups;
+    std::unordered_map<int, std::vector<std::shared_ptr<std::unordered_set<int>>>>  m_resource_supply_groups;
 
     /** for whichever empire can propagate supply into this system, what is the
         additional range from this system that empire can propagate supply */
@@ -189,7 +189,7 @@ namespace {
     static const std::set<int> EMPTY_INT_SET;
     static const std::set<std::set<int>> EMPTY_INT_SET_SET;
     static const std::unordered_set<int> EMPTY_INT_UNORDERED_SET;
-    static const std::vector<std::shared_ptr<const std::unordered_set<int>>> EMPTY_INT_VECTOR_SHARED_UNORDERED_SET;
+    static const std::vector<std::shared_ptr<std::unordered_set<int>>> EMPTY_INT_VECTOR_SHARED_UNORDERED_SET;
     static const std::set<std::pair<int, int>> EMPTY_INT_PAIR_SET;
     static const std::map<int, float> EMPTY_INT_FLOAT_MAP;
     static const std::unordered_map<int, float> EMPTY_INT_FLOAT_UNORDERED_MAP;
@@ -243,10 +243,10 @@ std::unordered_set<int> SupplyManager::SupplyManagerImpl::FleetSupplyableSystemI
     return retval;
 }
 
-const std::unordered_map<int, std::vector<std::shared_ptr<const std::unordered_set<int>>>>& SupplyManager::SupplyManagerImpl::ResourceSupplyGroups() const
+const std::unordered_map<int, std::vector<std::shared_ptr<std::unordered_set<int>>>>& SupplyManager::SupplyManagerImpl::ResourceSupplyGroups() const
 { return m_resource_supply_groups; }
 
-const std::vector<std::shared_ptr<const std::unordered_set<int>>>& SupplyManager::SupplyManagerImpl::ResourceSupplyGroups(int empire_id) const {
+const std::vector<std::shared_ptr<std::unordered_set<int>>>& SupplyManager::SupplyManagerImpl::ResourceSupplyGroups(int empire_id) const {
     const auto& it = m_resource_supply_groups.find(empire_id);
     if (it != m_resource_supply_groups.end())
         return it->second;
@@ -2086,10 +2086,10 @@ const std::unordered_set<int>&                                    SupplyManager:
 std::unordered_set<int>                                           SupplyManager::FleetSupplyableSystemIDs(int empire_id, bool include_allies) const
 { return pimpl->FleetSupplyableSystemIDs(empire_id, include_allies); }
 
-const std::unordered_map<int, std::vector<std::shared_ptr<const std::unordered_set<int>>>>&         SupplyManager::ResourceSupplyGroups() const
+const std::unordered_map<int, std::vector<std::shared_ptr<std::unordered_set<int>>>>&         SupplyManager::ResourceSupplyGroups() const
 { return pimpl->ResourceSupplyGroups(); }
 
-const std::vector<std::shared_ptr<const std::unordered_set<int>>>&                         SupplyManager::ResourceSupplyGroups(int empire_id) const
+const std::vector<std::shared_ptr<std::unordered_set<int>>>&                         SupplyManager::ResourceSupplyGroups(int empire_id) const
 { return pimpl->ResourceSupplyGroups(empire_id); }
 
 const std::unordered_map<int, float>&                             SupplyManager::PropagatedSupplyRanges(int empire_id) const

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -664,41 +664,6 @@ namespace {
         return empire_to_stealth_supply;
     }
 
-    // /** Return a map from empire id to the stealth and supply of a supply generating object.*/
-    // boost::optional<std::unordered_map<int, std::set<std::pair<float, SupplyMerit>>>>
-    // CalculateEmpireToStealthSupply(const System& system) {
-    //     boost::optional<std::unordered_map<int, std::set<std::pair<float, SupplyMerit>>>>
-    //         empire_to_stealth_supply = boost::none;
-
-    //     // as of this writing, only planets can generate supply propagation
-    //     for (auto obj : Objects().FindObjects(system.PlanetIDs())) {
-    //         auto merit = CalculateSupplyMerit(obj);
-    //         if(!merit)
-    //             continue;
-
-    //         float stealth = obj->GetMeter(METER_STEALTH) ? obj->CurrentMeterValue(METER_STEALTH) : 0;
-    //         if (!empire_to_stealth_supply)
-    //             empire_to_stealth_supply = std::unordered_map<int, std::set<std::pair<float, SupplyMerit>>>();
-    //         (*empire_to_stealth_supply)[obj->Owner()].insert({stealth, *merit});
-    //     }
-
-    //     return empire_to_stealth_supply;
-    // }
-
-    // /** Return a map from system id to empire id to the stealth and supply of a supply generating object.*/
-    // std::unordered_map<int, std::unordered_map<int, std::set<std::pair<float, SupplyMerit>>>> CalculateSystemToEmpireToStealthSupply() {
-    //     std::unordered_map<int, std::unordered_map<int, std::set<std::pair<float, SupplyMerit>>>> system_to_empire_to_stealth_supply;
-
-    //     for (auto system_it : Objects().ExistingSystems()) {
-    //         if (auto system = std::dynamic_pointer_cast<const System>(system_it.second)) {
-    //             if (auto stealth_supply = CalculateEmpireToStealthSupply(*system))
-    //                 system_to_empire_to_stealth_supply[system->SystemID()] = *stealth_supply;
-    //         }
-    //     }
-
-    //     return system_to_empire_to_stealth_supply;
-    // }
-
     /** Return sets of contestings and blockading fleet's empire ids.
 
         The fleets determined to be blocking by this function may be different than

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -18,14 +18,124 @@
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/connected_components.hpp>
 
-SupplyManager::SupplyManager() :
+
+class SupplyManager::SupplyManagerImpl {
+public:
+    /** \name Structors */ //@{
+    SupplyManagerImpl();
+    SupplyManagerImpl& operator=(const SupplyManagerImpl& rhs);
+    //@}
+
+    /** \name Accessors */ //@{
+    /** Returns set of directed starlane traversals along which supply can flow.
+      * Results are pairs of system ids of start and end system of traversal. */
+    const std::map<int, std::set<std::pair<int, int> > >&   SupplyStarlaneTraversals() const;
+    const std::set<std::pair<int, int> >&                   SupplyStarlaneTraversals(int empire_id) const;
+
+    /** Returns set of directed starlane traversals along which supply could
+      * flow for this empire, but which can't due to some obstruction in one
+      * of the systems. */
+    const std::map<int, std::set<std::pair<int, int> > >&   SupplyObstructedStarlaneTraversals() const;
+    const std::set<std::pair<int, int> >&                   SupplyObstructedStarlaneTraversals(int empire_id) const;
+
+    /** Returns set of system ids where fleets can be supplied by this empire
+      * (as determined by object supply meters and rules of supply propagation
+      * and blockade). */
+    const std::map<int, std::set<int> >&                    FleetSupplyableSystemIDs() const;
+    const std::set<int>&                                    FleetSupplyableSystemIDs(int empire_id) const;
+    std::set<int>                                           FleetSupplyableSystemIDs(int empire_id, bool include_allies) const;
+    int                                                     EmpireThatCanSupplyAt(int system_id) const;
+
+    /** Returns set of sets of systems that can share industry (systems in
+      * separate groups are blockaded or otherwise separated). */
+    const std::map<int, std::set<std::set<int> > >&         ResourceSupplyGroups() const;
+    const std::set<std::set<int> >&                         ResourceSupplyGroups(int empire_id) const;
+
+    /** Returns the range from each system some empire can propagate supply.*/
+    const std::map<int, float>&                             PropagatedSupplyRanges() const;
+    /** Returns the range from each system that the empire with id \a empire_id
+      * can propagate supply.*/
+    const std::map<int, float>&                             PropagatedSupplyRanges(int empire_id) const;
+
+    /** Returns the distance from each system some empire is away
+      * from its closest source of supply without passing
+      * through obstructed systems for that empire. */
+    const std::map<int, float>&                             PropagatedSupplyDistances() const;
+    /** Returns the distance from each system for the empire with id
+      * \a empire_id to the closest source of supply without passing
+      * through obstructed systems for that empire. */
+    const std::map<int, float>&                             PropagatedSupplyDistances(int empire_id) const;
+
+    /** Returns true if system with id \a system_id is fleet supplyable or in
+      * one of the resource supply groups for empire with id \a empire_id */
+    bool        SystemHasFleetSupply(int system_id, int empire_id) const;
+    bool        SystemHasFleetSupply(int system_id, int empire_id, bool include_allies) const;
+
+    std::string Dump(int empire_id = ALL_EMPIRES) const;
+    //@}
+
+    /** \name Mutators */ //@{
+    /** Calculates systems at which fleets of empires can be supplied, and
+      * groups of systems that can exchange resources, and the starlane
+      * traversals used to do so. */
+    void    Update();
+    //@}
+
+    friend class boost::serialization::access;
+    template <class Archive>
+    void serialize(Archive& ar, const unsigned int version);
+
+private:
+    /** ordered pairs of system ids between which a starlane runs that can be
+        used to convey resources between systems. indexed first by empire id. */
+    std::map<int, std::set<std::pair<int, int> > >  m_supply_starlane_traversals;
+
+    /** ordered pairs of system ids between which a starlane could be used to
+        convey resources between system, but is not because something is
+        obstructing the resource flow.  That is, the resource flow isn't limited
+        by range, but by something blocking its flow. */
+    std::map<int, std::set<std::pair<int, int> > >  m_supply_starlane_obstructed_traversals;
+
+    /** ids of systems where fleets can be resupplied. indexed by empire id. */
+    std::map<int, std::set<int> >                   m_fleet_supplyable_system_ids;
+
+    /** sets of system ids that are connected by supply lines and are able to
+        share resources between systems or between objects in systems. indexed
+        by empire id. */
+    std::map<int, std::set<std::set<int> > >        m_resource_supply_groups;
+
+    /** for whichever empire can propagate supply into this system, what is the
+        additional range from this system that empire can propagate supply */
+    std::map<int, float>                            m_propagated_supply_ranges;
+
+    /** for each empire, what systems it can propagate supply into, and how many
+      * further supply jumps it could propagate past this system, if not blocked
+      * from doing so by supply obstructions. */
+    std::map<int, std::map<int, float>>             m_empire_propagated_supply_ranges;
+
+    /** for whichever empire can propagate supply into this system, how far
+      * that system is from the closest source of supply for that empire, along
+      * possible supply propgation connections (ie. not though a supply
+      * obstructed system for that empire) */
+    std::map<int, float>                            m_propagated_supply_distances;
+
+    /** for each empire, what systems it can propagate supply into, and how far
+      * that system is from the closest source of supply for that empire, along
+      * possible supply propgation connections (ie. not though a supply
+      * obstructed system) */
+    std::map<int, std::map<int, float>>             m_empire_propagated_supply_distances;
+
+};
+
+
+SupplyManager::SupplyManagerImpl::SupplyManagerImpl() :
     m_supply_starlane_traversals(),
     m_supply_starlane_obstructed_traversals(),
     m_fleet_supplyable_system_ids(),
     m_resource_supply_groups()
 {}
 
-SupplyManager& SupplyManager::operator=(const SupplyManager& rhs) {
+SupplyManager::SupplyManagerImpl& SupplyManager::SupplyManagerImpl::operator=(const SupplyManagerImpl& rhs) {
     m_supply_starlane_traversals =              rhs.m_supply_starlane_traversals;
     m_supply_starlane_obstructed_traversals =   rhs.m_supply_starlane_obstructed_traversals;
     m_fleet_supplyable_system_ids =             rhs.m_fleet_supplyable_system_ids;
@@ -40,37 +150,37 @@ namespace {
     static const std::map<int, float> EMPTY_INT_FLOAT_MAP;
 }
 
-const std::map<int, std::set<std::pair<int, int>>>& SupplyManager::SupplyStarlaneTraversals() const
+const std::map<int, std::set<std::pair<int, int>>>& SupplyManager::SupplyManagerImpl::SupplyStarlaneTraversals() const
 { return m_supply_starlane_traversals; }
 
-const std::set<std::pair<int, int>>& SupplyManager::SupplyStarlaneTraversals(int empire_id) const {
+const std::set<std::pair<int, int>>& SupplyManager::SupplyManagerImpl::SupplyStarlaneTraversals(int empire_id) const {
     std::map<int, std::set<std::pair<int, int>>>::const_iterator it = m_supply_starlane_traversals.find(empire_id);
     if (it != m_supply_starlane_traversals.end())
         return it->second;
     return EMPTY_INT_PAIR_SET;
 }
 
-const std::map<int, std::set<std::pair<int, int>>>& SupplyManager::SupplyObstructedStarlaneTraversals() const
+const std::map<int, std::set<std::pair<int, int>>>& SupplyManager::SupplyManagerImpl::SupplyObstructedStarlaneTraversals() const
 { return m_supply_starlane_obstructed_traversals; }
 
-const std::set<std::pair<int, int>>& SupplyManager::SupplyObstructedStarlaneTraversals(int empire_id) const {
+const std::set<std::pair<int, int>>& SupplyManager::SupplyManagerImpl::SupplyObstructedStarlaneTraversals(int empire_id) const {
     std::map<int, std::set<std::pair<int, int>>>::const_iterator it = m_supply_starlane_obstructed_traversals.find(empire_id);
     if (it != m_supply_starlane_obstructed_traversals.end())
         return it->second;
     return EMPTY_INT_PAIR_SET;
 }
 
-const std::map<int, std::set<int>>& SupplyManager::FleetSupplyableSystemIDs() const
+const std::map<int, std::set<int>>& SupplyManager::SupplyManagerImpl::FleetSupplyableSystemIDs() const
 { return m_fleet_supplyable_system_ids; }
 
-const std::set<int>& SupplyManager::FleetSupplyableSystemIDs(int empire_id) const {
+const std::set<int>& SupplyManager::SupplyManagerImpl::FleetSupplyableSystemIDs(int empire_id) const {
     std::map<int, std::set<int>>::const_iterator it = m_fleet_supplyable_system_ids.find(empire_id);
     if (it != m_fleet_supplyable_system_ids.end())
         return it->second;
     return EMPTY_INT_SET;
 }
 
-std::set<int> SupplyManager::FleetSupplyableSystemIDs(int empire_id, bool include_allies) const {
+std::set<int> SupplyManager::SupplyManagerImpl::FleetSupplyableSystemIDs(int empire_id, bool include_allies) const {
     std::set<int> retval = FleetSupplyableSystemIDs(empire_id);
     if (!include_allies)
         return retval;
@@ -86,7 +196,7 @@ std::set<int> SupplyManager::FleetSupplyableSystemIDs(int empire_id, bool includ
     return retval;
 }
 
-int SupplyManager::EmpireThatCanSupplyAt(int system_id) const {
+int SupplyManager::SupplyManagerImpl::EmpireThatCanSupplyAt(int system_id) const {
     for (const std::map<int, std::set<int>>::value_type& entry : m_fleet_supplyable_system_ids) {
         if (entry.second.find(system_id) != entry.second.end())
             return entry.first;
@@ -94,22 +204,22 @@ int SupplyManager::EmpireThatCanSupplyAt(int system_id) const {
     return ALL_EMPIRES;
 }
 
-const std::map<int, std::set<std::set<int>>>& SupplyManager::ResourceSupplyGroups() const
+const std::map<int, std::set<std::set<int>>>& SupplyManager::SupplyManagerImpl::ResourceSupplyGroups() const
 { return m_resource_supply_groups; }
 
-const std::set<std::set<int>>& SupplyManager::ResourceSupplyGroups(int empire_id) const {
+const std::set<std::set<int>>& SupplyManager::SupplyManagerImpl::ResourceSupplyGroups(int empire_id) const {
     std::map<int, std::set<std::set<int>>>::const_iterator it = m_resource_supply_groups.find(empire_id);
     if (it != m_resource_supply_groups.end())
         return it->second;
     return EMPTY_INT_SET_SET;
 }
 
-const std::map<int, float>& SupplyManager::PropagatedSupplyRanges() const {
+const std::map<int, float>& SupplyManager::SupplyManagerImpl::PropagatedSupplyRanges() const {
     std::cout << "BLAAAAH" << std::endl;
     return m_propagated_supply_ranges;
 }
 
-const std::map<int, float>& SupplyManager::PropagatedSupplyRanges(int empire_id) const
+const std::map<int, float>& SupplyManager::SupplyManagerImpl::PropagatedSupplyRanges(int empire_id) const
 {
     auto emp_it = m_empire_propagated_supply_ranges.find(empire_id);
     if (emp_it == m_empire_propagated_supply_ranges.end())
@@ -117,19 +227,19 @@ const std::map<int, float>& SupplyManager::PropagatedSupplyRanges(int empire_id)
     return emp_it->second;
 }
 
-const std::map<int, float>& SupplyManager::PropagatedSupplyDistances() const {
+const std::map<int, float>& SupplyManager::SupplyManagerImpl::PropagatedSupplyDistances() const {
     std::cout << "GLAARB" << std::endl;
     return m_propagated_supply_distances;
 }
 
-const std::map<int, float>& SupplyManager::PropagatedSupplyDistances(int empire_id) const {
+const std::map<int, float>& SupplyManager::SupplyManagerImpl::PropagatedSupplyDistances(int empire_id) const {
     auto emp_it = m_empire_propagated_supply_distances.find(empire_id);
     if (emp_it == m_empire_propagated_supply_distances.end())
         return EMPTY_INT_FLOAT_MAP;
     return emp_it->second;
 }
 
-bool SupplyManager::SystemHasFleetSupply(int system_id, int empire_id) const {
+bool SupplyManager::SupplyManagerImpl::SystemHasFleetSupply(int system_id, int empire_id) const {
     if (system_id == INVALID_OBJECT_ID)
         return false;
     if (empire_id == ALL_EMPIRES)
@@ -143,7 +253,7 @@ bool SupplyManager::SystemHasFleetSupply(int system_id, int empire_id) const {
     return false;
 }
 
-bool SupplyManager::SystemHasFleetSupply(int system_id, int empire_id, bool include_allies) const {
+bool SupplyManager::SupplyManagerImpl::SystemHasFleetSupply(int system_id, int empire_id, bool include_allies) const {
     if (!include_allies)
         return SystemHasFleetSupply(system_id, empire_id);
     if (system_id == INVALID_OBJECT_ID)
@@ -169,7 +279,7 @@ bool SupplyManager::SystemHasFleetSupply(int system_id, int empire_id, bool incl
     return false;
 }
 
-std::string SupplyManager::Dump(int empire_id) const {
+std::string SupplyManager::SupplyManagerImpl::Dump(int empire_id) const {
     std::string retval;
 
     try {
@@ -267,7 +377,7 @@ namespace {
     }
 }
 
-void SupplyManager::Update() {
+void SupplyManager::SupplyManagerImpl::Update() {
     m_supply_starlane_traversals.clear();
     m_supply_starlane_obstructed_traversals.clear();
     m_fleet_supplyable_system_ids.clear();
@@ -788,7 +898,7 @@ void SupplyManager::Update() {
 }
 
 template <class Archive>
-void SupplyManager::serialize(Archive& ar, const unsigned int version)
+void SupplyManager::SupplyManagerImpl::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_NVP(m_supply_starlane_traversals)
         & BOOST_SERIALIZATION_NVP(m_supply_starlane_obstructed_traversals)
@@ -799,6 +909,86 @@ void SupplyManager::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_propagated_supply_distances)
         & BOOST_SERIALIZATION_NVP(m_empire_propagated_supply_distances);
 }
+
+template void SupplyManager::SupplyManagerImpl::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, const unsigned int);
+template void SupplyManager::SupplyManagerImpl::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, const unsigned int);
+template void SupplyManager::SupplyManagerImpl::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, const unsigned int);
+template void SupplyManager::SupplyManagerImpl::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
+
+
+////////////////////////////////////////
+// Supply Manager
+////////////////////////////////////////
+
+SupplyManager::SupplyManager() :
+    pimpl(new SupplyManagerImpl)
+{}
+
+// Required to call pimpl destructor.
+SupplyManager::~SupplyManager() {}
+
+SupplyManager& SupplyManager::operator=(const SupplyManager& rhs) {
+    pimpl->operator=(*rhs.pimpl);
+    return *this;
+}
+
+const std::map<int, std::set<std::pair<int, int> > >&   SupplyManager::SupplyStarlaneTraversals() const
+{ return pimpl->SupplyStarlaneTraversals(); }
+
+const std::set<std::pair<int, int> >&                   SupplyManager::SupplyStarlaneTraversals(int empire_id) const
+{ return pimpl->SupplyStarlaneTraversals(empire_id); }
+
+const std::map<int, std::set<std::pair<int, int> > >&   SupplyManager::SupplyObstructedStarlaneTraversals() const
+{ return pimpl->SupplyObstructedStarlaneTraversals(); }
+
+const std::set<std::pair<int, int> >&                   SupplyManager::SupplyObstructedStarlaneTraversals(int empire_id) const
+{ return pimpl->SupplyObstructedStarlaneTraversals(empire_id); }
+
+const std::map<int, std::set<int> >&                    SupplyManager::FleetSupplyableSystemIDs() const
+{ return pimpl->FleetSupplyableSystemIDs(); }
+
+const std::set<int>&                                    SupplyManager::FleetSupplyableSystemIDs(int empire_id) const
+{ return pimpl->FleetSupplyableSystemIDs(empire_id); }
+
+std::set<int>                                           SupplyManager::FleetSupplyableSystemIDs(int empire_id, bool include_allies) const
+{ return pimpl->FleetSupplyableSystemIDs(empire_id, include_allies); }
+
+int                                                     SupplyManager::EmpireThatCanSupplyAt(int system_id) const
+{ return pimpl->EmpireThatCanSupplyAt(system_id); }
+
+const std::map<int, std::set<std::set<int> > >&         SupplyManager::ResourceSupplyGroups() const
+{ return pimpl->ResourceSupplyGroups(); }
+
+const std::set<std::set<int> >&                         SupplyManager::ResourceSupplyGroups(int empire_id) const
+{ return pimpl->ResourceSupplyGroups(empire_id); }
+
+const std::map<int, float>&                             SupplyManager::PropagatedSupplyRanges() const
+{ return pimpl->PropagatedSupplyRanges(); }
+
+const std::map<int, float>&                             SupplyManager::PropagatedSupplyRanges(int empire_id) const
+{ return pimpl->PropagatedSupplyRanges(empire_id); }
+
+const std::map<int, float>&                             SupplyManager::PropagatedSupplyDistances() const
+{ return pimpl->PropagatedSupplyDistances(); }
+
+const std::map<int, float>&                             SupplyManager::PropagatedSupplyDistances(int empire_id) const
+{ return pimpl->PropagatedSupplyDistances(empire_id); }
+
+bool                                                    SupplyManager::SystemHasFleetSupply(int system_id, int empire_id) const
+{ return pimpl->SystemHasFleetSupply(system_id, empire_id); }
+
+bool                                                    SupplyManager::SystemHasFleetSupply(int system_id, int empire_id, bool include_allies) const
+{ return pimpl->SystemHasFleetSupply(system_id, empire_id, include_allies); }
+
+std::string                                             SupplyManager::Dump(int empire_id /*= ALL_EMPIRES*/) const
+{ return pimpl->Dump(empire_id); }
+
+void                                                    SupplyManager::Update()
+{ return pimpl->Update(); }
+
+template <class Archive>
+void SupplyManager::serialize(Archive& ar, const unsigned int version)
+{ pimpl->serialize(ar, version); }
 
 template void SupplyManager::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, const unsigned int);
 template void SupplyManager::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, const unsigned int);

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -507,6 +507,11 @@ namespace {
             return std::tie(l.range, l.bonus, l.distance) == std::tie(r.range, r.bonus, r.distance);
         }
 
+        friend std::ostream& operator<<(std::ostream& os, const SupplyMerit& x) {
+            os << '(' << x.range << '/' << x.bonus << '/' << x.distance << ')';
+            return os;
+        }
+
         private:
         // Number of jumps that the supply can propagate.
         // TODO Should this be unsigned int?

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -423,16 +423,19 @@ std::unordered_map<int, std::vector<int>> CalculateColonyDisruptedSupply(
             }
         }
 
-        std::set<int> systems_where_others_have_supply_sources_and_current_empire_doesnt;
-        // add all systems where others have supply
+        std::set<int> systems_where_hostile_others_have_supply_sources_and_current_empire_doesnt;
+        // add all systems where hostile_others have supply
         for (const std::map<int, std::map<int, float>>::value_type& empire_supply : empire_system_supply_ranges) {
             if (empire_supply.first == empire_id || empire_supply.first == ALL_EMPIRES)
+                continue;
+
+            if (Empires().GetDiplomaticStatus(empire_id, empire_supply.first) != DIPLO_WAR)
                 continue;
 
             for (const std::map<int, float>::value_type& supply_range : empire_supply.second) {
                 if (supply_range.second <= 0.0f)
                     continue;
-                systems_where_others_have_supply_sources_and_current_empire_doesnt.insert(supply_range.first);
+                systems_where_hostile_others_have_supply_sources_and_current_empire_doesnt.insert(supply_range.first);
             }
         }
         // remove systems were this empire has supply
@@ -441,14 +444,14 @@ std::unordered_map<int, std::vector<int>> CalculateColonyDisruptedSupply(
             for (const std::map<int, float>::value_type& supply_range : it->second) {
                 if (supply_range.second <= 0.0f)
                     continue;
-                systems_where_others_have_supply_sources_and_current_empire_doesnt.erase(supply_range.first);
+                systems_where_hostile_others_have_supply_sources_and_current_empire_doesnt.erase(supply_range.first);
             }
         }
 
         // for systems where others have supply sources and this empire doesn't
         // and where this empire has no fleets...
         // supply is obstructed
-        for (int system_id : systems_where_others_have_supply_sources_and_current_empire_doesnt) {
+        for (int system_id : systems_where_hostile_others_have_supply_sources_and_current_empire_doesnt) {
             if (systems_containing_friendly_fleets.find(system_id) == systems_containing_friendly_fleets.end())
                 self_protected_supply.push_back(system_id);
         }
@@ -595,25 +598,19 @@ std::map<int, std::map<int, std::pair<float, float>>> SupplyManager::SupplyManag
             if (empire_ranges_here.size() == 1 && empire_ranges_here.begin()->second.size() < 2)
                 continue;   // only one empire has supply here
 
-            // at least two empires have supply sources here...
-            // check if one is stronger
+            // remove range entries and traversals for all empires hostile to any of the top empires
+            const auto & top_empires = empire_ranges_here.rbegin()->second;
 
-            // remove supply for all empires except the top-ranged empire here
-            // if there is a tie for top-ranged, remove all
-            std::map<float, std::set<int>>::reverse_iterator range_empire_it = empire_ranges_here.rbegin();
-            int top_range_empire_id = ALL_EMPIRES;
-            if (range_empire_it->second.size() == 1) {
-                // if just one empire has the most range, it is the top empire
-                top_range_empire_id = *(range_empire_it->second.begin());
-            }
-            //DebugLogger() << "top ranged empire here: " << top_range_empire_id;
-
-            // remove range entries and traversals for all but the top empire
-            // (or all empires if there is no single top empire)
             for (std::map<int, std::map<int, std::pair<float, float>>>::value_type& empire_supply : empire_propagating_supply_ranges) {
                 int empire_id = empire_supply.first;
-                if (empire_id == top_range_empire_id)
-                    continue;   // this is the top empire, so leave as the sole empire supplying here
+
+                // Dont remove if none of the top empires are hostile to this empire.
+                if (std::none_of(top_empires.begin(), top_empires.end(),
+                                 [empire_id](int a_top_empire_id) {
+                                     return (empire_id == a_top_empire_id) ? false :
+                                         Empires().GetDiplomaticStatus(empire_id, a_top_empire_id) == DIPLO_WAR;
+                                 }))
+                { continue; }
 
                 // remove from range entry...
                 std::map<int, std::pair<float, float>>& empire_ranges = empire_supply.second;
@@ -649,13 +646,13 @@ std::map<int, std::map<int, std::pair<float, float>>> SupplyManager::SupplyManag
             }
 
             //// DEBUG
-            //DebugLogger() << "after culling empires ranges at system " << sys_id << ":";
-            //for (std::map<int, std::map<int, float>>::value_type& empire_supply : empire_propagating_supply_ranges) {
+            // DebugLogger() << "after culling empires ranges at system " << sys_id << ":";
+            // for (std::map<int, std::map<int, float>>::value_type& empire_supply : empire_propagating_supply_ranges) {
             //    std::map<int, float>& system_ranges = empire_supply.second;
             //    std::map<int, float>::iterator range_it = system_ranges.find(sys_id);
             //    if (range_it != system_ranges.end())
             //        DebugLogger() << empire_supply.first << " : " << range_it->second;
-            //}
+            // }
             //// END DEBUG
         }
 
@@ -669,8 +666,8 @@ std::map<int, std::map<int, std::pair<float, float>>> SupplyManager::SupplyManag
         // for sources of supply of at least the minimum range for this
         // iteration that are in the current map, give adjacent systems one
         // less supply in the next iteration (unless as much or more is already
-        // there)
-        for (const std::map<int, std::map<int, std::pair<float, float>>>::value_type& empire_supply : empire_propagating_supply_ranges) {
+        // there for a hostile empire)
+            for (const std::map<int, std::map<int, std::pair<float, float>>>::value_type& empire_supply : empire_propagating_supply_ranges) {
             int empire_id = empire_supply.first;
             //DebugLogger() << ">-< Doing supply propagation for empire " << empire_id << " >-<";
             const std::map<int, std::pair<float, float>>& prev_sys_ranges = empire_supply.second;
@@ -703,12 +700,14 @@ std::map<int, std::map<int, std::pair<float, float>>> SupplyManager::SupplyManag
                     // propagation not obstructed.
 
 
-                    // does another empire already have as much or more supply here from a previous iteration?
+                    // does another hostile empire already have as much or more supply here from a previous iteration?
                     float other_empire_biggest_range = -10000.0f;   // arbitrary big numbeer
                     for (const std::map<int, std::map<int, std::pair<float, float>>>::value_type& other_empire_supply : empire_propagating_supply_ranges) {
                         int other_empire_id = other_empire_supply.first;
-                        if (other_empire_id == empire_id)
-                            continue;
+                        if ((other_empire_id == empire_id)
+                            || Empires().GetDiplomaticStatus(empire_id, other_empire_id) != DIPLO_WAR)
+                        { continue; }
+
                         const std::map<int, std::pair<float, float>>& prev_other_empire_sys_ranges = other_empire_supply.second;
                         std::map<int, std::pair<float, float>>::const_iterator prev_other_empire_range_it = prev_other_empire_sys_ranges.find(lane_end_sys_id);
                         if (prev_other_empire_range_it == prev_other_empire_sys_ranges.end())

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -57,19 +57,19 @@ public:
     const std::set<std::set<int> >&                         ResourceSupplyGroups(int empire_id) const;
 
     /** Returns the range from each system some empire can propagate supply.*/
-    const std::map<int, float>&                             PropagatedSupplyRanges() const;
+    const std::unordered_map<int, float>&                             PropagatedSupplyRanges() const;
     /** Returns the range from each system that the empire with id \a empire_id
       * can propagate supply.*/
-    const std::map<int, float>&                             PropagatedSupplyRanges(int empire_id) const;
+    const std::unordered_map<int, float>&                             PropagatedSupplyRanges(int empire_id) const;
 
     /** Returns the distance from each system some empire is away
       * from its closest source of supply without passing
       * through obstructed systems for that empire. */
-    const std::map<int, float>&                             PropagatedSupplyDistances() const;
+    const std::unordered_map<int, float>&                             PropagatedSupplyDistances() const;
     /** Returns the distance from each system for the empire with id
       * \a empire_id to the closest source of supply without passing
       * through obstructed systems for that empire. */
-    const std::map<int, float>&                             PropagatedSupplyDistances(int empire_id) const;
+    const std::unordered_map<int, float>&                             PropagatedSupplyDistances(int empire_id) const;
 
     /** Returns true if system with id \a system_id is fleet supplyable or in
       * one of the resource supply groups for empire with id \a empire_id */
@@ -88,7 +88,7 @@ public:
 
     /** Part of the Update function.*/
     std::map<int, std::map<int, std::pair<float, float>>> PropagateSupplyAlongUnobstructedStarlanes(
-        const std::map<int, std::map<int, float>>& empire_system_supply_ranges,
+        const std::unordered_map<int, std::unordered_map<int, float>>& empire_system_supply_ranges,
         std::map<int, std::set<int>>& empire_supply_unobstructed_systems);
 
     void DetermineSupplyConnectedSystemGroups();
@@ -119,24 +119,24 @@ private:
 
     /** for whichever empire can propagate supply into this system, what is the
         additional range from this system that empire can propagate supply */
-    std::map<int, float>                            m_propagated_supply_ranges;
+    std::unordered_map<int, float>                            m_propagated_supply_ranges;
 
     /** for each empire, what systems it can propagate supply into, and how many
       * further supply jumps it could propagate past this system, if not blocked
       * from doing so by supply obstructions. */
-    std::map<int, std::map<int, float>>             m_empire_propagated_supply_ranges;
+    std::unordered_map<int, std::unordered_map<int, float>>             m_empire_propagated_supply_ranges;
 
     /** for whichever empire can propagate supply into this system, how far
       * that system is from the closest source of supply for that empire, along
       * possible supply propgation connections (ie. not though a supply
       * obstructed system for that empire) */
-    std::map<int, float>                            m_propagated_supply_distances;
+    std::unordered_map<int, float>                            m_propagated_supply_distances;
 
     /** for each empire, what systems it can propagate supply into, and how far
       * that system is from the closest source of supply for that empire, along
       * possible supply propgation connections (ie. not though a supply
       * obstructed system) */
-    std::map<int, std::map<int, float>>             m_empire_propagated_supply_distances;
+    std::unordered_map<int, std::unordered_map<int, float>>             m_empire_propagated_supply_distances;
 
 };
 
@@ -162,6 +162,7 @@ namespace {
     static const std::unordered_set<int> EMPTY_INT_UNORDERED_SET;
     static const std::set<std::pair<int, int>> EMPTY_INT_PAIR_SET;
     static const std::map<int, float> EMPTY_INT_FLOAT_MAP;
+    static const std::unordered_map<int, float> EMPTY_INT_FLOAT_UNORDERED_MAP;
     static const std::unordered_map<std::pair<int, int>, float> EMPTY_MAP_PAIR_INT_TO_FLOAT;
 }
 
@@ -230,28 +231,28 @@ const std::set<std::set<int>>& SupplyManager::SupplyManagerImpl::ResourceSupplyG
     return EMPTY_INT_SET_SET;
 }
 
-const std::map<int, float>& SupplyManager::SupplyManagerImpl::PropagatedSupplyRanges() const {
+const std::unordered_map<int, float>& SupplyManager::SupplyManagerImpl::PropagatedSupplyRanges() const {
     std::cout << "BLAAAAH" << std::endl;
     return m_propagated_supply_ranges;
 }
 
-const std::map<int, float>& SupplyManager::SupplyManagerImpl::PropagatedSupplyRanges(int empire_id) const
+const std::unordered_map<int, float>& SupplyManager::SupplyManagerImpl::PropagatedSupplyRanges(int empire_id) const
 {
     auto emp_it = m_empire_propagated_supply_ranges.find(empire_id);
     if (emp_it == m_empire_propagated_supply_ranges.end())
-        return EMPTY_INT_FLOAT_MAP;
+        return EMPTY_INT_FLOAT_UNORDERED_MAP;
     return emp_it->second;
 }
 
-const std::map<int, float>& SupplyManager::SupplyManagerImpl::PropagatedSupplyDistances() const {
+const std::unordered_map<int, float>& SupplyManager::SupplyManagerImpl::PropagatedSupplyDistances() const {
     std::cout << "GLAARB" << std::endl;
     return m_propagated_supply_distances;
 }
 
-const std::map<int, float>& SupplyManager::SupplyManagerImpl::PropagatedSupplyDistances(int empire_id) const {
+const std::unordered_map<int, float>& SupplyManager::SupplyManagerImpl::PropagatedSupplyDistances(int empire_id) const {
     auto emp_it = m_empire_propagated_supply_distances.find(empire_id);
     if (emp_it == m_empire_propagated_supply_distances.end())
-        return EMPTY_INT_FLOAT_MAP;
+        return EMPTY_INT_FLOAT_UNORDERED_MAP;
     return emp_it->second;
 }
 
@@ -1524,7 +1525,7 @@ namespace {
     }
 
     std::unordered_map<int, std::vector<int>> CalculateColonyDisruptedSupply(
-        const std::map<int, std::map<int, float>>& empire_system_supply_ranges)
+        const std::unordered_map<int, std::unordered_map<int, float>>& empire_system_supply_ranges)
     {
         // Map from Empire to Systems where only other empires have supply sources and there is no
         // friendly fleet.  This is used to help the AI until it can full manage supply mechanics
@@ -1560,7 +1561,7 @@ namespace {
 
             std::set<int> systems_where_hostile_others_have_supply_sources_and_current_empire_doesnt;
             // add all systems where hostile_others have supply
-            for (const std::map<int, std::map<int, float>>::value_type& empire_supply : empire_system_supply_ranges) {
+            for (const auto& empire_supply : empire_system_supply_ranges) {
                 if (empire_supply.first == empire_id || empire_supply.first == ALL_EMPIRES)
                     continue;
 
@@ -1574,7 +1575,7 @@ namespace {
                 }
             }
             // remove systems were this empire has supply
-            std::map<int, std::map<int, float>>::const_iterator it = empire_system_supply_ranges.find(empire_id);
+            const auto& it = empire_system_supply_ranges.find(empire_id);
             if (it != empire_system_supply_ranges.end()) {
                 for (const std::map<int, float>::value_type& supply_range : it->second) {
                     if (supply_range.second <= 0.0f)
@@ -1595,7 +1596,7 @@ namespace {
     }
 
     void ObstructSupplyIfUncontestedHostileSupplySource(
-        const std::map<int, std::map<int, float>>& empire_system_supply_ranges,
+        const std::unordered_map<int, std::unordered_map<int, float>>& empire_system_supply_ranges,
         std::map<int, std::set<int>>& empire_supply_unobstructed_systems)
     {
         for (auto& empire_to_colony_disrupted_systems : CalculateColonyDisruptedSupply(empire_system_supply_ranges)) {
@@ -1607,7 +1608,7 @@ namespace {
 }
 
 std::map<int, std::map<int, std::pair<float, float>>> SupplyManager::SupplyManagerImpl::PropagateSupplyAlongUnobstructedStarlanes(
-    const std::map<int, std::map<int, float>>& empire_system_supply_ranges,
+    const std::unordered_map<int, std::unordered_map<int, float>>& empire_system_supply_ranges,
     std::map<int, std::set<int>>& empire_supply_unobstructed_systems
 )
 {
@@ -1636,7 +1637,7 @@ std::map<int, std::map<int, std::pair<float, float>>> SupplyManager::SupplyManag
     std::map<int, std::map<int, std::pair<float, float>>> empire_propagating_supply_ranges;
     float max_range = 0.0f;
 
-    for (const std::map<int, std::map<int, float>>::value_type& empire_supply : empire_system_supply_ranges) {
+    for (const auto& empire_supply : empire_system_supply_ranges) {
         int empire_id = empire_supply.first;
         const std::set<int>& unobstructed_systems = empire_supply_unobstructed_systems[empire_id];
 
@@ -2200,7 +2201,7 @@ void SupplyManager::SupplyManagerImpl::UpdateOld() {
 
     // map from empire id to map from system id to range (in starlane jumps)
     // that supply can be propagated out of that system by that empire.
-    std::map<int, std::map<int, float> > empire_system_supply_ranges;
+    std::unordered_map<int, std::unordered_map<int, float> > empire_system_supply_ranges;
     // map from empire id to which systems are obstructed for it for supply
     // propagation
     std::map<int, std::set<int> > empire_supply_unobstructed_systems;
@@ -2347,16 +2348,16 @@ const std::map<int, std::set<std::set<int> > >&         SupplyManager::ResourceS
 const std::set<std::set<int> >&                         SupplyManager::ResourceSupplyGroups(int empire_id) const
 { return pimpl->ResourceSupplyGroups(empire_id); }
 
-const std::map<int, float>&                             SupplyManager::PropagatedSupplyRanges() const
+const std::unordered_map<int, float>&                             SupplyManager::PropagatedSupplyRanges() const
 { return pimpl->PropagatedSupplyRanges(); }
 
-const std::map<int, float>&                             SupplyManager::PropagatedSupplyRanges(int empire_id) const
+const std::unordered_map<int, float>&                             SupplyManager::PropagatedSupplyRanges(int empire_id) const
 { return pimpl->PropagatedSupplyRanges(empire_id); }
 
-const std::map<int, float>&                             SupplyManager::PropagatedSupplyDistances() const
+const std::unordered_map<int, float>&                             SupplyManager::PropagatedSupplyDistances() const
 { return pimpl->PropagatedSupplyDistances(); }
 
-const std::map<int, float>&                             SupplyManager::PropagatedSupplyDistances(int empire_id) const
+const std::unordered_map<int, float>&                             SupplyManager::PropagatedSupplyDistances(int empire_id) const
 { return pimpl->PropagatedSupplyDistances(empire_id); }
 
 bool                                                    SupplyManager::SystemHasFleetSupply(int system_id, int empire_id) const

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -459,7 +459,7 @@ std::unordered_map<int, std::vector<int>> CalculateColonyDisruptedSupply(
     return empire_to_colony_disrupted_systems;
 }
 
-void ObstructSupplyIfAggresiveArmedFleetOccupiesSystemWithNoSupply(
+void ObstructSupplyIfUncontestedHostileSupplySource(
     const std::map<int, std::map<int, float>>& empire_system_supply_ranges,
     std::map<int, std::set<int>>& empire_supply_unobstructed_systems)
 {
@@ -984,7 +984,7 @@ void SupplyManager::SupplyManagerImpl::Update() {
     // probably temporary: additional restriction here for supply propagation
     // but not for general system obstruction as determind within Empire::UpdateSupplyUnobstructedSystems
     /////
-    ObstructSupplyIfAggresiveArmedFleetOccupiesSystemWithNoSupply(
+    ObstructSupplyIfUncontestedHostileSupplySource(
         empire_system_supply_ranges,
         empire_supply_unobstructed_systems);
     /////

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -884,9 +884,12 @@ namespace {
 
             m_tranches.insert({merit_threshold, tranche});
 
-            // Create the remaining tranches down to zero merit.
+            // Create the remaining tranches down to lower of zero merit or the minimum detected
+            // merit reduced by one jump of merit reduction.
             auto zero_merit = SupplyMerit();
-            while (merit_threshold > zero_merit) {
+            const auto min_merit = std::min(zero_merit, merit_and_source.begin()->first).OneJumpLessMerit();
+
+            while (merit_threshold > min_merit) {
                 merit_threshold = merit_threshold.OneJumpLessMerit();
                 m_tranches.insert({merit_threshold, SupplyTranche(merit_threshold)});
             }

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -866,10 +866,10 @@ namespace {
             }
 
             // Divide into tranches of the minimum drop in merit across a single starlane.
-            const auto max_merit = merit_and_source.rbegin()->first;
+            m_max_merit = merit_and_source.rbegin()->first;
 
             auto merit_source_it = merit_and_source.rbegin();
-            auto merit_threshold = max_merit.OneJumpLessMerit();
+            auto merit_threshold = m_max_merit.OneJumpLessMerit();
             auto tranche = SupplyTranche(merit_threshold);
 
             SupplyMerit merit;
@@ -948,8 +948,12 @@ namespace {
             operator[](merit).Remove(system_id, source_id);
         }
 
+        const SupplyMerit& MaxMerit() const
+        {return m_max_merit;}
+
         private:
         std::map<SupplyMerit, SupplyTranche> m_tranches;
+        SupplyMerit m_max_merit;
 
 
     };

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -9,8 +9,11 @@
 #include "../universe/Fleet.h"
 #include "../universe/Enums.h"
 #include "../util/AppInterface.h"
+#include "../util/Serialize.h"
 #include "../util/Logger.h"
 
+#include <boost/serialization/map.hpp>
+#include <boost/serialization/set.hpp>
 #include <boost/graph/connected_components.hpp>
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/connected_components.hpp>
@@ -277,7 +280,7 @@ void SupplyManager::Update() {
     // can't exchange with any other systems.
 
     // which systems can share resources depends on system supply ranges, which
-    // systems have obstructions to supply propagation for reach empire, and
+    // systems have obstructions to supply propagation for each empire, and
     // the ranges and obstructions of other empires' supply, as only one empire
     // can supply each system or propagate along each starlane. one empire's
     // propagating supply can push back another's, if the pusher's range is
@@ -783,3 +786,21 @@ void SupplyManager::Update() {
         }
     }
 }
+
+template <class Archive>
+void SupplyManager::serialize(Archive& ar, const unsigned int version)
+{
+    ar  & BOOST_SERIALIZATION_NVP(m_supply_starlane_traversals)
+        & BOOST_SERIALIZATION_NVP(m_supply_starlane_obstructed_traversals)
+        & BOOST_SERIALIZATION_NVP(m_fleet_supplyable_system_ids)
+        & BOOST_SERIALIZATION_NVP(m_resource_supply_groups)
+        & BOOST_SERIALIZATION_NVP(m_propagated_supply_ranges)
+        & BOOST_SERIALIZATION_NVP(m_empire_propagated_supply_ranges)
+        & BOOST_SERIALIZATION_NVP(m_propagated_supply_distances)
+        & BOOST_SERIALIZATION_NVP(m_empire_propagated_supply_distances);
+}
+
+template void SupplyManager::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, const unsigned int);
+template void SupplyManager::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, const unsigned int);
+template void SupplyManager::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, const unsigned int);
+template void SupplyManager::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -561,6 +561,15 @@ void RemoveSystemFromTraversals(
     }
 }
 
+/** Add an obstructed traversal.*/
+void AddObstructedTraversal(
+    const int sys_id, const int end_sys_id,
+    const std::set<int>& supply_unobstructed_systems,
+    const std::set<std::pair<int, int>>& lane_traversals,
+    std::set<std::pair<int, int>>& obstructed_traversals)
+{
+    obstructed_traversals.insert(std::make_pair(sys_id, end_sys_id));
+}
 }
 
 std::map<int, std::map<int, std::pair<float, float>>> SupplyManager::SupplyManagerImpl::PropagateSupplyAlongUnobstructedStarlanes(
@@ -724,7 +733,10 @@ std::map<int, std::map<int, std::pair<float, float>>> SupplyManager::SupplyManag
                     if (unobstructed_systems.find(lane_end_sys_id) == unobstructed_systems.end()) {
                         // propagation obstructed!
                         //DebugLogger() << "Added obstructed traversal from " << system_id << " to " << lane_end_sys_id << " due to not being on unobstructed systems";
-                        m_supply_starlane_obstructed_traversals[empire_id].insert(std::make_pair(system_id, lane_end_sys_id));
+                        AddObstructedTraversal(system_id, lane_end_sys_id,
+                                               empire_supply_unobstructed_systems[empire_id],
+                                               m_supply_starlane_traversals[empire_id],
+                                               m_supply_starlane_obstructed_traversals[empire_id]);
                         continue;
                     }
                     // propagation not obstructed.
@@ -748,7 +760,10 @@ std::map<int, std::map<int, std::pair<float, float>>> SupplyManager::SupplyManag
 
                     // if so, add a blocked traversal and continue
                     if (range_after_one_more_jump <= other_empire_biggest_range) {
-                        m_supply_starlane_obstructed_traversals[empire_id].insert(std::make_pair(system_id, lane_end_sys_id));
+                        AddObstructedTraversal(system_id, lane_end_sys_id,
+                                               empire_supply_unobstructed_systems[empire_id],
+                                               m_supply_starlane_traversals[empire_id],
+                                               m_supply_starlane_obstructed_traversals[empire_id]);
                         //DebugLogger() << "Added obstructed traversal from " << system_id << " to " << lane_end_sys_id << " due to other empire biggest range being " << other_empire_biggest_range;
                         continue;
                     }

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -664,14 +664,14 @@ namespace {
                 continue;
 
             boost::optional<std::unordered_set<int>> contesting_empires;
-            boost::optional<std::unordered_set<int>> blockading_empires;
-            std::tie(contesting_empires, blockading_empires) = CalculateBlockadingFleetsEmpireIDs(*system);
+            boost::optional<std::unordered_set<int>> blockading_fleets_empire_ids;
+            std::tie(contesting_empires, blockading_fleets_empire_ids) = CalculateBlockadingFleetsEmpireIDs(*system);
 
             if (contesting_empires && !contesting_empires->empty())
                 system_to_contesting_fleets_empire_ids[system->SystemID()]= *contesting_empires;
 
-            if (blockading_empires && !blockading_empires->empty())
-                system_to_blockading_fleets_empire_ids[system->SystemID()] = *blockading_empires;
+            if (blockading_fleets_empire_ids && !blockading_fleets_empire_ids->empty())
+                system_to_blockading_fleets_empire_ids[system->SystemID()] = *blockading_fleets_empire_ids;
         }
         return {system_to_contesting_fleets_empire_ids, system_to_blockading_fleets_empire_ids};
     }
@@ -761,23 +761,23 @@ namespace {
         // TODO resort and add source id?
         boost::optional<std::set<std::tuple<SupplyMerit, float, int, int>>> merit_stealth_supply_empire;
         boost::optional<std::unordered_set<int>> contesting_empires;
-        boost::optional<std::unordered_set<int>> blockading_empires;
-        boost::optional<int> colony_blockading_empires;
+        boost::optional<std::unordered_set<int>> blockading_fleets_empire_ids;
+        boost::optional<int> blockading_colonies_empire_id;
     };
 
     boost::optional<SupplySystemPOD> CalculateInitialSupply(const System &system) {
         auto stealth_supply = CalculateMeritStealthSupplyEmpire(system);
 
         boost::optional<std::unordered_set<int>> contesting_empires;
-        boost::optional<std::unordered_set<int>> blockading_empires;
-        std::tie(contesting_empires, blockading_empires) = CalculateBlockadingFleetsEmpireIDs(system);
+        boost::optional<std::unordered_set<int>> blockading_fleets_empire_ids;
+        std::tie(contesting_empires, blockading_fleets_empire_ids) = CalculateBlockadingFleetsEmpireIDs(system);
 
         auto blockading_colony = CalculateBlockadingColonyEmpireID(system, stealth_supply, contesting_empires);
 
-        if (!stealth_supply && !contesting_empires && !blockading_empires && !blockading_colony)
+        if (!stealth_supply && !contesting_empires && !blockading_fleets_empire_ids && !blockading_colony)
             return boost::none;
 
-        return SupplySystemPOD({stealth_supply, contesting_empires, blockading_empires, blockading_colony});
+        return SupplySystemPOD({stealth_supply, contesting_empires, blockading_fleets_empire_ids, blockading_colony});
     }
 
     /** Return a map from system id to SupplySystemrPOD. */
@@ -935,15 +935,15 @@ namespace {
     //     auto stealth_supply = CalculateEmpireToStealthSupply(system);
 
     //     boost::optional<std::unordered_set<int>> contesting_empires;
-    //     boost::optional<std::unordered_set<int>> blockading_empires;
-    //     std::tie(contesting_empires, blockading_empires) = CalculateBlockadingFleetsEmpireIDs(system);
+    //     boost::optional<std::unordered_set<int>> blockading_fleets_empire_ids;
+    //     std::tie(contesting_empires, blockading_fleets_empire_ids) = CalculateBlockadingFleetsEmpireIDs(system);
 
     //     auto blockading_colony = CalculateBlockadingColonyEmpireID(system, stealth_supply, contesting_empires);
 
-    //     if (!stealth_supply && !contesting_empires && !blockading_empires && !blockading_colony)
+    //     if (!stealth_supply && !contesting_empires && !blockading_fleets_empire_ids && !blockading_colony)
     //         return boost::none;
 
-    //     return SupplySystemPOD({stealth_supply, contesting_empires, blockading_empires, blockading_colony});
+    //     return SupplySystemPOD({stealth_supply, contesting_empires, blockading_fleets_empire_ids, blockading_colony});
     // }
 
     // // /** Return a map from system id to SupplySystemPOD. */

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -864,6 +864,11 @@ void SupplyManager::SupplyManagerImpl::Update() {
     // propagating supply can push back another's, if the pusher's range is
     // larger.
 
+
+    // Map from empire id to a map from system id to the stealth and supply ranges of empire
+    // objects in that system.
+    std::unordered_map<int, std::unordered_map<int, std::set<std::pair<float, float>>>> empire_to_system_to_stealth_supply;
+
     // map from empire id to map from system id to range (in starlane jumps)
     // that supply can be propagated out of that system by that empire.
     std::map<int, std::map<int, float> > empire_system_supply_ranges;
@@ -871,10 +876,12 @@ void SupplyManager::SupplyManagerImpl::Update() {
     // propagation
     std::map<int, std::set<int> > empire_supply_unobstructed_systems;
 
-    for (const std::map<int, Empire*>::value_type& entry : Empires()) {
-        const Empire* empire = entry.second;
-        empire_system_supply_ranges[entry.first] = empire->SystemSupplyRanges();
-        empire_supply_unobstructed_systems[entry.first] = empire->SupplyUnobstructedSystems();
+    for (const auto& entry : Empires()) {
+        const auto empire_id = entry.first;
+        const auto& empire = entry.second;
+        empire_to_system_to_stealth_supply[empire_id] = empire->SystemToStealthAndSupplyRange();
+        empire_system_supply_ranges[empire_id] = empire->SystemSupplyRanges();
+        empire_supply_unobstructed_systems[empire_id] = empire->SupplyUnobstructedSystems();
 
         //std::stringstream ss;
         //for (int system_id : empire_supply_unobstructed_systems[entry.first])

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -882,6 +882,29 @@ std::pair<float, std::unordered_set<int>> ContestSystem(
     return {max_supply_range, empires_needing_traversal_adjustment};
 }
 
+/** Adjust the supply lane traversals, after a system is contested. */
+void AdjustStarlaneTraversals(
+    std::unordered_map<int, std::unordered_map<std::pair<int, int>, float>>& supply_starlane_traversals,
+    std::unordered_map<int, std::unordered_map<std::pair<int, int>, float>>& supply_starlane_obstructed_traversals,
+    SupplySystemPOD& pod, const System& system,
+    const std::unordered_map<int, float>& empire_to_detection,
+    const std::unordered_set<int> & empires_needing_traversal_adjustment)
+{
+    // Check each empire that needs adjustment and if they have no more traversals in the SystemPOD
+    // remove them from the traversals maps.
+
+    for(auto empire_id : empires_needing_traversal_adjustment) {
+
+        // There no empires or empire id is not present
+        if (!pod.empire_to_stealth_supply || pod.empire_to_stealth_supply->empty()
+            || (pod.empire_to_stealth_supply->find(empire_id) == pod.empire_to_stealth_supply->end()))
+        {
+            RemoveSystemFromTraversals(system.SystemID(), supply_starlane_traversals[empire_id],
+                                       supply_starlane_obstructed_traversals[empire_id]);
+        }
+    }
+}
+
 std::unordered_map<int, std::vector<int>> CalculateColonyDisruptedSupply(
     const std::map<int, std::map<int, float>>& empire_system_supply_ranges)
 {

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -203,7 +203,8 @@ std::set<int> SupplyManager::SupplyManagerImpl::FleetSupplyableSystemIDs(int emp
     for (auto empire_id_sys_id_set : m_fleet_supplyable_system_ids) {
         int other_empire_id = empire_id_sys_id_set.first;
         const std::set<int>& systems = empire_id_sys_id_set.second;
-        if (systems.empty() || Empires().GetDiplomaticStatus(empire_id, other_empire_id) != DIPLO_PEACE)
+        if (systems.empty() || ((empire_id != other_empire_id)
+                                && Empires().GetDiplomaticStatus(empire_id, other_empire_id) != DIPLO_PEACE))
             continue;
         retval.insert(systems.begin(), systems.end());
     }
@@ -277,7 +278,7 @@ bool SupplyManager::SupplyManagerImpl::SystemHasFleetSupply(int system_id, int e
 
     std::set<int> empire_ids{empire_id};
     for (auto e_pair : Empires()) {
-        if (Empires().GetDiplomaticStatus(empire_id, e_pair.first) == DIPLO_PEACE)
+        if (e_pair.first == empire_id || Empires().GetDiplomaticStatus(empire_id, e_pair.first) == DIPLO_PEACE)
             empire_ids.insert(e_pair.first);
     }
 

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -491,7 +491,7 @@ namespace {
             distance(0.0f)
         {}
 
-        SupplyMerit OneJumpLessMerit(float _dist) const {
+        SupplyMerit OneJumpLessMerit(float _dist = 0.0f) const {
             auto other     = SupplyMerit();
             other.range    = range - 1;
             other.distance = distance + _dist;
@@ -853,7 +853,7 @@ namespace {
             const auto max_merit = merit_and_source.rbegin()->first;
 
             auto merit_source_it = merit_and_source.rbegin();
-            auto merit_threshold = max_merit.OneJumpLessMerit(0.0f);
+            auto merit_threshold = max_merit.OneJumpLessMerit();
             auto tranche = SupplyTranche(merit_threshold);
 
             SupplyMerit merit;

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -2491,7 +2491,7 @@ void SupplyManager::SupplyManagerImpl::UpdateOld() {
     for (const auto& entry : Empires()) {
         const auto empire_id = entry.first;
         const auto& empire = entry.second;
-        empire_to_system_to_stealth_supply[empire_id] = empire->SystemToStealthAndSupplyRange();
+        // empire_to_system_to_stealth_supply[empire_id] = empire->SystemToStealthAndSupplyRange();
         empire_system_supply_ranges[empire_id] = empire->SystemSupplyRanges();
         empire_supply_unobstructed_systems[empire_id] = empire->SupplyUnobstructedSystems();
 

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -570,6 +570,33 @@ void AddObstructedTraversal(
 {
     obstructed_traversals.insert(std::make_pair(sys_id, end_sys_id));
 }
+
+/** Add a traversal */
+void AddTraversal(
+    const int sys_id, const int end_sys_id,
+    const std::set<int>& supply_unobstructed_systems,
+    std::set<std::pair<int, int>>& lane_traversals,
+    std::set<std::pair<int, int>>& obstructed_traversals)
+{
+
+    //DebugLogger() << "Added traversal from " << sys_id << " to " << end_sys_id;
+    // always record a traversal, so connectivity is calculated properly
+    lane_traversals.insert(std::make_pair(sys_id, end_sys_id));
+
+    // erase any previous obstructed traversal that just succeeded
+    if (obstructed_traversals.find(std::make_pair(sys_id, end_sys_id)) !=
+        obstructed_traversals.end())
+    {
+        //DebugLogger() << "Removed obstructed traversal from " << sys_id << " to " << end_sys_id;
+        obstructed_traversals.erase(std::make_pair(sys_id, end_sys_id));
+    }
+    if (obstructed_traversals.find(std::make_pair(end_sys_id, sys_id)) !=
+        obstructed_traversals.end())
+    {
+        //DebugLogger() << "Removed obstructed traversal from " << end_sys_id << " to " << sys_id;
+        obstructed_traversals.erase(std::make_pair(end_sys_id, sys_id));
+    }
+}
 }
 
 std::map<int, std::map<int, std::pair<float, float>>> SupplyManager::SupplyManagerImpl::PropagateSupplyAlongUnobstructedStarlanes(
@@ -796,23 +823,11 @@ std::map<int, std::map<int, std::pair<float, float>>> SupplyManager::SupplyManag
                             //DebugLogger() << " ... distance decreased!";
                         }
                     }
-                    // always record a traversal, so connectivity is calculated properly
-                    m_supply_starlane_traversals[empire_id].insert(std::make_pair(system_id, lane_end_sys_id));
-                    //DebugLogger() << "Added traversal from " << system_id << " to " << lane_end_sys_id;
 
-                    // erase any previous obstructed traversal that just succeeded
-                    if (m_supply_starlane_obstructed_traversals[empire_id].find(std::make_pair(system_id, lane_end_sys_id)) !=
-                        m_supply_starlane_obstructed_traversals[empire_id].end())
-                    {
-                        //DebugLogger() << "Removed obstructed traversal from " << system_id << " to " << lane_end_sys_id;
-                        m_supply_starlane_obstructed_traversals[empire_id].erase(std::make_pair(system_id, lane_end_sys_id));
-                    }
-                    if (m_supply_starlane_obstructed_traversals[empire_id].find(std::make_pair(lane_end_sys_id, system_id)) !=
-                        m_supply_starlane_obstructed_traversals[empire_id].end())
-                    {
-                        //DebugLogger() << "Removed obstructed traversal from " << lane_end_sys_id << " to " << system_id;
-                        m_supply_starlane_obstructed_traversals[empire_id].erase(std::make_pair(lane_end_sys_id, system_id));
-                    }
+                    AddTraversal(system_id, lane_end_sys_id,
+                                 empire_supply_unobstructed_systems[empire_id],
+                                 m_supply_starlane_traversals[empire_id],
+                                 m_supply_starlane_obstructed_traversals[empire_id]);
                 }
             }
         }

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -842,7 +842,20 @@ void SupplyManager::SupplyManagerImpl::DetermineSupplyConnectedSystemGroups(
             m_resource_supply_groups[empire_id].insert(component_set.second);
         }
     }
+}
 
+namespace {
+    /** Return a map from empire id to detection strength.*/
+    std::unordered_map<int, float> EmpireToDetectionStrengths() {
+        std::unordered_map<int, float> retval;
+        for (const auto& entry : Empires()) {
+            const auto  empire_id = entry.first;
+            const auto& empire = entry.second;
+            const auto  meter = empire->GetMeter("METER_DETECTION_STRENGTH");
+            retval[empire_id] = meter ? meter->Current() : 0.0f;
+        }
+        return retval;
+    }
 }
 
 void SupplyManager::SupplyManagerImpl::Update() {
@@ -875,6 +888,9 @@ void SupplyManager::SupplyManagerImpl::Update() {
     // map from empire id to which systems are obstructed for it for supply
     // propagation
     std::map<int, std::set<int> > empire_supply_unobstructed_systems;
+
+    /** Map from empire id to detection strength.*/
+    auto empire_to_detection = EmpireToDetectionStrengths();
 
     for (const auto& entry : Empires()) {
         const auto empire_id = entry.first;

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -918,7 +918,9 @@ namespace {
         std::map<SupplyMerit, SupplyTranche>::iterator begin() { return m_tranches.begin(); }
         std::map<SupplyMerit, SupplyTranche>::iterator end()   { return m_tranches.end(); }
 
-        // void Remove(const int system_id, const std::unordered_map<int, SupplyMerit>
+        void Remove(const int system_id, int source_id, const SupplyMerit& merit) {
+            operator[](merit).Remove(system_id, source_id);
+        }
 
         private:
         std::map<SupplyMerit, SupplyTranche> m_tranches;

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -895,6 +895,18 @@ namespace {
             }
         }
 
+        /** Add these sources to the correct tranche*/
+        void Add(std::map<SupplyMerit, std::tuple<int, float, int, int>>& merit_to_source_stealth_system_empire) {
+            for (auto&& merit_and_source_stealth_system_empire : merit_to_source_stealth_system_empire) {
+                operator[](merit_and_source_stealth_system_empire.first).Add(
+                    std::get<0>(merit_and_source_stealth_system_empire.second),
+                    merit_and_source_stealth_system_empire.first,
+                    std::get<1>(merit_and_source_stealth_system_empire.second),
+                    std::get<2>(merit_and_source_stealth_system_empire.second),
+                    std::get<3>(merit_and_source_stealth_system_empire.second));
+            }
+        }
+
         /** Return the tranche that would hold a source with \p merit.*/
         SupplyTranche& operator[](const SupplyMerit& merit) {
             auto it = m_tranches.lower_bound(merit);

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -412,26 +412,25 @@ float ComputeInitialSupplyBonuses(const int empire_id, const int sys_id)
     // empires with ships / planets in system (that haven't already made it obstructed for another empire)
     bool has_ship = false, has_outpost = false, has_colony = false;
     if (std::shared_ptr<const System> sys = GetSystem(sys_id)) {
-        std::vector<int> obj_ids;
-        std::copy(sys->ContainedObjectIDs().begin(), sys->ContainedObjectIDs().end(), std::back_inserter(obj_ids));
-        for (std::shared_ptr<UniverseObject> obj : Objects().FindObjects(obj_ids)) {
-            if (!obj)
-                continue;
-            if (!obj->OwnedBy(empire_id))
-                continue;
-            if (obj->ObjectType() == OBJ_SHIP) {
+
+        for (auto ship : Objects().FindObjects(sys->ShipIDs())) {
+            if (ship && ship->OwnedBy(empire_id)) {
                 has_ship = true;
+                break;
+            }
+        }
+
+        for (auto obj : Objects().FindObjects(sys->PlanetIDs())) {
+            std::shared_ptr<Planet> planet = std::dynamic_pointer_cast<Planet>(obj);
+            if (!planet || !planet->OwnedBy(empire_id))
                 continue;
+
+            if (!planet->SpeciesName().empty()) {
+                    has_colony = true;
+                    break;
             }
-            if (obj->ObjectType() == OBJ_PLANET) {
-                if (std::shared_ptr<Planet> planet = std::dynamic_pointer_cast<Planet>(obj)) {
-                    if (!planet->SpeciesName().empty())
-                        has_colony = true;
-                    else
-                        has_outpost = true;
-                    continue;
-                }
-            }
+
+            has_outpost = true;
         }
     }
     if (has_ship)

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -13,6 +13,7 @@
 #include "../util/Serialize.h"
 #include "../util/Logger.h"
 
+#include <boost/serialization/vector.hpp>
 #include <boost/serialization/map.hpp>
 #include <boost/serialization/set.hpp>
 #include <boost/serialization/unordered_map.hpp>
@@ -53,8 +54,8 @@ public:
 
     /** Returns set of sets of systems that can share industry (systems in
       * separate groups are blockaded or otherwise separated). */
-    const std::map<int, std::set<std::set<int> > >&         ResourceSupplyGroups() const;
-    const std::set<std::set<int> >&                         ResourceSupplyGroups(int empire_id) const;
+    const std::unordered_map<int, std::vector<std::unordered_set<int> > >&         ResourceSupplyGroups() const;
+    const std::vector<std::unordered_set<int> >&                         ResourceSupplyGroups(int empire_id) const;
 
     /** Returns the range from each system some empire can propagate supply.*/
     const std::unordered_map<int, float>&                             PropagatedSupplyRanges() const;
@@ -115,7 +116,7 @@ private:
     /** sets of system ids that are connected by supply lines and are able to
         share resources between systems or between objects in systems. indexed
         by empire id. */
-    std::map<int, std::set<std::set<int> > >        m_resource_supply_groups;
+    std::unordered_map<int, std::vector<std::unordered_set<int> > >        m_resource_supply_groups;
 
     /** for whichever empire can propagate supply into this system, what is the
         additional range from this system that empire can propagate supply */
@@ -160,6 +161,7 @@ namespace {
     static const std::set<int> EMPTY_INT_SET;
     static const std::set<std::set<int>> EMPTY_INT_SET_SET;
     static const std::unordered_set<int> EMPTY_INT_UNORDERED_SET;
+    static const std::vector<std::unordered_set<int>> EMPTY_INT_VECTOR_UNORDERED_SET;
     static const std::set<std::pair<int, int>> EMPTY_INT_PAIR_SET;
     static const std::map<int, float> EMPTY_INT_FLOAT_MAP;
     static const std::unordered_map<int, float> EMPTY_INT_FLOAT_UNORDERED_MAP;
@@ -221,14 +223,14 @@ int SupplyManager::SupplyManagerImpl::EmpireThatCanSupplyAt(int system_id) const
     return ALL_EMPIRES;
 }
 
-const std::map<int, std::set<std::set<int>>>& SupplyManager::SupplyManagerImpl::ResourceSupplyGroups() const
+const std::unordered_map<int, std::vector<std::unordered_set<int>>>& SupplyManager::SupplyManagerImpl::ResourceSupplyGroups() const
 { return m_resource_supply_groups; }
 
-const std::set<std::set<int>>& SupplyManager::SupplyManagerImpl::ResourceSupplyGroups(int empire_id) const {
-    std::map<int, std::set<std::set<int>>>::const_iterator it = m_resource_supply_groups.find(empire_id);
+const std::vector<std::unordered_set<int>>& SupplyManager::SupplyManagerImpl::ResourceSupplyGroups(int empire_id) const {
+    const auto& it = m_resource_supply_groups.find(empire_id);
     if (it != m_resource_supply_groups.end())
         return it->second;
-    return EMPTY_INT_SET_SET;
+    return EMPTY_INT_VECTOR_UNORDERED_SET;
 }
 
 const std::unordered_map<int, float>& SupplyManager::SupplyManagerImpl::PropagatedSupplyRanges() const {
@@ -355,9 +357,9 @@ std::string SupplyManager::SupplyManagerImpl::Dump(int empire_id) const {
             retval += "\n\n";
         }
 
-        for (const std::map<int, std::set<std::set<int>>>::value_type& empire_supply : m_resource_supply_groups) {
+        for (const auto& empire_supply : m_resource_supply_groups) {
             retval += "Supply groups for empire " + std::to_string(empire_supply.first) + "\n";
-            for (const std::set<std::set<int>>::value_type& system_group : empire_supply.second) {
+            for (const auto& system_group : empire_supply.second) {
                 retval += "group: ";
                 for (int system_id : system_group) {
                     std::shared_ptr<const System> sys = GetSystem(system_id);
@@ -1914,7 +1916,7 @@ void SupplyManager::SupplyManagerImpl::DetermineSupplyConnectedSystemGroups() {
         // output: std::map<int, std::set<std::set<int>>>& m_resource_supply_groups
 
         // first, sort into a map from component id to set of system ids in component
-        std::unordered_map<int, std::set<int>> component_sets_map;
+        std::unordered_map<int, std::unordered_set<int>> component_sets_map;
         for (std::size_t comp_graph_id = 0; comp_graph_id != components.size(); ++comp_graph_id) {
             int label = components[comp_graph_id];
             int sys_id = graph_id_to_sys_id[comp_graph_id];
@@ -1922,8 +1924,8 @@ void SupplyManager::SupplyManagerImpl::DetermineSupplyConnectedSystemGroups() {
         }
 
         // copy sets in map into set of sets
-        for (auto && component_set : component_sets_map) {
-            m_resource_supply_groups[empire_id].insert(component_set.second);
+        for (auto & component_set : component_sets_map) {
+            m_resource_supply_groups[empire_id].push_back(component_set.second);
         }
     }
 }
@@ -2342,10 +2344,10 @@ std::unordered_set<int>                                           SupplyManager:
 int                                                     SupplyManager::EmpireThatCanSupplyAt(int system_id) const
 { return pimpl->EmpireThatCanSupplyAt(system_id); }
 
-const std::map<int, std::set<std::set<int> > >&         SupplyManager::ResourceSupplyGroups() const
+const std::unordered_map<int, std::vector<std::unordered_set<int>>>&         SupplyManager::ResourceSupplyGroups() const
 { return pimpl->ResourceSupplyGroups(); }
 
-const std::set<std::set<int> >&                         SupplyManager::ResourceSupplyGroups(int empire_id) const
+const std::vector<std::unordered_set<int>>&                         SupplyManager::ResourceSupplyGroups(int empire_id) const
 { return pimpl->ResourceSupplyGroups(empire_id); }
 
 const std::unordered_map<int, float>&                             SupplyManager::PropagatedSupplyRanges() const

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -504,6 +504,7 @@ namespace {
             return std::tie(l.range, l.bonus, r.distance) < std::tie(r.range, r.bonus, l.distance);
         }
 
+        // TODO?: Should all merits with zero range be equal even if some have a positive bonus?
         friend bool operator==(const SupplyMerit& l, const SupplyMerit& r) {
             return std::tie(l.range, l.bonus, l.distance) == std::tie(r.range, r.bonus, r.distance);
         }
@@ -512,6 +513,15 @@ namespace {
             os << '(' << x.range << '/' << x.bonus << '/' << x.distance << ')';
             return os;
         }
+
+        float Range() const
+        {return range;}
+
+        float Bonus() const
+        {return bonus;}
+
+        float Distance() const
+        {return distance;}
 
         private:
         // Number of jumps that the supply can propagate.

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -966,7 +966,11 @@ namespace {
             // Divide into tranches of the minimum drop in merit across a single starlane.
             m_max_merit = merit_and_source.rbegin()->first;
 
-            auto merit_source_it = merit_and_source.rbegin();
+            using merit_source_rit_type = std::set<std::pair<SupplyMerit, std::shared_ptr<UniverseObject>>>::reverse_iterator;
+            // Precompute rend to avoid Clang ambiguity in operator!=
+            const merit_source_rit_type merit_source_rend = merit_and_source.rend();
+            merit_source_rit_type merit_source_it = merit_and_source.rbegin();
+
             auto merit_threshold = SupplyMerit(m_max_merit).OneJumpLessMerit();
             auto tranche = SupplyTranche(merit_threshold);
 
@@ -974,7 +978,7 @@ namespace {
             std::shared_ptr<UniverseObject> source;
 
             DebugLogger() << "SupplyTranches() adding " << merit_and_source.size() << " supply sources to tranches.";
-            while (merit_source_it != merit_and_source.rend()) {
+            while (merit_source_it != merit_source_rend) {
                 std::tie(merit, source) = *merit_source_it;
 
                 if (merit <= merit_threshold) {
@@ -1190,7 +1194,11 @@ namespace {
         if (!pod.merit_stealth_supply_empire && !candidates.empty())
             pod.merit_stealth_supply_empire = std::set<SupplyPODTuple>();
 
-        for (auto candidate_it = candidates.rbegin(); candidate_it != candidates.rend(); ++candidate_it) {
+        using candidate_it_type = std::set<SupplyPODTuple>::reverse_iterator;
+        candidate_it_type candidate_it = candidates.rbegin();
+        // Explicitly type rend to avoid operator!= ambiguity in Clang.
+        const candidate_it_type candidates_rend = candidates.rend();
+        for (; candidate_it != candidates_rend; ++candidate_it) {
             auto& candidate = *candidate_it;
             const SupplyMerit& candidate_merit = std::get<ssMerit>(candidate);
             float candidate_stealth;
@@ -1216,9 +1224,12 @@ namespace {
             // A list of individual others to remove from the list.
             std::vector<std::set<SupplyPODTuple>::reverse_iterator> marked_for_removals;
 
-            for (auto other_it = pod.merit_stealth_supply_empire->rbegin();
-                 other_it != pod.merit_stealth_supply_empire->rend(); ++other_it)
-            {
+            using other_it_type = std::set<SupplyPODTuple>::reverse_iterator;
+            other_it_type other_it = pod.merit_stealth_supply_empire->rbegin();
+            // Explicitly type rend to avoid Clang operator!= ambiguity.
+            const other_it_type other_it_rend = pod.merit_stealth_supply_empire->rend();
+
+            for (;other_it != other_it_rend; ++other_it) {
                 const SupplyMerit& other_merit = std::get<ssMerit>(*other_it);
                 float other_stealth;
                 int other_source_id, other_empire_id;

--- a/Empire/Supply.h
+++ b/Empire/Supply.h
@@ -16,7 +16,7 @@
 extern const int ALL_EMPIRES;
 
 // Inject a ordered pair hash into std namespace so that it is the default specialization of
-// std::hash(pair).  If this is a problem with other uses of hased pairs, then
+// std::hash(pair).  If this is a problem with other uses of hashed pairs, then
 // directly use OrderedPairHash in the unordered_xs.
 
 namespace std {

--- a/Empire/Supply.h
+++ b/Empire/Supply.h
@@ -75,6 +75,10 @@ public:
       * through obstructed systems for that empire. */
     const std::unordered_map<int, float>&                             PropagatedSupplyDistances(int empire_id) const;
 
+    /** Returns the stealth of the supply in each system for the empire with id
+      * \a empire_id if the empire has supply in system. */
+    const std::unordered_map<int, float>&                             SupplyStealth(int empire_id) const;
+
     /** Returns true if system with id \a system_id is fleet supplyable or in
       * one of the resource supply groups for empire with id \a empire_id */
     bool        SystemHasFleetSupply(int system_id, int empire_id) const;

--- a/Empire/Supply.h
+++ b/Empire/Supply.h
@@ -60,23 +60,16 @@ public:
     const std::unordered_map<int, std::unordered_set<int>>&           FleetSupplyableSystemIDs() const;
     const std::unordered_set<int>&                                    FleetSupplyableSystemIDs(int empire_id) const;
     std::unordered_set<int>                                           FleetSupplyableSystemIDs(int empire_id, bool include_allies) const;
-    int                                                     EmpireThatCanSupplyAt(int system_id) const;
 
     /** Returns set of sets of systems that can share industry (systems in
       * separate groups are blockaded or otherwise separated). */
     const std::unordered_map<int, std::vector<std::shared_ptr<const std::unordered_set<int>>>>& ResourceSupplyGroups() const;
     const std::vector<std::shared_ptr<const std::unordered_set<int>>>&                          ResourceSupplyGroups(int empire_id) const;
 
-    /** Returns the range from each system some empire can propagate supply.*/
-    const std::unordered_map<int, float>&                             PropagatedSupplyRanges() const;
     /** Returns the range from each system that the empire with id \a empire_id
       * can propagate supply.*/
     const std::unordered_map<int, float>&                             PropagatedSupplyRanges(int empire_id) const;
 
-    /** Returns the distance from each system some empire is away
-      * from its closest source of supply without passing
-      * through obstructed systems for that empire. */
-    const std::unordered_map<int, float>&                             PropagatedSupplyDistances() const;
     /** Returns the distance from each system for the empire with id
       * \a empire_id to the closest source of supply without passing
       * through obstructed systems for that empire. */

--- a/Empire/Supply.h
+++ b/Empire/Supply.h
@@ -5,6 +5,7 @@
 
 #include <boost/serialization/access.hpp>
 #include <boost/functional/hash.hpp>
+#include <boost/optional/optional.hpp>
 
 #include <map>
 #include <set>
@@ -93,8 +94,9 @@ public:
     bool        SystemHasFleetSupply(int system_id, int empire_id) const;
     bool        SystemHasFleetSupply(int system_id, int empire_id, bool include_allies) const;
 
-    /** Return the map from system id to empire id and system bonuses. */
-    const std::unordered_map<int, std::map<int, SupplySystemBonusTuple>>& SystemBonuses() const;
+    /** Return an ordered map from empire id to each system supply and detailed bonuses. */
+    using system_iterator = std::unordered_map<int, std::map<int, std::vector<SupplySystemEmpireTuple>>>::const_iterator;
+    boost::optional<const system_iterator> SystemSupply(const int system_id) const;
 
     std::string Dump(int empire_id = ALL_EMPIRES) const;
     //@}

--- a/Empire/Supply.h
+++ b/Empire/Supply.h
@@ -72,9 +72,12 @@ public:
     std::unordered_set<int>                                           FleetSupplyableSystemIDs(int empire_id, bool include_allies) const;
 
     /** Returns set of sets of systems that can share industry (systems in
-      * separate groups are blockaded or otherwise separated). */
-    const std::unordered_map<int, std::vector<std::shared_ptr<const std::unordered_set<int>>>>& ResourceSupplyGroups() const;
-    const std::vector<std::shared_ptr<const std::unordered_set<int>>>&                          ResourceSupplyGroups(int empire_id) const;
+        separate groups are blockaded or otherwise separated).  The sets should
+        not be modified.  However, due to this bug
+        https://svn.boost.org/trac/boost/ticket/10488 in boost::serialization
+        they can't be declared const. */
+    const std::unordered_map<int, std::vector<std::shared_ptr<std::unordered_set<int>>>>& ResourceSupplyGroups() const;
+    const std::vector<std::shared_ptr<std::unordered_set<int>>>&                          ResourceSupplyGroups(int empire_id) const;
 
     /** Returns the range from each system that the empire with id \a empire_id
       * can propagate supply.*/

--- a/Empire/Supply.h
+++ b/Empire/Supply.h
@@ -8,6 +8,7 @@
 #include <map>
 #include <set>
 #include <string>
+#include <memory>
 
 extern const int ALL_EMPIRES;
 
@@ -16,6 +17,7 @@ class FO_COMMON_API SupplyManager {
 public:
     /** \name Structors */ //@{
     SupplyManager();
+    ~SupplyManager();
     SupplyManager& operator=(const SupplyManager& rhs);
     //@}
 
@@ -75,44 +77,8 @@ public:
     //@}
 
 private:
-    /** ordered pairs of system ids between which a starlane runs that can be
-        used to convey resources between systems. indexed first by empire id. */
-    std::map<int, std::set<std::pair<int, int>>>    m_supply_starlane_traversals;
-
-    /** ordered pairs of system ids between which a starlane could be used to
-        convey resources between system, but is not because something is
-        obstructing the resource flow.  That is, the resource flow isn't limited
-        by range, but by something blocking its flow. */
-    std::map<int, std::set<std::pair<int, int>>>    m_supply_starlane_obstructed_traversals;
-
-    /** ids of systems where fleets can be resupplied. indexed by empire id. */
-    std::map<int, std::set<int>>                    m_fleet_supplyable_system_ids;
-
-    /** sets of system ids that are connected by supply lines and are able to
-        share resources between systems or between objects in systems. indexed
-        by empire id. */
-    std::map<int, std::set<std::set<int>>>          m_resource_supply_groups;
-
-    /** for whichever empire can propagate supply into this system, what is the
-        additional range from this system that empire can propagate supply */
-    std::map<int, float>                            m_propagated_supply_ranges;
-
-    /** for each empire, what systems it can propagate supply into, and how many
-      * further supply jumps it could propagate past this system, if not blocked
-      * from doing so by supply obstructions. */
-    std::map<int, std::map<int, float>>             m_empire_propagated_supply_ranges;
-
-    /** for whichever empire can propagate supply into this system, how far
-      * that system is from the closest source of supply for that empire, along
-      * possible supply propgation connections (ie. not though a supply
-      * obstructed system for that empire) */
-    std::map<int, float>                            m_propagated_supply_distances;
-
-    /** for each empire, what systems it can propagate supply into, and how far
-      * that system is from the closest source of supply for that empire, along
-      * possible supply propgation connections (ie. not though a supply
-      * obstructed system) */
-    std::map<int, std::map<int, float>>             m_empire_propagated_supply_distances;
+    class SupplyManagerImpl;
+    std::unique_ptr<SupplyManagerImpl> const pimpl;
 
 
     friend class boost::serialization::access;

--- a/Empire/Supply.h
+++ b/Empire/Supply.h
@@ -31,6 +31,10 @@ namespace std {
     };
 }
 
+// A tuple to report the per system bonus augmenting supply competition.
+using SupplySystemBonusTuple = std::tuple<float, float, float, float>;
+enum SupplySystemBonusFields {ssBonus, ssVisibilityBonus, ssShipBonus, ssColonyBonus};
+std::string SupplySystemBonusTupleString(const SupplySystemBonusTuple& x);
 
 /** Used to calcuate all empires' supply distributions. */
 class FO_COMMON_API SupplyManager {
@@ -83,6 +87,9 @@ public:
       * one of the resource supply groups for empire with id \a empire_id */
     bool        SystemHasFleetSupply(int system_id, int empire_id) const;
     bool        SystemHasFleetSupply(int system_id, int empire_id, bool include_allies) const;
+
+    /** Return the map from system id to empire id and system bonuses. */
+    const std::unordered_map<int, std::map<int, SupplySystemBonusTuple>>& SystemBonuses() const;
 
     std::string Dump(int empire_id = ALL_EMPIRES) const;
     //@}

--- a/Empire/Supply.h
+++ b/Empire/Supply.h
@@ -64,8 +64,8 @@ public:
 
     /** Returns set of sets of systems that can share industry (systems in
       * separate groups are blockaded or otherwise separated). */
-    const std::unordered_map<int, std::vector<std::unordered_set<int>>>& ResourceSupplyGroups() const;
-    const std::vector<std::unordered_set<int>>&                          ResourceSupplyGroups(int empire_id) const;
+    const std::unordered_map<int, std::vector<std::shared_ptr<const std::unordered_set<int>>>>& ResourceSupplyGroups() const;
+    const std::vector<std::shared_ptr<const std::unordered_set<int>>>&                          ResourceSupplyGroups(int empire_id) const;
 
     /** Returns the range from each system some empire can propagate supply.*/
     const std::unordered_map<int, float>&                             PropagatedSupplyRanges() const;

--- a/Empire/Supply.h
+++ b/Empire/Supply.h
@@ -33,8 +33,13 @@ namespace std {
 
 // A tuple to report the per system bonus augmenting supply competition.
 using SupplySystemBonusTuple = std::tuple<float, float, float, float>;
-enum SupplySystemBonusFields {ssBonus, ssVisibilityBonus, ssShipBonus, ssColonyBonus};
+enum SupplySystemBonusFields {ssbBonus, ssbVisibilityBonus, ssbShipBonus, ssbColonyBonus};
 std::string SupplySystemBonusTupleString(const SupplySystemBonusTuple& x);
+
+// A tuple to report the per system per empire supply factors.
+using SupplySystemEmpireTuple = std::tuple<int, float, SupplySystemBonusTuple, float, float>;
+enum SupplySystemEmpireFields {sseSource, sseRange, sseBonus, sseDistance, sseStealth};
+std::string SupplySystemEmpireTupleString(const SupplySystemEmpireTuple& x);
 
 /** Used to calcuate all empires' supply distributions. */
 class FO_COMMON_API SupplyManager {

--- a/Empire/Supply.h
+++ b/Empire/Supply.h
@@ -64,8 +64,8 @@ public:
 
     /** Returns set of sets of systems that can share industry (systems in
       * separate groups are blockaded or otherwise separated). */
-    const std::map<int, std::set<std::set<int>>>&           ResourceSupplyGroups() const;
-    const std::set<std::set<int>>&                          ResourceSupplyGroups(int empire_id) const;
+    const std::unordered_map<int, std::vector<std::unordered_set<int>>>& ResourceSupplyGroups() const;
+    const std::vector<std::unordered_set<int>>&                          ResourceSupplyGroups(int empire_id) const;
 
     /** Returns the range from each system some empire can propagate supply.*/
     const std::unordered_map<int, float>&                             PropagatedSupplyRanges() const;

--- a/Empire/Supply.h
+++ b/Empire/Supply.h
@@ -68,19 +68,19 @@ public:
     const std::set<std::set<int>>&                          ResourceSupplyGroups(int empire_id) const;
 
     /** Returns the range from each system some empire can propagate supply.*/
-    const std::map<int, float>&                             PropagatedSupplyRanges() const;
+    const std::unordered_map<int, float>&                             PropagatedSupplyRanges() const;
     /** Returns the range from each system that the empire with id \a empire_id
       * can propagate supply.*/
-    const std::map<int, float>&                             PropagatedSupplyRanges(int empire_id) const;
+    const std::unordered_map<int, float>&                             PropagatedSupplyRanges(int empire_id) const;
 
     /** Returns the distance from each system some empire is away
       * from its closest source of supply without passing
       * through obstructed systems for that empire. */
-    const std::map<int, float>&                             PropagatedSupplyDistances() const;
+    const std::unordered_map<int, float>&                             PropagatedSupplyDistances() const;
     /** Returns the distance from each system for the empire with id
       * \a empire_id to the closest source of supply without passing
       * through obstructed systems for that empire. */
-    const std::map<int, float>&                             PropagatedSupplyDistances(int empire_id) const;
+    const std::unordered_map<int, float>&                             PropagatedSupplyDistances(int empire_id) const;
 
     /** Returns true if system with id \a system_id is fleet supplyable or in
       * one of the resource supply groups for empire with id \a empire_id */

--- a/Empire/Supply.h
+++ b/Empire/Supply.h
@@ -57,9 +57,9 @@ public:
     /** Returns set of system ids where fleets can be supplied by this empire
       * (as determined by object supply meters and rules of supply propagation
       * and blockade). */
-    const std::map<int, std::set<int>>&                     FleetSupplyableSystemIDs() const;
-    const std::set<int>&                                    FleetSupplyableSystemIDs(int empire_id) const;
-    std::set<int>                                           FleetSupplyableSystemIDs(int empire_id, bool include_allies) const;
+    const std::unordered_map<int, std::unordered_set<int>>&           FleetSupplyableSystemIDs() const;
+    const std::unordered_set<int>&                                    FleetSupplyableSystemIDs(int empire_id) const;
+    std::unordered_set<int>                                           FleetSupplyableSystemIDs(int empire_id, bool include_allies) const;
     int                                                     EmpireThatCanSupplyAt(int system_id) const;
 
     /** Returns set of sets of systems that can share industry (systems in

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -839,9 +839,10 @@ MapWnd::MovementLineData::MovementLineData() :
     colour(GG::CLR_ZERO)
 {}
 
-MapWnd::MovementLineData::MovementLineData(const std::list<MovePathNode>& path_,
-                                           const std::unordered_map<std::pair<int, int>, LaneEndpoints, UnorderedPairHash, UnorderedPairEqual>& lane_end_points_map,
-                                           GG::Clr colour_/*= GG::CLR_WHITE*/, int empireID /*= ALL_EMPIRES*/) :
+MapWnd::MovementLineData::MovementLineData(
+    const std::list<MovePathNode>& path_,
+    const std::unordered_map<std::pair<int, int>, LaneEndpoints, OrderedPairHash>& lane_end_points_map,
+    GG::Clr colour_/*= GG::CLR_WHITE*/, int empireID /*= ALL_EMPIRES*/) :
     path(path_),
     colour(colour_)
 {

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -3265,12 +3265,12 @@ namespace {
         // Convert supply starlanes to non-directional.  This saves half
         // of the lookups.
         GetPathsThroughSupplyLanes::SupplyLaneMMap resource_supply_lanes_undirected;
-        const std::set<std::pair<int, int>>
+        const auto&
             resource_supply_lanes_directed = GetSupplyManager().SupplyStarlaneTraversals(empire_id);
 
-        for (const std::set<std::pair<int, int>>::value_type& supply_lane : resource_supply_lanes_directed) {
-            resource_supply_lanes_undirected.insert({supply_lane.first, supply_lane.second});
-            resource_supply_lanes_undirected.insert({supply_lane.second, supply_lane.first});
+        for (const auto& supply_lane : resource_supply_lanes_directed) {
+            resource_supply_lanes_undirected.insert({supply_lane.first.first, supply_lane.first.second});
+            resource_supply_lanes_undirected.insert({supply_lane.first.second, supply_lane.first.first});
         }
 
         // For each pool of resources find all paths available through
@@ -3416,7 +3416,7 @@ void MapWnd::InitStarlaneRenderingBuffers() {
                 GG::Clr lane_colour = UNOWNED_LANE_COLOUR;    // default colour if no empires transfer resources along starlane
                 for (std::map<int, Empire*>::value_type& entry : Empires()) {
                     Empire* empire = entry.second;
-                    const std::set<std::pair<int, int>>& resource_supply_lanes = GetSupplyManager().SupplyStarlaneTraversals(entry.first);
+                    const auto& resource_supply_lanes = GetSupplyManager().SupplyStarlaneTraversals(entry.first);
 
                     //std::cout << "resource supply starlane traversals for empire " << empire->Name() << ": " << resource_supply_lanes.size() << std::endl;
 
@@ -3485,7 +3485,7 @@ void MapWnd::InitStarlaneRenderingBuffers() {
 
                 for (std::map<int, Empire*>::value_type& entry : Empires()) {
                     Empire* empire = entry.second;
-                    const std::set<std::pair<int, int>>& resource_obstructed_supply_lanes =
+                    const auto& resource_obstructed_supply_lanes =
                         GetSupplyManager().SupplyObstructedStarlaneTraversals(entry.first);
 
                     // see if this lane exists in this empire's supply propagation lanes set.  either direction accepted.

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -810,6 +810,13 @@ LaneEndpoints& LaneEndpoints::operator=(LaneEndpoints&& other) {
     return *this;
 }
 
+LaneEndpoints& LaneEndpoints::ReverseDirection() {
+    std::swap(s1, s2);
+    std::swap(X1, X2);
+    std::swap(Y1, Y2);
+    return *this;
+}
+
 ////////////////////////////////////////////////
 // MapWnd::MovementLineData::Vertex
 ////////////////////////////////////////////////

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -728,12 +728,87 @@ void MapWndPopup::Close()
 //LaneEndpoints
 //////////////////////////////////
 LaneEndpoints::LaneEndpoints() :
+    s1(nullptr),
+    s2(nullptr),
     X1(static_cast<float>(UniverseObject::INVALID_POSITION)),
     Y1(static_cast<float>(UniverseObject::INVALID_POSITION)),
     X2(static_cast<float>(UniverseObject::INVALID_POSITION)),
     Y2(static_cast<float>(UniverseObject::INVALID_POSITION))
 {}
 
+LaneEndpoints::LaneEndpoints(const std::shared_ptr<const System>& _s1, const std::shared_ptr<const System>& _s2) :
+    s1(_s1), s2(_s2),
+    X1(0.0f), Y1(0.0f), X2(0.0f), Y2(0.0f)
+{
+    double X1_calc = _s1->X();
+    double Y1_calc = _s1->Y();
+    double X2_calc = _s2->X();
+    double Y2_calc = _s2->Y();
+
+    // get unit vector
+    double deltaX = X2_calc - X1_calc;
+    double deltaY = Y2_calc - Y1_calc;
+    double mag = std::sqrt(deltaX*deltaX + deltaY*deltaY);
+
+    double ring_radius = ClientUI::SystemCircleSize() / 2.0 + 0.5;
+
+    // safety check.  don't modify original coordinates if they're too close togther
+    if (mag > 2*ring_radius) {
+        // rescale vector to length of ring radius
+        double offsetX = deltaX / mag * ring_radius;
+        double offsetY = deltaY / mag * ring_radius;
+
+        // move start and end points inwards by rescaled vector
+        X1_calc += offsetX;
+        Y1_calc += offsetY;
+        X2_calc -= offsetX;
+        Y2_calc -= offsetY;
+    }
+
+    X1 = static_cast<float>(X1_calc);
+    Y1 = static_cast<float>(Y1_calc);
+    X2 = static_cast<float>(X2_calc);
+    Y2 = static_cast<float>(Y2_calc);
+}
+
+LaneEndpoints::~LaneEndpoints()
+{}
+
+LaneEndpoints::LaneEndpoints(const LaneEndpoints& other) :
+    s1(other.s1), s2(other.s2),
+    X1(other.X1), Y1(other.Y1), X2(other.X2), Y2(other.Y2)
+{}
+
+// Move constructor
+LaneEndpoints::LaneEndpoints(LaneEndpoints&& other) :
+    s1(other.s1), s2(other.s2),
+    X1(other.X1), Y1(other.Y1), X2(other.X2), Y2(other.Y2)
+{}
+
+LaneEndpoints& LaneEndpoints::operator=(const LaneEndpoints& other) {
+    if (this != &other) {
+        s1 = other.s1;
+        s2 = other.s2;
+        X1 = other.X1;
+        Y1 = other.Y1;
+        X2 = other.X2;
+        Y2 = other.Y2;
+    }
+    return *this;
+}
+
+// Move assignment
+LaneEndpoints& LaneEndpoints::operator=(LaneEndpoints&& other) {
+    if (this != &other) {
+        s1 = std::move(other.s1);
+        s2 = std::move(other.s2);
+        X1 = other.X1;
+        Y1 = other.Y1;
+        X2 = other.X2;
+        Y2 = other.Y2;
+    }
+    return *this;
+}
 
 ////////////////////////////////////////////////
 // MapWnd::MovementLineData::Vertex

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -833,7 +833,7 @@ MapWnd::MovementLineData::MovementLineData() :
 {}
 
 MapWnd::MovementLineData::MovementLineData(const std::list<MovePathNode>& path_,
-                                           const std::map<std::pair<int, int>, LaneEndpoints>& lane_end_points_map,
+                                           const std::unordered_map<std::pair<int, int>, LaneEndpoints, UnorderedPairHash, UnorderedPairEqual>& lane_end_points_map,
                                            GG::Clr colour_/*= GG::CLR_WHITE*/, int empireID /*= ALL_EMPIRES*/) :
     path(path_),
     colour(colour_)
@@ -899,7 +899,7 @@ MapWnd::MovementLineData::MovementLineData(const std::list<MovePathNode>& path_,
         std::pair<int, int> lane_ids = UnorderedIntPair(prev_sys_id, next_sys_id);
 
         // get lane end points
-        std::map<std::pair<int, int>, LaneEndpoints>::const_iterator ends_it = lane_end_points_map.find(lane_ids);
+        const auto& ends_it = lane_end_points_map.find(lane_ids);
         if (ends_it == lane_end_points_map.end()) {
             ErrorLogger() << "couldn't get endpoints of lane for move line";
             break;
@@ -3469,7 +3469,7 @@ void MapWnd::InitStarlaneEndPoints() {
                 continue;
 
             // check that this lane isn't already in map / being rendered.
-            std::pair<int, int> lane = UnorderedIntPair(start_system->ID(), dest_system->ID()); 
+            std::pair<int, int> lane = {start_system->ID(), dest_system->ID()};
 
             if (m_starlane_endpoints.find(lane) != m_starlane_endpoints.end())
                 continue;
@@ -3479,9 +3479,9 @@ void MapWnd::InitStarlaneEndPoints() {
             // get and store universe position endpoints for this starlane.  make sure to store in the same order
             // as the system ids in the lane id pair
             if (start_system->ID() == lane.first)
-                m_starlane_endpoints.insert({lane, LaneEndpoints(start_system, dest_system)});
+                m_starlane_endpoints.insert(std::make_pair(lane, LaneEndpoints(start_system, dest_system)));
             else
-                m_starlane_endpoints.insert({lane, LaneEndpoints(dest_system, start_system)});
+                m_starlane_endpoints.insert(std::make_pair(lane, LaneEndpoints(dest_system, start_system)));
         }
     }
 }
@@ -4583,7 +4583,7 @@ std::pair<double, double> MapWnd::MovingFleetMapPositionOnLane(std::shared_ptr<c
     std::pair<int, int> lane = UnorderedIntPair(sys1_id, sys2_id);
 
     // get apparent positions of endpoints for this lane that have been pre-calculated
-    std::map<std::pair<int, int>, LaneEndpoints>::const_iterator endpoints_it = m_starlane_endpoints.find(lane);
+    const auto& endpoints_it = m_starlane_endpoints.find(lane);
     if (endpoints_it == m_starlane_endpoints.end()) {
         // couldn't find an entry for the lane this fleet is one, so just
         // return actual position of fleet on starlane - ignore the distance

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -782,11 +782,11 @@ MapWnd::MovementLineData::MovementLineData(const std::list<MovePathNode>& path_,
     int     next_sys_id =               INVALID_OBJECT_ID;
 
     const Empire* empire = GetEmpire(empireID);
-    std::set<int> unobstructed;
+    const std::set<int>* unobstructed;
     bool s_flag = false;
     bool calc_s_flag = false;
     if (empire) {
-        unobstructed = empire->SupplyUnobstructedSystems();
+        unobstructed = &empire->SupplyUnobstructedSystems();
         calc_s_flag = true;
         //s_flag = ((first_node.object_id != INVALID_OBJECT_ID) && unobstructed.find(first_node.object_id)==unobstructed.end());
     }
@@ -838,7 +838,7 @@ MapWnd::MovementLineData::MovementLineData(const std::list<MovePathNode>& path_,
         // 3) Add points for line segment to list of Vertices
         bool b_flag = node.post_blockade;
         s_flag = s_flag || (calc_s_flag &&
-            ((node.object_id != INVALID_OBJECT_ID) && unobstructed.find(node.object_id)==unobstructed.end()));
+            ((node.object_id != INVALID_OBJECT_ID) && unobstructed->find(node.object_id)==unobstructed->end()));
         vertices.push_back(Vertex(start_xy.first,   start_xy.second,    prev_eta,   false,          b_flag, s_flag));
         vertices.push_back(Vertex(end_xy.first,     end_xy.second,      node.eta,   node.turn_end,  b_flag, s_flag));
 

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -2029,12 +2029,12 @@ void MapWnd::RenderSystems() {
                     if (system->NumStarlanes() > 0) {
                         glColor(GetOptionsDB().Get<GG::Clr>("UI.unowned-starlane-colour"));
 
-                        if (m_supply_lane_empire_id) {
-                            int empire_id = GetSupplyManager().EmpireThatCanSupplyAt(system_icon.first);
-                            if ((empire_id == m_supply_lane_empire_id) && (empire_id != ALL_EMPIRES)) {
-                                if (Empire* empire = GetEmpire(empire_id)) {
+                        // If the active supply viewing empire has supply here color the circle
+                        if (m_supply_lane_empire_id && *m_supply_lane_empire_id != ALL_EMPIRES) {
+                            const auto& supply_map = GetSupplyManager().FleetSupplyableSystemIDs(*m_supply_lane_empire_id);
+                            if (supply_map.find(system_icon.first) != supply_map.end()) {
+                                if (Empire* empire = GetEmpire(*m_supply_lane_empire_id))
                                     glColor(empire->Color());
-                                }
                             }
                         }
                         CircleArc(circle_ul, circle_lr, 0.0, TWO_PI, false);

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -5482,7 +5482,7 @@ void MapWnd::SelectedShipsChanged() {
         selected_ship_ids = fleet_wnd->SelectedShipIDs();
 
     // if old and new sets of selected fleets are the same, don't need to change anything
-    if (selected_ship_ids == m_selected_fleet_ids)
+    if (selected_ship_ids == m_selected_ship_ids)
         return;
 
     // set new selected fleets

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -2686,7 +2686,7 @@ void MapWnd::InitTurn() {
 
 void MapWnd::MidTurnUpdate() {
     DebugLogger() << "MapWnd::MidTurnUpdate";
-    ScopedTimer timer("MapWnd::MidTurnUpdate", true);
+    SectionedScopedTimer timer("MapWnd::MidTurnUpdate", boost::chrono::microseconds(100));
 
     GetUniverse().InitializeSystemGraph(HumanClientApp::GetApp()->EmpireID());
 
@@ -2705,7 +2705,8 @@ void MapWnd::MidTurnUpdate() {
 
 void MapWnd::InitTurnRendering() {
     DebugLogger() << "MapWnd::InitTurnRendering";
-    ScopedTimer timer("MapWnd::InitTurnRendering", true);
+    SectionedScopedTimer timer("MapWnd::InitTurnRendering", boost::chrono::microseconds(100));
+    timer.EnterSection("init");
 
     // adjust size of map window for universe and application size
     Resize(GG::Pt(static_cast<GG::X>(GetUniverse().UniverseWidth() * ZOOM_MAX + AppWidth() * 1.5),
@@ -2810,7 +2811,7 @@ void MapWnd::InitTurnRendering() {
 
 void MapWnd::InitSystemRenderingBuffers() {
     DebugLogger() << "MapWnd::InitSystemRenderingBuffers";
-    ScopedTimer timer("MapWnd::InitSystemRenderingBuffers", true);
+    SectionedScopedTimer timer("MapWnd::InitSystemRenderingBuffers", boost::chrono::microseconds(100));
 
     // clear out all the old buffers
     ClearSystemRenderingBuffers();
@@ -3327,7 +3328,8 @@ namespace {
 
 void MapWnd::InitStarlaneRenderingBuffers() {
     DebugLogger() << "MapWnd::InitStarlaneRenderingBuffers";
-    ScopedTimer timer("MapWnd::InitStarlaneRenderingBuffers", true);
+    SectionedScopedTimer timer("MapWnd::InitStarlaneRenderingBuffers", boost::chrono::microseconds(100));
+    timer.EnterSection("client collection");
 
     // clear old buffers
     ClearStarlaneRenderingBuffers();
@@ -3357,6 +3359,8 @@ void MapWnd::InitStarlaneRenderingBuffers() {
                        member_to_core, under_alloc_res_grp_core_members);
 
 
+    //DebugLogger() << "           MapWnd::InitStarlaneRenderingBuffers  finished empire Info collection";
+    timer.EnterSection("general");
 
     // calculate in-universe apparent starlane endpoints and create buffers for starlane rendering
     m_starlane_endpoints.clear();
@@ -3511,6 +3515,7 @@ void MapWnd::InitStarlaneRenderingBuffers() {
         }
     }
 
+    timer.EnterSection("fill buffers");
 
     // fill new buffers
     m_starlane_vertices.createServerBuffer();
@@ -3559,7 +3564,7 @@ LaneEndpoints MapWnd::StarlaneEndPointsFromSystemPositions(double X1, double Y1,
 
 void MapWnd::InitFieldRenderingBuffers() {
     DebugLogger() << "MapWnd::InitFieldRenderingBuffers";
-    ScopedTimer timer("MapWnd::InitFieldRenderingBuffers", true);
+    SectionedScopedTimer timer("MapWnd::InitFieldRenderingBuffers", boost::chrono::microseconds(100));
 
     ClearFieldRenderingBuffers();
 
@@ -3668,7 +3673,7 @@ void MapWnd::ClearFieldRenderingBuffers() {
 void MapWnd::InitVisibilityRadiiRenderingBuffers() {
     DebugLogger() << "MapWnd::InitVisibilityRadiiRenderingBuffers";
     //std::cout << "InitVisibilityRadiiRenderingBuffers" << std::endl;
-    ScopedTimer timer("MapWnd::InitVisibilityRadiiRenderingBuffers", true);
+    SectionedScopedTimer timer("MapWnd::InitVisibilityRadiiRenderingBuffers", boost::chrono::microseconds(100));
 
     ClearVisibilityRadiiRenderingBuffers();
 
@@ -4046,6 +4051,7 @@ void MapWnd::ReselectLastSystem() {
 }
 
 void MapWnd::SelectSystem(int system_id) {
+    SectionedScopedTimer timer("MapWnd::SelectSystem", boost::chrono::microseconds(100));
     //std::cout << "MapWnd::SelectSystem(" << system_id << ")" << std::endl;
     std::shared_ptr<const System> system = GetSystem(system_id);
     if (!system && system_id != INVALID_OBJECT_ID) {
@@ -4134,13 +4140,15 @@ void MapWnd::ReselectLastFleet() {
     }
 }
 
-void MapWnd::SelectPlanet(int planetID)
-{ m_production_wnd->SelectPlanet(planetID); }   // calls SidePanel::SelectPlanet()
+void MapWnd::SelectPlanet(int planet_id) {
+    SectionedScopedTimer timer("MapWnd::SelectPlanet", boost::chrono::microseconds(100));
+}
 
 void MapWnd::SelectFleet(int fleet_id)
 { SelectFleet(GetFleet(fleet_id)); }
 
 void MapWnd::SelectFleet(std::shared_ptr<Fleet> fleet) {
+    SectionedScopedTimer timer("MapWnd::SelectFleet", boost::chrono::microseconds(100));
     FleetUIManager& manager = FleetUIManager::GetFleetUIManager();
 
     if (!fleet) {
@@ -4531,7 +4539,7 @@ void MapWnd::DeferredRefreshFleetButtons() {
         return;
     m_deferred_refresh_fleet_buttons = false;
 
-    ScopedTimer timer("RefreshFleetButtons()");
+    SectionedScopedTimer timer("MapWnd::DeferredRefreshFleetButtons", boost::chrono::microseconds(100));
 
     // determine fleets that need buttons so that fleets at the same location can
     // be grouped by empire owner and buttons created
@@ -4645,7 +4653,7 @@ void MapWnd::DeleteFleetButtons() {
 }
 
 void MapWnd::RemoveFleetsStateChangedSignal(const std::vector<std::shared_ptr<Fleet>>& fleets) {
-    ScopedTimer timer("RemoveFleetsStateChangedSignal()", true);
+    SectionedScopedTimer timer("MapWnd::RemoveFleetsStateChangedSignal", boost::chrono::microseconds(100));
     for (std::shared_ptr<Fleet> fleet : fleets) {
         boost::unordered_map<int, boost::signals2::connection>::iterator
             found_signal = m_fleet_state_change_signals.find(fleet->ID());
@@ -4657,7 +4665,7 @@ void MapWnd::RemoveFleetsStateChangedSignal(const std::vector<std::shared_ptr<Fl
 }
 
 void MapWnd::AddFleetsStateChangedSignal(const std::vector<std::shared_ptr<Fleet>>& fleets) {
-    ScopedTimer timer("AddFleetsStateChangedSignal()", true);
+    SectionedScopedTimer timer("MapWnd::AddFleetsStateChangedSignal", boost::chrono::microseconds(100));
     for (std::shared_ptr<Fleet> fleet : fleets) {
         m_fleet_state_change_signals[fleet->ID()] =
             GG::Connect(fleet->StateChangedSignal, &MapWnd::RefreshFleetButtons, this);
@@ -4665,20 +4673,20 @@ void MapWnd::AddFleetsStateChangedSignal(const std::vector<std::shared_ptr<Fleet
 }
 
 void MapWnd::FleetsInsertedSignalHandler(const std::vector<std::shared_ptr<Fleet>>& fleets) {
-    ScopedTimer timer("FleetsInsertedSignalHandler()", true);
+    SectionedScopedTimer timer("MapWnd::FleetsInsertedSignalHandler", boost::chrono::microseconds(100));
     RefreshFleetButtons();
     RemoveFleetsStateChangedSignal(fleets);
     AddFleetsStateChangedSignal(fleets);
 }
 
 void MapWnd::FleetsRemovedSignalHandler(const std::vector<std::shared_ptr<Fleet>>& fleets) {
-    ScopedTimer timer("FleetsRemovedSignalHandler()", true);
+    SectionedScopedTimer timer("MapWnd::FleetsRemovedSignalHandler", boost::chrono::microseconds(100));
     RefreshFleetButtons();
     RemoveFleetsStateChangedSignal(fleets);
 }
 
 void MapWnd::RefreshFleetSignals() {
-    ScopedTimer timer("RefreshFleetSignals()", true);
+    SectionedScopedTimer timer("MapWnd::RefreshFleetSignals", boost::chrono::microseconds(100));
     // disconnect old fleet statechangedsignal connections
     for (boost::unordered_map<int, boost::signals2::connection>::value_type& con : m_fleet_state_change_signals)
     { con.second.disconnect(); }
@@ -5286,7 +5294,7 @@ void MapWnd::SelectedFleetsChanged() {
 }
 
 void MapWnd::SelectedShipsChanged() {
-    ScopedTimer timer("MapWnd::SelectedShipsChanged", true);
+    SectionedScopedTimer timer("MapWnd::SelectedShipsChanged", boost::chrono::microseconds(100));
 
     // get selected ships
     std::set<int> selected_ship_ids;

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -1439,6 +1439,7 @@ MapWnd::MapWnd() :
         }
         if (PlayerListWnd* plr_wnd = cui->GetPlayerListWnd()) {
             GG::Connect(plr_wnd->ClosingSignal, boost::bind(&MapWnd::HideEmpires, this));     // Wnd is manually closed by user
+            GG::Connect(plr_wnd->SelectedPlayersChangedSignal, boost::bind(&MapWnd::SelectedPlayersChanged, this));
             if (plr_wnd->Visible()) {
                 m_btn_empires->SetUnpressedGraphic(GG::SubTexture(ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "buttons" / "empires_mouseover.png")));
                 m_btn_empires->SetRolloverGraphic (GG::SubTexture(ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "buttons" / "empires.png")));
@@ -2962,6 +2963,21 @@ void MapWnd::ClearSystemRenderingBuffers() {
     m_galaxy_gas_texture_coords.clear();
     m_star_texture_coords.clear();
     m_star_circle_vertices.clear();
+}
+
+void MapWnd::SelectedPlayersChanged() {
+    // If there is a single empire selected in the Empires window, then render its supply lanes.
+    const auto cui = ClientUI::GetClientUI();
+    if (!cui)
+        return;
+    const auto plr_wnd = cui->GetPlayerListWnd();
+    if (!plr_wnd)
+        return;
+    const auto players = plr_wnd->SelectedPlayerIDs();
+    if (players.size() != 1)
+        return;
+
+    ChangeSupplyLaneRenderedEmpire(*players.begin());
 }
 
 void MapWnd::ChangeSupplyLaneRenderedEmpire(int empire_id) {

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -3615,8 +3615,8 @@ void MapWnd::InitStarlaneRenderingBuffers() {
 
 
             // Should the whole lane be colored?
-            // Are both endpoints visible?
-            if (observed_empire && start_visible && end_visible) {
+            // Is either endpoint visible?
+            if (observed_empire && (start_visible || end_visible)) {
                 timer.EnterSection("full lane coloring");
                 // Is the lane detectable?
                 if (forward_detectable || backward_detectable) {

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -6608,7 +6608,7 @@ namespace { //helper function for DispatchFleetsExploring
         if (!empire)
             return std::pair<int, int>(INVALID_OBJECT_ID, INT_MAX);
 
-        std::set<int> supplyable_systems = GetSupplyManager().FleetSupplyableSystemIDs(empire->EmpireID());
+        const auto& supplyable_systems = GetSupplyManager().FleetSupplyableSystemIDs(empire->EmpireID());
         std::map<int, std::set<int>> starlanes = empire->KnownStarlanes();
         std::set<int> frontier;
         frontier.insert(system_id);
@@ -6669,7 +6669,7 @@ void MapWnd::DispatchFleetsExploring() {
 
     //list all unknow systems with the distance to the nearest supply available
     std::map<int, int> unknown_systems;
-    const std::set<int>& supplyable_systems = GetSupplyManager().FleetSupplyableSystemIDs(empire_id);
+    const auto& supplyable_systems = GetSupplyManager().FleetSupplyableSystemIDs(empire_id);
     for (int system_id : candidates_unknown_systems) {
         std::shared_ptr<System> system = GetSystem(system_id);
         if (!system)

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -2964,6 +2964,14 @@ void MapWnd::ClearSystemRenderingBuffers() {
     m_star_circle_vertices.clear();
 }
 
+void MapWnd::ChangeSupplyLaneRenderedEmpire(int empire_id) {
+    // Update supply lane rendering if it changed.
+    auto m_supply_lane_empire_id_old = m_supply_lane_empire_id;
+    m_supply_lane_empire_id = (empire_id != ALL_EMPIRES) ? boost::optional<int>(empire_id) : boost::none;
+    if (m_supply_lane_empire_id != m_supply_lane_empire_id_old)
+        InitStarlaneRenderingBuffers();
+}
+
 namespace GetPathsThroughSupplyLanes {
     // SupplyLaneMap map keyed by system containing all systems
     // corresponding to valid supply lane destinations
@@ -4092,16 +4100,11 @@ void MapWnd::SelectSystem(int system_id) {
         system_id = INVALID_OBJECT_ID;
     }
 
-
     if (system) {
         // ensure meter estimates are up to date, particularly for which ship is selected
         GetUniverse().UpdateMeterEstimates(system_id, true);
 
-        // // If the selected system is owned then display the supply lanes for the owner.
-        auto m_supply_lane_empire_id_old = m_supply_lane_empire_id;
-        m_supply_lane_empire_id = (system->Owner() != ALL_EMPIRES) ? boost::optional<int>(system->Owner()) : boost::none;
-        if (m_supply_lane_empire_id != m_supply_lane_empire_id_old)
-            InitStarlaneRenderingBuffers();
+        ChangeSupplyLaneRenderedEmpire(system->Owner());
     }
 
     if (SidePanel::SystemID() != system_id) {
@@ -4186,11 +4189,7 @@ void MapWnd::SelectPlanet(int planet_id) {
     if (!planet)
         return;
 
-    // If the selected planet is owned then display the supply lanes for the owner.
-    auto m_supply_lane_empire_id_old = m_supply_lane_empire_id;
-    m_supply_lane_empire_id = (planet->Owner() != ALL_EMPIRES) ? boost::optional<int>(planet->Owner()) : boost::none;
-    if (m_supply_lane_empire_id != m_supply_lane_empire_id_old)
-        InitStarlaneRenderingBuffers();
+    ChangeSupplyLaneRenderedEmpire(planet->Owner());
 }
 
 void MapWnd::SelectFleet(int fleet_id)
@@ -4260,11 +4259,7 @@ void MapWnd::SelectFleet(std::shared_ptr<Fleet> fleet) {
     // signals being emitted and connected to MapWnd::SelectedFleetsChanged
     fleet_wnd->SelectFleet(fleet->ID());
 
-    // If the selected fleet is owned then display the supply lanes for the owner.
-    auto m_supply_lane_empire_id_old = m_supply_lane_empire_id;
-    m_supply_lane_empire_id = (fleet->Owner() != ALL_EMPIRES) ? boost::optional<int>(fleet->Owner()) : boost::none;
-    if (m_supply_lane_empire_id != m_supply_lane_empire_id_old)
-        InitStarlaneRenderingBuffers();
+    ChangeSupplyLaneRenderedEmpire(fleet->Owner());
 }
 
 void MapWnd::RemoveFleet(int fleet_id) {

--- a/UI/MapWnd.h
+++ b/UI/MapWnd.h
@@ -461,22 +461,18 @@ private:
     ModeratorActionsWnd*        m_moderator_wnd;    //!< buttons to select moderator actions
     CombatReportWnd*            m_combat_report_wnd;//!< shows graphical reports of combats
 
-    struct UnorderedPairHash {
+    struct OrderedPairHash {
         std::size_t operator()(const std::pair<int, int> x) const {
-            // Use XOR so that the hash is order independent.
-            return std::hash<int>{}(x.first) ^ std::hash<int>{}(x.second) ;
-        }
-    };
-
-    struct UnorderedPairEqual {
-        bool operator()(const std::pair<int, int>& x, const std::pair<int, int>& y) const {
-            return (((x.first == y.first) && (x.second == y.second))
-                    || ((x.first == y.second) && (x.second == y.first)));
+            // Use boost::hash_combine to preserve order.
+            std::size_t seed(0);
+            boost::hash_combine(seed, x.first);
+            boost::hash_combine(seed, x.second);
+            return seed;
         }
     };
 
     // A map from an unordered pair of systems to starlanes endpoint in universe coordinates
-    std::unordered_map<std::pair<int, int>, LaneEndpoints, UnorderedPairHash, UnorderedPairEqual> m_starlane_endpoints;
+    std::unordered_map<std::pair<int, int>, LaneEndpoints, OrderedPairHash> m_starlane_endpoints;
 
     /** Icons representing fleets at a system that are not departing, indexed
         by system. */
@@ -500,7 +496,7 @@ private:
         struct Vertex;                                  // apparent universe positions of move line points, derived from actual universe positions contained in MovePathNodes
         MovementLineData();
         MovementLineData(const std::list<MovePathNode>& path_,
-                         const std::unordered_map<std::pair<int, int>, LaneEndpoints, UnorderedPairHash, UnorderedPairEqual>& lane_end_points_map,
+                         const std::unordered_map<std::pair<int, int>, LaneEndpoints, OrderedPairHash>& lane_end_points_map,
                          GG::Clr colour_ = GG::CLR_WHITE, int empireID = ALL_EMPIRES);
 
         std::list<MovePathNode>             path;       // raw path data from which line rendering is determined

--- a/UI/MapWnd.h
+++ b/UI/MapWnd.h
@@ -50,6 +50,8 @@ struct LaneEndpoints {
     LaneEndpoints& operator=(const LaneEndpoints& other);
     LaneEndpoints& operator=(LaneEndpoints&& other);
 
+    LaneEndpoints& ReverseDirection(); ///< Swap the endpoints to change the direction.
+
     std::shared_ptr<const System> s1, s2;
     float X1, Y1, X2, Y2;
 };

--- a/UI/MapWnd.h
+++ b/UI/MapWnd.h
@@ -42,6 +42,14 @@ class ShaderProgram;
  * positioning fleet buttons that are moving along the starlane. */
 struct LaneEndpoints {
     LaneEndpoints();
+    LaneEndpoints(const std::shared_ptr<const System>& s1, const std::shared_ptr<const System>& s2);
+    ~LaneEndpoints();
+    LaneEndpoints(const LaneEndpoints& other);
+    LaneEndpoints(LaneEndpoints&& other);
+    LaneEndpoints& operator=(const LaneEndpoints& other);
+    LaneEndpoints& operator=(LaneEndpoints&& other);
+
+    std::shared_ptr<const System> s1, s2;
     float X1, Y1, X2, Y2;
 };
 

--- a/UI/MapWnd.h
+++ b/UI/MapWnd.h
@@ -302,6 +302,7 @@ private:
     void            InitTurnRendering();                        //!< sets up rendering of system icons, galaxy gas, starlanes at start of turn
     void            InitSystemRenderingBuffers();               //!< initializes or refreshes buffers for rendering of system icons and galaxy gas
     void            ClearSystemRenderingBuffers();
+    void            InitStarlaneEndPoints();
     void            InitStarlaneRenderingBuffers();             //!< initializes or refreshes buffers for rendering of starlanes
     void            ClearStarlaneRenderingBuffers();
     void            InitFieldRenderingBuffers();
@@ -311,10 +312,6 @@ private:
     void            InitScaleCircleRenderingBuffer();
     void            ClearScaleCircleRenderingBuffer();
     void            ClearStarfieldRenderingBuffers();
-
-    /* Takes X and Y coordinates of a pair of systems and moves these points inwards along the vector
-     * between them by the radius of a system on screen (at zoom 1.0) and return result */ 
-    LaneEndpoints   StarlaneEndPointsFromSystemPositions(double X1, double Y1, double X2, double Y2);
 
     void            RenderStarfields();                         //!< renders the background starfiends
     void            RenderGalaxyGas();                          //!< renders gassy substance to make shape of galaxy

--- a/UI/MapWnd.h
+++ b/UI/MapWnd.h
@@ -444,6 +444,9 @@ private:
     /** Change which empire is used for supply lane rendering.*/
     void            ChangeSupplyLaneRenderedEmpire(int empire_id);
 
+    /** Handle a SelectedPlayersChangedSignal. */
+    void            SelectedPlayersChanged();
+
     /** The ID of the empire to render the colored supply lanes for or none.*/
     boost::optional<int>        m_supply_lane_empire_id;
 

--- a/UI/MapWnd.h
+++ b/UI/MapWnd.h
@@ -441,6 +441,9 @@ private:
     void            SelectedFleetsChanged();
     void            SelectedShipsChanged();
 
+    /** The ID of the empire to render the colored supply lanes for or none.*/
+    boost::optional<int>        m_supply_lane_empire_id;
+
     std::set<int>               m_selected_fleet_ids;
     std::set<int>               m_selected_ship_ids;
 

--- a/UI/MapWnd.h
+++ b/UI/MapWnd.h
@@ -441,6 +441,9 @@ private:
     void            SelectedFleetsChanged();
     void            SelectedShipsChanged();
 
+    /** Change which empire is used for supply lane rendering.*/
+    void            ChangeSupplyLaneRenderedEmpire(int empire_id);
+
     /** The ID of the empire to render the colored supply lanes for or none.*/
     boost::optional<int>        m_supply_lane_empire_id;
 

--- a/UI/MultiIconValueIndicator.cpp
+++ b/UI/MultiIconValueIndicator.cpp
@@ -62,8 +62,12 @@ MultiIconValueIndicator::MultiIconValueIndicator(GG::X w, const std::vector<int>
         AttachChild(m_icons.back());
         x += IconWidth() + IconSpacing();
     }
+    x += EDGE_PAD;
+    const auto height = EDGE_PAD + IconHeight() + ClientUI::Pts()*3/2;
     if (!m_icons.empty())
-        Resize(GG::Pt(Width(), EDGE_PAD + IconHeight() + ClientUI::Pts()*3/2));
+        Resize(GG::Pt(x, height));
+    else
+        Resize(GG::Pt(GG::X0, height));
     Update();
 }
 

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -1046,20 +1046,20 @@ void ProductionWnd::UpdateInfoPanel() {
     std::shared_ptr<UniverseObject> loc_obj = GetUniverseObject(prod_loc_id);
     if (loc_obj) {
         // extract available and allocated PP at production location
-        std::map<std::set<int>, float> available_pp = queue.AvailablePP(empire->GetResourcePool(RE_INDUSTRY));
-        const std::map<std::set<int>, float>& allocated_pp = queue.AllocatedPP();
+        const auto& available_pp = queue.AvailablePP(empire->GetResourcePool(RE_INDUSTRY));
+        const auto& allocated_pp = queue.AllocatedPP();
 
         float available_pp_at_loc = 0.0f, allocated_pp_at_loc = 0.0f;   // for the resource sharing group containing the selected production location
 
-        for (const std::map<std::set<int>, float>::value_type& map : available_pp) {
-            if (map.first.find(prod_loc_id) != map.first.end()) {
+        for (const auto& map : available_pp) {
+            if (map.first->find(prod_loc_id) != map.first->end()) {
                 available_pp_at_loc = map.second;
                 break;
             }
         }
 
-        for (const std::map<std::set<int>, float>::value_type& map : allocated_pp) {
-            if (map.first.find(prod_loc_id) != map.first.end()) {
+        for (const auto& map : allocated_pp) {
+            if (map.first->find(prod_loc_id) != map.first->end()) {
                 allocated_pp_at_loc = map.second;
                 break;
             }

--- a/UI/SidePanel.h
+++ b/UI/SidePanel.h
@@ -16,6 +16,7 @@
 
 class CUIDropDownList;
 class MultiIconValueIndicator;
+class SystemSupplySummaryPanel;
 
 class SidePanel : public CUIWnd {
 public:
@@ -151,7 +152,7 @@ private:
 
     PlanetPanelContainer*       m_planet_panel_container;
     MultiIconValueIndicator*    m_system_resource_summary;
-
+    SystemSupplySummaryPanel*   m_system_supply_summary;
     bool                        m_selection_enabled;
 
     static bool                 s_needs_update;

--- a/UI/SystemSupplySummaryPanel.cpp
+++ b/UI/SystemSupplySummaryPanel.cpp
@@ -1,0 +1,229 @@
+#include "SystemSupplySummaryPanel.h"
+
+#include <GG/Texture.h>
+
+#include "../util/i18n.h"
+#include "../util/Logger.h"
+#include "../universe/PopCenter.h"
+#include "../universe/UniverseObject.h"
+#include "../universe/System.h"
+#include "../universe/Enums.h"
+#include "../client/human/HumanClientApp.h"
+#include "../Empire/Empire.h"
+#include "ClientUI.h"
+#include "CUIControls.h"
+#include "CUIDrawUtil.h"
+
+#include <iomanip>
+
+namespace {
+    constexpr double    TWO_PI = 2.0*3.1415926536;
+
+    constexpr int       EDGE_PAD(3);
+
+    int         IconSpacing()
+    { return ClientUI::Pts(); }
+    GG::X       IconWidth()
+    { return GG::X(IconSpacing()*2); }
+    GG::Y       IconHeight()
+    { return GG::Y(IconSpacing()*2); }
+
+    // Copied pasted from CombatEvents.cpp
+    // TODO find this code a home.
+    std::string WrapColorTag(std::string const & text, const GG::Clr& c) {
+        std::stringstream stream;
+        stream << "<rgba "
+               << std::setw(3) << static_cast<int>(c.r) << " "
+               << std::setw(3) << static_cast<int>(c.g) << " "
+               << std::setw(3) << static_cast<int>(c.b) << " "
+               << std::setw(3) << static_cast<int>(c.a)
+               << ">" << text << "</rgba>";
+        return stream.str();
+    }
+
+    std::string EmpireColorWrappedText(const Empire* empire, const std::string& text) {
+        // TODO: refactor this to somewhere that links with the UI code.
+        GG::Clr c = (empire ? empire->Color() : ClientUI::DefaultLinkColor());
+        return WrapColorTag(text, c);
+    }
+
+
+
+    /** Gives information about all supply in system. */
+    class SystemSupplyBrowseWnd : public GG::BrowseInfoWnd {
+        public:
+        SystemSupplyBrowseWnd(int system_id);
+
+        bool WndHasBrowseInfo(const Wnd* wnd, std::size_t mode) const override
+        { return !m_is_empty; }
+
+        bool IsEmpty() const
+        { return m_is_empty; }
+
+        void Render() override;
+
+        private:
+        bool m_is_empty;
+        CUILabel* m_label;
+    };
+
+
+    SystemSupplyBrowseWnd::SystemSupplyBrowseWnd(int system_id) :
+        GG::BrowseInfoWnd(GG::X0, GG::Y0, GG::X1, GG::Y1),
+        m_label(nullptr)
+    {
+        const auto system_supply_it = GetSupplyManager().SystemSupply(system_id);
+        m_is_empty = !system_supply_it;
+        if (m_is_empty)
+            return;
+
+        const auto system = GetSystem(system_id);
+
+        // Get detection strength
+        int viewing_empire_id = HumanClientApp::GetApp()->EmpireID();
+        const Empire* client_empire = GetEmpire(viewing_empire_id);
+        const auto detection_meter = client_empire->GetMeter("METER_DETECTION_STRENGTH");
+        const auto detection_strength =  detection_meter ? detection_meter->Current() : 0.0f;
+
+        std::stringstream ss;
+        ss << std::left << (system ? system->Name() : UserString("UNKNOWN"))
+           << " (" << system_id << ") supply details." <<std::endl;
+        ss << std::setw(50) << EmpireColorWrappedText(nullptr, "Empire")
+           << std::setw(50) << EmpireColorWrappedText(nullptr, "Source")
+           << std::setw(7) <<"(id)"
+           << std::setw(7) << "Range"
+           << std::setw(7) << "Dist" << std::setw(9) << "Stealth"
+           << std::setw(9) << "Bonus =" << std::setw(10) << "(Visible"
+           << std::setw(10) << "+ Ship +" << std::setw(8) << "Colony)" <<std::endl;
+
+        bool at_least_one_visible = false;
+        int num_rows = 1;
+        DebugLogger() << " Supply in system " << system->Name() << "(" << system_id << ") ";
+        for (const auto& empire_and_supply_fields : (*system_supply_it)->second) {
+            auto empire_id = empire_and_supply_fields.first;
+            auto empire = GetEmpire(empire_id);
+            for (const auto& supply_tuple : empire_and_supply_fields.second) {
+                num_rows += 1;
+                const auto& source_id = std::get<sseSource>(supply_tuple);
+                const auto& range = std::get<sseRange>(supply_tuple);
+                const auto& bonus_tuple = std::get<sseBonus>(supply_tuple);
+                const auto& distance = std::get<sseDistance>(supply_tuple);
+                const auto& stealth = std::get<sseStealth>(supply_tuple);
+                const auto& bonus = std::get<ssbBonus>(bonus_tuple);
+                const auto& visibility = std::get<ssbVisibilityBonus>(bonus_tuple);
+                const auto& ships = std::get<ssbShipBonus>(bonus_tuple);
+                const auto& colony = std::get<ssbColonyBonus>(bonus_tuple);
+
+                if (stealth >= detection_strength && empire_id != viewing_empire_id)
+                    continue;
+                at_least_one_visible = true;
+
+                auto source = Objects().Object(source_id);
+                ss << std::setw(50) << EmpireColorWrappedText(empire, (empire ? empire->Name() : UserString("UNKNOWN")));
+                ss << std::setw(50) << EmpireColorWrappedText(empire, (source ? source->Name() : UserString("UNKNOWN")));
+
+                ss << std::setw(7) << std::to_string(source_id);
+                ss << std::setw(7) << std::setprecision(2) << range;
+                ss << std::setw(7) << std::setprecision(3) << distance;
+                ss << std::setw(9) << std::setprecision(2) << stealth;
+                ss << std::setw(9) << std::setprecision(2) << bonus <<"= (";
+                ss << std::setw(10) << std::setprecision(2) << visibility << " + ";
+                ss << std::setw(10) << std::setprecision(2) << ships << " + ";
+                ss << std::setw(8) << std::setprecision(2) << colony << ")";
+                ss << std::endl;
+
+                DebugLogger() << "Harrow for empire = "<< empire_and_supply_fields.first <<" supply "
+                              << SupplySystemEmpireTupleString(supply_tuple);
+            }
+        }
+
+        m_label = new CUILabel(ss.str(), GG::FORMAT_LEFT | GG::FORMAT_NOWRAP);
+        m_label->MoveTo(GG::Pt(GG::X0, GG::Y0));
+        m_label->SetFont(ClientUI::GetBoldFont());
+        Resize(m_label->TextLowerRight());
+        AttachChild(m_label);
+
+        if (!at_least_one_visible)
+            m_is_empty = true;
+    }
+
+    void SystemSupplyBrowseWnd::Render() {
+        GG::Pt ul = UpperLeft();
+        GG::Pt lr = LowerRight();
+        // main background
+        GG::FlatRectangle(ul, lr, OpaqueColor(ClientUI::WndColor()), ClientUI::WndOuterBorderColor(), 1);
+
+    }
+}
+
+class SystemSupplySummaryPanel::Impl {
+    public:
+    Impl(SystemSupplySummaryPanel& wnd, const int system_id);
+
+    bool            IsEmpty() const;
+
+    void            Update();
+
+    private:
+    SystemSupplySummaryPanel&  m_wnd;
+
+    int m_system_id;
+
+    StatisticIcon* m_icon;
+    std::shared_ptr<SystemSupplyBrowseWnd> m_browse_window;
+};
+
+SystemSupplySummaryPanel::Impl::Impl(SystemSupplySummaryPanel& wnd, const int system_id) :
+    m_wnd(wnd),
+    m_system_id(system_id),
+    m_icon(),
+    m_browse_window()
+{
+    const auto height = EDGE_PAD + IconHeight() + ClientUI::Pts()*3/2;
+    const auto width = EDGE_PAD + IconWidth() + ClientUI::Pts()*3/2;
+    m_wnd.Resize(GG::Pt(width, height));
+    DebugLogger() << "size = " << m_wnd.Size();
+
+    std::shared_ptr<GG::Texture> texture = ClientUI::MeterIcon(METER_SUPPLY);
+
+    m_icon = new StatisticIcon(texture, GG::X0, GG::Y0, IconWidth(), IconHeight());
+    GG::Pt icon_ul = GG::Pt(GG::X(EDGE_PAD), GG::Y(EDGE_PAD));
+    GG::Pt icon_lr = icon_ul + GG::Pt(IconWidth(), IconHeight() + ClientUI::Pts()*3/2);
+    m_icon->SizeMove(icon_ul, icon_lr);
+    // TODO an a context menu that goes to Pedia Supply info
+    //m_icon->InstallEventFilter(this);
+    m_wnd.AttachChild(m_icon);
+
+    Update();
+}
+
+bool SystemSupplySummaryPanel::Impl::IsEmpty() const
+{ return !m_browse_window || m_browse_window->IsEmpty(); }
+
+void SystemSupplySummaryPanel::Impl::Update() {
+    m_browse_window = std::make_shared<SystemSupplyBrowseWnd>(m_system_id);
+    m_icon->SetBrowseInfoWnd(m_browse_window);
+}
+
+
+SystemSupplySummaryPanel::SystemSupplySummaryPanel(const int system_id) :
+    GG::Wnd(GG::X0, GG::Y0, GG::X1, GG::Y1, GG::INTERACTIVE),
+    pimpl(new Impl(*this, system_id))
+{}
+
+SystemSupplySummaryPanel::~SystemSupplySummaryPanel()
+{}
+
+void SystemSupplySummaryPanel::Render() {
+    GG::Pt ul = UpperLeft();
+    GG::Pt lr = LowerRight();
+
+    // outline of whole control
+    GG::FlatRectangle(ul, lr, ClientUI::WndColor(), ClientUI::WndOuterBorderColor(), 1);
+}
+
+void SystemSupplySummaryPanel::Update()
+{ return pimpl->Update(); }
+
+bool SystemSupplySummaryPanel::IsEmpty()
+{ return pimpl->IsEmpty(); }

--- a/UI/SystemSupplySummaryPanel.h
+++ b/UI/SystemSupplySummaryPanel.h
@@ -1,0 +1,28 @@
+#ifndef _SystemSupplySummaryPanel_h_
+#define _SystemSupplySummaryPanel_h_
+
+#include <GG/Wnd.h>
+
+#include "../universe/EnumsFwd.h"
+
+/** Display the supply icon a popup with the system supply details. */
+class SystemSupplySummaryPanel : public GG::Wnd {
+public:
+    /**Use \p system_id to display supply details.*/
+    SystemSupplySummaryPanel(const int system_id);
+    ~SystemSupplySummaryPanel();
+
+    void Render() override;
+
+    /** Update the data for the popup.*/
+    void            Update();
+
+    /**Return true if the system_id is mapped to a System.*/
+    bool            IsEmpty();
+
+private:
+    class Impl;
+    std::unique_ptr<Impl> pimpl;
+};
+
+#endif

--- a/Xcode/FreeOrion.xcodeproj/project.pbxproj
+++ b/Xcode/FreeOrion.xcodeproj/project.pbxproj
@@ -257,6 +257,7 @@
 		8275F4031AD31381003568FF /* ShipDesignPanel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8275F3F11AD31381003568FF /* ShipDesignPanel.cpp */; };
 		8275F4041AD31381003568FF /* SpecialsPanel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8275F3F31AD31381003568FF /* SpecialsPanel.cpp */; };
 		8275F4051AD31381003568FF /* SystemResourceSummaryBrowseWnd.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8275F3F51AD31381003568FF /* SystemResourceSummaryBrowseWnd.cpp */; };
+		8275F3FF1AD31381003569FF /* SystemSupplySummaryPanel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8275F3E91AD31381003569FF /* SystemSupplySummaryPanel.cpp */; };
 		8275F4061AD31381003568FF /* TextBrowseWnd.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8275F3F71AD31381003568FF /* TextBrowseWnd.cpp */; };
 		827902381737C6EA008AF126 /* ModeratorActionsWnd.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 827902361737C6EA008AF126 /* ModeratorActionsWnd.cpp */; };
 		8280AC5D19C0741B00ADDB65 /* libboost_iostreams.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8280AC5C19C0741B00ADDB65 /* libboost_iostreams.a */; };
@@ -997,6 +998,8 @@
 		8275F3F41AD31381003568FF /* SpecialsPanel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SpecialsPanel.h; sourceTree = "<group>"; };
 		8275F3F51AD31381003568FF /* SystemResourceSummaryBrowseWnd.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SystemResourceSummaryBrowseWnd.cpp; sourceTree = "<group>"; };
 		8275F3F61AD31381003568FF /* SystemResourceSummaryBrowseWnd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SystemResourceSummaryBrowseWnd.h; sourceTree = "<group>"; };
+		8275F3E91AD31381003569FF /* SystemSupplySummaryPanel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = SystemSupplySummaryPanel.cpp; sourceTree = "<group>"; };
+		8275F3EA1AD31381003569FF /* SystemSupplySummaryPanel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = SystemSupplySummaryPanel.h; sourceTree = "<group>"; };
 		8275F3F71AD31381003568FF /* TextBrowseWnd.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = TextBrowseWnd.cpp; sourceTree = "<group>"; };
 		8275F3F81AD31381003568FF /* TextBrowseWnd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TextBrowseWnd.h; sourceTree = "<group>"; };
 		827902361737C6EA008AF126 /* ModeratorActionsWnd.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ModeratorActionsWnd.cpp; sourceTree = "<group>"; };
@@ -1727,6 +1730,8 @@
 				471D5CDF0A98A3F900DA9C21 /* SystemIcon.h */,
 				8275F3F51AD31381003568FF /* SystemResourceSummaryBrowseWnd.cpp */,
 				8275F3F61AD31381003568FF /* SystemResourceSummaryBrowseWnd.h */,
+				8275F3E91AD31381003569FF /* SystemSupplySummaryPanel.cpp */,
+				8275F3EA1AD31381003569FF /* SystemSupplySummaryPanel.h */,
 				82970BED1A0CF53A008B37EF /* TechTreeArcs.cpp */,
 				82970BEE1A0CF53A008B37EF /* TechTreeArcs.h */,
 				2F22EC0412F7F4CF00456CDE /* TechTreeLayout.cpp */,
@@ -2708,6 +2713,7 @@
 				8275F3FC1AD31381003568FF /* IconTextBrowseWnd.cpp in Sources */,
 				470DF9A10A9CE53500A88AD6 /* HumanClientApp.cpp in Sources */,
 				8275F3FF1AD31381003568FF /* MultiIconValueIndicator.cpp in Sources */,
+				8275F3FF1AD31381003569FF /* SystemSupplySummaryPanel.cpp in Sources */,
 				CE71ED7B1DADAB130085A4DC /* DependencyVersions.cpp in Sources */,
 				471031390CEF618C00A7DF2B /* HumanClientFSM.cpp in Sources */,
 				8275F4021AD31381003568FF /* ResourcePanel.cpp in Sources */,

--- a/client/human/CMakeLists.txt
+++ b/client/human/CMakeLists.txt
@@ -27,6 +27,7 @@ set(freeorion_HEADER
     HumanClientApp.cpp
     HumanClientApp.h
     ../../network/ClientNetworking.h
+    ../../Empire/Supply.h
     ../../UI/About.h
     ../../UI/AccordionPanel.h
     ../../UI/BuildDesignatorWnd.h
@@ -83,6 +84,7 @@ set(freeorion_HEADER
     ../../UI/SpecialsPanel.h
     ../../UI/SystemIcon.h
     ../../UI/SystemResourceSummaryBrowseWnd.h
+    ../../UI/SystemSupplySummaryPanel.h
     ../../UI/TechTreeArcs.h
     ../../UI/TechTreeLayout.h
     ../../UI/TechTreeWnd.h
@@ -97,6 +99,7 @@ set(freeorion_SOURCES
     HumanClientFSM.cpp
     ../../combat/CombatSystem.cpp
     ../../network/ClientNetworking.cpp
+    ../../Empire/Supply.cpp
     ../../UI/About.cpp
     ../../UI/AccordionPanel.cpp
     ../../UI/BuildDesignatorWnd.cpp
@@ -152,6 +155,7 @@ set(freeorion_SOURCES
     ../../UI/SpecialsPanel.cpp
     ../../UI/SystemIcon.cpp
     ../../UI/SystemResourceSummaryBrowseWnd.cpp
+    ../../UI/SystemSupplySummaryPanel.cpp
     ../../UI/TechTreeArcs.cpp
     ../../UI/TechTreeLayout.cpp
     ../../UI/TechTreeWnd.cpp

--- a/msvc2015/FreeOrion/FreeOrion.vcxproj
+++ b/msvc2015/FreeOrion/FreeOrion.vcxproj
@@ -207,6 +207,7 @@
     <ClInclude Include="..\..\UI\SpecialsPanel.h" />
     <ClInclude Include="..\..\UI\SystemIcon.h" />
     <ClInclude Include="..\..\UI\SystemResourceSummaryBrowseWnd.h" />
+    <ClInclude Include="..\..\UI\SystemSupplySummaryPanel.h" />
     <ClInclude Include="..\..\UI\TechTreeArcs.h" />
     <ClInclude Include="..\..\UI\TechTreeLayout.h" />
     <ClInclude Include="..\..\UI\TechTreeWnd.h" />
@@ -318,6 +319,7 @@
     <ClCompile Include="..\..\UI\SpecialsPanel.cpp" />
     <ClCompile Include="..\..\UI\SystemIcon.cpp" />
     <ClCompile Include="..\..\UI\SystemResourceSummaryBrowseWnd.cpp" />
+    <ClCompile Include="..\..\UI\SystemSupplySummaryPanel.cpp" />
     <ClCompile Include="..\..\UI\TechTreeArcs.cpp" />
     <ClCompile Include="..\..\UI\TechTreeLayout.cpp" />
     <ClCompile Include="..\..\UI\TechTreeWnd.cpp" />

--- a/msvc2015/FreeOrion/FreeOrion.vcxproj.filters
+++ b/msvc2015/FreeOrion/FreeOrion.vcxproj.filters
@@ -225,6 +225,9 @@
     <ClInclude Include="..\..\UI\SystemResourceSummaryBrowseWnd.h">
       <Filter>Header Files\UI</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\UI\SystemSupplySummaryPanel.h">
+      <Filter>Header Files\UI</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\UI\TechTreeWnd.h">
       <Filter>Header Files\UI</Filter>
     </ClInclude>
@@ -542,6 +545,9 @@
       <Filter>Source Files\UI</Filter>
     </ClCompile>
     <ClCompile Include="..\..\UI\SystemResourceSummaryBrowseWnd.cpp">
+      <Filter>Source Files\UI</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\UI\SystemSupplySummaryPanel.cpp">
       <Filter>Source Files\UI</Filter>
     </ClCompile>
     <ClCompile Include="..\..\UI\PlayerListWnd.cpp">

--- a/python/AI/AIFramework.cpp
+++ b/python/AI/AIFramework.cpp
@@ -14,10 +14,10 @@
 #include "../SetWrapper.h"
 #include "../CommonWrappers.h"
 #include "AIWrapper.h"
+#include "../map_indexing_suite_safe.hpp"
 
 #include <boost/python.hpp>
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
-#include <boost/python/suite/indexing/map_indexing_suite.hpp>
 #include <boost/python/docstring_options.hpp>
 #include <boost/mpl/vector.hpp>
 #include <boost/timer.hpp>

--- a/python/AI/AIFramework.cpp
+++ b/python/AI/AIFramework.cpp
@@ -87,8 +87,8 @@ BOOST_PYTHON_MODULE(freeOrionAIInterface)
         .def(map_indexing_suite<std::map<int, bool> >())
     ;
 
-    FreeOrionPython::SetWrapper<int>::Wrap("IntSet");
-    FreeOrionPython::SetWrapper<std::string>::Wrap("StringSet");
+    FreeOrionPython::SetWrapper<std::set<int>>::Wrap("IntSet");
+    FreeOrionPython::SetWrapper<std::set<std::string>>::Wrap("StringSet");
 }
  
 //////////////////////

--- a/python/AI/AIWrapper.cpp
+++ b/python/AI/AIWrapper.cpp
@@ -12,10 +12,10 @@
 #include "../../Empire/Diplomacy.h"
 #include "../SetWrapper.h"
 #include "../CommonWrappers.h"
+#include "../map_indexing_suite_safe.hpp"
 
 #include <boost/python.hpp>
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
-#include <boost/python/suite/indexing/map_indexing_suite.hpp>
 #include <boost/mpl/vector.hpp>
 #include <boost/timer.hpp>
 #include <boost/python/list.hpp>

--- a/python/EmpireWrapper.cpp
+++ b/python/EmpireWrapper.cpp
@@ -270,7 +270,7 @@ namespace FreeOrionPython {
 
         class_<ResourcePool, std::shared_ptr<ResourcePool>, boost::noncopyable>("resPool", boost::python::no_init);
         //FreeOrionPython::SetWrapper<int>::Wrap("IntSet");
-        FreeOrionPython::SetWrapper<IntSet>::Wrap("IntSetSet");
+        FreeOrionPython::SetWrapper<std::set<std::set<int>>>::Wrap("IntSetSet");
         class_<std::map<std::set<int>, float> > ("resPoolMap")
             .def(boost::python::map_indexing_suite<std::map<std::set<int>, float>, true>())
         ;

--- a/python/EmpireWrapper.cpp
+++ b/python/EmpireWrapper.cpp
@@ -270,6 +270,7 @@ namespace FreeOrionPython {
 
         class_<ResourcePool, std::shared_ptr<ResourcePool>, boost::noncopyable>("resPool", boost::python::no_init);
         //FreeOrionPython::SetWrapper<int>::Wrap("IntSet");
+        FreeOrionPython::SetWrapper<std::unordered_set<int>>::Wrap("IntUSet");
         FreeOrionPython::SetWrapper<std::set<std::set<int>>>::Wrap("IntSetSet");
         class_<std::map<std::set<int>, float> > ("resPoolMap")
             .def(boost::python::map_indexing_suite<std::map<std::set<int>, float>, true>())

--- a/python/EmpireWrapper.cpp
+++ b/python/EmpireWrapper.cpp
@@ -169,9 +169,9 @@ namespace {
         const std::shared_ptr<ResourcePool>& industry_pool = empire.GetResourcePool(RE_INDUSTRY);
         const ProductionQueue& prodQueue = empire.GetProductionQueue();
         std::map<std::set<int>, float> planetsWithAvailablePP;
-        for (const std::map<std::set<int>, float>::value_type& objects_pp : prodQueue.AvailablePP(industry_pool)) {
+        for (const auto& objects_pp : prodQueue.AvailablePP(industry_pool)) {
             std::set<int> planetSet;
-            for (int object_id : objects_pp.first) {
+            for (int object_id : *objects_pp.first) {
                 if (/* std::shared_ptr<const Planet> planet = */ GetPlanet(object_id))
                     planetSet.insert(object_id);
             }
@@ -185,10 +185,10 @@ namespace {
     std::map<std::set<int>, float> PlanetsWithAllocatedPP_P(const Empire& empire) {
         const ProductionQueue& prodQueue = empire.GetProductionQueue();
         std::map<std::set<int>, float> planetsWithAllocatedPP;
-        std::map<std::set<int>, float> objectsWithAllocatedPP = prodQueue.AllocatedPP();
-        for (const std::map<std::set<int>, float>::value_type& objects_pp : objectsWithAllocatedPP) {
+        const auto& objectsWithAllocatedPP = prodQueue.AllocatedPP();
+        for (const auto& objects_pp : objectsWithAllocatedPP) {
             std::set<int> planetSet;
-            for (int object_id : objects_pp.first) {
+            for (int object_id : *objects_pp.first) {
                 if (/* std::shared_ptr<const Planet> planet = */ GetPlanet(object_id))
                     planetSet.insert(object_id);
             }
@@ -203,10 +203,10 @@ namespace {
         const std::shared_ptr<ResourcePool>& industry_pool = empire.GetResourcePool(RE_INDUSTRY);
         const ProductionQueue& prodQueue = empire.GetProductionQueue();
         std::set<std::set<int> > planetsWithWastedPP;
-        std::set<std::set<int> > objectsWithWastedPP = prodQueue.ObjectsWithWastedPP(industry_pool);
-        for (const std::set<int>&  objects : objectsWithWastedPP) {
+        const auto& objectsWithWastedPP = prodQueue.ObjectsWithWastedPP(industry_pool);
+        for (const auto&  objects : objectsWithWastedPP) {
                  std::set<int> planetSet;
-                 for (int object_id : objects) {
+                 for (int object_id : *objects) {
                      if (/* std::shared_ptr<const Planet> planet = */ GetPlanet(object_id))
                          planetSet.insert(object_id);
                  }

--- a/python/EmpireWrapper.cpp
+++ b/python/EmpireWrapper.cpp
@@ -145,12 +145,10 @@ namespace {
 
     boost::function<std::map<int,int>(const Empire&)> jumpsToSuppliedSystemFunc =               &jumpsToSuppliedSystemP;
 
-    std::vector<int> EmpireFleetSupplyableSystemIDsP(const Empire& empire) {
-        const auto& x = GetSupplyManager().FleetSupplyableSystemIDs(empire.EmpireID());
-        std::vector<int> retval(x.begin(), x.end());
-        return retval;
-    }
-    boost::function<std::vector<int> (const Empire&)> empireFleetSupplyableSystemIDsFunc =  &EmpireFleetSupplyableSystemIDsP;
+    const std::unordered_set<int>& EmpireFleetSupplyableSystemIDsP(const Empire& empire)
+    { return GetSupplyManager().FleetSupplyableSystemIDs(empire.EmpireID()); }
+    boost::function<const std::unordered_set<int>& (const Empire&)> empireFleetSupplyableSystemIDsFunc =  &EmpireFleetSupplyableSystemIDsP;
+
 
     std::map<int, float> EmpireSystemSupplyRangesP(const Empire& empire) {
         std::map<int, float> retval(empire.SystemSupplyRanges().begin(), empire.SystemSupplyRanges().end());
@@ -342,8 +340,8 @@ namespace FreeOrionPython {
 
             .add_property("fleetSupplyableSystemIDs",   make_function(
                                                             empireFleetSupplyableSystemIDsFunc,
-                                                            return_value_policy<return_by_value>(),
-                                                            boost::mpl::vector<std::vector<int>, const Empire& >()
+                                                            return_value_policy<copy_const_reference>(),
+                                                            boost::mpl::vector<const std::unordered_set<int>&, const Empire& >()
                                                         ))
             .add_property("supplyUnobstructedSystems",  make_function(&Empire::SupplyUnobstructedSystems,   return_internal_reference<>()))
             .add_property("systemSupplyRanges",         make_function(

--- a/python/EmpireWrapper.cpp
+++ b/python/EmpireWrapper.cpp
@@ -145,9 +145,9 @@ namespace {
 
     boost::function<std::map<int,int>(const Empire&)> jumpsToSuppliedSystemFunc =               &jumpsToSuppliedSystemP;
 
-    const std::set<int>& EmpireFleetSupplyableSystemIDsP(const Empire& empire)
+    const std::unordered_set<int>& EmpireFleetSupplyableSystemIDsP(const Empire& empire)
     { return GetSupplyManager().FleetSupplyableSystemIDs(empire.EmpireID()); }
-    boost::function<const std::set<int>& (const Empire&)> empireFleetSupplyableSystemIDsFunc =  &EmpireFleetSupplyableSystemIDsP;
+    boost::function<const std::unordered_set<int>& (const Empire&)> empireFleetSupplyableSystemIDsFunc =  &EmpireFleetSupplyableSystemIDsP;
 
     typedef std::pair<float, int> FloatIntPair;
 
@@ -333,7 +333,7 @@ namespace FreeOrionPython {
             .add_property("fleetSupplyableSystemIDs",   make_function(
                                                             empireFleetSupplyableSystemIDsFunc,
                                                             return_value_policy<copy_const_reference>(),
-                                                            boost::mpl::vector<const std::set<int>&, const Empire& >()
+                                                            boost::mpl::vector<const std::unordered_set<int>&, const Empire& >()
                                                         ))
             .add_property("supplyUnobstructedSystems",  make_function(&Empire::SupplyUnobstructedSystems,   return_internal_reference<>()))
             .add_property("systemSupplyRanges",         make_function(&Empire::SystemSupplyRanges,          return_internal_reference<>()))

--- a/python/EmpireWrapper.cpp
+++ b/python/EmpireWrapper.cpp
@@ -271,8 +271,9 @@ namespace FreeOrionPython {
         FreeOrionPython::SetWrapper<std::unordered_set<int>>::Wrap("IntUSet");
         FreeOrionPython::SetWrapper<std::set<std::set<int>>>::Wrap("IntSetSet");
         class_<std::map<std::set<int>, float> > ("resPoolMap")
-            .def(boost::python::map_indexing_suite<std::map<std::set<int>, float>, true>())
-        ;
+            .def(boost::python::map_indexing_suite<std::map<std::set<int>, float>, true>());
+        class_<std::unordered_map<int, float>> ("Float_IntUMap")
+            .def(boost::python::map_indexing_suite<std::unordered_map<int, float>, true>());
 
         ///////////////////
         //     Empire    //

--- a/python/EmpireWrapper.cpp
+++ b/python/EmpireWrapper.cpp
@@ -87,11 +87,12 @@ namespace {
     typedef std::map<std::pair<int, int>,int > PairIntInt_IntMap;
 
     std::vector<IntPair> obstructedStarlanesP(const Empire& empire) {
-        const std::set<IntPair>& laneset = GetSupplyManager().SupplyObstructedStarlaneTraversals(empire.EmpireID());
+        const auto& laneset = GetSupplyManager().SupplyObstructedStarlaneTraversals(empire.EmpireID());
         std::vector<IntPair> retval;
+        // TODO remove this try catch.  It was introduced in a large AI commit a7dfe4c5b8.
         try {
-            for (const std::pair<int, int>& lane : laneset)
-            { retval.push_back(lane); }
+            for (const auto& lane : laneset)
+            { retval.push_back(lane.first); }
         } catch (...) {
         }
         return retval;

--- a/python/EmpireWrapper.cpp
+++ b/python/EmpireWrapper.cpp
@@ -11,13 +11,13 @@
 #include "../util/AppInterface.h"
 #include "../util/Logger.h"
 #include "SetWrapper.h"
+#include "map_indexing_suite_safe.hpp"
 
 #include <GG/Clr.h>
 
 #include <boost/function.hpp>
 #include <boost/mpl/vector.hpp>
 #include <boost/python.hpp>
-#include <boost/python/suite/indexing/map_indexing_suite.hpp>
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 #include <boost/python/tuple.hpp>
 #include <boost/python/to_python_converter.hpp>

--- a/python/EmpireWrapper.cpp
+++ b/python/EmpireWrapper.cpp
@@ -150,11 +150,6 @@ namespace {
     boost::function<const std::unordered_set<int>& (const Empire&)> empireFleetSupplyableSystemIDsFunc =  &EmpireFleetSupplyableSystemIDsP;
 
 
-    std::map<int, float> EmpireSystemSupplyRangesP(const Empire& empire) {
-        std::map<int, float> retval(empire.SystemSupplyRanges().begin(), empire.SystemSupplyRanges().end());
-        return retval;
-    }
-    boost::function<std::map<int, float> (const Empire&)> empireSystemSuppleRangesFunc =  &EmpireSystemSupplyRangesP;
 
     typedef std::pair<float, int> FloatIntPair;
 
@@ -345,11 +340,7 @@ namespace FreeOrionPython {
                                                             boost::mpl::vector<const std::unordered_set<int>&, const Empire& >()
                                                         ))
             .add_property("supplyUnobstructedSystems",  make_function(&Empire::SupplyUnobstructedSystems,   return_internal_reference<>()))
-            .add_property("systemSupplyRanges",         make_function(
-                                                        empireSystemSuppleRangesFunc,
-                                                        return_value_policy<return_by_value>(),
-                                                        boost::mpl::vector<std::map<int, float>, const Empire&>()
-                                                        ))
+            .add_property("systemSupplyRanges",         make_function(&Empire::SystemSupplyRanges,          return_internal_reference<>()))
 
             .def("numSitReps",                      &Empire::NumSitRepEntries)
             .def("getSitRep",                       make_function(

--- a/python/EmpireWrapper.cpp
+++ b/python/EmpireWrapper.cpp
@@ -152,6 +152,12 @@ namespace {
     }
     boost::function<std::vector<int> (const Empire&)> empireFleetSupplyableSystemIDsFunc =  &EmpireFleetSupplyableSystemIDsP;
 
+    std::map<int, float> EmpireSystemSupplyRangesP(const Empire& empire) {
+        std::map<int, float> retval(empire.SystemSupplyRanges().begin(), empire.SystemSupplyRanges().end());
+        return retval;
+    }
+    boost::function<std::map<int, float> (const Empire&)> empireSystemSuppleRangesFunc =  &EmpireSystemSupplyRangesP;
+
     typedef std::pair<float, int> FloatIntPair;
 
     typedef PairToTupleConverter<float, int> FloatIntPairConverter;
@@ -339,7 +345,11 @@ namespace FreeOrionPython {
                                                             boost::mpl::vector<std::vector<int>, const Empire& >()
                                                         ))
             .add_property("supplyUnobstructedSystems",  make_function(&Empire::SupplyUnobstructedSystems,   return_internal_reference<>()))
-            .add_property("systemSupplyRanges",         make_function(&Empire::SystemSupplyRanges,          return_internal_reference<>()))
+            .add_property("systemSupplyRanges",         make_function(
+                                                        empireSystemSuppleRangesFunc,
+                                                        return_value_policy<return_by_value>(),
+                                                        boost::mpl::vector<std::map<int, float>, const Empire&>()
+                                                        ))
 
             .def("numSitReps",                      &Empire::NumSitRepEntries)
             .def("getSitRep",                       make_function(

--- a/python/EmpireWrapper.cpp
+++ b/python/EmpireWrapper.cpp
@@ -145,9 +145,12 @@ namespace {
 
     boost::function<std::map<int,int>(const Empire&)> jumpsToSuppliedSystemFunc =               &jumpsToSuppliedSystemP;
 
-    const std::unordered_set<int>& EmpireFleetSupplyableSystemIDsP(const Empire& empire)
-    { return GetSupplyManager().FleetSupplyableSystemIDs(empire.EmpireID()); }
-    boost::function<const std::unordered_set<int>& (const Empire&)> empireFleetSupplyableSystemIDsFunc =  &EmpireFleetSupplyableSystemIDsP;
+    std::vector<int> EmpireFleetSupplyableSystemIDsP(const Empire& empire) {
+        const auto& x = GetSupplyManager().FleetSupplyableSystemIDs(empire.EmpireID());
+        std::vector<int> retval(x.begin(), x.end());
+        return retval;
+    }
+    boost::function<std::vector<int> (const Empire&)> empireFleetSupplyableSystemIDsFunc =  &EmpireFleetSupplyableSystemIDsP;
 
     typedef std::pair<float, int> FloatIntPair;
 
@@ -332,8 +335,8 @@ namespace FreeOrionPython {
 
             .add_property("fleetSupplyableSystemIDs",   make_function(
                                                             empireFleetSupplyableSystemIDsFunc,
-                                                            return_value_policy<copy_const_reference>(),
-                                                            boost::mpl::vector<const std::unordered_set<int>&, const Empire& >()
+                                                            return_value_policy<return_by_value>(),
+                                                            boost::mpl::vector<std::vector<int>, const Empire& >()
                                                         ))
             .add_property("supplyUnobstructedSystems",  make_function(&Empire::SupplyUnobstructedSystems,   return_internal_reference<>()))
             .add_property("systemSupplyRanges",         make_function(&Empire::SystemSupplyRanges,          return_internal_reference<>()))

--- a/python/SetWrapper.h
+++ b/python/SetWrapper.h
@@ -1,7 +1,6 @@
 #ifndef PYTHON_SETWRAPPER_H
 #define PYTHON_SETWRAPPER_H
 
-#include <set>
 #include <string>
 
 #include <boost/python.hpp>
@@ -13,14 +12,14 @@ namespace FreeOrionPython {
     using boost::python::def;
     using boost::python::iterator;
 
-    /* SetWrapper class encapsulates functions that expose the STL std::set<>
-     * class to Python in a limited, read-only fashion.  The set can be iterated
+    /* SetWrapper class encapsulates functions that expose the STL std::set<> like
+     * classes to Python in a limited, read-only fashion.  The set can be iterated
      * through in Python, and printed. */
-    template <typename ElementType>
+    template <typename Set>
     class SetWrapper {
     public:
-        typedef typename std::set<ElementType> Set;
-        typedef typename Set::const_iterator SetIterator;
+        using SetIterator = typename Set::const_iterator;
+        using ElementType = typename Set::value_type;
 
         static unsigned int size(const Set& self) {
             return static_cast<unsigned int>(self.size());  // ignore warning http://lists.boost.org/Archives/boost/2007/04/120377.php

--- a/python/UniverseWrapper.cpp
+++ b/python/UniverseWrapper.cpp
@@ -15,10 +15,10 @@
 #include "../universe/Enums.h"
 #include "../util/Logger.h"
 #include "../util/MultiplayerCommon.h"
+#include "map_indexing_suite_safe.hpp"
 
 #include <boost/mpl/vector.hpp>
 #include <boost/python.hpp>
-#include <boost/python/suite/indexing/map_indexing_suite.hpp>
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 
 

--- a/python/map_indexing_suite_safe.hpp
+++ b/python/map_indexing_suite_safe.hpp
@@ -1,0 +1,191 @@
+//  (C) Copyright Joel de Guzman 2003.
+//  Distributed under the Boost Software License, Version 1.0. (See
+//  accompanying file LICENSE_1_0.txt or copy at
+//  http://www.boost.org/LICENSE_1_0.txt)
+
+// TODO This file is a copy of the boost python file map_indexing_suite.hpp
+// except that the class registration of the value_type has been guarded
+// so that registrations of the same key and data do not result in a runtime warning.
+// It "assumes" that the already registered value_type is ok.
+
+#ifndef MAP_INDEXING_SUITE_JDG20038_HPP_SAFE
+# define MAP_INDEXING_SUITE_JDG20038_HPP_SAFE
+
+# include <boost/python/suite/indexing/indexing_suite.hpp>
+# include <boost/python/iterator.hpp>
+# include <boost/python/call_method.hpp>
+# include <boost/python/tuple.hpp>
+
+namespace boost { namespace python {
+
+    // Forward declaration
+    template <class Container, bool NoProxy, class DerivedPolicies>
+    class map_indexing_suite;
+
+    namespace detail
+    {
+        template <class Container, bool NoProxy>
+        class final_map_derived_policies
+            : public map_indexing_suite<Container,
+                NoProxy, final_map_derived_policies<Container, NoProxy> > {};
+    }
+
+    // The map_indexing_suite class is a predefined indexing_suite derived
+    // class for wrapping std::map (and std::map like) classes. It provides
+    // all the policies required by the indexing_suite (see indexing_suite).
+    // Example usage:
+    //
+    //  class X {...};
+    //
+    //  ...
+    //
+    //      class_<std::map<std::string, X> >("XMap")
+    //          .def(map_indexing_suite<std::map<std::string, X> >())
+    //      ;
+    //
+    // By default indexed elements are returned by proxy. This can be
+    // disabled by supplying *true* in the NoProxy template parameter.
+    //
+    template <
+        class Container,
+        bool NoProxy = false,
+        class DerivedPolicies
+            = detail::final_map_derived_policies<Container, NoProxy> >
+    class map_indexing_suite
+        : public indexing_suite<
+            Container
+          , DerivedPolicies
+          , NoProxy
+          , true
+          , typename Container::value_type::second_type
+          , typename Container::key_type
+          , typename Container::key_type
+        >
+    {
+    public:
+
+        typedef typename Container::value_type value_type;
+        typedef typename Container::value_type::second_type data_type;
+        typedef typename Container::key_type key_type;
+        typedef typename Container::key_type index_type;
+        typedef typename Container::size_type size_type;
+        typedef typename Container::difference_type difference_type;
+
+        template <class Class>
+        static void
+        extension_def(Class& cl)
+        {
+            //  Wrap the map's element (value_type)
+            std::string elem_name = "map_indexing_suite_";
+            object class_name(cl.attr("__name__"));
+            extract<std::string> class_name_extractor(class_name);
+            elem_name += class_name_extractor();
+            elem_name += "_entry";
+
+            typedef typename mpl::if_<
+                mpl::and_<is_class<data_type>, mpl::bool_<!NoProxy> >
+              , return_internal_reference<>
+              , default_call_policies
+            >::type get_data_return_policy;
+
+            /* The code below this line added by freeorion. */
+            boost::python::type_info info = boost::python::type_id<value_type>();
+            const boost::python::converter::registration* reg = boost::python::converter::registry::query(info);
+            if ((reg == NULL) || ((*reg).m_to_python == NULL))
+            /* The code above this line added by freeorion. */
+                class_<value_type>(elem_name.c_str())
+                    .def("__repr__", &DerivedPolicies::print_elem)
+                    .def("data", &DerivedPolicies::get_data, get_data_return_policy())
+                    .def("key", &DerivedPolicies::get_key)
+                    ;
+        }
+
+        static object
+        print_elem(typename Container::value_type const& e)
+        {
+            return "(%s, %s)" % python::make_tuple(e.first, e.second);
+        }
+
+        static
+        typename mpl::if_<
+            mpl::and_<is_class<data_type>, mpl::bool_<!NoProxy> >
+          , data_type&
+          , data_type
+        >::type
+        get_data(typename Container::value_type& e)
+        {
+            return e.second;
+        }
+
+        static typename Container::key_type
+        get_key(typename Container::value_type& e)
+        {
+            return e.first;
+        }
+
+        static data_type&
+        get_item(Container& container, index_type i_)
+        {
+            typename Container::iterator i = container.find(i_);
+            if (i == container.end())
+            {
+                PyErr_SetString(PyExc_KeyError, "Invalid key");
+                throw_error_already_set();
+            }
+            return i->second;
+        }
+
+        static void
+        set_item(Container& container, index_type i, data_type const& v)
+        {
+            container[i] = v;
+        }
+
+        static void
+        delete_item(Container& container, index_type i)
+        {
+            container.erase(i);
+        }
+
+        static size_t
+        size(Container& container)
+        {
+            return container.size();
+        }
+
+        static bool
+        contains(Container& container, key_type const& key)
+        {
+            return container.find(key) != container.end();
+        }
+
+        static bool
+        compare_index(Container& container, index_type a, index_type b)
+        {
+            return container.key_comp()(a, b);
+        }
+
+        static index_type
+        convert_index(Container& /*container*/, PyObject* i_)
+        {
+            extract<key_type const&> i(i_);
+            if (i.check())
+            {
+                return i();
+            }
+            else
+            {
+                extract<key_type> i(i_);
+                if (i.check())
+                    return i();
+            }
+
+            PyErr_SetString(PyExc_TypeError, "Invalid index type");
+            throw_error_already_set();
+            return index_type();
+        }
+    };
+
+}} // namespace boost::python
+
+#endif // MAP_INDEXING_SUITE_JDG20038_HPP_SAFE

--- a/python/server/ServerFramework.cpp
+++ b/python/server/ServerFramework.cpp
@@ -48,8 +48,8 @@ BOOST_PYTHON_MODULE(freeorion) {
         .def(map_indexing_suite<std::map<int, bool> >())
     ;
 
-    FreeOrionPython::SetWrapper<int>::Wrap("IntSet");
-    FreeOrionPython::SetWrapper<std::string>::Wrap("StringSet");
+    FreeOrionPython::SetWrapper<std::set<int>>::Wrap("IntSet");
+    FreeOrionPython::SetWrapper<std::set<std::string>>::Wrap("StringSet");
 }
 
 namespace {

--- a/python/server/ServerFramework.cpp
+++ b/python/server/ServerFramework.cpp
@@ -7,11 +7,11 @@
 #include "../../util/Logger.h"
 #include "../../universe/Universe.h"
 #include "../../universe/UniverseGenerator.h"
+#include "../map_indexing_suite_safe.hpp"
 
 #include <boost/filesystem.hpp>
 #include <boost/python.hpp>
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
-#include <boost/python/suite/indexing/map_indexing_suite.hpp>
 #include <boost/python/docstring_options.hpp>
 
 

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -735,7 +735,6 @@ void ServerApp::NewGameInit(const GalaxySetupData& galaxy_setup_data,
 
         empire->UpdateSupplyUnobstructedSystems();  // determines which systems can propagate fleet and resource (same for both)
         empire->UpdateSystemSupplyRanges();         // sets range systems can propagate fleet and resourse supply (separately)
-        empire->UpdateSystemToStealthAndSupplyRange();         // sets range systems can propagate fleet and resourse supply (separately)
     }
 
     GetSupplyManager().Update();
@@ -1146,7 +1145,6 @@ void ServerApp::LoadGameInit(const std::vector<PlayerSaveGameData>& player_save_
             continue;   // skip eliminated empires.  presumably this shouldn't be an issue when initializing a new game, but apparently I thought this was worth checking for...
         empire->UpdateSupplyUnobstructedSystems();  // determines which systems can propagate fleet and resource (same for both)
         empire->UpdateSystemSupplyRanges();         // sets range systems can propagate fleet and resourse supply (separately)
-        empire->UpdateSystemToStealthAndSupplyRange();         // sets range systems can propagate fleet and resourse supply (separately)
     }
 
     GetSupplyManager().Update();
@@ -2898,7 +2896,6 @@ void ServerApp::PostCombatProcessTurns() {
         empire->UpdateSupplyUnobstructedSystems();  // determines which systems can propagate fleet and resource (same for both)
         empire->UpdateSupplyBlockadedSystems();
         empire->UpdateSystemSupplyRanges();         // sets range systems can propagate fleet and resourse supply (separately)
-        empire->UpdateSystemToStealthAndSupplyRange();         // sets range systems can propagate fleet and resourse supply (separately)
     }
 
     GetSupplyManager().Update();

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -735,6 +735,7 @@ void ServerApp::NewGameInit(const GalaxySetupData& galaxy_setup_data,
 
         empire->UpdateSupplyUnobstructedSystems();  // determines which systems can propagate fleet and resource (same for both)
         empire->UpdateSystemSupplyRanges();         // sets range systems can propagate fleet and resourse supply (separately)
+        empire->UpdateSystemToStealthAndSupplyRange();         // sets range systems can propagate fleet and resourse supply (separately)
     }
 
     GetSupplyManager().Update();
@@ -1145,6 +1146,7 @@ void ServerApp::LoadGameInit(const std::vector<PlayerSaveGameData>& player_save_
             continue;   // skip eliminated empires.  presumably this shouldn't be an issue when initializing a new game, but apparently I thought this was worth checking for...
         empire->UpdateSupplyUnobstructedSystems();  // determines which systems can propagate fleet and resource (same for both)
         empire->UpdateSystemSupplyRanges();         // sets range systems can propagate fleet and resourse supply (separately)
+        empire->UpdateSystemToStealthAndSupplyRange();         // sets range systems can propagate fleet and resourse supply (separately)
     }
 
     GetSupplyManager().Update();
@@ -2895,6 +2897,7 @@ void ServerApp::PostCombatProcessTurns() {
 
         empire->UpdateSupplyUnobstructedSystems();  // determines which systems can propagate fleet and resource (same for both)
         empire->UpdateSystemSupplyRanges();         // sets range systems can propagate fleet and resourse supply (separately)
+        empire->UpdateSystemToStealthAndSupplyRange();         // sets range systems can propagate fleet and resourse supply (separately)
     }
 
     GetSupplyManager().Update();

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -2896,6 +2896,7 @@ void ServerApp::PostCombatProcessTurns() {
             continue;   // skip eliminated empires
 
         empire->UpdateSupplyUnobstructedSystems();  // determines which systems can propagate fleet and resource (same for both)
+        empire->UpdateSupplyBlockadedSystems();
         empire->UpdateSystemSupplyRanges();         // sets range systems can propagate fleet and resourse supply (separately)
         empire->UpdateSystemToStealthAndSupplyRange();         // sets range systems can propagate fleet and resourse supply (separately)
     }

--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -7442,13 +7442,13 @@ namespace {
                 return false;
             if (m_from_objects.empty())
                 return false;
-            const std::set<std::set<int> >& groups = GetSupplyManager().ResourceSupplyGroups(m_empire_id);
+            const auto& groups = GetSupplyManager().ResourceSupplyGroups(m_empire_id);
             if (groups.empty())
                 return false;
 
             // is candidate object connected to a subcondition matching object by resource supply?
             for (std::shared_ptr<const UniverseObject> from_object : m_from_objects) {
-                for (const std::set<int>& group : groups) {
+                for (const auto& group : groups) {
                     if (group.find(from_object->SystemID()) != group.end()) {
                         // found resource sharing group containing test object.  Does it also contain candidate?
                         if (group.find(candidate->SystemID()) != group.end())

--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -7333,8 +7333,8 @@ namespace {
                 return false;
 
             const SupplyManager& supply = GetSupplyManager();
-            const std::map<int, std::set<int> >& empire_supplyable_systems = supply.FleetSupplyableSystemIDs();
-            std::map<int, std::set<int> >::const_iterator it = empire_supplyable_systems.find(m_empire_id);
+            const auto& empire_supplyable_systems = supply.FleetSupplyableSystemIDs();
+            const auto& it = empire_supplyable_systems.find(m_empire_id);
             if (it == empire_supplyable_systems.end())
                 return false;
             return it->second.find(candidate->SystemID()) != it->second.end();

--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -7449,9 +7449,9 @@ namespace {
             // is candidate object connected to a subcondition matching object by resource supply?
             for (std::shared_ptr<const UniverseObject> from_object : m_from_objects) {
                 for (const auto& group : groups) {
-                    if (group.find(from_object->SystemID()) != group.end()) {
+                    if (group->find(from_object->SystemID()) != group->end()) {
                         // found resource sharing group containing test object.  Does it also contain candidate?
-                        if (group.find(candidate->SystemID()) != group.end())
+                        if (group->find(candidate->SystemID()) != group->end())
                             return true;    // test object and candidate object are in same resourse sharing group
                         else
                             // test object is not in resource sharing group with candidate

--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -812,10 +812,7 @@ void Fleet::MovementPhase() {
     }
 
     Empire* empire = GetEmpire(fleet->Owner());
-    std::set<int> supply_unobstructed_systems;
-    if (empire)
-        supply_unobstructed_systems.insert(empire->SupplyUnobstructedSystems().begin(),
-                                           empire->SupplyUnobstructedSystems().end());
+    const std::set<int>& supply_unobstructed_systems = empire ? empire->SupplyUnobstructedSystems() : EMPTY_SET;
 
     std::vector<std::shared_ptr<Ship>> ships = Objects().FindObjects<Ship>(m_ships);
 
@@ -1179,7 +1176,7 @@ bool Fleet::BlockadedAtSystem(int start_system_id, int dest_system_id) const {
 
     const Empire* empire = GetEmpire(this->Owner());
     if (empire) {
-        std::set<int> unobstructed_systems = empire->SupplyUnobstructedSystems();
+        const std::set<int>& unobstructed_systems = empire->SupplyUnobstructedSystems();
         if (unobstructed_systems.find(start_system_id) != unobstructed_systems.end())
             return false;
         if (empire->UnrestrictedLaneTravel(start_system_id, dest_system_id)) {

--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -245,7 +245,7 @@ std::list<MovePathNode> Fleet::MovePath(const std::list<int>& route, bool flag_b
 
     // determine all systems where fleet(s) can be resupplied if fuel runs out
     const Empire* empire = GetEmpire(this->Owner());
-    const std::set<int> fleet_supplied_systems = GetSupplyManager().FleetSupplyableSystemIDs(this->Owner(), ALLOW_ALLIED_SUPPLY);
+    const auto& fleet_supplied_systems = GetSupplyManager().FleetSupplyableSystemIDs(this->Owner(), ALLOW_ALLIED_SUPPLY);
     const std::set<int>& unobstructed_systems = empire ? empire->SupplyUnobstructedSystems() : EMPTY_SET;
 
     // determine if, given fuel available and supplyable systems, fleet will ever be able to move

--- a/universe/ValueRef.cpp
+++ b/universe/ValueRef.cpp
@@ -705,15 +705,15 @@ double Variable<double>::Eval(const ScriptingContext& context) const
             return ship->TotalWeaponsDamage();
 
     } else if (property_name == "PropagatedSupplyRange") {
-        const std::map<int, float>& ranges = GetSupplyManager().PropagatedSupplyRanges();
-        std::map<int, float>::const_iterator range_it = ranges.find(object->SystemID());
+        const auto& ranges = GetSupplyManager().PropagatedSupplyRanges();
+        const auto& range_it = ranges.find(object->SystemID());
         if (range_it == ranges.end())
             return 0.0;
         return range_it->second;
 
     } else if (property_name == "PropagatedSupplyDistance") {
-        const std::map<int, float>& ranges = GetSupplyManager().PropagatedSupplyDistances();
-        std::map<int, float>::const_iterator range_it = ranges.find(object->SystemID());
+        const auto& ranges = GetSupplyManager().PropagatedSupplyDistances();
+        const auto& range_it = ranges.find(object->SystemID());
         if (range_it == ranges.end())
             return 0.0;
         return range_it->second;
@@ -1219,6 +1219,7 @@ namespace {
     static std::map<std::string, int> EMPTY_STRING_INT_MAP;
     static std::map<int, int> EMPTY_INT_INT_MAP;
     static std::map<int, float> EMPTY_INT_FLOAT_MAP;
+    static std::unordered_map<int, float> EMPTY_INT_FLOAT_UNORDERED_MAP;
 
     const std::map<std::string, int>& GetEmpireStringIntMap(int empire_id, const std::string& parsed_map_name) {
         Empire* empire = GetEmpire(empire_id);
@@ -1276,10 +1277,10 @@ namespace {
         return EMPTY_INT_INT_MAP;
     }
 
-    const std::map<int, float>& GetEmpireIntFloatMap(int empire_id, const std::string& parsed_map_name) {
+    const std::unordered_map<int, float>& GetEmpireIntFloatMap(int empire_id, const std::string& parsed_map_name) {
         Empire* empire = GetEmpire(empire_id);
         if (!empire)
-            return EMPTY_INT_FLOAT_MAP;
+            return EMPTY_INT_FLOAT_UNORDERED_MAP;
 
         if (parsed_map_name == "PropagatedSystemSupplyRange")
             return GetSupplyManager().PropagatedSupplyRanges(empire_id);
@@ -1288,7 +1289,7 @@ namespace {
         if (parsed_map_name == "PropagatedSystemSupplyDistance")
             return GetSupplyManager().PropagatedSupplyDistances(empire_id);
 
-        return EMPTY_INT_FLOAT_MAP;
+        return EMPTY_INT_FLOAT_UNORDERED_MAP;
     }
 
     int GetIntEmpirePropertyNoKeyImpl(int empire_id, const std::string& parsed_property_name) {
@@ -1382,8 +1383,8 @@ namespace {
 
         // single empire
         if (empire_id != ALL_EMPIRES) {
-            const std::map<int, float>& map = GetEmpireIntFloatMap(empire_id, parsed_property_name);
-            std::map<int, float>::const_iterator it = map.find(map_key);
+            const auto& map = GetEmpireIntFloatMap(empire_id, parsed_property_name);
+            const auto& it = map.find(map_key);
             if (it == map.end())
                 return 0.0f;
             return it->second;
@@ -1391,8 +1392,8 @@ namespace {
 
         // all empires summed
         for (std::map<int, Empire*>::value_type& empire_entry : Empires()) {
-            const std::map<int, float>& map = GetEmpireIntFloatMap(empire_entry.first, parsed_property_name);
-            std::map<int, float>::const_iterator map_it = map.find(map_key);
+            const auto& map = GetEmpireIntFloatMap(empire_entry.first, parsed_property_name);
+            const auto& map_it = map.find(map_key);
             if (map_it != map.end())
                 sum += map_it->second;
         }

--- a/universe/ValueRef.cpp
+++ b/universe/ValueRef.cpp
@@ -704,7 +704,9 @@ double Variable<double>::Eval(const ScriptingContext& context) const
         if (std::shared_ptr<const Ship> ship = std::dynamic_pointer_cast<const Ship>(object))
             return ship->TotalWeaponsDamage();
 
-    } else if (property_name == "PropagatedSupplyRange") {
+    } /* TODO remove these properties from the parser? or find a way to represent a multivalent result.
+
+        else if (property_name == "PropagatedSupplyRange") {
         const auto& ranges = GetSupplyManager().PropagatedSupplyRanges();
         const auto& range_it = ranges.find(object->SystemID());
         if (range_it == ranges.end())
@@ -717,7 +719,7 @@ double Variable<double>::Eval(const ScriptingContext& context) const
         if (range_it == ranges.end())
             return 0.0;
         return range_it->second;
-    }
+        }*/
 
     ErrorLogger() << "Variable<double>::Eval unrecognized object property: "
                   << TraceReference(m_property_name, m_ref_type, context);
@@ -785,9 +787,12 @@ int Variable<int>::Eval(const ScriptingContext& context) const
 
     if (property_name == "Owner") {
         return object->Owner();
-    } else if (property_name == "SupplyingEmpire") {
-        return GetSupplyManager().EmpireThatCanSupplyAt(object->SystemID());
-    } else if (property_name == "ID") {
+    }
+    /* TODO replace with multi-valent result.
+else if (property_name == "SupplyingEmpire") {
+      return GetSupplyManager().EmpireThatCanSupplyAt(object->SystemID());
+    } */
+    else if (property_name == "ID") {
         return object->ID();
     } else if (property_name == "CreationTurn") {
         return object->CreationTurn();

--- a/util/Serialize.ipp
+++ b/util/Serialize.ipp
@@ -23,6 +23,8 @@
 #include <boost/serialization/list.hpp>
 #include <boost/serialization/map.hpp>
 #include <boost/serialization/set.hpp>
+#include <boost/serialization/unordered_map.hpp>
+#include <boost/serialization/unordered_set.hpp>
 #include <boost/serialization/vector.hpp>
 #include <boost/serialization/weak_ptr.hpp>
 #include <boost/ptr_container/serialize_ptr_vector.hpp>

--- a/util/SerializeEmpire.cpp
+++ b/util/SerializeEmpire.cpp
@@ -197,20 +197,3 @@ template void DiplomaticMessage::serialize<freeorion_bin_iarchive>(freeorion_bin
 template void DiplomaticMessage::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, const unsigned int);
 template void DiplomaticMessage::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
 
-template <class Archive>
-void SupplyManager::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_NVP(m_supply_starlane_traversals)
-        & BOOST_SERIALIZATION_NVP(m_supply_starlane_obstructed_traversals)
-        & BOOST_SERIALIZATION_NVP(m_fleet_supplyable_system_ids)
-        & BOOST_SERIALIZATION_NVP(m_resource_supply_groups)
-        & BOOST_SERIALIZATION_NVP(m_propagated_supply_ranges)
-        & BOOST_SERIALIZATION_NVP(m_empire_propagated_supply_ranges)
-        & BOOST_SERIALIZATION_NVP(m_propagated_supply_distances)
-        & BOOST_SERIALIZATION_NVP(m_empire_propagated_supply_distances);
-}
-
-template void SupplyManager::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, const unsigned int);
-template void SupplyManager::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, const unsigned int);
-template void SupplyManager::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, const unsigned int);
-template void SupplyManager::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);


### PR DESCRIPTION
This PR goes with the [forum](http://freeorion.org/forum/viewtopic.php?f=6&t=10391&p=87613#p87613) post, showing images of the progress towards adding stealth and detection to the supply resolution.  

The PR is not complete, but given the difficult merge with the MapWnd.cpp changes yesterday I would like to coordinate, if possible with the changes to diplomacy and supply for allied supply.

If we decide to use some/all of this PR then I will break it up like other large PR I've proposed in the past.

This PR does the following
- Changes the supply resolution to include the supply source's stealth and the competing empire's detection strength in the calculations.  Simply, if an empire can't detect a competing empire's supply then it can't blockade nor can its supply block that supply source.  Otherwise, it works as before.
- Changes the map display of supply to only show one empire at a time.  This avoids trying to visualize overlapping supply networks.  The displayed supply network is selected by the player clicking on a planet, fleet, ship in the MapWnd or the empire name in the Empire window.
- Adds a system supply icon in the SidePanel that displays the details of the supply calculation.  It shows range, distance, stealth, the total bonus and the individual components of the bonus.  
- It extends the python wrappers to pass unordered_maps and unordered_sets.