### PR TITLE
Fix logger static initialization problems.

### DIFF
--- a/util/Logger.cpp
+++ b/util/Logger.cpp
@@ -356,6 +356,16 @@ void OverrideAllLoggersThresholds(const boost::optional<LogLevel>& threshold) {
 
 LoggerCreatedSignalType LoggerCreatedSignal;
 
+namespace {
+    // Initialize LoggerCreatedSignal.  During static initialization another
+    // compilation unit might call ConfigureLogger() before Logger.cpp has been
+    // initialized.
+    bool InitializeLoggerCreatedSignal() {
+        LoggerCreatedSignal = LoggerCreatedSignalType();
+        return true;
+    };
+}
+
 void ConfigureLogger(NamedThreadedLogger& logger, const std::string& name) {
     // Note: Do not log in this function.  If a logger is used during
     // static initialization it will cause boost::log to recursively call
@@ -366,6 +376,9 @@ void ConfigureLogger(NamedThreadedLogger& logger, const std::string& name) {
         return;
 
     CreateFileSinkFrontEnd(name);
+
+    // Store as static to initialize once.
+    static bool dummy = InitializeLoggerCreatedSignal();
 
     LoggerCreatedSignal(name);
 }

--- a/util/Logger.cpp
+++ b/util/Logger.cpp
@@ -233,9 +233,12 @@ namespace {
     void CreateFileSinkFrontEnd(const std::string& channel_name) {
         auto& file_sink_backend = GetSinkBackend();
 
-        // Return if the file sink backed has not been configured
-        if (!file_sink_backend)
+        // If the file sink backend has not been configured store the name so
+        // that a frontend can be added later.
+        if (!file_sink_backend) {
+            GetLoggersToSinkFrontEnds().AddOrReplaceLoggerName(channel_name, nullptr);
             return;
+        }
 
         // Create a sink frontend for formatting.
         boost::shared_ptr<TextFileSinkFrontend> sink_frontend


### PR DESCRIPTION
This PR fixes three errors that occur during initialization of logger.

This may help with some of the issues in https://github.com/freeorion/freeorion/issues/1575 if the OSX linker was creating a start up order that triggered these bugs.   

These are difficult to trigger, so I do not have code that reliably replicates the problems.

The bugs and fixes are:
- If ConfigureLogger() is called before the LoggerCreatedSignal has been static initialized from a different compilation unit, then an uninitialized pointer is dereferenced.  This is link order dependent. The fix is to force the correct sequencing with a static function variable in ConfigureLogger().

-  If a logger front end file sink is configured before the back end file sink is created, the logger was not being stored for late configuration.  This prevented log messages from being routed to the file in cases where the configuration was not triggered via another pathway.  This is startup order dependent, The fix was to restore the correct behavior of storing the logger for late configuration.

- The `min_channel_severity` was accessed from multiple thread with no synchronization.  I did not observe any crashes with this problem.