### PR TITLE
Improve AI pathfinding

### DIFF
--- a/default/python/AI/ExplorationAI.py
+++ b/default/python/AI/ExplorationAI.py
@@ -102,8 +102,7 @@ def assign_scouts_to_explore_systems():
         fleet_id = this_fleet_list[0]
         fleet_mission = foAI.foAIstate.get_fleet_mission(fleet_id)
         target = universe_object.System(this_sys_id)
-        if MoveUtilsAI.can_travel_to_system_and_return_to_resupply(fleet_id, fleet_mission.get_location_target(),
-                                                                   target):
+        if MoveUtilsAI.can_travel_to_system(fleet_id, fleet_mission.get_location_target(), target, ensure_return=True):
             fleet_mission.set_target(MissionType.EXPLORATION, target)
             sent_list.append(this_sys_id)
         else:  # system too far out, skip it, but can add scout back to available pool

--- a/default/python/AI/MoveUtilsAI.py
+++ b/default/python/AI/MoveUtilsAI.py
@@ -6,8 +6,10 @@ import fleet_orders
 import ColonisationAI
 import FleetUtilsAI
 import PlanetUtilsAI
+import pathfinding
 from freeorion_tools import ppstring
 from AIDependencies import INVALID_ID, DRYDOCK_HAPPINESS_THRESHOLD
