### PR TITLE
Refactor use of OrderPtr alias.

### DIFF
--- a/AI/AIInterface.cpp
+++ b/AI/AIInterface.cpp
@@ -264,7 +264,7 @@ namespace AIInterface {
         if (destination_id != INVALID_OBJECT_ID && destination_id == start_id)
             DebugLogger() << "AIInterface::IssueFleetMoveOrder : pass destination system id (" << destination_id << ") that fleet is already in";
 
-        AIClientApp::GetApp()->Orders().IssueOrder(OrderPtr(new FleetMoveOrder(empire_id, fleet_id, start_id, destination_id)));
+        AIClientApp::GetApp()->Orders().IssueOrder(std::make_shared<FleetMoveOrder>(empire_id, fleet_id, start_id, destination_id));
 
         return 1;
     }
@@ -287,7 +287,7 @@ namespace AIInterface {
             return 0;
         }
 
-        AIClientApp::GetApp()->Orders().IssueOrder(OrderPtr(new RenameOrder(empire_id, object_id, new_name)));
+        AIClientApp::GetApp()->Orders().IssueOrder(std::make_shared<RenameOrder>(empire_id, object_id, new_name));
 
         return 1;
     }
@@ -314,7 +314,7 @@ namespace AIInterface {
                     return 0;
                 }
 
-                AIClientApp::GetApp()->Orders().IssueOrder(OrderPtr(new ScrapOrder(empire_id, object_id)));
+                AIClientApp::GetApp()->Orders().IssueOrder(std::make_shared<ScrapOrder>(empire_id, object_id));
             }
 
             return 1;
@@ -371,7 +371,7 @@ namespace AIInterface {
 
         int new_fleet_id = ClientApp::GetApp()->GetNewObjectID();
 
-        AIClientApp::GetApp()->Orders().IssueOrder(OrderPtr(new NewFleetOrder(empire_id, fleet_name, new_fleet_id, system_id, ship_ids)));
+        AIClientApp::GetApp()->Orders().IssueOrder(std::make_shared<NewFleetOrder>(empire_id, fleet_name, new_fleet_id, system_id, ship_ids));
 
         return new_fleet_id;
     }
@@ -422,7 +422,7 @@ namespace AIInterface {
 
         std::vector<int> ship_ids;
         ship_ids.push_back(ship_id);
-        AIClientApp::GetApp()->Orders().IssueOrder(OrderPtr(new FleetTransferOrder(empire_id, new_fleet_id, ship_ids)));
+        AIClientApp::GetApp()->Orders().IssueOrder(std::make_shared<FleetTransferOrder>(empire_id, new_fleet_id, ship_ids));
 
         return 1;
     }
@@ -475,7 +475,7 @@ namespace AIInterface {
             return 0;
         }
 
-        AIClientApp::GetApp()->Orders().IssueOrder(OrderPtr(new ColonizeOrder(empire_id, ship_id, planet_id)));
+        AIClientApp::GetApp()->Orders().IssueOrder(std::make_shared<ColonizeOrder>(empire_id, ship_id, planet_id));
 
         return 1;
     }
@@ -545,7 +545,7 @@ namespace AIInterface {
             return 0;
         }
 
-        AIClientApp::GetApp()->Orders().IssueOrder(OrderPtr(new InvadeOrder(empire_id, ship_id, planet_id)));
+        AIClientApp::GetApp()->Orders().IssueOrder(std::make_shared<InvadeOrder>(empire_id, ship_id, planet_id));
 
         return 1;
     }
@@ -600,7 +600,7 @@ namespace AIInterface {
             return 0;
         }
 
-        AIClientApp::GetApp()->Orders().IssueOrder(OrderPtr(new BombardOrder(empire_id, ship_id, planet_id)));
+        AIClientApp::GetApp()->Orders().IssueOrder(std::make_shared<BombardOrder>(empire_id, ship_id, planet_id));
 
         return 1;
     }
@@ -618,8 +618,8 @@ namespace AIInterface {
             return 0;
         }
 
-        AIClientApp::GetApp()->Orders().IssueOrder(OrderPtr(
-            new AggressiveOrder(empire_id, object_id, aggressive)));
+        AIClientApp::GetApp()->Orders().IssueOrder(
+            std::make_shared<AggressiveOrder>(empire_id, object_id, aggressive));
 
         return 1;
     }
@@ -674,8 +674,8 @@ namespace AIInterface {
             return 0;
         }
 
-        AIClientApp::GetApp()->Orders().IssueOrder(OrderPtr(
-            new GiveObjectToEmpireOrder(empire_id, object_id, recipient_id)));
+        AIClientApp::GetApp()->Orders().IssueOrder(
+            std::make_shared<GiveObjectToEmpireOrder>(empire_id, object_id, recipient_id));
 
         return 1;
     }
@@ -697,8 +697,8 @@ namespace AIInterface {
             return 0;
         }
 
-        AIClientApp::GetApp()->Orders().IssueOrder(OrderPtr(
-            new ChangeFocusOrder(empire_id, planet_id, focus)));
+        AIClientApp::GetApp()->Orders().IssueOrder(
+            std::make_shared<ChangeFocusOrder>(empire_id, planet_id, focus));
 
         return 1;
     }
@@ -712,8 +712,8 @@ namespace AIInterface {
 
         int empire_id = AIClientApp::GetApp()->EmpireID();
 
-        AIClientApp::GetApp()->Orders().IssueOrder(OrderPtr(
-            new ResearchQueueOrder(empire_id, tech_name, position)));
+        AIClientApp::GetApp()->Orders().IssueOrder(
+            std::make_shared<ResearchQueueOrder>(empire_id, tech_name, position));
 
         return 1;
     }
@@ -727,7 +727,7 @@ namespace AIInterface {
 
         int empire_id = AIClientApp::GetApp()->EmpireID();
 
-        AIClientApp::GetApp()->Orders().IssueOrder(OrderPtr(new ResearchQueueOrder(empire_id, tech_name)));
+        AIClientApp::GetApp()->Orders().IssueOrder(std::make_shared<ResearchQueueOrder>(empire_id, tech_name));
 
         return 1;
     }
@@ -741,8 +741,8 @@ namespace AIInterface {
             return 0;
         }
 
-        AIClientApp::GetApp()->Orders().IssueOrder(OrderPtr(
-            new ProductionQueueOrder(empire_id, ProductionQueue::ProductionItem(BT_BUILDING, item_name), 1, location_id)));
+        AIClientApp::GetApp()->Orders().IssueOrder(
+            std::make_shared<ProductionQueueOrder>(empire_id, ProductionQueue::ProductionItem(BT_BUILDING, item_name), 1, location_id));
 
         return 1;
     }
