### PR TITLE
Consistent research queue mouse click behaviour

### DIFF
--- a/UI/ResearchWnd.cpp
+++ b/UI/ResearchWnd.cpp
@@ -490,10 +490,12 @@ void ResearchWnd::Update() {
 void ResearchWnd::CenterOnTech(const std::string& tech_name)
 { m_tech_tree_wnd->CenterOnTech(tech_name); }
 
-void ResearchWnd::ShowTech(const std::string& tech_name) {
-    m_tech_tree_wnd->CenterOnTech(tech_name);
+void ResearchWnd::ShowTech(const std::string& tech_name, bool force) {
     m_tech_tree_wnd->SetEncyclopediaTech(tech_name);
-    m_tech_tree_wnd->SelectTech(tech_name);
+    if (force || m_tech_tree_wnd->TechIsVisible(tech_name)) {
+        m_tech_tree_wnd->CenterOnTech(tech_name);
+        m_tech_tree_wnd->SelectTech(tech_name);
+    }
 }
 
 void ResearchWnd::ShowPedia()
@@ -642,7 +644,7 @@ void ResearchWnd::QueueItemClickedSlot(GG::ListBox::iterator it, const GG::Pt& p
             auto queue_row = boost::polymorphic_downcast<QueueRow*>(*it);
             if (!queue_row)
                 return;
-            ShowTech(queue_row->elem.name);
+            ShowTech(queue_row->elem.name, false);
         }
     }
 }

--- a/UI/ResearchWnd.cpp
+++ b/UI/ResearchWnd.cpp
@@ -636,16 +636,24 @@ void ResearchWnd::DeleteQueueItem(GG::ListBox::iterator it) {
 
 void ResearchWnd::QueueItemClickedSlot(GG::ListBox::iterator it, const GG::Pt& pt, const GG::Flags<GG::ModKey>& modkeys) {
     if (m_queue_wnd->GetQueueListBox()->DisplayingValidQueueItems()) {
+        if (modkeys & GG::MOD_KEY_CTRL) {
+            DeleteQueueItem(it);
+        } else {
+            auto queue_row = boost::polymorphic_downcast<QueueRow*>(*it);
+            if (!queue_row)
+                return;
+            ShowTech(queue_row->elem.name);
+        }
+    }
+}
+
+void ResearchWnd::QueueItemDoubleClickedSlot(GG::ListBox::iterator it, const GG::Pt& pt, const GG::Flags<GG::ModKey>& modkeys) {
+    if (m_queue_wnd->GetQueueListBox()->DisplayingValidQueueItems()) {
         QueueRow* queue_row = boost::polymorphic_downcast<QueueRow*>(*it);
         if (!queue_row)
             return;
         ShowTech(queue_row->elem.name);
     }
-}
-
-void ResearchWnd::QueueItemDoubleClickedSlot(GG::ListBox::iterator it, const GG::Pt& pt, const GG::Flags<GG::ModKey>& modkeys) {
-    if (m_queue_wnd->GetQueueListBox()->DisplayingValidQueueItems())
-        DeleteQueueItem(it);
 }
 
 void ResearchWnd::QueueItemPaused(GG::ListBox::iterator it, bool pause) {

--- a/UI/ResearchWnd.h
+++ b/UI/ResearchWnd.h
@@ -34,7 +34,10 @@ public:
     void    Update();
 
     void    CenterOnTech(const std::string& tech_name);
-    void    ShowTech(const std::string& tech_name);
+    /** Set encyclopedia entry to tech article for @p tech_name
+     *  Selects and centers tech @p tech_name if tech is initially visible
+     *  or if @p force is true(default). */
+    void    ShowTech(const std::string& tech_name, bool force = true);
     void    QueueItemMoved(GG::ListBox::Row* row, std::size_t position);
     void    Sanitize();
 

--- a/UI/TechTreeWnd.cpp
+++ b/UI/TechTreeWnd.cpp
@@ -233,6 +233,9 @@ public:
     void Render() override;
 
     void LDrag(const GG::Pt& pt, const GG::Pt& move, GG::Flags<GG::ModKey> mod_keys) override;
+
+    /** Set checked value of control for TechStatus @p status to @p state */
+    void SetTechStatus(TechStatus status, bool state);
     //@}
 
 private:
@@ -470,6 +473,16 @@ void TechTreeWnd::TechTreeControls::LDrag(const GG::Pt& pt, const GG::Pt& move, 
 
         GG::Wnd::LDrag(pt, final_move, mod_keys);
     }
+}
+
+void TechTreeWnd::TechTreeControls::SetTechStatus(TechStatus status, bool state) {
+    auto control_it = m_status_buttons.find(status);
+    if (control_it == m_status_buttons.end()) {
+        WarnLogger() << "No control for status " << status << " found";
+        return;
+    }
+
+    control_it->second->SetCheck(state);
 }
 
 
@@ -2201,6 +2214,8 @@ void TechTreeWnd::SetTechStatus(const TechStatus status, const bool state) {
         m_layout_panel->HideStatus(status);
         m_tech_list->HideStatus(status);
     }
+
+    m_tech_tree_controls->SetTechStatus(status, state);
 }
 
 void TechTreeWnd::ToggleViewType(bool show_list_view)

--- a/UI/TechTreeWnd.cpp
+++ b/UI/TechTreeWnd.cpp
@@ -2268,6 +2268,9 @@ void TechTreeWnd::TogglePedia() {
 bool TechTreeWnd::PediaVisible()
 { return m_enc_detail_panel->Visible(); }
 
+bool TechTreeWnd::TechIsVisible(const std::string& tech_name) const
+{ return TechVisible(tech_name, GetCategoriesShown(), GetTechStatusesShown()); }
+
 void TechTreeWnd::TechLeftClickedSlot(const std::string& tech_name,
                                   const GG::Flags<GG::ModKey>& modkeys)
 {

--- a/UI/TechTreeWnd.h
+++ b/UI/TechTreeWnd.h
@@ -37,6 +37,8 @@ public:
     std::set<std::string>   GetCategoriesShown() const;
     std::set<TechStatus>    GetTechStatusesShown() const;
     bool                    PediaVisible();
+    /** If tech @p tech_name is currently visible */
+    bool                    TechIsVisible(const std::string& tech_name) const;
     //@}
 
     //! \name Mutators //@{


### PR DESCRIPTION
Addresses a few inconsistencies in research queue wrt left mouse clicks.

First two commits refer to #1537, changing to the following behaviour when clicking an item in queue:
* LeftClick: Set pedia article to this tech.  If tech is visible, select and zoom to the entry in tree or list view.
* Control+LeftClick: Remove item from queue
* DoubleLeftClick: Same as LeftClick, but will force visibility of tech category and status.

This is consistent behaviour with the production queue and the design window finished ship designs list.

Third commit addresses an issue with tech status control not changing state when centering on a tech, as done with DoubleLeftClick.