### PR TITLE
Fix bug in production queue projections

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -1118,7 +1118,11 @@ void ProductionQueue::Update() {
             std::tie(item_cost, build_turns) = queue_item_costs_and_times[key];
             float total_item_cost = item_cost * element.blocksize;
 
-            float additional_pp_to_complete_element = total_item_cost * (1.0f - element.progress); // additional PP, beyond already-accumulated PP to finish this element once
+            // calculate additional PP, beyond already-accumulated PP to finish all repeats of this element; 
+            // that is the total_item_cost times the number of repeats, less the current progress percentage times
+            // the total_item_cost, below reorganized as total_item_cost times the difference between the number
+            // of repeats and the percentage element.progress.
+            float additional_pp_to_complete_element = total_item_cost * (element.remaining - element.progress);
             //DebugLogger()  << " element total cost: " << element_total_cost << "; progress: " << element.progress;
             if (additional_pp_to_complete_element < EPSILON) {
                 //DebugLogger()  << "     will complete next turn";


### PR DESCRIPTION
A bug introduced with the shift to percentage completion caused early termination of calculations relating to elements with a repeat count greater than 1, which would then often cause elements later in the queue to show substantially premature projected completion times (up to hundreds of turns difference).

A simple test case I used to compare results was starting up a single player game with mostly default stats, but no monsters, no AIs, and choosing Gysache.  I advanced for 5 turns with no other actions, to get the production meter to plateau, and then added 5x2 Scouts (5 repeats of a 2-unit block), 20x2 Outpost ships, 10x5 Outposts ships and another 10x5 Outpost ships.  Without this correction the projections for first completions show projected as happening after 2, 13, 73 and 117 turns; with this correction they are projected at 2, 15, 184 and 384 turns (which appear as accurate as I can reasonably confirm without deleting all ships as they are produced). 

Even if we are not too concerned actually about predictions of things 70+ turns in the future, a discrepancy of  ~15% already 13 turns out, which apparently can steadily increase up to 150% at ~75 turns out, seems like enough that I think if we do wind up doing a bugfix release for 0.4.7, that this should be included in that (should we have a label or milestone for that?)