### PR TITLE
Improve server startup sequencing.

### DIFF
--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -149,11 +149,6 @@ ServerApp::ServerApp() :
     GG::Connect(Empires().DiplomaticStatusChangedSignal,  &ServerApp::HandleDiplomaticStatusChange, this);
     GG::Connect(Empires().DiplomaticMessageChangedSignal, &ServerApp::HandleDiplomaticMessageChange,this);
 
-    if (!m_python_server.Initialize()) {
-        ErrorLogger() << "Server's python interpreter failed to initialize.";
-        Exit(0);
-    }
-
     m_signals.async_wait(boost::bind(&ServerApp::SignalHandler, this, _1, _2));
 }
 
@@ -333,6 +328,17 @@ void ServerApp::Run() {
         }
     } catch (const NormalExitException&)
     {}
+}
+
+void ServerApp::InitializePython() {
+    if (m_python_server.IsPythonRunning())
+        return;
+
+    if (!m_python_server.Initialize()) {
+        ErrorLogger() << "Server's python interpreter failed to initialize.";
+        // TODO go to Shutdown in FSM.
+        Exit(0);
+    }
 }
 
 void ServerApp::CleanupAIs() {

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -232,9 +232,9 @@ void ServerApp::CreateAIClients(const std::vector<PlayerSetupData>& player_setup
     args.push_back("\"" + AI_CLIENT_EXE + "\"");
     args.push_back("place_holder");
     size_t player_pos = args.size()-1;
-    std::stringstream maxAggrStr;
-    maxAggrStr << max_aggression;
-    args.push_back(maxAggrStr.str());
+    std::stringstream max_aggr_str;
+    max_aggr_str << max_aggression;
+    args.push_back(max_aggr_str.str());
     args.push_back("--resource-dir");
     args.push_back("\"" + GetOptionsDB().Get<std::string>("resource-dir") + "\"");
     args.push_back("--log-level");
@@ -597,8 +597,10 @@ void ServerApp::NewMPGameInit(const MultiplayerLobbyData& multiplayer_lobby_data
         SendNewGameStartMessages();
 }
 
-void ServerApp::NewGameInitConcurrentWithJoiners(const GalaxySetupData& galaxy_setup_data,
-                            const std::vector<PlayerSetupData>& player_setup_data) {
+void ServerApp::NewGameInitConcurrentWithJoiners(
+    const GalaxySetupData& galaxy_setup_data,
+    const std::vector<PlayerSetupData>& player_setup_data)
+{
     DebugLogger() << "ServerApp::NewGameInitConcurrentWithJoiners";
 
     m_galaxy_setup_data = galaxy_setup_data;
@@ -710,7 +712,7 @@ bool ServerApp::NewGameInitVerifyJoiners(
 
     std::map<int, PlayerSetupData> player_id_setup_data;
 
-    bool host_is_human(false);
+    bool host_is_human{false};
     for (const auto& psd : player_setup_data) {
         if (psd.m_client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER) {
             player_id_setup_data[psd.m_player_id] = psd;
@@ -735,7 +737,8 @@ bool ServerApp::NewGameInitVerifyJoiners(
         return false;
     }
 
-    if (player_id_setup_data[m_networking.HostPlayerID()].m_client_type != Networking::CLIENT_TYPE_HUMAN_PLAYER)
+    if (player_id_setup_data[m_networking.HostPlayerID()].m_client_type
+        != Networking::CLIENT_TYPE_HUMAN_PLAYER)
     {
         ErrorLogger() << "NewGameInitVerifyJoiners : Host player with id "
                       << m_networking.HostPlayerID() << " is not human.";

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -587,11 +587,9 @@ void ServerApp::NewMPGameInit(const MultiplayerLobbyData& multiplayer_lobby_data
     }
 
     std::vector<PlayerSetupData> psds;
-    for (std::map<int, PlayerSetupData>::iterator it = player_id_setup_data.begin();
-         it!= player_id_setup_data.end(); ++it)
-    {
-        it->second.m_player_id = it->first;
-        psds.push_back(it->second);
+    for (auto& id_and_psd : player_id_setup_data) {
+        id_and_psd.second.m_player_id = id_and_psd.first;
+        psds.push_back(id_and_psd.second);
     }
 
     NewGameInitConcurrentWithJoiners(multiplayer_lobby_data, psds);
@@ -606,10 +604,7 @@ void ServerApp::NewGameInitConcurrentWithJoiners(const GalaxySetupData& galaxy_s
 
     // validate some connection info / determine which players need empires created
     std::map<int, PlayerSetupData> active_players_id_setup_data;
-    for (std::vector<PlayerSetupData>::const_iterator player_setup_data_it = player_setup_data.begin();
-         player_setup_data_it != player_setup_data.end(); ++player_setup_data_it) {
-        const PlayerSetupData& psd = *player_setup_data_it;
-
+    for (const auto& psd : player_setup_data) {
         if (!psd.m_player_name.empty()
             && (psd.m_client_type == Networking::CLIENT_TYPE_AI_PLAYER
                 || psd.m_client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER))
@@ -712,10 +707,8 @@ void ServerApp::NewGameInitVerifyJoiners(const GalaxySetupData& galaxy_setup_dat
 
     std::map<int, PlayerSetupData> player_id_setup_data;
 
-    for (std::vector<PlayerSetupData>::const_iterator setup_data_it = player_setup_data.begin();
-         setup_data_it != player_setup_data.end(); ++setup_data_it)
-    {
-        const PlayerSetupData& psd = *setup_data_it;
+    bool host_is_human(false);
+    for (const auto& psd : player_setup_data) {
         if (psd.m_client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER) {
             // In a single player game, the host player is always the human player, so
             // this is just a matter of finding which player setup data is for

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -231,6 +231,33 @@ void ServerApp::CreateAIClients(const std::vector<PlayerSetupData>& player_setup
     // binary / executable to run for AI clients
     const std::string AI_CLIENT_EXE = AIClientExe();
 
+
+    // TODO: add other command line args to AI client invocation as needed
+    std::vector<std::string> args, arg;
+    args.push_back("\"" + AI_CLIENT_EXE + "\"");
+    args.push_back("place_holder");
+    size_t player_pos = args.size()-1;
+    std::stringstream maxAggrStr;
+    maxAggrStr << max_aggression;
+    args.push_back(maxAggrStr.str());
+    args.push_back("--resource-dir");
+    args.push_back("\"" + GetOptionsDB().Get<std::string>("resource-dir") + "\"");
+    args.push_back("--log-level");
+    args.push_back(GetOptionsDB().Get<std::string>("log-level"));
+    args.push_back("--ai-path");
+    args.push_back(GetOptionsDB().Get<std::string>("ai-path"));
+    DebugLogger() << "starting AIs with " << AI_CLIENT_EXE ;
+    DebugLogger() << "ai-aggression set to " << max_aggression;
+    DebugLogger() << "ai-path set to '" << GetOptionsDB().Get<std::string>("ai-path") << "'";
+    std::string ai_config = GetOptionsDB().Get<std::string>("ai-config");
+    if (!ai_config.empty()) {
+        args.push_back("--ai-config");
+        args.push_back(ai_config);
+        DebugLogger() << "ai-config set to '" << ai_config << "'";
+    } else {
+        DebugLogger() << "ai-config not set.";
+    }
+
     // for each AI client player, create a new AI client process
     for (const PlayerSetupData& psd : player_setup_data) {
         if (psd.m_client_type != Networking::CLIENT_TYPE_AI_PLAYER)
@@ -243,33 +270,10 @@ void ServerApp::CreateAIClients(const std::vector<PlayerSetupData>& player_setup
             return;
         }
 
-        std::string ai_config = GetOptionsDB().Get<std::string>("ai-config");
-        // TODO: add other command line args to AI client invocation as needed
-        std::vector<std::string> args;
-        args.push_back("\"" + AI_CLIENT_EXE + "\"");
-        args.push_back(player_name);
-        std::stringstream maxAggrStr;
-        maxAggrStr << max_aggression;
-        args.push_back(maxAggrStr.str());
-        args.push_back("--resource-dir");
-        args.push_back("\"" + GetOptionsDB().Get<std::string>("resource-dir") + "\"");
-        args.push_back("--log-level");
-        args.push_back(GetOptionsDB().Get<std::string>("log-level"));
-        args.push_back("--ai-path");
-        args.push_back(GetOptionsDB().Get<std::string>("ai-path"));
-        DebugLogger() << "starting " << AI_CLIENT_EXE << " with GameSetup.ai-aggression set to " << max_aggression;
-        DebugLogger() << "ai-path set to '" << GetOptionsDB().Get<std::string>("ai-path") << "'";
-        if (!ai_config.empty()) {
-            args.push_back("--ai-config");
-            args.push_back(ai_config);
-            DebugLogger() << "ai-config set to '" << ai_config << "'";
-        } else {
-            DebugLogger() << "ai-config not set.";
-        }
-
+        args[player_pos] = player_name;
         m_ai_client_processes.push_back(Process(AI_CLIENT_EXE, args));
 
-        DebugLogger() << "done starting " << AI_CLIENT_EXE;
+        DebugLogger() << "done starting AI " << player_name;
     }
 
     // set initial AI process priority to low

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -231,13 +231,13 @@ private:
       * empires to turn processing list, does start-of-turn empire supply and
       * resource pool determination. */
     void    NewGameInitConcurrentWithJoiners(const GalaxySetupData& galaxy_setup_data,
-                                             const std::map<int, PlayerSetupData>& player_id_setup_data);
+                                             const std::vector<PlayerSetupData>& player_setup_data);
 
     /** Compiles and sends out basic
       * information about players in game to all other players as part of the
       * game start messages sent to players. */
     void    NewGameInitVerifyJoiners(const GalaxySetupData& galaxy_setup_data,
-                                     const std::map<int, PlayerSetupData>& player_id_setup_data);
+                                     const std::vector<PlayerSetupData>& player_setup_data);
 
     /** Clears any old game stored orders, victors or eliminated players, ads
       * empires to turn processing list, does start-of-turn empire supply and

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -223,6 +223,9 @@ private:
 
     void    Run();          ///< initializes app state, then executes main event handler/render loop (Poll())
 
+    /** Initialize the python engine or exit. */
+    void InitializePython();
+
     /** Called when server process receive termination signal */
     void    SignalHandler(const boost::system::error_code& error, int signal_number);
 

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -186,9 +186,13 @@ public:
       * are thereby victorious. */
     void    CheckForEmpireElimination();
 
-    /** Intializes single player game universe, sends out initial game state to
-      * clients, and signals clients to start first turn */
+    /** Intializes single player game universe.*/
     void    NewSPGameInit(const SinglePlayerSetupData& single_player_setup_data);
+
+    /** Verifies single player game AIs are compatible with already
+      * created universe. Sends out initial game state to
+      * clients, and signals clients to start first turn */
+    void    VerifySPGameAIs(const SinglePlayerSetupData& single_player_setup_data);
 
     /** Intializes multi player game universe, sends out initial game state to
       * clients, and signals clients to start first turn */
@@ -225,11 +229,15 @@ private:
 
     /** Clears any old game stored orders, victors or eliminated players, ads
       * empires to turn processing list, does start-of-turn empire supply and
-      * resource pool determination, and compiles and sends out basic
-      * information about players in game for all other players as part of the
+      * resource pool determination. */
+    void    NewGameInitConcurrentWithJoiners(const GalaxySetupData& galaxy_setup_data,
+                                             const std::map<int, PlayerSetupData>& player_id_setup_data);
+
+    /** Compiles and sends out basic
+      * information about players in game to all other players as part of the
       * game start messages sent to players. */
-    void    NewGameInit(const GalaxySetupData& galaxy_setup_data,
-                        const std::map<int, PlayerSetupData>& player_id_setup_data);
+    void    NewGameInitVerifyJoiners(const GalaxySetupData& galaxy_setup_data,
+                                     const std::map<int, PlayerSetupData>& player_id_setup_data);
 
     /** Clears any old game stored orders, victors or eliminated players, ads
       * empires to turn processing list, does start-of-turn empire supply and

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -189,10 +189,9 @@ public:
     /** Intializes single player game universe.*/
     void    NewSPGameInit(const SinglePlayerSetupData& single_player_setup_data);
 
-    /** Verifies single player game AIs are compatible with already
-      * created universe. Sends out initial game state to
-      * clients, and signals clients to start first turn */
-    void    VerifySPGameAIs(const SinglePlayerSetupData& single_player_setup_data);
+    /** Return true if single player game AIs are compatible with created
+      * universe and are ready to start a new game. */
+    bool    VerifySPGameAIs(const SinglePlayerSetupData& single_player_setup_data);
 
     /** Intializes multi player game universe, sends out initial game state to
       * clients, and signals clients to start first turn */
@@ -236,11 +235,12 @@ private:
     void    NewGameInitConcurrentWithJoiners(const GalaxySetupData& galaxy_setup_data,
                                              const std::vector<PlayerSetupData>& player_setup_data);
 
-    /** Compiles and sends out basic
-      * information about players in game to all other players as part of the
-      * game start messages sent to players. */
-    void    NewGameInitVerifyJoiners(const GalaxySetupData& galaxy_setup_data,
+    /** Return true if player data is consistent with starting a new game. */
+    bool    NewGameInitVerifyJoiners(const GalaxySetupData& galaxy_setup_data,
                                      const std::vector<PlayerSetupData>& player_setup_data);
+
+    /** Sends out initial new game state to clients, and signals clients to start first turn. */
+    void SendNewGameStartMessages();
 
     /** Clears any old game stored orders, victors or eliminated players, ads
       * empires to turn processing list, does start-of-turn empire supply and

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -1206,7 +1206,9 @@ sc::result WaitingForSPGameJoiners::react(const CheckStartConditions& u) {
         DebugLogger() << "WaitingForSPGameJoiners::react(const CheckStartConditions& u) : have all " << m_num_expected_players << " expected players connected.";
         if (m_single_player_setup_data->m_new_game) {
             DebugLogger() << "Verify AIs SP game...";
-            server.VerifySPGameAIs(*m_single_player_setup_data);
+            if (server.VerifySPGameAIs(*m_single_player_setup_data))
+                server. SendNewGameStartMessages();
+
         } else {
             DebugLogger() << "Loading SP game save file: " << m_single_player_setup_data->m_filename;
             try {

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -1053,27 +1053,26 @@ WaitingForSPGameJoiners::WaitingForSPGameJoiners(my_context c) :
         // for new games, single player setup data contains full m_players
         // vector, so can just use the contents of that to create AI
         // clients
-        for (std::vector<PlayerSetupData>::iterator psd_it = players.begin(); psd_it != players.end(); ++psd_it) {
-            if (psd_it->m_player_name.empty()) {
-                if (psd_it->m_client_type == Networking::CLIENT_TYPE_AI_PLAYER)
-                    psd_it->m_player_name = "AI_" + boost::lexical_cast<std::string>(player_num++);
-                else if (psd_it->m_client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER)
-                    psd_it->m_player_name = "Human_Player_" + boost::lexical_cast<std::string>(player_num++);
-                else if (psd_it->m_client_type == Networking::CLIENT_TYPE_HUMAN_OBSERVER)
-                    psd_it->m_player_name = "Observer_" + boost::lexical_cast<std::string>(player_num++);
-                else if (psd_it->m_client_type == Networking::CLIENT_TYPE_HUMAN_MODERATOR)
-                    psd_it->m_player_name = "Moderator_" + boost::lexical_cast<std::string>(player_num++);
+        for (auto& psd : players) {
+            if (psd.m_player_name.empty()) {
+                if (psd.m_client_type == Networking::CLIENT_TYPE_AI_PLAYER)
+                    psd.m_player_name = "AI_" + boost::lexical_cast<std::string>(player_num++);
+                else if (psd.m_client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER)
+                    psd.m_player_name = "Human_Player_" + boost::lexical_cast<std::string>(player_num++);
+                else if (psd.m_client_type == Networking::CLIENT_TYPE_HUMAN_OBSERVER)
+                    psd.m_player_name = "Observer_" + boost::lexical_cast<std::string>(player_num++);
+                else if (psd.m_client_type == Networking::CLIENT_TYPE_HUMAN_MODERATOR)
+                    psd.m_player_name = "Moderator_" + boost::lexical_cast<std::string>(player_num++);
                 else
-                    psd_it->m_player_name = "Player_" + boost::lexical_cast<std::string>(player_num++);
+                    psd.m_player_name = "Player_" + boost::lexical_cast<std::string>(player_num++);
             }
 
-            if (psd_it->m_client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER) {
-                psd_it->m_player_id = server.Networking().HostPlayerID();
+            if (psd.m_client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER) {
+                psd.m_player_id = server.Networking().HostPlayerID();
             } else {
-                psd_it->m_player_id = player_id++;
+                psd.m_player_id = player_id++;
             }
         }
-
 
     } else {
         // for loaded games, all that is specified is the filename, and the
@@ -1156,7 +1155,7 @@ sc::result WaitingForSPGameJoiners::react(const JoinGame& msg) {
 
     // is this an AI?
     if (client_type == Networking::CLIENT_TYPE_AI_PLAYER) {
-        std::map<std::string, int>::const_iterator expected_it = m_expected_ai_player_ids.find(player_name);
+        const auto& expected_it = m_expected_ai_player_ids.find(player_name);
         // verify that player name was expected
         if (expected_it == m_expected_ai_player_ids.end()) {
             // unexpected ai player

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -1126,6 +1126,8 @@ WaitingForSPGameJoiners::WaitingForSPGameJoiners(my_context c) :
 
     server.CreateAIClients(players, m_single_player_setup_data->m_ai_aggr);    // also disconnects any currently-connected AI clients
 
+    server.InitializePython();
+
     if (m_single_player_setup_data->m_new_game) {
         // For SP game start inializaing while waiting for AI callbacks.
         DebugLogger() << "Initializing new SP game...";
@@ -1264,6 +1266,8 @@ WaitingForMPGameJoiners::WaitingForMPGameJoiners(my_context c) :
     }
 
     server.CreateAIClients(player_setup_data, m_lobby_data->m_ai_aggr);
+
+    server.InitializePython();
 
     // force immediate check if all expected AIs are present, so that the FSM
     // won't get stuck in this state waiting for JoinGame messages that will

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -1047,27 +1047,33 @@ WaitingForSPGameJoiners::WaitingForSPGameJoiners(my_context c) :
 
     // Ensure all players have unique non-empty names   // TODO: the uniqueness part...
     unsigned int player_num = 1;
-    for (PlayerSetupData& psd : players) {
-        if (psd.m_player_name.empty()) {
-            if (psd.m_client_type == Networking::CLIENT_TYPE_AI_PLAYER)
-                psd.m_player_name = "AI_" + std::to_string(player_num++);
-            else if (psd.m_client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER)
-                psd.m_player_name = "Human_Player_" + std::to_string(player_num++);
-            else if (psd.m_client_type == Networking::CLIENT_TYPE_HUMAN_OBSERVER)
-                psd.m_player_name = "Observer_" + std::to_string(player_num++);
-            else if (psd.m_client_type == Networking::CLIENT_TYPE_HUMAN_MODERATOR)
-                psd.m_player_name = "Moderator_" + std::to_string(player_num++);
-            else
-                psd.m_player_name = "Player_" + std::to_string(player_num++);
-        }
-    }
+    int player_id = server.m_networking.NewPlayerID();
 
     if (m_single_player_setup_data->m_new_game) {
-        // DO NOTHING
-
         // for new games, single player setup data contains full m_players
         // vector, so can just use the contents of that to create AI
         // clients
+        for (std::vector<PlayerSetupData>::iterator psd_it = players.begin(); psd_it != players.end(); ++psd_it) {
+            if (psd_it->m_player_name.empty()) {
+                if (psd_it->m_client_type == Networking::CLIENT_TYPE_AI_PLAYER)
+                    psd_it->m_player_name = "AI_" + boost::lexical_cast<std::string>(player_num++);
+                else if (psd_it->m_client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER)
+                    psd_it->m_player_name = "Human_Player_" + boost::lexical_cast<std::string>(player_num++);
+                else if (psd_it->m_client_type == Networking::CLIENT_TYPE_HUMAN_OBSERVER)
+                    psd_it->m_player_name = "Observer_" + boost::lexical_cast<std::string>(player_num++);
+                else if (psd_it->m_client_type == Networking::CLIENT_TYPE_HUMAN_MODERATOR)
+                    psd_it->m_player_name = "Moderator_" + boost::lexical_cast<std::string>(player_num++);
+                else
+                    psd_it->m_player_name = "Player_" + boost::lexical_cast<std::string>(player_num++);
+            }
+
+            if (psd_it->m_client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER) {
+                psd_it->m_player_id = server.Networking().HostPlayerID();
+            } else {
+                psd_it->m_player_id = player_id++;
+            }
+        }
+
 
     } else {
         // for loaded games, all that is specified is the filename, and the
@@ -1099,18 +1105,32 @@ WaitingForSPGameJoiners::WaitingForSPGameJoiners(my_context c) :
                 //psd.m_starting_species_name // left default
                 psd.m_save_game_empire_id = psgd.m_empire_id;
                 psd.m_client_type =         psgd.m_client_type;
+
+                if (psd.m_client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER) {
+                    psd.m_player_id = server.Networking().HostPlayerID();
+                } else {
+                    psd.m_player_id = player_id++;
+                }
+
                 players.push_back(psd);
             }
         }
     }
 
     m_num_expected_players = players.size();
-    m_expected_ai_player_names.clear();
-    for (const PlayerSetupData& psd : players)
-        if (psd.m_client_type == Networking::CLIENT_TYPE_AI_PLAYER)
-            m_expected_ai_player_names.insert(psd.m_player_name);
+    m_expected_ai_player_ids.clear();
+    for (const auto& player_data : players) {
+        if (player_data.m_client_type == Networking::CLIENT_TYPE_AI_PLAYER)
+            m_expected_ai_player_ids.insert(std::make_pair(player_data.m_player_name, player_data.m_player_id));
+    }
 
     server.CreateAIClients(players, m_single_player_setup_data->m_ai_aggr);    // also disconnects any currently-connected AI clients
+
+    if (m_single_player_setup_data->m_new_game) {
+        // For SP game start inializaing while waiting for AI callbacks.
+        DebugLogger() << "Initializing new SP game...";
+        server.NewSPGameInit(*m_single_player_setup_data);
+    }
 
     // force immediate check if all expected AIs are present, so that the FSM
     // won't get stuck in this state waiting for JoinGame messages that will
@@ -1132,37 +1152,40 @@ sc::result WaitingForSPGameJoiners::react(const JoinGame& msg) {
     std::string client_version_string;
     ExtractJoinGameMessageData(message, player_name, client_type, client_version_string);
 
-    int player_id = server.m_networking.NewPlayerID();
-
     // is this an AI?
     if (client_type == Networking::CLIENT_TYPE_AI_PLAYER) {
+        std::map<std::string, int>::const_iterator expected_it = m_expected_ai_player_ids.find(player_name);
         // verify that player name was expected
-        if (m_expected_ai_player_names.find(player_name) == m_expected_ai_player_names.end()) {
+        if (expected_it == m_expected_ai_player_ids.end()) {
             // unexpected ai player
             ErrorLogger() << "WaitingForSPGameJoiners::react(const JoinGame& msg) received join game message for player \"" << player_name << "\" which was not an expected AI player name.    Terminating connection.";
             server.m_networking.Disconnect(player_connection);
         } else {
             // expected player
             // let the networking system know what socket this player is on
-            player_connection->EstablishPlayer(player_id, player_name, client_type, client_version_string);
-            player_connection->SendMessage(JoinAckMessage(player_id));
+            player_connection->EstablishPlayer(expected_it->second, player_name, client_type, client_version_string);
+            player_connection->SendMessage(JoinAckMessage(expected_it->second));
 
             // remove name from expected names list, so as to only allow one connection per AI
-            m_expected_ai_player_names.erase(player_name);
+            m_expected_ai_player_ids.erase(player_name);
         }
 
     } else if (client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER) {
         // verify that there is room left for this player
-        int already_connected_players = m_expected_ai_player_names.size() + server.m_networking.NumEstablishedPlayers();
+        int already_connected_players = m_expected_ai_player_ids.size() + server.m_networking.NumEstablishedPlayers();
         if (already_connected_players >= m_num_expected_players) {
             // too many human players
             ErrorLogger() << "WaitingForSPGameJoiners::react(const JoinGame& msg): A human player attempted to join the game but there was not enough room.  Terminating connection.";
             // TODO: send message to attempted joiner saying game is full
             server.m_networking.Disconnect(player_connection);
         } else {
-            // expected human player
-            player_connection->EstablishPlayer(player_id, player_name, client_type, client_version_string);
-            player_connection->SendMessage(JoinAckMessage(player_id));
+            // unexpected but welcome human player
+            int host_id = server.Networking().HostPlayerID();
+            player_connection->EstablishPlayer(host_id, player_name, client_type, client_version_string);
+            player_connection->SendMessage(JoinAckMessage(host_id));
+
+            DebugLogger() << "Initializing new SP game...";
+            server.NewSPGameInit(*m_single_player_setup_data);
         }
     } else {
         ErrorLogger() << "WaitingForSPGameJoiners::react(const JoinGame& msg): Received JoinGame message with invalid client type: " << client_type;
@@ -1181,8 +1204,8 @@ sc::result WaitingForSPGameJoiners::react(const CheckStartConditions& u) {
     if (static_cast<int>(server.m_networking.NumEstablishedPlayers()) == m_num_expected_players) {
         DebugLogger() << "WaitingForSPGameJoiners::react(const CheckStartConditions& u) : have all " << m_num_expected_players << " expected players connected.";
         if (m_single_player_setup_data->m_new_game) {
-            DebugLogger() << "Initializing new SP game...";
-            server.NewSPGameInit(*m_single_player_setup_data);
+            DebugLogger() << "Verify AIs SP game...";
+            server.VerifySPGameAIs(*m_single_player_setup_data);
         } else {
             DebugLogger() << "Loading SP game save file: " << m_single_player_setup_data->m_filename;
             try {

--- a/server/ServerFSM.h
+++ b/server/ServerFSM.h
@@ -195,10 +195,10 @@ struct WaitingForSPGameJoiners : sc::state<WaitingForSPGameJoiners, ServerFSM> {
     sc::result react(const LoadSaveFileFailed& u);
     sc::result react(const Error& msg);
 
-    std::shared_ptr<SinglePlayerSetupData> m_single_player_setup_data;
+    std::shared_ptr<SinglePlayerSetupData>   m_single_player_setup_data;
     std::vector<PlayerSaveGameData>          m_player_save_game_data;
-    std::shared_ptr<ServerSaveGameData> m_server_save_game_data;
-    std::set<std::string>                    m_expected_ai_player_names;
+    std::shared_ptr<ServerSaveGameData>      m_server_save_game_data;
+    std::map<std::string, int>               m_expected_ai_player_ids;
     int                                      m_num_expected_players;
 
     SERVER_ACCESSOR

--- a/server/ServerFSM.h
+++ b/server/ServerFSM.h
@@ -198,7 +198,7 @@ struct WaitingForSPGameJoiners : sc::state<WaitingForSPGameJoiners, ServerFSM> {
     std::shared_ptr<SinglePlayerSetupData>   m_single_player_setup_data;
     std::vector<PlayerSaveGameData>          m_player_save_game_data;
     std::shared_ptr<ServerSaveGameData>      m_server_save_game_data;
-    std::map<std::string, int>               m_expected_ai_player_ids;
+    std::map<std::string, int>               m_expected_ai_names_and_ids;
     int                                      m_num_expected_players;
 
     SERVER_ACCESSOR

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -172,6 +172,8 @@ struct FO_COMMON_API MultiplayerLobbyData : public GalaxySetupData {
     std::string Dump() const;
 
     bool                                        m_new_game;
+    // TODO: Change from a list<(player_id, PlayerSetupData)> where
+    // PlayerSetupData contain player_id to a vector of PlayerSetupData
     std::list<std::pair<int, PlayerSetupData> > m_players;              // <player_id, PlayerSetupData>
 
     std::string                                 m_save_game;            //< File name of a save file

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -104,6 +104,7 @@ struct PlayerSetupData {
     /** \name Structors */ //@{
     PlayerSetupData() :
         m_player_name(),
+        m_player_id(Networking::INVALID_PLAYER_ID),
         m_empire_name(),
         m_empire_color(GG::Clr(0, 0, 0, 0)),
         m_starting_species_name(),
@@ -114,6 +115,7 @@ struct PlayerSetupData {
     //@}
 
     std::string             m_player_name;          ///< the player's name
+    int                     m_player_id;            ///< player id
 
     std::string             m_empire_name;          ///< the name of the player's empire when starting a new game
     GG::Clr                 m_empire_color;         ///< the color used to represent this player's empire when starting a new game

--- a/util/SerializeMultiplayerCommon.cpp
+++ b/util/SerializeMultiplayerCommon.cpp
@@ -72,6 +72,7 @@ template <class Archive>
 void PlayerSetupData::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_NVP(m_player_name)
+        & BOOST_SERIALIZATION_NVP(m_player_id)
         & BOOST_SERIALIZATION_NVP(m_empire_name)
         & BOOST_SERIALIZATION_NVP(m_empire_color)
         & BOOST_SERIALIZATION_NVP(m_starting_species_name)


### PR DESCRIPTION
This may fix #1369.  However, I don't have the multiple OSs to test it for myself.

This PR changes the startup sequencing for new games as explained below.

The previous startup sequencing for a new game was: start the python engine, start accepting network connections, generate the universe, spawn any AIs, wait for the AIs to callback, and finally send the game start data to all of the players.  

This PR changes the sequence to: start accepting network connections, spawn the AIs, then start the python engine and generate the universe in parallel, wait for the AIs to callback and universe generation to complete,  and finally send the game start data to the players.

The PR provides the following benefits:
- the network connection starts responding to requests up a few seconds earlier.
- python startup and universe generation can overlap AI startup resulting in faster startup.
- the AI ids are assigned independent of their callback order and their shared_ptr sort order.  This is the change that might fix #1369.



