### PR TITLE
Give Super Tester species perfect stealth

### DIFF
--- a/default/scripting/species/SP_SUPERTEST.focs.txt
+++ b/default/scripting/species/SP_SUPERTEST.focs.txt
@@ -37,6 +37,10 @@ Species
             effects = SetDetection value = Value + 10000
 
         EffectsGroup
+            scope = Source
+            effects = SetStealth value = Value + 500
+
+        EffectsGroup
             scope = And [
                 Source
                 Capital


### PR DESCRIPTION
For AI testing purposes, I often build super testers on turn 1, and keep passing turns while observing the AI behavior. When not playing the game, the AI will eventually conquer the planet. 

Giving the super testers perfect stealth means that the AI will not detect the human player and act as if it wasn't there.