### PR TITLE
Add policy comment to colony building definitions

### DIFF
--- a/default/scripting/buildings/colonies/SP_ABADDONI.focs.txt
+++ b/default/scripting/buildings/colonies/SP_ABADDONI.focs.txt
@@ -1,3 +1,5 @@
+// For long term changes - Do not modify this definition directly
+//                     Instead modify and execute col_bld_gen.py and use the result.
 BuildingType
     name = "BLD_COL_ABADDONI"
     description = "BLD_COL_ABADDONI_DESC"

--- a/default/scripting/buildings/colonies/SP_BANFORO.focs.txt
+++ b/default/scripting/buildings/colonies/SP_BANFORO.focs.txt
@@ -1,3 +1,5 @@
+// For long term changes - Do not modify this definition directly
+//                     Instead modify and execute col_bld_gen.py and use the result.
 BuildingType
     name = "BLD_COL_BANFORO"
     description = "BLD_COL_BANFORO_DESC"
@@ -30,12 +32,12 @@ BuildingType
                  OwnerHasTech name = "SHP_ORG_HULL"
                  OwnerHasTech name = "SHP_QUANT_ENRG_MAG"
              ])
-             + 20 * (Statistic If Condition = OwnerHasTech Name = "SHP_QUANT_ENRG_MAG")
-             + 10 * (Statistic If Condition = OwnerHasTech Name = "SHP_IMPROVED_ENGINE_COUPLINGS")
-             + 10 * (Statistic If Condition = OwnerHasTech Name = "SHP_N_DIMENSIONAL_ENGINE_MATRIX")
-             + 10 * (Statistic If Condition = OwnerHasTech Name = "SHP_SINGULARITY_ENGINE_CORE")
-             + 10 * (Statistic If Condition = OwnerHasTech Name = "SHP_TRANSSPACE_DRIVE")
-             + 10 * (Statistic If Condition = OwnerHasTech Name = "SHP_INTSTEL_LOG")
+             + 20 * (Statistic If Condition = OwnerHasTech name = "SHP_QUANT_ENRG_MAG")
+             + 10 * (Statistic If Condition = OwnerHasTech name = "SHP_IMPROVED_ENGINE_COUPLINGS")
+             + 10 * (Statistic If Condition = OwnerHasTech name = "SHP_N_DIMENSIONAL_ENGINE_MATRIX")
+             + 10 * (Statistic If Condition = OwnerHasTech name = "SHP_SINGULARITY_ENGINE_CORE")
+             + 10 * (Statistic If Condition = OwnerHasTech name = "SHP_TRANSSPACE_DRIVE")
+             + 10 * (Statistic If Condition = OwnerHasTech name = "SHP_INTSTEL_LOG")
         )
     )
     tags = [ "SP_BANFORO" "CTRL_EXTINCT" ]

--- a/default/scripting/buildings/colonies/SP_CHATO.focs.txt
+++ b/default/scripting/buildings/colonies/SP_CHATO.focs.txt
@@ -1,3 +1,5 @@
+// For long term changes - Do not modify this definition directly
+//                     Instead modify and execute col_bld_gen.py and use the result.
 BuildingType
     name = "BLD_COL_CHATO"
     description = "BLD_COL_CHATO_DESC"

--- a/default/scripting/buildings/colonies/SP_CRAY.focs.txt
+++ b/default/scripting/buildings/colonies/SP_CRAY.focs.txt
@@ -1,3 +1,5 @@
+// For long term changes - Do not modify this definition directly
+//                     Instead modify and execute col_bld_gen.py and use the result.
 BuildingType
     name = "BLD_COL_CRAY"
     description = "BLD_COL_CRAY_DESC"

--- a/default/scripting/buildings/colonies/SP_DERTHREAN.focs.txt
+++ b/default/scripting/buildings/colonies/SP_DERTHREAN.focs.txt
@@ -1,3 +1,5 @@
+// For long term changes - Do not modify this definition directly
+//                     Instead modify and execute col_bld_gen.py and use the result.
 BuildingType
     name = "BLD_COL_DERTHREAN"
     description = "BLD_COL_DERTHREAN_DESC"

--- a/default/scripting/buildings/colonies/SP_EAXAW.focs.txt
+++ b/default/scripting/buildings/colonies/SP_EAXAW.focs.txt
@@ -1,3 +1,5 @@
+// For long term changes - Do not modify this definition directly
+//                     Instead modify and execute col_bld_gen.py and use the result.
 BuildingType
     name = "BLD_COL_EAXAW"
     description = "BLD_COL_EAXAW_DESC"

