### PR TITLE
Fix bug #1177 Sidepanel stat icons flickers during turn updates.

### DIFF
--- a/UI/AccordionPanel.cpp
+++ b/UI/AccordionPanel.cpp
@@ -118,5 +118,6 @@ void AccordionPanel::DoLayout() {
     GG::Pt expand_button_ul(m_is_left ? GG::X(-(EXPAND_BUTTON_SIZE + m_border_margin))
                             : (Width() + GG::X(-(EXPAND_BUTTON_SIZE + m_border_margin))), GG::Y0);
     GG::Pt expand_button_lr = expand_button_ul + GG::Pt(GG::X(EXPAND_BUTTON_SIZE), GG::Y(EXPAND_BUTTON_SIZE));
+    Wnd::MoveChildUp(m_expand_button);
     m_expand_button->SizeMove(expand_button_ul, expand_button_lr);
 }

--- a/UI/BuildingsPanel.cpp
+++ b/UI/BuildingsPanel.cpp
@@ -243,7 +243,6 @@ void BuildingsPanel::DoLayout() {
 
     Resize(GG::Pt(Width(), height));
 
-    Wnd::MoveChildUp(m_expand_button);
 
     m_expand_button->MoveTo(GG::Pt(Width() - m_expand_button->Width(), GG::Y0));
 

--- a/UI/BuildingsPanel.cpp
+++ b/UI/BuildingsPanel.cpp
@@ -243,9 +243,6 @@ void BuildingsPanel::DoLayout() {
 
     Resize(GG::Pt(Width(), height));
 
-
-    m_expand_button->MoveTo(GG::Pt(Width() - m_expand_button->Width(), GG::Y0));
-
     SetCollapsed(!s_expanded_map[m_planet_id]);
 }
 

--- a/UI/CUIControls.cpp
+++ b/UI/CUIControls.cpp
@@ -1398,6 +1398,20 @@ GG::Clr StatisticIcon::ValueColor(int index) const {
     return ClientUI::TextColor();
 }
 
+GG::Pt StatisticIcon::MinUsableSize() const {
+    if (!m_icon)
+        return GG::Pt(GG::X1, GG::Y1);
+
+    if (m_num_values <= 0 || !m_text)
+        return m_icon->Size();
+
+    if (Width() >= Value(Height()))
+        return GG::Pt(m_text->RelativeUpperLeft().x + m_text->MinUsableSize().x,
+                      std::max(m_icon->RelativeLowerRight().y, m_text->MinUsableSize().y));
+     else
+        return GG::Pt(std::max(m_icon->RelativeLowerRight().x, m_text->MinUsableSize().x),
+                      m_icon->RelativeLowerRight().y + m_text->MinUsableSize().y);
+}
 
 ///////////////////////////////////////
 // class CUIToolBar

--- a/UI/CUIControls.h
+++ b/UI/CUIControls.h
@@ -426,6 +426,7 @@ public:
 
     /** \name Accessors */ //@{
     double          GetValue(int index = 0) const;
+    GG::Pt          MinUsableSize() const override;
     //@}
 
     /** \name Mutators */ //@{

--- a/UI/MilitaryPanel.cpp
+++ b/UI/MilitaryPanel.cpp
@@ -238,8 +238,6 @@ void MilitaryPanel::DoLayout() {
         Resize(GG::Pt(Width(), m_multi_meter_status_bar->Bottom() + EDGE_PAD - top));
     }
 
-    m_expand_button->MoveTo(GG::Pt(Width() - m_expand_button->Width(), GG::Y0));
-
     SetCollapsed(!s_expanded_map[m_planet_id]);
 }
 

--- a/UI/MilitaryPanel.cpp
+++ b/UI/MilitaryPanel.cpp
@@ -41,16 +41,27 @@ MilitaryPanel::MilitaryPanel(GG::X w, int planet_id) :
 
     GG::Connect(m_expand_button->LeftClickedSignal, &MilitaryPanel::ExpandCollapseButtonPressed, this);
 
