### PR TITLE
Add named loggers: preamble.

### DIFF
--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -87,7 +87,7 @@ AIClientApp::AIClientApp(const std::vector<std::string>& args) :
         m_max_aggression = boost::lexical_cast<int>(args.at(2));
     }
 
-    InitLogger(AICLIENT_LOG_FILENAME, "AI");
+    InitLoggingSystem(AICLIENT_LOG_FILENAME, "AI");
     DebugLogger() << PlayerName() + " ai client initialized.";
 }
 

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -208,7 +208,7 @@ HumanClientApp::HumanClientApp(int width, int height, bool calculate_fps, const 
 
     const std::string HUMAN_CLIENT_LOG_FILENAME((GetUserDataDir() / "freeorion.log").string());
 
-    InitLogger(HUMAN_CLIENT_LOG_FILENAME, "Client");
+    InitLoggingSystem(HUMAN_CLIENT_LOG_FILENAME, "Client");
 
     try {
         InfoLogger() << "GL Version String: " << GetGLVersionString();

--- a/python/LoggingWrapper.cpp
+++ b/python/LoggingWrapper.cpp
@@ -1,6 +1,7 @@
 #include <string>
 
 #include "../util/Logger.h"
+#include <boost/log/trivial.hpp>
 
 #include <boost/python.hpp>
 

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -140,7 +140,7 @@ ServerApp::ServerApp() :
 {
     const std::string SERVER_LOG_FILENAME((GetUserDataDir() / "freeoriond.log").string());
 
-    InitLogger(SERVER_LOG_FILENAME, "Server");
+    InitLoggingSystem(SERVER_LOG_FILENAME, "Server");
 
     LogDependencyVersions();
 

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -155,7 +155,7 @@ namespace {
            << " error message: " << problem;
 
         if (fatal) {
-            FatalLogger() << ss.str();
+            ErrorLogger() << ss.str();
             SendMessageToAllPlayers(msg.m_message);
         } else {
             ErrorLogger() << ss.str();

--- a/universe/Tech.cpp
+++ b/universe/Tech.cpp
@@ -504,7 +504,7 @@ void TechManager::AllChildren(const Tech* tech, std::map<std::string, std::strin
     for (const std::string& unlocked_tech : tech->UnlockedTechs()) {
         if (unlocked_tech == tech->Name()) {
             // infinite loop
-            FatalLogger() << "Tech " << unlocked_tech << " unlocks itself";
+            ErrorLogger() << "Tech " << unlocked_tech << " unlocks itself";
             continue;
         }
         children[unlocked_tech] = tech->Name();

--- a/util/Logger.cpp
+++ b/util/Logger.cpp
@@ -50,7 +50,7 @@ int g_indent = 0;
 std::string DumpIndent()
 { return std::string(g_indent * 4, ' '); }
 
-void InitLogger(const std::string& logFile, const std::string& process) {
+void InitLoggingSystem(const std::string& logFile, const std::string& process) {
     logging::add_file_log(
         keywords::file_name = logFile.c_str(),
         keywords::auto_flush = true,

--- a/util/Logger.h
+++ b/util/Logger.h
@@ -8,9 +8,11 @@
 #include "Export.h"
 
 
-/** Initializes the logging system. Log to the given file.
- * If the file already exists it will be deleted. */
-FO_COMMON_API void InitLogger(const std::string& logFile, const std::string& pattern);
+
+/** Initializes the logging system. Log to the given file.  If the file already
+ * exists it will be deleted. \p root_logger_name is the name by which the
+ * default logger "" appears in the log file.*/
+FO_COMMON_API void InitLoggingSystem(const std::string& logFile, const std::string& root_logger_name);
 
 /** Accessors for the App's logger */
 FO_COMMON_API void SetLoggerPriority(int priority);

--- a/util/Logger.h
+++ b/util/Logger.h
@@ -41,9 +41,6 @@ BOOST_LOG_ATTRIBUTE_KEYWORD(log_src_linenum, "SrcLinenum", int);
 #define ErrorLogger()\
     FO_LOGGER(error)
 
-#define FatalLogger()\
-    FO_LOGGER(fatal)
-
 extern int g_indent;
 
 /** A function that returns the correct amount of spacing for the current

--- a/util/ScopedTimer.cpp
+++ b/util/ScopedTimer.cpp
@@ -6,6 +6,7 @@
 #include <boost/unordered_map.hpp>
 
 #include <iomanip>
+#include <sstream>
 
 class ScopedTimer::Impl {
 public:


### PR DESCRIPTION
This is part of the broken up PR #1481.

These are 4 minor commits that precede the core portion of the named loggers implementation

The purpose of this PR is reduce the extraneous noise in the core PR.

This PR:
+ removes the `fatal` logging level
+ renames `InitLogger` to `InitLoggingSystem`
+ adds two includes which will be removed from `Logger.h` to files which depend on them.