### PR TITLE
Fix telepathic detection

### DIFF
--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -1659,7 +1659,11 @@ void Universe::ApplyEffectDerivedVisibilities() {
         for (const auto& object_entry : empire_entry.second) {
             if (object_entry.first <= INVALID_OBJECT_ID)
                 continue;
-            m_empire_object_visibility[empire_entry.first][object_entry.first] = object_entry.second;
+            // TODO: If/when the parser for SetVisibility is expanded to allow ValueRefs like
+            // max(Target.visibility, Basic)
+            // then the folllowing should be reverted to a simple assignment.
+            m_empire_object_visibility[empire_entry.first][object_entry.first] = 
+                std::max(object_entry.second, m_empire_object_visibility[empire_entry.first][object_entry.first]);
         }
     }
 }

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -2977,6 +2977,19 @@ void Universe::GetEmpireObjectVisibilityTurnMap(EmpireObjectVisibilityTurnMap& e
         empire_object_visibility_turns[encoding_empire] = it->second;
 }
 
+void Universe::GetEffectSpecifiedVisibilities(EmpireObjectVisibilityMap& effect_specified_empire_object_visibilities, int encoding_empire) const {
+    if (encoding_empire == ALL_EMPIRES) {
+        effect_specified_empire_object_visibilities = m_effect_specified_empire_object_visibilities;
+        return;
+    }
+    
+    // include just requested empire's visibility effects
+    effect_specified_empire_object_visibilities.clear();
+    auto it = m_effect_specified_empire_object_visibilities.find(encoding_empire);
+    if (it != m_effect_specified_empire_object_visibilities.end())
+        effect_specified_empire_object_visibilities[encoding_empire] = it->second;
+}
+
 void Universe::GetEmpireKnownDestroyedObjects(ObjectKnowledgeMap& empire_known_destroyed_object_ids, int encoding_empire) const {
     if (&empire_known_destroyed_object_ids == &m_empire_known_destroyed_object_ids)
         return;

--- a/universe/Universe.h
+++ b/universe/Universe.h
@@ -512,6 +512,9 @@ private:
     void    GetEmpireObjectVisibilityTurnMap(EmpireObjectVisibilityTurnMap& empire_object_visibility_turns, int encoding_empire) const;
 
     /***/
+    void    GetEffectSpecifiedVisibilities(EmpireObjectVisibilityMap& effect_specified_empire_object_visibilities, int encoding_empire) const;
+    
+    /***/
     void    GetEmpireKnownDestroyedObjects(ObjectKnowledgeMap& empire_known_destroyed_object_ids, int encoding_empire) const;
 
     /***/

--- a/util/SerializeUniverse.cpp
+++ b/util/SerializeUniverse.cpp
@@ -48,6 +48,7 @@ void Universe::serialize(Archive& ar, const unsigned int version)
     EmpireObjectMap                 empire_latest_known_objects;
     EmpireObjectVisibilityMap       empire_object_visibility;
     EmpireObjectVisibilityTurnMap   empire_object_visibility_turns;
+    EmpireObjectVisibilityMap       effect_specified_visibilities;
     ObjectKnowledgeMap              empire_known_destroyed_object_ids;
     ObjectKnowledgeMap              empire_stale_knowledge_object_ids;
     ShipDesignMap                   ship_designs;
@@ -63,6 +64,7 @@ void Universe::serialize(Archive& ar, const unsigned int version)
         GetEmpireKnownObjectsToSerialize(   empire_latest_known_objects,        m_encoding_empire);
         GetEmpireObjectVisibilityMap(       empire_object_visibility,           m_encoding_empire);
         GetEmpireObjectVisibilityTurnMap(   empire_object_visibility_turns,     m_encoding_empire);
+        GetEffectSpecifiedVisibilities(     effect_specified_visibilities,      m_encoding_empire);
         GetEmpireKnownDestroyedObjects(     empire_known_destroyed_object_ids,  m_encoding_empire);
         GetEmpireStaleKnowledgeObjects(     empire_stale_knowledge_object_ids,  m_encoding_empire);
         GetShipDesignsToSerialize(          ship_designs,                       m_encoding_empire);
@@ -84,16 +86,19 @@ void Universe::serialize(Archive& ar, const unsigned int version)
 
     ar  & BOOST_SERIALIZATION_NVP(empire_object_visibility);
     ar  & BOOST_SERIALIZATION_NVP(empire_object_visibility_turns);
+    ar  & BOOST_SERIALIZATION_NVP(effect_specified_visibilities);
     ar  & BOOST_SERIALIZATION_NVP(empire_known_destroyed_object_ids);
     ar  & BOOST_SERIALIZATION_NVP(empire_stale_knowledge_object_ids);
     DebugLogger() << "Universe::serialize : " << serializing_label
                   << " empire object visibility for " << empire_object_visibility.size() << ", "
                   << empire_object_visibility_turns.size() << ", "
+                  << effect_specified_visibilities.size() << ", "
                   << empire_known_destroyed_object_ids.size() << ", "
                   << empire_stale_knowledge_object_ids.size() <<  " empires";
     if (Archive::is_loading::value) {
         m_empire_object_visibility.swap(empire_object_visibility);
         m_empire_object_visibility_turns.swap(empire_object_visibility_turns);
+        m_effect_specified_empire_object_visibilities.swap(effect_specified_visibilities);
         m_empire_known_destroyed_object_ids.swap(empire_known_destroyed_object_ids);
         m_empire_stale_knowledge_object_ids.swap(empire_stale_knowledge_object_ids);
     }


### PR DESCRIPTION
This follows on the discussion in #1708 and on our forums, it fixes #1618 

The first commit causes m_empire_object_visibility to be serialized with the universe to prevent
visibility-effect-related errors/discrepancies upon savefile loading as was noted in #1618.  Since this changes serialization and breaks savefile compatibility, the examples from #1618 won't work, but the following two files are made with this and demonstrate the fix, with the desired result being that both files will have the same combat/no-combat status on turn T(17).  With just the first commit from this PR the result is no combat.
[T_minus_1.sav.zip](https://github.com/freeorion/freeorion/files/1267713/T_minus_1.sav.zip)
[T_minus_2.sav.zip](https://github.com/freeorion/freeorion/files/1267714/T_minus_2.sav.zip)

The second commit adjusts the backend processing of effects from SetVisibility so that they act as only a boon, never decreasing visibility.  This is compatible with all current uses in the scripts, and fixes #1618.  

As noted in the discussions, there is another more involved change being contemplated, which would change the parsing of SetVisibility to allow ValueRefs including min/max, and then the datatype for m_empire_object_visibility would be also planned to change.  In that event the second commit here should be reverted, but the material from the first commit would only need a small adjustment to datatype.  So even though this PR might be considered to be an interim fix, I think it is worthwhile.