### PR TITLE
Fix FleetWnd doesn't update StatsIcon when ship with fighters is merged.

### DIFF
--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -1531,32 +1531,76 @@ void FleetDataPanel::SetStatIconValues() {
         min_fuel = *std::min_element(fuels.begin(), fuels.end());
     if (!speeds.empty())
         min_speed = *std::min_element(speeds.begin(), speeds.end());
+
     for (std::pair<MeterType, StatisticIcon*> entry : m_stat_icons) {
         MeterType stat_name = entry.first;
-        if (stat_name == METER_SPEED)
-            entry.second->SetValue(min_speed);
-        else if (stat_name == METER_FUEL)
-            entry.second->SetValue(min_fuel);
-        else if (stat_name == METER_SHIELD)
-            entry.second->SetValue(shield_tally/ship_count);
-        else if (stat_name == METER_STRUCTURE)
-            entry.second->SetValue(structure_tally);
-        else if (stat_name == METER_CAPACITY)
-            entry.second->SetValue(damage_tally);
-        else if (stat_name == METER_SECONDARY_STAT)
-            entry.second->SetValue(fighters_tally);
-        else if (stat_name == METER_POPULATION)
-            entry.second->SetValue(colony_tally);
-        else if (stat_name == METER_SIZE)
-            entry.second->SetValue(ship_count);
-        else if (stat_name == METER_TROOPS)
-            entry.second->SetValue(troops_tally);
-        else if (stat_name == METER_INDUSTRY)
-            entry.second->SetValue(fleet->ResourceOutput(RE_INDUSTRY));
-        else if (stat_name == METER_RESEARCH)
-            entry.second->SetValue(fleet->ResourceOutput(RE_RESEARCH));
-        else if (stat_name == METER_TRADE)
-            entry.second->SetValue(fleet->ResourceOutput(RE_TRADE));
+        const auto& icon = entry.second;
+        icon->Hide();
+        switch(stat_name) {
+        case METER_SIZE:
+            icon->SetValue(ship_count);
+            icon->Show();
+            break;
+        case METER_CAPACITY:
+            icon->SetValue(damage_tally);
+            if (fleet->HasArmedShips())
+                icon->Show();
+            break;
+        case METER_SECONDARY_STAT:
+            icon->SetValue(fighters_tally);
+            if (fleet->HasFighterShips())
+                icon->Show();
+            break;
+        case METER_TROOPS:
+            icon->SetValue(troops_tally);
+            if (fleet->HasTroopShips())
+                icon->Show();
+            break;
+        case METER_POPULATION:
+            icon->SetValue(colony_tally);
+            if (fleet->HasColonyShips())
+                icon->Show();
+            break;
+        case METER_INDUSTRY: {
+            const auto resource_output = fleet->ResourceOutput(RE_INDUSTRY);
+            icon->SetValue(resource_output);
+            if (resource_output > 0.0f)
+                icon->Show();
+        }
+            break;
+        case METER_RESEARCH: {
+            const auto resource_output = fleet->ResourceOutput(RE_RESEARCH);
+            icon->SetValue(resource_output);
+            if (resource_output > 0.0f)
+                icon->Show();
+        }
+            break;
+        case METER_TRADE: {
+            const auto resource_output = fleet->ResourceOutput(RE_TRADE);
+            icon->SetValue(resource_output);
+            if (resource_output > 0.0f)
+                icon->Show();
+        }
+            break;
+        case METER_STRUCTURE:
+            icon->SetValue(structure_tally);
+            icon->Show();
+            break;
+        case METER_SHIELD:
+            icon->SetValue(shield_tally/ship_count);
+            icon->Show();
+            break;
+        case METER_FUEL:
+            icon->SetValue(min_fuel);
+            icon->Show();
+            break;
+        case METER_SPEED:
+            icon->SetValue(min_speed);
+            icon->Show();
+            break;
+        default:
+            break;
+        }
     }
 }
 
