### PR TITLE
Unrestricted lane travel conform comments

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -2005,11 +2005,11 @@ void Empire::UpdateSupplyUnobstructedSystems(const std::set<int>& known_systems)
             // so it is obstructed, so isn't included in the unobstructed
             // systems set.  Furthermore, this empire's available system exit
             // lanes for this system are cleared
-            if (!m_available_system_exit_lanes[sys_id].empty()) {
+            if (!m_preserved_system_exit_lanes[sys_id].empty()) {
                 //DebugLogger() << "Empire::UpdateSupplyUnobstructedSystems clearing available lanes for system ("<<sys_id<<"); available lanes were:";
-                //for (int system_id : m_available_system_exit_lanes[sys_id])
+                //for (int system_id : m_preserved_system_exit_lanes[sys_id])
                 //    DebugLogger() << "...... "<< system_id;
-                m_available_system_exit_lanes[sys_id].clear();
+                m_preserved_system_exit_lanes[sys_id].clear();
             }
         }
     }
@@ -2027,9 +2027,9 @@ void Empire::RecordPendingLaneUpdate(int start_system_id, int dest_system_id) {
     }
 }
 
-void Empire::UpdateAvailableLanes() {
+void Empire::UpdatePreservedLanes() {
     for (auto& system : m_pending_system_exit_lanes) {
-        m_available_system_exit_lanes[system.first].insert(system.second.begin(), system.second.end());
+        m_preserved_system_exit_lanes[system.first].insert(system.second.begin(), system.second.end());
         system.second.clear();
     }
     m_pending_system_exit_lanes.clear(); // TODO: consider: not really necessary, & may be more efficient to not clear.
@@ -2041,9 +2041,9 @@ const std::map<int, float>& Empire::SystemSupplyRanges() const
 const std::set<int>& Empire::SupplyUnobstructedSystems() const
 { return m_supply_unobstructed_systems; }
 
-const bool Empire::UnrestrictedLaneTravel(int start_system_id, int dest_system_id) const {
-    auto find_it = m_available_system_exit_lanes.find(start_system_id);
-    if (find_it != m_available_system_exit_lanes.end() ) {
+const bool Empire::PreservedLaneTravel(int start_system_id, int dest_system_id) const {
+    auto find_it = m_preserved_system_exit_lanes.find(start_system_id);
+    if (find_it != m_preserved_system_exit_lanes.end() ) {
         if (find_it->second.find(dest_system_id) != find_it->second.end())
             return true;
     }

--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -680,7 +680,7 @@ private:
     // cached calculation results, returned by reference
     std::map<int, float>            m_supply_system_ranges;         ///< number of starlane jumps away from each system (by id) supply can be conveyed.  This is the number due to a system's contents conveying supply and is computed and set by UpdateSystemSupplyRanges
     std::set<int>                   m_supply_unobstructed_systems;  ///< ids of system that don't block supply from flowing
-    std::map<int, std::set<int>>    m_available_system_exit_lanes;  ///< for each system known to this empire, the set of available/non-blockaded exit lanes for fleet travel
+    std::map<int, std::set<int>>    m_available_system_exit_lanes;  ///< for each system known to this empire, the set of exit lanes preserved for fleet travel even if otherwise blockaded
     std::map<int, std::set<int>>    m_pending_system_exit_lanes;    ///< pending updates to m_available_system_exit_lanes
 
     friend class boost::serialization::access;

--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -385,8 +385,9 @@ public:
       * exchange supply between themselves (even if not leaving the system). */
     const std::set<int>&                    SupplyUnobstructedSystems() const;
 
-    /** Returns true if the start system is known to this empire and travel to
-        the dest system is not restricted by blockade.  */
+    /** Returns true if the specified lane travel is preserved against being blockaded (i.e., the empire
+     * has in the start system at least one fleet that meets the requirements to preserve the lane (which
+     * is determined in Empire::UpdateSupplyUnobstructedSystems(). */
     const bool                              UnrestrictedLaneTravel(int start_system_id, int dest_system_id) const;
 
     const std::set<int>&                    ExploredSystems() const;    ///< returns set of ids of systems that this empire has explored

--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -388,7 +388,7 @@ public:
     /** Returns true if the specified lane travel is preserved against being blockaded (i.e., the empire
      * has in the start system at least one fleet that meets the requirements to preserve the lane (which
      * is determined in Empire::UpdateSupplyUnobstructedSystems(). */
-    const bool                              UnrestrictedLaneTravel(int start_system_id, int dest_system_id) const;
+    const bool                              PreservedLaneTravel(int start_system_id, int dest_system_id) const;
 
     const std::set<int>&                    ExploredSystems() const;    ///< returns set of ids of systems that this empire has explored
     const std::map<int, std::set<int>>      KnownStarlanes() const;     ///< returns map from system id (start) to set of system ids (endpoints) of all starlanes known to this empire
@@ -511,7 +511,7 @@ public:
     /** Records, in a list of pending updates, the start_system exit lane to the specified destination as accessible to this empire*/
     void RecordPendingLaneUpdate(int start_system_id, int dest_system_id);
     /** Processes all the pending lane access updates.  This is managed as a two step process to avoid order-of-processing issues. */
-    void UpdateAvailableLanes();
+    void UpdatePreservedLanes();
 
     /** Checks for production projects that have been completed, and places them
       * at their respective production sites.  Which projects have been
@@ -681,8 +681,8 @@ private:
     // cached calculation results, returned by reference
     std::map<int, float>            m_supply_system_ranges;         ///< number of starlane jumps away from each system (by id) supply can be conveyed.  This is the number due to a system's contents conveying supply and is computed and set by UpdateSystemSupplyRanges
     std::set<int>                   m_supply_unobstructed_systems;  ///< ids of system that don't block supply from flowing
-    std::map<int, std::set<int>>    m_available_system_exit_lanes;  ///< for each system known to this empire, the set of exit lanes preserved for fleet travel even if otherwise blockaded
-    std::map<int, std::set<int>>    m_pending_system_exit_lanes;    ///< pending updates to m_available_system_exit_lanes
+    std::map<int, std::set<int>>    m_preserved_system_exit_lanes;  ///< for each system known to this empire, the set of exit lanes preserved for fleet travel even if otherwise blockaded
+    std::map<int, std::set<int>>    m_pending_system_exit_lanes;    ///< pending updates to m_preserved_system_exit_lanes
 
     friend class boost::serialization::access;
     Empire();

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -4652,7 +4652,7 @@ void MapWnd::SetFleetMovementLine(int fleet_id) {
             //DebugLogger() << "MapWnd::SetFleetMovementLine fleet id " << fleet_id<<" blockaded at system "<< route.front() <<
             //    " with m_arrival_lane "<< fleet->ArrivalStarlane()<<" and next destination "<<*route_it;
             if (route_it != route.end() && !( (*route_it == fleet->ArrivalStarlane())  ||
-                (empire && empire->UnrestrictedLaneTravel(fleet->SystemID(), *route_it)) ) )
+                (empire && empire->PreservedLaneTravel(fleet->SystemID(), *route_it)) ) )
             {
                 for (MovePathNode& node : path) {
                     //DebugLogger() <<   "MapWnd::SetFleetMovementLine fleet id " << fleet_id<<" node obj " << node.object_id <<
@@ -4700,7 +4700,7 @@ void MapWnd::SetProjectedFleetMovementLine(int fleet_id, const std::list<int>& t
             //DebugLogger() << "MapWnd::SetFleetMovementLine fleet id " << fleet_id<<" blockaded at system "<< route.front() <<
             //" with m_arrival_lane "<< fleet->ArrivalStarlane()<<" and next destination "<<*route_it;
             if (route_it != travel_route.end() && !((*route_it == fleet->ArrivalStarlane()) ||
-                (empire && empire->UnrestrictedLaneTravel(fleet->SystemID(), *route_it))))
+                (empire && empire->PreservedLaneTravel(fleet->SystemID(), *route_it))))
             {
                 for (MovePathNode& node : path) {
                     //DebugLogger() <<   "MapWnd::SetFleetMovementLine fleet id " << fleet_id << " node obj " << node.object_id <<

--- a/default/python/AI/pathfinding.py
+++ b/default/python/AI/pathfinding.py
@@ -39,7 +39,7 @@ def _more_careful_travel_starlane_func(c, d):
 # is being done) arrived second but are currently preserving travel along the starlane of interest.
 def _somewhat_careful_travel_starlane_func(c, d):
     return any((c in _get_unobstructed_systems(),
-                fo.getEmpire().unrestrictedLaneTravel(c, d)))
+                fo.getEmpire().preservedLaneTravel(c, d)))
 
 
 # For some activities like scouting, we may want to allow an extra bit of risk from routing through a system which

--- a/python/EmpireWrapper.cpp
+++ b/python/EmpireWrapper.cpp
@@ -340,7 +340,7 @@ namespace FreeOrionPython {
 
             .def("population",                      &Empire::Population)
 
-            .def("unrestrictedLaneTravel",          &Empire::UnrestrictedLaneTravel)
+            .def("preservedLaneTravel",          &Empire::PreservedLaneTravel)
             .add_property("fleetSupplyableSystemIDs",   make_function(
                                                             empireFleetSupplyableSystemIDsFunc,
                                                             return_value_policy<copy_const_reference>(),

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -3149,7 +3149,7 @@ void ServerApp::PostCombatProcessTurns() {
     for (auto& entry : empires) {
         if (!entry.second->Eliminated()) {
             Empire* empire = entry.second;
-            empire->UpdateAvailableLanes();
+            empire->UpdatePreservedLanes();
             empire->UpdateUnobstructedFleets();     // must be done after *all* noneliminated empires have updated their unobstructed systems
         }
     }

--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -474,7 +474,7 @@ std::list<MovePathNode> Fleet::MovePath(const std::list<int>& route, bool flag_b
                 if (next_system) {
                     //DebugLogger() << "Fleet::MovePath checking unrestriced lane travel";
                     clear_exit = clear_exit || (next_system && next_system->ID() == m_arrival_starlane) ||
-                    (empire && empire->UnrestrictedLaneTravel(cur_system->ID(), next_system->ID()));
+                    (empire && empire->PreservedLaneTravel(cur_system->ID(), next_system->ID()));
                 }
             }
             if (flag_blockades && !clear_exit) {
@@ -1220,7 +1220,7 @@ bool Fleet::BlockadedAtSystem(int start_system_id, int dest_system_id) const {
         auto unobstructed_systems = empire->SupplyUnobstructedSystems();
         if (unobstructed_systems.find(start_system_id) != unobstructed_systems.end())
             return false;
-        if (empire->UnrestrictedLaneTravel(start_system_id, dest_system_id)) {
+        if (empire->PreservedLaneTravel(start_system_id, dest_system_id)) {
             return false;
         } else {
             //DebugLogger() << "Fleet::BlockadedAtSystem fleet " << ID() << " considering travel from system (" << start_system_id << ") to system (" << dest_system_id << ")";

--- a/util/SerializeEmpire.cpp
+++ b/util/SerializeEmpire.cpp
@@ -127,7 +127,7 @@ void Empire::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_available_hull_types)
         & BOOST_SERIALIZATION_NVP(m_supply_system_ranges)
         & BOOST_SERIALIZATION_NVP(m_supply_unobstructed_systems)
-        & BOOST_SERIALIZATION_NVP(m_available_system_exit_lanes);
+        & BOOST_SERIALIZATION_NVP(m_preserved_system_exit_lanes);
 
     if (GetUniverse().AllObjectsVisible() ||
         GetUniverse().EncodingEmpire() == ALL_EMPIRES ||


### PR DESCRIPTION
As noted in Issue #1780, there is currently a mismatch between the description and actual operation of  ```UnrestrictedLaneTravel()```; this PR proposes to correct that by correcting the comments/description to conform to the actual operation.  

(This is presented along with the main alternative correction for consideration in #1782, which instead proposes to conform the operation to the current description, which essentially causes it to merge in the results from ```Empire::SupplyUnobstructedSystems()```.)

As noted in the above Issue, for the main code base either approach would not make a current difference in operation, because of the manner in which all current uses of ```UnrestrictedLaneTravel()``` are also accompanied (directly or indirectly) by references to ```Empire::SupplyUnobstructedSystems```.

However, the AI could beneficially use the more specific information as retained in this PR (and that information could be separately recreated if necessary, but that would seem cluttered and wasteful).

A further clarification that might be helpful as part of this PR could be to change the attribute and method names to be ```m_preserved_system_exit_lanes``` and ```PreservedLaneTravel()```
