### PR TITLE
Promote usage of turn_state.State

### DIFF
--- a/default/python/AI/AIFleetMission.py
+++ b/default/python/AI/AIFleetMission.py
@@ -435,8 +435,7 @@ class AIFleetMission(object):
                     # if (MissionType.SECURE == self.type) or
                     secure_targets = set(AIstate.colonyTargetedSystemIDs +
                                          AIstate.outpostTargetedSystemIDs +
-                                         AIstate.invasionTargetedSystemIDs +
-                                         AIstate.blockadeTargetedSystemIDs)
+                                         AIstate.invasionTargetedSystemIDs)
                     if last_sys_target in secure_targets:  # consider a secure mission
                         if last_sys_target in AIstate.colonyTargetedSystemIDs:
                             secure_type = "Colony"
@@ -444,8 +443,6 @@ class AIFleetMission(object):
                             secure_type = "Outpost"
                         elif last_sys_target in AIstate.invasionTargetedSystemIDs:
                             secure_type = "Invasion"
-                        elif last_sys_target in AIstate.blockadeTargetedSystemIDs:
-                            secure_type = "Blockade"
                         else:
                             secure_type = "Unidentified"
                         print ("Fleet %d has completed initial stage of its mission "
@@ -528,8 +525,7 @@ class AIFleetMission(object):
         # if (not self.hasAnyAIMissionTypes()):
         if not self.target and (system_id not in set(AIstate.colonyTargetedSystemIDs +
                                                      AIstate.outpostTargetedSystemIDs +
-                                                     AIstate.invasionTargetedSystemIDs +
-                                                     AIstate.blockadeTargetedSystemIDs)):
+                                                     AIstate.invasionTargetedSystemIDs)):
             if self._need_repair():
                 repair_fleet_order = MoveUtilsAI.get_repair_fleet_order(self.fleet, start_sys_id)
                 if repair_fleet_order and repair_fleet_order.is_valid():

--- a/default/python/AI/AIstate.py
+++ b/default/python/AI/AIstate.py
@@ -38,7 +38,6 @@ outpostFleetIDs = []
 invasionFleetIDs = []
 fleetsLostBySystem = {}  # keys are system_ids, values are ratings for the fleets lost
 empireStars = {}
-popCtrIDs = []
 outpostIDs = []
 
 
@@ -798,7 +797,6 @@ class AIstate(object):
         self.__clean_fleet_roles(just_resumed=True)
         fleetsLostBySystem.clear()
         empireStars.clear()
-        popCtrIDs[:] = []
         outpostIDs[:] = []
         ResourcesAI.lastFociCheck[0] = 0
         self.qualifyingColonyBaseTargets.clear()

--- a/default/python/AI/AIstate.py
+++ b/default/python/AI/AIstate.py
@@ -38,7 +38,6 @@ outpostFleetIDs = []
 invasionFleetIDs = []
 fleetsLostBySystem = {}  # keys are system_ids, values are ratings for the fleets lost
 empireStars = {}
-outpostIDs = []
 
 
 class ConversionError(Exception):
@@ -797,7 +796,6 @@ class AIstate(object):
         self.__clean_fleet_roles(just_resumed=True)
         fleetsLostBySystem.clear()
         empireStars.clear()
-        outpostIDs[:] = []
         ResourcesAI.lastFociCheck[0] = 0
         self.qualifyingColonyBaseTargets.clear()
         self.qualifyingOutpostBaseTargets.clear()

--- a/default/python/AI/AIstate.py
+++ b/default/python/AI/AIstate.py
@@ -38,7 +38,6 @@ outpostFleetIDs = []
 invasionFleetIDs = []
 fleetsLostBySystem = {}  # keys are system_ids, values are ratings for the fleets lost
 popCtrSystemIDs = []
-colonizedSystems = {}
 empireStars = {}
 popCtrIDs = []
 outpostIDs = []
@@ -801,7 +800,6 @@ class AIstate(object):
         self.__clean_fleet_roles(just_resumed=True)
         fleetsLostBySystem.clear()
         popCtrSystemIDs[:] = []  # resets without detroying existing references
-        colonizedSystems.clear()
         empireStars.clear()
         popCtrIDs[:] = []
         outpostIDs[:] = []

--- a/default/python/AI/AIstate.py
+++ b/default/python/AI/AIstate.py
@@ -28,7 +28,6 @@ from common.configure_logging import convenience_function_references_for_logger
 colonyTargetedSystemIDs = []
 outpostTargetedSystemIDs = []
 opponentPlanetIDs = []
-opponentSystemIDs = []  # TODO: Currently never filled but some (uncommented) code in MilitaryAI refers to this...
 invasionTargets = []
 invasionTargetedSystemIDs = []
 blockadeTargetedSystemIDs = []  # TODO also never filled atm... either implement this or remove redundant code

--- a/default/python/AI/AIstate.py
+++ b/default/python/AI/AIstate.py
@@ -30,7 +30,6 @@ outpostTargetedSystemIDs = []
 opponentPlanetIDs = []
 invasionTargets = []
 invasionTargetedSystemIDs = []
-blockadeTargetedSystemIDs = []  # TODO also never filled atm... either implement this or remove redundant code
 fleetsLostBySystem = {}  # keys are system_ids, values are ratings for the fleets lost
 empireStars = {}
 

--- a/default/python/AI/AIstate.py
+++ b/default/python/AI/AIstate.py
@@ -32,7 +32,6 @@ invasionTargets = []
 invasionTargetedSystemIDs = []
 blockadeTargetedSystemIDs = []  # TODO also never filled atm... either implement this or remove redundant code
 militarySystemIDs = []
-outpostFleetIDs = []
 invasionFleetIDs = []
 fleetsLostBySystem = {}  # keys are system_ids, values are ratings for the fleets lost
 empireStars = {}

--- a/default/python/AI/AIstate.py
+++ b/default/python/AI/AIstate.py
@@ -40,7 +40,6 @@ fleetsLostBySystem = {}  # keys are system_ids, values are ratings for the fleet
 empireStars = {}
 popCtrIDs = []
 outpostIDs = []
-outpostSystemIDs = []
 
 
 class ConversionError(Exception):
@@ -801,7 +800,6 @@ class AIstate(object):
         empireStars.clear()
         popCtrIDs[:] = []
         outpostIDs[:] = []
-        outpostSystemIDs[:] = []
         ResourcesAI.lastFociCheck[0] = 0
         self.qualifyingColonyBaseTargets.clear()
         self.qualifyingOutpostBaseTargets.clear()

--- a/default/python/AI/AIstate.py
+++ b/default/python/AI/AIstate.py
@@ -32,7 +32,6 @@ invasionTargets = []
 invasionTargetedSystemIDs = []
 blockadeTargetedSystemIDs = []  # TODO also never filled atm... either implement this or remove redundant code
 militarySystemIDs = []
-colonyFleetIDs = []
 outpostFleetIDs = []
 invasionFleetIDs = []
 fleetsLostBySystem = {}  # keys are system_ids, values are ratings for the fleets lost

--- a/default/python/AI/AIstate.py
+++ b/default/python/AI/AIstate.py
@@ -966,6 +966,14 @@ class AIstate(object):
         self.__update_system_status()
         self.__report_system_threats()
         self.__report_system_defenses()
+        self.__report_exploration_status()
+
+    def __report_exploration_status(self):
+        universe = fo.getUniverse()
+        explored_system_ids = self.get_explored_system_ids()
+        print "Unexplored Systems: %s " % map(universe.getSystem, self.get_unexplored_system_ids())
+        print "Explored SystemIDs: %s" % map(universe.getSystem, explored_system_ids)
+        print "Explored PlanetIDs: %s" % PlanetUtilsAI.get_planets_in__systems_ids(explored_system_ids)
 
     def log_peace_request(self, initiating_empire_id, recipient_empire_id):
         """Keep a record of peace requests made or received by this empire."""

--- a/default/python/AI/AIstate.py
+++ b/default/python/AI/AIstate.py
@@ -32,7 +32,6 @@ invasionTargets = []
 invasionTargetedSystemIDs = []
 blockadeTargetedSystemIDs = []  # TODO also never filled atm... either implement this or remove redundant code
 militarySystemIDs = []
-invasionFleetIDs = []
 fleetsLostBySystem = {}  # keys are system_ids, values are ratings for the fleets lost
 empireStars = {}
 

--- a/default/python/AI/AIstate.py
+++ b/default/python/AI/AIstate.py
@@ -31,7 +31,6 @@ opponentPlanetIDs = []
 invasionTargets = []
 invasionTargetedSystemIDs = []
 blockadeTargetedSystemIDs = []  # TODO also never filled atm... either implement this or remove redundant code
-militarySystemIDs = []
 fleetsLostBySystem = {}  # keys are system_ids, values are ratings for the fleets lost
 empireStars = {}
 

--- a/default/python/AI/AIstate.py
+++ b/default/python/AI/AIstate.py
@@ -37,7 +37,6 @@ colonyFleetIDs = []
 outpostFleetIDs = []
 invasionFleetIDs = []
 fleetsLostBySystem = {}  # keys are system_ids, values are ratings for the fleets lost
-popCtrSystemIDs = []
 empireStars = {}
 popCtrIDs = []
 outpostIDs = []
@@ -799,7 +798,6 @@ class AIstate(object):
             self.ensure_have_fleet_missions([fleetID])
         self.__clean_fleet_roles(just_resumed=True)
         fleetsLostBySystem.clear()
-        popCtrSystemIDs[:] = []  # resets without detroying existing references
         empireStars.clear()
         popCtrIDs[:] = []
         outpostIDs[:] = []

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -268,7 +268,6 @@ def survey_universe():
                 empire_colonizers["SP_" + spec_name] = []  # get it into colonizer list even if no colony yet
         AIstate.popCtrIDs[:] = []
         AIstate.outpostIDs[:] = []
-        AIstate.outpostSystemIDs[:] = []
         pilot_ratings.clear()
         unowned_empty_planet_ids.clear()
         facilities_by_species_grade.clear()
@@ -379,8 +378,6 @@ def survey_universe():
                 state.set_have_gas_giant()
 
         if empire_has_colony_in_sys:
-            if not empire_has_pop_ctr_in_sys:
-                AIstate.outpostSystemIDs.append(sys_id)
             AIstate.empireStars.setdefault(system.starType, []).append(sys_id)
             sys_status = foAI.foAIstate.systemStatus.setdefault(sys_id, {})
             if sys_status.get('fleetThreat', 0) > 0:

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -270,7 +270,6 @@ def survey_universe():
         AIstate.popCtrSystemIDs[:] = []
         AIstate.outpostIDs[:] = []
         AIstate.outpostSystemIDs[:] = []
