### PR TITLE
Avoid paths with hostile ships during auto-explore

### DIFF
--- a/default/python/interface_mock/result/freeOrionAIInterface.py
+++ b/default/python/interface_mock/result/freeOrionAIInterface.py
@@ -2449,6 +2449,21 @@ class universe(object):
         """
         return IntVec()
 
+    def shortestNonHostilePath(self, number1, number2, number3):
+        """
+        Shortest sequence of System ids and distance from System (number1) to System (number2) with no hostile Fleets
+        as determined by visibility of Empire (number3).  (number3) must be a valid empire.
+
+        :param number1:
+        :type number1: int
+        :param number2:
+        :type number2: int
+        :param number3:
+        :type number3: int
+        :rtype: IntVec
+        """
+        return IntVec()
+
     def updateMeterEstimates(self, item_list):
         """
         :param item_list:

--- a/default/python/interface_mock/result/freeorion.py
+++ b/default/python/interface_mock/result/freeorion.py
@@ -2169,6 +2169,21 @@ class universe(object):
         """
         return IntVec()
 
+    def shortestNonHostilePath(self, number1, number2, number3):
+        """
+        Shortest sequence of System ids and distance from System (number1) to System (number2) with no hostile Fleets
+        as determined by visibility of Empire (number3).  (number3) must be a valid empire.
+
+        :param number1:
+        :type number1: int
+        :param number2:
+        :type number2: int
+        :param number3:
+        :type number3: int
+        :rtype: IntVec
+        """
+        return IntVec()
+
     def updateMeterEstimates(self, item_list):
         """
         :param item_list:

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1184,6 +1184,9 @@ Sets how far apart to render dots for fleet supply lines.
 OPTIONS_DB_FLEET_SUPPLY_LINE_DOT_RATE
 Sets how fast to render dots for fleet supply lines.
 
+OPTIONS_DB_FLEET_EXPLORE_IGNORE_HOSTILE
+Ignore hostile ships when a fleet is set to explore
+
 OPTIONS_DB_GALAXY_MAP_DETECTION_RANGE
 Toggles whether to show circles around objects to indicate their detection range on the galaxy map.
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1187,6 +1187,12 @@ Sets how fast to render dots for fleet supply lines.
 OPTIONS_DB_FLEET_EXPLORE_IGNORE_HOSTILE
 Ignore hostile ships when a fleet is set to explore
 
+OPTIONS_DB_FLEET_EXPLORE_SYSTEM_ROUTE_LIMIT
+Max number of fleet routes used to determine favored route to an unexplored system. A value of 0 or less indicates no limit.
+
+OPTIONS_DB_FLEET_EXPLORE_SYSTEM_KNOWN_MULTIPLIER
+Multiplier to priority value of unexplored systems which have been previously seen by the empire. A value less than 1.0 will prefer known systems over unknown systems.
+
 OPTIONS_DB_GALAXY_MAP_DETECTION_RANGE
 Toggles whether to show circles around objects to indicate their detection range on the galaxy map.
 

--- a/universe/Building.cpp
+++ b/universe/Building.cpp
@@ -89,6 +89,13 @@ void Building::Copy(std::shared_ptr<const UniverseObject> copied_object, int emp
     }
 }
 
