### PR TITLE
Fix bug #963 two mouse pointers shown when focus is lost.

### DIFF
--- a/GG/GG/GUI.h
+++ b/GG/GG/GUI.h
@@ -468,9 +468,13 @@ protected:
     // EventPumpBase interface
     void SetFPS(double FPS);               ///< sets the FPS value based on the most recent calculation
     void SetDeltaT(unsigned int delta_t);  ///< sets the time between the most recent frame and the one before it, in ms
+
     //@}
 
     virtual void   Run() = 0;              ///< initializes GUI state, then executes main event handler/render loop (PollAndRender())
+
+    /** Determine if the app has the mouse focus. */
+    virtual bool AppHasMouseFocus() const { return true; };
 
 private:
     bool           ProcessBrowseInfoImpl(Wnd* wnd);

--- a/GG/GG/SDL/SDLGUI.h
+++ b/GG/GG/SDL/SDLGUI.h
@@ -119,6 +119,8 @@ public:
 
     void Run() override;
 
+    bool AppHasMouseFocus() const override;
+
     void            operator()();      ///< external interface to Run()
 
     void            SetWindowTitle(const std::string& title);

--- a/GG/src/GUI.cpp
+++ b/GG/src/GUI.cpp
@@ -1774,7 +1774,7 @@ void GUI::Render()
     glEnable(GL_BLEND);
     glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
-    if (m_impl->m_render_cursor && m_impl->m_cursor)
+    if (m_impl->m_render_cursor && m_impl->m_cursor && AppHasMouseFocus())
         m_impl->m_cursor->Render(m_impl->m_mouse_pos);
     Exit2DMode();
 }

--- a/GG/src/SDL/SDLGUI.cpp
+++ b/GG/src/SDL/SDLGUI.cpp
@@ -890,6 +890,12 @@ void SDLGUI::Run()
     }
 }
 
+bool SDLGUI::AppHasMouseFocus() const {
+    auto window_flags = SDL_GetWindowFlags(m_window);
+
+    return window_flags & SDL_WINDOW_MOUSE_FOCUS;
+}
+
 std::vector<std::string> SDLGUI::GetSupportedResolutions() const
 {
     std::vector<std::string> mode_vec;


### PR DESCRIPTION
This PR fixes #963.

It only renders the mouse when SDL says that the app has focus.

I've tested it on linux, but since the OSX and Windows windowing systems that SDL proxies are considerably different, additional testing is a good idea.
