### PR TITLE
Remove all Logger(X) declarations from anonymous namespaces.

### DIFF
--- a/UI/CombatReport/CombatLogWnd.cpp
+++ b/UI/CombatReport/CombatLogWnd.cpp
@@ -19,9 +19,7 @@
 #include "../AccordionPanel.h"
 #include "../../Empire/Empire.h"
 
-namespace {
-    DeclareThreadSafeLogger(combat_log);
-}
+DeclareThreadSafeLogger(combat_log);
 
 class CombatLogWnd::Impl {
 public:

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -68,9 +68,7 @@
 class CombatLogManager;
 CombatLogManager&   GetCombatLogManager();
 
-namespace {
-    DeclareThreadSafeLogger(FSM);
-}
+DeclareThreadSafeLogger(FSM);
 
 ////////////////////////////////////////////////////////////
 // HumanClientFSM

--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -24,9 +24,7 @@
 #include <iterator>
 #include <sstream>
 
-namespace {
-    DeclareThreadSafeLogger(combat);
-}
+DeclareThreadSafeLogger(combat);
 
 ////////////////////////////////////////////////
 // CombatInfo

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -34,9 +34,9 @@
 using boost::asio::ip::tcp;
 using namespace Networking;
 
-namespace {
-    DeclareThreadSafeLogger(network);
+DeclareThreadSafeLogger(network);
 
+namespace {
     /** A simple client that broadcasts UDP datagrams on the local network for
         FreeOrion servers, and reports any it finds. */
     class ServerDiscoverer {

--- a/network/ServerNetworking.cpp
+++ b/network/ServerNetworking.cpp
@@ -13,9 +13,7 @@ using boost::asio::ip::tcp;
 using boost::asio::ip::udp;
 using namespace Networking;
 
-namespace {
-    DeclareThreadSafeLogger(network);
-}
+DeclareThreadSafeLogger(network);
 
 /** A simple server that listens for FreeOrion-server-discovery UDP datagrams
     on the local network and sends out responses to them. */

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -28,9 +28,9 @@
 class CombatLogManager;
 CombatLogManager&   GetCombatLogManager();
 
-namespace {
-    DeclareThreadSafeLogger(FSM);
+DeclareThreadSafeLogger(FSM);
 
+namespace {
     void SendMessageToAllPlayers(const Message& message) {
         ServerApp* server = ServerApp::GetApp();
         if (!server) {

--- a/universe/Effect.cpp
+++ b/universe/Effect.cpp
@@ -28,9 +28,7 @@
 #include <cctype>
 #include <iterator>
 
-namespace {
-    DeclareThreadSafeLogger(effects);
-}
+DeclareThreadSafeLogger(effects);
 
 using boost::io::str;
 

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -30,9 +30,7 @@
 
 FO_COMMON_API extern const int INVALID_DESIGN_ID;
 
-namespace {
-    DeclareThreadSafeLogger(effects);
-}
+DeclareThreadSafeLogger(effects);
 
 #if defined(_MSC_VER)
 #  if (_MSC_VER == 1900)


### PR DESCRIPTION
This is intended to change the linker behavior on OSX which is only
linking some of the loggers.

See issue #1575.