### PR TITLE
replace "planet bombarded" sitreps with "planet attacked"

### DIFF
--- a/default/stringtables/de.txt
+++ b/default/stringtables/de.txt
@@ -3329,17 +3329,17 @@ In %system%: Ein %shipdesign% wurde beschädigt.
 SITREP_UNOWNED_SHIP_DAMAGED_AT_SYSTEM_LABEL
 Fremdes Schiff beschädigt
 
-SITREP_PLANET_BOMBARDED_AT_SYSTEM
-Der Planet %planet% im System %system% vom Imperium %empire% ist bombardiert worden.
+SITREP_PLANET_ATTACKED_AT_SYSTEM
+Der Planet %planet% im System %system% vom Imperium %empire% ist angegriffen worden.
 
-SITREP_PLANET_BOMBARDED_AT_SYSTEM_LABEL
-Imperiumsplanet bombardiert
+SITREP_PLANET_ATTACKED_AT_SYSTEM_LABEL
+Imperiumsplanet angegriffen
 
-SITREP_UNOWNED_PLANET_BOMBARDED_AT_SYSTEM
-Der Planet %planet% von %system% ist bombardiert worden.
+SITREP_UNOWNED_PLANET_ATTACKED_AT_SYSTEM
+Der Planet %planet% von %system% ist angegriffen worden.
 
-SITREP_UNOWNED_PLANET_BOMBARDED_AT_SYSTEM_LABEL
-Unbekannter Planet bombardiert
+SITREP_UNOWNED_PLANET_ATTACKED_AT_SYSTEM_LABEL
+Unbekannter Planet angegriffen
 
 SITREP_GROUND_BATTLE
 Ein Bodenangriff fand auf %planet% statt.

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -5971,17 +5971,17 @@ At %system%: a %shipdesign% was damaged.
 SITREP_UNOWNED_SHIP_DAMAGED_AT_SYSTEM_LABEL
 Unowned Ship Damaged
 
-SITREP_PLANET_BOMBARDED_AT_SYSTEM
-At %system%: the %empire% planet %planet% was bombarded.
+SITREP_PLANET_ATTACKED_AT_SYSTEM
+At %system%: the %empire% planet %planet% was attacked.
 
-SITREP_PLANET_BOMBARDED_AT_SYSTEM_LABEL
-Empire Planet Bombarded
+SITREP_PLANET_ATTACKED_AT_SYSTEM_LABEL
+Empire Planet Attacked
 
-SITREP_UNOWNED_PLANET_BOMBARDED_AT_SYSTEM
-At %system%: The planet %planet% was bombarded.
+SITREP_UNOWNED_PLANET_ATTACKED_AT_SYSTEM
+At %system%: The planet %planet% was attacked.
 
-SITREP_UNOWNED_PLANET_BOMBARDED_AT_SYSTEM_LABEL
-Unowned Planet Bombarded
+SITREP_UNOWNED_PLANET_ATTACKED_AT_SYSTEM_LABEL
+Unowned Planet Attacked
 
 SITREP_GROUND_BATTLE
 On %planet%: there was a ground battle.

--- a/default/stringtables/fr.txt
+++ b/default/stringtables/fr.txt
@@ -5965,17 +5965,17 @@ Dans %system% : un %shipdesign% a été endommagé.
 SITREP_UNOWNED_SHIP_DAMAGED_AT_SYSTEM_LABEL
 Astronef libre endommagé
 
-SITREP_PLANET_BOMBARDED_AT_SYSTEM
-Dans %system% : la planète %planet% de %empire% a été bombardée.
+SITREP_PLANET_ATTACKED_AT_SYSTEM
+Dans %system% : la planète %planet% de %empire% a été attaquée.
 
-SITREP_PLANET_BOMBARDED_AT_SYSTEM_LABEL
-Planète impériale bombardée
+SITREP_PLANET_ATTACKED_AT_SYSTEM_LABEL
+Planète impériale attaquée
 
