### PR TITLE
Simplify part stacking rules by using the FOCS "exclusions" keyword

### DIFF
--- a/default/scripting/ship_parts/Cloaks.focs.txt
+++ b/default/scripting/ship_parts/Cloaks.focs.txt
@@ -1,6 +1,7 @@
 Part
     name = "ST_CLOAK_4"
     description = "ST_CLOAK_4_DESC"
+    exclusions = [[ALL_CLOAKS]]
     class = Stealth
     capacity = 80
     mountableSlotTypes = Internal
@@ -8,12 +9,12 @@ Part
     buildtime = 10
     tags = [ "PEDIA_PC_STEALTH" ]
     location = OwnedBy empire = Source.Owner
-    effectsgroups = [[CLOAK_STACKING]]   //Make sure to add new cloaks to SUM_CLOAK_CAPACITY and BEST_CLOAK_EFFECT
     icon = "icons/ship_parts/cloak-4.png"
 
 Part
     name = "ST_CLOAK_3"
     description = "ST_CLOAK_3_DESC"
+    exclusions = [[ALL_CLOAKS]]
     class = Stealth
     capacity = 60
     mountableSlotTypes = Internal
@@ -21,12 +22,12 @@ Part
     buildtime = 7
     tags = [ "PEDIA_PC_STEALTH" ]
     location = OwnedBy empire = Source.Owner
-    effectsgroups = [[CLOAK_STACKING]]   //Make sure to add new cloaks to SUM_CLOAK_CAPACITY and BEST_CLOAK_EFFECT
     icon = "icons/ship_parts/cloak-3.png"
 
 Part
     name = "ST_CLOAK_2"
     description = "ST_CLOAK_2_DESC"
+    exclusions = [[ALL_CLOAKS]]
     class = Stealth
     capacity = 40
     mountableSlotTypes = Internal
@@ -34,12 +35,12 @@ Part
     buildtime = 5
     tags = [ "PEDIA_PC_STEALTH" ]
     location = OwnedBy empire = Source.Owner
-    effectsgroups = [[CLOAK_STACKING]]   //Make sure to add new cloaks to SUM_CLOAK_CAPACITY and BEST_CLOAK_EFFECT
     icon = "icons/ship_parts/cloak-2.png"
 
 Part
     name = "ST_CLOAK_1"
     description = "ST_CLOAK_1_DESC"
+    exclusions = [[ALL_CLOAKS]]
     class = Stealth
     capacity = 20
     mountableSlotTypes = Internal
@@ -47,9 +48,19 @@ Part
     buildtime = 3
     tags = [ "PEDIA_PC_STEALTH" ]
     location = OwnedBy empire = Source.Owner
-    effectsgroups = [[CLOAK_STACKING]]   //Make sure to add new cloaks to SUM_CLOAK_CAPACITY and BEST_CLOAK_EFFECT
     icon = "icons/ship_parts/cloak-1.png"
 
-#include "stacking.macros"
+
+// Helper macro containing the names of all cloaks
+ALL_CLOAKS
+'''
+[
+    "ST_CLOAK_1"
+    "ST_CLOAK_2"
+    "ST_CLOAK_3"
+    "ST_CLOAK_4"
+]
+'''
+
 
 #include "/scripting/common/upkeep.macros"

--- a/default/scripting/ship_parts/Detectors.focs.txt
+++ b/default/scripting/ship_parts/Detectors.focs.txt
@@ -1,6 +1,7 @@
 Part
     name = "DT_DETECTOR_4"
     description = "DT_DETECTOR_4_DESC"
+    exclusions = [[ALL_DETECTORS]]
     class = Detection
     capacity = 200
     mountableSlotTypes = External
@@ -8,12 +9,12 @@ Part
     buildtime = 5
     tags = [ "PEDIA_PC_DETECTION" ]
     location = OwnedBy empire = Source.Owner
-    effectsgroups = [[DETECTOR_STACKING]]   //Make sure to add new detectors to SUM_DETECTOR_CAPACITY and BEST_DETECTOR_EFFECT
     icon = "icons/ship_parts/detector-4.png"
 
 Part
     name = "DT_DETECTOR_3"
     description = "DT_DETECTOR_3_DESC"
