### PR TITLE
Move delete fleet responsiblity from fleetwnd to FleetTransferOrder.

### DIFF
--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -1842,7 +1842,6 @@ public:
                     ErrorLogger() << "FleetsListBox::AcceptDrops  unable to get dropped fleet?";
                     continue;
                 }
-                int dropped_fleet_id = dropped_fleet->ID();
 
                 // get fleet's ships in a vector, as this is what FleetTransferOrder takes
                 const std::set<int>& ship_ids_set = dropped_fleet->ShipIDs();

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -388,20 +388,6 @@ namespace {
         // order ships moved into target fleet
         HumanClientApp::GetApp()->Orders().IssueOrder(
             OrderPtr(new FleetTransferOrder(client_empire_id, target_fleet->ID(), empire_system_ship_ids)));
-
-
-        // delete empty fleets from which ships have been taken
-        GetUniverse().InhibitUniverseObjectSignals(true);
-        for (int fleet_id : empire_system_fleet_ids) {
-            HumanClientApp::GetApp()->Orders().IssueOrder(OrderPtr(
-               new DeleteFleetOrder(client_empire_id, fleet_id)));
-        }
-        GetUniverse().InhibitUniverseObjectSignals(false);
-
-        // signal to update UI
-        system->FleetsRemovedSignal(empire_system_fleets);
-        system->StateChangedSignal();
-        target_fleet->StateChangedSignal();
     }
 
    /** Returns map from object ID to issued colonize orders affecting it. */
@@ -1865,11 +1851,6 @@ public:
                 // order the transfer
                 HumanClientApp::GetApp()->Orders().IssueOrder(
                     OrderPtr(new FleetTransferOrder(empire_id, target_fleet_id, ship_ids_vec)));
-
-                // delete empty fleets
-                if (dropped_fleet->Empty())
-                    HumanClientApp::GetApp()->Orders().IssueOrder(
-                        OrderPtr(new DeleteFleetOrder(empire_id, dropped_fleet_id)));
             }
 
         } else if (!dropped_ships.empty()) {
@@ -1895,15 +1876,6 @@ public:
             // order the transfer
             HumanClientApp::GetApp()->Orders().IssueOrder(
                 OrderPtr(new FleetTransferOrder(empire_id, target_fleet_id, ship_ids_vec)));
-
-            // delete empty fleets
-            for (int fleet_id : dropped_ships_fleets) {
-                std::shared_ptr<const Fleet> fleet = GetFleet(fleet_id);
-                if (fleet && fleet->Empty())
-                    HumanClientApp::GetApp()->Orders().IssueOrder(
-                        OrderPtr(new DeleteFleetOrder(empire_id, fleet->ID())));
-            }
-
         }
         //DebugLogger() << "FleetsListBox::AcceptDrops finished";
     }
@@ -2285,7 +2257,6 @@ public:
         if (!ship_from_dropped_wnd)
             return;
 
-        int dropped_ship_fleet_id = ship_from_dropped_wnd->FleetID();
         int empire_id = HumanClientApp::GetApp()->EmpireID();
 
         if (ClientPlayerIsModerator())
@@ -2293,13 +2264,6 @@ public:
 
         HumanClientApp::GetApp()->Orders().IssueOrder(
             OrderPtr(new FleetTransferOrder(empire_id, m_fleet_id, ship_ids)));
-
-        // delete old fleet if now empty
-        const ObjectMap& objects = GetUniverse().Objects();
-        if (std::shared_ptr<const Fleet> dropped_ship_old_fleet = objects.Object<Fleet>(dropped_ship_fleet_id))
-            if (dropped_ship_old_fleet->Empty())
-                HumanClientApp::GetApp()->Orders().IssueOrder(
-                    OrderPtr(new DeleteFleetOrder(empire_id, dropped_ship_fleet_id)));
     }
 
     void SizeMove(const GG::Pt& ul, const GG::Pt& lr) override {

--- a/util/Order.cpp
+++ b/util/Order.cpp
@@ -454,7 +454,12 @@ void FleetTransferOrder::ExecuteImpl() const {
     for (std::shared_ptr<Fleet> modified_fleet : modified_fleets) {
         if (!modified_fleet->Empty())
             modified_fleet->StateChangedSignal();
-        // if modified fleet is empty, it should be immently destroyed, so that updating it now is redundant
+        else {
+            if (std::shared_ptr<System> system = GetSystem(modified_fleet->SystemID()))
+                system->Remove(modified_fleet->ID());
+
+            GetUniverse().Destroy(modified_fleet->ID());
+        }
     }
 }
 

--- a/util/Order.h
+++ b/util/Order.h
@@ -281,6 +281,7 @@ private:
      *
      *  Postconditions:
      *     - all ships in m_add_ships will be moved from their initial fleet to the destination fleet
+     *     - any resulting empty fleets will be deleted
      */
     void ExecuteImpl() const override;
 


### PR DESCRIPTION
When a ship/fleet is transferred into a fleet, the current `FleetWnd` UI code is repsonsible for checking if the source fleet is now empty and deleting the fleet.  

This PR moves this responsibility from the UI code into the FleetTransferOrder code.  The Orders code is part of the the game logic maintaining correct game state.  The UI code is not.