### PR TITLE
Fix hostless server reaction if on disconnection in WaitingForMPGameJoiners

### DIFF
--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -1529,6 +1529,17 @@ sc::result WaitingForMPGameJoiners::react(const CheckStartConditions& u) {
     return discard_event();
 }
 
+sc::result WaitingForMPGameJoiners::react(const Hostless& msg) {
+    TraceLogger(FSM) << "(ServerFSM) WaitingForMPGameJoiners.Hostless";
+    ServerApp& server = Server();
+
+    // Remove the ai processes.  They either all acknowledged the shutdown and are free or were all killed.
+    server.m_ai_client_processes.clear();
+
+    // Don't DisconnectAll. It cause segfault here.
+    return transit<MPLobby>();
+}
+
 sc::result WaitingForMPGameJoiners::react(const ShutdownServer& msg) {
     TraceLogger(FSM) << "(ServerFSM) WaitingForMPGameJoiners.ShutdownServer";
     return transit<ShuttingDownServer>();

--- a/server/ServerFSM.h
+++ b/server/ServerFSM.h
@@ -241,6 +241,7 @@ struct WaitingForMPGameJoiners : sc::state<WaitingForMPGameJoiners, ServerFSM> {
         sc::custom_reaction<JoinGame>,
         sc::custom_reaction<CheckStartConditions>,
         sc::custom_reaction<ShutdownServer>,
+        sc::custom_reaction<Hostless>,
         sc::custom_reaction<Error>
     > reactions;
 
@@ -253,6 +254,7 @@ struct WaitingForMPGameJoiners : sc::state<WaitingForMPGameJoiners, ServerFSM> {
     // state, as all the relevant info about AIs is provided by the lobby data.
     // as such, no file load error handling reaction is needed in this state.
     sc::result react(const ShutdownServer& u);
+    sc::result react(const Hostless& u);
     sc::result react(const Error& msg);
 
     std::shared_ptr<MultiplayerLobbyData>   m_lobby_data;


### PR DESCRIPTION
Fix `Hostless` event processing if unrecoverable disconnection happened during server state `WaitingForMPGameJoiners`.