### PR TITLE
Use unique_ptr for the ShipDesign parser.

### DIFF
--- a/UI/ChatWnd.cpp
+++ b/UI/ChatWnd.cpp
@@ -170,7 +170,7 @@ void MessageWndEdit::FindGameWords() {
     }
      // add ship design names
 
-    for (const std::map<std::string, ShipDesign*>::value_type& entry : GetPredefinedShipDesignManager()) {
+    for (const auto& entry : GetPredefinedShipDesignManager()) {
         if (entry.second->Name() != "")
             m_game_words.insert(UserString(entry.second->Name()));
     }
@@ -195,12 +195,12 @@ void MessageWndEdit::FindGameWords() {
             m_game_words.insert(UserString(entry.second->Name()));
     }
     // add ship hulls
-    for (const std::map<std::string, ShipDesign*>::value_type& entry : GetPredefinedShipDesignManager()) {
+    for (const auto& entry : GetPredefinedShipDesignManager()) {
         if (entry.second->Hull() != "")
             m_game_words.insert(UserString(entry.second->Hull()));
     }
     // add ship parts
-    for (const std::map<std::string, ShipDesign*>::value_type& entry : GetPredefinedShipDesignManager()) {
+    for (const auto& entry : GetPredefinedShipDesignManager()) {
         for (const std::string& part_name : entry.second->Parts()) {
             if (part_name != "")
                 m_game_words.insert(UserString(part_name));

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -161,7 +161,7 @@ namespace {
                     std::map<std::string, std::unique_ptr<ShipDesign>> file_designs;
                     parse::ship_designs(design_path, file_designs);
 
-                    for (auto& design_entry : file_designs) {
+                    for (auto&& design_entry : file_designs) {
                         if (m_saved_designs.find(design_entry.first) == m_saved_designs.end()) {
                             m_saved_designs[design_entry.first] = std::move(design_entry.second);
                         }

--- a/parse/Parse.h
+++ b/parse/Parse.h
@@ -49,11 +49,11 @@ namespace parse {
     FO_PARSE_API bool ship_hulls(std::map<std::string, HullType*>& hulls);
 
     FO_PARSE_API bool ship_designs(const boost::filesystem::path& path,
-                                   std::map<std::string, ShipDesign*>& designs);
+                                   std::map<std::string, std::unique_ptr<ShipDesign>>& designs);
 
-    FO_PARSE_API bool ship_designs(std::map<std::string, ShipDesign*>& designs);
+    FO_PARSE_API bool ship_designs(std::map<std::string, std::unique_ptr<ShipDesign>>& designs);
 
-    FO_PARSE_API bool monster_designs(std::map<std::string, ShipDesign*>& designs);
+    FO_PARSE_API bool monster_designs(std::map<std::string, std::unique_ptr<ShipDesign>>& designs);
 
     FO_PARSE_API bool fleet_plans(std::vector<FleetPlan*>& fleet_plans_);
 

--- a/parse/ShipDesignsParser.cpp
+++ b/parse/ShipDesignsParser.cpp
@@ -23,18 +23,19 @@ namespace std {
 namespace {
     const boost::phoenix::function<parse::detail::is_unique> is_unique_;
 
-    struct insert_ship_design {
-        typedef void result_type;
+    void insert_ship_design(std::map<std::string, std::unique_ptr<ShipDesign>>& designs,
+                            const std::string& name, const std::string& description,
+                            const std::string& hull, const std::vector<std::string>& parts,
+                            const std::string& icon, const std::string& model,
+                            bool name_desc_in_stringtable)
+    {
+        // TODO use make_unique when converting to C++14
+        auto design = std::unique_ptr<ShipDesign>(
+            new ShipDesign(name, description, 0, ALL_EMPIRES, hull, parts, icon, model, name_desc_in_stringtable, false));
 
-        void operator()(std::map<std::string, std::unique_ptr<ShipDesign>>& designs,
-                        const std::string& name,
-                        ShipDesign* design) const
-        {
-            std::unique_ptr<ShipDesign> designp(design);
-            designs.insert(std::make_pair(name, std::move(designp)));
-        }
+        auto inserted_design = designs.insert(std::make_pair(design->Name(false), std::move(design)));
     };
-    const boost::phoenix::function<insert_ship_design> insert_design_;
+    BOOST_PHOENIX_ADAPT_FUNCTION(void, insert_ship_design_, insert_ship_design, 8)
 
     struct rules {
         rules() {
@@ -87,7 +88,7 @@ namespace {
                         parse::detail::label(Icon_token)     > tok.string [ _e = _1 ]
                      )
                 >    parse::detail::label(Model_token)       > tok.string
-                [ insert_design_(_r1, _a, new_<ShipDesign>(_a, _b, 0, ALL_EMPIRES, _c, _d, _e, _1, _f)) ]
+                [ insert_ship_design_(_r1, _a, _b, _c, _d, _e, _1, _f) ]
                 ;
 
             start

--- a/parse/ShipDesignsParser.cpp
+++ b/parse/ShipDesignsParser.cpp
@@ -5,6 +5,7 @@
 #include "../universe/ShipDesign.h"
 
 #include <boost/spirit/include/phoenix.hpp>
+#include <boost/phoenix/function/adapt_function.hpp>
 
 
 FO_COMMON_API extern const int ALL_EMPIRES;
@@ -13,8 +14,8 @@ FO_COMMON_API extern const int ALL_EMPIRES;
 
 #if DEBUG_PARSERS
 namespace std {
-    inline ostream& operator<<(ostream& os, const std::map<std::string, ShipDesign*>&) { return os; }
-    inline ostream& operator<<(ostream& os, const std::pair<const std::string, ShipDesign*>&) { return os; }
+    inline ostream& operator<<(ostream& os, const std::map<std::string, std::unique_ptr<ShipDesign>>&) { return os; }
+    inline ostream& operator<<(ostream& os, const std::pair<const std::string, std::unique_ptr<ShipDesign>>&) { return os; }
     inline ostream& operator<<(ostream& os, const std::vector<std::string>&) { return os; }
 }
 #endif
@@ -22,7 +23,18 @@ namespace std {
 namespace {
     const boost::phoenix::function<parse::detail::is_unique> is_unique_;
 
-    const boost::phoenix::function<parse::detail::insert> insert_;
+    struct insert_ship_design {
+        typedef void result_type;
+
+        void operator()(std::map<std::string, std::unique_ptr<ShipDesign>>& designs,
+                        const std::string& name,
+                        ShipDesign* design) const
+        {
+            std::unique_ptr<ShipDesign> designp(design);
+            designs.insert(std::make_pair(name, std::move(designp)));
+        }
+    };
+    const boost::phoenix::function<insert_ship_design> insert_design_;
 
     struct rules {
         rules() {
@@ -75,7 +87,7 @@ namespace {
                         parse::detail::label(Icon_token)     > tok.string [ _e = _1 ]
                      )
                 >    parse::detail::label(Model_token)       > tok.string
-                [ insert_(_r1, _a, new_<ShipDesign>(_a, _b, 0, ALL_EMPIRES, _c, _d, _e, _1, _f)) ]
+                [ insert_design_(_r1, _a, new_<ShipDesign>(_a, _b, 0, ALL_EMPIRES, _c, _d, _e, _1, _f)) ]
                 ;
 
             start
@@ -94,11 +106,11 @@ namespace {
         }
 
         typedef parse::detail::rule<
-            void (std::string&, std::string&, std::string&, bool&, const std::map<std::string, ShipDesign*>&)
+            void (std::string&, std::string&, std::string&, bool&, const std::map<std::string, std::unique_ptr<ShipDesign>>&)
         > design_prefix_rule;
 
         typedef parse::detail::rule<
-            void (std::map<std::string, ShipDesign*>&),
+            void (std::map<std::string, std::unique_ptr<ShipDesign>>&),
             boost::spirit::qi::locals<
                 std::string,
                 std::string,
@@ -110,7 +122,7 @@ namespace {
         > design_rule;
 
         typedef parse::detail::rule<
-            void (std::map<std::string, ShipDesign*>&)
+            void (std::map<std::string, std::unique_ptr<ShipDesign>>&)
         > start_rule;
 
         design_prefix_rule design_prefix;
@@ -120,24 +132,24 @@ namespace {
 }
 
 namespace parse {
-    bool ship_designs(const boost::filesystem::path& path, std::map<std::string, ShipDesign*>& designs)
-    { return detail::parse_file<rules, std::map<std::string, ShipDesign*>>(path, designs); }
+    bool ship_designs(const boost::filesystem::path& path, std::map<std::string, std::unique_ptr<ShipDesign>>& designs)
+    { return detail::parse_file<rules, std::map<std::string, std::unique_ptr<ShipDesign>>>(path, designs); }
 
-    bool ship_designs(std::map<std::string, ShipDesign*>& designs) {
+    bool ship_designs(std::map<std::string, std::unique_ptr<ShipDesign>>& designs) {
         bool result = true;
 
         for(const boost::filesystem::path& file : ListScripts("scripting/ship_designs")) {
-            result &= detail::parse_file<rules, std::map<std::string, ShipDesign*>>(file, designs);
+            result &= detail::parse_file<rules, std::map<std::string, std::unique_ptr<ShipDesign>>>(file, designs);
         }
 
         return result;
     }
 
-    bool monster_designs(std::map<std::string, ShipDesign*>& designs) {
+    bool monster_designs(std::map<std::string, std::unique_ptr<ShipDesign>>& designs) {
         bool result = true;
 
         for (const boost::filesystem::path& file : ListScripts("scripting/monster_designs")) {
-            result &= detail::parse_file<rules, std::map<std::string, ShipDesign*>>(file, designs);
+            result &= detail::parse_file<rules, std::map<std::string, std::unique_ptr<ShipDesign>>>(file, designs);
         }
 
         return result;

--- a/python/server/ServerWrapper.cpp
+++ b/python/server/ServerWrapper.cpp
@@ -412,7 +412,7 @@ namespace {
 
     list ShipDesignGetPremadeList() {
         list py_ship_designs;
-        for (const std::map<std::string, ShipDesign*>::value_type& entry : GetPredefinedShipDesignManager()) {
+        for (const auto& entry : GetPredefinedShipDesignManager()) {
             py_ship_designs.append(object(entry.first));
         }
         return list(py_ship_designs);

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -1070,23 +1070,15 @@ PredefinedShipDesignManager::PredefinedShipDesignManager() {
     }
 
     TraceLogger() << "Predefined Ship Designs:";
-    for (const auto& entry : m_ship_designs) {
-        const ShipDesign* d = entry.second;
-        TraceLogger() << " ... " << d->Name();
-    }
+    for (const auto& entry : m_ship_designs)
+        TraceLogger() << " ... " << entry.second->Name();
+
     TraceLogger() << "Monster Ship Designs:";
-    for (const auto& entry : m_monster_designs) {
-        const ShipDesign* d = entry.second;
-        TraceLogger() << " ... " << d->Name();
-    }
+    for (const auto& entry : m_monster_designs)
+        TraceLogger() << " ... " << entry.second->Name();
 
     // Only update the global pointer on sucessful construction.
     s_instance = this;
-}
-
-PredefinedShipDesignManager::~PredefinedShipDesignManager() {
-    for (std::map<std::string, ShipDesign*>::value_type& entry : m_ship_designs)
-        delete entry.second;
 }
 
 void PredefinedShipDesignManager::AddShipDesignsToEmpire(Empire* empire,
@@ -1098,14 +1090,14 @@ void PredefinedShipDesignManager::AddShipDesignsToEmpire(Empire* empire,
     Universe& universe = GetUniverse();
 
     for (const std::string& design_name : design_names) {
-        std::map<std::string, ShipDesign*>::const_iterator design_it = m_ship_designs.find(design_name);
+        const auto& design_it = m_ship_designs.find(design_name);
         if (design_it == m_ship_designs.end()) {
             ErrorLogger() << "Couldn't find predefined ship design with name " << design_name << " to add to empire";
             continue;
         }
 
         // only add producible designs to empires
-        const ShipDesign* d = design_it->second;
+        const std::unique_ptr<ShipDesign>& d = design_it->second;
         if (!d->Producible())
             continue;
 
@@ -1127,7 +1119,7 @@ void PredefinedShipDesignManager::AddShipDesignsToEmpire(Empire* empire,
 
 namespace {
     void AddDesignToUniverse(std::map<std::string, int>& design_generic_ids,
-                             ShipDesign* design, bool monster)
+                             const std::unique_ptr<ShipDesign>& design, bool monster)
     {
         if (!design)
             return;
@@ -1183,15 +1175,11 @@ namespace {
 const std::map<std::string, int>& PredefinedShipDesignManager::AddShipDesignsToUniverse() const {
     m_design_generic_ids.clear();   // std::map<std::string, int>
 
-    for (const std::map<std::string, ShipDesign*>::value_type& entry : m_ship_designs) {
-        ShipDesign* d = entry.second;
-        AddDesignToUniverse(m_design_generic_ids, d, false);
-    }
+    for (const auto& entry : m_ship_designs)
+        AddDesignToUniverse(m_design_generic_ids, entry.second, false);
 
-    for (const std::map<std::string, ShipDesign*>::value_type& entry : m_monster_designs) {
-        ShipDesign* d = entry.second;
-        AddDesignToUniverse(m_design_generic_ids, d, true);
-    }
+    for (const auto& entry : m_monster_designs)
+        AddDesignToUniverse(m_design_generic_ids, entry.second, true);
 
     return m_design_generic_ids;
 }

--- a/universe/ShipDesign.h
+++ b/universe/ShipDesign.h
@@ -570,7 +570,7 @@ FO_COMMON_API const ShipDesign* GetShipDesign(int ship_design_id);
 
 class FO_COMMON_API PredefinedShipDesignManager {
 public:
-    typedef std::map<std::string, ShipDesign*>::const_iterator iterator;
+    typedef std::map<std::string, std::unique_ptr<ShipDesign>>::const_iterator iterator;
     typedef std::map<std::string, int>::const_iterator generic_iterator;
 
     /** \name Accessors */ //@{
@@ -614,10 +614,9 @@ public:
 
 private:
     PredefinedShipDesignManager();
-    ~PredefinedShipDesignManager();
 
-    std::map<std::string, ShipDesign*>  m_ship_designs;
-    std::map<std::string, ShipDesign*>  m_monster_designs;
+    std::map<std::string, std::unique_ptr<ShipDesign>>  m_ship_designs;
+    std::map<std::string, std::unique_ptr<ShipDesign>>  m_monster_designs;
     mutable std::map<std::string, int>  m_design_generic_ids;   // ids of designs from this manager that have been added to the universe with no empire as the creator
 
     static PredefinedShipDesignManager* s_instance;


### PR DESCRIPTION
**Problem**
The ShipDesignParser is a generator.  In C++11 is should return a `std::unique_ptr<>` to indicate that it has created something that requires memory management and that it is passing management responsibility to the calling function.  The calling function can chose to receive it as a `unique_ptr<>` or transfer it to a `shared_ptr<>` if it needs a shared ownership model.

Furthermore the error condition near line 29 leaks the passed in pointer.  This is a static leak, it only leaks objects that have failed to parse once per game.

**Solution**
Return `std::unique_ptr<>`s.