### PR TITLE
Hostless server

### DIFF
--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -691,6 +691,19 @@ void ClientUI::ShowIntroScreen()
     HumanClientApp::GetApp()->Remove(m_multiplayer_lobby_wnd);
 }
 
+void ClientUI::ShowMultiPlayerLobbyWnd() {
+    if (m_map_wnd) {
+        HumanClientApp::GetApp()->Remove(m_map_wnd);
+        m_map_wnd->RemoveWindows();
+        m_map_wnd->Hide();
+    }
+
+    HumanClientApp::GetApp()->Register(m_multiplayer_lobby_wnd);
+    HumanClientApp::GetApp()->Remove(m_message_wnd);
+    HumanClientApp::GetApp()->Remove(m_player_list_wnd);
+    HumanClientApp::GetApp()->Remove(m_intro_screen);
+}
+
 std::shared_ptr<MultiPlayerLobbyWnd> ClientUI::GetMultiPlayerLobbyWnd()
 { return m_multiplayer_lobby_wnd; }
 
@@ -717,7 +730,7 @@ bool ClientUI::ZoomToPlanet(int id) {
         GetMapWnd()->SelectSystem(planet->SystemID());
         GetMapWnd()->SelectPlanet(id);
         return true;
-    }        
+    }
     return false;
 }
 
@@ -1023,7 +1036,7 @@ std::shared_ptr<GG::Font> ClientUI::GetFont(int pts/* = Pts()*/) {
         } catch (...) {
              return GG::GUI::GetGUI()->GetStyleFactory()->DefaultFont(pts);
         }
