### PR TITLE
Fix Fleet::Copy() doesn't clear m_travel_route with partially visible subject.

### DIFF
--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -154,7 +154,10 @@ void Fleet::Copy(std::shared_ptr<const UniverseObject> copied_object, int empire
                 if (!copied_fleet->m_travel_route.empty())
                     m_travel_route.push_back(moving_to);
                 ShortenRouteToEndAtSystem(travel_route, moving_to);
-                if (!travel_route.empty() && travel_route.front() != 0 && travel_route.size() != copied_fleet_route.size()) {
+                if (!travel_route.empty()
+                    && travel_route.front() != INVALID_OBJECT_ID
+                    && travel_route.size() != copied_fleet_route.size())
+                {
                     try {
                         travel_distance -= GetPathfinder()->ShortestPath(travel_route.back(),
                                                                       copied_fleet_route.back()).second;

--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -150,7 +150,8 @@ void Fleet::Copy(std::shared_ptr<const UniverseObject> copied_object, int empire
 
                 const std::list<int>& copied_fleet_route = copied_fleet->m_travel_route;
 
-                if (m_travel_route.empty() && !copied_fleet->m_travel_route.empty())
+                m_travel_route.clear();
+                if (!copied_fleet->m_travel_route.empty())
                     m_travel_route.push_back(moving_to);
                 ShortenRouteToEndAtSystem(travel_route, moving_to);
                 if (!travel_route.empty() && travel_route.front() != 0 && travel_route.size() != copied_fleet_route.size()) {

--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -163,8 +163,8 @@ void Fleet::Copy(std::shared_ptr<const UniverseObject> copied_object, int empire
                                                                       copied_fleet_route.back()).second;
                     } catch (...) {
                         DebugLogger() << "Fleet::Copy couldn't find route to system(s):"
-                                               << " travel route back: " << travel_route.back()
-                                               << " or copied fleet route back: " << copied_fleet_route.back();
+                                      << " travel route back: " << travel_route.back()
+                                      << " or copied fleet route back: " << copied_fleet_route.back();
                     }
                 }
 


### PR DESCRIPTION
If a fleet with a travel route is cloned from a fleet only partially
visible to an empire its `m_travel_route` is not cleared, which may result
in an inconsistent path in the resulting fleet.

This bug interacts with [Universe::UpdateEmpireLatestKnownObjectsAndVisibilityTurns()](https://github.com/freeorion/freeorion/blob/master/universe/Universe.cpp#L2397) which re-uses the existing fleet object to make traveling fleet clones with correct previous and next system ids but an empty path.  If `known_object` already has a path that does not contain the next system id then the whole path is pruned to an empty path.

This bug goes on the cause other bugs, such as fleet buttons not appearing because the fleet is enroute, but has no final destination.  

The fix is simply to clear the `m_travel_route`.

