### PR TITLE
Switch Mac build from 32 to 64 bit

### DIFF
--- a/Xcode/FreeOrion.xcodeproj/project.pbxproj
+++ b/Xcode/FreeOrion.xcodeproj/project.pbxproj
@@ -106,17 +106,7 @@
 		3A7604B21749A15500363653 /* ConditionParser3.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 825936DD147E3B1B00B840A5 /* ConditionParser3.cpp */; };
 		3A7604B31749A15500363653 /* ConditionParser4.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8250FDE115FCEFC400523C1C /* ConditionParser4.cpp */; };
 		3A7604B41749A16200363653 /* BuildingsParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 825936D7147E3B1B00B840A5 /* BuildingsParser.cpp */; };
-		3ABEAB3B1749BFED00E34912 /* freeorioncommon.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 47103BE20CF04D8800A7DF2B /* freeorioncommon.dylib */; };
-		3ABEAB3C1749C21B00E34912 /* libboost_serialization.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EEEEA7613ACB91A0085B1A0 /* libboost_serialization.a */; };
-		3ABEAB3F1749C27700E34912 /* libboost_filesystem.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EEEEA7313ACB91A0085B1A0 /* libboost_filesystem.a */; };
-		3ABEAB711749C2F400E34912 /* libboost_signals.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EEEEA7713ACB91A0085B1A0 /* libboost_signals.a */; };
-		3ABEAB741749C36200E34912 /* libboost_system.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EEEEA7813ACB91A0085B1A0 /* libboost_system.a */; };
-		3ABEAB801749C51B00E34912 /* libboost_thread.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EEEEA7913ACB91A0085B1A0 /* libboost_thread.a */; };
 		3ABEAB871749C72000E34912 /* Universe.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 471D5D0F0A98A3F900DA9C21 /* Universe.cpp */; };
-		3ABEAB901749C8F500E34912 /* libboost_thread.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EEEEA7913ACB91A0085B1A0 /* libboost_thread.a */; };
-		3ABEAB971749C93400E34912 /* libboost_signals.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EEEEA7713ACB91A0085B1A0 /* libboost_signals.a */; };
-		3ABEAB9C1749C96400E34912 /* libboost_signals.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EEEEA7713ACB91A0085B1A0 /* libboost_signals.a */; };
-		3ABEABA11749C9CA00E34912 /* libboost_thread.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EEEEA7913ACB91A0085B1A0 /* libboost_thread.a */; };
 		3ABEABA41749D05700E34912 /* freeorionparse.dylib in Copy Shared Libraries */ = {isa = PBXBuildFile; fileRef = 82C07438149DE46200E76876 /* freeorionparse.dylib */; };
 		3ABEABA51749D05E00E34912 /* freeorioncommon.dylib in Copy Shared Libraries */ = {isa = PBXBuildFile; fileRef = 47103BE20CF04D8800A7DF2B /* freeorioncommon.dylib */; };
 		470DF9A10A9CE53500A88AD6 /* HumanClientApp.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 471D5C640A98A3F900DA9C21 /* HumanClientApp.cpp */; };
@@ -242,7 +232,6 @@
 		825EA76016DB9DB10002A797 /* ModeratorAction.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 825EA75E16DB9DB10002A797 /* ModeratorAction.cpp */; };
 		82655A401716D9240007EEDD /* CombatSystem.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 471D5C6D0A98A3F900DA9C21 /* CombatSystem.cpp */; };
 		82682D8219C24DEC0041C465 /* libGLEW.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 82E250AD19C2317700F0E2F2 /* libGLEW.a */; };
-		82714D771ADABE680071A329 /* libboost_log.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 82714D761ADABE680071A329 /* libboost_log.a */; };
 		8275F3F91AD31381003568FF /* AccordionPanel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8275F3DD1AD31381003568FF /* AccordionPanel.cpp */; };
 		8275F3FA1AD31381003568FF /* BuildingsPanel.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8275F3DF1AD31381003568FF /* BuildingsPanel.cpp */; };
 		8275F3FB1AD31381003568FF /* CensusBrowseWnd.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8275F3E11AD31381003568FF /* CensusBrowseWnd.cpp */; };
@@ -257,12 +246,7 @@
 		8275F4051AD31381003568FF /* SystemResourceSummaryBrowseWnd.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8275F3F51AD31381003568FF /* SystemResourceSummaryBrowseWnd.cpp */; };
 		8275F4061AD31381003568FF /* TextBrowseWnd.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8275F3F71AD31381003568FF /* TextBrowseWnd.cpp */; };
 		827902381737C6EA008AF126 /* ModeratorActionsWnd.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 827902361737C6EA008AF126 /* ModeratorActionsWnd.cpp */; };
-		8280AC5D19C0741B00ADDB65 /* libboost_iostreams.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8280AC5C19C0741B00ADDB65 /* libboost_iostreams.a */; };
-		8280AC5E19C0741B00ADDB65 /* libboost_iostreams.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8280AC5C19C0741B00ADDB65 /* libboost_iostreams.a */; };
-		8280AC5F19C0741C00ADDB65 /* libboost_iostreams.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8280AC5C19C0741B00ADDB65 /* libboost_iostreams.a */; };
-		8280AC6019C0741C00ADDB65 /* libboost_iostreams.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 8280AC5C19C0741B00ADDB65 /* libboost_iostreams.a */; };
 		8288432E1850A1770023C4D7 /* Python.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 34F0E427113F491C00A10EED /* Python.framework */; };
-		8288432F1850A1960023C4D7 /* libboost_python.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EEEEA7413ACB91A0085B1A0 /* libboost_python.a */; };
 		828843341850A2550023C4D7 /* LoggingWrapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 343EC6760F3F61D000782AD3 /* LoggingWrapper.cpp */; };
 		82884C4B1850B0E60023C4D7 /* EnumWrapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 343EC6750F3F61D000782AD3 /* EnumWrapper.cpp */; };
 		8289A72919BDB307001256C1 /* SDLGUI.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 471023BA0CEF3AAC00A7DF2B /* SDLGUI.cpp */; };