+bool Building::HostileToEmpire(int empire_id) const {
+    if (OwnedBy(empire_id))
+        return false;
+    return empire_id == ALL_EMPIRES || Unowned() ||
+           Empires().GetDiplomaticStatus(Owner(), empire_id) == DIPLO_WAR;
+}
+
 std::set<std::string> Building::Tags() const {
     const BuildingType* type = ::GetBuildingType(m_building_type);
     if (!type)

--- a/universe/Building.h
+++ b/universe/Building.h
@@ -21,6 +21,7 @@ namespace Condition {
 class FO_COMMON_API Building : public UniverseObject {
 public:
     /** \name Accessors */ //@{
+    bool HostileToEmpire(int empire_id) const override;
     std::set<std::string> Tags() const override;
 
     bool HasTag(const std::string& name) const override;

--- a/universe/Fighter.cpp
+++ b/universe/Fighter.cpp
@@ -2,6 +2,8 @@
 
 #include "Predicates.h"
 #include "Enums.h"
+#include "../Empire/EmpireManager.h"
+#include "../util/AppInterface.h"
 #include "../util/Logger.h"
 
 
@@ -20,6 +22,14 @@ Fighter::Fighter(int empire_id, int launched_from_id, const std::string& species
 
 Fighter::~Fighter()
 {}
+
+bool Fighter::HostileToEmpire(int empire_id) const
+{
+    if (OwnedBy(empire_id))
+        return false;
+    return empire_id == ALL_EMPIRES || Unowned() ||
+           Empires().GetDiplomaticStatus(Owner(), empire_id) == DIPLO_WAR;
+}
 
 UniverseObjectType Fighter::ObjectType() const
 { return OBJ_FIGHTER; }

--- a/universe/Fighter.h
+++ b/universe/Fighter.h
@@ -15,6 +15,8 @@ public:
     Fighter();
     ~Fighter();
 
+    bool HostileToEmpire(int empire_id) const override;
+
     UniverseObjectType ObjectType() const override;
 
     std::string Dump() const override;

--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -168,6 +168,14 @@ void Fleet::Copy(std::shared_ptr<const UniverseObject> copied_object, int empire
     }
 }
 
+bool Fleet::HostileToEmpire(int empire_id) const
+{
+    if (OwnedBy(empire_id))
+        return false;
+    return empire_id == ALL_EMPIRES || Unowned() ||
+           Empires().GetDiplomaticStatus(Owner(), empire_id) == DIPLO_WAR;
+}
+
 UniverseObjectType Fleet::ObjectType() const
 { return OBJ_FLEET; }
 

--- a/universe/Fleet.h
+++ b/universe/Fleet.h
@@ -30,6 +30,8 @@ struct MovePathNode {
 class FO_COMMON_API Fleet : public UniverseObject {
 public:
     /** \name Accessors */ //@{
+    bool HostileToEmpire(int empire_id) const override;
+
     UniverseObjectType ObjectType() const override;
 
     std::string Dump() const override;

--- a/universe/Pathfinder.h
+++ b/universe/Pathfinder.h
@@ -23,6 +23,7 @@ class FO_COMMON_API Pathfinder {
 public:
 
     typedef std::shared_ptr<const Pathfinder> ConstPtr;
+    typedef std::shared_ptr<UniverseObjectVisitor> SystemExclusionPredicateType;
 
     /** \name Structors */ //@{
     Pathfinder();
@@ -59,6 +60,18 @@ public:
       * is out of range, or if the empire ID is not known. */
     std::pair<std::list<int>, double>
                             ShortestPath(int system1_id, int system2_id, int empire_id = ALL_EMPIRES) const;
+
+    /** Shortest path known to an empire between two systems, excluding routes
+     *  for systems containing objects for @p system_predicate.
+     * @param system1_id source System id
+     * @param system2_id destination System id
+     * @param empire_id ID of viewing Empire
+     * @param system_predicate UniverseObjectVisitor, A System is excluded as a potential node in any route
+     *                         if it is or contains a matched object
+     * 
+     * @returns list of System ids, distance between systems */
+    std::pair<std::list<int>, double> ShortestPath(int system1_id, int system2_id, int empire_id,
+                                                   const SystemExclusionPredicateType& system_predicate) const;
 
     /** Returns the shortest starlane path distance between any two objects, accounting
       * for cases where one or the other are fleets / ships on starlanes between

--- a/universe/Planet.cpp
+++ b/universe/Planet.cpp
@@ -135,6 +135,24 @@ void Planet::Copy(std::shared_ptr<const UniverseObject> copied_object, int empir
     }
 }
 
+bool Planet::HostileToEmpire(int empire_id) const
+{
+    if (OwnedBy(empire_id))
+        return false;
+
+    // Empire owned planets are hostile to ALL_EMPIRES
+    if (empire_id == ALL_EMPIRES)
+        return !Unowned();
+
+    // Unowned planets are only considered hostile if populated
+    auto pop_meter = GetMeter(METER_TARGET_POPULATION);
+    if (Unowned())
+        return pop_meter && (pop_meter->Current() != 0.0f);
+
+    // both empires are normal empires
+    return Empires().GetDiplomaticStatus(Owner(), empire_id) == DIPLO_WAR;
+}
+
 std::set<std::string> Planet::Tags() const {
     const Species* species = GetSpecies(SpeciesName());
     if (!species)

--- a/universe/Planet.h
+++ b/universe/Planet.h
@@ -16,6 +16,8 @@ class FO_COMMON_API Planet :
 {
 public:
     /** \name Accessors */ //@{
+    bool HostileToEmpire(int empire_id) const override;
+
     std::set<std::string> Tags() const override;
 
     bool HasTag(const std::string& name) const override;

--- a/universe/Predicates.h
+++ b/universe/Predicates.h
@@ -119,4 +119,32 @@ std::shared_ptr<UniverseObject> OwnedVisitor<T>::Visit(std::shared_ptr<T> obj) c
     return nullptr;
 }
 
+template <class T>
+struct HostileVisitor : UniverseObjectVisitor
+{
+    HostileVisitor(int viewing_empire, int owning_empire = ALL_EMPIRES);
+
+    virtual ~HostileVisitor()
+    {}
+
+    std::shared_ptr<UniverseObject> Visit(std::shared_ptr<T> obj) const override;
+
+    const int viewing_empire_id;
+    const int owning_empire_id;
+};
+
+template <class T>
+HostileVisitor<T>::HostileVisitor(int viewing_empire, int owning_empire) :
+    viewing_empire_id(viewing_empire),
+    owning_empire_id(owning_empire)
+{}
+
+template <class T>
+std::shared_ptr<UniverseObject> HostileVisitor<T>::Visit(std::shared_ptr<T> obj) const
+{
+    if (obj->HostileToEmpire(viewing_empire_id))
+        return obj;
+    return nullptr;
+}
+
 #endif // _Predicates_h_

--- a/universe/Ship.cpp
+++ b/universe/Ship.cpp
@@ -145,6 +145,14 @@ void Ship::Copy(std::shared_ptr<const UniverseObject> copied_object, int empire_
     }
 }
 
+bool Ship::HostileToEmpire(int empire_id) const
+{
+    if (OwnedBy(empire_id))
+        return false;
+    return empire_id == ALL_EMPIRES || Unowned() ||
+           Empires().GetDiplomaticStatus(Owner(), empire_id) == DIPLO_WAR;
+}
+
 std::set<std::string> Ship::Tags() const {
     std::set<std::string> retval;
 

--- a/universe/Ship.h
+++ b/universe/Ship.h
@@ -19,6 +19,7 @@ public:
     typedef std::map<std::pair<MeterType, std::string>, Meter>          PartMeterMap;
 
     /** \name Accessors */ //@{
+    bool HostileToEmpire(int empire_id) const override;
     std::set<std::string> Tags() const override;
     bool HasTag(const std::string& name) const override;
     UniverseObjectType ObjectType() const override;

--- a/universe/UniverseObject.cpp
+++ b/universe/UniverseObject.cpp
@@ -278,6 +278,9 @@ bool UniverseObject::Unowned() const
 bool UniverseObject::OwnedBy(int empire) const
 { return empire != ALL_EMPIRES && empire == Owner(); }
 
+bool UniverseObject::HostileToEmpire(int empire_id) const
+{ return false; }
+
 Visibility UniverseObject::GetVisibility(int empire_id) const
 { return GetUniverse().GetObjectVisibilityByEmpire(this->ID(), empire_id); }
 

--- a/universe/UniverseObject.h
+++ b/universe/UniverseObject.h
@@ -63,6 +63,8 @@ public:
     virtual int                 Owner() const;                      ///< returns the ID of the empire that owns this object, or ALL_EMPIRES if there is no owner
     bool                        Unowned() const;                    ///< returns true iff there are no owners of this object
     bool                        OwnedBy(int empire) const;          ///< returns true iff the empire with id \a empire owns this object; unowned objects always return false;
+    /** Object owner is at war with empire @p empire_id */
+    virtual bool                HostileToEmpire(int empire_id) const;
 
     virtual int                 SystemID() const;                   ///< returns the ID number of the system in which this object can be found, or INVALID_OBJECT_ID if the object is not within any system
 

--- a/util/Order.h
+++ b/util/Order.h
@@ -205,7 +205,12 @@ public:
     /** \name Structors */ //@{
     FleetMoveOrder();
 
-    FleetMoveOrder(int empire, int fleet_id, int start_system_id, int dest_system_id, bool append = false);
+    FleetMoveOrder(int empire_id, int fleet_id, int start_system_id, int dest_system_id,
+                   std::vector<int> route, bool append = false);
+
+    FleetMoveOrder(int empire_id, int fleet_id, int start_system_id, int dest_system_id, bool append = false);
+
+    FleetMoveOrder(int empire_id, int fleet_id, std::vector<int> route);
     //@}
 
     /** \name Accessors */ //@{


### PR DESCRIPTION
Did not find an open issue, at least one request is posted in [this thread](http://freeorion.org/forum/viewtopic.php?f=28&t=10651)

Only the shortest route to a system is checked with no attempt to find an alternate route.