### PR TITLE
Add a post-effect, pre-obstruction, vis update

### DIFF
--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -2943,6 +2943,10 @@ void ServerApp::PostCombatProcessTurns() {
 
     DebugLogger() << "ServerApp::PostCombatProcessTurns empire resources updates";
 
+    // now that we've had combat and applied Effects, update visibilities again, prior
+    //  to updating system obstructions below.
+    m_universe.UpdateEmpireObjectVisibilities();
+    m_universe.UpdateEmpireLatestKnownObjectsAndVisibilityTurns();
 
     // Determine how much of each resource is available, and determine how to
     // distribute it to planets or on queues


### PR DESCRIPTION
Adds a visibility update
  after combat resolution and effect application, but
  before determination of system obstructions for empires,
  to prevent certain visibility-related obstructions from
  persisting for an extra turn past the point at which the
  visibility issue was resolved.

This PR addresses the problems cited in Issue #1569 .  

The current sequence of relevant actions is that we have 
  - a fleet movement phase followed by 
  - a visibility update and 
  - combat resolution, and then 
  - another visibility update 
(all the above still using meter values from the prior turn), 
and then finally we have 
  - effects application and meter updates
followed by
  - system obstruction determination
and various more steps, eventually including advancing the turn number and a final visibility update

The fact that system obstruction is currently determined based on pre-effect visibility status means that any obstructions due entirely to the system not having been previously sufficiently visible will currently be cleared on the ***same turn*** the system becomes sufficiently visible if that is due purely to fleet movement and previous-turn meter values, but currently require an ***extra turn*** to clear if the visibility is gained through newly processed effects like Derelict Scout or through meter changes like the fading of ion cloud obscuration.

Besides affecting fleet travel as noted in the cited issue, this also affects supply propagation (though I think it is only in a much more restrictive set of circumstances that the supply propagation issue could ever matter).

I think a reasonable resolution is to add a visibility update after effects application and meter updates but before system obstruction determination.   I have confirmed that this fixes the extra turn of fleet movement blockage in the Derelict Scout case (and believe that it would also resolve it for the moving ion cloud case).

This does have at least the possibility of changing behavior other than that cited in the issue, due to the visibility being recorded as changed one turn sooner in these cases, but besides the supply issue noted above which I don't think is a problem I cannot think of any such cases in current content, and regardless, in all such cases the new behavior would be harmonizing the timing of results obtained from visibility-changes-due-purely-to-movement with those from visibility-changes-due-to-effects-and-meter-changes, which seems appropriate to me.