### PR TITLE
Improve python error handling during game shutdown and crashes.

### DIFF
--- a/UI/InGameMenu.cpp
+++ b/UI/InGameMenu.cpp
@@ -197,7 +197,7 @@ void InGameMenu::Options() {
 }
 
 void InGameMenu::Exit() {
-    HumanClientApp::GetApp()->ResetToIntro();
+    HumanClientApp::GetApp()->ResetToIntro(false);
     CloseClicked();
 }
 

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -479,7 +479,7 @@ void HumanClientApp::NewSinglePlayerGame(bool quickstart) {
 
     m_connected = m_networking->ConnectToLocalHostServer();
     if (!m_connected) {
-        ResetToIntro();
+        ResetToIntro(true);
         ClientUI::MessageBox(UserString("ERR_CONNECT_TIMED_OUT"), true);
         return;
     }
@@ -566,7 +566,7 @@ void HumanClientApp::NewSinglePlayerGame(bool quickstart) {
 
     } else {
         ErrorLogger() << "HumanClientApp::NewSinglePlayerGame failed to start new game, killing server.";
-        ResetToIntro();
+        ResetToIntro(true);
     }
 }
 
@@ -605,7 +605,7 @@ void HumanClientApp::MultiPlayerGame() {
     if (!m_connected) {
         ClientUI::MessageBox(UserString("ERR_CONNECT_TIMED_OUT"), true);
         if (server_connect_wnd->Result().second == "HOST GAME SELECTED")
-            ResetToIntro();
+            ResetToIntro(true);
         return;
     }
 
@@ -666,7 +666,7 @@ void HumanClientApp::LoadSinglePlayerGame(std::string filename/* = ""*/) {
 
     // end any currently-playing game before loading new one
     if (m_game_started) {
-        ResetToIntro();
+        ResetToIntro(false);
         // delay to make sure old game is fully cleaned up before attempting to start a new one
         std::this_thread::sleep_for(std::chrono::seconds(3));
     } else {
@@ -685,7 +685,7 @@ void HumanClientApp::LoadSinglePlayerGame(std::string filename/* = ""*/) {
     DebugLogger() << "HumanClientApp::LoadSinglePlayerGame() Connecting to server";
     m_connected = m_networking->ConnectToLocalHostServer();
     if (!m_connected) {
-        ResetToIntro();
+        ResetToIntro(true);
         ClientUI::MessageBox(UserString("ERR_CONNECT_TIMED_OUT"), true);
         return;
     }
@@ -719,7 +719,7 @@ void HumanClientApp::RequestSavePreviews(const std::string& directory, PreviewIn
         DebugLogger() << "HumanClientApp::RequestSavePreviews Connecting to server";
         m_connected = m_networking->ConnectToLocalHostServer();
         if (!m_connected) {
-            ResetToIntro();
+            ResetToIntro(true);
             ClientUI::MessageBox(UserString("ERR_CONNECT_TIMED_OUT"), true);
             return;
         }
@@ -999,7 +999,7 @@ void HumanClientApp::HandleAppQuitting() {
 
 bool HumanClientApp::HandleHotkeyResetGame() {
     DebugLogger() << "HumanClientApp::HandleHotkeyResetGame()";
-    ResetToIntro();
+    ResetToIntro(false);
     return true;
 }
 
@@ -1212,18 +1212,18 @@ namespace {
     };
 }
 
-void HumanClientApp::ResetToIntro()
-{ ResetOrExitApp(true); }
+void HumanClientApp::ResetToIntro(bool is_error /*= false*/)
+{ ResetOrExitApp(true, is_error); }
 
 void HumanClientApp::ExitApp()
-{ ResetOrExitApp(false); }
+{ ResetOrExitApp(false, false); }
 
-void HumanClientApp::ResetOrExitApp(bool reset) {
+void HumanClientApp::ResetOrExitApp(bool reset, bool is_error) {
     DebugLogger() << (reset ? "HumanClientApp::ResetToIntro" : "HumanClientApp::ExitApp");
 
     m_game_started = false;
 
-    if (m_save_game_in_progress) {
+    if (m_save_game_in_progress && !is_error) {
         DebugLogger() << "save game in progress. Checking with player.";
         auto dlg = GG::Wnd::Create<SaveGamePendingDialog>(reset, this->SaveGameCompletedSignal);
         dlg->Run();

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -1212,18 +1212,18 @@ namespace {
     };
 }
 
-void HumanClientApp::ResetToIntro(bool is_error /*= false*/)
-{ ResetOrExitApp(true, is_error); }
+void HumanClientApp::ResetToIntro(bool skip_savegame)
+{ ResetOrExitApp(true, skip_savegame); }
 
 void HumanClientApp::ExitApp()
 { ResetOrExitApp(false, false); }
 
-void HumanClientApp::ResetOrExitApp(bool reset, bool is_error) {
+void HumanClientApp::ResetOrExitApp(bool reset, bool skip_savegame) {
     DebugLogger() << (reset ? "HumanClientApp::ResetToIntro" : "HumanClientApp::ExitApp");
 
     m_game_started = false;
 
-    if (m_save_game_in_progress && !is_error) {
+    if (m_save_game_in_progress && !skip_savegame) {
         DebugLogger() << "save game in progress. Checking with player.";
         auto dlg = GG::Wnd::Create<SaveGamePendingDialog>(reset, this->SaveGameCompletedSignal);
         dlg->Run();

--- a/client/human/HumanClientApp.h
+++ b/client/human/HumanClientApp.h
@@ -69,7 +69,7 @@ public:
     /** Update the logger in OptionsDB and the other processes if hosting. */
     void                ChangeLoggerThreshold(const std::string& option_name, LogLevel option_value);
 
-    void                ResetToIntro(bool is_error);
+    void                ResetToIntro(bool skip_savegame);
     void                ExitApp();
     void                ResetClientData();
     void                LoadSinglePlayerGame(std::string filename = "");///< loads a single player game chosen by the user; returns true if a game was loaded, and false if the operation was cancelled
@@ -131,7 +131,9 @@ private:
 
     void            DisconnectedFromServer();           ///< called by ClientNetworking when the TCP connection to the server is lost
 
-    void            ResetOrExitApp(bool reset, bool is_error);
+    /** Either reset to IntroMenu (\p reset is true), or exit the
+        application.  If \p skip_savegame is true abort in progress save games.*/
+    void            ResetOrExitApp(bool reset, bool skip_savegame);
 
     std::unique_ptr<HumanClientFSM> m_fsm;
 

--- a/client/human/HumanClientApp.h
+++ b/client/human/HumanClientApp.h
@@ -69,7 +69,7 @@ public:
     /** Update the logger in OptionsDB and the other processes if hosting. */
     void                ChangeLoggerThreshold(const std::string& option_name, LogLevel option_value);
 
-    void                ResetToIntro();
+    void                ResetToIntro(bool is_error);
     void                ExitApp();
     void                ResetClientData();
     void                LoadSinglePlayerGame(std::string filename = "");///< loads a single player game chosen by the user; returns true if a game was loaded, and false if the operation was cancelled
@@ -131,7 +131,7 @@ private:
 
     void            DisconnectedFromServer();           ///< called by ClientNetworking when the TCP connection to the server is lost
 
-    void            ResetOrExitApp(bool reset);
+    void            ResetOrExitApp(bool reset, bool is_error);
 
     std::unique_ptr<HumanClientFSM> m_fsm;
 

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -190,7 +190,7 @@ boost::statechart::result WaitingForSPHostAck::react(const Disconnection& d) {
 
     // See reaction_transition_note.
     auto retval = discard_event();
-    Client().ResetToIntro();
+    Client().ResetToIntro(true);
     ClientUI::MessageBox(UserString("SERVER_LOST"), true);
     return retval;
 }
@@ -210,7 +210,7 @@ boost::statechart::result WaitingForSPHostAck::react(const Error& msg) {
     // See reaction_transition_note.
     auto retval = discard_event();
     if (fatal) {
-        Client().ResetToIntro();
+        Client().ResetToIntro(true);
         ClientUI::MessageBox(UserString(problem), true);
         client.GetClientUI().GetMessageWnd()->HandleGameStatusUpdate(UserString("RETURN_TO_INTRO") + "\n");
     }
@@ -272,7 +272,7 @@ boost::statechart::result WaitingForMPHostAck::react(const Disconnection& d) {
 
     // See reaction_transition_note.
     auto retval = discard_event();
-    Client().ResetToIntro();
+    Client().ResetToIntro(true);
     ClientUI::MessageBox(UserString("SERVER_LOST"), true);
     return retval;
 }
@@ -292,7 +292,7 @@ boost::statechart::result WaitingForMPHostAck::react(const Error& msg) {
     // See reaction_transition_note.
     auto retval = discard_event();
     if (fatal) {
-        Client().ResetToIntro();
+        Client().ResetToIntro(true);
         ClientUI::MessageBox(UserString(problem), true);
         client.GetClientUI().GetMessageWnd()->HandleGameStatusUpdate(UserString("RETURN_TO_INTRO") + "\n");
     }
@@ -350,7 +350,7 @@ boost::statechart::result WaitingForMPJoinAck::react(const Disconnection& d) {
 
     // See reaction_transition_note.
     auto retval = discard_event();
-    Client().ResetToIntro();
+    Client().ResetToIntro(true);
     ClientUI::MessageBox(UserString("SERVER_LOST"), true);
     return retval;
 }
@@ -370,7 +370,7 @@ boost::statechart::result WaitingForMPJoinAck::react(const Error& msg) {
     // See reaction_transition_note.
     auto retval = discard_event();
     if (fatal) {
-        Client().ResetToIntro();
+        Client().ResetToIntro(true);
         ClientUI::MessageBox(UserString(problem), true);
         client.GetClientUI().GetMessageWnd()->HandleGameStatusUpdate(UserString("RETURN_TO_INTRO") + "\n");
     }
@@ -408,7 +408,7 @@ boost::statechart::result MPLobby::react(const Disconnection& d) {
 
     // See reaction_transition_note.
     auto retval = discard_event();
-    Client().ResetToIntro();
+    Client().ResetToIntro(true);
     ClientUI::MessageBox(UserString("SERVER_LOST"), true);
     return retval;
 }
@@ -457,7 +457,7 @@ boost::statechart::result MPLobby::react(const CancelMPGameClicked& a)
 
     // See reaction_transition_note.
     auto retval = discard_event();
-    Client().ResetToIntro();
+    Client().ResetToIntro(true);
     return retval;
 }
 
@@ -496,7 +496,7 @@ boost::statechart::result MPLobby::react(const Error& msg) {
     // See reaction_transition_note.
     auto retval = discard_event();
     if (fatal) {
-        Client().ResetToIntro();
+        Client().ResetToIntro(true);
         ClientUI::MessageBox(UserString(problem), true);
     }
 
@@ -578,7 +578,7 @@ boost::statechart::result PlayingGame::react(const Disconnection& d) {
 
     // See reaction_transition_note.
     auto retval = discard_event();
-    Client().ResetToIntro();
+    Client().ResetToIntro(true);
     ClientUI::MessageBox(UserString("SERVER_LOST"), true);
     return retval;
 }
@@ -636,7 +636,7 @@ boost::statechart::result PlayingGame::react(const EndGame& msg) {
 
     // See reaction_transition_note.
     auto retval = discard_event();
-    Client().ResetToIntro();
+    Client().ResetToIntro(true);
     ClientUI::MessageBox(reason_message, error);
     return retval;
 }
@@ -663,7 +663,7 @@ boost::statechart::result PlayingGame::react(const Error& msg) {
     // See reaction_transition_note.
     auto retval = discard_event();
     if (fatal)
-        Client().ResetToIntro();
+        Client().ResetToIntro(true);
 
     ClientUI::MessageBox(UserString(problem), fatal);
 

--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -3,7 +3,6 @@ these methods in turn activate other portions of the python AI code."""
 import pickle  # Python object serialization library
 import sys
 import random
-import logging
 
 from common.configure_logging import redirect_logging_to_freeorion_logger, convenience_function_references_for_logger
 

--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -1,15 +1,17 @@
 """The FreeOrionAI module contains the methods which can be made by the C AIInterface;
 these methods in turn activate other portions of the python AI code."""
+from common.configure_logging import redirect_logging_to_freeorion_logger, convenience_function_references_for_logger
+
+# Logging is redirected before other imports so that import errors appear in log files.
+redirect_logging_to_freeorion_logger()
+(debug, info, warn, error, fatal) = convenience_function_references_for_logger()
+
 import pickle  # Python object serialization library
 import sys
 import random
 
-from common.configure_logging import redirect_logging_to_freeorion_logger, convenience_function_references_for_logger
-
 import freeOrionAIInterface as fo  # interface used to interact with FreeOrion AI client  # pylint: disable=import-error
 
-redirect_logging_to_freeorion_logger()
-(debug, info, warn, error, fatal) = convenience_function_references_for_logger()
 
 from common.option_tools import parse_config
 parse_config(fo.getOptionsDBOptionStr("ai-config"), fo.getUserConfigDir())

--- a/default/python/common/configure_logging.py
+++ b/default/python/common/configure_logging.py
@@ -128,12 +128,19 @@ class _stdXLikeStream(object):
 
     def write(self, msg):
         # Grab the caller's call frame info
-        (_, filename, line_number, function_name, _, _) = inspect.stack()[1]
+        stack = inspect.stack()
+        if len(stack) > 1:
+            (_, filename, line_number, function_name, _, _) = inspect.stack()[1]
+        else:
+            # No available call frame info
+            (filename, line_number, function_name) = ("", "", "")
+
         try:
             self.logger(msg, "python", str(os.path.split(filename)[1]), str(function_name), str(line_number))
 
         finally:
-            # Explicitly del references to the callers frame to avoid persistent reference cycles
+            # Explicitly del references to the caller's frame to avoid persistent reference cycles
+            del stack
             del filename
             del line_number
             del function_name

--- a/default/python/turn_events/turn_events.py
+++ b/default/python/turn_events/turn_events.py
@@ -1,3 +1,9 @@
+from common.configure_logging import redirect_logging_to_freeorion_logger, convenience_function_references_for_logger
+
+# Logging is redirected before other imports so that import errors appear in log files.
+redirect_logging_to_freeorion_logger()
+(debug, info, warn, error, fatal) = convenience_function_references_for_logger()
+
 import sys
 from random import random, uniform, choice
 from math import sin, cos, pi, hypot

--- a/default/python/universe_generation/universe_generator.py
+++ b/default/python/universe_generation/universe_generator.py
@@ -1,6 +1,10 @@
-import random
-
 from common.configure_logging import redirect_logging_to_freeorion_logger, convenience_function_references_for_logger
+
+# Logging is redirected before other imports so that import errors appear in log files.
+redirect_logging_to_freeorion_logger()
+(debug, info, warn, error, fatal) = convenience_function_references_for_logger()
+
+import random
 
 import freeorion as fo
 
@@ -15,9 +19,6 @@ from specials import distribute_specials
 from util import int_hash, seed_rng, report_error, error_list
 from universe_tables import MAX_JUMPS_BETWEEN_SYSTEMS, MAX_STARLANE_LENGTH
 import universe_statistics
-
-redirect_logging_to_freeorion_logger()
-(debug, info, warn, error, fatal) = convenience_function_references_for_logger()
 
 
 class PyGalaxySetupData:

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -327,14 +327,15 @@ void ServerApp::Run() {
     {}
 }
 
-void ServerApp::InitializePython() {
+bool ServerApp::InitializePython() {
     if (m_python_server.IsPythonRunning())
-        return;
+        return true;
 
-    if (!m_python_server.Initialize()) {
-        ErrorLogger() << "Server's python interpreter failed to initialize.";
-        m_fsm->process_event(ShutdownServer());
-    }
+    if (m_python_server.Initialize())
+        return true;
+
+    ErrorLogger() << "Server's python interpreter failed to initialize.";
+    return false;
 }
 
 void ServerApp::CleanupAIs() {

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -327,15 +327,14 @@ void ServerApp::Run() {
     {}
 }
 
-bool ServerApp::InitializePython() {
+void ServerApp::InitializePython() {
     if (m_python_server.IsPythonRunning())
-        return true;
+        return;
 
     if (m_python_server.Initialize())
-        return true;
+        return;
 
     ErrorLogger() << "Server's python interpreter failed to initialize.";
-    return false;
 }
 
 void ServerApp::CleanupAIs() {

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -218,7 +218,7 @@ private:
     void    Run();          ///< initializes app state, then executes main event handler/render loop (Poll())
 
     /** Initialize the python engine if not already running. Return true on success. */
-    bool InitializePython();
+    void InitializePython();
 
     /** Called when server process receive termination signal */
     void    SignalHandler(const boost::system::error_code& error, int signal_number);

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -217,8 +217,8 @@ private:
 
     void    Run();          ///< initializes app state, then executes main event handler/render loop (Poll())
 
-    /** Initialize the python engine or exit. */
-    void InitializePython();
+    /** Initialize the python engine if not already running. Return true on success. */
+    bool InitializePython();
 
     /** Called when server process receive termination signal */
     void    SignalHandler(const boost::system::error_code& error, int signal_number);

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -234,6 +234,10 @@ void ServerFSM::HandleNonLobbyDisconnection(const Disconnection& d) {
                      << ", named \"" << player_connection->PlayerName() << "\".";
 
     bool must_quit = false;
+    if (id == ALL_EMPIRES) {
+        ErrorLogger(FSM) << "Client quit before id was assigned.";
+        must_quit = true;
+    }
 
     // Did an active player (AI or Human) disconnect?  If so, game is over
     if (player_connection->GetClientType() == Networking::CLIENT_TYPE_HUMAN_OBSERVER ||

--- a/server/ServerFSM.h
+++ b/server/ServerFSM.h
@@ -201,6 +201,7 @@ struct WaitingForSPGameJoiners : sc::state<WaitingForSPGameJoiners, ServerFSM> {
         sc::custom_reaction<JoinGame>,
         sc::custom_reaction<CheckStartConditions>,
         sc::custom_reaction<LoadSaveFileFailed>,
+        sc::custom_reaction<ShutdownServer>,
         sc::custom_reaction<Error>
     > reactions;
 
@@ -212,6 +213,7 @@ struct WaitingForSPGameJoiners : sc::state<WaitingForSPGameJoiners, ServerFSM> {
     // in SP games, save data is loaded when setting up AI clients, in order to
     // know which / how many to set up.  Loading might fail.
     sc::result react(const LoadSaveFileFailed& u);
+    sc::result react(const ShutdownServer& u);
     sc::result react(const Error& msg);
 
     std::shared_ptr<SinglePlayerSetupData>   m_single_player_setup_data;
@@ -231,6 +233,7 @@ struct WaitingForMPGameJoiners : sc::state<WaitingForMPGameJoiners, ServerFSM> {
         sc::in_state_reaction<Disconnection, ServerFSM, &ServerFSM::HandleNonLobbyDisconnection>,
         sc::custom_reaction<JoinGame>,
         sc::custom_reaction<CheckStartConditions>,
+        sc::custom_reaction<ShutdownServer>,
         sc::custom_reaction<Error>
     > reactions;
 
@@ -242,6 +245,7 @@ struct WaitingForMPGameJoiners : sc::state<WaitingForMPGameJoiners, ServerFSM> {
     // unlike in SP game setup, no save file data needs to be loaded in this
     // state, as all the relevant info about AIs is provided by the lobby data.
     // as such, no file load error handling reaction is needed in this state.
+    sc::result react(const ShutdownServer& u);
     sc::result react(const Error& msg);
 
     std::shared_ptr<MultiplayerLobbyData>   m_lobby_data;


### PR DESCRIPTION
This PR fixes issue [#1659 insufficient exception logging in AI scripts.](https://github.com/freeorion/freeorion/issues/1659)

It fixes the following issues with startup, shutdown and error reporting related to the python engine.
- adds a parameter `is_error` to `ResetToIntro()` so that in progress saves can be short circuited when the reset is caused by an error.
- refactors python initialization in the server, so that failure to initialize will cause the server to shutdown. The server shutdown is delayed until after the AI client have connected to allow for a orderly shutdown of the AI clients.
- detects disconnection of the AI clients before they are assigned an ID.
- in `_stdXLikeStream.write()` from `configure_logging.py`  it detects when streamed output is not associated with a python execution stack and does not print a filename and location for the output.  This happens with errors trapped in the C++ code and then printed with `PyErr_Print()`.

I've included the patch used to test various methods of generating errors/exiting the AI/server python processes, to document what is expected to work.

Each clause in the patch exercises a different method of causing an exit/exception in the python code, traversing boost python, the AI, server and human client executables.  

All methods, except those that use python `os` to kill the process, log the error.   Methods that are not within a structure (like `try ..catch`) that recovers from the error, shutdown gracefully if fatal.  Using python `os` to kill the AI process shutsdown quietly, but correctly.  Using python `os` to kill the server process, strands the AI processes.  

````diff
diff --git a/default/python/AI/FreeOrionAI.py b/default/python/AI/FreeOrionAI.py
index fe45735..72cc31d 100644
--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -12,6 +12,25 @@ import random
 
 import freeOrionAIInterface as fo  # interface used to interact with FreeOrion AI client  # pylint: disable=import-error
 
+# debug("Testing exit handling messaging in FreeOrionAI imports")
+# debug("About to RaiseException(\"test\")")
+# raise Exception('test')
+# debug("About to exit(99)")
+# exit(99)
+# debug("About to exit(0)")
+# exit(0)
+# debug("About to sys.exit(0)")
+# sys.exit(0)
+# debug("About to SystemExit()")
+# raise SystemExit()
+# debug("About to quit()")
+# quit()
+# debug("About to os.abort(). Note: The log will end abruptly.")
+# import os; os.abort()
+# debug("About to os.system('exit'). Note: This should do nothing.")
+# import os; os.system('exit')
+# debug("About to OS _exit. Note: The log will end abruptly.")
+# import os; os._exit(os.EX_OK)
 
 from common.option_tools import parse_config
 parse_config(fo.getOptionsDBOptionStr("ai-config"), fo.getUserConfigDir())
@@ -79,6 +98,12 @@ def startNewGame(aggression_input=fo.aggression.aggressive):  # pylint: disable=
         info("This empire has been eliminated. Ignoring new game start message.")
         return
 
+    # debug("Testing error handling messaging in FreeOrionAI startNewGame")
+    # debug("About to RaiseException(\"test\")")
+    # raise Exception('test')
+    # debug("About to exit(99)")
+    # exit(99)
+
     turn_timer.start("Server Processing")
 
     # initialize AIstate
@@ -232,6 +257,28 @@ def generateOrders():  # pylint: disable=invalid-name
     at end of this function, fo.doneTurn() should be called to indicate to the client that orders are finished
     and can be sent to the server for processing."""
 
+    if fo.currentTurn() > 1:
+        # debug("Testing error handling messages in generateOrders.")
+        # debug("About to RaiseException(\"test\")")
+        # raise Exception('test')
+        # debug("About to exit(99)")
+        # exit(99)
+        # debug("About to exit(0)")
+        # exit(0)
+        # debug("About to sys.exit(0)")
+        # sys.exit(0)
+        # debug("About to SystemExit()")
+        # raise SystemExit()
+        # debug("About to quit()")
+        # quit()
+        # debug("About to os.abort(). Note: The log will end abruptly")
+        # import os; os.abort()
+        # debug("About to os.system('exit'). Note: This should do nothing.")
+        # import os; os.system('exit')
+        # debug("About to OS _exit. Note: The log will end abruptly")
+        # import os; os._exit(os.EX_OK)
+        pass
+
     rules = fo.getGameRules()
     print "Defined game rules:"
     for rule in rules.getRulesAsStrings:
diff --git a/default/python/turn_events/turn_events.py b/default/python/turn_events/turn_events.py
index 7448c26..4405d2d 100644
--- a/default/python/turn_events/turn_events.py
+++ b/default/python/turn_events/turn_events.py
@@ -11,10 +11,23 @@ from math import sin, cos, pi, hypot
 import freeorion as fo
 from universe_tables import MONSTER_FREQUENCY
 
+# debug("Testing exit handling messages in turn_events imports.")
+# debug("About to RaiseException(\"test\")")
+# raise Exception('test')
+# debug("About to exit(99)")
+# exit(99)
 
 def execute_turn_events():
     print "Executing turn events for turn", fo.current_turn()
 
+    if fo.current_turn() > 1:
+        debug("Testing exit handling messages in execute_turn_events.")
+        # debug("About to RaiseException(\"test\")")
+        # raise Exception('test')
+        # debug("About to exit(99)")
+        # exit(99)
+        pass
+
     # creating fields
     systems = fo.get_systems()
     radius = fo.get_universe_width() / 2.0
diff --git a/default/python/universe_generation/universe_generator.py b/default/python/universe_generation/universe_generator.py
index fb5166e..a37ff62 100755
--- a/default/python/universe_generation/universe_generator.py
+++ b/default/python/universe_generation/universe_generator.py
@@ -8,6 +8,26 @@ import random
 
 import freeorion as fo
 
+# debug("Testing exit handling messaging in universe_generator imports")
+# debug("About to RaiseException(\"test\")")
+# raise Exception('test')
+# debug("About to exit(99)")
+# exit(99)
+# debug("About to exit(0)")
+# exit(0)
+# debug("About to sys.exit(0)")
+# sys.exit(0)
+# debug("About to SystemExit()")
+# raise SystemExit()
+# debug("About to quit()")
+# quit()
+# debug("About to os.abort(). Note: The log will end abruptly and strand the AI processes.")
+# import os; os.abort()
+# debug("About to os.system('exit'). Note: This should do nothing.")
+# import os; os.system('exit')
+# debug("About to OS _exit. Note: The log will end abruptly and strand the AI processes.")
+# import os; os._exit(os.EX_OK)
+
 from starnames import name_star_systems
 from galaxy import calc_star_system_positions
 from starsystems import name_planets, generate_systems
@@ -66,6 +86,26 @@ def create_universe(psd_map):
     """
     print "Python Universe Generator"
 
+    # debug("Testing exit handling messaging in universe_generator create_universe")
+    # debug("About to RaiseException(\"test\")")
+    # raise Exception('test')
+    # debug("About to exit(99)")
+    # exit(99)
+    # debug("About to exit(0)")
+    # exit(0)
+    # debug("About to sys.exit(0)")
+    # sys.exit(0)
+    # debug("About to SystemExit()")
+    # raise SystemExit()
+    # debug("About to quit()")
+    # quit()
+    # debug("About to os.abort(). Note: The log will end abruptly and strand the AI processes.")
+    # import os; os.abort()
+    # debug("About to os.system('exit'). Note: This should do nothing.")
+    # import os; os.system('exit')
+    # debug("About to OS _exit. Note: The log will end abruptly and strand the AI processes.")
+    # import os; os._exit(os.EX_OK)
+
     # fetch universe and player setup data
     gsd = PyGalaxySetupData(fo.get_galaxy_setup_data())
     gsd.dump()

````