-        AIstate.colonizedSystems.clear()
         pilot_ratings.clear()
         unowned_empty_planet_ids.clear()
         facilities_by_species_grade.clear()
@@ -309,8 +308,6 @@ def survey_universe():
             weapons_grade = "WEAPONS_0.0"
             if owner_id == empire_id:
                 empire_has_colony_in_sys = True
-                AIstate.colonizedSystems.setdefault(sys_id, []).append(
-                    pid)  # track these to plan Solar Generators and Singularity Generators, etc.
                 if planet_population <= 0.0:
                     empire_outpost_ids.add(pid)
                     AIstate.outpostIDs.append(pid)
@@ -776,7 +773,7 @@ def evaluate_planet(planet_id, mission_type, spec_name, detail=None):
     # only count existing presence if not target planet
     # TODO: consider neighboring sytems for smaller contribution, and bigger contributions for
     # local colonies versus local outposts
-    locally_owned_planets = [lpid for lpid in AIstate.colonizedSystems.get(this_sysid, []) if lpid != planet_id]
+    locally_owned_planets = [lpid for lpid in state.get_empire_planets_by_system(include_outposts=True).get(this_sysid, []) if lpid != planet_id]
     planets_with_species = state.get_inhabited_planets()
     locally_owned_pop_ctrs = [lpid for lpid in locally_owned_planets if lpid in planets_with_species]
     # triple count pop_ctrs

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -554,10 +554,6 @@ def get_colony_fleets():
     foAI.foAIstate.colonisablePlanetIDs.clear()
     foAI.foAIstate.colonisablePlanetIDs.update(sorted_planets)
 
-    # get outpost fleets
-    all_outpost_fleet_ids = FleetUtilsAI.get_empire_fleet_ids_by_role(MissionType.OUTPOST)
-    AIstate.outpostFleetIDs = FleetUtilsAI.extract_fleet_ids_without_mission_types(all_outpost_fleet_ids)
-
     evaluated_outpost_planets = assign_colonisation_values(evaluated_outpost_planet_ids, MissionType.OUTPOST, None)
     # if outposted planet would be in supply range, let outpost value be best of outpost value or colonization value
     for pid in set(evaluated_outpost_planets).intersection(evaluated_colony_planets):
@@ -1241,7 +1237,9 @@ def assign_colony_fleets_to_colonise():
                       MissionType.COLONISATION)
 
     # assign fleet targets to colonisable outposts
