### PR TITLE
Fix ListBox handling of dropped windows.

### DIFF
--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -97,13 +97,7 @@ extern GG_API const ListBoxStyle LIST_BROWSEUPDATES;  ///< Causes a signal to be
     <br>Note that drag-and-drop support is a key part of ListBox's
     functionality.  As such, special effort has been made to make its use as
     natural and flexible as possible.  This includes allowing arbitrary
-    reordering of ListBox rows when the LIST_NOSORT is in effect, and includes
-    the use of the DontAcceptDrop exception.  The DontAcceptDrop exception can
-    be thrown by any client of the ListBox in response to its
-    DropAcceptableSignal.  Such a throw will cause the drop to be refused.
-    Note that a DropAcceptableSignal is emitted for each row dropped into the
-    ListBox, so individual rows may be accepted or rejected from a single
-    multi-row drop. */
+    reordering of ListBox rows when the LIST_NOSORT is in effect.*/
 class GG_API ListBox : public Control
 {
 public:
@@ -495,13 +489,6 @@ public:
     };
 
     /** \name Exceptions */ ///@{
-    /** The base class for ListBox exceptions. */
-    GG_ABSTRACT_EXCEPTION(Exception);
-
-    /** Thrown by a ListBox that does not wish to accept a potential drop, for
-        whatever reason. This may be throw by anyone -- even in client code
-        activated by a DropAcceptableSignal. */
-    GG_CONCRETE_EXCEPTION(DontAcceptDrop, GG::ListBox, Exception);
     //@}
 
 protected:

--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -223,9 +223,9 @@ public:
 
     /** \name Signal Types */ ///@{
     /** emitted when the list box is cleared */
-    typedef boost::signals2::signal<void ()>                                                ClearedSignalType;
+    typedef boost::signals2::signal<void ()>                                                ClearedRowsSignalType;
     /** emitted when one or more rows are selected or deselected */
-    typedef boost::signals2::signal<void (const SelectionSet&)>                             SelChangedSignalType;
+    typedef boost::signals2::signal<void (const SelectionSet&)>                             SelRowsChangedSignalType;
     /** the signature of row-change-notification signals */
     typedef boost::signals2::signal<void (iterator)>                                        RowSignalType;
     /** the signature of const row-change-notification signals */
@@ -233,18 +233,18 @@ public:
     /** the signature of row-click-notification signals */
     typedef boost::signals2::signal<void(iterator, const Pt&,const GG::Flags<GG::ModKey>&)> RowClickSignalType;
     /** the signature of row-move-notification signals */
-    typedef boost::signals2::signal<void (iterator, iterator)>                              RowMovedSignalType;
+    typedef boost::signals2::signal<void (iterator, iterator)>                              MovedRowSignalType;
 
-    typedef RowSignalType      BeforeInsertSignalType;   ///< emitted before a row is inserted into the list box
-    typedef RowSignalType      AfterInsertSignalType;    ///< emitted after a row is inserted into the list box
-    typedef RowSignalType      DroppedSignalType;        ///< emitted when a row is inserted into the list box via drag-and-drop
-    typedef ConstRowSignalType DropAcceptableSignalType; ///< emitted when a row may be inserted into the list box via drag-and-drop
-    typedef RowClickSignalType LeftClickedSignalType;    ///< emitted when a row in the listbox is left-clicked; provides the row left-clicked and the clicked point
-    typedef RowClickSignalType RightClickedSignalType;   ///< emitted when a row in the listbox is right-clicked; provides the row right-clicked and the clicked point
-    typedef RowClickSignalType DoubleClickedSignalType;  ///< emitted when a row in the listbox is left-double-clicked
-    typedef RowSignalType      BeforeEraseSignalType;    ///< emitted when a row in the listbox is erased; provides the deleted Row, and is emitted before the row is removed
-    typedef RowSignalType      AfterEraseSignalType;     ///< emitted when a row in the listbox is erased; provides the deleted Row, and is emitted after the row is removed
-    typedef RowSignalType      BrowsedSignalType;        ///< emitted when a row in the listbox is "browsed" (rolled over) by the cursor; provides the browsed row
+    typedef RowSignalType      BeforeInsertRowSignalType;   ///< emitted before a row is inserted into the list box
+    typedef RowSignalType      AfterInsertRowSignalType;    ///< emitted after a row is inserted into the list box
+    typedef RowSignalType      DroppedRowSignalType;        ///< emitted when a row is inserted into the list box via drag-and-drop
+    typedef ConstRowSignalType DropRowAcceptableSignalType; ///< emitted when a row may be inserted into the list box via drag-and-drop
+    typedef RowClickSignalType LeftClickedRowSignalType;    ///< emitted when a row in the listbox is left-clicked; provides the row left-clicked and the clicked point
+    typedef RowClickSignalType RightClickedRowSignalType;   ///< emitted when a row in the listbox is right-clicked; provides the row right-clicked and the clicked point
+    typedef RowClickSignalType DoubleClickedRowSignalType;  ///< emitted when a row in the listbox is left-double-clicked
+    typedef RowSignalType      BeforeEraseRowSignalType;    ///< emitted when a row in the listbox is erased; provides the deleted Row, and is emitted before the row is removed
+    typedef RowSignalType      AfterEraseRowSignalType;     ///< emitted when a row in the listbox is erased; provides the deleted Row, and is emitted after the row is removed
+    typedef RowSignalType      BrowsedRowSignalType;        ///< emitted when a row in the listbox is "browsed" (rolled over) by the cursor; provides the browsed row
     //@}
 
     /** \name Constants */ ///@{
@@ -324,19 +324,19 @@ public:
     bool AllowingDrops();
 
 
-    mutable ClearedSignalType        ClearedSignal;         /// the cleared signal object for this ListBox
-    mutable BeforeInsertSignalType   BeforeInsertSignal;    ///< the before insert signal object for this ListBox
-    mutable AfterInsertSignalType    AfterInsertSignal;     ///< the after insert signal object for this ListBox
-    mutable SelChangedSignalType     SelChangedSignal;      ///< the selection change signal object for this ListBox
-    mutable DroppedSignalType        DroppedSignal;         ///< the dropped signal object for this ListBox
-    mutable DropAcceptableSignalType DropAcceptableSignal;  ///< the drop-acceptability signal object for this ListBox
-    mutable RowMovedSignalType       MovedSignal;           ///< the moved signal object for this ListBox
-    mutable LeftClickedSignalType    LeftClickedSignal;     ///< the left click signal object for this ListBox
-    mutable RightClickedSignalType   RightClickedSignal;    ///< the right click signal object for this ListBox
-    mutable DoubleClickedSignalType  DoubleClickedSignal;   ///< the double click signal object for this ListBox
-    mutable BeforeEraseSignalType    BeforeEraseSignal;     ///< the before erase signal object for this ListBox
-    mutable AfterEraseSignalType     AfterEraseSignal;      ///< the after erase signal object for this ListBox
-    mutable BrowsedSignalType        BrowsedSignal;         ///< the browsed signal object for this ListBox
+    mutable ClearedRowsSignalType        ClearedRowsSignal;        /// the cleared signal object for this ListBox
+    mutable BeforeInsertRowSignalType    BeforeInsertRowSignal;    ///< the before insert signal object for this ListBox
+    mutable AfterInsertRowSignalType     AfterInsertRowSignal;     ///< the after insert signal object for this ListBox
+    mutable SelRowsChangedSignalType     SelRowsChangedSignal;     ///< the selection change signal object for this ListBox
+    mutable DroppedRowSignalType         DroppedRowSignal;         ///< the dropped signal object for this ListBox
+    mutable DropRowAcceptableSignalType  DropRowAcceptableSignal;  ///< the drop-acceptability signal object for this ListBox
+    mutable MovedRowSignalType           MovedRowSignal;           ///< the moved signal object for this ListBox
+    mutable LeftClickedRowSignalType     LeftClickedRowSignal;     ///< the left click signal object for this ListBox
+    mutable RightClickedRowSignalType    RightClickedRowSignal;    ///< the right click signal object for this ListBox
+    mutable DoubleClickedRowSignalType   DoubleClickedRowSignal;   ///< the double click signal object for this ListBox
+    mutable BeforeEraseRowSignalType     BeforeEraseRowSignal;     ///< the before erase signal object for this ListBox
+    mutable AfterEraseRowSignalType      AfterEraseRowSignal;      ///< the after erase signal object for this ListBox
+    mutable BrowsedRowSignalType         BrowsedRowSignal;         ///< the browsed signal object for this ListBox
     //@}
 
     /** \name Mutators */ ///@{

