### PR TITLE
Only enable DropDownList mouse scrolling when dropped or shift keyed pressed.

### DIFF
--- a/GG/GG/DropDownList.h
+++ b/GG/GG/DropDownList.h
@@ -218,6 +218,9 @@ public:
     /** Sets whether to normalize rows when inserted (true) or leave them as
       * they are. */
     void            NormalizeRowsOnInsert(bool enable = true);
+
+    /** Set the drop down list to only mouse scroll if it is dropped. */
+    void            SetOnlyMouseScrollWhenDropped(bool enable);
     //@}
 
 protected:

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -482,6 +482,7 @@ boost::optional<DropDownList::iterator> ModalListPicker::MouseWheelCommon(
     }
     if (move != 0) {
         std::advance(cur_it, move);
+        LB()->BringRowIntoView(cur_it);
         return cur_it;
     }
     return boost::none;

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -122,7 +122,7 @@ private:
     const DropDownList* m_relative_to_wnd;
     bool                m_dropped; ///< Is the drop down list open.
 
-    /** Should the list wnd scroll when dropped? */
+    /** Should the list wnd scroll only when dropped? */
     bool                m_only_mouse_scroll_when_dropped;
 };
 

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -525,9 +525,12 @@ void ModalListPicker::KeyPress(Key key, std::uint32_t key_code_point, Flags<ModK
 
 void ModalListPicker::MouseWheel(const Pt& pt, int move, Flags<ModKey> mod_keys)
 {
-    if (!LB()->InWindow(pt))
+    bool in_anchor_or_dropped_list = (LB()->InWindow(pt) || (m_relative_to_wnd && m_relative_to_wnd->InWindow(pt)));
+    if (!in_anchor_or_dropped_list)
         return;
-    SignalChanged(Select(MouseWheelCommon(pt, move, mod_keys)));
+
+    auto corrected_move = (LB()->InWindow(pt)? move : -move);
+    SignalChanged(Select(MouseWheelCommon(pt, corrected_move, mod_keys)));
 }
 
 ////////////////////////////////////////////////
@@ -909,7 +912,9 @@ void DropDownList::KeyPress(Key key, std::uint32_t key_code_point, Flags<ModKey>
 void DropDownList::MouseWheel(const Pt& pt, int move, Flags<ModKey> mod_keys)
 {
     if (!Disabled()) {
-        m_modal_picker->SignalChanged(m_modal_picker->Select(m_modal_picker->MouseWheelCommon(pt, -move, mod_keys)));
+        auto corrected_move = (LB()->InWindow(pt)? move : -move);
+        m_modal_picker->SignalChanged(
+            m_modal_picker->Select(m_modal_picker->MouseWheelCommon(pt, corrected_move, mod_keys)));
     } else {
         Control::MouseWheel(pt, move, mod_keys);
     }

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -30,7 +30,6 @@
 #include <GG/Scroll.h>
 #include <GG/StyleFactory.h>
 #include <GG/WndEvent.h>
-#include "../util/Logger.h"
 
 #include <boost/optional/optional.hpp>
 

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -392,6 +392,7 @@ namespace {
         drop_list->Resize(GG::Pt(drop_list->MinUsableSize().x, GG::Y(ClientUI::Pts() + 4)));
         drop_list->SetMaxSize(GG::Pt(drop_list->MaxSize().x, drop_list->Size().y));
         drop_list->SetStyle(GG::LIST_NOSORT);
+        drop_list->SetOnlyMouseScrollWhenDropped(true);
 
         // Insert the levels into the list
         for (auto ii = static_cast<std::size_t>(LogLevel::min); ii <= static_cast<std::size_t>(LogLevel::max); ++ii) {
@@ -1138,6 +1139,7 @@ void OptionsWnd::ResolutionOption(GG::ListBox* page, int indentation_level) {
     drop_list->SetStyle(GG::LIST_NOSORT);
     drop_list->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
     drop_list->SetBrowseText(UserString("OPTIONS_VIDEO_MODE_LIST_DESCRIPTION"));
+    drop_list->SetOnlyMouseScrollWhenDropped(true);
 
     GG::Layout* layout = new GG::Layout(GG::X0, GG::Y0, GG::X1, GG::Y1, 2, 1, 0, LAYOUT_MARGIN);
     layout->Add(drop_list_label, 0, 0);

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -447,6 +447,8 @@ namespace {
                                                        m_in_progress, GG::X(FONT_PTS*2.5), false);
             m_block_size_selector = new QuantitySelector(elem, GG::X1, GG::Y(MARGIN), GG::Y(FONT_PTS-2*MARGIN),
                                                          m_in_progress, GG::X(FONT_PTS*2.5), true);
+            m_quantity_selector->SetOnlyMouseScrollWhenDropped(true);
+            m_block_size_selector->SetOnlyMouseScrollWhenDropped(true);
         }
 
         m_name_text = new CUILabel(name_text, GG::FORMAT_TOP | GG::FORMAT_LEFT);

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -958,6 +958,7 @@ SidePanel::PlanetPanel::PlanetPanel(GG::X w, int planet_id, StarType star_type) 
     m_focus_drop->SetColWidth(0, m_focus_drop->DisplayedRowWidth());
     m_focus_drop->SetColStretch(0, 0.0);
     m_focus_drop->SetColStretch(1, 1.0);
+    m_focus_drop->SetOnlyMouseScrollWhenDropped(true);
 
 
     // meter panels


### PR DESCRIPTION
Addresses the first part of issue #1573.