### PR TITLE
Improve app termination correctness.

### DIFF
--- a/GG/GG/GUI.h
+++ b/GG/GG/GUI.h
@@ -411,6 +411,12 @@ public:
       * focus. bool parameter is true when gaining focus, and false otherwise.*/
      boost::signals2::signal<void (bool)>   FocusChangedSignal;
 
+    /** Emitted whenever the window manager requests the window close. */
+    boost::signals2::signal<void ()>    WindowClosingSignal;
+
+    /** Emitted whenever the app is requested to close. */
+    boost::signals2::signal<void ()>    AppQuittingSignal;
+
     /** \name Exceptions */ ///@{
     /** The base class for GUI exceptions. */
     GG_ABSTRACT_EXCEPTION(Exception);

--- a/GG/src/SDL/SDLGUI.cpp
+++ b/GG/src/SDL/SDLGUI.cpp
@@ -790,7 +790,7 @@ void SDLGUI::HandleSystemEvents()
                     SDL_DisableScreenSaver();
                     break;
                 case SDL_WINDOWEVENT_CLOSE:
-
+                    WindowClosingSignal();
                     break;
             }
             break;
@@ -807,7 +807,7 @@ void SDLGUI::HandleNonGGEvent(const SDL_Event& event)
 {
     switch (event.type) {
     case SDL_QUIT:
-        Exit(0);
+        AppQuittingSignal();
         break;
     }
 }

--- a/UI/InGameMenu.cpp
+++ b/UI/InGameMenu.cpp
@@ -188,7 +188,7 @@ void InGameMenu::Options() {
 }
 
 void InGameMenu::Exit() {
-    HumanClientApp::GetApp()->EndGame();
+    HumanClientApp::GetApp()->ResetToIntro();
     CloseClicked();
 }
 

--- a/UI/InGameMenu.cpp
+++ b/UI/InGameMenu.cpp
@@ -188,7 +188,7 @@ void InGameMenu::Options() {
 }
 
 void InGameMenu::Exit() {
-    HumanClientApp::GetApp()->ResetGame();
+    HumanClientApp::GetApp()->ResetToIntro();
     CloseClicked();
 }
 

--- a/UI/InGameMenu.cpp
+++ b/UI/InGameMenu.cpp
@@ -188,7 +188,7 @@ void InGameMenu::Options() {
 }
 
 void InGameMenu::Exit() {
-    HumanClientApp::GetApp()->ResetToIntro();
+    HumanClientApp::GetApp()->ResetGame();
     CloseClicked();
 }
 

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -153,7 +153,7 @@ void AIClientApp::Run() {
         HandlePythonAICrash();
     }
 
