### PR TITLE
Switch reductions in tech costs to reductions in tech research time when conditions are met

### DIFF
--- a/default/scripting/techs/learning/PSIONICS.focs.txt
+++ b/default/scripting/techs/learning/PSIONICS.focs.txt
@@ -3,11 +3,11 @@ Tech
     description = "LRN_PSIONICS_DESC"
     short_description = "THEORY_SHORT_DESC"
     category = "LEARNING_CATEGORY"
-    researchcost = 300 * [[TECH_COST_MULTIPLIER]] - (250 * [[TECH_COST_MULTIPLIER]] * Statistic If condition = AND [
+    researchcost = 300 * [[TECH_COST_MULTIPLIER]]
+    researchturns = 8 - (4 * Statistic If condition = AND [
         OwnedBy empire = Source.Owner
         HasTag name = "TELEPATHIC"
     ])
-    researchturns = 4
     tags = [ "PEDIA_LEARNING_CATEGORY" "THEORY" ]
     prerequisites = "LRN_TRANSLING_THT"
     graphic = "icons/tech/psionics.png"

--- a/default/scripting/techs/spy/STEALTH_1.focs.txt
+++ b/default/scripting/techs/spy/STEALTH_1.focs.txt
@@ -3,8 +3,8 @@ Tech
     description = "SPY_STEALTH_1_DESC"
     short_description = "PLANET_PROTECT_SHORT_DESC"
     category = "SPY_CATEGORY"
-    researchcost = (100 - (50 * Statistic If Condition = OwnerHasTech Name = "SPY_STEALTH_PART_1" )) * [[TECH_COST_MULTIPLIER]]
-    researchturns = 5
+    researchcost = 100 * [[TECH_COST_MULTIPLIER]]
+    researchturns = 8 - (4 * Statistic If condition = OwnerHasTech Name = "SPY_STEALTH_PART_1")
     tags = [ "PEDIA_SPY_CATEGORY" ]
     prerequisites = "SPY_ROOT_DECEPTION"
     effectsgroups =

--- a/default/scripting/techs/spy/STEALTH_2.focs.txt
+++ b/default/scripting/techs/spy/STEALTH_2.focs.txt
@@ -3,8 +3,8 @@ Tech
     description = "SPY_STEALTH_2_DESC"
     short_description = "PLANET_PROTECT_SHORT_DESC"
     category = "SPY_CATEGORY"
-    researchcost = 200 * [[TECH_COST_MULTIPLIER]] - (100 * [[TECH_COST_MULTIPLIER]] * Statistic If Condition = OwnerHasTech Name = "SPY_STEALTH_PART_2" )
-    researchturns = 6
+    researchcost = 200 * [[TECH_COST_MULTIPLIER]]
+    researchturns = 7 - (3 * Statistic If condition = OwnerHasTech Name = "SPY_STEALTH_PART_2")
     tags = [ "PEDIA_SPY_CATEGORY" ]
     prerequisites = "SPY_STEALTH_1"
     effectsgroups =

--- a/default/scripting/techs/spy/STEALTH_3.focs.txt
+++ b/default/scripting/techs/spy/STEALTH_3.focs.txt
@@ -3,8 +3,8 @@ Tech
     description = "SPY_STEALTH_3_DESC"
     short_description = "PLANET_PROTECT_SHORT_DESC"
     category = "SPY_CATEGORY"
-    researchcost = 500 * [[TECH_COST_MULTIPLIER]] - (250 * [[TECH_COST_MULTIPLIER]] * Statistic If Condition = OwnerHasTech Name = "SPY_STEALTH_PART_3" )
-    researchturns = 7
+    researchcost = 500 * [[TECH_COST_MULTIPLIER]]
+    researchturns = 8 - (3 * Statistic If condition = OwnerHasTech Name = "SPY_STEALTH_PART_3")
     tags = [ "PEDIA_SPY_CATEGORY" ]
     prerequisites = "SPY_STEALTH_2"
     effectsgroups =


### PR DESCRIPTION
An experiment. I don't have a great motivational explanation, but it seems like reducing the minimum turns, instead of the cost of researching stuff, when conditions are met, makes sense. Letting the player focus on the "boosted" tech instead of spreading the RP over more techs seems more interesting.

Particular numbers are work in progress, documentation needs updating.

Also makes the scripts a bit simpler.