### PR TITLE
Research tree balancing—Learning focused

### DIFF
--- a/default/scripting/techs/construction/FORCE_ENERGY_STRC.focs.txt
+++ b/default/scripting/techs/construction/FORCE_ENERGY_STRC.focs.txt
@@ -15,31 +15,31 @@ Tech
             scope = And [
                 ProductionCenter
                 OwnedBy empire = Source.Owner
-                Industry high = RootCandidate.TargetIndustry - 3
+                Industry high = RootCandidate.TargetIndustry - 2
             ]
-            effects = SetIndustry value = Value + 2
+            effects = SetIndustry value = Value + 1
 
         EffectsGroup
             scope = And [
                 ProductionCenter
                 OwnedBy empire = Source.Owner
-                Research high = RootCandidate.TargetResearch - 3
+                Research high = RootCandidate.TargetResearch - 2
             ]
-            effects = SetResearch value = Value + 2
+            effects = SetResearch value = Value + 1
 
         EffectsGroup
             scope = And [
                 ProductionCenter
                 OwnedBy empire = Source.Owner
-                Construction high = RootCandidate.TargetConstruction - 3
+                Construction high = RootCandidate.TargetConstruction - 2
             ]
-            effects = SetConstruction value = Value + 2
+            effects = SetConstruction value = Value + 1
 
         EffectsGroup
             scope = And [
                 ProductionCenter
                 OwnedBy empire = Source.Owner
-                Industry low = RootCandidate.TargetIndustry - 3 high = RootCandidate.TargetIndustry
+                Industry low = RootCandidate.TargetIndustry - 2 high = RootCandidate.TargetIndustry
             ]
             effects = SetIndustry value = Target.TargetIndustry
 
@@ -47,7 +47,7 @@ Tech
             scope = And [
                 ProductionCenter
                 OwnedBy empire = Source.Owner
-                Research low = RootCandidate.TargetResearch - 3 high = RootCandidate.TargetResearch
+                Research low = RootCandidate.TargetResearch - 2 high = RootCandidate.TargetResearch
             ]
             effects = SetResearch value = Target.TargetResearch
 

--- a/default/scripting/techs/learning/ARTIF_MINDS.focs.txt
+++ b/default/scripting/techs/learning/ARTIF_MINDS.focs.txt
@@ -15,7 +15,7 @@ Tech
                 TargetPopulation low = 0.0001
             ]
             priority = [[VERY_LATE_PRIORITY]]
-            effects = SetTargetResearch value = Value + 10 * [[RESEARCH_PER_POP]]
+            effects = SetTargetResearch value = Value + Target.Construction / 10 
     ]
     graphic = "icons/tech/basic_autolabs.png"
 

--- a/default/scripting/techs/learning/COLLAPSER.focs.txt
+++ b/default/scripting/techs/learning/COLLAPSER.focs.txt
@@ -6,7 +6,7 @@ Tech
     researchcost = 1500 * [[TECH_COST_MULTIPLIER]]
     researchturns = 8
     tags = [ "PEDIA_LEARNING_CATEGORY" ]
-    prerequisites = ["LRN_ART_BLACK_HOLE" "LRN_STELLAR_TOMOGRAPHY" "LRN_SPATIAL_DISTORT_GEN"]
+    prerequisites = ["LRN_ART_BLACK_HOLE"  "LRN_SPATIAL_DISTORT_GEN"]
     unlock = Item type = Building name = "BLD_BLACK_HOLE_COLLAPSER"
     graphic = "icons/tech/black_hole_collapse.png"
 

--- a/default/scripting/techs/learning/GRAVITONICS.focs.txt
+++ b/default/scripting/techs/learning/GRAVITONICS.focs.txt
@@ -6,7 +6,10 @@ Tech
     researchcost = 80 * [[TECH_COST_MULTIPLIER]]
     researchturns = 5
     tags = [ "PEDIA_LEARNING_CATEGORY" ]
-    prerequisites = "LRN_FORCE_FIELD"
+    prerequisites = [
+        "LRN_FORCE_FIELD" 
+        "LRN_STELLAR_TOMOGRAPHY"
+    ]
     unlock = [
         Item type = Building name = "BLD_STARLANE_BORE"
         Item type = Building name = "BLD_SCRYING_SPHERE"

--- a/default/scripting/techs/learning/QUANT_NET.focs.txt
+++ b/default/scripting/techs/learning/QUANT_NET.focs.txt
@@ -3,7 +3,7 @@ Tech
     description = "LRN_QUANT_NET_DESC"
     short_description = "RESEARCH_SHORT_DESC"
     category = "LEARNING_CATEGORY"
-    researchcost = 200 * [[TECH_COST_MULTIPLIER]]
+    researchcost = 180 * [[TECH_COST_MULTIPLIER]]
     researchturns = 6
     tags = [ "PEDIA_LEARNING_CATEGORY" ]
     prerequisites = "LRN_NDIM_SUBSPACE"
@@ -15,7 +15,7 @@ Tech
                 Focus type = "FOCUS_RESEARCH"
             ]
             priority = [[LATE_PRIORITY]]
