### PR TITLE
Fix planet selection when the Production Wnd is open so that the…

### DIFF
--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -943,8 +943,10 @@ bool ProductionWnd::PediaVisible()
 void ProductionWnd::CenterOnBuild(int queue_idx, bool open)
 { m_build_designator_wnd->CenterOnBuild(queue_idx, open); }
 
-void ProductionWnd::SelectPlanet(int planet_id)
-{ m_build_designator_wnd->SelectPlanet(planet_id); }
+void ProductionWnd::SelectPlanet(int planet_id) {
+    m_build_designator_wnd->SelectPlanet(planet_id);
+    UpdateInfoPanel();
+}
 
 void ProductionWnd::SelectDefaultPlanet()
 { m_build_designator_wnd->SelectDefaultPlanet(); }


### PR DESCRIPTION
…Production Wnd Info Panel gets updated upon change in selected planet.

As [discussed at the forum](http://www.freeorion.org/forum/viewtopic.php?f=28&t=10525) the lack of update can be particularly vexing/confusing when trying to track down wasted PP.   If the selected system is blockaded then the Info Panel information is on a planet by planet basis, but to get it to update after changing planets you have to close and then reopen the Production Window after changing the selected planet.

 This PR fixes the behavior so that the Production Wnd Info Panel gets updated when the selected planet is changed.  This is a minor bug so I am just flagging this as optional for 0.4.7, but the fix is also quite simple so I do propose we get this into RC2.

I have tested this with the savegame provided at that forum post (note, it seems the save file is only compatible with the 0.4.7 branch, not master).   

Also note, although this PR fixes the UI behavior, there could still be some associated confusion from people not realizing that if the system is blockaded then each planet is a separate Resource Group and so each one has to be separately checked for wasted PP.    A further improvement to help clarify that might be to change the second to last line of the Info Panel, which currently reads "Points Available Here  nnnn", to have two different forms.  If the system is not blockaded it could read "Points Available Regionally  nnnn" and if the system is blockaded then it could read "Points Available at Planet Sol III   nnnn".  (But I would not propose trying to squeeze that into 0.4.7).