### PR TITLE
allow AI (higher aggressions) to use History Analyser earlier

### DIFF
--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -1496,10 +1496,10 @@ def find_automatic_historic_analyzer_candidates():
         # aggression: (min_pp, min_turn, min_pp_to_queue_another_one)
         fo.aggression.beginner: (100, 100, ARB_LARGE_NUMBER),
         fo.aggression.turtle: (75, 75, ARB_LARGE_NUMBER),
-        fo.aggression.cautious: (60, 60, ARB_LARGE_NUMBER),
-        fo.aggression.typical: (30, 50, ARB_LARGE_NUMBER),
-        fo.aggression.aggressive: (25, 50, ARB_LARGE_NUMBER),
-        fo.aggression.maniacal: (25, 50, 100)
+        fo.aggression.cautious: (40, 40, ARB_LARGE_NUMBER),
+        fo.aggression.typical: (20, 20, 50),
+        fo.aggression.aggressive: (10, 10, 40),
+        fo.aggression.maniacal: (8, 5, 30)
     }
 
     min_pp, turn_trigger, min_pp_per_additional = conditions.get(foAI.foAIstate.character.get_trait(Aggression).key,

--- a/default/python/AI/TechsListsAI.py
+++ b/default/python/AI/TechsListsAI.py
@@ -112,6 +112,7 @@ class TechGroup1(TechGroup):
             "GRO_PLANET_ECOL",
             "GRO_SUBTER_HAB",
             "LRN_ALGO_ELEGANCE",
+            "LRN_PHYS_BRAIN",
             "LRN_ARTIF_MINDS",
             "CON_ORBITAL_CON",  # not a economy tech in the strictest sense but bonus supply often equals more planets
             "PRO_ROBOTIC_PROD",
@@ -128,8 +129,9 @@ class TechGroup1(TechGroup):
         self.hull.extend([
             "SHP_MIL_ROBO_CONT",
         ])
-        # always start with the same first 6 techs
+        # always start with the same first 7 techs; leaves 2 econ, 3 weap, 1 hull
         self.enqueue(
+            self.economy,
             self.economy,
             self.economy,
             self.economy,
@@ -161,7 +163,7 @@ class TechGroup1b(TechGroup1):
             self.economy,
             self.weapon,
             self.weapon,
-
+            self.economy,
         )
 
 


### PR DESCRIPTION
cautious through maniacal AIs, moves forward both when they study LRN_PHYS_BRAIN and can build their first history analyser and also when then could build additional ones (if they have conquered another capital)