### PR TITLE
Add all CompleteConstruction() functions for GG and UI constructors.

### DIFF
--- a/GG/GG/BrowseInfoWnd.h
+++ b/GG/GG/BrowseInfoWnd.h
@@ -109,6 +109,7 @@ public:
     TextBoxBrowseInfoWnd(X w, const std::shared_ptr<Font>& font, Clr color, Clr border_color, Clr text_color,
                          Flags<TextFormat> format = FORMAT_LEFT | FORMAT_WORDBREAK,
                          unsigned int border_width = 2, unsigned int text_margin = 4);
+    void CompleteConstruction() override;
     //@}
 
     /** \name Accessors */ ///@{

--- a/GG/GG/BrowseInfoWnd.h
+++ b/GG/GG/BrowseInfoWnd.h
@@ -159,6 +159,7 @@ private:
     unsigned int            m_border_width;
     X                       m_preferred_width;
     TextControl*            m_text_control;
+    unsigned int            m_text_margin;
 };
 
 } // namespace GG

--- a/GG/GG/Button.h
+++ b/GG/GG/Button.h
@@ -170,6 +170,7 @@ public:
     StateButton(const std::string& str, const std::shared_ptr<Font>& font, Flags<TextFormat> format,
                 Clr color, std::shared_ptr<StateButtonRepresenter> representer, Clr text_color = CLR_BLACK); ///< Ctor
     //@}
+    void CompleteConstruction() override;
 
     /** \name Accessors */ ///@{
     Pt MinUsableSize() const override;

--- a/GG/GG/Button.h
+++ b/GG/GG/Button.h
@@ -62,10 +62,11 @@ public:
     typedef boost::signals2::signal<void ()> ClickedSignalType;
     //@}
 
-    /** \name Structors */ ///@{
+   /** \name Structors */ ///@{
     Button(const std::string& str, const std::shared_ptr<Font>& font, Clr color,
            Clr text_color = CLR_BLACK, Flags<WndFlag> flags = INTERACTIVE);
     //@}
+    void CompleteConstruction() override;
 
     /** \name Accessors */ ///@{
     Pt MinUsableSize() const override;

--- a/GG/GG/GroupBox.h
+++ b/GG/GG/GroupBox.h
@@ -47,6 +47,7 @@ public:
     GroupBox(X x, Y y, X w, Y h, const std::string& label, const std::shared_ptr<Font>& font, Clr color,
              Clr text_color = CLR_BLACK, Clr interior = CLR_ZERO, Flags<WndFlag> flags = NO_WND_FLAGS);
     //@}
+    void CompleteConstruction() override;
 
     /** \name Accessors */ ///@{
     Pt ClientUpperLeft() const override;

--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -134,11 +134,11 @@ public:
 
         /** \name Structors */ ///@{
         Row();
-
         Row(X w, Y h, const std::string& drag_drop_data_type, Alignment align = ALIGN_VCENTER, unsigned int margin = 2);
-
         virtual ~Row();
         //@}
+
+        void CompleteConstruction() override;
 
         /** \name Accessors */ ///@{
         /** Returns the string by which this row may be sorted. */

--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -260,6 +260,8 @@ public:
     virtual ~ListBox();
     //@}
 
+    void CompleteConstruction() override;
+
     /** \name Accessors */ ///@{
     Pt MinUsableSize() const override;
     Pt ClientUpperLeft() const override;

--- a/GG/GG/RichText/ImageBlock.h
+++ b/GG/GG/RichText/ImageBlock.h
@@ -59,6 +59,7 @@ public:
      * @param image_path The path to the image.
      */
     ImageBlock(const boost::filesystem::path& path, X x, Y y, X w, GG::Flags<GG::WndFlag> flags);
+    void CompleteConstruction() override;
 
     //! Implement from BlockControl sets the maximum width, returns the actual size based on that.
     Pt SetMaxWidth(X width) override;

--- a/GG/GG/Scroll.h
+++ b/GG/GG/Scroll.h
@@ -81,6 +81,7 @@ public:
     /** Ctor. */
     Scroll(Orientation orientation, Clr color, Clr interior);
     //@}
+    void CompleteConstruction() override;
 
     /** \name Accessors */ ///@{
     Pt MinUsableSize() const override;

--- a/GG/GG/ScrollPanel.h
+++ b/GG/GG/ScrollPanel.h
@@ -49,6 +49,7 @@ public:
     ScrollPanel();
     //! Create a ScrollPanel with content.
     ScrollPanel(X x, Y y, X w, Y h, Wnd* content);
+    void CompleteConstruction() override;
 
     void SizeMove(const Pt& ul, const Pt& lr) override;
     void Render() override;

--- a/GG/GG/Slider.h
+++ b/GG/GG/Slider.h
@@ -72,6 +72,7 @@ public:
     Slider(T min, T max, Orientation orientation, Clr color,
            unsigned int tab_width, unsigned int line_width = 5, Flags<WndFlag> flags = INTERACTIVE);
     //@}
+    void CompleteConstruction() override;
 
     /** \name Accessors */ ///@{
     Pt MinUsableSize() const override;
@@ -172,6 +173,11 @@ Slider<T>::Slider(T min, T max, Orientation orientation,
     m_dragging_tab(false)
 {
     Control::SetColor(color);
+}
+
+template <class T>
+void Slider<T>::CompleteConstruction()
+{
     AttachChild(m_tab);
     m_tab->InstallEventFilter(this);
     SizeMove(UpperLeft(), LowerRight());

--- a/GG/GG/Spin.h
+++ b/GG/GG/Spin.h
@@ -221,7 +221,7 @@ void Spin<T>::CompleteConstruction()
     AttachChild(m_down_button);
     ConnectSignals();
     SizeMove(UpperLeft(), LowerRight());
-    Spin<T>::SetEditTextFromValue();    // should call any derived-class overloads in derived-class constructor. can't do a virtual method call in base class constructor.
+    Spin<T>::SetEditTextFromValue();
 }
 
 template<class T>

--- a/GG/GG/Spin.h
+++ b/GG/GG/Spin.h
@@ -198,7 +198,7 @@ Spin<T>::Spin(T value, T step, T min, T max, bool edits, const std::shared_ptr<F
     m_down_button(nullptr),
     m_button_width(15)
 {
-    std::shared_ptr<StyleFactory> style = GetStyleFactory();
+    const auto& style = GetStyleFactory();
     Control::SetColor(color);
     m_edit = style->NewSpinEdit("", font, CLR_ZERO, text_color, CLR_ZERO);
     std::shared_ptr<Font> small_font = GUI::GetGUI()->GetFont(font, static_cast<int>(font->PointSize() * 0.75));
@@ -212,7 +212,7 @@ Spin<T>::Spin(T value, T step, T min, T max, bool edits, const std::shared_ptr<F
 template<class T>
 void Spin<T>::CompleteConstruction()
 {
-    std::shared_ptr<StyleFactory> style = GetStyleFactory();
+    const auto& style = GetStyleFactory();
     m_edit->InstallEventFilter(this);
     m_up_button->InstallEventFilter(this);
     m_down_button->InstallEventFilter(this);

--- a/GG/GG/TabWnd.h
+++ b/GG/GG/TabWnd.h
@@ -206,7 +206,9 @@ public:
     /** \name Structors */ ///@{
     TabBar(const std::shared_ptr<Font>& font, Clr color, Clr text_color = CLR_BLACK,
            Flags<WndFlag> flags = INTERACTIVE);
+    void CompleteConstruction() override;
     //@}
+public:
 
     /** \name Accessors */ ///@{
     Pt MinUsableSize() const override;

--- a/GG/GG/TabWnd.h
+++ b/GG/GG/TabWnd.h
@@ -44,9 +44,9 @@ class GG_API OverlayWnd : public Wnd
 public:
     /** \name Structors */ ///@{
     OverlayWnd(X x, Y y, X w, Y h, Flags<WndFlag> flags = NO_WND_FLAGS);
-
     ~OverlayWnd();
     //@}
+    void CompleteConstruction() override;
 
     /** \name Accessors */ ///@{
     Pt MinUsableSize() const override;
@@ -119,6 +119,7 @@ public:
     /** \name Structors */ ///@{
     TabWnd(X x, Y y, X w, Y h, const std::shared_ptr<Font>& font, Clr color, Clr text_color = CLR_BLACK);
     //@}
+    void CompleteConstruction() override;
 
     /** \name Accessors */ ///@{
     Pt MinUsableSize() const override;

--- a/GG/GG/Wnd.h
+++ b/GG/GG/Wnd.h
@@ -696,6 +696,14 @@ public:
         std::out_of_range if \a mode is not a valid browse mode. */
     void SetBrowseInfoWnd(const std::shared_ptr<BrowseInfoWnd>& wnd, std::size_t mode = 0);
 
+    /** Sets the Wnd that is used to show browse info about this Wnd in the
+        browse info mode \a mode.  \throw std::out_of_range May throw
+        std::out_of_range if \a mode is not a valid browse mode.
+
+        Temporary overload which inserts \p wnd into a shared_ptr.
+        TODO remove once conversion to shared_ptr children is complete. */
+    void SetBrowseInfoWnd(BrowseInfoWnd* wnd, std::size_t mode = 0);
+
     /** Removes the Wnd that is used to show browse info about this Wnd in the
         browse info mode \a mode (but does nothing to the mode itself).
         \throw std::out_of_range May throw std::out_of_range if \a mode is not

--- a/GG/GG/dialogs/ColorDlg.h
+++ b/GG/GG/dialogs/ColorDlg.h
@@ -190,6 +190,7 @@ public:
     ColorDlg(X x, Y y, Clr original_color, const std::shared_ptr<Font>& font,
              Clr dialog_color, Clr border_color, Clr text_color = CLR_BLACK);
     //@}
+    void CompleteConstruction() override;
 
     /** \name Accessors */ ///@{
     /** Returns true iff the user selected a color and then clicked the "Ok"

--- a/GG/GG/dialogs/FileDlg.h
+++ b/GG/GG/dialogs/FileDlg.h
@@ -69,6 +69,7 @@ public:
     FileDlg(const std::string& directory, const std::string& filename, bool save, bool multi, const std::shared_ptr<Font>& font,
             Clr color, Clr border_color, Clr text_color = CLR_BLACK);
     //@}
+    void CompleteConstruction() override;
 
     /** \name Accessors */ ///@{
     std::set<std::string> Result() const; ///< returns a set of strings that contains the files chosen by the user; there will be only one file if \a multi == false was passed to the ctor
@@ -176,6 +177,9 @@ private:
     Button*          m_cancel_button;
     TextControl*     m_files_label;
     TextControl*     m_file_types_label;
+
+    std::string      m_init_directory; ///< directory passed to constructor
+    std::string      m_init_filename; ///< filename passed to constructor
 
     static boost::filesystem::path s_working_dir; ///< declared static so each instance of FileDlg opens up the same directory
 };

--- a/GG/GG/dialogs/ThreeButtonDlg.h
+++ b/GG/GG/dialogs/ThreeButtonDlg.h
@@ -63,6 +63,7 @@ public:
                    Clr border_color, Clr button_color, Clr text_color, std::size_t buttons, const std::string& zero = "", 
                    const std::string& one = "", const std::string& two = "");
     //@}
+    void CompleteConstruction() override;
 
     /** \name Accessors */ ///@{
     Clr         ButtonColor() const;   ///< returns the color of the buttons in the dialog
@@ -99,6 +100,7 @@ private:
     Button*     m_button_0;
     Button*     m_button_1;
     Button*     m_button_2;
+    Layout*     m_button_layout;
 };
 
 } // namespace GG

--- a/GG/src/BrowseInfoWnd.cpp
+++ b/GG/src/BrowseInfoWnd.cpp
@@ -88,10 +88,14 @@ TextBoxBrowseInfoWnd::TextBoxBrowseInfoWnd(X w, const std::shared_ptr<Font>& fon
     m_preferred_width(w),
     m_text_control(GetStyleFactory()->NewTextControl("", m_font, text_color, format))
 {
-    m_text_control->Resize(Pt(w, m_text_control->Height()));
+    SetLayoutBorderMargin(text_margin);
+}
+
+void TextBoxBrowseInfoWnd::CompleteConstruction()
+{
+    m_text_control->Resize(Pt(Width(), m_text_control->Height()));
     AttachChild(m_text_control);
     GridLayout();
-    SetLayoutBorderMargin(text_margin);
     InitBuffer();
 }
 

--- a/GG/src/BrowseInfoWnd.cpp
+++ b/GG/src/BrowseInfoWnd.cpp
@@ -86,16 +86,16 @@ TextBoxBrowseInfoWnd::TextBoxBrowseInfoWnd(X w, const std::shared_ptr<Font>& fon
     m_border_color(border_color),
     m_border_width(border_width),
     m_preferred_width(w),
-    m_text_control(GetStyleFactory()->NewTextControl("", m_font, text_color, format))
-{
-    SetLayoutBorderMargin(text_margin);
-}
+    m_text_control(GetStyleFactory()->NewTextControl("", m_font, text_color, format)),
+    m_text_margin(text_margin)
+{}
 
 void TextBoxBrowseInfoWnd::CompleteConstruction()
 {
     m_text_control->Resize(Pt(Width(), m_text_control->Height()));
     AttachChild(m_text_control);
     GridLayout();
+    SetLayoutBorderMargin(m_text_margin);
     InitBuffer();
 }
 

--- a/GG/src/Button.cpp
+++ b/GG/src/Button.cpp
@@ -56,12 +56,14 @@ Button::Button(const std::string& str, const std::shared_ptr<Font>& font, Clr co
     m_state(BN_UNPRESSED)
 {
     m_color = color;
-    AttachChild(m_label);
     m_label->Hide();
 
     if (INSTRUMENT_ALL_SIGNALS)
         LeftClickedSignal.connect(&ClickedEcho);
 }
+
+void Button::CompleteConstruction()
+{ AttachChild(m_label); }
 
 Pt Button::MinUsableSize() const
 { return m_label->MinUsableSize(); }

--- a/GG/src/Button.cpp
+++ b/GG/src/Button.cpp
@@ -275,6 +275,10 @@ StateButton::StateButton(const std::string& str, const std::shared_ptr<Font>& fo
     m_checked(false)
 {
     m_color = color;
+}
+
+void StateButton::CompleteConstruction()
+{
     AttachChild(m_label);
     m_label->Hide();
 

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -46,6 +46,7 @@ public:
     typedef boost::signals2::signal<void (iterator)>   SelChangedSignalType;
 
     ModalListPicker(Clr color, const DropDownList* relative_to_wnd, size_t m_num_shown_rows);
+    void CompleteConstruction() override;
     ~ModalListPicker();
 
     /** ModalListPicker is run then it returns true if it was not destroyed while running.*/
@@ -169,6 +170,9 @@ ModalListPicker::ModalListPicker(Clr color, const DropDownList* relative_to_wnd,
     m_relative_to_wnd(relative_to_wnd),
     m_dropped(false),
     m_only_mouse_scroll_when_dropped(false)
+{}
+
+void ModalListPicker::CompleteConstruction()
 {
     m_lb_wnd->SelRowsChangedSignal.connect(
         boost::bind(&ModalListPicker::LBSelChangedSlot, this, _1));
@@ -538,7 +542,7 @@ void ModalListPicker::MouseWheel(const Pt& pt, int move, Flags<ModKey> mod_keys)
 ////////////////////////////////////////////////
 DropDownList::DropDownList(size_t num_shown_elements, Clr color) :
     Control(X0, Y0, X(1 + 2 * ListBox::BORDER_THICK), Y(1 + 2 * ListBox::BORDER_THICK), INTERACTIVE),
-    m_modal_picker(std::make_shared<ModalListPicker>(color, this, num_shown_elements))
+    m_modal_picker(std::shared_ptr<ModalListPicker>(Wnd::Create<ModalListPicker>(color, this, num_shown_elements)))
 {
     SetStyle(LIST_SINGLESEL);
 

--- a/GG/src/GroupBox.cpp
+++ b/GG/src/GroupBox.cpp
@@ -62,7 +62,7 @@ GroupBox::GroupBox(X x, Y y, X w, Y h, const std::string& label, const std::shar
 
 void GroupBox::CompleteConstruction()
 {
-   if (m_label) {
+    if (m_label) {
         m_label->MoveTo(Pt(X0, -m_font->Lineskip()));
         m_label->MoveTo(Pt(X1, m_font->Lineskip()));
         AttachChild(m_label);

--- a/GG/src/GroupBox.cpp
+++ b/GG/src/GroupBox.cpp
@@ -58,8 +58,11 @@ GroupBox::GroupBox(X x, Y y, X w, Y h, const std::string& label, const std::shar
     m_font(font),
     m_label(label.empty() ? nullptr : GUI::GetGUI()->GetStyleFactory()->NewTextControl(label, m_font, m_text_color, FORMAT_LEFT | FORMAT_TOP)),
     m_set_client_corners_equal_to_box_corners(false)
+{}
+
+void GroupBox::CompleteConstruction()
 {
-    if (m_label) {
+   if (m_label) {
         m_label->MoveTo(Pt(X0, -m_font->Lineskip()));
         m_label->MoveTo(Pt(X1, m_font->Lineskip()));
         AttachChild(m_label);

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -2225,7 +2225,7 @@ std::pair<bool, bool> ListBox::AddOrRemoveScrolls(
     // Use the precalculated client size if possible.
     auto cl_sz = maybe_client_size ? *maybe_client_size : ClientSizeExcludingScrolls();
 
-    const std::shared_ptr<const StyleFactory> style = GetStyleFactory();
+    const auto& style = GetStyleFactory();
 
     bool horizontal_needed = (required_total_extents.first ? true : false);
     bool vertical_needed = (required_total_extents.second ? true : false);

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -205,7 +205,7 @@ ListBox::Row::Row() :
     m_margin(ListBox::DEFAULT_MARGIN),
     m_ignore_adjust_layout(false),
     m_is_normalized(false)
-{ SetLayout(Wnd::Create<DeferredLayout>(X0, Y0, Width(), Height(), 1, 1, m_margin, m_margin)); }
+{}
 
 ListBox::Row::Row(X w, Y h, const std::string& drag_drop_data_type,
                   Alignment align/* = ALIGN_VCENTER*/, unsigned int margin/* = 2*/) : 
@@ -218,10 +218,10 @@ ListBox::Row::Row(X w, Y h, const std::string& drag_drop_data_type,
     m_margin(margin),
     m_ignore_adjust_layout(false),
     m_is_normalized(false)
-{
-    SetLayout(Wnd::Create<DeferredLayout>(X0, Y0, w, h, 1, 1, m_margin, m_margin));
-    SetDragDropDataType(drag_drop_data_type);
-}
+{ SetDragDropDataType(drag_drop_data_type); }
+
+void ListBox::Row::CompleteConstruction()
+{ SetLayout(Wnd::Create<DeferredLayout>(X0, Y0, Width(), Height(), 1, 1, m_margin, m_margin)); }
 
 ListBox::Row::~Row()
 {}

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -562,6 +562,10 @@ ListBox::ListBox(Clr color, Clr interior/* = CLR_ZERO*/) :
     m_add_padding_at_end(true)
 {
     Control::SetColor(color);
+}
+
+void ListBox::CompleteConstruction()
+{
     ValidateStyle();
     SetChildClippingMode(ClipToClient);
     m_auto_scroll_timer.Stop();

--- a/GG/src/MultiEdit.cpp
+++ b/GG/src/MultiEdit.cpp
@@ -1236,7 +1236,7 @@ void MultiEdit::AdjustScrolls()
 
     const int GAP = PIXEL_MARGIN - 2; // the space between the client area and the border
 
-    std::shared_ptr<StyleFactory> style = GetStyleFactory();
+    const auto& style = GetStyleFactory();
 
     Y vscroll_min = (m_style & MULTI_TERMINAL_STYLE) ? cl_sz.y - m_contents_sz.y : Y0;
     if (cl_sz.y - m_contents_sz.y > 0 ) {

--- a/GG/src/RichText/ImageBlock.cpp
+++ b/GG/src/RichText/ImageBlock.cpp
@@ -48,10 +48,15 @@ namespace GG {
         try {
             std::shared_ptr<Texture> texture = GetTextureManager().GetTexture(path);
             m_graphic = Wnd::Create<StaticGraphic>(texture, GRAPHIC_PROPSCALE | GRAPHIC_SHRINKFIT | GRAPHIC_CENTER);
-            AttachChild(m_graphic);
         } catch (GG::Texture::BadFile&) {
             // No can do inside GiGi.
         }
+    }
+
+    void ImageBlock::CompleteConstruction()
+    {
+        if (m_graphic)
+            AttachChild(m_graphic);
     }
 
     Pt ImageBlock::SetMaxWidth(X width)
@@ -120,7 +125,7 @@ namespace GG {
                 return nullptr;
 
             // Create a new image block, basing the path on the root path.
-            return new ImageBlock(combined_path, X0, Y0, X1, Flags<WndFlag>());
+            return Wnd::Create<ImageBlock>(combined_path, X0, Y0, X1, Flags<WndFlag>());
         }
 
         // Sets the root of image search path.

--- a/GG/src/RichText/TextBlock.cpp
+++ b/GG/src/RichText/TextBlock.cpp
@@ -39,6 +39,11 @@ namespace GG {
         // With these setting the height is largely ignored, so we set it to one.
         m_text = Wnd::Create<TextControl>(GG::X0, GG::Y0, w, Y1, str, font, color,
                                           format | FORMAT_WORDBREAK | FORMAT_LINEWRAP | FORMAT_TOP, flags);
+    }
+
+    void TextBlock::CompleteConstruction()
+    {
+        BlockControl::CompleteConstruction();
         AttachChild(m_text);
     }
 

--- a/GG/src/RichText/TextBlock.h
+++ b/GG/src/RichText/TextBlock.h
@@ -42,6 +42,7 @@ public:
     TextBlock(X x, Y y, X w, const std::string& str, const std::shared_ptr<Font>& font, Clr color,
               Flags<TextFormat> format, Flags<WndFlag> flags);
 
+    void CompleteConstruction() override;
     void Render() override
     {};
 

--- a/GG/src/Scroll.cpp
+++ b/GG/src/Scroll.cpp
@@ -70,7 +70,7 @@ Scroll::Scroll(Orientation orientation, Clr color, Clr interior) :
     m_tab_dragged(false)
 {
     Control::SetColor(color);
-    std::shared_ptr<StyleFactory> style = GetStyleFactory();
+    const auto& style = GetStyleFactory();
     if (m_orientation == VERTICAL) {
         m_decr = style->NewScrollUpButton(color);
         m_incr = style->NewScrollDownButton(color);

--- a/GG/src/Scroll.cpp
+++ b/GG/src/Scroll.cpp
@@ -80,6 +80,10 @@ Scroll::Scroll(Orientation orientation, Clr color, Clr interior) :
         m_incr = style->NewScrollRightButton(color);
         m_tab = style->NewHScrollTabButton(color);
     }
+}
+
+void Scroll::CompleteConstruction()
+{
     if (m_decr) {
         AttachChild(m_decr);
         m_decr->LeftClickedSignal.connect(boost::bind(&Scroll::ScrollLineIncrDecrImpl, this, true, -1));

--- a/GG/src/ScrollPanel.cpp
+++ b/GG/src/ScrollPanel.cpp
@@ -82,7 +82,7 @@ namespace GG {
         SetChildClippingMode(ClipToClient);
 
         // Get the scroll bar from the current style factory.
-        std::shared_ptr<StyleFactory> style = GetStyleFactory();
+        const auto& style = GetStyleFactory();
         m_vscroll = style->NewMultiEditVScroll(CLR_WHITE, CLR_BLACK);
 
         // Don't accept less than MIN_SCROLL_WIDTH pixels wide scrolls.

--- a/GG/src/ScrollPanel.cpp
+++ b/GG/src/ScrollPanel.cpp
@@ -73,6 +73,9 @@ namespace GG {
         m_vscroll(nullptr),
         m_content(content),
         m_background_color(CLR_ZERO)
+    {}
+
+    void ScrollPanel::CompleteConstruction()
     {
         // Very important to clip the content of this panel,
         // to actually only show the currently viewed part.
@@ -88,7 +91,7 @@ namespace GG {
         }
 
         AttachChild(m_vscroll);
-        AttachChild(content);
+        AttachChild(m_content);
 
         m_vscroll->ScrolledSignal.connect(boost::bind(&ScrollPanel::OnScrolled, this, _1, _2, _3, _4));
 

--- a/GG/src/StyleFactory.cpp
+++ b/GG/src/StyleFactory.cpp
@@ -112,7 +112,7 @@ TextControl* StyleFactory::NewTextControl(const std::string& str, const std::sha
 { return Wnd::Create<TextControl>(X0, Y0, X1, Y1, str, font, color, format, NO_WND_FLAGS); }
 
 TabBar* StyleFactory::NewTabBar(const std::shared_ptr<Font>& font, Clr color, Clr text_color/* = CLR_BLACK*/) const
-{ return new TabBar(font, color, text_color, INTERACTIVE); }
+{ return Wnd::Create<TabBar>(font, color, text_color, INTERACTIVE); }
 
 ListBox* StyleFactory::NewDropDownListListBox(Clr color, Clr interior/* = CLR_ZERO*/) const
 {

--- a/GG/src/StyleFactory.cpp
+++ b/GG/src/StyleFactory.cpp
@@ -101,7 +101,7 @@ ListBox* StyleFactory::NewListBox(Clr color, Clr interior/* = CLR_ZERO*/) const
 { return Wnd::Create<ListBox>(color, interior); }
 
 Scroll* StyleFactory::NewScroll(Orientation orientation, Clr color, Clr interior) const
-{ return new Scroll(orientation, color, interior); }
+{ return Wnd::Create<Scroll>(orientation, color, interior); }
 
 Slider<int>* StyleFactory::NewIntSlider(int min, int max, Orientation orientation,
                                         Clr color, int tab_width, int line_width/* = 5*/) const

--- a/GG/src/StyleFactory.cpp
+++ b/GG/src/StyleFactory.cpp
@@ -85,7 +85,7 @@ std::string StyleFactory::Translate(const std::string& key) const
 
 Button* StyleFactory::NewButton(const std::string& str, const std::shared_ptr<Font>& font,
                                 Clr color, Clr text_color/* = CLR_BLACK*/, Flags<WndFlag> flags/* = INTERACTIVE*/) const
-{ return new Button(str, font, color, text_color, flags); }
+{ return Wnd::Create<Button>(str, font, color, text_color, flags); }
 
 RadioButtonGroup* StyleFactory::NewRadioButtonGroup(Orientation orientation) const
 { return Wnd::Create<RadioButtonGroup>(orientation); }

--- a/GG/src/StyleFactory.cpp
+++ b/GG/src/StyleFactory.cpp
@@ -105,7 +105,7 @@ Scroll* StyleFactory::NewScroll(Orientation orientation, Clr color, Clr interior
 
 Slider<int>* StyleFactory::NewIntSlider(int min, int max, Orientation orientation,
                                         Clr color, int tab_width, int line_width/* = 5*/) const
-{ return new Slider<int>(min, max, orientation, color, tab_width, line_width, INTERACTIVE); }
+{ return Wnd::Create<Slider<int>>(min, max, orientation, color, tab_width, line_width, INTERACTIVE); }
 
 TextControl* StyleFactory::NewTextControl(const std::string& str, const std::shared_ptr<Font>& font,
                                           Clr color/* = CLR_BLACK*/, Flags<TextFormat> format/* = FORMAT_NONE*/) const

--- a/GG/src/StyleFactory.cpp
+++ b/GG/src/StyleFactory.cpp
@@ -174,7 +174,8 @@ StateButton* StyleFactory::NewTabBarTab(const std::string& str,
                                         const std::shared_ptr<Font>& font, Flags<TextFormat> format, Clr color,
                                         Clr text_color/* = CLR_BLACK*/) const
 {
-    auto retval = new StateButton(str, font, format, color, std::make_shared<BeveledTabRepresenter>(), text_color);
+    auto retval = Wnd::Create<StateButton>(
+        str, font, format, color, std::make_shared<BeveledTabRepresenter>(), text_color);
     retval->Resize(retval->MinUsableSize() + Pt(X(12), Y0));
     return retval;
 }

--- a/GG/src/TabWnd.cpp
+++ b/GG/src/TabWnd.cpp
@@ -54,7 +54,10 @@ const std::size_t OverlayWnd::NO_WND = std::numeric_limits<std::size_t>::max();
 OverlayWnd::OverlayWnd(X x, Y y, X w, Y h, Flags<WndFlag> flags) :
     Wnd(x, y, w, h, flags),
     m_current_wnd_index(NO_WND)
-{ SetLayout(Wnd::Create<Layout>(X0, Y0, w, h, 1, 1)); }
+{}
+
+void OverlayWnd::CompleteConstruction()
+{ SetLayout(Wnd::Create<Layout>(X0, Y0, Width(), Height(), 1, 1)); }
 
 OverlayWnd::~OverlayWnd()
 {
@@ -166,7 +169,11 @@ TabWnd::TabWnd(X x, Y y, X w, Y h, const std::shared_ptr<Font>& font, Clr color,
                Clr text_color/* = CLR_BLACK*/) :
     Wnd(x, y, w, h, INTERACTIVE),
     m_tab_bar(GetStyleFactory()->NewTabBar(font, color, text_color)),
-    m_overlay(new OverlayWnd(X0, Y0, X1, Y1))
+    m_overlay(Wnd::Create<OverlayWnd>(X0, Y0, X1, Y1))
+{
+}
+
+void TabWnd::CompleteConstruction()
 {
     auto layout = Wnd::Create<Layout>(X0, Y0, Width(), Height(), 2, 1);
     layout->SetRowStretch(1, 1.0);

--- a/GG/src/TabWnd.cpp
+++ b/GG/src/TabWnd.cpp
@@ -264,7 +264,6 @@ void TabWnd::TabChanged(std::size_t index, bool signal)
 // static(s)
 const std::size_t TabBar::NO_TAB = TabWnd::NO_WND;
 const X TabBar::BUTTON_WIDTH(10);
-
 TabBar::TabBar(const std::shared_ptr<Font>& font, Clr color, Clr text_color/* = CLR_BLACK*/,
                Flags<WndFlag> flags/* = INTERACTIVE*/) :
     Control(X0, Y0, X1, TabHeightFromFont(font), flags),
@@ -277,6 +276,10 @@ TabBar::TabBar(const std::shared_ptr<Font>& font, Clr color, Clr text_color/* = 
     m_first_tab_shown(0)
 {
     SetColor(color);
+}
+
+void TabBar::CompleteConstruction()
+{
 
     SetChildClippingMode(ClipToClient);
 

--- a/GG/src/TabWnd.cpp
+++ b/GG/src/TabWnd.cpp
@@ -290,7 +290,7 @@ void TabBar::CompleteConstruction()
 
     SetChildClippingMode(ClipToClient);
 
-    std::shared_ptr<StyleFactory> style_factory = GetStyleFactory();
+    const auto& style_factory = GetStyleFactory();
 
     m_tabs = style_factory->NewRadioButtonGroup(HORIZONTAL);
     m_tabs->ExpandButtons(true);
@@ -389,7 +389,7 @@ std::size_t TabBar::AddTab(const std::string& name)
 void TabBar::InsertTab(std::size_t index, const std::string& name)
 {
     assert(index <= m_tab_buttons.size());
-    std::shared_ptr<StyleFactory> style_factory = GetStyleFactory();
+    const auto& style_factory = GetStyleFactory();
     StateButton* button = style_factory->NewTabBarTab(name,
                                                       m_font, FORMAT_CENTER, Color(),
                                                       m_text_color);

--- a/GG/src/TabWnd.cpp
+++ b/GG/src/TabWnd.cpp
@@ -170,8 +170,7 @@ TabWnd::TabWnd(X x, Y y, X w, Y h, const std::shared_ptr<Font>& font, Clr color,
     Wnd(x, y, w, h, INTERACTIVE),
     m_tab_bar(GetStyleFactory()->NewTabBar(font, color, text_color)),
     m_overlay(Wnd::Create<OverlayWnd>(X0, Y0, X1, Y1))
-{
-}
+{}
 
 void TabWnd::CompleteConstruction()
 {
@@ -287,7 +286,6 @@ TabBar::TabBar(const std::shared_ptr<Font>& font, Clr color, Clr text_color/* = 
 
 void TabBar::CompleteConstruction()
 {
-
     SetChildClippingMode(ClipToClient);
 
     const auto& style_factory = GetStyleFactory();

--- a/GG/src/Wnd.cpp
+++ b/GG/src/Wnd.cpp
@@ -896,6 +896,9 @@ void Wnd::SetBrowseModeTime(unsigned int time, std::size_t mode/* = 0*/)
 void Wnd::SetBrowseInfoWnd(const std::shared_ptr<BrowseInfoWnd>& wnd, std::size_t mode/* = 0*/)
 { m_browse_modes.at(mode).wnd = wnd; }
 
+void Wnd::SetBrowseInfoWnd(BrowseInfoWnd* wnd, std::size_t mode/* = 0*/)
+{ m_browse_modes.at(mode).wnd = std::shared_ptr<BrowseInfoWnd>(wnd); }
+
 void Wnd::ClearBrowseInfoWnd(std::size_t mode/* = 0*/)
 { m_browse_modes.at(mode).wnd.reset(); }
 

--- a/GG/src/dialogs/ColorDlg.cpp
+++ b/GG/src/dialogs/ColorDlg.cpp
@@ -611,6 +611,11 @@ ColorDlg::ColorDlg(X x, Y y, Clr original_color, const std::shared_ptr<Font>& fo
     m_sliders_ok_cancel_layout->Add(m_ok, 7, 0, 1, 3);
     m_cancel = style->NewButton(style->Translate("Cancel"), font, m_color, m_text_color);
     m_sliders_ok_cancel_layout->Add(m_cancel, 8, 0, 1, 3);
+}
+
+void ColorDlg::CompleteConstruction()
+{
+    Wnd::CompleteConstruction();
 
     auto master_layout = Wnd::Create<Layout>(X0, Y0, ClientWidth(), ClientHeight(), 3, 2, 5, 5);
     master_layout->SetColumnStretch(0, 1.25);

--- a/GG/src/dialogs/ColorDlg.cpp
+++ b/GG/src/dialogs/ColorDlg.cpp
@@ -517,7 +517,7 @@ ColorDlg::ColorDlg(X x, Y y, Clr original_color, const std::shared_ptr<Font>& fo
     m_current_color = m_original_color_specified ? Convert(m_original_color) : Convert(CLR_BLACK);
     Clr color = Convert(m_current_color);
 
-    std::shared_ptr<StyleFactory> style = GetStyleFactory();
+    const auto& style = GetStyleFactory();
 
     const int COLOR_BUTTON_ROWS = 4;
     const int COLOR_BUTTON_COLS = 5;

--- a/GG/src/dialogs/ColorDlg.cpp
+++ b/GG/src/dialogs/ColorDlg.cpp
@@ -381,7 +381,6 @@ void ValuePicker::SetValueFromPt(Pt pt)
 // ColorDlg
 ////////////////////////////////////////////////
 
-// ColorDlg::ColorButton
 ColorDlg::ColorButton::ColorButton(const Clr& color) :
     Button("", nullptr, color),
     m_represented_color(CLR_BLACK)
@@ -567,7 +566,7 @@ ColorDlg::ColorDlg(X x, Y y, Clr original_color, const std::shared_ptr<Font>& fo
                                                  COLOR_BUTTON_ROWS, COLOR_BUTTON_COLS, 0, 4);
     for (int i = 0; i < COLOR_BUTTON_ROWS; ++i) {
         for (int j = 0; j < COLOR_BUTTON_COLS; ++j) {
-            m_color_buttons.push_back(new ColorButton(m_color));
+            m_color_buttons.push_back(Wnd::Create<ColorButton>(m_color));
             m_color_buttons.back()->SetRepresentedColor(s_custom_colors[i * COLOR_BUTTON_COLS + j]);
             m_color_buttons_layout->Add(m_color_buttons.back(), i, j);
         }

--- a/GG/src/dialogs/FileDlg.cpp
+++ b/GG/src/dialogs/FileDlg.cpp
@@ -171,7 +171,7 @@ FileDlg::FileDlg(const std::string& directory, const std::string& filename, bool
     m_init_directory(directory),
     m_init_filename(filename)
 {
-    std::shared_ptr<StyleFactory> style = GetStyleFactory();
+    const auto& style = GetStyleFactory();
 
     if (m_save)
         multi = false;
@@ -183,7 +183,7 @@ FileDlg::FileDlg(const std::string& directory, const std::string& filename, bool
 
 void FileDlg::CompleteConstruction()
 {
-    std::shared_ptr<StyleFactory> style = GetStyleFactory();
+    const auto& style = GetStyleFactory();
 
     m_files_edit = style->NewEdit("", m_font, m_border_color, m_text_color);
     m_filter_list = style->NewDropDownList(3, m_border_color);
@@ -356,7 +356,7 @@ void FileDlg::OkHandler(bool double_click)
     parse(m_files_edit->Text().c_str(), (+anychar_p)[append(files)], space_p);
     std::sort(files.begin(), files.end());
 
-    std::shared_ptr<StyleFactory> style = GetStyleFactory();
+    const auto& style = GetStyleFactory();
 
     if (m_save) { // file save case
         if (m_ok_button->Text() != m_save_str) {
@@ -689,7 +689,7 @@ void FileDlg::UpdateDirectoryText()
 
 void FileDlg::OpenDirectory()
 {
-    std::shared_ptr<StyleFactory> style = GetStyleFactory();
+    const auto& style = GetStyleFactory();
 
     // see if there is a directory selected; if so open the directory.
     // if more than one is selected, take the first one

--- a/GG/src/dialogs/FileDlg.cpp
+++ b/GG/src/dialogs/FileDlg.cpp
@@ -167,11 +167,22 @@ FileDlg::FileDlg(const std::string& directory, const std::string& filename, bool
     m_ok_button(nullptr),
     m_cancel_button(nullptr),
     m_files_label(nullptr),
-    m_file_types_label(nullptr)
+    m_file_types_label(nullptr),
+    m_init_directory(directory),
+    m_init_filename(filename)
 {
+    std::shared_ptr<StyleFactory> style = GetStyleFactory();
+
     if (m_save)
         multi = false;
 
+    // finally, we can create the listbox with the files in it, sized to fill the available space
+    m_files_list = style->NewListBox(m_border_color);
+    m_files_list->SetStyle(LIST_NOSORT | (multi ? LIST_NONE : LIST_SINGLESEL));
+}
+
+void FileDlg::CompleteConstruction()
+{
     std::shared_ptr<StyleFactory> style = GetStyleFactory();
 
     m_files_edit = style->NewEdit("", m_font, m_border_color, m_text_color);
@@ -185,10 +196,6 @@ FileDlg::FileDlg(const std::string& directory, const std::string& filename, bool
     m_ok_button = style->NewButton(m_save ? m_save_str : m_open_str, m_font, m_color, m_text_color);
     m_cancel_button = style->NewButton(style->Translate("Cancel"), m_font, m_color, m_text_color);
 
-    // finally, we can create the listbox with the files in it, sized to fill the available space
-    m_files_list = style->NewListBox(m_border_color);
-    m_files_list->SetStyle(LIST_NOSORT | (multi ? LIST_NONE : LIST_SINGLESEL));
-
     DoLayout();
 
     AttachChild(m_files_edit);
@@ -200,14 +207,14 @@ FileDlg::FileDlg(const std::string& directory, const std::string& filename, bool
     AttachChild(m_files_label);
     AttachChild(m_file_types_label);
 
-    if (directory != "") {
+    if (m_init_directory != "") {
 #if defined(_WIN32)
         // convert UTF-8 file name to UTF-16
         boost::filesystem::path::string_type directory_native;
-        utf8::utf8to16(directory.begin(), directory.end(), std::back_inserter(directory_native));
+        utf8::utf8to16(m_init_directory.begin(), m_init_directory.end(), std::back_inserter(directory_native));
         fs::path dir_path = fs::system_complete(fs::path(directory_native));
 #else
-        fs::path dir_path = fs::system_complete(fs::path(directory));
+        fs::path dir_path = fs::system_complete(fs::path(m_init_directory));
 #endif
         if (!fs::exists(dir_path))
             throw BadInitialDirectory("FileDlg::FileDlg() : Initial directory \"" + dir_path.string() + "\" does not exist.");
@@ -231,8 +238,8 @@ FileDlg::FileDlg(const std::string& directory, const std::string& filename, bool
     m_filter_list->SelChangedSignal.connect(
         boost::bind(&FileDlg::FilterChanged, this, _1));
 
-    if (!filename.empty()) {
-        fs::path filename_path = fs::system_complete(fs::path(filename));
+    if (!m_init_filename.empty()) {
+        fs::path filename_path = fs::system_complete(fs::path(m_init_filename));
         m_files_edit->SetText(filename_path.leaf().string());
     }
 }

--- a/GG/src/dialogs/ThreeButtonDlg.cpp
+++ b/GG/src/dialogs/ThreeButtonDlg.cpp
@@ -50,7 +50,8 @@ ThreeButtonDlg::ThreeButtonDlg(X w, Y h, const std::string& msg, const std::shar
     m_result(0),
     m_button_0(nullptr),
     m_button_1(nullptr),
-    m_button_2(nullptr)
+    m_button_2(nullptr),
+    m_button_layout(Wnd::Create<Layout>(X0, Y0, X1, Y1, 2, 1, 10))
 {
     if (buttons < 1)
         buttons = 1;
@@ -60,7 +61,6 @@ ThreeButtonDlg::ThreeButtonDlg(X w, Y h, const std::string& msg, const std::shar
     const int SPACING = 10;
     const Y BUTTON_HEIGHT = font->Height() + 10;
 
-    auto layout = Wnd::Create<Layout>(X0, Y0, X1, Y1, 2, 1, 10);
     auto button_layout = Wnd::Create<Layout>(X0, Y0, X1, Y1, 1, buttons, 0, 10);
 
     std::shared_ptr<StyleFactory> style = GetStyleFactory();
@@ -69,9 +69,9 @@ ThreeButtonDlg::ThreeButtonDlg(X w, Y h, const std::string& msg, const std::shar
                                                       FORMAT_CENTER | FORMAT_VCENTER | FORMAT_WORDBREAK);
     message_text->Resize(Pt(ClientWidth() - 2 * SPACING, Height()));
     message_text->SetResetMinSize(true);
-    layout->Add(message_text, 0, 0);
-    layout->SetRowStretch(0, 1);
-    layout->SetMinimumRowHeight(1, BUTTON_HEIGHT);
+    m_button_layout->Add(message_text, 0, 0);
+    m_button_layout->SetRowStretch(0, 1);
+    m_button_layout->SetMinimumRowHeight(1, BUTTON_HEIGHT);
 
     m_button_0 = style->NewButton((zero == "" ? (buttons < 3 ? "Ok" : "Yes") : zero),
                                   font, m_button_color, m_text_color);
@@ -87,9 +87,14 @@ ThreeButtonDlg::ThreeButtonDlg(X w, Y h, const std::string& msg, const std::shar
                                       font, m_button_color, m_text_color);
         button_layout->Add(m_button_2, 0, 2);
     }
-    layout->Add(button_layout, 1, 0);
+    m_button_layout->Add(button_layout, 1, 0);
+}
 
-    SetLayout(layout);
+void ThreeButtonDlg::CompleteConstruction()
+{
+    Wnd::CompleteConstruction();
+
+    SetLayout(m_button_layout);
 
     m_button_0->LeftClickedSignal.connect(
         boost::bind(&ThreeButtonDlg::Button0Clicked, this));

--- a/GG/src/dialogs/ThreeButtonDlg.cpp
+++ b/GG/src/dialogs/ThreeButtonDlg.cpp
@@ -63,7 +63,7 @@ ThreeButtonDlg::ThreeButtonDlg(X w, Y h, const std::string& msg, const std::shar
 
     auto button_layout = Wnd::Create<Layout>(X0, Y0, X1, Y1, 1, buttons, 0, 10);
 
-    std::shared_ptr<StyleFactory> style = GetStyleFactory();
+    const auto& style = GetStyleFactory();
 
     TextControl* message_text = style->NewTextControl(msg, font, m_text_color,
                                                       FORMAT_CENTER | FORMAT_VCENTER | FORMAT_WORDBREAK);

--- a/GG/test/acceptance/TestTextControl.cpp
+++ b/GG/test/acceptance/TestTextControl.cpp
@@ -18,7 +18,7 @@ int main(int argc, char* argv[])
     const std::shared_ptr<GG::Font> font =
     GG::GUI::GetGUI()->GetStyleFactory()->DefaultFont(12, &charsets[0], &charsets[0] + charsets.size());
 
-    GG::Wnd* quit_dlg =
+    auto quit_dlg =
     GG::Wnd::Create<GG::ThreeButtonDlg>(GG::X(10), GG::Y(10), message, font, GG::CLR_SHADOW,
                                         GG::CLR_SHADOW, GG::CLR_SHADOW, GG::CLR_WHITE, 1);
 

--- a/GG/test/acceptance/runner/Application.cpp
+++ b/GG/test/acceptance/runner/Application.cpp
@@ -204,7 +204,7 @@ Application::Application(int argc, char** argv, unsigned width, unsigned height)
 }
 
 void Application::Run(GG::Wnd* wnd) {
-    self->Run(wnd);
+    self->Run(std::forward<GG::Wnd*>(wnd));
 }
 
 
@@ -240,7 +240,7 @@ Application::Impl::~Impl()
 void Application::Impl::Run(GG::Wnd* window) {
     try {
 
-        m_app->Register(window);
+        m_app->Register(std::forward<GG::Wnd*>(window));
         (*m_app)();
 
     } catch (const std::invalid_argument& e) {

--- a/GG/test/acceptance/runner/Dialog.cpp
+++ b/GG/test/acceptance/runner/Dialog.cpp
@@ -7,11 +7,18 @@
 
 
 Dialog::Dialog(GG::Wnd* child, const std::shared_ptr<GG::Font>& font):
-    GG::Wnd(GG::X0, GG::Y0, GG::X(300), GG::Y(300), GG::DRAGABLE | GG::RESIZABLE | GG::MODAL | GG::INTERACTIVE) {
+    GG::Wnd(GG::X0, GG::Y0, GG::X(300), GG::Y(300), GG::DRAGABLE | GG::RESIZABLE | GG::MODAL | GG::INTERACTIVE),
+    m_child(std::forward<GG::Wnd*>(child))
+{}
+
+void Dialog::CompleteConstruction()
+{
+    Wnd::CompleteConstruction();
+
     SetLayout(GG::Wnd::Create<GG::Layout>(GG::X0, GG::Y0, GG::X1, GG::Y1, 1, 1, 2, 2));
     GetLayout()->SetColumnStretch(0, 1.0);
     //GetLayout()->SetRowStretch(0, 1.0);
-    GetLayout()->Add(child, 0 , 0);
+    GetLayout()->Add(m_child, 0 , 0);
 }
 
 void Dialog::Render() {

--- a/GG/test/acceptance/runner/Dialog.h
+++ b/GG/test/acceptance/runner/Dialog.h
@@ -7,7 +7,7 @@
 
 //! A Simple resizable dialog with a single child that fills it.
 class Dialog: public GG::Wnd{
-    public:
+public:
     Dialog(GG::Wnd* child, const std::shared_ptr<GG::Font>& font);
 
     void CompleteConstruction() override;
@@ -17,7 +17,7 @@ class Dialog: public GG::Wnd{
 
     void SizeMove( const GG::Pt& ul, const GG::Pt& lr) override;
 
-    private:
+private:
     GG::Wnd* m_child;
 };
 

--- a/GG/test/acceptance/runner/Dialog.h
+++ b/GG/test/acceptance/runner/Dialog.h
@@ -7,14 +7,18 @@
 
 //! A Simple resizable dialog with a single child that fills it.
 class Dialog: public GG::Wnd{
-public:
+    public:
     Dialog(GG::Wnd* child, const std::shared_ptr<GG::Font>& font);
 
+    void CompleteConstruction() override;
     void Render() override;
 
     GG::Pt ClientLowerRight() const override;
 
     void SizeMove( const GG::Pt& ul, const GG::Pt& lr) override;
+
+    private:
+    GG::Wnd* m_child;
 };
 
 #endif // Dialog_h

--- a/GG/test/unit/TestButton.cpp
+++ b/GG/test/unit/TestButton.cpp
@@ -104,7 +104,8 @@ BOOST_AUTO_TEST_SUITE(TestButton)
 BOOST_AUTO_TEST_CASE( constructor )
 {
     std::shared_ptr<GG::Font> font(new MockFont());
-    InspectButton button("Test", font, GG::CLR_WHITE, GG::CLR_GREEN);
+    auto buttonp = GG::Wnd::Create<InspectButton>("Test", font, GG::CLR_WHITE, GG::CLR_GREEN);
+    auto& button = *buttonp;
 
     BOOST_CHECK(button.Text() == "Test");
     BOOST_CHECK(button.State() == GG::Button::BN_UNPRESSED);

--- a/UI/About.cpp
+++ b/UI/About.cpp
@@ -20,8 +20,7 @@ About::About():
            GG::INTERACTIVE | GG::DRAGABLE | GG::MODAL)
 {}
 
-void About::CompleteConstruction()
-{
+void About::CompleteConstruction() {
     CUIWnd::CompleteConstruction();
 
     m_done_btn = Wnd::Create<CUIButton>(UserString("DONE"));

--- a/UI/About.cpp
+++ b/UI/About.cpp
@@ -18,7 +18,12 @@
 About::About():
     CUIWnd(UserString("ABOUT_WINDOW_TITLE"), GG::X(80), GG::Y(130), GG::X(600), GG::Y(500),
            GG::INTERACTIVE | GG::DRAGABLE | GG::MODAL)
+{}
+
+void About::CompleteConstruction()
 {
+    CUIWnd::CompleteConstruction();
+
     m_done_btn = Wnd::Create<CUIButton>(UserString("DONE"));
     m_license = Wnd::Create<CUIButton>(UserString("LICENSE"));
     m_vision = Wnd::Create<CUIButton>(UserString("VISION"));

--- a/UI/About.h
+++ b/UI/About.h
@@ -10,8 +10,9 @@ public:
 //! \name Structors
 //!@{
     About();
-    ~About();
+    void CompleteConstruction() override;
 //!@}
+    ~About();
 
 //! \name Mutators
 //!@{

--- a/UI/AccordionPanel.cpp
+++ b/UI/AccordionPanel.cpp
@@ -13,7 +13,7 @@ AccordionPanel::AccordionPanel(GG::X w, GG::Y h, bool is_button_on_left /*= fals
 {
     boost::filesystem::path button_texture_dir = ClientUI::ArtDir() / "icons" / "buttons";
 
-    m_expand_button = new CUIButton(
+    m_expand_button = Wnd::Create<CUIButton>(
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "downarrownormal.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "downarrowclicked.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "downarrowmouseover.png")));

--- a/UI/AccordionPanel.cpp
+++ b/UI/AccordionPanel.cpp
@@ -10,7 +10,11 @@ AccordionPanel::AccordionPanel(GG::X w, GG::Y h, bool is_button_on_left /*= fals
     m_is_left(is_button_on_left),
     m_interior_color(ClientUI::WndColor()),
     m_border_margin(0)
+{}
+
+void AccordionPanel::CompleteConstruction()
 {
+    GG::Control::CompleteConstruction();
     boost::filesystem::path button_texture_dir = ClientUI::ArtDir() / "icons" / "buttons";
 
     m_expand_button = Wnd::Create<CUIButton>(
@@ -22,7 +26,7 @@ AccordionPanel::AccordionPanel(GG::X w, GG::Y h, bool is_button_on_left /*= fals
 
     AttachChild(m_expand_button);
 
-    DoLayout();
+    AccordionPanel::DoLayout();
     InitBuffer();
 }
 

--- a/UI/AccordionPanel.cpp
+++ b/UI/AccordionPanel.cpp
@@ -12,8 +12,7 @@ AccordionPanel::AccordionPanel(GG::X w, GG::Y h, bool is_button_on_left /*= fals
     m_border_margin(0)
 {}
 
-void AccordionPanel::CompleteConstruction()
-{
+void AccordionPanel::CompleteConstruction() {
     GG::Control::CompleteConstruction();
     boost::filesystem::path button_texture_dir = ClientUI::ArtDir() / "icons" / "buttons";
 

--- a/UI/AccordionPanel.h
+++ b/UI/AccordionPanel.h
@@ -19,6 +19,8 @@ public:
     virtual ~AccordionPanel();
     //@}
 
+    void CompleteConstruction() override;
+
     GG::Pt ClientUpperLeft() const override;
 
     GG::Pt ClientLowerRight() const override;

--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -532,8 +532,7 @@ BuildDesignatorWnd::BuildSelector::BuildSelector(const std::string& config_name)
     m_empire_id(ALL_EMPIRES)
 {}
 
-void BuildDesignatorWnd::BuildSelector::CompleteConstruction()
-{
+void BuildDesignatorWnd::BuildSelector::CompleteConstruction() {
     // create build type toggle buttons (ship, building, all)
     m_build_type_buttons[BT_BUILDING] = GG::Wnd::Create<CUIStateButton>(UserString("PRODUCTION_WND_CATEGORY_BT_BUILDING"), GG::FORMAT_CENTER, std::make_shared<CUILabelButtonRepresenter>());
     AttachChild(m_build_type_buttons[BT_BUILDING]);
@@ -964,8 +963,7 @@ BuildDesignatorWnd::BuildDesignatorWnd(GG::X w, GG::Y h) :
     m_side_panel(nullptr)
 {}
 
-void BuildDesignatorWnd::CompleteConstruction()
-{
+void BuildDesignatorWnd::CompleteConstruction() {
     GG::Wnd::CompleteConstruction();
 
     m_enc_detail_panel = GG::Wnd::Create<EncyclopediaDetailPanel>(

--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -426,6 +426,7 @@ class BuildDesignatorWnd::BuildSelector : public CUIWnd {
 public:
     /** \name Structors */ //@{
     BuildSelector(const std::string& config_name = "");
+    void CompleteConstruction() override;
     //@}
 
     /** \name Accessors */ //@{
@@ -519,6 +520,9 @@ BuildDesignatorWnd::BuildSelector::BuildSelector(const std::string& config_name)
     m_buildable_items(GG::Wnd::Create<BuildableItemsListBox>()),
     m_production_location(INVALID_OBJECT_ID),
     m_empire_id(ALL_EMPIRES)
+{}
+
+void BuildDesignatorWnd::BuildSelector::CompleteConstruction()
 {
     // create build type toggle buttons (ship, building, all)
     m_build_type_buttons[BT_BUILDING] = new CUIStateButton(UserString("PRODUCTION_WND_CATEGORY_BT_BUILDING"), GG::FORMAT_CENTER, std::make_shared<CUILabelButtonRepresenter>());
@@ -559,6 +563,8 @@ BuildDesignatorWnd::BuildSelector::BuildSelector(const std::string& config_name)
     //    m_buildable_items->SetColWidth(i, col_widths[i]);
     //    m_buildable_items->SetColAlignment(i, GG::ALIGN_LEFT);
     //}
+
+    CUIWnd::CompleteConstruction();
 
     DoLayout();
 }
@@ -947,13 +953,14 @@ BuildDesignatorWnd::BuildDesignatorWnd(GG::X w, GG::Y h) :
     m_build_selector(nullptr),
     m_side_panel(nullptr)
 {
-    m_enc_detail_panel = new EncyclopediaDetailPanel(GG::ONTOP | GG::INTERACTIVE | GG::DRAGABLE | GG::RESIZABLE | CLOSABLE | PINABLE, PROD_PEDIA_WND_NAME);
+    m_enc_detail_panel = GG::Wnd::Create<EncyclopediaDetailPanel>(
+        GG::ONTOP | GG::INTERACTIVE | GG::DRAGABLE | GG::RESIZABLE | CLOSABLE | PINABLE, PROD_PEDIA_WND_NAME);
     // Wnd is manually closed by user
     m_enc_detail_panel->ClosingSignal.connect(
         boost::bind(&BuildDesignatorWnd::HidePedia, this));
 
-    m_side_panel = new SidePanel(PROD_SIDEPANEL_WND_NAME);
-    m_build_selector = new BuildSelector(PROD_SELECTOR_WND_NAME);
+    m_side_panel = GG::Wnd::Create<SidePanel>(PROD_SIDEPANEL_WND_NAME);
+    m_build_selector = GG::Wnd::Create<BuildSelector>(PROD_SELECTOR_WND_NAME);
     InitializeWindows();
     HumanClientApp::GetApp()->RepositionWindowsSignal.connect(
         boost::bind(&BuildDesignatorWnd::InitializeWindows, this));

--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -268,8 +268,10 @@ namespace {
             }
 
             // create tooltip
-            return std::make_shared<IconTextBrowseWnd>(
-                ClientUI::BuildingIcon(item.name), title, main_text);
+            // TODO remove extra wrapping of shared_ptr after conversion to GG shared_ptr
+            return std::shared_ptr<IconTextBrowseWnd>(
+                GG::Wnd::Create<IconTextBrowseWnd>(
+                    ClientUI::BuildingIcon(item.name), title, main_text));
         }
 
         // production item is a ship
@@ -319,8 +321,10 @@ namespace {
                 }
 
             // create tooltip
-            return std::make_shared<IconTextBrowseWnd>(
-                ClientUI::ShipDesignIcon(item.design_id), title, main_text);
+            // TODO remove extra wrapping of shared_ptr after conversion to GG shared_ptr
+            return std::shared_ptr<GG::BrowseInfoWnd>(
+                GG::Wnd::Create<IconTextBrowseWnd>(
+                    ClientUI::ShipDesignIcon(item.design_id), title, main_text));
         }
 
         // other production item (?)

--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -368,8 +368,7 @@ namespace {
             //std::cout << "ProductionItemRow(building) height: " << Value(Height()) << std::endl;
         };
 
-        void CompleteConstruction() override
-        {
+        void CompleteConstruction() override {
             GG::ListBox::Row::CompleteConstruction();
 
             push_back(m_panel);

--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -525,15 +525,15 @@ BuildDesignatorWnd::BuildSelector::BuildSelector(const std::string& config_name)
 void BuildDesignatorWnd::BuildSelector::CompleteConstruction()
 {
     // create build type toggle buttons (ship, building, all)
-    m_build_type_buttons[BT_BUILDING] = new CUIStateButton(UserString("PRODUCTION_WND_CATEGORY_BT_BUILDING"), GG::FORMAT_CENTER, std::make_shared<CUILabelButtonRepresenter>());
+    m_build_type_buttons[BT_BUILDING] = GG::Wnd::Create<CUIStateButton>(UserString("PRODUCTION_WND_CATEGORY_BT_BUILDING"), GG::FORMAT_CENTER, std::make_shared<CUILabelButtonRepresenter>());
     AttachChild(m_build_type_buttons[BT_BUILDING]);
-    m_build_type_buttons[BT_SHIP] = new CUIStateButton(UserString("PRODUCTION_WND_CATEGORY_BT_SHIP"), GG::FORMAT_CENTER, std::make_shared<CUILabelButtonRepresenter>());
+    m_build_type_buttons[BT_SHIP] = GG::Wnd::Create<CUIStateButton>(UserString("PRODUCTION_WND_CATEGORY_BT_SHIP"), GG::FORMAT_CENTER, std::make_shared<CUILabelButtonRepresenter>());
     AttachChild(m_build_type_buttons[BT_SHIP]);
 
     // create availability toggle buttons (available, not available)
-    m_availability_buttons.push_back(new CUIStateButton(UserString("PRODUCTION_WND_AVAILABILITY_AVAILABLE"), GG::FORMAT_CENTER, std::make_shared<CUILabelButtonRepresenter>()));
+    m_availability_buttons.push_back(GG::Wnd::Create<CUIStateButton>(UserString("PRODUCTION_WND_AVAILABILITY_AVAILABLE"), GG::FORMAT_CENTER, std::make_shared<CUILabelButtonRepresenter>()));
     AttachChild(m_availability_buttons.back());
-    m_availability_buttons.push_back(new CUIStateButton(UserString("PRODUCTION_WND_AVAILABILITY_UNAVAILABLE"), GG::FORMAT_CENTER, std::make_shared<CUILabelButtonRepresenter>()));
+    m_availability_buttons.push_back(GG::Wnd::Create<CUIStateButton>(UserString("PRODUCTION_WND_AVAILABILITY_UNAVAILABLE"), GG::FORMAT_CENTER, std::make_shared<CUILabelButtonRepresenter>()));
     AttachChild(m_availability_buttons.back());
 
     // selectable list of buildable items

--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -350,7 +350,6 @@ namespace {
             }
 
             m_panel = GG::Wnd::Create<ProductionItemPanel>(w, h, m_item, empire_id, location_id);
-            push_back(m_panel);
 
             if (const Empire* empire = GetEmpire(empire_id)) {
                 if (!empire->ProducibleItem(m_item, location_id)) {
@@ -363,6 +362,13 @@ namespace {
             SetBrowseInfoWnd(ProductionItemRowBrowseWnd(m_item, location_id, empire_id));
 
             //std::cout << "ProductionItemRow(building) height: " << Value(Height()) << std::endl;
+        };
+
+        void CompleteConstruction() override
+        {
+            GG::ListBox::Row::CompleteConstruction();
+
+            push_back(m_panel);
         }
 
         const ProductionQueue::ProductionItem& Item() const

--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -958,7 +958,12 @@ BuildDesignatorWnd::BuildDesignatorWnd(GG::X w, GG::Y h) :
     m_enc_detail_panel(nullptr),
     m_build_selector(nullptr),
     m_side_panel(nullptr)
+{}
+
+void BuildDesignatorWnd::CompleteConstruction()
 {
+    GG::Wnd::CompleteConstruction();
+
     m_enc_detail_panel = GG::Wnd::Create<EncyclopediaDetailPanel>(
         GG::ONTOP | GG::INTERACTIVE | GG::DRAGABLE | GG::RESIZABLE | CLOSABLE | PINABLE, PROD_PEDIA_WND_NAME);
     // Wnd is manually closed by user

--- a/UI/BuildDesignatorWnd.h
+++ b/UI/BuildDesignatorWnd.h
@@ -17,6 +17,7 @@ public:
     /** \name Structors */ //@{
     BuildDesignatorWnd(GG::X w, GG::Y h);
     //@}
+    void CompleteConstruction() override;
 
     /** \name Accessors */ //@{
     bool InWindow(const GG::Pt& pt) const override;

--- a/UI/BuildingsPanel.cpp
+++ b/UI/BuildingsPanel.cpp
@@ -52,7 +52,11 @@ BuildingsPanel::BuildingsPanel(GG::X w, int columns, int planet_id) :
     m_planet_id(planet_id),
     m_columns(columns),
     m_building_indicators()
-{
+{}
+
+void BuildingsPanel::CompleteConstruction() {
+    AccordionPanel::CompleteConstruction();
+
     SetName("BuildingsPanel");
 
     if (m_columns < 1) {

--- a/UI/BuildingsPanel.cpp
+++ b/UI/BuildingsPanel.cpp
@@ -282,7 +282,7 @@ BuildingIndicator::BuildingIndicator(GG::X w, const std::string& building_type,
     const BuildingType* type = GetBuildingType(building_type);
     const std::string& desc = type ? type->Description() : "";
 
-    SetBrowseInfoWnd(std::make_shared<IconTextBrowseWnd>(
+    SetBrowseInfoWnd(GG::Wnd::Create<IconTextBrowseWnd>(
         texture, UserString(building_type), UserString(desc)));
 
     m_graphic = GG::Wnd::Create<GG::StaticGraphic>(texture, GG::GRAPHIC_FITGRAPHIC | GG::GRAPHIC_PROPSCALE);
@@ -384,7 +384,7 @@ void BuildingIndicator::Refresh() {
         if (GetOptionsDB().Get<bool>("UI.dump-effects-descriptions") && !type->Effects().empty())
             desc += "\n" + Dump(type->Effects());
 
-        SetBrowseInfoWnd(std::make_shared<IconTextBrowseWnd>(
+        SetBrowseInfoWnd(GG::Wnd::Create<IconTextBrowseWnd>(
             texture, UserString(type->Name()), desc));
     }
 

--- a/UI/BuildingsPanel.cpp
+++ b/UI/BuildingsPanel.cpp
@@ -266,7 +266,6 @@ BuildingIndicator::BuildingIndicator(GG::X w, int building_id) :
     if (std::shared_ptr<const Building> building = GetBuilding(m_building_id))
         building->StateChangedSignal.connect(
             boost::bind(&BuildingIndicator::RequirePreRender, this));
-    Refresh();
 }
 
 BuildingIndicator::BuildingIndicator(GG::X w, const std::string& building_type,
@@ -283,7 +282,6 @@ BuildingIndicator::BuildingIndicator(GG::X w, const std::string& building_type,
         texture, UserString(building_type), UserString(desc)));
 
     m_graphic = GG::Wnd::Create<GG::StaticGraphic>(texture, GG::GRAPHIC_FITGRAPHIC | GG::GRAPHIC_PROPSCALE);
-    AttachChild(m_graphic);
 
     float next_progress = turn_spending / std::max(1.0, total_cost);
 
@@ -294,9 +292,18 @@ BuildingIndicator::BuildingIndicator(GG::X w, const std::string& building_type,
                                                            ClientUI::TechWndProgressBarColor(),
                                                            GG::LightColor(ClientUI::ResearchableTechFillColor()));
 
-    AttachChild(m_progress_bar);
+}
 
-    RequirePreRender();
+void BuildingIndicator::CompleteConstruction() {
+    GG::Wnd::CompleteConstruction();
+
+    if (m_building_id == INVALID_OBJECT_ID) {
+        AttachChild(m_graphic);
+        AttachChild(m_progress_bar);
+        RequirePreRender();
+    } else {
+        Refresh();
+    }
 }
 
 void BuildingIndicator::Render() {

--- a/UI/BuildingsPanel.h
+++ b/UI/BuildingsPanel.h
@@ -71,6 +71,8 @@ public:
     BuildingIndicator(GG::X w, const std::string& building_type,
                       double turns_completed, double total_turns, double total_cost, double turn_spending);
 
+    void CompleteConstruction() override;
+
     /** \name Mutators */ //@{
     void PreRender() override;
 

--- a/UI/BuildingsPanel.h
+++ b/UI/BuildingsPanel.h
@@ -15,6 +15,7 @@ public:
     BuildingsPanel(GG::X w, int columns, int planet_id);
     ~BuildingsPanel();
     //@}
+    void CompleteConstruction() override;
 
     /** \name Accessors */ //@{
     int PlanetID() const { return m_planet_id; }

--- a/UI/CUIControls.cpp
+++ b/UI/CUIControls.cpp
@@ -1639,11 +1639,17 @@ void ColorSelector::RClick(const GG::Pt& pt, GG::Flags<GG::ModKey> mod_keys) {
 // class FileDlg
 ///////////////////////////////////////
 FileDlg::FileDlg(const std::string& directory, const std::string& filename, bool save, bool multi,
-                 const std::vector<std::pair<std::string, std::string>>& types) :
+                 std::vector<std::pair<std::string, std::string>> types) :
     GG::FileDlg(directory, filename, save, multi, ClientUI::GetFont(),
-                ClientUI::CtrlColor(), ClientUI::CtrlBorderColor(), ClientUI::TextColor())
+                ClientUI::CtrlColor(), ClientUI::CtrlBorderColor(), ClientUI::TextColor()),
+    m_init_file_filters(std::forward<std::vector<std::pair<std::string, std::string>>>(types))
+{}
+
+void FileDlg::CompleteConstruction()
 {
-    SetFileFilters(types);
+    GG::FileDlg::CompleteConstruction();
+
+    SetFileFilters(m_init_file_filters);
     AppendMissingSaveExtension(true);
 }
 

--- a/UI/CUIControls.cpp
+++ b/UI/CUIControls.cpp
@@ -1169,12 +1169,6 @@ StatisticIcon::StatisticIcon(const std::shared_ptr<GG::Texture> texture,
     m_text(nullptr)
 {
     m_icon = GG::Wnd::Create<GG::StaticGraphic>(texture, GG::GRAPHIC_FITGRAPHIC);
-
-    SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
-
-    AttachChild(m_icon);
-
-    RequirePreRender();
 }
 
 StatisticIcon::StatisticIcon(const std::shared_ptr<GG::Texture> texture,
@@ -1189,12 +1183,6 @@ StatisticIcon::StatisticIcon(const std::shared_ptr<GG::Texture> texture,
     m_text(nullptr)
 {
     m_icon = GG::Wnd::Create<GG::StaticGraphic>(texture, GG::GRAPHIC_FITGRAPHIC);
-
-    SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
-
-    AttachChild(m_icon);
-
-    RequirePreRender();
 }
 
 StatisticIcon::StatisticIcon(const std::shared_ptr<GG::Texture> texture,
@@ -1209,7 +1197,6 @@ StatisticIcon::StatisticIcon(const std::shared_ptr<GG::Texture> texture,
     m_icon(nullptr),
     m_text(nullptr)
 {
-    SetName("StatisticIcon");
     m_icon = GG::Wnd::Create<GG::StaticGraphic>(texture, GG::GRAPHIC_FITGRAPHIC);
 
     m_values[0] = value0;
@@ -1218,6 +1205,13 @@ StatisticIcon::StatisticIcon(const std::shared_ptr<GG::Texture> texture,
     m_digits[1] = digits1;
     m_show_signs[0] = showsign0;
     m_show_signs[1] = showsign1;
+}
+
+void StatisticIcon::CompleteConstruction()
+{
+    GG::Control::CompleteConstruction();
+
+    SetName("StatisticIcon");
 
     SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
 

--- a/UI/CUIControls.cpp
+++ b/UI/CUIControls.cpp
@@ -1422,7 +1422,7 @@ namespace {
             m_species_label = GG::Wnd::Create<CUILabel>(localized_name, GG::FORMAT_LEFT | GG::FORMAT_VCENTER);
             if (!species_desc.empty()) {
                 SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
-                SetBrowseInfoWnd(std::make_shared<IconTextBrowseWnd>(species_icon, localized_name,
+                SetBrowseInfoWnd(GG::Wnd::Create<IconTextBrowseWnd>(species_icon, localized_name,
                                                                      species_desc));
             }
         }

--- a/UI/CUIControls.cpp
+++ b/UI/CUIControls.cpp
@@ -1398,8 +1398,7 @@ namespace {
             Init(species_name, localized_name, species_desc, w, h, species_icon);
         };
 
-        void CompleteConstruction() override
-        {
+        void CompleteConstruction() override {
             GG::ListBox::Row::CompleteConstruction();
 
             push_back(m_icon);
@@ -1524,8 +1523,7 @@ namespace {
             m_color_square(GG::Wnd::Create<ColorSquare>(color, h))
         {}
 
-        void CompleteConstruction() override
-        {
+        void CompleteConstruction() override {
             GG::ListBox::Row::CompleteConstruction();
             push_back(m_color_square);
         }

--- a/UI/CUIControls.cpp
+++ b/UI/CUIControls.cpp
@@ -1143,8 +1143,7 @@ CUISimpleDropDownListRow::CUISimpleDropDownListRow(const std::string& row_text, 
     m_row_label(GG::Wnd::Create<CUILabel>(row_text, GG::FORMAT_LEFT | GG::FORMAT_NOWRAP))
 {}
 
-void CUISimpleDropDownListRow::CompleteConstruction()
-{
+void CUISimpleDropDownListRow::CompleteConstruction() {
     GG::ListBox::Row::CompleteConstruction();
 
     push_back(m_row_label);
@@ -1207,8 +1206,7 @@ StatisticIcon::StatisticIcon(const std::shared_ptr<GG::Texture> texture,
     m_show_signs[1] = showsign1;
 }
 
-void StatisticIcon::CompleteConstruction()
-{
+void StatisticIcon::CompleteConstruction() {
     GG::Control::CompleteConstruction();
 
     SetName("StatisticIcon");
@@ -1665,8 +1663,7 @@ FileDlg::FileDlg(const std::string& directory, const std::string& filename, bool
     m_init_file_filters(std::forward<std::vector<std::pair<std::string, std::string>>>(types))
 {}
 
-void FileDlg::CompleteConstruction()
-{
+void FileDlg::CompleteConstruction() {
     GG::FileDlg::CompleteConstruction();
 
     SetFileFilters(m_init_file_filters);

--- a/UI/CUIControls.h
+++ b/UI/CUIControls.h
@@ -202,6 +202,7 @@ public:
     /** \name Structors */ //@{
     CUIStateButton(const std::string& str, GG::Flags<GG::TextFormat> format, std::shared_ptr<GG::StateButtonRepresenter> representer);
     //@}
+
 };
 
 /** Tab bar with buttons for selecting tabbed windows. */

--- a/UI/CUIControls.h
+++ b/UI/CUIControls.h
@@ -392,7 +392,10 @@ private:
   * lists, such as the ones used in the game setup dialogs. */
 struct CUISimpleDropDownListRow : public GG::ListBox::Row {
     CUISimpleDropDownListRow(const std::string& row_text, GG::Y row_height = DEFAULT_ROW_HEIGHT);
+    void CompleteConstruction() override;
     static const GG::Y DEFAULT_ROW_HEIGHT;
+private:
+    CUILabel* m_row_label;
 };
 
 /** Encapsulates an icon and text that goes with it in a single control.  For

--- a/UI/CUIControls.h
+++ b/UI/CUIControls.h
@@ -555,8 +555,11 @@ class FileDlg : public GG::FileDlg {
 public:
     /** \name Structors */ //@{
     FileDlg(const std::string& directory, const std::string& filename, bool save, bool multi,
-            const std::vector<std::pair<std::string, std::string>>& types);
+            std::vector<std::pair<std::string, std::string>> types);
     //@}
+    void CompleteConstruction() override;
+private:
+    const std::vector<std::pair<std::string, std::string>> m_init_file_filters;
 };
 
 /** Despite the name, this is actually used to display info in both the Research and Production screens. */

--- a/UI/CUIControls.h
+++ b/UI/CUIControls.h
@@ -424,6 +424,8 @@ public:
                   GG::X w = GG::X1, GG::Y h = GG::Y1); ///< initializes with two values
     //@}
 
+    void CompleteConstruction() override;
+
     /** \name Accessors */ //@{
     double          GetValue(int index = 0) const;
     GG::Pt          MinUsableSize() const override;

--- a/UI/CUIControls.h
+++ b/UI/CUIControls.h
@@ -84,7 +84,6 @@ public:
     /** \name Structors */ //@{
     SettableInWindowCUIButton(const GG::SubTexture& unpressed, const GG::SubTexture& pressed, const GG::SubTexture& rollover, boost::function<bool(const SettableInWindowCUIButton*, const GG::Pt&)> in_window_function);
     //@}
-
     /** \name Accessors */ //@{
     bool InWindow(const GG::Pt& pt) const override;
     //@}

--- a/UI/CUILinkTextBlock.cpp
+++ b/UI/CUILinkTextBlock.cpp
@@ -12,8 +12,7 @@ CUILinkTextBlock::CUILinkTextBlock(const std::string& str, const std::shared_ptr
                                                       GG::MULTI_NO_VSCROLL))
 {}
 
-void CUILinkTextBlock::CompleteConstruction()
-{
+void CUILinkTextBlock::CompleteConstruction() {
     GG::BlockControl::CompleteConstruction();
 
     AttachChild(m_link_text);

--- a/UI/CUILinkTextBlock.cpp
+++ b/UI/CUILinkTextBlock.cpp
@@ -10,7 +10,12 @@ CUILinkTextBlock::CUILinkTextBlock(const std::string& str, const std::shared_ptr
     m_link_text(GG::Wnd::Create<CUILinkTextMultiEdit>(str, GG::MULTI_WORDBREAK | GG::MULTI_READ_ONLY | GG::MULTI_LEFT |
                                                       GG::MULTI_LINEWRAP | GG::MULTI_TOP | GG::MULTI_NO_HSCROLL |
                                                       GG::MULTI_NO_VSCROLL))
+{}
+
+void CUILinkTextBlock::CompleteConstruction()
 {
+    GG::BlockControl::CompleteConstruction();
+
     AttachChild(m_link_text);
 
     m_link_text->SetColor(GG::CLR_ZERO);

--- a/UI/CUILinkTextBlock.h
+++ b/UI/CUILinkTextBlock.h
@@ -15,6 +15,7 @@ public:
                      const GG::Clr& color,
                      GG::Flags< GG::WndFlag > flags);
 
+    void CompleteConstruction() override;
     GG::Pt SetMaxWidth(GG::X width) override;
 
     void Render() override

--- a/UI/CUISpin.h
+++ b/UI/CUISpin.h
@@ -30,8 +30,7 @@ public:
                     ClientUI::TextColor())
     {}
 
-    void CompleteConstruction() override
-    {
+    void CompleteConstruction() override {
         GG::Spin<T>::CompleteConstruction();
 
         GG::Spin<T>::ValueChangedSignal.connect(detail::PlayValueChangedSound());

--- a/UI/CUISpin.h
+++ b/UI/CUISpin.h
@@ -26,9 +26,14 @@ public:
 
     /** \name Structors */ //@{
     CUISpin(T value, T step, T min, T max, bool edits) :
-        GG::Spin<T>(value, step, min, max, edits, ClientUI::GetFont(), ClientUI::CtrlBorderColor(),
+    GG::Spin<T>(value, step, min, max, edits, ClientUI::GetFont(), ClientUI::CtrlBorderColor(),
                     ClientUI::TextColor())
+    {}
+
+    void CompleteConstruction() override
     {
+        GG::Spin<T>::CompleteConstruction();
+
         GG::Spin<T>::ValueChangedSignal.connect(detail::PlayValueChangedSound());
         if (GG::Spin<T>::GetEdit())
             GG::Spin<T>::GetEdit()->SetHiliteColor(ClientUI::EditHiliteColor());

--- a/UI/CUISpin.h
+++ b/UI/CUISpin.h
@@ -27,7 +27,7 @@ public:
     /** \name Structors */ //@{
     CUISpin(T value, T step, T min, T max, bool edits) :
     GG::Spin<T>(value, step, min, max, edits, ClientUI::GetFont(), ClientUI::CtrlBorderColor(),
-                    ClientUI::TextColor())
+                ClientUI::TextColor())
     {}
 
     void CompleteConstruction() override {

--- a/UI/CUIStyle.cpp
+++ b/UI/CUIStyle.cpp
@@ -77,7 +77,7 @@ GG::Button* CUIStyle::NewScrollDownButton(GG::Clr color) const
 { return NewScrollUpButton(color); }
 
 GG::Button* CUIStyle::NewVScrollTabButton(GG::Clr color) const
-{ return new CUIScroll::ScrollTab(GG::VERTICAL, 1, (color == GG::CLR_ZERO) ? ClientUI::CtrlColor() : color, ClientUI::CtrlBorderColor()); }
+{ return GG::Wnd::Create<CUIScroll::ScrollTab>(GG::VERTICAL, 1, (color == GG::CLR_ZERO) ? ClientUI::CtrlColor() : color, ClientUI::CtrlBorderColor()); }
 
 GG::Button* CUIStyle::NewScrollLeftButton(GG::Clr color) const
 { return NewScrollUpButton(color); }
@@ -86,19 +86,19 @@ GG::Button* CUIStyle::NewScrollRightButton(GG::Clr color) const
 { return NewScrollUpButton(color); }
 
 GG::Button* CUIStyle::NewHScrollTabButton(GG::Clr color) const
-{ return new CUIScroll::ScrollTab(GG::HORIZONTAL, 1, (color == GG::CLR_ZERO) ? ClientUI::CtrlColor() : color, ClientUI::CtrlBorderColor()); }
+{ return GG::Wnd::Create<CUIScroll::ScrollTab>(GG::HORIZONTAL, 1, (color == GG::CLR_ZERO) ? ClientUI::CtrlColor() : color, ClientUI::CtrlBorderColor()); }
 
 GG::Button* CUIStyle::NewVSliderTabButton(GG::Clr color) const
-{ return new CUIScroll::ScrollTab(GG::VERTICAL, 0, ClientUI::CtrlColor(), ClientUI::CtrlBorderColor()); }
+{ return GG::Wnd::Create<CUIScroll::ScrollTab>(GG::VERTICAL, 0, ClientUI::CtrlColor(), ClientUI::CtrlBorderColor()); }
 
 GG::Button* CUIStyle::NewHSliderTabButton(GG::Clr color) const
-{ return new CUIScroll::ScrollTab(GG::HORIZONTAL, 0, ClientUI::CtrlColor(), ClientUI::CtrlBorderColor()); }
+{ return GG::Wnd::Create<CUIScroll::ScrollTab>(GG::HORIZONTAL, 0, ClientUI::CtrlColor(), ClientUI::CtrlBorderColor()); }
 
 GG::Button* CUIStyle::NewSpinIncrButton(const std::shared_ptr<GG::Font>& font, GG::Clr color) const
-{ return new CUIArrowButton(SHAPE_UP, false, GG::INTERACTIVE | GG::REPEAT_BUTTON_DOWN); }
+{ return GG::Wnd::Create<CUIArrowButton>(SHAPE_UP, false, GG::INTERACTIVE | GG::REPEAT_BUTTON_DOWN); }
 
 GG::Button* CUIStyle::NewSpinDecrButton(const std::shared_ptr<GG::Font>& font, GG::Clr color) const
-{ return new CUIArrowButton(SHAPE_DOWN, false, GG::INTERACTIVE | GG::REPEAT_BUTTON_DOWN); }
+{ return GG::Wnd::Create<CUIArrowButton>(SHAPE_DOWN, false, GG::INTERACTIVE | GG::REPEAT_BUTTON_DOWN); }
 
 GG::StateButton* CUIStyle::NewTabBarTab(const std::string& str,
                                         const std::shared_ptr<GG::Font>& font, GG::Flags<GG::TextFormat> format, GG::Clr color,
@@ -112,10 +112,10 @@ GG::StateButton* CUIStyle::NewTabBarTab(const std::string& str,
 }
 
 GG::Button* CUIStyle::NewTabBarLeftButton(const std::shared_ptr<GG::Font>& font, GG::Clr color, GG::Clr text_color/* = GG::CLR_BLACK*/) const
-{ return new CUIArrowButton(SHAPE_LEFT, true, GG::INTERACTIVE); }
+{ return GG::Wnd::Create<CUIArrowButton>(SHAPE_LEFT, true, GG::INTERACTIVE); }
 
 GG::Button* CUIStyle::NewTabBarRightButton(const std::shared_ptr<GG::Font>& font, GG::Clr color, GG::Clr text_color/* = GG::CLR_BLACK*/) const
-{ return new CUIArrowButton(SHAPE_RIGHT, true, GG::INTERACTIVE); }
+{ return GG::Wnd::Create<CUIArrowButton>(SHAPE_RIGHT, true, GG::INTERACTIVE); }
 
 void CUIStyle::DeleteWnd(GG::Wnd* wnd) const
 { delete wnd; }

--- a/UI/CUIStyle.cpp
+++ b/UI/CUIStyle.cpp
@@ -68,7 +68,7 @@ GG::Slider<int>* CUIStyle::NewIntSlider(int min, int max, GG::Orientation orient
 
 
 GG::TabBar* CUIStyle::NewTabBar(const std::shared_ptr<GG::Font>& font, GG::Clr color, GG::Clr text_color/* = GG::CLR_BLACK*/) const
-{ return new CUITabBar(font, color, text_color); }
+{ return GG::Wnd::Create<CUITabBar>(font, color, text_color); }
 
 GG::Button* CUIStyle::NewScrollUpButton(GG::Clr color) const
 { return nullptr; }

--- a/UI/CUIStyle.cpp
+++ b/UI/CUIStyle.cpp
@@ -60,7 +60,7 @@ GG::ListBox* CUIStyle::NewListBox(GG::Clr color, GG::Clr interior/* = GG::CLR_ZE
 { return GG::Wnd::Create<CUIListBox>(); }
 
 GG::Scroll* CUIStyle::NewScroll(GG::Orientation orientation, GG::Clr color, GG::Clr interior) const
-{ return new CUIScroll(orientation); }
+{ return GG::Wnd::Create<CUIScroll>(orientation); }
 
 GG::Slider<int>* CUIStyle::NewIntSlider(int min, int max, GG::Orientation orientation,
                                         GG::Clr color, int tab_width, int line_width/* = 5*/) const

--- a/UI/CUIStyle.cpp
+++ b/UI/CUIStyle.cpp
@@ -104,7 +104,7 @@ GG::StateButton* CUIStyle::NewTabBarTab(const std::string& str,
                                         const std::shared_ptr<GG::Font>& font, GG::Flags<GG::TextFormat> format, GG::Clr color,
                                         GG::Clr text_color/* = GG::CLR_BLACK*/) const
 {
-    auto retval = new CUIStateButton(str, format, std::make_shared<CUITabRepresenter>());
+    auto retval = GG::Wnd::Create<CUIStateButton>(str, format, std::make_shared<CUITabRepresenter>());
     retval->SetColor(ClientUI::WndColor());
     retval->GetLabel()->SetTextColor(DarkColor(ClientUI::TextColor()));
     retval->Resize(retval->MinUsableSize() + GG::Pt(GG::X(12), GG::Y0));

--- a/UI/CUIWnd.cpp
+++ b/UI/CUIWnd.cpp
@@ -161,8 +161,7 @@ CUIWnd::CUIWnd(const std::string& wnd_name, GG::Flags<GG::WndFlag> flags, const 
     m_config_name(AddWindowOptions(config_name, INVALID_POS, INVALID_POS, 1, 1, visible, false, false))
 { SetName(wnd_name); }
 
-void CUIWnd::CompleteConstruction()
-{
+void CUIWnd::CompleteConstruction() {
     GG::Wnd::CompleteConstruction();
     Init();
     ValidatePosition();
@@ -856,8 +855,7 @@ CUIEditWnd::CUIEditWnd(GG::X w, const std::string& prompt_text, const std::strin
     m_edit = GG::Wnd::Create<CUIEdit>(edit_text);
 }
 
-void CUIEditWnd::CompleteConstruction()
-{
+void CUIEditWnd::CompleteConstruction() {
     CUIWnd::CompleteConstruction();
 
     m_ok_bn = GG::Wnd::Create<CUIButton>(UserString("OK"));

--- a/UI/CUIWnd.cpp
+++ b/UI/CUIWnd.cpp
@@ -144,12 +144,11 @@ CUIWnd::CUIWnd(const std::string& wnd_name,
     m_drag_offset(-GG::X1, -GG::Y1),
     m_config_name(AddWindowOptions(config_name, x, y, w, h, visible, false, false))
 {
-    Init(wnd_name);
+    SetName(wnd_name);
     if (!m_config_name.empty()) {
         // Default position was already supplied
         GetOptionsDB().Set<bool>("UI.windows." + m_config_name + ".initialized", true);
     }
-    ValidatePosition();
 }
 
 CUIWnd::CUIWnd(const std::string& wnd_name, GG::Flags<GG::WndFlag> flags, const std::string& config_name, bool visible) :
@@ -160,10 +159,15 @@ CUIWnd::CUIWnd(const std::string& wnd_name, GG::Flags<GG::WndFlag> flags, const 
     m_pinable(flags & PINABLE),
     m_drag_offset(-GG::X1, -GG::Y1),
     m_config_name(AddWindowOptions(config_name, INVALID_POS, INVALID_POS, 1, 1, visible, false, false))
-{ Init(wnd_name); }
+{ SetName(wnd_name); }
 
-void CUIWnd::Init(const std::string& wnd_name) {
-    SetName(wnd_name);
+void CUIWnd::CompleteConstruction()
+{
+    Init();
+    ValidatePosition();
+}
+
+void CUIWnd::Init() {
     InitButtons();
     SetChildClippingMode(ClipToClientAndWindowSeparately);
 
@@ -851,6 +855,12 @@ CUIEditWnd::CUIEditWnd(GG::X w, const std::string& prompt_text, const std::strin
     CUIWnd(prompt_text, GG::X0, GG::Y0, w, GG::Y1, flags)
 {
     m_edit = GG::Wnd::Create<CUIEdit>(edit_text);
+}
+
+void CUIEditWnd::CompleteConstruction()
+{
+    CUIWnd::CompleteConstruction();
+
     m_ok_bn = GG::Wnd::Create<CUIButton>(UserString("OK"));
     m_cancel_bn = GG::Wnd::Create<CUIButton>(UserString("CANCEL"));
 
@@ -865,8 +875,8 @@ CUIEditWnd::CUIEditWnd(GG::X w, const std::string& prompt_text, const std::strin
     m_cancel_bn->Resize(GG::Pt(BUTTON_WIDTH, m_cancel_bn->MinUsableSize().y));
     m_cancel_bn->OffsetMove(GG::Pt(GG::X0, (m_edit->Height() - m_ok_bn->Height()) / 2));
 
-    Resize(GG::Pt(w, std::max(m_edit->Bottom(), m_cancel_bn->Bottom()) + BottomBorder() + 3));
-    MoveTo(GG::Pt((GG::GUI::GetGUI()->AppWidth() - w) / 2, (GG::GUI::GetGUI()->AppHeight() - Height()) / 2));
+    Resize(GG::Pt(Width(), std::max(m_edit->Bottom(), m_cancel_bn->Bottom()) + BottomBorder() + 3));
+    MoveTo(GG::Pt((GG::GUI::GetGUI()->AppWidth() - Width()) / 2, (GG::GUI::GetGUI()->AppHeight() - Height()) / 2));
 
     AttachChild(m_edit);
     AttachChild(m_ok_bn);

--- a/UI/CUIWnd.cpp
+++ b/UI/CUIWnd.cpp
@@ -187,9 +187,6 @@ void CUIWnd::Init() {
     else
         HumanClientApp::GetApp()->WindowResizedSignal.connect(
             boost::bind(&CUIWnd::ResetDefaultPosition, this));
-
-    // call to CUIWnd::MinimizedWidth() because MinimizedWidth is virtual
-    SetMinSize(GG::Pt(CUIWnd::MinimizedSize().x, TopBorder() + INNER_BORDER_ANGLE_OFFSET + BORDER_BOTTOM + 50));
 }
 
 void CUIWnd::InitSizeMove(const GG::Pt& ul, const GG::Pt& lr) {
@@ -248,8 +245,9 @@ void CUIWnd::SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
         }
 
         // Limit window size to be no larger than the containing window.
-        GG::Pt new_size(std::min(lr.x - ul.x, available_size.x),
-                        std::min(lr.y - ul.y, available_size.y));
+        GG::Pt new_size(std::max(std::min(lr.x - ul.x, available_size.x), MinimizedSize().x),
+                        std::max(std::min(lr.y - ul.y, available_size.y),
+                                 TopBorder() + INNER_BORDER_ANGLE_OFFSET + BORDER_BOTTOM + 50));
 
         // Clamp position of this window to keep its entire area visible in the
         // containing window.

--- a/UI/CUIWnd.cpp
+++ b/UI/CUIWnd.cpp
@@ -426,7 +426,7 @@ void CUIWnd::InitButtons() {
 
     // create the close button
     if (m_closable) {
-        m_close_button = new CUIButton(
+        m_close_button = Wnd::Create<CUIButton>(
             GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "close.png")),
             GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "close_clicked.png")),
             GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "close_mouseover.png")));
@@ -442,7 +442,7 @@ void CUIWnd::InitButtons() {
 
     // create the minimize button
     if (m_minimizable) {
-        m_minimize_button = new CUI_MinRestoreButton();
+        m_minimize_button = Wnd::Create<CUI_MinRestoreButton>();
         m_minimize_button->Resize(GG::Pt(GG::X(ClientUI::TitlePts()), GG::Y(ClientUI::TitlePts())));
         m_minimize_button->LeftClickedSignal.connect(
             boost::bind(&CUIWnd::MinimizeClicked, this));
@@ -452,7 +452,7 @@ void CUIWnd::InitButtons() {
 
     // create the pin button
     if (m_pinable) {
-        m_pin_button = new CUI_PinButton();
+        m_pin_button = Wnd::Create<CUI_PinButton>();
         m_pin_button->Resize(GG::Pt(GG::X(ClientUI::TitlePts()), GG::Y(ClientUI::TitlePts())));
         m_pin_button->LeftClickedSignal.connect(
             boost::bind(&CUIWnd::PinClicked, this));

--- a/UI/CUIWnd.cpp
+++ b/UI/CUIWnd.cpp
@@ -163,6 +163,7 @@ CUIWnd::CUIWnd(const std::string& wnd_name, GG::Flags<GG::WndFlag> flags, const 
 
 void CUIWnd::CompleteConstruction()
 {
+    GG::Wnd::CompleteConstruction();
     Init();
     ValidatePosition();
 }

--- a/UI/CUIWnd.h
+++ b/UI/CUIWnd.h
@@ -97,6 +97,7 @@ public:
            const std::string& config_name = "",
            bool visible = true);
 
+    void CompleteConstruction() override;
     /** Virtual destructor. */
     virtual ~CUIWnd();
     //@}
@@ -185,7 +186,7 @@ protected:
 
     virtual void    InitBuffers();
     void            LoadOptions();                  //!< loads options for this window from the OptionsDB
-    void            Init(const std::string& t);     //!< performs initialization common to all CUIWnd constructors
+    void            Init();                         //!< performs initialization common to all CUIWnd constructors
     void            ResetDefaultPosition();         //!< called via signal from the ClientUI, passes the value from CalculatePosition() to InitSizeMove()
 
     void SetParent(GG::Wnd* wnd) override;
@@ -232,6 +233,7 @@ protected:
 class CUIEditWnd : public CUIWnd {
 public:
     CUIEditWnd(GG::X w, const std::string& prompt_text, const std::string& edit_text, GG::Flags<GG::WndFlag> flags = GG::MODAL);
+    void CompleteConstruction() override;
 
     void ModalInit() override;
 

--- a/UI/CensusBrowseWnd.cpp
+++ b/UI/CensusBrowseWnd.cpp
@@ -136,8 +136,7 @@ CensusBrowseWnd::CensusBrowseWnd(const std::string& title_text, const std::map<s
     m_tag_counts(tag_counts)
 {}
 
-void CensusBrowseWnd::CompleteConstruction()
-{
+void CensusBrowseWnd::CompleteConstruction() {
     GG::BrowseInfoWnd::CompleteConstruction();
 
     const GG::Y ROW_HEIGHT(MeterIconSize().y);

--- a/UI/CensusBrowseWnd.cpp
+++ b/UI/CensusBrowseWnd.cpp
@@ -48,8 +48,7 @@ public:
         m_census_val = GG::Wnd::Create<CUILabel>(DoubleToString(census_val, num_digits, false), GG::FORMAT_RIGHT);
     }
 
-    void CompleteConstruction() override
-    {
+    void CompleteConstruction() override {
         GG::Control::CompleteConstruction();
 
         SetChildClippingMode(ClipToClient);

--- a/UI/CensusBrowseWnd.cpp
+++ b/UI/CensusBrowseWnd.cpp
@@ -34,15 +34,11 @@ public:
         GG::Control(GG::X0, GG::Y0, w, h, GG::NO_WND_FLAGS),
         m_icon(nullptr),
         m_name(nullptr),
-        m_census_val(nullptr)
+        m_census_val(nullptr),
+        m_show_icon(show_icon)
     {
-        m_show_icon = show_icon;
-        SetChildClippingMode(ClipToClient);
-
-        if (m_show_icon) {
+        if (m_show_icon)
             m_icon = GG::Wnd::Create<GG::StaticGraphic>(ClientUI::SpeciesIcon(name), GG::GRAPHIC_FITGRAPHIC);
-            AttachChild(m_icon);
-        }
 
         m_name = GG::Wnd::Create<CUILabel>(UserString(name), GG::FORMAT_RIGHT);
 
@@ -50,6 +46,16 @@ public:
         num_digits =    census_val < 100 ? num_digits : 3; // this allows the decimal point to line up when there number above and below 100.
         num_digits =   census_val < 1000 ? num_digits : 4; // this allows the decimal point to line up when there number above and below 1000.
         m_census_val = GG::Wnd::Create<CUILabel>(DoubleToString(census_val, num_digits, false), GG::FORMAT_RIGHT);
+    }
+
+    void CompleteConstruction() override
+    {
+        GG::Control::CompleteConstruction();
+
+        SetChildClippingMode(ClipToClient);
+
+        if (m_show_icon)
+            AttachChild(m_icon);
 
         AttachChild(m_name);
         AttachChild(m_census_val);

--- a/UI/CensusBrowseWnd.cpp
+++ b/UI/CensusBrowseWnd.cpp
@@ -126,30 +126,34 @@ private:
 CensusBrowseWnd::CensusBrowseWnd(const std::string& title_text, const std::map<std::string, float>& population_counts,
                                  const std::map<std::string, float>& tag_counts) :
     GG::BrowseInfoWnd(GG::X0, GG::Y0, BrowseTextWidth(), GG::Y1),
-    m_title_text(nullptr),
-    m_species_text(nullptr),
-    m_list(nullptr),
-    m_tags_text(nullptr),
-    m_tags_list(nullptr),
-    m_offset(GG::X0, ICON_BROWSE_ICON_HEIGHT/2)
+    m_title_text(GG::Wnd::Create<CUILabel>(title_text, GG::FORMAT_LEFT)),
+    m_species_text(GG::Wnd::Create<CUILabel>(UserString("CENSUS_SPECIES_HEADER"), GG::FORMAT_BOTTOM)),
+    m_list(GG::Wnd::Create<CUIListBox>()),
+    m_tags_text(GG::Wnd::Create<CUILabel>(UserString("CENSUS_TAG_HEADER"), GG::FORMAT_BOTTOM)),
+    m_tags_list(GG::Wnd::Create<CUIListBox>()),
+    m_offset(GG::X0, ICON_BROWSE_ICON_HEIGHT/2),
+    m_population_counts(population_counts),
+    m_tag_counts(tag_counts)
+{}
+
+void CensusBrowseWnd::CompleteConstruction()
 {
+    GG::BrowseInfoWnd::CompleteConstruction();
+
     const GG::Y ROW_HEIGHT(MeterIconSize().y);
     const GG::Y HALF_HEIGHT(GG::Y(int(ClientUI::Pts()/2)));
 
     GG::Y top = GG::Y0;
 
-    m_title_text = GG::Wnd::Create<CUILabel>(title_text, GG::FORMAT_LEFT);
     m_title_text->MoveTo(GG::Pt(GG::X(EDGE_PAD) + m_offset.x, top + m_offset.y));
     m_title_text->Resize(GG::Pt(BrowseTextWidth(), ROW_HEIGHT));
     m_title_text->SetFont(ClientUI::GetBoldFont());
 
     top += ROW_HEIGHT;
-    m_species_text = GG::Wnd::Create<CUILabel>(UserString("CENSUS_SPECIES_HEADER"), GG::FORMAT_BOTTOM);
     m_species_text->MoveTo(GG::Pt(GG::X(EDGE_PAD) + m_offset.x, top + m_offset.y));
     m_species_text->Resize(GG::Pt(BrowseTextWidth(), ROW_HEIGHT + HALF_HEIGHT));
 
     top += ROW_HEIGHT + HALF_HEIGHT;
-    m_list = GG::Wnd::Create<CUIListBox>();
     m_list->MoveTo(GG::Pt(m_offset.x, top + m_offset.y));
     m_list->Resize(GG::Pt(BrowseTextWidth(), ROW_HEIGHT));
     m_list->SetStyle(GG::LIST_NOSEL | GG::LIST_NOSORT);
@@ -161,8 +165,9 @@ CensusBrowseWnd::CensusBrowseWnd(const std::string& title_text, const std::map<s
 
     // put into multimap to sort by population, ascending
     std::multimap<float, std::string> counts_species;
-    for (const std::map<std::string, float>::value_type& entry : population_counts)
+    for (const std::map<std::string, float>::value_type& entry : m_population_counts)
     { counts_species.insert({entry.second, entry.first}); }
+    m_population_counts.clear();
 
     // add species rows
     for (std::multimap<float, std::string>::const_reverse_iterator it = counts_species.rbegin();
@@ -178,12 +183,10 @@ CensusBrowseWnd::CensusBrowseWnd(const std::string& title_text, const std::map<s
     m_list->Resize(GG::Pt(BrowseTextWidth(), top - 2* ROW_HEIGHT - HALF_HEIGHT));
 
     GG::Y top2 = top;
-    m_tags_text = GG::Wnd::Create<CUILabel>(UserString("CENSUS_TAG_HEADER"), GG::FORMAT_BOTTOM);
     m_tags_text->MoveTo(GG::Pt(GG::X(EDGE_PAD) + m_offset.x, top2 + m_offset.y));
     m_tags_text->Resize(GG::Pt(BrowseTextWidth(), ROW_HEIGHT + HALF_HEIGHT));
 
     top2 += ROW_HEIGHT + HALF_HEIGHT;
-    m_tags_list = GG::Wnd::Create<CUIListBox>();
     m_tags_list->MoveTo(GG::Pt(m_offset.x, top2 + m_offset.y));
     m_tags_list->Resize(GG::Pt(BrowseTextWidth(), ROW_HEIGHT));
     m_tags_list->SetStyle(GG::LIST_NOSEL | GG::LIST_NOSORT);
@@ -210,8 +213,8 @@ CensusBrowseWnd::CensusBrowseWnd(const std::string& title_text, const std::map<s
     // add tags/characteristics rows
     for (const std::string& tag_ord : tag_order) {
         //DebugLogger() << "Census checking for tag '"<< tag_ord <<"'";
-        std::map<std::string, float>::const_iterator it2 = tag_counts.find(tag_ord);
-        if (it2 != tag_counts.end()) {
+        std::map<std::string, float>::const_iterator it2 = m_tag_counts.find(tag_ord);
+        if (it2 != m_tag_counts.end()) {
             auto row = GG::Wnd::Create<GG::ListBox::Row>(m_list->Width(), ROW_HEIGHT, "Census Characteristics Row");
             row->push_back(GG::Wnd::Create<CensusRowPanel>(m_tags_list->Width(), ROW_HEIGHT, it2->first, it2->second, false));
             m_tags_list->Insert(row);
@@ -219,6 +222,7 @@ CensusBrowseWnd::CensusBrowseWnd(const std::string& title_text, const std::map<s
             top2 += ROW_HEIGHT;
         }
     }
+    m_tag_counts.clear();
 
     m_tags_list->Resize(GG::Pt(BrowseTextWidth(), top2 -top -ROW_HEIGHT - HALF_HEIGHT + (EDGE_PAD*3)));
 

--- a/UI/CensusBrowseWnd.h
+++ b/UI/CensusBrowseWnd.h
@@ -11,6 +11,7 @@ public:
     CensusBrowseWnd(const std::string& title_text, const std::map<std::string, float>& population_counts,
                     const std::map<std::string, float>& tag_counts);
 
+    void CompleteConstruction() override;
     bool WndHasBrowseInfo(const Wnd* wnd, std::size_t mode) const override;
 
     void Render() override;
@@ -26,6 +27,8 @@ private:
     GG::Label*      m_tags_text;
     GG::ListBox*    m_tags_list;
     GG::Pt          m_offset;
+    std::map<std::string, float>    m_population_counts;
+    std::map<std::string, float>    m_tag_counts;
 
     void InitRowSizes();
 };

--- a/UI/ChatWnd.cpp
+++ b/UI/ChatWnd.cpp
@@ -322,7 +322,12 @@ MessageWnd::MessageWnd(const std::string& config_name) :
     m_display_show_time(0),
     m_history(),
     m_history_position()
+{}
+
+void MessageWnd::CompleteConstruction()
 {
+    CUIWnd::CompleteConstruction();
+
     m_display = GG::Wnd::Create<CUIMultiEdit>("", GG::MULTI_WORDBREAK | GG::MULTI_READ_ONLY | GG::MULTI_TERMINAL_STYLE | GG::MULTI_INTEGRAL_HEIGHT);
     AttachChild(m_display);
     m_display->SetMaxLinesOfHistory(100); // executing this line seems to cause crashes in MultiEdit when adding more lines to the control than the history limit

--- a/UI/ChatWnd.cpp
+++ b/UI/ChatWnd.cpp
@@ -324,8 +324,7 @@ MessageWnd::MessageWnd(const std::string& config_name) :
     m_history_position()
 {}
 
-void MessageWnd::CompleteConstruction()
-{
+void MessageWnd::CompleteConstruction() {
     CUIWnd::CompleteConstruction();
 
     m_display = GG::Wnd::Create<CUIMultiEdit>("", GG::MULTI_WORDBREAK | GG::MULTI_READ_ONLY | GG::MULTI_TERMINAL_STYLE | GG::MULTI_INTEGRAL_HEIGHT);

--- a/UI/ChatWnd.h
+++ b/UI/ChatWnd.h
@@ -14,8 +14,8 @@ class MessageWndEdit;
 
 class MessageWnd : public CUIWnd {
 public:
-    //! \name Structors //@{
     MessageWnd(const std::string& config_name = "");
+    void CompleteConstruction() override;
     //@}
 
     //! \name Mutators //@{

--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -615,8 +615,8 @@ ClientUI::ClientUI() :
     if (GetOptionsDB().Get<bool>("window-reset"))
         CUIWnd::InvalidateUnusedOptions();
 
-    m_message_wnd = new MessageWnd(MESSAGE_WND_NAME);
-    m_player_list_wnd = new PlayerListWnd(PLAYER_LIST_WND_NAME);
+    m_message_wnd = GG::Wnd::Create<MessageWnd>(MESSAGE_WND_NAME);
+    m_player_list_wnd = GG::Wnd::Create<PlayerListWnd>(PLAYER_LIST_WND_NAME);
     InitializeWindows();
 
     m_intro_screen = GG::Wnd::Create<IntroScreen>();

--- a/UI/CombatReport/CombatLogWnd.cpp
+++ b/UI/CombatReport/CombatLogWnd.cpp
@@ -115,6 +115,7 @@ namespace {
         CombatLogAccordionPanel(GG::X w, CombatLogWnd::Impl &log_,
                                 int viewing_empire_id_, ConstCombatEventPtr event_);
         ~CombatLogAccordionPanel();
+        void CompleteConstruction() override;
 
         private:
         /** toggles panel expanded or collapsed */
@@ -139,7 +140,10 @@ namespace {
         event(event_),
         title(log.DecorateLinkText(event->CombatLogDescription(viewing_empire_id))),
         details()
-    {
+    {}
+
+    void CombatLogAccordionPanel::CompleteConstruction() {
+        AccordionPanel::CompleteConstruction();
         AccordionPanel::SetInteriorColor(ClientUI::CtrlColor());
 
         m_expand_button->LeftClickedSignal.connect(

--- a/UI/CombatReport/CombatReportWnd.cpp
+++ b/UI/CombatReport/CombatReportWnd.cpp
@@ -208,7 +208,13 @@ CombatReportWnd::CombatReportWnd(const std::string& config_name) :
            GG::INTERACTIVE | GG::RESIZABLE | GG::DRAGABLE | GG::ONTOP | CLOSABLE,
            config_name, false),
     m_impl(nullptr)
-{ m_impl.reset(new Impl(*this)); }
+{}
+
+void CombatReportWnd::CompleteConstruction()
+{
+    m_impl.reset(new Impl(*this));
+    CUIWnd::CompleteConstruction();
+}
 
 CombatReportWnd::~CombatReportWnd()
 {}

--- a/UI/CombatReport/CombatReportWnd.cpp
+++ b/UI/CombatReport/CombatReportWnd.cpp
@@ -210,8 +210,7 @@ CombatReportWnd::CombatReportWnd(const std::string& config_name) :
     m_impl(nullptr)
 {}
 
-void CombatReportWnd::CompleteConstruction()
-{
+void CombatReportWnd::CompleteConstruction() {
     m_impl.reset(new Impl(*this));
     CUIWnd::CompleteConstruction();
 }

--- a/UI/CombatReport/CombatReportWnd.h
+++ b/UI/CombatReport/CombatReportWnd.h
@@ -10,7 +10,8 @@
 class CombatReportWnd : public CUIWnd {
 public:
     CombatReportWnd(const std::string& config_name = "");
-    // Must have explicit destructor since CombatReportPrivate is incomplete here
+    void CompleteConstruction() override;
+    // Must have explicit destructor since Impl is incomplete here
     virtual ~CombatReportWnd();
 
     void CloseClicked() override;

--- a/UI/CombatReport/GraphicalSummary.cpp
+++ b/UI/CombatReport/GraphicalSummary.cpp
@@ -643,7 +643,7 @@ private:
             parent(parent),
             button(nullptr)
         {
-            button = new CUIButton("-");
+            button = Wnd::Create<CUIButton>("-");
             parent->AttachChild(button);
             button->LeftClickedSignal.connect(
                 boost::bind(&ToggleData::Toggle, this));

--- a/UI/CombatReport/GraphicalSummary.cpp
+++ b/UI/CombatReport/GraphicalSummary.cpp
@@ -348,15 +348,16 @@ public:
         m_side_summary(combat_summary),
         m_x_axis_label(nullptr),
         m_sizer(sizer)
-    {
+    {}
 
-        GG::Clr axis_label_color = combat_summary.SideColor();
+    void CompleteConstruction() override {
+        GG::Clr axis_label_color = m_side_summary.SideColor();
 
         m_x_axis_label = GG::Wnd::Create<CUILabel>(
             (boost::format( UserString("COMBAT_FLEET_HEALTH_AXIS_LABEL") )
-             % combat_summary.SideName()
-             % static_cast<int>(combat_summary.total_current_health)
-             % static_cast<int>(combat_summary.total_max_health)).str(),
+             % m_side_summary.SideName()
+             % static_cast<int>(m_side_summary.total_current_health)
+             % static_cast<int>(m_side_summary.total_max_health)).str(),
             GG::FORMAT_LEFT);
         m_x_axis_label->SetColor(axis_label_color);
         AttachChild(m_x_axis_label);
@@ -370,6 +371,7 @@ public:
         AttachChild(m_dead_label);
 
         MakeBars();
+
     }
 
     void MakeBars() {
@@ -766,7 +768,7 @@ void GraphicalSummaryWnd::GenerateGraph() {
     for (std::map<int, CombatSummary>::value_type& summary : m_summaries) {
         if (summary.second.total_max_health > EPSILON) {
             summary.second.Sort();
-            auto box = new SideBar(summary.second, *m_sizer);
+            auto box = GG::Wnd::Create<SideBar>(summary.second, *m_sizer);
             m_side_boxes.push_back(box);
             AttachChild(box);
         }

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -779,8 +779,7 @@ PartControl::PartControl(const PartType* part) :
     m_part(part)
 {}
 
-void PartControl::CompleteConstruction()
-{
+void PartControl::CompleteConstruction() {
     GG::Control::CompleteConstruction();
     if (!m_part)
         return;
@@ -1350,8 +1349,7 @@ DesignWnd::PartPalette::PartPalette(const std::string& config_name) :
     m_superfluous_parts_button(nullptr)
 {}
 
-void DesignWnd::PartPalette::CompleteConstruction()
-{
+void DesignWnd::PartPalette::CompleteConstruction() {
     //TempUISoundDisabler sound_disabler;     // should be redundant with disabler in DesignWnd::DesignWnd.  uncomment if this is not the case
     SetChildClippingMode(ClipToClient);
 
@@ -1794,8 +1792,7 @@ BasesListBox::HullAndNamePanel::HullAndNamePanel(GG::X w, GG::Y h, const std::st
     m_name = GG::Wnd::Create<CUILabel>(name, GG::FORMAT_WORDBREAK | GG::FORMAT_CENTER | GG::FORMAT_TOP);
 }
 
-void BasesListBox::HullAndNamePanel::CompleteConstruction()
-{
+void BasesListBox::HullAndNamePanel::CompleteConstruction() {
     GG::Control::CompleteConstruction();
     AttachChild(m_graphic);
     AttachChild(m_name);
@@ -1832,8 +1829,7 @@ BasesListBox::BasesListBoxRow::BasesListBoxRow(GG::X w, GG::Y h, const std::stri
     SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
 }
 
-void BasesListBox::BasesListBoxRow::CompleteConstruction()
-{
+void BasesListBox::BasesListBoxRow::CompleteConstruction() {
     CUIListBox::Row::CompleteConstruction();
     push_back(m_hull_panel);
 }
@@ -1885,8 +1881,7 @@ BasesListBox::HullAndPartsListBoxRow::HullAndPartsListBoxRow(GG::X w, GG::Y h, c
     m_parts(parts)
 {}
 
-void BasesListBox::HullAndPartsListBoxRow::CompleteConstruction()
-{
+void BasesListBox::HullAndPartsListBoxRow::CompleteConstruction() {
     BasesListBoxRow::CompleteConstruction();
     SetDragDropDataType(HULL_PARTS_ROW_DROP_TYPE_STRING);
 }
@@ -1897,8 +1892,7 @@ BasesListBox::CompletedDesignListBoxRow::CompletedDesignListBoxRow(
     m_design_id(design.ID())
 {}
 
-void BasesListBox::CompletedDesignListBoxRow::CompleteConstruction()
-{
+void BasesListBox::CompletedDesignListBoxRow::CompleteConstruction() {
     BasesListBoxRow::CompleteConstruction();
     SetDragDropDataType(COMPLETE_DESIGN_ROW_DROP_STRING);
 }
@@ -1914,8 +1908,7 @@ BasesListBox::BasesListBox(const BasesListBox::AvailabilityManager& availabiliti
     m_availabilities_state(availabilities_state)
 {}
 
-void BasesListBox::CompleteConstruction()
-{
+void BasesListBox::CompleteConstruction() {
     QueueListBox::CompleteConstruction();
 
     InitRowSizes();
@@ -2668,8 +2661,7 @@ SavedDesignsListBox::SavedDesignListBoxRow::SavedDesignListBoxRow(
     m_design_uuid(design.UUID())
 {}
 
-void SavedDesignsListBox::SavedDesignListBoxRow::CompleteConstruction()
-{
+void SavedDesignsListBox::SavedDesignListBoxRow::CompleteConstruction() {
     BasesListBoxRow::CompleteConstruction();
     SetDragDropDataType(SAVED_DESIGN_ROW_DROP_STRING);
 }
@@ -2769,8 +2761,7 @@ DesignWnd::BaseSelector::BaseSelector(const std::string& config_name) :
     m_availabilities_state{false, true, false}
 {}
 
-void DesignWnd::BaseSelector::CompleteConstruction()
-{
+void DesignWnd::BaseSelector::CompleteConstruction() {
     auto& m_obsolete_button = std::get<Availability::Obsolete>(m_availabilities_buttons);
     m_obsolete_button = GG::Wnd::Create<CUIStateButton>(UserString("PRODUCTION_WND_AVAILABILITY_OBSOLETE"), GG::FORMAT_CENTER, std::make_shared<CUILabelButtonRepresenter>());
     AttachChild(m_obsolete_button);
@@ -3017,8 +3008,7 @@ SlotControl::SlotControl(double x, double y, ShipSlotType slot_type) :
     m_background(nullptr)
 {}
 
-void SlotControl::CompleteConstruction()
-{
+void SlotControl::CompleteConstruction() {
     GG::Control::CompleteConstruction();
 
     m_background = GG::Wnd::Create<GG::StaticGraphic>(SlotBackgroundTexture(m_slot_type), GG::GRAPHIC_FITGRAPHIC | GG::GRAPHIC_PROPSCALE);
@@ -3471,8 +3461,7 @@ DesignWnd::MainPanel::MainPanel(const std::string& config_name) :
     m_disabled_by_part_conflict(false)
 {}
 
-void DesignWnd::MainPanel::CompleteConstruction()
-{
+void DesignWnd::MainPanel::CompleteConstruction() {
     SetChildClippingMode(ClipToClient);
 
     m_design_name_label = GG::Wnd::Create<CUILabel>(UserString("DESIGN_WND_DESIGN_NAME"), GG::FORMAT_RIGHT, GG::INTERACTIVE);
@@ -4363,8 +4352,7 @@ DesignWnd::DesignWnd(GG::X w, GG::Y h) :
     m_main_panel(nullptr)
 {}
 
-void DesignWnd::CompleteConstruction()
-{
+void DesignWnd::CompleteConstruction() {
     GG::Wnd::CompleteConstruction();
 
     Sound::TempUISoundDisabler sound_disabler;

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -748,6 +748,7 @@ public:
     /** \name Structors */ //@{
     PartControl(const PartType* part);
     //@}
+    void CompleteConstruction() override;
 
     /** \name Accessors */ //@{
     const PartType*     Part() const { return m_part; }
@@ -776,7 +777,11 @@ PartControl::PartControl(const PartType* part) :
     m_icon(nullptr),
     m_background(nullptr),
     m_part(part)
+{}
+
+void PartControl::CompleteConstruction()
 {
+    GG::Control::CompleteConstruction();
     if (!m_part)
         return;
 
@@ -1786,11 +1791,11 @@ BasesListBox::HullAndNamePanel::HullAndNamePanel(GG::X w, GG::Y h, const std::st
                                                    GG::GRAPHIC_PROPSCALE | GG::GRAPHIC_FITGRAPHIC);
     m_graphic->Resize(GG::Pt(w, h));
     m_name = GG::Wnd::Create<CUILabel>(name, GG::FORMAT_WORDBREAK | GG::FORMAT_CENTER | GG::FORMAT_TOP);
-
 }
 
 void BasesListBox::HullAndNamePanel::CompleteConstruction()
 {
+    GG::Control::CompleteConstruction();
     AttachChild(m_graphic);
     AttachChild(m_name);
 }
@@ -2934,6 +2939,7 @@ public:
     SlotControl();
     SlotControl(double x, double y, ShipSlotType slot_type);
     //@}
+    void CompleteConstruction() override;
 
     /** \name Accessors */ //@{
     ShipSlotType    SlotType() const;
@@ -3003,7 +3009,12 @@ SlotControl::SlotControl(double x, double y, ShipSlotType slot_type) :
     m_y_position_fraction(y),
     m_part_control(nullptr),
     m_background(nullptr)
+{}
+
+void SlotControl::CompleteConstruction()
 {
+    GG::Control::CompleteConstruction();
+
     m_background = GG::Wnd::Create<GG::StaticGraphic>(SlotBackgroundTexture(m_slot_type), GG::GRAPHIC_FITGRAPHIC | GG::GRAPHIC_PROPSCALE);
     m_background->Resize(GG::Pt(SLOT_CONTROL_WIDTH, SLOT_CONTROL_HEIGHT));
     m_background->Show();
@@ -3013,11 +3024,11 @@ SlotControl::SlotControl(double x, double y, ShipSlotType slot_type) :
 
     // set up empty slot tool tip
     std::string title_text;
-    if (slot_type == SL_EXTERNAL)
+    if (m_slot_type == SL_EXTERNAL)
         title_text = UserString("SL_EXTERNAL");
-    else if (slot_type == SL_INTERNAL)
+    else if (m_slot_type == SL_INTERNAL)
         title_text = UserString("SL_INTERNAL");
-    else if (slot_type == SL_CORE)
+    else if (m_slot_type == SL_CORE)
         title_text = UserString("SL_CORE");
 
     SetBrowseInfoWnd(std::make_shared<IconTextBrowseWnd>(

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -1663,6 +1663,7 @@ public:
                  const boost::optional<std::string>& drop_type = boost::none,
                  const boost::optional<std::string>& empty_prompt = boost::none);
     //@}
+    void CompleteConstruction() override;
 
     /** \name Accessors */ //@{
     //@}
@@ -1911,7 +1912,12 @@ BasesListBox::BasesListBox(const BasesListBox::AvailabilityManager& availabiliti
                  empty_prompt ? *empty_prompt : UserString("ADD_FIRST_DESIGN_DESIGN_QUEUE_PROMPT")),
     m_empire_id_shown(ALL_EMPIRES),
     m_availabilities_state(availabilities_state)
+{}
+
+void BasesListBox::CompleteConstruction()
 {
+    QueueListBox::CompleteConstruction();
+
     InitRowSizes();
     SetStyle(GG::LIST_NOSEL | GG::LIST_NOSORT);
 

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -1300,6 +1300,7 @@ class DesignWnd::PartPalette : public CUIWnd {
 public:
     /** \name Structors */ //@{
     PartPalette(const std::string& config_name);
+    void CompleteConstruction() override;
     //@}
 
     /** \name Mutators */ //@{
@@ -1342,6 +1343,9 @@ DesignWnd::PartPalette::PartPalette(const std::string& config_name) :
            config_name),
     m_parts_list(nullptr),
     m_superfluous_parts_button(nullptr)
+{}
+
+void DesignWnd::PartPalette::CompleteConstruction()
 {
     //TempUISoundDisabler sound_disabler;     // should be redundant with disabler in DesignWnd::DesignWnd.  uncomment if this is not the case
     SetChildClippingMode(ClipToClient);
@@ -1396,6 +1400,8 @@ DesignWnd::PartPalette::PartPalette(const std::string& config_name) :
     ShowAllClasses(false);
     ShowAvailability(true, false);
     ShowSuperfluous(false);
+
+    CUIWnd::CompleteConstruction();
 
     DoLayout();
 }
@@ -2673,6 +2679,7 @@ class DesignWnd::BaseSelector : public CUIWnd {
 public:
     /** \name Structors */ //@{
     BaseSelector(const std::string& config_name);
+    void CompleteConstruction() override;
     //@}
 
     /** \name Mutators */ //@{
@@ -2722,6 +2729,9 @@ DesignWnd::BaseSelector::BaseSelector(const std::string& config_name) :
     m_saved_designs_list(nullptr),
     m_monsters_list(nullptr),
     m_availabilities_state{false, true, false}
+{}
+
+void DesignWnd::BaseSelector::CompleteConstruction()
 {
     auto& m_obsolete_button = std::get<Availability::Obsolete>(m_availabilities_buttons);
     m_obsolete_button = new CUIStateButton(UserString("PRODUCTION_WND_AVAILABILITY_OBSOLETE"), GG::FORMAT_CENTER, std::make_shared<CUILabelButtonRepresenter>());
@@ -2780,6 +2790,8 @@ DesignWnd::BaseSelector::BaseSelector(const std::string& config_name) :
         DesignWnd::BaseSelector::DesignSelectedSignal);
     m_monsters_list->DesignClickedSignal.connect(
         DesignWnd::BaseSelector::DesignClickedSignal);
+
+    CUIWnd::CompleteConstruction();
 
     DoLayout();
 }
@@ -3238,6 +3250,7 @@ public:
 
     /** \name Structors */ //@{
     MainPanel(const std::string& config_name);
+    void CompleteConstruction() override;
     //@}
 
     /** \name Accessors */ //@{
@@ -3412,6 +3425,9 @@ DesignWnd::MainPanel::MainPanel(const std::string& config_name) :
     m_clear_button(nullptr),
     m_disabled_by_name(false),
     m_disabled_by_part_conflict(false)
+{}
+
+void DesignWnd::MainPanel::CompleteConstruction()
 {
     SetChildClippingMode(ClipToClient);
 
@@ -3445,6 +3461,8 @@ DesignWnd::MainPanel::MainPanel(const std::string& config_name) :
     DesignConfirmedSignal.connect(boost::bind(&DesignWnd::MainPanel::AddDesign, this));
 
     DesignChanged(); // Initialize components that rely on the current state of the design.
+
+    CUIWnd::CompleteConstruction();
 
     DoLayout();
 }
@@ -4303,10 +4321,10 @@ DesignWnd::DesignWnd(GG::X w, GG::Y h) :
     Sound::TempUISoundDisabler sound_disabler;
     SetChildClippingMode(ClipToClient);
 
-    m_detail_panel = new EncyclopediaDetailPanel(GG::ONTOP | GG::INTERACTIVE | GG::DRAGABLE | GG::RESIZABLE | PINABLE, DES_PEDIA_WND_NAME);
-    m_main_panel = new MainPanel(DES_MAIN_WND_NAME);
-    m_part_palette = new PartPalette(DES_PART_PALETTE_WND_NAME);
-    m_base_selector = new BaseSelector(DES_BASE_SELECTOR_WND_NAME);
+    m_detail_panel = GG::Wnd::Create<EncyclopediaDetailPanel>(GG::ONTOP | GG::INTERACTIVE | GG::DRAGABLE | GG::RESIZABLE | PINABLE, DES_PEDIA_WND_NAME);
+    m_main_panel = GG::Wnd::Create<MainPanel>(DES_MAIN_WND_NAME);
+    m_part_palette = GG::Wnd::Create<PartPalette>(DES_PART_PALETTE_WND_NAME);
+    m_base_selector = GG::Wnd::Create<BaseSelector>(DES_BASE_SELECTOR_WND_NAME);
     InitializeWindows();
     HumanClientApp::GetApp()->RepositionWindowsSignal.connect(
         boost::bind(&DesignWnd::InitializeWindows, this));

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -4344,7 +4344,12 @@ DesignWnd::DesignWnd(GG::X w, GG::Y h) :
     m_base_selector(nullptr),
     m_part_palette(nullptr),
     m_main_panel(nullptr)
+{}
+
+void DesignWnd::CompleteConstruction()
 {
+    GG::Wnd::CompleteConstruction();
+
     Sound::TempUISoundDisabler sound_disabler;
     SetChildClippingMode(ClipToClient);
 

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -1689,6 +1689,7 @@ public:
     public:
         HullAndNamePanel(GG::X w, GG::Y h, const std::string& hull, const std::string& name);
 
+        void CompleteConstruction() override;
         void SizeMove(const GG::Pt& ul, const GG::Pt& lr) override;
 
         void Render() override
@@ -1706,6 +1707,7 @@ public:
         public:
         BasesListBoxRow(GG::X w, GG::Y h, const std::string& hull, const std::string& name);
 
+        void CompleteConstruction() override;
         void Render() override;
 
         void SizeMove(const GG::Pt& ul, const GG::Pt& lr) override;
@@ -1721,6 +1723,7 @@ public:
     public:
         HullAndPartsListBoxRow(GG::X w, GG::Y h, const std::string& hull,
                                const std::vector<std::string>& parts);
+        void CompleteConstruction() override;
         const std::string&              Hull() const    { return m_hull_name; }
         const std::vector<std::string>& Parts() const   { return m_parts; }
     protected:
@@ -1731,6 +1734,7 @@ public:
     class CompletedDesignListBoxRow : public BasesListBoxRow {
     public:
         CompletedDesignListBoxRow(GG::X w, GG::Y h, const ShipDesign& design);
+        void CompleteConstruction() override;
         int                             DesignID() const { return m_design_id; }
     private:
         int                             m_design_id;
@@ -1781,8 +1785,13 @@ BasesListBox::HullAndNamePanel::HullAndNamePanel(GG::X w, GG::Y h, const std::st
     m_graphic = GG::Wnd::Create<GG::StaticGraphic>(ClientUI::HullIcon(hull),
                                                    GG::GRAPHIC_PROPSCALE | GG::GRAPHIC_FITGRAPHIC);
     m_graphic->Resize(GG::Pt(w, h));
-    AttachChild(m_graphic);
     m_name = GG::Wnd::Create<CUILabel>(name, GG::FORMAT_WORDBREAK | GG::FORMAT_CENTER | GG::FORMAT_TOP);
+
+}
+
+void BasesListBox::HullAndNamePanel::CompleteConstruction()
+{
+    AttachChild(m_graphic);
     AttachChild(m_name);
 }
 
@@ -1813,9 +1822,14 @@ BasesListBox::BasesListBoxRow::BasesListBoxRow(GG::X w, GG::Y h, const std::stri
     }
 
     m_hull_panel = GG::Wnd::Create<HullAndNamePanel>(w, h, hull, name);
-    push_back(m_hull_panel);
 
     SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
+}
+
+void BasesListBox::BasesListBoxRow::CompleteConstruction()
+{
+    CUIListBox::Row::CompleteConstruction();
+    push_back(m_hull_panel);
 }
 
 void BasesListBox::BasesListBoxRow::Render() {
@@ -1863,7 +1877,11 @@ BasesListBox::HullAndPartsListBoxRow::HullAndPartsListBoxRow(GG::X w, GG::Y h, c
     BasesListBoxRow(w, h, hull, UserString(hull)),
     m_hull_name(hull),
     m_parts(parts)
+{}
+
+void BasesListBox::HullAndPartsListBoxRow::CompleteConstruction()
 {
+    BasesListBoxRow::CompleteConstruction();
     SetDragDropDataType(HULL_PARTS_ROW_DROP_TYPE_STRING);
 }
 
@@ -1871,7 +1889,11 @@ BasesListBox::CompletedDesignListBoxRow::CompletedDesignListBoxRow(
     GG::X w, GG::Y h, const ShipDesign &design) :
     BasesListBoxRow(w, h, design.Hull(), design.Name()),
     m_design_id(design.ID())
+{}
+
+void BasesListBox::CompletedDesignListBoxRow::CompleteConstruction()
 {
+    BasesListBoxRow::CompleteConstruction();
     SetDragDropDataType(COMPLETE_DESIGN_ROW_DROP_STRING);
 }
 
@@ -2064,6 +2086,7 @@ class SavedDesignsListBox : public BasesListBox {
     class SavedDesignListBoxRow : public BasesListBoxRow {
         public:
         SavedDesignListBoxRow(GG::X w, GG::Y h, const ShipDesign& design);
+        void CompleteConstruction() override;
         const boost::uuids::uuid        DesignUUID() const;
         const std::string&              DesignName() const;
         const std::string&              Description() const;
@@ -2632,7 +2655,11 @@ SavedDesignsListBox::SavedDesignListBoxRow::SavedDesignListBoxRow(
     GG::X w, GG::Y h, const ShipDesign& design) :
     BasesListBoxRow(w, h, design.Hull(), design.Name()),
     m_design_uuid(design.UUID())
+{}
+
+void SavedDesignsListBox::SavedDesignListBoxRow::CompleteConstruction()
 {
+    BasesListBoxRow::CompleteConstruction();
     SetDragDropDataType(SAVED_DESIGN_ROW_DROP_STRING);
 }
 

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -3980,17 +3980,17 @@ void DesignWnd::MainPanel::DesignChanged() {
     m_confirm_button->SetText(UserString("DESIGN_WND_ADD_FINISHED"));
 
     if (!m_hull) {
-        m_replace_button->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+        m_replace_button->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
             UserString("DESIGN_INVALID"), UserString("DESIGN_UPDATE_INVALID_NO_CANDIDATE")));
-        m_confirm_button->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+        m_confirm_button->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
             UserString("DESIGN_INVALID"), UserString("DESIGN_INV_NO_HULL")));
         return;
     }
 
     if (client_empire_id == ALL_EMPIRES) {
-        m_replace_button->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+        m_replace_button->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
             UserString("DESIGN_INVALID"), UserString("DESIGN_INV_MODERATOR")));
-        m_confirm_button->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+        m_confirm_button->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
             UserString("DESIGN_INVALID"), UserString("DESIGN_INV_MODERATOR")));
         return;
     }
@@ -3998,9 +3998,9 @@ void DesignWnd::MainPanel::DesignChanged() {
     if (!IsDesignNameValid()) {
         m_disabled_by_name = true;
 
-        m_replace_button->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+        m_replace_button->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
             UserString("DESIGN_INVALID"), UserString("DESIGN_INV_NO_NAME")));
-        m_confirm_button->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+        m_confirm_button->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
             UserString("DESIGN_INVALID"), UserString("DESIGN_INV_NO_NAME")));
         return;
     }
@@ -4044,12 +4044,12 @@ void DesignWnd::MainPanel::DesignChanged() {
 
 
         if (m_disabled_by_part_conflict) {
-            m_replace_button->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+            m_replace_button->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
                 UserString("DESIGN_COMPONENT_CONFLICT"),
                 boost::io::str(FlexibleFormat(UserString("DESIGN_COMPONENT_CONFLICT_DETAIL"))
                                % UserString(problematic_components.first)
                                % UserString(problematic_components.second))));
-            m_confirm_button->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+            m_confirm_button->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
                 UserString("DESIGN_COMPONENT_CONFLICT"),
                 boost::io::str(FlexibleFormat(UserString("DESIGN_COMPONENT_CONFLICT_DETAIL"))
                                % UserString(problematic_components.first)
@@ -4085,7 +4085,7 @@ void DesignWnd::MainPanel::DesignChanged() {
         if (cur_design && !(*cur_design == **replaced_saved_design)) {
             m_replace_button->SetText(UserString("DESIGN_WND_UPDATE_SAVED"));
             m_replace_button->SetBrowseInfoWnd(
-                std::make_shared<TextBrowseWnd>(
+                GG::Wnd::Create<TextBrowseWnd>(
                     UserString("DESIGN_WND_UPDATE_SAVED"),
                     boost::io::str(FlexibleFormat(UserString("DESIGN_WND_UPDATE_DETAIL_SAVED"))
                                    % (*replaced_saved_design)->Name()
@@ -4097,7 +4097,7 @@ void DesignWnd::MainPanel::DesignChanged() {
     if (producible && replaced_current_design) {
         if (!existing_design_name) {
             // A current design can be replaced if it doesn't duplicate an existing design
-            m_replace_button->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+            m_replace_button->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
                 UserString("DESIGN_WND_UPDATE_FINISHED"),
                 boost::io::str(FlexibleFormat(UserString("DESIGN_WND_UPDATE_DETAIL_FINISHED"))
                                % (*replaced_current_design)->Name()
@@ -4105,7 +4105,7 @@ void DesignWnd::MainPanel::DesignChanged() {
             m_replace_button->Disable(false);
         } else {
             // Otherwise mark it as known.
-            m_replace_button->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+            m_replace_button->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
                 UserString("DESIGN_KNOWN"),
                 boost::io::str(FlexibleFormat(UserString("DESIGN_KNOWN_DETAIL"))
                                % *existing_design_name)));
@@ -4119,7 +4119,7 @@ void DesignWnd::MainPanel::DesignChanged() {
         // A new saved design can always be created
         m_confirm_button->SetText(UserString("DESIGN_WND_ADD_SAVED"));
         m_confirm_button->SetBrowseInfoWnd(
-            std::make_shared<TextBrowseWnd>(
+            GG::Wnd::Create<TextBrowseWnd>(
                 UserString("DESIGN_WND_ADD_SAVED"),
                 boost::io::str(FlexibleFormat(UserString("DESIGN_WND_ADD_DETAIL_SAVED"))
                                % new_design_name)));
@@ -4127,7 +4127,7 @@ void DesignWnd::MainPanel::DesignChanged() {
     } else if (producible) {
         if (!existing_design_name) {
             // A new current can be added if it does not duplicate an existing design.
-            m_confirm_button->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+            m_confirm_button->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
                 UserString("DESIGN_WND_ADD_FINISHED"),
                 boost::io::str(FlexibleFormat(UserString("DESIGN_WND_ADD_DETAIL_FINISHED"))
                                % new_design_name)));
@@ -4135,7 +4135,7 @@ void DesignWnd::MainPanel::DesignChanged() {
 
         } else {
             // Otherwise the design is already known.
-            m_confirm_button->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+            m_confirm_button->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
                 UserString("DESIGN_KNOWN"),
                 boost::io::str(FlexibleFormat(UserString("DESIGN_KNOWN_DETAIL"))
                                % *existing_design_name)));

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -807,7 +807,7 @@ void PartControl::CompleteConstruction()
 
     //DebugLogger() << "PartControl::PartControl part name: " << m_part->Name();
     SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
-    SetBrowseInfoWnd(std::make_shared<IconTextBrowseWnd>(
+    SetBrowseInfoWnd(GG::Wnd::Create<IconTextBrowseWnd>(
         ClientUI::PartIcon(m_part->Name()),
         UserString(m_part->Name()),
         UserString(m_part->Description()) + "\n" + m_part->CapacityDescription()
@@ -3037,7 +3037,7 @@ void SlotControl::CompleteConstruction()
     else if (m_slot_type == SL_CORE)
         title_text = UserString("SL_CORE");
 
-    SetBrowseInfoWnd(std::make_shared<IconTextBrowseWnd>(
+    SetBrowseInfoWnd(GG::Wnd::Create<IconTextBrowseWnd>(
         SlotBackgroundTexture(m_slot_type),
         title_text,
         UserString("SL_TOOLTIP_DESC")
@@ -3232,7 +3232,7 @@ void SlotControl::SetPart(const PartType* part_type) {
         else if (m_slot_type == SL_CORE)
             title_text = UserString("SL_CORE");
 
-        m_part_control->SetBrowseInfoWnd(std::make_shared<IconTextBrowseWnd>(
+        m_part_control->SetBrowseInfoWnd(GG::Wnd::Create<IconTextBrowseWnd>(
             ClientUI::PartIcon(part_type->Name()),
             UserString(part_type->Name()) + " (" + title_text + ")",
             UserString(part_type->Description())

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -1374,24 +1374,24 @@ void DesignWnd::PartPalette::CompleteConstruction()
         if (!part_of_this_class_exists)
             continue;
 
-        m_class_buttons[part_class] = new CUIStateButton(UserString(boost::lexical_cast<std::string>(part_class)), GG::FORMAT_CENTER, std::make_shared<CUILabelButtonRepresenter>());
+        m_class_buttons[part_class] = GG::Wnd::Create<CUIStateButton>(UserString(boost::lexical_cast<std::string>(part_class)), GG::FORMAT_CENTER, std::make_shared<CUILabelButtonRepresenter>());
         AttachChild(m_class_buttons[part_class]);
         m_class_buttons[part_class]->CheckedSignal.connect(
             boost::bind(&DesignWnd::PartPalette::ToggleClass, this, part_class, true));
     }
 
     // availability buttons
-    m_availability_buttons.first = new CUIStateButton(UserString("PRODUCTION_WND_AVAILABILITY_AVAILABLE"), GG::FORMAT_CENTER, std::make_shared<CUILabelButtonRepresenter>());
+    m_availability_buttons.first = GG::Wnd::Create<CUIStateButton>(UserString("PRODUCTION_WND_AVAILABILITY_AVAILABLE"), GG::FORMAT_CENTER, std::make_shared<CUILabelButtonRepresenter>());
     AttachChild(m_availability_buttons.first);
     m_availability_buttons.first->CheckedSignal.connect(
         boost::bind(&DesignWnd::PartPalette::ToggleAvailability, this, true, true));
-    m_availability_buttons.second = new CUIStateButton(UserString("PRODUCTION_WND_AVAILABILITY_UNAVAILABLE"), GG::FORMAT_CENTER, std::make_shared<CUILabelButtonRepresenter>());
+    m_availability_buttons.second = GG::Wnd::Create<CUIStateButton>(UserString("PRODUCTION_WND_AVAILABILITY_UNAVAILABLE"), GG::FORMAT_CENTER, std::make_shared<CUILabelButtonRepresenter>());
     AttachChild(m_availability_buttons.second);
     m_availability_buttons.second->CheckedSignal.connect(
         boost::bind(&DesignWnd::PartPalette::ToggleAvailability, this, false, true));
 
     // superfluous parts button
-    m_superfluous_parts_button = new CUIStateButton(UserString("PRODUCTION_WND_REDUNDANT"), GG::FORMAT_CENTER, std::make_shared<CUILabelButtonRepresenter>());
+    m_superfluous_parts_button = GG::Wnd::Create<CUIStateButton>(UserString("PRODUCTION_WND_REDUNDANT"), GG::FORMAT_CENTER, std::make_shared<CUILabelButtonRepresenter>());
     AttachChild(m_superfluous_parts_button);
     m_superfluous_parts_button->CheckedSignal.connect(
         boost::bind(&DesignWnd::PartPalette::ToggleSuperfluous, this, true));
@@ -2734,21 +2734,21 @@ DesignWnd::BaseSelector::BaseSelector(const std::string& config_name) :
 void DesignWnd::BaseSelector::CompleteConstruction()
 {
     auto& m_obsolete_button = std::get<Availability::Obsolete>(m_availabilities_buttons);
-    m_obsolete_button = new CUIStateButton(UserString("PRODUCTION_WND_AVAILABILITY_OBSOLETE"), GG::FORMAT_CENTER, std::make_shared<CUILabelButtonRepresenter>());
+    m_obsolete_button = GG::Wnd::Create<CUIStateButton>(UserString("PRODUCTION_WND_AVAILABILITY_OBSOLETE"), GG::FORMAT_CENTER, std::make_shared<CUILabelButtonRepresenter>());
     AttachChild(m_obsolete_button);
     m_obsolete_button->CheckedSignal.connect(
         boost::bind(&DesignWnd::BaseSelector::ToggleAvailability, this, Availability::Obsolete));
     m_obsolete_button->SetCheck(m_availabilities_state.GetAvailability(Availability::Obsolete));
 
     auto& m_available_button = std::get<Availability::Available>(m_availabilities_buttons);
-    m_available_button = new CUIStateButton(UserString("PRODUCTION_WND_AVAILABILITY_AVAILABLE"), GG::FORMAT_CENTER, std::make_shared<CUILabelButtonRepresenter>());
+    m_available_button = GG::Wnd::Create<CUIStateButton>(UserString("PRODUCTION_WND_AVAILABILITY_AVAILABLE"), GG::FORMAT_CENTER, std::make_shared<CUILabelButtonRepresenter>());
     AttachChild(m_available_button);
     m_available_button->CheckedSignal.connect(
         boost::bind(&DesignWnd::BaseSelector::ToggleAvailability, this, Availability::Available));
     m_available_button->SetCheck(m_availabilities_state.GetAvailability(Availability::Available));
 
     auto& m_unavailable_button = std::get<Availability::Future>(m_availabilities_buttons);
-    m_unavailable_button = new CUIStateButton(UserString("PRODUCTION_WND_AVAILABILITY_UNAVAILABLE"), GG::FORMAT_CENTER, std::make_shared<CUILabelButtonRepresenter>());
+    m_unavailable_button = GG::Wnd::Create<CUIStateButton>(UserString("PRODUCTION_WND_AVAILABILITY_UNAVAILABLE"), GG::FORMAT_CENTER, std::make_shared<CUILabelButtonRepresenter>());
     AttachChild(m_unavailable_button);
     m_unavailable_button->CheckedSignal.connect(
         boost::bind(&DesignWnd::BaseSelector::ToggleAvailability, this, Availability::Future));

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -2754,7 +2754,7 @@ void DesignWnd::BaseSelector::CompleteConstruction()
         boost::bind(&DesignWnd::BaseSelector::ToggleAvailability, this, Availability::Future));
     m_unavailable_button->SetCheck(m_availabilities_state.GetAvailability(Availability::Future));
 
-    m_tabs = new GG::TabWnd(GG::X(5), GG::Y(2), GG::X(10), GG::Y(10), ClientUI::GetFont(), ClientUI::WndColor(), ClientUI::TextColor());
+    m_tabs = GG::Wnd::Create<GG::TabWnd>(GG::X(5), GG::Y(2), GG::X(10), GG::Y(10), ClientUI::GetFont(), ClientUI::WndColor(), ClientUI::TextColor());
     m_tabs->TabChangedSignal.connect(
         boost::bind(&DesignWnd::BaseSelector::Reset, this));
     AttachChild(m_tabs);

--- a/UI/DesignWnd.h
+++ b/UI/DesignWnd.h
@@ -57,6 +57,7 @@ public:
     /** \name Structors */ //@{
     DesignWnd(GG::X w, GG::Y h);
     //@}
+    void CompleteConstruction() override;
 
     /** \name Mutators */ //@{
     void SizeMove(const GG::Pt& ul, const GG::Pt& lr) override;

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -570,17 +570,17 @@ EncyclopediaDetailPanel::EncyclopediaDetailPanel(GG::Flags<GG::WndFlag> flags, c
 
     boost::filesystem::path button_texture_dir = ClientUI::ArtDir() / "icons" / "buttons";
 
-    m_index_button = new CUIButton(
+    m_index_button = Wnd::Create<CUIButton>(
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "uparrownormal.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "uparrowclicked.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "uparrowmouseover.png")));
 
-    m_back_button = new CUIButton(
+    m_back_button = Wnd::Create<CUIButton>(
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "leftarrownormal.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "leftarrowclicked.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "leftarrowmouseover.png")));
 
-    m_next_button = new CUIButton(
+    m_next_button = Wnd::Create<CUIButton>(
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "rightarrownormal.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "rightarrowclicked.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "rightarrowmouseover.png")));

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -557,6 +557,12 @@ EncyclopediaDetailPanel::EncyclopediaDetailPanel(GG::Flags<GG::WndFlag> flags, c
     m_graph(nullptr),
     m_needs_refresh(false)
 {
+}
+
+void EncyclopediaDetailPanel::CompleteConstruction()
+{
+    CUIWnd::CompleteConstruction();
+
     const int PTS = ClientUI::Pts();
     const int NAME_PTS = PTS*3/2;
     const int SUMMARY_PTS = PTS*4/3;
@@ -599,7 +605,7 @@ EncyclopediaDetailPanel::EncyclopediaDetailPanel(GG::Flags<GG::WndFlag> flags, c
                                                ClientUI::GetFont(), ClientUI::TextColor(),
                                                GG::FORMAT_TOP | GG::FORMAT_LEFT | GG::FORMAT_LINEWRAP | GG::FORMAT_WORDBREAK,
                                                GG::INTERACTIVE);
-    m_scroll_panel = new GG::ScrollPanel(GG::X(0), GG::Y(0), ClientWidth(), ClientHeight(), m_description_rich_text);
+    m_scroll_panel = GG::Wnd::Create<GG::ScrollPanel>(GG::X(0), GG::Y(0), ClientWidth(), ClientHeight(), m_description_rich_text);
 
     // Copy default block factory.
     std::shared_ptr<GG::RichText::BLOCK_FACTORY_MAP> factory_map(new GG::RichText::BLOCK_FACTORY_MAP(*GG::RichText::DefaultBlockFactoryMap()));

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -559,8 +559,7 @@ EncyclopediaDetailPanel::EncyclopediaDetailPanel(GG::Flags<GG::WndFlag> flags, c
 {
 }
 
-void EncyclopediaDetailPanel::CompleteConstruction()
-{
+void EncyclopediaDetailPanel::CompleteConstruction() {
     CUIWnd::CompleteConstruction();
 
     const int PTS = ClientUI::Pts();

--- a/UI/EncyclopediaDetailPanel.h
+++ b/UI/EncyclopediaDetailPanel.h
@@ -32,6 +32,7 @@ public:
     EncyclopediaDetailPanel(GG::Flags<GG::WndFlag> flags = GG::ONTOP | GG::INTERACTIVE | GG::DRAGABLE |
                                                            GG::RESIZABLE | CLOSABLE | PINABLE,
                             const std::string& config_name = "");
+    void CompleteConstruction() override;
     virtual ~EncyclopediaDetailPanel();
     //!@}
 

--- a/UI/FleetButton.cpp
+++ b/UI/FleetButton.cpp
@@ -225,7 +225,7 @@ FleetButton::FleetButton(const std::vector<int>& fleet_IDs, SizeType size_type) 
 
     // Create scanline renderer control, use opposite color of fleet btn
     GG::Clr opposite_clr(255 - Color().r, 255 - Color().g, 255 - Color().b, 64);
-    m_scanline_control = new ScanlineControl(GG::X0, GG::Y0, Width(), Height(), false, opposite_clr);
+    m_scanline_control = GG::Wnd::Create<ScanlineControl>(GG::X0, GG::Y0, Width(), Height(), false, opposite_clr);
 
 }
 

--- a/UI/FleetButton.cpp
+++ b/UI/FleetButton.cpp
@@ -229,8 +229,7 @@ FleetButton::FleetButton(const std::vector<int>& fleet_IDs, SizeType size_type) 
 
 }
 
-void FleetButton::CompleteConstruction()
-{
+void FleetButton::CompleteConstruction() {
     Button::CompleteConstruction();
 
     for (auto& icon: m_icons) {

--- a/UI/FleetButton.cpp
+++ b/UI/FleetButton.cpp
@@ -226,7 +226,6 @@ FleetButton::FleetButton(const std::vector<int>& fleet_IDs, SizeType size_type) 
     // Create scanline renderer control, use opposite color of fleet btn
     GG::Clr opposite_clr(255 - Color().r, 255 - Color().g, 255 - Color().b, 64);
     m_scanline_control = GG::Wnd::Create<ScanlineControl>(GG::X0, GG::Y0, Width(), Height(), false, opposite_clr);
-
 }
 
 void FleetButton::CompleteConstruction() {
@@ -254,7 +253,6 @@ void FleetButton::CompleteConstruction() {
 
     SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
 }
-
 
 FleetButton::~FleetButton() {
     for (auto& icon : m_icons) {

--- a/UI/FleetButton.h
+++ b/UI/FleetButton.h
@@ -26,6 +26,7 @@ public:
     /** \name Structors */ //@{
     FleetButton(const std::vector<int>& fleet_IDs, SizeType size_type = FLEET_BUTTON_LARGE);
     FleetButton(int fleet_id, SizeType size_type = FLEET_BUTTON_LARGE);
+    void CompleteConstruction() override;
     virtual ~FleetButton();
     //@}
 

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -1666,7 +1666,7 @@ void FleetDataPanel::Init() {
     AttachChild(m_fleet_destination_text);
 
     if (m_fleet_id == INVALID_OBJECT_ID) {
-        m_aggression_toggle = new CUIButton(
+        m_aggression_toggle = Wnd::Create<CUIButton>(
             GG::SubTexture(FleetAggressiveIcon()),
             GG::SubTexture(FleetPassiveIcon()),
             GG::SubTexture(FleetAggressiveMouseoverIcon()));
@@ -1706,7 +1706,7 @@ void FleetDataPanel::Init() {
 
         int client_empire_id = HumanClientApp::GetApp()->EmpireID();
         if (fleet->OwnedBy(client_empire_id) || fleet->GetVisibility(client_empire_id) >= VIS_FULL_VISIBILITY) {
-            m_aggression_toggle = new CUIButton(
+            m_aggression_toggle = Wnd::Create<CUIButton>(
                 GG::SubTexture(FleetAggressiveIcon()),
                 GG::SubTexture(FleetPassiveIcon()),
                 GG::SubTexture(FleetAggressiveMouseoverIcon()));

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -2330,6 +2330,7 @@ class FleetDetailPanel : public GG::Wnd {
 public:
     FleetDetailPanel(GG::X w, GG::Y h, int fleet_id, bool order_issuing_enabled, GG::Flags<GG::WndFlag> flags = GG::NO_WND_FLAGS);
 
+    void CompleteConstruction() override;
     void SizeMove(const GG::Pt& ul, const GG::Pt& lr) override;
 
     int             FleetID() const;
@@ -2367,11 +2368,12 @@ FleetDetailPanel::FleetDetailPanel(GG::X w, GG::Y h, int fleet_id, bool order_is
     m_order_issuing_enabled(order_issuing_enabled),
     m_ships_lb(nullptr)
 {
+    GG::Wnd::CompleteConstruction();
+
     SetName("FleetDetailPanel");
     SetChildClippingMode(ClipToClient);
 
     m_ships_lb = GG::Wnd::Create<ShipsListBox>(INVALID_OBJECT_ID, order_issuing_enabled);
-    AttachChild(m_ships_lb);
     m_ships_lb->SetHiliteColor(GG::CLR_ZERO);
 
     SetFleet(fleet_id);
@@ -2389,7 +2391,11 @@ FleetDetailPanel::FleetDetailPanel(GG::X w, GG::Y h, int fleet_id, bool order_is
         boost::bind(&FleetDetailPanel::ShipRightClicked, this, _1, _2, _3));
     GetUniverse().UniverseObjectDeleteSignal.connect(
         boost::bind(&FleetDetailPanel::UniverseObjectDeleted, this, _1));
+}
 
+void FleetDetailPanel::CompleteConstruction()
+{
+    AttachChild(m_ships_lb);
     DoLayout();
 }
 

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -2559,7 +2559,7 @@ void FleetDetailPanel::ShipRightClicked(GG::ListBox::iterator it, const GG::Pt& 
     if (ship->OwnedBy(client_empire_id) || ClientPlayerIsModerator()) {
         auto rename_action = [ship, client_empire_id]() {
             std::string ship_name = ship->Name();
-            std::shared_ptr<CUIEditWnd> edit_wnd(GG::Wnd::Create<CUIEditWnd>(GG::X(350), UserString("ENTER_NEW_NAME"), ship_name));
+            std::shared_ptr<CUIEditWnd> edit_wnd(GG::Wnd::Create<CUIEditWnd>(GG::X(350), UserString("ENTER_NEW_NAME"), ship_name)); // TODO change the shared_ptr to auto after conversion of Wnd::Create
             edit_wnd->Run();
 
             std::string new_name = edit_wnd->Result();
@@ -3409,7 +3409,7 @@ void FleetWnd::FleetRightClicked(GG::ListBox::iterator it, const GG::Pt& pt, con
     {
         auto rename_action = [fleet, client_empire_id]() {
             std::string fleet_name = fleet->Name();
-            std::shared_ptr<CUIEditWnd> edit_wnd(GG::Wnd::Create<CUIEditWnd>(GG::X(350), UserString("ENTER_NEW_NAME"), fleet_name));
+            std::shared_ptr<CUIEditWnd> edit_wnd(GG::Wnd::Create<CUIEditWnd>(GG::X(350), UserString("ENTER_NEW_NAME"), fleet_name)); // TODO change the shared_ptr to auto after conversion of Wnd::Create
             edit_wnd->Run();
 
             std::string new_name = edit_wnd->Result();

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -870,28 +870,28 @@ void ShipDataPanel::Refresh() {
 
         entry.second->ClearBrowseInfoWnd();
         if (entry.first == METER_CAPACITY) {  // refers to damage
-            entry.second->SetBrowseInfoWnd(std::make_shared<ShipDamageBrowseWnd>(
+            entry.second->SetBrowseInfoWnd(GG::Wnd::Create<ShipDamageBrowseWnd>(
                 m_ship_id, entry.first));
 
         } else if (entry.first == METER_TROOPS) {
-            entry.second->SetBrowseInfoWnd(std::make_shared<IconTextBrowseWnd>(
+            entry.second->SetBrowseInfoWnd(GG::Wnd::Create<IconTextBrowseWnd>(
                 TroopIcon(), UserString("SHIP_TROOPS_TITLE"),
                 UserString("SHIP_TROOPS_STAT")));
 
         } else if (entry.first == METER_SECONDARY_STAT) {
-            entry.second->SetBrowseInfoWnd(std::make_shared<ShipFightersBrowseWnd>(
+            entry.second->SetBrowseInfoWnd(GG::Wnd::Create<ShipFightersBrowseWnd>(
                 m_ship_id, entry.first));
             entry.second->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip.extended-delay"), 1);
-            entry.second->SetBrowseInfoWnd(std::make_shared<ShipFightersBrowseWnd>(
+            entry.second->SetBrowseInfoWnd(GG::Wnd::Create<ShipFightersBrowseWnd>(
                 m_ship_id, entry.first, true), 1);
 
         } else if (entry.first == METER_POPULATION) {
-            entry.second->SetBrowseInfoWnd(std::make_shared<IconTextBrowseWnd>(
+            entry.second->SetBrowseInfoWnd(GG::Wnd::Create<IconTextBrowseWnd>(
                 ColonyIcon(), UserString("SHIP_COLONY_TITLE"),
                 UserString("SHIP_COLONY_STAT")));
 
         } else {
-            entry.second->SetBrowseInfoWnd(std::make_shared<MeterBrowseWnd>(
+            entry.second->SetBrowseInfoWnd(GG::Wnd::Create<MeterBrowseWnd>(
                 m_ship_id, entry.first, AssociatedMeterType(entry.first)));
         }
     }
@@ -1600,7 +1600,7 @@ void FleetDataPanel::UpdateAggressionToggle() {
         m_aggression_toggle->SetUnpressedGraphic(GG::SubTexture(FleetAggressiveIcon()));
         m_aggression_toggle->SetPressedGraphic  (GG::SubTexture(FleetPassiveIcon()));
         m_aggression_toggle->SetRolloverGraphic (GG::SubTexture(FleetAggressiveMouseoverIcon()));
-        m_aggression_toggle->SetBrowseInfoWnd(std::make_shared<IconTextBrowseWnd>(
+        m_aggression_toggle->SetBrowseInfoWnd(GG::Wnd::Create<IconTextBrowseWnd>(
             FleetAggressiveIcon(), UserString("FW_AGGRESSIVE"), UserString("FW_AGGRESSIVE_DESC")));
     } else if (aggression == FLEET_PASSIVE) {
         m_aggression_toggle->SetUnpressedGraphic(GG::SubTexture(FleetPassiveIcon()));
@@ -1609,13 +1609,13 @@ void FleetDataPanel::UpdateAggressionToggle() {
         else
             m_aggression_toggle->SetPressedGraphic  (GG::SubTexture(FleetAggressiveIcon()));
         m_aggression_toggle->SetRolloverGraphic (GG::SubTexture(FleetPassiveMouseoverIcon()));
-        m_aggression_toggle->SetBrowseInfoWnd(std::make_shared<IconTextBrowseWnd>(
+        m_aggression_toggle->SetBrowseInfoWnd(GG::Wnd::Create<IconTextBrowseWnd>(
             FleetPassiveIcon(), UserString("FW_PASSIVE"), UserString("FW_PASSIVE_DESC")));
     } else {    // aggression == INVALID_FLEET_AGGRESSION
         m_aggression_toggle->SetUnpressedGraphic(GG::SubTexture(FleetAutoIcon()));
         m_aggression_toggle->SetPressedGraphic  (GG::SubTexture(FleetAggressiveIcon()));
         m_aggression_toggle->SetRolloverGraphic (GG::SubTexture(FleetAutoMouseoverIcon()));
-        m_aggression_toggle->SetBrowseInfoWnd(std::make_shared<IconTextBrowseWnd>(
+        m_aggression_toggle->SetBrowseInfoWnd(GG::Wnd::Create<IconTextBrowseWnd>(
             FleetPassiveIcon(), UserString("FW_AUTO"), UserString("FW_AUTO_DESC")));
     }
 }

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -641,8 +641,7 @@ namespace {
                 SetDragDropDataType(SHIP_DROP_TYPE_STRING);
         }
 
-        void CompleteConstruction() override
-        {
+        void CompleteConstruction() override {
             GG::ListBox::Row::CompleteConstruction();
 
             m_panel = GG::Wnd::Create<ShipDataPanel>(Width(), Height(), m_ship_id);
@@ -1752,8 +1751,7 @@ namespace {
             SetChildClippingMode(ClipToClient);
         }
 
-        void CompleteConstruction() override
-        {
+        void CompleteConstruction() override {
             GG::ListBox::Row::CompleteConstruction();
 
             m_panel = GG::Wnd::Create<FleetDataPanel>(Width(), Height(), m_fleet_id);

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -639,11 +639,14 @@ namespace {
             SetChildClippingMode(ClipToClient);
             if (GetShip(m_ship_id))
                 SetDragDropDataType(SHIP_DROP_TYPE_STRING);
-            {
-                //ScopedTimer timer("ShipRow Panel creation / pushing");
-                m_panel = GG::Wnd::Create<ShipDataPanel>(w, h, m_ship_id);
-                push_back(m_panel);
-            }
+        }
+
+        void CompleteConstruction() override
+        {
+            GG::ListBox::Row::CompleteConstruction();
+
+            m_panel = GG::Wnd::Create<ShipDataPanel>(Width(), Height(), m_ship_id);
+            push_back(m_panel);
         }
 
         void SizeMove(const GG::Pt& ul, const GG::Pt& lr) override {
@@ -1747,7 +1750,13 @@ namespace {
         {
             SetName("FleetRow");
             SetChildClippingMode(ClipToClient);
-            m_panel = GG::Wnd::Create<FleetDataPanel>(w, h, m_fleet_id);
+        }
+
+        void CompleteConstruction() override
+        {
+            GG::ListBox::Row::CompleteConstruction();
+
+            m_panel = GG::Wnd::Create<FleetDataPanel>(Width(), Height(), m_fleet_id);
             push_back(m_panel);
         }
 

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -2689,7 +2689,6 @@ FleetWnd::FleetWnd(const std::vector<int>& fleet_ids, bool order_issuing_enabled
         ErrorLogger() << "FleetWnd::FleetWnd couldn't find requested selected fleet with id " << selected_fleet_id;
         selected_fleet_id = INVALID_OBJECT_ID;
     }
-
 }
 
 void FleetWnd::CompleteConstruction()

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -2393,8 +2393,7 @@ FleetDetailPanel::FleetDetailPanel(GG::X w, GG::Y h, int fleet_id, bool order_is
         boost::bind(&FleetDetailPanel::UniverseObjectDeleted, this, _1));
 }
 
-void FleetDetailPanel::CompleteConstruction()
-{
+void FleetDetailPanel::CompleteConstruction() {
     AttachChild(m_ships_lb);
     DoLayout();
 }
@@ -2691,8 +2690,7 @@ FleetWnd::FleetWnd(const std::vector<int>& fleet_ids, bool order_issuing_enabled
     }
 }
 
-void FleetWnd::CompleteConstruction()
-{
+void FleetWnd::CompleteConstruction() {
     Sound::TempUISoundDisabler sound_disabler;
 
     // add fleet aggregate stat icons

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -2547,10 +2547,10 @@ void FleetDetailPanel::ShipRightClicked(GG::ListBox::iterator it, const GG::Pt& 
     if (ship->OwnedBy(client_empire_id) || ClientPlayerIsModerator()) {
         auto rename_action = [ship, client_empire_id]() {
             std::string ship_name = ship->Name();
-            CUIEditWnd edit_wnd(GG::X(350), UserString("ENTER_NEW_NAME"), ship_name);
-            edit_wnd.Run();
+            std::shared_ptr<CUIEditWnd> edit_wnd(GG::Wnd::Create<CUIEditWnd>(GG::X(350), UserString("ENTER_NEW_NAME"), ship_name));
+            edit_wnd->Run();
 
-            std::string new_name = edit_wnd.Result();
+            std::string new_name = edit_wnd->Result();
 
             if (!ClientPlayerIsModerator()) {
                 if (new_name != "" && new_name != ship_name) {
@@ -2666,6 +2666,19 @@ FleetWnd::FleetWnd(const std::vector<int>& fleet_ids, bool order_issuing_enabled
     for (int fleet_id : fleet_ids)
         m_fleet_ids.insert(fleet_id);
 
+    // verify that the selected fleet id is valid.
+    // TODO this appears to do nothing with selected_fleet_id after the verification.
+    if (selected_fleet_id != INVALID_OBJECT_ID &&
+        m_fleet_ids.find(selected_fleet_id) == m_fleet_ids.end())
+    {
+        ErrorLogger() << "FleetWnd::FleetWnd couldn't find requested selected fleet with id " << selected_fleet_id;
+        selected_fleet_id = INVALID_OBJECT_ID;
+    }
+
+}
+
+void FleetWnd::CompleteConstruction()
+{
     Sound::TempUISoundDisabler sound_disabler;
 
     // add fleet aggregate stat icons
@@ -2726,15 +2739,9 @@ FleetWnd::FleetWnd(const std::vector<int>& fleet_ids, bool order_issuing_enabled
 
     RefreshStateChangedSignals();
 
-    // verify that the selected fleet id is valid.
-    if (selected_fleet_id != INVALID_OBJECT_ID &&
-        m_fleet_ids.find(selected_fleet_id) == m_fleet_ids.end())
-    {
-        ErrorLogger() << "FleetWnd::FleetWnd couldn't find requested selected fleet with id " << selected_fleet_id;
-        selected_fleet_id = INVALID_OBJECT_ID;
-    }
-
     ResetDefaultPosition();
+    MapWndPopup::CompleteConstruction();
+
     SetMinSize(GG::Pt(CUIWnd::MinimizedSize().x, TopBorder() + INNER_BORDER_ANGLE_OFFSET + BORDER_BOTTOM +
                                                  ListRowHeight() + 2*GG::Y(PAD)));
     DoLayout();
@@ -3392,10 +3399,10 @@ void FleetWnd::FleetRightClicked(GG::ListBox::iterator it, const GG::Pt& pt, con
     {
         auto rename_action = [fleet, client_empire_id]() {
             std::string fleet_name = fleet->Name();
-            CUIEditWnd edit_wnd(GG::X(350), UserString("ENTER_NEW_NAME"), fleet_name);
-            edit_wnd.Run();
+            std::shared_ptr<CUIEditWnd> edit_wnd(GG::Wnd::Create<CUIEditWnd>(GG::X(350), UserString("ENTER_NEW_NAME"), fleet_name));
+            edit_wnd->Run();
 
-            std::string new_name = edit_wnd.Result();
+            std::string new_name = edit_wnd->Result();
 
             if (ClientPlayerIsModerator())
                 return; // todo: handle moderator actions for this...

--- a/UI/FleetWnd.h
+++ b/UI/FleetWnd.h
@@ -97,6 +97,7 @@ public:
 
     ~FleetWnd();
     //@}
+    void CompleteConstruction() override;
 
     //! \name Accessors //@{
     int                     SystemID() const;                   ///< returns ID of system whose fleets are shown in this FleetWnd, which may be INVALID_OBJECT_ID if this FleetWnd isn't set to show fleets of a system

--- a/UI/GalaxySetupWnd.cpp
+++ b/UI/GalaxySetupWnd.cpp
@@ -81,21 +81,21 @@ namespace {
         RuleListRow(GG::X w, GG::Y h, RowContentsWnd* contents) :
             GG::ListBox::Row(w, h, ""),
             m_contents(contents)
-        {
-            SetChildClippingMode(ClipToClient);
-            if (m_contents)
-                push_back(m_contents);
-        }
+        {}
 
         RuleListRow(GG::X w, GG::Y h, Wnd* contents, int indentation = 0) :
             GG::ListBox::Row(w, h, ""),
             m_contents(nullptr)
         {
-            SetChildClippingMode(ClipToClient);
-            if (contents) {
+            if (contents)
                 m_contents = GG::Wnd::Create<RowContentsWnd>(w, h, contents, indentation);
+        }
+
+        void CompleteConstruction() override {
+            GG::ListBox::Row::CompleteConstruction();
+            SetChildClippingMode(ClipToClient);
+            if (m_contents)
                 push_back(m_contents);
-            }
         }
 
         void SizeMove(const GG::Pt& ul, const GG::Pt& lr) override {
@@ -404,7 +404,11 @@ namespace {
             GG::ListBox::Row(w, h, "", GG::ALIGN_VCENTER, 0)
         {
             GG::Wnd::SetName(key);
-            auto species_label = GG::Wnd::Create<CUILabel>(UserString(key), GG::FORMAT_LEFT | GG::FORMAT_VCENTER);
+        }
+
+        void CompleteConstruction() override {
+            GG::ListBox::Row::CompleteConstruction();
+            auto species_label = GG::Wnd::Create<CUILabel>(UserString(Name()), GG::FORMAT_LEFT | GG::FORMAT_VCENTER);
             push_back(species_label);
         }
     };

--- a/UI/GalaxySetupWnd.cpp
+++ b/UI/GalaxySetupWnd.cpp
@@ -531,7 +531,12 @@ const GG::X GalaxySetupPanel::DefaultWidth() {
 
 GalaxySetupPanel::GalaxySetupPanel(GG::X w, GG::Y h) :
     GG::Control(GG::X0, GG::Y0, w, h, GG::NO_WND_FLAGS)
+{}
+
+void GalaxySetupPanel::CompleteConstruction()
 {
+    GG::Control::CompleteConstruction();
+
     Sound::TempUISoundDisabler sound_disabler;
 
     // seed

--- a/UI/GalaxySetupWnd.cpp
+++ b/UI/GalaxySetupWnd.cpp
@@ -44,8 +44,15 @@ namespace {
         {
             if (!m_contents)
                 return;
-            AttachChild(m_contents);
             m_contents->MoveTo(GG::Pt(GG::X(indentation_level * INDENTATION), GG::Y0));
+        }
+
+        void CompleteConstruction() override {
+            GG::Control::CompleteConstruction();
+
+            if (!m_contents)
+                return;
+            AttachChild(m_contents);
             DoLayout();
         }
 

--- a/UI/GalaxySetupWnd.cpp
+++ b/UI/GalaxySetupWnd.cpp
@@ -543,7 +543,7 @@ GalaxySetupPanel::GalaxySetupPanel(GG::X w, GG::Y h) :
     boost::filesystem::path button_texture_dir = ClientUI::ArtDir() / "icons" / "buttons";
 
     // random seed button
-    m_random = new CUIButton(
+    m_random = Wnd::Create<CUIButton>(
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "randomize.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "randomize_clicked.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "randomize_mouseover.png")));
@@ -1004,8 +1004,8 @@ GalaxySetupWnd::GalaxySetupWnd() :
     static auto temp_tex = std::make_shared<GG::Texture>();
     m_preview_image =  GG::Wnd::Create<GG::StaticGraphic>(temp_tex, GG::GRAPHIC_FITGRAPHIC | GG::GRAPHIC_PROPSCALE); // create a blank graphic
 
-    m_ok = new CUIButton(UserString("OK"));
-    m_cancel = new CUIButton(UserString("CANCEL"));
+    m_ok = Wnd::Create<CUIButton>(UserString("OK"));
+    m_cancel = Wnd::Create<CUIButton>(UserString("CANCEL"));
 
     AttachChild(m_galaxy_setup_panel);
     AttachChild(m_game_rules_panel);

--- a/UI/GalaxySetupWnd.cpp
+++ b/UI/GalaxySetupWnd.cpp
@@ -937,6 +937,9 @@ void GalaxySetupPanel::ShapeChanged(GG::DropDownList::iterator it)
 ////////////////////////////////////////////////
 GalaxySetupWnd::GalaxySetupWnd() :
     CUIWnd(UserString("GSETUP_WINDOW_TITLE"), GG::INTERACTIVE | GG::MODAL)
+{}
+
+void GalaxySetupWnd::CompleteConstruction()
 {
     Sound::TempUISoundDisabler sound_disabler;
 
@@ -1038,6 +1041,8 @@ GalaxySetupWnd::GalaxySetupWnd() :
         boost::bind(&GalaxySetupWnd::CancelClicked, this));
 
     PreviewImageChanged(m_galaxy_setup_panel->PreviewImage());
+
+    CUIWnd::CompleteConstruction();
 }
 
 const std::string& GalaxySetupWnd::EmpireName() const

--- a/UI/GalaxySetupWnd.cpp
+++ b/UI/GalaxySetupWnd.cpp
@@ -544,8 +544,7 @@ GalaxySetupPanel::GalaxySetupPanel(GG::X w, GG::Y h) :
     GG::Control(GG::X0, GG::Y0, w, h, GG::NO_WND_FLAGS)
 {}
 
-void GalaxySetupPanel::CompleteConstruction()
-{
+void GalaxySetupPanel::CompleteConstruction() {
     GG::Control::CompleteConstruction();
 
     Sound::TempUISoundDisabler sound_disabler;
@@ -955,8 +954,7 @@ GalaxySetupWnd::GalaxySetupWnd() :
     CUIWnd(UserString("GSETUP_WINDOW_TITLE"), GG::INTERACTIVE | GG::MODAL)
 {}
 
-void GalaxySetupWnd::CompleteConstruction()
-{
+void GalaxySetupWnd::CompleteConstruction() {
     Sound::TempUISoundDisabler sound_disabler;
 
     m_galaxy_setup_panel = GG::Wnd::Create<GalaxySetupPanel>();

--- a/UI/GalaxySetupWnd.h
+++ b/UI/GalaxySetupWnd.h
@@ -70,6 +70,8 @@ public:
     GalaxySetupPanel(GG::X w = GG::X(FontBasedUpscale(305)), GG::Y h = GG::Y(330));
     //!@}
 
+    void CompleteConstruction() override;
+
     /** \name Accessors*/ //!@{
     const std::string&              GetSeed() const;                //!< Returns string version of seed. This value is converted to a number or (if that fails) hashed to get the actual seed value.
     int                             Systems() const;                //!< Returns the number of star systems to use in generating the galaxy

--- a/UI/GalaxySetupWnd.h
+++ b/UI/GalaxySetupWnd.h
@@ -138,6 +138,7 @@ class GalaxySetupWnd : public CUIWnd {
 public:
     /** \name Structors*/ //!@{
     GalaxySetupWnd();
+    void CompleteConstruction() override;
     //!@}
 
     /** \name Accessors*/ //!@{

--- a/UI/InGameMenu.cpp
+++ b/UI/InGameMenu.cpp
@@ -27,7 +27,12 @@ namespace {
 InGameMenu::InGameMenu():
     CUIWnd(UserString("GAME_MENU_WINDOW_TITLE"),
            GG::INTERACTIVE | GG::MODAL)
+{}
+
+void InGameMenu::CompleteConstruction()
 {
+    CUIWnd::CompleteConstruction();
+
     m_save_btn = Wnd::Create<CUIButton>(UserString("GAME_MENU_SAVE"));
     m_load_btn = Wnd::Create<CUIButton>(UserString("GAME_MENU_LOAD"));
     m_options_btn = Wnd::Create<CUIButton>(UserString("INTRO_BTN_OPTIONS"));
@@ -160,9 +165,9 @@ void InGameMenu::Save() {
         // When saving in multiplayer, you cannot see the old saves or
         // browse directories, only give a save file name.
         DebugLogger() << "... running save file dialog";
-        SaveFileDialog dlg(app->SinglePlayerGame() ? SAVE_GAME_EXTENSION : MP_SAVE_FILE_EXTENSION);
-        dlg.Run();
-        filename = dlg.Result();
+        auto dlg = GG::Wnd::Create<SaveFileDialog>(app->SinglePlayerGame() ? SAVE_GAME_EXTENSION : MP_SAVE_FILE_EXTENSION);
+        dlg->Run();
+        filename = dlg->Result();
 
         if (!filename.empty()) {
             if (!app->CanSaveNow()) {
@@ -188,8 +193,8 @@ void InGameMenu::Load() {
 }
 
 void InGameMenu::Options() {
-    OptionsWnd options_wnd;
-    options_wnd.Run();
+    auto options_wnd = GG::Wnd::Create<OptionsWnd>();
+    options_wnd->Run();
 }
 
 void InGameMenu::Exit() {

--- a/UI/InGameMenu.cpp
+++ b/UI/InGameMenu.cpp
@@ -28,11 +28,11 @@ InGameMenu::InGameMenu():
     CUIWnd(UserString("GAME_MENU_WINDOW_TITLE"),
            GG::INTERACTIVE | GG::MODAL)
 {
-    m_save_btn = new CUIButton(UserString("GAME_MENU_SAVE"));
-    m_load_btn = new CUIButton(UserString("GAME_MENU_LOAD"));
-    m_options_btn = new CUIButton(UserString("INTRO_BTN_OPTIONS"));
-    m_exit_btn = new CUIButton(UserString("GAME_MENU_RESIGN"));
-    m_done_btn = new CUIButton(UserString("DONE"));
+    m_save_btn = Wnd::Create<CUIButton>(UserString("GAME_MENU_SAVE"));
+    m_load_btn = Wnd::Create<CUIButton>(UserString("GAME_MENU_LOAD"));
+    m_options_btn = Wnd::Create<CUIButton>(UserString("INTRO_BTN_OPTIONS"));
+    m_exit_btn = Wnd::Create<CUIButton>(UserString("GAME_MENU_RESIGN"));
+    m_done_btn = Wnd::Create<CUIButton>(UserString("DONE"));
 
     AttachChild(m_save_btn);
     AttachChild(m_load_btn);

--- a/UI/InGameMenu.cpp
+++ b/UI/InGameMenu.cpp
@@ -29,8 +29,7 @@ InGameMenu::InGameMenu():
            GG::INTERACTIVE | GG::MODAL)
 {}
 
-void InGameMenu::CompleteConstruction()
-{
+void InGameMenu::CompleteConstruction() {
     CUIWnd::CompleteConstruction();
 
     m_save_btn = Wnd::Create<CUIButton>(UserString("GAME_MENU_SAVE"));

--- a/UI/InGameMenu.cpp
+++ b/UI/InGameMenu.cpp
@@ -64,7 +64,7 @@ void InGameMenu::CompleteConstruction()
     if (!HumanClientApp::GetApp()->CanSaveNow()) {
         m_save_btn->Disable();
         m_save_btn->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
-        m_save_btn->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+        m_save_btn->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
             UserString("BUTTON_DISABLED"),
             UserString("SAVE_DISABLED_BROWSE_TEXT"),
             GG::X(400)

--- a/UI/InGameMenu.h
+++ b/UI/InGameMenu.h
@@ -7,6 +7,7 @@ class InGameMenu : public CUIWnd {
 public:
     /** \name Structors */ //@{
     InGameMenu();
+    void CompleteConstruction() override;
 
     ~InGameMenu();
     //@}

--- a/UI/IntroScreen.cpp
+++ b/UI/IntroScreen.cpp
@@ -242,8 +242,8 @@ IntroScreen::IntroScreen() :
     m_logo(nullptr),
     m_version(nullptr)
 {
-    m_menu = new CUIWnd(UserString("INTRO_WINDOW_TITLE"), GG::X1, GG::Y1,
-                        MAIN_MENU_WIDTH, MAIN_MENU_HEIGHT, GG::ONTOP | GG::INTERACTIVE);
+    m_menu = GG::Wnd::Create<CUIWnd>(UserString("INTRO_WINDOW_TITLE"), GG::X1, GG::Y1,
+                                  MAIN_MENU_WIDTH, MAIN_MENU_HEIGHT, GG::ONTOP | GG::INTERACTIVE);
 
     m_splash = GG::Wnd::Create<GG::StaticGraphic>(ClientUI::GetTexture(ClientUI::ArtDir() / "splash.png"), GG::GRAPHIC_FITGRAPHIC, GG::INTERACTIVE);
 
@@ -328,28 +328,31 @@ void IntroScreen::OnLoadGame() {
 }
 
 void IntroScreen::OnOptions() {
-    OptionsWnd options_wnd;
-    options_wnd.Run();
+    auto  options_wnd = GG::Wnd::Create<OptionsWnd>();
+    options_wnd->Run();
 }
 
 void IntroScreen::OnPedia() {
     static const std::string INTRO_PEDIA_WND_NAME = "introscreen.pedia";
-    EncyclopediaDetailPanel enc_panel(GG::MODAL | GG::INTERACTIVE | GG::DRAGABLE |
-                                      GG::RESIZABLE | CLOSABLE | PINABLE, INTRO_PEDIA_WND_NAME);
-    enc_panel.SizeMove(GG::Pt(GG::X(100), GG::Y(100)), Size() - GG::Pt(GG::X(100), GG::Y(100)));
-    enc_panel.ClearItems();
-    enc_panel.SetIndex();
-    enc_panel.ValidatePosition();
+    auto enc_panel = GG::Wnd::Create<EncyclopediaDetailPanel>(
+        GG::MODAL | GG::INTERACTIVE | GG::DRAGABLE |
+        GG::RESIZABLE | CLOSABLE | PINABLE, INTRO_PEDIA_WND_NAME);
+    enc_panel->SizeMove(GG::Pt(GG::X(100), GG::Y(100)), Size() - GG::Pt(GG::X(100), GG::Y(100)));
+    enc_panel->ClearItems();
+    enc_panel->SetIndex();
+    enc_panel->ValidatePosition();
 
-    enc_panel.ClosingSignal.connect(
-        boost::bind(&EncyclopediaDetailPanel::EndRun, &enc_panel));
+    enc_panel->ClosingSignal.connect(
+        boost::bind(&EncyclopediaDetailPanel::EndRun, enc_panel));
 
-    enc_panel.Run();
+    enc_panel->Run();
+
+    delete enc_panel;
 }
 
 void IntroScreen::OnAbout() {
-    About about_wnd;
-    about_wnd.Run();
+    auto about_wnd = GG::Wnd::Create<About>();
+    about_wnd->Run();
 }
 
 void IntroScreen::OnWebsite()

--- a/UI/IntroScreen.cpp
+++ b/UI/IntroScreen.cpp
@@ -258,16 +258,16 @@ IntroScreen::IntroScreen() :
     m_splash->AttachChild(m_version);
 
     //create buttons
-    m_single_player = new CUIButton(UserString("INTRO_BTN_SINGLE_PLAYER"));
-    m_quick_start =   new CUIButton(UserString("INTRO_BTN_QUICK_START"));
-    m_multi_player =  new CUIButton(UserString("INTRO_BTN_MULTI_PLAYER"));
-    m_load_game =     new CUIButton(UserString("INTRO_BTN_LOAD_GAME"));
-    m_options =       new CUIButton(UserString("INTRO_BTN_OPTIONS"));
-    m_pedia =         new CUIButton(UserString("INTRO_BTN_PEDIA"));
-    m_about =         new CUIButton(UserString("INTRO_BTN_ABOUT"));
-    m_website =       new CUIButton(UserString("INTRO_BTN_WEBSITE"));
-    m_credits =       new CUIButton(UserString("INTRO_BTN_CREDITS"));
-    m_exit_game =     new CUIButton(UserString("INTRO_BTN_EXIT"));
+    m_single_player = Wnd::Create<CUIButton>(UserString("INTRO_BTN_SINGLE_PLAYER"));
+    m_quick_start =   Wnd::Create<CUIButton>(UserString("INTRO_BTN_QUICK_START"));
+    m_multi_player =  Wnd::Create<CUIButton>(UserString("INTRO_BTN_MULTI_PLAYER"));
+    m_load_game =     Wnd::Create<CUIButton>(UserString("INTRO_BTN_LOAD_GAME"));
+    m_options =       Wnd::Create<CUIButton>(UserString("INTRO_BTN_OPTIONS"));
+    m_pedia =         Wnd::Create<CUIButton>(UserString("INTRO_BTN_PEDIA"));
+    m_about =         Wnd::Create<CUIButton>(UserString("INTRO_BTN_ABOUT"));
+    m_website =       Wnd::Create<CUIButton>(UserString("INTRO_BTN_WEBSITE"));
+    m_credits =       Wnd::Create<CUIButton>(UserString("INTRO_BTN_CREDITS"));
+    m_exit_game =     Wnd::Create<CUIButton>(UserString("INTRO_BTN_EXIT"));
 
     //attach buttons
     m_menu->AttachChild(m_single_player);

--- a/UI/IntroScreen.cpp
+++ b/UI/IntroScreen.cpp
@@ -241,7 +241,12 @@ IntroScreen::IntroScreen() :
     m_splash(nullptr),
     m_logo(nullptr),
     m_version(nullptr)
+{}
+
+void IntroScreen::CompleteConstruction()
 {
+    GG::Wnd::CompleteConstruction();
+
     m_menu = GG::Wnd::Create<CUIWnd>(UserString("INTRO_WINDOW_TITLE"), GG::X1, GG::Y1,
                                   MAIN_MENU_WIDTH, MAIN_MENU_HEIGHT, GG::ONTOP | GG::INTERACTIVE);
 

--- a/UI/IntroScreen.cpp
+++ b/UI/IntroScreen.cpp
@@ -332,7 +332,7 @@ void IntroScreen::OnLoadGame() {
 }
 
 void IntroScreen::OnOptions() {
-    auto  options_wnd = GG::Wnd::Create<OptionsWnd>();
+    auto options_wnd = GG::Wnd::Create<OptionsWnd>();
     options_wnd->Run();
 }
 

--- a/UI/IntroScreen.cpp
+++ b/UI/IntroScreen.cpp
@@ -243,8 +243,7 @@ IntroScreen::IntroScreen() :
     m_version(nullptr)
 {}
 
-void IntroScreen::CompleteConstruction()
-{
+void IntroScreen::CompleteConstruction() {
     GG::Wnd::CompleteConstruction();
 
     m_menu = GG::Wnd::Create<CUIWnd>(UserString("INTRO_WINDOW_TITLE"), GG::X1, GG::Y1,

--- a/UI/IntroScreen.h
+++ b/UI/IntroScreen.h
@@ -20,6 +20,8 @@ public:
     ~IntroScreen();
     //!@}
 
+    void CompleteConstruction() override;
+
     /** \name Mutators*/ //!@{
     void KeyPress(GG::Key key, std::uint32_t key_code_point, GG::Flags<GG::ModKey> mod_keys) override;
 

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -704,14 +704,15 @@ private:
 MapWndPopup::MapWndPopup(const std::string& t, GG::X default_x, GG::Y default_y, GG::X default_w, GG::Y default_h,
                          GG::Flags<GG::WndFlag> flags, const std::string& config_name) :
     CUIWnd(t, default_x, default_y, default_w, default_h, flags, config_name)
-{
-    if (MapWnd *mwnd = ClientUI::GetClientUI()->GetMapWnd())
-        mwnd->RegisterPopup(this);
-}
+{}
 
 MapWndPopup::MapWndPopup(const std::string& t, GG::Flags<GG::WndFlag> flags, const std::string& config_name) :
     CUIWnd(t, flags, config_name)
-{
+{}
+
+void MapWndPopup::CompleteConstruction() {
+    CUIWnd::CompleteConstruction();
+
     // MapWndPopupWnd is registered as a top level window, the same as ClientUI and MapWnd.
     // Consequently, when the GUI shutsdown either could be destroyed before this Wnd
     if (auto client = ClientUI::GetClientUI())

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -1410,7 +1410,7 @@ MapWnd::MapWnd() :
     ///////////////////
 
     // system-view side panel
-    m_side_panel = new SidePanel(MAP_SIDEPANEL_WND_NAME);
+    m_side_panel = GG::Wnd::Create<SidePanel>(MAP_SIDEPANEL_WND_NAME);
     GG::GUI::GetGUI()->Register(m_side_panel);
 
     SidePanel::SystemSelectedSignal.connect(
@@ -1435,7 +1435,7 @@ MapWnd::MapWnd() :
         boost::bind(&MapWnd::UpdateSidePanelSystemObjectMetersAndResourcePools, this));
 
     // situation report window
-    m_sitrep_panel = new SitRepPanel(SITREP_WND_NAME);
+    m_sitrep_panel = GG::Wnd::Create<SitRepPanel>(SITREP_WND_NAME);
     // Wnd is manually closed by user
     m_sitrep_panel->ClosingSignal.connect(
         boost::bind(&MapWnd::HideSitRep, this));
@@ -1445,7 +1445,7 @@ MapWnd::MapWnd() :
     }
 
     // encyclopedia panel
-    m_pedia_panel = new EncyclopediaDetailPanel(GG::ONTOP | GG::INTERACTIVE | GG::DRAGABLE | GG::RESIZABLE | CLOSABLE | PINABLE, MAP_PEDIA_WND_NAME);
+    m_pedia_panel = GG::Wnd::Create<EncyclopediaDetailPanel>(GG::ONTOP | GG::INTERACTIVE | GG::DRAGABLE | GG::RESIZABLE | CLOSABLE | PINABLE, MAP_PEDIA_WND_NAME);
     // Wnd is manually closed by user
     m_pedia_panel->ClosingSignal.connect(
         boost::bind(&MapWnd::HidePedia, this));
@@ -1455,7 +1455,7 @@ MapWnd::MapWnd() :
     }
 
     // objects list
-    m_object_list_wnd = new ObjectListWnd(OBJECT_WND_NAME);
+    m_object_list_wnd = GG::Wnd::Create<ObjectListWnd>(OBJECT_WND_NAME);
     // Wnd is manually closed by user
     m_object_list_wnd->ClosingSignal.connect(
         boost::bind(&MapWnd::HideObjects, this));
@@ -1467,7 +1467,7 @@ MapWnd::MapWnd() :
     }
 
     // moderator actions
-    m_moderator_wnd = new ModeratorActionsWnd(MODERATOR_WND_NAME);
+    m_moderator_wnd = GG::Wnd::Create<ModeratorActionsWnd>(MODERATOR_WND_NAME);
     m_moderator_wnd->ClosingSignal.connect(
         boost::bind(&MapWnd::HideModeratorActions, this));
     if (m_moderator_wnd->Visible()) {
@@ -1476,7 +1476,7 @@ MapWnd::MapWnd() :
     }
 
     // Combat report
-    m_combat_report_wnd = new CombatReportWnd(COMBAT_REPORT_WND_NAME);
+    m_combat_report_wnd = GG::Wnd::Create<CombatReportWnd>(COMBAT_REPORT_WND_NAME);
 
     // position CUIWnds owned by the MapWnd
     InitializeWindows();
@@ -6249,8 +6249,8 @@ bool MapWnd::ShowMenu() {
     m_btn_menu->SetUnpressedGraphic(GG::SubTexture(ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "buttons" / "menu_mouseover.png")));
     m_btn_menu->SetRolloverGraphic (GG::SubTexture(ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "buttons" / "menu.png")));
 
-    InGameMenu menu;
-    menu.Run();
+    std::shared_ptr<InGameMenu> menu(GG::Wnd::Create<InGameMenu>());
+    menu->Run();
     m_menu_showing = false;
 
     m_btn_menu->SetUnpressedGraphic(GG::SubTexture(ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "buttons" / "menu.png")));

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -985,7 +985,7 @@ MapWnd::MapWnd() :
     // turn button
     // determine size from the text that will go into the button, using a test year string
     std::string turn_button_longest_reasonable_text =  boost::io::str(FlexibleFormat(UserString("MAP_BTN_TURN_UPDATE")) % "99999"); // it is unlikely a game will go over 100000 turns
-    m_btn_turn = new CUIButton(turn_button_longest_reasonable_text);
+    m_btn_turn = Wnd::Create<CUIButton>(turn_button_longest_reasonable_text);
     m_btn_turn->Resize(m_btn_turn->MinUsableSize());
     m_btn_turn->LeftClickedSignal.connect(
         boost::bind(&MapWnd::EndTurn, this));
@@ -995,7 +995,7 @@ MapWnd::MapWnd() :
     boost::filesystem::path button_texture_dir = ClientUI::ArtDir() / "icons" / "buttons";
 
     // auto turn button
-    m_btn_auto_turn = new CUIButton(
+    m_btn_auto_turn = Wnd::Create<CUIButton>(
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "manual_turn.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "auto_turn.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "manual_turn_mouseover.png")));
@@ -1019,7 +1019,7 @@ MapWnd::MapWnd() :
                              boost::bind(&WndRight, _1), boost::bind(&WndBottom, _1),
                     _2);
     // Menu button
-    m_btn_menu = new SettableInWindowCUIButton(
+    m_btn_menu = Wnd::Create<SettableInWindowCUIButton>(
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "menu.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "menu_clicked.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "menu_mouseover.png")),
@@ -1036,7 +1036,7 @@ MapWnd::MapWnd() :
                              boost::bind(&WndRight, _1),  boost::bind(&WndBottom, _1),
                     _2);
     // Encyclo"pedia" button
-    m_btn_pedia = new SettableInWindowCUIButton(
+    m_btn_pedia = Wnd::Create<SettableInWindowCUIButton>(
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "pedia.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "pedia_clicked.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "pedia_mouseover.png")),
@@ -1053,7 +1053,7 @@ MapWnd::MapWnd() :
                              boost::bind(&WndRight, _1),  boost::bind(&WndBottom, _1),
                     _2);
     // Graphs button
-    m_btn_graphs = new SettableInWindowCUIButton(
+    m_btn_graphs = Wnd::Create<SettableInWindowCUIButton>(
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "charts.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "charts_clicked.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "charts_mouseover.png")),
@@ -1070,7 +1070,7 @@ MapWnd::MapWnd() :
                              boost::bind(&WndRight, _1),  boost::bind(&WndBottom, _1),
                     _2);
     // Design button
-    m_btn_design = new SettableInWindowCUIButton(
+    m_btn_design = Wnd::Create<SettableInWindowCUIButton>(
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "design.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "design_clicked.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "design_mouseover.png")),
@@ -1087,7 +1087,7 @@ MapWnd::MapWnd() :
                              boost::bind(&WndRight, _1),  boost::bind(&WndBottom, _1),
                     _2);
     // Production button
-    m_btn_production = new SettableInWindowCUIButton(
+    m_btn_production = Wnd::Create<SettableInWindowCUIButton>(
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "production.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "production_clicked.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "production_mouseover.png")),
@@ -1104,7 +1104,7 @@ MapWnd::MapWnd() :
                              boost::bind(&WndRight, _1),  boost::bind(&WndBottom, _1),
                     _2);
     // Research button
-    m_btn_research = new SettableInWindowCUIButton(
+    m_btn_research = Wnd::Create<SettableInWindowCUIButton>(
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "research.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "research_clicked.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "research_mouseover.png")),
@@ -1121,7 +1121,7 @@ MapWnd::MapWnd() :
                              boost::bind(&WndRight, _1),  boost::bind(&WndBottom, _1),
                     _2);
     // Objects button
-    m_btn_objects = new SettableInWindowCUIButton(
+    m_btn_objects = Wnd::Create<SettableInWindowCUIButton>(
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "objects.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "objects_clicked.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "objects_mouseover.png")),
@@ -1138,7 +1138,7 @@ MapWnd::MapWnd() :
                              boost::bind(&WndRight, _1),  boost::bind(&WndBottom, _1),
                     _2);
     // Empires button
-    m_btn_empires = new SettableInWindowCUIButton(
+    m_btn_empires = Wnd::Create<SettableInWindowCUIButton>(
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "empires.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "empires_clicked.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "empires_mouseover.png")),
@@ -1155,7 +1155,7 @@ MapWnd::MapWnd() :
                              boost::bind(&WndRight, _1), boost::bind(&WndBottom, _1),
                     _2);
     // SitRep button
-    m_btn_siterep = new SettableInWindowCUIButton(
+    m_btn_siterep = Wnd::Create<SettableInWindowCUIButton>(
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "sitrep.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "sitrep_clicked.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "sitrep_mouseover.png")),
@@ -1172,7 +1172,7 @@ MapWnd::MapWnd() :
                              boost::bind(&WndRight, _1), boost::bind(&WndBottom, _1),
                     _2);
     // Messages button
-    m_btn_messages = new SettableInWindowCUIButton(
+    m_btn_messages = Wnd::Create<SettableInWindowCUIButton>(
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "messages.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "messages_clicked.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "messages_mouseover.png")),
@@ -1189,7 +1189,7 @@ MapWnd::MapWnd() :
                              boost::bind(&WndRight, _1), boost::bind(&WndBottom, _1),
                     _2);
     // Moderator button
-    m_btn_moderator = new SettableInWindowCUIButton(
+    m_btn_moderator = Wnd::Create<SettableInWindowCUIButton>(
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "moderator.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "moderator_clicked.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "moderator_mouseover.png")),
@@ -1241,12 +1241,12 @@ MapWnd::MapWnd() :
     GG::SubTexture wasted_ressource_clicked_subtexture = GG::SubTexture(ClientUI::GetTexture(button_texture_dir /
                                                                 "wasted_resource_clicked.png", false));
 
-    m_industry_wasted = new CUIButton(
+    m_industry_wasted = Wnd::Create<CUIButton>(
         wasted_ressource_subtexture,
         wasted_ressource_clicked_subtexture,
         wasted_ressource_mouseover_subtexture);
 
-    m_research_wasted = new CUIButton(
+    m_research_wasted = Wnd::Create<CUIButton>(
         wasted_ressource_subtexture,
         wasted_ressource_clicked_subtexture,
         wasted_ressource_mouseover_subtexture);
@@ -4907,7 +4907,7 @@ void MapWnd::CreateFleetButtonsOfType (
             continue;
 
         // create new fleetbutton for this cluster of fleets
-        auto fb = new FleetButton(fleet_IDs, fleet_button_size);
+        auto fb = GG::Wnd::Create<FleetButton>(fleet_IDs, fleet_button_size);
 
         // store per type of fleet button.
         type_fleet_buttons[key].insert(fb);

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -522,6 +522,7 @@ public:
     }
 
     void CompleteConstruction() override {
+        GG::Control::CompleteConstruction();
         AttachChild(m_label);
         std::set<int> dummy = std::set<int>();
         Update(1.0, dummy, INVALID_OBJECT_ID);

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -967,8 +967,7 @@ MapWnd::MapWnd() :
     m_zoom_slider(nullptr)
 {}
 
-void MapWnd::CompleteConstruction()
-{
+void MapWnd::CompleteConstruction() {
     GG::Wnd::CompleteConstruction();
 
     SetName("MapWnd");

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -6317,7 +6317,7 @@ void MapWnd::RefreshFleetResourceIndicator() {
     m_fleet->SetValue(total_fleet_count);
     m_fleet->ClearBrowseInfoWnd();
     m_fleet->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
-    m_fleet->SetBrowseInfoWnd(std::make_shared<FleetDetailBrowseWnd>(
+    m_fleet->SetBrowseInfoWnd(GG::Wnd::Create<FleetDetailBrowseWnd>(
         empire_id, GG::X(FontBasedUpscale(200))));
 }
 
@@ -6337,7 +6337,7 @@ void MapWnd::RefreshResearchResourceIndicator() {
     double total_RP_wasted = total_RP_output - total_RP_spent;
     double total_RP_target_output = empire->GetResourcePool(RE_RESEARCH)->TargetOutput();
 
-    m_research->SetBrowseInfoWnd(std::make_shared<ResourceBrowseWnd>(
+    m_research->SetBrowseInfoWnd(GG::Wnd::Create<ResourceBrowseWnd>(
         UserString("MAP_RESEARCH_TITLE"), UserString("RESEARCH_INFO_RP"),
         total_RP_spent, total_RP_output, total_RP_target_output
     ));
@@ -6385,7 +6385,7 @@ void MapWnd::RefreshIndustryResourceIndicator() {
     double total_PP_wasted = total_PP_output - total_PP_spent;
     double total_PP_target_output = empire->GetResourcePool(RE_INDUSTRY)->TargetOutput();
 
-    m_industry->SetBrowseInfoWnd(std::make_shared<ResourceBrowseWnd>(
+    m_industry->SetBrowseInfoWnd(GG::Wnd::Create<ResourceBrowseWnd>(
         UserString("MAP_PRODUCTION_TITLE"), UserString("PRODUCTION_INFO_PP"),
         total_PP_spent, total_PP_output, total_PP_target_output));
 
@@ -6439,7 +6439,7 @@ void MapWnd::RefreshPopulationIndicator() {
     }
 
     m_population->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
-    m_population->SetBrowseInfoWnd(std::make_shared<CensusBrowseWnd>(
+    m_population->SetBrowseInfoWnd(GG::Wnd::Create<CensusBrowseWnd>(
         UserString("MAP_POPULATION_DISTRIBUTION"), population_counts, tag_counts));
 }
 

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -1038,7 +1038,7 @@ void MapWnd::CompleteConstruction()
     m_btn_menu->LeftClickedSignal.connect(
         boost::bind(&MapWnd::ShowMenu, this));
     m_btn_menu->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
-    m_btn_menu->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+    m_btn_menu->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
         UserString("MAP_BTN_MENU"), UserString("MAP_BTN_MENU_DESC")));
 
     in_window_func =
@@ -1055,7 +1055,7 @@ void MapWnd::CompleteConstruction()
     m_btn_pedia->LeftClickedSignal.connect(
         boost::bind(&MapWnd::TogglePedia, this));
     m_btn_pedia->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
-    m_btn_pedia->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+    m_btn_pedia->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
         UserString("MAP_BTN_PEDIA"), UserString("MAP_BTN_PEDIA_DESC")));
 
     in_window_func =
@@ -1072,7 +1072,7 @@ void MapWnd::CompleteConstruction()
     m_btn_graphs->LeftClickedSignal.connect(
         boost::bind(&MapWnd::ShowGraphs, this));
     m_btn_graphs->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
-    m_btn_graphs->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+    m_btn_graphs->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
         UserString("MAP_BTN_GRAPH"), UserString("MAP_BTN_GRAPH_DESC")));
 
     in_window_func =
@@ -1089,7 +1089,7 @@ void MapWnd::CompleteConstruction()
     m_btn_design->LeftClickedSignal.connect(
         boost::bind(&MapWnd::ToggleDesign, this));
     m_btn_design->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
-    m_btn_design->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+    m_btn_design->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
         UserString("MAP_BTN_DESIGN"), UserString("MAP_BTN_DESIGN_DESC")));
 
     in_window_func =
@@ -1106,7 +1106,7 @@ void MapWnd::CompleteConstruction()
     m_btn_production->LeftClickedSignal.connect(
         boost::bind(&MapWnd::ToggleProduction, this));
     m_btn_production->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
-    m_btn_production->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+    m_btn_production->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
         UserString("MAP_BTN_PRODUCTION"), UserString("MAP_BTN_PRODUCTION_DESC")));
 
     in_window_func =
@@ -1123,7 +1123,7 @@ void MapWnd::CompleteConstruction()
     m_btn_research->LeftClickedSignal.connect(
         boost::bind(&MapWnd::ToggleResearch, this));
     m_btn_research->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
-    m_btn_research->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+    m_btn_research->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
         UserString("MAP_BTN_RESEARCH"), UserString("MAP_BTN_RESEARCH_DESC")));
 
     in_window_func =
@@ -1140,7 +1140,7 @@ void MapWnd::CompleteConstruction()
     m_btn_objects->LeftClickedSignal.connect(
         boost::bind(&MapWnd::ToggleObjects, this));
     m_btn_objects->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
-    m_btn_objects->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+    m_btn_objects->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
         UserString("MAP_BTN_OBJECTS"), UserString("MAP_BTN_OBJECTS_DESC")));
 
     in_window_func =
@@ -1157,7 +1157,7 @@ void MapWnd::CompleteConstruction()
     m_btn_empires->LeftClickedSignal.connect(
         boost::bind(&MapWnd::ToggleEmpires, this));
     m_btn_empires->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
-    m_btn_empires->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+    m_btn_empires->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
         UserString("MAP_BTN_EMPIRES"), UserString("MAP_BTN_EMPIRES_DESC")));
 
     in_window_func =
@@ -1174,7 +1174,7 @@ void MapWnd::CompleteConstruction()
     m_btn_siterep->LeftClickedSignal.connect(
         boost::bind(&MapWnd::ToggleSitRep, this));
     m_btn_siterep->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
-    m_btn_siterep->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+    m_btn_siterep->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
         UserString("MAP_BTN_SITREP"), UserString("MAP_BTN_SITREP_DESC")));
 
     in_window_func =
@@ -1191,7 +1191,7 @@ void MapWnd::CompleteConstruction()
     m_btn_messages->LeftClickedSignal.connect(
         boost::bind(&MapWnd::ToggleMessages, this));
     m_btn_messages->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
-    m_btn_messages->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+    m_btn_messages->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
         UserString("MAP_BTN_MESSAGES"), UserString("MAP_BTN_MESSAGES_DESC")));
 
     in_window_func =
@@ -1208,7 +1208,7 @@ void MapWnd::CompleteConstruction()
     m_btn_moderator->LeftClickedSignal.connect(
         boost::bind(&MapWnd::ToggleModeratorActions, this));
     m_btn_moderator->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
-    m_btn_moderator->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+    m_btn_moderator->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
         UserString("MAP_BTN_MODERATOR"), UserString("MAP_BTN_MODERATOR_DESC")));
 
 
@@ -5828,7 +5828,7 @@ void MapWnd::ToggleAutoEndTurn() {
         m_btn_auto_turn->SetRolloverGraphic(    GG::SubTexture(ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "buttons" / "manual_turn_mouseover.png")));
 
         m_btn_auto_turn->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
-        m_btn_auto_turn->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+        m_btn_auto_turn->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
             UserString("MAP_BTN_MANUAL_TURN_ADVANCE"),
             UserString("MAP_BTN_MANUAL_TURN_ADVANCE_DESC")
         ));
@@ -5839,7 +5839,7 @@ void MapWnd::ToggleAutoEndTurn() {
         m_btn_auto_turn->SetRolloverGraphic(    GG::SubTexture(ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "buttons" / "auto_turn_mouseover.png")));
 
         m_btn_auto_turn->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
-        m_btn_auto_turn->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+        m_btn_auto_turn->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
             UserString("MAP_BTN_AUTO_ADVANCE_ENABLED"),
             UserString("MAP_BTN_AUTO_ADVANCE_ENABLED_DESC")
         ));
@@ -6294,7 +6294,7 @@ void MapWnd::RefreshTradeResourceIndicator() {
     m_trade->SetValue(empire->ResourceStockpile(RE_TRADE));
     m_trade->ClearBrowseInfoWnd();
     m_trade->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
-    m_trade->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+    m_trade->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
         UserString("MAP_TRADE_TITLE"), UserString("MAP_TRADE_TEXT")));
 }
 
@@ -6348,7 +6348,7 @@ void MapWnd::RefreshResearchResourceIndicator() {
         m_research_wasted->Show();
         m_research_wasted->ClearBrowseInfoWnd();
         m_research_wasted->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
-        m_research_wasted->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+        m_research_wasted->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
             UserString("MAP_RES_WASTED_TITLE"),
             boost::io::str(FlexibleFormat(UserString("MAP_RES_WASTED_TEXT"))
                            % DoubleToString(total_RP_output, 3, false)
@@ -6365,7 +6365,7 @@ void MapWnd::RefreshDetectionIndicator() {
     m_detection->SetValue(empire->GetMeter("METER_DETECTION_STRENGTH")->Current());
     m_detection->ClearBrowseInfoWnd();
     m_detection->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
-    m_detection->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+    m_detection->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
         UserString("MAP_DETECTION_TITLE"), UserString("MAP_DETECTION_TEXT")));
 }
 
@@ -6395,7 +6395,7 @@ void MapWnd::RefreshIndustryResourceIndicator() {
         m_industry_wasted->Show();
         m_industry_wasted->ClearBrowseInfoWnd();
         m_industry_wasted->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
-        m_industry_wasted->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+        m_industry_wasted->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
             UserString("MAP_PROD_WASTED_TITLE"),
             boost::io::str(FlexibleFormat(UserString("MAP_PROD_WASTED_TEXT"))
                            % DoubleToString(total_PP_output, 3, false)

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -519,6 +519,9 @@ public:
         m_enabled(false)
     {
         m_label = GG::Wnd::Create<GG::TextControl>(GG::X0, GG::Y0, GG::X1, GG::Y1, "", ClientUI::GetFont(), ClientUI::TextColor());
+    }
+
+    void CompleteConstruction() override {
         AttachChild(m_label);
         std::set<int> dummy = std::set<int>();
         Update(1.0, dummy, INVALID_OBJECT_ID);
@@ -960,7 +963,12 @@ MapWnd::MapWnd() :
     m_FPS(nullptr),
     m_scale_line(nullptr),
     m_zoom_slider(nullptr)
+{}
+
+void MapWnd::CompleteConstruction()
 {
+    GG::Wnd::CompleteConstruction();
+
     SetName("MapWnd");
 
     GetUniverse().UniverseObjectDeleteSignal.connect(

--- a/UI/MapWnd.h
+++ b/UI/MapWnd.h
@@ -61,6 +61,8 @@ public:
     ~MapWnd();
     //!@}
 
+    void CompleteConstruction() override;
+
     //! \name Accessors //!@{
     GG::Pt ClientUpperLeft() const override;
 

--- a/UI/MapWnd.h
+++ b/UI/MapWnd.h
@@ -559,6 +559,8 @@ public:
 
     MapWndPopup(const std::string& t, GG::Flags<GG::WndFlag> flags, const std::string& config_name = "");
 
+    void CompleteConstruction() override;
+
     virtual ~MapWndPopup();
 
     void CloseClicked() override;

--- a/UI/MeterBrowseWnd.cpp
+++ b/UI/MeterBrowseWnd.cpp
@@ -623,19 +623,14 @@ namespace {
         ShipFightersBrowseRow(const std::string& label, int qty, double value, double base_value = 0.0f) :
             GG::ListBox::Row(FighterBrowseListWidth(), MeterBrowseRowHeight(), "")
         {
-            SetMargin(EDGE_PAD);
             const GG::Clr QTY_COLOR = GG::CLR_GRAY;
 
-            auto label_control = GG::Wnd::Create<CUILabel>(label, GG::FORMAT_RIGHT);
-            push_back(label_control);
-            label_control->Resize(GG::Pt(FighterBrowseLabelWidth(), MeterBrowseRowHeight()));
+            m_label_control = GG::Wnd::Create<CUILabel>(label, GG::FORMAT_RIGHT);
 
             std::string qty_text;
             if (qty > 1)
                 qty_text = ColourWrappedtext("* " + IntToString(qty), QTY_COLOR);
-            auto qty_control = GG::Wnd::Create<CUILabel>(qty_text);
-            push_back(qty_control);
-            qty_control->Resize(GG::Pt(MeterBrowseQtyWidth(), MeterBrowseRowHeight()));
+            m_qty_control = GG::Wnd::Create<CUILabel>(qty_text);
 
             std::string value_text;
             if (base_value > 0.0f) {
@@ -644,12 +639,31 @@ namespace {
             } else {
                 value_text = IntToString(value);
             }
-            auto value_control = GG::Wnd::Create<CUILabel>(value_text, GG::FORMAT_RIGHT);
-            push_back(value_control);
-            value_control->Resize(GG::Pt(MeterBrowseValueWidth(), MeterBrowseRowHeight()));
+            m_value_control = GG::Wnd::Create<CUILabel>(value_text, GG::FORMAT_RIGHT);
+        }
+
+        void CompleteConstruction() override
+        {
+            GG::ListBox::Row::CompleteConstruction();
+
+            SetMargin(EDGE_PAD);
+
+            push_back(m_label_control);
+            m_label_control->Resize(GG::Pt(FighterBrowseLabelWidth(), MeterBrowseRowHeight()));
+
+            push_back(m_qty_control);
+            m_qty_control->Resize(GG::Pt(MeterBrowseQtyWidth(), MeterBrowseRowHeight()));
+
+            push_back(m_value_control);
+            m_value_control->Resize(GG::Pt(MeterBrowseValueWidth(), MeterBrowseRowHeight()));
 
             // Resize(GG::Pt(FighterBrowseListWidth(), MeterBrowseRowHeight()));
         }
+
+    private:
+        CUILabel* m_label_control;
+        CUILabel* m_qty_control;
+        CUILabel* m_value_control;
     };
 }
 

--- a/UI/MeterBrowseWnd.cpp
+++ b/UI/MeterBrowseWnd.cpp
@@ -642,8 +642,7 @@ namespace {
             m_value_control = GG::Wnd::Create<CUILabel>(value_text, GG::FORMAT_RIGHT);
         }
 
-        void CompleteConstruction() override
-        {
+        void CompleteConstruction() override {
             GG::ListBox::Row::CompleteConstruction();
 
             SetMargin(EDGE_PAD);

--- a/UI/MilitaryPanel.cpp
+++ b/UI/MilitaryPanel.cpp
@@ -34,8 +34,7 @@ MilitaryPanel::MilitaryPanel(GG::X w, int planet_id) :
     m_multi_meter_status_bar(nullptr)
 {}
 
-void MilitaryPanel::CompleteConstruction()
-{
+void MilitaryPanel::CompleteConstruction() {
     AccordionPanel::CompleteConstruction();
 
     SetName("MilitaryPanel");

--- a/UI/MilitaryPanel.cpp
+++ b/UI/MilitaryPanel.cpp
@@ -140,12 +140,11 @@ void MilitaryPanel::Update() {
     m_multi_icon_value_indicator->Update();
 
     // tooltips
-    std::shared_ptr<GG::BrowseInfoWnd> browse_wnd;
-
     for (auto& meter_stat : m_meter_stats) {
         meter_stat.second->SetValue(obj->InitialMeterValue(meter_stat.first));
 
-        browse_wnd = std::make_shared<MeterBrowseWnd>(m_planet_id, meter_stat.first, AssociatedMeterType(meter_stat.first));
+        // TODO remove extra wrapping of shared_ptr after conversion to GG shared_ptr
+        auto browse_wnd = std::shared_ptr<GG::BrowseInfoWnd>(GG::Wnd::Create<MeterBrowseWnd>(m_planet_id, meter_stat.first, AssociatedMeterType(meter_stat.first)));
         meter_stat.second->SetBrowseInfoWnd(browse_wnd);
         m_multi_icon_value_indicator->SetToolTip(meter_stat.first, browse_wnd);
     }

--- a/UI/MilitaryPanel.cpp
+++ b/UI/MilitaryPanel.cpp
@@ -32,7 +32,12 @@ MilitaryPanel::MilitaryPanel(GG::X w, int planet_id) :
     m_meter_stats(),
     m_multi_icon_value_indicator(nullptr),
     m_multi_meter_status_bar(nullptr)
+{}
+
+void MilitaryPanel::CompleteConstruction()
 {
+    AccordionPanel::CompleteConstruction();
+
     SetName("MilitaryPanel");
 
     std::shared_ptr<const Planet> planet = GetPlanet();

--- a/UI/MilitaryPanel.h
+++ b/UI/MilitaryPanel.h
@@ -17,6 +17,7 @@ public:
     MilitaryPanel(GG::X w, int planet_id);
     ~MilitaryPanel();
     //@}
+    void CompleteConstruction() override;
 
     /** \name Accessors */ //@{
     bool EventFilter(GG::Wnd* w, const GG::WndEvent& event) override;

--- a/UI/ModeratorActionsWnd.cpp
+++ b/UI/ModeratorActionsWnd.cpp
@@ -43,6 +43,10 @@ ModeratorActionsWnd::ModeratorActionsWnd(const std::string& config_name) :
     m_add_starlane_button(nullptr),
     m_remove_starlane_button(nullptr)
 {
+}
+
+void ModeratorActionsWnd::CompleteConstruction()
+{
     ClientUI* ui = ClientUI::GetClientUI();
     GG::Flags<GG::GraphicStyle> style = GG::GRAPHIC_CENTER | GG::GRAPHIC_VCENTER | GG::GRAPHIC_FITGRAPHIC | GG::GRAPHIC_PROPSCALE;
 
@@ -189,6 +193,8 @@ ModeratorActionsWnd::ModeratorActionsWnd(const std::string& config_name) :
     AttachChild(m_remove_starlane_button);
     m_remove_starlane_button->LeftClickedSignal.connect(
         boost::bind(&ModeratorActionsWnd::RemoveStarlane, this));
+
+    CUIWnd::CompleteConstruction();
 
     DoLayout();
 }

--- a/UI/ModeratorActionsWnd.cpp
+++ b/UI/ModeratorActionsWnd.cpp
@@ -59,7 +59,7 @@ void ModeratorActionsWnd::CompleteConstruction()
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "nomoderatoraction_mouseover.png")));
 
     m_no_action_button->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
-    m_no_action_button->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+    m_no_action_button->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
         UserString("MOD_NONE"), UserString("MOD_NONE")));
     AttachChild(m_no_action_button);
     m_no_action_button->LeftClickedSignal.connect(
@@ -72,7 +72,7 @@ void ModeratorActionsWnd::CompleteConstruction()
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "addstar_mouseover.png")));
 
     m_create_system_button->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
-    m_create_system_button->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+    m_create_system_button->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
         UserString("MOD_CREATE_SYSTEM"), UserString("MOD_CREATE_SYSTEM")));
     AttachChild(m_create_system_button);
 
@@ -100,7 +100,7 @@ void ModeratorActionsWnd::CompleteConstruction()
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "addplanet_mouseover.png")));
 
     m_create_planet_button->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
-    m_create_planet_button->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+    m_create_planet_button->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
         UserString("MOD_CREATE_PLANET"), UserString("MOD_CREATE_PLANET")));
     AttachChild(m_create_planet_button);
     m_create_planet_button->LeftClickedSignal.connect(
@@ -143,7 +143,7 @@ void ModeratorActionsWnd::CompleteConstruction()
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "delete_mouseover.png")));
 
     m_delete_object_button->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
-    m_delete_object_button->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+    m_delete_object_button->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
         UserString("MOD_DESTROY"), UserString("MOD_DESTROY")));
     AttachChild(m_delete_object_button);
     m_delete_object_button->LeftClickedSignal.connect(
@@ -156,7 +156,7 @@ void ModeratorActionsWnd::CompleteConstruction()
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "setowner_mouseover.png")));
 
     m_set_owner_button->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
-    m_set_owner_button->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+    m_set_owner_button->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
         UserString("MOD_SET_OWNER"), UserString("MOD_SET_OWNER")));
     AttachChild(m_set_owner_button);
 
@@ -175,7 +175,7 @@ void ModeratorActionsWnd::CompleteConstruction()
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "addstarlane_mouseover.png")));
 
     m_add_starlane_button->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
-    m_add_starlane_button->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+    m_add_starlane_button->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
         UserString("MOD_ADD_STARLANE"), UserString("MOD_ADD_STARLANE")));
     AttachChild(m_add_starlane_button);
     m_add_starlane_button->LeftClickedSignal.connect(
@@ -188,7 +188,7 @@ void ModeratorActionsWnd::CompleteConstruction()
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "removestarlane_mouseover.png")));
 
     m_remove_starlane_button->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
-    m_remove_starlane_button->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+    m_remove_starlane_button->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
         UserString("MOD_REMOVE_STARLANE"), UserString("MOD_REMOVE_STARLANE")));
     AttachChild(m_remove_starlane_button);
     m_remove_starlane_button->LeftClickedSignal.connect(

--- a/UI/ModeratorActionsWnd.cpp
+++ b/UI/ModeratorActionsWnd.cpp
@@ -45,8 +45,7 @@ ModeratorActionsWnd::ModeratorActionsWnd(const std::string& config_name) :
 {
 }
 
-void ModeratorActionsWnd::CompleteConstruction()
-{
+void ModeratorActionsWnd::CompleteConstruction() {
     ClientUI* ui = ClientUI::GetClientUI();
     GG::Flags<GG::GraphicStyle> style = GG::GRAPHIC_CENTER | GG::GRAPHIC_VCENTER | GG::GRAPHIC_FITGRAPHIC | GG::GRAPHIC_PROPSCALE;
 

--- a/UI/ModeratorActionsWnd.cpp
+++ b/UI/ModeratorActionsWnd.cpp
@@ -49,7 +49,7 @@ ModeratorActionsWnd::ModeratorActionsWnd(const std::string& config_name) :
     boost::filesystem::path button_texture_dir = ClientUI::ArtDir() / "icons" / "buttons";
 
     // button for no action
-    m_no_action_button = new CUIButton(
+    m_no_action_button = Wnd::Create<CUIButton>(
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "nomoderatoraction.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "nomoderatoraction_clicked.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "nomoderatoraction_mouseover.png")));
@@ -62,7 +62,7 @@ ModeratorActionsWnd::ModeratorActionsWnd(const std::string& config_name) :
         boost::bind(&ModeratorActionsWnd::NoActionClicked, this));
 
     // button for create system and droplist to select system type to create
-    m_create_system_button = new CUIButton(
+    m_create_system_button = Wnd::Create<CUIButton>(
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "addstar.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "addstar_clicked.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "addstar_mouseover.png")));
@@ -90,7 +90,7 @@ ModeratorActionsWnd::ModeratorActionsWnd(const std::string& config_name) :
         boost::bind(&ModeratorActionsWnd::StarTypeSelected, this, _1));
 
     // button for create planet and droplists to select planet type and size
-    m_create_planet_button = new CUIButton(
+    m_create_planet_button = Wnd::Create<CUIButton>(
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "addplanet.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "addplanet_clicked.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "addplanet_mouseover.png")));
@@ -133,7 +133,7 @@ ModeratorActionsWnd::ModeratorActionsWnd(const std::string& config_name) :
         boost::bind(&ModeratorActionsWnd::PlanetSizeSelected, this, _1));
 
     // button for destroying object
-    m_delete_object_button = new CUIButton(
+    m_delete_object_button = Wnd::Create<CUIButton>(
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "delete.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "delete_clicked.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "delete_mouseover.png")));
@@ -146,7 +146,7 @@ ModeratorActionsWnd::ModeratorActionsWnd(const std::string& config_name) :
         boost::bind(&ModeratorActionsWnd::DeleteObjectClicked, this));
 
     // button for setting owner
-    m_set_owner_button = new CUIButton(
+    m_set_owner_button = Wnd::Create<CUIButton>(
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "setowner.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "setowner_clicked.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "setowner_mouseover.png")));
@@ -165,7 +165,7 @@ ModeratorActionsWnd::ModeratorActionsWnd(const std::string& config_name) :
         boost::bind(&ModeratorActionsWnd::EmpireSelected, this, _1));
 
     // button for creating starlane
-    m_add_starlane_button = new CUIButton(
+    m_add_starlane_button = Wnd::Create<CUIButton>(
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "addstarlane.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "addstarlane_clicked.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "addstarlane_mouseover.png")));
@@ -178,7 +178,7 @@ ModeratorActionsWnd::ModeratorActionsWnd(const std::string& config_name) :
         boost::bind(&ModeratorActionsWnd::AddStarlane, this));
 
     // button for removing starlane
-    m_remove_starlane_button = new CUIButton(
+    m_remove_starlane_button = Wnd::Create<CUIButton>(
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "removestarlane.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "removestarlane_clicked.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "removestarlane_mouseover.png")));

--- a/UI/ModeratorActionsWnd.h
+++ b/UI/ModeratorActionsWnd.h
@@ -14,6 +14,7 @@ class ModeratorActionsWnd : public CUIWnd {
 public:
     //! \name Structors //!@{
     ModeratorActionsWnd(const std::string& config_name = "");
+    void CompleteConstruction() override;
 
     virtual ~ModeratorActionsWnd();
     //!@}

--- a/UI/MultiIconValueIndicator.cpp
+++ b/UI/MultiIconValueIndicator.cpp
@@ -37,7 +37,12 @@ MultiIconValueIndicator::MultiIconValueIndicator(GG::X w, const std::vector<int>
     m_icons(),
     m_meter_types(meter_types),
     m_object_ids(object_ids)
+{}
+
+void MultiIconValueIndicator::CompleteConstruction()
 {
+    GG::Wnd::CompleteConstruction();
+
     SetName("MultiIconValueIndicator");
 
     GG::X x(EDGE_PAD);

--- a/UI/MultiIconValueIndicator.cpp
+++ b/UI/MultiIconValueIndicator.cpp
@@ -39,8 +39,7 @@ MultiIconValueIndicator::MultiIconValueIndicator(GG::X w, const std::vector<int>
     m_object_ids(object_ids)
 {}
 
-void MultiIconValueIndicator::CompleteConstruction()
-{
+void MultiIconValueIndicator::CompleteConstruction() {
     GG::Wnd::CompleteConstruction();
 
     SetName("MultiIconValueIndicator");

--- a/UI/MultiIconValueIndicator.h
+++ b/UI/MultiIconValueIndicator.h
@@ -20,6 +20,8 @@ public:
 
     MultiIconValueIndicator(GG::X w, const std::vector<int>& object_ids, const std::vector<std::pair<MeterType, MeterType>>& meter_types);
 
+    void CompleteConstruction() override;
+
     bool            Empty();
 
     void Render() override;

--- a/UI/MultiplayerLobbyWnd.cpp
+++ b/UI/MultiplayerLobbyWnd.cpp
@@ -252,7 +252,7 @@ namespace {
                                                              GG::GRAPHIC_CENTER | GG::GRAPHIC_FITGRAPHIC | GG::GRAPHIC_PROPSCALE, GG::INTERACTIVE));
                 at(5)->SetMinSize(GG::Pt(GG::X(ClientUI::Pts()), PlayerFontHeight()));
                 at(5)->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
-                at(5)->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+                at(5)->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
                     m_player_data.m_player_ready ? UserString("READY_BN") : UserString("NOT_READY_BN"),
                     "", PlayerReadyBrowseWidth()));
                 if (HumanClientApp::GetApp()->Networking().PlayerIsHost(m_player_id)) {
@@ -307,7 +307,7 @@ namespace {
                                                              GG::GRAPHIC_CENTER | GG::GRAPHIC_FITGRAPHIC | GG::GRAPHIC_PROPSCALE, GG::INTERACTIVE));
                 at(5)->SetMinSize(GG::Pt(GG::X(ClientUI::Pts()), PlayerFontHeight()));
                 at(5)->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
-                at(5)->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+                at(5)->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
                     m_player_data.m_player_ready ? UserString("READY_BN") : UserString("NOT_READY_BN"),
                     "", PlayerReadyBrowseWidth()));
             }
@@ -422,7 +422,7 @@ namespace {
                 push_back(GG::Wnd::Create<GG::StaticGraphic>(GetReadyTexture(m_player_data.m_player_ready),
                                                              GG::GRAPHIC_CENTER | GG::GRAPHIC_FITGRAPHIC | GG::GRAPHIC_PROPSCALE, GG::INTERACTIVE));
                 at(5)->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
-                at(5)->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(
+                at(5)->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
                     m_player_data.m_player_ready ? UserString("READY_BN") : UserString("NOT_READY_BN"),
                     "", PlayerReadyBrowseWidth()));
                 at(5)->SetMinSize(GG::Pt(GG::X(ClientUI::Pts()), PlayerFontHeight()));

--- a/UI/MultiplayerLobbyWnd.cpp
+++ b/UI/MultiplayerLobbyWnd.cpp
@@ -113,8 +113,7 @@ namespace {
                 }
             }
 
-            void CompleteConstruction() override
-            {
+            void CompleteConstruction() override {
                 GG::ListBox::Row::CompleteConstruction();
                 push_back(m_label);
                 push_back(GG::Wnd::Create<Spacer>());
@@ -226,8 +225,7 @@ namespace {
             m_initial_disabled(disabled)
         {}
 
-        void CompleteConstruction() override
-        {
+        void CompleteConstruction() override {
             PlayerRow::CompleteConstruction();
 
             // human / AI / observer indicator / selector
@@ -353,8 +351,7 @@ namespace {
             m_initial_disabled(disabled)
         {}
 
-        void CompleteConstruction() override
-        {
+        void CompleteConstruction() override {
             PlayerRow::CompleteConstruction();
 
             // human / AI / observer indicator / selector
@@ -474,8 +471,7 @@ namespace {
             PlayerRow()
         {}
 
-        void CompleteConstruction() override
-        {
+        void CompleteConstruction() override {
             PlayerRow::CompleteConstruction();
 
             auto type_drop = GG::Wnd::Create<TypeSelector>(GG::X(90), PlayerRowHeight(), Networking::INVALID_CLIENT_TYPE, false);

--- a/UI/MultiplayerLobbyWnd.cpp
+++ b/UI/MultiplayerLobbyWnd.cpp
@@ -526,9 +526,9 @@ void MultiPlayerLobbyWnd::CompleteConstruction()
 
     m_new_load_game_buttons = GG::Wnd::Create<GG::RadioButtonGroup>(GG::VERTICAL);
     m_new_load_game_buttons->AddButton(
-        new CUIStateButton(UserString("NEW_GAME_BN"), GG::FORMAT_LEFT, std::make_shared<CUIRadioRepresenter>()));
+        GG::Wnd::Create<CUIStateButton>(UserString("NEW_GAME_BN"), GG::FORMAT_LEFT, std::make_shared<CUIRadioRepresenter>()));
     m_new_load_game_buttons->AddButton(
-        new CUIStateButton(UserString("LOAD_GAME_BN"), GG::FORMAT_LEFT, std::make_shared<CUIRadioRepresenter>()));
+        GG::Wnd::Create<CUIStateButton>(UserString("LOAD_GAME_BN"), GG::FORMAT_LEFT, std::make_shared<CUIRadioRepresenter>()));
 
     m_browse_saves_btn = Wnd::Create<CUIButton>("...");
     m_save_file_text = GG::Wnd::Create<CUILabel>("", GG::FORMAT_NOWRAP);

--- a/UI/MultiplayerLobbyWnd.cpp
+++ b/UI/MultiplayerLobbyWnd.cpp
@@ -541,8 +541,7 @@ MultiPlayerLobbyWnd::MultiPlayerLobbyWnd() :
     m_start_conditions_text(nullptr)
 {}
 
-void MultiPlayerLobbyWnd::CompleteConstruction()
-{
+void MultiPlayerLobbyWnd::CompleteConstruction() {
     Sound::TempUISoundDisabler sound_disabler;
 
     m_chat_input_edit = GG::Wnd::Create<CUIEdit>("");
@@ -626,8 +625,7 @@ MultiPlayerLobbyWnd::PlayerLabelRow::PlayerLabelRow(GG::X width /* = GG::X(580)*
     GG::ListBox::Row(width, PlayerRowHeight(), "")
 {}
 
-void MultiPlayerLobbyWnd::PlayerLabelRow::CompleteConstruction()
-{
+void MultiPlayerLobbyWnd::PlayerLabelRow::CompleteConstruction() {
 
     GG::ListBox::Row::CompleteConstruction();
 

--- a/UI/MultiplayerLobbyWnd.cpp
+++ b/UI/MultiplayerLobbyWnd.cpp
@@ -547,8 +547,8 @@ MultiPlayerLobbyWnd::MultiPlayerLobbyWnd() :
     }
     m_players_lb->SetColHeaders(m_players_lb_headers);
 
-    m_ready_bn = new CUIButton(UserString("READY_BN"));
-    m_cancel_bn = new CUIButton(UserString("CANCEL"));
+    m_ready_bn = Wnd::Create<CUIButton>(UserString("READY_BN"));
+    m_cancel_bn = Wnd::Create<CUIButton>(UserString("CANCEL"));
 
     m_start_conditions_text = GG::Wnd::Create<CUILabel>(UserString("MULTIPLAYER_GAME_START_CONDITIONS"), GG::FORMAT_LEFT);
 

--- a/UI/MultiplayerLobbyWnd.cpp
+++ b/UI/MultiplayerLobbyWnd.cpp
@@ -512,6 +512,9 @@ MultiPlayerLobbyWnd::MultiPlayerLobbyWnd() :
     m_ready_bn(nullptr),
     m_cancel_bn(nullptr),
     m_start_conditions_text(nullptr)
+{}
+
+void MultiPlayerLobbyWnd::CompleteConstruction()
 {
     Sound::TempUISoundDisabler sound_disabler;
 
@@ -586,6 +589,8 @@ MultiPlayerLobbyWnd::MultiPlayerLobbyWnd() :
         boost::bind(&MultiPlayerLobbyWnd::PreviewImageChanged, this, _1));
     m_cancel_bn->LeftClickedSignal.connect(
         boost::bind(&MultiPlayerLobbyWnd::CancelClicked, this));
+
+    CUIWnd::CompleteConstruction();
 
     Refresh();
 }

--- a/UI/MultiplayerLobbyWnd.h
+++ b/UI/MultiplayerLobbyWnd.h
@@ -17,6 +17,7 @@ class MultiPlayerLobbyWnd : public CUIWnd {
 public:
     /** \name Structors */ //@{
     MultiPlayerLobbyWnd();
+    void CompleteConstruction() override;
     //@}
 
     /** \name Accessors */ //@{

--- a/UI/MultiplayerLobbyWnd.h
+++ b/UI/MultiplayerLobbyWnd.h
@@ -42,6 +42,8 @@ protected:
     struct PlayerLabelRow : GG::ListBox::Row {
         PlayerLabelRow(GG::X width = GG::X(600));
 
+        void CompleteConstruction() override;
+
         /** Set text of control at @p column to @p str */
         void SetText(size_t column, const std::string& str);
 

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -1034,8 +1034,7 @@ FilterDialog::FilterDialog(const std::map<UniverseObjectType, std::set<VIS_DISPL
     m_condition_widget = GG::Wnd::Create<ConditionWidget>(GG::X(3), GG::Y(3), condition_filter);
 }
 
-void FilterDialog::CompleteConstruction()
-{
+void FilterDialog::CompleteConstruction() {
     CUIWnd::CompleteConstruction();
 
     m_filters_layout = GG::Wnd::Create<GG::Layout>(GG::X0, GG::Y0, GG::X(390), GG::Y(90), 4, 7);
@@ -2301,8 +2300,7 @@ ObjectListWnd::ObjectListWnd(const std::string& config_name) :
     m_collapse_button(nullptr)
 {}
 
-void ObjectListWnd::CompleteConstruction()
-{
+void ObjectListWnd::CompleteConstruction() {
     m_list_box = GG::Wnd::Create<ObjectListBox>();
     m_list_box->SetHiliteColor(GG::CLR_ZERO);
     m_list_box->SetStyle(GG::LIST_NOSORT);

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -542,14 +542,22 @@ private:
     public:
         ConditionRow(const std::string& key, GG::Y row_height) :
             GG::ListBox::Row(GG::X1, row_height, ""),
-            m_condition_key(key)
+            m_condition_key(key),
+            m_label(GG::Wnd::Create<CUILabel>(UserString(m_condition_key), GG::FORMAT_LEFT | GG::FORMAT_NOWRAP))
+        {}
+
+        void CompleteConstruction() override
         {
+            GG::ListBox::Row::CompleteConstruction();
+
             SetChildClippingMode(ClipToClient);
-            push_back(GG::Wnd::Create<CUILabel>(UserString(m_condition_key), GG::FORMAT_LEFT | GG::FORMAT_NOWRAP));
+            push_back(m_label);
         }
+
         const std::string&  GetKey() const { return m_condition_key; }
     private:
         std::string m_condition_key;
+        CUILabel* m_label;
     };
 
     class StringRow : public GG::ListBox::Row  {
@@ -558,14 +566,23 @@ private:
             GG::ListBox::Row(GG::X1, row_height, ""),
             m_string(text)
         {
-            SetChildClippingMode(ClipToClient);
             const std::string& label = (text.empty() ? EMPTY_STRING :
                 (stringtable_lookup ? UserString(text) : text));
-            push_back(GG::Wnd::Create<CUILabel>(label, GG::FORMAT_LEFT | GG::FORMAT_NOWRAP));
+            m_label = GG::Wnd::Create<CUILabel>(label, GG::FORMAT_LEFT | GG::FORMAT_NOWRAP);
         }
+
+        void CompleteConstruction() override
+        {
+            GG::ListBox::Row::CompleteConstruction();
+
+            SetChildClippingMode(ClipToClient);
+            push_back(m_label);
+        }
+
         const std::string&  Text() const { return m_string; }
     private:
         std::string m_string;
+        CUILabel* m_label;
     };
 
     const std::string&              GetString() {
@@ -1493,13 +1510,15 @@ public:
         m_obj_init(obj),
         m_expanded_init(expanded),
         m_indent_init(indent)
+    {}
+
+    void CompleteConstruction() override
     {
+        GG::ListBox::Row::CompleteConstruction();
+
         SetName("ObjectRow");
         SetChildClippingMode(ClipToClient);
-        Init();
-    }
 
-    void Init() {
         m_panel = GG::Wnd::Create<ObjectPanel>(ClientWidth() - GG::X(2 * GetLayout()->BorderMargin()),
                                                ClientHeight() - GG::Y(2 * GetLayout()->BorderMargin()),
                                                m_obj_init, m_expanded_init, !m_contained_object_panels.empty(), m_indent_init);
@@ -1710,6 +1729,12 @@ public:
         m_panel(nullptr)
     {
         m_panel = GG::Wnd::Create<ObjectHeaderPanel>(w, h);
+    }
+
+    void CompleteConstruction() override
+    {
+        GG::ListBox::Row::CompleteConstruction();
+
         push_back(m_panel);
         m_panel->ColumnButtonLeftClickSignal.connect(
             ColumnHeaderLeftClickSignal);

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -1797,7 +1797,11 @@ public:
         m_filter_condition(nullptr),
         m_visibilities(),
         m_header_row(nullptr)
-    {
+    {}
+
+    void CompleteConstruction() override {
+        CUIListBox::CompleteConstruction();
+
         // preinitialize listbox/row column widths, because what
         // ListBox::Insert does on default is not suitable for this case
         ManuallyManageColProps();

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -390,6 +390,16 @@ public:
         }
     }
 
+    void CompleteConstruction() override {
+        GG::Control::CompleteConstruction();
+        AttachChild(m_class_drop);
+        SetMinSize(m_class_drop->Size());
+
+        UpdateParameterControls();
+
+        // TODO: set newly created parameter controls' values based on init condition
+    }
+
     ~ConditionWidget() {
         delete m_class_drop;
         delete m_string_drop;
@@ -690,7 +700,6 @@ private:
         m_class_drop = GG::Wnd::Create<CUIDropDownList>(DropListDropHeight());
         m_class_drop->Resize(GG::Pt(DropListWidth(), DropListHeight()));
         m_class_drop->SetStyle(GG::LIST_NOSORT);
-        AttachChild(m_class_drop);
 
         std::vector<std::string> row_keys ={ALL_CONDITION,              PLANETTYPE_CONDITION,       PLANETSIZE_CONDITION,
                                             HASGROWTHSPECIAL_CONDITION, GGWITHPTYPE_CONDITION,      ASTWITHPTYPE_CONDITION,
@@ -700,7 +709,6 @@ private:
                                             CANCOLONIZE_CONDITION,      HOMEWORLD_CONDITION,        METERVALUE_CONDITION,
                                             CAPITAL_CONDITION };
 
-        SetMinSize(m_class_drop->Size());
         GG::ListBox::iterator select_row_it = m_class_drop->end();
         const std::string& init_condition_key = ConditionClassName(init_condition);
 
@@ -719,9 +727,6 @@ private:
         else if (!m_class_drop->Empty())
             m_class_drop->Select(0);
 
-        UpdateParameterControls();
-
-        // TODO: set newly created parameter controls' values based on init condition
     }
 
     void    ConditionClassSelected(GG::ListBox::iterator iterator)
@@ -1026,7 +1031,7 @@ FilterDialog::FilterDialog(const std::map<UniverseObjectType, std::set<VIS_DISPL
     m_cancel_button(nullptr),
     m_apply_button(nullptr)
 {
-    m_condition_widget = new ConditionWidget(GG::X(3), GG::Y(3), condition_filter);
+    m_condition_widget = GG::Wnd::Create<ConditionWidget>(GG::X(3), GG::Y(3), condition_filter);
 }
 
 void FilterDialog::CompleteConstruction()

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -556,8 +556,7 @@ private:
             m_label(GG::Wnd::Create<CUILabel>(UserString(m_condition_key), GG::FORMAT_LEFT | GG::FORMAT_NOWRAP))
         {}
 
-        void CompleteConstruction() override
-        {
+        void CompleteConstruction() override {
             GG::ListBox::Row::CompleteConstruction();
 
             SetChildClippingMode(ClipToClient);
@@ -581,8 +580,7 @@ private:
             m_label = GG::Wnd::Create<CUILabel>(label, GG::FORMAT_LEFT | GG::FORMAT_NOWRAP);
         }
 
-        void CompleteConstruction() override
-        {
+        void CompleteConstruction() override {
             GG::ListBox::Row::CompleteConstruction();
 
             SetChildClippingMode(ClipToClient);
@@ -1516,8 +1514,7 @@ public:
         m_indent_init(indent)
     {}
 
-    void CompleteConstruction() override
-    {
+    void CompleteConstruction() override {
         GG::ListBox::Row::CompleteConstruction();
 
         SetName("ObjectRow");
@@ -1735,8 +1732,7 @@ public:
         m_panel = GG::Wnd::Create<ObjectHeaderPanel>(w, h);
     }
 
-    void CompleteConstruction() override
-    {
+    void CompleteConstruction() override {
         GG::ListBox::Row::CompleteConstruction();
 
         push_back(m_panel);

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -960,6 +960,7 @@ class FilterDialog : public CUIWnd {
 public:
     FilterDialog(const std::map<UniverseObjectType, std::set<VIS_DISPLAY>>& vis_filters,
                  const Condition::ConditionBase* const condition_filter);
+    void CompleteConstruction() override;
 
     bool ChangesAccepted();
 
@@ -1008,6 +1009,13 @@ FilterDialog::FilterDialog(const std::map<UniverseObjectType, std::set<VIS_DISPL
     m_cancel_button(nullptr),
     m_apply_button(nullptr)
 {
+    m_condition_widget = new ConditionWidget(GG::X(3), GG::Y(3), condition_filter);
+}
+
+void FilterDialog::CompleteConstruction()
+{
+    CUIWnd::CompleteConstruction();
+
     m_filters_layout = GG::Wnd::Create<GG::Layout>(GG::X0, GG::Y0, GG::X(390), GG::Y(90), 4, 7);
     AttachChild(m_filters_layout);
 
@@ -1073,7 +1081,7 @@ FilterDialog::FilterDialog(const std::map<UniverseObjectType, std::set<VIS_DISPL
 
 
     // TODO: Add multiple condition widgets initialized for input condition
-    m_condition_widget = new ConditionWidget(GG::X(3), m_filters_layout->Height() + GG::Y(3), condition_filter);
+    m_condition_widget->MoveTo(GG::Pt(GG::X(3), m_filters_layout->Height() + GG::Y(3)));
     m_cancel_button = Wnd::Create<CUIButton>(UserString("CANCEL"));
     m_apply_button = Wnd::Create<CUIButton>(UserString("APPLY"));
 
@@ -2257,6 +2265,9 @@ ObjectListWnd::ObjectListWnd(const std::string& config_name) :
     m_list_box(nullptr),
     m_filter_button(nullptr),
     m_collapse_button(nullptr)
+{}
+
+void ObjectListWnd::CompleteConstruction()
 {
     m_list_box = GG::Wnd::Create<ObjectListBox>();
     m_list_box->SetHiliteColor(GG::CLR_ZERO);
@@ -2281,6 +2292,8 @@ ObjectListWnd::ObjectListWnd(const std::string& config_name) :
     m_collapse_button->LeftClickedSignal.connect(
         boost::bind(&ObjectListWnd::CollapseExpandClicked, this));
     AttachChild(m_collapse_button);
+
+    CUIWnd::CompleteConstruction();
 
     DoLayout();
 }
@@ -2582,12 +2595,12 @@ int ObjectListWnd::ObjectInRow(GG::ListBox::iterator it) const {
 }
 
 void ObjectListWnd::FilterClicked() {
-    FilterDialog dlg(m_list_box->Visibilities(), m_list_box->FilterCondition());
-    dlg.Run();
+    auto dlg = GG::Wnd::Create<FilterDialog>(m_list_box->Visibilities(), m_list_box->FilterCondition());
+    dlg->Run();
 
-    if (dlg.ChangesAccepted()) {
-        m_list_box->SetVisibilityFilters(dlg.GetVisibilityFilters());
-        m_list_box->SetFilterCondition(dlg.GetConditionFilter());
+    if (dlg->ChangesAccepted()) {
+        m_list_box->SetVisibilityFilters(dlg->GetVisibilityFilters());
+        m_list_box->SetFilterCondition(dlg->GetConditionFilter());
     }
 }
 

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -1066,7 +1066,7 @@ void FilterDialog::CompleteConstruction()
         int row = 1;
 
         for (auto visibility : {SHOW_VISIBLE, SHOW_PREVIOUSLY_VISIBLE, SHOW_DESTROYED}) {
-            auto button = new CUIStateButton(" ", GG::FORMAT_CENTER, std::make_shared<CUICheckBoxRepresenter>());
+            auto button = GG::Wnd::Create<CUIStateButton>(" ", GG::FORMAT_CENTER, std::make_shared<CUICheckBoxRepresenter>());
             button->SetCheck(vis_display.count(visibility));
             m_filters_layout->Add(button, row, col, GG::ALIGN_CENTER | GG::ALIGN_VCENTER);
             button->CheckedSignal.connect(

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -1028,7 +1028,7 @@ FilterDialog::FilterDialog(const std::map<UniverseObjectType, std::set<VIS_DISPL
         const auto visibility = std::get<0>(entry);
         const auto label_key = std::get<1>(entry);
 
-        label = new CUIButton(UserString(label_key));
+        label = Wnd::Create<CUIButton>(UserString(label_key));
         label->Resize(GG::Pt(button_width, label->MinUsableSize().y));
         m_filters_layout->Add(label, row, 0, GG::ALIGN_CENTER);
         label->LeftClickedSignal.connect(
@@ -1050,7 +1050,7 @@ FilterDialog::FilterDialog(const std::map<UniverseObjectType, std::set<VIS_DISPL
 
         m_filters_layout->SetColumnStretch(col, 1.0);
 
-        label = new CUIButton(" " + UserString(boost::lexical_cast<std::string>(uot)) + " ");
+        label = Wnd::Create<CUIButton>(" " + UserString(boost::lexical_cast<std::string>(uot)) + " ");
         m_filters_layout->Add(label, 0, col, GG::ALIGN_CENTER | GG::ALIGN_VCENTER);
         label->LeftClickedSignal.connect(
             boost::bind(&FilterDialog::UpdateVisFiltersFromObjectTypeButton, this, uot));
@@ -1074,8 +1074,8 @@ FilterDialog::FilterDialog(const std::map<UniverseObjectType, std::set<VIS_DISPL
 
     // TODO: Add multiple condition widgets initialized for input condition
     m_condition_widget = new ConditionWidget(GG::X(3), m_filters_layout->Height() + GG::Y(3), condition_filter);
-    m_cancel_button = new CUIButton(UserString("CANCEL"));
-    m_apply_button = new CUIButton(UserString("APPLY"));
+    m_cancel_button = Wnd::Create<CUIButton>(UserString("CANCEL"));
+    m_apply_button = Wnd::Create<CUIButton>(UserString("APPLY"));
 
     AttachChild(m_condition_widget);
     AttachChild(m_cancel_button);
@@ -1326,12 +1326,12 @@ public:
             boost::filesystem::path button_texture_dir = ClientUI::ArtDir() / "icons" / "buttons";
 
             if (m_expanded) {
-                m_expand_button = new CUIButton(
+                m_expand_button = Wnd::Create<CUIButton>(
                     GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "minusnormal.png"     , true)),
                     GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "minusclicked.png"    , true)),
                     GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "minusmouseover.png"  , true)));
             } else {
-                m_expand_button = new CUIButton(
+                m_expand_button = Wnd::Create<CUIButton>(
                     GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "plusnormal.png"   , true)),
                     GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "plusclicked.png"  , true)),
                     GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "plusmouseover.png", true)));
@@ -1674,7 +1674,7 @@ private:
     std::vector<GG::Button*>    GetControls() {
         std::vector<GG::Button*> retval;
 
-        auto control = new CUIButton("-");
+        auto control = Wnd::Create<CUIButton>("-");
         retval.push_back(control);
 
         for (unsigned int i = 0; i < NUM_COLUMNS; ++i) {
@@ -1682,7 +1682,7 @@ private:
             const std::string& header_name = GetColumnName(static_cast<int>(i));
             if (!header_name.empty())
                 text = UserString(header_name);
-            control = new CUIButton(text);
+            control = Wnd::Create<CUIButton>(text);
             retval.push_back(control);
         }
 
@@ -2272,12 +2272,12 @@ ObjectListWnd::ObjectListWnd(const std::string& config_name) :
         boost::bind(&ObjectListWnd::DoLayout, this));
     AttachChild(m_list_box);
 
-    m_filter_button = new CUIButton(UserString("FILTERS"));
+    m_filter_button = Wnd::Create<CUIButton>(UserString("FILTERS"));
     m_filter_button->LeftClickedSignal.connect(
         boost::bind(&ObjectListWnd::FilterClicked, this));
     AttachChild(m_filter_button);
 
-    m_collapse_button = new CUIButton(UserString("COLLAPSE_ALL"));
+    m_collapse_button = Wnd::Create<CUIButton>(UserString("COLLAPSE_ALL"));
     m_collapse_button->LeftClickedSignal.connect(
         boost::bind(&ObjectListWnd::CollapseExpandClicked, this));
     AttachChild(m_collapse_button);

--- a/UI/ObjectListWnd.h
+++ b/UI/ObjectListWnd.h
@@ -13,6 +13,7 @@ class ObjectListWnd : public CUIWnd {
 public:
     //! \name Structors //!@{
     ObjectListWnd(const std::string& config_name = "");
+    void CompleteConstruction() override;
     //!@}
 
     /** \name Mutators */ //@{

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -96,14 +96,14 @@ namespace {
 
         void operator()() {
             try {
-                FileDlg dlg(m_path.string(), m_edit->Text(), false, false, m_filters);
+                auto dlg = GG::Wnd::Create<FileDlg>(m_path.string(), m_edit->Text(), false, false, m_filters);
                 if (m_directory)
-                    dlg.SelectDirectories(true);
-                dlg.Run();
-                if (!dlg.Result().empty()) {
+                    dlg->SelectDirectories(true);
+                dlg->Run();
+                if (!dlg->Result().empty()) {
                     fs::path path = m_return_relative_path ?
-                        RelativePath(m_path, fs::path(*dlg.Result().begin())) :
-                    fs::absolute(*dlg.Result().begin());
+                        RelativePath(m_path, fs::path(*(dlg->Result().begin()))) :
+                        fs::absolute(*(dlg->Result().begin()));
                     *m_edit << path.string();
                     m_edit->EditedSignal(m_edit->Text());
                 }

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -256,7 +256,7 @@ namespace {
             }
 
 
-            m_hscroll = new CUIScroll(GG::HORIZONTAL);
+            m_hscroll =  GG::Wnd::Create<CUIScroll>(GG::HORIZONTAL);
             AttachChild(m_hscroll);
 
             m_hscroll->ScrolledSignal.connect(

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -54,12 +54,17 @@ namespace {
     public:
         RowContentsWnd(GG::X w, GG::Y h, Wnd* contents, int indentation_level) :
             Control(GG::X0, GG::Y0, w, h, GG::INTERACTIVE),
-            m_contents(contents)
-        {
+            m_contents(contents),
+            m_indentation_level(indentation_level)
+        {}
+
+        void CompleteConstruction() override {
+            GG::Control::CompleteConstruction();
+
             if (!m_contents)
                 return;
             AttachChild(m_contents);
-            m_contents->MoveTo(GG::Pt(GG::X(indentation_level * INDENTATION), GG::Y0));
+            m_contents->MoveTo(GG::Pt(GG::X(m_indentation_level * INDENTATION), GG::Y0));
             DoLayout();
         }
 
@@ -82,6 +87,7 @@ namespace {
         }
     private:
         Wnd* m_contents;
+        int m_indentation_level;
     };
 
     struct BrowseForPathButtonFunctor {

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -450,8 +450,7 @@ OptionsWnd::OptionsWnd():
     m_done_button(nullptr)
 {}
 
-void OptionsWnd::CompleteConstruction()
-{
+void OptionsWnd::CompleteConstruction() {
     m_done_button = Wnd::Create<CUIButton>(UserString("DONE"));
     // FIXME: PAGE_WIDTH is needed to prevent triggering an assert within the TabBar class.
     // The placement of the tab register buttons assumes that the whole TabWnd is at least

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -447,8 +447,8 @@ void OptionsWnd::CompleteConstruction()
     // FIXME: PAGE_WIDTH is needed to prevent triggering an assert within the TabBar class.
     // The placement of the tab register buttons assumes that the whole TabWnd is at least
     // wider than the first tab button.
-    m_tabs = new GG::TabWnd(GG::X0, GG::Y0, PAGE_WIDTH, GG::Y1, ClientUI::GetFont(),
-                            ClientUI::WndColor(), ClientUI::TextColor());
+    m_tabs = GG::Wnd::Create<GG::TabWnd>(GG::X0, GG::Y0, PAGE_WIDTH, GG::Y1, ClientUI::GetFont(),
+                                         ClientUI::WndColor(), ClientUI::TextColor());
 
     CUIWnd::CompleteConstruction();
 

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -232,8 +232,7 @@ namespace {
             m_hscroll(nullptr)
         {}
 
-        void CompleteConstruction() override
-        {
+        void CompleteConstruction() override {
             CUIWnd::CompleteConstruction();
 
             GG::Y top = GG::Y1;
@@ -328,8 +327,7 @@ namespace {
                 m_contents = GG::Wnd::Create<RowContentsWnd>(w, h, contents, indentation);
         }
 
-        void CompleteConstruction() override
-        {
+        void CompleteConstruction() override {
             GG::ListBox::Row::CompleteConstruction();
             if (m_contents)
                 push_back(m_contents);

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -224,7 +224,12 @@ namespace {
             m_font_graphic(nullptr),
             m_title_font_graphic(nullptr),
             m_hscroll(nullptr)
+        {}
+
+        void CompleteConstruction() override
         {
+            CUIWnd::CompleteConstruction();
+
             GG::Y top = GG::Y1;
 
             std::shared_ptr<GG::Font> font = ClientUI::GetFont();
@@ -259,6 +264,7 @@ namespace {
             DoLayout();
         }
 
+    public:
         void SizeMove(const GG::Pt& ul, const GG::Pt& lr) override {
             GG::Pt old_size = GG::Wnd::Size();
 
@@ -293,7 +299,7 @@ namespace {
     };
 
     void ShowFontTextureWnd() {
-        auto font_wnd = new FontTextureWnd();
+        auto font_wnd =  GG::Wnd::Create<FontTextureWnd>();
         font_wnd->Run();
         delete font_wnd;
     }
@@ -433,6 +439,9 @@ OptionsWnd::OptionsWnd():
            OPTIONS_WND_NAME),
     m_tabs(nullptr),
     m_done_button(nullptr)
+{}
+
+void OptionsWnd::CompleteConstruction()
 {
     m_done_button = Wnd::Create<CUIButton>(UserString("DONE"));
     // FIXME: PAGE_WIDTH is needed to prevent triggering an assert within the TabBar class.
@@ -440,6 +449,8 @@ OptionsWnd::OptionsWnd():
     // wider than the first tab button.
     m_tabs = new GG::TabWnd(GG::X0, GG::Y0, PAGE_WIDTH, GG::Y1, ClientUI::GetFont(),
                             ClientUI::WndColor(), ClientUI::TextColor());
+
+    CUIWnd::CompleteConstruction();
 
     ResetDefaultPosition();
     SetMinSize(GG::Pt(PAGE_WIDTH + 20, PAGE_HEIGHT + 70));

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -311,8 +311,6 @@ namespace {
             m_contents(contents)
         {
             SetChildClippingMode(ClipToClient);
-            if (m_contents)
-                push_back(m_contents);
         }
 
         OptionsListRow(GG::X w, GG::Y h, Wnd* contents, int indentation = 0) :
@@ -320,10 +318,15 @@ namespace {
             m_contents(nullptr)
         {
             SetChildClippingMode(ClipToClient);
-            if (contents) {
+            if (contents)
                 m_contents = GG::Wnd::Create<RowContentsWnd>(w, h, contents, indentation);
+        }
+
+        void CompleteConstruction() override
+        {
+            GG::ListBox::Row::CompleteConstruction();
+            if (m_contents)
                 push_back(m_contents);
-            }
         }
 
         void SizeMove(const GG::Pt& ul, const GG::Pt& lr) override {

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -434,7 +434,7 @@ OptionsWnd::OptionsWnd():
     m_tabs(nullptr),
     m_done_button(nullptr)
 {
-    m_done_button = new CUIButton(UserString("DONE"));
+    m_done_button = Wnd::Create<CUIButton>(UserString("DONE"));
     // FIXME: PAGE_WIDTH is needed to prevent triggering an assert within the TabBar class.
     // The placement of the tab register buttons assumes that the whole TabWnd is at least
     // wider than the first tab button.
@@ -989,7 +989,7 @@ void OptionsWnd::FileOptionImpl(GG::ListBox* page, int indentation_level, const 
     auto text_control = GG::Wnd::Create<CUILabel>(text, GG::FORMAT_LEFT | GG::FORMAT_NOWRAP, GG::INTERACTIVE);
     auto edit = GG::Wnd::Create<CUIEdit>(GetOptionsDB().Get<std::string>(option_name));
     edit->Resize(GG::Pt(50*SPIN_WIDTH, edit->Height())); // won't resize within layout bigger than its initial size, so giving a big initial size here
-    auto button = new CUIButton("...");
+    auto button = Wnd::Create<CUIButton>("...");
 
     auto layout = GG::Wnd::Create<GG::Layout>(GG::X0, GG::Y0, ROW_WIDTH, button->MinUsableSize().y,
                                               1, 3, 0, 5);

--- a/UI/OptionsWnd.h
+++ b/UI/OptionsWnd.h
@@ -18,6 +18,7 @@ public:
     //! \name Structors
     //!@{
     OptionsWnd();
+    void CompleteConstruction() override;
 
     ~OptionsWnd();
     //!@}

--- a/UI/PlayerListWnd.cpp
+++ b/UI/PlayerListWnd.cpp
@@ -119,7 +119,12 @@ namespace {
             m_host(false),
             m_win_status(NEITHER),
             m_selected(false)
+        {}
+
+        void CompleteConstruction() override
         {
+            GG::Control::CompleteConstruction();
+
             SetChildClippingMode(ClipToClient);
 
             //m_player_name_text = GG::Wnd::Create<CUILabel>("", GG::FORMAT_LEFT);

--- a/UI/PlayerListWnd.cpp
+++ b/UI/PlayerListWnd.cpp
@@ -461,7 +461,13 @@ namespace {
         {
             SetName("PlayerRow");
             SetChildClippingMode(ClipToClient);
-            m_panel = GG::Wnd::Create<PlayerDataPanel>(w, h, m_player_id);
+        }
+
+        void CompleteConstruction() override
+        {
+
+            GG::ListBox::Row::CompleteConstruction();
+            m_panel = GG::Wnd::Create<PlayerDataPanel>(Width(), Height(), m_player_id);
             push_back(m_panel);
         }
 

--- a/UI/PlayerListWnd.cpp
+++ b/UI/PlayerListWnd.cpp
@@ -121,8 +121,7 @@ namespace {
             m_selected(false)
         {}
 
-        void CompleteConstruction() override
-        {
+        void CompleteConstruction() override {
             GG::Control::CompleteConstruction();
 
             SetChildClippingMode(ClipToClient);
@@ -468,8 +467,7 @@ namespace {
             SetChildClippingMode(ClipToClient);
         }
 
-        void CompleteConstruction() override
-        {
+        void CompleteConstruction() override {
 
             GG::ListBox::Row::CompleteConstruction();
             m_panel = GG::Wnd::Create<PlayerDataPanel>(Width(), Height(), m_player_id);

--- a/UI/PlayerListWnd.cpp
+++ b/UI/PlayerListWnd.cpp
@@ -551,8 +551,7 @@ PlayerListWnd::PlayerListWnd(const std::string& config_name) :
     m_player_list(nullptr)
 {}
 
-void PlayerListWnd::CompleteConstruction()
-{
+void PlayerListWnd::CompleteConstruction() {
     CUIWnd::CompleteConstruction();
 
     m_player_list = GG::Wnd::Create<PlayerListBox>();

--- a/UI/PlayerListWnd.cpp
+++ b/UI/PlayerListWnd.cpp
@@ -538,7 +538,12 @@ PlayerListWnd::PlayerListWnd(const std::string& config_name) :
            GG::INTERACTIVE | GG::DRAGABLE | GG::ONTOP | GG::RESIZABLE | CLOSABLE | PINABLE,
            config_name),
     m_player_list(nullptr)
+{}
+
+void PlayerListWnd::CompleteConstruction()
 {
+    CUIWnd::CompleteConstruction();
+
     m_player_list = GG::Wnd::Create<PlayerListBox>();
     m_player_list->SetHiliteColor(GG::CLR_ZERO);
     m_player_list->SetStyle(GG::LIST_NOSORT);
@@ -658,7 +663,10 @@ void PlayerListWnd::SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
 }
 
 void PlayerListWnd::DoLayout()
-{ m_player_list->SizeMove(GG::Pt(), GG::Pt(ClientWidth(), ClientHeight() - GG::Y(INNER_BORDER_ANGLE_OFFSET))); }
+{
+    if (m_player_list)
+        m_player_list->SizeMove(GG::Pt(), GG::Pt(ClientWidth(), ClientHeight() - GG::Y(INNER_BORDER_ANGLE_OFFSET)));
+}
 
 void PlayerListWnd::CloseClicked()
 { ClosingSignal(); }

--- a/UI/PlayerListWnd.h
+++ b/UI/PlayerListWnd.h
@@ -11,6 +11,7 @@ class PlayerListWnd : public CUIWnd {
 public:
     //! \name Structors //@{
     PlayerListWnd(const std::string& config_name);
+    void CompleteConstruction() override;
     //@}
 
     //! \name Accessors //@{

--- a/UI/PopulationPanel.cpp
+++ b/UI/PopulationPanel.cpp
@@ -32,7 +32,11 @@ PopulationPanel::PopulationPanel(GG::X w, int object_id) :
     m_meter_stats(),
     m_multi_icon_value_indicator(nullptr),
     m_multi_meter_status_bar(nullptr)
+{}
+
+void PopulationPanel::CompleteConstruction()
 {
+    AccordionPanel::CompleteConstruction();
     SetName("PopulationPanel");
 
     std::shared_ptr<const PopCenter> pop = GetPopCenter();

--- a/UI/PopulationPanel.cpp
+++ b/UI/PopulationPanel.cpp
@@ -169,12 +169,11 @@ void PopulationPanel::Update() {
     m_multi_icon_value_indicator->Update();
 
     // tooltips
-    std::shared_ptr<GG::BrowseInfoWnd> browse_wnd;
-
     for (auto& meter_stat : m_meter_stats) {
         meter_stat.second->SetValue(pop->InitialMeterValue(meter_stat.first));
 
-        browse_wnd = std::make_shared<MeterBrowseWnd>(m_popcenter_id, meter_stat.first, AssociatedMeterType(meter_stat.first));
+        // TODO remove extra wrapping of shared_ptr after conversion to GG shared_ptr
+        auto browse_wnd = std::shared_ptr<GG::BrowseInfoWnd>(GG::Wnd::Create<MeterBrowseWnd>(m_popcenter_id, meter_stat.first, AssociatedMeterType(meter_stat.first)));
         meter_stat.second->SetBrowseInfoWnd(browse_wnd);
         m_multi_icon_value_indicator->SetToolTip(meter_stat.first, browse_wnd);
     }

--- a/UI/PopulationPanel.cpp
+++ b/UI/PopulationPanel.cpp
@@ -34,8 +34,7 @@ PopulationPanel::PopulationPanel(GG::X w, int object_id) :
     m_multi_meter_status_bar(nullptr)
 {}
 
-void PopulationPanel::CompleteConstruction()
-{
+void PopulationPanel::CompleteConstruction() {
     AccordionPanel::CompleteConstruction();
     SetName("PopulationPanel");
 

--- a/UI/PopulationPanel.h
+++ b/UI/PopulationPanel.h
@@ -19,6 +19,7 @@ public:
     PopulationPanel(GG::X w, int object_id);
     ~PopulationPanel();
     //@}
+    void CompleteConstruction() override;
 
     /** \name Accessors */ //@{
     int PopCenterID() const { return m_popcenter_id; }

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -321,7 +321,8 @@ namespace {
             title_text = std::to_string(elem.blocksize) + "x ";
         title_text += item_name;
 
-        return std::make_shared<IconTextBrowseWnd>(icon, title_text, main_text);
+        // TODO remove extra wrapping of shared_ptr after conversion to GG shared_ptr
+        return std::shared_ptr<GG::BrowseInfoWnd>(GG::Wnd::Create<IconTextBrowseWnd>(icon, title_text, main_text));
     }
 
     //////////////////////////////////////////////////

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -654,6 +654,9 @@ namespace {
             QueueListBox(BuildDesignatorWnd::PRODUCTION_ITEM_DROP_TYPE,  UserString("PRODUCTION_QUEUE_PROMPT"))
         {}
 
+        void CompleteConstruction() override
+        { QueueListBox::CompleteConstruction(); }
+
         boost::signals2::signal<void (GG::ListBox::iterator, int)>  QueueItemRalliedToSignal;
         boost::signals2::signal<void ()>                            ShowPediaSignal;
         boost::signals2::signal<void (GG::ListBox::iterator, bool)> QueueItemPausedSignal;

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -808,8 +808,7 @@ ProductionWnd::ProductionWnd(GG::X w, GG::Y h) :
     m_empire_shown_id(ALL_EMPIRES)
 {}
 
-void ProductionWnd::CompleteConstruction()
-{
+void ProductionWnd::CompleteConstruction() {
      GG::Wnd::CompleteConstruction();
    //DebugLogger() << "ProductionWindow:  app-width: "<< GetOptionsDB().Get<int>("app-width")
     //              << " ; windowed width: " << GetOptionsDB().Get<int>("app-width-windowed");

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -54,15 +54,21 @@ namespace {
             else
                 nameText = boost::io::str(FlexibleFormat(UserString("PRODUCTION_QUEUE_REPETITIONS")) % quantity);
             //nameText += GetShipDesign(designID)->Name();
-            auto text = GG::Wnd::Create<CUILabel>(nameText, GG::FORMAT_TOP | GG::FORMAT_LEFT | GG::FORMAT_NOWRAP);
-            text->SetTextColor(txtClr);
-            text->OffsetMove(GG::Pt(GG::X0, GG::Y(-3)));
-            AttachChild(text);
-            Resize(GG::Pt(nwidth, text->Height()));
+            m_text = GG::Wnd::Create<CUILabel>(nameText, GG::FORMAT_TOP | GG::FORMAT_LEFT | GG::FORMAT_NOWRAP);
+            m_text->SetTextColor(txtClr);
+            m_text->OffsetMove(GG::Pt(GG::X0, GG::Y(-3)));
+        }
+
+        void CompleteConstruction() override {
+            GG::Control::CompleteConstruction();
+            AttachChild(m_text);
+            Resize(GG::Pt(Width(), m_text->Height()));
         }
 
         void Render() override
         {}
+
+        CUILabel* m_text;
     };
 
     //////////////
@@ -202,6 +208,7 @@ namespace {
                                  const ProductionQueue::Element& build, double turn_cost, double total_cost,
                                  int turns, int number, double completed_progress);
 
+        void CompleteConstruction() override;
         void PreRender() override;
         void Render() override;
         void SizeMove(const GG::Pt& ul, const GG::Pt& lr) override;
@@ -415,7 +422,10 @@ namespace {
         m_turn_spending(turn_spending),
         m_total_cost(total_cost),
         m_completed_progress(completed_progress)
-    {
+    {}
+
+    void QueueProductionItemPanel::CompleteConstruction() {
+    GG::Control::CompleteConstruction();
         SetChildClippingMode(ClipToClient);
 
         GG::Clr clr = m_in_progress

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -73,17 +73,23 @@ namespace {
         QuantRow(int quantity, int designID, GG::X nwidth, GG::Y h,
                  bool inProgress, bool amBlockType) :
             GG::ListBox::Row(),
-            m_quant(quantity)
+            m_quant(quantity),
+            m_label(GG::Wnd::Create<QuantLabel>(m_quant, designID, nwidth, h, inProgress, amBlockType))
+        {}
+
+        void CompleteConstruction() override
         {
-            auto newLabel = GG::Wnd::Create<QuantLabel>(m_quant, designID, nwidth, h, inProgress, amBlockType);
-            push_back(newLabel);
-            Resize(GG::Pt(nwidth, newLabel->Height()-GG::Y0));//might subtract more; assessing aesthetics
+            GG::ListBox::Row::CompleteConstruction();
+
+            push_back(m_label);
+            Resize(GG::Pt(m_label->Width(), m_label->Height()-GG::Y0));//might subtract more; assessing aesthetics
         }
 
         int Quant() const { return m_quant; }
 
     private:
         int m_quant;
+        QuantLabel* m_label;
     };
 
     //////////////////////
@@ -337,11 +343,10 @@ namespace {
             if (pp_accumulated == -1.0f)
                 pp_accumulated = 0.0f;
 
-            panel = GG::Wnd::Create<QueueProductionItemPanel>(GG::X0, GG::Y0, ClientWidth() - MARGIN - MARGIN,
-                                                              elem, elem.allocated_pp, total_cost, minimum_turns, elem.remaining,
-                                                              pp_accumulated);
-            push_back(panel);
-
+            panel = GG::Wnd::Create<QueueProductionItemPanel>(
+                GG::X0, GG::Y0, ClientWidth() - MARGIN - MARGIN,
+                elem, elem.allocated_pp, total_cost, minimum_turns, elem.remaining,
+                pp_accumulated);
             SetDragDropDataType(BuildDesignatorWnd::PRODUCTION_ITEM_DROP_TYPE);
 
             SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
@@ -351,6 +356,13 @@ namespace {
                 boost::bind(&QueueRow::RowQuantChanged, this, _1, _2));
 
             RequirePreRender();
+        }
+
+        void CompleteConstruction() override
+        {
+            GG::ListBox::Row::CompleteConstruction();
+
+            push_back(panel);
         }
 
         void PreRender() override {
@@ -379,6 +391,7 @@ namespace {
         const int                                           queue_index;
         const ProductionQueue::Element                      elem;
         mutable boost::signals2::signal<void (int,int,int)> RowQuantChangedSignal;
+
     };
 
     //////////////////////////////////////////////////

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -724,6 +724,9 @@ public:
         CUIWnd("", x, y, w, h, GG::INTERACTIVE | GG::RESIZABLE | GG::DRAGABLE | GG::ONTOP | PINABLE,
                "production.ProductionQueueWnd"),
         m_queue_lb(nullptr)
+    {}
+
+    void CompleteConstruction() override
     {
         m_queue_lb = GG::Wnd::Create<ProdQueueListBox>();
         m_queue_lb->SetStyle(GG::LIST_NOSORT | GG::LIST_NOSEL | GG::LIST_USERDELETE);
@@ -732,6 +735,9 @@ public:
         SetEmpire(HumanClientApp::GetApp()->EmpireID());
 
         AttachChild(m_queue_lb);
+
+        CUIWnd::CompleteConstruction();
+
         DoLayout();
     }
     //@}
@@ -780,7 +786,7 @@ ProductionWnd::ProductionWnd(GG::X w, GG::Y h) :
     GG::X queue_width(GetOptionsDB().Get<int>("UI.queue-width"));
     GG::Y info_height(ClientUI::Pts()*8);
 
-    m_production_info_panel = new ProductionInfoPanel(UserString("PRODUCTION_WND_TITLE"), UserString("PRODUCTION_INFO_PP"),
+    m_production_info_panel = GG::Wnd::Create<ProductionInfoPanel>(UserString("PRODUCTION_WND_TITLE"), UserString("PRODUCTION_INFO_PP"),
                                                       GG::X0, GG::Y0, queue_width, info_height,
                                                       "production.InfoPanel");
     m_queue_wnd = GG::Wnd::Create<ProductionQueueWnd>(GG::X0, info_height, queue_width, ClientSize().y - info_height);

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -83,8 +83,7 @@ namespace {
             m_label(GG::Wnd::Create<QuantLabel>(m_quant, designID, nwidth, h, inProgress, amBlockType))
         {}
 
-        void CompleteConstruction() override
-        {
+        void CompleteConstruction() override {
             GG::ListBox::Row::CompleteConstruction();
 
             push_back(m_label);
@@ -366,8 +365,7 @@ namespace {
             RequirePreRender();
         }
 
-        void CompleteConstruction() override
-        {
+        void CompleteConstruction() override {
             GG::ListBox::Row::CompleteConstruction();
 
             push_back(panel);
@@ -753,8 +751,7 @@ public:
         m_queue_lb(nullptr)
     {}
 
-    void CompleteConstruction() override
-    {
+    void CompleteConstruction() override {
         m_queue_lb = GG::Wnd::Create<ProdQueueListBox>();
         m_queue_lb->SetStyle(GG::LIST_NOSORT | GG::LIST_NOSEL | GG::LIST_USERDELETE);
         m_queue_lb->SetName("ProductionQueue ListBox");

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -792,8 +792,12 @@ ProductionWnd::ProductionWnd(GG::X w, GG::Y h) :
     m_build_designator_wnd(nullptr),
     m_order_issuing_enabled(false),
     m_empire_shown_id(ALL_EMPIRES)
+{}
+
+void ProductionWnd::CompleteConstruction()
 {
-    //DebugLogger() << "ProductionWindow:  app-width: "<< GetOptionsDB().Get<int>("app-width")
+     GG::Wnd::CompleteConstruction();
+   //DebugLogger() << "ProductionWindow:  app-width: "<< GetOptionsDB().Get<int>("app-width")
     //              << " ; windowed width: " << GetOptionsDB().Get<int>("app-width-windowed");
 
     GG::X queue_width(GetOptionsDB().Get<int>("UI.queue-width"));

--- a/UI/ProductionWnd.h
+++ b/UI/ProductionWnd.h
@@ -19,6 +19,7 @@ public:
 
     virtual ~ProductionWnd();
     //@}
+    void CompleteConstruction() override;
 
     /** \name Accessors */ //@{
     int             SelectedPlanetID() const;

--- a/UI/QueueListBox.cpp
+++ b/UI/QueueListBox.cpp
@@ -54,6 +54,17 @@ QueueListBox::QueueListBox(const boost::optional<std::string>& drop_type_str, co
 {
     if (drop_type_str)
         AllowDropType(*drop_type_str);
+}
+
+void QueueListBox::CompleteConstruction()
+{
+    CUIListBox::CompleteConstruction();
+
+    SetNumCols(1);
+    ManuallyManageColProps();
+    NormalizeRowsOnInsert(false);
+
+    ShowPromptSlot();
 
     BeforeInsertRowSignal.connect(
         boost::bind(&QueueListBox::EnsurePromptHiddenSlot, this, _1));
@@ -63,12 +74,6 @@ QueueListBox::QueueListBox(const boost::optional<std::string>& drop_type_str, co
         boost::bind(&QueueListBox::ShowPromptSlot, this));
     GG::ListBox::RightClickedRowSignal.connect(
         boost::bind(&QueueListBox::ItemRightClicked, this, _1, _2, _3));
-
-    SetNumCols(1);
-    ManuallyManageColProps();
-    NormalizeRowsOnInsert(false);
-
-    ShowPromptSlot();
 }
 
 GG::X QueueListBox::RowWidth() const

--- a/UI/QueueListBox.cpp
+++ b/UI/QueueListBox.cpp
@@ -14,16 +14,18 @@
 struct PromptRow : GG::ListBox::Row {
     PromptRow(GG::X w, std::string prompt_str) :
         GG::ListBox::Row(w, GG::Y(20), ""),
-        m_prompt(nullptr)
-    {
-        //std::cout << "PromptRow(" << w << ", ...)" << std::endl;
+        m_prompt(GG::Wnd::Create<CUILabel>(prompt_str, GG::FORMAT_TOP | GG::FORMAT_LEFT | GG::FORMAT_LINEWRAP | GG::FORMAT_WORDBREAK))
+    {}
 
-        m_prompt = GG::Wnd::Create<CUILabel>(prompt_str, GG::FORMAT_TOP | GG::FORMAT_LEFT | GG::FORMAT_LINEWRAP | GG::FORMAT_WORDBREAK);
+    void CompleteConstruction() override
+    {
+        GG::ListBox::Row::CompleteConstruction();        //std::cout << "PromptRow(" << w << ", ...)" << std::endl;
+
         m_prompt->MoveTo(GG::Pt(GG::X(2), GG::Y(2)));
         m_prompt->Resize(GG::Pt(Width() - 10, Height()));
         m_prompt->SetTextColor(GG::LightColor(ClientUI::TextColor()));
         m_prompt->ClipText(true);
-        Resize(GG::Pt(w, m_prompt->Height()));
+        Resize(GG::Pt(Width(), m_prompt->Height()));
         push_back(m_prompt);
     }
 

--- a/UI/QueueListBox.cpp
+++ b/UI/QueueListBox.cpp
@@ -56,8 +56,7 @@ QueueListBox::QueueListBox(const boost::optional<std::string>& drop_type_str, co
         AllowDropType(*drop_type_str);
 }
 
-void QueueListBox::CompleteConstruction()
-{
+void QueueListBox::CompleteConstruction() {
     CUIListBox::CompleteConstruction();
 
     SetNumCols(1);

--- a/UI/QueueListBox.cpp
+++ b/UI/QueueListBox.cpp
@@ -17,8 +17,7 @@ struct PromptRow : GG::ListBox::Row {
         m_prompt(GG::Wnd::Create<CUILabel>(prompt_str, GG::FORMAT_TOP | GG::FORMAT_LEFT | GG::FORMAT_LINEWRAP | GG::FORMAT_WORDBREAK))
     {}
 
-    void CompleteConstruction() override
-    {
+    void CompleteConstruction() override {
         GG::ListBox::Row::CompleteConstruction();        //std::cout << "PromptRow(" << w << ", ...)" << std::endl;
 
         m_prompt->MoveTo(GG::Pt(GG::X(2), GG::Y(2)));

--- a/UI/QueueListBox.h
+++ b/UI/QueueListBox.h
@@ -12,6 +12,8 @@ class QueueListBox :
 public:
     QueueListBox(const boost::optional<std::string>& drop_type_str, const std::string& prompt_str);
 
+    void CompleteConstruction() override;
+
     void Render() override;
 
     void SizeMove(const GG::Pt& ul, const GG::Pt& lr) override;

--- a/UI/ResearchWnd.cpp
+++ b/UI/ResearchWnd.cpp
@@ -434,6 +434,11 @@ ResearchWnd::ResearchWnd(GG::X w, GG::Y h, bool initially_hidden /*= true*/) :
         boost::bind(&ResearchWnd::QueueItemPaused, this, _1, _2));
     m_tech_tree_wnd->AddTechsToQueueSignal.connect(
         boost::bind(&ResearchWnd::AddTechsToQueueSlot, this, _1, _2));
+}
+
+void ResearchWnd::CompleteConstruction()
+{
+    GG::Wnd::CompleteConstruction();
 
     AttachChild(m_research_info_panel);
     AttachChild(m_queue_wnd);

--- a/UI/ResearchWnd.cpp
+++ b/UI/ResearchWnd.cpp
@@ -222,8 +222,7 @@ namespace {
         m_turns_remaining_text->SetChildClippingMode(ClipToClient);
     }
 
-    void QueueTechPanel::CompleteConstruction()
-    {
+    void QueueTechPanel::CompleteConstruction() {
         GG::Control::CompleteConstruction();
         AttachChild(m_name_text);
         AttachChild(m_RPs_and_turns_text);
@@ -444,8 +443,7 @@ ResearchWnd::ResearchWnd(GG::X w, GG::Y h, bool initially_hidden /*= true*/) :
         boost::bind(&ResearchWnd::AddTechsToQueueSlot, this, _1, _2));
 }
 
-void ResearchWnd::CompleteConstruction()
-{
+void ResearchWnd::CompleteConstruction() {
     GG::Wnd::CompleteConstruction();
 
     AttachChild(m_research_info_panel);

--- a/UI/ResearchWnd.cpp
+++ b/UI/ResearchWnd.cpp
@@ -363,8 +363,7 @@ public:
         m_queue_lb(nullptr)
     {}
 
-    void CompleteConstruction() override
-    {
+    void CompleteConstruction() override {
         m_queue_lb = GG::Wnd::Create<ResearchQueueListBox>(std::string("RESEARCH_QUEUE_ROW"), UserString("RESEARCH_QUEUE_PROMPT"));
         m_queue_lb->SetStyle(GG::LIST_NOSORT | GG::LIST_NOSEL | GG::LIST_USERDELETE);
         m_queue_lb->SetName("ResearchQueue ListBox");

--- a/UI/ResearchWnd.cpp
+++ b/UI/ResearchWnd.cpp
@@ -298,6 +298,9 @@ public:
         QueueListBox(drop_type_str, prompt_str)
     {}
 
+    void CompleteConstruction() override
+    { QueueListBox::CompleteConstruction(); }
+
     boost::signals2::signal<void ()>                            ShowPediaSignal;
     boost::signals2::signal<void (GG::ListBox::iterator, bool)> QueueItemPausedSignal;
 

--- a/UI/ResearchWnd.cpp
+++ b/UI/ResearchWnd.cpp
@@ -41,6 +41,7 @@ namespace {
         QueueTechPanel(GG::X x, GG::Y y, GG::X w, const std::string& tech_name, double allocated_rp,
                        int turns_left, double turns_completed, int empire_id, bool paused = false);
 
+        void CompleteConstruction() override;
         void Render() override;
 
         void SizeMove(const GG::Pt& ul, const GG::Pt& lr) override;
@@ -219,7 +220,11 @@ namespace {
         m_turns_remaining_text->SetTextColor(clr);
         m_turns_remaining_text->ClipText(true);
         m_turns_remaining_text->SetChildClippingMode(ClipToClient);
+    }
 
+    void QueueTechPanel::CompleteConstruction()
+    {
+        GG::Control::CompleteConstruction();
         AttachChild(m_name_text);
         AttachChild(m_RPs_and_turns_text);
         AttachChild(m_turns_remaining_text);

--- a/UI/ResearchWnd.cpp
+++ b/UI/ResearchWnd.cpp
@@ -354,6 +354,9 @@ public:
         CUIWnd("", x, y, w, h, GG::INTERACTIVE | GG::RESIZABLE | GG::DRAGABLE | GG::ONTOP | PINABLE,
                "research.ResearchQueueWnd"),
         m_queue_lb(nullptr)
+    {}
+
+    void CompleteConstruction() override
     {
         m_queue_lb = GG::Wnd::Create<ResearchQueueListBox>(std::string("RESEARCH_QUEUE_ROW"), UserString("RESEARCH_QUEUE_PROMPT"));
         m_queue_lb->SetStyle(GG::LIST_NOSORT | GG::LIST_NOSEL | GG::LIST_USERDELETE);
@@ -362,6 +365,9 @@ public:
         SetEmpire(HumanClientApp::GetApp()->EmpireID());
 
         AttachChild(m_queue_lb);
+
+        CUIWnd::CompleteConstruction();
+
         DoLayout();
     }
     //@}

--- a/UI/ResearchWnd.h
+++ b/UI/ResearchWnd.h
@@ -16,6 +16,7 @@ public:
     ResearchWnd(GG::X w, GG::Y h, bool initially_hidden = true);
     ~ResearchWnd();
     //@}
+    void CompleteConstruction() override;
 
     /** \name Accessors */ //@{
     int     ShownEmpireID() const;

--- a/UI/ResourceBrowseWnd.cpp
+++ b/UI/ResourceBrowseWnd.cpp
@@ -28,8 +28,7 @@ ResourceBrowseWnd::ResourceBrowseWnd(const std::string& title_text, const std::s
     m_offset(GG::X0, ICON_BROWSE_ICON_HEIGHT/2)
 {}
 
-void ResourceBrowseWnd::CompleteConstruction()
-{
+void ResourceBrowseWnd::CompleteConstruction() {
     GG::BrowseInfoWnd::CompleteConstruction();
 
     const GG::Y ROW_HEIGHT(ClientUI::Pts()*4/3);

--- a/UI/ResourceBrowseWnd.cpp
+++ b/UI/ResourceBrowseWnd.cpp
@@ -15,23 +15,27 @@ namespace {
 ResourceBrowseWnd::ResourceBrowseWnd(const std::string& title_text, const std::string& unit_label,
                                      float used, float output, float target_output) :
     GG::BrowseInfoWnd(GG::X0, GG::Y0, BrowseTextWidth(), GG::Y1),
-    m_title_text(nullptr),
-    m_used_points_label(nullptr),
-    m_used_points(nullptr),
-    m_used_points_P_label(nullptr),
-    m_output_points_label(nullptr),
-    m_output_points(nullptr),
-    m_output_points_P_label(nullptr),
-    m_target_points_label(nullptr),
-    m_target_points(nullptr),
-    m_target_points_P_label(nullptr),
+    m_title_text(GG::Wnd::Create<CUILabel>(title_text, GG::FORMAT_CENTER)),
+    m_used_points_label(GG::Wnd::Create<CUILabel>(UserString("RESOURCE_TT_USED"), GG::FORMAT_RIGHT)),
+    m_used_points(GG::Wnd::Create<CUILabel>(DoubleToString(used, 3, false), GG::FORMAT_LEFT)),
+    m_used_points_P_label(GG::Wnd::Create<CUILabel>(unit_label, GG::FORMAT_LEFT)),
+    m_output_points_label(GG::Wnd::Create<CUILabel>(UserString("RESOURCE_TT_OUTPUT"), GG::FORMAT_RIGHT)),
+    m_output_points(GG::Wnd::Create<CUILabel>(DoubleToString(output, 3, false), GG::FORMAT_LEFT)),
+    m_output_points_P_label(GG::Wnd::Create<CUILabel>(unit_label, GG::FORMAT_LEFT)),
+    m_target_points_label(GG::Wnd::Create<CUILabel>(UserString("RESOURCE_TT_TARGET_OUTPUT"), GG::FORMAT_RIGHT)),
+    m_target_points(GG::Wnd::Create<CUILabel>(DoubleToString(target_output, 3, false), GG::FORMAT_LEFT)),
+    m_target_points_P_label(GG::Wnd::Create<CUILabel>(unit_label, GG::FORMAT_LEFT)),
     m_offset(GG::X0, ICON_BROWSE_ICON_HEIGHT/2)
+{}
+
+void ResourceBrowseWnd::CompleteConstruction()
 {
+    GG::BrowseInfoWnd::CompleteConstruction();
+
     const GG::Y ROW_HEIGHT(ClientUI::Pts()*4/3);
 
     GG::Pt top_left =  m_offset;
 
-    m_title_text = GG::Wnd::Create<CUILabel>(title_text, GG::FORMAT_CENTER);
     m_title_text->MoveTo(GG::Pt(top_left.x + EDGE_PAD, top_left.y));
     m_title_text->Resize(GG::Pt(BrowseTextWidth() - 2*EDGE_PAD, ROW_HEIGHT));
     m_title_text->SetFont(ClientUI::GetBoldFont());
@@ -56,15 +60,6 @@ ResourceBrowseWnd::ResourceBrowseWnd(const std::string& title_text, const std::s
     const GG::Pt P_LABEL_SIZE(Width() - 2 - 5 - P_LABEL_X, GG::Y(STAT_TEXT_PTS + 4));
 
 
-    m_used_points_label = GG::Wnd::Create<CUILabel>(UserString("RESOURCE_TT_USED"), GG::FORMAT_RIGHT);
-    m_used_points = GG::Wnd::Create<CUILabel>(DoubleToString(used, 3, false), GG::FORMAT_LEFT);
-    m_used_points_P_label = GG::Wnd::Create<CUILabel>(unit_label, GG::FORMAT_LEFT);
-    m_output_points_label = GG::Wnd::Create<CUILabel>(UserString("RESOURCE_TT_OUTPUT"), GG::FORMAT_RIGHT);
-    m_output_points = GG::Wnd::Create<CUILabel>(DoubleToString(output, 3, false), GG::FORMAT_LEFT);
-    m_output_points_P_label = GG::Wnd::Create<CUILabel>(unit_label, GG::FORMAT_LEFT);
-    m_target_points_label = GG::Wnd::Create<CUILabel>(UserString("RESOURCE_TT_TARGET_OUTPUT"), GG::FORMAT_RIGHT);
-    m_target_points = GG::Wnd::Create<CUILabel>(DoubleToString(target_output, 3, false), GG::FORMAT_LEFT);
-    m_target_points_P_label = GG::Wnd::Create<CUILabel>(unit_label, GG::FORMAT_LEFT);
 
     AttachChild(m_used_points_label);
     AttachChild(m_used_points);

--- a/UI/ResourceBrowseWnd.h
+++ b/UI/ResourceBrowseWnd.h
@@ -9,6 +9,7 @@
 class ResourceBrowseWnd : public GG::BrowseInfoWnd {
 public:
     ResourceBrowseWnd(const std::string& title_text, const std::string& unit_label, float used, float output, float target_output);
+    void CompleteConstruction() override;
 
     bool WndHasBrowseInfo(const Wnd* wnd, std::size_t mode) const override;
 

--- a/UI/ResourcePanel.cpp
+++ b/UI/ResourcePanel.cpp
@@ -37,7 +37,12 @@ ResourcePanel::ResourcePanel(GG::X w, int object_id) :
     m_meter_stats(),
     m_multi_icon_value_indicator(nullptr),
     m_multi_meter_status_bar(nullptr)
+{}
+
+void ResourcePanel::CompleteConstruction()
 {
+    AccordionPanel::CompleteConstruction();
+
     SetName("ResourcePanel");
 
     std::shared_ptr<const ResourceCenter> res = GetResCenter();

--- a/UI/ResourcePanel.cpp
+++ b/UI/ResourcePanel.cpp
@@ -39,8 +39,7 @@ ResourcePanel::ResourcePanel(GG::X w, int object_id) :
     m_multi_meter_status_bar(nullptr)
 {}
 
-void ResourcePanel::CompleteConstruction()
-{
+void ResourcePanel::CompleteConstruction() {
     AccordionPanel::CompleteConstruction();
 
     SetName("ResourcePanel");

--- a/UI/ResourcePanel.cpp
+++ b/UI/ResourcePanel.cpp
@@ -174,12 +174,11 @@ void ResourcePanel::Update() {
     m_multi_icon_value_indicator->Update();
 
     // tooltips
-    std::shared_ptr<GG::BrowseInfoWnd> browse_wnd;
-
     for (auto& meter_stat : m_meter_stats) {
         meter_stat.second->SetValue(obj->InitialMeterValue(meter_stat.first));
 
-        browse_wnd = std::make_shared<MeterBrowseWnd>(m_rescenter_id, meter_stat.first, AssociatedMeterType(meter_stat.first));
+        // TODO remove extra wrapping of shared_ptr after conversion to GG shared_ptr
+        auto browse_wnd = std::shared_ptr<GG::BrowseInfoWnd>(GG::Wnd::Create<MeterBrowseWnd>(m_rescenter_id, meter_stat.first, AssociatedMeterType(meter_stat.first)));
         meter_stat.second->SetBrowseInfoWnd(browse_wnd);
         m_multi_icon_value_indicator->SetToolTip(meter_stat.first, browse_wnd);
     }

--- a/UI/ResourcePanel.h
+++ b/UI/ResourcePanel.h
@@ -19,6 +19,7 @@ public:
     ResourcePanel(GG::X w, int object_id);
     ~ResourcePanel();
     //@}
+    void CompleteConstruction() override;
 
     /** \name Accessors */ //@{
     int ResourceCenterID() const { return m_rescenter_id; }

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -382,8 +382,7 @@ public:
         SaveFileRow(columns, "")
     {}
 
-    void CompleteConstruction() override
-    {
+    void CompleteConstruction() override {
         SaveFileRow::CompleteConstruction();
 
         SetMargin(ROW_MARGIN);
@@ -402,8 +401,7 @@ public:
     SaveFileDirectoryRow(const std::shared_ptr<std::vector<SaveFileColumn>>& columns, const std::string& directory) :
         SaveFileRow(columns, directory) {}
 
-    void CompleteConstruction() override
-    {
+    void CompleteConstruction() override {
         SaveFileRow::CompleteConstruction();
         SetMargin(ROW_MARGIN);
     }
@@ -460,8 +458,7 @@ public:
         SetBrowseModeTime(tooltip_delay);
     }
 
-    void CompleteConstruction() override
-    {
+    void CompleteConstruction() override {
         SaveFileRow::CompleteConstruction();
 
         SetMargin (ROW_MARGIN);

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -655,8 +655,8 @@ void SaveFileDialog::Init() {
     m_file_list = GG::Wnd::Create<SaveFileListBox>();
     m_file_list->SetStyle(GG::LIST_SINGLESEL | GG::LIST_SORTDESCENDING);
 
-    m_confirm_btn = new CUIButton(UserString("OK"));
-    auto cancel_btn = new CUIButton(UserString("CANCEL"));
+    m_confirm_btn = Wnd::Create<CUIButton>(UserString("OK"));
+    auto cancel_btn = Wnd::Create<CUIButton>(UserString("CANCEL"));
 
     m_name_edit = GG::Wnd::Create<CUIEdit>("");
     if (m_extension != MP_SAVE_FILE_EXTENSION && m_extension != SP_SAVE_FILE_EXTENSION) {
@@ -677,7 +677,7 @@ void SaveFileDialog::Init() {
     if (!m_server_previews) {
         m_layout->Add(m_current_dir_edit, 0, 1, 1, 3);
 
-        auto delete_btn = new CUIButton(UserString("DELETE"));
+        auto delete_btn = Wnd::Create<CUIButton>(UserString("DELETE"));
         m_layout->Add(delete_btn, 2, 3);
         delete_btn->LeftClickedSignal.connect(
             boost::bind(&SaveFileDialog::AskDelete, this));

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -380,7 +380,12 @@ class SaveFileHeaderRow: public SaveFileRow {
 public:
     SaveFileHeaderRow(const std::shared_ptr<std::vector<SaveFileColumn>>& columns) :
         SaveFileRow(columns, "")
+    {}
+
+    void CompleteConstruction() override
     {
+        SaveFileRow::CompleteConstruction();
+
         SetMargin(ROW_MARGIN);
 
         for (const SaveFileColumn& column : *m_columns)
@@ -395,7 +400,11 @@ public:
 class SaveFileDirectoryRow: public SaveFileRow {
 public:
     SaveFileDirectoryRow(const std::shared_ptr<std::vector<SaveFileColumn>>& columns, const std::string& directory) :
-        SaveFileRow(columns, directory) {
+        SaveFileRow(columns, directory) {}
+
+    void CompleteConstruction() override
+    {
+        SaveFileRow::CompleteConstruction();
         SetMargin(ROW_MARGIN);
     }
 
@@ -448,8 +457,14 @@ public:
         m_all_columns(columns),
         m_full_preview(full)
     {
-        SetMargin (ROW_MARGIN);
         SetBrowseModeTime(tooltip_delay);
+    }
+
+    void CompleteConstruction() override
+    {
+        SaveFileRow::CompleteConstruction();
+
+        SetMargin (ROW_MARGIN);
     }
 
     void Init() override {

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -628,7 +628,6 @@ SaveFileDialog::SaveFileDialog (const std::string& extension, bool load) :
     m_extension = extension;
     m_load_only = load;
     m_server_previews = false;
-    Init();
 }
 
 SaveFileDialog::SaveFileDialog (bool load) :
@@ -639,6 +638,11 @@ SaveFileDialog::SaveFileDialog (bool load) :
     m_load_only = load;
     m_server_previews = true;
     m_extension = MP_SAVE_FILE_EXTENSION;
+}
+
+void SaveFileDialog::CompleteConstruction()
+{
+    CUIWnd::CompleteConstruction();
     Init();
 }
 

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -655,8 +655,7 @@ SaveFileDialog::SaveFileDialog (bool load) :
     m_extension = MP_SAVE_FILE_EXTENSION;
 }
 
-void SaveFileDialog::CompleteConstruction()
-{
+void SaveFileDialog::CompleteConstruction() {
     CUIWnd::CompleteConstruction();
     Init();
 }

--- a/UI/SaveFileDialog.h
+++ b/UI/SaveFileDialog.h
@@ -30,6 +30,7 @@ public:
     /// Contruct for getting the previews from the server
     SaveFileDialog(bool load = false);
 
+    void CompleteConstruction() override;
     ~SaveFileDialog();
     //@}
 

--- a/UI/ServerConnectWnd.cpp
+++ b/UI/ServerConnectWnd.cpp
@@ -51,7 +51,12 @@ ServerConnectWnd::ServerConnectWnd() :
     m_player_name_edit(nullptr),
     m_ok_bn(nullptr),
     m_cancel_bn(nullptr)
+{}
+
+void ServerConnectWnd::CompleteConstruction()
 {
+    CUIWnd::CompleteConstruction();
+
     Sound::TempUISoundDisabler sound_disabler;
 
     auto player_name_label = GG::Wnd::Create<CUILabel>(UserString("PLAYER_NAME_LABEL"), GG::FORMAT_LEFT);

--- a/UI/ServerConnectWnd.cpp
+++ b/UI/ServerConnectWnd.cpp
@@ -53,8 +53,7 @@ ServerConnectWnd::ServerConnectWnd() :
     m_cancel_bn(nullptr)
 {}
 
-void ServerConnectWnd::CompleteConstruction()
-{
+void ServerConnectWnd::CompleteConstruction() {
     CUIWnd::CompleteConstruction();
 
     Sound::TempUISoundDisabler sound_disabler;

--- a/UI/ServerConnectWnd.h
+++ b/UI/ServerConnectWnd.h
@@ -14,6 +14,7 @@ class ServerConnectWnd : public CUIWnd
 public:
     /** \name Structors */ //@{
     ServerConnectWnd();
+    void CompleteConstruction() override;
     //@}
 
     //! \name Mutators

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -1923,7 +1923,7 @@ void SidePanel::PlanetPanel::Refresh() {
             }
 
             std::string info = visibility_info + "\n\n" + detection_info;
-            SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(UserString("METER_STEALTH"), info));
+            SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(UserString("METER_STEALTH"), info));
         }
         else if (visibility == VIS_BASIC_VISIBILITY) {
             visibility_info = UserString("PL_BASIC_VISIBILITY");
@@ -1948,7 +1948,7 @@ void SidePanel::PlanetPanel::Refresh() {
             }
 
             std::string info = visibility_info + "\n\n" + detection_info;
-            SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(UserString("METER_STEALTH"), info));
+            SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(UserString("METER_STEALTH"), info));
         }
     }
 

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -472,6 +472,7 @@ public:
 
     ~PlanetPanel();
     //@}
+    void CompleteConstruction() override;
 
     /** \name Accessors */ //@{
     bool InWindow(const GG::Pt& pt) const override;
@@ -900,7 +901,12 @@ SidePanel::PlanetPanel::PlanetPanel(GG::X w, int planet_id, StarType star_type) 
     m_buildings_panel(nullptr),
     m_specials_panel(nullptr),
     m_star_type(star_type)
+{}
+
+void SidePanel::PlanetPanel::CompleteConstruction()
 {
+    GG::Control::CompleteConstruction();
+
     SetName(UserString("PLANET_PANEL"));
 
     std::shared_ptr<const Planet> planet = GetPlanet(m_planet_id);
@@ -937,7 +943,7 @@ SidePanel::PlanetPanel::PlanetPanel(GG::X w, int planet_id, StarType star_type) 
     else
         font = ClientUI::GetFont(ClientUI::Pts()*4/3);
 
-    GG::X panel_width = w - MaxPlanetDiameter() - 2*EDGE_PAD;
+    GG::X panel_width = Width() - MaxPlanetDiameter() - 2*EDGE_PAD;
 
     // create planet name control
     m_planet_name = GG::Wnd::Create<GG::TextControl>(GG::X0, GG::Y0, GG::X1, GG::Y1, " ", font, ClientUI::TextColor());

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -2465,7 +2465,7 @@ SidePanel::PlanetPanelContainer::PlanetPanelContainer() :
     Wnd(GG::X0, GG::Y0, GG::X1, GG::Y1, GG::INTERACTIVE),
     m_planet_panels(),
     m_selected_planet_id(INVALID_OBJECT_ID),
-    m_vscroll(new CUIScroll(GG::VERTICAL)),
+    m_vscroll(GG::Wnd::Create<CUIScroll>(GG::VERTICAL)),
     m_ignore_recursive_resize(false)
 {
     SetName("PlanetPanelContainer");

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -996,15 +996,15 @@ SidePanel::PlanetPanel::PlanetPanel(GG::X w, int planet_id, StarType star_type) 
     AttachChild(m_env_size);
 
 
-    m_colonize_button = new CUIButton(UserString("PL_COLONIZE"));
+    m_colonize_button = Wnd::Create<CUIButton>(UserString("PL_COLONIZE"));
     m_colonize_button->LeftClickedSignal.connect(
         boost::bind(&SidePanel::PlanetPanel::ClickColonize, this));
 
-    m_invade_button   = new CUIButton(UserString("PL_INVADE"));
+    m_invade_button   = Wnd::Create<CUIButton>(UserString("PL_INVADE"));
     m_invade_button->LeftClickedSignal.connect(
         boost::bind(&SidePanel::PlanetPanel::ClickInvade, this));
 
-    m_bombard_button  = new CUIButton(UserString("PL_BOMBARD"));
+    m_bombard_button  = Wnd::Create<CUIButton>(UserString("PL_BOMBARD"));
     m_bombard_button->LeftClickedSignal.connect(
         boost::bind(&SidePanel::PlanetPanel::ClickBombard, this));
 
@@ -2824,12 +2824,12 @@ SidePanel::SidePanel(const std::string& config_name) :
 
     boost::filesystem::path button_texture_dir = ClientUI::ArtDir() / "icons" / "buttons";
 
-    m_button_prev = new CUIButton(
+    m_button_prev = Wnd::Create<CUIButton>(
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "leftarrownormal.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "leftarrowclicked.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "leftarrowmouseover.png")));
 
-    m_button_next = new CUIButton(
+    m_button_next = Wnd::Create<CUIButton>(
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "rightarrownormal.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "rightarrowclicked.png")),
         GG::SubTexture(ClientUI::GetTexture(button_texture_dir / "rightarrowmouseover.png")));

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -903,8 +903,7 @@ SidePanel::PlanetPanel::PlanetPanel(GG::X w, int planet_id, StarType star_type) 
     m_star_type(star_type)
 {}
 
-void SidePanel::PlanetPanel::CompleteConstruction()
-{
+void SidePanel::PlanetPanel::CompleteConstruction() {
     GG::Control::CompleteConstruction();
 
     SetName(UserString("PLANET_PANEL"));
@@ -2825,8 +2824,7 @@ SidePanel::SidePanel(const std::string& config_name) :
     m_selection_enabled(false)
 {}
 
-void SidePanel::CompleteConstruction()
-{
+void SidePanel::CompleteConstruction() {
     CUIWnd::CompleteConstruction();
 
     m_planet_panel_container = GG::Wnd::Create<PlanetPanelContainer>();

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -809,9 +809,9 @@ class SidePanel::SystemNameDropDownList : public CUIDropDownList {
 
         auto rename_action = [this, system]() {
             const std::string& old_name(system->Name());
-            CUIEditWnd edit_wnd(GG::X(350), UserString("SP_ENTER_NEW_SYSTEM_NAME"), old_name);
-            edit_wnd.Run();
-            const std::string& new_name(edit_wnd.Result());
+            std::shared_ptr<CUIEditWnd> edit_wnd(GG::Wnd::Create<CUIEditWnd>(GG::X(350), UserString("SP_ENTER_NEW_SYSTEM_NAME"), old_name));
+            edit_wnd->Run();
+            const std::string& new_name(edit_wnd->Result());
             if (m_order_issuing_enabled && !new_name.empty() && new_name != old_name) {
                 HumanClientApp::GetApp()->Orders().IssueOrder(
                     std::make_shared<RenameOrder>(HumanClientApp::GetApp()->EmpireID(), system->ID(), new_name));
@@ -2057,14 +2057,14 @@ void SidePanel::PlanetPanel::RClick(const GG::Pt& pt, GG::Flags<GG::ModKey> mod_
         && m_planet_name->InClient(pt))
     {
         auto rename_action = [this, planet]() { // rename planet
-            CUIEditWnd edit_wnd(GG::X(350), UserString("SP_ENTER_NEW_PLANET_NAME"), planet->Name());
-            edit_wnd.Run();
-            if (edit_wnd.Result() != ""
-                && edit_wnd.Result() != planet->Name()
+            std::shared_ptr<CUIEditWnd> edit_wnd(GG::Wnd::Create<CUIEditWnd>(GG::X(350), UserString("SP_ENTER_NEW_PLANET_NAME"), planet->Name()));
+            edit_wnd->Run();
+            if (edit_wnd->Result() != ""
+                && edit_wnd->Result() != planet->Name()
                 && m_order_issuing_enabled)
             {
                 HumanClientApp::GetApp()->Orders().IssueOrder(
-                    std::make_shared<RenameOrder>(HumanClientApp::GetApp()->EmpireID(), planet->ID(), edit_wnd.Result()));
+                    std::make_shared<RenameOrder>(HumanClientApp::GetApp()->EmpireID(), planet->ID(), edit_wnd->Result()));
                 Refresh();
             }
 
@@ -2807,7 +2807,6 @@ boost::signals2::signal<void (int)>        SidePanel::PlanetDoubleClickedSignal;
 boost::signals2::signal<void (int)>        SidePanel::BuildingRightClickedSignal;
 boost::signals2::signal<void (int)>        SidePanel::SystemSelectedSignal;
 
-
 SidePanel::SidePanel(const std::string& config_name) :
     CUIWnd("", GG::INTERACTIVE | GG::RESIZABLE | GG::DRAGABLE | GG::ONTOP, config_name),
     m_system_name(nullptr),
@@ -2818,7 +2817,12 @@ SidePanel::SidePanel(const std::string& config_name) :
     m_planet_panel_container(nullptr),
     m_system_resource_summary(nullptr),
     m_selection_enabled(false)
+{}
+
+void SidePanel::CompleteConstruction()
 {
+    CUIWnd::CompleteConstruction();
+
     m_planet_panel_container = GG::Wnd::Create<PlanetPanelContainer>();
     AttachChild(m_planet_panel_container);
 

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -810,7 +810,7 @@ class SidePanel::SystemNameDropDownList : public CUIDropDownList {
 
         auto rename_action = [this, system]() {
             const std::string& old_name(system->Name());
-            std::shared_ptr<CUIEditWnd> edit_wnd(GG::Wnd::Create<CUIEditWnd>(GG::X(350), UserString("SP_ENTER_NEW_SYSTEM_NAME"), old_name));
+            std::shared_ptr<CUIEditWnd> edit_wnd(GG::Wnd::Create<CUIEditWnd>(GG::X(350), UserString("SP_ENTER_NEW_SYSTEM_NAME"), old_name)); // TODO change the shared_ptr to auto after conversion of Wnd::Create
             edit_wnd->Run();
             const std::string& new_name(edit_wnd->Result());
             if (m_order_issuing_enabled && !new_name.empty() && new_name != old_name) {
@@ -2062,7 +2062,7 @@ void SidePanel::PlanetPanel::RClick(const GG::Pt& pt, GG::Flags<GG::ModKey> mod_
         && m_planet_name->InClient(pt))
     {
         auto rename_action = [this, planet]() { // rename planet
-            std::shared_ptr<CUIEditWnd> edit_wnd(GG::Wnd::Create<CUIEditWnd>(GG::X(350), UserString("SP_ENTER_NEW_PLANET_NAME"), planet->Name()));
+            std::shared_ptr<CUIEditWnd> edit_wnd(GG::Wnd::Create<CUIEditWnd>(GG::X(350), UserString("SP_ENTER_NEW_PLANET_NAME"), planet->Name())); // TODO change the shared_ptr to auto after conversion of Wnd::Create
             edit_wnd->Run();
             if (edit_wnd->Result() != ""
                 && edit_wnd->Result() != planet->Name()

--- a/UI/SidePanel.h
+++ b/UI/SidePanel.h
@@ -22,6 +22,7 @@ public:
 
     /** \name Structors */ //@{
     SidePanel(const std::string& config_name);
+    void CompleteConstruction() override;
     ~SidePanel();
     //@}
 

--- a/UI/SitRepPanel.cpp
+++ b/UI/SitRepPanel.cpp
@@ -226,8 +226,7 @@ namespace {
             m_link_text(nullptr)
         {}
 
-        void CompleteConstruction() override
-        {
+        void CompleteConstruction() override {
             GG::Control::CompleteConstruction();
 
             SetChildClippingMode(ClipToClient);
@@ -329,8 +328,7 @@ namespace {
             SetName("SitRepRow");
         }
 
-        void CompleteConstruction() override
-        {
+        void CompleteConstruction() override {
             GG::ListBox::Row::CompleteConstruction();
 
             SetMargin(sitrep_row_margin);

--- a/UI/SitRepPanel.cpp
+++ b/UI/SitRepPanel.cpp
@@ -388,8 +388,7 @@ SitRepPanel::SitRepPanel(const std::string& config_name) :
     m_hidden_sitrep_templates(HiddenSitRepTemplateStringsFromOptions())
 {}
 
-void SitRepPanel::CompleteConstruction()
-{
+void SitRepPanel::CompleteConstruction() {
     Sound::TempUISoundDisabler sound_disabler;
     SetChildClippingMode(DontClip);
 

--- a/UI/SitRepPanel.cpp
+++ b/UI/SitRepPanel.cpp
@@ -386,13 +386,13 @@ SitRepPanel::SitRepPanel(const std::string& config_name) :
     m_sitreps_lb->NormalizeRowsOnInsert(false);
     AttachChild(m_sitreps_lb);
 
-    m_prev_turn_button = new CUIButton(UserString("BACK"));
+    m_prev_turn_button = Wnd::Create<CUIButton>(UserString("BACK"));
     AttachChild(m_prev_turn_button);
-    m_next_turn_button = new CUIButton(UserString("NEXT"));
+    m_next_turn_button = Wnd::Create<CUIButton>(UserString("NEXT"));
     AttachChild(m_next_turn_button);
-    m_last_turn_button = new CUIButton(UserString("LAST"));
+    m_last_turn_button = Wnd::Create<CUIButton>(UserString("LAST"));
     AttachChild(m_last_turn_button);
-    m_filter_button = new CUIButton(UserString("FILTERS"));
+    m_filter_button = Wnd::Create<CUIButton>(UserString("FILTERS"));
     AttachChild(m_filter_button);
 
     m_prev_turn_button->LeftClickedSignal.connect(

--- a/UI/SitRepPanel.cpp
+++ b/UI/SitRepPanel.cpp
@@ -375,6 +375,9 @@ SitRepPanel::SitRepPanel(const std::string& config_name) :
     m_filter_button(nullptr),
     m_showing_turn(INVALID_GAME_TURN),
     m_hidden_sitrep_templates(HiddenSitRepTemplateStringsFromOptions())
+{}
+
+void SitRepPanel::CompleteConstruction()
 {
     Sound::TempUISoundDisabler sound_disabler;
     SetChildClippingMode(DontClip);
@@ -407,6 +410,8 @@ SitRepPanel::SitRepPanel(const std::string& config_name) :
         boost::bind(&SitRepPanel::IgnoreSitRep, this, _1, _2, _3));
     m_sitreps_lb->RightClickedRowSignal.connect(
         boost::bind(&SitRepPanel::DismissalMenu, this, _1, _2, _3));
+
+    CUIWnd::CompleteConstruction();
 
     DoLayout();
 }

--- a/UI/SitRepPanel.cpp
+++ b/UI/SitRepPanel.cpp
@@ -224,7 +224,12 @@ namespace {
             m_sitrep_entry(sitrep),
             m_icon(nullptr),
             m_link_text(nullptr)
+        {}
+
+        void CompleteConstruction() override
         {
+            GG::Control::CompleteConstruction();
+
             SetChildClippingMode(ClipToClient);
 
             int icon_dim = GetIconSize();
@@ -255,7 +260,7 @@ namespace {
             m_link_text->RightClickedSignal.connect(
                 boost::bind(&SitRepDataPanel::RClick, this, _1, _2));
 
-            DoLayout(GG::Pt(left, top), w);
+            DoLayout(UpperLeft(), Width());
         }
 
         void Render() override {

--- a/UI/SitRepPanel.cpp
+++ b/UI/SitRepPanel.cpp
@@ -322,6 +322,12 @@ namespace {
             m_sitrep(sitrep)
         {
             SetName("SitRepRow");
+        }
+
+        void CompleteConstruction() override
+        {
+            GG::ListBox::Row::CompleteConstruction();
+
             SetMargin(sitrep_row_margin);
             SetChildClippingMode(ClipToClient);
             SetMinSize(GG::Pt(GG::X(2 * GetIconSize() + 2 * sitrep_edge_to_content_spacing),

--- a/UI/SitRepPanel.h
+++ b/UI/SitRepPanel.h
@@ -12,6 +12,7 @@ class SitRepPanel : public CUIWnd {
 public:
     /** \name Structors */ //@{
     SitRepPanel(const std::string& config_name = "");
+    void CompleteConstruction() override;
     //@}
 
     /** \name Accessors */ //@{

--- a/UI/SpecialsPanel.cpp
+++ b/UI/SpecialsPanel.cpp
@@ -24,6 +24,11 @@ SpecialsPanel::SpecialsPanel(GG::X w, int object_id) :
     m_icons()
 {
     SetName("SpecialsPanel");
+}
+
+void SpecialsPanel::CompleteConstruction()
+{
+    GG::Wnd::CompleteConstruction();
     Update();
 }
 

--- a/UI/SpecialsPanel.cpp
+++ b/UI/SpecialsPanel.cpp
@@ -100,7 +100,7 @@ void SpecialsPanel::Update() {
             desc += "\n" + Dump(special->Effects());
         }
 
-        graphic->SetBrowseInfoWnd(std::make_shared<IconTextBrowseWnd>(
+        graphic->SetBrowseInfoWnd(GG::Wnd::Create<IconTextBrowseWnd>(
             ClientUI::SpecialIcon(special->Name()), UserString(special->Name()), desc));
         m_icons[entry.first] = graphic;
 

--- a/UI/SpecialsPanel.cpp
+++ b/UI/SpecialsPanel.cpp
@@ -26,8 +26,7 @@ SpecialsPanel::SpecialsPanel(GG::X w, int object_id) :
     SetName("SpecialsPanel");
 }
 
-void SpecialsPanel::CompleteConstruction()
-{
+void SpecialsPanel::CompleteConstruction() {
     GG::Wnd::CompleteConstruction();
     Update();
 }

--- a/UI/SpecialsPanel.h
+++ b/UI/SpecialsPanel.h
@@ -11,6 +11,7 @@ public:
     /** \name Structors */ //@{
     SpecialsPanel(GG::X w, int object_id);
     //@}
+    void CompleteConstruction() override;
 
     /** \name Accessors */ //@{
     bool InWindow(const GG::Pt& pt) const override;

--- a/UI/SystemIcon.cpp
+++ b/UI/SystemIcon.cpp
@@ -211,8 +211,7 @@ OwnerColoredSystemName::OwnerColoredSystemName(int system_id, int font_size, boo
         GG::X0, GG::Y0, GG::X1, GG::Y1, "<s>" + wrapped_system_name + "</s>", font, text_color);
 }
 
-void OwnerColoredSystemName::CompleteConstruction()
-{
+void OwnerColoredSystemName::CompleteConstruction() {
     GG::Control::CompleteConstruction();
 
     AttachChild(m_text);
@@ -252,8 +251,7 @@ SystemIcon::SystemIcon(GG::X x, GG::Y y, GG::X w, int system_id) :
     m_showing_name(false)
 {}
 
-void SystemIcon::CompleteConstruction()
-{
+void SystemIcon::CompleteConstruction() {
     GG::Control::CompleteConstruction();
 
     ClientUI* ui = ClientUI::GetClientUI();

--- a/UI/SystemIcon.cpp
+++ b/UI/SystemIcon.cpp
@@ -207,11 +207,17 @@ OwnerColoredSystemName::OwnerColoredSystemName(int system_id, int font_size, boo
         wrapped_system_name = wrapped_system_name + " (" + std::to_string(system_id) + ")";
     }
 
-    auto text = GG::Wnd::Create<GG::TextControl>(
+    m_text = GG::Wnd::Create<GG::TextControl>(
         GG::X0, GG::Y0, GG::X1, GG::Y1, "<s>" + wrapped_system_name + "</s>", font, text_color);
-    AttachChild(text);
-    GG::Pt text_size(text->TextLowerRight() - text->TextUpperLeft());
-    text->SizeMove(GG::Pt(GG::X0, GG::Y0), text_size);
+}
+
+void OwnerColoredSystemName::CompleteConstruction()
+{
+    GG::Control::CompleteConstruction();
+
+    AttachChild(m_text);
+    GG::Pt text_size(m_text->TextLowerRight() - m_text->TextUpperLeft());
+    m_text->SizeMove(GG::Pt(GG::X0, GG::Y0), text_size);
     Resize(text_size);
 }
 
@@ -244,19 +250,24 @@ SystemIcon::SystemIcon(GG::X x, GG::Y y, GG::X w, int system_id) :
     m_selected(false),
     m_colored_name(nullptr),
     m_showing_name(false)
+{}
+
+void SystemIcon::CompleteConstruction()
 {
+    GG::Control::CompleteConstruction();
+
     ClientUI* ui = ClientUI::GetClientUI();
     if (std::shared_ptr<const System> system = GetSystem(m_system_id)) {
         StarType star_type = system->GetStarType();
         m_disc_texture = ui->GetModuloTexture(ClientUI::ArtDir() / "stars",
                                               ClientUI::StarTypeFilePrefixes()[star_type],
-                                              system_id);
+                                              m_system_id);
         m_halo_texture = ui->GetModuloTexture(ClientUI::ArtDir() / "stars",
                                               ClientUI::HaloStarTypeFilePrefixes()[star_type],
-                                              system_id);
+                                              m_system_id);
         m_tiny_texture = ui->GetModuloTexture(ClientUI::ArtDir() / "stars",
                                               "tiny_" + ClientUI::StarTypeFilePrefixes()[star_type],
-                                              system_id);
+                                              m_system_id);
     } else {
         m_disc_texture = ui->GetTexture(ClientUI::ArtDir() / "misc" / "missing.png");
         m_halo_texture = m_disc_texture;

--- a/UI/SystemIcon.h
+++ b/UI/SystemIcon.h
@@ -27,9 +27,11 @@ class OwnerColoredSystemName : public GG::Control {
 public:
     OwnerColoredSystemName(int system_id, int font_size, bool blank_unexplored_and_none);
 
+    void CompleteConstruction() override;
     void Render() override;
-
     void SizeMove(const GG::Pt& ul, const GG::Pt& lr) override;
+private:
+    GG::TextControl* m_text;
 };
 
 /** A control that allows interaction with a star system.  This class allows
@@ -44,6 +46,7 @@ public:
 
     ~SystemIcon();
     //!@}
+    void CompleteConstruction() override;
 
     //! \name Accessors //!@{
     /** Checks to see if point lies inside in-system fleet buttons before

--- a/UI/TechTreeWnd.cpp
+++ b/UI/TechTreeWnd.cpp
@@ -1084,9 +1084,9 @@ TechTreeWnd::LayoutPanel::LayoutPanel(GG::X w, GG::Y h) :
     m_vscroll = new CUIScroll(GG::VERTICAL);
     m_hscroll = new CUIScroll(GG::HORIZONTAL);
 
-    m_zoom_in_button = new CUIButton("+");
+    m_zoom_in_button = Wnd::Create<CUIButton>("+");
     m_zoom_in_button->SetColor(ClientUI::WndColor());
-    m_zoom_out_button = new CUIButton("-");
+    m_zoom_out_button = Wnd::Create<CUIButton>("-");
     m_zoom_out_button->SetColor(ClientUI::WndColor());
 
     DoLayout();
@@ -1731,31 +1731,31 @@ TechTreeWnd::TechListBox::TechListBox(GG::X w, GG::Y h) :
     graphic_col->SetChildClippingMode(ClipToWindow);
     m_header_row->push_back(graphic_col);
 
-    auto name_col = new CUIButton(UserString("TECH_WND_LIST_COLUMN_NAME"));
+    auto name_col = Wnd::Create<CUIButton>(UserString("TECH_WND_LIST_COLUMN_NAME"));
     name_col->Resize(GG::Pt(col_widths[1], HEIGHT));
     name_col->SetChildClippingMode(ClipToWindow);
     name_col->LeftClickedSignal.connect([this]() { ToggleSortCol(1); });
     m_header_row->push_back(name_col);
 
-    auto cost_col = new CUIButton(UserString("TECH_WND_LIST_COLUMN_COST"));
+    auto cost_col = Wnd::Create<CUIButton>(UserString("TECH_WND_LIST_COLUMN_COST"));
     cost_col->Resize(GG::Pt(col_widths[2], HEIGHT));
     cost_col->SetChildClippingMode(ClipToWindow);
     cost_col->LeftClickedSignal.connect([this]() { ToggleSortCol(2); });
     m_header_row->push_back(cost_col);
 
-    auto time_col = new CUIButton(UserString("TECH_WND_LIST_COLUMN_TIME"));
+    auto time_col = Wnd::Create<CUIButton>(UserString("TECH_WND_LIST_COLUMN_TIME"));
     time_col->Resize(GG::Pt(col_widths[3], HEIGHT));
     time_col->SetChildClippingMode(ClipToWindow);
     time_col->LeftClickedSignal.connect([this]() { ToggleSortCol(3); });
     m_header_row->push_back(time_col);
 
-    auto category_col = new CUIButton( UserString("TECH_WND_LIST_COLUMN_CATEGORY"));
+    auto category_col = Wnd::Create<CUIButton>( UserString("TECH_WND_LIST_COLUMN_CATEGORY"));
     category_col->Resize(GG::Pt(col_widths[4], HEIGHT));
     category_col->SetChildClippingMode(ClipToWindow);
     category_col->LeftClickedSignal.connect([this]() { ToggleSortCol(4); });
     m_header_row->push_back(category_col);
 
-    auto descr_col = new CUIButton(UserString("TECH_WND_LIST_COLUMN_DESCRIPTION"));
+    auto descr_col = Wnd::Create<CUIButton>(UserString("TECH_WND_LIST_COLUMN_DESCRIPTION"));
     descr_col->Resize(GG::Pt(col_widths[5], HEIGHT));
     descr_col->SetChildClippingMode(ClipToWindow);
     descr_col->LeftClickedSignal.connect([this]() { ToggleSortCol(5); });

--- a/UI/TechTreeWnd.cpp
+++ b/UI/TechTreeWnd.cpp
@@ -275,8 +275,7 @@ TechTreeWnd::TechTreeControls::TechTreeControls(const std::string& config_name) 
     CUIWnd(UserString("TECH_DISPLAY"), GG::INTERACTIVE | GG::DRAGABLE | GG::RESIZABLE | GG::ONTOP, config_name)
 {}
 
-void TechTreeWnd::TechTreeControls::CompleteConstruction()
-{
+void TechTreeWnd::TechTreeControls::CompleteConstruction() {
    const int tooltip_delay = GetOptionsDB().Get<int>("UI.tooltip-delay");
     const boost::filesystem::path icon_dir = ClientUI::ArtDir() / "icons" / "tech" / "controls";
 
@@ -715,8 +714,7 @@ TechTreeWnd::LayoutPanel::TechPanel::TechPanel(const std::string& tech_name, con
     SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
 }
 
-void TechTreeWnd::LayoutPanel::TechPanel::CompleteConstruction()
-{
+void TechTreeWnd::LayoutPanel::TechPanel::CompleteConstruction() {
     GG::Wnd::CompleteConstruction();
     Update();
 }
@@ -1093,8 +1091,7 @@ TechTreeWnd::LayoutPanel::LayoutPanel(GG::X w, GG::Y h) :
     m_zoom_out_button(nullptr)
 {}
 
-void TechTreeWnd::LayoutPanel::CompleteConstruction()
-{
+void TechTreeWnd::LayoutPanel::CompleteConstruction() {
     GG::Wnd::CompleteConstruction();
 
     SetChildClippingMode(ClipToClient);
@@ -1652,8 +1649,7 @@ TechTreeWnd::TechListBox::TechRow::TechRow(GG::X w, const std::string& tech_name
     m_tech(tech_name)
 {}
 
-void TechTreeWnd::TechListBox::TechRow::CompleteConstruction()
-{
+void TechTreeWnd::TechListBox::TechRow::CompleteConstruction() {
 
     CUIListBox::Row::CompleteConstruction();
 

--- a/UI/TechTreeWnd.cpp
+++ b/UI/TechTreeWnd.cpp
@@ -1530,6 +1530,8 @@ public:
     virtual ~TechListBox();
     //@}
 
+    void CompleteConstruction() override;
+
     /** \name Accessors */ //@{
     std::set<std::string>   GetCategoriesShown() const;
     std::set<TechStatus>    GetTechStatusesShown() const;
@@ -1716,6 +1718,11 @@ TechTreeWnd::TechListBox::TechListBox(GG::X w, GG::Y h) :
     CUIListBox()
 {
     Resize(GG::Pt(w, h));
+}
+
+void TechTreeWnd::TechListBox::CompleteConstruction() {
+    CUIListBox::CompleteConstruction();
+
     DoubleClickedRowSignal.connect(
         boost::bind(&TechListBox::TechDoubleClicked, this, _1, _2, _3));
     LeftClickedRowSignal.connect(
@@ -1736,7 +1743,7 @@ TechTreeWnd::TechListBox::TechListBox(GG::X w, GG::Y h) :
     m_tech_statuses_shown.insert(TS_RESEARCHABLE);
     m_tech_statuses_shown.insert(TS_COMPLETE);
 
-    GG::X row_width = w - ClientUI::ScrollWidth() - ClientUI::Pts();
+    GG::X row_width = Width() - ClientUI::ScrollWidth() - ClientUI::Pts();
     std::vector<GG::X> col_widths = TechRow::ColWidths(row_width);
     const GG::Y HEIGHT(Value(col_widths[0]));
     m_header_row = GG::Wnd::Create<GG::ListBox::Row>(row_width, HEIGHT, "");

--- a/UI/TechTreeWnd.cpp
+++ b/UI/TechTreeWnd.cpp
@@ -1099,7 +1099,7 @@ void TechTreeWnd::LayoutPanel::CompleteConstruction()
 
     m_scale = std::pow(ZOOM_STEP_SIZE, GetOptionsDB().Get<double>("UI.tech-layout-zoom-scale")); //(LATHANDA) Initialise Fullzoom and do real zooming using GL. TODO: Check best size
 
-    m_layout_surface = new LayoutSurface();
+    m_layout_surface = GG::Wnd::Create<LayoutSurface>();
 
     m_vscroll = GG::Wnd::Create<CUIScroll>(GG::VERTICAL);
     m_hscroll = GG::Wnd::Create<CUIScroll>(GG::HORIZONTAL);
@@ -1380,6 +1380,8 @@ void TechTreeWnd::LayoutPanel::Layout(bool keep_position) {
     const std::string selected_tech = m_selected_tech_name;
 
     // cleanup old data for new layout
+    for (const auto& tech_panel: m_techs)
+        m_layout_surface->DetachChild(tech_panel.second);
     Clear();
 
     DebugLogger() << "Tech Tree Layout Preparing Tech Data";

--- a/UI/TechTreeWnd.cpp
+++ b/UI/TechTreeWnd.cpp
@@ -1557,6 +1557,8 @@ private:
     public:
         TechRow(GG::X w, const std::string& tech_name);
 
+        void CompleteConstruction() override;
+
         void Render() override;
 
         const std::string&          GetTech() { return m_tech; }
@@ -1630,12 +1632,18 @@ bool TechTreeWnd::TechListBox::TechRowCmp(const GG::ListBox::Row& lhs, const GG:
 TechTreeWnd::TechListBox::TechRow::TechRow(GG::X w, const std::string& tech_name) :
     CUIListBox::Row(w, GG::Y(ClientUI::Pts() * 2 + 5), "TechListBox::TechRow"),
     m_tech(tech_name)
+{}
+
+void TechTreeWnd::TechListBox::TechRow::CompleteConstruction()
 {
+
+    CUIListBox::Row::CompleteConstruction();
+
     const Tech* this_row_tech = ::GetTech(m_tech);
     if (!this_row_tech)
         return;
 
-    std::vector<GG::X> col_widths = ColWidths(w);
+    std::vector<GG::X> col_widths = ColWidths(Width());
     const GG::X GRAPHIC_WIDTH =   col_widths[0];
     const GG::Y ICON_HEIGHT(std::max(ClientUI::Pts(), Value(GRAPHIC_WIDTH) - 6));
     // TODO replace string padding with new TextFormat flag

--- a/UI/TechTreeWnd.cpp
+++ b/UI/TechTreeWnd.cpp
@@ -282,7 +282,7 @@ void TechTreeWnd::TechTreeControls::CompleteConstruction()
     for (const std::string& category : GetTechManager().CategoryNames()) {
         GG::Clr icon_clr = ClientUI::CategoryColor(category);
         std::shared_ptr<GG::SubTexture> icon = std::make_shared<GG::SubTexture>(ClientUI::CategoryIcon(category));
-        m_cat_buttons[category] = new GG::StateButton("", ClientUI::GetFont(), GG::FORMAT_NONE, GG::CLR_ZERO,
+        m_cat_buttons[category] = GG::Wnd::Create<GG::StateButton>("", ClientUI::GetFont(), GG::FORMAT_NONE, GG::CLR_ZERO,
                                                      std::make_shared<CUIIconButtonRepresenter>(icon, icon_clr));
         m_cat_buttons[category]->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(UserString(category), ""));
         m_cat_buttons[category]->SetBrowseModeTime(tooltip_delay);
@@ -291,7 +291,7 @@ void TechTreeWnd::TechTreeControls::CompleteConstruction()
 
     GG::Clr icon_color = GG::Clr(113, 150, 182, 255);
     // and one for "ALL"
-    m_all_cat_button = new GG::StateButton("", ClientUI::GetFont(), GG::FORMAT_NONE, GG::CLR_ZERO,
+    m_all_cat_button = GG::Wnd::Create<GG::StateButton>("", ClientUI::GetFont(), GG::FORMAT_NONE, GG::CLR_ZERO,
                                            std::make_shared<CUIIconButtonRepresenter>(std::make_shared<GG::SubTexture>(ClientUI::GetTexture(icon_dir / "00_all_cats.png", true)), icon_color));
     m_all_cat_button->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(UserString("ALL"), ""));
     m_all_cat_button->SetBrowseModeTime(tooltip_delay);
@@ -299,7 +299,7 @@ void TechTreeWnd::TechTreeControls::CompleteConstruction()
     AttachChild(m_all_cat_button);
 
     // create a button for each tech status
-    m_status_buttons[TS_UNRESEARCHABLE] = new GG::StateButton("", ClientUI::GetFont(), GG::FORMAT_NONE, GG::CLR_ZERO,
+    m_status_buttons[TS_UNRESEARCHABLE] = GG::Wnd::Create<GG::StateButton>("", ClientUI::GetFont(), GG::FORMAT_NONE, GG::CLR_ZERO,
                                                               std::make_shared<CUIIconButtonRepresenter>(std::make_shared<GG::SubTexture>(ClientUI::GetTexture(icon_dir / "01_locked.png", true)), icon_color));
     m_status_buttons[TS_UNRESEARCHABLE]->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(UserString("TECH_WND_STATUS_LOCKED"), ""));
     m_status_buttons[TS_UNRESEARCHABLE]->SetBrowseModeTime(tooltip_delay);
@@ -307,7 +307,7 @@ void TechTreeWnd::TechTreeControls::CompleteConstruction()
         GetOptionsDB().Get<bool>("UI.research.tech-tree-control.status.unresearchable"));
     AttachChild(m_status_buttons[TS_UNRESEARCHABLE]);
 
-    m_status_buttons[TS_HAS_RESEARCHED_PREREQ] = new GG::StateButton("", ClientUI::GetFont(), GG::FORMAT_NONE, GG::CLR_ZERO,
+    m_status_buttons[TS_HAS_RESEARCHED_PREREQ] = GG::Wnd::Create<GG::StateButton>("", ClientUI::GetFont(), GG::FORMAT_NONE, GG::CLR_ZERO,
                                                                      std::make_shared<CUIIconButtonRepresenter>(std::make_shared<GG::SubTexture>(ClientUI::GetTexture(icon_dir / "02_partial.png", true)), icon_color));
     m_status_buttons[TS_HAS_RESEARCHED_PREREQ]->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(UserString("TECH_WND_STATUS_PARTIAL_UNLOCK"), ""));
     m_status_buttons[TS_HAS_RESEARCHED_PREREQ]->SetBrowseModeTime(tooltip_delay);
@@ -315,7 +315,7 @@ void TechTreeWnd::TechTreeControls::CompleteConstruction()
         GetOptionsDB().Get<bool>("UI.research.tech-tree-control.status.has_researched_prereq"));
     AttachChild(m_status_buttons[TS_HAS_RESEARCHED_PREREQ]);
 
-    m_status_buttons[TS_RESEARCHABLE] = new GG::StateButton("", ClientUI::GetFont(), GG::FORMAT_NONE, GG::CLR_ZERO,
+    m_status_buttons[TS_RESEARCHABLE] = GG::Wnd::Create<GG::StateButton>("", ClientUI::GetFont(), GG::FORMAT_NONE, GG::CLR_ZERO,
                                                             std::make_shared<CUIIconButtonRepresenter>(std::make_shared<GG::SubTexture>(ClientUI::GetTexture(icon_dir / "03_unlocked.png", true)), icon_color));
     m_status_buttons[TS_RESEARCHABLE]->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(UserString("TECH_WND_STATUS_RESEARCHABLE"), ""));
     m_status_buttons[TS_RESEARCHABLE]->SetBrowseModeTime(tooltip_delay);
@@ -323,7 +323,7 @@ void TechTreeWnd::TechTreeControls::CompleteConstruction()
         GetOptionsDB().Get<bool>("UI.research.tech-tree-control.status.researchable"));
     AttachChild(m_status_buttons[TS_RESEARCHABLE]);
 
-    m_status_buttons[TS_COMPLETE] = new GG::StateButton("", ClientUI::GetFont(), GG::FORMAT_NONE, GG::CLR_ZERO,
+    m_status_buttons[TS_COMPLETE] = GG::Wnd::Create<GG::StateButton>("", ClientUI::GetFont(), GG::FORMAT_NONE, GG::CLR_ZERO,
                                                         std::make_shared<CUIIconButtonRepresenter>(std::make_shared<GG::SubTexture>(ClientUI::GetTexture(icon_dir / "04_completed.png", true)), icon_color));
     m_status_buttons[TS_COMPLETE]->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(UserString("TECH_WND_STATUS_COMPLETED"), ""));
     m_status_buttons[TS_COMPLETE]->SetBrowseModeTime(tooltip_delay);
@@ -332,8 +332,9 @@ void TechTreeWnd::TechTreeControls::CompleteConstruction()
     AttachChild(m_status_buttons[TS_COMPLETE]);
 
     // create button to switch between tree and list views
-    m_view_type_button = new GG::StateButton("", ClientUI::GetFont(), GG::FORMAT_NONE, GG::CLR_ZERO,
-                                             std::make_shared<CUIIconButtonRepresenter>(std::make_shared<GG::SubTexture>(ClientUI::GetTexture(icon_dir / "06_view_tree.png", true)), icon_color,
+    m_view_type_button = GG::Wnd::Create<GG::StateButton>(
+        "", ClientUI::GetFont(), GG::FORMAT_NONE, GG::CLR_ZERO,
+        std::make_shared<CUIIconButtonRepresenter>(std::make_shared<GG::SubTexture>(ClientUI::GetTexture(icon_dir / "06_view_tree.png", true)), icon_color,
                                                                                       std::make_shared<GG::SubTexture>(ClientUI::GetTexture(icon_dir / "05_view_list.png", true)), GG::Clr(110, 172, 150, 255)));
     m_view_type_button->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(UserString("TECH_WND_VIEW_TYPE"), ""));
     m_view_type_button->SetBrowseModeTime(tooltip_delay);

--- a/UI/TechTreeWnd.cpp
+++ b/UI/TechTreeWnd.cpp
@@ -211,8 +211,10 @@ std::shared_ptr<GG::BrowseInfoWnd> TechPanelRowBrowseWnd(const std::string& tech
             % turns);
     }
 
-    return std::make_shared<IconTextBrowseWnd>(
-        ClientUI::TechIcon(tech_name), UserString(tech_name), main_text);
+    // TODO remove extra wrapping of shared_ptr after conversion to GG shared_ptr
+    return std::shared_ptr<GG::BrowseInfoWnd>(
+        GG::Wnd::Create<IconTextBrowseWnd>(
+            ClientUI::TechIcon(tech_name), UserString(tech_name), main_text));
 }
 
 

--- a/UI/TechTreeWnd.cpp
+++ b/UI/TechTreeWnd.cpp
@@ -504,6 +504,8 @@ public:
     LayoutPanel(GG::X w, GG::Y h);
     //@}
 
+    void CompleteConstruction() override;
+
     /** \name Accessors */ //@{
     GG::Pt ClientLowerRight() const override;
 
@@ -615,6 +617,7 @@ class TechTreeWnd::LayoutPanel::TechPanel : public GG::Wnd {
 public:
     TechPanel(const std::string& tech_name, const TechTreeWnd::LayoutPanel* panel);
     virtual         ~TechPanel();
+    void CompleteConstruction() override;
 
     bool InWindow(const GG::Pt& pt) const override;
 
@@ -708,7 +711,11 @@ TechTreeWnd::LayoutPanel::TechPanel::TechPanel(const std::string& tech_name, con
     // intentionally not attaching as child; TechPanel::Render the child Render() function instead.
 
     SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
+}
 
+void TechTreeWnd::LayoutPanel::TechPanel::CompleteConstruction()
+{
+    GG::Wnd::CompleteConstruction();
     Update();
 }
 
@@ -1082,7 +1089,12 @@ TechTreeWnd::LayoutPanel::LayoutPanel(GG::X w, GG::Y h) :
     m_hscroll(nullptr),
     m_zoom_in_button(nullptr),
     m_zoom_out_button(nullptr)
+{}
+
+void TechTreeWnd::LayoutPanel::CompleteConstruction()
 {
+    GG::Wnd::CompleteConstruction();
+
     SetChildClippingMode(ClipToClient);
 
     m_scale = std::pow(ZOOM_STEP_SIZE, GetOptionsDB().Get<double>("UI.tech-layout-zoom-scale")); //(LATHANDA) Initialise Fullzoom and do real zooming using GL. TODO: Check best size
@@ -1995,9 +2007,14 @@ TechTreeWnd::TechTreeWnd(GG::X w, GG::Y h, bool initially_hidden /*= true*/) :
     m_tech_list(nullptr),
     m_init_flag(initially_hidden)
 {
+}
+
+void TechTreeWnd::CompleteConstruction() {
+    GG::Wnd::CompleteConstruction();
+
     Sound::TempUISoundDisabler sound_disabler;
 
-    m_layout_panel = GG::Wnd::Create<LayoutPanel>(w, h);
+    m_layout_panel = GG::Wnd::Create<LayoutPanel>(Width(), Height());
     m_layout_panel->TechLeftClickedSignal.connect(
         boost::bind(&TechTreeWnd::TechLeftClickedSlot, this, _1, _2));
     m_layout_panel->TechDoubleClickedSignal.connect(
@@ -2006,7 +2023,7 @@ TechTreeWnd::TechTreeWnd(GG::X w, GG::Y h, bool initially_hidden /*= true*/) :
         boost::bind(&TechTreeWnd::TechPediaDisplaySlot, this, _1));
     AttachChild(m_layout_panel);
 
-    m_tech_list = GG::Wnd::Create<TechListBox>(w, h);
+    m_tech_list = GG::Wnd::Create<TechListBox>(Width(), Height());
     m_tech_list->TechLeftClickedSignal.connect(
         boost::bind(&TechTreeWnd::TechLeftClickedSlot, this, _1, _2));
     m_tech_list->TechDoubleClickedSignal.connect(

--- a/UI/TechTreeWnd.cpp
+++ b/UI/TechTreeWnd.cpp
@@ -284,7 +284,7 @@ void TechTreeWnd::TechTreeControls::CompleteConstruction()
         std::shared_ptr<GG::SubTexture> icon = std::make_shared<GG::SubTexture>(ClientUI::CategoryIcon(category));
         m_cat_buttons[category] = GG::Wnd::Create<GG::StateButton>("", ClientUI::GetFont(), GG::FORMAT_NONE, GG::CLR_ZERO,
                                                      std::make_shared<CUIIconButtonRepresenter>(icon, icon_clr));
-        m_cat_buttons[category]->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(UserString(category), ""));
+        m_cat_buttons[category]->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(UserString(category), ""));
         m_cat_buttons[category]->SetBrowseModeTime(tooltip_delay);
         AttachChild(m_cat_buttons[category]);
     }
@@ -293,7 +293,7 @@ void TechTreeWnd::TechTreeControls::CompleteConstruction()
     // and one for "ALL"
     m_all_cat_button = GG::Wnd::Create<GG::StateButton>("", ClientUI::GetFont(), GG::FORMAT_NONE, GG::CLR_ZERO,
                                            std::make_shared<CUIIconButtonRepresenter>(std::make_shared<GG::SubTexture>(ClientUI::GetTexture(icon_dir / "00_all_cats.png", true)), icon_color));
-    m_all_cat_button->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(UserString("ALL"), ""));
+    m_all_cat_button->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(UserString("ALL"), ""));
     m_all_cat_button->SetBrowseModeTime(tooltip_delay);
     m_all_cat_button->SetCheck(true);
     AttachChild(m_all_cat_button);
@@ -301,7 +301,7 @@ void TechTreeWnd::TechTreeControls::CompleteConstruction()
     // create a button for each tech status
     m_status_buttons[TS_UNRESEARCHABLE] = GG::Wnd::Create<GG::StateButton>("", ClientUI::GetFont(), GG::FORMAT_NONE, GG::CLR_ZERO,
                                                               std::make_shared<CUIIconButtonRepresenter>(std::make_shared<GG::SubTexture>(ClientUI::GetTexture(icon_dir / "01_locked.png", true)), icon_color));
-    m_status_buttons[TS_UNRESEARCHABLE]->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(UserString("TECH_WND_STATUS_LOCKED"), ""));
+    m_status_buttons[TS_UNRESEARCHABLE]->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(UserString("TECH_WND_STATUS_LOCKED"), ""));
     m_status_buttons[TS_UNRESEARCHABLE]->SetBrowseModeTime(tooltip_delay);
     m_status_buttons[TS_UNRESEARCHABLE]->SetCheck(
         GetOptionsDB().Get<bool>("UI.research.tech-tree-control.status.unresearchable"));
@@ -309,7 +309,7 @@ void TechTreeWnd::TechTreeControls::CompleteConstruction()
 
     m_status_buttons[TS_HAS_RESEARCHED_PREREQ] = GG::Wnd::Create<GG::StateButton>("", ClientUI::GetFont(), GG::FORMAT_NONE, GG::CLR_ZERO,
                                                                      std::make_shared<CUIIconButtonRepresenter>(std::make_shared<GG::SubTexture>(ClientUI::GetTexture(icon_dir / "02_partial.png", true)), icon_color));
-    m_status_buttons[TS_HAS_RESEARCHED_PREREQ]->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(UserString("TECH_WND_STATUS_PARTIAL_UNLOCK"), ""));
+    m_status_buttons[TS_HAS_RESEARCHED_PREREQ]->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(UserString("TECH_WND_STATUS_PARTIAL_UNLOCK"), ""));
     m_status_buttons[TS_HAS_RESEARCHED_PREREQ]->SetBrowseModeTime(tooltip_delay);
     m_status_buttons[TS_HAS_RESEARCHED_PREREQ]->SetCheck(
         GetOptionsDB().Get<bool>("UI.research.tech-tree-control.status.has_researched_prereq"));
@@ -317,7 +317,7 @@ void TechTreeWnd::TechTreeControls::CompleteConstruction()
 
     m_status_buttons[TS_RESEARCHABLE] = GG::Wnd::Create<GG::StateButton>("", ClientUI::GetFont(), GG::FORMAT_NONE, GG::CLR_ZERO,
                                                             std::make_shared<CUIIconButtonRepresenter>(std::make_shared<GG::SubTexture>(ClientUI::GetTexture(icon_dir / "03_unlocked.png", true)), icon_color));
-    m_status_buttons[TS_RESEARCHABLE]->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(UserString("TECH_WND_STATUS_RESEARCHABLE"), ""));
+    m_status_buttons[TS_RESEARCHABLE]->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(UserString("TECH_WND_STATUS_RESEARCHABLE"), ""));
     m_status_buttons[TS_RESEARCHABLE]->SetBrowseModeTime(tooltip_delay);
     m_status_buttons[TS_RESEARCHABLE]->SetCheck(
         GetOptionsDB().Get<bool>("UI.research.tech-tree-control.status.researchable"));
@@ -325,7 +325,7 @@ void TechTreeWnd::TechTreeControls::CompleteConstruction()
 
     m_status_buttons[TS_COMPLETE] = GG::Wnd::Create<GG::StateButton>("", ClientUI::GetFont(), GG::FORMAT_NONE, GG::CLR_ZERO,
                                                         std::make_shared<CUIIconButtonRepresenter>(std::make_shared<GG::SubTexture>(ClientUI::GetTexture(icon_dir / "04_completed.png", true)), icon_color));
-    m_status_buttons[TS_COMPLETE]->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(UserString("TECH_WND_STATUS_COMPLETED"), ""));
+    m_status_buttons[TS_COMPLETE]->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(UserString("TECH_WND_STATUS_COMPLETED"), ""));
     m_status_buttons[TS_COMPLETE]->SetBrowseModeTime(tooltip_delay);
     m_status_buttons[TS_COMPLETE]->SetCheck(
         GetOptionsDB().Get<bool>("UI.research.tech-tree-control.status.completed"));
@@ -336,7 +336,7 @@ void TechTreeWnd::TechTreeControls::CompleteConstruction()
         "", ClientUI::GetFont(), GG::FORMAT_NONE, GG::CLR_ZERO,
         std::make_shared<CUIIconButtonRepresenter>(std::make_shared<GG::SubTexture>(ClientUI::GetTexture(icon_dir / "06_view_tree.png", true)), icon_color,
                                                                                       std::make_shared<GG::SubTexture>(ClientUI::GetTexture(icon_dir / "05_view_list.png", true)), GG::Clr(110, 172, 150, 255)));
-    m_view_type_button->SetBrowseInfoWnd(std::make_shared<TextBrowseWnd>(UserString("TECH_WND_VIEW_TYPE"), ""));
+    m_view_type_button->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(UserString("TECH_WND_VIEW_TYPE"), ""));
     m_view_type_button->SetBrowseModeTime(tooltip_delay);
     m_view_type_button->SetCheck(false);
     AttachChild(m_view_type_button);

--- a/UI/TechTreeWnd.cpp
+++ b/UI/TechTreeWnd.cpp
@@ -225,7 +225,8 @@ class TechTreeWnd::TechTreeControls : public CUIWnd {
 public:
     //! \name Structors //@{
     TechTreeControls(const std::string& config_name = "");
-    //@}
+    void CompleteConstruction() override;
+     //@}
 
     //! \name Mutators //@{
     void SizeMove(const GG::Pt& ul, const GG::Pt& lr) override;
@@ -270,8 +271,11 @@ const int TechTreeWnd::TechTreeControls::UPPER_LEFT_PAD = 2;
 
 TechTreeWnd::TechTreeControls::TechTreeControls(const std::string& config_name) :
     CUIWnd(UserString("TECH_DISPLAY"), GG::INTERACTIVE | GG::DRAGABLE | GG::RESIZABLE | GG::ONTOP, config_name)
+{}
+
+void TechTreeWnd::TechTreeControls::CompleteConstruction()
 {
-    const int tooltip_delay = GetOptionsDB().Get<int>("UI.tooltip-delay");
+   const int tooltip_delay = GetOptionsDB().Get<int>("UI.tooltip-delay");
     const boost::filesystem::path icon_dir = ClientUI::ArtDir() / "icons" / "tech" / "controls";
 
     // create a button for each tech category...
@@ -337,6 +341,9 @@ TechTreeWnd::TechTreeControls::TechTreeControls(const std::string& config_name) 
     AttachChild(m_view_type_button);
 
     SetChildClippingMode(ClipToClient);
+
+    CUIWnd::CompleteConstruction();
+
     DoButtonLayout();
 }
 
@@ -1991,8 +1998,8 @@ TechTreeWnd::TechTreeWnd(GG::X w, GG::Y h, bool initially_hidden /*= true*/) :
     m_tech_list->TechPediaDisplaySignal.connect(
         boost::bind(&TechTreeWnd::TechPediaDisplaySlot, this, _1));
 
-    m_enc_detail_panel = new EncyclopediaDetailPanel(GG::ONTOP | GG::INTERACTIVE | GG::DRAGABLE | GG::RESIZABLE | CLOSABLE | PINABLE, RES_PEDIA_WND_NAME);
-    m_tech_tree_controls = new TechTreeControls(RES_CONTROLS_WND_NAME);
+    m_enc_detail_panel = GG::Wnd::Create<EncyclopediaDetailPanel>(GG::ONTOP | GG::INTERACTIVE | GG::DRAGABLE | GG::RESIZABLE | CLOSABLE | PINABLE, RES_PEDIA_WND_NAME);
+    m_tech_tree_controls =  GG::Wnd::Create<TechTreeControls>(RES_CONTROLS_WND_NAME);
 
     m_enc_detail_panel->ClosingSignal.connect(
         boost::bind(&TechTreeWnd::HidePedia, this));

--- a/UI/TechTreeWnd.cpp
+++ b/UI/TechTreeWnd.cpp
@@ -1089,8 +1089,8 @@ TechTreeWnd::LayoutPanel::LayoutPanel(GG::X w, GG::Y h) :
 
     m_layout_surface = new LayoutSurface();
 
-    m_vscroll = new CUIScroll(GG::VERTICAL);
-    m_hscroll = new CUIScroll(GG::HORIZONTAL);
+    m_vscroll = GG::Wnd::Create<CUIScroll>(GG::VERTICAL);
+    m_hscroll = GG::Wnd::Create<CUIScroll>(GG::HORIZONTAL);
 
     m_zoom_in_button = Wnd::Create<CUIButton>("+");
     m_zoom_in_button->SetColor(ClientUI::WndColor());

--- a/UI/TechTreeWnd.h
+++ b/UI/TechTreeWnd.h
@@ -31,6 +31,7 @@ public:
     TechTreeWnd(GG::X w, GG::Y h, bool initially_hidden = true);
     ~TechTreeWnd();
     //@}
+    void CompleteConstruction() override;
 
     /** \name Accessors */ //@{
     double                  Scale() const;

--- a/UI/TextBrowseWnd.cpp
+++ b/UI/TextBrowseWnd.cpp
@@ -30,11 +30,16 @@ TextBrowseWnd::TextBrowseWnd(const std::string& title_text, const std::string& m
     m_main_text->Resize(GG::Pt(w, ICON_BROWSE_ICON_HEIGHT));
     m_main_text->SetResetMinSize(true);
     m_main_text->Resize(m_main_text->MinSize());
+}
+
+void TextBrowseWnd::CompleteConstruction()
+{
+    GG::BrowseInfoWnd::CompleteConstruction();
 
     AttachChild(m_main_text);
     AttachChild(m_title_text);
 
-    Resize(GG::Pt(w, ROW_HEIGHT + m_main_text->Height()));
+    Resize(GG::Pt(Width(), IconTextBrowseWndRowHeight() + m_main_text->Height()));
 }
 
 bool TextBrowseWnd::WndHasBrowseInfo(const Wnd* wnd, std::size_t mode) const {

--- a/UI/TextBrowseWnd.cpp
+++ b/UI/TextBrowseWnd.cpp
@@ -32,8 +32,7 @@ TextBrowseWnd::TextBrowseWnd(const std::string& title_text, const std::string& m
     m_main_text->Resize(m_main_text->MinSize());
 }
 
-void TextBrowseWnd::CompleteConstruction()
-{
+void TextBrowseWnd::CompleteConstruction() {
     GG::BrowseInfoWnd::CompleteConstruction();
 
     AttachChild(m_main_text);

--- a/UI/TextBrowseWnd.h
+++ b/UI/TextBrowseWnd.h
@@ -11,6 +11,8 @@ class TextBrowseWnd : public GG::BrowseInfoWnd {
 public:
     TextBrowseWnd(const std::string& title_text, const std::string& main_text, GG::X w = GG::X(200));
 
+    void CompleteConstruction() override;
+
     bool WndHasBrowseInfo(const Wnd* wnd, std::size_t mode) const override;
 
     void Render() override;

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -271,9 +271,10 @@ HumanClientApp::HumanClientApp(int width, int height, bool calculate_fps, const 
         boost::bind(&HumanClientApp::UpdateFPSLimit, this));
 
     std::shared_ptr<GG::BrowseInfoWnd> default_browse_info_wnd(
-        new GG::TextBoxBrowseInfoWnd(GG::X(400), ClientUI::GetFont(),
-                                     GG::Clr(0, 0, 0, 200), ClientUI::WndOuterBorderColor(), ClientUI::TextColor(),
-                                     GG::FORMAT_LEFT | GG::FORMAT_WORDBREAK, 1));
+        GG::Wnd::Create<GG::TextBoxBrowseInfoWnd>(
+            GG::X(400), ClientUI::GetFont(),
+            GG::Clr(0, 0, 0, 200), ClientUI::WndOuterBorderColor(), ClientUI::TextColor(),
+            GG::FORMAT_LEFT | GG::FORMAT_WORDBREAK, 1));
     GG::Wnd::SetDefaultBrowseInfoWnd(default_browse_info_wnd);
 
     std::shared_ptr<GG::Texture> cursor_texture = m_ui->GetTexture(ClientUI::ArtDir() / "cursors" / "default_cursor.png");

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -468,11 +468,11 @@ void HumanClientApp::NewSinglePlayerGame(bool quickstart) {
     bool ended_with_ok = false;
     std::vector<std::pair<std::string, std::string>> game_rules = GetGameRules().GetRulesAsStrings();
     if (!quickstart) {
-        GalaxySetupWnd galaxy_wnd;
-        galaxy_wnd.Run();
-        ended_with_ok = galaxy_wnd.EndedWithOk();
+        auto galaxy_wnd = GG::Wnd::Create<GalaxySetupWnd>();
+        galaxy_wnd->Run();
+        ended_with_ok = galaxy_wnd->EndedWithOk();
         if (ended_with_ok)
-            game_rules = galaxy_wnd.GetRulesAsStrings();
+            game_rules = galaxy_wnd->GetRulesAsStrings();
     }
 
     m_connected = m_networking->ConnectToLocalHostServer();
@@ -574,10 +574,10 @@ void HumanClientApp::MultiPlayerGame() {
         return;
     }
 
-    ServerConnectWnd server_connect_wnd;
-    server_connect_wnd.Run();
+    auto server_connect_wnd = GG::Wnd::Create<ServerConnectWnd>();
+    server_connect_wnd->Run();
 
-    std::string server_name = server_connect_wnd.Result().second;
+    std::string server_name = server_connect_wnd->Result().second;
 
     if (server_name.empty())
         return;
@@ -602,16 +602,16 @@ void HumanClientApp::MultiPlayerGame() {
     m_connected = m_networking->ConnectToServer(server_name);
     if (!m_connected) {
         ClientUI::MessageBox(UserString("ERR_CONNECT_TIMED_OUT"), true);
-        if (server_connect_wnd.Result().second == "HOST GAME SELECTED")
+        if (server_connect_wnd->Result().second == "HOST GAME SELECTED")
             ResetToIntro();
         return;
     }
 
-    if (server_connect_wnd.Result().second == "HOST GAME SELECTED") {
-        m_networking->SendMessage(HostMPGameMessage(server_connect_wnd.Result().first));
+    if (server_connect_wnd->Result().second == "HOST GAME SELECTED") {
+        m_networking->SendMessage(HostMPGameMessage(server_connect_wnd->Result().first));
         m_fsm->process_event(HostMPGameRequested());
     } else {
-        m_networking->SendMessage(JoinGameMessage(server_connect_wnd.Result().first, Networking::CLIENT_TYPE_HUMAN_PLAYER));
+        m_networking->SendMessage(JoinGameMessage(server_connect_wnd->Result().first, Networking::CLIENT_TYPE_HUMAN_PLAYER));
         m_fsm->process_event(JoinMPGameRequested());
     }
 }
@@ -648,10 +648,10 @@ void HumanClientApp::LoadSinglePlayerGame(std::string filename/* = ""*/) {
         }
     } else {
         try {
-            SaveFileDialog sfd(SP_SAVE_FILE_EXTENSION, true);
-            sfd.Run();
-            if (!sfd.Result().empty())
-                filename = sfd.Result();
+            auto sfd = GG::Wnd::Create<SaveFileDialog>(SP_SAVE_FILE_EXTENSION, true);
+            sfd->Run();
+            if (!sfd->Result().empty())
+                filename = sfd->Result();
         } catch (const std::exception& e) {
             ClientUI::MessageBox(e.what(), true);
         }
@@ -1167,9 +1167,9 @@ void HumanClientApp::Autosave() {
 }
 
 std::string HumanClientApp::SelectLoadFile() {
-    SaveFileDialog sfd(true);
-    sfd.Run();
-    return sfd.Result();
+    auto sfd = GG::Wnd::Create<SaveFileDialog>(true);
+    sfd->Run();
+    return sfd->Result();
 }
 
 void HumanClientApp::ResetClientData() {


### PR DESCRIPTION
This PR adds a `CompleteConstruction()` override to all classes that will require a factory function instead of a constructor.

The method is to convert 
````
ConstructorForT(parameters) {
    some_code
    m_child = Wnd::Create<T>;
    AttachChild(m_child);
}
````
to
````
ConstructorForT(parameters) {
    some_code
    m_child = Wnd::Create<T>;
}

void CompleteConstruction() {
    AttachChild(m_child);
}
````
Where necessary virtual functions that were indirectly called in constructors, and hence did not have access to a virtual function table, are made explicitly non-virtual or refactored to be called at the appropriate time or with the appropriate pre conditions.

There are some additional conversions to use `Wnd::Create<T>` which were not included in previous PRs.  Some were due to were due to the virtual function issue, some are top-level windows and some were converted from style factory functions.

