### PR TITLE
Change ship design parser ignore UUID and ShipDesignManifest.focs.txt.

### DIFF
--- a/parse/ShipDesignsParser.cpp
+++ b/parse/ShipDesignsParser.cpp
@@ -56,6 +56,8 @@ namespace {
                 =    tok.ShipDesign_
                 >    parse::detail::label(Name_token)
                 >   tok.string        [ _pass = is_unique_(_r5, ShipDesign_token, _1), _r1 = _1 ]
+                >    (parse::detail::label(UUID_token)        > tok.string [ _pass = true ]
+                      | eps [ _pass = true ])
                 >    parse::detail::label(Description_token) > tok.string [ _r2 = _1 ]
                 > (
                      tok.NoStringtableLookup_ [ _r4 = false ]

--- a/parse/ShipDesignsParser.cpp
+++ b/parse/ShipDesignsParser.cpp
@@ -122,8 +122,14 @@ namespace {
 }
 
 namespace parse {
-    bool ship_designs(const boost::filesystem::path& path, std::map<std::string, ShipDesign*>& designs)
-    { return detail::parse_file<rules, std::map<std::string, ShipDesign*>>(path, designs); }
+    bool ship_designs(const boost::filesystem::path& path, std::map<std::string, ShipDesign*>& designs) {
+        // Ignore the ship design manifest.
+        if (path.filename() == "ShipDesignManifest.focs.txt" ) {
+            return true;;
+        }
+
+        return detail::parse_file<rules, std::map<std::string, ShipDesign*>>(path, designs);
+    }
 
     bool ship_designs(std::map<std::string, ShipDesign*>& designs) {
         bool result = true;

--- a/parse/Tokens.h
+++ b/parse/Tokens.h
@@ -504,6 +504,7 @@
     (Unresearchable)                            \
     (UpgradeVisibility)                         \
     (UserString)                                \
+    (UUID)                                      \
     (Value)                                     \
     (Victory)                                   \
     (VisibleToEmpire)                           \


### PR DESCRIPTION
This PR changes the ship design parser to ignore a file called "ShipDesignManifest.focs.txt" and to ignore any UUIDs in ship designs.  

I am posting a PR which will allow editing of saved designs and arbitrary ordering of ship designs and monsters.  It uses "ShipDesignManifest.focs.txt" to provide an ordered list of UUIDs to store that ordering off-line.

Applying this PR before people start testing the other PR will mean that when the UUIDs are added to their saved designs, no error messages will be generated when they switch to another branch.