### PR TITLE
Fix bug #1690 python traceback info missing from log.

### DIFF
--- a/default/python/AI/DiplomaticCorp.py
+++ b/default/python/AI/DiplomaticCorp.py
@@ -5,7 +5,7 @@ import freeOrionAIInterface as fo
 import FreeOrionAI as foAI
 from character.character_module import Aggression
 from character.character_strings_module import possible_greetings
-from freeorion_tools import UserStringList, chat_on_error
+from freeorion_tools import UserStringList
 
 from common.configure_logging import convenience_function_references_for_logger
 (debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
@@ -25,7 +25,6 @@ class DiplomaticCorp(object):
     def __init__(self):
         self.be_chatty = True
 
-    @chat_on_error
     def handle_diplomatic_message(self, message):
         """Handle a diplomatic message update from the server,
         such as if another player declares war, accepts peace, or cancels a proposed peace treaty.
@@ -82,7 +81,6 @@ class DiplomaticCorp(object):
             greets = UserStringList("AI_FIRST_TURN_GREETING_BEGINNER")
         return random.choice(greets)
 
-    @chat_on_error
     def handle_diplomatic_status_update(self, status_update):
         """Handle an update about the diplomatic status between players, which may
         or may not include this player."""

--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -33,7 +33,7 @@ import ResearchAI
 import ResourcesAI
 import TechsListsAI
 from AIDependencies import INVALID_ID
-from freeorion_tools import chat_on_error, handle_debug_chat, AITimer, init_handlers
+from freeorion_tools import handle_debug_chat, AITimer, init_handlers
 from common.listeners import listener
 from character.character_module import Aggression
 from character.character_strings_module import get_trait_name_aggression, possible_capitals
@@ -66,7 +66,6 @@ foAIstate = AIStateMock()
 diplomatic_corp = None
 
 
-@chat_on_error
 def startNewGame(aggression_input=fo.aggression.aggressive):  # pylint: disable=invalid-name
     """Called by client when a new game is started (but not when a game is loaded).
     Should clear any pre-existing state and set up whatever is needed for AI to generate orders."""
@@ -107,7 +106,6 @@ def startNewGame(aggression_input=fo.aggression.aggressive):  # pylint: disable=
     TechsListsAI.test_tech_integrity()
 
 
-@chat_on_error
 def resumeLoadedGame(saved_state_string):  # pylint: disable=invalid-name
     """Called by client to when resume a loaded game."""
     if fo.getEmpire() is None:
@@ -145,7 +143,6 @@ def resumeLoadedGame(saved_state_string):  # pylint: disable=invalid-name
     TechsListsAI.test_tech_integrity()
 
 
-@chat_on_error
 def prepareForSave():  # pylint: disable=invalid-name
     """Called by client when the game is about to be saved, to let the Python AI know it should save any AI state
     information, such as plans or knowledge about the game from previous turns,
@@ -170,7 +167,6 @@ def prepareForSave():  # pylint: disable=invalid-name
         error("foAIstate unable to pickle save-state string; the save file should be playable but the AI may have a different aggression.", exc_info=True)
 
 
-@chat_on_error
 def handleChatMessage(sender_id, message_text):  # pylint: disable=invalid-name
     """Called when this player receives a chat message. sender_id is the player who sent the message, and
     message_text is the text of the sent message."""
@@ -193,7 +189,6 @@ def handleChatMessage(sender_id, message_text):  # pylint: disable=invalid-name
         diplomatic_corp.handle_midgame_chat(sender_id, message_text)
 
 
-@chat_on_error
 def handleDiplomaticMessage(message):  # pylint: disable=invalid-name
     """Called when this player receives a diplomatic message update from the server,
     such as if another player declares war, accepts peace, or cancels a proposed peace treaty."""
@@ -209,7 +204,6 @@ def handleDiplomaticMessage(message):  # pylint: disable=invalid-name
     diplomatic_corp.handle_diplomatic_message(message)
 
 
-@chat_on_error
 def handleDiplomaticStatusUpdate(status_update):  # pylint: disable=invalid-name
     """Called when this player receives an update about the diplomatic status between players, which may
     or may not include this player."""
@@ -225,7 +219,6 @@ def handleDiplomaticStatusUpdate(status_update):  # pylint: disable=invalid-name
     diplomatic_corp.handle_diplomatic_status_update(status_update)
 
 
-@chat_on_error
 @listener
 def generateOrders():  # pylint: disable=invalid-name
     """Called once per turn to tell the Python AI to generate and issue orders to control its empire.

--- a/default/python/AI/freeorion_tools/_freeorion_tools.py
+++ b/default/python/AI/freeorion_tools/_freeorion_tools.py
@@ -89,17 +89,6 @@ def ppstring(foo):
         return str(foo)
 
 
-def chat_on_error(function):
-    @wraps(function)
-    def wrapper(*args, **kw):
-        try:
-            return function(*args, **kw)
-        except Exception as e:
-            logging.getLogger().exception(e)
-            raise
-    return wrapper
-
-
 class ConsoleLogHandler(logging.Handler):
     """A log handler to send errors to the console. """
     def emit(self, record):

--- a/default/python/common/configure_logging.py
+++ b/default/python/common/configure_logging.py
@@ -83,6 +83,7 @@ import sys
 import logging
 import inspect
 import os
+import traceback
 
 try:
     import freeorion_logger  # FreeOrion logger interface pylint: disable=import-error
@@ -183,6 +184,12 @@ def _create_narrow_handler(level):
     return h
 
 
+def _unhandled_exception_hook(*exc_info):
+    traceback_msg = "Uncaught exception: {0}".format(
+        "".join(traceback.format_exception(*exc_info)))
+    logging.getLogger().error(traceback_msg)
+
+
 def redirect_logging_to_freeorion_logger(initial_log_level=logging.DEBUG):
     """Redirect stdout, stderr and the logging.logger to hosting process' freeorion_logger."""
 
@@ -198,6 +205,9 @@ def redirect_logging_to_freeorion_logger(initial_log_level=logging.DEBUG):
         logger.addHandler(_create_narrow_handler(logging.ERROR))
         logger.addHandler(_create_narrow_handler(logging.FATAL))
         logger.addHandler(_create_narrow_handler(logging.NOTSET))
+
+        # Replace the system unhandled exception handler
+        sys.excepthook = _unhandled_exception_hook
 
         logger.setLevel(initial_log_level)
         logger.info("The python logger is initialized with a log level of %s" %

--- a/default/python/common/configure_logging.py
+++ b/default/python/common/configure_logging.py
@@ -165,6 +165,8 @@ class _LoggerHandler(logging.Handler):
         msg = str(record.message) + "\n"
         if record.exc_info:
             if not isinstance(record.exc_info, tuple):
+                # record.exc_info is not a local variable and will be garbage collected when record
+                # is garbage collected by the logging library
                 record.exc_info = sys.exc_info()
             traceback_msg = "".join(traceback.format_exception(*record.exc_info))
             msg += traceback_msg

--- a/default/python/common/configure_logging.py
+++ b/default/python/common/configure_logging.py
@@ -161,7 +161,14 @@ class _LoggerHandler(logging.Handler):
         }[level]
 
     def emit(self, record):
-        self.logger(str(record.msg) + "\n", str(record.name), str(record.filename),
+        record.message = record.getMessage()
+        msg = str(record.message) + "\n"
+        if record.exc_info:
+            if not isinstance(record.exc_info, tuple):
+                record.exc_info = sys.exc_info()
+            traceback_msg = "".join(traceback.format_exception(*record.exc_info))
+            msg += traceback_msg
+        self.logger(msg, str(record.name), str(record.filename),
                     str(record.funcName), str(record.lineno))
 
 


### PR DESCRIPTION
This might fix bug #1690.

I was initially unable to the behavior described in #1690.  However, while testing #1716, I saw similar behavior, with traceback information of uncaught python exceptions not appearing in either the log or the console window.

The problem is that uncaught python exceptions are handled by `sys.excepthook` and it was not overridden.  

This PR overrides `sys.excepthook` with  `_unhandled_exception_hook()` which sends the
traceback information to the log.

This will need testing from someone who can replicate the bug.