+    exclusions = [[ALL_DETECTORS]]
     class = Detection
     capacity = 150
     mountableSlotTypes = External
@@ -21,12 +22,12 @@ Part
     buildtime = 5
     tags = [ "PEDIA_PC_DETECTION" ]
     location = OwnedBy empire = Source.Owner
-    effectsgroups = [[DETECTOR_STACKING]]   //Make sure to add new detectors to SUM_DETECTOR_CAPACITY and BEST_DETECTOR_EFFECT
     icon = "icons/ship_parts/detector-3.png"
 
 Part
     name = "DT_DETECTOR_2"
     description = "DT_DETECTOR_2_DESC"
+    exclusions = [[ALL_DETECTORS]]
     class = Detection
     capacity = 75
     mountableSlotTypes = External
@@ -34,12 +35,12 @@ Part
     buildtime = 4
     tags = [ "PEDIA_PC_DETECTION" ]
     location = OwnedBy empire = Source.Owner
-    effectsgroups = [[DETECTOR_STACKING]]   //Make sure to add new detectors to SUM_DETECTOR_CAPACITY and BEST_DETECTOR_EFFECT
     icon = "icons/ship_parts/detector-2.png"
 
 Part
     name = "DT_DETECTOR_1"
     description = "DT_DETECTOR_1_DESC"
+    exclusions = [[ALL_DETECTORS]]
     class = Detection
     capacity = 25
     mountableSlotTypes = External
@@ -47,9 +48,18 @@ Part
     buildtime = 2
     tags = [ "PEDIA_PC_DETECTION" ]
     location = OwnedBy empire = Source.Owner
-    effectsgroups = [[DETECTOR_STACKING]]   //Make sure to add new detectors to SUM_DETECTOR_CAPACITY and BEST_DETECTOR_EFFECT
     icon = "icons/ship_parts/detector-1.png"
 
-#include "stacking.macros"
+
+// Helper macro that contains all detector parts
+ALL_DETECTORS
+'''
+[
+    "DT_DETECTOR_1"
+    "DT_DETECTOR_2"
+    "DT_DETECTOR_3"
+    "DT_DETECTOR_4"
+]
+'''
 
 #include "/scripting/common/upkeep.macros"

--- a/default/scripting/ship_parts/Shields.focs.txt
+++ b/default/scripting/ship_parts/Shields.focs.txt
@@ -1,6 +1,7 @@
 Part
     name = "SH_DEFENSE_GRID"
     description = "SH_DEFENSE_GRID_DESC"
+    exclusions = [[ALL_SHIELDS]]
     class = Shield
     capacity = 3
     mountableSlotTypes = Internal
@@ -8,12 +9,12 @@ Part
     buildtime = 2
     tags = [ "PEDIA_PC_SHIELD" ]
     location = OwnedBy empire = Source.Owner
-    effectsgroups = [[SHIELD_STACKING]]    //Make sure to add new shields to SUM_SHIELD_CAPACITY and BEST_SHIELD_EFFECT
     icon = "icons/ship_parts/defense_grid.png"
 
 Part
     name = "SH_DEFLECTOR"
     description = "SH_DEFLECTOR_DESC"
+    exclusions = [[ALL_SHIELDS]]
     class = Shield
     capacity = 5
     mountableSlotTypes = Internal
@@ -21,12 +22,12 @@ Part
     buildtime = 4
     tags = [ "PEDIA_PC_SHIELD" ]
     location = OwnedBy empire = Source.Owner
-    effectsgroups = [[SHIELD_STACKING]]    //Make sure to add new shields to SUM_SHIELD_CAPACITY and BEST_SHIELD_EFFECT
     icon = "icons/ship_parts/deflector_shield.png"
 
 Part
     name = "SH_PLASMA"
     description = "SH_PLASMA_DESC"
+    exclusions = [[ALL_SHIELDS]]
     class = Shield
     capacity = 9
     mountableSlotTypes = Internal
@@ -34,12 +35,12 @@ Part
     buildtime = 5
     tags = [ "PEDIA_PC_SHIELD" ]
     location = OwnedBy empire = Source.Owner
