### PR TITLE
Update Research List view with newly visible techs

### DIFF
--- a/UI/TechTreeWnd.cpp
+++ b/UI/TechTreeWnd.cpp
@@ -1856,7 +1856,10 @@ std::set<TechStatus> TechTreeWnd::TechListBox::GetTechStatusesShown() const
 { return m_tech_statuses_shown; }
 
 void TechTreeWnd::TechListBox::Reset()
-{ Populate(); }
+{
+    m_tech_row_cache.clear();
+    Populate();
+}
 
 void TechTreeWnd::TechListBox::Update(bool populate /* = true */) {
     if (populate)


### PR DESCRIPTION
Minor refactor to address linked issue:
* TechListBox::Update did not add newly available techs to the cached list.  ~As there was no case of Populate or Update to be called without the other, Populate was removed to avoid calling them out of order.~

* Scroll is retained only by the tech in the first displayed row.  If the tech is no longer visible, the list will fallback to the top row.

* Cache container changed to unordered_map to support scroll retention (unique key).  Translated key was not otherwise used and ordering is no longer needed.

Fixes #1505 