### PR TITLE
Extend README

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,12 +5,6 @@ developers and one time contributors.  This guide should help you to create
 contributions that can be easily integrated into the FreeOrion project.
 
 
-## Respect the FreeOrion Vision Statement when contributing
-
-All contributions should follow the spirit of the [FreeOrion Vision Statement].
-We can't consider any contributions that miss or oppose the Vision Statement.
-
-
 ## I found an error in the game or I want to file a bug report
 
 So you stumbled on a reproducible error in FreeOrion?  You can report it in

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,6 +5,12 @@ developers and one time contributors.  This guide should help you to create
 contributions that can be easily integrated into the FreeOrion project.
 
 
+## Respect the FreeOrion Vision Statement when contributing
+
+All contributions should follow the spirit of the [FreeOrion Vision Statement].
+We can't consider any contributions that miss or oppose the Vision Statement.
+
+
 ## I found an error in the game or I want to file a bug report
 
 So you stumbled on a reproducible error in FreeOrion?  You can report it in
@@ -58,6 +64,7 @@ when working within the FreeOrion project.  Those are:
 * [Release Issue template] - Template for release checklist Issues.
 
 
+[FreeOrion Vision Statement]: README.md#FreeOrion
 [FreeOrion Git]: https://github.com/freeorion/freeorion.git
 [FreeOrion Issues]: https://github.com/freeorion/freeorion/issues
 [FreeOrion Forum]: http://www.freeorion.org/forum/

--- a/README.md
+++ b/README.md
@@ -75,19 +75,18 @@ details please see the [Contribution Guidelines](CONTRIBUTING.md).
 
 ## License
 
