### PR TITLE
Fix missing pedia articles in Ship Part subcategory

### DIFF
--- a/default/scripting/ship_parts/SP_DIM.focs.txt
+++ b/default/scripting/ship_parts/SP_DIM.focs.txt
@@ -5,7 +5,7 @@ Part
     mountableSlotTypes = Internal
     buildcost = 1
     buildtime = 1
-    tags = [ "PEDIA_GENERAL" ]
+    tags = [ "PEDIA_PC_GENERAL" ]
     location = All
     effectsgroups = [
         EffectsGroup

--- a/default/scripting/ship_parts/SP_DISTORTION_MODULATOR.focs.txt
+++ b/default/scripting/ship_parts/SP_DISTORTION_MODULATOR.focs.txt
@@ -5,7 +5,7 @@ Part
     mountableSlotTypes = Internal
     buildcost = 15 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildtime = 10
-    tags = [ "PEDIA_GENERAL" ]
+    tags = [ "PEDIA_PC_GENERAL" ]
     location = OwnedBy empire = Source.Owner
     effectsgroups =
         EffectsGroup


### PR DESCRIPTION
- "Distortion Modulator" and "Dimensional Cleaver" pedia articles missing in "Ship Part/General" subcategory
(follows #1378 Categorize Ship Part pedia articles)