--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -300,10 +300,9 @@ public:
     double          ColStretch(std::size_t n) const;   ///< Return the stretch factor of column \a n.
     Alignment       RowAlignment(iterator it) const;   ///< returns the alignment of row \a it; must be ALIGN_TOP, ALIGN_VCENTER, or ALIGN_BOTTOM; not range-checked
 
-    /** Returns the set of data types allowed to be dropped over this ListBox
-        when drag-and-drop is enabled. \note If this set contains "", all drop
-        types are allowed. */
-    const std::set<std::string>& AllowedDropTypes() const;
+    /** Returns true iff \p type is allowed to be dropped over this ListBox
+        when drag-and-drop is enabled. */
+    bool AllowedDropType(const std::string& type) const;
 
     /** Whether the list should autoscroll when the user is attempting to drop
         an item into a location that is not currently visible. */

--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -469,12 +469,6 @@ public:
         drag-and-drop is enabled. \note Passing "" enables all drop types. */
     void            AllowDropType(const std::string& str);
 
-    /** Disallows Rows with data type \a str to be dropped over this ListBox
-        when drag-and-drop is enabled. \note If "" is still an allowed drop
-        type, drops of type \a str will still be allowed, even after disallowed
-        with a call to this function. */
-    void            DisallowDropType(const std::string& str);
-
     /** Set this to determine whether the list should autoscroll when the user
         is attempting to drop an item into a location that is not currently
         visible. */

--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -316,6 +316,10 @@ public:
         auto-scrolling. */
     unsigned int    AutoScrollInterval() const;
 
+    /** Return true if drops are allowed.*/
+    bool AllowingDrops();
+
+
     mutable ClearedSignalType        ClearedSignal;         /// the cleared signal object for this ListBox
     mutable BeforeInsertSignalType   BeforeInsertSignal;    ///< the before insert signal object for this ListBox
     mutable AfterInsertSignalType    AfterInsertSignal;     ///< the after insert signal object for this ListBox
@@ -450,6 +454,8 @@ public:
      *  the top (true), or only use as much space as it needs. */
     void            AddPaddingAtEnd(bool enable = true);
 
+    /** Allow drops if \p allow is true.*/
+    void            AllowDrops(bool allow);
     /** Allows Rows with data type \a str to be dropped over this ListBox when
         drag-and-drop is enabled. \note Passing "" enables all drop types. */
     void            AllowDropType(const std::string& str);
@@ -622,6 +628,8 @@ private:
                     m_sort_cmp;         ///< the predicate used to sort the values in the m_sort_col column of two rows
     std::set<std::string>
                     m_allowed_drop_types;///< the line item types allowed for use in this listbox
+
+    bool            m_allow_drops;      ///< are we accepting drops
 
     bool            m_auto_scroll_during_drag_drops;
     unsigned int    m_auto_scroll_margin;

--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -232,6 +232,8 @@ public:
     typedef boost::signals2::signal<void (const_iterator)>                                  ConstRowSignalType;
     /** the signature of row-click-notification signals */
     typedef boost::signals2::signal<void(iterator, const Pt&,const GG::Flags<GG::ModKey>&)> RowClickSignalType;
+    /** the signature of row-move-notification signals */
+    typedef boost::signals2::signal<void (iterator, iterator)>                              RowMovedSignalType;
 
     typedef RowSignalType      BeforeInsertSignalType;   ///< emitted before a row is inserted into the list box
     typedef RowSignalType      AfterInsertSignalType;    ///< emitted after a row is inserted into the list box
@@ -328,6 +330,7 @@ public:
     mutable SelChangedSignalType     SelChangedSignal;      ///< the selection change signal object for this ListBox
     mutable DroppedSignalType        DroppedSignal;         ///< the dropped signal object for this ListBox
     mutable DropAcceptableSignalType DropAcceptableSignal;  ///< the drop-acceptability signal object for this ListBox
+    mutable RowMovedSignalType       MovedSignal;           ///< the moved signal object for this ListBox
     mutable LeftClickedSignalType    LeftClickedSignal;     ///< the left click signal object for this ListBox
     mutable RightClickedSignalType   RightClickedSignal;    ///< the right click signal object for this ListBox
     mutable DoubleClickedSignalType  DoubleClickedSignal;   ///< the double click signal object for this ListBox

--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -35,6 +35,8 @@
 #include <GG/Control.h>
 #include <GG/Timer.h>
 
+#include <boost/optional/optional.hpp>
+
 #include <memory>
 #include <set>
 #include <unordered_set>
@@ -456,6 +458,10 @@ public:
 
     /** Allow drops if \p allow is true.*/
     void            AllowDrops(bool allow);
+
+    /** Allow all drop types if \p allow is true.*/
+    void            AllowAllDropTypes(bool allow);
+
     /** Allows Rows with data type \a str to be dropped over this ListBox when
         drag-and-drop is enabled. \note Passing "" enables all drop types. */
     void            AllowDropType(const std::string& str);
@@ -626,10 +632,13 @@ private:
     std::size_t     m_sort_col;         ///< the index of the column data used to sort the list
     boost::function<bool (const Row&, const Row&, std::size_t)>
                     m_sort_cmp;         ///< the predicate used to sort the values in the m_sort_col column of two rows
-    std::set<std::string>
-                    m_allowed_drop_types;///< the line item types allowed for use in this listbox
 
     bool            m_allow_drops;      ///< are we accepting drops
