### PR TITLE
Fix issue 1422 human client FSM transition order issues.

### DIFF
--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -542,12 +542,17 @@ boost::statechart::result PlayingGame::react(const Error& msg) {
     ErrorLogger() << "PlayingGame::react(const Error& msg) error: "
                   << problem << "\nProblem is" << (fatal ? "fatal" : "non-fatal");
 
+    //Note: Any transit<> transition must occur before the MessageBox().
+    // MessageBox blocks and can allow other events to transit<> to a new state
+    // which makes this transit fatal.
+
+    auto retval = discard_event();
     if (fatal)
-        Client().ResetToIntro();    // initiates state transition, so nothing extra required in this function
+        Client().ResetToIntro();
 
     ClientUI::MessageBox(UserString(problem), fatal);
 
-    return discard_event();
+    return retval;
 }
 
 boost::statechart::result PlayingGame::react(const TurnProgress& msg) {

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -959,9 +959,8 @@ boost::statechart::result QuittingGame::react(const TerminateServer& u) {
 
     // Reset the game or quit the app as appropriate
     if (m_reset_to_intro) {
-        auto retval = transit<IntroMenu>();
         Client().ResetClientData();
-        return retval;
+        return transit<IntroMenu>();
     } else {
         throw HumanClientApp::CleanQuit();
     }

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -114,9 +114,13 @@ boost::statechart::result WaitingForSPHostAck::react(const HostSPGame& msg) {
 
 boost::statechart::result WaitingForSPHostAck::react(const Disconnection& d) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) PlayingGame.Disconnection";
-    //Note: Any transit<> transition must occur before the MessageBox().
-    // MessageBox blocks and can allow other events to transit<> to a new state
-    // which makes this transit fatal.
+    // Note: All transitions, transit<> or disable_event(), must occur in the order
+    // that they cause changes to the state machine.
+    // - MessageBox blocks the UI, but continues handling events so other events
+    //   can transit<> to a new state which makes this transition potentially fatal.
+    // - Some client functions (ResetToIntro()) change the state machine, so a transition after
+    //   that function is undefined and potentially fatal.
+
     auto retval = discard_event();
     Client().ResetToIntro();
     ClientUI::MessageBox(UserString("SERVER_LOST"), true);
@@ -134,9 +138,13 @@ boost::statechart::result WaitingForSPHostAck::react(const Error& msg) {
     //Note: transit<> frees this pointer so Client() must be called before.
     HumanClientApp& client = Client();
 
-    //Note: Any transit<> transition must occur before the MessageBox().
-    // MessageBox blocks and can allow other events to transit<> to a new state
-    // which makes this transit fatal.
+    // Note: All transitions, transit<> or disable_event(), must occur in the order
+    // that they cause changes to the state machine.
+    // - MessageBox blocks the UI, but continues handling events so other events
+    //   can transit<> to a new state which makes this transition potentially fatal.
+    // - Some client functions (ResetToIntro()) change the state machine, so a transition after
+    //   that function is undefined and potentially fatal.
+
     auto retval = discard_event();
     if (fatal) {
         Client().ResetToIntro();
@@ -177,9 +185,13 @@ boost::statechart::result WaitingForMPHostAck::react(const HostMPGame& msg) {
 
 boost::statechart::result WaitingForMPHostAck::react(const Disconnection& d) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) PlayingGame.Disconnection";
-    //Note: Any transit<> transition must occur before the MessageBox().
-    // MessageBox blocks and can allow other events to transit<> to a new state
-    // which makes this transit fatal.
+    // Note: All transitions, transit<> or disable_event(), must occur in the order
+    // that they cause changes to the state machine.
+    // - MessageBox blocks the UI, but continues handling events so other events
+    //   can transit<> to a new state which makes this transition potentially fatal.
+    // - Some client functions (ResetToIntro()) change the state machine, so a transition after
+    //   that function is undefined and potentially fatal.
+
     auto retval = discard_event();
     Client().ResetToIntro();
     ClientUI::MessageBox(UserString("SERVER_LOST"), true);
@@ -197,9 +209,13 @@ boost::statechart::result WaitingForMPHostAck::react(const Error& msg) {
     //Note: transit<> frees this pointer so Client() must be called before.
     HumanClientApp& client = Client();
 
-    //Note: Any transit<> transition must occur before the MessageBox().
-    // MessageBox blocks and can allow other events to transit<> to a new state
-    // which makes this transit fatal.
+    // Note: All transitions, transit<> or disable_event(), must occur in the order
+    // that they cause changes to the state machine.
+    // - MessageBox blocks the UI, but continues handling events so other events
+    //   can transit<> to a new state which makes this transition potentially fatal.
+    // - Some client functions (ResetToIntro()) change the state machine, so a transition after
+    //   that function is undefined and potentially fatal.
+
     auto retval = discard_event();
     if (fatal) {
         Client().ResetToIntro();
@@ -239,9 +255,13 @@ boost::statechart::result WaitingForMPJoinAck::react(const JoinGame& msg) {
 
 boost::statechart::result WaitingForMPJoinAck::react(const Disconnection& d) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) PlayingGame.Disconnection";
-    //Note: Any transit<> transition must occur before the MessageBox().
-    // MessageBox blocks and can allow other events to transit<> to a new state
-    // which makes this transit fatal.
+    // Note: All transitions, transit<> or disable_event(), must occur in the order
+    // that they cause changes to the state machine.
+    // - MessageBox blocks the UI, but continues handling events so other events
+    //   can transit<> to a new state which makes this transition potentially fatal.
+    // - Some client functions (ResetToIntro()) change the state machine, so a transition after
+    //   that function is undefined and potentially fatal.
+
     auto retval = discard_event();
     Client().ResetToIntro();
     ClientUI::MessageBox(UserString("SERVER_LOST"), true);
@@ -259,9 +279,13 @@ boost::statechart::result WaitingForMPJoinAck::react(const Error& msg) {
     //Note: transit<> frees this pointer so Client() must be called before.
     HumanClientApp& client = Client();
 
-    //Note: Any transit<> transition must occur before the MessageBox().
-    // MessageBox blocks and can allow other events to transit<> to a new state
-    // which makes this transit fatal.
+    // Note: All transitions, transit<> or disable_event(), must occur in the order
+    // that they cause changes to the state machine.
+    // - MessageBox blocks the UI, but continues handling events so other events
+    //   can transit<> to a new state which makes this transition potentially fatal.
+    // - Some client functions (ResetToIntro()) change the state machine, so a transition after
+    //   that function is undefined and potentially fatal.
+
     auto retval = discard_event();
     if (fatal) {
         Client().ResetToIntro();
@@ -299,9 +323,13 @@ MPLobby::~MPLobby() {
 
 boost::statechart::result MPLobby::react(const Disconnection& d) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) MPLobby.Disconnection";
-    //Note: Any transit<> transition must occur before the MessageBox().
-    // MessageBox blocks and can allow other events to transit<> to a new state
-    // which makes this transit fatal.
+    // Note: All transitions, transit<> or disable_event(), must occur in the order
+    // that they cause changes to the state machine.
+    // - MessageBox blocks the UI, but continues handling events so other events
+    //   can transit<> to a new state which makes this transition potentially fatal.
+    // - Some client functions (ResetToIntro()) change the state machine, so a transition after
+    //   that function is undefined and potentially fatal.
+
     auto retval = discard_event();
     Client().ResetToIntro();
     ClientUI::MessageBox(UserString("SERVER_LOST"), true);
@@ -344,9 +372,13 @@ boost::statechart::result MPLobby::react(const LobbyChat& msg) {
 boost::statechart::result MPLobby::react(const CancelMPGameClicked& a)
 {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) MPLobby.CancelMPGameClicked";
-    //Note: Any transit<> transition must occur before the MessageBox().
-    // MessageBox blocks and can allow other events to transit<> to a new state
-    // which makes this transit fatal.
+    // Note: All transitions, transit<> or disable_event(), must occur in the order
+    // that they cause changes to the state machine.
+    // - MessageBox blocks the UI, but continues handling events so other events
+    //   can transit<> to a new state which makes this transition potentially fatal.
+    // - Some client functions (ResetToIntro()) change the state machine, so a transition after
+    //   that function is undefined and potentially fatal.
+
     auto retval = discard_event();
     Client().ResetToIntro();
     return retval;
@@ -383,9 +415,13 @@ boost::statechart::result MPLobby::react(const Error& msg) {
 
     ErrorLogger() << "MPLobby::react(const Error& msg) error: " << problem;
 
-    //Note: Any transit<> transition must occur before the MessageBox().
-    // MessageBox blocks and can allow other events to transit<> to a new state
-    // which makes this transit fatal.
+    // Note: All transitions, transit<> or disable_event(), must occur in the order
+    // that they cause changes to the state machine.
+    // - MessageBox blocks the UI, but continues handling events so other events
+    //   can transit<> to a new state which makes this transition potentially fatal.
+    // - Some client functions (ResetToIntro()) change the state machine, so a transition after
+    //   that function is undefined and potentially fatal.
+
     auto retval = discard_event();
     if (fatal) {
         Client().ResetToIntro();
@@ -456,9 +492,13 @@ boost::statechart::result PlayingGame::react(const PlayerChat& msg) {
 
 boost::statechart::result PlayingGame::react(const Disconnection& d) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) PlayingGame.Disconnection";
-    //Note: Any transit<> transition must occur before the MessageBox().
-    // MessageBox blocks and can allow other events to transit<> to a new state
-    // which makes this transit fatal.
+    // Note: All transitions, transit<> or disable_event(), must occur in the order
+    // that they cause changes to the state machine.
+    // - MessageBox blocks the UI, but continues handling events so other events
+    //   can transit<> to a new state which makes this transition potentially fatal.
+    // - Some client functions (ResetToIntro()) change the state machine, so a transition after
+    //   that function is undefined and potentially fatal.
+
     auto retval = discard_event();
     Client().ResetToIntro();
     ClientUI::MessageBox(UserString("SERVER_LOST"), true);
@@ -515,9 +555,13 @@ boost::statechart::result PlayingGame::react(const EndGame& msg) {
         error = true;
         break;
     }
-    //Note: Any transit<> transition must occur before the MessageBox().
-    // MessageBox blocks and can allow other events to transit<> to a new state
-    // which makes this transit fatal.
+    // Note: All transitions, transit<> or disable_event(), must occur in the order
+    // that they cause changes to the state machine.
+    // - MessageBox blocks the UI, but continues handling events so other events
+    //   can transit<> to a new state which makes this transition potentially fatal.
+    // - Some client functions (ResetToIntro()) change the state machine, so a transition after
+    //   that function is undefined and potentially fatal.
+
     auto retval = discard_event();
     Client().ResetToIntro();
     ClientUI::MessageBox(reason_message, error);
@@ -542,9 +586,12 @@ boost::statechart::result PlayingGame::react(const Error& msg) {
     ErrorLogger() << "PlayingGame::react(const Error& msg) error: "
                   << problem << "\nProblem is" << (fatal ? "fatal" : "non-fatal");
 
-    //Note: Any transit<> transition must occur before the MessageBox().
-    // MessageBox blocks and can allow other events to transit<> to a new state
-    // which makes this transit fatal.
+    // Note: All transitions, transit<> or disable_event(), must occur in the order
+    // that they cause changes to the state machine.
+    // - MessageBox blocks the UI, but continues handling events so other events
+    //   can transit<> to a new state which makes this transition potentially fatal.
+    // - Some client functions (ResetToIntro()) change the state machine, so a transition after
+    //   that function is undefined and potentially fatal.
 
     auto retval = discard_event();
     if (fatal)

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -114,8 +114,11 @@ boost::statechart::result WaitingForSPHostAck::react(const HostSPGame& msg) {
 
 boost::statechart::result WaitingForSPHostAck::react(const Disconnection& d) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) PlayingGame.Disconnection";
-    // Note: All transitions, transit<> or disable_event(), must occur in the order
-    // that they cause changes to the state machine.
+    // Note: All transitions, transit<> or discard_event(), must occur in the order
+    // that they cause changes to the state machine.  If a function is called that may internally
+    // cause a transition, then the transistion in this function must happen first lexically and
+    // the return value must be saved to return at the end of the function, so that temporally and
+    // state-wise all the transistions occur at the correct time and from/to the correct state.
     // - MessageBox blocks the UI, but continues handling events so other events
     //   can transit<> to a new state which makes this transition potentially fatal.
     // - Some client functions (ResetToIntro()) change the state machine, so a transition after
@@ -138,8 +141,11 @@ boost::statechart::result WaitingForSPHostAck::react(const Error& msg) {
     //Note: transit<> frees this pointer so Client() must be called before.
     HumanClientApp& client = Client();
 
-    // Note: All transitions, transit<> or disable_event(), must occur in the order
-    // that they cause changes to the state machine.
+    // Note: All transitions, transit<> or discard_event(), must occur in the order
+    // that they cause changes to the state machine.  If a function is called that may internally
+    // cause a transition, then the transistion in this function must happen first lexically and
+    // the return value must be saved to return at the end of the function, so that temporally and
+    // state-wise all the transistions occur at the correct time and from/to the correct state.
     // - MessageBox blocks the UI, but continues handling events so other events
     //   can transit<> to a new state which makes this transition potentially fatal.
     // - Some client functions (ResetToIntro()) change the state machine, so a transition after
@@ -185,8 +191,11 @@ boost::statechart::result WaitingForMPHostAck::react(const HostMPGame& msg) {
 
 boost::statechart::result WaitingForMPHostAck::react(const Disconnection& d) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) PlayingGame.Disconnection";
-    // Note: All transitions, transit<> or disable_event(), must occur in the order
-    // that they cause changes to the state machine.
+    // Note: All transitions, transit<> or discard_event(), must occur in the order
+    // that they cause changes to the state machine.  If a function is called that may internally
+    // cause a transition, then the transistion in this function must happen first lexically and
+    // the return value must be saved to return at the end of the function, so that temporally and
+    // state-wise all the transistions occur at the correct time and from/to the correct state.
     // - MessageBox blocks the UI, but continues handling events so other events
     //   can transit<> to a new state which makes this transition potentially fatal.
     // - Some client functions (ResetToIntro()) change the state machine, so a transition after
@@ -209,8 +218,11 @@ boost::statechart::result WaitingForMPHostAck::react(const Error& msg) {
     //Note: transit<> frees this pointer so Client() must be called before.
     HumanClientApp& client = Client();
 
-    // Note: All transitions, transit<> or disable_event(), must occur in the order
-    // that they cause changes to the state machine.
+    // Note: All transitions, transit<> or discard_event(), must occur in the order
+    // that they cause changes to the state machine.  If a function is called that may internally
+    // cause a transition, then the transistion in this function must happen first lexically and
+    // the return value must be saved to return at the end of the function, so that temporally and
+    // state-wise all the transistions occur at the correct time and from/to the correct state.
     // - MessageBox blocks the UI, but continues handling events so other events
     //   can transit<> to a new state which makes this transition potentially fatal.
     // - Some client functions (ResetToIntro()) change the state machine, so a transition after
@@ -255,8 +267,11 @@ boost::statechart::result WaitingForMPJoinAck::react(const JoinGame& msg) {
 
 boost::statechart::result WaitingForMPJoinAck::react(const Disconnection& d) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) PlayingGame.Disconnection";
-    // Note: All transitions, transit<> or disable_event(), must occur in the order
-    // that they cause changes to the state machine.
+    // Note: All transitions, transit<> or discard_event(), must occur in the order
+    // that they cause changes to the state machine.  If a function is called that may internally
+    // cause a transition, then the transistion in this function must happen first lexically and
+    // the return value must be saved to return at the end of the function, so that temporally and
+    // state-wise all the transistions occur at the correct time and from/to the correct state.
     // - MessageBox blocks the UI, but continues handling events so other events
     //   can transit<> to a new state which makes this transition potentially fatal.
     // - Some client functions (ResetToIntro()) change the state machine, so a transition after
@@ -279,8 +294,11 @@ boost::statechart::result WaitingForMPJoinAck::react(const Error& msg) {
     //Note: transit<> frees this pointer so Client() must be called before.
     HumanClientApp& client = Client();
 
-    // Note: All transitions, transit<> or disable_event(), must occur in the order
-    // that they cause changes to the state machine.
+    // Note: All transitions, transit<> or discard_event(), must occur in the order
+    // that they cause changes to the state machine.  If a function is called that may internally
+    // cause a transition, then the transistion in this function must happen first lexically and
+    // the return value must be saved to return at the end of the function, so that temporally and
+    // state-wise all the transistions occur at the correct time and from/to the correct state.
     // - MessageBox blocks the UI, but continues handling events so other events
     //   can transit<> to a new state which makes this transition potentially fatal.
     // - Some client functions (ResetToIntro()) change the state machine, so a transition after
@@ -323,8 +341,11 @@ MPLobby::~MPLobby() {
 
 boost::statechart::result MPLobby::react(const Disconnection& d) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) MPLobby.Disconnection";
-    // Note: All transitions, transit<> or disable_event(), must occur in the order
-    // that they cause changes to the state machine.
+    // Note: All transitions, transit<> or discard_event(), must occur in the order
+    // that they cause changes to the state machine.  If a function is called that may internally
+    // cause a transition, then the transistion in this function must happen first lexically and
+    // the return value must be saved to return at the end of the function, so that temporally and
+    // state-wise all the transistions occur at the correct time and from/to the correct state.
     // - MessageBox blocks the UI, but continues handling events so other events
     //   can transit<> to a new state which makes this transition potentially fatal.
     // - Some client functions (ResetToIntro()) change the state machine, so a transition after
@@ -372,8 +393,11 @@ boost::statechart::result MPLobby::react(const LobbyChat& msg) {
 boost::statechart::result MPLobby::react(const CancelMPGameClicked& a)
 {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) MPLobby.CancelMPGameClicked";
-    // Note: All transitions, transit<> or disable_event(), must occur in the order
-    // that they cause changes to the state machine.
+    // Note: All transitions, transit<> or discard_event(), must occur in the order
+    // that they cause changes to the state machine.  If a function is called that may internally
+    // cause a transition, then the transistion in this function must happen first lexically and
+    // the return value must be saved to return at the end of the function, so that temporally and
+    // state-wise all the transistions occur at the correct time and from/to the correct state.
     // - MessageBox blocks the UI, but continues handling events so other events
     //   can transit<> to a new state which makes this transition potentially fatal.
     // - Some client functions (ResetToIntro()) change the state machine, so a transition after
@@ -415,8 +439,11 @@ boost::statechart::result MPLobby::react(const Error& msg) {
 
     ErrorLogger() << "MPLobby::react(const Error& msg) error: " << problem;
 
-    // Note: All transitions, transit<> or disable_event(), must occur in the order
-    // that they cause changes to the state machine.
+    // Note: All transitions, transit<> or discard_event(), must occur in the order
+    // that they cause changes to the state machine.  If a function is called that may internally
+    // cause a transition, then the transistion in this function must happen first lexically and
+    // the return value must be saved to return at the end of the function, so that temporally and
+    // state-wise all the transistions occur at the correct time and from/to the correct state.
     // - MessageBox blocks the UI, but continues handling events so other events
     //   can transit<> to a new state which makes this transition potentially fatal.
     // - Some client functions (ResetToIntro()) change the state machine, so a transition after
@@ -492,8 +519,11 @@ boost::statechart::result PlayingGame::react(const PlayerChat& msg) {
 
 boost::statechart::result PlayingGame::react(const Disconnection& d) {
     if (TRACE_EXECUTION) DebugLogger() << "(HumanClientFSM) PlayingGame.Disconnection";
-    // Note: All transitions, transit<> or disable_event(), must occur in the order
-    // that they cause changes to the state machine.
+    // Note: All transitions, transit<> or discard_event(), must occur in the order
+    // that they cause changes to the state machine.  If a function is called that may internally
+    // cause a transition, then the transistion in this function must happen first lexically and
+    // the return value must be saved to return at the end of the function, so that temporally and
+    // state-wise all the transistions occur at the correct time and from/to the correct state.
     // - MessageBox blocks the UI, but continues handling events so other events
     //   can transit<> to a new state which makes this transition potentially fatal.
     // - Some client functions (ResetToIntro()) change the state machine, so a transition after
@@ -555,8 +585,11 @@ boost::statechart::result PlayingGame::react(const EndGame& msg) {
         error = true;
         break;
     }
-    // Note: All transitions, transit<> or disable_event(), must occur in the order
-    // that they cause changes to the state machine.
+    // Note: All transitions, transit<> or discard_event(), must occur in the order
+    // that they cause changes to the state machine.  If a function is called that may internally
+    // cause a transition, then the transistion in this function must happen first lexically and
+    // the return value must be saved to return at the end of the function, so that temporally and
+    // state-wise all the transistions occur at the correct time and from/to the correct state.
     // - MessageBox blocks the UI, but continues handling events so other events
     //   can transit<> to a new state which makes this transition potentially fatal.
     // - Some client functions (ResetToIntro()) change the state machine, so a transition after
@@ -586,8 +619,11 @@ boost::statechart::result PlayingGame::react(const Error& msg) {
     ErrorLogger() << "PlayingGame::react(const Error& msg) error: "
                   << problem << "\nProblem is" << (fatal ? "fatal" : "non-fatal");
 
-    // Note: All transitions, transit<> or disable_event(), must occur in the order
-    // that they cause changes to the state machine.
+    // Note: All transitions, transit<> or discard_event(), must occur in the order
+    // that they cause changes to the state machine.  If a function is called that may internally
+    // cause a transition, then the transistion in this function must happen first lexically and
+    // the return value must be saved to return at the end of the function, so that temporally and
+    // state-wise all the transistions occur at the correct time and from/to the correct state.
     // - MessageBox blocks the UI, but continues handling events so other events
     //   can transit<> to a new state which makes this transition potentially fatal.
     // - Some client functions (ResetToIntro()) change the state machine, so a transition after


### PR DESCRIPTION
I think that this PR fixes #1422.

The problem is that moving `discard_event()` to after the transition within `ResetToIntro()` means that the discard event null transition occurs from a state that has already been exited.

The PR expands the comments clarifying the boost state machine behavior everywhere in the code. 

Hopefully this corrects, my previous unclear explanation of what was happening in this section of code. 