@@ -275,7 +259,6 @@
 		8298A1AE18F9BB980001D3DA /* SaveFileDialog.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 8298A1AC18F9BB980001D3DA /* SaveFileDialog.cpp */; };
 		829BBB6217D09017009D3735 /* ValueRefParserImpl.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 829BBB6117D09017009D3735 /* ValueRefParserImpl.cpp */; };
 		829E16B11811181F00F7F52D /* EmpireStatsParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 829E16B01811181F00F7F52D /* EmpireStatsParser.cpp */; };
-		82AB1D13194D97A1009C8220 /* libboost_regex.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EEEEA7513ACB91A0085B1A0 /* libboost_regex.a */; };
 		82B3265319B603C1005082AC /* ConditionParser7.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 82B3265219B603C1005082AC /* ConditionParser7.cpp */; };
 		82B4313414A74E07003EEE42 /* UniverseGenerator.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 82B4313314A74E07003EEE42 /* UniverseGenerator.cpp */; };
 		82B9AEA11AA71CCC00486B2A /* CombatLogWnd.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 82B9AE991AA71CCC00486B2A /* CombatLogWnd.cpp */; };
@@ -313,11 +296,56 @@
 		82E9DDF119530E5D007E681B /* CombatEvent.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 82E9DDED19530E5D007E681B /* CombatEvent.cpp */; };
 		82E9DDF219530E5D007E681B /* CombatEvents.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 82E9DDEF19530E5D007E681B /* CombatEvents.cpp */; };
 		82EC868B1B40504700D4584D /* Encyclopedia.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 82EC86891B40504700D4584D /* Encyclopedia.cpp */; };
