### PR TITLE
Add --continue game startup option.

### DIFF
--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -685,6 +685,9 @@ void ClientUI::ShowIntroScreen()
         m_map_wnd->Hide();
     }
 
+    // Update intro screen Load & Continue buttons if all savegames are deleted.
+    m_intro_screen->RequirePreRender();
+
     HumanClientApp::GetApp()->Register(m_intro_screen);
     HumanClientApp::GetApp()->Remove(m_message_wnd);
     HumanClientApp::GetApp()->Remove(m_player_list_wnd);

--- a/UI/IntroScreen.cpp
+++ b/UI/IntroScreen.cpp
@@ -311,7 +311,7 @@ void IntroScreen::CompleteConstruction() {
     m_exit_game->LeftClickedSignal.connect(
         boost::bind(&IntroScreen::OnExitGame, this));
 
-    DoLayout();
+    RequirePreRender();
 }
 
 IntroScreen::~IntroScreen()
@@ -405,10 +405,21 @@ void IntroScreen::KeyPress(GG::Key key, std::uint32_t key_code_point, GG::Flags<
 void IntroScreen::Close()
 { OnExitGame(); }
 
+void IntroScreen::SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
+    GG::Pt old_size = GG::Wnd::Size();
+
+    GG::Wnd::SizeMove(ul, lr);
+
+    if (old_size != GG::Wnd::Size())
+        RequirePreRender();
+}
+
 void IntroScreen::Render()
 {}
 
