### PR TITLE
Let AI character gate usage of growth focus

### DIFF
--- a/default/python/AI/ResourcesAI.py
+++ b/default/python/AI/ResourcesAI.py
@@ -34,7 +34,6 @@ _focus_names = {INDUSTRY: "Industry", RESEARCH: "Research", GROWTH: "Growth", PR
 # TODO use the priorityRatio to weight
 RESEARCH_WEIGHTING = 2.3
 
-useGrowth = True
 limitAssessments = False
 
 lastFociCheck = [0]
@@ -400,7 +399,7 @@ def assess_protection_focus(pid, pinfo):
 
 def set_planet_growth_specials(focus_manager):
     """set resource foci of planets with potentially useful growth factors. Remove planets from list of candidates."""
-    if not useGrowth:
+    if not foAI.foAIstate.character.may_use_growth_focus():
         return
 
     # TODO Consider actual resource output of the candidate locations rather than only population

--- a/default/python/AI/character/character_module.py
+++ b/default/python/AI/character/character_module.py
@@ -238,6 +238,10 @@ class Trait(object):
         """Return true if allowed to target research/industry > 1.5"""
         return True
 
+    def may_use_growth_focus(self):
+        """Return True if permitted to use growth focus."""
+        return True
+
     def may_travel_beyond_supply(self, distance):  # pylint: disable=no-self-use,unused-argument
         """Return True if able to travel distance hops beyond empire supply"""
         # TODO Remove this tap it is one of the empire id dependent taps. See EmpireIDTrait.
@@ -378,6 +382,11 @@ class Aggression(Trait):
 
     def may_research_heavily(self):
         return self.aggression > fo.aggression.cautious
+
+    def may_use_growth_focus(self):
+        # For now, allow using growth focus for all aggression settings
+        # but leaving this here for easier modification.
+        return self.aggression >= fo.aggression.beginner
 
     def may_research_xeno_genetics_variances(self):
         return self.aggression >= fo.aggression.cautious
@@ -548,7 +557,7 @@ def _make_single_function_combiner(funcnamei, f_combo):
 # Create combiners for traits that all must be true
 for funcname in ["may_explore_system", "may_surge_industry", "may_maximize_research", "may_invade",
                  "may-invade_with_bases", "may_build_building", "may_produce_troops",
-                 "may_dither_focus_to_gain_research", "may_research_heavily",
+                 "may_dither_focus_to_gain_research", "may_research_heavily", "may_use_growth_focus",
                  "may_travel_beyond_supply", "may_research_xeno_genetics_variances",
                  "prefer_research_defensive", "prefer_research_low_aggression", "may_research_tech",
                  "may_research_tech_classic"]:


### PR DESCRIPTION
Seems like something that should be controlled by the character module than some bland module level switch ```useGrowth=True```. 

Typical aggression seems reasonable for using a (somewhat) advanced focus but obviously open for discussion.