-    send_colony_ships(AIstate.outpostFleetIDs, foAI.foAIstate.colonisableOutpostIDs.items(),
+    all_outpost_fleet_ids = FleetUtilsAI.get_empire_fleet_ids_by_role(MissionType.OUTPOST)
+    send_colony_ships(FleetUtilsAI.extract_fleet_ids_without_mission_types(all_outpost_fleet_ids),
+                      foAI.foAIstate.colonisableOutpostIDs.items(),
                       MissionType.OUTPOST)
 
 

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -485,7 +485,7 @@ def get_colony_fleets():
         if not planet:
             continue
         sys_id = planet.systemID
-        for pid2 in state.get_empire_planets_by_system(include_outposts=False).get(sys_id, []):
+        for pid2 in state.get_empire_planets_by_system(sys_id, include_outposts=False):
             planet2 = universe.getPlanet(pid2)
             if not (planet2 and planet2.speciesName in empire_colonizers):
                 continue
@@ -773,7 +773,8 @@ def evaluate_planet(planet_id, mission_type, spec_name, detail=None):
     # only count existing presence if not target planet
     # TODO: consider neighboring sytems for smaller contribution, and bigger contributions for
     # local colonies versus local outposts
-    locally_owned_planets = [lpid for lpid in state.get_empire_planets_by_system(include_outposts=True).get(this_sysid, []) if lpid != planet_id]
+    locally_owned_planets = [lpid for lpid in state.get_empire_planets_by_system(this_sysid, include_outposts=True)
+                             if lpid != planet_id]
     planets_with_species = state.get_inhabited_planets()
     locally_owned_pop_ctrs = [lpid for lpid in locally_owned_planets if lpid in planets_with_species]
     # triple count pop_ctrs

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -274,7 +274,6 @@ def survey_universe():
         for spec_name in AIDependencies.EXTINCT_SPECIES:
             if tech_is_complete("TECH_COL_" + spec_name):
                 empire_colonizers["SP_" + spec_name] = []  # get it into colonizer list even if no colony yet
-        AIstate.outpostIDs[:] = []
         pilot_ratings.clear()
         unowned_empty_planet_ids.clear()
         facilities_by_species_grade.clear()
@@ -287,7 +286,6 @@ def survey_universe():
         if not system:
             continue
         empire_has_colony_in_sys = False
-        empire_has_pop_ctr_in_sys = False
         local_ast = False
         local_gg = False
         empire_has_qualifying_planet = False
@@ -315,7 +313,6 @@ def survey_universe():
                 empire_has_colony_in_sys = True
                 if planet_population <= 0.0:
                     empire_outpost_ids.add(pid)
-                    AIstate.outpostIDs.append(pid)
                 elif this_spec:
                     empire_has_qualifying_planet = True
                     for metab in [tag for tag in this_spec.tags if tag in AIDependencies.metabolismBoostMap]:
@@ -339,8 +336,6 @@ def survey_universe():
                 else:
                     # Logic says this should not happen, but it seems to happen some time for a single turm
                     # TODO What causes this?
-                    empire_outpost_ids.add(pid)
-                    AIstate.outpostIDs.append(pid)
                     warn("Found a planet we own that has pop > 0 but has no species")
                     warn("Planet: %s" % universe.getPlanet(pid))
                     warn("Species: %s(%s)" % (spec_name, this_spec))
@@ -471,7 +466,7 @@ def get_colony_fleets():
                 build_planet = universe.getPlanet(element.locationID)
                 queued_colony_bases.append(build_planet.systemID)
 
-    evaluated_colony_planet_ids = list(unowned_empty_planet_ids.union(AIstate.outpostIDs) - set(
+    evaluated_colony_planet_ids = list(unowned_empty_planet_ids.union(state.get_empire_outposts()) - set(
         colony_targeted_planet_ids))  # places for possible colonyBase
 
     # don't want to lose the info by clearing, but #TODO: should double check if still own colonizer planet

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -71,11 +71,11 @@ def _get_planet_size(planet):
 
 
 def colony_pod_cost():
-    return AIDependencies.COLONY_POD_COST * (1 + len(state.get_inhabited_planets())*AIDependencies.COLONY_POD_UPKEEP)
+    return AIDependencies.COLONY_POD_COST * (1 + state.get_number_of_colonies()*AIDependencies.COLONY_POD_UPKEEP)
 
 
 def outpod_pod_cost():
-    return AIDependencies.OUTPOST_POD_COST * (1 + len(state.get_inhabited_planets())*AIDependencies.COLONY_POD_UPKEEP)
+    return AIDependencies.OUTPOST_POD_COST * (1 + state.get_number_of_colonies()*AIDependencies.COLONY_POD_UPKEEP)
 
 
 def calc_max_pop(planet, species, detail):

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -773,8 +773,7 @@ def evaluate_planet(planet_id, mission_type, spec_name, detail=None):
     # only count existing presence if not target planet
     # TODO: consider neighboring sytems for smaller contribution, and bigger contributions for
     # local colonies versus local outposts
-    locally_owned_planets = [lpid for lpid in state.get_empire_planets_by_system(this_sysid, include_outposts=True)
-                             if lpid != planet_id]
+    locally_owned_planets = [lpid for lpid in state.get_empire_planets_by_system(this_sysid) if lpid != planet_id]
     planets_with_species = state.get_inhabited_planets()
     locally_owned_pop_ctrs = [lpid for lpid in locally_owned_planets if lpid in planets_with_species]
     # triple count pop_ctrs

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -295,7 +295,6 @@ def survey_universe():
         unowned_empty_planet_ids.clear()
         facilities_by_species_grade.clear()
         system_facilities.clear()
-        state.update()
 
     # var setup done
 

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -267,7 +267,6 @@ def survey_universe():
             if tech_is_complete("TECH_COL_" + spec_name):
                 empire_colonizers["SP_" + spec_name] = []  # get it into colonizer list even if no colony yet
         AIstate.popCtrIDs[:] = []
-        AIstate.popCtrSystemIDs[:] = []
         AIstate.outpostIDs[:] = []
         AIstate.outpostSystemIDs[:] = []
         pilot_ratings.clear()
@@ -380,9 +379,7 @@ def survey_universe():
                 state.set_have_gas_giant()
 
         if empire_has_colony_in_sys:
-            if empire_has_pop_ctr_in_sys:
-                AIstate.popCtrSystemIDs.append(sys_id)
-            else:
+            if not empire_has_pop_ctr_in_sys:
                 AIstate.outpostSystemIDs.append(sys_id)
             AIstate.empireStars.setdefault(system.starType, []).append(sys_id)
             sys_status = foAI.foAIstate.systemStatus.setdefault(sys_id, {})
@@ -850,7 +847,7 @@ def evaluate_planet(planet_id, mission_type, spec_name, detail=None):
     fixed_ind = 0
     fixed_res = 0
     if system:
-        already_got_this_one = this_sysid in (AIstate.popCtrSystemIDs + AIstate.outpostSystemIDs)
+        already_got_this_one = this_sysid in state.get_empire_planets_by_system()
         # TODO: Should probably consider pilot rating also for Phototropic species
         if "PHOTOTROPHIC" not in tag_list and pilot_rating >= state.best_pilot_rating:
             if system.starType == fo.starType.red and tech_is_complete("LRN_STELLAR_TOMOGRAPHY"):

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -246,15 +246,6 @@ def survey_universe():
     empire_id = fo.empireID()
     current_turn = fo.currentTurn()
 
-    # get outpost and colonization planets
-    explored_system_ids = foAI.foAIstate.get_explored_system_ids()
-    un_ex_sys_ids = foAI.foAIstate.get_unexplored_system_ids()
-
-    print "Unexplored Systems: %s " % map(universe.getSystem, un_ex_sys_ids)
-    print "Explored SystemIDs: %s" % map(universe.getSystem, explored_system_ids)
-    print "Explored PlanetIDs: %s" % PlanetUtilsAI.get_planets_in__systems_ids(explored_system_ids)
-    print
-
     # set up / reset various variables; the 'if' is purely for code folding convenience
     if True:
         colony_status['colonies_under_attack'] = []

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -488,7 +488,7 @@ def get_colony_fleets():
         if not planet:
             continue
         sys_id = planet.systemID
-        for pid2 in state.get_empire_inhabited_planets_by_system().get(sys_id, []):
+        for pid2 in state.get_empire_planets_by_system(include_outposts=False).get(sys_id, []):
             planet2 = universe.getPlanet(pid2)
             if not (planet2 and planet2.speciesName in empire_colonizers):
                 continue

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -406,9 +406,6 @@ def get_colony_fleets():
     universe = fo.getUniverse()
     empire = fo.getEmpire()
 
-    colonization_timer.start('Getting avail colony fleets')
-    all_colony_fleet_ids = FleetUtilsAI.get_empire_fleet_ids_by_role(MissionType.COLONISATION)
-
     colonization_timer.start('Identify Existing colony/outpost targets')
     colony_targeted_planet_ids = FleetUtilsAI.get_targeted_planet_ids(universe.planetIDs, MissionType.COLONISATION)
     all_colony_targeted_system_ids = PlanetUtilsAI.get_systems(colony_targeted_planet_ids)
@@ -436,7 +433,6 @@ def get_colony_fleets():
     # export targeted systems for other AI modules
     AIstate.colonyTargetedSystemIDs = all_colony_targeted_system_ids
     AIstate.outpostTargetedSystemIDs = all_outpost_targeted_system_ids
-    AIstate.colonyFleetIDs[:] = FleetUtilsAI.extract_fleet_ids_without_mission_types(all_colony_fleet_ids)
 
     colonization_timer.start('Identify colony base targets')
     # keys are sets of ints; data is doubles
@@ -1213,8 +1209,7 @@ def get_claimed_stars():
 
 def assign_colony_fleets_to_colonise():
     universe = fo.getUniverse()
-    all_outpost_base_fleet_ids = FleetUtilsAI.get_empire_fleet_ids_by_role(
-        MissionType.ORBITAL_OUTPOST)
+    all_outpost_base_fleet_ids = FleetUtilsAI.get_empire_fleet_ids_by_role(MissionType.ORBITAL_OUTPOST)
     avail_outpost_base_fleet_ids = FleetUtilsAI.extract_fleet_ids_without_mission_types(all_outpost_base_fleet_ids)
     for fid in avail_outpost_base_fleet_ids:
         fleet = universe.getFleet(fid)
@@ -1240,7 +1235,9 @@ def assign_colony_fleets_to_colonise():
             ai_fleet_mission.set_target(MissionType.ORBITAL_OUTPOST, ai_target)
 
     # assign fleet targets to colonisable planets
-    send_colony_ships(AIstate.colonyFleetIDs, foAI.foAIstate.colonisablePlanetIDs.items(),
+    all_colony_fleet_ids = FleetUtilsAI.get_empire_fleet_ids_by_role(MissionType.COLONISATION)
+    send_colony_ships(FleetUtilsAI.extract_fleet_ids_without_mission_types(all_colony_fleet_ids),
+                      foAI.foAIstate.colonisablePlanetIDs.items(),
                       MissionType.COLONISATION)
 
     # assign fleet targets to colonisable outposts

--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -32,6 +32,7 @@ import ProductionAI
 import ResearchAI
 import ResourcesAI
 import TechsListsAI
+import turn_state
 from AIDependencies import INVALID_ID
 from freeorion_tools import handle_debug_chat, AITimer, init_handlers
 from common.listeners import listener
@@ -306,6 +307,7 @@ def generateOrders():  # pylint: disable=invalid-name
                            '%s (%s): [[%s]]' % (empire.name, get_trait_name_aggression(foAIstate.character), greet))
 
     foAIstate.prepare_for_new_turn()
+    turn_state.state.update()
     debug("Calling AI Modules")
     # call AI modules
     action_list = [ColonisationAI.survey_universe,

--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -34,9 +34,6 @@ def get_invasion_fleets():
     empire = fo.getEmpire()
     empire_id = fo.empireID()
 
-    all_invasion_fleet_ids = FleetUtilsAI.get_empire_fleet_ids_by_role(MissionType.INVASION)
-    AIstate.invasionFleetIDs = FleetUtilsAI.extract_fleet_ids_without_mission_types(all_invasion_fleet_ids)
-
     home_system_id = PlanetUtilsAI.get_capital_sys_id()
     visible_system_ids = list(foAI.foAIstate.visInteriorSystemIDs) + list(foAI.foAIstate.visBorderSystemIDs)
 
@@ -594,7 +591,8 @@ def assign_invasion_fleets_to_invade():
 
     assign_invasion_bases()
 
-    invasion_fleet_ids = AIstate.invasionFleetIDs
+    all_invasion_fleet_ids = FleetUtilsAI.get_empire_fleet_ids_by_role(MissionType.INVASION)
+    invasion_fleet_ids = FleetUtilsAI.extract_fleet_ids_without_mission_types(all_invasion_fleet_ids)
     send_invasion_fleets(invasion_fleet_ids, AIstate.invasionTargets, MissionType.INVASION)
     all_invasion_fleet_ids = FleetUtilsAI.get_empire_fleet_ids_by_role(MissionType.INVASION)
     for fid in FleetUtilsAI.extract_fleet_ids_without_mission_types(all_invasion_fleet_ids):

--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -114,7 +114,7 @@ def get_invasion_fleets():
                 continue
             best_base_planet = INVALID_ID
             best_trooper_count = 0
-            for pid2 in state.get_empire_planets_by_system(include_outposts=False).get(sys_id, []):
+            for pid2 in state.get_empire_planets_by_system(sys_id, include_outposts=False):
                 if available_pp.get(pid2, 0) < 2:  # TODO: improve troop base PP sufficiency determination
                     break
                 planet2 = universe.getPlanet(pid2)

--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -114,7 +114,7 @@ def get_invasion_fleets():
                 continue
             best_base_planet = INVALID_ID
             best_trooper_count = 0
-            for pid2 in state.get_empire_inhabited_planets_by_system().get(sys_id, []):
+            for pid2 in state.get_empire_planets_by_system(include_outposts=False).get(sys_id, []):
                 if available_pp.get(pid2, 0) < 2:  # TODO: improve troop base PP sufficiency determination
                     break
                 planet2 = universe.getPlanet(pid2)

--- a/default/python/AI/MilitaryAI.py
+++ b/default/python/AI/MilitaryAI.py
@@ -745,13 +745,6 @@ def get_military_fleets(mil_fleets_ids=None, try_reset=True, thisround="Main"):
         print "------------------------------\nFinal %s Round Military Allocations: %s \n-----------------------" % (thisround, dict([(sid, alloc) for sid, alloc, _, _, _ in new_allocations]))
         print "(Apparently) remaining military rating: %.1f" % remaining_mil_rating
 
-    # export military systems for other AI modules
-    if "Main" in thisround:
-        AIstate.militarySystemIDs = list(set([sid for sid, _, _, _, _ in new_allocations]).union(
-                [sid for sid in allocation_helper.already_assigned_rating
-                 if allocation_helper.already_assigned_rating[sid] > 0]))
-    else:
-        AIstate.militarySystemIDs = list(set([sid for sid, _, _, _, _ in new_allocations]).union(AIstate.militarySystemIDs))
     return new_allocations
 
 

--- a/default/python/AI/MilitaryAI.py
+++ b/default/python/AI/MilitaryAI.py
@@ -7,12 +7,12 @@ import FleetUtilsAI
 from CombatRatingsAI import combine_ratings
 import PlanetUtilsAI
 import PriorityAI
-import ColonisationAI
 import ProductionAI
 import CombatRatingsAI
 from freeorion_tools import ppstring, cache_by_turn
 from AIDependencies import INVALID_ID
 from common.configure_logging import convenience_function_references_for_logger
+from turn_state import state
 (debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
 
 MinThreat = 10  # the minimum threat level that will be ascribed to an unknown threat capable of killing scouts
@@ -683,8 +683,7 @@ def get_military_fleets(mil_fleets_ids=None, try_reset=True, thisround="Main"):
         # TODO blockade enemy systems
 
         # interior systems
-        targetable_ids = set(ColonisationAI.systems_by_supply_tier.get(0, []) +
-                             ColonisationAI.systems_by_supply_tier.get(1, []))
+        targetable_ids = set(state.get_systems_by_supply_tier(0))
         current_mil_systems = [sid for sid, _, _, _, _ in allocation_helper.allocations]
         interior_targets1 = targetable_ids.difference(current_mil_systems)
         interior_targets = [sid for sid in interior_targets1 if (

--- a/default/python/AI/MilitaryAI.py
+++ b/default/python/AI/MilitaryAI.py
@@ -818,7 +818,7 @@ def assign_military_fleets_to_systems(use_fleet_id_list=None, allocations=None, 
             fleet_mission = foAI.foAIstate.get_fleet_mission(fleet_id)
             fleet_mission.clear_fleet_orders()
             fleet_mission.clear_target()
-            if sys_id in list(set(AIstate.colonyTargetedSystemIDs + AIstate.outpostTargetedSystemIDs + AIstate.invasionTargetedSystemIDs + AIstate.blockadeTargetedSystemIDs)):
+            if sys_id in set(AIstate.colonyTargetedSystemIDs + AIstate.outpostTargetedSystemIDs + AIstate.invasionTargetedSystemIDs):
                 mission_type = MissionType.SECURE
             else:
                 mission_type = MissionType.MILITARY

--- a/default/python/AI/MoveUtilsAI.py
+++ b/default/python/AI/MoveUtilsAI.py
@@ -28,7 +28,7 @@ def create_move_orders_to_system(fleet, target):
     starting_system = fleet.get_system()  # current fleet location or current target system if on starlane
     # if the mission does not end at the targeted system, make sure we can actually return to supply after moving.
     ensure_return = target.id not in set(AIstate.colonyTargetedSystemIDs + AIstate.outpostTargetedSystemIDs
-                                         + AIstate.invasionTargetedSystemIDs + AIstate.blockadeTargetedSystemIDs)
+                                         + AIstate.invasionTargetedSystemIDs)
     system_targets = can_travel_to_system(fleet.id, starting_system, target, ensure_return=ensure_return)
     result = [fleet_orders.OrderMove(fleet, system) for system in system_targets]
     if not result and starting_system.id != target.id:

--- a/default/python/AI/PriorityAI.py
+++ b/default/python/AI/PriorityAI.py
@@ -413,7 +413,7 @@ def _calculate_military_priority():
     allotted_invasion_targets = 1 + int(fo.currentTurn()/25)
     target_planet_ids = [pid for pid, pscore, trp in AIstate.invasionTargets[:allotted_invasion_targets]] + [pid for pid, pscore in foAI.foAIstate.colonisablePlanetIDs.items()[:allottedColonyTargets]] + [pid for pid, pscore in foAI.foAIstate.colonisableOutpostIDs.items()[:allottedColonyTargets]]
 
-    my_systems = set(AIstate.popCtrSystemIDs).union(AIstate.outpostSystemIDs)
+    my_systems = set(state.get_empire_planets_by_system())
     target_systems = set(PlanetUtilsAI.get_systems(target_planet_ids))
 
     cur_ship_rating = ProductionAI.cur_best_military_design_rating()

--- a/default/python/AI/PriorityAI.py
+++ b/default/python/AI/PriorityAI.py
@@ -127,7 +127,7 @@ def _calculate_research_priority():
     industry_surge = (foAI.foAIstate.character.may_surge_industry(total_pp, total_rp) and
                       (((orb_gen_tech in research_queue_list[:2] or got_orb_gen) and state.have_gas_giant) or
                        ((mgrav_prod_tech in research_queue_list[:2] or got_mgrav_prod) and state.have_asteroids)) and
-                      (not (len(AIstate.popCtrIDs) >= 12)))
+                      (not (len(state.get_inhabited_planets()) >= 12)))
     # get current industry production & Target
     owned_planet_ids = PlanetUtilsAI.get_owned_planets_by_empire(universe.planetIDs)
     planets = map(universe.getPlanet, owned_planet_ids)
@@ -227,7 +227,7 @@ def _calculate_colonisation_priority():
     enemies_sighted = foAI.foAIstate.misc.get('enemies_sighted', {})
     galaxy_is_sparse = ColonisationAI.galaxy_is_sparse()
     total_pp = fo.getEmpire().productionPoints
-    num_colonies = len(list(AIstate.popCtrIDs))
+    num_colonies = len(state.get_inhabited_planets())
     colony_growth_barrier = foAI.foAIstate.character.max_number_colonies()
     colony_cost = AIDependencies.COLONY_POD_COST * (1 + AIDependencies.COLONY_POD_UPKEEP * num_colonies)
     turns_to_build = 8  # TODO: check for susp anim pods, build time 10
@@ -280,7 +280,7 @@ def _calculate_outpost_priority():
     enemies_sighted = foAI.foAIstate.misc.get('enemies_sighted', {})
     galaxy_is_sparse = ColonisationAI.galaxy_is_sparse()
     total_pp = fo.getEmpire().productionPoints
-    num_colonies = len(list(AIstate.popCtrIDs))
+    num_colonies = len(state.get_inhabited_planets())
     colony_growth_barrier = foAI.foAIstate.character.max_number_colonies()
     if num_colonies > colony_growth_barrier:
         return 0.0
@@ -330,7 +330,7 @@ def _calculate_invasion_priority():
     empire = fo.getEmpire()
     enemies_sighted = foAI.foAIstate.misc.get('enemies_sighted', {})
     multiplier = 1
-    num_colonies = len(list(AIstate.popCtrIDs))
+    num_colonies = len(state.get_inhabited_planets())
     colony_growth_barrier = foAI.foAIstate.character.max_number_colonies()
     if num_colonies > colony_growth_barrier:
         return 0.0

--- a/default/python/AI/PriorityAI.py
+++ b/default/python/AI/PriorityAI.py
@@ -127,7 +127,7 @@ def _calculate_research_priority():
     industry_surge = (foAI.foAIstate.character.may_surge_industry(total_pp, total_rp) and
                       (((orb_gen_tech in research_queue_list[:2] or got_orb_gen) and state.have_gas_giant) or
                        ((mgrav_prod_tech in research_queue_list[:2] or got_mgrav_prod) and state.have_asteroids)) and
-                      (not (len(state.get_inhabited_planets()) >= 12)))
+                      (state.get_number_of_colonies() < 12))
     # get current industry production & Target
     owned_planet_ids = PlanetUtilsAI.get_owned_planets_by_empire(universe.planetIDs)
     planets = map(universe.getPlanet, owned_planet_ids)
@@ -227,7 +227,7 @@ def _calculate_colonisation_priority():
     enemies_sighted = foAI.foAIstate.misc.get('enemies_sighted', {})
     galaxy_is_sparse = ColonisationAI.galaxy_is_sparse()
     total_pp = fo.getEmpire().productionPoints
-    num_colonies = len(state.get_inhabited_planets())
+    num_colonies = state.get_number_of_colonies()
     colony_growth_barrier = foAI.foAIstate.character.max_number_colonies()
     colony_cost = AIDependencies.COLONY_POD_COST * (1 + AIDependencies.COLONY_POD_UPKEEP * num_colonies)
     turns_to_build = 8  # TODO: check for susp anim pods, build time 10
@@ -280,9 +280,8 @@ def _calculate_outpost_priority():
     enemies_sighted = foAI.foAIstate.misc.get('enemies_sighted', {})
     galaxy_is_sparse = ColonisationAI.galaxy_is_sparse()
     total_pp = fo.getEmpire().productionPoints
-    num_colonies = len(state.get_inhabited_planets())
     colony_growth_barrier = foAI.foAIstate.character.max_number_colonies()
-    if num_colonies > colony_growth_barrier:
+    if state.get_number_of_colonies() > colony_growth_barrier:
         return 0.0
     mil_prio = foAI.foAIstate.get_priority(PriorityType.PRODUCTION_MILITARY)
 
@@ -330,9 +329,8 @@ def _calculate_invasion_priority():
     empire = fo.getEmpire()
     enemies_sighted = foAI.foAIstate.misc.get('enemies_sighted', {})
     multiplier = 1
-    num_colonies = len(state.get_inhabited_planets())
     colony_growth_barrier = foAI.foAIstate.character.max_number_colonies()
-    if num_colonies > colony_growth_barrier:
+    if state.get_number_of_colonies() > colony_growth_barrier:
         return 0.0
 
     if len(foAI.foAIstate.colonisablePlanetIDs) > 0:

--- a/default/python/AI/PriorityAI.py
+++ b/default/python/AI/PriorityAI.py
@@ -39,11 +39,11 @@ def calculate_priorities():
 
     print "\n*** Updating Colonization Status ***\n"
     prioritiees_timer.start('Evaluating Colonization Status')
-    ColonisationAI.get_colony_fleets()  # sets foAI.foAIstate.colonisablePlanetIDs and foAI.foAIstate.outpostPlanetIDs and many other values used by other modules
+    ColonisationAI.get_colony_fleets()  # sets foAI.foAIstate.colonisablePlanetIDs and many other values used by other modules
 
     print "\n*** Updating Invasion Status ***\n"
     prioritiees_timer.start('Evaluating Invasion Status')
-    InvasionAI.get_invasion_fleets()  # sets AIstate.invasionFleetIDs, AIstate.opponentPlanetIDs, and AIstate.invasionTargetedPlanetIDs
+    InvasionAI.get_invasion_fleets()  # sets AIstate.opponentPlanetIDs, and AIstate.invasionTargetedPlanetIDs
 
     print "\n*** Updating Military Status ***\n"
     prioritiees_timer.start('Evaluating Military Status')

--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -709,7 +709,7 @@ def generate_production_orders():
                     use_sys = ([(-1, INVALID_ID)] + sorted([(dist, sys_id) for sys_id, dist in distance_map.items()]))[:2][-1][-1]  # kinda messy, but ensures a value
                 if use_sys != INVALID_ID:
                     try:
-                        use_loc = state.get_empire_planets_by_system(use_sys, include_outposts=True)[0]
+                        use_loc = state.get_empire_planets_by_system(use_sys)[0]
                         res = fo.issueEnqueueBuildingProductionOrder(building_name, use_loc)
                         print "Enqueueing %s at planet %d (%s) , with result %d" % (building_name, use_loc, universe.getPlanet(use_loc).name, res)
                         if res:
@@ -736,8 +736,7 @@ def generate_production_orders():
         if not bh_pilots and len(queued_building_locs) == 0 and (red_pilots or not already_got_one):
             use_loc = None
             nominal_home = homeworld or universe.getPlanet(
-                (red_pilots + state.get_empire_planets_by_system(AIstate.empireStars[fo.starType.red][0],
-                                                                 include_outposts=True))[0])
+                (red_pilots + state.get_empire_planets_by_system(AIstate.empireStars[fo.starType.red][0]))[0])
             distance_map = {}
             for sys_id in AIstate.empireStars.get(fo.starType.red, []):
                 if sys_id == INVALID_ID:
@@ -748,7 +747,7 @@ def generate_production_orders():
                     pass
             red_sys_list = sorted([(dist, sys_id) for sys_id, dist in distance_map.items()])
             for dist, sys_id in red_sys_list:
-                for loc in state.get_empire_planets_by_system(sys_id, include_outposts=True):
+                for loc in state.get_empire_planets_by_system(sys_id):
                     planet = universe.getPlanet(loc)
                     if planet and planet.speciesName not in ["", None]:
                         species = fo.getSpecies(planet.speciesName)
@@ -797,7 +796,7 @@ def generate_production_orders():
                 use_sys = ([(-1, INVALID_ID)] + sorted([(dist, sys_id) for sys_id, dist in distance_map.items()]))[:2][-1][-1]  # kinda messy, but ensures a value
             if use_sys != INVALID_ID:
                 try:
-                    use_loc = state.get_empire_planets_by_system(use_sys, include_outposts=True)[0]
+                    use_loc = state.get_empire_planets_by_system(use_sys)[0]
                     res = fo.issueEnqueueBuildingProductionOrder(building_name, use_loc)
                     print "Enqueueing %s at planet %d (%s) , with result %d" % (building_name, use_loc, universe.getPlanet(use_loc).name, res)
                     if res:
@@ -876,7 +875,7 @@ def generate_production_orders():
                 use_sys = ([(-1, INVALID_ID)] + sorted([(dist, sys_id) for sys_id, dist in distance_map.items()]))[:2][-1][-1]  # kinda messy, but ensures a value
             if use_sys != INVALID_ID:
                 try:
-                    use_loc = state.get_empire_planets_by_system(use_sys, include_outposts=True)[0]
+                    use_loc = state.get_empire_planets_by_system(use_sys)[0]
                     res = fo.issueEnqueueBuildingProductionOrder(building_name, use_loc)
                     print "Enqueueing %s at planet %d (%s) , with result %d" % (building_name, use_loc, universe.getPlanet(use_loc).name, res)
                     if res:
@@ -986,7 +985,7 @@ def generate_production_orders():
                 if (pid in queued_locs) or (building_name in [bld.buildingTypeName for bld in map(universe.getBuilding, planet.buildingIDs)]):
                     scanner_locs[planet.systemID] = True
         max_scanner_builds = max(1, int(empire.productionPoints / 30))
-        for sys_id in state.get_empire_planets_by_system(include_outposts=True).keys():
+        for sys_id in state.get_empire_planets_by_system().keys():
             if len(queued_locs) >= max_scanner_builds:
                 break
             if sys_id in scanner_locs:
@@ -999,7 +998,7 @@ def generate_production_orders():
             if not need_scanner:
                 continue
             build_locs = []
-            for pid in state.get_empire_planets_by_system(sys_id, include_outposts=True):
+            for pid in state.get_empire_planets_by_system(sys_id):
                 planet = universe.getPlanet(pid)
                 if not planet:
                     continue
@@ -1427,8 +1426,7 @@ def build_ship_facilities(bld_name, best_pilot_facilities, top_locs=None):
                            for pid in best_pilot_facilities.get("BLD_SHIPYARD_BASE", [])).difference(current_coverage)
         try_systems = open_systems.intersection(ColonisationAI.system_facilities.get(
             prereq_bldg, {}).get('systems', [])) if prereq_bldg else open_systems
-        try_locs = set(pid for sys_id in try_systems
-                       for pid in state.get_empire_planets_by_system(sys_id, include_outposts=True))
+        try_locs = set(pid for sys_id in try_systems for pid in state.get_empire_planets_by_system(sys_id))
     else:
         current_locs = best_pilot_facilities.get(bld_name, [])
         try_locs = set(best_pilot_facilities.get(prereq_bldg, [])).difference(
@@ -1456,8 +1454,7 @@ def build_ship_facilities(bld_name, best_pilot_facilities, top_locs=None):
         print "Enqueueing %s at planet %s , with result %d" % (bld_name, universe.getPlanet(pid), res)
         if res:
             num_queued += 1
-            already_covered.extend(state.get_empire_planets_by_system(universe.getPlanet(pid).systemID,
-                                                                      include_outposts=True))
+            already_covered.extend(state.get_empire_planets_by_system(universe.getPlanet(pid).systemID))
 
 
 def _print_production_queue(after_turn=False):

--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -1080,7 +1080,7 @@ def generate_production_orders():
 
     queued_clny_bld_locs = [element.locationID for element in production_queue if element.name.startswith('BLD_COL_')]
     colony_bldg_entries = ([entry for entry in foAI.foAIstate.colonisablePlanetIDs.items() if entry[1][0] > 60 and
-                           entry[0] not in queued_clny_bld_locs and entry[0] in ColonisationAI.empire_outpost_ids]
+                           entry[0] not in queued_clny_bld_locs and entry[0] in state.get_empire_outposts()]
                            [:PriorityAI.allottedColonyTargets+2])
     for entry in colony_bldg_entries:
         pid = entry[0]

--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -709,7 +709,7 @@ def generate_production_orders():
                     use_sys = ([(-1, INVALID_ID)] + sorted([(dist, sys_id) for sys_id, dist in distance_map.items()]))[:2][-1][-1]  # kinda messy, but ensures a value
                 if use_sys != INVALID_ID:
                     try:
-                        use_loc = AIstate.colonizedSystems[use_sys][0]
+                        use_loc = state.get_empire_planets_by_system(include_outposts=True)[use_sys][0]
                         res = fo.issueEnqueueBuildingProductionOrder(building_name, use_loc)
                         print "Enqueueing %s at planet %d (%s) , with result %d" % (building_name, use_loc, universe.getPlanet(use_loc).name, res)
                         if res:
@@ -736,7 +736,7 @@ def generate_production_orders():
         if not bh_pilots and len(queued_building_locs) == 0 and (red_pilots or not already_got_one):
             use_loc = None
             nominal_home = homeworld or universe.getPlanet(
-                (red_pilots + AIstate.colonizedSystems[AIstate.empireStars[fo.starType.red][0]])[0])
+                (red_pilots + state.get_empire_planets_by_system(include_outposts=True)[AIstate.empireStars[fo.starType.red][0]])[0])
             distance_map = {}
             for sys_id in AIstate.empireStars.get(fo.starType.red, []):
                 if sys_id == INVALID_ID:
@@ -747,7 +747,7 @@ def generate_production_orders():
                     pass
             red_sys_list = sorted([(dist, sys_id) for sys_id, dist in distance_map.items()])
             for dist, sys_id in red_sys_list:
-                for loc in AIstate.colonizedSystems[sys_id]:
+                for loc in state.get_empire_planets_by_system(include_outposts=True)[sys_id]:
                     planet = universe.getPlanet(loc)
                     if planet and planet.speciesName not in ["", None]:
                         species = fo.getSpecies(planet.speciesName)
@@ -755,7 +755,7 @@ def generate_production_orders():
                             break
                 else:
                     use_loc = list(
-                        set(red_pilots).intersection(AIstate.colonizedSystems[sys_id]) or AIstate.colonizedSystems[sys_id]
+                        set(red_pilots).intersection(state.get_empire_planets_by_system(include_outposts=True)[sys_id]) or state.get_empire_planets_by_system(include_outposts=True)[sys_id]
                     )[0]
                 if use_loc is not None:
                     break
@@ -795,7 +795,7 @@ def generate_production_orders():
                 use_sys = ([(-1, INVALID_ID)] + sorted([(dist, sys_id) for sys_id, dist in distance_map.items()]))[:2][-1][-1]  # kinda messy, but ensures a value
             if use_sys != INVALID_ID:
                 try:
-                    use_loc = AIstate.colonizedSystems[use_sys][0]
+                    use_loc = state.get_empire_planets_by_system(include_outposts=True)[use_sys][0]
                     res = fo.issueEnqueueBuildingProductionOrder(building_name, use_loc)
                     print "Enqueueing %s at planet %d (%s) , with result %d" % (building_name, use_loc, universe.getPlanet(use_loc).name, res)
                     if res:
@@ -874,7 +874,7 @@ def generate_production_orders():
                 use_sys = ([(-1, INVALID_ID)] + sorted([(dist, sys_id) for sys_id, dist in distance_map.items()]))[:2][-1][-1]  # kinda messy, but ensures a value
             if use_sys != INVALID_ID:
                 try:
-                    use_loc = AIstate.colonizedSystems[use_sys][0]
+                    use_loc = state.get_empire_planets_by_system(include_outposts=True)[use_sys][0]
                     res = fo.issueEnqueueBuildingProductionOrder(building_name, use_loc)
                     print "Enqueueing %s at planet %d (%s) , with result %d" % (building_name, use_loc, universe.getPlanet(use_loc).name, res)
                     if res:
@@ -984,7 +984,7 @@ def generate_production_orders():
                 if (pid in queued_locs) or (building_name in [bld.buildingTypeName for bld in map(universe.getBuilding, planet.buildingIDs)]):
                     scanner_locs[planet.systemID] = True
         max_scanner_builds = max(1, int(empire.productionPoints / 30))
-        for sys_id in AIstate.colonizedSystems:
+        for sys_id in state.get_empire_planets_by_system(include_outposts=True):
             if len(queued_locs) >= max_scanner_builds:
                 break
             if sys_id in scanner_locs:
@@ -997,7 +997,7 @@ def generate_production_orders():
             if not need_scanner:
                 continue
             build_locs = []
-            for pid in AIstate.colonizedSystems[sys_id]:
+            for pid in state.get_empire_planets_by_system(include_outposts=True)[sys_id]:
                 planet = universe.getPlanet(pid)
                 if not planet:
                     continue
@@ -1425,7 +1425,7 @@ def build_ship_facilities(bld_name, best_pilot_facilities, top_locs=None):
                            for pid in best_pilot_facilities.get("BLD_SHIPYARD_BASE", [])).difference(current_coverage)
         try_systems = open_systems.intersection(ColonisationAI.system_facilities.get(
             prereq_bldg, {}).get('systems', [])) if prereq_bldg else open_systems
-        try_locs = set(pid for sys_id in try_systems for pid in AIstate.colonizedSystems.get(sys_id, []))
+        try_locs = set(pid for sys_id in try_systems for pid in state.get_empire_planets_by_system(include_outposts=True).get(sys_id, []))
     else:
         current_locs = best_pilot_facilities.get(bld_name, [])
         try_locs = set(best_pilot_facilities.get(prereq_bldg, [])).difference(
@@ -1453,7 +1453,7 @@ def build_ship_facilities(bld_name, best_pilot_facilities, top_locs=None):
         print "Enqueueing %s at planet %s , with result %d" % (bld_name, universe.getPlanet(pid), res)
         if res:
             num_queued += 1
-            already_covered.extend(AIstate.colonizedSystems[universe.getPlanet(pid).systemID])
+            already_covered.extend(state.get_empire_planets_by_system(include_outposts=True)[universe.getPlanet(pid).systemID])
 
 
 def _print_production_queue(after_turn=False):

--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -238,7 +238,7 @@ def generate_production_orders():
     building_expense = 0.0
     building_ratio = foAI.foAIstate.character.preferred_building_ratio([0.4, 0.35, 0.30])
     print "Buildings present on all owned planets:"
-    for pid in list(state.get_inhabited_planets()) + list(AIstate.outpostIDs):
+    for pid in state.get_all_empire_planets():
         planet = universe.getPlanet(pid)
         if planet:
             print "%30s: %s" % (planet.name, [universe.getBuilding(bldg).name for bldg in planet.buildingIDs])
@@ -557,7 +557,7 @@ def generate_production_orders():
             asteroid_yards = {}
             shipyard_systems = {}
             builder_systems = {}
-            for pid in list(state.get_inhabited_planets()) + list(AIstate.outpostIDs):
+            for pid in state.get_all_empire_planets():
                 planet = universe.getPlanet(pid)
                 this_spec = planet.speciesName
                 sys_id = planet.systemID
@@ -638,7 +638,7 @@ def generate_production_orders():
     if empire.buildingTypeAvailable(building_name) and foAI.foAIstate.character.may_build_building(building_name):
         queued_building_locs = [element.locationID for element in production_queue if (element.name == building_name)]
         building_type = fo.getBuildingType(building_name)
-        for pid in list(state.get_inhabited_planets()) + list(AIstate.outpostIDs):  # TODO: check to ensure that a resource center exists in system, or GGG would be wasted
+        for pid in state.get_all_empire_planets():  # TODO: check to ensure that a resource center exists in system, or GGG would be wasted
             if pid not in queued_building_locs and building_type.canBeProduced(empire.empireID, pid):  # TODO: verify that canBeProduced() checks for preexistence of a barring building
                 planet = universe.getPlanet(pid)
                 if planet.systemID in systems_with_species:
@@ -664,7 +664,7 @@ def generate_production_orders():
     building_name = "BLD_SOL_ORB_GEN"
     if empire.buildingTypeAvailable(building_name) and foAI.foAIstate.character.may_build_building(building_name):
         already_got_one = 99
-        for pid in list(state.get_inhabited_planets()) + list(AIstate.outpostIDs):
+        for pid in state.get_all_empire_planets():
             planet = universe.getPlanet(pid)
             if planet and building_name in [bld.buildingTypeName for bld in map(universe.getBuilding, planet.buildingIDs)]:
                 system = universe.getSystem(planet.systemID)
@@ -728,7 +728,7 @@ def generate_production_orders():
         len(AIstate.empireStars.get(fo.starType.red, [])) > 0
     ):
         already_got_one = False
-        for pid in list(state.get_inhabited_planets()) + list(AIstate.outpostIDs):
+        for pid in state.get_all_empire_planets():
             planet = universe.getPlanet(pid)
             if planet and building_name in [bld.buildingTypeName for bld in map(universe.getBuilding, planet.buildingIDs)]:
                 already_got_one = True  # has been built, needs one turn to activate
@@ -776,7 +776,7 @@ def generate_production_orders():
     building_name = "BLD_BLACK_HOLE_POW_GEN"
     if empire.buildingTypeAvailable(building_name) and  foAI.foAIstate.character.may_build_building(building_name):
         already_got_one = False
-        for pid in list(state.get_inhabited_planets()) + list(AIstate.outpostIDs):
+        for pid in state.get_all_empire_planets():
             planet = universe.getPlanet(pid)
             if planet and building_name in [bld.buildingTypeName for bld in map(universe.getBuilding, planet.buildingIDs)]:
                 already_got_one = True
@@ -809,7 +809,7 @@ def generate_production_orders():
     building_name = "BLD_ENCLAVE_VOID"
     if empire.buildingTypeAvailable(building_name):
         already_got_one = False
-        for pid in list(state.get_inhabited_planets()) + list(AIstate.outpostIDs):
+        for pid in state.get_all_empire_planets():
             planet = universe.getPlanet(pid)
             if planet and building_name in [bld.buildingTypeName for bld in map(universe.getBuilding, planet.buildingIDs)]:
                 already_got_one = True
@@ -827,7 +827,7 @@ def generate_production_orders():
     building_name = "BLD_GENOME_BANK"
     if empire.buildingTypeAvailable(building_name):
         already_got_one = False
-        for pid in list(state.get_inhabited_planets()) + list(AIstate.outpostIDs):
+        for pid in state.get_all_empire_planets():
             planet = universe.getPlanet(pid)
             if planet and building_name in [bld.buildingTypeName for bld in map(universe.getBuilding, planet.buildingIDs)]:
                 already_got_one = True
@@ -850,7 +850,7 @@ def generate_production_orders():
         AIstate.empireStars.get(fo.starType.neutron, [])
     ):
         # building_type = fo.getBuildingType(building_name)