+
+    /** Set to boost::none to allow all types.  Otherwise each string is an
+        allowed type.*/
+    boost::optional<std::unordered_set<std::string>>
+                    m_allowed_drop_types;
 
     bool            m_auto_scroll_during_drag_drops;
     unsigned int    m_auto_scroll_margin;

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -161,9 +161,9 @@ ModalListPicker::ModalListPicker(Clr color, const DropDownList* relative_to_wnd,
     m_relative_to_wnd(relative_to_wnd),
     m_dropped(false)
 {
-    m_lb_wnd->SelChangedSignal.connect(
+    m_lb_wnd->SelRowsChangedSignal.connect(
         boost::bind(&ModalListPicker::LBSelChangedSlot, this, _1));
-    m_lb_wnd->LeftClickedSignal.connect(
+    m_lb_wnd->LeftClickedRowSignal.connect(
         boost::bind(&ModalListPicker::LBLeftClickSlot, this, _1, _2, _3));
     GUI::GetGUI()->WindowResizedSignal.connect(
         boost::bind(&ModalListPicker::WindowResizedSlot, this, _1, _2));

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -805,10 +805,15 @@ void ListBox::StartingChildDragDrop(const Wnd* wnd, const Pt& offset)
 void ListBox::AcceptDrops(const Pt& pt, const std::vector<Wnd*>& wnds, Flags<ModKey> mod_keys)
 {
     iterator insertion_it = RowUnderPt(pt);
+    bool inserting_at_first_row = insertion_it == m_first_row_shown;
     for (Wnd* wnd : wnds) {
         Row* row = boost::polymorphic_downcast<Row*>(wnd);
         Insert(row, insertion_it, true, true);
     }
+
+    // Adjust to show rows inserted before the first row.
+    if (inserting_at_first_row)
+        SetFirstRowShown(std::prev(m_first_row_shown, wnds.size()));
 }
 
 void ListBox::ChildrenDraggedAway(const std::vector<Wnd*>& wnds, const Wnd* destination)

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -1467,14 +1467,6 @@ void ListBox::AllowDropType(const std::string& str)
     m_allowed_drop_types->insert(str);
 }
 
-void ListBox::DisallowDropType(const std::string& str)
-{
-    // Create the set if necessary
-    if (!m_allowed_drop_types)
-        m_allowed_drop_types = std::unordered_set<std::string>();
-    m_allowed_drop_types->erase(str);
-}
-
 void ListBox::AutoScrollDuringDragDrops(bool auto_scroll)
 { m_auto_scroll_during_drag_drops = auto_scroll; }
 

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -548,6 +548,7 @@ ListBox::ListBox(Clr color, Clr interior/* = CLR_ZERO*/) :
     m_clip_cells(false),
     m_sort_col(0),
     m_sort_cmp(DefaultRowCmp<Row>()),
+    m_allow_drops(false),
     m_auto_scroll_during_drag_drops(true),
     m_auto_scroll_margin(8),
     m_auto_scrolling_up(false),
@@ -585,6 +586,11 @@ ListBox::ListBox(Clr color, Clr interior/* = CLR_ZERO*/) :
 ListBox::~ListBox()
 { delete m_header_row; }
 
+void ListBox::AllowDrops(bool allow)
+{ m_allow_drops = allow; }
+
+bool ListBox::AllowingDrops()
+{ return m_allow_drops; }
 void ListBox::DropsAcceptable(DropsAcceptableIter first, DropsAcceptableIter last,
                               const Pt& pt, Flags<ModKey> mod_keys) const
 {

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -804,10 +804,9 @@ void ListBox::StartingChildDragDrop(const Wnd* wnd, const Pt& offset)
 
 void ListBox::AcceptDrops(const Pt& pt, const std::vector<Wnd*>& wnds, Flags<ModKey> mod_keys)
 {
-    // TODO: Pull the call to RowUnderPt() out and reuse the value in each loop iteration.
+    iterator insertion_it = RowUnderPt(pt);
     for (Wnd* wnd : wnds) {
         Row* row = boost::polymorphic_downcast<Row*>(wnd);
-        iterator insertion_it = RowUnderPt(pt);
         Insert(row, insertion_it, true, true);
     }
 }

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -570,17 +570,17 @@ ListBox::ListBox(Clr color, Clr interior/* = CLR_ZERO*/) :
     InstallEventFilter(this);
 
     if (INSTRUMENT_ALL_SIGNALS) {
-        ClearedSignal.connect(ListSignalEcho(*this, "ListBox::ClearedSignal"));
-        BeforeInsertSignal.connect(ListSignalEcho(*this, "ListBox::BeforeInsertSignal"));
-        AfterInsertSignal.connect(ListSignalEcho(*this, "ListBox::AfterinsertSignal"));
-        SelChangedSignal.connect(ListSignalEcho(*this, "ListBox::SelChangedSignal"));
-        DroppedSignal.connect(ListSignalEcho(*this, "ListBox::DroppedSignal"));
-        LeftClickedSignal.connect(ListSignalEcho(*this, "ListBox::LeftClickedSignal"));
-        RightClickedSignal.connect(ListSignalEcho(*this, "ListBox::RightClickedSignal"));
-        DoubleClickedSignal.connect(ListSignalEcho(*this, "ListBox::DoubleClickedSignal"));
-        BeforeEraseSignal.connect(ListSignalEcho(*this, "ListBox::BeforeEraseSignal"));
-        AfterEraseSignal.connect(ListSignalEcho(*this, "ListBox::AfterEraseSignal"));
-        BrowsedSignal.connect(ListSignalEcho(*this, "ListBox::BrowsedSignal"));
+        ClearedRowsSignal.connect(ListSignalEcho(*this, "ListBox::ClearedRowsSignal"));
+        BeforeInsertRowSignal.connect(ListSignalEcho(*this, "ListBox::BeforeInsertRowSignal"));
+        AfterInsertRowSignal.connect(ListSignalEcho(*this, "ListBox::AfterinsertRowSignal"));
+        SelRowsChangedSignal.connect(ListSignalEcho(*this, "ListBox::SelRowsChangedSignal"));
+        DroppedRowSignal.connect(ListSignalEcho(*this, "ListBox::DroppedRowSignal"));
+        LeftClickedRowSignal.connect(ListSignalEcho(*this, "ListBox::LeftClickedRowSignal"));
+        RightClickedRowSignal.connect(ListSignalEcho(*this, "ListBox::RightClickedRowSignal"));
+        DoubleClickedRowSignal.connect(ListSignalEcho(*this, "ListBox::DoubleClickedRowSignal"));
+        BeforeEraseRowSignal.connect(ListSignalEcho(*this, "ListBox::BeforeEraseRowSignal"));
+        AfterEraseRowSignal.connect(ListSignalEcho(*this, "ListBox::AfterEraseRowSignal"));
+        BrowsedRowSignal.connect(ListSignalEcho(*this, "ListBox::BrowsedRowSignal"));
     }
 }
 
@@ -621,7 +621,7 @@ void ListBox::HandleRowRightClicked(const Pt& pt, GG::Flags<GG::ModKey> mod) {
     iterator row_it = RowUnderPt(pt);
     if (row_it != m_rows.end()) {
         m_rclick_row = row_it;
-        RightClickedSignal(row_it, pt, mod);
+        RightClickedRowSignal(row_it, pt, mod);
     }
 }
 
@@ -852,7 +852,7 @@ void ListBox::ChildrenDraggedAway(const std::vector<Wnd*>& wnds, const Wnd* dest
         m_selections = new_selections;
 
         if (m_selections.size() != initially_selected_rows.size()) {
-            SelChangedSignal(m_selections);
+            SelRowsChangedSignal(m_selections);
         }
     }
 }
@@ -1106,7 +1106,7 @@ void ListBox::Clear()
     m_hscroll = nullptr;
 
     RequirePreRender();
-    ClearedSignal();
+    ClearedRowsSignal();
 }
 
 void ListBox::SelectRow(iterator it, bool signal/* = false*/)
@@ -1126,7 +1126,7 @@ void ListBox::SelectRow(iterator it, bool signal/* = false*/)
     m_selections.insert(it);
 
     if (signal && previous_selections != m_selections)
-        SelChangedSignal(m_selections);
+        SelRowsChangedSignal(m_selections);
 }
 
 void ListBox::DeselectRow(iterator it, bool signal/* = false*/)
@@ -1139,7 +1139,7 @@ void ListBox::DeselectRow(iterator it, bool signal/* = false*/)
         m_selections.erase(it);
 
     if (signal && previous_selections != m_selections)
-        SelChangedSignal(m_selections);
+        SelRowsChangedSignal(m_selections);
 }
 
 void ListBox::SelectAll(bool signal/* = false*/)
@@ -1162,7 +1162,7 @@ void ListBox::SelectAll(bool signal/* = false*/)
     }
 
     if (signal && previous_selections != m_selections)
-        SelChangedSignal(m_selections);
+        SelRowsChangedSignal(m_selections);
 }
 
 void ListBox::DeselectAll(bool signal/* = false*/)
