### PR TITLE
Fix client networking synchronous message hang

### DIFF
--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -131,13 +131,10 @@ void AIClientApp::Run() {
 
                 if (!Networking().IsRxConnected())
                     break;
-                if (Networking().MessageAvailable()) {
-                    Message msg;
-                    Networking().GetMessage(msg);
-                    HandleMessage(msg);
-                } else {
+                if (const auto msg = Networking().GetMessage())
+                    HandleMessage(*msg);
+                else
                     std::this_thread::sleep_for(std::chrono::milliseconds(10));
-                }
 
             } catch (boost::python::error_already_set) {
                 /* If the python interpreter is still running then keep

--- a/client/ClientApp.cpp
+++ b/client/ClientApp.cpp
@@ -141,21 +141,17 @@ std::string ClientApp::GetVisibleObjectName(std::shared_ptr<const UniverseObject
 }
 
 int ClientApp::GetNewObjectID() {
-    Message msg;
-    m_networking->SendSynchronousMessage(RequestNewObjectIDMessage(m_networking->PlayerID()), msg);
-    std::string text = msg.Text();
-    if (text.empty())
+    const auto msg = m_networking->SendSynchronousMessage(RequestNewObjectIDMessage(m_networking->PlayerID()));
+    if (!msg || msg->Text().empty())
         throw std::runtime_error("ClientApp::GetNewObjectID() didn't get a new object ID");
-    return boost::lexical_cast<int>(text);
+    return boost::lexical_cast<int>(msg->Text());
 }
 
 int ClientApp::GetNewDesignID() {
-    Message msg;
-    m_networking->SendSynchronousMessage(RequestNewDesignIDMessage(m_networking->PlayerID()), msg);
-    std::string text = msg.Text();
-    if (text.empty())
+    const auto msg = m_networking->SendSynchronousMessage(RequestNewDesignIDMessage(m_networking->PlayerID()));
+    if (!msg || msg->Text().empty())
         throw std::runtime_error("ClientApp::GetNewDesignID() didn't get a new design ID");
-    return boost::lexical_cast<int>(text);
+    return boost::lexical_cast<int>(msg->Text());
 }
 
 ClientApp* ClientApp::GetApp()

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -799,14 +799,12 @@ void HumanClientApp::HandleSystemEvents() {
     if (m_connected && !m_networking->IsConnected()) {
         m_connected = false;
         DisconnectedFromServer();
-    } else if (m_networking->MessageAvailable()) {
-        Message msg;
-        m_networking->GetMessage(msg);
+    } else if (auto msg = Networking().GetMessage()) {
         try {
-            HandleMessage(msg);
+            HandleMessage(*msg);
         } catch (const std::exception& e) {
             ErrorLogger() << "exception handing message: " << e.what();
-            ErrorLogger() << "message type: " << msg.Type() << " and text: " << msg.Text();
+            ErrorLogger() << "message type: " << msg->Type() << " and text: " << msg->Text();
         }
     }
 }

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -684,13 +684,12 @@ void HumanClientApp::RequestSavePreviews(const std::string& directory, PreviewIn
         }
     }
     DebugLogger() << "HumanClientApp::RequestSavePreviews Requesting previews for " << generic_directory;
-    Message response;
-    m_networking->SendSynchronousMessage(RequestSavePreviewsMessage(PlayerID(), generic_directory), response);
-    if (response.Type() == Message::DISPATCH_SAVE_PREVIEWS){
-        ExtractDispatchSavePreviewsMessageData(response, previews);
+    const auto response = m_networking->SendSynchronousMessage(RequestSavePreviewsMessage(PlayerID(), generic_directory));
+    if (response && response->Type() == Message::DISPATCH_SAVE_PREVIEWS){
+        ExtractDispatchSavePreviewsMessageData(*response, previews);
         DebugLogger() << "HumanClientApp::RequestSavePreviews Got " << previews.previews.size() << " previews.";
     }else{
-        ErrorLogger() << "HumanClientApp::RequestSavePreviews: Wrong response type from server: " << response.Type();
+        ErrorLogger() << "HumanClientApp::RequestSavePreviews: Wrong response type from server: " << response->Type();
     }
 }
 

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -685,10 +685,10 @@ void HumanClientApp::RequestSavePreviews(const std::string& directory, PreviewIn
     }
     DebugLogger() << "HumanClientApp::RequestSavePreviews Requesting previews for " << generic_directory;
     const auto response = m_networking->SendSynchronousMessage(RequestSavePreviewsMessage(PlayerID(), generic_directory));
-    if (response && response->Type() == Message::DISPATCH_SAVE_PREVIEWS){
+    if (response && response->Type() == Message::DISPATCH_SAVE_PREVIEWS) {
         ExtractDispatchSavePreviewsMessageData(*response, previews);
         DebugLogger() << "HumanClientApp::RequestSavePreviews Got " << previews.previews.size() << " previews.";
-    }else{
+    } else {
         ErrorLogger() << "HumanClientApp::RequestSavePreviews: Wrong response type from server: " << response->Type();
     }
 }

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -499,6 +499,7 @@ void ClientNetworking::Impl::NetworkingThread(const std::shared_ptr<const Client
     } catch (const boost::system::system_error& error) {
         HandleException(error);
     }
+    m_incoming_messages.StopGrowing();
     m_outgoing_messages.clear();
     m_io_service.reset();
     { // Mutex scope

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -449,7 +449,7 @@ void ClientNetworking::Impl::SendSynchronousMessage(const Message& message, Mess
                       << message;
     SendMessage(message);
     // note that this is a blocking operation
-    m_incoming_messages.EraseFirstSynchronousResponse(response_message);
+    m_incoming_messages.GetFirstSynchronousMessage(response_message);
     if (TRACE_EXECUTION)
         DebugLogger() << "ClientNetworking::SendSynchronousMessage : received "
                       << "response message " << response_message;

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -499,7 +499,6 @@ void ClientNetworking::Impl::NetworkingThread(const std::shared_ptr<const Client
     } catch (const boost::system::system_error& error) {
         HandleException(error);
     }
-    m_incoming_messages.Clear();
     m_outgoing_messages.clear();
     m_io_service.reset();
     { // Mutex scope

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -436,14 +436,10 @@ void ClientNetworking::Impl::SendMessage(const Message& message) {
 }
 
 boost::optional<Message> ClientNetworking::Impl::GetMessage() {
-    if (m_incoming_messages.Empty())
-        return boost::none;
-
-    Message message;
-    m_incoming_messages.PopFront(message);
-    if (TRACE_EXECUTION)
+    const auto message = m_incoming_messages.PopFront();
+    if (message && TRACE_EXECUTION)
         DebugLogger() << "ClientNetworking::GetMessage() : received message "
-                      << message;
+                      << *message;
     return message;
 }
 

--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -98,7 +98,7 @@ public:
 
     /** Sends \a message to the server, then blocks until it sees the first
         synchronous response from the server. */
-    void SendSynchronousMessage(const Message& message, Message& response_message);
+    boost::optional<Message> SendSynchronousMessage(const Message& message);
 
     /** Disconnects the client from the server. First tries to send any pending transmit messages. */
     void DisconnectFromServer();

--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -1,6 +1,8 @@
 #ifndef _ClientNetworking_h_
 #define _ClientNetworking_h_
 
+#include <boost/optional/optional_fwd.hpp>
+
 #include <string>
 #include <vector>
 #include <memory>
@@ -61,9 +63,6 @@ public:
     /** Returns true iff the client is connected to send to the server. */
     bool IsTxConnected() const;
 
-    /** Returns true iff there is at least one incoming message available. */
-    bool MessageAvailable() const;
-
     /** Returns the ID of the player on this client. */
     int PlayerID() const;
 
@@ -93,12 +92,9 @@ public:
         the message for sending and returns immediately. */
     void SendMessage(const Message& message);
 
-    /** Gets the next incoming message from the server, places it into \a
-        message, and removes it from the incoming message queue.  The function
-        assumes that there is at least one message in the incoming queue.
-        Users must call MessageAvailable() first to make sure this is the
-        case. */
-    void GetMessage(Message& message);
+    /** Return the next incoming message from the server if available or boost::none.
+        Remove the message from the incoming message queue. */
+    boost::optional<Message> GetMessage();
 
     /** Sends \a message to the server, then blocks until it sees the first
         synchronous response from the server. */

--- a/network/MessageQueue.cpp
+++ b/network/MessageQueue.cpp
@@ -12,7 +12,7 @@ namespace {
 }
 
 MessageQueue::MessageQueue(boost::mutex& monitor) :
-    m_monitor(monitor)
+    m_monitor(monitor), m_stopped_growing(false)
 {}
 
 bool MessageQueue::Empty() const {
@@ -46,6 +46,12 @@ boost::optional<Message> MessageQueue::PopFront() {
     swap(message, m_queue.front());
     m_queue.pop_front();
     return message;
+}
+
+void MessageQueue::StopGrowing() {
+    boost::mutex::scoped_lock lock(m_monitor);
+    m_stopped_growing = true;
+    m_have_synchronous_response.notify_one();
 }
 
 void MessageQueue::EraseFirstSynchronousResponse(Message& message) {

--- a/network/MessageQueue.cpp
+++ b/network/MessageQueue.cpp
@@ -2,6 +2,7 @@
 
 #include "Message.h"
 
+#include <boost/optional/optional.hpp>
 
 namespace {
     struct SynchronousResponseMessage {
@@ -37,10 +38,14 @@ void MessageQueue::PushBack(Message& message) {
         m_have_synchronous_response.notify_one();
 }
 
-void MessageQueue::PopFront(Message& message) {
+boost::optional<Message> MessageQueue::PopFront() {
     boost::mutex::scoped_lock lock(m_monitor);
+    if (m_queue.empty())
+        return boost::none;
+    Message message;
     swap(message, m_queue.front());
     m_queue.pop_front();
+    return message;
 }
 
 void MessageQueue::EraseFirstSynchronousResponse(Message& message) {

--- a/network/MessageQueue.cpp
+++ b/network/MessageQueue.cpp
@@ -54,7 +54,7 @@ void MessageQueue::StopGrowing() {
     m_have_synchronous_response.notify_one();
 }
 
-void MessageQueue::EraseFirstSynchronousResponse(Message& message) {
+void MessageQueue::GetFirstSynchronousMessage(Message& message) {
     boost::mutex::scoped_lock lock(m_monitor);
     std::list<Message>::iterator it = std::find_if(m_queue.begin(), m_queue.end(), SynchronousResponseMessage());
     while (it == m_queue.end()) {

--- a/network/MessageQueue.cpp
+++ b/network/MessageQueue.cpp
@@ -12,7 +12,8 @@ namespace {
 }
 
 MessageQueue::MessageQueue(boost::mutex& monitor, const bool& rx_connected) :
-    m_monitor{monitor}, m_rx_connected{rx_connected}
+    m_monitor{monitor},
+    m_rx_connected{rx_connected}
 {}
 
 bool MessageQueue::Empty() const {

--- a/network/MessageQueue.h
+++ b/network/MessageQueue.h
@@ -35,7 +35,7 @@ public:
 
     /** Returns the first synchronous repsonse message in the queue.  If no such message is found, this function blocks
         the calling thread until a synchronous response element is added. */
-    void EraseFirstSynchronousResponse(Message& message);
+    void GetFirstSynchronousMessage(Message& message);
     /** Indicates that no more new message will be added to the queue. This causes any pending
         GetFirstSynchronousMessage() to return boost::none.*/
     void StopGrowing();

--- a/network/MessageQueue.h
+++ b/network/MessageQueue.h
@@ -30,12 +30,13 @@ public:
     /** Adds \a message to the end of the queue. */
     void PushBack(Message& message);
 
-    /** Returns the front message in the queue. */
+    /** Return and remove the first message in the queue. */
     boost::optional<Message> PopFront();
 
-    /** Returns the first synchronous repsonse message in the queue.  If no such message is found, this function blocks
-        the calling thread until a synchronous response element is added. */
-    void GetFirstSynchronousMessage(Message& message);
+    /** Return and remove the first synchronous repsonse message from the queue or return
+        boost::none if there is no synchronous message and the queue has stopped growwing. */
+    boost::optional<Message> GetFirstSynchronousMessage();
+
     /** Indicates that no more new message will be added to the queue. This causes any pending
         GetFirstSynchronousMessage() to return boost::none.*/
     void StopGrowing();

--- a/network/MessageQueue.h
+++ b/network/MessageQueue.h
@@ -36,11 +36,15 @@ public:
     /** Returns the first synchronous repsonse message in the queue.  If no such message is found, this function blocks
         the calling thread until a synchronous response element is added. */
     void EraseFirstSynchronousResponse(Message& message);
+    /** Indicates that no more new message will be added to the queue. This causes any pending
+        GetFirstSynchronousMessage() to return boost::none.*/
+    void StopGrowing();
 
 private:
     std::list<Message> m_queue;
     boost::condition   m_have_synchronous_response;
     boost::mutex&      m_monitor;
+    bool               m_stopped_growing = false;
 };
 
 

--- a/network/MessageQueue.h
+++ b/network/MessageQueue.h
@@ -3,6 +3,7 @@
 
 #include <boost/thread/condition.hpp>
 #include <boost/thread/mutex.hpp>
+#include <boost/optional/optional_fwd.hpp>
 
 #include <list>
 
@@ -30,7 +31,7 @@ public:
     void PushBack(Message& message);
 
     /** Returns the front message in the queue. */
-    void PopFront(Message& message);
+    boost::optional<Message> PopFront();
 
     /** Returns the first synchronous repsonse message in the queue.  If no such message is found, this function blocks
         the calling thread until a synchronous response element is added. */

--- a/network/MessageQueue.h
+++ b/network/MessageQueue.h
@@ -16,7 +16,7 @@ class Message;
 class FO_COMMON_API MessageQueue
 {
 public:
-    MessageQueue(boost::mutex& monitor);
+    MessageQueue(boost::mutex& monitor, const bool& rx_connected);
 
     /** Returns true iff the queue is empty. */
     bool Empty() const;
@@ -33,19 +33,19 @@ public:
     /** Return and remove the first message in the queue. */
     boost::optional<Message> PopFront();
 
+    /** Indicates that no more new message will be added to the queue. This causes any pending
+        GetFirstSynchronousMessage() to return boost::none.*/
+    void RxDisconnected();
+
     /** Return and remove the first synchronous repsonse message from the queue or return
         boost::none if there is no synchronous message and the queue has stopped growwing. */
     boost::optional<Message> GetFirstSynchronousMessage();
-
-    /** Indicates that no more new message will be added to the queue. This causes any pending
-        GetFirstSynchronousMessage() to return boost::none.*/
-    void StopGrowing();
 
 private:
     std::list<Message> m_queue;
     boost::condition   m_have_synchronous_response;
     boost::mutex&      m_monitor;
-    bool               m_stopped_growing = false;
+    const bool&        m_rx_connected;
 };
 
 


### PR DESCRIPTION
This PR fixes a bug reported on the [forum](http://freeorion.org/forum/viewtopic.php?f=28&t=10497&sid=dfee4de00afbbb552882a49ac6e2d965).

The problem as reported by Scara on the forum is that repeatedly loading games can cause a `freeoriona` AI client to hang.

This was difficult to replicate.  I only replicated it twice, and only attached the debugger once.  I was unable to observe the hang after applying this PR.  However, if someone has a more reliable way to replicate this hang, it would be good to test the PR that way.

The underlying problem is that the AI process in unresponsive and blocks on network requests when processing time consuming requests, like `GAME_START` and `TURN_UPDATE`.  This PR does not fix that problem, because I couldn't imagine a simple fix suitable for days before a release.

The specific problem I observed is that in the `MessageQueue` in `ClientNetworking` it is possible for `EraseFirstSynchronousResponse()` to hang after the AI client has shutdown the networking thread.  

First, In a few places `MessageQueue` was checking a condition under one mutex lock and then in a different function, under a different mutex lock using that result.

`MessageQueue` provided `MessageAvailable()` which was used to guard `GetMessage(Message)`.  I removed `MessageAvailable()` and change the signature of `GetMessage` to  `optional<Message> GetMessage()`.  The queue state is now checked and changed under the same mutex.

Second, in the synchronous message reception, `MessageQueue` never checked that `ClientNeworking` was still connected and receiving. 

 Now `optional<Message> GetSynchronouMessage(sent_message)` checks after each failed receive attempt to see if the rx network has shutdown.
