### PR TITLE
Config file processing function for the "main" files

### DIFF
--- a/Xcode/FreeOrion.xcodeproj/project.pbxproj
+++ b/Xcode/FreeOrion.xcodeproj/project.pbxproj
@@ -317,6 +317,7 @@
 		82F55DE818B0FF0A00FA9E11 /* libboost_date_time.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 82483B7A15F4F24100D27614 /* libboost_date_time.a */; };
 		9E632AEC13AD24D1003D1874 /* libboost_python.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EEEEA7413ACB91A0085B1A0 /* libboost_python.a */; };
 		9E632AED13AD24D1003D1874 /* libboost_regex.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EEEEA7513ACB91A0085B1A0 /* libboost_regex.a */; };
+		B77F3BF51EAAA88800CDF399 /* ConfigFileProcess.cpp in Sources */ = {isa = PBXBuildFile; fileRef = B77F3BF41EAAA88800CDF399 /* ConfigFileProcess.cpp */; };
 		CE0ED5F91BCFE16E00375001 /* AIWrapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE0ED5F71BCFE16E00375001 /* AIWrapper.cpp */; };
 		CE13B48F1C8CB0CF0085A4DC /* CommonParamsParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE13B48E1C8CB0CF0085A4DC /* CommonParamsParser.cpp */; };
 		CE2BAD8F1E3E43E40085A4DC /* Pathfinder.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE2BAD8D1E3E43E40085A4DC /* Pathfinder.cpp */; };
@@ -1072,6 +1073,8 @@
 		9EEEEA7713ACB91A0085B1A0 /* libboost_signals.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libboost_signals.a; sourceTree = "<group>"; };
 		9EEEEA7813ACB91A0085B1A0 /* libboost_system.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libboost_system.a; sourceTree = "<group>"; };
 		9EEEEA7913ACB91A0085B1A0 /* libboost_thread.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libboost_thread.a; sourceTree = "<group>"; };
+		B77F3BF41EAAA88800CDF399 /* ConfigFileProcess.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ConfigFileProcess.cpp; sourceTree = "<group>"; };
+		B77F3BF61EAAA8D100CDF399 /* ConfigFileProcess.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = ConfigFileProcess.h; sourceTree = "<group>"; };
 		CE0ED5F71BCFE16E00375001 /* AIWrapper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AIWrapper.cpp; sourceTree = "<group>"; };
 		CE0ED5F81BCFE16E00375001 /* AIWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIWrapper.h; sourceTree = "<group>"; };
 		CE13B48D1C8CB0CF0085A4DC /* CommonParams.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CommonParams.h; sourceTree = "<group>"; };
@@ -1487,6 +1490,8 @@
 				471D5C5E0A98A3F900DA9C21 /* ClientApp.h */,
 				47102F890CEF55F700A7DF2B /* ClientFSMEvents.cpp */,
 				47102F8A0CEF55F700A7DF2B /* ClientFSMEvents.h */,
+				B77F3BF41EAAA88800CDF399 /* ConfigFileProcess.cpp */,
+				B77F3BF61EAAA8D100CDF399 /* ConfigFileProcess.h */,
 				471D5C5F0A98A3F900DA9C21 /* doc */,
 				471D5C610A98A3F900DA9C21 /* human */,
 			);
@@ -2498,6 +2503,7 @@
 				82592EF0147E381B00B840A5 /* EffectAccounting.cpp in Sources */,
 				82592EF6147E387100B840A5 /* ObjectMap.cpp in Sources */,
 				82BEB659159853B300B024CB /* Diplomacy.cpp in Sources */,
+				B77F3BF51EAAA88800CDF399 /* ConfigFileProcess.cpp in Sources */,
 				8250FDE515FCEFDE00523C1C /* Field.cpp in Sources */,
 				825EA76016DB9DB10002A797 /* ModeratorAction.cpp in Sources */,
 				82C96D0B16E4C1F900579E56 /* SerializeModeratorAction.cpp in Sources */,

--- a/client/AI/camain.cpp
+++ b/client/AI/camain.cpp
@@ -1,14 +1,10 @@
 #include "AIClientApp.h"
 
+#include "../ConfigFileProcess.h"
 #include "../../parse/Parse.h"
-#include "../../util/OptionsDB.h"
-#include "../../util/Directories.h"
 #include "../../util/Logger.h"
-#include "../../util/XMLDoc.h"
 
 #include <GG/utf8/checked.h>