-        for pid in list(state.get_inhabited_planets()) + list(AIstate.outpostIDs):
+        for pid in state.get_all_empire_planets():
             planet = universe.getPlanet(pid)
             if planet:
                 building_names = [bld.buildingTypeName for bld in map(universe.getBuilding, planet.buildingIDs)]
@@ -979,7 +979,7 @@ def generate_production_orders():
     if empire.buildingTypeAvailable(building_name):
         queued_locs = [element.locationID for element in production_queue if (element.name == building_name)]
         scanner_locs = {}
-        for pid in list(state.get_inhabited_planets()) + list(AIstate.outpostIDs):
+        for pid in state.get_all_empire_planets():
             planet = universe.getPlanet(pid)
             if planet:
                 if (pid in queued_locs) or (building_name in [bld.buildingTypeName for bld in map(universe.getBuilding, planet.buildingIDs)]):
@@ -1066,7 +1066,7 @@ def generate_production_orders():
 
     building_name = "BLD_XENORESURRECTION_LAB"
     queued_xeno_lab_locs = [element.locationID for element in production_queue if element.name == building_name]
-    for pid in list(state.get_inhabited_planets())+list(AIstate.outpostIDs):
+    for pid in state.get_all_empire_planets():
         if pid in queued_xeno_lab_locs or not empire.canBuild(fo.buildType.building, building_name, pid):
             continue
         res = fo.issueEnqueueBuildingProductionOrder(building_name, pid)
