### PR TITLE
[universe_generation] Reformat imports

### DIFF
--- a/default/python/universe_generation/empires.py
+++ b/default/python/universe_generation/empires.py
@@ -1,17 +1,15 @@
-import os.path
 import random
 
 import freeorion as fo
 
-from starsystems import star_types_real, pick_star_type
-from planets import calc_planet_size, calc_planet_type, planet_sizes_real, planet_types_real
-from names import get_name_list, random_name
-from options import (HS_ACCEPTABLE_PLANET_TYPES, HS_MIN_PLANETS_IN_VICINITY_TOTAL,
-                     HS_MIN_PLANETS_IN_VICINITY_PER_SYSTEM, HS_MIN_DISTANCE_PRIORITY_LIMIT, HS_MAX_JUMP_DISTANCE_LIMIT,
-                     HS_VICINITY_RANGE, HS_MIN_SYSTEMS_IN_VICINITY, HS_ACCEPTABLE_PLANET_SIZES)
-
-from util import report_error
 import universe_statistics
+from names import get_name_list, random_name
+from options import (HS_ACCEPTABLE_PLANET_SIZES, HS_ACCEPTABLE_PLANET_TYPES, HS_MAX_JUMP_DISTANCE_LIMIT,
+                     HS_MIN_DISTANCE_PRIORITY_LIMIT, HS_MIN_PLANETS_IN_VICINITY_PER_SYSTEM,
+                     HS_MIN_PLANETS_IN_VICINITY_TOTAL, HS_MIN_SYSTEMS_IN_VICINITY, HS_VICINITY_RANGE)
+from planets import calc_planet_size, calc_planet_type, planet_sizes_real, planet_types_real
+from starsystems import pick_star_type, star_types_real
+from util import report_error
 
 
 def get_empire_name_generator():

--- a/default/python/universe_generation/fields.py
+++ b/default/python/universe_generation/fields.py
@@ -1,6 +1,7 @@
-from random import randint, uniform, choice, sample
+from random import choice, sample, uniform
 
 import freeorion as fo
+
 from util import report_error
 
 

--- a/default/python/universe_generation/galaxy.py
+++ b/default/python/universe_generation/galaxy.py
@@ -1,11 +1,12 @@
 import sys
-from random import random, uniform, randint, gauss
-from math import pi, sin, cos, acos, sqrt, ceil, floor
 from collections import defaultdict
+from math import acos, ceil, cos, floor, pi, sin, sqrt
+from random import gauss, randint, random, uniform
 
 import freeorion as fo
-import util
+
 import universe_tables
+import util
 
 
 class AdjacencyGrid(object):

--- a/default/python/universe_generation/monsters.py
+++ b/default/python/universe_generation/monsters.py
@@ -1,9 +1,11 @@
 import random
+
 import freeorion as fo
-from util import MapGenerationError, report_error
+
 import universe_statistics
 import universe_tables
 from galaxy import DisjointSets
+from util import MapGenerationError, report_error
 
 
 class StarlaneAlteringMonsters(object):

--- a/default/python/universe_generation/names.py
+++ b/default/python/universe_generation/names.py
@@ -3,6 +3,7 @@ from itertools import cycle
 
 import freeorion as fo
 
+
 # tuples of consonants and vowels for random name generation
 consonants = ("b", "c", "d", "f", "g", "h", "j", "k", "l", "m", "n", "p", "q", "r", "s", "t", "v", "w", "x", "y", "z")
 vowels = ("a", "e", "i", "o", "u")

--- a/default/python/universe_generation/names.py
+++ b/default/python/universe_generation/names.py
@@ -3,7 +3,6 @@ from itertools import cycle
 
 import freeorion as fo
 
-
 # tuples of consonants and vowels for random name generation
 consonants = ("b", "c", "d", "f", "g", "h", "j", "k", "l", "m", "n", "p", "q", "r", "s", "t", "v", "w", "x", "y", "z")
 vowels = ("a", "e", "i", "o", "u")

--- a/default/python/universe_generation/natives.py
+++ b/default/python/universe_generation/natives.py
@@ -7,6 +7,7 @@ import planets
 import universe_statistics
 import universe_tables
 
+
 natives_for_planet_type = {}
 planet_types_for_natives = {}
 

--- a/default/python/universe_generation/natives.py
+++ b/default/python/universe_generation/natives.py
@@ -1,5 +1,5 @@
-import random
 import itertools
+import random
 
 import freeorion as fo
 

--- a/default/python/universe_generation/options.py
+++ b/default/python/universe_generation/options.py
@@ -1,6 +1,6 @@
 import freeorion as fo
-from planets import planet_types_real, planet_sizes_real
 
+from planets import planet_sizes_real, planet_types_real
 
 ###############################
 ## STAR GROUP NAMING OPTIONS ##

--- a/default/python/universe_generation/options.py
+++ b/default/python/universe_generation/options.py
@@ -2,6 +2,7 @@ import freeorion as fo
 
 from planets import planet_sizes_real, planet_types_real
 
+
 ###############################
 ## STAR GROUP NAMING OPTIONS ##
 ###############################

--- a/default/python/universe_generation/planets.py
+++ b/default/python/universe_generation/planets.py
@@ -1,9 +1,10 @@
-import sys
 import random
-import freeorion as fo
-import util
-import universe_tables as tables
+import sys
 
