### PR TITLE
Temp balance pass for Solar and other large hulls

### DIFF
--- a/default/scripting/ship_hulls/asteroid/SH_SCATTERED_ASTEROID.focs.txt
+++ b/default/scripting/ship_hulls/asteroid/SH_SCATTERED_ASTEROID.focs.txt
@@ -27,7 +27,7 @@ Hull
         Slot type = Internal position = (0.70, 0.50)
         Slot type = Core     position = (0.45, 0.50)
     ]
-    buildCost = 120.0 * [[FLEET_UPKEEP_MULTIPLICATOR]]
+    buildCost = 160.0 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildTime = 8
     tags = [ "ASTEROID_HULL" "PEDIA_HULL_LINE_ASTEROIDS" ]
     location = And [

--- a/default/scripting/ship_hulls/energy/SH_SOLAR.focs.txt
+++ b/default/scripting/ship_hulls/energy/SH_SOLAR.focs.txt
@@ -4,7 +4,7 @@ Hull
     speed = 120
     fuel = 5
     stealth = -55
-    structure = 200
+    structure = 100
     slots = [
         Slot type = External position = (0.10, 0.15)
         Slot type = External position = (0.20, 0.15)
@@ -14,7 +14,7 @@ Hull
         Slot type = External position = (0.60, 0.15)
         Slot type = External position = (0.70, 0.15)
         Slot type = External position = (0.80, 0.15)
-        Slot type = External position = (0.90, 0.15)
+        //Slot type = External position = (0.90, 0.15)
         Slot type = External position = (0.10, 0.85)
         Slot type = External position = (0.20, 0.85)
         Slot type = External position = (0.30, 0.85)
@@ -23,19 +23,19 @@ Hull
         Slot type = External position = (0.60, 0.85)
         Slot type = External position = (0.70, 0.85)
         Slot type = External position = (0.80, 0.85)
-        Slot type = External position = (0.90, 0.85)
+        //Slot type = External position = (0.90, 0.85)
         Slot type = Internal position = (0.20, 0.40)
         Slot type = Internal position = (0.20, 0.60)
         Slot type = Internal position = (0.35, 0.40)
         Slot type = Internal position = (0.35, 0.60)
-        Slot type = Internal position = (0.65, 0.40)
-        Slot type = Internal position = (0.65, 0.60)
-        Slot type = Internal position = (0.80, 0.40)
-        Slot type = Internal position = (0.80, 0.60)
+        //Slot type = Internal position = (0.65, 0.40)
+        //Slot type = Internal position = (0.65, 0.60)
+        //Slot type = Internal position = (0.80, 0.40)
+        //Slot type = Internal position = (0.80, 0.60)
         Slot type = Core     position = (0.50, 0.50)
     ]
-    buildCost = 120.0 * [[FLEET_UPKEEP_MULTIPLICATOR]]
-    buildTime = 10
+    buildCost = 250.0 * [[FLEET_UPKEEP_MULTIPLICATOR]]
+    buildTime =8
     tags = [ "ENERGY_HULL" "PEDIA_HULL_LINE_ENERGY" ]
     location = And [
         Contains And [

--- a/default/scripting/ship_hulls/robotic/SH_TITANIC.focs.txt
+++ b/default/scripting/ship_hulls/robotic/SH_TITANIC.focs.txt
@@ -27,7 +27,7 @@ Hull
         Slot type = Internal position = (0.70, 0.50)
         Slot type = Core     position = (0.45, 0.50)
     ]
-    buildCost = 160 * [[FLEET_UPKEEP_MULTIPLICATOR]]
+    buildCost = 180 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildTime = 5
     tags = [ "ROBOTIC_HULL" "PEDIA_HULL_LINE_ROBOTIC" ]
     location = And [

--- a/default/scripting/techs/ships/energy/SHP_ENRG_BOUND_MAN.focs.txt
+++ b/default/scripting/techs/ships/energy/SHP_ENRG_BOUND_MAN.focs.txt
@@ -10,7 +10,10 @@ Tech
         "LRN_GRAVITONICS"
         "SHP_ENRG_FRIGATE"
     ]
-    unlock = Item type = ShipHull name = "SH_FRACTAL_ENERGY"
+    unlock = [
+        Item type = ShipHull name = "SH_FRACTAL_ENERGY"
+        Item type = Building name = "BLD_SHIPYARD_ENRG_SOLAR"
+    ]
     graphic = "icons/ship_hulls/fractal_energy_hull_small.png"
 
 #include "/scripting/common/base_prod.macros"

--- a/default/scripting/techs/ships/energy/SHP_QUANT_ENRG_MAG.focs.txt
+++ b/default/scripting/techs/ships/energy/SHP_QUANT_ENRG_MAG.focs.txt
@@ -10,7 +10,10 @@ Tech
         "LRN_GRAVITONICS"
         "SHP_ENRG_FRIGATE"
     ]
-    unlock = Item type = ShipHull name = "SH_QUANTUM_ENERGY"
+    unlock = [
+        Item type = ShipHull name = "SH_QUANTUM_ENERGY"
+        Item type = Building name = "BLD_SHIPYARD_ENRG_SOLAR"
+    ]
     graphic = "icons/ship_hulls/quantum_energy_hull_small.png"
 
 #include "/scripting/common/base_prod.macros"

--- a/default/scripting/techs/ships/energy/SHP_SOLAR_CONT.focs.txt
+++ b/default/scripting/techs/ships/energy/SHP_SOLAR_CONT.focs.txt
@@ -13,7 +13,7 @@ Tech
     ]
     unlock = [
         Item type = ShipHull name = "SH_SOLAR"
-        Item type = Building name = "BLD_SHIPYARD_ENRG_SOLAR"
+        //Item type = Building name = "BLD_SHIPYARD_ENRG_SOLAR"
     ]
     graphic = "icons/ship_hulls/solar_hull_small.png"
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -12658,9 +12658,9 @@ SH_SOLAR
 Solar Hull
 
 SH_SOLAR_DESC
