### PR TITLE
Fix unconsistency in XML serialization IDAllocator.

### DIFF
--- a/universe/IDAllocator.cpp
+++ b/universe/IDAllocator.cpp
@@ -305,7 +305,7 @@ void IDAllocator::SerializeForEmpire(Archive& ar, const unsigned int version, co
                 & BOOST_SERIALIZATION_NVP(m_offset_to_empire_id);
         } else {
             auto temp_empire_id = empire_id;
-            ar  & boost::serialization::make_nvp("m_empire_id", temp_empire_id);
+            ar  & boost::serialization::make_nvp(BOOST_PP_STRINGIZE(m_empire_id), temp_empire_id);
 
             // Filter the map for empires so they only have their own actual next id and no
             // information about other clients.
@@ -321,8 +321,8 @@ void IDAllocator::SerializeForEmpire(Archive& ar, const unsigned int version, co
                 temp_offset_to_empire_id[it->second % m_stride] = empire_id;
             }
 
-            ar & boost::serialization::make_nvp("m_empire_id_to_next_assigned_object_id", temp_empire_id_to_object_id);
-            ar & boost::serialization::make_nvp("m_offset_to_empire_id", temp_offset_to_empire_id);
+            ar & boost::serialization::make_nvp(BOOST_PP_STRINGIZE(m_empire_id_to_next_assigned_object_id), temp_empire_id_to_object_id);
+            ar & boost::serialization::make_nvp(BOOST_PP_STRINGIZE(m_offset_to_empire_id), temp_offset_to_empire_id);
 
             DebugLogger(IDallocator) << "Serialized [" << [this, &temp_empire_id_to_object_id](){
                 std::stringstream ss;

--- a/universe/IDAllocator.cpp
+++ b/universe/IDAllocator.cpp
@@ -305,7 +305,7 @@ void IDAllocator::SerializeForEmpire(Archive& ar, const unsigned int version, co
                 & BOOST_SERIALIZATION_NVP(m_offset_to_empire_id);
         } else {
             auto temp_empire_id = empire_id;
-            ar  & BOOST_SERIALIZATION_NVP(temp_empire_id);
+            ar  & boost::serialization::make_nvp("m_empire_id", temp_empire_id);
 
             // Filter the map for empires so they only have their own actual next id and no
             // information about other clients.
@@ -321,8 +321,8 @@ void IDAllocator::SerializeForEmpire(Archive& ar, const unsigned int version, co
                 temp_offset_to_empire_id[it->second % m_stride] = empire_id;
             }
 
-            ar & BOOST_SERIALIZATION_NVP(temp_empire_id_to_object_id);
-            ar & BOOST_SERIALIZATION_NVP(temp_offset_to_empire_id);
+            ar & boost::serialization::make_nvp("m_empire_id_to_next_assigned_object_id", temp_empire_id_to_object_id);
+            ar & boost::serialization::make_nvp("m_offset_to_empire_id", temp_offset_to_empire_id);
 
             DebugLogger(IDallocator) << "Serialized [" << [this, &temp_empire_id_to_object_id](){
                 std::stringstream ss;

--- a/universe/IDAllocator.cpp
+++ b/universe/IDAllocator.cpp
@@ -267,7 +267,7 @@ std::string IDAllocator::StateString() const {
 }
 
 template <class Archive>
-void IDAllocator::SerializeForEmpire(Archive& ar, const unsigned int version, const int empire_id) {
+void IDAllocator::SerializeForEmpire(Archive& ar, const unsigned int version, int empire_id) {
     DebugLogger(IDallocator) << (Archive::is_loading::value ? "Deserialize " : "Serialize ")
                              << "IDAllocator()  server id = "
                              << m_server_id << " empire id = " << empire_id;
@@ -304,8 +304,7 @@ void IDAllocator::SerializeForEmpire(Archive& ar, const unsigned int version, co
                 & BOOST_SERIALIZATION_NVP(m_empire_id_to_next_assigned_object_id)
                 & BOOST_SERIALIZATION_NVP(m_offset_to_empire_id);
         } else {
-            auto temp_empire_id = empire_id;
-            ar  & boost::serialization::make_nvp(BOOST_PP_STRINGIZE(m_empire_id), temp_empire_id);
+            ar  & boost::serialization::make_nvp(BOOST_PP_STRINGIZE(m_empire_id), empire_id);
 
             // Filter the map for empires so they only have their own actual next id and no
             // information about other clients.

--- a/universe/IDAllocator.h
+++ b/universe/IDAllocator.h
@@ -72,7 +72,7 @@ public:
 
     /** Serialize while stripping out information not known to \p empire_id. */
     template <class Archive>
-        void SerializeForEmpire(Archive& ar, const unsigned int version, const int empire_id);
+        void SerializeForEmpire(Archive& ar, const unsigned int version, int empire_id);
 
 private:
     /** Return the empire that should have assigned \p id. */


### PR DESCRIPTION
Fixes #1733 
Macro `BOOST_SERIALIZATION_NVP` caused XML tag be named after variable `temp_empire_id` but in loading arm it awaits for `m_empire_id` so it caused error in the client.
`boost::serialization::make_nvp` allows to set XML tag name independent of used variable.