### PR TITLE
Fix bug#1556 server terminates on non unique parses

### DIFF
--- a/parse/BuildingsParser.cpp
+++ b/parse/BuildingsParser.cpp
@@ -49,7 +49,7 @@ namespace {
             building_type
                 =   tok.BuildingType_
                 >   parse::detail::label(Name_token)
-                >   tok.string        [ _pass = is_unique_(_r1, "BuildingType", _1), _a = _1 ]
+                >   tok.string        [ _pass = is_unique_(_r1, BuildingType_token, _1), _a = _1 ]
                 >   parse::detail::label(Description_token)         > tok.string        [ _b = _1 ]
                 >   (   parse::detail::label(CaptureResult_token)   >> parse::capture_result_enum() [ _d = _1 ]
                     |   eps [ _d = CR_CAPTURE ]

--- a/parse/BuildingsParser.cpp
+++ b/parse/BuildingsParser.cpp
@@ -21,17 +21,9 @@ namespace std {
 #endif
 
 namespace {
-    struct insert_ {
-        typedef void result_type;
+    const boost::phoenix::function<parse::detail::is_unique> is_unique_;
 
-        void operator()(std::map<std::string, BuildingType*>& building_types, BuildingType* building_type) const {
-            if (!building_types.insert(std::make_pair(building_type->Name(), building_type)).second) {
-                std::string error_str = "ERROR: More than one building type has the name " + building_type->Name();
-                throw std::runtime_error(error_str.c_str());
-            }
-        }
-    };
-    const boost::phoenix::function<insert_> insert;
+    const boost::phoenix::function<parse::detail::insert> insert_;
 
     struct rules {
         rules() {
@@ -48,6 +40,7 @@ namespace {
             qi::_b_type _b;
             qi::_c_type _c;
             qi::_d_type _d;
+            qi::_pass_type _pass;
             qi::_r1_type _r1;
             qi::eps_type eps;
 
@@ -55,14 +48,15 @@ namespace {
 
             building_type
                 =   tok.BuildingType_
-                >   parse::detail::label(Name_token)                > tok.string        [ _a = _1 ]
+                >   parse::detail::label(Name_token)
+                >   tok.string        [ _pass = is_unique_(_r1, "BuildingType", _1), _a = _1 ]
                 >   parse::detail::label(Description_token)         > tok.string        [ _b = _1 ]
                 >   (   parse::detail::label(CaptureResult_token)   >> parse::capture_result_enum() [ _d = _1 ]
                     |   eps [ _d = CR_CAPTURE ]
                     )
                 >   parse::detail::common_params_parser() [ _c = _1 ]
                 >   parse::detail::label(Icon_token)      > tok.string
-                [ insert(_r1, new_<BuildingType>(_a, _b, _c, _d, _1)) ]
+                [ insert_(_r1, _a, new_<BuildingType>(_a, _b, _c, _d, _1)) ]
                 ;
 
             start

--- a/parse/FieldsParser.cpp
+++ b/parse/FieldsParser.cpp
@@ -47,7 +47,7 @@ namespace {
             field
                 =   tok.FieldType_
                 >   parse::detail::label(Name_token)
-                >   tok.string        [ _pass = is_unique_(_r1, "FieldType", _1), _a = _1 ]
+                >   tok.string        [ _pass = is_unique_(_r1, FieldType_token, _1), _a = _1 ]
                 >   parse::detail::label(Description_token)         > tok.string [ _b = _1 ]
                 >   parse::detail::label(Stealth_token)             > parse::detail::double_ [ _c = _1]
                 >   parse::detail::tags_parser()(_d)

--- a/parse/ParseImpl.h
+++ b/parse/ParseImpl.h
@@ -19,7 +19,7 @@ namespace parse { namespace detail {
         typedef bool result_type;
 
         template <typename Map>
-        result_type operator() (const Map& map, const std::string& type, const std::string& key) const {
+        result_type operator() (const Map& map, const char* const type, const std::string& key) const {
             // Will this key be unique?
             auto will_be_unique = (map.count(key) == 0);
             if (!will_be_unique)

--- a/parse/ParseImpl.h
+++ b/parse/ParseImpl.h
@@ -13,6 +13,31 @@
 
 
 namespace parse { namespace detail {
+
+    /// A functor to determine if \p key will be unique in \p map of \p type, and log an error otherwise.
+    struct is_unique {
+        typedef bool result_type;
+
+        template <typename Map>
+        result_type operator() (const Map& map, const std::string& type, const std::string& key) const {
+            // Will this key be unique?
+            auto will_be_unique = (map.count(key) == 0);
+            if (!will_be_unique)
+                ErrorLogger() << "More than one " <<  type << " has the same name, " << key << ".";
+            return will_be_unique;
+        }
+    };
+
+    /// A functor to insert a \p value with key \p key into \p map.
+    struct insert {
+        typedef void result_type;
+
+        template <typename Map, typename Value>
+        result_type operator() (Map& map, const std::string& key, Value* value) const {
+            map.insert(std::make_pair(key, value));
+        }
+    };
+
     template <
         typename signature = boost::spirit::qi::unused_type,
         typename locals = boost::spirit::qi::unused_type

--- a/parse/ParseImpl.h
+++ b/parse/ParseImpl.h
@@ -33,9 +33,8 @@ namespace parse { namespace detail {
         typedef void result_type;
 
         template <typename Map, typename Value>
-        result_type operator() (Map& map, const std::string& key, Value* value) const {
-            map.insert(std::make_pair(key, value));
-        }
+        result_type operator() (Map& map, const std::string& key, Value* value) const
+        { map.insert(std::make_pair(key, value)); }
     };
 
     template <

--- a/parse/ShipDesignsParser.cpp
+++ b/parse/ShipDesignsParser.cpp
@@ -55,7 +55,7 @@ namespace {
             design_prefix
                 =    tok.ShipDesign_
                 >    parse::detail::label(Name_token)
-                >   tok.string        [ _pass = is_unique_(_r5, "ShipDesign", _1), _r1 = _1 ]
+                >   tok.string        [ _pass = is_unique_(_r5, ShipDesign_token, _1), _r1 = _1 ]
                 >    parse::detail::label(Description_token) > tok.string [ _r2 = _1 ]
                 > (
                      tok.NoStringtableLookup_ [ _r4 = false ]

--- a/parse/ShipHullsParser.cpp
+++ b/parse/ShipHullsParser.cpp
@@ -29,17 +29,9 @@ namespace std {
 #endif
 
 namespace {
-    struct insert_hull_ {
-        typedef void result_type;
+    const boost::phoenix::function<parse::detail::is_unique> is_unique_;
 
-        void operator()(std::map<std::string, HullType*>& hulls, HullType* hull) const {
-            if (!hulls.insert(std::make_pair(hull->Name(), hull)).second) {
-                std::string error_str = "ERROR: More than one ship hull has the name " + hull->Name();
-                throw std::runtime_error(error_str.c_str());
-            }
-        }
-    };
-    const boost::phoenix::function<insert_hull_> insert_hull;
+    const boost::phoenix::function<parse::detail::insert> insert_;
 
     struct rules {
         rules() {
@@ -62,6 +54,7 @@ namespace {
             qi::_e_type _e;
             qi::_f_type _f;
             qi::_r1_type _r1;
+            qi::_pass_type _pass;
             qi::_val_type _val;
             qi::eps_type eps;
             qi::lit_type lit;
@@ -96,13 +89,15 @@ namespace {
 
             hull
                 =   tok.Hull_
-                >   parse::detail::more_common_params_parser()  [ _a = _1 ]
+                >   parse::detail::more_common_params_parser()
+                    [_pass = is_unique_(_r1, "HullType", phoenix::bind(&MoreCommonParams::name, _1)), _a = _1 ]
                 >   hull_stats                                  [ _c = _1 ]
                 >  -slots(_e)
                 >   parse::detail::common_params_parser()       [ _d = _1 ]
                 >   parse::detail::label(Icon_token)    > tok.string    [ _f = _1 ]
                 >   parse::detail::label(Graphic_token) > tok.string
-                    [ insert_hull(_r1, new_<HullType>(_c, _d, _a, _e, _f, _1)) ]
+                [ insert_(_r1, phoenix::bind(&MoreCommonParams::name, _a),
+                          new_<HullType>(_c, _d, _a, _e, _f, _1)) ]
                 ;
 
             start

--- a/parse/ShipHullsParser.cpp
+++ b/parse/ShipHullsParser.cpp
@@ -90,7 +90,7 @@ namespace {
             hull
                 =   tok.Hull_
                 >   parse::detail::more_common_params_parser()
-                    [_pass = is_unique_(_r1, "HullType", phoenix::bind(&MoreCommonParams::name, _1)), _a = _1 ]
+                    [_pass = is_unique_(_r1, HullType_token, phoenix::bind(&MoreCommonParams::name, _1)), _a = _1 ]
                 >   hull_stats                                  [ _c = _1 ]
                 >  -slots(_e)
                 >   parse::detail::common_params_parser()       [ _d = _1 ]

--- a/parse/ShipPartsParser.cpp
+++ b/parse/ShipPartsParser.cpp
@@ -27,18 +27,9 @@ namespace std {
 #endif
 
 namespace {
-    struct insert_part_type_ {
-        typedef void result_type;
+    const boost::phoenix::function<parse::detail::is_unique> is_unique_;
 
-        void operator()(std::map<std::string, PartType*>& part_types, PartType* part_type) const {
-            if (!part_types.insert(std::make_pair(part_type->Name(), part_type)).second) {
-                std::string error_str = "ERROR: More than one ship part has the name " + part_type->Name();
-                throw std::runtime_error(error_str.c_str());
-            }
-        }
-    };
-    const boost::phoenix::function<insert_part_type_> insert_part_type;
-
+    const boost::phoenix::function<parse::detail::insert> insert_;
 
     struct rules {
         rules() {
@@ -61,6 +52,7 @@ namespace {
             qi::_f_type _f;
             qi::_g_type _g;
             qi::_h_type _h;
+            qi::_pass_type _pass;
             qi::_r1_type _r1;
             qi::eps_type eps;
 
@@ -78,7 +70,8 @@ namespace {
 
             part_type
                 = ( tok.Part_
-                >   parse::detail::more_common_params_parser()       [ _a = _1 ]
+                >   parse::detail::more_common_params_parser()
+                    [_pass = is_unique_(_r1, "PartType", phoenix::bind(&MoreCommonParams::name, _1)), _a = _1 ]
                 >   parse::detail::label(Class_token)       > parse::ship_part_class_enum() [ _c = _1 ]
                 > (  (parse::detail::label(Capacity_token)  > parse::detail::double_ [ _d = _1 ])
                    | (parse::detail::label(Damage_token)    > parse::detail::double_ [ _d = _1 ])
@@ -94,7 +87,8 @@ namespace {
                 >   slots(_f)
                 >   parse::detail::common_params_parser()           [ _e = _1 ]
                 >   parse::detail::label(Icon_token)        > tok.string    [ _b = _1 ]
-                  ) [ insert_part_type(_r1, new_<PartType>(_c, _d, _h, _e, _a, _f, _b, _g)) ]
+                  ) [ insert_(_r1, phoenix::bind(&MoreCommonParams::name, _a),
+                              new_<PartType>(_c, _d, _h, _e, _a, _f, _b, _g)) ]
                 ;
 
             start

--- a/parse/ShipPartsParser.cpp
+++ b/parse/ShipPartsParser.cpp
@@ -71,7 +71,7 @@ namespace {
             part_type
                 = ( tok.Part_
                 >   parse::detail::more_common_params_parser()
-                    [_pass = is_unique_(_r1, "PartType", phoenix::bind(&MoreCommonParams::name, _1)), _a = _1 ]
+                    [_pass = is_unique_(_r1, PartType_token, phoenix::bind(&MoreCommonParams::name, _1)), _a = _1 ]
                 >   parse::detail::label(Class_token)       > parse::ship_part_class_enum() [ _c = _1 ]
                 > (  (parse::detail::label(Capacity_token)  > parse::detail::double_ [ _d = _1 ])
                    | (parse::detail::label(Damage_token)    > parse::detail::double_ [ _d = _1 ])

--- a/parse/SpecialsParser.cpp
+++ b/parse/SpecialsParser.cpp
@@ -20,17 +20,9 @@ namespace std {
 #endif
 
 namespace {
-    struct insert_ {
-        typedef void result_type;
+    const boost::phoenix::function<parse::detail::is_unique> is_unique_;
 
-        void operator()(std::map<std::string, Special*>& specials, Special* special) const {
-            if (!specials.insert(std::make_pair(special->Name(), special)).second) {
-                std::string error_str = "ERROR: More than one special has the name " + special->Name();
-                throw std::runtime_error(error_str.c_str());
-            }
-        }
-    };
-    const boost::phoenix::function<insert_> insert;
+    const boost::phoenix::function<parse::detail::insert> insert_;
 
     struct rules {
         rules() {
@@ -51,16 +43,19 @@ namespace {
             qi::_f_type _f;
             qi::_g_type _g;
             qi::_h_type _h;
+            qi::_pass_type _pass;
             qi::_r1_type _r1;
             qi::_r2_type _r2;
+            qi::_r3_type _r3;
             qi::eps_type eps;
 
             const parse::lexer& tok = parse::lexer::instance();
 
             special_prefix
                 =    tok.Special_
-                >    parse::detail::label(Name_token)               > tok.string [ _r1 = _1 ]
-                >    parse::detail::label(Description_token)        > tok.string [ _r2 = _1 ]
+                >    parse::detail::label(Name_token)
+                >    tok.string        [ _pass = is_unique_(_r1, "Special", _1), _r2 = _1 ]
+                >    parse::detail::label(Description_token)        > tok.string [ _r3 = _1 ]
                 ;
 
             spawn
@@ -73,14 +68,14 @@ namespace {
                 ;
 
             special
-                =    special_prefix(_a, _b)
+                =    special_prefix(_r1, _a, _b)
                 >  -(parse::detail::label(Stealth_token)            > parse::double_value_ref() [ _g = _1 ])
                 >    spawn(_c, _d)
                 >  -(parse::detail::label(Capacity_token)           > parse::double_value_ref() [ _h = _1 ])
                 >  -(parse::detail::label(Location_token)           > parse::detail::condition_parser [ _e = _1 ])
                 >  -(parse::detail::label(EffectsGroups_token)      > parse::detail::effects_group_parser() [ _f = _1 ])
                 >    parse::detail::label(Graphic_token)            > tok.string
-                [ insert(_r1, new_<Special>(_a, _b, _g, _f, _c, _d, _h, _e, _1)) ]
+                [ insert_(_r1, _a, new_<Special>(_a, _b, _g, _f, _c, _d, _h, _e, _1)) ]
                 ;
 
             start
@@ -101,7 +96,7 @@ namespace {
         }
 
         typedef parse::detail::rule<
-            void (std::string&, std::string&)
+            void (const std::map<std::string, Special*>&, std::string&, std::string&)
         > special_prefix_rule;
 
         typedef parse::detail::rule<

--- a/parse/SpecialsParser.cpp
+++ b/parse/SpecialsParser.cpp
@@ -54,7 +54,7 @@ namespace {
             special_prefix
                 =    tok.Special_
                 >    parse::detail::label(Name_token)
-                >    tok.string        [ _pass = is_unique_(_r1, "Special", _1), _r2 = _1 ]
+                >    tok.string        [ _pass = is_unique_(_r1, Special_token, _1), _r2 = _1 ]
                 >    parse::detail::label(Description_token)        > tok.string [ _r3 = _1 ]
                 ;
 

--- a/parse/SpeciesParser.cpp
+++ b/parse/SpeciesParser.cpp
@@ -104,7 +104,7 @@ namespace {
 
             species_strings
                 =    parse::detail::label(Name_token)                   > tok.string
-                     [ _pass = is_unique_(_r1, "Species", _1), _a = _1 ]
+                     [ _pass = is_unique_(_r1, Species_token, _1), _a = _1 ]
                 >    parse::detail::label(Description_token)            > tok.string [ _b = _1 ]
                 >    parse::detail::label(Gameplay_Description_token)   > tok.string [ _c = _1 ]
                     [ _val = construct<SpeciesStrings>(_a, _b, _c) ]

--- a/parse/TechsParser.cpp
+++ b/parse/TechsParser.cpp
@@ -145,7 +145,7 @@ namespace {
 
             category
                 =   tok.Category_
-                >   parse::detail::label(Name_token)    > tok.string [ _pass = is_unique_(_r1, "Tech Category", _1), _a = _1 ]
+                >   parse::detail::label(Name_token)    > tok.string [ _pass = is_unique_(_r1, Category_token, _1), _a = _1 ]
                 >   parse::detail::label(Graphic_token) > tok.string [ _b = _1 ]
                 >   parse::detail::label(Colour_token)  > parse::detail::color_parser() [ insert_category_(_r1, new_<TechCategory>(_a, _b, _1)) ]
                 ;

--- a/parse/Tokens.cpp
+++ b/parse/Tokens.cpp
@@ -3,7 +3,7 @@
 #include <boost/preprocessor/stringize.hpp>
 
 
-#define DEFINE_TOKEN(r, _, name) const char* BOOST_PP_CAT(name, _token) = BOOST_PP_STRINGIZE(name);
+#define DEFINE_TOKEN(r, _, name) const char* const BOOST_PP_CAT(name, _token) = BOOST_PP_STRINGIZE(name);
 BOOST_PP_SEQ_FOR_EACH(DEFINE_TOKEN, _, TOKEN_SEQ_1)
 BOOST_PP_SEQ_FOR_EACH(DEFINE_TOKEN, _, TOKEN_SEQ_2)
 BOOST_PP_SEQ_FOR_EACH(DEFINE_TOKEN, _, TOKEN_SEQ_3)

--- a/parse/Tokens.h
+++ b/parse/Tokens.h
@@ -513,7 +513,7 @@
     (Y)                                         \
     (Yellow)
 
-#define DECLARE_TOKEN(r, _, elem) extern const char* BOOST_PP_CAT(elem, _token);
+#define DECLARE_TOKEN(r, _, elem) extern const char* const BOOST_PP_CAT(elem, _token);
 BOOST_PP_SEQ_FOR_EACH(DECLARE_TOKEN, _, TOKEN_SEQ_1)
 BOOST_PP_SEQ_FOR_EACH(DECLARE_TOKEN, _, TOKEN_SEQ_2)
 BOOST_PP_SEQ_FOR_EACH(DECLARE_TOKEN, _, TOKEN_SEQ_3)

--- a/parse/Tokens.h
+++ b/parse/Tokens.h
@@ -166,6 +166,7 @@
     (HullSpeed)                                 \
     (HullStealth)                               \
     (HullStructure)                             \
+    (HullType)                                  \
     (Human)                                     \
     (Icon)                                      \
     (ID)                                        \
@@ -281,6 +282,7 @@
     (Parts)                                     \
     (PartOfClassInShipDesign)                   \
     (PartsInShipDesign)                         \
+    (PartType)                                  \
     (Passive)                                   \
     (Planet)                                    \
     (Planetbound)                               \

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -1075,17 +1075,17 @@ PredefinedShipDesignManager::PredefinedShipDesignManager() {
         throw;
     }
 
-    if (true || GetOptionsDB().Get<bool>("verbose-logging")) {
+    if (GetOptionsDB().Get<bool>("verbose-logging")) {
         DebugLogger() << "Predefined Ship Designs:";
         for (const std::map<std::string, ShipDesign*>::value_type& entry : m_ship_designs) {
             const ShipDesign* d = entry.second;
             DebugLogger() << " ... " << d->Name();
         }
-        // DebugLogger() << "Monster Ship Designs:";
-        // for (const std::map<std::string, ShipDesign*>::value_type& entry : m_monster_designs) {
-        //     const ShipDesign* d = entry.second;
-        //     DebugLogger() << " ... " << d->Name();
-        // }
+        DebugLogger() << "Monster Ship Designs:";
+        for (const std::map<std::string, ShipDesign*>::value_type& entry : m_monster_designs) {
+            const ShipDesign* d = entry.second;
+            DebugLogger() << " ... " << d->Name();
+        }
     }
 
     // Only update the global pointer on sucessful construction.

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -1075,17 +1075,17 @@ PredefinedShipDesignManager::PredefinedShipDesignManager() {
         throw;
     }
 
-    if (GetOptionsDB().Get<bool>("verbose-logging")) {
+    if (true || GetOptionsDB().Get<bool>("verbose-logging")) {
         DebugLogger() << "Predefined Ship Designs:";
         for (const std::map<std::string, ShipDesign*>::value_type& entry : m_ship_designs) {
             const ShipDesign* d = entry.second;
             DebugLogger() << " ... " << d->Name();
         }
-        DebugLogger() << "Monster Ship Designs:";
-        for (const std::map<std::string, ShipDesign*>::value_type& entry : m_monster_designs) {
-            const ShipDesign* d = entry.second;
-            DebugLogger() << " ... " << d->Name();
-        }
+        // DebugLogger() << "Monster Ship Designs:";
+        // for (const std::map<std::string, ShipDesign*>::value_type& entry : m_monster_designs) {
+        //     const ShipDesign* d = entry.second;
+        //     DebugLogger() << " ... " << d->Name();
+        // }
     }
 
     // Only update the global pointer on sucessful construction.


### PR DESCRIPTION
This PR fixes #1556.

***Problem Description***

The problem has several contributing factors.
- the parser code indicates some errors with the `boost::spirit error` handling and emits `ErrorLogger()` messages and throws `std::runtime_error` for uniqueness errors.
- The universe <X>TypeManagers are singletons created as static local function variables.  
- The <X>TypeManagers parse in their constructors.  Any exceptions in the constructor cause the construction to fail and the constructor to be run on every access of the manager.  Consequently, exceptions are thrown on the server, in the UI, in the python code and other difficult to catch locations.  

***This Solution***
This PR transforms the non-uniqueness exceptions into a failure condition on the parse of the name of the type in question.  These errors are now handled with the regular `boost::spirit` error handler.