-		82F55DE818B0FF0A00FA9E11 /* libboost_date_time.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 82483B7A15F4F24100D27614 /* libboost_date_time.a */; };
-		9E632AEC13AD24D1003D1874 /* libboost_python.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EEEEA7413ACB91A0085B1A0 /* libboost_python.a */; };
-		9E632AED13AD24D1003D1874 /* libboost_regex.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EEEEA7513ACB91A0085B1A0 /* libboost_regex.a */; };
-		B7A7D5371ECF2D5000E086C2 /* libboost_date_time.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 82483B7A15F4F24100D27614 /* libboost_date_time.a */; };
-		B7A7D5381ECF2D6E00E086C2 /* libboost_regex.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 9EEEEA7513ACB91A0085B1A0 /* libboost_regex.a */; };
+		B72A827F1F5AEEBA00C25F91 /* freeorionparse.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 82C07438149DE46200E76876 /* freeorionparse.dylib */; };
+		B72A82811F5AF08A00C25F91 /* libboost_date_time.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B72A82801F5AF08A00C25F91 /* libboost_date_time.dylib */; };
+		B72A82831F5AF0AC00C25F91 /* libboost_filesystem.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B72A82821F5AF0AC00C25F91 /* libboost_filesystem.dylib */; };
+		B72A82851F5AF0B900C25F91 /* libboost_iostreams.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B72A82841F5AF0B900C25F91 /* libboost_iostreams.dylib */; };
+		B72A82881F5AF0DA00C25F91 /* libboost_log_setup.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B72A82861F5AF0DA00C25F91 /* libboost_log_setup.dylib */; };
+		B72A82891F5AF0DA00C25F91 /* libboost_log.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B72A82871F5AF0DA00C25F91 /* libboost_log.dylib */; };
+		B72A828D1F5AF0FE00C25F91 /* libboost_regex.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B72A828A1F5AF0FE00C25F91 /* libboost_regex.dylib */; };
+		B72A828E1F5AF0FE00C25F91 /* libboost_serialization.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B72A828B1F5AF0FE00C25F91 /* libboost_serialization.dylib */; };
+		B72A828F1F5AF0FE00C25F91 /* libboost_signals.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B72A828C1F5AF0FE00C25F91 /* libboost_signals.dylib */; };
+		B72A82911F5AF12000C25F91 /* libboost_system.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B72A82901F5AF12000C25F91 /* libboost_system.dylib */; };
+		B72A82931F5AF13300C25F91 /* libboost_thread.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B72A82921F5AF13300C25F91 /* libboost_thread.dylib */; };
+		B72A82941F5AF1AD00C25F91 /* libboost_date_time.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B72A82801F5AF08A00C25F91 /* libboost_date_time.dylib */; };
+		B72A82951F5AF1B300C25F91 /* libboost_filesystem.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B72A82821F5AF0AC00C25F91 /* libboost_filesystem.dylib */; };
+		B72A82961F5AF1B600C25F91 /* libboost_iostreams.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B72A82841F5AF0B900C25F91 /* libboost_iostreams.dylib */; };
+		B72A82971F5AF1BA00C25F91 /* libboost_log_setup.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B72A82861F5AF0DA00C25F91 /* libboost_log_setup.dylib */; };
+		B72A82981F5AF1C600C25F91 /* libboost_log.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B72A82871F5AF0DA00C25F91 /* libboost_log.dylib */; };
+		B72A82991F5AF1D200C25F91 /* libboost_serialization.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B72A828B1F5AF0FE00C25F91 /* libboost_serialization.dylib */; };
+		B72A829A1F5AF1D600C25F91 /* libboost_signals.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B72A828C1F5AF0FE00C25F91 /* libboost_signals.dylib */; };
+		B72A829B1F5AF1DB00C25F91 /* libboost_system.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B72A82901F5AF12000C25F91 /* libboost_system.dylib */; };
+		B72A829C1F5AF1E000C25F91 /* libboost_thread.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B72A82921F5AF13300C25F91 /* libboost_thread.dylib */; };
+		B72A829E1F5AF1F500C25F91 /* libboost_python.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B72A829D1F5AF1F500C25F91 /* libboost_python.dylib */; };
+		B72A829F1F5AF22800C25F91 /* libboost_filesystem.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B72A82821F5AF0AC00C25F91 /* libboost_filesystem.dylib */; };
+		B72A82A01F5AF22E00C25F91 /* libboost_iostreams.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B72A82841F5AF0B900C25F91 /* libboost_iostreams.dylib */; };
+		B72A82A21F5AF24400C25F91 /* libboost_locale.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B72A82A11F5AF24400C25F91 /* libboost_locale.dylib */; };
+		B72A82A31F5AF24F00C25F91 /* libboost_log.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B72A82871F5AF0DA00C25F91 /* libboost_log.dylib */; };
+		B72A82A41F5AF25300C25F91 /* libboost_log_setup.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B72A82861F5AF0DA00C25F91 /* libboost_log_setup.dylib */; };
+		B72A82A51F5AF25800C25F91 /* libboost_regex.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B72A828A1F5AF0FE00C25F91 /* libboost_regex.dylib */; };
+		B72A82A61F5AF25D00C25F91 /* libboost_signals.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B72A828C1F5AF0FE00C25F91 /* libboost_signals.dylib */; };
+		B72A82A71F5AF26200C25F91 /* libboost_system.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B72A82901F5AF12000C25F91 /* libboost_system.dylib */; };
+		B72A82A81F5AF26600C25F91 /* libboost_thread.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B72A82921F5AF13300C25F91 /* libboost_thread.dylib */; };
+		B72A82A91F5AF27F00C25F91 /* libboost_filesystem.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B72A82821F5AF0AC00C25F91 /* libboost_filesystem.dylib */; };
+		B72A82AA1F5AF28300C25F91 /* libboost_iostreams.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B72A82841F5AF0B900C25F91 /* libboost_iostreams.dylib */; };
+		B72A82AB1F5AF28800C25F91 /* libboost_log.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B72A82871F5AF0DA00C25F91 /* libboost_log.dylib */; };
+		B72A82AC1F5AF28D00C25F91 /* libboost_log_setup.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B72A82861F5AF0DA00C25F91 /* libboost_log_setup.dylib */; };
+		B72A82AD1F5AF29100C25F91 /* libboost_python.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B72A829D1F5AF1F500C25F91 /* libboost_python.dylib */; };
+		B72A82AE1F5AF29600C25F91 /* libboost_regex.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B72A828A1F5AF0FE00C25F91 /* libboost_regex.dylib */; };
+		B72A82AF1F5AF29B00C25F91 /* libboost_system.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B72A82901F5AF12000C25F91 /* libboost_system.dylib */; };
+		B72A82B01F5AF29F00C25F91 /* libboost_thread.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = B72A82921F5AF13300C25F91 /* libboost_thread.dylib */; };
+		B72A82B11F5AF2B600C25F91 /* libboost_date_time.dylib in Copy Shared Libraries */ = {isa = PBXBuildFile; fileRef = B72A82801F5AF08A00C25F91 /* libboost_date_time.dylib */; };
+		B72A82B21F5AF2BA00C25F91 /* libboost_filesystem.dylib in Copy Shared Libraries */ = {isa = PBXBuildFile; fileRef = B72A82821F5AF0AC00C25F91 /* libboost_filesystem.dylib */; };
+		B72A82B31F5AF2C000C25F91 /* libboost_iostreams.dylib in Copy Shared Libraries */ = {isa = PBXBuildFile; fileRef = B72A82841F5AF0B900C25F91 /* libboost_iostreams.dylib */; };
+		B72A82B51F5AF2E300C25F91 /* libboost_locale.dylib in Copy Shared Libraries */ = {isa = PBXBuildFile; fileRef = B72A82A11F5AF24400C25F91 /* libboost_locale.dylib */; };
+		B72A82B61F5AF2E800C25F91 /* libboost_log.dylib in Copy Shared Libraries */ = {isa = PBXBuildFile; fileRef = B72A82871F5AF0DA00C25F91 /* libboost_log.dylib */; };
+		B72A82B71F5AF2ED00C25F91 /* libboost_log_setup.dylib in Copy Shared Libraries */ = {isa = PBXBuildFile; fileRef = B72A82861F5AF0DA00C25F91 /* libboost_log_setup.dylib */; };
+		B72A82B81F5AF2F500C25F91 /* libboost_python.dylib in Copy Shared Libraries */ = {isa = PBXBuildFile; fileRef = B72A829D1F5AF1F500C25F91 /* libboost_python.dylib */; };
+		B72A82B91F5AF2F900C25F91 /* libboost_regex.dylib in Copy Shared Libraries */ = {isa = PBXBuildFile; fileRef = B72A828A1F5AF0FE00C25F91 /* libboost_regex.dylib */; };
+		B72A82BA1F5AF2FE00C25F91 /* libboost_serialization.dylib in Copy Shared Libraries */ = {isa = PBXBuildFile; fileRef = B72A828B1F5AF0FE00C25F91 /* libboost_serialization.dylib */; };
+		B72A82BB1F5AF30300C25F91 /* libboost_signals.dylib in Copy Shared Libraries */ = {isa = PBXBuildFile; fileRef = B72A828C1F5AF0FE00C25F91 /* libboost_signals.dylib */; };
+		B72A82BC1F5AF30800C25F91 /* libboost_system.dylib in Copy Shared Libraries */ = {isa = PBXBuildFile; fileRef = B72A82901F5AF12000C25F91 /* libboost_system.dylib */; };
+		B72A82BD1F5AF30E00C25F91 /* libboost_thread.dylib in Copy Shared Libraries */ = {isa = PBXBuildFile; fileRef = B72A82921F5AF13300C25F91 /* libboost_thread.dylib */; };
 		B7A7D5391ECF2D9D00E086C2 /* libz.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 822E325B19BEED6C00A7B707 /* libz.a */; };
 		CE0ED5F91BCFE16E00375001 /* AIWrapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE0ED5F71BCFE16E00375001 /* AIWrapper.cpp */; };
 		CE13B48F1C8CB0CF0085A4DC /* CommonParamsParser.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE13B48E1C8CB0CF0085A4DC /* CommonParamsParser.cpp */; };
@@ -343,15 +371,7 @@
 		CE71ED7C1DADAB140085A4DC /* DependencyVersions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE97F70A1BC7D74D0002988B /* DependencyVersions.cpp */; };
 		CE76B9CF1CBD7ACC0085A4DC /* ChangeLog.md in Resources */ = {isa = PBXBuildFile; fileRef = CE76B9CD1CBD7A990085A4DC /* ChangeLog.md */; };
 		CEC4ADC11BC13741000DFA9B /* AIFramework.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CEC4ADBF1BC13741000DFA9B /* AIFramework.cpp */; };
