### PR TITLE
Fix bug #1680, add `RichText::CompleteConstruction()`, make `TextLinker::FindLinks()` stable.

### DIFF
--- a/GG/GG/RichText/RichText.h
+++ b/GG/GG/RichText/RichText.h
@@ -71,6 +71,8 @@ public:
              Clr color = CLR_BLACK, Flags<TextFormat> format = FORMAT_NONE,
              Flags<WndFlag> flags = NO_WND_FLAGS);
 
+    void CompleteConstruction() override;
+
     ~RichText();
     //@}
 

--- a/GG/src/RichText/RichText.cpp
+++ b/GG/src/RichText/RichText.cpp
@@ -185,7 +185,7 @@ namespace GG {
 
         // Set the mapping from tags to factories that should be used to generate blocks from them.
         void SetBlockFactoryMap(std::shared_ptr<RichText::BLOCK_FACTORY_MAP> block_factory_map)
-        { m_block_factory_map = block_factory_map; }
+        { m_block_factory_map = std::move(block_factory_map); }
 
     private:
         // Easier access to m_block_factory_map

--- a/GG/src/RichText/RichText.cpp
+++ b/GG/src/RichText/RichText.cpp
@@ -192,6 +192,9 @@ namespace GG {
         RichText::BLOCK_FACTORY_MAP& FactoryMap()
         { return *m_block_factory_map; }
 
+        // Parses content into tags.
+        std::vector<RichTextTag> ParseTags(const std::string& content);
+
         // Create blocks from tags.
         void PopulateBlocks(const std::vector<RichTextTag>& tags);
 
@@ -225,11 +228,8 @@ namespace GG {
         m_blocks.clear();
         m_owner->DetachChildren();
 
-        // Get a set of tags registered for rich text usage.
-        std::set<std::string> known_tags = MapKeys(*m_block_factory_map);
-
         // Parse the content into a vector of tags.
-        std::vector<RichTextTag> tags = TagParser::ParseTags(content, known_tags);
+        auto tags = ParseTags(content);
 
         // Create blocks from the tags and populate the control with them.
         PopulateBlocks(tags);
@@ -263,6 +263,18 @@ namespace GG {
             keys.insert(pair.first);
         }
         return keys;
+    }
+
+    // Parses content into tags.
+    std::vector<RichTextTag> RichTextPrivate::ParseTags(const std::string& content)
+    {
+        // Get a set of tags registered for rich text usage.
+        std::set<std::string> known_tags = MapKeys(*m_block_factory_map);
+
+        // Parse the content into a vector of tags.
+        std::vector<RichTextTag> tags = TagParser::ParseTags(content, known_tags);
+
+        return tags;
     }
 
     // Create blocks from tags.

--- a/UI/LinkText.cpp
+++ b/UI/LinkText.cpp
@@ -51,7 +51,6 @@ void LinkText::Render() {
 
 void LinkText::SetText(const std::string& str) {
     m_raw_text = str;
-    GG::TextControl::SetText(m_raw_text);   // so that line data is updated for use in FindLinks
     FindLinks();
     MarkLinks();
 }
@@ -306,6 +305,10 @@ void TextLinker::FindLinks() {
 
     GG::Y y_posn(0); // y-coordinate of the top of the current line
     Link link;
+
+    // control text needs to be updated so that the line data is calculated from
+    // the raw text and not the marked text set in MarkText().
+    SetLinkedText(RawText());
 
     for (const GG::Font::LineData& curr_line : GetLineData()) {
         for (const GG::Font::LineData::CharData& curr_char : curr_line.char_data) {

--- a/UI/LinkText.cpp
+++ b/UI/LinkText.cpp
@@ -274,32 +274,6 @@ void TextLinker::MouseLeave_() {
     MarkLinks();
 }
 
-const std::vector<GG::Font::LineData>& TextLinker::GetLineData() const {
-    static std::vector<GG::Font::LineData> retval;
-    return retval;
-}
-
-const std::shared_ptr<GG::Font>& TextLinker::GetFont() const {
-    static std::shared_ptr<GG::Font> retval;
-    if (!retval)
-        retval = ClientUI::GetFont();
-    return retval;
-}
-
-GG::Pt TextLinker::TextUpperLeft() const
-{ return GG::Pt(); }
-
-GG::Pt TextLinker::TextLowerRight() const
-{ return GG::Pt(); }
-
-void TextLinker::SetLinkedText(const std::string& str)
-{}
-
-const std::string& TextLinker::RawText() const {
-    static std::string retval;
-    return retval;
-}
-
 void TextLinker::FindLinks() {
     m_links.clear();
 


### PR DESCRIPTION
I hope that this PR fixes bug #1680.  I was not able to replicate the crash from the Pedia.  I was able to replicate the intermittent crash from the environment assessment.

This PR fixes the following two problems:
- `RichText` did not have a `CompleteConstruction()` function, so `PopulateBlocks()` was attaching blocks (children) during its construction.  
- `FindLinks()` returned different, incorrect results when run after a call to `MarkText()`.  `FindLinks()` uses the line data to generate the links, that `MarkText()` uses to set the text, which generates new line data that yields incorrect links when processed with `FindLinks()`.  Eventually, the incorrect links index out of bounds characters and cause a crash.

`MultiEdit` not having a `CompleteConstruction()` hid these problems.  That is why https://github.com/freeorion/freeorion/commit/aeb1df1695c97524ee95dd5c35222b303b71808a revealed them.

The solutions in this PR are:
- Add `RichText::CompleteConstruction()`, which involved refactoring `PopulateBlocks()` into `CreateBlocks()` and `AttachBlocks()` to be run in the constructor and `CompleteConstruction()` functions respectively.
- Call `SetLinkedText(RawText())` at the start of each call to `FindLinks()`.  The solution is not ideal since the underlying `TextControl` will make repeated calls to `ExpensiveParseFromTextToTextElements()`.  

This PR will need testing since I was not able to duplicate the Pedia crash.