### PR TITLE
Fix Bug #1639 Dragging parts in DesignWnd incorrectly hides parts.

### DIFF
--- a/GG/src/Wnd.cpp
+++ b/GG/src/Wnd.cpp
@@ -576,7 +576,9 @@ void Wnd::AttachChild(std::shared_ptr<Wnd> wnd)
         std::cerr << std::endl << "Wnd::AttachChild called either during the constructor "
                   << "or after the destructor has run. Not attaching child."
                   << std::endl << " parent = " << m_name << " child = " << wnd->m_name;
-        throw;
+        // Soft failure:
+        // Intentionally do nothing, to create minimal disruption to non-dev
+        // players if a dev accidentally puts an AttachChild in its own constructor.
     }
 }
 

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -3132,11 +3132,7 @@ void SlotControl::ChildrenDraggedAway(const std::vector<GG::Wnd*>& wnds, const G
     const PartControl* part_control = dynamic_cast<const PartControl*>(wnd);
     if (part_control != m_part_control.get())
         return;
-    // SlotContentsAlteredSignal is connected to this->SetPart, which will
-    // delete m_part_control if it is not null.  The drop-accepting Wnd is
-    // responsible for deleting the accepted Wnd, so setting m_part_control = nullptr
-    // here prevents this->SetPart from deleting it prematurely
-    m_part_control = nullptr;
+    DetachChildAndReset(m_part_control);
     SlotContentsAlteredSignal(nullptr);
 }
 
@@ -3148,12 +3144,17 @@ void SlotControl::DragDropEnter(const GG::Pt& pt, std::map<const Wnd*, bool>& dr
 
     DropsAcceptable(drop_wnds_acceptable.begin(), drop_wnds_acceptable.end(), pt, mod_keys);
 
+    // Note:  If this SlotControl is being dragged over this indicates the dragged part would
+    //        replace this part.
     if (drop_wnds_acceptable.begin()->second && m_part_control)
         m_part_control->Hide();
 }
 
 void SlotControl::DragDropLeave() {
-    if (m_part_control)
+    // Note:  If m_part_control is being dragged, this does nothing, because it is detached.
+    //        If this SlotControl is being dragged over this indicates the dragged part would
+    //        replace this part.
+    if (m_part_control && !GG::GUI::GetGUI()->DragDropWnd(m_part_control.get()))
         m_part_control->Show();
 }
 

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -3018,8 +3018,6 @@ void SlotControl::CompleteConstruction() {
 }
 
 bool SlotControl::EventFilter(GG::Wnd* w, const GG::WndEvent& event) {
-    //std::cout << "SlotControl::EventFilter " << EventTypeName(event) << std::endl << std::flush;
-
     if (w == this)
         return false;
 
@@ -3029,10 +3027,6 @@ bool SlotControl::EventFilter(GG::Wnd* w, const GG::WndEvent& event) {
     case GG::WndEvent::CheckDrops:
     case GG::WndEvent::DragDropLeave:
     case GG::WndEvent::DragDroppedOn:
-        if (w == this) {
-            ErrorLogger() << "SlotControl::EventFilter w == this";
-            return false;
-        }
         HandleEvent(event);
         return true;
         break;

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -3045,22 +3045,17 @@ void SlotControl::DropsAcceptable(DropsAcceptableIter first, DropsAcceptableIter
     if (std::distance(first, last) != 1)
         return;
 
-    bool acceptable_part_found = false;
     for (DropsAcceptableIter it = first; it != last; ++it) {
-        if (!acceptable_part_found && it->first->DragDropDataType() == PART_CONTROL_DROP_TYPE_STRING) {
-            const auto part_control = boost::polymorphic_downcast<const PartControl* const>(it->first);
-            const PartType* part_type = part_control->Part();
-            if (part_type &&
-                part_type->CanMountInSlotType(m_slot_type) &&
-                part_control != m_part_control.get())
-            {
-                it->second = true;
-                acceptable_part_found = true;
-            } else {
-                it->second = false;
-            }
-        } else {
-            it->second = false;
+        if (it->first->DragDropDataType() != PART_CONTROL_DROP_TYPE_STRING)
+            continue;
+        const auto part_control = boost::polymorphic_downcast<const PartControl* const>(it->first);
+        const PartType* part_type = part_control->Part();
+        if (part_type &&
+            part_type->CanMountInSlotType(m_slot_type) &&
+            part_control != m_part_control.get())
+        {
+            it->second = true;
+            return;
         }
     }
 }

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -892,20 +892,18 @@ void PartsListBox::PartsListBoxRow::ChildrenDraggedAway(const std::vector<GG::Wn
     // should only be one wnd in list because PartControls doesn't allow selection, so dragging is
     // only one-at-a-time
     auto control = dynamic_cast<GG::Control*>(wnds.front());
-    if (!control)
+    if (!control || empty())
         return;
 
     // find control in row
     unsigned int ii = 0;
-    for (; ii <= size(); ++ii) {
-        if (ii == size())
-            return;
-        if (empty())
-            continue;
-
+    for (; ii < size(); ++ii) {
         if (at(ii) != control)
             continue;
     }
+
+    if (ii == size())
+        return;
 
     RemoveCell(ii);  // Wnd that accepts drop takes ownership of dragged-away control
 


### PR DESCRIPTION
This PR depends on #1632 and fixes issues raised in #1639.

The PR uses `GUI::DragDropWnd()` to check if a `PartControl` that is dragged over a slot should hide to indicate that the part can be replaced or not hide because it is being dragged over itself.

The PR also refactors some code associated with the dragging and dropping of `PartControls` in order to reduce repeated code and level of nesting.