### PR TITLE
Fix attempting to start 2nd server causing the human client to hang.

### DIFF
--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -414,7 +414,9 @@ namespace {
 namespace {
     class LocalServerAlreadyRunningException : public std::runtime_error {
     public:
-        explicit LocalServerAlreadyRunningException(const std::string& s) : std::runtime_error(s) {}
+        LocalServerAlreadyRunningException() :
+            std::runtime_error("LOCAL_SERVER_ALREADY_RUNNING_ERROR")
+        {}
     };
 }
 
@@ -422,7 +424,7 @@ void HumanClientApp::StartServer() {
     auto connected = m_networking->ConnectToLocalHostServer(std::chrono::milliseconds(100));
     if (connected) {
         ErrorLogger() << "Can't start local server because a server is already connecting at 127.0.0.0.";
-        throw LocalServerAlreadyRunningException("LOCAL_SERVER_ALREADY_RUNNING_ERROR");
+        throw LocalServerAlreadyRunningException();
     }
 
     std::string SERVER_CLIENT_EXE = ServerClientExe();

--- a/client/human/HumanClientApp.h
+++ b/client/human/HumanClientApp.h
@@ -53,7 +53,9 @@ public:
 
     void                SetSinglePlayerGame(bool sp = true);
 
-    void                StartServer();                  ///< starts a server process on localhost
+    /** Starts a server process on localhost.  Throws a runtime_error if
+        another server is already running. */
+    void                StartServer();
     void                FreeServer();                   ///< frees (relinquishes ownership and control of) any running server process already started by this client; performs no cleanup of other processes, such as AIs
     void                NewSinglePlayerGame(bool quickstart = false);
     void                MultiPlayerGame();                              ///< shows multiplayer connection window, and then transitions to multiplayer lobby if connected

--- a/client/human/HumanClientApp.h
+++ b/client/human/HumanClientApp.h
@@ -53,10 +53,6 @@ public:
 
     void                SetSinglePlayerGame(bool sp = true);
 
-    /** Starts a server process on localhost.  Throws a runtime_error if
-        another server is already running. */
-    void                StartServer();
-    void                FreeServer();                   ///< frees (relinquishes ownership and control of) any running server process already started by this client; performs no cleanup of other processes, such as AIs
     void                NewSinglePlayerGame(bool quickstart = false);
     void                MultiPlayerGame();                              ///< shows multiplayer connection window, and then transitions to multiplayer lobby if connected
     void                StartMultiPlayerGameFromLobby();                ///< begins
@@ -120,6 +116,18 @@ protected:
     void Initialize() override;
 
 private:
+    /** Starts a server process on localhost.
+
+        Throws a runtime_error if the server process can't be started.
+
+        Throws LocalServerAlreadyRunningException (derived from runtime_error
+        in HumanClientApp.cpp) if another server is already running. */
+    void                StartServer();
+    /** frees (relinquishes ownership and control of) any running server
+        process already started by this client; performs no cleanup of other
+        processes, such as AIs. */
+    void                FreeServer();
+
     void HandleSystemEvents() override;
 
     void RenderBegin() override;

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -893,6 +893,9 @@ The server is not responding.
 SERVER_LOST
 The connection to the server has been lost.
 
+LOCAL_SERVER_ALREADY_RUNNING_ERROR
+Can't start server.  A local server is already running.
+
 PLAYER_DISCONNECTED
 Player %1% no longer has a connection to the server.
 

--- a/network/ServerNetworking.cpp
+++ b/network/ServerNetworking.cpp
@@ -112,6 +112,10 @@ bool PlayerConnection::SendMessage(const Message& message) {
     return SyncWriteMessage(message);
 }
 
+bool PlayerConnection::IsEstablished() const {
+    return (m_ID != INVALID_PLAYER_ID || !m_player_name.empty() || m_client_type != Networking::INVALID_CLIENT_TYPE);
+}
+
 void PlayerConnection::EstablishPlayer(int id, const std::string& player_name, Networking::ClientType client_type,
                                        const std::string& client_version_string)
 {
@@ -120,7 +124,7 @@ void PlayerConnection::EstablishPlayer(int id, const std::string& player_name, N
                          << client_type << ", " << client_version_string << ")";
 
     // ensure that this connection isn't already established
-    if (m_ID != INVALID_PLAYER_ID || !m_player_name.empty() || m_client_type != Networking::INVALID_CLIENT_TYPE) {
+    if (IsEstablished()) {
         ErrorLogger(network) << "PlayerConnection::EstablishPlayer attempting to re-establish an already established connection.";
         return;
     }

--- a/network/ServerNetworking.cpp
+++ b/network/ServerNetworking.cpp
@@ -113,7 +113,7 @@ bool PlayerConnection::SendMessage(const Message& message) {
 }
 
 bool PlayerConnection::IsEstablished() const {
-    return (m_ID != INVALID_PLAYER_ID || !m_player_name.empty() || m_client_type != Networking::INVALID_CLIENT_TYPE);
+    return (m_ID != INVALID_PLAYER_ID && !m_player_name.empty() && m_client_type != Networking::INVALID_CLIENT_TYPE);
 }
 
 void PlayerConnection::EstablishPlayer(int id, const std::string& player_name, Networking::ClientType client_type,

--- a/network/ServerNetworking.h
+++ b/network/ServerNetworking.h
@@ -188,6 +188,9 @@ public:
     /** Checks if client associated with this connection runs on the same
         physical machine as the server */
     bool IsLocalConnection() const;
+
+    /** Checks if the player is established, has a valid name, id and client type. */
+    bool IsEstablished() const;
     //@}
 
     /** \name Mutators */ //@{

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1148,12 +1148,12 @@ void ServerApp::LoadGameInit(const std::vector<PlayerSaveGameData>& player_save_
          player_connection_it != m_networking.established_end(); ++player_connection_it)
     {
         const PlayerConnectionPtr player_connection = *player_connection_it;
-        int player_id = player_connection->PlayerID();
-        if (player_id == Networking::INVALID_PLAYER_ID) {
-            ErrorLogger() << "LoadGameInit got invalid player id from connection";
+        if (!player_connection->IsEstablished()) {
+            ErrorLogger() << "LoadGameInit got player from connection";
             continue;
         }
 
+        int player_id = player_connection->PlayerID();
 
         // get index into save game data for this player id
         int player_save_game_data_index = -1;   // default invalid index

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -445,9 +445,15 @@ MPLobby::MPLobby(my_context c) :
         std::list<PlayerConnectionPtr> to_disconnect;
         // Try to use connections:
         for (const auto& player_connection : server.m_networking) {
+            // If connection was not established disconnect it.
+            if (!player_connection->IsEstablished()) {
+                to_disconnect.push_back(player_connection);
+                continue;
+            }
+
             int player_id = player_connection->PlayerID();
             DebugLogger(FSM) << "(ServerFSM) MPLobby. Fill MPLobby player " << player_id;
-            if (player_id != Networking::INVALID_PLAYER_ID && player_connection->GetClientType() != Networking::CLIENT_TYPE_AI_PLAYER) {
+            if (player_connection->GetClientType() != Networking::CLIENT_TYPE_AI_PLAYER) {
                 PlayerSetupData player_setup_data;
                 player_setup_data.m_player_id =     player_id;
                 player_setup_data.m_player_name =   player_connection->PlayerName();
@@ -460,7 +466,7 @@ MPLobby::MPLobby(my_context c) :
                     player_setup_data.m_starting_species_name = sm.SequentialPlayableSpeciesName(player_id);
 
                 m_lobby_data->m_players.push_back(std::make_pair(player_id, player_setup_data));
-            } else if (player_id != Networking::INVALID_PLAYER_ID && player_connection->GetClientType() == Networking::CLIENT_TYPE_AI_PLAYER) {
+            } else if (player_connection->GetClientType() == Networking::CLIENT_TYPE_AI_PLAYER) {
                 PlayerSetupData player_setup_data;
                 player_setup_data.m_player_id =     Networking::INVALID_PLAYER_ID;
                 player_setup_data.m_player_name =   UserString("AI_PLAYER") + "_" + std::to_string(m_ai_next_index++);
@@ -474,9 +480,6 @@ MPLobby::MPLobby(my_context c) :
 
                 m_lobby_data->m_players.push_back(std::make_pair(Networking::INVALID_PLAYER_ID, player_setup_data));
                 // disconnect AI
-                to_disconnect.push_back(player_connection);
-            } else {
-                // If connection was not established disconnect it.
                 to_disconnect.push_back(player_connection);
             }
         }
@@ -835,9 +838,9 @@ sc::result MPLobby::react(const LobbyUpdate& msg) {
                  player_connection_it != server.m_networking.established_end(); ++player_connection_it)
             {
                 PlayerConnectionPtr player_connection = *player_connection_it;
-                int player_id = player_connection->PlayerID();
-                if (player_id == Networking::INVALID_PLAYER_ID)
+                if (!player_connection->IsEstablished())
                     continue;
+                int player_id = player_connection->PlayerID();
 
                 // get lobby data for this player connection
                 bool found_player_lobby_data = false;


### PR DESCRIPTION
**Problem**
A server is already running and the human client attempts to start a new game or load a game.  The screen goes black and provides no additional feedback to the player, nor any way to recover.

**This Solution**
This PR informs the player with a popup, "Can't start server.  A local server is already running." if the server can't start.  The player can then either quit this client or resign/quit from the other client/server and start a game from this client.

This PR attempts to connect to a server for 100ms before starting a local server.  If it successfully connects it will not start another server.  Otherwise it starts the server as normal.  This results in a 100ms delay in starting up a local server.

There are changes to the server code to prevent the 2nd client's disconnection (which is an unestablished player connection on the server) from causing the game to shutdown. 