### PR TITLE
Boost v1.64.0 - Provide serialization::make_array for numeric::ublas

### DIFF
--- a/universe/Universe.h
+++ b/universe/Universe.h
@@ -8,6 +8,12 @@
 
 #include <boost/signals2/signal.hpp>
 #include <boost/unordered_map.hpp>
+// Fix for issue #1513 (boost ticket #12978)
+// Starting with v1.64, boost::numeric::ublas was not updated for changes to
+// boost::serialization, which moved array_wrapper to separate header
+#if BOOST_VERSION >= 106400
+    #include <boost/serialization/array_wrapper.hpp>
+#endif
 #include <boost/numeric/ublas/symmetric.hpp>
 #include <boost/serialization/access.hpp>
 #include <boost/thread/shared_mutex.hpp>


### PR DESCRIPTION
Posting as PR in case anyone takes issue with comment.

@Vezzra Since comment does not affect testing, please cherry-pick if this holds up RC2.

Resolves #1513