@@ -1141,7 +1141,7 @@ def generate_production_orders():
             block_str, element.name, element.turnsLeft, element.allocation,
             element.progress, universe.getObject(element.locationID).name)
         if element.turnsLeft == -1:
-            if element.locationID not in list(state.get_inhabited_planets()) + AIstate.outpostIDs:
+            if element.locationID not in state.get_all_empire_planets():
                 # dequeue_list.append(queue_index) #TODO add assessment of recapture -- invasion target etc.
                 print "element %s will never be completed as stands and location %d no longer owned; could consider deleting from queue" % (element.name, element.locationID)  # TODO:
             else:
@@ -1534,7 +1534,7 @@ def find_automatic_historic_analyzer_candidates():
 
     # find possible locations
     possible_locations = set()
-    for pid in list(state.get_inhabited_planets()) + list(AIstate.outpostIDs):
+    for pid in state.get_all_empire_planets():
         planet = universe.getPlanet(pid)
         if not planet or planet.currentMeterValue(fo.meterType.targetPopulation) < 1:
             continue

--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -381,7 +381,7 @@ def generate_production_orders():
                 queued_defenses[sys_id] = queued_defenses.get(sys_id, 0) + element.blocksize*element.remaining
                 defense_allocation += element.allocation
         print "Queued Defenses:", [(ppstring(PlanetUtilsAI.sys_name_ids([sys_id])), num) for sys_id, num in queued_defenses.items()]