@@ -1175,7 +1175,7 @@ void ListBox::DeselectAll(bool signal/* = false*/)
     }
 
     if (signal && previous_selections != m_selections)
-        SelChangedSignal(m_selections);
+        SelRowsChangedSignal(m_selections);
 }
 
 ListBox::iterator ListBox::begin()
@@ -1200,7 +1200,7 @@ void ListBox::SetSelections(const SelectionSet& s, bool signal/* = false*/)
     m_selections = s;
 
     if (signal && previous_selections != m_selections)
-        SelChangedSignal(m_selections);
+        SelRowsChangedSignal(m_selections);
 }
 
 void ListBox::SetCaret(iterator it)
@@ -1758,7 +1758,7 @@ bool ListBox::EventFilter(Wnd* w, const WndEvent& event)
                 else
                     ClickAtRow(sel_row, mod_keys);
                 m_lclick_row = sel_row;
-                LeftClickedSignal(sel_row, pt, mod_keys);
+                LeftClickedRowSignal(sel_row, pt, mod_keys);
             }
         }
         break;
@@ -1767,7 +1767,7 @@ bool ListBox::EventFilter(Wnd* w, const WndEvent& event)
     case WndEvent::LDoubleClick: {
         iterator row = RowUnderPt(pt);
         if (row != m_rows.end() && row == m_lclick_row && InClient(pt)) {
-            DoubleClickedSignal(row, pt, mod_keys);
+            DoubleClickedRowSignal(row, pt, mod_keys);
             m_old_sel_row = m_rows.end();
         } else {
             LClick(pt, mod_keys);
@@ -1788,7 +1788,7 @@ bool ListBox::EventFilter(Wnd* w, const WndEvent& event)
         iterator row = RowUnderPt(pt);
         if (row != m_rows.end() && row == m_old_rdown_row && InClient(pt)) {
             m_rclick_row = row;
-            RightClickedSignal(row, pt, mod_keys);
+            RightClickedRowSignal(row, pt, mod_keys);
         }
         m_old_rdown_row = m_rows.end();
         break;
@@ -1798,7 +1798,7 @@ bool ListBox::EventFilter(Wnd* w, const WndEvent& event)
         if (m_style & LIST_BROWSEUPDATES) {
             iterator sel_row = RowUnderPt(pt);
             if (m_last_row_browsed != sel_row)
-                BrowsedSignal(m_last_row_browsed = sel_row);
+                BrowsedRowSignal(m_last_row_browsed = sel_row);
         }
         break;
     }
@@ -1809,7 +1809,7 @@ bool ListBox::EventFilter(Wnd* w, const WndEvent& event)
     case WndEvent::MouseLeave: {
         if (m_style & LIST_BROWSEUPDATES) {
             if (m_last_row_browsed != m_rows.end())
-                BrowsedSignal(m_last_row_browsed = m_rows.end());
+                BrowsedRowSignal(m_last_row_browsed = m_rows.end());
         }
         break;
     }
@@ -1911,7 +1911,7 @@ ListBox::iterator ListBox::Insert(Row* row, iterator it, bool dropped, bool sign
     row->InstallEventFilter(this);
 
     if (signal)
-        BeforeInsertSignal(it);
+        BeforeInsertRowSignal(it);
 
     if (m_rows.empty()) {
         m_rows.push_back(row);
@@ -1946,11 +1946,11 @@ ListBox::iterator ListBox::Insert(Row* row, iterator it, bool dropped, bool sign
     row->RightClickedSignal.connect(boost::bind(&ListBox::HandleRowRightClicked, this, _1, _2));
 
     if (signal) {
-        AfterInsertSignal(it);
+        AfterInsertRowSignal(it);
         if (dropped)
-            DroppedSignal(retval);
+            DroppedRowSignal(retval);
         if (moved)
-            MovedSignal(retval, original_dropped_position);
+            MovedRowSignal(retval, original_dropped_position);
     }
 
     RequirePreRender();
@@ -2483,7 +2483,7 @@ void ListBox::ClickAtRow(iterator it, Flags<ModKey> mod_keys)
     }
 
     if (previous_selections != m_selections)
-        SelChangedSignal(m_selections);
+        SelRowsChangedSignal(m_selections);
 }
 
 void ListBox::NormalizeRow(Row* row)

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -573,7 +573,6 @@ ListBox::ListBox(Clr color, Clr interior/* = CLR_ZERO*/) :
         AfterInsertSignal.connect(ListSignalEcho(*this, "ListBox::AfterinsertSignal"));
         SelChangedSignal.connect(ListSignalEcho(*this, "ListBox::SelChangedSignal"));
         DroppedSignal.connect(ListSignalEcho(*this, "ListBox::DroppedSignal"));
-        DropAcceptableSignal.connect(ListSignalEcho(*this, "ListBox::DropAcceptableSignal"));
         LeftClickedSignal.connect(ListSignalEcho(*this, "ListBox::LeftClickedSignal"));
         RightClickedSignal.connect(ListSignalEcho(*this, "ListBox::RightClickedSignal"));
         DoubleClickedSignal.connect(ListSignalEcho(*this, "ListBox::DoubleClickedSignal"));
@@ -596,11 +595,7 @@ void ListBox::DropsAcceptable(DropsAcceptableIter first, DropsAcceptableIter las
             (m_allowed_drop_types.find("") != m_allowed_drop_types.end() ||
              m_allowed_drop_types.find(row->DragDropDataType()) != m_allowed_drop_types.end()))
         {
-            iterator insertion_it = RowUnderPt(pt);
-            try {
-                DropAcceptableSignal(insertion_it);
-                it->second = true;
-            } catch (const DontAcceptDrop&) {}
+            it->second = true;
         }
     }
 }

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -727,8 +727,8 @@ Alignment ListBox::RowAlignment(iterator it) const
 double ListBox::ColStretch(std::size_t n) const
 { return m_col_stretches[n]; }
 
-const std::set<std::string>& ListBox::AllowedDropTypes() const
-{ return m_allowed_drop_types; }
+bool ListBox::AllowedDropType(const std::string& type) const
+{ return m_allowed_drop_types.count("") || m_allowed_drop_types.count(type); }
 
 bool ListBox::AutoScrollDuringDragDrops() const
 { return m_auto_scroll_during_drag_drops; }

--- a/GG/src/dialogs/FileDlg.cpp
+++ b/GG/src/dialogs/FileDlg.cpp
@@ -222,9 +222,9 @@ FileDlg::FileDlg(const std::string& directory, const std::string& filename, bool
         boost::bind(&FileDlg::OkClicked, this));
     m_cancel_button->LeftClickedSignal.connect(
         boost::bind(&FileDlg::CancelClicked, this));
