### PR TITLE
Convert ScopedTimer,  GG and remaining to std::chrono.

### DIFF
--- a/GG/GG/EventPump.h
+++ b/GG/GG/EventPump.h
@@ -34,7 +34,7 @@
 #include <GG/GUI.h>
 
 // TODO change boost to std when C++11 is adopted.
-#include <boost/chrono/chrono.hpp>
+#include <chrono>
 
 
 namespace GG {
@@ -47,9 +47,9 @@ struct GG_API EventPumpState
 {
     EventPumpState();
 
-    boost::chrono::high_resolution_clock::time_point last_FPS_time;    ///< The last time an FPS calculation was done.
-    boost::chrono::high_resolution_clock::time_point last_frame_time;  ///< The time of the last frame rendered.
-    boost::chrono::high_resolution_clock::time_point most_recent_time; ///< The time recorded on the previous iteration of the event pump loop.
+    std::chrono::high_resolution_clock::time_point last_FPS_time;    ///< The last time an FPS calculation was done.
+    std::chrono::high_resolution_clock::time_point last_frame_time;  ///< The time of the last frame rendered.
+    std::chrono::high_resolution_clock::time_point most_recent_time; ///< The time recorded on the previous iteration of the event pump loop.
     std::size_t  frames;           ///< The number of frames rendered since \a last_frame_time.
 };
 

--- a/GG/GG/GUI.h
+++ b/GG/GG/GUI.h
@@ -33,7 +33,7 @@
 #include <GG/WndEvent.h>
 
 // TODO change boost to std when C++11 is adopted.
-#include <boost/chrono/chrono.hpp>
+#include <chrono>
 
 
 namespace boost { namespace archive {
@@ -251,7 +251,7 @@ public:
     void            SetFocusWnd(Wnd* wnd);          ///< sets the input focus window to \a wnd
     /** Suspend the GUI thread for \p us microseconds.  Singlethreaded GUI subclasses may do
         nothing here, or may pause for \p us microseconds. */
-    virtual void    Wait(boost::chrono::microseconds us);
+    virtual void    Wait(std::chrono::microseconds us);
     virtual void    Wait(unsigned int ms);          ///< suspends the GUI thread for \a ms milliseconds.  Singlethreaded GUI subclasses may do nothing here, or may pause for \a ms milliseconds.
     void            Register(Wnd* wnd);             ///< adds \a wnd into the z-list.  Registering a null pointer or registering the same window multiple times is a no-op.
     void            RegisterModal(Wnd* wnd);        ///< adds \a wnd onto the modal windows "stack"

--- a/GG/src/EventPump.cpp
+++ b/GG/src/EventPump.cpp
@@ -30,9 +30,9 @@
 using namespace GG;
 
 EventPumpState::EventPumpState() :
-    last_FPS_time(boost::chrono::high_resolution_clock::now()),
-    last_frame_time(boost::chrono::high_resolution_clock::now()),
-    most_recent_time(boost::chrono::high_resolution_clock::now()),
+    last_FPS_time(std::chrono::high_resolution_clock::now()),
+    last_frame_time(std::chrono::high_resolution_clock::now()),
+    most_recent_time(std::chrono::high_resolution_clock::now()),
     frames(0)
 {}
 
@@ -40,31 +40,31 @@ EventPumpState::EventPumpState() :
 void EventPumpBase::LoopBody(GUI* gui, EventPumpState& state, bool do_non_rendering, bool do_rendering)
 {
     if (do_non_rendering) {
-        boost::chrono::high_resolution_clock::time_point time = boost::chrono::high_resolution_clock::now();
+        std::chrono::high_resolution_clock::time_point time = std::chrono::high_resolution_clock::now();
 
         // send an idle message, so that the gui has timely updates for triggering browse info windows, etc.
         gui->HandleGGEvent(GUI::IDLE, GGK_UNKNOWN, 0, gui->ModKeys(), gui->MousePosition(), Pt());
 
         // govern FPS speed if needed
         if (double max_FPS = gui->MaxFPS()) {
-            boost::chrono::microseconds min_us_per_frame = boost::chrono::duration_cast<boost::chrono::microseconds>(
-            boost::chrono::duration<double>(1.0 / (max_FPS + 1)));
-            boost::chrono::microseconds us_elapsed = boost::chrono::duration_cast<boost::chrono::microseconds>(
+            std::chrono::microseconds min_us_per_frame = std::chrono::duration_cast<std::chrono::microseconds>(
+            std::chrono::duration<double>(1.0 / (max_FPS + 1)));
+            std::chrono::microseconds us_elapsed = std::chrono::duration_cast<std::chrono::microseconds>(
                 time - state.last_frame_time);
-            boost::chrono::microseconds us_to_wait = (min_us_per_frame - us_elapsed);
-            if (boost::chrono::microseconds(0) < us_to_wait) {
+            std::chrono::microseconds us_to_wait = (min_us_per_frame - us_elapsed);
+            if (std::chrono::microseconds(0) < us_to_wait) {
                 gui->Wait(us_to_wait);
-                time = boost::chrono::high_resolution_clock::now();
+                time = std::chrono::high_resolution_clock::now();
             }
         }
         state.last_frame_time = time;
 
         // track FPS if needed
-        gui->SetDeltaT(boost::chrono::duration_cast<boost::chrono::microseconds>(time - state.most_recent_time).count());
+        gui->SetDeltaT(std::chrono::duration_cast<std::chrono::microseconds>(time - state.most_recent_time).count());
         if (gui->FPSEnabled()) {
             ++state.frames;
-            if (boost::chrono::seconds(1) < time - state.last_FPS_time) { // calculate FPS at most once a second
-                double time_since_last_FPS = boost::chrono::duration_cast<boost::chrono::microseconds>(
+            if (std::chrono::seconds(1) < time - state.last_FPS_time) { // calculate FPS at most once a second
+                double time_since_last_FPS = std::chrono::duration_cast<std::chrono::microseconds>(
                     time - state.last_FPS_time).count() / 1000000.0;
                 gui->SetFPS(state.frames / time_since_last_FPS);
                 state.last_FPS_time = time;

--- a/GG/src/GUI.cpp
+++ b/GG/src/GUI.cpp
@@ -49,9 +49,9 @@
 
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/format.hpp>
-#include <boost/thread.hpp>
 #include <boost/xpressive/xpressive.hpp>
 
+#include <thread>
 #include <cassert>
 #include <iostream>
 #include <fstream>
@@ -1198,10 +1198,10 @@ bool GUI::SetNextFocusWndInCycle()
 }
 
 void GUI::Wait(unsigned int ms)
-{ boost::this_thread::sleep_for(boost::chrono::milliseconds(ms)); }
+{ std::this_thread::sleep_for(std::chrono::milliseconds(ms)); }
 
-void GUI::Wait(boost::chrono::microseconds us)
-{ boost::this_thread::sleep_for(us); }
+void GUI::Wait(std::chrono::microseconds us)
+{ std::this_thread::sleep_for(us); }
 
 void GUI::Register(Wnd* wnd)
 { if (wnd) s_impl->m_zlist.Add(wnd); }

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -651,7 +651,7 @@ void EncyclopediaDetailPanel::DoLayout() {
     const int BTN_WIDTH = 24;
     const int Y_OFFSET = 22;
 
-    SectionedScopedTimer timer("EncyclopediaDetailPanel::DoLayout", boost::chrono::milliseconds(1));
+    SectionedScopedTimer timer("EncyclopediaDetailPanel::DoLayout", std::chrono::milliseconds(1));
 
     // name
     GG::Pt ul = GG::Pt(GG::X(6), GG::Y(Y_OFFSET));

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -2516,7 +2516,7 @@ void MapWnd::EnableOrderIssuing(bool enable/* = true*/) {
 void MapWnd::InitTurn() {
     int turn_number = CurrentTurn();
     DebugLogger() << "Initializing turn " << turn_number;
-    SectionedScopedTimer timer("MapWnd::InitTurn", boost::chrono::milliseconds(1));
+    SectionedScopedTimer timer("MapWnd::InitTurn", std::chrono::milliseconds(1));
     timer.EnterSection("init");
 
     //DebugLogger() << GetSupplyManager().Dump();

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -22,6 +22,8 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/filesystem/fstream.hpp>
 
+#include <thread>
+
 class CombatLogManager;
 CombatLogManager&   GetCombatLogManager();
 
@@ -133,7 +135,7 @@ void AIClientApp::Run() {
                     Networking().GetMessage(msg);
                     HandleMessage(msg);
                 } else {
-                    boost::this_thread::sleep_for(boost::chrono::milliseconds(10));
+                    std::this_thread::sleep_for(std::chrono::milliseconds(10));
                 }
 
             } catch (boost::python::error_already_set) {
@@ -192,7 +194,7 @@ void AIClientApp::HandlePythonAICrash() {
     ErrorLogger() << err_msg.str() << " id = " << PlayerID();
     Networking().SendMessage(
         ErrorMessage(PlayerID(), str(FlexibleFormat(UserString("ERROR_PYTHON_AI_CRASHED")) % PlayerName()) , true));
-    boost::this_thread::sleep_for(boost::chrono::milliseconds(500));
+   std::this_thread::sleep_for(std::chrono::milliseconds(500));
 }
 
 

--- a/client/human/chmain.cpp
+++ b/client/human/chmain.cpp
@@ -16,6 +16,8 @@
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/fstream.hpp>
 
+#include <thread>
+#include <chrono>
 #include <iostream>
 
 #if defined(FREEORION_LINUX)

--- a/client/human/chmain.cpp
+++ b/client/human/chmain.cpp
@@ -215,15 +215,15 @@ int mainConfigOptionsSetup(const std::vector<std::string>& args) {
 #ifndef FREEORION_CHMAIN_KEEP_STACKTRACE
     } catch (const std::invalid_argument& e) {
         std::cerr << "main() caught exception(std::invalid_argument): " << e.what() << std::endl;
-        boost::this_thread::sleep_for(boost::chrono::seconds(3));
+        std::this_thread::sleep_for(std::chrono::seconds(3));
         return 1;
     } catch (const std::runtime_error& e) {
         std::cerr << "main() caught exception(std::runtime_error): " << e.what() << std::endl;
-        boost::this_thread::sleep_for(boost::chrono::seconds(3));
+        std::this_thread::sleep_for(std::chrono::seconds(3));
         return 1;
     } catch (const std::exception& e) {
         std::cerr << "main() caught exception(std::exception): " << e.what() << std::endl;
-        boost::this_thread::sleep_for(boost::chrono::seconds(3));
+        std::this_thread::sleep_for(std::chrono::seconds(3));
         return 1;
     }
 #endif

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -37,11 +37,11 @@
 #include <boost/filesystem/operations.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/functional/hash.hpp>
-#include <boost/thread/thread.hpp>
 #include <boost/date_time/posix_time/time_formatters.hpp>
 
 
 #include <ctime>
+#include <thread>
 
 namespace fs = boost::filesystem;
 
@@ -352,7 +352,7 @@ void ServerApp::CleanupAIs() {
     if (ai_connection_lingering) {
         // time for AIs to react?
         DebugLogger() << "ServerApp::CleanupAIs() waiting 1 second for AI processes to clean up...";
-        boost::this_thread::sleep_for(boost::chrono::seconds(1));
+        std::this_thread::sleep_for(std::chrono::seconds(1));
     }
 
     DebugLogger() << "ServerApp::CleanupAIs() killing " << m_ai_client_processes.size() << " AI clients.";

--- a/util/ScopedTimer.cpp
+++ b/util/ScopedTimer.cpp
@@ -3,7 +3,6 @@
 #include "OptionsDB.h"
 #include "Logger.h"
 
-#include <boost/chrono/io/duration_io.hpp>
 #include <boost/unordered_map.hpp>
 
 #include <iomanip>
@@ -11,15 +10,15 @@
 class ScopedTimer::Impl {
 public:
     Impl(const std::string& timed_name, bool enable_output,
-         boost::chrono::microseconds threshold) :
-        m_start(boost::chrono::high_resolution_clock::now()),
+         std::chrono::microseconds threshold) :
+        m_start(std::chrono::high_resolution_clock::now()),
         m_name(timed_name),
         m_enable_output(enable_output),
         m_threshold(threshold)
     {}
 
     ~Impl() {
-        boost::chrono::nanoseconds duration = boost::chrono::high_resolution_clock::now() - m_start;
+        std::chrono::nanoseconds duration = std::chrono::high_resolution_clock::now() - m_start;
         if (!ShouldOutput(duration))
             return;
 
@@ -29,32 +28,32 @@ public:
         DebugLogger() << ss.str();
     }
 
-    bool ShouldOutput(const boost::chrono::nanoseconds & duration) {
+    bool ShouldOutput(const std::chrono::nanoseconds & duration) {
         return (duration >= m_threshold && (m_enable_output || GetOptionsDB().Get<bool>("verbose-logging")));
     }
 
-    void FormatDuration(std::stringstream& ss, const boost::chrono::nanoseconds & duration) {
-        ss << boost::chrono::symbol_format << std::setw(8) << std::right;
-        if (duration >= boost::chrono::milliseconds(10))
-            ss << boost::chrono::duration_cast<boost::chrono::milliseconds>(duration);
-        else if (duration >= boost::chrono::microseconds(10))
-            ss << boost::chrono::duration_cast<boost::chrono::microseconds>(duration);
+    void FormatDuration(std::stringstream& ss, const std::chrono::nanoseconds & duration) {
+        ss << std::setw(8) << std::right;
+        if (duration >= std::chrono::milliseconds(10))
+            ss << std::chrono::duration_cast<std::chrono::milliseconds>(duration).count() << " ms";
+        else if (duration >= std::chrono::microseconds(10))
+            ss << std::chrono::duration_cast<std::chrono::microseconds>(duration).count() << " µs";
         else
-            ss << boost::chrono::duration_cast<boost::chrono::nanoseconds>(duration);
+            ss << std::chrono::duration_cast<std::chrono::nanoseconds>(duration).count() << " ns";
     }
 
-    boost::chrono::high_resolution_clock::time_point m_start;
+    std::chrono::high_resolution_clock::time_point m_start;
     std::string                                      m_name;
     bool                                             m_enable_output;
-    boost::chrono::microseconds                      m_threshold;
+    std::chrono::microseconds                      m_threshold;
 };
 
 ScopedTimer::ScopedTimer(const std::string& timed_name, bool enable_output,
-                         boost::chrono::microseconds threshold) :
+                         std::chrono::microseconds threshold) :
     m_impl(new Impl(timed_name, enable_output, threshold))
 {}
 
-ScopedTimer::ScopedTimer(const std::string& timed_name, boost::chrono::microseconds threshold) :
+ScopedTimer::ScopedTimer(const std::string& timed_name, std::chrono::microseconds threshold) :
     m_impl(new Impl(timed_name, true, threshold))
 {}
 
@@ -68,8 +67,8 @@ class SectionedScopedTimer::Impl : public ScopedTimer::Impl {
 
     /** Sections store a time and a duration for each section of the elapsed time report.*/
     struct Sections {
-        Sections(const boost::chrono::high_resolution_clock::time_point &now,
-                 const boost::chrono::nanoseconds& time_from_start) :
+        Sections(const std::chrono::high_resolution_clock::time_point &now,
+                 const std::chrono::nanoseconds& time_from_start) :
             m_table(), m_section_start(now), m_curr(), m_section_names()
         {
             // Create a dummy "" section so that m_curr is always a valid iterator.
@@ -78,7 +77,7 @@ class SectionedScopedTimer::Impl : public ScopedTimer::Impl {
         }
 
         /** Add time to the current section and then setup the new section. */
-        void Accumulate(const boost::chrono::high_resolution_clock::time_point &now,
+        void Accumulate(const std::chrono::high_resolution_clock::time_point &now,
                         const std::string & section_name)
         {
             if (m_curr->first == section_name)
@@ -91,7 +90,7 @@ class SectionedScopedTimer::Impl : public ScopedTimer::Impl {
             // Create a new section if needed and update m_curr.
             std::pair<SectionTable::iterator, bool> maybe_new = m_table.insert(
                 std::make_pair(section_name,
-                               boost::chrono::high_resolution_clock::duration::zero()));
+                               std::chrono::high_resolution_clock::duration::zero()));
             m_curr = maybe_new.first;
 
             // Insert succeed, so grab the new section name.
@@ -101,11 +100,11 @@ class SectionedScopedTimer::Impl : public ScopedTimer::Impl {
         }
 
         //Table of section durations
-        typedef boost::unordered_map<std::string, boost::chrono::nanoseconds> SectionTable;
+        typedef boost::unordered_map<std::string, std::chrono::nanoseconds> SectionTable;
         SectionTable m_table;
 
         // Currently running section start time and iterator
-        boost::chrono::high_resolution_clock::time_point m_section_start;
+        std::chrono::high_resolution_clock::time_point m_section_start;
 
         // m_curr always points to the section currently accumulating
         // time or to the dummy "" blank section.
@@ -118,13 +117,13 @@ class SectionedScopedTimer::Impl : public ScopedTimer::Impl {
 
 public:
     Impl(const std::string& timed_name, bool enable_output,
-         boost::chrono::microseconds threshold) :
+         std::chrono::microseconds threshold) :
         ScopedTimer::Impl(timed_name, enable_output, threshold)
     {}
 
     /** The destructor will print the table of accumulated times. */
     ~Impl() {
-        boost::chrono::nanoseconds duration = boost::chrono::high_resolution_clock::now() - m_start;
+        std::chrono::nanoseconds duration = std::chrono::high_resolution_clock::now() - m_start;
 
         if (!ShouldOutput(duration))
             return;
@@ -183,7 +182,7 @@ public:
     }
 
     void EnterSection(const std::string& section_name) {
-        boost::chrono::high_resolution_clock::time_point now(boost::chrono::high_resolution_clock::now());
+        std::chrono::high_resolution_clock::time_point now(std::chrono::high_resolution_clock::now());
 
         // One time initialization.
         if (!m_sections)
@@ -193,7 +192,7 @@ public:
     }
 
     /** CreateSections allow m_sections to only be initialized if it is used.*/
-    Sections* CreateSections(const boost::chrono::high_resolution_clock::time_point &now) {
+    Sections* CreateSections(const std::chrono::high_resolution_clock::time_point &now) {
         m_sections.reset(new Sections(now, now - m_start));
         return m_sections.get();
     }
@@ -206,11 +205,11 @@ public:
 };
 
 SectionedScopedTimer::SectionedScopedTimer(const std::string& timed_name, bool enable_output,
-                         boost::chrono::microseconds threshold) :
+                         std::chrono::microseconds threshold) :
     m_impl(new Impl(timed_name, enable_output, threshold))
 {}
 
-SectionedScopedTimer::SectionedScopedTimer(const std::string& timed_name, boost::chrono::microseconds threshold) :
+SectionedScopedTimer::SectionedScopedTimer(const std::string& timed_name, std::chrono::microseconds threshold) :
     m_impl(new Impl(timed_name, true, threshold))
 {}
 

--- a/util/ScopedTimer.h
+++ b/util/ScopedTimer.h
@@ -6,8 +6,7 @@
 
 #include "Export.h"
 
-// TODO change boost to std when C++11 is adopted.
-#include <boost/chrono/chrono.hpp>
+#include <chrono>
 
 /** Outputs time during which this object existed.
     Created in the scope of a function, and passed the appropriate
@@ -21,8 +20,8 @@
 class FO_COMMON_API ScopedTimer {
 public:
     ScopedTimer(const std::string& timed_name, bool enable_output = false,
-                boost::chrono::microseconds threshold = boost::chrono::milliseconds(1));
-    ScopedTimer(const std::string& timed_name, boost::chrono::microseconds threshold);
+                std::chrono::microseconds threshold = std::chrono::milliseconds(1));
+    ScopedTimer(const std::string& timed_name, std::chrono::microseconds threshold);
     ~ScopedTimer();
 
     class Impl;
@@ -61,7 +60,7 @@ private:
 
     void function_to_profile () {
 
-        SectionedScopedTimer timer("Title", boost::chrono::milliseconds(1));
+        SectionedScopedTimer timer("Title", std::chrono::milliseconds(1));
         timer.EnterSection("initial section");
 
         profiled_code();
@@ -89,8 +88,8 @@ private:
 class FO_COMMON_API SectionedScopedTimer {
 public:
     SectionedScopedTimer(const std::string& timed_name, bool enable_output = false,
-                         boost::chrono::microseconds threshold = boost::chrono::milliseconds(1));
-    SectionedScopedTimer(const std::string& timed_name, boost::chrono::microseconds threshold);
+                         std::chrono::microseconds threshold = std::chrono::milliseconds(1));
+    SectionedScopedTimer(const std::string& timed_name, std::chrono::microseconds threshold);
     ~SectionedScopedTimer();
 
     /** Start recording times for \p section_name.


### PR DESCRIPTION
This PR converts everything not associated with `boost::asio` to use `std::chrono`.

The only useful feature that we are giving up is time short form unit formatting,  (ms, µs and s). 