### PR TITLE
Fix LeakSanitizer errors.

### DIFF
--- a/GG/GG/RichText/RichText.h
+++ b/GG/GG/RichText/RichText.h
@@ -59,7 +59,7 @@ public:
     };
 
     //! The type of the object where we store control factories of tags.
-    typedef std::map<std::string, IBlockControlFactory*> BLOCK_FACTORY_MAP;
+    typedef std::map<std::string, std::shared_ptr<IBlockControlFactory>> BLOCK_FACTORY_MAP;
 
     //! The special tag that is used to represent plaintext.
     // Allows you to register a custom control for displaying plaintext.
@@ -92,7 +92,7 @@ public:
     void SetBlockFactoryMap(const std::shared_ptr<BLOCK_FACTORY_MAP>& block_factory_map);
 
     //! Registers a factory in the default block factory map.
-    static int RegisterDefaultBlock(const std::string& tag, IBlockControlFactory* factory);
+    static int RegisterDefaultBlock(const std::string& tag, std::shared_ptr<IBlockControlFactory>&& factory);
 
     //! Access the default block factory map.
     static std::shared_ptr<RichText::BLOCK_FACTORY_MAP>& DefaultBlockFactoryMap();

--- a/GG/src/RichText/ImageBlock.cpp
+++ b/GG/src/RichText/ImageBlock.cpp
@@ -153,7 +153,7 @@ namespace GG {
     };
 
     // Register image block as the image tag handler.
-    static int dummy = RichText::RegisterDefaultBlock(ImageBlock::IMAGE_TAG, new ImageBlockFactory());
+    static int dummy = RichText::RegisterDefaultBlock(ImageBlock::IMAGE_TAG, std::make_shared<ImageBlockFactory>());
 
     //! Set the root path from which to look for images with the factory.
     bool ImageBlock::SetImagePath(RichText::IBlockControlFactory* factory, const fs::path& path)
@@ -176,7 +176,7 @@ namespace GG {
         // Find the image block factory from the default map and give it the path.
         RichText::BLOCK_FACTORY_MAP::const_iterator factory_it = RichText::DefaultBlockFactoryMap()->find(IMAGE_TAG);
         if (factory_it != RichText::DefaultBlockFactoryMap()->end()) {
-            if (ImageBlockFactory* factory = dynamic_cast<ImageBlockFactory*>(factory_it->second)) {
+            if (ImageBlockFactory* factory = dynamic_cast<ImageBlockFactory*>(factory_it->second.get())) {
                 return SetImagePath(factory, path);
             }
         }

--- a/GG/src/RichText/RichText.cpp
+++ b/GG/src/RichText/RichText.cpp
@@ -313,10 +313,10 @@ namespace GG {
         return tag_map;
     }
 
-    int RichText::RegisterDefaultBlock(const std::string& tag, IBlockControlFactory* factory)
+    int RichText::RegisterDefaultBlock(const std::string& tag, std::shared_ptr<IBlockControlFactory>&& factory)
     {
         Font::RegisterKnownTag(tag);
-        (*DefaultBlockFactoryMap()) [tag] = factory;
+        (*DefaultBlockFactoryMap()) [tag] = std::move(factory);
 
         // Return a dummy to enable static registration.
         return 0;

--- a/GG/src/RichText/TextBlock.cpp
+++ b/GG/src/RichText/TextBlock.cpp
@@ -70,5 +70,5 @@ namespace GG {
 
     // Register text block as the default plaintext handler.
     static int dummy =
-        RichText::RegisterDefaultBlock(RichText::PLAINTEXT_TAG, new TextBlockFactory());
+        RichText::RegisterDefaultBlock(RichText::PLAINTEXT_TAG, std::make_shared<TextBlockFactory>());
 }

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -613,7 +613,7 @@ EncyclopediaDetailPanel::EncyclopediaDetailPanel(GG::Flags<GG::WndFlag> flags, c
         boost::bind(&EncyclopediaDetailPanel::HandleLinkDoubleClick, this, _1, _2));
     factory->LinkRightClickedSignal.connect(
         boost::bind(&EncyclopediaDetailPanel::HandleLinkDoubleClick, this, _1, _2));
-    (*factory_map)[GG::RichText::PLAINTEXT_TAG] = factory;
+    (*factory_map)[GG::RichText::PLAINTEXT_TAG] = std::shared_ptr<GG::RichText::IBlockControlFactory>(factory);
     m_description_rich_text->SetBlockFactoryMap(factory_map);
     m_description_rich_text->SetPadding(DESCRIPTION_PADDING);
 


### PR DESCRIPTION
This commit fix leaks in GG. Can be reproduced with tests compiled with sanitizer.

```
==30868==ERROR: LeakSanitizer: detected memory leaks

Direct leak of 40 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6f06612 in operator new(unsigned long) (/usr/lib/gcc/x86_64-pc-linux-gnu/5.4.0/libasan.so.2+0x99612)
    #1 0x7ffff4356846 in __static_initialization_and_destruction_0 /mnt/another/srcs/GIT/freeorion/GG/src/RichText/ImageBlock.cpp:156
    #2 0x7ffff435697d in _GLOBAL__sub_I_ImageBlock.cpp /mnt/another/srcs/GIT/freeorion/GG/src/RichText/ImageBlock.cpp:185
    #3 0x7ffff7de92a9  (/lib64/ld-linux-x86-64.so.2+0xf2a9)

Objects leaked above:
0x60400000df50 (40 bytes)

Direct leak of 8 byte(s) in 1 object(s) allocated from:
    #0 0x7ffff6f06612 in operator new(unsigned long) (/usr/lib/gcc/x86_64-pc-linux-gnu/5.4.0/libasan.so.2+0x99612)
    #1 0x7ffff437cc06 in __static_initialization_and_destruction_0 /mnt/another/srcs/GIT/freeorion/GG/src/RichText/TextBlock.cpp:73
    #2 0x7ffff437cd26 in _GLOBAL__sub_I_TextBlock.cpp /mnt/another/srcs/GIT/freeorion/GG/src/RichText/TextBlock.cpp:74
    #3 0x7ffff7de92a9  (/lib64/ld-linux-x86-64.so.2+0xf2a9)

Objects leaked above:
0x60200000edd0 (8 bytes)

SUMMARY: AddressSanitizer: 48 byte(s) leaked in 2 allocation(s).
```