### PR TITLE
AI blockade avoidance

### DIFF
--- a/default/python/AI/freeorion_tools/_freeorion_tools.py
+++ b/default/python/AI/freeorion_tools/_freeorion_tools.py
@@ -158,6 +158,26 @@ def cache_by_session(function):
     return wrapper
 
 
+def cache_by_session_with_turnwise_update(function):
+    """
+    Cache a function value during session, updated each turn.
+    Wraps only functions with hashable arguments.
+    """
+    _cache = {}
+
+    @wraps(function)
+    def wrapper(*args, **kwargs):
+        key = (function , args, tuple(kwargs.items()))
+        this_turn = fo.currentTurn()
+        if key in _cache and _cache[key][0] == this_turn:
+            return _cache[key][1]
+        res = function(*args, **kwargs)
+        _cache[key] = (this_turn, res)
+        return res
+    wrapper._cache = _cache
+    return wrapper
+
+
 def cache_by_turn(function):
     """
     Cache a function value by turn, stored in foAIstate so also provides a history that may be analysed. The cache


### PR DESCRIPTION
This allows the AI to use the information from Empire::UnrestrictedLaneTravel() to have its non-warship fleets plot routes around blockaded starlanes (in the existing code, they generally just hold off from trying to pass through any system with more enemy forces than one's own, and wait for reinforcements to come).

For testing, there is a _DEBUG_CHAT variable that can be set to get chat messages when the AI has rerouted around a danger.

In the discussion in #1761 there was some mention of possibly having the AI pass in a list of fully prohibited systems to be routed around, and that could still be a useful augmentation after this PR, particularly useful in situations where the AI knew it was planning on withdrawing forces from a contested system, for example.  