### PR TITLE
Catch exception when failing to pickle save state string.

### DIFF
--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -144,9 +144,12 @@ def prepareForSave():  # pylint: disable=invalid-name
     print "Preparing for game save by serializing state"
 
     # serialize (convert to string) global state dictionary and send to AI client to be stored in save file
-    dump_string = pickle.dumps(foAIstate)
-    print "foAIstate pickled to string, about to send to server"
-    fo.setSaveStateString(dump_string)
+    try:
+        dump_string = pickle.dumps(foAIstate)
+        print "foAIstate pickled to string, about to send to server"
+        fo.setSaveStateString(dump_string)
+    except:
+        print_error("foAIstate unable to pickle save-state string; the save file should be playable but the AI may have a different aggression.", trace=True)
 
 
 @chat_on_error


### PR DESCRIPTION
May prevent occasional AI crash when unable to pickle the save state. As suggested here: https://github.com/freeorion/freeorion/issues/1285