### PR TITLE
Improve performance of python logger

### DIFF
--- a/default/python/common/configure_logging.py
+++ b/default/python/common/configure_logging.py
@@ -82,7 +82,6 @@ log.
 import sys
 import string
 import logging
-import inspect
 import os
 
 try:

--- a/default/python/common/configure_logging.py
+++ b/default/python/common/configure_logging.py
@@ -128,14 +128,20 @@ class _stdXLikeStream(object):
 
     def write(self, msg):
         # Grab the caller's call frame info
-        try:
+        if hasattr(sys, '_getframe'):
             frame = sys._getframe(1)
-            line_number = frame.f_lineno
-            function_name = frame.f_code.co_name
-            filename = frame.f_code.co_filename
-            if string.lower(filename[-4:]) in ('.pyc', '.pyo'):
-                filename = filename[:-4] + '.py'
-        except:
+            try:
+                line_number = frame.f_lineno
+                function_name = frame.f_code.co_name
+                filename = frame.f_code.co_filename
+                if string.lower(filename[-4:]) in ('.pyc', '.pyo'):
+                    filename = filename[:-4] + '.py'
+            except:
+                (filename, line_number, function_name) = ("", "", "")
+            finally:
+                # Explicitly del references to the caller's frame to avoid persistent reference cycles
+                del frame
+        else:
             (filename, line_number, function_name) = ("", "", "")
 
         try:

--- a/default/python/common/configure_logging.py
+++ b/default/python/common/configure_logging.py
@@ -80,6 +80,7 @@ log.
 
 """
 import sys
+import string
 import logging
 import inspect
 import os
@@ -129,7 +130,12 @@ class _stdXLikeStream(object):
     def write(self, msg):
         # Grab the caller's call frame info
         try:
-            (filename, line_number, function_name, _, _) = inspect.getframeinfo(sys._getframe(1), context=0)
+            frame = sys._getframe(1)
+            line_number = frame.f_lineno
+            function_name = frame.f_code.co_name
+            filename = frame.f_code.co_filename
+            if string.lower(filename[-4:]) in ('.pyc', '.pyo'):
+                filename = filename[:-4] + '.py'
         except:
             (filename, line_number, function_name) = ("", "", "")
 

--- a/default/python/common/configure_logging.py
+++ b/default/python/common/configure_logging.py
@@ -128,11 +128,9 @@ class _stdXLikeStream(object):
 
     def write(self, msg):
         # Grab the caller's call frame info
-        stack = inspect.stack()
-        if len(stack) > 1:
-            (_, filename, line_number, function_name, _, _) = inspect.stack()[1]
-        else:
-            # No available call frame info
+        try:
+            (filename, line_number, function_name, _, _) = inspect.getframeinfo(sys._getframe(1), context=0)
+        except:
             (filename, line_number, function_name) = ("", "", "")
 
         try:
@@ -140,7 +138,6 @@ class _stdXLikeStream(object):
 
         finally:
             # Explicitly del references to the caller's frame to avoid persistent reference cycles
-            del stack
             del filename
             del line_number
             del function_name

--- a/default/python/common/configure_logging.py
+++ b/default/python/common/configure_logging.py
@@ -80,7 +80,6 @@ log.
 
 """
 import sys
-import string
 import logging
 import os
 

--- a/default/python/common/configure_logging.py
+++ b/default/python/common/configure_logging.py
@@ -134,8 +134,6 @@ class _stdXLikeStream(object):
                 line_number = frame.f_lineno
                 function_name = frame.f_code.co_name
                 filename = frame.f_code.co_filename
-                if string.lower(filename[-4:]) in ('.pyc', '.pyo'):
-                    filename = filename[:-4] + '.py'
             except:
                 (filename, line_number, function_name) = ("", "", "")
             finally:


### PR DESCRIPTION
Aims to fix #1715 

Problem: The ```inspect.stack()``` function walks through the stack which takes a long time.

Solution: We only require information about a single frame which we can find using the ```sys._getframe(1)``` call.

Note that ```sys._getframe``` does not exist for all python versions. Official documentation states
```
This function should be used for internal and specialized purposes only. It is not guaranteed to exist in all implementations of Python.
```
At least my version of ```inspect.stack()``` relies on that function call anyway so I expect it to matter only on systems which did not support the current implementation either. However, feedback from different OS / python versions would be useful.



Performance for the test case described in #1715 improved from 7 seconds to 350ms for me which makes FreeOrion playable again for me.