### PR TITLE
Uncompressed Save Option

### DIFF
--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -630,7 +630,8 @@ OptionsWnd::OptionsWnd():
     IntOption(current_page, 0, "effects-threads-server",    UserString("OPTIONS_EFFECTS_THREADS_SERVER"));
     IntOption(current_page, 0, "effects-threads-ai",        UserString("OPTIONS_EFFECTS_THREADS_AI"));
     BoolOption(current_page, 0, "auto-add-saved-designs",   UserString("OPTIONS_ADD_SAVED_DESIGNS"));
-    BoolOption(current_page, 0, "binary-serialization",     UserString("OPTIONS_USE_BINARY_SERIALIZATION"));  // Consider changing to Enum to support more serialization formats
+    BoolOption(current_page, 0, "binary-serialization",     UserString("OPTIONS_USE_BINARY_SERIALIZATION"));
+    BoolOption(current_page, 0, "xml-zlib-serialization",   UserString("OPTIONS_USE_XML_ZLIB_SERIALIZATION"));
     BoolOption(current_page, 0, "verbose-logging",          UserString("OPTIONS_VERBOSE_LOGGING_DESC"));
     BoolOption(current_page, 0, "verbose-sitrep",           UserString("OPTIONS_VERBOSE_SITREP_DESC"));
     BoolOption(current_page, 0, "effect-accounting",        UserString("OPTIONS_EFFECT_ACCOUNTING"));

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1546,6 +1546,9 @@ Automatically quits once any turns specified by --auto-advance-n-turns are compl
 OPTIONS_DB_BINARY_SERIALIZATION
 Use Binary serialization for saving games. Binary serialization is faster to save and load, but may not be possible to load on a different operating system.
 
+OPTIONS_DB_XML_ZLIB_SERIALIZATION
+When saving games with XML serialization, compress most of the XML before writing the file. Compression substantially reduces save file sizes, but may make saves unloadable due to memory requirements to decompress the save data.
+
 OPTIONS_DB_UI_WINDOWS_EXISTS
 True if the window with a given config name currently exists, false if one was created and deleted, doesn't exist if no window has yet been created with that name.
 
@@ -2570,6 +2573,9 @@ Add All Saved Ship Designs at Game Start
 
 OPTIONS_USE_BINARY_SERIALIZATION
 Create Binary Save Files
+
+OPTIONS_USE_XML_ZLIB_SERIALIZATION
+Use Compression for XML Save Files 
 
 
 ##