--- a/default/scripting/buildings/colonies/SP_EGASSEM.focs.txt
+++ b/default/scripting/buildings/colonies/SP_EGASSEM.focs.txt
@@ -1,3 +1,5 @@
+// For long term changes - Do not modify this definition directly
+//                     Instead modify and execute col_bld_gen.py and use the result.
 BuildingType
     name = "BLD_COL_EGASSEM"
     description = "BLD_COL_EGASSEM_DESC"

--- a/default/scripting/buildings/colonies/SP_ETTY.focs.txt
+++ b/default/scripting/buildings/colonies/SP_ETTY.focs.txt
@@ -1,3 +1,5 @@
+// For long term changes - Do not modify this definition directly
+//                     Instead modify and execute col_bld_gen.py and use the result.
 BuildingType
     name = "BLD_COL_ETTY"
     description = "BLD_COL_ETTY_DESC"

--- a/default/scripting/buildings/colonies/SP_EXOBOT.focs.txt
+++ b/default/scripting/buildings/colonies/SP_EXOBOT.focs.txt
@@ -1,3 +1,5 @@
+// For long term changes - Do not modify this definition directly
+//                     Instead modify and execute col_bld_gen.py and use the result.
 BuildingType
     name = "BLD_COL_EXOBOT"
     description = "BLD_COL_EXOBOT_DESC"

--- a/default/scripting/buildings/colonies/SP_FURTHEST.focs.txt
+++ b/default/scripting/buildings/colonies/SP_FURTHEST.focs.txt
@@ -1,3 +1,5 @@
+// For long term changes - Do not modify this definition directly
+//                     Instead modify and execute col_bld_gen.py and use the result.
 BuildingType
     name = "BLD_COL_FURTHEST"
     description = "BLD_COL_FURTHEST_DESC"

--- a/default/scripting/buildings/colonies/SP_GEORGE.focs.txt
+++ b/default/scripting/buildings/colonies/SP_GEORGE.focs.txt
@@ -1,3 +1,5 @@
+// For long term changes - Do not modify this definition directly
+//                     Instead modify and execute col_bld_gen.py and use the result.
 BuildingType
     name = "BLD_COL_GEORGE"
     description = "BLD_COL_GEORGE_DESC"

--- a/default/scripting/buildings/colonies/SP_GYSACHE.focs.txt
+++ b/default/scripting/buildings/colonies/SP_GYSACHE.focs.txt
@@ -1,3 +1,5 @@
+// For long term changes - Do not modify this definition directly
+//                     Instead modify and execute col_bld_gen.py and use the result.
 BuildingType
     name = "BLD_COL_GYSACHE"
     description = "BLD_COL_GYSACHE_DESC"

--- a/default/scripting/buildings/colonies/SP_HAPPY.focs.txt
+++ b/default/scripting/buildings/colonies/SP_HAPPY.focs.txt
@@ -1,3 +1,5 @@
+// For long term changes - Do not modify this definition directly
+//                     Instead modify and execute col_bld_gen.py and use the result.
 BuildingType
     name = "BLD_COL_HAPPY"
     description = "BLD_COL_HAPPY_DESC"

--- a/default/scripting/buildings/colonies/SP_HHHOH.focs.txt
+++ b/default/scripting/buildings/colonies/SP_HHHOH.focs.txt
@@ -1,3 +1,5 @@
+// For long term changes - Do not modify this definition directly
+//                     Instead modify and execute col_bld_gen.py and use the result.
 BuildingType
     name = "BLD_COL_HHHOH"
     description = "BLD_COL_HHHOH_DESC"

--- a/default/scripting/buildings/colonies/SP_HUMAN.focs.txt
+++ b/default/scripting/buildings/colonies/SP_HUMAN.focs.txt
@@ -1,3 +1,5 @@
+// For long term changes - Do not modify this definition directly
+//                     Instead modify and execute col_bld_gen.py and use the result.
 BuildingType
     name = "BLD_COL_HUMAN"
     description = "BLD_COL_HUMAN_DESC"

--- a/default/scripting/buildings/colonies/SP_KILANDOW.focs.txt
+++ b/default/scripting/buildings/colonies/SP_KILANDOW.focs.txt
@@ -1,3 +1,5 @@
+// For long term changes - Do not modify this definition directly
+//                     Instead modify and execute col_bld_gen.py and use the result.
 BuildingType
     name = "BLD_COL_KILANDOW"
     description = "BLD_COL_KILANDOW_DESC"
