### PR TITLE
Add GG::Wnd::Create<T>() and GG::Wnd::CompleteConstruction().

### DIFF
--- a/GG/GG/Wnd.h
+++ b/GG/GG/Wnd.h
@@ -338,8 +338,8 @@ public:
     }
 
     /** CompleteConstruction() should be overriden to complete construction of derived classes that
-        need a fully formed weak_from_this() (i.e. to call AttachChild()) to be correctly constructed. */
-    virtual void CompleteConstruction(){};
+        need a fully formed weak_from_this() (e.g. to call AttachChild()) to be correctly constructed. */
+    virtual void CompleteConstruction() {};
 
     /** \name Accessors */ ///@{
     /** Returns true iff a click over this window does not pass through.  Note


### PR DESCRIPTION
After the conversion to using shared_ptr to track manage Wnd, AttachChild() will
not be callable within a constructor, because it requires a completely
constructed shared_from_this().

Wnd::Create<T> is a generic factory function for Wnd derived types T.  It
constructs the shared pointer and then calls CompleteConstruction() to handle
operations that require a shared_from_this().

T can override CompleteConstruction() to provide any post
constructor work needed to complete the class T.