### PR TITLE
Use Wnd::Create to move some modal wnds from stack to heap.

### DIFF
--- a/UI/CUIControls.cpp
+++ b/UI/CUIControls.cpp
@@ -1627,10 +1627,10 @@ void ColorSelector::SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
 void ColorSelector::LClick(const GG::Pt& pt, GG::Flags<GG::ModKey> mod_keys) {
     GG::X x = std::min(pt.x, GG::GUI::GetGUI()->AppWidth() - 315);    // 315 is width of ColorDlg from GG::ColorDlg:::ColorDlg
     GG::Y y = std::min(pt.y, GG::GUI::GetGUI()->AppHeight() - 300);   // 300 is height of ColorDlg from GG::ColorDlg:::ColorDlg
-    GG::ColorDlg dlg(x, y, Color(), ClientUI::GetFont(), ClientUI::CtrlColor(), ClientUI::CtrlBorderColor(), ClientUI::TextColor());
-    dlg.Run();
-    if (dlg.ColorWasSelected()) {
-        GG::Clr clr = dlg.Result();
+    auto dlg = GG::Wnd::Create<GG::ColorDlg>(x, y, Color(), ClientUI::GetFont(), ClientUI::CtrlColor(), ClientUI::CtrlBorderColor(), ClientUI::TextColor());
+    dlg->Run();
+    if (dlg->ColorWasSelected()) {
+        GG::Clr clr = dlg->Result();
         SetColor(clr);
         ColorChangedSignal(clr);
     }

--- a/UI/CUIControls.cpp
+++ b/UI/CUIControls.cpp
@@ -1627,7 +1627,7 @@ void ColorSelector::SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
 void ColorSelector::LClick(const GG::Pt& pt, GG::Flags<GG::ModKey> mod_keys) {
     GG::X x = std::min(pt.x, GG::GUI::GetGUI()->AppWidth() - 315);    // 315 is width of ColorDlg from GG::ColorDlg:::ColorDlg
     GG::Y y = std::min(pt.y, GG::GUI::GetGUI()->AppHeight() - 300);   // 300 is height of ColorDlg from GG::ColorDlg:::ColorDlg
-    auto dlg = GG::Wnd::Create<GG::ColorDlg>(x, y, Color(), ClientUI::GetFont(), ClientUI::CtrlColor(), ClientUI::CtrlBorderColor(), ClientUI::TextColor());
+    auto dlg = /*TODO: Remove extra shared_ptr wrap after Wnd::Create converted to return shared_ptr*/std::shared_ptr<GG::ColorDlg>(GG::Wnd::Create<GG::ColorDlg>(x, y, Color(), ClientUI::GetFont(), ClientUI::CtrlColor(), ClientUI::CtrlBorderColor(), ClientUI::TextColor()));
     dlg->Run();
     if (dlg->ColorWasSelected()) {
         GG::Clr clr = dlg->Result();

--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -994,12 +994,12 @@ ClientUI* ClientUI::GetClientUI()
 { return s_the_UI; }
 
 void ClientUI::MessageBox(const std::string& message, bool play_alert_sound/* = false*/) {
-    GG::ThreeButtonDlg dlg(GG::X(320), GG::Y(200), message, GetFont(Pts()+2),
-                           WndColor(), WndOuterBorderColor(), CtrlColor(), TextColor(), 1,
-                           UserString("OK"));
+    auto dlg = GG::Wnd::Create<GG::ThreeButtonDlg>(GG::X(320), GG::Y(200), message, GetFont(Pts()+2),
+                                                   WndColor(), WndOuterBorderColor(), CtrlColor(), TextColor(), 1,
+                                                   UserString("OK"));
     if (play_alert_sound)
         Sound::GetSound().PlaySound(GetOptionsDB().Get<std::string>("UI.sound.alert"), true);
-    dlg.Run();
+    dlg->Run();
 }
 
 std::shared_ptr<GG::Texture> ClientUI::GetTexture(const boost::filesystem::path& path, bool mipmap/* = false*/) {

--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -994,9 +994,9 @@ ClientUI* ClientUI::GetClientUI()
 { return s_the_UI; }
 
 void ClientUI::MessageBox(const std::string& message, bool play_alert_sound/* = false*/) {
-    auto dlg = GG::Wnd::Create<GG::ThreeButtonDlg>(GG::X(320), GG::Y(200), message, GetFont(Pts()+2),
-                                                   WndColor(), WndOuterBorderColor(), CtrlColor(), TextColor(), 1,
-                                                   UserString("OK"));
+    auto dlg = /*TODO: Remove extra shared_ptr wrap after Wnd::Create converted to return shared_ptr*/std::shared_ptr<GG::ThreeButtonDlg>(GG::Wnd::Create<GG::ThreeButtonDlg>(GG::X(320), GG::Y(200), message, GetFont(Pts()+2),
+                                                                                                                                                                              WndColor(), WndOuterBorderColor(), CtrlColor(), TextColor(), 1,
+                                                                                                                                                                              UserString("OK")));
     if (play_alert_sound)
         Sound::GetSound().PlaySound(GetOptionsDB().Get<std::string>("UI.sound.alert"), true);
     dlg->Run();

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -2494,9 +2494,9 @@ void CompletedDesignsListBox::BaseRightClicked(GG::ListBox::iterator it, const G
     };
     
     auto rename_design_action = [&empire_id, &design_id, design, &design_row]() {
-        CUIEditWnd edit_wnd(GG::X(350), UserString("DESIGN_ENTER_NEW_DESIGN_NAME"), design->Name());
-        edit_wnd.Run();
-        const std::string& result = edit_wnd.Result();
+        auto edit_wnd = GG::Wnd::Create<CUIEditWnd>(GG::X(350), UserString("DESIGN_ENTER_NEW_DESIGN_NAME"), design->Name());
+        edit_wnd->Run();
+        const std::string& result = edit_wnd->Result();
         if (result != "" && result != design->Name()) {
             HumanClientApp::GetApp()->Orders().IssueOrder(
                 std::make_shared<ShipDesignOrder>(empire_id, design_id, result));

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -2494,7 +2494,7 @@ void CompletedDesignsListBox::BaseRightClicked(GG::ListBox::iterator it, const G
     };
     
     auto rename_design_action = [&empire_id, &design_id, design, &design_row]() {
-        auto edit_wnd = GG::Wnd::Create<CUIEditWnd>(GG::X(350), UserString("DESIGN_ENTER_NEW_DESIGN_NAME"), design->Name());
+        auto edit_wnd = /*TODO: Remove extra shared_ptr wrap after Wnd::Create converted to return shared_ptr*/std::shared_ptr<CUIEditWnd>(GG::Wnd::Create<CUIEditWnd>(GG::X(350), UserString("DESIGN_ENTER_NEW_DESIGN_NAME"), design->Name()));
         edit_wnd->Run();
         const std::string& result = edit_wnd->Result();
         if (result != "" && result != design->Name()) {

--- a/UI/IntroScreen.cpp
+++ b/UI/IntroScreen.cpp
@@ -380,12 +380,13 @@ void IntroScreen::OnCredits() {
 
     int credit_side_pad(30);
 
-    CreditsWnd credits_wnd(GG::X0, nUpperLine, GG::GUI::GetGUI()->AppWidth(), nLowerLine-nUpperLine,
-                           credits,
-                           credit_side_pad, 0, Value(m_menu->Left()) - credit_side_pad,
-                           Value(nLowerLine-nUpperLine), Value((nLowerLine-nUpperLine))/2);
+    auto credits_wnd = GG::Wnd::Create<CreditsWnd>(
+        GG::X0, nUpperLine, GG::GUI::GetGUI()->AppWidth(), nLowerLine-nUpperLine,
+        credits,
+        credit_side_pad, 0, Value(m_menu->Left()) - credit_side_pad,
+        Value(nLowerLine-nUpperLine), Value((nLowerLine-nUpperLine))/2);
 
-    credits_wnd.Run();
+    credits_wnd->Run();
 }
 
 void IntroScreen::OnExitGame() {

--- a/UI/IntroScreen.cpp
+++ b/UI/IntroScreen.cpp
@@ -332,15 +332,15 @@ void IntroScreen::OnLoadGame() {
 }
 
 void IntroScreen::OnOptions() {
-    auto options_wnd = GG::Wnd::Create<OptionsWnd>();
+    auto options_wnd = /*TODO: Remove extra shared_ptr wrap after Wnd::Create converted to return shared_ptr*/std::shared_ptr<OptionsWnd>(GG::Wnd::Create<OptionsWnd>());
     options_wnd->Run();
 }
 
 void IntroScreen::OnPedia() {
     static const std::string INTRO_PEDIA_WND_NAME = "introscreen.pedia";
-    auto enc_panel = GG::Wnd::Create<EncyclopediaDetailPanel>(
+    auto enc_panel = /*TODO: Remove extra shared_ptr wrap after Wnd::Create converted to return shared_ptr*/std::shared_ptr<EncyclopediaDetailPanel>(GG::Wnd::Create<EncyclopediaDetailPanel>(
         GG::MODAL | GG::INTERACTIVE | GG::DRAGABLE |
-        GG::RESIZABLE | CLOSABLE | PINABLE, INTRO_PEDIA_WND_NAME);
+        GG::RESIZABLE | CLOSABLE | PINABLE, INTRO_PEDIA_WND_NAME));
     enc_panel->SizeMove(GG::Pt(GG::X(100), GG::Y(100)), Size() - GG::Pt(GG::X(100), GG::Y(100)));
     enc_panel->ClearItems();
     enc_panel->SetIndex();
@@ -353,7 +353,7 @@ void IntroScreen::OnPedia() {
 }
 
 void IntroScreen::OnAbout() {
-    auto about_wnd = GG::Wnd::Create<About>();
+    auto about_wnd = /*TODO: Remove extra shared_ptr wrap after Wnd::Create converted to return shared_ptr*/std::shared_ptr<About>(GG::Wnd::Create<About>());
     about_wnd->Run();
 }
 
@@ -378,11 +378,11 @@ void IntroScreen::OnCredits() {
 
     int credit_side_pad(30);
 
-    auto credits_wnd = GG::Wnd::Create<CreditsWnd>(
+    auto credits_wnd = /*TODO: Remove extra shared_ptr wrap after Wnd::Create converted to return shared_ptr*/std::shared_ptr<CreditsWnd>(GG::Wnd::Create<CreditsWnd>(
         GG::X0, nUpperLine, GG::GUI::GetGUI()->AppWidth(), nLowerLine-nUpperLine,
         credits,
         credit_side_pad, 0, Value(m_menu->Left()) - credit_side_pad,
-        Value(nLowerLine-nUpperLine), Value((nLowerLine-nUpperLine))/2);
+        Value(nLowerLine-nUpperLine), Value((nLowerLine-nUpperLine))/2));
 
     credits_wnd->Run();
 }

--- a/UI/IntroScreen.cpp
+++ b/UI/IntroScreen.cpp
@@ -350,8 +350,6 @@ void IntroScreen::OnPedia() {
         boost::bind(&EncyclopediaDetailPanel::EndRun, enc_panel));
 
     enc_panel->Run();
-
-    delete enc_panel;
 }
 
 void IntroScreen::OnAbout() {

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -306,7 +306,6 @@ namespace {
     void ShowFontTextureWnd() {
         auto font_wnd =  GG::Wnd::Create<FontTextureWnd>();
         font_wnd->Run();
-        delete font_wnd;
     }
 
     class OptionsListRow : public GG::ListBox::Row {

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -213,9 +213,9 @@ namespace {
         };
 
         static std::pair<GG::Key, GG::Flags<GG::ModKey>> GetKeypress() {
-            KeyPressCatcher ct;
-            ct.Run();
-            return std::make_pair(ct.m_key, ct.m_mods);
+            auto ct = GG::Wnd::Create<KeyPressCatcher>();
+            ct->Run();
+            return std::make_pair(ct->m_key, ct->m_mods);
         };
     };
 

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -102,7 +102,7 @@ namespace {
 
         void operator()() {
             try {
-                auto dlg = GG::Wnd::Create<FileDlg>(m_path.string(), m_edit->Text(), false, false, m_filters);
+                auto dlg = /*TODO: Remove extra shared_ptr wrap after Wnd::Create converted to return shared_ptr*/std::shared_ptr<FileDlg>(GG::Wnd::Create<FileDlg>(m_path.string(), m_edit->Text(), false, false, m_filters));
                 if (m_directory)
                     dlg->SelectDirectories(true);
                 dlg->Run();
@@ -213,7 +213,7 @@ namespace {
         };
 
         static std::pair<GG::Key, GG::Flags<GG::ModKey>> GetKeypress() {
-            auto ct = GG::Wnd::Create<KeyPressCatcher>();
+            auto ct = /*TODO: Remove extra shared_ptr wrap after Wnd::Create converted to return shared_ptr*/std::shared_ptr<KeyPressCatcher>(GG::Wnd::Create<KeyPressCatcher>());
             ct->Run();
             return std::make_pair(ct->m_key, ct->m_mods);
         };
@@ -304,7 +304,7 @@ namespace {
     };
 
     void ShowFontTextureWnd() {
-        auto font_wnd =  GG::Wnd::Create<FontTextureWnd>();
+        auto font_wnd =  /*TODO: Remove extra shared_ptr wrap after Wnd::Create converted to return shared_ptr*/std::shared_ptr<FontTextureWnd>(GG::Wnd::Create<FontTextureWnd>());
         font_wnd->Run();
     }
 

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -122,10 +122,10 @@ namespace {
 
     bool Prompt(const std::string& question){
         std::shared_ptr<GG::Font> font = ClientUI::GetFont();
-        auto prompt = GG::Wnd::Create<GG::ThreeButtonDlg>(
+        auto prompt = /*TODO: Remove extra shared_ptr wrap after Wnd::Create converted to return shared_ptr*/std::shared_ptr<GG::ThreeButtonDlg>(GG::Wnd::Create<GG::ThreeButtonDlg>(
             PROMT_WIDTH, PROMPT_HEIGHT, question, font,
             ClientUI::CtrlColor(), ClientUI::CtrlBorderColor(), ClientUI::CtrlColor(), ClientUI::TextColor(),
-            std::size_t(2), UserString("YES"), UserString("CANCEL"), "");
+            std::size_t(2), UserString("YES"), UserString("CANCEL"), ""));
         prompt->Run();
         return prompt->Result() == 0;
     }

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -122,11 +122,12 @@ namespace {
 
     bool Prompt(const std::string& question){
         std::shared_ptr<GG::Font> font = ClientUI::GetFont();
-        GG::ThreeButtonDlg prompt(PROMT_WIDTH, PROMPT_HEIGHT, question, font,
-                                  ClientUI::CtrlColor(), ClientUI::CtrlBorderColor(), ClientUI::CtrlColor(), ClientUI::TextColor(),
-                                  std::size_t(2), UserString("YES"), UserString("CANCEL"), "");
-        prompt.Run();
-        return prompt.Result() == 0;
+        auto prompt = GG::Wnd::Create<GG::ThreeButtonDlg>(
+            PROMT_WIDTH, PROMPT_HEIGHT, question, font,
+            ClientUI::CtrlColor(), ClientUI::CtrlBorderColor(), ClientUI::CtrlColor(), ClientUI::TextColor(),
+            std::size_t(2), UserString("YES"), UserString("CANCEL"), "");
+        prompt->Run();
+        return prompt->Result() == 0;
     }
 
     /// Returns true if list contains a row with the text str

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -1224,8 +1224,8 @@ void HumanClientApp::ResetOrExitApp(bool reset) {
 
     if (m_save_game_in_progress) {
         DebugLogger() << "save game in progress. Checking with player.";
-        auto dlg = SaveGamePendingDialog(reset, this->SaveGameCompletedSignal);
-        dlg.Run();
+        auto dlg = GG::Wnd::Create<SaveGamePendingDialog>(reset, this->SaveGameCompletedSignal);
+        dlg->Run();
     }
 
     m_fsm->process_event(StartQuittingGame(reset, m_server_process));

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -1224,7 +1224,7 @@ void HumanClientApp::ResetOrExitApp(bool reset) {
 
     if (m_save_game_in_progress) {
         DebugLogger() << "save game in progress. Checking with player.";
-        auto dlg = GG::Wnd::Create<SaveGamePendingDialog>(reset, this->SaveGameCompletedSignal);
+        auto dlg = /*TODO: Remove extra shared_ptr wrap after Wnd::Create converted to return shared_ptr*/std::shared_ptr<SaveGamePendingDialog>(GG::Wnd::Create<SaveGamePendingDialog>(reset, this->SaveGameCompletedSignal));
         dlg->Run();
     }
 


### PR DESCRIPTION
This PR fixes #1655, which is caused because some of the modal windows were still being created on the stack and only calling their constructors and not their `CompleteConstruction()` functions.