-		CED22D4D1EB8F15B0085A4DC /* libboost_log.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 82714D761ADABE680071A329 /* libboost_log.a */; };
-		CED22D4F1EB8F15B0085A4DC /* libboost_log.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 82714D761ADABE680071A329 /* libboost_log.a */; };
-		CED22D511EB8F15B0085A4DC /* libboost_log.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 82714D761ADABE680071A329 /* libboost_log.a */; };
-		CED22D541EB8F2B50085A4DC /* libboost_log_setup.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CED22D531EB8F2B50085A4DC /* libboost_log_setup.a */; };
-		CED22D551EB8F2B50085A4DC /* libboost_log_setup.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CED22D531EB8F2B50085A4DC /* libboost_log_setup.a */; };
-		CED22D561EB8F2B50085A4DC /* libboost_log_setup.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CED22D531EB8F2B50085A4DC /* libboost_log_setup.a */; };
-		CED22D571EB8F2B50085A4DC /* libboost_log_setup.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CED22D531EB8F2B50085A4DC /* libboost_log_setup.a */; };
 		CED6E5521C6DDC0F0085A4DC /* Fighter.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CED6E5501C6DDC0F0085A4DC /* Fighter.cpp */; };
-		CEDABCF01C688D050085A4DC /* libboost_locale.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CEDABCEF1C688D050085A4DC /* libboost_locale.a */; };
 		CEDABCF31C688E290085A4DC /* libiconv.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = CEDABCF21C688E290085A4DC /* libiconv.dylib */; };
 		CEDC4AEF1BD3E361009BB38D /* EmpireWrapper.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 343EC6740F3F61D000782AD3 /* EmpireWrapper.cpp */; };
 		CEED195F1C79BA2F0085A4DC /* Supply.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CEED195D1C79BA2F0085A4DC /* Supply.cpp */; };
@@ -378,13 +398,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = 8DD76F620486A84900D96B5E;
 			remoteInfo = FreeOrionClient;
-		};
-		3ABEAB1E1749BDF100E34912 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 47103BE10CF04D8800A7DF2B;
-			remoteInfo = Common;
 		};
 		471D65480A98B73C00DA9C21 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -442,13 +455,6 @@
 			remoteGlobalIDString = 829C76351689EFD4005881B4;
 			remoteInfo = Configure;
 		};
-		829C763E1689F0EA005881B4 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 829C76351689EFD4005881B4;
-			remoteInfo = INIT;
-		};
 		82A1B47019240B3100A3C137 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
@@ -476,6 +482,27 @@
 			proxyType = 1;
 			remoteGlobalIDString = 3402E25C0F5A317400DF6FE7;
 			remoteInfo = FreeOrion;
+		};
+		B72A82791F5AEE4F00C25F91 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 829C76351689EFD4005881B4;
+			remoteInfo = Configure;
+		};
+		B72A827B1F5AEE5700C25F91 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 829C76351689EFD4005881B4;
+			remoteInfo = Configure;
+		};
+		B72A827D1F5AEE6E00C25F91 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 08FB7793FE84155DC02AAC07 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 82C073D8149DE46200E76876;
+			remoteInfo = Parse;
 		};
 /* End PBXContainerItemProxy section */
 
@@ -513,6 +540,18 @@
 			files = (
 				3ABEABA51749D05E00E34912 /* freeorioncommon.dylib in Copy Shared Libraries */,
 				3ABEABA41749D05700E34912 /* freeorionparse.dylib in Copy Shared Libraries */,
+				B72A82B11F5AF2B600C25F91 /* libboost_date_time.dylib in Copy Shared Libraries */,
+				B72A82B21F5AF2BA00C25F91 /* libboost_filesystem.dylib in Copy Shared Libraries */,
+				B72A82B31F5AF2C000C25F91 /* libboost_iostreams.dylib in Copy Shared Libraries */,
+				B72A82B51F5AF2E300C25F91 /* libboost_locale.dylib in Copy Shared Libraries */,
+				B72A82B61F5AF2E800C25F91 /* libboost_log.dylib in Copy Shared Libraries */,
+				B72A82B71F5AF2ED00C25F91 /* libboost_log_setup.dylib in Copy Shared Libraries */,
+				B72A82B81F5AF2F500C25F91 /* libboost_python.dylib in Copy Shared Libraries */,
+				B72A82B91F5AF2F900C25F91 /* libboost_regex.dylib in Copy Shared Libraries */,
+				B72A82BA1F5AF2FE00C25F91 /* libboost_serialization.dylib in Copy Shared Libraries */,
+				B72A82BB1F5AF30300C25F91 /* libboost_signals.dylib in Copy Shared Libraries */,
+				B72A82BC1F5AF30800C25F91 /* libboost_system.dylib in Copy Shared Libraries */,
+				B72A82BD1F5AF30E00C25F91 /* libboost_thread.dylib in Copy Shared Libraries */,
 			);
 			name = "Copy Shared Libraries";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -844,7 +883,6 @@
 		8242C81A176B0C8E001E1CF2 /* ScopedTimer.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ScopedTimer.cpp; sourceTree = "<group>"; };
 		8242C81B176B0C8E001E1CF2 /* ScopedTimer.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ScopedTimer.h; sourceTree = "<group>"; };
 		8246FECF194D8F83008C07B5 /* IntComplexValueRefParser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = IntComplexValueRefParser.cpp; sourceTree = "<group>"; };
-		82483B7A15F4F24100D27614 /* libboost_date_time.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libboost_date_time.a; sourceTree = "<group>"; };
 		82483B7B15F4F26200D27614 /* libFreeImage.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libFreeImage.a; sourceTree = "<group>"; };
 		8250FDE115FCEFC400523C1C /* ConditionParser4.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ConditionParser4.cpp; sourceTree = "<group>"; };
 		8250FDE215FCEFC400523C1C /* FieldsParser.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FieldsParser.cpp; sourceTree = "<group>"; };
@@ -968,7 +1006,6 @@
 		825E7258196EC28A00F8114D /* default */ = {isa = PBXFileReference; lastKnownFileType = folder; name = default; path = ../default; sourceTree = "<group>"; };
 		825EA75E16DB9DB10002A797 /* ModeratorAction.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ModeratorAction.cpp; sourceTree = "<group>"; };
 		825EA75F16DB9DB10002A797 /* ModeratorAction.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ModeratorAction.h; sourceTree = "<group>"; };
-		82714D761ADABE680071A329 /* libboost_log.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libboost_log.a; sourceTree = "<group>"; };
 		8275F3DD1AD31381003568FF /* AccordionPanel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AccordionPanel.cpp; sourceTree = "<group>"; };
 		8275F3DE1AD31381003568FF /* AccordionPanel.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AccordionPanel.h; sourceTree = "<group>"; };
 		8275F3DF1AD31381003568FF /* BuildingsPanel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = BuildingsPanel.cpp; sourceTree = "<group>"; };
@@ -999,7 +1036,6 @@
 		827902371737C6EA008AF126 /* ModeratorActionsWnd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ModeratorActionsWnd.h; sourceTree = "<group>"; };
 		827AF376185B26AE001CD79C /* UniverseGenerator.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = UniverseGenerator.h; sourceTree = "<group>"; };
 		827AF39F185B2FB9001CD79C /* Export.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Export.h; sourceTree = "<group>"; };
-		8280AC5C19C0741B00ADDB65 /* libboost_iostreams.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libboost_iostreams.a; sourceTree = "<group>"; };
 		8289A72A19BDB3D8001256C1 /* SDL2.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = SDL2.framework; sourceTree = "<group>"; };
 		828AB7D315F7BCDD0075BE24 /* libpng.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libpng.a; sourceTree = "<group>"; };
 		828C793D160778AA0075F220 /* FieldIcon.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = FieldIcon.cpp; sourceTree = "<group>"; };
@@ -1063,13 +1099,18 @@
 		82ED913E194F5C85002F0A4A /* make_dmg.py */ = {isa = PBXFileReference; lastKnownFileType = text.script.python; path = make_dmg.py; sourceTree = "<group>"; };
 		82ED9141194F5CDD002F0A4A /* make_versioncpp.py */ = {isa = PBXFileReference; lastKnownFileType = text.script.python; name = make_versioncpp.py; path = ../cmake/make_versioncpp.py; sourceTree = "<group>"; };
 		8DD76F6C0486A84900D96B5E /* FreeOrion */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = FreeOrion; sourceTree = BUILT_PRODUCTS_DIR; };
