### PR TITLE
Fix bug combat log window layout initial position has incorrect offset.

### DIFF
--- a/UI/CombatReport/CombatLogWnd.cpp
+++ b/UI/CombatReport/CombatLogWnd.cpp
@@ -386,7 +386,7 @@ void CombatLogWnd::Impl::SetLog(int log_id) {
                            GetOptionsDB().Get<bool>("verbose-combat-logging");
 
     m_wnd.DeleteChildren();
-    GG::Layout* layout = new GG::DeferredLayout(m_wnd.UpperLeft().x, m_wnd.UpperLeft().y,
+    GG::Layout* layout = new GG::DeferredLayout(m_wnd.RelativeUpperLeft().x, m_wnd.RelativeUpperLeft().y,
                                                 m_wnd.Width(), m_wnd.Height(),
                                                 1, 1, ///< numrows, numcols
                                                 0, 0 ///< wnd margin, cell margin


### PR DESCRIPTION
The problem as described in the [forum](http://freeorion.org/forum/viewtopic.php?f=28&t=10512&sid=780912247a46d3c866de451b34b61eb9) and other places, is that the combat log is often draw with the incorrect offset from the upper left corner of the combat log tab wnd.

The problem is that the combat log layout is initialized with the absolute position of its parent window and it should be initialized with the relative position.

This PR fixes the problem.

This should be included in 0.4.7. RC2, since it is a small fix easily verified fix.

I marked it as cherry-pick for release so that it would be discussed.  The bug is a minor UI bug that has persisted for a while, so it is not essential for the release.  However, as the forum post indicates, it is an obvious and inconvenient bug for beginners who are more likely to use the combat log regularly.