@@ -756,8 +756,8 @@ namespace AIInterface {
             return 0;
         }
 
-        AIClientApp::GetApp()->Orders().IssueOrder(OrderPtr(
-            new ProductionQueueOrder(empire_id, ProductionQueue::ProductionItem(BT_SHIP, design_id), 1, location_id)));
+        AIClientApp::GetApp()->Orders().IssueOrder(
+            std::make_shared<ProductionQueueOrder>(empire_id, ProductionQueue::ProductionItem(BT_SHIP, design_id), 1, location_id));
 
         return 1;
     }
@@ -776,8 +776,8 @@ namespace AIInterface {
             return 0;
         }
 
-        AIClientApp::GetApp()->Orders().IssueOrder(OrderPtr(
-            new ProductionQueueOrder(empire_id, queue_index, new_quantity, new_blocksize)));
+        AIClientApp::GetApp()->Orders().IssueOrder(
+            std::make_shared<ProductionQueueOrder>(empire_id, queue_index, new_quantity, new_blocksize));
 
         return 1;
     }
@@ -809,8 +809,8 @@ namespace AIInterface {
             return 0;
         }
 
-        AIClientApp::GetApp()->Orders().IssueOrder(OrderPtr(
-            new ProductionQueueOrder(empire_id, old_queue_index, new_queue_index)));
+        AIClientApp::GetApp()->Orders().IssueOrder(
+            std::make_shared<ProductionQueueOrder>(empire_id, old_queue_index, new_queue_index));
 
         return 1;
     }
@@ -825,8 +825,8 @@ namespace AIInterface {
             return 0;
         }
 
-        AIClientApp::GetApp()->Orders().IssueOrder(OrderPtr(
-            new ProductionQueueOrder(empire_id, queue_index)));
+        AIClientApp::GetApp()->Orders().IssueOrder(
+            std::make_shared<ProductionQueueOrder>(empire_id, queue_index));
 
         return 1;
     }
@@ -857,7 +857,8 @@ namespace AIInterface {
         }
 
         int new_design_id = AIClientApp::GetApp()->GetNewDesignID();
-        AIClientApp::GetApp()->Orders().IssueOrder(OrderPtr(new ShipDesignOrder(empire_id, new_design_id, *design)));
+        AIClientApp::GetApp()->Orders().IssueOrder(
+            std::make_shared<ShipDesignOrder>(empire_id, new_design_id, *design));
         delete design;
 
         return 1;

--- a/UI/BuildingsPanel.cpp
+++ b/UI/BuildingsPanel.cpp
@@ -35,9 +35,9 @@ namespace {
         const ClientApp* app = ClientApp::GetApp();
         if (!app)
             return retval;
-        for (const std::map<int, OrderPtr>::value_type& entry : app->Orders()) {
-            if (std::shared_ptr<ScrapOrder> order = std::dynamic_pointer_cast<ScrapOrder>(entry.second)) {
-                retval[order->ObjectID()] = entry.first;
+        for (const auto& id_and_order : app->Orders()) {
+            if (std::shared_ptr<ScrapOrder> order = std::dynamic_pointer_cast<ScrapOrder>(id_and_order.second)) {
+                retval[order->ObjectID()] = id_and_order.first;
             }
         }
         return retval;

--- a/UI/BuildingsPanel.cpp
+++ b/UI/BuildingsPanel.cpp
@@ -422,7 +422,7 @@ void BuildingIndicator::RClick(const GG::Pt& pt, GG::Flags<GG::ModKey> mod_keys)
     }
 
     auto scrap_building_action = [this, empire_id]() {
-        HumanClientApp::GetApp()->Orders().IssueOrder(OrderPtr(new ScrapOrder(empire_id, m_building_id)));};
+        HumanClientApp::GetApp()->Orders().IssueOrder(std::make_shared<ScrapOrder>(empire_id, m_building_id));};
     auto un_scrap_building_action = [building]() {
         // find order to scrap this building, and recind it
         std::map<int, int> pending_scrap_orders = PendingScrapOrders();

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -206,7 +206,7 @@ namespace {
                         DebugLogger() << "SavedDesignsManager::LoadAllSavedDesigns adding saved design: " << entry.second->Name();
                         int new_design_id = HumanClientApp::GetApp()->GetNewDesignID();
                         HumanClientApp::GetApp()->Orders().IssueOrder(
-                            OrderPtr(new ShipDesignOrder(empire_id, new_design_id, *(entry.second))));
+                            std::make_shared<ShipDesignOrder>(empire_id, new_design_id, *(entry.second)));
                     } else {
                         DebugLogger() << "SavedDesignsManager::LoadAllSavedDesigns saved design already present: " << entry.second->Name();
                     }
@@ -1569,7 +1569,7 @@ void BasesListBox::QueueItemMoved(GG::ListBox::Row* row, std::size_t position) {
             Insert(control, insert_before_row);
         control->Resize(ListRowSize());
         HumanClientApp::GetApp()->Orders()
-            .IssueOrder(OrderPtr(new ShipDesignOrder(m_empire_id_shown, design_id, insert_before_id)));
+            .IssueOrder(std::make_shared<ShipDesignOrder>(m_empire_id_shown, design_id, insert_before_id));
     }
 }
 
@@ -1803,7 +1803,7 @@ void BasesListBox::BaseLeftClicked(GG::ListBox::iterator it, const GG::Pt& pt, c
             return;
         if (modkeys & GG::MOD_KEY_CTRL)
             HumanClientApp::GetApp()->Orders().IssueOrder(
-                OrderPtr(new ShipDesignOrder(HumanClientApp::GetApp()->EmpireID(), id, true)));
+                std::make_shared<ShipDesignOrder>(HumanClientApp::GetApp()->EmpireID(), id, true));
         else
             DesignClickedSignal(design);
         return;