-        for sys_id, pids in state.get_empire_inhabited_planets_by_system().items():
+        for sys_id, pids in state.get_empire_planets_by_system(include_outposts=False).items():
             if foAI.foAIstate.systemStatus.get(sys_id, {}).get('fleetThreat', 1) > 0:
                 continue  # don't build orbital shields if enemy fleet present
             if defense_allocation > max_defense_portion * total_pp:
@@ -416,7 +416,7 @@ def generate_production_orders():
     system_colonies = {}
     colony_systems = {}
     empire_species = state.get_empire_planets_by_species()
-    systems_with_species = state.get_empire_inhabited_planets_by_system()
+    systems_with_species = state.get_empire_planets_by_system(include_outposts=False)
     for spec_name in ColonisationAI.empire_colonizers:
         if (len(ColonisationAI.empire_colonizers[spec_name]) == 0) and (spec_name in empire_species):  # not enough current shipyards for this species#TODO: also allow orbital incubators and/or asteroid ships
             for pid in state.get_empire_planets_with_species(spec_name):  # SP_EXOBOT may not actually have a colony yet but be in empireColonizers
@@ -1033,7 +1033,7 @@ def generate_production_orders():
 
         max_dock_builds = int(0.8 + empire.productionPoints/120.0)
         print "Considering building %s, found current and queued systems %s" % (building_name, ppstring(PlanetUtilsAI.sys_name_ids(cur_drydoc_sys.union(queued_sys))))
-        for sys_id, pids in state.get_empire_inhabited_planets_by_system().items():  # TODO: sort/prioritize in some fashion
+        for sys_id, pids in state.get_empire_planets_by_system(include_outposts=False).items():  # TODO: sort/prioritize in some fashion
             local_top_pilots = dict(top_pilot_systems.get(sys_id, []))
             local_drydocks = ColonisationAI.empire_dry_docks.get(sys_id, [])
             if len(queued_locs) >= max_dock_builds:

--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -118,10 +118,10 @@ def cur_best_military_design_rating():
 def get_best_ship_info(priority, loc=None):
     """ Returns 3 item tuple: designID, design, buildLocList."""
     if loc is None:
-        planet_ids = AIstate.popCtrIDs
+        planet_ids = state.get_inhabited_planets()
     elif isinstance(loc, list):
-        planet_ids = set(loc).intersection(AIstate.popCtrIDs)
-    elif isinstance(loc, int) and loc in AIstate.popCtrIDs:
+        planet_ids = set(loc).intersection(state.get_inhabited_planets())
+    elif isinstance(loc, int) and loc in state.get_inhabited_planets():
         planet_ids = [loc]
     else:  # problem
         return None, None, None
@@ -238,7 +238,7 @@ def generate_production_orders():
     building_expense = 0.0
     building_ratio = foAI.foAIstate.character.preferred_building_ratio([0.4, 0.35, 0.30])
     print "Buildings present on all owned planets:"
-    for pid in list(AIstate.popCtrIDs) + list(AIstate.outpostIDs):
+    for pid in list(state.get_inhabited_planets()) + list(AIstate.outpostIDs):
         planet = universe.getPlanet(pid)
         if planet:
             print "%30s: %s" % (planet.name, [universe.getBuilding(bldg).name for bldg in planet.buildingIDs])
@@ -465,7 +465,7 @@ def generate_production_orders():
             res = fo.issueRequeueProductionOrder(production_queue.size - 1, 0)  # move to front
             print "Requeueing BLD_SHIPYARD_BASE to front of build queue, with result %d" % res
 
-    pop_ctrs = list(AIstate.popCtrIDs)
+    pop_ctrs = list(state.get_inhabited_planets())
     red_popctrs = sorted([(ColonisationAI.pilot_ratings.get(pid, 0), pid) for pid in pop_ctrs
                           if colony_systems.get(pid, INVALID_ID) in AIstate.empireStars.get(fo.starType.red, [])],
                          reverse=True)
@@ -557,7 +557,7 @@ def generate_production_orders():
             asteroid_yards = {}
             shipyard_systems = {}
             builder_systems = {}
-            for pid in list(AIstate.popCtrIDs) + list(AIstate.outpostIDs):
+            for pid in list(state.get_inhabited_planets()) + list(AIstate.outpostIDs):
                 planet = universe.getPlanet(pid)
                 this_spec = planet.speciesName
                 sys_id = planet.systemID
@@ -638,7 +638,7 @@ def generate_production_orders():
     if empire.buildingTypeAvailable(building_name) and foAI.foAIstate.character.may_build_building(building_name):
         queued_building_locs = [element.locationID for element in production_queue if (element.name == building_name)]
         building_type = fo.getBuildingType(building_name)
