### PR TITLE
Add named loggers with individually controlled log levels.

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -1335,13 +1335,11 @@ namespace {
         }
 
         TraceLogger() << "Alignments:";
-        for (const Alignment& p : m_alignments) {
+        for (const auto& p : m_alignments)
             TraceLogger() << " ... " << p.Name();
-        }
         TraceLogger() << "Alignment Effects:";
-        for (std::shared_ptr<Effect::EffectsGroup> p : m_effects_groups) {
+        for (const auto& p : m_effects_groups)
             TraceLogger() << " ... " /*<< p.Dump()*/;
-        }
     }
 
     /** returns the singleton alignment manager */

--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -2687,7 +2687,7 @@ void Empire::AddShipDesign(int ship_design_id, int next_design_id) {
 
             ShipDesignsChangedSignal();
 
-            TraceLogger() << "AddShipDesign::  " << ship_design->Name() << " ("<<ship_design_id
+            TraceLogger() << "AddShipDesign::  " << ship_design->Name() << " (" << ship_design_id
                           << ") to empire #" << EmpireID()
                           << (is_at_end_of_list ? " at end of list." : " in front of id ")
                           << next_design_id;

--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -1334,15 +1334,13 @@ namespace {
             throw e;
         }
 
-        if (GetOptionsDB().Get<bool>("verbose-logging")) {
-            DebugLogger() << "Alignments:";
-            for (const Alignment& p : m_alignments) {
-                DebugLogger() << " ... " << p.Name();
-            }
-            DebugLogger() << "Alignment Effects:";
-            for (std::shared_ptr<Effect::EffectsGroup> p : m_effects_groups) {
-                DebugLogger() << " ... " /*<< p.Dump()*/;
-            }
+        TraceLogger() << "Alignments:";
+        for (const Alignment& p : m_alignments) {
+            TraceLogger() << " ... " << p.Name();
+        }
+        TraceLogger() << "Alignment Effects:";
+        for (std::shared_ptr<Effect::EffectsGroup> p : m_effects_groups) {
+            TraceLogger() << " ... " /*<< p.Dump()*/;
         }
     }
 
@@ -2691,11 +2689,10 @@ void Empire::AddShipDesign(int ship_design_id, int next_design_id) {
 
             ShipDesignsChangedSignal();
 
-            if (GetOptionsDB().Get<bool>("verbose-logging"))
-                DebugLogger() << "AddShipDesign::  " << ship_design->Name() << " ("<<ship_design_id
-                              << ") to empire #" << EmpireID()
-                              << (is_at_end_of_list ? " at end of list." : " in front of id ")
-                              << next_design_id;
+            TraceLogger() << "AddShipDesign::  " << ship_design->Name() << " ("<<ship_design_id
+                          << ") to empire #" << EmpireID()
+                          << (is_at_end_of_list ? " at end of list." : " in front of id ")
+                          << next_design_id;
         }
     } else {
         // design in not valid

--- a/UI/CombatReport/CombatLogWnd.cpp
+++ b/UI/CombatReport/CombatLogWnd.cpp
@@ -19,6 +19,10 @@
 #include "../AccordionPanel.h"
 #include "../../Empire/Empire.h"
 
+namespace {
+    CreateThreadedLogger(combat_log);
+}
+
 class CombatLogWnd::Impl {
 public:
     Impl(CombatLogWnd& _log);
@@ -385,9 +389,6 @@ void CombatLogWnd::Impl::SetLog(int log_id) {
         return;
     }
 
-    bool verbose_logging = GetOptionsDB().Get<bool>("verbose-logging") ||
-                           GetOptionsDB().Get<bool>("verbose-combat-logging");
-
     m_wnd.DeleteChildren();
     GG::Layout* layout = new GG::DeferredLayout(m_wnd.RelativeUpperLeft().x, m_wnd.RelativeUpperLeft().y,
                                                 m_wnd.Width(), m_wnd.Height(),
@@ -399,8 +400,7 @@ void CombatLogWnd::Impl::SetLog(int log_id) {
     int client_empire_id = HumanClientApp::GetApp()->EmpireID();
 
     // Write Header text
-    if (verbose_logging)
-        DebugLogger() << "Showing combat log #" << log_id << " with " << log->combat_events.size() << " events";
+    DebugLogger(combat_log) << "Showing combat log #" << log_id << " with " << log->combat_events.size() << " events";
 
     std::shared_ptr<const System> system = GetSystem(log->system_id);
     const std::string& sys_name = (system ? system->PublicName(client_empire_id) : UserString("ERROR"));
@@ -419,8 +419,7 @@ void CombatLogWnd::Impl::SetLog(int log_id) {
 
     // Write Logs
     for (CombatEventPtr event : log->combat_events) {
-        if (verbose_logging)
-            DebugLogger() << "event debug info: " << event->DebugString();
+        DebugLogger(combat_log) << "event debug info: " << event->DebugString();
 
         for (GG::Wnd* wnd : MakeCombatLogPanel(m_font->SpaceWidth()*10, client_empire_id, event)) {
             AddRow(wnd);

--- a/UI/CombatReport/CombatLogWnd.cpp
+++ b/UI/CombatReport/CombatLogWnd.cpp
@@ -20,7 +20,7 @@
 #include "../../Empire/Empire.h"
 
 namespace {
-    CreateThreadedLogger(combat_log);
+    DeclareThreadSafeLogger(combat_log);
 }
 
 class CombatLogWnd::Impl {

--- a/UI/Hotkeys.cpp
+++ b/UI/Hotkeys.cpp
@@ -222,10 +222,8 @@ void Hotkey::ReadFromOptions(OptionsDB& db) {
         hotkey.m_key = key_modkey_pair.first;
         hotkey.m_mod_keys = key_modkey_pair.second;
 
-        if (GetOptionsDB().Get<bool>("verbose-logging")) {
-          DebugLogger() << "Added hotkey '" << hotkey.m_key << "' with modifiers '"
-                        << hotkey.m_mod_keys << "' for hotkey '" << hotkey.m_name << "'";
-        }
+        TraceLogger() << "Added hotkey '" << hotkey.m_key << "' with modifiers '"
+                      << hotkey.m_mod_keys << "' for hotkey '" << hotkey.m_name << "'";
     }
 }
 

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -568,7 +568,6 @@ OptionsWnd::OptionsWnd():
 
     CreateSectionHeader(current_page, 0, UserString("OPTIONS_DESCRIPTIONS"));
     BoolOption(current_page,   0, "UI.dump-effects-descriptions",          UserString("OPTIONS_DUMP_EFFECTS_GROUPS_DESC"));
-    BoolOption(current_page,   0, "verbose-logging",                       UserString("OPTIONS_VERBOSE_LOGGING_DESC"));
     BoolOption(current_page,   0, "verbose-sitrep",                        UserString("OPTIONS_VERBOSE_SITREP_DESC"));
     BoolOption(current_page,   0, "UI.show-id-after-names",                UserString("OPTIONS_SHOW_IDS_AFTER_NAMES"));
 

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -699,18 +699,14 @@ OptionsWnd::OptionsWnd():
     current_page = CreatePage(UserString("OPTIONS_PAGE_LOGS"));
     CreateSectionHeader(current_page, 0, UserString("OPTIONS_DB_UI_LOGGER_THRESHOLDS"),
                         UserString("OPTIONS_DB_UI_LOGGER_THRESHOLD_TOOLTIP"));
-    CreateSectionHeader(current_page, 0, UserString("OPTIONS_DB_UI_LOGGER_THRESHOLD_PER_PROCESS"),
-                        UserString("OPTIONS_DB_UI_LOGGER_THRESHOLD_PER_PROCESS_TOOLTIP"));
 
     const auto log_file_sinks = LoggerOptionsLabelsAndLevels(LoggerTypes::exec);
     for (const auto& sink : log_file_sinks) {
         const auto& option = std::get<0>(sink);
         const auto& option_label = std::get<1>(sink);
-        LoggerLevelOption(*current_page, true, option_label, option);
+        const auto&& full_label = str(FlexibleFormat(UserString("OPTIONS_DB_UI_LOGGER_PER_PROCESS_GENERAL")) % option_label);
+        LoggerLevelOption(*current_page, true, full_label, option);
     }
-
-    CreateSectionHeader(current_page, 0, UserString("OPTIONS_DB_UI_LOGGER_THRESHOLD_PER_SOURCE"),
-                        UserString("OPTIONS_DB_UI_LOGGER_THRESHOLD_PER_SOURCE_TOOLTIP"));
 
     const auto log_file_sources = LoggerOptionsLabelsAndLevels(LoggerTypes::named);
     for (const auto& source : log_file_sources) {

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -252,8 +252,7 @@ void AIClientApp::HandleMessage(const Message& msg) {
 
         DebugLogger() << "Message::GAME_START loaded_game_data: " << loaded_game_data;
         if (loaded_game_data) {
-            if (GetOptionsDB().Get<bool>("verbose-logging"))
-                DebugLogger() << "Message::GAME_START save_state_string: " << save_state_string;
+            TraceLogger() << "Message::GAME_START save_state_string: " << save_state_string;
             m_AI->ResumeLoadedGame(save_state_string);
             Orders().ApplyOrders();
         } else {

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -226,6 +226,11 @@ HumanClientApp::HumanClientApp(int width, int height, bool calculate_fps, const 
     RegisterLoggerWithOptionsDB("ai", true);
     RegisterLoggerWithOptionsDB("client", true);
     RegisterLoggerWithOptionsDB("server", true);
+    RegisterLoggerWithOptionsDB("combat_log");
+    RegisterLoggerWithOptionsDB("combat");
+    RegisterLoggerWithOptionsDB("effects");
+    RegisterLoggerWithOptionsDB("FSM");
+    RegisterLoggerWithOptionsDB("network");
 
     InfoLogger() << FreeOrionVersionString();
 

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -298,13 +298,11 @@ HumanClientApp::HumanClientApp(int width, int height, bool calculate_fps, const 
 
     std::map<std::string, std::map<int, int>> named_key_maps;
     parse::keymaps(named_key_maps);
-    if (GetOptionsDB().Get<bool>("verbose-logging")) {
-        DebugLogger() << "Keymaps:";
-        for (std::map<std::string, std::map<int, int>>::value_type& km : named_key_maps) {
-            DebugLogger() << "Keymap name = \"" << km.first << "\"";
-            for (std::map<int, int>::value_type& keys : km.second)
-                DebugLogger() << "    " << char(keys.first) << " : " << char(keys.second);
-        }
+    TraceLogger() << "Keymaps:";
+    for (std::map<std::string, std::map<int, int>>::value_type& km : named_key_maps) {
+        TraceLogger() << "Keymap name = \"" << km.first << "\"";
+        for (std::map<int, int>::value_type& keys : km.second)
+            TraceLogger() << "    " << char(keys.first) << " : " << char(keys.second);
     }
     std::map<std::string, std::map<int, int>>::const_iterator km_it = named_key_maps.find("TEST");
     if (km_it != named_key_maps.end()) {

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -69,7 +69,7 @@ class CombatLogManager;
 CombatLogManager&   GetCombatLogManager();
 
 namespace {
-    CreateThreadedLogger(FSM);
+    DeclareThreadSafeLogger(FSM);
 }
 
 ////////////////////////////////////////////////////////////

--- a/client/human/HumanClientFSM.h
+++ b/client/human/HumanClientFSM.h
@@ -12,10 +12,6 @@
 
 #include <chrono>
 
-/** This function returns true iff the FSM's state instrumentation should be
-  * output to the logger's debug stream. */
-bool TraceHumanClientFSMExecution();
-
 // Human client-specific events not already defined in ClientFSMEvents.h
 
 /** Indicates that the "Start Game" button was clicked in the MP Lobby UI, in

--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -22,7 +22,11 @@
 #include "../network/Message.h"
 
 #include <iterator>
+#include <sstream>
 
+namespace {
+    CreateThreadedLogger(combat);
+}
 
 ////////////////////////////////////////////////
 // CombatInfo
@@ -41,8 +45,6 @@ CombatInfo::CombatInfo(int system_id_, int turn_) :
         ErrorLogger() << "CombatInfo constructed with invalid system id: " << system_id;
         return;
     }
-    bool verbose_logging = GetOptionsDB().Get<bool>("verbose-logging") || GetOptionsDB().Get<bool>("verbose-combat-logging");
-
     // add system to full / complete objects in combat - NOTE: changed from copy of system
     objects.Insert(system);
 
@@ -101,8 +103,7 @@ CombatInfo::CombatInfo(int system_id_, int turn_) :
                 empire_known_objects[empire_id].Insert(GetEmpireKnownShip(ship->ID(), empire_id));}
                 ship_known += std::to_string(empire_id) + ", ";
         }
-        if (verbose_logging)
-            DebugLogger() << ship_known;
+        DebugLogger(combat) << ship_known;
     }
 
     // planets
@@ -119,8 +120,7 @@ CombatInfo::CombatInfo(int system_id_, int turn_) :
                 planet_known += std::to_string(empire_id) + ", ";
             }
         }
-        if (verbose_logging)
-            DebugLogger() << planet_known;
+        DebugLogger(combat) << planet_known;
     }
 
     // after battle is simulated, any changes to latest known or actual objects
@@ -306,7 +306,6 @@ namespace {
             ErrorLogger() << "couldn't get target structure or shield meter";
             return;
         }
-        bool verbose_logging = GetOptionsDB().Get<bool>("verbose-logging") || GetOptionsDB().Get<bool>("verbose-combat-logging");
 
         Meter* target_shield = target->UniverseObject::GetMeter(METER_SHIELD);
         float shield = (target_shield ? target_shield->Current() : 0.0f);
@@ -321,8 +320,7 @@ namespace {
         if (damage > 0.0f) {
             target_structure->AddToCurrent(-damage);
             damaged_object_ids.insert(target->ID());
-            if (verbose_logging)
-                DebugLogger() << "COMBAT: Ship " << attacker->Name() << " (" << attacker->ID() << ") does " << damage << " damage to Ship " << target->Name() << " (" << target->ID() << ")";
+            DebugLogger(combat) << "COMBAT: Ship " << attacker->Name() << " (" << attacker->ID() << ") does " << damage << " damage to Ship " << target->Name() << " (" << target->ID() << ")";
         }
 
         combat_event->AddEvent(round, target->ID(), target->Owner(), weapon.part_type_name, power, shield, damage);
@@ -339,7 +337,6 @@ namespace {
         float power = weapon.part_attack;
         if (power <= 0.0f)
             return;
-        bool verbose_logging = GetOptionsDB().Get<bool>("verbose-logging") || GetOptionsDB().Get<bool>("verbose-combat-logging");
 
         std::set<int>& damaged_object_ids = combat_info.damaged_object_ids;
 
@@ -363,11 +360,9 @@ namespace {
             return;
         }
 
-        if (verbose_logging) {
-            DebugLogger() << "AttackShipPlanet: attacker: " << attacker->Name() << " power: " << power
-                          << "\ntarget: " << target->Name() << " shield: " << target_shield->Current()
-                          << " defense: " << target_defense->Current() << " infra: " << target_construction->Current();
-        }
+        DebugLogger(combat) << "AttackShipPlanet: attacker: " << attacker->Name() << " power: " << power
+                            << "\ntarget: " << target->Name() << " shield: " << target_shield->Current()
+                            << " defense: " << target_defense->Current() << " infra: " << target_construction->Current();
 
         // damage shields, limited by shield current value and damage amount.
         // remaining damage, if any, above shield current value goes to defense.
@@ -386,18 +381,21 @@ namespace {
 
         if (shield_damage >= 0) {
             target_shield->AddToCurrent(-shield_damage);
-            if (verbose_logging)
-                DebugLogger() << "COMBAT: Ship " << attacker->Name() << " (" << attacker->ID() << ") does " << shield_damage << " shield damage to Planet " << target->Name() << " (" << target->ID() << ")";
+            DebugLogger(combat) << "COMBAT: Ship " << attacker->Name() << " (" << attacker->ID() << ") does "
+                                << shield_damage << " shield damage to Planet " << target->Name() << " ("
+                                << target->ID() << ")";
         }
         if (defense_damage >= 0) {
             target_defense->AddToCurrent(-defense_damage);
-            if (verbose_logging)
-                DebugLogger() << "COMBAT: Ship " << attacker->Name() << " (" << attacker->ID() << ") does " << defense_damage << " defense damage to Planet " << target->Name() << " (" << target->ID() << ")";
+            DebugLogger(combat) << "COMBAT: Ship " << attacker->Name() << " (" << attacker->ID() << ") does "
+                                << defense_damage << " defense damage to Planet " << target->Name() << " ("
+                                << target->ID() << ")";
         }
         if (construction_damage >= 0) {
             target_construction->AddToCurrent(-construction_damage);
-            if (verbose_logging)
-                DebugLogger() << "COMBAT: Ship " << attacker->Name() << " (" << attacker->ID() << ") does " << construction_damage << " instrastructure damage to Planet " << target->Name() << " (" << target->ID() << ")";
+            DebugLogger(combat) << "COMBAT: Ship " << attacker->Name() << " (" << attacker->ID() << ") does "
+                                << construction_damage << " instrastructure damage to Planet " << target->Name()
+                                << " (" << target->ID() << ")";
         }
 
         //TODO report the planet damage details more clearly
@@ -428,7 +426,6 @@ namespace {
                           WeaponsPlatformEvent::WeaponsPlatformEventPtr& combat_event)
     {
         if (!attacker || !target) return;
-        bool verbose_logging = GetOptionsDB().Get<bool>("verbose-logging") || GetOptionsDB().Get<bool>("verbose-combat-logging");
 
         float power = 0.0f;
         const Meter* attacker_damage = attacker->UniverseObject::GetMeter(METER_DEFENSE);
@@ -446,19 +443,18 @@ namespace {
         Meter* target_shield = target->UniverseObject::GetMeter(METER_SHIELD);
         float shield = (target_shield ? target_shield->Current() : 0.0f);
 
-        if (verbose_logging) {
-            DebugLogger() << "AttackPlanetShip: attacker: " << attacker->Name() << " power: " << power
-                          << "  target: " << target->Name() << " shield: " << target_shield->Current()
-                          << " structure: " << target_structure->Current();
-        }
+        DebugLogger(combat) << "AttackPlanetShip: attacker: " << attacker->Name() << " power: " << power
+                            << "  target: " << target->Name() << " shield: " << target_shield->Current()
+                            << " structure: " << target_structure->Current();
 
         float damage = std::max(0.0f, power - shield);
 
         if (damage > 0.0f) {
             target_structure->AddToCurrent(-damage);
             damaged_object_ids.insert(target->ID());
-            if (verbose_logging)
-                DebugLogger() << "COMBAT: Planet " << attacker->Name() << " (" << attacker->ID() << ") does " << damage << " damage to Ship " << target->Name() << " (" << target->ID() << ")";
+            DebugLogger(combat) << "COMBAT: Planet " << attacker->Name() << " (" << attacker->ID()
+                                << ") does " << damage << " damage to Ship " << target->Name() << " ("
+                                << target->ID() << ")";
         }
 
         combat_event->AddEvent(round, target->ID(), target->Owner(), weapon.part_type_name, power, shield, damage);
@@ -491,7 +487,6 @@ namespace {
                            AttacksEventPtr &attacks_event)
     {
         if (!attacker || !target) return;
-        bool verbose_logging = GetOptionsDB().Get<bool>("verbose-logging") || GetOptionsDB().Get<bool>("verbose-combat-logging");
 
         float power = attacker->Damage();
 
@@ -506,19 +501,18 @@ namespace {
         //Meter* target_shield = target->UniverseObject::GetMeter(METER_SHIELD);
         float shield = 0.0f; //(target_shield ? target_shield->Current() : 0.0f);
 
-        if (verbose_logging) {
-            DebugLogger() << "AttackFighterShip: Fighter of empire " << attacker->Owner() << " power: " << power
-                          << "  target: " << target->Name() //<< " shield: " << target_shield->Current()
-                          << " structure: " << target_structure->Current();
-        }
+        DebugLogger() << "AttackFighterShip: Fighter of empire " << attacker->Owner() << " power: " << power
+                      << "  target: " << target->Name() //<< " shield: " << target_shield->Current()
+                      << " structure: " << target_structure->Current();
 
         float damage = std::max(0.0f, power - shield);
 
         if (damage > 0.0f) {
             target_structure->AddToCurrent(-damage);
             damaged_object_ids.insert(target->ID());
-            if (verbose_logging)
-                DebugLogger() << "COMBAT: Fighter of empire " << attacker->Owner() << " (" << attacker->ID() << ") does " << damage << " damage to Ship " << target->Name() << " (" << target->ID() << ")";
+            DebugLogger(combat) << "COMBAT: Fighter of empire " << attacker->Owner() << " (" << attacker->ID()
+                                << ") does " << damage << " damage to Ship " << target->Name() << " ("
+                                << target->ID() << ")";
         }
 
         float pierced_shield_value(-1.0);
@@ -619,10 +613,7 @@ namespace {
         if (obj->ObjectType() != OBJ_FIGHTER &&
             GetUniverse().GetObjectVisibilityByEmpire(obj->ID(), empire_id) <= VIS_BASIC_VISIBILITY)
         {
-            bool verbose_logging = GetOptionsDB().Get<bool>("verbose-logging") ||
-                                   GetOptionsDB().Get<bool>("verbose-combat-logging");
-            if (verbose_logging)
-                DebugLogger() << obj->Name() << " not sufficiently visible to empire " << empire_id;
+            DebugLogger(combat) << obj->Name() << " not sufficiently visible to empire " << empire_id;
             return false;
         }
 
@@ -908,8 +899,6 @@ namespace {
         /// Checks if target is destroyed and if it is, update lists of living objects.
         /// Return true if is incapacitated
         bool CheckDestruction(const std::shared_ptr<const UniverseObject>& target) {
-            bool verbose_logging = GetOptionsDB().Get<bool>("verbose-logging") ||
-                                   GetOptionsDB().Get<bool>("verbose-combat-logging");
             int target_id = target->ID();
             // check for destruction of target object
 
@@ -932,16 +921,14 @@ namespace {
 
             } else if (target->ObjectType() == OBJ_SHIP) {
                 if (target->CurrentMeterValue(METER_STRUCTURE) <= 0.0f) {
-                    if (verbose_logging)
-                        DebugLogger() << "!! Target Ship " << target_id << " is destroyed!";
+                    DebugLogger(combat) << "!! Target Ship " << target_id << " is destroyed!";
                     // object id destroyed
                     combat_info.destroyed_object_ids.insert(target_id);
                     // all empires in battle know object was destroyed
                     for (int empire_id : combat_info.empire_ids) {
                         if (empire_id != ALL_EMPIRES) {
-                            if (verbose_logging)
-                                DebugLogger() << "Giving knowledge of destroyed object " << target_id
-                                              << " to empire " << empire_id;
+                            DebugLogger(combat) << "Giving knowledge of destroyed object " << target_id
+                                          << " to empire " << empire_id;
                             combat_info.destroyed_object_knowers[empire_id].insert(target_id);
                         }
                     }
@@ -963,8 +950,7 @@ namespace {
                 if (!ObjectCanAttack(target) &&
                     valid_attacker_object_ids.find(target_id) != valid_attacker_object_ids.end())
                 {
-                    if (verbose_logging)
-                        DebugLogger() << "!! Target Planet " << target_id << " knocked out, can no longer attack";
+                    DebugLogger(combat) << "!! Target Planet " << target_id << " knocked out, can no longer attack";
                     // remove disabled planet's ID from lists of valid attackers
                     valid_attacker_object_ids.erase(target_id);
                 }
@@ -978,15 +964,11 @@ namespace {
                     // on the next turn, so check that it has been attacked
                     // before excluding it from any remaining battle
                     if (combat_info.damaged_object_ids.find(target_id) == combat_info.damaged_object_ids.end()) {
-                        if (verbose_logging) {
-                            DebugLogger() << "!! Planet " << target_id << "has not yet been attacked, "
-                                          << "so will not yet be removed from battle, despite being essentially incapacitated";
-                        }
+                        DebugLogger(combat) << "!! Planet " << target_id << "has not yet been attacked, "
+                                            << "so will not yet be removed from battle, despite being essentially incapacitated";
                         return false;
                     }
-                    if (verbose_logging) {
-                        DebugLogger() << "!! Target Planet " << target_id << " is entirely knocked out of battle";
-                    }
+                    DebugLogger(combat) << "!! Target Planet " << target_id << " is entirely knocked out of battle";
 
                     // remove disabled planet's ID from lists of valid targets
                     valid_target_object_ids.erase(target_id);   // probably not necessary as this set isn't used in this loop
@@ -1008,8 +990,6 @@ namespace {
         /// check if any empire has no remaining target or attacker objects.
         /// If so, remove that empire's entry
         void CleanEmpires() {
-            bool verbose_logging = GetOptionsDB().Get<bool>("verbose-logging") ||
-                                   GetOptionsDB().Get<bool>("verbose-combat-logging");
             std::map<int, EmpireCombatInfo> temp = empire_infos;
             for (std::map<int, EmpireCombatInfo>::value_type& empire : empire_infos) {
                 if (!empire.second.HasTargets() &&
@@ -1017,8 +997,7 @@ namespace {
                     !empire.second.HasUnlauchedArmedFighters(combat_info))
                 {
                     temp.erase(empire.first);
-                    if (verbose_logging)
-                        DebugLogger() << "No valid attacking objects left for empire with id: " << empire.first;
+                    DebugLogger(combat) << "No valid attacking objects left for empire with id: " << empire.first;
                 }
             }
             empire_infos = temp;
@@ -1038,9 +1017,7 @@ namespace {
 
         /**Report for each empire the stealth objects in the combat. */
         InitialStealthEvent::StealthInvisbleMap ReportInvisibleObjects(const CombatInfo& combat_info) const {
-            bool verbose_logging = GetOptionsDB().Get<bool>("verbose-logging") ||
-                                   GetOptionsDB().Get<bool>("verbose-combat-logging");
-            if (verbose_logging) DebugLogger() << "Reporting Invisible Objects";
+            DebugLogger(combat) << "Reporting Invisible Objects";
             InitialStealthEvent::StealthInvisbleMap report;
             for (int object_id : valid_target_object_ids) {
                 std::shared_ptr<const UniverseObject> obj = combat_info.objects.Object(object_id);
@@ -1048,7 +1025,7 @@ namespace {
                 // for all empires, can they attack this object?
                 for (int attacking_empire_id : combat_info.empire_ids) {
                     Visibility visibility = VIS_NO_VISIBILITY;
-                    if (verbose_logging) DebugLogger() << "Target " << obj->Name() << " by empire = "<< attacking_empire_id;
+                    DebugLogger(combat) << "Target " << obj->Name() << " by empire = "<< attacking_empire_id;
                     std::map<int, std::map<int, Visibility>>::const_iterator target_visible_it
                         = combat_info.empire_object_visibility.find(obj->Owner());
                     if (target_visible_it != combat_info.empire_object_visibility.end()) {
@@ -1063,7 +1040,7 @@ namespace {
                         if (ObjectUnTargettableByMonsters(obj, monster_detection)) {
                             // Note: This does put information about invisible and basic visible objects and
                             // trusts that the combat logger only informs player/ai of what they should know
-                            if (verbose_logging) DebugLogger() << " Monster "  << obj->Name() << " " << visibility << " to empire " << attacking_empire_id;
+                            DebugLogger(combat) << " Monster "  << obj->Name() << " " << visibility << " to empire " << attacking_empire_id;
                             report[attacking_empire_id][obj->Owner()]
                                 .insert(std::make_pair(obj->ID(), visibility));
                         }
@@ -1072,7 +1049,7 @@ namespace {
                         if (ObjectUnTargettableByEmpire(obj, attacking_empire_id)) {
                             // Note: This does put information about invisible and basic visible objects and
                             // trusts that the combat logger only informs player/ai of what they should know
-                            if (verbose_logging) DebugLogger() << " Ship " << obj->Name() << " " << visibility << " to empire " << attacking_empire_id;
+                            DebugLogger(combat) << " Ship " << obj->Name() << " " << visibility << " to empire " << attacking_empire_id;
                             report[attacking_empire_id][obj->Owner()]
                                 .insert(std::make_pair(obj->ID(), visibility));
                         }
@@ -1087,65 +1064,65 @@ namespace {
 
         // Populate lists of things that can attack and be attacked. List attackers also by empire.
         void PopulateAttackersAndTargets(const CombatInfo& combat_info) {
-            bool verbose_logging = GetOptionsDB().Get<bool>("verbose-logging") ||
-                                   GetOptionsDB().Get<bool>("verbose-combat-logging");
             for (ObjectMap::const_iterator<> it = combat_info.objects.const_begin();
                  it != combat_info.objects.const_end(); ++it)
             {
                 std::shared_ptr<const UniverseObject> obj = *it;
-                std::string obj_status = "Considerting object " + obj->Name() + " owned by " + std::to_string(obj->Owner());
-                if (ObjectCanAttack(obj)) {
-                    if (verbose_logging)
-                        obj_status += "... can attack";
+                bool can_attack{ObjectCanAttack(obj)};
+                if (can_attack) {
                     valid_attacker_object_ids.insert(it->ID());
                     empire_infos[obj->Owner()].attacker_ids.insert(it->ID());
                 }
-                if (ObjectTypeCanBeAttacked(obj)) {
-                    obj_status += "... can be attacked";
+
+                bool can_be_attacked{ObjectTypeCanBeAttacked(obj)};
+                if (can_be_attacked) {
                     valid_target_object_ids.insert(it->ID());
                 }
-                if (verbose_logging)
-                    DebugLogger() << obj_status;
+                DebugLogger(combat) << "Considerting object " + obj->Name() + " owned by " + std::to_string(obj->Owner())
+                                    << (can_attack ? "... can attack" : "")
+                                    << (can_be_attacked ? "... can be attacked": "");
             }
         }
 
         // Get a map from empire to set of IDs of objects that empire's objects
         // could potentially target.
         void PopulateEmpireTargets(const CombatInfo& combat_info) {
-            bool verbose_logging = GetOptionsDB().Get<bool>("verbose-logging") ||
-                                   GetOptionsDB().Get<bool>("verbose-combat-logging");
             for (int object_id : valid_target_object_ids) {
                 std::shared_ptr<const UniverseObject> obj = combat_info.objects.Object(object_id);
-                if (verbose_logging)
-                    DebugLogger() << "Considering attackability of object " << obj->Name() 
-                                  << " owned by " << std::to_string(obj->Owner());
-
-                std::string obj_status = "object: " + obj->Name() + " attackable by ";
-                std:: string empire_list;
-                std:: string empire_list_all;
-                // for all empires, can they attack this object?
                 for (int attacking_empire_id : combat_info.empire_ids) {
-                    if (attacking_empire_id == ALL_EMPIRES) {
-                        if (ObjectAttackableByMonsters(obj, monster_detection)) {
-                            obj_status += "monsters and ";
-                            empire_infos[ALL_EMPIRES].target_ids.insert(object_id);
-                        }
-
-                    } else {
-                        empire_list_all += std::to_string(attacking_empire_id) + ", ";
-                        if (ObjectAttackableByEmpire(obj, attacking_empire_id)) {
-                            empire_list += std::to_string(attacking_empire_id) + ", ";
-                            empire_infos[attacking_empire_id].target_ids.insert(object_id);
-                        }
+                    if (attacking_empire_id == ALL_EMPIRES
+                        && ObjectAttackableByMonsters(obj, monster_detection))
+                    {
+                        empire_infos[ALL_EMPIRES].target_ids.insert(object_id);
+                    } else if (ObjectAttackableByEmpire(obj, attacking_empire_id)) {
+                        empire_infos[attacking_empire_id].target_ids.insert(object_id);
                     }
                 }
-                if (verbose_logging) {
-                    if (empire_list.empty())
-                        obj_status += "NONE of the empires present (" + empire_list_all + ")";
-                    else
-                        obj_status += "empires " + empire_list;
-                    DebugLogger() << obj_status;
-                }
+
+                DebugLogger(combat) << [&combat_info, &obj, this]() {
+                    std::stringstream ss;
+                    ss << "Considering attackability of object " << obj->Name()
+                       << " owned by " << std::to_string(obj->Owner())
+                       << " attackable by ";
+
+                    bool no_one{true};
+                    for (int attacking_empire_id : combat_info.empire_ids) {
+                        if (attacking_empire_id == ALL_EMPIRES
+                            && ObjectAttackableByMonsters(obj, monster_detection))
+                        {
+                            ss << "monsters and ";
+                            no_one = false;
+                        } else if (ObjectAttackableByEmpire(obj, attacking_empire_id)) {
+                            if (!no_one)
+                                ss << ", ";
+                            ss << std::to_string(attacking_empire_id);
+                            no_one = false;
+                        }
+                    }
+                    if (no_one)
+                        ss << "none of the empires present";
+                    return ss.str();
+                }();
             }
         }
     };
@@ -1158,11 +1135,8 @@ namespace {
         if (attacker->ObjectType() == OBJ_SHIP)
             return potential_target_ids;    // ships can attack anything!
 
-        bool verbose_logging = GetOptionsDB().Get<bool>("verbose-logging") ||
-                               GetOptionsDB().Get<bool>("verbose-combat-logging");
-
         std::set<int> valid_target_ids;
-        std::string invalid_target_ids;
+        bool any_invalid_targets{false};
 
         for (int target_id : potential_target_ids) {
             std::shared_ptr<UniverseObject> target = combat_state.combat_info.objects.Object(target_id);
@@ -1175,21 +1149,40 @@ namespace {
                 // planets can only attack ships (not other planets or fighters)
                 if (target->ObjectType() == OBJ_SHIP) {
                     valid_target_ids.insert(target_id);
-                } else if (verbose_logging) {
-                    invalid_target_ids += std::to_string(target_id) + " ";
+                } else {
+                    any_invalid_targets = true;
                 }
             } else if (attacker->ObjectType() == OBJ_FIGHTER) {
                 // fighters can't attack planets
                 if (target->ObjectType() != OBJ_PLANET) {
                     valid_target_ids.insert(target_id);
-                } else if (verbose_logging) {
-                    invalid_target_ids += std::to_string(target_id) + " ";
+                } else {
+                    any_invalid_targets = true;
                 }
             }
         }
 
-        if (verbose_logging && !invalid_target_ids.empty())
-            DebugLogger() << "Attacker " << attacker->ID() << " can't attack potential targets: " << invalid_target_ids;
+        if (any_invalid_targets)
+            DebugLogger(combat) << [&attacker, &potential_target_ids, &combat_state](){
+                std::stringstream ss;
+                ss << "Attacker " << attacker->ID() << " can't attack potential targets: ";
+
+                for (int target_id : potential_target_ids) {
+                    std::shared_ptr<UniverseObject> target = combat_state.combat_info.objects.Object(target_id);
+                    if (!target)
+                        continue;
+
+                    // planets can only attack ships (not other planets or fighters)
+                    if (attacker->ObjectType() == OBJ_PLANET && target->ObjectType() != OBJ_SHIP)
+                        ss << std::to_string(target_id) << " ";
+
+                    // fighters can't attack planets
+                    else if (attacker->ObjectType() == OBJ_FIGHTER && target->ObjectType() == OBJ_PLANET)
+                        ss << std::to_string(target_id) << " ";
+                }
+
+                return ss.str();
+            }();
 
         return valid_target_ids;
     }
@@ -1200,11 +1193,8 @@ namespace {
                          WeaponsPlatformEvent::WeaponsPlatformEventPtr &platform_event,
                          std::shared_ptr<FightersAttackFightersEvent>& fighter_on_fighter_event)
     {
-        bool verbose_logging = GetOptionsDB().Get<bool>("verbose-logging") ||
-                               GetOptionsDB().Get<bool>("verbose-combat-logging");
         if (weapons.empty()) {
-            if (verbose_logging)
-                DebugLogger() << "no weapons' can't attack";
+            DebugLogger(combat) << "no weapons' can't attack";
             return;   // no ability to attack!
         }
 
@@ -1215,8 +1205,7 @@ namespace {
                 continue;
 
             // select object from valid targets for this object's owner   TODO: with this weapon...
-            if (verbose_logging)
-                DebugLogger() << "Attacking with weapon " << weapon.part_type_name << " with power " << weapon.part_attack;
+            DebugLogger(combat) << "Attacking with weapon " << weapon.part_type_name << " with power " << weapon.part_attack;
 
             // get valid targets set for attacker owner.  need to do this for
             // each weapon that is attacking, as the previous shot might have
@@ -1225,28 +1214,28 @@ namespace {
 
             std::map<int, EmpireCombatInfo >::iterator target_vec_it = combat_state.empire_infos.find(attacker_owner_id);
             if (target_vec_it == combat_state.empire_infos.end() || !target_vec_it->second.HasTargets()) {
-                if (verbose_logging)
-                    DebugLogger() << "No targets for empire: " << attacker_owner_id;
+                DebugLogger(combat) << "No targets for empire: " << attacker_owner_id;
                 break;
             }
 
             const std::set<int> valid_target_ids = ValidTargetsForAttackerType(attacker, combat_state, target_vec_it->second.target_ids);
             if (valid_target_ids.empty()) {
-                if (verbose_logging)
-                    DebugLogger() << "No valid targets for attacker " << attacker->ID();
+                DebugLogger(combat) << "No valid targets for attacker " << attacker->ID();
                 break;
             }
             //const std::set<int>& valid_target_ids = target_vec_it->second.target_ids;
 
-            if (verbose_logging) { 
-                std::string id_list;
+            DebugLogger(combat) << [&valid_target_ids, &attacker, &attacker_owner_id]() {
+                std::stringstream ss;
+                ss << "Valid targets for attacker with id: " << attacker->ID()
+                   << " owned by empire: " << attacker_owner_id
+                   << " :  ";
                 for (int target_id : valid_target_ids)
-                { id_list += std::to_string(target_id) + " "; }
+                { ss << std::to_string(target_id) + " "; }
+                return ss.str();
+            }();
 
-                DebugLogger() << "Valid targets for attacker with id: " << attacker->ID()
-                << " owned by empire: " << attacker_owner_id
-                << " :  " << id_list;
-            }
+
             // END DEBUG
 
             // select target object
@@ -1258,8 +1247,7 @@ namespace {
                 ErrorLogger() << "AutoResolveCombat couldn't get target object with id " << target_id;
                 continue;
             }
-            if (verbose_logging)
-                DebugLogger() << "Target: " << target->Name();
+            DebugLogger(combat) << "Target: " << target->Name();
 
             // do actual attacks
             Attack(attacker, weapon, target, combat_state.combat_info, bout, round, attacks_event,
@@ -1312,11 +1300,8 @@ namespace {
                         AutoresolveInfo& combat_state, int bout, int round,
                         FighterLaunchesEventPtr &launches_event)
     {
-        bool verbose_logging = GetOptionsDB().Get<bool>("verbose-logging") ||
-                               GetOptionsDB().Get<bool>("verbose-combat-logging");
         if (weapons.empty()) {
-            if (verbose_logging)
-                DebugLogger() << "no weapons' can't launch figters!";
+            DebugLogger(combat) << "no weapons' can't launch figters!";
             return;   // no ability to attack!
         }
 
@@ -1332,11 +1317,10 @@ namespace {
 
             int attacker_owner_id = attacker->Owner();
 
-            if (verbose_logging)
-                DebugLogger() << "Launching " << weapon.fighters_launched
-                              << " with damage " << weapon.fighter_damage
-                              << " for empire id: " << attacker_owner_id
-                              << " from ship id: " << attacker->ID();
+            DebugLogger(combat) << "Launching " << weapon.fighters_launched
+                                << " with damage " << weapon.fighter_damage
+                                << " for empire id: " << attacker_owner_id
+                                << " from ship id: " << attacker->ID();
 
             std::vector<int> new_fighter_ids =
                 combat_state.AddFighters(weapon.fighters_launched, weapon.fighter_damage,
@@ -1433,8 +1417,6 @@ namespace {
     std::vector<PartAttackInfo> GetWeapons(std::shared_ptr<UniverseObject>& attacker) {
         // loop over weapons of attacking object.  each gets a shot at a
         // randomly selected target object
-        bool verbose_logging = GetOptionsDB().Get<bool>("verbose-logging") ||
-                               GetOptionsDB().Get<bool>("verbose-combat-logging");
         std::vector<PartAttackInfo> weapons;
 
         std::shared_ptr<Ship> attack_ship = std::dynamic_pointer_cast<Ship>(attacker);
@@ -1444,14 +1426,12 @@ namespace {
         if (attack_ship) {
             weapons = ShipWeaponsStrengths(attack_ship);    // includes info about fighter launches with PC_FIGHTER_BAY part class, and direct fire weapons with PC_DIRECT_WEAPON part class
             for (PartAttackInfo& part : weapons) {
-                if (verbose_logging) {
-                    if (part.part_class == PC_DIRECT_WEAPON) {
-                        DebugLogger() << "Attacker Ship direct weapon: " << part.part_type_name
-                                      << " attack: " << part.part_attack;
-                    } else if (part.part_class == PC_FIGHTER_BAY) {
-                        DebugLogger() << "Attacker Ship fighter launch: " << part.fighters_launched
-                                      << " damage: " << part.fighter_damage;
-                    }
+                if (part.part_class == PC_DIRECT_WEAPON) {
+                    DebugLogger(combat) << "Attacker Ship direct weapon: " << part.part_type_name
+                                        << " attack: " << part.part_attack;
+                } else if (part.part_class == PC_FIGHTER_BAY) {
+                    DebugLogger(combat) << "Attacker Ship fighter launch: " << part.fighters_launched
+                                        << " damage: " << part.fighter_damage;
                 }
             }
 
@@ -1467,22 +1447,21 @@ namespace {
     void CombatRound(int bout, CombatInfo& combat_info, AutoresolveInfo& combat_state) {
         BoutEvent::BoutEventPtr bout_event = std::make_shared<BoutEvent>(bout);
         combat_info.combat_events.push_back(bout_event);
-        bool verbose_logging = GetOptionsDB().Get<bool>("verbose-logging") ||
-                               GetOptionsDB().Get<bool>("verbose-combat-logging");
         if (combat_state.valid_attacker_object_ids.empty()) {
-            if (verbose_logging)
-                DebugLogger() << "Combat bout " << bout << " aborted due to no remaining attackers.";
+            DebugLogger(combat) << "Combat bout " << bout << " aborted due to no remaining attackers.";
             return;
         }
 
         std::vector<int> shuffled_attackers;
         combat_state.GetShuffledValidAttackerIDs(shuffled_attackers);
 
-        if (verbose_logging) {
-            DebugLogger() << "Attacker IDs:";
+        DebugLogger() << [&shuffled_attackers](){
+            std::stringstream ss;
+            ss << "Attacker IDs:";
             for (int attacker : shuffled_attackers)
-            { DebugLogger() << attacker; }
-        }
+            { ss << attacker; }
+            return ss.str();
+        }();
 
         AttacksEventPtr attacks_event = std::make_shared<AttacksEvent>();
         bout_event->AddEvent(attacks_event);
@@ -1509,8 +1488,7 @@ namespace {
                 DebugLogger() << "Planet " << attacker->Name() << " could not attack.";
                 continue;
             }
-            if (verbose_logging)
-                DebugLogger() << "Planet: " << attacker->Name();
+            DebugLogger(combat) << "Planet: " << attacker->Name();
 
             std::vector<PartAttackInfo> weapons = GetWeapons(attacker); // includes info about fighter launches with PC_FIGHTER_BAY part class, and direct fire weapons (ships, planets, or fighters) with PC_DIRECT_WEAPON part class
             WeaponsPlatformEvent::WeaponsPlatformEventPtr platform_event
@@ -1534,8 +1512,7 @@ namespace {
                 DebugLogger() << "Attacker " << attacker->Name() << " could not attack.";
                 continue;
             }
-            if (verbose_logging)
-                DebugLogger() << "Attacker: " << attacker->Name();
+            DebugLogger(combat) << "Attacker: " << attacker->Name();
 
             // loop over weapons of the attacking object.  each gets a shot at a
             // randomly selected target object
@@ -1570,8 +1547,7 @@ namespace {
 
                 LaunchFighters(attacker, weapons, combat_state, bout, round++, launches_event);
 
-                if (verbose_logging)
-                    DebugLogger() << "Attacker: " << attacker->Name();
+                DebugLogger(combat) << "Attacker: " << attacker->Name();
             }
 
             if (!launches_event->AreSubEventsEmpty(ALL_EMPIRES))
@@ -1625,7 +1601,6 @@ namespace {
 void AutoResolveCombat(CombatInfo& combat_info) {
     if (combat_info.objects.Empty())
         return;
-    bool verbose_logging = GetOptionsDB().Get<bool>("verbose-logging") || GetOptionsDB().Get<bool>("verbose-combat-logging");
 
     std::shared_ptr<const System> system = combat_info.objects.Object<System>(combat_info.system_id);
     if (!system)
@@ -1633,10 +1608,8 @@ void AutoResolveCombat(CombatInfo& combat_info) {
     else
         DebugLogger() << "AutoResolveCombat at " << system->Name();
 
-    if (verbose_logging) {
-        DebugLogger() << "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%";
-        DebugLogger() << "AutoResolveCombat objects before resolution: " << combat_info.objects.Dump();
-    }
+    DebugLogger(combat) << "%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%";
+    DebugLogger(combat) << "AutoResolveCombat objects before resolution: " << combat_info.objects.Dump();
 
     // reasonably unpredictable but reproducible random seeding
     int base_seed = 0;
@@ -1663,13 +1636,11 @@ void AutoResolveCombat(CombatInfo& combat_info) {
         // empires may have valid targets, but nothing to attack with.  If all
         // empires have no attackers or no valid targers, combat is over
         if (!combat_state.CanSomeoneAttackSomething()) {
-            if (verbose_logging)
-                DebugLogger() << "No empire has valid targets and something to attack with; combat over.";
+            DebugLogger(combat) << "No empire has valid targets and something to attack with; combat over.";
             break;
         }
 
-        if (verbose_logging)
-            DebugLogger() << "Combat at " << system->Name() << " (" << combat_info.system_id << ") Bout " << bout;
+        DebugLogger(combat) << "Combat at " << system->Name() << " (" << combat_info.system_id << ") Bout " << bout;
 
         CombatRound(bout, combat_info, combat_state);
         last_bout = bout;
@@ -1688,12 +1659,10 @@ void AutoResolveCombat(CombatInfo& combat_info) {
     for (std::map<int, ObjectMap>::value_type& entry : combat_info.empire_known_objects)
     { entry.second.Copy(combat_info.objects); }
 
-    if (verbose_logging) {
-        DebugLogger() << "AutoResolveCombat objects after resolution: " << combat_info.objects.Dump();
+    DebugLogger(combat) << "AutoResolveCombat objects after resolution: " << combat_info.objects.Dump();
 
-        DebugLogger() << "combat event log start:";
-        for (CombatEventPtr event : combat_info.combat_events)
-        { DebugLogger() << event->DebugString(); }
-        DebugLogger() << "combat event log end:";
-    }
+    DebugLogger(combat) << "combat event log start:";
+    for (CombatEventPtr event : combat_info.combat_events)
+    { DebugLogger(combat) << event->DebugString(); }
+    DebugLogger(combat) << "combat event log end:";
 }

--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -25,7 +25,7 @@
 #include <sstream>
 
 namespace {
-    CreateThreadedLogger(combat);
+    DeclareThreadSafeLogger(combat);
 }
 
 ////////////////////////////////////////////////

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1348,24 +1348,15 @@ When searching the pedia, check for matches in article contents.
 OPTIONS_DB_UI_LOGGER_THRESHOLDS
 Logger thresholds
 
-# Sub section title for logger threshold per application.
-OPTIONS_DB_UI_LOGGER_THRESHOLD_PER_PROCESS
-Per process
-
-# Sub section title for logger threshold of individual sources
-OPTIONS_DB_UI_LOGGER_THRESHOLD_PER_SOURCE
-Per source
-
 OPTIONS_DB_UI_LOGGER_THRESHOLD_TOOLTIP
 '''Each log output file (freeorion.log, freeoriond.log, and AI_x.log) collects log records from sources (sections of code). 
 Setting the threshold for a source will enable logs records of that level or higher for that source. 
-Each process client, server, and ai has a default source and may have additional detailed sources (eg. combat resolution logs).'''
+Each process client, server, and ai has a general source and may have additional detailed sources (eg. combat resolution logs).'''
 
-OPTIONS_DB_UI_LOGGER_THRESHOLD_PER_PROCESS_TOOLTIP
-'''Setting the threshold for a process will produce only log records of that level or higher for the default source, but not affect other sources.'''
-
-OPTIONS_DB_UI_LOGGER_THRESHOLD_PER_SOURCE_TOOLTIP
-'''Setting the threshold for a source will produce logs of that level or higher for that source in all processes.'''
+# This is a label to designate the logger as the general or default logger for a process
+# %1% is the name of a process logger, client, server or ai
+OPTIONS_DB_UI_LOGGER_PER_PROCESS_GENERAL
+%1% general
 
 OPTIONS_DB_KEYPRESS_REPEAT_DELAY
 Sets delay between holding a key and repeat keypresses being generated

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1569,9 +1569,6 @@ Toggles dump of effects groups in tech, building or ship part descriptions.
 OPTIONS_DB_VERBOSE_LOGGING_DESC
 Toggles verbose logging of universe contents and effect evaluation.
 
-OPTIONS_DB_VERBOSE_COMBAT_LOGGING_DESC
-Toggles verbose logging of combat resolution information.
-
 OPTIONS_DB_VERBOSE_SITREP_DESC
 Toggles inclusion of situation report messages with errors.
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1566,9 +1566,6 @@ Stores whether to reset the stored fullscreen resolution. If false, the stored v
 OPTIONS_DB_DUMP_EFFECTS_GROUPS_DESC
 Toggles dump of effects groups in tech, building or ship part descriptions.
 
-OPTIONS_DB_VERBOSE_LOGGING_DESC
-Toggles verbose logging of universe contents and effect evaluation.
-
 OPTIONS_DB_VERBOSE_SITREP_DESC
 Toggles inclusion of situation report messages with errors.
 

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -35,7 +35,7 @@ using boost::asio::ip::tcp;
 using namespace Networking;
 
 namespace {
-    CreateThreadedLogger(network);
+    DeclareThreadSafeLogger(network);
 
     /** A simple client that broadcasts UDP datagrams on the local network for
         FreeOrion servers, and reports any it finds. */

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -35,7 +35,7 @@ using boost::asio::ip::tcp;
 using namespace Networking;
 
 namespace {
-    const bool TRACE_EXECUTION = false;
+    CreateThreadedLogger(network);
 
     /** A simple client that broadcasts UDP datagrams on the local network for
         FreeOrion servers, and reports any it finds. */
@@ -314,11 +314,11 @@ bool ClientNetworking::Impl::ConnectToServer(
 
     tcp::resolver::iterator end_it;
 
-    DebugLogger() << "Attempt to connect to server at one of these addresses:";
+    DebugLogger(network) << "Attempt to connect to server at one of these addresses:";
     for (tcp::resolver::iterator it = resolver.resolve(query); it != end_it; ++it) {
-        DebugLogger() << "  tcp::resolver::iterator host_name: " << it->host_name()
-                      << "  address: " << it->endpoint().address()
-                      << "  port: " << it->endpoint().port();
+        DebugLogger(network) << "  tcp::resolver::iterator host_name: " << it->host_name()
+                             << "  address: " << it->endpoint().address()
+                             << "  port: " << it->endpoint().port();
     }
 
     try {
@@ -335,13 +335,13 @@ bool ClientNetworking::Impl::ConnectToServer(
                 auto connection_time = Clock::now() - start_time;
 
                 if (IsConnected()) {
-                    DebugLogger() << "Connected to server at host_name: " << it->host_name()
-                                  << "  address: " << it->endpoint().address()
-                                  << "  port: " << it->endpoint().port();
+                    DebugLogger(network) << "Connected to server at host_name: " << it->host_name()
+                                         << "  address: " << it->endpoint().address()
+                                         << "  port: " << it->endpoint().port();
 
-                    //DebugLogger() << "ConnectToServer() : Client using "
-                    //              << ((GetOptionsDB().Get<bool>("binary-serialization")) ? "binary": "xml")
-                    //              << " serialization.";
+                    //DebugLogger(network) << "ConnectToServer() : Client using "
+                    //                     << ((GetOptionsDB().Get<bool>("binary-serialization")) ? "binary": "xml")
+                    //                     << " serialization.";
 
                     // Prepare the socket
 
@@ -359,31 +359,30 @@ bool ClientNetworking::Impl::ConnectToServer(
                     // then deliver an OS dependent error when/if the other side of the connection
                     // times out or closes.
                     m_socket.set_option(boost::asio::socket_base::keep_alive(true));
-                    DebugLogger() << "Connecting to server took "
-                                  << std::chrono::duration_cast<std::chrono::milliseconds>(connection_time).count() << " ms.";
+                    DebugLogger(network) << "Connecting to server took "
+                                         << std::chrono::duration_cast<std::chrono::milliseconds>(connection_time).count() << " ms.";
 
-                    DebugLogger() << "ConnectToServer() : starting networking thread";
+                    DebugLogger(network) << "ConnectToServer() : starting networking thread";
                     boost::thread(boost::bind(&ClientNetworking::Impl::NetworkingThread, this, self->shared_from_this()));
                     break;
                 } else {
-                    if (TRACE_EXECUTION)
-                        DebugLogger() << "Failed to connect to host_name: " << it->host_name()
-                                      << "  address: " << it->endpoint().address()
-                                      << "  port: " << it->endpoint().port();
+                    TraceLogger(network) << "Failed to connect to host_name: " << it->host_name()
+                                         << "  address: " << it->endpoint().address()
+                                         << "  port: " << it->endpoint().port();
                     if (timeout < connection_time) {
-                        ErrorLogger() << "Timed out ("
-                                      << std::chrono::duration_cast<std::chrono::milliseconds>(connection_time).count() << " ms."
-                                      << ") attempting to connect to server.";
+                        ErrorLogger(network) << "Timed out ("
+                                             << std::chrono::duration_cast<std::chrono::milliseconds>(connection_time).count() << " ms."
+                                             << ") attempting to connect to server.";
                     }
                 }
             }
         }
         if (!IsConnected())
-            DebugLogger() << "ConnectToServer() : failed to connect to server.";
+            DebugLogger(network) << "ConnectToServer() : failed to connect to server.";
 
     } catch (const std::exception& e) {
-        ErrorLogger() << "ConnectToServer() : unable to connect to server at "
-                      << ip_address << " due to exception: " << e.what();
+        ErrorLogger(network) << "ConnectToServer() : unable to connect to server at "
+                             << ip_address << " due to exception: " << e.what();
     }
     return IsConnected();
 }
@@ -419,7 +418,7 @@ void ClientNetworking::Impl::DisconnectFromServer() {
 }
 
 void ClientNetworking::Impl::SetPlayerID(int player_id) {
-    DebugLogger() << "ClientNetworking::SetPlayerID: player id set to: " << player_id;
+    DebugLogger(network) << "ClientNetworking::SetPlayerID: player id set to: " << player_id;
     m_player_id = player_id;
 }
 
@@ -428,33 +427,31 @@ void ClientNetworking::Impl::SetHostPlayerID(int host_player_id)
 
 void ClientNetworking::Impl::SendMessage(const Message& message) {
     if (!IsTxConnected()) {
-        ErrorLogger() << "ClientNetworking::SendMessage can't send message when not transmit connected";
+        ErrorLogger(network) << "ClientNetworking::SendMessage can't send message when not transmit connected";
         return;
     }
-    if (TRACE_EXECUTION)
-        DebugLogger() << "ClientNetworking::SendMessage() : sending message " << message;
+    TraceLogger(network) << "ClientNetworking::SendMessage() : sending message " << message;
     m_io_service.post(boost::bind(&ClientNetworking::Impl::SendMessageImpl, this, message));
 }
 
 boost::optional<Message> ClientNetworking::Impl::GetMessage() {
     const auto message = m_incoming_messages.PopFront();
-    if (message && TRACE_EXECUTION)
-        DebugLogger() << "ClientNetworking::GetMessage() : received message "
-                      << *message;
+    if (message)
+        TraceLogger(network) << "ClientNetworking::GetMessage() : received message "
+                             << *message;
     return message;
 }
 
 boost::optional<Message> ClientNetworking::Impl::SendSynchronousMessage(const Message& message) {
-    if (TRACE_EXECUTION)
-        DebugLogger() << "ClientNetworking::SendSynchronousMessage : sending message "
-                      << message;
+    TraceLogger(network) << "ClientNetworking::SendSynchronousMessage : sending message "
+                         << message;
     SendMessage(message);
     // note that this is a blocking operation
     auto response_message = m_incoming_messages.GetFirstSynchronousMessage();
 
-    if (response_message && TRACE_EXECUTION)
-        DebugLogger() << "ClientNetworking::SendSynchronousMessage : received "
-                      << "response message " << *response_message;
+    if (response_message)
+        TraceLogger(network) << "ClientNetworking::SendSynchronousMessage : received "
+                             << "response message " << *response_message;
 
     return response_message;
 }
@@ -463,13 +460,11 @@ void ClientNetworking::Impl::HandleConnection(tcp::resolver::iterator* it,
                                               const boost::system::error_code& error)
 {
     if (error) {
-        if (TRACE_EXECUTION)
-            DebugLogger() << "ClientNetworking::HandleConnection : connection "
-                          << "error #"<<error.value()<<" \"" << error.message() << "\""
-                          << "... retrying";
+        TraceLogger(network) << "ClientNetworking::HandleConnection : connection "
+                             << "error #"<<error.value()<<" \"" << error.message() << "\""
+                             << "... retrying";
     } else {
-        if (TRACE_EXECUTION)
-            DebugLogger() << "ClientNetworking::HandleConnection : connected";
+        TraceLogger(network) << "ClientNetworking::HandleConnection : connected";
 
         boost::mutex::scoped_lock lock(m_mutex);
         m_rx_connected = true;
@@ -479,17 +474,17 @@ void ClientNetworking::Impl::HandleConnection(tcp::resolver::iterator* it,
 
 void ClientNetworking::Impl::HandleException(const boost::system::system_error& error) {
     if (error.code() == boost::asio::error::eof) {
-        DebugLogger() << "Client connection disconnected by EOF from server.";
+        DebugLogger(network) << "Client connection disconnected by EOF from server.";
         m_socket.close();
     }
     else if (error.code() == boost::asio::error::connection_reset)
-        DebugLogger() << "Client connection disconnected, due to connection reset from server.";
+        DebugLogger(network) << "Client connection disconnected, due to connection reset from server.";
     else if (error.code() == boost::asio::error::operation_aborted)
-        DebugLogger() << "Client connection closed by client.";
+        DebugLogger(network) << "Client connection closed by client.";
     else {
-        ErrorLogger() << "ClientNetworking::NetworkingThread() : Networking thread will be terminated "
-                      << "due to unhandled exception error #" << error.code().value() << " \""
-                      << error.code().message() << "\"";
+        ErrorLogger(network) << "ClientNetworking::NetworkingThread() : Networking thread will be terminated "
+                             << "due to unhandled exception error #" << error.code().value() << " \""
+                             << error.code().message() << "\"";
     }
 }
 
@@ -511,8 +506,7 @@ void ClientNetworking::Impl::NetworkingThread(const std::shared_ptr<const Client
         m_rx_connected = false;
         m_tx_connected = false;
     }
-    if (TRACE_EXECUTION)
-        DebugLogger() << "ClientNetworking::NetworkingThread() : Networking thread terminated.";
+    TraceLogger(network) << "ClientNetworking::NetworkingThread() : Networking thread terminated.";
 }
 
 void ClientNetworking::Impl::HandleMessageBodyRead(const std::shared_ptr<const ClientNetworking>& keep_alive,
@@ -591,7 +585,7 @@ void ClientNetworking::Impl::HandleMessageWrite(boost::system::error_code error,
 
 void ClientNetworking::Impl::AsyncWriteMessage() {
     if (!m_socket.is_open()) {
-        ErrorLogger() << "Socket is closed. Dropping message.";
+        ErrorLogger(network) << "Socket is closed. Dropping message.";
         return;
     }
 

--- a/network/ServerNetworking.cpp
+++ b/network/ServerNetworking.cpp
@@ -14,7 +14,7 @@ using boost::asio::ip::udp;
 using namespace Networking;
 
 namespace {
-    CreateThreadedLogger(network);
+    DeclareThreadSafeLogger(network);
 }
 
 /** A simple server that listens for FreeOrion-server-discovery UDP datagrams

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1378,10 +1378,8 @@ void ServerApp::GenerateUniverse(std::map<int, PlayerSetupData>& player_setup_da
     universe.BackPropagateObjectMeters();
     Empires().BackPropagateMeters();
 
-    if (GetOptionsDB().Get<bool>("verbose-logging")) {
-        DebugLogger() << "!!!!!!!!!!!!!!!!!!! After setting active meters to targets";
-        DebugLogger() << universe.Objects().Dump();
-    }
+    TraceLogger() << "!!!!!!!!!!!!!!!!!!! After setting active meters to targets";
+    TraceLogger() << universe.Objects().Dump();
 
     universe.UpdateEmpireObjectVisibilities();
 }
@@ -2933,11 +2931,8 @@ void ServerApp::PostCombatProcessTurns() {
     m_networking.SendMessageAll(TurnProgressMessage(Message::EMPIRE_PRODUCTION));
     DebugLogger() << "ServerApp::PostCombatProcessTurns effects and meter updates";
 
-
-    if (GetOptionsDB().Get<bool>("verbose-logging")) {
-        DebugLogger() << "!!!!!!! BEFORE TURN PROCESSING EFFECTS APPLICATION";
-        DebugLogger() << objects.Dump();
-    }
+    TraceLogger() << "!!!!!!! BEFORE TURN PROCESSING EFFECTS APPLICATION";
+    TraceLogger() << objects.Dump();
 
     // execute all effects and update meters prior to production, research, etc.
     if (GetOptionsDB().Get<bool>("reseed-prng-server")) {
@@ -2950,11 +2945,8 @@ void ServerApp::PostCombatProcessTurns() {
     // have added or removed starlanes.
     m_universe.InitializeSystemGraph();
 
-    if (GetOptionsDB().Get<bool>("verbose-logging")) {
-        DebugLogger() << "!!!!!!! AFTER TURN PROCESSING EFFECTS APPLICATION";
-        DebugLogger() << objects.Dump();
-    }
-
+    TraceLogger() << "!!!!!!! AFTER TURN PROCESSING EFFECTS APPLICATION";
+    TraceLogger() << objects.Dump();
 
     DebugLogger() << "ServerApp::PostCombatProcessTurns empire resources updates";
 
@@ -2991,10 +2983,8 @@ void ServerApp::PostCombatProcessTurns() {
         }
     }
 
-    if (GetOptionsDB().Get<bool>("verbose-logging")) {
-        DebugLogger() << "!!!!!!! AFTER UPDATING RESOURCE POOLS AND SUPPLY STUFF";
-        DebugLogger() << objects.Dump();
-    }
+    TraceLogger() << "!!!!!!! AFTER UPDATING RESOURCE POOLS AND SUPPLY STUFF";
+    TraceLogger() << objects.Dump();
 
     DebugLogger() << "ServerApp::PostCombatProcessTurns queue progress checking";
 
@@ -3011,11 +3001,8 @@ void ServerApp::PostCombatProcessTurns() {
         empire->CheckTradeSocialProgress();
     }
 
-
-    if (GetOptionsDB().Get<bool>("verbose-logging")) {
-        DebugLogger() << "!!!!!!! AFTER CHECKING QUEUE AND RESOURCE PROGRESS";
-        DebugLogger() << objects.Dump();
-    }
+    TraceLogger() << "!!!!!!! AFTER CHECKING QUEUE AND RESOURCE PROGRESS";
+    TraceLogger() << objects.Dump();
 
     // execute turn events implemented as Python scripts
     ExecuteScriptedTurnEvents();
@@ -3026,10 +3013,8 @@ void ServerApp::PostCombatProcessTurns() {
     // they are created.
     m_universe.ApplyMeterEffectsAndUpdateMeters(false);
 
-    if (GetOptionsDB().Get<bool>("verbose-logging")) {
-        DebugLogger() << "!!!!!!! AFTER UPDATING METERS OF ALL OBJECTS";
-        DebugLogger() << objects.Dump();
-    }
+    TraceLogger() << "!!!!!!! AFTER UPDATING METERS OF ALL OBJECTS";
+    TraceLogger() << objects.Dump();
 
     // Population growth or loss, resource current meter growth, etc.
     for (std::shared_ptr<UniverseObject> obj : objects) {
@@ -3037,11 +3022,8 @@ void ServerApp::PostCombatProcessTurns() {
         obj->ClampMeters();  // ensures growth doesn't leave meters over MAX.  should otherwise be redundant with ClampMeters() in Universe::ApplyMeterEffectsAndUpdateMeters()
     }
 
-
-    if (GetOptionsDB().Get<bool>("verbose-logging")) {
-        DebugLogger() << "!!!!!!!!!!!!!!!!!!!!!!AFTER GROWTH AND CLAMPING";
-        DebugLogger() << objects.Dump();
-    }
+    TraceLogger() << "!!!!!!!!!!!!!!!!!!!!!!AFTER GROWTH AND CLAMPING";
+    TraceLogger() << objects.Dump();
 
     // store initial values of meters for this turn.
     m_universe.BackPropagateObjectMeters();
@@ -3075,10 +3057,8 @@ void ServerApp::PostCombatProcessTurns() {
     // update empire-visibility filtered graphs after visiblity update
     m_universe.UpdateEmpireVisibilityFilteredSystemGraphs();
 
-    if (GetOptionsDB().Get<bool>("verbose-logging")) {
-        DebugLogger() << "!!!!!!!!!!!!!!!!!!!!!!AFTER TURN PROCESSING POP GROWTH PRODCUTION RESEARCH";
-        DebugLogger() << objects.Dump();
-    }
+    TraceLogger() << "!!!!!!!!!!!!!!!!!!!!!!AFTER TURN PROCESSING POP GROWTH PRODCUTION RESEARCH";
+    TraceLogger() << objects.Dump();
 
     // this has to be here for the sitreps it creates to be in the right turn
     CheckForEmpireElimination();

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -29,7 +29,7 @@ class CombatLogManager;
 CombatLogManager&   GetCombatLogManager();
 
 namespace {
-    CreateThreadedLogger(FSM);
+    DeclareThreadSafeLogger(FSM);
 
     void SendMessageToAllPlayers(const Message& message) {
         ServerApp* server = ServerApp::GetApp();

--- a/universe/Building.cpp
+++ b/universe/Building.cpp
@@ -330,7 +330,7 @@ BuildingTypeManager::BuildingTypeManager() {
     }
 
     TraceLogger() << "Building Types:";
-    for (const std::map<const std::string, BuildingType*>::value_type& entry : m_building_types) {
+    for (const auto& entry : m_building_types) {
         TraceLogger() << " ... " << entry.first;
     }
 

--- a/universe/Building.cpp
+++ b/universe/Building.cpp
@@ -320,9 +320,7 @@ BuildingTypeManager::BuildingTypeManager() {
     if (s_instance)
         throw std::runtime_error("Attempted to create more than one BuildingTypeManager.");
 
-    if (GetOptionsDB().Get<bool>("verbose-logging")) {
-        DebugLogger() << "BuildingTypeManager::BuildingTypeManager() about to parse buildings.";
-    }
+    TraceLogger() << "BuildingTypeManager::BuildingTypeManager() about to parse buildings.";
 
     try {
         parse::buildings(m_building_types);
@@ -331,11 +329,9 @@ BuildingTypeManager::BuildingTypeManager() {
         throw e;
     }
 
-    if (GetOptionsDB().Get<bool>("verbose-logging")) {
-        DebugLogger() << "Building Types:";
-        for (const std::map<const std::string, BuildingType*>::value_type& entry : m_building_types) {
-            DebugLogger() << " ... " << entry.first;
-        }
+    TraceLogger() << "Building Types:";
+    for (const std::map<const std::string, BuildingType*>::value_type& entry : m_building_types) {
+        TraceLogger() << " ... " << entry.first;
     }
 
     // Only update the global pointer on sucessful construction.

--- a/universe/Effect.cpp
+++ b/universe/Effect.cpp
@@ -367,10 +367,10 @@ void SetMeter::Execute(const TargetsCauses& targets_causes, AccountingMap* accou
         TargetSet                           targets               = targets_and_cause.target_set;
 
 
-        DebugLogger(effects) << "\n\nExecute SetMeter effect: \n" << Dump();
-        DebugLogger(effects) << "SetMeter execute targets before: ";
+        TraceLogger(effects) << "\n\nExecute SetMeter effect: \n" << Dump();
+        TraceLogger(effects) << "SetMeter execute targets before: ";
         for (std::shared_ptr<UniverseObject> target : targets)
-            DebugLogger(effects) << " ... " << target->Dump();
+            TraceLogger(effects) << " ... " << target->Dump();
 
         if (!accounting_map) {
             // without accounting, can do default batch execute
@@ -416,9 +416,9 @@ void SetMeter::Execute(const TargetsCauses& targets_causes, AccountingMap* accou
             }
         }
 
-        DebugLogger(effects) << "SetMeter execute targets after: ";
+        TraceLogger(effects) << "SetMeter execute targets after: ";
         for (std::shared_ptr<UniverseObject> target : targets)
-            DebugLogger(effects) << " ... " << target->Dump();
+            TraceLogger(effects) << " ... " << target->Dump();
     }
 }
 
@@ -582,16 +582,16 @@ void SetShipPartMeter::Execute(const TargetsCauses& targets_causes, AccountingMa
         const TargetsAndCause&              targets_and_cause     = targets_entry.second;
         TargetSet                           targets               = targets_and_cause.target_set;
 
-        DebugLogger(effects) << "\n\nExecute SetShipPartMeter effect: \n" << Dump();
-        DebugLogger(effects) << "SetShipPartMeter execute targets before: ";
+        TraceLogger(effects) << "\n\nExecute SetShipPartMeter effect: \n" << Dump();
+        TraceLogger(effects) << "SetShipPartMeter execute targets before: ";
         for (std::shared_ptr<UniverseObject> target : targets)
-            DebugLogger(effects) << " ... " << target->Dump();
+            TraceLogger(effects) << " ... " << target->Dump();
 
         Execute(source_context, targets);
 
-        DebugLogger(effects) << "SetShipPartMeter execute targets after: ";
+        TraceLogger(effects) << "SetShipPartMeter execute targets after: ";
         for (std::shared_ptr<UniverseObject> target : targets)
-            DebugLogger(effects) << " ... " << target->Dump();
+            TraceLogger(effects) << " ... " << target->Dump();
     }
 }
 

--- a/universe/Effect.cpp
+++ b/universe/Effect.cpp
@@ -30,7 +30,7 @@
 #include <iterator>
 
 namespace {
-    CreateThreadedLogger(effects);
+    DeclareThreadSafeLogger(effects);
 }
 
 using boost::io::str;

--- a/universe/Effect.cpp
+++ b/universe/Effect.cpp
@@ -29,6 +29,9 @@
 #include <cctype>
 #include <iterator>
 
+namespace {
+    CreateThreadedLogger(effects);
+}
 
 using boost::io::str;
 
@@ -351,8 +354,6 @@ void SetMeter::Execute(const TargetsCauses& targets_causes, AccountingMap* accou
                        bool only_meter_effects, bool only_appearance_effects,
                        bool include_empire_meter_effects, bool only_generate_sitrep_effects) const
 {
-    bool log_verbose = GetOptionsDB().Get<bool>("verbose-logging");
-
     if (only_appearance_effects || only_generate_sitrep_effects)
         return;
 
@@ -365,15 +366,17 @@ void SetMeter::Execute(const TargetsCauses& targets_causes, AccountingMap* accou
         const TargetsAndCause&              targets_and_cause     = targets_entry.second;
         TargetSet                           targets               = targets_and_cause.target_set;
 
-        if (log_verbose) {
-            DebugLogger() << "\n\nExecute SetMeter effect: \n" << Dump();
-            DebugLogger() << "SetMeter execute targets before: ";
+        DebugLogger(effects) << [&targets, this]() {
+            std::stringstream ss;
+            ss << "\n\nExecute SetMeter effect: \n" << Dump();
+            ss << "SetMeter execute targets before: ";
             for (std::shared_ptr<UniverseObject> target : targets)
-                DebugLogger() << " ... " << target->Dump();
-        }
+                ss << " ... " << target->Dump();
+            return ss.str();
+        }();
 
-        if (!accounting_map && !log_verbose) {
-            // without accounting and without verbose logging, can do default batch execute
+        if (!accounting_map) {
+            // without accounting, can do default batch execute
             Execute(source_context, targets);
 
         } else if (!accounting_map) {
@@ -416,12 +419,14 @@ void SetMeter::Execute(const TargetsCauses& targets_causes, AccountingMap* accou
             }
         }
 
-        if (log_verbose) {
-            DebugLogger() << "SetMeter execute targets after: ";
+        DebugLogger(effects) << [&targets]() {
+            std::stringstream ss;
+            ss << "SetMeter execute targets after: ";
             for (std::shared_ptr<UniverseObject> target : targets) {
-                DebugLogger() << " ... " << target->Dump();
+                ss << " ... " << target->Dump();
             }
-        }
+            return ss.str();
+        }();
     }
 }
 
@@ -573,8 +578,6 @@ void SetShipPartMeter::Execute(const TargetsCauses& targets_causes, AccountingMa
                                bool only_meter_effects, bool only_appearance_effects,
                                bool include_empire_meter_effects, bool only_generate_sitrep_effects) const
 {
-    bool log_verbose = GetOptionsDB().Get<bool>("verbose-logging");
-
     if (only_appearance_effects || only_generate_sitrep_effects)
         return;
 
@@ -587,20 +590,24 @@ void SetShipPartMeter::Execute(const TargetsCauses& targets_causes, AccountingMa
         const TargetsAndCause&              targets_and_cause     = targets_entry.second;
         TargetSet                           targets               = targets_and_cause.target_set;
 
-        if (log_verbose) {
-            DebugLogger() << "\n\nExecute SetShipPartMeter effect: \n" << Dump();
-            DebugLogger() << "SetShipPartMeter execute targets before: ";
+        DebugLogger(effects) << [&targets, this]() {
+            std::stringstream ss;
+            ss << "\n\nExecute SetShipPartMeter effect: \n" << Dump();
+            ss << "SetShipPartMeter execute targets before: ";
             for (std::shared_ptr<UniverseObject> target : targets)
-                DebugLogger() << " ... " << target->Dump();
-        }
+                ss << " ... " << target->Dump();
+            return ss.str();
+        }();
 
         Execute(source_context, targets);
 
-        if (log_verbose) {
-            DebugLogger() << "SetShipPartMeter execute targets after: ";
+        DebugLogger(effects) << [&targets, this]() {
+            std::stringstream ss;
+            ss  << "SetShipPartMeter execute targets after: ";
             for (std::shared_ptr<UniverseObject> target : targets)
-                DebugLogger() << " ... " << target->Dump();
-        }
+               ss << " ... " << target->Dump();
+            return ss.str();
+        }();
     }
 }
 

--- a/universe/Effect.cpp
+++ b/universe/Effect.cpp
@@ -366,14 +366,11 @@ void SetMeter::Execute(const TargetsCauses& targets_causes, AccountingMap* accou
         const TargetsAndCause&              targets_and_cause     = targets_entry.second;
         TargetSet                           targets               = targets_and_cause.target_set;
 
-        DebugLogger(effects) << [&targets, this]() {
-            std::stringstream ss;
-            ss << "\n\nExecute SetMeter effect: \n" << Dump();
-            ss << "SetMeter execute targets before: ";
-            for (std::shared_ptr<UniverseObject> target : targets)
-                ss << " ... " << target->Dump();
-            return ss.str();
-        }();
+
+        DebugLogger(effects) << "\n\nExecute SetMeter effect: \n" << Dump();
+        DebugLogger(effects) << "SetMeter execute targets before: ";
+        for (std::shared_ptr<UniverseObject> target : targets)
+            DebugLogger(effects) << " ... " << target->Dump();
 
         if (!accounting_map) {
             // without accounting, can do default batch execute
@@ -419,14 +416,9 @@ void SetMeter::Execute(const TargetsCauses& targets_causes, AccountingMap* accou
             }
         }
 
-        DebugLogger(effects) << [&targets]() {
-            std::stringstream ss;
-            ss << "SetMeter execute targets after: ";
-            for (std::shared_ptr<UniverseObject> target : targets) {
-                ss << " ... " << target->Dump();
-            }
-            return ss.str();
-        }();
+        DebugLogger(effects) << "SetMeter execute targets after: ";
+        for (std::shared_ptr<UniverseObject> target : targets)
+            DebugLogger(effects) << " ... " << target->Dump();
     }
 }
 
@@ -590,24 +582,16 @@ void SetShipPartMeter::Execute(const TargetsCauses& targets_causes, AccountingMa
         const TargetsAndCause&              targets_and_cause     = targets_entry.second;
         TargetSet                           targets               = targets_and_cause.target_set;
 
-        DebugLogger(effects) << [&targets, this]() {
-            std::stringstream ss;
-            ss << "\n\nExecute SetShipPartMeter effect: \n" << Dump();
-            ss << "SetShipPartMeter execute targets before: ";
-            for (std::shared_ptr<UniverseObject> target : targets)
-                ss << " ... " << target->Dump();
-            return ss.str();
-        }();
+        DebugLogger(effects) << "\n\nExecute SetShipPartMeter effect: \n" << Dump();
+        DebugLogger(effects) << "SetShipPartMeter execute targets before: ";
+        for (std::shared_ptr<UniverseObject> target : targets)
+            DebugLogger(effects) << " ... " << target->Dump();
 
         Execute(source_context, targets);
 
-        DebugLogger(effects) << [&targets, this]() {
-            std::stringstream ss;
-            ss  << "SetShipPartMeter execute targets after: ";
-            for (std::shared_ptr<UniverseObject> target : targets)
-               ss << " ... " << target->Dump();
-            return ss.str();
-        }();
+        DebugLogger(effects) << "SetShipPartMeter execute targets after: ";
+        for (std::shared_ptr<UniverseObject> target : targets)
+            DebugLogger(effects) << " ... " << target->Dump();
     }
 }
 

--- a/universe/Encyclopedia.cpp
+++ b/universe/Encyclopedia.cpp
@@ -22,7 +22,7 @@ Encyclopedia::Encyclopedia() :
     }
 
     TraceLogger() << "(Category) Encyclopedia Articles:";
-    for (std::map<std::string, std::vector<EncyclopediaArticle>>::value_type& entry : articles) {
+    for (const auto& entry : articles) {
         const std::string& category = entry.first;
         for (const EncyclopediaArticle& article : entry.second)
         { TraceLogger() << "(" << category << ") : " << article.name; }

--- a/universe/Encyclopedia.cpp
+++ b/universe/Encyclopedia.cpp
@@ -21,12 +21,10 @@ Encyclopedia::Encyclopedia() :
         throw e;
     }
 
-    if (GetOptionsDB().Get<bool>("verbose-logging")) {
-        DebugLogger() << "(Category) Encyclopedia Articles:";
-        for (std::map<std::string, std::vector<EncyclopediaArticle>>::value_type& entry : articles) {
-            const std::string& category = entry.first;
-            for (const EncyclopediaArticle& article : entry.second)
-            { DebugLogger() << "(" << category << ") : " << article.name; }
-        }
+    TraceLogger() << "(Category) Encyclopedia Articles:";
+    for (std::map<std::string, std::vector<EncyclopediaArticle>>::value_type& entry : articles) {
+        const std::string& category = entry.first;
+        for (const EncyclopediaArticle& article : entry.second)
+        { TraceLogger() << "(" << category << ") : " << article.name; }
     }
 }

--- a/universe/Field.cpp
+++ b/universe/Field.cpp
@@ -236,9 +236,8 @@ FieldTypeManager::FieldTypeManager() {
     }
 
     TraceLogger() << "Field Types:";
-    for (const std::map<std::string, FieldType*>::value_type& entry : *this) {
+    for (const auto& entry : *this)
         TraceLogger() << " ... " << entry.first;
-    }
 
     // Only update the global pointer on sucessful construction.
     s_instance = this;

--- a/universe/Field.cpp
+++ b/universe/Field.cpp
@@ -235,11 +235,9 @@ FieldTypeManager::FieldTypeManager() {
         throw e;
     }
 
-    if (GetOptionsDB().Get<bool>("verbose-logging")) {
-        DebugLogger() << "Field Types:";
-        for (const std::map<std::string, FieldType*>::value_type& entry : *this) {
-            DebugLogger() << " ... " << entry.first;
-        }
+    TraceLogger() << "Field Types:";
+    for (const std::map<std::string, FieldType*>::value_type& entry : *this) {
+        TraceLogger() << " ... " << entry.first;
     }
 
     // Only update the global pointer on sucessful construction.

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -123,7 +123,7 @@ PartTypeManager::PartTypeManager() {
     }
 
     TraceLogger() << "Part Types:";
-    for (const std::map<std::string, PartType*>::value_type& entry : m_parts) {
+    for (const auto& entry : m_parts) {
         const PartType* p = entry.second;
         TraceLogger() << " ... " << p->Name() << " class: " << p->Class();
     }
@@ -482,7 +482,7 @@ HullTypeManager::HullTypeManager() {
     }
 
     TraceLogger() << "Hull Types:";
-    for (const std::map<std::string, HullType*>::value_type& entry : m_hulls) {
+    for (const auto& entry : m_hulls) {
         const HullType* h = entry.second;
         TraceLogger() << " ... " << h->Name();
     }
@@ -1072,12 +1072,12 @@ PredefinedShipDesignManager::PredefinedShipDesignManager() {
     }
 
     TraceLogger() << "Predefined Ship Designs:";
-    for (const std::map<std::string, ShipDesign*>::value_type& entry : m_ship_designs) {
+    for (const auto& entry : m_ship_designs) {
         const ShipDesign* d = entry.second;
         TraceLogger() << " ... " << d->Name();
     }
     TraceLogger() << "Monster Ship Designs:";
-    for (const std::map<std::string, ShipDesign*>::value_type& entry : m_monster_designs) {
+    for (const auto& entry : m_monster_designs) {
         const ShipDesign* d = entry.second;
         TraceLogger() << " ... " << d->Name();
     }

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -122,12 +122,10 @@ PartTypeManager::PartTypeManager() {
         throw;
     }
 
-    if (GetOptionsDB().Get<bool>("verbose-logging")) {
-        DebugLogger() << "Part Types:";
-        for (const std::map<std::string, PartType*>::value_type& entry : m_parts) {
-            const PartType* p = entry.second;
-            DebugLogger() << " ... " << p->Name() << " class: " << p->Class();
-        }
+    TraceLogger() << "Part Types:";
+    for (const std::map<std::string, PartType*>::value_type& entry : m_parts) {
+        const PartType* p = entry.second;
+        TraceLogger() << " ... " << p->Name() << " class: " << p->Class();
     }
 
     // Only update the global pointer on sucessful construction.
@@ -483,12 +481,10 @@ HullTypeManager::HullTypeManager() {
         throw;
     }
 
-    if (GetOptionsDB().Get<bool>("verbose-logging")) {
-        DebugLogger() << "Hull Types:";
-        for (const std::map<std::string, HullType*>::value_type& entry : m_hulls) {
-            const HullType* h = entry.second;
-            DebugLogger() << " ... " << h->Name();
-        }
+    TraceLogger() << "Hull Types:";
+    for (const std::map<std::string, HullType*>::value_type& entry : m_hulls) {
+        const HullType* h = entry.second;
+        TraceLogger() << " ... " << h->Name();
     }
 
     // Only update the global pointer on sucessful construction.
@@ -1075,17 +1071,15 @@ PredefinedShipDesignManager::PredefinedShipDesignManager() {
         throw;
     }
 
-    if (GetOptionsDB().Get<bool>("verbose-logging")) {
-        DebugLogger() << "Predefined Ship Designs:";
-        for (const std::map<std::string, ShipDesign*>::value_type& entry : m_ship_designs) {
-            const ShipDesign* d = entry.second;
-            DebugLogger() << " ... " << d->Name();
-        }
-        DebugLogger() << "Monster Ship Designs:";
-        for (const std::map<std::string, ShipDesign*>::value_type& entry : m_monster_designs) {
-            const ShipDesign* d = entry.second;
-            DebugLogger() << " ... " << d->Name();
-        }
+    TraceLogger() << "Predefined Ship Designs:";
+    for (const std::map<std::string, ShipDesign*>::value_type& entry : m_ship_designs) {
+        const ShipDesign* d = entry.second;
+        TraceLogger() << " ... " << d->Name();
+    }
+    TraceLogger() << "Monster Ship Designs:";
+    for (const std::map<std::string, ShipDesign*>::value_type& entry : m_monster_designs) {
+        const ShipDesign* d = entry.second;
+        TraceLogger() << " ... " << d->Name();
     }
 
     // Only update the global pointer on sucessful construction.

--- a/universe/Special.cpp
+++ b/universe/Special.cpp
@@ -24,9 +24,8 @@ namespace {
             }
 
             TraceLogger() << "Specials:";
-            for (const std::map<std::string, Special*>::value_type& entry : m_specials) {
+            for (const auto& entry : m_specials)
                 TraceLogger() << " ... " << entry.first;
-            }
         }
         ~SpecialManager() {
             for (std::map<std::string, Special*>::value_type& entry : m_specials) {

--- a/universe/Special.cpp
+++ b/universe/Special.cpp
@@ -23,11 +23,9 @@ namespace {
                 throw e;
             }
 
-            if (GetOptionsDB().Get<bool>("verbose-logging")) {
-                DebugLogger() << "Specials:";
-                for (const std::map<std::string, Special*>::value_type& entry : m_specials) {
-                    DebugLogger() << " ... " << entry.first;
-                }
+            TraceLogger() << "Specials:";
+            for (const std::map<std::string, Special*>::value_type& entry : m_specials) {
+                TraceLogger() << " ... " << entry.first;
             }
         }
         ~SpecialManager() {

--- a/universe/Species.cpp
+++ b/universe/Species.cpp
@@ -330,7 +330,7 @@ SpeciesManager::SpeciesManager() {
     }
 
     TraceLogger() << "Species:";
-    for (const std::map<std::string, Species*>::value_type& entry : m_species) {
+    for (const auto& entry : m_species) {
         const Species* s = entry.second;
         TraceLogger() << " ... " << s->Name() << "  \t" <<
             (s->Playable() ?        "Playable " : "         ") <<

--- a/universe/Species.cpp
+++ b/universe/Species.cpp
@@ -329,16 +329,14 @@ SpeciesManager::SpeciesManager() {
         throw e;
     }
 
-    if (GetOptionsDB().Get<bool>("verbose-logging")) {
-        DebugLogger() << "Species:";
-        for (const std::map<std::string, Species*>::value_type& entry : m_species) {
-            const Species* s = entry.second;
-            DebugLogger() << " ... " << s->Name() << "  \t" <<
-                (s->Playable() ?        "Playable " : "         ") <<
-                (s->Native() ?          "Native " : "       ") <<
-                (s->CanProduceShips() ? "CanProduceShips " : "                ") <<
-                (s->CanColonize() ?     "CanColonize " : "            ");
-        }
+    TraceLogger() << "Species:";
+    for (const std::map<std::string, Species*>::value_type& entry : m_species) {
+        const Species* s = entry.second;
+        TraceLogger() << " ... " << s->Name() << "  \t" <<
+            (s->Playable() ?        "Playable " : "         ") <<
+            (s->Native() ?          "Native " : "       ") <<
+            (s->CanProduceShips() ? "CanProduceShips " : "                ") <<
+            (s->CanColonize() ?     "CanColonize " : "            ");
     }
 
     // Only update the global pointer on sucessful construction.

--- a/universe/System.cpp
+++ b/universe/System.cpp
@@ -479,8 +479,7 @@ void System::AddStarlane(int id) {
     if (!HasStarlaneTo(id) && id != this->ID()) {
         m_starlanes_wormholes[id] = false;
         StateChangedSignal();
-        if (GetOptionsDB().Get<bool>("verbose-logging"))
-            DebugLogger() << "Added starlane from system " << this->Name() << " (" << this->ID() << ") system " << id;
+        TraceLogger() << "Added starlane from system " << this->Name() << " (" << this->ID() << ") system " << id;
     }
 }
 

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -691,9 +691,9 @@ void Universe::UpdateMeterEstimatesImpl(const std::vector<int>& objects_vec) {
         }
     }
 
-    DebugLogger(effects) << "UpdateMeterEstimatesImpl after resetting meters objects:";
+    TraceLogger(effects) << "UpdateMeterEstimatesImpl after resetting meters objects:";
     for (std::shared_ptr<UniverseObject> obj : object_ptrs)
-            DebugLogger(effects) << obj->Dump();
+            TraceLogger(effects) << obj->Dump();
 
     // cache all activation and scoping condition results before applying Effects, since the application of
     // these Effects may affect the activation and scoping evaluations
@@ -703,9 +703,9 @@ void Universe::UpdateMeterEstimatesImpl(const std::vector<int>& objects_vec) {
     // Apply and record effect meter adjustments
     ExecuteEffects(targets_causes, do_accounting, true, false, false, false);
 
-    DebugLogger(effects) << "UpdateMeterEstimatesImpl after executing effects objects:";
+    TraceLogger(effects) << "UpdateMeterEstimatesImpl after executing effects objects:";
     for (std::shared_ptr<UniverseObject> obj : object_ptrs)
-        DebugLogger(effects) << obj->Dump();
+        TraceLogger(effects) << obj->Dump();
 
     // Apply known discrepancies between expected and calculated meter maxes at start of turn.  This
     // accounts for the unknown effects on the meter, and brings the estimate in line with the actual
@@ -729,7 +729,7 @@ void Universe::UpdateMeterEstimatesImpl(const std::vector<int>& objects_vec) {
                 Meter* meter = obj->GetMeter(type);
 
                 if (meter) {
-                    DebugLogger(effects) << "object " << obj_id << " has meter " << type
+                    TraceLogger(effects) << "object " << obj_id << " has meter " << type
                                          << ": discrepancy: " << discrepancy << " and : " << meter->Dump();
 
                     meter->AddToCurrent(discrepancy);
@@ -753,9 +753,9 @@ void Universe::UpdateMeterEstimatesImpl(const std::vector<int>& objects_vec) {
         obj->ClampMeters();
     }
 
-    DebugLogger(effects) << "UpdateMeterEstimatesImpl after discrepancies and clamping objects:";
+    TraceLogger(effects) << "UpdateMeterEstimatesImpl after discrepancies and clamping objects:";
     for (std::shared_ptr<UniverseObject> obj : object_ptrs)
-        DebugLogger(effects) << obj->Dump();
+        TraceLogger(effects) << obj->Dump();
 
 }
 
@@ -964,7 +964,7 @@ namespace {
     {
         ScopedTimer timer("StoreTargetsAndCausesOfEffectsGroups");
 
-        DebugLogger(effects) << GenerateReport();
+        TraceLogger(effects) << GenerateReport();
 
         // get objects matched by scope
         const Condition::ConditionBase* scope = m_effects_group->Scope();
@@ -1042,9 +1042,9 @@ void Universe::GetEffectsAndTargets(Effect::TargetsCauses& targets_causes,
     // transfer target objects from input vector to a set
     Effect::TargetSet all_potential_targets = m_objects.FindObjects(target_objects);
 
-    DebugLogger(effects) << "target objects:";
+    TraceLogger(effects) << "target objects:";
     for (std::shared_ptr<UniverseObject> obj : all_potential_targets)
-        DebugLogger(effects) << obj->Dump();
+        TraceLogger(effects) << obj->Dump();
 
     // caching space for each source object's results of finding matches for
     // scope conditions. Index INVALID_OBJECT_ID stores results for
@@ -1073,7 +1073,7 @@ void Universe::GetEffectsAndTargets(Effect::TargetsCauses& targets_causes,
     eval_timer.restart();
 
     // 1) EffectsGroups from Species
-    DebugLogger(effects) << "Universe::GetEffectsAndTargets for SPECIES";
+    TraceLogger(effects) << "Universe::GetEffectsAndTargets for SPECIES";
     type_timer.restart();
 
     // find each species planets in single pass, maintaining object map order per-species
@@ -1133,7 +1133,7 @@ void Universe::GetEffectsAndTargets(Effect::TargetsCauses& targets_causes,
     }
 
     // 2) EffectsGroups from Specials
-    DebugLogger(effects) << "Universe::GetEffectsAndTargets for SPECIALS";
+    TraceLogger(effects) << "Universe::GetEffectsAndTargets for SPECIALS";
     type_timer.restart();
     std::map<std::string, std::vector<std::shared_ptr<const UniverseObject>>> specials_objects;
     // determine objects with specials in a single pass
@@ -1172,7 +1172,7 @@ void Universe::GetEffectsAndTargets(Effect::TargetsCauses& targets_causes,
     double special_time = type_timer.elapsed();
 
     // 3) EffectsGroups from Techs
-    DebugLogger(effects) << "Universe::GetEffectsAndTargets for TECHS";
+    TraceLogger(effects) << "Universe::GetEffectsAndTargets for TECHS";
     type_timer.restart();
     std::list<std::vector<std::shared_ptr<const UniverseObject>>> tech_sources;
     for (std::map<int, Empire*>::value_type& entry : Empires()) {
@@ -1200,7 +1200,7 @@ void Universe::GetEffectsAndTargets(Effect::TargetsCauses& targets_causes,
     double tech_time = type_timer.elapsed();
 
     // 4) EffectsGroups from Buildings
-    DebugLogger(effects) << "Universe::GetEffectsAndTargets for BUILDINGS";
+    TraceLogger(effects) << "Universe::GetEffectsAndTargets for BUILDINGS";
     type_timer.restart();
 
     // determine buildings of each type in a single pass
@@ -1241,7 +1241,7 @@ void Universe::GetEffectsAndTargets(Effect::TargetsCauses& targets_causes,
     double building_time = type_timer.elapsed();
 
     // 5) EffectsGroups from Ship Hull and Ship Parts
-    DebugLogger(effects) << "Universe::GetEffectsAndTargets for SHIPS hulls and parts";
+    TraceLogger(effects) << "Universe::GetEffectsAndTargets for SHIPS hulls and parts";
     type_timer.restart();
     // determine ship hulls and parts of each type in a single pass
     // the same ship might be added multiple times if it contains the part multiple times
@@ -1317,7 +1317,7 @@ void Universe::GetEffectsAndTargets(Effect::TargetsCauses& targets_causes,
     double ships_time = type_timer.elapsed();
 
     // 6) EffectsGroups from Fields
-    DebugLogger(effects) << "Universe::GetEffectsAndTargets for FIELDS";
+    TraceLogger(effects) << "Universe::GetEffectsAndTargets for FIELDS";
     type_timer.restart();
     // determine fields of each type in a single pass
     std::map<std::string, std::vector<std::shared_ptr<const UniverseObject>>> fields_by_type;
@@ -1474,7 +1474,7 @@ void Universe::ExecuteEffects(const Effect::TargetsCauses& targets_causes,
             if (group_targets_causes.empty())
                 continue;
 
-            DebugLogger(effects) << "\n\n * * * * * * * * * * * (new effects group log entry)";
+            TraceLogger(effects) << "\n\n * * * * * * * * * * * (new effects group log entry)";
 
             // execute Effects in the EffectsGroup
             effects_group->Execute(group_targets_causes,

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -691,14 +691,9 @@ void Universe::UpdateMeterEstimatesImpl(const std::vector<int>& objects_vec) {
         }
     }
 
-    DebugLogger(effects) << [&object_ptrs]() {
-        std::stringstream ss;
-        ss << "UpdateMeterEstimatesImpl after resetting meters objects:";
-        for (std::shared_ptr<UniverseObject> obj : object_ptrs) {
-            ss << obj->Dump();
-        }
-        return ss.str();
-    }();
+    DebugLogger(effects) << "UpdateMeterEstimatesImpl after resetting meters objects:";
+    for (std::shared_ptr<UniverseObject> obj : object_ptrs)
+            DebugLogger(effects) << obj->Dump();
 
     // cache all activation and scoping condition results before applying Effects, since the application of
     // these Effects may affect the activation and scoping evaluations
@@ -708,14 +703,9 @@ void Universe::UpdateMeterEstimatesImpl(const std::vector<int>& objects_vec) {
     // Apply and record effect meter adjustments
     ExecuteEffects(targets_causes, do_accounting, true, false, false, false);
 
-    DebugLogger(effects) << [&object_ptrs]() {
-        std::stringstream ss;
-        ss << "UpdateMeterEstimatesImpl after executing effects objects:";
-        for (std::shared_ptr<UniverseObject> obj : object_ptrs) {
-            ss << obj->Dump();
-        }
-        return ss.str();
-    }();
+    DebugLogger(effects) << "UpdateMeterEstimatesImpl after executing effects objects:";
+    for (std::shared_ptr<UniverseObject> obj : object_ptrs)
+        DebugLogger(effects) << obj->Dump();
 
     // Apply known discrepancies between expected and calculated meter maxes at start of turn.  This
     // accounts for the unknown effects on the meter, and brings the estimate in line with the actual
@@ -740,7 +730,7 @@ void Universe::UpdateMeterEstimatesImpl(const std::vector<int>& objects_vec) {
 
                 if (meter) {
                     DebugLogger(effects) << "object " << obj_id << " has meter " << type
-                                          << ": discrepancy: " << discrepancy << " and : " << meter->Dump();
+                                         << ": discrepancy: " << discrepancy << " and : " << meter->Dump();
 
                     meter->AddToCurrent(discrepancy);
 
@@ -763,14 +753,9 @@ void Universe::UpdateMeterEstimatesImpl(const std::vector<int>& objects_vec) {
         obj->ClampMeters();
     }
 
-    DebugLogger(effects) << [&object_ptrs]() {
-        std::stringstream ss;
-        ss << "UpdateMeterEstimatesImpl after discrepancies and clamping objects:";
-        for (std::shared_ptr<UniverseObject> obj : object_ptrs) {
-            ss << obj->Dump();
-        }
-        return ss.str();
-    }();
+    DebugLogger(effects) << "UpdateMeterEstimatesImpl after discrepancies and clamping objects:";
+    for (std::shared_ptr<UniverseObject> obj : object_ptrs)
+        DebugLogger(effects) << obj->Dump();
 
 }
 
@@ -1057,15 +1042,9 @@ void Universe::GetEffectsAndTargets(Effect::TargetsCauses& targets_causes,
     // transfer target objects from input vector to a set
     Effect::TargetSet all_potential_targets = m_objects.FindObjects(target_objects);
 
-    DebugLogger(effects) << [&all_potential_targets]() {
-        std::stringstream ss;
-        ss << "target objects:";
-        for (std::shared_ptr<UniverseObject> obj : all_potential_targets) {
-            ss << obj->Dump();
-        }
-        return ss.str();
-    }();
-
+    DebugLogger(effects) << "target objects:";
+    for (std::shared_ptr<UniverseObject> obj : all_potential_targets)
+        DebugLogger(effects) << obj->Dump();
 
     // caching space for each source object's results of finding matches for
     // scope conditions. Index INVALID_OBJECT_ID stores results for

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -45,7 +45,6 @@ namespace {
     const bool ENABLE_VISIBILITY_EMPIRE_MEMORY = true;      // toggles using memory with visibility, so that empires retain knowledge of objects viewed on previous turns
 
     void AddOptions(OptionsDB& db) {
-        db.Add("verbose-logging",           UserStringNop("OPTIONS_DB_VERBOSE_LOGGING_DESC"),           false,  Validator<bool>());
         db.Add("effects-threads-ui",        UserStringNop("OPTIONS_DB_EFFECTS_THREADS_UI_DESC"),        8,      RangedValidator<int>(1, 32));
         db.Add("effects-threads-ai",        UserStringNop("OPTIONS_DB_EFFECTS_THREADS_AI_DESC"),        2,      RangedValidator<int>(1, 32));
         db.Add("effects-threads-server",    UserStringNop("OPTIONS_DB_EFFECTS_THREADS_SERVER_DESC"),    8,      RangedValidator<int>(1, 32));

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -46,7 +46,6 @@ namespace {
 
     void AddOptions(OptionsDB& db) {
         db.Add("verbose-logging",           UserStringNop("OPTIONS_DB_VERBOSE_LOGGING_DESC"),           false,  Validator<bool>());
-        db.Add("verbose-combat-logging",    UserStringNop("OPTIONS_DB_VERBOSE_COMBAT_LOGGING_DESC"),    false,  Validator<bool>());
         db.Add("effects-threads-ui",        UserStringNop("OPTIONS_DB_EFFECTS_THREADS_UI_DESC"),        8,      RangedValidator<int>(1, 32));
         db.Add("effects-threads-ai",        UserStringNop("OPTIONS_DB_EFFECTS_THREADS_AI_DESC"),        2,      RangedValidator<int>(1, 32));
         db.Add("effects-threads-server",    UserStringNop("OPTIONS_DB_EFFECTS_THREADS_SERVER_DESC"),    8,      RangedValidator<int>(1, 32));

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -951,9 +951,8 @@ namespace {
            << m_effects_group->AccountingLabel()
            << "  specific_cause: " << m_specific_cause_name
            << "  sources: ";
-        for (std::shared_ptr<const UniverseObject> obj : *m_sources) {
+        for (const auto& obj : *m_sources)
             ss << obj->Name() << " (" << std::to_string(obj->ID()) << ")  ";
-        }
         ss << ")";
         return ss.str();
     }

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -30,7 +30,7 @@
 #include <boost/timer.hpp>
 
 namespace {
-    CreateThreadedLogger(effects);
+    DeclareThreadSafeLogger(effects);
 }
 
 #if defined(_MSC_VER)

--- a/util/Logger.cpp
+++ b/util/Logger.cpp
@@ -32,6 +32,7 @@ namespace attr = boost::log::attributes;
 namespace keywords = boost::log::keywords;
 namespace sinks = boost::log::sinks;
 
+// TODO consider adding thread and process id as options
 
 namespace {
     // Create the log logger for logging of logger and logging related events.

--- a/util/Logger.h
+++ b/util/Logger.h
@@ -94,10 +94,9 @@
     TraceLogger() << "Put any streamable output here.  It will only be
                   << "computed at the trace threshold or greater.";
 
-
     The named loggers are declared with:
 
-    CreateThreadedLogger(name_of_logger);
+    DeclareThreadSafeLogger(name_of_logger);
 
     A good place for the declaration is an anonymous namespace.  It is
     idempotent, so multiple calls won't change the logging system state.  It is
@@ -215,7 +214,7 @@ using NamedThreadedLogger = boost::log::sources::severity_channel_logger_mt<
 FO_COMMON_API void ConfigureLogger(NamedThreadedLogger& logger, const std::string& name);
 
 // Place in source file to create the previously defined global logger \p name
-#define CreateThreadedLogger(name)                                      \
+#define DeclareThreadSafeLogger(name)                                   \
     BOOST_LOG_INLINE_GLOBAL_LOGGER_INIT(                                \
         FO_GLOBAL_LOGGER_NAME(name), NamedThreadedLogger)               \
     {                                                                   \
@@ -237,7 +236,7 @@ FO_COMMON_API std::vector<std::string> CreatedLoggersNames();
 // Create the default logger
 #ifndef FREEORION_WIN32
 
-CreateThreadedLogger();
+DeclareThreadSafeLogger();
 
 #else
 

--- a/util/OptionsDB.cpp
+++ b/util/OptionsDB.cpp
@@ -360,8 +360,7 @@ void OptionsDB::SetFromCommandLine(const std::vector<std::string>& args) {
                                                     "", new Validator<std::string>(), false, false, false); // don't attempt to store options that have only been specified on the command line
                 }
 
-                if (GetOptionsDB().Get<bool>("verbose-logging"))
-                    DebugLogger() << "Option \"" << option_name << "\", was specified on the command line but was not recognized.  It may not be registered yet or could be a typo.";
+                WarnLogger() << "Option \"" << option_name << "\", was specified on the command line but was not recognized.  It may not be registered yet or could be a typo.";
             } else {
                 Option& option = it->second;
                 if (option.value.empty())
@@ -475,8 +474,8 @@ void OptionsDB::SetFromXMLRecursive(const XMLElement& elem, const std::string& s
                 m_options[option_name] = Option(static_cast<char>(0), option_name, elem.Text(), elem.Text(),
                                                 "", new Validator<std::string>(), true, false, false);
             }
-            if (GetOptionsDB().Get<bool>("verbose-logging"))
-                DebugLogger() << "Option \"" << option_name << "\", was in config.xml but was not recognized.  It may not be registered yet or you may need to delete your config.xml if it is out of date.";
+
+            TraceLogger() << "Option \"" << option_name << "\", was in config.xml but was not recognized.  It may not be registered yet or you may need to delete your config.xml if it is out of date.";
             m_dirty = true;
             return;
         }

--- a/util/ScopedTimer.cpp
+++ b/util/ScopedTimer.cpp
@@ -1,6 +1,5 @@
 #include "ScopedTimer.h"
 
-#include "OptionsDB.h"
 #include "Logger.h"
 
 #include <boost/unordered_map.hpp>
@@ -30,7 +29,7 @@ public:
     }
 
     bool ShouldOutput(const std::chrono::nanoseconds & duration) {
-        return (duration >= m_threshold && (m_enable_output || GetOptionsDB().Get<bool>("verbose-logging")));
+        return ((duration >= m_threshold) && m_enable_output );
     }
 
     void FormatDuration(std::stringstream& ss, const std::chrono::nanoseconds & duration) {


### PR DESCRIPTION
### Merge Message 

Adds named loggers with individually controlled log levels.

### Motivation

There are currently several different ways to control which log messages are generated and printed in the log files
  * a command-line option --log-level that sets the log level for all log messages.
  * a verbose-combat-logging option in OptionsDB that gates logging of detailed combat mechanics and the combat log window.
  * a verbose-logging option in OptionsDB that gates combat and effects processing logging and other miscellaneous locations.
  * a compiled in option TRACE_EXECUTION used to gate logging in the networking and finite state machine (FSM) code.

  These can be configured/toggled from the following locations.

  Method | Command line | config.xml, persistent_config.xml | OptionsWnd | compiler only
  --| -- | -- | -- | --
  log-level | X | X | |
  verbose-logging | X | X | X |
  verbose-combat-logging | X | X | X |
  TRACE_EXECUTION |  |  | | X

### Goal
This PR creates a consistent system where it is easy to create/remove named loggers for specific sections of code that can be configured from the command-line, or OptionsDB or the OptionWnd at runtime.

### Usage
The default logger works the same as before.

Create a new named logger. 
```cpp
    CreateThreadedLogger(name_of_logger);
````

Create a log message.
```cpp
    ErrorLogger(name_of_logger) << "any streamable output, only computed "
                                << "at the error threshold or greater "
                                << "for the 'name_of_logger' logger.";
    WarnLogger(name_of_logger)  << "streamable output";
    InfoLogger(name_of_logger)  << "streamable output";
    DebugLogger(name_of_logger) << "streamable output";
    TraceLogger(name_of_logger) << "streamable output";
```

The `XLogger(name_of_logger) << ` is a macro that gates computation of everything to the right of the stream operator (`<<`) based on the runtime threshold of the specific logger.  So providing that all of the work assembling the log message is in functions to the right of the stream operator (`<<`) no work will be done for log messages that would not be printed in the log outputs.

(Optionallly) Set the log threshold in config.xml/persistent_config.xml
```xml
  <logging>
    <sources>
      <name_of_logger>warn</name_of_logger>
    </sources>
  </logging>
```

(Optionally) Set the log threshold from the OptionsWnd with the Other/Logging/Log threshold for individual sources/name_of_logger drop down list.

(Optionally) Override each executables defaut logger to specific log levels in  config.xml/persistent_config.xml.

```xml
  <logging>
    <execs>
      <ai>warn</ai>
      <client>debug</client>
      <server>trace</server>
    </execs>
  </logging>
```

(Optionally) Override each executables default logger to specific log levels from the OptionsWnd with the Other/Logging/Log threshold for default logger for process/<ai/client/server> drop down list.

(Optionally) Override all individual loggers of all executables log levels with the command-line/OptionsDB option

``` --log-level <error/warn/debug/info/debug/trace>```

### Changes in this PR.
The changes are in three steps: refactor `Logger` to allow names loggers, add ability to set logger thresholds from OptionsWnd, replace the various detailed loggers with the new named loggers.

### Additional Notes
- Adds a dependency on boost log_setup.
- Splits logger OptionsDB dependency into LoggerWOptionsDB so that logger is more suitable for a testing environment and doesn't need to pull in the entire OptionsDB framework.
- Moves year/month/day from each log line to the head of file to make space for more relevant information.
- OptionsDB now dumps messages about unrecognized options to the console because they are initialized during static initialization before the logger backend is configured.  I left those as is, so that this PR didn't change the intent of any log messages.  The messages should be changed as the current usage of OptionsDB no longer agrees with the expectation that all options be present and accounted for at static initialization.
