### PR TITLE
Improve AI trooper movement

### DIFF
--- a/default/python/AI/FleetUtilsAI.py
+++ b/default/python/AI/FleetUtilsAI.py
@@ -1,3 +1,4 @@
+import math
 import sys
 
 import freeOrionAIInterface as fo  # pylint: disable=import-error
@@ -598,3 +599,12 @@ def get_max_fuel(fleet_id):
 def get_fleet_upkeep():
     # TODO: Use new upkeep calculation
     return 1 + AIDependencies.SHIP_UPKEEP * foAI.foAIstate.shipCount
+
+
+def calculate_estimated_time_of_arrival(fleet_id, target_system_id):
+    universe = fo.getUniverse()
+    fleet = universe.getFleet(fleet_id)
+    if not fleet or not fleet.speed:
+        return 99999
+    distance = universe.shortestPathDistance(fleet_id, target_system_id)
+    return math.ceil(float(distance) / fleet.speed)

--- a/default/python/AI/MilitaryAI.py
+++ b/default/python/AI/MilitaryAI.py
@@ -860,3 +860,12 @@ def get_tot_mil_rating():
 def get_num_military_ships():
     return sum(foAI.foAIstate.fleetStatus.get(fid, {}).get('nships', 0)
                for fid in FleetUtilsAI.get_empire_fleet_ids_by_role(MissionType.MILITARY))
+
+
+def get_military_fleets_with_target_system(target_system_id):
+    military_mission_types = [MissionType.MILITARY,  MissionType.SECURE]
+    found_fleets = []
+    for fleet_mission in foAI.foAIstate.get_fleet_missions_with_any_mission_types(military_mission_types):
+        if fleet_mission.target and fleet_mission.target.id == target_system_id:
+            found_fleets.append(fleet_mission.fleet.id)
+    return found_fleets

--- a/default/python/AI/fleet_orders.py
+++ b/default/python/AI/fleet_orders.py
@@ -33,7 +33,7 @@ def trooper_move_reqs_met(main_fleet_mission, order, verbose):
     invasion_system = invasion_target.get_system()
     supplied_systems = fo.getEmpire().fleetSupplyableSystemIDs
     # if about to leave supply lines
-    if order.target.id not in supplied_systems:
+    if order.target.id not in supplied_systems or fo.getUniverse().jumpDistance(order.fleet.id, invasion_system.id) < 5:
         if invasion_planet.currentMeterValue(fo.meterType.maxShield):
             military_support_fleets = MilitaryAI.get_military_fleets_with_target_system(invasion_system.id)
             if not military_support_fleets:

--- a/default/python/AI/fleet_orders.py
+++ b/default/python/AI/fleet_orders.py
@@ -28,13 +28,12 @@ def trooper_move_reqs_met(main_fleet_mission, order, verbose):
     # is already a military fleet assigned to secure the target, and don't take final jump unless the planet is
     # (to the AI's knowledge) down to zero shields.  Additional checks will also be done by the later
     # generic movement code
-    system_id = order.fleet.get_system().id
     invasion_target = main_fleet_mission.target
     invasion_planet = invasion_target.get_object()
     invasion_system = invasion_target.get_system()
     supplied_systems = fo.getEmpire().fleetSupplyableSystemIDs
     # if about to leave supply lines
-    if order.target.id not in supplied_systems and system_id in supplied_systems:
+    if order.target.id not in supplied_systems:
         if invasion_planet.currentMeterValue(fo.meterType.maxShield):
             military_support_fleets = MilitaryAI.get_military_fleets_with_target_system(invasion_system.id)
             if not military_support_fleets:

--- a/python/UniverseWrapper.cpp
+++ b/python/UniverseWrapper.cpp
@@ -119,6 +119,11 @@ namespace {
     }
     boost::function<std::vector<int>(const Universe&, int, int, int)> ShortestPathFunc =        &ShortestPath;
 
+    double                  ShortestPathDistance(const Universe& universe, int object1_id, int object2_id) {
+        return universe.GetPathfinder()->ShortestPathDistance(object1_id, object2_id);
+    }
+    boost::function<double(const Universe&, int, int)> ShortestPathDistanceFunc =               &ShortestPathDistance;
+
     std::vector<int>        LeastJumpsPath(const Universe& universe, int start_sys, int end_sys, int empire_id) {
         std::vector<int> retval;
         std::pair<std::list<int>, int> path = universe.GetPathfinder()->LeastJumpsPath(start_sys, end_sys, empire_id);
@@ -337,6 +342,12 @@ namespace FreeOrionPython {
                                                     ShortestPathFunc,
                                                     return_value_policy<return_by_value>(),
                                                     boost::mpl::vector<std::vector<int>, const Universe&, int, int, int>()
+                                                ))
+
+            .def("shortestPathDistance",        make_function(
+                                                    ShortestPathDistanceFunc,
+                                                    return_value_policy<return_by_value>(),
+                                                    boost::mpl::vector<double, const Universe&, int, int>()
                                                 ))
 
             .def("leastJumpsPath",              make_function(


### PR DESCRIPTION
Currently, the AI will advance its troop ships beyond its supply as soon as it has allocated military resources to the target system regardless how long the military fleet will take to arrive.

This PR adresses the issue by calculating the estimated time it will take the military fleets to arrive at the target system and only advance the troop ships, if those would arrive later than the military fleets.

An additional commit adresses another flaw of the current logic: The AI would correctly wait at its borders but once it started moving into enemy territory, it would not stop despite not having military resources allocated.
In this PR, the behaviour is checked to always require a military fleet (with correct arrival time, see above) if trooper want to advance into unsupplied systems regardless of their current position.

The behaviour of the AI can be further improved by making sure that the troopers will stay at a safe distance, preferably out of enemy scout range. This is intended for a later PR.

Resolves #1538 
