### PR TITLE
Add PingServer() and PingLocalHostServer() to client networking.

### DIFF
--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -427,8 +427,7 @@ namespace {
 }
 
 void HumanClientApp::StartServer() {
-    auto connected = m_networking->ConnectToLocalHostServer(std::chrono::milliseconds(100));
-    if (connected) {
+    if (m_networking->PingLocalHostServer(std::chrono::milliseconds(100))) {
         ErrorLogger() << "Can't start local server because a server is already connecting at 127.0.0.0.";
         throw LocalServerAlreadyRunningException();
     }

--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -72,8 +72,17 @@ public:
 
     /** Connects to the server on the client's host.  On failure, repeated
         attempts will be made until \a timeout seconds has elapsed. */
-    bool ConnectToLocalHostServer(const std::chrono::milliseconds& timeout =
-                                  std::chrono::seconds(10));
+    bool ConnectToLocalHostServer(
+        const std::chrono::milliseconds& timeout = std::chrono::seconds(10));
+
+    /** Return true if the server can be connected to within \p timeout seconds. */
+    bool PingServer(
+        const std::string& ip_address,
+        const std::chrono::milliseconds& timeout = std::chrono::seconds(10));
+
+    /** Return true if the local server can be connected to within \p timeout seconds. */
+    bool PingLocalHostServer(
+        const std::chrono::milliseconds& timeout = std::chrono::seconds(10));
 
     /** Sends \a message to the server.  This function actually just enqueues
         the message for sending and returns immediately. */


### PR DESCRIPTION
This allows attempting to connect to the server to time out without
reporting an error.