### PR TITLE
Python exposure of effect accounting 

### DIFF
--- a/python/EnumWrapper.cpp
+++ b/python/EnumWrapper.cpp
@@ -136,6 +136,18 @@ namespace FreeOrionPython {
             .value("destroy",       CR_DESTROY)
             .value("retain",        CR_RETAIN)
         ;
+        enum_<EffectsCauseType>("effectsCauseType")
+            .value("invalid",       INVALID_EFFECTS_GROUP_CAUSE_TYPE)
+            .value("unknown",       ECT_UNKNOWN_CAUSE)
+            .value("inherent",      ECT_INHERENT)
+            .value("tech",          ECT_TECH)
+            .value("building",      ECT_BUILDING)
+            .value("field",         ECT_FIELD)
+            .value("special",       ECT_SPECIAL)
+            .value("species",       ECT_SPECIES)
+            .value("shipPart",      ECT_SHIP_PART)
+            .value("shipHull",      ECT_SHIP_HULL)
+        ;
         enum_<ShipSlotType>("shipSlotType")
             .value("external",      SL_EXTERNAL)
             .value("internal",      SL_INTERNAL)

--- a/python/UniverseWrapper.cpp
+++ b/python/UniverseWrapper.cpp
@@ -308,7 +308,7 @@ namespace FreeOrionPython {
             .def(boost::python::vector_indexing_suite<
                  std::vector<Effect::AccountingInfo>, true>())
         ;
-        class_<std::map<Visibility, int>>("MeterTypeAccountingInfoVecMap")
+        class_<std::map<MeterType, std::vector<Effect::AccountingInfo>>>("MeterTypeAccountingInfoVecMap")
             .def(boost::python::map_indexing_suite<
                  std::map<MeterType, std::vector<Effect::AccountingInfo>>, true>())
         ;

--- a/universe/EffectAccounting.cpp
+++ b/universe/EffectAccounting.cpp
@@ -26,6 +26,16 @@ Effect::AccountingInfo::AccountingInfo() :
     running_meter_total(0.0)
 {}
 
+bool Effect::AccountingInfo::operator==(const Effect::AccountingInfo& rhs) const {
+    return
+        cause_type == rhs.cause_type &&
+        specific_cause == rhs.specific_cause &&
+        custom_label == rhs.custom_label &&
+        source_id == rhs.source_id &&
+        meter_change == rhs.meter_change &&
+        running_meter_total == rhs.running_meter_total;
+}
+
 Effect::TargetsAndCause::TargetsAndCause() :
     target_set(),
     effect_cause()

--- a/universe/EffectAccounting.h
+++ b/universe/EffectAccounting.h
@@ -31,6 +31,7 @@ namespace Effect {
       * by effects groups acting on meters of objects. */
     struct AccountingInfo : public EffectCause {
         AccountingInfo();
+        bool operator==(const AccountingInfo& rhs) const;
 
         int     source_id;          ///< source object of effect
         float   meter_change;       ///< net change on meter due to this effect, as best known by client's empire

--- a/universe/EffectAccounting.h
+++ b/universe/EffectAccounting.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <vector>
 
+#include "../util/Export.h"
 
 class UniverseObject;
 
@@ -18,7 +19,7 @@ namespace Effect {
 
     /** Description of cause of an effect: the general cause type, and the
       * specific cause.  eg. Building and a particular BuildingType. */
-    struct EffectCause {
+    struct FO_COMMON_API EffectCause {
         EffectCause();
         EffectCause(EffectsCauseType cause_type_, const std::string& specific_cause_,
                     const std::string& custom_label_ = "");
@@ -29,7 +30,7 @@ namespace Effect {
 
     /** Accounting information about what the causes are and changes produced
       * by effects groups acting on meters of objects. */
-    struct AccountingInfo : public EffectCause {
+    struct FO_COMMON_API AccountingInfo : public EffectCause {
         AccountingInfo();
         bool operator==(const AccountingInfo& rhs) const;
 


### PR DESCRIPTION
This is Geoff's branch, plus a fix from me.  This allows the AI to get the more detailed meter accounting breakdowns that the human player can see in tooltips.   

A motivating application is to let the AI better figure out if a stealth effect on a planet is a permanent thing that should forbid invasion attempts (until detection improves sufficiently) or a temporary thing that could be planned around but still be expected to allow an invasion in the near term.

Since the initial commit has compile problems on Linux for me, and [apparently runtime problems on Windows for Geoff](http://www.freeorion.org/forum/viewtopic.php?p=90113#p90113), I'd propose this be squash-merged for a clean commit to master.