### PR TITLE
Add max capacity effects for locked weapons

### DIFF
--- a/default/scripting/ship_parts/Weapons.focs.txt
+++ b/default/scripting/ship_parts/Weapons.focs.txt
@@ -10,7 +10,7 @@ Part
     tags = [ "PEDIA_PC_DIRECT_WEAPON" ]
     location = OwnedBy empire = Source.Owner
     effectsgroups =
-        [[WEAPON_BASE_UNOWNED_EFFECTS(SR_WEAPON_1_1)]]
+        [[WEAPON_BASE_DEFAULT_EFFECTS(SR_WEAPON_1_1)]]
     icon = "icons/ship_parts/mass-driver.png"
 
 Part
@@ -26,7 +26,7 @@ Part
     tags = [ "PEDIA_PC_DIRECT_WEAPON" ]
     location = OwnedBy empire = Source.Owner
     effectsgroups =
-        [[WEAPON_BASE_UNOWNED_EFFECTS(SR_WEAPON_0_1)]]
+        [[WEAPON_BASE_DEFAULT_EFFECTS(SR_WEAPON_0_1)]]
     icon = "icons/ship_parts/flak.png"
 
 Part
@@ -41,7 +41,7 @@ Part
     tags = [ "PEDIA_PC_DIRECT_WEAPON" ]
     location = OwnedBy empire = Source.Owner
     effectsgroups =
-        [[WEAPON_BASE_UNOWNED_EFFECTS(SR_WEAPON_2_1)]]
+        [[WEAPON_BASE_DEFAULT_EFFECTS(SR_WEAPON_2_1)]]
     icon = "icons/ship_parts/laser.png"
 
 Part
@@ -56,7 +56,7 @@ Part
     tags = [ "PEDIA_PC_DIRECT_WEAPON" ]
     location = OwnedBy empire = Source.Owner
     effectsgroups =
-        [[WEAPON_BASE_UNOWNED_EFFECTS(SR_WEAPON_3_1)]]
+        [[WEAPON_BASE_DEFAULT_EFFECTS(SR_WEAPON_3_1)]]
     icon = "icons/ship_parts/plasma.png"
 
 Part
@@ -71,7 +71,7 @@ Part
     tags = [ "PEDIA_PC_DIRECT_WEAPON" ]
     location = OwnedBy empire = Source.Owner
     effectsgroups =
-        [[WEAPON_BASE_UNOWNED_EFFECTS(SR_WEAPON_4_1)]]
+        [[WEAPON_BASE_DEFAULT_EFFECTS(SR_WEAPON_4_1)]]
     icon = "icons/ship_parts/death-ray.png"
 
 Part
@@ -134,16 +134,20 @@ Part
     location = OwnedBy empire = Source.Owner
     icon = "icons/ship_parts/snowflake_laser.png"
 
-#include "/scripting/common/upkeep.macros"
-
-WEAPON_BASE_UNOWNED_EFFECTS
+// If unowned or owner has not unlocked the ship part yet.
+WEAPON_BASE_DEFAULT_EFFECTS
 '''        EffectsGroup
             scope = Source
-            activation = Unowned    // if owned by a player, gets weapon meters set by effects in relevant techs
-            stackinggroup = "WEAPON_BASE_UNOWNED_EFFECTS_@1@"
+            activation = Or [
+                Unowned
+                Not OwnerHasShipPartAvailable name = "@1@"
+            ]
+            stackinggroup = "WEAPON_BASE_DEFAULT_EFFECTS_@1@"
             accountinglabel = "@1@"
             effects = [
                 SetMaxCapacity partname = "@1@" value = Value + PartCapacity name = "@1@"
                 SetMaxSecondaryStat partname = "@1@" value = Value + PartSecondaryStat name = "@1@"
             ]
 '''
+
+#include "/scripting/common/upkeep.macros"

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -9137,6 +9137,12 @@ DESC_OWNER_HAS_SHIP_DESIGN
 DESC_OWNER_HAS_SHIP_DESIGN_NOT
 ''' ship design not unlocked for empire'''
 
+DESC_OWNER_HAS_SHIP_PART
+''' ship part unlocked for empire'''
+
+DESC_OWNER_HAS_SHIP_PART_NOT
+''' ship part not unlocked for empire'''
+
 # %1% FIXME
 # %2% FIXME
 # %3% FIXME

