### PR TITLE
Fix AI usage of growth focus

### DIFF
--- a/default/python/AI/AIDependencies.py
+++ b/default/python/AI/AIDependencies.py
@@ -172,6 +172,7 @@ HONEYCOMB_IND_MULTIPLIER = 2.5
 # </editor-fold>
 
 # <editor-fold desc="Research related specials">
+COMPUTRONIUM_SPECIAL = "COMPUTRONIUM_SPECIAL"
 COMPUTRONIUM_RES_MULTIPLIER = 1.0
 # </editor-fold>
 

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -318,7 +318,7 @@ def survey_universe():
                             yard_here = [pid]
                         if this_spec.canColonize and planet.currentMeterValue(fo.meterType.targetPopulation) >= 3:
                             empire_colonizers.setdefault(spec_name, []).extend(yard_here)
-                    if "COMPUTRONIUM_SPECIAL" in planet.specials:  # only counting it if planet is populated
+                    if AIDependencies.COMPUTRONIUM_SPECIAL in planet.specials:  # only counting it if planet is populated
                         state.set_have_computronium()
 
                 this_grade_facilities = facilities_by_species_grade.setdefault(weapons_grade, {})
@@ -1149,14 +1149,14 @@ def evaluate_planet(planet_id, mission_type, spec_name, detail=None):
             if "TEMPORAL_ANOMALY_SPECIAL" in planet.specials:
                 research_bonus += discount_multiplier * 2 * AIDependencies.RESEARCH_PER_POP * max_pop_size * 25
                 detail.append("Temporal Anomaly Research")
-            if "COMPUTRONIUM_SPECIAL" in planet.specials:
+            if AIDependencies.COMPUTRONIUM_SPECIAL in planet.specials:
                 comp_bonus = (0.5 * AIDependencies.TECH_COST_MULTIPLIER * AIDependencies.RESEARCH_PER_POP *
                               AIDependencies.COMPUTRONIUM_RES_MULTIPLIER * empire_status['researchers'] *
                               discount_multiplier)
                 if state.have_computronium:
                     comp_bonus *= backup_factor
                 research_bonus += comp_bonus
-                detail.append("COMPUTRONIUM_SPECIAL")
+                detail.append(AIDependencies.COMPUTRONIUM_SPECIAL)
 
         retval += max(ind_val + asteroid_bonus + gas_giant_bonus, research_bonus,
                       growth_val) + fixed_ind + fixed_res + supply_val

--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -942,7 +942,7 @@ def generate_production_orders():
                     res = fo.issueScrapOrder(bldg)
                     print "Tried scrapping %s at planet %s, got result %d" % (building_name, planet.name, res)
         elif foAI.foAIstate.character.may_build_building(building_name) and can_build_camp and (t_pop >= 36):
-            if (planet.focus == FocusType.FOCUS_GROWTH) or ("COMPUTRONIUM_SPECIAL" in planet.specials) or (pid == capital_id):
+            if (planet.focus == FocusType.FOCUS_GROWTH) or (AIDependencies.COMPUTRONIUM_SPECIAL in planet.specials) or (pid == capital_id):
                 continue
                 # pass  # now that focus setting takes these into account, probably works ok to have conc camp, but let's not push it
             queued_building_locs = [element.locationID for element in production_queue if (element.name == building_name)]

--- a/default/python/AI/ResourcesAI.py
+++ b/default/python/AI/ResourcesAI.py
@@ -435,8 +435,9 @@ def set_planet_growth_specials(focus_manager):
             # the increased population on the planet using this growth focus
             # is mostly wasted, so ignore it for now.
             pop = planet.currentMeterValue(fo.meterType.population)
-            if pop > potential_pop_increase - 2 * planet.size:
-                _print_evaluation("would lose more population (%.1f) than total gain everywhere else." % pop)
+            pop_gain = potential_pop_increase - planet.size
+            if pop > pop_gain:
+                _print_evaluation("would lose more pop (%.1f) than gain everywhere else (%.1f)." % (pop, pop_gain))
                 continue
 
             # If we have a computronium special here, then research focus will have higher priority.
@@ -445,7 +446,7 @@ def set_planet_growth_specials(focus_manager):
                 continue
 
             _print_evaluation("considered (pop %.1f, growth gain %.1f, current focus %s)" % (
-                pop, potential_pop_increase - 2*planet.size, pinfo.current_focus))
+                pop, pop_gain, pinfo.current_focus))
 
             # add a bias to discourage switching out growth focus to avoid focus change penalties
             if pinfo.current_focus == GROWTH:

--- a/default/python/AI/ResourcesAI.py
+++ b/default/python/AI/ResourcesAI.py
@@ -403,7 +403,7 @@ def set_planet_growth_specials(focus_manager):
     if not useGrowth:
         return
 
-    # TODO: also consider potential future benefit re currently unpopulated planets
+    # TODO Consider actual resource output of the candidate locations rather than only population
     for special, locations in ColonisationAI.available_growth_specials.iteritems():
         # Find which metabolism is boosted by this special
         metabolism = AIDependencies.metabolismBoosts.get(special)

--- a/default/python/AI/ResourcesAI.py
+++ b/default/python/AI/ResourcesAI.py
@@ -400,37 +400,72 @@ def assess_protection_focus(pid, pinfo):
 
 def set_planet_growth_specials(focus_manager):
     """set resource foci of planets with potentially useful growth factors. Remove planets from list of candidates."""
