### PR TITLE
AI savegame compatibility framework

### DIFF
--- a/default/python/AI/AIstate.py
+++ b/default/python/AI/AIstate.py
@@ -17,7 +17,7 @@ import PlanetUtilsAI
 from freeorion_tools import dict_from_map, print_error
 from universe_object import System
 from AIDependencies import INVALID_ID
-from character.character_module import create_character
+from character.character_module import create_character, Aggression
 
 
 # moving ALL or NEARLY ALL 'global' variables into AIState object rather than module
@@ -158,7 +158,13 @@ class AIstate(object):
                 convert_to_version(state, v+1)
             self.__dict__ = state
         except ConversionError:
-            self.__init__(aggression=fo.aggression.typical)
+            try:
+                aggression = state['character'].get_trait(Aggression).key
+            except Exception as e:
+                print >> sys.stderr, "Could not find the aggression level of the AI, defaulting to typical."
+                print >> sys.stderr, e
+                aggression = fo.aggression.typical
+            self.__init__(aggression)
 
     def generate_uid(self, first=False):
         """

--- a/default/python/AI/AIstate.py
+++ b/default/python/AI/AIstate.py
@@ -96,6 +96,9 @@ class AIstate(object):
     version = 0
 
     def __init__(self, aggression):
+        # Do not allow to create AIstate instances with an invalid version number.
+        assert(hasattr(AIstate, 'version') and isinstance(AIstate.version, int) and AIstate.version >= 0)
+
         # Debug info
         # unique id for game
         self.uid = self.generate_uid(first=True)

--- a/default/python/AI/AIstate.py
+++ b/default/python/AI/AIstate.py
@@ -64,13 +64,13 @@ def convert_to_version(state, version):
     current_version = state.get("version", -1)
     print "  Current version: %d" % current_version
     if current_version == version:
-        raise ConversionError("Can't convert AI Savegame to the same version.")
+        raise ConversionError("Can't convert AI savegame to the same compatibility version.")
 
     if current_version > version:
-        raise ConversionError("Can't convert to an older version.")
+        raise ConversionError("Can't convert AI savegame to an older compatibility version.")
 
     if version != current_version + 1:
-        raise ConversionError("Can't skip a version.")
+        raise ConversionError("Can't skip a compatibility version when converting AI savegame.")
 
     if version == 0:
         pass  # only version number added

--- a/default/python/AI/AIstate.py
+++ b/default/python/AI/AIstate.py
@@ -97,7 +97,12 @@ class AIstate(object):
 
     def __init__(self, aggression):
         # Do not allow to create AIstate instances with an invalid version number.
-        assert(hasattr(AIstate, 'version') and isinstance(AIstate.version, int) and AIstate.version >= 0)
+        if not hasattr(AIstate, 'version'):
+            raise ConversionError("AIstate must have an integer version attribute for savegame compatibility")
+        if not isinstance(AIstate.version, int):
+            raise ConversionError("Version attribute of AIstate must be an integer!")
+        if AIstate.version < 0:
+            raise ConversionError("AIstate savegame compatibility version must be a positive integer!")
 
         # Debug info
         # unique id for game


### PR DESCRIPTION
Basic principle:

1. The AIstate class has a version number.
2. Whenever the AIstate class is modified in a way that would break savegame compatibility
  i.  The version number must be increased by 1
  ii. The convert_to_version() function must implement the required changes to get a playable AIstate instance compatible with the new AIstate version.
3. If the old state is several versions old, then convert it iteratively to the next version until the current version is reached (i.e. 1->2->3->4)
4. If conversion fails, inform the player about the problem and try to play with a fresh AIstate instance.
