### PR TITLE
Persist tech tree m_status_buttons tech status.

### DIFF
--- a/UI/TechTreeWnd.cpp
+++ b/UI/TechTreeWnd.cpp
@@ -62,7 +62,7 @@ namespace {
         // Default status for TechTreeControl filter.
         db.Add<bool>("UI.research.tech-tree-control.status.unresearchable",
                      UserStringNop("OPTIONS_DB_UI_TECH_TREE_STATUS_UNRESEARCHABLE"),
-                     false,         Validator<bool>());
+                     false,        Validator<bool>());
         db.Add<bool>("UI.research.tech-tree-control.status.has_researched_prereq",
                      UserStringNop("OPTIONS_DB_UI_TECH_TREE_STATUS_HAS_RESEARCHED_PREREQ"),
                      true,         Validator<bool>());

--- a/UI/TechTreeWnd.cpp
+++ b/UI/TechTreeWnd.cpp
@@ -58,6 +58,20 @@ namespace {
                default_pts * 12,        StepValidator<int>(1));
         db.Add("UI.research.listbox.column-widths.description", UserStringNop("OPTIONS_DB_UI_TECH_LISTBOX_COL_WIDTH_DESCRIPTION"),
                default_pts * 18,        StepValidator<int>(1));
+
+        // Default status for TechTreeControl filter.
+        db.Add<bool>("UI.research.tech-tree-control.status.unresearchable",
+                     UserStringNop("OPTIONS_DB_UI_TECH_TREE_STATUS_UNRESEARCHABLE"),
+                     false,         Validator<bool>());
+        db.Add<bool>("UI.research.tech-tree-control.status.has_researched_prereq",
+                     UserStringNop("OPTIONS_DB_UI_TECH_TREE_STATUS_HAS_RESEARCHED_PREREQ"),
+                     true,         Validator<bool>());
+        db.Add<bool>("UI.research.tech-tree-control.status.researchable",
+                     UserStringNop("OPTIONS_DB_UI_TECH_TREE_STATUS_RESEARCHABLE"),
+                     true,         Validator<bool>());
+        db.Add<bool>("UI.research.tech-tree-control.status.completed",
+                     UserStringNop("OPTIONS_DB_UI_TECH_TREE_STATUS_COMPLETED"),
+                     true,         Validator<bool>());
     }
     bool temp_bool = RegisterOptions(&AddOptions);
 
@@ -282,28 +296,32 @@ TechTreeWnd::TechTreeControls::TechTreeControls(const std::string& config_name) 
                                                               std::make_shared<CUIIconButtonRepresenter>(std::make_shared<GG::SubTexture>(ClientUI::GetTexture(icon_dir / "01_locked.png", true)), icon_color));
     m_status_buttons[TS_UNRESEARCHABLE]->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(UserString("TECH_WND_STATUS_LOCKED"), ""));
     m_status_buttons[TS_UNRESEARCHABLE]->SetBrowseModeTime(tooltip_delay);
-    m_status_buttons[TS_UNRESEARCHABLE]->SetCheck(false);
+    m_status_buttons[TS_UNRESEARCHABLE]->SetCheck(
+        GetOptionsDB().Get<bool>("UI.research.tech-tree-control.status.unresearchable"));
     AttachChild(m_status_buttons[TS_UNRESEARCHABLE]);
 
     m_status_buttons[TS_HAS_RESEARCHED_PREREQ] = new GG::StateButton("", ClientUI::GetFont(), GG::FORMAT_NONE, GG::CLR_ZERO,
                                                                      std::make_shared<CUIIconButtonRepresenter>(std::make_shared<GG::SubTexture>(ClientUI::GetTexture(icon_dir / "02_partial.png", true)), icon_color));
     m_status_buttons[TS_HAS_RESEARCHED_PREREQ]->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(UserString("TECH_WND_STATUS_PARTIAL_UNLOCK"), ""));
     m_status_buttons[TS_HAS_RESEARCHED_PREREQ]->SetBrowseModeTime(tooltip_delay);
-    m_status_buttons[TS_HAS_RESEARCHED_PREREQ]->SetCheck(true);
+    m_status_buttons[TS_HAS_RESEARCHED_PREREQ]->SetCheck(
+        GetOptionsDB().Get<bool>("UI.research.tech-tree-control.status.has_researched_prereq"));
     AttachChild(m_status_buttons[TS_HAS_RESEARCHED_PREREQ]);
 
     m_status_buttons[TS_RESEARCHABLE] = new GG::StateButton("", ClientUI::GetFont(), GG::FORMAT_NONE, GG::CLR_ZERO,
                                                             std::make_shared<CUIIconButtonRepresenter>(std::make_shared<GG::SubTexture>(ClientUI::GetTexture(icon_dir / "03_unlocked.png", true)), icon_color));
     m_status_buttons[TS_RESEARCHABLE]->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(UserString("TECH_WND_STATUS_RESEARCHABLE"), ""));
     m_status_buttons[TS_RESEARCHABLE]->SetBrowseModeTime(tooltip_delay);