--- a/server/SaveLoad.cpp
+++ b/server/SaveLoad.cpp
@@ -209,7 +209,7 @@ int SaveGame(const std::string& filename, const ServerSaveGameData& server_save_
                     xoa << BOOST_SERIALIZATION_NVP(empire_manager);
                     xoa << BOOST_SERIALIZATION_NVP(species_manager);
                     xoa << BOOST_SERIALIZATION_NVP(combat_log_manager);
-                    xoa << BOOST_SERIALIZATION_NVP(universe);
+                    Serialize(xoa, universe);
                     s_sink.flush();
 
                     // wrap gamestate string in iostream::stream to extract serialized data
@@ -264,7 +264,7 @@ int SaveGame(const std::string& filename, const ServerSaveGameData& server_save_
                     xoa << BOOST_SERIALIZATION_NVP(empire_manager);
                     xoa << BOOST_SERIALIZATION_NVP(species_manager);
                     xoa << BOOST_SERIALIZATION_NVP(combat_log_manager);
-                    xoa << BOOST_SERIALIZATION_NVP(universe);
+                    Serialize(xoa, universe);
 
                     save_completed_as_xml = true;
                 } catch (...) {
@@ -289,7 +289,7 @@ int SaveGame(const std::string& filename, const ServerSaveGameData& server_save_
             boa << BOOST_SERIALIZATION_NVP(empire_manager);
             boa << BOOST_SERIALIZATION_NVP(species_manager);
             boa << BOOST_SERIALIZATION_NVP(combat_log_manager);
-            boa << BOOST_SERIALIZATION_NVP(universe);
+            Serialize(boa, universe);
 
             DebugLogger() << "Done serializing";
         }
@@ -347,7 +347,7 @@ void LoadGame(const std::string& filename, ServerSaveGameData& server_save_game_
             ia >> BOOST_SERIALIZATION_NVP(empire_manager);
             ia >> BOOST_SERIALIZATION_NVP(species_manager);
             ia >> BOOST_SERIALIZATION_NVP(combat_log_manager);
-            ia >> BOOST_SERIALIZATION_NVP(universe);
+            Deserialize(ia, universe);
 
             DebugLogger() << "Done deserializing";
         } catch (...) {
@@ -374,7 +374,7 @@ void LoadGame(const std::string& filename, ServerSaveGameData& server_save_game_
                 xia >> BOOST_SERIALIZATION_NVP(empire_manager);
                 xia >> BOOST_SERIALIZATION_NVP(species_manager);
                 xia >> BOOST_SERIALIZATION_NVP(combat_log_manager);
-                xia >> BOOST_SERIALIZATION_NVP(universe);
+                Deserialize(xia, universe);
 
             } else {
                 // assume compressed XML
@@ -431,7 +431,7 @@ void LoadGame(const std::string& filename, ServerSaveGameData& server_save_game_
                 xia2 >> BOOST_SERIALIZATION_NVP(empire_manager);
                 xia2 >> BOOST_SERIALIZATION_NVP(species_manager);
                 xia2 >> BOOST_SERIALIZATION_NVP(combat_log_manager);
-                xia2 >> BOOST_SERIALIZATION_NVP(universe);
+                Deserialize(xia2, universe);
             }
         }
 

--- a/util/MultiplayerCommon.cpp
+++ b/util/MultiplayerCommon.cpp
@@ -27,6 +27,7 @@ namespace {
         db.Add<std::string>("log-level",            UserStringNop("OPTIONS_DB_LOG_LEVEL"),             "DEBUG");
         db.Add<std::string>("stringtable-filename", UserStringNop("OPTIONS_DB_STRINGTABLE_FILENAME"),  PathString(GetRootDataDir() / "default" / "stringtables" / "en.txt"));
         db.Add("binary-serialization",              UserStringNop("OPTIONS_DB_BINARY_SERIALIZATION"),  false);
+        db.Add("xml-zlib-serialization",            UserStringNop("OPTIONS_DB_XML_ZLIB_SERIALIZATION"),true);
 
         // AI Testing options-- the following options are to facilitate AI testing and do not currently have an options page widget; 
         // they are intended to be changed via the command line and are not currently storable in the configuration file.

--- a/util/SaveGamePreviewUtils.cpp
+++ b/util/SaveGamePreviewUtils.cpp
@@ -132,6 +132,10 @@ void SaveGamePreviewData::serialize(Archive& ar, unsigned int version)
            & BOOST_SERIALIZATION_NVP(freeorion_version);
         if (version >= 3) {
             ar & BOOST_SERIALIZATION_NVP(save_format_marker);
+            if (version >= 4) {
+                ar & BOOST_SERIALIZATION_NVP(uncompressed_text_size)
+                   & BOOST_SERIALIZATION_NVP(compressed_text_size);
+            }
         }
     }
     ar & BOOST_SERIALIZATION_NVP(magic_number)

--- a/util/SaveGamePreviewUtils.cpp
+++ b/util/SaveGamePreviewUtils.cpp
@@ -29,7 +29,7 @@ namespace fs = boost::filesystem;
 
 namespace {
     const std::string UNABLE_TO_OPEN_FILE("Unable to open file");
-    const std::string XML_SAVE_FILE_DESCRIPTION("This is an XML archive FreeOrion saved game. Initial header information is uncompressed, and the main gamestate information is stored as zlib-comprssed XML archive in the last entry in the main archive.");
+    const std::string XML_SAVE_FILE_DESCRIPTION("This is an XML archive FreeOrion saved game. Initial header information is uncompressed. The main gamestate information follows, possibly stored as zlib-comprssed XML archive in the last entry in the main archive.");
     const std::string BIN_SAVE_FILE_DESCRIPTION("This is binary archive FreeOrion saved game.");
 
     /// Splits time and date on separate lines for an ISO datetime string

--- a/util/SaveGamePreviewUtils.cpp
+++ b/util/SaveGamePreviewUtils.cpp
@@ -111,7 +111,8 @@ SaveGamePreviewData::SaveGamePreviewData() :
     main_player_empire_name(UserString("UNKNOWN_VALUE_SYMBOL_2")),
     current_turn(-1),
     number_of_empires(-1),
-    number_of_human_players(-1)
+    number_of_human_players(-1),
+    save_format_marker("")
 {}
 
 bool SaveGamePreviewData::Valid() const
@@ -129,6 +130,9 @@ void SaveGamePreviewData::serialize(Archive& ar, unsigned int version)
         }
         ar & BOOST_SERIALIZATION_NVP(description)
            & BOOST_SERIALIZATION_NVP(freeorion_version);
+        if (version >= 3) {
+            ar & BOOST_SERIALIZATION_NVP(save_format_marker);
+        }
     }
     ar & BOOST_SERIALIZATION_NVP(magic_number)
        & BOOST_SERIALIZATION_NVP(main_player_name);

--- a/util/SaveGamePreviewUtils.h
+++ b/util/SaveGamePreviewUtils.h
@@ -39,13 +39,15 @@ struct FO_COMMON_API SaveGamePreviewData {
     short               number_of_empires;              /// The number of empires in the game
     short               number_of_human_players;        /// The number of human players in the game
 
-    std::string         save_format_marker;             /// What format was used for this save?
+    std::string         save_format_marker = "";        /// What format was used for this save?
+    unsigned int        uncompressed_text_size = 0;     /// How many bytes capacity does the uncompressed save text take up? (ie. the part that was / will be compressed with zlib for compressed xml format saves)
+    unsigned int        compressed_text_size = 0;       /// How many bytes capacity does the compressed save text take up?
 
     template <class Archive>
     void serialize(Archive& ar, unsigned int version);
 };
 
-BOOST_CLASS_VERSION(SaveGamePreviewData, 3);
+BOOST_CLASS_VERSION(SaveGamePreviewData, 4);
 
 extern template FO_COMMON_API void SaveGamePreviewData::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, unsigned int);
 extern template FO_COMMON_API void SaveGamePreviewData::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, unsigned int);

