### PR TITLE
Revert blocksize increase handling to be proportional reduction

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -2382,10 +2382,10 @@ void Empire::SetProductionQuantityAndBlocksize(int index, int quantity, int bloc
     //std::cout << "original block size: " << original_blocksize << "  new blocksize: " << blocksize << "  memory blocksize: " << m_production_queue[index].blocksize_memory << std::endl;
     if (blocksize <= m_production_queue[index].blocksize_memory) {
         // if reducing block size, progress on retained portion is unchanged.
-        // if increasing block size, progress is reset to 0, unless this is undoing a recent reduction in block size
+        // if increasing block size, progress is proportionally reduced, unless undoing a recent reduction in block size
         m_production_queue[index].progress = m_production_queue[index].progress_memory;
     } else {
-        m_production_queue[index].progress = 0.0f;
+        m_production_queue[index].progress = m_production_queue[index].progress_memory * m_production_queue[index].blocksize_memory / blocksize;
     }
 }
 


### PR DESCRIPTION
If the blocksize of a production queue build item is increased, reduce the progress in proportion to the increase. This essentially reverts a recent change (which seems like it might have accidentally slipped into c6cc240 since the commit message makes no mention of it), and fixes #1574

Per discussion at http://www.freeorion.org/forum/viewtopic.php?p=89017#p89017