### PR TITLE
correct help message for auto-add-saved-designs option so that it matches actual behavior

### DIFF
--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1348,7 +1348,7 @@ OPTIONS_DB_UI_AUTO_REPOSITION_WINDOWS
 Toggles whether to automatically reposition windows when the application size changes.
 
 OPTIONS_DB_AUTO_ADD_SAVED_DESIGNS
-At game start automatically add all user-saved ship designs to the player-empire known designs.
+Automatically add all user-saved ship designs to the player-empire known designs, if and only if the ShipDesign screen is visited on turn 1.
 
 OPTIONS_DB_DESIGN_PEDIA_DYNAMIC
 In the Design Window, dynamically update the pedia detail page while the design name is being edited.


### PR DESCRIPTION
As was pointed out below, I had gotten a bit mixed up about the option behavior; I have changed this PR to simply be for harmonizing the option help message with the actual behavior.

Previous (now stale) description:
It has long vexed me that this option did not actually accomplish its function (so instead, saved designs were required to be manually loaded each game), and I finally saw where to move things so that it does work.  

In the new location the attempted loading of saved designs can be triggered additional times during the first turn if new designs are added during that turn, but I think there is no harm from this-- it takes only a tiny fraction of a second and the SavedDesignsManager realizes that each one is already present and that nothing more need be done.

I am hoping this could make it into 0.4.7