### PR TITLE
Unrestricted lane travel functional correction

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -2021,6 +2021,8 @@ const std::set<int>& Empire::SupplyUnobstructedSystems() const
 { return m_supply_unobstructed_systems; }
 
 const bool Empire::UnrestrictedLaneTravel(int start_system_id, int dest_system_id) const {
+    if (m_supply_unobstructed_systems.find(start_system_id) != m_supply_unobstructed_systems.end())
+        return true;
     auto find_it = m_available_system_exit_lanes.find(start_system_id);
     if (find_it != m_available_system_exit_lanes.end() ) {
         if (find_it->second.find(dest_system_id) != find_it->second.end())

--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -662,7 +662,7 @@ private:
     // cached calculation results, returned by reference
     std::map<int, float>            m_supply_system_ranges;         ///< number of starlane jumps away from each system (by id) supply can be conveyed.  This is the number due to a system's contents conveying supply and is computed and set by UpdateSystemSupplyRanges
     std::set<int>                   m_supply_unobstructed_systems;  ///< ids of system that don't block supply from flowing
-    std::map<int, std::set<int>>    m_available_system_exit_lanes;  ///< for each system known to this empire, the set of available/non-blockaded exit lanes for fleet travel
+    std::map<int, std::set<int>>    m_available_system_exit_lanes;  ///< for each system known to this empire, the set of exit lanes preserved for fleet travel even if otherwise blockaded
     std::map<int, std::set<int>>    m_pending_system_exit_lanes;    ///< pending updates to m_available_system_exit_lanes
 
     friend class boost::serialization::access;


### PR DESCRIPTION
As noted in Issue #1780, there is currently a mismatch between the description and actual operation of  ```UnrestrictedLaneTravel()```; this PR proposes to correct that by conforming the operation to the description.  This is presented along with the alternative correction in PR #1781, which proposes to simply conform the description to the actual operation.

As noted in that other PR, I think that other approach would be more convenient/helpful for the AI and so I prefer that other PR.  But I thought it would help clarify the discussion to put them both up for review.