### PR TITLE
Improve app termination save pending

### DIFF
--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -1130,13 +1130,13 @@ namespace {
     // The dialog automatically closes if the save completes while the user is waiting
     class SaveGamePendingDialog : public GG::ThreeButtonDlg {
         public:
-        SaveGamePendingDialog(boost::signals2::signal<void()>& save_completed_signal) :
+        SaveGamePendingDialog(bool reset, boost::signals2::signal<void()>& save_completed_signal) :
             GG::ThreeButtonDlg(
                 GG::X(320), GG::Y(200), UserString("SAVE_GAME_IN_PROGRESS"),
                 ClientUI::GetFont(ClientUI::Pts()+2),
                 ClientUI::WndColor(), ClientUI::WndOuterBorderColor(),
                 ClientUI::CtrlColor(), ClientUI::TextColor(), 1,
-                UserString("ABORT_SAVE_AND_QUIT"))
+                (reset ? UserString("ABORT_SAVE_AND_RESET") : UserString("ABORT_SAVE_AND_EXIT")))
         { GG::Connect(save_completed_signal, &SaveGamePendingDialog::SaveCompletedHandler, this); }
 
         void SaveCompletedHandler() {
@@ -1159,7 +1159,7 @@ void HumanClientApp::ResetOrExitApp(bool reset) {
 
     if (m_save_game_in_progress) {
         DebugLogger() << "save game in progress. Checking with player.";
-        auto dlg = SaveGamePendingDialog(this->SaveGameCompletedSignal);
+        auto dlg = SaveGamePendingDialog(reset, this->SaveGameCompletedSignal);
         dlg.Run();
     }
 

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -33,6 +33,7 @@
 #include "../../parse/Parse.h"
 
 #include <GG/BrowseInfoWnd.h>
+#include <GG/dialogs/ThreeButtonDlg.h>
 #include <GG/Cursor.h>
 #include <GG/utf8/checked.h>
 
@@ -1115,6 +1116,28 @@ void HumanClientApp::ResetClientData() {
     m_empires.Clear();
     m_orders.Reset();
     GetCombatLogManager().Clear();
+}
+
+namespace {
+    // Ask the player if they want to wait for the save game to complete
+    // The dialog automatically closes if the save completes while the user is waiting
+    class SaveGamePendingDialog : public GG::ThreeButtonDlg {
+        public:
+        SaveGamePendingDialog(boost::signals2::signal<void()>& save_completed_signal) :
+            GG::ThreeButtonDlg(
+                GG::X(320), GG::Y(200), UserString("SAVE_GAME_IN_PROGRESS"),
+                ClientUI::GetFont(ClientUI::Pts()+2),
+                ClientUI::WndColor(), ClientUI::WndOuterBorderColor(),
+                ClientUI::CtrlColor(), ClientUI::TextColor(), 1,
+                UserString("STOP_WAITING"))
+        { GG::Connect(save_completed_signal, &SaveGamePendingDialog::SaveCompletedHandler, this); }
+
+        void SaveCompletedHandler()
+        {
+            DebugLogger() << "SaveGamePendingDialog:: save game completed handled.";
+            m_done = true;
+        }
+    };
 }
 
 void HumanClientApp::ResetToIntro() {

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -1136,7 +1136,7 @@ namespace {
                 ClientUI::GetFont(ClientUI::Pts()+2),
                 ClientUI::WndColor(), ClientUI::WndOuterBorderColor(),
                 ClientUI::CtrlColor(), ClientUI::TextColor(), 1,
-                UserString("STOP_WAITING"))
+                UserString("ABORT_SAVE_AND_QUIT"))
         { GG::Connect(save_completed_signal, &SaveGamePendingDialog::SaveCompletedHandler, this); }
 
         void SaveCompletedHandler()

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -1139,9 +1139,8 @@ namespace {
                 UserString("ABORT_SAVE_AND_QUIT"))
         { GG::Connect(save_completed_signal, &SaveGamePendingDialog::SaveCompletedHandler, this); }
 
-        void SaveCompletedHandler()
-        {
-            DebugLogger() << "SaveGamePendingDialog:: save game completed handled.";
+        void SaveCompletedHandler() {
+            DebugLogger() << "SaveGamePendingDialog::SaveCompletedHandler save game completed handled.";
             m_done = true;
         }
     };

--- a/client/human/HumanClientApp.h
+++ b/client/human/HumanClientApp.h
@@ -56,6 +56,8 @@ public:
     void                StartMultiPlayerGameFromLobby();                ///< begins
     void                CancelMultiplayerGameFromLobby();               ///< cancels out of multiplayer game
     void                SaveGame(const std::string& filename);          ///< saves the current game; blocks until all save-related network traffic is resolved.
+    /** Accepts acknowledgement that server has completed the save.*/
+    void                SaveGameCompleted();
     void                StartGame();
 
     /** Check if the CombatLogManager has incomplete logs that need fetching and start fetching
@@ -122,6 +124,7 @@ private:
 
     void            DisconnectedFromServer();           ///< called by ClientNetworking when the TCP connection to the server is lost
 
+    void            ResetOrExitApp(bool reset);
 
     std::unique_ptr<HumanClientFSM> m_fsm;
 
@@ -135,6 +138,9 @@ private:
     bool                        m_connected;            ///< true if we are in a state in which we are supposed to be connected to the server
     int                         m_auto_turns;           ///< auto turn counter
     bool                        m_have_window_focus;
+
+    bool                        m_save_game_in_progress;
+    boost::signals2::signal<void ()> SaveGameCompletedSignal;
 };
 
 #endif // _HumanClientApp_h_

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -664,11 +664,11 @@ boost::statechart::result WaitingForTurnData::react(const SaveGameComplete& msg)
     int bytes_written;
     ExtractServerSaveGameCompleteMessageData(msg.m_message, save_filename, bytes_written);
 
-
     Client().GetClientUI().GetMessageWnd()->HandleGameStatusUpdate(
         boost::io::str(FlexibleFormat(UserString("SERVER_SAVE_COMPLETE")) % save_filename % bytes_written) + "\n");
 
-    DebugLogger() << "Save Complete on Server";
+    Client().SaveGameCompleted();
+
     return discard_event();
 }
 
@@ -775,11 +775,10 @@ boost::statechart::result PlayingTurn::react(const SaveGameComplete& msg) {
     int bytes_written;
     ExtractServerSaveGameCompleteMessageData(msg.m_message, save_filename, bytes_written);
 
-
     Client().GetClientUI().GetMessageWnd()->HandleGameStatusUpdate(
         boost::io::str(FlexibleFormat(UserString("SERVER_SAVE_COMPLETE")) % save_filename % bytes_written) + "\n");
 
-    DebugLogger() << "Save Complete on Server";
+    Client().SaveGameCompleted();
     return discard_event();
 }
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -902,8 +902,8 @@ Unable to save during AI processing. Try again when AIs have finished turns.
 SAVE_GAME_IN_PROGRESS
 A save game is in progress.  Click Stop Waiting to abandon the save.
 
-STOP_WAITING
-Stop waiting.
+ABORT_SAVE_AND_QUIT
+Abort Save and Quit.
 
 EMPIRE_NOT_FOUND_CANT_HANDLE_ORDERS
 You do not control an empire and cannot issue orders.

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -899,6 +899,12 @@ Error when reading save file.
 UNABLE_TO_SAVE_NOW_TRY_AGAIN
 Unable to save during AI processing. Try again when AIs have finished turns.
 
+SAVE_GAME_IN_PROGRESS
+A save game is in progress.  Click Stop Waiting to abandon the save.
+
+STOP_WAITING
+Stop waiting.
+
 EMPIRE_NOT_FOUND_CANT_HANDLE_ORDERS
 You do not control an empire and cannot issue orders.
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -900,10 +900,13 @@ UNABLE_TO_SAVE_NOW_TRY_AGAIN
 Unable to save during AI processing. Try again when AIs have finished turns.
 
 SAVE_GAME_IN_PROGRESS
-A save game is in progress.  Click Stop Waiting to abandon the save.
+A save game is in progress.
 
-ABORT_SAVE_AND_QUIT
-Abort Save and Quit.
+ABORT_SAVE_AND_RESET
+Return to Main Menu without saving.
+
+ABORT_SAVE_AND_EXIT
+Exit FreeOrion without saving.
 
 EMPIRE_NOT_FOUND_CANT_HANDLE_ORDERS
 You do not control an empire and cannot issue orders.


### PR DESCRIPTION
This improves/fixes [Issue #971 Save game operation fails silently if user resigns and quits the game quickly enough](https://github.com/freeorion/freeorion/issues/971).

The problem as described in the issue is that application can exit while the server is either collecting or writing the save game.

This PR solves this by popping up a dialog when there is a pending save and the user tries to return to the intro menu or completely exit the game.  The dialog says "A save game is in progress.  Click Stop Waiting to abandon the save."

If the player waits the application will quit/exit when the save completes.

If the player clicks "Stop Waiting" then the app will continue with the exit, without waiting for the save to complete.

A deficiency is that when the player elects to stop waiting the exit may wait  for 5 seconds and then kill the server.  Neither the server process or the AI processes are interruptible.  However, the player will have been informed and chosen to abandon the save and kill the server. 

I think this fixes the bug.