### PR TITLE
add "dismiss sensor ghost" also to fleet btn / map wnd

### DIFF
--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -3472,7 +3472,7 @@ void FleetWnd::FleetRightClicked(GG::ListBox::iterator it, const GG::Pt& pt, con
 
 
     // Allow dismissal of stale visibility information
-    if (!fleet->OwnedBy(client_empire_id)){
+    if (!fleet->OwnedBy(client_empire_id)) {
         auto forget_fleet_action = [this, client_empire_id, fleet]() {
             // Remove visibility information for this fleet from
             // the empire's visibility table.
@@ -3497,9 +3497,9 @@ void FleetWnd::FleetRightClicked(GG::ListBox::iterator it, const GG::Pt& pt, con
         if (last_turn_visible_it != visibility_turn_map.end()
             && last_turn_visible_it->second < CurrentTurn())
         {
-            popup->AddMenuItem(GG::MenuItem(UserString("FW_ORDER_DISMISS_SENSOR_GHOST"),   false, false, forget_fleet_action));
+            popup->AddMenuItem(GG::MenuItem(UserString("FW_ORDER_DISMISS_SENSOR_GHOST"), false, false, forget_fleet_action));
         }
-   }
+    }
 
     popup->Run();
 }

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -3429,6 +3429,9 @@ Split Ships Into Fleets For Each Design
 FW_ORDER_DISMISS_SENSOR_GHOST
 Dismiss Sensor Ghost
 
+FW_ORDER_DISMISS_SENSOR_GHOST_ALL
+Dismiss All Sensor Ghosts
+
 ORDER_SHIP_SCRAP
 Scrap Ship
 


### PR DESCRIPTION
I suggest to move dismissing sensor ghosts from the fleet wnd to the map wnd.
To dismiss a sensor ghost, the player currently needs to first l-click the fleet, then move the mouse to the fleet wnd, and dismiss the fleet per r-click popup.
With this PR, the player only need to r-click the fleet button on the map to get to the popup, which saves one l-click and moving the mouse.