### PR TITLE
SitRep navigation for MeterType pedia links

### DIFF
--- a/UI/SitRepPanel.cpp
+++ b/UI/SitRepPanel.cpp
@@ -82,7 +82,8 @@ namespace {
                 ClientUI::GetClientUI()->ZoomToShipPart(data);
             } else if (link_type == VarText::SPECIES_TAG) {
                 ClientUI::GetClientUI()->ZoomToSpecies(data);
-
+            } else if (link_type == VarText::METER_TYPE_TAG) {
+                ClientUI::GetClientUI()->ZoomToMeterTypeArticle(data);
             } else if (link_type == TextLinker::ENCYCLOPEDIA_TAG) {
                 ClientUI::GetClientUI()->ZoomToEncyclopediaEntry(data);
             }


### PR DESCRIPTION
Adds missing navigation of MeterType links in SitReps

(preemptively adding `cherry-pick for release`, in event a new RC is done)