### PR TITLE
Read config file function for the "main" files

### DIFF
--- a/client/AI/camain.cpp
+++ b/client/AI/camain.cpp
@@ -4,7 +4,7 @@
 #include "../../util/OptionsDB.h"
 #include "../../util/Directories.h"
 #include "../../util/Logger.h"
-#include "../../util/XMLDoc.h"
+#include "../../util/Version.h"
 
 #include <GG/utf8/checked.h>
 
@@ -44,26 +44,9 @@ int wmain(int argc, wchar_t* argv[], wchar_t* envp[]) {
     InitDirs((args.empty() ? "" : *args.begin()));
 #endif
 
-    try {
-        // TODO Code combining config, persistent_config and commandline args is copy-pasted
-        // slightly differently in chmain, dmain and camain.  Make it into a single function.
-        XMLDoc doc;
-        {
-            boost::filesystem::ifstream ifs(GetConfigPath());
-            if (ifs) {
-                doc.ReadDoc(ifs);
-                GetOptionsDB().SetFromXML(doc);
-            }
-            boost::filesystem::ifstream pifs(GetPersistentConfigPath());
-            if (pifs) {
-                doc.ReadDoc(pifs);
-                GetOptionsDB().SetFromXML(doc);
-            }
-        }
-        GetOptionsDB().SetFromCommandLine(args);
-    } catch (const std::exception&) {
-        std::cerr << "main() unable to read config file: " << std::endl;
-    }
+    // if config.xml and persistent_config.xml are present, read and set options entries
+    GetOptionsDB().SetFromFile(GetConfigPath(), FreeOrionVersionString());
+    GetOptionsDB().SetFromFile(GetPersistentConfigPath());
 
 #ifndef FREEORION_CAMAIN_KEEP_STACKTRACE
     try {

--- a/client/human/chmain.cpp
+++ b/client/human/chmain.cpp
@@ -6,7 +6,6 @@
 #include "../../util/Directories.h"
 #include "../../util/Logger.h"
 #include "../../util/Version.h"
-#include "../../util/XMLDoc.h"
 #include "../../util/i18n.h"
 #include "../../UI/Hotkeys.h"
 
@@ -136,39 +135,9 @@ int mainConfigOptionsSetup(const std::vector<std::string>& args) {
         // Add the keyboard shortcuts
         Hotkey::AddOptions(GetOptionsDB());
 
-
-        // TODO Code combining config, persistent_config and commandline args is copy-pasted
-        // slightly differently in chmain, dmain and camain.  Make it into a single function.
-
-        // read config.xml and set options entries from it, if present
-        {
-            XMLDoc doc;
-            try {
-                boost::filesystem::ifstream ifs(GetConfigPath());
-                if (ifs) {
-                    doc.ReadDoc(ifs);
-                    // reject config files from out-of-date version
-                    if (doc.root_node.ContainsChild("version-string") &&
-                        doc.root_node.Child("version-string").Text() == FreeOrionVersionString())
-                    {
-                        GetOptionsDB().SetFromXML(doc);
-                    }
-                }
-            } catch (const std::exception&) {
-                std::cerr << UserString("UNABLE_TO_READ_CONFIG_XML") << std::endl;
-            }
-            try {
-                boost::filesystem::ifstream pifs(GetPersistentConfigPath());
-                if (pifs) {
-                    doc.ReadDoc(pifs);
-                    GetOptionsDB().SetFromXML(doc);
-                }
-            } catch (const std::exception&) {
-                std::cerr << UserString("UNABLE_TO_READ_PERSISTENT_CONFIG_XML")  << ": " 
-                          << GetPersistentConfigPath() << std::endl;
-            }
-        }
-
+        // if config.xml and persistent_config.xml are present, read and set options entries
+        GetOptionsDB().SetFromFile(GetConfigPath(), FreeOrionVersionString());
+        GetOptionsDB().SetFromFile(GetPersistentConfigPath());
 
         // override previously-saved and default options with command line parameters and flags
         GetOptionsDB().SetFromCommandLine(args);

--- a/util/OptionsDB.cpp
+++ b/util/OptionsDB.cpp
@@ -431,6 +431,24 @@ void OptionsDB::SetFromCommandLine(const std::vector<std::string>& args) {
     }
 }
 
+void OptionsDB::SetFromFile(const boost::filesystem::path& file_path,
+                            const std::string& version) {
+    XMLDoc doc;
+    try {
+        boost::filesystem::ifstream ifs(file_path);
+        if (ifs) {
+            doc.ReadDoc(ifs);
+            if (version.empty() || (doc.root_node.ContainsChild("version-string") &&
+                                    doc.root_node.Child("version-string").Text() == version)) {
+                GetOptionsDB().SetFromXML(doc);
+            }
+        }
+    } catch (const std::exception&) {
+        std::cerr << UserString("UNABLE_TO_READ_CONFIG_XML")  << ": "
+                  << file_path << std::endl;
+    }
+}
+
 void OptionsDB::SetFromXML(const XMLDoc& doc) {
     for (const XMLElement& child : doc.root_node.children)
     { SetFromXMLRecursive(child, ""); }

--- a/util/OptionsDB.cpp
+++ b/util/OptionsDB.cpp
@@ -432,14 +432,16 @@ void OptionsDB::SetFromCommandLine(const std::vector<std::string>& args) {
 }
 
 void OptionsDB::SetFromFile(const boost::filesystem::path& file_path,
-                            const std::string& version) {
+                            const std::string& version)
+{
     XMLDoc doc;
     try {
         boost::filesystem::ifstream ifs(file_path);
         if (ifs) {
             doc.ReadDoc(ifs);
             if (version.empty() || (doc.root_node.ContainsChild("version-string") &&
-                                    doc.root_node.Child("version-string").Text() == version)) {
+                                    doc.root_node.Child("version-string").Text() == version))
+            {
                 GetOptionsDB().SetFromXML(doc);
             }
         }

--- a/util/OptionsDB.h
+++ b/util/OptionsDB.h
@@ -6,6 +6,7 @@
 #include "OptionValidators.h"
 
 #include <boost/any.hpp>
+#include <boost/filesystem/fstream.hpp>
 #include <boost/signals2/signal.hpp>
 
 #include <map>
@@ -305,6 +306,12 @@ public:
         m_dirty |= it->second.SetFromValue(value);
     }
 
+    /** if an xml file exists at \a file_path and has the same version tag as \a version, fill the
+      * DB options contained in that file (read the file using XMLDoc, then fill the DB using SetFromXML)
+      * if the \a version string is empty, bypass that check */
+    void        SetFromFile(const boost::filesystem::path& file_path,
+                            const std::string& version = "");
+    
     /** fills some or all of the options of the DB from values passed in from
       * the command line */
     void        SetFromCommandLine(const std::vector<std::string>& args);


### PR DESCRIPTION
My third attempt (after #1519 and #1520 ) to do (what was in theory) a simple refactoring of the camain, chmain, and dmain files. There was a To-Do comment in those files:

> TODO Code combining config, persistent_config and commandline args is copy-pasted slightly differently in chmain, dmain and camain. Make it into a single function.

I tried a single player game, and didn't notice any changes (as expected).

@LGM-Doyle made a suggestion that was better/simpler than what I was trying, so hopefully the third PR will be the last...