### PR TITLE
Use unique_ptr for BuildingType parser

### DIFF
--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -788,7 +788,7 @@ void BuildDesignatorWnd::BuildSelector::PopulateList() {
         // craete and insert rows...
         std::vector<GG::ListBox::Row*> rows;
         rows.reserve(std::distance(manager.begin(), manager.end()));
-        for (const std::map<std::string, BuildingType*>::value_type& entry : manager) {
+        for (const auto& entry : manager) {
             const std::string name = entry.first;
             if (!BuildableItemVisible(BT_BUILDING, name))
                 continue;

--- a/UI/ChatWnd.cpp
+++ b/UI/ChatWnd.cpp
@@ -190,7 +190,7 @@ void MessageWndEdit::FindGameWords() {
             m_game_words.insert(UserString(tech_name));
     }
     // add building type names
-    for (const std::map<std::string, BuildingType*>::value_type& entry : GetBuildingTypeManager()) {
+    for (const auto& entry : GetBuildingTypeManager()) {
         if (entry.second->Name() != "")
             m_game_words.insert(UserString(entry.second->Name()));
     }

--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -795,7 +795,7 @@ bool ClientUI::ZoomToContent(const std::string& name, bool reverse_lookup/* = fa
                 return ZoomToTech(tech->Name());
         }
 
-        for (const std::map<std::string, BuildingType*>::value_type& entry : GetBuildingTypeManager())
+        for (const auto& entry : GetBuildingTypeManager())
             if (boost::iequals(name, UserString(entry.first)))
                 return ZoomToBuildingType(entry.first);
 

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -242,7 +242,7 @@ namespace {
             }
 
         } else if (dir_name == "ENC_BUILDING_TYPE") {
-            for (const std::map<std::string, BuildingType*>::value_type& entry : GetBuildingTypeManager()) {
+            for (const auto& entry : GetBuildingTypeManager()) {
                 std::string custom_category = DetermineCustomCategory(entry.second->Tags());
                 if (custom_category.empty()) {
                     sorted_entries_list.insert({UserString(entry.first),
@@ -470,7 +470,7 @@ namespace {
                     dir_entries[UserString(tech_name)] = std::make_pair(VarText::TECH_TAG, tech_name);
 
             // building types
-            for (const std::map<std::string, BuildingType*>::value_type& entry : GetBuildingTypeManager())
+            for (const auto& entry : GetBuildingTypeManager())
                 if (DetermineCustomCategory(entry.second->Tags()) == dir_name)
                     dir_entries[UserString(entry.first)] = std::make_pair(VarText::BUILDING_TYPE_TAG, entry.first);
 

--- a/parse/Parse.h
+++ b/parse/Parse.h
@@ -28,7 +28,7 @@ namespace parse {
     FO_PARSE_API void init();
 
     FO_PARSE_API bool buildings(std::map<std::string,
-                                BuildingType*>& building_types);
+                                std::unique_ptr<BuildingType>>& building_types);
 
     FO_PARSE_API bool fields(std::map<std::string, FieldType*>& field_types);
 

--- a/universe/Building.cpp
+++ b/universe/Building.cpp
@@ -338,15 +338,9 @@ BuildingTypeManager::BuildingTypeManager() {
     s_instance = this;
 }
 
-BuildingTypeManager::~BuildingTypeManager() {
-    for (std::map<std::string, BuildingType*>::value_type& entry : m_building_types) {
-        delete entry.second;
-    }
-}
-
 const BuildingType* BuildingTypeManager::GetBuildingType(const std::string& name) const {
-    std::map<std::string, BuildingType*>::const_iterator it = m_building_types.find(name);
-    return it != m_building_types.end() ? it->second : nullptr;
+    const auto& it = m_building_types.find(name);
+    return it != m_building_types.end() ? it->second.get() : nullptr;
 }
 
 BuildingTypeManager& BuildingTypeManager::GetBuildingTypeManager() {

--- a/universe/Building.h
+++ b/universe/Building.h
@@ -194,7 +194,7 @@ private:
 /** Holds all FreeOrion building types.  Types may be looked up by name. */
 class BuildingTypeManager {
 public:
-    typedef std::map<std::string, BuildingType*>::const_iterator iterator;
+    typedef std::map<std::string, std::unique_ptr<BuildingType>>::const_iterator iterator;
 
     /** \name Accessors */ //@{
     /** returns the building type with the name \a name; you should use the
@@ -214,9 +214,8 @@ public:
 
 private:
     BuildingTypeManager();
-    ~BuildingTypeManager();
 
-    std::map<std::string, BuildingType*> m_building_types;
+    std::map<std::string, std::unique_ptr<BuildingType>> m_building_types;
 
     static BuildingTypeManager* s_instance;
 };

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -1217,9 +1217,9 @@ void Universe::GetEffectsAndTargets(Effect::TargetsCauses& targets_causes,
     }
 
     // enforce building types effects order
-    for (const std::map<std::string, BuildingType*>::value_type& entry : GetBuildingTypeManager()) {
+    for (const auto& entry : GetBuildingTypeManager()) {
         const std::string&  building_type_name = entry.first;
-        const BuildingType* building_type      = entry.second;
+        const BuildingType* building_type      = entry.second.get();
         std::map<std::string, std::vector<std::shared_ptr<const UniverseObject>>>::iterator buildings_by_type_it =
             buildings_by_type.find(building_type_name);
 


### PR DESCRIPTION
**Problem**
The BuildingTypeParser is a generator.  In C++11 is should return a `std::unique_ptr<>` to indicate that it has created something that requires memory management and that it is passing management responsibility to the calling function.  The calling function can chose to receive it as a `unique_ptr<>` or transfer it to a `shared_ptr<>` if it needs a shared ownership model.

Furthermore the error condition near line 29 leaks the passed in pointer.  This is a static leak, it only leaks objects that have failed to parse once per game.

**Solution**
Return `std::unique_ptr<>`s.