### PR TITLE
Add permissive extension parameter to list scripts

### DIFF
--- a/parse/Parse.cpp
+++ b/parse/Parse.cpp
@@ -441,25 +441,33 @@ namespace parse {
      * @param[in] path relative or absolute directory (searched recursively)
      * @return Any *.focs.txt files in path or 'GetResourceDir() / path'.
      */
-    std::vector<boost::filesystem::path> ListScripts(const boost::filesystem::path& path) {
-        std::vector<boost::filesystem::path> retval;
+    std::vector<boost::filesystem::path> ListScripts(const boost::filesystem::path& path, bool allow_permissive) {
+        std::vector<boost::filesystem::path> scripts;
 
         try {
-            for (const boost::filesystem::path& file : ListDir(path)) {
+            const auto& files = ListDir(path);
+            for (const auto& file : files) {
                 std::string fn_ext = file.extension().string();
                 std::string fn_stem_ext = file.stem().extension().string();
                 if (fn_ext == ".txt" && fn_stem_ext == ".focs") {
-                    retval.push_back(file);
+                    scripts.push_back(file);
                 } else {
                     TraceLogger() << "Parse: Skipping file " << file.string()
                                   << " due to extension (" << fn_stem_ext << fn_ext << ")";
                 }
             }
+
+            // If in permissive mode and no scripts are found allow all files to be scripts.
+            if (scripts.empty() && !files.empty()) {
+                WarnLogger() << path << " does not contain scripts with the expected suffix .focs.txt. "
+                             << " Trying a more permissive mode and ignoring file suffix.";
+                scripts = files;
+            }
         } catch (const boost::filesystem::filesystem_error& ec) {
             ErrorLogger() << "Error accessing file " << ec.path1() << " (" << ec.what() << ")";
         }
 
-        return retval;
+        return scripts;
     }
 
     const sregex FILENAME_TEXT = -+_;   // any character, one or more times, not greedy

--- a/parse/Parse.cpp
+++ b/parse/Parse.cpp
@@ -458,8 +458,8 @@ namespace parse {
             }
 
             // If in permissive mode and no scripts are found allow all files to be scripts.
-            if (scripts.empty() && !files.empty()) {
-                WarnLogger() << path << " does not contain scripts with the expected suffix .focs.txt. "
+            if (allow_permissive && scripts.empty() && !files.empty()) {
+                WarnLogger() << PathString(path) << " does not contain scripts with the expected suffix .focs.txt. "
                              << " Trying a more permissive mode and ignoring file suffix.";
                 scripts = files;
             }

--- a/parse/Parse.h
+++ b/parse/Parse.h
@@ -70,7 +70,9 @@ namespace parse {
 
     FO_PARSE_API bool read_file(const boost::filesystem::path& path, std::string& file_contents);
 
-    FO_PARSE_API std::vector< boost::filesystem::path > ListScripts(const boost::filesystem::path& path);
+    /** Find all FOCS scripts (files with .focs.txt suffix) in \p path.  If \p allow_permissive =
+        true then if \p path is not empty and there are no .focs.txt files allow all files to qualify.*/
+    FO_PARSE_API std::vector< boost::filesystem::path > ListScripts(const boost::filesystem::path& path, bool permissive = false);
 
     FO_PARSE_API void file_substitution(std::string& text, const boost::filesystem::path& file_search_path);
 

--- a/parse/ShipDesignsParser.cpp
+++ b/parse/ShipDesignsParser.cpp
@@ -170,8 +170,12 @@ namespace {
 
 namespace parse {
     bool ship_designs(const boost::filesystem::path& path, std::map<std::string, std::unique_ptr<ShipDesign>>& designs) {
+        // Allow files with any suffix in order to convert legacy ShipDesign files.
+        bool permissive_mode = true;
+        const auto& scripts = ListScripts(path, permissive_mode);
+
         bool result = true;
-        for(const boost::filesystem::path& file : ListScripts(path)) {
+        for(const boost::filesystem::path& file : scripts) {
             try {
                 result &= detail::parse_file<rules, std::map<std::string, std::unique_ptr<ShipDesign>>>(file, designs);
             } catch (const std::runtime_error& e) {


### PR DESCRIPTION
This add a parameter `allow_permissive` to `ListScripts()` which if no scripts are found with the correct FOCS extension ".focs.txt" will allow all files in the directory to be interpreted as scripts.

This is motivated because the legacy ship design files have an extension of just ".txt", so they are ignored by `ListScripts`