### PR TITLE
Replace shadowed/shadowing variables

### DIFF
--- a/AI/AIInterface.cpp
+++ b/AI/AIInterface.cpp
@@ -669,8 +669,8 @@ namespace AIInterface {
         // can only give to empires with something present to receive the gift
         bool recipient_has_something_here = false;
         auto system_objects = Objects().FindObjects<const UniverseObject>(system->ObjectIDs());
-        for (auto& obj : system_objects) {
-            if (obj->Owner() == recipient_id) {
+        for (auto& system_object : system_objects) {
+            if (system_object->Owner() == recipient_id) {
                 recipient_has_something_here = true;
                 break;
             }

--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -3122,9 +3122,9 @@ void Empire::CheckProductionProgress() {
         // ship design
         // Do not group unarmed ships with no troops (i.e. scouts and
         // colony ships).
-        for (auto& entry : new_ships_by_rally_point_id_and_design_id) {
-            int rally_point_id = entry.first;
-            auto& new_ships_by_design = entry.second;
+        for (auto& rally_ships : new_ships_by_rally_point_id_and_design_id) {
+            int rally_point_id = rally_ships.first;
+            auto& new_ships_by_design = rally_ships.second;
 
             for (auto& ships_by_design : new_ships_by_design) {
                 std::vector<int> ship_ids;

--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -3166,23 +3166,24 @@ void Empire::CheckProductionProgress() {
                     ship->SetFleetID(fleet->ID());
                 }
 
-                for (auto& fleet : fleets) {
+                for (auto& next_fleet : fleets) {
                     // rename fleet, given its id and the ship that is in it
-                    fleet->Rename(fleet->GenerateFleetName());
-                    fleet->SetAggressive(fleet->HasArmedShips() || fleet->HasFighterShips());
+                    next_fleet->Rename(next_fleet->GenerateFleetName());
+                    next_fleet->SetAggressive(next_fleet->HasArmedShips() || next_fleet->HasFighterShips());
 
                     if (rally_point_id != INVALID_OBJECT_ID) {
                         if (GetSystem(rally_point_id)) {
-                            fleet->CalculateRouteTo(rally_point_id);
+                            next_fleet->CalculateRouteTo(rally_point_id);
                         } else if (auto rally_obj = GetUniverseObject(rally_point_id)) {
                             if (GetSystem(rally_obj->SystemID()))
-                                fleet->CalculateRouteTo(rally_obj->SystemID());
+                                next_fleet->CalculateRouteTo(rally_obj->SystemID());
                         } else {
                             ErrorLogger() << "Unable to find system to route to with rally point id: " << rally_point_id;
                         }
                     }
 
-                    DebugLogger() << "New Fleet \"" + fleet->Name() + "\" created on turn: " << fleet->CreationTurn();
+                    DebugLogger() << "New Fleet \"" << next_fleet->Name()
+                                  <<"\" created on turn: " << next_fleet->CreationTurn();
                 }
             }
         }

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -1580,13 +1580,13 @@ void Font::FillTemplatedText(
         std::shared_ptr<TextElement> elem = (*te_it);
 
         // For each character in the TextElement.
-        auto it = elem->text.begin();
+        auto text_it = elem->text.begin();
         auto end_it = elem->text.end();
-        while (it != end_it) {
+        while (text_it != end_it) {
 
             // Find and set the width of the character glyph.
             elem->widths.push_back(X0);
-            std::uint32_t c = utf8::next(it, end_it);
+            std::uint32_t c = utf8::next(text_it, end_it);
             if (c != WIDE_NEWLINE) {
                 auto it = m_glyphs.find(c);
                 // use a space when an unrendered glyph is requested (the

--- a/GG/src/Layout.cpp
+++ b/GG/src/Layout.cpp
@@ -433,10 +433,12 @@ void Layout::DoLayout(Pt ul, Pt lr)
     // resize cells and their contents
     m_ignore_child_resize = true;
     for (auto& wnd_position : m_wnd_positions) {
-        Pt ul(X(m_column_params[wnd_position.second.first_column].current_origin),
-              Y(m_row_params[wnd_position.second.first_row].current_origin));
-        Pt lr(X(m_column_params[wnd_position.second.last_column - 1].current_origin + m_column_params[wnd_position.second.last_column - 1].current_width),
-              Y(m_row_params[wnd_position.second.last_row - 1].current_origin + m_row_params[wnd_position.second.last_row - 1].current_width));
+        Pt wnd_ul(X(m_column_params[wnd_position.second.first_column].current_origin),
+                  Y(m_row_params[wnd_position.second.first_row].current_origin));
+        Pt wnd_lr(X(m_column_params[wnd_position.second.last_column - 1].current_origin +
+                    m_column_params[wnd_position.second.last_column - 1].current_width),
+                  Y(m_row_params[wnd_position.second.last_row - 1].current_origin +
+                    m_row_params[wnd_position.second.last_row - 1].current_width));
         Pt ul_margin(X0, Y0);
         Pt lr_margin(X0, Y0);
         if (0 < wnd_position.second.first_row)
@@ -448,13 +450,13 @@ void Layout::DoLayout(Pt ul, Pt lr)
         if (wnd_position.second.last_column < m_column_params.size())
             lr_margin.x += static_cast<int>(m_cell_margin / 2.0 + 0.5);
 
-        ul += ul_margin;
-        lr -= lr_margin;
+        wnd_ul += ul_margin;
+        wnd_lr -= lr_margin;
 
         if (wnd_position.second.alignment == ALIGN_NONE) { // expand to fill available space
-            wnd_position.first->SizeMove(ul, lr);
+            wnd_position.first->SizeMove(wnd_ul, wnd_lr);
         } else { // align as appropriate
-            Pt available_space = lr - ul;
+            Pt available_space = wnd_lr - wnd_ul;
             Pt min_usable_size = wnd_position.first->MinUsableSize();
             Pt min_size = wnd_position.first->MinSize();
 
@@ -463,7 +465,7 @@ void Layout::DoLayout(Pt ul, Pt lr)
             // down to 0-height cells.  Note that they can still get horizontally
             // squashed.
             if (TextControl* text_control = dynamic_cast<TextControl*>(wnd_position.first)) {
-                X text_width = (lr.x - ul.x);
+                X text_width = (wnd_lr.x - wnd_ul.x);
                 min_usable_size = text_control->MinUsableSize(text_width);
                 min_size = min_usable_size;
             }
@@ -472,30 +474,30 @@ void Layout::DoLayout(Pt ul, Pt lr)
                            std::min(available_space.y, std::max(wnd_position.second.original_size.y, std::max(min_size.y, min_usable_size.y))));
             Pt resize_ul, resize_lr;
             if (wnd_position.second.alignment & ALIGN_LEFT) {
-                resize_ul.x = ul.x;
+                resize_ul.x = wnd_ul.x;
                 resize_lr.x = resize_ul.x + window_size.x;
             } else if (wnd_position.second.alignment & ALIGN_CENTER) {
-                resize_ul.x = ul.x + (available_space.x - window_size.x) / 2;
+                resize_ul.x = wnd_ul.x + (available_space.x - window_size.x) / 2;
                 resize_lr.x = resize_ul.x + window_size.x;
             } else if (wnd_position.second.alignment & ALIGN_RIGHT) {
-                resize_lr.x = lr.x;
+                resize_lr.x = wnd_lr.x;
                 resize_ul.x = resize_lr.x - window_size.x;
             } else {
-                resize_ul.x = ul.x;
-                resize_lr.x = lr.x;
+                resize_ul.x = wnd_ul.x;
+                resize_lr.x = wnd_lr.x;
             }
             if (wnd_position.second.alignment & ALIGN_TOP) {
-                resize_ul.y = ul.y;
+                resize_ul.y = wnd_ul.y;
                 resize_lr.y = resize_ul.y + window_size.y;
             } else if (wnd_position.second.alignment & ALIGN_VCENTER) {
-                resize_ul.y = ul.y + (available_space.y - window_size.y) / 2;
+                resize_ul.y = wnd_ul.y + (available_space.y - window_size.y) / 2;
                 resize_lr.y = resize_ul.y + window_size.y;
             } else if (wnd_position.second.alignment & ALIGN_BOTTOM) {
-                resize_lr.y = lr.y;
+                resize_lr.y = wnd_lr.y;
                 resize_ul.y = resize_lr.y - window_size.y;
             } else {
-                resize_ul.y = ul.y;
-                resize_lr.y = lr.y;
+                resize_ul.y = wnd_ul.y;
+                resize_lr.y = wnd_lr.y;
             }
             wnd_position.first->SizeMove(resize_ul, resize_lr);
         }

--- a/GG/src/Menu.cpp
+++ b/GG/src/Menu.cpp
@@ -206,12 +206,10 @@ void PopupMenu::Render()
 
                 if (!menu.next_level[j].separator) {
                     // TODO cache line data v expensive calculation
-                    std::vector<std::shared_ptr<Font::TextElement>> text_elements =
-                        m_font->ExpensiveParseFromTextToTextElements(menu.next_level[j].label, fmt);
-                    std::vector<Font::LineData> lines =
-                        m_font->DetermineLines(menu.next_level[j].label, fmt, X0, text_elements);
+                    auto element_data = m_font->ExpensiveParseFromTextToTextElements(menu.next_level[j].label, fmt);
+                    auto line_data = m_font->DetermineLines(menu.next_level[j].label, fmt, X0, element_data);
 
-                    m_font->RenderText(line_rect.ul, line_rect.lr, menu.next_level[j].label, fmt, lines);
+                    m_font->RenderText(line_rect.ul, line_rect.lr, menu.next_level[j].label, fmt, line_data);
 
                 } else {
                     Line(line_rect.ul.x + HORIZONTAL_MARGIN, line_rect.ul.y + INDICATOR_HEIGHT/2 + INDICATOR_VERTICAL_MARGIN,

--- a/GG/src/Menu.cpp
+++ b/GG/src/Menu.cpp
@@ -45,7 +45,7 @@ MenuItem::MenuItem() :
     MenuItem("", false, false)
 {}
 
-MenuItem::MenuItem(bool separator) :
+MenuItem::MenuItem(bool separator_) :
     disabled(true),
     checked(false),
     separator(true),

--- a/GG/src/MultiEdit.cpp
+++ b/GG/src/MultiEdit.cpp
@@ -220,9 +220,9 @@ void MultiEdit::Render()
                 // so that any tages associated with that finel character will be processed.
                 GetFont()->RenderText(text_pos, text_lr, Text(), text_format, lines, state, row, idx2, row + 1, CPSize(line.char_data.size()));
             } else { // just draw normal text on this line
-                Pt lr = text_pos + Pt(line.char_data.back().extent, GetFont()->Height());
+                Pt text_lr = text_pos + Pt(line.char_data.back().extent, GetFont()->Height());
                 glColor(text_color_to_use);
-                GetFont()->RenderText(text_pos, lr, Text(), text_format, lines, state, row, CP0, row + 1, CPSize(line.char_data.size()));
+                GetFont()->RenderText(text_pos, text_lr, Text(), text_format, lines, state, row, CP0, row + 1, CPSize(line.char_data.size()));
             }
         }
 

--- a/GG/src/RichText/TagParser.cpp
+++ b/GG/src/RichText/TagParser.cpp
@@ -30,10 +30,10 @@
 
 namespace GG {
 
-    RichTextTag::RichTextTag(const std::string& tag,
+    RichTextTag::RichTextTag(const std::string& tag_,
                              const std::string& params_string,
-                             const std::string& content)
-    : tag(tag), tag_params(params_string), content(content)
+                             const std::string& content_)
+    : tag(tag_), tag_params(params_string), content(content_)
     {
     }
 

--- a/GG/src/Texture.cpp
+++ b/GG/src/Texture.cpp
@@ -441,9 +441,9 @@ void Texture::InitFromRawData(X width, Y height, const unsigned char* image, GLe
             image_copy.reset(GetRawBytes());
         unsigned char* image_to_use = image_copy ? image_copy.get() : const_cast<unsigned char*>(image);
         gluBuild2DMipmaps(GL_PROXY_TEXTURE_2D, format, Value(GL_texture_width), Value(GL_texture_height), format, type, image_to_use);
-        GLint checked_format;
-        glGetTexLevelParameteriv(GL_PROXY_TEXTURE_2D, 0, GL_TEXTURE_INTERNAL_FORMAT, &checked_format);
-        if (!checked_format)
+        GLint mipmap_checked_format;
+        glGetTexLevelParameteriv(GL_PROXY_TEXTURE_2D, 0, GL_TEXTURE_INTERNAL_FORMAT, &mipmap_checked_format);
+        if (!mipmap_checked_format)
             throw InsufficientResources("Insufficient resources to create requested mipmapped OpenGL texture");
         gluBuild2DMipmaps(GL_TEXTURE_2D, format, Value(GL_texture_width), Value(GL_texture_height), format, type, image_to_use);
     } else {

--- a/GG/src/dialogs/FileDlg.cpp
+++ b/GG/src/dialogs/FileDlg.cpp
@@ -536,10 +536,12 @@ void FileDlg::UpdateList()
     // define file filters based on the filter strings in the filter drop list
     std::vector<rule<>> file_filters;
 
-    DropDownList::iterator it = m_filter_list->CurrentItem();
-    if (it != m_filter_list->end()) {
+    auto filter_it = m_filter_list->CurrentItem();
+    if (filter_it != m_filter_list->end()) {
         std::vector<std::string> filter_specs; // the filter specifications (e.g. "*.png")
-        parse(m_file_filters[std::distance(m_filter_list->begin(), it)].second.c_str(), *(!ch_p(',') >> (+(anychar_p - ','))[append(filter_specs)]), space_p);
+        parse(m_file_filters[std::distance(m_filter_list->begin(), filter_it)].second.c_str(),
+              *(!ch_p(',') >> (+(anychar_p - ','))[append(filter_specs)]),
+              space_p);
         file_filters.resize(filter_specs.size());
         for (std::size_t i = 0; i < filter_specs.size(); ++i) {
             auto non_wildcards = std::make_shared<std::vector<std::string>>(); // the parts of the filter spec that are not wildcards

--- a/UI/CombatReport/CombatReportData.cpp
+++ b/UI/CombatReport/CombatReportData.cpp
@@ -27,9 +27,9 @@ ParticipantSummary::ParticipantSummary() :
     max_health(0.0f)
 {}
 
-ParticipantSummary::ParticipantSummary(int object_id, int empire_id, const CombatParticipantState& state) :
-    object_id(object_id),
-    empire_id(empire_id),
+ParticipantSummary::ParticipantSummary(int object_id_, int empire_id_, const CombatParticipantState& state) :
+    object_id(object_id_),
+    empire_id(empire_id_),
     current_health(0.0f),
     max_health(0.0f)
 {

--- a/UI/CombatReport/GraphicalSummary.cpp
+++ b/UI/CombatReport/GraphicalSummary.cpp
@@ -641,17 +641,17 @@ private:
         bool GetValue() const
         { return (**sizer).Get(option_key); }
 
-        ToggleData(const std::string& label_true, const std::string& label_false,
-                   const std::string& tip_true, const std::string& tip_false,
-                   std::string option_key,
-                   std::unique_ptr<BarSizer>* sizer, std::shared_ptr<OptionsBar> parent) :
-            label_true(label_true),
-            label_false(label_false),
-            tip_true(tip_true),
-            tip_false(tip_false),
-            option_key(option_key),
-            sizer(sizer),
-            parent(std::forward<std::shared_ptr<OptionsBar>>(parent)),
+        ToggleData(const std::string& label_true_, const std::string& label_false_,
+                   const std::string& tip_true_, const std::string& tip_false_,
+                   std::string option_key_,
+                   std::unique_ptr<BarSizer>* sizer_, std::shared_ptr<OptionsBar> parent_) :
+            label_true(label_true_),
+            label_false(label_false_),
+            tip_true(tip_true_),
+            tip_false(tip_false_),
+            option_key(option_key_),
+            sizer(sizer_),
+            parent(std::forward<std::shared_ptr<OptionsBar>>(parent_)),
             button(nullptr)
         {
             button = Wnd::Create<CUIButton>("-");

--- a/UI/CombatReport/GraphicalSummary.cpp
+++ b/UI/CombatReport/GraphicalSummary.cpp
@@ -655,7 +655,7 @@ private:
             button(nullptr)
         {
             button = Wnd::Create<CUIButton>("-");
-            parent->AttachChild(button);
+            parent_->AttachChild(button);
             button->LeftClickedSignal.connect(
                 boost::bind(&ToggleData::Toggle, this));
             SetValue(GetValue());

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -3982,9 +3982,9 @@ void DesignWnd::MainPanel::DoLayout() {
     GG::Rect background_rect = GG::Rect(ul, ClientLowerRight());
 
     if (m_background_image) {
-        GG::Pt ul = background_rect.UpperLeft();
-        GG::Pt lr = ClientSize();
-        m_background_image->SizeMove(ul, lr);
+        GG::Pt bg_ul = background_rect.UpperLeft();
+        GG::Pt bg_lr = ClientSize();
+        m_background_image->SizeMove(bg_ul, bg_lr);
         background_rect = m_background_image->RenderedArea();
     }
 

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -4254,17 +4254,17 @@ void DesignWnd::MainPanel::AcceptDrops(const GG::Pt& pt, std::vector<std::shared
     if (!wnd)
         return;
 
-    if (const auto control = dynamic_cast<const BasesListBox::CompletedDesignListBoxRow*>(wnd.get())) {
-        SetDesign(GetShipDesign(control->DesignID()));
+    if (const auto completed_design_row = dynamic_cast<const BasesListBox::CompletedDesignListBoxRow*>(wnd.get())) {
+        SetDesign(GetShipDesign(completed_design_row->DesignID()));
     }
-    else if (const auto control = dynamic_cast<const BasesListBox::HullAndPartsListBoxRow*>(wnd.get())) {
-        const std::string& hull = control->Hull();
-        const std::vector<std::string>& parts = control->Parts();
+    else if (const auto hullandparts_row = dynamic_cast<const BasesListBox::HullAndPartsListBoxRow*>(wnd.get())) {
+        const std::string& hull = hullandparts_row->Hull();
+        const std::vector<std::string>& parts = hullandparts_row->Parts();
 
         SetDesignComponents(hull, parts);
     }
-    else if (const auto control = dynamic_cast<const SavedDesignsListBox::SavedDesignListBoxRow*>(wnd.get())) {
-        const auto& uuid = control->DesignUUID();
+    else if (const auto saved_design_row = dynamic_cast<const SavedDesignsListBox::SavedDesignListBoxRow*>(wnd.get())) {
+        const auto& uuid = saved_design_row->DesignUUID();
         SetDesign(GetSavedDesignsManager().GetDesign(uuid));
     }
 }

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -4348,10 +4348,10 @@ void DesignWnd::MainPanel::ReplaceDesign() {
         // Update the replaced design on the bench
         SetDesign(manager.GetDesign(new_uuid));
 
-    } else if (const auto replaced_design = EditingCurrentDesign()) {
+    } else if (const auto current_maybe_design = EditingCurrentDesign()) {
         auto& manager = GetCurrentDesignsManager();
         int empire_id = HumanClientApp::GetApp()->EmpireID();
-        int replaced_id = (*replaced_design)->ID();
+        int replaced_id = (*current_maybe_design)->ID();
 
         if (new_design_id == INVALID_DESIGN_ID) return;
 

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -268,7 +268,6 @@ namespace {
             }
 
         } else if (dir_name == "ENC_HOMEWORLDS") {
-            int client_empire_id = HumanClientApp::GetApp()->EmpireID();
             const SpeciesManager& species_manager = GetSpeciesManager();
             for (const auto& entry : species_manager) {
                 const auto& species = entry.second;

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -2750,17 +2750,16 @@ void EncyclopediaDetailPanel::RefreshImpl() {
             m_graph->Clear();
 
             // add lines for each empire
-            for (const auto& entry : empire_lines) {
-                int empire_id = entry.first;
+            for (const auto& empire_linemap : empire_lines) {
+                int empire_id = empire_linemap.first;
 
                 GG::Clr empire_clr = GG::CLR_WHITE;
                 if (const Empire* empire = GetEmpire(empire_id))
                     empire_clr = empire->Color();
 
-                const std::map<int, double>& empire_line = entry.second;
                 // convert formats...
                 std::vector<std::pair<double, double>> line_data_pts;
-                for (const auto& entry : empire_line)
+                for (const auto& entry : empire_linemap.second)
                 { line_data_pts.push_back({entry.first, entry.second}); }
 
                 m_graph->AddSeries(line_data_pts, empire_clr);

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -2006,17 +2006,17 @@ protected:
             return;
 
         // extract drop target fleet from row under drop point
-        const FleetRow* fleet_row = boost::polymorphic_downcast<const FleetRow*>(row->get());
+        const FleetRow* target_fleet_row = boost::polymorphic_downcast<const FleetRow*>(row->get());
         std::shared_ptr<const Fleet> target_fleet;
-        if (fleet_row)
-            target_fleet = GetFleet(fleet_row->FleetID());
+        if (target_fleet_row)
+            target_fleet = GetFleet(target_fleet_row->FleetID());
 
         // loop through dropped Wnds, checking if each is a valid ship or fleet.  this doesn't
         // consider whether there is a mixture of fleets and ships, as each row is considered
         // independently.  actual drops will probably only accept one or the other, not a mixture
         // of fleets and ships being dropped simultaneously.
         for (DropsAcceptableIter it = first; it != last; ++it) {
-            if (it->first == fleet_row)
+            if (it->first == target_fleet_row)
                 continue;   // can't drop onto self
 
             // for either of fleet or ship being dropped, check if merge or transfer is valid.

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -3320,8 +3320,8 @@ void FleetWnd::FleetRightClicked(GG::ListBox::iterator it, const GG::Pt& pt, con
         auto split_action = [this, &ship_ids_set]() {
             ScopedTimer split_fleet_timer("FleetWnd::SplitFleet", true);
             // remove first ship from set, so it stays in its existing fleet
-            auto it = ship_ids_set.begin();
-            ship_ids_set.erase(it);
+            auto ship_id_it = ship_ids_set.begin();
+            ship_ids_set.erase(ship_id_it);
 
             // assemble container of containers of ids of fleets to create.
             // one ship id per vector

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -3383,8 +3383,8 @@ void FleetWnd::FleetRightClicked(GG::ListBox::iterator it, const GG::Pt& pt, con
         && fleet->OwnedBy(client_empire_id))
     {
         auto scrap_action = [fleet, client_empire_id]() {
-            std::set<int> ship_ids_set = fleet->ShipIDs();
-            for (int ship_id : ship_ids_set) {
+            std::set<int> ship_ids = fleet->ShipIDs();
+            for (int ship_id : ship_ids) {
                 HumanClientApp::GetApp()->Orders().IssueOrder(
                     std::make_shared<ScrapOrder>(client_empire_id, ship_id));
             }

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -2547,9 +2547,9 @@ void FleetDetailPanel::ShipRightClicked(GG::ListBox::iterator it, const GG::Pt& 
         auto unscrap_action = [ship]() {
             // find order to scrap this ship, and recind it
             auto pending_scrap_orders = PendingScrapOrders();
-            auto it = pending_scrap_orders.find(ship->ID());
-            if (it != pending_scrap_orders.end())
-                HumanClientApp::GetApp()->Orders().RescindOrder(it->second);
+            auto pending_order_it = pending_scrap_orders.find(ship->ID());
+            if (pending_order_it != pending_scrap_orders.end())
+                HumanClientApp::GetApp()->Orders().RescindOrder(pending_order_it->second);
         };
         // create popup menu with "Cancel Scrap" option
         popup->AddMenuItem(GG::MenuItem(UserString("ORDER_CANCEL_SHIP_SCRAP"), false, false, unscrap_action));

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -1372,8 +1372,8 @@ void FleetDataPanel::Refresh() {
     } else if (auto fleet = GetFleet(m_fleet_id)) {
         int client_empire_id = HumanClientApp::GetApp()->EmpireID();
         // set fleet name and destination text
-        std::string fleet_name = fleet->PublicName(client_empire_id);
-        if (!fleet->Unowned() && fleet_name == UserString("FW_FOREIGN_FLEET")) {
+        std::string public_fleet_name = fleet->PublicName(client_empire_id);
+        if (!fleet->Unowned() && public_fleet_name == UserString("FW_FOREIGN_FLEET")) {
             const Empire* ship_owner_empire = GetEmpire(fleet->Owner());
             const std::string& owner_name = (ship_owner_empire ? ship_owner_empire->Name() : UserString("FW_FOREIGN"));
             std::string fleet_name = boost::io::str(FlexibleFormat(UserString("FW_EMPIRE_FLEET")) % owner_name);
@@ -1383,9 +1383,9 @@ void FleetDataPanel::Refresh() {
             m_fleet_name_text->SetText(fleet_name);
         } else {
             if (GetOptionsDB().Get<bool>("UI.show-id-after-names")) {
-                fleet_name = fleet_name + " (" + std::to_string(m_fleet_id) + ")";
+                public_fleet_name = public_fleet_name + " (" + std::to_string(m_fleet_id) + ")";
             }
-            m_fleet_name_text->SetText(fleet_name);
+            m_fleet_name_text->SetText(public_fleet_name);
         }
         m_fleet_destination_text->SetText(FleetDestinationText(m_fleet_id));
 

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -3691,8 +3691,8 @@ namespace {
                                               GG::GL2DVertexBuffer& starlane_vertices,
                                               GG::GLRGBAColorBuffer& starlane_colors)
     {
-        const Empire* empire = GetEmpire(empire_id);
-        if (!empire)
+        auto this_empire = GetEmpire(empire_id);
+        if (!this_empire)
             return;
 
         const auto& this_client_known_destroyed_objects =

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -2051,12 +2051,12 @@ void MapWnd::RenderSystems() {
                     }
 
                     // draw outer circle in color of supplying empire
-                    int empire_id = GetSupplyManager().EmpireThatCanSupplyAt(system_icon.first);
-                    if (empire_id != ALL_EMPIRES) {
-                        if (const Empire* empire = GetEmpire(empire_id))
+                    int supply_empire_id = GetSupplyManager().EmpireThatCanSupplyAt(system_icon.first);
+                    if (supply_empire_id != ALL_EMPIRES) {
+                        if (const Empire* empire = GetEmpire(supply_empire_id))
                             glColor(empire->Color());
                         else
-                            ErrorLogger() << "MapWnd::RenderSystems(): could not load empire with id " << empire_id;
+                            ErrorLogger() << "MapWnd::RenderSystems(): could not load empire with id " << supply_empire_id;
                     } else
                         glColor(GetOptionsDB().Get<GG::Clr>("UI.unowned-starlane-colour"));
 

--- a/UI/MultiMeterStatusBar.cpp
+++ b/UI/MultiMeterStatusBar.cpp
@@ -162,8 +162,6 @@ void MultiMeterStatusBar::Render() {
         const GG::Y INITIAL_TOP(BAR_TOP);
         if (SHOW_INITIAL) {
             // initial value
-            const GG::X INITIAL_RIGHT(BAR_LEFT + BAR_MAX_LENGTH * m_initial_values[i] / MULTI_METER_STATUS_BAR_DISPLAYED_METER_RANGE);
-            const GG::Y INITIAL_TOP(BAR_TOP);
             glColor(m_bar_colours[i]);
             m_bar_shading_texture->OrthoBlit(GG::Pt(BAR_LEFT, INITIAL_TOP), GG::Pt(INITIAL_RIGHT, BAR_BOTTOM));
             // black border

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -2567,8 +2567,8 @@ void ObjectListWnd::ObjectRightClicked(GG::ListBox::iterator it, const GG::Pt& p
             auto produce_building_action = [this, entry, app, cur_empire, &focus_ship_building_common_action]() {
                 std::string bld = entry.first;
                 bool needs_queue_update(false);
-                for (const auto& entry : m_list_box->Selections()) {
-                    ObjectRow *row = dynamic_cast<ObjectRow *>(entry->get());
+                for (const auto& selection : m_list_box->Selections()) {
+                    ObjectRow *row = dynamic_cast<ObjectRow *>(selection->get());
                     if (!row)
                         continue;
                     std::shared_ptr<Planet> one_planet = GetPlanet(row->ObjectID());

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -2526,13 +2526,13 @@ void ObjectListWnd::ObjectRightClicked(GG::ListBox::iterator it, const GG::Pt& p
             popup->AddMenuItem(std::move(focusMenuItem));
 
         GG::MenuItem ship_menu_item(UserString("MENUITEM_ENQUEUE_SHIPDESIGN"), false, false);
-        for (auto it = avail_designs.begin();
-             it != avail_designs.end() && ship_menuitem_id < MENUITEM_SET_BUILDING_BASE; ++it)
+        for (auto design_it = avail_designs.begin();
+             design_it != avail_designs.end() && ship_menuitem_id < MENUITEM_SET_BUILDING_BASE; ++design_it)
         {
             ship_menuitem_id++;
 
-            auto produce_ship_action = [this, it, app, cur_empire, &focus_ship_building_common_action]() {
-                int ship_design = it->first;
+            auto produce_ship_action = [this, design_it, app, cur_empire, &focus_ship_building_common_action]() {
+                int ship_design = design_it->first;
                 bool needs_queue_update(false);
                 for (const auto& entry : m_list_box->Selections()) {
                     ObjectRow* row = dynamic_cast<ObjectRow*>(entry->get());
@@ -2553,7 +2553,7 @@ void ObjectListWnd::ObjectRightClicked(GG::ListBox::iterator it, const GG::Pt& p
             };
 
             std::stringstream out;
-            out << GetShipDesign(it->first)->Name() << " (" << it->second << ")";
+            out << GetShipDesign(design_it->first)->Name() << " (" << design_it->second << ")";
             ship_menu_item.next_level.push_back(GG::MenuItem(out.str(), false, false, produce_ship_action));
         }
 

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -1043,7 +1043,7 @@ void FilterDialog::CompleteConstruction() {
     GG::X button_width = GG::X(ClientUI::Pts()*8);
     std::shared_ptr<GG::Button> label;
 
-    int row = 1;
+    int vis_row = 1;
 
     for (const auto entry : {
             std::make_tuple(SHOW_VISIBLE, UserStringNop("VISIBLE")),
@@ -1056,11 +1056,11 @@ void FilterDialog::CompleteConstruction() {
 
         label = Wnd::Create<CUIButton>(UserString(label_key));
         label->Resize(GG::Pt(button_width, label->MinUsableSize().y));
-        m_filters_layout->Add(label, row, 0, GG::ALIGN_CENTER);
+        m_filters_layout->Add(label, vis_row, 0, GG::ALIGN_CENTER);
         label->LeftClickedSignal.connect(
             boost::bind(&FilterDialog::UpdateVisFilterFromVisibilityButton, this, visibility));
 
-        ++row;
+        ++vis_row;
     }
 
     m_filters_layout->SetMinimumRowHeight(0, label->MinUsableSize().y);

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -736,10 +736,10 @@ private:
         DetachChildAndReset(m_param_spin2);
 
         // determine which condition is selected
-        GG::ListBox::iterator row_it = m_class_drop->CurrentItem();
-        if (row_it == m_class_drop->end())
+        auto class_row_it = m_class_drop->CurrentItem();
+        if (class_row_it == m_class_drop->end())
             return;
-        ConditionRow* condition_row = dynamic_cast<ConditionRow*>(row_it->get());
+        ConditionRow* condition_row = dynamic_cast<ConditionRow*>(class_row_it->get());
         if (!condition_row)
             return;
         const std::string& condition_key = condition_row->GetKey();

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -925,7 +925,7 @@ GG::Spin<int>* OptionsWnd::IntOption(GG::ListBox* page, int indentation_level, c
     text_control->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
     text_control->SetBrowseText(UserString(GetOptionsDB().GetDescription(option_name)));
     spin->ValueChangedSignal.connect(
-        [option_name](const int& value){ GetOptionsDB().Set(option_name, value); });
+        [option_name](const int& new_value){ GetOptionsDB().Set(option_name, new_value); });
     return spin.get();
 }
 

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -432,8 +432,8 @@ namespace {
             [option_name, drop_list](const GG::ListBox::const_iterator& it) {
                 if (it == drop_list->end())
                     return;
-                const auto row = dynamic_cast<CUISimpleDropDownListRow* const>(it->get());
-                const auto& option_value = row->Name();
+                const auto dropdown_row = dynamic_cast<CUISimpleDropDownListRow* const>(it->get());
+                const auto& option_value = dropdown_row->Name();
                 HumanClientApp::GetApp()->ChangeLoggerThreshold(option_name, to_LogLevel(option_value));
             });
     }

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -1254,13 +1254,13 @@ void OptionsWnd::ResolutionOption(GG::ListBox* page, int indentation_level) {
         [drop_list](GG::ListBox::iterator it) {
             if (it == drop_list->end())
                 return;
-            const auto& row = *it;
-            if (!row)
+            const auto& drop_list_row = *it;
+            if (!drop_list_row)
                 return;
             int w, h;
             using namespace boost::spirit::classic;
             rule<> resolution_p = int_p[assign_a(w)] >> str_p(" x ") >> int_p[assign_a(h)];
-            parse(row->Name().c_str(), resolution_p);
+            parse(drop_list_row->Name().c_str(), resolution_p);
             GetOptionsDB().Set<int>("app-width", w);
             GetOptionsDB().Set<int>("app-height", h);
         }

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -962,7 +962,7 @@ GG::Spin<double>* OptionsWnd::DoubleOption(GG::ListBox* page, int indentation_le
     text_control->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
     text_control->SetBrowseText(UserString(GetOptionsDB().GetDescription(option_name)));
     spin->ValueChangedSignal.connect(
-        [option_name](const double& value){ GetOptionsDB().Set(option_name, value); });
+        [option_name](const double& new_value){ GetOptionsDB().Set(option_name, new_value); });
     return spin.get();
 }
 

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -106,15 +106,15 @@ namespace {
 
         /** \name Structors */
         QuantitySelector(const ProductionQueue::Element &build, GG::X xoffset, GG::Y yoffset,
-                         GG::Y h, bool inProgress, GG::X nwidth, bool amBlockType) :
+                         GG::Y h_, bool inProgress, GG::X nwidth, bool amBlockType_) :
             CUIDropDownList(12),
             quantity(build.remaining),
             prevQuant(build.remaining),
             blocksize(build.blocksize),
             prevBlocksize(build.blocksize),
-            amBlockType(amBlockType),
+            amBlockType(amBlockType_),
             amOn(false),
-            h(h)
+            h(h_)
         {
             MoveTo(GG::Pt(xoffset, yoffset));
             Resize(GG::Pt(nwidth, h - GG::Y(2)));

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -331,12 +331,12 @@ namespace {
     const GG::Y Y_MARGIN = GG::Y(MARGIN);
 
     struct QueueRow : GG::ListBox::Row {
-        QueueRow(GG::X w, const ProductionQueue::Element& elem, int queue_index_) :
+        QueueRow(GG::X w, const ProductionQueue::Element& elem_, int queue_index_) :
             GG::ListBox::Row(w, QueueProductionItemPanel::DefaultHeight(),
                              BuildDesignatorWnd::PRODUCTION_ITEM_DROP_TYPE),
             panel(nullptr),
             queue_index(queue_index_),
-            elem(elem)
+            elem(elem_)
         {
             const Empire* empire = GetEmpire(HumanClientApp::GetApp()->EmpireID());
             float total_cost(1.0f);

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -135,15 +135,15 @@ namespace {
             else
                 myQuantSet.insert(quantity);
 
-            for (int quantity : myQuantSet) {
-                auto row =  GG::Wnd::Create<QuantRow>(quantity, build.item.design_id, nwidth, h, inProgress, amBlockType);
+            for (int droplist_quantity : myQuantSet) {
+                auto row =  GG::Wnd::Create<QuantRow>(droplist_quantity, build.item.design_id, nwidth, h, inProgress, amBlockType);
                 GG::DropDownList::iterator latest_it = Insert(row);
 
                 if (amBlockType) {
-                    if (build.blocksize == quantity)
+                    if (build.blocksize == droplist_quantity)
                         Select(latest_it);
                 } else {
-                    if (build.remaining == quantity)
+                    if (build.remaining == droplist_quantity)
                         Select(latest_it);
                 }
             }

--- a/UI/ResearchWnd.cpp
+++ b/UI/ResearchWnd.cpp
@@ -277,8 +277,6 @@ namespace {
     }
 
     GG::Y QueueTechPanel::DefaultHeight() {
-        const int MARGIN = 2;
-
         const int FONT_PTS = ClientUI::Pts();
         const GG::Y METER_HEIGHT(FONT_PTS);
 

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -1022,13 +1022,13 @@ std::string SaveFileDialog::GetDirPath() const {
     return retval;
 }
 
-void SaveFileDialog::SetDirPath(const string& path) {
-    std::string dirname = path;
+void SaveFileDialog::SetDirPath(const string& dir_path) {
+    std::string dirname = dir_path;
     if (m_server_previews) {
         // Indicate that the path is on the server
-        if (path.find("./") == 0) {
+        if (dir_path.find("./") == 0) {
             dirname = SERVER_LABEL + dirname.substr(1);
-        } else if (path.find(SERVER_LABEL) == 0) {
+        } else if (dir_path.find(SERVER_LABEL) == 0) {
             // Already has label. No need to change
         } else {
             dirname = SERVER_LABEL + "/" + dirname;

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -696,11 +696,11 @@ public:
         const std::string texture_filename;
         const auto& planet_data = GetRotatingPlanetData();
 
-        auto it = planet_data.find(planet->Type());
+        auto planet_data_it = planet_data.find(planet->Type());
         int num_planets_of_type;
-        if (it != planet_data.end() && (num_planets_of_type = planet_data.find(planet->Type())->second.size())) {
+        if (planet_data_it != planet_data.end() && (num_planets_of_type = planet_data.find(planet->Type())->second.size())) {
             unsigned int hash_value = static_cast<int>(m_planet_id);
-            const RotatingPlanetData& rpd = it->second[hash_value % num_planets_of_type];
+            const RotatingPlanetData& rpd = planet_data_it->second[hash_value % num_planets_of_type];
             m_surface_texture = ClientUI::GetTexture(ClientUI::ArtDir() / rpd.filename, true);
             m_shininess = rpd.shininess;
 
@@ -3033,8 +3033,8 @@ void SidePanel::RefreshInPreRender() {
 }
 
 void SidePanel::RefreshSystemNames() {
-    auto system = GetSystem(s_system_id);
-    if (!system)
+    auto selected_system = GetSystem(s_system_id);
+    if (!selected_system)
         return;
 
     // Repopulate the system with all of the names of known systems, if it is closed.

--- a/UI/SitRepPanel.cpp
+++ b/UI/SitRepPanel.cpp
@@ -494,8 +494,8 @@ namespace {
             for (auto& entry : empires)
                 sr_empires.insert(entry.second);
         }
-        for (Empire* empire : sr_empires) {
-            for (Empire::SitRepItr sitrep_it = empire->SitRepBegin(); sitrep_it != empire->SitRepEnd(); ++sitrep_it) {
+        for (auto sitrep_empire : sr_empires) {
+            for (Empire::SitRepItr sitrep_it = sitrep_empire->SitRepBegin(); sitrep_it != sitrep_empire->SitRepEnd(); ++sitrep_it) {
                 if (!verbose_sitrep) {
                     if (!sitrep_it->Validate())
                         continue;

--- a/UI/Sound.cpp
+++ b/UI/Sound.cpp
@@ -392,7 +392,7 @@ void Sound::Impl::PlayMusic(const boost::filesystem::path& path, int loops /* = 
     ALenum m_openal_error;
     std::string filename = PathToString(path);
     FILE* m_f = nullptr;
-    vorbis_info* vorbis_info;
+    vorbis_info* vorbis_info_ptr;
     m_music_loops = 0;
 
 #ifdef FREEORION_WIN32
@@ -424,12 +424,12 @@ void Sound::Impl::PlayMusic(const boost::filesystem::path& path, int loops /* = 
             {
                 ov_test_open(&m_ogg_file); // it is, now fully open the file
                 /* now we need to take some info we will need later */
-                vorbis_info = ov_info(&m_ogg_file, -1);
-                if (vorbis_info->channels == 1)
+                vorbis_info_ptr = ov_info(&m_ogg_file, -1);
+                if (vorbis_info_ptr->channels == 1)
                     m_ogg_format = AL_FORMAT_MONO16;
                 else
                     m_ogg_format = AL_FORMAT_STEREO16;
-                m_ogg_freq = vorbis_info->rate;
+                m_ogg_freq = vorbis_info_ptr->rate;
                 m_music_loops = loops;
                 /* fill up the buffers and queue them up for the first time */
                 if (!RefillBuffer(&m_ogg_file, m_ogg_format, m_ogg_freq, m_music_buffers[0], BUFFER_SIZE, m_music_loops))
@@ -535,7 +535,7 @@ void Sound::Impl::PlaySound(const boost::filesystem::path& path, bool is_ui_soun
         } else {
             if ((file = fopen(filename.c_str(), "rb")) != nullptr) { // make sure we CAN open it
                 OggVorbis_File ogg_file;
-                vorbis_info *vorbis_info;
+                vorbis_info * vorbis_info_ptr;
                 ALenum ogg_format;
 #ifdef FREEORION_WIN32
                 if (!(ov_test_callbacks(file, &ogg_file, nullptr, 0, callbacks))) // check if it's a proper ogg
@@ -545,13 +545,13 @@ void Sound::Impl::PlaySound(const boost::filesystem::path& path, bool is_ui_soun
                 {
                     ov_test_open(&ogg_file); // it is, now fully open the file
                     /* now we need to take some info we will need later */
-                    vorbis_info = ov_info(&ogg_file, -1);
-                    if (vorbis_info->channels == 1)
+                    vorbis_info_ptr = ov_info(&ogg_file, -1);
+                    if (vorbis_info_ptr->channels == 1)
                         ogg_format = AL_FORMAT_MONO16;
                     else
                         ogg_format = AL_FORMAT_STEREO16;
-                    ogg_freq = vorbis_info->rate;
-                    ogg_int64_t byte_size = ov_pcm_total(&ogg_file, -1) * vorbis_info->channels * 2;
+                    ogg_freq = vorbis_info_ptr->rate;
+                    ogg_int64_t byte_size = ov_pcm_total(&ogg_file, -1) * vorbis_info_ptr->channels * 2;
                     if (byte_size <= 1024 * 1024 * 1024) {
                         /* fill up the buffers and queue them up for the first time */
                         ALuint sound_handle;

--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -1123,7 +1123,7 @@ namespace {
         }
 
         // Return a log report of attackability of \p obj
-        std::string ReportAttackabilityOfTarget(const CombatInfo& combat_info,
+        std::string ReportAttackabilityOfTarget(const CombatInfo& combat_info_,
                                                 const std::shared_ptr<const UniverseObject>& obj)
         {
             std::stringstream ss;
@@ -1132,7 +1132,7 @@ namespace {
                << " attackable by ";
 
             bool no_one{true};
-            for (int attacking_empire_id : combat_info.empire_ids) {
+            for (int attacking_empire_id : combat_info_.empire_ids) {
                 if (attacking_empire_id == ALL_EMPIRES) {
                     if (ObjectAttackableByMonsters(obj, monster_detection)) {
                         ss << "monsters and ";

--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -811,12 +811,12 @@ namespace {
         CombatInfo&                     combat_info;                // a reference to the combat info
         int                             next_fighter_id;
 
-        AutoresolveInfo(CombatInfo& combat_info) :
+        AutoresolveInfo(CombatInfo& combat_info_) :
             valid_target_object_ids(),
             valid_attacker_object_ids(),
             empire_infos(),
             monster_detection(0.0f),
-            combat_info(combat_info),
+            combat_info(combat_info_),
             next_fighter_id(-10001) // give fighters negative ids so as to avoid clashes with any positiv-id of persistent UniverseObjects
         {
             monster_detection = GetMonsterDetection(combat_info);

--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -1038,18 +1038,18 @@ namespace {
         }
 
         /**Report for each empire the stealth objects in the combat. */
-        InitialStealthEvent::StealthInvisbleMap ReportInvisibleObjects(const CombatInfo& combat_info) const {
+        InitialStealthEvent::StealthInvisbleMap ReportInvisibleObjects(const CombatInfo& combat_info_) const {
             DebugLogger(combat) << "Reporting Invisible Objects";
             InitialStealthEvent::StealthInvisbleMap report;
             for (int object_id : valid_target_object_ids) {
-                auto obj = combat_info.objects.Object(object_id);
+                auto obj = combat_info_.objects.Object(object_id);
 
                 // for all empires, can they attack this object?
-                for (int attacking_empire_id : combat_info.empire_ids) {
+                for (int attacking_empire_id : combat_info_.empire_ids) {
                     Visibility visibility = VIS_NO_VISIBILITY;
                     DebugLogger(combat) << "Target " << obj->Name() << " by empire = "<< attacking_empire_id;
-                    auto target_visible_it = combat_info.empire_object_visibility.find(obj->Owner());
-                    if (target_visible_it != combat_info.empire_object_visibility.end()) {
+                    auto target_visible_it = combat_info_.empire_object_visibility.find(obj->Owner());
+                    if (target_visible_it != combat_info_.empire_object_visibility.end()) {
                         auto target_attacker_visibility_it = target_visible_it->second.find(obj->ID());
                         if (target_attacker_visibility_it != target_visible_it->second.end()) {
                             visibility = target_attacker_visibility_it->second;

--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -1106,10 +1106,10 @@ namespace {
 
         // Get a map from empire to set of IDs of objects that empire's objects
         // could potentially target.
-        void PopulateEmpireTargets(const CombatInfo& combat_info) {
+        void PopulateEmpireTargets(const CombatInfo& combat_info_) {
             for (int object_id : valid_target_object_ids) {
-                auto obj = combat_info.objects.Object(object_id);
-                for (int attacking_empire_id : combat_info.empire_ids) {
+                auto obj = combat_info_.objects.Object(object_id);
+                for (int attacking_empire_id : combat_info_.empire_ids) {
                     if (attacking_empire_id == ALL_EMPIRES) {
                         if (ObjectAttackableByMonsters(obj, monster_detection))
                             empire_infos[ALL_EMPIRES].target_ids.insert(object_id);
@@ -1118,7 +1118,7 @@ namespace {
                     }
                 }
 
-                DebugLogger(combat) << ReportAttackabilityOfTarget(combat_info, obj);
+                DebugLogger(combat) << ReportAttackabilityOfTarget(combat_info_, obj);
             }
         }
 

--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -1083,9 +1083,9 @@ namespace {
         typedef std::set<int>::const_iterator const_id_iterator;
 
         // Populate lists of things that can attack and be attacked. List attackers also by empire.
-        void PopulateAttackersAndTargets(const CombatInfo& combat_info) {
-            for (auto it = combat_info.objects.const_begin();
-                 it != combat_info.objects.const_end(); ++it)
+        void PopulateAttackersAndTargets(const CombatInfo& combat_info_) {
+            for (auto it = combat_info_.objects.const_begin();
+                 it != combat_info_.objects.const_end(); ++it)
             {
                 auto obj = *it;
                 bool can_attack{ObjectCanAttack(obj)};

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -344,7 +344,6 @@ sc::result Idle::react(const HostSPGame& msg) {
     try {
         host_player_name = GetHostNameFromSinglePlayerSetupData(*single_player_setup_data);
     } catch (const std::exception& e) {
-        const PlayerConnectionPtr& player_connection = msg.m_player_connection;
         player_connection->SendMessage(ErrorMessage(UserStringNop("UNABLE_TO_READ_SAVE_FILE"), true));
         return discard_event();
     }

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -238,8 +238,8 @@ std::set<int> Universe::EmpireVisibleObjectIDs(int empire_id/* = ALL_EMPIRES*/) 
     // if an empire has visibility of it
     for (auto obj_it = m_objects.const_begin(); obj_it != m_objects.const_end(); ++obj_it) {
         int id = obj_it->ID();
-        for (int empire_id : empire_ids) {
-            Visibility vis = GetObjectVisibilityByEmpire(id, empire_id);
+        for (int detector_empire_id : empire_ids) {
+            Visibility vis = GetObjectVisibilityByEmpire(id, detector_empire_id);
             if (vis >= VIS_BASIC_VISIBILITY) {
                 retval.insert(id);
                 break;

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -2721,8 +2721,8 @@ std::set<int> Universe::RecursiveDestroy(int object_id) {
         Destroy(object_id);
         retval.insert(object_id);
 
-    } else if (auto fleet = std::dynamic_pointer_cast<Fleet>(obj)) {
-        for (int ship_id : fleet->ShipIDs()) {
+    } else if (auto obj_fleet = std::dynamic_pointer_cast<Fleet>(obj)) {
+        for (int ship_id : obj_fleet->ShipIDs()) {
             if (system)
                 system->Remove(ship_id);
             Destroy(ship_id);

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -1896,9 +1896,8 @@ namespace {
             // being detectable by an empire requires the object to have
             // low enough stealth (0 or below the empire's detection strength)
             for (const auto& empire_entry : empire_detection_strengths) {
-                int empire_id = empire_entry.first;
-                if (object_stealth <= empire_entry.second || object_stealth == 0.0f || obj->OwnedBy(empire_id))
-                    retval[empire_id][object_pos].push_back(object_id);
+                if (object_stealth <= empire_entry.second || object_stealth == 0.0f || obj->OwnedBy(empire_entry.first))
+                    retval[empire_entry.first][object_pos].push_back(object_id);
             }
         }
         return retval;

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -2733,8 +2733,8 @@ std::set<int> Universe::RecursiveDestroy(int object_id) {
         Destroy(object_id);
         retval.insert(object_id);
 
-    } else if (auto planet = std::dynamic_pointer_cast<Planet>(obj)) {
-        for (int building_id : planet->BuildingIDs()) {
+    } else if (auto obj_planet = std::dynamic_pointer_cast<Planet>(obj)) {
+        for (int building_id : obj_planet->BuildingIDs()) {
             if (system)
                 system->Remove(building_id);
             Destroy(building_id);

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -1597,10 +1597,6 @@ namespace {
     static const std::string EMPTY_STRING;
 
     const std::string& GetSpeciesFromObject(std::shared_ptr<const UniverseObject> obj) {
-        std::shared_ptr<const Fleet> obj_fleet;
-        std::shared_ptr<const Ship> obj_ship;
-        std::shared_ptr<const Building> obj_building;
-
         switch (obj->ObjectType()) {
         case OBJ_PLANET: {
             auto obj_planet = std::static_pointer_cast<const Planet>(obj);

--- a/universe/UniverseGenerator.cpp
+++ b/universe/UniverseGenerator.cpp
@@ -390,7 +390,6 @@ namespace {
         typedef std::pair<double, double> VectTypeQQ;
         typedef std::pair<VectTypeQQ, double> VectAndMagTypeQQ;
 
-        std::map<int, VectAndMagTypeQQ> laneVectsMap;  // componenets of vectors of lanes of current system, indexed by destination system number
         std::set<std::pair<int, int>> lanesToRemoveSet;  // start and end stars of lanes to be removed in final step...
 
         // make sure data is consistent
@@ -415,6 +414,7 @@ namespace {
             auto startY = entry.second->Y();
             auto cur_sys_id = entry.first;
 
+            /** componenets of vectors of lanes of current system, indexed by destination system number */
             std::map<int, VectAndMagTypeQQ> laneVectsMap;
 
             // get unit vectors for all lanes of this system

--- a/universe/UniverseObject.cpp
+++ b/universe/UniverseObject.cpp
@@ -184,13 +184,13 @@ std::string UniverseObject::Dump() const {
     } else {
         os << "  at: (" << this->X() << ", " << this->Y() << ")";
         int near_id = GetPathfinder()->NearestSystemTo(this->X(), this->Y());
-        auto system = GetSystem(near_id);
-        if (system) {
-            const std::string& sys_name = system->Name();
+        auto near_system = GetSystem(near_id);
+        if (near_system) {
+            const std::string& sys_name = near_system->Name();
             if (sys_name.empty())
-                os << " nearest (System " << system->ID() << ")";
+                os << " nearest (System " << near_system->ID() << ")";
             else
-                os << " nearest " << system->Name();
+                os << " nearest " << near_system->Name();
         }
     }
     if (Unowned()) {

--- a/universe/ValueRef.cpp
+++ b/universe/ValueRef.cpp
@@ -135,20 +135,20 @@ namespace {
         auto first = property_name.begin();
         auto last = property_name.end();
         while (first != last) {
-            std::string property_name = *first;
-            retval += " " + property_name + " ";
-            if (property_name == "Planet") {
+            std::string property_name_part = *first;
+            retval += " " + property_name_part + " ";
+            if (property_name_part == "Planet") {
                 if (auto b = std::dynamic_pointer_cast<const Building>(obj)) {
                     retval += "(" + std::to_string(b->PlanetID()) + "): ";
                     obj = GetPlanet(b->PlanetID());
                 } else
                     obj = nullptr;
-            } else if (property_name == "System") {
+            } else if (property_name_part == "System") {
                 if (obj) {
                     retval += "(" + std::to_string(obj->SystemID()) + "): ";
                     obj = GetSystem(obj->SystemID());
                 }
-            } else if (property_name == "Fleet") {
+            } else if (property_name_part == "Fleet") {
                 if (auto s = std::dynamic_pointer_cast<const Ship>(obj))  {
                     retval += "(" + std::to_string(s->FleetID()) + "): ";
                     obj = GetFleet(s->FleetID());

--- a/universe/ValueRef.cpp
+++ b/universe/ValueRef.cpp
@@ -932,8 +932,8 @@ int Variable<int>::Eval(const ScriptingContext& context) const
 
     }
     else if (property_name == "LastTurnBattleHere") {
-        if (auto system = std::dynamic_pointer_cast<const System>(object))
-            return system->LastTurnBattleHere();
+        if (auto const_system = std::dynamic_pointer_cast<const System>(object))
+            return const_system->LastTurnBattleHere();
         else if (auto system = GetSystem(object->SystemID()))
             return system->LastTurnBattleHere();
         else

--- a/universe/ValueRef.h
+++ b/universe/ValueRef.h
@@ -69,13 +69,13 @@ struct ScriptingContext {
       * there is no root candidate in the parent context, then the input object
       * becomes the root candidate. */
     ScriptingContext(const ScriptingContext& parent_context,
-                     std::shared_ptr<const UniverseObject> condition_local_candidate) :
+                     std::shared_ptr<const UniverseObject> condition_local_candidate_) :
         source(                     parent_context.source),
         effect_target(              parent_context.effect_target),
         condition_root_candidate(   parent_context.condition_root_candidate ?
                                         parent_context.condition_root_candidate :
-                                        condition_local_candidate),                 // if parent context doesn't already have a root candidate, the new local candidate is the root
-        condition_local_candidate(  condition_local_candidate),                     // new local candidate
+                                        condition_local_candidate_),                 // if parent context doesn't already have a root candidate, the new local candidate is the root
+        condition_local_candidate(  condition_local_candidate_),                     // new local candidate
         current_value(              parent_context.current_value)
     {}
 

--- a/util/Directories.cpp
+++ b/util/Directories.cpp
@@ -622,9 +622,9 @@ fs::path GetPath(const std::string& path_string) {
     } catch (const boost::bad_lexical_cast& ec) {
         // try partial match
         std::string retval = path_string;
-        for (const auto& path_type : PathTypeStrings()) {
-            std::string path_type_string = PathToString(GetPath(path_type));
-            boost::replace_all(retval, path_type, path_type_string);
+        for (const auto& path_type_str : PathTypeStrings()) {
+            std::string path_type_string = PathToString(GetPath(path_type_str));
+            boost::replace_all(retval, path_type_str, path_type_string);
         }
         if (path_string != retval) {
             return FilenameToPath(retval);

--- a/util/Order.cpp
+++ b/util/Order.cpp
@@ -252,8 +252,8 @@ void NewFleetOrder::ExecuteImpl() const {
         if (!modified_fleet->Empty())
             modified_fleet->StateChangedSignal();
         else {
-            if (auto system = GetSystem(modified_fleet->SystemID()))
-                system->Remove(modified_fleet->ID());
+            if (auto modified_fleet_system = GetSystem(modified_fleet->SystemID()))
+                modified_fleet_system->Remove(modified_fleet->ID());
 
             GetUniverse().Destroy(modified_fleet->ID());
         }


### PR DESCRIPTION
Majority are renames, a few cases were dropped where they matched the previous definition.

The last commit attempts to resolve an issue with `GraphicalSummary::parent`, while the resolution works on my machine, I'm cautious it is not correct.

Only remaining noted warnings for `-Wshadow` are for utf8/checked, I left those for a potential update of library.