@@ -1851,7 +1851,7 @@ void BasesListBox::BaseRightClicked(GG::ListBox::iterator it, const GG::Pt& pt, 
         // Context menu actions
         auto delete_design_action = [&client_empire_id, &design_id]() {
             HumanClientApp::GetApp()->Orders().IssueOrder(
-                OrderPtr(new ShipDesignOrder(client_empire_id, design_id, true)));
+                std::make_shared<ShipDesignOrder>(client_empire_id, design_id, true));
         };
 
         auto rename_design_action = [&client_empire_id, &design_id, design, &design_row]() {
@@ -1860,7 +1860,7 @@ void BasesListBox::BaseRightClicked(GG::ListBox::iterator it, const GG::Pt& pt, 
             const std::string& result = edit_wnd.Result();
             if (result != "" && result != design->Name()) {
                 HumanClientApp::GetApp()->Orders().IssueOrder(
-                    OrderPtr(new ShipDesignOrder(client_empire_id, design_id, result)));
+                    std::make_shared<ShipDesignOrder>(client_empire_id, design_id, result));
                 if (!design_row->empty())
                     if (ShipDesignPanel* design_panel = dynamic_cast<ShipDesignPanel*>(design_row->at(0)))
                         design_panel->Update();
@@ -1907,7 +1907,7 @@ void BasesListBox::BaseRightClicked(GG::ListBox::iterator it, const GG::Pt& pt, 
             DebugLogger() << "BasesListBox::BaseRightClicked Add Saved Design" << design->Name();
             int new_design_id = HumanClientApp::GetApp()->GetNewDesignID();
             HumanClientApp::GetApp()->Orders().IssueOrder(
-                OrderPtr(new ShipDesignOrder(empire_id, new_design_id, *design)));
+                std::make_shared<ShipDesignOrder>(empire_id, new_design_id, *design));
         };
 
         // add all saved designs
@@ -3573,7 +3573,7 @@ int DesignWnd::AddDesign() {
 
     int new_design_id = HumanClientApp::GetApp()->GetNewDesignID();
     HumanClientApp::GetApp()->Orders().IssueOrder(
-        OrderPtr(new ShipDesignOrder(empire_id, new_design_id, design)));
+        std::make_shared<ShipDesignOrder>(empire_id, new_design_id, design));
     m_main_panel->ReregisterDesigns();
     m_main_panel->DesignChangedSignal();
 
@@ -3590,9 +3590,9 @@ void DesignWnd::ReplaceDesign() {
     if (new_design_id == INVALID_DESIGN_ID) return;
 
     //move it to before the replaced design
-    HumanClientApp::GetApp()->Orders().IssueOrder(OrderPtr(new ShipDesignOrder(empire_id, new_design_id, replaced_id )));
+    HumanClientApp::GetApp()->Orders().IssueOrder(std::make_shared<ShipDesignOrder>(empire_id, new_design_id, replaced_id ));
     //remove old design
-    HumanClientApp::GetApp()->Orders().IssueOrder(OrderPtr(new ShipDesignOrder(empire_id, replaced_id, true)));
+    HumanClientApp::GetApp()->Orders().IssueOrder(std::make_shared<ShipDesignOrder>(empire_id, replaced_id, true));
     DebugLogger() << "Replaced design #" << replaced_id << " with #" << new_design_id ;
 }
 

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -275,9 +275,9 @@ namespace {
 
         // create new fleet with ships
         HumanClientApp::GetApp()->Orders().IssueOrder(
-            OrderPtr(new NewFleetOrder(client_empire_id, order_fleet_names, order_fleet_ids,
+            std::make_shared<NewFleetOrder>(client_empire_id, order_fleet_names, order_fleet_ids,
                                        *systems_containing_new_fleets.begin(),
-                                       order_ship_id_groups, order_ship_aggressives)));
+                                       order_ship_id_groups, order_ship_aggressives));
     }
 
     void CreateNewFleetFromShips(const std::vector<int>& ship_ids,
@@ -381,7 +381,7 @@ namespace {
 
         // order ships moved into target fleet
         HumanClientApp::GetApp()->Orders().IssueOrder(
-            OrderPtr(new FleetTransferOrder(client_empire_id, target_fleet->ID(), empire_system_ship_ids)));
+            std::make_shared<FleetTransferOrder>(client_empire_id, target_fleet->ID(), empire_system_ship_ids));
     }
 
    /** Returns map from object ID to issued colonize orders affecting it. */
@@ -1397,7 +1397,7 @@ void FleetDataPanel::ToggleAggression() {
 
         // toggle fleet aggression status
         HumanClientApp::GetApp()->Orders().IssueOrder(
-            OrderPtr(new AggressiveOrder(client_empire_id, m_fleet_id, new_aggression_state)));
+            std::make_shared<AggressiveOrder>(client_empire_id, m_fleet_id, new_aggression_state));
     } else if (m_is_new_fleet_drop_target) {
         // cycle new fleet aggression
         if (m_new_fleet_aggression == INVALID_FLEET_AGGRESSION)
@@ -1908,7 +1908,7 @@ public:
 
                 // order the transfer
                 HumanClientApp::GetApp()->Orders().IssueOrder(
-                    OrderPtr(new FleetTransferOrder(empire_id, target_fleet_id, ship_ids_vec)));
+                    std::make_shared<FleetTransferOrder>(empire_id, target_fleet_id, ship_ids_vec));
             }
 
         } else if (!dropped_ships.empty()) {
@@ -1933,7 +1933,7 @@ public:
 
             // order the transfer
             HumanClientApp::GetApp()->Orders().IssueOrder(
-                OrderPtr(new FleetTransferOrder(empire_id, target_fleet_id, ship_ids_vec)));
+                std::make_shared<FleetTransferOrder>(empire_id, target_fleet_id, ship_ids_vec));
         }
         //DebugLogger() << "FleetsListBox::AcceptDrops finished";
     }
@@ -2321,7 +2321,7 @@ public:
             return; // todo: handle moderator actions for this...
 
         HumanClientApp::GetApp()->Orders().IssueOrder(
-            OrderPtr(new FleetTransferOrder(empire_id, m_fleet_id, ship_ids)));
+            std::make_shared<FleetTransferOrder>(empire_id, m_fleet_id, ship_ids));
     }
 
     void SizeMove(const GG::Pt& ul, const GG::Pt& lr) override {
@@ -2587,7 +2587,7 @@ void FleetDetailPanel::ShipRightClicked(GG::ListBox::iterator it, const GG::Pt& 
             if (!ClientPlayerIsModerator()) {
                 if (new_name != "" && new_name != ship_name) {
                     HumanClientApp::GetApp()->Orders().IssueOrder(
-                        OrderPtr(new RenameOrder(client_empire_id, ship->ID(), new_name)));
+                        std::make_shared<RenameOrder>(client_empire_id, ship->ID(), new_name));
                 }
             } else {
                 // TODO: Moderator action for renaming ships
@@ -2604,7 +2604,7 @@ void FleetDetailPanel::ShipRightClicked(GG::ListBox::iterator it, const GG::Pt& 
         // create popup menu with "Scrap" option
         auto scrap_action = [ship, client_empire_id]() {
             HumanClientApp::GetApp()->Orders().IssueOrder(
-                OrderPtr(new ScrapOrder(client_empire_id, ship->ID())));
+                std::make_shared<ScrapOrder>(client_empire_id, ship->ID()));
         };
         popup.AddMenuItem(GG::MenuItem(UserString("ORDER_SHIP_SCRAP"), false, false, scrap_action));
     } else if (!ClientPlayerIsModerator()
@@ -3427,7 +3427,7 @@ void FleetWnd::FleetRightClicked(GG::ListBox::iterator it, const GG::Pt& pt, con
 
             if (!new_name.empty() && new_name != fleet_name) {
                 HumanClientApp::GetApp()->Orders().IssueOrder(
-                    OrderPtr(new RenameOrder(client_empire_id, fleet->ID(), new_name)));
+                    std::make_shared<RenameOrder>(client_empire_id, fleet->ID(), new_name));
             }
         };
         popup.AddMenuItem(GG::MenuItem(UserString("RENAME"),                       false, false, rename_action));
@@ -3446,8 +3446,7 @@ void FleetWnd::FleetRightClicked(GG::ListBox::iterator it, const GG::Pt& pt, con
             std::set<int> ship_ids_set = fleet->ShipIDs();
             for (int ship_id : ship_ids_set) {
                 HumanClientApp::GetApp()->Orders().IssueOrder(
-                    OrderPtr(new ScrapOrder(client_empire_id, ship_id))
-                );
+                    std::make_shared<ScrapOrder>(client_empire_id, ship_id));
             }
         };
 
