### PR TITLE
Convert parse::X to return an X

### DIFF
--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -318,8 +318,7 @@ HumanClientApp::HumanClientApp(int width, int height, bool calculate_fps, const 
 
     this->SetMouseLRSwapped(GetOptionsDB().Get<bool>("UI.swap-mouse-lr"));
 
-    std::map<std::string, std::map<int, int>> named_key_maps;
-    parse::keymaps(named_key_maps);
+    auto named_key_maps = parse::keymaps();
     TraceLogger() << "Keymaps:";
     for (auto& km : named_key_maps) {
         TraceLogger() << "Keymap name = \"" << km.first << "\"";

--- a/parse/BuildingsParser.cpp
+++ b/parse/BuildingsParser.cpp
@@ -41,7 +41,9 @@ namespace {
     BOOST_PHOENIX_ADAPT_FUNCTION(void, insert_building_, insert_building, 6)
 
     struct rules {
-        rules() {
+        rules(const std::string& filename,
+              const parse::text_iterator& first, const parse::text_iterator& last)
+        {
             namespace phoenix = boost::phoenix;
             namespace qi = boost::spirit::qi;
 
@@ -82,7 +84,7 @@ namespace {
             debug(building_type);
 #endif
 
-            qi::on_error<qi::fail>(start, parse::report_error(_1, _2, _3, _4));
+            qi::on_error<qi::fail>(start, parse::report_error(filename, first, last, _1, _2, _3, _4));
         }
 
         typedef parse::detail::rule<

--- a/parse/BuildingsParser.cpp
+++ b/parse/BuildingsParser.cpp
@@ -107,13 +107,12 @@ namespace {
 }
 
 namespace parse {
-    bool buildings(std::map<std::string, std::unique_ptr<BuildingType>>& building_types) {
-        bool result = true;
-
+    std::map<std::string, std::unique_ptr<BuildingType>> buildings() {
+        std::map<std::string, std::unique_ptr<BuildingType>> building_types;
         for (const boost::filesystem::path& file : ListScripts("scripting/buildings")) {
-            result &= detail::parse_file<rules, std::map<std::string, std::unique_ptr<BuildingType>>>(file, building_types);
+            /*auto success =*/ detail::parse_file<rules, std::map<std::string, std::unique_ptr<BuildingType>>>(file, building_types);
         }
 
-        return result;
+        return building_types;
     }
 }

--- a/parse/EmpireStatsParser.cpp
+++ b/parse/EmpireStatsParser.cpp
@@ -16,7 +16,9 @@ namespace std {
 
 namespace {
     struct rules {
-        rules() {
+        rules(const std::string& filename,
+              const parse::text_iterator& first, const parse::text_iterator& last)
+        {
             namespace phoenix = boost::phoenix;
             namespace qi = boost::spirit::qi;
 
@@ -50,7 +52,7 @@ namespace {
             debug(stat);
 #endif
 
-            qi::on_error<qi::fail>(start, parse::report_error(_1, _2, _3, _4));
+            qi::on_error<qi::fail>(start, parse::report_error(filename, first, last, _1, _2, _3, _4));
         }
 
         typedef parse::detail::rule<

--- a/parse/EmpireStatsParser.cpp
+++ b/parse/EmpireStatsParser.cpp
@@ -70,13 +70,13 @@ namespace {
 }
 
 namespace parse {
-    bool statistics(std::map<std::string, ValueRef::ValueRefBase<double>*>& stats_) {
-        bool result = true;
+    std::map<std::string, ValueRef::ValueRefBase<double>*> statistics() {
+        std::map<std::string, ValueRef::ValueRefBase<double>*> stats_;
 
         for (const boost::filesystem::path& file : ListScripts("scripting/empire_statistics")) {
-            result &= detail::parse_file<rules, std::map<std::string, ValueRef::ValueRefBase<double>*>>(file, stats_);
+            /*auto success =*/ detail::parse_file<rules, std::map<std::string, ValueRef::ValueRefBase<double>*>>(file, stats_);
         }
 
-        return result;
+        return stats_;
     }
 }

--- a/parse/EncyclopediaParser.cpp
+++ b/parse/EncyclopediaParser.cpp
@@ -26,7 +26,9 @@ namespace {
     const boost::phoenix::function<insert_> insert;
 
     struct rules {
-        rules() {
+        rules(const std::string& filename,
+              const parse::text_iterator& first, const parse::text_iterator& last)
+        {
             namespace phoenix = boost::phoenix;
             namespace qi = boost::spirit::qi;
 
@@ -64,7 +66,7 @@ namespace {
             debug(article);
 #endif
 
-            qi::on_error<qi::fail>(start, parse::report_error(_1, _2, _3, _4));
+            qi::on_error<qi::fail>(start, parse::report_error(filename, first, last, _1, _2, _3, _4));
         }
 
         typedef parse::detail::rule<

--- a/parse/EncyclopediaParser.cpp
+++ b/parse/EncyclopediaParser.cpp
@@ -17,11 +17,13 @@ namespace std {
 #endif
 
 namespace {
+    using ArticleMap = std::map<std::string, std::vector<EncyclopediaArticle>>;
+
     struct insert_ {
         typedef void result_type;
 
-        void operator()(Encyclopedia& enc, const EncyclopediaArticle& article) const
-        { enc.articles[article.category].push_back(article); }
+        void operator()(ArticleMap& articles, const EncyclopediaArticle& article) const
+        { articles[article.category].push_back(article); }
     };
     const boost::phoenix::function<insert_> insert;
 
@@ -70,7 +72,7 @@ namespace {
         }
 
         typedef parse::detail::rule<
-            void (Encyclopedia&),
+            void (ArticleMap&),
             boost::spirit::qi::locals<
                 std::string,
                 std::string,
@@ -80,7 +82,7 @@ namespace {
         > strings_rule;
 
         typedef parse::detail::rule<
-            void (Encyclopedia&)
+            void (ArticleMap&)
         > start_rule;
 
 
@@ -90,15 +92,14 @@ namespace {
 }
 
 namespace parse {
-    bool encyclopedia_articles(Encyclopedia& enc) {
-        bool result = true;
-
+    ArticleMap encyclopedia_articles() {
         std::vector<boost::filesystem::path> file_list = ListScripts("scripting/encyclopedia");
 
+        ArticleMap articles;
         for (const boost::filesystem::path& file : file_list) {
-            result &= detail::parse_file<rules, Encyclopedia>(file, enc);
+            /*auto success =*/ detail::parse_file<rules, ArticleMap>(file, articles);
         }
 
-        return result;
+        return articles;
     }
 }

--- a/parse/FieldsParser.cpp
+++ b/parse/FieldsParser.cpp
@@ -103,13 +103,13 @@ namespace {
 }
 
 namespace parse {
-    bool fields(std::map<std::string, std::unique_ptr<FieldType>>& field_types) {
-        bool result = true;
+    std::map<std::string, std::unique_ptr<FieldType>> fields() {
+        std::map<std::string, std::unique_ptr<FieldType>> field_types;
 
         for (const boost::filesystem::path& file : ListScripts("scripting/fields")) {
-            result &= detail::parse_file<rules, std::map<std::string, std::unique_ptr<FieldType>>>(file, field_types);
+            /*auto success =*/ detail::parse_file<rules, std::map<std::string, std::unique_ptr<FieldType>>>(file, field_types);
         }
 
-        return result;
+        return field_types;
     }
 }

--- a/parse/FieldsParser.cpp
+++ b/parse/FieldsParser.cpp
@@ -37,7 +37,9 @@ namespace {
     BOOST_PHOENIX_ADAPT_FUNCTION(void, insert_fieldtype_, insert_fieldtype, 7)
 
     struct rules {
-        rules() {
+        rules(const std::string& filename,
+              const parse::text_iterator& first, const parse::text_iterator& last)
+        {
             namespace phoenix = boost::phoenix;
             namespace qi = boost::spirit::qi;
 
@@ -77,7 +79,7 @@ namespace {
             debug(field);
 #endif
 
-            qi::on_error<qi::fail>(start, parse::report_error(_1, _2, _3, _4));
+            qi::on_error<qi::fail>(start, parse::report_error(filename, first, last, _1, _2, _3, _4));
         }
 
         typedef parse::detail::rule<

--- a/parse/FleetPlansParser.cpp
+++ b/parse/FleetPlansParser.cpp
@@ -19,7 +19,9 @@ namespace std {
 
 namespace {
     struct rules {
-        rules() {
+        rules(const std::string& filename,
+              const parse::text_iterator& first, const parse::text_iterator& last)
+        {
             namespace phoenix = boost::phoenix;
             namespace qi = boost::spirit::qi;
 
@@ -57,7 +59,7 @@ namespace {
             debug(fleet_plan);
 #endif
 
-            qi::on_error<qi::fail>(start, parse::report_error(_1, _2, _3, _4));
+            qi::on_error<qi::fail>(start, parse::report_error(filename, first, last, _1, _2, _3, _4));
         }
 
         typedef parse::detail::rule<

--- a/parse/FleetPlansParser.cpp
+++ b/parse/FleetPlansParser.cpp
@@ -80,8 +80,10 @@ namespace {
 }
 
 namespace parse {
-    bool fleet_plans(std::vector<FleetPlan*>& fleet_plans_) {
+    std::vector<FleetPlan*> fleet_plans() {
+        std::vector<FleetPlan*> fleet_plans_;
         const boost::filesystem::path& path = GetResourceDir() / "scripting/starting_unlocks/fleets.inf";
-        return detail::parse_file<rules, std::vector<FleetPlan*>>(path, fleet_plans_);
+        /*auto success =*/ detail::parse_file<rules, std::vector<FleetPlan*>>(path, fleet_plans_);
+        return fleet_plans_;
     }
 }

--- a/parse/GameRulesParser.cpp
+++ b/parse/GameRulesParser.cpp
@@ -75,7 +75,9 @@ namespace {
     const boost::phoenix::function<insert_rule_> add_rule;
 
     struct rules {
-        rules() {
+        rules(const std::string& filename,
+              const parse::text_iterator& first, const parse::text_iterator& last)
+        {
             namespace phoenix = boost::phoenix;
             namespace qi = boost::spirit::qi;
 
@@ -189,7 +191,7 @@ namespace {
             debug(game_rule_string_list);
 #endif
 
-            qi::on_error<qi::fail>(start, parse::report_error(_1, _2, _3, _4));
+            qi::on_error<qi::fail>(start, parse::report_error(filename, first, last, _1, _2, _3, _4));
         }
 
         typedef parse::detail::rule<

--- a/parse/ItemsParser.cpp
+++ b/parse/ItemsParser.cpp
@@ -49,13 +49,17 @@ namespace {
 }
 
 namespace parse {
-    bool items(std::vector<ItemSpec>& items_) {
+    std::vector<ItemSpec> items() {
+        std::vector<ItemSpec> items_;
         const boost::filesystem::path& path = GetResourceDir() / "scripting/starting_unlocks/items.inf";
-        return detail::parse_file<rules, std::vector<ItemSpec>>(path, items_);
+        /*auto success =*/ detail::parse_file<rules, std::vector<ItemSpec>>(path, items_);
+        return items_;
     }
 
-    bool starting_buildings(std::vector<ItemSpec>& starting_buildings_) {
+    std::vector<ItemSpec> starting_buildings() {
+        std::vector<ItemSpec> starting_buildings_;
         const boost::filesystem::path& path = GetResourceDir() / "scripting/starting_unlocks/buildings.inf";
-        return detail::parse_file<rules, std::vector<ItemSpec> >(path, starting_buildings_);
+        /*auto success =*/ detail::parse_file<rules, std::vector<ItemSpec> >(path, starting_buildings_);
+        return starting_buildings_;
     }
 }

--- a/parse/ItemsParser.cpp
+++ b/parse/ItemsParser.cpp
@@ -17,7 +17,9 @@ namespace std {
 
 namespace {
     struct rules {
-        rules() {
+        rules(const std::string& filename,
+              const parse::text_iterator& first, const parse::text_iterator& last)
+        {
             namespace phoenix = boost::phoenix;
             namespace qi = boost::spirit::qi;
 
@@ -35,7 +37,7 @@ namespace {
 
             start.name("start");
 
-            qi::on_error<qi::fail>(start, parse::report_error(_1, _2, _3, _4));
+            qi::on_error<qi::fail>(start, parse::report_error(filename, first, last, _1, _2, _3, _4));
         }
 
         typedef parse::detail::rule<

--- a/parse/KeymapParser.cpp
+++ b/parse/KeymapParser.cpp
@@ -110,8 +110,10 @@ namespace {
 }
 
 namespace parse {
-    bool keymaps(NamedKeymaps& nkm) {
+    NamedKeymaps keymaps() {
+        NamedKeymaps nkm;
         boost::filesystem::path path = GetResourceDir() / "scripting/keymaps.inf";
-        return detail::parse_file<rules, NamedKeymaps>(path, nkm);
+        /*auto success =*/ detail::parse_file<rules, NamedKeymaps>(path, nkm);
+        return nkm;
     }
 }

--- a/parse/KeymapParser.cpp
+++ b/parse/KeymapParser.cpp
@@ -43,7 +43,9 @@ namespace {
     const boost::phoenix::function<insert_key_map_> insert_key_map;
 
     struct rules {
-        rules() {
+        rules(const std::string& filename,
+              const parse::text_iterator& first, const parse::text_iterator& last)
+        {
             namespace phoenix = boost::phoenix;
             namespace qi = boost::spirit::qi;
 
@@ -84,7 +86,7 @@ namespace {
             debug(article);
 #endif
 
-            qi::on_error<qi::fail>(start, parse::report_error(_1, _2, _3, _4));
+            qi::on_error<qi::fail>(start, parse::report_error(filename, first, last, _1, _2, _3, _4));
         }
 
         typedef parse::detail::rule<

--- a/parse/MonsterFleetPlansParser.cpp
+++ b/parse/MonsterFleetPlansParser.cpp
@@ -30,7 +30,9 @@ namespace {
     const boost::phoenix::function<new_monster_fleet_plan_> new_monster_fleet_plan;
 
     struct rules {
-        rules() {
+        rules(const std::string& filename,
+              const parse::text_iterator& first, const parse::text_iterator& last)
+        {
             namespace phoenix = boost::phoenix;
             namespace qi = boost::spirit::qi;
 
@@ -95,7 +97,7 @@ namespace {
             debug(monster_fleet_plan);
 #endif
 
-            qi::on_error<qi::fail>(start, parse::report_error(_1, _2, _3, _4));
+            qi::on_error<qi::fail>(start, parse::report_error(filename, first, last, _1, _2, _3, _4));
         }
 
         typedef parse::detail::rule<> generic_rule;

--- a/parse/MonsterFleetPlansParser.cpp
+++ b/parse/MonsterFleetPlansParser.cpp
@@ -127,8 +127,10 @@ namespace {
 }
 
 namespace parse {
-    bool monster_fleet_plans(std::vector<MonsterFleetPlan*>& monster_fleet_plans_) {
+    std::vector<MonsterFleetPlan*> monster_fleet_plans() {
+        std::vector<MonsterFleetPlan*> monster_fleet_plans_;
         boost::filesystem::path path = GetResourceDir() / "scripting/monster_fleets.inf";
-        return detail::parse_file<rules, std::vector<MonsterFleetPlan*>>(path, monster_fleet_plans_);
+        /*auto success =*/ detail::parse_file<rules, std::vector<MonsterFleetPlan*>>(path, monster_fleet_plans_);
+        return monster_fleet_plans_;
     }
 }

--- a/parse/Parse.cpp
+++ b/parse/Parse.cpp
@@ -635,7 +635,7 @@ namespace parse {
          */
         void parse_file_common(const boost::filesystem::path& path, const parse::lexer& lexer,
                                std::string& filename, std::string& file_contents,
-                               parse::text_iterator& first, parse::token_iterator& it)
+                               parse::text_iterator& first, parse::text_iterator& last, parse::token_iterator& it)
         {
             filename = path.string();
 
@@ -651,15 +651,9 @@ namespace parse {
             file_substitution(file_contents, path.parent_path());
             macro_substitution(file_contents);
 
-            first = parse::text_iterator(file_contents.begin());
-            parse::text_iterator last(file_contents.end());
+            first = file_contents.begin();
+            last = file_contents.end();
 
-            // WARNING: These static global values assume that only one file is parsed at a time.
-            // That assumption is incorrect, and these values will be unreliable.
-            parse::detail::s_text_it = &first;
-            parse::detail::s_begin = first;
-            parse::detail::s_end = last;
-            parse::detail::s_filename = filename.c_str();
             it = lexer.begin(first, last);
         }
     }

--- a/parse/Parse.h
+++ b/parse/Parse.h
@@ -27,26 +27,25 @@ class GameRules;
 namespace parse {
     FO_PARSE_API void init();
 
-    FO_PARSE_API bool buildings(std::map<std::string,
-                                std::unique_ptr<BuildingType>>& building_types);
+    FO_PARSE_API std::map<std::string, std::unique_ptr<BuildingType>> buildings();
 
-    FO_PARSE_API bool fields(std::map<std::string, std::unique_ptr<FieldType>>& field_types);
+    FO_PARSE_API std::map<std::string, std::unique_ptr<FieldType>> fields();
 
-    FO_PARSE_API bool specials(std::map<std::string, std::unique_ptr<Special>>& specials_);
+    FO_PARSE_API std::map<std::string, std::unique_ptr<Special>> specials();
 
-    FO_PARSE_API bool species(std::map<std::string, std::unique_ptr<Species>>& species_);
+    FO_PARSE_API std::map<std::string, std::unique_ptr<Species>> species();
 
     FO_PARSE_API bool techs(TechManager::TechContainer& techs_,
                             std::map<std::string, std::unique_ptr<TechCategory>>& tech_categories,
                             std::set<std::string>& categories_seen);
 
-    FO_PARSE_API bool items(std::vector<ItemSpec>& items_);
+    FO_PARSE_API std::vector<ItemSpec> items();
 
-    FO_PARSE_API bool starting_buildings(std::vector<ItemSpec>& starting_buildings_);
+    FO_PARSE_API std::vector<ItemSpec> starting_buildings();
 
-    FO_PARSE_API bool ship_parts(std::map<std::string, std::unique_ptr<PartType>>& parts);
+    FO_PARSE_API std::map<std::string, std::unique_ptr<PartType>> ship_parts();
 
-    FO_PARSE_API bool ship_hulls(std::map<std::string, std::unique_ptr<HullType>>& hulls);
+    FO_PARSE_API std::map<std::string, std::unique_ptr<HullType>> ship_hulls();
 
     /** Parse all ship designs in directory \p path, store them with their filename in \p
         design_and_path. If a file exists called ShipDesignOrdering.focs.txt, parse it and
@@ -62,17 +61,17 @@ namespace parse {
     FO_PARSE_API bool monster_designs(std::vector<std::unique_ptr<ShipDesign>>& designs,
                                       std::vector<boost::uuids::uuid>& ordering);
 
-    FO_PARSE_API bool fleet_plans(std::vector<FleetPlan*>& fleet_plans_);
+    FO_PARSE_API std::vector<FleetPlan*> fleet_plans();
 
-    FO_PARSE_API bool monster_fleet_plans(std::vector<MonsterFleetPlan*>& monster_fleet_plans_);
+    FO_PARSE_API std::vector<MonsterFleetPlan*> monster_fleet_plans();
 
-    FO_PARSE_API bool statistics(std::map<std::string, ValueRef::ValueRefBase<double>*>& stats_);
+    FO_PARSE_API std::map<std::string, ValueRef::ValueRefBase<double>*> statistics();
 
     FO_PARSE_API bool encyclopedia_articles(Encyclopedia& enc);
 
-    FO_PARSE_API bool keymaps(std::map<std::string, std::map<int, int>>& nkm);
+    FO_PARSE_API std::map<std::string, std::map<int, int>> keymaps();
 
-    FO_PARSE_API bool game_rules(GameRules& rules);
+    FO_PARSE_API bool game_rules(GameRules& game_rules);
 
     FO_PARSE_API bool read_file(const boost::filesystem::path& path, std::string& file_contents);
 

--- a/parse/Parse.h
+++ b/parse/Parse.h
@@ -21,7 +21,7 @@ class PartType;
 class ShipDesign;
 class Special;
 class Species;
-struct Encyclopedia;
+struct EncyclopediaArticle;
 class GameRules;
 
 namespace parse {
@@ -73,7 +73,7 @@ namespace parse {
 
     FO_PARSE_API std::map<std::string, ValueRef::ValueRefBase<double>*> statistics();
 
-    FO_PARSE_API bool encyclopedia_articles(Encyclopedia& enc);
+    FO_PARSE_API std::map<std::string, std::vector<EncyclopediaArticle>> encyclopedia_articles();
 
     FO_PARSE_API std::map<std::string, std::map<int, int>> keymaps();
 

--- a/parse/Parse.h
+++ b/parse/Parse.h
@@ -35,9 +35,11 @@ namespace parse {
 
     FO_PARSE_API std::map<std::string, std::unique_ptr<Species>> species();
 
-    FO_PARSE_API bool techs(TechManager::TechContainer& techs_,
-                            std::map<std::string, std::unique_ptr<TechCategory>>& tech_categories,
-                            std::set<std::string>& categories_seen);
+    FO_PARSE_API std::tuple<
+        TechManager::TechContainer, // techs_
+        std::map<std::string, std::unique_ptr<TechCategory>>, // tech_categories,
+        std::set<std::string> // categories_seen
+        > techs();
 
     FO_PARSE_API std::vector<ItemSpec> items();
 

--- a/parse/Parse.h
+++ b/parse/Parse.h
@@ -50,16 +50,20 @@ namespace parse {
     /** Parse all ship designs in directory \p path, store them with their filename in \p
         design_and_path. If a file exists called ShipDesignOrdering.focs.txt, parse it and
         store the order in \p ordering. */
-    FO_PARSE_API bool ship_designs(const boost::filesystem::path& path,
-                                   std::vector<std::pair<std::unique_ptr<ShipDesign>,
-                                                         boost::filesystem::path>>& designs_and_paths,
-                                   std::vector<boost::uuids::uuid>& ordering);
+    FO_PARSE_API std::pair<
+        std::vector<std::pair<std::unique_ptr<ShipDesign>, boost::filesystem::path>>, // designs_and_paths,
+        std::vector<boost::uuids::uuid> // ordering
+        > ship_designs(const boost::filesystem::path& path);
 
-    FO_PARSE_API bool ship_designs(std::vector<std::unique_ptr<ShipDesign>>& designs,
-                                   std::vector<boost::uuids::uuid>& ordering);
+    FO_PARSE_API std::pair<
+        std::vector<std::unique_ptr<ShipDesign>>, // designs
+        std::vector<boost::uuids::uuid> // ordering
+        > ship_designs();
 
-    FO_PARSE_API bool monster_designs(std::vector<std::unique_ptr<ShipDesign>>& designs,
-                                      std::vector<boost::uuids::uuid>& ordering);
+    FO_PARSE_API std::pair<
+        std::vector<std::unique_ptr<ShipDesign>>, // designs
+        std::vector<boost::uuids::uuid> // ordering
+        > monster_designs();
 
     FO_PARSE_API std::vector<FleetPlan*> fleet_plans();
 

--- a/parse/ParseImpl.h
+++ b/parse/ParseImpl.h
@@ -100,6 +100,7 @@ namespace parse { namespace detail {
                            std::string& filename,
                            std::string& file_contents,
                            text_iterator& first,
+                           text_iterator& last,
                            token_iterator& it);
 
     template <typename Rules, typename Arg1>
@@ -108,19 +109,20 @@ namespace parse { namespace detail {
         std::string filename;
         std::string file_contents;
         text_iterator first;
+        text_iterator last;
         token_iterator it;
 
         boost::timer timer;
 
         const lexer& lexer = lexer::instance();
 
-        parse_file_common(path, lexer, filename, file_contents, first, it);
+        parse_file_common(path, lexer, filename, file_contents, first, last, it);
 
         //TraceLogger() << "Parse: parsed contents for " << path.string() << " : \n" << file_contents;
 
         boost::spirit::qi::in_state_type in_state;
 
-        static Rules rules;
+        Rules rules(filename, first, last);
 
         bool success = boost::spirit::qi::phrase_parse(it, lexer.end(), rules.start(boost::phoenix::ref(arg1)), in_state("WS")[lexer.self]);
 

--- a/parse/ReportParseError.h
+++ b/parse/ReportParseError.h
@@ -35,34 +35,31 @@ namespace parse {
         void pretty_print(std::ostream& os, boost::spirit::info const& what);
 
         void default_send_error_string(const std::string& str);
-
-        // WARNING: These static global values assume that only one file is parsed at a time.
-        // That assumption is incorrect, and these values will be unreliable.
-        extern const char*      s_filename;
-        extern text_iterator*   s_text_it;
-        extern text_iterator    s_begin;
-        extern text_iterator    s_end;
     }
 
     struct report_error_ {
         typedef void result_type;
 
         template <typename Arg1, typename Arg2, typename Arg3, typename Arg4>
-        void operator()(Arg1 first, Arg2, Arg3 it, Arg4 rule_name) const
+        void operator()(const std::string& filename, const text_iterator& begin, const text_iterator& end,
+                        Arg1 first, Arg2, Arg3 it, Arg4 rule_name) const
         {
             std::string error_string;
-            generate_error_string(first, it, rule_name, error_string);
+            generate_error_string(filename, begin, end, first, it, rule_name, error_string);
             send_error_string(error_string);
         }
 
         static boost::function<void (const std::string&)> send_error_string;
 
     private:
-        std::pair<text_iterator, unsigned int> line_start_and_line_number(text_iterator error_position) const;
-        std::string get_line(text_iterator line_start) const;
-        std::string get_lines_before(text_iterator line_start) const;
-        std::string get_lines_after(text_iterator line_start) const;
-        void generate_error_string(const token_iterator& first,
+        std::pair<text_iterator, unsigned int> line_start_and_line_number(
+            const text_iterator& begin, const text_iterator& end, text_iterator error_position) const;
+        std::string get_line(const text_iterator& end, text_iterator line_start) const;
+        std::string get_lines_before(const text_iterator& begin, const text_iterator& end, text_iterator line_start) const;
+        std::string get_lines_after(const text_iterator& begin, const text_iterator& end, text_iterator line_start) const;
+        void generate_error_string(const std::string& filename,
+                                   const text_iterator& begin, const text_iterator& end,
+                                   const token_iterator& first,
                                    const token_iterator& it,
                                    const boost::spirit::info& rule_name,
                                    std::string& str) const;

--- a/parse/ShipDesignsParser.cpp
+++ b/parse/ShipDesignsParser.cpp
@@ -66,7 +66,9 @@ namespace {
     BOOST_PHOENIX_ADAPT_FUNCTION(boost::uuids::uuid, parse_uuid_, parse_uuid, 1)
 
     struct rules {
-        rules() {
+        rules(const std::string& filename,
+              const parse::text_iterator& first, const parse::text_iterator& last)
+        {
             namespace phoenix = boost::phoenix;
             namespace qi = boost::spirit::qi;
 
@@ -135,7 +137,7 @@ namespace {
             debug(design);
 #endif
 
-            qi::on_error<qi::fail>(start, parse::report_error(_1, _2, _3, _4));
+            qi::on_error<qi::fail>(start, parse::report_error(filename, first, last, _1, _2, _3, _4));
         }
 
         using design_prefix_rule = parse::detail::rule<
@@ -164,7 +166,9 @@ namespace {
     };
 
     struct manifest_rules {
-        manifest_rules() {
+        manifest_rules(const std::string& filename,
+              const parse::text_iterator& first, const parse::text_iterator& last)
+        {
             namespace phoenix = boost::phoenix;
             namespace qi = boost::spirit::qi;
 
@@ -193,7 +197,7 @@ namespace {
             debug(design_manifest);
 #endif
 
-            qi::on_error<qi::fail>(start, parse::report_error(_1, _2, _3, _4));
+            qi::on_error<qi::fail>(start, parse::report_error(filename, first, last, _1, _2, _3, _4));
         }
 
         using manifest_rule = parse::detail::rule<void (std::vector<boost::uuids::uuid>&)>;

--- a/parse/ShipDesignsParser.cpp
+++ b/parse/ShipDesignsParser.cpp
@@ -210,16 +210,19 @@ namespace {
 }
 
 namespace parse {
-    bool ship_designs(const boost::filesystem::path& path,
-                      std::vector<std::pair<std::unique_ptr<ShipDesign>, boost::filesystem::path>>& designs_and_paths,
-                      std::vector<boost::uuids::uuid>& ordering)
-    {
+    std::pair<
+        std::vector<std::pair<std::unique_ptr<ShipDesign>, boost::filesystem::path>>, // designs_and_paths
+        std::vector<boost::uuids::uuid> //ordering
+        >
+    ship_designs(const boost::filesystem::path& path) {
+        std::vector<std::pair<std::unique_ptr<ShipDesign>, boost::filesystem::path>> designs_and_paths;
+        std::vector<boost::uuids::uuid> ordering;
+
         boost::filesystem::path manifest_file;
 
         // Allow files with any suffix in order to convert legacy ShipDesign files.
         bool permissive_mode = true;
         const auto& scripts = ListScripts(path, permissive_mode);
-        bool result = true;
 
         for (const auto& file : scripts) {
             if (file.filename() == "ShipDesignOrdering.focs.txt" ) {
@@ -230,48 +233,55 @@ namespace parse {
             try {
                 boost::optional<std::unique_ptr<ShipDesign>> maybe_design;
                 auto partial_result = detail::parse_file<rules, boost::optional<std::unique_ptr<ShipDesign>>>(file, maybe_design);
-                result &= partial_result;
                 if (!partial_result || !maybe_design)
                     continue;
                 designs_and_paths.push_back({std::move(*maybe_design), file});
 
             } catch (const std::runtime_error& e) {
-                result = false;
                 ErrorLogger() << "Failed to parse ship design in " << file << " from " << path << " because " << e.what();;
             }
         }
 
         if (!manifest_file.empty()) {
             try {
-                result &= detail::parse_file<manifest_rules, std::vector<boost::uuids::uuid>>(manifest_file, ordering);
+                /*auto success =*/ detail::parse_file<manifest_rules, std::vector<boost::uuids::uuid>>(manifest_file, ordering);
             } catch (const std::runtime_error& e) {
-                result = false;
                 ErrorLogger() << "Failed to parse ship design manifest in " << manifest_file << " from " << path
                               << " because " << e.what();;
             }
         }
 
-        return result;
+        return {std::move(designs_and_paths), ordering};
     }
 }
 namespace {
     /** Remove the file paths from the returned ShipDesigns.*/
-    bool only_ship_designs(const boost::filesystem::path& path,
-                           std::vector<std::unique_ptr<ShipDesign>>& designs,
-                           std::vector<boost::uuids::uuid>& ordering)
-    {
-        std::vector<std::pair<std::unique_ptr<ShipDesign>, boost::filesystem::path>> designs_and_paths;
-        auto result = parse::ship_designs(path,  designs_and_paths, ordering);
-        for (auto& design_and_path : designs_and_paths)
+    std::pair<
+        std::vector<std::unique_ptr<ShipDesign>>, // designs
+        std::vector<boost::uuids::uuid> // ordering
+        >
+    only_ship_designs(const boost::filesystem::path& path) {
+        auto design_paths_and_ordering = parse::ship_designs(path);
+
+        std::vector<std::unique_ptr<ShipDesign>> designs;
+        for (auto& design_and_path : design_paths_and_ordering.first)
             designs.push_back(std::move(design_and_path.first));
-        return result;
+        return {std::move(designs), design_paths_and_ordering.second};
     }
 }
 
 namespace parse {
-    bool ship_designs(std::vector<std::unique_ptr<ShipDesign>>& designs, std::vector<boost::uuids::uuid>& ordering)
-    { return only_ship_designs("scripting/ship_designs",  designs, ordering); }
+    std::pair<
+        std::vector<std::unique_ptr<ShipDesign>>, // designs
+        std::vector<boost::uuids::uuid> // ordering
+        >
+    ship_designs()
+    { return only_ship_designs("scripting/ship_designs"); }
 
-    bool monster_designs(std::vector<std::unique_ptr<ShipDesign>>& designs, std::vector<boost::uuids::uuid>& ordering)
-    { return only_ship_designs("scripting/monster_designs", designs, ordering); }
+    std::pair<
+        std::vector<std::unique_ptr<ShipDesign>>, // designs
+        std::vector<boost::uuids::uuid> // ordering
+        >
+    monster_designs()
+    { return only_ship_designs("scripting/monster_designs"); }
 }

--- a/parse/ShipHullsParser.cpp
+++ b/parse/ShipHullsParser.cpp
@@ -45,7 +45,9 @@ namespace {
     BOOST_PHOENIX_ADAPT_FUNCTION(void, insert_hulltype_, insert_hulltype, 7)
 
     struct rules {
-        rules() {
+        rules(const std::string& filename,
+              const parse::text_iterator& first, const parse::text_iterator& last)
+        {
             namespace phoenix = boost::phoenix;
             namespace qi = boost::spirit::qi;
 
@@ -125,7 +127,7 @@ namespace {
             debug(hull);
 #endif
 
-            qi::on_error<qi::fail>(start, parse::report_error(_1, _2, _3, _4));
+            qi::on_error<qi::fail>(start, parse::report_error(filename, first, last, _1, _2, _3, _4));
         }
 
         typedef parse::detail::rule<

--- a/parse/ShipHullsParser.cpp
+++ b/parse/ShipHullsParser.cpp
@@ -178,13 +178,13 @@ namespace {
 }
 
 namespace parse {
-    bool ship_hulls(std::map<std::string, std::unique_ptr<HullType>>& hulls) {
-        bool result = true;
+    std::map<std::string, std::unique_ptr<HullType>> ship_hulls() {
+        std::map<std::string, std::unique_ptr<HullType>> hulls;
 
         for (const boost::filesystem::path& file : ListScripts("scripting/ship_hulls")) {
-            result &= detail::parse_file<rules, std::map<std::string, std::unique_ptr<HullType>>>(file, hulls);
+            /*auto success =*/ detail::parse_file<rules, std::map<std::string, std::unique_ptr<HullType>>>(file, hulls);
         }
 
-        return result;
+        return hulls;
     }
 }

--- a/parse/ShipPartsParser.cpp
+++ b/parse/ShipPartsParser.cpp
@@ -47,7 +47,9 @@ namespace {
     BOOST_PHOENIX_ADAPT_FUNCTION(void, insert_parttype_, insert_parttype, 9)
 
     struct rules {
-        rules() {
+        rules(const std::string& filename,
+              const parse::text_iterator& first, const parse::text_iterator& last)
+        {
             namespace phoenix = boost::phoenix;
             namespace qi = boost::spirit::qi;
 
@@ -115,7 +117,7 @@ namespace {
             debug(part_type);
 #endif
 
-            qi::on_error<qi::fail>(start, parse::report_error(_1, _2, _3, _4));
+            qi::on_error<qi::fail>(start, parse::report_error(filename, first, last, _1, _2, _3, _4));
         }
 
         typedef parse::detail::rule<

--- a/parse/ShipPartsParser.cpp
+++ b/parse/ShipPartsParser.cpp
@@ -150,13 +150,13 @@ namespace {
 }
 
 namespace parse {
-    bool ship_parts(std::map<std::string, std::unique_ptr<PartType>>& parts) {
-        bool result = true;
+    std::map<std::string, std::unique_ptr<PartType>> ship_parts() {
+        std::map<std::string, std::unique_ptr<PartType>> parts;
 
         for (const auto& file : ListScripts("scripting/ship_parts")) {
-            result &= detail::parse_file<rules, std::map<std::string, std::unique_ptr<PartType>>>(file, parts);
+            /*auto success =*/ detail::parse_file<rules, std::map<std::string, std::unique_ptr<PartType>>>(file, parts);
         }
 
-        return result;
+        return parts;
     }
 }

--- a/parse/SpecialsParser.cpp
+++ b/parse/SpecialsParser.cpp
@@ -170,13 +170,13 @@ namespace {
 }
 
 namespace parse {
-    bool specials(std::map<std::string, std::unique_ptr<Special>>& specials_) {
-        bool result = true;
+    std::map<std::string, std::unique_ptr<Special>> specials() {
+        std::map<std::string, std::unique_ptr<Special>> specials_;
 
         for (const boost::filesystem::path& file : ListScripts("scripting/specials")) {
-            result &= detail::parse_file<rules, std::map<std::string, std::unique_ptr<Special>>>(file, specials_);
+            /*auto success =*/ detail::parse_file<rules, std::map<std::string, std::unique_ptr<Special>>>(file, specials_);
         }
 
-        return result;
+        return specials_;
     }
 }

--- a/parse/SpecialsParser.cpp
+++ b/parse/SpecialsParser.cpp
@@ -65,7 +65,9 @@ namespace {
     BOOST_PHOENIX_ADAPT_FUNCTION(void, insert_special_, insert_special, 2)
 
     struct rules {
-        rules() {
+        rules(const std::string& filename,
+              const parse::text_iterator& first, const parse::text_iterator& last)
+        {
             namespace phoenix = boost::phoenix;
             namespace qi = boost::spirit::qi;
 
@@ -130,7 +132,7 @@ namespace {
             debug(special);
 #endif
 
-            qi::on_error<qi::fail>(start, parse::report_error(_1, _2, _3, _4));
+            qi::on_error<qi::fail>(start, parse::report_error(filename, first, last, _1, _2, _3, _4));
         }
 
         typedef parse::detail::rule<

--- a/parse/SpeciesParser.cpp
+++ b/parse/SpeciesParser.cpp
@@ -253,13 +253,13 @@ namespace {
 }
 
 namespace parse {
-    bool species(std::map<std::string, std::unique_ptr<Species>>& species_) {
-        bool result = true;
+    std::map<std::string, std::unique_ptr<Species>> species() {
+        std::map<std::string, std::unique_ptr<Species>> species_;
 
         for (const boost::filesystem::path& file : ListScripts("scripting/species")) {
-            result &= detail::parse_file<rules, std::map<std::string, std::unique_ptr<Species>>>(file, species_);
+            /*auto success =*/ detail::parse_file<rules, std::map<std::string, std::unique_ptr<Species>>>(file, species_);
         }
 
-        return result;
+        return species_;
     }
 }

--- a/parse/SpeciesParser.cpp
+++ b/parse/SpeciesParser.cpp
@@ -49,7 +49,9 @@ namespace {
 
 
     struct rules {
-        rules() {
+        rules(const std::string& filename,
+              const parse::text_iterator& first, const parse::text_iterator& last)
+        {
             namespace phoenix = boost::phoenix;
             namespace qi = boost::spirit::qi;
 
@@ -168,7 +170,7 @@ namespace {
             debug(start);
 #endif
 
-            qi::on_error<qi::fail>(start, parse::report_error(_1, _2, _3, _4));
+            qi::on_error<qi::fail>(start, parse::report_error(filename, first, last, _1, _2, _3, _4));
         }
 
         typedef parse::detail::rule<

--- a/parse/TechsParser.cpp
+++ b/parse/TechsParser.cpp
@@ -239,21 +239,24 @@ namespace {
 }
 
 namespace parse {
-    bool techs(TechManager::TechContainer& techs_,
-               std::map<std::string, std::unique_ptr<TechCategory>>& categories,
-               std::set<std::string>& categories_seen)
-    {
-        bool result = true;
+    std::tuple<
+        TechManager::TechContainer, // techs_
+        std::map<std::string, std::unique_ptr<TechCategory>>, // tech_categories,
+        std::set<std::string>> // categories_seen
+    techs() {
+        TechManager::TechContainer techs_;
+        std::map<std::string, std::unique_ptr<TechCategory>> categories;
+        std::set<std::string> categories_seen;
 
         g_categories_seen = &categories_seen;
         g_categories = &categories;
 
-        result &= detail::parse_file<rules, TechManager::TechContainer>(GetResourceDir() / "scripting/techs/Categories.inf", techs_);
+        /*auto success =*/ detail::parse_file<rules, TechManager::TechContainer>(GetResourceDir() / "scripting/techs/Categories.inf", techs_);
 
         for (const boost::filesystem::path& file : ListScripts("scripting/techs")) {
-            result &= detail::parse_file<rules, TechManager::TechContainer>(file, techs_);
+            /*auto success =*/ detail::parse_file<rules, TechManager::TechContainer>(file, techs_);
         }
 
-        return result;
+        return std::make_tuple(std::move(techs_), std::move(categories), categories_seen);
     }
 }

--- a/parse/TechsParser.cpp
+++ b/parse/TechsParser.cpp
@@ -71,7 +71,9 @@ namespace {
 
 
     struct rules {
-        rules() {
+        rules(const std::string& filename,
+              const parse::text_iterator& first, const parse::text_iterator& last)
+        {
             namespace phoenix = boost::phoenix;
             namespace qi = boost::spirit::qi;
 
@@ -173,7 +175,7 @@ namespace {
             debug(category);
 #endif
 
-            qi::on_error<qi::fail>(start, parse::report_error(_1, _2, _3, _4));
+            qi::on_error<qi::fail>(start, parse::report_error(filename, first, last, _1, _2, _3, _4));
         }
 
         typedef parse::detail::rule<

--- a/python/server/ServerWrapper.cpp
+++ b/python/server/ServerWrapper.cpp
@@ -349,8 +349,7 @@ namespace {
     // Wrapper for preunlocked items
     list LoadItemSpecList() {
         list py_items;
-        std::vector<ItemSpec> items;
-        parse::items(items);
+        auto items = parse::items();
         for (const auto& item : items) {
             py_items.append(object(item));
         }
@@ -360,8 +359,7 @@ namespace {
     // Wrapper for starting buildings
     list LoadStartingBuildings() {
         list py_items;
-        std::vector<ItemSpec> buildings;
-        parse::starting_buildings(buildings);
+        auto buildings = parse::starting_buildings();
         for (auto building : buildings) {
             if (GetBuildingType(building.name))
                 py_items.append(object(building));
@@ -474,8 +472,7 @@ namespace {
 
     list LoadFleetPlanList() {
         list py_fleet_plans;
-        std::vector<FleetPlan*> fleet_plans;
-        parse::fleet_plans(fleet_plans);
+        auto fleet_plans = parse::fleet_plans();
         for (FleetPlan* fleet_plan : fleet_plans) {
             py_fleet_plans.append(new FleetPlanWrapper(fleet_plan));
         }
@@ -536,8 +533,7 @@ namespace {
 
     list LoadMonsterFleetPlanList() {
         list py_monster_fleet_plans;
-        std::vector<MonsterFleetPlan*> monster_fleet_plans;
-        parse::monster_fleet_plans(monster_fleet_plans);
+        auto monster_fleet_plans = parse::monster_fleet_plans();
         for (auto* fleet_plan : monster_fleet_plans) {
             py_monster_fleet_plans.append(new MonsterFleetPlanWrapper(fleet_plan));
         }

--- a/universe/Building.cpp
+++ b/universe/Building.cpp
@@ -355,7 +355,7 @@ BuildingTypeManager::BuildingTypeManager() {
     TraceLogger() << "BuildingTypeManager::BuildingTypeManager() about to parse buildings.";
 
     try {
-        parse::buildings(m_building_types);
+        m_building_types = parse::buildings();
     } catch (const std::exception& e) {
         ErrorLogger() << "Failed parsing buildings: error: " << e.what();
         throw e;

--- a/universe/Building.cpp
+++ b/universe/Building.cpp
@@ -368,8 +368,6 @@ BuildingTypeManager::BuildingTypeManager() {
 
     // Only update the global pointer on sucessful construction.
     s_instance = this;
-
-    DebugLogger() << "BuildingTypeManager checksum: " << GetCheckSum();
 }
 
 const BuildingType* BuildingTypeManager::GetBuildingType(const std::string& name) const {
@@ -388,6 +386,8 @@ unsigned int BuildingTypeManager::GetCheckSum() const {
         CheckSums::CheckSumCombine(retval, name_type_pair);
     CheckSums::CheckSumCombine(retval, m_building_types.size());
 
+
+    DebugLogger() << "BuildingTypeManager checksum: " << retval;
     return retval;
 }
 

--- a/universe/Encyclopedia.cpp
+++ b/universe/Encyclopedia.cpp
@@ -17,7 +17,7 @@ Encyclopedia::Encyclopedia() :
     empty_article()
 {
     try {
-        parse::encyclopedia_articles(*this);
+        articles = parse::encyclopedia_articles();
         DebugLogger() << "Encyclopedia Articles checksum: " << GetCheckSum();
 
     } catch (const std::exception& e) {

--- a/universe/Field.cpp
+++ b/universe/Field.cpp
@@ -244,7 +244,7 @@ FieldTypeManager::FieldTypeManager() {
     ScopedTimer timer("FieldTypeManager Init", true, std::chrono::milliseconds(1));
 
     try {
-        parse::fields(m_field_types);
+        m_field_types = parse::fields();
     } catch (const std::exception& e) {
         ErrorLogger() << "Failed parsing fields: error: " << e.what();
         throw e;

--- a/universe/Field.cpp
+++ b/universe/Field.cpp
@@ -227,6 +227,7 @@ unsigned int FieldType::GetCheckSum() const {
     CheckSums::CheckSumCombine(retval, m_effects);
     CheckSums::CheckSumCombine(retval, m_graphic);
 
+    DebugLogger() << "FieldTypeManager checksum: " << retval;
     return retval;
 }
 
@@ -258,8 +259,6 @@ FieldTypeManager::FieldTypeManager() {
 
     // Only update the global pointer on sucessful construction.
     s_instance = this;
-
-    DebugLogger() << "FieldTypeManager checksum: " << GetCheckSum();
 }
 
 const FieldType* FieldTypeManager::GetFieldType(const std::string& name) const {

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -1488,10 +1488,10 @@ LoadShipDesignsAndManifestOrderFromFileSystem(const boost::filesystem::path& dir
                        std::pair<std::unique_ptr<ShipDesign>,
                                  boost::filesystem::path>,
                        boost::hash<boost::uuids::uuid>>  saved_designs;
-    std::vector<boost::uuids::uuid> disk_ordering;
 
-    std::vector<std::pair<std::unique_ptr<ShipDesign>, boost::filesystem::path>> designs_and_paths;
-    parse::ship_designs(dir, designs_and_paths, disk_ordering);
+    auto designs_paths_and_ordering = parse::ship_designs(dir);
+    auto& designs_and_paths = designs_paths_and_ordering.first;
+    auto& disk_ordering = designs_paths_and_ordering.second;
 
     for (auto&& design_and_path : designs_and_paths) {
         auto& design = design_and_path.first;

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -191,7 +191,7 @@ PartTypeManager::PartTypeManager() {
     ScopedTimer timer("PartTypeManager Init", true, std::chrono::milliseconds(1));
 
     try {
-        parse::ship_parts(m_parts);
+        m_parts = parse::ship_parts();
     } catch (const std::exception& e) {
         ErrorLogger() << "Failed parsing ship parts: error: " << e.what();
         throw;
@@ -632,7 +632,7 @@ HullTypeManager::HullTypeManager() {
     ScopedTimer timer("HullTypeManager Init", true, std::chrono::milliseconds(1));
 
     try {
-        parse::ship_hulls(m_hulls);
+        m_hulls = parse::ship_hulls();
     } catch (const std::exception& e) {
         ErrorLogger() << "Failed parsing ship hulls: error: " << e.what();
         throw;

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -208,8 +208,6 @@ PartTypeManager::PartTypeManager() {
 
     // Only update the global pointer on sucessful construction.
     s_instance = this;
-
-    DebugLogger() << "PartTypeManager checksum: " << GetCheckSum();
 }
 
 const PartType* PartTypeManager::GetPartType(const std::string& name) const {
@@ -234,6 +232,8 @@ unsigned int PartTypeManager::GetCheckSum() const {
         CheckSums::CheckSumCombine(retval, name_part_pair);
     CheckSums::CheckSumCombine(retval, m_parts.size());
 
+
+    DebugLogger() << "PartTypeManager checksum: " << retval;
     return retval;
 }
 
@@ -651,8 +651,6 @@ HullTypeManager::HullTypeManager() {
 
     // Only update the global pointer on sucessful construction.
     s_instance = this;
-
-    DebugLogger() << "HullTypeManager checksum: " << GetCheckSum();
 }
 
 const HullType* HullTypeManager::GetHullType(const std::string& name) const {
@@ -677,6 +675,7 @@ unsigned int HullTypeManager::GetCheckSum() const {
         CheckSums::CheckSumCombine(retval, name_hull_pair);
     CheckSums::CheckSumCombine(retval, m_hulls.size());
 
+    DebugLogger() << "HullTypeManager checksum: " << retval;
     return retval;
 }
 
@@ -1367,8 +1366,6 @@ PredefinedShipDesignManager::PredefinedShipDesignManager() {
 
     // Only update the global pointer on sucessful construction.
     s_instance = this;
-
-    DebugLogger() << "PredefinedShipDesignManager checksum: " << GetCheckSum();
 }
 
 namespace {
@@ -1466,6 +1463,7 @@ unsigned int PredefinedShipDesignManager::GetCheckSum() const {
     build_checksum(m_ship_ordering);
     build_checksum(m_monster_ordering);
 
+    DebugLogger() << "PredefinedShipDesignManager checksum: " << retval;
     return retval;
 }
 

--- a/universe/Special.cpp
+++ b/universe/Special.cpp
@@ -20,7 +20,7 @@ namespace {
             ScopedTimer timer("SpecialManager Init", true, std::chrono::milliseconds(1));
 
             try {
-                parse::specials(m_specials);
+                m_specials = parse::specials();
             } catch (const std::exception& e) {
                 ErrorLogger() << "Failed parsing specials: error: " << e.what();
                 throw e;

--- a/universe/Special.cpp
+++ b/universe/Special.cpp
@@ -29,8 +29,6 @@ namespace {
             TraceLogger() << "Specials:";
             for (const auto& entry : m_specials)
                 TraceLogger() << " ... " << entry.first;
-
-            DebugLogger() << "SpecialManager checksum: " << GetCheckSum();
         }
         std::vector<std::string> SpecialNames() const {
             std::vector<std::string> retval;
@@ -48,6 +46,7 @@ namespace {
             for (auto const& name_type_pair : m_specials)
                 CheckSums::CheckSumCombine(retval, name_type_pair);
             CheckSums::CheckSumCombine(retval, m_specials.size());
+            DebugLogger() << "SpecialManager checksum: " << retval;
             return retval;
         }
     private:

--- a/universe/Species.cpp
+++ b/universe/Species.cpp
@@ -388,8 +388,6 @@ SpeciesManager::SpeciesManager() {
 
     // Only update the global pointer on sucessful construction.
     s_instance = this;
-
-    DebugLogger() << "SpeciesManager checksum: " << GetCheckSum();
 }
 
 const Species* SpeciesManager::GetSpecies(const std::string& name) const {
@@ -593,6 +591,7 @@ unsigned int SpeciesManager::GetCheckSum() const {
         CheckSums::CheckSumCombine(retval, name_type_pair);
     CheckSums::CheckSumCombine(retval, m_species.size());
 
+    DebugLogger() << "SpeciesManager checksum: " << retval;
     return retval;
 }
 

--- a/universe/Species.cpp
+++ b/universe/Species.cpp
@@ -359,7 +359,7 @@ SpeciesManager::SpeciesManager() {
     ScopedTimer timer("SpeciesManager Init", true, std::chrono::milliseconds(1));
 
     try {
-        parse::species(m_species);
+        m_species = parse::species();
     } catch (const std::exception& e) {
         ErrorLogger() << "Failed parsing species: error: " << e.what();
         throw e;

--- a/universe/Tech.cpp
+++ b/universe/Tech.cpp
@@ -359,7 +359,7 @@ TechManager::TechManager() {
     std::set<std::string> categories_seen_in_techs;
 
     try {
-        parse::techs(m_techs, m_categories, categories_seen_in_techs);
+        std::tie(m_techs, m_categories, categories_seen_in_techs) = parse::techs();
     } catch (const std::exception& e) {
         ErrorLogger() << "Failed parsing techs: error: " << e.what();
         throw e;

--- a/universe/Tech.cpp
+++ b/universe/Tech.cpp
@@ -431,8 +431,6 @@ TechManager::TechManager() {
 
     // Only update the global pointer on sucessful construction.
     s_instance = this;
-
-    DebugLogger() << "TechManager checksum: " << GetCheckSum();
 }
 
 std::string TechManager::FindIllegalDependencies() {
@@ -620,6 +618,7 @@ unsigned int TechManager::GetCheckSum() const {
         CheckSums::CheckSumCombine(retval, tech);
     CheckSums::CheckSumCombine(retval, m_techs.size());
 
+    DebugLogger() << "TechManager checksum: " << retval;
     return retval;
 }
 

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -91,7 +91,7 @@ namespace EmpireStatistics {
         static std::map<std::string, ValueRef::ValueRefBase<double>*> s_stats;
         if (s_stats.empty()) {
             try {
-                parse::statistics(s_stats);
+                s_stats = parse::statistics();
             } catch (const std::exception& e) {
                 ErrorLogger() << "Failed parsing empire statistics: error: " << e.what();
                 throw e;

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -92,11 +92,6 @@ namespace EmpireStatistics {
         if (s_stats.empty()) {
             try {
                 parse::statistics(s_stats);
-
-                unsigned int checksum{0};
-                CheckSums::CheckSumCombine(checksum, s_stats);
-                DebugLogger() << "Empire Statistics checksum: " << checksum;
-
             } catch (const std::exception& e) {
                 ErrorLogger() << "Failed parsing empire statistics: error: " << e.what();
                 throw e;


### PR DESCRIPTION
This PR changes to

`auto parsed_stuff = parse::stuff();`

from
````
std::container parsed_stuff;
/* ignored error condition */ parse::stuff(parsed_stuff);
````
The idiom is clearer. The returned parsed content is returned.  The
container is constructed where it is used.