-            effects = SetTargetResearch value = Value + Target.Population * 2.5 * [[RESEARCH_PER_POP]]
+            effects = SetTargetResearch value = Value + Target.Population * 1.5 * [[RESEARCH_PER_POP]]
     ]
     graphic = "icons/tech/quantum_networking.png"
 

--- a/default/scripting/techs/learning/STELLAR_TOMOGRAPHY.focs.txt
+++ b/default/scripting/techs/learning/STELLAR_TOMOGRAPHY.focs.txt
@@ -3,10 +3,13 @@ Tech
     description = "LRN_STELLAR_TOMOGRAPHY_DESC"
     short_description = "RESEARCH_SHORT_DESC"
     category = "LEARNING_CATEGORY"
-    researchcost = 125 * [[TECH_COST_MULTIPLIER]]
+    researchcost = 60 * [[TECH_COST_MULTIPLIER]]
     researchturns = 6
     tags = [ "PEDIA_LEARNING_CATEGORY" ]
-    prerequisites = "LRN_EVERYTHING"
+    prerequisites = [
+        "LRN_ARTIF_MINDS"
+        "CON_ORBITAL_CON"
+    ]
     effectsgroups = [
         EffectsGroup
             scope = And [
@@ -16,7 +19,7 @@ Tech
                 Focus type = "FOCUS_RESEARCH"
             ]
             priority = [[LATE_PRIORITY]]
-            effects = SetTargetResearch value = Value + Target.Population * 5 * [[RESEARCH_PER_POP]]
+            effects = SetTargetResearch value = Value + Target.Population * 3 * [[RESEARCH_PER_POP]]
 
         EffectsGroup
             scope = And [
@@ -26,7 +29,7 @@ Tech
                 Focus type = "FOCUS_RESEARCH"
             ]
             priority = [[LATE_PRIORITY]]
-            effects = SetTargetResearch value = Value + Target.Population * 3.75 * [[RESEARCH_PER_POP]]
+            effects = SetTargetResearch value = Value + Target.Population * 2 * [[RESEARCH_PER_POP]]
 
         EffectsGroup
             scope = And [
@@ -36,7 +39,7 @@ Tech
                 Focus type = "FOCUS_RESEARCH"
             ]
             priority = [[LATE_PRIORITY]]
-            effects = SetTargetResearch value = Value + Target.Population * 2.5 * [[RESEARCH_PER_POP]]
+            effects = SetTargetResearch value = Value + Target.Population * 1 * [[RESEARCH_PER_POP]]
 
         EffectsGroup
             scope = And [
@@ -46,7 +49,7 @@ Tech
                 Focus type = "FOCUS_RESEARCH"
             ]
             priority = [[LATE_PRIORITY]]
-            effects = SetTargetResearch value = Value + Target.Population * 1 * [[RESEARCH_PER_POP]]
+            effects = SetTargetResearch value = Value + Target.Population * 0.5 * [[RESEARCH_PER_POP]]
     ]
     graphic = "icons/tech/stellar_tomography.png"
 

--- a/default/scripting/techs/production/SENTIENT_AUTOMATION.focs.txt
+++ b/default/scripting/techs/production/SENTIENT_AUTOMATION.focs.txt
@@ -18,7 +18,7 @@ Tech
                 TargetPopulation low = 0.0001
             ]
             priority = [[VERY_LATE_PRIORITY]]
-            effects = SetTargetIndustry value = Value + 5
+            effects = SetTargetIndustry value = Value + Target.Construction / 4
     ]
     graphic = "icons/tech/basic_autofactories.png"
 


### PR DESCRIPTION
Work in progress
- Moves Stellar Tomography earlier in tree, reduces costs and effect
- Changes Nascent AI to give an infrastructure based bonus
- Changes Adaptive Automation to give Infrastructure based bonus
- Reduces cost and power of Quantum Networking
- Reduces stat change bonus from Force Energy Structures

Follows from various forum discussions, objective is to make the research tree more interesting and less powerful, with more early/mid game bonuses but reduced overall bonuses. Tones down Force Energy because that's been way overpowered for a long time, and if the total bonuses available are to be reduced you don't need the substantial speed bump it gives.

I tried the Nasent AI infrastructure change as an experiment and liked it so much I did the same to Adaptive Automation, on balance it's a much more effective change than I was expecting and reduces the incentive to micromanage colony focus settings in the turns after conquest/colonisation.

I've been playing with this for a few weeks now and while the AI hasn't been adjusted I much prefer the tempo it gives the game: further work to follow but we said incremental changes were better and easier for the @freeorion/ai-team to adapt to.