-void IntroScreen::DoLayout() {
+void IntroScreen::PreRender() {
+    GG::Wnd::PreRender();
+
     m_splash->Resize(this->Size());
     m_logo->Resize(GG::Pt(this->Width(), this->Height() / 10));
     m_version->MoveTo(GG::Pt(this->Width() - m_version->Width(), this->Height() - m_version->Height()));

--- a/UI/IntroScreen.cpp
+++ b/UI/IntroScreen.cpp
@@ -274,19 +274,6 @@ void IntroScreen::CompleteConstruction() {
     m_credits =       Wnd::Create<CUIButton>(UserString("INTRO_BTN_CREDITS"));
     m_exit_game =     Wnd::Create<CUIButton>(UserString("INTRO_BTN_EXIT"));
 
-    //attach buttons
-    m_menu->AttachChild(m_continue);
-    m_menu->AttachChild(m_single_player);
-    m_menu->AttachChild(m_quick_start);
-    m_menu->AttachChild(m_multi_player);
-    m_menu->AttachChild(m_load_game);
-    m_menu->AttachChild(m_options);
-    m_menu->AttachChild(m_pedia);
-    m_menu->AttachChild(m_about);
-    m_menu->AttachChild(m_website);
-    m_menu->AttachChild(m_credits);
-    m_menu->AttachChild(m_exit_game);
-
     //connect signals and slots
     m_continue->LeftClickedSignal.connect(
         boost::bind(&IntroScreen::OnContinue, this));
@@ -460,26 +447,41 @@ void IntroScreen::PreRender() {
 
     button_lr += button_ul;
 
-    const auto place_button = [&button_ul, &button_lr, &button_cell_height, &mainmenu_height](GG::Button* button) {
-        button->SizeMove(button_ul, button_lr);
-        button_ul.y += GG::Y(button_cell_height);
-        button_lr.y += GG::Y(button_cell_height);
-        mainmenu_height += button_cell_height;
+    const auto place_button =
+        [&button_ul, &button_lr, &button_cell_height, &mainmenu_height]
+        (CUIWnd* menu, std::shared_ptr<GG::Button> button)
+        {
+            button->SizeMove(button_ul, button_lr);
+            menu->AttachChild(std::move(button));
+            button_ul.y += GG::Y(button_cell_height);
+            button_lr.y += GG::Y(button_cell_height);
+            mainmenu_height += button_cell_height;
+        };
+
+    const auto unplace_button = [](CUIWnd* menu, const std::shared_ptr<GG::Button>& button) {
+        menu->DetachChild(button);
     };
 
-    place_button(m_continue.get());
-    place_button(m_single_player.get());
-    place_button(m_quick_start.get());
-    place_button(m_multi_player.get());
-    place_button(m_load_game.get());
-    place_button(m_options.get());
-    place_button(m_pedia.get());
-    place_button(m_about.get());
-    place_button(m_website.get());
-    place_button(m_credits.get());
+    if (HumanClientApp::GetApp()->IsLoadGameAvailable())
+        place_button(m_menu.get(), m_continue);
+    else
+        unplace_button(m_menu.get(), m_continue);
+    place_button(m_menu.get(), m_single_player);
+    place_button(m_menu.get(), m_quick_start);
+    place_button(m_menu.get(), m_multi_player);
+    if (HumanClientApp::GetApp()->IsLoadGameAvailable())
+        place_button(m_menu.get(), m_load_game);
+    else
+        unplace_button(m_menu.get(), m_load_game);
+    place_button(m_menu.get(), m_options);
+    place_button(m_menu.get(), m_pedia);
+    place_button(m_menu.get(), m_about);
+    place_button(m_menu.get(), m_website);
+    place_button(m_menu.get(), m_credits);
 
     button_ul.y += GG::Y(button_cell_height) * 0.75;
     button_lr.y += GG::Y(button_cell_height) * 0.75;
+    m_menu->AttachChild(m_exit_game);
     m_exit_game->SizeMove(button_ul, button_lr);
 
     // position menu window

--- a/UI/IntroScreen.cpp
+++ b/UI/IntroScreen.cpp
@@ -262,6 +262,7 @@ void IntroScreen::CompleteConstruction() {
     m_splash->AttachChild(m_version);
 
     //create buttons
+    m_continue =      Wnd::Create<CUIButton>(UserString("INTRO_BTN_CONTINUE"));
     m_single_player = Wnd::Create<CUIButton>(UserString("INTRO_BTN_SINGLE_PLAYER"));
     m_quick_start =   Wnd::Create<CUIButton>(UserString("INTRO_BTN_QUICK_START"));
     m_multi_player =  Wnd::Create<CUIButton>(UserString("INTRO_BTN_MULTI_PLAYER"));
@@ -274,6 +275,8 @@ void IntroScreen::CompleteConstruction() {
     m_exit_game =     Wnd::Create<CUIButton>(UserString("INTRO_BTN_EXIT"));
 
     //attach buttons
+    if (GetOptionsDB().Get<bool>("autosave.last-turn"))
+        m_menu->AttachChild(m_continue);
     m_menu->AttachChild(m_single_player);
     m_menu->AttachChild(m_quick_start);
     m_menu->AttachChild(m_multi_player);
@@ -286,6 +289,8 @@ void IntroScreen::CompleteConstruction() {
     m_menu->AttachChild(m_exit_game);
 
     //connect signals and slots
+    m_continue->LeftClickedSignal.connect(
+        boost::bind(&IntroScreen::OnContinue, this));
     m_single_player->LeftClickedSignal.connect(
         boost::bind(&IntroScreen::OnSinglePlayer, this));
     m_quick_start->LeftClickedSignal.connect(
@@ -312,6 +317,10 @@ void IntroScreen::CompleteConstruction() {
 
 IntroScreen::~IntroScreen()
 {}
+
+void IntroScreen::OnContinue() {
+    HumanClientApp::GetApp()->ContinueSinglePlayerGame();
+}
 
 void IntroScreen::OnSinglePlayer() {
     HumanClientApp::GetApp()->NewSinglePlayerGame();
@@ -416,6 +425,8 @@ void IntroScreen::DoLayout() {
     GG::Y mainmenu_height(0);           //height of the mainmenu
 
     //calculate necessary button width
+    if (GetOptionsDB().Get<bool>("autosave.last-turn"))
+        button_width = std::max(button_width, m_continue->MinUsableSize().x);
     button_width = std::max(button_width, m_single_player->MinUsableSize().x);
     button_width = std::max(button_width, m_quick_start->MinUsableSize().x);
     button_width = std::max(button_width, m_multi_player->MinUsableSize().x);
@@ -432,7 +443,7 @@ void IntroScreen::DoLayout() {
     button_cell_height = std::max(MIN_BUTTON_HEIGHT, m_exit_game->MinUsableSize().y);
     //culate window width and height
     mainmenu_width  =         button_width  + H_MAINMENU_MARGIN;
-    mainmenu_height = 10.75 * button_cell_height + V_MAINMENU_MARGIN; // 10 rows + 0.75 before exit button
+    mainmenu_height = 11.75 * button_cell_height + V_MAINMENU_MARGIN; // 11 rows + 0.75 before exit button
 
     // place buttons
     GG::Pt button_ul(GG::X(15), GG::Y(12));
@@ -440,6 +451,9 @@ void IntroScreen::DoLayout() {
 
     button_lr += button_ul;
 
+    m_continue->SizeMove(button_ul, button_lr);
+    button_ul.y += GG::Y(button_cell_height);
+    button_lr.y += GG::Y(button_cell_height);
     m_single_player->SizeMove(button_ul, button_lr);
     button_ul.y += GG::Y(button_cell_height);
     button_lr.y += GG::Y(button_cell_height);

--- a/UI/IntroScreen.cpp
+++ b/UI/IntroScreen.cpp
@@ -275,8 +275,7 @@ void IntroScreen::CompleteConstruction() {
     m_exit_game =     Wnd::Create<CUIButton>(UserString("INTRO_BTN_EXIT"));
 
     //attach buttons
-    if (GetOptionsDB().Get<bool>("autosave.last-turn"))
-        m_menu->AttachChild(m_continue);
+    m_menu->AttachChild(m_continue);
     m_menu->AttachChild(m_single_player);
     m_menu->AttachChild(m_quick_start);
     m_menu->AttachChild(m_multi_player);
@@ -425,8 +424,7 @@ void IntroScreen::DoLayout() {
     GG::Y mainmenu_height(0);           //height of the mainmenu
 
     //calculate necessary button width
-    if (GetOptionsDB().Get<bool>("autosave.last-turn"))
-        button_width = std::max(button_width, m_continue->MinUsableSize().x);
+    button_width = std::max(button_width, m_continue->MinUsableSize().x);
     button_width = std::max(button_width, m_single_player->MinUsableSize().x);
     button_width = std::max(button_width, m_quick_start->MinUsableSize().x);
     button_width = std::max(button_width, m_multi_player->MinUsableSize().x);
@@ -441,9 +439,9 @@ void IntroScreen::DoLayout() {
 
     //calculate  necessary button height
     button_cell_height = std::max(MIN_BUTTON_HEIGHT, m_exit_game->MinUsableSize().y);
-    //culate window width and height
+    // calculate window width and height
     mainmenu_width  =         button_width  + H_MAINMENU_MARGIN;
-    mainmenu_height = 11.75 * button_cell_height + V_MAINMENU_MARGIN; // 11 rows + 0.75 before exit button
+    mainmenu_height = 1.75 * button_cell_height + V_MAINMENU_MARGIN; // 1.75 for the exit button
 
     // place buttons
     GG::Pt button_ul(GG::X(15), GG::Y(12));
@@ -451,36 +449,26 @@ void IntroScreen::DoLayout() {
 
     button_lr += button_ul;
 
-    m_continue->SizeMove(button_ul, button_lr);
-    button_ul.y += GG::Y(button_cell_height);
-    button_lr.y += GG::Y(button_cell_height);
-    m_single_player->SizeMove(button_ul, button_lr);
-    button_ul.y += GG::Y(button_cell_height);
-    button_lr.y += GG::Y(button_cell_height);
-    m_quick_start->SizeMove(button_ul, button_lr);
-    button_ul.y += GG::Y(button_cell_height);
-    button_lr.y += GG::Y(button_cell_height);
-    m_multi_player->SizeMove(button_ul, button_lr);
-    button_ul.y += GG::Y(button_cell_height);
-    button_lr.y += GG::Y(button_cell_height);
-    m_load_game->SizeMove(button_ul, button_lr);
-    button_ul.y += GG::Y(button_cell_height);
-    button_lr.y += GG::Y(button_cell_height);
-    m_options->SizeMove(button_ul, button_lr);
-    button_ul.y += GG::Y(button_cell_height);
-    button_lr.y += GG::Y(button_cell_height);
-    m_pedia->SizeMove(button_ul, button_lr);
-    button_ul.y += GG::Y(button_cell_height);
-    button_lr.y += GG::Y(button_cell_height);
-    m_about->SizeMove(button_ul, button_lr);
-    button_ul.y += GG::Y(button_cell_height);
-    button_lr.y += GG::Y(button_cell_height);
-    m_website->SizeMove(button_ul, button_lr);
-    button_ul.y += GG::Y(button_cell_height);
-    button_lr.y += GG::Y(button_cell_height);
-    m_credits->SizeMove(button_ul, button_lr);
-    button_ul.y += GG::Y(button_cell_height) * 1.75;
-    button_lr.y += GG::Y(button_cell_height) * 1.75;
+    const auto place_button = [&button_ul, &button_lr, &button_cell_height, &mainmenu_height](GG::Button* button) {
+        button->SizeMove(button_ul, button_lr);
+        button_ul.y += GG::Y(button_cell_height);
+        button_lr.y += GG::Y(button_cell_height);
+        mainmenu_height += button_cell_height;
+    };
+
+    place_button(m_continue.get());
+    place_button(m_single_player.get());
+    place_button(m_quick_start.get());
+    place_button(m_multi_player.get());
+    place_button(m_load_game.get());
+    place_button(m_options.get());
+    place_button(m_pedia.get());
+    place_button(m_about.get());
+    place_button(m_website.get());
+    place_button(m_credits.get());
+
+    button_ul.y += GG::Y(button_cell_height) * 0.75;
+    button_lr.y += GG::Y(button_cell_height) * 0.75;
     m_exit_game->SizeMove(button_ul, button_lr);
 
     // position menu window

--- a/UI/IntroScreen.h
+++ b/UI/IntroScreen.h
@@ -27,6 +27,7 @@ public:
 
     void Render() override;
 
+    void            OnContinue();
     void            OnSinglePlayer();  //!< called when single player is clicked
     void            OnQuickStart();    //!< called when quick start is clicked
     void            OnMultiPlayer();   //!< ...
@@ -44,6 +45,7 @@ public:
     //!@}
 
 private:
+    std::shared_ptr<GG::Button>         m_continue;      //!< continues from last autosave
     std::shared_ptr<GG::Button>         m_single_player;//!< opens up the single player game dialog
     std::shared_ptr<GG::Button>         m_quick_start;  //!< starts a single-player game with the default options (no dialog)
     std::shared_ptr<GG::Button>         m_multi_player; //!< opens up the multi player game dialog

--- a/UI/IntroScreen.h
+++ b/UI/IntroScreen.h
@@ -26,6 +26,8 @@ public:
     void KeyPress(GG::Key key, std::uint32_t key_code_point, GG::Flags<GG::ModKey> mod_keys) override;
 
     void Render() override;
+    void PreRender() override;
+    void SizeMove(const GG::Pt& ul, const GG::Pt& lr) override;
 
     void            OnContinue();
     void            OnSinglePlayer();  //!< called when single player is clicked
@@ -39,8 +41,6 @@ public:
     void            OnCredits();
     void            OnExitGame();
 
-
-    void            DoLayout();
     virtual void    Close();
     //!@}
 

--- a/UI/IntroScreen.h
+++ b/UI/IntroScreen.h
@@ -26,6 +26,11 @@ public:
     void KeyPress(GG::Key key, std::uint32_t key_code_point, GG::Flags<GG::ModKey> mod_keys) override;
 
     void Render() override;
+
+    /**Note:  Since there is poor filesystem tracking of deleted savegames, use
+       RequirePreRender() to force an update of the conditional placement of
+       the Continue and Load buttons when a player might have deleted the last
+       savegame. */
     void PreRender() override;
     void SizeMove(const GG::Pt& ul, const GG::Pt& lr) override;
 

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -671,6 +671,10 @@ void HumanClientApp::LoadSinglePlayerGame(std::string filename/* = ""*/) {
         try {
             auto sfd = GG::Wnd::Create<SaveFileDialog>(SP_SAVE_FILE_EXTENSION, true);
             sfd->Run();
+
+            // Update intro screen Load & Continue buttons if all savegames are deleted.
+            m_ui->GetIntroScreen()->RequirePreRender();
+
             if (!sfd->Result().empty())
                 filename = sfd->Result();
         } catch (const std::exception& e) {

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -1206,9 +1206,10 @@ void HumanClientApp::Autosave() {
 
     auto autosave_file_path = CreateNewAutosaveFilePath(EmpireID(), m_single_player_game);
 
-    // check for and remove excess oldest autosaves
+    // check for and remove excess oldest autosaves.  The minimum is 1 for the
+    // initial or final save.
     boost::filesystem::path autosave_dir_path(GetSaveDir() / "auto");
-    int max_autosaves = GetOptionsDB().Get<int>("autosave.limit");
+    int max_autosaves = std::max(1, GetOptionsDB().Get<int>("autosave.limit"));
     RemoveOldestFiles(max_autosaves, autosave_dir_path);
 
     // create new save

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -1193,6 +1193,10 @@ namespace {
 }
 
 void HumanClientApp::Autosave() {
+    // only host can save in multiplayer
+    if (!m_single_player_game && !Networking().PlayerIsHost(PlayerID()))
+        return;
+
     // Create an auto save for 1) new games on turn 1, 2) if auto save is
     // requested on turn number modulo autosave.turns or 3) on the last turn of
     // play.

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -1228,6 +1228,10 @@ void HumanClientApp::Autosave() {
     }
 }
 
+void HumanClientApp::ContinueSinglePlayerGame() {
+    LoadSinglePlayerGame(NewestSinglePlayerAutosave());
+}
+
 std::string HumanClientApp::SelectLoadFile() {
     auto sfd = GG::Wnd::Create<SaveFileDialog>(true);
     sfd->Run();

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -953,10 +953,8 @@ void HumanClientApp::HandleWindowResize(GG::X w, GG::Y h) {
     if (ClientUI* ui = ClientUI::GetClientUI()) {
         if (auto&& map_wnd = ui->GetMapWnd())
             map_wnd->DoLayout();
-        if (auto&& intro_screen = ui->GetIntroScreen()) {
+        if (auto&& intro_screen = ui->GetIntroScreen())
             intro_screen->Resize(GG::Pt(w, h));
-            intro_screen->DoLayout();
-        }
     }
 
     if (!GetOptionsDB().Get<bool>("fullscreen") &&

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -690,7 +690,7 @@ void HumanClientApp::LoadSinglePlayerGame(std::string filename/* = ""*/) {
 
     // end any currently-playing game before loading new one
     if (m_game_started) {
-        ResetToIntro(false);
+        ResetToIntro(true);
         // delay to make sure old game is fully cleaned up before attempting to start a new one
         std::this_thread::sleep_for(std::chrono::seconds(3));
     } else {

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -643,7 +643,8 @@ void HumanClientApp::SaveGame(const std::string& filename) {
 }
 
 void HumanClientApp::SaveGameCompleted() {
-    m_game_saves_in_progress.pop();
+    if (!m_game_saves_in_progress.empty())
+        m_game_saves_in_progress.pop();
 
     // Either indicate that all saves are completed or start the next save.
     // Autosaves and player saves can be concurrent.

--- a/client/human/HumanClientApp.h
+++ b/client/human/HumanClientApp.h
@@ -78,6 +78,7 @@ public:
     void                Autosave();                                     ///< autosaves the current game, iff autosaves are enabled and any turn number requirements are met
     /** Load the newest single player autosave and continue playing game. */
     void                ContinueSinglePlayerGame();
+    bool                IsLoadGameAvailable() const;
     std::string         SelectLoadFile();                               //< Lets the user select a multiplayer save to load.
     void                InitAutoTurns(int auto_turns);                  ///< Initialize auto turn counter
     void                DecAutoTurns(int n = 1);                        ///< Decrease auto turn counter

--- a/client/human/HumanClientApp.h
+++ b/client/human/HumanClientApp.h
@@ -73,9 +73,11 @@ public:
     void                ResetToIntro(bool skip_savegame);
     void                ExitApp();
     void                ResetClientData(bool save_connection = false);
-    void                LoadSinglePlayerGame(std::string filename = "");///< loads a single player game chosen by the user; returns true if a game was loaded, and false if the operation was cancelled
+    void                LoadSinglePlayerGame(std::string filename = "");
     void                RequestSavePreviews(const std::string& directory, PreviewInformation& previews); ///< Requests the savegame previews for choosing one.
     void                Autosave();                                     ///< autosaves the current game, iff autosaves are enabled and any turn number requirements are met
+    /** Load the newest single player autosave and continue playing game. */
+    void                ContinueSinglePlayerGame();
     std::string         SelectLoadFile();                               //< Lets the user select a multiplayer save to load.
     void                InitAutoTurns(int auto_turns);                  ///< Initialize auto turn counter
     void                DecAutoTurns(int n = 1);                        ///< Decrease auto turn counter

--- a/client/human/chmain.cpp
+++ b/client/human/chmain.cpp
@@ -128,6 +128,7 @@ int mainConfigOptionsSetup(const std::vector<std::string>& args) {
         GetOptionsDB().Add<bool>("fake-mode-change",        UserStringNop("OPTIONS_DB_FAKE_MODE_CHANGE"),     FAKE_MODE_CHANGE_FLAG);
         GetOptionsDB().Add<int>("fullscreen-monitor-id",    UserStringNop("OPTIONS_DB_FULLSCREEN_MONITOR_ID"), 0, RangedValidator<int>(0, 5));
         GetOptionsDB().AddFlag('q', "quickstart",           UserStringNop("OPTIONS_DB_QUICKSTART"),            false);
+        GetOptionsDB().AddFlag("continue",                  UserStringNop("OPTIONS_DB_CONTINUE"),              false);
         GetOptionsDB().AddFlag("auto-quit",                 UserStringNop("OPTIONS_DB_AUTO_QUIT"),             false);
         GetOptionsDB().Add<int>("auto-advance-n-turns",     UserStringNop("OPTIONS_DB_AUTO_N_TURNS"),          0, RangedValidator<int>(0, 400), false);
         GetOptionsDB().Add<std::string>("load",             UserStringNop("OPTIONS_DB_LOAD"),                  "", Validator<std::string>(), false);
@@ -242,6 +243,13 @@ int mainSetupAndRun() {
             // standard quickstart, without requiring the user to click the
             // quickstart button).
             app.NewSinglePlayerGame(true);  // acceptable to call before app()
+        }
+
+        if (GetOptionsDB().Get<bool>("continue")) {
+            // immediately start the server, establish network connections, and
+            // go into a single player game, continuing from the newest
+            // autosave game.
+            app.ContinueSinglePlayerGame();  // acceptable to call before app()
         }
 
         std::string load_filename = GetOptionsDB().Get<std::string>("load");

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1641,10 +1641,10 @@ OPTIONS_DB_AI_CONFIG_TRAIT_EMPIREID_FORCED_VALUE
 Forced value of the EmpireID Trait.  A value from 0 to 39.
 
 OPTIONS_DB_AUTOSAVE_SINGLE_PLAYER
-If true, autosaves will occur during single-player games.
+Enable single-player autosaves.
 
 OPTIONS_DB_AUTOSAVE_MULTIPLAYER
-If true, autosaves will occur during multiplayer games.
+Enable multi-player autosaves.
 
 OPTIONS_DB_AUTOSAVE_TURNS
 Sets the number of turns between autosaves.
@@ -1653,10 +1653,10 @@ OPTIONS_DB_AUTOSAVE_LIMIT
 Sets the maximum number of autosave files to keep.
 
 OPTIONS_DB_AUTOSAVE_GALAXY_CREATION
-Toggles whether to autosave after the galaxy is created before any game play.
+Enable autosave after the galaxy is created before any game play.
 
 OPTIONS_DB_AUTOSAVE_GAME_CLOSE
-Toggles whether to autosave when resigning or closing the game.
+Enable autosave when resigning or closing the game.
 
 OPTIONS_DB_UI_MOUSE_LR_SWAP
 Swaps results of clicking left and right mouse buttons.

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1667,6 +1667,9 @@ The volume (0 to 255) at which music should be played.
 OPTIONS_DB_QUICKSTART
 Starts a new quick-start game, bypassing the main menu.
 
+OPTIONS_DB_CONTINUE
+Continues play from lastest autosave, bypassing the main menu.
+
 OPTIONS_DB_AUTO_N_TURNS
 Hits the "Turn" button automatically on the first N turns (up to 400 turns, defaults to zero); useful for various testing particularly with --quickstart or --load, possibly also --auto-quit.
 
@@ -1861,6 +1864,9 @@ A:
 
 INTRO_WINDOW_TITLE
 FreeOrion Main Menu
+
+INTRO_BTN_CONTINUE
+Continue
 
 INTRO_BTN_SINGLE_PLAYER
 Single Player


### PR DESCRIPTION
I've cross posted this to the forum, as http://freeorion.org/forum/viewtopic.php?f=6&t=10674

This PR adds a "--continue" command line option and a "Continue" button to the intro menu.

It depends on #1670.  I made it a separate PR so that it could be discussed separately on the forum.

To continue means to find the newest single player autosave, load it and continue play.  The "--continue" option skips the intro menu the same as the "--quickstart" option.  

The "Continue" button on the main menu is enabled by the autosave.last-turn option added in #1670.