-    if (Networking().Connected()) {
+    if (Networking().IsConnected()) {
         DebugLogger() << "Acknowledge server shutdown message.";
         Networking().SendMessage(AIEndGameAcknowledgeMessage(Networking().PlayerID()));
         Networking().DisconnectFromServer();

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -158,7 +158,7 @@ void AIClientApp::Run() {
 
 void AIClientApp::ConnectToServer() {
     typedef boost::chrono::steady_clock Clock;
-    const boost::chrono::milliseconds SERVER_CONNECT_TIMEOUT(4500);
+    const boost::chrono::milliseconds SERVER_CONNECT_TIMEOUT(10000);
     const boost::chrono::milliseconds SERVER_STARTUP_POLLING_TIME(10);
 
     bool connected = false;

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -24,6 +24,7 @@
 #include <boost/chrono/chrono_io.hpp>
 
 #include <thread>
+#include <chrono>
 
 class CombatLogManager;
 CombatLogManager&   GetCombatLogManager();
@@ -157,9 +158,9 @@ void AIClientApp::Run() {
 }
 
 void AIClientApp::ConnectToServer() {
-    typedef boost::chrono::steady_clock Clock;
-    const boost::chrono::milliseconds SERVER_CONNECT_TIMEOUT(10000);
-    const boost::chrono::milliseconds SERVER_STARTUP_POLLING_TIME(10);
+    typedef std::chrono::steady_clock Clock;
+    const std::chrono::milliseconds SERVER_CONNECT_TIMEOUT(10000);
+    const std::chrono::milliseconds SERVER_STARTUP_POLLING_TIME(10);
 
     bool connected = false;
     Clock::time_point start_time = Clock::now();
@@ -171,11 +172,11 @@ void AIClientApp::ConnectToServer() {
 
     if (!connected) {
         ErrorLogger() << "Timed out.  Failed to connect to server in "
-                      << boost::chrono::duration_cast<boost::chrono::milliseconds>(connection_time) << ".";
+                      << std::chrono::duration_cast<std::chrono::milliseconds>(connection_time).count() << " ms.";
         Exit(1);
     }
     DebugLogger() << "Connecting to server took "
-                  << boost::chrono::duration_cast<boost::chrono::milliseconds>(connection_time) << ".";
+                  << std::chrono::duration_cast<std::chrono::milliseconds>(connection_time).count() << " ms.";
 }
 
 void AIClientApp::StartPythonAI() {

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -153,7 +153,11 @@ void AIClientApp::Run() {
         HandlePythonAICrash();
     }
 
-    Networking().DisconnectFromServer();
+    if (Networking().Connected()) {
+        DebugLogger() << "Acknowledge server shutdown message.";
+        Networking().SendMessage(AIEndGameAcknowledgeMessage(Networking().PlayerID()));
+        Networking().DisconnectFromServer();
+    }
 }
 
 void AIClientApp::ConnectToServer() {

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -94,7 +94,7 @@ AIClientApp::AIClientApp(const std::vector<std::string>& args) :
 AIClientApp::~AIClientApp() {
     Networking().DisconnectFromServer();
 
-    DebugLogger() << "AIClientApp exited cleanly for ai client " << PlayerName() << " id = " << PlayerID();
+    DebugLogger() << "AIClientApp exited cleanly for ai client " << PlayerName();
 }
 
 void AIClientApp::operator()()
@@ -142,7 +142,6 @@ void AIClientApp::Run() {
             } catch (boost::python::error_already_set) {
                 /* If the python interpreter is still running then keep
                    going, otherwise exit.*/
-                ErrorLogger() << " reached inner catch.";
                 m_AI->HandleErrorAlreadySet();
                 if (!m_AI->IsPythonRunning())
                     throw;
@@ -151,12 +150,9 @@ void AIClientApp::Run() {
     } catch (const NormalExitException&) {
         // intentionally empty.
     } catch (boost::python::error_already_set) {
-        ErrorLogger() << " reached outer catch.";
         HandlePythonAICrash();
-        ErrorLogger() << "exit error already set ";
     }
 
-    ErrorLogger() << "try disconnect from server ";
     Networking().DisconnectFromServer();
 }
 
@@ -179,10 +175,9 @@ void AIClientApp::HandlePythonAICrash() {
     // know the AI's PlayerName.
     std::stringstream err_msg;
     err_msg << "AIClientApp failed due to error in python AI code for " << PlayerName() << ".  Exiting Soon.";
-    ErrorLogger() << err_msg.str() << " id = " << PlayerID() << " is connected = " << Networking().IsConnected();
+    ErrorLogger() << err_msg.str() << " id = " << PlayerID();
     Networking().SendMessage(
         ErrorMessage(PlayerID(), str(FlexibleFormat(UserString("ERROR_PYTHON_AI_CRASHED")) % PlayerName()) , true));
-    ErrorLogger() << "exit handle python ai crash ";
 }
 
 

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -92,8 +92,7 @@ AIClientApp::AIClientApp(const std::vector<std::string>& args) :
 }
 
 AIClientApp::~AIClientApp() {
-    if (Networking().Connected())
-        Networking().DisconnectFromServer();
+    Networking().DisconnectFromServer();
 
     DebugLogger() << "Shut down " + PlayerName() + " ai client.";
 }
@@ -130,7 +129,7 @@ void AIClientApp::Run() {
         while (1) {
             try {
 
-                if (!Networking().Connected())
+                if (!Networking().IsRxConnected())
                     break;
                 if (Networking().MessageAvailable()) {
                     Message msg;

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -153,11 +153,7 @@ void AIClientApp::Run() {
         HandlePythonAICrash();
     }
 
-    if (Networking().IsConnected()) {
-        DebugLogger() << "Acknowledge server shutdown message.";
-        Networking().SendMessage(AIEndGameAcknowledgeMessage(Networking().PlayerID()));
-        Networking().DisconnectFromServer();
-    }
+    Networking().DisconnectFromServer();
 }
 
 void AIClientApp::ConnectToServer() {
@@ -345,6 +341,8 @@ void AIClientApp::HandleMessage(const Message& msg) {
 
     case Message::END_GAME: {
         DebugLogger() << "Message::END_GAME : Exiting";
+        DebugLogger() << "Acknowledge server shutdown message.";
+        Networking().SendMessage(AIEndGameAcknowledgeMessage(Networking().PlayerID()));
         Exit(0);
         break;
     }

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -163,17 +163,19 @@ void AIClientApp::ConnectToServer() {
 
     bool connected = false;
     Clock::time_point start_time = Clock::now();
-    boost::chrono::milliseconds connection_time(0);
+    Clock::duration connection_time{0};
     while (!connected && (connection_time < SERVER_CONNECT_TIMEOUT )) {
         connected = Networking().ConnectToLocalHostServer(SERVER_STARTUP_POLLING_TIME);
-        connection_time = boost::chrono::duration_cast<boost::chrono::milliseconds>(Clock::now() - start_time);
+        connection_time = Clock::now() - start_time;
     }
 
     if (!connected) {
-        ErrorLogger() << "AIClientApp::Run : Failed to connect to localhost server after " << connection_time << ".  Exiting.";
+        ErrorLogger() << "Timed out.  Failed to connect to server in "
+                      << boost::chrono::duration_cast<boost::chrono::milliseconds>(connection_time) << ".";
         Exit(1);
     }
-    DebugLogger() << "AI connected to local server took " << connection_time << ".";
+    DebugLogger() << "Connecting to server took "
+                  << boost::chrono::duration_cast<boost::chrono::milliseconds>(connection_time) << ".";
 }
 
 void AIClientApp::StartPythonAI() {

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -158,25 +158,8 @@ void AIClientApp::Run() {
 }
 
 void AIClientApp::ConnectToServer() {
-    typedef std::chrono::steady_clock Clock;
-    const std::chrono::milliseconds SERVER_CONNECT_TIMEOUT(10000);
-    const std::chrono::milliseconds SERVER_STARTUP_POLLING_TIME(10);
-
-    bool connected = false;
-    Clock::time_point start_time = Clock::now();
-    Clock::duration connection_time{0};
-    while (!connected && (connection_time < SERVER_CONNECT_TIMEOUT )) {
-        connected = Networking().ConnectToLocalHostServer(SERVER_STARTUP_POLLING_TIME);
-        connection_time = Clock::now() - start_time;
-    }
-
-    if (!connected) {
-        ErrorLogger() << "Timed out.  Failed to connect to server in "
-                      << std::chrono::duration_cast<std::chrono::milliseconds>(connection_time).count() << " ms.";
+    if (!Networking().ConnectToLocalHostServer())
         Exit(1);
-    }
-    DebugLogger() << "Connecting to server took "
-                  << std::chrono::duration_cast<std::chrono::milliseconds>(connection_time).count() << " ms.";
 }
 
 void AIClientApp::StartPythonAI() {

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -94,7 +94,7 @@ AIClientApp::AIClientApp(const std::vector<std::string>& args) :
 AIClientApp::~AIClientApp() {
     Networking().DisconnectFromServer();
 
-    DebugLogger() << "Shut down " + PlayerName() + " ai client.";
+    DebugLogger() << "AIClientApp exited cleanly for ai client " << PlayerName();
 }
 
 void AIClientApp::operator()()

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -202,7 +202,7 @@ void AIClientApp::HandleMessage(const Message& msg) {
                 ErrorLogger() << "AIClientApp::HandleMessage for HOST_ID : Couldn't parese message text: " << text;
             }
         }
-        m_networking.SetHostPlayerID(host_id);
+        m_networking->SetHostPlayerID(host_id);
         break;
     }
 
@@ -210,7 +210,7 @@ void AIClientApp::HandleMessage(const Message& msg) {
         if (msg.SendingPlayer() == Networking::INVALID_PLAYER_ID) {
             if (PlayerID() == Networking::INVALID_PLAYER_ID) {
                 DebugLogger() << "AIClientApp::HandleMessage : Received JOIN_GAME acknowledgement";
-                m_networking.SetPlayerID(msg.ReceivingPlayer());
+                m_networking->SetPlayerID(msg.ReceivingPlayer());
             } else {
                 ErrorLogger() << "AIClientApp::HandleMessage : Received erroneous JOIN_GAME acknowledgement when already in a game";
             }

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -94,7 +94,7 @@ AIClientApp::AIClientApp(const std::vector<std::string>& args) :
 AIClientApp::~AIClientApp() {
     Networking().DisconnectFromServer();
 
-    DebugLogger() << "AIClientApp exited cleanly for ai client " << PlayerName();
+    DebugLogger() << "AIClientApp exited cleanly for ai client " << PlayerName() << " id = " << PlayerID();
 }
 
 void AIClientApp::operator()()
@@ -142,6 +142,7 @@ void AIClientApp::Run() {
             } catch (boost::python::error_already_set) {
                 /* If the python interpreter is still running then keep
                    going, otherwise exit.*/
+                ErrorLogger() << " reached inner catch.";
                 m_AI->HandleErrorAlreadySet();
                 if (!m_AI->IsPythonRunning())
                     throw;
@@ -150,9 +151,12 @@ void AIClientApp::Run() {
     } catch (const NormalExitException&) {
         // intentionally empty.
     } catch (boost::python::error_already_set) {
+        ErrorLogger() << " reached outer catch.";
         HandlePythonAICrash();
+        ErrorLogger() << "exit error already set ";
     }
 
+    ErrorLogger() << "try disconnect from server ";
     Networking().DisconnectFromServer();
 }
 
@@ -175,9 +179,10 @@ void AIClientApp::HandlePythonAICrash() {
     // know the AI's PlayerName.
     std::stringstream err_msg;
     err_msg << "AIClientApp failed due to error in python AI code for " << PlayerName() << ".  Exiting Soon.";
-    ErrorLogger() << err_msg.str() << " id = " << PlayerID();
+    ErrorLogger() << err_msg.str() << " id = " << PlayerID() << " is connected = " << Networking().IsConnected();
     Networking().SendMessage(
         ErrorMessage(PlayerID(), str(FlexibleFormat(UserString("ERROR_PYTHON_AI_CRASHED")) % PlayerName()) , true));
+    ErrorLogger() << "exit handle python ai crash ";
 }
 
 

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -178,7 +178,6 @@ void AIClientApp::HandlePythonAICrash() {
     ErrorLogger() << err_msg.str() << " id = " << PlayerID();
     Networking().SendMessage(
         ErrorMessage(PlayerID(), str(FlexibleFormat(UserString("ERROR_PYTHON_AI_CRASHED")) % PlayerName()) , true));
-   std::this_thread::sleep_for(std::chrono::milliseconds(500));
 }
 
 

--- a/client/AI/camain.cpp
+++ b/client/AI/camain.cpp
@@ -93,7 +93,7 @@ int wmain(int argc, wchar_t* argv[], wchar_t* envp[]) {
         return 1;
     }
 #endif
-
+    DebugLogger() << "AI client main exited cleanly.";
     return 0;
 }
 

--- a/client/ClientApp.cpp
+++ b/client/ClientApp.cpp
@@ -15,9 +15,9 @@
 ClientApp::ClientApp() :
     IApp(),
     m_universe(),
+    m_networking(std::make_shared<ClientNetworking>()),
     m_empire_id(ALL_EMPIRES),
-    m_current_turn(INVALID_GAME_TURN),
-    m_networking(std::make_shared<ClientNetworking>())
+    m_current_turn(INVALID_GAME_TURN)
 {}
 
 ClientApp::~ClientApp()

--- a/client/ClientApp.cpp
+++ b/client/ClientApp.cpp
@@ -16,14 +16,15 @@ ClientApp::ClientApp() :
     IApp(),
     m_universe(),
     m_empire_id(ALL_EMPIRES),
-    m_current_turn(INVALID_GAME_TURN)
+    m_current_turn(INVALID_GAME_TURN),
+    m_networking(std::make_shared<ClientNetworking>())
 {}
 
 ClientApp::~ClientApp()
 {}
 
 int ClientApp::PlayerID() const
-{ return m_networking.PlayerID(); }
+{ return m_networking->PlayerID(); }
 
 int ClientApp::EmpireID() const
 { return m_empire_id; }
@@ -72,7 +73,7 @@ const OrderSet& ClientApp::Orders() const
 { return m_orders; }
 
 const ClientNetworking& ClientApp::Networking() const
-{ return m_networking; }
+{ return *m_networking; }
 
 int ClientApp::EmpirePlayerID(int empire_id) const {
     for (const std::map<int, PlayerInfo>::value_type& entry : m_player_info)
@@ -94,7 +95,7 @@ Networking::ClientType ClientApp::GetPlayerClientType(int player_id) const {
 }
 
 Networking::ClientType ClientApp::GetClientType() const
-{ return GetPlayerClientType(m_networking.PlayerID()); }
+{ return GetPlayerClientType(m_networking->PlayerID()); }
 
 const std::map<int, PlayerInfo>& ClientApp::Players() const
 { return m_player_info; }
@@ -115,7 +116,7 @@ void ClientApp::SetPlayerStatus(int player_id, Message::PlayerStatus status) {
 }
 
 void ClientApp::StartTurn() {
-    m_networking.SendMessage(TurnOrdersMessage(m_networking.PlayerID(), m_orders));
+    m_networking->SendMessage(TurnOrdersMessage(m_networking->PlayerID(), m_orders));
     m_orders.Reset();
 }
 
@@ -123,7 +124,7 @@ OrderSet& ClientApp::Orders()
 { return m_orders; }
 
 ClientNetworking& ClientApp::Networking()
-{ return m_networking; }
+{ return *m_networking; }
 
 std::string ClientApp::GetVisibleObjectName(std::shared_ptr<const UniverseObject> object) {
     if (!object) {
@@ -140,7 +141,7 @@ std::string ClientApp::GetVisibleObjectName(std::shared_ptr<const UniverseObject
 
 int ClientApp::GetNewObjectID() {
     Message msg;
-    m_networking.SendSynchronousMessage(RequestNewObjectIDMessage(m_networking.PlayerID()), msg);
+    m_networking->SendSynchronousMessage(RequestNewObjectIDMessage(m_networking->PlayerID()), msg);
     std::string text = msg.Text();
     if (text.empty())
         throw std::runtime_error("ClientApp::GetNewObjectID() didn't get a new object ID");
@@ -149,7 +150,7 @@ int ClientApp::GetNewObjectID() {
 
 int ClientApp::GetNewDesignID() {
     Message msg;
-    m_networking.SendSynchronousMessage(RequestNewDesignIDMessage(m_networking.PlayerID()), msg);
+    m_networking->SendSynchronousMessage(RequestNewDesignIDMessage(m_networking->PlayerID()), msg);
     std::string text = msg.Text();
     if (text.empty())
         throw std::runtime_error("ClientApp::GetNewDesignID() didn't get a new design ID");

--- a/client/ClientApp.h
+++ b/client/ClientApp.h
@@ -257,7 +257,7 @@ protected:
     EmpireManager               m_empires;
     SupplyManager               m_supply_manager;
     OrderSet                    m_orders;
-    ClientNetworking            m_networking;
+    std::shared_ptr<ClientNetworking> m_networking;
     int                         m_empire_id;
     int                         m_current_turn;
     /** Indexed by player id, contains info about all players in the game */

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -1156,7 +1156,7 @@ void HumanClientApp::QuitGame() {
     }
 }
 
-void HumanClientApp::ResetGame() {
+void HumanClientApp::ResetGame(bool suppress_FSM_reset /*= false*/) {
     QuitGame();
 
     m_networking->SetPlayerID(Networking::INVALID_PLAYER_ID);
@@ -1169,7 +1169,8 @@ void HumanClientApp::ResetGame() {
     m_orders.Reset();
     GetCombatLogManager().Clear();
 
-    m_fsm->process_event(ResetToIntroMenu());
+    if (!suppress_FSM_reset)
+        m_fsm->process_event(ResetToIntroMenu());
 }
 
 void HumanClientApp::InitAutoTurns(int auto_turns) {

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -448,8 +448,12 @@ void HumanClientApp::NewSinglePlayerGame(bool quickstart) {
 
     bool failed = false;
     Clock::time_point start_time = Clock::now();
+    Clock::duration connection_time{0};
     while (!m_networking.ConnectToLocalHostServer(SERVER_STARTUP_POLLING_TIME)) {
-        if (SERVER_CONNECT_TIMEOUT < Clock::now() - start_time) {
+        connection_time = Clock::now() - start_time;
+        if (SERVER_CONNECT_TIMEOUT < connection_time) {
+            ErrorLogger() << "Timed out.  Failed to connect to server in "
+                          << boost::chrono::duration_cast<boost::chrono::milliseconds>(connection_time) << ".";
             ClientUI::MessageBox(UserString("ERR_CONNECT_TIMED_OUT"), true);
             failed = true;
             break;
@@ -661,18 +665,22 @@ void HumanClientApp::LoadSinglePlayerGame(std::string filename/* = ""*/) {
 
     DebugLogger() << "HumanClientApp::LoadSinglePlayerGame() Connecting to server";
     Clock::time_point start_time = Clock::now();
+    Clock::duration connection_time{0};
     while (!m_networking.ConnectToLocalHostServer(SERVER_STARTUP_POLLING_TIME)) {
-        if (SERVER_CONNECT_TIMEOUT < Clock::now() - start_time) {
-            ErrorLogger() << "HumanClientApp::LoadSinglePlayerGame() server connecting timed out";
+        connection_time = Clock::now() - start_time;
+        if (SERVER_CONNECT_TIMEOUT < connection_time) {
+            ErrorLogger() << "Timed out.  Failed to connect to server in "
+                          << boost::chrono::duration_cast<boost::chrono::milliseconds>(connection_time) << ".";
             ClientUI::MessageBox(UserString("ERR_CONNECT_TIMED_OUT"), true);
             KillServer();
             return;
         }
     }
 
-    DebugLogger() << "HumanClientApp::LoadSinglePlayerGame() Connected to server";
-
     m_connected = true;
+    DebugLogger() << "HumanClientApp::LoadSinglePlayerGame : Connecting to server took "
+                      << boost::chrono::duration_cast<boost::chrono::milliseconds>(connection_time) << ".";
+
     m_networking.SetPlayerID(Networking::INVALID_PLAYER_ID);
     m_networking.SetHostPlayerID(Networking::INVALID_PLAYER_ID);
     SetEmpireID(ALL_EMPIRES);
@@ -701,15 +709,20 @@ void HumanClientApp::RequestSavePreviews(const std::string& directory, PreviewIn
 
         DebugLogger() << "HumanClientApp::RequestSavePreviews Connecting to server";
         Clock::time_point start_time = Clock::now();
+        Clock::duration connection_time{0};
         while (!m_networking.ConnectToLocalHostServer(SERVER_STARTUP_POLLING_TIME)) {
-            if (SERVER_CONNECT_TIMEOUT < Clock::now() - start_time) {
-                ErrorLogger() << "HumanClientApp::LoadSinglePlayerGame() server connecting timed out";
+            connection_time = Clock::now() - start_time;
+            if (SERVER_CONNECT_TIMEOUT < connection_time) {
+                ErrorLogger() << "Timed out.  Failed to connect to server in "
+                              << boost::chrono::duration_cast<boost::chrono::milliseconds>(connection_time) << ".";
                 ClientUI::MessageBox(UserString("ERR_CONNECT_TIMED_OUT"), true);
                 KillServer();
                 return;
             }
         }
         m_connected = true;
+        DebugLogger() << "HumanClientApp::RequestSavePreviews : Connecting to server took "
+                      << boost::chrono::duration_cast<boost::chrono::milliseconds>(connection_time) << ".";
     }
     DebugLogger() << "HumanClientApp::RequestSavePreviews Requesting previews for " << generic_directory;
     Message response;

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -1109,6 +1109,14 @@ void HumanClientApp::QuitGame() {
     DebugLogger() << "HumanClientApp::EndGame";
     m_game_started = false;
 
+    if (m_server_process.Empty()) {
+        if (m_networking->IsTxConnected()) {
+            WarnLogger() << "Disconnecting from server that is already killed.";
+            m_networking->DisconnectFromServer();
+        }
+        return;
+    }
+
     if (m_networking->IsTxConnected()) {
         DebugLogger() << "HumanClientApp::EndGame Sending server shutdown message.";
         m_networking->SendMessage(ShutdownServerMessage(m_networking->PlayerID()));

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -45,6 +45,9 @@
 #include <boost/algorithm/string.hpp>
 #include <boost/chrono/chrono_io.hpp>
 
+#include <chrono>
+#include <thread>
+
 #include <sstream>
 
 
@@ -84,9 +87,9 @@ void SigHandler(int sig) {
 #endif //ENABLE_CRASH_BACKTRACE
 
 namespace {
-    typedef boost::chrono::steady_clock Clock;
-    const boost::chrono::milliseconds SERVER_CONNECT_TIMEOUT(10000);
-    const boost::chrono::milliseconds SERVER_STARTUP_POLLING_TIME(10);
+    typedef std::chrono::steady_clock Clock;
+    const std::chrono::milliseconds SERVER_CONNECT_TIMEOUT(10000);
+    const std::chrono::milliseconds SERVER_STARTUP_POLLING_TIME(10);
 
     const bool          INSTRUMENT_MESSAGE_HANDLING = false;
 
@@ -452,7 +455,7 @@ void HumanClientApp::NewSinglePlayerGame(bool quickstart) {
         connection_time = Clock::now() - start_time;
         if (SERVER_CONNECT_TIMEOUT < connection_time) {
             ErrorLogger() << "Timed out.  Failed to connect to server in "
-                          << boost::chrono::duration_cast<boost::chrono::milliseconds>(connection_time) << ".";
+                          << std::chrono::duration_cast<std::chrono::milliseconds>(connection_time).count() << " ms.";
             ClientUI::MessageBox(UserString("ERR_CONNECT_TIMED_OUT"), true);
             KillServer();
             return;
@@ -461,7 +464,7 @@ void HumanClientApp::NewSinglePlayerGame(bool quickstart) {
 
     m_connected = true;
     DebugLogger() << "HumanClientApp::NewSinglePlayerGame : Connecting to server took "
-                  << boost::chrono::duration_cast<boost::chrono::milliseconds>(connection_time) << ".";
+                  << std::chrono::duration_cast<std::chrono::milliseconds>(connection_time).count() << " ms.";
 
     if (quickstart || ended_with_ok) {
 
@@ -545,7 +548,7 @@ void HumanClientApp::NewSinglePlayerGame(bool quickstart) {
         ErrorLogger() << "HumanClientApp::NewSinglePlayerGame failed to start new game, killing server.";
         DebugLogger() << "HumanClientApp::NewSinglePlayerGame Sending server shutdown message.";
         m_networking.SendMessage(ShutdownServerMessage(m_networking.PlayerID()));
-        boost::this_thread::sleep_for(boost::chrono::seconds(1));
+        std::this_thread::sleep_for(std::chrono::seconds(1));
         m_networking.DisconnectFromServer();
         if (!m_networking.Connected())
             DebugLogger() << "HumanClientApp::NewSinglePlayerGame Disconnected from server.";
@@ -648,7 +651,7 @@ void HumanClientApp::LoadSinglePlayerGame(std::string filename/* = ""*/) {
     if (m_game_started) {
         EndGame();
         // delay to make sure old game is fully cleaned up before attempting to start a new one
-        boost::this_thread::sleep_for(boost::chrono::seconds(3));
+        std::this_thread::sleep_for(std::chrono::seconds(3));
     } else {
         DebugLogger() << "HumanClientApp::LoadSinglePlayerGame() not already in a game, so don't need to end it";
     }
@@ -669,7 +672,7 @@ void HumanClientApp::LoadSinglePlayerGame(std::string filename/* = ""*/) {
         connection_time = Clock::now() - start_time;
         if (SERVER_CONNECT_TIMEOUT < connection_time) {
             ErrorLogger() << "Timed out.  Failed to connect to server in "
-                          << boost::chrono::duration_cast<boost::chrono::milliseconds>(connection_time) << ".";
+                          << std::chrono::duration_cast<std::chrono::milliseconds>(connection_time).count() << " ms.";
             ClientUI::MessageBox(UserString("ERR_CONNECT_TIMED_OUT"), true);
             KillServer();
             return;
@@ -678,7 +681,7 @@ void HumanClientApp::LoadSinglePlayerGame(std::string filename/* = ""*/) {
 
     m_connected = true;
     DebugLogger() << "HumanClientApp::LoadSinglePlayerGame : Connecting to server took "
-                      << boost::chrono::duration_cast<boost::chrono::milliseconds>(connection_time) << ".";
+                  << std::chrono::duration_cast<std::chrono::milliseconds>(connection_time).count() << " ms.";
 
     m_networking.SetPlayerID(Networking::INVALID_PLAYER_ID);
     m_networking.SetHostPlayerID(Networking::INVALID_PLAYER_ID);
@@ -713,7 +716,7 @@ void HumanClientApp::RequestSavePreviews(const std::string& directory, PreviewIn
             connection_time = Clock::now() - start_time;
             if (SERVER_CONNECT_TIMEOUT < connection_time) {
                 ErrorLogger() << "Timed out.  Failed to connect to server in "
-                              << boost::chrono::duration_cast<boost::chrono::milliseconds>(connection_time) << ".";
+                              << std::chrono::duration_cast<std::chrono::milliseconds>(connection_time).count() << " ms.";
                 ClientUI::MessageBox(UserString("ERR_CONNECT_TIMED_OUT"), true);
                 KillServer();
                 return;
@@ -721,7 +724,7 @@ void HumanClientApp::RequestSavePreviews(const std::string& directory, PreviewIn
         }
         m_connected = true;
         DebugLogger() << "HumanClientApp::RequestSavePreviews : Connecting to server took "
-                      << boost::chrono::duration_cast<boost::chrono::milliseconds>(connection_time) << ".";
+                      << std::chrono::duration_cast<std::chrono::milliseconds>(connection_time).count() << " ms.";
     }
     DebugLogger() << "HumanClientApp::RequestSavePreviews Requesting previews for " << generic_directory;
     Message response;
@@ -1164,7 +1167,7 @@ void HumanClientApp::EndGame(bool suppress_FSM_reset) {
     if (m_networking.Connected()) {
         DebugLogger() << "HumanClientApp::EndGame Sending server shutdown message.";
         m_networking.SendMessage(ShutdownServerMessage(m_networking.PlayerID()));
-        boost::this_thread::sleep_for(boost::chrono::seconds(1));
+        std::this_thread::sleep_for(std::chrono::seconds(1));
         m_networking.DisconnectFromServer();
         if (!m_networking.Connected())
             DebugLogger() << "HumanClientApp::EndGame Disconnected from server.";

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -1140,9 +1140,13 @@ void HumanClientApp::QuitGame() {
             std::this_thread::sleep_for(POLLING_INTERVAL);
         }
 
-        if (m_networking->IsConnected()) {
-            m_networking->DisconnectFromServer();
+        if (!m_networking->IsConnected()) {
+            // Treat disconnection as acknowledgement of shutdown and free the process
+            if (!m_server_process.Empty())
+                m_server_process.Free();
+        } else {
             ErrorLogger() << "HumanClientApp::EndGame Unexpectedly still connected to server...?";
+            m_networking->DisconnectFromServer();
         }
     }
 

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -321,8 +321,7 @@ void HumanClientApp::ConnectKeyboardAcceleratorSignals() {
 }
 
 HumanClientApp::~HumanClientApp() {
-    if (m_networking.Connected())
-        m_networking.DisconnectFromServer();
+    m_networking.DisconnectFromServer();
     m_server_process.RequestTermination();
 }
 
@@ -536,7 +535,8 @@ void HumanClientApp::NewSinglePlayerGame(bool quickstart) {
         m_networking.SendMessage(ShutdownServerMessage(m_networking.PlayerID()));
         std::this_thread::sleep_for(std::chrono::seconds(1));
         m_networking.DisconnectFromServer();
-        if (!m_networking.Connected())
+        // TODO refactor this.  disconnect is asynchronous and might not have taken effect by now.
+        if (!m_networking.IsConnected())
             DebugLogger() << "HumanClientApp::NewSinglePlayerGame Disconnected from server.";
         else
             ErrorLogger() << "HumanClientApp::NewSinglePlayerGame Unexpectedly still connected to server...?";
@@ -545,7 +545,7 @@ void HumanClientApp::NewSinglePlayerGame(bool quickstart) {
 }
 
 void HumanClientApp::MultiPlayerGame() {
-    if (m_networking.Connected()) {
+    if (m_networking.IsConnected()) {
         ErrorLogger() << "HumanClientApp::MultiPlayerGame aborting because already connected to a server";
         return;
     }
@@ -677,7 +677,7 @@ void HumanClientApp::RequestSavePreviews(const std::string& directory, PreviewIn
     DebugLogger() << "HumanClientApp::RequestSavePreviews directory: " << directory << " valid UTF-8: " << utf8::is_valid(directory.begin(), directory.end());
 
     std::string  generic_directory = directory;//PathString(fs::path(directory));
-    if (!m_networking.Connected()) {
+    if (!m_networking.IsConnected()) {
         DebugLogger() << "HumanClientApp::RequestSavePreviews: No game running. Start a server for savegame queries.";
 
         m_single_player_game = true;
@@ -804,7 +804,7 @@ void HumanClientApp::HandleSystemEvents() {
     } catch (const utf8::invalid_utf8& e) {
         ErrorLogger() << "UTF-8 error handling system event: " << e.what();
     }
-    if (m_connected && !m_networking.Connected()) {
+    if (m_connected && !m_networking.IsConnected()) {
         m_connected = false;
         DisconnectedFromServer();
     } else if (m_networking.MessageAvailable()) {
@@ -1129,12 +1129,13 @@ void HumanClientApp::EndGame(bool suppress_FSM_reset) {
     DebugLogger() << "HumanClientApp::EndGame";
     m_game_started = false;
 
-    if (m_networking.Connected()) {
+    if (m_networking.IsTxConnected()) {
         DebugLogger() << "HumanClientApp::EndGame Sending server shutdown message.";
         m_networking.SendMessage(ShutdownServerMessage(m_networking.PlayerID()));
         std::this_thread::sleep_for(std::chrono::seconds(1));
         m_networking.DisconnectFromServer();
-        if (!m_networking.Connected())
+        // TODO fix this.  disconnect is asynchronous and may not have acted by now.
+        if (!m_networking.IsConnected())
             DebugLogger() << "HumanClientApp::EndGame Disconnected from server.";
         else
             ErrorLogger() << "HumanClientApp::EndGame Unexpectedly still connected to server...?";

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -530,15 +530,6 @@ void HumanClientApp::NewSinglePlayerGame(bool quickstart) {
         m_fsm->process_event(HostSPGameRequested());
     } else {
         ErrorLogger() << "HumanClientApp::NewSinglePlayerGame failed to start new game, killing server.";
-        DebugLogger() << "HumanClientApp::NewSinglePlayerGame Sending server shutdown message.";
-        m_networking->SendMessage(ShutdownServerMessage(m_networking->PlayerID()));
-        std::this_thread::sleep_for(std::chrono::seconds(1));
-        m_networking->DisconnectFromServer();
-        // TODO refactor this.  disconnect is asynchronous and might not have taken effect by now.
-        if (!m_networking->IsConnected())
-            DebugLogger() << "HumanClientApp::NewSinglePlayerGame Disconnected from server.";
-        else
-            ErrorLogger() << "HumanClientApp::NewSinglePlayerGame Unexpectedly still connected to server...?";
         KillServer();
     }
 }

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -321,7 +321,7 @@ void HumanClientApp::ConnectKeyboardAcceleratorSignals() {
 }
 
 HumanClientApp::~HumanClientApp() {
-    m_networking.DisconnectFromServer();
+    m_networking->DisconnectFromServer();
     m_server_process.RequestTermination();
 }
 
@@ -412,16 +412,16 @@ void HumanClientApp::StartServer() {
 
 void HumanClientApp::FreeServer() {
     m_server_process.Free();
-    m_networking.SetPlayerID(Networking::INVALID_PLAYER_ID);
-    m_networking.SetHostPlayerID(Networking::INVALID_PLAYER_ID);
+    m_networking->SetPlayerID(Networking::INVALID_PLAYER_ID);
+    m_networking->SetHostPlayerID(Networking::INVALID_PLAYER_ID);
     SetEmpireID(ALL_EMPIRES);
 }
 
 void HumanClientApp::KillServer() {
     DebugLogger() << "HumanClientApp::KillServer()";
     m_server_process.Kill();
-    m_networking.SetPlayerID(Networking::INVALID_PLAYER_ID);
-    m_networking.SetHostPlayerID(Networking::INVALID_PLAYER_ID);
+    m_networking->SetPlayerID(Networking::INVALID_PLAYER_ID);
+    m_networking->SetHostPlayerID(Networking::INVALID_PLAYER_ID);
     SetEmpireID(ALL_EMPIRES);
 }
 
@@ -444,7 +444,7 @@ void HumanClientApp::NewSinglePlayerGame(bool quickstart) {
         ended_with_ok = galaxy_wnd.EndedWithOk();
     }
 
-    m_connected = m_networking.ConnectToLocalHostServer();
+    m_connected = m_networking->ConnectToLocalHostServer();
     if (!m_connected) {
         ClientUI::MessageBox(UserString("ERR_CONNECT_TIMED_OUT"), true);
         KillServer();
@@ -527,16 +527,16 @@ void HumanClientApp::NewSinglePlayerGame(bool quickstart) {
             setup_data.m_players.push_back(ai_setup_data);
         }
 
-        m_networking.SendMessage(HostSPGameMessage(setup_data));
+        m_networking->SendMessage(HostSPGameMessage(setup_data));
         m_fsm->process_event(HostSPGameRequested());
     } else {
         ErrorLogger() << "HumanClientApp::NewSinglePlayerGame failed to start new game, killing server.";
         DebugLogger() << "HumanClientApp::NewSinglePlayerGame Sending server shutdown message.";
-        m_networking.SendMessage(ShutdownServerMessage(m_networking.PlayerID()));
+        m_networking->SendMessage(ShutdownServerMessage(m_networking->PlayerID()));
         std::this_thread::sleep_for(std::chrono::seconds(1));
-        m_networking.DisconnectFromServer();
+        m_networking->DisconnectFromServer();
         // TODO refactor this.  disconnect is asynchronous and might not have taken effect by now.
-        if (!m_networking.IsConnected())
+        if (!m_networking->IsConnected())
             DebugLogger() << "HumanClientApp::NewSinglePlayerGame Disconnected from server.";
         else
             ErrorLogger() << "HumanClientApp::NewSinglePlayerGame Unexpectedly still connected to server...?";
@@ -545,7 +545,7 @@ void HumanClientApp::NewSinglePlayerGame(bool quickstart) {
 }
 
 void HumanClientApp::MultiPlayerGame() {
-    if (m_networking.IsConnected()) {
+    if (m_networking->IsConnected()) {
         ErrorLogger() << "HumanClientApp::MultiPlayerGame aborting because already connected to a server";
         return;
     }
@@ -575,7 +575,7 @@ void HumanClientApp::MultiPlayerGame() {
     }
 
 
-    m_connected = m_networking.ConnectToServer(server_name);
+    m_connected = m_networking->ConnectToServer(server_name);
     if (!m_connected) {
         ClientUI::MessageBox(UserString("ERR_CONNECT_TIMED_OUT"), true);
         if (server_connect_wnd.Result().second == "HOST GAME SELECTED")
@@ -584,10 +584,10 @@ void HumanClientApp::MultiPlayerGame() {
     }
 
     if (server_connect_wnd.Result().second == "HOST GAME SELECTED") {
-        m_networking.SendMessage(HostMPGameMessage(server_connect_wnd.Result().first));
+        m_networking->SendMessage(HostMPGameMessage(server_connect_wnd.Result().first));
         m_fsm->process_event(HostMPGameRequested());
     } else {
-        m_networking.SendMessage(JoinGameMessage(server_connect_wnd.Result().first, Networking::CLIENT_TYPE_HUMAN_PLAYER));
+        m_networking->SendMessage(JoinGameMessage(server_connect_wnd.Result().first, Networking::CLIENT_TYPE_HUMAN_PLAYER));
         m_fsm->process_event(JoinMPGameRequested());
     }
 }
@@ -600,7 +600,7 @@ void HumanClientApp::CancelMultiplayerGameFromLobby()
 
 void HumanClientApp::SaveGame(const std::string& filename) {
     Message response_msg;
-    m_networking.SendMessage(HostSaveGameInitiateMessage(PlayerID(), filename));
+    m_networking->SendMessage(HostSaveGameInitiateMessage(PlayerID(), filename));
     DebugLogger() << "HumanClientApp::SaveGame sent save initiate message to server...";
 }
 
@@ -650,15 +650,15 @@ void HumanClientApp::LoadSinglePlayerGame(std::string filename/* = ""*/) {
     }
 
     DebugLogger() << "HumanClientApp::LoadSinglePlayerGame() Connecting to server";
-    m_connected = m_networking.ConnectToLocalHostServer();
+    m_connected = m_networking->ConnectToLocalHostServer();
     if (!m_connected) {
         ClientUI::MessageBox(UserString("ERR_CONNECT_TIMED_OUT"), true);
         KillServer();
         return;
     }
 
-    m_networking.SetPlayerID(Networking::INVALID_PLAYER_ID);
-    m_networking.SetHostPlayerID(Networking::INVALID_PLAYER_ID);
+    m_networking->SetPlayerID(Networking::INVALID_PLAYER_ID);
+    m_networking->SetHostPlayerID(Networking::INVALID_PLAYER_ID);
     SetEmpireID(ALL_EMPIRES);
 
     SinglePlayerSetupData setup_data;
@@ -668,7 +668,7 @@ void HumanClientApp::LoadSinglePlayerGame(std::string filename/* = ""*/) {
     // leving setup_data.m_players empty : not specified when loading a game, as server will generate from save file
 
 
-    m_networking.SendMessage(HostSPGameMessage(setup_data));
+    m_networking->SendMessage(HostSPGameMessage(setup_data));
     m_fsm->process_event(HostSPGameRequested());
 }
 
@@ -677,14 +677,14 @@ void HumanClientApp::RequestSavePreviews(const std::string& directory, PreviewIn
     DebugLogger() << "HumanClientApp::RequestSavePreviews directory: " << directory << " valid UTF-8: " << utf8::is_valid(directory.begin(), directory.end());
 
     std::string  generic_directory = directory;//PathString(fs::path(directory));
-    if (!m_networking.IsConnected()) {
+    if (!m_networking->IsConnected()) {
         DebugLogger() << "HumanClientApp::RequestSavePreviews: No game running. Start a server for savegame queries.";
 
         m_single_player_game = true;
         StartServer();
 
         DebugLogger() << "HumanClientApp::RequestSavePreviews Connecting to server";
-        m_connected = m_networking.ConnectToLocalHostServer();
+        m_connected = m_networking->ConnectToLocalHostServer();
         if (!m_connected) {
             ClientUI::MessageBox(UserString("ERR_CONNECT_TIMED_OUT"), true);
             KillServer();
@@ -693,7 +693,7 @@ void HumanClientApp::RequestSavePreviews(const std::string& directory, PreviewIn
     }
     DebugLogger() << "HumanClientApp::RequestSavePreviews Requesting previews for " << generic_directory;
     Message response;
-    m_networking.SendSynchronousMessage(RequestSavePreviewsMessage(PlayerID(), generic_directory), response);
+    m_networking->SendSynchronousMessage(RequestSavePreviewsMessage(PlayerID(), generic_directory), response);
     if (response.Type() == Message::DISPATCH_SAVE_PREVIEWS){
         ExtractDispatchSavePreviewsMessageData(response, previews);
         DebugLogger() << "HumanClientApp::RequestSavePreviews Got " << previews.previews.size() << " previews.";
@@ -804,12 +804,12 @@ void HumanClientApp::HandleSystemEvents() {
     } catch (const utf8::invalid_utf8& e) {
         ErrorLogger() << "UTF-8 error handling system event: " << e.what();
     }
-    if (m_connected && !m_networking.IsConnected()) {
+    if (m_connected && !m_networking->IsConnected()) {
         m_connected = false;
         DisconnectedFromServer();
-    } else if (m_networking.MessageAvailable()) {
+    } else if (m_networking->MessageAvailable()) {
         Message msg;
-        m_networking.GetMessage(msg);
+        m_networking->GetMessage(msg);
         try {
             HandleMessage(msg);
         } catch (const std::exception& e) {
@@ -860,7 +860,7 @@ void HumanClientApp::HandleSaveGameDataRequest() {
         std::cerr << "HumanClientApp::HandleSaveGameDataRequest(" << Message::SAVE_GAME_DATA_REQUEST << ")\n";
     SaveGameUIData ui_data;
     m_ui->GetSaveGameUIData(ui_data);
-    m_networking.SendMessage(ClientSaveDataMessage(PlayerID(), Orders(), ui_data));
+    m_networking->SendMessage(ClientSaveDataMessage(PlayerID(), Orders(), ui_data));
 }
 
 void HumanClientApp::UpdateCombatLogs(const Message& msg){
@@ -990,7 +990,7 @@ void HumanClientApp::HandleTurnUpdate()
 void HumanClientApp::UpdateCombatLogManager() {
     boost::optional<std::vector<int>> incomplete_ids = GetCombatLogManager().IncompleteLogIDs();
     if (incomplete_ids)
-        m_networking.SendMessage(RequestCombatLogsMessage(PlayerID(), *incomplete_ids));
+        m_networking->SendMessage(RequestCombatLogsMessage(PlayerID(), *incomplete_ids));
 }
 
 namespace {
@@ -1129,13 +1129,13 @@ void HumanClientApp::EndGame(bool suppress_FSM_reset) {
     DebugLogger() << "HumanClientApp::EndGame";
     m_game_started = false;
 
-    if (m_networking.IsTxConnected()) {
+    if (m_networking->IsTxConnected()) {
         DebugLogger() << "HumanClientApp::EndGame Sending server shutdown message.";
-        m_networking.SendMessage(ShutdownServerMessage(m_networking.PlayerID()));
+        m_networking->SendMessage(ShutdownServerMessage(m_networking->PlayerID()));
         std::this_thread::sleep_for(std::chrono::seconds(1));
-        m_networking.DisconnectFromServer();
+        m_networking->DisconnectFromServer();
         // TODO fix this.  disconnect is asynchronous and may not have acted by now.
-        if (!m_networking.IsConnected())
+        if (!m_networking->IsConnected())
             DebugLogger() << "HumanClientApp::EndGame Disconnected from server.";
         else
             ErrorLogger() << "HumanClientApp::EndGame Unexpectedly still connected to server...?";
@@ -1146,8 +1146,8 @@ void HumanClientApp::EndGame(bool suppress_FSM_reset) {
         m_server_process.RequestTermination();
     }
 
-    m_networking.SetPlayerID(Networking::INVALID_PLAYER_ID);
-    m_networking.SetHostPlayerID(Networking::INVALID_PLAYER_ID);
+    m_networking->SetPlayerID(Networking::INVALID_PLAYER_ID);
+    m_networking->SetHostPlayerID(Networking::INVALID_PLAYER_ID);
     SetEmpireID(ALL_EMPIRES);
     m_ui->GetMapWnd()->Sanitize();
 

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -259,10 +259,8 @@ HumanClientApp::HumanClientApp(int width, int height, bool calculate_fps, const 
     GG::Connect(WindowResizedSignal,    &HumanClientApp::HandleWindowResize,    this);
     GG::Connect(FocusChangedSignal,     &HumanClientApp::HandleFocusChange,     this);
     GG::Connect(WindowMovedSignal,      &HumanClientApp::HandleWindowMove,      this);
-    /* TODO: Wire these signals if theyare needed
     GG::Connect(WindowClosingSignal,    &HumanClientApp::HandleWindowClosing,   this);
-    GG::Connect(WindowClosedSignal,     &HumanClientApp::HandleWindowClose,     this);
-    */
+    GG::Connect(AppQuittingSignal,      &HumanClientApp::HandleAppQuitting,   this);
 
     SetStringtableDependentOptionDefaults();
     SetGLVersionDependentOptionDefaults();
@@ -915,12 +913,15 @@ void HumanClientApp::HandleWindowResize(GG::X w, GG::Y h) {
     GetOptionsDB().Commit();
 }
 
-void HumanClientApp::HandleWindowClosing()
-{ DebugLogger() << "HumanClientApp::HandleWindowClosing()"; }
+void HumanClientApp::HandleWindowClosing() {
+    DebugLogger() << "HumanClientApp::HandleWindowClosing()";
+    EndGame(true);
+    Exit(0);
+}
 
-void HumanClientApp::HandleWindowClose() {
-    DebugLogger() << "HumanClientApp::HandleWindowClose()";
-    EndGame();
+void HumanClientApp::HandleAppQuitting() {
+    DebugLogger() << "HumanClientApp::HandleAppQuitting()";
+    EndGame(true);
     Exit(0);
 }
 

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -85,7 +85,7 @@ void SigHandler(int sig) {
 
 namespace {
     typedef boost::chrono::steady_clock Clock;
-    const boost::chrono::milliseconds SERVER_CONNECT_TIMEOUT(4500);
+    const boost::chrono::milliseconds SERVER_CONNECT_TIMEOUT(10000);
     const boost::chrono::milliseconds SERVER_STARTUP_POLLING_TIME(10);
 
     const bool          INSTRUMENT_MESSAGE_HANDLING = false;

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -1132,9 +1132,9 @@ void HumanClientApp::QuitGame() {
         }
 
         if (!m_networking->IsConnected()) {
-            // Treat disconnection as acknowledgement of shutdown and free the process
-            if (!m_server_process.Empty())
-                m_server_process.Free();
+            // Treat disconnection as acknowledgement of shutdown and free the
+            // process to allow orderly shutdown.
+            m_server_process.Free();
         } else {
             ErrorLogger() << "HumanClientApp::EndGame Unexpectedly still connected to server...?";
             m_networking->DisconnectFromServer();

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -321,6 +321,7 @@ void HumanClientApp::ConnectKeyboardAcceleratorSignals() {
 HumanClientApp::~HumanClientApp() {
     m_networking->DisconnectFromServer();
     m_server_process.RequestTermination();
+    DebugLogger() << "HumanClientApp exited cleanly.";
 }
 
 bool HumanClientApp::SinglePlayerGame() const

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -42,7 +42,7 @@
 #include <boost/filesystem/fstream.hpp>
 #include <boost/format.hpp>
 #include <boost/serialization/vector.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/algorithm/string.hpp>
 
 #include <sstream>
 
@@ -445,7 +445,7 @@ void HumanClientApp::NewSinglePlayerGame(bool quickstart) {
 
     bool failed = false;
     unsigned int start_time = Ticks();
-    while (!m_networking.ConnectToLocalHostServer(boost::posix_time::seconds(2))) {
+    while (!m_networking.ConnectToLocalHostServer(boost::chrono::milliseconds(2000))) {
         if (SERVER_CONNECT_TIMEOUT < Ticks() - start_time) {
             ClientUI::MessageBox(UserString("ERR_CONNECT_TIMED_OUT"), true);
             failed = true;
@@ -579,7 +579,7 @@ void HumanClientApp::MultiPlayerGame() {
     }
 
     unsigned int start_time = Ticks();
-    while (!m_networking.ConnectToServer(server_name, boost::posix_time::seconds(2))) {
+    while (!m_networking.ConnectToServer(server_name, boost::chrono::milliseconds(2000))) {
         if (SERVER_CONNECT_TIMEOUT < Ticks() - start_time) {
             ClientUI::MessageBox(UserString("ERR_CONNECT_TIMED_OUT"), true);
             if (server_connect_wnd.Result().second == "HOST GAME SELECTED")

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -1131,8 +1131,8 @@ void HumanClientApp::QuitGame() {
         m_networking->SendMessage(ShutdownServerMessage(m_networking->PlayerID()));
 
         // Poll the server until it disconnects or timesout and then kill it
-        constexpr auto POLLING_TIME = std::chrono::milliseconds(10000);
-        constexpr auto POLLING_INTERVAL = std::chrono::milliseconds(10);
+        const auto POLLING_TIME = std::chrono::milliseconds(10000);
+        const auto POLLING_INTERVAL = std::chrono::milliseconds(10);
 
         using Clock = std::chrono::steady_clock;
         auto start_time = Clock::now();

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -86,7 +86,7 @@ void SigHandler(int sig) {
 namespace {
     typedef boost::chrono::steady_clock Clock;
     const boost::chrono::milliseconds SERVER_CONNECT_TIMEOUT(4500);
-    const boost::chrono::milliseconds SERVER_STARTUP_POLLING_TIME(2000);
+    const boost::chrono::milliseconds SERVER_STARTUP_POLLING_TIME(10);
 
     const bool          INSTRUMENT_MESSAGE_HANDLING = false;
 

--- a/client/human/HumanClientApp.h
+++ b/client/human/HumanClientApp.h
@@ -110,7 +110,7 @@ private:
     void            HandleWindowMove(GG::X w, GG::Y h);
     void            HandleWindowResize(GG::X w, GG::Y h);
     void            HandleWindowClosing();
-    void            HandleWindowClose();
+    void            HandleAppQuitting();
     void            HandleFocusChange(bool gained_focus);
 
     void            ConnectKeyboardAcceleratorSignals();///< installs the following 3 global hotkeys: quit, exit, togglefullscreen

--- a/client/human/HumanClientApp.h
+++ b/client/human/HumanClientApp.h
@@ -51,7 +51,6 @@ public:
 
     void                StartServer();                  ///< starts a server process on localhost
     void                FreeServer();                   ///< frees (relinquishes ownership and control of) any running server process already started by this client; performs no cleanup of other processes, such as AIs
-    void                KillServer();                   ///< kills any running server process already started by this client; performs no cleanup of other processes, such as AIs
     void                NewSinglePlayerGame(bool quickstart = false);
     void                MultiPlayerGame();                              ///< shows multiplayer connection window, and then transitions to multiplayer lobby if connected
     void                StartMultiPlayerGameFromLobby();                ///< begins
@@ -66,9 +65,10 @@ public:
 
     void                QuitGame();                                     ///< kills the server (if appropriate) and ends the current game
     /** Kill the server (if appropriate) and ends the current game, leaving the application in its
-        start state.  If \p suppress_FSM_reset is true don't initiate the FSM transistion to the
-        Intro menu.  This is used from within the FSM. */
-    void                ResetGame(bool suppress_FSM_reset = false);
+        start state.*/
+    void                ResetGame();
+    /** Reset to the Intro Menu. */
+    void                ResetToIntro();
     void                LoadSinglePlayerGame(std::string filename = "");///< loads a single player game chosen by the user; returns true if a game was loaded, and false if the operation was cancelled
     void                RequestSavePreviews(const std::string& directory, PreviewInformation& previews); ///< Requests the savegame previews for choosing one.
     void                Autosave();                                     ///< autosaves the current game, iff autosaves are enabled and any turn number requirements are met

--- a/client/human/HumanClientApp.h
+++ b/client/human/HumanClientApp.h
@@ -64,7 +64,8 @@ public:
      */
     void                UpdateCombatLogManager();
 
-    void                EndGame(bool suppress_FSM_reset = false);       ///< kills the server (if appropriate) and ends the current game, leaving the application in its start state
+    void                QuitGame();                                     ///< kills the server (if appropriate) and ends the current game
+    void                ResetGame();                                    ///< kills the server (if appropriate) and ends the current game, leaving the application in its start state
     void                LoadSinglePlayerGame(std::string filename = "");///< loads a single player game chosen by the user; returns true if a game was loaded, and false if the operation was cancelled
     void                RequestSavePreviews(const std::string& directory, PreviewInformation& previews); ///< Requests the savegame previews for choosing one.
     void                Autosave();                                     ///< autosaves the current game, iff autosaves are enabled and any turn number requirements are met
@@ -109,13 +110,12 @@ private:
 
     void            HandleWindowMove(GG::X w, GG::Y h);
     void            HandleWindowResize(GG::X w, GG::Y h);
-    void            HandleWindowClosing();
     void            HandleAppQuitting();
     void            HandleFocusChange(bool gained_focus);
 
     void            ConnectKeyboardAcceleratorSignals();///< installs the following 3 global hotkeys: quit, exit, togglefullscreen
-    bool            QuitGame();                         ///< quit current game to IntroScreen
-    bool            ExitGame();                         ///< quit current game & freeorion to Desktop
+    bool            HandleHotkeyResetGame();            ///< quit current game to IntroScreen
+    bool            HandleHotkeyExitApp();              ///< quit current game & freeorion to Desktop
     bool            ToggleFullscreen();                 ///< toggle to/from fullscreen display
 
     void            UpdateFPSLimit();                   ///< polls options database to find if FPS should be limited, and if so, to what rate

--- a/client/human/HumanClientApp.h
+++ b/client/human/HumanClientApp.h
@@ -65,7 +65,10 @@ public:
     void                UpdateCombatLogManager();
 
     void                QuitGame();                                     ///< kills the server (if appropriate) and ends the current game
-    void                ResetGame();                                    ///< kills the server (if appropriate) and ends the current game, leaving the application in its start state
+    /** Kill the server (if appropriate) and ends the current game, leaving the application in its
+        start state.  If \p suppress_FSM_reset is true don't initiate the FSM transistion to the
+        Intro menu.  This is used from within the FSM. */
+    void                ResetGame(bool suppress_FSM_reset = false);
     void                LoadSinglePlayerGame(std::string filename = "");///< loads a single player game chosen by the user; returns true if a game was loaded, and false if the operation was cancelled
     void                RequestSavePreviews(const std::string& directory, PreviewInformation& previews); ///< Requests the savegame previews for choosing one.
     void                Autosave();                                     ///< autosaves the current game, iff autosaves are enabled and any turn number requirements are met

--- a/client/human/HumanClientApp.h
+++ b/client/human/HumanClientApp.h
@@ -63,12 +63,9 @@ public:
      */
     void                UpdateCombatLogManager();
 
-    void                QuitGame();                                     ///< kills the server (if appropriate) and ends the current game
-    /** Kill the server (if appropriate) and ends the current game, leaving the application in its
-        start state.*/
-    void                ResetGame();
-    /** Reset to the Intro Menu. */
     void                ResetToIntro();
+    void                ExitApp();
+    void                ResetClientData();
     void                LoadSinglePlayerGame(std::string filename = "");///< loads a single player game chosen by the user; returns true if a game was loaded, and false if the operation was cancelled
     void                RequestSavePreviews(const std::string& directory, PreviewInformation& previews); ///< Requests the savegame previews for choosing one.
     void                Autosave();                                     ///< autosaves the current game, iff autosaves are enabled and any turn number requirements are met

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -280,7 +280,7 @@ boost::statechart::result MPLobby::react(const LobbyChat& msg) {
 boost::statechart::result MPLobby::react(const CancelMPGameClicked& a)
 {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) MPLobby.CancelMPGameClicked";
-    Client().EndGame(true);
+    Client().QuitGame();
     return transit<IntroMenu>();
 }
 
@@ -378,7 +378,7 @@ boost::statechart::result PlayingGame::react(const PlayerChat& msg) {
 
 boost::statechart::result PlayingGame::react(const Disconnection& d) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) PlayingGame.Disconnection";
-    Client().EndGame(true);
+    Client().QuitGame();
     //Note: Any transit<> transition must occur before the MessageBox().
     // MessageBox blocks and can allow other events to transit<> to a new state
     // which makes this transit fatal.
@@ -430,11 +430,11 @@ boost::statechart::result PlayingGame::react(const EndGame& msg) {
     bool error = false;
     switch (reason) {
     case Message::LOCAL_CLIENT_DISCONNECT:
-        Client().EndGame(true);
+        Client().QuitGame();
         reason_message = UserString("SERVER_LOST");
         break;
     case Message::PLAYER_DISCONNECT:
-        Client().EndGame(true);
+        Client().QuitGame();
         reason_message = boost::io::str(FlexibleFormat(UserString("PLAYER_DISCONNECTED")) % reason_player_name);
         error = true;
         break;
@@ -474,7 +474,7 @@ boost::statechart::result PlayingGame::react(const Error& msg) {
 
     if (fatal) {
         ClientUI::MessageBox(UserString(problem), true);
-        client.EndGame(true);
+        client.QuitGame();
     }
     return retval;
 }
@@ -668,7 +668,7 @@ PlayingTurn::PlayingTurn(my_context ctx) :
             // if no auto turns left, and supposed to quit after that, quit
             DebugLogger() << "auto-quit ending game.";
             std::cout << "auto-quit ending game." << std::endl;
-            Client().EndGame(true);
+            Client().QuitGame();
             throw HumanClientApp::CleanQuit();
         }
 

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -109,7 +109,7 @@ boost::statechart::result WaitingForSPHostAck::react(const HostSPGame& msg) {
 
 boost::statechart::result WaitingForSPHostAck::react(const Disconnection& d) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) PlayingGame.Disconnection";
-    Client().ResetGame();
+    Client().ResetGame(true);
     //Note: Any transit<> transition must occur before the MessageBox().
     // MessageBox blocks and can allow other events to transit<> to a new state
     // which makes this transit fatal.
@@ -164,7 +164,7 @@ boost::statechart::result WaitingForMPHostAck::react(const HostMPGame& msg) {
 
 boost::statechart::result WaitingForMPHostAck::react(const Disconnection& d) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) PlayingGame.Disconnection";
-    Client().ResetGame();
+    Client().ResetGame(true);
     //Note: Any transit<> transition must occur before the MessageBox().
     // MessageBox blocks and can allow other events to transit<> to a new state
     // which makes this transit fatal.
@@ -218,7 +218,7 @@ boost::statechart::result WaitingForMPJoinAck::react(const JoinGame& msg) {
 
 boost::statechart::result WaitingForMPJoinAck::react(const Disconnection& d) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) PlayingGame.Disconnection";
-    Client().ResetGame();
+    Client().ResetGame(true);
     //Note: Any transit<> transition must occur before the MessageBox().
     // MessageBox blocks and can allow other events to transit<> to a new state
     // which makes this transit fatal.
@@ -313,7 +313,7 @@ boost::statechart::result MPLobby::react(const LobbyChat& msg) {
 boost::statechart::result MPLobby::react(const CancelMPGameClicked& a)
 {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) MPLobby.CancelMPGameClicked";
-    Client().ResetGame();
+    Client().ResetGame(true);
     return transit<IntroMenu>();
 }
 
@@ -411,7 +411,7 @@ boost::statechart::result PlayingGame::react(const PlayerChat& msg) {
 
 boost::statechart::result PlayingGame::react(const Disconnection& d) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) PlayingGame.Disconnection";
-    Client().ResetGame();
+    Client().ResetGame(true);
     //Note: Any transit<> transition must occur before the MessageBox().
     // MessageBox blocks and can allow other events to transit<> to a new state
     // which makes this transit fatal.
@@ -463,11 +463,11 @@ boost::statechart::result PlayingGame::react(const EndGame& msg) {
     bool error = false;
     switch (reason) {
     case Message::LOCAL_CLIENT_DISCONNECT:
-        Client().ResetGame();
+        Client().ResetGame(true);
         reason_message = UserString("SERVER_LOST");
         break;
     case Message::PLAYER_DISCONNECT:
-        Client().ResetGame();
+        Client().ResetGame(true);
         reason_message = boost::io::str(FlexibleFormat(UserString("PLAYER_DISCONNECTED")) % reason_player_name);
         error = true;
         break;
@@ -507,7 +507,8 @@ boost::statechart::result PlayingGame::react(const Error& msg) {
 
     if (fatal) {
         ClientUI::MessageBox(UserString(problem), true);
-        client.ResetGame();
+        client.ResetGame(true);
+        return transit<IntroMenu>();
     }
     return retval;
 }

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -117,7 +117,8 @@ boost::statechart::result WaitingForSPHostAck::react(const Disconnection& d) {
     //Note: Any transit<> transition must occur before the MessageBox().
     // MessageBox blocks and can allow other events to transit<> to a new state
     // which makes this transit fatal.
-    boost::statechart::result retval = transit<IntroMenu>();
+    auto retval = discard_event();
+    Client().ResetToIntro();
     ClientUI::MessageBox(UserString("SERVER_LOST"), true);
     return retval;
 }
@@ -136,13 +137,12 @@ boost::statechart::result WaitingForSPHostAck::react(const Error& msg) {
     //Note: Any transit<> transition must occur before the MessageBox().
     // MessageBox blocks and can allow other events to transit<> to a new state
     // which makes this transit fatal.
-    boost::statechart::result retval = fatal ? transit<IntroMenu>() : discard_event();
-
+    auto retval = discard_event();
     if (fatal) {
+        Client().ResetToIntro();
         ClientUI::MessageBox(UserString(problem), true);
         client.GetClientUI().GetMessageWnd()->HandleGameStatusUpdate(UserString("RETURN_TO_INTRO") + "\n");
     }
-
     return retval;
 }
 
@@ -180,7 +180,8 @@ boost::statechart::result WaitingForMPHostAck::react(const Disconnection& d) {
     //Note: Any transit<> transition must occur before the MessageBox().
     // MessageBox blocks and can allow other events to transit<> to a new state
     // which makes this transit fatal.
-    boost::statechart::result retval = transit<IntroMenu>();
+    auto retval = discard_event();
+    Client().ResetToIntro();
     ClientUI::MessageBox(UserString("SERVER_LOST"), true);
     return retval;
 }
@@ -199,13 +200,12 @@ boost::statechart::result WaitingForMPHostAck::react(const Error& msg) {
     //Note: Any transit<> transition must occur before the MessageBox().
     // MessageBox blocks and can allow other events to transit<> to a new state
     // which makes this transit fatal.
-    boost::statechart::result retval = fatal ? transit<IntroMenu>() : discard_event();
-
+    auto retval = discard_event();
     if (fatal) {
+        Client().ResetToIntro();
         ClientUI::MessageBox(UserString(problem), true);
         client.GetClientUI().GetMessageWnd()->HandleGameStatusUpdate(UserString("RETURN_TO_INTRO") + "\n");
     }
-
     return retval;
 }
 
@@ -242,7 +242,8 @@ boost::statechart::result WaitingForMPJoinAck::react(const Disconnection& d) {
     //Note: Any transit<> transition must occur before the MessageBox().
     // MessageBox blocks and can allow other events to transit<> to a new state
     // which makes this transit fatal.
-    boost::statechart::result retval = transit<IntroMenu>();
+    auto retval = discard_event();
+    Client().ResetToIntro();
     ClientUI::MessageBox(UserString("SERVER_LOST"), true);
     return retval;
 }
@@ -261,16 +262,15 @@ boost::statechart::result WaitingForMPJoinAck::react(const Error& msg) {
     //Note: Any transit<> transition must occur before the MessageBox().
     // MessageBox blocks and can allow other events to transit<> to a new state
     // which makes this transit fatal.
-    boost::statechart::result retval = fatal ? transit<IntroMenu>() : discard_event();
-
+    auto retval = discard_event();
     if (fatal) {
+        Client().ResetToIntro();
         ClientUI::MessageBox(UserString(problem), true);
         client.GetClientUI().GetMessageWnd()->HandleGameStatusUpdate(UserString("RETURN_TO_INTRO") + "\n");
     }
 
     return retval;
 }
-
 
 boost::statechart::result WaitingForMPJoinAck::react(const StartQuittingGame& e) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) Quit or reset to main menu.";
@@ -302,7 +302,8 @@ boost::statechart::result MPLobby::react(const Disconnection& d) {
     //Note: Any transit<> transition must occur before the MessageBox().
     // MessageBox blocks and can allow other events to transit<> to a new state
     // which makes this transit fatal.
-    boost::statechart::result retval = transit<IntroMenu>();
+    auto retval = discard_event();
+    Client().ResetToIntro();
     ClientUI::MessageBox(UserString("SERVER_LOST"), true);
     return retval;
 }
@@ -343,7 +344,12 @@ boost::statechart::result MPLobby::react(const LobbyChat& msg) {
 boost::statechart::result MPLobby::react(const CancelMPGameClicked& a)
 {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) MPLobby.CancelMPGameClicked";
-    return transit<IntroMenu>();
+    //Note: Any transit<> transition must occur before the MessageBox().
+    // MessageBox blocks and can allow other events to transit<> to a new state
+    // which makes this transit fatal.
+    auto retval = discard_event();
+    Client().ResetToIntro();
+    return retval;
 }
 
 boost::statechart::result MPLobby::react(const StartMPGameClicked& a) {
@@ -380,10 +386,11 @@ boost::statechart::result MPLobby::react(const Error& msg) {
     //Note: Any transit<> transition must occur before the MessageBox().
     // MessageBox blocks and can allow other events to transit<> to a new state
     // which makes this transit fatal.
-    boost::statechart::result retval = fatal ? transit<IntroMenu>() : discard_event();
-
-    if (fatal)
+    auto retval = discard_event();
+    if (fatal) {
+        Client().ResetToIntro();
         ClientUI::MessageBox(UserString(problem), true);
+    }
 
     return retval;
 }
@@ -452,7 +459,8 @@ boost::statechart::result PlayingGame::react(const Disconnection& d) {
     //Note: Any transit<> transition must occur before the MessageBox().
     // MessageBox blocks and can allow other events to transit<> to a new state
     // which makes this transit fatal.
-    boost::statechart::result retval = transit<IntroMenu>();
+    auto retval = discard_event();
+    Client().ResetToIntro();
     ClientUI::MessageBox(UserString("SERVER_LOST"), true);
     return retval;
 }
@@ -510,7 +518,8 @@ boost::statechart::result PlayingGame::react(const EndGame& msg) {
     //Note: Any transit<> transition must occur before the MessageBox().
     // MessageBox blocks and can allow other events to transit<> to a new state
     // which makes this transit fatal.
-    boost::statechart::result retval = transit<IntroMenu>();
+    auto retval = discard_event();
+    Client().ResetToIntro();
     ClientUI::MessageBox(reason_message, error);
     return retval;
 }
@@ -533,18 +542,16 @@ boost::statechart::result PlayingGame::react(const Error& msg) {
     ErrorLogger() << "PlayingGame::react(const Error& msg) error: "
                   << problem << "\nProblem is" <<(fatal ? "":"non-")<<" fatal";
 
-    //Note: transit<> frees this pointer so Client() must be called before.
-    HumanClientApp& client = Client();
-
     //Note: Any transit<> transition must occur before the MessageBox().
     // MessageBox blocks and can allow other events to transit<> to a new state
     // which makes this transit fatal.
-    boost::statechart::result retval = fatal ? transit<IntroMenu>() : discard_event();
-    ClientUI::MessageBox(UserString(problem), false);
-
+    auto retval = discard_event();
     if (fatal) {
+        Client().ResetToIntro();
         ClientUI::MessageBox(UserString(problem), true);
         return transit<IntroMenu>();
+    } else {
+        ClientUI::MessageBox(UserString(problem), false);
     }
     return retval;
 }

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -60,7 +60,6 @@ IntroMenu::IntroMenu(my_context ctx) :
     Base(ctx)
 {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) IntroMenu";
-    Client().ResetGame();
     Client().GetClientUI().ShowIntroScreen();
 }
 
@@ -516,12 +515,6 @@ boost::statechart::result PlayingGame::react(const EndGame& msg) {
     return retval;
 }
 
-boost::statechart::result PlayingGame::react(const ResetToIntroMenu& msg) {
-    if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) PlayingGame.ResetToIntroMenu";
-    Client().GetClientUI().GetMessageWnd()->HandleGameStatusUpdate(UserString("RETURN_TO_INTRO") + "\n");
-    return transit<IntroMenu>();
-}
-
 boost::statechart::result PlayingGame::react(const StartQuittingGame& e) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) Quit or reset to main menu.";
 
@@ -745,8 +738,7 @@ PlayingTurn::PlayingTurn(my_context ctx) :
             // if no auto turns left, and supposed to quit after that, quit
             DebugLogger() << "auto-quit ending game.";
             std::cout << "auto-quit ending game." << std::endl;
-            Client().QuitGame();
-            throw HumanClientApp::CleanQuit();
+            Client().ExitApp();
         }
 
         // if there are still auto turns left, advance the turn automatically,
@@ -966,7 +958,7 @@ boost::statechart::result QuittingGame::react(const TerminateServer& u) {
 
     // Reset the game or quit the app as appropriate
     if (m_reset_to_intro) {
-        // Client().ResetClientData();
+        Client().ResetClientData();
         return transit<IntroMenu>();
     } else {
         throw HumanClientApp::CleanQuit();

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -59,7 +59,7 @@ IntroMenu::IntroMenu(my_context ctx) :
     Base(ctx)
 {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) IntroMenu";
-    Client().KillServer();
+    Client().ResetGame();
     Client().GetClientUI().ShowIntroScreen();
 }
 
@@ -109,7 +109,6 @@ boost::statechart::result WaitingForSPHostAck::react(const HostSPGame& msg) {
 
 boost::statechart::result WaitingForSPHostAck::react(const Disconnection& d) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) PlayingGame.Disconnection";
-    Client().ResetGame(true);
     //Note: Any transit<> transition must occur before the MessageBox().
     // MessageBox blocks and can allow other events to transit<> to a new state
     // which makes this transit fatal.
@@ -164,7 +163,6 @@ boost::statechart::result WaitingForMPHostAck::react(const HostMPGame& msg) {
 
 boost::statechart::result WaitingForMPHostAck::react(const Disconnection& d) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) PlayingGame.Disconnection";
-    Client().ResetGame(true);
     //Note: Any transit<> transition must occur before the MessageBox().
     // MessageBox blocks and can allow other events to transit<> to a new state
     // which makes this transit fatal.
@@ -218,7 +216,6 @@ boost::statechart::result WaitingForMPJoinAck::react(const JoinGame& msg) {
 
 boost::statechart::result WaitingForMPJoinAck::react(const Disconnection& d) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) PlayingGame.Disconnection";
-    Client().ResetGame(true);
     //Note: Any transit<> transition must occur before the MessageBox().
     // MessageBox blocks and can allow other events to transit<> to a new state
     // which makes this transit fatal.
@@ -313,7 +310,6 @@ boost::statechart::result MPLobby::react(const LobbyChat& msg) {
 boost::statechart::result MPLobby::react(const CancelMPGameClicked& a)
 {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) MPLobby.CancelMPGameClicked";
-    Client().ResetGame(true);
     return transit<IntroMenu>();
 }
 
@@ -411,7 +407,6 @@ boost::statechart::result PlayingGame::react(const PlayerChat& msg) {
 
 boost::statechart::result PlayingGame::react(const Disconnection& d) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) PlayingGame.Disconnection";
-    Client().ResetGame(true);
     //Note: Any transit<> transition must occur before the MessageBox().
     // MessageBox blocks and can allow other events to transit<> to a new state
     // which makes this transit fatal.
@@ -463,11 +458,9 @@ boost::statechart::result PlayingGame::react(const EndGame& msg) {
     bool error = false;
     switch (reason) {
     case Message::LOCAL_CLIENT_DISCONNECT:
-        Client().ResetGame(true);
         reason_message = UserString("SERVER_LOST");
         break;
     case Message::PLAYER_DISCONNECT:
-        Client().ResetGame(true);
         reason_message = boost::io::str(FlexibleFormat(UserString("PLAYER_DISCONNECTED")) % reason_player_name);
         error = true;
         break;
@@ -507,7 +500,6 @@ boost::statechart::result PlayingGame::react(const Error& msg) {
 
     if (fatal) {
         ClientUI::MessageBox(UserString(problem), true);
-        client.ResetGame(true);
         return transit<IntroMenu>();
     }
     return retval;

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -86,6 +86,11 @@ boost::statechart::result IntroMenu::react(const JoinMPGameRequested& a) {
     return transit<WaitingForMPJoinAck>();
 }
 
+boost::statechart::result IntroMenu::react(const StartQuittingGame& e) {
+    if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) Quit or reset to main menu.";
+    post_event(e);
+    return transit<QuittingGame>();
+}
 
 ////////////////////////////////////////////////////////////
 // WaitingForSPHostAck
@@ -142,6 +147,15 @@ boost::statechart::result WaitingForSPHostAck::react(const Error& msg) {
     return retval;
 }
 
+boost::statechart::result WaitingForSPHostAck::react(const StartQuittingGame& e) {
+    if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) Quit or reset to main menu.";
+
+    Client().GetClientUI().GetMessageWnd()->HandleGameStatusUpdate(UserString("RETURN_TO_INTRO") + "\n");
+
+    post_event(e);
+    return transit<QuittingGame>();
+}
+
 
 ////////////////////////////////////////////////////////////
 // WaitingForMPHostAck
@@ -196,6 +210,15 @@ boost::statechart::result WaitingForMPHostAck::react(const Error& msg) {
     return retval;
 }
 
+boost::statechart::result WaitingForMPHostAck::react(const StartQuittingGame& e) {
+    if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) Quit or reset to main menu.";
+
+    Client().GetClientUI().GetMessageWnd()->HandleGameStatusUpdate(UserString("RETURN_TO_INTRO") + "\n");
+
+    post_event(e);
+    return transit<QuittingGame>();
+}
+
 
 ////////////////////////////////////////////////////////////
 // WaitingForMPJoinAck
@@ -247,6 +270,16 @@ boost::statechart::result WaitingForMPJoinAck::react(const Error& msg) {
     }
 
     return retval;
+}
+
+
+boost::statechart::result WaitingForMPJoinAck::react(const StartQuittingGame& e) {
+    if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) Quit or reset to main menu.";
+
+    Client().GetClientUI().GetMessageWnd()->HandleGameStatusUpdate(UserString("RETURN_TO_INTRO") + "\n");
+
+    post_event(e);
+    return transit<QuittingGame>();
 }
 
 
@@ -354,6 +387,15 @@ boost::statechart::result MPLobby::react(const Error& msg) {
         ClientUI::MessageBox(UserString(problem), true);
 
     return retval;
+}
+
+boost::statechart::result MPLobby::react(const StartQuittingGame& e) {
+    if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) Quit or reset to main menu.";
+
+    Client().GetClientUI().GetMessageWnd()->HandleGameStatusUpdate(UserString("RETURN_TO_INTRO") + "\n");
+
+    post_event(e);
+    return transit<QuittingGame>();
 }
 
 
@@ -476,9 +518,17 @@ boost::statechart::result PlayingGame::react(const EndGame& msg) {
 
 boost::statechart::result PlayingGame::react(const ResetToIntroMenu& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) PlayingGame.ResetToIntroMenu";
-
     Client().GetClientUI().GetMessageWnd()->HandleGameStatusUpdate(UserString("RETURN_TO_INTRO") + "\n");
     return transit<IntroMenu>();
+}
+
+boost::statechart::result PlayingGame::react(const StartQuittingGame& e) {
+    if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) Quit or reset to main menu.";
+
+    Client().GetClientUI().GetMessageWnd()->HandleGameStatusUpdate(UserString("RETURN_TO_INTRO") + "\n");
+
+    post_event(e);
+    return transit<QuittingGame>();
 }
 
 boost::statechart::result PlayingGame::react(const Error& msg) {

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -313,7 +313,7 @@ boost::statechart::result MPLobby::react(const LobbyChat& msg) {
 boost::statechart::result MPLobby::react(const CancelMPGameClicked& a)
 {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) MPLobby.CancelMPGameClicked";
-    Client().QuitGame();
+    Client().ResetGame();
     return transit<IntroMenu>();
 }
 
@@ -411,7 +411,7 @@ boost::statechart::result PlayingGame::react(const PlayerChat& msg) {
 
 boost::statechart::result PlayingGame::react(const Disconnection& d) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) PlayingGame.Disconnection";
-    Client().QuitGame();
+    Client().ResetGame();
     //Note: Any transit<> transition must occur before the MessageBox().
     // MessageBox blocks and can allow other events to transit<> to a new state
     // which makes this transit fatal.
@@ -463,11 +463,11 @@ boost::statechart::result PlayingGame::react(const EndGame& msg) {
     bool error = false;
     switch (reason) {
     case Message::LOCAL_CLIENT_DISCONNECT:
-        Client().QuitGame();
+        Client().ResetGame();
         reason_message = UserString("SERVER_LOST");
         break;
     case Message::PLAYER_DISCONNECT:
-        Client().QuitGame();
+        Client().ResetGame();
         reason_message = boost::io::str(FlexibleFormat(UserString("PLAYER_DISCONNECTED")) % reason_player_name);
         error = true;
         break;
@@ -507,7 +507,7 @@ boost::statechart::result PlayingGame::react(const Error& msg) {
 
     if (fatal) {
         ClientUI::MessageBox(UserString(problem), true);
-        client.QuitGame();
+        client.ResetGame();
     }
     return retval;
 }

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -107,6 +107,17 @@ boost::statechart::result WaitingForSPHostAck::react(const HostSPGame& msg) {
     return transit<PlayingGame>();
 }
 
+boost::statechart::result WaitingForSPHostAck::react(const Disconnection& d) {
+    if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) PlayingGame.Disconnection";
+    Client().ResetGame();
+    //Note: Any transit<> transition must occur before the MessageBox().
+    // MessageBox blocks and can allow other events to transit<> to a new state
+    // which makes this transit fatal.
+    boost::statechart::result retval = transit<IntroMenu>();
+    ClientUI::MessageBox(UserString("SERVER_LOST"), true);
+    return retval;
+}
+
 boost::statechart::result WaitingForSPHostAck::react(const Error& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) WaitingForSPHostAck.Error";
     std::string problem;
@@ -151,6 +162,17 @@ boost::statechart::result WaitingForMPHostAck::react(const HostMPGame& msg) {
     return transit<MPLobby>();
 }
 
+boost::statechart::result WaitingForMPHostAck::react(const Disconnection& d) {
+    if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) PlayingGame.Disconnection";
+    Client().ResetGame();
+    //Note: Any transit<> transition must occur before the MessageBox().
+    // MessageBox blocks and can allow other events to transit<> to a new state
+    // which makes this transit fatal.
+    boost::statechart::result retval = transit<IntroMenu>();
+    ClientUI::MessageBox(UserString("SERVER_LOST"), true);
+    return retval;
+}
+
 boost::statechart::result WaitingForMPHostAck::react(const Error& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) WaitingForMPHostAck.Error";
     std::string problem;
@@ -192,6 +214,17 @@ boost::statechart::result WaitingForMPJoinAck::react(const JoinGame& msg) {
     Client().Networking().SetPlayerID(msg.m_message.ReceivingPlayer());
 
     return transit<MPLobby>();
+}
+
+boost::statechart::result WaitingForMPJoinAck::react(const Disconnection& d) {
+    if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) PlayingGame.Disconnection";
+    Client().ResetGame();
+    //Note: Any transit<> transition must occur before the MessageBox().
+    // MessageBox blocks and can allow other events to transit<> to a new state
+    // which makes this transit fatal.
+    boost::statechart::result retval = transit<IntroMenu>();
+    ClientUI::MessageBox(UserString("SERVER_LOST"), true);
+    return retval;
 }
 
 boost::statechart::result WaitingForMPJoinAck::react(const Error& msg) {

--- a/client/human/HumanClientFSM.h
+++ b/client/human/HumanClientFSM.h
@@ -37,10 +37,6 @@ struct JoinMPGameRequested : boost::statechart::event<JoinMPGameRequested> {};
 // Indicates that the player's turn has been sent to the server.
 struct TurnEnded : boost::statechart::event<TurnEnded> {};
 
-/** Indicates that a game has ended and that the state should be reset to
-  * IntroMenu. */
-struct ResetToIntroMenu : boost::statechart::event<ResetToIntroMenu> {};
-
 // Posted to advance the turn, including when auto-advancing the first turn
 struct AdvanceTurn : boost::statechart::event<AdvanceTurn> {};
 
@@ -66,7 +62,6 @@ struct TerminateServer : boost::statechart::event<TerminateServer> {};
     (HostMPGameRequested)                                       \
     (JoinMPGameRequested)                                       \
     (TurnEnded)                                                 \
-    (ResetToIntroMenu)                                          \
     (StartQuittingGame)                                         \
     (ShutdownServer)                                            \
     (WaitForDisconnect)                                         \
@@ -249,7 +244,6 @@ struct PlayingGame : boost::statechart::state<PlayingGame, HumanClientFSM, Waiti
         boost::statechart::custom_reaction<Diplomacy>,
         boost::statechart::custom_reaction<DiplomaticStatusUpdate>,
         boost::statechart::custom_reaction<EndGame>,
-        boost::statechart::custom_reaction<ResetToIntroMenu>,
         boost::statechart::custom_reaction<StartQuittingGame>,
         boost::statechart::custom_reaction<Error>,
         boost::statechart::custom_reaction<TurnProgress>,
@@ -266,7 +260,6 @@ struct PlayingGame : boost::statechart::state<PlayingGame, HumanClientFSM, Waiti
     boost::statechart::result react(const Diplomacy& d);
     boost::statechart::result react(const DiplomaticStatusUpdate& u);
     boost::statechart::result react(const EndGame& msg);
-    boost::statechart::result react(const ResetToIntroMenu& msg);
     boost::statechart::result react(const StartQuittingGame& msg);
     boost::statechart::result react(const Error& msg);
     boost::statechart::result react(const TurnProgress& msg);

--- a/client/human/HumanClientFSM.h
+++ b/client/human/HumanClientFSM.h
@@ -361,8 +361,10 @@ struct QuittingGame : boost::statechart::state<QuittingGame, HumanClientFSM> {
     boost::statechart::result react(const Disconnection& msg);
     boost::statechart::result react(const TerminateServer& msg);
 
-    // Determines whether QuittingGame ends by exiting the app or returning to the Intro menu.
     std::chrono::steady_clock::time_point m_start_time;
+
+    // if m_reset_to_intro is true QuittingGame transits to the Intro menu, otherwise it
+    // exits the app.
     bool m_reset_to_intro;
     Process* m_server_process;
 

--- a/client/human/HumanClientFSM.h
+++ b/client/human/HumanClientFSM.h
@@ -114,7 +114,8 @@ struct IntroMenu : boost::statechart::state<IntroMenu, HumanClientFSM> {
     typedef boost::mpl::list<
         boost::statechart::custom_reaction<HostSPGameRequested>,
         boost::statechart::custom_reaction<HostMPGameRequested>,
-        boost::statechart::custom_reaction<JoinMPGameRequested>
+        boost::statechart::custom_reaction<JoinMPGameRequested>,
+        boost::statechart::custom_reaction<StartQuittingGame>
     > reactions;
 
     IntroMenu(my_context ctx);
@@ -123,6 +124,7 @@ struct IntroMenu : boost::statechart::state<IntroMenu, HumanClientFSM> {
     boost::statechart::result react(const HostSPGameRequested& a);
     boost::statechart::result react(const HostMPGameRequested& a);
     boost::statechart::result react(const JoinMPGameRequested& a);
+    boost::statechart::result react(const StartQuittingGame& msg);
 
     CLIENT_ACCESSOR
 };
@@ -136,6 +138,7 @@ struct WaitingForSPHostAck : boost::statechart::simple_state<WaitingForSPHostAck
     typedef boost::mpl::list<
         boost::statechart::custom_reaction<HostSPGame>,
         boost::statechart::custom_reaction<Disconnection>,
+        boost::statechart::custom_reaction<StartQuittingGame>,
         boost::statechart::custom_reaction<Error>
     > reactions;
 
@@ -144,6 +147,7 @@ struct WaitingForSPHostAck : boost::statechart::simple_state<WaitingForSPHostAck
 
     boost::statechart::result react(const HostSPGame& a);
     boost::statechart::result react(const Disconnection& d);
+    boost::statechart::result react(const StartQuittingGame& msg);
     boost::statechart::result react(const Error& msg);
 
     CLIENT_ACCESSOR
@@ -158,6 +162,7 @@ struct WaitingForMPHostAck : boost::statechart::simple_state<WaitingForMPHostAck
     typedef boost::mpl::list<
         boost::statechart::custom_reaction<HostMPGame>,
         boost::statechart::custom_reaction<Disconnection>,
+        boost::statechart::custom_reaction<StartQuittingGame>,
         boost::statechart::custom_reaction<Error>
     > reactions;
 
@@ -166,6 +171,7 @@ struct WaitingForMPHostAck : boost::statechart::simple_state<WaitingForMPHostAck
 
     boost::statechart::result react(const HostMPGame& a);
     boost::statechart::result react(const Disconnection& d);
+    boost::statechart::result react(const StartQuittingGame& msg);
     boost::statechart::result react(const Error& msg);
 
     CLIENT_ACCESSOR
@@ -181,6 +187,7 @@ struct WaitingForMPJoinAck : boost::statechart::simple_state<WaitingForMPJoinAck
     typedef boost::mpl::list<
         boost::statechart::custom_reaction<JoinGame>,
         boost::statechart::custom_reaction<Disconnection>,
+        boost::statechart::custom_reaction<StartQuittingGame>,
         boost::statechart::custom_reaction<Error>
     > reactions;
 
@@ -189,6 +196,7 @@ struct WaitingForMPJoinAck : boost::statechart::simple_state<WaitingForMPJoinAck
 
     boost::statechart::result react(const JoinGame& a);
     boost::statechart::result react(const Disconnection& d);
+    boost::statechart::result react(const StartQuittingGame& msg);
     boost::statechart::result react(const Error& msg);
 
     CLIENT_ACCESSOR
@@ -207,6 +215,7 @@ struct MPLobby : boost::statechart::state<MPLobby, HumanClientFSM> {
         boost::statechart::custom_reaction<CancelMPGameClicked>,
         boost::statechart::custom_reaction<StartMPGameClicked>,
         boost::statechart::custom_reaction<GameStart>,
+        boost::statechart::custom_reaction<StartQuittingGame>,
         boost::statechart::custom_reaction<Error>
     > reactions;
 
@@ -220,6 +229,7 @@ struct MPLobby : boost::statechart::state<MPLobby, HumanClientFSM> {
     boost::statechart::result react(const CancelMPGameClicked& a);
     boost::statechart::result react(const StartMPGameClicked& a);
     boost::statechart::result react(const GameStart& msg);
+    boost::statechart::result react(const StartQuittingGame& msg);
     boost::statechart::result react(const Error& msg);
 
     CLIENT_ACCESSOR
@@ -240,6 +250,7 @@ struct PlayingGame : boost::statechart::state<PlayingGame, HumanClientFSM, Waiti
         boost::statechart::custom_reaction<DiplomaticStatusUpdate>,
         boost::statechart::custom_reaction<EndGame>,
         boost::statechart::custom_reaction<ResetToIntroMenu>,
+        boost::statechart::custom_reaction<StartQuittingGame>,
         boost::statechart::custom_reaction<Error>,
         boost::statechart::custom_reaction<TurnProgress>,
         boost::statechart::custom_reaction<TurnPartialUpdate>
@@ -256,6 +267,7 @@ struct PlayingGame : boost::statechart::state<PlayingGame, HumanClientFSM, Waiti
     boost::statechart::result react(const DiplomaticStatusUpdate& u);
     boost::statechart::result react(const EndGame& msg);
     boost::statechart::result react(const ResetToIntroMenu& msg);
+    boost::statechart::result react(const StartQuittingGame& msg);
     boost::statechart::result react(const Error& msg);
     boost::statechart::result react(const TurnProgress& msg);
     boost::statechart::result react(const TurnPartialUpdate& msg);

--- a/client/human/HumanClientFSM.h
+++ b/client/human/HumanClientFSM.h
@@ -116,6 +116,7 @@ struct WaitingForSPHostAck : boost::statechart::simple_state<WaitingForSPHostAck
 
     typedef boost::mpl::list<
         boost::statechart::custom_reaction<HostSPGame>,
+        boost::statechart::custom_reaction<Disconnection>,
         boost::statechart::custom_reaction<Error>
     > reactions;
 
@@ -123,6 +124,7 @@ struct WaitingForSPHostAck : boost::statechart::simple_state<WaitingForSPHostAck
     ~WaitingForSPHostAck();
 
     boost::statechart::result react(const HostSPGame& a);
+    boost::statechart::result react(const Disconnection& d);
     boost::statechart::result react(const Error& msg);
 
     CLIENT_ACCESSOR
@@ -136,6 +138,7 @@ struct WaitingForMPHostAck : boost::statechart::simple_state<WaitingForMPHostAck
 
     typedef boost::mpl::list<
         boost::statechart::custom_reaction<HostMPGame>,
+        boost::statechart::custom_reaction<Disconnection>,
         boost::statechart::custom_reaction<Error>
     > reactions;
 
@@ -143,6 +146,7 @@ struct WaitingForMPHostAck : boost::statechart::simple_state<WaitingForMPHostAck
     ~WaitingForMPHostAck();
 
     boost::statechart::result react(const HostMPGame& a);
+    boost::statechart::result react(const Disconnection& d);
     boost::statechart::result react(const Error& msg);
 
     CLIENT_ACCESSOR
@@ -157,6 +161,7 @@ struct WaitingForMPJoinAck : boost::statechart::simple_state<WaitingForMPJoinAck
 
     typedef boost::mpl::list<
         boost::statechart::custom_reaction<JoinGame>,
+        boost::statechart::custom_reaction<Disconnection>,
         boost::statechart::custom_reaction<Error>
     > reactions;
 
@@ -164,6 +169,7 @@ struct WaitingForMPJoinAck : boost::statechart::simple_state<WaitingForMPJoinAck
     ~WaitingForMPJoinAck();
 
     boost::statechart::result react(const JoinGame& a);
+    boost::statechart::result react(const Disconnection& d);
     boost::statechart::result react(const Error& msg);
 
     CLIENT_ACCESSOR

--- a/client/human/chmain.cpp
+++ b/client/human/chmain.cpp
@@ -286,7 +286,6 @@ int mainSetupAndRun() {
 
     } catch (const HumanClientApp::CleanQuit&) {
         // do nothing
-        std::cout << "mainSetupAndRun caught CleanQuit" << std::endl;
     }
 #ifndef FREEORION_CHMAIN_KEEP_STACKTRACE
     catch (const std::invalid_argument& e) {
@@ -308,6 +307,7 @@ int mainSetupAndRun() {
     }
 #endif
 
+    DebugLogger() << "Human client main exited cleanly.";
     return 0;
 }
 

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -358,7 +358,8 @@ void ClientNetworking::HandleException(const boost::system::system_error& error)
         DebugLogger() << "Client connection closed by client.";
     else {
         ErrorLogger() << "ClientNetworking::NetworkingThread() : Networking thread will be terminated "
-                      << "due to unhandled exception \"" << error.what() << "\"";
+                      << "due to unhandled exception error #" << error.code().value() << " \""
+                      << error.code().message() << "\"";
     }
 }
 

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -176,8 +176,6 @@ bool ClientNetworking::ConnectToServer(
 
     try {
         for (tcp::resolver::iterator it = resolver.resolve(query); it != end_it; ++it) {
-            if (verbose)
-
             m_socket.close();
             boost::asio::basic_waitable_timer<boost::chrono::high_resolution_clock> timer(m_io_service);
 
@@ -195,6 +193,7 @@ bool ClientNetworking::ConnectToServer(
                 DebugLogger() << "tcp::resolver::iterator host_name: " << it->host_name()
                               << "  address: " << it->endpoint().address()
                               << "  port: " << it->endpoint().port();
+
                 DebugLogger() << "ClientNetworking::ConnectToServer : connected to server";
                 if (GetOptionsDB().Get<bool>("binary-serialization"))
                     DebugLogger() << "ClientNetworking::ConnectToServer : this client using binary serialization.";

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -19,7 +19,7 @@ using boost::asio::ip::tcp;
 using namespace Networking;
 
 namespace {
-    const bool TRACE_EXECUTION = false;
+    const bool TRACE_EXECUTION = true;
 
     /** A simple client that broadcasts UDP datagrams on the local network for
         FreeOrion servers, and reports any it finds. */
@@ -315,7 +315,9 @@ void ClientNetworking::HandleConnection(tcp::resolver::iterator* it,
     if (error) {
         if (!m_cancel_retries) {
             if (TRACE_EXECUTION)
-                DebugLogger() << "ClientNetworking::HandleConnection : connection error ... retrying";
+                DebugLogger() << "ClientNetworking::HandleConnection : connection "
+                              << "error #"<<error.value()<<" \"" << error.message() << "\""
+                              << "... retrying";
             m_socket.async_connect(**it, boost::bind(&ClientNetworking::HandleConnection, this,
                                                      it,
                                                      timer,

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -204,7 +204,21 @@ bool ClientNetworking::ConnectToServer(
                                   << ((GetOptionsDB().Get<bool>("binary-serialization")) ? "binary": "xml")
                                   << " serialization.";
 
+                    // Prepare the socket
+
+                    // linger option has different meanings on different platforms.  It affects the
+                    // behavior of the socket.close().  It can do the following:
+                    // - close both send and receive immediately,
+                    // - finish sending any pending send packets and wait up to SOCKET_LINGER_TIME for
+                    // ACKs,
+                    // - finish sending pending sent packets and wait up to SOCKET_LINGER_TIME for ACKs
+                    // and for the other side of the connection to close,
+                    // linger may/may not cause close() to block until the linger time has elapsed.
                     m_socket.set_option(boost::asio::socket_base::linger(true, SOCKET_LINGER_TIME));
+
+                    // keep alive is an OS dependent option that will keep the TCP connection alive and
+                    // then deliver an OS dependent error when/if the other side of the connection
+                    // times out or closes.
                     m_socket.set_option(boost::asio::socket_base::keep_alive(true));
                     DebugLogger() << "Connecting to server took "
                                   << std::chrono::duration_cast<std::chrono::milliseconds>(connection_time).count() << " ms.";

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -375,9 +375,11 @@ void ClientNetworking::NetworkingThread(std::shared_ptr<ClientNetworking>& self)
     m_incoming_messages.Clear();
     m_outgoing_messages.clear();
     m_io_service.reset();
-    boost::mutex::scoped_lock lock(m_mutex);
-    m_rx_connected = false;
-    m_tx_connected = false;
+    {
+        boost::mutex::scoped_lock lock(m_mutex);
+        m_rx_connected = false;
+        m_tx_connected = false;
+    }
     if (TRACE_EXECUTION)
         DebugLogger() << "ClientNetworking::NetworkingThread() : Networking thread terminated.";
 }

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -336,15 +336,7 @@ void ClientNetworking::NetworkingThread() {
         if (!m_outgoing_messages.empty())
             AsyncWriteMessage();
         AsyncReadMessage();
-        while (1) {
-            try {
-                m_io_service.run();
-                break;
-            } catch (const boost::system::system_error& error) {
-                HandleException(error);
-                break;
-            }
-        }
+        m_io_service.run();
     } catch (const boost::system::system_error& error) {
         HandleException(error);
     }

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -162,11 +162,9 @@ ClientNetworking::ServerList ClientNetworking::DiscoverLANServers() {
 
 bool ClientNetworking::ConnectToServer(
     const std::string& ip_address,
-    std::chrono::milliseconds timeout/* = std::chrono::seconds(10)*/,
-    bool verbose)
+    std::chrono::milliseconds timeout/* = std::chrono::seconds(10)*/)
 {
-    if (verbose)
-        DebugLogger() << "ClientNetworking::ConnectToServer : attempting to connect to server at " << ip_address;
+    DebugLogger() << "ClientNetworking::ConnectToServer : attempting to connect to server at " << ip_address;
 
     using namespace boost::asio::ip;
     tcp::resolver resolver(m_io_service);
@@ -206,14 +204,14 @@ bool ClientNetworking::ConnectToServer(
                 DebugLogger() << "ClientNetworking::ConnectToServer : starting networking thread";
                 boost::thread(boost::bind(&ClientNetworking::NetworkingThread, this));
                 break;
-            } else if (verbose) {
+            } else {
                 DebugLogger() << "tcp::resolver::iterator host_name: " << it->host_name()
                               << "  address: " << it->endpoint().address()
                               << "  port: " << it->endpoint().port();
                 DebugLogger() << "ClientNetworking::ConnectToServer : no connection yet...";
             }
         }
-        if (!Connected() && verbose)
+        if (!Connected())
             DebugLogger() << "ClientNetworking::ConnectToServer : failed to connect to server (no exceptions)";
 
     } catch (const std::exception& e) {
@@ -224,14 +222,13 @@ bool ClientNetworking::ConnectToServer(
 }
 
 bool ClientNetworking::ConnectToLocalHostServer(
-    std::chrono::milliseconds timeout/* = std::chrono::seconds(10)*/,
-    bool verbose)
+    std::chrono::milliseconds timeout/* = std::chrono::seconds(10)*/)
 {
     bool retval = false;
 #if FREEORION_WIN32
     try {
 #endif
-        retval = ConnectToServer("127.0.0.1", timeout, verbose);
+        retval = ConnectToServer("127.0.0.1", timeout);
 #if FREEORION_WIN32
     } catch (const boost::system::system_error& e) {
         if (e.code().value() != WSAEADDRNOTAVAIL)

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -251,10 +251,13 @@ bool ClientNetworking::ConnectToLocalHostServer(
 }
 
 void ClientNetworking::DisconnectFromServer() {
-    if (Connected())
+    if (Connected()) {
         m_io_service.post(boost::bind(&ClientNetworking::DisconnectFromServerImpl, this));
-    // HACK! wait a bit for the disconnect to occur
-    std::this_thread::sleep_for(std::chrono::seconds(1));
+        // HACK! wait a bit for the disconnect to occur
+        //only wait ~1 refresh period
+        DebugLogger() << "ClientNetworking::DisconnectFromServer wait";
+        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
 }
 
 void ClientNetworking::SetPlayerID(int player_id) {

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -107,7 +107,7 @@ namespace {
         { m_socket.close(); }
 
         boost::asio::io_service*       m_io_service;
-        boost::asio::basic_waitable_timer<std::chrono::high_resolution_clock> m_timer;
+        boost::asio::high_resolution_timer m_timer;
         boost::asio::ip::udp::socket   m_socket;
 
         std::array<char, 1024> m_recv_buf;
@@ -179,7 +179,7 @@ bool ClientNetworking::ConnectToServer(
     try {
         for (tcp::resolver::iterator it = resolver.resolve(query); it != end_it; ++it) {
             m_socket.close();
-            boost::asio::basic_waitable_timer<std::chrono::high_resolution_clock> timer(m_io_service);
+            boost::asio::high_resolution_timer timer(m_io_service);
 
             m_socket.async_connect(*it, boost::bind(&ClientNetworking::HandleConnection, this,
                                                     &it,
@@ -290,7 +290,7 @@ void ClientNetworking::SendSynchronousMessage(Message message, Message& response
 }
 
 void ClientNetworking::HandleConnection(tcp::resolver::iterator* it,
-                                        boost::asio::basic_waitable_timer<std::chrono::high_resolution_clock>* timer,
+                                        boost::asio::high_resolution_timer* timer,
                                         const boost::system::error_code& error)
 {
     if (error) {

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -182,10 +182,19 @@ bool ClientNetworking::ConnectToServer(
             m_socket.close();
             boost::asio::high_resolution_timer timer(m_io_service);
 
+#ifndef FREEORION_MACOSX
             m_socket.async_connect(*it, boost::bind(&ClientNetworking::HandleConnection, this,
                                                     &it,
                                                     &timer,
                                                     boost::asio::placeholders::error));
+#else
+            auto backoff_time = std::chrono::milliseconds(10);
+            m_socket.async_connect(*it, boost::bind(&ClientNetworking::HandleConnection, this,
+                                                    &it,
+                                                    &timer,
+                                                    backoff_time,
+                                                    boost::asio::placeholders::error));
+#endif
             timer.expires_from_now(timeout);
             timer.async_wait(boost::bind(&ClientNetworking::CancelRetries, this));
             m_cancel_retries = false;
@@ -298,6 +307,7 @@ void ClientNetworking::SendSynchronousMessage(Message message, Message& response
                                << "response message " << response_message;
 }
 
+#ifndef FREEORION_MACOSX
 void ClientNetworking::HandleConnection(tcp::resolver::iterator* it,
                                         boost::asio::high_resolution_timer* timer,
                                         const boost::system::error_code& error)
@@ -319,6 +329,39 @@ void ClientNetworking::HandleConnection(tcp::resolver::iterator* it,
         m_connected = true;
     }
 }
+#else
+void ClientNetworking::HandleConnection(tcp::resolver::iterator* it,
+                                        boost::asio::high_resolution_timer* timer,
+                                        std::chrono::milliseconds& backoff_time,
+                                        const boost::system::error_code& error)
+{
+    if (error) {
+        if (!m_cancel_retries) {
+            // Try a progressive backoff to prevent MAXOSX from blocking repeated connection attempts.
+            DebugLogger() << "Retry connection after backoff of " << backoff_time.count() << " ms.";
+            std::this_thread::sleep_for(backoff_time);
+            // double backoff time until 1 sec then start again at 10ms
+            backoff_time =  (backoff_time > std::chrono::seconds(1)) ? std::chrono::milliseconds(10) : (2 * backoff_time);
+
+            if (TRACE_EXECUTION)
+                DebugLogger() << "ClientNetworking::HandleConnection : connection "
+                              << "error #"<<error.value()<<" \"" << error.message() << "\""
+                              << "... retrying";
+            m_socket.async_connect(**it, boost::bind(&ClientNetworking::HandleConnection, this,
+                                                     it,
+                                                     timer,
+                                                     backoff_time,
+                                                     boost::asio::placeholders::error));
+        }
+    } else {
+        if (TRACE_EXECUTION)
+            DebugLogger() << "ClientNetworking::HandleConnection : connected";
+        timer->cancel();
+        boost::mutex::scoped_lock lock(m_mutex);
+        m_connected = true;
+    }
+}
+#endif
 
 void ClientNetworking::CancelRetries()
 { m_cancel_retries = true; }

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -383,7 +383,6 @@ void ClientNetworking::NetworkingThread(std::shared_ptr<ClientNetworking>& self)
         m_rx_connected = false;
         m_tx_connected = false;
     }
-    DebugLogger() << "ClientNetworking::NetworkingThread() : Networking thread terminated noisy.";
     if (TRACE_EXECUTION)
         DebugLogger() << "ClientNetworking::NetworkingThread() : Networking thread terminated.";
 }
@@ -393,9 +392,6 @@ void ClientNetworking::HandleMessageBodyRead(boost::system::error_code error,
 {
     if (error)
         throw boost::system::system_error(error);
-
-    if (bytes_transferred == 0 )
-        DebugLogger() << "0 length received in header";
 
     assert(static_cast<int>(bytes_transferred) <= m_incoming_header[4]);
     if (static_cast<int>(bytes_transferred) == m_incoming_header[4]) {
@@ -407,10 +403,6 @@ void ClientNetworking::HandleMessageBodyRead(boost::system::error_code error,
 void ClientNetworking::HandleMessageHeaderRead(boost::system::error_code error, std::size_t bytes_transferred) {
     if (error)
         throw boost::system::system_error(error);
-
-    if (bytes_transferred == 0 )
-        DebugLogger() << "0 length received in body";
-
     assert(bytes_transferred <= Message::HeaderBufferSize);
     if (bytes_transferred != Message::HeaderBufferSize)
         return;
@@ -446,8 +438,6 @@ void ClientNetworking::HandleMessageWrite(boost::system::error_code error, std::
     if (static_cast<int>(bytes_transferred) != static_cast<int>(Message::HeaderBufferSize) + m_outgoing_header[4])
         return;
 
-    DebugLogger() << "tx success num bytes = " << bytes_transferred;
-
     m_outgoing_messages.pop_front();
     if (!m_outgoing_messages.empty())
         AsyncWriteMessage();
@@ -460,7 +450,6 @@ void ClientNetworking::HandleMessageWrite(boost::system::error_code error, std::
             should_shutdown = !m_tx_connected;
         }
         if (should_shutdown) {
-            DebugLogger() << "tx queue empty trying to disconnect.";
             DisconnectFromServerImpl();
         }
     }
@@ -512,11 +501,7 @@ void ClientNetworking::DisconnectFromServerImpl() {
         m_rx_connected = m_socket.is_open();
     }
 
-    DebugLogger() << "shutdown both is_open() = " << m_socket.is_open()
-                  << " outgoing pending = " << (!m_outgoing_messages.empty());
-
     if (!m_outgoing_messages.empty()) {
-        DebugLogger() << "wait on pending final txs";
         return;
     }
 

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -162,7 +162,7 @@ ClientNetworking::ServerList ClientNetworking::DiscoverLANServers() {
 
 bool ClientNetworking::ConnectToServer(
     const std::string& ip_address,
-    std::chrono::milliseconds timeout/* = std::chrono::seconds(5)*/,
+    std::chrono::milliseconds timeout/* = std::chrono::seconds(10)*/,
     bool verbose)
 {
     if (verbose)
@@ -224,7 +224,7 @@ bool ClientNetworking::ConnectToServer(
 }
 
 bool ClientNetworking::ConnectToLocalHostServer(
-    std::chrono::milliseconds timeout/* = std::chrono::seconds(5)*/,
+    std::chrono::milliseconds timeout/* = std::chrono::seconds(10)*/,
     bool verbose)
 {
     bool retval = false;

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -357,13 +357,13 @@ void ClientNetworking::HandleConnection(tcp::resolver::iterator* it,
 }
 
 void ClientNetworking::HandleException(const boost::system::system_error& error) {
-    if (error.code() == boost::asio::error::eof ||
-        error.code() == boost::asio::error::connection_reset ||
-        error.code() == boost::asio::error::operation_aborted)
-    {
-        DebugLogger() << "ClientNetworking::NetworkingThread() : Networking thread will be terminated "
-                      << "due to disconnect exception \"" << error.what() << "\"";
-    } else {
+    if (error.code() == boost::asio::error::eof)
+        DebugLogger() << "Client connection disconnected by EOF from server.";
+    else if (error.code() == boost::asio::error::connection_reset)
+        DebugLogger() << "Client connection disconnected, due to connection reset from server.";
+    else if (error.code() == boost::asio::error::operation_aborted)
+        DebugLogger() << "Client connection closed by client.";
+    else {
         ErrorLogger() << "ClientNetworking::NetworkingThread() : Networking thread will be terminated "
                       << "due to unhandled exception \"" << error.what() << "\"";
     }

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -284,7 +284,7 @@ void ClientNetworking::DisconnectFromServer() {
     { // Create a scope for the mutex
         boost::mutex::scoped_lock lock(m_mutex);
         is_open = m_rx_connected || m_tx_connected;
-    } // Destroy the scope for the mutex.
+    }
 
     if (is_open)
         m_io_service.post(boost::bind(&ClientNetworking::DisconnectFromServerImpl, this));
@@ -378,7 +378,7 @@ void ClientNetworking::NetworkingThread(std::shared_ptr<ClientNetworking>& self)
     m_incoming_messages.Clear();
     m_outgoing_messages.clear();
     m_io_service.reset();
-    {
+    { // Mutex scope
         boost::mutex::scoped_lock lock(m_mutex);
         m_rx_connected = false;
         m_tx_connected = false;

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -13,7 +13,6 @@
 #include <boost/thread/condition.hpp>
 #include <boost/thread/thread.hpp>
 
-
 using boost::asio::ip::tcp;
 using namespace Networking;
 
@@ -63,7 +62,7 @@ namespace {
                                 this,
                                 boost::asio::placeholders::error,
                                 boost::asio::placeholders::bytes_transferred));
-                m_timer.expires_from_now(boost::posix_time::seconds(2));
+                m_timer.expires_from_now(boost::chrono::seconds(2));
                 m_timer.async_wait(boost::bind(&ServerDiscoverer::CloseSocket, this));
                 m_io_service->run();
                 m_io_service->reset();
@@ -106,7 +105,7 @@ namespace {
         { m_socket.close(); }
 
         boost::asio::io_service*       m_io_service;
-        boost::asio::deadline_timer    m_timer;
+        boost::asio::high_resolution_timer m_timer;
         boost::asio::ip::udp::socket   m_socket;
 
         std::array<char, 1024> m_recv_buf;
@@ -161,7 +160,7 @@ ClientNetworking::ServerList ClientNetworking::DiscoverLANServers() {
 
 bool ClientNetworking::ConnectToServer(
     const std::string& ip_address,
-    boost::posix_time::seconds timeout/* = boost::posix_time::seconds(5)*/)
+    boost::chrono::milliseconds timeout/* = boost::chrono::seconds(5)*/)
 {
     DebugLogger() << "ClientNetworking::ConnectToServer : attempting to connect to server at " << ip_address;
 
@@ -180,7 +179,7 @@ bool ClientNetworking::ConnectToServer(
                           << "  port: " << it->endpoint().port();
 
             m_socket.close();
-            boost::asio::deadline_timer timer(m_io_service);
+            boost::asio::high_resolution_timer timer(m_io_service);
 
             m_socket.async_connect(*it, boost::bind(&ClientNetworking::HandleConnection, this,
                                                     &it,
@@ -218,7 +217,7 @@ bool ClientNetworking::ConnectToServer(
 }
 
 bool ClientNetworking::ConnectToLocalHostServer(
-    boost::posix_time::seconds timeout/* = boost::posix_time::seconds(5)*/)
+    boost::chrono::milliseconds timeout/* = boost::chrono::seconds(5)*/)
 {
     bool retval = false;
 #if FREEORION_WIN32
@@ -283,7 +282,7 @@ void ClientNetworking::SendSynchronousMessage(Message message, Message& response
 }
 
 void ClientNetworking::HandleConnection(tcp::resolver::iterator* it,
-                                        boost::asio::deadline_timer* timer,
+                                        boost::asio::high_resolution_timer* timer,
                                         const boost::system::error_code& error)
 {
     if (error) {

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -19,7 +19,7 @@ using boost::asio::ip::tcp;
 using namespace Networking;
 
 namespace {
-    const bool TRACE_EXECUTION = true;
+    const bool TRACE_EXECUTION = false;
 
     /** A simple client that broadcasts UDP datagrams on the local network for
         FreeOrion servers, and reports any it finds. */

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -383,6 +383,7 @@ void ClientNetworking::NetworkingThread(std::shared_ptr<ClientNetworking>& self)
         m_rx_connected = false;
         m_tx_connected = false;
     }
+    DebugLogger() << "ClientNetworking::NetworkingThread() : Networking thread terminated noisy.";
     if (TRACE_EXECUTION)
         DebugLogger() << "ClientNetworking::NetworkingThread() : Networking thread terminated.";
 }
@@ -392,6 +393,9 @@ void ClientNetworking::HandleMessageBodyRead(boost::system::error_code error,
 {
     if (error)
         throw boost::system::system_error(error);
+
+    if (bytes_transferred == 0 )
+        DebugLogger() << "0 length received in header";
 
     assert(static_cast<int>(bytes_transferred) <= m_incoming_header[4]);
     if (static_cast<int>(bytes_transferred) == m_incoming_header[4]) {
@@ -403,6 +407,10 @@ void ClientNetworking::HandleMessageBodyRead(boost::system::error_code error,
 void ClientNetworking::HandleMessageHeaderRead(boost::system::error_code error, std::size_t bytes_transferred) {
     if (error)
         throw boost::system::system_error(error);
+
+    if (bytes_transferred == 0 )
+        DebugLogger() << "0 length received in body";
+
     assert(bytes_transferred <= Message::HeaderBufferSize);
     if (bytes_transferred != Message::HeaderBufferSize)
         return;
@@ -438,6 +446,8 @@ void ClientNetworking::HandleMessageWrite(boost::system::error_code error, std::
     if (static_cast<int>(bytes_transferred) != static_cast<int>(Message::HeaderBufferSize) + m_outgoing_header[4])
         return;
 
+    DebugLogger() << "tx success num bytes = " << bytes_transferred;
+
     m_outgoing_messages.pop_front();
     if (!m_outgoing_messages.empty())
         AsyncWriteMessage();
@@ -450,6 +460,7 @@ void ClientNetworking::HandleMessageWrite(boost::system::error_code error, std::
             should_shutdown = !m_tx_connected;
         }
         if (should_shutdown) {
+            DebugLogger() << "tx queue empty trying to disconnect.";
             DisconnectFromServerImpl();
         }
     }
@@ -501,7 +512,11 @@ void ClientNetworking::DisconnectFromServerImpl() {
         m_rx_connected = m_socket.is_open();
     }
 
+    DebugLogger() << "shutdown both is_open() = " << m_socket.is_open()
+                  << " outgoing pending = " << (!m_outgoing_messages.empty());
+
     if (!m_outgoing_messages.empty()) {
+        DebugLogger() << "wait on pending final txs";
         return;
     }
 

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -105,7 +105,7 @@ namespace {
         { m_socket.close(); }
 
         boost::asio::io_service*       m_io_service;
-        boost::asio::high_resolution_timer m_timer;
+        boost::asio::basic_waitable_timer<boost::chrono::high_resolution_clock> m_timer;
         boost::asio::ip::udp::socket   m_socket;
 
         std::array<char, 1024> m_recv_buf;
@@ -179,7 +179,7 @@ bool ClientNetworking::ConnectToServer(
             if (verbose)
 
             m_socket.close();
-            boost::asio::high_resolution_timer timer(m_io_service);
+            boost::asio::basic_waitable_timer<boost::chrono::high_resolution_clock> timer(m_io_service);
 
             m_socket.async_connect(*it, boost::bind(&ClientNetworking::HandleConnection, this,
                                                     &it,
@@ -289,7 +289,7 @@ void ClientNetworking::SendSynchronousMessage(Message message, Message& response
 }
 
 void ClientNetworking::HandleConnection(tcp::resolver::iterator* it,
-                                        boost::asio::high_resolution_timer* timer,
+                                        boost::asio::basic_waitable_timer<boost::chrono::high_resolution_clock>* timer,
                                         const boost::system::error_code& error)
 {
     if (error) {

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -13,6 +13,8 @@
 #include <boost/thread/condition.hpp>
 #include <boost/thread/thread.hpp>
 
+#include <thread>
+
 using boost::asio::ip::tcp;
 using namespace Networking;
 
@@ -62,7 +64,7 @@ namespace {
                                 this,
                                 boost::asio::placeholders::error,
                                 boost::asio::placeholders::bytes_transferred));
-                m_timer.expires_from_now(boost::chrono::seconds(2));
+                m_timer.expires_from_now(std::chrono::seconds(2));
                 m_timer.async_wait(boost::bind(&ServerDiscoverer::CloseSocket, this));
                 m_io_service->run();
                 m_io_service->reset();
@@ -105,7 +107,7 @@ namespace {
         { m_socket.close(); }
 
         boost::asio::io_service*       m_io_service;
-        boost::asio::basic_waitable_timer<boost::chrono::high_resolution_clock> m_timer;
+        boost::asio::basic_waitable_timer<std::chrono::high_resolution_clock> m_timer;
         boost::asio::ip::udp::socket   m_socket;
 
         std::array<char, 1024> m_recv_buf;
@@ -160,7 +162,7 @@ ClientNetworking::ServerList ClientNetworking::DiscoverLANServers() {
 
 bool ClientNetworking::ConnectToServer(
     const std::string& ip_address,
-    boost::chrono::milliseconds timeout/* = boost::chrono::seconds(5)*/,
+    std::chrono::milliseconds timeout/* = std::chrono::seconds(5)*/,
     bool verbose)
 {
     if (verbose)
@@ -177,7 +179,7 @@ bool ClientNetworking::ConnectToServer(
     try {
         for (tcp::resolver::iterator it = resolver.resolve(query); it != end_it; ++it) {
             m_socket.close();
-            boost::asio::basic_waitable_timer<boost::chrono::high_resolution_clock> timer(m_io_service);
+            boost::asio::basic_waitable_timer<std::chrono::high_resolution_clock> timer(m_io_service);
 
             m_socket.async_connect(*it, boost::bind(&ClientNetworking::HandleConnection, this,
                                                     &it,
@@ -222,7 +224,7 @@ bool ClientNetworking::ConnectToServer(
 }
 
 bool ClientNetworking::ConnectToLocalHostServer(
-    boost::chrono::milliseconds timeout/* = boost::chrono::seconds(5)*/,
+    std::chrono::milliseconds timeout/* = std::chrono::seconds(5)*/,
     bool verbose)
 {
     bool retval = false;
@@ -243,7 +245,7 @@ void ClientNetworking::DisconnectFromServer() {
     if (Connected())
         m_io_service.post(boost::bind(&ClientNetworking::DisconnectFromServerImpl, this));
     // HACK! wait a bit for the disconnect to occur
-    boost::this_thread::sleep_for(boost::chrono::seconds(1));
+    std::this_thread::sleep_for(std::chrono::seconds(1));
 }
 
 void ClientNetworking::SetPlayerID(int player_id) {
@@ -288,7 +290,7 @@ void ClientNetworking::SendSynchronousMessage(Message message, Message& response
 }
 
 void ClientNetworking::HandleConnection(tcp::resolver::iterator* it,
-                                        boost::asio::basic_waitable_timer<boost::chrono::high_resolution_clock>* timer,
+                                        boost::asio::basic_waitable_timer<std::chrono::high_resolution_clock>* timer,
                                         const boost::system::error_code& error)
 {
     if (error) {

--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -112,7 +112,7 @@ public:
         synchronous response from the server. */
     void SendSynchronousMessage(Message message, Message& response_message);
 
-    /** Disconnects the client from the server. */
+    /** Disconnects the client from the server. Try to send any pending transmit messages. */
     void DisconnectFromServer();
 
     /** Sets player ID for this client. */

--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -128,9 +128,11 @@ private:
                           const boost::system::error_code& error);
     void CancelRetries();
     void NetworkingThread(std::shared_ptr<ClientNetworking> &self);
-    void HandleMessageBodyRead(     boost::system::error_code error, std::size_t bytes_transferred);
-    void HandleMessageHeaderRead(   boost::system::error_code error, std::size_t bytes_transferred);
-    void AsyncReadMessage();
+    void HandleMessageBodyRead(const std::shared_ptr<ClientNetworking>& keep_alive,
+                               boost::system::error_code error, std::size_t bytes_transferred);
+    void HandleMessageHeaderRead(const std::shared_ptr<ClientNetworking>& keep_alive,
+                                 boost::system::error_code error, std::size_t bytes_transferred);
+    void AsyncReadMessage(const std::shared_ptr<ClientNetworking>& keep_alive);
     void HandleMessageWrite(        boost::system::error_code error, std::size_t bytes_transferred);
     void AsyncWriteMessage();
     void SendMessageImpl(Message message);

--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -82,12 +82,14 @@ public:
     /** Connects to the server at \a ip_address.  On failure, repeated
         attempts will be made until \a timeout seconds has elapsed. */
     bool ConnectToServer(const std::string& ip_address,
-                         boost::chrono::milliseconds timeout = boost::chrono::seconds(5));
+                         boost::chrono::milliseconds timeout = boost::chrono::seconds(5),
+                         bool verbose = false);
 
     /** Connects to the server on the client's host.  On failure, repeated
         attempts will be made until \a timeout seconds has elapsed. */
     bool ConnectToLocalHostServer(boost::chrono::milliseconds timeout =
-                                  boost::chrono::seconds(5));
+                                  boost::chrono::seconds(5),
+                                  bool verbose = false);
 
     /** Sends \a message to the server.  This function actually just enqueues
         the message for sending and returns immediately. */

--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -119,7 +119,7 @@ public:
 private:
     void HandleException(const boost::system::system_error& error);
     void HandleConnection(boost::asio::ip::tcp::resolver::iterator* it,
-                          boost::asio::high_resolution_timer* timer,
+                          boost::asio::basic_waitable_timer<boost::chrono::high_resolution_clock>* timer,
                           const boost::system::error_code& error);
     void CancelRetries();
     void NetworkingThread();

--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -112,7 +112,7 @@ public:
         synchronous response from the server. */
     void SendSynchronousMessage(Message message, Message& response_message);
 
-    /** Disconnects the client from the server. Try to send any pending transmit messages. */
+    /** Disconnects the client from the server. First tries to send any pending transmit messages. */
     void DisconnectFromServer();
 
     /** Sets player ID for this client. */
@@ -127,7 +127,7 @@ private:
     void HandleConnection(boost::asio::ip::tcp::resolver::iterator* it,
                           const boost::system::error_code& error);
     void CancelRetries();
-    void NetworkingThread(std::shared_ptr<ClientNetworking> &self);
+    void NetworkingThread(std::shared_ptr<ClientNetworking>& self);
     void HandleMessageBodyRead(const std::shared_ptr<ClientNetworking>& keep_alive,
                                boost::system::error_code error, std::size_t bytes_transferred);
     void HandleMessageHeaderRead(const std::shared_ptr<ClientNetworking>& keep_alive,
@@ -143,7 +143,12 @@ private:
 
     boost::asio::io_service         m_io_service;
     boost::asio::ip::tcp::socket    m_socket;
+
+    // m_mutex guards m_incoming_message, m_rx_connected and m_tx_connected which are written by
+    // the networking thread and read by the main thread to check incoming messages and connection
+    // status.
     mutable boost::mutex            m_mutex;
+
     MessageQueue                    m_incoming_messages; // accessed from multiple threads, but its interface is threadsafe
     std::list<Message>              m_outgoing_messages;
     bool                            m_rx_connected;      // accessed from multiple threads

--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -16,7 +16,6 @@
 #   undef MessageBox
 #endif
 
-
 /** Encapsulates the networking facilities of the client.  The client must
     execute its networking code in a separate thread from its main processing
     thread, for UI and networking responsiveness, and to process synchronous
@@ -117,7 +116,6 @@ public:
 private:
     void HandleException(const boost::system::system_error& error);
     void HandleConnection(boost::asio::ip::tcp::resolver::iterator* it,
-                          boost::asio::high_resolution_timer* timer,
                           const boost::system::error_code& error);
     void CancelRetries();
     void NetworkingThread();
@@ -138,7 +136,6 @@ private:
     MessageQueue                    m_incoming_messages; // accessed from multiple threads, but its interface is threadsafe
     std::list<Message>              m_outgoing_messages;
     bool                            m_connected;         // accessed from multiple threads
-    bool                            m_cancel_retries;
 
     Message::HeaderBuffer           m_incoming_header;
     Message                         m_incoming_message;

--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -16,6 +16,9 @@
 #   undef MessageBox
 #endif
 
+#ifndef FREEORION_MACOSX
+#include <chrono>
+#endif
 
 /** Encapsulates the networking facilities of the client.  The client must
     execute its networking code in a separate thread from its main processing
@@ -116,9 +119,16 @@ public:
 
 private:
     void HandleException(const boost::system::system_error& error);
+#ifndef FREEORION_MACOSX
     void HandleConnection(boost::asio::ip::tcp::resolver::iterator* it,
                           boost::asio::high_resolution_timer* timer,
                           const boost::system::error_code& error);
+#else
+    void HandleConnection(boost::asio::ip::tcp::resolver::iterator* it,
+                          boost::asio::high_resolution_timer* timer,
+                          std::chrono::milliseconds& backoff_time,
+                          const boost::system::error_code& error);
+#endif
     void CancelRetries();
     void NetworkingThread();
     void HandleMessageBodyRead(     boost::system::error_code error, std::size_t bytes_transferred);

--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -10,6 +10,7 @@
 // FreeOrion function names.
 #define NOMINMAX
 #include <boost/asio.hpp>
+#include <boost/asio/high_resolution_timer.hpp>
 #ifdef FREEORION_WIN32
 #   undef Message
 #   undef MessageBox
@@ -81,12 +82,12 @@ public:
     /** Connects to the server at \a ip_address.  On failure, repeated
         attempts will be made until \a timeout seconds has elapsed. */
     bool ConnectToServer(const std::string& ip_address,
-                         boost::posix_time::seconds timeout = boost::posix_time::seconds(5));
+                         boost::chrono::milliseconds timeout = boost::chrono::seconds(5));
 
     /** Connects to the server on the client's host.  On failure, repeated
         attempts will be made until \a timeout seconds has elapsed. */
-    bool ConnectToLocalHostServer(boost::posix_time::seconds timeout =
-                                  boost::posix_time::seconds(5));
+    bool ConnectToLocalHostServer(boost::chrono::milliseconds timeout =
+                                  boost::chrono::seconds(5));
 
     /** Sends \a message to the server.  This function actually just enqueues
         the message for sending and returns immediately. */
@@ -116,7 +117,7 @@ public:
 private:
     void HandleException(const boost::system::system_error& error);
     void HandleConnection(boost::asio::ip::tcp::resolver::iterator* it,
-                          boost::asio::deadline_timer* timer,
+                          boost::asio::high_resolution_timer* timer,
                           const boost::system::error_code& error);
     void CancelRetries();
     void NetworkingThread();

--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -119,7 +119,7 @@ public:
 private:
     void HandleException(const boost::system::system_error& error);
     void HandleConnection(boost::asio::ip::tcp::resolver::iterator* it,
-                          boost::asio::basic_waitable_timer<std::chrono::high_resolution_clock>* timer,
+                          boost::asio::high_resolution_timer* timer,
                           const boost::system::error_code& error);
     void CancelRetries();
     void NetworkingThread();

--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -146,7 +146,8 @@ private:
 
     // m_mutex guards m_incoming_message, m_rx_connected and m_tx_connected which are written by
     // the networking thread and read by the main thread to check incoming messages and connection
-    // status.
+    // status. As those read and write operations are not atomic, shared access has to be
+    // protected to prevent unpredictable results.
     mutable boost::mutex            m_mutex;
 
     MessageQueue                    m_incoming_messages; // accessed from multiple threads, but its interface is threadsafe

--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -29,7 +29,7 @@
     periodically request the next incoming message; the arrival of incoming
     messages is never explicitly signalled to the main thread.  The same
     applies to unintentional disconnects from the server.  The client must
-    periodically check Connected().
+    periodically check IsConnected().
 
     The ClientNetworking has three modes of operation.  First, it can discover
     FreeOrion servers on the local network; this is a blocking operation with
@@ -57,8 +57,14 @@ public:
     //@}
 
     /** \name Accessors */ //@{
-    /** Returns true iff the client is connected to the server. */
-    bool Connected() const;
+    /** Returns true iff the client is full duplex connected to the server. */
+    bool IsConnected() const;
+
+    /** Returns true iff the client is connected to receive from the server. */
+    bool IsRxConnected() const;
+
+    /** Returns true iff the client is connected to send to the server. */
+    bool IsTxConnected() const;
 
     /** Returns true iff there is at least one incoming message available. */
     bool MessageAvailable() const;
@@ -135,7 +141,8 @@ private:
     mutable boost::mutex            m_mutex;
     MessageQueue                    m_incoming_messages; // accessed from multiple threads, but its interface is threadsafe
     std::list<Message>              m_outgoing_messages;
-    bool                            m_connected;         // accessed from multiple threads
+    bool                            m_rx_connected;      // accessed from multiple threads
+    bool                            m_tx_connected;      // accessed from multiple threads
 
     Message::HeaderBuffer           m_incoming_header;
     Message                         m_incoming_message;

--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -82,13 +82,13 @@ public:
     /** Connects to the server at \a ip_address.  On failure, repeated
         attempts will be made until \a timeout seconds has elapsed. */
     bool ConnectToServer(const std::string& ip_address,
-                         std::chrono::milliseconds timeout = std::chrono::seconds(5),
+                         std::chrono::milliseconds timeout = std::chrono::seconds(10),
                          bool verbose = false);
 
     /** Connects to the server on the client's host.  On failure, repeated
         attempts will be made until \a timeout seconds has elapsed. */
     bool ConnectToLocalHostServer(std::chrono::milliseconds timeout =
-                                  std::chrono::seconds(5),
+                                  std::chrono::seconds(10),
                                   bool verbose = false);
 
     /** Sends \a message to the server.  This function actually just enqueues

--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -16,9 +16,6 @@
 #   undef MessageBox
 #endif
 
-#ifndef FREEORION_MACOSX
-#include <chrono>
-#endif
 
 /** Encapsulates the networking facilities of the client.  The client must
     execute its networking code in a separate thread from its main processing
@@ -119,16 +116,9 @@ public:
 
 private:
     void HandleException(const boost::system::system_error& error);
-#ifndef FREEORION_MACOSX
     void HandleConnection(boost::asio::ip::tcp::resolver::iterator* it,
                           boost::asio::high_resolution_timer* timer,
                           const boost::system::error_code& error);
-#else
-    void HandleConnection(boost::asio::ip::tcp::resolver::iterator* it,
-                          boost::asio::high_resolution_timer* timer,
-                          std::chrono::milliseconds& backoff_time,
-                          const boost::system::error_code& error);
-#endif
     void CancelRetries();
     void NetworkingThread();
     void HandleMessageBodyRead(     boost::system::error_code error, std::size_t bytes_transferred);

--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -82,14 +82,12 @@ public:
     /** Connects to the server at \a ip_address.  On failure, repeated
         attempts will be made until \a timeout seconds has elapsed. */
     bool ConnectToServer(const std::string& ip_address,
-                         std::chrono::milliseconds timeout = std::chrono::seconds(10),
-                         bool verbose = false);
+                         std::chrono::milliseconds timeout = std::chrono::seconds(10));
 
     /** Connects to the server on the client's host.  On failure, repeated
         attempts will be made until \a timeout seconds has elapsed. */
     bool ConnectToLocalHostServer(std::chrono::milliseconds timeout =
-                                  std::chrono::seconds(10),
-                                  bool verbose = false);
+                                  std::chrono::seconds(10));
 
     /** Sends \a message to the server.  This function actually just enqueues
         the message for sending and returns immediately. */

--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -82,13 +82,13 @@ public:
     /** Connects to the server at \a ip_address.  On failure, repeated
         attempts will be made until \a timeout seconds has elapsed. */
     bool ConnectToServer(const std::string& ip_address,
-                         boost::chrono::milliseconds timeout = boost::chrono::seconds(5),
+                         std::chrono::milliseconds timeout = std::chrono::seconds(5),
                          bool verbose = false);
 
     /** Connects to the server on the client's host.  On failure, repeated
         attempts will be made until \a timeout seconds has elapsed. */
-    bool ConnectToLocalHostServer(boost::chrono::milliseconds timeout =
-                                  boost::chrono::seconds(5),
+    bool ConnectToLocalHostServer(std::chrono::milliseconds timeout =
+                                  std::chrono::seconds(5),
                                   bool verbose = false);
 
     /** Sends \a message to the server.  This function actually just enqueues
@@ -119,7 +119,7 @@ public:
 private:
     void HandleException(const boost::system::system_error& error);
     void HandleConnection(boost::asio::ip::tcp::resolver::iterator* it,
-                          boost::asio::basic_waitable_timer<boost::chrono::high_resolution_clock>* timer,
+                          boost::asio::basic_waitable_timer<std::chrono::high_resolution_clock>* timer,
                           const boost::system::error_code& error);
     void CancelRetries();
     void NetworkingThread();

--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -16,6 +16,9 @@
 #   undef MessageBox
 #endif
 
+#include <memory>
+
+
 /** Encapsulates the networking facilities of the client.  The client must
     execute its networking code in a separate thread from its main processing
     thread, for UI and networking responsiveness, and to process synchronous
@@ -47,7 +50,7 @@
     even if it is not at the front of the queue at the time.  This implies
     that some response messages may be handled out of order with respect to
     regular messages, but these are in fact the desired semantics. */
-class ClientNetworking {
+class ClientNetworking : public std::enable_shared_from_this<ClientNetworking> {
 public:
     /** The type of list returned by a call to DiscoverLANServers(). */
     typedef std::vector<std::pair<boost::asio::ip::address, std::string> >  ServerList;
@@ -124,7 +127,7 @@ private:
     void HandleConnection(boost::asio::ip::tcp::resolver::iterator* it,
                           const boost::system::error_code& error);
     void CancelRetries();
-    void NetworkingThread();
+    void NetworkingThread(std::shared_ptr<ClientNetworking> &self);
     void HandleMessageBodyRead(     boost::system::error_code error, std::size_t bytes_transferred);
     void HandleMessageHeaderRead(   boost::system::error_code error, std::size_t bytes_transferred);
     void AsyncReadMessage();

--- a/network/Message.cpp
+++ b/network/Message.cpp
@@ -583,6 +583,9 @@ Message EndGameMessage(int receiver, Message::EndGameReason reason,
     return Message(Message::END_GAME, Networking::INVALID_PLAYER_ID, receiver, os.str());
 }
 
+Message AIEndGameAcknowledgeMessage(int sender)
+{ return Message(Message::AI_END_GAME_ACK, sender, Networking::INVALID_PLAYER_ID, DUMMY_EMPTY_MESSAGE); }
+
 Message ModeratorActionMessage(int sender, const Moderator::ModeratorAction& action) {
     std::ostringstream os;
     {

--- a/network/Message.h
+++ b/network/Message.h
@@ -84,6 +84,7 @@ public:
         REQUEST_NEW_DESIGN_ID,  ///< sent by client to server requesting a new design ID.
         DISPATCH_NEW_DESIGN_ID, ///< sent by server to client with the new design ID.
         END_GAME,               ///< sent by the server when the current game is to ending (see EndGameReason for the possible reasons this message is sent out)
+        AI_END_GAME_ACK,        ///< sent by the ai client when it has shutdown
         MODERATOR_ACTION,       ///< sent by client to server when a moderator edits the universe
         SHUT_DOWN_SERVER,       ///< sent by host client to server to kill the server process
         REQUEST_SAVE_PREVIEWS,  ///< sent by client to request previews of available savegames
@@ -310,6 +311,9 @@ FO_COMMON_API Message DiplomaticStatusMessage(int receiver, const DiplomaticStat
 
 /** creates an END_GAME message used to terminate an active game. */
 FO_COMMON_API Message EndGameMessage(int receiver, Message::EndGameReason reason, const std::string& reason_player_name = "");
+
+/** creates an AI_END_GAME_ACK message used to indicate that the AI has shutdown. */
+FO_COMMON_API Message AIEndGameAcknowledgeMessage(int sender);
 
 /** creates a MODERATOR_ACTION message used to implement moderator commands. */
 FO_COMMON_API Message ModeratorActionMessage(int sender, const Moderator::ModeratorAction& mod_action);

--- a/network/ServerNetworking.cpp
+++ b/network/ServerNetworking.cpp
@@ -312,6 +312,9 @@ bool PlayerConnection::SyncWriteMessage(const Message& message) {
 }
 
 void PlayerConnection::AsyncErrorHandler(boost::system::error_code handled_error, boost::system::error_code error) {
+    ErrorLogger() << "PlayerConnection::WriteMessage(): player id = " << m_ID
+                  << " error #" << handled_error.value() << " \"" << handled_error.message()
+                  << " handled.";
     EventSignal(boost::bind(m_disconnected_callback, shared_from_this()));
 }
 

--- a/network/ServerNetworking.cpp
+++ b/network/ServerNetworking.cpp
@@ -327,9 +327,6 @@ bool PlayerConnection::SyncWriteMessage(const Message& message) {
 }
 
 void PlayerConnection::AsyncErrorHandler(boost::system::error_code handled_error, boost::system::error_code error) {
-    ErrorLogger() << "PlayerConnection::WriteMessage(): player id = " << m_ID
-                  << " error #" << handled_error.value() << " \"" << handled_error.message()
-                  << " handled.";
     EventSignal(boost::bind(m_disconnected_callback, shared_from_this()));
 }
 

--- a/network/ServerNetworking.cpp
+++ b/network/ServerNetworking.cpp
@@ -77,9 +77,10 @@ PlayerConnection::PlayerConnection(boost::asio::io_service& io_service,
 PlayerConnection::~PlayerConnection() {
     boost::system::error_code ec;
     m_socket.shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
-    if (ec) {
+    if (ec && (m_ID != INVALID_PLAYER_ID)) {
         ErrorLogger() << "PlayerConnection::~PlayerConnection: shutdown error #"
-                      << ec.value() << " \"" << ec.message() << "\"";
+                      << ec.value() << " \"" << ec.message() << "\""
+                      << " for player id " << m_ID;
     }
     m_socket.close();
 }

--- a/network/ServerNetworking.cpp
+++ b/network/ServerNetworking.cpp
@@ -208,9 +208,12 @@ void PlayerConnection::HandleMessageBodyRead(boost::system::error_code error,
     if (error) {
         if (error == boost::asio::error::eof ||
             error == boost::asio::error::connection_reset) {
+            ErrorLogger() << "PlayerConnection::HandleMessageBodyRead(): "
+                          << "error #"<<error.value()<<" \"" << error.message() << "\"";
             EventSignal(boost::bind(m_disconnected_callback, shared_from_this()));
         } else {
-            ErrorLogger() << "PlayerConnection::HandleMessageBodyRead(): error \"" << error << "\"";
+            ErrorLogger() << "PlayerConnection::HandleMessageBodyRead(): "
+                          << "error #"<<error.value()<<" \"" << error.message() << "\"";
         }
     } else {
         assert(static_cast<int>(bytes_transferred) <= m_incoming_header_buffer[4]);
@@ -250,6 +253,9 @@ void PlayerConnection::HandleMessageHeaderRead(boost::system::error_code error,
         if (m_new_connection) {
             // wait half a second if the first data read is an error; we
             // probably just need more setup time
+            ErrorLogger() << "PlayerConnection::HandleMessageHeaderRead(): "
+                          << "new connection error #" << error.value() << " \""
+                          << error.message() << "\"" << " waiting for 0.5s";
             std::this_thread::sleep_for(std::chrono::milliseconds(500));
         } else {
             if (error == boost::asio::error::eof ||

--- a/network/ServerNetworking.cpp
+++ b/network/ServerNetworking.cpp
@@ -9,6 +9,7 @@
 #include <boost/iterator/filter_iterator.hpp>
 #include <boost/thread/thread.hpp>
 
+#include <thread>
 
 using boost::asio::ip::tcp;
 using boost::asio::ip::udp;
@@ -249,7 +250,7 @@ void PlayerConnection::HandleMessageHeaderRead(boost::system::error_code error,
         if (m_new_connection) {
             // wait half a second if the first data read is an error; we
             // probably just need more setup time
-            boost::this_thread::sleep_for(boost::chrono::milliseconds(500));
+            std::this_thread::sleep_for(std::chrono::milliseconds(500));
         } else {
             if (error == boost::asio::error::eof ||
                 error == boost::asio::error::connection_reset) {

--- a/network/ServerNetworking.cpp
+++ b/network/ServerNetworking.cpp
@@ -80,6 +80,8 @@ PlayerConnection::~PlayerConnection() {
             DebugLogger() << "Player connection shutdown.";
         else if (error == boost::asio::error::connection_aborted)
             DebugLogger() << "Player connection closed by server.";
+        else if (error == boost::asio::error::not_connected)
+            DebugLogger() << "Player connection already down.";
         else {
 
             ErrorLogger() << "PlayerConnection::~PlayerConnection: shutdown error #"

--- a/network/ServerNetworking.cpp
+++ b/network/ServerNetworking.cpp
@@ -78,7 +78,8 @@ PlayerConnection::~PlayerConnection() {
     boost::system::error_code ec;
     m_socket.shutdown(boost::asio::ip::tcp::socket::shutdown_both, ec);
     if (ec) {
-        ErrorLogger() << "PlayerConnection::~PlayerConnection: shutdown error \"" << ec << "\"";
+        ErrorLogger() << "PlayerConnection::~PlayerConnection: shutdown error #"
+                      << ec.value() << " \"" << ec.message() << "\"";
     }
     m_socket.close();
 }

--- a/network/ServerNetworking.cpp
+++ b/network/ServerNetworking.cpp
@@ -254,6 +254,9 @@ void PlayerConnection::HandleMessageHeaderRead(boost::system::error_code error,
         // mask the problem.  For now, this is sufficient, since rapid
         // connects and disconnects are not a priority.
         if (m_new_connection) {
+            ErrorLogger() << "PlayerConnection::HandleMessageHeaderRead(): "
+                          << "new connection error \"" << error << "\""
+                          << " waiting for 0.5s";
             // wait half a second if the first data read is an error; we
             // probably just need more setup time
             ErrorLogger() << "PlayerConnection::HandleMessageHeaderRead(): "

--- a/network/ServerNetworking.cpp
+++ b/network/ServerNetworking.cpp
@@ -197,6 +197,7 @@ namespace {
         case Message::END_GAME:                 return "End Game";
         case Message::MODERATOR_ACTION:         return "Moderator Action";
         case Message::SHUT_DOWN_SERVER:         return "Shut Down Server";
+        case Message::AI_END_GAME_ACK:          return "Acknowledge Shut Down Server";
         case Message::REQUEST_SAVE_PREVIEWS:    return "Request save previews";
         case Message::REQUEST_COMBAT_LOGS:      return "Request combat logs";
         default:                                return "Unknown Type";

--- a/network/ServerNetworking.cpp
+++ b/network/ServerNetworking.cpp
@@ -255,8 +255,8 @@ void PlayerConnection::HandleMessageHeaderRead(boost::system::error_code error,
         // connects and disconnects are not a priority.
         if (m_new_connection) {
             ErrorLogger() << "PlayerConnection::HandleMessageHeaderRead(): "
-                          << "new connection error \"" << error << "\""
-                          << " waiting for 0.5s";
+                          << "new connection error #" << error.value() << " \""
+                          << error.message() << "\"" << " waiting for 0.5s";
             // wait half a second if the first data read is an error; we
             // probably just need more setup time
             ErrorLogger() << "PlayerConnection::HandleMessageHeaderRead(): "
@@ -269,7 +269,7 @@ void PlayerConnection::HandleMessageHeaderRead(boost::system::error_code error,
                 EventSignal(boost::bind(m_disconnected_callback, shared_from_this()));
             } else {
                 ErrorLogger() << "PlayerConnection::HandleMessageHeaderRead(): "
-                              << "error \"" << error << "\"";
+                              << "error #"<<error.value()<<" \"" << error.message() << "\"";
             }
         }
     } else {

--- a/network/ServerNetworking.cpp
+++ b/network/ServerNetworking.cpp
@@ -70,16 +70,16 @@ PlayerConnection::~PlayerConnection() {
     boost::system::error_code error;
     m_socket.shutdown(boost::asio::ip::tcp::socket::shutdown_both, error);
     if (error && (m_ID != INVALID_PLAYER_ID)) {
-        if (error == boost::asio::error::eof) {
+        if (error == boost::asio::error::eof)
             DebugLogger() << "Player connection disconnected by EOF from client.";
-            m_socket.close();
-        }
         else if (error == boost::asio::error::connection_reset)
-            DebugLogger() << "Player connection disconnected, due to connection reset by client.";
+            DebugLogger() << "Player connection disconnected, reset by client.";
         else if (error == boost::asio::error::operation_aborted)
-            DebugLogger() << "Player connection closed by server.";
+            DebugLogger() << "Player operation aborted by server.";
         else if (error == boost::asio::error::shut_down)
             DebugLogger() << "Player connection shutdown.";
+        else if (error == boost::asio::error::connection_aborted)
+            DebugLogger() << "Player connection closed by server.";
         else {
 
             ErrorLogger() << "PlayerConnection::~PlayerConnection: shutdown error #"

--- a/network/ServerNetworking.h
+++ b/network/ServerNetworking.h
@@ -88,11 +88,11 @@ public:
     //@}
 
     /** \name Mutators */ //@{
-    /** Sends message \a message to \a player_connection. */
-    void SendMessage(const Message& message, PlayerConnectionPtr player_connection);
+    /** Sends a synchronous message \a message to \a player_connection and returns true on success. */
+    bool SendMessage(const Message& message, PlayerConnectionPtr player_connection);
 
-    /** Sends message \a message to the player indicated in the message. */
-    void SendMessage(const Message& message);
+    /** Sends a synchronous message \a message to the player indicated in the message and returns true on success. */
+    bool SendMessage(const Message& message);
 
     /** Disconnects the server from player \a id. */
     void Disconnect(int id);
@@ -197,8 +197,8 @@ public:
     /** Starts the connection reading incoming messages on its socket. */
     void Start();
 
-    /** Sends \a message to out on the connection. */
-    void SendMessage(const Message& message);
+    /** Sends \a synchronous message to out on the connection and return true on success. */
+    bool SendMessage(const Message& message);
 
     /** Establishes a connection as a player with a specific name and id.
         This function must only be called once. */
@@ -224,7 +224,10 @@ private:
     void HandleMessageBodyRead(boost::system::error_code error, std::size_t bytes_transferred);
     void HandleMessageHeaderRead(boost::system::error_code error, std::size_t bytes_transferred);
     void AsyncReadMessage();
+    bool SyncWriteMessage(const Message& message);
+    void AsyncErrorHandler(boost::system::error_code handled_error, boost::system::error_code error);
 
+    boost::asio::io_service&        m_service;
     boost::asio::ip::tcp::socket    m_socket;
     Message::HeaderBuffer           m_incoming_header_buffer;
     Message                         m_incoming_message;

--- a/python/AI/AIFramework.cpp
+++ b/python/AI/AIFramework.cpp
@@ -144,7 +144,7 @@ void PythonAI::GenerateOrders() {
         generateOrdersPythonFunction();
     } catch (error_already_set err) {
         HandleErrorAlreadySet();
-        if (IsPythonRunning())
+        if (!IsPythonRunning())
             throw;
 
         ErrorLogger() << "PythonAI::GenerateOrders : Python error caught.  Partial orders sent to server";

--- a/python/AI/AIFramework.cpp
+++ b/python/AI/AIFramework.cpp
@@ -144,7 +144,6 @@ void PythonAI::GenerateOrders() {
         generateOrdersPythonFunction();
     } catch (error_already_set err) {
         HandleErrorAlreadySet();
-        ErrorLogger() << " reached inner catch in generate orders.";
         if (!IsPythonRunning())
             throw;
 

--- a/python/AI/AIFramework.cpp
+++ b/python/AI/AIFramework.cpp
@@ -144,6 +144,7 @@ void PythonAI::GenerateOrders() {
         generateOrdersPythonFunction();
     } catch (error_already_set err) {
         HandleErrorAlreadySet();
+        ErrorLogger() << " reached inner catch in generate orders.";
         if (!IsPythonRunning())
             throw;
 

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -460,6 +460,14 @@ void ServerApp::HandleNonPlayerMessage(const Message& msg, PlayerConnectionPtr p
 void ServerApp::PlayerDisconnected(PlayerConnectionPtr player_connection)
 { m_fsm->process_event(Disconnection(player_connection)); }
 
+void ServerApp::ShutdownTimedoutHandler(boost::system::error_code error) {
+    if (error)
+        DebugLogger() << "Shutdown timed out cancelled";
+
+    DebugLogger() << "Shutdown timed out.  Disconnecting remaining clients.";
+    m_fsm->process_event(DisconnectClients());
+}
+
 void ServerApp::SelectNewHost() {
     int new_host_id = Networking::INVALID_PLAYER_ID;
     int old_host_id = m_networking.HostPlayerID();

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -326,8 +326,7 @@ void ServerApp::InitializePython() {
 
     if (!m_python_server.Initialize()) {
         ErrorLogger() << "Server's python interpreter failed to initialize.";
-        // TODO go to Shutdown in FSM.
-        Exit(0);
+        m_fsm->process_event(ShutdownServer());
     }
 }
 

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -413,7 +413,7 @@ void ServerApp::HandleMessage(const Message& msg, PlayerConnectionPtr player_con
     case Message::DEBUG:                    break;
 
     case Message::SHUT_DOWN_SERVER:         HandleShutdownMessage(msg, player_connection);  break;
-    case Message::AI_END_GAME_ACK:           m_fsm->process_event(LeaveGame(msg, player_connection));        break;
+    case Message::AI_END_GAME_ACK:          m_fsm->process_event(LeaveGame(msg, player_connection));        break;
 
     case Message::REQUEST_SAVE_PREVIEWS:    UpdateSavePreviews(msg, player_connection); break;
     case Message::REQUEST_COMBAT_LOGS:      m_fsm->process_event(RequestCombatLogs(msg, player_connection));break;

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -164,11 +164,9 @@ void ServerApp::operator()()
 { Run(); }
 
 void ServerApp::SignalHandler(const boost::system::error_code& error, int signal_number) {
-    if (!error)
-        throw NormalExitException();
-
-    ErrorLogger() << "Exiting due to OS error (" << error.value() << ") " << error.message();
-    Exit(1);
+    if (error)
+        ErrorLogger() << "Exiting due to OS error (" << error.value() << ") " << error.message();
+    m_fsm->process_event(ShutdownServer());
 }
 
 void ServerApp::Exit(int code) {
@@ -1318,7 +1316,7 @@ void ServerApp::GenerateUniverse(std::map<int, PlayerSetupData>& player_setup_da
         m_python_server.HandleErrorAlreadySet();
         if (!m_python_server.IsPythonRunning()) {
             ErrorLogger() << "Python interpreter is no longer running.  Exiting.";
-            Exit(0);
+            m_fsm->process_event(ShutdownServer());
         }
     }
 
@@ -1371,7 +1369,7 @@ void ServerApp::ExecuteScriptedTurnEvents() {
                 ErrorLogger() << "Python interpreter successfully restarted.";
             } else {
                 ErrorLogger() << "Python interpreter failed to restart.  Exiting.";
-                Exit(0);
+                m_fsm->process_event(ShutdownServer());
             }
         }
     }

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -169,14 +169,6 @@ void ServerApp::SignalHandler(const boost::system::error_code& error, int signal
     m_fsm->process_event(ShutdownServer());
 }
 
-void ServerApp::Exit(int code) {
-    DebugLogger() << "Initiating Exit (code " << code << " - " << (code ? "error" : "normal") << " termination)";
-    CleanupAIs();
-    if (code)
-        exit(code);
-    throw NormalExitException();
-}
-
 namespace {
     std::string AIClientExe()
     {

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -423,6 +423,7 @@ void ServerApp::HandleMessage(const Message& msg, PlayerConnectionPtr player_con
     case Message::DEBUG:                    break;
 
     case Message::SHUT_DOWN_SERVER:         HandleShutdownMessage(msg, player_connection);  break;
+    case Message::AI_END_GAME_ACK:           m_fsm->process_event(LeaveGame(msg, player_connection));        break;
 
     case Message::REQUEST_SAVE_PREVIEWS:    UpdateSavePreviews(msg, player_connection); break;
     case Message::REQUEST_COMBAT_LOGS:      m_fsm->process_event(RequestCombatLogs(msg, player_connection));break;
@@ -442,7 +443,7 @@ void ServerApp::HandleShutdownMessage(const Message& msg, PlayerConnectionPtr pl
         return;
     }
     DebugLogger() << "ServerApp::HandleShutdownMessage shutting down";
-    Exit(0);
+    m_fsm->process_event(ShutdownServer());
 }
 
 void ServerApp::HandleNonPlayerMessage(const Message& msg, PlayerConnectionPtr player_connection) {
@@ -455,8 +456,8 @@ void ServerApp::HandleNonPlayerMessage(const Message& msg, PlayerConnectionPtr p
     default:
         if ((m_networking.size() == 1) && (player_connection->IsLocalConnection()) && (msg.Type() == Message::SHUT_DOWN_SERVER)) {
             DebugLogger() << "ServerApp::HandleNonPlayerMessage received Message::SHUT_DOWN_SERVER from the sole "
-                                   << "connected player, who is local and so the request is being honored; server shutting down.";
-                                   Exit(0);
+                          << "connected player, who is local and so the request is being honored; server shutting down.";
+            m_fsm->process_event(ShutdownServer());
         } else {
             ErrorLogger() << "ServerApp::HandleNonPlayerMessage : Received an invalid message type \""
                                             << msg.Type() << "\" for a non-player Message.  Terminating connection.";

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -328,6 +328,7 @@ private:
     friend struct WaitingForTurnEndIdle;
     friend struct WaitingForSaveData;
     friend struct ProcessingTurn;
+    friend struct ShuttingDownServer;
 };
 
 // template implementations

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -134,7 +134,6 @@ public:
 
     /** \name Mutators */ //@{
     void    operator()();               ///< external interface to Run()
-    void    Exit(int code);             ///< does basic clean-up, then calls exit(); callable from anywhere in user code via GetApp()
 
     /** Returns the galaxy setup data used for the current game */
     GalaxySetupData&    GetGalaxySetupData() { return m_galaxy_setup_data; }

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -284,6 +284,9 @@ private:
     /** Called by ServerNetworking when a player's TCP connection is closed*/
     void    PlayerDisconnected(PlayerConnectionPtr player_connection);
 
+    /** Handle shutdown timeout by killing all ais. */
+    void ShutdownTimedoutHandler(boost::system::error_code error);
+
     /** Called when the host player has disconnected.  Select a new host player*/
     void    SelectNewHost();
 

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -1843,7 +1843,10 @@ ShuttingDownServer::ShuttingDownServer(my_context c) :
         if (player->GetClientType() == Networking::CLIENT_TYPE_AI_PLAYER) {
             if (good_connection) {
                 // Only expect acknowledgement from sockets that are up.
+                DebugLogger() << "Expected shutdown ack from id = " << player->PlayerID();
                 m_player_id_ack_expected.insert(player->PlayerID());
+            } else {
+                DebugLogger() << "Not Expecting shutdown ack from id = " << player->PlayerID() << " bad connection";
             }
         }
     }

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -1816,8 +1816,8 @@ sc::result ProcessingTurn::react(const CheckTurnEndConditions& c) {
 ////////////////////////////////////////////////////////////
 // ShuttingDownServer
 ////////////////////////////////////////////////////////////
-constexpr auto SHUTDOWN_POLLING_TIME = boost::chrono::milliseconds(5000);
-constexpr auto SHUTDOWN_POLLING_INTERVAL = boost::chrono::milliseconds(10);
+const auto SHUTDOWN_POLLING_TIME = boost::chrono::milliseconds(5000);
+const auto SHUTDOWN_POLLING_INTERVAL = boost::chrono::milliseconds(10);
 
 ShuttingDownServer::ShuttingDownServer(my_context c) :
     my_base(c),

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -1843,10 +1843,7 @@ ShuttingDownServer::ShuttingDownServer(my_context c) :
         if (player->GetClientType() == Networking::CLIENT_TYPE_AI_PLAYER) {
             if (good_connection) {
                 // Only expect acknowledgement from sockets that are up.
-                DebugLogger() << "Expected shutdown ack from id = " << player->PlayerID();
                 m_player_id_ack_expected.insert(player->PlayerID());
-            } else {
-                DebugLogger() << "Not Expecting shutdown ack from id = " << player->PlayerID() << " bad connection";
             }
         }
     }

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -241,7 +241,7 @@ void ServerFSM::HandleNonLobbyDisconnection(const Disconnection& d) {
         DebugLogger() << "ServerFSM::HandleNonLobbyDisconnection : All human players disconnected; server terminating.";
         // HACK! Pause for a bit to let the player disconnected and end game messages propogate.
         boost::this_thread::sleep_for(boost::chrono::seconds(2));
-        m_server.Exit(1);
+        m_server.m_fsm->process_event(ShutdownServer());
     }
 }
 

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -1831,11 +1831,12 @@ ShuttingDownServer::ShuttingDownServer(my_context c) :
 
     DebugLogger() << "ShuttingDownServer informing AIs game is ending";
 
+    // Inform all players that the game is ending.  Only check the AIs for acknowledgement, because
+    // they are the server's child processes.
     for (PlayerConnectionPtr player : server.m_networking) {
-        if (player->GetClientType() == Networking::CLIENT_TYPE_AI_PLAYER) {
-            player->SendMessage(EndGameMessage(player->PlayerID(), Message::PLAYER_DISCONNECT));
+        player->SendMessage(EndGameMessage(player->PlayerID(), Message::PLAYER_DISCONNECT));
+        if (player->GetClientType() == Networking::CLIENT_TYPE_AI_PLAYER)
             m_player_id_ack_expected.insert(player->PlayerID());
-        }
     }
 
     DebugLogger() << "ShuttingDownServer expecting " << m_player_id_ack_expected.size() << " AIs to ACK shutdown.";

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -239,8 +239,6 @@ void ServerFSM::HandleNonLobbyDisconnection(const Disconnection& d) {
     // independently of everything else, if there are no humans left, it's time to terminate
     if (m_server.m_networking.empty() || m_server.m_ai_client_processes.size() == m_server.m_networking.NumEstablishedPlayers()) {
         DebugLogger() << "ServerFSM::HandleNonLobbyDisconnection : All human players disconnected; server terminating.";
-        // HACK! Pause for a bit to let the player disconnected and end game messages propogate.
-        boost::this_thread::sleep_for(boost::chrono::seconds(2));
         m_server.m_fsm->process_event(ShutdownServer());
     }
 }

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -382,7 +382,7 @@ sc::result MPLobby::react(const Disconnection& d) {
     // if there are no humans left, it's time to terminate
     if (server.m_networking.empty() || server.m_ai_client_processes.size() == server.m_networking.NumEstablishedPlayers()) {
         DebugLogger() << "MPLobby.Disconnection : All human players disconnected; server terminating.";
-        server.Exit(1);
+        return transit<ShuttingDownServer>();
     }
 
     if (server.m_networking.PlayerIsHost(player_connection->PlayerID()))
@@ -1023,6 +1023,12 @@ sc::result MPLobby::react(const HostSPGame& msg) {
     msg.m_player_connection->SendMessage(ErrorMessage(UserStringNop("SERVER_ALREADY_HOSTING_GAME"), true));
     Server().m_networking.Disconnect(msg.m_player_connection);
     return discard_event();
+}
+
+sc::result MPLobby::react(const ShutdownServer& msg) {
+    if (TRACE_EXECUTION) DebugLogger() << "(ServerFSM) PlayingGame.ShutdownServer";
+
+    return transit<ShuttingDownServer>();
 }
 
 sc::result MPLobby::react(const Error& msg) {

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -1909,6 +1909,7 @@ sc::result ShuttingDownServer::react(const CheckEndConditions& u) {
     if (SHUTDOWN_POLLING_TIME > (Clock::now() - m_start_time)) {
         if (TRACE_EXECUTION) DebugLogger() << "Waiting for " << m_player_id_ack_expected.size() << " AI clients to ACK shutdown.";
         boost::this_thread::sleep_for(SHUTDOWN_POLLING_INTERVAL);
+        post_event(CheckEndConditions());
         return discard_event();
     }
 

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -325,6 +325,12 @@ sc::result Idle::react(const HostSPGame& msg) {
     return transit<WaitingForSPGameJoiners>();
 }
 
+sc::result Idle::react(const ShutdownServer& msg) {
+    if (TRACE_EXECUTION) DebugLogger() << "(ServerFSM) PlayingGame.ShutdownServer";
+
+    return transit<ShuttingDownServer>();
+}
+
 sc::result Idle::react(const Error& msg) {
     auto fatal = HandleErrorMessage(msg, Server());
     if (fatal)

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -1431,6 +1431,12 @@ sc::result PlayingGame::react(const ModeratorAct& msg) {
     return discard_event();
 }
 
+sc::result PlayingGame::react(const ShutdownServer& msg) {
+    if (TRACE_EXECUTION) DebugLogger() << "(ServerFSM) PlayingGame.ShutdownServer";
+
+    return transit<ShuttingDownServer>();
+}
+
 sc::result PlayingGame::react(const RequestCombatLogs& msg) {
     DebugLogger() << "(ServerFSM) PlayingGame::RequestCombatLogs message received";
     Server().UpdateCombatLogs(msg.m_message, msg.m_player_connection);

--- a/server/ServerFSM.h
+++ b/server/ServerFSM.h
@@ -12,12 +12,13 @@
 #include <boost/statechart/in_state_reaction.hpp>
 #include <boost/statechart/state.hpp>
 #include <boost/statechart/state_machine.hpp>
-#include <boost/chrono/chrono.hpp>
+#include <boost/asio/high_resolution_timer.hpp>
 
 #include <memory>
 #include <set>
 #include <vector>
 #include <unordered_set>
+#include <chrono>
 
 
 struct MultiplayerLobbyData;
@@ -363,7 +364,7 @@ struct ProcessingTurn : sc::state<ProcessingTurn, PlayingGame> {
 
 /** The server state in which the server is shutting down and waiting for AIs to exit. */
 struct ShuttingDownServer : sc::state<ShuttingDownServer, ServerFSM> {
-    using Clock = boost::chrono::steady_clock;
+    using Clock = std::chrono::high_resolution_clock;
     typedef boost::mpl::list<
         sc::in_state_reaction<Disconnection>,
         sc::custom_reaction<LeaveGame>,
@@ -381,8 +382,8 @@ struct ShuttingDownServer : sc::state<ShuttingDownServer, ServerFSM> {
     sc::result react(const Disconnection& d);
     sc::result react(const Error& msg);
 
-    std::unordered_set<int>                 m_player_id_ack_expected;
-    boost::chrono::steady_clock::time_point m_start_time;
+    std::unordered_set<int>            m_player_id_ack_expected;
+    boost::asio::high_resolution_timer m_timeout;
 
     SERVER_ACCESSOR
 };

--- a/server/ServerFSM.h
+++ b/server/ServerFSM.h
@@ -158,6 +158,7 @@ struct MPLobby : sc::state<MPLobby, ServerFSM> {
         sc::custom_reaction<StartMPGame>,
         sc::custom_reaction<HostMPGame>,
         sc::custom_reaction<HostSPGame>,
+        sc::custom_reaction<ShutdownServer>,
         sc::custom_reaction<Error>
     > reactions;
 
@@ -171,6 +172,7 @@ struct MPLobby : sc::state<MPLobby, ServerFSM> {
     sc::result react(const StartMPGame& msg);
     sc::result react(const HostMPGame& msg);
     sc::result react(const HostSPGame& msg);
+    sc::result react(const ShutdownServer& u);
     sc::result react(const Error& msg);
 
     std::shared_ptr<MultiplayerLobbyData> m_lobby_data;

--- a/server/ServerFSM.h
+++ b/server/ServerFSM.h
@@ -134,6 +134,7 @@ struct Idle : sc::state<Idle, ServerFSM> {
     typedef boost::mpl::list<
         sc::custom_reaction<HostMPGame>,
         sc::custom_reaction<HostSPGame>,
+        sc::custom_reaction<ShutdownServer>,
         sc::custom_reaction<Error>
     > reactions;
 
@@ -142,6 +143,7 @@ struct Idle : sc::state<Idle, ServerFSM> {
 
     sc::result react(const HostMPGame& msg);
     sc::result react(const HostSPGame& msg);
+    sc::result react(const ShutdownServer& u);
     sc::result react(const Error& msg);
 
     SERVER_ACCESSOR

--- a/server/ServerFSM.h
+++ b/server/ServerFSM.h
@@ -43,6 +43,7 @@ struct CheckEndConditions : sc::event<CheckEndConditions>               {};
 struct CheckTurnEndConditions : sc::event<CheckTurnEndConditions>       {};
 struct ProcessTurn : sc::event<ProcessTurn>                             {};
 struct DisconnectClients : sc::event<DisconnectClients>                 {};
+struct ShutdownServer : sc::event<ShutdownServer>                       {};
 
 
 //  Message events
@@ -250,6 +251,7 @@ struct PlayingGame : sc::state<PlayingGame, ServerFSM, WaitingForTurnEnd> {
         sc::custom_reaction<Diplomacy>,
         sc::custom_reaction<ModeratorAct>,
         sc::custom_reaction<RequestCombatLogs>,
+        sc::custom_reaction<ShutdownServer>,
         sc::custom_reaction<Error>
     > reactions;
 
@@ -259,6 +261,7 @@ struct PlayingGame : sc::state<PlayingGame, ServerFSM, WaitingForTurnEnd> {
     sc::result react(const PlayerChat& msg);
     sc::result react(const Diplomacy& msg);
     sc::result react(const ModeratorAct& msg);
+    sc::result react(const ShutdownServer& u);
     sc::result react(const RequestCombatLogs& msg);
     sc::result react(const Error& msg);
 

--- a/server/dmain.cpp
+++ b/server/dmain.cpp
@@ -115,6 +115,7 @@ int wmain(int argc, wchar_t* argv[], wchar_t* envp[]) {
     }
 #endif
 
+    DebugLogger() << "freeorion server main exited cleanly.";
     return 0;
 }
 

--- a/util/Process.cpp
+++ b/util/Process.cpp
@@ -63,6 +63,10 @@ bool Process::SetLowPriority(bool low) {
 }
 
 void Process::Kill() {
+    // Early exit if already killed.
+    if (!m_impl && m_empty && !m_low_priority)
+        return;
+
     DebugLogger() << "Process::Kill";
     if (m_impl) {
         DebugLogger() << "Process::Kill calling m_impl->Kill()";


### PR DESCRIPTION
This PR makes the server shutdown more consistent.

It should fix the second case of [~ServerApp() never called](https://github.com/freeorion/freeorion/issues/1330).  It might also fix [freeorion segfaults after the server quits](https://github.com/freeorion/freeorion/issues/1092), but that issue was sketchy on the details.

There were a few problems that resulted in the app often crashing instead of shutting down gracefully.

The SDL events for window closing and app quitting were never exposed or handled.  They always resulted in a crash, that looked like the app closing.

Shutdown events, initiated from the human client apps, started a 1 second timer and then killed the server.  The server responded by requesting the AIs shutdown and starting a 1 second timer and then killing the AIs.  There were other 1 second delays sprinkled around.  So, frequently the server was killed before it could shutdown.

The PR does the following:
- exposes the SDL events for window closing and app quitting.  These were unhandled before so the app just crashed.
- handles those events in the human client app
- changes the human client app to ask for shutdown and then poll for the disconnect event.
- adds a new state to the server FSM so that it can request the AIs termination and then wait for the ACK messages.
- uses that state in place of ServerApp::Exit() to cleanly exit the app.

I've tested this by closing the app with the exit button, with the hotkey, with the window manager close button, by removing the last human from the multiplayer lobby, with the SIGINT and SIGTERM signals, and by crashing the python AI.  In all cases the server exits cleanly.  The human client either resets to the intro screen or exits gracefully.  When the python AI executable generates a terminate exception, which can't be handled then that executable crashes, but the server still exits gracefully.