-    effectsgroups = [[SHIELD_STACKING]]    //Make sure to add new shields to SUM_SHIELD_CAPACITY and BEST_SHIELD_EFFECT
     icon = "icons/ship_parts/plasma_shield.png"
 
 Part
     name = "SH_BLACK"
     description = "SH_BLACK_DESC"
+    exclusions = [[ALL_SHIELDS]]
     class = Shield
     capacity = 15
     mountableSlotTypes = Internal
@@ -47,12 +48,12 @@ Part
     buildtime = 6
     tags = [ "PEDIA_PC_SHIELD" ]
     location = OwnedBy empire = Source.Owner
-    effectsgroups = [[SHIELD_STACKING]]    //Make sure to add new shields to SUM_SHIELD_CAPACITY and BEST_SHIELD_EFFECT
     icon = "icons/ship_parts/blackshield.png"
 
 Part
     name = "SH_MULTISPEC"
     description = "SH_MULTISPEC_DESC"
+    exclusions = [[ALL_SHIELDS]]
     class = Shield
     capacity = 10
     mountableSlotTypes = Internal
@@ -61,7 +62,6 @@ Part
     tags = [ "PEDIA_PC_SHIELD" ]
     location = OwnedBy empire = Source.Owner
     effectsgroups = [
-        [[SHIELD_STACKING]]     //Make sure to add new shields to SUM_SHIELD_CAPACITY and BEST_SHIELD_EFFECT
         EffectsGroup
             scope = Source
             activation = Star type = [Red Orange Yellow White Blue]
@@ -70,6 +70,17 @@ Part
     ]
     icon = "icons/ship_parts/multi-spectral.png"
 
-#include "stacking.macros"
+
+// Helper macro containing the name of all shields
+ALL_SHIELDS
+'''
+[
+    "SH_MULTISPEC"
+    "SH_BLACK"
+    "SH_PLASMA"
+    "SH_DEFLECTOR"
+    "SH_DEFENSE_GRID"
+]
+'''
 
 #include "/scripting/common/upkeep.macros"

