### PR TITLE
Allow invasion through planet shields

### DIFF
--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -1431,7 +1431,9 @@ std::set<std::shared_ptr<const Ship>> AutomaticallyChosenInvasionShips(int targe
         if (!AvailableToInvade(ship, system_id, empire_id))
             continue;
 
-        invasion_troops += ship->TroopCapacity();
+        // how many troops are invading?
+        float effective_troops = ship->TroopCapacityAgainstShields(target_planet->CurrentMeterValue(METER_SHIELD));
+        invasion_troops += effective_troops;
 
         retval.insert(ship);
 
@@ -1632,7 +1634,7 @@ void SidePanel::PlanetPanel::Refresh() {
     bool habitable =        planet_env_for_colony_species >= PE_HOSTILE && planet_env_for_colony_species <= PE_GOOD;
     bool visible =          GetUniverse().GetObjectVisibilityByEmpire(m_planet_id, client_empire_id) >= VIS_PARTIAL_VISIBILITY;
     bool shielded =         planet->CurrentMeterValue(METER_SHIELD) > 0.0;
-    bool has_defenses =     planet->CurrentMeterValue(METER_MAX_SHIELD) > 0.0 || 
+    bool has_defenses =     planet->CurrentMeterValue(METER_MAX_SHIELD) > 0.0 ||
                                     planet->CurrentMeterValue(METER_MAX_DEFENSE) > 0.0 ||
                                     planet->CurrentMeterValue(METER_MAX_TROOPS) > 0.0;
     bool being_colonized =  planet->IsAboutToBeColonized();
@@ -1643,7 +1645,7 @@ void SidePanel::PlanetPanel::Refresh() {
     bool at_war_with_me =   !mine && (populated || (has_owner && Empires().GetDiplomaticStatus(client_empire_id, planet->Owner()) == DIPLO_WAR));
 
     bool being_invaded =    planet->IsAboutToBeInvaded();
-    bool invadable =        at_war_with_me && !shielded && visible && !being_invaded && !invasion_ships.empty();
+    bool invadable =        at_war_with_me && /*!shielded && visible && */ !being_invaded && !invasion_ships.empty();
 
     bool being_bombarded =  planet->IsAboutToBeBombarded();
     bool bombardable =      at_war_with_me && visible && !being_bombarded && !bombard_ships.empty();
@@ -1767,7 +1769,9 @@ void SidePanel::PlanetPanel::Refresh() {
         AttachChild(m_invade_button);
         float invasion_troops = 0.0f;
         for (std::shared_ptr<const Ship> invasion_ship : invasion_ships) {
-            invasion_troops += invasion_ship->TroopCapacity();
+            // how many troops are invading?
+            float effective_troops = invasion_ship->TroopCapacityAgainstShields(planet->CurrentMeterValue(METER_SHIELD));
+            invasion_troops += effective_troops;
         }
         std::string invasion_troops_text = DoubleToString(invasion_troops, 3, false);
 
@@ -2323,7 +2327,7 @@ void SidePanel::PlanetPanel::ClickInvade() {
     std::shared_ptr<const Planet> planet = GetPlanet(m_planet_id);
     if (!planet ||
         !m_order_issuing_enabled ||
-        (planet->CurrentMeterValue(METER_POPULATION) <= 0.0 && planet->Unowned()))
+        (planet->CurrentMeterValue(METER_POPULATION) <= 0.0 && planet->Unowned()))  // can't invade planets that have both no population and no owner, as these are unowned empty planets. with an owner but no population is an outpost, with population but no owner is a native-populated planet.
     { return; }
 
     int empire_id = HumanClientApp::GetApp()->EmpireID();

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -2309,7 +2309,8 @@ namespace {
                 continue;
 
             // how many troops are invading?
-            planet_empire_troops[invade_planet_id][ship->Owner()] += ship->TroopCapacity();
+            float effective_troops = ship->TroopCapacityAgainstShields(planet->CurrentMeterValue(METER_SHIELD));
+            planet_empire_troops[invade_planet_id][ship->Owner()] += effective_troops;
 
             std::shared_ptr<System> system = GetSystem(ship->SystemID());
 
@@ -2326,8 +2327,10 @@ namespace {
             if (system)
                 system->Remove(ship->ID());
 
-            DebugLogger() << "HandleInvasion has accounted for "<< ship->TroopCapacity()
+            DebugLogger() << "HandleInvasion has accounted for " << ship->TroopCapacity()
                           << " troops to invade " << planet->Name()
+                          << " which has shieids " << planet->CurrentMeterValue(METER_SHIELD)
+                          << " giving effective invading troops " << effective_troops
                           << " and is destroying ship " << ship->ID()
                           << " named " << ship->Name();
 

--- a/universe/Ship.cpp
+++ b/universe/Ship.cpp
@@ -335,6 +335,9 @@ float Ship::TroopCapacity() const {
     return retval;
 }
 
+float Ship::TroopCapacityAgainstShields(float against_shields) const
+{ return TroopCapacity() / (1.0f + std::log(std::max(1.0f, against_shields + 1.0f))); }
+
 bool Ship::CanHaveTroops() const {
     const ShipDesign* design = Design();
     return design ? design->HasTroops() : false;

--- a/universe/Ship.h
+++ b/universe/Ship.h
@@ -68,6 +68,7 @@ public:
     float                       Speed() const;
     float                       ColonyCapacity() const;
     float                       TroopCapacity() const;
+    float                       TroopCapacityAgainstShields(float against_shields) const;
 
     bool                        OrderedScrapped() const         { return m_ordered_scrapped; }          ///< returns true iff this ship has been ordered scrapped, or false otherwise
     int                         OrderedColonizePlanet() const   { return m_ordered_colonize_planet_id; }///< returns the ID of the planet this ship has been ordered to colonize, or INVALID_OBJECT_ID if this ship hasn't been ordered to colonize a planet

--- a/util/Order.cpp
+++ b/util/Order.cpp
@@ -613,10 +613,10 @@ void InvadeOrder::ExecuteImpl() const {
         ErrorLogger() << "InvadeOrder::ExecuteImpl given unpopulated planet";
         return;
     }
-    if (planet->CurrentMeterValue(METER_SHIELD) > 0.0) {
+    /*if (planet->CurrentMeterValue(METER_SHIELD) > 0.0) {
         ErrorLogger() << "InvadeOrder::ExecuteImpl given planet with shield > 0";
         return;
-    }
+    }*/
     if (planet->OwnedBy(empire_id)) {
         ErrorLogger() << "InvadeOrder::ExecuteImpl given planet that is already owned by the order-issuing empire";
         return;


### PR DESCRIPTION
Allows invasion of planets that have shields, but with reduce effective troop numbers as the level of shielding increases. Could possibly be used as a feature or ability of a species, government policy, or type of troop pod.