### PR TITLE
Strip whitespace from planet names

### DIFF
--- a/default/python/universe_generation/starsystems.py
+++ b/default/python/universe_generation/starsystems.py
@@ -58,6 +58,7 @@ def name_planets(system):
         name = fo.user_string("NEW_PLANET_NAME")
         name = name.replace("%1%", sys_name)
         name = name.replace("%2%", fo.planet_cardinal_suffix(planet))
+        name = name.strip()
         fo.set_name(planet, name)
 
 


### PR DESCRIPTION
Before this PR, there is a trailing whitespace if a planet has no cardinal suffix:
```
print planet
P_59<Russell Asteroids >
```
With this PR, the trailing whitespace is removed:
```
print planet
P_59<Russell Asteroids>
```