### PR TITLE
Remove delete fleet from orders.

### DIFF
--- a/AI/AIInterface.cpp
+++ b/AI/AIInterface.cpp
@@ -605,10 +605,6 @@ namespace AIInterface {
         return 1;
     }
 
-    int IssueDeleteFleetOrder() {
-        return 0;
-    }
-
     int IssueAggressionOrder(int object_id, bool aggressive) {
         int empire_id = AIClientApp::GetApp()->EmpireID();
 

--- a/AI/AIInterface.h
+++ b/AI/AIInterface.h
@@ -332,7 +332,6 @@ namespace AIInterface {
     int IssueColonizeOrder(int ship_id, int planet_id);
     int IssueInvadeOrder(int ship_id, int planet_id);
     int IssueBombardOrder(int ship_id, int planet_id);
-    int IssueDeleteFleetOrder();
     int IssueAggressionOrder(int object_id, bool aggressive);
     int IssueGiveObjectToEmpireOrder(int object_id, int recipient_id);
 

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -276,14 +276,6 @@ namespace {
             OrderPtr(new NewFleetOrder(client_empire_id, order_fleet_names, order_fleet_ids,
                                        *systems_containing_new_fleets.begin(),
                                        order_ship_id_groups, order_ship_aggressives)));
-
-
-        // delete empty fleets from which ships may have been taken
-        for (std::shared_ptr<const Fleet> fleet : Objects().FindObjects<Fleet>(original_fleet_ids)) {
-            if (fleet && fleet->Empty())
-                HumanClientApp::GetApp()->Orders().IssueOrder(OrderPtr(
-                    new DeleteFleetOrder(client_empire_id, fleet->ID())));
-        }
     }
 
     void CreateNewFleetFromShips(const std::vector<int>& ship_ids,

--- a/util/Order.cpp
+++ b/util/Order.cpp
@@ -241,7 +241,7 @@ void NewFleetOrder::ExecuteImpl() const {
     system->FleetsInsertedSignal(created_fleets);
     system->StateChangedSignal();
 
-    // signal change to fleet states
+    // Signal changed state of modified fleets and remove any empty fleets.
     for (std::shared_ptr<Fleet> modified_fleet : modified_fleets) {
         if (!modified_fleet->Empty())
             modified_fleet->StateChangedSignal();

--- a/util/Order.cpp
+++ b/util/Order.cpp
@@ -797,44 +797,6 @@ bool BombardOrder::UndoImpl() const {
 }
 
 ////////////////////////////////////////////////
-// DeleteFleetOrder
-////////////////////////////////////////////////
-DeleteFleetOrder::DeleteFleetOrder() :
-    Order(),
-    m_fleet(-1)
-{}
-
-DeleteFleetOrder::DeleteFleetOrder(int empire, int fleet) :
-    Order(empire),
-    m_fleet(fleet)
-{}
-
-void DeleteFleetOrder::ExecuteImpl() const {
-    ValidateEmpireID();
-
-    std::shared_ptr<Fleet> fleet = GetFleet(FleetID());
-
-    if (!fleet) {
-        ErrorLogger() << "Illegal fleet id specified in fleet delete order: " << FleetID();
-        return;
-    }
-
-    if (!fleet->OwnedBy(EmpireID())) {
-        ErrorLogger() << "Empire attempted to issue deletion order to another's fleet.";
-        return;
-    }
-
-    if (!fleet->Empty())
-        return; // should be no ships to delete
-
-    std::shared_ptr<System> system = GetSystem(fleet->SystemID());
-    if (system)
-        system->Remove(fleet->ID());
-
-    GetUniverse().Destroy(FleetID());
-}
-
-////////////////////////////////////////////////
 // ChangeFocusOrder
 ////////////////////////////////////////////////
 ChangeFocusOrder::ChangeFocusOrder() :

--- a/util/Order.cpp
+++ b/util/Order.cpp
@@ -167,6 +167,7 @@ void NewFleetOrder::ExecuteImpl() const {
     std::vector<std::shared_ptr<Fleet>> created_fleets;
     created_fleets.reserve(m_ship_id_groups.size());
 
+    std::unordered_set<std::shared_ptr<Fleet>> modified_fleets;
 
     // create fleet for each group of ships
     for (int i = 0; i < static_cast<int>(m_ship_id_groups.size()); ++i) {
@@ -221,8 +222,10 @@ void NewFleetOrder::ExecuteImpl() const {
 
         // remove ships from old fleet(s) and add to new
         for (std::shared_ptr<Ship> ship : validated_ships) {
-            if (std::shared_ptr<Fleet> old_fleet = GetFleet(ship->FleetID()))
+            if (std::shared_ptr<Fleet> old_fleet = GetFleet(ship->FleetID())) {
+                modified_fleets.insert(old_fleet);
                 old_fleet->RemoveShip(ship->ID());
+            }
             ship->SetFleetID(fleet->ID());
         }
         fleet->AddShips(validated_ships_ids);
@@ -237,6 +240,19 @@ void NewFleetOrder::ExecuteImpl() const {
 
     system->FleetsInsertedSignal(created_fleets);
     system->StateChangedSignal();
+
+    // signal change to fleet states
+    for (std::shared_ptr<Fleet> modified_fleet : modified_fleets) {
+        if (!modified_fleet->Empty())
+            modified_fleet->StateChangedSignal();
+        else {
+            if (std::shared_ptr<System> system = GetSystem(modified_fleet->SystemID()))
+                system->Remove(modified_fleet->ID());
+
+            GetUniverse().Destroy(modified_fleet->ID());
+        }
+    }
+
 }
 
 ////////////////////////////////////////////////

--- a/util/Order.h
+++ b/util/Order.h
@@ -434,46 +434,6 @@ private:
 
 
 /////////////////////////////////////////////////////
-// DeleteFleetOrder
-/////////////////////////////////////////////////////
-/** The Order subclass that represents removing an existing fleet that contains
-  * no ships. This is mainly a utility order that is issued automatically by the
-  * game when the user removes all ships from a fleet. */
-class FO_COMMON_API DeleteFleetOrder : public Order {
-public:
-    /** \name Structors */ //@{
-    DeleteFleetOrder();
-
-    DeleteFleetOrder(int empire, int fleet);
-    //@}
-
-    /** \name Accessors */ //@{
-    /** Returns ID of the fleet to be deleted. */
-    int FleetID() const
-    { return m_fleet; }
-    //@}
-
-private:
-    /**
-     *  Preconditions:
-     *     - m_fleet must be the ID of a fleet owned by issuing empire
-     *     - the fleet must contain no ships
-     *
-     *  Postconditions:
-     *     - the fleet is deleted
-     */
-    //< either ExecuteServerApply or ExecuteServerRevoke is called!!!
-    void ExecuteImpl() const override;
-
-    int m_fleet;
-
-    friend class boost::serialization::access;
-    template <class Archive>
-    void serialize(Archive& ar, const unsigned int version);
-};
-
-
-/////////////////////////////////////////////////////
 // ChangeFocusOrder
 /////////////////////////////////////////////////////
 /** the Order subclass that represents changing a planet focus*/

--- a/util/SerializeOrderSet.cpp
+++ b/util/SerializeOrderSet.cpp
@@ -20,7 +20,6 @@ BOOST_CLASS_EXPORT(FleetTransferOrder)
 BOOST_CLASS_EXPORT(ColonizeOrder)
 BOOST_CLASS_EXPORT(InvadeOrder)
 BOOST_CLASS_EXPORT(BombardOrder)
-BOOST_CLASS_EXPORT(DeleteFleetOrder)
 BOOST_CLASS_EXPORT(ChangeFocusOrder)
 BOOST_CLASS_EXPORT(ResearchQueueOrder)
 BOOST_CLASS_EXPORT(ProductionQueueOrder)
@@ -104,13 +103,6 @@ void BombardOrder::serialize(Archive& ar, const unsigned int version)
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Order)
         & BOOST_SERIALIZATION_NVP(m_ship)
         & BOOST_SERIALIZATION_NVP(m_planet);
-}
-
-template <class Archive>
-void DeleteFleetOrder::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Order)
-        & BOOST_SERIALIZATION_NVP(m_fleet);
 }
 
 template <class Archive>


### PR DESCRIPTION
This PR follows #1459.

This PR changes NewFleetOrder to delete any empty fleets created by removing ships from existing fleets while creating the new fleet.  It removes the redundant code from the UI.

This PR then removes the unused DeleteFleetOrder.