-
-#include <boost/filesystem/fstream.hpp>
 
 #if defined(FREEORION_LINUX)
 /* Freeorion aims to have exceptions handled and operation continue normally.
@@ -44,26 +40,7 @@ int wmain(int argc, wchar_t* argv[], wchar_t* envp[]) {
     InitDirs((args.empty() ? "" : *args.begin()));
 #endif
 
-    try {
-        // TODO Code combining config, persistent_config and commandline args is copy-pasted
-        // slightly differently in chmain, dmain and camain.  Make it into a single function.
-        XMLDoc doc;
-        {
-            boost::filesystem::ifstream ifs(GetConfigPath());
-            if (ifs) {
-                doc.ReadDoc(ifs);
-                GetOptionsDB().SetFromXML(doc);
-            }
-            boost::filesystem::ifstream pifs(GetPersistentConfigPath());
-            if (pifs) {
-                doc.ReadDoc(pifs);
-                GetOptionsDB().SetFromXML(doc);
-            }
-        }
-        GetOptionsDB().SetFromCommandLine(args);
-    } catch (const std::exception&) {
-        std::cerr << "main() unable to read config file: " << std::endl;
-    }
+    ConfigFileProcess(args);
 
 #ifndef FREEORION_CAMAIN_KEEP_STACKTRACE
     try {

--- a/client/ConfigFileProcess.cpp
+++ b/client/ConfigFileProcess.cpp
@@ -1,0 +1,40 @@
+#include "ConfigFileProcess.h"
+
+
+//
+// combining config, persistent_config and commandline args
+//
+void ConfigFileProcess(const std::vector<std::string> args)
+{
+    XMLDoc doc;
+
+    // read config.xml and set options entries from it, if present
+    try {
+        boost::filesystem::ifstream ifs(GetConfigPath());
+        if (ifs) {
+            doc.ReadDoc(ifs);
+            // reject config files from out-of-date version
+            if (doc.root_node.ContainsChild("version-string") &&
+                doc.root_node.Child("version-string").Text() == FreeOrionVersionString())
+            {
+                GetOptionsDB().SetFromXML(doc);
+            }
+        }
+    } catch (const std::exception&) {
+        std::cerr << UserString("UNABLE_TO_READ_CONFIG_XML") << std::endl;
+    }
+        
+    try {
+        boost::filesystem::ifstream pifs(GetPersistentConfigPath());
+        if (pifs) {
+            doc.ReadDoc(pifs);
+            GetOptionsDB().SetFromXML(doc);
+        }
+    } catch (const std::exception&) {
+        std::cerr << UserString("UNABLE_TO_READ_PERSISTENT_CONFIG_XML")  << ": "
+            << GetPersistentConfigPath() << std::endl;
+    }
+
+    // override previously-saved and default options with command line parameters and flags
+    GetOptionsDB().SetFromCommandLine(args);
+}

--- a/client/ConfigFileProcess.h
+++ b/client/ConfigFileProcess.h
@@ -1,0 +1,22 @@
+#ifndef _ConfigFileProcess_h_
+#define _ConfigFileProcess_h_
+
+#include <vector>
+#include <string>
+#include <map>
+#include <iostream>
+
+#include "../util/Directories.h"
+#include "../util/OptionsDB.h"
+#include "../util/i18n.h"
+#include "../util/Version.h"
+#include "../util/XMLDoc.h"
+
+#include <boost/filesystem/fstream.hpp>
+
+// client/human/chmain, server/dmain and client/AI/camain have common code
+//   put them here instead of duplicating in the three files
+
+void ConfigFileProcess(const std::vector<std::string> args);
+
+#endif

--- a/client/human/chmain.cpp
+++ b/client/human/chmain.cpp
@@ -1,24 +1,17 @@
-
+#include "chmain.h"
 
 #include "HumanClientApp.h"
 #include "../../parse/Parse.h"
-#include "../../util/OptionsDB.h"
-#include "../../util/Directories.h"
 #include "../../util/Logger.h"
-#include "../../util/Version.h"
-#include "../../util/XMLDoc.h"
-#include "../../util/i18n.h"
 #include "../../UI/Hotkeys.h"
 
 #include <GG/utf8/checked.h>
 
 #include <boost/format.hpp>
 #include <boost/filesystem/operations.hpp>
-#include <boost/filesystem/fstream.hpp>
 
 #include <thread>
 #include <chrono>
-#include <iostream>
 
 #if defined(FREEORION_LINUX)
 /* Freeorion aims to have exceptions handled and operation continue normally.
@@ -136,42 +129,7 @@ int mainConfigOptionsSetup(const std::vector<std::string>& args) {
         // Add the keyboard shortcuts
         Hotkey::AddOptions(GetOptionsDB());
 
-
-        // TODO Code combining config, persistent_config and commandline args is copy-pasted
-        // slightly differently in chmain, dmain and camain.  Make it into a single function.
-
-        // read config.xml and set options entries from it, if present
-        {
-            XMLDoc doc;
-            try {
-                boost::filesystem::ifstream ifs(GetConfigPath());
-                if (ifs) {
-                    doc.ReadDoc(ifs);
-                    // reject config files from out-of-date version
-                    if (doc.root_node.ContainsChild("version-string") &&
-                        doc.root_node.Child("version-string").Text() == FreeOrionVersionString())
-                    {
-                        GetOptionsDB().SetFromXML(doc);
-                    }
-                }
-            } catch (const std::exception&) {
-                std::cerr << UserString("UNABLE_TO_READ_CONFIG_XML") << std::endl;
-            }
-            try {
-                boost::filesystem::ifstream pifs(GetPersistentConfigPath());
-                if (pifs) {
-                    doc.ReadDoc(pifs);
-                    GetOptionsDB().SetFromXML(doc);
-                }
-            } catch (const std::exception&) {
-                std::cerr << UserString("UNABLE_TO_READ_PERSISTENT_CONFIG_XML")  << ": " 
-                          << GetPersistentConfigPath() << std::endl;
-            }
-        }
-
-
-        // override previously-saved and default options with command line parameters and flags
-        GetOptionsDB().SetFromCommandLine(args);
+        ConfigFileProcess(args);
 
         CompleteXDGMigration();
 

--- a/client/human/chmain.h
+++ b/client/human/chmain.h
@@ -1,8 +1,7 @@
 #ifndef _CHMAIN_H
 #define _CHMAIN_H
 
-#include <string>
-#include <vector>
+#include "../ConfigFileProcess.h"
 
 int mainConfigOptionsSetup(const std::vector<std::string>& args);
 int mainSetupAndRun();

--- a/server/dmain.cpp
+++ b/server/dmain.cpp
@@ -1,16 +1,10 @@
 #include "ServerApp.h"
 
+#include "../client/ConfigFileProcess.h"
 #include "../parse/Parse.h"
-#include "../util/OptionsDB.h"
-#include "../util/Directories.h"
-#include "../util/i18n.h"
 #include "../util/Logger.h"
-#include "../util/Version.h"
-#include "../util/XMLDoc.h"
 
 #include <GG/utf8/checked.h>
-
-#include <boost/filesystem/fstream.hpp>
 
 #if defined(FREEORION_LINUX)
 /* Freeorion aims to have exceptions handled and operation continue normally.
@@ -53,31 +47,7 @@ int wmain(int argc, wchar_t* argv[], wchar_t* envp[]) {
         GetOptionsDB().AddFlag('v', "version",      UserStringNop("OPTIONS_DB_VERSION"),      false);
         GetOptionsDB().AddFlag('s', "singleplayer", UserStringNop("OPTIONS_DB_SINGLEPLAYER"), false);
 
-        // TODO Code combining config, persistent_config and commandline args is copy-pasted
-        // slightly differently in chmain, dmain and camain.  Make it into a single function.
-
-        // read config.xml and set options entries from it, if present
-        XMLDoc doc;
-        {
-            boost::filesystem::ifstream ifs(GetConfigPath());
-            if (ifs) {
-                doc.ReadDoc(ifs);
-                GetOptionsDB().SetFromXML(doc);
-            }
-
-            try {
-                boost::filesystem::ifstream pifs(GetPersistentConfigPath());
-                if (pifs) {
-                    doc.ReadDoc(pifs);
-                    GetOptionsDB().SetFromXML(doc);
-                }
-            } catch (const std::exception&) {
-                ErrorLogger() << "main() unable to read persistent option config file: " 
-                              << GetPersistentConfigPath() << std::endl;
-            }
-        }
-
-        GetOptionsDB().SetFromCommandLine(args);
+        ConfigFileProcess(args);
 
         if (GetOptionsDB().Get<bool>("help")) {
             GetOptionsDB().GetUsage(std::cerr);


### PR DESCRIPTION
I found this To-Do comment in the three "main" cpp files, so I made it (refactoring) happen.

`TODO Code combining config, persistent_config and commandline args is copy-pasted
slightly differently in chmain, dmain and camain.  Make it into a single function.`

I tried a single player game, and didn't notice any changes (as expected).

Since I am adding a cpp and header file to the repository, it is possible that I should have changed something else for compilation with Linux or Windows (??).
The Xcode project file is modified, for Mac OSX compilation.