### PR TITLE
Refactor Message class.

### DIFF
--- a/AI/AIInterface.cpp
+++ b/AI/AIInterface.cpp
@@ -526,7 +526,7 @@ namespace AIInterface {
             ErrorLogger() << "IssueInvadeOrder : planet with passed planet_id " << planet_id
                           << " and species " << this_species << " is not invadable due to one or more of: owned by invader empire, "
                           << "not visible to invader empire, has shields above zero, or is already being invaded.";
-            if (!unowned) 
+            if (!unowned)
                 ErrorLogger() << "IssueInvadeOrder : planet (id " << planet_id << ") is not unowned";
             if (!visible)
                 ErrorLogger() << "IssueInvadeOrder : planet (id " << planet_id << ") is not visible";
@@ -864,10 +864,7 @@ namespace AIInterface {
     }
 
     void SendPlayerChatMessage(int recipient_player_id, const std::string& message_text) {
-        if (recipient_player_id == -1)
-            AIClientApp::GetApp()->Networking().SendMessage(GlobalChatMessage(PlayerID(), message_text));
-        else
-            AIClientApp::GetApp()->Networking().SendMessage(SingleRecipientChatMessage(PlayerID(), recipient_player_id, message_text));
+        AIClientApp::GetApp()->Networking().SendMessage(PlayerChatMessage(PlayerID(), message_text, recipient_player_id));
     }
 
     void SendDiplomaticMessage(const DiplomaticMessage& diplo_message) {

--- a/AI/AIInterface.cpp
+++ b/AI/AIInterface.cpp
@@ -864,7 +864,7 @@ namespace AIInterface {
     }
 
     void SendPlayerChatMessage(int recipient_player_id, const std::string& message_text) {
-        AIClientApp::GetApp()->Networking().SendMessage(PlayerChatMessage(PlayerID(), message_text, recipient_player_id));
+        AIClientApp::GetApp()->Networking().SendMessage(PlayerChatMessage(message_text, recipient_player_id));
     }
 
     void SendDiplomaticMessage(const DiplomaticMessage& diplo_message) {
@@ -875,7 +875,7 @@ namespace AIInterface {
         int recipient_empire_id = diplo_message.RecipientEmpireID();
         int recipient_player_id = app->EmpirePlayerID(recipient_empire_id);
         if (recipient_player_id == Networking::INVALID_PLAYER_ID) return;
-        app->Networking().SendMessage(DiplomacyMessage(sender_player_id, recipient_player_id, diplo_message));
+        app->Networking().SendMessage(DiplomacyMessage(diplo_message));
     }
 
     void DoneTurn() {

--- a/UI/ChatWnd.cpp
+++ b/UI/ChatWnd.cpp
@@ -260,7 +260,7 @@ void MessageWndEdit::AutoComplete() {
                 }
             }
             // If not an exact match try to complete the word
-            if (!exact_match) 
+            if (!exact_match)
                 CompleteWord(m_game_words, partial_word, cursor_pos, full_line);
         }
     }
@@ -291,7 +291,7 @@ bool MessageWndEdit::CompleteWord(const std::set<std::string>& names, const std:
             }
         }
     }
-  
+
     if (!partial_word_match)
         return false;
 
@@ -462,11 +462,11 @@ namespace {
         int sender_id = HumanClientApp::GetApp()->PlayerID();
 
         if (recipients.empty()) {
-            net.SendMessage(GlobalChatMessage(sender_id, text));
+            net.SendMessage(PlayerChatMessage(sender_id, text));
         } else {
             recipients.insert(sender_id);   // ensure recipient sees own sent message
             for (int recipient_id : recipients)
-                net.SendMessage(SingleRecipientChatMessage(sender_id, recipient_id, text));
+                net.SendMessage(PlayerChatMessage(sender_id, text, recipient_id));
         }
     }
 

