### PR TITLE
limit AI to add max 10 items to research queue - Speedup for AI-Turn

### DIFF
--- a/default/python/AI/ResearchAI.py
+++ b/default/python/AI/ResearchAI.py
@@ -683,7 +683,7 @@ def generate_classic_research_orders():
                 tech_base.update(missing_prereqs + [tech])
         cum_cost = 0
         print "  Enqueued Tech: %20s \t\t %8s \t %s" % ("Name", "Cost", "CumulativeCost")
-        for name in techs_to_add:
+        for name in techs_to_add[:10]:
             try:
                 enqueue_res = fo.issueEnqueueTechOrder(name, -1)
                 if enqueue_res == 1:


### PR DESCRIPTION
in turn 2 the AI adds all techs to the research queue and then never again adds anything. Boost seams to be slow on call to  fo.getEmpire().researchQueue when there are 100+ elements in the queue, so i reduced it to max 10 elements that can be added to the research queue per turn.