### PR TITLE
Fix "SyntaxError: cannot assign to None" in freeOrionAIInterface.py

### DIFF
--- a/default/python/interface_mock/result/freeOrionAIInterface.py
+++ b/default/python/interface_mock/result/freeOrionAIInterface.py
@@ -3370,14 +3370,14 @@ class ruleType(Enum):
 
     int = None  # ruleType(-1, "int")
     toggle = None  # ruleType(0, "toggle")
-    None = None  # ruleType(1, "None")
+    none = None  # ruleType(1, "None")
     double = None  # ruleType(2, "double")
     string = None  # ruleType(3, "string")
 
 
 ruleType.int = ruleType(-1, "int")
 ruleType.toggle = ruleType(0, "toggle")
-ruleType.None = ruleType(1, "None")
+ruleType.none = ruleType(1, "None")
 ruleType.double = ruleType(2, "double")
 ruleType.string = ruleType(3, "string")
 


### PR DESCRIPTION
Not sure if this is the correct fix for https://github.com/freeorion/freeorion/issues/1804