### PR TITLE
Don't ignore command line options in AI.

### DIFF
--- a/client/AI/camain.cpp
+++ b/client/AI/camain.cpp
@@ -47,6 +47,7 @@ int wmain(int argc, wchar_t* argv[], wchar_t* envp[]) {
     // if config.xml and persistent_config.xml are present, read and set options entries
     GetOptionsDB().SetFromFile(GetConfigPath(), FreeOrionVersionString());
     GetOptionsDB().SetFromFile(GetPersistentConfigPath());
+    GetOptionsDB().SetFromCommandLine(args);
 
 #ifndef FREEORION_CAMAIN_KEEP_STACKTRACE
     try {


### PR DESCRIPTION
Enable using command line arguments for AI's option DB.

Before AI used default options for `resource-dir` which based on current dir.
It works in the normal mode because AIs start before universe generator and then universe generator move current directory to own. But in the hostless mode the next game session will be started with changes current directory so AIs fail to found resources.
The server sets correct `resource-dir` but AI ignored it.