### PR TITLE
Reduce client networking build dependencies.

### DIFF
--- a/UI/CUIControls.cpp
+++ b/UI/CUIControls.cpp
@@ -27,22 +27,22 @@
 
 namespace {
     void PlayButtonClickSound()
-    { Sound::GetSound().PlaySound(GetOptionsDB().Get<std::string>("UI.sound.button-click"), true); }
+    { Sound::GetSound().PlaySoundEffect(GetOptionsDB().Get<std::string>("UI.sound.button-click"), true); }
 
     void PlayButtonRolloverSound()
-    { Sound::GetSound().PlaySound(GetOptionsDB().Get<std::string>("UI.sound.button-rollover"), true); }
+    { Sound::GetSound().PlaySoundEffect(GetOptionsDB().Get<std::string>("UI.sound.button-rollover"), true); }
 
     void PlayListSelectSound(const GG::ListBox::SelectionSet&)
-    { Sound::GetSound().PlaySound(GetOptionsDB().Get<std::string>("UI.sound.list-select"), true); }
+    { Sound::GetSound().PlaySoundEffect(GetOptionsDB().Get<std::string>("UI.sound.list-select"), true); }
 
     void PlayDropDownListOpenSound()
-    { Sound::GetSound().PlaySound(GetOptionsDB().Get<std::string>("UI.sound.list-pulldown"), true); }
+    { Sound::GetSound().PlaySoundEffect(GetOptionsDB().Get<std::string>("UI.sound.list-pulldown"), true); }
 
     void PlayItemDropSound(GG::ListBox::iterator)
-    { Sound::GetSound().PlaySound(GetOptionsDB().Get<std::string>("UI.sound.item-drop"), true); }
+    { Sound::GetSound().PlaySoundEffect(GetOptionsDB().Get<std::string>("UI.sound.item-drop"), true); }
 
     void PlayTextTypingSound(const std::string&)
-    { Sound::GetSound().PlaySound(GetOptionsDB().Get<std::string>("UI.sound.text-typing"), true); }
+    { Sound::GetSound().PlaySoundEffect(GetOptionsDB().Get<std::string>("UI.sound.text-typing"), true); }
 
     const double ARROW_BRIGHTENING_SCALE_FACTOR = 1.5;
     const double STATE_BUTTON_BRIGHTENING_SCALE_FACTOR = 1.25;

--- a/UI/CUISpin.h
+++ b/UI/CUISpin.h
@@ -48,7 +48,7 @@ namespace detail {
     inline void PlayValueChangedSound::operator()(double) const
     {
         std::string file_name = GetOptionsDB().Get<std::string>("UI.sound.button-click");
-        Sound::GetSound().PlaySound(file_name, true);
+        Sound::GetSound().PlaySoundEffect(file_name, true);
     }
     inline void PlayValueChangedSound::operator()(int) const {operator()(0.0);}
 }

--- a/UI/CUIWnd.cpp
+++ b/UI/CUIWnd.cpp
@@ -20,11 +20,11 @@
 
 namespace {
     void PlayMinimizeSound()
-    { Sound::GetSound().PlaySound(GetOptionsDB().Get<std::string>("UI.sound.window-maximize"), true); }
+    { Sound::GetSound().PlaySoundEffect(GetOptionsDB().Get<std::string>("UI.sound.window-maximize"), true); }
     void PlayMaximizeSound()
-    { Sound::GetSound().PlaySound(GetOptionsDB().Get<std::string>("UI.sound.window-minimize"), true); }
+    { Sound::GetSound().PlaySoundEffect(GetOptionsDB().Get<std::string>("UI.sound.window-minimize"), true); }
     void PlayCloseSound()
-    { Sound::GetSound().PlaySound(GetOptionsDB().Get<std::string>("UI.sound.window-close"), true); }
+    { Sound::GetSound().PlaySoundEffect(GetOptionsDB().Get<std::string>("UI.sound.window-close"), true); }
 
     void AddOptions(OptionsDB& db) {
         db.AddFlag('w', "window-reset", UserStringNop("OPTIONS_DB_WINDOW_RESET"), false);

--- a/UI/ChatWnd.cpp
+++ b/UI/ChatWnd.cpp
@@ -385,40 +385,40 @@ void MessageWnd::HandlePlayerChatMessage(const std::string& text, int sender_pla
     m_display_show_time = GG::GUI::GetGUI()->Ticks();
 }
 
-void MessageWnd::HandlePlayerStatusUpdate(Message::PlayerStatus player_status, int about_player_id)
+void MessageWnd::HandlePlayerStatusUpdate(MessagePacket::PlayerStatus player_status, int about_player_id)
 {}
 
-void MessageWnd::HandleTurnPhaseUpdate(Message::TurnProgressPhase phase_id) {
+void MessageWnd::HandleTurnPhaseUpdate(MessagePacket::TurnProgressPhase phase_id) {
     std::string phase_str;
     switch (phase_id) {
-    case Message::FLEET_MOVEMENT:
+    case MessagePacket::FLEET_MOVEMENT:
         phase_str = UserString("TURN_PROGRESS_PHASE_FLEET_MOVEMENT");
         break;
-    case Message::COMBAT:
+    case MessagePacket::COMBAT:
         phase_str = UserString("TURN_PROGRESS_PHASE_COMBAT");
         break;
-    case Message::EMPIRE_PRODUCTION:
+    case MessagePacket::EMPIRE_PRODUCTION:
         phase_str = UserString("TURN_PROGRESS_PHASE_EMPIRE_GROWTH");
         break;
-    case Message::WAITING_FOR_PLAYERS:
+    case MessagePacket::WAITING_FOR_PLAYERS:
         phase_str = UserString("TURN_PROGRESS_PHASE_WAITING");
         break;
-    case Message::PROCESSING_ORDERS:
+    case MessagePacket::PROCESSING_ORDERS:
         phase_str = UserString("TURN_PROGRESS_PHASE_ORDERS");
         break;
-    case Message::COLONIZE_AND_SCRAP:
+    case MessagePacket::COLONIZE_AND_SCRAP:
         phase_str = UserString("TURN_PROGRESS_COLONIZE_AND_SCRAP");
         break;
-    case Message::DOWNLOADING:
+    case MessagePacket::DOWNLOADING:
         phase_str = UserString("TURN_PROGRESS_PHASE_DOWNLOADING");
         break;
-    case Message::LOADING_GAME:
+    case MessagePacket::LOADING_GAME:
         phase_str = UserString("TURN_PROGRESS_PHASE_LOADING_GAME");
         break;
-    case Message::GENERATING_UNIVERSE:
+    case MessagePacket::GENERATING_UNIVERSE:
         phase_str = UserString("TURN_PROGRESS_PHASE_GENERATING_UNIVERSE");
         break;
-    case Message::STARTING_AIS:
+    case MessagePacket::STARTING_AIS:
         phase_str = UserString("TURN_PROGRESS_STARTING_AIS");
         break;
     default:

--- a/UI/ChatWnd.cpp
+++ b/UI/ChatWnd.cpp
@@ -6,6 +6,7 @@
 #include "../Empire/Empire.h"
 #include "../Empire/EmpireManager.h"
 #include "../network/Message.h"
+#include "../network/ClientNetworking.h"
 #include "../universe/Universe.h"
 #include "../universe/Ship.h"
 #include "../universe/ShipDesign.h"

--- a/UI/ChatWnd.h
+++ b/UI/ChatWnd.h
@@ -24,8 +24,8 @@ public:
     void PreRender() override;
 
     void            HandlePlayerChatMessage(const std::string& text, int sender_player_id, int recipient_player_id);
-    void            HandlePlayerStatusUpdate(Message::PlayerStatus player_status, int about_player_id);
-    void            HandleTurnPhaseUpdate(Message::TurnProgressPhase phase_id);
+    void            HandlePlayerStatusUpdate(MessagePacket::PlayerStatus player_status, int about_player_id);
+    void            HandleTurnPhaseUpdate(MessagePacket::TurnProgressPhase phase_id);
     void            HandleGameStatusUpdate(const std::string& text);
     void            HandleLogMessage(const std::string& text);
     void            Clear();

--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -980,7 +980,7 @@ void ClientUI::MessageBox(const std::string& message, bool play_alert_sound/* = 
                            WndColor(), WndOuterBorderColor(), CtrlColor(), TextColor(), 1,
                            UserString("OK"));
     if (play_alert_sound)
-        Sound::GetSound().PlaySound(SoundDir() / "alert.ogg", true);
+        Sound::GetSound().PlaySoundEffect(SoundDir() / "alert.ogg", true);
     dlg.Run();
 }
 

--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -50,6 +50,7 @@
 #  ifdef MessageBox
 #    undef MessageBox
 #  endif
+#  undef PlaySound
 #endif
 
 const Tech* GetTech(const std::string& name);

--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -46,13 +46,6 @@
 #include <string>
 #include <algorithm>
 
-#ifdef FREEORION_WIN32
-#  ifdef MessageBox
-#    undef MessageBox
-#  endif
-#  undef PlaySound
-#endif
-
 const Tech* GetTech(const std::string& name);
 
 bool TextureFileNameCompare(const std::shared_ptr<GG::Texture> t1, const std::shared_ptr<GG::Texture> t2)

--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -975,7 +975,7 @@ void ClientUI::RestoreFromSaveData(const SaveGameUIData& ui_data)
 ClientUI* ClientUI::GetClientUI()
 { return s_the_UI; }
 
-void ClientUI::MessageBox(const std::string& message, bool play_alert_sound/* = false*/) {
+void ClientUI::MessagePopup(const std::string& message, bool play_alert_sound/* = false*/) {
     GG::ThreeButtonDlg dlg(GG::X(320), GG::Y(200), message, GetFont(Pts()+2),
                            WndColor(), WndOuterBorderColor(), CtrlColor(), TextColor(), 1,
                            UserString("OK"));

--- a/UI/ClientUI.h
+++ b/UI/ClientUI.h
@@ -109,7 +109,7 @@ public:
     /** Shows a message dialog box with the given message; if
       * \a play_alert_sound is true, and UI sound effects are currently enabled,
       * the default alert sound will be played as the message box opens */
-    static void MessageBox(const std::string& message, bool play_alert_sound = false);
+    static void MessagePopup(const std::string& message, bool play_alert_sound = false);
 
     /** Loads the requested texture from file \a name; mipmap textures are
       * generated if \a mipmap is true; loads default missing.png if name isn't

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -246,7 +246,7 @@ namespace {
 
         } catch (const std::exception& e) {
             ErrorLogger() << "Error writing design file.  Exception: " << ": " << e.what();
-            ClientUI::MessageBox(e.what(), true);
+            ClientUI::MessagePopup(e.what(), true);
         }
     }
 
@@ -287,7 +287,7 @@ namespace {
                 WriteDesignToFile(design_id, save_path);
             }
         } catch (const std::exception& e) {
-            ClientUI::MessageBox(e.what(), true);
+            ClientUI::MessagePopup(e.what(), true);
             return;
         }
     }

--- a/UI/FleetButton.cpp
+++ b/UI/FleetButton.cpp
@@ -351,10 +351,10 @@ void FleetButton::RenderRollover() {
 }
 
 void FleetButton::PlayFleetButtonRolloverSound()
-{ Sound::GetSound().PlaySound(GetOptionsDB().Get<std::string>("UI.sound.fleet-button-rollover"), true); }
+{ Sound::GetSound().PlaySoundEffect(GetOptionsDB().Get<std::string>("UI.sound.fleet-button-rollover"), true); }
 
 void FleetButton::PlayFleetButtonOpenSound()
-{ Sound::GetSound().PlaySound(GetOptionsDB().Get<std::string>("UI.sound.fleet-button-click"), true); }
+{ Sound::GetSound().PlaySoundEffect(GetOptionsDB().Get<std::string>("UI.sound.fleet-button-click"), true); }
 
 /////////////////////
 // Free Functions

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -244,7 +244,7 @@ namespace {
                 ScopedTimer get_id_timer("GetNewObjectID");
                 new_fleet_id = GetNewObjectID();
                 if (new_fleet_id == INVALID_OBJECT_ID) {
-                    ClientUI::MessageBox(UserString("SERVER_TIMEOUT"), true);
+                    ClientUI::MessagePopup(UserString("SERVER_TIMEOUT"), true);
                     return;
                 }
             }

--- a/UI/InGameMenu.cpp
+++ b/UI/InGameMenu.cpp
@@ -172,7 +172,7 @@ void InGameMenu::Save() {
 
     } catch (const std::exception& e) {
         ErrorLogger() << "Exception thrown attempting save: " << e.what();
-        ClientUI::MessageBox(e.what(), true);
+        ClientUI::MessagePopup(e.what(), true);
     }
 }
 

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -277,7 +277,7 @@ namespace {
     { return HumanClientApp::GetApp()->GetClientType() == Networking::CLIENT_TYPE_HUMAN_MODERATOR; }
 
     void PlayTurnButtonClickSound()
-    { Sound::GetSound().PlaySound(GetOptionsDB().Get<std::string>("UI.sound.turn-button-click"), true); }
+    { Sound::GetSound().PlaySoundEffect(GetOptionsDB().Get<std::string>("UI.sound.turn-button-click"), true); }
 
     bool ToggleBoolOption(const std::string& option_name) {
         bool initially_enabled = GetOptionsDB().Get<bool>(option_name);
@@ -2743,7 +2743,7 @@ void MapWnd::InitTurn() {
     }
 
     if (GetOptionsDB().Get<bool>("UI.sound.new-turn.toggle"))
-        Sound::GetSound().PlaySound(GetOptionsDB().Get<std::string>("UI.sound.new-turn.sound-file"), true);
+        Sound::GetSound().PlaySoundEffect(GetOptionsDB().Get<std::string>("UI.sound.new-turn.sound-file"), true);
 }
 
 void MapWnd::MidTurnUpdate() {

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -47,6 +47,7 @@
 #include "../universe/UniverseObject.h"
 #include "../Empire/Empire.h"
 #include "../network/Message.h"
+#include "../network/ClientNetworking.h"
 #include "../client/human/HumanClientApp.h"
 
 #include <boost/timer.hpp>

--- a/UI/MultiplayerLobbyWnd.cpp
+++ b/UI/MultiplayerLobbyWnd.cpp
@@ -9,6 +9,7 @@
 #include "../util/Logger.h"
 #include "../util/Serialize.h"
 #include "../network/Message.h"
+#include "../network/ClientNetworking.h"
 #include "../client/human/HumanClientApp.h"
 #include "CUIControls.h"
 #include "Hotkeys.h"

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -5,6 +5,7 @@
 #include "CUISpin.h"
 #include "FleetButton.h"
 #include "../client/human/HumanClientApp.h"
+#include "../network/ClientNetworking.h"
 #include "../util/i18n.h"
 #include "../util/Logger.h"
 #include "../util/Order.h"

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -1,3 +1,10 @@
+#ifdef FREEORION_WIN32
+// windows.h defines the macros min and max. Disabling the generation of
+// the min and max macros and undefining those should avoid name collisions
+// with std c++ library and FreeOrion function names.
+#define NOMINMAX
+#endif
+
 #include "OptionsWnd.h"
 
 #include "../client/human/HumanClientApp.h"
@@ -20,6 +27,14 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/filesystem/operations.hpp>
 
+#ifdef FREEORION_WIN32
+// windows.h defines the macros Message, MessageBox, and
+// PlaySound. Undefining those should avoid name collisions with std c++
+// library and FreeOrion function names.
+#   undef Message
+#   undef MessageBox
+#   undef PlaySound
+#endif
 
 namespace fs = boost::filesystem;
 

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -27,15 +27,6 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/filesystem/operations.hpp>
 
-#ifdef FREEORION_WIN32
-// windows.h defines the macros Message, MessageBox, and
-// PlaySound. Undefining those should avoid name collisions with std c++
-// library and FreeOrion function names.
-#   undef Message
-#   undef MessageBox
-#   undef PlaySound
-#endif
-
 namespace fs = boost::filesystem;
 
 namespace {

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -1160,7 +1160,7 @@ void OptionsWnd::SoundOptionsFeedback::SoundEffectsEnableClicked(bool checked) {
         try {
             Sound::GetSound().Enable();
             GetOptionsDB().Set("UI.sound.enabled", true);
-            Sound::GetSound().PlaySound(GetOptionsDB().Get<std::string>("UI.sound.button-click"), true);
+            Sound::GetSound().PlaySoundEffect(GetOptionsDB().Get<std::string>("UI.sound.button-click"), true);
         } catch (Sound::InitializationFailureException const &e) {
             SoundInitializationFailure(e);
         }
@@ -1196,7 +1196,7 @@ void OptionsWnd::SoundOptionsFeedback::MusicVolumeSlid(int pos, int low, int hig
 void OptionsWnd::SoundOptionsFeedback::UISoundsVolumeSlid(int pos, int low, int high) const {
     GetOptionsDB().Set("UI.sound.volume", pos);
     Sound::GetSound().SetUISoundsVolume(pos);
-    Sound::GetSound().PlaySound(GetOptionsDB().Get<std::string>("UI.sound.button-click"), true);
+    Sound::GetSound().PlaySoundEffect(GetOptionsDB().Get<std::string>("UI.sound.button-click"), true);
 }
 
 void OptionsWnd::SoundOptionsFeedback::SetMusicButton(GG::StateButton* button)

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -120,7 +120,7 @@ namespace {
                     m_edit->EditedSignal(m_edit->Text());
                 }
             } catch (const std::exception& e) {
-                ClientUI::MessageBox(e.what(), true);
+                ClientUI::MessagePopup(e.what(), true);
             }
         }
 
@@ -1212,5 +1212,5 @@ void OptionsWnd::SoundOptionsFeedback::SoundInitializationFailure(Sound::Initial
         m_effects_button->SetCheck(false);
     if (m_music_button)
         m_music_button->SetCheck(false);
-    ClientUI::MessageBox(UserString(e.what()), false);
+    ClientUI::MessagePopup(UserString(e.what()), false);
 }

--- a/UI/PlayerListWnd.cpp
+++ b/UI/PlayerListWnd.cpp
@@ -5,6 +5,7 @@
 #include "../Empire/Empire.h"
 #include "../Empire/EmpireManager.h"
 #include "../network/Message.h"
+#include "../network/ClientNetworking.h"
 #include "../util/i18n.h"
 #include "../util/Logger.h"
 #include "../util/OptionsDB.h"

--- a/UI/PlayerListWnd.cpp
+++ b/UI/PlayerListWnd.cpp
@@ -114,7 +114,7 @@ namespace {
             m_empire_research_text(nullptr),
             m_empire_detection_text(nullptr),
             m_diplo_status(INVALID_DIPLOMATIC_STATUS),
-            m_player_status(Message::WAITING),
+            m_player_status(MessagePacket::WAITING),
             m_player_type(Networking::INVALID_CLIENT_TYPE),
             m_host(false),
             m_win_status(NEITHER),
@@ -193,9 +193,9 @@ namespace {
 
             // render player status icon
             switch (m_player_status) {
-            case Message::PLAYING_TURN:     PlayingIcon()->OrthoBlit(UpperLeft() + m_player_status_icon_ul, UpperLeft() + m_player_status_icon_ul + ICON_SIZE); break;
-            case Message::RESOLVING_COMBAT: CombatIcon()->OrthoBlit( UpperLeft() + m_player_status_icon_ul, UpperLeft() + m_player_status_icon_ul + ICON_SIZE); break;
-            case Message::WAITING:          WaitingIcon()->OrthoBlit(UpperLeft() + m_player_status_icon_ul, UpperLeft() + m_player_status_icon_ul + ICON_SIZE); break;
+            case MessagePacket::PLAYING_TURN:     PlayingIcon()->OrthoBlit(UpperLeft() + m_player_status_icon_ul, UpperLeft() + m_player_status_icon_ul + ICON_SIZE); break;
+            case MessagePacket::RESOLVING_COMBAT: CombatIcon()->OrthoBlit( UpperLeft() + m_player_status_icon_ul, UpperLeft() + m_player_status_icon_ul + ICON_SIZE); break;
+            case MessagePacket::WAITING:          WaitingIcon()->OrthoBlit(UpperLeft() + m_player_status_icon_ul, UpperLeft() + m_player_status_icon_ul + ICON_SIZE); break;
             default:    break;
             }
 
@@ -342,7 +342,7 @@ namespace {
             m_host = player_info.host;
         }
 
-        void            SetStatus(Message::PlayerStatus player_status)
+        void            SetStatus(MessagePacket::PlayerStatus player_status)
         { m_player_status = player_status; }
 
     private:
@@ -436,7 +436,7 @@ namespace {
         GG::Pt                  m_win_status_icon_ul;
 
         DiplomaticStatus        m_diplo_status;
-        Message::PlayerStatus   m_player_status;
+        MessagePacket::PlayerStatus   m_player_status;
         Networking::ClientType  m_player_type;
         bool                    m_host;
         enum {
@@ -474,7 +474,7 @@ namespace {
                 m_panel->Update();
         }
 
-        void    SetStatus(Message::PlayerStatus player_status) {
+        void    SetStatus(MessagePacket::PlayerStatus player_status) {
             if (m_panel)
                 m_panel->SetStatus(player_status);
         }
@@ -568,7 +568,7 @@ std::set<int> PlayerListWnd::SelectedPlayerIDs() const {
     return retval;
 }
 
-void PlayerListWnd::HandlePlayerStatusUpdate(Message::PlayerStatus player_status, int about_player_id) {
+void PlayerListWnd::HandlePlayerStatusUpdate(MessagePacket::PlayerStatus player_status, int about_player_id) {
     for (CUIListBox::Row* row : *m_player_list) {
         if (PlayerRow* player_row = dynamic_cast<PlayerRow*>(row)) {
             if (about_player_id == Networking::INVALID_PLAYER_ID) {

--- a/UI/PlayerListWnd.h
+++ b/UI/PlayerListWnd.h
@@ -20,7 +20,7 @@ public:
     //! \name Mutators //@{
     void SizeMove(const GG::Pt& ul, const GG::Pt& lr) override;
 
-    void            HandlePlayerStatusUpdate(Message::PlayerStatus player_status, int about_player_id);
+    void            HandlePlayerStatusUpdate(MessagePacket::PlayerStatus player_status, int about_player_id);
     void            Update();
     void            Refresh();
     void            Clear();

--- a/UI/ServerConnectWnd.cpp
+++ b/UI/ServerConnectWnd.cpp
@@ -13,6 +13,7 @@
 #include "../util/OptionsDB.h"
 #include "../util/Directories.h"
 #include "../client/human/HumanClientApp.h"
+#include "../network/ClientNetworking.h"
 #include "ClientUI.h"
 #include "CUIControls.h"
 #include "Sound.h"

--- a/UI/ServerConnectWnd.cpp
+++ b/UI/ServerConnectWnd.cpp
@@ -99,7 +99,7 @@ ServerConnectWnd::ServerConnectWnd() :
 
     ResetDefaultPosition();
 
-    m_LAN_servers = HumanClientApp::GetApp()->Networking().DiscoverLANServers();
+    m_LAN_servers = HumanClientApp::GetApp()->Networking().DiscoverLANServerNames();
     Init();
 }
 
@@ -146,16 +146,16 @@ void ServerConnectWnd::Init() {
 void ServerConnectWnd::PopulateServerList()
 {
     m_servers_lb->Clear();
-    for (const ClientNetworking::ServerList::value_type& server : m_LAN_servers) {
+    for (const auto& server : m_LAN_servers) {
         GG::ListBox::Row* row = new GG::ListBox::Row;
-        row->push_back(new CUILabel(server.second));
+        row->push_back(new CUILabel(server));
         m_servers_lb->Insert(row);
     }
 }
 
 void ServerConnectWnd::RefreshServerList()
 {
-    m_LAN_servers = HumanClientApp::GetApp()->Networking().DiscoverLANServers();
+    m_LAN_servers = HumanClientApp::GetApp()->Networking().DiscoverLANServerNames();
     PopulateServerList();
 }
 

--- a/UI/ServerConnectWnd.cpp
+++ b/UI/ServerConnectWnd.cpp
@@ -99,7 +99,6 @@ ServerConnectWnd::ServerConnectWnd() :
 
     ResetDefaultPosition();
 
-    m_LAN_servers = HumanClientApp::GetApp()->Networking().DiscoverLANServerNames();
     Init();
 }
 
@@ -146,7 +145,8 @@ void ServerConnectWnd::Init() {
 void ServerConnectWnd::PopulateServerList()
 {
     m_servers_lb->Clear();
-    for (const auto& server : m_LAN_servers) {
+    const auto server_names = HumanClientApp::GetApp()->Networking().DiscoverLANServerNames();
+    for (const auto& server : server_names) {
         GG::ListBox::Row* row = new GG::ListBox::Row;
         row->push_back(new CUILabel(server));
         m_servers_lb->Insert(row);
@@ -155,7 +155,6 @@ void ServerConnectWnd::PopulateServerList()
 
 void ServerConnectWnd::RefreshServerList()
 {
-    m_LAN_servers = HumanClientApp::GetApp()->Networking().DiscoverLANServerNames();
     PopulateServerList();
 }
 

--- a/UI/ServerConnectWnd.h
+++ b/UI/ServerConnectWnd.h
@@ -6,7 +6,6 @@
 #include <GG/ListBox.h>
 
 #include "CUIWnd.h"
-#include "../network/ClientNetworking.h"
 
 
 /** server connections window */
@@ -55,8 +54,6 @@ private:
     GG::Edit*                           m_player_name_edit;
     GG::Button*                         m_ok_bn;
     GG::Button*                         m_cancel_bn;
-
-    ClientNetworking::ServerNames        m_LAN_servers;
 };
 
 #endif // _ServerConnectWnd_h_

--- a/UI/ServerConnectWnd.h
+++ b/UI/ServerConnectWnd.h
@@ -56,7 +56,7 @@ private:
     GG::Button*                         m_ok_bn;
     GG::Button*                         m_cancel_bn;
 
-    ClientNetworking::ServerList        m_LAN_servers;
+    ClientNetworking::ServerNames        m_LAN_servers;
 };
 
 #endif // _ServerConnectWnd_h_

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -60,7 +60,7 @@ namespace {
     /** @content_tag{CTRL_BOMBARD_} Prefix tag allowing automatic ship selection for bombard, must post-fix a valid planet tag **/
     const std::string TAG_BOMBARD_PREFIX = "CTRL_BOMBARD_";
 
-    void        PlaySidePanelOpenSound()       {Sound::GetSound().PlaySound(GetOptionsDB().Get<std::string>("UI.sound.sidepanel-open"), true);}
+    void        PlaySidePanelOpenSound()       {Sound::GetSound().PlaySoundEffect(GetOptionsDB().Get<std::string>("UI.sound.sidepanel-open"), true);}
 
     struct RotatingPlanetData {
         RotatingPlanetData(const XMLElement& elem) {

--- a/UI/Sound.cpp
+++ b/UI/Sound.cpp
@@ -48,7 +48,7 @@ public:
     void StopMusic();
 
     /** Plays a sound file. */
-    void PlaySound(const boost::filesystem::path& path, bool is_ui_sound = false);
+    void PlaySoundEffect(const boost::filesystem::path& path, bool is_ui_sound = false);
 
     /** Frees the cached sound data associated with the filename. */
     void FreeSound(const boost::filesystem::path& path);
@@ -185,8 +185,8 @@ void Sound::ResumeMusic()
 void Sound::StopMusic()
 { m_impl->StopMusic(); }
 
-void Sound::PlaySound(const boost::filesystem::path& path, bool is_ui_sound/* = false*/)
-{ m_impl->PlaySound(path, is_ui_sound); }
+void Sound::PlaySoundEffect(const boost::filesystem::path& path, bool is_ui_sound/* = false*/)
+{ m_impl->PlaySoundEffect(path, is_ui_sound); }
 
 void Sound::FreeSound(const boost::filesystem::path& path)
 { m_impl->FreeSound(path); }
@@ -488,7 +488,7 @@ void Sound::Impl::StopMusic() {
     }
 }
 
-void Sound::Impl::PlaySound(const boost::filesystem::path& path, bool is_ui_sound/* = false*/) {
+void Sound::Impl::PlaySoundEffect(const boost::filesystem::path& path, bool is_ui_sound/* = false*/) {
     if (!m_initialized || !GetOptionsDB().Get<bool>("UI.sound.enabled") || (is_ui_sound && UISoundsTemporarilyDisabled()))
         return;
 
@@ -556,13 +556,13 @@ void Sound::Impl::PlaySound(const boost::filesystem::path& path, bool is_ui_soun
                     }
                     else
                     {
-                        ErrorLogger() << "PlaySound: unable to open file " << filename.c_str() << " too big to buffer. Aborting\n";
+                        ErrorLogger() << "PlaySoundEffect: unable to open file " << filename.c_str() << " too big to buffer. Aborting\n";
                     }
                     ov_clear(&ogg_file);
                 }
                 else
                 {
-                    ErrorLogger() << "PlaySound: unable to open file " << filename.c_str() << " possibly not a .ogg vorbis file. Aborting\n";
+                    ErrorLogger() << "PlaySoundEffect: unable to open file " << filename.c_str() << " possibly not a .ogg vorbis file. Aborting\n";
                 }
             }
         }
@@ -578,11 +578,11 @@ void Sound::Impl::PlaySound(const boost::filesystem::path& path, bool is_ui_soun
                 }
             }
             if (!found_source)
-                ErrorLogger() << "PlaySound: Could not find aviable source - playback aborted\n";
+                ErrorLogger() << "PlaySoundEffect: Could not find aviable source - playback aborted\n";
         }
         source_state = alGetError();
         if (source_state != AL_NONE)
-            ErrorLogger() << "PlaySound: OpenAL ERROR: " << alGetString(source_state);
+            ErrorLogger() << "PlaySoundEffect: OpenAL ERROR: " << alGetString(source_state);
             /* it's important to check for errors, as some functions won't work properly if
              * they're called when there is a unchecked previous error. */
     }
@@ -644,7 +644,7 @@ void Sound::Impl::SetMusicVolume(int vol) {
         /* it is highly unlikely that we'll get an error here but better safe than sorry */
         m_openal_error = alGetError();
         if (m_openal_error != AL_NONE)
-            ErrorLogger() << "PlaySound: OpenAL ERROR: " << alGetString(m_openal_error);
+            ErrorLogger() << "PlaySoundEffect: OpenAL ERROR: " << alGetString(m_openal_error);
     }
 }
 
@@ -663,7 +663,7 @@ void Sound::Impl::SetUISoundsVolume(int vol) {
         /* it is highly unlikely that we'll get an error here but better safe than sorry */
         m_openal_error = alGetError();
         if (m_openal_error != AL_NONE)
-            ErrorLogger() << "PlaySound: OpenAL ERROR: " << alGetString(m_openal_error);
+            ErrorLogger() << "PlaySoundEffect: OpenAL ERROR: " << alGetString(m_openal_error);
     }
 }
 

--- a/UI/Sound.h
+++ b/UI/Sound.h
@@ -42,7 +42,7 @@ public:
     void StopMusic();
 
     /** Plays a sound file. */
-    void PlaySound(const boost::filesystem::path& path, bool is_ui_sound = false);
+    void PlaySoundEffect(const boost::filesystem::path& path, bool is_ui_sound = false);
 
     /** Frees the cached sound data associated with the filename. */
     void FreeSound(const boost::filesystem::path& path);

--- a/UI/SystemIcon.cpp
+++ b/UI/SystemIcon.cpp
@@ -29,7 +29,7 @@
 
 namespace {
     bool PlaySounds()                   { return GetOptionsDB().Get<bool>("UI.sound.enabled"); }
-    void PlaySystemIconRolloverSound()  { if (PlaySounds()) Sound::GetSound().PlaySound(GetOptionsDB().Get<std::string>("UI.sound.system-icon-rollover")); }
+    void PlaySystemIconRolloverSound()  { if (PlaySounds()) Sound::GetSound().PlaySoundEffect(GetOptionsDB().Get<std::string>("UI.sound.system-icon-rollover")); }
 
     // Wrap content int an rgba tag with color color. Opacity ignored.
     std::string ColorTag(const std::string& content, GG::Clr color){

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -132,7 +132,7 @@ void AIClientApp::Run() {
                 if (!Networking().IsRxConnected())
                     break;
                 if (Networking().MessageAvailable()) {
-                    Message msg;
+                    MessagePacket msg;
                     Networking().GetMessage(msg);
                     HandleMessage(msg);
                 } else {
@@ -181,15 +181,15 @@ void AIClientApp::HandlePythonAICrash() {
 }
 
 
-void AIClientApp::HandleMessage(const Message& msg) {
+void AIClientApp::HandleMessage(const MessagePacket& msg) {
     //DebugLogger() << "AIClientApp::HandleMessage " << msg.Type();
     switch (msg.Type()) {
-    case Message::ERROR_MSG: {
+    case MessagePacket::ERROR_MSG: {
         ErrorLogger() << "AIClientApp::HandleMessage : Received ERROR message from server: " << msg.Text();
         break;
     }
 
-    case Message::HOST_ID: {
+    case MessagePacket::HOST_ID: {
         const std::string& text = msg.Text();
         int host_id = Networking::INVALID_PLAYER_ID;
         if (text.empty()) {
@@ -205,7 +205,7 @@ void AIClientApp::HandleMessage(const Message& msg) {
         break;
     }
 
-    case Message::JOIN_GAME: {
+    case MessagePacket::JOIN_GAME: {
         if (msg.SendingPlayer() == Networking::INVALID_PLAYER_ID) {
             if (PlayerID() == Networking::INVALID_PLAYER_ID) {
                 DebugLogger() << "AIClientApp::HandleMessage : Received JOIN_GAME acknowledgement";
@@ -217,7 +217,7 @@ void AIClientApp::HandleMessage(const Message& msg) {
         break;
     }
 
-    case Message::GAME_START: {
+    case MessagePacket::GAME_START: {
         if (msg.SendingPlayer() == Networking::INVALID_PLAYER_ID) {
             DebugLogger() << "AIClientApp::HandleMessage : Received GAME_START message; starting AI turn...";
             bool single_player_game;        // ignored
@@ -305,17 +305,17 @@ void AIClientApp::HandleMessage(const Message& msg) {
         break;
     }
 
-    case Message::SAVE_GAME_DATA_REQUEST: {
-        //DebugLogger() << "AIClientApp::HandleMessage Message::SAVE_GAME_DATA_REQUEST";
+    case MessagePacket::SAVE_GAME_DATA_REQUEST: {
+        //DebugLogger() << "AIClientApp::HandleMessage MessagePacket::SAVE_GAME_DATA_REQUEST";
         Networking().SendMessage(ClientSaveDataMessage(PlayerID(), Orders(), m_AI->GetSaveStateString()));
         //DebugLogger() << "AIClientApp::HandleMessage sent save data message";
         break;
     }
 
-    case Message::SAVE_GAME_COMPLETE:
+    case MessagePacket::SAVE_GAME_COMPLETE:
         break;
 
-    case Message::TURN_UPDATE: {
+    case MessagePacket::TURN_UPDATE: {
         if (msg.SendingPlayer() == Networking::INVALID_PLAYER_ID) {
             //DebugLogger() << "AIClientApp::HandleMessage : extracting turn update message data";
             ExtractTurnUpdateMessageData(msg,                     m_empire_id,        m_current_turn,
@@ -329,16 +329,16 @@ void AIClientApp::HandleMessage(const Message& msg) {
         break;
     }
 
-    case Message::TURN_PARTIAL_UPDATE:
+    case MessagePacket::TURN_PARTIAL_UPDATE:
         if (msg.SendingPlayer() == Networking::INVALID_PLAYER_ID)
             ExtractTurnPartialUpdateMessageData(msg, m_empire_id, m_universe);
         break;
 
-    case Message::TURN_PROGRESS:
-    case Message::PLAYER_STATUS:
+    case MessagePacket::TURN_PROGRESS:
+    case MessagePacket::PLAYER_STATUS:
         break;
 
-    case Message::END_GAME: {
+    case MessagePacket::END_GAME: {
         DebugLogger() << "Message::END_GAME : Exiting";
         DebugLogger() << "Acknowledge server shutdown message.";
         Networking().SendMessage(AIEndGameAcknowledgeMessage(Networking().PlayerID()));
@@ -346,18 +346,18 @@ void AIClientApp::HandleMessage(const Message& msg) {
         break;
     }
 
-    case Message::PLAYER_CHAT:
+    case MessagePacket::PLAYER_CHAT:
         m_AI->HandleChatMessage(msg.SendingPlayer(), msg.Text());
         break;
 
-    case Message::DIPLOMACY: {
+    case MessagePacket::DIPLOMACY: {
         DiplomaticMessage diplo_message;
         ExtractDiplomacyMessageData(msg, diplo_message);
         m_AI->HandleDiplomaticMessage(diplo_message);
         break;
     }
 
-    case Message::DIPLOMATIC_STATUS: {
+    case MessagePacket::DIPLOMATIC_STATUS: {
         DiplomaticStatusUpdateInfo diplo_update;
         ExtractDiplomaticStatusMessageData(msg, diplo_update);
         m_AI->HandleDiplomaticStatusUpdate(diplo_update);
@@ -365,7 +365,7 @@ void AIClientApp::HandleMessage(const Message& msg) {
     }
 
     default: {
-        ErrorLogger() << "AIClientApp::HandleMessage : Received unknown Message type code " << msg.Type();
+        ErrorLogger() << "AIClientApp::HandleMessage : Received unknown MessagePacket type code " << msg.Type();
         break;
     }
     }

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -9,6 +9,7 @@
 #include "../../util/i18n.h"
 #include "../util/AppInterface.h"
 #include "../../network/Message.h"
+#include "../../network/ClientNetworking.h"
 #include "../util/Random.h"
 
 #include "../../universe/System.h"

--- a/client/AI/AIClientApp.h
+++ b/client/AI/AIClientApp.h
@@ -39,7 +39,7 @@ private:
     void                ConnectToServer();
     void                StartPythonAI();
     void                HandlePythonAICrash();
-    void                HandleMessage(const Message& msg);
+    void                HandleMessage(const MessagePacket& msg);
 
 
     /** Implementation of AI logic. */

--- a/client/ClientApp.cpp
+++ b/client/ClientApp.cpp
@@ -7,6 +7,7 @@
 #include "../Empire/Empire.h"
 #include "../Empire/EmpireManager.h"
 #include "../network/Networking.h"
+#include "../network/ClientNetworking.h"
 
 #include <stdexcept>
 #include <boost/bind.hpp>

--- a/client/ClientApp.cpp
+++ b/client/ClientApp.cpp
@@ -104,13 +104,13 @@ const std::map<int, PlayerInfo>& ClientApp::Players() const
 std::map<int, PlayerInfo>& ClientApp::Players()
 { return m_player_info; }
 
-const std::map<int, Message::PlayerStatus>& ClientApp::PlayerStatus() const
+const std::map<int, MessagePacket::PlayerStatus>& ClientApp::PlayerStatus() const
 { return m_player_status; }
 
-std::map<int, Message::PlayerStatus>& ClientApp::PlayerStatus()
+std::map<int, MessagePacket::PlayerStatus>& ClientApp::PlayerStatus()
 { return m_player_status; }
 
-void ClientApp::SetPlayerStatus(int player_id, Message::PlayerStatus status) {
+void ClientApp::SetPlayerStatus(int player_id, MessagePacket::PlayerStatus status) {
     if (player_id == Networking::INVALID_PLAYER_ID)
         return;
     m_player_status[player_id] = status;
@@ -141,7 +141,7 @@ std::string ClientApp::GetVisibleObjectName(std::shared_ptr<const UniverseObject
 }
 
 int ClientApp::GetNewObjectID() {
-    Message msg;
+    MessagePacket msg;
     m_networking->SendSynchronousMessage(RequestNewObjectIDMessage(m_networking->PlayerID()), msg);
     std::string text = msg.Text();
     if (text.empty())
@@ -150,7 +150,7 @@ int ClientApp::GetNewObjectID() {
 }
 
 int ClientApp::GetNewDesignID() {
-    Message msg;
+    MessagePacket msg;
     m_networking->SendSynchronousMessage(RequestNewDesignIDMessage(m_networking->PlayerID()), msg);
     std::string text = msg.Text();
     if (text.empty())

--- a/client/ClientApp.h
+++ b/client/ClientApp.h
@@ -3,12 +3,13 @@
 
 #include "../Empire/EmpireManager.h"
 #include "../Empire/Supply.h"
-#include "../network/ClientNetworking.h"
 #include "../network/Message.h"
 #include "../universe/Universe.h"
 #include "../util/OrderSet.h"
 #include "../util/AppInterface.h"
 #include "../util/MultiplayerCommon.h"
+
+class ClientNetworking;
 
 /** \brief Abstract base class for the application framework classes
  *

--- a/client/ClientApp.h
+++ b/client/ClientApp.h
@@ -4,6 +4,7 @@
 #include "../Empire/EmpireManager.h"
 #include "../Empire/Supply.h"
 #include "../network/ClientNetworking.h"
+#include "../network/Message.h"
 #include "../universe/Universe.h"
 #include "../util/OrderSet.h"
 #include "../util/AppInterface.h"

--- a/client/ClientApp.h
+++ b/client/ClientApp.h
@@ -68,8 +68,8 @@ public:
      *      their player identifier as key.
      *
      * @{ */
-    std::map<int, Message::PlayerStatus>& PlayerStatus();
-    const std::map<int, Message::PlayerStatus>& PlayerStatus() const;
+    std::map<int, MessagePacket::PlayerStatus>& PlayerStatus();
+    const std::map<int, MessagePacket::PlayerStatus>& PlayerStatus() const;
     /** @} */
 
     /** @brief Return the ::Universe known to this client
@@ -219,13 +219,13 @@ public:
      */
     void SetSinglePlayerGame(bool single_player = true);
 
-    /** @brief Set the Message::PlayerStatus @a status for @a player_id
+    /** @brief Set the MessagePacket::PlayerStatus @a status for @a player_id
      *
      * @param player_id A player identifier.
-     * @param status The new Message::PlayerStatus of the player identified by
+     * @param status The new MessagePacket::PlayerStatus of the player identified by
      *      @a player_id.
      */
-    void SetPlayerStatus(int player_id, Message::PlayerStatus status);
+    void SetPlayerStatus(int player_id, MessagePacket::PlayerStatus status);
 
     /** @brief Return a new universe object identifier
      *
@@ -268,7 +268,7 @@ protected:
     /** Indexed by player id, contains the last known PlayerStatus for each
      *      player.
      */
-    std::map<int, Message::PlayerStatus>
+    std::map<int, MessagePacket::PlayerStatus>
                                 m_player_status;
 
 private:

--- a/client/ClientFSMEvents.cpp
+++ b/client/ClientFSMEvents.cpp
@@ -1,5 +1,5 @@
 #include "ClientFSMEvents.h"
 
 
-MessageEventBase::MessageEventBase(Message& message)
+MessageEventBase::MessageEventBase(MessagePacket& message)
 { swap(m_message, message); }

--- a/client/ClientFSMEvents.h
+++ b/client/ClientFSMEvents.h
@@ -11,16 +11,16 @@
 struct Disconnection : boost::statechart::event<Disconnection> {};
 
 
-//  Message events
+//  MessagePacket events
 /** The base class for all state machine events that are based on Messages. */
 struct MessageEventBase
 {
-    MessageEventBase(Message& message);
+    MessageEventBase(MessagePacket& message);
 
-    Message m_message;
+    MessagePacket m_message;
 };
 
-// Define Boost.Preprocessor list of all Message events
+// Define Boost.Preprocessor list of all MessagePacket events
 #define MESSAGE_EVENTS                         \
     (DispatchCombatLogs)                       \
     (Error)                                    \
@@ -48,7 +48,7 @@ struct MessageEventBase
         boost::statechart::event<name>,                                 \
         MessageEventBase                                                \
     {                                                                   \
-        name(Message& message) : MessageEventBase(message) {}           \
+        name(MessagePacket& message) : MessageEventBase(message) {}           \
     };
 
 BOOST_PP_SEQ_FOR_EACH(DECLARE_MESSAGE_EVENT, _, MESSAGE_EVENTS)

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -77,11 +77,11 @@ void SigHandler(int sig) {
         close(fd);
     }
 
-    // Now we try to display a MessageBox; this might fail and also
+    // Now we try to display a MessagePopup; this might fail and also
     // corrupt the heap, but since we're dying anyway that's no big
     // deal
 
-    ClientUI::MessageBox("The client has just crashed!\nFile a bug report and\nattach the file called 'crash.txt'\nif necessary", true);
+    ClientUI::MessagePopup("The client has just crashed!\nFile a bug report and\nattach the file called 'crash.txt'\nif necessary", true);
 
     raise(sig);
 }
@@ -299,7 +299,7 @@ HumanClientApp::HumanClientApp(int width, int height, bool calculate_fps, const 
 
     // Placed after mouse initialization.
     if (inform_user_sound_failed)
-        ClientUI::MessageBox(UserString("ERROR_SOUND_INITIALIZATION_FAILED"), false);
+        ClientUI::MessagePopup(UserString("ERROR_SOUND_INITIALIZATION_FAILED"), false);
 
     // Register LinkText tags with GG::Font
     RegisterLinkTags();
@@ -426,7 +426,7 @@ void HumanClientApp::NewSinglePlayerGame(bool quickstart) {
             StartServer();
         } catch (const std::runtime_error& err) {
             ErrorLogger() << "HumanClientApp::NewSinglePlayerGame : Couldn't start server.  Got error message: " << err.what();
-            ClientUI::MessageBox(UserString("SERVER_WONT_START"), true);
+            ClientUI::MessagePopup(UserString("SERVER_WONT_START"), true);
             return;
         }
     }
@@ -441,7 +441,7 @@ void HumanClientApp::NewSinglePlayerGame(bool quickstart) {
     m_connected = m_networking->ConnectToLocalHostServer();
     if (!m_connected) {
         ResetToIntro();
-        ClientUI::MessageBox(UserString("ERR_CONNECT_TIMED_OUT"), true);
+        ClientUI::MessagePopup(UserString("ERR_CONNECT_TIMED_OUT"), true);
         return;
     }
 
@@ -551,7 +551,7 @@ void HumanClientApp::MultiPlayerGame() {
                 FreeServer();
             } catch (const std::runtime_error& err) {
                 ErrorLogger() << "Couldn't start server.  Got error message: " << err.what();
-                ClientUI::MessageBox(UserString("SERVER_WONT_START"), true);
+                ClientUI::MessagePopup(UserString("SERVER_WONT_START"), true);
                 return;
             }
             server_name = "localhost";
@@ -562,7 +562,7 @@ void HumanClientApp::MultiPlayerGame() {
 
     m_connected = m_networking->ConnectToServer(server_name);
     if (!m_connected) {
-        ClientUI::MessageBox(UserString("ERR_CONNECT_TIMED_OUT"), true);
+        ClientUI::MessagePopup(UserString("ERR_CONNECT_TIMED_OUT"), true);
         if (server_connect_wnd.Result().second == "HOST GAME SELECTED")
             ResetToIntro();
         return;
@@ -614,7 +614,7 @@ void HumanClientApp::LoadSinglePlayerGame(std::string filename/* = ""*/) {
             if (!sfd.Result().empty())
                 filename = sfd.Result();
         } catch (const std::exception& e) {
-            ClientUI::MessageBox(e.what(), true);
+            ClientUI::MessagePopup(e.what(), true);
         }
     }
 
@@ -645,7 +645,7 @@ void HumanClientApp::LoadSinglePlayerGame(std::string filename/* = ""*/) {
     m_connected = m_networking->ConnectToLocalHostServer();
     if (!m_connected) {
         ResetToIntro();
-        ClientUI::MessageBox(UserString("ERR_CONNECT_TIMED_OUT"), true);
+        ClientUI::MessagePopup(UserString("ERR_CONNECT_TIMED_OUT"), true);
         return;
     }
 
@@ -679,7 +679,7 @@ void HumanClientApp::RequestSavePreviews(const std::string& directory, PreviewIn
         m_connected = m_networking->ConnectToLocalHostServer();
         if (!m_connected) {
             ResetToIntro();
-            ClientUI::MessageBox(UserString("ERR_CONNECT_TIMED_OUT"), true);
+            ClientUI::MessagePopup(UserString("ERR_CONNECT_TIMED_OUT"), true);
             return;
         }
     }

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -16,6 +16,7 @@
 #include "../../UI/Sound.h"
 #include "../../network/Message.h"
 #include "../../network/Networking.h"
+#include "../../network/ClientNetworking.h"
 #include "../../util/i18n.h"
 #include "../../util/MultiplayerCommon.h"
 #include "../../util/OptionsDB.h"

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -341,13 +341,13 @@ bool HumanClientApp::CanSaveNow() const {
         if (info.client_type != Networking::CLIENT_TYPE_AI_PLAYER)
             continue;   // only care about AIs
 
-        std::map<int, Message::PlayerStatus>::const_iterator
+        std::map<int, MessagePacket::PlayerStatus>::const_iterator
             status_it = m_player_status.find(entry.first);
 
         if (status_it == this->m_player_status.end()) {
             return false;  // missing status for AI; can't assume it's ready
         }
-        if (status_it->second != Message::WAITING) {
+        if (status_it->second != MessagePacket::WAITING) {
             return false;
         }
     }
@@ -585,7 +585,7 @@ void HumanClientApp::CancelMultiplayerGameFromLobby()
 
 void HumanClientApp::SaveGame(const std::string& filename) {
     m_save_game_in_progress = true;
-    Message response_msg;
+    MessagePacket response_msg;
     m_networking->SendMessage(HostSaveGameInitiateMessage(PlayerID(), filename));
     DebugLogger() << "HumanClientApp::SaveGame sent save initiate message to server...";
 }
@@ -684,9 +684,9 @@ void HumanClientApp::RequestSavePreviews(const std::string& directory, PreviewIn
         }
     }
     DebugLogger() << "HumanClientApp::RequestSavePreviews Requesting previews for " << generic_directory;
-    Message response;
+    MessagePacket response;
     m_networking->SendSynchronousMessage(RequestSavePreviewsMessage(PlayerID(), generic_directory), response);
-    if (response.Type() == Message::DISPATCH_SAVE_PREVIEWS){
+    if (response.Type() == MessagePacket::DISPATCH_SAVE_PREVIEWS){
         ExtractDispatchSavePreviewsMessageData(response, previews);
         DebugLogger() << "HumanClientApp::RequestSavePreviews Got " << previews.previews.size() << " previews.";
     }else{
@@ -800,7 +800,7 @@ void HumanClientApp::HandleSystemEvents() {
         m_connected = false;
         DisconnectedFromServer();
     } else if (m_networking->MessageAvailable()) {
-        Message msg;
+        MessagePacket msg;
         m_networking->GetMessage(msg);
         try {
             HandleMessage(msg);
@@ -816,32 +816,32 @@ void HumanClientApp::RenderBegin() {
     Sound::GetSound().DoFrame();
 }
 
-void HumanClientApp::HandleMessage(Message& msg) {
+void HumanClientApp::HandleMessage(MessagePacket& msg) {
     if (INSTRUMENT_MESSAGE_HANDLING)
         std::cerr << "HumanClientApp::HandleMessage(" << msg.Type() << ")\n";
 
     switch (msg.Type()) {
-    case Message::ERROR_MSG:                m_fsm->process_event(Error(msg));                   break;
-    case Message::HOST_MP_GAME:             m_fsm->process_event(HostMPGame(msg));              break;
-    case Message::HOST_SP_GAME:             m_fsm->process_event(HostSPGame(msg));              break;
-    case Message::JOIN_GAME:                m_fsm->process_event(JoinGame(msg));                break;
-    case Message::HOST_ID:                  m_fsm->process_event(HostID(msg));                  break;
-    case Message::LOBBY_UPDATE:             m_fsm->process_event(LobbyUpdate(msg));             break;
-    case Message::LOBBY_CHAT:               m_fsm->process_event(LobbyChat(msg));               break;
-    case Message::SAVE_GAME_DATA_REQUEST:   m_fsm->process_event(SaveGameDataRequest(msg));     break;
-    case Message::SAVE_GAME_COMPLETE:       m_fsm->process_event(SaveGameComplete(msg));        break;
+    case MessagePacket::ERROR_MSG:                m_fsm->process_event(Error(msg));                   break;
+    case MessagePacket::HOST_MP_GAME:             m_fsm->process_event(HostMPGame(msg));              break;
+    case MessagePacket::HOST_SP_GAME:             m_fsm->process_event(HostSPGame(msg));              break;
+    case MessagePacket::JOIN_GAME:                m_fsm->process_event(JoinGame(msg));                break;
+    case MessagePacket::HOST_ID:                  m_fsm->process_event(HostID(msg));                  break;
+    case MessagePacket::LOBBY_UPDATE:             m_fsm->process_event(LobbyUpdate(msg));             break;
+    case MessagePacket::LOBBY_CHAT:               m_fsm->process_event(LobbyChat(msg));               break;
+    case MessagePacket::SAVE_GAME_DATA_REQUEST:   m_fsm->process_event(SaveGameDataRequest(msg));     break;
+    case MessagePacket::SAVE_GAME_COMPLETE:       m_fsm->process_event(SaveGameComplete(msg));        break;
 
-    case Message::GAME_START:               m_fsm->process_event(GameStart(msg));               break;
-    case Message::TURN_UPDATE:              m_fsm->process_event(TurnUpdate(msg));              break;
-    case Message::TURN_PARTIAL_UPDATE:      m_fsm->process_event(TurnPartialUpdate(msg));       break;
-    case Message::TURN_PROGRESS:            m_fsm->process_event(TurnProgress(msg));            break;
-    case Message::PLAYER_STATUS:            m_fsm->process_event(::PlayerStatus(msg));          break;
-    case Message::PLAYER_CHAT:              m_fsm->process_event(PlayerChat(msg));              break;
-    case Message::DIPLOMACY:                m_fsm->process_event(Diplomacy(msg));               break;
-    case Message::DIPLOMATIC_STATUS:        m_fsm->process_event(DiplomaticStatusUpdate(msg));  break;
-    case Message::END_GAME:                 m_fsm->process_event(::EndGame(msg));               break;
+    case MessagePacket::GAME_START:               m_fsm->process_event(GameStart(msg));               break;
+    case MessagePacket::TURN_UPDATE:              m_fsm->process_event(TurnUpdate(msg));              break;
+    case MessagePacket::TURN_PARTIAL_UPDATE:      m_fsm->process_event(TurnPartialUpdate(msg));       break;
+    case MessagePacket::TURN_PROGRESS:            m_fsm->process_event(TurnProgress(msg));            break;
+    case MessagePacket::PLAYER_STATUS:            m_fsm->process_event(::PlayerStatus(msg));          break;
+    case MessagePacket::PLAYER_CHAT:              m_fsm->process_event(PlayerChat(msg));              break;
+    case MessagePacket::DIPLOMACY:                m_fsm->process_event(Diplomacy(msg));               break;
+    case MessagePacket::DIPLOMATIC_STATUS:        m_fsm->process_event(DiplomaticStatusUpdate(msg));  break;
+    case MessagePacket::END_GAME:                 m_fsm->process_event(::EndGame(msg));               break;
 
-    case Message::DISPATCH_COMBAT_LOGS:     m_fsm->process_event(DispatchCombatLogs(msg));       break;
+    case MessagePacket::DISPATCH_COMBAT_LOGS:     m_fsm->process_event(DispatchCombatLogs(msg));       break;
     default:
         ErrorLogger() << "HumanClientApp::HandleMessage : Received an unknown message type \"" << msg.Type() << "\".";
     }
@@ -849,13 +849,13 @@ void HumanClientApp::HandleMessage(Message& msg) {
 
 void HumanClientApp::HandleSaveGameDataRequest() {
     if (INSTRUMENT_MESSAGE_HANDLING)
-        std::cerr << "HumanClientApp::HandleSaveGameDataRequest(" << Message::SAVE_GAME_DATA_REQUEST << ")\n";
+        std::cerr << "HumanClientApp::HandleSaveGameDataRequest(" << MessagePacket::SAVE_GAME_DATA_REQUEST << ")\n";
     SaveGameUIData ui_data;
     m_ui->GetSaveGameUIData(ui_data);
     m_networking->SendMessage(ClientSaveDataMessage(PlayerID(), Orders(), ui_data));
 }
 
-void HumanClientApp::UpdateCombatLogs(const Message& msg){
+void HumanClientApp::UpdateCombatLogs(const MessagePacket& msg){
     DebugLogger() << "HCL Update Combat Logs";
 
     // Unpack the combat logs from the message

--- a/client/human/HumanClientApp.h
+++ b/client/human/HumanClientApp.h
@@ -83,7 +83,7 @@ public:
     float               GLVersion() const;
 
     void                HandleSaveGameDataRequest();
-    void                UpdateCombatLogs(const Message& msg);
+    void                UpdateCombatLogs(const MessagePacket& msg);
 
     void                OpenURL(const std::string& url);
     //@}
@@ -108,7 +108,7 @@ private:
 
     void RenderBegin() override;
 
-    void            HandleMessage(Message& msg);
+    void            HandleMessage(MessagePacket& msg);
 
     void            HandleWindowMove(GG::X w, GG::Y h);
     void            HandleWindowResize(GG::X w, GG::Y h);

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -502,7 +502,7 @@ boost::statechart::result PlayingGame::react(const Disconnection& d) {
 boost::statechart::result PlayingGame::react(const PlayerStatus& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) PlayingGame.PlayerStatus";
     int about_player_id;
-    Message::PlayerStatus status;
+    MessagePacket::PlayerStatus status;
     ExtractPlayerStatusMessageData(msg.m_message, about_player_id, status);
 
     Client().SetPlayerStatus(about_player_id, status);
@@ -535,16 +535,16 @@ boost::statechart::result PlayingGame::react(const DiplomaticStatusUpdate& u) {
 
 boost::statechart::result PlayingGame::react(const EndGame& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) PlayingGame.EndGame";
-    Message::EndGameReason reason;
+    MessagePacket::EndGameReason reason;
     std::string reason_player_name;
     ExtractEndGameMessageData(msg.m_message, reason, reason_player_name);
     std::string reason_message;
     bool error = false;
     switch (reason) {
-    case Message::LOCAL_CLIENT_DISCONNECT:
+    case MessagePacket::LOCAL_CLIENT_DISCONNECT:
         reason_message = UserString("SERVER_LOST");
         break;
-    case Message::PLAYER_DISCONNECT:
+    case MessagePacket::PLAYER_DISCONNECT:
         reason_message = boost::io::str(FlexibleFormat(UserString("PLAYER_DISCONNECTED")) % reason_player_name);
         error = true;
         break;
@@ -588,7 +588,7 @@ boost::statechart::result PlayingGame::react(const Error& msg) {
 boost::statechart::result PlayingGame::react(const TurnProgress& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) PlayingGame.TurnProgress";
 
-    Message::TurnProgressPhase phase_id;
+    MessagePacket::TurnProgressPhase phase_id;
     ExtractTurnProgressMessageData(msg.m_message, phase_id);
     Client().GetClientUI().GetMessageWnd()->HandleTurnPhaseUpdate(phase_id);
 
@@ -748,9 +748,9 @@ PlayingTurn::PlayingTurn(my_context ctx) :
     // TODO: reselect last fleet if stored in save game ui data?
     Client().GetClientUI().GetMessageWnd()->HandleGameStatusUpdate(
         boost::io::str(FlexibleFormat(UserString("TURN_BEGIN")) % CurrentTurn()) + "\n");
-    Client().GetClientUI().GetMessageWnd()->HandlePlayerStatusUpdate(Message::PLAYING_TURN, Client().PlayerID());
+    Client().GetClientUI().GetMessageWnd()->HandlePlayerStatusUpdate(MessagePacket::PLAYING_TURN, Client().PlayerID());
     Client().GetClientUI().GetPlayerListWnd()->Refresh();
-    Client().GetClientUI().GetPlayerListWnd()->HandlePlayerStatusUpdate(Message::PLAYING_TURN, Client().PlayerID());
+    Client().GetClientUI().GetPlayerListWnd()->HandlePlayerStatusUpdate(MessagePacket::PLAYING_TURN, Client().PlayerID());
 
     if (Client().GetApp()->GetClientType() != Networking::CLIENT_TYPE_HUMAN_OBSERVER)
         Client().GetClientUI().GetMapWnd()->EnableOrderIssuing(true);
@@ -836,7 +836,7 @@ boost::statechart::result PlayingTurn::react(const TurnEnded& msg) {
 boost::statechart::result PlayingTurn::react(const PlayerStatus& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) PlayingTurn.PlayerStatus";
     int about_player_id;
-    Message::PlayerStatus status;
+    MessagePacket::PlayerStatus status;
     ExtractPlayerStatusMessageData(msg.m_message, about_player_id, status);
 
     Client().SetPlayerStatus(about_player_id, status);
@@ -848,7 +848,7 @@ boost::statechart::result PlayingTurn::react(const PlayerStatus& msg) {
     {
         // check status of all non-mod non-obs players: are they all done their turns?
         bool all_participants_waiting = true;
-        const std::map<int, Message::PlayerStatus>& player_status = Client().PlayerStatus();
+        const std::map<int, MessagePacket::PlayerStatus>& player_status = Client().PlayerStatus();
         for (std::map<int, PlayerInfo>::value_type& entry : Client().Players()) {
             int player_id = entry.first;
 
@@ -856,12 +856,12 @@ boost::statechart::result PlayingTurn::react(const PlayerStatus& msg) {
                 entry.second.client_type != Networking::CLIENT_TYPE_HUMAN_PLAYER)
             { continue; }   // only active participants matter...
 
-            std::map<int, Message::PlayerStatus>::const_iterator status_it = player_status.find(player_id);
+            std::map<int, MessagePacket::PlayerStatus>::const_iterator status_it = player_status.find(player_id);
             if (status_it == player_status.end()) {
                 all_participants_waiting = false;
                 break;
             }
-            if (status_it->second != Message::WAITING) {
+            if (status_it->second != MessagePacket::WAITING) {
                 all_participants_waiting = false;
                 break;
             }

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -166,7 +166,7 @@ boost::statechart::result WaitingForSPHostAck::react(const Disconnection& d) {
     // See reaction_transition_note.
     auto retval = discard_event();
     Client().ResetToIntro();
-    ClientUI::MessageBox(UserString("SERVER_LOST"), true);
+    ClientUI::MessagePopup(UserString("SERVER_LOST"), true);
     return retval;
 }
 
@@ -185,7 +185,7 @@ boost::statechart::result WaitingForSPHostAck::react(const Error& msg) {
     auto retval = discard_event();
     if (fatal) {
         Client().ResetToIntro();
-        ClientUI::MessageBox(UserString(problem), true);
+        ClientUI::MessagePopup(UserString(problem), true);
         client.GetClientUI().GetMessageWnd()->HandleGameStatusUpdate(UserString("RETURN_TO_INTRO") + "\n");
     }
     return retval;
@@ -226,7 +226,7 @@ boost::statechart::result WaitingForMPHostAck::react(const Disconnection& d) {
     // See reaction_transition_note.
     auto retval = discard_event();
     Client().ResetToIntro();
-    ClientUI::MessageBox(UserString("SERVER_LOST"), true);
+    ClientUI::MessagePopup(UserString("SERVER_LOST"), true);
     return retval;
 }
 
@@ -245,7 +245,7 @@ boost::statechart::result WaitingForMPHostAck::react(const Error& msg) {
     auto retval = discard_event();
     if (fatal) {
         Client().ResetToIntro();
-        ClientUI::MessageBox(UserString(problem), true);
+        ClientUI::MessagePopup(UserString(problem), true);
         client.GetClientUI().GetMessageWnd()->HandleGameStatusUpdate(UserString("RETURN_TO_INTRO") + "\n");
     }
     return retval;
@@ -285,7 +285,7 @@ boost::statechart::result WaitingForMPJoinAck::react(const Disconnection& d) {
     // See reaction_transition_note.
     auto retval = discard_event();
     Client().ResetToIntro();
-    ClientUI::MessageBox(UserString("SERVER_LOST"), true);
+    ClientUI::MessagePopup(UserString("SERVER_LOST"), true);
     return retval;
 }
 
@@ -304,7 +304,7 @@ boost::statechart::result WaitingForMPJoinAck::react(const Error& msg) {
     auto retval = discard_event();
     if (fatal) {
         Client().ResetToIntro();
-        ClientUI::MessageBox(UserString(problem), true);
+        ClientUI::MessagePopup(UserString(problem), true);
         client.GetClientUI().GetMessageWnd()->HandleGameStatusUpdate(UserString("RETURN_TO_INTRO") + "\n");
     }
 
@@ -342,7 +342,7 @@ boost::statechart::result MPLobby::react(const Disconnection& d) {
     // See reaction_transition_note.
     auto retval = discard_event();
     Client().ResetToIntro();
-    ClientUI::MessageBox(UserString("SERVER_LOST"), true);
+    ClientUI::MessagePopup(UserString("SERVER_LOST"), true);
     return retval;
 }
 
@@ -424,7 +424,7 @@ boost::statechart::result MPLobby::react(const Error& msg) {
     auto retval = discard_event();
     if (fatal) {
         Client().ResetToIntro();
-        ClientUI::MessageBox(UserString(problem), true);
+        ClientUI::MessagePopup(UserString(problem), true);
     }
 
     return retval;
@@ -495,7 +495,7 @@ boost::statechart::result PlayingGame::react(const Disconnection& d) {
     // See reaction_transition_note.
     auto retval = discard_event();
     Client().ResetToIntro();
-    ClientUI::MessageBox(UserString("SERVER_LOST"), true);
+    ClientUI::MessagePopup(UserString("SERVER_LOST"), true);
     return retval;
 }
 
@@ -553,7 +553,7 @@ boost::statechart::result PlayingGame::react(const EndGame& msg) {
     // See reaction_transition_note.
     auto retval = discard_event();
     Client().ResetToIntro();
-    ClientUI::MessageBox(reason_message, error);
+    ClientUI::MessagePopup(reason_message, error);
     return retval;
 }
 
@@ -580,7 +580,7 @@ boost::statechart::result PlayingGame::react(const Error& msg) {
     if (fatal)
         Client().ResetToIntro();
 
-    ClientUI::MessageBox(UserString(problem), fatal);
+    ClientUI::MessagePopup(UserString(problem), fatal);
 
     return retval;
 }

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -5,6 +5,7 @@
 #include "../../universe/System.h"
 #include "../../universe/Species.h"
 #include "../../network/Networking.h"
+#include "../../network/ClientNetworking.h"
 #include "../../util/i18n.h"
 #include "../../util/MultiplayerCommon.h"
 #include "../../util/OptionsDB.h"

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -2,6 +2,21 @@
 
 #include "ClientNetworking.h"
 
+#include "Message.h"
+#include "MessageQueue.h"
+
+// boost::asio pulls in windows.h which in turn defines the macros Message,
+// MessageBox, min and max. Disabling the generation of the min and max macros
+// and undefining those should avoid name collisions with std c++ library and
+// FreeOrion function names.
+#define NOMINMAX
+#include <boost/asio.hpp>
+#include <boost/asio/high_resolution_timer.hpp>
+#ifdef FREEORION_WIN32
+#   undef Message
+#   undef MessageBox
+#endif
+
 #include "Networking.h"
 #include "../util/Logger.h"
 #include "../util/MultiplayerCommon.h"
@@ -119,10 +134,125 @@ namespace {
     };
 }
 
+
+
+class ClientNetworking::Impl {
+public:
+    /** The type of list returned by a call to DiscoverLANServers(). */
+    typedef std::vector<std::pair<boost::asio::ip::address, std::string> >  ServerList;
+
+    /** \name Structors */ //@{
+    Impl();
+    //@}
+
+    /** \name Accessors */ //@{
+    /** Returns true iff the client is full duplex connected to the server. */
+    bool IsConnected() const;
+
+    /** Returns true iff the client is connected to receive from the server. */
+    bool IsRxConnected() const;
+
+    /** Returns true iff the client is connected to send to the server. */
+    bool IsTxConnected() const;
+
+    /** Returns true iff there is at least one incoming message available. */
+    bool MessageAvailable() const;
+
+    /** Returns the ID of the player on this client. */
+    int PlayerID() const;
+
+    /** Returns the ID of the host player, or INVALID_PLAYER_ID if there is no host player. */
+    int HostPlayerID() const;
+
+    /** Returns whether the indicated player ID is the host. */
+    bool PlayerIsHost(int player_id) const;
+    //@}
+
+    /** \name Mutators */ //@{
+    /** Returns a list of the addresses and names of all servers on the Local
+        Area Network. */
+    ServerList DiscoverLANServers();
+
+    /** Connects to the server at \a ip_address.  On failure, repeated
+        attempts will be made until \a timeout seconds has elapsed. */
+    bool ConnectToServer(const ClientNetworking* const self,
+                         const std::string& ip_address,
+                         std::chrono::milliseconds timeout = std::chrono::seconds(10));
+
+    /** Connects to the server on the client's host.  On failure, repeated
+        attempts will be made until \a timeout seconds has elapsed. */
+    bool ConnectToLocalHostServer(const ClientNetworking* const self,
+                                  std::chrono::milliseconds timeout =
+                                  std::chrono::seconds(10));
+
+    /** Sends \a message to the server.  This function actually just enqueues
+        the message for sending and returns immediately. */
+    void SendMessage(const Message& message);
+
+    /** Gets the next incoming message from the server, places it into \a
+        message, and removes it from the incoming message queue.  The function
+        assumes that there is at least one message in the incoming queue.
+        Users must call MessageAvailable() first to make sure this is the
+        case. */
+    void GetMessage(Message& message);
+
+    /** Sends \a message to the server, then blocks until it sees the first
+        synchronous response from the server. */
+    void SendSynchronousMessage(const Message& message, Message& response_message);
+
+    /** Disconnects the client from the server. */
+    void DisconnectFromServer();
+
+    /** Sets player ID for this client. */
+    void SetPlayerID(int player_id);
+
+    /** Sets Host player ID. */
+    void SetHostPlayerID(int host_player_id);
+    //@}
+
+private:
+    void HandleException(const boost::system::system_error& error);
+    void HandleConnection(boost::asio::ip::tcp::resolver::iterator* it,
+                          const boost::system::error_code& error);
+    void CancelRetries();
+    void NetworkingThread(const std::shared_ptr<const ClientNetworking>& self);
+    void HandleMessageBodyRead(const std::shared_ptr<const ClientNetworking>& keep_alive,
+                               boost::system::error_code error, std::size_t bytes_transferred);
+    void HandleMessageHeaderRead(const std::shared_ptr<const ClientNetworking>& keep_alive,
+                                 boost::system::error_code error, std::size_t bytes_transferred);
+    void AsyncReadMessage(const std::shared_ptr<const ClientNetworking>& keep_alive);
+    void HandleMessageWrite(        boost::system::error_code error, std::size_t bytes_transferred);
+    void AsyncWriteMessage();
+    void SendMessageImpl(Message message);
+    void DisconnectFromServerImpl();
+
+    int                             m_player_id;
+    int                             m_host_player_id;
+
+    boost::asio::io_service         m_io_service;
+    boost::asio::ip::tcp::socket    m_socket;
+
+    // m_mutex guards m_incoming_message, m_rx_connected and m_tx_connected which are written by
+    // the networking thread and read by the main thread to check incoming messages and connection
+    // status. As those read and write operations are not atomic, shared access has to be
+    // protected to prevent unpredictable results.
+    mutable boost::mutex            m_mutex;
+
+    MessageQueue                    m_incoming_messages; // accessed from multiple threads, but its interface is threadsafe
+    std::list<Message>              m_outgoing_messages;
+    bool                            m_rx_connected;      // accessed from multiple threads
+    bool                            m_tx_connected;      // accessed from multiple threads
+
+    Message::HeaderBuffer           m_incoming_header;
+    Message                         m_incoming_message;
+    Message::HeaderBuffer           m_outgoing_header;
+};
+
+
 ////////////////////////////////////////////////
-// ClientNetworking
+// ClientNetworking Impl
 ////////////////////////////////////////////////
-ClientNetworking::ClientNetworking() :
+ClientNetworking::Impl::Impl() :
     m_player_id(Networking::INVALID_PLAYER_ID),
     m_host_player_id(Networking::INVALID_PLAYER_ID),
     m_io_service(),
@@ -132,37 +262,37 @@ ClientNetworking::ClientNetworking() :
     m_tx_connected(false)
 {}
 
-bool ClientNetworking::IsConnected() const {
+bool ClientNetworking::Impl::IsConnected() const {
     boost::mutex::scoped_lock lock(m_mutex);
     return m_rx_connected && m_tx_connected;
 }
 
-bool ClientNetworking::IsRxConnected() const {
+bool ClientNetworking::Impl::IsRxConnected() const {
     boost::mutex::scoped_lock lock(m_mutex);
     return m_rx_connected;
 }
 
-bool ClientNetworking::IsTxConnected() const {
+bool ClientNetworking::Impl::IsTxConnected() const {
     boost::mutex::scoped_lock lock(m_mutex);
     return m_tx_connected;
 }
 
-bool ClientNetworking::MessageAvailable() const
+bool ClientNetworking::Impl::MessageAvailable() const
 { return !m_incoming_messages.Empty(); }
 
-int ClientNetworking::PlayerID() const
+int ClientNetworking::Impl::PlayerID() const
 { return m_player_id; }
 
-int ClientNetworking::HostPlayerID() const
+int ClientNetworking::Impl::HostPlayerID() const
 { return m_host_player_id; }
 
-bool ClientNetworking::PlayerIsHost(int player_id) const {
+bool ClientNetworking::Impl::PlayerIsHost(int player_id) const {
     if (player_id == Networking::INVALID_PLAYER_ID)
         return false;
     return player_id == m_host_player_id;
 }
 
-ClientNetworking::ServerList ClientNetworking::DiscoverLANServers() {
+ClientNetworking::ServerList ClientNetworking::Impl::DiscoverLANServers() {
     if (!IsConnected())
         return ServerList();
     ServerDiscoverer discoverer(m_io_service);
@@ -170,7 +300,8 @@ ClientNetworking::ServerList ClientNetworking::DiscoverLANServers() {
     return discoverer.Servers();
 }
 
-bool ClientNetworking::ConnectToServer(
+bool ClientNetworking::Impl::ConnectToServer(
+    const ClientNetworking* const self,
     const std::string& ip_address,
     std::chrono::milliseconds timeout/* = std::chrono::seconds(10)*/)
 {
@@ -198,7 +329,7 @@ bool ClientNetworking::ConnectToServer(
             for (tcp::resolver::iterator it = resolver.resolve(query); it != end_it; ++it) {
                 m_socket.close();
 
-                m_socket.async_connect(*it, boost::bind(&ClientNetworking::HandleConnection, this,
+                m_socket.async_connect(*it, boost::bind(&ClientNetworking::Impl::HandleConnection, this,
                                                         &it,
                                                         boost::asio::placeholders::error));
                 m_io_service.run();
@@ -235,8 +366,7 @@ bool ClientNetworking::ConnectToServer(
                                   << std::chrono::duration_cast<std::chrono::milliseconds>(connection_time).count() << " ms.";
 
                     DebugLogger() << "ConnectToServer() : starting networking thread";
-                    auto self = shared_from_this();
-                    boost::thread(boost::bind(&ClientNetworking::NetworkingThread, this, self));
+                    boost::thread(boost::bind(&ClientNetworking::Impl::NetworkingThread, this, self->shared_from_this()));
                     break;
                 } else {
                     if (TRACE_EXECUTION)
@@ -261,14 +391,15 @@ bool ClientNetworking::ConnectToServer(
     return IsConnected();
 }
 
-bool ClientNetworking::ConnectToLocalHostServer(
+bool ClientNetworking::Impl::ConnectToLocalHostServer(
+    const ClientNetworking* const self,
     std::chrono::milliseconds timeout/* = std::chrono::seconds(10)*/)
 {
     bool retval = false;
 #if FREEORION_WIN32
     try {
 #endif
-        retval = ConnectToServer("127.0.0.1", timeout);
+        retval = ConnectToServer(self, "127.0.0.1", timeout);
 #if FREEORION_WIN32
     } catch (const boost::system::system_error& e) {
         if (e.code().value() != WSAEADDRNOTAVAIL)
@@ -278,7 +409,7 @@ bool ClientNetworking::ConnectToLocalHostServer(
     return retval;
 }
 
-void ClientNetworking::DisconnectFromServer() {
+void ClientNetworking::Impl::DisconnectFromServer() {
     bool is_open(false);
 
     { // Create a scope for the mutex
@@ -287,28 +418,28 @@ void ClientNetworking::DisconnectFromServer() {
     }
 
     if (is_open)
-        m_io_service.post(boost::bind(&ClientNetworking::DisconnectFromServerImpl, this));
+        m_io_service.post(boost::bind(&ClientNetworking::Impl::DisconnectFromServerImpl, this));
 }
 
-void ClientNetworking::SetPlayerID(int player_id) {
+void ClientNetworking::Impl::SetPlayerID(int player_id) {
     DebugLogger() << "ClientNetworking::SetPlayerID: player id set to: " << player_id;
     m_player_id = player_id;
 }
 
-void ClientNetworking::SetHostPlayerID(int host_player_id)
+void ClientNetworking::Impl::SetHostPlayerID(int host_player_id)
 { m_host_player_id = host_player_id; }
 
-void ClientNetworking::SendMessage(Message message) {
+void ClientNetworking::Impl::SendMessage(const Message& message) {
     if (!IsTxConnected()) {
         ErrorLogger() << "ClientNetworking::SendMessage can't send message when not transmit connected";
         return;
     }
     if (TRACE_EXECUTION)
         DebugLogger() << "ClientNetworking::SendMessage() : sending message " << message;
-    m_io_service.post(boost::bind(&ClientNetworking::SendMessageImpl, this, message));
+    m_io_service.post(boost::bind(&ClientNetworking::Impl::SendMessageImpl, this, message));
 }
 
-void ClientNetworking::GetMessage(Message& message) {
+void ClientNetworking::Impl::GetMessage(Message& message) {
     if (!MessageAvailable()) {
         ErrorLogger() << "ClientNetworking::GetMessage can't get message if none available";
         return;
@@ -319,7 +450,7 @@ void ClientNetworking::GetMessage(Message& message) {
                       << message;
 }
 
-void ClientNetworking::SendSynchronousMessage(Message message, Message& response_message) {
+void ClientNetworking::Impl::SendSynchronousMessage(const Message& message, Message& response_message) {
     if (TRACE_EXECUTION)
         DebugLogger() << "ClientNetworking::SendSynchronousMessage : sending message "
                                << message;
@@ -331,7 +462,7 @@ void ClientNetworking::SendSynchronousMessage(Message message, Message& response
                                << "response message " << response_message;
 }
 
-void ClientNetworking::HandleConnection(tcp::resolver::iterator* it,
+void ClientNetworking::Impl::HandleConnection(tcp::resolver::iterator* it,
                                         const boost::system::error_code& error)
 {
     if (error) {
@@ -349,7 +480,7 @@ void ClientNetworking::HandleConnection(tcp::resolver::iterator* it,
     }
 }
 
-void ClientNetworking::HandleException(const boost::system::system_error& error) {
+void ClientNetworking::Impl::HandleException(const boost::system::system_error& error) {
     if (error.code() == boost::asio::error::eof) {
         DebugLogger() << "Client connection disconnected by EOF from server.";
         m_socket.close();
@@ -365,7 +496,7 @@ void ClientNetworking::HandleException(const boost::system::system_error& error)
     }
 }
 
-void ClientNetworking::NetworkingThread(std::shared_ptr<ClientNetworking>& self) {
+void ClientNetworking::Impl::NetworkingThread(const std::shared_ptr<const ClientNetworking>& self) {
     auto protect_from_destruction_in_other_thread = self;
     try {
         if (!m_outgoing_messages.empty())
@@ -387,7 +518,7 @@ void ClientNetworking::NetworkingThread(std::shared_ptr<ClientNetworking>& self)
         DebugLogger() << "ClientNetworking::NetworkingThread() : Networking thread terminated.";
 }
 
-void ClientNetworking::HandleMessageBodyRead(const std::shared_ptr<ClientNetworking>& keep_alive,
+void ClientNetworking::Impl::HandleMessageBodyRead(const std::shared_ptr<const ClientNetworking>& keep_alive,
                                              boost::system::error_code error, std::size_t bytes_transferred)
 {
     if (error)
@@ -400,7 +531,7 @@ void ClientNetworking::HandleMessageBodyRead(const std::shared_ptr<ClientNetwork
     }
 }
 
-void ClientNetworking::HandleMessageHeaderRead(const std::shared_ptr<ClientNetworking>& keep_alive,
+void ClientNetworking::Impl::HandleMessageHeaderRead(const std::shared_ptr<const ClientNetworking>& keep_alive,
                                                boost::system::error_code error, std::size_t bytes_transferred)
 {
     if (error)
@@ -415,13 +546,13 @@ void ClientNetworking::HandleMessageHeaderRead(const std::shared_ptr<ClientNetwo
     boost::asio::async_read(
         m_socket,
         boost::asio::buffer(m_incoming_message.Data(), m_incoming_message.Size()),
-        boost::bind(&ClientNetworking::HandleMessageBodyRead,
+        boost::bind(&ClientNetworking::Impl::HandleMessageBodyRead,
                     this, keep_alive,
                     boost::asio::placeholders::error,
                     boost::asio::placeholders::bytes_transferred));
 }
 
-void ClientNetworking::AsyncReadMessage(const std::shared_ptr<ClientNetworking>& keep_alive) {
+void ClientNetworking::Impl::AsyncReadMessage(const std::shared_ptr<const ClientNetworking>& keep_alive) {
     // If keep_alive's count < 2 the networking thread is orphaned so shut down
     if (keep_alive.use_count() < 2)
         DisconnectFromServerImpl();
@@ -429,12 +560,12 @@ void ClientNetworking::AsyncReadMessage(const std::shared_ptr<ClientNetworking>&
     if (m_socket.is_open())
         boost::asio::async_read(
             m_socket, boost::asio::buffer(m_incoming_header),
-            boost::bind(&ClientNetworking::HandleMessageHeaderRead, this, keep_alive,
+            boost::bind(&ClientNetworking::Impl::HandleMessageHeaderRead, this, keep_alive,
                         boost::asio::placeholders::error,
                         boost::asio::placeholders::bytes_transferred));
 }
 
-void ClientNetworking::HandleMessageWrite(boost::system::error_code error, std::size_t bytes_transferred) {
+void ClientNetworking::Impl::HandleMessageWrite(boost::system::error_code error, std::size_t bytes_transferred) {
     if (error) {
         throw boost::system::system_error(error);
         return;
@@ -461,7 +592,7 @@ void ClientNetworking::HandleMessageWrite(boost::system::error_code error, std::
     }
 }
 
-void ClientNetworking::AsyncWriteMessage() {
+void ClientNetworking::Impl::AsyncWriteMessage() {
     if (!m_socket.is_open()) {
         ErrorLogger() << "Socket is closed. Dropping message.";
         return;
@@ -473,12 +604,12 @@ void ClientNetworking::AsyncWriteMessage() {
     buffers.push_back(boost::asio::buffer(m_outgoing_messages.front().Data(),
                                           m_outgoing_messages.front().Size()));
     boost::asio::async_write(m_socket, buffers,
-                             boost::bind(&ClientNetworking::HandleMessageWrite, this,
+                             boost::bind(&ClientNetworking::Impl::HandleMessageWrite, this,
                                          boost::asio::placeholders::error,
                                          boost::asio::placeholders::bytes_transferred));
 }
 
-void ClientNetworking::SendMessageImpl(Message message) {
+void ClientNetworking::Impl::SendMessageImpl(Message message) {
     bool start_write = m_outgoing_messages.empty();
     m_outgoing_messages.push_back(Message());
     swap(m_outgoing_messages.back(), message);
@@ -486,7 +617,7 @@ void ClientNetworking::SendMessageImpl(Message message) {
         AsyncWriteMessage();
 }
 
-void ClientNetworking::DisconnectFromServerImpl() {
+void ClientNetworking::Impl::DisconnectFromServerImpl() {
     // Depending behavior of linger on OS's of the sending and receiving machines this call to close could
     // - immediately disconnect both send and receive channels
     // - immediately disconnect send, but continue receiving until all pending sent packets are
@@ -515,3 +646,65 @@ void ClientNetworking::DisconnectFromServerImpl() {
     if (m_socket.is_open())
         m_socket.shutdown(boost::asio::ip::tcp::socket::shutdown_both);
 }
+
+
+
+////////////////////////////////////////////////
+// ClientNetworking
+////////////////////////////////////////////////
+ClientNetworking::ClientNetworking() :
+    m_impl(new ClientNetworking::Impl())
+{}
+
+ClientNetworking::~ClientNetworking() = default;
+
+bool ClientNetworking::IsConnected() const
+{ return m_impl->IsConnected(); }
+
+bool ClientNetworking::IsRxConnected() const
+{ return m_impl->IsRxConnected(); }
+
+bool ClientNetworking::IsTxConnected() const
+{ return m_impl->IsTxConnected(); }
+
+bool ClientNetworking::MessageAvailable() const
+{ return m_impl->MessageAvailable(); }
+
+int ClientNetworking::PlayerID() const
+{ return m_impl->PlayerID(); }
+
+int ClientNetworking::HostPlayerID() const
+{ return m_impl->HostPlayerID(); }
+
+bool ClientNetworking::PlayerIsHost(int player_id) const
+{ return m_impl->PlayerIsHost(player_id); }
+
+ClientNetworking::ServerList ClientNetworking::DiscoverLANServers()
+{ return m_impl->DiscoverLANServers(); }
+
+bool ClientNetworking::ConnectToServer(
+    const std::string& ip_address,
+    std::chrono::milliseconds timeout/* = std::chrono::seconds(10)*/)
+{ return m_impl->ConnectToServer(this, ip_address, timeout); }
+
+bool ClientNetworking::ConnectToLocalHostServer(
+    std::chrono::milliseconds timeout/* = std::chrono::seconds(10)*/)
+{ return m_impl->ConnectToLocalHostServer(this, timeout); }
+
+void ClientNetworking::DisconnectFromServer()
+{ return m_impl->DisconnectFromServer(); }
+
+void ClientNetworking::SetPlayerID(int player_id)
+{ return m_impl->SetPlayerID(player_id); }
+
+void ClientNetworking::SetHostPlayerID(int host_player_id)
+{ return m_impl->SetHostPlayerID(host_player_id); }
+
+void ClientNetworking::SendMessage(const Message& message)
+{ return m_impl->SendMessage(message); }
+
+void ClientNetworking::GetMessage(Message& message)
+{ m_impl->GetMessage(message); }
+
+void ClientNetworking::SendSynchronousMessage(const Message& message, Message& response_message)
+{ m_impl->SendSynchronousMessage(message, response_message); }

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -5,17 +5,12 @@
 #include "Message.h"
 #include "MessageQueue.h"
 
-// boost::asio pulls in windows.h which in turn defines the macros Message,
-// MessageBox, min and max. Disabling the generation of the min and max macros
-// and undefining those should avoid name collisions with std c++ library and
-// FreeOrion function names.
+// boost::asio pulls in windows.h which in turn defines the macros,
+// min and max. Disabling the generation of the min and max macros
+// should avoid name collisions with std c++ library function names.
 #define NOMINMAX
 #include <boost/asio.hpp>
 #include <boost/asio/high_resolution_timer.hpp>
-#ifdef FREEORION_WIN32
-#   undef Message
-#   undef MessageBox
-#endif
 
 #include "Networking.h"
 #include "../util/Logger.h"

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -221,7 +221,7 @@ private:
     void HandleMessageHeaderRead(const std::shared_ptr<const ClientNetworking>& keep_alive,
                                  boost::system::error_code error, std::size_t bytes_transferred);
     void AsyncReadMessage(const std::shared_ptr<const ClientNetworking>& keep_alive);
-    void HandleMessageWrite(        boost::system::error_code error, std::size_t bytes_transferred);
+    void HandleMessageWrite(boost::system::error_code error, std::size_t bytes_transferred);
     void AsyncWriteMessage();
     void SendMessageImpl(Message message);
     void DisconnectFromServerImpl();
@@ -457,17 +457,17 @@ void ClientNetworking::Impl::GetMessage(Message& message) {
 void ClientNetworking::Impl::SendSynchronousMessage(const Message& message, Message& response_message) {
     if (TRACE_EXECUTION)
         DebugLogger() << "ClientNetworking::SendSynchronousMessage : sending message "
-                               << message;
+                      << message;
     SendMessage(message);
     // note that this is a blocking operation
     m_incoming_messages.EraseFirstSynchronousResponse(response_message);
     if (TRACE_EXECUTION)
         DebugLogger() << "ClientNetworking::SendSynchronousMessage : received "
-                               << "response message " << response_message;
+                      << "response message " << response_message;
 }
 
 void ClientNetworking::Impl::HandleConnection(tcp::resolver::iterator* it,
-                                        const boost::system::error_code& error)
+                                              const boost::system::error_code& error)
 {
     if (error) {
         if (TRACE_EXECUTION)
@@ -523,7 +523,7 @@ void ClientNetworking::Impl::NetworkingThread(const std::shared_ptr<const Client
 }
 
 void ClientNetworking::Impl::HandleMessageBodyRead(const std::shared_ptr<const ClientNetworking>& keep_alive,
-                                             boost::system::error_code error, std::size_t bytes_transferred)
+                                                   boost::system::error_code error, std::size_t bytes_transferred)
 {
     if (error)
         throw boost::system::system_error(error);
@@ -536,7 +536,7 @@ void ClientNetworking::Impl::HandleMessageBodyRead(const std::shared_ptr<const C
 }
 
 void ClientNetworking::Impl::HandleMessageHeaderRead(const std::shared_ptr<const ClientNetworking>& keep_alive,
-                                               boost::system::error_code error, std::size_t bytes_transferred)
+                                                     boost::system::error_code error, std::size_t bytes_transferred)
 {
     if (error)
         throw boost::system::system_error(error);

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -297,9 +297,8 @@ ClientNetworking::ServerNames ClientNetworking::Impl::DiscoverLANServerNames() {
         return ServerNames();
     ServerDiscoverer discoverer(m_io_service);
     discoverer.DiscoverServers();
-    auto servers = discoverer.Servers();
     ServerNames names;
-    for (const auto& server : servers) {
+    for (const auto& server : discoverer.Servers()) {
         names.push_back(server.second);
     }
     return names;

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -177,12 +177,12 @@ public:
         attempts will be made until \a timeout seconds has elapsed. */
     bool ConnectToServer(const ClientNetworking* const self,
                          const std::string& ip_address,
-                         std::chrono::milliseconds timeout = std::chrono::seconds(10));
+                         const std::chrono::milliseconds& timeout = std::chrono::seconds(10));
 
     /** Connects to the server on the client's host.  On failure, repeated
         attempts will be made until \a timeout seconds has elapsed. */
     bool ConnectToLocalHostServer(const ClientNetworking* const self,
-                                  std::chrono::milliseconds timeout =
+                                  const std::chrono::milliseconds& timeout =
                                   std::chrono::seconds(10));
 
     /** Sends \a message to the server.  This function actually just enqueues
@@ -308,7 +308,7 @@ ClientNetworking::ServerNames ClientNetworking::Impl::DiscoverLANServerNames() {
 bool ClientNetworking::Impl::ConnectToServer(
     const ClientNetworking* const self,
     const std::string& ip_address,
-    std::chrono::milliseconds timeout/* = std::chrono::seconds(10)*/)
+    const std::chrono::milliseconds& timeout/* = std::chrono::seconds(10)*/)
 {
     using Clock = std::chrono::high_resolution_clock;
     Clock::time_point start_time = Clock::now();
@@ -398,7 +398,7 @@ bool ClientNetworking::Impl::ConnectToServer(
 
 bool ClientNetworking::Impl::ConnectToLocalHostServer(
     const ClientNetworking* const self,
-    std::chrono::milliseconds timeout/* = std::chrono::seconds(10)*/)
+    const std::chrono::milliseconds& timeout/* = std::chrono::seconds(10)*/)
 {
     bool retval = false;
 #if FREEORION_WIN32
@@ -689,11 +689,11 @@ ClientNetworking::ServerNames ClientNetworking::DiscoverLANServerNames()
 
 bool ClientNetworking::ConnectToServer(
     const std::string& ip_address,
-    std::chrono::milliseconds timeout/* = std::chrono::seconds(10)*/)
+    const std::chrono::milliseconds& timeout/* = std::chrono::seconds(10)*/)
 { return m_impl->ConnectToServer(this, ip_address, timeout); }
 
 bool ClientNetworking::ConnectToLocalHostServer(
-    std::chrono::milliseconds timeout/* = std::chrono::seconds(10)*/)
+    const std::chrono::milliseconds& timeout/* = std::chrono::seconds(10)*/)
 { return m_impl->ConnectToLocalHostServer(this, timeout); }
 
 void ClientNetworking::DisconnectFromServer()

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -215,7 +215,7 @@ private:
     void HandleConnection(boost::asio::ip::tcp::resolver::iterator* it,
                           const boost::system::error_code& error);
     void CancelRetries();
-    void NetworkingThread(const std::shared_ptr<const ClientNetworking>& self);
+    void NetworkingThread(const std::shared_ptr<const ClientNetworking> self);
     void HandleMessageBodyRead(const std::shared_ptr<const ClientNetworking>& keep_alive,
                                boost::system::error_code error, std::size_t bytes_transferred);
     void HandleMessageHeaderRead(const std::shared_ptr<const ClientNetworking>& keep_alive,
@@ -501,7 +501,7 @@ void ClientNetworking::Impl::HandleException(const boost::system::system_error& 
     }
 }
 
-void ClientNetworking::Impl::NetworkingThread(const std::shared_ptr<const ClientNetworking>& self) {
+void ClientNetworking::Impl::NetworkingThread(const std::shared_ptr<const ClientNetworking> self) {
     auto protect_from_destruction_in_other_thread = self;
     try {
         if (!m_outgoing_messages.empty())

--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -25,7 +25,7 @@
 #   undef MessageBox
 #endif
 
-class Message;
+class MessagePacket;
 
 /** Encapsulates the networking facilities of the client.  The client must
     execute its networking code in a separate thread from its main processing
@@ -108,18 +108,18 @@ public:
 
     /** Sends \a message to the server.  This function actually just enqueues
         the message for sending and returns immediately. */
-    void SendMessage(const Message& message);
+    void SendMessage(const MessagePacket& message);
 
     /** Gets the next incoming message from the server, places it into \a
         message, and removes it from the incoming message queue.  The function
         assumes that there is at least one message in the incoming queue.
         Users must call MessageAvailable() first to make sure this is the
         case. */
-    void GetMessage(Message& message);
+    void GetMessage(MessagePacket& message);
 
     /** Sends \a message to the server, then blocks until it sees the first
         synchronous response from the server. */
-    void SendSynchronousMessage(const Message& message, Message& response_message);
+    void SendSynchronousMessage(const MessagePacket& message, MessagePacket& response_message);
 
     /** Disconnects the client from the server. First tries to send any pending transmit messages. */
     void DisconnectFromServer();

--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -1,9 +1,6 @@
 #ifndef _ClientNetworking_h_
 #define _ClientNetworking_h_
 
-#include "Message.h"
-#include "MessageQueue.h"
-
 // boost::asio pulls in windows.h which in turn defines the macros Message,
 // MessageBox, min and max. Disabling the generation of the min and max macros
 // and undefining those should avoid name collisions with std c++ library and
@@ -18,6 +15,7 @@
 
 #include <memory>
 
+class Message;
 
 /** Encapsulates the networking facilities of the client.  The client must
     execute its networking code in a separate thread from its main processing
@@ -57,6 +55,7 @@ public:
 
     /** \name Structors */ //@{
     ClientNetworking();
+    ~ClientNetworking();
     //@}
 
     /** \name Accessors */ //@{
@@ -99,7 +98,7 @@ public:
 
     /** Sends \a message to the server.  This function actually just enqueues
         the message for sending and returns immediately. */
-    void SendMessage(Message message);
+    void SendMessage(const Message& message);
 
     /** Gets the next incoming message from the server, places it into \a
         message, and removes it from the incoming message queue.  The function
@@ -110,7 +109,7 @@ public:
 
     /** Sends \a message to the server, then blocks until it sees the first
         synchronous response from the server. */
-    void SendSynchronousMessage(Message message, Message& response_message);
+    void SendSynchronousMessage(const Message& message, Message& response_message);
 
     /** Disconnects the client from the server. First tries to send any pending transmit messages. */
     void DisconnectFromServer();
@@ -123,41 +122,8 @@ public:
     //@}
 
 private:
-    void HandleException(const boost::system::system_error& error);
-    void HandleConnection(boost::asio::ip::tcp::resolver::iterator* it,
-                          const boost::system::error_code& error);
-    void CancelRetries();
-    void NetworkingThread(std::shared_ptr<ClientNetworking>& self);
-    void HandleMessageBodyRead(const std::shared_ptr<ClientNetworking>& keep_alive,
-                               boost::system::error_code error, std::size_t bytes_transferred);
-    void HandleMessageHeaderRead(const std::shared_ptr<ClientNetworking>& keep_alive,
-                                 boost::system::error_code error, std::size_t bytes_transferred);
-    void AsyncReadMessage(const std::shared_ptr<ClientNetworking>& keep_alive);
-    void HandleMessageWrite(        boost::system::error_code error, std::size_t bytes_transferred);
-    void AsyncWriteMessage();
-    void SendMessageImpl(Message message);
-    void DisconnectFromServerImpl();
-
-    int                             m_player_id;
-    int                             m_host_player_id;
-
-    boost::asio::io_service         m_io_service;
-    boost::asio::ip::tcp::socket    m_socket;
-
-    // m_mutex guards m_incoming_message, m_rx_connected and m_tx_connected which are written by
-    // the networking thread and read by the main thread to check incoming messages and connection
-    // status. As those read and write operations are not atomic, shared access has to be
-    // protected to prevent unpredictable results.
-    mutable boost::mutex            m_mutex;
-
-    MessageQueue                    m_incoming_messages; // accessed from multiple threads, but its interface is threadsafe
-    std::list<Message>              m_outgoing_messages;
-    bool                            m_rx_connected;      // accessed from multiple threads
-    bool                            m_tx_connected;      // accessed from multiple threads
-
-    Message::HeaderBuffer           m_incoming_header;
-    Message                         m_incoming_message;
-    Message::HeaderBuffer           m_outgoing_header;
+    class Impl;
+    std::unique_ptr<Impl> const m_impl;
 };
 
 #endif

--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -51,7 +51,7 @@ class Message;
 class ClientNetworking : public std::enable_shared_from_this<ClientNetworking> {
 public:
     /** The type of list returned by a call to DiscoverLANServers(). */
-    typedef std::vector<std::pair<boost::asio::ip::address, std::string>> ServerList;
+    using ServerNames =  std::vector<std::string>;
 
     /** \name Structors */ //@{
     ClientNetworking();
@@ -84,7 +84,7 @@ public:
     /** \name Mutators */ //@{
     /** Returns a list of the addresses and names of all servers on the Local
         Area Network. */
-    ServerList DiscoverLANServers();
+    ServerNames DiscoverLANServerNames();
 
     /** Connects to the server at \a ip_address.  On failure, repeated
         attempts will be made until \a timeout seconds has elapsed. */

--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -8,6 +8,23 @@
 
 #include <memory>
 
+#ifdef FREEORION_WIN32
+#include "Message.h"
+#include "MessageQueue.h"
+
+// boost::asio pulls in windows.h which in turn defines the macros Message,
+// MessageBox, min and max. Disabling the generation of the min and max macros
+// and undefining those should avoid name collisions with std c++ library and
+// FreeOrion function names.
+#define NOMINMAX
+#include <boost/asio.hpp>
+#include <boost/asio/high_resolution_timer.hpp>
+
+// Undef Message and MessageBox from the windows API
+#   undef Message
+#   undef MessageBox
+#endif
+
 class Message;
 
 /** Encapsulates the networking facilities of the client.  The client must

--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -90,7 +90,7 @@ public:
                                   std::chrono::seconds(10));
 
     /** Sends \a message to the server.  This function actually just enqueues
-        the message for sending a nd returns immediately. */
+        the message for sending and returns immediately. */
     void SendMessage(const Message& message);
 
     /** Gets the next incoming message from the server, places it into \a

--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -1,17 +1,10 @@
 #ifndef _ClientNetworking_h_
 #define _ClientNetworking_h_
 
-// boost::asio pulls in windows.h which in turn defines the macros Message,
-// MessageBox, min and max. Disabling the generation of the min and max macros
-// and undefining those should avoid name collisions with std c++ library and
-// FreeOrion function names.
-#define NOMINMAX
-#include <boost/asio.hpp>
-#include <boost/asio/high_resolution_timer.hpp>
-#ifdef FREEORION_WIN32
-#   undef Message
-#   undef MessageBox
-#endif
+#include <string>
+#include <vector>
+#include <memory>
+#include <chrono>
 
 #include <memory>
 
@@ -89,15 +82,15 @@ public:
     /** Connects to the server at \a ip_address.  On failure, repeated
         attempts will be made until \a timeout seconds has elapsed. */
     bool ConnectToServer(const std::string& ip_address,
-                         std::chrono::milliseconds timeout = std::chrono::seconds(10));
+                         const std::chrono::milliseconds& timeout = std::chrono::seconds(10));
 
     /** Connects to the server on the client's host.  On failure, repeated
         attempts will be made until \a timeout seconds has elapsed. */
-    bool ConnectToLocalHostServer(std::chrono::milliseconds timeout =
+    bool ConnectToLocalHostServer(const std::chrono::milliseconds& timeout =
                                   std::chrono::seconds(10));
 
     /** Sends \a message to the server.  This function actually just enqueues
-        the message for sending and returns immediately. */
+        the message for sending a nd returns immediately. */
     void SendMessage(const Message& message);
 
     /** Gets the next incoming message from the server, places it into \a

--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -8,23 +8,6 @@
 
 #include <memory>
 
-#ifdef FREEORION_WIN32
-#include "Message.h"
-#include "MessageQueue.h"
-
-// boost::asio pulls in windows.h which in turn defines the macros Message,
-// MessageBox, min and max. Disabling the generation of the min and max macros
-// and undefining those should avoid name collisions with std c++ library and
-// FreeOrion function names.
-#define NOMINMAX
-#include <boost/asio.hpp>
-#include <boost/asio/high_resolution_timer.hpp>
-
-// Undef Message and MessageBox from the windows API
-#   undef Message
-#   undef MessageBox
-#endif
-
 class MessagePacket;
 
 /** Encapsulates the networking facilities of the client.  The client must

--- a/network/Message.cpp
+++ b/network/Message.cpp
@@ -43,7 +43,7 @@ namespace {
 ////////////////////////////////////////////////
 // Free Functions
 ////////////////////////////////////////////////
-std::ostream& operator<<(std::ostream& os, const Message& msg) {
+std::ostream& operator<<(std::ostream& os, const MessagePacket& msg) {
     os << "Message: "
        << msg.Type() << " "
        << msg.SendingPlayer();
@@ -65,9 +65,9 @@ std::ostream& operator<<(std::ostream& os, const Message& msg) {
 
 
 ////////////////////////////////////////////////
-// Message
+// MessagePacket
 ////////////////////////////////////////////////
-Message::Message() :
+MessagePacket::MessagePacket() :
     m_type(UNDEFINED),
     m_sending_player(0),
     m_receiving_player(0),
@@ -76,7 +76,7 @@ Message::Message() :
     m_message_text()
 {}
 
-Message::Message(MessageType type, int sending_player, int receiving_player,
+MessagePacket::MessagePacket(MessageType type, int sending_player, int receiving_player,
                  const std::string& text, bool synchronous_response/* = false*/) :
     m_type(type),
     m_sending_player(sending_player),
@@ -86,36 +86,36 @@ Message::Message(MessageType type, int sending_player, int receiving_player,
     m_message_text(new char[text.size()])
 { std::copy(text.begin(), text.end(), m_message_text.get()); }
 
-Message::MessageType Message::Type() const
+MessagePacket::MessageType MessagePacket::Type() const
 { return m_type; }
 
-int Message::SendingPlayer() const
+int MessagePacket::SendingPlayer() const
 { return m_sending_player; }
 
-int Message::ReceivingPlayer() const
+int MessagePacket::ReceivingPlayer() const
 { return m_receiving_player; }
 
-bool Message::SynchronousResponse() const
+bool MessagePacket::SynchronousResponse() const
 { return m_synchronous_response; }
 
-std::size_t Message::Size() const
+std::size_t MessagePacket::Size() const
 { return m_message_size; }
 
-const char* Message::Data() const
+const char* MessagePacket::Data() const
 { return m_message_text.get(); }
 
-std::string Message::Text() const
+std::string MessagePacket::Text() const
 { return std::string(m_message_text.get(), m_message_size); }
 
-void Message::Resize(std::size_t size) {
+void MessagePacket::Resize(std::size_t size) {
     m_message_size = size;
     m_message_text.reset(new char[m_message_size]);
 }
 
-char* Message::Data()
+char* MessagePacket::Data()
 { return m_message_text.get(); }
 
-void Message::Swap(Message& rhs) {
+void MessagePacket::Swap(MessagePacket& rhs) {
     std::swap(m_type, rhs.m_type);
     std::swap(m_sending_player, rhs.m_sending_player);
     std::swap(m_receiving_player, rhs.m_receiving_player);
@@ -124,7 +124,7 @@ void Message::Swap(Message& rhs) {
     std::swap(m_message_text, rhs.m_message_text);
 }
 
-bool operator==(const Message& lhs, const Message& rhs) {
+bool operator==(const MessagePacket& lhs, const MessagePacket& rhs) {
     return
         lhs.Type() == rhs.Type() &&
         lhs.SendingPlayer() == rhs.SendingPlayer() &&
@@ -132,21 +132,21 @@ bool operator==(const Message& lhs, const Message& rhs) {
         lhs.Text() == rhs.Text();
 }
 
-bool operator!=(const Message& lhs, const Message& rhs)
+bool operator!=(const MessagePacket& lhs, const MessagePacket& rhs)
 { return !(lhs == rhs); }
 
-void swap(Message& lhs, Message& rhs)
+void swap(MessagePacket& lhs, MessagePacket& rhs)
 { lhs.Swap(rhs); }
 
-void BufferToHeader(const Message::HeaderBuffer& buffer, Message& message) {
-    message.m_type = static_cast<Message::MessageType>(buffer[0]);
+void BufferToHeader(const MessagePacket::HeaderBuffer& buffer, MessagePacket& message) {
+    message.m_type = static_cast<MessagePacket::MessageType>(buffer[0]);
     message.m_sending_player = buffer[1];
     message.m_receiving_player = buffer[2];
     message.m_synchronous_response = (buffer[3] != 0);
     message.m_message_size = buffer[4];
 }
 
-void HeaderToBuffer(const Message& message, Message::HeaderBuffer& buffer) {
+void HeaderToBuffer(const MessagePacket& message, MessagePacket::HeaderBuffer& buffer) {
     buffer[0] = message.Type();
     buffer[1] = message.SendingPlayer();
     buffer[2] = message.ReceivingPlayer();
@@ -155,29 +155,29 @@ void HeaderToBuffer(const Message& message, Message::HeaderBuffer& buffer) {
 }
 
 ////////////////////////////////////////////////
-// Message named ctors
+// MessagePacket named ctors
 ////////////////////////////////////////////////
-Message ErrorMessage(const std::string& problem, bool fatal/* = true*/) {
+MessagePacket ErrorMessage(const std::string& problem, bool fatal/* = true*/) {
     std::ostringstream os;
     {
         freeorion_xml_oarchive oa(os);
         oa << BOOST_SERIALIZATION_NVP(problem)
            << BOOST_SERIALIZATION_NVP(fatal);
     }
-    return Message(Message::ERROR_MSG, Networking::INVALID_PLAYER_ID, Networking::INVALID_PLAYER_ID, os.str());
+    return MessagePacket(MessagePacket::ERROR_MSG, Networking::INVALID_PLAYER_ID, Networking::INVALID_PLAYER_ID, os.str());
 }
 
-Message ErrorMessage(int player_id, const std::string& problem, bool fatal/* = true*/) {
+MessagePacket ErrorMessage(int player_id, const std::string& problem, bool fatal/* = true*/) {
     std::ostringstream os;
     {
         freeorion_xml_oarchive oa(os);
         oa << BOOST_SERIALIZATION_NVP(problem)
            << BOOST_SERIALIZATION_NVP(fatal);
     }
-    return Message(Message::ERROR_MSG, Networking::INVALID_PLAYER_ID, player_id, os.str());
+    return MessagePacket(MessagePacket::ERROR_MSG, Networking::INVALID_PLAYER_ID, player_id, os.str());
 }
 
-Message HostSPGameMessage(const SinglePlayerSetupData& setup_data) {
+MessagePacket HostSPGameMessage(const SinglePlayerSetupData& setup_data) {
     std::ostringstream os;
     {
         std::string client_version_string = FreeOrionVersionString();
@@ -185,10 +185,10 @@ Message HostSPGameMessage(const SinglePlayerSetupData& setup_data) {
         oa << BOOST_SERIALIZATION_NVP(setup_data)
            << BOOST_SERIALIZATION_NVP(client_version_string);
     }
-    return Message(Message::HOST_SP_GAME, Networking::INVALID_PLAYER_ID, Networking::INVALID_PLAYER_ID, os.str());
+    return MessagePacket(MessagePacket::HOST_SP_GAME, Networking::INVALID_PLAYER_ID, Networking::INVALID_PLAYER_ID, os.str());
 }
 
-Message HostMPGameMessage(const std::string& host_player_name)
+MessagePacket HostMPGameMessage(const std::string& host_player_name)
 {
     std::ostringstream os;
     {
@@ -197,10 +197,10 @@ Message HostMPGameMessage(const std::string& host_player_name)
         oa << BOOST_SERIALIZATION_NVP(host_player_name)
            << BOOST_SERIALIZATION_NVP(client_version_string);
     }
-    return Message(Message::HOST_MP_GAME, Networking::INVALID_PLAYER_ID, Networking::INVALID_PLAYER_ID, os.str());
+    return MessagePacket(MessagePacket::HOST_MP_GAME, Networking::INVALID_PLAYER_ID, Networking::INVALID_PLAYER_ID, os.str());
 }
 
-Message JoinGameMessage(const std::string& player_name, Networking::ClientType client_type) {
+MessagePacket JoinGameMessage(const std::string& player_name, Networking::ClientType client_type) {
     std::ostringstream os;
     {
         freeorion_xml_oarchive oa(os);
@@ -209,15 +209,15 @@ Message JoinGameMessage(const std::string& player_name, Networking::ClientType c
            << BOOST_SERIALIZATION_NVP(client_type)
            << BOOST_SERIALIZATION_NVP(client_version_string);
     }
-    return Message(Message::JOIN_GAME, Networking::INVALID_PLAYER_ID, Networking::INVALID_PLAYER_ID, os.str());
+    return MessagePacket(MessagePacket::JOIN_GAME, Networking::INVALID_PLAYER_ID, Networking::INVALID_PLAYER_ID, os.str());
 }
 
-Message HostIDMessage(int host_player_id) {
-    return Message(Message::HOST_ID, Networking::INVALID_PLAYER_ID, Networking::INVALID_PLAYER_ID,
+MessagePacket HostIDMessage(int host_player_id) {
+    return MessagePacket(MessagePacket::HOST_ID, Networking::INVALID_PLAYER_ID, Networking::INVALID_PLAYER_ID,
                    std::to_string(host_player_id));
 }
 
-Message GameStartMessage(int player_id, bool single_player_game, int empire_id,
+MessagePacket GameStartMessage(int player_id, bool single_player_game, int empire_id,
                          int current_turn, const EmpireManager& empires,
                          const Universe& universe, const SpeciesManager& species,
                          CombatLogManager& combat_logs, const SupplyManager& supply,
@@ -259,10 +259,10 @@ Message GameStartMessage(int player_id, bool single_player_game, int empire_id,
             oa << BOOST_SERIALIZATION_NVP(galaxy_setup_data);
         }
     }
-    return Message(Message::GAME_START, Networking::INVALID_PLAYER_ID, player_id, os.str());
+    return MessagePacket(MessagePacket::GAME_START, Networking::INVALID_PLAYER_ID, player_id, os.str());
 }
 
-Message GameStartMessage(int player_id, bool single_player_game, int empire_id,
+MessagePacket GameStartMessage(int player_id, bool single_player_game, int empire_id,
                          int current_turn, const EmpireManager& empires,
                          const Universe& universe, const SpeciesManager& species,
                          CombatLogManager& combat_logs, const SupplyManager& supply,
@@ -319,10 +319,10 @@ Message GameStartMessage(int player_id, bool single_player_game, int empire_id,
             oa << BOOST_SERIALIZATION_NVP(galaxy_setup_data);
         }
     }
-    return Message(Message::GAME_START, Networking::INVALID_PLAYER_ID, player_id, os.str());
+    return MessagePacket(MessagePacket::GAME_START, Networking::INVALID_PLAYER_ID, player_id, os.str());
 }
 
-Message GameStartMessage(int player_id, bool single_player_game, int empire_id,
+MessagePacket GameStartMessage(int player_id, bool single_player_game, int empire_id,
                          int current_turn, const EmpireManager& empires,
                          const Universe& universe, const SpeciesManager& species,
                          CombatLogManager& combat_logs, const SupplyManager& supply,
@@ -379,47 +379,47 @@ Message GameStartMessage(int player_id, bool single_player_game, int empire_id,
             oa << BOOST_SERIALIZATION_NVP(galaxy_setup_data);
         }
     }
-    return Message(Message::GAME_START, Networking::INVALID_PLAYER_ID, player_id, os.str());
+    return MessagePacket(MessagePacket::GAME_START, Networking::INVALID_PLAYER_ID, player_id, os.str());
 }
 
-Message HostSPAckMessage(int player_id)
-{ return Message(Message::HOST_SP_GAME, Networking::INVALID_PLAYER_ID, player_id, ACKNOWLEDGEMENT); }
+MessagePacket HostSPAckMessage(int player_id)
+{ return MessagePacket(MessagePacket::HOST_SP_GAME, Networking::INVALID_PLAYER_ID, player_id, ACKNOWLEDGEMENT); }
 
-Message HostMPAckMessage(int player_id)
-{ return Message(Message::HOST_MP_GAME, Networking::INVALID_PLAYER_ID, player_id, ACKNOWLEDGEMENT); }
+MessagePacket HostMPAckMessage(int player_id)
+{ return MessagePacket(MessagePacket::HOST_MP_GAME, Networking::INVALID_PLAYER_ID, player_id, ACKNOWLEDGEMENT); }
 
-Message JoinAckMessage(int player_id)
-{ return Message(Message::JOIN_GAME, Networking::INVALID_PLAYER_ID, player_id, ACKNOWLEDGEMENT); }
+MessagePacket JoinAckMessage(int player_id)
+{ return MessagePacket(MessagePacket::JOIN_GAME, Networking::INVALID_PLAYER_ID, player_id, ACKNOWLEDGEMENT); }
 
-Message TurnOrdersMessage(int sender, const OrderSet& orders) {
+MessagePacket TurnOrdersMessage(int sender, const OrderSet& orders) {
     std::ostringstream os;
     {
         freeorion_xml_oarchive oa(os);
         Serialize(oa, orders);
     }
-    return Message(Message::TURN_ORDERS, sender, Networking::INVALID_PLAYER_ID, os.str());
+    return MessagePacket(MessagePacket::TURN_ORDERS, sender, Networking::INVALID_PLAYER_ID, os.str());
 }
 
-Message TurnProgressMessage(Message::TurnProgressPhase phase_id, int player_id) {
+MessagePacket TurnProgressMessage(MessagePacket::TurnProgressPhase phase_id, int player_id) {
     std::ostringstream os;
     {
         freeorion_xml_oarchive oa(os);
         oa << BOOST_SERIALIZATION_NVP(phase_id);
     }
-    return Message(Message::TURN_PROGRESS, Networking::INVALID_PLAYER_ID, player_id, os.str());
+    return MessagePacket(MessagePacket::TURN_PROGRESS, Networking::INVALID_PLAYER_ID, player_id, os.str());
 }
 
-Message PlayerStatusMessage(int player_id, int about_player_id, Message::PlayerStatus player_status) {
+MessagePacket PlayerStatusMessage(int player_id, int about_player_id, MessagePacket::PlayerStatus player_status) {
     std::ostringstream os;
     {
         freeorion_xml_oarchive oa(os);
         oa << BOOST_SERIALIZATION_NVP(about_player_id)
            << BOOST_SERIALIZATION_NVP(player_status);
     }
-    return Message(Message::PLAYER_STATUS, Networking::INVALID_PLAYER_ID, player_id, os.str());
+    return MessagePacket(MessagePacket::PLAYER_STATUS, Networking::INVALID_PLAYER_ID, player_id, os.str());
 }
 
-Message TurnUpdateMessage(int player_id, int empire_id, int current_turn,
+MessagePacket TurnUpdateMessage(int player_id, int empire_id, int current_turn,
                           const EmpireManager& empires, const Universe& universe,
                           const SpeciesManager& species, CombatLogManager& combat_logs,
                           const SupplyManager& supply,
@@ -450,10 +450,10 @@ Message TurnUpdateMessage(int player_id, int empire_id, int current_turn,
             oa << BOOST_SERIALIZATION_NVP(players);
         }
     }
-    return Message(Message::TURN_UPDATE, Networking::INVALID_PLAYER_ID, player_id, os.str());
+    return MessagePacket(MessagePacket::TURN_UPDATE, Networking::INVALID_PLAYER_ID, player_id, os.str());
 }
 
-Message TurnPartialUpdateMessage(int player_id, int empire_id, const Universe& universe,
+MessagePacket TurnPartialUpdateMessage(int player_id, int empire_id, const Universe& universe,
                                  bool use_binary_serialization) {
     std::ostringstream os;
     {
@@ -467,10 +467,10 @@ Message TurnPartialUpdateMessage(int player_id, int empire_id, const Universe& u
             Serialize(oa, universe);
         }
     }
-    return Message(Message::TURN_PARTIAL_UPDATE, Networking::INVALID_PLAYER_ID, player_id, os.str());
+    return MessagePacket(MessagePacket::TURN_PARTIAL_UPDATE, Networking::INVALID_PLAYER_ID, player_id, os.str());
 }
 
-Message ClientSaveDataMessage(int sender, const OrderSet& orders, const SaveGameUIData& ui_data) {
+MessagePacket ClientSaveDataMessage(int sender, const OrderSet& orders, const SaveGameUIData& ui_data) {
     std::ostringstream os;
     {
         freeorion_xml_oarchive oa(os);
@@ -481,10 +481,10 @@ Message ClientSaveDataMessage(int sender, const OrderSet& orders, const SaveGame
            << BOOST_SERIALIZATION_NVP(ui_data)
            << BOOST_SERIALIZATION_NVP(save_state_string_available);
     }
-    return Message(Message::CLIENT_SAVE_DATA, sender, Networking::INVALID_PLAYER_ID, os.str());
+    return MessagePacket(MessagePacket::CLIENT_SAVE_DATA, sender, Networking::INVALID_PLAYER_ID, os.str());
 }
 
-Message ClientSaveDataMessage(int sender, const OrderSet& orders, const std::string& save_state_string) {
+MessagePacket ClientSaveDataMessage(int sender, const OrderSet& orders, const std::string& save_state_string) {
     std::ostringstream os;
     {
         freeorion_xml_oarchive oa(os);
@@ -495,10 +495,10 @@ Message ClientSaveDataMessage(int sender, const OrderSet& orders, const std::str
            << BOOST_SERIALIZATION_NVP(save_state_string_available)
            << BOOST_SERIALIZATION_NVP(save_state_string);
 }
-    return Message(Message::CLIENT_SAVE_DATA, sender, Networking::INVALID_PLAYER_ID, os.str());
+    return MessagePacket(MessagePacket::CLIENT_SAVE_DATA, sender, Networking::INVALID_PLAYER_ID, os.str());
 }
 
-Message ClientSaveDataMessage(int sender, const OrderSet& orders) {
+MessagePacket ClientSaveDataMessage(int sender, const OrderSet& orders) {
     std::ostringstream os;
     {
         freeorion_xml_oarchive oa(os);
@@ -508,59 +508,59 @@ Message ClientSaveDataMessage(int sender, const OrderSet& orders) {
         oa << BOOST_SERIALIZATION_NVP(ui_data_available)
            << BOOST_SERIALIZATION_NVP(save_state_string_available);
     }
-    return Message(Message::CLIENT_SAVE_DATA, sender, Networking::INVALID_PLAYER_ID, os.str());
+    return MessagePacket(MessagePacket::CLIENT_SAVE_DATA, sender, Networking::INVALID_PLAYER_ID, os.str());
 }
 
-Message RequestNewObjectIDMessage(int sender)
-{ return Message(Message::REQUEST_NEW_OBJECT_ID, sender, Networking::INVALID_PLAYER_ID, DUMMY_EMPTY_MESSAGE); }
+MessagePacket RequestNewObjectIDMessage(int sender)
+{ return MessagePacket(MessagePacket::REQUEST_NEW_OBJECT_ID, sender, Networking::INVALID_PLAYER_ID, DUMMY_EMPTY_MESSAGE); }
 
-Message DispatchObjectIDMessage(int player_id, int new_id) {
-    return Message(Message::DISPATCH_NEW_OBJECT_ID, Networking::INVALID_PLAYER_ID, player_id,
+MessagePacket DispatchObjectIDMessage(int player_id, int new_id) {
+    return MessagePacket(MessagePacket::DISPATCH_NEW_OBJECT_ID, Networking::INVALID_PLAYER_ID, player_id,
                    std::to_string(new_id), true);
 }
 
-Message RequestNewDesignIDMessage(int sender)
-{ return Message(Message::REQUEST_NEW_DESIGN_ID, sender, Networking::INVALID_PLAYER_ID, DUMMY_EMPTY_MESSAGE, true); }
+MessagePacket RequestNewDesignIDMessage(int sender)
+{ return MessagePacket(MessagePacket::REQUEST_NEW_DESIGN_ID, sender, Networking::INVALID_PLAYER_ID, DUMMY_EMPTY_MESSAGE, true); }
 
-Message DispatchDesignIDMessage(int player_id, int new_id) {
-    return Message(Message::DISPATCH_NEW_DESIGN_ID, Networking::INVALID_PLAYER_ID, player_id,
+MessagePacket DispatchDesignIDMessage(int player_id, int new_id) {
+    return MessagePacket(MessagePacket::DISPATCH_NEW_DESIGN_ID, Networking::INVALID_PLAYER_ID, player_id,
                    std::to_string(new_id), true);
 }
 
-Message HostSaveGameInitiateMessage(int sender, const std::string& filename)
-{ return Message(Message::SAVE_GAME_INITIATE, sender, Networking::INVALID_PLAYER_ID, filename); }
+MessagePacket HostSaveGameInitiateMessage(int sender, const std::string& filename)
+{ return MessagePacket(MessagePacket::SAVE_GAME_INITIATE, sender, Networking::INVALID_PLAYER_ID, filename); }
 
-Message ServerSaveGameDataRequestMessage(int receiver, bool synchronous_response) {
-    return Message(Message::SAVE_GAME_DATA_REQUEST, Networking::INVALID_PLAYER_ID,
+MessagePacket ServerSaveGameDataRequestMessage(int receiver, bool synchronous_response) {
+    return MessagePacket(MessagePacket::SAVE_GAME_DATA_REQUEST, Networking::INVALID_PLAYER_ID,
                    receiver, DUMMY_EMPTY_MESSAGE, synchronous_response);
 }
 
-Message ServerSaveGameCompleteMessage(const std::string& save_filename, int bytes_written) {
+MessagePacket ServerSaveGameCompleteMessage(const std::string& save_filename, int bytes_written) {
     std::ostringstream os;
     {
         freeorion_xml_oarchive oa(os);
         oa << BOOST_SERIALIZATION_NVP(save_filename)
            << BOOST_SERIALIZATION_NVP(bytes_written);
     }
-    return Message(Message::SAVE_GAME_COMPLETE, Networking::INVALID_PLAYER_ID, Networking::INVALID_PLAYER_ID, os.str());
+    return MessagePacket(MessagePacket::SAVE_GAME_COMPLETE, Networking::INVALID_PLAYER_ID, Networking::INVALID_PLAYER_ID, os.str());
 }
 
-Message GlobalChatMessage(int sender, const std::string& msg)
-{ return Message(Message::PLAYER_CHAT, sender, Networking::INVALID_PLAYER_ID, msg); }
+MessagePacket GlobalChatMessage(int sender, const std::string& msg)
+{ return MessagePacket(MessagePacket::PLAYER_CHAT, sender, Networking::INVALID_PLAYER_ID, msg); }
 
-Message SingleRecipientChatMessage(int sender, int receiver, const std::string& msg)
-{ return Message(Message::PLAYER_CHAT, sender, receiver, msg); }
+MessagePacket SingleRecipientChatMessage(int sender, int receiver, const std::string& msg)
+{ return MessagePacket(MessagePacket::PLAYER_CHAT, sender, receiver, msg); }
 
-Message DiplomacyMessage(int sender, int receiver, const DiplomaticMessage& diplo_message) {
+MessagePacket DiplomacyMessage(int sender, int receiver, const DiplomaticMessage& diplo_message) {
     std::ostringstream os;
     {
         freeorion_xml_oarchive oa(os);
         oa << BOOST_SERIALIZATION_NVP(diplo_message);
     }
-    return Message(Message::DIPLOMACY, sender, receiver, os.str());
+    return MessagePacket(MessagePacket::DIPLOMACY, sender, receiver, os.str());
 }
 
-Message DiplomaticStatusMessage(int receiver, const DiplomaticStatusUpdateInfo& diplo_update) {
+MessagePacket DiplomaticStatusMessage(int receiver, const DiplomaticStatusUpdateInfo& diplo_update) {
     std::ostringstream os;
     {
         freeorion_xml_oarchive oa(os);
@@ -568,10 +568,10 @@ Message DiplomaticStatusMessage(int receiver, const DiplomaticStatusUpdateInfo& 
            << BOOST_SERIALIZATION_NVP(diplo_update.empire2_id)
            << BOOST_SERIALIZATION_NVP(diplo_update.diplo_status);
     }
-    return Message(Message::DIPLOMATIC_STATUS, Networking::INVALID_PLAYER_ID, receiver, os.str());
+    return MessagePacket(MessagePacket::DIPLOMATIC_STATUS, Networking::INVALID_PLAYER_ID, receiver, os.str());
 }
 
-Message EndGameMessage(int receiver, Message::EndGameReason reason,
+MessagePacket EndGameMessage(int receiver, MessagePacket::EndGameReason reason,
                        const std::string& reason_player_name/* = ""*/)
 {
     std::ostringstream os;
@@ -580,95 +580,95 @@ Message EndGameMessage(int receiver, Message::EndGameReason reason,
         oa << BOOST_SERIALIZATION_NVP(reason)
            << BOOST_SERIALIZATION_NVP(reason_player_name);
     }
-    return Message(Message::END_GAME, Networking::INVALID_PLAYER_ID, receiver, os.str());
+    return MessagePacket(MessagePacket::END_GAME, Networking::INVALID_PLAYER_ID, receiver, os.str());
 }
 
-Message AIEndGameAcknowledgeMessage(int sender)
-{ return Message(Message::AI_END_GAME_ACK, sender, Networking::INVALID_PLAYER_ID, DUMMY_EMPTY_MESSAGE); }
+MessagePacket AIEndGameAcknowledgeMessage(int sender)
+{ return MessagePacket(MessagePacket::AI_END_GAME_ACK, sender, Networking::INVALID_PLAYER_ID, DUMMY_EMPTY_MESSAGE); }
 
-Message ModeratorActionMessage(int sender, const Moderator::ModeratorAction& action) {
+MessagePacket ModeratorActionMessage(int sender, const Moderator::ModeratorAction& action) {
     std::ostringstream os;
     {
         const Moderator::ModeratorAction* mod_action = &action;
         freeorion_xml_oarchive oa(os);
         oa << BOOST_SERIALIZATION_NVP(mod_action);
     }
-    return Message(Message::MODERATOR_ACTION, sender, Networking::INVALID_PLAYER_ID, os.str());
+    return MessagePacket(MessagePacket::MODERATOR_ACTION, sender, Networking::INVALID_PLAYER_ID, os.str());
 }
 
-Message ShutdownServerMessage(int sender)
-{ return Message(Message::SHUT_DOWN_SERVER, sender, Networking::INVALID_PLAYER_ID, DUMMY_EMPTY_MESSAGE); }
+MessagePacket ShutdownServerMessage(int sender)
+{ return MessagePacket(MessagePacket::SHUT_DOWN_SERVER, sender, Networking::INVALID_PLAYER_ID, DUMMY_EMPTY_MESSAGE); }
 
 /** requests previews of savefiles from server synchronously */
-Message RequestSavePreviewsMessage(int sender, std::string directory)
-{ return Message(Message::REQUEST_SAVE_PREVIEWS, sender, Networking::INVALID_PLAYER_ID, directory); }
+MessagePacket RequestSavePreviewsMessage(int sender, std::string directory)
+{ return MessagePacket(MessagePacket::REQUEST_SAVE_PREVIEWS, sender, Networking::INVALID_PLAYER_ID, directory); }
 
 /** returns the savegame previews to the client */
-Message DispatchSavePreviewsMessage(int receiver, const PreviewInformation& previews) {
+MessagePacket DispatchSavePreviewsMessage(int receiver, const PreviewInformation& previews) {
     std::ostringstream os;
     {
         freeorion_xml_oarchive oa(os);
         oa << BOOST_SERIALIZATION_NVP(previews);
     }
-    return Message(Message::DISPATCH_SAVE_PREVIEWS, Networking::INVALID_PLAYER_ID, receiver, os.str(), true);
+    return MessagePacket(MessagePacket::DISPATCH_SAVE_PREVIEWS, Networking::INVALID_PLAYER_ID, receiver, os.str(), true);
 }
 
-Message RequestCombatLogsMessage(int sender, const std::vector<int>& ids) {
+MessagePacket RequestCombatLogsMessage(int sender, const std::vector<int>& ids) {
     std::ostringstream os;
     freeorion_xml_oarchive oa(os);
     oa << BOOST_SERIALIZATION_NVP(ids);
-    return Message(Message::REQUEST_COMBAT_LOGS, sender, Networking::INVALID_PLAYER_ID, os.str());
+    return MessagePacket(MessagePacket::REQUEST_COMBAT_LOGS, sender, Networking::INVALID_PLAYER_ID, os.str());
 }
 
-Message DispatchCombatLogsMessage(int receiver, const std::vector<std::pair<int, const CombatLog>>& logs) {
+MessagePacket DispatchCombatLogsMessage(int receiver, const std::vector<std::pair<int, const CombatLog>>& logs) {
     std::ostringstream os;
     freeorion_xml_oarchive oa(os);
     oa << BOOST_SERIALIZATION_NVP(logs);
-    return Message(Message::DISPATCH_COMBAT_LOGS, Networking::INVALID_PLAYER_ID, receiver, os.str(), true);
+    return MessagePacket(MessagePacket::DISPATCH_COMBAT_LOGS, Networking::INVALID_PLAYER_ID, receiver, os.str(), true);
 }
 
 ////////////////////////////////////////////////
-// Multiplayer Lobby Message named ctors
+// Multiplayer Lobby MessagePacket named ctors
 ////////////////////////////////////////////////
-Message LobbyUpdateMessage(int sender, const MultiplayerLobbyData& lobby_data) {
+MessagePacket LobbyUpdateMessage(int sender, const MultiplayerLobbyData& lobby_data) {
     std::ostringstream os;
     {
         freeorion_xml_oarchive oa(os);
         oa << BOOST_SERIALIZATION_NVP(lobby_data);
     }
-    return Message(Message::LOBBY_UPDATE, sender, Networking::INVALID_PLAYER_ID, os.str());
+    return MessagePacket(MessagePacket::LOBBY_UPDATE, sender, Networking::INVALID_PLAYER_ID, os.str());
 }
 
-Message ServerLobbyUpdateMessage(int receiver, const MultiplayerLobbyData& lobby_data) {
+MessagePacket ServerLobbyUpdateMessage(int receiver, const MultiplayerLobbyData& lobby_data) {
     std::ostringstream os;
     {
         freeorion_xml_oarchive oa(os);
         oa << BOOST_SERIALIZATION_NVP(lobby_data);
     }
-    return Message(Message::LOBBY_UPDATE, Networking::INVALID_PLAYER_ID, receiver, os.str());
+    return MessagePacket(MessagePacket::LOBBY_UPDATE, Networking::INVALID_PLAYER_ID, receiver, os.str());
 }
 
-Message LobbyChatMessage(int sender, int receiver, const std::string& data)
-{ return Message(Message::LOBBY_CHAT, sender, receiver, data); }
+MessagePacket LobbyChatMessage(int sender, int receiver, const std::string& data)
+{ return MessagePacket(MessagePacket::LOBBY_CHAT, sender, receiver, data); }
 
-Message ServerLobbyChatMessage(int sender, int receiver, const std::string& data)
-{ return Message(Message::LOBBY_CHAT, sender, receiver, data); }
+MessagePacket ServerLobbyChatMessage(int sender, int receiver, const std::string& data)
+{ return MessagePacket(MessagePacket::LOBBY_CHAT, sender, receiver, data); }
 
-Message StartMPGameMessage(int player_id)
-{ return Message(Message::START_MP_GAME, player_id, Networking::INVALID_PLAYER_ID, DUMMY_EMPTY_MESSAGE); }
+MessagePacket StartMPGameMessage(int player_id)
+{ return MessagePacket(MessagePacket::START_MP_GAME, player_id, Networking::INVALID_PLAYER_ID, DUMMY_EMPTY_MESSAGE); }
 
 
 ////////////////////////////////////////////////
-// Message data extractors
+// MessagePacket data extractors
 ////////////////////////////////////////////////
-void ExtractErrorMessageData(const Message& msg, std::string& problem, bool& fatal) {
+void ExtractErrorMessageData(const MessagePacket& msg, std::string& problem, bool& fatal) {
     try {
         std::istringstream is(msg.Text());
         freeorion_xml_iarchive ia(is);
         ia >> BOOST_SERIALIZATION_NVP(problem)
            >> BOOST_SERIALIZATION_NVP(fatal);
     } catch (const std::exception& err) {
-        ErrorLogger() << "ExtractErrorMessageData(const Message& msg, std::string& problem, bool& fatal) failed!  Message:\n"
+        ErrorLogger() << "ExtractErrorMessageData(const MessagePacket& msg, std::string& problem, bool& fatal) failed!  Message:\n"
                       << msg.Text() << "\n"
                       << "Error: " << err.what();
         problem = UserStringNop("SERVER_MESSAGE_NOT_UNDERSTOOD");
@@ -676,7 +676,7 @@ void ExtractErrorMessageData(const Message& msg, std::string& problem, bool& fat
     }
 }
 
-void ExtractHostMPGameMessageData(const Message& msg, std::string& host_player_name, std::string& client_version_string) {
+void ExtractHostMPGameMessageData(const MessagePacket& msg, std::string& host_player_name, std::string& client_version_string) {
     try {
         std::istringstream is(msg.Text());
         freeorion_xml_iarchive ia(is);
@@ -684,28 +684,28 @@ void ExtractHostMPGameMessageData(const Message& msg, std::string& host_player_n
            >> BOOST_SERIALIZATION_NVP(client_version_string);
 
     } catch (const std::exception& err) {
-        ErrorLogger() << "ExtractHostMPGameMessageData(const Message& msg, std::string& host_player_name, std::string& client_version_string) failed!  Message:\n"
+        ErrorLogger() << "ExtractHostMPGameMessageData(const MessagePacket& msg, std::string& host_player_name, std::string& client_version_string) failed!  Message:\n"
                       << msg.Text() << "\n"
                       << "Error: " << err.what();
         throw err;
     }
 }
 
-void ExtractLobbyUpdateMessageData(const Message& msg, MultiplayerLobbyData& lobby_data) {
+void ExtractLobbyUpdateMessageData(const MessagePacket& msg, MultiplayerLobbyData& lobby_data) {
     try {
         std::istringstream is(msg.Text());
         freeorion_xml_iarchive ia(is);
         ia >> BOOST_SERIALIZATION_NVP(lobby_data);
 
     } catch (const std::exception& err) {
-        ErrorLogger() << "ExtractLobbyUpdateMessageData(const Message& msg, MultiplayerLobbyData& lobby_data) failed!  Message:\n"
+        ErrorLogger() << "ExtractLobbyUpdateMessageData(const MessagePacket& msg, MultiplayerLobbyData& lobby_data) failed!  Message:\n"
                       << msg.Text() << "\n"
                       << "Error: " << err.what();
         throw err;
     }
 }
 
-void ExtractGameStartMessageData(const Message& msg, bool& single_player_game, int& empire_id, int& current_turn,
+void ExtractGameStartMessageData(const MessagePacket& msg, bool& single_player_game, int& empire_id, int& current_turn,
                         EmpireManager& empires, Universe& universe, SpeciesManager& species, CombatLogManager& combat_logs,
                         SupplyManager& supply,
                         std::map<int, PlayerInfo>& players, OrderSet& orders, bool& loaded_game_data, bool& ui_data_available,
@@ -793,13 +793,13 @@ void ExtractGameStartMessageData(const Message& msg, bool& single_player_game, i
         }
 
     } catch (const std::exception& err) {
-        ErrorLogger() << "ExtractGameStartMessageData(...) failed!  Message probably long, so not outputting to log.\n"
+        ErrorLogger() << "ExtractGameStartMessageData(...) failed!  MessagePacket probably long, so not outputting to log.\n"
                       << "Error: " << err.what();
         throw err;
     }
 }
 
-void ExtractJoinGameMessageData(const Message& msg, std::string& player_name, Networking::ClientType& client_type,
+void ExtractJoinGameMessageData(const MessagePacket& msg, std::string& player_name, Networking::ClientType& client_type,
                         std::string& version_string)
 {
     DebugLogger() << "ExtractJoinGameMessageData() from " << player_name << " client type " << client_type;
@@ -811,7 +811,7 @@ void ExtractJoinGameMessageData(const Message& msg, std::string& player_name, Ne
            >> BOOST_SERIALIZATION_NVP(version_string);
 
     } catch (const std::exception& err) {
-        ErrorLogger() << "ExtractJoinGameMessageData(const Message& msg, std::string& player_name, "
+        ErrorLogger() << "ExtractJoinGameMessageData(const MessagePacket& msg, std::string& player_name, "
                       << "Networking::ClientType client_type, std::string& version_string) failed!  Message:\n"
                       << msg.Text() << "\n"
                       << "Error: " << err.what();
@@ -819,21 +819,21 @@ void ExtractJoinGameMessageData(const Message& msg, std::string& player_name, Ne
     }
 }
 
-void ExtractTurnOrdersMessageData(const Message& msg, OrderSet& orders) {
+void ExtractTurnOrdersMessageData(const MessagePacket& msg, OrderSet& orders) {
     try {
         std::istringstream is(msg.Text());
         freeorion_xml_iarchive ia(is);
         Deserialize(ia, orders);
 
     } catch (const std::exception& err) {
-        ErrorLogger() << "ExtractTurnOrdersMessageData(const Message& msg, OrderSet& orders) failed!  Message:\n"
+        ErrorLogger() << "ExtractTurnOrdersMessageData(const MessagePacket& msg, OrderSet& orders) failed!  Message:\n"
                       << msg.Text() << "\n"
                       << "Error: " << err.what();
         throw err;
     }
 }
 
-void ExtractTurnUpdateMessageData(const Message& msg, int empire_id, int& current_turn, EmpireManager& empires,
+void ExtractTurnUpdateMessageData(const MessagePacket& msg, int empire_id, int& current_turn, EmpireManager& empires,
                                   Universe& universe, SpeciesManager& species, CombatLogManager& combat_logs,
                                   SupplyManager& supply, std::map<int, PlayerInfo>& players)
 {
@@ -868,13 +868,13 @@ void ExtractTurnUpdateMessageData(const Message& msg, int empire_id, int& curren
         }
 
     } catch (const std::exception& err) {
-        ErrorLogger() << "ExtractTurnUpdateMessageData(...) failed!  Message probably long, so not outputting to log.\n"
+        ErrorLogger() << "ExtractTurnUpdateMessageData(...) failed!  MessagePacket probably long, so not outputting to log.\n"
                       << "Error: " << err.what();
         throw err;
     }
 }
 
-void ExtractTurnPartialUpdateMessageData(const Message& msg, int empire_id, Universe& universe) {
+void ExtractTurnPartialUpdateMessageData(const MessagePacket& msg, int empire_id, Universe& universe) {
     try {
         ScopedTimer timer("Mid Turn Update Unpacking", true);
 
@@ -894,13 +894,13 @@ void ExtractTurnPartialUpdateMessageData(const Message& msg, int empire_id, Univ
         }
 
     } catch (const std::exception& err) {
-        ErrorLogger() << "ExtracturnPartialUpdateMessageData(...) failed!  Message probably long, so not outputting to log.\n"
+        ErrorLogger() << "ExtracturnPartialUpdateMessageData(...) failed!  MessagePacket probably long, so not outputting to log.\n"
                       << "Error: " << err.what();
         throw err;
     }
 }
 
-void ExtractClientSaveDataMessageData(const Message& msg, OrderSet& orders, bool& ui_data_available,
+void ExtractClientSaveDataMessageData(const MessagePacket& msg, OrderSet& orders, bool& ui_data_available,
                                       SaveGameUIData& ui_data, bool& save_state_string_available,
                                       std::string& save_state_string)
 {
@@ -923,27 +923,27 @@ void ExtractClientSaveDataMessageData(const Message& msg, OrderSet& orders, bool
         }
 
     } catch (const std::exception& err) {
-        ErrorLogger() << "ExtractClientSaveDataMessageData(...) failed!  Message probably long, so not outputting to log.\n"
+        ErrorLogger() << "ExtractClientSaveDataMessageData(...) failed!  MessagePacket probably long, so not outputting to log.\n"
                       << "Error: " << err.what();
         throw err;
     }
 }
 
-void ExtractTurnProgressMessageData(const Message& msg, Message::TurnProgressPhase& phase_id) {
+void ExtractTurnProgressMessageData(const MessagePacket& msg, MessagePacket::TurnProgressPhase& phase_id) {
     try {
         std::istringstream is(msg.Text());
         freeorion_xml_iarchive ia(is);
         ia >> BOOST_SERIALIZATION_NVP(phase_id);
 
     } catch (const std::exception& err) {
-        ErrorLogger() << "ExtractTurnProgressMessageData(const Message& msg, Message::TurnProgressPhase& phase_id) failed!  Message:\n"
+        ErrorLogger() << "ExtractTurnProgressMessageData(const MessagePacket& msg, MessagePacket::TurnProgressPhase& phase_id) failed!  Message:\n"
                       << msg.Text() << "\n"
                       << "Error: " << err.what();
         throw err;
     }
 }
 
-void ExtractPlayerStatusMessageData(const Message& msg, int& about_player_id, Message::PlayerStatus& status) {
+void ExtractPlayerStatusMessageData(const MessagePacket& msg, int& about_player_id, MessagePacket::PlayerStatus& status) {
     try {
         std::istringstream is(msg.Text());
         freeorion_xml_iarchive ia(is);
@@ -951,14 +951,14 @@ void ExtractPlayerStatusMessageData(const Message& msg, int& about_player_id, Me
            >> BOOST_SERIALIZATION_NVP(status);
  
     } catch (const std::exception& err) {
-        ErrorLogger() << "ExtractPlayerStatusMessageData(const Message& msg, int& about_player_id, Message::PlayerStatus&) failed!  Message:\n"
+        ErrorLogger() << "ExtractPlayerStatusMessageData(const MessagePacket& msg, int& about_player_id, MessagePacket::PlayerStatus&) failed!  Message:\n"
                       << msg.Text() << "\n"
                       << "Error: " << err.what();
         throw err;
     }
 }
 
-void ExtractHostSPGameMessageData(const Message& msg, SinglePlayerSetupData& setup_data, std::string& client_version_string) {
+void ExtractHostSPGameMessageData(const MessagePacket& msg, SinglePlayerSetupData& setup_data, std::string& client_version_string) {
     try {
         std::istringstream is(msg.Text());
         freeorion_xml_iarchive ia(is);
@@ -966,14 +966,14 @@ void ExtractHostSPGameMessageData(const Message& msg, SinglePlayerSetupData& set
            >> BOOST_SERIALIZATION_NVP(client_version_string);
 
     } catch (const std::exception& err) {
-        ErrorLogger() << "ExtractHostSPGameMessageData(const Message& msg, SinglePlayerSetupData& setup_data, std::string& client_version_string) failed!  Message:\n"
+        ErrorLogger() << "ExtractHostSPGameMessageData(const MessagePacket& msg, SinglePlayerSetupData& setup_data, std::string& client_version_string) failed!  Message:\n"
                       << msg.Text() << "\n"
                       << "Error: " << err.what();
         throw err;
     }
 }
 
-void ExtractEndGameMessageData(const Message& msg, Message::EndGameReason& reason, std::string& reason_player_name) {
+void ExtractEndGameMessageData(const MessagePacket& msg, MessagePacket::EndGameReason& reason, std::string& reason_player_name) {
     try {
         std::istringstream is(msg.Text());
         freeorion_xml_iarchive ia(is);
@@ -981,7 +981,7 @@ void ExtractEndGameMessageData(const Message& msg, Message::EndGameReason& reaso
            >> BOOST_SERIALIZATION_NVP(reason_player_name);
 
     } catch (const std::exception& err) {
-        ErrorLogger() << "ExtractEndGameMessageData(const Message& msg, Message::EndGameReason& reason, "
+        ErrorLogger() << "ExtractEndGameMessageData(const MessagePacket& msg, MessagePacket::EndGameReason& reason, "
                       << "std::string& reason_player_name) failed!  Message:\n"
                       << msg.Text() << "\n"
                       << "Error: " << err.what();
@@ -989,28 +989,28 @@ void ExtractEndGameMessageData(const Message& msg, Message::EndGameReason& reaso
     }
 }
 
-void ExtractModeratorActionMessageData(const Message& msg, Moderator::ModeratorAction*& mod_action) {
+void ExtractModeratorActionMessageData(const MessagePacket& msg, Moderator::ModeratorAction*& mod_action) {
     try {
         std::istringstream is(msg.Text());
         freeorion_xml_iarchive ia(is);
         ia >> BOOST_SERIALIZATION_NVP(mod_action);
 
     } catch (const std::exception& err) {
-        ErrorLogger() << "ExtractModeratorActionMessageData(const Message& msg, Moderator::ModeratorAction& mod_act) "
+        ErrorLogger() << "ExtractModeratorActionMessageData(const MessagePacket& msg, Moderator::ModeratorAction& mod_act) "
                       << "failed!  Message:\n"
                       << msg.Text() << "\n"
                       << "Error: " << err.what();
     }
 }
 
-void ExtractDiplomacyMessageData(const Message& msg, DiplomaticMessage& diplo_message) {
+void ExtractDiplomacyMessageData(const MessagePacket& msg, DiplomaticMessage& diplo_message) {
     try {
         std::istringstream is(msg.Text());
         freeorion_xml_iarchive ia(is);
         ia >> BOOST_SERIALIZATION_NVP(diplo_message);
 
     } catch (const std::exception& err) {
-        ErrorLogger() << "ExtractDiplomacyMessageData(const Message& msg, DiplomaticMessage& "
+        ErrorLogger() << "ExtractDiplomacyMessageData(const MessagePacket& msg, DiplomaticMessage& "
                       << "diplo_message) failed!  Message:\n"
                       << msg.Text() << "\n"
                       << "Error: " << err.what();
@@ -1018,7 +1018,7 @@ void ExtractDiplomacyMessageData(const Message& msg, DiplomaticMessage& diplo_me
     }
 }
 
-void ExtractDiplomaticStatusMessageData(const Message& msg, DiplomaticStatusUpdateInfo& diplo_update) {
+void ExtractDiplomaticStatusMessageData(const MessagePacket& msg, DiplomaticStatusUpdateInfo& diplo_update) {
     try {
         std::istringstream is(msg.Text());
         freeorion_xml_iarchive ia(is);
@@ -1027,31 +1027,31 @@ void ExtractDiplomaticStatusMessageData(const Message& msg, DiplomaticStatusUpda
            >> BOOST_SERIALIZATION_NVP(diplo_update.diplo_status);
 
     } catch (const std::exception& err) {
-        ErrorLogger() << "ExtractDiplomaticStatusMessageData(const Message& msg, DiplomaticStatusUpdate& diplo_update) failed!  Message:\n"
+        ErrorLogger() << "ExtractDiplomaticStatusMessageData(const MessagePacket& msg, DiplomaticStatusUpdate& diplo_update) failed!  Message:\n"
                       << msg.Text() << "\n"
                       << "Error: " << err.what();
         throw err;
     }
 }
 
-void ExtractRequestSavePreviewsMessageData(const Message& msg, std::string& directory)
+void ExtractRequestSavePreviewsMessageData(const MessagePacket& msg, std::string& directory)
 { directory = msg.Text(); }
 
-void ExtractDispatchSavePreviewsMessageData(const Message& msg, PreviewInformation& previews) {
+void ExtractDispatchSavePreviewsMessageData(const MessagePacket& msg, PreviewInformation& previews) {
     try {
         std::istringstream is(msg.Text());
         freeorion_xml_iarchive ia(is);
         ia >> BOOST_SERIALIZATION_NVP(previews);
 
     } catch(const std::exception& err) {
-        ErrorLogger() << "ExtractDispatchSavePreviewsMessageData(const Message& msg, PreviewInformation& previews) failed!  Message:\n"
+        ErrorLogger() << "ExtractDispatchSavePreviewsMessageData(const MessagePacket& msg, PreviewInformation& previews) failed!  Message:\n"
                       << msg.Text() << "\n"
                       << "Error: " << err.what();
         throw err;
     }
 }
 
-FO_COMMON_API void ExtractServerSaveGameCompleteMessageData(const Message& msg, std::string& save_filename, int& bytes_written) {
+FO_COMMON_API void ExtractServerSaveGameCompleteMessageData(const MessagePacket& msg, std::string& save_filename, int& bytes_written) {
     try {
         std::istringstream is(msg.Text());
         freeorion_xml_iarchive ia(is);
@@ -1059,20 +1059,20 @@ FO_COMMON_API void ExtractServerSaveGameCompleteMessageData(const Message& msg, 
            >> BOOST_SERIALIZATION_NVP(bytes_written);
 
     } catch(const std::exception& err) {
-        ErrorLogger() << "ExtractServerSaveGameCompleteServerSaveGameCompleteMessageData(const Message& msg, std::string& save_filename, int& bytes_written) failed!  Message:\n"
+        ErrorLogger() << "ExtractServerSaveGameCompleteServerSaveGameCompleteMessageData(const MessagePacket& msg, std::string& save_filename, int& bytes_written) failed!  Message:\n"
                       << msg.Text() << "\n"
                       << "Error: " << err.what();
         throw err;
     }
 }
 
-FO_COMMON_API void ExtractRequestCombatLogsMessageData(const Message& msg, std::vector<int>& ids) {
+FO_COMMON_API void ExtractRequestCombatLogsMessageData(const MessagePacket& msg, std::vector<int>& ids) {
     try {
         std::istringstream is(msg.Text());
         freeorion_xml_iarchive ia(is);
         ia >> BOOST_SERIALIZATION_NVP(ids);
     } catch(const std::exception& err) {
-        ErrorLogger() << "ExtractRequestCombatLogMessageData(const Message& msg, std::vector<int>& ids) failed!  Message:\n"
+        ErrorLogger() << "ExtractRequestCombatLogMessageData(const MessagePacket& msg, std::vector<int>& ids) failed!  Message:\n"
                       << msg.Text() << "\n"
                       << "Error: " << err.what();
         throw err;
@@ -1080,14 +1080,14 @@ FO_COMMON_API void ExtractRequestCombatLogsMessageData(const Message& msg, std::
 }
 
 FO_COMMON_API void ExtractDispatchCombatLogsMessageData(
-    const Message& msg, std::vector<std::pair<int, CombatLog>>& logs)
+    const MessagePacket& msg, std::vector<std::pair<int, CombatLog>>& logs)
 {
     try {
         std::istringstream is(msg.Text());
         freeorion_xml_iarchive ia(is);
         ia >> BOOST_SERIALIZATION_NVP(logs);
     } catch(const std::exception& err) {
-        ErrorLogger() << "ExtractDispatchCombatLogMessageData(const Message& msg, std::vector<std::pair<int, const CombatLog&>>& logs) failed!  Message:\n"
+        ErrorLogger() << "ExtractDispatchCombatLogMessageData(const MessagePacket& msg, std::vector<std::pair<int, const CombatLog&>>& logs) failed!  Message:\n"
                       << msg.Text() << "\n"
                       << "Error: " << err.what();
         throw err;

--- a/network/Message.h
+++ b/network/Message.h
@@ -22,7 +22,7 @@ class SupplyManager;
 class SpeciesManager;
 class CombatLog;
 class CombatLogManager;
-class Message;
+class MessagePacket;
 struct MultiplayerLobbyData;
 class OrderSet;
 struct PlayerInfo;
@@ -45,7 +45,7 @@ namespace Moderator {
   * thread unsafe on many platforms, so a dynamically allocated char array is
   * used instead.  (It was feared that using another STL container of char might
   * misbehave as well.) */
-class FO_COMMON_API Message {
+class FO_COMMON_API MessagePacket {
 public:
     typedef std::array<int, 5> HeaderBuffer;
 
@@ -118,9 +118,9 @@ public:
     )
 
     /** \name Structors */ //@{
-    Message();
+    MessagePacket();
 
-    Message(MessageType message_type,
+    MessagePacket(MessageType message_type,
             int sending_player,
             int receiving_player,
             const std::string& text,
@@ -140,7 +140,7 @@ public:
     /** \name Accessors */ //@{
     void        Resize(std::size_t size);   ///< Resizes the underlying char buffer to \a size uninitialized bytes.
     char*       Data();                     ///< Returns the underlying buffer.
-    void        Swap(Message& rhs);         ///< Swaps the contents of \a *this with \a rhs.  Does not throw.
+    void        Swap(MessagePacket& rhs);         ///< Swaps the contents of \a *this with \a rhs.  Does not throw.
     //@}
 
 private:
@@ -152,51 +152,51 @@ private:
 
     boost::shared_array<char> m_message_text;
 
-    friend FO_COMMON_API void BufferToHeader(const HeaderBuffer&, Message&);
+    friend FO_COMMON_API void BufferToHeader(const HeaderBuffer&, MessagePacket&);
 };
 
 /** Fills in the relevant portions of \a message with the values in the buffer \a buffer. */
-FO_COMMON_API void BufferToHeader(const Message::HeaderBuffer& buffer, Message& message);
+FO_COMMON_API void BufferToHeader(const MessagePacket::HeaderBuffer& buffer, MessagePacket& message);
 
 /** Fills \a header_buf from the relevant portions of \a message. */
-FO_COMMON_API void HeaderToBuffer(const Message& message, Message::HeaderBuffer& buffer);
+FO_COMMON_API void HeaderToBuffer(const MessagePacket& message, MessagePacket::HeaderBuffer& buffer);
 
-bool operator==(const Message& lhs, const Message& rhs);
-bool operator!=(const Message& lhs, const Message& rhs);
+bool operator==(const MessagePacket& lhs, const MessagePacket& rhs);
+bool operator!=(const MessagePacket& lhs, const MessagePacket& rhs);
 
-FO_COMMON_API void swap(Message& lhs, Message& rhs); ///< Swaps the contents of \a lhs and \a rhs.  Does not throw.
+FO_COMMON_API void swap(MessagePacket& lhs, MessagePacket& rhs); ///< Swaps the contents of \a lhs and \a rhs.  Does not throw.
 
 
 ////////////////////////////////////////////////
-// Message stringification
+// MessagePacket stringification
 ////////////////////////////////////////////////
 
 /** Writes \a msg to \a os.  The format of the output is designed for debugging purposes. */
-FO_COMMON_API std::ostream& operator<<(std::ostream& os, const Message& msg);
+FO_COMMON_API std::ostream& operator<<(std::ostream& os, const MessagePacket& msg);
 
 
 ////////////////////////////////////////////////
-// Message named ctors
+// MessagePacket named ctors
 ////////////////////////////////////////////////
 
 /** creates an ERROR_MSG message*/
-FO_COMMON_API Message ErrorMessage(const std::string& problem, bool fatal = true);
-FO_COMMON_API Message ErrorMessage(int player_id, const std::string& problem, bool fatal = true);
+FO_COMMON_API MessagePacket ErrorMessage(const std::string& problem, bool fatal = true);
+FO_COMMON_API MessagePacket ErrorMessage(int player_id, const std::string& problem, bool fatal = true);
 
 /** creates a HOST_SP_GAME message*/
-FO_COMMON_API Message HostSPGameMessage(const SinglePlayerSetupData& setup_data);
+FO_COMMON_API MessagePacket HostSPGameMessage(const SinglePlayerSetupData& setup_data);
 
 /** creates a minimal HOST_MP_GAME message used to initiate multiplayer "lobby" setup*/
-FO_COMMON_API Message HostMPGameMessage(const std::string& host_player_name);
+FO_COMMON_API MessagePacket HostMPGameMessage(const std::string& host_player_name);
 
 /** creates a JOIN_GAME message.  The sender's player name and client type are sent in the message.*/
-FO_COMMON_API Message JoinGameMessage(const std::string& player_name, Networking::ClientType client_type);
+FO_COMMON_API MessagePacket JoinGameMessage(const std::string& player_name, Networking::ClientType client_type);
 
 /** creates a HOST_ID message.  The player ID of the host is sent in the message. */
-FO_COMMON_API Message HostIDMessage(int host_player_id);
+FO_COMMON_API MessagePacket HostIDMessage(int host_player_id);
 
 /** creates a GAME_START message.  Contains the initial game state visible to player \a player_id.*/
-FO_COMMON_API Message GameStartMessage(int player_id, bool single_player_game, int empire_id, int current_turn,
+FO_COMMON_API MessagePacket GameStartMessage(int player_id, bool single_player_game, int empire_id, int current_turn,
                                        const EmpireManager& empires, const Universe& universe,
                                        const SpeciesManager& species, CombatLogManager& combat_logs,
                                        const SupplyManager& supply, const std::map<int, PlayerInfo>& players,
@@ -204,7 +204,7 @@ FO_COMMON_API Message GameStartMessage(int player_id, bool single_player_game, i
 
 /** creates a GAME_START message.  Contains the initial game state visible to
   * player \a player_id.  Also includes data loaded from a saved game. */
-FO_COMMON_API Message GameStartMessage(int player_id, bool single_player_game, int empire_id, int current_turn,
+FO_COMMON_API MessagePacket GameStartMessage(int player_id, bool single_player_game, int empire_id, int current_turn,
                                        const EmpireManager& empires, const Universe& universe,
                                        const SpeciesManager& species, CombatLogManager& combat_logs,
                                        const SupplyManager& supply,
@@ -214,7 +214,7 @@ FO_COMMON_API Message GameStartMessage(int player_id, bool single_player_game, i
 
 /** creates a GAME_START message.  Contains the initial game state visible to
   * player \a player_id.  Also includes state string loaded from a saved game. */
-FO_COMMON_API Message GameStartMessage(int player_id, bool single_player_game, int empire_id, int current_turn,
+FO_COMMON_API MessagePacket GameStartMessage(int player_id, bool single_player_game, int empire_id, int current_turn,
                                        const EmpireManager& empires, const Universe& universe,
                                        const SpeciesManager& species, CombatLogManager& combat_logs,
                                        const SupplyManager& supply,
@@ -224,152 +224,152 @@ FO_COMMON_API Message GameStartMessage(int player_id, bool single_player_game, i
 
 /** creates a HOST_SP_GAME acknowledgement message.  The \a player_id is the ID
   * of the receiving player.  This message should only be sent by the server.*/
-FO_COMMON_API Message HostSPAckMessage(int player_id);
+FO_COMMON_API MessagePacket HostSPAckMessage(int player_id);
 
 /** creates a HOST_MP_GAME acknowledgement message.  The \a player_id is the ID
   * of the receiving player.  This message should only be sent by the server.*/
-FO_COMMON_API Message HostMPAckMessage(int player_id);
+FO_COMMON_API MessagePacket HostMPAckMessage(int player_id);
 
 /** creates a JOIN_GAME acknowledgement message.  The \a player_id is the ID of
   * the receiving player.  This message should only be sent by the server.*/
-FO_COMMON_API Message JoinAckMessage(int player_id);
+FO_COMMON_API MessagePacket JoinAckMessage(int player_id);
 
 /** creates a TURN_ORDERS message. */
-FO_COMMON_API Message TurnOrdersMessage(int sender, const OrderSet& orders);
+FO_COMMON_API MessagePacket TurnOrdersMessage(int sender, const OrderSet& orders);
 
 /** creates a TURN_PROGRESS message. */
-FO_COMMON_API Message TurnProgressMessage(Message::TurnProgressPhase phase_id, int player_id = Networking::INVALID_PLAYER_ID);
+FO_COMMON_API MessagePacket TurnProgressMessage(MessagePacket::TurnProgressPhase phase_id, int player_id = Networking::INVALID_PLAYER_ID);
 
 /** creates a PLAYER_STATUS message. */
-FO_COMMON_API Message PlayerStatusMessage(int player_id, int about_player_id, Message::PlayerStatus player_status);
+FO_COMMON_API MessagePacket PlayerStatusMessage(int player_id, int about_player_id, MessagePacket::PlayerStatus player_status);
 
 /** creates a TURN_UPDATE message. */
-FO_COMMON_API Message TurnUpdateMessage(int player_id, int empire_id, int current_turn,
+FO_COMMON_API MessagePacket TurnUpdateMessage(int player_id, int empire_id, int current_turn,
                                         const EmpireManager& empires, const Universe& universe,
                                         const SpeciesManager& species, CombatLogManager& combat_logs,
                                         const SupplyManager& supply,
                                         const std::map<int, PlayerInfo>& players, bool use_binary_serialization);
 
 /** create a TURN_PARTIAL_UPDATE message. */
-FO_COMMON_API Message TurnPartialUpdateMessage(int player_id, int empire_id, const Universe& universe,
+FO_COMMON_API MessagePacket TurnPartialUpdateMessage(int player_id, int empire_id, const Universe& universe,
                                                bool use_binary_serialization);
 
 /** creates a CLIENT_SAVE_DATA message, including UI data but without a state string. */
-FO_COMMON_API Message ClientSaveDataMessage(int sender, const OrderSet& orders, const SaveGameUIData& ui_data);
+FO_COMMON_API MessagePacket ClientSaveDataMessage(int sender, const OrderSet& orders, const SaveGameUIData& ui_data);
 
 /** creates a CLIENT_SAVE_DATA message, without UI data but with a state string. */
-FO_COMMON_API Message ClientSaveDataMessage(int sender, const OrderSet& orders, const std::string& save_state_string);
+FO_COMMON_API MessagePacket ClientSaveDataMessage(int sender, const OrderSet& orders, const std::string& save_state_string);
 
 /** creates a CLIENT_SAVE_DATA message, without UI data and without a state string. */
-Message ClientSaveDataMessage(int sender, const OrderSet& orders);
+FO_COMMON_API MessagePacket ClientSaveDataMessage(int sender, const OrderSet& orders);
 
 /** creates an REQUEST_NEW_OBJECT_ID message. This message is a synchronous
     message, when sent it will wait for a reply from the server */
-FO_COMMON_API Message RequestNewObjectIDMessage(int sender);
+FO_COMMON_API MessagePacket RequestNewObjectIDMessage(int sender);
 
 /** creates an DISPATCH_NEW_OBJECT_ID  message.  This message is sent to a
   * client who is waiting for a new object ID */
-FO_COMMON_API Message DispatchObjectIDMessage(int player_id, int new_id);
+FO_COMMON_API MessagePacket DispatchObjectIDMessage(int player_id, int new_id);
 
 /** creates an REQUEST_NEW_DESIGN_ID message. This message is a synchronous
     message, when sent it will wait for a reply from the server */
-FO_COMMON_API Message RequestNewDesignIDMessage(int sender);
+FO_COMMON_API MessagePacket RequestNewDesignIDMessage(int sender);
 
 /** creates an DISPATCH_NEW_DESIGN_ID  message.  This message is sent to a
   * client who is waiting for a new design ID */
-FO_COMMON_API Message DispatchDesignIDMessage(int player_id, int new_id);
+FO_COMMON_API MessagePacket DispatchDesignIDMessage(int player_id, int new_id);
 
 /** creates a SAVE_GAME_INITIATE request message.  This message should only be sent by
   * the host player.*/
-FO_COMMON_API Message HostSaveGameInitiateMessage(int sender, const std::string& filename);
+FO_COMMON_API MessagePacket HostSaveGameInitiateMessage(int sender, const std::string& filename);
 
 /** creates a SAVE_GAME_DATA_REQUEST data request message.  This message should
     only be sent by the server to get game data from a client, or to respond to
     the host player requesting a save be initiated. */
-FO_COMMON_API Message ServerSaveGameDataRequestMessage(int receiver, bool synchronous_response);
+FO_COMMON_API MessagePacket ServerSaveGameDataRequestMessage(int receiver, bool synchronous_response);
 
 /** creates a SAVE_GAME_COMPLETE complete message.  This message should only be
     sent by the server to inform clients that the last initiated save has been
     completed successfully. */
-FO_COMMON_API Message ServerSaveGameCompleteMessage(const std::string& save_filename, int bytes_written);
+FO_COMMON_API MessagePacket ServerSaveGameCompleteMessage(const std::string& save_filename, int bytes_written);
 
 /** creates a PLAYER_CHAT, which is sent to the server, and then from the server
   * to all players, including the originating player.*/
-FO_COMMON_API Message GlobalChatMessage(int sender, const std::string& msg);
+FO_COMMON_API MessagePacket GlobalChatMessage(int sender, const std::string& msg);
 
 /** creates a PLAYER_CHAT message, which is sent to the server, and then from
   * the server to a single recipient player */
-FO_COMMON_API Message SingleRecipientChatMessage(int sender, int receiver, const std::string& msg);
+FO_COMMON_API MessagePacket SingleRecipientChatMessage(int sender, int receiver, const std::string& msg);
 
 /** creates a DIPLOMACY message, which is sent between players via the server to
   * declare, proposed, or accept / reject diplomatic arrangements or agreements. */
-FO_COMMON_API Message DiplomacyMessage(int sender, int receiver, const DiplomaticMessage& diplo_message);
+FO_COMMON_API MessagePacket DiplomacyMessage(int sender, int receiver, const DiplomaticMessage& diplo_message);
 
 /** creates a DIPLOMATIC_STATUS message, which is sent to players by the server to
   * update them on diplomatic status changes between players. */
-FO_COMMON_API Message DiplomaticStatusMessage(int receiver, const DiplomaticStatusUpdateInfo& diplo_update);
+FO_COMMON_API MessagePacket DiplomaticStatusMessage(int receiver, const DiplomaticStatusUpdateInfo& diplo_update);
 
 /** creates an END_GAME message used to terminate an active game. */
-FO_COMMON_API Message EndGameMessage(int receiver, Message::EndGameReason reason, const std::string& reason_player_name = "");
+FO_COMMON_API MessagePacket EndGameMessage(int receiver, MessagePacket::EndGameReason reason, const std::string& reason_player_name = "");
 
 /** creates an AI_END_GAME_ACK message used to indicate that the AI has shutdown. */
-FO_COMMON_API Message AIEndGameAcknowledgeMessage(int sender);
+FO_COMMON_API MessagePacket AIEndGameAcknowledgeMessage(int sender);
 
 /** creates a MODERATOR_ACTION message used to implement moderator commands. */
-FO_COMMON_API Message ModeratorActionMessage(int sender, const Moderator::ModeratorAction& mod_action);
+FO_COMMON_API MessagePacket ModeratorActionMessage(int sender, const Moderator::ModeratorAction& mod_action);
 
 /** tells server to shut down. */
-FO_COMMON_API Message ShutdownServerMessage(int sender);
+FO_COMMON_API MessagePacket ShutdownServerMessage(int sender);
 
 /** requests previews of savefiles from server */
-FO_COMMON_API Message RequestSavePreviewsMessage(int sender, std::string directory);
+FO_COMMON_API MessagePacket RequestSavePreviewsMessage(int sender, std::string directory);
 
 /** returns the savegame previews to the client */
-FO_COMMON_API Message DispatchSavePreviewsMessage(int receiver, const PreviewInformation& preview);
+FO_COMMON_API MessagePacket DispatchSavePreviewsMessage(int receiver, const PreviewInformation& preview);
 
 /** requests combat logs from server */
-FO_COMMON_API Message RequestCombatLogsMessage(int sender, const std::vector<int>& ids);
+FO_COMMON_API MessagePacket RequestCombatLogsMessage(int sender, const std::vector<int>& ids);
 
 /** returns combat logs to the client */
-FO_COMMON_API Message DispatchCombatLogsMessage(int receiver, const std::vector<std::pair<int, const CombatLog>>& logs);
+FO_COMMON_API MessagePacket DispatchCombatLogsMessage(int receiver, const std::vector<std::pair<int, const CombatLog>>& logs);
 
 ////////////////////////////////////////////////
-// Multiplayer Lobby Message named ctors
+// Multiplayer Lobby MessagePacket named ctors
 ////////////////////////////////////////////////
 
 /** creates an LOBBY_UPDATE message containing changes to the lobby settings that need to propogate to the 
     server, then to other users.  Clients must send all such updates to the server directly; the server
     will send updates to the other clients as needed.*/
-FO_COMMON_API Message LobbyUpdateMessage(int sender, const MultiplayerLobbyData& lobby_data);
+FO_COMMON_API MessagePacket LobbyUpdateMessage(int sender, const MultiplayerLobbyData& lobby_data);
 
 /** creates an LOBBY_UPDATE message containing changes to the lobby settings that need to propogate to the users.  
     This message should only be sent by the server.*/
-FO_COMMON_API Message ServerLobbyUpdateMessage(int receiver, const MultiplayerLobbyData& lobby_data);
+FO_COMMON_API MessagePacket ServerLobbyUpdateMessage(int receiver, const MultiplayerLobbyData& lobby_data);
 
 /** creates an LOBBY_CHAT message containing a chat string to be broadcast to player \a receiver, or all players if \a
     receiver is Networking::INVALID_PLAYER_ID. Note that the receiver of this message is always the server.*/
-FO_COMMON_API Message LobbyChatMessage(int sender, int receiver, const std::string& text);
+FO_COMMON_API MessagePacket LobbyChatMessage(int sender, int receiver, const std::string& text);
 
 /** creates an LOBBY_CHAT message containing a chat string from \a sender to be displayed in \a receiver's lobby dialog.
     This message should only be sent by the server.*/
-FO_COMMON_API Message ServerLobbyChatMessage(int sender, int receiver, const std::string& text);
+FO_COMMON_API MessagePacket ServerLobbyChatMessage(int sender, int receiver, const std::string& text);
 
 /** creates a START_MP_GAME used to finalize the multiplayer lobby setup.*/
-FO_COMMON_API Message StartMPGameMessage(int player_id);
+FO_COMMON_API MessagePacket StartMPGameMessage(int player_id);
 
 
 ////////////////////////////////////////////////
-// Message data extractors
+// MessagePacket data extractors
 ////////////////////////////////////////////////
 
-FO_COMMON_API void ExtractErrorMessageData(const Message& msg, std::string& problem, bool& fatal);
+FO_COMMON_API void ExtractErrorMessageData(const MessagePacket& msg, std::string& problem, bool& fatal);
 
-FO_COMMON_API void ExtractHostMPGameMessageData(const Message& msg, std::string& host_player_name,
+FO_COMMON_API void ExtractHostMPGameMessageData(const MessagePacket& msg, std::string& host_player_name,
                                                 std::string& client_version_string);
 
-FO_COMMON_API void ExtractLobbyUpdateMessageData(const Message& msg, MultiplayerLobbyData& lobby_data);
+FO_COMMON_API void ExtractLobbyUpdateMessageData(const MessagePacket& msg, MultiplayerLobbyData& lobby_data);
 
-FO_COMMON_API void ExtractGameStartMessageData(const Message& msg, bool& single_player_game, int& empire_id,
+FO_COMMON_API void ExtractGameStartMessageData(const MessagePacket& msg, bool& single_player_game, int& empire_id,
                                                int& current_turn, EmpireManager& empires, Universe& universe,
                                                SpeciesManager& species, CombatLogManager& combat_logs,
                                                SupplyManager& supply,
@@ -378,45 +378,45 @@ FO_COMMON_API void ExtractGameStartMessageData(const Message& msg, bool& single_
                                                SaveGameUIData& ui_data, bool& save_state_string_available,
                                                std::string& save_state_string, GalaxySetupData& galaxy_setup_data);
 
-FO_COMMON_API void ExtractJoinGameMessageData(const Message& msg, std::string& player_name,
+FO_COMMON_API void ExtractJoinGameMessageData(const MessagePacket& msg, std::string& player_name,
                                               Networking::ClientType& client_type,
                                               std::string& version_string);
 
-FO_COMMON_API void ExtractTurnOrdersMessageData(const Message& msg, OrderSet& orders);
+FO_COMMON_API void ExtractTurnOrdersMessageData(const MessagePacket& msg, OrderSet& orders);
 
-FO_COMMON_API void ExtractTurnUpdateMessageData(const Message& msg, int empire_id, int& current_turn, EmpireManager& empires,
+FO_COMMON_API void ExtractTurnUpdateMessageData(const MessagePacket& msg, int empire_id, int& current_turn, EmpireManager& empires,
                                                 Universe& universe, SpeciesManager& species, CombatLogManager& combat_logs,
                                                 SupplyManager& supply, std::map<int, PlayerInfo>& players);
 
-FO_COMMON_API void ExtractTurnPartialUpdateMessageData(const Message& msg, int empire_id, Universe& universe);
+FO_COMMON_API void ExtractTurnPartialUpdateMessageData(const MessagePacket& msg, int empire_id, Universe& universe);
 
-FO_COMMON_API void ExtractClientSaveDataMessageData(const Message& msg, OrderSet& orders,
+FO_COMMON_API void ExtractClientSaveDataMessageData(const MessagePacket& msg, OrderSet& orders,
                                                     bool& ui_data_available, SaveGameUIData& ui_data,
                                                     bool& save_state_string_available,
                                                     std::string& save_state_string);
 
-FO_COMMON_API void ExtractTurnProgressMessageData(const Message& msg, Message::TurnProgressPhase& phase_id);
+FO_COMMON_API void ExtractTurnProgressMessageData(const MessagePacket& msg, MessagePacket::TurnProgressPhase& phase_id);
 
-FO_COMMON_API void ExtractPlayerStatusMessageData(const Message& msg, int& about_player_id, Message::PlayerStatus& status);
+FO_COMMON_API void ExtractPlayerStatusMessageData(const MessagePacket& msg, int& about_player_id, MessagePacket::PlayerStatus& status);
 
-FO_COMMON_API void ExtractHostSPGameMessageData(const Message& msg, SinglePlayerSetupData& setup_data, std::string& client_version_string);
+FO_COMMON_API void ExtractHostSPGameMessageData(const MessagePacket& msg, SinglePlayerSetupData& setup_data, std::string& client_version_string);
 
-FO_COMMON_API void ExtractEndGameMessageData(const Message& msg, Message::EndGameReason& reason, std::string& reason_player_name);
+FO_COMMON_API void ExtractEndGameMessageData(const MessagePacket& msg, MessagePacket::EndGameReason& reason, std::string& reason_player_name);
 
-FO_COMMON_API void ExtractModeratorActionMessageData(const Message& msg, Moderator::ModeratorAction*& action);
+FO_COMMON_API void ExtractModeratorActionMessageData(const MessagePacket& msg, Moderator::ModeratorAction*& action);
 
-FO_COMMON_API void ExtractDiplomacyMessageData(const Message& msg, DiplomaticMessage& diplo_message);
+FO_COMMON_API void ExtractDiplomacyMessageData(const MessagePacket& msg, DiplomaticMessage& diplo_message);
 
-FO_COMMON_API void ExtractDiplomaticStatusMessageData(const Message& msg, DiplomaticStatusUpdateInfo& diplo_update);
+FO_COMMON_API void ExtractDiplomaticStatusMessageData(const MessagePacket& msg, DiplomaticStatusUpdateInfo& diplo_update);
 
-FO_COMMON_API void ExtractRequestSavePreviewsMessageData(const Message& msg, std::string& directory);
+FO_COMMON_API void ExtractRequestSavePreviewsMessageData(const MessagePacket& msg, std::string& directory);
 
-FO_COMMON_API void ExtractDispatchSavePreviewsMessageData(const Message& msg, PreviewInformation& previews);
+FO_COMMON_API void ExtractDispatchSavePreviewsMessageData(const MessagePacket& msg, PreviewInformation& previews);
 
-FO_COMMON_API void ExtractServerSaveGameCompleteMessageData(const Message& msg, std::string& save_filename, int& bytes_written);
+FO_COMMON_API void ExtractServerSaveGameCompleteMessageData(const MessagePacket& msg, std::string& save_filename, int& bytes_written);
 
-FO_COMMON_API void ExtractRequestCombatLogsMessageData(const Message& msg, std::vector<int>& ids);
+FO_COMMON_API void ExtractRequestCombatLogsMessageData(const MessagePacket& msg, std::vector<int>& ids);
 
-FO_COMMON_API void ExtractDispatchCombatLogsMessageData(const Message& msg, std::vector<std::pair<int, CombatLog>>& logs);
+FO_COMMON_API void ExtractDispatchCombatLogsMessageData(const MessagePacket& msg, std::vector<std::pair<int, CombatLog>>& logs);
 
 #endif // _Message_h_

--- a/network/MessageQueue.cpp
+++ b/network/MessageQueue.cpp
@@ -5,7 +5,7 @@
 
 namespace {
     struct SynchronousResponseMessage {
-        bool operator()(const Message& message) const
+        bool operator()(const MessagePacket& message) const
         { return message.SynchronousResponse(); }
     };
 }
@@ -29,23 +29,23 @@ void MessageQueue::Clear() {
     m_queue.clear();
 }
 
-void MessageQueue::PushBack(Message& message) {
+void MessageQueue::PushBack(MessagePacket& message) {
     boost::mutex::scoped_lock lock(m_monitor);
-    m_queue.push_back(Message());
+    m_queue.push_back(MessagePacket());
     swap(m_queue.back(), message);
     if (m_queue.back().SynchronousResponse())
         m_have_synchronous_response.notify_one();
 }
 
-void MessageQueue::PopFront(Message& message) {
+void MessageQueue::PopFront(MessagePacket& message) {
     boost::mutex::scoped_lock lock(m_monitor);
     swap(message, m_queue.front());
     m_queue.pop_front();
 }
 
-void MessageQueue::EraseFirstSynchronousResponse(Message& message) {
+void MessageQueue::EraseFirstSynchronousResponse(MessagePacket& message) {
     boost::mutex::scoped_lock lock(m_monitor);
-    std::list<Message>::iterator it = std::find_if(m_queue.begin(), m_queue.end(), SynchronousResponseMessage());
+    std::list<MessagePacket>::iterator it = std::find_if(m_queue.begin(), m_queue.end(), SynchronousResponseMessage());
     while (it == m_queue.end()) {
         m_have_synchronous_response.wait(lock);
         it = std::find_if(m_queue.begin(), m_queue.end(), SynchronousResponseMessage());

--- a/network/MessageQueue.h
+++ b/network/MessageQueue.h
@@ -9,7 +9,7 @@
 #include "../util/Export.h"
 
 
-class Message;
+class MessagePacket;
 
 /** A thread-safe message queue.  The entire public interface is guarded with mutex locks. */
 class FO_COMMON_API MessageQueue
@@ -27,17 +27,17 @@ public:
     void Clear();
 
     /** Adds \a message to the end of the queue. */
-    void PushBack(Message& message);
+    void PushBack(MessagePacket& message);
 
     /** Returns the front message in the queue. */
-    void PopFront(Message& message);
+    void PopFront(MessagePacket& message);
 
     /** Returns the first synchronous repsonse message in the queue.  If no such message is found, this function blocks
         the calling thread until a synchronous response element is added. */
-    void EraseFirstSynchronousResponse(Message& message);
+    void EraseFirstSynchronousResponse(MessagePacket& message);
 
 private:
-    std::list<Message> m_queue;
+    std::list<MessagePacket> m_queue;
     boost::condition   m_have_synchronous_response;
     boost::mutex&      m_monitor;
 };

--- a/network/ServerNetworking.h
+++ b/network/ServerNetworking.h
@@ -17,7 +17,7 @@ class DiscoveryServer;
 class PlayerConnection;
 
 typedef std::shared_ptr<PlayerConnection> PlayerConnectionPtr;
-typedef boost::function<void (Message, PlayerConnectionPtr)> MessageAndConnectionFn;
+typedef boost::function<void (MessagePacket, PlayerConnectionPtr)> MessageAndConnectionFn;
 typedef boost::function<void (PlayerConnectionPtr)> ConnectionFn;
 typedef boost::function<void ()> NullaryFn;
 
@@ -89,10 +89,10 @@ public:
 
     /** \name Mutators */ //@{
     /** Sends a synchronous message \a message to \a player_connection and returns true on success. */
-    bool SendMessage(const Message& message, PlayerConnectionPtr player_connection);
+    bool SendMessage(const MessagePacket& message, PlayerConnectionPtr player_connection);
 
     /** Sends a synchronous message \a message to the player indicated in the message and returns true on success. */
-    bool SendMessage(const Message& message);
+    bool SendMessage(const MessagePacket& message);
 
     /** Disconnects the server from player \a id. */
     void Disconnect(int id);
@@ -198,7 +198,7 @@ public:
     void Start();
 
     /** Sends \a synchronous message to out on the connection and return true on success. */
-    bool SendMessage(const Message& message);
+    bool SendMessage(const MessagePacket& message);
 
     /** Establishes a connection as a player with a specific name and id.
         This function must only be called once. */
@@ -224,13 +224,13 @@ private:
     void HandleMessageBodyRead(boost::system::error_code error, std::size_t bytes_transferred);
     void HandleMessageHeaderRead(boost::system::error_code error, std::size_t bytes_transferred);
     void AsyncReadMessage();
-    bool SyncWriteMessage(const Message& message);
+    bool SyncWriteMessage(const MessagePacket& message);
     void AsyncErrorHandler(boost::system::error_code handled_error, boost::system::error_code error);
 
     boost::asio::io_service&        m_service;
     boost::asio::ip::tcp::socket    m_socket;
-    Message::HeaderBuffer           m_incoming_header_buffer;
-    Message                         m_incoming_message;
+    MessagePacket::HeaderBuffer           m_incoming_header_buffer;
+    MessagePacket                         m_incoming_message;
     int                             m_ID;
     std::string                     m_player_name;
     bool                            m_new_connection;

--- a/server/SaveLoad.cpp
+++ b/server/SaveLoad.cpp
@@ -279,7 +279,7 @@ void LoadGame(const std::string& filename, ServerSaveGameData& server_save_game_
 
     // player notifications
     if (ServerApp* server = ServerApp::GetApp())
-        server->Networking().SendMessage(TurnProgressMessage(Message::LOADING_GAME));
+        server->Networking().SendMessage(TurnProgressMessage(MessagePacket::LOADING_GAME));
 
     GetUniverse().EncodingEmpire() = ALL_EMPIRES;
 

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -195,7 +195,7 @@ void ServerApp::CreateAIClients(const std::vector<PlayerSetupData>& player_setup
         }
     }
     if (need_AIs)
-        m_networking.SendMessage(TurnProgressMessage(Message::STARTING_AIS));
+        m_networking.SendMessage(TurnProgressMessage(MessagePacket::STARTING_AIS));
 
 
     // disconnect any old AI clients
@@ -340,7 +340,7 @@ void ServerApp::CleanupAIs() {
     try {
         for (PlayerConnectionPtr player : m_networking) {
             if (player->GetClientType() == Networking::CLIENT_TYPE_AI_PLAYER) {
-                player->SendMessage(EndGameMessage(player->PlayerID(), Message::PLAYER_DISCONNECT));
+                player->SendMessage(EndGameMessage(player->PlayerID(), MessagePacket::PLAYER_DISCONNECT));
                 ai_connection_lingering = true;
             }
         }
@@ -384,7 +384,7 @@ void ServerApp::SetAIsProcessPriorityToLow(bool set_to_low) {
     }
 }
 
-void ServerApp::HandleMessage(const Message& msg, PlayerConnectionPtr player_connection) {
+void ServerApp::HandleMessage(const MessagePacket& msg, PlayerConnectionPtr player_connection) {
     if (msg.SendingPlayer() != player_connection->PlayerID()) {
         ErrorLogger() << "ServerApp::HandleMessage : Received an message with a sender ID ("
                       << msg.SendingPlayer() << ") that differs from the sending player connection ID: "
@@ -395,27 +395,27 @@ void ServerApp::HandleMessage(const Message& msg, PlayerConnectionPtr player_con
     //DebugLogger() << "ServerApp::HandleMessage type " << boost::lexical_cast<std::string>(msg.Type());
 
     switch (msg.Type()) {
-    case Message::HOST_SP_GAME:             m_fsm->process_event(HostSPGame(msg, player_connection));       break;
-    case Message::START_MP_GAME:            m_fsm->process_event(StartMPGame(msg, player_connection));      break;
-    case Message::LOBBY_UPDATE:             m_fsm->process_event(LobbyUpdate(msg, player_connection));      break;
-    case Message::LOBBY_CHAT:               m_fsm->process_event(LobbyChat(msg, player_connection));        break;
-    case Message::SAVE_GAME_INITIATE:       m_fsm->process_event(SaveGameRequest(msg, player_connection));  break;
-    case Message::TURN_ORDERS:              m_fsm->process_event(TurnOrders(msg, player_connection));       break;
-    case Message::CLIENT_SAVE_DATA:         m_fsm->process_event(ClientSaveData(msg, player_connection));   break;
-    case Message::PLAYER_CHAT:              m_fsm->process_event(PlayerChat(msg, player_connection));       break;
-    case Message::DIPLOMACY:                m_fsm->process_event(Diplomacy(msg, player_connection));        break;
-    case Message::REQUEST_NEW_OBJECT_ID:    m_fsm->process_event(RequestObjectID(msg, player_connection));  break;
-    case Message::REQUEST_NEW_DESIGN_ID:    m_fsm->process_event(RequestDesignID(msg, player_connection));  break;
-    case Message::MODERATOR_ACTION:         m_fsm->process_event(ModeratorAct(msg, player_connection));     break;
+    case MessagePacket::HOST_SP_GAME:             m_fsm->process_event(HostSPGame(msg, player_connection));       break;
+    case MessagePacket::START_MP_GAME:            m_fsm->process_event(StartMPGame(msg, player_connection));      break;
+    case MessagePacket::LOBBY_UPDATE:             m_fsm->process_event(LobbyUpdate(msg, player_connection));      break;
+    case MessagePacket::LOBBY_CHAT:               m_fsm->process_event(LobbyChat(msg, player_connection));        break;
+    case MessagePacket::SAVE_GAME_INITIATE:       m_fsm->process_event(SaveGameRequest(msg, player_connection));  break;
+    case MessagePacket::TURN_ORDERS:              m_fsm->process_event(TurnOrders(msg, player_connection));       break;
+    case MessagePacket::CLIENT_SAVE_DATA:         m_fsm->process_event(ClientSaveData(msg, player_connection));   break;
+    case MessagePacket::PLAYER_CHAT:              m_fsm->process_event(PlayerChat(msg, player_connection));       break;
+    case MessagePacket::DIPLOMACY:                m_fsm->process_event(Diplomacy(msg, player_connection));        break;
+    case MessagePacket::REQUEST_NEW_OBJECT_ID:    m_fsm->process_event(RequestObjectID(msg, player_connection));  break;
+    case MessagePacket::REQUEST_NEW_DESIGN_ID:    m_fsm->process_event(RequestDesignID(msg, player_connection));  break;
+    case MessagePacket::MODERATOR_ACTION:         m_fsm->process_event(ModeratorAct(msg, player_connection));     break;
 
-    case Message::ERROR_MSG:
-    case Message::DEBUG:                    break;
+    case MessagePacket::ERROR_MSG:
+    case MessagePacket::DEBUG:                    break;
 
-    case Message::SHUT_DOWN_SERVER:         HandleShutdownMessage(msg, player_connection);  break;
-    case Message::AI_END_GAME_ACK:          m_fsm->process_event(LeaveGame(msg, player_connection));        break;
+    case MessagePacket::SHUT_DOWN_SERVER:         HandleShutdownMessage(msg, player_connection);  break;
+    case MessagePacket::AI_END_GAME_ACK:          m_fsm->process_event(LeaveGame(msg, player_connection));        break;
 
-    case Message::REQUEST_SAVE_PREVIEWS:    UpdateSavePreviews(msg, player_connection); break;
-    case Message::REQUEST_COMBAT_LOGS:      m_fsm->process_event(RequestCombatLogs(msg, player_connection));break;
+    case MessagePacket::REQUEST_SAVE_PREVIEWS:    UpdateSavePreviews(msg, player_connection); break;
+    case MessagePacket::REQUEST_COMBAT_LOGS:      m_fsm->process_event(RequestCombatLogs(msg, player_connection));break;
 
     default:
         ErrorLogger() << "ServerApp::HandleMessage : Received an unknown message type \"" << msg.Type() << "\".  Terminating connection.";
@@ -424,7 +424,7 @@ void ServerApp::HandleMessage(const Message& msg, PlayerConnectionPtr player_con
     }
 }
 
-void ServerApp::HandleShutdownMessage(const Message& msg, PlayerConnectionPtr player_connection) {
+void ServerApp::HandleShutdownMessage(const MessagePacket& msg, PlayerConnectionPtr player_connection) {
     int player_id = player_connection->PlayerID();
     bool is_host = m_networking.PlayerIsHost(player_id);
     if (!is_host) {
@@ -435,21 +435,21 @@ void ServerApp::HandleShutdownMessage(const Message& msg, PlayerConnectionPtr pl
     m_fsm->process_event(ShutdownServer());
 }
 
-void ServerApp::HandleNonPlayerMessage(const Message& msg, PlayerConnectionPtr player_connection) {
+void ServerApp::HandleNonPlayerMessage(const MessagePacket& msg, PlayerConnectionPtr player_connection) {
     switch (msg.Type()) {
-    case Message::HOST_SP_GAME: m_fsm->process_event(HostSPGame(msg, player_connection));   break;
-    case Message::HOST_MP_GAME: m_fsm->process_event(HostMPGame(msg, player_connection));   break;
-    case Message::JOIN_GAME:    m_fsm->process_event(JoinGame(msg, player_connection));     break;
-    case Message::ERROR_MSG:    m_fsm->process_event(Error(msg, player_connection));        break;
-    case Message::DEBUG:        break;
+    case MessagePacket::HOST_SP_GAME: m_fsm->process_event(HostSPGame(msg, player_connection));   break;
+    case MessagePacket::HOST_MP_GAME: m_fsm->process_event(HostMPGame(msg, player_connection));   break;
+    case MessagePacket::JOIN_GAME:    m_fsm->process_event(JoinGame(msg, player_connection));     break;
+    case MessagePacket::ERROR_MSG:    m_fsm->process_event(Error(msg, player_connection));        break;
+    case MessagePacket::DEBUG:        break;
     default:
-        if ((m_networking.size() == 1) && (player_connection->IsLocalConnection()) && (msg.Type() == Message::SHUT_DOWN_SERVER)) {
-            DebugLogger() << "ServerApp::HandleNonPlayerMessage received Message::SHUT_DOWN_SERVER from the sole "
+        if ((m_networking.size() == 1) && (player_connection->IsLocalConnection()) && (msg.Type() == MessagePacket::SHUT_DOWN_SERVER)) {
+            DebugLogger() << "ServerApp::HandleNonPlayerMessage received MessagePacket::SHUT_DOWN_SERVER from the sole "
                           << "connected player, who is local and so the request is being honored; server shutting down.";
             m_fsm->process_event(ShutdownServer());
         } else {
             ErrorLogger() << "ServerApp::HandleNonPlayerMessage : Received an invalid message type \""
-                                            << msg.Type() << "\" for a non-player Message.  Terminating connection.";
+                                            << msg.Type() << "\" for a non-player MessagePacket.  Terminating connection.";
             m_networking.Disconnect(player_connection);
             break;
         }
@@ -630,7 +630,7 @@ void ServerApp::NewGameInitConcurrentWithJoiners(
 
     // create universe and empires for players
     DebugLogger() << "ServerApp::NewGameInitConcurrentWithJoiners: Creating Universe";
-    m_networking.SendMessage(TurnProgressMessage(Message::GENERATING_UNIVERSE));
+    m_networking.SendMessage(TurnProgressMessage(MessagePacket::GENERATING_UNIVERSE));
 
 
     // m_current_turn set above so that every UniverseObject created before game
@@ -849,7 +849,7 @@ void ServerApp::LoadSPGameInit(const std::vector<PlayerSaveGameData>& player_sav
     LoadGameInit(player_save_game_data, player_id_to_save_game_data_index, server_save_game_data);
 }
 
-void ServerApp::UpdateSavePreviews(const Message& msg, PlayerConnectionPtr player_connection){
+void ServerApp::UpdateSavePreviews(const MessagePacket& msg, PlayerConnectionPtr player_connection){
     DebugLogger() << "ServerApp::UpdateSavePreviews: ServerApp UpdateSavePreviews";
 
     std::string directory_name;
@@ -877,7 +877,7 @@ void ServerApp::UpdateSavePreviews(const Message& msg, PlayerConnectionPtr playe
     DebugLogger() << "ServerApp::UpdateSavePreviews: Previews sent.";
 }
 
-void ServerApp::UpdateCombatLogs(const Message& msg, PlayerConnectionPtr player_connection){
+void ServerApp::UpdateCombatLogs(const MessagePacket& msg, PlayerConnectionPtr player_connection){
     std::vector<int> ids;
     ExtractRequestCombatLogsMessageData(msg, ids);
 
@@ -2660,7 +2660,7 @@ void ServerApp::PreCombatProcessTurns() {
     DebugLogger() << "ServerApp::ProcessTurns executing orders";
 
     // inform players of order execution
-    m_networking.SendMessage(TurnProgressMessage(Message::PROCESSING_ORDERS));
+    m_networking.SendMessage(TurnProgressMessage(MessagePacket::PROCESSING_ORDERS));
 
     // clear bombardment state before executing orders, so result after is only
     // determined by what orders set.
@@ -2694,7 +2694,7 @@ void ServerApp::PreCombatProcessTurns() {
     }
 
     // player notifications
-    m_networking.SendMessage(TurnProgressMessage(Message::COLONIZE_AND_SCRAP));
+    m_networking.SendMessage(TurnProgressMessage(MessagePacket::COLONIZE_AND_SCRAP));
 
     DebugLogger() << "ServerApp::ProcessTurns colonization";
     HandleColonization();
@@ -2713,7 +2713,7 @@ void ServerApp::PreCombatProcessTurns() {
     // process movement phase
 
     // player notifications
-    m_networking.SendMessage(TurnProgressMessage(Message::FLEET_MOVEMENT));
+    m_networking.SendMessage(TurnProgressMessage(MessagePacket::FLEET_MOVEMENT));
 
 
     // fleet movement
@@ -2747,7 +2747,7 @@ void ServerApp::PreCombatProcessTurns() {
     }
 
     // indicate that the clients are waiting for their new Universes
-    m_networking.SendMessage(TurnProgressMessage(Message::DOWNLOADING));
+    m_networking.SendMessage(TurnProgressMessage(MessagePacket::DOWNLOADING));
 
     // send partial turn updates to all players after orders and movement
     for (ServerNetworking::const_established_iterator player_it = m_networking.established_begin();
@@ -2764,7 +2764,7 @@ void ServerApp::PreCombatProcessTurns() {
 void ServerApp::ProcessCombats() {
     ScopedTimer timer("ServerApp::ProcessCombats", true);
     DebugLogger() << "ServerApp::ProcessCombats";
-    m_networking.SendMessage(TurnProgressMessage(Message::COMBAT));
+    m_networking.SendMessage(TurnProgressMessage(MessagePacket::COMBAT));
 
     std::set<int> human_controlled_empire_ids = HumanControlledEmpires(this, m_networking);
     std::vector<CombatInfo> combats;   // map from system ID to CombatInfo for that system
@@ -2897,7 +2897,7 @@ void ServerApp::PostCombatProcessTurns() {
     // process production and growth phase
 
     // notify players that production and growth is being processed
-    m_networking.SendMessage(TurnProgressMessage(Message::EMPIRE_PRODUCTION));
+    m_networking.SendMessage(TurnProgressMessage(MessagePacket::EMPIRE_PRODUCTION));
     DebugLogger() << "ServerApp::PostCombatProcessTurns effects and meter updates";
 
 
@@ -3069,7 +3069,7 @@ void ServerApp::PostCombatProcessTurns() {
 
 
     // indicate that the clients are waiting for their new gamestate
-    m_networking.SendMessage(TurnProgressMessage(Message::DOWNLOADING));
+    m_networking.SendMessage(TurnProgressMessage(MessagePacket::DOWNLOADING));
 
 
     // compile map of PlayerInfo, indexed by player ID

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -208,10 +208,10 @@ public:
                            std::shared_ptr<ServerSaveGameData> server_save_game_data);
     //@}
 
-    void UpdateSavePreviews(const Message& msg, PlayerConnectionPtr player_connection);
+    void UpdateSavePreviews(const MessagePacket& msg, PlayerConnectionPtr player_connection);
 
     /** Send the requested combat logs to the client.*/
-    void UpdateCombatLogs(const Message& msg, PlayerConnectionPtr player_connection);
+    void UpdateCombatLogs(const MessagePacket& msg, PlayerConnectionPtr player_connection);
 
     ServerNetworking&           Networking();     ///< returns the networking object for the server
 
@@ -271,15 +271,15 @@ private:
 
     /** Handles an incoming message from the server with the appropriate action
       * or response */
-    void    HandleMessage(const Message& msg, PlayerConnectionPtr player_connection);
+    void    HandleMessage(const MessagePacket& msg, PlayerConnectionPtr player_connection);
 
     /** Checks validity of shut down message from player, then attempts to
       * cleanly shut down this server process. */
-    void    HandleShutdownMessage(const Message& msg, PlayerConnectionPtr player_connection);
+    void    HandleShutdownMessage(const MessagePacket& msg, PlayerConnectionPtr player_connection);
 
     /** When Messages arrive from connections that are not established players,
       * they arrive via a call to this function*/
-    void    HandleNonPlayerMessage(const Message& msg, PlayerConnectionPtr player_connection);
+    void    HandleNonPlayerMessage(const MessagePacket& msg, PlayerConnectionPtr player_connection);
 
     /** Called by ServerNetworking when a player's TCP connection is closed*/
     void    PlayerDisconnected(PlayerConnectionPtr player_connection);

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -31,7 +31,7 @@ CombatLogManager&   GetCombatLogManager();
 namespace {
     const bool TRACE_EXECUTION = true;
 
-    void SendMessageToAllPlayers(const Message& message) {
+    void SendMessageToAllPlayers(const MessagePacket& message) {
         ServerApp* server = ServerApp::GetApp();
         if (!server) {
             ErrorLogger() << "SendMessageToAllPlayers couldn't get server.";
@@ -48,7 +48,7 @@ namespace {
         }
     }
 
-    void SendMessageToHost(const Message& message) {
+    void SendMessageToHost(const MessagePacket& message) {
         ServerApp* server = ServerApp::GetApp();
         if (!server) {
             ErrorLogger() << "SendMessageToHost couldn't get server.";
@@ -175,7 +175,7 @@ Disconnection::Disconnection(PlayerConnectionPtr& player_connection) :
 ////////////////////////////////////////////////////////////
 // MessageEventBase
 ////////////////////////////////////////////////////////////
-MessageEventBase::MessageEventBase(const Message& message, PlayerConnectionPtr& player_connection) :
+MessageEventBase::MessageEventBase(const MessagePacket& message, PlayerConnectionPtr& player_connection) :
     m_message(message),
     m_player_connection(player_connection)
 {}
@@ -231,7 +231,7 @@ void ServerFSM::HandleNonLobbyDisconnection(const Disconnection& d) {
                 if ((*it)->PlayerID() == id)
                     continue;
                 // in the future we may find a way to recover from this, but for now we will immediately send a game ending message as well
-                (*it)->SendMessage(EndGameMessage((*it)->PlayerID(), Message::PLAYER_DISCONNECT, player_connection->PlayerName()));
+                (*it)->SendMessage(EndGameMessage((*it)->PlayerID(), MessagePacket::PLAYER_DISCONNECT, player_connection->PlayerName()));
             }
         }
     }
@@ -257,7 +257,7 @@ Idle::~Idle()
 sc::result Idle::react(const HostMPGame& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(ServerFSM) Idle.HostMPGame";
     ServerApp& server = Server();
-    const Message& message = msg.m_message;
+    const MessagePacket& message = msg.m_message;
     const PlayerConnectionPtr& player_connection = msg.m_player_connection;
 
     std::string host_player_name;
@@ -289,7 +289,7 @@ sc::result Idle::react(const HostMPGame& msg) {
 sc::result Idle::react(const HostSPGame& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(ServerFSM) Idle.HostSPGame";
     ServerApp& server = Server();
-    const Message& message = msg.m_message;
+    const MessagePacket& message = msg.m_message;
     const PlayerConnectionPtr& player_connection = msg.m_player_connection;
 
     auto single_player_setup_data = std::make_shared<SinglePlayerSetupData>();
@@ -468,7 +468,7 @@ sc::result MPLobby::react(const JoinGame& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(ServerFSM) MPLobby.JoinGame";
     ServerApp& server = Server();
     const SpeciesManager& sm = GetSpeciesManager();
-    const Message& message = msg.m_message;
+    const MessagePacket& message = msg.m_message;
     const PlayerConnectionPtr& player_connection = msg.m_player_connection;
 
     std::string player_name;
@@ -561,7 +561,7 @@ sc::result MPLobby::react(const JoinGame& msg) {
 sc::result MPLobby::react(const LobbyUpdate& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(ServerFSM) MPLobby.LobbyUpdate";
     ServerApp& server = Server();
-    const Message& message = msg.m_message;
+    const MessagePacket& message = msg.m_message;
 
     MultiplayerLobbyData incoming_lobby_data;
     ExtractLobbyUpdateMessageData(message, incoming_lobby_data);
@@ -932,7 +932,7 @@ sc::result MPLobby::react(const LobbyUpdate& msg) {
 sc::result MPLobby::react(const LobbyChat& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(ServerFSM) MPLobby.LobbyChat";
     ServerApp& server = Server();
-    const Message& message = msg.m_message;
+    const MessagePacket& message = msg.m_message;
 
     if (message.ReceivingPlayer() == Networking::INVALID_PLAYER_ID) { // the receiver is everyone (except the sender)
         for (ServerNetworking::const_established_iterator it = server.m_networking.established_begin(); it != server.m_networking.established_end(); ++it) {
@@ -949,7 +949,7 @@ sc::result MPLobby::react(const LobbyChat& msg) {
 sc::result MPLobby::react(const StartMPGame& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(ServerFSM) MPLobby.StartMPGame";
     ServerApp& server = Server();
-    const Message& message = msg.m_message;
+    const MessagePacket& message = msg.m_message;
     const PlayerConnectionPtr& player_connection = msg.m_player_connection;
 
     if (server.m_networking.PlayerIsHost(player_connection->PlayerID())) {
@@ -1159,7 +1159,7 @@ WaitingForSPGameJoiners::~WaitingForSPGameJoiners()
 sc::result WaitingForSPGameJoiners::react(const JoinGame& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(ServerFSM) WaitingForSPGameJoiners.JoinGame";
     ServerApp& server = Server();
-    const Message& message = msg.m_message;
+    const MessagePacket& message = msg.m_message;
     const PlayerConnectionPtr& player_connection = msg.m_player_connection;
 
     std::string player_name("Default_Player_Name_in_WaitingForSPGameJoiners::react(const JoinGame& msg)");
@@ -1300,7 +1300,7 @@ WaitingForMPGameJoiners::~WaitingForMPGameJoiners()
 sc::result WaitingForMPGameJoiners::react(const JoinGame& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(ServerFSM) WaitingForMPGameJoiners.JoinGame";
     ServerApp& server = Server();
-    const Message& message = msg.m_message;
+    const MessagePacket& message = msg.m_message;
     const PlayerConnectionPtr& player_connection = msg.m_player_connection;
 
     std::string player_name("Default_Player_Name_in_WaitingForMPGameJoiners::react(const JoinGame& msg)");
@@ -1407,7 +1407,7 @@ sc::result PlayingGame::react(const PlayerChat& msg) {
 
 sc::result PlayingGame::react(const Diplomacy& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(ServerFSM) PlayingGame.Diplomacy";
-    const Message& message = msg.m_message;
+    const MessagePacket& message = msg.m_message;
 
     DiplomaticMessage diplo_message;
     ExtractDiplomacyMessageData(message, diplo_message);
@@ -1418,7 +1418,7 @@ sc::result PlayingGame::react(const Diplomacy& msg) {
 
 sc::result PlayingGame::react(const ModeratorAct& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(ServerFSM) PlayingGame.ModeratorAct";
-    const Message& message = msg.m_message;
+    const MessagePacket& message = msg.m_message;
     int player_id = message.SendingPlayer();
     ServerApp& server = Server();
 
@@ -1441,7 +1441,7 @@ sc::result PlayingGame::react(const ModeratorAct& msg) {
 
         // update player(s) of changed gamestate as result of action
         bool use_binary_serialization = player_connection->ClientVersionStringMatchesThisServer();
-        server.m_networking.SendMessage(TurnProgressMessage(Message::DOWNLOADING, player_id));
+        server.m_networking.SendMessage(TurnProgressMessage(MessagePacket::DOWNLOADING, player_id));
         server.m_networking.SendMessage(TurnPartialUpdateMessage(player_id, server.PlayerEmpireID(player_id),
                                                                  GetUniverse(), use_binary_serialization));
     }
@@ -1488,7 +1488,7 @@ WaitingForTurnEnd::~WaitingForTurnEnd()
 sc::result WaitingForTurnEnd::react(const TurnOrders& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(ServerFSM) WaitingForTurnEnd.TurnOrders";
     ServerApp& server = Server();
-    const Message& message = msg.m_message;
+    const MessagePacket& message = msg.m_message;
 
     OrderSet* order_set = new OrderSet;
     ExtractTurnOrdersMessageData(message, *order_set);
@@ -1562,13 +1562,13 @@ sc::result WaitingForTurnEnd::react(const TurnOrders& msg) {
         PlayerConnectionPtr player_ctn = *player_it;
         player_ctn->SendMessage(PlayerStatusMessage(player_ctn->PlayerID(),
                                                     message.SendingPlayer(),
-                                                    Message::WAITING));
+                                                    MessagePacket::WAITING));
     }
 
     // inform player who just submitted of their new status.  Note: not sure why
     // this only needs to be send to the submitting player and not all others as
     // well ...
-    server.m_networking.SendMessage(TurnProgressMessage(Message::WAITING_FOR_PLAYERS,
+    server.m_networking.SendMessage(TurnProgressMessage(MessagePacket::WAITING_FOR_PLAYERS,
                                                         message.SendingPlayer()));
 
     // if player who just submitted is the local human player, raise AI process priority
@@ -1635,7 +1635,7 @@ WaitingForTurnEndIdle::~WaitingForTurnEndIdle()
 sc::result WaitingForTurnEndIdle::react(const SaveGameRequest& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(ServerFSM) WaitingForTurnEndIdle.SaveGameRequest";
     ServerApp& server = Server();
-    const Message& message = msg.m_message;
+    const MessagePacket& message = msg.m_message;
     const PlayerConnectionPtr& player_connection = msg.m_player_connection;
 
     if (!server.m_networking.PlayerIsHost(player_connection->PlayerID())) {
@@ -1676,7 +1676,7 @@ WaitingForSaveData::~WaitingForSaveData()
 sc::result WaitingForSaveData::react(const ClientSaveData& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(ServerFSM) WaitingForSaveData.ClientSaveData";
     ServerApp& server = Server();
-    const Message& message = msg.m_message;
+    const MessagePacket& message = msg.m_message;
     const PlayerConnectionPtr& player_connection = msg.m_player_connection;
 
     int player_id = player_connection->PlayerID();
@@ -1803,7 +1803,7 @@ sc::result ProcessingTurn::react(const ProcessTurn& u) {
             {
                 PlayerConnectionPtr recipient_player_ctn = *recipient_player_it;
                 server.m_networking.SendMessage(
-                    PlayerStatusMessage(recipient_player_ctn->PlayerID(), player_ctn->PlayerID(), Message::PLAYING_TURN));
+                    PlayerStatusMessage(recipient_player_ctn->PlayerID(), player_ctn->PlayerID(), MessagePacket::PLAYING_TURN));
             }
         }
     }
@@ -1839,7 +1839,7 @@ ShuttingDownServer::ShuttingDownServer(my_context c) :
     // Inform all players that the game is ending.  Only check the AIs for acknowledgement, because
     // they are the server's child processes.
     for (PlayerConnectionPtr player : server.m_networking) {
-        auto good_connection = player->SendMessage(EndGameMessage(player->PlayerID(), Message::PLAYER_DISCONNECT));
+        auto good_connection = player->SendMessage(EndGameMessage(player->PlayerID(), MessagePacket::PLAYER_DISCONNECT));
         if (player->GetClientType() == Networking::CLIENT_TYPE_AI_PLAYER) {
             if (good_connection) {
                 // Only expect acknowledgement from sockets that are up.
@@ -1863,7 +1863,7 @@ ShuttingDownServer::~ShuttingDownServer()
 
 sc::result ShuttingDownServer::react(const LeaveGame& msg) {
     if (TRACE_EXECUTION) DebugLogger() << "(ServerFSM) ShuttingDownServer.LeaveGame";
-    const Message& message = msg.m_message;
+    const MessagePacket& message = msg.m_message;
     int player_id = message.SendingPlayer();
 
     auto ack_found = m_player_id_ack_expected.find(player_id);

--- a/server/ServerFSM.h
+++ b/server/ServerFSM.h
@@ -47,16 +47,16 @@ struct DisconnectClients : sc::event<DisconnectClients>                 {};
 struct ShutdownServer : sc::event<ShutdownServer>                       {};
 
 
-//  Message events
+//  MessagePacket events
 /** The base class for all state machine events that are based on Messages. */
 struct MessageEventBase {
-    MessageEventBase(const Message& message, PlayerConnectionPtr& player_connection);
+    MessageEventBase(const MessagePacket& message, PlayerConnectionPtr& player_connection);
 
-    Message              m_message;
+    MessagePacket              m_message;
     PlayerConnectionPtr  m_player_connection;
 };
 
-// Define Boost.Preprocessor list of all Message events
+// Define Boost.Preprocessor list of all MessagePacket events
 #define MESSAGE_EVENTS                      \
     (HostMPGame)                            \
     (HostSPGame)                            \
@@ -83,7 +83,7 @@ struct MessageEventBase {
         sc::event<name>,                                                        \
         MessageEventBase                                                        \
     {                                                                           \
-        name(const Message& message, PlayerConnectionPtr& player_connection) :  \
+        name(const MessagePacket& message, PlayerConnectionPtr& player_connection) :  \
             MessageEventBase(message, player_connection)                        \
         {}                                                                      \
     };


### PR DESCRIPTION
This reduces the dependency of compilation units downstream of ClientNetworking.h, improving incremental build times by a factor of 4 when ClientNetworking is changed.  Sadly, it make no difference in the total clean build time.

It moves several dependencies from the header into the cpp file.

It changes function signatures so that forward declarations are as good as full definitions.

It reduces the number of files that include ClientNetworking.h.

I wish I had done this before I started hacking on ClientNetworking.