@@ -30,12 +32,12 @@ BuildingType
                  OwnerHasTech name = "SHP_ORG_HULL"
                  OwnerHasTech name = "SHP_QUANT_ENRG_MAG"
              ])
-             + 20 * (Statistic If Condition = OwnerHasTech Name = "SHP_QUANT_ENRG_MAG")
-             + 10 * (Statistic If Condition = OwnerHasTech Name = "SHP_IMPROVED_ENGINE_COUPLINGS")
-             + 10 * (Statistic If Condition = OwnerHasTech Name = "SHP_N_DIMENSIONAL_ENGINE_MATRIX")
-             + 10 * (Statistic If Condition = OwnerHasTech Name = "SHP_SINGULARITY_ENGINE_CORE")
-             + 10 * (Statistic If Condition = OwnerHasTech Name = "SHP_TRANSSPACE_DRIVE")
-             + 10 * (Statistic If Condition = OwnerHasTech Name = "SHP_INTSTEL_LOG")
+             + 20 * (Statistic If Condition = OwnerHasTech name = "SHP_QUANT_ENRG_MAG")
+             + 10 * (Statistic If Condition = OwnerHasTech name = "SHP_IMPROVED_ENGINE_COUPLINGS")
+             + 10 * (Statistic If Condition = OwnerHasTech name = "SHP_N_DIMENSIONAL_ENGINE_MATRIX")
+             + 10 * (Statistic If Condition = OwnerHasTech name = "SHP_SINGULARITY_ENGINE_CORE")
+             + 10 * (Statistic If Condition = OwnerHasTech name = "SHP_TRANSSPACE_DRIVE")
+             + 10 * (Statistic If Condition = OwnerHasTech name = "SHP_INTSTEL_LOG")
         )
     )
     tags = [ "SP_KILANDOW" "CTRL_EXTINCT" ]

--- a/default/scripting/buildings/colonies/SP_KOBUNTURA.focs.txt
+++ b/default/scripting/buildings/colonies/SP_KOBUNTURA.focs.txt
@@ -1,3 +1,5 @@
+// For long term changes - Do not modify this definition directly
+//                     Instead modify and execute col_bld_gen.py and use the result.
 BuildingType
     name = "BLD_COL_KOBUNTURA"
     description = "BLD_COL_KOBUNTURA_DESC"

--- a/default/scripting/buildings/colonies/SP_LAENFA.focs.txt
+++ b/default/scripting/buildings/colonies/SP_LAENFA.focs.txt
@@ -1,3 +1,5 @@
+// For long term changes - Do not modify this definition directly
+//                     Instead modify and execute col_bld_gen.py and use the result.
 BuildingType
     name = "BLD_COL_LAENFA"
     description = "BLD_COL_LAENFA_DESC"

--- a/default/scripting/buildings/colonies/SP_MISIORLA.focs.txt
+++ b/default/scripting/buildings/colonies/SP_MISIORLA.focs.txt
@@ -1,3 +1,5 @@
+// For long term changes - Do not modify this definition directly
+//                     Instead modify and execute col_bld_gen.py and use the result.
 BuildingType
     name = "BLD_COL_MISIORLA"
     description = "BLD_COL_MISIORLA_DESC"
@@ -30,12 +32,12 @@ BuildingType
                  OwnerHasTech name = "SHP_ORG_HULL"
                  OwnerHasTech name = "SHP_QUANT_ENRG_MAG"
              ])
-             + 20 * (Statistic If Condition = OwnerHasTech Name = "SHP_QUANT_ENRG_MAG")
-             + 10 * (Statistic If Condition = OwnerHasTech Name = "SHP_IMPROVED_ENGINE_COUPLINGS")
-             + 10 * (Statistic If Condition = OwnerHasTech Name = "SHP_N_DIMENSIONAL_ENGINE_MATRIX")
-             + 10 * (Statistic If Condition = OwnerHasTech Name = "SHP_SINGULARITY_ENGINE_CORE")
-             + 10 * (Statistic If Condition = OwnerHasTech Name = "SHP_TRANSSPACE_DRIVE")
-             + 10 * (Statistic If Condition = OwnerHasTech Name = "SHP_INTSTEL_LOG")
+             + 20 * (Statistic If Condition = OwnerHasTech name = "SHP_QUANT_ENRG_MAG")
+             + 10 * (Statistic If Condition = OwnerHasTech name = "SHP_IMPROVED_ENGINE_COUPLINGS")
+             + 10 * (Statistic If Condition = OwnerHasTech name = "SHP_N_DIMENSIONAL_ENGINE_MATRIX")
+             + 10 * (Statistic If Condition = OwnerHasTech name = "SHP_SINGULARITY_ENGINE_CORE")
+             + 10 * (Statistic If Condition = OwnerHasTech name = "SHP_TRANSSPACE_DRIVE")
+             + 10 * (Statistic If Condition = OwnerHasTech name = "SHP_INTSTEL_LOG")
         )
     )
     tags = [ "SP_MISIORLA" "CTRL_EXTINCT" ]

