### PR TITLE
Improve ShipDesign constructor to (almost) always produce a valid design.

### DIFF
--- a/AI/AIInterface.cpp
+++ b/AI/AIInterface.cpp
@@ -851,10 +851,12 @@ namespace AIInterface {
         const auto uuid = boost::uuids::random_generator()();
 
         // create design from stuff chosen in UI
-        ShipDesign* design = new ShipDesign(name, description, current_turn, ClientApp::GetApp()->EmpireID(),
-                                            hull, parts, icon, model, name_desc_in_stringtable, false, uuid);
+        ShipDesign* design;
+        try {
+            design = new ShipDesign(name, description, current_turn, ClientApp::GetApp()->EmpireID(),
+                                    hull, parts, icon, model, name_desc_in_stringtable, false, uuid);
 
-        if (!design) {
+        } catch (const std::runtime_error&) {
             ErrorLogger() << "IssueCreateShipDesignOrderOrder failed to create a new ShipDesign object";
             return 0;
         }

--- a/AI/AIInterface.cpp
+++ b/AI/AIInterface.cpp
@@ -849,10 +849,10 @@ namespace AIInterface {
         // create design from stuff chosen in UI
         ShipDesign* design;
         try {
-            design = new ShipDesign(name, description, current_turn, ClientApp::GetApp()->EmpireID(),
+            design = new ShipDesign(std::invalid_argument(""), name, description, current_turn, ClientApp::GetApp()->EmpireID(),
                                     hull, parts, icon, model, name_desc_in_stringtable, false, uuid);
 
-        } catch (const std::runtime_error&) {
+        } catch (const std::invalid_argument&) {
             ErrorLogger() << "IssueCreateShipDesignOrderOrder failed to create a new ShipDesign object";
             return 0;
         }

--- a/AI/AIInterface.cpp
+++ b/AI/AIInterface.cpp
@@ -840,10 +840,6 @@ namespace AIInterface {
             ErrorLogger() << "IssueCreateShipDesignOrderOrder : passed an empty name, description, or hull.";
             return 0;
         }
-        if (!ShipDesign::ValidDesign(hull, parts)) {
-            ErrorLogger() << "IssueCreateShipDesignOrderOrder : pass a hull and parts that do not make a valid ShipDesign";
-            return 0;
-        }
 
         int empire_id = AIClientApp::GetApp()->EmpireID();
         int current_turn = CurrentTurn();

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -3318,9 +3318,10 @@ void DesignWnd::MainPanel::RefreshIncompleteDesign() const {
     // update stored design
     m_incomplete_design.reset();
     try {
-        m_incomplete_design.reset(new ShipDesign(name, description, CurrentTurn(), ClientApp::GetApp()->EmpireID(),
+        m_incomplete_design.reset(new ShipDesign(std::invalid_argument(""),
+                                                 name, description, CurrentTurn(), ClientApp::GetApp()->EmpireID(),
                                                  hull, parts, icon, "", false, false, uuid));
-    } catch (const std::runtime_error& e) {
+    } catch (const std::invalid_argument& e) {
         ErrorLogger() << "DesignWnd::MainPanel::RefreshIncompleteDesign " << e.what();
     }
 }
@@ -3545,7 +3546,7 @@ int DesignWnd::AddDesign() {
         const auto uuid = boost::uuids::random_generator()();
 
         // create design from stuff chosen in UI
-        ShipDesign design(name, description, CurrentTurn(), ClientApp::GetApp()->EmpireID(),
+        ShipDesign design(std::invalid_argument(""), name, description, CurrentTurn(), ClientApp::GetApp()->EmpireID(),
                           hull_name, parts, icon, "some model", false, false, uuid);
 
         int new_design_id = HumanClientApp::GetApp()->GetNewDesignID();
@@ -3557,7 +3558,7 @@ int DesignWnd::AddDesign() {
         DebugLogger() << "Added new design: " << design.Name();
 
         return new_design_id;
-    } catch (std::runtime_error&) {
+    } catch (std::invalid_argument&) {
         ErrorLogger() << "DesignWnd::AddDesign tried to add an invalid ShipDesign";
         return INVALID_DESIGN_ID;
     }

--- a/default/python/interface_mock/parse_docs.py
+++ b/default/python/interface_mock/parse_docs.py
@@ -228,4 +228,4 @@ if __name__ == '__main__':
     # double standarts
     # canBuild ['empire', 'buildType', 'str', 'int'], ['empire', 'buildType', 'int', 'int']
     # inField ['field', 'universeObject'], ['field', 'float', 'float']
-    # validShipDesign ['str', 'StringVec'], ['shipDesign']
+    # validShipDesign ['str', 'StringVec']

--- a/default/python/interface_mock/result/freeOrionAIInterface.py
+++ b/default/python/interface_mock/result/freeOrionAIInterface.py
@@ -3758,7 +3758,6 @@ def userStringList(string):
 def validShipDesign(string, string_list):
     """
     Returns true (boolean) if the passed hull (string) and parts (StringVec) make up a valid ship design, and false (boolean) otherwise. Valid ship designs don't have any parts in slots that can't accept that type of part, and contain only hulls and parts that exist (and may also need to contain the correct number of parts - this needs to be verified).
-    Returns true (boolean) if the passed ship design (ShipDesign) is valid, and false otherwise.
 
     :param string:
     :type string: str

--- a/default/python/interface_mock/result/freeorion.py
+++ b/default/python/interface_mock/result/freeorion.py
@@ -4111,7 +4111,6 @@ def user_string(string):
 def validShipDesign(string, string_list):
     """
     Returns true (boolean) if the passed hull (string) and parts (StringVec) make up a valid ship design, and false (boolean) otherwise. Valid ship designs don't have any parts in slots that can't accept that type of part, and contain only hulls and parts that exist (and may also need to contain the correct number of parts - this needs to be verified).
-    Returns true (boolean) if the passed ship design (ShipDesign) is valid, and false otherwise.
 
     :param string:
     :type string: str

--- a/default/scripting/monster_designs/SM_GUARD_2.focs.txt
+++ b/default/scripting/monster_designs/SM_GUARD_2.focs.txt
@@ -8,7 +8,7 @@ ShipDesign
         "SR_WEAPON_0_1"
         "AR_PRECURSOR_PLATE"
         "AR_PRECURSOR_PLATE"
-
+        ""
     ]
     icon = "icons/monsters/sentinel.png"
     model = "seed"

--- a/default/scripting/monster_designs/SM_GUARD_3.focs.txt
+++ b/default/scripting/monster_designs/SM_GUARD_3.focs.txt
@@ -11,6 +11,7 @@ ShipDesign
         "AR_PRECURSOR_PLATE"
         "AR_PRECURSOR_PLATE"
         "SH_BLACK"
+        ""
     ]
     icon = "icons/monsters/warden.png"
     model = "seed"

--- a/default/scripting/monster_designs/SM_KRILL_3.focs.txt
+++ b/default/scripting/monster_designs/SM_KRILL_3.focs.txt
@@ -7,6 +7,7 @@ ShipDesign
         "FT_KRILL"
         "FT_BAY_KRILL"
         "FT_BAY_KRILL"
+        ""
     ]
     icon = "icons/monsters/krill-3.png"
     model = "seed"

--- a/default/scripting/monster_designs/SM_KRILL_4.focs.txt
+++ b/default/scripting/monster_designs/SM_KRILL_4.focs.txt
@@ -8,6 +8,7 @@ ShipDesign
         "FT_BAY_KRILL"
         "FT_BAY_KRILL"
         "FT_BAY_KRILL"
+        ""
     ]
     icon = "icons/monsters/krill-4.png"
     model = "seed"

--- a/python/UniverseWrapper.cpp
+++ b/python/UniverseWrapper.cpp
@@ -186,7 +186,6 @@ namespace {
 
     bool                    (*ValidDesignHullAndParts)(const std::string& hull,
                                                        const std::vector<std::string>& parts) = &ShipDesign::ValidDesign;
-    bool                    (*ValidDesignDesign)(const ShipDesign&) =                           &ShipDesign::ValidDesign;
 
     const std::vector<std::string>& (ShipDesign::*PartsVoid)(void) const =                      &ShipDesign::Parts;
     // The following (PartsSlotType) is not currently used, but left as an example for this kind of wrapper
@@ -526,7 +525,6 @@ namespace FreeOrionPython {
             .add_property("dump",               &ShipDesign::Dump)
         ;
         def("validShipDesign",                  ValidDesignHullAndParts, "Returns true (boolean) if the passed hull (string) and parts (StringVec) make up a valid ship design, and false (boolean) otherwise. Valid ship designs don't have any parts in slots that can't accept that type of part, and contain only hulls and parts that exist (and may also need to contain the correct number of parts - this needs to be verified).");
-        def("validShipDesign",                  ValidDesignDesign, "Returns true (boolean) if the passed ship design (ShipDesign) is valid, and false otherwise.");
         def("getShipDesign",                    &GetShipDesign,                             return_value_policy<reference_existing_object>(), "Returns the ship design (ShipDesign) with the indicated id number (int).");
 
         class_<PartType, noncopyable>("partType", no_init)

--- a/python/server/ServerWrapper.cpp
+++ b/python/server/ServerWrapper.cpp
@@ -392,8 +392,9 @@ namespace {
         // Create the design and add it to the universe
         ShipDesign* design;
         try {
-            design = new ShipDesign(name, description, BEFORE_FIRST_TURN, ALL_EMPIRES, hull, parts, icon, model, true, monster);
-        } catch (const std::runtime_error&) {
+            design = new ShipDesign(std::invalid_argument(""), name, description, BEFORE_FIRST_TURN, ALL_EMPIRES,
+                                    hull, parts, icon, model, true, monster);
+        } catch (const std::invalid_argument&) {
             ErrorLogger() << "CreateShipDesign: invalid ship design";
             return false;
         }

--- a/python/server/ServerWrapper.cpp
+++ b/python/server/ServerWrapper.cpp
@@ -396,11 +396,14 @@ namespace {
         }
 
         // Create the design and add it to the universe
-        ShipDesign* design = new ShipDesign(name, description, BEFORE_FIRST_TURN, ALL_EMPIRES, hull, parts, icon, model, true, monster);
-        if (!design) {
+        ShipDesign* design;
+        try {
+            design = new ShipDesign(name, description, BEFORE_FIRST_TURN, ALL_EMPIRES, hull, parts, icon, model, true, monster);
+        } catch (const std::runtime_error&) {
             ErrorLogger() << "CreateShipDesign: couldn't create ship design";
             return false;
         }
+
         if (universe.InsertShipDesign(design) == INVALID_DESIGN_ID) {
             ErrorLogger() << "CreateShipDesign: couldn't insert ship design into universe";
             delete design;

--- a/python/server/ServerWrapper.cpp
+++ b/python/server/ServerWrapper.cpp
@@ -389,18 +389,12 @@ namespace {
             parts.push_back(extract<std::string>(py_parts[i]));
         }
 
-        // Check if design is valid
-        if (!ShipDesign::ValidDesign(hull, parts)) {
-            ErrorLogger() << "CreateShipDesign: invalid ship design";
-            return false;
-        }
-
         // Create the design and add it to the universe
         ShipDesign* design;
         try {
             design = new ShipDesign(name, description, BEFORE_FIRST_TURN, ALL_EMPIRES, hull, parts, icon, model, true, monster);
         } catch (const std::runtime_error&) {
-            ErrorLogger() << "CreateShipDesign: couldn't create ship design";
+            ErrorLogger() << "CreateShipDesign: invalid ship design";
             return false;
         }
 

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -824,12 +824,13 @@ bool ShipDesign::ProductionLocation(int empire_id, int location_id) const {
 void ShipDesign::SetID(int id)
 { m_id = id; }
 
-bool ShipDesign::ValidDesign(const std::string& hull, const std::vector<std::string>& parts) {
+bool ShipDesign::ValidDesign(const std::string& hull, const std::vector<std::string>& parts_in) {
+    auto parts = parts_in;
     return !MaybeInvalidDesign(hull, parts);
 }
 
 boost::optional<std::pair<std::string, std::vector<std::string>>>
-ShipDesign::MaybeInvalidDesign(const std::string& hull_in, const std::vector<std::string>& parts_in) {
+ShipDesign::MaybeInvalidDesign(const std::string& hull_in, std::vector<std::string>& parts_in) {
     bool is_valid = true;
 
     auto hull = hull_in;
@@ -865,12 +866,9 @@ ShipDesign::MaybeInvalidDesign(const std::string& hull_in, const std::vector<std
                      << (parts.size() - hull_type->NumSlots()) << " parts.";
     }
 
-    // If parts is smaller than the full hull size pad it.
-    if (parts.size() != hull_type->NumSlots()) {
-        is_valid = false;
-        WarnLogger() << "Invalid ShipDesign given " << parts.size() << " parts for hull with "
-                     << hull_type->NumSlots() << " slots.  Adding "
-                     << (hull_type->NumSlots() - parts.size()) << " empty parts.";
+    // If parts is smaller than the full hull size pad it and the incoming parts
+    if (parts.size() < hull_type->NumSlots()) {
+        parts_in.resize(hull_type->NumSlots(), "");
     }
 
     // Truncate or pad with "" parts.

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -557,17 +557,7 @@ ShipDesign::ShipDesign(const std::string& name, const std::string& description,
     m_3D_model(model),
     m_name_desc_in_stringtable(name_desc_in_stringtable)
 {
-    // expand parts list to have empty values if fewer parts are given than hull has slots
-    if (const HullType* hull_type = GetHullType(m_hull)) {
-        if (m_parts.size() < hull_type->NumSlots())
-            m_parts.resize(hull_type->NumSlots(), "");
-    }
-
-    if (!ValidDesign(m_hull, m_parts)) {
-        ErrorLogger() << "constructing an invalid ShipDesign!";
-        ErrorLogger() << Dump();
-        throw std::runtime_error("invalid ShipDesign");
-    }
+    MakeValid();
     BuildStatCaches();
 }
 

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -492,6 +492,9 @@ HullTypeManager::HullTypeManager() {
         TraceLogger() << " ... " << h->Name();
     }
 
+    if (m_hulls.empty())
+        ErrorLogger() << "HullTypeManager expects at least one hull type.  All ship design construction will fail.";
+
     // Only update the global pointer on sucessful construction.
     s_instance = this;
 }

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -1107,11 +1107,7 @@ namespace {
 
 
         // duplicate design to add to Universe
-        ShipDesign* copy = new ShipDesign(design->Name(false), design->Description(false),
-                                          design->DesignedOnTurn(), design->DesignedByEmpire(),
-                                          design->Hull(), design->Parts(), design->Icon(),
-                                          design->Model(), design->LookupInStringtable(),
-                                          monster, design->UUID());
+        ShipDesign* copy = new ShipDesign(*design);
 
         bool success = universe.InsertShipDesignID(copy, new_design_id);
         if (!success) {

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -1112,10 +1112,6 @@ namespace {
                                           design->Hull(), design->Parts(), design->Icon(),
                                           design->Model(), design->LookupInStringtable(),
                                           monster, design->UUID());
-        if (!copy) {
-            ErrorLogger() << "PredefinedShipDesignManager::AddShipDesignsToUniverse() couldn't duplicate the design with name " << design->Name();
-            return;
-        }
 
         bool success = universe.InsertShipDesignID(copy, new_design_id);
         if (!success) {

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -562,6 +562,7 @@ ShipDesign::ShipDesign(const std::string& name, const std::string& description,
     if (!ValidDesign(m_hull, m_parts)) {
         ErrorLogger() << "constructing an invalid ShipDesign!";
         ErrorLogger() << Dump();
+        throw std::runtime_error("invalid ShipDesign");
     }
     BuildStatCaches();
 }

--- a/universe/ShipDesign.h
+++ b/universe/ShipDesign.h
@@ -417,7 +417,11 @@ FO_COMMON_API const HullType* GetHullType(const std::string& name);
 class FO_COMMON_API ShipDesign {
 public:
     /** \name Structors */ //@{
+private:
+    /** The ShipDesign constructor constructs invalid designs and is only used by boost
+        serialization. */
     ShipDesign();
+public:
     ShipDesign(const std::string& name, const std::string& description,
                int designed_on_turn, int designed_by_empire, const std::string& hull,
                const std::vector<std::string>& parts,

--- a/universe/ShipDesign.h
+++ b/universe/ShipDesign.h
@@ -9,6 +9,7 @@
 #include <set>
 #include <string>
 #include <vector>
+#include <stdexcept>
 
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/filesystem/operations.hpp>
@@ -425,21 +426,38 @@ private:
         serialization. */
     ShipDesign();
 public:
-    /** The public ShipDesign constructor will only construct valid ship designs.  If the passed
-        in parameters (\p hull and \p parts) would result in an invalid design it throws
-        std::runtime_error. */
-    ShipDesign(const std::string& name, const std::string& description,
+    /** The public ShipDesign constructor will only construct valid ship
+        designs, as long as the HullTypeManager has at least one hull.
+
+        If \p should_throw is not boost::none and the passed in parameters (\p
+        hull and \p parts) would result in an invalid design it generates an
+        explicit log message showing the FOCS corresponding to the passed in
+        parameters and the FOCS corresponding to a corrected valid design and
+        then throws std::invalid_argument.  This can be used to test design
+        validity and provide an explcit log message.
+
+        should_throw is not used but it is a literal reminder that
+        std::invalid_argument should be caught.
+
+        If \p should_throw is boost::none it will correct the errors in
+        parameters, print a log message and return a valid ship design.  The
+        only exception is if there are no ship hull in the HullManager.  Then
+        the constructor will not throw, but will return an invalid ship design
+        with a empty "" hull.
+    */
+    ShipDesign(const boost::optional<std::invalid_argument>& should_throw,
+               const std::string& name, const std::string& description,
                int designed_on_turn, int designed_by_empire, const std::string& hull,
                const std::vector<std::string>& parts,
                const std::string& icon, const std::string& model,
                bool name_desc_in_stringtable = false, bool monster = false,
                const boost::uuids::uuid& uuid = boost::uuids::nil_uuid()
               );
-    /** The public ShipDesign constructor will only construct valid ship designs.  If the passed
-        in parameters (\p hull and \p parts) would result in an invalid design it throws
-        std::runtime_error. */
+
+    /**  The public ShipDesign constructor will only construct valid ship
+         designs, as long as the HullTypeManager has at least one hull. */
     ShipDesign(const std::string& name, const std::string& description,
-               const std::string& hull,
+               int designed_on_turn, int designed_by_empire, const std::string& hull,
                const std::vector<std::string>& parts,
                const std::string& icon, const std::string& model,
                bool name_desc_in_stringtable = false, bool monster = false,
@@ -542,8 +560,13 @@ private:
         MaybeInvalidDesign(const std::string& hull, const std::vector<std::string>& parts);
 
     /** Force design invariants to be true. If design invariants are not begin met provide an
-        explicit log message about how it was corrected. */
-    void MakeValid();
+        explicit log message about how it was corrected and throw
+        std::invalid_argument if \p should_throw is not none.
+
+        should_throw is not used but it is a literal reminder that
+        std::invalid_argument should be caught.
+    */
+    void ForceValidDesignOrThrow(const boost::optional<std::invalid_argument>& should_throw);
 
     void BuildStatCaches();
 

--- a/universe/ShipDesign.h
+++ b/universe/ShipDesign.h
@@ -11,6 +11,9 @@
 #include <vector>
 
 #include <boost/algorithm/string/case_conv.hpp>
+#include <boost/filesystem/operations.hpp>
+#include <boost/functional/hash.hpp>
+#include <boost/optional/optional.hpp>
 #include <boost/variant.hpp>
 #include <boost/serialization/access.hpp>
 #include <boost/serialization/nvp.hpp>
@@ -530,10 +533,18 @@ public:
     void                            Rename(const std::string& name) { m_name = name; }  ///< renames this design to \a name
     //@}
 
-    ///< returns true if the \a hull and parts vectors passed make a valid ShipDesign
-    static bool                     ValidDesign(const std::string& hull, const std::vector<std::string>& parts);
-
+    /** Return true if \p hull and \p parts would make a valid design. */
+    static bool ValidDesign(const std::string& hull, const std::vector<std::string>& parts);
 private:
+    /** Return a valid hull and parts  pair iff the \p hull and \p parts vectors would not make  a
+        valid ShipDesign. Otherwise return none. */
+    static boost::optional<std::pair<std::string, std::vector<std::string>>>
+        MaybeInvalidDesign(const std::string& hull, const std::vector<std::string>& parts);
+
+    /** Force design invariants to be true. If design invariants are not begin met provide an
+        explicit log message about how it was corrected. */
+    void MakeValid();
+
     void BuildStatCaches();
 
     int                         m_id = INVALID_OBJECT_ID;

--- a/universe/ShipDesign.h
+++ b/universe/ShipDesign.h
@@ -527,11 +527,6 @@ public:
     ///< returns true if the \a hull and parts vectors passed make a valid ShipDesign
     static bool                     ValidDesign(const std::string& hull, const std::vector<std::string>& parts);
 
-    /** returns true if the \a design passed is a valid ShipDesign in terms of
-      * (its hull and parts.  does not check any other member variables */
-    static bool                     ValidDesign(const ShipDesign& design)
-    { return ValidDesign(design.m_hull, design.m_parts); }
-
 private:
     void BuildStatCaches();
 

--- a/universe/ShipDesign.h
+++ b/universe/ShipDesign.h
@@ -554,21 +554,22 @@ public:
     /** Return true if \p hull and \p parts would make a valid design. */
     static bool ValidDesign(const std::string& hull, const std::vector<std::string>& parts);
 private:
-    /** Return a valid hull and parts  pair iff the \p hull and \p parts vectors would not make  a
-        valid ShipDesign. Otherwise return none.
+    /** Return a valid hull and parts pair iff the \p hull and \p parts vectors
+        would not make a valid ShipDesign.
         Also pad parts with "" if it is shorter than the \p hull number of slots.
-    */
+        Otherwise return none. If \p produce_log is true then produce log messages. */
     static boost::optional<std::pair<std::string, std::vector<std::string>>>
-        MaybeInvalidDesign(const std::string& hull, std::vector<std::string>& parts);
+        MaybeInvalidDesign(const std::string& hull, std::vector<std::string>& parts, bool produce_log);
 
-    /** Force design invariants to be true. If design invariants are not begin met provide an
-        explicit log message about how it was corrected and throw
-        std::invalid_argument if \p should_throw is not none.
+    /** Force design invariants to be true. If design invariants are not begin
+        met and \p produce_log is true provide an explicit log message about how it
+        was corrected and throw std::invalid_argument if \p should_throw is not
+        none.
 
-        should_throw is not used but it is a literal reminder that
+        \p should_throw is not used but it is a literal reminder that
         std::invalid_argument should be caught.
     */
-    void ForceValidDesignOrThrow(const boost::optional<std::invalid_argument>& should_throw);
+    void ForceValidDesignOrThrow(const boost::optional<std::invalid_argument>& should_throw, bool produce_log);
 
     void BuildStatCaches();
 

--- a/universe/ShipDesign.h
+++ b/universe/ShipDesign.h
@@ -418,10 +418,13 @@ class FO_COMMON_API ShipDesign {
 public:
     /** \name Structors */ //@{
 private:
-    /** The ShipDesign constructor constructs invalid designs and is only used by boost
+    /** The ShipDesign() constructor constructs invalid designs and is only used by boost
         serialization. */
     ShipDesign();
 public:
+    /** The public ShipDesign constructor will only construct valid ship designs.  If the passed
+        in parameters (\p hull and \p parts) would result in an invalid design it throws
+        std::runtime_error. */
     ShipDesign(const std::string& name, const std::string& description,
                int designed_on_turn, int designed_by_empire, const std::string& hull,
                const std::vector<std::string>& parts,
@@ -429,6 +432,9 @@ public:
                bool name_desc_in_stringtable = false, bool monster = false,
                const boost::uuids::uuid& uuid = boost::uuids::nil_uuid()
               );
+    /** The public ShipDesign constructor will only construct valid ship designs.  If the passed
+        in parameters (\p hull and \p parts) would result in an invalid design it throws
+        std::runtime_error. */
     ShipDesign(const std::string& name, const std::string& description,
                const std::string& hull,
                const std::vector<std::string>& parts,

--- a/universe/ShipDesign.h
+++ b/universe/ShipDesign.h
@@ -555,9 +555,11 @@ public:
     static bool ValidDesign(const std::string& hull, const std::vector<std::string>& parts);
 private:
     /** Return a valid hull and parts  pair iff the \p hull and \p parts vectors would not make  a
-        valid ShipDesign. Otherwise return none. */
+        valid ShipDesign. Otherwise return none.
+        Also pad parts with "" if it is shorter than the \p hull number of slots.
+    */
     static boost::optional<std::pair<std::string, std::vector<std::string>>>
-        MaybeInvalidDesign(const std::string& hull, const std::vector<std::string>& parts);
+        MaybeInvalidDesign(const std::string& hull, std::vector<std::string>& parts);
 
     /** Force design invariants to be true. If design invariants are not begin met provide an
         explicit log message about how it was corrected and throw

--- a/util/Order.cpp
+++ b/util/Order.cpp
@@ -1024,10 +1024,17 @@ void ShipDesignOrder::ExecuteImpl() const {
 
             return;
         }
-        ShipDesign* new_ship_design = new ShipDesign(m_name, m_description,
-                                                     m_designed_on_turn, EmpireID(), m_hull, m_parts,
-                                                     m_icon, m_3D_model, m_name_desc_in_stringtable,
-                                                     m_is_monster, m_uuid);
+
+        ShipDesign* new_ship_design;
+        try {
+            new_ship_design = new ShipDesign(m_name, m_description,
+                                             m_designed_on_turn, EmpireID(), m_hull, m_parts,
+                                             m_icon, m_3D_model, m_name_desc_in_stringtable,
+                                             m_is_monster, m_uuid);
+        } catch (const std::runtime_error&) {
+            ErrorLogger() << "Couldn't create ship design.";
+            return;
+        }
 
         universe.InsertShipDesignID(new_ship_design, m_design_id);
         universe.SetEmpireKnowledgeOfShipDesign(m_design_id, EmpireID());

--- a/util/Order.cpp
+++ b/util/Order.cpp
@@ -1027,11 +1027,11 @@ void ShipDesignOrder::ExecuteImpl() const {
 
         ShipDesign* new_ship_design;
         try {
-            new_ship_design = new ShipDesign(m_name, m_description,
+            new_ship_design = new ShipDesign(std::invalid_argument(""), m_name, m_description,
                                              m_designed_on_turn, EmpireID(), m_hull, m_parts,
                                              m_icon, m_3D_model, m_name_desc_in_stringtable,
                                              m_is_monster, m_uuid);
-        } catch (const std::runtime_error&) {
+        } catch (const std::invalid_argument&) {
             ErrorLogger() << "Couldn't create ship design.";
             return;
         }

--- a/util/SerializeUniverse.cpp
+++ b/util/SerializeUniverse.cpp
@@ -283,7 +283,7 @@ void ShipDesign::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_3D_model)
         & BOOST_SERIALIZATION_NVP(m_name_desc_in_stringtable);
     if (Archive::is_loading::value) {
-        ForceValidDesignOrThrow(boost::none);
+        ForceValidDesignOrThrow(boost::none, true);
         BuildStatCaches();
     }
 }

--- a/util/SerializeUniverse.cpp
+++ b/util/SerializeUniverse.cpp
@@ -283,14 +283,7 @@ void ShipDesign::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_3D_model)
         & BOOST_SERIALIZATION_NVP(m_name_desc_in_stringtable);
     if (Archive::is_loading::value) {
-        if (!ValidDesign(m_hull, m_parts)) {
-            const auto first_hull_it = GetHullTypeManager().begin();
-            m_hull = first_hull_it != GetHullTypeManager().end() ? first_hull_it->first : "";
-            m_parts.clear();
-            ErrorLogger() << "Deserialized ship design " << m_name << " has invalid hull and/or parts. "
-                          << " Defaulting to empty hull of type \"" << m_hull << "\"";
-        }
-
+        MakeValid();
         BuildStatCaches();
     }
 }

--- a/util/SerializeUniverse.cpp
+++ b/util/SerializeUniverse.cpp
@@ -282,8 +282,17 @@ void ShipDesign::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_icon)
         & BOOST_SERIALIZATION_NVP(m_3D_model)
         & BOOST_SERIALIZATION_NVP(m_name_desc_in_stringtable);
-    if (Archive::is_loading::value)
+    if (Archive::is_loading::value) {
+        if (!ValidDesign(m_hull, m_parts)) {
+            const auto first_hull_it = GetHullTypeManager().begin();
+            m_hull = first_hull_it != GetHullTypeManager().end() ? first_hull_it->first : "";
+            m_parts.clear();
+            ErrorLogger() << "Deserialized ship design " << m_name << " has invalid hull and/or parts. "
+                          << " Defaulting to empty hull of type \"" << m_hull << "\"";
+        }
+
         BuildStatCaches();
+    }
 }
 
 template

--- a/util/SerializeUniverse.cpp
+++ b/util/SerializeUniverse.cpp
@@ -283,7 +283,7 @@ void ShipDesign::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_3D_model)
         & BOOST_SERIALIZATION_NVP(m_name_desc_in_stringtable);
     if (Archive::is_loading::value) {
-        MakeValid();
+        ForceValidDesignOrThrow(boost::none);
         BuildStatCaches();
     }
 }


### PR DESCRIPTION
This PR depends on #1589.

It modifies the `ShipDesign` constructors so that they will
always produce a valid design except if the `HullTypeManager` has
no hulls at all.  In that case, the hull will be the empty string.

If provided with invalid input parameters the constructor will
remove parts or replace the hull with the first hull from the
hull manager, until it has a valid design.

When provided with invalid input parameters the constructor
produces an explicit error message showing the erroneous FOCS and
the corrected FOCS.  I've included an example at the bottom of
this post.

There is an option in the constructor to request it to throw on
bad input rather than produce the degraded design.  This enables
it to produce the detailed error message, because before the
constructor throws it has access to a complete `ShipDesign`.

Parsing and deserialization uses the other, non throwing, option
of generating a degraded but valid design.


***Sample error***:


````
11:17:15.918952 [debug] client : ShipDesign.cpp:932 : Invalid ShipDesign part "FT_HANGAR_1" can't be mounted in SL_EXTERNAL slot. Removing "FT_HANGAR_1"
11:17:15.918987 [debug] client : ShipDesign.cpp:932 : Invalid ShipDesign part "FT_BAY_1" can't be mounted in SL_INTERNAL slot. Removing "FT_BAY_1"
11:17:15.919029 [warn] client : ShipDesign.cpp:972 : Invalid ShipDesign:
ShipDesign
    name = "SD_CARRIER parts conflict with slot"
    uuid = "08a58b08-0929-496d-84fc-faa91424ca34"
    description = "SD_CARRIER_DESC"
    hull = "SH_STANDARD"
    parts = [
        "AR_STD_PLATE"
        "FT_HANGAR_1"
        "FT_BAY_1"
        "FT_BAY_1"
    ]
    model = "mark1"

ShipDesign was made valid as:
ShipDesign
    name = "SD_CARRIER parts conflict with slot"
    uuid = "08a58b08-0929-496d-84fc-faa91424ca34"
    description = "SD_CARRIER_DESC"
    hull = "SH_STANDARD"
    parts = [
        "AR_STD_PLATE"
        ""
        "FT_BAY_1"
        ""
    ]
    model = "mark1"
````

