### PR TITLE
Fix bug #1405 auto quit pauses but doesn't exit.

### DIFF
--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -843,12 +843,7 @@ void HumanClientApp::HandleSystemEvents() {
         m_connected = false;
         DisconnectedFromServer();
     } else if (auto msg = Networking().GetMessage()) {
-        try {
-            HandleMessage(*msg);
-        } catch (const std::exception& e) {
-            ErrorLogger() << "exception handing message: " << e.what();
-            ErrorLogger() << "message type: " << msg->Type() << " and text: " << msg->Text();
-        }
+        HandleMessage(*msg);
     }
 }
 

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -724,10 +724,8 @@ boost::statechart::result WaitingForGameStart::react(const GameStart& msg) {
     if (!is_new_game)
         Client().GetClientUI().RestoreFromSaveData(ui_data);
 
-    // if I am the host on the first turn, do an autosave. on later turns, will
-    // have just loaded save, so don't need to autosave. might also have just
-    // loaded a turn 1 autosave, but not sure how to check for that here...
-    if (Client().CurrentTurn() == 1 && Client().Networking().PlayerIsHost(Client().PlayerID()))
+    // if I am the host on the first turn, do an autosave.
+    if (is_new_game && Client().Networking().PlayerIsHost(Client().PlayerID()))
         Client().Autosave();
 
     return transit<PlayingTurn>();


### PR DESCRIPTION
This PR refactors and changes the following auto-save and auto-quit functionality:
- always create a final turn auto-save when auto-quitting
- do not catch all exceptions in HumanClientApp message queue.  Catching all exceptions creates a race state with `CleanQuit` exception which may be caught in the message queue catch statement depending on timing.  It is unclear from the code and the commit that added the `try ... catch` what exceptions were meant to be caught.
- move auto-quit to the completion of the (now automatic) auto-save.  Previously, the auto-quit was in a race with the auto-save which would prevent the auto-quit from happening on some machines.

Based on information in @geoffthemedio 's logs posted in #1405 I think that there were multiple race states preventing auto-quit from working consistently.  The auto-quit needed to be initiated after the auto-save completed and outside of the window where the message queue was polled.  The auto-save being in progress prevents the server from exiting and the `CleanQuit` exception being caught prevents the client from exiting.