### PR TITLE
Ai trooper design and production

### DIFF
--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -128,11 +128,16 @@ def get_best_ship_info(priority, loc=None):
         if not best_designs:
             return None, None, None
 
+        # best_designs are already sorted by rating high to low, so the top rating is the first encountered within
+        # our planet search list
         for design_stats in best_designs:
             top_rating, pid, top_id, cost, stats = design_stats
             if pid in planet_ids:
                 break
-        valid_locs = [item[1] for item in best_designs if item[0] == top_rating and item[2] == top_id]
+        else:
+            return None, None, None  # apparently can't build for this priority within the desired planet group
+        valid_locs = [pid for rating, pid, design_id, _, _ in best_designs if
+                      rating == top_rating and design_id == top_id and pid in planet_ids]
         return top_id, fo.getShipDesign(top_id), valid_locs
     else:
         return None, None, None  # must be missing a Shipyard or other orbital (or missing tech)

--- a/default/python/AI/ShipDesignAI.py
+++ b/default/python/AI/ShipDesignAI.py
@@ -1825,7 +1825,8 @@ class TroopShipDesignerBaseClass(ShipDesigner):
 
     def _class_specific_filter(self, partname_dict):
         for slot in partname_dict:
-            remaining_parts = [part for part in partname_dict[slot] if get_part_type(part).partClass in TROOPS]
+            remaining_parts = [part for part in partname_dict[slot] if
+                               get_part_type(part).partClass in TROOPS.union(ARMOUR)]
             partname_dict[slot] = remaining_parts
 
 

--- a/default/python/AI/ShipDesignAI.py
+++ b/default/python/AI/ShipDesignAI.py
@@ -84,6 +84,14 @@ TESTDESIGN_PREFERRED_HULL = "SH_BASIC_MEDIUM"
 MISSING_REQUIREMENT_MULTIPLIER = -1000
 INVALID_DESIGN_RATING = -999  # this needs to be negative but greater than MISSING_REQUIREMENT_MULTIPLIER
 
+# For Trooper designs, set a maximum number of troopers per ship that will be considered for ratings purposes, to
+# prevent the AI from settling on trooper designs with the absolute largest hulls, which may nominally have the lowest
+# per-unit-cost but which then result in much trooper overkill/waste when actually deployed.  The application of this
+# limit does (in normal use) take into account shipbuilder species modifiers.
+# Current limit set to 48 to allow up to a grav hull filled with Advanced Troop Pods and Good offensive troopers (or
+# partly filled with Great advanced offensive troopers)
+MAX_TROOPERS_PER_SHIP = 48
+
 # Potentially, not adding techs to AIDependencies is intended for testing purposes.
 # Therefore, chat the player only once to inform him about the issue to prevent spam.
 _raised_warnings = set()
@@ -1796,7 +1804,7 @@ class TroopShipDesignerBaseClass(ShipDesigner):
         if self.design_stats.troops == 0:
             return INVALID_DESIGN_RATING
         else:
-            return self.design_stats.troops/self._adjusted_production_cost()
+            return min(MAX_TROOPERS_PER_SHIP, self.design_stats.troops)/self._adjusted_production_cost()
 
     def _starting_guess(self, available_parts, num_slots):
         # fill completely with biggest troop pods. If none are available for this slot type, leave empty.


### PR DESCRIPTION
This PR addresses a couple AI trooper issues that were recently [discussed on the forums](http://www.freeorion.org/forum/viewtopic.php?p=88413#p88413), including  #1517.  It also contains an additional AI trooper design adjustment.

The main problems cited in the forum were observations of (1) the AI building half-strength troopers (using inferior species), and also (2) the AI's unstopping progression towards larger and larger trooper hulls, eventually resulting in Titanic troopers which wind up resulting in substantial overkill/waste.

1) It turns out that this was related to the AI empire being broken into multiple resource groups, though not under the circumstances I had first theorized would justify the behavior.  There were two problems causing the AI to not properly restricting its search for each respective resource group, both related to the algorithm structure that it would first identify the best design buildable anywhere in the respective resource group, and then get all locations that design could be built at with the same best rating.   This latter step of getting all the respective locations was failing to still limit the search within the resource group.  Furthermore, if it had been unable to find *any* suitable designs within the resource group, then it was taking the last considered design and rating as if it was the best one; if it was however in fact a poor design or from a planet with poor offensive troops and therefore a poor rating, then it would only consider building troopers at locations that could provide the same design with the same poor rating.  The first commit fixes this problem.

2) The second problem, with excessively large trooper ships, was not a bug per-se, but just a weakness from failing to prevent that situation.  The second commit here solves that by imposing a limit on how much capacity the AI will consider when calculating its trooper rating.  Extra pods beyond that would add cost without increasing the rated capacity and so would lower the rating.  I initially set the limit at 48, to allow for a full grav hull with advanced troop pods and Good Offensive Troops.  This seems like a reasonable solution but can probably still be improved.  If the AI had Great troops it would wind up either choosing a smaller hull (the generally ideal solution) or possibly leaving some spots empty (which would be reasonable but might not really be ideal).  Also, if the AI got titanic hulls while not yet having any Good/Great ground or not having advanced troop pods, it might still wind up building some titanic trooper (but they would still not be as much overkill/waste as it can get into currently). 

3) While working on this I noticed that the AI was not considering armor for its troopers, so if it had any structural requirements for them (which it can get to when it starts expecting into mines) then it would currently necessitate a stronger hull; the third commit here allows it to consider using armor to bolster structure when needed.

4) a fourth commit here puts the main call to the ShipDesignAI into verbose mode to facilitate review and testing of this PR; I will remove that last commit before merging this or cherrypicking to 0.4.7.