### PR TITLE
Move ShipDesign::INVALID_DESIGN_ID to extern

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -13,7 +13,6 @@
 #include "../universe/Ship.h"
 #include "../universe/Predicates.h"
 #include "../universe/Planet.h"
-#include "../universe/ShipDesign.h"
 #include "../universe/System.h"
 #include "../universe/Universe.h"
 #include "../universe/Enums.h"
@@ -594,13 +593,13 @@ void ResearchQueue::clear() {
 ProductionQueue::ProductionItem::ProductionItem() :
     build_type(INVALID_BUILD_TYPE),
     name(),
-    design_id(ShipDesign::INVALID_DESIGN_ID)
+    design_id(INVALID_DESIGN_ID)
 {}
 
 ProductionQueue::ProductionItem::ProductionItem(BuildType build_type_, std::string name_) :
     build_type(build_type_),
     name(name_),
-    design_id(ShipDesign::INVALID_DESIGN_ID)
+    design_id(INVALID_DESIGN_ID)
 {}
 
 ProductionQueue::ProductionItem::ProductionItem(BuildType build_type_, int design_id_) :
@@ -766,7 +765,7 @@ std::string ProductionQueue::ProductionItem::Dump() const {
     std::string retval = "ProductionItem: " + boost::lexical_cast<std::string>(build_type) + " ";
     if (!name.empty())
         retval += "name: " + name;
-    if (design_id != ShipDesign::INVALID_DESIGN_ID)
+    if (design_id != INVALID_DESIGN_ID)
         retval += "id: " + std::to_string(design_id);
     return retval;
 }
@@ -2678,7 +2677,7 @@ void Empire::AddShipDesign(int ship_design_id, int next_design_id) {
         // design is valid, so just add the id to empire's set of ids that it knows about
         if (m_ship_designs.find(ship_design_id) == m_ship_designs.end()) {
             std::vector<int>::iterator point = m_ship_designs_ordered.end();
-            bool is_at_end_of_list = (next_design_id == ShipDesign::INVALID_DESIGN_ID);
+            bool is_at_end_of_list = (next_design_id == INVALID_DESIGN_ID);
             if (!is_at_end_of_list)
                 point = std::find(m_ship_designs_ordered.begin(), m_ship_designs_ordered.end(), next_design_id);
 
@@ -2715,7 +2714,7 @@ int Empire::AddShipDesign(ShipDesign* ship_design) {
     // design is apparently new, so add it to the universe and put its new id in the empire's set of designs
     int new_design_id = GetNewDesignID();   // on the sever, this just generates a new design id.  on clients, it polls the sever for a new id
 
-    if (new_design_id == ShipDesign::INVALID_DESIGN_ID) {
+    if (new_design_id == INVALID_DESIGN_ID) {
         ErrorLogger() << "Empire::AddShipDesign Unable to get new design id";
         return new_design_id;
     }

--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -4,7 +4,6 @@
 #include "ResourcePool.h"
 #include "../util/Export.h"
 #include "../universe/Meter.h"
-#include "../universe/ShipDesign.h"
 #include "../universe/UniverseObject.h"
 
 #include <GG/Clr.h>
@@ -15,6 +14,7 @@
 struct ItemSpec;
 class ShipDesign;
 class SitRepEntry;
+FO_COMMON_API extern const int INVALID_DESIGN_ID;
 FO_COMMON_API extern const int INVALID_GAME_TURN;
 FO_COMMON_API extern const int INVALID_OBJECT_ID;
 FO_COMMON_API extern const int ALL_EMPIRES;
@@ -466,7 +466,7 @@ public:
     void        AddExploredSystem(int ID);                  ///< Inserts the given ID into the Empire's list of explored systems.
 
     /** inserts given design id into the empire's set of designs in front of next design */
-    void        AddShipDesign(int ship_design_id, int next_design_id = ShipDesign::INVALID_DESIGN_ID);
+    void        AddShipDesign(int ship_design_id, int next_design_id = INVALID_DESIGN_ID);
     int         AddShipDesign(ShipDesign* ship_design);     ///< inserts given ShipDesign into the Universe, adds the design's id to the Empire's set of ids, and returns the new design's id, which is INVALID_OBJECT_ID on failure.  If successful, universe takes ownership of passed ShipDesign.
 
     std::string NewShipName();                              ///< generates a random ship name, appending II, III, etc., to it if it has been used before by this empire

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -37,6 +37,8 @@
 #include <algorithm>
 #include <iterator>
 
+FO_COMMON_API extern const int INVALID_DESIGN_ID;
+
 namespace {
     const std::string   PART_CONTROL_DROP_TYPE_STRING = "Part Control";
     const std::string   HULL_PARTS_ROW_DROP_TYPE_STRING = "Hull and Parts Row";
@@ -1560,7 +1562,7 @@ void BasesListBox::QueueItemMoved(GG::ListBox::Row* row, std::size_t position) {
         const BasesListBox::CompletedDesignListBoxRow* insert_before_control = (insert_before_row == end()) ? nullptr :
             boost::polymorphic_downcast<const BasesListBox::CompletedDesignListBoxRow*>(*insert_before_row);
         int insert_before_id = insert_before_control
-            ? insert_before_control->DesignID() : ShipDesign::INVALID_DESIGN_ID;
+            ? insert_before_control->DesignID() : INVALID_DESIGN_ID;
 
         if (design_id != insert_before_id)
             //insert_before_row may be end() to insert as last item
@@ -1927,7 +1929,7 @@ void BasesListBox::BaseDoubleClicked(GG::ListBox::iterator it, const GG::Pt& pt,
 
     CompletedDesignListBoxRow* cd_row = dynamic_cast<CompletedDesignListBoxRow*>(*it);
     if (cd_row) {
-        if (cd_row->DesignID() != ShipDesign::INVALID_DESIGN_ID)
+        if (cd_row->DesignID() != INVALID_DESIGN_ID)
             DesignSelectedSignal(cd_row->DesignID());
         return;
     }
@@ -2588,7 +2590,7 @@ public:
     /** Returns a pointer to the design currently being modified (if any).  May
         return an empty pointer if not currently modifying a design. */
     std::shared_ptr<const ShipDesign> GetIncompleteDesign() const;
-    int                                 GetCompleteDesignID() const;//!< returns ID of complete design currently being shown in this panel.  returns ShipDesign::INVALID_DESIGN_ID if not showing a complete design
+    int                                 GetCompleteDesignID() const;//!< returns ID of complete design currently being shown in this panel.  returns INVALID_DESIGN_ID if not showing a complete design
     int                                 GetReplacedDesignID() const;//!< returns ID of completed design selected to be replaced.
 
     bool                                CurrentDesignIsRegistered(std::string& design_name);//!< returns true iff a design with the same hull and parts is already registered with thsi empire; if so, also populates design_name with the name of that design
@@ -2709,8 +2711,8 @@ DesignWnd::MainPanel::MainPanel(const std::string& config_name) :
            config_name),
     m_hull(nullptr),
     m_slots(),
-    m_complete_design_id(ShipDesign::INVALID_DESIGN_ID),
-    m_replaced_design_id(ShipDesign::INVALID_DESIGN_ID),
+    m_complete_design_id(INVALID_DESIGN_ID),
+    m_replaced_design_id(INVALID_DESIGN_ID),
     m_incomplete_design(),
     m_completed_design_dump_strings(),
     m_background_image(nullptr),
@@ -3041,7 +3043,7 @@ void DesignWnd::MainPanel::SetDesign(const ShipDesign* ship_design) {
     }
 
     m_complete_design_id = ship_design->ID();
-    m_replaced_design_id = ship_design->IsMonster() ? ShipDesign::INVALID_DESIGN_ID : ship_design->ID();
+    m_replaced_design_id = ship_design->IsMonster() ? INVALID_DESIGN_ID : ship_design->ID();
 
     m_design_name->SetText(ship_design->Name());
     m_design_description->SetText(ship_design->Description());
@@ -3061,7 +3063,7 @@ void DesignWnd::MainPanel::SetDesign(int design_id)
 void DesignWnd::MainPanel::SetDesignComponents(const std::string& hull,
                                                const std::vector<std::string>& parts)
 {
-    m_replaced_design_id = ShipDesign::INVALID_DESIGN_ID;
+    m_replaced_design_id = INVALID_DESIGN_ID;
     SetHull(hull);
     SetParts(parts);
 }
@@ -3177,7 +3179,7 @@ void DesignWnd::MainPanel::DesignChanged() {
     m_replace_button->ClearBrowseInfoWnd();
     m_confirm_button->ClearBrowseInfoWnd();
 
-    m_complete_design_id = ShipDesign::INVALID_DESIGN_ID;
+    m_complete_design_id = INVALID_DESIGN_ID;
     int client_empire_id = HumanClientApp::GetApp()->EmpireID();
     std::string design_name;
     m_disabled_by_name = false;
@@ -3273,7 +3275,7 @@ void DesignWnd::MainPanel::DesignChanged() {
         std::string new_design_name = ValidatedDesignName();
         const ShipDesign* replaced_ship_design = GetShipDesign(m_replaced_design_id);
 
-        if (m_replaced_design_id != ShipDesign::INVALID_DESIGN_ID && replaced_ship_design) {
+        if (m_replaced_design_id != INVALID_DESIGN_ID && replaced_ship_design) {
             m_replace_button->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
                 UserString("DESIGN_WND_UPDATE"),
                 boost::io::str(FlexibleFormat(UserString("DESIGN_WND_UPDATE_DETAIL"))
@@ -3398,7 +3400,7 @@ void DesignWnd::MainPanel::AcceptDrops(const GG::Pt& pt, const std::vector<GG::W
             boost::polymorphic_downcast<const BasesListBox::CompletedDesignListBoxRow*>(wnd);
         if (control) {
             int design_id = control->DesignID();
-            if (design_id != ShipDesign::INVALID_DESIGN_ID)
+            if (design_id != INVALID_DESIGN_ID)
                 SetDesign(design_id);
         }
     }
@@ -3547,14 +3549,14 @@ void DesignWnd::ShowShipDesignInEncyclopedia(int design_id)
 int DesignWnd::AddDesign() {
     int empire_id = HumanClientApp::GetApp()->EmpireID();
     const Empire* empire = GetEmpire(empire_id);
-    if (!empire) return ShipDesign::INVALID_DESIGN_ID;
+    if (!empire) return INVALID_DESIGN_ID;
 
     std::vector<std::string> parts = m_main_panel->Parts();
     const std::string& hull_name = m_main_panel->Hull();
 
     if (!ShipDesign::ValidDesign(hull_name, parts)) {
         ErrorLogger() << "DesignWnd::AddDesign tried to add an invalid ShipDesign";
-        return ShipDesign::INVALID_DESIGN_ID;
+        return INVALID_DESIGN_ID;
     }
 
     std::string name = m_main_panel->ValidatedDesignName();
@@ -3585,7 +3587,7 @@ void DesignWnd::ReplaceDesign() {
     int empire_id = HumanClientApp::GetApp()->EmpireID();
     int replaced_id = m_main_panel->GetReplacedDesignID();
 
-    if (new_design_id == ShipDesign::INVALID_DESIGN_ID) return;
+    if (new_design_id == INVALID_DESIGN_ID) return;
 
     //move it to before the replaced design
     HumanClientApp::GetApp()->Orders().IssueOrder(OrderPtr(new ShipDesignOrder(empire_id, new_design_id, replaced_id )));

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -12,7 +12,6 @@
 #include "../universe/Encyclopedia.h"
 #include "../universe/Universe.h"
 #include "../universe/Tech.h"
-#include "../universe/ShipDesign.h"
 #include "../universe/Building.h"
 #include "../universe/Planet.h"
 #include "../universe/System.h"
@@ -48,6 +47,8 @@
 #include <boost/algorithm/string/predicate.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <unordered_map>
+
+FO_COMMON_API extern const int INVALID_DESIGN_ID;
 
 using boost::io::str;
 
@@ -2908,7 +2909,7 @@ void EncyclopediaDetailPanel::SetEmpire(const std::string& empire_id) {
 }
 
 void EncyclopediaDetailPanel::SetDesign(int design_id) {
-    int current_item_id = ShipDesign::INVALID_DESIGN_ID;
+    int current_item_id = INVALID_DESIGN_ID;
     if (m_items_it != m_items.end()) {
         try {
             current_item_id = boost::lexical_cast<int>(m_items_it->second);
@@ -2974,7 +2975,7 @@ void EncyclopediaDetailPanel::SetItem(const Empire* empire)
 { SetEmpire(empire ? empire->EmpireID() : ALL_EMPIRES); }
 
 void EncyclopediaDetailPanel::SetItem(const ShipDesign* design)
-{ SetDesign(design ? design->ID() : ShipDesign::INVALID_DESIGN_ID); }
+{ SetDesign(design ? design->ID() : INVALID_DESIGN_ID); }
 
 void EncyclopediaDetailPanel::SetItem(const MeterType& meter_type)
 { SetMeterType(boost::lexical_cast<std::string>(meter_type)); }

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -35,6 +35,8 @@
 #include <unordered_set>
 
 
+FO_COMMON_API extern const int INVALID_DESIGN_ID;
+
 namespace {
     const GG::Pt        DataPanelIconSpace()
     { return GG::Pt(GG::X(ClientUI::Pts()*3), GG::Y(ClientUI::Pts()*2.5)); }
@@ -294,7 +296,7 @@ namespace {
     {
         DebugLogger() << "CreateNewFleetFromShipsWithDesign with " << ship_ids.size()
                                << " ship ids and design id: " << design_id;
-        if (ship_ids.empty() || design_id == ShipDesign::INVALID_DESIGN_ID)
+        if (ship_ids.empty() || design_id == INVALID_DESIGN_ID)
             return;
         int client_empire_id = HumanClientApp::GetApp()->EmpireID();
         if (client_empire_id == ALL_EMPIRES && !ClientPlayerIsModerator())

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -39,6 +39,7 @@
 #include "../universe/Planet.h"
 #include "../universe/Predicates.h"
 #include "../universe/Ship.h"
+#include "../universe/ShipDesign.h"
 #include "../universe/Species.h"
 #include "../universe/System.h"
 #include "../universe/Field.h"

--- a/python/server/ServerWrapper.cpp
+++ b/python/server/ServerWrapper.cpp
@@ -6,7 +6,6 @@
 #include "../../universe/System.h"
 #include "../../universe/Planet.h"
 #include "../../universe/Building.h"
-#include "../../universe/ShipDesign.h"
 #include "../../universe/Fleet.h"
 #include "../../universe/Ship.h"
 #include "../../universe/Field.h"
@@ -70,6 +69,8 @@ using boost::python::make_tuple;
 using boost::python::extract;
 using boost::python::len;
 
+
+FO_COMMON_API extern const int INVALID_DESIGN_ID;
 
 // Helper stuff (classes, functions etc.) exposed to the
 // server side Python scripts
@@ -400,7 +401,7 @@ namespace {
             ErrorLogger() << "CreateShipDesign: couldn't create ship design";
             return false;
         }
-        if (universe.InsertShipDesign(design) == ShipDesign::INVALID_DESIGN_ID) {
+        if (universe.InsertShipDesign(design) == INVALID_DESIGN_ID) {
             ErrorLogger() << "CreateShipDesign: couldn't insert ship design into universe";
             delete design;
             return false;

--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -10,7 +10,6 @@
 #include "Fleet.h"
 #include "Ship.h"
 #include "ObjectMap.h"
-#include "ShipDesign.h"
 #include "Planet.h"
 #include "System.h"
 #include "Species.h"
@@ -30,6 +29,7 @@
 using boost::io::str;
 
 extern int g_indent;
+FO_COMMON_API extern const int INVALID_DESIGN_ID;
 
 bool UserStringExists(const std::string& str);
 
@@ -3971,7 +3971,7 @@ bool Enqueued::operator==(const ConditionBase& rhs) const {
 
 namespace {
     int NumberOnQueue(const ProductionQueue& queue, BuildType build_type, const int location_id,
-                      const std::string& name = "", int design_id = ShipDesign::INVALID_DESIGN_ID)
+                      const std::string& name = "", int design_id = INVALID_DESIGN_ID)
     {
         int retval = 0;
         for (const ProductionQueue::Element& element : queue) {
@@ -3985,7 +3985,7 @@ namespace {
                 if (!name.empty() && element.item.name != name)
                     continue;
             } else if (build_type == BT_SHIP) {
-                if (design_id != ShipDesign::INVALID_DESIGN_ID) {
+                if (design_id != INVALID_DESIGN_ID) {
                     // if looking for ships, accept design by id number...
                     if (design_id != element.item.design_id)
                         continue;
@@ -4061,7 +4061,7 @@ void Enqueued::Eval(const ScriptingContext& parent_context,
     if (simple_eval_safe) {
         // evaluate valuerefs once, and use to check all candidate objects
         std::string name =  (m_name ?       m_name->Eval(parent_context) :      "");
-        int design_id =     (m_design_id ?  m_design_id->Eval(parent_context) : ShipDesign::INVALID_DESIGN_ID);
+        int design_id =     (m_design_id ?  m_design_id->Eval(parent_context) : INVALID_DESIGN_ID);
         int empire_id =     (m_empire_id ?  m_empire_id->Eval(parent_context) : ALL_EMPIRES);
         int low =           (m_low ?        m_low->Eval(parent_context) :       0);
         int high =          (m_high ?       m_high->Eval(parent_context) :      INT_MAX);
@@ -4199,7 +4199,7 @@ bool Enqueued::Match(const ScriptingContext& local_context) const {
     }
     std::string name =  (m_name ?       m_name->Eval(local_context) :       "");
     int empire_id =     (m_empire_id ?  m_empire_id->Eval(local_context) :  ALL_EMPIRES);
-    int design_id =     (m_design_id ?  m_design_id->Eval(local_context) :  ShipDesign::INVALID_DESIGN_ID);
+    int design_id =     (m_design_id ?  m_design_id->Eval(local_context) :  INVALID_DESIGN_ID);
     int low =           (m_low ?        m_low->Eval(local_context) :        0);
     int high =          (m_high ?       m_high->Eval(local_context) :       INT_MAX);
     return EnqueuedSimpleMatch(m_build_type, name, design_id, empire_id, low, high)(candidate);
@@ -5146,7 +5146,7 @@ namespace {
         bool operator()(std::shared_ptr<const UniverseObject> candidate) const {
             if (!candidate)
                 return false;
-            if (m_design_id == ShipDesign::INVALID_DESIGN_ID)
+            if (m_design_id == INVALID_DESIGN_ID)
                 return false;
             if (std::shared_ptr<const Ship> ship = std::dynamic_pointer_cast<const Ship>(candidate))
                 if (ship->DesignID() == m_design_id)
@@ -6297,7 +6297,7 @@ void OwnerHasShipDesignAvailable::Eval(const ScriptingContext& parent_context,
         // evaluate number limits once, use to match all candidates
         std::shared_ptr<const UniverseObject> no_object;
         ScriptingContext local_context(parent_context, no_object);
-        int id = m_id ? m_id->Eval(local_context) : ShipDesign::INVALID_DESIGN_ID;
+        int id = m_id ? m_id->Eval(local_context) : INVALID_DESIGN_ID;
         EvalImpl(matches, non_matches, search_domain, OwnerHasShipDesignAvailableSimpleMatch(id));
     } else {
         // re-evaluate allowed turn range for each candidate object
@@ -6337,7 +6337,7 @@ bool OwnerHasShipDesignAvailable::Match(const ScriptingContext& local_context) c
         return false;
     }
 
-    int id = m_id ? m_id->Eval(local_context) : ShipDesign::INVALID_DESIGN_ID;
+    int id = m_id ? m_id->Eval(local_context) : INVALID_DESIGN_ID;
     return OwnerHasShipDesignAvailableSimpleMatch(id)(candidate);
 }
 

--- a/universe/Effect.cpp
+++ b/universe/Effect.cpp
@@ -19,7 +19,6 @@
 #include "Field.h"
 #include "Fleet.h"
 #include "Ship.h"
-#include "ShipDesign.h"
 #include "Tech.h"
 #include "Species.h"
 #include "Enums.h"
@@ -36,6 +35,7 @@ namespace {
 using boost::io::str;
 
 extern int g_indent;
+FO_COMMON_API extern const int INVALID_DESIGN_ID;
 
 namespace {
     /** creates a new fleet at a specified \a x and \a y location within the
@@ -1393,7 +1393,7 @@ void CreateShip::Execute(const ScriptingContext& context) const {
         return;
     }
 
-    int design_id = ShipDesign::INVALID_DESIGN_ID;
+    int design_id = INVALID_DESIGN_ID;
     if (m_design_id) {
         design_id = m_design_id->Eval(context);
         if (!GetShipDesign(design_id)) {
@@ -1409,7 +1409,7 @@ void CreateShip::Execute(const ScriptingContext& context) const {
         }
         design_id = ship_design->ID();
     }
-    if (design_id == ShipDesign::INVALID_DESIGN_ID) {
+    if (design_id == INVALID_DESIGN_ID) {
         ErrorLogger() << "CreateShip::Execute got invalid ship design id: -1";
         return;
     }

--- a/universe/Ship.cpp
+++ b/universe/Ship.cpp
@@ -15,12 +15,13 @@
 
 #include <boost/lexical_cast.hpp>
 
+FO_COMMON_API extern const int INVALID_DESIGN_ID;
 class Species;
 const Species* GetSpecies(const std::string& name);
 
 Ship::Ship() :
     UniverseObject(),
-    m_design_id(ShipDesign::INVALID_DESIGN_ID),
+    m_design_id(INVALID_DESIGN_ID),
     m_fleet_id(INVALID_OBJECT_ID),
     m_ordered_scrapped(false),
     m_ordered_colonize_planet_id(INVALID_OBJECT_ID),

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -19,6 +19,8 @@
 #include <cfloat>
 #include <boost/filesystem/fstream.hpp>
 
+extern FO_COMMON_API const int INVALID_DESIGN_ID = -1;
+
 using boost::io::str;
 
 namespace {
@@ -517,10 +519,6 @@ HullTypeManager::iterator HullTypeManager::end() const
 ////////////////////////////////////////////////
 // ShipDesign
 ////////////////////////////////////////////////
-// static(s)
-const int       ShipDesign::INVALID_DESIGN_ID = -1;
-const int       ShipDesign::MAX_ID            = 2000000000;
-
 ShipDesign::ShipDesign() :
     m_id(INVALID_OBJECT_ID),
     m_name(),
@@ -1117,7 +1115,7 @@ void PredefinedShipDesignManager::AddShipDesignsToEmpire(Empire* empire,
 
         int design_id = this->GetDesignID(design_name);
 
-        if (design_id == ShipDesign::INVALID_DESIGN_ID) {
+        if (design_id == INVALID_DESIGN_ID) {
             ErrorLogger() << "PredefinedShipDesignManager::AddShipDesignsToEmpire couldn't add a design to an empire";
             continue;
         } else {
@@ -1155,7 +1153,7 @@ namespace {
 
         // generate id for new design
         int new_design_id = GetNewDesignID();
-        if (new_design_id == ShipDesign::INVALID_DESIGN_ID) {
+        if (new_design_id == INVALID_DESIGN_ID) {
             ErrorLogger() << "PredefinedShipDesignManager::AddShipDesignsToUniverse Unable to get new design id";
             return;
         }
@@ -1224,7 +1222,7 @@ PredefinedShipDesignManager::generic_iterator PredefinedShipDesignManager::end_g
 int PredefinedShipDesignManager::GetDesignID(const std::string& name) const {
     std::map<std::string, int>::const_iterator it = m_design_generic_ids.find(name);
     if (it == m_design_generic_ids.end())
-        return ShipDesign::INVALID_DESIGN_ID;
+        return INVALID_DESIGN_ID;
     return it->second;
 }
 

--- a/universe/ShipDesign.h
+++ b/universe/ShipDesign.h
@@ -512,9 +512,6 @@ public:
     static bool                     ValidDesign(const ShipDesign& design)
     { return ValidDesign(design.m_hull, design.m_parts); }
 
-    static const int                INVALID_DESIGN_ID;
-    static const int                MAX_ID;
-
 private:
     void BuildStatCaches();
 

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -13,7 +13,6 @@
 #include "Fleet.h"
 #include "Planet.h"
 #include "Ship.h"
-#include "ShipDesign.h"
 #include "System.h"
 #include "Field.h"
 #include "UniverseObject.h"
@@ -28,6 +27,8 @@
 
 #include <boost/property_map/property_map.hpp>
 #include <boost/timer.hpp>
+
+FO_COMMON_API extern const int INVALID_DESIGN_ID;
 
 namespace {
     DeclareThreadSafeLogger(effects);
@@ -94,7 +95,7 @@ namespace EmpireStatistics {
 Universe::Universe() :
     m_pathfinder(new Pathfinder),
     m_last_allocated_object_id(-1), // this is conicidentally equal to INVALID_OBJECT_ID as of this writing, but the reason for this to be -1 is so that the first object has id 0, and all object ids are non-negative
-    m_last_allocated_design_id(-1), // same, but for ShipDesign::INVALID_DESIGN_ID
+    m_last_allocated_design_id(-1), // same, but for INVALID_DESIGN_ID
     m_universe_width(1000.0),
     m_inhibit_universe_object_signals(false),
     m_encoding_empire(ALL_EMPIRES),
@@ -209,7 +210,7 @@ const std::set<int>& Universe::EmpireStaleKnowledgeObjectIDs(int empire_id) cons
 }
 
 const ShipDesign* Universe::GetShipDesign(int ship_design_id) const {
-    if (ship_design_id == ShipDesign::INVALID_DESIGN_ID)
+    if (ship_design_id == INVALID_DESIGN_ID)
         return nullptr;
     ship_design_iterator it = m_ship_designs.find(ship_design_id);
     return (it != m_ship_designs.end() ? it->second : nullptr);
@@ -351,7 +352,7 @@ std::shared_ptr<T> Universe::InsertID(T* obj, int id) {
 }
 
 int Universe::InsertShipDesign(ShipDesign* ship_design) {
-    int retval = ShipDesign::INVALID_DESIGN_ID;
+    int retval = INVALID_DESIGN_ID;
     if (ship_design) {
         if (m_last_allocated_design_id + 1 < MAX_ID) {
             m_ship_designs[++m_last_allocated_design_id] = ship_design;
@@ -359,7 +360,7 @@ int Universe::InsertShipDesign(ShipDesign* ship_design) {
             retval = m_last_allocated_design_id;
         } else { // we'll probably never execute this branch, considering how many IDs are available
             // find a hole in the assigned IDs in which to place the object
-            int last_id_seen = ShipDesign::INVALID_DESIGN_ID;
+            int last_id_seen = INVALID_DESIGN_ID;
             for (ShipDesignMap::value_type& entry : m_ship_designs) {
                 if (1 < entry.first - last_id_seen) {
                     m_ship_designs[last_id_seen + 1] = ship_design;
@@ -376,7 +377,7 @@ int Universe::InsertShipDesign(ShipDesign* ship_design) {
 bool Universe::InsertShipDesignID(ShipDesign* ship_design, int id) {
     bool retval = false;
 
-    if (ship_design  &&  id != ShipDesign::INVALID_DESIGN_ID  &&  id < ShipDesign::MAX_ID) {
+    if (ship_design  &&  id != INVALID_DESIGN_ID  &&  id < MAX_ID) {
         ship_design->SetID(id);
         m_ship_designs[id] = ship_design;
         retval = true;
@@ -1543,7 +1544,7 @@ namespace {
 
     int GetDesignIDFromObject(std::shared_ptr<const UniverseObject> obj) {
         if (obj->ObjectType() != OBJ_SHIP)
-            return ShipDesign::INVALID_DESIGN_ID;
+            return INVALID_DESIGN_ID;
         std::shared_ptr<const Ship> shp = std::static_pointer_cast<const Ship>(obj);
         return shp->DesignID();
     }
@@ -1567,7 +1568,7 @@ void Universe::CountDestructionInStats(int object_id, int source_object_id) {
     if (Empire* source_empire = GetEmpire(empire_for_source_id)) {
         source_empire->EmpireShipsDestroyed()[empire_for_obj_id]++;
 
-        if (design_for_obj_id != ShipDesign::INVALID_DESIGN_ID)
+        if (design_for_obj_id != INVALID_DESIGN_ID)
             source_empire->ShipDesignsDestroyed()[design_for_obj_id]++;
 
         if (species_for_obj.empty())
@@ -1578,7 +1579,7 @@ void Universe::CountDestructionInStats(int object_id, int source_object_id) {
         if (!species_for_obj.empty())
             obj_empire->SpeciesShipsLost()[species_for_obj]++;
 
-        if (design_for_obj_id != ShipDesign::INVALID_DESIGN_ID)
+        if (design_for_obj_id != INVALID_DESIGN_ID)
             obj_empire->ShipDesignsLost()[design_for_obj_id]++;
     }
 }
@@ -2558,7 +2559,7 @@ void Universe::SetEmpireKnowledgeOfDestroyedObject(int object_id, int empire_id)
 }
 
 void Universe::SetEmpireKnowledgeOfShipDesign(int ship_design_id, int empire_id) {
-    if (ship_design_id == ShipDesign::INVALID_DESIGN_ID) {
+    if (ship_design_id == INVALID_DESIGN_ID) {
         ErrorLogger() << "SetEmpireKnowledgeOfShipDesign called with INVALID_DESIGN_ID";
         return;
     }

--- a/universe/ValueRef.cpp
+++ b/universe/ValueRef.cpp
@@ -3,7 +3,6 @@
 #include "Building.h"
 #include "Fleet.h"
 #include "Ship.h"
-#include "ShipDesign.h"
 #include "Planet.h"
 #include "Predicates.h"
 #include "Species.h"
@@ -32,6 +31,8 @@
 
 std::string DoubleToString(double val, int digits, bool always_show_sign);
 bool UserStringExists(const std::string& str);
+
+FO_COMMON_API extern const int INVALID_DESIGN_ID;
 
 namespace {
     std::shared_ptr<const UniverseObject> FollowReference(std::vector<std::string>::const_iterator first,
@@ -818,7 +819,7 @@ int Variable<int>::Eval(const ScriptingContext& context) const
         if (std::shared_ptr<const Ship> ship = std::dynamic_pointer_cast<const Ship>(object))
             return ship->DesignID();
         else
-            return ShipDesign::INVALID_DESIGN_ID;
+            return INVALID_DESIGN_ID;
 
     } else if (property_name == "SpeciesID") {
         if (std::shared_ptr<const Planet> planet = std::dynamic_pointer_cast<const Planet>(object))
@@ -1616,10 +1617,10 @@ int ComplexVariable<int>::Eval(const ScriptingContext& context) const
 
     // non-empire properties
     if (variable_name == "PartsInShipDesign") {
-        int design_id = ShipDesign::INVALID_DESIGN_ID;
+        int design_id = INVALID_DESIGN_ID;
         if (m_int_ref1) {
             design_id = m_int_ref1->Eval(context);
-            if (design_id == ShipDesign::INVALID_DESIGN_ID)
+            if (design_id == INVALID_DESIGN_ID)
                 return 0;
         } else {
             return 0;
@@ -1644,10 +1645,10 @@ int ComplexVariable<int>::Eval(const ScriptingContext& context) const
         return count;
 
     } else if (variable_name == "PartOfClassInShipDesign") {
-        int design_id = ShipDesign::INVALID_DESIGN_ID;
+        int design_id = INVALID_DESIGN_ID;
         if (m_int_ref1) {
             design_id = m_int_ref1->Eval(context);
-            if (design_id == ShipDesign::INVALID_DESIGN_ID)
+            if (design_id == INVALID_DESIGN_ID)
                 return 0;
         } else {
             return 0;
@@ -1731,10 +1732,10 @@ int ComplexVariable<int>::Eval(const ScriptingContext& context) const
         return hull_type->Slots().size();
 
     } else if (variable_name == "SlotsInShipDesign") {
-        int design_id = ShipDesign::INVALID_DESIGN_ID;
+        int design_id = INVALID_DESIGN_ID;
         if (m_int_ref1) {
             design_id = m_int_ref1->Eval(context);
-            if (design_id == ShipDesign::INVALID_DESIGN_ID)
+            if (design_id == INVALID_DESIGN_ID)
                 return 0;
         } else {
             return 0;

--- a/util/VarText.cpp
+++ b/util/VarText.cpp
@@ -15,6 +15,8 @@
 
 #include <map>
 
+FO_COMMON_API extern const int INVALID_DESIGN_ID;
+
 // Forward declarations
 class Tech;
 class BuildingType;
@@ -83,7 +85,7 @@ namespace {
 
     /// Returns substitution string for a ship design tag
     std::string ShipDesignString(const std::string& data, const std::string& tag, bool& valid) {
-        int design_id = ShipDesign::INVALID_DESIGN_ID;
+        int design_id = INVALID_DESIGN_ID;
         try {
             design_id = boost::lexical_cast<int>(data);
         } catch (const std::exception&) {


### PR DESCRIPTION
While working on PR #1561 , there was the suggestion to make ShipDesign::INVALID_DESIGN_ID into a FO_COMMON_API extern variable. This will reduce the number of times that ShipDesign.h is "included".

In particular, this allows me to remove ShipDesign.h from Empire.h.
(Empire.h is used in 61 cpp files and Order.h. Many of those do not need ShipDesign.h.)

I also removed ShipDesign::MAX_ID.
It was only used in one line in the entire code, in Universe.cpp
In that file, I replaced ShipDesign::MAX_ID with the local variable MAX_ID, as they both have the same value.

(This commit will cause a conflict with 1561. I figured I would wait to see which one is merged with master first, then rebase/fix the other PR at that time.)