-        for pid in list(AIstate.popCtrIDs) + list(AIstate.outpostIDs):  # TODO: check to ensure that a resource center exists in system, or GGG would be wasted
+        for pid in list(state.get_inhabited_planets()) + list(AIstate.outpostIDs):  # TODO: check to ensure that a resource center exists in system, or GGG would be wasted
             if pid not in queued_building_locs and building_type.canBeProduced(empire.empireID, pid):  # TODO: verify that canBeProduced() checks for preexistence of a barring building
                 planet = universe.getPlanet(pid)
                 if planet.systemID in systems_with_species:
@@ -664,7 +664,7 @@ def generate_production_orders():
     building_name = "BLD_SOL_ORB_GEN"
     if empire.buildingTypeAvailable(building_name) and foAI.foAIstate.character.may_build_building(building_name):
         already_got_one = 99
-        for pid in list(AIstate.popCtrIDs) + list(AIstate.outpostIDs):
+        for pid in list(state.get_inhabited_planets()) + list(AIstate.outpostIDs):
             planet = universe.getPlanet(pid)
             if planet and building_name in [bld.buildingTypeName for bld in map(universe.getBuilding, planet.buildingIDs)]:
                 system = universe.getSystem(planet.systemID)
@@ -728,7 +728,7 @@ def generate_production_orders():
         len(AIstate.empireStars.get(fo.starType.red, [])) > 0
     ):
         already_got_one = False
-        for pid in list(AIstate.popCtrIDs) + list(AIstate.outpostIDs):
+        for pid in list(state.get_inhabited_planets()) + list(AIstate.outpostIDs):
             planet = universe.getPlanet(pid)
             if planet and building_name in [bld.buildingTypeName for bld in map(universe.getBuilding, planet.buildingIDs)]:
                 already_got_one = True  # has been built, needs one turn to activate
@@ -776,7 +776,7 @@ def generate_production_orders():
     building_name = "BLD_BLACK_HOLE_POW_GEN"
     if empire.buildingTypeAvailable(building_name) and  foAI.foAIstate.character.may_build_building(building_name):
         already_got_one = False
-        for pid in list(AIstate.popCtrIDs) + list(AIstate.outpostIDs):
+        for pid in list(state.get_inhabited_planets()) + list(AIstate.outpostIDs):
             planet = universe.getPlanet(pid)
             if planet and building_name in [bld.buildingTypeName for bld in map(universe.getBuilding, planet.buildingIDs)]:
                 already_got_one = True
@@ -809,7 +809,7 @@ def generate_production_orders():
     building_name = "BLD_ENCLAVE_VOID"
     if empire.buildingTypeAvailable(building_name):
         already_got_one = False
-        for pid in list(AIstate.popCtrIDs) + list(AIstate.outpostIDs):
+        for pid in list(state.get_inhabited_planets()) + list(AIstate.outpostIDs):
             planet = universe.getPlanet(pid)
             if planet and building_name in [bld.buildingTypeName for bld in map(universe.getBuilding, planet.buildingIDs)]:
                 already_got_one = True
@@ -827,7 +827,7 @@ def generate_production_orders():
     building_name = "BLD_GENOME_BANK"
     if empire.buildingTypeAvailable(building_name):
         already_got_one = False
-        for pid in list(AIstate.popCtrIDs) + list(AIstate.outpostIDs):
+        for pid in list(state.get_inhabited_planets()) + list(AIstate.outpostIDs):
             planet = universe.getPlanet(pid)
             if planet and building_name in [bld.buildingTypeName for bld in map(universe.getBuilding, planet.buildingIDs)]:
                 already_got_one = True
@@ -850,7 +850,7 @@ def generate_production_orders():
         AIstate.empireStars.get(fo.starType.neutron, [])
     ):
         # building_type = fo.getBuildingType(building_name)
-        for pid in list(AIstate.popCtrIDs) + list(AIstate.outpostIDs):
+        for pid in list(state.get_inhabited_planets()) + list(AIstate.outpostIDs):
             planet = universe.getPlanet(pid)
             if planet:
                 building_names = [bld.buildingTypeName for bld in map(universe.getBuilding, planet.buildingIDs)]
@@ -916,7 +916,7 @@ def generate_production_orders():
     building_name = "BLD_CONC_CAMP"
     verbose_camp = False
     building_type = fo.getBuildingType(building_name)
-    for pid in AIstate.popCtrIDs:
+    for pid in state.get_inhabited_planets():
         planet = universe.getPlanet(pid)
         if not planet:
             continue
@@ -979,7 +979,7 @@ def generate_production_orders():
     if empire.buildingTypeAvailable(building_name):
         queued_locs = [element.locationID for element in production_queue if (element.name == building_name)]
         scanner_locs = {}
-        for pid in list(AIstate.popCtrIDs) + list(AIstate.outpostIDs):
+        for pid in list(state.get_inhabited_planets()) + list(AIstate.outpostIDs):
             planet = universe.getPlanet(pid)
             if planet:
                 if (pid in queued_locs) or (building_name in [bld.buildingTypeName for bld in map(universe.getBuilding, planet.buildingIDs)]):
@@ -1066,7 +1066,7 @@ def generate_production_orders():
 
     building_name = "BLD_XENORESURRECTION_LAB"
     queued_xeno_lab_locs = [element.locationID for element in production_queue if element.name == building_name]
-    for pid in list(AIstate.popCtrIDs)+list(AIstate.outpostIDs):
+    for pid in list(state.get_inhabited_planets())+list(AIstate.outpostIDs):
         if pid in queued_xeno_lab_locs or not empire.canBuild(fo.buildType.building, building_name, pid):
             continue
         res = fo.issueEnqueueBuildingProductionOrder(building_name, pid)
@@ -1099,7 +1099,7 @@ def generate_production_orders():
             print >> sys.stderr, "Failed enqueueing %s at planet %d (%s) , with result %d" % (building_name, pid, planet.name, res)
 
     building_name = "BLD_EVACUATION"
-    for pid in AIstate.popCtrIDs:
+    for pid in state.get_inhabited_planets():
         planet = universe.getPlanet(pid)
         if not planet:
             continue
@@ -1141,7 +1141,7 @@ def generate_production_orders():
             block_str, element.name, element.turnsLeft, element.allocation,
             element.progress, universe.getObject(element.locationID).name)
         if element.turnsLeft == -1:
-            if element.locationID not in AIstate.popCtrIDs + AIstate.outpostIDs:
+            if element.locationID not in list(state.get_inhabited_planets()) + AIstate.outpostIDs:
                 # dequeue_list.append(queue_index) #TODO add assessment of recapture -- invasion target etc.
                 print "element %s will never be completed as stands and location %d no longer owned; could consider deleting from queue" % (element.name, element.locationID)  # TODO:
             else:
@@ -1534,7 +1534,7 @@ def find_automatic_historic_analyzer_candidates():
 
     # find possible locations
     possible_locations = set()
-    for pid in list(AIstate.popCtrIDs) + list(AIstate.outpostIDs):
+    for pid in list(state.get_inhabited_planets()) + list(AIstate.outpostIDs):
         planet = universe.getPlanet(pid)
         if not planet or planet.currentMeterValue(fo.meterType.targetPopulation) < 1:
             continue

--- a/default/python/AI/ShipDesignAI.py
+++ b/default/python/AI/ShipDesignAI.py
@@ -54,6 +54,7 @@ import CombatRatingsAI
 import FleetUtilsAI
 from AIDependencies import INVALID_ID
 from freeorion_tools import UserString, tech_is_complete
