### PR TITLE
Ai fleet mission fix

### DIFF
--- a/default/python/AI/AIFleetMission.py
+++ b/default/python/AI/AIFleetMission.py
@@ -507,24 +507,17 @@ class AIFleetMission(object):
                     self.orders.append(resupply_fleet_order)
             return  # no targets
 
-        # for some targets fleet has to visit systems and therefore fleet visit them
         if self.target:
+            # for some targets fleet has to visit systems and therefore fleet visit them
             system_to_visit = self.target.get_system()
             orders_to_visit_systems = MoveUtilsAI.create_move_orders_to_system(self.fleet, system_to_visit)
             # TODO: if fleet doesn't have enough fuel to get to final target, consider resetting Mission
             for fleet_order in orders_to_visit_systems:
                 self.orders.append(fleet_order)
 
-        # if fleet is in some system = fleet.system_id >=0, then also generate system AIFleetOrders
-        if system_id >= 0 and self.target:
-            # system in where fleet is
-            system_target = System(system_id)
-            # if mission aiTarget has required system where fleet is, then generate fleet_order from this aiTarget
-            # for all targets in all mission types get required systems to visit
-            if system_target == self.target.get_system():
-                # from target required to visit get fleet orders to accomplish target
-                fleet_order = self._get_fleet_order_from_target(self.type, self.target)
-                self.orders.append(fleet_order)
+            # also generate appropriate final orders
+            fleet_order = self._get_fleet_order_from_target(self.type, self.target)
+            self.orders.append(fleet_order)
 
     def _need_repair(self, repair_limit=0.70):
         """Check if fleet needs to be repaired.

--- a/default/python/AI/ExplorationAI.py
+++ b/default/python/AI/ExplorationAI.py
@@ -5,7 +5,7 @@ from EnumsAI import MissionType
 import universe_object
 import MoveUtilsAI
 import PlanetUtilsAI
-from freeorion_tools import dict_from_map
+from freeorion_tools import dict_from_map, print_error
 from AIDependencies import INVALID_ID
 
 
@@ -55,7 +55,11 @@ def assign_scouts_to_explore_systems():
     print "Already targeted: %s" % already_covered
     needs_vis = foAI.foAIstate.misc.setdefault('needs_vis', [])
     check_list = foAI.foAIstate.needsEmergencyExploration + needs_vis + explore_list
-    needs_coverage = [sys_id for sys_id in check_list if sys_id not in already_covered]  # emergency coverage can be due to invasion detection trouble, etc.
+    if INVALID_ID in check_list:  # shouldn't normally happen, unless due to bug elsewhere
+        for sys_list, name in [(foAI.foAIstate.needsEmergencyExploration, "foAI.foAIstate.needsEmergencyExploration"), (needs_vis, "needs_vis"), (explore_list, "explore_list")]:
+            if INVALID_ID in sys_list:
+                print_error("INVALID_ID found in " + name)
+    needs_coverage = [sys_id for sys_id in check_list if sys_id not in already_covered and sys_id != INVALID_ID]  # emergency coverage can be due to invasion detection trouble, etc.
     print "Needs coverage: %s" % needs_coverage
 
     print "Available scouts & AIstate locs: %s" % [(x, foAI.foAIstate.fleetStatus.get(x, {}).get('sysID', INVALID_ID)) for x in available_scouts]

--- a/default/python/AI/fleet_orders.py
+++ b/default/python/AI/fleet_orders.py
@@ -304,7 +304,7 @@ class OrderOutpost(AIFleetOrder):
         if ship_id is None:
             ship_id = FleetUtilsAI.get_ship_id_with_role(self.fleet.id, ShipRoleType.BASE_OUTPOST)
         ship = universe.getShip(ship_id)
-        return ship is not None and self.fleet.get_system() == self.target.get_system() and ship.canColonize
+        return ship is not None and self.fleet.get_object().systemID == self.target.get_system().id and ship.canColonize
 
     def issue_order(self):
         if not super(OrderOutpost, self).issue_order():
@@ -369,7 +369,7 @@ class OrderColonize(AIFleetOrder):
         ship = universe.getShip(ship_id)
         if ship and not ship.canColonize:
             print >> sys.stderr, "colonization fleet %d has no colony ship" % self.fleet.id
-        return ship is not None and self.fleet.get_system() == self.target.get_system() and ship.canColonize
+        return ship is not None and self.fleet.get_object().systemID == self.target.get_system().id and ship.canColonize
 
 
 class OrderAttack(AIFleetOrder):
@@ -420,7 +420,7 @@ class OrderInvade(AIFleetOrder):
         planet = self.target.get_object()
         return all((
             ship is not None,
-            self.fleet.get_system().id == planet.systemID,
+            self.fleet.get_object().systemID == planet.systemID,
             ship.canInvade,
             not planet.currentMeterValue(fo.meterType.shield)
         ))
@@ -482,7 +482,7 @@ class OrderMilitary(AIFleetOrder):
         ship_id = FleetUtilsAI.get_ship_id_with_role(self.fleet.id, ShipRoleType.MILITARY)
         universe = fo.getUniverse()
         ship = universe.getShip(ship_id)
-        return ship is not None and self.fleet.get_system() == self.target and (ship.isArmed or ship.hasFighters)
+        return ship is not None and self.fleet.get_object().systemID == self.target.id and (ship.isArmed or ship.hasFighters)
 
     def issue_order(self):
         if not super(OrderMilitary, self).issue_order():

--- a/default/python/AI/fleet_orders.py
+++ b/default/python/AI/fleet_orders.py
@@ -490,7 +490,9 @@ class OrderMilitary(AIFleetOrder):
         target_sys_id = self.target.id
         fleet = self.target.get_object()
         system_status = foAI.foAIstate.systemStatus.get(target_sys_id, {})
-        if fleet and fleet.systemID == target_sys_id and not (system_status.get('fleetThreat', 0) + system_status.get('planetThreat', 0) + system_status.get('monsterThreat', 0)):
+        if all((fleet, fleet.systemID == target_sys_id, system_status.get('currently_visible', False),
+               not (system_status.get('fleetThreat', 0) + system_status.get('planetThreat', 0) +
+                        system_status.get('monsterThreat', 0)))):
             self.order_issued = True
 
 


### PR DESCRIPTION
no longer have the AI fleet order generation process require the fleet to arrive at its destination before its final (generally mission critical) order is generated, in order to ensure the mission is not prematurely cleared simply because all of its move orders have been issued.  Fixes #1494

The first three commits fix bugs/weaknesses that were either made apparent or caused by the final commit (which was actually written first); putting them in this order ensures (I believe) that at no point in the sequence of commits does the AI become more buggy rather than less.

@Cjkjvfnby , @Morlic-fo  as highlighted by the fleetorder commit, it turns out that many of the uses of [fleet.get_system()](https://github.com/freeorion/freeorion/blob/master/default/python/AI/universe_object.py#L80) in various flavors of can_issue_order() in fleet_orders.py were using it to try verifying that the fleet is actually at the respective system, not merely that the fleet is on a starlane ending at that system.  It seems that this mismatch had been hidden because of how the fleets were only generating their final order once actually at their final destination.  Without this fleetorder change the errors would now pop up because the fleets will often check about issuing their final order while still on the final travel leg to the destination; for many this may not actually cause problems, but at least for the case of invasion fleets a failure in that final order can trigger an exploration request to get visibility on the system, and the way things are set up it was setting -1 as the target system for emergency exploration, which would actually wind up causing a crash later in AIstate.

I think the most straightforward short term fix for this immediate problem is the one I have done here, to change most of these checks like
```self.fleet.get_system() == self.target```

over to 
```self.fleet.get_object().systemID == self.target.id```

but longer term, to guard against similar usage troubles, I am inclined to think we should rename the current fleet.get_system() to be fleet.get__next_system(), and make a fleet.get_system() that returns just the actual current system, or in the event the fleet is on a starlane then it could return a pseudo-system object with ID -1.  I suppose we'll just need to look carefully at all the code to what will really make the most sense.  So long as you guys agree with the fix in the commits here there is no reason to rush a change to fleet.get_system(), but I'd like you guys to be mulling it over.