--- a/default/scripting/buildings/colonies/SP_MUURSH.focs.txt
+++ b/default/scripting/buildings/colonies/SP_MUURSH.focs.txt
@@ -1,3 +1,5 @@
+// For long term changes - Do not modify this definition directly
+//                     Instead modify and execute col_bld_gen.py and use the result.
 BuildingType
     name = "BLD_COL_MUURSH"
     description = "BLD_COL_MUURSH_DESC"

--- a/default/scripting/buildings/colonies/SP_PHINNERT.focs.txt
+++ b/default/scripting/buildings/colonies/SP_PHINNERT.focs.txt
@@ -1,3 +1,5 @@
+// For long term changes - Do not modify this definition directly
+//                     Instead modify and execute col_bld_gen.py and use the result.
 BuildingType
     name = "BLD_COL_PHINNERT"
     description = "BLD_COL_PHINNERT_DESC"

--- a/default/scripting/buildings/colonies/SP_REPLICON.focs.txt
+++ b/default/scripting/buildings/colonies/SP_REPLICON.focs.txt
@@ -1,7 +1,9 @@
+// For long term changes - Do not modify this definition directly
+//                     Instead modify and execute col_bld_gen.py and use the result.
 BuildingType
     name = "BLD_COL_REPLICON"
     description = "BLD_COL_REPLICON_DESC"