-		9EEEEA7313ACB91A0085B1A0 /* libboost_filesystem.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libboost_filesystem.a; sourceTree = "<group>"; };
-		9EEEEA7413ACB91A0085B1A0 /* libboost_python.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libboost_python.a; sourceTree = "<group>"; };
-		9EEEEA7513ACB91A0085B1A0 /* libboost_regex.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libboost_regex.a; sourceTree = "<group>"; };
-		9EEEEA7613ACB91A0085B1A0 /* libboost_serialization.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libboost_serialization.a; sourceTree = "<group>"; };
-		9EEEEA7713ACB91A0085B1A0 /* libboost_signals.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libboost_signals.a; sourceTree = "<group>"; };
-		9EEEEA7813ACB91A0085B1A0 /* libboost_system.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libboost_system.a; sourceTree = "<group>"; };
-		9EEEEA7913ACB91A0085B1A0 /* libboost_thread.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libboost_thread.a; sourceTree = "<group>"; };
+		B72A82801F5AF08A00C25F91 /* libboost_date_time.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libboost_date_time.dylib; sourceTree = "<group>"; };
+		B72A82821F5AF0AC00C25F91 /* libboost_filesystem.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libboost_filesystem.dylib; sourceTree = "<group>"; };
+		B72A82841F5AF0B900C25F91 /* libboost_iostreams.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libboost_iostreams.dylib; sourceTree = "<group>"; };
+		B72A82861F5AF0DA00C25F91 /* libboost_log_setup.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libboost_log_setup.dylib; sourceTree = "<group>"; };
+		B72A82871F5AF0DA00C25F91 /* libboost_log.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libboost_log.dylib; sourceTree = "<group>"; };
+		B72A828A1F5AF0FE00C25F91 /* libboost_regex.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libboost_regex.dylib; sourceTree = "<group>"; };
+		B72A828B1F5AF0FE00C25F91 /* libboost_serialization.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libboost_serialization.dylib; sourceTree = "<group>"; };
+		B72A828C1F5AF0FE00C25F91 /* libboost_signals.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libboost_signals.dylib; sourceTree = "<group>"; };
+		B72A82901F5AF12000C25F91 /* libboost_system.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libboost_system.dylib; sourceTree = "<group>"; };
+		B72A82921F5AF13300C25F91 /* libboost_thread.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libboost_thread.dylib; sourceTree = "<group>"; };
+		B72A829D1F5AF1F500C25F91 /* libboost_python.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libboost_python.dylib; sourceTree = "<group>"; };
+		B72A82A11F5AF24400C25F91 /* libboost_locale.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; path = libboost_locale.dylib; sourceTree = "<group>"; };
 		CE0ED5F71BCFE16E00375001 /* AIWrapper.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AIWrapper.cpp; sourceTree = "<group>"; };
 		CE0ED5F81BCFE16E00375001 /* AIWrapper.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIWrapper.h; sourceTree = "<group>"; };
 		CE13B48D1C8CB0CF0085A4DC /* CommonParams.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CommonParams.h; sourceTree = "<group>"; };
@@ -1113,39 +1154,30 @@
 		CEC4ADC01BC13741000DFA9B /* AIFramework.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = AIFramework.h; sourceTree = "<group>"; };
 		CEC4ADC21BC15195000DFA9B /* CommonFramework.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CommonFramework.cpp; sourceTree = "<group>"; };
 		CEC4ADC31BC15195000DFA9B /* CommonFramework.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CommonFramework.h; sourceTree = "<group>"; };
-		CED22D531EB8F2B50085A4DC /* libboost_log_setup.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libboost_log_setup.a; sourceTree = "<group>"; };
 		CED6E5501C6DDC0F0085A4DC /* Fighter.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Fighter.cpp; sourceTree = "<group>"; };
 		CED6E5511C6DDC0F0085A4DC /* Fighter.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Fighter.h; sourceTree = "<group>"; };
-		CEDABCEF1C688D050085A4DC /* libboost_locale.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; path = libboost_locale.a; sourceTree = "<group>"; };
 		CEDABCF21C688E290085A4DC /* libiconv.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libiconv.dylib; path = usr/lib/libiconv.dylib; sourceTree = SDKROOT; };
 		CEED195D1C79BA2F0085A4DC /* Supply.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = Supply.cpp; sourceTree = "<group>"; };
 		CEED195E1C79BA2F0085A4DC /* Supply.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = Supply.h; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
-		3ABEAB361749BF8A00E34912 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				3ABEAB3B1749BFED00E34912 /* freeorioncommon.dylib in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		3ABEAB391749BFDB00E34912 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				82E5239F192FEAA6001E2374 /* CoreFoundation.framework in Frameworks */,
-				B7A7D5371ECF2D5000E086C2 /* libboost_date_time.a in Frameworks */,
-				3ABEAB3F1749C27700E34912 /* libboost_filesystem.a in Frameworks */,
-				8280AC5D19C0741B00ADDB65 /* libboost_iostreams.a in Frameworks */,
-				82714D771ADABE680071A329 /* libboost_log.a in Frameworks */,
-				CED22D541EB8F2B50085A4DC /* libboost_log_setup.a in Frameworks */,
-				B7A7D5381ECF2D6E00E086C2 /* libboost_regex.a in Frameworks */,
-				3ABEAB3C1749C21B00E34912 /* libboost_serialization.a in Frameworks */,
-				3ABEAB711749C2F400E34912 /* libboost_signals.a in Frameworks */,
-				3ABEAB741749C36200E34912 /* libboost_system.a in Frameworks */,
-				3ABEAB801749C51B00E34912 /* libboost_thread.a in Frameworks */,
+				B72A827F1F5AEEBA00C25F91 /* freeorionparse.dylib in Frameworks */,
+				B72A82811F5AF08A00C25F91 /* libboost_date_time.dylib in Frameworks */,
+				B72A82831F5AF0AC00C25F91 /* libboost_filesystem.dylib in Frameworks */,
+				B72A82851F5AF0B900C25F91 /* libboost_iostreams.dylib in Frameworks */,
+				B72A82891F5AF0DA00C25F91 /* libboost_log.dylib in Frameworks */,
+				B72A82881F5AF0DA00C25F91 /* libboost_log_setup.dylib in Frameworks */,
+				B72A828D1F5AF0FE00C25F91 /* libboost_regex.dylib in Frameworks */,
+				B72A828E1F5AF0FE00C25F91 /* libboost_serialization.dylib in Frameworks */,
+				B72A828F1F5AF0FE00C25F91 /* libboost_signals.dylib in Frameworks */,
+				B72A82911F5AF12000C25F91 /* libboost_system.dylib in Frameworks */,
+				B72A82931F5AF13300C25F91 /* libboost_thread.dylib in Frameworks */,
 				B7A7D5391ECF2D9D00E086C2 /* libz.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1155,13 +1187,16 @@
 			buildActionMask = 2147483647;
 			files = (
 				8288432E1850A1770023C4D7 /* Python.framework in Frameworks */,
