### PR TITLE
Improve unconsumed_event() functions.  Add state names.

### DIFF
--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -90,8 +90,28 @@ void HumanClientFSM::unconsumed_event(const boost::statechart::event_base &event
     BOOST_PP_SEQ_FOR_EACH(EVENT_CASE, _, HUMAN_CLIENT_FSM_EVENTS)
     BOOST_PP_SEQ_FOR_EACH(EVENT_CASE, _, MESSAGE_EVENTS)
 #undef EVENT_CASE
-    ErrorLogger(FSM) << "HumanClientFSM : A " << most_derived_message_type_str << " event was passed to "
-        "the HumanClientFSM.  This event is illegal in the FSM's current state.  It is being ignored.";
+
+    if (terminated()) {
+        ErrorLogger(FSM) << "A " << most_derived_message_type_str << " event was passed to "
+            "the HumanClientFSM.  The FSM has terminated.  The event is being ignored.";
+        return;
+    }
+
+    std::stringstream ss;
+    ss << "[";
+    for (auto leaf_state_it = state_begin(); leaf_state_it != state_end();) {
+        // The following use of typeid assumes that
+        // BOOST_STATECHART_USE_NATIVE_RTTI is defined
+        ss << typeid( *leaf_state_it ).name();
+        ++leaf_state_it;
+        if (leaf_state_it != state_end())
+            ss << ", ";
+    }
+    ss << "]";
+
+    ErrorLogger(FSM) << "A " << most_derived_message_type_str
+                     << " event was not handled by any of these states : "
+                     << ss.str() << ".  It is being ignored.";
 }
 
 

--- a/server/ServerFSM.h
+++ b/server/ServerFSM.h
@@ -46,6 +46,16 @@ struct ProcessTurn : sc::event<ProcessTurn>                             {};
 struct DisconnectClients : sc::event<DisconnectClients>                 {};
 struct ShutdownServer : sc::event<ShutdownServer>                       {};
 
+/** This is a Boost.Preprocessor list of all non MessageEventBase events. It is
+  * used to generate the unconsumed events message. */
+#define NON_MESSAGE_SERVER_FSM_EVENTS           \
+    (LoadSaveFileFailed)                        \
+    (CheckStartConditions)                      \
+    (CheckEndConditions)                        \
+    (CheckTurnEndConditions)                    \
+    (ProcessTurn)                               \
+    (DisconnectClients)                         \
+    (ShutdownServer)
 
 //  Message events
 /** The base class for all state machine events that are based on Messages. */


### PR DESCRIPTION
This improves the unconsumed_event() log messages in HumanClientAppFSM
and ServerFSM to include the names of all of the available states that
could not process the given event.

An example message is now:

A JoinMPGameRequested event was not handled by any of these states : [11PlayingTurn].  It is being ignored.

The number "11" is the internal Boost::State state number and is part of the name.