### PR TITLE
Parse on background thread

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -16,6 +16,7 @@
 #include "../universe/System.h"
 #include "../universe/Universe.h"
 #include "../universe/Enums.h"
+#include "../universe/Tech.h"
 #include "../universe/UniverseObject.h"
 #include "../universe/ValueRef.h"
 #include "ResourcePool.h"

--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -1,6 +1,5 @@
 #include "Empire.h"
 
-#include "../parse/Parse.h"
 #include "../util/i18n.h"
 #include "../util/MultiplayerCommon.h"
 #include "../util/ScopedTimer.h"

--- a/Empire/EmpireManager.h
+++ b/Empire/EmpireManager.h
@@ -8,6 +8,7 @@
 
 #include <GG/Clr.h>
 
+#include <boost/filesystem.hpp>
 #include <boost/serialization/access.hpp>
 #include <boost/signals2/signal.hpp>
 
@@ -124,5 +125,8 @@ extern template FO_COMMON_API void EmpireManager::serialize<freeorion_xml_iarchi
 
 /** The colors that are available for use for empires in the game. */
 FO_COMMON_API const std::vector<GG::Clr>& EmpireColors();
+
+/** Initialize empire colors from \p path */
+FO_COMMON_API void InitEmpireColors(const boost::filesystem::path& path);
 
 #endif // _EmpireManager_h_

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -8,6 +8,7 @@
 #include "IconTextBrowseWnd.h"
 #include "Sound.h"
 #include "TextBrowseWnd.h"
+#include "../parse/Parse.h"
 #include "../util/i18n.h"
 #include "../util/Logger.h"
 #include "../util/Order.h"