-'''This mighty flagship is essentially a miniature sun, and as such is a great source of both [[metertype METER_FUEL]] and visibility. All accompanying friendly ships completely recover fuel between combat, and all enemy ships in the vicinity receive a penalty to [[metertype METER_STEALTH]]. This hull has eighteen external slots, eight internal slots and a core slot—a far greater internal capacity than any other hull.
+'''This mighty flagship is essentially a miniature sun, and as such is a great source of both [[metertype METER_FUEL]] and visibility. All accompanying friendly ships completely recover fuel between combat, and all enemy ships in the vicinity receive a penalty to [[metertype METER_STEALTH]]. This hull has 16 external slots, 4 internal slots and a core slot—a greater internal capacity than any other hull.
 
-[[metertype METER_STRUCTURE]] is extremely high, [[metertype METER_STEALTH]] is very low, [[metertype METER_DETECTION]] is medium and [[metertype METER_SPEED]] is very high. However, this ship has the ability to enter a star and hide, giving it perfect [[metertype METER_STEALTH]] on the galaxy map when it is in a system with a star of type other than [[STAR_BLACK]] or [[STAR_NEUTRON]], and in combat, when it is hiding inside such a star.
+[[metertype METER_STRUCTURE]] is high, [[metertype METER_STEALTH]] is very low, [[metertype METER_DETECTION]] is medium and [[metertype METER_SPEED]] is very high. However, this ship has the ability to enter a star and hide, giving it perfect [[metertype METER_STEALTH]] on the galaxy map when it is in a system with a star of type other than [[STAR_BLACK]] or [[STAR_NEUTRON]], and in combat, when it is hiding inside such a star.
 
 This ship requires a tremendous amount of energy to construct and must harness energy from particle-antiparticle collisions on the event horizon of a [[STAR_BLACK]] in its formation. It can only be built at a location with a [[buildingtype BLD_SHIPYARD_BASE]], an [[buildingtype BLD_SHIPYARD_ENRG_COMP]] and a [[buildingtype BLD_SHIPYARD_ENRG_SOLAR]].'''
 


### PR DESCRIPTION
A fix for #1400 for 0.4.7 release, increases costs for several larger hulls and removes several slots from the Solar.

The costs are probably about right, the Solar Hull changes aren't but will do for now: the big problem isn't the hull itself, but the insane speed is the big problem and that means reworking the engine parts to be better, more expensive but non-stacking.

The Solar Hull should have huge numbers of slots, but being able to get a base speed of 300 is a problem.