@@ -1627,6 +1671,8 @@ void FleetDataPanel::DoLayout() {
     // position stat icons, centering them vertically if there's more space than required
     GG::Pt icon_ul = GG::Pt(name_ul.x, LabelHeight() + std::max(GG::Y0, (ClientHeight() - LabelHeight() - StatIconSize().y) / 2));
     for (std::pair<MeterType, StatisticIcon*>& entry : m_stat_icons) {
+        if (!entry.second->Visible())
+            continue;
         entry.second->SizeMove(icon_ul, icon_ul + StatIconSize());
         icon_ul.x += StatIconSize().x;
     }
@@ -1660,21 +1706,13 @@ void FleetDataPanel::Init() {
 
         std::vector<std::tuple<MeterType, std::shared_ptr<GG::Texture>, std::string>> meters_icons_browsetext;
         meters_icons_browsetext.emplace_back(METER_SIZE, FleetCountIcon(), "FW_FLEET_COUNT_SUMMARY");
-        if (fleet->HasArmedShips())
-            meters_icons_browsetext.emplace_back(METER_CAPACITY, DamageIcon(), "FW_FLEET_DAMAGE_SUMMARY");
-        if (fleet->HasFighterShips())
-            meters_icons_browsetext.emplace_back(METER_SECONDARY_STAT, FightersIcon(), "FW_FLEET_FIGHTER_SUMMARY");
-        if (fleet->HasTroopShips())
-            meters_icons_browsetext.emplace_back(METER_TROOPS, TroopIcon(), "FW_FLEET_TROOP_SUMMARY");
-        if (fleet->HasColonyShips())
-            meters_icons_browsetext.emplace_back(METER_POPULATION, ColonyIcon(), "FW_FLEET_COLONY_SUMMARY");
-        if (fleet->ResourceOutput(RE_INDUSTRY) > 0.0f)
-            meters_icons_browsetext.emplace_back(METER_INDUSTRY, IndustryIcon(), "FW_FLEET_INDUSTRY_SUMMARY");
-        if (fleet->ResourceOutput(RE_RESEARCH) > 0.0f)
-            meters_icons_browsetext.emplace_back(METER_RESEARCH, ResearchIcon(), "FW_FLEET_RESEARCH_SUMMARY");
-        if (fleet->ResourceOutput(RE_TRADE) > 0.0f)
-            meters_icons_browsetext.emplace_back(METER_TRADE, TradeIcon(), "FW_FLEET_TRADE_SUMMARY");
-
+        meters_icons_browsetext.emplace_back(METER_CAPACITY, DamageIcon(), "FW_FLEET_DAMAGE_SUMMARY");
+        meters_icons_browsetext.emplace_back(METER_SECONDARY_STAT, FightersIcon(), "FW_FLEET_FIGHTER_SUMMARY");
+        meters_icons_browsetext.emplace_back(METER_TROOPS, TroopIcon(), "FW_FLEET_TROOP_SUMMARY");
+        meters_icons_browsetext.emplace_back(METER_POPULATION, ColonyIcon(), "FW_FLEET_COLONY_SUMMARY");
+        meters_icons_browsetext.emplace_back(METER_INDUSTRY, IndustryIcon(), "FW_FLEET_INDUSTRY_SUMMARY");
+        meters_icons_browsetext.emplace_back(METER_RESEARCH, ResearchIcon(), "FW_FLEET_RESEARCH_SUMMARY");
+        meters_icons_browsetext.emplace_back(METER_TRADE, TradeIcon(), "FW_FLEET_TRADE_SUMMARY");
         meters_icons_browsetext.emplace_back(METER_STRUCTURE, ClientUI::MeterIcon(METER_STRUCTURE), "FW_FLEET_STRUCTURE_SUMMARY");
         meters_icons_browsetext.emplace_back(METER_SHIELD, ClientUI::MeterIcon(METER_SHIELD), "FW_FLEET_SHIELD_SUMMARY");
         meters_icons_browsetext.emplace_back(METER_FUEL, ClientUI::MeterIcon(METER_FUEL), "FW_FLEET_FUEL_SUMMARY");


### PR DESCRIPTION
The problem is that when the FleetDataPanel is initialized it determines
which StatisticIcons are included based on its fleet's current
capabilities.  When a ship is transferred in with new capabilities, like
fighters, it does not have a StatisticIcon to update with the new
values.

This commit unconditionally, includes all StatisticIcons possible for
fleets and then conditionally displays those with non null values.

This problem was reported in the [forum](http://freeorion.org/forum/viewtopic.php?f=28&t=10488&sid=3057b40a92976e087d01437ed58e885e)