### PR TITLE
Override default config options after initial adjustments

### DIFF
--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -571,6 +571,7 @@ void BuildDesignatorWnd::BuildSelector::CompleteConstruction() {
     CUIWnd::CompleteConstruction();
 
     DoLayout();
+    SaveDefaultedOptions();
 }
 
 const std::set<BuildType>& BuildDesignatorWnd::BuildSelector::GetBuildTypesShown() const

--- a/UI/CUIControls.cpp
+++ b/UI/CUIControls.cpp
@@ -1835,7 +1835,7 @@ namespace {
 ProductionInfoPanel::ProductionInfoPanel(const std::string& title, const std::string& point_units_str,
                                          const GG::X x, const GG::Y y, const GG::X w, const GG::Y h,
                                          const std::string& config_name) :
-    CUIWnd(title, x, y, w, h, GG::INTERACTIVE | GG::RESIZABLE | GG::DRAGABLE | GG::ONTOP | PINABLE, config_name),
+    CUIWnd(title, x, y, w, h, GG::INTERACTIVE | GG::RESIZABLE | GG::DRAGABLE | GG::ONTOP | PINABLE, config_name, false),
     m_units_str(point_units_str),
     m_title_str(title),
     m_empire_id(ALL_EMPIRES),

--- a/UI/CUIWnd.cpp
+++ b/UI/CUIWnd.cpp
@@ -622,7 +622,6 @@ GG::Rect CUIWnd::CalculatePosition() const
 { return GG::Rect(INVALID_X, INVALID_Y, INVALID_X, INVALID_Y); }
 
 void CUIWnd::SetDefaultedOptions() {
-    std::unordered_set<std::string> retval;
     OptionsDB& db = GetOptionsDB();
     std::set<std::string> window_options;
     db.FindOptions(window_options, "UI.windows." + m_config_name);

--- a/UI/CUIWnd.cpp
+++ b/UI/CUIWnd.cpp
@@ -165,6 +165,7 @@ void CUIWnd::CompleteConstruction() {
     GG::Wnd::CompleteConstruction();
     Init();
     ValidatePosition();
+    SetDefaultedOptions();
 }
 
 void CUIWnd::Init() {
@@ -202,7 +203,11 @@ void CUIWnd::InitSizeMove(const GG::Pt& ul, const GG::Pt& lr) {
             // this position to the window.
             if (db.Get<bool>("UI.windows." + m_config_name + ".initialized") ||
                 db.Get<int>("UI.windows." + m_config_name + ".left" + windowed) == INVALID_X)
-            { SizeMove(ul, lr); }
+            {
+                SetDefaultedOptions();
+                SizeMove(ul, lr);
+                SaveDefaultedOptions();
+            }
             db.Set<bool>("UI.windows."+m_config_name+".initialized", true);
         } else {
             ErrorLogger() << "CUIWnd::InitSizeMove() : attempted to check if window using name \"" << m_config_name
@@ -615,6 +620,67 @@ void CUIWnd::ResetDefaultPosition() {
 
 GG::Rect CUIWnd::CalculatePosition() const
 { return GG::Rect(INVALID_X, INVALID_Y, INVALID_X, INVALID_Y); }
+
+void CUIWnd::SetDefaultedOptions() {
+    std::unordered_set<std::string> retval;
+    OptionsDB& db = GetOptionsDB();
+    std::set<std::string> window_options;
+    db.FindOptions(window_options, "UI.windows." + m_config_name);
+    for (auto& option : window_options) {
+        if (db.IsDefaultValue(option))
+            m_defaulted_options.emplace(option);
+    }
+}
+
+void CUIWnd::SaveDefaultedOptions() {
+    OptionsDB& db = GetOptionsDB();
+    std::string config_prefix = "UI.windows." + m_config_name;
+    std::string windowed = "";
+    if (!db.Get<bool>("fullscreen"))
+        windowed = "-windowed";
+    GG::Pt size;
+    if (m_minimized)
+        size = m_original_size;
+    else
+        size = Size();
+
+    std::string config_name = config_prefix + ".left" + windowed;
+    int int_value = Value(RelativeUpperLeft().x);
+    if (m_defaulted_options.count(config_name))
+        db.SetDefault<int>(config_name, int_value);
+
+    config_name = config_prefix + ".top" + windowed;
+    int_value = Value(RelativeUpperLeft().y);
+    if (m_defaulted_options.count(config_name))
+        db.SetDefault<int>(config_name, int_value);
+
+    config_name = config_prefix + ".width" + windowed;
+    int_value = Value(size.x);
+    if (m_defaulted_options.count(config_name))
+        db.SetDefault<int>(config_name, int_value);
+
+    config_name = config_prefix + ".height" + windowed;
+    int_value = Value(size.y);
+    if (m_defaulted_options.count(config_name))
+        db.SetDefault<int>(config_name, int_value);
+
+    if (!Modal()) {
+        config_name = config_prefix + ".visible";
+        bool bool_value = Visible();
+        if (m_defaulted_options.count(config_name))
+            db.SetDefault<bool>(config_name, bool_value);
+
+        config_name = config_prefix + ".pinned";
+        bool_value = m_pinned;
+        if (m_defaulted_options.count(config_name))
+            db.SetDefault<bool>(config_name, bool_value);
+
+        config_name = config_prefix + ".minimized";
+        bool_value = m_minimized;
+        if (m_defaulted_options.count(config_name))
+            db.SetDefault<bool>(config_name, bool_value);
+    }
+}
 
 void CUIWnd::SaveOptions() const {
     OptionsDB& db = GetOptionsDB();

--- a/UI/CUIWnd.h
+++ b/UI/CUIWnd.h
@@ -6,6 +6,7 @@
 #include <GG/Wnd.h>
 #include <GG/WndEvent.h>
 #include <GG/GLClientAndServerBuffer.h>
+#include <unordered_set>
 
 
 /** a simple minimize/restore button that toggles its appearance between the styles for minimize and restore*/
@@ -190,6 +191,10 @@ protected:
     void            ResetDefaultPosition();         //!< called via signal from the ClientUI, passes the value from CalculatePosition() to InitSizeMove()
 
     void SetParent(const std::shared_ptr<GG::Wnd>& wnd) override;
+    /** Flags options currently at their default values for later use in SaveDefaultedOptions */
+    void            SetDefaultedOptions();
+    /** Sets the default value any options previously determined from calls to SetDefaultedOptions to their current value */
+    void            SaveDefaultedOptions();
     //@}
 
     bool                    m_resizable;            //!< true if the window is able to be resized
@@ -210,6 +215,8 @@ protected:
     std::shared_ptr<GG::Button>             m_close_button = nullptr;     //!< the close button
     std::shared_ptr<CUI_MinRestoreButton>   m_minimize_button = nullptr;  //!< the minimize/restore button
     std::shared_ptr<CUI_PinButton>          m_pin_button = nullptr;       //!< the pin button
+
+    std::unordered_set<std::string> m_defaulted_options;
 
     GG::GL2DVertexBuffer                                m_vertex_buffer;
     std::vector<std::pair<std::size_t, std::size_t>>    m_buffer_indices;

--- a/UI/ChatWnd.cpp
+++ b/UI/ChatWnd.cpp
@@ -348,6 +348,7 @@ void MessageWnd::CompleteConstruction() {
     m_history.push_front("");
 
     DoLayout();
+    SaveDefaultedOptions();
 }
 
 void MessageWnd::DoLayout() {

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -1394,6 +1394,7 @@ void DesignWnd::PartPalette::CompleteConstruction() {
     CUIWnd::CompleteConstruction();
 
     DoLayout();
+    SaveDefaultedOptions();
 }
 
 void DesignWnd::PartPalette::SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
@@ -2809,6 +2810,7 @@ void DesignWnd::BaseSelector::CompleteConstruction() {
     CUIWnd::CompleteConstruction();
 
     DoLayout();
+    SaveDefaultedOptions();
 }
 
 void DesignWnd::BaseSelector::SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
@@ -3463,6 +3465,7 @@ void DesignWnd::MainPanel::CompleteConstruction() {
     CUIWnd::CompleteConstruction();
 
     DoLayout();
+    SaveDefaultedOptions();
 }
 
 boost::optional<const ShipDesign*> DesignWnd::MainPanel::EditingSavedDesign() const {

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -666,6 +666,7 @@ void EncyclopediaDetailPanel::CompleteConstruction() {
     SetChildClippingMode(ClipToWindow);
     DoLayout();
     MoveChildUp(m_graph);
+    SaveDefaultedOptions();
 
     AddItem(TextLinker::ENCYCLOPEDIA_TAG, "ENC_INDEX");
 }

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -2706,6 +2706,8 @@ void FleetWnd::CompleteConstruction() {
     SetMinSize(GG::Pt(CUIWnd::MinimizedSize().x, TopBorder() + INNER_BORDER_ANGLE_OFFSET + BORDER_BOTTOM +
                                                  ListRowHeight() + 2*GG::Y(PAD)));
     DoLayout();
+    SaveDefaultedOptions();
+    SaveOptions();
 }
 
 FleetWnd::~FleetWnd() {

--- a/UI/GalaxySetupWnd.cpp
+++ b/UI/GalaxySetupWnd.cpp
@@ -1046,6 +1046,7 @@ void GalaxySetupWnd::CompleteConstruction() {
 
     ResetDefaultPosition();
     DoLayout();
+    SaveDefaultedOptions();
 
     m_galaxy_setup_panel->ImageChangedSignal.connect(
         boost::bind(&GalaxySetupWnd::PreviewImageChanged, this, _1));

--- a/UI/IntroScreen.cpp
+++ b/UI/IntroScreen.cpp
@@ -334,7 +334,7 @@ void IntroScreen::OnPedia() {
     auto enc_panel = GG::Wnd::Create<EncyclopediaDetailPanel>(
         GG::MODAL | GG::INTERACTIVE | GG::DRAGABLE |
         GG::RESIZABLE | CLOSABLE | PINABLE, INTRO_PEDIA_WND_NAME);
-    enc_panel->SizeMove(GG::Pt(GG::X(100), GG::Y(100)), Size() - GG::Pt(GG::X(100), GG::Y(100)));
+    enc_panel->InitSizeMove(GG::Pt(GG::X(100), GG::Y(100)), Size() - GG::Pt(GG::X(100), GG::Y(100)));
     enc_panel->ClearItems();
     enc_panel->SetIndex();
     enc_panel->ValidatePosition();
@@ -490,5 +490,5 @@ void IntroScreen::PreRender() {
     GG::Pt lr(Width()  * GetOptionsDB().Get<double>("UI.main-menu.x") + mainmenu_width/2,
               Height() * GetOptionsDB().Get<double>("UI.main-menu.y") + mainmenu_height/2);
 
-    m_menu->SizeMove(ul, lr);
+    m_menu->InitSizeMove(ul, lr);
 }

--- a/UI/ModeratorActionsWnd.cpp
+++ b/UI/ModeratorActionsWnd.cpp
@@ -196,6 +196,7 @@ void ModeratorActionsWnd::CompleteConstruction() {
     CUIWnd::CompleteConstruction();
 
     DoLayout();
+    SaveDefaultedOptions();
 }
 
 ModeratorActionsWnd::~ModeratorActionsWnd()

--- a/UI/MultiplayerLobbyWnd.cpp
+++ b/UI/MultiplayerLobbyWnd.cpp
@@ -598,6 +598,7 @@ void MultiPlayerLobbyWnd::CompleteConstruction() {
     ResetDefaultPosition();
     SetMinSize(GG::Pt(LOBBY_WND_WIDTH, LOBBY_WND_HEIGHT));
     DoLayout();
+    SaveDefaultedOptions();
 
     // default settings (new game)
     m_new_load_game_buttons->SetCheck(0);

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -1119,6 +1119,8 @@ void FilterDialog::CompleteConstruction() {
     button_lr = button_lr - GG::Pt(m_cancel_button->Width() + GG::X(3), GG::Y0);
     m_apply_button->Resize(GG::Pt(button_width, m_apply_button->MinUsableSize().y));
     m_apply_button->MoveTo(button_lr - m_apply_button->Size());
+    SaveDefaultedOptions();
+    SaveOptions();
 }
 
 bool FilterDialog::ChangesAccepted()

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -741,6 +741,8 @@ void OptionsWnd::CompleteConstruction() {
     m_tabs->SetCurrentWnd(0);
 
     DoLayout();
+    SaveDefaultedOptions();
+    SaveOptions();
 
     // Connect the done and cancel button
     m_done_button->LeftClickedSignal.connect(

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -759,6 +759,7 @@ public:
         CUIWnd::CompleteConstruction();
 
         DoLayout();
+        SaveDefaultedOptions();
     }
     //@}
 

--- a/UI/ResearchWnd.cpp
+++ b/UI/ResearchWnd.cpp
@@ -372,6 +372,8 @@ public:
         CUIWnd::CompleteConstruction();
 
         DoLayout();
+        SaveDefaultedOptions();
+        SaveOptions();
     }
     //@}
 
@@ -448,7 +450,7 @@ void ResearchWnd::CompleteConstruction() {
 
     SetChildClippingMode(ClipToClient);
 
-    DoLayout();
+    DoLayout(true);
 }
 
 ResearchWnd::~ResearchWnd()
@@ -461,14 +463,25 @@ void ResearchWnd::SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
         DoLayout();
 }
 
-void ResearchWnd::DoLayout() {
+void ResearchWnd::DoLayout(bool init) {
     m_research_info_panel->MoveTo(GG::Pt(GG::X0, GG::Y0));
-    m_research_info_panel->Resize(GG::Pt(GG::X(GetOptionsDB().Get<int>("UI.queue-width")),
-                                         m_research_info_panel->MinUsableSize().y));
+    GG::X queue_width = GG::X(init ? GetOptionsDB().GetDefault<int>("UI.queue-width") :
+                                     GetOptionsDB().Get<int>("UI.queue-width"));
+    if (init) {
+        GG::Pt info_ul = m_research_info_panel->UpperLeft();
+        GG::Pt info_lr(info_ul.x + queue_width, info_ul.y + m_research_info_panel->MinUsableSize().y);
+        m_research_info_panel->InitSizeMove(info_ul, info_lr);
+    } else {
+        m_research_info_panel->Resize(GG::Pt(queue_width, m_research_info_panel->MinUsableSize().y));
+    }
+
     GG::Pt queue_ul = GG::Pt(GG::X(2), m_research_info_panel->Height());
     GG::Pt queue_size = GG::Pt(m_research_info_panel->Width() - 4,
                                ClientSize().y - 4 - m_research_info_panel->Height());
-    m_queue_wnd->SizeMove(queue_ul, queue_ul + queue_size);
+    if (init)
+        m_queue_wnd->InitSizeMove(queue_ul, queue_ul + queue_size);
+    else
+        m_queue_wnd->SizeMove(queue_ul, queue_ul + queue_size);
 
     GG::Pt tech_tree_wnd_size = ClientSize() - GG::Pt(m_research_info_panel->Width(), GG::Y0);
     GG::Pt tech_tree_wnd_ul = GG::Pt(m_research_info_panel->Width(), GG::Y0);

--- a/UI/ResearchWnd.h
+++ b/UI/ResearchWnd.h
@@ -51,7 +51,7 @@ public:
     //@}
 
 private:
-    void    DoLayout();
+    void    DoLayout(bool init = false);
     void    ResearchQueueChangedSlot();
     void    UpdateQueue();
     void    UpdateInfoPanel();     ///< Updates research summary at top left of production screen, and signals that the empire's minerals research pool has changed (propagates to the mapwnd to update indicator)

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -740,6 +740,8 @@ void SaveFileDialog::Init() {
     }
 
     UpdatePreviewList();
+    SaveDefaultedOptions();
+    SaveOptions();
 }
 
 SaveFileDialog::~SaveFileDialog()

--- a/UI/TechTreeWnd.cpp
+++ b/UI/TechTreeWnd.cpp
@@ -345,6 +345,8 @@ void TechTreeWnd::TechTreeControls::CompleteConstruction() {
     CUIWnd::CompleteConstruction();
 
     DoButtonLayout();
+    SaveDefaultedOptions();
+    SaveOptions();
 }
 
 void TechTreeWnd::TechTreeControls::DoButtonLayout() {
@@ -2086,6 +2088,7 @@ void TechTreeWnd::CompleteConstruction() {
     if (m_tech_tree_controls->Bottom() > m_layout_panel->Bottom() - ClientUI::ScrollWidth()) {
         m_tech_tree_controls->MoveTo(GG::Pt(m_tech_tree_controls->Left(),
                                             m_layout_panel->Bottom() - ClientUI::ScrollWidth() - m_tech_tree_controls->Height()));
+        m_tech_tree_controls->SaveDefaultedOptions();
     }
 
     HumanClientApp::GetApp()->RepositionWindowsSignal.connect(

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -125,16 +125,21 @@ namespace {
     const int MIN_WIDTH = 800;
     const int MIN_HEIGHT = 600;
 
+    /** Sets the default and current values for the string option @p option_name to @p option_value if initially empty */
+    void SetEmptyStringDefaultOption(const std::string& option_name, const std::string& option_value) {
+        OptionsDB& db = GetOptionsDB();
+        if (db.Get<std::string>(option_name).empty()) {
+            db.SetDefault<std::string>(option_name, option_value);
+            db.Set(option_name, option_value);
+        }
+    }
+
     /* Sets the value of options that need language-dependent default values.*/
     void SetStringtableDependentOptionDefaults() {
-        if (GetOptionsDB().Get<std::string>("GameSetup.empire-name").empty())
-            GetOptionsDB().Set("GameSetup.empire-name", UserString("DEFAULT_EMPIRE_NAME"));
-
-        if (GetOptionsDB().Get<std::string>("GameSetup.player-name").empty())
-            GetOptionsDB().Set("GameSetup.player-name", UserString("DEFAULT_PLAYER_NAME"));
-
-        if (GetOptionsDB().Get<std::string>("multiplayersetup.player-name").empty())
-            GetOptionsDB().Set("multiplayersetup.player-name", UserString("DEFAULT_PLAYER_NAME"));
+        SetEmptyStringDefaultOption("GameSetup.empire-name", UserString("DEFAULT_EMPIRE_NAME"));
+        std::string player_name = UserString("DEFAULT_PLAYER_NAME");
+        SetEmptyStringDefaultOption("GameSetup.player-name", player_name);
+        SetEmptyStringDefaultOption("multiplayersetup.player-name", player_name);
     }
 
     std::string GetGLVersionString()

--- a/util/OptionsDB.h
+++ b/util/OptionsDB.h
@@ -309,6 +309,17 @@ public:
         m_dirty |= it->second.SetFromValue(value);
     }
 
+    /** Set the default value of option @p name to @p value */
+    template <class T>
+    void        SetDefault(const std::string& name, const T& value) {
+        std::map<std::string, Option>::iterator it = m_options.find(name);
+        if (!OptionExists(it))
+            throw std::runtime_error("Attempted to set default value of nonexistent option \"" + name + "\".");
+        if (it->second.default_value.type() != typeid(T))
+            throw boost::bad_any_cast();
+        it->second.default_value = value;
+    }
+
     /** if an xml file exists at \a file_path and has the same version tag as \a version, fill the
       * DB options contained in that file (read the file using XMLDoc, then fill the DB using SetFromXML)
       * if the \a version string is empty, bypass that check */


### PR DESCRIPTION
Updates the default value in OptionsDB to reflect the resulting default after initialization.
Majority of these cases are in windows inheriting CUIWnd.

With #1552 creating a persistent config results in only two entries on my system for `app-left-windowed` and `app-top-windowed` from default config.