--- a/parse/ConditionParser7.cpp
+++ b/parse/ConditionParser7.cpp
@@ -75,12 +75,21 @@ namespace {
                 [ _val = new_<Condition::Location>(_a, _b, _c) ]
                 ;
 
+            owner_has_shippart_available
+                =   (tok.OwnerHasShipPartAvailable_
+                    >>  (parse::detail::label(Name_token)
+                         > parse::string_value_ref() [ _val = new_<Condition::OwnerHasShipPartAvailable>(_1) ]
+                        )
+                    )
+                ;
+
             start
                 %=   ordered_bombarded_by
                 |    contains
                 |    contained_by
                 |    star_type
                 |    location
+                |    owner_has_shippart_available
                 ;
 
             ordered_bombarded_by.name("OrderedBombardedBy");
@@ -88,6 +97,7 @@ namespace {
             contained_by.name("ContainedBy");
             star_type.name("StarType");
             location.name("Location");
+            owner_has_shippart_available.name("OwnerHasShipPartAvailable");
 
 #if DEBUG_CONDITION_PARSERS
             debug(ordered_bombarded_by);
@@ -95,6 +105,7 @@ namespace {
             debug(contained_by);
             debug(star_type);
             debug(location);
+            debug(owner_has_shippart_available);
 #endif
         }
 
@@ -117,6 +128,7 @@ namespace {
         parse::condition_parser_rule            contained_by;
         star_type_vec_rule                      star_type;
         string_ref_rule                         location;
+        parse::condition_parser_rule            owner_has_shippart_available;
         parse::condition_parser_rule            start;
     };
 }

--- a/parse/Tokens.h
+++ b/parse/Tokens.h
@@ -265,6 +265,7 @@
     (OutpostsOwned)                             \
     (OwnedBy)                                   \
     (Owner)                                     \
+    (OwnerHasShipPartAvailable)                 \
     (OwnerHasTech)                              \
     (OwnerTradeStockpile)                       \
     (Parameters)                                \

--- a/universe/Condition.h
+++ b/universe/Condition.h
@@ -1915,6 +1915,44 @@ private:
     void serialize(Archive& ar, const unsigned int version);
 };
 
+/** Matches all objects whose owner who has the ship part @a name available. */
+struct FO_COMMON_API OwnerHasShipPartAvailable : public ConditionBase {
+    explicit OwnerHasShipPartAvailable(const std::string& name);
+
+    explicit OwnerHasShipPartAvailable(ValueRef::ValueRefBase<std::string>* name) :
+        ConditionBase(),
+        m_name(name)
+    {}
+
+    virtual ~OwnerHasShipPartAvailable();
+
+    bool operator==(const ConditionBase& rhs) const override;
+
+    void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
+              ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
+
+    bool RootCandidateInvariant() const override;
+
+    bool TargetInvariant() const override;
+
+    bool SourceInvariant() const override;
+
+    std::string Description(bool negated = false) const override;
+
+    std::string Dump() const override;
+
+    void SetTopLevelContent(const std::string& content_name) override;
+
+private:
+    bool Match(const ScriptingContext& local_context) const override;
+
+    ValueRef::ValueRefBase<std::string>* m_name;
+
+    friend class boost::serialization::access;
+    template <class Archive>
+    void serialize(Archive& ar, const unsigned int version);
+};
+
 /** Matches all objects that are visible to at least one Empire in \a empire_ids. */
 struct FO_COMMON_API VisibleToEmpire : public ConditionBase {
     explicit VisibleToEmpire(ValueRef::ValueRefBase<int>* empire_id) :
@@ -2888,6 +2926,14 @@ void OwnerHasShipDesignAvailable::serialize(Archive& ar, const unsigned int vers
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(ConditionBase)
         & BOOST_SERIALIZATION_NVP(m_id);
+}
+
+template <class Archive>
+void OwnerHasShipPartAvailable::serialize(Archive& ar,
+                                          const unsigned int version)
+{
+    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(ConditionBase)
+        & BOOST_SERIALIZATION_NVP(m_name);
 }
 
 template <class Archive>


### PR DESCRIPTION
Fixes #1386 

Grants ~a reduced~ damage and shot value for weapons that are not yet researched by an empire, but owned by some means.