### PR TITLE
Remove short_description value for "subcategory container" articles

### DIFF
--- a/default/scripting/encyclopedia/ENC_SHIP_HULL.focs.txt
+++ b/default/scripting/encyclopedia/ENC_SHIP_HULL.focs.txt
@@ -1,6 +1,6 @@
 Article
     name = "ENC_SHIP_HULL"
     category = "ENC_SHIP_HULL"
-    short_description = "ENC_SHIP_HULL"
+    short_description = ""
     description = "ENC_SHIP_HULL_DESC"
     icon = "icons/ship_hulls/generic_hull.png"

--- a/default/scripting/encyclopedia/ENC_SHIP_PART.focs.txt
+++ b/default/scripting/encyclopedia/ENC_SHIP_PART.focs.txt
@@ -1,6 +1,6 @@
 Article
     name = "ENC_SHIP_PART"
     category = "ENC_SHIP_PART"
-    short_description = "ENC_SHIP_PART"
+    short_description = ""
     description = "ENC_SHIP_PART_DESC"
     icon = "icons/ship_parts/generic_part.png"

--- a/default/scripting/encyclopedia/ENC_SPECIES.focs.txt
+++ b/default/scripting/encyclopedia/ENC_SPECIES.focs.txt
@@ -1,6 +1,6 @@
 Article
     name = "ENC_SPECIES"
     category = "ENC_SPECIES"
-    short_description = "ENC_SPECIES"
+    short_description = ""
     description = "ENC_SPECIES_DESC"
     icon = "icons/species/humanoid-01.png"

--- a/default/scripting/encyclopedia/ENC_TECH.focs.txt
+++ b/default/scripting/encyclopedia/ENC_TECH.focs.txt
@@ -1,6 +1,6 @@
 Article
     name = "ENC_TECH"
     category = "ENC_TECH"
-    short_description = "ENC_TECH"
+    short_description = ""
     description = "ENC_TECH_DESC"
     icon = "icons/meter/research.png"

--- a/default/scripting/encyclopedia/FIELDS.focs.txt
+++ b/default/scripting/encyclopedia/FIELDS.focs.txt
@@ -1,6 +1,6 @@
 Article
     name = "ENC_FIELD_TYPE"
     category = "ENC_FIELD_TYPE"
-    short_description = "FIELDS_TITLE"
+    short_description = ""
     description = "FIELDS_TEXT"
     icon = "icons/tech/galactic_exploration.png"


### PR DESCRIPTION
- Prevent duplicated terms (e.g. "Ship Part Ship Part") in short description of some Pedia articles
- [See discussion here.](https://github.com/freeorion/freeorion/pull/1402#discussion_r106715150)