-    m_files_list->SelChangedSignal.connect(
+    m_files_list->SelRowsChangedSignal.connect(
         boost::bind(&FileDlg::FileSetChanged, this, _1));
-    m_files_list->DoubleClickedSignal.connect(
+    m_files_list->DoubleClickedRowSignal.connect(
         boost::bind(&FileDlg::FileDoubleClicked, this, _1, _2, _3));
     m_files_edit->EditedSignal.connect(
         boost::bind(&FileDlg::FilesEditChanged, this, _1));

--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -543,11 +543,11 @@ BuildDesignatorWnd::BuildSelector::BuildSelector(const std::string& config_name)
 
     // selectable list of buildable items
     AttachChild(m_buildable_items);
-    m_buildable_items->LeftClickedSignal.connect(
+    m_buildable_items->LeftClickedRowSignal.connect(
         boost::bind(&BuildDesignatorWnd::BuildSelector::BuildItemLeftClicked, this, _1, _2, _3));
-    m_buildable_items->DoubleClickedSignal.connect(
+    m_buildable_items->DoubleClickedRowSignal.connect(
         boost::bind(&BuildDesignatorWnd::BuildSelector::BuildItemDoubleClicked, this, _1, _2, _3));
-    m_buildable_items->RightClickedSignal.connect(
+    m_buildable_items->RightClickedRowSignal.connect(
         boost::bind(&BuildDesignatorWnd::BuildSelector::BuildItemRightClicked, this, _1, _2, _3));
 
     //GG::ListBox::Row* header = new GG::ListBox::Row();

--- a/UI/CUIControls.cpp
+++ b/UI/CUIControls.cpp
@@ -714,9 +714,9 @@ void CUIScroll::SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
 CUIListBox::CUIListBox(void):
     ListBox(ClientUI::CtrlBorderColor(), ClientUI::CtrlColor())
 {
-    SelChangedSignal.connect(-1,
+    SelRowsChangedSignal.connect(-1,
         &PlayListSelectSound);
-    DroppedSignal.connect(-1,
+    DroppedRowSignal.connect(-1,
         &PlayItemDropSound);
 }
 

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -1544,11 +1544,13 @@ void BasesListBox::ChildrenDraggedAway(const std::vector<GG::Wnd*>& wnds, const 
     DetachChild(wnds.front());
 }
 
-void BasesListBox::QueueItemMoved(const GG::ListBox::iterator& row_it, const GG::ListBox::iterator& original_position_it) {
+void BasesListBox::QueueItemMoved(const GG::ListBox::iterator& row_it,
+                                  const GG::ListBox::iterator& original_position_it)
+{
     if (BasesListBox::CompletedDesignListBoxRow* control =
         dynamic_cast<BasesListBox::CompletedDesignListBoxRow*>(*row_it))
     {
-        if(!GetEmpire(m_empire_id_shown))
+        if (!GetEmpire(m_empire_id_shown))
            return;
 
         int design_id = control->DesignID();
@@ -1563,7 +1565,6 @@ void BasesListBox::QueueItemMoved(const GG::ListBox::iterator& row_it, const GG:
         control->Resize(ListRowSize());
         HumanClientApp::GetApp()->Orders()
             .IssueOrder(std::make_shared<ShipDesignOrder>(m_empire_id_shown, design_id, insert_before_id));
-        return;
     }
 }
 

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -1461,11 +1461,11 @@ BasesListBox::BasesListBox(const boost::optional<std::string>& drop_type) :
     InitRowSizes();
     SetStyle(GG::LIST_NOSEL | GG::LIST_NOSORT);
 
-    DoubleClickedSignal.connect(
+    DoubleClickedRowSignal.connect(
         boost::bind(&BasesListBox::BaseDoubleClicked, this, _1, _2, _3));
-    LeftClickedSignal.connect(
+    LeftClickedRowSignal.connect(
         boost::bind(&BasesListBox::BaseLeftClicked, this, _1, _2, _3));
-    MovedSignal.connect(
+    MovedRowSignal.connect(
         boost::bind(&BasesListBox::QueueItemMoved, this, _1, _2));
 }
 

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -1183,7 +1183,7 @@ public:
     static const std::string BASES_LIST_BOX_DROP_TYPE;
 
     /** \name Structors */ //@{
-    BasesListBox(const std::string& drop_type = "");
+    BasesListBox(const boost::optional<std::string>& drop_type = boost::none);
     //@}
 
     /** \name Accessors */ //@{
@@ -1448,7 +1448,7 @@ bool BasesListBox::SavedDesignListBoxRow::LookupInStringtable() const {
 
 const std::string BasesListBox::BASES_LIST_BOX_DROP_TYPE = "BasesListBoxRow";
 
-BasesListBox::BasesListBox(const std::string& drop_type) :
+BasesListBox::BasesListBox(const boost::optional<std::string>& drop_type) :
     QueueListBox(drop_type,  UserString("ADD_FIRST_DESIGN_DESIGN_QUEUE_PROMPT")),
     m_empire_id_shown(ALL_EMPIRES),
     m_availabilities_shown{false, false},

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -1183,7 +1183,7 @@ public:
     static const std::string BASES_LIST_BOX_DROP_TYPE;
 
     /** \name Structors */ //@{
-    BasesListBox(const boost::optional<std::string>& drop_type = boost::none);
+    explicit BasesListBox(const boost::optional<std::string>& drop_type = boost::none);
     //@}
 
     /** \name Accessors */ //@{

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -2231,7 +2231,7 @@ public:
         for (GG::ListBox::Row* row : rows)
         { row->Resize(row_size); }
 
-        SelChangedSignal(this->Selections());
+        SelRowsChangedSignal(this->Selections());
     }
 
     void            SetFleet(int fleet_id) {
@@ -2388,9 +2388,9 @@ FleetDetailPanel::FleetDetailPanel(GG::X w, GG::Y h, int fleet_id, bool order_is
         m_ships_lb->AllowDropType(SHIP_DROP_TYPE_STRING);
     }
 
-    m_ships_lb->SelChangedSignal.connect(
+    m_ships_lb->SelRowsChangedSignal.connect(
         boost::bind(&FleetDetailPanel::ShipSelectionChanged, this, _1));
-    m_ships_lb->RightClickedSignal.connect(
+    m_ships_lb->RightClickedRowSignal.connect(
         boost::bind(&FleetDetailPanel::ShipRightClicked, this, _1, _2, _3));
     GetUniverse().UniverseObjectDeleteSignal.connect(
         boost::bind(&FleetDetailPanel::UniverseObjectDeleted, this, _1));
@@ -2702,13 +2702,13 @@ FleetWnd::FleetWnd(const std::vector<int>& fleet_ids, bool order_issuing_enabled
     // create fleet list box
     m_fleets_lb = new FleetsListBox(m_order_issuing_enabled);
     m_fleets_lb->SetHiliteColor(GG::CLR_ZERO);
-    m_fleets_lb->SelChangedSignal.connect(
+    m_fleets_lb->SelRowsChangedSignal.connect(
         boost::bind(&FleetWnd::FleetSelectionChanged, this, _1));
-    m_fleets_lb->LeftClickedSignal.connect(
+    m_fleets_lb->LeftClickedRowSignal.connect(
         boost::bind(&FleetWnd::FleetLeftClicked, this, _1, _2, _3));
-    m_fleets_lb->RightClickedSignal.connect(
+    m_fleets_lb->RightClickedRowSignal.connect(
         boost::bind(&FleetWnd::FleetRightClicked, this, _1, _2, _3));
-    m_fleets_lb->DoubleClickedSignal.connect(
+    m_fleets_lb->DoubleClickedRowSignal.connect(
         boost::bind(&FleetWnd::FleetDoubleClicked, this, _1, _2, _3));
     AttachChild(m_fleets_lb);
     m_fleets_lb->SetStyle(GG::LIST_NOSORT | GG::LIST_BROWSEUPDATES);

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -2257,11 +2257,11 @@ ObjectListWnd::ObjectListWnd(const std::string& config_name) :
     m_list_box->SetHiliteColor(GG::CLR_ZERO);
     m_list_box->SetStyle(GG::LIST_NOSORT);
 
-    m_list_box->SelChangedSignal.connect(
+    m_list_box->SelRowsChangedSignal.connect(
         boost::bind(&ObjectListWnd::ObjectSelectionChanged, this, _1));
-    m_list_box->DoubleClickedSignal.connect(
+    m_list_box->DoubleClickedRowSignal.connect(
         boost::bind(&ObjectListWnd::ObjectDoubleClicked, this, _1, _2, _3));
-    m_list_box->RightClickedSignal.connect(
+    m_list_box->RightClickedRowSignal.connect(
         boost::bind(&ObjectListWnd::ObjectRightClicked, this, _1, _2, _3));
     m_list_box->ExpandCollapseSignal.connect(
         boost::bind(&ObjectListWnd::DoLayout, this));

--- a/UI/PlayerListWnd.cpp
+++ b/UI/PlayerListWnd.cpp
@@ -542,11 +542,11 @@ PlayerListWnd::PlayerListWnd(const std::string& config_name) :
     m_player_list = new PlayerListBox();
     m_player_list->SetHiliteColor(GG::CLR_ZERO);
     m_player_list->SetStyle(GG::LIST_NOSORT);
-    m_player_list->SelChangedSignal.connect(
+    m_player_list->SelRowsChangedSignal.connect(
         boost::bind(&PlayerListWnd::PlayerSelectionChanged, this, _1));
-    m_player_list->DoubleClickedSignal.connect(
+    m_player_list->DoubleClickedRowSignal.connect(
         boost::bind(&PlayerListWnd::PlayerDoubleClicked, this, _1, _2, _3));
-    m_player_list->RightClickedSignal.connect(
+    m_player_list->RightClickedRowSignal.connect(
         boost::bind(&PlayerListWnd::PlayerRightClicked, this, _1, _2, _3));
     AttachChild(m_player_list);
 

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -640,7 +640,7 @@ namespace {
 
             auto pedia_action = [&it, this, pt, modkeys]() {
                 ShowPediaSignal();
-                this->LeftClickedSignal(it, pt, modkeys);
+                this->LeftClickedRowSignal(it, pt, modkeys);
             };
             auto resume_action = [&it, this]() { this->QueueItemPausedSignal(it, false); };
             auto pause_action = [&it, this]() { this->QueueItemPausedSignal(it, true); };
@@ -770,13 +770,13 @@ ProductionWnd::ProductionWnd(GG::X w, GG::Y h) :
         boost::bind(&ProductionWnd::ChangeBuildQuantitySlot, this, _1, _2));
     m_build_designator_wnd->SystemSelectedSignal.connect(
         SystemSelectedSignal);
-    m_queue_wnd->GetQueueListBox()->MovedSignal.connect(
+    m_queue_wnd->GetQueueListBox()->MovedRowSignal.connect(
         boost::bind(&ProductionWnd::QueueItemMoved, this, _1, _2));
     m_queue_wnd->GetQueueListBox()->QueueItemDeletedSignal.connect(
         boost::bind(&ProductionWnd::DeleteQueueItem, this, _1));
-    m_queue_wnd->GetQueueListBox()->LeftClickedSignal.connect(
+    m_queue_wnd->GetQueueListBox()->LeftClickedRowSignal.connect(
         boost::bind(&ProductionWnd::QueueItemClickedSlot, this, _1, _2, _3));
-    m_queue_wnd->GetQueueListBox()->DoubleClickedSignal.connect(
+    m_queue_wnd->GetQueueListBox()->DoubleClickedRowSignal.connect(
         boost::bind(&ProductionWnd::QueueItemDoubleClickedSlot, this, _1, _2, _3));
     m_queue_wnd->GetQueueListBox()->QueueItemRalliedToSignal.connect(
         boost::bind(&ProductionWnd::QueueItemRallied, this, _1, _2));

--- a/UI/ProductionWnd.h
+++ b/UI/ProductionWnd.h
@@ -121,7 +121,7 @@ private:
     void    ChangeBuildQuantityBlockSlot(int queue_idx, int quantity, int blocksize);
 
     void    DeleteQueueItem(GG::ListBox::iterator it);
-    void    QueueItemMoved(GG::ListBox::Row* row, std::size_t position);
+    void    QueueItemMoved(const GG::ListBox::iterator& row_it, const GG::ListBox::iterator& original_position_it);
     void    QueueItemClickedSlot(GG::ListBox::iterator it, const GG::Pt& pt, const GG::Flags<GG::ModKey>& modkeys);
     void    QueueItemDoubleClickedSlot(GG::ListBox::iterator it, const GG::Pt& pt, const GG::Flags<GG::ModKey>& modkeys);
     void    QueueItemRallied(GG::ListBox::iterator it, int object_id);

--- a/UI/QueueListBox.cpp
+++ b/UI/QueueListBox.cpp
@@ -99,8 +99,8 @@ void QueueListBox::DropsAcceptable(DropsAcceptableIter first, DropsAcceptableIte
     }
 
     for (DropsAcceptableIter it = first; it != last; ++it) {
-        it->second = m_order_issuing_enabled &&
-            AllowedDropTypes().find(it->first->DragDropDataType()) != AllowedDropTypes().end();
+        it->second = (m_order_issuing_enabled &&
+                      AllowedDropType(it->first->DragDropDataType()));
     }
 }
 
@@ -116,7 +116,7 @@ void QueueListBox::AcceptDrops(const GG::Pt& pt, const std::vector<GG::Wnd*>& wn
     GG::Wnd* wnd = *wnds.begin();
     const std::string& drop_type = wnd->DragDropDataType();
     GG::ListBox::Row* row = boost::polymorphic_downcast<GG::ListBox::Row*>(wnd);
-    if (AllowedDropTypes().find(drop_type) == AllowedDropTypes().end() ||
+    if (!AllowedDropType(drop_type) ||
         !row ||
         std::find(begin(), end(), row) == end())
     {
@@ -163,8 +163,7 @@ void QueueListBox::DragDropHere(const GG::Pt& pt, std::map<const GG::Wnd*, bool>
     CUIListBox::DragDropHere(pt, drop_wnds_acceptable, mod_keys);
 
     if (drop_wnds_acceptable.size() == 1 &&
-        AllowedDropTypes().find(drop_wnds_acceptable.begin()->first->DragDropDataType()) !=
-        AllowedDropTypes().end())
+        AllowedDropType(drop_wnds_acceptable.begin()->first->DragDropDataType()))
     {
         m_drop_point = RowUnderPt(pt);
         m_show_drop_point = true;

--- a/UI/QueueListBox.cpp
+++ b/UI/QueueListBox.cpp
@@ -123,6 +123,7 @@ void QueueListBox::AcceptDrops(const GG::Pt& pt, const std::vector<GG::Wnd*>& wn
         delete wnd;
         return;
     }
+    ListBox::AcceptDrops(pt, std::vector<GG::Wnd*>{wnd}, mod_keys);
     iterator it = RowUnderPt(pt);
     QueueItemMovedSignal(row, std::distance(begin(), it));
 }

--- a/UI/QueueListBox.cpp
+++ b/UI/QueueListBox.cpp
@@ -88,22 +88,6 @@ void QueueListBox::KeyPress(GG::Key key, std::uint32_t key_code_point, GG::Flags
     }
 }
 
-void QueueListBox::DropsAcceptable(DropsAcceptableIter first, DropsAcceptableIter last,
-                                   const GG::Pt& pt, GG::Flags<GG::ModKey> mod_keys) const
-{
-    for (DropsAcceptableIter it = first; it != last; ++it)
-        it->second = false;
-
-    if (std::distance(first, last) != 1) {
-        ErrorLogger() << "QueueListBox::DropsAcceptable unexpected passed more than one Wnd to test";
-    }
-
-    for (DropsAcceptableIter it = first; it != last; ++it) {
-        it->second = (m_order_issuing_enabled &&
-                      AllowedDropType(it->first->DragDropDataType()));
-    }
-}
-
 void QueueListBox::AcceptDrops(const GG::Pt& pt, const std::vector<GG::Wnd*>& wnds, GG::Flags<GG::ModKey> mod_keys) {
     if (wnds.empty())
         return;
@@ -180,6 +164,7 @@ void QueueListBox::DragDropLeave() {
 
 void QueueListBox::EnableOrderIssuing(bool enable/* = true*/) {
     m_order_issuing_enabled = enable;
+    AllowDrops(enable);
     for (GG::ListBox::Row* row : *this)
         row->Disable(!enable);
 }

--- a/UI/QueueListBox.cpp
+++ b/UI/QueueListBox.cpp
@@ -89,8 +89,6 @@ void QueueListBox::KeyPress(GG::Key key, std::uint32_t key_code_point, GG::Flags
 }
 
 void QueueListBox::AcceptDrops(const GG::Pt& pt, const std::vector<GG::Wnd*>& wnds, GG::Flags<GG::ModKey> mod_keys) {
-    if (wnds.empty())
-        return;
     if (wnds.size() > 1) {
         // delete any extra wnds that won't be processed below
         for (std::vector<GG::Wnd*>::const_iterator it = ++wnds.begin(); it != wnds.end(); ++it)
@@ -108,8 +106,6 @@ void QueueListBox::AcceptDrops(const GG::Pt& pt, const std::vector<GG::Wnd*>& wn
         return;
     }
     ListBox::AcceptDrops(pt, std::vector<GG::Wnd*>{wnd}, mod_keys);
-    iterator it = RowUnderPt(pt);
-    QueueItemMovedSignal(row, std::distance(begin(), it));
 }
 
 void QueueListBox::Render() {

--- a/UI/QueueListBox.cpp
+++ b/UI/QueueListBox.cpp
@@ -177,17 +177,15 @@ void QueueListBox::Clear() {
     DragDropLeave();
 }
 
-std::function<void()> QueueListBox::MoveToTopAction(GG::ListBox::iterator it) const {
+std::function<void()> QueueListBox::MoveToTopAction(GG::ListBox::iterator it) {
     return [it, this]() {
-        if (GG::ListBox::Row* row = *it)
-            QueueItemMovedSignal(row, 0);
+        ListBox::Insert(*it, begin(), true, true);
     };
 }
 
-std::function<void()> QueueListBox::MoveToBottomAction(GG::ListBox::iterator it) const {
+std::function<void()> QueueListBox::MoveToBottomAction(GG::ListBox::iterator it) {
     return [it, this]() {
-        if (GG::ListBox::Row* row = *it)
-            QueueItemMovedSignal(row, NumRows());
+        ListBox::Insert(*it, end(), true, true);
     };
 }
 

--- a/UI/QueueListBox.cpp
+++ b/UI/QueueListBox.cpp
@@ -53,13 +53,13 @@ QueueListBox::QueueListBox(const boost::optional<std::string>& drop_type_str, co
     if (drop_type_str)
         AllowDropType(*drop_type_str);
 
-    BeforeInsertSignal.connect(
+    BeforeInsertRowSignal.connect(
         boost::bind(&QueueListBox::EnsurePromptHiddenSlot, this, _1));
-    AfterEraseSignal.connect(
+    AfterEraseRowSignal.connect(
         boost::bind(&QueueListBox::ShowPromptConditionallySlot, this, _1));
-    ClearedSignal.connect(
+    ClearedRowsSignal.connect(
         boost::bind(&QueueListBox::ShowPromptSlot, this));
-    GG::ListBox::RightClickedSignal.connect(
+    GG::ListBox::RightClickedRowSignal.connect(
         boost::bind(&QueueListBox::ItemRightClicked, this, _1, _2, _3));
 
     SetNumCols(1);

--- a/UI/QueueListBox.cpp
+++ b/UI/QueueListBox.cpp
@@ -42,7 +42,7 @@ private:
 ////////////////////////////////////////////////////////////
 // QueueListBox
 ////////////////////////////////////////////////////////////
-QueueListBox::QueueListBox(const std::string& drop_type_str, const std::string& prompt_str) :
+QueueListBox::QueueListBox(const boost::optional<std::string>& drop_type_str, const std::string& prompt_str) :
     CUIListBox(),
     m_drop_point(end()),
     m_show_drop_point(false),
@@ -50,8 +50,8 @@ QueueListBox::QueueListBox(const std::string& drop_type_str, const std::string& 
     m_showing_prompt(false),
     m_prompt_str(prompt_str)
 {
-    if (!drop_type_str.empty())
-        AllowDropType(drop_type_str);
+    if (drop_type_str)
+        AllowDropType(*drop_type_str);
 
     BeforeInsertSignal.connect(
         boost::bind(&QueueListBox::EnsurePromptHiddenSlot, this, _1));

--- a/UI/QueueListBox.h
+++ b/UI/QueueListBox.h
@@ -35,9 +35,6 @@ public:
 protected:
     void KeyPress(GG::Key key, std::uint32_t key_code_point, GG::Flags<GG::ModKey> mod_keys) override;
 
-    void DropsAcceptable(DropsAcceptableIter first, DropsAcceptableIter last,
-                         const GG::Pt& pt, GG::Flags<GG::ModKey> mod_keys) const override;
-
     virtual void    ItemRightClickedImpl(GG::ListBox::iterator it, const GG::Pt& pt, const GG::Flags<GG::ModKey>& modkeys);
 
     /** Return a functor that will signal that \p it should be moved to the top of the list.*/

--- a/UI/QueueListBox.h
+++ b/UI/QueueListBox.h
@@ -1,6 +1,8 @@
 #ifndef _QueueListBox_h_
 #define _QueueListBox_h_
 
+#include <boost/optional/optional.hpp>
+
 #include "CUIControls.h"
 
 /** A list box type for representing queues (eg the research and production queues). */
@@ -8,7 +10,7 @@ class QueueListBox :
     public CUIListBox
 {
 public:
-    QueueListBox(const std::string& drop_type_str, const std::string& prompt_str);
+    QueueListBox(const boost::optional<std::string>& drop_type_str, const std::string& prompt_str);
 
     void Render() override;
 

--- a/UI/QueueListBox.h
+++ b/UI/QueueListBox.h
@@ -31,7 +31,6 @@ public:
 
     void            Clear();
 
-    boost::signals2::signal<void (GG::ListBox::Row*, std::size_t)>  QueueItemMovedSignal;
     boost::signals2::signal<void (GG::ListBox::iterator)>           QueueItemDeletedSignal;
 
 protected:

--- a/UI/QueueListBox.h
+++ b/UI/QueueListBox.h
@@ -40,10 +40,10 @@ protected:
     virtual void    ItemRightClickedImpl(GG::ListBox::iterator it, const GG::Pt& pt, const GG::Flags<GG::ModKey>& modkeys);
 
     /** Return a functor that will signal that \p it should be moved to the top of the list.*/
-    virtual std::function<void()> MoveToTopAction(GG::ListBox::iterator it) const;
+    virtual std::function<void()> MoveToTopAction(GG::ListBox::iterator it);
 
     /** Return a functor that will signal that \p it should be moved to the bottom of the list.*/
-    virtual std::function<void()> MoveToBottomAction(GG::ListBox::iterator it) const;
+    virtual std::function<void()> MoveToBottomAction(GG::ListBox::iterator it);
 
     /** Return a functor that will signal that \p it should be deleted.*/
     virtual std::function<void()> DeleteAction(GG::ListBox::iterator it) const;

--- a/UI/ResearchWnd.cpp
+++ b/UI/ResearchWnd.cpp
@@ -301,7 +301,7 @@ protected:
         // mostly duplicated equivalent in QueueListBox, but with an extra command...
         auto pedia_action = [&it, this, pt, modkeys]() {
             ShowPediaSignal();
-            this->LeftClickedSignal(it, pt, modkeys);
+            this->LeftClickedRowSignal(it, pt, modkeys);
         };
         auto resume_action = [&it, this]() { this->QueueItemPausedSignal(it, false); };
         auto pause_action = [&it, this]() { this->QueueItemPausedSignal(it, true); };
@@ -410,13 +410,13 @@ ResearchWnd::ResearchWnd(GG::X w, GG::Y h, bool initially_hidden /*= true*/) :
     m_queue_wnd = new ResearchQueueWnd(GG::X0, GG::Y(100), queue_width, GG::Y(ClientSize().y - 100));
     m_tech_tree_wnd = new TechTreeWnd(tech_tree_wnd_size.x, tech_tree_wnd_size.y, initially_hidden);
 
-    m_queue_wnd->GetQueueListBox()->MovedSignal.connect(
+    m_queue_wnd->GetQueueListBox()->MovedRowSignal.connect(
         boost::bind(&ResearchWnd::QueueItemMoved, this, _1, _2));
     m_queue_wnd->GetQueueListBox()->QueueItemDeletedSignal.connect(
         boost::bind(&ResearchWnd::DeleteQueueItem, this, _1));
-    m_queue_wnd->GetQueueListBox()->LeftClickedSignal.connect(
+    m_queue_wnd->GetQueueListBox()->LeftClickedRowSignal.connect(
         boost::bind(&ResearchWnd::QueueItemClickedSlot, this, _1, _2, _3));
-    m_queue_wnd->GetQueueListBox()->DoubleClickedSignal.connect(
+    m_queue_wnd->GetQueueListBox()->DoubleClickedRowSignal.connect(
         boost::bind(&ResearchWnd::QueueItemDoubleClickedSlot, this, _1, _2, _3));
     m_queue_wnd->GetQueueListBox()->ShowPediaSignal.connect(
         boost::bind(&ResearchWnd::ShowPedia, this));

--- a/UI/ResearchWnd.cpp
+++ b/UI/ResearchWnd.cpp
@@ -289,7 +289,7 @@ namespace {
 //////////////////////////////////////////////////
 class ResearchQueueListBox : public QueueListBox {
 public:
-    ResearchQueueListBox(const std::string& drop_type_str, const std::string& prompt_str) :
+    ResearchQueueListBox(const boost::optional<std::string>& drop_type_str, const std::string& prompt_str) :
         QueueListBox(drop_type_str, prompt_str)
     {}
 
@@ -352,7 +352,7 @@ public:
                "research.ResearchQueueWnd"),
         m_queue_lb(nullptr)
     {
-        m_queue_lb = new ResearchQueueListBox("RESEARCH_QUEUE_ROW", UserString("RESEARCH_QUEUE_PROMPT"));
+        m_queue_lb = new ResearchQueueListBox(std::string("RESEARCH_QUEUE_ROW"), UserString("RESEARCH_QUEUE_PROMPT"));
         m_queue_lb->SetStyle(GG::LIST_NOSORT | GG::LIST_NOSEL | GG::LIST_USERDELETE);
         m_queue_lb->SetName("ResearchQueue ListBox");
 

--- a/UI/ResearchWnd.h
+++ b/UI/ResearchWnd.h
@@ -38,7 +38,7 @@ public:
      *  Selects and centers tech @p tech_name if tech is initially visible
      *  or if @p force is true(default). */
     void    ShowTech(const std::string& tech_name, bool force = true);
-    void    QueueItemMoved(GG::ListBox::Row* row, std::size_t position);
+    void    QueueItemMoved(const GG::ListBox::iterator& row_it, const GG::ListBox::iterator& original_position_it);
     void    Sanitize();
 
     void    ShowPedia();

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -740,9 +740,9 @@ void SaveFileDialog::Init() {
         boost::bind(&SaveFileDialog::Confirm, this));
     cancel_btn->LeftClickedSignal.connect(
         boost::bind(&SaveFileDialog::Cancel, this));
-    m_file_list->SelChangedSignal.connect(
+    m_file_list->SelRowsChangedSignal.connect(
         boost::bind(&SaveFileDialog::SelectionChanged, this, _1));
-    m_file_list->DoubleClickedSignal.connect(
+    m_file_list->DoubleClickedRowSignal.connect(
         boost::bind(&SaveFileDialog::DoubleClickRow, this, _1, _2, _3));
     m_name_edit->EditedSignal.connect(
         boost::bind(&SaveFileDialog::FileNameEdited, this, _1));

--- a/UI/ServerConnectWnd.cpp
+++ b/UI/ServerConnectWnd.cpp
@@ -102,7 +102,7 @@ ServerConnectWnd::ServerConnectWnd() :
 
     m_host_or_join_radio_group->ButtonChangedSignal.connect(
         boost::bind(&ServerConnectWnd::EnableDisableControls, this));
-    m_servers_lb->SelChangedSignal.connect(
+    m_servers_lb->SelRowsChangedSignal.connect(
         boost::bind(&ServerConnectWnd::ServerSelected, this, _1));
     m_find_LAN_servers_bn->LeftClickedSignal.connect(
         boost::bind(&ServerConnectWnd::PopulateServerList, this));

--- a/UI/SitRepPanel.cpp
+++ b/UI/SitRepPanel.cpp
@@ -403,9 +403,9 @@ SitRepPanel::SitRepPanel(const std::string& config_name) :
         boost::bind(&SitRepPanel::LastClicked, this));
     m_filter_button->LeftClickedSignal.connect(
         boost::bind(&SitRepPanel::FilterClicked, this));
-    m_sitreps_lb->DoubleClickedSignal.connect(
+    m_sitreps_lb->DoubleClickedRowSignal.connect(
         boost::bind(&SitRepPanel::IgnoreSitRep, this, _1, _2, _3));
-    m_sitreps_lb->RightClickedSignal.connect(
+    m_sitreps_lb->RightClickedRowSignal.connect(
         boost::bind(&SitRepPanel::DismissalMenu, this, _1, _2, _3));
 
     DoLayout();

--- a/UI/TechTreeWnd.cpp
+++ b/UI/TechTreeWnd.cpp
@@ -1697,11 +1697,11 @@ TechTreeWnd::TechListBox::TechListBox(GG::X w, GG::Y h) :
     CUIListBox()
 {
     Resize(GG::Pt(w, h));
-    DoubleClickedSignal.connect(
+    DoubleClickedRowSignal.connect(
         boost::bind(&TechListBox::TechDoubleClicked, this, _1, _2, _3));
-    LeftClickedSignal.connect(
+    LeftClickedRowSignal.connect(
         boost::bind(&TechListBox::TechLeftClicked, this, _1, _2, _3));
-    RightClickedSignal.connect(
+    RightClickedRowSignal.connect(
         boost::bind(&TechListBox::TechRightClicked, this, _1, _2, _3));
 
     SetStyle(GG::LIST_NOSEL);


### PR DESCRIPTION
There are a number of issues with QueueListBox and ListBox handling of dropped windows:
- they use `string` to indicate if a drop type should be accepted.  However, they use opposite conventions for the empty string '""'  to indicate allow no types or allow all types.
- QueueListBox::AcceptsDrops never actually accepted the dropped window.  In all cases its derived classes  just regenerated everything.
- there was an unused plan to throw an exception to indicate not accepting a dropped window.  

This PR adds the `ListBox` functions `void AllowDrops(bool)`, `bool AllowingDrops()`, `void AllowAllDropTypes(bool)` and `bool AllowedDropType(string)` as clearer alternatives to passing empty strings to allowing all/no drops.

This PR improves `AcceptDrops` so that `QueueListBox` uses the `AcceptDrops` of `ListBox` and doesn't require derived classes to completely redraw themselves in response to a drop.

This PR removes the exception that was never caught and never thrown.