### PR TITLE
Change ServerApp to store OrderSets with unique_ptr

### DIFF
--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -151,7 +151,7 @@ public:
 
     /** Adds turn orders for the given empire for the current turn. order_set
       * will be freed when all processing is done for the turn */
-    void    SetEmpireTurnOrders(int empire_id, OrderSet* order_set);
+    void    SetEmpireTurnOrders(int empire_id, std::unique_ptr<OrderSet>&& order_set);
 
     /** Sets all empire turn orders to an empty set. */
     void    ClearEmpireTurnOrders();
@@ -319,7 +319,7 @@ private:
     /** Turn sequence map is used for turn processing. Each empire is added at
       * the start of a game or reload and then the map maintains OrderSets for
       * that turn. */
-    std::map<int, OrderSet*>                m_turn_sequence;
+    std::map<int, std::unique_ptr<OrderSet>>         m_turn_sequence;
 
     // Give FSM and its states direct access.  We are using the FSM code as a
     // control-flow mechanism; it is all notionally part of this class.

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -1517,7 +1517,7 @@ sc::result WaitingForTurnEnd::react(const TurnOrders& msg) {
     const Message& message = msg.m_message;
     const PlayerConnectionPtr& sender = msg.m_player_connection;
 
-    OrderSet* order_set = new OrderSet;
+    auto order_set = std::unique_ptr<OrderSet>(new OrderSet);
     ExtractTurnOrdersMessageData(message, *order_set);
 
     int player_id = sender->PlayerID();
@@ -1576,7 +1576,7 @@ sc::result WaitingForTurnEnd::react(const TurnOrders& msg) {
 
         TraceLogger(FSM) << "WaitingForTurnEnd.TurnOrders : Received orders from player " << player_id;
 
-        server.SetEmpireTurnOrders(empire->EmpireID(), order_set);
+        server.SetEmpireTurnOrders(empire->EmpireID(), std::move(order_set));
     }
 
 
@@ -1724,7 +1724,7 @@ sc::result WaitingForSaveData::react(const ClientSaveData& msg) {
     // received orders are ignored if there are already existing orders?
     std::shared_ptr<OrderSet> order_set;
     if (const Empire* empire = GetEmpire(server.PlayerEmpireID(player_id))) {
-        OrderSet* existing_orders = server.m_turn_sequence[empire->EmpireID()];
+        const auto& existing_orders = server.m_turn_sequence[empire->EmpireID()];
         if (existing_orders)
             order_set.reset(new OrderSet(*existing_orders));
         else


### PR DESCRIPTION
In some locations m_turn_sequence was being cleared or set to a new heap
object without deleting the old order.

Changing to unique_ptr fixes the leaks.