### PR TITLE
Gate initial and last turn autosaves with OptionsDB options.

### DIFF
--- a/UI/InGameMenu.cpp
+++ b/UI/InGameMenu.cpp
@@ -176,7 +176,6 @@ void InGameMenu::Save() {
             DebugLogger() << "... initiating save to " << filename ;
             app->SaveGame(filename);
             CloseClicked();
-            DebugLogger() << "... save done";
         }
 
     } catch (const std::exception& e) {

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -692,6 +692,8 @@ void OptionsWnd::CompleteConstruction() {
     BoolOption(current_page, 0, "autosave.multiplayer",   UserString("OPTIONS_MULTIPLAYER"));
     IntOption(current_page,  0, "autosave.turns",         UserString("OPTIONS_AUTOSAVE_TURNS_BETWEEN"));
     IntOption(current_page,  0, "autosave.limit",         UserString("OPTIONS_AUTOSAVE_LIMIT"));
+    BoolOption(current_page, 0, "autosave.initial-turn",  UserString("OPTIONS_AUTOSAVE_INITIAL_TURN"));
+    BoolOption(current_page, 0, "autosave.last-turn",     UserString("OPTIONS_AUTOSAVE_LAST_TURN"));
     m_tabs->SetCurrentWnd(0);
 
     // Keyboard shortcuts tab

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -688,12 +688,12 @@ void OptionsWnd::CompleteConstruction() {
 
     // Ausosave settings tab
     current_page = CreatePage(UserString("OPTIONS_PAGE_AUTOSAVE"));
-    BoolOption(current_page, 0, "autosave.single-player", UserString("OPTIONS_SINGLEPLAYER"));
-    BoolOption(current_page, 0, "autosave.multiplayer",   UserString("OPTIONS_MULTIPLAYER"));
-    IntOption(current_page,  0, "autosave.turns",         UserString("OPTIONS_AUTOSAVE_TURNS_BETWEEN"));
-    IntOption(current_page,  0, "autosave.limit",         UserString("OPTIONS_AUTOSAVE_LIMIT"));
-    BoolOption(current_page, 0, "autosave.initial-turn",  UserString("OPTIONS_AUTOSAVE_INITIAL_TURN"));
-    BoolOption(current_page, 0, "autosave.last-turn",     UserString("OPTIONS_AUTOSAVE_LAST_TURN"));
+    BoolOption(current_page, 0, "autosave.single-player",   UserString("OPTIONS_SINGLEPLAYER"));
+    BoolOption(current_page, 0, "autosave.multiplayer",     UserString("OPTIONS_MULTIPLAYER"));
+    IntOption(current_page,  0, "autosave.turns",           UserString("OPTIONS_AUTOSAVE_TURNS_BETWEEN"));
+    IntOption(current_page,  0, "autosave.limit",           UserString("OPTIONS_AUTOSAVE_LIMIT"));
+    BoolOption(current_page, 0, "autosave.galaxy-creation", UserString("OPTIONS_DB_AUTOSAVE_GALAXY_CREATION"));
+    BoolOption(current_page, 0, "autosave.game-close",      UserString("OPTIONS_DB_AUTOSAVE_GAME_CLOSE"));
     m_tabs->SetCurrentWnd(0);
 
     // Keyboard shortcuts tab

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -642,7 +642,8 @@ void HumanClientApp::SaveGame(const std::string& filename) {
 void HumanClientApp::SaveGameCompleted() {
     m_game_saves_in_progress.pop();
 
-    // Either indicate that all save are completed or start the next save.
+    // Either indicate that all saves are completed or start the next save.
+    // Autosaves and player saves can be concurrent.
     if (m_game_saves_in_progress.empty()) {
         DebugLogger() << "Save games completed.";
         SaveGamesCompletedSignal();

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -98,8 +98,8 @@ namespace {
         db.Add("autosave.multiplayer",          UserStringNop("OPTIONS_DB_AUTOSAVE_MULTIPLAYER"),       true,   Validator<bool>());
         db.Add("autosave.turns",                UserStringNop("OPTIONS_DB_AUTOSAVE_TURNS"),             1,      RangedValidator<int>(1, 50));
         db.Add("autosave.limit",                UserStringNop("OPTIONS_DB_AUTOSAVE_LIMIT"),             10,     RangedValidator<int>(1, 100));
-        db.Add("autosave.initial-turn",         UserStringNop("OPTIONS_DB_AUTOSAVE_INITIAL_TURN"),      true,   Validator<bool>());
-        db.Add("autosave.last-turn",            UserStringNop("OPTIONS_DB_AUTOSAVE_LAST_TURN"),         true,   Validator<bool>());
+        db.Add("autosave.galaxy-creation",      UserStringNop("OPTIONS_DB_AUTOSAVE_GALAXY_CREATION"),      true,   Validator<bool>());
+        db.Add("autosave.game-close",           UserStringNop("OPTIONS_DB_AUTOSAVE_GAME_CLOSE"),         true,   Validator<bool>());
         db.Add("UI.swap-mouse-lr",              UserStringNop("OPTIONS_DB_UI_MOUSE_LR_SWAP"),           false);
         db.Add("UI.keypress-repeat-delay",      UserStringNop("OPTIONS_DB_KEYPRESS_REPEAT_DELAY"),      360,    RangedValidator<int>(0, 1000));
         db.Add("UI.keypress-repeat-interval",   UserStringNop("OPTIONS_DB_KEYPRESS_REPEAT_INTERVAL"),   20,     RangedValidator<int>(0, 1000));
@@ -1164,8 +1164,8 @@ void HumanClientApp::Autosave() {
              || (!m_single_player_game && GetOptionsDB().Get<bool>("autosave.multiplayer"))));
 
     // is_initial_save is gated in HumanClientFSM for new game vs loaded game
-    bool is_initial_save = (GetOptionsDB().Get<bool>("autosave.initial-turn") && CurrentTurn() == 1);
-    bool is_final_save = (GetOptionsDB().Get<bool>("autosave.last-turn") && !m_game_started);
+    bool is_initial_save = (GetOptionsDB().Get<bool>("autosave.galaxy-creation") && CurrentTurn() == 1);
+    bool is_final_save = (GetOptionsDB().Get<bool>("autosave.game-close") && !m_game_started);
 
     if (!(is_initial_save || is_valid_autosave || is_final_save))
         return;
@@ -1250,7 +1250,7 @@ void HumanClientApp::ResetOrExitApp(bool reset, bool skip_savegame) {
 
     // Only save if not exiting due to an error.
     if (!skip_savegame) {
-        if (was_playing && GetOptionsDB().Get<bool>("autosave.last-turn"))
+        if (was_playing && GetOptionsDB().Get<bool>("autosave.game-close"))
             Autosave();
 
         if (!m_game_saves_in_progress.empty()) {

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -1169,14 +1169,15 @@ void HumanClientApp::Autosave() {
     if (!(is_initial_save || is_valid_autosave || is_final_save))
         return;
 
-    auto autosave_dir_path = CreateNewAutosaveFilePath(EmpireID(), m_single_player_game);
+    auto autosave_file_path = CreateNewAutosaveFilePath(EmpireID(), m_single_player_game);
 
     // check for and remove excess oldest autosaves
+    boost::filesystem::path autosave_dir_path(GetSaveDir() / "auto");
     int max_autosaves = GetOptionsDB().Get<int>("autosave.limit");
     RemoveOldestFiles(max_autosaves, autosave_dir_path);
 
     // create new save
-    auto path_string = PathString(autosave_dir_path);
+    auto path_string = PathString(autosave_file_path);
 
     if (is_initial_save)
         DebugLogger() << "Turn 0 autosave to: " << path_string;

--- a/client/human/HumanClientApp.h
+++ b/client/human/HumanClientApp.h
@@ -149,6 +149,8 @@ private:
     int                         m_auto_turns;           ///< auto turn counter
     bool                        m_have_window_focus;
 
+    /** Filenames of all in progress saves.  There maybe multiple saves in
+        progress if a player and an autosave are initiated at the same time. */
     std::queue<std::string>     m_game_saves_in_progress;
     boost::signals2::signal<void ()> SaveGamesCompletedSignal;
 };

--- a/client/human/HumanClientApp.h
+++ b/client/human/HumanClientApp.h
@@ -9,6 +9,7 @@
 #include <GG/SDL/SDLGUI.h>
 
 #include <memory>
+#include <queue>
 #include <string>
 
 struct HumanClientFSM;
@@ -148,8 +149,8 @@ private:
     int                         m_auto_turns;           ///< auto turn counter
     bool                        m_have_window_focus;
 
-    bool                        m_save_game_in_progress;
-    boost::signals2::signal<void ()> SaveGameCompletedSignal;
+    std::queue<std::string>     m_game_saves_in_progress;
+    boost::signals2::signal<void ()> SaveGamesCompletedSignal;
 };
 
 #endif // _HumanClientApp_h_

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1638,11 +1638,11 @@ Sets the number of turns between autosaves.
 OPTIONS_DB_AUTOSAVE_LIMIT
 Sets the maximum number of autosave files to keep.
 
-OPTIONS_DB_AUTOSAVE_INTIAL_TURN
-If true, autosave the initial turn before any game play.
+OPTIONS_DB_AUTOSAVE_GALAXY_CREATION
+Toggles whether to autosave after the galaxy is created before any game play.
 
-OPTIONS_DB_AUTOSAVE_LAST_TURN
-If true, autosave on game exit.
+OPTIONS_DB_AUTOSAVE_GAME_CLOSE
+Toggles whether to autosave when resigning or closing the game.
 
 OPTIONS_DB_UI_MOUSE_LR_SWAP
 Swaps results of clicking left and right mouse buttons.
@@ -2272,12 +2272,6 @@ Autosaves limit
 
 OPTIONS_AUTOSAVE_TURNS_BETWEEN
 Turns between autosaves
-
-OPTIONS_AUTOSAVE_INITIAL_TURN
-Autosave on turn 0 before any game play
-
-OPTIONS_AUTOSAVE_LAST_TURN
-Autosave before game exit
 
 OPTIONS_LANGUAGE
 Language file

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1638,6 +1638,12 @@ Sets the number of turns between autosaves.
 OPTIONS_DB_AUTOSAVE_LIMIT
 Sets the maximum number of autosave files to keep.
 
+OPTIONS_DB_AUTOSAVE_INTIAL_TURN
+If true, autosave the initial turn before any game play.
+
+OPTIONS_DB_AUTOSAVE_LAST_TURN
+If true, autosave on game exit.
+
 OPTIONS_DB_UI_MOUSE_LR_SWAP
 Swaps results of clicking left and right mouse buttons.
 
@@ -2266,6 +2272,12 @@ Autosaves limit
 
 OPTIONS_AUTOSAVE_TURNS_BETWEEN
 Turns between autosaves
+
+OPTIONS_AUTOSAVE_INITIAL_TURN
+Autosave on turn 0 before any game play
+
+OPTIONS_AUTOSAVE_LAST_TURN
+Autosave before game exit
 
 OPTIONS_LANGUAGE
 Language file


### PR DESCRIPTION
This addresses the concern that the autoquit autosave was not gated by an option, raised here https://github.com/freeorion/freeorion/pull/1653#issuecomment-320354748.

It also adds an option to gate the initial turn autosave.

The options are named:
- autosave.initial-turn
- autosave.last-turn

This PR depends on #1665, because they both make changes to the shutdown sequence.