-    buildcost = 50 * [[COLONY_UPKEEP_MULTIPLICATOR]]
+    buildcost = 50 * [[COLONY_UPKEEP_MULTIPLICATOR]] * [[BUILDING_COST_MULTIPLIER]]
     buildtime = 1.0 * max(5.0, 1.0 +
         (Statistic Min Value = ShortestPath Object = Target.SystemID Object = LocalCandidate.SystemID
             Condition = And [
@@ -112,5 +114,5 @@ BuildingType
     icon = "icons/species/replicon.png"
 
 #include "/scripting/common/misc.macros"
-
 #include "/scripting/common/upkeep.macros"
+#include "/scripting/common/base_prod.macros"

--- a/default/scripting/buildings/colonies/SP_SCYLIOR.focs.txt
+++ b/default/scripting/buildings/colonies/SP_SCYLIOR.focs.txt
@@ -1,3 +1,5 @@
+// For long term changes - Do not modify this definition directly
+//                     Instead modify and execute col_bld_gen.py and use the result.
 BuildingType
     name = "BLD_COL_SCYLIOR"
     description = "BLD_COL_SCYLIOR_DESC"

--- a/default/scripting/buildings/colonies/SP_SETINON.focs.txt
+++ b/default/scripting/buildings/colonies/SP_SETINON.focs.txt
@@ -1,3 +1,5 @@
+// For long term changes - Do not modify this definition directly
+//                     Instead modify and execute col_bld_gen.py and use the result.
 BuildingType
     name = "BLD_COL_SETINON"
     description = "BLD_COL_SETINON_DESC"

--- a/default/scripting/buildings/colonies/SP_SILEXIAN.focs.txt
+++ b/default/scripting/buildings/colonies/SP_SILEXIAN.focs.txt
@@ -1,3 +1,5 @@
+// For long term changes - Do not modify this definition directly
+//                     Instead modify and execute col_bld_gen.py and use the result.
 BuildingType
     name = "BLD_COL_SILEXIAN"
     description = "BLD_COL_SILEXIAN_DESC"

--- a/default/scripting/buildings/colonies/SP_SSLITH.focs.txt
+++ b/default/scripting/buildings/colonies/SP_SSLITH.focs.txt
@@ -1,3 +1,5 @@
+// For long term changes - Do not modify this definition directly
+//                     Instead modify and execute col_bld_gen.py and use the result.
 BuildingType
     name = "BLD_COL_SSLITH"
     description = "BLD_COL_SSLITH_DESC"

--- a/default/scripting/buildings/colonies/SP_SUPER_TEST.focs.txt
+++ b/default/scripting/buildings/colonies/SP_SUPER_TEST.focs.txt
@@ -1,3 +1,5 @@
+// For long term changes - Do not modify this definition directly
+//                     Instead modify and execute col_bld_gen.py and use the result.
 BuildingType
     name = "BLD_COL_SUPER_TEST"
     description = "BLD_COL_SUPER_TEST_DESC"

--- a/default/scripting/buildings/colonies/SP_TAEGHIRUS.focs.txt
+++ b/default/scripting/buildings/colonies/SP_TAEGHIRUS.focs.txt
@@ -1,3 +1,5 @@
+// For long term changes - Do not modify this definition directly
+//                     Instead modify and execute col_bld_gen.py and use the result.
 BuildingType
     name = "BLD_COL_TAEGHIRUS"
     description = "BLD_COL_TAEGHIRUS_DESC"

--- a/default/scripting/buildings/colonies/SP_TRITH.focs.txt
+++ b/default/scripting/buildings/colonies/SP_TRITH.focs.txt
@@ -1,3 +1,5 @@
+// For long term changes - Do not modify this definition directly
+//                     Instead modify and execute col_bld_gen.py and use the result.
 BuildingType
     name = "BLD_COL_TRITH"
     description = "BLD_COL_TRITH_DESC"

--- a/default/scripting/buildings/colonies/SP_UGMORS.focs.txt
+++ b/default/scripting/buildings/colonies/SP_UGMORS.focs.txt
@@ -1,3 +1,5 @@
+// For long term changes - Do not modify this definition directly
+//                     Instead modify and execute col_bld_gen.py and use the result.
 BuildingType
     name = "BLD_COL_UGMORS"
     description = "BLD_COL_UGMORS_DESC"

--- a/default/scripting/buildings/colonies/col_bld_gen.py
+++ b/default/scripting/buildings/colonies/col_bld_gen.py
@@ -79,7 +79,9 @@ species_time_factor = {
 
 
 # Main template
-t_main = string.Template('''BuildingType
+t_main = string.Template('''// For long term changes - Do not modify this definition directly
+//                     Instead modify and execute col_bld_gen.py and use the result.
+BuildingType
     name = "BLD_COL_${name}"
     description = "BLD_COL_${name}_DESC"
     buildcost = ${cost} * [[COLONY_UPKEEP_MULTIPLICATOR]] * [[BUILDING_COST_MULTIPLIER]]

--- a/default/scripting/buildings/colonies/col_bld_gen.py
+++ b/default/scripting/buildings/colonies/col_bld_gen.py
@@ -1,50 +1,84 @@
+"""col_bld_gen.py
+
+Utility script to generate consistent colony building definitions for each species.
+This script is not utilized by the game.
+
+When executed, definition files will be generated in the current working directory.
+"""
+
 import os
 import os.path
 import string
 
 
+# List of all species in game: definition key, graphic file(relative to default/data/art)
 species_list = [
-    ("SP_SUPER_TEST", "Super Tester", "icons/species/other-04.png"),
-    ("SP_ABADDONI", "Abaddoni", "icons/species/abaddonnian.png"),
-    ("SP_BANFORO", "Banforo", "icons/species/banforo.png"),
-    ("SP_CHATO", "Chato", "icons/species/chato-matou-gormoshk.png"),
-    ("SP_CRAY", "Cray", "icons/species/cray.png"),
-    ("SP_DERTHREAN", "Derthrean", "icons/species/derthrean.png"),
-    ("SP_EAXAW", "Eaxaw", "icons/species/eaxaw.png"),
-    ("SP_EGASSEM", "Egassem", "icons/species/egassem.png"),
-    ("SP_ETTY", "Etty", "icons/species/etty.png"),
-    ("SP_FURTHEST", "Furthest", "icons/species/furthest.png"),
-    ("SP_GEORGE", "George", "icons/species/george.png"),
-    ("SP_GYSACHE", "Gysache", "icons/species/gysache.png"),
-    ("SP_HAPPY", "Happybirthday", "icons/species/ichthyoid-06.png"),
-    ("SP_HHHOH", "Hhhoh", "icons/species/hhhoh.png"),
-    ("SP_HUMAN", "Human", "icons/species/human.png"),
-    ("SP_KILANDOW", "Kilandow", "icons/species/kilandow.png"),
-    ("SP_KOBUNTURA", "Kobuntura", "icons/species/intangible-04.png"),
-    ("SP_LAENFA", "Laenfa", "icons/species/laenfa.png"),
-    ("SP_MISIORLA", "Misiorla", "icons/species/misiorla.png"),
-    ("SP_MUURSH", "Mu Ursh", "icons/species/muursh.png"),
-    ("SP_PHINNERT", "Phinnert", "icons/species/phinnert.png"),
-    ("SP_SCYLIOR", "Scylior", "icons/species/scylior.png"),
-    ("SP_SETINON", "Setinon", "icons/species/amorphous-02.png"),
-    ("SP_SILEXIAN", "Silexian", "icons/species/robotic-06.png"),
-    ("SP_SSLITH", "Sslith", "icons/species/sslith.png"),
-    ("SP_TAEGHIRUS", "Tae Ghirus", "icons/species/t-aeghirus.png"),
-    ("SP_TRITH", "Trith", "icons/species/trith.png"),
-    ("SP_REPLICON", "Replicons", "icons/species/replicon.png"),
-    ("SP_UGMORS", "Ugmors", "icons/species/amorphous-06.png"),
-    ("SP_EXOBOT", "Exobot", "icons/species/robotic-01.png")
+    ("SP_SUPER_TEST", "icons/species/other-04.png"),
+    ("SP_ABADDONI", "icons/species/abaddonnian.png"),
+    ("SP_BANFORO", "icons/species/banforo.png"),
+    ("SP_CHATO", "icons/species/chato-matou-gormoshk.png"),
+    ("SP_CRAY", "icons/species/cray.png"),
+    ("SP_DERTHREAN", "icons/species/derthrean.png"),
+    ("SP_EAXAW", "icons/species/eaxaw.png"),
+    ("SP_EGASSEM", "icons/species/egassem.png"),
+    ("SP_ETTY", "icons/species/etty.png"),
+    ("SP_FURTHEST", "icons/species/furthest.png"),
+    ("SP_GEORGE", "icons/species/george.png"),
+    ("SP_GYSACHE", "icons/species/gysache.png"),
+    ("SP_HAPPY", "icons/species/ichthyoid-06.png"),
+    ("SP_HHHOH", "icons/species/hhhoh.png"),
+    ("SP_HUMAN", "icons/species/human.png"),
+    ("SP_KILANDOW", "icons/species/kilandow.png"),
+    ("SP_KOBUNTURA", "icons/species/intangible-04.png"),
+    ("SP_LAENFA", "icons/species/laenfa.png"),
+    ("SP_MISIORLA", "icons/species/misiorla.png"),
+    ("SP_MUURSH", "icons/species/muursh.png"),
+    ("SP_PHINNERT", "icons/species/phinnert.png"),
+    ("SP_SCYLIOR", "icons/species/scylior.png"),
+    ("SP_SETINON", "icons/species/amorphous-02.png"),
+    ("SP_SILEXIAN", "icons/species/robotic-06.png"),
+    ("SP_SSLITH", "icons/species/sslith.png"),
+    ("SP_TAEGHIRUS", "icons/species/t-aeghirus.png"),
+    ("SP_TRITH", "icons/species/trith.png"),
+    ("SP_REPLICON", "icons/species/replicon.png"),
+    ("SP_UGMORS", "icons/species/amorphous-06.png"),
+    ("SP_EXOBOT", "icons/species/robotic-01.png")
 ]
 
-tech_dict = dict(
-    SP_BANFORO="TECH_COL_BANFORO",
-    SP_KILANDOW="TECH_COL_KILANDOW",
-    SP_MISIORLA="TECH_COL_MISIORLA"
-)
+# Species which start as extinct and tech enabling colonization without a suitable colony in supply range
+species_extinct_techs = {
+    "SP_BANFORO": "TECH_COL_BANFORO",
+    "SP_KILANDOW": "TECH_COL_KILANDOW",
+    "SP_MISIORLA": "TECH_COL_MISIORLA"
+}
 
-time_factor = {"SP_HAPPY": "1.2", "SP_PHINNERT": "0.75"}
+# Default gamerule to toggle availablity of colony buildings for a species (no rule)
+colony_gamerule_default = ""
+
+# Species specific gamerule enabling colony building
+species_colony_gamerules = {
+    "SP_SUPER_TEST": "RULE_ENABLE_SUPER_TESTER"
+}
+
+# default base buildcost
+buildcost_default = 50
+
+# Species specific overrides to base buildcost
+species_buildcost = {
+    "SP_EXOBOT": 70
+}
+
+# default buildtime factor
+buildtime_factor_default = "1.0"
+
+# Species specific overrides to default buildtime factor
+species_time_factor = {
+    "SP_HAPPY": "1.2",
+    "SP_PHINNERT": "0.75"
+}
 
 
+# Main template
 t_main = string.Template('''BuildingType
     name = "BLD_COL_${name}"
     description = "BLD_COL_${name}_DESC"
@@ -124,7 +158,8 @@ t_main = string.Template('''BuildingType
 #include "/scripting/common/base_prod.macros"
 ''')
 
-t_species_condition = string.Template(
+# Location and Enqueued condition template
+t_species_cond = string.Template(
     '''ResourceSupplyConnected empire = Source.Owner condition = And [
             Planet
             OwnedBy empire = Source.Owner
@@ -133,7 +168,8 @@ t_species_condition = string.Template(
             Happiness low = 5
         ]''')
 
-t_species_condition_extinct = string.Template(
+# Location and Enqueued condition template for extinct species
+t_species_cond_extinct = string.Template(
     '''ResourceSupplyConnected empire = Source.Owner condition = And [
             Planet
             OwnedBy empire = Source.Owner
@@ -151,16 +187,40 @@ t_species_condition_extinct = string.Template(
             ]
         ]''')
 
-t_buildtime = string.Template('''${t_factor} * max(5.0, 1.0 +
-        (Statistic Min Value = ShortestPath Object = Target.SystemID Object = LocalCandidate.SystemID
-            Condition = And [
+# buildtime statistic condition template
+t_buildtime_stat_cond = string.Template(
+    '''Condition = And [
                 Planet
                 OwnedBy empire = Source.Owner
                 Species name = "${id}"
                 Population low = [[MIN_RECOLONIZING_SIZE]]
                 Happiness low = 5
                 ResourceSupplyConnected empire = Source.Owner condition = Target
+            ]''')
+
+# buildtime statistic condition template for extinct species
+t_buildtime_stat_cond_extinct = string.Template(
+    '''Condition = And [
+                Planet
+                OwnedBy empire = Source.Owner
+            Or [
+               And [
+                   Species name = "${id}"
+                   Population low = [[MIN_RECOLONIZING_SIZE]]
+                   Happiness low = 5
+                ]
+                And [
+                    HasSpecial name = "EXTINCT_${name}_SPECIAL"
+                    Contains Building name = "BLD_XENORESURRECTION_LAB"
+                ]
             ]
+                ResourceSupplyConnected empire = Source.Owner condition = Target
+            ]''')
+
+# buildtime template
+t_buildtime = string.Template('''${t_factor} * max(5.0, 1.0 +
+        (Statistic Min Value = ShortestPath Object = Target.SystemID Object = LocalCandidate.SystemID
+            ${stat_condition}
         ) / (60
              + 20 * (Statistic If Condition = Or [
                  OwnerHasTech name = "SHP_MIL_ROBO_CONT"
@@ -180,73 +240,45 @@ t_buildtime = string.Template('''${t_factor} * max(5.0, 1.0 +
         )
     )''')
 
-t_buildtime_extinct = string.Template('''${t_factor} * max(5.0, 1.0 +
-        (Statistic Min Value = ShortestPath Object = Target.SystemID Object = LocalCandidate.SystemID
-            Condition = And [
-                Planet
-                OwnedBy empire = Source.Owner
-            Or [
-               And [
-                   Species name = "${id}"
-                   Population low = [[MIN_RECOLONIZING_SIZE]]
-                   Happiness low = 5
-                ]
-                And [
-                    HasSpecial name = "EXTINCT_${name}_SPECIAL"
-                    Contains Building name = "BLD_XENORESURRECTION_LAB"
-                ]
-            ]
-                ResourceSupplyConnected empire = Source.Owner condition = Target
-            ]
-        ) / (60
-             + 20 * (Statistic If Condition = Or [
-                 OwnerHasTech name = "SHP_MIL_ROBO_CONT"
-                 OwnerHasTech name = "SHP_ORG_HULL"
-                 OwnerHasTech name = "SHP_QUANT_ENRG_MAG"
-             ])
-             + 20 * (Statistic If Condition = Or [
-                 OwnerHasTech name = "SHP_ORG_HULL"
-                 OwnerHasTech name = "SHP_QUANT_ENRG_MAG"
-             ])
-             + 20 * (Statistic If Condition = OwnerHasTech Name = "SHP_QUANT_ENRG_MAG")
-             + 10 * (Statistic If Condition = OwnerHasTech Name = "SHP_IMPROVED_ENGINE_COUPLINGS")
-             + 10 * (Statistic If Condition = OwnerHasTech Name = "SHP_N_DIMENSIONAL_ENGINE_MATRIX")
-             + 10 * (Statistic If Condition = OwnerHasTech Name = "SHP_SINGULARITY_ENGINE_CORE")
-             + 10 * (Statistic If Condition = OwnerHasTech Name = "SHP_TRANSSPACE_DRIVE")
-             + 10 * (Statistic If Condition = OwnerHasTech Name = "SHP_INTSTEL_LOG")
-        )
-    )''')
-
 outpath = os.getcwd()
-print ("Output folder: %s" % outpath)
+print("Output folder: %s" % outpath)
 
-for sp_id, sp_desc_name, sp_graphic in species_list:
+for sp_id, sp_graphic in species_list:
     sp_name = sp_id.split("_", 1)[1]
     sp_tags = '"' + sp_id + '"'
     sp_filename = sp_id + ".focs.txt"
-    sp_tech = tech_dict.get(sp_id, '')
+    sp_gamerule = species_colony_gamerules.get(sp_id, colony_gamerule_default)
+    extinct_tech = species_extinct_techs.get(sp_id, '')
 
     data = {
         'id': sp_id,
         'name': sp_name,
         'tags': sp_tags,
         'graphic': sp_graphic,
-        'cost': 50,
-        'time': t_buildtime.substitute(id=sp_id, t_factor=time_factor.get(sp_id, "1.0")),
-        'species_condition': t_species_condition.substitute(id=sp_id)
+        'cost': species_buildcost.get(sp_id, buildcost_default),
+        'time': '',
+        'species_condition': ''
     }
 
     if sp_id == "SP_EXOBOT":
         data['tags'] += ' "CTRL_ALWAYS_REPORT"'
-        data['cost'] = 70
         data['time'] = 5
         data['species_condition'] = r"// no existing Exobot colony required!"
-    elif sp_id in ("SP_BANFORO", "SP_KILANDOW", "SP_MISIORLA"):
-        data['tags'] += ' "CTRL_EXTINCT"'
-        data['species_condition'] = t_species_condition_extinct.substitute(tech_name=sp_tech, id=sp_id, name=sp_name)
-        data['time'] = t_buildtime_extinct.substitute(id=sp_id, name=sp_name, t_factor=time_factor.get(sp_id, "1.0"))
-    elif sp_id == "SP_SUPER_TEST":
-        data['species_condition'] += "\n        ((GameRule name = \"RULE_ENABLE_SUPER_TESTER\") > 0)"
+    else:
+        if extinct_tech != '':
+            data['tags'] += ' "CTRL_EXTINCT"'
+            data['time'] = t_buildtime.substitute(t_factor=species_time_factor.get(sp_id, buildtime_factor_default),
+                                                  stat_condition=t_buildtime_stat_cond_extinct.substitute(id=sp_id,
+                                                                                                          name=sp_name))
+            data['species_condition'] = t_species_cond_extinct.substitute(tech_name=extinct_tech, id=sp_id,
+                                                                          name=sp_name)
+        else:
+            data['time'] = t_buildtime.substitute(t_factor=species_time_factor.get(sp_id, buildtime_factor_default),
+                                                  stat_condition=t_buildtime_stat_cond.substitute(id=sp_id))
+            data['species_condition'] = t_species_cond.substitute(id=sp_id)
+
+    if sp_gamerule:
+        data['species_condition'] += ("\n        ((GameRule name = \"%s\") > 0)" % sp_gamerule)
 
     with open(os.path.join(outpath, sp_filename), "w") as f:
         f.write(t_main.substitute(**data))


### PR DESCRIPTION
Inserts a comment at top of colony building definitions to remind of policy to update script.
Suggestions welcome for alternative to `Upstream Changes`, since that may not always be accurate.

Regenerated definitions catches an unrelated change for Replicon colony buildings (building cost modifier).