### PR TITLE
Limit engine parts to one per ship, increase stats

### DIFF
--- a/default/python/AI/ShipDesignAI.py
+++ b/default/python/AI/ShipDesignAI.py
@@ -850,7 +850,7 @@ class ShipDesigner(object):
         self.production_time = local_time_cache.get(self.hull.name, self.hull.productionTime(fo.empireID(), self.pid))
 
         # read out part stats
-        shield_counter = cloak_counter = detection_counter = colonization_counter = 0  # to deal with Non-stacking parts
+        shield_counter = cloak_counter = detection_counter = colonization_counter = engine_counter = 0  # to deal with Non-stacking parts
         hangar_parts = set()
         for part in self.parts:
             self.production_cost += local_cost_cache.get(part.name, part.productionCost(fo.empireID(), self.pid))
@@ -861,7 +861,11 @@ class ShipDesigner(object):
             if partclass in FUEL:
                 self.design_stats.fuel += capacity
             elif partclass in ENGINES:
-                self.design_stats.speed += capacity
+                engine_counter += 1
+                if engine_counter == 1:
+                    self.design_stats.speed += capacity
+                else:
+                    self.design_stats.speed = 0
             elif partclass in COLONISATION:
                 colonization_counter += 1
                 if colonization_counter == 1:

--- a/default/scripting/ship_parts/FU_IMPROVED_ENGINE_COUPLINGS.focs.txt
+++ b/default/scripting/ship_parts/FU_IMPROVED_ENGINE_COUPLINGS.focs.txt
@@ -8,9 +8,9 @@ Part
         "FU_TRANSPATIAL_DRIVE"
     ]
     class = Speed
-    capacity = 10
+    capacity = 20
     mountableSlotTypes = Internal
-    buildcost = 10 * [[FLEET_UPKEEP_MULTIPLICATOR]]
+    buildcost = 15 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildtime = 3
     tags = [ "PEDIA_PC_SPEED" ]
     location = OwnedBy empire = Source.Owner

--- a/default/scripting/ship_parts/FU_IMPROVED_ENGINE_COUPLINGS.focs.txt
+++ b/default/scripting/ship_parts/FU_IMPROVED_ENGINE_COUPLINGS.focs.txt
@@ -1,6 +1,12 @@
 Part
     name = "FU_IMPROVED_ENGINE_COUPLINGS"
     description = "FU_IMPROVED_ENGINE_COUPLINGS_DESC"
+    exclusions = [
+        "FU_IMPROVED_ENGINE_COUPLINGS"
+        "FU_N_DIMENSIONAL_ENGINE_MATRIX"
+        "FU_SINGULARITY_ENGINE_CORE"
+        "FU_TRANSPATIAL_DRIVE"
+    ]
     class = Speed
     capacity = 10
     mountableSlotTypes = Internal

--- a/default/scripting/ship_parts/FU_N_DIMENSIONAL_ENGINE_MATRIX.focs.txt
+++ b/default/scripting/ship_parts/FU_N_DIMENSIONAL_ENGINE_MATRIX.focs.txt
@@ -8,10 +8,10 @@ Part
         "FU_TRANSPATIAL_DRIVE"
     ]
     class = Speed
-    capacity = 20
+    capacity = 40
     mountableSlotTypes = Internal
-    buildcost = 20 * [[FLEET_UPKEEP_MULTIPLICATOR]]
-    buildtime = 4
+    buildcost = 25 * [[FLEET_UPKEEP_MULTIPLICATOR]]
+    buildtime = 5
     tags = [ "PEDIA_PC_SPEED" ]
     location = OwnedBy empire = Source.Owner
     icon = "icons/ship_parts/engine-2.png"

--- a/default/scripting/ship_parts/FU_N_DIMENSIONAL_ENGINE_MATRIX.focs.txt
+++ b/default/scripting/ship_parts/FU_N_DIMENSIONAL_ENGINE_MATRIX.focs.txt
@@ -9,7 +9,7 @@ Part
     ]
     class = Speed
     capacity = 40
-    mountableSlotTypes = Internal
+    mountableSlotTypes = [ Internal Core ]
     buildcost = 25 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildtime = 5
     tags = [ "PEDIA_PC_SPEED" ]

--- a/default/scripting/ship_parts/FU_N_DIMENSIONAL_ENGINE_MATRIX.focs.txt
+++ b/default/scripting/ship_parts/FU_N_DIMENSIONAL_ENGINE_MATRIX.focs.txt
@@ -1,6 +1,12 @@
 Part
     name = "FU_N_DIMENSIONAL_ENGINE_MATRIX"
     description = "FU_N_DIMENSIONAL_ENGINE_MATRIX_DESC"
+    exclusions = [
+        "FU_IMPROVED_ENGINE_COUPLINGS"
+        "FU_N_DIMENSIONAL_ENGINE_MATRIX"
+        "FU_SINGULARITY_ENGINE_CORE"
+        "FU_TRANSPATIAL_DRIVE"
+    ]
     class = Speed
     capacity = 20
     mountableSlotTypes = Internal

--- a/default/scripting/ship_parts/FU_SINGULARITY_ENGINE_CORE.focs.txt
+++ b/default/scripting/ship_parts/FU_SINGULARITY_ENGINE_CORE.focs.txt
@@ -8,10 +8,10 @@ Part
         "FU_TRANSPATIAL_DRIVE"
     ]
     class = Speed