-    m_status_buttons[TS_RESEARCHABLE]->SetCheck(true);
+    m_status_buttons[TS_RESEARCHABLE]->SetCheck(
+        GetOptionsDB().Get<bool>("UI.research.tech-tree-control.status.researchable"));
     AttachChild(m_status_buttons[TS_RESEARCHABLE]);
 
     m_status_buttons[TS_COMPLETE] = new GG::StateButton("", ClientUI::GetFont(), GG::FORMAT_NONE, GG::CLR_ZERO,
                                                         std::make_shared<CUIIconButtonRepresenter>(std::make_shared<GG::SubTexture>(ClientUI::GetTexture(icon_dir / "04_completed.png", true)), icon_color));
     m_status_buttons[TS_COMPLETE]->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(UserString("TECH_WND_STATUS_COMPLETED"), ""));
     m_status_buttons[TS_COMPLETE]->SetBrowseModeTime(tooltip_delay);
-    m_status_buttons[TS_COMPLETE]->SetCheck(true);
+    m_status_buttons[TS_COMPLETE]->SetCheck(
+        GetOptionsDB().Get<bool>("UI.research.tech-tree-control.status.completed"));
     AttachChild(m_status_buttons[TS_COMPLETE]);
 
     // create button to switch between tree and list views
@@ -2033,10 +2051,10 @@ TechTreeWnd::TechTreeWnd(GG::X w, GG::Y h, bool initially_hidden /*= true*/) :
     //long time and generates errors, but is never seen by the user.
     if (!m_init_flag) {
         ShowAllCategories();
-        SetTechStatus(TS_RESEARCHABLE, true);
-        SetTechStatus(TS_HAS_RESEARCHED_PREREQ, true);
-        SetTechStatus(TS_COMPLETE, true);
-        // leave unresearchable hidden by default
+        SetTechStatus(TS_COMPLETE, GetOptionsDB().Get<bool>("UI.research.tech-tree-control.status.completed"));
+        SetTechStatus(TS_UNRESEARCHABLE, GetOptionsDB().Get<bool>("UI.research.tech-tree-control.status.unresearchable"));
+        SetTechStatus(TS_HAS_RESEARCHED_PREREQ, GetOptionsDB().Get<bool>("UI.research.tech-tree-control.status.has_researched_prereq"));
+        SetTechStatus(TS_RESEARCHABLE, GetOptionsDB().Get<bool>("UI.research.tech-tree-control.status.researchable"));
     }
 
     ShowTreeView();
@@ -2104,10 +2122,10 @@ void TechTreeWnd::Show(bool children) {
     if (m_init_flag) {
         m_init_flag = false;
         ShowAllCategories();
-        SetTechStatus(TS_RESEARCHABLE, true);
-        SetTechStatus(TS_HAS_RESEARCHED_PREREQ, true);
-        SetTechStatus(TS_COMPLETE, true);
-        // leave unresearchable hidden by default
+        SetTechStatus(TS_COMPLETE, GetOptionsDB().Get<bool>("UI.research.tech-tree-control.status.completed"));
+        SetTechStatus(TS_UNRESEARCHABLE, GetOptionsDB().Get<bool>("UI.research.tech-tree-control.status.unresearchable"));
+        SetTechStatus(TS_HAS_RESEARCHED_PREREQ, GetOptionsDB().Get<bool>("UI.research.tech-tree-control.status.has_researched_prereq"));
+        SetTechStatus(TS_RESEARCHABLE, GetOptionsDB().Get<bool>("UI.research.tech-tree-control.status.researchable"));
     }
 }
 
