### PR TITLE
Fix bugs in DesignWnd hulls (un)available scrolling.

### DIFF
--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -1251,23 +1251,14 @@ void ListBox::BringRowIntoView(iterator target)
 
 void ListBox::SetFirstRowShown(iterator it)
 {
-    if (it == m_rows.end())
+    if (it == m_rows.end() && !m_rows.empty())
         return;
 
     RequirePreRender();
 
+    m_first_row_shown = it;
+
     AdjustScrolls(false);
-
-    if (!m_vscroll && m_first_row_shown == m_rows.begin())
-        return;
-
-    m_first_row_shown = m_vscroll ? it : m_rows.begin();
-
-    Y acc(0);
-    for (iterator it2 = m_rows.begin(); it2 != m_first_row_shown; ++it2)
-        acc += (*it2)->Height();
-    m_vscroll->ScrollTo(Value(acc));
-    SignalScroll(*m_vscroll, true);
 }
 
 void ListBox::SetVScrollWheelIncrement(unsigned int increment)

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -2215,6 +2215,11 @@ std::pair<bool, bool> ListBox::AddOrRemoveScrolls(
     // Remove unecessary vscroll
     if (m_vscroll && !vertical_needed) {
         vscroll_added_or_removed = true;
+
+        //Scroll back to zero
+        m_vscroll->ScrollTo(0);
+        SignalScroll(*m_vscroll, true);
+
         DeleteChild(m_vscroll);
         m_vscroll = nullptr;
     }
@@ -2244,6 +2249,13 @@ std::pair<bool, bool> ListBox::AddOrRemoveScrolls(
                               line_size, std::max(line_size, page_size));
 
         MoveChildUp(m_vscroll);
+
+        // Scroll to the correct location
+        Y acc(0);
+        for (iterator it2 = m_rows.begin(); it2 != m_first_row_shown; ++it2)
+            acc += (*it2)->Height();
+        m_vscroll->ScrollTo(Value(acc));
+        SignalScroll(*m_vscroll, true);
     }
 
     bool hscroll_added_or_removed = false;
@@ -2251,6 +2263,11 @@ std::pair<bool, bool> ListBox::AddOrRemoveScrolls(
     // Remove unecessary hscroll
     if (m_hscroll && !horizontal_needed) {
         hscroll_added_or_removed = true;
+
+        //Scroll back to zero
+        m_hscroll->ScrollTo(0);
+        SignalScroll(*m_hscroll, true);
+
         DeleteChild(m_hscroll);
         m_hscroll = nullptr;
     }

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -1583,18 +1583,27 @@ void BasesListBox::Populate() {
 
     DebugLogger() << "BasesListBox::Populate";
 
+    // make note of first visible row to preserve state
+    auto init_first_row_shown = FirstRowShown();
+    std::size_t init_first_row_offset = std::distance(begin(), init_first_row_shown);
+
     // populate list as appropriate for types of bases shown
-    if (m_showing_empty_hulls)
+    if (m_showing_empty_hulls) {
         PopulateWithEmptyHulls();
 
+        if (Empty() || init_first_row_shown == FirstRowShown() || init_first_row_offset < NumRows())
+            return;
+
+        SetFirstRowShown(begin());
+        BringRowIntoView(--end());
+    }
+
     if (m_showing_completed_designs) {
-        // make note of first visible row to preserve state
-        std::size_t first_visible_row = std::distance(begin(), FirstRowShown());
         PopulateWithCompletedDesigns();
         if (!Empty())
             BringRowIntoView(--end());
-        if (first_visible_row < NumRows())
-            BringRowIntoView(std::next(begin(), first_visible_row));
+        if (init_first_row_offset < NumRows())
+            BringRowIntoView(std::next(begin(), init_first_row_offset));
     }
 
     if (m_showing_saved_designs)


### PR DESCRIPTION
This PR fixes the UI problem described below, which I found while play testing the release candidate.

Steps to replicate starting from the DesignWnd
- display the hulls
- show both available and unavailable hulls.
- scroll to some non-zero offset
- hide both available and unavailable hulls.
- show one type of hull.

Nothing will display.  It should show the hulls that have just been toggled to show.

This PR fixes the problem by starting the vscroll at the correct position when it is added and when it is removed, not adjusting the vscroll position when the first_row_shown is changed and adjusting the offset to the hulls shown if only the last item of a type of hulls would display.

I've marked this as optional for v0.4.7, since the bug is not a crash and clicking away from the hulls list and back again is a simple and obvious workaround.