### PR TITLE
Use more efficient pickling for AI savegames

### DIFF
--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -6,7 +6,11 @@ from common.configure_logging import redirect_logging_to_freeorion_logger, conve
 redirect_logging_to_freeorion_logger()
 (debug, info, warn, error, fatal) = convenience_function_references_for_logger()
 
-import pickle  # Python object serialization library
+try:
+    import cPickle as pickle # Python object serialization library
+except:
+    info("cPickle not available on this machine, falling back to pickle")
+    import pickle
 import sys
 import random
 

--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -161,7 +161,7 @@ def prepareForSave():  # pylint: disable=invalid-name
 
     # serialize (convert to string) global state dictionary and send to AI client to be stored in save file
     try:
-        dump_string = pickle.dumps(foAIstate)
+        dump_string = pickle.dumps(foAIstate, protocol=2)
         print "foAIstate pickled to string, about to send to server"
         fo.setSaveStateString(dump_string)
     except:


### PR DESCRIPTION
While not being a real issue right now, the AI savegame pickling can be made more efficient with 2 rather trivial changes:

* Reduce savestring size by using a more efficient pickling protocol. It breaks compatibility with Python versions <2.3 but we do not support these anyway (I think). Typical size reduction in my tests is ~30%.
* If available, use the cPickle module rather than the pickle module. It should exist on pretty much any platform as it is part of the standard library but just to be sure there is a fallback to use standard pickle as the subset of API we use is identical. It improves (un)pickling speed while being fully compatible with existing savegame strings.

Relevant parts of the documentation (https://docs.python.org/2/library/pickle.html):
>By default, the pickle data format uses a printable ASCII representation. This is slightly more voluminous than a binary representation. The big advantage of using printable ASCII (and of some other characteristics of pickle’s representation) is that for debugging or recovery purposes it is possible for a human to read the pickled file with a standard text editor.
>
>There are currently 3 different protocols which can be used for pickling.
>
 >   Protocol version 0 is the original ASCII protocol and is backwards compatible with earlier versions of Python.
>    Protocol version 1 is the old binary format which is also compatible with earlier versions of Python.
>    Protocol version 2 was introduced in Python 2.3. It provides much more efficient pickling of new-style classes.
> [...]
>The pickle module has an optimized cousin called the cPickle module. As its name implies, cPickle is written in C, so it can be up to 1000 times faster than pickle. However it does not support subclassing of the Pickler() and Unpickler() classes, because in cPickle these are functions, not classes. Most applications have no need for this functionality, and can benefit from the improved performance of cPickle. Other than that, the interfaces of the two modules are nearly identical; the common interface is described in this manual and differences are pointed out where necessary. In the following discussions, we use the term “pickle” to collectively describe the pickle and cPickle modules.
>
>The data streams the two modules produce are guaranteed to be interchangeable.