@@ -2158,6 +2176,24 @@ void TechTreeWnd::ToggleAllCategories() {
 }
 
 void TechTreeWnd::SetTechStatus(const TechStatus status, const bool state) {
+    switch (status) {
+    case TS_UNRESEARCHABLE:
+        GetOptionsDB().Set<bool>("UI.research.tech-tree-control.status.unresearchable", state);
+        break;
+    case TS_HAS_RESEARCHED_PREREQ:
+        GetOptionsDB().Set<bool>("UI.research.tech-tree-control.status.has_researched_prereq", state);
+        break;
+    case TS_RESEARCHABLE:
+        GetOptionsDB().Set<bool>("UI.research.tech-tree-control.status.researchable", state);
+        break;
+    case TS_COMPLETE:
+        GetOptionsDB().Set<bool>("UI.research.tech-tree-control.status.completed", state);
+        break;
+    default:
+        ; // do nothing
+    }
+    GetOptionsDB().Commit();
+
     if (state) {
         m_layout_panel->ShowStatus(status);
         m_tech_list->ShowStatus(status);

--- a/UI/TechTreeWnd.cpp
+++ b/UI/TechTreeWnd.cpp
@@ -2021,10 +2021,7 @@ TechTreeWnd::TechTreeWnd(GG::X w, GG::Y h, bool initially_hidden /*= true*/) :
     {
         TechStatus tech_status = status_button.first;
         GG::Connect(status_button.second->CheckedSignal, [this, tech_status](bool checked) {
-            if(checked)
-                this->ShowStatus(tech_status);
-            else
-                this->HideStatus(tech_status);
+            this->SetTechStatus(tech_status, checked);
         });
     }
 
@@ -2036,9 +2033,9 @@ TechTreeWnd::TechTreeWnd(GG::X w, GG::Y h, bool initially_hidden /*= true*/) :
     //long time and generates errors, but is never seen by the user.
     if (!m_init_flag) {
         ShowAllCategories();
-        ShowStatus(TS_RESEARCHABLE);
-        ShowStatus(TS_HAS_RESEARCHED_PREREQ);
-        ShowStatus(TS_COMPLETE);
+        SetTechStatus(TS_RESEARCHABLE, true);
+        SetTechStatus(TS_HAS_RESEARCHED_PREREQ, true);
+        SetTechStatus(TS_COMPLETE, true);
         // leave unresearchable hidden by default
     }
 
@@ -2107,9 +2104,9 @@ void TechTreeWnd::Show(bool children) {
     if (m_init_flag) {
         m_init_flag = false;
         ShowAllCategories();
-        ShowStatus(TS_RESEARCHABLE);
-        ShowStatus(TS_HAS_RESEARCHED_PREREQ);
-        ShowStatus(TS_COMPLETE);
+        SetTechStatus(TS_RESEARCHABLE, true);
+        SetTechStatus(TS_HAS_RESEARCHED_PREREQ, true);
+        SetTechStatus(TS_COMPLETE, true);
         // leave unresearchable hidden by default
     }
 }
@@ -2160,14 +2157,14 @@ void TechTreeWnd::ToggleAllCategories() {
         ShowAllCategories();
 }
 
-void TechTreeWnd::ShowStatus(TechStatus status) {
-    m_layout_panel->ShowStatus(status);
-    m_tech_list->ShowStatus(status);
-}
-
-void TechTreeWnd::HideStatus(TechStatus status) {
-    m_layout_panel->HideStatus(status);
-    m_tech_list->HideStatus(status);
+void TechTreeWnd::SetTechStatus(const TechStatus status, const bool state) {
+    if (state) {
+        m_layout_panel->ShowStatus(status);
+        m_tech_list->ShowStatus(status);
+    } else {
+        m_layout_panel->HideStatus(status);
+        m_tech_list->HideStatus(status);
+    }
 }
 
 void TechTreeWnd::ToggleViewType(bool show_list_view)
@@ -2197,7 +2194,7 @@ void TechTreeWnd::CenterOnTech(const std::string& tech_name) {
     if (!tech) return;
     const Empire* empire = GetEmpire(HumanClientApp::GetApp()->EmpireID());
     if (empire)
-        ShowStatus(empire->GetTechStatus(tech_name));
+        SetTechStatus(empire->GetTechStatus(tech_name), true);
     ShowCategory(tech->Category());
 
     // centre on it

--- a/UI/TechTreeWnd.h
+++ b/UI/TechTreeWnd.h
@@ -52,8 +52,7 @@ public:
     void            HideAllCategories();
     void            ToggleAllCategories();
 
-    void            ShowStatus(const TechStatus status);
-    void            HideStatus(const TechStatus status);
+    void            SetTechStatus(const TechStatus status, const bool state);
 
     void            ToggleViewType(bool show_list_view);
     void            ShowTreeView();

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1233,6 +1233,18 @@ Sets bar color of progress bars in the tech tree.
 OPTIONS_DB_UI_TECH_PROGRESS
 Sets background color of progress bars in the tech tree.
 
+OPTIONS_DB_UI_TECH_TREE_STATUS_UNRESEARCHABLE
+Stores the tech tree control filter unresearchable status.
+
+OPTIONS_DB_UI_TECH_TREE_STATUS_HAS_RESEARCHED_PREREQ
+Stores the tech tree control filter has researched prereq status.
+
+OPTIONS_DB_UI_TECH_TREE_STATUS_RESEARCHABLE
+Stores the tech tree control filter researchable status.
+
+OPTIONS_DB_UI_TECH_TREE_STATUS_COMPLETED
+Stores the tech tree control filter completed status.
+
 OPTIONS_DB_UI_SCROLL_WIDTH
 Sets UI scroll width.
 


### PR DESCRIPTION
This PR persists the TechTreeWnd's m_status_button TS_COMPLETE, TS_RESEARCHABLE, TS_UNRESEARCHABLE and TS_HAS_RESEARCHED_PREREQ states in OptionsDB.