+from turn_state import state
 
 from common.configure_logging import convenience_function_references_for_logger
 (debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
@@ -307,7 +308,7 @@ class ShipDesignCache(object):
             hulls_to_update.update(hullnames)
 
         # no need to update items we already cached in this turn
-        pids = AIstate.popCtrIDs
+        pids = list(state.get_inhabited_planets())
         if self.production_cost and pids:
             cached_items = set(self.production_cost[pids[0]].keys())
             parts_to_update -= cached_items
@@ -408,7 +409,7 @@ class ShipDesignCache(object):
         #
         self.hulls_for_planets.clear()
         self.parts_for_planets.clear()
-        inhabited_planets = AIstate.popCtrIDs
+        inhabited_planets = state.get_inhabited_planets()
         if not inhabited_planets:
             print "No inhabited planets found. The design process was aborted."
             return
@@ -1080,7 +1081,7 @@ class ShipDesigner(object):
         :type consider_fleet_count: bool
         """
         if loc is None:
-            planets = AIstate.popCtrIDs
+            planets = state.get_inhabited_planets()
         elif isinstance(loc, int):
             planets = [loc]
         elif isinstance(loc, list):

--- a/default/python/AI/freeorion_tools/_freeorion_tools.py
+++ b/default/python/AI/freeorion_tools/_freeorion_tools.py
@@ -239,7 +239,6 @@ class ReadOnlyDict(Mapping):
           print my_dict[k]
       for k, v in my_dict.iteritems():
           print k, v
-      my_dict['a'].append(3)  # this actually modifies the dict!
       my_dict[5] = 4  # throws TypeError
       del my_dict[1]  # throws TypeError
      """

--- a/default/python/AI/freeorion_tools/_freeorion_tools.py
+++ b/default/python/AI/freeorion_tools/_freeorion_tools.py
@@ -255,9 +255,6 @@ class ReadOnlyDict(Mapping):
     def __getitem__(self, item):
         return self._data[item]
 
-    def __contains__(self, item):
-        return item in self._data
-
     def __iter__(self):
         return iter(self._data)
 
@@ -266,6 +263,3 @@ class ReadOnlyDict(Mapping):
 
     def __str__(self):
         return str(self._data)
-
-    def __nonzero__(self):
-        return self.__len__() > 0

--- a/default/python/AI/freeorion_tools/_freeorion_tools.py
+++ b/default/python/AI/freeorion_tools/_freeorion_tools.py
@@ -3,6 +3,7 @@ import cProfile, pstats, StringIO
 import re
 import logging
 import sys
+from collections import Mapping
 from functools import wraps
 
 import freeOrionAIInterface as fo  # pylint: disable=import-error
@@ -218,3 +219,54 @@ def get_partial_visibility_turn(obj_id):
     """
     visibility_turns_map = fo.getUniverse().getVisibilityTurnsMap(obj_id, fo.empireID())
     return visibility_turns_map.get(fo.visibility.partial, -9999)
+
+
+class ReadOnlyDict(Mapping):
+    """A dict that offers only read access.
+
+     Note that if the values of the ReadOnlyDict are mutable,
+     then those objects may actually be changed.
+
+     It is strongly advised to store only immutable objects.
+     A slight protection is offered by checking for hashability of the values.
+
+      Example usage:
+      my_dict = ReadOnlyDict({1:2, 3:4})
+      print my_dict[1]
+      for k in my_dict:
+          print my_dict.get(k, -1)
+      for k in my_dict.keys():
+          print my_dict[k]
+      for k, v in my_dict.iteritems():
+          print k, v
+      my_dict['a'].append(3)  # this actually modifies the dict!
+      my_dict[5] = 4  # throws TypeError
+      del my_dict[1]  # throws TypeError
+     """
+
+    def __init__(self, *args, **kwargs):
+        self._data = dict(*args, **kwargs)
+        for k, v in self._data.iteritems():
+            try:
+                hash(v)
+            except TypeError:
+                print >> sys.stderr, "Tried to store a non-hashable value in ReadOnlyDict"
+                raise
+
+    def __getitem__(self, item):
+        return self._data[item]
+
+    def __contains__(self, item):
+        return item in self._data
+
+    def __iter__(self):
+        return iter(self._data)
+
+    def __len__(self):
+        return len(self._data)
+
+    def __str__(self):
+        return str(self._data)
+
+    def __nonzero__(self):
+        return self.__len__() > 0

--- a/default/python/AI/turn_state.py
+++ b/default/python/AI/turn_state.py
@@ -159,6 +159,9 @@ class State(object):
             result.setdefault(x.species_name, []).append(x.pid)
         return result
 
+    def get_number_of_colonies(self):
+        return len(self.get_inhabited_planets())
+
     @property
     def have_gas_giant(self):
         return self.__have_gas_giant

--- a/default/python/AI/turn_state.py
+++ b/default/python/AI/turn_state.py
@@ -95,7 +95,7 @@ class State(object):
             supply_tier = 0
         return self.__systems_by_jumps_to_supply.get(supply_tier, tuple())
 
-    def get_empire_inhabited_planets_by_system(self):
+    def get_empire_planets_by_system(self, include_outposts):
         """
         Return dict from system id to planet ids of empire with species.
 
@@ -103,7 +103,8 @@ class State(object):
         """
         # TODO: as currently used, is duplicative with combo of foAI.foAIstate.popCtrSystemIDs and foAI.foAIstate.colonizedSystems
         empire_id = fo.empireID()
-        empire_planets_with_species = (x for x in self.__planet_info.itervalues() if x.owner == empire_id and x.species_name)
+        empire_planets_with_species = (x for x in self.__planet_info.itervalues()
+                                       if x.owner == empire_id and (x.species_name or include_outposts))
         result = {}
         for x in empire_planets_with_species:
             result.setdefault(x.system_id, []).append(x.pid)

--- a/default/python/AI/turn_state.py
+++ b/default/python/AI/turn_state.py
@@ -101,7 +101,7 @@ class State(object):
 
         :rtype: dict[int, list[int]]
         """
-        # TODO: as currently used, is duplicative with combo of foAI.foAIstate.popCtrSystemIDs and foAI.foAIstate.colonizedSystems
+        # TODO: as currently used, is duplicative with combo of foAI.foAIstate.popCtrSystemIDs
         empire_id = fo.empireID()
         empire_planets_with_species = (x for x in self.__planet_info.itervalues()
                                        if x.owner == empire_id and (x.species_name or include_outposts))

--- a/default/python/AI/turn_state.py
+++ b/default/python/AI/turn_state.py
@@ -127,6 +127,14 @@ class State(object):
         empire_id = fo.empireID()
         return frozenset(x.pid for x in self.__planet_info.itervalues() if x.owner == empire_id and x.species_name)
 
+    def get_empire_outposts(self):
+        empire_id = fo.empireID()
+        return tuple(x.pid for x in self.__planet_info.itervalues() if x.owner == empire_id and x.species_name)
+
+    def get_all_empire_planets(self):
+        empire_id = fo.empireID()
+        return tuple(x.pid for x in self.__planet_info.itervalues() if x.owner == empire_id)
+
     def get_empire_planets_with_species(self, species_name):
         """
         Return tuple of empire planet ids with species.

--- a/default/python/AI/turn_state.py
+++ b/default/python/AI/turn_state.py
@@ -97,7 +97,7 @@ class State(object):
             supply_tier = 0
         return self.__systems_by_jumps_to_supply.get(supply_tier, tuple())
 
-    def get_empire_planets_by_system(self, include_outposts):
+    def get_empire_planets_by_system(self, sys_id=None, include_outposts=True):
         """
         Return dict from system id to planet ids of empire with species.
 
@@ -107,14 +107,15 @@ class State(object):
         if include_outposts not in self.__empire_planets_by_system:
             empire_id = fo.empireID()
             empire_planets = (x for x in self.__planet_info.itervalues()
-                               if x.owner == empire_id and (x.species_name or include_outposts))
+                              if x.owner == empire_id and (x.species_name or include_outposts))
             result = {}
             for x in empire_planets:
                 result.setdefault(x.system_id, []).append(x.pid)
             self.__empire_planets_by_system[include_outposts] = ReadOnlyDict(
                     {k: tuple(v) for k, v in result.iteritems()}
             )
-
+        if sys_id is not None:
+            return self.__empire_planets_by_system[include_outposts].get(sys_id, tuple())
         return self.__empire_planets_by_system[include_outposts]
 
     def get_inhabited_planets(self):

--- a/default/python/AI/turn_state.py
+++ b/default/python/AI/turn_state.py
@@ -129,7 +129,7 @@ class State(object):
 
     def get_empire_outposts(self):
         empire_id = fo.empireID()
-        return tuple(x.pid for x in self.__planet_info.itervalues() if x.owner == empire_id and x.species_name)
+        return tuple(x.pid for x in self.__planet_info.itervalues() if x.owner == empire_id and not x.species_name)
 
     def get_all_empire_planets(self):
         empire_id = fo.empireID()

--- a/default/python/AI/turn_state.py
+++ b/default/python/AI/turn_state.py
@@ -73,12 +73,13 @@ class State(object):
         :return: Supply value of a system or -99 if system is not connected
         :rtype: int
         """
-        retval = self.__system_supply.get(sys_id, -99)
-        if retval == -99:
+        retval = self.__system_supply.get(sys_id, None)
+        if retval is None:
             # This is only expected to happen if a system has no path to any supplied system.
             # As the current code should not allow such queries, this is logged as warning.
             # If future code breaks this assumption, feel free to adjust logging.
             warn("Queried supply value of a system not mapped in empire.supplyProjections().")
+            return -99  # pretend it is very far away from supply
         return retval
 
     def get_systems_by_supply_tier(self, supply_tier):

--- a/default/python/tests/AI/test_read_only_dict.py
+++ b/default/python/tests/AI/test_read_only_dict.py
@@ -1,0 +1,86 @@
+from freeorion_tools import ReadOnlyDict
+
+dict_content = {
+    1: -1,
+    1.09: 1.1,
+    'abc': 'xyz',
+    (1, 2, 3): ('a', 1, (1,2)),
+}
+
+
+def test_dict_content():
+    test_dict = ReadOnlyDict(dict_content)
+    assert test_dict.keys() == dict_content.keys()
+    assert test_dict.values() == dict_content.values()
+    assert test_dict.items() == dict_content.items()
+    assert len(test_dict) == len(dict_content)
+
+
+def test_membership():
+    test_dict = ReadOnlyDict(dict_content)
+    # check for membership checks and retrieval
+    for key, value in dict_content.iteritems():
+        assert key in test_dict
+        assert test_dict[key] == value
+        assert test_dict.get(key, -99999) == value
+
+def test_non_existing_keys():
+    test_dict = ReadOnlyDict(dict_content)
+    # check correct functionality if keys not in dict
+    assert 'INVALID_KEY' not in test_dict
+    assert test_dict.get('INVALID_KEY', -99999) == -99999
+    try:
+        _ = test_dict['INVALID_KEY']
+        raise AssertionError("Invalid key lookup didn't raise a KeyError")
+    except KeyError:
+        pass
+
+
+def test_str_conversion():
+    # check bool and str conversions
+    test_dict = ReadOnlyDict(dict_content)
+    assert str(test_dict) == str(dict_content)
+
+def test_bool():
+    test_dict = ReadOnlyDict(dict_content)
+    assert bool(test_dict)
+    assert test_dict
+    empty_dict = ReadOnlyDict()
+    assert not len(empty_dict)
+    assert not empty_dict
+
+
+def test_conversion_to_dict():
+    read_only_dict = ReadOnlyDict(dict_content)
+    normal_dict = dict(read_only_dict)
+    assert len(normal_dict) == len(dict_content)
+    assert normal_dict.items() == dict_content.items()
+
+
+def test_deletion():
+    test_dict = ReadOnlyDict(dict_content)
+    # check that dict can not be modified
+    try:
+        del test_dict[1]
+        raise AssertionError("Can delete items from the dict.")
+    except TypeError:
+        pass
+
+
+def test_setitem():
+    test_dict = ReadOnlyDict(dict_content)
+    try:
+        test_dict['INVALID_KEY'] = 1
+        raise AssertionError("Can add items to the dict.")
+    except TypeError:
+        pass
+    assert 'INVALID_KEY' not in test_dict
+
+
+def test_nonhashable_values():
+    # make sure can't store unhashable items (as heuristic for mutable items)
+    try:
+        _ = ReadOnlyDict({1: [1]})
+        raise AssertionError("Can store mutable items in dict.")
+    except TypeError:
+        pass


### PR DESCRIPTION
This PR aims to further reduce the clutter that exists in the AI code.

1) Move various functionality from ```ColonizationAI.survey_universe()``` to the ```turn_state``` module. The responsibility of updating the turn_state is given to ```FreeOrionAI.generateOrders()```. Further work is needed to eventually completely remove ```survey_universe()```.

2) Unify the usage of various module level variables by the function ```turn_state.State.get_empire_planets_by_system()```. By default, it returns a map from systems where the AI owns a planet to a tuple of planets in that system. The parameter ```include_outposts``` defaults to True but can be set to False to only consider inhabited planets.
Optionally, a system_id can be passed to the function. If specified, return the empire owned planets in the system instead of the whole map.
As the function gets called at various places, the map is cached with (mostly) only read-access. The data structure is safe enough to return without having to worry about outside modifications which are still possible but require special effort so are irrelevant for our work.

3) Inline or strictly remove multiple (cross-)module level variables that serve no purpose in today's code.