@@ -213,12 +214,12 @@ namespace {
         SavedDesignsManager()
         {}
 
-        const std::list<boost::uuids::uuid>& OrderedDesignUUIDs() const
-        { return m_ordered_uuids; }
+        const std::list<boost::uuids::uuid>& OrderedDesignUUIDs() const;
 
         std::vector<int> OrderedIDs() const override;
 
-        void LoadDesignsFromFileSystem();
+        void StartParsingDesignsFromFileSystem(bool is_new_game);
+        void CheckPendingDesigns() const;
 
         const ShipDesign* GetDesign(const boost::uuids::uuid& uuid) const;
 
@@ -235,14 +236,29 @@ namespace {
         /** Save the design with the original filename or throw out_of_range. */
         void SaveDesign(const boost::uuids::uuid &uuid);
 
+        /** SaveDesignConst allows CheckPendingDesigns to correct the designs
+            in the saved directory.*/
+        void SaveDesignConst(const boost::uuids::uuid &uuid) const;
+
         void SaveDesign(int design_id);
 
-        std::list<boost::uuids::uuid> m_ordered_uuids;
+        /** A const version of SaveManifest to allow CheckPendingDesigns to
+            correct and save the loaded designs. */
+        void SaveManifestConst() const;
+
+        /** Future ship design type being parsed by parser.  mutable so that it can
+        be assigned to m_saved_designs when completed.*/
+        mutable boost::optional<std::future<PredefinedShipDesignManager::ParsedShipDesignsType>>
+        m_pending_designs = boost::none;
+
+        mutable std::list<boost::uuids::uuid> m_ordered_uuids;
         /// Saved designs with filename
-        std::unordered_map<boost::uuids::uuid,
+        mutable std::unordered_map<boost::uuids::uuid,
                            std::pair<std::unique_ptr<ShipDesign>,
                                      boost::filesystem::path>,
                            boost::hash<boost::uuids::uuid>>  m_saved_designs;
+
+        mutable bool m_is_new_game = false;
     };
 
 
@@ -358,7 +374,13 @@ namespace {
     // SavedDesignsManager implementations          
     //////////////////////////////////////////////////
 
+    const std::list<boost::uuids::uuid>& SavedDesignsManager::OrderedDesignUUIDs() const {
+        CheckPendingDesigns();
+        return m_ordered_uuids;
+    }
+
     std::vector<int> SavedDesignsManager::OrderedIDs() const {
+        CheckPendingDesigns();
         std::vector<int> retval;
         for (const auto uuid: m_ordered_uuids) {
             const auto& it = m_saved_designs.find(uuid);
@@ -369,23 +391,52 @@ namespace {
         return retval;
     }
 
-    void SavedDesignsManager::LoadDesignsFromFileSystem() {
+    void SavedDesignsManager::StartParsingDesignsFromFileSystem(bool is_new_game) {
         auto saved_designs_dir = SavedDesignsDir();
         if (!exists(saved_designs_dir))
             return;
 
+        m_is_new_game = is_new_game;
+
+        TraceLogger() << "Start parsing saved designs from directory";
+        m_pending_designs = std::async(std::launch::async, parse::ship_designs, saved_designs_dir);
+    }
+
+    void SavedDesignsManager::CheckPendingDesigns() const {
+        if (!m_pending_designs)
+            return;
+
+        TraceLogger() << "Waiting for pending saved designs";
+
+        // Only print waiting message if not immediately ready
+        while (m_pending_designs->wait_for(std::chrono::seconds(1)) == std::future_status::timeout) {
+            DebugLogger() << "Waiting for saved ShipDesigns to parse.";
+        }
+
         bool inconsistent;
         std::vector<boost::uuids::uuid> ordering;
 
-        std::tie(inconsistent, m_saved_designs, ordering) =
-            LoadShipDesignsAndManifestOrderFromFileSystem(saved_designs_dir);
+        try {
+            TraceLogger() << "Receive parsed saved designs.";
+
+            auto parsed_designs = m_pending_designs->get();
+
+            std::tie(inconsistent, m_saved_designs, ordering) =
+                LoadShipDesignsAndManifestOrderFromParseResults(parsed_designs);
+
+        } catch (const std::exception& e) {
+            ErrorLogger() << "Failed parsing designs: error: " << e.what();
+            throw;
+        }
+
+        m_pending_designs = boost::none;
 
         m_ordered_uuids = std::list<boost::uuids::uuid>(ordering.begin(), ordering.end());
 
         // Write any corrected ordering back to disk.
         if (inconsistent) {
             WarnLogger() << "Writing corrected ship designs back to saved designs.";
-            SaveManifest();
+            SaveManifestConst();
 
             // Correct file name extension
             // Nothing fancy, just convert '.txt' to '.txt.focs.txt' which the scripting system is
@@ -405,18 +456,37 @@ namespace {
 
 
             for (auto& uuid: m_ordered_uuids)
-                SaveDesign(uuid);
+                SaveDesignConst(uuid);
         }
+
+        if (!m_is_new_game)
+            return;
+
+        m_is_new_game = false;
+
+        // If requested on the first turn copy all of the saved designs to the client empire.
+        if (GetOptionsDB().Get<bool>("auto-add-saved-designs")) {
+            const auto empire_id = HumanClientApp::GetApp()->EmpireID();
+            TraceLogger() << "Adding saved designs to empire.";
+            for (const auto& uuid : m_ordered_uuids)
+                AddSavedDesignToCurrentDesigns(uuid, empire_id, false);
+        }
+
     }
 
     const ShipDesign* SavedDesignsManager::GetDesign(const boost::uuids::uuid& uuid) const {
+        CheckPendingDesigns();
         const auto& it = m_saved_designs.find(uuid);
         if (it == m_saved_designs.end())
             return nullptr;
         return it->second.first.get();
     }
 
-    void SavedDesignsManager::SaveManifest() {
+    void SavedDesignsManager::SaveManifest()
+    { SaveManifestConst(); }
+
+    void SavedDesignsManager::SaveManifestConst() const {
+        CheckPendingDesigns();
         boost::filesystem::path designs_dir_path = GetDesignsDir();
 
         std::string file_name = DESIGN_MANIFEST_PREFIX + DESIGN_FILENAME_EXTENSION;
@@ -440,6 +510,7 @@ namespace {
             return next;
         }
 
+        CheckPendingDesigns();
         if (m_saved_designs.count(design.UUID())) {
             // UUID already exists so this is a move.  Remove the old UUID location
             const auto existing_it = std::find(m_ordered_uuids.begin(), m_ordered_uuids.end(), design.UUID());
@@ -468,6 +539,7 @@ namespace {
         if (moved_uuid == next_uuid)
             return false;
 
+        CheckPendingDesigns();
         if (!m_saved_designs.count(moved_uuid)) {
             ErrorLogger() << "Unable to move saved design because moved design is missing.";
             return false;
@@ -495,6 +567,7 @@ namespace {
     }
 
     void SavedDesignsManager::Erase(const boost::uuids::uuid& erased_uuid) {
+        CheckPendingDesigns();
         const auto& saved_design_it = m_saved_designs.find(erased_uuid);
         if (saved_design_it != m_saved_designs.end()) {
             const auto& file = saved_design_it->second.second;
@@ -506,8 +579,12 @@ namespace {
         m_ordered_uuids.erase(uuid_it);
     }
 
+    void SavedDesignsManager::SaveDesign(const boost::uuids::uuid &uuid)
+    { SaveDesignConst(uuid); }
+
     /** Save the design with the original filename or throw out_of_range..*/
-    void SavedDesignsManager::SaveDesign(const boost::uuids::uuid &uuid) {
+    void SavedDesignsManager::SaveDesignConst(const boost::uuids::uuid &uuid) const {
+        CheckPendingDesigns();
         const auto& design_and_filename = m_saved_designs.at(uuid);
 
         WriteToFile(design_and_filename.second, design_and_filename.first->Dump());
@@ -669,7 +746,7 @@ void ShipDesignManager::StartGame(int empire_id, bool is_new_game) {
 
     m_saved_designs.reset(new SavedDesignsManager());
     auto saved_designs = dynamic_cast<SavedDesignsManager*>(m_saved_designs.get());
-    saved_designs->LoadDesignsFromFileSystem();
+    saved_designs->StartParsingDesignsFromFileSystem(is_new_game);
 
     // Only setup saved and current designs for new games
     if (!is_new_game)
@@ -696,15 +773,6 @@ void ShipDesignManager::StartGame(int empire_id, bool is_new_game) {
                 std::make_shared<ShipDesignOrder>(empire_id, design_id, true));
         }
     }
-
-    // If requested on the first turn copy all of the saved designs to the client empire.
-    if (GetOptionsDB().Get<bool>("auto-add-saved-designs")) {
-
-        DebugLogger() << "Adding saved designs to empire.";
-        for (const auto& uuid : saved_designs->OrderedDesignUUIDs())
-            AddSavedDesignToCurrentDesigns(uuid, empire_id, false);
-    }
-
 }
 
 void ShipDesignManager::Save(SaveGameUIData& data) const {

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -596,8 +596,13 @@ namespace {
     //////////////////////////////////////////////////
 
     std::vector<int> CurrentShipDesignManager::OrderedIDs() const {
-        std::vector<int> retval;
+        // Make sure that saved designs are included.
+        // Only OrderedIDs is part of the Designs base class and
+        // accessible outside this file.
+        GetSavedDesignsManager().CheckPendingDesigns();
+
         // Remove all obsolete ids from the list
+        std::vector<int> retval;
         std::copy_if(m_ordered_ids.begin(), m_ordered_ids.end(), std::back_inserter(retval),
                      [this](const int id){
                          const auto it = m_id_to_obsolete_and_loc.find(id);

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -150,7 +150,7 @@ namespace {
      * @param[in] name name entry of the article
      */
     const EncyclopediaArticle& GetPediaArticle(const std::string& name) {
-        const auto& articles = GetEncyclopedia().articles;
+        const auto& articles = GetEncyclopedia().Articles();
         for (const auto& entry : articles) {
             for (const EncyclopediaArticle& article : entry.second) {
                 if (article.name == name) {
@@ -193,7 +193,7 @@ namespace {
                                              str}});
             }
 
-            for (const auto& entry : encyclopedia.articles) {
+            for (const auto& entry : encyclopedia.Articles()) {
                 // Do not add sub-categories
                 const EncyclopediaArticle& article = GetPediaArticle(entry.first);
                 // No article found or specifically a top-level category
@@ -507,8 +507,9 @@ namespace {
         }
 
         // Add any defined entries for this directory
-        auto category_it = encyclopedia.articles.find(dir_name);
-        if (category_it != encyclopedia.articles.end()) {
+        const auto& articles = encyclopedia.Articles();
+        auto category_it = articles.find(dir_name);
+        if (category_it != articles.end()) {
             for (const EncyclopediaArticle& article : category_it->second) {
                 // Prevent duplicate addition of hard-coded directories that also have a content definition
                 if (article.name == dir_name)
@@ -1226,7 +1227,7 @@ namespace {
         }
 
         // search for article in custom pedia entries.
-        for (const auto& entry : GetEncyclopedia().articles) {
+        for (const auto& entry : GetEncyclopedia().Articles()) {
             for (const EncyclopediaArticle& article : entry.second) {
                 if (article.name != item_name)
                     continue;

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -34,7 +34,6 @@
 #include "../util/ScopedTimer.h"
 #include "../client/human/HumanClientApp.h"
 #include "../combat/CombatLogManager.h"
-#include "../parse/Parse.h"
 
 #include <GG/DrawUtil.h>
 #include <GG/GUI.h>

--- a/UI/InGameMenu.cpp
+++ b/UI/InGameMenu.cpp
@@ -185,7 +185,7 @@ void InGameMenu::Load() {
 }
 
 void InGameMenu::Options() {
-    auto options_wnd = GG::Wnd::Create<OptionsWnd>();
+    auto options_wnd = GG::Wnd::Create<OptionsWnd>(true);
     options_wnd->Run();
 }
 

--- a/UI/IntroScreen.cpp
+++ b/UI/IntroScreen.cpp
@@ -325,7 +325,7 @@ void IntroScreen::OnLoadGame() {
 }
 
 void IntroScreen::OnOptions() {
-    auto options_wnd = GG::Wnd::Create<OptionsWnd>();
+    auto options_wnd = GG::Wnd::Create<OptionsWnd>(false);
     options_wnd->Run();
 }
 

--- a/UI/OptionsWnd.h
+++ b/UI/OptionsWnd.h
@@ -17,7 +17,7 @@ class OptionsWnd : public CUIWnd {
 public:
     //! \name Structors
     //!@{
-    OptionsWnd();
+    OptionsWnd(bool is_game_running_);
     void CompleteConstruction() override;
 
     ~OptionsWnd();
@@ -82,17 +82,19 @@ private:
     void                VolumeOption(GG::ListBox* page, int indentation_level, const std::string& toggle_option_name,
                                      const std::string& volume_option_name, const std::string& text, bool toggle_value,
                                      SoundOptionsFeedback &fb);
-    void                FileOptionImpl(GG::ListBox* page, int indentation_level, const std::string& option_name, const std::string& text, const boost::filesystem::path& path, const std::vector<std::pair<std::string, std::string>>& filters, std::function<bool (const std::string&)> string_validator, bool directory, bool relative_path);
+    void                FileOptionImpl(GG::ListBox* page, int indentation_level, const std::string& option_name, const std::string& text, const boost::filesystem::path& path, const std::vector<std::pair<std::string, std::string>>& filters, std::function<bool (const std::string&)> string_validator, bool directory, bool relative_path, bool disabled);
     void                FileOption(GG::ListBox* page, int indentation_level, const std::string& option_name, const std::string& text, const boost::filesystem::path& path, std::function<bool (const std::string&)> string_validator = nullptr);
     void                FileOption(GG::ListBox* page, int indentation_level, const std::string& option_name, const std::string& text, const boost::filesystem::path& path, const std::pair<std::string, std::string>& filter, std::function<bool (const std::string&)> string_validator = nullptr);
     void                FileOption(GG::ListBox* page, int indentation_level, const std::string& option_name, const std::string& text, const boost::filesystem::path& path, const std::vector<std::pair<std::string, std::string>>& filters, std::function<bool (const std::string&)> string_validator = nullptr);
-    void                DirectoryOption(GG::ListBox* page, int indentation_level, const std::string& option_name, const std::string& text, const boost::filesystem::path& path);
+    void                DirectoryOption(GG::ListBox* page, int indentation_level, const std::string& option_name, const std::string& text, const boost::filesystem::path& path, bool disabled = false);
     void                SoundFileOption(GG::ListBox* page, int indentation_level, const std::string& option_name, const std::string& text);
     void                ColorOption(GG::ListBox* page, int indentation_level, const std::string& option_name, const std::string& text);
     void                FontOption(GG::ListBox* page, int indentation_level, const std::string& option_name, const std::string& text);
     void                ResolutionOption(GG::ListBox* page, int indentation_level);
 
     void                DoneClicked();
+
+    bool is_game_running;
 
     std::shared_ptr<GG::TabWnd> m_tabs;
     std::shared_ptr<GG::Button> m_done_button;

--- a/Xcode/FreeOrion.xcodeproj/project.pbxproj
+++ b/Xcode/FreeOrion.xcodeproj/project.pbxproj
@@ -816,6 +816,7 @@
 		471D5D2F0A98A3F900DA9C21 /* OrderSet.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = OrderSet.h; sourceTree = "<group>"; };
 		471D5D300A98A3F900DA9C21 /* Process.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = Process.cpp; sourceTree = "<group>"; };
 		471D5D310A98A3F900DA9C21 /* Process.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = Process.h; sourceTree = "<group>"; };
+		471D5D310B98A3F900DA9C21 /* Pending.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = Pending.h; sourceTree = "<group>"; };
 		471D5D320A98A3F900DA9C21 /* Random.cpp */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.cpp.cpp; path = Random.cpp; sourceTree = "<group>"; };
 		471D5D330A98A3F900DA9C21 /* Random.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = Random.h; sourceTree = "<group>"; };
 		471D5D350A98A3F900DA9C21 /* Serialize.h */ = {isa = PBXFileReference; fileEncoding = 30; lastKnownFileType = sourcecode.c.h; path = Serialize.h; sourceTree = "<group>"; };
@@ -1871,6 +1872,7 @@
 				471D5D2F0A98A3F900DA9C21 /* OrderSet.h */,
 				471D5D300A98A3F900DA9C21 /* Process.cpp */,
 				471D5D310A98A3F900DA9C21 /* Process.h */,
+				471D5D310B98A3F900DA9C21 /* Pending.h */,
 				471D5D320A98A3F900DA9C21 /* Random.cpp */,
 				471D5D330A98A3F900DA9C21 /* Random.h */,
 				82E68F61190ECB8400BB1AD9 /* SaveGamePreviewUtils.cpp */,

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -142,6 +142,9 @@ void AIClientApp::Run() {
         // join game
         Networking().SendMessage(JoinGameMessage(PlayerName(), Networking::CLIENT_TYPE_AI_PLAYER));
 
+        // Start parsing content
+        ParseUniverseObjectTypes();
+
         // respond to messages until disconnected
         while (1) {
             try {

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -143,7 +143,7 @@ void AIClientApp::Run() {
         Networking().SendMessage(JoinGameMessage(PlayerName(), Networking::CLIENT_TYPE_AI_PLAYER));
 
         // Start parsing content
-        ParseUniverseObjectTypes();
+        StartBackgroundParsing();
 
         // respond to messages until disconnected
         while (1) {

--- a/client/AI/camain.cpp
+++ b/client/AI/camain.cpp
@@ -1,6 +1,5 @@
 #include "AIClientApp.h"
 
-#include "../../parse/Parse.h"
 #include "../../util/OptionsDB.h"
 #include "../../util/Directories.h"
 #include "../../util/Logger.h"

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -350,6 +350,9 @@ HumanClientApp::HumanClientApp(int width, int height, bool calculate_fps, const 
     RegisterLinkTags();
 
     m_fsm->initiate();
+
+    // Start parsing content
+    ParseUniverseObjectTypes();
 }
 
 void HumanClientApp::ConnectKeyboardAcceleratorSignals() {

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -352,7 +352,7 @@ HumanClientApp::HumanClientApp(int width, int height, bool calculate_fps, const 
     m_fsm->initiate();
 
     // Start parsing content
-    ParseUniverseObjectTypes();
+    StartBackgroundParsing();
     GetOptionsDB().OptionChangedSignal("resource-dir").connect(
         boost::bind(&HumanClientApp::HandleResoureDirChange, this));
 }
@@ -1437,7 +1437,7 @@ void HumanClientApp::UpdateFPSLimit() {
 void HumanClientApp::HandleResoureDirChange() {
     if (!m_game_started) {
         DebugLogger() << "Resource directory changed.  Reparsing universe ...";
-        ParseUniverseObjectTypes();
+        StartBackgroundParsing();
     } else {
         WarnLogger() << "Resource directory changes will take effect on application restart.";
     }

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -318,7 +318,7 @@ HumanClientApp::HumanClientApp(int width, int height, bool calculate_fps, const 
 
     this->SetMouseLRSwapped(GetOptionsDB().Get<bool>("UI.swap-mouse-lr"));
 
-    auto named_key_maps = parse::keymaps();
+    auto named_key_maps = parse::keymaps(GetResourceDir() / "scripting/keymaps.inf");
     TraceLogger() << "Keymaps:";
     for (auto& km : named_key_maps) {
         TraceLogger() << "Keymap name = \"" << km.first << "\"";

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -353,6 +353,8 @@ HumanClientApp::HumanClientApp(int width, int height, bool calculate_fps, const 
 
     // Start parsing content
     ParseUniverseObjectTypes();
+    GetOptionsDB().OptionChangedSignal("resource-dir").connect(
+        boost::bind(&HumanClientApp::HandleResoureDirChange, this));
 }
 
 void HumanClientApp::ConnectKeyboardAcceleratorSignals() {
@@ -1429,6 +1431,15 @@ void HumanClientApp::UpdateFPSLimit() {
     } else {
         SetMaxFPS(0.0); // disable fps limit
         DebugLogger() << "Disabled FPS limit";
+    }
+}
+
+void HumanClientApp::HandleResoureDirChange() {
+    if (!m_game_started) {
+        DebugLogger() << "Resource directory changed.  Reparsing universe ...";
+        ParseUniverseObjectTypes();
+    } else {
+        WarnLogger() << "Resource directory changes will take effect on application restart.";
     }
 }
 

--- a/client/human/HumanClientApp.h
+++ b/client/human/HumanClientApp.h
@@ -152,6 +152,10 @@ private:
 
     void            UpdateFPSLimit();                   ///< polls options database to find if FPS should be limited, and if so, to what rate
 
+    /** If a game is not running re-parse the universe otherwise inform the
+        player changes will effect new games. */
+    void            HandleResoureDirChange();
+
     void            DisconnectedFromServer();           ///< called by ClientNetworking when the TCP connection to the server is lost
 
     /** Either reset to IntroMenu (\p reset is true), or exit the

--- a/client/human/chmain.cpp
+++ b/client/human/chmain.cpp
@@ -1,7 +1,6 @@
 
 
 #include "HumanClientApp.h"
-#include "../../parse/Parse.h"
 #include "../../util/OptionsDB.h"
 #include "../../util/Directories.h"
 #include "../../util/Logger.h"

--- a/msvc2015/Common/Common.vcxproj
+++ b/msvc2015/Common/Common.vcxproj
@@ -202,6 +202,7 @@
     <ClInclude Include="..\..\util\Order.h" />
     <ClInclude Include="..\..\util\OrderSet.h" />
     <ClInclude Include="..\..\util\Process.h" />
+    <ClInclude Include="..\..\util\Pending.h" />
     <ClInclude Include="..\..\util\Random.h" />
     <ClInclude Include="..\..\util\ScopedTimer.h" />
     <ClInclude Include="..\..\util\Serialize.h" />

--- a/msvc2015/Common/Common.vcxproj.filters
+++ b/msvc2015/Common/Common.vcxproj.filters
@@ -178,6 +178,9 @@
     <ClInclude Include="..\..\util\Process.h">
       <Filter>Header Files\util</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\util\Pending.h">
+      <Filter>Header Files\util</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\util\Random.h">
       <Filter>Header Files\util</Filter>
     </ClInclude>

--- a/parse/BuildingsParser.cpp
+++ b/parse/BuildingsParser.cpp
@@ -120,10 +120,10 @@ namespace {
 }
 
 namespace parse {
-    start_rule_payload buildings() {
+    start_rule_payload buildings(const boost::filesystem::path& path) {
         const lexer lexer;
         start_rule_payload building_types;
-        for (const boost::filesystem::path& file : ListScripts("scripting/buildings")) {
+        for (const boost::filesystem::path& file : ListScripts(path)) {
             /*auto success =*/ detail::parse_file<grammar, start_rule_payload>(lexer, file, building_types);
         }
 

--- a/parse/EmpireStatsParser.cpp
+++ b/parse/EmpireStatsParser.cpp
@@ -80,11 +80,11 @@ namespace {
 }
 
 namespace parse {
-    start_rule_payload statistics() {
+    start_rule_payload statistics(const boost::filesystem::path& path) {
         const lexer lexer;
         start_rule_payload stats_;
 
-        for (const boost::filesystem::path& file : ListScripts("scripting/empire_statistics")) {
+        for (const boost::filesystem::path& file : ListScripts(path)) {
             /*auto success =*/ detail::parse_file<grammar, start_rule_payload>(lexer, file, stats_);
         }
 

--- a/parse/EncyclopediaParser.cpp
+++ b/parse/EncyclopediaParser.cpp
@@ -94,9 +94,9 @@ namespace {
 }
 
 namespace parse {
-    ArticleMap encyclopedia_articles() {
+    ArticleMap encyclopedia_articles(const boost::filesystem::path& path) {
         const lexer lexer;
-        std::vector<boost::filesystem::path> file_list = ListScripts("scripting/encyclopedia");
+        std::vector<boost::filesystem::path> file_list = ListScripts(path);
 
         ArticleMap articles;
         for (const boost::filesystem::path& file : file_list) {

--- a/parse/EncyclopediaParser.cpp
+++ b/parse/EncyclopediaParser.cpp
@@ -17,7 +17,7 @@ namespace std {
 #endif
 
 namespace {
-    using ArticleMap = std::map<std::string, std::vector<EncyclopediaArticle>>;
+    using ArticleMap = Encyclopedia::ArticleMap;
 
     struct insert_ {
         typedef void result_type;

--- a/parse/FieldsParser.cpp
+++ b/parse/FieldsParser.cpp
@@ -117,11 +117,11 @@ namespace {
 }
 
 namespace parse {
-    start_rule_payload fields() {
+    start_rule_payload fields(const boost::filesystem::path& path) {
         const lexer lexer;
         start_rule_payload field_types;
 
-        for (const boost::filesystem::path& file : ListScripts("scripting/fields")) {
+        for (const boost::filesystem::path& file : ListScripts(path)) {
             /*auto success =*/ detail::parse_file<grammar, start_rule_payload>(lexer, file, field_types);
         }
 

--- a/parse/FleetPlansParser.cpp
+++ b/parse/FleetPlansParser.cpp
@@ -83,10 +83,9 @@ namespace {
 }
 
 namespace parse {
-    start_rule_payload fleet_plans() {
+    start_rule_payload fleet_plans(const boost::filesystem::path& path) {
         const lexer lexer;
         start_rule_payload fleet_plans_;
-        const boost::filesystem::path& path = GetResourceDir() / "scripting/starting_unlocks/fleets.inf";
         /*auto success =*/ detail::parse_file<grammar, start_rule_payload>(lexer, path, fleet_plans_);
         return fleet_plans_;
     }

--- a/parse/GameRulesParser.cpp
+++ b/parse/GameRulesParser.cpp
@@ -232,10 +232,9 @@ namespace {
 }
 
 namespace parse {
-    GameRules game_rules() {
+    GameRules game_rules(const boost::filesystem::path& path) {
         GameRules game_rules;
         const lexer lexer;
-        boost::filesystem::path path = GetResourceDir() / "scripting/game_rules.focs.txt";
         /*auto success =*/ detail::parse_file<grammar, GameRules>(lexer, path, game_rules);
         return game_rules;
     }

--- a/parse/GameRulesParser.cpp
+++ b/parse/GameRulesParser.cpp
@@ -232,9 +232,11 @@ namespace {
 }
 
 namespace parse {
-    bool game_rules(GameRules& game_rules) {
+    GameRules game_rules() {
+        GameRules game_rules;
         const lexer lexer;
         boost::filesystem::path path = GetResourceDir() / "scripting/game_rules.focs.txt";
-        return detail::parse_file<grammar, GameRules>(lexer, path, game_rules);
+        /*auto success =*/ detail::parse_file<grammar, GameRules>(lexer, path, game_rules);
+        return game_rules;
     }
 }

--- a/parse/ItemsParser.cpp
+++ b/parse/ItemsParser.cpp
@@ -57,18 +57,16 @@ namespace {
 }
 
 namespace parse {
-    start_rule_payload items() {
+    start_rule_payload items(const boost::filesystem::path& path) {
         const lexer lexer;
         start_rule_payload items_;
-        const boost::filesystem::path& path = GetResourceDir() / "scripting/starting_unlocks/items.inf";
         /*auto success =*/ detail::parse_file<grammar, start_rule_payload>(lexer, path, items_);
         return items_;
     }
 
-    start_rule_payload starting_buildings() {
+    start_rule_payload starting_buildings(const boost::filesystem::path& path) {
         const lexer lexer;
         start_rule_payload starting_buildings_;
-        const boost::filesystem::path& path = GetResourceDir() / "scripting/starting_unlocks/buildings.inf";
         /*auto success =*/ detail::parse_file<grammar, start_rule_payload >(lexer, path, starting_buildings_);
         return starting_buildings_;
     }

--- a/parse/KeymapParser.cpp
+++ b/parse/KeymapParser.cpp
@@ -113,10 +113,9 @@ namespace {
 }
 
 namespace parse {
-    NamedKeymaps keymaps() {
+    NamedKeymaps keymaps(const boost::filesystem::path& path) {
         const lexer lexer;
         NamedKeymaps nkm;
-        boost::filesystem::path path = GetResourceDir() / "scripting/keymaps.inf";
         /*auto success =*/ detail::parse_file<grammar, NamedKeymaps>(lexer, path, nkm);
         return nkm;
     }

--- a/parse/MonsterFleetPlansParser.cpp
+++ b/parse/MonsterFleetPlansParser.cpp
@@ -138,10 +138,9 @@ namespace {
 }
 
 namespace parse {
-    start_rule_payload monster_fleet_plans() {
+    start_rule_payload monster_fleet_plans(const boost::filesystem::path& path) {
         const lexer lexer;
         start_rule_payload monster_fleet_plans_;
-        boost::filesystem::path path = GetResourceDir() / "scripting/monster_fleets.inf";
         /*auto success =*/ detail::parse_file<grammar, start_rule_payload>(lexer, path, monster_fleet_plans_);
         return monster_fleet_plans_;
     }

--- a/parse/Parse.h
+++ b/parse/Parse.h
@@ -18,7 +18,7 @@ class FleetPlan;
 class HullType;
 class MonsterFleetPlan;
 class PartType;
-class ShipDesign;
+struct ParsedShipDesign;
 class Special;
 class Species;
 struct EncyclopediaArticle;
@@ -47,7 +47,7 @@ namespace parse {
         design_and_path. If a file exists called ShipDesignOrdering.focs.txt, parse it and
         store the order in \p ordering. */
     using ship_designs_type = std::pair<
-        std::vector<std::pair<std::unique_ptr<ShipDesign>, boost::filesystem::path>>, // designs_and_paths,
+        std::vector<std::pair<std::unique_ptr<ParsedShipDesign>, boost::filesystem::path>>, // designs_and_paths,
         std::vector<boost::uuids::uuid> // ordering
         >;
     FO_PARSE_API ship_designs_type ship_designs(const boost::filesystem::path& path);

--- a/parse/Parse.h
+++ b/parse/Parse.h
@@ -7,10 +7,14 @@
 #   define FO_PARSE_API
 #endif
 
-#include "../universe/Tech.h"
+#include "../universe/ValueRefFwd.h"
 
 #include <boost/filesystem/path.hpp>
 #include <boost/uuid/uuid.hpp>
+
+#include <map>
+#include <set>
+#include <vector>
 
 class BuildingType;
 class FieldType;
@@ -23,6 +27,7 @@ class Special;
 class Species;
 struct EncyclopediaArticle;
 class GameRules;
+struct ItemSpec;
 
 namespace parse {
     FO_PARSE_API std::map<std::string, std::unique_ptr<BuildingType>> buildings(const boost::filesystem::path& path);
@@ -33,7 +38,10 @@ namespace parse {
 
     FO_PARSE_API std::map<std::string, std::unique_ptr<Species>> species(const boost::filesystem::path& path);
 
-    FO_PARSE_API TechManager::TechParseTuple techs(const boost::filesystem::path& path);
+    /* T in techs<T> can only be TechManager::TechParseTuple.  This decouples
+       Parse.h from Tech.h so that all parsers are not recompiled when Tech.h changes.*/
+    template <typename T>
+    FO_PARSE_API T techs(const boost::filesystem::path& path);
 
     FO_PARSE_API std::vector<ItemSpec> items(const boost::filesystem::path& path);
 

--- a/parse/Parse.h
+++ b/parse/Parse.h
@@ -62,7 +62,7 @@ namespace parse {
 
     FO_PARSE_API std::map<std::string, std::map<int, int>> keymaps();
 
-    FO_PARSE_API bool game_rules(GameRules& game_rules);
+    FO_PARSE_API GameRules game_rules();
 
     FO_PARSE_API bool read_file(const boost::filesystem::path& path, std::string& file_contents);
 

--- a/parse/Parse.h
+++ b/parse/Parse.h
@@ -33,11 +33,7 @@ namespace parse {
 
     FO_PARSE_API std::map<std::string, std::unique_ptr<Species>> species();
 
-    FO_PARSE_API std::tuple<
-        TechManager::TechContainer, // techs_
-        std::map<std::string, std::unique_ptr<TechCategory>>, // tech_categories,
-        std::set<std::string> // categories_seen
-        > techs();
+    FO_PARSE_API TechManager::TechParseTuple techs();
 
     FO_PARSE_API std::vector<ItemSpec> items();
 

--- a/parse/Parse.h
+++ b/parse/Parse.h
@@ -25,23 +25,23 @@ struct EncyclopediaArticle;
 class GameRules;
 
 namespace parse {
-    FO_PARSE_API std::map<std::string, std::unique_ptr<BuildingType>> buildings();
+    FO_PARSE_API std::map<std::string, std::unique_ptr<BuildingType>> buildings(const boost::filesystem::path& path);
 
-    FO_PARSE_API std::map<std::string, std::unique_ptr<FieldType>> fields();
+    FO_PARSE_API std::map<std::string, std::unique_ptr<FieldType>> fields(const boost::filesystem::path& path);
 
-    FO_PARSE_API std::map<std::string, std::unique_ptr<Special>> specials();
+    FO_PARSE_API std::map<std::string, std::unique_ptr<Special>> specials(const boost::filesystem::path& path);
 
-    FO_PARSE_API std::map<std::string, std::unique_ptr<Species>> species();
+    FO_PARSE_API std::map<std::string, std::unique_ptr<Species>> species(const boost::filesystem::path& path);
 
-    FO_PARSE_API TechManager::TechParseTuple techs();
+    FO_PARSE_API TechManager::TechParseTuple techs(const boost::filesystem::path& path);
 
-    FO_PARSE_API std::vector<ItemSpec> items();
+    FO_PARSE_API std::vector<ItemSpec> items(const boost::filesystem::path& path);
 
-    FO_PARSE_API std::vector<ItemSpec> starting_buildings();
+    FO_PARSE_API std::vector<ItemSpec> starting_buildings(const boost::filesystem::path& path);
 
-    FO_PARSE_API std::map<std::string, std::unique_ptr<PartType>> ship_parts();
+    FO_PARSE_API std::map<std::string, std::unique_ptr<PartType>> ship_parts(const boost::filesystem::path& path);
 
-    FO_PARSE_API std::map<std::string, std::unique_ptr<HullType>> ship_hulls();
+    FO_PARSE_API std::map<std::string, std::unique_ptr<HullType>> ship_hulls(const boost::filesystem::path& path);
 
     /** Parse all ship designs in directory \p path, store them with their filename in \p
         design_and_path. If a file exists called ShipDesignOrdering.focs.txt, parse it and
@@ -52,17 +52,17 @@ namespace parse {
         >;
     FO_PARSE_API ship_designs_type ship_designs(const boost::filesystem::path& path);
 
-    FO_PARSE_API std::vector<FleetPlan*> fleet_plans();
+    FO_PARSE_API std::vector<FleetPlan*> fleet_plans(const boost::filesystem::path& path);
 
-    FO_PARSE_API std::vector<MonsterFleetPlan*> monster_fleet_plans();
+    FO_PARSE_API std::vector<MonsterFleetPlan*> monster_fleet_plans(const boost::filesystem::path& path);
 
-    FO_PARSE_API std::map<std::string, ValueRef::ValueRefBase<double>*> statistics();
+    FO_PARSE_API std::map<std::string, ValueRef::ValueRefBase<double>*> statistics(const boost::filesystem::path& path);
 
-    FO_PARSE_API std::map<std::string, std::vector<EncyclopediaArticle>> encyclopedia_articles();
+    FO_PARSE_API std::map<std::string, std::vector<EncyclopediaArticle>> encyclopedia_articles(const boost::filesystem::path& path);
 
-    FO_PARSE_API std::map<std::string, std::map<int, int>> keymaps();
+    FO_PARSE_API std::map<std::string, std::map<int, int>> keymaps(const boost::filesystem::path& path);
 
-    FO_PARSE_API GameRules game_rules();
+    FO_PARSE_API GameRules game_rules(const boost::filesystem::path& path);
 
     FO_PARSE_API bool read_file(const boost::filesystem::path& path, std::string& file_contents);
 

--- a/parse/ShipDesignsParser.cpp
+++ b/parse/ShipDesignsParser.cpp
@@ -16,22 +16,22 @@ FO_COMMON_API extern const int ALL_EMPIRES;
 
 #if DEBUG_PARSERS
 namespace std {
-    inline ostream& operator<<(ostream& os, const std::map<std::string, std::unique_ptr<ShipDesign>>&) { return os; }
-    inline ostream& operator<<(ostream& os, const std::pair<const std::string, std::unique_ptr<ShipDesign>>&) { return os; }
+    inline ostream& operator<<(ostream& os, const std::map<std::string, std::unique_ptr<ParsedShipDesign>>&) { return os; }
+    inline ostream& operator<<(ostream& os, const std::pair<const std::string, std::unique_ptr<ParsedShipDesign>>&) { return os; }
     inline ostream& operator<<(ostream& os, const std::vector<std::string>&) { return os; }
 }
 #endif
 
 namespace {
-    void insert_ship_design(boost::optional<std::unique_ptr<ShipDesign>>& maybe_design,
+    void insert_ship_design(boost::optional<std::unique_ptr<ParsedShipDesign>>& maybe_design,
                             const std::string& name, const std::string& description,
                             const std::string& hull, const std::vector<std::string>& parts,
                             const std::string& icon, const std::string& model,
                             bool name_desc_in_stringtable, const boost::uuids::uuid& uuid)
     {
         // TODO use make_unique when converting to C++14
-        auto design = std::unique_ptr<ShipDesign>(
-            new ShipDesign(name, description, 0, ALL_EMPIRES, hull, parts, icon, model,
+        auto design = std::unique_ptr<ParsedShipDesign>(
+            new ParsedShipDesign(name, description, 0, ALL_EMPIRES, hull, parts, icon, model,
                            name_desc_in_stringtable, false, uuid));
 
         maybe_design = std::move(design);
@@ -65,7 +65,7 @@ namespace {
     // A lazy UUID parser
     BOOST_PHOENIX_ADAPT_FUNCTION(boost::uuids::uuid, parse_uuid_, parse_uuid, 1)
 
-    using start_rule_signature = void (boost::optional<std::unique_ptr<ShipDesign>>&);
+    using start_rule_signature = void (boost::optional<std::unique_ptr<ParsedShipDesign>>&);
 
     struct grammar : public parse::detail::grammar<start_rule_signature> {
         grammar(const parse::lexer& tok,
@@ -133,7 +133,7 @@ namespace {
                 ;
 
             design_prefix.name("Name, UUID, Description, Lookup Flag, Hull");
-            design.name("ShipDesign");
+            design.name("ParsedShipDesign");
 
 #if DEBUG_PARSERS
             debug(design_prefix);
@@ -147,7 +147,7 @@ namespace {
             void (std::string&, std::string&, std::string&, bool&, boost::uuids::uuid&)>;
 
         using design_rule = parse::detail::rule<
-            void (boost::optional<std::unique_ptr<ShipDesign>>&),
+            void (boost::optional<std::unique_ptr<ParsedShipDesign>>&),
             boost::spirit::qi::locals<
                 std::string,
                 std::string,
@@ -196,7 +196,7 @@ namespace {
                 =   +design_manifest(_r1)
                 ;
 
-            design_manifest.name("ShipDesignOrdering");
+            design_manifest.name("ParsedShipDesignOrdering");
 
 #if DEBUG_PARSERS
             debug(design_manifest);
@@ -217,17 +217,21 @@ namespace {
 
 namespace parse {
     std::pair<
-        std::vector<std::pair<std::unique_ptr<ShipDesign>, boost::filesystem::path>>, // designs_and_paths
+        std::vector<std::pair<std::unique_ptr<ParsedShipDesign>, boost::filesystem::path>>, // designs_and_paths
         std::vector<boost::uuids::uuid> //ordering
         >
     ship_designs(const boost::filesystem::path& path) {
+        /* Note: Parsing to ParsedShipDesign instead of ShipDesign means that
+           checks of parts, hulls etc are done elsewhere.  A successful parse
+           depends only on the parsed string and not other potentially
+           concurrent parses of hulls and parts.*/
         const lexer lexer;
-        std::vector<std::pair<std::unique_ptr<ShipDesign>, boost::filesystem::path>> designs_and_paths;
+        std::vector<std::pair<std::unique_ptr<ParsedShipDesign>, boost::filesystem::path>> designs_and_paths;
         std::vector<boost::uuids::uuid> ordering;
 
         boost::filesystem::path manifest_file;
 
-        // Allow files with any suffix in order to convert legacy ShipDesign files.
+        // Allow files with any suffix in order to convert legacy ParsedShipDesign files.
         bool permissive_mode = true;
         const auto& scripts = ListScripts(path, permissive_mode);
 
@@ -238,8 +242,8 @@ namespace parse {
             }
 
             try {
-                boost::optional<std::unique_ptr<ShipDesign>> maybe_design;
-                auto partial_result = detail::parse_file<grammar, boost::optional<std::unique_ptr<ShipDesign>>>(
+                boost::optional<std::unique_ptr<ParsedShipDesign>> maybe_design;
+                auto partial_result = detail::parse_file<grammar, boost::optional<std::unique_ptr<ParsedShipDesign>>>(
                     lexer, file, maybe_design);
 
                 if (!partial_result || !maybe_design)

--- a/parse/ShipHullsParser.cpp
+++ b/parse/ShipHullsParser.cpp
@@ -193,11 +193,11 @@ namespace {
 }
 
 namespace parse {
-    start_rule_payload ship_hulls() {
+    start_rule_payload ship_hulls(const boost::filesystem::path& path) {
         const lexer lexer;
         start_rule_payload hulls;
 
-        for (const boost::filesystem::path& file : ListScripts("scripting/ship_hulls")) {
+        for (const boost::filesystem::path& file : ListScripts(path)) {
             /*auto success =*/ detail::parse_file<grammar, start_rule_payload>(lexer, file, hulls);
         }
 

--- a/parse/ShipPartsParser.cpp
+++ b/parse/ShipPartsParser.cpp
@@ -167,11 +167,11 @@ namespace {
 }
 
 namespace parse {
-    start_rule_payload ship_parts() {
+    start_rule_payload ship_parts(const boost::filesystem::path& path) {
         const lexer lexer;
         start_rule_payload parts;
 
-        for (const auto& file : ListScripts("scripting/ship_parts")) {
+        for (const auto& file : ListScripts(path)) {
             /*auto success =*/ detail::parse_file<grammar, start_rule_payload>(lexer, file, parts);
         }
 

--- a/parse/SpecialsParser.cpp
+++ b/parse/SpecialsParser.cpp
@@ -182,11 +182,11 @@ namespace {
 }
 
 namespace parse {
-    start_rule_payload specials() {
+    start_rule_payload specials(const boost::filesystem::path& path) {
         const lexer lexer;
         start_rule_payload specials_;
 
-        for (const boost::filesystem::path& file : ListScripts("scripting/specials")) {
+        for (const boost::filesystem::path& file : ListScripts(path)) {
             /*auto success =*/ detail::parse_file<grammar, start_rule_payload>(lexer, file, specials_);
         }
 

--- a/parse/SpeciesParser.cpp
+++ b/parse/SpeciesParser.cpp
@@ -269,11 +269,11 @@ namespace {
 }
 
 namespace parse {
-    start_rule_payload species() {
+    start_rule_payload species(const boost::filesystem::path& path) {
         const lexer lexer;
         start_rule_payload species_;
 
-        for (const boost::filesystem::path& file : ListScripts("scripting/species")) {
+        for (const boost::filesystem::path& file : ListScripts(path)) {
             /*auto success =*/ detail::parse_file<grammar, start_rule_payload>(lexer, file, species_);
         }
 

--- a/parse/TechsParser.cpp
+++ b/parse/TechsParser.cpp
@@ -260,11 +260,7 @@ namespace {
 }
 
 namespace parse {
-    std::tuple<
-        TechManager::TechContainer, // techs_
-        std::map<std::string, std::unique_ptr<TechCategory>>, // tech_categories,
-        std::set<std::string>> // categories_seen
-    techs() {
+    TechManager::TechParseTuple techs() {
         const lexer lexer;
         TechManager::TechContainer techs_;
         std::map<std::string, std::unique_ptr<TechCategory>> categories;

--- a/parse/TechsParser.cpp
+++ b/parse/TechsParser.cpp
@@ -6,6 +6,7 @@
 #include "ValueRefParser.h"
 
 #include "../universe/Species.h"
+#include "../universe/Tech.h"
 #include "../util/Directories.h"
 
 #include <boost/spirit/include/phoenix.hpp>
@@ -260,7 +261,8 @@ namespace {
 }
 
 namespace parse {
-    TechManager::TechParseTuple techs(const boost::filesystem::path& path) {
+    template <typename T>
+    T techs(const boost::filesystem::path& path) {
         const lexer lexer;
         TechManager::TechContainer techs_;
         std::map<std::string, std::unique_ptr<TechCategory>> categories;
@@ -278,3 +280,8 @@ namespace parse {
         return std::make_tuple(std::move(techs_), std::move(categories), categories_seen);
     }
 }
+
+// explicitly instantiate techs.
+// This allows Tech.h to only be included in this .cpp file and not Parse.h
+// which recompiles all parsers if Tech.h changes.
+template FO_PARSE_API TechManager::TechParseTuple parse::techs<TechManager::TechParseTuple>(const boost::filesystem::path& path);

--- a/parse/TechsParser.cpp
+++ b/parse/TechsParser.cpp
@@ -260,7 +260,7 @@ namespace {
 }
 
 namespace parse {
-    TechManager::TechParseTuple techs() {
+    TechManager::TechParseTuple techs(const boost::filesystem::path& path) {
         const lexer lexer;
         TechManager::TechContainer techs_;
         std::map<std::string, std::unique_ptr<TechCategory>> categories;
@@ -269,9 +269,9 @@ namespace parse {
         g_categories_seen = &categories_seen;
         g_categories = &categories;
 
-        /*auto success =*/ detail::parse_file<grammar, TechManager::TechContainer>(lexer, GetResourceDir() / "scripting/techs/Categories.inf", techs_);
+        /*auto success =*/ detail::parse_file<grammar, TechManager::TechContainer>(lexer, path / "Categories.inf", techs_);
 
-        for (const boost::filesystem::path& file : ListScripts("scripting/techs")) {
+        for (const boost::filesystem::path& file : ListScripts(path)) {
             /*auto success =*/ detail::parse_file<grammar, TechManager::TechContainer>(lexer, file, techs_);
         }
 

--- a/python/server/ServerFramework.cpp
+++ b/python/server/ServerFramework.cpp
@@ -75,9 +75,6 @@ bool PythonServer::InitModules() {
     }
     AddToSysPath(GetPythonUniverseGeneratorDir());
 
-    // import universe generator script file
-    m_python_module_universe_generator = import("universe_generator");
-
     // Confirm existence of the directory containing the turn event Python
     // scripts and add it to Pythons sys.path to make sure Python will find
     // our scripts
@@ -141,6 +138,18 @@ bool PythonServer::IsSuccessAuth(const std::string& player_name, const std::stri
 }
 
 bool PythonServer::CreateUniverse(std::map<int, PlayerSetupData>& player_setup_data) {
+    // Confirm existence of the directory containing the universe generation
+    // Python scripts and add it to Pythons sys.path to make sure Python will
+    // find our scripts
+    if (!fs::exists(GetPythonUniverseGeneratorDir())) {
+        ErrorLogger() << "Can't find folder containing universe generation scripts";
+        return false;
+    }
+    AddToSysPath(GetPythonUniverseGeneratorDir());
+
+    // import universe generator script file
+    m_python_module_universe_generator = import("universe_generator");
+
     dict py_player_setup_data;
 
     // the universe generator module should contain an "error_report" function,

--- a/python/server/ServerWrapper.cpp
+++ b/python/server/ServerWrapper.cpp
@@ -349,7 +349,7 @@ namespace {
     // Wrapper for preunlocked items
     list LoadItemSpecList() {
         list py_items;
-        auto items = parse::items();
+        auto& items = GetUniverse().InitiallyUnlockedItems();
         for (const auto& item : items) {
             py_items.append(object(item));
         }
@@ -359,7 +359,7 @@ namespace {
     // Wrapper for starting buildings
     list LoadStartingBuildings() {
         list py_items;
-        auto buildings = parse::starting_buildings();
+        auto& buildings = GetUniverse().InitiallyUnlockedBuildings();
         for (auto building : buildings) {
             if (GetBuildingType(building.name))
                 py_items.append(object(building));
@@ -436,8 +436,9 @@ namespace {
     class FleetPlanWrapper {
     public:
         // name ctors
-        FleetPlanWrapper(FleetPlan* fleet_plan)
-        { m_fleet_plan = fleet_plan; }
+        FleetPlanWrapper(FleetPlan* fleet_plan) :
+            m_fleet_plan(std::make_shared<FleetPlan>(*fleet_plan))
+        {}
 
         FleetPlanWrapper(const std::string& fleet_name, const list& py_designs)
         {
@@ -445,11 +446,8 @@ namespace {
             for (int i = 0; i < len(py_designs); i++) {
                 designs.push_back(extract<std::string>(py_designs[i]));
             }
-            m_fleet_plan = new FleetPlan(fleet_name, designs, false);
+            m_fleet_plan = std::make_shared<FleetPlan>(fleet_name, designs, false);
         }
-
-        virtual ~FleetPlanWrapper()
-        { delete m_fleet_plan; }
 
         // name accessors
         object Name()
@@ -467,12 +465,13 @@ namespace {
         { return *m_fleet_plan; }
 
     private:
-        FleetPlan* m_fleet_plan;
+        // Use shared_ptr insead of unique_ptr because boost::python requires a deleter
+        std::shared_ptr<FleetPlan> m_fleet_plan;
     };
 
     list LoadFleetPlanList() {
         list py_fleet_plans;
-        auto fleet_plans = parse::fleet_plans();
+        auto& fleet_plans = GetUniverse().InitiallyUnlockedFleetPlans();
         for (FleetPlan* fleet_plan : fleet_plans) {
             py_fleet_plans.append(new FleetPlanWrapper(fleet_plan));
         }
@@ -483,9 +482,9 @@ namespace {
     class MonsterFleetPlanWrapper {
     public:
         // name ctors
-        MonsterFleetPlanWrapper(MonsterFleetPlan* monster_fleet_plan) {
-            m_monster_fleet_plan = monster_fleet_plan;
-        }
+        MonsterFleetPlanWrapper(MonsterFleetPlan* monster_fleet_plan) :
+            m_monster_fleet_plan(std::make_shared<MonsterFleetPlan>(*monster_fleet_plan))
+        {}
 
         MonsterFleetPlanWrapper(const std::string& fleet_name, const list& py_designs,
                                 double spawn_rate, int spawn_limit)
@@ -495,12 +494,9 @@ namespace {
                 designs.push_back(extract<std::string>(py_designs[i]));
             }
             m_monster_fleet_plan =
-            new MonsterFleetPlan(fleet_name, designs, spawn_rate,
-                                 spawn_limit, 0, false);
+                std::make_shared<MonsterFleetPlan>(fleet_name, designs, spawn_rate,
+                                                   spawn_limit, nullptr, false);
         }
-
-        virtual ~MonsterFleetPlanWrapper()
-        { delete m_monster_fleet_plan; }
 
         // name accessors
         object Name()
@@ -528,12 +524,13 @@ namespace {
         { return *m_monster_fleet_plan; }
 
     private:
-        MonsterFleetPlan* m_monster_fleet_plan;
+        // Use shared_ptr insead of unique_ptr because boost::python requires a deleter
+        std::shared_ptr<MonsterFleetPlan> m_monster_fleet_plan;
     };
 
     list LoadMonsterFleetPlanList() {
         list py_monster_fleet_plans;
-        auto monster_fleet_plans = parse::monster_fleet_plans();
+        auto& monster_fleet_plans = GetUniverse().MonsterFleetPlans();
         for (auto* fleet_plan : monster_fleet_plans) {
             py_monster_fleet_plans.append(new MonsterFleetPlanWrapper(fleet_plan));
         }

--- a/python/server/ServerWrapper.cpp
+++ b/python/server/ServerWrapper.cpp
@@ -23,7 +23,6 @@
 #include "../../util/i18n.h"
 #include "../../util/OptionsDB.h"
 #include "../../util/SitRepEntry.h"
-#include "../../parse/Parse.h"
 
 #include "../../Empire/Empire.h"
 #include "../../Empire/EmpireManager.h"

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -148,7 +148,7 @@ ServerApp::ServerApp() :
     m_fsm->initiate();
 
     // Start parsing content
-    ParseUniverseObjectTypes();
+    StartBackgroundParsing();
 
     Empires().DiplomaticStatusChangedSignal.connect(
         boost::bind(&ServerApp::HandleDiplomaticStatusChange, this, _1, _2));
@@ -190,8 +190,8 @@ namespace {
 #include <stdlib.h>
 #endif
 
-void ServerApp::ParseUniverseObjectTypes() {
-    IApp::ParseUniverseObjectTypes();
+void ServerApp::StartBackgroundParsing() {
+    IApp::StartBackgroundParsing();
     const auto& rdir = GetResourceDir();
     m_universe.SetInitiallyUnlockedItems(
         Pending::StartParsing(parse::items, rdir / "scripting/starting_unlocks/items.inf"));

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -618,6 +618,9 @@ void ServerApp::NewGameInitConcurrentWithJoiners(
 {
     DebugLogger() << "ServerApp::NewGameInitConcurrentWithJoiners";
 
+    // Start parsing content
+    ParseUniverseObjectTypes();
+
     m_galaxy_setup_data = galaxy_setup_data;
     GetGameRules().SetFromStrings(m_galaxy_setup_data.GetGameRules());
 
@@ -823,6 +826,9 @@ void ServerApp::SendNewGameStartMessages() {
 void ServerApp::LoadSPGameInit(const std::vector<PlayerSaveGameData>& player_save_game_data,
                                std::shared_ptr<ServerSaveGameData> server_save_game_data)
 {
+    // Start parsing content
+    ParseUniverseObjectTypes();
+
     // Need to determine which data in player_save_game_data should be assigned to which established player
     std::vector<std::pair<int, int>> player_id_to_save_game_data_index;
 
@@ -1090,6 +1096,9 @@ void ServerApp::LoadMPGameInit(const MultiplayerLobbyData& lobby_data,
                                const std::vector<PlayerSaveGameData>& player_save_game_data,
                                std::shared_ptr<ServerSaveGameData> server_save_game_data)
 {
+    // Start parsing content
+    ParseUniverseObjectTypes();
+
     // Need to determine which data in player_save_game_data should be assigned to which established player
     std::vector<std::pair<int, int>> player_id_to_save_game_data_index;
 

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -203,6 +203,7 @@ void ServerApp::ParseUniverseObjectTypes() {
     m_universe.SetInitiallyUnlockedBuildings(StartParsing(parse::starting_buildings));
     m_universe.SetInitiallyUnlockedFleetPlans(StartParsing(parse::fleet_plans));
     m_universe.SetMonsterFleetPlans(StartParsing(parse::monster_fleet_plans));
+    m_universe.SetEmpireStats(StartParsing(parse::statistics));
 }
 
 void ServerApp::CreateAIClients(const std::vector<PlayerSetupData>& player_setup_data, int max_aggression) {

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -5,6 +5,7 @@
 #include "../combat/CombatSystem.h"
 #include "../combat/CombatEvents.h"
 #include "../combat/CombatLogManager.h"
+#include "../parse/Parse.h"
 #include "../universe/Building.h"
 #include "../universe/Effect.h"
 #include "../universe/Fleet.h"
@@ -187,9 +188,21 @@ namespace {
 #include <stdlib.h>
 #endif
 
+namespace {
+    template <typename ParserFunc>
+    auto StartParsing(const ParserFunc& parser) -> std::future<decltype(parser())> {
+        return std::async(std::launch::async, parser);
+    }
+
+}
+
 void ServerApp::ParseUniverseObjectTypes() {
     IApp::ParseUniverseObjectTypes();
     DebugLogger() << "Server Parser";
+    m_universe.SetInitiallyUnlockedItems(StartParsing(parse::items));
+    m_universe.SetInitiallyUnlockedBuildings(StartParsing(parse::starting_buildings));
+    m_universe.SetInitiallyUnlockedFleetPlans(StartParsing(parse::fleet_plans));
+    m_universe.SetMonsterFleetPlans(StartParsing(parse::monster_fleet_plans));
 }
 
 void ServerApp::CreateAIClients(const std::vector<PlayerSetupData>& player_setup_data, int max_aggression) {

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -187,6 +187,11 @@ namespace {
 #include <stdlib.h>
 #endif
 
+void ServerApp::ParseUniverseObjectTypes() {
+    IApp::ParseUniverseObjectTypes();
+    DebugLogger() << "Server Parser";
+}
+
 void ServerApp::CreateAIClients(const std::vector<PlayerSetupData>& player_setup_data, int max_aggression) {
     DebugLogger() << "ServerApp::CreateAIClients: " << player_setup_data.size() << " player (maybe not all AIs) at max aggression: " << max_aggression;
     // check if AI clients are needed for given setup data

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -28,6 +28,7 @@
 #include "../util/OptionsDB.h"
 #include "../util/Order.h"
 #include "../util/OrderSet.h"
+#include "../util/Pending.h"
 #include "../util/SaveGamePreviewUtils.h"
 #include "../util/SitRepEntry.h"
 #include "../util/ScopedTimer.h"
@@ -189,24 +190,19 @@ namespace {
 #include <stdlib.h>
 #endif
 
-namespace {
-    template <typename ParserFunc>
-    auto StartParsing(const ParserFunc& parser, const boost::filesystem::path& subdir)
-        -> std::future<decltype(parser(subdir))>
-    {
-        return std::async(std::launch::async, parser, subdir);
-    }
-}
-
 void ServerApp::ParseUniverseObjectTypes() {
     IApp::ParseUniverseObjectTypes();
-    DebugLogger() << "Server Parser";
     const auto& rdir = GetResourceDir();
-    m_universe.SetInitiallyUnlockedItems(StartParsing(parse::items, rdir / "scripting/starting_unlocks/items.inf"));
-    m_universe.SetInitiallyUnlockedBuildings(StartParsing(parse::starting_buildings, rdir / "scripting/starting_unlocks/buildings.inf"));
-    m_universe.SetInitiallyUnlockedFleetPlans(StartParsing(parse::fleet_plans, rdir / "scripting/starting_unlocks/fleets.inf"));
-    m_universe.SetMonsterFleetPlans(StartParsing(parse::monster_fleet_plans, rdir / "scripting/monster_fleets.inf"));
-    m_universe.SetEmpireStats(StartParsing(parse::statistics, rdir / "scripting/empire_statistics"));
+    m_universe.SetInitiallyUnlockedItems(
+        Pending::StartParsing(parse::items, rdir / "scripting/starting_unlocks/items.inf"));
+    m_universe.SetInitiallyUnlockedBuildings(
+        Pending::StartParsing(parse::starting_buildings, rdir / "scripting/starting_unlocks/buildings.inf"));
+    m_universe.SetInitiallyUnlockedFleetPlans(
+        Pending::StartParsing(parse::fleet_plans, rdir / "scripting/starting_unlocks/fleets.inf"));
+    m_universe.SetMonsterFleetPlans(
+        Pending::StartParsing(parse::monster_fleet_plans, rdir / "scripting/monster_fleets.inf"));
+    m_universe.SetEmpireStats(
+        Pending::StartParsing(parse::statistics, rdir / "scripting/empire_statistics"));
 }
 
 void ServerApp::CreateAIClients(const std::vector<PlayerSetupData>& player_setup_data, int max_aggression) {

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -190,20 +190,22 @@ namespace {
 
 namespace {
     template <typename ParserFunc>
-    auto StartParsing(const ParserFunc& parser) -> std::future<decltype(parser())> {
-        return std::async(std::launch::async, parser);
+    auto StartParsing(const ParserFunc& parser, const boost::filesystem::path& subdir)
+        -> std::future<decltype(parser(subdir))>
+    {
+        return std::async(std::launch::async, parser, subdir);
     }
-
 }
 
 void ServerApp::ParseUniverseObjectTypes() {
     IApp::ParseUniverseObjectTypes();
     DebugLogger() << "Server Parser";
-    m_universe.SetInitiallyUnlockedItems(StartParsing(parse::items));
-    m_universe.SetInitiallyUnlockedBuildings(StartParsing(parse::starting_buildings));
-    m_universe.SetInitiallyUnlockedFleetPlans(StartParsing(parse::fleet_plans));
-    m_universe.SetMonsterFleetPlans(StartParsing(parse::monster_fleet_plans));
-    m_universe.SetEmpireStats(StartParsing(parse::statistics));
+    const auto& rdir = GetResourceDir();
+    m_universe.SetInitiallyUnlockedItems(StartParsing(parse::items, rdir / "scripting/starting_unlocks/items.inf"));
+    m_universe.SetInitiallyUnlockedBuildings(StartParsing(parse::starting_buildings, rdir / "scripting/starting_unlocks/buildings.inf"));
+    m_universe.SetInitiallyUnlockedFleetPlans(StartParsing(parse::fleet_plans, rdir / "scripting/starting_unlocks/fleets.inf"));
+    m_universe.SetMonsterFleetPlans(StartParsing(parse::monster_fleet_plans, rdir / "scripting/monster_fleets.inf"));
+    m_universe.SetEmpireStats(StartParsing(parse::statistics, rdir / "scripting/empire_statistics"));
 }
 
 void ServerApp::CreateAIClients(const std::vector<PlayerSetupData>& player_setup_data, int max_aggression) {

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -16,6 +16,7 @@
 #include "../universe/Special.h"
 #include "../universe/System.h"
 #include "../universe/Species.h"
+#include "../universe/Tech.h"
 #include "../universe/UniverseGenerator.h"
 #include "../universe/Enums.h"
 #include "../Empire/Empire.h"

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -144,6 +144,9 @@ ServerApp::ServerApp() :
 
     m_fsm->initiate();
 
+    // Start parsing content
+    ParseUniverseObjectTypes();
+
     Empires().DiplomaticStatusChangedSignal.connect(
         boost::bind(&ServerApp::HandleDiplomaticStatusChange, this, _1, _2));
     Empires().DiplomaticMessageChangedSignal.connect(
@@ -618,9 +621,6 @@ void ServerApp::NewGameInitConcurrentWithJoiners(
 {
     DebugLogger() << "ServerApp::NewGameInitConcurrentWithJoiners";
 
-    // Start parsing content
-    ParseUniverseObjectTypes();
-
     m_galaxy_setup_data = galaxy_setup_data;
     GetGameRules().SetFromStrings(m_galaxy_setup_data.GetGameRules());
 
@@ -826,9 +826,6 @@ void ServerApp::SendNewGameStartMessages() {
 void ServerApp::LoadSPGameInit(const std::vector<PlayerSaveGameData>& player_save_game_data,
                                std::shared_ptr<ServerSaveGameData> server_save_game_data)
 {
-    // Start parsing content
-    ParseUniverseObjectTypes();
-
     // Need to determine which data in player_save_game_data should be assigned to which established player
     std::vector<std::pair<int, int>> player_id_to_save_game_data_index;
 
@@ -1096,9 +1093,6 @@ void ServerApp::LoadMPGameInit(const MultiplayerLobbyData& lobby_data,
                                const std::vector<PlayerSaveGameData>& player_save_game_data,
                                std::shared_ptr<ServerSaveGameData> server_save_game_data)
 {
-    // Start parsing content
-    ParseUniverseObjectTypes();
-
     // Need to determine which data in player_save_game_data should be assigned to which established player
     std::vector<std::pair<int, int>> player_id_to_save_game_data_index;
 

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -134,6 +134,8 @@ public:
     /** \name Mutators */ //@{
     void    operator()();               ///< external interface to Run()
 
+    void ParseUniverseObjectTypes() override;
+
     /** Returns the galaxy setup data used for the current game */
     GalaxySetupData&    GetGalaxySetupData() { return m_galaxy_setup_data; }
 

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -134,7 +134,7 @@ public:
     /** \name Mutators */ //@{
     void    operator()();               ///< external interface to Run()
 
-    void ParseUniverseObjectTypes() override;
+    void StartBackgroundParsing() override;
 
     /** Returns the galaxy setup data used for the current game */
     GalaxySetupData&    GetGalaxySetupData() { return m_galaxy_setup_data; }

--- a/server/dmain.cpp
+++ b/server/dmain.cpp
@@ -1,6 +1,5 @@
 #include "ServerApp.h"
 
-#include "../parse/Parse.h"
 #include "../util/OptionsDB.h"
 #include "../util/Directories.h"
 #include "../util/i18n.h"

--- a/universe/Building.cpp
+++ b/universe/Building.cpp
@@ -352,19 +352,6 @@ BuildingTypeManager::BuildingTypeManager() :
     if (s_instance)
         throw std::runtime_error("Attempted to create more than one BuildingTypeManager.");
 
-    m_pending_building_types = std::async(std::launch::async, []{
-            TraceLogger() << "BuildingTypeManager::BuildingTypeManager() about to parse buildings.";
-
-            auto building_types = parse::buildings();
-
-            TraceLogger() << "Building Types:";
-            for (const auto& entry : building_types) {
-                TraceLogger() << " ... " << entry.first;
-            }
-
-            return building_types;
-        });
-
     // Only update the global pointer on sucessful construction.
     s_instance = this;
 }

--- a/universe/Building.cpp
+++ b/universe/Building.cpp
@@ -9,7 +9,6 @@
 #include "ValueRef.h"
 #include "../Empire/Empire.h"
 #include "../Empire/EmpireManager.h"
-#include "../parse/Parse.h"
 #include "../util/OptionsDB.h"
 #include "../util/Logger.h"
 #include "../util/AppInterface.h"

--- a/universe/Building.cpp
+++ b/universe/Building.cpp
@@ -389,28 +389,11 @@ unsigned int BuildingTypeManager::GetCheckSum() const {
     return retval;
 }
 
-void BuildingTypeManager::SetBuildingTypes(std::future<BuildingTypeMap>&& pending_building_types)
+void BuildingTypeManager::SetBuildingTypes(Pending::Pending<BuildingTypeMap>&& pending_building_types)
 { m_pending_building_types = std::move(pending_building_types); }
 
-void BuildingTypeManager::CheckPendingBuildingTypes() const {
-    if (!m_pending_building_types)
-        return;
-
-    // Only print waiting message if not immediately ready
-    while (m_pending_building_types->wait_for(std::chrono::seconds(1)) == std::future_status::timeout) {
-        DebugLogger() << "Waiting for Building types to parse.";
-    }
-
-    try {
-        auto x = std::move(m_pending_building_types->get());
-        std::swap(m_building_types, x);
-    } catch (const std::exception& e) {
-        ErrorLogger() << "Failed parsing buildings: error: " << e.what();
-        throw e;
-    }
-
-    m_pending_building_types = boost::none;
-}
+void BuildingTypeManager::CheckPendingBuildingTypes() const
+{ Pending::SwapPending(m_pending_building_types, m_building_types); }
 
 ///////////////////////////////////////////////////////////
 // Free Functions                                        //

--- a/universe/Building.h
+++ b/universe/Building.h
@@ -6,10 +6,9 @@
 #include "ValueRefFwd.h"
 #include "ShipDesign.h"
 #include "../util/Export.h"
+#include "../util/Pending.h"
 
 #include <boost/algorithm/string/case_conv.hpp>
-
-#include <future>
 
 class BuildingType;
 namespace Effect {
@@ -225,7 +224,7 @@ public:
     //@}
 
     /** Sets building types to the future value of \p pending_building_types. */
-    FO_COMMON_API void SetBuildingTypes(std::future<BuildingTypeMap>&& pending_building_types);
+    FO_COMMON_API void SetBuildingTypes(Pending::Pending<BuildingTypeMap>&& pending_building_types);
 
 private:
     BuildingTypeManager();
@@ -235,7 +234,7 @@ private:
 
     /** Future building type being parsed by parser.  mutable so that it can
         be assigned to m_building_types when completed.*/
-    mutable boost::optional<std::future<BuildingTypeMap>> m_pending_building_types = boost::none;
+    mutable boost::optional<Pending::Pending<BuildingTypeMap>> m_pending_building_types = boost::none;
 
     /** Set of building types.  mutable so that when the parse complete it can
         be updated. */

--- a/universe/Building.h
+++ b/universe/Building.h
@@ -9,6 +9,8 @@
 
 #include <boost/algorithm/string/case_conv.hpp>
 
+#include <future>
+
 class BuildingType;
 namespace Effect {
     class EffectsGroup;
@@ -195,7 +197,8 @@ private:
 /** Holds all FreeOrion building types.  Types may be looked up by name. */
 class BuildingTypeManager {
 public:
-    typedef std::map<std::string, std::unique_ptr<BuildingType>>::const_iterator iterator;
+    using BuildingTypeMap = std::map<std::string, std::unique_ptr<BuildingType>>;
+    using iterator = BuildingTypeMap::const_iterator;
 
     /** \name Accessors */ //@{
     /** returns the building type with the name \a name; you should use the
@@ -203,10 +206,10 @@ public:
     const BuildingType*         GetBuildingType(const std::string& name) const;
 
     /** iterator to the first building type */
-    iterator                    begin() const   { return m_building_types.begin(); }
+    FO_COMMON_API iterator                    begin() const;
 
     /** iterator to the last + 1th building type */
-    iterator                    end() const     { return m_building_types.end(); }
+    FO_COMMON_API iterator                    end() const;
 
     /** returns the instance of this singleton class; you should use the free
       * function GetBuildingTypeManager() instead */
@@ -221,10 +224,22 @@ public:
     unsigned int                GetCheckSum() const;
     //@}
 
+    /** Sets building types to the future value of \p pending_building_types. */
+    FO_COMMON_API void SetBuildingTypes(std::future<BuildingTypeMap>&& pending_building_types);
+
 private:
     BuildingTypeManager();
 
-    std::map<std::string, std::unique_ptr<BuildingType>> m_building_types;
+    /** Assigns any m_pending_building_types to m_bulding_types. */
+    void CheckPendingBuildingTypes() const;
+
+    /** Future building type being parsed by parser.  mutable so that it can
+        be assigned to m_building_types when completed.*/
+    mutable boost::optional<std::future<BuildingTypeMap>> m_pending_building_types = boost::none;
+
+    /** Set of building types.  mutable so that when the parse complete it can
+        be updated. */
+    mutable BuildingTypeMap m_building_types;
 
     static BuildingTypeManager* s_instance;
 };

--- a/universe/Encyclopedia.cpp
+++ b/universe/Encyclopedia.cpp
@@ -7,7 +7,7 @@
 #include "../parse/Parse.h"
 
 
-const Encyclopedia& GetEncyclopedia() {
+Encyclopedia& GetEncyclopedia() {
     static Encyclopedia encyclopedia;
     return encyclopedia;
 }
@@ -15,10 +15,7 @@ const Encyclopedia& GetEncyclopedia() {
 Encyclopedia::Encyclopedia() :
     empty_article(),
     m_articles()
-{
-    m_pending_articles = std::async(std::launch::async, []{
-            return parse::encyclopedia_articles();});
-}
+{}
 
 unsigned int Encyclopedia::GetCheckSum() const {
     unsigned int retval{0};

--- a/universe/Encyclopedia.cpp
+++ b/universe/Encyclopedia.cpp
@@ -13,30 +13,17 @@ const Encyclopedia& GetEncyclopedia() {
 }
 
 Encyclopedia::Encyclopedia() :
-    articles(),
-    empty_article()
+    empty_article(),
+    m_articles()
 {
-    try {
-        articles = parse::encyclopedia_articles();
-        DebugLogger() << "Encyclopedia Articles checksum: " << GetCheckSum();
-
-    } catch (const std::exception& e) {
-        ErrorLogger() << "Failed parsing encyclopedia articles: error: " << e.what();
-        throw e;
-    }
-
-    TraceLogger() << "(Category) Encyclopedia Articles:";
-    for (const auto& entry : articles) {
-        const std::string& category = entry.first;
-        for (const EncyclopediaArticle& article : entry.second)
-        { TraceLogger() << "(" << category << ") : " << article.name; }
-    }
+    m_pending_articles = std::async(std::launch::async, []{
+            return parse::encyclopedia_articles();});
 }
 
 unsigned int Encyclopedia::GetCheckSum() const {
     unsigned int retval{0};
 
-    for (const auto& n : articles) {
+    for (const auto& n : Articles()) {
         CheckSums::CheckSumCombine(retval, n.first);
         for (const auto& a : n.second) {
             CheckSums::CheckSumCombine(retval, a.name);
@@ -47,7 +34,39 @@ unsigned int Encyclopedia::GetCheckSum() const {
         }
         CheckSums::CheckSumCombine(retval, n.second.size());
     }
-    CheckSums::CheckSumCombine(retval, articles.size());
+    CheckSums::CheckSumCombine(retval, Articles().size());
 
     return retval;
+}
+
+void Encyclopedia::SetArticles(std::future<ArticleMap>&& future)
+{ m_pending_articles = std::move(future); }
+
+const Encyclopedia::ArticleMap& Encyclopedia::Articles() const {
+    if (m_pending_articles != boost::none) {
+        // Only print waiting message if not immediately ready
+        while (m_pending_articles->wait_for(std::chrono::seconds(1)) == std::future_status::timeout) {
+            DebugLogger() << "Waiting for Articles to parse.";
+        }
+
+        try {
+            auto x = std::move(m_pending_articles->get());
+            std::swap(m_articles, x);
+
+            TraceLogger() << "(Category) Encyclopedia Articles:";
+            for (const auto& entry : m_articles) {
+                const std::string& category = entry.first;
+                for (const EncyclopediaArticle& article : entry.second)
+                { TraceLogger() << "(" << category << ") : " << article.name; }
+            }
+
+        } catch (const std::exception& e) {
+            ErrorLogger() << "Failed parsing articles: error: " << e.what();
+            throw e;
+        }
+
+        m_pending_articles = boost::none;
+    }
+
+    return m_articles;
 }

--- a/universe/Encyclopedia.cpp
+++ b/universe/Encyclopedia.cpp
@@ -4,7 +4,6 @@
 #include "../util/Logger.h"
 #include "../util/OptionsDB.h"
 #include "../util/CheckSums.h"
-#include "../parse/Parse.h"
 
 
 Encyclopedia& GetEncyclopedia() {

--- a/universe/Encyclopedia.h
+++ b/universe/Encyclopedia.h
@@ -1,12 +1,13 @@
 #ifndef _Encyclopedia_h_
 #define _Encyclopedia_h_
 
+#include "../util/Pending.h"
+
 #include <boost/optional/optional.hpp>
 
 #include <string>
 #include <map>
 #include <vector>
-#include <future>
 
 #include "../util/Export.h"
 
@@ -42,7 +43,7 @@ public:
     unsigned int GetCheckSum() const;
 
     /** Sets articles to the value of \p future. */
-    FO_COMMON_API void SetArticles(std::future<ArticleMap>&& future);
+    FO_COMMON_API void SetArticles(Pending::Pending<ArticleMap>&& future);
 
     FO_COMMON_API const ArticleMap& Articles() const;
 
@@ -51,7 +52,7 @@ private:
     mutable ArticleMap m_articles;
 
     /** Future articles.  mutable so that it can be assigned to m_articles when completed.*/
-    mutable boost::optional<std::future<ArticleMap>> m_pending_articles = boost::none;
+    mutable boost::optional<Pending::Pending<ArticleMap>> m_pending_articles = boost::none;
 };
 
 FO_COMMON_API Encyclopedia& GetEncyclopedia();

--- a/universe/Encyclopedia.h
+++ b/universe/Encyclopedia.h
@@ -54,6 +54,6 @@ private:
     mutable boost::optional<std::future<ArticleMap>> m_pending_articles = boost::none;
 };
 
-FO_COMMON_API const Encyclopedia& GetEncyclopedia();
+FO_COMMON_API Encyclopedia& GetEncyclopedia();
 
 #endif

--- a/universe/Encyclopedia.h
+++ b/universe/Encyclopedia.h
@@ -1,9 +1,12 @@
 #ifndef _Encyclopedia_h_
 #define _Encyclopedia_h_
 
+#include <boost/optional/optional.hpp>
+
 #include <string>
 #include <map>
 #include <vector>
+#include <future>
 
 #include "../util/Export.h"
 
@@ -31,11 +34,24 @@ struct FO_COMMON_API EncyclopediaArticle {
     std::string icon;
 };
 
-struct FO_COMMON_API Encyclopedia {
+class FO_COMMON_API Encyclopedia {
+public:
+    using ArticleMap = std::map<std::string, std::vector<EncyclopediaArticle>>;
+
     Encyclopedia();
     unsigned int GetCheckSum() const;
-    std::map<std::string, std::vector<EncyclopediaArticle>> articles;
+
+    /** Sets articles to the value of \p future. */
+    FO_COMMON_API void SetArticles(std::future<ArticleMap>&& future);
+
+    FO_COMMON_API const ArticleMap& Articles() const;
+
     const EncyclopediaArticle                               empty_article;
+private:
+    mutable ArticleMap m_articles;
+
+    /** Future articles.  mutable so that it can be assigned to m_articles when completed.*/
+    mutable boost::optional<std::future<ArticleMap>> m_pending_articles = boost::none;
 };
 
 FO_COMMON_API const Encyclopedia& GetEncyclopedia();

--- a/universe/Field.cpp
+++ b/universe/Field.cpp
@@ -7,7 +7,6 @@
 #include "Predicates.h"
 #include "Universe.h"
 #include "ValueRef.h"
-#include "../parse/Parse.h"
 #include "../util/AppInterface.h"
 #include "../util/OptionsDB.h"
 #include "../util/Logger.h"

--- a/universe/Field.h
+++ b/universe/Field.h
@@ -5,6 +5,8 @@
 
 #include "../util/Export.h"
 
+#include <future>
+
 namespace Effect {
     class EffectsGroup;
 }
@@ -116,7 +118,8 @@ private:
 
 class FieldTypeManager {
 public:
-    typedef std::map<std::string, std::unique_ptr<FieldType>>::const_iterator iterator;
+    using FieldTypeMap = std::map<std::string, std::unique_ptr<FieldType>>;
+    using iterator = FieldTypeMap::const_iterator;
 
     /** \name Accessors */ //@{
     /** returns the field type with the name \a name; you should use the
@@ -124,10 +127,10 @@ public:
     const FieldType*            GetFieldType(const std::string& name) const;
 
     /** iterator to the first field type */
-    iterator                    begin() const   { return m_field_types.begin(); }
+    FO_COMMON_API iterator      begin() const;
 
     /** iterator to the last + 1th field type */
-    iterator                    end() const     { return m_field_types.end(); }
+    FO_COMMON_API iterator      end() const;
 
     /** returns the instance of this singleton class; you should use the free
       * function GetFieldTypeManager() instead */
@@ -141,10 +144,21 @@ public:
       * clients and server. */
     unsigned int                GetCheckSum() const;
     //@}
+
+    /** Sets types to the value of \p future. */
+    FO_COMMON_API void SetFieldTypes(std::future<FieldTypeMap>&& future);
+
 private:
     FieldTypeManager();
 
-    std::map<std::string, std::unique_ptr<FieldType>> m_field_types;
+    /** Assigns any m_pending_types to m_field_types. */
+    void CheckPendingFieldTypes() const;
+
+    /** Future types being parsed by parser.  mutable so that it can
+        be assigned to m_field_types when completed.*/
+    mutable boost::optional<std::future<FieldTypeMap>> m_pending_types = boost::none;
+
+    mutable FieldTypeMap   m_field_types;
     static FieldTypeManager*            s_instance;
 };
 

--- a/universe/Field.h
+++ b/universe/Field.h
@@ -4,8 +4,7 @@
 #include "UniverseObject.h"
 
 #include "../util/Export.h"
-
-#include <future>
+#include "../util/Pending.h"
 
 namespace Effect {
     class EffectsGroup;
@@ -146,7 +145,7 @@ public:
     //@}
 
     /** Sets types to the value of \p future. */
-    FO_COMMON_API void SetFieldTypes(std::future<FieldTypeMap>&& future);
+    FO_COMMON_API void SetFieldTypes(Pending::Pending<FieldTypeMap>&& future);
 
 private:
     FieldTypeManager();
@@ -156,7 +155,7 @@ private:
 
     /** Future types being parsed by parser.  mutable so that it can
         be assigned to m_field_types when completed.*/
-    mutable boost::optional<std::future<FieldTypeMap>> m_pending_types = boost::none;
+    mutable boost::optional<Pending::Pending<FieldTypeMap>> m_pending_types = boost::none;
 
     mutable FieldTypeMap   m_field_types;
     static FieldTypeManager*            s_instance;

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -1641,14 +1641,3 @@ LoadShipDesignsAndManifestOrderFromParseResults(
 
     return std::make_tuple(ship_manifest_inconsistent, std::move(saved_designs), ordering);
 }
-
-std::tuple<
-    bool,
-    std::unordered_map<boost::uuids::uuid,
-                       std::pair<std::unique_ptr<ShipDesign>, boost::filesystem::path>,
-                       boost::hash<boost::uuids::uuid>>,
-    std::vector<boost::uuids::uuid>>
-LoadShipDesignsAndManifestOrderFromFileSystem(const boost::filesystem::path& dir) {
-    auto designs_paths_and_ordering = parse::ship_designs(dir);
-    return LoadShipDesignsAndManifestOrderFromParseResults(designs_paths_and_ordering);
-}

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -5,8 +5,6 @@
 #include "../util/AppInterface.h"
 #include "../util/MultiplayerCommon.h"
 #include "../util/CheckSums.h"
-#include "../util/ScopedTimer.h"
-#include "../parse/Parse.h"
 #include "../Empire/Empire.h"
 #include "../Empire/EmpireManager.h"
 #include "Condition.h"

--- a/universe/ShipDesign.h
+++ b/universe/ShipDesign.h
@@ -849,14 +849,4 @@ FO_COMMON_API std::tuple<
     std::vector<boost::uuids::uuid>>
 LoadShipDesignsAndManifestOrderFromParseResults(PredefinedShipDesignManager::ParsedShipDesignsType& parsed);
 
-/** Load all ship designs in \p dir and return a tuple is_error, the map from
-    uuid to ship design and path and the ship ordering from the manifest. */
-FO_COMMON_API std::tuple<
-    bool,
-    std::unordered_map<boost::uuids::uuid,
-        std::pair<std::unique_ptr<ShipDesign>, boost::filesystem::path>,
-        boost::hash<boost::uuids::uuid>>,
-    std::vector<boost::uuids::uuid>>
-LoadShipDesignsAndManifestOrderFromFileSystem(const boost::filesystem::path& dir);
-
 #endif // _ShipDesign_h_

--- a/universe/ShipDesign.h
+++ b/universe/ShipDesign.h
@@ -11,7 +11,6 @@
 #include <string>
 #include <vector>
 #include <stdexcept>
-#include <future>
 
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/filesystem/operations.hpp>
@@ -26,6 +25,7 @@
 #include "EnumsFwd.h"
 
 #include "../util/Export.h"
+#include "../util/Pending.h"
 
 FO_COMMON_API extern const int INVALID_OBJECT_ID;
 namespace Condition {
@@ -214,7 +214,7 @@ public:
     //@}
 
     /** Sets part types to the future value of \p pending_part_types. */
-    FO_COMMON_API void SetPartTypes(std::future<PartTypeMap>&& pending_part_types);
+    FO_COMMON_API void SetPartTypes(Pending::Pending<PartTypeMap>&& pending_part_types);
 
 private:
     PartTypeManager();
@@ -224,7 +224,7 @@ private:
 
     /** Future part type being parsed by parser.  mutable so that it can
         be assigned to m_part_types when completed.*/
-    mutable boost::optional<std::future<PartTypeMap>> m_pending_part_types = boost::none;
+    mutable boost::optional<Pending::Pending<PartTypeMap>> m_pending_part_types = boost::none;
 
     /** Set of part types.  mutable so that when the parse completes it can
         be updated. */
@@ -454,7 +454,7 @@ public:
     //@}
 
     /** Sets hull types to the future value of \p pending_hull_types. */
-    FO_COMMON_API void SetHullTypes(std::future<HullTypeMap>&& pending_hull_types);
+    FO_COMMON_API void SetHullTypes(Pending::Pending<HullTypeMap>&& pending_hull_types);
 
 private:
     HullTypeManager();
@@ -465,7 +465,7 @@ private:
 
     /** Future hull type being parsed by parser.  mutable so that it can
         be assigned to m_hull_types when completed.*/
-    mutable boost::optional<std::future<HullTypeMap>> m_pending_hull_types = boost::none;
+    mutable boost::optional<Pending::Pending<HullTypeMap>> m_pending_hull_types = boost::none;
 
     /** Set of hull types.  mutable so that when the parse completes it can
         be updated. */
@@ -753,11 +753,11 @@ public:
 
     /** Sets ship design types to the future value of \p pending_designs
         found in \p subdir. */
-    FO_COMMON_API void SetShipDesignTypes(std::future<ParsedShipDesignsType>&& pending_designs);
+    FO_COMMON_API void SetShipDesignTypes(Pending::Pending<ParsedShipDesignsType>&& pending_designs);
 
     /** Sets monster design types to the future value of \p
         pending_design_types found in \p subdir. */
-    FO_COMMON_API void SetMonsterDesignTypes(std::future<ParsedShipDesignsType>&& pending_designs);
+    FO_COMMON_API void SetMonsterDesignTypes(Pending::Pending<ParsedShipDesignsType>&& pending_designs);
 
 private:
     PredefinedShipDesignManager();
@@ -767,8 +767,8 @@ private:
 
     /** Future ship design type being parsed by parser.  mutable so that it can
         be assigned to m_ship design_types when completed.*/
-    mutable boost::optional<std::future<ParsedShipDesignsType>> m_pending_designs = boost::none;
-    mutable boost::optional<std::future<ParsedShipDesignsType>> m_pending_monsters = boost::none;
+    mutable boost::optional<Pending::Pending<ParsedShipDesignsType>> m_pending_designs = boost::none;
+    mutable boost::optional<Pending::Pending<ParsedShipDesignsType>> m_pending_monsters = boost::none;
 
     mutable std::unordered_map<boost::uuids::uuid, std::unique_ptr<ShipDesign>,
                                boost::hash<boost::uuids::uuid>>  m_designs;

--- a/universe/ShipDesign.h
+++ b/universe/ShipDesign.h
@@ -428,7 +428,8 @@ namespace CheckSums {
 /** Holds FreeOrion hull types */
 class FO_COMMON_API HullTypeManager {
 public:
-    typedef std::map<std::string, std::unique_ptr<HullType>>::const_iterator iterator;
+    using HullTypeMap = std::map<std::string, std::unique_ptr<HullType>>;
+    using iterator = HullTypeMap::const_iterator;
 
     /** \name Accessors */ //@{
     /** returns the hull type with the name \a name; you should use the free function GetHullType() instead */
@@ -441,7 +442,7 @@ public:
     iterator end() const;
 
     /** returns the instance of this singleton class; you should use the free function GetHullTypeManager() instead */
-    static const HullTypeManager& GetHullTypeManager();
+    static HullTypeManager& GetHullTypeManager();
 
     /** Returns a number, calculated from the contained data, which should be
       * different for different contained data, and must be the same for
@@ -452,15 +453,29 @@ public:
     unsigned int GetCheckSum() const;
     //@}
 
+    /** Sets hull types to the future value of \p pending_hull_types. */
+    FO_COMMON_API void SetHullTypes(std::future<HullTypeMap>&& pending_hull_types);
+
 private:
     HullTypeManager();
 
-    std::map<std::string, std::unique_ptr<HullType>> m_hulls;
+
+    /** Assigns any m_pending_hull_types to m_bulding_types. */
+    void CheckPendingHullTypes() const;
+
+    /** Future hull type being parsed by parser.  mutable so that it can
+        be assigned to m_hull_types when completed.*/
+    mutable boost::optional<std::future<HullTypeMap>> m_pending_hull_types = boost::none;
+
+    /** Set of hull types.  mutable so that when the parse completes it can
+        be updated. */
+    mutable HullTypeMap m_hulls;
+
     static HullTypeManager* s_instance;
 };
 
 /** returns the singleton hull type manager */
-FO_COMMON_API const HullTypeManager& GetHullTypeManager();
+FO_COMMON_API HullTypeManager& GetHullTypeManager();
 
 /** Returns the ship HullType specification object with name \a name.  If no such HullType exists,
   * 0 is returned instead. */

--- a/universe/ShipDesign.h
+++ b/universe/ShipDesign.h
@@ -481,6 +481,33 @@ FO_COMMON_API HullTypeManager& GetHullTypeManager();
   * 0 is returned instead. */
 FO_COMMON_API const HullType* GetHullType(const std::string& name);
 
+/** ParsedShipDesign holds the results of a parsed ship design which can be
+    converted to a ShipDesign. */
+struct FO_COMMON_API ParsedShipDesign {
+    ParsedShipDesign(const std::string& name, const std::string& description,
+                     int designed_on_turn, int designed_by_empire, const std::string& hull,
+                     const std::vector<std::string>& parts,
+                     const std::string& icon, const std::string& model,
+                     bool name_desc_in_stringtable = false, bool monster = false,
+                     const boost::uuids::uuid& uuid = boost::uuids::nil_uuid());
+
+    std::string                 m_name;
+    std::string                 m_description;
+    boost::uuids::uuid          m_uuid;
+
+    int                         m_designed_on_turn;
+    int                         m_designed_by_empire;
+
+    std::string                 m_hull;
+    std::vector<std::string>    m_parts;
+    bool                        m_is_monster;
+
+    std::string                 m_icon;
+    std::string                 m_3D_model;
+
+    bool                        m_name_desc_in_stringtable;
+};
+
 class FO_COMMON_API ShipDesign {
 public:
     /** \name Structors */ //@{
@@ -514,18 +541,10 @@ public:
                const std::vector<std::string>& parts,
                const std::string& icon, const std::string& model,
                bool name_desc_in_stringtable = false, bool monster = false,
-               const boost::uuids::uuid& uuid = boost::uuids::nil_uuid()
-              );
+               const boost::uuids::uuid& uuid = boost::uuids::nil_uuid());
 
-    /**  The public ShipDesign constructor will only construct valid ship
-         designs, as long as the HullTypeManager has at least one hull. */
-    ShipDesign(const std::string& name, const std::string& description,
-               int designed_on_turn, int designed_by_empire, const std::string& hull,
-               const std::vector<std::string>& parts,
-               const std::string& icon, const std::string& model,
-               bool name_desc_in_stringtable = false, bool monster = false,
-               const boost::uuids::uuid& uuid = boost::uuids::nil_uuid()
-              );
+    /** Convert a parsed ship design and do any required verification. */
+    ShipDesign(const ParsedShipDesign& design);
     //@}
 
     /** \name Accessors */ //@{

--- a/universe/Special.cpp
+++ b/universe/Special.cpp
@@ -44,27 +44,14 @@ unsigned int SpecialsManager::GetCheckSum() const {
     return retval;
 }
 
-void SpecialsManager::SetSpecialsTypes(std::future<SpecialsTypeMap>&& future)
+void SpecialsManager::SetSpecialsTypes(Pending::Pending<SpecialsTypeMap>&& future)
 { m_pending_types = std::move(future); }
 
 void SpecialsManager::CheckPendingSpecialsTypes() const {
     if (!m_pending_types)
         return;
 
-    // Only print waiting message if not immediately ready
-    while (m_pending_types->wait_for(std::chrono::seconds(1)) == std::future_status::timeout) {
-        DebugLogger() << "Waiting for Specials types to parse.";
-    }
-
-    try {
-        auto x = std::move(m_pending_types->get());
-        std::swap(m_specials, x);
-
-    } catch (const std::exception& e) {
-        ErrorLogger() << "Failed parsing specials: error: " << e.what();
-    }
-
-    m_pending_types = boost::none;
+    Pending::SwapPending(m_pending_types, m_specials);
 }
 
 SpecialsManager& GetSpecialsManager() {

--- a/universe/Special.cpp
+++ b/universe/Special.cpp
@@ -4,7 +4,6 @@
 #include "Effect.h"
 #include "UniverseObject.h"
 #include "ValueRef.h"
-#include "../parse/Parse.h"
 #include "../util/OptionsDB.h"
 #include "../util/Logger.h"
 #include "../util/AppInterface.h"

--- a/universe/Special.h
+++ b/universe/Special.h
@@ -8,12 +8,12 @@
 #include <boost/optional/optional.hpp>
 
 #include "../util/Export.h"
+#include "../util/Pending.h"
 
 #include <memory>
 #include <string>
 #include <vector>
 #include <map>
-#include <future>
 
 
 namespace Effect {
@@ -134,7 +134,7 @@ class FO_COMMON_API SpecialsManager {
     unsigned int GetCheckSum() const;
 
     /** Sets types to the value of \p future. */
-    FO_COMMON_API void SetSpecialsTypes(std::future<SpecialsTypeMap>&& future);
+    FO_COMMON_API void SetSpecialsTypes(Pending::Pending<SpecialsTypeMap>&& future);
 
     private:
     /** Assigns any m_pending_types to m_specials. */
@@ -142,7 +142,7 @@ class FO_COMMON_API SpecialsManager {
 
     /** Future types being parsed by parser.  mutable so that it can
         be assigned to m_species_types when completed.*/
-    mutable boost::optional<std::future<SpecialsTypeMap>> m_pending_types = boost::none;
+    mutable boost::optional<Pending::Pending<SpecialsTypeMap>> m_pending_types = boost::none;
 
     mutable SpecialsTypeMap m_specials;
 };

--- a/universe/Special.h
+++ b/universe/Special.h
@@ -5,6 +5,7 @@
 #include "ValueRefFwd.h"
 
 #include <boost/serialization/nvp.hpp>
+#include <boost/optional/optional.hpp>
 
 #include "../util/Export.h"
 
@@ -12,6 +13,7 @@
 #include <string>
 #include <vector>
 #include <map>
+#include <future>
 
 
 namespace Effect {
@@ -120,8 +122,10 @@ void Special::serialize(Archive& ar, const unsigned int version)
 }
 
 /** Look up table for specials.*/
-class SpecialsManager {
+class FO_COMMON_API SpecialsManager {
     public:
+    using SpecialsTypeMap = std::map<std::string, std::unique_ptr<Special>>;
+
     SpecialsManager();
     ~SpecialsManager();
 
@@ -129,10 +133,20 @@ class SpecialsManager {
     const Special* GetSpecial(const std::string& name) const;
     unsigned int GetCheckSum() const;
 
+    /** Sets types to the value of \p future. */
+    FO_COMMON_API void SetSpecialsTypes(std::future<SpecialsTypeMap>&& future);
+
     private:
-    std::map<std::string, std::unique_ptr<Special>> m_specials;
+    /** Assigns any m_pending_types to m_specials. */
+    void CheckPendingSpecialsTypes() const;
+
+    /** Future types being parsed by parser.  mutable so that it can
+        be assigned to m_species_types when completed.*/
+    mutable boost::optional<std::future<SpecialsTypeMap>> m_pending_types = boost::none;
+
+    mutable SpecialsTypeMap m_specials;
 };
 
-const SpecialsManager& GetSpecialsManager();
+FO_COMMON_API SpecialsManager& GetSpecialsManager();
 
 #endif // _Special_h_

--- a/universe/Special.h
+++ b/universe/Special.h
@@ -11,6 +11,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <map>
 
 
 namespace Effect {
@@ -117,5 +118,21 @@ void Special::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_location)
         & BOOST_SERIALIZATION_NVP(m_graphic);
 }
+
+/** Look up table for specials.*/
+class SpecialsManager {
+    public:
+    SpecialsManager();
+    ~SpecialsManager();
+
+    std::vector<std::string> SpecialNames() const;
+    const Special* GetSpecial(const std::string& name) const;
+    unsigned int GetCheckSum() const;
+
+    private:
+    std::map<std::string, std::unique_ptr<Special>> m_specials;
+};
+
+const SpecialsManager& GetSpecialsManager();
 
 #endif // _Special_h_

--- a/universe/Special.h
+++ b/universe/Special.h
@@ -123,7 +123,7 @@ void Special::serialize(Archive& ar, const unsigned int version)
 
 /** Look up table for specials.*/
 class FO_COMMON_API SpecialsManager {
-    public:
+public:
     using SpecialsTypeMap = std::map<std::string, std::unique_ptr<Special>>;
 
     SpecialsManager();
@@ -136,7 +136,7 @@ class FO_COMMON_API SpecialsManager {
     /** Sets types to the value of \p future. */
     FO_COMMON_API void SetSpecialsTypes(Pending::Pending<SpecialsTypeMap>&& future);
 
-    private:
+private:
     /** Assigns any m_pending_types to m_specials. */
     void CheckPendingSpecialsTypes() const;
 

--- a/universe/Species.cpp
+++ b/universe/Species.cpp
@@ -356,55 +356,28 @@ SpeciesManager::SpeciesManager() {
     if (s_instance)
         throw std::runtime_error("Attempted to create more than one SpeciesManager.");
 
-    ScopedTimer timer("SpeciesManager Init", true, std::chrono::milliseconds(1));
-
-    try {
-        m_species = parse::species();
-    } catch (const std::exception& e) {
-        ErrorLogger() << "Failed parsing species: error: " << e.what();
-        throw e;
-    }
-
-    TraceLogger() << [this]() {
-            std::string retval("Species:");
-            for (const auto& pair : m_species) {
-                const auto& species = pair.second;
-                retval.append("\n\t" + species->Name() + "  \t");
-                retval.append(species->Playable() ?
-                                 "Playable " :
-                                 "         ");
-                retval.append(species->Native() ?
-                                 "Native " :
-                                 "       ");
-                retval.append(species->CanProduceShips() ?
-                                 "CanProduceShips " :
-                                 "                ");
-                retval.append(species->CanColonize() ?
-                                 "CanColonize " :
-                                 "            ");
-            }
-            return retval;
-        }();
-
     // Only update the global pointer on sucessful construction.
     s_instance = this;
 }
 
 const Species* SpeciesManager::GetSpecies(const std::string& name) const {
+    CheckPendingSpeciesTypes();
     auto it = m_species.find(name);
-    return it != m_species.end() ? it->second.get() : nullptr;
+    return it != end() ? it->second.get() : nullptr;
 }
 
 Species* SpeciesManager::GetSpecies(const std::string& name) {
+    CheckPendingSpeciesTypes();
     auto it = m_species.find(name);
-    return it != m_species.end() ? it->second.get() : nullptr;
+    return it != end() ? it->second.get() : nullptr;
 }
 
 int SpeciesManager::GetSpeciesID(const std::string& name) const {
+    CheckPendingSpeciesTypes();
     iterator it = m_species.find(name);
-    if (it == m_species.end())
+    if (it == end())
         return -1;
-    return std::distance(m_species.begin(), it);
+    return std::distance(begin(), it);
 }
 
 SpeciesManager& SpeciesManager::GetSpeciesManager() {
@@ -412,29 +385,84 @@ SpeciesManager& SpeciesManager::GetSpeciesManager() {
     return manager;
 }
 
-SpeciesManager::iterator SpeciesManager::begin() const
-{ return m_species.begin(); }
+void SpeciesManager::SetSpeciesTypes(std::future<SpeciesTypeMap>&& future)
+{ m_pending_types = std::move(future); }
 
-SpeciesManager::iterator SpeciesManager::end() const
-{ return m_species.end(); }
+void SpeciesManager::CheckPendingSpeciesTypes() const {
+    if (!m_pending_types && m_species.empty())
+        throw;
+
+    if (!m_pending_types)
+        return;
+
+    // Only print waiting message if not immediately ready
+    while (m_pending_types->wait_for(std::chrono::seconds(1)) == std::future_status::timeout) {
+        DebugLogger() << "Waiting for Species types to parse.";
+    }
+
+    try {
+        auto x = std::move(m_pending_types->get());
+        std::swap(m_species, x);
+    } catch (const std::exception& e) {
+        ErrorLogger() << "Failed parsing species: error: " << e.what();
+        throw e;
+    }
+
+    m_pending_types = boost::none;
+
+    TraceLogger() << [this]() {
+        std::string retval("Species:");
+        for (const auto& pair : m_species) {
+            const auto& species = pair.second;
+            retval.append("\n\t" + species->Name() + "  \t");
+            retval.append(species->Playable() ?
+                          "Playable " :
+                          "         ");
+            retval.append(species->Native() ?
+                          "Native " :
+                          "       ");
+            retval.append(species->CanProduceShips() ?
+                          "CanProduceShips " :
+                          "                ");
+            retval.append(species->CanColonize() ?
+                          "CanColonize " :
+                          "            ");
+        }
+        return retval;
+    }();
+}
+
+SpeciesManager::iterator SpeciesManager::begin() const {
+    CheckPendingSpeciesTypes();
+    return m_species.begin();
+}
+
+SpeciesManager::iterator SpeciesManager::end() const {
+    CheckPendingSpeciesTypes();
+    return m_species.end();
+}
 
 SpeciesManager::playable_iterator SpeciesManager::playable_begin() const
-{ return playable_iterator(PlayableSpecies(), m_species.begin(), m_species.end()); }
+{ return playable_iterator(PlayableSpecies(), begin(), end()); }
 
 SpeciesManager::playable_iterator SpeciesManager::playable_end() const
-{ return playable_iterator(PlayableSpecies(), m_species.end(), m_species.end()); }
+{ return playable_iterator(PlayableSpecies(), end(), end()); }
 
 SpeciesManager::native_iterator SpeciesManager::native_begin() const
-{ return native_iterator(NativeSpecies(), m_species.begin(), m_species.end()); }
+{ return native_iterator(NativeSpecies(), begin(), end()); }
 
 SpeciesManager::native_iterator SpeciesManager::native_end() const
-{ return native_iterator(NativeSpecies(), m_species.end(), m_species.end()); }
+{ return native_iterator(NativeSpecies(), end(), end()); }
 
-bool SpeciesManager::empty() const
-{ return m_species.empty(); }
+bool SpeciesManager::empty() const {
+    CheckPendingSpeciesTypes();
+    return m_species.empty();
+}
 
-int SpeciesManager::NumSpecies() const
-{ return m_species.size(); }
+int SpeciesManager::NumSpecies() const {
+    CheckPendingSpeciesTypes();
+    return m_species.size();
+}
 
 int SpeciesManager::NumPlayableSpecies() const
 { return std::distance(playable_begin(), playable_end()); }
@@ -447,11 +475,12 @@ namespace {
 }
 
 const std::string& SpeciesManager::RandomSpeciesName() const {
+    CheckPendingSpeciesTypes();
     if (m_species.empty())
         return EMPTY_STRING;
 
     int species_idx = RandSmallInt(0, static_cast<int>(m_species.size()) - 1);
-    return std::next(m_species.begin(), species_idx)->first;
+    return std::next(begin(), species_idx)->first;
 }
 
 const std::string& SpeciesManager::RandomPlayableSpeciesName() const {
@@ -472,11 +501,13 @@ const std::string& SpeciesManager::SequentialPlayableSpeciesName(int id) const {
 }
 
 void SpeciesManager::ClearSpeciesHomeworlds() {
+    CheckPendingSpeciesTypes();
     for (auto& entry : m_species)
         entry.second->SetHomeworlds(std::set<int>());
 }
 
 void SpeciesManager::SetSpeciesHomeworlds(const std::map<std::string, std::set<int>>& species_homeworld_ids) {
+    CheckPendingSpeciesTypes();
     ClearSpeciesHomeworlds();
     for (auto& entry : species_homeworld_ids) {
         const std::string& species_name = entry.first;
@@ -484,7 +515,7 @@ void SpeciesManager::SetSpeciesHomeworlds(const std::map<std::string, std::set<i
 
         Species* species = nullptr;
         auto species_it = m_species.find(species_name);
-        if (species_it != m_species.end())
+        if (species_it != end())
             species = species_it->second.get();
 
         if (species) {
@@ -508,6 +539,7 @@ void SpeciesManager::SetSpeciesSpeciesOpinion(const std::string& opinionated_spe
 { m_species_species_opinions[opinionated_species][rated_species] = opinion; }
 
 std::map<std::string, std::set<int>> SpeciesManager::GetSpeciesHomeworldsMap(int encoding_empire/* = ALL_EMPIRES*/) const {
+    CheckPendingSpeciesTypes();
     std::map<std::string, std::set<int>> retval;
     for (const auto& entry : m_species) {
         const std::string species_name = entry.first;
@@ -586,6 +618,7 @@ std::map<std::string, std::map<std::string, int>>& SpeciesManager::SpeciesShipsD
 { return m_species_species_ships_destroyed; }
 
 unsigned int SpeciesManager::GetCheckSum() const {
+    CheckPendingSpeciesTypes();
     unsigned int retval{0};
     for (auto const& name_type_pair : m_species)
         CheckSums::CheckSumCombine(retval, name_type_pair);

--- a/universe/Species.cpp
+++ b/universe/Species.cpp
@@ -7,7 +7,6 @@
 #include "UniverseObject.h"
 #include "ValueRef.h"
 #include "Enums.h"
-#include "../parse/Parse.h"
 #include "../util/OptionsDB.h"
 #include "../util/Logger.h"
 #include "../util/Random.h"

--- a/universe/Species.cpp
+++ b/universe/Species.cpp
@@ -362,21 +362,21 @@ SpeciesManager::SpeciesManager() {
 const Species* SpeciesManager::GetSpecies(const std::string& name) const {
     CheckPendingSpeciesTypes();
     auto it = m_species.find(name);
-    return it != end() ? it->second.get() : nullptr;
+    return it != m_species.end() ? it->second.get() : nullptr;
 }
 
 Species* SpeciesManager::GetSpecies(const std::string& name) {
     CheckPendingSpeciesTypes();
     auto it = m_species.find(name);
-    return it != end() ? it->second.get() : nullptr;
+    return it != m_species.end() ? it->second.get() : nullptr;
 }
 
 int SpeciesManager::GetSpeciesID(const std::string& name) const {
     CheckPendingSpeciesTypes();
-    iterator it = m_species.find(name);
-    if (it == end())
+    auto it = m_species.find(name);
+    if (it == m_species.end())
         return -1;
-    return std::distance(begin(), it);
+    return std::distance(m_species.begin(), it);
 }
 
 SpeciesManager& SpeciesManager::GetSpeciesManager() {

--- a/universe/Species.h
+++ b/universe/Species.h
@@ -9,7 +9,9 @@
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/serialization/nvp.hpp>
 #include <boost/iterator/filter_iterator.hpp>
+#include <boost/optional/optional.hpp>
 
+#include <future>
 #include <map>
 #include <memory>
 #include <set>
@@ -233,7 +235,8 @@ private:
     { bool operator()(const std::map<std::string, std::unique_ptr<Species>>::value_type& species_entry) const; };
 
 public:
-    typedef std::map<std::string, std::unique_ptr<Species>>::const_iterator iterator;
+    using SpeciesTypeMap = std::map<std::string, std::unique_ptr<Species>>;
+    using iterator = SpeciesTypeMap::const_iterator;
     typedef boost::filter_iterator<PlayableSpecies, iterator>   playable_iterator;
     typedef boost::filter_iterator<NativeSpecies, iterator>     native_iterator;
 
@@ -336,6 +339,10 @@ public:
 
     std::map<std::string, std::map<int, float>>&        SpeciesObjectPopulations(int encoding_empire = ALL_EMPIRES);
     std::map<std::string, std::map<std::string, int>>&  SpeciesShipsDestroyed(int encoding_empire = ALL_EMPIRES);
+
+    /** Sets species types to the value of \p future. */
+    FO_COMMON_API void SetSpeciesTypes(std::future<SpeciesTypeMap>&& future);
+
     //@}
 
 private:
@@ -345,7 +352,14 @@ private:
       * specified in \a species_homeworld_ids */
     void    SetSpeciesHomeworlds(const std::map<std::string, std::set<int>>& species_homeworld_ids);
 
-    std::map<std::string, std::unique_ptr<Species>>     m_species;
+    /** Assigns any m_pending_types to m_species. */
+    void CheckPendingSpeciesTypes() const;
+
+    /** Future types being parsed by parser.  mutable so that it can
+        be assigned to m_species_types when completed.*/
+    mutable boost::optional<std::future<SpeciesTypeMap>> m_pending_types = boost::none;
+
+    mutable SpeciesTypeMap                              m_species;
     std::map<std::string, std::map<int, float>>         m_species_empire_opinions;
     std::map<std::string, std::map<std::string, float>> m_species_species_opinions;
 

--- a/universe/Species.h
+++ b/universe/Species.h
@@ -5,13 +5,13 @@
 #include "EnumsFwd.h"
 #include "../util/Export.h"
 #include "../util/Serialize.h"
+#include "../util/Pending.h"
 
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/serialization/nvp.hpp>
 #include <boost/iterator/filter_iterator.hpp>
 #include <boost/optional/optional.hpp>
 
-#include <future>
 #include <map>
 #include <memory>
 #include <set>
@@ -341,7 +341,7 @@ public:
     std::map<std::string, std::map<std::string, int>>&  SpeciesShipsDestroyed(int encoding_empire = ALL_EMPIRES);
 
     /** Sets species types to the value of \p future. */
-    FO_COMMON_API void SetSpeciesTypes(std::future<SpeciesTypeMap>&& future);
+    FO_COMMON_API void SetSpeciesTypes(Pending::Pending<SpeciesTypeMap>&& future);
 
     //@}
 
@@ -357,7 +357,7 @@ private:
 
     /** Future types being parsed by parser.  mutable so that it can
         be assigned to m_species_types when completed.*/
-    mutable boost::optional<std::future<SpeciesTypeMap>> m_pending_types = boost::none;
+    mutable boost::optional<Pending::Pending<SpeciesTypeMap>> m_pending_types = boost::none;
 
     mutable SpeciesTypeMap                              m_species;
     std::map<std::string, std::map<int, float>>         m_species_empire_opinions;

--- a/universe/Tech.cpp
+++ b/universe/Tech.cpp
@@ -3,7 +3,6 @@
 #include "Effect.h"
 #include "UniverseObject.h"
 #include "ObjectMap.h"
-#include "../parse/Parse.h"
 #include "../util/OptionsDB.h"
 #include "../util/Logger.h"
 #include "../util/AppInterface.h"

--- a/universe/Tech.cpp
+++ b/universe/Tech.cpp
@@ -278,16 +278,19 @@ bool operator!=(const ItemSpec& lhs, const ItemSpec& rhs)
 TechManager* TechManager::s_instance = nullptr;
 
 const Tech* TechManager::GetTech(const std::string& name) const {
+    CheckPendingTechs();
     iterator it = m_techs.get<NameIndex>().find(name);
     return it == m_techs.get<NameIndex>().end() ? nullptr : it->get();
 }
 
 const TechCategory* TechManager::GetTechCategory(const std::string& name) const {
+    CheckPendingTechs();
     auto it = m_categories.find(name);
     return it == m_categories.end() ? nullptr : it->second.get();
 }
 
 std::vector<std::string> TechManager::CategoryNames() const {
+    CheckPendingTechs();
     std::vector<std::string> retval;
     for (const auto& entry : m_categories)
         retval.push_back(entry.first);
@@ -295,6 +298,7 @@ std::vector<std::string> TechManager::CategoryNames() const {
 }
 
 std::vector<std::string> TechManager::TechNames() const {
+    CheckPendingTechs();
     std::vector<std::string> retval;
     for (const auto& tech : m_techs.get<NameIndex>())
         retval.push_back(tech->Name());
@@ -302,6 +306,7 @@ std::vector<std::string> TechManager::TechNames() const {
 }
 
 std::vector<std::string> TechManager::TechNames(const std::string& name) const {
+    CheckPendingTechs();
     std::vector<std::string> retval;
     for (TechManager::category_iterator it = category_begin(name); it != category_end(name); ++it) {
         retval.push_back((*it)->Name());
@@ -310,6 +315,7 @@ std::vector<std::string> TechManager::TechNames(const std::string& name) const {
 }
 
 std::vector<const Tech*> TechManager::AllNextTechs(const std::set<std::string>& known_techs) {
+    CheckPendingTechs();
     std::vector<const Tech*> retval;
     std::set<const Tech*> checked_techs;
     iterator end_it = m_techs.get<NameIndex>().end();
@@ -319,13 +325,16 @@ std::vector<const Tech*> TechManager::AllNextTechs(const std::set<std::string>& 
     return retval;
 }
 
-const Tech* TechManager::CheapestNextTech(const std::set<std::string>& known_techs, int empire_id)
-{ return Cheapest(AllNextTechs(known_techs), empire_id); }
+const Tech* TechManager::CheapestNextTech(const std::set<std::string>& known_techs, int empire_id) {
+    CheckPendingTechs();
+    return Cheapest(AllNextTechs(known_techs), empire_id);
+}
 
 std::vector<const Tech*> TechManager::NextTechsTowards(const std::set<std::string>& known_techs,
                                                        const std::string& desired_tech,
                                                        int empire_id)
 {
+    CheckPendingTechs();
     std::vector<const Tech*> retval;
     std::set<const Tech*> checked_techs;
     NextTechs(retval, known_techs, checked_techs, m_techs.get<NameIndex>().find(desired_tech),
@@ -338,32 +347,60 @@ const Tech* TechManager::CheapestNextTechTowards(const std::set<std::string>& kn
                                                  int empire_id)
 { return Cheapest(NextTechsTowards(known_techs, desired_tech, empire_id), empire_id); }
 
-TechManager::iterator TechManager::begin() const
-{ return m_techs.get<NameIndex>().begin(); }
+TechManager::iterator TechManager::begin() const {
+    CheckPendingTechs();
+    return m_techs.get<NameIndex>().begin();
+}
 
-TechManager::iterator TechManager::end() const
-{ return m_techs.get<NameIndex>().end(); }
+TechManager::iterator TechManager::end() const {
+    CheckPendingTechs();
+    return m_techs.get<NameIndex>().end();
+}
 
-TechManager::category_iterator TechManager::category_begin(const std::string& name) const
-{ return m_techs.get<CategoryIndex>().lower_bound(name); }
+TechManager::category_iterator TechManager::category_begin(const std::string& name) const {
+    CheckPendingTechs();
+    return m_techs.get<CategoryIndex>().lower_bound(name);
+}
 
-TechManager::category_iterator TechManager::category_end(const std::string& name) const
-{ return m_techs.get<CategoryIndex>().upper_bound(name); }
+TechManager::category_iterator TechManager::category_end(const std::string& name) const {
+    CheckPendingTechs();
+    return m_techs.get<CategoryIndex>().upper_bound(name);
+}
 
 TechManager::TechManager() {
     if (s_instance)
         throw std::runtime_error("Attempted to create more than one TechManager.");
 
-    ScopedTimer timer("TechManager Init", true, std::chrono::milliseconds(1));
+    // Only update the global pointer on sucessful construction.
+    s_instance = this;
+}
+
+void TechManager::SetTechs(std::future<TechManager::TechParseTuple>&& future)
+{ m_pending_types = std::move(future); }
+
+void TechManager::CheckPendingTechs() const {
+    if (!m_pending_types)
+        return;
+    // Only print waiting message if not immediately ready
+    while (m_pending_types->wait_for(std::chrono::seconds(1)) == std::future_status::timeout) {
+        DebugLogger() << "Waiting for Techs to parse.";
+    }
 
     std::set<std::string> categories_seen_in_techs;
 
+    auto copy_categories = m_categories;
+    auto copy_techs = m_techs;
     try {
-        std::tie(m_techs, m_categories, categories_seen_in_techs) = parse::techs();
+        std::tie(m_techs, m_categories, categories_seen_in_techs) = std::move(m_pending_types->get());
     } catch (const std::exception& e) {
-        ErrorLogger() << "Failed parsing techs: error: " << e.what();
-        throw e;
+        ErrorLogger() << "Parsing techs failed with error: " << e.what();
+        m_pending_types = boost::none;
+        m_categories = copy_categories;
+        m_techs = copy_techs;
+        return;
     }
+
+    m_pending_types = boost::none;
 
     std::set<std::string> empty_defined_categories;
     for (const auto& map : m_categories) {
@@ -423,17 +460,15 @@ TechManager::TechManager() {
 
 #ifdef OUTPUT_TECH_LIST
     for (const Tech* tech : m_techs.get<NameIndex>()) {
-        std::cerr << UserString(tech->Name()) << " (" 
+        std::cerr << UserString(tech->Name()) << " ("
                   << UserString(tech->Category()) << ") - "
                   << tech->Graphic() << std::endl;
     }
 #endif
-
-    // Only update the global pointer on sucessful construction.
-    s_instance = this;
 }
 
-std::string TechManager::FindIllegalDependencies() {
+std::string TechManager::FindIllegalDependencies() const {
+    CheckPendingTechs();
     assert(!m_techs.empty());
     std::string retval;
     for (const auto& tech : m_techs) {
@@ -455,7 +490,8 @@ std::string TechManager::FindIllegalDependencies() {
     return retval;
 }
 
-std::string TechManager::FindFirstDependencyCycle() {
+std::string TechManager::FindFirstDependencyCycle() const {
+    CheckPendingTechs();
     assert(!m_techs.empty());
     static const std::set<std::string> EMPTY_STRING_SET;    // used in case an invalid tech is processed
 
@@ -511,7 +547,8 @@ std::string TechManager::FindFirstDependencyCycle() {
     return "";
 }
 
-std::string TechManager::FindRedundantDependency() {
+std::string TechManager::FindRedundantDependency() const {
+    CheckPendingTechs();
     assert(!m_techs.empty());
 
     for (const auto& tech : m_techs) {
@@ -547,7 +584,7 @@ std::string TechManager::FindRedundantDependency() {
     return "";
 }
 
-void TechManager::AllChildren(const Tech* tech, std::map<std::string, std::string>& children) {
+void TechManager::AllChildren(const Tech* tech, std::map<std::string, std::string>& children) const {
     for (const std::string& unlocked_tech : tech->UnlockedTechs()) {
         if (unlocked_tech == tech->Name()) {
             // infinite loop
@@ -609,6 +646,7 @@ std::vector<std::string> TechManager::RecursivePrereqs(const std::string& tech_n
 }
 
 unsigned int TechManager::GetCheckSum() const {
+    CheckPendingTechs();
     unsigned int retval{0};
     for (auto const& name_type_pair : m_categories)
         CheckSums::CheckSumCombine(retval, name_type_pair);

--- a/universe/Tech.h
+++ b/universe/Tech.h
@@ -5,6 +5,7 @@
 
 #include "EnumsFwd.h"
 #include "../util/Export.h"
+#include "../util/Pending.h"
 
 #include <boost/multi_index_container.hpp>
 #include <boost/multi_index/key_extractors.hpp>
@@ -16,7 +17,6 @@
 #include <string>
 #include <vector>
 #include <map>
-#include <future>
 
 #include <GG/Clr.h>
 
@@ -307,7 +307,7 @@ public:
         std::set<std::string> // categories_seen
         >;
         /** Sets types to the value of \p future. */
-    FO_COMMON_API void SetTechs(std::future<TechParseTuple>&& future);
+    FO_COMMON_API void SetTechs(Pending::Pending<TechParseTuple>&& future);
 
 
     /** returns the instance of this singleton class; you should use the free function GetTechManager() instead */
@@ -335,7 +335,7 @@ private:
 
     /** Future types being parsed by parser.  mutable so that it can
         be assigned to m_species_types when completed.*/
-    mutable boost::optional<std::future<TechParseTuple>> m_pending_types = boost::none;
+    mutable boost::optional<Pending::Pending<TechParseTuple>> m_pending_types = boost::none;
 
     mutable TechCategoryMap                         m_categories;
     mutable TechContainer                           m_techs;

--- a/universe/Tech.h
+++ b/universe/Tech.h
@@ -306,7 +306,7 @@ public:
         std::map<std::string, std::unique_ptr<TechCategory>>, // tech_categories,
         std::set<std::string> // categories_seen
         >;
-        /** Sets types to the value of \p future. */
+    /** Sets types to the value of \p future. */
     FO_COMMON_API void SetTechs(Pending::Pending<TechParseTuple>&& future);
 
 

--- a/universe/Tech.h
+++ b/universe/Tech.h
@@ -10,11 +10,13 @@
 #include <boost/multi_index/key_extractors.hpp>
 #include <boost/multi_index/ordered_index.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
+#include <boost/optional/optional.hpp>
 
 #include <set>
 #include <string>
 #include <vector>
 #include <map>
+#include <future>
 
 #include <GG/Clr.h>
 
@@ -22,7 +24,6 @@ namespace Effect
 { class EffectsGroup; }
 class TechManager;
 struct ItemSpec;
-
 
 /** encasulates the data for a single FreeOrion technology */
 class FO_COMMON_API Tech {
@@ -234,6 +235,8 @@ public:
         >
     > TechContainer;
 
+    using TechCategoryMap = std::map<std::string, std::unique_ptr<TechCategory>>;
+
     /** iterator that runs over techs within a category */
     typedef TechContainer::index<CategoryIndex>::type::const_iterator category_iterator;
 
@@ -298,28 +301,44 @@ public:
     unsigned int                    GetCheckSum() const;
     //@}
 
+    using TechParseTuple = std::tuple<
+        TechManager::TechContainer, // techs_
+        std::map<std::string, std::unique_ptr<TechCategory>>, // tech_categories,
+        std::set<std::string> // categories_seen
+        >;
+        /** Sets types to the value of \p future. */
+    FO_COMMON_API void SetTechs(std::future<TechParseTuple>&& future);
+
+
     /** returns the instance of this singleton class; you should use the free function GetTechManager() instead */
     static TechManager& GetTechManager();
 
 private:
     TechManager();
 
+    /** Assigns any m_pending_types to m_specials. */
+    void CheckPendingTechs() const;
+
     /** returns an error string indicating the first instance of an illegal prerequisite relationship between
         two techs in m_techs, or an empty string if there are no illegal dependencies  */
-    std::string FindIllegalDependencies();
+    std::string FindIllegalDependencies() const;
 
     /** returns an error string indicating the first prerequisite dependency cycle found in m_techs, or an
         empty string if there are no dependency cycles */
-    std::string FindFirstDependencyCycle();
+    std::string FindFirstDependencyCycle() const;
 
     /** returns an error string indicating the first instance of a redundant dependency, or an empty string if there
         are no redundant dependencies.  An example of a redundant dependency is A --> C, if A --> B and B --> C. */
-    std::string FindRedundantDependency();
+    std::string FindRedundantDependency() const;
 
-    void AllChildren(const Tech* tech, std::map<std::string, std::string>& children);
+    void AllChildren(const Tech* tech, std::map<std::string, std::string>& children) const;
 
-    std::map<std::string, std::unique_ptr<TechCategory>> m_categories;
-    TechContainer                           m_techs;
+    /** Future types being parsed by parser.  mutable so that it can
+        be assigned to m_species_types when completed.*/
+    mutable boost::optional<std::future<TechParseTuple>> m_pending_types = boost::none;
+
+    mutable TechCategoryMap                         m_categories;
+    mutable TechContainer                           m_techs;
 
     static TechManager*                     s_instance;
 };

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -8,7 +8,6 @@
 #include "../util/ScopedTimer.h"
 #include "../util/CheckSums.h"
 #include "../util/MultiplayerCommon.h"
-#include "../parse/Parse.h"
 #include "../Empire/Empire.h"
 #include "../Empire/EmpireManager.h"
 #include "IDAllocator.h"

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -188,7 +188,7 @@ const std::vector<FleetPlan*>& Universe::InitiallyUnlockedFleetPlans() const
 void Universe::SetMonsterFleetPlans(Pending::Pending<std::vector<MonsterFleetPlan*>>&& future)
 { m_pending_monster_fleet_plans = std::move(future); }
 
-const std::vector<MonsterFleetPlan*>&  Universe::MonsterFleetPlans() const
+const std::vector<MonsterFleetPlan*>& Universe::MonsterFleetPlans() const
 { return Pending::SwapPending(m_pending_monster_fleet_plans, m_monster_fleet_plans); }
 
 void Universe::SetEmpireStats(Pending::Pending<EmpireStatsMap> future)

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -87,22 +87,6 @@ namespace boost {
 
 extern FO_COMMON_API const int ALL_EMPIRES            = -1;
 
-namespace EmpireStatistics {
-    const std::map<std::string, ValueRef::ValueRefBase<double>*>& GetEmpireStats() {
-        static std::map<std::string, ValueRef::ValueRefBase<double>*> s_stats;
-        if (s_stats.empty()) {
-            try {
-                s_stats = parse::statistics();
-            } catch (const std::exception& e) {
-                ErrorLogger() << "Failed parsing empire statistics: error: " << e.what();
-                throw e;
-            }
-        }
-        return s_stats;
-    }
-}
-
-
 /////////////////////////////////////////////
 // class Universe
 /////////////////////////////////////////////
@@ -249,6 +233,13 @@ void Universe::SetMonsterFleetPlans(std::future<std::vector<MonsterFleetPlan*>>&
 
 const std::vector<MonsterFleetPlan*>&  Universe::MonsterFleetPlans() const
 { return SwapPendingParsed(m_pending_monster_fleet_plans, m_monster_fleet_plans); }
+
+void Universe::SetEmpireStats(std::future<EmpireStatsMap> future)
+{ m_pending_empire_stats = std::move(future); }
+
+const Universe::EmpireStatsMap& Universe::EmpireStats() const
+{ return SwapPendingParsed(m_pending_empire_stats, m_empire_stats); }
+
 
 const ObjectMap& Universe::EmpireKnownObjects(int empire_id) const {
     if (empire_id == ALL_EMPIRES)
@@ -2926,7 +2917,7 @@ void Universe::UpdateStatRecords() {
     }
 
     // process each stat
-    for (const auto& stat_entry : EmpireStatistics::GetEmpireStats()) {
+    for (const auto& stat_entry : EmpireStats()) {
         const std::string& stat_name = stat_entry.first;
 
         const ValueRef::ValueRefBase<double>* value_ref = stat_entry.second;

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -19,6 +19,7 @@
 #include "System.h"
 #include "Field.h"
 #include "UniverseObject.h"
+#include "UniverseGenerator.h"
 #include "Effect.h"
 #include "Predicates.h"
 #include "Special.h"
@@ -119,6 +120,13 @@ Universe::Universe() :
 
 Universe::~Universe() {
     Clear();
+
+    for (auto& fleet : m_unlocked_fleet_plans)
+        delete fleet;
+    for (auto& fleet : m_monster_fleet_plans)
+        delete fleet;
+    for (auto& stat : m_empire_stats)
+        delete stat.second;
 }
 
 void Universe::Clear() {
@@ -174,6 +182,73 @@ void Universe::ResetAllIDAllocation(const std::vector<int>& empire_ids) {
     DebugLogger() << "Reset id allocators with highest object id = " << highest_allocated_id
                   << " and highest design id = " << highest_allocated_design_id;
 }
+
+namespace {
+    /** Wait for the \p pending parse to complete.  Return boost::none on errors.*/
+    template <typename T>
+    boost::optional<T> WaitForParse(boost::optional<std::future<T>>& pending) {
+        if (!pending)
+            return boost::none;
+
+        std::future_status status;
+        do {
+            status = pending->wait_for(std::chrono::seconds(1));
+            if (status == std::future_status::timeout)
+                DebugLogger() << "Waiting for parse to complete.";
+
+            if (status == std::future_status::deferred) {
+                ErrorLogger() << "Unable to handle deferred future.";
+                throw "deferred future not handled";
+            }
+
+        } while (status != std::future_status::ready);
+
+        try {
+            auto x = std::move(pending->get());
+            pending = boost::none;
+            return x;
+        } catch (const std::exception& e) {
+            ErrorLogger() << "Parsing failed with error: " << e.what();
+        }
+
+        return boost::none;
+    }
+
+    /** If there is a pending parse, wait for it and swap it with the stored
+        value.  Return the stored value.*/
+    template <typename T>
+    T& SwapPendingParsed(boost::optional<std::future<T>>& pending, T& stored) {
+        if (auto tt = WaitForParse(pending))
+            std::swap(*tt, stored);
+        return stored;
+    }
+}
+
+void Universe::SetInitiallyUnlockedItems(std::future<std::vector<ItemSpec>>&& future)
+{ m_pending_items = std::move(future); }
+
+const std::vector<ItemSpec>& Universe::InitiallyUnlockedItems() const
+{ return SwapPendingParsed(m_pending_items, m_unlocked_items); }
+
+void Universe::SetInitiallyUnlockedBuildings(std::future<std::vector<ItemSpec>>&& future)
+{ m_pending_buildings = std::move(future); }
+
+const std::vector<ItemSpec>& Universe::InitiallyUnlockedBuildings() const
+{ return SwapPendingParsed(m_pending_buildings, m_unlocked_buildings); }
+
+void Universe::SetInitiallyUnlockedFleetPlans(std::future<std::vector<FleetPlan*>>&& future)
+{ m_pending_fleet_plans = std::move(future);
+    DebugLogger() << "MXX fleet plans blanged";
+}
+
+const std::vector<FleetPlan*>& Universe::InitiallyUnlockedFleetPlans() const
+{ return SwapPendingParsed(m_pending_fleet_plans, m_unlocked_fleet_plans); }
+
+void Universe::SetMonsterFleetPlans(std::future<std::vector<MonsterFleetPlan*>>&& future)
+{ m_pending_monster_fleet_plans = std::move(future); }
+
+const std::vector<MonsterFleetPlan*>&  Universe::MonsterFleetPlans() const
+{ return SwapPendingParsed(m_pending_monster_fleet_plans, m_monster_fleet_plans); }
 
 const ObjectMap& Universe::EmpireKnownObjects(int empire_id) const {
     if (empire_id == ALL_EMPIRES)

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -24,6 +24,7 @@
 #include "Predicates.h"
 #include "Special.h"
 #include "Species.h"
+#include "Tech.h"
 #include "Condition.h"
 #include "ValueRef.h"
 #include "Enums.h"

--- a/universe/Universe.h
+++ b/universe/Universe.h
@@ -408,22 +408,22 @@ public:
     /** Set items unlocked before turn 1 from \p future.*/
     void SetInitiallyUnlockedItems(Pending::Pending<std::vector<ItemSpec>>&& future);
     /** Items unlocked before turn 1.*/
-    const std::vector<ItemSpec>&  InitiallyUnlockedItems() const;
+    const std::vector<ItemSpec>& InitiallyUnlockedItems() const;
 
     /** Set buildings unlocked before turn 1 from \p future.*/
     void SetInitiallyUnlockedBuildings(Pending::Pending<std::vector<ItemSpec>>&& future);
     /** Buildings unlocked before turn 1.*/
-    const std::vector<ItemSpec>&  InitiallyUnlockedBuildings() const;
+    const std::vector<ItemSpec>& InitiallyUnlockedBuildings() const;
 
     /** Set fleets unlocked before turn 1 from \p future.*/
     void SetInitiallyUnlockedFleetPlans(Pending::Pending<std::vector<FleetPlan*>>&& future);
     /** Fleets unlocked before turn 1.*/
-    const std::vector<FleetPlan*>&  InitiallyUnlockedFleetPlans() const;
+    const std::vector<FleetPlan*>& InitiallyUnlockedFleetPlans() const;
 
     /** Set items unlocked before turn 1 from \p future..*/
     void SetMonsterFleetPlans(Pending::Pending<std::vector<MonsterFleetPlan*>>&& future);
     /** Items unlocked before turn 1.*/
-    const std::vector<MonsterFleetPlan*>&  MonsterFleetPlans() const;
+    const std::vector<MonsterFleetPlan*>& MonsterFleetPlans() const;
 
     /** Set the empire stats from \p future. */
     using EmpireStatsMap = std::map<std::string, ValueRef::ValueRefBase<double>*>;

--- a/universe/Universe.h
+++ b/universe/Universe.h
@@ -6,6 +6,7 @@
 #include "ValueRefFwd.h"
 #include "ObjectMap.h"
 #include "UniverseObject.h"
+#include "../util/Pending.h"
 
 #include <boost/signals2/signal.hpp>
 // Fix for issue #1513 (boost ticket #12978)
@@ -24,7 +25,6 @@
 #include <set>
 #include <string>
 #include <vector>
-#include <future>
 
 #include "../util/Export.h"
 
@@ -68,7 +68,6 @@ namespace boost {
 }
 #  endif
 #endif
-
 
 /** The Universe class contains the majority of FreeOrion gamestate: All the
   * UniverseObjects in a game, and (of less importance) all ShipDesigns in a
@@ -407,28 +406,28 @@ public:
     //@}
 
     /** Set items unlocked before turn 1 from \p future.*/
-    void SetInitiallyUnlockedItems(std::future<std::vector<ItemSpec>>&& future);
+    void SetInitiallyUnlockedItems(Pending::Pending<std::vector<ItemSpec>>&& future);
     /** Items unlocked before turn 1.*/
     const std::vector<ItemSpec>&  InitiallyUnlockedItems() const;
 
     /** Set buildings unlocked before turn 1 from \p future.*/
-    void SetInitiallyUnlockedBuildings(std::future<std::vector<ItemSpec>>&& future);
+    void SetInitiallyUnlockedBuildings(Pending::Pending<std::vector<ItemSpec>>&& future);
     /** Buildings unlocked before turn 1.*/
     const std::vector<ItemSpec>&  InitiallyUnlockedBuildings() const;
 
     /** Set fleets unlocked before turn 1 from \p future.*/
-    void SetInitiallyUnlockedFleetPlans(std::future<std::vector<FleetPlan*>>&& future);
+    void SetInitiallyUnlockedFleetPlans(Pending::Pending<std::vector<FleetPlan*>>&& future);
     /** Fleets unlocked before turn 1.*/
     const std::vector<FleetPlan*>&  InitiallyUnlockedFleetPlans() const;
 
     /** Set items unlocked before turn 1 from \p future..*/
-    void SetMonsterFleetPlans(std::future<std::vector<MonsterFleetPlan*>>&& future);
+    void SetMonsterFleetPlans(Pending::Pending<std::vector<MonsterFleetPlan*>>&& future);
     /** Items unlocked before turn 1.*/
     const std::vector<MonsterFleetPlan*>&  MonsterFleetPlans() const;
 
     /** Set the empire stats from \p future. */
     using EmpireStatsMap = std::map<std::string, ValueRef::ValueRefBase<double>*>;
-    void SetEmpireStats(std::future<EmpireStatsMap> future);
+    void SetEmpireStats(Pending::Pending<EmpireStatsMap> future);
 private:
     const EmpireStatsMap& EmpireStats() const;
 public:
@@ -529,14 +528,14 @@ private:
                                     m_stat_records;                     ///< storage for statistics calculated for empires. Indexed by stat name (string), contains a map indexed by empire id, contains a map from turn number (int) to stat value (double).
 
     /** @name Parsed items
-        Various unlocked items are kept as a std::future while being parsed and
+        Various unlocked items are kept as a Pending::Pending while being parsed and
         then transfered.  They are mutable to allow processing in const accessors. */
     ///@{
-    mutable boost::optional<std::future<std::vector<ItemSpec>>> m_pending_items = boost::none;
-    mutable boost::optional<std::future<std::vector<ItemSpec>>> m_pending_buildings = boost::none;
-    mutable boost::optional<std::future<std::vector<FleetPlan*>>> m_pending_fleet_plans = boost::none;
-    mutable boost::optional<std::future<std::vector<MonsterFleetPlan*>>> m_pending_monster_fleet_plans = boost::none;
-    mutable boost::optional<std::future<EmpireStatsMap>> m_pending_empire_stats = boost::none;
+    mutable boost::optional<Pending::Pending<std::vector<ItemSpec>>> m_pending_items = boost::none;
+    mutable boost::optional<Pending::Pending<std::vector<ItemSpec>>> m_pending_buildings = boost::none;
+    mutable boost::optional<Pending::Pending<std::vector<FleetPlan*>>> m_pending_fleet_plans = boost::none;
+    mutable boost::optional<Pending::Pending<std::vector<MonsterFleetPlan*>>> m_pending_monster_fleet_plans = boost::none;
+    mutable boost::optional<Pending::Pending<EmpireStatsMap>> m_pending_empire_stats = boost::none;
 
     mutable std::vector<ItemSpec> m_unlocked_items;
     mutable std::vector<ItemSpec> m_unlocked_buildings;

--- a/universe/Universe.h
+++ b/universe/Universe.h
@@ -23,6 +23,7 @@
 #include <set>
 #include <string>
 #include <vector>
+#include <future>
 
 #include "../util/Export.h"
 
@@ -34,6 +35,10 @@ class ShipDesign;
 class System;
 class Pathfinder;
 class IDAllocator;
+struct ItemSpec;
+class FleetPlan;
+class MonsterFleetPlan;
+
 
 namespace Condition {
     struct ConditionBase;
@@ -400,6 +405,25 @@ public:
     }
     //@}
 
+    /** Set items unlocked before turn 1 from \p future.*/
+    void SetInitiallyUnlockedItems(std::future<std::vector<ItemSpec>>&& future);
+    /** Items unlocked before turn 1.*/
+    const std::vector<ItemSpec>&  InitiallyUnlockedItems() const;
+
+    /** Set buildings unlocked before turn 1 from \p future.*/
+    void SetInitiallyUnlockedBuildings(std::future<std::vector<ItemSpec>>&& future);
+    /** Buildings unlocked before turn 1.*/
+    const std::vector<ItemSpec>&  InitiallyUnlockedBuildings() const;
+
+    /** Set fleets unlocked before turn 1 from \p future.*/
+    void SetInitiallyUnlockedFleetPlans(std::future<std::vector<FleetPlan*>>&& future);
+    /** Fleets unlocked before turn 1.*/
+    const std::vector<FleetPlan*>&  InitiallyUnlockedFleetPlans() const;
+
+    /** Set items unlocked before turn 1 from \p future..*/
+    void SetMonsterFleetPlans(std::future<std::vector<MonsterFleetPlan*>>&& future);
+    /** Items unlocked before turn 1.*/
+    const std::vector<MonsterFleetPlan*>&  MonsterFleetPlans() const;
     /** ObfuscateIDGenerator applies randomization to the IDAllocator to prevent clients from
         inferring too much information about other client's id generation activities. */
     void ObfuscateIDGenerator();
@@ -494,6 +518,21 @@ private:
 
     std::map<std::string, std::map<int, std::map<int, double>>>
                                     m_stat_records;                     ///< storage for statistics calculated for empires. Indexed by stat name (string), contains a map indexed by empire id, contains a map from turn number (int) to stat value (double).
+
+    /** @name Parsed items
+        Various unlocked items are kept as a std::future while being parsed and
+        then transfered.  They are mutable to allow processing in const accessors. */
+    ///@{
+    mutable boost::optional<std::future<std::vector<ItemSpec>>> m_pending_items = boost::none;
+    mutable boost::optional<std::future<std::vector<ItemSpec>>> m_pending_buildings = boost::none;
+    mutable boost::optional<std::future<std::vector<FleetPlan*>>> m_pending_fleet_plans = boost::none;
+    mutable boost::optional<std::future<std::vector<MonsterFleetPlan*>>> m_pending_monster_fleet_plans = boost::none;
+
+    mutable std::vector<ItemSpec> m_unlocked_items;
+    mutable std::vector<ItemSpec> m_unlocked_buildings;
+    mutable std::vector<FleetPlan*> m_unlocked_fleet_plans;
+    mutable std::vector<MonsterFleetPlan*> m_monster_fleet_plans;
+    ///@}
 
     /** Fills \a designs_to_serialize with ShipDesigns known to the empire with
       * the ID \a encoding empire.  If encoding_empire is ALL_EMPIRES, then all

--- a/universe/Universe.h
+++ b/universe/Universe.h
@@ -3,6 +3,7 @@
 
 
 #include "EnumsFwd.h"
+#include "ValueRefFwd.h"
 #include "ObjectMap.h"
 #include "UniverseObject.h"
 
@@ -424,6 +425,14 @@ public:
     void SetMonsterFleetPlans(std::future<std::vector<MonsterFleetPlan*>>&& future);
     /** Items unlocked before turn 1.*/
     const std::vector<MonsterFleetPlan*>&  MonsterFleetPlans() const;
+
+    /** Set the empire stats from \p future. */
+    using EmpireStatsMap = std::map<std::string, ValueRef::ValueRefBase<double>*>;
+    void SetEmpireStats(std::future<EmpireStatsMap> future);
+private:
+    const EmpireStatsMap& EmpireStats() const;
+public:
+
     /** ObfuscateIDGenerator applies randomization to the IDAllocator to prevent clients from
         inferring too much information about other client's id generation activities. */
     void ObfuscateIDGenerator();
@@ -527,11 +536,13 @@ private:
     mutable boost::optional<std::future<std::vector<ItemSpec>>> m_pending_buildings = boost::none;
     mutable boost::optional<std::future<std::vector<FleetPlan*>>> m_pending_fleet_plans = boost::none;
     mutable boost::optional<std::future<std::vector<MonsterFleetPlan*>>> m_pending_monster_fleet_plans = boost::none;
+    mutable boost::optional<std::future<EmpireStatsMap>> m_pending_empire_stats = boost::none;
 
     mutable std::vector<ItemSpec> m_unlocked_items;
     mutable std::vector<ItemSpec> m_unlocked_buildings;
     mutable std::vector<FleetPlan*> m_unlocked_fleet_plans;
     mutable std::vector<MonsterFleetPlan*> m_monster_fleet_plans;
+    mutable EmpireStatsMap m_empire_stats;
     ///@}
 
     /** Fills \a designs_to_serialize with ShipDesigns known to the empire with

--- a/universe/UniverseGenerator.cpp
+++ b/universe/UniverseGenerator.cpp
@@ -4,7 +4,6 @@
 #include "../util/Random.h"
 #include "../util/i18n.h"
 #include "../util/Logger.h"
-#include "../parse/Parse.h"
 #include "../Empire/Empire.h"
 #include "../Empire/EmpireManager.h"
 

--- a/util/AppInterface.cpp
+++ b/util/AppInterface.cpp
@@ -9,6 +9,7 @@
 #include "../universe/Tech.h"
 #include "../util/Directories.h"
 #include "../util/MultiplayerCommon.h"
+#include "../util/Pending.h"
 
 #include <boost/filesystem.hpp>
 
@@ -45,26 +46,19 @@ int IApp::MAX_AI_PLAYERS() {
     return max_number_AIs;
 }
 
-namespace {
-    template <typename ParserFunc>
-    auto StartParsing(const ParserFunc& parser, const boost::filesystem::path& subdir)
-        -> std::future<decltype(parser(subdir))>
-    {
-        return std::async(std::launch::async, parser, subdir);
-    }
-}
-
 void IApp::ParseUniverseObjectTypes() {
     const auto& rdir = GetResourceDir();
-    GetBuildingTypeManager().SetBuildingTypes(StartParsing(parse::buildings, rdir / "scripting/buildings"));
-    GetEncyclopedia().SetArticles(StartParsing(parse::encyclopedia_articles, rdir / "scripting/encyclopedia"));
-    GetFieldTypeManager().SetFieldTypes(StartParsing(parse::fields, rdir / "scripting/fields"));
-    GetSpecialsManager().SetSpecialsTypes(StartParsing(parse::specials, rdir / "scripting/specials"));
-    GetSpeciesManager().SetSpeciesTypes(StartParsing(parse::species, rdir / "scripting/species"));
-    GetPartTypeManager().SetPartTypes(StartParsing(parse::ship_parts, rdir / "scripting/ship_parts"));
-    GetHullTypeManager().SetHullTypes(StartParsing(parse::ship_hulls, rdir / "scripting/ship_hulls"));
-    GetPredefinedShipDesignManager().SetShipDesignTypes(StartParsing(parse::ship_designs, rdir / "scripting/ship_designs"));
-    GetPredefinedShipDesignManager().SetMonsterDesignTypes(StartParsing(parse::ship_designs, rdir / "scripting/monster_designs"));
-    GetGameRules().Add(StartParsing(parse::game_rules, rdir / "scripting/game_rules.focs.txt"));
-    GetTechManager().SetTechs(StartParsing(parse::techs<TechManager::TechParseTuple>, rdir / "scripting/techs"));
+    GetBuildingTypeManager().SetBuildingTypes(Pending::StartParsing(parse::buildings, rdir / "scripting/buildings"));
+    GetEncyclopedia().SetArticles(Pending::StartParsing(parse::encyclopedia_articles, rdir / "scripting/encyclopedia"));
+    GetFieldTypeManager().SetFieldTypes(Pending::StartParsing(parse::fields, rdir / "scripting/fields"));
+    GetSpecialsManager().SetSpecialsTypes(Pending::StartParsing(parse::specials, rdir / "scripting/specials"));
+    GetSpeciesManager().SetSpeciesTypes(Pending::StartParsing(parse::species, rdir / "scripting/species"));
+    GetPartTypeManager().SetPartTypes(Pending::StartParsing(parse::ship_parts, rdir / "scripting/ship_parts"));
+    GetHullTypeManager().SetHullTypes(Pending::StartParsing(parse::ship_hulls, rdir / "scripting/ship_hulls"));
+    GetPredefinedShipDesignManager().SetShipDesignTypes(
+        Pending::StartParsing(parse::ship_designs, rdir / "scripting/ship_designs"));
+    GetPredefinedShipDesignManager().SetMonsterDesignTypes(
+        Pending::StartParsing(parse::ship_designs, rdir / "scripting/monster_designs"));
+    GetGameRules().Add(Pending::StartParsing(parse::game_rules, rdir / "scripting/game_rules.focs.txt"));
+    GetTechManager().SetTechs(Pending::StartParsing(parse::techs<TechManager::TechParseTuple>, rdir / "scripting/techs"));
 }

--- a/util/AppInterface.cpp
+++ b/util/AppInterface.cpp
@@ -46,10 +46,11 @@ namespace {
 }
 
 void IApp::ParseUniverseObjectTypes() {
-    GetEncyclopedia().SetArticles(StartParsing(parse::encyclopedia_articles));
     GetBuildingTypeManager().SetBuildingTypes(StartParsing(parse::buildings));
+    GetEncyclopedia().SetArticles(StartParsing(parse::encyclopedia_articles));
     GetFieldTypeManager().SetFieldTypes(StartParsing(parse::fields));
     GetSpecialsManager().SetSpecialsTypes(StartParsing(parse::specials));
     GetSpeciesManager().SetSpeciesTypes(StartParsing(parse::species));
     GetTechManager().SetTechs(StartParsing(parse::techs));
+    GetPartTypeManager().SetPartTypes(StartParsing(parse::ship_parts));
 }

--- a/util/AppInterface.cpp
+++ b/util/AppInterface.cpp
@@ -53,4 +53,5 @@ void IApp::ParseUniverseObjectTypes() {
     GetSpeciesManager().SetSpeciesTypes(StartParsing(parse::species));
     GetTechManager().SetTechs(StartParsing(parse::techs));
     GetPartTypeManager().SetPartTypes(StartParsing(parse::ship_parts));
+    GetHullTypeManager().SetHullTypes(StartParsing(parse::ship_hulls));
 }

--- a/util/AppInterface.cpp
+++ b/util/AppInterface.cpp
@@ -43,12 +43,6 @@ namespace {
 }
 
 void IApp::ParseUniverseObjectTypes() {
-    auto pending_articles = std::async(std::launch::async, []{
-            return parse::encyclopedia_articles();});
-    GetEncyclopedia().SetArticles(std::move(pending_articles));
-
-    auto pending_building_types = std::async(std::launch::async, [] {
-            return parse::buildings();});
-    GetBuildingTypeManager().SetBuildingTypes(std::move(pending_building_types));
-
+    GetEncyclopedia().SetArticles(StartParsing(parse::encyclopedia_articles));
+    GetBuildingTypeManager().SetBuildingTypes(StartParsing(parse::buildings));
 }

--- a/util/AppInterface.cpp
+++ b/util/AppInterface.cpp
@@ -6,6 +6,7 @@
 #include "../universe/Field.h"
 #include "../universe/Special.h"
 #include "../universe/Species.h"
+#include "../util/MultiplayerCommon.h"
 
 #include <boost/filesystem.hpp>
 
@@ -65,5 +66,5 @@ void IApp::ParseUniverseObjectTypes() {
     GetHullTypeManager().SetHullTypes(StartParsing(parse::ship_hulls));
     GetPredefinedShipDesignManager().SetShipDesignTypes(StartParsing2(parse::ship_designs, "scripting/ship_designs"));
     GetPredefinedShipDesignManager().SetMonsterDesignTypes(StartParsing2(parse::ship_designs, "scripting/monster_designs"));
-
+    GetGameRules().Add(StartParsing(parse::game_rules));
 }

--- a/util/AppInterface.cpp
+++ b/util/AppInterface.cpp
@@ -4,6 +4,7 @@
 #include "../universe/Building.h"
 #include "../universe/Encyclopedia.h"
 #include "../universe/Field.h"
+#include "../universe/Species.h"
 
 #include <future>
 
@@ -47,4 +48,5 @@ void IApp::ParseUniverseObjectTypes() {
     GetEncyclopedia().SetArticles(StartParsing(parse::encyclopedia_articles));
     GetBuildingTypeManager().SetBuildingTypes(StartParsing(parse::buildings));
     GetFieldTypeManager().SetFieldTypes(StartParsing(parse::fields));
+    GetSpeciesManager().SetSpeciesTypes(StartParsing(parse::species));
 }

--- a/util/AppInterface.cpp
+++ b/util/AppInterface.cpp
@@ -35,6 +35,13 @@ int IApp::MAX_AI_PLAYERS() {
     return max_number_AIs;
 }
 
+namespace {
+    template <typename ParserFunc>
+    auto StartParsing(const ParserFunc& parser) -> std::future<decltype(parser())> {
+        return std::async(std::launch::async, parser);
+    }
+}
+
 void IApp::ParseUniverseObjectTypes() {
     auto pending_articles = std::async(std::launch::async, []{
             return parse::encyclopedia_articles();});

--- a/util/AppInterface.cpp
+++ b/util/AppInterface.cpp
@@ -51,4 +51,5 @@ void IApp::ParseUniverseObjectTypes() {
     GetFieldTypeManager().SetFieldTypes(StartParsing(parse::fields));
     GetSpecialsManager().SetSpecialsTypes(StartParsing(parse::specials));
     GetSpeciesManager().SetSpeciesTypes(StartParsing(parse::species));
+    GetTechManager().SetTechs(StartParsing(parse::techs));
 }

--- a/util/AppInterface.cpp
+++ b/util/AppInterface.cpp
@@ -2,6 +2,7 @@
 
 #include "../parse/Parse.h"
 #include "../universe/Building.h"
+#include "../universe/Encyclopedia.h"
 
 #include <future>
 
@@ -35,9 +36,12 @@ int IApp::MAX_AI_PLAYERS() {
 }
 
 void IApp::ParseUniverseObjectTypes() {
+    auto pending_articles = std::async(std::launch::async, []{
+            return parse::encyclopedia_articles();});
+    GetEncyclopedia().SetArticles(std::move(pending_articles));
+
     auto pending_building_types = std::async(std::launch::async, [] {
-            return parse::buildings();
-        });
+            return parse::buildings();});
     GetBuildingTypeManager().SetBuildingTypes(std::move(pending_building_types));
 
 }

--- a/util/AppInterface.cpp
+++ b/util/AppInterface.cpp
@@ -4,6 +4,7 @@
 #include "../universe/Building.h"
 #include "../universe/Encyclopedia.h"
 #include "../universe/Field.h"
+#include "../universe/Special.h"
 #include "../universe/Species.h"
 
 #include <future>
@@ -48,5 +49,6 @@ void IApp::ParseUniverseObjectTypes() {
     GetEncyclopedia().SetArticles(StartParsing(parse::encyclopedia_articles));
     GetBuildingTypeManager().SetBuildingTypes(StartParsing(parse::buildings));
     GetFieldTypeManager().SetFieldTypes(StartParsing(parse::fields));
+    GetSpecialsManager().SetSpecialsTypes(StartParsing(parse::specials));
     GetSpeciesManager().SetSpeciesTypes(StartParsing(parse::species));
 }

--- a/util/AppInterface.cpp
+++ b/util/AppInterface.cpp
@@ -6,12 +6,15 @@
 #include "../universe/Field.h"
 #include "../universe/Special.h"
 #include "../universe/Species.h"
+#include "../universe/Tech.h"
 #include "../util/Directories.h"
 #include "../util/MultiplayerCommon.h"
 
 #include <boost/filesystem.hpp>
 
 #include <future>
+
+extern template TechManager::TechParseTuple parse::techs<TechManager::TechParseTuple>(const boost::filesystem::path& path);
 
 const int INVALID_GAME_TURN = -(2 << 15) + 1;
 const int BEFORE_FIRST_TURN = -(2 << 14);
@@ -58,10 +61,10 @@ void IApp::ParseUniverseObjectTypes() {
     GetFieldTypeManager().SetFieldTypes(StartParsing(parse::fields, rdir / "scripting/fields"));
     GetSpecialsManager().SetSpecialsTypes(StartParsing(parse::specials, rdir / "scripting/specials"));
     GetSpeciesManager().SetSpeciesTypes(StartParsing(parse::species, rdir / "scripting/species"));
-    GetTechManager().SetTechs(StartParsing(parse::techs, rdir / "scripting/techs"));
     GetPartTypeManager().SetPartTypes(StartParsing(parse::ship_parts, rdir / "scripting/ship_parts"));
     GetHullTypeManager().SetHullTypes(StartParsing(parse::ship_hulls, rdir / "scripting/ship_hulls"));
     GetPredefinedShipDesignManager().SetShipDesignTypes(StartParsing(parse::ship_designs, rdir / "scripting/ship_designs"));
     GetPredefinedShipDesignManager().SetMonsterDesignTypes(StartParsing(parse::ship_designs, rdir / "scripting/monster_designs"));
     GetGameRules().Add(StartParsing(parse::game_rules, rdir / "scripting/game_rules.focs.txt"));
+    GetTechManager().SetTechs(StartParsing(parse::techs<TechManager::TechParseTuple>, rdir / "scripting/techs"));
 }

--- a/util/AppInterface.cpp
+++ b/util/AppInterface.cpp
@@ -1,5 +1,10 @@
 #include "AppInterface.h"
 
+#include "../parse/Parse.h"
+#include "../universe/Building.h"
+
+#include <future>
+
 const int INVALID_GAME_TURN = -(2 << 15) + 1;
 const int BEFORE_FIRST_TURN = -(2 << 14);
 const int IMPOSSIBLY_LARGE_TURN = 2 << 15;
@@ -27,4 +32,12 @@ int IApp::MAX_AI_PLAYERS() {
     // different threads.
     static const int max_number_AIs = 40;
     return max_number_AIs;
+}
+
+void IApp::ParseUniverseObjectTypes() {
+    auto pending_building_types = std::async(std::launch::async, [] {
+            return parse::buildings();
+        });
+    GetBuildingTypeManager().SetBuildingTypes(std::move(pending_building_types));
+
 }

--- a/util/AppInterface.cpp
+++ b/util/AppInterface.cpp
@@ -6,6 +6,7 @@
 #include "../universe/Field.h"
 #include "../universe/Special.h"
 #include "../universe/Species.h"
+#include "../util/Directories.h"
 #include "../util/MultiplayerCommon.h"
 
 #include <boost/filesystem.hpp>
@@ -43,12 +44,7 @@ int IApp::MAX_AI_PLAYERS() {
 
 namespace {
     template <typename ParserFunc>
-    auto StartParsing(const ParserFunc& parser) -> std::future<decltype(parser())> {
-        return std::async(std::launch::async, parser);
-    }
-
-    template <typename ParserFunc>
-    auto StartParsing2(const ParserFunc& parser, const boost::filesystem::path& subdir)
+    auto StartParsing(const ParserFunc& parser, const boost::filesystem::path& subdir)
         -> std::future<decltype(parser(subdir))>
     {
         return std::async(std::launch::async, parser, subdir);
@@ -56,15 +52,16 @@ namespace {
 }
 
 void IApp::ParseUniverseObjectTypes() {
-    GetBuildingTypeManager().SetBuildingTypes(StartParsing(parse::buildings));
-    GetEncyclopedia().SetArticles(StartParsing(parse::encyclopedia_articles));
-    GetFieldTypeManager().SetFieldTypes(StartParsing(parse::fields));
-    GetSpecialsManager().SetSpecialsTypes(StartParsing(parse::specials));
-    GetSpeciesManager().SetSpeciesTypes(StartParsing(parse::species));
-    GetTechManager().SetTechs(StartParsing(parse::techs));
-    GetPartTypeManager().SetPartTypes(StartParsing(parse::ship_parts));
-    GetHullTypeManager().SetHullTypes(StartParsing(parse::ship_hulls));
-    GetPredefinedShipDesignManager().SetShipDesignTypes(StartParsing2(parse::ship_designs, "scripting/ship_designs"));
-    GetPredefinedShipDesignManager().SetMonsterDesignTypes(StartParsing2(parse::ship_designs, "scripting/monster_designs"));
-    GetGameRules().Add(StartParsing(parse::game_rules));
+    const auto& rdir = GetResourceDir();
+    GetBuildingTypeManager().SetBuildingTypes(StartParsing(parse::buildings, rdir / "scripting/buildings"));
+    GetEncyclopedia().SetArticles(StartParsing(parse::encyclopedia_articles, rdir / "scripting/encyclopedia"));
+    GetFieldTypeManager().SetFieldTypes(StartParsing(parse::fields, rdir / "scripting/fields"));
+    GetSpecialsManager().SetSpecialsTypes(StartParsing(parse::specials, rdir / "scripting/specials"));
+    GetSpeciesManager().SetSpeciesTypes(StartParsing(parse::species, rdir / "scripting/species"));
+    GetTechManager().SetTechs(StartParsing(parse::techs, rdir / "scripting/techs"));
+    GetPartTypeManager().SetPartTypes(StartParsing(parse::ship_parts, rdir / "scripting/ship_parts"));
+    GetHullTypeManager().SetHullTypes(StartParsing(parse::ship_hulls, rdir / "scripting/ship_hulls"));
+    GetPredefinedShipDesignManager().SetShipDesignTypes(StartParsing(parse::ship_designs, rdir / "scripting/ship_designs"));
+    GetPredefinedShipDesignManager().SetMonsterDesignTypes(StartParsing(parse::ship_designs, rdir / "scripting/monster_designs"));
+    GetGameRules().Add(StartParsing(parse::game_rules, rdir / "scripting/game_rules.focs.txt"));
 }

--- a/util/AppInterface.cpp
+++ b/util/AppInterface.cpp
@@ -47,7 +47,7 @@ int IApp::MAX_AI_PLAYERS() {
     return max_number_AIs;
 }
 
-void IApp::ParseUniverseObjectTypes() {
+void IApp::StartBackgroundParsing() {
     const auto& rdir = GetResourceDir();
     GetBuildingTypeManager().SetBuildingTypes(Pending::StartParsing(parse::buildings, rdir / "scripting/buildings"));
     GetEncyclopedia().SetArticles(Pending::StartParsing(parse::encyclopedia_articles, rdir / "scripting/encyclopedia"));

--- a/util/AppInterface.cpp
+++ b/util/AppInterface.cpp
@@ -3,6 +3,7 @@
 #include "../parse/Parse.h"
 #include "../universe/Building.h"
 #include "../universe/Encyclopedia.h"
+#include "../universe/Field.h"
 
 #include <future>
 
@@ -45,4 +46,5 @@ namespace {
 void IApp::ParseUniverseObjectTypes() {
     GetEncyclopedia().SetArticles(StartParsing(parse::encyclopedia_articles));
     GetBuildingTypeManager().SetBuildingTypes(StartParsing(parse::buildings));
+    GetFieldTypeManager().SetFieldTypes(StartParsing(parse::fields));
 }

--- a/util/AppInterface.cpp
+++ b/util/AppInterface.cpp
@@ -1,6 +1,7 @@
 #include "AppInterface.h"
 
 #include "../parse/Parse.h"
+#include "../Empire/EmpireManager.h"
 #include "../universe/Building.h"
 #include "../universe/Encyclopedia.h"
 #include "../universe/Field.h"
@@ -61,4 +62,6 @@ void IApp::ParseUniverseObjectTypes() {
         Pending::StartParsing(parse::ship_designs, rdir / "scripting/monster_designs"));
     GetGameRules().Add(Pending::StartParsing(parse::game_rules, rdir / "scripting/game_rules.focs.txt"));
     GetTechManager().SetTechs(Pending::StartParsing(parse::techs<TechManager::TechParseTuple>, rdir / "scripting/techs"));
+
+    InitEmpireColors(rdir / "empire_colors.xml");
 }

--- a/util/AppInterface.cpp
+++ b/util/AppInterface.cpp
@@ -7,6 +7,8 @@
 #include "../universe/Special.h"
 #include "../universe/Species.h"
 
+#include <boost/filesystem.hpp>
+
 #include <future>
 
 const int INVALID_GAME_TURN = -(2 << 15) + 1;
@@ -43,6 +45,13 @@ namespace {
     auto StartParsing(const ParserFunc& parser) -> std::future<decltype(parser())> {
         return std::async(std::launch::async, parser);
     }
+
+    template <typename ParserFunc>
+    auto StartParsing2(const ParserFunc& parser, const boost::filesystem::path& subdir)
+        -> std::future<decltype(parser(subdir))>
+    {
+        return std::async(std::launch::async, parser, subdir);
+    }
 }
 
 void IApp::ParseUniverseObjectTypes() {
@@ -54,4 +63,7 @@ void IApp::ParseUniverseObjectTypes() {
     GetTechManager().SetTechs(StartParsing(parse::techs));
     GetPartTypeManager().SetPartTypes(StartParsing(parse::ship_parts));
     GetHullTypeManager().SetHullTypes(StartParsing(parse::ship_hulls));
+    GetPredefinedShipDesignManager().SetShipDesignTypes(StartParsing2(parse::ship_designs, "scripting/ship_designs"));
+    GetPredefinedShipDesignManager().SetMonsterDesignTypes(StartParsing2(parse::ship_designs, "scripting/monster_designs"));
+
 }

--- a/util/AppInterface.h
+++ b/util/AppInterface.h
@@ -32,7 +32,7 @@ public:
     virtual Universe& GetUniverse() = 0;
 
     /** Start parsing universe object types on a separate thread. */
-    virtual void ParseUniverseObjectTypes();
+    virtual void StartBackgroundParsing();
 
     /** Returns the set of known Empires for this application. */
     virtual EmpireManager& Empires() = 0;

--- a/util/AppInterface.h
+++ b/util/AppInterface.h
@@ -32,7 +32,7 @@ public:
     virtual Universe& GetUniverse() = 0;
 
     /** Start parsing universe object types on a separate thread. */
-    void ParseUniverseObjectTypes();
+    virtual void ParseUniverseObjectTypes();
 
     /** Returns the set of known Empires for this application. */
     virtual EmpireManager& Empires() = 0;

--- a/util/AppInterface.h
+++ b/util/AppInterface.h
@@ -31,6 +31,9 @@ public:
     /** Returns applications copy of Universe. */
     virtual Universe& GetUniverse() = 0;
 
+    /** Start parsing universe object types on a separate thread. */
+    void ParseUniverseObjectTypes();
+
     /** Returns the set of known Empires for this application. */
     virtual EmpireManager& Empires() = 0;
 

--- a/util/CMakeLists.txt
+++ b/util/CMakeLists.txt
@@ -14,6 +14,7 @@ target_sources(freeorioncommon
         ${CMAKE_CURRENT_LIST_DIR}/OptionValidators.h
         ${CMAKE_CURRENT_LIST_DIR}/Order.h
         ${CMAKE_CURRENT_LIST_DIR}/OrderSet.h
+        ${CMAKE_CURRENT_LIST_DIR}/Pending.h
         ${CMAKE_CURRENT_LIST_DIR}/Process.h
         ${CMAKE_CURRENT_LIST_DIR}/Random.h
         ${CMAKE_CURRENT_LIST_DIR}/SaveGamePreviewUtils.h

--- a/util/MultiplayerCommon.cpp
+++ b/util/MultiplayerCommon.cpp
@@ -57,26 +57,13 @@ bool RegisterGameRules(GameRulesFn function) {
 
 GameRules& GetGameRules() {
     static GameRules game_rules;
-    bool do_parse = game_rules.Empty();
-
     if (!GameRulesRegistry().empty()) {
+        DebugLogger() << "Adding options rules";
         for (GameRulesFn fn : GameRulesRegistry())
             fn(game_rules);
         GameRulesRegistry().clear();
     }
 
-    if (do_parse) {
-        try {
-            parse::game_rules(game_rules);
-        } catch (const std::exception& e) {
-            ErrorLogger() << "Failed parsing game rules: error: " << e.what();
-            throw e;
-        }
-
-        DebugLogger() << "Registered and Parsed Game Rules:";
-        for (const auto& entry : game_rules.GetRulesAsStrings())
-            DebugLogger() << " ... " << entry.first << " : " << entry.second;
-    }
     return game_rules;
 }
 
@@ -101,9 +88,30 @@ GameRules::Rule::Rule(RuleType rule_type_, const std::string& name_, const boost
 GameRules::GameRules()
 {}
 
+bool GameRules::Empty() const {
+    CheckPendingGameRules();
+    return m_game_rules.empty();
+}
+
+std::unordered_map<std::string, GameRules::Rule>::const_iterator GameRules::begin() const {
+    CheckPendingGameRules();
+    return m_game_rules.begin();
+}
+
+std::unordered_map<std::string, GameRules::Rule>::const_iterator GameRules::end() const {
+    CheckPendingGameRules();
+    return m_game_rules.end();
+}
+
+bool GameRules::RuleExists(const std::string& name) const {
+    CheckPendingGameRules();
+    return m_game_rules.count(name);
+}
+
 bool GameRules::RuleExists(const std::string& name, RuleType rule_type) const {
     if (rule_type == INVALID_RULE_TYPE)
         return false;
+    CheckPendingGameRules();
     auto rule_it = m_game_rules.find(name);
     if (rule_it == m_game_rules.end())
         return false;
@@ -111,6 +119,7 @@ bool GameRules::RuleExists(const std::string& name, RuleType rule_type) const {
 }
 
 GameRules::RuleType GameRules::GetRuleType(const std::string& name) const {
+    CheckPendingGameRules();
     auto rule_it = m_game_rules.find(name);
     if (rule_it == m_game_rules.end())
         return INVALID_RULE_TYPE;
@@ -118,6 +127,7 @@ GameRules::RuleType GameRules::GetRuleType(const std::string& name) const {
 }
 
 bool GameRules::RuleIsInternal(const std::string& name) const {
+    CheckPendingGameRules();
     auto rule_it = m_game_rules.find(name);
     if (rule_it == m_game_rules.end())
         return false;
@@ -125,6 +135,7 @@ bool GameRules::RuleIsInternal(const std::string& name) const {
 }
 
 const std::string& GameRules::GetDescription(const std::string& rule_name) const {
+    CheckPendingGameRules();
     auto it = m_game_rules.find(rule_name);
     if (it == m_game_rules.end())
         throw std::runtime_error(("GameRules::GetDescription(): No option called \"" + rule_name + "\" could be found.").c_str());
@@ -132,6 +143,7 @@ const std::string& GameRules::GetDescription(const std::string& rule_name) const
 }
 
 std::shared_ptr<const ValidatorBase> GameRules::GetValidator(const std::string& rule_name) const {
+    CheckPendingGameRules();
     auto it = m_game_rules.find(rule_name);
     if (it == m_game_rules.end())
         throw std::runtime_error(("GameRules::GetValidator(): No option called \"" + rule_name + "\" could be found.").c_str());
@@ -139,6 +151,7 @@ std::shared_ptr<const ValidatorBase> GameRules::GetValidator(const std::string& 
 }
 
 void GameRules::ClearExternalRules() {
+    CheckPendingGameRules();
     auto it = m_game_rules.begin();
     while (it != m_game_rules.end()) {
         bool engine_internal = it->second.storable; // OptionsDB::Option member used to store if this option is engine-internal
@@ -150,18 +163,24 @@ void GameRules::ClearExternalRules() {
 }
 
 void GameRules::ResetToDefaults() {
+    CheckPendingGameRules();
     for (auto& it : m_game_rules)
         it.second.SetToDefault();
 }
 
 std::vector<std::pair<std::string, std::string>> GameRules::GetRulesAsStrings() const {
+    CheckPendingGameRules();
     std::vector<std::pair<std::string, std::string>> retval;
     for (const auto& rule : m_game_rules)
         retval.push_back(std::make_pair(rule.first, rule.second.ValueToString()));
     return retval;
 }
 
+void GameRules::Add(std::future<GameRules>&& future)
+{ m_pending_rules = std::move(future); }
+
 void GameRules::SetFromStrings(const std::vector<std::pair<std::string, std::string>>& names_values) {
+    CheckPendingGameRules();
     DebugLogger() << "Setting Rules from Strings:";
     for (const auto& entry : names_values)
         DebugLogger() << "  " << entry.first << " : " << entry.second;
@@ -187,6 +206,37 @@ void GameRules::SetFromStrings(const std::vector<std::pair<std::string, std::str
         DebugLogger() << "  " << entry.first << " : " << entry.second.ValueToString();
 }
 
+void GameRules::CheckPendingGameRules() const {
+    if (!m_pending_rules)
+        return;
+
+    // Only print waiting message if not immediately ready
+    while (m_pending_rules->wait_for(std::chrono::seconds(1)) == std::future_status::timeout) {
+        DebugLogger() << "Waiting for Rules to parse.";
+    }
+
+    DebugLogger() << "Adding parsed rules";
+    try {
+        auto new_rules = std::move(m_pending_rules->get());
+        for (const auto& rule : new_rules) {
+            const auto& name = rule.first;
+            if (m_game_rules.count(name)) {
+                ErrorLogger() << "GameRules::Add<>() : Rule " << name << " was added twice. Skipping ...";
+                continue;
+            }
+            m_game_rules[name] = rule.second;
+        }
+    } catch (const std::exception& e) {
+        ErrorLogger() << "Failed parsing rules: error: " << e.what();
+        throw;
+    }
+
+    m_pending_rules = boost::none;
+
+    DebugLogger() << "Registered and Parsed Game Rules:";
+    for (const auto& entry : GetRulesAsStrings())
+        DebugLogger() << " ... " << entry.first << " : " << entry.second;
+}
 
 /////////////////////////////////////////////////////
 // GalaxySetupData

--- a/util/MultiplayerCommon.cpp
+++ b/util/MultiplayerCommon.cpp
@@ -5,7 +5,6 @@
 #include "LoggerWithOptionsDB.h"
 #include "OptionsDB.h"
 #include "Random.h"
-#include "../parse/Parse.h"
 #include "../universe/Fleet.h"
 #include "../universe/Planet.h"
 #include "../universe/System.h"

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -3,8 +3,9 @@
 
 #include "../universe/EnumsFwd.h"
 #include "../network/Networking.h"
-#include "OptionsDB.h"
 #include "Export.h"
+#include "OptionsDB.h"
+#include "Pending.h"
 #include "Serialize.h"
 
 #include <GG/Clr.h>
@@ -13,7 +14,6 @@
 #include <set>
 #include <vector>
 #include <map>
-#include <future>
 #include <boost/serialization/access.hpp>
 
 
@@ -124,7 +124,7 @@ public:
     }
 
     /** Adds rules from the \p future. */
-    void Add(std::future<GameRules>&& future);
+    void Add(Pending::Pending<GameRules>&& future);
 
     template <typename T>
     void    Set(const std::string& name, const T& value)
@@ -152,7 +152,7 @@ private:
 
     /** Future rules being parsed by parser.  mutable so that it can
         be assigned to m_game_rules when completed.*/
-    mutable boost::optional<std::future<GameRules>> m_pending_rules = boost::none;
+    mutable boost::optional<Pending::Pending<GameRules>> m_pending_rules = boost::none;
 
     mutable GameRulesTypeMap m_game_rules;
 

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -13,6 +13,7 @@
 #include <set>
 #include <vector>
 #include <map>
+#include <future>
 #include <boost/serialization/access.hpp>
 
 
@@ -26,7 +27,7 @@ class GameRules;
 /////////////////////////////////////////////
 // Free Functions
 /////////////////////////////////////////////
-typedef void (*GameRulesFn)(GameRules&); ///< the function signature for functions that add Rules to the GameRules (void (GameRules&))
+using GameRulesFn = void (*) (GameRules&); ///< the function signature for functions that add Rules to the GameRules (void (GameRules&))
 
 /** adds \a function to a vector of pointers to functions that add Rules to
   * the GameRules.  This function returns a boolean so that it can be used to
@@ -70,16 +71,16 @@ public:
         std::string category = "";
     };
 
-    /** \name Accessors */ //@{
-    bool Empty() const
-    { return m_game_rules.empty(); }
-    std::unordered_map<std::string, Rule>::const_iterator begin() const
-    { return m_game_rules.begin(); }
-    std::unordered_map<std::string, Rule>::const_iterator end() const
-    { return m_game_rules.end(); }
+    using GameRulesTypeMap = std::unordered_map<std::string, Rule>;
 
-    bool RuleExists(const std::string& name) const
-    { return m_game_rules.find(name) != m_game_rules.end(); }
+    GameRules();
+
+    /** \name Accessors */ //@{
+    bool Empty() const;
+    std::unordered_map<std::string, Rule>::const_iterator begin() const;
+    std::unordered_map<std::string, Rule>::const_iterator end() const;
+
+    bool RuleExists(const std::string& name) const;
     bool RuleExists(const std::string& name, RuleType rule_type) const;
     RuleType GetRuleType(const std::string& name) const;
     bool RuleIsInternal(const std::string& name) const;
@@ -98,6 +99,7 @@ public:
     template <typename T>
     T       Get(const std::string& name) const
     {
+        CheckPendingGameRules();
         auto it = m_game_rules.find(name);
         if (it == m_game_rules.end())
             throw std::runtime_error("GameRules::Get<>() : Attempted to get nonexistent rule \"" + name + "\".");
@@ -112,6 +114,7 @@ public:
                 const std::string& category, T default_value,
                 bool engine_interal, const ValidatorBase& validator = Validator<T>())
     {
+        CheckPendingGameRules();
         auto it = m_game_rules.find(name);
         if (it != m_game_rules.end())
             throw std::runtime_error("GameRules::Add<>() : Rule " + name + " was added twice.");
@@ -120,9 +123,13 @@ public:
         DebugLogger() << "Added game rule named " << name << " with default value " << default_value;
     }
 
+    /** Adds rules from the \p future. */
+    void Add(std::future<GameRules>&& future);
+
     template <typename T>
     void    Set(const std::string& name, const T& value)
     {
+        CheckPendingGameRules();
         auto it = m_game_rules.find(name);
         if (it == m_game_rules.end())
             throw std::runtime_error("GameRules::Set<>() : Attempted to set nonexistent rule \"" + name + "\".");
@@ -140,9 +147,14 @@ public:
     //@}
 
 private:
-    GameRules();
+    /** Assigns any m_pending_rules to m_game_rules. */
+    void CheckPendingGameRules() const;
 
-    std::unordered_map<std::string, Rule> m_game_rules;
+    /** Future rules being parsed by parser.  mutable so that it can
+        be assigned to m_game_rules when completed.*/
+    mutable boost::optional<std::future<GameRules>> m_pending_rules = boost::none;
+
+    mutable GameRulesTypeMap m_game_rules;
 
     friend FO_COMMON_API GameRules& GetGameRules();
 };

--- a/util/Pending.h
+++ b/util/Pending.h
@@ -1,0 +1,106 @@
+#ifndef _Pending_h_
+#define _Pending_h_
+
+#include "Export.h"
+#include "Logger.h"
+
+#include <boost/filesystem/path.hpp>
+#include <boost/optional/optional.hpp>
+
+#include <future>
+#include <string>
+
+/** namespace Pending collection classes and functions used for
+    asynchronously parsing universe types, statistics etc.*/
+namespace Pending {
+    /** Pending holds the std::future results of a T.*/
+    template <typename T>
+    struct FO_COMMON_API Pending {
+        Pending (boost::optional<std::future<T>>&& pending_, const std::string& name_) :
+            pending(std::move(pending_)),
+            filename(name_)
+            {}
+
+        Pending (Pending&& other) :
+            pending(std::move(other.pending)),
+            filename(std::move(other.filename))
+            {}
+
+        Pending& operator=(Pending&& other) {
+            pending = std::move(other.pending);
+            filename = std::move(other.filename);
+            return *this;
+        }
+
+        boost::optional<std::future<T>> pending = boost::none;
+        std::string filename;
+    };
+
+    /** Wait for the \p pending parse to complete.  Set pending to boost::none
+        and return the parsed T.  Return boost::none on errors.*/
+    template <typename T>
+    boost::optional<T> WaitForPending(boost::optional<Pending<T>>& pending) {
+        if (!pending)
+            return boost::none;
+
+        std::future_status status;
+        do {
+            status = pending->pending->wait_for(std::chrono::seconds(1));
+            if (status == std::future_status::timeout)
+                DebugLogger() << "Waiting for parse of \"" << pending->filename << "\" to complete.";
+
+            if (status == std::future_status::deferred) {
+                ErrorLogger() << "Pending parse is unable to handle deferred future.";
+                throw "deferred future not handled";
+            }
+
+        } while (status != std::future_status::ready);
+
+        try {
+            auto x = std::move(pending->pending->get());
+            pending = boost::none;
+            return x;
+        } catch (const std::exception& e) {
+            ErrorLogger() << "Parsing of \"" << pending->filename << "\" failed with error: " << e.what();
+        }
+
+        return boost::none;
+    }
+
+    /** If there is a pending parse, wait for it and swap it with the stored
+        value.  Return the stored value.*/
+    template <typename T>
+    T& SwapPending(boost::optional<Pending<T>>& pending, T& stored) {
+        if (auto tt = WaitForPending(pending))
+            std::swap(*tt, stored);
+        return stored;
+    }
+
+    /** If there is a pending parse, wait for it and swap it with the stored
+        value.  Return the stored value.
+
+        TODO: remove this function once all of the raw pointer containers are removed.
+    */
+    template <typename T>
+    T& SwapPendingRawPointers(boost::optional<Pending<T>>& pending, T& stored) {
+        if (auto parsed = WaitForPending(pending)) {
+            std::swap(*parsed, stored);
+
+            // Don't leak old types
+            for (auto& entry : *parsed)
+                delete entry.second;
+        }
+        return stored;
+    }
+
+    /** Return a Pending<T> constructed with \p parser and \p path*/
+    template <typename Func>
+    auto StartParsing(const Func& parser, const boost::filesystem::path& path)
+        -> Pending<decltype(parser(path))>
+    {
+        return Pending<decltype(parser(path))>(
+            std::async(std::launch::async, parser, path), path.filename().string());
+    }
+}
+
+#endif // _Pending_h_

--- a/util/Pending.h
+++ b/util/Pending.h
@@ -16,15 +16,18 @@ namespace Pending {
     /** Pending holds the std::future results of a T.*/
     template <typename T>
     struct FO_COMMON_API Pending {
-        Pending (boost::optional<std::future<T>>&& pending_, const std::string& name_) :
+        Pending(
+            boost::optional<std::future<T>>&& pending_,
+            const std::string& name_
+        ) :
             pending(std::move(pending_)),
             filename(name_)
-            {}
+        {}
 
-        Pending (Pending&& other) :
+        Pending(Pending&& other) :
             pending(std::move(other.pending)),
             filename(std::move(other.filename))
-            {}
+        {}
 
         Pending& operator=(Pending&& other) {
             pending = std::move(other.pending);

--- a/util/Pending.h
+++ b/util/Pending.h
@@ -59,7 +59,7 @@ namespace Pending {
         try {
             auto x = std::move(pending->pending->get());
             pending = boost::none;
-            return x;
+            return std::move(x);
         } catch (const std::exception& e) {
             ErrorLogger() << "Parsing of \"" << pending->filename << "\" failed with error: " << e.what();
         }


### PR DESCRIPTION
I will break this PR into smaller PRs that are easier to review.  

This PR moves parsing from the main UI thread to another thread.  I describe specific improvements below.

Most of the commits fall into two categories related to fixing bugs in the lexer or making the parsing multi-threaded, as described in the sections below.


**Improvements**
- This PR improves startup performance by removing parsing from the foreground thread.  A simple example is to start the Intro screen and then select the buildings section of the Pedia.  It will open faster, because parsing starts and possibly completes before the window is opened.

- It fixes the bug where the singleton lexer prevented concurrent parsing, and caused errors in file length checking and error reporting.  This PR restores checking for and reporting on parsers failing because of garbage in the file after the parsed content.

- It fixes the leak due to parsers being static initialized, used at startup, never used again and only recovered when the app is closed.

- It decouples the universe object managers from the parser the directory structure.  This is a step towards enabling testing universe and game engine code without an existing scripting directory.

- It moves the parsed file paths out of the parser and into the app code.  This make the scripting directory structure a property of the app, not the parser.

- It enables the resource directory to be changed without requiring a restart.

**Bug fix overview**
The lexer is currently a statically initialized singleton.  It is bound to a single specific file.  Consequently, only one file can be parsed at a time.  This is true even on a single thread.

This causes problems with ship designs containing parts and species using macros.  The check for correctly parsed file length was disabled to hide this bug.  The parser can crash the application if an error iterator from one file points beyond the end of the file being parsed, when the error is presented to the UI.

The fix is to create one lexer per file being concurrently parsed.  After the fix, the `parse::THING` functions are safe to call concurrently and multi-threaded.

The problem is replicated for every parser that is bound to the lexer.

Many of the parsers are statically initialized.  The order of initialization is at the discretion of the linker and the loader and difficult to infer, as noted by several comments in the code.  This PR changes all the parsers to be on the stack and makes initialization order explicit and obvious.

Secondly, not a bug, but many of the parsers are rules with a distinguished rule often called `start`.  This is exactly the purpose of `spirit::grammar`.  This PR replaces rules with a single distinguished rule with a grammar.

The fix portion of this PR is repetitive, but straightforward.  Find a singleton parser.  Convert it to a grammar.  Pass it as a parameter to its dependents.  Remove the singleton.  Repeat.


**Multithreaded parsing overview**
The parsing is made multi-threaded by converting the universe object managers to take a `std::future<>` with the results of the parse.  Parsing can be started early on separate threads in the clients and the server before it is needed in the `MapWnd`, pedia or universe generation. 



