### PR TITLE
Fix crash caused by erasing map elements while iterating in System.cpp.

### DIFF
--- a/universe/System.cpp
+++ b/universe/System.cpp
@@ -162,10 +162,15 @@ void System::Copy(std::shared_ptr<const UniverseObject> copied_object, int empir
             // to exist any more
 
             // remove previously known lanes that aren't currently visible
-            for (std::map<int, bool>::value_type& entry : this->m_starlanes_wormholes) {
-                int lane_end_sys_id = entry.first;
-                if (visible_lanes_holes.find(lane_end_sys_id) == visible_lanes_holes.end())
-                    this->m_starlanes_wormholes.erase(lane_end_sys_id);
+            for (auto entry_it = m_starlanes_wormholes.begin(); entry_it != m_starlanes_wormholes.end();
+                 /* conditional increment in deleting loop */)
+            {
+                int lane_end_sys_id = entry_it->first;
+                if (visible_lanes_holes.find(lane_end_sys_id) == visible_lanes_holes.end()) {
+                    entry_it = m_starlanes_wormholes.erase(entry_it);
+                } else {
+                    ++entry_it;
+                }
             }
         }
     }


### PR DESCRIPTION
This might fix the crash reported in [the forum](http://freeorion.org/forum/viewtopic.php?f=28&t=10456&sid=6abcfe7c1f17f67c51ee477fdfa7c7f7), where after the Experimentors are active the game crashes on OSX.

In System::Copy there is for loop iterating over the map of starlanes and deleting elements. It does not account for the deleted elements while iterating so it could step into nowhere.  

This PR fixes that problem.  However, since I can't replicate the crash it may not fix the crash.