### PR TITLE
Remove suppress_immediate_execution in OrderSet::IssueOrder.

### DIFF
--- a/GG/src/Menu.cpp
+++ b/GG/src/Menu.cpp
@@ -35,7 +35,6 @@ using namespace GG;
 
 namespace {
     const int BORDER_THICKNESS = 1; // thickness with which to draw menu borders
-    const int MENU_SEPARATION = 10; // distance between menu texts in a MenuBar, in pixels
 }
 
 

--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -176,26 +176,23 @@ namespace {
     std::shared_ptr<const UniverseObject> GetSourceObjectForEmpire(int empire_id) {
         // get a source object, which is owned by the empire,
         // preferably the capital
-        std::shared_ptr<const UniverseObject> source;
         if (empire_id == ALL_EMPIRES)
-            return source;
+            return nullptr;
         const Empire* empire = GetEmpire(empire_id);
         if (!empire)
-            return source;
+            return nullptr;
 
-        if (source = GetUniverseObject(empire->CapitalID()))
+        if (auto source = GetUniverseObject(empire->CapitalID()))
             return source;
 
         // not a valid source?!  scan through all objects to find one owned by this empire
-        for (std::shared_ptr<const UniverseObject> obj : GetUniverse().Objects()) {
-            if (obj->OwnedBy(empire_id)) {
-                source = obj;
-                break;
-            }
+        for (const auto& obj : GetUniverse().Objects()) {
+            if (obj->OwnedBy(empire_id))
+                return obj;
         }
 
         // if this empire doesn't own ANYTHING, default to a null source
-        return source;
+        return nullptr;
     }
 
     std::string EnqueueAndLocationConditionDescription(const std::string& building_name, int candidate_object_id,

--- a/UI/CUIDrawUtil.h
+++ b/UI/CUIDrawUtil.h
@@ -132,7 +132,7 @@ public:
     void StopUsing();
 
 private:
-    struct Impl;
+    class Impl;
 
     std::unique_ptr<Impl> const m_impl;
 };

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -4223,7 +4223,7 @@ std::pair<int, boost::uuids::uuid> DesignWnd::MainPanel::AddDesign() {
         } else {
             int empire_id = HumanClientApp::GetApp()->EmpireID();
             const Empire* empire = GetEmpire(empire_id);
-            if (!empire) return {INVALID_DESIGN_ID, boost::uuids::uuid{0}};
+            if (!empire) return {INVALID_DESIGN_ID, boost::uuids::uuid{{0}}};
 
             auto& manager = GetCurrentDesignsManager();
             const auto& all_ids = manager.AllOrderedIDs();
@@ -4241,7 +4241,7 @@ std::pair<int, boost::uuids::uuid> DesignWnd::MainPanel::AddDesign() {
 
     } catch (std::invalid_argument&) {
         ErrorLogger() << "DesignWnd::AddDesign tried to add an invalid ShipDesign";
-        return {INVALID_DESIGN_ID, boost::uuids::uuid{0}};
+        return {INVALID_DESIGN_ID, boost::uuids::uuid{{0}}};
     }
 }
 

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -265,8 +265,7 @@ namespace {
     /** Add \p design to the \p is_front of \p empire_id's list of current designs. */
     void AddSavedDesignToCurrentDesigns(
         const boost::uuids::uuid& uuid, const int empire_id,
-        const bool is_front = true,
-        const bool suppress_immediate_execution = false)
+        const bool is_front = true)
     {
         const auto empire = GetEmpire(empire_id);
         if (!empire) {
@@ -306,8 +305,7 @@ namespace {
         current_manager.InsertBefore(new_design_id, before_id);
 
         HumanClientApp::GetApp()->Orders().IssueOrder(
-            std::make_shared<ShipDesignOrder>(empire_id, new_design_id, new_current_design),
-            suppress_immediate_execution);
+            std::make_shared<ShipDesignOrder>(empire_id, new_design_id, new_current_design));
     }
 
     /** Set whether a currently known design is obsolete or not. Not obsolete means that it is
@@ -674,9 +672,6 @@ void ShipDesignManager::StartGame(int empire_id) {
     auto saved_designs = dynamic_cast<SavedDesignsManager*>(m_saved_designs.get());
     saved_designs->LoadDesignsFromFileSystem();
 
-    // Prevent orders issued here from being executed twice, once here and again in MapWnd::InitTurn()
-    bool suppress_immediate_execution = true;
-
     // Skip the remainder for loaded games
     if (HumanClientApp::GetApp()->CurrentTurn() != 1)
         return;
@@ -698,8 +693,7 @@ void ShipDesignManager::StartGame(int empire_id) {
         const auto ids = empire->ShipDesigns();
         for (const auto design_id : ids) {
             HumanClientApp::GetApp()->Orders().IssueOrder(
-                std::make_shared<ShipDesignOrder>(empire_id, design_id, true),
-            suppress_immediate_execution);
+                std::make_shared<ShipDesignOrder>(empire_id, design_id, true));
         }
     }
 
@@ -707,7 +701,7 @@ void ShipDesignManager::StartGame(int empire_id) {
     if (GetOptionsDB().Get<bool>("auto-add-saved-designs")) {
         DebugLogger() << "Adding saved designs to empire.";
         for (const auto& uuid : saved_designs->OrderedDesignUUIDs())
-            AddSavedDesignToCurrentDesigns(uuid, empire_id, false, suppress_immediate_execution);
+            AddSavedDesignToCurrentDesigns(uuid, empire_id, false);
     }
 
 }

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -174,8 +174,7 @@ namespace {
         ids that are used to order the display of ShipDesigns in the DesignWnd and the ProductionWnd. */
     class CurrentShipDesignManager : public ShipDesignManager::Designs {
         public:
-        CurrentShipDesignManager(int empire_id) :
-            m_empire_id(empire_id),
+        CurrentShipDesignManager() :
             m_ordered_ids()
         {}
 
@@ -203,7 +202,6 @@ namespace {
         std::vector<std::pair<int, bool>> Save() const;
 
         private:
-        int m_empire_id;
         std::list<int> m_ordered_ids;
 
         // An index from the id to the obsolescence state and the location in the m_ordered_ids list.
@@ -212,8 +210,7 @@ namespace {
 
     class SavedDesignsManager : public ShipDesignManager::Designs {
     public:
-        SavedDesignsManager(const int empire_id) :
-            m_empire_id(empire_id)
+        SavedDesignsManager()
         {}
 
         const std::list<boost::uuids::uuid>& OrderedDesignUUIDs() const
@@ -240,7 +237,6 @@ namespace {
 
         void SaveDesign(int design_id);
 
-        int m_empire_id;
         std::list<boost::uuids::uuid> m_ordered_uuids;
         /// Saved designs with filename
         std::unordered_map<boost::uuids::uuid,
@@ -655,8 +651,8 @@ namespace {
 //////////////////////////////////////////////////
 
 ShipDesignManager::ShipDesignManager() :
-    m_current_designs(new CurrentShipDesignManager(INVALID_OBJECT_ID)),
-    m_saved_designs(new SavedDesignsManager(INVALID_OBJECT_ID))
+    m_current_designs(new CurrentShipDesignManager()),
+    m_saved_designs(new SavedDesignsManager())
 {}
 
 ShipDesignManager::~ShipDesignManager()
@@ -671,10 +667,10 @@ void ShipDesignManager::StartGame(int empire_id) {
 
     DebugLogger() << "ShipDesignManager initializing.";
 
-    m_current_designs.reset(new CurrentShipDesignManager(empire_id));
+    m_current_designs.reset(new CurrentShipDesignManager());
     auto current_designs = dynamic_cast<CurrentShipDesignManager*>(m_current_designs.get());
 
-    m_saved_designs.reset(new SavedDesignsManager(empire_id));
+    m_saved_designs.reset(new SavedDesignsManager());
     auto saved_designs = dynamic_cast<SavedDesignsManager*>(m_saved_designs.get());
     saved_designs->LoadDesignsFromFileSystem();
 
@@ -729,7 +725,7 @@ ShipDesignManager::Designs* ShipDesignManager::CurrentDesigns() {
     if (retval == nullptr) {
         ErrorLogger() << "ShipDesignManager m_current_designs was not correctly initialized "
                       << "with ShipDesignManager::GameStart().";
-        m_current_designs.reset(new CurrentShipDesignManager(INVALID_OBJECT_ID));
+        m_current_designs.reset(new CurrentShipDesignManager());
         return m_current_designs.get();
     }
     return retval;
@@ -740,8 +736,8 @@ ShipDesignManager::Designs* ShipDesignManager::SavedDesigns() {
     if (retval == nullptr) {
         ErrorLogger() << "ShipDesignManager m_saved_designs was not correctly initialized "
                       << "with ShipDesignManager::GameStart().";
-        m_current_designs.reset(new CurrentShipDesignManager(INVALID_OBJECT_ID));
-        return m_current_designs.get();
+        m_saved_designs.reset(new SavedDesignsManager());
+        return m_saved_designs.get();
     }
     return retval;
 }
@@ -2074,7 +2070,6 @@ class SavedDesignsListBox : public BasesListBox {
 
         private:
         boost::uuids::uuid              m_design_uuid;
-        HullAndNamePanel*               m_panel;
     };
 
     protected:
@@ -2629,8 +2624,7 @@ void SavedDesignsListBox::QueueItemMoved(const GG::ListBox::iterator& row_it,
 SavedDesignsListBox::SavedDesignListBoxRow::SavedDesignListBoxRow(
     GG::X w, GG::Y h, const ShipDesign& design) :
     BasesListBoxRow(w, h, design.Hull(), design.Name()),
-    m_design_uuid(design.UUID()),
-    m_panel(nullptr)
+    m_design_uuid(design.UUID())
 {
     SetDragDropDataType(SAVED_DESIGN_ROW_DROP_STRING);
 }

--- a/UI/DesignWnd.h
+++ b/UI/DesignWnd.h
@@ -5,7 +5,7 @@
 #include <boost/uuid/uuid.hpp>
 
 class EncyclopediaDetailPanel;
-class SaveGameUIData;
+struct SaveGameUIData;
 
 struct Availability {
     // Declaring an enum inside a struct makes the syntax when using the enum with tuples simpler,

--- a/UI/DesignWnd.h
+++ b/UI/DesignWnd.h
@@ -36,7 +36,7 @@ public:
     ShipDesignManager();
     virtual ~ShipDesignManager();
 
-    virtual void StartGame(int empire_id);
+    virtual void StartGame(int empire_id, bool is_new_game);
     virtual void Load(const SaveGameUIData& data);
     virtual void Save(SaveGameUIData& data) const;
 

--- a/UI/MeterBrowseWnd.cpp
+++ b/UI/MeterBrowseWnd.cpp
@@ -391,10 +391,6 @@ void MeterBrowseWnd::UpdateEffectLabelsAndValues(GG::Y& top) {
     for (const Effect::AccountingInfo& info : *maybe_info_vec) {
         std::shared_ptr<const UniverseObject> source = GetUniverseObject(info.source_id);
 
-        const Empire*   empire = nullptr;
-        std::shared_ptr<const Building> building;
-        std::shared_ptr<const Planet> planet;
-        //std::shared_ptr<const Ship> ship;
         std::string     text;
         std::string     name;
         if (source)
@@ -403,7 +399,7 @@ void MeterBrowseWnd::UpdateEffectLabelsAndValues(GG::Y& top) {
         switch (info.cause_type) {
         case ECT_TECH: {
             name.clear();
-            if ((empire = GetEmpire(source->Owner())))
+            if (const auto empire = GetEmpire(source->Owner()))
                 name = empire->Name();
             const std::string& label_template = (info.custom_label.empty()
                 ? UserString("TT_TECH")
@@ -415,8 +411,8 @@ void MeterBrowseWnd::UpdateEffectLabelsAndValues(GG::Y& top) {
         }
         case ECT_BUILDING: {
             name.clear();
-            if (building = std::dynamic_pointer_cast<const Building>(source))
-                if (planet = GetPlanet(building->PlanetID()))
+            if (const auto& building = std::dynamic_pointer_cast<const Building>(source))
+                if (const auto& planet = GetPlanet(building->PlanetID()))
                     name = planet->Name();
             const std::string& label_template = (info.custom_label.empty()
                 ? UserString("TT_BUILDING")

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -1020,13 +1020,13 @@ bool HumanClientApp::ToggleFullscreen() {
     return true;
 }
 
-void HumanClientApp::StartGame() {
+void HumanClientApp::StartGame(bool is_new_game) {
     m_game_started = true;
 
     if (auto&& map_wnd = ClientUI::GetClientUI()->GetMapWnd())
         map_wnd->ResetEmpireShown();
 
-    ClientUI::GetClientUI()->GetShipDesignManager()->StartGame(EmpireID());
+    ClientUI::GetClientUI()->GetShipDesignManager()->StartGame(EmpireID(), is_new_game);
 
     UpdateCombatLogManager();
 }

--- a/client/human/HumanClientApp.h
+++ b/client/human/HumanClientApp.h
@@ -58,6 +58,7 @@ public:
     void                SaveGame(const std::string& filename);          ///< saves the current game; blocks until all save-related network traffic is resolved.
     /** Accepts acknowledgement that server has completed the save.*/
     void                SaveGameCompleted();
+    /** \p is_new_game should be true for a new game and false for a loaded game. */
     void                StartGame(bool is_new_game);
 
     /** Check if the CombatLogManager has incomplete logs that need fetching and start fetching

--- a/client/human/HumanClientApp.h
+++ b/client/human/HumanClientApp.h
@@ -58,7 +58,7 @@ public:
     void                SaveGame(const std::string& filename);          ///< saves the current game; blocks until all save-related network traffic is resolved.
     /** Accepts acknowledgement that server has completed the save.*/
     void                SaveGameCompleted();
-    void                StartGame();
+    void                StartGame(bool is_new_game);
 
     /** Check if the CombatLogManager has incomplete logs that need fetching and start fetching
         them from the server.

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -718,9 +718,10 @@ boost::statechart::result WaitingForGameStart::react(const GameStart& msg) {
 
     GetGameRules().SetFromStrings(Client().GetGalaxySetupData().GetGameRules());
 
-    Client().StartGame();
+    bool is_new_game = !(loaded_game_data && ui_data_available);
+    Client().StartGame(is_new_game);
 
-    if (loaded_game_data && ui_data_available)
+    if (!is_new_game)
         Client().GetClientUI().RestoreFromSaveData(ui_data);
 
     // if I am the host on the first turn, do an autosave. on later turns, will

--- a/network/Message.h
+++ b/network/Message.h
@@ -22,7 +22,7 @@ enum class LogLevel;
 class EmpireManager;
 class SupplyManager;
 class SpeciesManager;
-class CombatLog;
+struct CombatLog;
 class CombatLogManager;
 class Message;
 struct MultiplayerLobbyData;

--- a/universe/Pathfinder.cpp
+++ b/universe/Pathfinder.cpp
@@ -574,12 +574,12 @@ class Pathfinder::PathfinderImpl {
         multimap for Neighbors.*/
      void NeighborsCacheHit(
          boost::unordered_multimap<int, int>& result, size_t _n_outer, size_t _n_inner,
-         size_t ii, const distance_matrix_storage<short>::row_ref row) const;
+         size_t ii, distance_matrix_storage<short>::row_ref row) const;
 
     std::unordered_set<int> WithinJumps(size_t jumps, const std::vector<int>& candidates) const;
     void WithinJumpsCacheHit(
         std::unordered_set<int>* result, size_t jump_limit,
-        size_t ii, const distance_matrix_storage<short>::row_ref row) const;
+        size_t ii, distance_matrix_storage<short>::row_ref row) const;
 
     std::pair<std::vector<std::shared_ptr<const UniverseObject>>, std::vector<std::shared_ptr<const UniverseObject>>>
     WithinJumpsOfOthers(
@@ -600,7 +600,7 @@ class Pathfinder::PathfinderImpl {
     void WithinJumpsOfOthersCacheHit(
         bool& answer, int jumps,
         const std::vector<std::shared_ptr<const UniverseObject>>& others,
-        size_t ii, const distance_matrix_storage<short>::row_ref row) const;
+        size_t ii, distance_matrix_storage<short>::row_ref row) const;
 
     int NearestSystemTo(double x, double y) const;
     void InitializeSystemGraph(const std::vector<int> system_ids, int for_empire_id = ALL_EMPIRES);
@@ -1017,7 +1017,7 @@ std::multimap<double, int> Pathfinder::PathfinderImpl::ImmediateNeighbors(int sy
 
 void Pathfinder::PathfinderImpl::WithinJumpsCacheHit(
     std::unordered_set<int>* result, size_t jump_limit,
-    size_t ii, const distance_matrix_storage<short>::row_ref row) const {
+    size_t ii, distance_matrix_storage<short>::row_ref row) const {
 
     // Scan the LUT of system ids and add any result from the row within
     // the neighborhood range to the results.
@@ -1088,7 +1088,7 @@ struct WithinJumpsOfOthersObjectVisitor : public boost::static_visitor<bool> {
 struct WithinJumpsOfOthersOtherVisitor : public boost::static_visitor<bool> {
     WithinJumpsOfOthersOtherVisitor(const Pathfinder::PathfinderImpl& _pf,
                                     int _jumps,
-                                    const distance_matrix_storage<short>::row_ref _row) :
+                                    distance_matrix_storage<short>::row_ref _row) :
         pf(_pf), jumps(_jumps), row(_row)
     {}
 
@@ -1114,14 +1114,14 @@ struct WithinJumpsOfOthersOtherVisitor : public boost::static_visitor<bool> {
     }
     const Pathfinder::PathfinderImpl& pf;
     int jumps;
-    const distance_matrix_storage<short>::row_ref row;
+    distance_matrix_storage<short>::row_ref row;
 };
 
 
 void Pathfinder::PathfinderImpl::WithinJumpsOfOthersCacheHit(
     bool& answer, int jumps,
     const std::vector<std::shared_ptr<const UniverseObject>>& others,
-    size_t ii, const distance_matrix_storage<short>::row_ref row) const
+    size_t ii, distance_matrix_storage<short>::row_ref row) const
 {
     // Check if any of the others are within jumps of candidate, by looping
     // through all of the others and applying the WithinJumpsOfOthersOtherVisitor.

--- a/util/Order.cpp
+++ b/util/Order.cpp
@@ -34,12 +34,19 @@ Empire* Order::GetValidatedEmpire() const {
 }
 
 void Order::Execute() const {
+    if (m_executed)
+        return;
+
     ExecuteImpl();
     m_executed = true;
 }
 
-bool Order::Undo() const
-{ return UndoImpl(); }
+bool Order::Undo() const {
+    auto undone =  UndoImpl();
+    if (undone)
+        m_executed = false;
+    return undone;
+}
 
 bool Order::Executed() const
 { return m_executed; }

--- a/util/Order.h
+++ b/util/Order.h
@@ -53,6 +53,8 @@ public:
      *  For all order subclasses, the empire ID for the order
      *  must be that of an existing empire.
      *
+     *  The order has not already been executed.
+     *
      *  Subclasses add additional preconditions.  An std::runtime_error
      *   should be thrown if any precondition fails.
      */
@@ -60,7 +62,8 @@ public:
 
     /** If this function returns true, it reverts the game state to what it was
      *  before this order was executed, otherwise it returns false and has no
-     *  effect. */
+     *  effect. If an order is undone on the client and then still sent to the server it will be
+     *  executed on the server, which is probably not desired. */
     bool Undo() const;
 
 protected:

--- a/util/OrderSet.cpp
+++ b/util/OrderSet.cpp
@@ -15,17 +15,15 @@ const OrderPtr OrderSet::ExamineOrder(int order) const {
     return retval;
 }
 
-int OrderSet::IssueOrder(const OrderPtr& order, bool suppress_immediate_execution /*= false*/)
-{ return IssueOrder(OrderPtr(order), suppress_immediate_execution); }
+int OrderSet::IssueOrder(const OrderPtr& order)
+{ return IssueOrder(OrderPtr(order)); }
 
-int OrderSet::IssueOrder(OrderPtr&& order, bool suppress_immediate_execution /*= false*/) {
+int OrderSet::IssueOrder(OrderPtr&& order) {
     int retval = ((m_orders.rbegin() != m_orders.rend()) ? m_orders.rbegin()->first + 1 : 0);
 
     // Insert the order into the m_orders map.  forward the rvalue to use the move constructor.
     auto inserted = m_orders.insert(std::make_pair(retval, std::forward<OrderPtr>(order)));
-
-    if (!suppress_immediate_execution)
-        inserted.first->second->Execute();
+    inserted.first->second->Execute();
 
     return retval;
 }

--- a/util/OrderSet.h
+++ b/util/OrderSet.h
@@ -52,11 +52,11 @@ public:
     //@}
 
     /** \name Mutators */ //@{
-    /** If \p suppress_immediate_execution is false, then execute the \p order immediately on the client.
-        Always store the \p order in the OrderSet to be executed later on the server.
+    /** Execute the \p order immediately on the client.
+        Store the \p order in the OrderSet to be executed later on the server.
         Return an index that can be used to reference the order. */
-    int            IssueOrder(const OrderPtr& order, bool suppress_immediate_execution = false);
-    int            IssueOrder(OrderPtr&& order, bool suppress_immediate_execution = false);
+    int            IssueOrder(const OrderPtr& order);
+    int            IssueOrder(OrderPtr&& order);
 
     /** Applies all Orders in the OrderSet.  As of this writing, this is needed only after deserializing an OrderSet
         client-side during game loading. */

--- a/util/OrderSet.h
+++ b/util/OrderSet.h
@@ -17,7 +17,23 @@ class Order;
 /** The pointer type used to store Orders in OrderSets. */
 typedef std::shared_ptr<Order> OrderPtr;
 
-/** a collection of orders that may be searched using arbitrary predicate functions and functors*/
+/** A collection of orders that may be searched using arbitrary predicate
+    functions and functors.
+
+    An OrderSet is typically composed on the client with IssueOrder(order), and
+    then sent to the server to be executed again. IssueOrder(order) immediately
+    executes the order to change the client's backend state.  The second
+    execution on the server changes the server game state. Orders only executed
+    on the client do not change the server save game state.
+
+    On game reload, reloaded orders need to be re-executed on the client because
+    the client state start from the last saved server state. Orders are
+    saved/serialized as unexecuted so that when they are loaded they can be
+    mixed with newly issued orders and both the loaded and newly issued orders
+    will only execute once.
+
+    RescindOrder(order) will try Order::Undo() and if that succeeds remove the
+    order from the set.  */
 class FO_COMMON_API OrderSet {
 private:
     typedef std::map<int, OrderPtr> OrderMap;
@@ -62,7 +78,9 @@ public:
         client-side during game loading. */
     void           ApplyOrders();
 
-    bool           RescindOrder(int order);    ///< removes the order from the OrderSet; returns true on success, false if there was no such order or the order is non-rescindable
+    /** Try to Undo() \p order and if it succeeds remove the order from the
+        set.  Return true if \p order exists and was successfully removed. */
+    bool           RescindOrder(int order);
     void           Reset(); ///< clears all orders; should be called at the beginning of a new turn
     //@}
 

--- a/util/SerializeOrderSet.cpp
+++ b/util/SerializeOrderSet.cpp
@@ -14,6 +14,8 @@
 ////////////////////////////////////////////////////////////
 
 // exports for boost serialization of polymorphic Order hierarchy
+BOOST_CLASS_EXPORT(Order)
+BOOST_CLASS_VERSION(Order, 1)
 BOOST_CLASS_EXPORT(RenameOrder)
 BOOST_CLASS_EXPORT(NewFleetOrder)
 BOOST_CLASS_EXPORT(FleetMoveOrder)
@@ -34,8 +36,15 @@ BOOST_CLASS_EXPORT(ForgetOrder)
 template <class Archive>
 void Order::serialize(Archive& ar, const unsigned int version)
 {
-    ar  & BOOST_SERIALIZATION_NVP(m_empire)
-        & BOOST_SERIALIZATION_NVP(m_executed);
+    ar  & BOOST_SERIALIZATION_NVP(m_empire);
+    /* m_executed is intentionally not serialized so that an order is run once
+      on the client and then deserialized and run once on the server.
+      ar    & BOOST_SERIALIZATION_NVP(m_executed); */
+    if (Archive::is_loading::value && version < 1) {
+        bool dummy_executed;
+        ar  & boost::serialization::make_nvp("m_executed", dummy_executed);
+    }
+
 }
 
 template <class Archive>

--- a/util/SerializeOrderSet.cpp
+++ b/util/SerializeOrderSet.cpp
@@ -37,8 +37,8 @@ template <class Archive>
 void Order::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_NVP(m_empire);
-    /* m_executed is intentionally not serialized so that an order is run once
-      on the client and then deserialized and run once on the server.
+    /** m_executed is intentionally not serialized so that orders always deserialize with m_execute
+      = false.  See class comment for OrderSet.
       ar    & BOOST_SERIALIZATION_NVP(m_executed); */
     if (Archive::is_loading::value && version < 1) {
         bool dummy_executed;


### PR DESCRIPTION
Replace it with single execution on the client and server of each order.

This means that if an order needs to be issued during game load it can
take immediate effect on the client, and still not be re-executed by the
MapWnd initialization.

This does not need a special bool parameter.  It just works regardless of whether the order is coming from a loaded order or an order issued before or after the `MapInit()` function.