### PR TITLE
Get rid of excess Production Update messages in log files

### DIFF
--- a/AI/AIInterface.cpp
+++ b/AI/AIInterface.cpp
@@ -220,8 +220,15 @@ namespace AIInterface {
     }
 
     void UpdateResourcePools() {
-        for (std::map<int, Empire*>::value_type& entry : AIClientApp::GetApp()->Empires())
-            entry.second->UpdateResourcePools();
+//        for (std::map<int, Empire*>::value_type& entry : AIClientApp::GetApp()->Empires())
+//            entry.second->UpdateResourcePools();
+        int empire_id = AIClientApp::GetApp()->EmpireID();
+        Empire* empire = ::GetEmpire(empire_id);
+        if (!empire) {
+            ErrorLogger() << "UpdateResourcePools : couldn't get empire with id " << empire_id;
+            return;
+        }
+        empire->UpdateResourcePools();
     }
 
     void UpdateResearchQueue() {


### PR DESCRIPTION
This should address issue [#521 Debug logs of Production update printed to all AI logs](https://github.com/freeorion/freeorion/issues/521) (the oldest "optional for 0.4.7" issue).

Short Version: The function UpdateResourcePools loops over all empires, even though it only needs to run on the one matching its empire_id. Changed the selection code to be the same as UpdateResearchQueue and UpdateProductionQueue. The only change in the game should be a bit fewer wasted CPU cycles and unneeded print statements in the AI and freeorion logs. (In my test game, the AI behavior was the same.)

Additional Info: The poster for #521 suspected that the same messages were being sent to all the AI logs. What was actually happening was the same inefficient code was being run on every player client (human and AI). It was looping over all empires, sending messages to its Logger for each one, and after a bit of boondoggling would exit without doing anything if the loop empire was not the same as the client empire_id. (Non-matching ids are the sources of the message "not enough PP to be worth simulating future turns production"). To the best of my knowledge, looping over all empires and calling empire->UpdateResourcePools for each one is unnecessary.