### PR TITLE
Convert savefile previews to use aynchronous client messaging.

### DIFF
--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -710,6 +710,27 @@ void ClientUI::ShowMultiPlayerLobbyWnd() {
 std::shared_ptr<MultiPlayerLobbyWnd> ClientUI::GetMultiPlayerLobbyWnd()
 { return m_multiplayer_lobby_wnd; }
 
+
+std::shared_ptr<SaveFileDialog> ClientUI::GetSaveFileDialog()
+{ return m_savefile_dialog; }
+
+std::string ClientUI::GetFilenameWithSaveFileDialog(
+    const SaveFileDialog::Purpose purpose, const SaveFileDialog::SaveType type)
+{
+    // There can only be a single savefile_dialog at a time, becauase it is for
+    // a specific purpose.
+    if (m_savefile_dialog)
+        return "";
+
+    m_savefile_dialog = GG::Wnd::Create<SaveFileDialog>(purpose, type);
+
+    m_savefile_dialog->Run();
+    auto filename = m_savefile_dialog->Result();
+
+    m_savefile_dialog = nullptr;
+    return filename;
+}
+
 void ClientUI::GetSaveGameUIData(SaveGameUIData& data) const {
     GetMapWndConst()->GetSaveGameUIData(data);
     m_ship_designs->Save(data);

--- a/UI/ClientUI.h
+++ b/UI/ClientUI.h
@@ -6,6 +6,7 @@
 
 #include <boost/filesystem/path.hpp>
 
+#include "SaveFileDialog.h"
 #include "../universe/EnumsFwd.h"
 #include "../util/Random.h"
 
@@ -42,6 +43,9 @@ public:
     std::shared_ptr<IntroScreen>            GetIntroScreen();                           //!< Returns the intro screen / splash window.
     std::shared_ptr<MultiPlayerLobbyWnd>    GetMultiPlayerLobbyWnd();                   //!< Returns the multiplayer lobby window.
 
+    /** Returns a perhaps nullptr to any existing SaveFileDialog*/
+    std::shared_ptr<SaveFileDialog>         GetSaveFileDialog();
+
     ShipDesignManager* GetShipDesignManager() { return m_ship_designs.get(); };
 
     void    GetSaveGameUIData(SaveGameUIData& data) const;              //!< populates the relevant UI state that should be restored after a save-and-load cycle
@@ -53,6 +57,13 @@ public:
      **/
     void    ShowIntroScreen();
     void    ShowMultiPlayerLobbyWnd();
+
+    /** Creates a SaveFileDialog with \p purpose, Save or Load and \p type,
+        SinglePlayer or MultiPlayer if one does not already exist. Returns the
+        filename provided by the player, if any.*/
+    std::string GetFilenameWithSaveFileDialog(const SaveFileDialog::Purpose purpose,
+                                              const SaveFileDialog::SaveType type);
+
     void    InitTurn(int turn_number);                                  //!< resets all active controls to use the latest data when it has been changed at the beginning of a new turn
     void    RestoreFromSaveData(const SaveGameUIData& elem);            //!< restores the UI state that was saved in an earlier call to GetSaveGameUIData().
 
@@ -229,6 +240,7 @@ private:
     std::shared_ptr<PlayerListWnd>          m_player_list_wnd;      //!< the players list
     std::shared_ptr<IntroScreen>            m_intro_screen;         //!< splash screen / main menu when starting program
     std::shared_ptr<MultiPlayerLobbyWnd>    m_multiplayer_lobby_wnd;//!< the multiplayer lobby
+    std::shared_ptr<SaveFileDialog>         m_savefile_dialog = nullptr;
 
     PrefixedTextures    m_prefixed_textures;
 

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -141,7 +141,7 @@ namespace {
                 return ReportFileError(file);
 
             ofs << ss;
-            TraceLogger() << "Wrote to " << PathString(file);
+            TraceLogger() << "Wrote to " << PathToString(file);
 
         } catch (const boost::filesystem::filesystem_error& e) {
             ErrorLogger() << "Error writing to file.  Exception: " << ": " << e.what();
@@ -166,7 +166,7 @@ namespace {
         std::string file_name =
             DESIGN_FILENAME_PREFIX + boost::uuids::to_string(design.UUID()) + DESIGN_FILENAME_EXTENSION;
 
-        return boost::filesystem::absolute(PathString(designs_dir_path / file_name));
+        return boost::filesystem::absolute(PathToString(designs_dir_path / file_name));
     }
 
 
@@ -422,7 +422,7 @@ namespace {
         std::string file_name = DESIGN_MANIFEST_PREFIX + DESIGN_FILENAME_EXTENSION;
 
         boost::filesystem::path file =
-            boost::filesystem::absolute(PathString(designs_dir_path / file_name));
+            boost::filesystem::absolute(PathToString(designs_dir_path / file_name));
 
         std::stringstream ss;
         ss << DESIGN_MANIFEST_PREFIX << "\n";

--- a/UI/InGameMenu.cpp
+++ b/UI/InGameMenu.cpp
@@ -154,10 +154,6 @@ void InGameMenu::Save() {
         return;
     }
 
-    const std::string SAVE_GAME_EXTENSION =
-        app->SinglePlayerGame() ?
-        SP_SAVE_FILE_EXTENSION : MP_SAVE_FILE_EXTENSION;
-
     try {
         std::string filename;
 

--- a/UI/InGameMenu.cpp
+++ b/UI/InGameMenu.cpp
@@ -164,7 +164,9 @@ void InGameMenu::Save() {
         // When saving in multiplayer, you cannot see the old saves or
         // browse directories, only give a save file name.
         DebugLogger() << "... running save file dialog";
-        auto dlg = GG::Wnd::Create<SaveFileDialog>(app->SinglePlayerGame() ? SAVE_GAME_EXTENSION : MP_SAVE_FILE_EXTENSION);
+        auto dlg = GG::Wnd::Create<SaveFileDialog>(
+            SaveFileDialog::Purpose::Save,
+            app->SinglePlayerGame() ? SaveFileDialog::SaveType::SinglePlayer : SaveFileDialog::SaveType::MultiPlayer);
         dlg->Run();
         filename = dlg->Result();
 

--- a/UI/InGameMenu.cpp
+++ b/UI/InGameMenu.cpp
@@ -155,16 +155,12 @@ void InGameMenu::Save() {
     }
 
     try {
-        std::string filename;
-
         // When saving in multiplayer, you cannot see the old saves or
         // browse directories, only give a save file name.
         DebugLogger() << "... running save file dialog";
-        auto dlg = GG::Wnd::Create<SaveFileDialog>(
+        auto filename = ClientUI::GetClientUI()->GetFilenameWithSaveFileDialog(
             SaveFileDialog::Purpose::Save,
             app->SinglePlayerGame() ? SaveFileDialog::SaveType::SinglePlayer : SaveFileDialog::SaveType::MultiPlayer);
-        dlg->Run();
-        filename = dlg->Result();
 
         if (!filename.empty()) {
             if (!app->CanSaveNow()) {

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -703,7 +703,8 @@ void OptionsWnd::CompleteConstruction() {
     // Directories tab
     current_page = CreatePage(UserString("OPTIONS_PAGE_DIRECTORIES"));
     DirectoryOption(current_page, 0, "resource-dir", UserString("OPTIONS_FOLDER_SETTINGS"), GetRootDataDir());  // GetRootDataDir() returns the default browse path when modifying this directory option.  the actual default directory (before modifying) is gotten from the specified option name "resource-dir"
-    DirectoryOption(current_page, 0, "save-dir",     UserString("OPTIONS_FOLDER_SAVE"),     GetUserDataDir());
+    DirectoryOption(current_page, 0, "save-dir", UserString("OPTIONS_FOLDER_SAVE"),     GetUserDataDir());
+    DirectoryOption(current_page, 0, "server-save-dir", UserString("OPTIONS_SERVER_FOLDER_SAVE"),     GetUserDataDir());
     m_tabs->SetCurrentWnd(0);
 
     // Logging page

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -109,17 +109,6 @@ namespace {
         return text;
     }
 
-    std::string GenericPathString(const fs::path& path) {
-#ifndef FREEORION_WIN32
-        return path.generic_string();
-#else
-        fs::path::string_type native_string = path.generic_wstring();
-        std::string retval;
-        utf8::utf16to8(native_string.begin(), native_string.end(), std::back_inserter(retval));
-        return retval;
-#endif
-    }
-
     bool Prompt(const std::string& question){
         std::shared_ptr<GG::Font> font = ClientUI::GetFont();
         auto prompt = GG::Wnd::Create<GG::ThreeButtonDlg>(

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -514,8 +514,12 @@ public:
     void LoadLocalSaveGamePreviews(const fs::path& path, const std::string& extension) {
         LoadDirectories(FindLocalRelativeDirs(path));
 
+        auto abs_path = path;
+        if (abs_path.is_relative())
+            abs_path = GetSaveDir() / path;
+
         vector<FullPreview> previews;
-        ::LoadSaveGamePreviews(path, extension, previews);
+        ::LoadSaveGamePreviews(abs_path, extension, previews);
         LoadSaveGamePreviews(previews);
     }
 
@@ -661,13 +665,11 @@ void SaveFileDialog::Init() {
     auto filename_label = GG::Wnd::Create<CUILabel>(UserString("SAVE_FILENAME"), GG::FORMAT_NOWRAP);
     auto directory_label = GG::Wnd::Create<CUILabel>(UserString("SAVE_DIRECTORY"), GG::FORMAT_NOWRAP);
 
-    DebugLogger() << "pathstring: " << PathToString(GetSaveDir());
-    m_current_dir_edit = GG::Wnd::Create<CUIEdit>(PathToString(GetSaveDir()));
-
     m_layout->Add(directory_label, 0, 0);
 
     std::shared_ptr<GG::Font> font = ClientUI::GetFont();
     if (!m_server_previews) {
+        m_current_dir_edit = GG::Wnd::Create<CUIEdit>(PathToString(GetSaveDir()));
         m_layout->Add(m_current_dir_edit, 0, 1, 1, 3);
 
         auto delete_btn = Wnd::Create<CUIButton>(UserString("DELETE"));
@@ -680,6 +682,7 @@ void SaveFileDialog::Init() {
         m_layout->SetMinimumColumnWidth(3, std::max( cancel_btn->MinUsableSize().x,
                                         delete_btn->MinUsableSize().x) + SAVE_FILE_BUTTON_MARGIN);
     } else {
+        m_current_dir_edit = GG::Wnd::Create<CUIEdit>(SERVER_LABEL + "/.");
         m_layout->Add(m_current_dir_edit, 0, 1, 1, 3);
         GG::Flags<GG::TextFormat> fmt = GG::FORMAT_NONE;
         std::string server_label(SERVER_LABEL+SERVER_LABEL+SERVER_LABEL);

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -566,12 +566,6 @@ public:
                 DebugLogger() << "SaveFileDialog::LoadDirectories name: " << utf8_dir_name << " valid UTF-8: " << IsValidUTF8(utf8_dir_name);
                 auto row = GG::Wnd::Create<SaveFileDirectoryRow>(m_visible_columns, utf8_dir_name);
                 Insert(row);
-
-                //boost::filesystem::path::string_type path_native = last_bit_of_path.native();
-                //std::string path_string;
-                //utf8::utf16to8(path_native.begin(), path_native.end(), std::back_inserter(path_string));
-                //DebugLogger() << "SaveFileDialog::LoadDirectories name: " << path_string << " valid UTF-8: " << IsValidUTF8(path_string);
-                //Insert(GG::Wnd::Create<SaveFileDirectoryRow>(path_string));
             }
         }
     }

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -969,26 +969,23 @@ void SaveFileDialog::SetPreviewList(const fs::path& path) {
 
 void SaveFileDialog::SetPreviewList(const PreviewInformation& preview_info) {
     auto setup_func = [this, &preview_info]() {
-        m_file_list->LoadSaveGamePreviews(preview_info.previews);
-        m_remote_dir_dropdown->Clear();
-        SetDirPath(preview_info.folder);
 
-        auto row = GG::Wnd::Create<GG::DropDownList::Row>();
-        row->push_back(GG::Wnd::Create<CUILabel>(SERVER_LABEL));
-        m_remote_dir_dropdown->Insert(row);
-
+        // Prefix directories with the server label;
+        std::vector<std::string> prefixed_subdirs;
         for (const std::string& subdir : preview_info.subdirectories) {
-            auto row = GG::Wnd::Create<GG::DropDownList::Row>();
             if (subdir.find("/") == 0) {
-                row->push_back(GG::Wnd::Create<CUILabel>(SERVER_LABEL + subdir));
+                prefixed_subdirs.push_back(SERVER_LABEL + subdir);
             } else if(subdir.find("./") == 0) {
-                row->push_back(GG::Wnd::Create<CUILabel>(SERVER_LABEL + subdir.substr(1)));
+                prefixed_subdirs.push_back(SERVER_LABEL + subdir.substr(1));
             } else {
-                row->push_back(GG::Wnd::Create<CUILabel>(SERVER_LABEL + "/" + subdir));
+                prefixed_subdirs.push_back(SERVER_LABEL + "/" + subdir);
             }
-
-            m_remote_dir_dropdown->Insert(row);
         }
+        m_file_list->LoadDirectories(prefixed_subdirs);
+
+        m_file_list->LoadSaveGamePreviews(preview_info.previews);
+        // m_remote_dir_dropdown->Clear();
+        SetDirPath(preview_info.folder);
     };
 
     SetPreviewListCore(setup_func);

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -936,7 +936,7 @@ void SaveFileDialog::SetPreviewList(const PreviewInformation& preview_info) {
         // Prefix directories with the server label;
         std::vector<std::string> prefixed_subdirs;
         for (const std::string& subdir : preview_info.subdirectories) {
-            if (subdir.find("/") == 0) {
+            if (subdir.find("/") == 0 || subdir.find("\\") == 0) {
                 prefixed_subdirs.push_back(SERVER_LABEL + subdir);
             } else if(subdir.find("./") == 0) {
                 prefixed_subdirs.push_back(SERVER_LABEL + subdir.substr(1));
@@ -1037,11 +1037,11 @@ void SaveFileDialog::SetDirPath(const string& path) {
         dirname = GenericPathString(fs::path(path));
         // Indicate that the path is on the server
         if (path.find("./") == 0) {
-            dirname = SERVER_LABEL + path.substr(1);
+            dirname = SERVER_LABEL + dirname.substr(1);
         } else if (path.find(SERVER_LABEL) == 0) {
             // Already has label. No need to change
         } else {
-            dirname = SERVER_LABEL + "/" + path;
+            dirname = SERVER_LABEL + "/" + dirname;
         }
     } else {
         // Normalize path

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -823,14 +823,14 @@ void SaveFileDialog::Confirm() {
     DebugLogger() << "SaveFileDialog::Confirm: Confirming";
 
     if (!CheckChoiceValidity()) {
-        DebugLogger() << "SaveFileDialog::Confirm: Invalid choice. abort.";
+        WarnLogger() << "SaveFileDialog::Confirm: Invalid choice. abort.";
         return;
     }
 
     /// Check if we chose a directory
     std::string choice = m_name_edit->Text();
     if (choice.empty()) {
-        DebugLogger() << "SaveFileDialog::Confirm: Returning no file.";
+        WarnLogger() << "SaveFileDialog::Confirm: Returning no file.";
         CloseClicked();
         return;
     }
@@ -845,13 +845,18 @@ void SaveFileDialog::Confirm() {
     DebugLogger() << "chosen_full_path PathString: " << PathString(chosen_full_path) << " valid utf-8: " << IsValidUTF8(PathString(chosen_full_path));
     DebugLogger() << "chosen_full_path is directory? : " << fs::is_directory(chosen_full_path);
 
-
     if (fs::is_directory(chosen_full_path)) {
         DebugLogger() << "SaveFileDialog::Confirm: " << PathString(chosen_full_path) << " is a directory. Listing content.";
         UpdateDirectory(PathString(chosen_full_path));
         return;
+    }
 
-    } else if (!m_load_only) {
+    if (m_server_previews && choice_path.generic_string().find(SERVER_LABEL) == 0) {
+        UpdateDirectory(PathString(choice_path));
+        return;
+    }
+
+    if (!m_load_only) {
         // append appropriate extension if invalid
         std::string chosen_ext = fs::path(chosen_full_path).extension().string();
         if (chosen_ext != m_extension) {

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -544,7 +544,7 @@ public:
         for (fs::directory_iterator it(path); it != end_it; ++it) {
             if (fs::is_directory(it->path())) {
                 fs::path last_bit_of_path = it->path().filename();
-                std::string utf8_dir_name = PathString(last_bit_of_path);
+                std::string utf8_dir_name = PathToString(last_bit_of_path);
                 DebugLogger() << "SaveFileDialog::FindLocalRelativeDirs name: " << utf8_dir_name
                               << " valid UTF-8: " << IsValidUTF8(utf8_dir_name);
                 dirs.push_back(utf8_dir_name);
@@ -661,8 +661,8 @@ void SaveFileDialog::Init() {
     auto filename_label = GG::Wnd::Create<CUILabel>(UserString("SAVE_FILENAME"), GG::FORMAT_NOWRAP);
     auto directory_label = GG::Wnd::Create<CUILabel>(UserString("SAVE_DIRECTORY"), GG::FORMAT_NOWRAP);
 
-    DebugLogger() << "pathstring: " << PathString(GetSaveDir());
-    m_current_dir_edit = GG::Wnd::Create<CUIEdit>(PathString(GetSaveDir()));
+    DebugLogger() << "pathstring: " << PathToString(GetSaveDir());
+    m_current_dir_edit = GG::Wnd::Create<CUIEdit>(PathToString(GetSaveDir()));
 
     m_layout->Add(directory_label, 0, 0);
 
@@ -815,20 +815,20 @@ void SaveFileDialog::Confirm() {
     DebugLogger() << "choice: " << choice << " valid utf-8: " << IsValidUTF8(choice);
 
     fs::path current_dir = FilenameToPath(GetDirPath());
-    DebugLogger() << "current dir PathString: " << PathString(current_dir) << " valid utf-8: " << IsValidUTF8(PathString(current_dir));
+    DebugLogger() << "current dir PathString: " << PathToString(current_dir) << " valid utf-8: " << IsValidUTF8(PathToString(current_dir));
 
     fs::path chosen_full_path = current_dir / choice_path;
-    DebugLogger() << "chosen_full_path PathString: " << PathString(chosen_full_path) << " valid utf-8: " << IsValidUTF8(PathString(chosen_full_path));
+    DebugLogger() << "chosen_full_path PathString: " << PathToString(chosen_full_path) << " valid utf-8: " << IsValidUTF8(PathToString(chosen_full_path));
     DebugLogger() << "chosen_full_path is directory? : " << fs::is_directory(chosen_full_path);
 
     if (fs::is_directory(chosen_full_path)) {
-        DebugLogger() << "SaveFileDialog::Confirm: " << PathString(chosen_full_path) << " is a directory. Listing content.";
-        UpdateDirectory(PathString(chosen_full_path));
+        DebugLogger() << "SaveFileDialog::Confirm: " << PathToString(chosen_full_path) << " is a directory. Listing content.";
+        UpdateDirectory(PathToString(chosen_full_path));
         return;
     }
 
     if (m_server_previews && choice_path.generic_string().find(SERVER_LABEL) == 0) {
-        UpdateDirectory(PathString(choice_path));
+        UpdateDirectory(choice);
         return;
     }
 
@@ -840,7 +840,7 @@ void SaveFileDialog::Confirm() {
             chosen_full_path += m_extension;
             m_name_edit->SetText(m_name_edit->Text() + m_extension);
         }
-        DebugLogger() << "SaveFileDialog::Confirm: File " << PathString(chosen_full_path) << " chosen.";
+        DebugLogger() << "SaveFileDialog::Confirm: File " << PathToString(chosen_full_path) << " chosen.";
         // If not loading and file exists(and is regular file), ask to confirm override
         if (fs::is_regular_file(chosen_full_path)) {
             std::string question = str((FlexibleFormat(UserString("SAVE_REALLY_OVERRIDE")) % choice));
@@ -1048,7 +1048,7 @@ void SaveFileDialog::SetDirPath(const string& path) {
         fs::path path(dirname);
         if (fs::is_directory(path)) {
             path = fs::canonical(path);
-            dirname = PathString(path);
+            dirname = PathToString(path);
         }
     }
     m_current_dir_edit->SetText(dirname);
@@ -1064,5 +1064,5 @@ std::string SaveFileDialog::Result() const {
     fs::path current_dir = FilenameToPath(GetDirPath());
     fs::path chosen_full_path = current_dir / choice_path;
 
-    return PathString(chosen_full_path);
+    return PathToString(chosen_full_path);
 }

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -944,10 +944,7 @@ void SaveFileDialog::UpdatePreviewList() {
     if (!m_server_previews) {
         SetPreviewList(FilenameToPath(GetDirPath()));
     } else {
-        DebugLogger() << "Requesting save previews from server";
-        PreviewInformation preview_info;
-        HumanClientApp::GetApp()->RequestSavePreviews(GetDirPath(), preview_info);
-        SetPreviewList(preview_info);
+        HumanClientApp::GetApp()->RequestSavePreviews(GetDirPath());
     }
 }
 

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -660,7 +660,7 @@ void SaveFileDialog::Init() {
 
     auto filename_label = GG::Wnd::Create<CUILabel>(UserString("SAVE_FILENAME"), GG::FORMAT_NOWRAP);
     auto directory_label = GG::Wnd::Create<CUILabel>(UserString("SAVE_DIRECTORY"), GG::FORMAT_NOWRAP);
-    //std::cout << "pathstrnig: " << PathString(GetSaveDir()) << std::endl;
+
     DebugLogger() << "pathstring: " << PathString(GetSaveDir());
     m_current_dir_edit = GG::Wnd::Create<CUIEdit>(PathString(GetSaveDir()));
 
@@ -910,7 +910,6 @@ void SaveFileDialog::SelectionChanged(const GG::ListBox::SelectionSet& selection
 }
 
 void SaveFileDialog::UpdateDirectory(const std::string& newdir) {
-    //std::cout << "SaveFileDialog::UpdateDirectory newdir: " << newdir << std::endl;
     SetDirPath(newdir);
     UpdatePreviewList();
 }
@@ -1003,7 +1002,6 @@ void SaveFileDialog::DirectoryEdited(const string& filename)
 std::string SaveFileDialog::GetDirPath() const {
     const std::string& path_edit_text = m_current_dir_edit->Text();
 
-    //std::cout << "SaveFileDialog::GetDirPath text: " << path_edit_text << " valid UTF-8: " << utf8::is_valid(path_edit_text.begin(), path_edit_text.end()) << std::endl;
     //DebugLogger() << "SaveFileDialog::GetDirPath text: " << path_edit_text << " valid UTF-8: " << utf8::is_valid(path_edit_text.begin(), path_edit_text.end());
     if (!m_server_previews) {
         return path_edit_text;
@@ -1026,7 +1024,6 @@ std::string SaveFileDialog::GetDirPath() const {
     } else {
         // Translate the server label into the standard relative path marker the server understands
         std::string retval = "." + dir.substr(SERVER_LABEL.size());
-        //std::cout << "SaveFileDialog::GetDirPath retval: " << retval << " valid UTF-8: " << utf8::is_valid(retval.begin(), retval.end()) << std::endl;
         DebugLogger() << "SaveFileDialog::GetDirPath retval: " << retval << " valid UTF-8: " << utf8::is_valid(retval.begin(), retval.end());
         return retval;
     }

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -632,25 +632,15 @@ private:
     }
 };
 
-SaveFileDialog::SaveFileDialog (const std::string& extension, bool load) :
+SaveFileDialog::SaveFileDialog(const Purpose purpose /* =Purpose::Load*/,
+                               const SaveType type /*= SaveType::SinglePlayer*/) :
     CUIWnd(UserString("GAME_MENU_SAVE_FILES"),
            GG::INTERACTIVE | GG::DRAGABLE | GG::MODAL | GG::RESIZABLE,
-           SAVE_FILE_WND_NAME)
-{
-    m_extension = extension;
-    m_load_only = load;
-    m_server_previews = false;
-}
-
-SaveFileDialog::SaveFileDialog (bool load) :
-    CUIWnd(UserString("GAME_MENU_SAVE_FILES"),
-           GG::INTERACTIVE | GG::DRAGABLE | GG::MODAL | GG::RESIZABLE,
-           SAVE_FILE_WND_NAME)
-{
-    m_load_only = load;
-    m_server_previews = true;
-    m_extension = MP_SAVE_FILE_EXTENSION;
-}
+           SAVE_FILE_WND_NAME),
+    m_extension((type == SaveType::SinglePlayer) ? SP_SAVE_FILE_EXTENSION : MP_SAVE_FILE_EXTENSION),
+    m_load_only(purpose == Purpose::Load),
+    m_server_previews((type == SaveType::SinglePlayer) ? false : true)
+{}
 
 void SaveFileDialog::CompleteConstruction() {
     CUIWnd::CompleteConstruction();

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -1023,7 +1023,7 @@ std::string SaveFileDialog::GetDirPath() const {
         return ".";
     } else {
         // Translate the server label into the standard relative path marker the server understands
-        std::string retval = "." + dir.substr(SERVER_LABEL.size());
+        auto retval = GenericPathString(fs::path("." + dir.substr(SERVER_LABEL.size())));
         DebugLogger() << "SaveFileDialog::GetDirPath retval: " << retval << " valid UTF-8: " << utf8::is_valid(retval.begin(), retval.end());
         return retval;
     }

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -1024,20 +1024,16 @@ std::string SaveFileDialog::GetDirPath() const {
     if (dir.length() < SERVER_LABEL.size()) {
         ErrorLogger() << "SaveFileDialog::GetDirPath: Error decorating directory for server: not long enough";
         return ".";
-    } else {
-        // Translate the server label into the standard relative path marker the server understands
-        auto retval = GenericPathString(fs::path("." + dir.substr(SERVER_LABEL.size())));
-        DebugLogger() << "SaveFileDialog::GetDirPath retval: " << retval << " valid UTF-8: " << utf8::is_valid(retval.begin(), retval.end());
-        return retval;
     }
+
+    auto retval = "." + dir.substr(SERVER_LABEL.size());
+    DebugLogger() << "SaveFileDialog::GetDirPath retval: " << retval << " valid UTF-8: " << utf8::is_valid(retval.begin(), retval.end());
+    return retval;
 }
 
 void SaveFileDialog::SetDirPath(const string& path) {
     std::string dirname = path;
     if (m_server_previews) {
-        // convert the path string into the boost filesystem "generic" format
-        // to allow scanning for delimeters like "/"
-        dirname = GenericPathString(fs::path(path));
         // Indicate that the path is on the server
         if (path.find("./") == 0) {
             dirname = SERVER_LABEL + dirname.substr(1);

--- a/UI/SaveFileDialog.h
+++ b/UI/SaveFileDialog.h
@@ -57,7 +57,16 @@ private:
     void UpdateDirectory(const std::string& newdir);                    //!< Change current directory
     void DirectoryDropdownSelect(GG::DropDownList::iterator selection); //!< On remote directory select
 
+    /** Either directly update from the local save directory, or request the
+        server for save preview information*/
     void UpdatePreviewList();
+    /** Update the preview list from a local save directory*/
+    void SetPreviewList(const boost::filesystem::path& path);
+    /** Update the previews with \p preview_information*/
+    void SetPreviewList(const PreviewInformation& preview_info);
+    /** Update the previews with preview info set by \p setup_preview_info*/
+    void SetPreviewListCore(const std::function<void ()>& setup_preview_info);
+
     bool CheckChoiceValidity();                         //!< Disables confirm if filename invalid. Returns false if not valid.
     void FileNameEdited(const std::string& filename);   //!< Called when the filename changes
     void DirectoryEdited(const std::string& filename);  //!< Called when the directory text changes

--- a/UI/SaveFileDialog.h
+++ b/UI/SaveFileDialog.h
@@ -21,14 +21,11 @@ struct PreviewInformation;
  */
 class SaveFileDialog : public CUIWnd {
 public:
-    /** \name Structors */ //@{
-    /// Constructor for local browsing
-    /// @param extension The extension to enforce on the file name
-    /// @param load If set to true, only allow choosing existing files
-    SaveFileDialog(const std::string& extension, bool load = false);
+    enum class Purpose {Save, Load};
+    enum class SaveType {SinglePlayer, MultiPlayer};
 
-    /// Contruct for getting the previews from the server
-    SaveFileDialog(bool load = false);
+    /** \name Structors */ //@{
+    SaveFileDialog(const Purpose purpose = Purpose::Load, const SaveType type = SaveType::SinglePlayer);
 
     void CompleteConstruction() override;
     ~SaveFileDialog();

--- a/UI/SaveFileDialog.h
+++ b/UI/SaveFileDialog.h
@@ -35,6 +35,9 @@ public:
     void ModalInit() override;
 
     void KeyPress(GG::Key key, std::uint32_t key_code_point, GG::Flags<GG::ModKey> mod_keys) override;
+
+    /** Update the previews with \p preview_information*/
+    void SetPreviewList(const PreviewInformation& preview_info);
     //@}
 
     /// Get the chosen save files full path
@@ -59,8 +62,6 @@ private:
     void UpdatePreviewList();
     /** Update the preview list from a local save directory*/
     void SetPreviewList(const boost::filesystem::path& path);
-    /** Update the previews with \p preview_information*/
-    void SetPreviewList(const PreviewInformation& preview_info);
     /** Update the previews with preview info set by \p setup_preview_info*/
     void SetPreviewListCore(const std::function<void ()>& setup_preview_info);
 

--- a/UI/SaveFileDialog.h
+++ b/UI/SaveFileDialog.h
@@ -55,7 +55,6 @@ private:
     void Cancel();                          //!< when m_load_btn button is pressed
     void SelectionChanged(const GG::ListBox::SelectionSet& files);      //!< When file selection changes.
     void UpdateDirectory(const std::string& newdir);                    //!< Change current directory
-    void DirectoryDropdownSelect(GG::DropDownList::iterator selection); //!< On remote directory select
 
     /** Either directly update from the local save directory, or request the
         server for save preview information*/
@@ -77,7 +76,6 @@ private:
     std::shared_ptr<SaveFileListBox>    m_file_list;        //!< The list of available saves
     std::shared_ptr<GG::Edit>           m_name_edit;        //!< The file name edit control;
     std::shared_ptr<GG::Edit>           m_current_dir_edit; //!< The editor for the save directory;
-    std::shared_ptr<GG::DropDownList>   m_remote_dir_dropdown; //!< Dropdown to select remote dir;
     std::shared_ptr<GG::Button>         m_confirm_btn;      //!< Button to confirm choice;
 
     std::string         m_loaded_dir;       //!< The directory whose contents are currently shown

--- a/UI/SaveFileDialog.h
+++ b/UI/SaveFileDialog.h
@@ -36,7 +36,7 @@ public:
 
     void KeyPress(GG::Key key, std::uint32_t key_code_point, GG::Flags<GG::ModKey> mod_keys) override;
 
-    /** Update the previews with \p preview_information*/
+    /** Update the previews with \p preview_info*/
     void SetPreviewList(const PreviewInformation& preview_info);
     //@}
 

--- a/UI/Sound.cpp
+++ b/UI/Sound.cpp
@@ -390,7 +390,7 @@ void Sound::Impl::PlayMusic(const boost::filesystem::path& path, int loops /* = 
         return;
 
     ALenum m_openal_error;
-    std::string filename = PathString(path);
+    std::string filename = PathToString(path);
     FILE* m_f = nullptr;
     vorbis_info* vorbis_info;
     m_music_loops = 0;
@@ -503,7 +503,7 @@ void Sound::Impl::PlaySound(const boost::filesystem::path& path, bool is_ui_soun
     if (!m_initialized || !GetOptionsDB().Get<bool>("UI.sound.enabled") || (is_ui_sound && UISoundsTemporarilyDisabled()))
         return;
 
-    std::string filename = PathString(path);
+    std::string filename = PathToString(path);
     ALuint current_buffer;
     ALenum source_state;
     ALsizei ogg_freq;
@@ -604,7 +604,7 @@ void Sound::Impl::FreeSound(const boost::filesystem::path& path) {
         return;
 
     ALenum m_openal_error;
-    std::string filename = PathString(path);
+    std::string filename = PathToString(path);
     std::map<std::string, ALuint>::iterator it = m_buffers.find(filename);
 
     if (it != m_buffers.end()) {

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -400,7 +400,7 @@ void HumanClientApp::SetSinglePlayerGame(bool sp/* = true*/)
 namespace {
     std::string ServerClientExe() {
 #ifdef FREEORION_WIN32
-        return PathString(GetBinDir() / "freeoriond.exe");
+        return PathToString(GetBinDir() / "freeoriond.exe");
 #else
         return (GetBinDir() / "freeoriond").string();
 #endif
@@ -1146,7 +1146,7 @@ namespace {
                 return boost::none;
 
             // Return the newest
-            return PathString(files_by_write_time.rbegin()->second);
+            return PathToString(files_by_write_time.rbegin()->second);
 
         } catch (const boost::filesystem::filesystem_error& e) {
             ErrorLogger() << "File system error " << e.what() << " while finding newest autosave";
@@ -1299,7 +1299,7 @@ void HumanClientApp::Autosave() {
     RemoveOldestFiles(max_autosaves, autosave_dir_path);
 
     // create new save
-    auto path_string = PathString(autosave_file_path);
+    auto path_string = PathToString(autosave_file_path);
 
     if (is_initial_save)
         DebugLogger() << "Turn 0 autosave to: " << path_string;

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -692,16 +692,13 @@ void HumanClientApp::LoadSinglePlayerGame(std::string filename/* = ""*/) {
         }
     } else {
         try {
-            auto sfd = GG::Wnd::Create<SaveFileDialog>(
+            filename = ClientUI::GetClientUI()->GetFilenameWithSaveFileDialog(
                 SaveFileDialog::Purpose::Load,
                 SaveFileDialog::SaveType::SinglePlayer);
-            sfd->Run();
 
             // Update intro screen Load & Continue buttons if all savegames are deleted.
             m_ui->GetIntroScreen()->RequirePreRender();
 
-            if (!sfd->Result().empty())
-                filename = sfd->Result();
         } catch (const std::exception& e) {
             ClientUI::MessageBox(e.what(), true);
         }
@@ -1321,11 +1318,9 @@ bool HumanClientApp::IsLoadGameAvailable() const {
 }
 
 std::string HumanClientApp::SelectLoadFile() {
-    auto sfd = GG::Wnd::Create<SaveFileDialog>(
+    return ClientUI::GetClientUI()->GetFilenameWithSaveFileDialog(
         SaveFileDialog::Purpose::Load,
         SaveFileDialog::SaveType::MultiPlayer);
-    sfd->Run();
-    return sfd->Result();
 }
 
 void HumanClientApp::ResetClientData(bool save_connection) {

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -1232,7 +1232,7 @@ namespace {
         // Add timestamp to autosave generated files
         std::string datetime_str = FilenameTimestamp();
 
-        boost::filesystem::path autosave_dir_path(GetSaveDir() / "auto");
+        boost::filesystem::path autosave_dir_path((is_single_player ? GetSaveDir() : GetServerSaveDir()) / "auto");
 
         std::string save_filename = boost::io::str(boost::format("FreeOrion_%s_%s_%04d_%s%s") % player_name % empire_name % CurrentTurn() % datetime_str % extension);
         boost::filesystem::path save_path(autosave_dir_path / save_filename);
@@ -1283,7 +1283,7 @@ void HumanClientApp::Autosave() {
     auto autosave_file_path = CreateNewAutosaveFilePath(EmpireID(), m_single_player_game);
 
     // check for and remove excess oldest autosaves.
-    boost::filesystem::path autosave_dir_path(GetSaveDir() / "auto");
+    boost::filesystem::path autosave_dir_path((m_single_player_game ? GetSaveDir() : GetServerSaveDir()) / "auto");
     int max_turns = std::max(1, GetOptionsDB().Get<int>("autosave.turn-limit"));
     bool is_two_saves_per_turn =
         (m_single_player_game

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -692,7 +692,9 @@ void HumanClientApp::LoadSinglePlayerGame(std::string filename/* = ""*/) {
         }
     } else {
         try {
-            auto sfd = GG::Wnd::Create<SaveFileDialog>(SP_SAVE_FILE_EXTENSION, true);
+            auto sfd = GG::Wnd::Create<SaveFileDialog>(
+                SaveFileDialog::Purpose::Load,
+                SaveFileDialog::SaveType::SinglePlayer);
             sfd->Run();
 
             // Update intro screen Load & Continue buttons if all savegames are deleted.
@@ -1319,7 +1321,9 @@ bool HumanClientApp::IsLoadGameAvailable() const {
 }
 
 std::string HumanClientApp::SelectLoadFile() {
-    auto sfd = GG::Wnd::Create<SaveFileDialog>(true);
+    auto sfd = GG::Wnd::Create<SaveFileDialog>(
+        SaveFileDialog::Purpose::Load,
+        SaveFileDialog::SaveType::MultiPlayer);
     sfd->Run();
     return sfd->Result();
 }

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -757,10 +757,11 @@ void HumanClientApp::LoadSinglePlayerGame(std::string filename/* = ""*/) {
     m_fsm->process_event(HostSPGameRequested());
 }
 
-void HumanClientApp::RequestSavePreviews(const std::string& directory) {
-    TraceLogger() << "HumanClientApp::RequestSavePreviews directory: " << directory << " valid UTF-8: " << utf8::is_valid(directory.begin(), directory.end());
+void HumanClientApp::RequestSavePreviews(const std::string& relative_directory) {
+    TraceLogger() << "HumanClientApp::RequestSavePreviews directory: " << relative_directory
+                  << " valid UTF-8: " << utf8::is_valid(relative_directory.begin(), relative_directory.end());
 
-    std::string  generic_directory = directory;//PathString(fs::path(directory));
+    std::string  generic_directory = relative_directory;
     if (!m_networking->IsConnected()) {
         DebugLogger() << "HumanClientApp::RequestSavePreviews: No game running. Start a server for savegame queries.";
 

--- a/client/human/HumanClientApp.h
+++ b/client/human/HumanClientApp.h
@@ -75,7 +75,9 @@ public:
     void                ExitApp();
     void                ResetClientData(bool save_connection = false);
     void                LoadSinglePlayerGame(std::string filename = "");
-    void                RequestSavePreviews(const std::string& directory); ///< Requests the savegame previews for choosing one.
+    /** Requests the savegame previews from the server in \p relative_directory
+        to the server save directory. */
+    void                RequestSavePreviews(const std::string& relative_directory);
     void                Autosave();                                     ///< autosaves the current game, iff autosaves are enabled and any turn number requirements are met
     /** Load the newest single player autosave and continue playing game. */
     void                ContinueSinglePlayerGame();

--- a/client/human/HumanClientApp.h
+++ b/client/human/HumanClientApp.h
@@ -75,7 +75,7 @@ public:
     void                ExitApp();
     void                ResetClientData(bool save_connection = false);
     void                LoadSinglePlayerGame(std::string filename = "");
-    void                RequestSavePreviews(const std::string& directory, PreviewInformation& previews); ///< Requests the savegame previews for choosing one.
+    void                RequestSavePreviews(const std::string& directory); ///< Requests the savegame previews for choosing one.
     void                Autosave();                                     ///< autosaves the current game, iff autosaves are enabled and any turn number requirements are met
     /** Load the newest single player autosave and continue playing game. */
     void                ContinueSinglePlayerGame();
@@ -93,6 +93,8 @@ public:
 
     void                HandleSaveGameDataRequest();
     void                UpdateCombatLogs(const Message& msg);
+    /** Update any open SaveGameDialog with previews from the server. */
+    void                HandleSaveGamePreviews(const Message& msg);
 
     void                OpenURL(const std::string& url);
     //@}

--- a/client/human/chmain.cpp
+++ b/client/human/chmain.cpp
@@ -169,7 +169,7 @@ int mainConfigOptionsSetup(const std::vector<std::string>& args) {
             {
                 DebugLogger() << "Default Resources directory missing or does not contain expected files. Cannot start game.";
                 throw std::runtime_error("Unable to load game resources at default location: " +
-                                         PathString(GetResourceDir()) + " : Install may be broken.");
+                                         PathToString(GetResourceDir()) + " : Install may be broken.");
             }
         }
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1607,6 +1607,9 @@ Adjusts the size of research screen controls, scaled with the text font size.
 OPTIONS_DB_SAVE_DIR
 The directory in which saved games are saved and from which they are loaded.
 
+OPTIONS_DB_SERVER_SAVE_DIR
+The publicly accessible directory for saved games on the server.
+
 OPTIONS_DB_RESOURCE_DIR
 Sets the root directory for the game resource files (game content and data files).
 
@@ -2709,6 +2712,9 @@ Resource Files
 
 OPTIONS_FOLDER_SAVE
 Save files
+
+OPTIONS_SERVER_FOLDER_SAVE
+Server Save files
 
 OPTIONS_LANGUAGE_FILE
 Language files

--- a/network/Message.cpp
+++ b/network/Message.cpp
@@ -543,8 +543,8 @@ Message ShutdownServerMessage()
 { return Message(Message::SHUT_DOWN_SERVER, DUMMY_EMPTY_MESSAGE); }
 
 /** requests previews of savefiles from server synchronously */
-Message RequestSavePreviewsMessage(std::string directory)
-{ return Message(Message::REQUEST_SAVE_PREVIEWS, directory); }
+Message RequestSavePreviewsMessage(std::string relative_directory)
+{ return Message(Message::REQUEST_SAVE_PREVIEWS, relative_directory); }
 
 /** returns the savegame previews to the client */
 Message DispatchSavePreviewsMessage(const PreviewInformation& previews) {

--- a/network/Message.h
+++ b/network/Message.h
@@ -297,7 +297,7 @@ FO_COMMON_API Message ModeratorActionMessage(const Moderator::ModeratorAction& m
 FO_COMMON_API Message ShutdownServerMessage();
 
 /** requests previews of savefiles from server */
-FO_COMMON_API Message RequestSavePreviewsMessage(std::string directory);
+FO_COMMON_API Message RequestSavePreviewsMessage(std::string relative_directory);
 
 /** returns the savegame previews to the client */
 FO_COMMON_API Message DispatchSavePreviewsMessage(const PreviewInformation& preview);

--- a/parse/Parse.cpp
+++ b/parse/Parse.cpp
@@ -461,7 +461,7 @@ namespace parse {
 
             // If in permissive mode and no scripts are found allow all files to be scripts.
             if (allow_permissive && scripts.empty() && !files.empty()) {
-                WarnLogger() << PathString(path) << " does not contain scripts with the expected suffix .focs.txt. "
+                WarnLogger() << PathToString(path) << " does not contain scripts with the expected suffix .focs.txt. "
                              << " Trying a more permissive mode and ignoring file suffix.";
                 scripts = files;
             }
@@ -569,9 +569,9 @@ namespace parse {
                     file_content.append("\n");
                     process_include_substitutions(file_content, match_path.parent_path(), files_included);
                     text = regex_replace(text, INCL_ONCE_SEARCH, file_content, regex_constants::format_first_only);
-                } else if (missing_include_files.insert(PathString(match_path)).second) {
-                    ErrorLogger() << "Parse: " << PathString(match_path) << " was not found for inclusion (Path:"
-                                  << PathString(base_path) << ") (File:" << fn_str << ")";
+                } else if (missing_include_files.insert(PathToString(match_path)).second) {
+                    ErrorLogger() << "Parse: " << PathToString(match_path) << " was not found for inclusion (Path:"
+                                  << PathToString(base_path) << ") (File:" << fn_str << ")";
                 }
             }
             // remove any remaining includes of this file

--- a/python/AI/AIWrapper.cpp
+++ b/python/AI/AIWrapper.cpp
@@ -81,10 +81,10 @@ namespace {
     }
 
     boost::python::str GetUserConfigDirWrapper()
-    { return boost::python::str(PathString(GetUserConfigDir())); }
+    { return boost::python::str(PathToString(GetUserConfigDir())); }
 
     boost::python::str GetUserDataDirWrapper()
-    { return boost::python::str(PathString(GetUserDataDir())); }
+    { return boost::python::str(PathToString(GetUserDataDir())); }
 
 }
 

--- a/python/server/ServerWrapper.cpp
+++ b/python/server/ServerWrapper.cpp
@@ -90,7 +90,7 @@ namespace {
 
     // Wrapper for GetResourceDir
     object GetResourceDirWrapper()
-    { return object(PathString(GetResourceDir())); }
+    { return object(PathToString(GetResourceDir())); }
 
     // Wrapper for getting empire objects
     list GetAllEmpires() {

--- a/server/SaveLoad.cpp
+++ b/server/SaveLoad.cpp
@@ -150,16 +150,19 @@ int SaveGame(const std::string& filename, const ServerSaveGameData& server_save_
 
     try {
         fs::path path = FilenameToPath(filename);
+
         // A relative path should be relative to the save directory.
         if (path.is_relative()) {
-            path = GetSaveDir() / path;
+            path = (multiplayer ? GetServerSaveDir() : GetSaveDir()) / path;
             DebugLogger() << "Made save path relative to save dir. Is now: " << path;
         }
 
         if (multiplayer) {
             // Make sure the path points into our save directory
-            if (!IsInDir(GetSaveDir(), path)) {
-                path = GetSaveDir() / path.filename();
+            if (!IsInDir(GetServerSaveDir(), path.parent_path())) {
+                WarnLogger() << "Path \"" << path << "\" is not in server save directory.";
+                path = GetServerSaveDir() / path.filename();
+                WarnLogger() << "Path changed to \"" << path << "\"";
             }
         }
 

--- a/server/SaveLoad.cpp
+++ b/server/SaveLoad.cpp
@@ -158,7 +158,7 @@ int SaveGame(const std::string& filename, const ServerSaveGameData& server_save_
 
         if (multiplayer) {
             // Make sure the path points into our save directory
-            if (!IsInside(path, GetSaveDir())) {
+            if (!IsInDir(GetSaveDir(), path)) {
                 path = GetSaveDir() / path.filename();
             }
         }

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -890,11 +890,11 @@ namespace {
         if (!fs::is_directory(directory))
             return list;
 
-        auto server_dir_str = PathString(fs::canonical(GetServerSaveDir()));
+        auto server_dir_str = PathToString(fs::canonical(GetServerSaveDir()));
 
         // Adds \p subdir to the list
         auto add_to_list = [&list, &server_dir_str](const fs::path& subdir) {
-            auto subdir_str = PathString(fs::canonical(subdir));
+            auto subdir_str = PathToString(fs::canonical(subdir));
             auto rel_path = subdir_str.substr(server_dir_str.length());
             list.push_back(rel_path);
             TraceLogger() << "Added relative path " << rel_path << " in " << subdir

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -926,7 +926,7 @@ void ServerApp::UpdateSavePreviews(const Message& msg, PlayerConnectionPtr playe
 
     DebugLogger() << "ServerApp::UpdateSavePreviews: Preview request for sub directory: " << relative_directory_name;
 
-    fs::path directory = GetServerSaveDir() / relative_directory_name;
+    fs::path directory = GetServerSaveDir() / FilenameToPath(relative_directory_name);
     // Do not allow a relative path to explore outside the save directory.
     bool contains_dot_dot = relative_directory_name.find("..") != std::string::npos;
     if (contains_dot_dot || !IsInServerSaveDir(directory)) {

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -863,7 +863,6 @@ namespace {
         /** Check that \p path is a file or directory in the server save
         directory. */
     bool IsInServerSaveDir(const fs::path& path) {
-
         fs::path server_dir = GetServerSaveDir();
         if (!fs::exists(server_dir) || !fs::is_directory(server_dir))
             return false;
@@ -891,11 +890,11 @@ namespace {
         if (!fs::is_directory(directory))
             return list;
 
-        std::string server_dir_str = fs::canonical(GetServerSaveDir()).generic_string();
+        auto server_dir_str = PathString(fs::canonical(GetServerSaveDir()));
 
         // Adds \p subdir to the list
         auto add_to_list = [&list, &server_dir_str](const fs::path& subdir) {
-            auto subdir_str = fs::canonical(subdir).generic_string();
+            auto subdir_str = PathString(fs::canonical(subdir));
             auto rel_path = subdir_str.substr(server_dir_str.length());
             list.push_back(rel_path);
             TraceLogger() << "Added relative path " << rel_path << " in " << subdir

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -866,7 +866,8 @@ namespace {
         if (!fs::exists(path))
             return false;
 
-        return IsInDir(GetServerSaveDir(), path);
+        return IsInDir(GetServerSaveDir(),
+                       (fs::is_regular_file(path) ? path.parent_path() : path));
     }
 
     /// Generates information on the subdirectories of \p directory
@@ -927,7 +928,7 @@ void ServerApp::UpdateSavePreviews(const Message& msg, PlayerConnectionPtr playe
     preview_information.folder = relative_directory_name;
     preview_information.subdirectories = ListSaveSubdirectories(directory);
     LoadSaveGamePreviews(
-        relative_directory_name,
+        directory,
         m_single_player_game? SP_SAVE_FILE_EXTENSION : MP_SAVE_FILE_EXTENSION,
         preview_information.previews);
     DebugLogger() << "ServerApp::UpdateSavePreviews: Sending " << preview_information.previews.size()

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -881,7 +881,7 @@ namespace {
             return false;
 
         // Check that the whole server save dir path matches the test path
-        return std::equal(canon_server.begin(), canon_server.end(), path.begin());
+        return std::equal(canon_server.begin(), canon_server.end(), canon_path.begin());
     }
 
     /// Generates information on the subdirectories of \p directory

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -863,25 +863,10 @@ namespace {
         /** Check that \p path is a file or directory in the server save
         directory. */
     bool IsInServerSaveDir(const fs::path& path) {
-        fs::path server_dir = GetServerSaveDir();
-        if (!fs::exists(server_dir) || !fs::is_directory(server_dir))
-            return false;
-
         if (!fs::exists(path))
             return false;
 
-        // Resolve any symbolic links, dots or dot-dots
-        auto canon_server = fs::canonical(server_dir);
-        auto canon_path = fs::canonical(path);
-
-        // Paths shorter than the server save dir are not in the server dir
-        auto save_dir_length = std::distance(canon_server.begin(), canon_server.end());
-        auto path_length = std::distance(canon_path.begin(), canon_path.end());
-        if (path_length < save_dir_length)
-            return false;
-
-        // Check that the whole server save dir path matches the test path
-        return std::equal(canon_server.begin(), canon_server.end(), canon_path.begin());
+        return IsInDir(GetServerSaveDir(), path);
     }
 
     /// Generates information on the subdirectories of \p directory

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -959,7 +959,7 @@ sc::result MPLobby::react(const LobbyUpdate& msg) {
         }
 
         // refresh save game empire data
-        boost::filesystem::path save_dir(GetSaveDir());
+        boost::filesystem::path save_dir(GetServerSaveDir());
         try {
             LoadEmpireSaveGameData((save_dir / m_lobby_data->m_save_game).string(),
                                    m_lobby_data->m_save_game_empire_data);
@@ -993,7 +993,7 @@ sc::result MPLobby::react(const LobbyUpdate& msg) {
 
             if (!m_lobby_data->m_new_game) {
                 // Load game ...
-                std::string save_filename = (GetSaveDir() / m_lobby_data->m_save_game).string();
+                std::string save_filename = (GetServerSaveDir() / m_lobby_data->m_save_game).string();
 
                 try {
                     LoadGame(save_filename,             *m_server_save_game_data,
@@ -1090,7 +1090,7 @@ sc::result MPLobby::react(const StartMPGame& msg) {
 
         } else {
             // Load game...
-            std::string save_filename = (GetSaveDir() / m_lobby_data->m_save_game).string();
+            std::string save_filename = (GetServerSaveDir() / m_lobby_data->m_save_game).string();
 
             try {
                 LoadGame(save_filename,             *m_server_save_game_data,

--- a/util/Directories.cpp
+++ b/util/Directories.cpp
@@ -478,7 +478,7 @@ fs::path RelativePath(const fs::path& from, const fs::path& to) {
     return retval;
 }
 
-std::string PathString(const fs::path& path) {
+std::string PathToString(const fs::path& path) {
 #ifndef FREEORION_WIN32
     return path.string();
 #else
@@ -519,7 +519,7 @@ std::vector<fs::path> ListDir(const fs::path& path) {
     std::vector<fs::path> retval;
     bool is_rel = path.is_relative();
     if (!is_rel && (fs::is_empty(path) || !fs::is_directory(path))) {
-        DebugLogger() << "ListDir: File " << PathString(path) << " was not included as it is empty or not a directoy";
+        DebugLogger() << "ListDir: File " << PathToString(path) << " was not included as it is empty or not a directoy";
     } else {
         const fs::path& default_path = is_rel ? GetResourceDir() / path : path;
 
@@ -529,7 +529,7 @@ std::vector<fs::path> ListDir(const fs::path& path) {
             if (fs::is_regular_file(dir_it->status())) {
                 retval.push_back(dir_it->path());
             } else if (!fs::is_directory(dir_it->status())) {
-                TraceLogger() << "Parse: Unknown file not included: " << PathString(dir_it->path());
+                TraceLogger() << "Parse: Unknown file not included: " << PathToString(dir_it->path());
             }
         }
     }

--- a/util/Directories.cpp
+++ b/util/Directories.cpp
@@ -487,7 +487,7 @@ std::string PathToString(const fs::path& path) {
     return retval;
 }
 
-const fs::path FilenameToPath(const std::string& path_str) {
+fs::path FilenameToPath(const std::string& path_str) {
     // convert UTF-8 directory string to UTF-16
     boost::filesystem::path::string_type directory_native;
     utf8::utf8to16(path_str.begin(), path_str.end(), std::back_inserter(directory_native));
@@ -499,7 +499,7 @@ const fs::path FilenameToPath(const std::string& path_str) {
 std::string PathToString(const fs::path& path)
 { return path.string(); }
 
-const fs::path FilenameToPath(const std::string& path_str)
+fs::path FilenameToPath(const std::string& path_str)
 { return fs::path(path_str); }
 
 #endif // defined(FREEORION_WIN32)

--- a/util/Directories.cpp
+++ b/util/Directories.cpp
@@ -97,6 +97,10 @@ void InitDirs(const std::string& argv0) {
     if (!exists(p))
         fs::create_directories(p);
 
+    // Intentionally do not create the server save dir.
+    // The server save dir is publically accessible and should not be
+    // automatically created for the user.
+
     g_initialized = true;
 }
 
@@ -260,6 +264,10 @@ void InitDirs(const std::string& argv0) {
         fs::create_directories(p);
     }
 
+    // Intentionally do not create the server save dir.
+    // The server save dir is publically accessible and should not be
+    // automatically created for the user.
+
     InitBinDir(argv0);
 
     g_initialized = true;
@@ -364,6 +372,10 @@ void InitDirs(const std::string& argv0) {
     fs::path p(GetSaveDir());
     if (!exists(p))
         fs::create_directories(p);
+
+    // Intentionally do not create the server save dir.
+    // The server save dir is publically accessible and should not be
+    // automatically created for the user.
 
     InitBinDir(argv0);
 

--- a/util/Directories.cpp
+++ b/util/Directories.cpp
@@ -450,6 +450,15 @@ const fs::path GetSaveDir() {
     return FilenameToPath(options_save_dir);
 }
 
+const fs::path GetServerSaveDir() {
+    // if server save dir option has been set, use specified location.  otherwise,
+    // use default location
+    std::string options_save_dir = GetOptionsDB().Get<std::string>("server-save-dir");
+    if (options_save_dir.empty())
+        options_save_dir = GetOptionsDB().GetDefault<std::string>("server-save-dir");
+    return FilenameToPath(options_save_dir);
+}
+
 fs::path RelativePath(const fs::path& from, const fs::path& to) {
     fs::path retval;
     fs::path from_abs = fs::absolute(from);

--- a/util/Directories.cpp
+++ b/util/Directories.cpp
@@ -478,27 +478,31 @@ fs::path RelativePath(const fs::path& from, const fs::path& to) {
     return retval;
 }
 
+#if defined(FREEORION_WIN32)
+
 std::string PathToString(const fs::path& path) {
-#ifndef FREEORION_WIN32
-    return path.string();
-#else
     fs::path::string_type native_string = path.native();
     std::string retval;
     utf8::utf16to8(native_string.begin(), native_string.end(), std::back_inserter(retval));
     return retval;
-#endif
 }
 
 const fs::path FilenameToPath(const std::string& path_str) {
-#if defined(FREEORION_WIN32)
     // convert UTF-8 directory string to UTF-16
     boost::filesystem::path::string_type directory_native;
     utf8::utf8to16(path_str.begin(), path_str.end(), std::back_inserter(directory_native));
     return fs::path(directory_native);
-#else
-    return fs::path(path_str);
-#endif
 }
+
+#else // defined(FREEORION_WIN32)
+
+std::string PathToString(const fs::path& path)
+{ return path.string(); }
+
+const fs::path FilenameToPath(const std::string& path_str)
+{ return fs::path(path_str); }
+
+#endif // defined(FREEORION_WIN32)
 
 std::string FilenameTimestamp() {
     boost::posix_time::time_facet* facet = new boost::posix_time::time_facet("%Y%m%d_%H%M%S");

--- a/util/Directories.cpp
+++ b/util/Directories.cpp
@@ -547,3 +547,25 @@ std::vector<fs::path> ListDir(const fs::path& path) {
 
 bool IsValidUTF8(const std::string& in)
 { return utf8::is_valid(in.begin(), in.end()); }
+
+bool IsInDir(const fs::path& dir, const fs::path& test_dir) {
+    if (!fs::exists(dir) || !fs::is_directory(dir))
+        return false;
+
+    if (!fs::exists(test_dir) || !fs::is_directory(test_dir))
+        return false;
+
+    // Resolve any symbolic links, dots or dot-dots
+    auto canon_dir = fs::canonical(dir);
+    auto canon_path = fs::canonical(test_dir);
+
+    // Paths shorter than dir are not in dir
+    auto dir_length = std::distance(canon_dir.begin(), canon_dir.end());
+    auto path_length = std::distance(canon_path.begin(), canon_path.end());
+    if (path_length < dir_length)
+        return false;
+
+    // Check that the whole dir path matches the test path
+    // Extra portions of path are contained in dir
+    return std::equal(canon_dir.begin(), canon_dir.end(), canon_path.begin());
+}

--- a/util/Directories.h
+++ b/util/Directories.h
@@ -78,6 +78,10 @@ FO_COMMON_API const boost::filesystem::path GetPersistentConfigPath();
   * the directory "save" within the user directory. */
 FO_COMMON_API const boost::filesystem::path GetSaveDir();
 
+/** Returns the directory where server save files are located.  This is typically
+  * the directory "save" within the user directory. */
+FO_COMMON_API const boost::filesystem::path GetServerSaveDir();
+
 /** Returns a canonical utf-8 string from the given filesystem path. */
 FO_COMMON_API std::string PathString(const boost::filesystem::path& path);
 

--- a/util/Directories.h
+++ b/util/Directories.h
@@ -82,7 +82,7 @@ FO_COMMON_API const boost::filesystem::path GetSaveDir();
   * the directory "save" within the user directory. */
 FO_COMMON_API const boost::filesystem::path GetServerSaveDir();
 
-/** Returns a canonical utf-8 string from the given filesystem path. */
+/** Returns a utf-8 string from the given filesystem path. */
 FO_COMMON_API std::string PathToString(const boost::filesystem::path& path);
 
 /** Returns current timestamp in a form that can be used in file names */

--- a/util/Directories.h
+++ b/util/Directories.h
@@ -97,5 +97,8 @@ FO_COMMON_API std::vector<boost::filesystem::path> ListDir(const boost::filesyst
 /** Returns true iff the string \a in is valid UTF-8. */
 FO_COMMON_API bool IsValidUTF8(const std::string& in);
 
+/** Returns true iff the \p test_dir is in \p dir and both \p dir and test_dir
+    are existing directories. */
+FO_COMMON_API bool IsInDir(const boost::filesystem::path& dir, const boost::filesystem::path& test_dir);
 
 #endif

--- a/util/Directories.h
+++ b/util/Directories.h
@@ -83,7 +83,7 @@ FO_COMMON_API const boost::filesystem::path GetSaveDir();
 FO_COMMON_API const boost::filesystem::path GetServerSaveDir();
 
 /** Returns a canonical utf-8 string from the given filesystem path. */
-FO_COMMON_API std::string PathString(const boost::filesystem::path& path);
+FO_COMMON_API std::string PathToString(const boost::filesystem::path& path);
 
 /** Returns current timestamp in a form that can be used in file names */
 FO_COMMON_API std::string FilenameTimestamp();

--- a/util/Directories.h
+++ b/util/Directories.h
@@ -40,7 +40,7 @@ FO_COMMON_API const boost::filesystem::path GetUserDataDir();
 
 /** Converts UTF-8 string into a path, doing any required wide-character
   * conversions as determined by the operating system / filesystem. */
-FO_COMMON_API const boost::filesystem::path FilenameToPath(const std::string& path_str);
+FO_COMMON_API boost::filesystem::path FilenameToPath(const std::string& path_str);
 
 /** Returns the directory that contains all game content files, such as string
   * table files, in-game tech, building, special, etc. definition files, and

--- a/util/MultiplayerCommon.cpp
+++ b/util/MultiplayerCommon.cpp
@@ -23,14 +23,14 @@ const std::string SP_SAVE_FILE_EXTENSION = ".sav";
 namespace {
     // command-line options
     void AddOptions(OptionsDB& db) {
-        db.Add<std::string>("resource-dir",         UserStringNop("OPTIONS_DB_RESOURCE_DIR"),          PathString(GetRootDataDir() / "default"));
-        db.Add<std::string>('S', "save-dir",        UserStringNop("OPTIONS_DB_SAVE_DIR"),              PathString(GetUserDataDir() / "save"));
-        db.Add<std::string>("server-save-dir",      UserStringNop("OPTIONS_DB_SERVER_SAVE_DIR"),       PathString(GetUserDataDir() / "save"));
+        db.Add<std::string>("resource-dir",         UserStringNop("OPTIONS_DB_RESOURCE_DIR"),          PathToString(GetRootDataDir() / "default"));
+        db.Add<std::string>('S', "save-dir",        UserStringNop("OPTIONS_DB_SAVE_DIR"),              PathToString(GetUserDataDir() / "save"));
+        db.Add<std::string>("server-save-dir",      UserStringNop("OPTIONS_DB_SERVER_SAVE_DIR"),       PathToString(GetUserDataDir() / "save"));
         db.Add<std::string>("log-level",            UserStringNop("OPTIONS_DB_LOG_LEVEL"),             "",
                             OrValidator<std::string>(LogLevelValidator(), DiscreteValidator<std::string>("")), false);
         db.Add<std::string>("log-file",             UserStringNop("OPTIONS_DB_LOG_FILE"),              "",
                             Validator<std::string>() , false);
-        db.Add<std::string>("stringtable-filename", UserStringNop("OPTIONS_DB_STRINGTABLE_FILENAME"),  PathString(GetRootDataDir() / "default" / "stringtables" / "en.txt"));
+        db.Add<std::string>("stringtable-filename", UserStringNop("OPTIONS_DB_STRINGTABLE_FILENAME"),  PathToString(GetRootDataDir() / "default" / "stringtables" / "en.txt"));
         db.Add("binary-serialization",              UserStringNop("OPTIONS_DB_BINARY_SERIALIZATION"),  false);
         db.Add("xml-zlib-serialization",            UserStringNop("OPTIONS_DB_XML_ZLIB_SERIALIZATION"),true);
 

--- a/util/MultiplayerCommon.cpp
+++ b/util/MultiplayerCommon.cpp
@@ -25,6 +25,7 @@ namespace {
     void AddOptions(OptionsDB& db) {
         db.Add<std::string>("resource-dir",         UserStringNop("OPTIONS_DB_RESOURCE_DIR"),          PathString(GetRootDataDir() / "default"));
         db.Add<std::string>('S', "save-dir",        UserStringNop("OPTIONS_DB_SAVE_DIR"),              PathString(GetUserDataDir() / "save"));
+        db.Add<std::string>("server-save-dir",      UserStringNop("OPTIONS_DB_SERVER_SAVE_DIR"),       PathString(GetUserDataDir() / "save"));
         db.Add<std::string>("log-level",            UserStringNop("OPTIONS_DB_LOG_LEVEL"),             "",
                             OrValidator<std::string>(LogLevelValidator(), DiscreteValidator<std::string>("")), false);
         db.Add<std::string>("log-file",             UserStringNop("OPTIONS_DB_LOG_FILE"),              "",

--- a/util/OptionsDB.cpp
+++ b/util/OptionsDB.cpp
@@ -163,9 +163,9 @@ void OptionsDB::Commit() {
         m_dirty = false;
     } else {
         std::cerr << UserString("UNABLE_TO_WRITE_CONFIG_XML") << std::endl;
-        std::cerr << PathString(GetConfigPath()) << std::endl;
+        std::cerr << PathToString(GetConfigPath()) << std::endl;
         ErrorLogger() << UserString("UNABLE_TO_WRITE_CONFIG_XML");
-        ErrorLogger() << PathString(GetConfigPath());
+        ErrorLogger() << PathToString(GetConfigPath());
     }
 }
 

--- a/util/SaveGamePreviewUtils.cpp
+++ b/util/SaveGamePreviewUtils.cpp
@@ -52,7 +52,7 @@ namespace {
 
         fs::ifstream ifs(path, std::ios_base::binary);
 
-        full.filename = PathString(path.filename());
+        full.filename = PathToString(path.filename());
 
         if (!ifs)
             throw std::runtime_error(UNABLE_TO_OPEN_FILE);
@@ -248,7 +248,7 @@ void LoadSaveGamePreviews(const fs::path& orig_path, const std::string& extensio
 
     for (fs::directory_iterator it(path); it != end_it; ++it) {
         try {
-            std::string filename = PathString(it->path().filename());
+            std::string filename = PathToString(it->path().filename());
             if ((it->path().filename().extension() == extension) && !fs::is_directory(it->path())) {
                 if (LoadSaveGamePreviewData(*it, data)) {
                     // Add preview entry to list

--- a/util/SaveGamePreviewUtils.cpp
+++ b/util/SaveGamePreviewUtils.cpp
@@ -234,7 +234,8 @@ void LoadSaveGamePreviews(const fs::path& orig_path, const std::string& extensio
     fs::path path = orig_path;
     // Relative path relative to the save directory
     if (path.is_relative()) {
-        path = GetSaveDir() / path;
+        ErrorLogger() << "LoadSaveGamePreviews: supplied path must not be relative, \"" << path << "\" ";
+        return;
     }
 
     if (!fs::exists(path)) {

--- a/util/SaveGamePreviewUtils.cpp
+++ b/util/SaveGamePreviewUtils.cpp
@@ -260,21 +260,3 @@ void LoadSaveGamePreviews(const fs::path& orig_path, const std::string& extensio
         }
     }
 }
-
-bool IsInside(const fs::path& path, const fs::path& directory) {
-    const fs::path target = fs::canonical(directory);
-
-    if (!path.has_parent_path()) {
-        return false;
-    }
-
-    fs::path cur = path.parent_path();
-    while (cur.has_parent_path()) {
-        if (cur == target) {
-            return true;
-        } else {
-            cur = cur.parent_path();
-        }
-    }
-    return false;
-}

--- a/util/SaveGamePreviewUtils.h
+++ b/util/SaveGamePreviewUtils.h
@@ -88,8 +88,4 @@ FO_COMMON_API std::string ColumnInPreview(const FullPreview& full, const std::st
 /// \param [out] previews The previews will be put here
 FO_COMMON_API void LoadSaveGamePreviews(const boost::filesystem::path& path, const std::string& extension,
                                         std::vector<FullPreview>& previews);
-
-/// If path is inside directory, returns true
-FO_COMMON_API bool IsInside(const boost::filesystem::path& path, const boost::filesystem::path& directory);
-
 #endif // SAVEGAMEPREVIEW_H

--- a/util/i18n.cpp
+++ b/util/i18n.cpp
@@ -7,7 +7,7 @@
 
 namespace {
     std::string GetDefaultStringTableFileName()
-    { return PathString(GetResourceDir() / "stringtables" / "en.txt"); }
+    { return PathToString(GetResourceDir() / "stringtables" / "en.txt"); }
 
     std::string GetStringTableFileName() {
         std::string option_filename = GetOptionsDB().Get<std::string>("stringtable-filename");


### PR DESCRIPTION
This PR converts retrieving save file preview from the server from using the synchronous client messaging to asynchronous.

The problems are the same as the problems with synchronous requests of object IDs, client glitches up to and including crashes.