-    capacity = 30
+    capacity = 80
     mountableSlotTypes = Core
-    buildcost = 30 * [[FLEET_UPKEEP_MULTIPLICATOR]]
-    buildtime = 5
+    buildcost = 40 * [[FLEET_UPKEEP_MULTIPLICATOR]]
+    buildtime = 6
     tags = [ "PEDIA_PC_SPEED" ]
     location = OwnedBy empire = Source.Owner
     icon = "icons/ship_parts/engine-3.png"

--- a/default/scripting/ship_parts/FU_SINGULARITY_ENGINE_CORE.focs.txt
+++ b/default/scripting/ship_parts/FU_SINGULARITY_ENGINE_CORE.focs.txt
@@ -1,6 +1,12 @@
 Part
     name = "FU_SINGULARITY_ENGINE_CORE"
     description = "FU_SINGULARITY_ENGINE_CORE_DESC"
+    exclusions = [
+        "FU_IMPROVED_ENGINE_COUPLINGS"
+        "FU_N_DIMENSIONAL_ENGINE_MATRIX"
+        "FU_SINGULARITY_ENGINE_CORE"
+        "FU_TRANSPATIAL_DRIVE"
+    ]
     class = Speed
     capacity = 30
     mountableSlotTypes = Core

--- a/default/scripting/ship_parts/FU_TRANSPATIAL_DRIVE.focs.txt
+++ b/default/scripting/ship_parts/FU_TRANSPATIAL_DRIVE.focs.txt
@@ -1,6 +1,12 @@
 Part
     name = "FU_TRANSPATIAL_DRIVE"
     description = "FU_TRANSPATIAL_DRIVE_DESC"
+    exclusions = [
+        "FU_IMPROVED_ENGINE_COUPLINGS"
+        "FU_N_DIMENSIONAL_ENGINE_MATRIX"
+        "FU_SINGULARITY_ENGINE_CORE"
+        "FU_TRANSPATIAL_DRIVE"
+    ]
     class = Speed
     capacity = 40
     mountableSlotTypes = Core

--- a/default/scripting/ship_parts/FU_TRANSPATIAL_DRIVE.focs.txt
+++ b/default/scripting/ship_parts/FU_TRANSPATIAL_DRIVE.focs.txt
@@ -8,7 +8,7 @@ Part
         "FU_TRANSPATIAL_DRIVE"
     ]
     class = Speed
-    capacity = 40
+    capacity = 60
     mountableSlotTypes = Core
     buildcost = 80 * [[FLEET_UPKEEP_MULTIPLICATOR]]
     buildtime = 8

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -12065,33 +12065,46 @@ Sensors
 DT_DETECTOR_4_DESC
 Very long-range detection.
 
+FU_ENGINE_PART_LIMIT
+Only one engine part may be equipped on a ship.
+
 FU_IMPROVED_ENGINE_COUPLINGS
 Improved Engine Couplings
 
 FU_IMPROVED_ENGINE_COUPLINGS_DESC
-'''Increases [[metertype METER_SPEED]] by 10.
+'''Better engine parts equate to better engines.
 
-Better engine parts equate to better engines.'''
+- Increases [[metertype METER_SPEED]] by 20.
+- [[FU_ENGINE_PART_LIMIT]]'''
 
 FU_N_DIMENSIONAL_ENGINE_MATRIX
 N-Dimensional Engine Matrix
 
 FU_N_DIMENSIONAL_ENGINE_MATRIX_DESC
-'''Increases [[metertype METER_SPEED]] by 20.
+'''N-Dimensional subspace research resulted in a more efficient engine matrix.
 
-N-Dimensional subspace research resulted in a more efficient engine matrix.'''
+- Increases [[metertype METER_SPEED]] by 40.
+- [[FU_ENGINE_PART_LIMIT]]'''
 
 FU_SINGULARITY_ENGINE_CORE
 Singularity Engine Core
 
 FU_SINGULARITY_ENGINE_CORE_DESC
-A smaller cousin of the [[buildingtype BLD_HYPER_DAM]] outfitted for ships, the Singularity Engine Core drastically boosts power generation. Increases [[metertype METER_SPEED]] by 30.
+'''A smaller cousin of the [[buildingtype BLD_HYPER_DAM]] outfitted for ships, the Singularity Engine Core drastically boosts power generation.
+
+- Increases [[metertype METER_SPEED]] by 80.
+- [[FU_ENGINE_PART_LIMIT]]'''
 
 FU_TRANSPATIAL_DRIVE
 Trans-spatial Drive
 
 FU_TRANSPATIAL_DRIVE_DESC
-An incredibly powerful drive that bends spacetime itself, increasing both [[metertype METER_SPEED]] and [[metertype METER_STEALTH]] by 40. Can only be mounted in a Core [[encyclopedia SLOT_TITLE]]. Stealth boost does not stack with other part bonuses.
+'''An incredibly powerful drive that bends spacetime itself.
+
+- Increases [[metertype METER_SPEED]] by 60
+- Increases [[metertype METER_STEALTH]] by 40
+- Stealth boost does not stack with other part bonuses.
+- [[FU_ENGINE_PART_LIMIT]]'''
 
 FU_BASIC_TANK
 Extra Fuel Tank


### PR DESCRIPTION
Restricts existing engine parts to one per design.
Increases capacity(speed) and adjusts build cost and time.
[Forum discussion](http://freeorion.org/forum/viewtopic.php?f=15&t=10540)