### PR TITLE
Remove ill-performing AI focus "dithering"

### DIFF
--- a/default/python/AI/character/character_module.py
+++ b/default/python/AI/character/character_module.py
@@ -230,10 +230,6 @@ class Trait(object):
         """
         return 0.0
 
-    def may_dither_focus_to_gain_research(self):  # pylint: disable=no-self-use,unused-argument
-        """Return True if permitted to trade production at a loss for research"""
-        return True
-
     def may_research_heavily(self):  # pylint: disable=no-self-use,unused-argument
         """Return true if allowed to target research/industry > 1.5"""
         return True
@@ -372,9 +368,6 @@ class Aggression(Trait):
 
     def military_safety_factor(self):
         return [4.0, 3.0, 2.0, 1.5, 1.2, 1.0][self.aggression]
-
-    def may_dither_focus_to_gain_research(self):
-        return self.aggression < fo.aggression.aggressive
 
     def may_research_heavily(self):
         return self.aggression > fo.aggression.cautious
@@ -547,8 +540,7 @@ def _make_single_function_combiner(funcnamei, f_combo):
 
 # Create combiners for traits that all must be true
 for funcname in ["may_explore_system", "may_surge_industry", "may_maximize_research", "may_invade",
-                 "may-invade_with_bases", "may_build_building", "may_produce_troops",
-                 "may_dither_focus_to_gain_research", "may_research_heavily",
+                 "may-invade_with_bases", "may_build_building", "may_produce_troops", "may_research_heavily",
                  "may_travel_beyond_supply", "may_research_xeno_genetics_variances",
                  "prefer_research_defensive", "prefer_research_low_aggression", "may_research_tech",
                  "may_research_tech_classic"]:


### PR DESCRIPTION
While the original idea may have been good and correct, nowadays the code logic/math is simply wrong and we pay much higher amount of PP than what is documented in that cryptic part of ancient code.
I didn't bother to check the math, but you can clearly see ingame that this isn't working at all as intended.

Besides wrong math, there is another problem: Temporarily dithering the focus means that other planets are indirectly pushed to change focus as well because the ratios and projected target research / production change. This implies even more focus change penalties and complete instability of the AI resource code producing all these wiggly lines in the resource output.