### PR TITLE
Improve server polling timeout consistency

### DIFF
--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -156,7 +156,7 @@ void AIClientApp::Run() {
 
 void AIClientApp::ConnectToServer() {
     typedef boost::chrono::steady_clock Clock;
-    const boost::chrono::milliseconds SERVER_CONNECT_TIMEOUT(4500);
+    const boost::chrono::milliseconds SERVER_CONNECT_TIMEOUT(10000);
     const boost::chrono::milliseconds SERVER_STARTUP_POLLING_TIME(10);
 
     bool connected = false;

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -161,17 +161,19 @@ void AIClientApp::ConnectToServer() {
 
     bool connected = false;
     Clock::time_point start_time = Clock::now();
-    boost::chrono::milliseconds connection_time(0);
+    Clock::duration connection_time{0};
     while (!connected && (connection_time < SERVER_CONNECT_TIMEOUT )) {
         connected = Networking().ConnectToLocalHostServer(SERVER_STARTUP_POLLING_TIME);
-        connection_time = boost::chrono::duration_cast<boost::chrono::milliseconds>(Clock::now() - start_time);
+        connection_time = Clock::now() - start_time;
     }
 
     if (!connected) {
-        ErrorLogger() << "AIClientApp::Run : Failed to connect to localhost server after " << connection_time << ".  Exiting.";
+        ErrorLogger() << "Timed out.  Failed to connect to server in "
+                      << boost::chrono::duration_cast<boost::chrono::milliseconds>(connection_time) << ".";
         Exit(1);
     }
-    DebugLogger() << "AI connected to local server took " << connection_time << ".";
+    DebugLogger() << "Connecting to server took "
+                  << boost::chrono::duration_cast<boost::chrono::milliseconds>(connection_time) << ".";
 }
 
 void AIClientApp::StartPythonAI() {

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -23,6 +23,8 @@
 #include <boost/filesystem/fstream.hpp>
 #include <boost/chrono/chrono_io.hpp>
 
+#include <chrono>
+
 class CombatLogManager;
 CombatLogManager&   GetCombatLogManager();
 
@@ -155,9 +157,9 @@ void AIClientApp::Run() {
 }
 
 void AIClientApp::ConnectToServer() {
-    typedef boost::chrono::steady_clock Clock;
-    const boost::chrono::milliseconds SERVER_CONNECT_TIMEOUT(10000);
-    const boost::chrono::milliseconds SERVER_STARTUP_POLLING_TIME(10);
+    typedef std::chrono::steady_clock Clock;
+    const std::chrono::milliseconds SERVER_CONNECT_TIMEOUT(10000);
+    const std::chrono::milliseconds SERVER_STARTUP_POLLING_TIME(10);
 
     bool connected = false;
     Clock::time_point start_time = Clock::now();
@@ -169,11 +171,11 @@ void AIClientApp::ConnectToServer() {
 
     if (!connected) {
         ErrorLogger() << "Timed out.  Failed to connect to server in "
-                      << boost::chrono::duration_cast<boost::chrono::milliseconds>(connection_time) << ".";
+                      << std::chrono::duration_cast<std::chrono::milliseconds>(connection_time).count() << " ms.";
         Exit(1);
     }
     DebugLogger() << "Connecting to server took "
-                  << boost::chrono::duration_cast<boost::chrono::milliseconds>(connection_time) << ".";
+                  << std::chrono::duration_cast<std::chrono::milliseconds>(connection_time).count() << " ms.";
 }
 
 void AIClientApp::StartPythonAI() {

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -21,6 +21,7 @@
 
 #include <boost/lexical_cast.hpp>
 #include <boost/filesystem/fstream.hpp>
+#include <boost/chrono/chrono_io.hpp>
 
 class CombatLogManager;
 CombatLogManager&   GetCombatLogManager();
@@ -154,25 +155,23 @@ void AIClientApp::Run() {
 }
 
 void AIClientApp::ConnectToServer() {
-    // connect
-    const int MAX_TRIES = 10;
-    int tries = 0;
-    volatile bool connected = false;
-    while (tries < MAX_TRIES) {
-        DebugLogger() << "Attempting to contact server";
-        connected = Networking().ConnectToLocalHostServer();
-        if (!connected) {
-            std::cerr << "FreeOrion AI client server contact attempt " << tries + 1 << " failed." << std::endl;
-            ErrorLogger() << "Server contact attempt " << tries + 1 << " failed";
-        } else {
-            break;
-        }
-        ++tries;
+    typedef boost::chrono::steady_clock Clock;
+    const boost::chrono::milliseconds SERVER_CONNECT_TIMEOUT(4500);
+    const boost::chrono::milliseconds SERVER_STARTUP_POLLING_TIME(10);
+
+    bool connected = false;
+    Clock::time_point start_time = Clock::now();
+    boost::chrono::milliseconds connection_time(0);
+    while (!connected && (connection_time < SERVER_CONNECT_TIMEOUT )) {
+        connected = Networking().ConnectToLocalHostServer(SERVER_STARTUP_POLLING_TIME);
+        connection_time = boost::chrono::duration_cast<boost::chrono::milliseconds>(Clock::now() - start_time);
     }
+
     if (!connected) {
-        ErrorLogger() << "AIClientApp::Run : Failed to connect to localhost server after " << MAX_TRIES << " tries.  Exiting.";
+        ErrorLogger() << "AIClientApp::Run : Failed to connect to localhost server after " << connection_time << ".  Exiting.";
         Exit(1);
     }
+    DebugLogger() << "AI connected to local server took " << connection_time << ".";
 }
 
 void AIClientApp::StartPythonAI() {

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -157,25 +157,8 @@ void AIClientApp::Run() {
 }
 
 void AIClientApp::ConnectToServer() {
-    typedef std::chrono::steady_clock Clock;
-    const std::chrono::milliseconds SERVER_CONNECT_TIMEOUT(10000);
-    const std::chrono::milliseconds SERVER_STARTUP_POLLING_TIME(10);
-
-    bool connected = false;
-    Clock::time_point start_time = Clock::now();
-    Clock::duration connection_time{0};
-    while (!connected && (connection_time < SERVER_CONNECT_TIMEOUT )) {
-        connected = Networking().ConnectToLocalHostServer(SERVER_STARTUP_POLLING_TIME);
-        connection_time = Clock::now() - start_time;
-    }
-
-    if (!connected) {
-        ErrorLogger() << "Timed out.  Failed to connect to server in "
-                      << std::chrono::duration_cast<std::chrono::milliseconds>(connection_time).count() << " ms.";
+    if (!Networking().ConnectToLocalHostServer())
         Exit(1);
-    }
-    DebugLogger() << "Connecting to server took "
-                  << std::chrono::duration_cast<std::chrono::milliseconds>(connection_time).count() << " ms.";
 }
 
 void AIClientApp::StartPythonAI() {

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -45,6 +45,9 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/chrono/chrono_io.hpp>
 
+#include <chrono>
+#include <thread>
+
 #include <sstream>
 
 
@@ -84,9 +87,9 @@ void SigHandler(int sig) {
 #endif //ENABLE_CRASH_BACKTRACE
 
 namespace {
-    typedef boost::chrono::steady_clock Clock;
-    const boost::chrono::milliseconds SERVER_CONNECT_TIMEOUT(10000);
-    const boost::chrono::milliseconds SERVER_STARTUP_POLLING_TIME(10);
+    typedef std::chrono::steady_clock Clock;
+    const std::chrono::milliseconds SERVER_CONNECT_TIMEOUT(10000);
+    const std::chrono::milliseconds SERVER_STARTUP_POLLING_TIME(10);
 
     const bool          INSTRUMENT_MESSAGE_HANDLING = false;
 
@@ -452,7 +455,7 @@ void HumanClientApp::NewSinglePlayerGame(bool quickstart) {
         connection_time = Clock::now() - start_time;
         if (SERVER_CONNECT_TIMEOUT < connection_time) {
             ErrorLogger() << "Timed out.  Failed to connect to server in "
-                          << boost::chrono::duration_cast<boost::chrono::milliseconds>(connection_time) << ".";
+                          << std::chrono::duration_cast<std::chrono::milliseconds>(connection_time).count() << " ms.";
             ClientUI::MessageBox(UserString("ERR_CONNECT_TIMED_OUT"), true);
             KillServer();
             return;
@@ -461,7 +464,7 @@ void HumanClientApp::NewSinglePlayerGame(bool quickstart) {
 
     m_connected = true;
     DebugLogger() << "HumanClientApp::NewSinglePlayerGame : Connecting to server took "
-                  << boost::chrono::duration_cast<boost::chrono::milliseconds>(connection_time) << ".";
+                  << std::chrono::duration_cast<std::chrono::milliseconds>(connection_time).count() << " ms.";
 
     if (quickstart || ended_with_ok) {
 
@@ -545,7 +548,7 @@ void HumanClientApp::NewSinglePlayerGame(bool quickstart) {
         ErrorLogger() << "HumanClientApp::NewSinglePlayerGame failed to start new game, killing server.";
         DebugLogger() << "HumanClientApp::NewSinglePlayerGame Sending server shutdown message.";
         m_networking.SendMessage(ShutdownServerMessage(m_networking.PlayerID()));
-        boost::this_thread::sleep_for(boost::chrono::seconds(1));
+        std::this_thread::sleep_for(std::chrono::seconds(1));
         m_networking.DisconnectFromServer();
         if (!m_networking.Connected())
             DebugLogger() << "HumanClientApp::NewSinglePlayerGame Disconnected from server.";
@@ -648,7 +651,7 @@ void HumanClientApp::LoadSinglePlayerGame(std::string filename/* = ""*/) {
     if (m_game_started) {
         EndGame();
         // delay to make sure old game is fully cleaned up before attempting to start a new one
-        boost::this_thread::sleep_for(boost::chrono::seconds(3));
+        std::this_thread::sleep_for(std::chrono::seconds(3));
     } else {
         DebugLogger() << "HumanClientApp::LoadSinglePlayerGame() not already in a game, so don't need to end it";
     }
@@ -669,7 +672,7 @@ void HumanClientApp::LoadSinglePlayerGame(std::string filename/* = ""*/) {
         connection_time = Clock::now() - start_time;
         if (SERVER_CONNECT_TIMEOUT < connection_time) {
             ErrorLogger() << "Timed out.  Failed to connect to server in "
-                          << boost::chrono::duration_cast<boost::chrono::milliseconds>(connection_time) << ".";
+                          << std::chrono::duration_cast<std::chrono::milliseconds>(connection_time).count() << " ms.";
             ClientUI::MessageBox(UserString("ERR_CONNECT_TIMED_OUT"), true);
             KillServer();
             return;
@@ -678,7 +681,7 @@ void HumanClientApp::LoadSinglePlayerGame(std::string filename/* = ""*/) {
 
     m_connected = true;
     DebugLogger() << "HumanClientApp::LoadSinglePlayerGame : Connecting to server took "
-                      << boost::chrono::duration_cast<boost::chrono::milliseconds>(connection_time) << ".";
+                  << std::chrono::duration_cast<std::chrono::milliseconds>(connection_time).count() << " ms.";
 
     m_networking.SetPlayerID(Networking::INVALID_PLAYER_ID);
     m_networking.SetHostPlayerID(Networking::INVALID_PLAYER_ID);
@@ -713,7 +716,7 @@ void HumanClientApp::RequestSavePreviews(const std::string& directory, PreviewIn
             connection_time = Clock::now() - start_time;
             if (SERVER_CONNECT_TIMEOUT < connection_time) {
                 ErrorLogger() << "Timed out.  Failed to connect to server in "
-                              << boost::chrono::duration_cast<boost::chrono::milliseconds>(connection_time) << ".";
+                              << std::chrono::duration_cast<std::chrono::milliseconds>(connection_time).count() << " ms.";
                 ClientUI::MessageBox(UserString("ERR_CONNECT_TIMED_OUT"), true);
                 KillServer();
                 return;
@@ -721,7 +724,7 @@ void HumanClientApp::RequestSavePreviews(const std::string& directory, PreviewIn
         }
         m_connected = true;
         DebugLogger() << "HumanClientApp::RequestSavePreviews : Connecting to server took "
-                      << boost::chrono::duration_cast<boost::chrono::milliseconds>(connection_time) << ".";
+                      << std::chrono::duration_cast<std::chrono::milliseconds>(connection_time).count() << " ms.";
     }
     DebugLogger() << "HumanClientApp::RequestSavePreviews Requesting previews for " << generic_directory;
     Message response;
@@ -1157,7 +1160,7 @@ void HumanClientApp::EndGame(bool suppress_FSM_reset) {
     if (m_networking.Connected()) {
         DebugLogger() << "HumanClientApp::EndGame Sending server shutdown message.";
         m_networking.SendMessage(ShutdownServerMessage(m_networking.PlayerID()));
-        boost::this_thread::sleep_for(boost::chrono::seconds(1));
+        std::this_thread::sleep_for(std::chrono::seconds(1));
         m_networking.DisconnectFromServer();
         if (!m_networking.Connected())
             DebugLogger() << "HumanClientApp::EndGame Disconnected from server.";

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -448,8 +448,12 @@ void HumanClientApp::NewSinglePlayerGame(bool quickstart) {
 
     bool failed = false;
     Clock::time_point start_time = Clock::now();
+    Clock::duration connection_time{0};
     while (!m_networking.ConnectToLocalHostServer(SERVER_STARTUP_POLLING_TIME)) {
-        if (SERVER_CONNECT_TIMEOUT < Clock::now() - start_time) {
+        connection_time = Clock::now() - start_time;
+        if (SERVER_CONNECT_TIMEOUT < connection_time) {
+            ErrorLogger() << "Timed out.  Failed to connect to server in "
+                          << boost::chrono::duration_cast<boost::chrono::milliseconds>(connection_time) << ".";
             ClientUI::MessageBox(UserString("ERR_CONNECT_TIMED_OUT"), true);
             failed = true;
             break;
@@ -661,18 +665,22 @@ void HumanClientApp::LoadSinglePlayerGame(std::string filename/* = ""*/) {
 
     DebugLogger() << "HumanClientApp::LoadSinglePlayerGame() Connecting to server";
     Clock::time_point start_time = Clock::now();
+    Clock::duration connection_time{0};
     while (!m_networking.ConnectToLocalHostServer(SERVER_STARTUP_POLLING_TIME)) {
-        if (SERVER_CONNECT_TIMEOUT < Clock::now() - start_time) {
-            ErrorLogger() << "HumanClientApp::LoadSinglePlayerGame() server connecting timed out";
+        connection_time = Clock::now() - start_time;
+        if (SERVER_CONNECT_TIMEOUT < connection_time) {
+            ErrorLogger() << "Timed out.  Failed to connect to server in "
+                          << boost::chrono::duration_cast<boost::chrono::milliseconds>(connection_time) << ".";
             ClientUI::MessageBox(UserString("ERR_CONNECT_TIMED_OUT"), true);
             KillServer();
             return;
         }
     }
 
-    DebugLogger() << "HumanClientApp::LoadSinglePlayerGame() Connected to server";
-
     m_connected = true;
+    DebugLogger() << "HumanClientApp::LoadSinglePlayerGame : Connecting to server took "
+                      << boost::chrono::duration_cast<boost::chrono::milliseconds>(connection_time) << ".";
+
     m_networking.SetPlayerID(Networking::INVALID_PLAYER_ID);
     m_networking.SetHostPlayerID(Networking::INVALID_PLAYER_ID);
     SetEmpireID(ALL_EMPIRES);
@@ -701,15 +709,20 @@ void HumanClientApp::RequestSavePreviews(const std::string& directory, PreviewIn
 
         DebugLogger() << "HumanClientApp::RequestSavePreviews Connecting to server";
         Clock::time_point start_time = Clock::now();
+        Clock::duration connection_time{0};
         while (!m_networking.ConnectToLocalHostServer(SERVER_STARTUP_POLLING_TIME)) {
-            if (SERVER_CONNECT_TIMEOUT < Clock::now() - start_time) {
-                ErrorLogger() << "HumanClientApp::LoadSinglePlayerGame() server connecting timed out";
+            connection_time = Clock::now() - start_time;
+            if (SERVER_CONNECT_TIMEOUT < connection_time) {
+                ErrorLogger() << "Timed out.  Failed to connect to server in "
+                              << boost::chrono::duration_cast<boost::chrono::milliseconds>(connection_time) << ".";
                 ClientUI::MessageBox(UserString("ERR_CONNECT_TIMED_OUT"), true);
                 KillServer();
                 return;
             }
         }
         m_connected = true;
+        DebugLogger() << "HumanClientApp::RequestSavePreviews : Connecting to server took "
+                      << boost::chrono::duration_cast<boost::chrono::milliseconds>(connection_time) << ".";
     }
     DebugLogger() << "HumanClientApp::RequestSavePreviews Requesting previews for " << generic_directory;
     Message response;

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -85,7 +85,7 @@ void SigHandler(int sig) {
 
 namespace {
     typedef boost::chrono::steady_clock Clock;
-    const boost::chrono::milliseconds SERVER_CONNECT_TIMEOUT(4500);
+    const boost::chrono::milliseconds SERVER_CONNECT_TIMEOUT(10000);
     const boost::chrono::milliseconds SERVER_STARTUP_POLLING_TIME(10);
 
     const bool          INSTRUMENT_MESSAGE_HANDLING = false;

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -42,7 +42,7 @@
 #include <boost/filesystem/fstream.hpp>
 #include <boost/format.hpp>
 #include <boost/serialization/vector.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/algorithm/string.hpp>
 
 #include <sstream>
 
@@ -445,7 +445,7 @@ void HumanClientApp::NewSinglePlayerGame(bool quickstart) {
 
     bool failed = false;
     unsigned int start_time = Ticks();
-    while (!m_networking.ConnectToLocalHostServer(boost::posix_time::seconds(2))) {
+    while (!m_networking.ConnectToLocalHostServer(boost::chrono::milliseconds(2000))) {
         if (SERVER_CONNECT_TIMEOUT < Ticks() - start_time) {
             ClientUI::MessageBox(UserString("ERR_CONNECT_TIMED_OUT"), true);
             failed = true;
@@ -579,7 +579,7 @@ void HumanClientApp::MultiPlayerGame() {
     }
 
     unsigned int start_time = Ticks();
-    while (!m_networking.ConnectToServer(server_name, boost::posix_time::seconds(2))) {
+    while (!m_networking.ConnectToServer(server_name, boost::chrono::milliseconds(2000))) {
         if (SERVER_CONNECT_TIMEOUT < Ticks() - start_time) {
             ClientUI::MessageBox(UserString("ERR_CONNECT_TIMED_OUT"), true);
             if (server_connect_wnd.Result().second == "HOST GAME SELECTED")

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -86,7 +86,7 @@ void SigHandler(int sig) {
 namespace {
     typedef boost::chrono::steady_clock Clock;
     const boost::chrono::milliseconds SERVER_CONNECT_TIMEOUT(4500);
-    const boost::chrono::milliseconds SERVER_STARTUP_POLLING_TIME(2000);
+    const boost::chrono::milliseconds SERVER_STARTUP_POLLING_TIME(10);
 
     const bool          INSTRUMENT_MESSAGE_HANDLING = false;
 

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -176,8 +176,6 @@ bool ClientNetworking::ConnectToServer(
 
     try {
         for (tcp::resolver::iterator it = resolver.resolve(query); it != end_it; ++it) {
-            if (verbose)
-
             m_socket.close();
             boost::asio::basic_waitable_timer<boost::chrono::high_resolution_clock> timer(m_io_service);
 
@@ -195,6 +193,7 @@ bool ClientNetworking::ConnectToServer(
                 DebugLogger() << "tcp::resolver::iterator host_name: " << it->host_name()
                               << "  address: " << it->endpoint().address()
                               << "  port: " << it->endpoint().port();
+
                 DebugLogger() << "ClientNetworking::ConnectToServer : connected to server";
                 if (GetOptionsDB().Get<bool>("binary-serialization"))
                     DebugLogger() << "ClientNetworking::ConnectToServer : this client using binary serialization.";

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -19,7 +19,7 @@ using boost::asio::ip::tcp;
 using namespace Networking;
 
 namespace {
-    const bool TRACE_EXECUTION = false;
+    const bool TRACE_EXECUTION = true;
 
     /** A simple client that broadcasts UDP datagrams on the local network for
         FreeOrion servers, and reports any it finds. */
@@ -315,7 +315,9 @@ void ClientNetworking::HandleConnection(tcp::resolver::iterator* it,
     if (error) {
         if (!m_cancel_retries) {
             if (TRACE_EXECUTION)
-                DebugLogger() << "ClientNetworking::HandleConnection : connection error ... retrying";
+                DebugLogger() << "ClientNetworking::HandleConnection : connection "
+                              << "error #"<<error.value()<<" \"" << error.message() << "\""
+                              << "... retrying";
             m_socket.async_connect(**it, boost::bind(&ClientNetworking::HandleConnection, this,
                                                      it,
                                                      timer,

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -162,11 +162,9 @@ ClientNetworking::ServerList ClientNetworking::DiscoverLANServers() {
 
 bool ClientNetworking::ConnectToServer(
     const std::string& ip_address,
-    std::chrono::milliseconds timeout/* = std::chrono::seconds(10)*/,
-    bool verbose)
+    std::chrono::milliseconds timeout/* = std::chrono::seconds(10)*/)
 {
-    if (verbose)
-        DebugLogger() << "ClientNetworking::ConnectToServer : attempting to connect to server at " << ip_address;
+    DebugLogger() << "ClientNetworking::ConnectToServer : attempting to connect to server at " << ip_address;
 
     using namespace boost::asio::ip;
     tcp::resolver resolver(m_io_service);
@@ -206,14 +204,14 @@ bool ClientNetworking::ConnectToServer(
                 DebugLogger() << "ClientNetworking::ConnectToServer : starting networking thread";
                 boost::thread(boost::bind(&ClientNetworking::NetworkingThread, this));
                 break;
-            } else if (verbose) {
+            } else {
                 DebugLogger() << "tcp::resolver::iterator host_name: " << it->host_name()
                               << "  address: " << it->endpoint().address()
                               << "  port: " << it->endpoint().port();
                 DebugLogger() << "ClientNetworking::ConnectToServer : no connection yet...";
             }
         }
-        if (!Connected() && verbose)
+        if (!Connected())
             DebugLogger() << "ClientNetworking::ConnectToServer : failed to connect to server (no exceptions)";
 
     } catch (const std::exception& e) {
@@ -224,14 +222,13 @@ bool ClientNetworking::ConnectToServer(
 }
 
 bool ClientNetworking::ConnectToLocalHostServer(
-    std::chrono::milliseconds timeout/* = std::chrono::seconds(10)*/,
-    bool verbose)
+    std::chrono::milliseconds timeout/* = std::chrono::seconds(10)*/)
 {
     bool retval = false;
 #if FREEORION_WIN32
     try {
 #endif
-        retval = ConnectToServer("127.0.0.1", timeout, verbose);
+        retval = ConnectToServer("127.0.0.1", timeout);
 #if FREEORION_WIN32
     } catch (const boost::system::system_error& e) {
         if (e.code().value() != WSAEADDRNOTAVAIL)

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -107,7 +107,7 @@ namespace {
         { m_socket.close(); }
 
         boost::asio::io_service*       m_io_service;
-        boost::asio::basic_waitable_timer<std::chrono::high_resolution_clock> m_timer;
+        boost::asio::high_resolution_timer m_timer;
         boost::asio::ip::udp::socket   m_socket;
 
         std::array<char, 1024> m_recv_buf;
@@ -179,7 +179,7 @@ bool ClientNetworking::ConnectToServer(
     try {
         for (tcp::resolver::iterator it = resolver.resolve(query); it != end_it; ++it) {
             m_socket.close();
-            boost::asio::basic_waitable_timer<std::chrono::high_resolution_clock> timer(m_io_service);
+            boost::asio::high_resolution_timer timer(m_io_service);
 
             m_socket.async_connect(*it, boost::bind(&ClientNetworking::HandleConnection, this,
                                                     &it,
@@ -290,7 +290,7 @@ void ClientNetworking::SendSynchronousMessage(Message message, Message& response
 }
 
 void ClientNetworking::HandleConnection(tcp::resolver::iterator* it,
-                                        boost::asio::basic_waitable_timer<std::chrono::high_resolution_clock>* timer,
+                                        boost::asio::high_resolution_timer* timer,
                                         const boost::system::error_code& error)
 {
     if (error) {

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -182,10 +182,19 @@ bool ClientNetworking::ConnectToServer(
             m_socket.close();
             boost::asio::high_resolution_timer timer(m_io_service);
 
+#ifndef FREEORION_MACOSX
             m_socket.async_connect(*it, boost::bind(&ClientNetworking::HandleConnection, this,
                                                     &it,
                                                     &timer,
                                                     boost::asio::placeholders::error));
+#else
+            auto backoff_time = std::chrono::milliseconds(10);
+            m_socket.async_connect(*it, boost::bind(&ClientNetworking::HandleConnection, this,
+                                                    &it,
+                                                    &timer,
+                                                    backoff_time,
+                                                    boost::asio::placeholders::error));
+#endif
             timer.expires_from_now(timeout);
             timer.async_wait(boost::bind(&ClientNetworking::CancelRetries, this));
             m_cancel_retries = false;
@@ -298,6 +307,7 @@ void ClientNetworking::SendSynchronousMessage(Message message, Message& response
                                << "response message " << response_message;
 }
 
+#ifndef FREEORION_MACOSX
 void ClientNetworking::HandleConnection(tcp::resolver::iterator* it,
                                         boost::asio::high_resolution_timer* timer,
                                         const boost::system::error_code& error)
@@ -319,6 +329,39 @@ void ClientNetworking::HandleConnection(tcp::resolver::iterator* it,
         m_connected = true;
     }
 }
+#else
+void ClientNetworking::HandleConnection(tcp::resolver::iterator* it,
+                                        boost::asio::high_resolution_timer* timer,
+                                        std::chrono::milliseconds& backoff_time,
+                                        const boost::system::error_code& error)
+{
+    if (error) {
+        if (!m_cancel_retries) {
+            // Try a progressive backoff to prevent MAXOSX from blocking repeated connection attempts.
+            DebugLogger() << "Retry connection after backoff of " << backoff_time.count() << " ms.";
+            std::this_thread::sleep_for(backoff_time);
+            // double backoff time until 1 sec then start again at 10ms
+            backoff_time =  (backoff_time > std::chrono::seconds(1)) ? std::chrono::milliseconds(10) : (2 * backoff_time);
+
+            if (TRACE_EXECUTION)
+                DebugLogger() << "ClientNetworking::HandleConnection : connection "
+                              << "error #"<<error.value()<<" \"" << error.message() << "\""
+                              << "... retrying";
+            m_socket.async_connect(**it, boost::bind(&ClientNetworking::HandleConnection, this,
+                                                     it,
+                                                     timer,
+                                                     backoff_time,
+                                                     boost::asio::placeholders::error));
+        }
+    } else {
+        if (TRACE_EXECUTION)
+            DebugLogger() << "ClientNetworking::HandleConnection : connected";
+        timer->cancel();
+        boost::mutex::scoped_lock lock(m_mutex);
+        m_connected = true;
+    }
+}
+#endif
 
 void ClientNetworking::CancelRetries()
 { m_cancel_retries = true; }

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -162,7 +162,7 @@ ClientNetworking::ServerList ClientNetworking::DiscoverLANServers() {
 
 bool ClientNetworking::ConnectToServer(
     const std::string& ip_address,
-    std::chrono::milliseconds timeout/* = std::chrono::seconds(5)*/,
+    std::chrono::milliseconds timeout/* = std::chrono::seconds(10)*/,
     bool verbose)
 {
     if (verbose)
@@ -224,7 +224,7 @@ bool ClientNetworking::ConnectToServer(
 }
 
 bool ClientNetworking::ConnectToLocalHostServer(
-    std::chrono::milliseconds timeout/* = std::chrono::seconds(5)*/,
+    std::chrono::milliseconds timeout/* = std::chrono::seconds(10)*/,
     bool verbose)
 {
     bool retval = false;

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -13,7 +13,6 @@
 #include <boost/thread/condition.hpp>
 #include <boost/thread/thread.hpp>
 
-
 using boost::asio::ip::tcp;
 using namespace Networking;
 
@@ -63,7 +62,7 @@ namespace {
                                 this,
                                 boost::asio::placeholders::error,
                                 boost::asio::placeholders::bytes_transferred));
-                m_timer.expires_from_now(boost::posix_time::seconds(2));
+                m_timer.expires_from_now(boost::chrono::seconds(2));
                 m_timer.async_wait(boost::bind(&ServerDiscoverer::CloseSocket, this));
                 m_io_service->run();
                 m_io_service->reset();
@@ -106,7 +105,7 @@ namespace {
         { m_socket.close(); }
 
         boost::asio::io_service*       m_io_service;
-        boost::asio::deadline_timer    m_timer;
+        boost::asio::high_resolution_timer m_timer;
         boost::asio::ip::udp::socket   m_socket;
 
         std::array<char, 1024> m_recv_buf;
@@ -161,7 +160,7 @@ ClientNetworking::ServerList ClientNetworking::DiscoverLANServers() {
 
 bool ClientNetworking::ConnectToServer(
     const std::string& ip_address,
-    boost::posix_time::seconds timeout/* = boost::posix_time::seconds(5)*/)
+    boost::chrono::milliseconds timeout/* = boost::chrono::seconds(5)*/)
 {
     DebugLogger() << "ClientNetworking::ConnectToServer : attempting to connect to server at " << ip_address;
 
@@ -180,7 +179,7 @@ bool ClientNetworking::ConnectToServer(
                           << "  port: " << it->endpoint().port();
 
             m_socket.close();
-            boost::asio::deadline_timer timer(m_io_service);
+            boost::asio::high_resolution_timer timer(m_io_service);
 
             m_socket.async_connect(*it, boost::bind(&ClientNetworking::HandleConnection, this,
                                                     &it,
@@ -218,7 +217,7 @@ bool ClientNetworking::ConnectToServer(
 }
 
 bool ClientNetworking::ConnectToLocalHostServer(
-    boost::posix_time::seconds timeout/* = boost::posix_time::seconds(5)*/)
+    boost::chrono::milliseconds timeout/* = boost::chrono::seconds(5)*/)
 {
     bool retval = false;
 #if FREEORION_WIN32
@@ -283,7 +282,7 @@ void ClientNetworking::SendSynchronousMessage(Message message, Message& response
 }
 
 void ClientNetworking::HandleConnection(tcp::resolver::iterator* it,
-                                        boost::asio::deadline_timer* timer,
+                                        boost::asio::high_resolution_timer* timer,
                                         const boost::system::error_code& error)
 {
     if (error) {

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -19,7 +19,7 @@ using boost::asio::ip::tcp;
 using namespace Networking;
 
 namespace {
-    const bool TRACE_EXECUTION = true;
+    const bool TRACE_EXECUTION = false;
 
     /** A simple client that broadcasts UDP datagrams on the local network for
         FreeOrion servers, and reports any it finds. */

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -105,7 +105,7 @@ namespace {
         { m_socket.close(); }
 
         boost::asio::io_service*       m_io_service;
-        boost::asio::high_resolution_timer m_timer;
+        boost::asio::basic_waitable_timer<boost::chrono::high_resolution_clock> m_timer;
         boost::asio::ip::udp::socket   m_socket;
 
         std::array<char, 1024> m_recv_buf;
@@ -179,7 +179,7 @@ bool ClientNetworking::ConnectToServer(
             if (verbose)
 
             m_socket.close();
-            boost::asio::high_resolution_timer timer(m_io_service);
+            boost::asio::basic_waitable_timer<boost::chrono::high_resolution_clock> timer(m_io_service);
 
             m_socket.async_connect(*it, boost::bind(&ClientNetworking::HandleConnection, this,
                                                     &it,
@@ -289,7 +289,7 @@ void ClientNetworking::SendSynchronousMessage(Message message, Message& response
 }
 
 void ClientNetworking::HandleConnection(tcp::resolver::iterator* it,
-                                        boost::asio::high_resolution_timer* timer,
+                                        boost::asio::basic_waitable_timer<boost::chrono::high_resolution_clock>* timer,
                                         const boost::system::error_code& error)
 {
     if (error) {

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -13,6 +13,8 @@
 #include <boost/thread/condition.hpp>
 #include <boost/thread/thread.hpp>
 
+#include <thread>
+
 using boost::asio::ip::tcp;
 using namespace Networking;
 
@@ -62,7 +64,7 @@ namespace {
                                 this,
                                 boost::asio::placeholders::error,
                                 boost::asio::placeholders::bytes_transferred));
-                m_timer.expires_from_now(boost::chrono::seconds(2));
+                m_timer.expires_from_now(std::chrono::seconds(2));
                 m_timer.async_wait(boost::bind(&ServerDiscoverer::CloseSocket, this));
                 m_io_service->run();
                 m_io_service->reset();
@@ -105,7 +107,7 @@ namespace {
         { m_socket.close(); }
 
         boost::asio::io_service*       m_io_service;
-        boost::asio::basic_waitable_timer<boost::chrono::high_resolution_clock> m_timer;
+        boost::asio::basic_waitable_timer<std::chrono::high_resolution_clock> m_timer;
         boost::asio::ip::udp::socket   m_socket;
 
         std::array<char, 1024> m_recv_buf;
@@ -160,7 +162,7 @@ ClientNetworking::ServerList ClientNetworking::DiscoverLANServers() {
 
 bool ClientNetworking::ConnectToServer(
     const std::string& ip_address,
-    boost::chrono::milliseconds timeout/* = boost::chrono::seconds(5)*/,
+    std::chrono::milliseconds timeout/* = std::chrono::seconds(5)*/,
     bool verbose)
 {
     if (verbose)
@@ -177,7 +179,7 @@ bool ClientNetworking::ConnectToServer(
     try {
         for (tcp::resolver::iterator it = resolver.resolve(query); it != end_it; ++it) {
             m_socket.close();
-            boost::asio::basic_waitable_timer<boost::chrono::high_resolution_clock> timer(m_io_service);
+            boost::asio::basic_waitable_timer<std::chrono::high_resolution_clock> timer(m_io_service);
 
             m_socket.async_connect(*it, boost::bind(&ClientNetworking::HandleConnection, this,
                                                     &it,
@@ -222,7 +224,7 @@ bool ClientNetworking::ConnectToServer(
 }
 
 bool ClientNetworking::ConnectToLocalHostServer(
-    boost::chrono::milliseconds timeout/* = boost::chrono::seconds(5)*/,
+    std::chrono::milliseconds timeout/* = std::chrono::seconds(5)*/,
     bool verbose)
 {
     bool retval = false;
@@ -243,7 +245,7 @@ void ClientNetworking::DisconnectFromServer() {
     if (Connected())
         m_io_service.post(boost::bind(&ClientNetworking::DisconnectFromServerImpl, this));
     // HACK! wait a bit for the disconnect to occur
-    boost::this_thread::sleep_for(boost::chrono::seconds(1));
+    std::this_thread::sleep_for(std::chrono::seconds(1));
 }
 
 void ClientNetworking::SetPlayerID(int player_id) {
@@ -288,7 +290,7 @@ void ClientNetworking::SendSynchronousMessage(Message message, Message& response
 }
 
 void ClientNetworking::HandleConnection(tcp::resolver::iterator* it,
-                                        boost::asio::basic_waitable_timer<boost::chrono::high_resolution_clock>* timer,
+                                        boost::asio::basic_waitable_timer<std::chrono::high_resolution_clock>* timer,
                                         const boost::system::error_code& error)
 {
     if (error) {

--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -82,12 +82,14 @@ public:
     /** Connects to the server at \a ip_address.  On failure, repeated
         attempts will be made until \a timeout seconds has elapsed. */
     bool ConnectToServer(const std::string& ip_address,
-                         boost::chrono::milliseconds timeout = boost::chrono::seconds(5));
+                         boost::chrono::milliseconds timeout = boost::chrono::seconds(5),
+                         bool verbose = false);
 
     /** Connects to the server on the client's host.  On failure, repeated
         attempts will be made until \a timeout seconds has elapsed. */
     bool ConnectToLocalHostServer(boost::chrono::milliseconds timeout =
-                                  boost::chrono::seconds(5));
+                                  boost::chrono::seconds(5),
+                                  bool verbose = false);
 
     /** Sends \a message to the server.  This function actually just enqueues
         the message for sending and returns immediately. */

--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -119,7 +119,7 @@ public:
 private:
     void HandleException(const boost::system::system_error& error);
     void HandleConnection(boost::asio::ip::tcp::resolver::iterator* it,
-                          boost::asio::high_resolution_timer* timer,
+                          boost::asio::basic_waitable_timer<boost::chrono::high_resolution_clock>* timer,
                           const boost::system::error_code& error);
     void CancelRetries();
     void NetworkingThread();

--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -16,7 +16,6 @@
 #   undef MessageBox
 #endif
 
-
 /** Encapsulates the networking facilities of the client.  The client must
     execute its networking code in a separate thread from its main processing
     thread, for UI and networking responsiveness, and to process synchronous
@@ -117,7 +116,6 @@ public:
 private:
     void HandleException(const boost::system::system_error& error);
     void HandleConnection(boost::asio::ip::tcp::resolver::iterator* it,
-                          boost::asio::high_resolution_timer* timer,
                           const boost::system::error_code& error);
     void CancelRetries();
     void NetworkingThread();
@@ -138,7 +136,6 @@ private:
     MessageQueue                    m_incoming_messages; // accessed from multiple threads, but its interface is threadsafe
     std::list<Message>              m_outgoing_messages;
     bool                            m_connected;         // accessed from multiple threads
-    bool                            m_cancel_retries;
 
     Message::HeaderBuffer           m_incoming_header;
     Message                         m_incoming_message;

--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -16,6 +16,9 @@
 #   undef MessageBox
 #endif
 
+#ifndef FREEORION_MACOSX
+#include <chrono>
+#endif
 
 /** Encapsulates the networking facilities of the client.  The client must
     execute its networking code in a separate thread from its main processing
@@ -116,9 +119,16 @@ public:
 
 private:
     void HandleException(const boost::system::system_error& error);
+#ifndef FREEORION_MACOSX
     void HandleConnection(boost::asio::ip::tcp::resolver::iterator* it,
                           boost::asio::high_resolution_timer* timer,
                           const boost::system::error_code& error);
+#else
+    void HandleConnection(boost::asio::ip::tcp::resolver::iterator* it,
+                          boost::asio::high_resolution_timer* timer,
+                          std::chrono::milliseconds& backoff_time,
+                          const boost::system::error_code& error);
+#endif
     void CancelRetries();
     void NetworkingThread();
     void HandleMessageBodyRead(     boost::system::error_code error, std::size_t bytes_transferred);

--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -10,6 +10,7 @@
 // FreeOrion function names.
 #define NOMINMAX
 #include <boost/asio.hpp>
+#include <boost/asio/high_resolution_timer.hpp>
 #ifdef FREEORION_WIN32
 #   undef Message
 #   undef MessageBox
@@ -81,12 +82,12 @@ public:
     /** Connects to the server at \a ip_address.  On failure, repeated
         attempts will be made until \a timeout seconds has elapsed. */
     bool ConnectToServer(const std::string& ip_address,
-                         boost::posix_time::seconds timeout = boost::posix_time::seconds(5));
+                         boost::chrono::milliseconds timeout = boost::chrono::seconds(5));
 
     /** Connects to the server on the client's host.  On failure, repeated
         attempts will be made until \a timeout seconds has elapsed. */
-    bool ConnectToLocalHostServer(boost::posix_time::seconds timeout =
-                                  boost::posix_time::seconds(5));
+    bool ConnectToLocalHostServer(boost::chrono::milliseconds timeout =
+                                  boost::chrono::seconds(5));
 
     /** Sends \a message to the server.  This function actually just enqueues
         the message for sending and returns immediately. */
@@ -116,7 +117,7 @@ public:
 private:
     void HandleException(const boost::system::system_error& error);
     void HandleConnection(boost::asio::ip::tcp::resolver::iterator* it,
-                          boost::asio::deadline_timer* timer,
+                          boost::asio::high_resolution_timer* timer,
                           const boost::system::error_code& error);
     void CancelRetries();
     void NetworkingThread();

--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -119,7 +119,7 @@ public:
 private:
     void HandleException(const boost::system::system_error& error);
     void HandleConnection(boost::asio::ip::tcp::resolver::iterator* it,
-                          boost::asio::basic_waitable_timer<std::chrono::high_resolution_clock>* timer,
+                          boost::asio::high_resolution_timer* timer,
                           const boost::system::error_code& error);
     void CancelRetries();
     void NetworkingThread();

--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -82,13 +82,13 @@ public:
     /** Connects to the server at \a ip_address.  On failure, repeated
         attempts will be made until \a timeout seconds has elapsed. */
     bool ConnectToServer(const std::string& ip_address,
-                         std::chrono::milliseconds timeout = std::chrono::seconds(5),
+                         std::chrono::milliseconds timeout = std::chrono::seconds(10),
                          bool verbose = false);
 
     /** Connects to the server on the client's host.  On failure, repeated
         attempts will be made until \a timeout seconds has elapsed. */
     bool ConnectToLocalHostServer(std::chrono::milliseconds timeout =
-                                  std::chrono::seconds(5),
+                                  std::chrono::seconds(10),
                                   bool verbose = false);
 
     /** Sends \a message to the server.  This function actually just enqueues

--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -16,9 +16,6 @@
 #   undef MessageBox
 #endif
 
-#ifndef FREEORION_MACOSX
-#include <chrono>
-#endif
 
 /** Encapsulates the networking facilities of the client.  The client must
     execute its networking code in a separate thread from its main processing
@@ -119,16 +116,9 @@ public:
 
 private:
     void HandleException(const boost::system::system_error& error);
-#ifndef FREEORION_MACOSX
     void HandleConnection(boost::asio::ip::tcp::resolver::iterator* it,
                           boost::asio::high_resolution_timer* timer,
                           const boost::system::error_code& error);
-#else
-    void HandleConnection(boost::asio::ip::tcp::resolver::iterator* it,
-                          boost::asio::high_resolution_timer* timer,
-                          std::chrono::milliseconds& backoff_time,
-                          const boost::system::error_code& error);
-#endif
     void CancelRetries();
     void NetworkingThread();
     void HandleMessageBodyRead(     boost::system::error_code error, std::size_t bytes_transferred);

--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -82,14 +82,12 @@ public:
     /** Connects to the server at \a ip_address.  On failure, repeated
         attempts will be made until \a timeout seconds has elapsed. */
     bool ConnectToServer(const std::string& ip_address,
-                         std::chrono::milliseconds timeout = std::chrono::seconds(10),
-                         bool verbose = false);
+                         std::chrono::milliseconds timeout = std::chrono::seconds(10));
 
     /** Connects to the server on the client's host.  On failure, repeated
         attempts will be made until \a timeout seconds has elapsed. */
     bool ConnectToLocalHostServer(std::chrono::milliseconds timeout =
-                                  std::chrono::seconds(10),
-                                  bool verbose = false);
+                                  std::chrono::seconds(10));
 
     /** Sends \a message to the server.  This function actually just enqueues
         the message for sending and returns immediately. */

--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -82,13 +82,13 @@ public:
     /** Connects to the server at \a ip_address.  On failure, repeated
         attempts will be made until \a timeout seconds has elapsed. */
     bool ConnectToServer(const std::string& ip_address,
-                         boost::chrono::milliseconds timeout = boost::chrono::seconds(5),
+                         std::chrono::milliseconds timeout = std::chrono::seconds(5),
                          bool verbose = false);
 
     /** Connects to the server on the client's host.  On failure, repeated
         attempts will be made until \a timeout seconds has elapsed. */
-    bool ConnectToLocalHostServer(boost::chrono::milliseconds timeout =
-                                  boost::chrono::seconds(5),
+    bool ConnectToLocalHostServer(std::chrono::milliseconds timeout =
+                                  std::chrono::seconds(5),
                                   bool verbose = false);
 
     /** Sends \a message to the server.  This function actually just enqueues
@@ -119,7 +119,7 @@ public:
 private:
     void HandleException(const boost::system::system_error& error);
     void HandleConnection(boost::asio::ip::tcp::resolver::iterator* it,
-                          boost::asio::basic_waitable_timer<boost::chrono::high_resolution_clock>* timer,
+                          boost::asio::basic_waitable_timer<std::chrono::high_resolution_clock>* timer,
                           const boost::system::error_code& error);
     void CancelRetries();
     void NetworkingThread();

--- a/network/ServerNetworking.cpp
+++ b/network/ServerNetworking.cpp
@@ -208,9 +208,12 @@ void PlayerConnection::HandleMessageBodyRead(boost::system::error_code error,
     if (error) {
         if (error == boost::asio::error::eof ||
             error == boost::asio::error::connection_reset) {
+            ErrorLogger() << "PlayerConnection::HandleMessageBodyRead(): "
+                          << "error #"<<error.value()<<" \"" << error.message() << "\"";
             EventSignal(boost::bind(m_disconnected_callback, shared_from_this()));
         } else {
-            ErrorLogger() << "PlayerConnection::HandleMessageBodyRead(): error \"" << error << "\"";
+            ErrorLogger() << "PlayerConnection::HandleMessageBodyRead(): "
+                          << "error #"<<error.value()<<" \"" << error.message() << "\"";
         }
     } else {
         assert(static_cast<int>(bytes_transferred) <= m_incoming_header_buffer[4]);
@@ -250,6 +253,9 @@ void PlayerConnection::HandleMessageHeaderRead(boost::system::error_code error,
         if (m_new_connection) {
             // wait half a second if the first data read is an error; we
             // probably just need more setup time
+            ErrorLogger() << "PlayerConnection::HandleMessageHeaderRead(): "
+                          << "new connection error #" << error.value() << " \""
+                          << error.message() << "\"" << " waiting for 0.5s";
             std::this_thread::sleep_for(std::chrono::milliseconds(500));
         } else {
             if (error == boost::asio::error::eof ||

--- a/network/ServerNetworking.cpp
+++ b/network/ServerNetworking.cpp
@@ -9,6 +9,7 @@
 #include <boost/iterator/filter_iterator.hpp>
 #include <boost/thread/thread.hpp>
 
+#include <thread>
 
 using boost::asio::ip::tcp;
 using boost::asio::ip::udp;
@@ -249,7 +250,7 @@ void PlayerConnection::HandleMessageHeaderRead(boost::system::error_code error,
         if (m_new_connection) {
             // wait half a second if the first data read is an error; we
             // probably just need more setup time
-            boost::this_thread::sleep_for(boost::chrono::milliseconds(500));
+            std::this_thread::sleep_for(std::chrono::milliseconds(500));
         } else {
             if (error == boost::asio::error::eof ||
                 error == boost::asio::error::connection_reset) {


### PR DESCRIPTION
This PR are some tweaks to the network polling, that I meant to push earlier.

The PR switches some clocks from posix clock to boost::chrono, so that all clocks in freeorion are of one type.

The PR makes the network polling more reasonable, so that the polling interval is 10ms, about one refresh interval.

It might address bug #1371, but I have not tested it.

