### PR TITLE
Fix MSVC link error

### DIFF
--- a/default/credits.xml
+++ b/default/credits.xml
@@ -59,7 +59,7 @@
       <PERSON name="Vincent Legoll"           nick="vincele"          task="Programming"/>
       <PERSON name="Fabian Wendt"             nick="Morlic"           task="Programming"/>
       <PERSON name=""                         nick="mel-odious"       task="Programming"/>
-      <PERSON name="Mark Shmuale"             nick="wheals"           task="Programming"/>
+      <PERSON name="S. Mark"                  nick="wheals"           task="Programming"/>
       <PERSON name="Andrey Solomatin"         nick="Cjkjvfnby"        task="Programming"/>
       <PERSON name=""                         nick="LGM-Doyle"        task="Programming"/>
       <PERSON name="D. Benage"                nick="dbenage-cx"       task="Programming"/>

--- a/python/UniverseWrapper.cpp
+++ b/python/UniverseWrapper.cpp
@@ -39,8 +39,6 @@ namespace boost {
     const volatile Field*           get_pointer(const volatile Field* p) { return p; }
     template<>
     const volatile Building*        get_pointer(const volatile Building* p) { return p; }
-    template<>
-    const volatile Universe*        get_pointer<const volatile Universe>(const volatile Universe* p) { return p; }
 }
 #  endif
 #endif


### PR DESCRIPTION
Before this, I consistently ran into the following error:
```
4>UniverseWrapper.obj : error LNK2005: "class Universe const volatile * __cdecl boost::get_pointer<class Universe const volatile >(class Universe const volatile *)" (??$get_pointer@$$CDVUniverse@@@boost@@YAPDVUniverse@@PDV1@@Z) already defined in AIWrapper.obj
4>../../FreeOrionCA.exe : fatal error LNK1169: one or more multiply defined symbols found
```
MSVC version: Microsoft Visual Studio Community 2015 14.0.24720.00 Update 1

Someone else who uses MSVC should probably test this. For what it's worth, [this comment](https://github.com/freeorion/freeorion/issues/1246#issuecomment-275485658) suggests the functions are no longer necessary with the removal of TemporaryPtr.

I also added an update to my preferred crediting since this is my first PR in a while, didn't want to cause the bother of a separate PR.