-    if useGrowth:
-        # TODO: also consider potential future benefit re currently unpopulated planets
-        for metab, metab_inc_pop in ColonisationAI.empire_metabolisms.items():
-            for special in [aspec for aspec in AIDependencies.metabolismBoostMap.get(metab, []) if aspec in ColonisationAI.available_growth_specials]:
-                ranked_planets = []
-                for pid in ColonisationAI.available_growth_specials[special]:
-                    pinfo = focus_manager.all_planet_info[pid]
-                    planet = pinfo.planet
-                    pop = planet.currentMeterValue(fo.meterType.population)
-                    if (pop > metab_inc_pop - 2 * planet.size) or (GROWTH not in planet.availableFoci):  # not enough benefit to lose local production, or can't put growth focus here
-                        continue
-                    for special2 in ["COMPUTRONIUM_SPECIAL"]:
-                        if special2 in planet.specials:
-                            break
-                    else:  # didn't have any specials that would override interest in growth special
-                        print "Considering Growth Focus for %s (%d) with special %s; planet has pop %.1f and %s metabolism incremental pop is %.1f" % (
-                            planet.name, pid, special, pop, metab, metab_inc_pop)
-                        if pinfo.current_focus == GROWTH:
-                            pop -= 4  # discourage changing current focus to minimize focus-changing penalties
-                        ranked_planets.append((pop, pid, pinfo.current_focus))
-                if not ranked_planets:
-                    continue
-                ranked_planets.sort()
-                print "Considering Growth Focus choice for special %s; possible planet pop, id pairs are %s" % (metab, ranked_planets)
-                for _spPop, spPID, cur_focus in ranked_planets:  # index 0 should be able to set focus, but just in case...
-                    planet = focus_manager.all_planet_info[spPID].planet
-                    if focus_manager.bake_future_focus(spPID, GROWTH):
-                        print "%s focus of planet %s (%d) at Growth Focus" % (["set", "left"][cur_focus == GROWTH], planet.name, spPID)
-                        break
-                    else:
-                        print "failed setting focus of planet %s (%d) at Growth Focus; focus left at %s" % (planet.name, spPID, planet.focus)
+    if not useGrowth:
+        return
+
+    # TODO: also consider potential future benefit re currently unpopulated planets
+    for special, locations in ColonisationAI.available_growth_specials.iteritems():
+        # Find which metabolism is boosted by this special
+        metabolism = AIDependencies.metabolismBoosts.get(special)
+        if not metabolism:
+            warn("Entry in available growth special not mapped to a metabolism")
+            continue
+
+        # Find the total population bonus we could get by using growth focus
+        potential_pop_increase = ColonisationAI.empire_metabolisms.get(metabolism, 0)
+        if not potential_pop_increase:
+            continue
+
+        debug("Considering setting growth focus for %s at locations %s for potential population bonus of %.1f" % (
+            special, locations, potential_pop_increase))
+
+        # Find the best suited planet to use growth special on, i.e. the planet where
+        # we will lose the least amount of resource generation when using growth focus.
+        def _print_evaluation(evaluation):
+            """Local helper function printing a formatted evaluation."""
+            debug("  - %s %s" % (planet, evaluation))
+        ranked_planets = []
+        for pid in locations:
+            pinfo = focus_manager.all_planet_info[pid]
+            planet = pinfo.planet
+            if GROWTH not in planet.availableFoci:
+                _print_evaluation("has no growth focus available.")
+                continue
+
+            # the increased population on the planet using this growth focus
+            # is mostly wasted, so ignore it for now.
+            pop = planet.currentMeterValue(fo.meterType.population)
+            if pop > potential_pop_increase - 2 * planet.size:
+                _print_evaluation("would lose more population (%.1f) than total gain everywhere else." % pop)
+                continue
+
+            # If we have a computronium special here, then research focus will have higher priority.
+            if AIDependencies.COMPUTRONIUM_SPECIAL in planet.specials and RESEARCH in planet.availableFoci:
+                _print_evaluation("has a usable %s" % AIDependencies.COMPUTRONIUM_SPECIAL)
+                continue
+
+            _print_evaluation("considered (pop %.1f, growth gain %.1f, current focus %s)" % (
+                pop, potential_pop_increase - 2*planet.size, pinfo.current_focus))
+
+            # add a bias to discourage switching out growth focus to avoid focus change penalties
+            if pinfo.current_focus == GROWTH:
+                pop -= 4
+
+            ranked_planets.append((pop, pid, planet))
+
+        if not ranked_planets:
+            debug("  --> No suitable location found.")
+            continue
+
+        # sort possible locations by population in ascending order and set population
+        # bonus at the planet with lowest possible population loss.
+        ranked_planets.sort()
+        for pop, pid, planet in ranked_planets:
+            if focus_manager.bake_future_focus(pid, GROWTH):
+                debug("  --> Using growth focus at %s" % planet)
+                break
+        else:
+            warn("  --> Failed to set growth focus at all candidate locations.")
 
 
 def set_planet_production_and_research_specials(focus_manager):
@@ -447,7 +482,7 @@ def set_planet_production_and_research_specials(focus_manager):
     already_have_comp_moon = False
     for pid, pinfo in focus_manager.raw_planet_info.items():
         planet = pinfo.planet
-        if "COMPUTRONIUM_SPECIAL" in planet.specials and RESEARCH in planet.availableFoci and not already_have_comp_moon:
+        if AIDependencies.COMPUTRONIUM_SPECIAL in planet.specials and RESEARCH in planet.availableFoci and not already_have_comp_moon:
             if focus_manager.bake_future_focus(pid, RESEARCH):
                 already_have_comp_moon = True
                 print "%s focus of planet %s (%d) (with Computronium Moon) at Research Focus" % (["set", "left"][pinfo.current_focus == RESEARCH], planet.name, pid)


### PR DESCRIPTION
The first commit of this PR is some general refactoring of the growth focus evaluation code to improve readability.

The second commit fixes the calculation of the "usable"  population gained by using growth focus. The AI underestimated the benefit of the growth focus which made it not using the focus in some situations where it was already beneficial to do so.