-    } 
+    }
 }
 
 std::shared_ptr<GG::Font> ClientUI::GetBoldFont(int pts/* = Pts()*/) {

--- a/UI/ClientUI.h
+++ b/UI/ClientUI.h
@@ -52,6 +52,7 @@ public:
         PlayerListWnd if visible, but doesn't create them just to hide them.
      **/
     void    ShowIntroScreen();
+    void    ShowMultiPlayerLobbyWnd();
     void    InitTurn(int turn_number);                                  //!< resets all active controls to use the latest data when it has been changed at the beginning of a new turn
     void    RestoreFromSaveData(const SaveGameUIData& elem);            //!< restores the UI state that was saved in an earlier call to GetSaveGameUIData().
 

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -1200,9 +1200,11 @@ std::string HumanClientApp::SelectLoadFile() {
     return sfd->Result();
 }
 
-void HumanClientApp::ResetClientData() {
-    m_networking->SetPlayerID(Networking::INVALID_PLAYER_ID);
-    m_networking->SetHostPlayerID(Networking::INVALID_PLAYER_ID);
+void HumanClientApp::ResetClientData(bool save_connection) {
+    if (! save_connection) {
+        m_networking->SetPlayerID(Networking::INVALID_PLAYER_ID);
+        m_networking->SetHostPlayerID(Networking::INVALID_PLAYER_ID);
+    }
     SetEmpireID(ALL_EMPIRES);
     m_ui->GetMapWnd()->Sanitize();
 

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -1201,7 +1201,7 @@ std::string HumanClientApp::SelectLoadFile() {
 }
 
 void HumanClientApp::ResetClientData(bool save_connection) {
-    if (! save_connection) {
+    if (!save_connection) {
         m_networking->SetPlayerID(Networking::INVALID_PLAYER_ID);
         m_networking->SetHostPlayerID(Networking::INVALID_PLAYER_ID);
     }

--- a/client/human/HumanClientApp.h
+++ b/client/human/HumanClientApp.h
@@ -72,7 +72,7 @@ public:
 
     void                ResetToIntro(bool skip_savegame);
     void                ExitApp();
-    void                ResetClientData();
+    void                ResetClientData(bool save_connection = false);
     void                LoadSinglePlayerGame(std::string filename = "");///< loads a single player game chosen by the user; returns true if a game was loaded, and false if the operation was cancelled
     void                RequestSavePreviews(const std::string& directory, PreviewInformation& previews); ///< Requests the savegame previews for choosing one.
     void                Autosave();                                     ///< autosaves the current game, iff autosaves are enabled and any turn number requirements are met

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -690,6 +690,19 @@ boost::statechart::result PlayingGame::react(const TurnPartialUpdate& msg) {
     return discard_event();
 }
 
+boost::statechart::result PlayingGame::react(const LobbyUpdate& msg) {
+    TraceLogger(FSM) << "(HumanClientFSM) PlayingGame.LobbyUpdate";
+
+    // need to re-post the lobby update message to be re-handled after
+    // transitioning into MPLobby
+    post_event(msg);
+
+    Client().ResetClientData(true);
+    Client().GetClientUI().ShowMultiPlayerLobbyWnd();
+
+    return transit<MPLobby>();
+}
+
 
 ////////////////////////////////////////////////////////////
 // WaitingForGameStart

--- a/client/human/HumanClientFSM.h
+++ b/client/human/HumanClientFSM.h
@@ -248,7 +248,8 @@ struct PlayingGame : boost::statechart::state<PlayingGame, HumanClientFSM, Waiti
         boost::statechart::custom_reaction<StartQuittingGame>,
         boost::statechart::custom_reaction<Error>,
         boost::statechart::custom_reaction<TurnProgress>,
-        boost::statechart::custom_reaction<TurnPartialUpdate>
+        boost::statechart::custom_reaction<TurnPartialUpdate>,
+        boost::statechart::custom_reaction<LobbyUpdate>
     > reactions;
 
     PlayingGame(my_context ctx);
@@ -265,6 +266,7 @@ struct PlayingGame : boost::statechart::state<PlayingGame, HumanClientFSM, Waiti
     boost::statechart::result react(const Error& msg);
     boost::statechart::result react(const TurnProgress& msg);
     boost::statechart::result react(const TurnPartialUpdate& msg);
+    boost::statechart::result react(const LobbyUpdate& msg);
 
     CLIENT_ACCESSOR
 };

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1078,7 +1078,7 @@ OPTIONS_DB_SINGLEPLAYER
 Start server in single player host mode. This only allows clients on localhost to connect.
 
 OPTIONS_DB_HOSTLESS
-Start server in hostless mode. Server doesn't require host.
+Start server in hostless mode. Server accepts players in the multiplayer lobby where returns after the game session ends.
 
 OPTIONS_DB_GENERATE_CONFIG_XML
 Uses default settings, settings from any existing config.xml file, and settings given on the command line to generate a config.xml file. This will overwrite the current config.xml file, if it exists.

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -959,7 +959,7 @@ SERVER_TURN_EVENTS_ERRORS
 Python scripted turn events executed with errors. See log files for detailed error messages. Game can continue, but gameplay will probably be impaired.
 
 SERVER_ALREADY_PLAYING_GAME
-Server doesn't accept players. The game is already started.
+The server is not currently accepting players because a game is being played.
 
 ERROR_PYTHON_AI_CRASHED
 Python AI for %1% crashed.

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1078,7 +1078,7 @@ OPTIONS_DB_SINGLEPLAYER
 Start server in single player host mode. This only allows clients on localhost to connect.
 
 OPTIONS_DB_HOSTLESS
-Start server in hostless mode. Server accepts players in the multiplayer lobby where returns after the game session ends.
+Start server in hostless mode. Server accepts players in the multiplayer lobby, and returns to the lobby after the game session ends.
 
 OPTIONS_DB_GENERATE_CONFIG_XML
 Uses default settings, settings from any existing config.xml file, and settings given on the command line to generate a config.xml file. This will overwrite the current config.xml file, if it exists.

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -958,6 +958,9 @@ Universe generation completed with errors. See log files for detailed error mess
 SERVER_TURN_EVENTS_ERRORS
 Python scripted turn events executed with errors. See log files for detailed error messages. Game can continue, but gameplay will probably be impaired.
 
+SERVER_ALREADY_PLAYING_GAME
+Server doesn't accept players. The game is already started.
+
 ERROR_PYTHON_AI_CRASHED
 Python AI for %1% crashed.
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1077,6 +1077,9 @@ Print version and exit.
 OPTIONS_DB_SINGLEPLAYER
 Start server in single player host mode. This only allows clients on localhost to connect.
 
+OPTIONS_DB_HOSTLESS
+Start server in hostless mode. Server doesn't require host.
+
 OPTIONS_DB_GENERATE_CONFIG_XML
 Uses default settings, settings from any existing config.xml file, and settings given on the command line to generate a config.xml file. This will overwrite the current config.xml file, if it exists.
 

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -760,7 +760,7 @@ bool ServerApp::NewGameInitVerifyJoiners(
         return false;
     }
 
-    if (!host_in_player_id_setup_data) {
+    if (!host_in_player_id_setup_data && !IsHostless()) {
         ErrorLogger() << "NewGameInitVerifyJoiners : Host id " << m_networking.HostPlayerID()
                       << " is not a valid player id.";
         return false;

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1477,6 +1477,9 @@ bool ServerApp::IsAvailableName(const std::string& player_name) const {
     return true;
 }
 
+bool ServerApp::IsHostless() const
+{ return GetOptionsDB().Get<bool>("hostless"); }
+
 Networking::ClientType ServerApp::GetEmpireClientType(int empire_id) const
 { return GetPlayerClientType(ServerApp::EmpirePlayerID(empire_id)); }
 

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -125,6 +125,9 @@ public:
 
     /** Checks if \a player_name are not used by other players. */
     bool IsAvailableName(const std::string& player_name) const;
+
+    /** Checks if server runs in a hostless mode. */
+    bool IsHostless() const;
     //@}
 
 

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -437,6 +437,8 @@ MPLobby::MPLobby(my_context c) :
     ServerApp& server = Server();
     const SpeciesManager& sm = GetSpeciesManager();
     if (server.IsHostless()) {
+        m_lobby_data->m_any_can_edit = true;
+
         std::list<PlayerConnectionPtr> to_disconnect;
         // Try to use connections:
         for (const auto& player_connection : server.m_networking) {

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -430,7 +430,7 @@ MPLobby::MPLobby(my_context c) :
     my_base(c),
     m_lobby_data(new MultiplayerLobbyData(std::move(Server().m_galaxy_setup_data))),
     m_server_save_game_data(new ServerSaveGameData()),
-    m_ai_count(1)
+    m_ai_next_index(1)
 {
     TraceLogger(FSM) << "(ServerFSM) MPLobby";
     ClockSeed();
@@ -462,14 +462,14 @@ MPLobby::MPLobby(my_context c) :
             } else if (player_id != Networking::INVALID_PLAYER_ID && player_connection->GetClientType() == Networking::CLIENT_TYPE_AI_PLAYER) {
                 PlayerSetupData player_setup_data;
                 player_setup_data.m_player_id =     -1;
-                player_setup_data.m_player_name =   UserString("AI_PLAYER") + "_" + std::to_string(m_ai_count++);
+                player_setup_data.m_player_name =   UserString("AI_PLAYER") + "_" + std::to_string(m_ai_next_index++);
                 player_setup_data.m_client_type =   Networking::CLIENT_TYPE_AI_PLAYER;
                 player_setup_data.m_empire_name =   GenerateEmpireName(player_setup_data.m_player_name, m_lobby_data->m_players);
                 player_setup_data.m_empire_color =  GetUnusedEmpireColour(m_lobby_data->m_players);
                 if (m_lobby_data->m_seed != "")
                     player_setup_data.m_starting_species_name = sm.RandomPlayableSpeciesName();
                 else
-                    player_setup_data.m_starting_species_name = sm.SequentialPlayableSpeciesName(player_id);
+                    player_setup_data.m_starting_species_name = sm.SequentialPlayableSpeciesName(m_ai_next_index);
 
                 m_lobby_data->m_players.push_back(std::make_pair(-1, player_setup_data));
                 // disconnect AI
@@ -723,14 +723,14 @@ sc::result MPLobby::react(const LobbyUpdate& msg) {
                     psd.m_empire_color = GetUnusedEmpireColour(incoming_lobby_data.m_players);
                 if (psd.m_player_name.empty())
                     // ToDo: Should we translate player_name?
-                    psd.m_player_name = UserString("AI_PLAYER") + "_" + std::to_string(m_ai_count++);
+                    psd.m_player_name = UserString("AI_PLAYER") + "_" + std::to_string(m_ai_next_index++);
                 if (psd.m_empire_name.empty())
                     psd.m_empire_name = GenerateEmpireName(psd.m_player_name, incoming_lobby_data.m_players);
                 if (psd.m_starting_species_name.empty()) {
                     if (m_lobby_data->m_seed != "")
                         psd.m_starting_species_name = GetSpeciesManager().RandomPlayableSpeciesName();
                     else
-                        psd.m_starting_species_name = GetSpeciesManager().SequentialPlayableSpeciesName(m_ai_count);
+                        psd.m_starting_species_name = GetSpeciesManager().SequentialPlayableSpeciesName(m_ai_next_index);
                 }
 
             } else if (psd.m_client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER) {

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -441,7 +441,7 @@ MPLobby::MPLobby(my_context c) :
         // Try to use connections:
         for (const auto& player_connection : server.m_networking) {
             int player_id = player_connection->PlayerID();
-            if (player_id != Networking::INVALID_PLAYER_ID) {
+            if (player_id != Networking::INVALID_PLAYER_ID && player_connection->GetClientType() != Networking::CLIENT_TYPE_AI_PLAYER ) {
                 PlayerSetupData player_setup_data;
                 player_setup_data.m_player_name =   player_connection->PlayerName();
                 player_setup_data.m_client_type =   player_connection->GetClientType();

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -461,7 +461,7 @@ MPLobby::MPLobby(my_context c) :
                 m_lobby_data->m_players.push_back(std::make_pair(player_id, player_setup_data));
             } else if (player_id != Networking::INVALID_PLAYER_ID && player_connection->GetClientType() == Networking::CLIENT_TYPE_AI_PLAYER) {
                 PlayerSetupData player_setup_data;
-                player_setup_data.m_player_id =     -1;
+                player_setup_data.m_player_id =     Networking::INVALID_PLAYER_ID;
                 player_setup_data.m_player_name =   UserString("AI_PLAYER") + "_" + std::to_string(m_ai_next_index++);
                 player_setup_data.m_client_type =   Networking::CLIENT_TYPE_AI_PLAYER;
                 player_setup_data.m_empire_name =   GenerateEmpireName(player_setup_data.m_player_name, m_lobby_data->m_players);
@@ -471,7 +471,7 @@ MPLobby::MPLobby(my_context c) :
                 else
                     player_setup_data.m_starting_species_name = sm.SequentialPlayableSpeciesName(m_ai_next_index);
 
-                m_lobby_data->m_players.push_back(std::make_pair(-1, player_setup_data));
+                m_lobby_data->m_players.push_back(std::make_pair(Networking::INVALID_PLAYER_ID, player_setup_data));
                 // disconnect AI
                 to_disconnect.push_back(player_connection);
             } else {

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -429,7 +429,8 @@ namespace {
 MPLobby::MPLobby(my_context c) :
     my_base(c),
     m_lobby_data(new MultiplayerLobbyData()),
-    m_server_save_game_data(new ServerSaveGameData())
+    m_server_save_game_data(new ServerSaveGameData()),
+    m_ai_count(1)
 {
     TraceLogger(FSM) << "(ServerFSM) MPLobby";
     ClockSeed();
@@ -675,7 +676,6 @@ sc::result MPLobby::react(const LobbyUpdate& msg) {
 
         DebugLogger(FSM) << "Get message from host or allowed player.";
 
-        static int AI_count = 1;
         const GG::Clr CLR_NONE = GG::Clr(0, 0, 0, 0);
 
         // assign unique names / colours to any lobby entry that lacks them, or
@@ -702,14 +702,14 @@ sc::result MPLobby::react(const LobbyUpdate& msg) {
                     psd.m_empire_color = GetUnusedEmpireColour(incoming_lobby_data.m_players);
                 if (psd.m_player_name.empty())
                     // ToDo: Should we translate player_name?
-                    psd.m_player_name = UserString("AI_PLAYER") + "_" + std::to_string(AI_count++);
+                    psd.m_player_name = UserString("AI_PLAYER") + "_" + std::to_string(m_ai_count++);
                 if (psd.m_empire_name.empty())
                     psd.m_empire_name = GenerateEmpireName(psd.m_player_name, incoming_lobby_data.m_players);
                 if (psd.m_starting_species_name.empty()) {
                     if (m_lobby_data->m_seed != "")
                         psd.m_starting_species_name = GetSpeciesManager().RandomPlayableSpeciesName();
                     else
-                        psd.m_starting_species_name = GetSpeciesManager().SequentialPlayableSpeciesName(AI_count);
+                        psd.m_starting_species_name = GetSpeciesManager().SequentialPlayableSpeciesName(m_ai_count);
                 }
 
             } else if (psd.m_client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER) {

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -234,7 +234,7 @@ void ServerFSM::HandleNonLobbyDisconnection(const Disconnection& d) {
                      << ", named \"" << player_connection->PlayerName() << "\".";
 
     bool must_quit = false;
-    if (id == ALL_EMPIRES) {
+    if (id == ALL_EMPIRES && (! m_server.IsHostless())) {
         ErrorLogger(FSM) << "Client quit before id was assigned.";
         must_quit = true;
     }
@@ -1619,6 +1619,13 @@ sc::result PlayingGame::react(const Hostless& msg) {
 sc::result PlayingGame::react(const RequestCombatLogs& msg) {
     DebugLogger(FSM) << "(ServerFSM) PlayingGame::RequestCombatLogs message received";
     Server().UpdateCombatLogs(msg.m_message, msg.m_player_connection);
+    return discard_event();
+}
+
+sc::result PlayingGame::react(const JoinGame& msg) {
+    DebugLogger(FSM) << "(ServerFSM) PlayingGame::JoinGame message received";
+    msg.m_player_connection->SendMessage(ErrorMessage(UserStringNop("SERVER_ALREADY_PLAYING_GAME")));
+    Server().Networking().Disconnect(msg.m_player_connection);
     return discard_event();
 }
 

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -428,7 +428,7 @@ namespace {
 
 MPLobby::MPLobby(my_context c) :
     my_base(c),
-    m_lobby_data(new MultiplayerLobbyData()),
+    m_lobby_data(new MultiplayerLobbyData(std::move(Server().m_galaxy_setup_data))),
     m_server_save_game_data(new ServerSaveGameData()),
     m_ai_count(1)
 {

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -234,7 +234,7 @@ void ServerFSM::HandleNonLobbyDisconnection(const Disconnection& d) {
                      << ", named \"" << player_connection->PlayerName() << "\".";
 
     bool must_quit = false;
-    if (id == ALL_EMPIRES && (! m_server.IsHostless())) {
+    if (id == ALL_EMPIRES && !m_server.IsHostless()) {
         ErrorLogger(FSM) << "Client quit before id was assigned.";
         must_quit = true;
     }

--- a/server/ServerFSM.h
+++ b/server/ServerFSM.h
@@ -45,6 +45,7 @@ struct CheckTurnEndConditions : sc::event<CheckTurnEndConditions>       {};
 struct ProcessTurn : sc::event<ProcessTurn>                             {};
 struct DisconnectClients : sc::event<DisconnectClients>                 {};
 struct ShutdownServer : sc::event<ShutdownServer>                       {};
+struct Hostless : sc::event<Hostless>                                   {}; // Empty event to move server into MPLobby state.
 
 /** This is a Boost.Preprocessor list of all non MessageEventBase events. It is
   * used to generate the unconsumed events message. */
@@ -136,14 +137,14 @@ private:
     ServerApp& m_server;
 };
 
-
 /** The server's initial state. */
 struct Idle : sc::state<Idle, ServerFSM> {
     typedef boost::mpl::list<
         sc::custom_reaction<HostMPGame>,
         sc::custom_reaction<HostSPGame>,
         sc::custom_reaction<ShutdownServer>,
-        sc::custom_reaction<Error>
+        sc::custom_reaction<Error>,
+        sc::custom_reaction<Hostless>
     > reactions;
 
     Idle(my_context c);
@@ -153,6 +154,7 @@ struct Idle : sc::state<Idle, ServerFSM> {
     sc::result react(const HostSPGame& msg);
     sc::result react(const ShutdownServer& u);
     sc::result react(const Error& msg);
+    sc::result react(const Hostless&);
 
     SERVER_ACCESSOR
 };

--- a/server/ServerFSM.h
+++ b/server/ServerFSM.h
@@ -276,6 +276,7 @@ struct PlayingGame : sc::state<PlayingGame, ServerFSM, WaitingForTurnEnd> {
         sc::custom_reaction<RequestCombatLogs>,
         sc::custom_reaction<ShutdownServer>,
         sc::custom_reaction<Hostless>,
+        sc::custom_reaction<JoinGame>,
         sc::custom_reaction<Error>
     > reactions;
 
@@ -288,6 +289,7 @@ struct PlayingGame : sc::state<PlayingGame, ServerFSM, WaitingForTurnEnd> {
     sc::result react(const ShutdownServer& u);
     sc::result react(const Hostless& u);
     sc::result react(const RequestCombatLogs& msg);
+    sc::result react(const JoinGame& msg);
     sc::result react(const Error& msg);
 
     SERVER_ACCESSOR

--- a/server/ServerFSM.h
+++ b/server/ServerFSM.h
@@ -56,7 +56,8 @@ struct Hostless : sc::event<Hostless>                                   {}; // E
     (CheckTurnEndConditions)                    \
     (ProcessTurn)                               \
     (DisconnectClients)                         \
-    (ShutdownServer)
+    (ShutdownServer)                            \
+    (Hostless)
 
 //  Message events
 /** The base class for all state machine events that are based on Messages. */
@@ -143,6 +144,7 @@ struct Idle : sc::state<Idle, ServerFSM> {
         sc::custom_reaction<HostMPGame>,
         sc::custom_reaction<HostSPGame>,
         sc::custom_reaction<ShutdownServer>,
+        sc::custom_reaction<Hostless>,
         sc::custom_reaction<Error>,
         sc::custom_reaction<Hostless>
     > reactions;
@@ -171,6 +173,7 @@ struct MPLobby : sc::state<MPLobby, ServerFSM> {
         sc::custom_reaction<HostMPGame>,
         sc::custom_reaction<HostSPGame>,
         sc::custom_reaction<ShutdownServer>,
+        sc::custom_reaction<Hostless>,
         sc::custom_reaction<Error>
     > reactions;
 
@@ -185,6 +188,7 @@ struct MPLobby : sc::state<MPLobby, ServerFSM> {
     sc::result react(const HostMPGame& msg);
     sc::result react(const HostSPGame& msg);
     sc::result react(const ShutdownServer& u);
+    sc::result react(const Hostless& u);
     sc::result react(const Error& msg);
 
     std::shared_ptr<MultiplayerLobbyData>   m_lobby_data;
@@ -270,6 +274,7 @@ struct PlayingGame : sc::state<PlayingGame, ServerFSM, WaitingForTurnEnd> {
         sc::custom_reaction<ModeratorAct>,
         sc::custom_reaction<RequestCombatLogs>,
         sc::custom_reaction<ShutdownServer>,
+        sc::custom_reaction<Hostless>,
         sc::custom_reaction<Error>
     > reactions;
 
@@ -280,6 +285,7 @@ struct PlayingGame : sc::state<PlayingGame, ServerFSM, WaitingForTurnEnd> {
     sc::result react(const Diplomacy& msg);
     sc::result react(const ModeratorAct& msg);
     sc::result react(const ShutdownServer& u);
+    sc::result react(const Hostless& u);
     sc::result react(const RequestCombatLogs& msg);
     sc::result react(const Error& msg);
 

--- a/server/ServerFSM.h
+++ b/server/ServerFSM.h
@@ -194,6 +194,7 @@ struct MPLobby : sc::state<MPLobby, ServerFSM> {
     std::shared_ptr<MultiplayerLobbyData>   m_lobby_data;
     std::vector<PlayerSaveGameData>         m_player_save_game_data;
     std::shared_ptr<ServerSaveGameData>     m_server_save_game_data;
+    int                                     m_ai_count;
 
     SERVER_ACCESSOR
 };

--- a/server/ServerFSM.h
+++ b/server/ServerFSM.h
@@ -194,7 +194,7 @@ struct MPLobby : sc::state<MPLobby, ServerFSM> {
     std::shared_ptr<MultiplayerLobbyData>   m_lobby_data;
     std::vector<PlayerSaveGameData>         m_player_save_game_data;
     std::shared_ptr<ServerSaveGameData>     m_server_save_game_data;
-    int                                     m_ai_count;
+    int                                     m_ai_next_index;
 
     SERVER_ACCESSOR
 };

--- a/server/dmain.cpp
+++ b/server/dmain.cpp
@@ -51,6 +51,7 @@ int wmain(int argc, wchar_t* argv[], wchar_t* envp[]) {
         GetOptionsDB().AddFlag('h', "help",         UserStringNop("OPTIONS_DB_HELP"),         false);
         GetOptionsDB().AddFlag('v', "version",      UserStringNop("OPTIONS_DB_VERSION"),      false);
         GetOptionsDB().AddFlag('s', "singleplayer", UserStringNop("OPTIONS_DB_SINGLEPLAYER"), false);
+        GetOptionsDB().AddFlag("hostless",          UserStringNop("OPTIONS_DB_HOSTLESS"),     false);
 
         // if config.xml and persistent_config.xml are present, read and set options entries
         GetOptionsDB().SetFromFile(GetConfigPath(), FreeOrionVersionString());

--- a/util/MultiplayerCommon.cpp
+++ b/util/MultiplayerCommon.cpp
@@ -224,6 +224,20 @@ GalaxySetupData::GalaxySetupData() :
     m_ai_aggr(MANIACAL)
 {}
 
+GalaxySetupData::GalaxySetupData(GalaxySetupData&& base) :
+    m_seed(std::move(base.m_seed)),
+    m_size(base.m_size),
+    m_shape(base.m_shape),
+    m_age(base.m_age),
+    m_starlane_freq(base.m_starlane_freq),
+    m_planet_density(base.m_planet_density),
+    m_specials_freq(base.m_specials_freq),
+    m_monster_freq(base.m_monster_freq),
+    m_native_freq(base.m_native_freq),
+    m_ai_aggr(base.m_ai_aggr),
+    m_game_rules(std::move(base.m_game_rules))
+{}
+
 const std::string& GalaxySetupData::GetSeed() const
 { return m_seed; }
 

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -151,6 +151,10 @@ private:
 struct FO_COMMON_API GalaxySetupData {
     /** \name Structors */ //@{
     GalaxySetupData();
+
+    GalaxySetupData(const GalaxySetupData&) = default;
+
+    GalaxySetupData(GalaxySetupData&& base);
     //@}
 
     /** \name Accessors */ //@{
@@ -167,6 +171,8 @@ struct FO_COMMON_API GalaxySetupData {
     const std::vector<std::pair<std::string, std::string>>&
                         GetGameRules() const;
     //@}
+
+    GalaxySetupData& operator=(const GalaxySetupData&) = default;
 
     std::string         m_seed;
     int                 m_size;
@@ -312,6 +318,15 @@ private:
 struct FO_COMMON_API MultiplayerLobbyData : public GalaxySetupData {
     /** \name Structors */ //@{
     MultiplayerLobbyData() :
+        m_any_can_edit(false),
+        m_new_game(true),
+        m_players(),
+        m_save_game(),
+        m_save_game_empire_data()
+    {}
+
+    MultiplayerLobbyData(GalaxySetupData&& base) :
+        GalaxySetupData(std::move(base)),
         m_any_can_edit(false),
         m_new_game(true),
         m_players(),


### PR DESCRIPTION
This PR adds server command-line options `--hostless` to launch server in hostless mode:

- Server works without host player.
- Server accepts players in multiplayer lobby and reject them when game is started.
- Players allowed to manage galaxy settings and AI players settings.
- When the game ends server with all connected players returns to multiplayer lobby with last galaxy setup and AI count.