### PR TITLE
Change OrderSet add suppress_ immediate_execution parameter.

### DIFF
--- a/util/OrderSet.cpp
+++ b/util/OrderSet.cpp
@@ -15,14 +15,15 @@ const OrderPtr OrderSet::ExamineOrder(int order) const {
     return retval;
 }
 
-int OrderSet::IssueOrder(const OrderPtr& order)
-{ return IssueOrder(OrderPtr(order)); }
+int OrderSet::IssueOrder(const OrderPtr& order, bool suppress_immediate_execution /*= false*/)
+{ return IssueOrder(OrderPtr(order), suppress_immediate_execution); }
 
-int OrderSet::IssueOrder(OrderPtr&& order) {
+int OrderSet::IssueOrder(OrderPtr&& order, bool suppress_immediate_execution /*= false*/) {
     int retval = ((m_orders.rbegin() != m_orders.rend()) ? m_orders.rbegin()->first + 1 : 0);
     auto inserted = m_orders.insert(std::make_pair(retval, std::forward<OrderPtr>(order)));
 
-    inserted.first->second->Execute();
+    if (!suppress_immediate_execution)
+        inserted.first->second->Execute();
 
     return retval;
 }

--- a/util/OrderSet.cpp
+++ b/util/OrderSet.cpp
@@ -20,6 +20,8 @@ int OrderSet::IssueOrder(const OrderPtr& order, bool suppress_immediate_executio
 
 int OrderSet::IssueOrder(OrderPtr&& order, bool suppress_immediate_execution /*= false*/) {
     int retval = ((m_orders.rbegin() != m_orders.rend()) ? m_orders.rbegin()->first + 1 : 0);
+
+    // Insert the order into the m_orders map.  forward the rvalue to use the move constructor.
     auto inserted = m_orders.insert(std::make_pair(retval, std::forward<OrderPtr>(order)));
 
     if (!suppress_immediate_execution)

--- a/util/OrderSet.cpp
+++ b/util/OrderSet.cpp
@@ -15,11 +15,14 @@ const OrderPtr OrderSet::ExamineOrder(int order) const {
     return retval;
 }
 
-int OrderSet::IssueOrder(const OrderPtr& order) {
-    int retval = ((m_orders.rbegin() != m_orders.rend()) ? m_orders.rbegin()->first + 1 : 0);
-    m_orders[retval] = order;
+int OrderSet::IssueOrder(const OrderPtr& order)
+{ return IssueOrder(OrderPtr(order)); }
 
-    order->Execute();
+int OrderSet::IssueOrder(OrderPtr&& order) {
+    int retval = ((m_orders.rbegin() != m_orders.rend()) ? m_orders.rbegin()->first + 1 : 0);
+    auto inserted = m_orders.insert(std::make_pair(retval, std::forward<OrderPtr>(order)));
+
+    inserted.first->second->Execute();
 
     return retval;
 }

--- a/util/OrderSet.h
+++ b/util/OrderSet.h
@@ -52,10 +52,11 @@ public:
     //@}
 
     /** \name Mutators */ //@{
-    /** executes a given Order, then stores it in the OrderSet. Returns an index that can be used to reference the
-        order. */
-    int            IssueOrder(const OrderPtr& order);
-    int            IssueOrder(OrderPtr&& order);
+    /** executes \p order unless \p suppress_immediate_execution is true, then
+        stores it in the OrderSet. Returns an index that can be used to
+        reference the order. */
+    int            IssueOrder(const OrderPtr& order, bool suppress_immediate_execution = false);
+    int            IssueOrder(OrderPtr&& order, bool suppress_immediate_execution = false);
 
     /** Applies all Orders in the OrderSet.  As of this writing, this is needed only after deserializing an OrderSet
         client-side during game loading. */

--- a/util/OrderSet.h
+++ b/util/OrderSet.h
@@ -52,9 +52,9 @@ public:
     //@}
 
     /** \name Mutators */ //@{
-    /** executes \p order unless \p suppress_immediate_execution is true, then
-        stores it in the OrderSet. Returns an index that can be used to
-        reference the order. */
+    /** If \p suppress_immediate_execution is false, then execute the \p order immediately on the client.
+        Always store the \p order in the OrderSet to be executed later on the server.
+        Return an index that can be used to reference the order. */
     int            IssueOrder(const OrderPtr& order, bool suppress_immediate_execution = false);
     int            IssueOrder(OrderPtr&& order, bool suppress_immediate_execution = false);
 

--- a/util/OrderSet.h
+++ b/util/OrderSet.h
@@ -53,8 +53,9 @@ public:
 
     /** \name Mutators */ //@{
     /** executes a given Order, then stores it in the OrderSet. Returns an index that can be used to reference the
-        order.*/
+        order. */
     int            IssueOrder(const OrderPtr& order);
+    int            IssueOrder(OrderPtr&& order);
 
     /** Applies all Orders in the OrderSet.  As of this writing, this is needed only after deserializing an OrderSet
         client-side during game loading. */


### PR DESCRIPTION
This allows orders to be injected into the OrderSet at startup and load
without being executed immediately and then again in MapWnd::InitTurn()

This will allow saved ship designs to be added to its empire by the human client at game start (new game or loaded game).