-SITREP_UNOWNED_PLANET_BOMBARDED_AT_SYSTEM
-Dans %system% : la planète %planet% a été bombardée.
+SITREP_UNOWNED_PLANET_ATTACKED_AT_SYSTEM
+Dans %system% : la planète %planet% a été attaquée.
 
-SITREP_UNOWNED_PLANET_BOMBARDED_AT_SYSTEM_LABEL
-Planète libre bombardée
+SITREP_UNOWNED_PLANET_ATTACKED_AT_SYSTEM_LABEL
+Planète libre attaquée
 
 SITREP_GROUND_BATTLE
 Sur %planet% : une bataille terrestre s'est déroulée.

--- a/default/stringtables/ru.txt
+++ b/default/stringtables/ru.txt
@@ -5401,17 +5401,17 @@ SITREP_UNOWNED_SHIP_DAMAGED_AT_SYSTEM
 SITREP_UNOWNED_SHIP_DAMAGED_AT_SYSTEM_LABEL
 Поврежден неопознанный корабль
 
-SITREP_PLANET_BOMBARDED_AT_SYSTEM
-Планета %planet% империи %empire% в системе %system% подверглась бомбардировкам
+SITREP_PLANET_ATTACKED_AT_SYSTEM
+В %system%: планета %planet% была атакована %empire%.  
 
-SITREP_PLANET_BOMBARDED_AT_SYSTEM_LABEL
-Бомбардировка планеты империи
-
-SITREP_UNOWNED_PLANET_BOMBARDED_AT_SYSTEM
-Планета %planet% в системе %system% подверглась бомбардировкам
-
-SITREP_UNOWNED_PLANET_BOMBARDED_AT_SYSTEM_LABEL
-Бомбардировка ничейной планеты
+SITREP_PLANET_ATTACKED_AT_SYSTEM_LABEL
+Наша планета атакована
+ 
+SITREP_UNOWNED_PLANET_ATTACKED_AT_SYSTEM
+В %system%: планета %planet% была атакована.
+ 
+SITREP_UNOWNED_PLANET_ATTACKED_AT_SYSTEM_LABEL
+Ничья планета была атакована
 
 SITREP_GROUND_BATTLE
 Наземная битва на планете %planet%

--- a/util/SitRepEntry.cpp
+++ b/util/SitRepEntry.cpp
@@ -229,16 +229,16 @@ SitRepEntry CreateCombatDamagedObjectSitRep(int object_id, int combat_system_id,
     } else if (std::shared_ptr<const Planet> planet = std::dynamic_pointer_cast<const Planet>(obj)) {
         if (planet->Unowned())
             sitrep = SitRepEntry(
-                UserStringNop("SITREP_UNOWNED_PLANET_BOMBARDED_AT_SYSTEM"),
+                UserStringNop("SITREP_UNOWNED_PLANET_ATTACKED_AT_SYSTEM"),
                 CurrentTurn() + 1,
                 "icons/sitrep/colony_bombarded.png",
-                UserStringNop("SITREP_UNOWNED_PLANET_BOMBARDED_AT_SYSTEM_LABEL"), true);
+                UserStringNop("SITREP_UNOWNED_PLANET_ATTACKED_AT_SYSTEM_LABEL"), true);
         else
             sitrep = SitRepEntry(
-                UserStringNop("SITREP_PLANET_BOMBARDED_AT_SYSTEM"),
+                UserStringNop("SITREP_PLANET_ATTACKED_AT_SYSTEM"),
                 CurrentTurn() + 1,
                 "icons/sitrep/colony_bombarded.png",
-                UserStringNop("SITREP_PLANET_BOMBARDED_AT_SYSTEM_LABEL"), true);
+                UserStringNop("SITREP_PLANET_ATTACKED_AT_SYSTEM_LABEL"), true);
         sitrep.AddVariable(VarText::PLANET_ID_TAG,     std::to_string(object_id));
 
     } else {


### PR DESCRIPTION
Currently when a planet is damaged by a ship a sitrep is generated stating the planet "was bombarded". That can be confused with when actual bombardement weapons are used; so I suggest to rename the sitrep messages to "planet attacked".