-				82F55DE818B0FF0A00FA9E11 /* libboost_date_time.a in Frameworks */,
-				8280AC5E19C0741B00ADDB65 /* libboost_iostreams.a in Frameworks */,
-				CED22D4D1EB8F15B0085A4DC /* libboost_log.a in Frameworks */,
-				CED22D551EB8F2B50085A4DC /* libboost_log_setup.a in Frameworks */,
-				8288432F1850A1960023C4D7 /* libboost_python.a in Frameworks */,
-				3ABEAB971749C93400E34912 /* libboost_signals.a in Frameworks */,
-				3ABEAB901749C8F500E34912 /* libboost_thread.a in Frameworks */,
+				B72A82941F5AF1AD00C25F91 /* libboost_date_time.dylib in Frameworks */,
+				B72A82951F5AF1B300C25F91 /* libboost_filesystem.dylib in Frameworks */,
+				B72A82961F5AF1B600C25F91 /* libboost_iostreams.dylib in Frameworks */,
+				B72A82981F5AF1C600C25F91 /* libboost_log.dylib in Frameworks */,
+				B72A82971F5AF1BA00C25F91 /* libboost_log_setup.dylib in Frameworks */,
+				B72A829E1F5AF1F500C25F91 /* libboost_python.dylib in Frameworks */,
+				B72A82991F5AF1D200C25F91 /* libboost_serialization.dylib in Frameworks */,
+				B72A829A1F5AF1D600C25F91 /* libboost_signals.dylib in Frameworks */,
+				B72A829B1F5AF1DB00C25F91 /* libboost_system.dylib in Frameworks */,
+				B72A829C1F5AF1E000C25F91 /* libboost_thread.dylib in Frameworks */,
 				478417730CF0589200BE4710 /* freeorioncommon.dylib in Frameworks */,
 				82BB623E19BEDF1700A0E281 /* freeorionparse.dylib in Frameworks */,
 				CE2C454E1C6503990085A4DC /* libz.a in Frameworks */,
