### PR TITLE
AI logger related fixes

### DIFF
--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -135,7 +135,7 @@ def resumeLoadedGame(saved_state_string):  # pylint: disable=invalid-name
             # assigning new state
             foAIstate = AIstate.AIstate(fo.aggression.aggressive)
             foAIstate.session_start_cleanup()
-            error("Fail to load aiState from saved game: %s", e, exc_info=True)
+            error("Fail to load aiState from saved game: %s" % e, exc_info=True)
 
     aggression_trait = foAIstate.character.get_trait(Aggression)
     diplomatic_corp_configs = {fo.aggression.beginner: DiplomaticCorp.BeginnerDiplomaticCorp,
@@ -250,7 +250,7 @@ def generateOrders():  # pylint: disable=invalid-name
             # not invalidate doneTurn()
             fo.doneTurn()
         except Exception as e:
-            error("Exception in doneTurn() on non-existent empire", e, exc_info=True)
+            error("Exception %s in doneTurn() on non-existent empire" % e, exc_info=True)
         return
 
     if empire.eliminated:
@@ -260,7 +260,7 @@ def generateOrders():  # pylint: disable=invalid-name
             # on last-seen gamestate if nothing can be ordered anyway...
             fo.doneTurn()
         except Exception as e:
-            error("Exception while trying doneTurn() on eliminated empire", e, exc_info=True)
+            error("Exception %s while trying doneTurn() on eliminated empire" % e, exc_info=True)
         return
 
     # This code block is required for correct AI work.
@@ -337,7 +337,7 @@ def generateOrders():  # pylint: disable=invalid-name
             action()
             main_timer.stop()
         except Exception as e:
-            error("Exception while trying to %s" % action.__name__, e, exc_info=True)
+            error("Exception %s while trying to %s" % (e, action.__name__), exc_info=True)
     main_timer.stop_print_and_clear()
     turn_timer.stop_print_and_clear()
     turn_timer.start("Server_Processing")
@@ -345,7 +345,7 @@ def generateOrders():  # pylint: disable=invalid-name
     try:
         fo.doneTurn()
     except Exception as e:
-        error("Exception while trying doneTurn()", e, exc_info=True)  # TODO move it to cycle above
+        error("Exception %s while trying doneTurn()" % e, exc_info=True)  # TODO move it to cycle above
 
     if using_statprof:
         try:


### PR DESCRIPTION
These changes appear necessary to me to fix an AI logging problem from 2f4e85ed, which would potentially cause the AI to semi-silently fail when it had an error rather than reporting it to the user via chat (and in conjunction with a recent naming error resulting from a942bf8d was in fact causing the AI to semi-silently fail).

@LGM-Doyle  All or most of these logging adjustments are to changes that you very recently made, and since you're the architect of the current AI logging structure I am a bit apprehensive that I am misunderstanding something here or else I would just directly commit it since it appears to me necessary to fix the AI.  But perhaps you have some other way you'd prefer it resolved...

@geoffthemedio since they are already tangentially involved I'd like to go ahead and ask you here about the changes in a942bf8d which then in turn exposed this logging error-- in one of your "grooming" commits you changed the naming convention / names under which a few empire methods were exposed to the AI, without making corresponding changes to the AI, and thus breaking it (but because of this logging error that wouldn't have immediately shown up in testing unless you manually checked the AI logs and even then the errors would not have been clearly identified).   We can fix those naming errors either by reverting those three names or by changing the places they are used by the AI.  Since seemingly all of the other names in the EmpireWrapper are still following the other naming convention, I would be more inclined to revert the three names -- if we are going to change the naming convention we can do them all at once.  If you have a preference please let me know ASAP.