--- a/util/SaveGamePreviewUtils.h
+++ b/util/SaveGamePreviewUtils.h
@@ -39,11 +39,13 @@ struct FO_COMMON_API SaveGamePreviewData {
     short               number_of_empires;              /// The number of empires in the game
     short               number_of_human_players;        /// The number of human players in the game
 
+    std::string         save_format_marker;             /// What format was used for this save?
+
     template <class Archive>
     void serialize(Archive& ar, unsigned int version);
 };
 
-BOOST_CLASS_VERSION(SaveGamePreviewData, 2);
+BOOST_CLASS_VERSION(SaveGamePreviewData, 3);
 
 extern template FO_COMMON_API void SaveGamePreviewData::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, unsigned int);
 extern template FO_COMMON_API void SaveGamePreviewData::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, unsigned int);
@@ -62,7 +64,7 @@ private:
 };
 
 /** The preview information the server sends to the client. */
-struct FO_COMMON_API PreviewInformation{
+struct FO_COMMON_API PreviewInformation {
     std::vector<std::string>    subdirectories; /// A list of all subfolders of the save game directory, in the format /name1/child1/grandchild
     std::string                 folder;         /// The directory whose previews are being listed now
     std::vector<FullPreview>    previews;       /// The previews of the saves in this folder


### PR DESCRIPTION
Adds an option to save with uncompressed XML. This makes the save files much bigger, but has some advantages:
* It will probably be portable, like compressed XML.
* It will probably produce save files that can be loaded even when the compressed XML can't due to the buffer required to decompress the XML being too big to allocate in memory. The uncompressed format can probably be streamed directly from disk, and shouldn't need to be all held in memory at once.
* It can be edited with a text editor to change the gamestate in the save.

Should be backwards compatible with old save files.

![save_save_different_formats](https://cloud.githubusercontent.com/assets/11386908/24174727/6ffec420-0e92-11e7-8e5d-df15e5099f6f.png)

Should resolve issue #622