+import freeorion as fo
+
+import universe_tables as tables
+import util
 
 # tuple of all valid planet sizes (with "no world")
 planet_sizes_all = (fo.planetSize.tiny, fo.planetSize.small, fo.planetSize.medium, fo.planetSize.large,

--- a/default/python/universe_generation/planets.py
+++ b/default/python/universe_generation/planets.py
@@ -6,6 +6,7 @@ import freeorion as fo
 import universe_tables as tables
 import util
 
+
 # tuple of all valid planet sizes (with "no world")
 planet_sizes_all = (fo.planetSize.tiny, fo.planetSize.small, fo.planetSize.medium, fo.planetSize.large,
                     fo.planetSize.huge, fo.planetSize.asteroids, fo.planetSize.gasGiant, fo.planetSize.noWorld)

--- a/default/python/universe_generation/specials.py
+++ b/default/python/universe_generation/specials.py
@@ -6,6 +6,7 @@ import freeorion as fo
 import universe_statistics
 import universe_tables
 
+
 # REPEAT_RATE along with calculate_number_of_specials_to_place determines if there are multiple
 # specials in a single location.  There can only be at most 4 specials in a single location.
 # The probabilites break down as follows:

--- a/default/python/universe_generation/specials.py
+++ b/default/python/universe_generation/specials.py
@@ -2,6 +2,7 @@ import random
 from collections import defaultdict
 
 import freeorion as fo
+
 import universe_statistics
 import universe_tables
 

--- a/default/python/universe_generation/starnames.py
+++ b/default/python/universe_generation/starnames.py
@@ -5,6 +5,7 @@ import freeorion as fo
 import names
 import options
 
+
 # for starname modifiers
 stargroup_words = []
 stargroup_chars = []

--- a/default/python/universe_generation/starnames.py
+++ b/default/python/universe_generation/starnames.py
@@ -1,8 +1,9 @@
 import random
-import freeorion as fo
-import options
-import names
 
+import freeorion as fo
+
+import names
+import options
 
 # for starname modifiers
 stargroup_words = []

--- a/default/python/universe_generation/starsystems.py
+++ b/default/python/universe_generation/starsystems.py
@@ -1,10 +1,12 @@
-import sys
 import random
-import freeorion as fo
-import planets
-import util
-import universe_tables
+import sys
 from itertools import product
+
+import freeorion as fo
+
+import planets
+import universe_tables
+import util
 
 # tuple of available star types
 star_types = (fo.starType.blue, fo.starType.white, fo.starType.yellow, fo.starType.orange,

--- a/default/python/universe_generation/starsystems.py
+++ b/default/python/universe_generation/starsystems.py
@@ -8,6 +8,7 @@ import planets
 import universe_tables
 import util
 
+
 # tuple of available star types
 star_types = (fo.starType.blue, fo.starType.white, fo.starType.yellow, fo.starType.orange,
               fo.starType.red, fo.starType.neutron, fo.starType.blackHole, fo.starType.noStar)

--- a/default/python/universe_generation/universe_generator.py
+++ b/default/python/universe_generation/universe_generator.py
@@ -1,4 +1,4 @@
-from common.configure_logging import redirect_logging_to_freeorion_logger, convenience_function_references_for_logger
+from common.configure_logging import convenience_function_references_for_logger, redirect_logging_to_freeorion_logger
 
 # Logging is redirected before other imports so that import errors appear in log files.
 redirect_logging_to_freeorion_logger()

--- a/default/python/universe_generation/universe_statistics.py
+++ b/default/python/universe_generation/universe_statistics.py
@@ -5,6 +5,7 @@ import natives
 import planets
 import universe_tables
 
+
 species_summary = {species: 0 for species in fo.get_native_species()}
 empire_species = {species: 0 for species in fo.get_playable_species()}
 potential_native_planet_summary = {planet_type: 0 for planet_type in planets.planet_types}

--- a/default/python/universe_generation/universe_statistics.py
+++ b/default/python/universe_generation/universe_statistics.py
@@ -1,8 +1,8 @@
 import freeorion as fo
-from common.print_utils import Table, Text, Float, Sequence
+from common.print_utils import Float, Sequence, Table, Text
 
-import planets
 import natives
+import planets
 import universe_tables
 
 species_summary = {species: 0 for species in fo.get_native_species()}

--- a/default/python/universe_generation/util.py
+++ b/default/python/universe_generation/util.py
@@ -1,8 +1,7 @@
-import sys
 import math
 import random
+import sys
 from hashlib import md5
-
 
 error_list = []
 


### PR DESCRIPTION
Reformat import in next way:
```
python imports
<empty line>
3d party imports (`import freeorion as fo`)
<empty line>
universe_generation imports
```

Each group split to two subgroups: `import ...` and `from ....`
All import in subgroups sorted by abc.  All import in line sorted by abc. 

Unused imports removed. 

Set 2 blank line after import.

Changes done via "Optimize import" action of PyCharm.  
I used custom setting, see attached screenshot

![import_sorting](https://user-images.githubusercontent.com/171597/30350147-3fd2d0be-981e-11e7-8d60-bd7b44eef07c.png)
![import_wrapping](https://user-images.githubusercontent.com/171597/30350148-3fda44d4-981e-11e7-970a-6125fda7bd13.png)
![2blank_after_import](https://user-images.githubusercontent.com/171597/30510462-3af8a5b2-9acd-11e7-821c-817f0d6e3500.png)