@@ -1173,12 +1208,14 @@
 			buildActionMask = 2147483647;
 			files = (
 				34F0E429113F497500A10EED /* Python.framework in Frameworks */,
-				8280AC6019C0741C00ADDB65 /* libboost_iostreams.a in Frameworks */,
-				CED22D511EB8F15B0085A4DC /* libboost_log.a in Frameworks */,
-				CED22D571EB8F2B50085A4DC /* libboost_log_setup.a in Frameworks */,
-				9E632AEC13AD24D1003D1874 /* libboost_python.a in Frameworks */,
-				9E632AED13AD24D1003D1874 /* libboost_regex.a in Frameworks */,
-				3ABEABA11749C9CA00E34912 /* libboost_thread.a in Frameworks */,
+				B72A82A91F5AF27F00C25F91 /* libboost_filesystem.dylib in Frameworks */,
+				B72A82AA1F5AF28300C25F91 /* libboost_iostreams.dylib in Frameworks */,
+				B72A82AB1F5AF28800C25F91 /* libboost_log.dylib in Frameworks */,
+				B72A82AC1F5AF28D00C25F91 /* libboost_log_setup.dylib in Frameworks */,
+				B72A82AD1F5AF29100C25F91 /* libboost_python.dylib in Frameworks */,
+				B72A82AE1F5AF29600C25F91 /* libboost_regex.dylib in Frameworks */,
+				B72A82AF1F5AF29B00C25F91 /* libboost_system.dylib in Frameworks */,
+				B72A82B01F5AF29F00C25F91 /* libboost_thread.dylib in Frameworks */,
 				478418EF0CF05A5600BE4710 /* libClientCommon.a in Frameworks */,
 				4784177A0CF058F000BE4710 /* freeorioncommon.dylib in Frameworks */,
 				82BB624019BEDF9F00A0E281 /* freeorionparse.dylib in Frameworks */,
@@ -1194,12 +1231,15 @@
 				828AB7D415F7BCDD0075BE24 /* libpng.a in Frameworks */,
 				82E5716115F63D8000BD29C8 /* libfreetype.a in Frameworks */,
 				82682D8219C24DEC0041C465 /* libGLEW.a in Frameworks */,
-				8280AC5F19C0741C00ADDB65 /* libboost_iostreams.a in Frameworks */,
-				CEDABCF01C688D050085A4DC /* libboost_locale.a in Frameworks */,
-				CED22D4F1EB8F15B0085A4DC /* libboost_log.a in Frameworks */,
-				CED22D561EB8F2B50085A4DC /* libboost_log_setup.a in Frameworks */,
-				82AB1D13194D97A1009C8220 /* libboost_regex.a in Frameworks */,
-				3ABEAB9C1749C96400E34912 /* libboost_signals.a in Frameworks */,
+				B72A829F1F5AF22800C25F91 /* libboost_filesystem.dylib in Frameworks */,
+				B72A82A01F5AF22E00C25F91 /* libboost_iostreams.dylib in Frameworks */,
+				B72A82A21F5AF24400C25F91 /* libboost_locale.dylib in Frameworks */,
+				B72A82A31F5AF24F00C25F91 /* libboost_log.dylib in Frameworks */,
+				B72A82A41F5AF25300C25F91 /* libboost_log_setup.dylib in Frameworks */,
+				B72A82A51F5AF25800C25F91 /* libboost_regex.dylib in Frameworks */,
+				B72A82A61F5AF25D00C25F91 /* libboost_signals.dylib in Frameworks */,
+				B72A82A71F5AF26200C25F91 /* libboost_system.dylib in Frameworks */,
+				B72A82A81F5AF26600C25F91 /* libboost_thread.dylib in Frameworks */,
 				82E5238F192FE8CE001E2374 /* AppKit.framework in Frameworks */,
 				82E52398192FE99D001E2374 /* Carbon.framework in Frameworks */,
 				82E52399192FE99D001E2374 /* Cocoa.framework in Frameworks */,
@@ -1917,18 +1957,18 @@
 		47B60DED0CF0761E00318761 /* boost */ = {
 			isa = PBXGroup;
 			children = (
-				82483B7A15F4F24100D27614 /* libboost_date_time.a */,
-				9EEEEA7313ACB91A0085B1A0 /* libboost_filesystem.a */,
-				8280AC5C19C0741B00ADDB65 /* libboost_iostreams.a */,
-				CEDABCEF1C688D050085A4DC /* libboost_locale.a */,
-				82714D761ADABE680071A329 /* libboost_log.a */,
-				CED22D531EB8F2B50085A4DC /* libboost_log_setup.a */,
-				9EEEEA7413ACB91A0085B1A0 /* libboost_python.a */,
-				9EEEEA7513ACB91A0085B1A0 /* libboost_regex.a */,
-				9EEEEA7613ACB91A0085B1A0 /* libboost_serialization.a */,
-				9EEEEA7713ACB91A0085B1A0 /* libboost_signals.a */,
-				9EEEEA7813ACB91A0085B1A0 /* libboost_system.a */,
-				9EEEEA7913ACB91A0085B1A0 /* libboost_thread.a */,
+				B72A82801F5AF08A00C25F91 /* libboost_date_time.dylib */,
+				B72A82821F5AF0AC00C25F91 /* libboost_filesystem.dylib */,
+				B72A82841F5AF0B900C25F91 /* libboost_iostreams.dylib */,
+				B72A82A11F5AF24400C25F91 /* libboost_locale.dylib */,
+				B72A82871F5AF0DA00C25F91 /* libboost_log.dylib */,
+				B72A82861F5AF0DA00C25F91 /* libboost_log_setup.dylib */,
+				B72A829D1F5AF1F500C25F91 /* libboost_python.dylib */,
+				B72A828A1F5AF0FE00C25F91 /* libboost_regex.dylib */,
+				B72A828B1F5AF0FE00C25F91 /* libboost_serialization.dylib */,
+				B72A828C1F5AF0FE00C25F91 /* libboost_signals.dylib */,
+				B72A82901F5AF12000C25F91 /* libboost_system.dylib */,
+				B72A82921F5AF13300C25F91 /* libboost_thread.dylib */,
 			);
 			name = boost;
 			sourceTree = "<group>";
@@ -2221,7 +2261,6 @@
 			buildRules = (
 			);
 			dependencies = (
-				829C763F1689F0EA005881B4 /* PBXTargetDependency */,
 				3402E2650F5A319B00DF6FE7 /* PBXTargetDependency */,
 				3402E2670F5A319B00DF6FE7 /* PBXTargetDependency */,
 				3402E2630F5A319B00DF6FE7 /* PBXTargetDependency */,
@@ -2242,6 +2281,7 @@
 			);
 			dependencies = (
 				82A1B47119240B3100A3C137 /* PBXTargetDependency */,
+				B72A827E1F5AEE6E00C25F91 /* PBXTargetDependency */,
 			);
 			name = Common;
 			productName = Common;
@@ -2257,6 +2297,7 @@
 			buildRules = (
 			);
 			dependencies = (
+				B72A827C1F5AEE5700C25F91 /* PBXTargetDependency */,
 			);
 			name = GG;
 			productName = GG;
@@ -2321,12 +2362,11 @@
 			buildConfigurationList = 82C07434149DE46200E76876 /* Build configuration list for PBXNativeTarget "Parse" */;
 			buildPhases = (
 				82C073D9149DE46200E76876 /* Sources */,
-				3ABEAB361749BF8A00E34912 /* Frameworks */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				3ABEAB1F1749BDF100E34912 /* PBXTargetDependency */,
+				B72A827A1F5AEE4F00C25F91 /* PBXTargetDependency */,
 			);
 			name = Parse;
 			productName = Common;
@@ -2776,11 +2816,6 @@
 			target = 8DD76F620486A84900D96B5E /* FreeOrionClient */;
 			targetProxy = 3402E2660F5A319B00DF6FE7 /* PBXContainerItemProxy */;
 		};
-		3ABEAB1F1749BDF100E34912 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 47103BE10CF04D8800A7DF2B /* Common */;
-			targetProxy = 3ABEAB1E1749BDF100E34912 /* PBXContainerItemProxy */;
-		};
 		471D65490A98B73C00DA9C21 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 471D5A2F0A988D5700DA9C21 /* GG */;