--- a/UI/ChatWnd.cpp
+++ b/UI/ChatWnd.cpp
@@ -459,14 +459,13 @@ void MessageWnd::OpenForInput() {
 namespace {
     void SendChatMessage(const std::string& text, std::set<int> recipients) {
         ClientNetworking& net = HumanClientApp::GetApp()->Networking();
-        int sender_id = HumanClientApp::GetApp()->PlayerID();
 
         if (recipients.empty()) {
-            net.SendMessage(PlayerChatMessage(sender_id, text));
+            net.SendMessage(PlayerChatMessage(text));
         } else {
-            recipients.insert(sender_id);   // ensure recipient sees own sent message
+            recipients.insert(HumanClientApp::GetApp()->PlayerID());   // ensure recipient sees own sent message
             for (int recipient_id : recipients)
-                net.SendMessage(PlayerChatMessage(sender_id, text, recipient_id));
+                net.SendMessage(PlayerChatMessage(text, recipient_id));
         }
     }
 

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -578,7 +578,7 @@ public:
         // the zoom_factor changes, so that it's pixel length on the screen is kept to a reasonable distance.  We also add
         // additional stopping points for the map scale to augment the usefulness of the linked map scale circle (whose
         // radius is the same as the map scale length).  These additional stopping points include the speeds and detection
-        // ranges of any selected fleets, and the detection ranges of all planets in the currently selected system, 
+        // ranges of any selected fleets, and the detection ranges of all planets in the currently selected system,
         // provided such values are at least 20 uu.
 
         // get selected fleet speeds and detection ranges
@@ -2491,8 +2491,7 @@ void MapWnd::RClick(const GG::Pt& pt, GG::Flags<GG::ModKey> mod_keys) {
             ClientNetworking& net = HumanClientApp::GetApp()->Networking();
             std::pair<double, double> u_pos = this->UniversePositionFromScreenCoords(pt);
             StarType star_type = m_moderator_wnd->SelectedStarType();
-            net.SendMessage(ModeratorActionMessage(HumanClientApp::GetApp()->PlayerID(),
-                Moderator::CreateSystem(u_pos.first, u_pos.second, star_type)));
+            net.SendMessage(ModeratorActionMessage(Moderator::CreateSystem(u_pos.first, u_pos.second, star_type)));
             return;
         }
     }
@@ -3103,7 +3102,7 @@ namespace GetPathsThroughSupplyLanes {
         const std::unordered_set<int>& terminal_points,
         const SupplyLaneMMap& supply_lanes);
 
-    
+
     // PathInfo stores the \p ids of systems one hop back on a path
     // toward an \p o originating terminal system.
     struct PathInfo {
@@ -3280,7 +3279,7 @@ namespace {
 
 
     /* Takes X and Y coordinates of a pair of systems and moves these points inwards along the vector
-     * between them by the radius of a system on screen (at zoom 1.0) and return result */ 
+     * between them by the radius of a system on screen (at zoom 1.0) and return result */
     LaneEndpoints StarlaneEndPointsFromSystemPositions(double X1, double Y1, double X2, double Y2) {
         // get unit vector
         double deltaX = X2 - X1, deltaY = Y2 - Y1;
@@ -5089,11 +5088,9 @@ void MapWnd::FieldRightClicked(int field_id) {
     if (ClientPlayerIsModerator()) {
         ModeratorActionSetting mas = m_moderator_wnd->SelectedAction();
         ClientNetworking& net = HumanClientApp::GetApp()->Networking();
-        int player_id = HumanClientApp::GetApp()->PlayerID();
 
         if (mas == MAS_Destroy) {
-            net.SendMessage(ModeratorActionMessage(player_id,
-                Moderator::DestroyUniverseObject(field_id)));
+            net.SendMessage(ModeratorActionMessage(Moderator::DestroyUniverseObject(field_id)));
         }
         return;
     }
@@ -5117,28 +5114,27 @@ void MapWnd::SystemRightClicked(int system_id, GG::Flags< GG::ModKey > mod_keys)
     if (ClientPlayerIsModerator()) {
         ModeratorActionSetting mas = m_moderator_wnd->SelectedAction();
         ClientNetworking& net = HumanClientApp::GetApp()->Networking();
-        int player_id = HumanClientApp::GetApp()->PlayerID();
 
         if (mas == MAS_Destroy) {
-            net.SendMessage(ModeratorActionMessage(player_id,
+            net.SendMessage(ModeratorActionMessage(
                 Moderator::DestroyUniverseObject(system_id)));
 
         } else if (mas == MAS_CreatePlanet) {
-            net.SendMessage(ModeratorActionMessage(player_id,
+            net.SendMessage(ModeratorActionMessage(
                 Moderator::CreatePlanet(system_id, m_moderator_wnd->SelectedPlanetType(),
                                         m_moderator_wnd->SelectedPlanetSize())));
 
         } else if (mas == MAS_AddStarlane) {
             int selected_system_id = SidePanel::SystemID();
             if (GetSystem(selected_system_id)) {
-                net.SendMessage(ModeratorActionMessage(player_id,
+                net.SendMessage(ModeratorActionMessage(
                     Moderator::AddStarlane(system_id, selected_system_id)));
             }
 
         } else if (mas == MAS_RemoveStarlane) {
             int selected_system_id = SidePanel::SystemID();
             if (GetSystem(selected_system_id)) {
-                net.SendMessage(ModeratorActionMessage(player_id,
+                net.SendMessage(ModeratorActionMessage(
                     Moderator::RemoveStarlane(system_id, selected_system_id)));
             }
         } else if (mas == MAS_SetOwner) {
@@ -5150,7 +5146,7 @@ void MapWnd::SystemRightClicked(int system_id, GG::Flags< GG::ModKey > mod_keys)
             for (std::shared_ptr<const UniverseObject> obj : Objects().FindObjects<const UniverseObject>(system->ContainedObjectIDs())) {
                 UniverseObjectType obj_type = obj->ObjectType();
                 if (obj_type >= OBJ_BUILDING && obj_type < OBJ_SYSTEM) {
-                    net.SendMessage(ModeratorActionMessage(player_id,
+                    net.SendMessage(ModeratorActionMessage(
                     Moderator::SetOwner(obj->ID(), empire_id)));
                 }
             }
@@ -5206,14 +5202,13 @@ void MapWnd::PlanetRightClicked(int planet_id) {
 
     ModeratorActionSetting mas = m_moderator_wnd->SelectedAction();
     ClientNetworking& net = HumanClientApp::GetApp()->Networking();
-    int player_id = HumanClientApp::GetApp()->PlayerID();
 
     if (mas == MAS_Destroy) {
-        net.SendMessage(ModeratorActionMessage(player_id,
+        net.SendMessage(ModeratorActionMessage(
             Moderator::DestroyUniverseObject(planet_id)));
     } else if (mas == MAS_SetOwner) {
         int empire_id = m_moderator_wnd->SelectedEmpire();
-        net.SendMessage(ModeratorActionMessage(player_id,
+        net.SendMessage(ModeratorActionMessage(
             Moderator::SetOwner(planet_id, empire_id)));
     }
 }
@@ -5226,14 +5221,13 @@ void MapWnd::BuildingRightClicked(int building_id) {
 
     ModeratorActionSetting mas = m_moderator_wnd->SelectedAction();
     ClientNetworking& net = HumanClientApp::GetApp()->Networking();
-    int player_id = HumanClientApp::GetApp()->PlayerID();
 
     if (mas == MAS_Destroy) {
-        net.SendMessage(ModeratorActionMessage(player_id,
+        net.SendMessage(ModeratorActionMessage(
             Moderator::DestroyUniverseObject(building_id)));
     } else if (mas == MAS_SetOwner) {
         int empire_id = m_moderator_wnd->SelectedEmpire();
-        net.SendMessage(ModeratorActionMessage(player_id,
+        net.SendMessage(ModeratorActionMessage(
             Moderator::SetOwner(building_id, empire_id)));
     }
 }
@@ -5436,17 +5430,16 @@ void MapWnd::FleetsRightClicked(const std::vector<int>& fleet_ids) {
 
     ModeratorActionSetting mas = m_moderator_wnd->SelectedAction();
     ClientNetworking& net = HumanClientApp::GetApp()->Networking();
-    int player_id = HumanClientApp::GetApp()->PlayerID();
 
     if (mas == MAS_Destroy) {
         for (int fleet_id : fleet_ids) {
-            net.SendMessage(ModeratorActionMessage(player_id,
+            net.SendMessage(ModeratorActionMessage(
                 Moderator::DestroyUniverseObject(fleet_id)));
         }
     } else if (mas == MAS_SetOwner) {
         int empire_id = m_moderator_wnd->SelectedEmpire();
         for (int fleet_id : fleet_ids) {
-            net.SendMessage(ModeratorActionMessage(player_id,
+            net.SendMessage(ModeratorActionMessage(
                 Moderator::SetOwner(fleet_id, empire_id)));
         }
     }
@@ -5468,17 +5461,16 @@ void MapWnd::ShipsRightClicked(const std::vector<int>& ship_ids) {
 
     ModeratorActionSetting mas = m_moderator_wnd->SelectedAction();
     ClientNetworking& net = HumanClientApp::GetApp()->Networking();
-    int player_id = HumanClientApp::GetApp()->PlayerID();
 
     if (mas == MAS_Destroy) {
         for (int ship_id : ship_ids) {
-            net.SendMessage(ModeratorActionMessage(player_id,
+            net.SendMessage(ModeratorActionMessage(
                 Moderator::DestroyUniverseObject(ship_id)));
         }
     } else if (mas == MAS_SetOwner) {
         int empire_id = m_moderator_wnd->SelectedEmpire();
         for (int ship_id : ship_ids) {
-            net.SendMessage(ModeratorActionMessage(player_id,
+            net.SendMessage(ModeratorActionMessage(
                 Moderator::SetOwner(ship_id, empire_id)));
         }
     }

--- a/UI/MultiplayerLobbyWnd.cpp
+++ b/UI/MultiplayerLobbyWnd.cpp
@@ -652,7 +652,7 @@ void MultiPlayerLobbyWnd::KeyPress(GG::Key key, std::uint32_t key_code_point, GG
          GG::GUI::GetGUI()->FocusWnd() == m_chat_input_edit)
     {
         std::string text = m_chat_input_edit->Text();   // copy, so subsequent clearing doesn't affect typed message that is used later...
-        HumanClientApp::GetApp()->Networking().SendMessage(PlayerChatMessage(HumanClientApp::GetApp()->PlayerID(), text));
+        HumanClientApp::GetApp()->Networking().SendMessage(PlayerChatMessage(text));
         m_chat_input_edit->SetText("");
 
         // look up this client's player name by ID
@@ -951,9 +951,8 @@ bool MultiPlayerLobbyWnd::PopulatePlayerList() {
 }
 
 void MultiPlayerLobbyWnd::SendUpdate() {
-    int player_id = HumanClientApp::GetApp()->PlayerID();
-    if (player_id != Networking::INVALID_PLAYER_ID)
-        HumanClientApp::GetApp()->Networking().SendMessage(LobbyUpdateMessage(player_id, m_lobby_data));
+    if (HumanClientApp::GetApp()->PlayerID() != Networking::INVALID_PLAYER_ID)
+        HumanClientApp::GetApp()->Networking().SendMessage(LobbyUpdateMessage(m_lobby_data));
 }
 
 bool MultiPlayerLobbyWnd::PlayerDataAcceptable() const {

--- a/UI/MultiplayerLobbyWnd.cpp
+++ b/UI/MultiplayerLobbyWnd.cpp
@@ -643,7 +643,7 @@ void MultiPlayerLobbyWnd::Render() {
     CUIWnd::Render();
     GG::Pt image_ul = g_preview_ul + ClientUpperLeft(), image_lr = image_ul + PREVIEW_SZ;
     GG::FlatRectangle(GG::Pt(image_ul.x - PREVIEW_MARGIN, image_ul.y - PREVIEW_MARGIN),
-                      GG::Pt(image_lr.x + PREVIEW_MARGIN, image_lr.y + PREVIEW_MARGIN), 
+                      GG::Pt(image_lr.x + PREVIEW_MARGIN, image_lr.y + PREVIEW_MARGIN),
                       GG::CLR_BLACK, ClientUI::WndInnerBorderColor(), 1);
 }
 
@@ -651,9 +651,8 @@ void MultiPlayerLobbyWnd::KeyPress(GG::Key key, std::uint32_t key_code_point, GG
     if ((key == GG::GGK_RETURN || key == GG::GGK_KP_ENTER) &&
          GG::GUI::GetGUI()->FocusWnd() == m_chat_input_edit)
     {
-        int receiver = Networking::INVALID_PLAYER_ID;   // all players by default
         std::string text = m_chat_input_edit->Text();   // copy, so subsequent clearing doesn't affect typed message that is used later...
-        HumanClientApp::GetApp()->Networking().SendMessage(LobbyChatMessage(HumanClientApp::GetApp()->PlayerID(), receiver, text));
+        HumanClientApp::GetApp()->Networking().SendMessage(PlayerChatMessage(HumanClientApp::GetApp()->PlayerID(), text));
         m_chat_input_edit->SetText("");
 
         // look up this client's player name by ID

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -1950,7 +1950,7 @@ public:
                     std::map<int, std::set<int>>::iterator fs_it = fleet_ships.find(fleet_id);
 
                     if (!ObjectCollapsed(system_id)) {
-                        AddObjectRow(fleet_id, system_id, 
+                        AddObjectRow(fleet_id, system_id,
                                         fs_it != fleet_ships.end() ? fs_it->second : std::set<int>(),
                                         indent);
                         ++indent;
@@ -2521,10 +2521,10 @@ void ObjectListWnd::ObjectRightClicked(GG::ListBox::iterator it, const GG::Pt& p
     // moderator actions...
     if (moderator) {
         auto destroy_object_action = [object_id, app, &net]() {
-            net.SendMessage(ModeratorActionMessage(app->PlayerID(), Moderator::DestroyUniverseObject(object_id)));
+            net.SendMessage(ModeratorActionMessage(Moderator::DestroyUniverseObject(object_id)));
         };
         auto set_owner_action = [object_id, app, &net]() {
-            net.SendMessage(ModeratorActionMessage(app->PlayerID(), Moderator::SetOwner(object_id, ALL_EMPIRES)));
+            net.SendMessage(ModeratorActionMessage(Moderator::SetOwner(object_id, ALL_EMPIRES)));
         };
         popup.AddMenuItem(GG::MenuItem(UserString("MOD_DESTROY"),      false, false, destroy_object_action));
         popup.AddMenuItem(GG::MenuItem(UserString("MOD_SET_OWNER"),    false, false, set_owner_action));

--- a/UI/PlayerListWnd.cpp
+++ b/UI/PlayerListWnd.cpp
@@ -207,7 +207,7 @@ namespace {
             case Networking::CLIENT_TYPE_HUMAN_MODERATOR:   ModeratorIcon()->OrthoBlit(UpperLeft() + m_player_type_icon_ul, UpperLeft() + m_player_type_icon_ul + ICON_SIZE); break;
             default:    break;
             }
- 
+
             if (m_host)
                 HostIcon()->OrthoBlit(UpperLeft() + m_host_icon_ul, UpperLeft() + m_host_icon_ul + ICON_SIZE);
 
@@ -731,7 +731,7 @@ void PlayerListWnd::PlayerRightClicked(GG::ListBox::iterator it, const GG::Pt& p
     auto make_send_diplomatic_action = [client_player_id, clicked_player_id, client_empire_id, clicked_empire_id](const std::function<DiplomaticMessage(int, int)>& message) {
         return [client_player_id, clicked_player_id, client_empire_id, clicked_empire_id, &message]() {
             HumanClientApp::GetApp()->Networking().SendMessage(
-                DiplomacyMessage(client_player_id, clicked_player_id, message(client_empire_id, clicked_empire_id)));
+                DiplomacyMessage(message(client_empire_id, clicked_empire_id)));
         };
     };
 

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -199,11 +199,7 @@ void AIClientApp::HandleMessage(const Message& msg) {
         if (text.empty()) {
             ErrorLogger() << "AIClientApp::HandleMessage for HOST_ID : Got empty message text?!";
         } else {
-            try {
-                host_id = boost::lexical_cast<int>(text);
-            } catch (...) {
-                ErrorLogger() << "AIClientApp::HandleMessage for HOST_ID : Couldn't parese message text: " << text;
-            }
+            host_id = boost::lexical_cast<int>(text);
         }
         m_networking->SetHostPlayerID(host_id);
         break;
@@ -213,12 +209,8 @@ void AIClientApp::HandleMessage(const Message& msg) {
         if (PlayerID() == Networking::INVALID_PLAYER_ID) {
             DebugLogger() << "AIClientApp::HandleMessage : Received JOIN_GAME acknowledgement";
             const std::string& text = msg.Text();
-            try {
-                int player_id = boost::lexical_cast<int>(text);
-                m_networking->SetPlayerID(player_id);
-            } catch(...) {
-                ErrorLogger() << "AIClientApp::HandleMessage : Received erroneous JOIN_GAME acknowledgement " << text;
-            }
+            int player_id = boost::lexical_cast<int>(text);
+            m_networking->SetPlayerID(player_id);
         } else {
             ErrorLogger() << "AIClientApp::HandleMessage : Received erroneous JOIN_GAME acknowledgement when already in a game";
         }

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -341,7 +341,6 @@ void AIClientApp::HandleMessage(const Message& msg) {
     }
 
     case Message::PLAYER_CHAT: {
-        const std::string& text = msg.Text();
         std::string data;
         int player_id;
         ExtractServerPlayerChatMessageData(msg, player_id, data);

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -304,7 +304,7 @@ void AIClientApp::HandleMessage(const Message& msg) {
 
     case Message::SAVE_GAME_DATA_REQUEST: {
         //DebugLogger() << "AIClientApp::HandleMessage Message::SAVE_GAME_DATA_REQUEST";
-        Networking().SendMessage(ClientSaveDataMessage(PlayerID(), Orders(), m_AI->GetSaveStateString()));
+        Networking().SendMessage(ClientSaveDataMessage(Orders(), m_AI->GetSaveStateString()));
         //DebugLogger() << "AIClientApp::HandleMessage sent save data message";
         break;
     }

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -181,7 +181,7 @@ void AIClientApp::HandlePythonAICrash() {
     err_msg << "AIClientApp failed due to error in python AI code for " << PlayerName() << ".  Exiting Soon.";
     ErrorLogger() << err_msg.str() << " id = " << PlayerID();
     Networking().SendMessage(
-        ErrorMessage(PlayerID(), str(FlexibleFormat(UserString("ERROR_PYTHON_AI_CRASHED")) % PlayerName()) , true));
+        ErrorMessage(str(FlexibleFormat(UserString("ERROR_PYTHON_AI_CRASHED")) % PlayerName()) , true));
 }
 
 
@@ -210,102 +210,103 @@ void AIClientApp::HandleMessage(const Message& msg) {
     }
 
     case Message::JOIN_GAME: {
-        if (msg.SendingPlayer() == Networking::INVALID_PLAYER_ID) {
-            if (PlayerID() == Networking::INVALID_PLAYER_ID) {
-                DebugLogger() << "AIClientApp::HandleMessage : Received JOIN_GAME acknowledgement";
-                m_networking->SetPlayerID(msg.ReceivingPlayer());
-            } else {
-                ErrorLogger() << "AIClientApp::HandleMessage : Received erroneous JOIN_GAME acknowledgement when already in a game";
+        if (PlayerID() == Networking::INVALID_PLAYER_ID) {
+            DebugLogger() << "AIClientApp::HandleMessage : Received JOIN_GAME acknowledgement";
+            const std::string& text = msg.Text();
+            try {
+                int player_id = boost::lexical_cast<int>(text);
+                m_networking->SetPlayerID(player_id);
+            } catch(...) {
+                ErrorLogger() << "AIClientApp::HandleMessage : Received erroneous JOIN_GAME acknowledgement " << text;
             }
+        } else {
+            ErrorLogger() << "AIClientApp::HandleMessage : Received erroneous JOIN_GAME acknowledgement when already in a game";
         }
         break;
     }
 
     case Message::GAME_START: {
-        if (msg.SendingPlayer() == Networking::INVALID_PLAYER_ID) {
-            DebugLogger() << "AIClientApp::HandleMessage : Received GAME_START message; starting AI turn...";
-            bool single_player_game;        // ignored
-            bool loaded_game_data;
-            bool ui_data_available;         // ignored
-            SaveGameUIData ui_data;         // ignored
-            bool state_string_available;    // ignored, as save_state_string is sent even if not set by ExtractMessageData
-            std::string save_state_string;
-            m_player_status.clear();
+        DebugLogger() << "AIClientApp::HandleMessage : Received GAME_START message; starting AI turn...";
+        bool single_player_game;        // ignored
+        bool loaded_game_data;
+        bool ui_data_available;         // ignored
+        SaveGameUIData ui_data;         // ignored
+        bool state_string_available;    // ignored, as save_state_string is sent even if not set by ExtractMessageData
+        std::string save_state_string;
+        m_player_status.clear();
 
-            ExtractGameStartMessageData(msg,                     single_player_game,     m_empire_id,
-                                        m_current_turn,          m_empires,              m_universe,
-                                        GetSpeciesManager(),     GetCombatLogManager(),  GetSupplyManager(),
-                                        m_player_info,           m_orders,               loaded_game_data,
-                                        ui_data_available,       ui_data,                state_string_available,
-                                        save_state_string,       m_galaxy_setup_data);
+        ExtractGameStartMessageData(msg,                     single_player_game,     m_empire_id,
+                                    m_current_turn,          m_empires,              m_universe,
+                                    GetSpeciesManager(),     GetCombatLogManager(),  GetSupplyManager(),
+                                    m_player_info,           m_orders,               loaded_game_data,
+                                    ui_data_available,       ui_data,                state_string_available,
+                                    save_state_string,       m_galaxy_setup_data);
 
-            DebugLogger() << "Extracted GameStart message for turn: " << m_current_turn << " with empire: " << m_empire_id;
+        DebugLogger() << "Extracted GameStart message for turn: " << m_current_turn << " with empire: " << m_empire_id;
 
-            GetUniverse().InitializeSystemGraph(m_empire_id);
+        GetUniverse().InitializeSystemGraph(m_empire_id);
 
-            DebugLogger() << "Message::GAME_START loaded_game_data: " << loaded_game_data;
-            if (loaded_game_data) {
-                if (GetOptionsDB().Get<bool>("verbose-logging"))
-                    DebugLogger() << "Message::GAME_START save_state_string: " << save_state_string;
-                m_AI->ResumeLoadedGame(save_state_string);
-                Orders().ApplyOrders();
-            } else {
-                DebugLogger() << "Message::GAME_START Starting New Game!";
-                // % Distribution of aggression levels
-                // Aggression   :  0   1   2   3   4   5   (0=Beginner, 5=Maniacal)
-                //                __  __  __  __  __  __
-                //Max 0         :100   0   0   0   0   0
-                //Max 1         : 25  75   0   0   0   0
-                //Max 2         :  0  25  75   0   0   0
-                //Max 3         :  0   0  25  75   0   0
-                //Max 4         :  0   0   0  25  75   0
-                //Max 5         :  0   0   0   0  25  75
-                
-                
-                // Optional aggression table, possibly for 0.4.4+?
-                // Aggression   :  0   1   2   3   4   5   (0=Beginner, 5=Maniacal)
-                //                __  __  __  __  __  __
-                //Max 0         :100   0   0   0   0   0
-                //Max 1         : 25  75   0   0   0   0
-                //Max 2         :  8  17  75   0   0   0
-                //Max 3         :  0   8  17  75   0   0
-                //Max 4         :  0   0   8  17  75   0
-                //Max 5         :  0   0   0   8  17  75
+        DebugLogger() << "Message::GAME_START loaded_game_data: " << loaded_game_data;
+        if (loaded_game_data) {
+            if (GetOptionsDB().Get<bool>("verbose-logging"))
+                DebugLogger() << "Message::GAME_START save_state_string: " << save_state_string;
+            m_AI->ResumeLoadedGame(save_state_string);
+            Orders().ApplyOrders();
+        } else {
+            DebugLogger() << "Message::GAME_START Starting New Game!";
+            // % Distribution of aggression levels
+            // Aggression   :  0   1   2   3   4   5   (0=Beginner, 5=Maniacal)
+            //                __  __  __  __  __  __
+            //Max 0         :100   0   0   0   0   0
+            //Max 1         : 25  75   0   0   0   0
+            //Max 2         :  0  25  75   0   0   0
+            //Max 3         :  0   0  25  75   0   0
+            //Max 4         :  0   0   0  25  75   0
+            //Max 5         :  0   0   0   0  25  75
 
-                const std::string g_seed = GetGalaxySetupData().m_seed;
-                const std::string emp_name = GetEmpire(m_empire_id)->Name();
-                unsigned int my_seed = 0;
+            // Optional aggression table, possibly for 0.4.4+?
+            // Aggression   :  0   1   2   3   4   5   (0=Beginner, 5=Maniacal)
+            //                __  __  __  __  __  __
+            //Max 0         :100   0   0   0   0   0
+            //Max 1         : 25  75   0   0   0   0
+            //Max 2         :  8  17  75   0   0   0
+            //Max 3         :  0   8  17  75   0   0
+            //Max 4         :  0   0   8  17  75   0
+            //Max 5         :  0   0   0   8  17  75
 
-                try {
-                    // generate consistent my_seed values from galaxy seed & empire name.
-                    boost::hash<std::string> string_hash;
-                    std::size_t h = string_hash(g_seed);
-                    my_seed = 3 * static_cast<unsigned int>(h) * static_cast<unsigned int>(string_hash(emp_name));
-                    DebugLogger() << "Message::GAME_START getting " << emp_name << " AI aggression, RNG Seed: " << my_seed;
-                } catch (...) {
-                    DebugLogger() << "Message::GAME_START getting " << emp_name << " AI aggression, could not initialise RNG.";
-                }
+            const std::string g_seed = GetGalaxySetupData().m_seed;
+            const std::string emp_name = GetEmpire(m_empire_id)->Name();
+            unsigned int my_seed = 0;
 
-                int rand_num = 0;
-                int this_aggr = m_max_aggression;
-
-                if (this_aggr > 0  && my_seed > 0) {
-                    Seed(my_seed);
-                    rand_num = RandSmallInt(0, 99);
-                    // if it's in the top 25% then decrease aggression.
-                    if (rand_num > 74) this_aggr--;
-                    // Leaving the following as commented out code for now. Possibly for 0.4.4+? 
-                    // in the top 8% ? decrease aggression again, unless it's already as low as it gets.
-                    // if (rand_num > 91 && this_aggr > 0) this_aggr--;
-                }
-
-                DebugLogger() << "Message::GAME_START setting AI aggression as " << this_aggr << " (from rnd " << rand_num << "; max aggression " << m_max_aggression << ")";
-
-                m_AI->SetAggression(this_aggr);
-                m_AI->StartNewGame();
+            try {
+                // generate consistent my_seed values from galaxy seed & empire name.
+                boost::hash<std::string> string_hash;
+                std::size_t h = string_hash(g_seed);
+                my_seed = 3 * static_cast<unsigned int>(h) * static_cast<unsigned int>(string_hash(emp_name));
+                DebugLogger() << "Message::GAME_START getting " << emp_name << " AI aggression, RNG Seed: " << my_seed;
+            } catch (...) {
+                DebugLogger() << "Message::GAME_START getting " << emp_name << " AI aggression, could not initialise RNG.";
             }
-            m_AI->GenerateOrders();
+
+            int rand_num = 0;
+            int this_aggr = m_max_aggression;
+
+            if (this_aggr > 0  && my_seed > 0) {
+                Seed(my_seed);
+                rand_num = RandSmallInt(0, 99);
+                // if it's in the top 25% then decrease aggression.
+                if (rand_num > 74) this_aggr--;
+                // Leaving the following as commented out code for now. Possibly for 0.4.4+?
+                // in the top 8% ? decrease aggression again, unless it's already as low as it gets.
+                // if (rand_num > 91 && this_aggr > 0) this_aggr--;
+            }
+
+            DebugLogger() << "Message::GAME_START setting AI aggression as " << this_aggr << " (from rnd " << rand_num << "; max aggression " << m_max_aggression << ")";
+
+            m_AI->SetAggression(this_aggr);
+            m_AI->StartNewGame();
         }
+        m_AI->GenerateOrders();
         break;
     }
 
@@ -320,22 +321,19 @@ void AIClientApp::HandleMessage(const Message& msg) {
         break;
 
     case Message::TURN_UPDATE: {
-        if (msg.SendingPlayer() == Networking::INVALID_PLAYER_ID) {
-            //DebugLogger() << "AIClientApp::HandleMessage : extracting turn update message data";
-            ExtractTurnUpdateMessageData(msg,                     m_empire_id,        m_current_turn,
-                                         m_empires,               m_universe,         GetSpeciesManager(),
-                                         GetCombatLogManager(),   GetSupplyManager(), m_player_info);
-            //DebugLogger() << "AIClientApp::HandleMessage : generating orders";
-            GetUniverse().InitializeSystemGraph(m_empire_id);
-            m_AI->GenerateOrders();
-            //DebugLogger() << "AIClientApp::HandleMessage : done handling turn update message";
-        }
+        //DebugLogger() << "AIClientApp::HandleMessage : extracting turn update message data";
+        ExtractTurnUpdateMessageData(msg,                     m_empire_id,        m_current_turn,
+                                     m_empires,               m_universe,         GetSpeciesManager(),
+                                     GetCombatLogManager(),   GetSupplyManager(), m_player_info);
+        //DebugLogger() << "AIClientApp::HandleMessage : generating orders";
+        GetUniverse().InitializeSystemGraph(m_empire_id);
+        m_AI->GenerateOrders();
+        //DebugLogger() << "AIClientApp::HandleMessage : done handling turn update message";
         break;
     }
 
     case Message::TURN_PARTIAL_UPDATE:
-        if (msg.SendingPlayer() == Networking::INVALID_PLAYER_ID)
-            ExtractTurnPartialUpdateMessageData(msg, m_empire_id, m_universe);
+        ExtractTurnPartialUpdateMessageData(msg, m_empire_id, m_universe);
         break;
 
     case Message::TURN_PROGRESS:
@@ -345,14 +343,19 @@ void AIClientApp::HandleMessage(const Message& msg) {
     case Message::END_GAME: {
         DebugLogger() << "Message::END_GAME : Exiting";
         DebugLogger() << "Acknowledge server shutdown message.";
-        Networking().SendMessage(AIEndGameAcknowledgeMessage(Networking().PlayerID()));
+        Networking().SendMessage(AIEndGameAcknowledgeMessage());
         Exit(0);
         break;
     }
 
-    case Message::PLAYER_CHAT:
-        m_AI->HandleChatMessage(msg.SendingPlayer(), msg.Text());
+    case Message::PLAYER_CHAT: {
+        const std::string& text = msg.Text();
+        std::string data;
+        int player_id;
+        ExtractServerPlayerChatMessageData(msg, player_id, data);
+        m_AI->HandleChatMessage(player_id, data);
         break;
+    }
 
     case Message::DIPLOMACY: {
         DiplomaticMessage diplo_message;

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -199,7 +199,11 @@ void AIClientApp::HandleMessage(const Message& msg) {
         if (text.empty()) {
             ErrorLogger() << "AIClientApp::HandleMessage for HOST_ID : Got empty message text?!";
         } else {
-            host_id = boost::lexical_cast<int>(text);
+            try {
+                host_id = boost::lexical_cast<int>(text);
+            } catch(const boost::bad_lexical_cast& ex) {
+                ErrorLogger() << "AIClientApp::HandleMessage for HOST_ID : Couldn't parse message text \"" << text << "\": " << ex.what();
+            }
         }
         m_networking->SetHostPlayerID(host_id);
         break;
@@ -209,8 +213,12 @@ void AIClientApp::HandleMessage(const Message& msg) {
         if (PlayerID() == Networking::INVALID_PLAYER_ID) {
             DebugLogger() << "AIClientApp::HandleMessage : Received JOIN_GAME acknowledgement";
             const std::string& text = msg.Text();
-            int player_id = boost::lexical_cast<int>(text);
-            m_networking->SetPlayerID(player_id);
+            try {
+                int player_id = boost::lexical_cast<int>(text);
+                m_networking->SetPlayerID(player_id);
+            } catch(const boost::bad_lexical_cast& ex) {
+                ErrorLogger() << "AIClientApp::HandleMessage for JOIN_GAME : Couldn't parse message text \"" << text << "\": " << ex.what();
+            }
         } else {
             ErrorLogger() << "AIClientApp::HandleMessage : Received erroneous JOIN_GAME acknowledgement when already in a game";
         }

--- a/client/ClientApp.cpp
+++ b/client/ClientApp.cpp
@@ -117,7 +117,7 @@ void ClientApp::SetPlayerStatus(int player_id, Message::PlayerStatus status) {
 }
 
 void ClientApp::StartTurn() {
-    m_networking->SendMessage(TurnOrdersMessage(m_networking->PlayerID(), m_orders));
+    m_networking->SendMessage(TurnOrdersMessage(m_orders));
     m_orders.Reset();
 }
 
@@ -141,14 +141,14 @@ std::string ClientApp::GetVisibleObjectName(std::shared_ptr<const UniverseObject
 }
 
 int ClientApp::GetNewObjectID() {
-    const auto msg = m_networking->SendSynchronousMessage(RequestNewObjectIDMessage(m_networking->PlayerID()));
+    const auto msg = m_networking->SendSynchronousMessage(RequestNewObjectIDMessage());
     if (!msg || msg->Text().empty())
         throw std::runtime_error("ClientApp::GetNewObjectID() didn't get a new object ID");
     return boost::lexical_cast<int>(msg->Text());
 }
 
 int ClientApp::GetNewDesignID() {
-    const auto msg = m_networking->SendSynchronousMessage(RequestNewDesignIDMessage(m_networking->PlayerID()));
+    const auto msg = m_networking->SendSynchronousMessage(RequestNewDesignIDMessage());
     if (!msg || msg->Text().empty())
         throw std::runtime_error("ClientApp::GetNewDesignID() didn't get a new design ID");
     return boost::lexical_cast<int>(msg->Text());

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -835,7 +835,6 @@ void HumanClientApp::HandleMessage(Message& msg) {
     case Message::JOIN_GAME:                m_fsm->process_event(JoinGame(msg));                break;
     case Message::HOST_ID:                  m_fsm->process_event(HostID(msg));                  break;
     case Message::LOBBY_UPDATE:             m_fsm->process_event(LobbyUpdate(msg));             break;
-    case Message::LOBBY_CHAT:               m_fsm->process_event(LobbyChat(msg));               break;
     case Message::SAVE_GAME_DATA_REQUEST:   m_fsm->process_event(SaveGameDataRequest(msg));     break;
     case Message::SAVE_GAME_COMPLETE:       m_fsm->process_event(SaveGameComplete(msg));        break;
 

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -597,7 +597,7 @@ void HumanClientApp::CancelMultiplayerGameFromLobby()
 void HumanClientApp::SaveGame(const std::string& filename) {
     m_save_game_in_progress = true;
     Message response_msg;
-    m_networking->SendMessage(HostSaveGameInitiateMessage(PlayerID(), filename));
+    m_networking->SendMessage(HostSaveGameInitiateMessage(filename));
     DebugLogger() << "HumanClientApp::SaveGame sent save initiate message to server...";
 }
 
@@ -695,7 +695,7 @@ void HumanClientApp::RequestSavePreviews(const std::string& directory, PreviewIn
         }
     }
     DebugLogger() << "HumanClientApp::RequestSavePreviews Requesting previews for " << generic_directory;
-    const auto response = m_networking->SendSynchronousMessage(RequestSavePreviewsMessage(PlayerID(), generic_directory));
+    const auto response = m_networking->SendSynchronousMessage(RequestSavePreviewsMessage(generic_directory));
     if (response && response->Type() == Message::DISPATCH_SAVE_PREVIEWS) {
         ExtractDispatchSavePreviewsMessageData(*response, previews);
         DebugLogger() << "HumanClientApp::RequestSavePreviews Got " << previews.previews.size() << " previews.";
@@ -859,7 +859,7 @@ void HumanClientApp::HandleSaveGameDataRequest() {
         std::cerr << "HumanClientApp::HandleSaveGameDataRequest(" << Message::SAVE_GAME_DATA_REQUEST << ")\n";
     SaveGameUIData ui_data;
     m_ui->GetSaveGameUIData(ui_data);
-    m_networking->SendMessage(ClientSaveDataMessage(PlayerID(), Orders(), ui_data));
+    m_networking->SendMessage(ClientSaveDataMessage(Orders(), ui_data));
 }
 
 void HumanClientApp::UpdateCombatLogs(const Message& msg){
@@ -986,7 +986,7 @@ void HumanClientApp::HandleTurnUpdate()
 void HumanClientApp::UpdateCombatLogManager() {
     boost::optional<std::vector<int>> incomplete_ids = GetCombatLogManager().IncompleteLogIDs();
     if (incomplete_ids)
-        m_networking->SendMessage(RequestCombatLogsMessage(PlayerID(), *incomplete_ids));
+        m_networking->SendMessage(RequestCombatLogsMessage(*incomplete_ids));
 }
 
 namespace {

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -418,7 +418,7 @@ boost::statechart::result MPLobby::react(const StartMPGameClicked& a) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) MPLobby.StartMPGameClicked";
 
     if (Client().Networking().PlayerIsHost(Client().Networking().PlayerID()))
-        Client().Networking().SendMessage(StartMPGameMessage(Client().PlayerID()));
+        Client().Networking().SendMessage(StartMPGameMessage());
     else
         ErrorLogger() << "MPLobby::react received start MP game event but this client is not the host.  Ignoring";
 
@@ -955,7 +955,7 @@ boost::statechart::result QuittingGame::react(const ShutdownServer& u) {
 
     if (Client().Networking().IsTxConnected()) {
         DebugLogger() << "Sending server shutdown message.";
-        Client().Networking().SendMessage(ShutdownServerMessage(Client().Networking().PlayerID()));
+        Client().Networking().SendMessage(ShutdownServerMessage());
 
         post_event(WaitForDisconnect());
 

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -152,12 +152,19 @@ WaitingForSPHostAck::~WaitingForSPHostAck()
 boost::statechart::result WaitingForSPHostAck::react(const HostSPGame& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) WaitingForSPHostAck.HostSPGame";
 
-    Client().Networking().SetPlayerID(msg.m_message.ReceivingPlayer());
-    Client().Networking().SetHostPlayerID(msg.m_message.ReceivingPlayer());
+    try {
+        int host_id = boost::lexical_cast<int>(msg.m_message.Text());
 
-    Client().GetClientUI().GetMapWnd()->Sanitize();
+        Client().Networking().SetPlayerID(host_id);
+        Client().Networking().SetHostPlayerID(host_id);
 
-    return transit<PlayingGame>();
+        Client().GetClientUI().GetMapWnd()->Sanitize();
+
+        return transit<PlayingGame>();
+    } catch (...) {
+        ErrorLogger() << "WaitingForSPHostAck::react(const HostSPGame& msg) couldn't parese message text: " << msg.m_message.Text();
+        return transit<IntroMenu>();
+    }
 }
 
 boost::statechart::result WaitingForSPHostAck::react(const Disconnection& d) {
@@ -174,7 +181,8 @@ boost::statechart::result WaitingForSPHostAck::react(const Error& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) WaitingForSPHostAck.Error";
     std::string problem;
     bool fatal;
-    ExtractErrorMessageData(msg.m_message, problem, fatal);
+    int player_id;
+    ExtractErrorMessageData(msg.m_message, player_id, problem, fatal);
 
     ErrorLogger() << "WaitingForSPHostAck::react(const Error& msg) error: " << problem;
 
@@ -214,10 +222,17 @@ WaitingForMPHostAck::~WaitingForMPHostAck()
 boost::statechart::result WaitingForMPHostAck::react(const HostMPGame& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) WaitingForMPHostAck.HostMPGame";
 
-    Client().Networking().SetPlayerID(msg.m_message.ReceivingPlayer());
-    Client().Networking().SetHostPlayerID(msg.m_message.ReceivingPlayer());
+    try {
+        int host_id = boost::lexical_cast<int>(msg.m_message.Text());
 
-    return transit<MPLobby>();
+        Client().Networking().SetPlayerID(host_id);
+        Client().Networking().SetHostPlayerID(host_id);
+
+        return transit<MPLobby>();
+    } catch (...) {
+        ErrorLogger() << "WaitingForMPHostAck::react(const HostMPGame& msg) couldn't parese message text: " << msg.m_message.Text();
+        return transit<IntroMenu>();
+    }
 }
 
 boost::statechart::result WaitingForMPHostAck::react(const Disconnection& d) {
@@ -234,7 +249,8 @@ boost::statechart::result WaitingForMPHostAck::react(const Error& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) WaitingForMPHostAck.Error";
     std::string problem;
     bool fatal;
-    ExtractErrorMessageData(msg.m_message, problem, fatal);
+    int player_id;
+    ExtractErrorMessageData(msg.m_message, player_id, problem, fatal);
 
     ErrorLogger() << "WaitingForMPHostAck::react(const Error& msg) error: " << problem;
 
@@ -274,9 +290,16 @@ WaitingForMPJoinAck::~WaitingForMPJoinAck()
 boost::statechart::result WaitingForMPJoinAck::react(const JoinGame& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) WaitingForMPJoinAck.JoinGame";
 
-    Client().Networking().SetPlayerID(msg.m_message.ReceivingPlayer());
+    try {
+        int player_id = boost::lexical_cast<int>(msg.m_message.Text());
 
-    return transit<MPLobby>();
+        Client().Networking().SetPlayerID(player_id);
+
+        return transit<MPLobby>();
+    } catch (...) {
+        ErrorLogger() << "WaitingForMPJoinAck::react(const JoinGame& msg) couldn't parese message text: " << msg.m_message.Text();
+        return transit<IntroMenu>();
+    }
 }
 
 boost::statechart::result WaitingForMPJoinAck::react(const Disconnection& d) {
@@ -293,7 +316,8 @@ boost::statechart::result WaitingForMPJoinAck::react(const Error& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) WaitingForMPJoinAck.Error";
     std::string problem;
     bool fatal;
-    ExtractErrorMessageData(msg.m_message, problem, fatal);
+    int player_id;
+    ExtractErrorMessageData(msg.m_message, player_id, problem, fatal);
 
     ErrorLogger() << "WaitingForMPJoinAck::react(const Error& msg) error: " << problem;
 
@@ -373,9 +397,14 @@ boost::statechart::result MPLobby::react(const LobbyUpdate& msg) {
     return discard_event();
 }
 
-boost::statechart::result MPLobby::react(const LobbyChat& msg) {
-    if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) MPLobby.LobbyChat";
-    Client().GetClientUI().GetMultiPlayerLobbyWnd()->ChatMessage(msg.m_message.SendingPlayer(), msg.m_message.Text());
+boost::statechart::result MPLobby::react(const PlayerChat& msg) {
+    if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) MPLobby.PlayerChat";
+
+    int player_id;
+    std::string data;
+    ExtractServerPlayerChatMessageData(msg.m_message, player_id, data);
+
+    Client().GetClientUI().GetMultiPlayerLobbyWnd()->ChatMessage(player_id, data);
     return discard_event();
 }
 
@@ -416,7 +445,8 @@ boost::statechart::result MPLobby::react(const Error& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) MPLobby.Error";
     std::string problem;
     bool fatal;
-    ExtractErrorMessageData(msg.m_message, problem, fatal);
+    int player_id;
+    ExtractErrorMessageData(msg.m_message, player_id, problem, fatal);
 
     ErrorLogger() << "MPLobby::react(const Error& msg) error: " << problem;
 
@@ -480,11 +510,11 @@ boost::statechart::result PlayingGame::react(const HostID& msg) {
 
 boost::statechart::result PlayingGame::react(const PlayerChat& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) PlayingGame.PlayerChat: " << msg.m_message.Text();
-    const std::string& text = msg.m_message.Text();
-    int sending_player_id = msg.m_message.SendingPlayer();
-    int recipient_player_id = msg.m_message.ReceivingPlayer();
+    std::string text;
+    int sending_player_id;
+    ExtractPlayerChatMessageData(msg.m_message, sending_player_id, text);
 
-    Client().GetClientUI().GetMessageWnd()->HandlePlayerChatMessage(text, sending_player_id, recipient_player_id);
+    Client().GetClientUI().GetMessageWnd()->HandlePlayerChatMessage(text, sending_player_id, Client().PlayerID());
 
     return discard_event();
 }
@@ -570,7 +600,8 @@ boost::statechart::result PlayingGame::react(const Error& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) PlayingGame.Error";
     std::string problem;
     bool fatal;
-    ExtractErrorMessageData(msg.m_message, problem, fatal);
+    int player_id;
+    ExtractErrorMessageData(msg.m_message, player_id, problem, fatal);
 
     ErrorLogger() << "PlayingGame::react(const Error& msg) error: "
                   << problem << "\nProblem is" << (fatal ? "fatal" : "non-fatal");

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -161,8 +161,8 @@ boost::statechart::result WaitingForSPHostAck::react(const HostSPGame& msg) {
         Client().GetClientUI().GetMapWnd()->Sanitize();
 
         return transit<PlayingGame>();
-    } catch (...) {
-        ErrorLogger() << "WaitingForSPHostAck::react(const HostSPGame& msg) couldn't parese message text: " << msg.m_message.Text();
+    } catch (const boost::bad_lexical_cast& ex) {
+        ErrorLogger() << "WaitingForSPHostAck::react(const HostSPGame& msg) couldn't parse message text: " << msg.m_message.Text() << " Error: " << ex.what();
         return transit<IntroMenu>();
     }
 }
@@ -229,8 +229,8 @@ boost::statechart::result WaitingForMPHostAck::react(const HostMPGame& msg) {
         Client().Networking().SetHostPlayerID(host_id);
 
         return transit<MPLobby>();
-    } catch (...) {
-        ErrorLogger() << "WaitingForMPHostAck::react(const HostMPGame& msg) couldn't parese message text: " << msg.m_message.Text();
+    } catch (const boost::bad_lexical_cast& ex) {
+        ErrorLogger() << "WaitingForMPHostAck::react(const HostMPGame& msg) couldn't parse message text: " << msg.m_message.Text() << " Error: " << ex.what();
         return transit<IntroMenu>();
     }
 }
@@ -296,8 +296,8 @@ boost::statechart::result WaitingForMPJoinAck::react(const JoinGame& msg) {
         Client().Networking().SetPlayerID(player_id);
 
         return transit<MPLobby>();
-    } catch (...) {
-        ErrorLogger() << "WaitingForMPJoinAck::react(const JoinGame& msg) couldn't parese message text: " << msg.m_message.Text();
+    } catch (const boost::bad_lexical_cast& ex) {
+        ErrorLogger() << "WaitingForMPJoinAck::react(const JoinGame& msg) couldn't parse message text: " << msg.m_message.Text() << " Error: " << ex.what();
         return transit<IntroMenu>();
     }
 }
@@ -376,11 +376,7 @@ boost::statechart::result MPLobby::react(const HostID& msg) {
     if (text.empty()) {
         ErrorLogger() << "MPLobby::react(const HostID& msg) got empty message text?!";
     } else {
-        try {
-            host_id = boost::lexical_cast<int>(text);
-        } catch (...) {
-            ErrorLogger() << "MPLobby::react(const HostID& msg) couldn't parese message text: " << text;
-        }
+        host_id = boost::lexical_cast<int>(text);
     }
     Client().Networking().SetHostPlayerID(host_id);
 
@@ -494,11 +490,7 @@ boost::statechart::result PlayingGame::react(const HostID& msg) {
     if (text.empty()) {
         ErrorLogger() << "PlayingGame::react(const HostID& msg) got empty message text?!";
     } else {
-        try {
-            host_id = boost::lexical_cast<int>(text);
-        } catch (...) {
-            ErrorLogger() << "PlayingGame::react(const HostID& msg) couldn't parese message text: " << text;
-        }
+        host_id = boost::lexical_cast<int>(text);
     }
     Client().Networking().SetHostPlayerID(host_id);
 

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -162,7 +162,7 @@ boost::statechart::result WaitingForSPHostAck::react(const HostSPGame& msg) {
 
         return transit<PlayingGame>();
     } catch (const boost::bad_lexical_cast& ex) {
-        ErrorLogger() << "WaitingForSPHostAck::react(const HostSPGame& msg) couldn't parse message text: " << msg.m_message.Text() << " Error: " << ex.what();
+        ErrorLogger() << "WaitingForSPHostAck::react(const HostSPGame& msg) Host id " << msg.m_message.Text() << " is not a number: " << ex.what();
         return transit<IntroMenu>();
     }
 }
@@ -230,7 +230,7 @@ boost::statechart::result WaitingForMPHostAck::react(const HostMPGame& msg) {
 
         return transit<MPLobby>();
     } catch (const boost::bad_lexical_cast& ex) {
-        ErrorLogger() << "WaitingForMPHostAck::react(const HostMPGame& msg) couldn't parse message text: " << msg.m_message.Text() << " Error: " << ex.what();
+        ErrorLogger() << "WaitingForMPHostAck::react(const HostMPGame& msg) Host id " << msg.m_message.Text() << " is not a number: " << ex.what();
         return transit<IntroMenu>();
     }
 }
@@ -297,7 +297,7 @@ boost::statechart::result WaitingForMPJoinAck::react(const JoinGame& msg) {
 
         return transit<MPLobby>();
     } catch (const boost::bad_lexical_cast& ex) {
-        ErrorLogger() << "WaitingForMPJoinAck::react(const JoinGame& msg) couldn't parse message text: " << msg.m_message.Text() << " Error: " << ex.what();
+        ErrorLogger() << "WaitingForMPJoinAck::react(const JoinGame& msg) Host id " << msg.m_message.Text() << " is not a number: " << ex.what();
         return transit<IntroMenu>();
     }
 }

--- a/client/human/HumanClientFSM.h
+++ b/client/human/HumanClientFSM.h
@@ -206,7 +206,7 @@ struct MPLobby : boost::statechart::state<MPLobby, HumanClientFSM> {
         boost::statechart::custom_reaction<Disconnection>,
         boost::statechart::custom_reaction<HostID>,
         boost::statechart::custom_reaction<LobbyUpdate>,
-        boost::statechart::custom_reaction<LobbyChat>,
+        boost::statechart::custom_reaction<PlayerChat>,
         boost::statechart::custom_reaction<CancelMPGameClicked>,
         boost::statechart::custom_reaction<StartMPGameClicked>,
         boost::statechart::custom_reaction<GameStart>,
@@ -220,7 +220,7 @@ struct MPLobby : boost::statechart::state<MPLobby, HumanClientFSM> {
     boost::statechart::result react(const Disconnection& d);
     boost::statechart::result react(const HostID& msg);
     boost::statechart::result react(const LobbyUpdate& msg);
-    boost::statechart::result react(const LobbyChat& msg);
+    boost::statechart::result react(const PlayerChat& msg);
     boost::statechart::result react(const CancelMPGameClicked& a);
     boost::statechart::result react(const StartMPGameClicked& a);
     boost::statechart::result react(const GameStart& msg);

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -521,8 +521,8 @@ void ClientNetworking::Impl::HandleMessageBodyRead(const std::shared_ptr<const C
     if (error)
         throw boost::system::system_error(error);
 
-    assert(static_cast<int>(bytes_transferred) <= m_incoming_header[4]);
-    if (static_cast<int>(bytes_transferred) == m_incoming_header[4]) {
+    assert(static_cast<int>(bytes_transferred) <= m_incoming_header[2]);
+    if (static_cast<int>(bytes_transferred) == m_incoming_header[2]) {
         m_incoming_messages.PushBack(m_incoming_message);
         AsyncReadMessage(keep_alive);
     }
@@ -538,7 +538,7 @@ void ClientNetworking::Impl::HandleMessageHeaderRead(const std::shared_ptr<const
         return;
 
     BufferToHeader(m_incoming_header, m_incoming_message);
-    m_incoming_message.Resize(m_incoming_header[4]);
+    m_incoming_message.Resize(m_incoming_header[2]);
     // Intentionally not checked for open.  We expect (header, body) pairs.
     boost::asio::async_read(
         m_socket,
@@ -568,8 +568,8 @@ void ClientNetworking::Impl::HandleMessageWrite(boost::system::error_code error,
         return;
     }
 
-    assert(static_cast<int>(bytes_transferred) <= static_cast<int>(Message::HeaderBufferSize) + m_outgoing_header[4]);
-    if (static_cast<int>(bytes_transferred) != static_cast<int>(Message::HeaderBufferSize) + m_outgoing_header[4])
+    assert(static_cast<int>(bytes_transferred) <= static_cast<int>(Message::HeaderBufferSize) + m_outgoing_header[2]);
+    if (static_cast<int>(bytes_transferred) != static_cast<int>(Message::HeaderBufferSize) + m_outgoing_header[2])
         return;
 
     m_outgoing_messages.pop_front();

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -521,8 +521,8 @@ void ClientNetworking::Impl::HandleMessageBodyRead(const std::shared_ptr<const C
     if (error)
         throw boost::system::system_error(error);
 
-    assert(static_cast<int>(bytes_transferred) <= m_incoming_header[2]);
-    if (static_cast<int>(bytes_transferred) == m_incoming_header[2]) {
+    assert(static_cast<int>(bytes_transferred) <= m_incoming_header[Message::Parts::SIZE]);
+    if (static_cast<int>(bytes_transferred) == m_incoming_header[Message::Parts::SIZE]) {
         m_incoming_messages.PushBack(m_incoming_message);
         AsyncReadMessage(keep_alive);
     }
@@ -538,7 +538,7 @@ void ClientNetworking::Impl::HandleMessageHeaderRead(const std::shared_ptr<const
         return;
 
     BufferToHeader(m_incoming_header, m_incoming_message);
-    m_incoming_message.Resize(m_incoming_header[2]);
+    m_incoming_message.Resize(m_incoming_header[Message::Parts::SIZE]);
     // Intentionally not checked for open.  We expect (header, body) pairs.
     boost::asio::async_read(
         m_socket,
@@ -568,8 +568,8 @@ void ClientNetworking::Impl::HandleMessageWrite(boost::system::error_code error,
         return;
     }
 
-    assert(static_cast<int>(bytes_transferred) <= static_cast<int>(Message::HeaderBufferSize) + m_outgoing_header[2]);
-    if (static_cast<int>(bytes_transferred) != static_cast<int>(Message::HeaderBufferSize) + m_outgoing_header[2])
+    assert(static_cast<int>(bytes_transferred) <= static_cast<int>(Message::HeaderBufferSize) + m_outgoing_header[Message::Parts::SIZE]);
+    if (static_cast<int>(bytes_transferred) != static_cast<int>(Message::HeaderBufferSize) + m_outgoing_header[Message::Parts::SIZE])
         return;
 
     m_outgoing_messages.pop_front();

--- a/network/Message.cpp
+++ b/network/Message.cpp
@@ -114,15 +114,15 @@ void swap(Message& lhs, Message& rhs)
 { lhs.Swap(rhs); }
 
 void BufferToHeader(const Message::HeaderBuffer& buffer, Message& message) {
-    message.m_type = static_cast<Message::MessageType>(buffer[0]);
-    message.m_synchronous_response = (buffer[1] != 0);
-    message.m_message_size = buffer[2];
+    message.m_type = static_cast<Message::MessageType>(buffer[Message::Parts::TYPE]);
+    message.m_synchronous_response = (buffer[Message::Parts::RESPONSE] != 0);
+    message.m_message_size = buffer[Message::Parts::SIZE];
 }
 
 void HeaderToBuffer(const Message& message, Message::HeaderBuffer& buffer) {
-    buffer[0] = message.Type();
-    buffer[1] = message.SynchronousResponse();
-    buffer[2] = message.Size();
+    buffer[Message::Parts::TYPE] = message.Type();
+    buffer[Message::Parts::RESPONSE] = message.SynchronousResponse();
+    buffer[Message::Parts::SIZE] = message.Size();
 }
 
 ////////////////////////////////////////////////

--- a/network/Message.cpp
+++ b/network/Message.cpp
@@ -180,7 +180,7 @@ Message HostIDMessage(int host_player_id) {
                    std::to_string(host_player_id));
 }
 
-Message GameStartMessage(int player_id, bool single_player_game, int empire_id,
+Message GameStartMessage(bool single_player_game, int empire_id,
                          int current_turn, const EmpireManager& empires,
                          const Universe& universe, const SpeciesManager& species,
                          CombatLogManager& combat_logs, const SupplyManager& supply,
@@ -225,7 +225,7 @@ Message GameStartMessage(int player_id, bool single_player_game, int empire_id,
     return Message(Message::GAME_START, os.str());
 }
 
-Message GameStartMessage(int player_id, bool single_player_game, int empire_id,
+Message GameStartMessage(bool single_player_game, int empire_id,
                          int current_turn, const EmpireManager& empires,
                          const Universe& universe, const SpeciesManager& species,
                          CombatLogManager& combat_logs, const SupplyManager& supply,
@@ -285,7 +285,7 @@ Message GameStartMessage(int player_id, bool single_player_game, int empire_id,
     return Message(Message::GAME_START, os.str());
 }
 
-Message GameStartMessage(int player_id, bool single_player_game, int empire_id,
+Message GameStartMessage(bool single_player_game, int empire_id,
                          int current_turn, const EmpireManager& empires,
                          const Universe& universe, const SpeciesManager& species,
                          CombatLogManager& combat_logs, const SupplyManager& supply,

--- a/network/Message.cpp
+++ b/network/Message.cpp
@@ -37,7 +37,6 @@
 
 namespace {
     const std::string DUMMY_EMPTY_MESSAGE = "Lathanda";
-    const std::string ACKNOWLEDGEMENT = "ACK";
 }
 
 ////////////////////////////////////////////////

--- a/network/Message.cpp
+++ b/network/Message.cpp
@@ -354,7 +354,7 @@ Message HostMPAckMessage(int player_id)
 Message JoinAckMessage(int player_id)
 { return Message(Message::JOIN_GAME, std::to_string(player_id)); }
 
-Message TurnOrdersMessage(int sender, const OrderSet& orders) {
+Message TurnOrdersMessage(const OrderSet& orders) {
     std::ostringstream os;
     {
         freeorion_xml_oarchive oa(os);
@@ -372,7 +372,7 @@ Message TurnProgressMessage(Message::TurnProgressPhase phase_id) {
     return Message(Message::TURN_PROGRESS, os.str());
 }
 
-Message PlayerStatusMessage(int player_id, int about_player_id, Message::PlayerStatus player_status) {
+Message PlayerStatusMessage(int about_player_id, Message::PlayerStatus player_status) {
     std::ostringstream os;
     {
         freeorion_xml_oarchive oa(os);
@@ -382,7 +382,7 @@ Message PlayerStatusMessage(int player_id, int about_player_id, Message::PlayerS
     return Message(Message::PLAYER_STATUS, os.str());
 }
 
-Message TurnUpdateMessage(int player_id, int empire_id, int current_turn,
+Message TurnUpdateMessage(int empire_id, int current_turn,
                           const EmpireManager& empires, const Universe& universe,
                           const SpeciesManager& species, CombatLogManager& combat_logs,
                           const SupplyManager& supply,
@@ -416,7 +416,7 @@ Message TurnUpdateMessage(int player_id, int empire_id, int current_turn,
     return Message(Message::TURN_UPDATE, os.str());
 }
 
-Message TurnPartialUpdateMessage(int player_id, int empire_id, const Universe& universe,
+Message TurnPartialUpdateMessage(int empire_id, const Universe& universe,
                                  bool use_binary_serialization) {
     std::ostringstream os;
     {
@@ -433,7 +433,7 @@ Message TurnPartialUpdateMessage(int player_id, int empire_id, const Universe& u
     return Message(Message::TURN_PARTIAL_UPDATE, os.str());
 }
 
-Message ClientSaveDataMessage(int sender, const OrderSet& orders, const SaveGameUIData& ui_data) {
+Message ClientSaveDataMessage(const OrderSet& orders, const SaveGameUIData& ui_data) {
     std::ostringstream os;
     {
         freeorion_xml_oarchive oa(os);
@@ -447,7 +447,7 @@ Message ClientSaveDataMessage(int sender, const OrderSet& orders, const SaveGame
     return Message(Message::CLIENT_SAVE_DATA, os.str());
 }
 
-Message ClientSaveDataMessage(int sender, const OrderSet& orders, const std::string& save_state_string) {
+Message ClientSaveDataMessage(const OrderSet& orders, const std::string& save_state_string) {
     std::ostringstream os;
     {
         freeorion_xml_oarchive oa(os);
@@ -461,7 +461,7 @@ Message ClientSaveDataMessage(int sender, const OrderSet& orders, const std::str
     return Message(Message::CLIENT_SAVE_DATA, os.str());
 }
 
-Message ClientSaveDataMessage(int sender, const OrderSet& orders) {
+Message ClientSaveDataMessage(const OrderSet& orders) {
     std::ostringstream os;
     {
         freeorion_xml_oarchive oa(os);
@@ -474,26 +474,26 @@ Message ClientSaveDataMessage(int sender, const OrderSet& orders) {
     return Message(Message::CLIENT_SAVE_DATA, os.str());
 }
 
-Message RequestNewObjectIDMessage(int sender)
+Message RequestNewObjectIDMessage()
 { return Message(Message::REQUEST_NEW_OBJECT_ID, DUMMY_EMPTY_MESSAGE); }
 
-Message DispatchObjectIDMessage(int player_id, int new_id) {
+Message DispatchObjectIDMessage(int new_id) {
     return Message(Message::DISPATCH_NEW_OBJECT_ID,
                    std::to_string(new_id), true);
 }
 
-Message RequestNewDesignIDMessage(int sender)
+Message RequestNewDesignIDMessage()
 { return Message(Message::REQUEST_NEW_DESIGN_ID, DUMMY_EMPTY_MESSAGE, true); }
 
-Message DispatchDesignIDMessage(int player_id, int new_id) {
+Message DispatchDesignIDMessage(int new_id) {
     return Message(Message::DISPATCH_NEW_DESIGN_ID,
                    std::to_string(new_id), true);
 }
 
-Message HostSaveGameInitiateMessage(int sender, const std::string& filename)
+Message HostSaveGameInitiateMessage(const std::string& filename)
 { return Message(Message::SAVE_GAME_INITIATE, filename); }
 
-Message ServerSaveGameDataRequestMessage(int receiver, bool synchronous_response) {
+Message ServerSaveGameDataRequestMessage(bool synchronous_response) {
     return Message(Message::SAVE_GAME_DATA_REQUEST, DUMMY_EMPTY_MESSAGE, synchronous_response);
 }
 
@@ -507,7 +507,7 @@ Message ServerSaveGameCompleteMessage(const std::string& save_filename, int byte
     return Message(Message::SAVE_GAME_COMPLETE, os.str());
 }
 
-Message DiplomacyMessage(int sender, int receiver, const DiplomaticMessage& diplo_message) {
+Message DiplomacyMessage(const DiplomaticMessage& diplo_message) {
     std::ostringstream os;
     {
         freeorion_xml_oarchive oa(os);
@@ -516,7 +516,7 @@ Message DiplomacyMessage(int sender, int receiver, const DiplomaticMessage& dipl
     return Message(Message::DIPLOMACY, os.str());
 }
 
-Message DiplomaticStatusMessage(int receiver, const DiplomaticStatusUpdateInfo& diplo_update) {
+Message DiplomaticStatusMessage(const DiplomaticStatusUpdateInfo& diplo_update) {
     std::ostringstream os;
     {
         freeorion_xml_oarchive oa(os);
@@ -527,7 +527,7 @@ Message DiplomaticStatusMessage(int receiver, const DiplomaticStatusUpdateInfo& 
     return Message(Message::DIPLOMATIC_STATUS, os.str());
 }
 
-Message EndGameMessage(int receiver, Message::EndGameReason reason,
+Message EndGameMessage(Message::EndGameReason reason,
                        const std::string& reason_player_name/* = ""*/)
 {
     std::ostringstream os;
@@ -542,7 +542,7 @@ Message EndGameMessage(int receiver, Message::EndGameReason reason,
 Message AIEndGameAcknowledgeMessage()
 { return Message(Message::AI_END_GAME_ACK, DUMMY_EMPTY_MESSAGE); }
 
-Message ModeratorActionMessage(int sender, const Moderator::ModeratorAction& action) {
+Message ModeratorActionMessage(const Moderator::ModeratorAction& action) {
     std::ostringstream os;
     {
         const Moderator::ModeratorAction* mod_action = &action;
@@ -552,15 +552,15 @@ Message ModeratorActionMessage(int sender, const Moderator::ModeratorAction& act
     return Message(Message::MODERATOR_ACTION, os.str());
 }
 
-Message ShutdownServerMessage(int sender)
+Message ShutdownServerMessage()
 { return Message(Message::SHUT_DOWN_SERVER, DUMMY_EMPTY_MESSAGE); }
 
 /** requests previews of savefiles from server synchronously */
-Message RequestSavePreviewsMessage(int sender, std::string directory)
+Message RequestSavePreviewsMessage(std::string directory)
 { return Message(Message::REQUEST_SAVE_PREVIEWS, directory); }
 
 /** returns the savegame previews to the client */
-Message DispatchSavePreviewsMessage(int receiver, const PreviewInformation& previews) {
+Message DispatchSavePreviewsMessage(const PreviewInformation& previews) {
     std::ostringstream os;
     {
         freeorion_xml_oarchive oa(os);
@@ -569,14 +569,14 @@ Message DispatchSavePreviewsMessage(int receiver, const PreviewInformation& prev
     return Message(Message::DISPATCH_SAVE_PREVIEWS, os.str(), true);
 }
 
-Message RequestCombatLogsMessage(int sender, const std::vector<int>& ids) {
+Message RequestCombatLogsMessage(const std::vector<int>& ids) {
     std::ostringstream os;
     freeorion_xml_oarchive oa(os);
     oa << BOOST_SERIALIZATION_NVP(ids);
     return Message(Message::REQUEST_COMBAT_LOGS, os.str());
 }
 
-Message DispatchCombatLogsMessage(int receiver, const std::vector<std::pair<int, const CombatLog>>& logs) {
+Message DispatchCombatLogsMessage(const std::vector<std::pair<int, const CombatLog>>& logs) {
     std::ostringstream os;
     freeorion_xml_oarchive oa(os);
     oa << BOOST_SERIALIZATION_NVP(logs);
@@ -586,7 +586,7 @@ Message DispatchCombatLogsMessage(int receiver, const std::vector<std::pair<int,
 ////////////////////////////////////////////////
 // Multiplayer Lobby Message named ctors
 ////////////////////////////////////////////////
-Message LobbyUpdateMessage(int sender, const MultiplayerLobbyData& lobby_data) {
+Message LobbyUpdateMessage(const MultiplayerLobbyData& lobby_data) {
     std::ostringstream os;
     {
         freeorion_xml_oarchive oa(os);
@@ -595,7 +595,7 @@ Message LobbyUpdateMessage(int sender, const MultiplayerLobbyData& lobby_data) {
     return Message(Message::LOBBY_UPDATE, os.str());
 }
 
-Message ServerLobbyUpdateMessage(int receiver, const MultiplayerLobbyData& lobby_data) {
+Message ServerLobbyUpdateMessage(const MultiplayerLobbyData& lobby_data) {
     std::ostringstream os;
     {
         freeorion_xml_oarchive oa(os);
@@ -604,7 +604,7 @@ Message ServerLobbyUpdateMessage(int receiver, const MultiplayerLobbyData& lobby
     return Message(Message::LOBBY_UPDATE, os.str());
 }
 
-Message PlayerChatMessage(int sender, const std::string& data, int receiver) {
+Message PlayerChatMessage(const std::string& data, int receiver) {
     std::ostringstream os;
     {
         freeorion_xml_oarchive oa(os);
@@ -614,7 +614,7 @@ Message PlayerChatMessage(int sender, const std::string& data, int receiver) {
     return Message(Message::PLAYER_CHAT, os.str());
 }
 
-Message ServerPlayerChatMessage(int sender, int receiver, const std::string& data) {
+Message ServerPlayerChatMessage(int sender, const std::string& data) {
     std::ostringstream os;
     {
         freeorion_xml_oarchive oa(os);
@@ -624,7 +624,7 @@ Message ServerPlayerChatMessage(int sender, int receiver, const std::string& dat
     return Message(Message::PLAYER_CHAT, os.str());
 }
 
-Message StartMPGameMessage(int player_id)
+Message StartMPGameMessage()
 { return Message(Message::START_MP_GAME, DUMMY_EMPTY_MESSAGE); }
 
 

--- a/network/Message.h
+++ b/network/Message.h
@@ -47,7 +47,9 @@ namespace Moderator {
   * misbehave as well.) */
 class FO_COMMON_API Message {
 public:
-    typedef std::array<int, 3> HeaderBuffer;
+    enum Parts : size_t {TYPE = 0, RESPONSE, SIZE, Parts_Count};
+
+    typedef std::array<int, Parts::Parts_Count> HeaderBuffer;
 
     constexpr static size_t HeaderBufferSize =
         std::tuple_size<HeaderBuffer>::value * sizeof(HeaderBuffer::value_type);

--- a/network/Message.h
+++ b/network/Message.h
@@ -188,16 +188,16 @@ FO_COMMON_API Message JoinGameMessage(const std::string& player_name, Networking
 /** creates a HOST_ID message.  The player ID of the host is sent in the message. */
 FO_COMMON_API Message HostIDMessage(int host_player_id);
 
-/** creates a GAME_START message.  Contains the initial game state visible to player \a player_id.*/
-FO_COMMON_API Message GameStartMessage(int player_id, bool single_player_game, int empire_id, int current_turn,
+/** creates a GAME_START message.  Contains the initial game state visible to the player.*/
+FO_COMMON_API Message GameStartMessage(bool single_player_game, int empire_id, int current_turn,
                                        const EmpireManager& empires, const Universe& universe,
                                        const SpeciesManager& species, CombatLogManager& combat_logs,
                                        const SupplyManager& supply, const std::map<int, PlayerInfo>& players,
                                        const GalaxySetupData& galaxy_setup_data, bool use_binary_serialization);
 
 /** creates a GAME_START message.  Contains the initial game state visible to
-  * player \a player_id.  Also includes data loaded from a saved game. */
-FO_COMMON_API Message GameStartMessage(int player_id, bool single_player_game, int empire_id, int current_turn,
+  * the player.  Also includes data loaded from a saved game. */
+FO_COMMON_API Message GameStartMessage(bool single_player_game, int empire_id, int current_turn,
                                        const EmpireManager& empires, const Universe& universe,
                                        const SpeciesManager& species, CombatLogManager& combat_logs,
                                        const SupplyManager& supply,
@@ -206,8 +206,8 @@ FO_COMMON_API Message GameStartMessage(int player_id, bool single_player_game, i
                                        const GalaxySetupData& galaxy_setup_data, bool use_binary_serialization);
 
 /** creates a GAME_START message.  Contains the initial game state visible to
-  * player \a player_id.  Also includes state string loaded from a saved game. */
-FO_COMMON_API Message GameStartMessage(int player_id, bool single_player_game, int empire_id, int current_turn,
+  * the player.  Also includes state string loaded from a saved game. */
+FO_COMMON_API Message GameStartMessage(bool single_player_game, int empire_id, int current_turn,
                                        const EmpireManager& empires, const Universe& universe,
                                        const SpeciesManager& species, CombatLogManager& combat_logs,
                                        const SupplyManager& supply,

--- a/network/Message.h
+++ b/network/Message.h
@@ -230,58 +230,58 @@ FO_COMMON_API Message HostMPAckMessage(int player_id);
 FO_COMMON_API Message JoinAckMessage(int player_id);
 
 /** creates a TURN_ORDERS message. */
-FO_COMMON_API Message TurnOrdersMessage(int sender, const OrderSet& orders);
+FO_COMMON_API Message TurnOrdersMessage(const OrderSet& orders);
 
 /** creates a TURN_PROGRESS message. */
 FO_COMMON_API Message TurnProgressMessage(Message::TurnProgressPhase phase_id);
 
 /** creates a PLAYER_STATUS message. */
-FO_COMMON_API Message PlayerStatusMessage(int player_id, int about_player_id, Message::PlayerStatus player_status);
+FO_COMMON_API Message PlayerStatusMessage(int about_player_id, Message::PlayerStatus player_status);
 
 /** creates a TURN_UPDATE message. */
-FO_COMMON_API Message TurnUpdateMessage(int player_id, int empire_id, int current_turn,
+FO_COMMON_API Message TurnUpdateMessage(int empire_id, int current_turn,
                                         const EmpireManager& empires, const Universe& universe,
                                         const SpeciesManager& species, CombatLogManager& combat_logs,
                                         const SupplyManager& supply,
                                         const std::map<int, PlayerInfo>& players, bool use_binary_serialization);
 
 /** create a TURN_PARTIAL_UPDATE message. */
-FO_COMMON_API Message TurnPartialUpdateMessage(int player_id, int empire_id, const Universe& universe,
+FO_COMMON_API Message TurnPartialUpdateMessage(int empire_id, const Universe& universe,
                                                bool use_binary_serialization);
 
 /** creates a CLIENT_SAVE_DATA message, including UI data but without a state string. */
-FO_COMMON_API Message ClientSaveDataMessage(int sender, const OrderSet& orders, const SaveGameUIData& ui_data);
+FO_COMMON_API Message ClientSaveDataMessage(const OrderSet& orders, const SaveGameUIData& ui_data);
 
 /** creates a CLIENT_SAVE_DATA message, without UI data but with a state string. */
-FO_COMMON_API Message ClientSaveDataMessage(int sender, const OrderSet& orders, const std::string& save_state_string);
+FO_COMMON_API Message ClientSaveDataMessage(const OrderSet& orders, const std::string& save_state_string);
 
 /** creates a CLIENT_SAVE_DATA message, without UI data and without a state string. */
-Message ClientSaveDataMessage(int sender, const OrderSet& orders);
+FO_COMMON_API Message ClientSaveDataMessage(const OrderSet& orders);
 
 /** creates an REQUEST_NEW_OBJECT_ID message. This message is a synchronous
     message, when sent it will wait for a reply from the server */
-FO_COMMON_API Message RequestNewObjectIDMessage(int sender);
+FO_COMMON_API Message RequestNewObjectIDMessage();
 
 /** creates an DISPATCH_NEW_OBJECT_ID  message.  This message is sent to a
   * client who is waiting for a new object ID */
-FO_COMMON_API Message DispatchObjectIDMessage(int player_id, int new_id);
+FO_COMMON_API Message DispatchObjectIDMessage(int new_id);
 
 /** creates an REQUEST_NEW_DESIGN_ID message. This message is a synchronous
     message, when sent it will wait for a reply from the server */
-FO_COMMON_API Message RequestNewDesignIDMessage(int sender);
+FO_COMMON_API Message RequestNewDesignIDMessage();
 
 /** creates an DISPATCH_NEW_DESIGN_ID  message.  This message is sent to a
   * client who is waiting for a new design ID */
-FO_COMMON_API Message DispatchDesignIDMessage(int player_id, int new_id);
+FO_COMMON_API Message DispatchDesignIDMessage(int new_id);
 
 /** creates a SAVE_GAME_INITIATE request message.  This message should only be sent by
   * the host player.*/
-FO_COMMON_API Message HostSaveGameInitiateMessage(int sender, const std::string& filename);
+FO_COMMON_API Message HostSaveGameInitiateMessage(const std::string& filename);
 
 /** creates a SAVE_GAME_DATA_REQUEST data request message.  This message should
     only be sent by the server to get game data from a client, or to respond to
     the host player requesting a save be initiated. */
-FO_COMMON_API Message ServerSaveGameDataRequestMessage(int receiver, bool synchronous_response);
+FO_COMMON_API Message ServerSaveGameDataRequestMessage(bool synchronous_response);
 
 /** creates a SAVE_GAME_COMPLETE complete message.  This message should only be
     sent by the server to inform clients that the last initiated save has been
@@ -290,35 +290,35 @@ FO_COMMON_API Message ServerSaveGameCompleteMessage(const std::string& save_file
 
 /** creates a DIPLOMACY message, which is sent between players via the server to
   * declare, proposed, or accept / reject diplomatic arrangements or agreements. */
-FO_COMMON_API Message DiplomacyMessage(int sender, int receiver, const DiplomaticMessage& diplo_message);
+FO_COMMON_API Message DiplomacyMessage(const DiplomaticMessage& diplo_message);
 
 /** creates a DIPLOMATIC_STATUS message, which is sent to players by the server to
   * update them on diplomatic status changes between players. */
-FO_COMMON_API Message DiplomaticStatusMessage(int receiver, const DiplomaticStatusUpdateInfo& diplo_update);
+FO_COMMON_API Message DiplomaticStatusMessage(const DiplomaticStatusUpdateInfo& diplo_update);
 
 /** creates an END_GAME message used to terminate an active game. */
-FO_COMMON_API Message EndGameMessage(int receiver, Message::EndGameReason reason, const std::string& reason_player_name = "");
+FO_COMMON_API Message EndGameMessage(Message::EndGameReason reason, const std::string& reason_player_name = "");
 
 /** creates an AI_END_GAME_ACK message used to indicate that the AI has shutdown. */
 FO_COMMON_API Message AIEndGameAcknowledgeMessage();
 
 /** creates a MODERATOR_ACTION message used to implement moderator commands. */
-FO_COMMON_API Message ModeratorActionMessage(int sender, const Moderator::ModeratorAction& mod_action);
+FO_COMMON_API Message ModeratorActionMessage(const Moderator::ModeratorAction& mod_action);
 
 /** tells server to shut down. */
-FO_COMMON_API Message ShutdownServerMessage(int sender);
+FO_COMMON_API Message ShutdownServerMessage();
 
 /** requests previews of savefiles from server */
-FO_COMMON_API Message RequestSavePreviewsMessage(int sender, std::string directory);
+FO_COMMON_API Message RequestSavePreviewsMessage(std::string directory);
 
 /** returns the savegame previews to the client */
-FO_COMMON_API Message DispatchSavePreviewsMessage(int receiver, const PreviewInformation& preview);
+FO_COMMON_API Message DispatchSavePreviewsMessage(const PreviewInformation& preview);
 
 /** requests combat logs from server */
-FO_COMMON_API Message RequestCombatLogsMessage(int sender, const std::vector<int>& ids);
+FO_COMMON_API Message RequestCombatLogsMessage(const std::vector<int>& ids);
 
 /** returns combat logs to the client */
-FO_COMMON_API Message DispatchCombatLogsMessage(int receiver, const std::vector<std::pair<int, const CombatLog>>& logs);
+FO_COMMON_API Message DispatchCombatLogsMessage(const std::vector<std::pair<int, const CombatLog>>& logs);
 
 ////////////////////////////////////////////////
 // Multiplayer Lobby Message named ctors
@@ -327,22 +327,22 @@ FO_COMMON_API Message DispatchCombatLogsMessage(int receiver, const std::vector<
 /** creates an LOBBY_UPDATE message containing changes to the lobby settings that need to propogate to the
     server, then to other users.  Clients must send all such updates to the server directly; the server
     will send updates to the other clients as needed.*/
-FO_COMMON_API Message LobbyUpdateMessage(int sender, const MultiplayerLobbyData& lobby_data);
+FO_COMMON_API Message LobbyUpdateMessage(const MultiplayerLobbyData& lobby_data);
 
 /** creates an LOBBY_UPDATE message containing changes to the lobby settings that need to propogate to the users.
     This message should only be sent by the server.*/
-FO_COMMON_API Message ServerLobbyUpdateMessage(int receiver, const MultiplayerLobbyData& lobby_data);
+FO_COMMON_API Message ServerLobbyUpdateMessage(const MultiplayerLobbyData& lobby_data);
 
 /** creates an PLAYER_CHAT message containing a chat string to be broadcast to player \a receiver, or all players if \a
     receiver is Networking::INVALID_PLAYER_ID. Note that the receiver of this message is always the server.*/
-FO_COMMON_API Message PlayerChatMessage(int sender, const std::string& text, int receiver = Networking::INVALID_PLAYER_ID);
+FO_COMMON_API Message PlayerChatMessage(const std::string& text, int receiver = Networking::INVALID_PLAYER_ID);
 
-/** creates an PLAYER_CHAT message containing a chat string from \a sender to be displayed in \a receiver's lobby dialog.
+/** creates an PLAYER_CHAT message containing a chat string from \a sender to be displayed in chat.
     This message should only be sent by the server.*/
-FO_COMMON_API Message ServerPlayerChatMessage(int sender, int receiver, const std::string& text);
+FO_COMMON_API Message ServerPlayerChatMessage(int sender, const std::string& text);
 
 /** creates a START_MP_GAME used to finalize the multiplayer lobby setup.*/
-FO_COMMON_API Message StartMPGameMessage(int player_id);
+FO_COMMON_API Message StartMPGameMessage();
 
 
 ////////////////////////////////////////////////

--- a/network/ServerNetworking.cpp
+++ b/network/ServerNetworking.cpp
@@ -226,8 +226,8 @@ void PlayerConnection::HandleMessageBodyRead(boost::system::error_code error,
                           << "error #" << error.value() << " \"" << error.message() << "\"";
         }
     } else {
-        assert(static_cast<int>(bytes_transferred) <= m_incoming_header_buffer[2]);
-        if (static_cast<int>(bytes_transferred) == m_incoming_header_buffer[2]) {
+        assert(static_cast<int>(bytes_transferred) <= m_incoming_header_buffer[Message::Parts::SIZE]);
+        if (static_cast<int>(bytes_transferred) == m_incoming_header_buffer[Message::Parts::SIZE]) {
             if (TRACE_EXECUTION && m_incoming_message.Type() != Message::REQUEST_NEW_DESIGN_ID) {   // new design id messages ignored due to log spam
                 DebugLogger() << "Server received message from player id: " << m_ID
                               << " of type " << MessageTypeName(m_incoming_message.Type())
@@ -284,7 +284,7 @@ void PlayerConnection::HandleMessageHeaderRead(boost::system::error_code error,
         assert(bytes_transferred <= Message::HeaderBufferSize);
         if (bytes_transferred == Message::HeaderBufferSize) {
             BufferToHeader(m_incoming_header_buffer, m_incoming_message);
-            m_incoming_message.Resize(m_incoming_header_buffer[2]);
+            m_incoming_message.Resize(m_incoming_header_buffer[Message::Parts::SIZE]);
             boost::asio::async_read(
                 m_socket,
                 boost::asio::buffer(m_incoming_message.Data(), m_incoming_message.Size()),

--- a/network/ServerNetworking.cpp
+++ b/network/ServerNetworking.cpp
@@ -439,12 +439,6 @@ bool ServerNetworking::ModeratorsInGame() const {
     return false;
 }
 
-bool ServerNetworking::SendMessage(const Message& message,
-                                   PlayerConnectionPtr player_connection)
-{
-    return player_connection->SendMessage(message);
-}
-
 bool ServerNetworking::SendMessageAll(const Message& message) {
     bool success = true;
     for (ServerNetworking::const_established_iterator player_it = established_begin();

--- a/network/ServerNetworking.h
+++ b/network/ServerNetworking.h
@@ -92,7 +92,7 @@ public:
     bool SendMessage(const Message& message, PlayerConnectionPtr player_connection);
 
     /** Sends a synchronous message \a message to the player indicated in the message and returns true on success. */
-    bool SendMessage(const Message& message);
+    bool SendMessageAll(const Message& message);
 
     /** Disconnects the server from player \a id. */
     void Disconnect(int id);

--- a/network/ServerNetworking.h
+++ b/network/ServerNetworking.h
@@ -88,9 +88,6 @@ public:
     //@}
 
     /** \name Mutators */ //@{
-    /** Sends a synchronous message \a message to \a player_connection and returns true on success. */
-    bool SendMessage(const Message& message, PlayerConnectionPtr player_connection);
-
     /** Sends a synchronous message \a message to the player indicated in the message and returns true on success. */
     bool SendMessageAll(const Message& message);
 

--- a/server/SaveLoad.cpp
+++ b/server/SaveLoad.cpp
@@ -315,7 +315,7 @@ void LoadGame(const std::string& filename, ServerSaveGameData& server_save_game_
 
     // player notifications
     if (ServerApp* server = ServerApp::GetApp())
-        server->Networking().SendMessage(TurnProgressMessage(Message::LOADING_GAME));
+        server->Networking().SendMessageAll(TurnProgressMessage(Message::LOADING_GAME));
 
     GetUniverse().EncodingEmpire() = ALL_EMPIRES;
 

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -804,12 +804,12 @@ void ServerApp::SendNewGameStartMessages() {
         int player_id = player_connection->PlayerID();
         int empire_id = PlayerEmpireID(player_id);
         bool use_binary_serialization = player_connection->ClientVersionStringMatchesThisServer();
-        player_connection->SendMessage(GameStartMessage(player_id,              m_single_player_game,
-                                                        empire_id,              m_current_turn,
-                                                        m_empires,              m_universe,
-                                                        GetSpeciesManager(),    GetCombatLogManager(),
-                                                        GetSupplyManager(),     player_info_map,
-                                                        m_galaxy_setup_data,    use_binary_serialization));
+        player_connection->SendMessage(GameStartMessage(m_single_player_game,    empire_id,
+                                                        m_current_turn,          m_empires,
+                                                        m_universe,              GetSpeciesManager(),
+                                                        GetCombatLogManager(),   GetSupplyManager(),
+                                                        player_info_map,         m_galaxy_setup_data,
+                                                        use_binary_serialization));
     }
 }
 
@@ -1242,14 +1242,14 @@ void ServerApp::LoadGameInit(const std::vector<PlayerSaveGameData>& player_save_
             if (!psgd.m_save_state_string.empty())
                 sss = &psgd.m_save_state_string;
 
-            player_connection->SendMessage(GameStartMessage(player_id, m_single_player_game, empire_id,
+            player_connection->SendMessage(GameStartMessage(m_single_player_game, empire_id,
                                                             m_current_turn, m_empires, m_universe,
                                                             GetSpeciesManager(), GetCombatLogManager(),
                                                             GetSupplyManager(), player_info_map, *orders, sss,
                                                             m_galaxy_setup_data, use_binary_serialization));
 
         } else if (client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER) {
-            player_connection->SendMessage(GameStartMessage(player_id, m_single_player_game, empire_id,
+            player_connection->SendMessage(GameStartMessage(m_single_player_game, empire_id,
                                                             m_current_turn, m_empires, m_universe,
                                                             GetSpeciesManager(), GetCombatLogManager(),
                                                             GetSupplyManager(),  player_info_map, *orders,
@@ -1260,7 +1260,7 @@ void ServerApp::LoadGameInit(const std::vector<PlayerSaveGameData>& player_save_
                    client_type == Networking::CLIENT_TYPE_HUMAN_MODERATOR)
         {
 
-            player_connection->SendMessage(GameStartMessage(player_id, m_single_player_game, ALL_EMPIRES,
+            player_connection->SendMessage(GameStartMessage(m_single_player_game, ALL_EMPIRES,
                                                             m_current_turn, m_empires, m_universe,
                                                             GetSpeciesManager(), GetCombatLogManager(),
                                                             GetSupplyManager(), player_info_map,

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -202,7 +202,7 @@ void ServerApp::CreateAIClients(const std::vector<PlayerSetupData>& player_setup
         }
     }
     if (need_AIs)
-        m_networking.SendMessage(TurnProgressMessage(Message::STARTING_AIS));
+        m_networking.SendMessageAll(TurnProgressMessage(Message::STARTING_AIS));
 
 
     // disconnect any old AI clients
@@ -397,12 +397,6 @@ void ServerApp::SetAIsProcessPriorityToLow(bool set_to_low) {
 }
 
 void ServerApp::HandleMessage(const Message& msg, PlayerConnectionPtr player_connection) {
-    if (msg.SendingPlayer() != player_connection->PlayerID()) {
-        ErrorLogger() << "ServerApp::HandleMessage : Received an message with a sender ID ("
-                      << msg.SendingPlayer() << ") that differs from the sending player connection ID: "
-                      << player_connection->PlayerID() << ".  Ignoring.";
-        return;
-    }
 
     //DebugLogger() << "ServerApp::HandleMessage type " << boost::lexical_cast<std::string>(msg.Type());
 
@@ -410,7 +404,6 @@ void ServerApp::HandleMessage(const Message& msg, PlayerConnectionPtr player_con
     case Message::HOST_SP_GAME:             m_fsm->process_event(HostSPGame(msg, player_connection));       break;
     case Message::START_MP_GAME:            m_fsm->process_event(StartMPGame(msg, player_connection));      break;
     case Message::LOBBY_UPDATE:             m_fsm->process_event(LobbyUpdate(msg, player_connection));      break;
-    case Message::LOBBY_CHAT:               m_fsm->process_event(LobbyChat(msg, player_connection));        break;
     case Message::SAVE_GAME_INITIATE:       m_fsm->process_event(SaveGameRequest(msg, player_connection));  break;
     case Message::TURN_ORDERS:              m_fsm->process_event(TurnOrders(msg, player_connection));       break;
     case Message::CLIENT_SAVE_DATA:         m_fsm->process_event(ClientSaveData(msg, player_connection));   break;
@@ -499,7 +492,7 @@ void ServerApp::SelectNewHost() {
     if (new_host_id == Networking::INVALID_PLAYER_ID) {
         // couldn't find a host... abort
         DebugLogger() << "ServerApp::SelectNewHost : Host disconnected and couldn't find a replacement.";
-        m_networking.SendMessage(ErrorMessage(UserStringNop("SERVER_UNABLE_TO_SELECT_HOST"), false));
+        m_networking.SendMessageAll(ErrorMessage(UserStringNop("SERVER_UNABLE_TO_SELECT_HOST"), false));
     }
 
     // set new host ID
@@ -628,7 +621,7 @@ void ServerApp::NewGameInitConcurrentWithJoiners(
 
     if (active_players_id_setup_data.empty()) {
         ErrorLogger() << "ServerApp::NewGameInitConcurrentWithJoiners found no active players!";
-        m_networking.SendMessage(ErrorMessage(UserStringNop("SERVER_FOUND_NO_ACTIVE_PLAYERS"), true));
+        m_networking.SendMessageAll(ErrorMessage(UserStringNop("SERVER_FOUND_NO_ACTIVE_PLAYERS"), true));
         return;
     }
 
@@ -642,7 +635,7 @@ void ServerApp::NewGameInitConcurrentWithJoiners(
 
     // create universe and empires for players
     DebugLogger() << "ServerApp::NewGameInitConcurrentWithJoiners: Creating Universe";
-    m_networking.SendMessage(TurnProgressMessage(Message::GENERATING_UNIVERSE));
+    m_networking.SendMessageAll(TurnProgressMessage(Message::GENERATING_UNIVERSE));
 
 
     // m_current_turn set above so that every UniverseObject created before game
@@ -736,7 +729,7 @@ bool ServerApp::NewGameInitVerifyJoiners(
     // ensure some reasonable inputs
     if (player_id_setup_data.empty()) {
         ErrorLogger() << "ServerApp::NewGameInitVerifyJoiners passed empty player_id_setup_data.  Aborting";
-        m_networking.SendMessage(ErrorMessage(UserStringNop("SERVER_FOUND_NO_ACTIVE_PLAYERS"), true));
+        m_networking.SendMessageAll(ErrorMessage(UserStringNop("SERVER_FOUND_NO_ACTIVE_PLAYERS"), true));
         return false;
     }
 
@@ -1090,7 +1083,7 @@ void ServerApp::LoadGameInit(const std::vector<PlayerSaveGameData>& player_save_
     // ensure some reasonable inputs
     if (player_save_game_data.empty()) {
         ErrorLogger() << "ServerApp::LoadGameInit passed empty player save game data.  Aborting";
-        m_networking.SendMessage(ErrorMessage(UserStringNop("SERVER_FOUND_NO_ACTIVE_PLAYERS"), true));
+        m_networking.SendMessageAll(ErrorMessage(UserStringNop("SERVER_FOUND_NO_ACTIVE_PLAYERS"), true));
         return;
     }
 
@@ -1331,7 +1324,7 @@ void ServerApp::GenerateUniverse(std::map<int, PlayerSetupData>& player_setup_da
     }
 
     if (!success)
-        ServerApp::GetApp()->Networking().SendMessage(ErrorMessage(UserStringNop("SERVER_UNIVERSE_GENERATION_ERRORS"), false));
+        ServerApp::GetApp()->Networking().SendMessageAll(ErrorMessage(UserStringNop("SERVER_UNIVERSE_GENERATION_ERRORS"), false));
 
 
     DebugLogger() << "Applying first turn effects and updating meters";
@@ -1386,7 +1379,7 @@ void ServerApp::ExecuteScriptedTurnEvents() {
 
     if (!success) {
         ErrorLogger() << "Python scripted turn events failed.";
-        ServerApp::GetApp()->Networking().SendMessage(ErrorMessage(UserStringNop("SERVER_TURN_EVENTS_ERRORS"), false));
+        ServerApp::GetApp()->Networking().SendMessageAll(ErrorMessage(UserStringNop("SERVER_TURN_EVENTS_ERRORS"), false));
     }
 }
 
@@ -2672,7 +2665,7 @@ void ServerApp::PreCombatProcessTurns() {
     DebugLogger() << "ServerApp::ProcessTurns executing orders";
 
     // inform players of order execution
-    m_networking.SendMessage(TurnProgressMessage(Message::PROCESSING_ORDERS));
+    m_networking.SendMessageAll(TurnProgressMessage(Message::PROCESSING_ORDERS));
 
     // clear bombardment state before executing orders, so result after is only
     // determined by what orders set.
@@ -2706,7 +2699,7 @@ void ServerApp::PreCombatProcessTurns() {
     }
 
     // player notifications
-    m_networking.SendMessage(TurnProgressMessage(Message::COLONIZE_AND_SCRAP));
+    m_networking.SendMessageAll(TurnProgressMessage(Message::COLONIZE_AND_SCRAP));
 
     DebugLogger() << "ServerApp::ProcessTurns colonization";
     HandleColonization();
@@ -2725,7 +2718,7 @@ void ServerApp::PreCombatProcessTurns() {
     // process movement phase
 
     // player notifications
-    m_networking.SendMessage(TurnProgressMessage(Message::FLEET_MOVEMENT));
+    m_networking.SendMessageAll(TurnProgressMessage(Message::FLEET_MOVEMENT));
 
 
     // fleet movement
@@ -2759,7 +2752,7 @@ void ServerApp::PreCombatProcessTurns() {
     }
 
     // indicate that the clients are waiting for their new Universes
-    m_networking.SendMessage(TurnProgressMessage(Message::DOWNLOADING));
+    m_networking.SendMessageAll(TurnProgressMessage(Message::DOWNLOADING));
 
     // send partial turn updates to all players after orders and movement
     for (ServerNetworking::const_established_iterator player_it = m_networking.established_begin();
@@ -2776,7 +2769,7 @@ void ServerApp::PreCombatProcessTurns() {
 void ServerApp::ProcessCombats() {
     ScopedTimer timer("ServerApp::ProcessCombats", true);
     DebugLogger() << "ServerApp::ProcessCombats";
-    m_networking.SendMessage(TurnProgressMessage(Message::COMBAT));
+    m_networking.SendMessageAll(TurnProgressMessage(Message::COMBAT));
 
     std::set<int> human_controlled_empire_ids = HumanControlledEmpires(this, m_networking);
     std::vector<CombatInfo> combats;   // map from system ID to CombatInfo for that system
@@ -2909,7 +2902,7 @@ void ServerApp::PostCombatProcessTurns() {
     // process production and growth phase
 
     // notify players that production and growth is being processed
-    m_networking.SendMessage(TurnProgressMessage(Message::EMPIRE_PRODUCTION));
+    m_networking.SendMessageAll(TurnProgressMessage(Message::EMPIRE_PRODUCTION));
     DebugLogger() << "ServerApp::PostCombatProcessTurns effects and meter updates";
 
 
@@ -3081,7 +3074,7 @@ void ServerApp::PostCombatProcessTurns() {
 
 
     // indicate that the clients are waiting for their new gamestate
-    m_networking.SendMessage(TurnProgressMessage(Message::DOWNLOADING));
+    m_networking.SendMessageAll(TurnProgressMessage(Message::DOWNLOADING));
 
 
     // compile map of PlayerInfo, indexed by player ID

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -1872,7 +1872,6 @@ ShuttingDownServer::~ShuttingDownServer()
 
 sc::result ShuttingDownServer::react(const LeaveGame& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(ServerFSM) ShuttingDownServer.LeaveGame";
-    const Message& message = msg.m_message;
     const PlayerConnectionPtr& player_connection = msg.m_player_connection;
     int player_id = player_connection->PlayerID();
 

--- a/server/ServerFSM.h
+++ b/server/ServerFSM.h
@@ -62,7 +62,6 @@ struct MessageEventBase {
     (HostSPGame)                            \
     (StartMPGame)                           \
     (LobbyUpdate)                           \
-    (LobbyChat)                             \
     (JoinGame)                              \
     (LeaveGame)                             \
     (SaveGameRequest)                       \
@@ -157,7 +156,7 @@ struct MPLobby : sc::state<MPLobby, ServerFSM> {
         sc::custom_reaction<Disconnection>,
         sc::custom_reaction<JoinGame>,
         sc::custom_reaction<LobbyUpdate>,
-        sc::custom_reaction<LobbyChat>,
+        sc::custom_reaction<PlayerChat>,
         sc::custom_reaction<StartMPGame>,
         sc::custom_reaction<HostMPGame>,
         sc::custom_reaction<HostSPGame>,
@@ -171,7 +170,7 @@ struct MPLobby : sc::state<MPLobby, ServerFSM> {
     sc::result react(const Disconnection& d);
     sc::result react(const JoinGame& msg);
     sc::result react(const LobbyUpdate& msg);
-    sc::result react(const LobbyChat& msg);
+    sc::result react(const PlayerChat& msg);
     sc::result react(const StartMPGame& msg);
     sc::result react(const HostMPGame& msg);
     sc::result react(const HostSPGame& msg);


### PR DESCRIPTION
1. Remove sender_id and receiver_id from header because we know this data in most cases from player connection.
2. Merge PLAYER_CHAT and LOBBY_CHAT messages.
3. Send broadcast Message by ServerNetworking::SendMessageAll and other
Message by PlayerConnection::SendMessage.
4. Add player_id into Message body where it was used in header.