+    const auto obj = GetUniverseObject(m_planet_id);
+    if (!obj) {
+        ErrorLogger() << "Invalid object id " << m_planet_id;
+        return;
+    }
+
     // small meter indicators - for use when panel is collapsed
-    m_meter_stats.push_back({METER_SHIELD, new StatisticIcon(ClientUI::MeterIcon(METER_SHIELD), 0, 3, false,
+    m_meter_stats.push_back({METER_SHIELD, new StatisticIcon(ClientUI::MeterIcon(METER_SHIELD),
+                                                             obj->InitialMeterValue(METER_SHIELD), 3, false,
                                                              GG::X0, GG::Y0, MeterIconSize().x, MeterIconSize().y)});
-    m_meter_stats.push_back({METER_DEFENSE, new StatisticIcon(ClientUI::MeterIcon(METER_DEFENSE), 0, 3, false,
+    m_meter_stats.push_back({METER_DEFENSE, new StatisticIcon(ClientUI::MeterIcon(METER_DEFENSE),
+                                                              obj->InitialMeterValue(METER_DEFENSE), 3, false,
                                                               GG::X0, GG::Y0, MeterIconSize().x, MeterIconSize().y)});
-    m_meter_stats.push_back({METER_TROOPS, new StatisticIcon(ClientUI::MeterIcon(METER_TROOPS), 0, 3, false,
+    m_meter_stats.push_back({METER_TROOPS, new StatisticIcon(ClientUI::MeterIcon(METER_TROOPS),
+                                                             obj->InitialMeterValue(METER_TROOPS), 3, false,
                                                              GG::X0, GG::Y0, MeterIconSize().x, MeterIconSize().y)});
-    m_meter_stats.push_back({METER_DETECTION, new StatisticIcon(ClientUI::MeterIcon(METER_DETECTION), 0, 3, false,
+    m_meter_stats.push_back({METER_DETECTION, new StatisticIcon(ClientUI::MeterIcon(METER_DETECTION),
+                                                                obj->InitialMeterValue(METER_DETECTION), 3, false,
                                                                 GG::X0, GG::Y0, MeterIconSize().x, MeterIconSize().y)});
-    m_meter_stats.push_back({METER_STEALTH, new StatisticIcon(ClientUI::MeterIcon(METER_STEALTH), 0, 3, false,
+    m_meter_stats.push_back({METER_STEALTH, new StatisticIcon(ClientUI::MeterIcon(METER_STEALTH),
+                                                              obj->InitialMeterValue(METER_STEALTH), 3, false,
                                                               GG::X0, GG::Y0, MeterIconSize().x, MeterIconSize().y)});
 
     // meter and production indicators

--- a/UI/MilitaryPanel.cpp
+++ b/UI/MilitaryPanel.cpp
@@ -194,16 +194,19 @@ void MilitaryPanel::DoLayout() {
     if (!s_expanded_map[m_planet_id]) {
         // position and reattach icons to be shown
         int n = 0;
+        GG::X stride = MeterIconSize().x * 7/2;
         for (std::pair<MeterType, StatisticIcon*>& meter_stat : m_meter_stats) {
-            GG::X x = MeterIconSize().x*n*7/2;
-
-            if (x > Width() - m_expand_button->Width() - MeterIconSize().x*5/2) break;  // ensure icon doesn't extend past right edge of panel
+            GG::X x = n * stride;
 
             StatisticIcon* icon = meter_stat.second;
-            AttachChild(icon);
             GG::Pt icon_ul(x, GG::Y0);
             GG::Pt icon_lr = icon_ul + MeterIconSize();
             icon->SizeMove(icon_ul, icon_lr);
+
+            if (x + icon->MinUsableSize().x >= ClientWidth())
+                break;
+
+            AttachChild(icon);
             icon->Show();
 
             n++;

--- a/UI/MilitaryPanel.cpp
+++ b/UI/MilitaryPanel.cpp
@@ -172,6 +172,14 @@ void MilitaryPanel::Update() {
 }
 
 void MilitaryPanel::Refresh() {
+    for (auto& meter_stat : m_meter_stats)
+        meter_stat.second->RequirePreRender();
+
+    RequirePreRender();
+}
+
+void MilitaryPanel::PreRender() {
+    AccordionPanel::PreRender();
     Update();
     DoLayout();
 }

--- a/UI/MilitaryPanel.h
+++ b/UI/MilitaryPanel.h
@@ -25,6 +25,7 @@ public:
     //@}
 
     /** \name Mutators */ //@{
+    void PreRender() override;
     /** expands or collapses panel to show details or just summary info */
     void ExpandCollapse(bool expanded);
 

--- a/UI/PopulationPanel.cpp
+++ b/UI/PopulationPanel.cpp
@@ -210,16 +210,19 @@ void PopulationPanel::DoLayout() {
     if (!s_expanded_map[m_popcenter_id]) {
         // position and reattach icons to be shown
         int n = 0;
+        GG::X stride = MeterIconSize().x * 7/2;
         for (const std::pair<MeterType, StatisticIcon*>& meter_stat : m_meter_stats) {
-            GG::X x = MeterIconSize().x*n*7/2;
-
-            if (x > Width() - m_expand_button->Width() - MeterIconSize().x*5/2) break;  // ensure icon doesn't extend past right edge of panel
+            GG::X x = n * stride;
 
             StatisticIcon* icon = meter_stat.second;
-            AttachChild(icon);
             GG::Pt icon_ul(x, GG::Y0);
             GG::Pt icon_lr = icon_ul + MeterIconSize();
             icon->SizeMove(icon_ul, icon_lr);
+
+            if (x + icon->MinUsableSize().x >= ClientWidth())
+                break;
+
+            AttachChild(icon);
             icon->Show();
 
             n++;

--- a/UI/PopulationPanel.cpp
+++ b/UI/PopulationPanel.cpp
@@ -188,6 +188,14 @@ void PopulationPanel::Update() {
 }
 
 void PopulationPanel::Refresh() {
+    for (auto& meter_stat : m_meter_stats)
+        meter_stat.second->RequirePreRender();
+
+    RequirePreRender();
+}
+
+void PopulationPanel::PreRender() {
+    AccordionPanel::PreRender();
     Update();
     DoLayout();
 }

--- a/UI/PopulationPanel.cpp
+++ b/UI/PopulationPanel.cpp
@@ -41,15 +41,24 @@ PopulationPanel::PopulationPanel(GG::X w, int object_id) :
 
     GG::Connect(m_expand_button->LeftClickedSignal, &PopulationPanel::ExpandCollapseButtonPressed, this);
 
+    const auto obj = GetUniverseObject(m_popcenter_id);
+    if (!obj) {
+        ErrorLogger() << "Invalid object id " << m_popcenter_id;
+        return;
+    }
+
     // small meter indicators - for use when panel is collapsed
     m_meter_stats.push_back(
-        std::make_pair(METER_POPULATION, new StatisticIcon(ClientUI::SpeciesIcon(pop->SpeciesName()), 0, 3, false,
+        std::make_pair(METER_POPULATION, new StatisticIcon(ClientUI::SpeciesIcon(pop->SpeciesName()),
+                                                           obj->InitialMeterValue(METER_POPULATION), 3, false,
                                                            GG::X0, GG::Y0, MeterIconSize().x, MeterIconSize().y)));
     m_meter_stats.push_back(
-        std::make_pair(METER_HAPPINESS, new StatisticIcon(ClientUI::MeterIcon(METER_HAPPINESS), 0, 3, false,
+        std::make_pair(METER_HAPPINESS, new StatisticIcon(ClientUI::MeterIcon(METER_HAPPINESS),
+                                                          obj->InitialMeterValue(METER_HAPPINESS), 3, false,
                                                           GG::X0, GG::Y0, MeterIconSize().x, MeterIconSize().y)));
     m_meter_stats.push_back(
-        std::make_pair(METER_CONSTRUCTION, new StatisticIcon(ClientUI::MeterIcon(METER_CONSTRUCTION), 0, 3, false,
+        std::make_pair(METER_CONSTRUCTION, new StatisticIcon(ClientUI::MeterIcon(METER_CONSTRUCTION),
+                                                             obj->InitialMeterValue(METER_CONSTRUCTION), 3, false,
                                                              GG::X0, GG::Y0, MeterIconSize().x, MeterIconSize().y)));
 
     // meter and production indicators

--- a/UI/PopulationPanel.cpp
+++ b/UI/PopulationPanel.cpp
@@ -254,8 +254,6 @@ void PopulationPanel::DoLayout() {
         Resize(GG::Pt(Width(), m_multi_meter_status_bar->Bottom() + EDGE_PAD - top));
     }
 
-    m_expand_button->MoveTo(GG::Pt(Width() - m_expand_button->Width(), GG::Y0));
-
     SetCollapsed(!s_expanded_map[m_popcenter_id]);
 }
 

--- a/UI/PopulationPanel.h
+++ b/UI/PopulationPanel.h
@@ -25,6 +25,8 @@ public:
     //@}
 
     /** \name Mutators */ //@{
+    void PreRender() override;
+
     bool EventFilter(GG::Wnd* w, const GG::WndEvent& event) override;
 
     /** expands or collapses panel to show details or just summary info */

--- a/UI/ResourcePanel.cpp
+++ b/UI/ResourcePanel.cpp
@@ -105,7 +105,7 @@ void ResourcePanel::ExpandCollapse(bool expanded) {
     if (expanded == s_expanded_map[m_rescenter_id]) return; // nothing to do
     s_expanded_map[m_rescenter_id] = expanded;
 
-    DoLayout();
+    RequirePreRender();
 }
 
 bool ResourcePanel::EventFilter(GG::Wnd* w, const GG::WndEvent& event) {
@@ -204,6 +204,14 @@ void ResourcePanel::Update() {
 }
 
 void ResourcePanel::Refresh() {
+    for (auto& meter_stat : m_meter_stats)
+        meter_stat.second->RequirePreRender();
+
+    RequirePreRender();
+}
+
+void ResourcePanel::PreRender() {
+    AccordionPanel::PreRender();
     Update();
     DoLayout();
 }

--- a/UI/ResourcePanel.cpp
+++ b/UI/ResourcePanel.cpp
@@ -46,18 +46,28 @@ ResourcePanel::ResourcePanel(GG::X w, int object_id) :
 
     GG::Connect(m_expand_button->LeftClickedSignal, &ResourcePanel::ExpandCollapseButtonPressed, this);
 
+    const auto obj = GetUniverseObject(m_rescenter_id);
+    if (!obj) {
+        ErrorLogger() << "Invalid object id " << m_rescenter_id;
+        return;
+    }
+
     // small meter indicators - for use when panel is collapsed
     m_meter_stats.push_back(
-        std::make_pair(METER_INDUSTRY, new StatisticIcon(ClientUI::MeterIcon(METER_INDUSTRY), 0, 3, false,
+        std::make_pair(METER_INDUSTRY, new StatisticIcon(ClientUI::MeterIcon(METER_INDUSTRY),
+                                                         obj->InitialMeterValue(METER_INDUSTRY), 3, false,
                                                          GG::X0, GG::Y0, MeterIconSize().x, MeterIconSize().y)));
     m_meter_stats.push_back(
-        std::make_pair(METER_RESEARCH, new StatisticIcon(ClientUI::MeterIcon(METER_RESEARCH), 0, 3, false,
+        std::make_pair(METER_RESEARCH, new StatisticIcon(ClientUI::MeterIcon(METER_RESEARCH),
+                                                         obj->InitialMeterValue(METER_RESEARCH), 3, false,
                                                          GG::X0, GG::Y0, MeterIconSize().x, MeterIconSize().y)));
     m_meter_stats.push_back(
-        std::make_pair(METER_TRADE, new StatisticIcon(ClientUI::MeterIcon(METER_TRADE), 0, 3, false,
+        std::make_pair(METER_TRADE, new StatisticIcon(ClientUI::MeterIcon(METER_TRADE),
+                                                      obj->InitialMeterValue(METER_TRADE), 3, false,
                                                       GG::X0, GG::Y0, MeterIconSize().x, MeterIconSize().y)));
     m_meter_stats.push_back(
-        std::make_pair(METER_SUPPLY, new StatisticIcon(ClientUI::MeterIcon(METER_SUPPLY), 0, 3, false,
+        std::make_pair(METER_SUPPLY, new StatisticIcon(ClientUI::MeterIcon(METER_SUPPLY),
+                                                       obj->InitialMeterValue(METER_SUPPLY), 3, false,
                                                        GG::X0, GG::Y0, MeterIconSize().x, MeterIconSize().y)));
 
     // meter and production indicators

--- a/UI/ResourcePanel.cpp
+++ b/UI/ResourcePanel.cpp
@@ -226,16 +226,19 @@ void ResourcePanel::DoLayout() {
     if (!s_expanded_map[m_rescenter_id]) {
         // position and reattach icons to be shown
         int n = 0;
+        GG::X stride = MeterIconSize().x * 7/2;
         for (std::pair<MeterType, StatisticIcon*>& meter_stat : m_meter_stats) {
-            GG::X x = MeterIconSize().x*n*7/2;
-
-            if (x > Width() - m_expand_button->Width() - MeterIconSize().x*5/2) break;  // ensure icon doesn't extend past right edge of panel
+            GG::X x = n * stride;
 
             StatisticIcon* icon = meter_stat.second;
-            AttachChild(icon);
             GG::Pt icon_ul(x, GG::Y0);
             GG::Pt icon_lr = icon_ul + MeterIconSize();
             icon->SizeMove(icon_ul, icon_lr);
+
+            if (x + icon->MinUsableSize().x >= ClientWidth())
+                break;
+
+            AttachChild(icon);
             icon->Show();
 
             n++;

--- a/UI/ResourcePanel.cpp
+++ b/UI/ResourcePanel.cpp
@@ -270,8 +270,6 @@ void ResourcePanel::DoLayout() {
         Resize(GG::Pt(Width(), m_multi_meter_status_bar->Bottom() + EDGE_PAD - top));
     }
 
-    m_expand_button->MoveTo(GG::Pt(Width() - m_expand_button->Width(), GG::Y0));
-
     SetCollapsed(!s_expanded_map[m_rescenter_id]);
 }
 

--- a/UI/ResourcePanel.h
+++ b/UI/ResourcePanel.h
@@ -25,6 +25,8 @@ public:
     //@}
 
     /** \name Mutators */ //@{
+    void PreRender() override;
+
     bool EventFilter(GG::Wnd* w, const GG::WndEvent& event) override;
 
     /** expands or collapses panel to show details or just summary info */


### PR DESCRIPTION
This fixes issue #1177.

The underlying problem was that the `StatisticIcons` for the Military, Population and Resource panels were initialized with zeros instead of the correct value, and then immediately rendered.

This PR:
- uses the correct initial values for the panel icons.
- adds `StatisticIcon::MinUsableSize()` so that the icons can be clipped as tightly as possible
- adds `PreRender()` to the panels so that the icons are only layed out once.
- moves the rendering, positioning and layering of the `AccordionPanel` expand button into `AccordionPanel`