@@ -2821,11 +2856,6 @@
 			target = 829C76351689EFD4005881B4 /* Configure */;
 			targetProxy = 8257A8D51A90B7EF0006777D /* PBXContainerItemProxy */;
 		};
-		829C763F1689F0EA005881B4 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 829C76351689EFD4005881B4 /* Configure */;
-			targetProxy = 829C763E1689F0EA005881B4 /* PBXContainerItemProxy */;
-		};
 		82A1B47119240B3100A3C137 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 829C76351689EFD4005881B4 /* Configure */;
@@ -2845,6 +2875,21 @@
 			isa = PBXTargetDependency;
 			target = 3402E25C0F5A317400DF6FE7 /* FreeOrion */;
 			targetProxy = 82EC622318C610AB000237C2 /* PBXContainerItemProxy */;
+		};
+		B72A827A1F5AEE4F00C25F91 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 829C76351689EFD4005881B4 /* Configure */;
+			targetProxy = B72A82791F5AEE4F00C25F91 /* PBXContainerItemProxy */;
+		};
+		B72A827C1F5AEE5700C25F91 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 829C76351689EFD4005881B4 /* Configure */;
+			targetProxy = B72A827B1F5AEE5700C25F91 /* PBXContainerItemProxy */;
+		};
+		B72A827E1F5AEE6E00C25F91 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 82C073D8149DE46200E76876 /* Parse */;
+			targetProxy = B72A827D1F5AEE6E00C25F91 /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -2869,7 +2914,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				ARCHS = "$(ARCHS_STANDARD)";
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				FRAMEWORK_SEARCH_PATHS = "\"$(SRCROOT)/dep/Frameworks\"";
@@ -2883,6 +2928,18 @@
 					__MACOSX__,
 					BOOST_DATE_TIME_NO_LOCALE,
 					BOOST_SPIRIT_USE_PHOENIX_V3,
+					BOOST_ALL_DYN_LINK,
+					BOOST_ARCHIVE_SOURCE,
+					BOOST_FILESYSTEM_SOURCE,
+					BOOST_IOSTREAMS_SOURCE,
+					BOOST_LOCALE_SOURCE,
+					BOOST_REGEX_SOURCE,
+					BOOST_SERIALIZATION_SOURCE,
+					BOOST_SYSTEM_SOURCE,
+					BOOST_LOG_BUILDING_THE_LIB,
+					BOOST_LOG_DLL,
+					BOOST_PYTHON_USE_GCC_SYMBOL_VISIBILITY,
+					BOOST_PYTHON_SOURCE,
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				HEADER_SEARCH_PATHS = (
@@ -3000,7 +3057,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				ARCHS = "$(ARCHS_STANDARD)";
 				COPY_PHASE_STRIP = YES;
 				FRAMEWORK_SEARCH_PATHS = "\"$(SRCROOT)/dep/Frameworks\"";
 				GCC_DEBUGGING_SYMBOLS = full;
@@ -3013,6 +3070,18 @@
 					__MACOSX__,
 					BOOST_DATE_TIME_NO_LOCALE,
 					BOOST_SPIRIT_USE_PHOENIX_V3,
+					BOOST_ALL_DYN_LINK,
+					BOOST_ARCHIVE_SOURCE,
+					BOOST_FILESYSTEM_SOURCE,
+					BOOST_IOSTREAMS_SOURCE,
+					BOOST_LOCALE_SOURCE,
+					BOOST_REGEX_SOURCE,
+					BOOST_SERIALIZATION_SOURCE,
+					BOOST_SYSTEM_SOURCE,
+					BOOST_LOG_BUILDING_THE_LIB,
+					BOOST_LOG_DLL,
+					BOOST_PYTHON_USE_GCC_SYMBOL_VISIBILITY,
+					BOOST_PYTHON_SOURCE,
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
 				HEADER_SEARCH_PATHS = (
@@ -3163,7 +3232,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
-				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
+				ARCHS = "$(ARCHS_STANDARD)";
 				COPY_PHASE_STRIP = YES;
 				FRAMEWORK_SEARCH_PATHS = "\"$(SRCROOT)/dep/Frameworks\"";
 				GCC_DEBUGGING_SYMBOLS = full;
@@ -3176,6 +3245,18 @@
 					__MACOSX__,
 					BOOST_DATE_TIME_NO_LOCALE,
 					BOOST_SPIRIT_USE_PHOENIX_V3,
+					BOOST_ALL_DYN_LINK,
+					BOOST_ARCHIVE_SOURCE,
+					BOOST_FILESYSTEM_SOURCE,
+					BOOST_IOSTREAMS_SOURCE,
+					BOOST_LOCALE_SOURCE,
+					BOOST_REGEX_SOURCE,
+					BOOST_SERIALIZATION_SOURCE,
+					BOOST_SYSTEM_SOURCE,
+					BOOST_LOG_BUILDING_THE_LIB,
+					BOOST_LOG_DLL,
+					BOOST_PYTHON_USE_GCC_SYMBOL_VISIBILITY,
+					BOOST_PYTHON_SOURCE,
 					NDEBUG,
 				);
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;


### PR DESCRIPTION
Compile the Mac OSX build from i386 to x86_64.

The other change was to correct a typo in CMakeLists. (BOOST_ALL_NO_LINK does not exist.)

I expect this to fail the Travis (Apple/Clang) build initially, because the current libraries are compiled for i386. This will require the Mac 64 bit libraries made by PR 29 for the FO-SDK.
https://github.com/freeorion/freeorion-sdk/pull/29
The `dep` folder (with static libraries, frameworks, and includes) will need to be copied to the FO build (inside the `Xcode` folder), along with this PR to switch the Apple/Clang code to 64 bit.

As a side effect, getting some of the `-fvisibility=hidden` issues straightened out (between the FO code and the SDK) should mean fewer warnings during the client build linking (dozens instead of hundreds).