### PR TITLE
Remove filename singletons from parser.

### DIFF
--- a/parse/BuildingsParser.cpp
+++ b/parse/BuildingsParser.cpp
@@ -41,7 +41,9 @@ namespace {
     BOOST_PHOENIX_ADAPT_FUNCTION(void, insert_building_, insert_building, 6)
 
     struct rules {
-        rules() {
+        rules(const std::string& filename,
+              const parse::text_iterator& first, const parse::text_iterator& last)
+        {
             namespace phoenix = boost::phoenix;
             namespace qi = boost::spirit::qi;
 
@@ -82,7 +84,7 @@ namespace {
             debug(building_type);
 #endif
 
-            qi::on_error<qi::fail>(start, parse::report_error(_1, _2, _3, _4));
+            qi::on_error<qi::fail>(start, parse::report_error(filename, first, last, _1, _2, _3, _4));
         }
 
         typedef parse::detail::rule<

--- a/parse/EmpireStatsParser.cpp
+++ b/parse/EmpireStatsParser.cpp
@@ -16,7 +16,9 @@ namespace std {
 
 namespace {
     struct rules {
-        rules() {
+        rules(const std::string& filename,
+              const parse::text_iterator& first, const parse::text_iterator& last)
+        {
             namespace phoenix = boost::phoenix;
             namespace qi = boost::spirit::qi;
 
@@ -50,7 +52,7 @@ namespace {
             debug(stat);
 #endif
 
-            qi::on_error<qi::fail>(start, parse::report_error(_1, _2, _3, _4));
+            qi::on_error<qi::fail>(start, parse::report_error(filename, first, last, _1, _2, _3, _4));
         }
 
         typedef parse::detail::rule<

--- a/parse/EncyclopediaParser.cpp
+++ b/parse/EncyclopediaParser.cpp
@@ -26,7 +26,9 @@ namespace {
     const boost::phoenix::function<insert_> insert;
 
     struct rules {
-        rules() {
+        rules(const std::string& filename,
+              const parse::text_iterator& first, const parse::text_iterator& last)
+        {
             namespace phoenix = boost::phoenix;
             namespace qi = boost::spirit::qi;
 
@@ -64,7 +66,7 @@ namespace {
             debug(article);
 #endif
 
-            qi::on_error<qi::fail>(start, parse::report_error(_1, _2, _3, _4));
+            qi::on_error<qi::fail>(start, parse::report_error(filename, first, last, _1, _2, _3, _4));
         }
 
         typedef parse::detail::rule<

--- a/parse/FieldsParser.cpp
+++ b/parse/FieldsParser.cpp
@@ -24,7 +24,9 @@ namespace {
     const boost::phoenix::function<parse::detail::insert> insert_;
 
     struct rules {
-        rules() {
+        rules(const std::string& filename,
+              const parse::text_iterator& first, const parse::text_iterator& last)
+        {
             namespace phoenix = boost::phoenix;
             namespace qi = boost::spirit::qi;
 
@@ -66,7 +68,7 @@ namespace {
             debug(field);
 #endif
 
-            qi::on_error<qi::fail>(start, parse::report_error(_1, _2, _3, _4));
+            qi::on_error<qi::fail>(start, parse::report_error(filename, first, last, _1, _2, _3, _4));
         }
 
         typedef parse::detail::rule<

--- a/parse/FleetPlansParser.cpp
+++ b/parse/FleetPlansParser.cpp
@@ -19,7 +19,9 @@ namespace std {
 
 namespace {
     struct rules {
-        rules() {
+        rules(const std::string& filename,
+              const parse::text_iterator& first, const parse::text_iterator& last)
+        {
             namespace phoenix = boost::phoenix;
             namespace qi = boost::spirit::qi;
 
@@ -57,7 +59,7 @@ namespace {
             debug(fleet_plan);
 #endif
 
-            qi::on_error<qi::fail>(start, parse::report_error(_1, _2, _3, _4));
+            qi::on_error<qi::fail>(start, parse::report_error(filename, first, last, _1, _2, _3, _4));
         }
 
         typedef parse::detail::rule<

--- a/parse/GameRulesParser.cpp
+++ b/parse/GameRulesParser.cpp
@@ -75,7 +75,9 @@ namespace {
     const boost::phoenix::function<insert_rule_> add_rule;
 
     struct rules {
-        rules() {
+        rules(const std::string& filename,
+              const parse::text_iterator& first, const parse::text_iterator& last)
+        {
             namespace phoenix = boost::phoenix;
             namespace qi = boost::spirit::qi;
 
@@ -189,7 +191,7 @@ namespace {
             debug(game_rule_string_list);
 #endif
 
-            qi::on_error<qi::fail>(start, parse::report_error(_1, _2, _3, _4));
+            qi::on_error<qi::fail>(start, parse::report_error(filename, first, last, _1, _2, _3, _4));
         }
 
         typedef parse::detail::rule<

--- a/parse/ItemsParser.cpp
+++ b/parse/ItemsParser.cpp
@@ -17,7 +17,9 @@ namespace std {
 
 namespace {
     struct rules {
-        rules() {
+        rules(const std::string& filename,
+              const parse::text_iterator& first, const parse::text_iterator& last)
+        {
             namespace phoenix = boost::phoenix;
             namespace qi = boost::spirit::qi;
 
@@ -35,7 +37,7 @@ namespace {
 
             start.name("start");
 
-            qi::on_error<qi::fail>(start, parse::report_error(_1, _2, _3, _4));
+            qi::on_error<qi::fail>(start, parse::report_error(filename, first, last, _1, _2, _3, _4));
         }
 
         typedef parse::detail::rule<

--- a/parse/KeymapParser.cpp
+++ b/parse/KeymapParser.cpp
@@ -43,7 +43,9 @@ namespace {
     const boost::phoenix::function<insert_key_map_> insert_key_map;
 
     struct rules {
-        rules() {
+        rules(const std::string& filename,
+              const parse::text_iterator& first, const parse::text_iterator& last)
+        {
             namespace phoenix = boost::phoenix;
             namespace qi = boost::spirit::qi;
 
@@ -84,7 +86,7 @@ namespace {
             debug(article);
 #endif
 
-            qi::on_error<qi::fail>(start, parse::report_error(_1, _2, _3, _4));
+            qi::on_error<qi::fail>(start, parse::report_error(filename, first, last, _1, _2, _3, _4));
         }
 
         typedef parse::detail::rule<

--- a/parse/MonsterFleetPlansParser.cpp
+++ b/parse/MonsterFleetPlansParser.cpp
@@ -30,7 +30,9 @@ namespace {
     const boost::phoenix::function<new_monster_fleet_plan_> new_monster_fleet_plan;
 
     struct rules {
-        rules() {
+        rules(const std::string& filename,
+              const parse::text_iterator& first, const parse::text_iterator& last)
+        {
             namespace phoenix = boost::phoenix;
             namespace qi = boost::spirit::qi;
 
@@ -95,7 +97,7 @@ namespace {
             debug(monster_fleet_plan);
 #endif
 
-            qi::on_error<qi::fail>(start, parse::report_error(_1, _2, _3, _4));
+            qi::on_error<qi::fail>(start, parse::report_error(filename, first, last, _1, _2, _3, _4));
         }
 
         typedef parse::detail::rule<> generic_rule;

--- a/parse/Parse.cpp
+++ b/parse/Parse.cpp
@@ -635,7 +635,7 @@ namespace parse {
          */
         void parse_file_common(const boost::filesystem::path& path, const parse::lexer& lexer,
                                std::string& filename, std::string& file_contents,
-                               parse::text_iterator& first, parse::token_iterator& it)
+                               parse::text_iterator& first, parse::text_iterator& last, parse::token_iterator& it)
         {
             filename = path.string();
 
@@ -651,15 +651,9 @@ namespace parse {
             file_substitution(file_contents, path.parent_path());
             macro_substitution(file_contents);
 
-            first = parse::text_iterator(file_contents.begin());
-            parse::text_iterator last(file_contents.end());
+            first = file_contents.begin();
+            last = file_contents.end();
 
-            // WARNING: These static global values assume that only one file is parsed at a time.
-            // That assumption is incorrect, and these values will be unreliable.
-            parse::detail::s_text_it = &first;
-            parse::detail::s_begin = first;
-            parse::detail::s_end = last;
-            parse::detail::s_filename = filename.c_str();
             it = lexer.begin(first, last);
         }
     }

--- a/parse/ParseImpl.h
+++ b/parse/ParseImpl.h
@@ -100,6 +100,7 @@ namespace parse { namespace detail {
                            std::string& filename,
                            std::string& file_contents,
                            text_iterator& first,
+                           text_iterator& last,
                            token_iterator& it);
 
     template <typename Rules, typename Arg1>
@@ -108,19 +109,20 @@ namespace parse { namespace detail {
         std::string filename;
         std::string file_contents;
         text_iterator first;
+        text_iterator last;
         token_iterator it;
 
         boost::timer timer;
 
         const lexer& lexer = lexer::instance();
 
-        parse_file_common(path, lexer, filename, file_contents, first, it);
+        parse_file_common(path, lexer, filename, file_contents, first, last, it);
 
         //TraceLogger() << "Parse: parsed contents for " << path.string() << " : \n" << file_contents;
 
         boost::spirit::qi::in_state_type in_state;
 
-        static Rules rules;
+        Rules rules(filename, first, last);
 
         bool success = boost::spirit::qi::phrase_parse(it, lexer.end(), rules.start(boost::phoenix::ref(arg1)), in_state("WS")[lexer.self]);
 

--- a/parse/ReportParseError.h
+++ b/parse/ReportParseError.h
@@ -35,34 +35,31 @@ namespace parse {
         void pretty_print(std::ostream& os, boost::spirit::info const& what);
 
         void default_send_error_string(const std::string& str);
-
-        // WARNING: These static global values assume that only one file is parsed at a time.
-        // That assumption is incorrect, and these values will be unreliable.
-        extern const char*      s_filename;
-        extern text_iterator*   s_text_it;
-        extern text_iterator    s_begin;
-        extern text_iterator    s_end;
     }
 
     struct report_error_ {
         typedef void result_type;
 
         template <typename Arg1, typename Arg2, typename Arg3, typename Arg4>
-        void operator()(Arg1 first, Arg2, Arg3 it, Arg4 rule_name) const
+        void operator()(const std::string& filename, const text_iterator& begin, const text_iterator& end,
+                        Arg1 first, Arg2, Arg3 it, Arg4 rule_name) const
         {
             std::string error_string;
-            generate_error_string(first, it, rule_name, error_string);
+            generate_error_string(filename, begin, end, first, it, rule_name, error_string);
             send_error_string(error_string);
         }
 
         static boost::function<void (const std::string&)> send_error_string;
 
     private:
-        std::pair<text_iterator, unsigned int> line_start_and_line_number(text_iterator error_position) const;
-        std::string get_line(text_iterator line_start) const;
-        std::string get_lines_before(text_iterator line_start) const;
-        std::string get_lines_after(text_iterator line_start) const;
-        void generate_error_string(const token_iterator& first,
+        std::pair<text_iterator, unsigned int> line_start_and_line_number(
+            const text_iterator& begin, const text_iterator& end, text_iterator error_position) const;
+        std::string get_line(const text_iterator& end, text_iterator line_start) const;
+        std::string get_lines_before(const text_iterator& begin, const text_iterator& end, text_iterator line_start) const;
+        std::string get_lines_after(const text_iterator& begin, const text_iterator& end, text_iterator line_start) const;
+        void generate_error_string(const std::string& filename,
+                                   const text_iterator& begin, const text_iterator& end,
+                                   const token_iterator& first,
                                    const token_iterator& it,
                                    const boost::spirit::info& rule_name,
                                    std::string& str) const;

--- a/parse/ShipDesignsParser.cpp
+++ b/parse/ShipDesignsParser.cpp
@@ -66,7 +66,9 @@ namespace {
     BOOST_PHOENIX_ADAPT_FUNCTION(boost::uuids::uuid, parse_uuid_, parse_uuid, 1)
 
     struct rules {
-        rules() {
+        rules(const std::string& filename,
+              const parse::text_iterator& first, const parse::text_iterator& last)
+        {
             namespace phoenix = boost::phoenix;
             namespace qi = boost::spirit::qi;
 
@@ -135,7 +137,7 @@ namespace {
             debug(design);
 #endif
 
-            qi::on_error<qi::fail>(start, parse::report_error(_1, _2, _3, _4));
+            qi::on_error<qi::fail>(start, parse::report_error(filename, first, last, _1, _2, _3, _4));
         }
 
         using design_prefix_rule = parse::detail::rule<
@@ -164,7 +166,9 @@ namespace {
     };
 
     struct manifest_rules {
-        manifest_rules() {
+        manifest_rules(const std::string& filename,
+              const parse::text_iterator& first, const parse::text_iterator& last)
+        {
             namespace phoenix = boost::phoenix;
             namespace qi = boost::spirit::qi;
 
@@ -193,7 +197,7 @@ namespace {
             debug(design_manifest);
 #endif
 
-            qi::on_error<qi::fail>(start, parse::report_error(_1, _2, _3, _4));
+            qi::on_error<qi::fail>(start, parse::report_error(filename, first, last, _1, _2, _3, _4));
         }
 
         using manifest_rule = parse::detail::rule<void (std::vector<boost::uuids::uuid>&)>;

--- a/parse/ShipHullsParser.cpp
+++ b/parse/ShipHullsParser.cpp
@@ -34,7 +34,9 @@ namespace {
     const boost::phoenix::function<parse::detail::insert> insert_;
 
     struct rules {
-        rules() {
+        rules(const std::string& filename,
+              const parse::text_iterator& first, const parse::text_iterator& last)
+        {
             namespace phoenix = boost::phoenix;
             namespace qi = boost::spirit::qi;
 
@@ -117,7 +119,7 @@ namespace {
             debug(hull);
 #endif
 
-            qi::on_error<qi::fail>(start, parse::report_error(_1, _2, _3, _4));
+            qi::on_error<qi::fail>(start, parse::report_error(filename, first, last, _1, _2, _3, _4));
         }
 
         typedef parse::detail::rule<

--- a/parse/ShipPartsParser.cpp
+++ b/parse/ShipPartsParser.cpp
@@ -32,7 +32,9 @@ namespace {
     const boost::phoenix::function<parse::detail::insert> insert_;
 
     struct rules {
-        rules() {
+        rules(const std::string& filename,
+              const parse::text_iterator& first, const parse::text_iterator& last)
+        {
             namespace phoenix = boost::phoenix;
             namespace qi = boost::spirit::qi;
 
@@ -103,7 +105,7 @@ namespace {
             debug(part_type);
 #endif
 
-            qi::on_error<qi::fail>(start, parse::report_error(_1, _2, _3, _4));
+            qi::on_error<qi::fail>(start, parse::report_error(filename, first, last, _1, _2, _3, _4));
         }
 
         typedef parse::detail::rule<

--- a/parse/SpecialsParser.cpp
+++ b/parse/SpecialsParser.cpp
@@ -65,7 +65,9 @@ namespace {
     BOOST_PHOENIX_ADAPT_FUNCTION(void, insert_special_, insert_special, 2)
 
     struct rules {
-        rules() {
+        rules(const std::string& filename,
+              const parse::text_iterator& first, const parse::text_iterator& last)
+        {
             namespace phoenix = boost::phoenix;
             namespace qi = boost::spirit::qi;
 
@@ -130,7 +132,7 @@ namespace {
             debug(special);
 #endif
 
-            qi::on_error<qi::fail>(start, parse::report_error(_1, _2, _3, _4));
+            qi::on_error<qi::fail>(start, parse::report_error(filename, first, last, _1, _2, _3, _4));
         }
 
         typedef parse::detail::rule<

--- a/parse/SpeciesParser.cpp
+++ b/parse/SpeciesParser.cpp
@@ -31,7 +31,9 @@ namespace {
     const boost::phoenix::function<parse::detail::insert> insert_;
 
     struct rules {
-        rules() {
+        rules(const std::string& filename,
+              const parse::text_iterator& first, const parse::text_iterator& last)
+        {
             namespace phoenix = boost::phoenix;
             namespace qi = boost::spirit::qi;
 
@@ -152,7 +154,7 @@ namespace {
             debug(start);
 #endif
 
-            qi::on_error<qi::fail>(start, parse::report_error(_1, _2, _3, _4));
+            qi::on_error<qi::fail>(start, parse::report_error(filename, first, last, _1, _2, _3, _4));
         }
 
         typedef parse::detail::rule<

--- a/parse/TechsParser.cpp
+++ b/parse/TechsParser.cpp
@@ -69,7 +69,9 @@ namespace {
 
 
     struct rules {
-        rules() {
+        rules(const std::string& filename,
+              const parse::text_iterator& first, const parse::text_iterator& last)
+        {
             namespace phoenix = boost::phoenix;
             namespace qi = boost::spirit::qi;
 
@@ -173,7 +175,7 @@ namespace {
             debug(category);
 #endif
 
-            qi::on_error<qi::fail>(start, parse::report_error(_1, _2, _3, _4));
+            qi::on_error<qi::fail>(start, parse::report_error(filename, first, last, _1, _2, _3, _4));
         }
 
         typedef parse::detail::rule<


### PR DESCRIPTION
The use of s_filename, s_text_it, s_begin, s_end and Rule as static
singletons requires parsing to be single threaded, non-recursive and
non-concurrent, or generate_error_string() will fail.

Any recursive or concurrent parse accessing two or more files (ships
with parts, species with macros, etc) would not have correct error
messages and might crash on a bad parse.  The second file opened resets
all of the singleton variables, which if there is an error in the first
file will be pointing to the wrong variables.  At best this indexes into
the wrong string.  At worst it indexes into a freed string.

This commit removes the singletons and threads the filename, begin and
end through the Rule object to generate_error_string().