### PR TITLE
Add UUID to ship design parser.

### DIFF
--- a/AI/AIInterface.cpp
+++ b/AI/AIInterface.cpp
@@ -23,6 +23,7 @@
 
 #include <boost/timer.hpp>
 #include <boost/python/str.hpp>
+#include <boost/uuid/random_generator.hpp>
 
 
 #include <map>
@@ -847,9 +848,11 @@ namespace AIInterface {
         int empire_id = AIClientApp::GetApp()->EmpireID();
         int current_turn = CurrentTurn();
 
+        const auto uuid = boost::uuids::random_generator()();
+
         // create design from stuff chosen in UI
         ShipDesign* design = new ShipDesign(name, description, current_turn, ClientApp::GetApp()->EmpireID(),
-                                            hull, parts, icon, model, nameDescInStringTable);
+                                            hull, parts, icon, model, nameDescInStringTable, false, uuid);
 
         if (!design) {
             ErrorLogger() << "IssueCreateShipDesignOrderOrder failed to create a new ShipDesign object";

--- a/AI/AIInterface.cpp
+++ b/AI/AIInterface.cpp
@@ -834,7 +834,7 @@ namespace AIInterface {
 
     int IssueCreateShipDesignOrder(const std::string& name, const std::string& description,
                                    const std::string& hull, const std::vector<std::string> parts,
-                                   const std::string& icon, const std::string& model, bool nameDescInStringTable)
+                                   const std::string& icon, const std::string& model, bool name_desc_in_stringtable)
     {
         if (name.empty() || description.empty() || hull.empty()) {
             ErrorLogger() << "IssueCreateShipDesignOrderOrder : passed an empty name, description, or hull.";
@@ -852,7 +852,7 @@ namespace AIInterface {
 
         // create design from stuff chosen in UI
         ShipDesign* design = new ShipDesign(name, description, current_turn, ClientApp::GetApp()->EmpireID(),
-                                            hull, parts, icon, model, nameDescInStringTable, false, uuid);
+                                            hull, parts, icon, model, name_desc_in_stringtable, false, uuid);
 
         if (!design) {
             ErrorLogger() << "IssueCreateShipDesignOrderOrder failed to create a new ShipDesign object";

--- a/AI/AIInterface.h
+++ b/AI/AIInterface.h
@@ -348,7 +348,7 @@ namespace AIInterface {
 
     int IssueCreateShipDesignOrder(const std::string& name, const std::string& description,
                                    const std::string& hull, const std::vector<std::string> parts,
-                                   const std::string& graphic, const std::string& model, bool nameDescInStringTable);
+                                   const std::string& graphic, const std::string& model, bool name_desc_in_stringtable);
 
     void SendPlayerChatMessage(int recipient_player_id, const std::string& message_text);
     void SendDiplomaticMessage(const DiplomaticMessage& diplo_message);

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -143,14 +143,8 @@ namespace {
             if (!exists(saved_designs_dir))
                 return;
 
-            DebugLogger() << "Parsing all files in " << saved_designs_dir << " for ship designs";
             std::map<std::string, std::unique_ptr<ShipDesign>> file_designs;
-            try {
-                parse::ship_designs(saved_designs_dir, file_designs);
-            } catch (const std::runtime_error& e) {
-                ErrorLogger() << "Failed to parse designs in " << saved_designs_dir << " because " << e.what();;
-                return;
-            }
+            parse::ship_designs(saved_designs_dir, file_designs);
 
             for (auto& design_entry : file_designs) {
                 if (m_saved_designs.find(design_entry.first) == m_saved_designs.end()) {

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -33,6 +33,7 @@
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/fstream.hpp>
+#include <boost/uuid/random_generator.hpp>
 
 #include <algorithm>
 #include <iterator>
@@ -3313,10 +3314,12 @@ void DesignWnd::MainPanel::RefreshIncompleteDesign() const {
 
     const std::string& icon = m_hull ? m_hull->Icon() : EMPTY_STRING;
 
+    const auto uuid = boost::uuids::random_generator()();
+
     // update stored design
     try {
         m_incomplete_design.reset(new ShipDesign(name, description, CurrentTurn(), ClientApp::GetApp()->EmpireID(),
-                                                 hull, parts, icon, ""));
+                                                 hull, parts, icon, "", false, false, uuid));
     } catch (const std::exception& e) {
         // had a weird crash in the above call a few times, but I can't seem to
         // replicate it now.  hopefully catching any exception here will
@@ -3542,9 +3545,11 @@ int DesignWnd::AddDesign() {
     if (const HullType* hull = GetHullType(hull_name))
         icon = hull->Icon();
 
+    const auto uuid = boost::uuids::random_generator()();
+
     // create design from stuff chosen in UI
     ShipDesign design(name, description, CurrentTurn(), ClientApp::GetApp()->EmpireID(),
-                      hull_name, parts, icon, "some model");
+                      hull_name, parts, icon, "some model", false, false, uuid);
 
     int new_design_id = HumanClientApp::GetApp()->GetNewDesignID();
     HumanClientApp::GetApp()->Orders().IssueOrder(

--- a/default/scripting/monster_designs/SM_ACIREMA_GUARD.focs.txt
+++ b/default/scripting/monster_designs/SM_ACIREMA_GUARD.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SM_ACIREMA_GUARD"
+    uuid = "08a58b08-0929-496d-84fc-fba91424ca16"
     description = "SM_ACIREMA_GUARD_DESC"
     hull = "SH_GUARD_MONSTER_BODY"
     parts = [

--- a/default/scripting/monster_designs/SM_ASH.focs.txt
+++ b/default/scripting/monster_designs/SM_ASH.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SM_ASH"
+    uuid = "08a58b08-0929-496d-84fc-fba91424ca11"
     description = "SM_ASH_DESC"
     hull = "SH_NEBULOUS_BODY"
     parts = [

--- a/default/scripting/monster_designs/SM_BLACK_KRAKEN.focs.txt
+++ b/default/scripting/monster_designs/SM_BLACK_KRAKEN.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SM_BLACK_KRAKEN"
+    uuid = "08a58b08-0929-496d-84fc-fba91424ca17"
     description = "SM_BLACK_KRAKEN_DESC"
     hull = "SH_BLACK_KRAKEN_BODY"
     parts = [

--- a/default/scripting/monster_designs/SM_BLOATED_JUGGERNAUT.focs.txt
+++ b/default/scripting/monster_designs/SM_BLOATED_JUGGERNAUT.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SM_BLOATED_JUGGERNAUT"
+    uuid = "08a58b08-0929-496d-84fc-fba91424ca22"
     description = "SM_BLOATED_JUGGERNAUT_DESC"
     hull = "SH_BLOATED_JUGGERNAUT_BODY"
     parts = [

--- a/default/scripting/monster_designs/SM_CLOUD.focs.txt
+++ b/default/scripting/monster_designs/SM_CLOUD.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SM_CLOUD"
+    uuid = "08a58b08-0929-496d-84fc-fba91424ca20"
     description = "SM_CLOUD_DESC"
     hull = "SH_NEBULOUS_BODY"
     parts = [

--- a/default/scripting/monster_designs/SM_COSMIC_DRAGON.focs.txt
+++ b/default/scripting/monster_designs/SM_COSMIC_DRAGON.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SM_COSMIC_DRAGON"
+    uuid = "08a58b08-0929-496d-84fc-fba91424ca00"
     description = "SM_COSMIC_DRAGON_DESC"
     hull = "SH_COSMIC_DRAGON_BODY"
     parts = [

--- a/default/scripting/monster_designs/SM_DAMPENING_CLOUD.focs.txt
+++ b/default/scripting/monster_designs/SM_DAMPENING_CLOUD.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SM_DAMPENING_CLOUD"
+    uuid = "08a58b08-0929-496d-84fc-fba91424ca33"
     description = "SM_DAMPENING_CLOUD_DESC"
     hull = "SH_DAMPENING_CLOUD_BODY"
     parts = [

--- a/default/scripting/monster_designs/SM_DIM.focs.txt
+++ b/default/scripting/monster_designs/SM_DIM.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SM_DIM"
+    uuid = "08a58b08-0929-496d-84fc-fba91424ca32"
     description = "SM_DIM_DESC"
     hull = "SH_NEBULOUS_BODY"
     parts = [

--- a/default/scripting/monster_designs/SM_DRAGON.focs.txt
+++ b/default/scripting/monster_designs/SM_DRAGON.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SM_DRAGON"
+    uuid = "08a58b08-0929-496d-84fc-fba91424ca06"
     description = "SM_DRAGON_DESC"
     hull = "SH_STRONG_MONSTER_BODY"
     parts = [

--- a/default/scripting/monster_designs/SM_DRONE.focs.txt
+++ b/default/scripting/monster_designs/SM_DRONE.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SM_DRONE"
+    uuid = "08a58b08-0929-496d-84fc-fba91424ca29"
     description = "SM_DRONE_DESC"
     hull = "SH_DRONE_BODY"
     parts = [

--- a/default/scripting/monster_designs/SM_DRONE_FACTORY.focs.txt
+++ b/default/scripting/monster_designs/SM_DRONE_FACTORY.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SM_DRONE_FACTORY"
+    uuid = "08a58b08-0929-496d-84fc-fba91424ca15"
     description = "SM_DRONE_FACTORY_DESC"
     hull = "SH_IMMOBILE_FACTORY"
     parts = [

--- a/default/scripting/monster_designs/SM_EXP_OUTPOST.focs.txt
+++ b/default/scripting/monster_designs/SM_EXP_OUTPOST.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SM_EXP_OUTPOST"
+    uuid = "08a58b08-0929-496d-84fc-fba91424ca07"
     description = "SM_EXP_OUTPOST_DESC"
     hull = "SH_EXP_OUTPOST_HULL"
     parts = [

--- a/default/scripting/monster_designs/SM_FLOATER.focs.txt
+++ b/default/scripting/monster_designs/SM_FLOATER.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SM_FLOATER"
+    uuid = "08a58b08-0929-496d-84fc-fba91424ca31"
     description = "SM_FLOATER_DESC"
     hull = "SH_FLOATER_BODY"
     parts = [

--- a/default/scripting/monster_designs/SM_GUARD_0.focs.txt
+++ b/default/scripting/monster_designs/SM_GUARD_0.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SM_GUARD_0"
+    uuid = "08a58b08-0929-496d-84fc-fba91424ca18"
     description = "SM_GUARD_0_DESC"
     hull = "SH_GUARD_0_BODY"
     parts = [

--- a/default/scripting/monster_designs/SM_GUARD_1.focs.txt
+++ b/default/scripting/monster_designs/SM_GUARD_1.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SM_GUARD_1"
+    uuid = "08a58b08-0929-496d-84fc-fba91424ca23"
     description = "SM_GUARD_1_DESC"
     hull = "SH_GUARD_1_BODY"
     parts = [

--- a/default/scripting/monster_designs/SM_GUARD_2.focs.txt
+++ b/default/scripting/monster_designs/SM_GUARD_2.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SM_GUARD_2"
+    uuid = "08a58b08-0929-496d-84fc-fba91424ca34"
     description = "SM_GUARD_2_DESC"
     hull = "SH_GUARD_MONSTER_BODY"
     parts = [

--- a/default/scripting/monster_designs/SM_GUARD_3.focs.txt
+++ b/default/scripting/monster_designs/SM_GUARD_3.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SM_GUARD_3"
+    uuid = "08a58b08-0929-496d-84fc-fba91424ca30"
     description = "SM_GUARD_3_DESC"
     hull = "SH_GUARD_3_BODY"
     parts = [

--- a/default/scripting/monster_designs/SM_JUGGERNAUT_1.focs.txt
+++ b/default/scripting/monster_designs/SM_JUGGERNAUT_1.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SM_JUGGERNAUT_1"
+    uuid = "08a58b08-0929-496d-84fc-fba91424ca12"
     description = "SM_JUGGERNAUT_1_DESC"
     hull = "SH_JUGGERNAUT_1_BODY"
     parts = [

--- a/default/scripting/monster_designs/SM_JUGGERNAUT_2.focs.txt
+++ b/default/scripting/monster_designs/SM_JUGGERNAUT_2.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SM_JUGGERNAUT_2"
+    uuid = "08a58b08-0929-496d-84fc-fba91424ca02"
     description = "SM_JUGGERNAUT_2_DESC"
     hull = "SH_JUGGERNAUT_2_BODY"
     parts = [

--- a/default/scripting/monster_designs/SM_JUGGERNAUT_3.focs.txt
+++ b/default/scripting/monster_designs/SM_JUGGERNAUT_3.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SM_JUGGERNAUT_3"
+    uuid = "08a58b08-0929-496d-84fc-fba91424ca03"
     description = "SM_JUGGERNAUT_3_DESC"
     hull = "SH_JUGGERNAUT_3_BODY"
     parts = [

--- a/default/scripting/monster_designs/SM_KRAKEN_1.focs.txt
+++ b/default/scripting/monster_designs/SM_KRAKEN_1.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SM_KRAKEN_1"
+    uuid = "08a58b08-0929-496d-84fc-fba91424ca05"
     description = "SM_KRAKEN_1_DESC"
     hull = "SH_KRAKEN_1_BODY"
     parts = [

--- a/default/scripting/monster_designs/SM_KRAKEN_2.focs.txt
+++ b/default/scripting/monster_designs/SM_KRAKEN_2.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SM_KRAKEN_2"
+    uuid = "08a58b08-0929-496d-84fc-fba91424ca14"
     description = "SM_KRAKEN_2_DESC"
     hull = "SH_KRAKEN_2_BODY"
     parts = [

--- a/default/scripting/monster_designs/SM_KRAKEN_3.focs.txt
+++ b/default/scripting/monster_designs/SM_KRAKEN_3.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SM_KRAKEN_3"
+    uuid = "08a58b08-0929-496d-84fc-fba91424ca08"
     description = "SM_KRAKEN_3_DESC"
     hull = "SH_KRAKEN_3_BODY"
     parts = [

--- a/default/scripting/monster_designs/SM_KRILL_1.focs.txt
+++ b/default/scripting/monster_designs/SM_KRILL_1.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SM_KRILL_1"
+    uuid = "08a58b08-0929-496d-84fc-fba91424ca26"
     description = "SM_KRILL_1_DESC"
     hull = "SH_KRILL_1_BODY"
     parts = [

--- a/default/scripting/monster_designs/SM_KRILL_2.focs.txt
+++ b/default/scripting/monster_designs/SM_KRILL_2.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SM_KRILL_2"
+    uuid = "08a58b08-0929-496d-84fc-fba91424ca28"
     description = "SM_KRILL_2_DESC"
     hull = "SH_KRILL_2_BODY"
     parts = [

--- a/default/scripting/monster_designs/SM_KRILL_3.focs.txt
+++ b/default/scripting/monster_designs/SM_KRILL_3.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SM_KRILL_3"
+    uuid = "08a58b08-0929-496d-84fc-fba91424ca01"
     description = "SM_KRILL_3_DESC"
     hull = "SH_KRILL_3_BODY"
     parts = [

--- a/default/scripting/monster_designs/SM_KRILL_4.focs.txt
+++ b/default/scripting/monster_designs/SM_KRILL_4.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SM_KRILL_4"
+    uuid = "08a58b08-0929-496d-84fc-fba91424ca19"
     description = "SM_KRILL_4_DESC"
     hull = "SH_KRILL_4_BODY"
     parts = [

--- a/default/scripting/monster_designs/SM_PSIONIC_SNOWFLAKE.focs.txt
+++ b/default/scripting/monster_designs/SM_PSIONIC_SNOWFLAKE.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SM_PSIONIC_SNOWFLAKE"
+    uuid = "08a58b08-0929-496d-84fc-fba91424ca09"
     description = "SM_PSIONIC_SNOWFLAKE_DESC"
     hull = "SH_PSIONIC_SNOWFLAKE_BODY"
     parts = [

--- a/default/scripting/monster_designs/SM_SNAIL.focs.txt
+++ b/default/scripting/monster_designs/SM_SNAIL.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SM_SNAIL"
+    uuid = "08a58b08-0929-496d-84fc-fba91424ca21"
     description = "SM_SNAIL_DESC"
     hull = "SH_ASTEROID"
     parts = [

--- a/default/scripting/monster_designs/SM_SNOWFLAKE_1.focs.txt
+++ b/default/scripting/monster_designs/SM_SNOWFLAKE_1.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SM_SNOWFLAKE_1"
+    uuid = "08a58b08-0929-496d-84fc-fba91424ca24"
     description = "SM_SNOWFLAKE_1_DESC"
     hull = "SH_SNOWFLAKE_1_BODY"
     parts = [

--- a/default/scripting/monster_designs/SM_SNOWFLAKE_2.focs.txt
+++ b/default/scripting/monster_designs/SM_SNOWFLAKE_2.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SM_SNOWFLAKE_2"
+    uuid = "08a58b08-0929-496d-84fc-fba91424ca25"
     description = "SM_SNOWFLAKE_2_DESC"
     hull = "SH_SNOWFLAKE_2_BODY"
     parts = [

--- a/default/scripting/monster_designs/SM_SNOWFLAKE_3.focs.txt
+++ b/default/scripting/monster_designs/SM_SNOWFLAKE_3.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SM_SNOWFLAKE_3"
+    uuid = "08a58b08-0929-496d-84fc-fba91424ca27"
     description = "SM_SNOWFLAKE_3_DESC"
     hull = "SH_SNOWFLAKE_3_BODY"
     parts = [

--- a/default/scripting/monster_designs/SM_TREE.focs.txt
+++ b/default/scripting/monster_designs/SM_TREE.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SM_TREE"
+    uuid = "08a58b08-0929-496d-84fc-fba91424ca10"
     description = "SM_TREE_DESC"
     hull = "SH_TREE_BODY"
     parts = "SR_WEAPON_1_1"

--- a/default/scripting/monster_designs/SM_VOID.focs.txt
+++ b/default/scripting/monster_designs/SM_VOID.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SM_VOID"
+    uuid = "08a58b08-0929-496d-84fc-fba91424ca04"
     description = "SM_VOID_DESC"
     hull = "SH_NEBULOUS_BODY"
     parts = [

--- a/default/scripting/monster_designs/SM_WHITE_KRAKEN.focs.txt
+++ b/default/scripting/monster_designs/SM_WHITE_KRAKEN.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SM_WHITE_KRAKEN"
+    uuid = "08a58b08-0929-496d-84fc-fba91424ca13"
     description = "SM_WHITE_KRAKEN_DESC"
     hull = "SH_WHITE_KRAKEN_BODY"
     parts = [

--- a/default/scripting/ship_designs/SD_AST_1.focs.txt
+++ b/default/scripting/ship_designs/SD_AST_1.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_AST_1"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca22"
     description = "SD_AST_1_DESC"
     hull = "SH_ASTEROID"
     parts = [

--- a/default/scripting/ship_designs/SD_BASE_DECOY.focs.txt
+++ b/default/scripting/ship_designs/SD_BASE_DECOY.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_BASE_DECOY"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca10"
     description = "SD_BASE_DECOY_DESC"
     hull = "SH_COLONY_BASE"
     parts = ""

--- a/default/scripting/ship_designs/SD_CARRIER.focs.txt
+++ b/default/scripting/ship_designs/SD_CARRIER.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_CARRIER"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca34"
     description = "SD_CARRIER_DESC"
     hull = "SH_STANDARD"
     parts = [

--- a/default/scripting/ship_designs/SD_CARRIER_2.focs.txt
+++ b/default/scripting/ship_designs/SD_CARRIER_2.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_CARRIER_2"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca05"
     description = "SD_CARRIER_2_DESC"
     hull = "SH_STANDARD"
     parts = [

--- a/default/scripting/ship_designs/SD_COLONY_SHIP.focs.txt
+++ b/default/scripting/ship_designs/SD_COLONY_SHIP.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_COLONY_SHIP"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca01"
     description = "SD_COLONY_SHIP_DESC"
     hull = "SH_BASIC_MEDIUM"
     parts = [

--- a/default/scripting/ship_designs/SD_CRYONIC_COLONY_SHIP.focs.txt
+++ b/default/scripting/ship_designs/SD_CRYONIC_COLONY_SHIP.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_CRYONIC_COLONY_SHIP"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca31"
     description = "SD_CRYONIC_COLONY_SHIP_DESC"
     hull = "SH_BASIC_MEDIUM"
     parts = [

--- a/default/scripting/ship_designs/SD_ENG_SCOUT.focs.txt
+++ b/default/scripting/ship_designs/SD_ENG_SCOUT.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_ENG_SCOUT"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca33"
     description = "SD_ENG_SCOUT_DESC"
     hull = "SH_COMPRESSED_ENERGY"
     parts = [

--- a/default/scripting/ship_designs/SD_GRAVITATING1.focs.txt
+++ b/default/scripting/ship_designs/SD_GRAVITATING1.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_GRAVITATING1"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca24"
     description = "SD_GRAVITATING1_DESC"
     hull = "SH_SELF_GRAVITATING"
     parts = [

--- a/default/scripting/ship_designs/SD_GRAVITATING2.focs.txt
+++ b/default/scripting/ship_designs/SD_GRAVITATING2.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_GRAVITATING2"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca20"
     description = "SD_GRAVITATING2_DESC"
     hull = "SH_SELF_GRAVITATING"
     parts = [

--- a/default/scripting/ship_designs/SD_LARGE_MARK_1.focs.txt
+++ b/default/scripting/ship_designs/SD_LARGE_MARK_1.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_LARGE_MARK_1"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca00"
     description = "SD_LARGE_MARK1_DESC"
     hull = "SH_STANDARD"
     parts = [

--- a/default/scripting/ship_designs/SD_LARGE_MARK_2.focs.txt
+++ b/default/scripting/ship_designs/SD_LARGE_MARK_2.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_LARGE_MARK_2"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca09"
     description = "SD_LARGE_MARK2_DESC"
     hull = "SH_STANDARD"
     parts = [

--- a/default/scripting/ship_designs/SD_LARGE_MARK_3.focs.txt
+++ b/default/scripting/ship_designs/SD_LARGE_MARK_3.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_LARGE_MARK_3"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca32"
     description = "SD_LARGE_MARK3_DESC"
     hull = "SH_STANDARD"
     parts = [

--- a/default/scripting/ship_designs/SD_LARGE_MARK_4.focs.txt
+++ b/default/scripting/ship_designs/SD_LARGE_MARK_4.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_LARGE_MARK_4"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca03"
     description = "SD_LARGE_MARK4_DESC"
     hull = "SH_STANDARD"
     parts = [

--- a/default/scripting/ship_designs/SD_MARK_1.focs.txt
+++ b/default/scripting/ship_designs/SD_MARK_1.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_MARK_1"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca21"
     description = "SD_MARK1_DESC"
     hull = "SH_BASIC_MEDIUM"
     parts = [

--- a/default/scripting/ship_designs/SD_ORG_OUTPOST_SHIP.focs.txt
+++ b/default/scripting/ship_designs/SD_ORG_OUTPOST_SHIP.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_ORG_OUTPOST_SHIP"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca08"
     description = "SD_ORG_OUTPOST_SHIP_DESC"
     hull = "SH_ORGANIC"
     parts = [

--- a/default/scripting/ship_designs/SD_ROBOTIC1.focs.txt
+++ b/default/scripting/ship_designs/SD_ROBOTIC1.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_ROBOTIC1"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca26"
     description = "SD_ROBOTIC1_DESC"
     hull = "SH_ROBOTIC"
     parts = [

--- a/default/scripting/ship_designs/SD_ROBOTIC2.focs.txt
+++ b/default/scripting/ship_designs/SD_ROBOTIC2.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_ROBOTIC2"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca29"
     description = "SD_ROBOTIC2_DESC"
     hull = "SH_ROBOTIC"
     parts = [

--- a/default/scripting/ship_designs/SD_ROBOTIC3.focs.txt
+++ b/default/scripting/ship_designs/SD_ROBOTIC3.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_ROBOTIC3"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca27"
     description = "SD_ROBOTIC3_DESC"
     hull = "SH_ROBOTIC"
     parts = [

--- a/default/scripting/ship_designs/SD_ROBOTIC_CARRIER1.focs.txt
+++ b/default/scripting/ship_designs/SD_ROBOTIC_CARRIER1.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_ROBOTIC_CARRIER1"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca37"
     description = "SD_ROBOTIC_CARRIER1_DESC"
     hull = "SH_ROBOTIC"
     parts = [

--- a/default/scripting/ship_designs/SD_ROBOTIC_CARRIER2.focs.txt
+++ b/default/scripting/ship_designs/SD_ROBOTIC_CARRIER2.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_ROBOTIC_CARRIER2"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca39"
     description = "SD_ROBOTIC_CARRIER2_DESC"
     hull = "SH_ROBOTIC"
     parts = [

--- a/default/scripting/ship_designs/SD_ROBOTIC_CARRIER3.focs.txt
+++ b/default/scripting/ship_designs/SD_ROBOTIC_CARRIER3.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_ROBOTIC_CARRIER3"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca38"
     description = "SD_ROBOTIC_CARRIER3_DESC"
     hull = "SH_ROBOTIC"
     parts = [

--- a/default/scripting/ship_designs/SD_ROBOTIC_OUTPOST_HULL.focs.txt
+++ b/default/scripting/ship_designs/SD_ROBOTIC_OUTPOST_HULL.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_ROBOTIC_OUTPOST"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca30"
     description = "SD_ROBOTIC_OUTPOST_DESC"
     hull = "SH_ROBOTIC"
     parts = [

--- a/default/scripting/ship_designs/SD_ROBO_FLUX_SCOUT.focs.txt
+++ b/default/scripting/ship_designs/SD_ROBO_FLUX_SCOUT.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_ROBO_FLUX_SCOUT"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca04"
     description = "SD_ROBO_FLUX_SCOUT_DESC"
     hull = "SH_SPATIAL_FLUX"
     parts = [

--- a/default/scripting/ship_designs/SD_ROBO_FLUX_TROOPS.focs.txt
+++ b/default/scripting/ship_designs/SD_ROBO_FLUX_TROOPS.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_ROBO_FLUX_TROOPS"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca35"
     description = "SD_ROBO_FLUX_TROOPS_DESC"
     hull = "SH_SPATIAL_FLUX"
     parts = [

--- a/default/scripting/ship_designs/SD_ROBO_FLUX_TROOPS_HVY.focs.txt
+++ b/default/scripting/ship_designs/SD_ROBO_FLUX_TROOPS_HVY.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_ROBO_FLUX_TROOPS_HVY"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca23"
     description = "SD_ROBO_FLUX_TROOPS_HVY_DESC"
     hull = "SH_SPATIAL_FLUX"
     parts = [

--- a/default/scripting/ship_designs/SD_ROBO_TITAN1.focs.txt
+++ b/default/scripting/ship_designs/SD_ROBO_TITAN1.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_ROBO_TITAN1"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca19"
     description = "SD_ROBO_TITAN1_DESC"
     hull = "SH_TITANIC"
     parts = [

--- a/default/scripting/ship_designs/SD_SCOUT.focs.txt
+++ b/default/scripting/ship_designs/SD_SCOUT.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_SCOUT"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca18"
     description = "SD_SCOUT_DESC"
     hull = "SH_BASIC_SMALL"
     parts = [

--- a/default/scripting/ship_designs/SD_SCOUT_2.focs.txt
+++ b/default/scripting/ship_designs/SD_SCOUT_2.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_SCOUT_2"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca25"
     description = "SD_SCOUT_2_DESC"
     hull = "SH_BASIC_SMALL"
     parts = [

--- a/default/scripting/ship_designs/SD_SCOUT_3.focs.txt
+++ b/default/scripting/ship_designs/SD_SCOUT_3.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_SCOUT_3"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca36"
     description = "SD_SCOUT_3_DESC"
     hull = "SH_BASIC_SMALL"
     parts = [

--- a/default/scripting/ship_designs/SD_SCOUT_4.focs.txt
+++ b/default/scripting/ship_designs/SD_SCOUT_4.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_SCOUT_4"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca28"
     description = "SD_SCOUT_4_DESC"
     hull = "SH_BASIC_SMALL"
     parts = [

--- a/default/scripting/ship_designs/SD_SMALL_MARK_1.focs.txt
+++ b/default/scripting/ship_designs/SD_SMALL_MARK_1.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_SMALL_MARK_1"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca07"
     description = "SD_SMALL_MARK1_DESC"
     hull = "SH_BASIC_SMALL"
     parts = [

--- a/default/scripting/ship_designs/SD_SMALL_TROOP_SHIP.focs.txt
+++ b/default/scripting/ship_designs/SD_SMALL_TROOP_SHIP.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_SMALL_TROOP_SHIP"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca06"
     description = "SD_SMALL_TROOP_SHIP_DESC"
     hull = "SH_BASIC_SMALL"
     parts = [

--- a/default/scripting/ship_designs/SD_TROOP_SHIP.focs.txt
+++ b/default/scripting/ship_designs/SD_TROOP_SHIP.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_TROOP_SHIP"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca02"
     description = "SD_TROOP_SHIP_DESC"
     hull = "SH_BASIC_MEDIUM"
     parts = [

--- a/default/scripting/ship_designs/required/SD_COLONY_BASE.focs.txt
+++ b/default/scripting/ship_designs/required/SD_COLONY_BASE.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_COLONY_BASE"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca11"
     description = "SD_COLONY_BASE_DESC"
     hull = "SH_COLONY_BASE"
     parts = "CO_COLONY_POD"

--- a/default/scripting/ship_designs/required/SD_CRYONIC_COLONY_BASE.focs.txt
+++ b/default/scripting/ship_designs/required/SD_CRYONIC_COLONY_BASE.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_CRYONIC_COLONY_BASE"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca15"
     description = "SD_CRYONIC_COLONY_BASE_DESC"
     hull = "SH_COLONY_BASE"
     parts = "CO_SUSPEND_ANIM_POD"

--- a/default/scripting/ship_designs/required/SD_DRAGON_TOOTH.focs.txt
+++ b/default/scripting/ship_designs/required/SD_DRAGON_TOOTH.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_DRAGON_TOOTH"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca12"
     description = "SD_DRAGON_TOOTH_DESC"
     hull = "SH_XENTRONIUM"
     parts = [

--- a/default/scripting/ship_designs/required/SD_OUTPOST_BASE.focs.txt
+++ b/default/scripting/ship_designs/required/SD_OUTPOST_BASE.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_OUTPOST_BASE"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca16"
     description = "SD_OUTPOST_BASE_DESC"
     hull = "SH_COLONY_BASE"
     parts = "CO_OUTPOST_POD"

--- a/default/scripting/ship_designs/required/SD_OUTPOST_SHIP.focs.txt
+++ b/default/scripting/ship_designs/required/SD_OUTPOST_SHIP.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_OUTPOST_SHIP"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca13"
     description = "SD_OUTPOST_SHIP_DESC"
     hull = "SH_BASIC_MEDIUM"
     parts = [

--- a/default/scripting/ship_designs/required/SD_TROOP_DROP.focs.txt
+++ b/default/scripting/ship_designs/required/SD_TROOP_DROP.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_TROOP_DROP"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca17"
     description = "SD_TROOP_DROP_DESC"
     hull = "SH_COLONY_BASE"
     parts = [

--- a/default/scripting/ship_designs/required/SD_TROOP_DROP_HEAVY.focs.txt
+++ b/default/scripting/ship_designs/required/SD_TROOP_DROP_HEAVY.focs.txt
@@ -1,5 +1,6 @@
 ShipDesign
     name = "SD_TROOP_DROP_HVY"
+    uuid = "08a58b08-0929-496d-84fc-faa91424ca14"
     description = "SD_TROOP_DROP_HVY_DESC"
     hull = "SH_COLONY_BASE"
     parts = [

--- a/parse/ShipDesignsParser.cpp
+++ b/parse/ShipDesignsParser.cpp
@@ -139,8 +139,13 @@ namespace {
 }
 
 namespace parse {
-    bool ship_designs(const boost::filesystem::path& path, std::map<std::string, std::unique_ptr<ShipDesign>>& designs)
-    { return detail::parse_file<rules, std::map<std::string, std::unique_ptr<ShipDesign>>>(path, designs); }
+    bool ship_designs(const boost::filesystem::path& path, std::map<std::string, std::unique_ptr<ShipDesign>>& designs) {
+        bool result = true;
+        for(const boost::filesystem::path& file : ListScripts(path)) {
+            result &= detail::parse_file<rules, std::map<std::string, std::unique_ptr<ShipDesign>>>(file, designs);
+        }
+        return result;
+    }
 
     bool ship_designs(std::map<std::string, std::unique_ptr<ShipDesign>>& designs) {
         bool result = true;

--- a/parse/ShipDesignsParser.cpp
+++ b/parse/ShipDesignsParser.cpp
@@ -7,7 +7,6 @@
 #include <boost/spirit/include/phoenix.hpp>
 #include <boost/phoenix/function/adapt_function.hpp>
 
-
 FO_COMMON_API extern const int ALL_EMPIRES;
 
 #define DEBUG_PARSERS 0
@@ -27,15 +26,15 @@ namespace {
                             const std::string& name, const std::string& description,
                             const std::string& hull, const std::vector<std::string>& parts,
                             const std::string& icon, const std::string& model,
-                            bool name_desc_in_stringtable)
+                            bool name_desc_in_stringtable, const std::string& uuid)
     {
         // TODO use make_unique when converting to C++14
         auto design = std::unique_ptr<ShipDesign>(
-            new ShipDesign(name, description, 0, ALL_EMPIRES, hull, parts, icon, model, name_desc_in_stringtable, false));
+            new ShipDesign(name, description, 0, ALL_EMPIRES, hull, parts, icon, model, name_desc_in_stringtable, false, uuid));
 
         auto inserted_design = designs.insert(std::make_pair(design->Name(false), std::move(design)));
     };
-    BOOST_PHOENIX_ADAPT_FUNCTION(void, insert_ship_design_, insert_ship_design, 8)
+    BOOST_PHOENIX_ADAPT_FUNCTION(void, insert_ship_design_, insert_ship_design, 9)
 
     struct rules {
         rules() {
@@ -55,12 +54,14 @@ namespace {
             qi::_d_type _d;
             qi::_e_type _e;
             qi::_f_type _f;
+            qi::_g_type _g;
             qi::_pass_type _pass;
             qi::_r1_type _r1;
             qi::_r2_type _r2;
             qi::_r3_type _r3;
             qi::_r4_type _r4;
             qi::_r5_type _r5;
+            qi::_r6_type _r6;
             qi::eps_type eps;
 
             const parse::lexer& tok = parse::lexer::instance();
@@ -68,7 +69,8 @@ namespace {
             design_prefix
                 =    tok.ShipDesign_
                 >    parse::detail::label(Name_token)
-                >   tok.string        [ _pass = is_unique_(_r5, ShipDesign_token, _1), _r1 = _1 ]
+                >   tok.string        [ _pass = is_unique_(_r6, ShipDesign_token, _1), _r1 = _1 ]
+                >    parse::detail::label(UUID_token)        > tok.string [ _r5 = _1 ]
                 >    parse::detail::label(Description_token) > tok.string [ _r2 = _1 ]
                 > (
                      tok.NoStringtableLookup_ [ _r4 = false ]
@@ -78,7 +80,7 @@ namespace {
                 ;
 
             design
-                =    design_prefix(_a, _b, _c, _f, _r1)
+                =    design_prefix(_a, _b, _c, _f, _g, _r1)
                 >    parse::detail::label(Parts_token)
                 >    (
                             ('[' > +tok.string [ push_back(_d, _1) ] > ']')
@@ -88,14 +90,14 @@ namespace {
                         parse::detail::label(Icon_token)     > tok.string [ _e = _1 ]
                      )
                 >    parse::detail::label(Model_token)       > tok.string
-                [ insert_ship_design_(_r1, _a, _b, _c, _d, _e, _1, _f) ]
+                [ insert_ship_design_(_r1, _a, _b, _c, _d, _e, _1, _f, _g) ]
                 ;
 
             start
                 =   +design(_r1)
                 ;
 
-            design_prefix.name("Name, Description, Lookup Flag, Hull");
+            design_prefix.name("Name, UUID, Description, Lookup Flag, Hull");
             design.name("ShipDesign");
 
 #if DEBUG_PARSERS
@@ -107,7 +109,8 @@ namespace {
         }
 
         typedef parse::detail::rule<
-            void (std::string&, std::string&, std::string&, bool&, const std::map<std::string, std::unique_ptr<ShipDesign>>&)
+            void (std::string&, std::string&, std::string&, bool&, std::string&,
+                  const std::map<std::string, std::unique_ptr<ShipDesign>>&)
         > design_prefix_rule;
 
         typedef parse::detail::rule<
@@ -118,7 +121,8 @@ namespace {
                 std::string,
                 std::vector<std::string>,
                 std::string,
-                bool
+                bool,
+                std::string
             >
         > design_rule;
 

--- a/parse/ShipDesignsParser.cpp
+++ b/parse/ShipDesignsParser.cpp
@@ -6,6 +6,7 @@
 
 #include <boost/spirit/include/phoenix.hpp>
 #include <boost/phoenix/function/adapt_function.hpp>
+#include <boost/uuid/uuid_io.hpp>
 
 FO_COMMON_API extern const int ALL_EMPIRES;
 
@@ -35,6 +36,19 @@ namespace {
         auto inserted_design = designs.insert(std::make_pair(design->Name(false), std::move(design)));
     };
     BOOST_PHOENIX_ADAPT_FUNCTION(void, insert_ship_design_, insert_ship_design, 9)
+
+    // A UUID parser
+    boost::uuids::uuid parse_uuid(const std::string& uuid_string) {
+        try {
+            return boost::lexical_cast<boost::uuids::uuid>(uuid_string);
+        } catch (boost::bad_lexical_cast&) {
+            std::stringstream ss;
+            ss << uuid_string << " is not a valid UUID.  A valid UUID looks like 01234567-89ab-cdef-0123-456789abcdef";
+            throw parse::FOCS_ParseError(ss.str());
+        }
+    };
+    // A lazy UUID parser
+    BOOST_PHOENIX_ADAPT_FUNCTION(boost::uuids::uuid, parse_uuid_, parse_uuid, 1)
 
     struct rules {
         rules() {

--- a/parse/ShipDesignsParser.cpp
+++ b/parse/ShipDesignsParser.cpp
@@ -69,8 +69,10 @@ namespace {
             design_prefix
                 =    tok.ShipDesign_
                 >    parse::detail::label(Name_token)
-                >   tok.string        [ _pass = is_unique_(_r6, ShipDesign_token, _1), _r1 = _1 ]
-                >    parse::detail::label(UUID_token)        > tok.string [ _r5 = _1 ]
+                >    tok.string        [ _pass = is_unique_(_r6, ShipDesign_token, _1), _r1 = _1 ]
+                >    (parse::detail::label(UUID_token)        > tok.string [ _r5 = _1 ]
+                      | eps [ _r5 = "" ]
+                     )
                 >    parse::detail::label(Description_token) > tok.string [ _r2 = _1 ]
                 > (
                      tok.NoStringtableLookup_ [ _r4 = false ]

--- a/parse/ShipDesignsParser.cpp
+++ b/parse/ShipDesignsParser.cpp
@@ -142,28 +142,19 @@ namespace parse {
     bool ship_designs(const boost::filesystem::path& path, std::map<std::string, std::unique_ptr<ShipDesign>>& designs) {
         bool result = true;
         for(const boost::filesystem::path& file : ListScripts(path)) {
-            result &= detail::parse_file<rules, std::map<std::string, std::unique_ptr<ShipDesign>>>(file, designs);
+            try {
+                result &= detail::parse_file<rules, std::map<std::string, std::unique_ptr<ShipDesign>>>(file, designs);
+            } catch (const std::runtime_error& e) {
+                result = false;
+                ErrorLogger() << "Failed to parse ship design in " << file << " from " << path << " because " << e.what();;
+            }
         }
         return result;
     }
 
-    bool ship_designs(std::map<std::string, std::unique_ptr<ShipDesign>>& designs) {
-        bool result = true;
+    bool ship_designs(std::map<std::string, std::unique_ptr<ShipDesign>>& designs)
+    { return ship_designs("scripting/ship_designs", designs); }
 
-        for(const boost::filesystem::path& file : ListScripts("scripting/ship_designs")) {
-            result &= detail::parse_file<rules, std::map<std::string, std::unique_ptr<ShipDesign>>>(file, designs);
-        }
-
-        return result;
-    }
-
-    bool monster_designs(std::map<std::string, std::unique_ptr<ShipDesign>>& designs) {
-        bool result = true;
-
-        for (const boost::filesystem::path& file : ListScripts("scripting/monster_designs")) {
-            result &= detail::parse_file<rules, std::map<std::string, std::unique_ptr<ShipDesign>>>(file, designs);
-        }
-
-        return result;
-    }
+    bool monster_designs(std::map<std::string, std::unique_ptr<ShipDesign>>& designs)
+    { return ship_designs("scripting/monster_designs", designs); }
 }

--- a/parse/ShipDesignsParser.cpp
+++ b/parse/ShipDesignsParser.cpp
@@ -59,7 +59,7 @@ namespace {
         } catch (boost::bad_lexical_cast&) {
             // This should never happen because the previous is_valid should short circuit.
             ErrorLogger() << uuid_string << " is not a valid UUID.  A valid UUID looks like 01234567-89ab-cdef-0123-456789abcdef";
-            return boost::uuids::uuid{{0}};
+            return boost::uuids::nil_generator()();
         }
     };
     // A lazy UUID parser

--- a/parse/Tokens.h
+++ b/parse/Tokens.h
@@ -504,6 +504,7 @@
     (Unresearchable)                            \
     (UpgradeVisibility)                         \
     (UserString)                                \
+    (UUID)                                      \
     (Value)                                     \
     (Victory)                                   \
     (VisibleToEmpire)                           \

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -1041,19 +1041,8 @@ PredefinedShipDesignManager::PredefinedShipDesignManager() {
 
     DebugLogger() << "Initializing PredefinedShipDesignManager";
 
-    try {
-        parse::ship_designs(m_ship_designs);
-    } catch (const std::exception& e) {
-        ErrorLogger() << "Failed parsing ship designs: error: " << e.what();
-        throw;
-    }
-
-    try {
-        parse::monster_designs(m_monster_designs);
-    } catch (const std::exception& e) {
-        ErrorLogger() << "Failed parsing monster designs: error: " << e.what();
-        throw;
-    }
+    parse::ship_designs(m_ship_designs);
+    parse::monster_designs(m_monster_designs);
 
     TraceLogger() << "Predefined Ship Designs:";
     for (const auto& entry : m_ship_designs)

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -540,10 +540,10 @@ ShipDesign::ShipDesign(const std::string& name, const std::string& description,
                        const std::vector<std::string>& parts,
                        const std::string& icon, const std::string& model,
                        bool name_desc_in_stringtable, bool monster,
-                       const boost::uuids::uuid uuid /*= boost::uuids::nil_uuid()*/) :
+                       const boost::uuids::uuid& uuid /*= boost::uuids::nil_uuid()*/) :
     m_name(name),
     m_description(description),
-    m_uuid{uuid},
+    m_uuid(uuid),
     m_designed_on_turn(designed_on_turn),
     m_designed_by_empire(designed_by_empire),
     m_hull(hull),
@@ -571,7 +571,7 @@ ShipDesign::ShipDesign(const std::string& name, const std::string& description,
                        const std::vector<std::string>& parts,
                        const std::string& icon, const std::string& model,
                        bool name_desc_in_stringtable, bool monster,
-                       const boost::uuids::uuid uuid /*= boost::uuids::nil_uuid()*/) :
+                       const boost::uuids::uuid& uuid /*= boost::uuids::nil_uuid()*/) :
     ShipDesign(name, description, 0, ALL_EMPIRES, hull, parts, icon, model, name_desc_in_stringtable, monster, uuid)
 {}
 

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -18,7 +18,6 @@
 
 #include <cfloat>
 #include <boost/filesystem/fstream.hpp>
-#include <boost/uuid/nil_generator.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/lexical_cast.hpp>
 
@@ -541,7 +540,7 @@ ShipDesign::ShipDesign(const std::string& name, const std::string& description,
                        const std::vector<std::string>& parts,
                        const std::string& icon, const std::string& model,
                        bool name_desc_in_stringtable, bool monster,
-                       const boost::uuids::uuid uuid /*= boost::uuids::uuid{{0}}*/) :
+                       const boost::uuids::uuid uuid /*= boost::uuids::nil_uuid()*/) :
     m_name(name),
     m_description(description),
     m_uuid{uuid},
@@ -572,7 +571,7 @@ ShipDesign::ShipDesign(const std::string& name, const std::string& description,
                        const std::vector<std::string>& parts,
                        const std::string& icon, const std::string& model,
                        bool name_desc_in_stringtable, bool monster,
-                       const boost::uuids::uuid uuid /*= boost::uuids::uuid{{0}}*/) :
+                       const boost::uuids::uuid uuid /*= boost::uuids::nil_uuid()*/) :
     ShipDesign(name, description, 0, ALL_EMPIRES, hull, parts, icon, model, name_desc_in_stringtable, monster, uuid)
 {}
 

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -19,6 +19,7 @@
 #include <cfloat>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
 
 extern FO_COMMON_API const int INVALID_DESIGN_ID = -1;
 
@@ -538,10 +539,11 @@ ShipDesign::ShipDesign(const std::string& name, const std::string& description,
                        int designed_on_turn, int designed_by_empire, const std::string& hull,
                        const std::vector<std::string>& parts,
                        const std::string& icon, const std::string& model,
-                       bool name_desc_in_stringtable, bool monster) :
+                       bool name_desc_in_stringtable, bool monster,
+                       const boost::uuids::uuid& uuid) :
     m_name(name),
     m_description(description),
-    m_uuid(boost::uuids::random_generator()()),
+    m_uuid{uuid == boost::uuids::uuid{{0}} ? boost::uuids::random_generator()() : uuid},
     m_designed_on_turn(designed_on_turn),
     m_designed_by_empire(designed_by_empire),
     m_hull(hull),

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -1093,7 +1093,8 @@ namespace {
         ShipDesign* copy = new ShipDesign(design->Name(false), design->Description(false),
                                           design->DesignedOnTurn(), design->DesignedByEmpire(),
                                           design->Hull(), design->Parts(), design->Icon(),
-                                          design->Model(), design->LookupInStringtable(), monster);
+                                          design->Model(), design->LookupInStringtable(),
+                                          monster, design->UUID());
         if (!copy) {
             ErrorLogger() << "PredefinedShipDesignManager::AddShipDesignsToUniverse() couldn't duplicate the design with name " << design->Name();
             return;

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -20,6 +20,7 @@
 #include <boost/filesystem/fstream.hpp>
 #include <boost/uuid/uuid_generators.hpp>
 #include <boost/uuid/uuid_io.hpp>
+#include <boost/lexical_cast.hpp>
 
 extern FO_COMMON_API const int INVALID_DESIGN_ID = -1;
 
@@ -540,10 +541,10 @@ ShipDesign::ShipDesign(const std::string& name, const std::string& description,
                        const std::vector<std::string>& parts,
                        const std::string& icon, const std::string& model,
                        bool name_desc_in_stringtable, bool monster,
-                       const boost::uuids::uuid& uuid) :
+                       const std::string uuid) :
     m_name(name),
     m_description(description),
-    m_uuid{uuid == boost::uuids::uuid{{0}} ? boost::uuids::random_generator()() : uuid},
+    m_uuid{(uuid.empty()) ? boost::uuids::random_generator()() : boost::lexical_cast<boost::uuids::uuid>(uuid)},
     m_designed_on_turn(designed_on_turn),
     m_designed_by_empire(designed_by_empire),
     m_hull(hull),
@@ -565,6 +566,15 @@ ShipDesign::ShipDesign(const std::string& name, const std::string& description,
     }
     BuildStatCaches();
 }
+
+ShipDesign::ShipDesign(const std::string& name, const std::string& description,
+                       const std::string& hull,
+                       const std::vector<std::string>& parts,
+                       const std::string& icon, const std::string& model,
+                       bool name_desc_in_stringtable, bool monster,
+                       const std::string& uuid) :
+    ShipDesign(name, description, 0, ALL_EMPIRES, hull, parts, icon, model, name_desc_in_stringtable, monster, uuid)
+{}
 
 const std::string& ShipDesign::Name(bool stringtable_lookup /* = true */) const {
     if (m_name_desc_in_stringtable && stringtable_lookup)
@@ -975,6 +985,7 @@ std::string ShipDesign::Dump() const {
     std::string retval = DumpIndent() + "ShipDesign\n";
     ++g_indent;
     retval += DumpIndent() + "name = \"" + m_name + "\"\n";
+    retval += DumpIndent() + "uuid = \"" + boost::uuids::to_string(m_uuid) + "\"\n";
     retval += DumpIndent() + "description = \"" + m_description + "\"\n";
 
     if (!m_name_desc_in_stringtable)

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -18,6 +18,7 @@
 
 #include <cfloat>
 #include <boost/filesystem/fstream.hpp>
+#include <boost/uuid/uuid_generators.hpp>
 
 extern FO_COMMON_API const int INVALID_DESIGN_ID = -1;
 
@@ -522,6 +523,7 @@ HullTypeManager::iterator HullTypeManager::end() const
 ShipDesign::ShipDesign() :
     m_name(),
     m_description(),
+    m_uuid(boost::uuids::random_generator()()),
     m_designed_on_turn(UniverseObject::INVALID_OBJECT_AGE),
     m_designed_by_empire(ALL_EMPIRES),
     m_hull(),
@@ -539,6 +541,7 @@ ShipDesign::ShipDesign(const std::string& name, const std::string& description,
                        bool name_desc_in_stringtable, bool monster) :
     m_name(name),
     m_description(description),
+    m_uuid(boost::uuids::random_generator()()),
     m_designed_on_turn(designed_on_turn),
     m_designed_by_empire(designed_by_empire),
     m_hull(hull),
@@ -572,6 +575,10 @@ void ShipDesign::SetName(const std::string& name) {
     if (m_name != "") {
         m_name = name;
     }
+}
+
+void ShipDesign::SetUUID(const boost::uuids::uuid& uuid) {
+    m_uuid = (m_uuid == boost::uuids::uuid{{0}}) ? boost::uuids::random_generator()() : uuid;
 }
 
 const std::string& ShipDesign::Description(bool stringtable_lookup /* = true */) const {

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -18,7 +18,7 @@
 
 #include <cfloat>
 #include <boost/filesystem/fstream.hpp>
-#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/nil_generator.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/lexical_cast.hpp>
 
@@ -525,7 +525,7 @@ HullTypeManager::iterator HullTypeManager::end() const
 ShipDesign::ShipDesign() :
     m_name(),
     m_description(),
-    m_uuid(boost::uuids::random_generator()()),
+    m_uuid(boost::uuids::nil_generator()()),
     m_designed_on_turn(UniverseObject::INVALID_OBJECT_AGE),
     m_designed_by_empire(ALL_EMPIRES),
     m_hull(),
@@ -541,10 +541,10 @@ ShipDesign::ShipDesign(const std::string& name, const std::string& description,
                        const std::vector<std::string>& parts,
                        const std::string& icon, const std::string& model,
                        bool name_desc_in_stringtable, bool monster,
-                       const std::string uuid) :
+                       const boost::uuids::uuid uuid /*= boost::uuids::uuid{{0}}*/) :
     m_name(name),
     m_description(description),
-    m_uuid{(uuid.empty()) ? boost::uuids::random_generator()() : boost::lexical_cast<boost::uuids::uuid>(uuid)},
+    m_uuid{uuid},
     m_designed_on_turn(designed_on_turn),
     m_designed_by_empire(designed_by_empire),
     m_hull(hull),
@@ -572,7 +572,7 @@ ShipDesign::ShipDesign(const std::string& name, const std::string& description,
                        const std::vector<std::string>& parts,
                        const std::string& icon, const std::string& model,
                        bool name_desc_in_stringtable, bool monster,
-                       const std::string& uuid) :
+                       const boost::uuids::uuid uuid /*= boost::uuids::uuid{{0}}*/) :
     ShipDesign(name, description, 0, ALL_EMPIRES, hull, parts, icon, model, name_desc_in_stringtable, monster, uuid)
 {}
 
@@ -589,9 +589,8 @@ void ShipDesign::SetName(const std::string& name) {
     }
 }
 
-void ShipDesign::SetUUID(const boost::uuids::uuid& uuid) {
-    m_uuid = (m_uuid == boost::uuids::uuid{{0}}) ? boost::uuids::random_generator()() : uuid;
-}
+void ShipDesign::SetUUID(const boost::uuids::uuid& uuid)
+{ m_uuid = uuid; }
 
 const std::string& ShipDesign::Description(bool stringtable_lookup /* = true */) const {
     if (m_name_desc_in_stringtable && stringtable_lookup)

--- a/universe/ShipDesign.h
+++ b/universe/ShipDesign.h
@@ -422,7 +422,9 @@ public:
                int designed_on_turn, int designed_by_empire, const std::string& hull,
                const std::vector<std::string>& parts,
                const std::string& icon, const std::string& model,
-               bool name_desc_in_stringtable = false, bool monster = false);
+               bool name_desc_in_stringtable = false, bool monster = false,
+               const boost::uuids::uuid& uuid = boost::uuids::uuid{{0}}
+              );
     //@}
 
     /** \name Accessors */ //@{

--- a/universe/ShipDesign.h
+++ b/universe/ShipDesign.h
@@ -423,14 +423,14 @@ public:
                const std::vector<std::string>& parts,
                const std::string& icon, const std::string& model,
                bool name_desc_in_stringtable = false, bool monster = false,
-               const std::string uuid = ""
+               const boost::uuids::uuid uuid = boost::uuids::uuid{{0}}
               );
     ShipDesign(const std::string& name, const std::string& description,
                const std::string& hull,
                const std::vector<std::string>& parts,
                const std::string& icon, const std::string& model,
                bool name_desc_in_stringtable = false, bool monster = false,
-               const std::string& uuid = ""
+               const boost::uuids::uuid uuid = boost::uuids::uuid{{0}}
               );
     //@}
 

--- a/universe/ShipDesign.h
+++ b/universe/ShipDesign.h
@@ -15,6 +15,7 @@
 #include <boost/serialization/access.hpp>
 #include <boost/serialization/nvp.hpp>
 #include <boost/uuid/uuid.hpp>
+#include <boost/uuid/nil_generator.hpp>
 
 #include "EnumsFwd.h"
 
@@ -112,7 +113,6 @@ public:
     /** \name Accessors */ //@{
     const std::string&      Name() const            { return m_name; };             ///< returns name of part
     const std::string&      Description() const     { return m_description; }       ///< returns description string, generally a UserString key.
-
     ShipPartClass           Class() const           { return m_class; }             ///< returns that class of part that this is.
     float                   Capacity() const;
     std::string             CapacityDescription() const;                            ///< returns a translated description of the part capacity, with numeric value
@@ -423,14 +423,14 @@ public:
                const std::vector<std::string>& parts,
                const std::string& icon, const std::string& model,
                bool name_desc_in_stringtable = false, bool monster = false,
-               const boost::uuids::uuid uuid = boost::uuids::uuid{{0}}
+               const boost::uuids::uuid uuid = boost::uuids::nil_uuid()
               );
     ShipDesign(const std::string& name, const std::string& description,
                const std::string& hull,
                const std::vector<std::string>& parts,
                const std::string& icon, const std::string& model,
                bool name_desc_in_stringtable = false, bool monster = false,
-               const boost::uuids::uuid uuid = boost::uuids::uuid{{0}}
+               const boost::uuids::uuid uuid = boost::uuids::nil_uuid()
               );
     //@}
 
@@ -445,8 +445,6 @@ public:
 
     /** Return the UUID. */
     boost::uuids::uuid              UUID() const { return m_uuid; }
-    /** Set the UUID. */
-    void                            SetUUID(const boost::uuids::uuid& uuid);
 
     /** returns description of design.  if \a stringtable_lookup is true and
       * the design was constructed specifying name_desc_in_stringtable true,
@@ -517,6 +515,8 @@ public:
 
     /** \name Mutators */ //@{
     void                            SetID(int id);                          ///< sets the ID number of the design to \a id .  Should only be used by Universe class when inserting new design into Universe.
+    /** Set the UUID. */
+    void                            SetUUID(const boost::uuids::uuid& uuid);
     void                            Rename(const std::string& name) { m_name = name; }  ///< renames this design to \a name
     //@}
 

--- a/universe/ShipDesign.h
+++ b/universe/ShipDesign.h
@@ -423,14 +423,14 @@ public:
                const std::vector<std::string>& parts,
                const std::string& icon, const std::string& model,
                bool name_desc_in_stringtable = false, bool monster = false,
-               const boost::uuids::uuid uuid = boost::uuids::nil_uuid()
+               const boost::uuids::uuid& uuid = boost::uuids::nil_uuid()
               );
     ShipDesign(const std::string& name, const std::string& description,
                const std::string& hull,
                const std::vector<std::string>& parts,
                const std::string& icon, const std::string& model,
                bool name_desc_in_stringtable = false, bool monster = false,
-               const boost::uuids::uuid uuid = boost::uuids::nil_uuid()
+               const boost::uuids::uuid& uuid = boost::uuids::nil_uuid()
               );
     //@}
 

--- a/universe/ShipDesign.h
+++ b/universe/ShipDesign.h
@@ -14,6 +14,7 @@
 #include <boost/variant.hpp>
 #include <boost/serialization/access.hpp>
 #include <boost/serialization/nvp.hpp>
+#include <boost/uuid/uuid.hpp>
 
 #include "EnumsFwd.h"
 
@@ -111,6 +112,7 @@ public:
     /** \name Accessors */ //@{
     const std::string&      Name() const            { return m_name; };             ///< returns name of part
     const std::string&      Description() const     { return m_description; }       ///< returns description string, generally a UserString key.
+
     ShipPartClass           Class() const           { return m_class; }             ///< returns that class of part that this is.
     float                   Capacity() const;
     std::string             CapacityDescription() const;                            ///< returns a translated description of the part capacity, with numeric value
@@ -432,6 +434,11 @@ public:
     const std::string&              Name(bool stringtable_lookup = true) const;
     void                            SetName(const std::string& name);
 
+    /** Return the UUID. */
+    boost::uuids::uuid              UUID() const { return m_uuid; }
+    /** Set the UUID. */
+    void                            SetUUID(const boost::uuids::uuid& uuid);
+
     /** returns description of design.  if \a stringtable_lookup is true and
       * the design was constructed specifying name_desc_in_stringtable true,
       * the description string is looked up in the stringtable before being
@@ -519,6 +526,7 @@ private:
 
     std::string                 m_name;
     std::string                 m_description;
+    boost::uuids::uuid          m_uuid;
 
     int                         m_designed_on_turn;
     int                         m_designed_by_empire;

--- a/universe/ShipDesign.h
+++ b/universe/ShipDesign.h
@@ -423,7 +423,14 @@ public:
                const std::vector<std::string>& parts,
                const std::string& icon, const std::string& model,
                bool name_desc_in_stringtable = false, bool monster = false,
-               const boost::uuids::uuid& uuid = boost::uuids::uuid{{0}}
+               const std::string uuid = ""
+              );
+    ShipDesign(const std::string& name, const std::string& description,
+               const std::string& hull,
+               const std::vector<std::string>& parts,
+               const std::string& icon, const std::string& model,
+               bool name_desc_in_stringtable = false, bool monster = false,
+               const std::string& uuid = ""
               );
     //@}
 

--- a/util/Order.cpp
+++ b/util/Order.cpp
@@ -17,6 +17,8 @@
 #include "../Empire/EmpireManager.h"
 #include "../Empire/Empire.h"
 
+#include <boost/uuid/nil_generator.hpp>
+
 #include <fstream>
 #include <vector>
 
@@ -952,23 +954,27 @@ void ProductionQueueOrder::ExecuteImpl() const {
 ////////////////////////////////////////////////
 // ShipDesignOrder
 ////////////////////////////////////////////////
-ShipDesignOrder::ShipDesignOrder()
+ShipDesignOrder::ShipDesignOrder() :
+    m_uuid(boost::uuids::nil_generator()())
 {}
 
 ShipDesignOrder::ShipDesignOrder(int empire, int existing_design_id_to_remember) :
     Order(empire),
-    m_design_id(existing_design_id_to_remember)
+    m_design_id(existing_design_id_to_remember),
+    m_uuid(boost::uuids::nil_generator()())
 {}
 
 ShipDesignOrder::ShipDesignOrder(int empire, int design_id_to_erase, bool dummy) :
     Order(empire),
     m_design_id(design_id_to_erase),
+    m_uuid(boost::uuids::nil_generator()()),
     m_delete_design_from_empire(true)
 {}
 
 ShipDesignOrder::ShipDesignOrder(int empire, int new_design_id, const ShipDesign& ship_design) :
     Order(empire),
     m_design_id(new_design_id),
+    m_uuid(ship_design.UUID()),
     m_create_new_design(true),
     m_name(ship_design.Name()),
     m_description(ship_design.Description()),
@@ -984,6 +990,7 @@ ShipDesignOrder::ShipDesignOrder(int empire, int new_design_id, const ShipDesign
 ShipDesignOrder::ShipDesignOrder(int empire, int existing_design_id, const std::string& new_name/* = ""*/, const std::string& new_description/* = ""*/) :
     Order(empire),
     m_design_id(existing_design_id),
+    m_uuid(boost::uuids::nil_generator()()),
     m_update_name_or_description(true),
     m_name(new_name),
     m_description(new_description)
@@ -992,6 +999,7 @@ ShipDesignOrder::ShipDesignOrder(int empire, int existing_design_id, const std::
 ShipDesignOrder::ShipDesignOrder(int empire, int design_id_to_move, int design_id_after) :
     Order(empire),
     m_design_id(design_id_to_move),
+    m_uuid(boost::uuids::nil_generator()()),
     m_move_design(true),
     m_design_id_after(design_id_after)
 {}
@@ -1019,7 +1027,7 @@ void ShipDesignOrder::ExecuteImpl() const {
         ShipDesign* new_ship_design = new ShipDesign(m_name, m_description,
                                                      m_designed_on_turn, EmpireID(), m_hull, m_parts,
                                                      m_icon, m_3D_model, m_name_desc_in_stringtable,
-                                                     m_is_monster);
+                                                     m_is_monster, m_uuid);
 
         universe.InsertShipDesignID(new_ship_design, m_design_id);
         universe.SetEmpireKnowledgeOfShipDesign(m_design_id, EmpireID());

--- a/util/Order.h
+++ b/util/Order.h
@@ -7,6 +7,7 @@
 
 #include <boost/serialization/access.hpp>
 #include <boost/serialization/nvp.hpp>
+#include <boost/uuid/uuid.hpp>
 
 #include <string>
 #include <vector>
@@ -613,6 +614,7 @@ private:
     void ExecuteImpl() const override;
 
     int m_design_id = INVALID_OBJECT_ID;
+    boost::uuids::uuid m_uuid;
     bool m_update_name_or_description = false;
     bool m_delete_design_from_empire = false;
     bool m_create_new_design = false;

--- a/util/Serialize.ipp
+++ b/util/Serialize.ipp
@@ -26,7 +26,8 @@
 #include <boost/serialization/vector.hpp>
 #include <boost/serialization/weak_ptr.hpp>
 #include <boost/ptr_container/serialize_ptr_vector.hpp>
-
+#include <boost/uuid/uuid_serialize.hpp>
+#include <boost/uuid/uuid_io.hpp>
 
 // disabling these tests as they reportedly cause problems on some systems
 // and binary serialization portability is apparently broken regardless of


### PR DESCRIPTION
This PR depends on #1545 to convert ship design parsing to use `unique_ptr`

It adds the ability to parse a UUID as part of the ship design.

It makes all ShipDesign creators, server for default designs and monsters, and clients AI and human correctly add either an existing from disk UUID or a new random UUID to ship designs.

The ShipDesignOrder correctly transfers UUIDs to the server.

It adds a UUID to each default design and monster.
