### PR TITLE
Clear effect generated visibilites after applying.

### DIFF
--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -1662,6 +1662,8 @@ void Universe::ApplyEffectDerivedVisibilities() {
             m_empire_object_visibility[empire_entry.first][object_entry.first] = object_entry.second;
         }
     }
+
+    m_effect_specified_empire_object_visibilities.clear();
 }
 
 void Universe::ForgetKnownObject(int empire_id, int object_id) {


### PR DESCRIPTION
This fixes bug #1618, where visibility effects were erroneously applied
repeatedly.