@@ -3493,7 +3492,7 @@ void FleetWnd::FleetRightClicked(GG::ListBox::iterator it, const GG::Pt& pt, con
                 continue;
             auto gift_action = [recipient_empire_id, fleet, client_empire_id]() {
                 HumanClientApp::GetApp()->Orders().IssueOrder(
-                    OrderPtr(new GiveObjectToEmpireOrder(client_empire_id, fleet->ID(), recipient_empire_id)));
+                    std::make_shared<GiveObjectToEmpireOrder>(client_empire_id, fleet->ID(), recipient_empire_id));
             };
             give_away_menu.next_level.push_back(GG::MenuItem(entry.second->Name(), false, false, gift_action));
         }
@@ -3528,7 +3527,7 @@ void FleetWnd::FleetRightClicked(GG::ListBox::iterator it, const GG::Pt& pt, con
             // in future so that the server doesn't keep resending this
             // fleet information.
             HumanClientApp::GetApp()->Orders().IssueOrder(
-                OrderPtr(new ForgetOrder(client_empire_id, fleet->ID()))
+                std::make_shared<ForgetOrder>(client_empire_id, fleet->ID())
             );
             // Client changes for immediate effect
             // Force the client to change immediately.

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -390,9 +390,9 @@ namespace {
         const ClientApp* app = ClientApp::GetApp();
         if (!app)
             return retval;
-        for (const std::map<int, OrderPtr>::value_type& entry : app->Orders()) {
-            if (std::shared_ptr<ScrapOrder> order = std::dynamic_pointer_cast<ScrapOrder>(entry.second)) {
-                retval[order->ObjectID()] = entry.first;
+        for (const auto& id_and_order : app->Orders()) {
+            if (std::shared_ptr<ScrapOrder> order = std::dynamic_pointer_cast<ScrapOrder>(id_and_order.second)) {
+                retval[order->ObjectID()] = id_and_order.first;
             }
         }
         return retval;
@@ -3462,10 +3462,10 @@ void FleetWnd::FleetRightClicked(GG::ListBox::iterator it, const GG::Pt& pt, con
         auto unscrap_action = [fleet]() {
             const OrderSet orders = HumanClientApp::GetApp()->Orders();
             for (int ship_id : fleet->ShipIDs()) {
-                for (const std::map<int, OrderPtr>::value_type& entry : orders) {
-                    if (std::shared_ptr<ScrapOrder> order = std::dynamic_pointer_cast<ScrapOrder>(entry.second)) {
+                for (const auto& id_and_order : orders) {
+                    if (std::shared_ptr<ScrapOrder> order = std::dynamic_pointer_cast<ScrapOrder>(id_and_order.second)) {
                         if (order->ObjectID() == ship_id) {
-                            HumanClientApp::GetApp()->Orders().RescindOrder(entry.first);
+                            HumanClientApp::GetApp()->Orders().RescindOrder(id_and_order.first);
                             // could break here, but won't to ensure there are no problems with doubled orders
                         }
                     }
@@ -3500,12 +3500,12 @@ void FleetWnd::FleetRightClicked(GG::ListBox::iterator it, const GG::Pt& pt, con
 
         if (fleet->OrderedGivenToEmpire() != ALL_EMPIRES) {
             auto ungift_action = [fleet]() {
-            for (const std::map<int, OrderPtr>::value_type& entry : HumanClientApp::GetApp()->Orders()) {
+            for (const auto& id_and_order : HumanClientApp::GetApp()->Orders()) {
                 if (std::shared_ptr<GiveObjectToEmpireOrder> order =
-                    std::dynamic_pointer_cast<GiveObjectToEmpireOrder>(entry.second))
+                    std::dynamic_pointer_cast<GiveObjectToEmpireOrder>(id_and_order.second))
                 {
                     if (order->ObjectID() == fleet->ID()) {
-                        HumanClientApp::GetApp()->Orders().RescindOrder(entry.first);
+                        HumanClientApp::GetApp()->Orders().RescindOrder(id_and_order.first);
                         // could break here, but won't to ensure there are no problems with doubled orders
                     }
                 }

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -5367,7 +5367,7 @@ void MapWnd::PlotFleetMovement(int system_id, bool execute_move, bool append) {
 
         // if actually ordering fleet movement, not just prospectively previewing, ... do so
         if (execute_move && !route.empty()){
-            HumanClientApp::GetApp()->Orders().IssueOrder(OrderPtr(new FleetMoveOrder(empire_id, fleet_id, start_system, system_id, append)));
+            HumanClientApp::GetApp()->Orders().IssueOrder(std::make_shared<FleetMoveOrder>(empire_id, fleet_id, start_system, system_id, append));
             StopFleetExploring(fleet_id);
         }
 
@@ -7022,12 +7022,12 @@ void MapWnd::DispatchFleetsExploring() {
                     //we have full fuel and no unknown planet in range. We can go to a far system, but we will have to wait for resupply
                     DebugLogger() << "MapWnd::DispatchFleetsExploring : Next system for fleet " << fleet->ID() << " is " << far_system_id << ". Not enough fuel for the round trip";
                     systems_order_sent.insert(far_system_id);
-                    HumanClientApp::GetApp()->Orders().IssueOrder(OrderPtr(new FleetMoveOrder(empire_id, fleet->ID(), fleet->SystemID(), far_system_id)));
+                    HumanClientApp::GetApp()->Orders().IssueOrder(std::make_shared<FleetMoveOrder>(empire_id, fleet->ID(), fleet->SystemID(), far_system_id));
                 } else {
                     //no unknown planet in range. Let's try to get home to resupply
                     std::pair<int, int> pair = GetNearestSupplyPoint(empire, fleet->SystemID());
                     DebugLogger() << "MapWnd::DispatchFleetsExploring : Fleet " << fleet->ID() << " going to resupply at " << pair.first;
-                    HumanClientApp::GetApp()->Orders().IssueOrder(OrderPtr(new FleetMoveOrder(empire_id, fleet->ID(), fleet->SystemID(), pair.first)));
+                    HumanClientApp::GetApp()->Orders().IssueOrder(std::make_shared<FleetMoveOrder>(empire_id, fleet->ID(), fleet->SystemID(), pair.first));
                 }
                 i = nbr_fleet_to_send; //stop the loop since every fleet will have order
             }
@@ -7038,7 +7038,7 @@ void MapWnd::DispatchFleetsExploring() {
             DebugLogger() << "MapWnd::DispatchFleetsExploring : Next system for fleet " << better_fleet_id << " is " << end_system_id;
             systems_order_sent.insert(end_system_id);
             fleet_idle.erase(better_fleet_id);
-            HumanClientApp::GetApp()->Orders().IssueOrder(OrderPtr(new FleetMoveOrder(empire_id, better_fleet_id, start_system_id, end_system_id)));
+            HumanClientApp::GetApp()->Orders().IssueOrder(std::make_shared<FleetMoveOrder>(empire_id, better_fleet_id, start_system_id, end_system_id));
         } else {
             remaining_system_to_explore = false; //from now on, each ship will be sent to a supply depot or a far system
         }

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -2465,7 +2465,7 @@ void ObjectListWnd::ObjectRightClicked(GG::ListBox::iterator it, const GG::Pt& p
                         continue;
 
                     one_planet->SetFocus(focus);
-                    app->Orders().IssueOrder(OrderPtr(new ChangeFocusOrder(app->EmpireID(), one_planet->ID(), focus)));
+                    app->Orders().IssueOrder(std::make_shared<ChangeFocusOrder>(app->EmpireID(), one_planet->ID(), focus));
                 }
 
                 focus_ship_building_common_action();
@@ -2495,7 +2495,7 @@ void ObjectListWnd::ObjectRightClicked(GG::ListBox::iterator it, const GG::Pt& p
                     if (!one_planet || !one_planet->OwnedBy(app->EmpireID()) || !cur_empire->ProducibleItem(BT_SHIP, ship_design, row->ObjectID()))
                         continue;
                     ProductionQueue::ProductionItem ship_item(BT_SHIP, ship_design);
-                    app->Orders().IssueOrder(OrderPtr(new ProductionQueueOrder(app->EmpireID(), ship_item, 1, row->ObjectID())));
+                    app->Orders().IssueOrder(std::make_shared<ProductionQueueOrder>(app->EmpireID(), ship_item, 1, row->ObjectID()));
                     needs_queue_update = true;
                 }
                 if (needs_queue_update)
@@ -2531,7 +2531,7 @@ void ObjectListWnd::ObjectRightClicked(GG::ListBox::iterator it, const GG::Pt& p
                         continue;
                     }
                     ProductionQueue::ProductionItem bld_item(BT_BUILDING, bld);
-                    app->Orders().IssueOrder(OrderPtr(new ProductionQueueOrder(app->EmpireID(), bld_item, 1, row->ObjectID())));
+                    app->Orders().IssueOrder(std::make_shared<ProductionQueueOrder>(app->EmpireID(), bld_item, 1, row->ObjectID()));
                     needs_queue_update = true;
                 }
                 if (needs_queue_update)

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -930,9 +930,9 @@ void ProductionWnd::QueueItemMoved(GG::ListBox::Row* row, std::size_t position) 
         return;
 
     HumanClientApp::GetApp()->Orders().IssueOrder(
-        OrderPtr(new ProductionQueueOrder(client_empire_id,
-                                          boost::polymorphic_downcast<QueueRow*>(row)->queue_index,
-                                          position)));
+        std::make_shared<ProductionQueueOrder>(client_empire_id,
+                                               boost::polymorphic_downcast<QueueRow*>(row)->queue_index,
+                                               position));
 
     empire->UpdateProductionQueue();
 }
@@ -1045,8 +1045,8 @@ void ProductionWnd::AddBuildToQueueSlot(const ProductionQueue::ProductionItem& i
     if (!empire)
         return;
 
-    HumanClientApp::GetApp()->Orders().IssueOrder(OrderPtr(
-        new ProductionQueueOrder(client_empire_id, item, number, location, pos)));
+    HumanClientApp::GetApp()->Orders().IssueOrder(
+        std::make_shared<ProductionQueueOrder>(client_empire_id, item, number, location, pos));
 
     empire->UpdateProductionQueue();
     m_build_designator_wnd->CenterOnBuild(pos >= 0 ? pos : m_queue_wnd->GetQueueListBox()->NumRows() - 1);
@@ -1060,8 +1060,8 @@ void ProductionWnd::ChangeBuildQuantitySlot(int queue_idx, int quantity) {
     if (!empire)
         return;
 
-    HumanClientApp::GetApp()->Orders().IssueOrder(OrderPtr(
-        new ProductionQueueOrder(client_empire_id, queue_idx, quantity, true)));
+    HumanClientApp::GetApp()->Orders().IssueOrder(
+        std::make_shared<ProductionQueueOrder>(client_empire_id, queue_idx, quantity, true));
 
     empire->UpdateProductionQueue();
 }
@@ -1074,8 +1074,8 @@ void ProductionWnd::ChangeBuildQuantityBlockSlot(int queue_idx, int quantity, in
     if (!empire)
         return;
 
-    HumanClientApp::GetApp()->Orders().IssueOrder(OrderPtr(
-        new ProductionQueueOrder(client_empire_id, queue_idx, quantity, blocksize)));
+    HumanClientApp::GetApp()->Orders().IssueOrder(
+        std::make_shared<ProductionQueueOrder>(client_empire_id, queue_idx, quantity, blocksize));
 
     empire->UpdateProductionQueue();
 }
@@ -1089,7 +1089,7 @@ void ProductionWnd::DeleteQueueItem(GG::ListBox::iterator it) {
         return;
 
     HumanClientApp::GetApp()->Orders().IssueOrder(
-        OrderPtr(new ProductionQueueOrder(client_empire_id, std::distance(m_queue_wnd->GetQueueListBox()->begin(), it))));
+        std::make_shared<ProductionQueueOrder>(client_empire_id, std::distance(m_queue_wnd->GetQueueListBox()->begin(), it)));
 
     empire->UpdateProductionQueue();
 }
@@ -1126,8 +1126,8 @@ void ProductionWnd::QueueItemRallied(GG::ListBox::iterator it, int object_id) {
         return;
 
     HumanClientApp::GetApp()->Orders().IssueOrder(
-        OrderPtr(new ProductionQueueOrder(client_empire_id, std::distance(m_queue_wnd->GetQueueListBox()->begin(), it),
-                                          rally_point_id, false, false)));
+        std::make_shared<ProductionQueueOrder>(client_empire_id, std::distance(m_queue_wnd->GetQueueListBox()->begin(), it),
+                                          rally_point_id, false, false));
 
     empire->UpdateProductionQueue();
 }
@@ -1141,8 +1141,8 @@ void ProductionWnd::QueueItemPaused(GG::ListBox::iterator it, bool pause) {
         return;
 
     HumanClientApp::GetApp()->Orders().IssueOrder(
-        OrderPtr(new ProductionQueueOrder(client_empire_id, std::distance(m_queue_wnd->GetQueueListBox()->begin(), it),
-                                          pause, -1.0f)));
+        std::make_shared<ProductionQueueOrder>(client_empire_id, std::distance(m_queue_wnd->GetQueueListBox()->begin(), it),
+                                          pause, -1.0f));
 
     empire->UpdateProductionQueue();
 }

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -1127,7 +1127,7 @@ void ProductionWnd::QueueItemRallied(GG::ListBox::iterator it, int object_id) {
 
     HumanClientApp::GetApp()->Orders().IssueOrder(
         std::make_shared<ProductionQueueOrder>(client_empire_id, std::distance(m_queue_wnd->GetQueueListBox()->begin(), it),
-                                          rally_point_id, false, false));
+                                               rally_point_id, false, false));
 
     empire->UpdateProductionQueue();
 }

--- a/UI/ResearchWnd.cpp
+++ b/UI/ResearchWnd.cpp
@@ -508,7 +508,7 @@ void ResearchWnd::QueueItemMoved(GG::ListBox::Row* row, std::size_t position) {
     if (QueueRow* queue_row = boost::polymorphic_downcast<QueueRow*>(row)) {
         int empire_id = HumanClientApp::GetApp()->EmpireID();
         HumanClientApp::GetApp()->Orders().IssueOrder(
-            OrderPtr(new ResearchQueueOrder(empire_id, queue_row->elem.name, static_cast<int>(position))));
+            std::make_shared<ResearchQueueOrder>(empire_id, queue_row->elem.name, static_cast<int>(position)));
         if (Empire* empire = GetEmpire(empire_id))
             empire->UpdateResearchQueue();
     }
@@ -606,10 +606,10 @@ void ResearchWnd::AddTechsToQueueSlot(const std::vector<std::string>& tech_vec, 
         // or that we skipped because it happened to already be in the right spot.
         if (pos == -1) {
             if (!queue.InQueue(tech_name)) {
-                orders.IssueOrder(OrderPtr(new ResearchQueueOrder(empire_id, tech_name, pos)));
+                orders.IssueOrder(std::make_shared<ResearchQueueOrder>(empire_id, tech_name, pos));
             }
         } else if (!queue.InQueue(tech_name) || ((queue.find(tech_name) - queue.begin()) > pos)) {
-            orders.IssueOrder(OrderPtr(new ResearchQueueOrder(empire_id, tech_name, pos)));
+            orders.IssueOrder(std::make_shared<ResearchQueueOrder>(empire_id, tech_name, pos));
             pos += 1;
         } else {
             if ((queue.find(tech_name) - queue.begin()) == pos)
@@ -625,7 +625,7 @@ void ResearchWnd::DeleteQueueItem(GG::ListBox::iterator it) {
     int empire_id = HumanClientApp::GetApp()->EmpireID();
     OrderSet& orders = HumanClientApp::GetApp()->Orders();
     if (QueueRow* queue_row = boost::polymorphic_downcast<QueueRow*>(*it))
-        orders.IssueOrder(OrderPtr(new ResearchQueueOrder(empire_id, queue_row->elem.name)));
+        orders.IssueOrder(std::make_shared<ResearchQueueOrder>(empire_id, queue_row->elem.name));
     if (Empire* empire = GetEmpire(empire_id))
         empire->UpdateResearchQueue();
 }
@@ -656,7 +656,7 @@ void ResearchWnd::QueueItemPaused(GG::ListBox::iterator it, bool pause) {
 
     if (QueueRow* queue_row = boost::polymorphic_downcast<QueueRow*>(*it))
         HumanClientApp::GetApp()->Orders().IssueOrder(
-            OrderPtr(new ResearchQueueOrder(client_empire_id, queue_row->elem.name, pause, -1.0f)));
+            std::make_shared<ResearchQueueOrder>(client_empire_id, queue_row->elem.name, pause, -1.0f));
 
     empire->UpdateResearchQueue();
 }

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -420,9 +420,9 @@ namespace {
         const ClientApp* app = ClientApp::GetApp();
         if (!app)
             return retval;
-        for (const std::map<int, OrderPtr>::value_type& entry : app->Orders()) {
-            if (std::shared_ptr<ColonizeOrder> order = std::dynamic_pointer_cast<ColonizeOrder>(entry.second)) {
-                retval[order->PlanetID()] = entry.first;
+        for (const auto& id_and_order : app->Orders()) {
+            if (std::shared_ptr<ColonizeOrder> order = std::dynamic_pointer_cast<ColonizeOrder>(id_and_order.second)) {
+                retval[order->PlanetID()] = id_and_order.first;
             }
         }
         return retval;
@@ -435,9 +435,9 @@ namespace {
         const ClientApp* app = ClientApp::GetApp();
         if (!app)
             return retval;
-        for (const std::map<int, OrderPtr>::value_type& entry : app->Orders()) {
-            if (std::shared_ptr<InvadeOrder> order = std::dynamic_pointer_cast<InvadeOrder>(entry.second)) {
-                retval[order->PlanetID()].insert(entry.first);
+        for (const auto& id_and_order : app->Orders()) {
+            if (std::shared_ptr<InvadeOrder> order = std::dynamic_pointer_cast<InvadeOrder>(id_and_order.second)) {
+                retval[order->PlanetID()].insert(id_and_order.first);
             }
         }
         return retval;
@@ -450,9 +450,9 @@ namespace {
         const ClientApp* app = ClientApp::GetApp();
         if (!app)
             return retval;
-        for (const std::map<int, OrderPtr>::value_type& entry : app->Orders()) {
-            if (std::shared_ptr<BombardOrder> order = std::dynamic_pointer_cast<BombardOrder>(entry.second)) {
-                retval[order->PlanetID()].insert(entry.first);
+        for (const auto& id_and_order : app->Orders()) {
+            if (std::shared_ptr<BombardOrder> order = std::dynamic_pointer_cast<BombardOrder>(id_and_order.second)) {
+                retval[order->PlanetID()].insert(id_and_order.first);
             }
         }
         return retval;
@@ -2094,12 +2094,12 @@ void SidePanel::PlanetPanel::RClick(const GG::Pt& pt, GG::Flags<GG::ModKey> mod_
         if (planet->OrderedGivenToEmpire() != ALL_EMPIRES) {
             auto ungift_action = [planet]() { // cancel give away order for this fleet
                 const OrderSet orders = HumanClientApp::GetApp()->Orders();
-                for (const std::map<int, OrderPtr>::value_type& entry : orders) {
+                for (const auto& id_and_order : orders) {
                     if (std::shared_ptr<GiveObjectToEmpireOrder> order =
-                        std::dynamic_pointer_cast<GiveObjectToEmpireOrder>(entry.second))
+                        std::dynamic_pointer_cast<GiveObjectToEmpireOrder>(id_and_order.second))
                     {
                         if (order->ObjectID() == planet->ID()) {
-                            HumanClientApp::GetApp()->Orders().RescindOrder(entry.first);
+                            HumanClientApp::GetApp()->Orders().RescindOrder(id_and_order.first);
                             // could break here, but won't to ensure there are no problems with doubled orders
                         }
                     }
@@ -2218,10 +2218,10 @@ namespace {
 
         // is selected ship already ordered to colonize?  If so, recind that order.
         if (ship->OrderedColonizePlanet() != INVALID_OBJECT_ID) {
-            for (const std::map<int, OrderPtr>::value_type& entry : orders) {
-                if (std::shared_ptr<ColonizeOrder> order = std::dynamic_pointer_cast<ColonizeOrder>(entry.second)) {
+            for (const auto& id_and_order : orders) {
+                if (std::shared_ptr<ColonizeOrder> order = std::dynamic_pointer_cast<ColonizeOrder>(id_and_order.second)) {
                     if (order->ShipID() == ship->ID()) {
-                        HumanClientApp::GetApp()->Orders().RescindOrder(entry.first);
+                        HumanClientApp::GetApp()->Orders().RescindOrder(id_and_order.first);
                         // could break here, but won't to ensure there are no problems with doubled orders
                     }
                 }
@@ -2230,10 +2230,10 @@ namespace {
 
         // is selected ship ordered to invade?  If so, recind that order
         if (ship->OrderedInvadePlanet() != INVALID_OBJECT_ID) {
-            for (const std::map<int, OrderPtr>::value_type& entry : orders) {
-               if (std::shared_ptr<InvadeOrder> order = std::dynamic_pointer_cast<InvadeOrder>(entry.second)) {
+            for (const auto& id_and_order : orders) {
+               if (std::shared_ptr<InvadeOrder> order = std::dynamic_pointer_cast<InvadeOrder>(id_and_order.second)) {
                     if (order->ShipID() == ship->ID()) {
-                        HumanClientApp::GetApp()->Orders().RescindOrder(entry.first);
+                        HumanClientApp::GetApp()->Orders().RescindOrder(id_and_order.first);
                         // could break here, but won't to ensure there are no problems with doubled orders
                     }
                 }
@@ -2242,10 +2242,10 @@ namespace {
 
         // is selected ship ordered scrapped?  If so, recind that order
         if (ship->OrderedScrapped()) {
-            for (const std::map<int, OrderPtr>::value_type& entry : orders) {
-                if (std::shared_ptr<ScrapOrder> order = std::dynamic_pointer_cast<ScrapOrder>(entry.second)) {
+            for (const auto& id_and_order : orders) {
+                if (std::shared_ptr<ScrapOrder> order = std::dynamic_pointer_cast<ScrapOrder>(id_and_order.second)) {
                     if (order->ObjectID() == ship->ID()) {
-                        HumanClientApp::GetApp()->Orders().RescindOrder(entry.first);
+                        HumanClientApp::GetApp()->Orders().RescindOrder(id_and_order.first);
                         // could break here, but won't to ensure there are no problems with doubled orders
                     }
                 }
@@ -2254,10 +2254,10 @@ namespace {
 
         // is selected ship order to bombard?  If so, recind that order
         if (ship->OrderedBombardPlanet() != INVALID_OBJECT_ID) {
-            for (const std::map<int, OrderPtr>::value_type& entry : orders) {
-               if (std::shared_ptr<BombardOrder> order = std::dynamic_pointer_cast<BombardOrder>(entry.second)) {
+            for (const auto& id_and_order : orders) {
+               if (std::shared_ptr<BombardOrder> order = std::dynamic_pointer_cast<BombardOrder>(id_and_order.second)) {
                     if (order->ShipID() == ship->ID()) {
-                        HumanClientApp::GetApp()->Orders().RescindOrder(entry.first);
+                        HumanClientApp::GetApp()->Orders().RescindOrder(id_and_order.first);
                         // could break here, but won't to ensure there are no problems with doubled orders
                     }
                 }

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -813,7 +813,7 @@ class SidePanel::SystemNameDropDownList : public CUIDropDownList {
             const std::string& new_name(edit_wnd.Result());
             if (m_order_issuing_enabled && !new_name.empty() && new_name != old_name) {
                 HumanClientApp::GetApp()->Orders().IssueOrder(
-                    OrderPtr(new RenameOrder(HumanClientApp::GetApp()->EmpireID(), system->ID(), new_name)));
+                    std::make_shared<RenameOrder>(HumanClientApp::GetApp()->EmpireID(), system->ID(), new_name));
                 if (SidePanel* side_panel = dynamic_cast<SidePanel*>(Parent()))
                     side_panel->Refresh();
             }
@@ -1964,8 +1964,8 @@ void SidePanel::PlanetPanel::SetFocus(const std::string& focus) {
         return;
     colony_projections.clear();// in case new or old focus was Growth (important that be cleared BEFORE Order is issued)
     species_colony_projections.clear();
-    HumanClientApp::GetApp()->Orders().IssueOrder(OrderPtr(
-        new ChangeFocusOrder(HumanClientApp::GetApp()->EmpireID(), planet->ID(), focus)));
+    HumanClientApp::GetApp()->Orders().IssueOrder(
+        std::make_shared<ChangeFocusOrder>(HumanClientApp::GetApp()->EmpireID(), planet->ID(), focus));
 }
 
 bool SidePanel::PlanetPanel::InWindow(const GG::Pt& pt) const {
@@ -2059,7 +2059,7 @@ void SidePanel::PlanetPanel::RClick(const GG::Pt& pt, GG::Flags<GG::ModKey> mod_
                 && m_order_issuing_enabled)
             {
                 HumanClientApp::GetApp()->Orders().IssueOrder(
-                    OrderPtr(new RenameOrder(HumanClientApp::GetApp()->EmpireID(), planet->ID(), edit_wnd.Result())));
+                    std::make_shared<RenameOrder>(HumanClientApp::GetApp()->EmpireID(), planet->ID(), edit_wnd.Result()));
                 Refresh();
             }
 
@@ -2083,7 +2083,7 @@ void SidePanel::PlanetPanel::RClick(const GG::Pt& pt, GG::Flags<GG::ModKey> mod_
             int recipient_empire_id = entry.first;
             auto gift_action = [recipient_empire_id, client_empire_id, planet]() {
                 HumanClientApp::GetApp()->Orders().IssueOrder(
-                    OrderPtr(new GiveObjectToEmpireOrder(client_empire_id, planet->ID(), recipient_empire_id)));
+                    std::make_shared<GiveObjectToEmpireOrder>(client_empire_id, planet->ID(), recipient_empire_id));
             };
             if (peaceful_empires_in_system.find(recipient_empire_id) == peaceful_empires_in_system.end())
                 continue;
@@ -2302,8 +2302,8 @@ void SidePanel::PlanetPanel::ClickColonize() {
 
         CancelColonizeInvadeBombardScrapShipOrders(ship);
 
-        HumanClientApp::GetApp()->Orders().IssueOrder(OrderPtr(
-            new ColonizeOrder(empire_id, ship->ID(), m_planet_id)));
+        HumanClientApp::GetApp()->Orders().IssueOrder(
+            std::make_shared<ColonizeOrder>(empire_id, ship->ID(), m_planet_id));
     }
     OrderButtonChangedSignal(m_planet_id);
 }
@@ -2346,8 +2346,8 @@ void SidePanel::PlanetPanel::ClickInvade() {
 
             CancelColonizeInvadeBombardScrapShipOrders(ship);
 
-            HumanClientApp::GetApp()->Orders().IssueOrder(OrderPtr(
-                new InvadeOrder(empire_id, ship->ID(), m_planet_id)));
+            HumanClientApp::GetApp()->Orders().IssueOrder(
+                std::make_shared<InvadeOrder>(empire_id, ship->ID(), m_planet_id));
         }
     }
     OrderButtonChangedSignal(m_planet_id);
@@ -2391,8 +2391,8 @@ void SidePanel::PlanetPanel::ClickBombard() {
 
             CancelColonizeInvadeBombardScrapShipOrders(ship);
 
-            HumanClientApp::GetApp()->Orders().IssueOrder(OrderPtr(
-                new BombardOrder(empire_id, ship->ID(), m_planet_id)));
+            HumanClientApp::GetApp()->Orders().IssueOrder(
+                std::make_shared<BombardOrder>(empire_id, ship->ID(), m_planet_id));
         }
     }
     OrderButtonChangedSignal(m_planet_id);

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -2705,8 +2705,8 @@ void ServerApp::PreCombatProcessTurns() {
             DebugLogger() << "No OrderSet for empire " << empire_orders.first;
             continue;
         }
-        for (const std::map<int, OrderPtr>::value_type& order : *order_set)
-            order.second->Execute();
+        for (const auto& id_and_order : *order_set)
+            id_and_order.second->Execute();
     }
 
     // clean up orders, which are no longer needed

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -1559,8 +1559,8 @@ sc::result WaitingForTurnEnd::react(const TurnOrders& msg) {
             return discard_event();
         }
 
-        for (const std::map<int, OrderPtr>::value_type& entry : *order_set) {
-            OrderPtr order = entry.second;
+        for (const auto& id_and_order : *order_set) {
+            auto& order = id_and_order.second;
             if (!order) {
                 ErrorLogger(FSM) << "WaitingForTurnEnd::react(TurnOrders&) couldn't get order from order set!";
                 continue;

--- a/util/OrderSet.cpp
+++ b/util/OrderSet.cpp
@@ -15,7 +15,7 @@ const OrderPtr OrderSet::ExamineOrder(int order) const {
     return retval;
 }
 
-int OrderSet::IssueOrder(OrderPtr order) {
+int OrderSet::IssueOrder(const OrderPtr& order) {
     int retval = ((m_orders.rbegin() != m_orders.rend()) ? m_orders.rbegin()->first + 1 : 0);
     m_orders[retval] = order;
 

--- a/util/OrderSet.h
+++ b/util/OrderSet.h
@@ -40,7 +40,7 @@ public:
     {
         OrderVec retval;
         for (const OrderMap::value_type& order : m_orders) {
-            OrderPtr o = order.second;
+            auto &o = order.second;
             if (pred(o))
                 retval.push_back(o);
         }
@@ -54,7 +54,7 @@ public:
     /** \name Mutators */ //@{
     /** executes a given Order, then stores it in the OrderSet. Returns an index that can be used to reference the
         order.*/
-    int            IssueOrder(OrderPtr order);
+    int            IssueOrder(const OrderPtr& order);
 
     /** Applies all Orders in the OrderSet.  As of this writing, this is needed only after deserializing an OrderSet
         client-side during game loading. */

--- a/util/OrderSet.h
+++ b/util/OrderSet.h
@@ -53,7 +53,7 @@ public:
 
     /** \name Mutators */ //@{
     /** executes a given Order, then stores it in the OrderSet. Returns an index that can be used to reference the
-        order.  \warning The OrderSet assumes that the Order is allocated on the heap, and takes ownership of it.*/
+        order.*/
     int            IssueOrder(OrderPtr order);
 
     /** Applies all Orders in the OrderSet.  As of this writing, this is needed only after deserializing an OrderSet


### PR DESCRIPTION
This PR improves the use of the `OrderPtr` alias by doing two things.

This PR replaces 
````OrderPtr( new X())````
code with 
````std::make_shared<X>()````

which is more exception safe and may result in fewer allocations if the `shared_ptr` control block is allocated with the `X`

The PR uses `auto` in all `OrderSet` for loops, replacing `entry` with `id_and_order` to increase clarity
