### PR TITLE
Let the AI surrender if it has no more populated planets

### DIFF
--- a/default/python/AI/AIstate.py
+++ b/default/python/AI/AIstate.py
@@ -994,6 +994,7 @@ class AIstate(object):
 
     def surrender(self):
         chat_human("Well played. I surrender.")
+        chat_human("NOTE: The AI will accept any peace or alliance proposal at this point.")
         self.surrendered = True
         my_empire_id = fo.empireID()
         for empire_id in fo.allEmpireIDs():

--- a/default/python/AI/AIstate.py
+++ b/default/python/AI/AIstate.py
@@ -13,7 +13,7 @@ from EnumsAI import MissionType, ShipRoleType
 import CombatRatingsAI
 import MilitaryAI
 import PlanetUtilsAI
-from freeorion_tools import dict_from_map, get_partial_visibility_turn
+from freeorion_tools import dict_from_map, get_partial_visibility_turn, chat_human
 from universe_object import System
 from AIDependencies import INVALID_ID
 from character.character_module import create_character, Aggression
@@ -87,6 +87,10 @@ def convert_to_version(state, version):
         for var_name in ['visInteriorSystemIDs', 'exploredSystemIDs', 'visBorderSystemIDs', 'unexploredSystemIDs']:
             state[var_name] = set(state.get(var_name, {}).keys())
 
+    elif version == 3:
+        # added functionality for AI to surrender
+        state['surrendered'] = False
+
     #   state["some_new_member"] = some_default_value
     #   del state["some_removed_member"]
     #   state["list_changed_to_set"] = set(state["list_changed_to_set"])
@@ -105,7 +109,7 @@ class AIstate(object):
     is playable with this AIstate version, i.e. new members must be added
     and outdated members must be modified and / or deleted.
     """
-    version = 2
+    version = 3
 
     def __init__(self, aggression):
         # Do not allow to create AIstate instances with an invalid version number.
@@ -169,6 +173,7 @@ class AIstate(object):
         self.__empire_standard_enemy = CombatRatingsAI.default_ship_stats().get_stats(hashable=True)
         self.empire_standard_enemy_rating = 0  # TODO: track on a per-empire basis
         self.character = create_character(aggression, self.empireID)
+        self.surrendered = False
 
     def __setstate__(self, state):
         try:
@@ -986,3 +991,7 @@ class AIstate(object):
 
     def get_standard_enemy(self):
         return CombatRatingsAI.ShipCombatStats(stats=self.__empire_standard_enemy)
+
+    def surrender(self):
+        chat_human("Well played. I surrender.")
+        self.surrendered = True

--- a/default/python/AI/AIstate.py
+++ b/default/python/AI/AIstate.py
@@ -995,3 +995,21 @@ class AIstate(object):
     def surrender(self):
         chat_human("Well played. I surrender.")
         self.surrendered = True
+        my_empire_id = fo.empireID()
+        for empire_id in fo.allEmpireIDs():
+            if empire_id == my_empire_id or fo.playerIsAI(empire_id):
+                continue
+            try:
+                msg = fo.diplomaticMessage(my_empire_id, empire_id,
+                                           fo.diplomaticMessageType.peaceProposal)
+                debug("Sending peace proposal")
+                fo.sendDiplomaticMessage(msg)
+            except:
+                pass
+            try:
+                msg = fo.diplomaticMessage(my_empire_id, empire_id,
+                                           fo.diplomaticMessageType.alliesProposal)
+                debug("Sending allies proposal")
+                fo.sendDiplomaticMessage(msg)
+            except:
+                pass

--- a/default/python/AI/DiplomaticCorp.py
+++ b/default/python/AI/DiplomaticCorp.py
@@ -37,9 +37,22 @@ class DiplomaticCorp(object):
         # TODO: remove the following early return once proper support for third party diplomatic history is added
         if message.recipient != fo.empireID():
             return
+
+        if message.type == fo.diplomaticMessageType.alliesProposal:
+            if foAI.foAIstate.surrendered:
+                fo.sendChatMessage(message.sender, "Yes, master.")
+                fo.sendDiplomaticMessage(fo.diplomaticMessage(message.recipient, message.sender,
+                                                              fo.diplomaticMessageType.acceptAlliesProposal))
+                return
+
         if message.type == fo.diplomaticMessageType.peaceProposal:
             foAI.foAIstate.log_peace_request(message.sender, message.recipient)
             proposal_sender_player = fo.empirePlayerID(message.sender)
+            if foAI.foAIstate.surrendered:
+                fo.sendChatMessage(message.sender, "Yes, master.")
+                fo.sendDiplomaticMessage(fo.diplomaticMessage(message.recipient, message.sender,
+                                                              fo.diplomaticMessageType.acceptPeaceProposal))
+                return
             attitude = foAI.foAIstate.character.attitude_to_empire(message.sender, foAI.foAIstate.diplomatic_logs)
             possible_acknowledgments = []
             aggression = foAI.foAIstate.character.get_trait(Aggression)

--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -257,6 +257,21 @@ def generateOrders():  # pylint: disable=invalid-name
             error("Exception %s while trying doneTurn() on eliminated empire" % e, exc_info=True)
         return
 
+    universe = fo.getUniverse()
+    if not any(planet and planet.speciesName and planet.ownedBy(empire.empireID)
+               for planet in map(universe.getPlanet, universe.planetIDs)):
+        debug("This empire has no colonies left. Surrendering.")
+        if not foAIstate.surrendered:
+            foAIstate.surrender()
+
+    if foAIstate.surrendered:
+        try:
+            debug("The AI has surrendered. Aborting order calculation.")
+            fo.doneTurn()
+        except Exception as e:
+            error("Exception %s while trying doneTurn() on surrendered AI" % e, exc_info=True)
+        return
+
     # This code block is required for correct AI work.
     info("Meter / Resource Pool updating...")
     fo.initMeterEstimatesDiscrepancies()


### PR DESCRIPTION
The AI basically lost if is has no more populated planets. There are no comeback mechanics that make it worth trying to play on. The AI will achieve nothing at that point.

Surrendering for now means offering humans peace/alliance (and accepting any such proposal) and from then on basically just passing the turn. This avoids all these random and often hard to track down errors and chat message spam that occurs if some AI code relies on the AI having some planets.

It may also give the human player a somewhat satisfying end so that he does not necessarily feel pushed to clean up all the remaining AI ships just to see the win SitRep (which of course still is possible).

For easier testing, best use ingame console:
```
start 2
ai.surrender()
```