### PR TITLE
Fix ResourceAI bugs regarding species without research focus

### DIFF
--- a/default/python/AI/ResourcesAI.py
+++ b/default/python/AI/ResourcesAI.py
@@ -528,7 +528,7 @@ def set_planet_industry_and_research_foci(focus_manager, priority_ratio):
         cumulative_pp += i_pp
         cumulative_rp += i_rp
         if RESEARCH not in pinfo.planet.availableFoci:
-            if focus_manager.bake_future_focus(pid, pinfo.current_focus, False):
+            if focus_manager.bake_future_focus(pid, INDUSTRY, False):
                 target_pp += i_pp
                 target_rp += i_rp
 

--- a/default/python/AI/ResourcesAI.py
+++ b/default/python/AI/ResourcesAI.py
@@ -528,7 +528,9 @@ def set_planet_industry_and_research_foci(focus_manager, priority_ratio):
         cumulative_pp += i_pp
         cumulative_rp += i_rp
         if RESEARCH not in pinfo.planet.availableFoci:
-            focus_manager.bake_future_focus(pid, pinfo.current_focus, False)
+            if focus_manager.bake_future_focus(pid, pinfo.current_focus, False):
+                target_pp += i_pp
+                target_rp += i_rp
 
     # smallest possible ratio of research to industry with an all industry focus
     maxi_ratio = cumulative_rp / max(0.01, cumulative_pp)

--- a/default/python/AI/ResourcesAI.py
+++ b/default/python/AI/ResourcesAI.py
@@ -602,10 +602,9 @@ def set_planet_industry_and_research_foci(focus_manager, priority_ratio):
         target_rp += (rr - tr)
         target_pp -= (ii - ri)
 
-    # Any planet in the ratios list and still raw is set to industry
-    for ratio, pid, pinfo in ratios:
-        if pid in focus_manager.raw_planet_info:
-            focus_manager.bake_future_focus(pid, INDUSTRY, False)
+    # Any planet still raw is set to industry
+    for pid in focus_manager.raw_planet_info:
+        focus_manager.bake_future_focus(pid, INDUSTRY, False)
 
 
 def set_planet_resource_foci():


### PR DESCRIPTION
The first two commits fix an issue for species that can not set research focus.´

The third commit is unlikely to have any real impact but offers recover from potential mistakes in the preceeding code (for example if a focus could not be set but is assumed to have been).