### PR TITLE
Improve MapWnd::PlotFleetMovement() performance.

### DIFF
--- a/GG/GG/Wnd.h
+++ b/GG/GG/Wnd.h
@@ -1015,6 +1015,9 @@ private:
     virtual void BeginNonclientClippingImpl();
     virtual void EndNonclientClippingImpl();
 
+    /** Code common to DetachChild and DetachChildren. */
+    void DetachChildCore(Wnd* wnd);
+
     /// m_parent may be expired or null if there is no parent.  m_parent will reset itself if expired.
     mutable std::weak_ptr<Wnd> m_parent;
     std::string       m_name;          ///< A user-significant name for this Wnd

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -2161,7 +2161,7 @@ public:
         const std::set<int>& this_client_stale_object_info =
             GetUniverse().EmpireStaleKnowledgeObjectIDs(this_client_empire_id);
 
-        const std::set<int> ship_ids = fleet->ShipIDs();
+        const std::set<int>& ship_ids = fleet->ShipIDs();
         std::vector<std::shared_ptr<GG::ListBox::Row>> rows;
         rows.reserve(ship_ids.size());
         for (int ship_id : ship_ids) {

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -5366,7 +5366,7 @@ void MapWnd::PlotFleetMovement(int system_id, bool execute_move, bool append) {
 
         // get path to destination...
         std::list<int> route = GetPathfinder()->ShortestPath(start_system, system_id, empire_id).first;
-        if (append && !fleet->TravelRoute().empty()) {
+        if (append && !fleet->TravelRoute().empty() && !route.empty()) {
             std::list<int> old_route(fleet->TravelRoute());
             old_route.erase(--old_route.end()); //end of old is begin of new
             route.splice(route.begin(), old_route);

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -6880,7 +6880,12 @@ void MapWnd::SetFleetExploring(const int fleet_id) {
 }
 
 void MapWnd::StopFleetExploring(const int fleet_id) {
-    m_fleets_exploring.erase(fleet_id);
+    auto it = m_fleets_exploring.find(fleet_id);
+    if (it == m_fleets_exploring.end())
+        return;
+
+    m_fleets_exploring.erase(it);
+
     DispatchFleetsExploring();
     // force UI update. Removing a fleet from the UI's list of exploring fleets
     // doesn't actually change the Fleet object's state in any way, so the UI

--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -645,71 +645,55 @@ namespace {
 }
 
 bool Fleet::HasMonsters() const {
-    for (auto& ship : Objects().FindObjects<const Ship>(m_ships)) {
-        if (ship->IsMonster())
-            return true;
-    }
-    return false;
+    auto isX = [](const std::shared_ptr<const Ship>& ship){ return ship->IsMonster(); };
+    return HasXShips(isX, m_ships);
 }
 
 bool Fleet::HasArmedShips() const {
-    for (auto& ship : Objects().FindObjects<const Ship>(m_ships)) {
-        if (ship->IsArmed())
-            return true;
-    }
-    return false;
+    auto isX = [](const std::shared_ptr<const Ship>& ship){ return ship->IsArmed(); };
+    return HasXShips(isX, m_ships);
 }
 
 bool Fleet::HasFighterShips() const {
-    for (auto& ship : Objects().FindObjects<const Ship>(m_ships)) {
-        if (ship->HasFighters())
-            return true;
-    }
-    return false;
+    auto isX = [](const std::shared_ptr<const Ship>& ship){ return ship->HasFighters(); };
+    return HasXShips(isX, m_ships);
 }
 
 bool Fleet::HasColonyShips() const {
-    for (auto& ship : Objects().FindObjects<const Ship>(m_ships)) {
+    auto isX = [](const std::shared_ptr<const Ship>& ship){
         if (ship->CanColonize())
-            if (const ShipDesign* design = ship->Design())
+            if (const auto design = ship->Design())
                 if (design->ColonyCapacity() > 0.0)
                     return true;
-    }
-    return false;
+        return false;
+    };
+    return HasXShips(isX, m_ships);
 }
 
 bool Fleet::HasOutpostShips() const {
-    for (auto& ship : Objects().FindObjects<const Ship>(m_ships)) {
+    auto isX = [](const std::shared_ptr<const Ship>& ship){
         if (ship->CanColonize())
-            if (const ShipDesign* design = ship->Design())
+            if (const auto design = ship->Design())
                 if (design->ColonyCapacity() == 0.0)
                     return true;
-    }
-    return false;
+        return false;
+    };
+    return HasXShips(isX, m_ships);
 }
 
 bool Fleet::HasTroopShips() const {
-    for (auto& ship : Objects().FindObjects<const Ship>(m_ships)) {
-        if (ship->HasTroops())
-            return true;
-    }
-    return false;
+    auto isX = [](const std::shared_ptr<const Ship>& ship){ return ship->HasTroops(); };
+    return HasXShips(isX, m_ships);
 }
 
 bool Fleet::HasShipsOrderedScrapped() const {
-    for (auto& ship : Objects().FindObjects<const Ship>(m_ships)) {
-        if (ship->OrderedScrapped())
-            return true;
-    }
-    return false;
+    auto isX = [](const std::shared_ptr<const Ship>& ship){ return ship->OrderedScrapped(); };
+    return HasXShips(isX, m_ships);
 }
 
 bool Fleet::HasShipsWithoutScrapOrders() const {
-    for (auto& ship : Objects().FindObjects<const Ship>(m_ships)) {
-        if (!ship->OrderedScrapped())
-            return true;
-    }
-    return false;
+    auto isX = [](const std::shared_ptr<const Ship>& ship){ return !ship->OrderedScrapped(); };
+    return HasXShips(isX, m_ships);
 }
 
 float Fleet::ResourceOutput(ResourceType type) const {

--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -759,7 +759,7 @@ void Fleet::SetRoute(const std::list<int>& route) {
             m_prev_system = SystemID();
         }
         std::list<int>::const_iterator it = m_travel_route.begin();
-        m_next_system = m_prev_system == SystemID() ? (*++it) : (*it);
+        m_next_system = m_prev_system == SystemID() && m_travel_route.size() > 1 ? (*++it) : (*it);
     }
 
     StateChangedSignal();

--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -626,6 +626,24 @@ int Fleet::FinalDestinationID() const {
     }
 } 
 
+namespace {
+    bool HasXShips(const std::function<bool(const std::shared_ptr<const Ship>&)>& pred, const std::set<int>& ship_ids) {
+        // Searching for each Ship one at a time is faster than
+        // FindObjects(ship_ids), because an early exit avoids searching the
+        // remaining ids.
+        return std::any_of(
+            ship_ids.begin(), ship_ids.end(),
+            [&pred](const int ship_id) {
+                const auto& ship = Objects().Object<const Ship>(ship_id);
+                if (!ship) {
+                    WarnLogger() << "Object map is missing ship with expected id " << ship_id;
+                    return false;
+                }
+                return pred(ship);
+            });
+    }
+}
+
 bool Fleet::HasMonsters() const {
     for (auto& ship : Objects().FindObjects<const Ship>(m_ships)) {
         if (ship->IsMonster())

--- a/util/Order.cpp
+++ b/util/Order.cpp
@@ -390,11 +390,13 @@ void FleetMoveOrder::ExecuteImpl() const {
         return;
     }
 
-    std::string waypoints;
-    for (int waypoint : route_list) {
-        waypoints += std::string(" ") + std::to_string(waypoint);
-    }
-    DebugLogger() << "FleetMoveOrder::ExecuteImpl Setting route of fleet " << fleet->ID() << " to " << waypoints;
+    DebugLogger() << [fleet, route_list]() {
+        std::stringstream ss;
+        ss << "FleetMoveOrder::ExecuteImpl Setting route of fleet " << fleet->ID() << " to ";
+        for (int waypoint : route_list)
+            ss << " " << std::to_string(waypoint);
+        return ss.str();
+    }();
 
     fleet->SetRoute(route_list);
 }


### PR DESCRIPTION
This is a collection of commits improving the performance of `MapWnd::PlotFleetMovement()`.  Performance improved from 10 ms to 2.5 ms for a specific test case.

The improvements are:
- don't delete the last path member and append an empty path.  This is a bug fix.
- stop processing `StopFleetExploring(fleet)` if fleet was not exploring
- In `Fleet::HasArmed/FighterShips()` check each ship for arms/fighters before finding the next ship in the objects map.  Previously, this found all the ships first, which is a waste if the first ship has arms/fighters.
- exit `Fleet::BlockadeAtSystem` as early as possible.
- fix a bug in `Fleet::SetRoute()` where `m_next_system` could end up being a null reference in a one hop path.
- refactor `GG::Wnd::DeleteChildren()` to delete `m_children` using `clear()` instead of `erase()` one at a time.