### PR TITLE
reapportions horizontal space in ObjectsWnd FilterDialog params…

### DIFF
--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -652,7 +652,7 @@ private:
     }
 
     GG::X   DropListWidth() const
-    { return GG::X(ClientUI::Pts()*18); }
+    { return GG::X(ClientUI::Pts()*15); }
 
     GG::X   ParamsDropListWidth() const
     { return CONDITION_WIDGET_WIDTH - DropListWidth(); }


### PR DESCRIPTION
…dropdown to improve legibility.  Depending on what font text size you are using, the second dropdown for conditions in the ObjectsWindow FIlterDialog will either be a little clipped or very clipped, enough so that I consider this a UI bug:

![napa_headlight_visa_record1](https://cloud.githubusercontent.com/assets/10995939/25346821/9b3b50e0-28cd-11e7-9bb7-6276773b8ccf.png)

At the font size shown above (16) none of the conditions need the full space allocated to their dropdown, but as you can see the params dropdown needed for some of the conditions can wind up so clipped that it requires a fair bit of knowledge to know what the entries really are.  A smaller font size does of course help with that, but even going to font 12 does not allow the params to be fully shown, and then of a smaller font size also would mean that the first condition dropdown would need even less space.

This PR makes a modest change to the apportioning of that horizontal space between the two dropdowns; at the shown font size (16) the second one still doesn't have enough space to show everything fully, but it is just barely enough to distinguish the two types of Ancient Ruins special: 
![napa_headlight_visa_record1](https://cloud.githubusercontent.com/assets/10995939/25347430/c5690284-28cf-11e7-8fb0-6e6592be24e9.png)
And, not shown, with this adjusted apportioning even the longer conditions are still not at all clipped in the first dropdown at font 16.

I am currently planning on merging this and cherrypicking in time for the RC2 deadline unless someone objects.