### PR TITLE
Fix a crash on startup during log initalization

### DIFF
--- a/util/Logger.cpp
+++ b/util/Logger.cpp
@@ -47,8 +47,8 @@ namespace {
     }
 
 
-    // Compile time constant pointers to constant char arrays.
-    constexpr const char* const log_level_names[] = {"trace", "debug", "info", "warn", "error"};
+    // Constant pointers to constant char arrays.
+    const char* const log_level_names[] = {"trace", "debug", "info", "warn", "error"};
 }
 
 


### PR DESCRIPTION
For some reason, when [`AddLoggerToOptionsDB`](https://github.com/freeorion/freeorion/blob/master/util/LoggerWithOptionsDB.cpp#L33) gets called during initialization of the logger, `log_level_names` is full of garbage data. Removing the `constexpr` as here fixes it.

I'm not sure if this is MSVC screwing up and not following the C++ standard, or the other compilers/versions of MSVC being too lax.

@LGM-Doyle You're working on the logger, so I figure you might know more about this?