### PR TITLE
Authentication support

### DIFF
--- a/UI/CMakeLists.txt
+++ b/UI/CMakeLists.txt
@@ -41,6 +41,7 @@ target_sources(freeorion
         ${CMAKE_CURRENT_LIST_DIR}/MultiplayerLobbyWnd.h
         ${CMAKE_CURRENT_LIST_DIR}/ObjectListWnd.h
         ${CMAKE_CURRENT_LIST_DIR}/OptionsWnd.h
+        ${CMAKE_CURRENT_LIST_DIR}/PasswordEnterWnd.h
         ${CMAKE_CURRENT_LIST_DIR}/PlayerListWnd.h
         ${CMAKE_CURRENT_LIST_DIR}/PopulationPanel.h
         ${CMAKE_CURRENT_LIST_DIR}/ProductionWnd.h
@@ -99,6 +100,7 @@ target_sources(freeorion
         ${CMAKE_CURRENT_LIST_DIR}/MultiplayerLobbyWnd.cpp
         ${CMAKE_CURRENT_LIST_DIR}/ObjectListWnd.cpp
         ${CMAKE_CURRENT_LIST_DIR}/OptionsWnd.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/PasswordEnterWnd.cpp
         ${CMAKE_CURRENT_LIST_DIR}/PlayerListWnd.cpp
         ${CMAKE_CURRENT_LIST_DIR}/PopulationPanel.cpp
         ${CMAKE_CURRENT_LIST_DIR}/ProductionWnd.cpp

--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -8,6 +8,7 @@
 #include "ChatWnd.h"
 #include "PlayerListWnd.h"
 #include "MultiplayerLobbyWnd.h"
+#include "PasswordEnterWnd.h"
 #include "Sound.h"
 #include "Hotkeys.h"
 
@@ -606,6 +607,7 @@ ClientUI::ClientUI() :
     m_player_list_wnd(nullptr),
     m_intro_screen(nullptr),
     m_multiplayer_lobby_wnd(nullptr),
+    m_password_enter_wnd(nullptr),
     m_ship_designs(new ShipDesignManager())
 {
     s_the_UI = this;
@@ -621,6 +623,7 @@ ClientUI::ClientUI() :
 
     m_intro_screen = GG::Wnd::Create<IntroScreen>();
     m_multiplayer_lobby_wnd = GG::Wnd::Create<MultiPlayerLobbyWnd>();
+    m_password_enter_wnd = GG::Wnd::Create<PasswordEnterWnd>();
 
     GetOptionsDB().OptionChangedSignal("app-width").connect(
         boost::bind(&ClientUI::HandleSizeChange, this, true));
@@ -709,6 +712,9 @@ void ClientUI::ShowMultiPlayerLobbyWnd() {
 
 std::shared_ptr<MultiPlayerLobbyWnd> ClientUI::GetMultiPlayerLobbyWnd()
 { return m_multiplayer_lobby_wnd; }
+
+std::shared_ptr<PasswordEnterWnd> ClientUI::GetPasswordEnterWnd()
+{ return m_password_enter_wnd; }
 
 
 std::shared_ptr<SaveFileDialog> ClientUI::GetSaveFileDialog()

--- a/UI/ClientUI.h
+++ b/UI/ClientUI.h
@@ -20,6 +20,7 @@ class MapWnd;
 class MessageWnd;
 class PlayerListWnd;
 class MultiPlayerLobbyWnd;
+class PasswordEnterWnd;
 struct SaveGameUIData;
 class System;
 class ShipDesignManager;
@@ -42,6 +43,7 @@ public:
     std::shared_ptr<PlayerListWnd>          GetPlayerListWnd();                         //!< Returns the players list window.
     std::shared_ptr<IntroScreen>            GetIntroScreen();                           //!< Returns the intro screen / splash window.
     std::shared_ptr<MultiPlayerLobbyWnd>    GetMultiPlayerLobbyWnd();                   //!< Returns the multiplayer lobby window.
+    std::shared_ptr<PasswordEnterWnd>       GetPasswordEnterWnd();                      //!< Returns the authentication window.
 
     /** Returns a perhaps nullptr to any existing SaveFileDialog*/
     std::shared_ptr<SaveFileDialog>         GetSaveFileDialog();
@@ -241,6 +243,7 @@ private:
     std::shared_ptr<IntroScreen>            m_intro_screen;         //!< splash screen / main menu when starting program
     std::shared_ptr<MultiPlayerLobbyWnd>    m_multiplayer_lobby_wnd;//!< the multiplayer lobby
     std::shared_ptr<SaveFileDialog>         m_savefile_dialog = nullptr;
+    std::shared_ptr<PasswordEnterWnd>       m_password_enter_wnd;   //!< the authentication window
 
     PrefixedTextures    m_prefixed_textures;
 

--- a/UI/PasswordEnterWnd.cpp
+++ b/UI/PasswordEnterWnd.cpp
@@ -11,8 +11,9 @@ namespace {
     const GG::Y WINDOW_HEIGHT(535);
 }
 
-PasswordEnterWnd::PasswordEnterWnd()
-    :CUIWnd(UserString("AUTHENTICATION_WINDOW_TITLE"), GG::X(80), GG::Y(130), WINDOW_WIDTH, WINDOW_HEIGHT,
+PasswordEnterWnd::PasswordEnterWnd() :
+    CUIWnd(UserString("AUTHENTICATION_WINDOW_TITLE"), GG::X(80), GG::Y(130),
+           WINDOW_WIDTH, WINDOW_HEIGHT,
            GG::INTERACTIVE | GG::DRAGABLE | GG::MODAL),
     m_player_name_edit(nullptr),
     m_password_edit(nullptr),

--- a/UI/PasswordEnterWnd.cpp
+++ b/UI/PasswordEnterWnd.cpp
@@ -7,8 +7,8 @@
 #include "../client/human/HumanClientApp.h"
 
 namespace {
-    const GG::X WINDOW_WIDTH(400);
-    const GG::Y WINDOW_HEIGHT(535);
+    const GG::X WINDOW_WIDTH(300);
+    const GG::Y WINDOW_HEIGHT(250);
 }
 
 PasswordEnterWnd::PasswordEnterWnd() :
@@ -22,21 +22,20 @@ PasswordEnterWnd::PasswordEnterWnd() :
 {}
 
 void PasswordEnterWnd::CompleteConstruction() {
-    auto auth_desc_label = GG::Wnd::Create<CUILabel>(UserString("AUTHENTICATION_DESC"), GG::FORMAT_LEFT);
+    auto auth_desc_label = GG::Wnd::Create<CUILabel>(UserString("AUTHENTICATION_DESC"), GG::FORMAT_LEFT | GG::FORMAT_WORDBREAK);
     auto player_name_label = GG::Wnd::Create<CUILabel>(UserString("PLAYER_NAME_LABEL"), GG::FORMAT_LEFT);
     m_player_name_edit = GG::Wnd::Create<CUIEdit>("");
     auto password_label = GG::Wnd::Create<CUILabel>(UserString("PASSWORD_LABEL"), GG::FORMAT_LEFT);
-    m_password_edit = GG::Wnd::Create<CUIEdit>("");
-    m_password_edit->SetTextColor(m_password_edit->InteriorColor());
-    m_password_edit->SetSelectedTextColor(m_password_edit->HiliteColor());
+    m_password_edit = GG::Wnd::Create<CensoredCUIEdit>("");
     m_ok_bn = Wnd::Create<CUIButton>(UserString("OK"));
     m_cancel_bn = Wnd::Create<CUIButton>(UserString("CANCEL"));
 
     const GG::X OK_CANCEL_BUTTON_WIDTH(100);
     const int CONTROL_MARGIN = 5;
 
-    auto layout = GG::Wnd::Create<GG::Layout>(GG::X0, GG::Y0, GG::X1, GG::Y1, 8, 4, CONTROL_MARGIN);
-    layout->SetMinimumColumnWidth(0, auth_desc_label->MinUsableSize().x + CONTROL_MARGIN);
+    auto layout = GG::Wnd::Create<GG::Layout>(GG::X0, GG::Y0, GG::X1, GG::Y1, 4, 4, CONTROL_MARGIN);
+    layout->SetMinimumColumnWidth(0, std::max(player_name_label->MinUsableSize().x,
+                                              password_label->MinUsableSize().x) + CONTROL_MARGIN);
     layout->SetColumnStretch(1, 1.0);
     layout->SetMinimumColumnWidth(2, OK_CANCEL_BUTTON_WIDTH + CONTROL_MARGIN);
     layout->SetMinimumColumnWidth(3, OK_CANCEL_BUTTON_WIDTH + CONTROL_MARGIN);

--- a/UI/PasswordEnterWnd.cpp
+++ b/UI/PasswordEnterWnd.cpp
@@ -1,0 +1,68 @@
+#include "PasswordEnterWnd.h"
+
+#include <GG/GUI.h>
+
+#include "../util/i18n.h"
+
+namespace {
+    const GG::X WINDOW_WIDTH(400);
+    const GG::Y WINDOW_HEIGHT(535);
+}
+
+PasswordEnterWnd::PasswordEnterWnd()
+    :CUIWnd(UserString("AUTHENTICATION_WINDOW_TITLE"), GG::X(80), GG::Y(130), WINDOW_WIDTH, WINDOW_HEIGHT,
+           GG::INTERACTIVE | GG::DRAGABLE | GG::MODAL),
+    m_player_name_edit(nullptr),
+    m_password_edit(nullptr),
+    m_ok_bn(nullptr),
+    m_cancel_bn(nullptr)
+{}
+
+void PasswordEnterWnd::CompleteConstruction() {
+    auto auth_desc_label = GG::Wnd::Create<CUILabel>(UserString("AUTHENTICATION_DESC"), GG::FORMAT_LEFT);
+    auto player_name_label = GG::Wnd::Create<CUILabel>(UserString("PLAYER_NAME_LABEL"), GG::FORMAT_LEFT);
+    m_player_name_edit = GG::Wnd::Create<CUIEdit>("");
+    auto password_label = GG::Wnd::Create<CUILabel>(UserString("PASSWORD_LABEL"), GG::FORMAT_LEFT);
+    m_password_edit = GG::Wnd::Create<CUIEdit>("");
+    m_ok_bn = Wnd::Create<CUIButton>(UserString("OK"));
+    m_cancel_bn = Wnd::Create<CUIButton>(UserString("CANCEL"));
+
+    const GG::X OK_CANCEL_BUTTON_WIDTH(100);
+    const int CONTROL_MARGIN = 5;
+
+    auto layout = GG::Wnd::Create<GG::Layout>(GG::X0, GG::Y0, GG::X1, GG::Y1, 8, 4, CONTROL_MARGIN);
+    layout->SetMinimumColumnWidth(0, auth_desc_label->MinUsableSize().x + CONTROL_MARGIN);
+    layout->SetColumnStretch(1, 1.0);
+    layout->SetMinimumColumnWidth(2, OK_CANCEL_BUTTON_WIDTH + CONTROL_MARGIN);
+    layout->SetMinimumColumnWidth(3, OK_CANCEL_BUTTON_WIDTH + CONTROL_MARGIN);
+    layout->SetMinimumRowHeight(0, auth_desc_label->Height() + (2 * CONTROL_MARGIN));
+    layout->SetMinimumRowHeight(1, m_player_name_edit->Height() + CONTROL_MARGIN);
+    layout->SetMinimumRowHeight(2, m_password_edit->Height() + CONTROL_MARGIN);
+    layout->SetMinimumRowHeight(3, m_ok_bn->MinUsableSize().y + CONTROL_MARGIN);
+
+    layout->Add(auth_desc_label, 0, 0, 1, 4, GG::ALIGN_VCENTER);
+    layout->Add(player_name_label, 1, 0, 1, 1, GG::ALIGN_VCENTER);
+    layout->Add(m_player_name_edit, 1, 1, 1, 3, GG::ALIGN_VCENTER);
+    layout->Add(password_label, 2, 0, 1, 1, GG::ALIGN_VCENTER);
+    layout->Add(m_password_edit, 2, 1, 1, 3, GG::ALIGN_VCENTER);
+    layout->Add(m_ok_bn, 3, 2);
+    layout->Add(m_cancel_bn, 3, 3);
+
+    SetLayout(layout);
+
+    ResetDefaultPosition();
+}
+
+GG::Rect PasswordEnterWnd::CalculatePosition() const {
+    GG::Pt new_ul((GG::GUI::GetGUI()->AppWidth() - WINDOW_WIDTH) / 2,
+                  (GG::GUI::GetGUI()->AppHeight() - WINDOW_HEIGHT) / 2);
+    GG::Pt new_sz(WINDOW_WIDTH, WINDOW_HEIGHT);
+    return GG::Rect(new_ul, new_ul + new_sz);
+}
+
+void PasswordEnterWnd::ModalInit()
+{ GG::GUI::GetGUI()->SetFocusWnd(m_password_edit); }
+
+void PasswordEnterWnd::KeyPress(GG::Key key, std::uint32_t key_code_point, GG::Flags<GG::ModKey> mod_keys) {
+}
+

--- a/UI/PasswordEnterWnd.cpp
+++ b/UI/PasswordEnterWnd.cpp
@@ -26,6 +26,8 @@ void PasswordEnterWnd::CompleteConstruction() {
     m_player_name_edit = GG::Wnd::Create<CUIEdit>("");
     auto password_label = GG::Wnd::Create<CUILabel>(UserString("PASSWORD_LABEL"), GG::FORMAT_LEFT);
     m_password_edit = GG::Wnd::Create<CUIEdit>("");
+    m_password_edit->SetTextColor(m_password_edit->InteriorColor());
+    m_password_edit->SetSelectedTextColor(m_password_edit->HiliteColor());
     m_ok_bn = Wnd::Create<CUIButton>(UserString("OK"));
     m_cancel_bn = Wnd::Create<CUIButton>(UserString("CANCEL"));
 
@@ -73,11 +75,19 @@ void PasswordEnterWnd::ModalInit()
 void PasswordEnterWnd::KeyPress(GG::Key key, std::uint32_t key_code_point, GG::Flags<GG::ModKey> mod_keys) {
     if (key == GG::GGK_ESCAPE) { // Same behaviour as if "Cancel" was pressed
         CancelClicked();
+    } else if (key == GG::GGK_RETURN || key == GG::GGK_KP_ENTER) {
+        if (GG::GUI::GetGUI()->FocusWnd() == m_player_name_edit) {
+            GG::GUI::GetGUI()->SetFocusWnd(m_password_edit);
+        } else if (GG::GUI::GetGUI()->FocusWnd() == m_password_edit) {
+            OkClicked();
+        }
     }
 }
 
-void PasswordEnterWnd::SetPlayerName(const std::string& player_name)
-{ m_player_name_edit->SetText(player_name); }
+void PasswordEnterWnd::SetPlayerName(const std::string& player_name) {
+    m_player_name_edit->SetText(player_name);
+    m_password_edit->SetText(std::string());
+}
 
 void PasswordEnterWnd::OkClicked() {
     HumanClientApp::GetApp()->Networking().SendMessage(AuthResponseMessage(*m_player_name_edit, *m_password_edit));

--- a/UI/PasswordEnterWnd.cpp
+++ b/UI/PasswordEnterWnd.cpp
@@ -3,6 +3,7 @@
 #include <GG/GUI.h>
 
 #include "../util/i18n.h"
+#include "../network/ClientNetworking.h"
 #include "../client/human/HumanClientApp.h"
 
 namespace {
@@ -70,12 +71,18 @@ void PasswordEnterWnd::ModalInit()
 { GG::GUI::GetGUI()->SetFocusWnd(m_password_edit); }
 
 void PasswordEnterWnd::KeyPress(GG::Key key, std::uint32_t key_code_point, GG::Flags<GG::ModKey> mod_keys) {
+    if (key == GG::GGK_ESCAPE) { // Same behaviour as if "Cancel" was pressed
+        CancelClicked();
+    }
 }
 
 void PasswordEnterWnd::SetPlayerName(const std::string& player_name)
 { m_player_name_edit->SetText(player_name); }
 
 void PasswordEnterWnd::OkClicked() {
+    HumanClientApp::GetApp()->Networking().SendMessage(AuthResponseMessage(*m_player_name_edit, *m_password_edit));
+    // hide window
+    HumanClientApp::GetApp()->Remove(shared_from_this());
 }
 
 void PasswordEnterWnd::CancelClicked()

--- a/UI/PasswordEnterWnd.cpp
+++ b/UI/PasswordEnterWnd.cpp
@@ -3,6 +3,7 @@
 #include <GG/GUI.h>
 
 #include "../util/i18n.h"
+#include "../client/human/HumanClientApp.h"
 
 namespace {
     const GG::X WINDOW_WIDTH(400);
@@ -51,6 +52,11 @@ void PasswordEnterWnd::CompleteConstruction() {
     SetLayout(layout);
 
     ResetDefaultPosition();
+
+    m_ok_bn->LeftClickedSignal.connect(
+        boost::bind(&PasswordEnterWnd::OkClicked, this));
+    m_cancel_bn->LeftClickedSignal.connect(
+        boost::bind(&PasswordEnterWnd::CancelClicked, this));
 }
 
 GG::Rect PasswordEnterWnd::CalculatePosition() const {
@@ -65,4 +71,13 @@ void PasswordEnterWnd::ModalInit()
 
 void PasswordEnterWnd::KeyPress(GG::Key key, std::uint32_t key_code_point, GG::Flags<GG::ModKey> mod_keys) {
 }
+
+void PasswordEnterWnd::SetPlayerName(const std::string& player_name)
+{ m_player_name_edit->SetText(player_name); }
+
+void PasswordEnterWnd::OkClicked() {
+}
+
+void PasswordEnterWnd::CancelClicked()
+{ HumanClientApp::GetApp()->CancelMultiplayerGameFromLobby(); }
 

--- a/UI/PasswordEnterWnd.cpp
+++ b/UI/PasswordEnterWnd.cpp
@@ -86,11 +86,12 @@ void PasswordEnterWnd::KeyPress(GG::Key key, std::uint32_t key_code_point, GG::F
 
 void PasswordEnterWnd::SetPlayerName(const std::string& player_name) {
     m_player_name_edit->SetText(player_name);
-    m_password_edit->SetText(std::string());
+    m_password_edit->SetText("");
 }
 
 void PasswordEnterWnd::OkClicked() {
-    HumanClientApp::GetApp()->Networking().SendMessage(AuthResponseMessage(*m_player_name_edit, *m_password_edit));
+    HumanClientApp::GetApp()->Networking().SendMessage(
+        AuthResponseMessage(*m_player_name_edit, m_password_edit->RawText()));
     // hide window
     HumanClientApp::GetApp()->Remove(shared_from_this());
 }

--- a/UI/PasswordEnterWnd.h
+++ b/UI/PasswordEnterWnd.h
@@ -1,0 +1,40 @@
+#ifndef _PasswordEnterDialog_h_
+#define _PasswordEnterDialog_h_
+
+#include <GG/Layout.h>
+
+#include "CUIWnd.h"
+#include "CUIControls.h"
+
+class PasswordEnterWnd : public CUIWnd {
+public:
+    /** \name Structors */ //@{
+    PasswordEnterWnd();
+    void CompleteConstruction() override;
+    //@}
+
+    //! \name Mutators
+    //!@{
+    void ModalInit() override;
+
+    void KeyPress(GG::Key key, std::uint32_t key_code_point, GG::Flags<GG::ModKey> mod_keys) override;
+    //!@}
+
+    /** \name Accessors */ //@{
+    /** returns a the player's name (.first) and the location of the server (.second -- IP address or name), or "" if none was selected */
+    const std::pair<std::string, std::string>& Result() const;
+    //@}
+
+protected:
+    GG::Rect CalculatePosition() const override;
+
+private:
+    std::shared_ptr<CUIEdit>            m_player_name_edit;
+    std::shared_ptr<CUIEdit>            m_password_edit;
+    std::shared_ptr<CUIButton>          m_ok_bn;
+    std::shared_ptr<CUIButton>          m_cancel_bn;
+};
+
+#endif // _PasswordEnterDialog_h_
+
+

--- a/UI/PasswordEnterWnd.h
+++ b/UI/PasswordEnterWnd.h
@@ -30,7 +30,7 @@ private:
     void CancelClicked();
 
     std::shared_ptr<CUIEdit>            m_player_name_edit;
-    std::shared_ptr<CUIEdit>            m_password_edit;
+    std::shared_ptr<CensoredCUIEdit>    m_password_edit;
     std::shared_ptr<CUIButton>          m_ok_bn;
     std::shared_ptr<CUIButton>          m_cancel_bn;
 };

--- a/UI/PasswordEnterWnd.h
+++ b/UI/PasswordEnterWnd.h
@@ -18,17 +18,17 @@ public:
     void ModalInit() override;
 
     void KeyPress(GG::Key key, std::uint32_t key_code_point, GG::Flags<GG::ModKey> mod_keys) override;
-    //!@}
 
-    /** \name Accessors */ //@{
-    /** returns a the player's name (.first) and the location of the server (.second -- IP address or name), or "" if none was selected */
-    const std::pair<std::string, std::string>& Result() const;
-    //@}
+    void SetPlayerName(const std::string& player_name);
+    //!@}
 
 protected:
     GG::Rect CalculatePosition() const override;
 
 private:
+    void OkClicked();
+    void CancelClicked();
+
     std::shared_ptr<CUIEdit>            m_player_name_edit;
     std::shared_ptr<CUIEdit>            m_password_edit;
     std::shared_ptr<CUIButton>          m_ok_bn;

--- a/Xcode/FreeOrion.xcodeproj/project.pbxproj
+++ b/Xcode/FreeOrion.xcodeproj/project.pbxproj
@@ -341,6 +341,7 @@
 		CE71ED7A1DADAB120085A4DC /* DependencyVersions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE97F70A1BC7D74D0002988B /* DependencyVersions.cpp */; };
 		CE71ED7B1DADAB130085A4DC /* DependencyVersions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE97F70A1BC7D74D0002988B /* DependencyVersions.cpp */; };
 		CE71ED7C1DADAB140085A4DC /* DependencyVersions.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE97F70A1BC7D74D0002988B /* DependencyVersions.cpp */; };
+		CE764D5F1F8153230085A4DC /* PasswordEnterWnd.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CE764D5D1F8153230085A4DC /* PasswordEnterWnd.cpp */; };
 		CE76B9CF1CBD7ACC0085A4DC /* ChangeLog.md in Resources */ = {isa = PBXBuildFile; fileRef = CE76B9CD1CBD7A990085A4DC /* ChangeLog.md */; };
 		CEC4ADC11BC13741000DFA9B /* AIFramework.cpp in Sources */ = {isa = PBXBuildFile; fileRef = CEC4ADBF1BC13741000DFA9B /* AIFramework.cpp */; };
 		CED22D4D1EB8F15B0085A4DC /* libboost_log.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 82714D761ADABE680071A329 /* libboost_log.a */; };
@@ -1107,6 +1108,8 @@
 		CE6183A51BB80D2E00952BEA /* ScrollPanel.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = ScrollPanel.cpp; sourceTree = "<group>"; };
 		CE6183AC1BB80D4900952BEA /* CUILinkTextBlock.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = CUILinkTextBlock.cpp; sourceTree = "<group>"; };
 		CE6183AD1BB80D4900952BEA /* CUILinkTextBlock.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CUILinkTextBlock.h; sourceTree = "<group>"; };
+		CE764D5D1F8153230085A4DC /* PasswordEnterWnd.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = PasswordEnterWnd.cpp; sourceTree = "<group>"; };
+		CE764D5E1F8153230085A4DC /* PasswordEnterWnd.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = PasswordEnterWnd.h; sourceTree = "<group>"; };
 		CE76B9CD1CBD7A990085A4DC /* ChangeLog.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; name = ChangeLog.md; path = ../ChangeLog.md; sourceTree = "<group>"; };
 		CE97F70A1BC7D74D0002988B /* DependencyVersions.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = DependencyVersions.cpp; sourceTree = "<group>"; };
 		CEC4ADBF1BC13741000DFA9B /* AIFramework.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; path = AIFramework.cpp; sourceTree = "<group>"; };
@@ -1693,6 +1696,8 @@
 				82132C2E15DA2BBC00F5B537 /* ObjectListWnd.h */,
 				471D5CCC0A98A3F900DA9C21 /* OptionsWnd.cpp */,
 				471D5CCD0A98A3F900DA9C21 /* OptionsWnd.h */,
+				CE764D5D1F8153230085A4DC /* PasswordEnterWnd.cpp */,
+				CE764D5E1F8153230085A4DC /* PasswordEnterWnd.h */,
 				2F60966312EEAD2200F58913 /* PlayerListWnd.cpp */,
 				2F60966412EEAD2200F58913 /* PlayerListWnd.h */,
 				8275F3ED1AD31381003568FF /* PopulationPanel.cpp */,
@@ -2707,6 +2712,7 @@
 				471D5E1E0A98A9AE00DA9C21 /* GalaxySetupWnd.cpp in Sources */,
 				8275F4041AD31381003568FF /* SpecialsPanel.cpp in Sources */,
 				8275F3FD1AD31381003568FF /* MeterBrowseWnd.cpp in Sources */,
+				CE764D5F1F8153230085A4DC /* PasswordEnterWnd.cpp in Sources */,
 				82B9AEA41AA71CCC00486B2A /* GraphicalSummary.cpp in Sources */,
 				82B9D447180C53FE0032F86D /* GraphControl.cpp in Sources */,
 				82B9AEA11AA71CCC00486B2A /* CombatLogWnd.cpp in Sources */,

--- a/client/ClientFSMEvents.h
+++ b/client/ClientFSMEvents.h
@@ -39,7 +39,8 @@ struct MessageEventBase {
     (Diplomacy)                                \
     (DiplomaticStatusUpdate)                   \
     (EndGame)                                  \
-    (CheckSum)
+    (CheckSum)                                 \
+    (AuthRequest)
 
 
 #define DECLARE_MESSAGE_EVENT(r, data, name)                            \

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -945,8 +945,9 @@ void HumanClientApp::HandleMessage(Message& msg) {
     case Message::DIPLOMATIC_STATUS:        m_fsm->process_event(DiplomaticStatusUpdate(msg));  break;
     case Message::END_GAME:                 m_fsm->process_event(::EndGame(msg));               break;
 
-    case Message::DISPATCH_COMBAT_LOGS:     m_fsm->process_event(DispatchCombatLogs(msg));       break;
+    case Message::DISPATCH_COMBAT_LOGS:     m_fsm->process_event(DispatchCombatLogs(msg));      break;
     case Message::DISPATCH_SAVE_PREVIEWS:   HandleSaveGamePreviews(msg);                         break;
+    case Message::AUTH_REQUEST:             m_fsm->process_event(AuthRequest(msg));             break;
     default:
         ErrorLogger() << "HumanClientApp::HandleMessage : Received an unknown message type \"" << msg.Type() << "\".";
     }

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -354,7 +354,9 @@ boost::statechart::result WaitingForMPJoinAck::react(const AuthRequest& msg) {
     std::string auth;
     ExtractAuthRequestMessageData(msg.m_message, player_name, auth);
 
-    Client().Register(Client().GetClientUI().GetPasswordEnterWnd());
+    auto password_dialog = Client().GetClientUI().GetPasswordEnterWnd();
+    password_dialog->SetPlayerName(player_name);
+    Client().Register(password_dialog);
 
     return discard_event();
 }
@@ -401,6 +403,15 @@ boost::statechart::result WaitingForMPJoinAck::react(const StartQuittingGame& e)
     return transit<QuittingGame>();
 }
 
+boost::statechart::result WaitingForMPJoinAck::react(const CancelMPGameClicked& a)
+{
+    TraceLogger(FSM) << "(HumanClientFSM) WaitingForMPJoinAck.CancelMPGameClicked";
+
+    // See reaction_transition_note.
+    auto retval = discard_event();
+    Client().ResetToIntro(true);
+    return retval;
+}
 
 ////////////////////////////////////////////////////////////
 // MPLobby

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -403,8 +403,7 @@ boost::statechart::result WaitingForMPJoinAck::react(const StartQuittingGame& e)
     return transit<QuittingGame>();
 }
 
-boost::statechart::result WaitingForMPJoinAck::react(const CancelMPGameClicked& a)
-{
+boost::statechart::result WaitingForMPJoinAck::react(const CancelMPGameClicked& a) {
     TraceLogger(FSM) << "(HumanClientFSM) WaitingForMPJoinAck.CancelMPGameClicked";
 
     // See reaction_transition_note.

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -346,6 +346,15 @@ boost::statechart::result WaitingForMPJoinAck::react(const JoinGame& msg) {
     }
 }
 
+boost::statechart::result WaitingForMPJoinAck::react(const AuthRequest& msg) {
+    TraceLogger(FSM) << "(HumanClientFSM) WaitingForMPJoinAck.AuthRequest";
+
+    std::string player_name;
+    std::string auth;
+    ExtractAuthRequestMessageData(msg.m_message, player_name, auth);
+    return discard_event();
+}
+
 boost::statechart::result WaitingForMPJoinAck::react(const Disconnection& d) {
     TraceLogger(FSM) << "(HumanClientFSM) PlayingGame.Disconnection";
 

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -13,6 +13,7 @@
 #include "../../UI/PlayerListWnd.h"
 #include "../../UI/IntroScreen.h"
 #include "../../UI/MultiplayerLobbyWnd.h"
+#include "../../UI/PasswordEnterWnd.h"
 #include "../../UI/MapWnd.h"
 
 #include <boost/format.hpp>
@@ -352,6 +353,9 @@ boost::statechart::result WaitingForMPJoinAck::react(const AuthRequest& msg) {
     std::string player_name;
     std::string auth;
     ExtractAuthRequestMessageData(msg.m_message, player_name, auth);
+
+    Client().Register(Client().GetClientUI().GetPasswordEnterWnd());
+
     return discard_event();
 }
 

--- a/client/human/HumanClientFSM.h
+++ b/client/human/HumanClientFSM.h
@@ -181,6 +181,7 @@ struct WaitingForMPJoinAck : boost::statechart::simple_state<WaitingForMPJoinAck
 
     typedef boost::mpl::list<
         boost::statechart::custom_reaction<JoinGame>,
+        boost::statechart::custom_reaction<AuthRequest>,
         boost::statechart::custom_reaction<Disconnection>,
         boost::statechart::custom_reaction<StartQuittingGame>,
         boost::statechart::custom_reaction<Error>
@@ -190,6 +191,7 @@ struct WaitingForMPJoinAck : boost::statechart::simple_state<WaitingForMPJoinAck
     ~WaitingForMPJoinAck();
 
     boost::statechart::result react(const JoinGame& a);
+    boost::statechart::result react(const AuthRequest& a);
     boost::statechart::result react(const Disconnection& d);
     boost::statechart::result react(const StartQuittingGame& msg);
     boost::statechart::result react(const Error& msg);

--- a/client/human/HumanClientFSM.h
+++ b/client/human/HumanClientFSM.h
@@ -184,6 +184,7 @@ struct WaitingForMPJoinAck : boost::statechart::simple_state<WaitingForMPJoinAck
         boost::statechart::custom_reaction<AuthRequest>,
         boost::statechart::custom_reaction<Disconnection>,
         boost::statechart::custom_reaction<StartQuittingGame>,
+        boost::statechart::custom_reaction<CancelMPGameClicked>,
         boost::statechart::custom_reaction<Error>
     > reactions;
 
@@ -194,6 +195,7 @@ struct WaitingForMPJoinAck : boost::statechart::simple_state<WaitingForMPJoinAck
     boost::statechart::result react(const AuthRequest& a);
     boost::statechart::result react(const Disconnection& d);
     boost::statechart::result react(const StartQuittingGame& msg);
+    boost::statechart::result react(const CancelMPGameClicked& msg);
     boost::statechart::result react(const Error& msg);
 
     CLIENT_ACCESSOR

--- a/default/python/README.md
+++ b/default/python/README.md
@@ -9,6 +9,8 @@ an execute_turn_events() function returning a boolean (successful completion).
 
 * AI/  -  Python code which controls the computer players.  This is a
 sub-module of the resource directory and can be changed with the --ai-path flag.
+* auth/  -  Python code which manages auth information stored either in a file
+or in a database.
 * common/  -  Common files for code utilized by both the AI and the server.
 * handlers/  -  see handlers/README.md
 * turn_events/  -  Python scripts that run at the beginning of every turn, and

--- a/default/python/auth/auth.py
+++ b/default/python/auth/auth.py
@@ -1,0 +1,4 @@
+
+def is_require_auth(player_name):
+    return False
+

--- a/default/python/auth/auth.py
+++ b/default/python/auth/auth.py
@@ -15,5 +15,5 @@ class AuthProvider:
         return player_name in self.logins
 
     def is_success_auth(self, player_name, auth):
-        return True
+        return self.logins.get(player_name) == auth
 

--- a/default/python/auth/auth.py
+++ b/default/python/auth/auth.py
@@ -1,4 +1,19 @@
+from common.configure_logging import redirect_logging_to_freeorion_logger, convenience_function_references_for_logger
 
-def is_require_auth(player_name):
-    return False
+# Logging is redirected before other imports so that import errors appear in log files.
+redirect_logging_to_freeorion_logger()
+(debug, info, warn, error, fatal) = convenience_function_references_for_logger()
+
+import sys
+
+class AuthProvider:
+    def __init__(self):
+        self.logins = { 'test' : 'test' }
+        print >> sys.stdout, "Auth initialized"
+ 
+    def is_require_auth(self, player_name):
+        return player_name in self.logins
+
+    def is_success_auth(self, player_name, auth):
+        return True
 

--- a/default/python/auth/auth.py
+++ b/default/python/auth/auth.py
@@ -6,10 +6,20 @@ redirect_logging_to_freeorion_logger()
 
 import sys
 
+import freeorion as fo
+
 class AuthProvider:
     def __init__(self):
-        self.logins = { 'test' : 'test' }
-        print >> sys.stdout, "Auth initialized"
+        self.logins = {}
+        try:
+            with open(fo.get_user_config_dir() + "/auth.txt") as f:
+                for line in f:
+                    l = line.rsplit(':', 1)
+                    self.logins[l[0]] = l[1]
+        except:
+            exctype, value = sys.exc_info()[:2]
+            warn("Cann't read auth file %s: %s %s" % (fo.get_user_config_dir() + "/auth.txt", exctype, value))
+        info("Auth initialized")
  
     def is_require_auth(self, player_name):
         return player_name in self.logins

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -973,6 +973,8 @@ Player name %1% already in use.
 ERROR_WRONG_PASSWORD
 Password wrong for player name %1%.
 
+ERROR_CONNECTION_WAS_REPLACED
+Your connection was replaced.
 
 ##
 ## Game Rules

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -970,6 +970,10 @@ Python AI for %1% crashed.
 ERROR_PLAYER_NAME_ALREADY_USED
 Player name %1% already in use.
 
+ERROR_WRONG_PASSWORD
+Password wrong for player name %1%.
+
+
 ##
 ## Game Rules
 ##

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1948,6 +1948,18 @@ Join a game
 REFRESH_LIST_BN
 Refresh list
 
+##
+## Password Dialog
+##
+
+AUTHENTICATION_WINDOW_TITLE
+Authentication
+
+AUTHENTICATION_DESC
+This player name requires authentication. Reminder! Password will be transfered plain-text.
+
+PASSWORD_LABEL
+Password
 
 ##
 ## Multiplayer lobby

--- a/msvc2015/FreeOrion/FreeOrion.vcxproj
+++ b/msvc2015/FreeOrion/FreeOrion.vcxproj
@@ -191,6 +191,7 @@
     <ClInclude Include="..\..\UI\MultiplayerLobbyWnd.h" />
     <ClInclude Include="..\..\UI\ObjectListWnd.h" />
     <ClInclude Include="..\..\UI\OptionsWnd.h" />
+    <ClInclude Include="..\..\UI\PasswordEnterWnd.h" />
     <ClInclude Include="..\..\UI\PlayerListWnd.h" />
     <ClInclude Include="..\..\UI\PopulationPanel.h" />
     <ClInclude Include="..\..\UI\ProductionWnd.h" />
@@ -301,6 +302,7 @@
     <ClCompile Include="..\..\UI\MultiplayerLobbyWnd.cpp" />
     <ClCompile Include="..\..\UI\ObjectListWnd.cpp" />
     <ClCompile Include="..\..\UI\OptionsWnd.cpp" />
+    <ClCompile Include="..\..\UI\PasswordEnterWnd.cpp" />
     <ClCompile Include="..\..\UI\PlayerListWnd.cpp" />
     <ClCompile Include="..\..\UI\PopulationPanel.cpp" />
     <ClCompile Include="..\..\UI\ProductionWnd.cpp" />

--- a/network/Message.cpp
+++ b/network/Message.cpp
@@ -643,6 +643,26 @@ Message ContentCheckSumMessage() {
     return Message(Message::CHECKSUM, os.str());
 }
 
+Message AuthRequestMessage(const std::string& player_name, const std::string& auth) {
+    std::ostringstream os;
+    {
+        freeorion_xml_oarchive oa(os);
+        oa << BOOST_SERIALIZATION_NVP(player_name)
+           << BOOST_SERIALIZATION_NVP(auth);
+    }
+    return Message(Message::AUTH_REQUEST, os.str());
+}
+
+Message AuthResponseMessage(const std::string& player_name, const std::string& auth) {
+    std::ostringstream os;
+    {
+        freeorion_xml_oarchive oa(os);
+        oa << BOOST_SERIALIZATION_NVP(player_name)
+           << BOOST_SERIALIZATION_NVP(auth);
+    }
+    return Message(Message::AUTH_RESPONSE, os.str());
+}
+
 ////////////////////////////////////////////////
 // Message data extractors
 ////////////////////////////////////////////////
@@ -1169,6 +1189,36 @@ void ExtractContentCheckSumMessageData(
 
     } catch(const std::exception& err) {
         ErrorLogger() << "ExtractContentCheckSumMessageData(const Message& msg, std::string& save_filename, std::map<std::string, unsigned int>) failed!  Message:\n"
+                      << msg.Text() << "\n"
+                      << "Error: " << err.what();
+        throw err;
+    }
+}
+
+void ExtractAuthRequestMessageData(const Message& msg, std::string& player_name, std::string& auth) {
+    try {
+        std::istringstream is(msg.Text());
+        freeorion_xml_iarchive ia(is);
+        ia >> BOOST_SERIALIZATION_NVP(player_name)
+           >> BOOST_SERIALIZATION_NVP(auth);
+
+    } catch(const std::exception& err) {
+        ErrorLogger() << "ExtractAuthRequestMessageData(const Message& msg, std::string& player_name, std::string& auth) failed!  Message:\n"
+                      << msg.Text() << "\n"
+                      << "Error: " << err.what();
+        throw err;
+    }
+}
+
+void ExtractAuthResponseMessageData(const Message& msg, std::string& player_name, std::string& auth) {
+    try {
+        std::istringstream is(msg.Text());
+        freeorion_xml_iarchive ia(is);
+        ia >> BOOST_SERIALIZATION_NVP(player_name)
+           >> BOOST_SERIALIZATION_NVP(auth);
+
+    } catch(const std::exception& err) {
+        ErrorLogger() << "ExtractAuthResponeMessageData(const Message& msg, std::string& player_name, std::string& auth) failed!  Message:\n"
                       << msg.Text() << "\n"
                       << "Error: " << err.what();
         throw err;

--- a/network/Message.h
+++ b/network/Message.h
@@ -95,7 +95,9 @@ public:
         REQUEST_COMBAT_LOGS,    ///< sent by client to request combat logs
         DISPATCH_COMBAT_LOGS,   ///< sent by host to client to provide combat logs
         LOGGER_CONFIG,          ///< sent by host to server and server to ais to configure logging
-        CHECKSUM                ///< sent by host to clients to specify what the parsed content checksum values should be
+        CHECKSUM,               ///< sent by host to clients to specify what the parsed content checksum values should be
+        AUTH_REQUEST,           ///< sent by server to client if choosed player_name require authentiation
+        AUTH_RESPONSE           ///< sent by client to server to provide password or other credentials
     )
 
     GG_CLASS_ENUM(TurnProgressPhase,
@@ -335,6 +337,12 @@ FO_COMMON_API Message StartMPGameMessage();
 /** creates a CHECKSUM message containing checksums of parsed content. */
 FO_COMMON_API Message ContentCheckSumMessage();
 
+/** creates a AUTH_REQUEST message containing \a player_name to login and \a auth additional authentication data. */
+FO_COMMON_API Message AuthRequestMessage(const std::string& player_name, const std::string& auth);
+
+/** creates a AUTH_RESPONSE message containing \a player_name to login and \a auth credentials. */
+FO_COMMON_API Message AuthResponseMessage(const std::string& player_name, const std::string& auth);
+
 ////////////////////////////////////////////////
 // Message data extractors
 ////////////////////////////////////////////////
@@ -403,5 +411,9 @@ FO_COMMON_API void ExtractDispatchCombatLogsMessageData(const Message& msg, std:
 FO_COMMON_API void ExtractLoggerConfigMessageData(const Message& msg, std::set<std::tuple<std::string, std::string, LogLevel>>& options);
 
 FO_COMMON_API void ExtractContentCheckSumMessageData(const Message& msg, std::map<std::string, unsigned int>& checksums);
+
+FO_COMMON_API void ExtractAuthRequestMessageData(const Message& msg, std::string& player_name, std::string& auth);
+
+FO_COMMON_API void ExtractAuthResponseMessageData(const Message& msg, std::string& player_name, std::string& auth);
 
 #endif // _Message_h_

--- a/network/ServerNetworking.cpp
+++ b/network/ServerNetworking.cpp
@@ -117,7 +117,8 @@ bool PlayerConnection::IsEstablished() const {
 }
 
 void PlayerConnection::AwaitPlayer(Networking::ClientType client_type,
-                                       const std::string& client_version_string) {
+                                   const std::string& client_version_string)
+{
     TraceLogger(network) << "PlayerConnection(@ " << this << ")::AwaitPlayer("
                          << client_type << ", " << client_version_string << ")";
     if (m_client_type != Networking::INVALID_CLIENT_TYPE) {

--- a/network/ServerNetworking.cpp
+++ b/network/ServerNetworking.cpp
@@ -116,6 +116,22 @@ bool PlayerConnection::IsEstablished() const {
     return (m_ID != INVALID_PLAYER_ID && !m_player_name.empty() && m_client_type != Networking::INVALID_CLIENT_TYPE);
 }
 
+void PlayerConnection::AwaitPlayer(Networking::ClientType client_type,
+                                       const std::string& client_version_string) {
+    TraceLogger(network) << "PlayerConnection(@ " << this << ")::AwaitPlayer("
+                         << client_type << ", " << client_version_string << ")";
+    if (m_client_type != Networking::INVALID_CLIENT_TYPE) {
+        ErrorLogger(network) << "PlayerConnection::AwaitPlayer attempting to re-await an already awaiting connection.";
+        return;
+    }
+    if (client_type == Networking::INVALID_CLIENT_TYPE || client_type >= NUM_CLIENT_TYPES) {
+        ErrorLogger(network) << "PlayerConnection::EstablishPlayer passed invalid client type: " << client_type;
+        return;
+    }
+    m_client_type = client_type;
+    m_client_version_string = client_version_string;
+}
+
 void PlayerConnection::EstablishPlayer(int id, const std::string& player_name, Networking::ClientType client_type,
                                        const std::string& client_version_string)
 {

--- a/network/ServerNetworking.cpp
+++ b/network/ServerNetworking.cpp
@@ -59,6 +59,7 @@ PlayerConnection::PlayerConnection(boost::asio::io_service& io_service,
     m_ID(INVALID_PLAYER_ID),
     m_new_connection(true),
     m_client_type(Networking::INVALID_CLIENT_TYPE),
+    m_authenticated(false),
     m_nonplayer_message_callback(nonplayer_message_callback),
     m_player_message_callback(player_message_callback),
     m_disconnected_callback(disconnected_callback)
@@ -116,6 +117,10 @@ bool PlayerConnection::IsEstablished() const {
     return (m_ID != INVALID_PLAYER_ID && !m_player_name.empty() && m_client_type != Networking::INVALID_CLIENT_TYPE);
 }
 
+bool PlayerConnection::IsAuthenticated() const {
+    return m_authenticated;
+}
+
 void PlayerConnection::AwaitPlayer(Networking::ClientType client_type,
                                    const std::string& client_version_string)
 {
@@ -170,6 +175,10 @@ void PlayerConnection::SetClientType(Networking::ClientType client_type) {
     m_client_type = client_type;
     if (m_client_type == Networking::INVALID_CLIENT_TYPE)
         ErrorLogger(network) << "PlayerConnection client type set to INVALID_CLIENT_TYPE...?";
+}
+
+void PlayerConnection::SetAuthenticated() {
+    m_authenticated = true;
 }
 
 const std::string& PlayerConnection::ClientVersionString() const

--- a/network/ServerNetworking.h
+++ b/network/ServerNetworking.h
@@ -200,6 +200,10 @@ public:
     /** Sends \a synchronous message to out on the connection and return true on success. */
     bool SendMessage(const Message& message);
 
+    /** Set player properties to use them after authentication successed. */
+    void AwaitPlayer(Networking::ClientType client_type,
+                         const std::string& client_version_string);
+
     /** Establishes a connection as a player with a specific name and id.
         This function must only be called once. */
     void EstablishPlayer(int id, const std::string& player_name, Networking::ClientType client_type,

--- a/network/ServerNetworking.h
+++ b/network/ServerNetworking.h
@@ -202,7 +202,7 @@ public:
 
     /** Set player properties to use them after authentication successed. */
     void AwaitPlayer(Networking::ClientType client_type,
-                         const std::string& client_version_string);
+                     const std::string& client_version_string);
 
     /** Establishes a connection as a player with a specific name and id.
         This function must only be called once. */

--- a/network/ServerNetworking.h
+++ b/network/ServerNetworking.h
@@ -191,6 +191,9 @@ public:
 
     /** Checks if the player is established, has a valid name, id and client type. */
     bool IsEstablished() const;
+
+    /** Checks if the player was authenticated. */
+    bool IsAuthenticated() const;
     //@}
 
     /** \name Mutators */ //@{
@@ -212,6 +215,9 @@ public:
     /** Sets this connection's client type. Useful for already-connected players
       * changing type such as in the multiplayer lobby. */
     void SetClientType(Networking::ClientType client_type);
+
+    /** Sets authenticated status for connection. */
+    void SetAuthenticated();
     //@}
 
     mutable boost::signals2::signal<void (const NullaryFn&)> EventSignal;
@@ -240,6 +246,7 @@ private:
     bool                            m_new_connection;
     Networking::ClientType          m_client_type;
     std::string                     m_client_version_string;
+    bool                            m_authenticated;
 
     MessageAndConnectionFn          m_nonplayer_message_callback;
     MessageAndConnectionFn          m_player_message_callback;

--- a/python/server/ServerFramework.cpp
+++ b/python/server/ServerFramework.cpp
@@ -101,7 +101,26 @@ bool PythonServer::InitModules() {
     // import auth script file
     m_python_module_auth = import("auth");
 
+    // Save AuthProvider instance in auth module's namespace
+    m_python_module_auth.attr("__dict__")["auth_provider"] = m_python_module_auth.attr("AuthProvider")();
+
     DebugLogger() << "Server Python modules successfully initialized!";
+    return true;
+}
+
+bool PythonServer::IsRequireAuth(const std::string& player_name, bool &result) const {
+    boost::python::object auth_provider = m_python_module_auth.attr("__dict__")["auth_provider"];
+    if (!auth_provider) {
+        ErrorLogger() << "Unable to get Python object auth_provider";
+        return false;
+    }
+    boost::python::object f = auth_provider.attr("is_require_auth");
+    if (!f) {
+        ErrorLogger() << "Unable to call Python method is_require_auth";
+        return false;
+    }
+    boost::python::object r = f(player_name);
+    result = boost::python::extract<bool>(r);
     return true;
 }
 

--- a/python/server/ServerFramework.cpp
+++ b/python/server/ServerFramework.cpp
@@ -90,6 +90,17 @@ bool PythonServer::InitModules() {
     // import universe generator script file
     m_python_module_turn_events = import("turn_events");
 
+    // Confirm existence of the directory containing the auth Python scripts
+    // and add it to Pythons sys.path to make sure Python will find our scripts
+    if (!fs::exists(GetPythonAuthDir())) {
+        ErrorLogger() << "Can't find folder containing auth scripts";
+        return false;
+    }
+    AddToSysPath(GetPythonAuthDir());
+
+    // import auth script file
+    m_python_module_auth = import("auth");
+
     DebugLogger() << "Server Python modules successfully initialized!";
     return true;
 }
@@ -128,3 +139,6 @@ const std::string GetPythonUniverseGeneratorDir()
 
 const std::string GetPythonTurnEventsDir()
 { return GetPythonDir() + "/turn_events"; }
+
+const std::string GetPythonAuthDir()
+{ return GetPythonDir() + "/auth"; }

--- a/python/server/ServerFramework.cpp
+++ b/python/server/ServerFramework.cpp
@@ -124,6 +124,22 @@ bool PythonServer::IsRequireAuth(const std::string& player_name, bool &result) c
     return true;
 }
 
+bool PythonServer::IsSuccessAuth(const std::string& player_name, const std::string& auth, bool &result) const {
+    boost::python::object auth_provider = m_python_module_auth.attr("__dict__")["auth_provider"];
+    if (!auth_provider) {
+        ErrorLogger() << "Unable to get Python object auth_provider";
+        return false;
+    }
+    boost::python::object f = auth_provider.attr("is_success_auth");
+    if (!f) {
+        ErrorLogger() << "Unable to call Python method is_success_auth";
+        return false;
+    }
+    boost::python::object r = f(player_name, auth);
+    result = boost::python::extract<bool>(r);
+    return true;
+}
+
 bool PythonServer::CreateUniverse(std::map<int, PlayerSetupData>& player_setup_data) {
     dict py_player_setup_data;
 

--- a/python/server/ServerFramework.h
+++ b/python/server/ServerFramework.h
@@ -14,6 +14,7 @@ public:
 
     bool CreateUniverse(std::map<int, PlayerSetupData>& player_setup_data); // Wraps call to the main Python universe generator function
     bool ExecuteTurnEvents();    // Wraps call to the main Python turn events function
+    bool IsRequireAuth(const std::string& player_name, bool &result) const; // Wraps call to AuthProvider's method is_require_auth
 
 private:
     // reference to imported Python universe generator module

--- a/python/server/ServerFramework.h
+++ b/python/server/ServerFramework.h
@@ -15,6 +15,7 @@ public:
     bool CreateUniverse(std::map<int, PlayerSetupData>& player_setup_data); // Wraps call to the main Python universe generator function
     bool ExecuteTurnEvents();    // Wraps call to the main Python turn events function
     bool IsRequireAuth(const std::string& player_name, bool &result) const; // Wraps call to AuthProvider's method is_require_auth
+    bool IsSuccessAuth(const std::string& player_name, const std::string& auth, bool &result) const; // Wraps call to AuthProvider's method is_success_auth
 
 private:
     // reference to imported Python universe generator module

--- a/python/server/ServerFramework.h
+++ b/python/server/ServerFramework.h
@@ -21,6 +21,9 @@ private:
 
     // reference to imported Python turn events module
     boost::python::object m_python_module_turn_events;
+
+    // reference to imported Python auth module
+    boost::python::object m_python_module_auth;
 };
 
 // Returns folder containing the Python universe generator scripts
@@ -29,5 +32,7 @@ const std::string GetPythonUniverseGeneratorDir();
 // Returns folder containing the Python turn events scripts
 const std::string GetPythonTurnEventsDir();
 
+// Returns folder containing the Python auth scripts
+const std::string GetPythonAuthDir();
 
 #endif /* defined(__FreeOrion__Python__ServerFramework__) */

--- a/python/server/ServerWrapper.cpp
+++ b/python/server/ServerWrapper.cpp
@@ -92,6 +92,10 @@ namespace {
     object GetResourceDirWrapper()
     { return object(PathToString(GetResourceDir())); }
 
+    // Wrapper for GetUserConfigDir
+    object GetUserConfigDirWrapper()
+    { return object(PathToString(GetUserConfigDir())); }
+
     // Wrapper for getting empire objects
     list GetAllEmpires() {
         list empire_list;
@@ -1299,6 +1303,7 @@ namespace FreeOrionPython {
         def("user_string",                          make_function(&UserString,      return_value_policy<copy_const_reference>()));
         def("roman_number",                         RomanNumber);
         def("get_resource_dir",                     GetResourceDirWrapper);
+        def("get_user_config_dir",                  GetUserConfigDirWrapper);
 
         def("all_empires",                          AllEmpires);
         def("invalid_object",                       InvalidObjectID);

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1519,6 +1519,11 @@ bool ServerApp::IsAuthRequired(const std::string& player_name) const {
     return true;
 }
 
+bool ServerApp::IsAuthSuccessed(const std::string& player_name, const std::string& auth) const {
+    /// ToDo: use python to check
+    return true;
+}
+
 bool ServerApp::IsHostless() const
 { return GetOptionsDB().Get<bool>("hostless"); }
 

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -455,11 +455,12 @@ void ServerApp::HandleLoggerConfig(const Message& msg, PlayerConnectionPtr playe
 
 void ServerApp::HandleNonPlayerMessage(const Message& msg, PlayerConnectionPtr player_connection) {
     switch (msg.Type()) {
-    case Message::HOST_SP_GAME: m_fsm->process_event(HostSPGame(msg, player_connection));   break;
-    case Message::HOST_MP_GAME: m_fsm->process_event(HostMPGame(msg, player_connection));   break;
-    case Message::JOIN_GAME:    m_fsm->process_event(JoinGame(msg, player_connection));     break;
-    case Message::ERROR_MSG:    m_fsm->process_event(Error(msg, player_connection));        break;
-    case Message::DEBUG:        break;
+    case Message::HOST_SP_GAME:  m_fsm->process_event(HostSPGame(msg, player_connection));   break;
+    case Message::HOST_MP_GAME:  m_fsm->process_event(HostMPGame(msg, player_connection));   break;
+    case Message::JOIN_GAME:     m_fsm->process_event(JoinGame(msg, player_connection));     break;
+    case Message::AUTH_RESPONSE: m_fsm->process_event(AuthResponse(msg, player_connection)); break;
+    case Message::ERROR_MSG:     m_fsm->process_event(Error(msg, player_connection));        break;
+    case Message::DEBUG:         break;
     default:
         if ((m_networking.size() == 1) && (player_connection->IsLocalConnection()) && (msg.Type() == Message::SHUT_DOWN_SERVER)) {
             DebugLogger() << "ServerApp::HandleNonPlayerMessage received Message::SHUT_DOWN_SERVER from the sole "
@@ -1510,6 +1511,11 @@ bool ServerApp::IsAvailableName(const std::string& player_name) const {
         if ((*it)->PlayerName() == player_name)
             return false;
     }
+    return true;
+}
+
+bool ServerApp::IsAuthRequired(const std::string& player_name) const {
+    /// ToDo: use python to check
     return true;
 }
 

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1516,7 +1516,7 @@ bool ServerApp::IsAvailableName(const std::string& player_name) const {
 
 bool ServerApp::IsAuthRequired(const std::string& player_name) {
     bool result = false;
-    bool success(false);
+    bool success = false;
     try {
         m_python_server.SetCurrentDir(GetPythonAuthDir());
         // Call the main Python turn events function
@@ -1537,14 +1537,15 @@ bool ServerApp::IsAuthRequired(const std::string& player_name) {
 
     if (!success) {
         ErrorLogger() << "Python scripted turn events failed.";
-        ServerApp::GetApp()->Networking().SendMessageAll(ErrorMessage(UserStringNop("SERVER_TURN_EVENTS_ERRORS"), false));
+        ServerApp::GetApp()->Networking().SendMessageAll(ErrorMessage(UserStringNop("SERVER_TURN_EVENTS_ERRORS"),
+                                                                      false));
     }
     return result;
 }
 
-bool ServerApp::IsAuthSuccessed(const std::string& player_name, const std::string& auth) {
+bool ServerApp::IsAuthSuccess(const std::string& player_name, const std::string& auth) {
     bool result = false;
-    bool success(false);
+    bool success = false;
     try {
         m_python_server.SetCurrentDir(GetPythonAuthDir());
         // Call the main Python turn events function
@@ -1565,7 +1566,8 @@ bool ServerApp::IsAuthSuccessed(const std::string& player_name, const std::strin
 
     if (!success) {
         ErrorLogger() << "Python scripted turn events failed.";
-        ServerApp::GetApp()->Networking().SendMessageAll(ErrorMessage(UserStringNop("SERVER_TURN_EVENTS_ERRORS"), false));
+        ServerApp::GetApp()->Networking().SendMessageAll(ErrorMessage(UserStringNop("SERVER_TURN_EVENTS_ERRORS"),
+                                                                      false));
     }
     return result;
 }

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1543,8 +1543,31 @@ bool ServerApp::IsAuthRequired(const std::string& player_name) {
 }
 
 bool ServerApp::IsAuthSuccessed(const std::string& player_name, const std::string& auth) {
-    /// ToDo: use python to check
-    return true;
+    bool result = false;
+    bool success(false);
+    try {
+        m_python_server.SetCurrentDir(GetPythonAuthDir());
+        // Call the main Python turn events function
+        success = m_python_server.IsSuccessAuth(player_name, auth, result);
+    } catch (boost::python::error_already_set err) {
+        success = false;
+        m_python_server.HandleErrorAlreadySet();
+        if (!m_python_server.IsPythonRunning()) {
+            ErrorLogger() << "Python interpreter is no longer running.  Attempting to restart.";
+            if (m_python_server.Initialize()) {
+                ErrorLogger() << "Python interpreter successfully restarted.";
+            } else {
+                ErrorLogger() << "Python interpreter failed to restart.  Exiting.";
+                m_fsm->process_event(ShutdownServer());
+            }
+        }
+    }
+
+    if (!success) {
+        ErrorLogger() << "Python scripted turn events failed.";
+        ServerApp::GetApp()->Networking().SendMessageAll(ErrorMessage(UserStringNop("SERVER_TURN_EVENTS_ERRORS"), false));
+    }
+    return result;
 }
 
 bool ServerApp::IsHostless() const

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -210,7 +210,7 @@ public:
     bool IsAuthRequired(const std::string& player_name);
 
     /** Checks if \a auth match \a player_name. */
-    bool IsAuthSuccessed(const std::string& player_name, const std::string& auth);
+    bool IsAuthSuccess(const std::string& player_name, const std::string& auth);
     //@}
 
     void UpdateSavePreviews(const Message& msg, PlayerConnectionPtr player_connection);

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -128,12 +128,6 @@ public:
 
     /** Checks if server runs in a hostless mode. */
     bool IsHostless() const;
-
-    /** Checks if \a player_name requires auth to login. */
-    bool IsAuthRequired(const std::string& player_name) const;
-
-    /** Checks if \a auth match \a player_name. */
-    bool IsAuthSuccessed(const std::string& player_name, const std::string& auth) const;
     //@}
 
 
@@ -211,6 +205,12 @@ public:
     void    LoadMPGameInit(const MultiplayerLobbyData& lobby_data,
                            const std::vector<PlayerSaveGameData>& player_save_game_data,
                            std::shared_ptr<ServerSaveGameData> server_save_game_data);
+
+    /** Checks if \a player_name requires auth to login. */
+    bool IsAuthRequired(const std::string& player_name);
+
+    /** Checks if \a auth match \a player_name. */
+    bool IsAuthSuccessed(const std::string& player_name, const std::string& auth);
     //@}
 
     void UpdateSavePreviews(const Message& msg, PlayerConnectionPtr player_connection);

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -128,9 +128,12 @@ public:
 
     /** Checks if server runs in a hostless mode. */
     bool IsHostless() const;
-    
+
     /** Checks if \a player_name requires auth to login. */
     bool IsAuthRequired(const std::string& player_name) const;
+
+    /** Checks if \a auth match \a player_name. */
+    bool IsAuthSuccessed(const std::string& player_name, const std::string& auth) const;
     //@}
 
 

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -128,6 +128,9 @@ public:
 
     /** Checks if server runs in a hostless mode. */
     bool IsHostless() const;
+    
+    /** Checks if \a player_name requires auth to login. */
+    bool IsAuthRequired(const std::string& player_name) const;
     //@}
 
 

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -570,10 +570,77 @@ sc::result MPLobby::react(const Disconnection& d) {
     return discard_event();
 }
 
+void MPLobby::EstablishPlayer(const PlayerConnectionPtr& player_connection,
+                              const std::string& player_name,
+                              Networking::ClientType client_type,
+                              const std::string& client_version_string)
+{
+    ServerApp& server = Server();
+    const SpeciesManager& sm = GetSpeciesManager();
+
+    // assign unique player ID to newly connected player
+    int player_id = server.m_networking.NewPlayerID();
+
+    // establish player with requested client type and acknowldge via connection
+    player_connection->EstablishPlayer(player_id, player_name, client_type, client_version_string);
+    player_connection->SendMessage(ContentCheckSumMessage());
+    player_connection->SendMessage(JoinAckMessage(player_id));
+
+    // inform player of host
+    player_connection->SendMessage(HostIDMessage(server.m_networking.HostPlayerID()));
+
+    // Inform AI of logging configuration.
+    if (client_type == Networking::CLIENT_TYPE_AI_PLAYER)
+        player_connection->SendMessage(
+            LoggerConfigMessage(Networking::INVALID_PLAYER_ID, LoggerOptionsLabelsAndLevels(LoggerTypes::both)));
+
+    // assign player info from defaults or from connection to lobby data players list
+    PlayerSetupData player_setup_data;
+    player_setup_data.m_player_name =   player_name;
+    player_setup_data.m_client_type =   client_type;
+    player_setup_data.m_empire_name =   (client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER) ? player_name : GenerateEmpireName(player_name, m_lobby_data->m_players);
+    player_setup_data.m_empire_color =  GetUnusedEmpireColour(m_lobby_data->m_players);
+    if (m_lobby_data->m_seed != "")
+        player_setup_data.m_starting_species_name = sm.RandomPlayableSpeciesName();
+    else
+        player_setup_data.m_starting_species_name = sm.SequentialPlayableSpeciesName(player_id);
+
+    // after setting all details, push into lobby data
+    m_lobby_data->m_players.push_back(std::make_pair(player_id, player_setup_data));
+
+    // drop ready player flag at new player
+    for (std::pair<int, PlayerSetupData>& plr : m_lobby_data->m_players) {
+        if (plr.second.m_empire_name == player_name) {
+            // change empire name
+            plr.second.m_empire_name = (plr.second.m_client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER) ? plr.second.m_player_name : GenerateEmpireName(plr.second.m_player_name, m_lobby_data->m_players);
+        }
+
+        plr.second.m_player_ready = false;
+    }
+
+    if (player_connection->IsAuthenticated()) {
+        // drop other connection with same name
+        std::list<PlayerConnectionPtr> to_disconnect;
+        for (ServerNetworking::const_established_iterator it = server.m_networking.established_begin();
+             it != server.m_networking.established_end(); ++it)
+        {
+            if ((*it)->PlayerName() == player_name && player_connection != (*it)) {
+                (*it)->SendMessage(ErrorMessage(UserString("ERROR_CONNECTION_WAS_REPLACED"), true));
+                to_disconnect.push_back(*it);
+            }
+        }
+        for (const auto& conn : to_disconnect)
+        { server.Networking().Disconnect(conn); }
+    }
+
+    for (auto it = server.m_networking.established_begin();
+         it != server.m_networking.established_end(); ++it)
+    { (*it)->SendMessage(ServerLobbyUpdateMessage(*m_lobby_data)); }
+}
+
 sc::result MPLobby::react(const JoinGame& msg) {
     TraceLogger(FSM) << "(ServerFSM) MPLobby.JoinGame";
     ServerApp& server = Server();
-    const SpeciesManager& sm = GetSpeciesManager();
     const Message& message = msg.m_message;
     const PlayerConnectionPtr& player_connection = msg.m_player_connection;
 
@@ -630,49 +697,7 @@ sc::result MPLobby::react(const JoinGame& msg) {
 
     player_name = new_player_name;
 
-    // assign unique player ID to newly connected player
-    int player_id = server.m_networking.NewPlayerID();
-
-    // establish player with requested client type and acknowldge via connection
-    player_connection->EstablishPlayer(player_id, player_name, client_type, client_version_string);
-    player_connection->SendMessage(ContentCheckSumMessage());
-    player_connection->SendMessage(JoinAckMessage(player_id));
-
-    // inform player of host
-    player_connection->SendMessage(HostIDMessage(server.m_networking.HostPlayerID()));
-
-    // Inform AI of logging configuration.
-    if (client_type == Networking::CLIENT_TYPE_AI_PLAYER)
-        player_connection->SendMessage(
-            LoggerConfigMessage(Networking::INVALID_PLAYER_ID, LoggerOptionsLabelsAndLevels(LoggerTypes::both)));
-
-    // assign player info from defaults or from connection to lobby data players list
-    PlayerSetupData player_setup_data;
-    player_setup_data.m_player_name =   player_name;
-    player_setup_data.m_client_type =   client_type;
-    player_setup_data.m_empire_name =   (client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER) ? player_name : GenerateEmpireName(player_name, m_lobby_data->m_players);
-    player_setup_data.m_empire_color =  GetUnusedEmpireColour(m_lobby_data->m_players);
-    if (m_lobby_data->m_seed != "")
-        player_setup_data.m_starting_species_name = sm.RandomPlayableSpeciesName();
-    else
-        player_setup_data.m_starting_species_name = sm.SequentialPlayableSpeciesName(player_id);
-
-    // after setting all details, push into lobby data
-    m_lobby_data->m_players.push_back(std::make_pair(player_id, player_setup_data));
-
-    // drop ready player flag at new player
-    for (std::pair<int, PlayerSetupData>& plr : m_lobby_data->m_players) {
-        if (plr.second.m_empire_name == player_name) {
-            // change empire name
-            plr.second.m_empire_name = (plr.second.m_client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER) ? plr.second.m_player_name : GenerateEmpireName(plr.second.m_player_name, m_lobby_data->m_players);
-        }
-
-        plr.second.m_player_ready = false;
-    }
-
-    for (auto it = server.m_networking.established_begin();
-         it != server.m_networking.established_end(); ++it)
-    { (*it)->SendMessage(ServerLobbyUpdateMessage(*m_lobby_data)); }
+    EstablishPlayer(player_connection, player_name, client_type, client_version_string);
 
     return discard_event();
 }
@@ -680,7 +705,6 @@ sc::result MPLobby::react(const JoinGame& msg) {
 sc::result MPLobby::react(const AuthResponse& msg) {
     TraceLogger(FSM) << "(ServerFSM) MPLobby.AuthResponse";
     ServerApp& server = Server();
-    const SpeciesManager& sm = GetSpeciesManager();
     const Message& message = msg.m_message;
     const PlayerConnectionPtr& player_connection = msg.m_player_connection;
 
@@ -695,69 +719,14 @@ sc::result MPLobby::react(const AuthResponse& msg) {
         server.Networking().Disconnect(player_connection);
         return discard_event();
     }
-
-    // TODO: Merge it with MPLobby::react(const JoinGame& msg)
-    // assign unique player ID to newly connected player
-    int player_id = server.m_networking.NewPlayerID();
+    player_connection->SetAuthenticated();
 
     Networking::ClientType client_type = player_connection->GetClientType();
 
-    // establish player with requested client type and acknowldge via connection
-    player_connection->EstablishPlayer(player_id,
-                                       player_name,
-                                       client_type,
-                                       player_connection->ClientVersionString());
-    player_connection->SendMessage(ContentCheckSumMessage());
-    player_connection->SendMessage(JoinAckMessage(player_id));
-
-    // inform player of host
-    player_connection->SendMessage(HostIDMessage(server.m_networking.HostPlayerID()));
-
-    // Inform AI of logging configuration.
-    if (client_type == Networking::CLIENT_TYPE_AI_PLAYER)
-        player_connection->SendMessage(
-            LoggerConfigMessage(Networking::INVALID_PLAYER_ID, LoggerOptionsLabelsAndLevels(LoggerTypes::both)));
-
-    // assign player info from defaults or from connection to lobby data players list
-    PlayerSetupData player_setup_data;
-    player_setup_data.m_player_name =   player_name;
-    player_setup_data.m_client_type =   client_type;
-    player_setup_data.m_empire_name =   (client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER) ? player_name : GenerateEmpireName(player_name, m_lobby_data->m_players);
-    player_setup_data.m_empire_color =  GetUnusedEmpireColour(m_lobby_data->m_players);
-    if (m_lobby_data->m_seed != "")
-        player_setup_data.m_starting_species_name = sm.RandomPlayableSpeciesName();
-    else
-        player_setup_data.m_starting_species_name = sm.SequentialPlayableSpeciesName(player_id);
-
-    // after setting all details, push into lobby data
-    m_lobby_data->m_players.push_back(std::make_pair(player_id, player_setup_data));
-
-    // drop ready player flag at new player
-    for (std::pair<int, PlayerSetupData>& plr : m_lobby_data->m_players) {
-        if (plr.second.m_empire_name == player_name) {
-            // change empire name
-            plr.second.m_empire_name = (plr.second.m_client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER) ? plr.second.m_player_name : GenerateEmpireName(plr.second.m_player_name, m_lobby_data->m_players);
-        }
-
-        plr.second.m_player_ready = false;
-    }
-
-    // drop other connection with same name
-    std::list<PlayerConnectionPtr> to_disconnect;
-    for (ServerNetworking::const_established_iterator it = server.m_networking.established_begin();
-         it != server.m_networking.established_end(); ++it)
-    {
-        if ((*it)->PlayerName() == player_name && player_connection != (*it)) {
-            (*it)->SendMessage(ErrorMessage(UserString("ERROR_CONNECTION_WAS_REPLACED"), true));
-            to_disconnect.push_back(*it);
-        }
-    }
-    for (const auto& conn : to_disconnect)
-    { server.Networking().Disconnect(conn); }
-
-    for (ServerNetworking::const_established_iterator it = server.m_networking.established_begin();
-         it != server.m_networking.established_end(); ++it)
-    { (*it)->SendMessage(ServerLobbyUpdateMessage(*m_lobby_data)); }
+    EstablishPlayer(player_connection,
+                    player_name,
+                    client_type,
+                    player_connection->ClientVersionString());
 
     return discard_event();
 }

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -436,6 +436,7 @@ MPLobby::MPLobby(my_context c) :
     TraceLogger(FSM) << "(ServerFSM) MPLobby";
     ClockSeed();
     ServerApp& server = Server();
+    server.InitializePython();
     const SpeciesManager& sm = GetSpeciesManager();
     if (server.IsHostless()) {
         DebugLogger(FSM) << "(ServerFSM) MPLobby. Fill MPLobby data from the previous game.";

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -1544,6 +1544,13 @@ sc::result WaitingForMPGameJoiners::react(const JoinGame& msg) {
         }
 
     } else if (client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER) {
+        if (server.IsAuthRequired(player_name)) {
+            // send authentication request
+            player_connection->AwaitPlayer(client_type, client_version_string);
+            player_connection->SendMessage(AuthRequestMessage(player_name, "PLAIN-TEXT"));
+            return discard_event();
+        }
+
         // verify that there is room left for this player
         int already_connected_players = m_expected_ai_player_names.size() + server.m_networking.NumEstablishedPlayers();
         if (already_connected_players >= m_num_expected_players) {
@@ -1551,6 +1558,48 @@ sc::result WaitingForMPGameJoiners::react(const JoinGame& msg) {
             ErrorLogger(FSM) << "WaitingForSPGameJoiners.JoinGame : A human player attempted to join the game but there was not enough room.  Terminating connection.";
             server.m_networking.Disconnect(player_connection);
         } else {
+
+            std::string original_player_name = player_name;
+
+            // Remove AI prefix to distinguish Human from AI.
+            std::string ai_prefix = UserString("AI_PLAYER") + "_";
+            if (client_type != Networking::CLIENT_TYPE_AI_PLAYER) {
+                while (player_name.compare(0, ai_prefix.size(), ai_prefix) == 0)
+                    player_name.erase(0, ai_prefix.size());
+            }
+            if(player_name.empty())
+                player_name = "_";
+
+            std::string new_player_name = player_name;
+
+            bool collision = true;
+            std::size_t t = 1;
+            while (t <= m_lobby_data->m_players.size() + 1 && collision) {
+                collision = false;
+                if (!server.IsAvailableName(new_player_name) || server.IsAuthRequired(new_player_name)) {
+                    collision = true;
+                } else {
+                    for (std::pair<int, PlayerSetupData>& plr : m_lobby_data->m_players) {
+                        if (plr.second.m_empire_name == new_player_name) {
+                            collision = true;
+                            break;
+                        }
+                    }
+                }
+
+                if (collision)
+                    new_player_name = player_name + std::to_string(++t); // start alternative names from 2
+            }
+
+            if (collision) {
+                player_connection->SendMessage(ErrorMessage(str(FlexibleFormat(UserString("ERROR_PLAYER_NAME_ALREADY_USED")) % original_player_name),
+                                                            true));
+                server.Networking().Disconnect(player_connection);
+                return discard_event();
+            }
+
+            player_name = new_player_name;
+
             // expected human player
             player_connection->EstablishPlayer(player_id, player_name, client_type, client_version_string);
             player_connection->SendMessage(JoinAckMessage(player_id));
@@ -1577,6 +1626,54 @@ sc::result WaitingForMPGameJoiners::react(const AuthResponse& msg) {
     std::string player_name;
     std::string auth;
     ExtractAuthResponseMessageData(message, player_name, auth);
+
+    if (!server.IsAuthSuccess(player_name, auth)) {
+        // wrong password
+        player_connection->SendMessage(ErrorMessage(str(FlexibleFormat(UserString("ERROR_WRONG_PASSWORD")) % player_name),
+                                                    true));
+        server.Networking().Disconnect(player_connection);
+        return discard_event();
+    }
+
+    player_connection->SetAuthenticated();
+    Networking::ClientType client_type = player_connection->GetClientType();
+
+    if (client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER) {
+        // drop other connection with same name
+        std::list<PlayerConnectionPtr> to_disconnect;
+        for (ServerNetworking::const_established_iterator it = server.m_networking.established_begin();
+             it != server.m_networking.established_end(); ++it)
+        {
+            if ((*it)->PlayerName() == player_name && player_connection != (*it)) {
+                (*it)->SendMessage(ErrorMessage(UserString("ERROR_CONNECTION_WAS_REPLACED"), true));
+                to_disconnect.push_back(*it);
+            }
+        }
+        for (const auto& conn : to_disconnect)
+        { server.Networking().Disconnect(conn); }
+
+        // verify that there is room left for this player
+        int already_connected_players = m_expected_ai_player_names.size() + server.m_networking.NumEstablishedPlayers();
+        if (already_connected_players >= m_num_expected_players) {
+            // too many human players
+            ErrorLogger(FSM) << "WaitingForSPGameJoiners.JoinGame : A human player attempted to join the game but there was not enough room.  Terminating connection.";
+            server.m_networking.Disconnect(player_connection);
+        } else {
+            // expected human player
+            int player_id = server.m_networking.NewPlayerID();
+            player_connection->EstablishPlayer(player_id, player_name, client_type, player_connection->ClientVersionString());
+            player_connection->SendMessage(JoinAckMessage(player_id));
+        }
+    } else {
+        // non-human player
+        ErrorLogger(FSM) << "WaitingForMPGameJoiners.AuthResponse : A non-human player attempted to join the game.";
+        server.m_networking.Disconnect(player_connection);
+    }
+
+    // force immediate check if all expected AIs are present, so that the FSM
+    // won't get stuck in this state waiting for JoinGame messages that will
+    // never come since no other AIs are left to join
+    post_event(CheckStartConditions());
 
     return discard_event();
 }

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -582,7 +582,7 @@ sc::result MPLobby::react(const JoinGame& msg) {
     std::string client_version_string;
     ExtractJoinGameMessageData(message, player_name, client_type, client_version_string);
 
-    if(client_type != Networking::CLIENT_TYPE_AI_PLAYER && server.IsAuthRequired(player_name)) {
+    if (client_type != Networking::CLIENT_TYPE_AI_PLAYER && server.IsAuthRequired(player_name)) {
         // send authentication request
         player_connection->AwaitPlayer(client_type, client_version_string);
         player_connection->SendMessage(AuthRequestMessage(player_name, "PLAIN-TEXT"));
@@ -688,7 +688,7 @@ sc::result MPLobby::react(const AuthResponse& msg) {
     std::string auth;
     ExtractAuthResponseMessageData(message, player_name, auth);
 
-    if (!server.IsAuthSuccessed(player_name, auth)) {
+    if (!server.IsAuthSuccess(player_name, auth)) {
         // wrong password
         player_connection->SendMessage(ErrorMessage(str(FlexibleFormat(UserString("ERROR_WRONG_PASSWORD")) % player_name),
                                                     true));
@@ -704,9 +704,9 @@ sc::result MPLobby::react(const AuthResponse& msg) {
 
     // establish player with requested client type and acknowldge via connection
     player_connection->EstablishPlayer(player_id,
-                    player_name,
-                    client_type,
-                    player_connection->ClientVersionString());
+                                       player_name,
+                                       client_type,
+                                       player_connection->ClientVersionString());
     player_connection->SendMessage(ContentCheckSumMessage());
     player_connection->SendMessage(JoinAckMessage(player_id));
 

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -606,7 +606,7 @@ sc::result MPLobby::react(const JoinGame& msg) {
     std::size_t t = 1;
     while (t <= m_lobby_data->m_players.size() + 1 && collision) {
         collision = false;
-        if (!server.IsAvailableName(new_player_name)) {
+        if (!server.IsAvailableName(new_player_name) || server.IsAuthRequired(new_player_name)) {
             collision = true;
         } else {
             for (std::pair<int, PlayerSetupData>& plr : m_lobby_data->m_players) {

--- a/server/ServerFSM.h
+++ b/server/ServerFSM.h
@@ -198,6 +198,12 @@ struct MPLobby : sc::state<MPLobby, ServerFSM> {
     std::shared_ptr<ServerSaveGameData>     m_server_save_game_data;
     int                                     m_ai_next_index;
 
+private:
+    void EstablishPlayer(const PlayerConnectionPtr& player_connection,
+                         const std::string& player_name,
+                         Networking::ClientType client_type,
+                         const std::string& client_version_string);
+
     SERVER_ACCESSOR
 };
 

--- a/server/ServerFSM.h
+++ b/server/ServerFSM.h
@@ -84,6 +84,7 @@ struct MessageEventBase {
     (PlayerChat)                            \
     (Diplomacy)                             \
     (ModeratorAct)                          \
+    (AuthResponse)                          \
     (Error)
 
 
@@ -166,6 +167,7 @@ struct MPLobby : sc::state<MPLobby, ServerFSM> {
     typedef boost::mpl::list<
         sc::custom_reaction<Disconnection>,
         sc::custom_reaction<JoinGame>,
+        sc::custom_reaction<AuthResponse>,
         sc::custom_reaction<LobbyUpdate>,
         sc::custom_reaction<PlayerChat>,
         sc::custom_reaction<StartMPGame>,
@@ -181,6 +183,7 @@ struct MPLobby : sc::state<MPLobby, ServerFSM> {
 
     sc::result react(const Disconnection& d);
     sc::result react(const JoinGame& msg);
+    sc::result react(const AuthResponse& msg);
     sc::result react(const LobbyUpdate& msg);
     sc::result react(const PlayerChat& msg);
     sc::result react(const StartMPGame& msg);
@@ -238,6 +241,7 @@ struct WaitingForMPGameJoiners : sc::state<WaitingForMPGameJoiners, ServerFSM> {
     typedef boost::mpl::list<
         sc::in_state_reaction<Disconnection, ServerFSM, &ServerFSM::HandleNonLobbyDisconnection>,
         sc::custom_reaction<JoinGame>,
+        sc::custom_reaction<AuthResponse>,
         sc::custom_reaction<CheckStartConditions>,
         sc::custom_reaction<ShutdownServer>,
         sc::custom_reaction<Hostless>,
@@ -248,6 +252,7 @@ struct WaitingForMPGameJoiners : sc::state<WaitingForMPGameJoiners, ServerFSM> {
     ~WaitingForMPGameJoiners();
 
     sc::result react(const JoinGame& msg);
+    sc::result react(const AuthResponse& msg);
     sc::result react(const CheckStartConditions& u);
     // unlike in SP game setup, no save file data needs to be loaded in this
     // state, as all the relevant info about AIs is provided by the lobby data.


### PR DESCRIPTION
Plain-text authentication support.

It introduces two new message types requesting and responding authentication information.
Access to persistence storage with player auth data rely on `auth` python module.
It also unifies checks in `JoinGame` and `AuthResponse` events in `MPLobby` and `WaitingForMPGamesJoiners` states which are inconsistent now.