-Artistic or creative content is licensed under the *Creative Commons
-Attribution-Share Alike 3.0 Unported* license
-(http://creativecommons.org/licenses/by-sa/3.0/).
+The FreeOrion source code is licensed under the terms of [GPL v2],
+game assets are licensed under the terms of [CC-BY-SA-3.0].  For more details
+please see the [License File](default/COPYING).
 
-This includes artwork, music, sounds, text that determines how art, music or
-sound is played or displayed in game, game content such as technologies,
-buildings, specials and their associated in-game text, and the scripts that
-determine their in-game functionality.
+Additional to the immediate project sources the FreeOrion source tree bundles
+some third party projects or assets which may be licensed under different
+terms than the FreeOrion project.  For more details please consult the
+accompanying license file.
 
-Game content scripts are also licensed under the *GNU General Public License,
-Version 2* (http://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
-
-Everything else is licensed under the GNU General Public License, Version 2.
+  * *GiGi* library located within the `GG/` directory.
+  * *Roboto* font located within the `default/data/fonts/` directory.
+  * *DejaVuSans* located within the `default/data/fonts/` directory.
 
 
 [FreeOrion Homepage]: http://www.freeorion.org/
@@ -100,3 +99,5 @@ Everything else is licensed under the GNU General Public License, Version 2.
 [Ubuntu Package]: https://launchpad.net/ubuntu/+source/freeorion
 [Fedora Package]: https://admin.fedoraproject.org/pkgdb/package/rpms/freeorion/
 [ArchLinux Package]: https://aur.archlinux.org/packages/freeorion/
+[GPL v2]: https://www.gnu.org/licenses/gpl-2.0.txt
+[CC-BY-SA-3.0]: https://creativecommons.org/licenses/by-sa/3.0/legalcode

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ scripts* are licensed under the terms of both [GPL v2] and [CC-BY-SA-3.0].
 For more details please see the [License File](default/COPYING).
 
 Additional to the immediate project sources, the FreeOrion source tree bundles
-some third party projects or assets which may be licensed under different
+some third party projects or assets which may be also licensed under different
 terms than the FreeOrion project.  For more details please consult the
 accompanying license file.
 

--- a/README.md
+++ b/README.md
@@ -1,30 +1,97 @@
-## Synopsis
+# FreeOrion
 
-Source code repository of the FreeOrion project.
+FreeOrion is a free, Open Source, turn-based space empire and galactic conquest
+computer game being designed and built by the FreeOrion project.
 
-FreeOrion is a free, open source, turn-based space empire and galactic conquest (4X) computer game being designed and built by the FreeOrion project. FreeOrion is inspired by the tradition of the Master of Orion games, but is not a clone or remake of that series or any other game. 
+Freeorion builds on the classic *4X* model by incorporating the nation-building
+elements of games such as *Europa Universalis 2*.  While its modular,
+Open Source design allows for a significant degree of customization of the game
+engine and the story elements by the community, the FreeOrion project is
+dedicated to the construction of a living, breathing universe in a
+*grand campaign* model.
 
-## Vision Statement
 
-FreeOrion, an open-source game inspired by Master of Orion, is a turn-based game of epic space strategy that builds on the classic '4X' model by incorporating the nation-building elements of games such as Europa Universalis 2 and a versatile tactical combat engine. While its modular, open-source design allows for a significant degree of customization of the game engine and the story elements by the community, the FreeOrion team is dedicated to the construction of a living, breathing universe in a 'grand campaign' model.
+## Requirements
 
-## How to contribute
+FreeOrion requires an *OpenGL 2.1* capable graphic card and a display with a
+minimum resolution of at least *800x600*.
 
-For more details please see our [Contribution Guidelines](CONTRIBUTING.md).
+FreeOrion requires at least *Windows XP* with *Service Pack 2* or later,
+*Mac OSX 10.7* or later or any reasonable recent Linux distribution on x86
+compatible processors.  Other operating systems and architectures have reported
+to be working by users, but are not actively supported by the FreeOrion project.
+
+
+## Download
+
+[FreeOrion Stable Releases] are the recommend way to play FreeOrion.  Stable
+Releases can be obtained as native installer binaries for Windows and Mac OSX
+or as source releases for Linux and other UNIX-ish platforms from GitHub.
+
+Also some Linux distributions like Fedora, Debian and Arch do provide prebuilt
+packages of FreeOrion.
+
+[FreeOrion Weekly Releases] are in-development releases intended for enthusiasts
+and testers, who want to track or contribute to the development.  Weekly
+Releases can be obtained as native installer binaries for Windows and Mac OSX
+from Sourceforge.
+
+
+## Install
+
+For both Windows and Mac OSX execute the native installer binaries and follow
+the on-screen instructions of the installer to install FreeOrion.
+
+For Linux or other from-source installations in general please refer to the
+[Compile Instructions].
+
+Various Linux distributions provide the stable release of FreeOrion in
+a prebuilt way.  Usually you can install those packages by either using
+a graphical package manager and searching for *FreeOrion* or by installing the
+packages via the command line.
+
+  * [Debian package] stable release: `# apt-get install freeorion`
+  * [Ubuntu package] stable release: `# apt-get install freeorion`
+  * [Fedora package] stable release: `# dnf install freeorion`
+                                  or `# yum install freeorion`
+  * [ArchLinux package] stable release
+
+
+## Get Help/Contact
+
+Feel free to visit the [FreeOrion Homepage] or the [FreeOrion Forum].
+
+
+## Contribute
+
+The FreeOrion project encourages anybody to contribute to FreeOrion. For more
+details please see the [Contribution Guidelines](CONTRIBUTING.md).
 
 
 ## License
 
-Artistic or creative content is licensed under the Creative Commons Attribution-Share Alike 3.0 Unported license.
-(http://creativecommons.org/licenses/by-sa/3.0/)
+Artistic or creative content is licensed under the *Creative Commons
+Attribution-Share Alike 3.0 Unported* license
+(http://creativecommons.org/licenses/by-sa/3.0/).
 
-This includes artwork, music, sounds, text that determines how art, music or sound is played or displayed in game, game content such as technologies, buildings, specials and their associated in-game text, and the scripts that determine their in-game functionality.
+This includes artwork, music, sounds, text that determines how art, music or
+sound is played or displayed in game, game content such as technologies,
+buildings, specials and their associated in-game text, and the scripts that
+determine their in-game functionality.
 
-Game content scripts are also licensed under the GNU General Public License, Version 2
-(http://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
+Game content scripts are also licensed under the *GNU General Public License,
+Version 2* (http://www.gnu.org/licenses/old-licenses/gpl-2.0.html).
 
 Everything else is licensed under the GNU General Public License, Version 2.
 
-## Homepage
 
-http://freeorion.org
+[FreeOrion Homepage]: http://www.freeorion.org/
+[FreeOrion Forum]: http://www.freeorion.org/forum/
+[FreeOrion Stable Releases]: https://github.com/freeorion/freeorion/releases
+[FreeOrion Weekly Releases]: https://sourceforge.net/projects/freeorion/files/FreeOrion/Test/
+[FreeOrion Development]: https://github.com/freeorion/freeorion
+[Compile Instructions]: http://www.freeorion.org/index.php/Compile
+[Debian Package]: https://packages.debian.org/source/sid/freeorion
+[Ubuntu Package]: https://launchpad.net/ubuntu/+source/freeorion
+[Fedora Package]: https://admin.fedoraproject.org/pkgdb/package/rpms/freeorion/
+[ArchLinux Package]: https://aur.archlinux.org/packages/freeorion/

--- a/README.md
+++ b/README.md
@@ -53,7 +53,6 @@ packages via the command line.
   * [Debian package] stable release: `# apt-get install freeorion`
   * [Ubuntu package] stable release: `# apt-get install freeorion`
   * [Fedora package] stable release: `# dnf install freeorion`
-                                  or `# yum install freeorion`
   * [ArchLinux package] stable release
 
 

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ to be working by users, but are not actively supported by the FreeOrion project.
 Releases can be obtained as native installer binaries for Windows and Mac OSX
 or as source releases for Linux and other UNIX-ish platforms from GitHub.
 
-Also some Linux distributions like Fedora, Debian and Arch do provide prebuilt
-packages of FreeOrion.
+Also some Linux distributions like Fedora, Debian and Arch do provide packages
+of FreeOrion.
 
 [FreeOrion Weekly Releases] are in-development releases intended for enthusiasts
 and testers, who want to track or contribute to the development.  Weekly

--- a/README.md
+++ b/README.md
@@ -1,14 +1,17 @@
 # FreeOrion
 
 FreeOrion is a free, Open Source, turn-based space empire and galactic conquest
-computer game being designed and built by the FreeOrion project.
+computer game.
 
-Freeorion builds on the classic *4X* model by incorporating the nation-building
-elements of games such as *Europa Universalis 2*.  While its modular,
-Open Source design allows for a significant degree of customization of the game
-engine and the story elements by the community, the FreeOrion project is
-dedicated to the construction of a living, breathing universe in a
-*grand campaign* model.
+FreeOrion is inspired by the tradition of the Master of Orion games, but does
+not try to be a clone or remake of that series or any other game.  It builds
+on the classic *4X* model by incorporating the nation-building elements of games
+such as *Europa Universalis 2*.
+
+While its modular, Open Source design allows for a significant degree of
+customization of the game engine and the story elements by the community, the
+FreeOrion project is dedicated to the construction of a living, breathing
+universe in a *grand campaign* model.
 
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ computer game.
 
 FreeOrion is inspired by the tradition of the Master of Orion games, but does
 not try to be a clone or remake of that series or any other game.  It builds
-on the classic *4X* model by incorporating the nation-building elements of games
-such as *Europa Universalis 2*.
+on the classic *4X* (eXplore, eXpand, eXploit and eXterminate) model.
 
 While its modular, Open Source design allows for a significant degree of
 customization of the game engine and the story elements by the community, the
@@ -20,7 +19,7 @@ FreeOrion requires an *OpenGL 2.1* capable graphic card and a display with a
 minimum resolution of at least *800x600*.
 
 FreeOrion requires at least *Windows XP* with *Service Pack 2* or later,
-*Mac OSX 10.7* or later or any reasonable recent Linux distribution on x86
+*Mac OSX 10.7* or later or any reasonably recent Linux distribution on x86
 compatible processors.  Other operating systems and architectures have reported
 to be working by users, but are not actively supported by the FreeOrion project.
 
@@ -75,11 +74,12 @@ details please see the [Contribution Guidelines](CONTRIBUTING.md).
 
 ## License
 
-The FreeOrion source code is licensed under the terms of [GPL v2],
-game assets are licensed under the terms of [CC-BY-SA-3.0].  For more details
-please see the [License File](default/COPYING).
+The FreeOrion *source code* is licensed under the terms of [GPL v2],
+*game assets* are licensed under the terms of [CC-BY-SA-3.0] and *game content
+scripts* are licensed under the terms of both [GPL v2] and [CC-BY-SA-3.0].
+For more details please see the [License File](default/COPYING).
 
-Additional to the immediate project sources the FreeOrion source tree bundles
+Additional to the immediate project sources, the FreeOrion source tree bundles
 some third party projects or assets which may be licensed under different
 terms than the FreeOrion project.  For more details please consult the
 accompanying license file.

--- a/README.md
+++ b/README.md
@@ -42,8 +42,11 @@ from Sourceforge.
 
 ## Install
 
-For both Windows and Mac OSX execute the native installer binaries and follow
-the on-screen instructions of the installer to install FreeOrion.
+For Windows execute the native installer binary and follow the on-screen
+instructions of the installer to install FreeOrion.
+
+For Mac OSX, open the downloaded DMG file and copy the contained FreeOrion
+application to your system Applications folder by Drag and Drop.
 
 For Linux or other from-source installations in general please refer to the
 [Compile Instructions].

--- a/README.md
+++ b/README.md
@@ -7,10 +7,9 @@ FreeOrion is inspired by the tradition of the Master of Orion games, but does
 not try to be a clone or remake of that series or any other game.  It builds
 on the classic *4X* (eXplore, eXpand, eXploit and eXterminate) model.
 
-While its modular, Open Source design allows for a significant degree of
-customization of the game engine and the story elements by the community, the
-FreeOrion project is dedicated to the construction of a living, breathing
-universe in a *grand campaign* model.
+By adding scripting capabilities to the game engine the FreeOrion project aims
+to give the community an easy way to customize the game mechanics and
+presentation to create a living, breathing universe in a *grand campaign* model.
 
 
 ## Requirements


### PR DESCRIPTION
The current README lacks IMO some significant pointer for users and developers alike.  A README should be considered an entry point to a project which helps the user to answer the most common questions he will encounter like:

* Get a clue of what this project is all about.
* What does the project require to run properly?
* How to obtain the project?
* How to install/run the project?
* Where to get help / get in touch with the project?
* Where to give feedback or even contribute?
* How to contribute?
* What license the project is developed under?

The ordering is intentional, as I tried to view this from the clueless but interested user that searches for a new game to waste their time on.  Also I tried to keep the README as short as possible and shaved off some  IMO pointless (non or corner case) information you find on the FreeOrion wiki pages with a similar topic.  While the new proposed README is far away from being perfect I tried to to answer the questions above to the best of my knowledge.  Feedback is appreciated.