### PR TITLE
Add named loggers: move version string into app.

### DIFF
--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -12,6 +12,8 @@
 #include "../../network/Message.h"
 #include "../../network/ClientNetworking.h"
 #include "../util/Random.h"
+#include "../util/Version.h"
+
 
 #include "../../universe/System.h"
 #include "../../universe/Species.h"
@@ -95,6 +97,8 @@ AIClientApp::AIClientApp(const std::vector<std::string>& args) :
 
     InitLoggingSystem(AICLIENT_LOG_FILENAME, "AI");
     InitLoggingOptionsDBSystem();
+
+    InfoLogger() << FreeOrionVersionString();
     DebugLogger() << PlayerName() + " ai client initialized.";
 }
 

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -227,6 +227,8 @@ HumanClientApp::HumanClientApp(int width, int height, bool calculate_fps, const 
     RegisterLoggerWithOptionsDB("client", true);
     RegisterLoggerWithOptionsDB("server", true);
 
+    InfoLogger() << FreeOrionVersionString();
+
     try {
         InfoLogger() << "GL Version String: " << GetGLVersionString();
     } catch (...) {

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -147,6 +147,7 @@ ServerApp::ServerApp() :
     InitLoggingSystem(SERVER_LOG_FILENAME, "Server");
     InitLoggingOptionsDBSystem();
 
+    InfoLogger() << FreeOrionVersionString();
     LogDependencyVersions();
 
     m_fsm->initiate();

--- a/util/Logger.cpp
+++ b/util/Logger.cpp
@@ -1,7 +1,5 @@
 #include "Logger.h"
 
-#include "Version.h"
-
 #include <boost/log/core.hpp>
 #include <boost/log/trivial.hpp>
 #include <boost/log/expressions.hpp>
@@ -323,7 +321,6 @@ void InitLoggingSystem(const std::string& log_file, const std::string& _unnamed_
     // Print setup message.
     auto date_time = std::time(nullptr);
     InfoLogger(log) << "Logger initialized at " << std::ctime(&date_time);
-    InfoLogger() << FreeOrionVersionString();
 }
 
 void ShutdownLoggingSystemFileSink() {


### PR DESCRIPTION
This is part of the broken up PR #1481.

This PR moves responsibility for adding the version string to the log file, out of the logger and into the application code.  The application has a version number, not the logger code.

It follows the core implementation #1529. 

