### PR TITLE
Remove client network synchronous messaging

### DIFF
--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -14,8 +14,7 @@ class Message;
 
 /** Encapsulates the networking facilities of the client.  The client must
     execute its networking code in a separate thread from its main processing
-    thread, for UI and networking responsiveness, and to process synchronous
-    communication with the server.
+    thread, for UI and networking responsiveness.
 
     Because of this, ClientNetworking operates in two threads: the main
     thread, in which the UI processing operates; the networking thread, which
@@ -27,22 +26,10 @@ class Message;
     applies to unintentional disconnects from the server.  The client must
     periodically check IsConnected().
 
-    The ClientNetworking has three modes of operation.  First, it can discover
+    The ClientNetworking has two modes of operation.  First, it can discover
     FreeOrion servers on the local network; this is a blocking operation with
     a timeout.  Second, it can send an asynchronous message to the server
-    (when connected); this is a non-blocking operation.  Third, it can send a
-    synchronous message to the server (when connected) and return the server's
-    response; this is a blocking operation.
-
-    Note that the SendSynchronousMessage() does not interrupt the sending or
-    receiving of asynchronous messages.  When SendSynchronousMessage() is
-    called and the main thread blocks to wait for the response message,
-    regular messages are still being sent and received.  Some of these regular
-    messages may arrive before the response message, but
-    SendSynchronousMessage() will still return the response message first,
-    even if it is not at the front of the queue at the time.  This implies
-    that some response messages may be handled out of order with respect to
-    regular messages, but these are in fact the desired semantics. */
+    (when connected); this is a non-blocking operation.*/
 class ClientNetworking : public std::enable_shared_from_this<ClientNetworking> {
 public:
     /** The type of list returned by a call to DiscoverLANServers(). */
@@ -95,10 +82,6 @@ public:
     /** Return the next incoming message from the server if available or boost::none.
         Remove the message from the incoming message queue. */
     boost::optional<Message> GetMessage();
-
-    /** Sends \a message to the server, then blocks until it sees the first
-        synchronous response from the server. */
-    boost::optional<Message> SendSynchronousMessage(const Message& message);
 
     /** Disconnects the client from the server. First tries to send any pending transmit messages. */
     void DisconnectFromServer();

--- a/network/Message.h
+++ b/network/Message.h
@@ -49,7 +49,7 @@ namespace Moderator {
   * misbehave as well.) */
 class FO_COMMON_API Message {
 public:
-    enum Parts : size_t {TYPE = 0, RESPONSE, SIZE, Parts_Count};
+    enum Parts : size_t {TYPE = 0, SIZE, Parts_Count};
 
     typedef std::array<int, Parts::Parts_Count> HeaderBuffer;
 
@@ -126,13 +126,11 @@ public:
     Message();
 
     Message(MessageType message_type,
-            const std::string& text,
-            bool synchronous_response = false);
+            const std::string& text);
     //@}
 
     /** \name Accessors */ //@{
     MessageType Type() const;               ///< Returns the type of the message.
-    bool        SynchronousResponse() const;///< Returns true if this message is in reponse to a synchronous message
     std::size_t Size() const;               ///< Returns the size of the underlying buffer.
     const char* Data() const;               ///< Returns the underlying buffer.
     std::string Text() const;               ///< Returns the underlying buffer as a std::string.
@@ -146,7 +144,6 @@ public:
 
 private:
     MessageType   m_type;
-    bool          m_synchronous_response;
     int           m_message_size;
 
     boost::shared_array<char> m_message_text;
@@ -269,7 +266,7 @@ FO_COMMON_API Message HostSaveGameInitiateMessage(const std::string& filename);
 /** creates a SAVE_GAME_DATA_REQUEST data request message.  This message should
     only be sent by the server to get game data from a client, or to respond to
     the host player requesting a save be initiated. */
-FO_COMMON_API Message ServerSaveGameDataRequestMessage(bool synchronous_response);
+FO_COMMON_API Message ServerSaveGameDataRequestMessage();
 
 /** creates a SAVE_GAME_COMPLETE complete message.  This message should only be
     sent by the server to inform clients that the last initiated save has been

--- a/network/MessageQueue.h
+++ b/network/MessageQueue.h
@@ -16,7 +16,7 @@ class Message;
 class FO_COMMON_API MessageQueue
 {
 public:
-    MessageQueue(boost::mutex& monitor, const bool& rx_connected);
+    MessageQueue(boost::mutex& monitor);
 
     /** Returns true iff the queue is empty. */
     bool Empty() const;
@@ -33,19 +33,9 @@ public:
     /** Return and remove the first message in the queue. */
     boost::optional<Message> PopFront();
 
-    /** Indicates that no more new message will be added to the queue. This causes any pending
-        GetFirstSynchronousMessage() to return boost::none.*/
-    void RxDisconnected();
-
-    /** Return and remove the first synchronous repsonse message from the queue or return
-        boost::none if there is no synchronous message and the queue has stopped growwing. */
-    boost::optional<Message> GetFirstSynchronousMessage();
-
 private:
     std::list<Message> m_queue;
-    boost::condition   m_have_synchronous_response;
     boost::mutex&      m_monitor;
-    const bool&        m_rx_connected;
 };
 
 

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -1847,7 +1847,7 @@ WaitingForSaveData::WaitingForSaveData(my_context c) :
     {
         PlayerConnectionPtr player = *player_it;
         int player_id = player->PlayerID();
-        player->SendMessage(ServerSaveGameDataRequestMessage(false));
+        player->SendMessage(ServerSaveGameDataRequestMessage());
         m_needed_reponses.insert(player_id);
     }
 }


### PR DESCRIPTION
This PR should follow #1738 which removes the last use of client synchronous messaging.

Synchronous messaging is broken in ways that can not be fixed.

If the client makes a synchronous request and the server FSM is in a
state that will not respond, the client hangs.

The implementation assumes that the client is single threaded.  If the
client is not single threaded and more than one thread makes a
synchronous request and the wrong thread receives any server response,
the client hangs.

If the server attempts to change the client FSM to a new state (like
shutdown) after a synchronous request is made, the client will ignore
the request.  Even if the server satisfies the synchronous request and
then sends the state change message, the client may send another
synchronous message before it handles the state change message.  Both
client and server hang.

The solution is to use TCP as an asynchronous protocol.  It works well 😉 