### PR TITLE
Fix bug #1707 pedia links not highlighting on rollover.

### DIFF
--- a/UI/CUIControls.cpp
+++ b/UI/CUIControls.cpp
@@ -1011,7 +1011,12 @@ CUILinkTextMultiEdit::CUILinkTextMultiEdit(const std::string& str, GG::Flags<GG:
 {}
 
 void CUILinkTextMultiEdit::CompleteConstruction() {
+    // Prevent double wrapping or setting the raw_text equal to an already
+    // wrapped raw text.  CUIMultiEdit::CompleteConstruction calls
+    // SetText when adjusting the scroll bars.
+    m_already_setting_text_so_dont_link = true;
     CUIMultiEdit::CompleteConstruction();
+    m_already_setting_text_so_dont_link = false;
 
     FindLinks();
     MarkLinks();


### PR DESCRIPTION
CUILinkTextMultiEdit uses the underlying TextControl to store the text
processed to include the tags and overrides virtual SetText() to assign
the processed text.  The problem is that the underlying TextControl
calls SetText() internally when adjusting the scroll bars in its
CompleteConstruction().

This commit brackets CUIMultiEdit::CompleteConstruction() in
CUILinkTextMultiEdit::CompleteConstruction() in a
m_already_setting_text_so_dont_link guard to prevent the double
wrapping.