### PR TITLE
Ai focus dithering fix

### DIFF
--- a/default/python/AI/AIDependencies.py
+++ b/default/python/AI/AIDependencies.py
@@ -48,6 +48,7 @@ TROOPS_PER_POP = 0.2
 
 PROT_FOCUS_MULTIPLIER = 2.0
 TECH_COST_MULTIPLIER = 2.0
+FOCUS_CHANGE_PENALTY = 1
 
 # Colonization details
 COLONY_POD_COST = 120  # TODO Query directly from part

--- a/default/python/AI/ResourcesAI.py
+++ b/default/python/AI/ResourcesAI.py
@@ -607,7 +607,7 @@ def set_planet_industry_and_research_foci(focus_manager, priority_ratio):
                 if (rr - tr) < 3:
                     continue
 
-                if (ci > ii + 8) or (((rr > ii) or ((rr - cr) >= 1 + 2 * research_penalty))  and ((cr - tr + 1 - research_penalty) >= (ii - ci))):
+                if ((rr - cr) >= 1 + 2 * research_penalty) and ((cr - tr + 1 - research_penalty) >= (ii - ci)):
                     target_pp += ci - 1 - research_penalty
                     target_rp += cr + 1
                     focus_manager.bake_future_focus(pid, RESEARCH, False)

--- a/default/python/AI/ResourcesAI.py
+++ b/default/python/AI/ResourcesAI.py
@@ -590,8 +590,8 @@ def set_planet_industry_and_research_foci(focus_manager, priority_ratio):
                 # RP at a good PP cost, and still need some RP, then consider doing it.
                 # Won't really work if AI has researched Force Energy Structures (meters fall too fast)
                 #TODO: add similar decision points by which research-rich planets might possibly choose to dither for industry points
-                if any((has_force ,
-                        foAI.foAIstate.character.may_dither_focus_to_gain_research(),
+                if any((has_force,
+                        not foAI.foAIstate.character.may_dither_focus_to_gain_research(),
                         target_rp >= priority_ratio * cumulative_pp)):
                     continue
 

--- a/default/python/AI/ResourcesAI.py
+++ b/default/python/AI/ResourcesAI.py
@@ -593,7 +593,7 @@ def set_planet_industry_and_research_foci(focus_manager, priority_ratio):
                 # if AI is aggressive+, and this planet in range where temporary Research focus can get an additional RP at cost of 1 PP, and still need some RP, then do it
                 if pop < t_pop - 5:
                     continue
-                if (ci > ii + 8) or (((rr > ii) or ((rr - cr) >= 1 + 2 * research_penalty)) and ((rr - tr) >= 3) and ((cr - tr) >= 0.7 * ((ii - ci) * (1 + 0.1 * research_penalty)))):
+                if (ci > ii + 8) or (((rr > ii) or ((rr - cr) >= 1 + 2 * research_penalty)) and ((rr - tr) >= 3) and ((cr - tr + 1 - research_penalty) >= (ii - ci))):
                     target_pp += ci - 1 - research_penalty
                     target_rp += cr + 1
                     focus_manager.bake_future_focus(pid, RESEARCH, False)

--- a/default/python/AI/character/character_module.py
+++ b/default/python/AI/character/character_module.py
@@ -378,7 +378,7 @@ class Aggression(Trait):
         return [4.0, 3.0, 2.0, 1.5, 1.2, 1.0][self.aggression]
 
     def may_dither_focus_to_gain_research(self):
-        return self.aggression < fo.aggression.aggressive
+        return self.aggression >= fo.aggression.aggressive
 
     def may_research_heavily(self):
         return self.aggression > fo.aggression.cautious


### PR DESCRIPTION
As discussed in #1766, AI Focus dithering (short term swaps between Research and Industry Focus), is currently underperforming because of a bug that causes the research phase of focus dithering to be cut short too soon.  In addition to fixing that bug, this PR restructures and clarifies the dither code.  I am also working on some further improvements I had mentioned in #1766, but those are taking some more time and I wanted to at least get this primary fix and clarification in for review right away.