--- a/default/scripting/ship_parts/stacking.macros
+++ b/default/scripting/ship_parts/stacking.macros
@@ -23,26 +23,6 @@ max(max(max(
 '''
 
 
-SUM_CLOAK_CAPACITY
-'''
-((PartCapacity name = "ST_CLOAK_1")* (PartsInShipDesign Name = "ST_CLOAK_1" design = Source.DesignID)
-+(PartCapacity name = "ST_CLOAK_2")* (PartsInShipDesign Name = "ST_CLOAK_2" design = Source.DesignID)
-+(PartCapacity name = "ST_CLOAK_3")* (PartsInShipDesign Name = "ST_CLOAK_3" design = Source.DesignID)
-+(PartCapacity name = "ST_CLOAK_4")* (PartsInShipDesign Name = "ST_CLOAK_4" design = Source.DesignID))
-'''
-
-
-CLOAK_STACKING
-'''
-EffectsGroup    // Make sure to add new cloak parts to the macros SUM_CLOAK_CAPACITY and BEST_CLOAK_EFFECT
-    scope = Source
-    activation = DesignHasPartClass Low=2 High=999 Class=Stealth
-    stackinggroup = "STEALTH_PART_STACK"
-    accountinglabel = "CLOAK_INTERFERENCE"
-    effects = SetStealth value = Value - [[SUM_CLOAK_CAPACITY]] + [[BEST_CLOAK_EFFECT]]
-'''
-
-
 BEST_SHIELD_EFFECT
 '''
 max(max(max(max(

--- a/default/scripting/ship_parts/stacking.macros
+++ b/default/scripting/ship_parts/stacking.macros
@@ -9,39 +9,6 @@ If new parts in these categories are introduced, make sure to add the X_STACKING
 SUM_X_CAPACITY and BEST_X_EFFECT macros.
 */
 
-BEST_DETECTOR_EFFECT
-'''
-max(max(max(
-    min(1, PartsInShipDesign Name = "DT_DETECTOR_1" design = Source.DesignID) // 0 if no "DT_DETECTOR_1" in the design else 1
-    * PartCapacity name = "DT_DETECTOR_1",
-    min(1, PartsInShipDesign Name = "DT_DETECTOR_2" design = Source.DesignID)
-    * PartCapacity name = "DT_DETECTOR_2"),
-    min(1, PartsInShipDesign Name = "DT_DETECTOR_3" design = Source.DesignID)
-    * PartCapacity name = "DT_DETECTOR_3"),
-    min(1, PartsInShipDesign Name = "DT_DETECTOR_4" design = Source.DesignID)
-    * PartCapacity name = "DT_DETECTOR_4")
-'''
-
-
-SUM_DETECTOR_CAPACITY
-'''
-((PartCapacity name = "DT_DETECTOR_1")* (PartsInShipDesign Name = "DT_DETECTOR_1" design = Source.DesignID)
-+(PartCapacity name = "DT_DETECTOR_2")* (PartsInShipDesign Name = "DT_DETECTOR_2" design = Source.DesignID)
-+(PartCapacity name = "DT_DETECTOR_3")* (PartsInShipDesign Name = "DT_DETECTOR_3" design = Source.DesignID)
-+(PartCapacity name = "DT_DETECTOR_4")* (PartsInShipDesign Name = "DT_DETECTOR_4" design = Source.DesignID))
-'''
-
-
-DETECTOR_STACKING
-'''
-EffectsGroup    // Make sure to add new detector parts to the macros SUM_DETECTOR_CAPACITY and BEST_DETECTOR_EFFECT
-    scope = Source
-    activation = DesignHasPartClass Low=2 High=999 Class=Detection
-    stackinggroup = "DETECTOR_PART_STACK"
-    accountinglabel = "DETECTOR_INTERFERENCE"
-    effects = SetDetection value = Value - [[SUM_DETECTOR_CAPACITY]] + [[BEST_DETECTOR_EFFECT]]
-'''
-
 BEST_CLOAK_EFFECT
 '''
 max(max(max(

--- a/default/scripting/ship_parts/stacking.macros
+++ b/default/scripting/ship_parts/stacking.macros
@@ -38,24 +38,3 @@ max(max(max(max(
     * PartCapacity name = "SH_MULTISPEC" 
     )
 '''
-
-
-SUM_SHIELD_CAPACITY
-'''
-((PartCapacity name = "SH_DEFENSE_GRID")* (PartsInShipDesign Name = "SH_DEFENSE_GRID" design = Source.DesignID)
-+(PartCapacity name = "SH_DEFLECTOR")* (PartsInShipDesign Name = "SH_DEFLECTOR" design = Source.DesignID)
-+(PartCapacity name = "SH_PLASMA")* (PartsInShipDesign Name = "SH_PLASMA" design = Source.DesignID)
-+(PartCapacity name = "SH_BLACK")* (PartsInShipDesign Name = "SH_BLACK" design = Source.DesignID)
-+(PartCapacity name = "SH_MULTISPEC")* (PartsInShipDesign Name = "SH_MULTISPEC" design = Source.DesignID))
-'''
-
-
-SHIELD_STACKING
-'''
-EffectsGroup    // Make sure to add new shield parts to the macros SUM_SHIELD_CAPACITY and BEST_SHIELD_EFFECT
-    scope = Source
-    activation = DesignHasPartClass Low=2 High=999 Class=Shield
-    stackinggroup = "SHIELD_PART_STACK"
-    accountinglabel = "SHIELD_INTERFERENCE"
-    effects = SetMaxShield value = Value - [[SUM_SHIELD_CAPACITY]] + [[BEST_SHIELD_EFFECT]]
-'''


### PR DESCRIPTION
The previous effectgroups were a workaround from a time where we did not have the ```exclusions``` keyword in FOCS which provides a simpler and more user friendly functionality by actually preventing the user from building invalid designs.

This also reduces the number of effects in the game, possibly leading to some minor performance improvements in the lategame.


Note that the BEST_SHIELD_EFFECT and BEST_CLOAK_EFFECT macros are kept for now because FU_TRANSPATIAL_DRIVE and SH_ROBOTIC_INTERFACE_SHIELDS rely on these.