### PR TITLE
Ship part upgrade revamp

### DIFF
--- a/default/scripting/techs/ship_weapons/ship_weapons.macros
+++ b/default/scripting/techs/ship_weapons/ship_weapons.macros
@@ -7,6 +7,17 @@ WEAPON_BASE_EFFECTS
                 SetMaxCapacity partname = "@1@" value = Value + PartCapacity name = "@1@"
                 SetMaxSecondaryStat partname = "@1@" value = Value + PartSecondaryStat name = "@1@"
             ]
+
+// The following is really only needed on the first resupplied turn after an upgrade is researched, since the resupply currently
+// takes place in a portion of the turn before meters are updated, but currently there is no good way to restrict this to
+// only that first resupply (and it is simply mildly inefficient to repeat the topup later).
+           EffectsGroup
+            scope = And [
+                        [[EMPIRE_OWNED_SHIP_WITH_PART]]
+                        Turn high = LocalCandidate.LastTurnResupplied 
+            ]
+            accountinglabel = "@1@"
+            effects = SetCapacity partname = "@1@" value = Value + [[ARBITRARY_BIG_NUMBER_FOR_METER_TOPUP]]
 '''
 
 // @1@ part name
@@ -19,10 +30,7 @@ WEAPON_UPGRADE_CAPACITY_EFFECTS
                         [[SHIP_PART_UPGRADE_RESUPPLY_CHECK(CurrentContent)]]
             ]
             accountinglabel = "@1@"
-            effects = [
-                SetCapacity partname = "@1@" value = Value + @2@
-                SetMaxCapacity partname = "@1@" value = Value + @2@
-            ]
-'''
+            effects = SetMaxCapacity partname = "@1@" value = Value + @2@
+            '''
 
 #include "../techs.macros"

--- a/default/scripting/techs/ship_weapons/ship_weapons.macros
+++ b/default/scripting/techs/ship_weapons/ship_weapons.macros
@@ -1,11 +1,7 @@
 // @1@ part name
 WEAPON_BASE_EFFECTS
 '''        EffectsGroup
-            scope = And [
-                Ship
-                OwnedBy empire = Source.Owner
-                DesignHasPart  name = "@1@"
-            ]
+            scope = [[EMPIRE_OWNED_SHIP_WITH_PART]]
             accountinglabel = "@1@"
             effects = [
                 SetMaxCapacity partname = "@1@" value = Value + PartCapacity name = "@1@"
@@ -19,10 +15,14 @@ WEAPON_UPGRADE_CAPACITY_EFFECTS
 '''
         EffectsGroup
             scope = And [
-                Ship
-                OwnedBy empire = Source.Owner
-                DesignHasPart  name = "@1@"
+                        [[EMPIRE_OWNED_SHIP_WITH_PART]]
+                        [[SHIP_PART_UPGRADE_RESUPPLY_CHECK(CurrentContent)]]
             ]
             accountinglabel = "@1@"
-            effects = SetMaxCapacity partname = "@1@" value = Value + @2@
+            effects = [
+                SetCapacity partname = "@1@" value = Value + @2@
+                SetMaxCapacity partname = "@1@" value = Value + @2@
+            ]
 '''
+
+#include "../techs.macros"

--- a/default/scripting/techs/techs.macros
+++ b/default/scripting/techs/techs.macros
@@ -11,7 +11,8 @@ EMPIRE_OWNED_SHIP_WITH_PART
             ]
 '''
 
-// For inclusion in a scope macro, which should have already limited scope to ships owned by an empire
+// For inclusion in a scope macro for an upgrade increase to a Max type meter (MaxCapacity or MaxSecondaryStat), and that scope 
+// should have already limited scope to ships owned by an empire
 // In most cases the substitution provided for @1@ may simply be "CurrentContent" (without the quote marks) but
 // if providing an explicit tech name then include quotes with the substitution, 
 // i.e., either use
@@ -22,3 +23,6 @@ SHIP_PART_UPGRADE_RESUPPLY_CHECK
 '''
            ( LocalCandidate.LastTurnResupplied > TurnTechResearched empire = LocalCandidate.Owner name = @1@ )
 '''
+
+ARBITRARY_BIG_NUMBER_FOR_METER_TOPUP
+''' 1000000 '''

--- a/default/scripting/techs/techs.macros
+++ b/default/scripting/techs/techs.macros
@@ -1,2 +1,24 @@
 CANDIDATE_BATTLE_CHECK
 '''Turn low = LocalCandidate.System.LastTurnBattleHere + 1'''
+
+// In typical usage this is used as a plain macro, not a substitution macro; the substitution is instead done within the calling macro
+EMPIRE_OWNED_SHIP_WITH_PART
+'''
+            And [
+                Ship
+                OwnedBy empire = Source.Owner
+                DesignHasPart  name = "@1@"
+            ]
+'''
+
+// For inclusion in a scope macro, which should have already limited scope to ships owned by an empire
+// In most cases the substitution provided for @1@ may simply be "CurrentContent" (without the quote marks) but
+// if providing an explicit tech name then include quotes with the substitution, 
+// i.e., either use
+// SHIP_PART_UPGRADE_RESUPPLY_CHECK("SOME_TECH")
+// or
+// SHIP_PART_UPGRADE_RESUPPLY_CHECK(CurrentContent)
+SHIP_PART_UPGRADE_RESUPPLY_CHECK
+'''
+           ( LocalCandidate.LastTurnResupplied > TurnTechResearched empire = LocalCandidate.Owner name = @1@ )
+'''


### PR DESCRIPTION
 - works with new valuerefs to directly upgrade part capacity via
   normal meter effects, so that 'surprise' upgrades do not take place during the (pre-combat) movement phase

As discussed somewhat, in the [Fuel Parts Upgrade thread](http://www.freeorion.org/forum/viewtopic.php?p=90144#p90144) (although, due to immediate-upgrade regardless of supply, having been decided on for fuel parts, this currently is only applied to weapons).

This resolves #1770.

For a clear example of the differing result in the combat situations contemplated in #1770, a test case can be staged with a starting Frigate, without SR 1_2 having been researched, sitting in supply one short jump from a monster.  So, with standard pilots damage 3.  (On my system, 50 stars, medium everything, zero AIs, RNG key 0, comes up like this with a suitable monster a jump right then up.)  Save the game with the frigate one jump from the monster.  With current handling, if you then research SR_1_2, and on the same turn that you research it (i.e., just after you get the research sitrep, but before the change shows in the regular ship meters), you launch the ship at the monster, and then check the log, you will see that the upgrade became effective during the movement phase and the ship was attacking with strength 4.  With this PR the upgrade does not become effective until the normal meter update, after that combat round, and the log shows the ship attacking with strength 3.

(edited to clean up references to the now-abandoned idea of the Max meters being superfluous)