### PR TITLE
Implement feature request #572 Autosaving at end of turn

### DIFF
--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -693,7 +693,7 @@ void OptionsWnd::CompleteConstruction() {
     BoolOption(current_page, 0, "autosave.multiplayer.turn-start",   UserString("OPTIONS_DB_AUTOSAVE_MULTIPLAYER_TURN_START"));
     BoolOption(current_page, 0, "autosave.multiplayer.turn-end",     UserString("OPTIONS_DB_AUTOSAVE_MULTIPLAYER_TURN_END"));
     IntOption(current_page,  0, "autosave.turns",           UserString("OPTIONS_AUTOSAVE_TURNS_BETWEEN"));
-    IntOption(current_page,  0, "autosave.limit",           UserString("OPTIONS_AUTOSAVE_LIMIT"));
+    IntOption(current_page,  0, "autosave.turn-limit",      UserString("OPTIONS_AUTOSAVE_LIMIT"));
     BoolOption(current_page, 0, "autosave.galaxy-creation", UserString("OPTIONS_DB_AUTOSAVE_GALAXY_CREATION"));
     BoolOption(current_page, 0, "autosave.game-close",      UserString("OPTIONS_DB_AUTOSAVE_GAME_CLOSE"));
     m_tabs->SetCurrentWnd(0);

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -688,8 +688,10 @@ void OptionsWnd::CompleteConstruction() {
 
     // Ausosave settings tab
     current_page = CreatePage(UserString("OPTIONS_PAGE_AUTOSAVE"));
-    BoolOption(current_page, 0, "autosave.single-player",   UserString("OPTIONS_SINGLEPLAYER"));
-    BoolOption(current_page, 0, "autosave.multiplayer",     UserString("OPTIONS_MULTIPLAYER"));
+    BoolOption(current_page, 0, "autosave.single-player.turn-start", UserString("OPTIONS_DB_AUTOSAVE_SINGLE_PLAYER_TURN_START"));
+    BoolOption(current_page, 0, "autosave.single-player.turn-end",   UserString("OPTIONS_DB_AUTOSAVE_SINGLE_PLAYER_TURN_END"));
+    BoolOption(current_page, 0, "autosave.multiplayer.turn-start",   UserString("OPTIONS_DB_AUTOSAVE_MULTIPLAYER_TURN_START"));
+    BoolOption(current_page, 0, "autosave.multiplayer.turn-end",     UserString("OPTIONS_DB_AUTOSAVE_MULTIPLAYER_TURN_END"));
     IntOption(current_page,  0, "autosave.turns",           UserString("OPTIONS_AUTOSAVE_TURNS_BETWEEN"));
     IntOption(current_page,  0, "autosave.limit",           UserString("OPTIONS_AUTOSAVE_LIMIT"));
     BoolOption(current_page, 0, "autosave.galaxy-creation", UserString("OPTIONS_DB_AUTOSAVE_GALAXY_CREATION"));

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -691,7 +691,6 @@ void OptionsWnd::CompleteConstruction() {
     BoolOption(current_page, 0, "autosave.single-player.turn-start", UserString("OPTIONS_DB_AUTOSAVE_SINGLE_PLAYER_TURN_START"));
     BoolOption(current_page, 0, "autosave.single-player.turn-end",   UserString("OPTIONS_DB_AUTOSAVE_SINGLE_PLAYER_TURN_END"));
     BoolOption(current_page, 0, "autosave.multiplayer.turn-start",   UserString("OPTIONS_DB_AUTOSAVE_MULTIPLAYER_TURN_START"));
-    BoolOption(current_page, 0, "autosave.multiplayer.turn-end",     UserString("OPTIONS_DB_AUTOSAVE_MULTIPLAYER_TURN_END"));
     IntOption(current_page,  0, "autosave.turns",           UserString("OPTIONS_AUTOSAVE_TURNS_BETWEEN"));
     IntOption(current_page,  0, "autosave.turn-limit",      UserString("OPTIONS_AUTOSAVE_LIMIT"));
     BoolOption(current_page, 0, "autosave.galaxy-creation", UserString("OPTIONS_DB_AUTOSAVE_GALAXY_CREATION"));

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -345,7 +345,13 @@ void AIClientApp::HandleMessage(const Message& msg) {
         ExtractTurnPartialUpdateMessageData(msg, m_empire_id, m_universe);
         break;
 
-    case Message::TURN_PROGRESS:
+    case Message::TURN_PROGRESS: {
+        Message::TurnProgressPhase phase_id;
+        ExtractTurnProgressMessageData(msg, phase_id);
+        ClientApp::HandleTurnPhaseUpdate(phase_id);
+        break;
+    }
+
     case Message::PLAYER_STATUS:
         break;
 

--- a/client/ClientApp.cpp
+++ b/client/ClientApp.cpp
@@ -118,7 +118,26 @@ void ClientApp::SetPlayerStatus(int player_id, Message::PlayerStatus status) {
 
 void ClientApp::StartTurn() {
     m_networking->SendMessage(TurnOrdersMessage(m_orders));
-    m_orders.Reset();
+}
+
+void ClientApp::HandleTurnPhaseUpdate(Message::TurnProgressPhase phase_id) {
+    switch (phase_id) {
+    case Message::WAITING_FOR_PLAYERS:
+        // Orders have been received by server, so clear the orders.
+        m_orders.Reset();
+        break;
+    case Message::FLEET_MOVEMENT:
+    case Message::COMBAT:
+    case Message::EMPIRE_PRODUCTION:
+    case Message::PROCESSING_ORDERS:
+    case Message::COLONIZE_AND_SCRAP:
+    case Message::DOWNLOADING:
+    case Message::LOADING_GAME:
+    case Message::GENERATING_UNIVERSE:
+    case Message::STARTING_AIS:
+    default:
+        break;
+    }
 }
 
 OrderSet& ClientApp::Orders()

--- a/client/ClientApp.h
+++ b/client/ClientApp.h
@@ -155,6 +155,10 @@ public:
     /** @brief Send the OrderSet to the server and start a new turn */
     virtual void StartTurn();
 
+    /** \brief Handle server acknowledgement of receipt of orders and clear
+        the orders. */
+    virtual void HandleTurnPhaseUpdate(Message::TurnProgressPhase phase_id);
+
     /** @brief Return the set of known Empire s for this client
      *
      * @return The EmpireManager instance in charge of maintaining the Empire

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -4,6 +4,7 @@
 #include "HumanClientApp.h"
 
 #include "HumanClientFSM.h"
+#include "../../UI/ChatWnd.h"
 #include "../../UI/CUIControls.h"
 #include "../../UI/CUIStyle.h"
 #include "../../UI/MapWnd.h"
@@ -856,6 +857,13 @@ void HumanClientApp::StartTurn() {
 
     ClientApp::StartTurn();
     m_fsm->process_event(TurnEnded());
+}
+
+void HumanClientApp::HandleTurnPhaseUpdate(Message::TurnProgressPhase phase_id) {
+    ClientApp::HandleTurnPhaseUpdate(phase_id);
+
+    // Pass updates to message window.
+    GetClientUI().GetMessageWnd()->HandleTurnPhaseUpdate(phase_id);
 }
 
 void HumanClientApp::HandleSystemEvents() {

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -99,7 +99,6 @@ namespace {
         db.Add("autosave.single-player.turn-start", UserStringNop("OPTIONS_DB_AUTOSAVE_SINGLE_PLAYER_TURN_START"),     true,   Validator<bool>());
         db.Add("autosave.single-player.turn-end",   UserStringNop("OPTIONS_DB_AUTOSAVE_SINGLE_PLAYER_TURN_END"),     false,   Validator<bool>());
         db.Add("autosave.multiplayer.turn-start",   UserStringNop("OPTIONS_DB_AUTOSAVE_MULTIPLAYER_TURN_START"),       true,   Validator<bool>());
-        db.Add("autosave.multiplayer.turn-end",     UserStringNop("OPTIONS_DB_AUTOSAVE_MULTIPLAYER_TURN_END"),       false,   Validator<bool>());
         db.Add("autosave.turns",                    UserStringNop("OPTIONS_DB_AUTOSAVE_TURNS"),             1,      RangedValidator<int>(1, 50));
         db.Add("autosave.turn-limit",               UserStringNop("OPTIONS_DB_AUTOSAVE_TURN_LIMIT"),       10,     RangedValidator<int>(1, 100));
         db.Add("autosave.galaxy-creation",      UserStringNop("OPTIONS_DB_AUTOSAVE_GALAXY_CREATION"),      true,   Validator<bool>());
@@ -858,9 +857,7 @@ void HumanClientApp::StartTurn() {
     }
 
     // Do the turn end autosave.
-    if ((m_single_player_game && GetOptionsDB().Get<bool>("autosave.single-player.turn-end"))
-        || (!m_single_player_game && GetOptionsDB().Get<bool>("autosave.multiplayer.turn-end")))
-    {
+    if (m_single_player_game && GetOptionsDB().Get<bool>("autosave.single-player.turn-end")) {
         DebugLogger() << "Starting end of turn autosave.";
         Autosave();
     }
@@ -1228,8 +1225,7 @@ void HumanClientApp::Autosave() {
              || GetOptionsDB().Get<bool>("autosave.single-player.turn-end")));
     bool is_multi_player_enabled =
         (!m_single_player_game
-         && (GetOptionsDB().Get<bool>("autosave.multiplayer.turn-start")
-             || GetOptionsDB().Get<bool>("autosave.multiplayer.turn-end")));
+         && GetOptionsDB().Get<bool>("autosave.multiplayer.turn-start"));
     bool is_valid_autosave =
         (autosave_turns > 0
          && CurrentTurn() % autosave_turns == 0
@@ -1253,8 +1249,7 @@ void HumanClientApp::Autosave() {
          && GetOptionsDB().Get<bool>("autosave.single-player.turn-end"))
         ||
         (!m_single_player_game
-         && GetOptionsDB().Get<bool>("autosave.multiplayer.turn-start")
-         && GetOptionsDB().Get<bool>("autosave.multiplayer.turn-end"));
+         && GetOptionsDB().Get<bool>("autosave.multiplayer.turn-start"));
     int max_autosaves =
         (max_turns * (is_two_saves_per_turn ? 2 : 1)
          + (GetOptionsDB().Get<bool>("autosave.galaxy-creation") ? 1 : 0)

--- a/client/human/HumanClientApp.h
+++ b/client/human/HumanClientApp.h
@@ -48,6 +48,9 @@ public:
 
     void StartTurn() override;
 
+    /** \brief Handle UI and state updates with changes in turn phase. */
+    void HandleTurnPhaseUpdate(Message::TurnProgressPhase phase_id) override;
+
     void                SetSinglePlayerGame(bool sp = true);
 
     void                StartServer();                  ///< starts a server process on localhost

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -675,7 +675,7 @@ boost::statechart::result PlayingGame::react(const TurnProgress& msg) {
 
     Message::TurnProgressPhase phase_id;
     ExtractTurnProgressMessageData(msg.m_message, phase_id);
-    Client().GetClientUI().GetMessageWnd()->HandleTurnPhaseUpdate(phase_id);
+    Client().HandleTurnPhaseUpdate(phase_id);
 
     return discard_event();
 }

--- a/client/human/chmain.cpp
+++ b/client/human/chmain.cpp
@@ -248,7 +248,7 @@ int mainSetupAndRun() {
         if (GetOptionsDB().Get<bool>("continue")) {
             // immediately start the server, establish network connections, and
             // go into a single player game, continuing from the newest
-            // autosave game.
+            // save game.
             app.ContinueSinglePlayerGame();  // acceptable to call before app()
         }
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1640,11 +1640,17 @@ Boolean for AI testing which indicates if all AIs are forced to have the same Em
 OPTIONS_DB_AI_CONFIG_TRAIT_EMPIREID_FORCED_VALUE
 Forced value of the EmpireID Trait.  A value from 0 to 39.
 
-OPTIONS_DB_AUTOSAVE_SINGLE_PLAYER
-Enable single-player autosaves.
+OPTIONS_DB_AUTOSAVE_SINGLE_PLAYER_TURN_START
+Enable single-player autosaves at turn start.
 
-OPTIONS_DB_AUTOSAVE_MULTIPLAYER
-Enable multi-player autosaves.
+OPTIONS_DB_AUTOSAVE_SINGLE_PLAYER_TURN_END
+Enable single-player autosaves at turn end.
+
+OPTIONS_DB_AUTOSAVE_MULTIPLAYER_TURN_START
+Enable multi-player autosaves at turn start.
+
+OPTIONS_DB_AUTOSAVE_MULTIPLAYER_TURN_END
+Enable multi-player autosaves at turn end.
 
 OPTIONS_DB_AUTOSAVE_TURNS
 Sets the number of turns between autosaves.
@@ -2286,12 +2292,6 @@ Automatically reposition windows
 
 OPTIONS_MISC_UI
 Miscellaneous UI Settings
-
-OPTIONS_SINGLEPLAYER
-Single player
-
-OPTIONS_MULTIPLAYER
-Multiplayer
 
 OPTIONS_AUTOSAVE_LIMIT
 Autosaves limit

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1674,7 +1674,7 @@ OPTIONS_DB_QUICKSTART
 Starts a new quick-start game, bypassing the main menu.
 
 OPTIONS_DB_CONTINUE
-Continues play from lastest autosave, bypassing the main menu.
+Continues play from latest save, bypassing the main menu.
 
 OPTIONS_DB_AUTO_N_TURNS
 Hits the "Turn" button automatically on the first N turns (up to 400 turns, defaults to zero); useful for various testing particularly with --quickstart or --load, possibly also --auto-quit.


### PR DESCRIPTION
This PR implements feature request #572, autosaving at the beginning and end of turn for single player games.

It should follow PR #1671.

It changes when orders are deleted on the AI and human clients, from immediately when sent to the server, to after the server has confirmed that it has received the orders.  This allows orders that have been sent to the server, but not yet acknowledged to be included in the end of turn save game.

The feature is not implemented for multiplayer, because of the relative timing issues with multiple players sending orders at different times.