### PR TITLE
Add links for browsing to a specified directory

### DIFF
--- a/UI/CUILinkTextBlock.cpp
+++ b/UI/CUILinkTextBlock.cpp
@@ -59,6 +59,7 @@ std::shared_ptr<GG::BlockControl> CUILinkTextBlock::Factory::CreateFromTag(const
     // Color ships and planets by their owner empires.
     block->m_link_text->SetDecorator(VarText::SHIP_ID_TAG, new ColorByOwner());
     block->m_link_text->SetDecorator(VarText::PLANET_ID_TAG, new ColorByOwner());
+    block->m_link_text->SetDecorator(TextLinker::BROWSE_PATH_TAG, new PathTypeDecorator());
 
     return block;
 }

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -916,6 +916,8 @@ void EncyclopediaDetailPanel::HandleLinkClick(const std::string& link_type, cons
             this->SetGraph(data);
         } else if (link_type == TextLinker::URL_TAG) {
             HumanClientApp::GetApp()->OpenURL(data);
+        } else if (link_type == TextLinker::BROWSE_PATH_TAG) {
+            HumanClientApp::GetApp()->BrowsePath(FilenameToPath(data));
         }
 
     } catch (const boost::bad_lexical_cast&) {

--- a/UI/LinkText.cpp
+++ b/UI/LinkText.cpp
@@ -17,6 +17,12 @@
 #include <boost/xpressive/xpressive.hpp>
 #include <boost/algorithm/string.hpp>
 
+// TextLinker static(s)
+const std::string TextLinker::ENCYCLOPEDIA_TAG("encyclopedia");
+const std::string TextLinker::GRAPH_TAG("graph");
+const std::string TextLinker::URL_TAG("url");
+const std::string TextLinker::BROWSE_PATH_TAG("browsepath");
+
 namespace {
     static const bool RENDER_DEBUGGING_LINK_RECTS = false;
 
@@ -229,12 +235,6 @@ struct TextLinker::Link {
 ///////////////////////////////////////
 // TextLinker
 ///////////////////////////////////////
-// static(s)
-const std::string TextLinker::ENCYCLOPEDIA_TAG("encyclopedia");
-const std::string TextLinker::GRAPH_TAG("graph");
-const std::string TextLinker::URL_TAG("url");
-const std::string TextLinker::BROWSE_PATH_TAG("browsepath");
-
 TextLinker::TextLinker() :
     m_links(),
     m_rollover_link(-1)

--- a/UI/LinkText.cpp
+++ b/UI/LinkText.cpp
@@ -8,16 +8,83 @@
 #include "../util/Logger.h"
 #include "../util/VarText.h"
 #include "../util/i18n.h"
+#include "../util/Directories.h"
+#include "../universe/Enums.h"
 
 #include <GG/DrawUtil.h>
 #include <GG/WndEvent.h>
 #include <GG/GUI.h>
+#include <boost/xpressive/xpressive.hpp>
+#include <boost/algorithm/string.hpp>
 
 namespace {
     static const bool RENDER_DEBUGGING_LINK_RECTS = false;
 
     // closing format tag
     static const std::string LINK_FORMAT_CLOSE = "</rgba>";
+
+    std::string AllParamsAsString(const std::vector<GG::Font::Substring>& params) {
+        std::string retval;
+        for (const auto& param : params) {
+            if (!retval.empty())
+                retval.append(" ");
+            retval.append(param);
+        }
+        return retval;
+    }
+
+    std::string ResolveNestedPathTypes(const std::string& text) {
+        if (text.empty())
+            return text;
+        std::string new_text = text;
+        for (const auto& path_type : PathTypeStrings()) {
+            std::string path_string = PathToString(GetPath(path_type));
+            boost::replace_all(new_text, path_type, path_string);
+        }
+        return new_text;
+    }
+
+    namespace xpr = boost::xpressive;
+    const xpr::sregex REGEX_NON_BRACKET = *~(xpr::set= '<', '>');
+    const std::string BROWSEPATH_TAG_OPEN_PRE("<" + TextLinker::BROWSE_PATH_TAG);
+    const std::string BROWSEPATH_TAG_CLOSE("</" + TextLinker::BROWSE_PATH_TAG + ">");
+    const xpr::sregex BROWSEPATH_SEARCH = BROWSEPATH_TAG_OPEN_PRE >> xpr::_s >> (xpr::s1 = REGEX_NON_BRACKET) >> ">" >>
+                                          (xpr::s2 = REGEX_NON_BRACKET) >> BROWSEPATH_TAG_CLOSE;
+
+    /** Parses TextLinker::BROWSE_PATH_TAG%s within @p text, replacing string representation of PathType%s with
+     *  current path for that PathType.  If link label is empty, inserts resolved link argument as label */
+    std::string BrowsePathLinkText(const std::string& text) {
+        if (!boost::contains(text, BROWSEPATH_TAG_CLOSE))
+            return text;
+
+        std::string retval(text);
+        auto text_it = retval.begin();
+        xpr::smatch match;
+
+        while (true) {
+            if (!xpr::regex_search(text_it, retval.end(), match, BROWSEPATH_SEARCH, xpr::regex_constants::match_any))
+                break;
+
+            auto link_arg = ResolveNestedPathTypes(match[1]);
+            std::string link_label(match[2]);
+            if (link_label.empty())
+                link_label = link_arg;
+            else
+                link_label = ResolveNestedPathTypes(link_label);
+
+            // Only support argument containing at least one valid PathType
+            if (link_arg == match[1].str() || boost::contains(link_arg, PathTypeToString(PATH_INVALID)))
+                link_label = UserString("ERROR") + ": " + link_label;
+
+            auto resolved_link = BROWSEPATH_TAG_OPEN_PRE + " " + link_arg + ">" + link_label + BROWSEPATH_TAG_CLOSE;
+
+            retval.replace(text_it + match.position(), text_it + match.position() + match.length(), resolved_link);
+
+            text_it = retval.end() - match.suffix().length();
+        }
+
+        return retval;
+    }
 }
 
 ///////////////////////////////////////
@@ -142,6 +209,14 @@ std::string ColorByOwner::Decorate(const std::string& object_id_str, const std::
     return GG::RgbaTag(color) + content + "</rgba>";
 }
 
+std::string PathTypeDecorator::Decorate(const std::string& path_type, const std::string& content) const {
+    return LinkDecorator::Decorate(path_type, BrowsePathLinkText(content));
+}
+
+std::string PathTypeDecorator::DecorateRollover(const std::string& path_type, const std::string& content) const {
+    return LinkDecorator::DecorateRollover(path_type, BrowsePathLinkText(content));
+}
+
 
 ///////////////////////////////////////
 // TextLinker::Link
@@ -162,6 +237,7 @@ struct TextLinker::Link {
 const std::string TextLinker::ENCYCLOPEDIA_TAG("encyclopedia");
 const std::string TextLinker::GRAPH_TAG("graph");
 const std::string TextLinker::URL_TAG("url");
+const std::string TextLinker::BROWSE_PATH_TAG("browsepath");
 
 TextLinker::TextLinker() :
     m_links(),
@@ -307,7 +383,8 @@ void TextLinker::FindLinks() {
                     tag->tag_name == VarText::METER_TYPE_TAG ||
                     tag->tag_name == TextLinker::ENCYCLOPEDIA_TAG ||
                     tag->tag_name == TextLinker::GRAPH_TAG ||
-                    tag->tag_name == TextLinker::URL_TAG)
+                    tag->tag_name == TextLinker::URL_TAG ||
+                    tag->tag_name == TextLinker::BROWSE_PATH_TAG)
                 {
                     link.type = tag->tag_name;
                     if (tag->close_tag) {
@@ -315,10 +392,21 @@ void TextLinker::FindLinks() {
                         m_links.push_back(link);
                         link = Link();
                     } else {
-                        if (!tag->params.empty())
-                            link.data = tag->params[0];
-                        else
+                        if (!tag->params.empty()) {
+                            if (tag->tag_name == TextLinker::BROWSE_PATH_TAG) {
+                                link.data = ResolveNestedPathTypes(AllParamsAsString(tag->params));
+                                // BROWSE_PATH_TAG requires a PathType within param
+                                if (link.data == std::string(tag->params[0])) {
+                                    ErrorLogger() << "Invalid param \"" << link.data << "\" for tag "
+                                                  << TextLinker::BROWSE_PATH_TAG;
+                                    link.data = PathTypeToString(PATH_INVALID);
+                                }
+                            } else {
+                                link.data = tag->params[0];
+                            }
+                        } else {
                             link.data.clear();
+                        }
                         link.text_posn.first = Value(curr_char.string_index);
                         for (auto& itag : curr_char.tags) {
                             link.text_posn.first -= Value(itag->StringSize());
@@ -499,4 +587,5 @@ void RegisterLinkTags() {
     GG::Font::RegisterKnownTag(TextLinker::ENCYCLOPEDIA_TAG);
     GG::Font::RegisterKnownTag(TextLinker::GRAPH_TAG);
     GG::Font::RegisterKnownTag(TextLinker::URL_TAG);
+    GG::Font::RegisterKnownTag(TextLinker::BROWSE_PATH_TAG);
 }

--- a/UI/LinkText.cpp
+++ b/UI/LinkText.cpp
@@ -62,7 +62,7 @@ namespace {
         xpr::smatch match;
 
         while (true) {
-            if (!xpr::regex_search(text_it, retval.end(), match, BROWSEPATH_SEARCH, xpr::regex_constants::match_any))
+            if (!xpr::regex_search(text_it, retval.end(), match, BROWSEPATH_SEARCH, xpr::regex_constants::match_default))
                 break;
 
             auto link_arg = ResolveNestedPathTypes(match[1]);
@@ -71,10 +71,6 @@ namespace {
                 link_label = link_arg;
             else
                 link_label = ResolveNestedPathTypes(link_label);
-
-            // Only support argument containing at least one valid PathType
-            if (link_arg == match[1].str() || boost::contains(link_arg, PathTypeToString(PATH_INVALID)))
-                link_label = UserString("ERROR") + ": " + link_label;
 
             auto resolved_link = BROWSEPATH_TAG_OPEN_PRE + " " + link_arg + ">" + link_label + BROWSEPATH_TAG_CLOSE;
 
@@ -395,12 +391,6 @@ void TextLinker::FindLinks() {
                         if (!tag->params.empty()) {
                             if (tag->tag_name == TextLinker::BROWSE_PATH_TAG) {
                                 link.data = ResolveNestedPathTypes(AllParamsAsString(tag->params));
-                                // BROWSE_PATH_TAG requires a PathType within param
-                                if (link.data == std::string(tag->params[0])) {
-                                    ErrorLogger() << "Invalid param \"" << link.data << "\" for tag "
-                                                  << TextLinker::BROWSE_PATH_TAG;
-                                    link.data = PathTypeToString(PATH_INVALID);
-                                }
                             } else {
                                 link.data = tag->params[0];
                             }

--- a/UI/LinkText.h
+++ b/UI/LinkText.h
@@ -47,6 +47,12 @@ public:
     std::string Decorate(const std::string& object_id_str, const std::string& content) const override;
 };
 
+class PathTypeDecorator : public LinkDecorator {
+public:
+    std::string Decorate(const std::string& path_type, const std::string& content) const override;
+    std::string DecorateRollover(const std::string& path_type, const std::string& content) const override;
+};
+
 class TextLinker {
 public:
     /** \name Structors */ //@{
@@ -67,6 +73,8 @@ public:
     static const std::string ENCYCLOPEDIA_TAG;
     static const std::string GRAPH_TAG;
     static const std::string URL_TAG;
+    /** Tag for clickable link to open users file manager at a specified directory */
+    static const std::string BROWSE_PATH_TAG;
 
 protected:
     void        Render_();

--- a/UI/SitRepPanel.cpp
+++ b/UI/SitRepPanel.cpp
@@ -6,6 +6,7 @@
 #include "../client/human/HumanClientApp.h"
 #include "../Empire/Empire.h"
 #include "../util/i18n.h"
+#include "../util/Directories.h"
 #include "../util/Logger.h"
 #include "../util/OptionsDB.h"
 #include "../util/SitRepEntry.h"
@@ -86,6 +87,8 @@ namespace {
                 ClientUI::GetClientUI()->ZoomToMeterTypeArticle(data);
             } else if (link_type == TextLinker::ENCYCLOPEDIA_TAG) {
                 ClientUI::GetClientUI()->ZoomToEncyclopediaEntry(data);
+            } else if (link_type == TextLinker::BROWSE_PATH_TAG) {
+                HumanClientApp::GetApp()->BrowsePath(FilenameToPath(data));
             }
         } catch (const boost::bad_lexical_cast&) {
             ErrorLogger() << "SitrepPanel.cpp HandleLinkClick caught lexical cast exception for link type: " << link_type << " and data: " << data;
@@ -248,6 +251,7 @@ namespace {
                                              ClientUI::GetFont(),
                                              GG::FORMAT_LEFT | GG::FORMAT_VCENTER | GG::FORMAT_WORDBREAK, ClientUI::TextColor());
             m_link_text->SetDecorator(VarText::EMPIRE_ID_TAG, new ColorEmpire());
+            m_link_text->SetDecorator(TextLinker::BROWSE_PATH_TAG, new PathTypeDecorator());
             AttachChild(m_link_text);
 
             m_link_text->LinkClickedSignal.connect(

--- a/client/human/HumanClientApp.h
+++ b/client/human/HumanClientApp.h
@@ -99,6 +99,8 @@ public:
     void                HandleSaveGamePreviews(const Message& msg);
 
     void                OpenURL(const std::string& url);
+    /** Opens the users preferred application for file manager at the specified path @p browse_path */
+    void                BrowsePath(const boost::filesystem::path& browse_path);
     //@}
 
     mutable FullscreenSwitchSignalType  FullscreenSwitchSignal;

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -5384,7 +5384,6 @@ Greetings Esteemed Entity, and Welcome to the FreeOrion Universe!
 GREETINGS_GUIDE_REFERENCE
 Newcomers to this universe may particularly wish to consult the [[encyclopedia QUICK_START_GUIDE_TITLE]].
 
-
 GREETINGS_GUIDE_TEXT
 '''[[GREETINGS_INTRO]]
 
@@ -8458,6 +8457,38 @@ Partial
 # Visibility levels
 VIS_FULL_VISIBILITY
 Full
+
+# Path types
+PATH_BINARY
+''''''
+
+# Path types
+PATH_RESOURCE
+''''''
+
+# Path types
+PATH_PYTHON
+''''''
+
+# Path types
+PATH_DATA_ROOT
+''''''
+
+# Path types
+PATH_DATA_USER
+''''''
+
+# Path types
+PATH_CONFIG
+''''''
+
+# Path types
+PATH_SAVE
+''''''
+
+# Path types
+PATH_TEMP
+''''''
 
 # Ship hull categories
 

--- a/universe/Enums.cpp
+++ b/universe/Enums.cpp
@@ -2,6 +2,18 @@
 
 #include <cassert>
 
+namespace {
+    const std::string EMPTY_STRING = "";
+    const std::string PATH_BINARY_STR = "PATH_BINARY";
+    const std::string PATH_RESOURCE_STR = "PATH_RESOURCE";
+    const std::string PATH_DATA_ROOT_STR = "PATH_DATA_ROOT";
+    const std::string PATH_DATA_USER_STR = "PATH_DATA_USER";
+    const std::string PATH_CONFIG_STR = "PATH_CONFIG";
+    const std::string PATH_SAVE_STR = "PATH_SAVE";
+    const std::string PATH_TEMP_STR = "PATH_TEMP";
+    const std::string PATH_PYTHON_STR = "PATH_PYTHON";
+    const std::string PATH_INVALID_STR = "PATH_INVALID";
+}
 
 MeterType ResourceToMeter(ResourceType type) {
     switch (type) {
@@ -55,4 +67,34 @@ MeterType AssociatedMeterType(MeterType meter_type) {
     case METER_SUPPLY:      return METER_MAX_SUPPLY;            break;
     default:                return INVALID_METER_TYPE;          break;
     }
+}
+
+const std::string& PathTypeToString(PathType path_type) {
+    switch (path_type) {
+        case PATH_BINARY:       return PATH_BINARY_STR;
+        case PATH_RESOURCE:     return PATH_RESOURCE_STR;
+        case PATH_PYTHON:       return PATH_PYTHON_STR;
+        case PATH_DATA_ROOT:    return PATH_DATA_ROOT_STR;
+        case PATH_DATA_USER:    return PATH_DATA_USER_STR;
+        case PATH_CONFIG:       return PATH_CONFIG_STR;
+        case PATH_SAVE:         return PATH_SAVE_STR;
+        case PATH_TEMP:         return PATH_TEMP_STR;
+        case PATH_INVALID:      return PATH_INVALID_STR;
+        default:                return EMPTY_STRING;
+    }
+}
+
+const std::vector<std::string>& PathTypeStrings() {
+    static std::vector<std::string> path_type_list;
+    if (path_type_list.empty()) {
+        for (auto path_type = PathType(0); path_type < PATH_INVALID; path_type = PathType(path_type + 1)) {
+            // PATH_PYTHON is only valid for FREEORION_WIN32 or FREEORION_MACOSX
+#if defined(FREEORION_LINUX)
+            if (path_type == PATH_PYTHON)
+                continue;
+#endif
+            path_type_list.push_back(PathTypeToString(path_type));
+        }
+    }
+    return path_type_list;
 }

--- a/universe/Enums.h
+++ b/universe/Enums.h
@@ -4,6 +4,8 @@
 #include <GG/Enum.h>
 
 #include <iostream>
+#include <string>
+#include <vector>
 
 #include "../util/Export.h"
 
@@ -325,6 +327,25 @@ GG_ENUM(ModeratorActionSetting,
     MAS_CreateSystem,
     MAS_CreatePlanet
 )
+
+/** Types of root directories */
+GG_ENUM(PathType,
+    PATH_BINARY,
+    PATH_RESOURCE,
+    PATH_PYTHON,
+    PATH_DATA_ROOT,
+    PATH_DATA_USER,
+    PATH_CONFIG,
+    PATH_SAVE,
+    PATH_TEMP,
+    PATH_INVALID
+)
+
+/** Returns a string representation of PathType */
+FO_COMMON_API const std::string& PathTypeToString(PathType path_type);
+
+/** Returns a vector of strings for all PathTypes */
+FO_COMMON_API const std::vector<std::string>& PathTypeStrings();
 
 
 #endif // _Enums_h_

--- a/universe/EnumsFwd.h
+++ b/universe/EnumsFwd.h
@@ -22,5 +22,6 @@ enum Visibility : int;
 enum CaptureResult : int;
 enum EffectsCauseType : int;
 enum ModeratorActionSetting : int;
+enum PathType : int;
 
 #endif // _EnumsFwd_h_

--- a/util/Directories.h
+++ b/util/Directories.h
@@ -5,6 +5,7 @@
 #include <string>
 
 #include "Export.h"
+#include "../universe/EnumsFwd.h"
 
 /** This function must be called before any Get*Dir function is called. It
   * stores the current working directory as well as creating local
@@ -100,5 +101,12 @@ FO_COMMON_API bool IsValidUTF8(const std::string& in);
 /** Returns true iff the \p test_dir is in \p dir and both \p dir and test_dir
     are existing directories. */
 FO_COMMON_API bool IsInDir(const boost::filesystem::path& dir, const boost::filesystem::path& test_dir);
+
+/** Returns path currently defined for @p path_type */
+FO_COMMON_API boost::filesystem::path GetPath(PathType path_type);
+
+/** Returns path for path type cast from @p path_string */
+FO_COMMON_API boost::filesystem::path GetPath(const std::string& path_string);
+
 
 #endif


### PR DESCRIPTION
Adds a text tag that supports opening a users preferred file manager at a configured directory.
(Usage: `<browsepath `*type*`>`*optional appended text*`</browsepath>`)

Initial purpose of this PR is to support a clickable link for a users config directory within a pedia article for #1552 


Testing requested for verification on Windows and OSX.
e.g. within the stringtable entry for a pedia article or sitrep add any or all of:
```
<browsepath PATH_CONFIG>Config Files</browsepath>
<browsepath PATH_DATA_USER/shipdesigns>Custom Ship Designs</browsepath>
<browsepath PATH_DATA_ROOT>Browse:PATH_DATA_ROOT</browsepath>
<browsepath PATH_RESOURCE></browsepath>
<browsepath PATH_RESOURCE/python/AI>PATH_RESOURCE/python/AI</browsepath>
[[browsepath PATH_SAVE]]
```
Clicking on the link in-game should open the preferred file manager at your configured user data directory.