+from turn_state import state
 
 from common.configure_logging import convenience_function_references_for_logger
 (debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
@@ -36,94 +38,38 @@ def create_move_orders_to_system(fleet, target):
     return result
 
 
-def can_travel_to_system(fleet_id, from_system_target, to_system_target, ensure_return=False):
+def can_travel_to_system(fleet_id, start, target, ensure_return=False):
     """
     Return list systems to be visited.
 
     :param fleet_id:
     :type fleet_id: int
-    :param from_system_target:
-    :type from_system_target: universe_object.System
-    :param to_system_target:
-    :type to_system_target:  universe_object.System
+    :param start:
+    :type start: universe_object.System
+    :param target:
+    :type target:  universe_object.System
     :param ensure_return:
     :type ensure_return: bool
     :return:
     :rtype: list
     """
-    empire = fo.getEmpire()
-    empire_id = empire.empireID
-    fleet_supplyable_system_ids = set(empire.fleetSupplyableSystemIDs)
-    # get current fuel and max fuel
-    universe = fo.getUniverse()
-    fuel = int(FleetUtilsAI.get_fuel(fleet_id))  # round down to get actually number of jumps
-    if fuel < 1.0 or from_system_target.id == to_system_target.id:
+    debug("Requesting path from %s to %s" % (start, target))
+    target_distance_from_supply = -min(state.get_system_supply(target.id), 0)
+
+    # low-aggression AIs may not travel far from supply
+    if not foAI.foAIstate.character.may_travel_beyond_supply(target_distance_from_supply):
+        debug("May not move %d out of supply" % target_distance_from_supply)
         return []
-    if True:  # TODO: sort out if shortestPath leaves off some intermediate destinations
-        path_func = universe.leastJumpsPath
-    else:
-        path_func = universe.shortestPath
-    start_sys_id = from_system_target.id
-    target_sys_id = to_system_target.id
-    if start_sys_id != INVALID_ID and target_sys_id != INVALID_ID:
-        short_path = list(path_func(start_sys_id, target_sys_id, empire_id))
-    else:
-        short_path = []
-    legs = zip(short_path[:-1], short_path[1:])
-    # suppliedStops = [ sid for sid in short_path if sid in fleet_supplyable_system_ids ]
-    # unsupplied_stops = [sid for sid in short_path if sid not in suppliedStops ]
-    unsupplied_stops = [sys_b for sys_a, sys_b in legs if ((sys_a not in fleet_supplyable_system_ids) and (sys_b not in fleet_supplyable_system_ids))]
-    # print "getting path from %s to %s "%(ppstring(PlanetUtilsAI.sys_name_ids([ start_sys_id ])), ppstring(PlanetUtilsAI.sys_name_ids([ target_sys_id ])) ),
-    # print " ::: found initial path %s having suppliedStops %s and unsupplied_stops %s ; tot fuel available is %.1f"%( ppstring(PlanetUtilsAI.sys_name_ids( short_path[:])), suppliedStops, unsupplied_stops, fuel)
-    if False:
-        if target_sys_id in fleet_supplyable_system_ids:
-            print "target has FleetSupply"
-        elif target_sys_id in ColonisationAI.annexable_ring1:
-            print "target in Ring 1"
-        elif target_sys_id in ColonisationAI.annexable_ring2 and foAI.foAIstate.character.may_travel_beyond_supply(2):
-            print "target in Ring 2, has enough aggression"
-        elif target_sys_id in ColonisationAI.annexable_ring3 and foAI.foAIstate.character.may_travel_beyond_supply(3):
-            print "target in Ring 2, has enough aggression"
-    if (not unsupplied_stops or not ensure_return or
-        target_sys_id in fleet_supplyable_system_ids and len(unsupplied_stops) <= fuel
-        or target_sys_id in ColonisationAI.annexable_ring1 and len(unsupplied_stops) < fuel
-        or target_sys_id in ColonisationAI.annexable_ring2 and foAI.foAIstate.character.may_travel_beyond_supply(2) and len(unsupplied_stops) < fuel - 1
-        or target_sys_id in ColonisationAI.annexable_ring3 and foAI.foAIstate.character.may_travel_beyond_supply(3) and len(unsupplied_stops) < fuel - 2):
-        return [universe_object.System(sid) for sid in short_path]
-    else:
-        # print " getting path from 'can_travel_to_system_and_return_to_resupply' ",
-        return can_travel_to_system_and_return_to_resupply(fleet_id, from_system_target, to_system_target)
 
+    min_fuel_at_target = target_distance_from_supply if ensure_return else 0
+    path_info = pathfinding.find_path_with_resupply(start.id, target.id, fleet_id,
+                                                    minimum_fuel_at_target=min_fuel_at_target)
+    if path_info is None:
+        debug("Found no valid path.")
+        return []
 
-def can_travel_to_system_and_return_to_resupply(fleet_id, from_system_target, to_system_target):
-    """
-    Filter systems where fleet can travel from starting system. # TODO rename function
-
-    :param fleet_id:
-    :type fleet_id: int
-    :param from_system_target:
-    :type from_system_target: universe_object.System
-    :param to_system_target:
-    :type to_system_target: universe_object.System
-    :return:
-    :rtype: list
-    """
-    system_targets = []
-    if not from_system_target.id == to_system_target.id:
-        fleet_supplyable_system_ids = fo.getEmpire().fleetSupplyableSystemIDs
-        fuel = int(FleetUtilsAI.get_fuel(fleet_id))  # int to get actual number of jumps
-        max_fuel = int(FleetUtilsAI.get_max_fuel(fleet_id))
-        # try to find path without going resupply first
-        supply_system_target = get_nearest_supplied_system(to_system_target.id)
-        system_targets = __find_path_with_fuel_to_system_with_possible_return(from_system_target, to_system_target, system_targets, fleet_supplyable_system_ids, max_fuel, fuel, supply_system_target)
-        # resupply in system first is required to find path
-        if from_system_target.id not in fleet_supplyable_system_ids and not system_targets:
-            # add supply system to visit
-            from_system_target = get_nearest_supplied_system(from_system_target.id)
-            system_targets.append(from_system_target)
-            # find path from supplied system to wanted system
-            system_targets = __find_path_with_fuel_to_system_with_possible_return(from_system_target, to_system_target, system_targets, fleet_supplyable_system_ids, max_fuel, max_fuel, supply_system_target)
-    return system_targets
+    debug("Found valid path: %s" % str(path_info))
+    return [universe_object.System(sys_id) for sys_id in path_info.path]
 
 
 def get_nearest_supplied_system(start_system_id):
@@ -221,73 +167,6 @@ def get_safe_path_leg_to_dest(fleet_id, start_id, dest_id):
     path_info = [PlanetUtilsAI.sys_name_ids([sys_id]) for sys_id in path_ids]
     print "Fleet %d requested safe path leg from %s to %s, found path %s" % (fleet_id, ppstring(start_info), ppstring(dest_info), ppstring(path_info))
     return path_ids[0]
-
-
-def __find_path_with_fuel_to_system_with_possible_return(from_system_target, to_system_target, result_system_targets, fleet_supplyable_system_ids, max_fuel, fuel, supply_system_target):
-    """
-    Return systems required to visit with fuel to nearest supplied system.
-
-    :param from_system_target:
-    :type from_system_target: universe_object.System
-    :param to_system_target:
-    :type to_system_target: universe_object.System
-    :param result_system_targets:
-    :type result_system_targets: list
-    :param fleet_supplyable_system_ids:
-    :type fleet_supplyable_system_ids: list
-    :param max_fuel:
-    :type max_fuel: int
-    :param fuel:
-    :type fuel: int
-    :param supply_system_target:
-    :type supply_system_target: universe_object.System
-    :return:
-    :rtype list:
-    """
-    empire_id = fo.empireID()
-    result = True
-    # try to find if there is possible path to wanted system from system
-    new_targets = result_system_targets[:]
-    if from_system_target and to_system_target and supply_system_target:
-        universe = fo.getUniverse()
-        if from_system_target.id != INVALID_ID and to_system_target.id != INVALID_ID:
-            least_jumps_path = universe.leastJumpsPath(from_system_target.id, to_system_target.id, empire_id)
-        else:
-            least_jumps_path = []
-            result = False
-        from_system_id = from_system_target.id
-        for system_id in least_jumps_path:
-            if from_system_id != system_id:
-                if from_system_id in fleet_supplyable_system_ids:
-                    # from supplied system fleet can travel without fuel consumption and also in this system refuels
-                    fuel = max_fuel
-                else:
-                    fuel -= 1
-
-                # leastJumpPath can differ from shortestPath
-                # TODO: use Graph Theory to optimize
-                if True or (system_id != to_system_target.id and system_id in fleet_supplyable_system_ids):  # TODO: restructure
-                    new_targets.append(universe_object.System(system_id))
-                if fuel < 0:
-                    result = False
-            from_system_id = system_id
-    else:
-        result = False
-
-    # if there is path to wanted system, then also if there is path back to supplyable system
-    if result:
-        # jump from A to B means least_jumps_path=[A,B], but min_jumps=1
-        min_jumps = len(universe.leastJumpsPath(to_system_target.id, supply_system_target.id, empire_id)) - 1
-
-        if min_jumps > fuel:
-            # print "fleetID:" + str(fleetID) + " fuel:" + str(fuel) + " required: " + str(min_jumps)
-            result = False
-        # else:
-        #     resultSystemAITargets.append(toSystemAITarget)
-
-    if not result:
-        return []
-    return new_targets
 
 
 def get_resupply_fleet_order(fleet_target, current_system_target):

--- a/default/python/AI/MoveUtilsAI.py
+++ b/default/python/AI/MoveUtilsAI.py
@@ -28,6 +28,9 @@ def create_move_orders_to_system(fleet, target):
     # TODO: use Graph Theory to construct move orders
     # TODO: add priority
     starting_system = fleet.get_system()  # current fleet location or current target system if on starlane
+    if starting_system == target:
+        # nothing to do here
+        return []
     # if the mission does not end at the targeted system, make sure we can actually return to supply after moving.
     ensure_return = target.id not in set(AIstate.colonyTargetedSystemIDs + AIstate.outpostTargetedSystemIDs
                                          + AIstate.invasionTargetedSystemIDs)
@@ -53,6 +56,9 @@ def can_travel_to_system(fleet_id, start, target, ensure_return=False):
     :return:
     :rtype: list
     """
+    if start == target:
+        return [universe_object.System(start.id)]
+
     debug("Requesting path from %s to %s" % (start, target))
     target_distance_from_supply = -min(state.get_system_supply(target.id), 0)
 

--- a/default/python/AI/pathfinding.py
+++ b/default/python/AI/pathfinding.py
@@ -90,7 +90,8 @@ def find_path_with_resupply(start, target, fleet_id):
         # which we already found to those systems
         for neighbor in universe.getImmediateNeighbors(current, empire_id):
             new_dist = path_info.distance + universe.linearDistance(current, neighbor)
-            new_fuel = fleet.maxFuel if neighbor in supplied_systems else path_info.fuel - 1
+            new_fuel = (fleet.maxFuel if (neighbor in supplied_systems or current in supplied_systems) else
+                        path_info.fuel - 1)
             if all((new_dist < dist or new_fuel > fuel) for dist, fuel, _ in path_cache.get(neighbor, [])):
                 predicted_distance = new_dist + universe.shortestPathDistance(neighbor, target)
                 if predicted_distance > max(2*shortest_possible_path_distance, shortest_possible_path_distance+5):

--- a/default/python/AI/pathfinding.py
+++ b/default/python/AI/pathfinding.py
@@ -71,7 +71,7 @@ def find_path_with_resupply(start, target, fleet_id, minimum_fuel_at_target=0):
     # supply graph suggests. For example, we could have recently refueled
     # in a system that is now blockaded by an enemy or we have found
     # the refuel special.
-    target_distance_from_supply = -min(state.get_systems_by_supply_tier(target), 0)
+    target_distance_from_supply = -min(state.get_system_supply(target), 0)
     if (fleet.maxFuel + 1 < (target_distance_from_supply + minimum_fuel_at_target) and
             universe.jumpDistance(start, target) > (start_fuel - minimum_fuel_at_target)):
         # can't possibly reach this system with the required fuel

--- a/default/python/AI/pathfinding.py
+++ b/default/python/AI/pathfinding.py
@@ -14,6 +14,28 @@ from turn_state import state
 #    - For large graphs, check if there are any must-visit nodes (e.g. only possible resupplying system),
 #      then try to find the shortest path between those and start/target.
 def find_path_with_resupply(start, target, fleet_id):
+    """Find the shortest possible path between two systems that complies with FreeOrion fuel mechanics.
+
+     If the fleet can travel the shortest possible path between start and target system, then return that path.
+     Otherwise, find the shortest possible detour including refueling.
+
+
+     The core algorithm is a modified A* with the universe.shortestPathDistance as heuristic.
+     While searching for a path, keep track of the fleet's fuel. Compared to standard A*/dijkstra,
+     nodes are locked only for a certain minimum level of fuel. If a longer path yields a higher fuel
+     level at a given system, then that path considered for pathfinding and added to the queue.
+
+
+    :param start: start system id
+    :type start: int
+    :param target:  target system id
+    :type target: int
+    :param fleet_id: fleet to find the path for
+    :type fleet_id: int
+    :return: shortest possible path including resupply-deroutes in the form of system ids
+             including both start and target system
+    :rtype: tuple[int]
+    """
     path_information = namedtuple('path_information', ['distance', 'fuel', 'path'])
     universe = fo.getUniverse()
     empire_id = fo.empireID()

--- a/default/python/AI/pathfinding.py
+++ b/default/python/AI/pathfinding.py
@@ -2,8 +2,17 @@ from heapq import heappush, heappop
 from collections import namedtuple
 
 import freeOrionAIInterface as fo
+from turn_state import state
 
 
+# TODO Allow short idling in system to refuel
+# TODO Consider additional optimizations:
+#    - Check if universe.shortestPath is valid before running pathfinder
+#      (seemingly not worth it - we have exact heuristic in that case)
+#    - Cut off branches that can't reach target due to supply distance
+#    - For large graphs, check existance on a simplified graph (use single node to represent supply clusters)
+#    - For large graphs, check if there are any must-visit nodes (e.g. only possible resupplying system),
+#      then try to find the shortest path between those and start/target.
 def find_path_with_resupply(start, target, fleet_id):
     path_information = namedtuple('path_information', ['distance', 'fuel', 'path'])
     universe = fo.getUniverse()
@@ -11,8 +20,22 @@ def find_path_with_resupply(start, target, fleet_id):
     fleet = universe.getFleet(fleet_id)
     supplied_systems = set(fo.getEmpire().fleetSupplyableSystemIDs)
 
-    # initialize data structures
     start_fuel = fleet.maxFuel if start in supplied_systems else fleet.fuel
+
+    # We have 1 free jump from supplied system into unsupplied systems.
+    # Thus, the target system must be at most maxFuel + 1 jumps away
+    # in order to reach the system under standard conditions.
+    # In some edge cases, we may have more supply here than what the
+    # supply graph suggests. For example, we could have recently refueled
+    # in a system that is now blockaded by an enemy or we have found
+    # the refuel special.
+    target_distance_from_supply = -state.get_systems_by_supply_tier(target)
+    if (fleet.maxFuel + 1 < target_distance_from_supply and
+            universe.jumpDistance(start, target) > start_fuel):
+        # can't possibly reach this system
+        return None
+
+    # initialize data structures
     path_cache = {}
     shortest_possible_path = universe.shortestPathDistance(start, target)
     queue = [(shortest_possible_path, path_information(distance=0, fuel=start_fuel, path=(start,)), start)]

--- a/default/python/AI/pathfinding.py
+++ b/default/python/AI/pathfinding.py
@@ -103,7 +103,7 @@ def find_path_with_resupply(start, target, fleet_id):
             predicted_distance = new_dist + universe.shortestPathDistance(neighbor, target)
 
             # Ignore paths that are much longer than the shortest possible path
-            if predicted_distance > max(2*shortest_possible_path_distance, shortest_possible_path_distance+5):
+            if predicted_distance > max(2*shortest_possible_path_distance, shortest_possible_path_distance+2000):
                 continue
 
             # All checks passed, consider this path for further pathfinding

--- a/default/python/AI/pathfinding.py
+++ b/default/python/AI/pathfinding.py
@@ -68,14 +68,14 @@ def find_path_with_resupply(start, target, fleet_id):
 
     while queue:
         # get next system u with path information
-        (_, path_info, u) = heappop(queue)
+        (_, path_info, current) = heappop(queue)
 
         # did we reach the target?
-        if u == target:
+        if current == target:
             return path_info
 
         # add information about how we reached here to the cache
-        path_cache.setdefault(u, []).append(path_info)
+        path_cache.setdefault(current, []).append(path_info)
 
         # check if we have enough fuel to travel to neighbors
         if path_info.fuel < 1:
@@ -84,8 +84,8 @@ def find_path_with_resupply(start, target, fleet_id):
         # add neighboring systems to the queue if the resulting path
         # is either shorter or offers more fuel than the other paths
         # which we already found to those systems
-        for neighbor in universe.getImmediateNeighbors(u, empire_id):
-            new_dist = path_info.distance + universe.linearDistance(u, neighbor)
+        for neighbor in universe.getImmediateNeighbors(current, empire_id):
+            new_dist = path_info.distance + universe.linearDistance(current, neighbor)
             new_fuel = fleet.maxFuel if neighbor in supplied_systems else path_info.fuel - 1
             if all((new_dist < dist or new_fuel > fuel) for dist, fuel, _ in path_cache.get(neighbor, [])):
                 predicted_distance = new_dist + universe.shortestPathDistance(neighbor, target)

--- a/default/python/AI/pathfinding.py
+++ b/default/python/AI/pathfinding.py
@@ -64,7 +64,11 @@ def find_path_with_resupply(start, target, fleet_id):
 
     # initialize data structures
     path_cache = {}
-    queue = [(shortest_possible_path_distance, path_information(distance=0, fuel=start_fuel, path=(start,)), start)]
+    queue = []
+
+    # add starting system to queue
+    heappush(queue, (shortest_possible_path_distance, path_information(distance=0, fuel=start_fuel, path=(start,)),
+                     start))
 
     while queue:
         # get next system u with path information

--- a/default/python/AI/pathfinding.py
+++ b/default/python/AI/pathfinding.py
@@ -2,6 +2,7 @@ from heapq import heappush, heappop
 from collections import namedtuple
 
 import freeOrionAIInterface as fo
+from AIDependencies import INVALID_ID
 from turn_state import state
 
 from common.configure_logging import convenience_function_references_for_logger
@@ -48,6 +49,10 @@ def find_path_with_resupply(start, target, fleet_id, minimum_fuel_at_target=0):
     empire_id = fo.empireID()
     fleet = universe.getFleet(fleet_id)
     supplied_systems = set(fo.getEmpire().fleetSupplyableSystemIDs)
+
+    if start == INVALID_ID or target == INVALID_ID:
+        warn("Requested path between invalid systems.")
+        return None
 
     # make sure the target is connected to the start system
     shortest_possible_path_distance = universe.shortestPathDistance(start, target)

--- a/default/python/AI/pathfinding.py
+++ b/default/python/AI/pathfinding.py
@@ -8,7 +8,8 @@ from common.configure_logging import convenience_function_references_for_logger
 (debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
 
 
-# TODO Allow short idling in system to refuel
+# TODO Allow short idling in system to use stationary refuel mechanics in unsupplied systems if we
+#      are very close the target system but can't reach it due to fuel constraints
 # TODO Consider additional optimizations:
 #    - Check if universe.shortestPath complies with fuel mechanics before running
 #      pathfinder (seemingly not worth it - we have exact heuristic in that case)

--- a/default/python/AI/pathfinding.py
+++ b/default/python/AI/pathfinding.py
@@ -1,0 +1,55 @@
+from heapq import heappush, heappop
+from collections import namedtuple
+
+import freeOrionAIInterface as fo
+
+
+def find_path_with_resupply(start, target, fleet_id):
+    path_information = namedtuple('path_information', ['distance', 'fuel', 'path'])
+    universe = fo.getUniverse()
+    empire_id = fo.empireID()
+    fleet = universe.getFleet(fleet_id)
+    supplied_systems = set(fo.getEmpire().fleetSupplyableSystemIDs)
+
+    # initialize data structures
+    start_fuel = fleet.maxFuel if start in supplied_systems else fleet.fuel
+    path_cache = {}
+    queue = [(path_information(distance=0, fuel=start_fuel, path=tuple()), start)]
+
+    while queue:
+        # get next system u with path information
+        (path_info, u) = heappop(queue)
+
+        # did we reach the target?
+        if u == target:
+            return path_info
+
+        # add information about how we reached here to the cache
+        path_cache.setdefault(u, []).append(path_info)
+
+        # check if we have enough fuel to travel to neighbors
+        if path_info.fuel < 1:
+            continue
+
+        # add neighboring systems to the queue if the resulting path
+        # is either shorter or offers more fuel than the other paths
+        # which we already found to those systems
+        for neighbor in universe.getImmediateNeighbors(u, empire_id):
+            new_dist = path_info.distance + universe.linearDistance(u, neighbor)
+            new_fuel = fleet.maxFuel if neighbor in supplied_systems else path_info.fuel - 1
+            if all((new_dist < dist or new_fuel > fuel) for dist, fuel, _ in path_cache.get(neighbor, [])):
+                heappush(queue, (path_information(new_dist, new_fuel, (path_info.path, u)), neighbor))
+
+    # no path exists, not even if we refuel on the way
+    return None
+
+
+def run(s1, s2):
+    universe = fo.getUniverse()
+    fleets = universe.fleetIDs
+    f = [fid for fid in universe.getSystem(126).fleetIDs][0]
+    if not (s1 and s2):
+        ss = universe.systemIDs
+        s1 = ss[0]
+        s2 = ss[1]
+    print find_path_with_resupply(s1, s2, f)

--- a/default/python/AI/pathfinding.py
+++ b/default/python/AI/pathfinding.py
@@ -14,11 +14,12 @@ def find_path_with_resupply(start, target, fleet_id):
     # initialize data structures
     start_fuel = fleet.maxFuel if start in supplied_systems else fleet.fuel
     path_cache = {}
-    queue = [(path_information(distance=0, fuel=start_fuel, path=tuple()), start)]
+    shortest_possible_path = universe.shortestPathDistance(start, target)
+    queue = [(shortest_possible_path, path_information(distance=0, fuel=start_fuel, path=(start,)), start)]
 
     while queue:
         # get next system u with path information
-        (path_info, u) = heappop(queue)
+        (_, path_info, u) = heappop(queue)
 
         # did we reach the target?
         if u == target:
@@ -38,7 +39,9 @@ def find_path_with_resupply(start, target, fleet_id):
             new_dist = path_info.distance + universe.linearDistance(u, neighbor)
             new_fuel = fleet.maxFuel if neighbor in supplied_systems else path_info.fuel - 1
             if all((new_dist < dist or new_fuel > fuel) for dist, fuel, _ in path_cache.get(neighbor, [])):
-                heappush(queue, (path_information(new_dist, new_fuel, (path_info.path, u)), neighbor))
+                predicted_distance = new_dist + universe.shortestPathDistance(neighbor, target)
+                heappush(queue, (predicted_distance, path_information(new_dist, new_fuel, path_info.path + (neighbor,)),
+                                 neighbor))
 
     # no path exists, not even if we refuel on the way
     return None
@@ -52,4 +55,6 @@ def run(s1, s2):
         ss = universe.systemIDs
         s1 = ss[0]
         s2 = ss[1]
-    print find_path_with_resupply(s1, s2, f)
+    path_info = find_path_with_resupply(s1, s2, f)
+    print map(universe.getSystem, path_info.path)
+

--- a/default/python/AI/pathfinding.py
+++ b/default/python/AI/pathfinding.py
@@ -71,7 +71,7 @@ def find_path_with_resupply(start, target, fleet_id, minimum_fuel_at_target=0):
     # supply graph suggests. For example, we could have recently refueled
     # in a system that is now blockaded by an enemy or we have found
     # the refuel special.
-    target_distance_from_supply = -state.get_systems_by_supply_tier(target)
+    target_distance_from_supply = -min(state.get_systems_by_supply_tier(target), 0)
     if (fleet.maxFuel + 1 < (target_distance_from_supply + minimum_fuel_at_target) and
             universe.jumpDistance(start, target) > (start_fuel - minimum_fuel_at_target)):
         # can't possibly reach this system with the required fuel

--- a/default/python/AI/pathfinding.py
+++ b/default/python/AI/pathfinding.py
@@ -132,15 +132,3 @@ def find_path_with_resupply(start, target, fleet_id, minimum_fuel_at_target=0):
     # no path exists, not even if we refuel on the way
     return None
 
-
-def run(s1, s2):
-    universe = fo.getUniverse()
-    fleets = universe.fleetIDs
-    f = [fid for fid in universe.getSystem(126).fleetIDs][0]
-    if not (s1 and s2):
-        ss = universe.systemIDs
-        s1 = ss[0]
-        s2 = ss[1]
-    path_info = find_path_with_resupply(s1, s2, f)
-    print map(universe.getSystem, path_info.path)
-

--- a/default/python/AI/pathfinding.py
+++ b/default/python/AI/pathfinding.py
@@ -40,6 +40,9 @@ def find_path_with_resupply(start, target, fleet_id):
             new_fuel = fleet.maxFuel if neighbor in supplied_systems else path_info.fuel - 1
             if all((new_dist < dist or new_fuel > fuel) for dist, fuel, _ in path_cache.get(neighbor, [])):
                 predicted_distance = new_dist + universe.shortestPathDistance(neighbor, target)
+                if predicted_distance > max(2*shortest_possible_path, shortest_possible_path+5):
+                    # do not consider unreasonable long paths
+                    continue
                 heappush(queue, (predicted_distance, path_information(new_dist, new_fuel, path_info.path + (neighbor,)),
                                  neighbor))
 

--- a/default/python/AI/pathfinding.py
+++ b/default/python/AI/pathfinding.py
@@ -82,12 +82,12 @@ def find_path_with_resupply(start, target, fleet_id, minimum_fuel_at_target=0):
     queue = []
 
     # add starting system to queue
-    heappush(queue, (shortest_possible_path_distance, path_information(distance=0, fuel=start_fuel, path=(start,)),
-                     start))
+    heappush(queue, (shortest_possible_path_distance, path_information(distance=0, fuel=start_fuel, path=(start,))))
 
     while queue:
         # get next system u with path information
-        (_, path_info, current) = heappop(queue)
+        (_, path_info) = heappop(queue)
+        current = path_info.path[-1]
 
         # did we reach the target?
         if current == target:
@@ -126,8 +126,7 @@ def find_path_with_resupply(start, target, fleet_id, minimum_fuel_at_target=0):
                 continue
 
             # All checks passed, consider this path for further pathfinding
-            heappush(queue, (predicted_distance, path_information(new_dist, new_fuel, path_info.path + (neighbor,)),
-                             neighbor))
+            heappush(queue, (predicted_distance, path_information(new_dist, new_fuel, path_info.path + (neighbor,))))
 
     # no path exists, not even if we refuel on the way
     return None


### PR DESCRIPTION
This PR replaces the current AI pathfinding with a new pathfinding algorithm that considers (re)fuel mechanics and allows to find paths that require detours to resupply (and planned for the future around systems blocked by e.g. a stationary monster).

The core algorithm is based on A* with the ```universe.shortestPathDistance```as heuristic. However, this implementation keeps track of the fleet's fuel during pathfinding. Reached nodes are only closed for a certain fuel level at that node, i.e. longer paths that leave the fleet with more fuel at a system will be considered in pathfinding. This is how detours for refueling are found.


The previous algorithms used jump distance rather than starlane distance, consider that fact when comparing results. Nowadays, the AI won't stop at each system anymore so using ```universe.shortestPathDistance``` is the prefered metric as long as fuel is taken into account.


With regard to performance:
1) The ```universe.shortestPathDistance``` as A* heuristic is exact if no detour is required. This means the shortest path will be found without traversing other branches in that case.
2) The algorithm ignores paths that would be "much" longer than the ```universe.shortestPathDistance``` to lessen the impact of worst-case scenarios (i.e. no valid path available). "Much longer" in this PR is defined as either twice as long as the ```universe.shortestPathDistance``` or at least 2000uu longer.

If it still turns out to be a performance hazard in some specific situations, there are some more optimizations that could be implemented (mentioned in ToDos) but performance seemed fine in my tests so far, so I didn't bother yet. As last measure, reimplementation in C++ is another option.