### PR TITLE
Do not issue next fleet order if previous one could not be issued

### DIFF
--- a/default/python/AI/AIFleetMission.py
+++ b/default/python/AI/AIFleetMission.py
@@ -393,6 +393,7 @@ class AIFleetMission(object):
                             self.clear_fleet_orders()
                             self.clear_target()
                             return
+                break  # do not order the next order until this one is finished.
         else:  # went through entire order list
             if order_completed:
                 print "Final order is completed"


### PR DESCRIPTION
Seems to partially fix an issue reported in http://freeorion.org/forum/viewtopic.php?f=28&t=10483#p88044

@Dilvish-fo: It seems to me that we would always want to break here if we can't issue an order but I can't tell if there was a reason not to introduce the ```break``` statement. If there are any negative side effects, we should discuss and adress those before merge.