### PR TITLE
Generalize dismiss ghost.

### DIFF
--- a/UI/FleetWnd.h
+++ b/UI/FleetWnd.h
@@ -145,6 +145,7 @@ protected:
     //@}
 
 private:
+    void            RequireRefresh();
     void            Refresh();                          ///< regenerates contents
     void            RefreshStateChangedSignals();
 
@@ -166,13 +167,15 @@ private:
     void            SetStatIconValues();          ///< sets values for multi-fleet aggregate stat icons at top of FleetWnd
     mutable boost::signals2::signal<void (FleetWnd*)> ClosingSignal;
 
-    boost::signals2::connection  m_system_connection;
+    boost::signals2::connection              m_system_connection;
+    std::vector<boost::signals2::connection> m_fleet_connections;
 
     std::set<int>       m_fleet_ids;        ///< IDs of fleets shown in this wnd (always.  set when creating wnd, either by being passed in directly, or found by checking indicated system for indicated empire's fleets.  If set directly, never updates.  If set by checking system, updates when the system has a fleet added or removed.
     int                 m_empire_id;        ///< ID of empire whose fleets are shown in this wnd.  May be ALL_EMPIRES if this FleetWnd wasn't set to shown a particular empire's fleets.
     int                 m_system_id;        ///< ID of system whose fleets are shown in this wnd.  May be INVALID_OBJECT_ID if this FleetWnd wasn't set to show a system's fleets.
 
     bool                m_order_issuing_enabled;
+    bool                m_needs_refresh = false;
 
     std::shared_ptr<FleetsListBox>      m_fleets_lb;
     std::shared_ptr<FleetDataPanel>     m_new_fleet_drop_target;

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -5563,9 +5563,7 @@ void MapWnd::FleetButtonRightClicked(const FleetButton* fleet_btn) {
 
         auto forget_fleet_actions = [this, empire_id, sensor_ghosts]() {
             for (auto fleet_id : sensor_ghosts) {
-                HumanClientApp::GetApp()->Orders().IssueOrder(std::make_shared<ForgetOrder>(empire_id, fleet_id));
-                GetUniverse().ForgetKnownObject(ALL_EMPIRES, fleet_id);
-                ClientUI::GetClientUI()->GetMapWnd()->RemoveFleet(fleet_id);
+                ForgetObject(fleet_id);
             }
         };
 

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -4620,6 +4620,50 @@ void MapWnd::SetProjectedFleetMovementLines(const std::vector<int>& fleet_ids,
 void MapWnd::ClearProjectedFleetMovementLines()
 { m_projected_fleet_lines.clear(); }
 
+void MapWnd::ForgetObject(int id) {
+    // Remove visibility information for this object from
+    // the empire's visibility table.
+    // The object is usually a ghost ship or fleet.
+    // Server changes cause a permanent effect
+    // Tell the server to change what the empire wants to know
+    // in future so that the server doesn't keep resending this
+    // object information.
+    auto obj = GetUniverseObject(id);
+    if (!obj)
+        return;
+
+    // If there is only 1 ship in a fleet, forget the fleet
+    auto ship = std::dynamic_pointer_cast<const Ship>(obj);
+    if (ship) {
+        if (auto ship_s_fleet = GetUniverse().Objects().Object<const Fleet>(ship->FleetID())) {
+            bool only_ship_in_fleet = ship_s_fleet->NumShips() == 1;
+            if (only_ship_in_fleet)
+                return ForgetObject(ship->FleetID());
+        }
+    }
+
+    int client_empire_id = HumanClientApp::GetApp()->EmpireID();
+
+    HumanClientApp::GetApp()->Orders().IssueOrder(
+        std::make_shared<ForgetOrder>(client_empire_id, obj->ID()));
+
+    // Client changes for immediate effect
+    // Force the client to change immediately.
+    GetUniverse().ForgetKnownObject(ALL_EMPIRES, obj->ID());
+
+    // Force a refresh
+    RequirePreRender();
+
+    // Update fleet wnd if needed
+    if (auto fleet = std::dynamic_pointer_cast<const Fleet>(obj)) {
+        RemoveFleet(fleet->ID());
+        fleet->StateChangedSignal();
+    }
+
+    if (ship)
+        ship->StateChangedSignal();
+}
+
 void MapWnd::DoSystemIconsLayout() {
     // position and resize system icons and gaseous substance
     const int SYSTEM_ICON_SIZE = SystemIconSize();

--- a/UI/MapWnd.h
+++ b/UI/MapWnd.h
@@ -190,6 +190,9 @@ public:
 
     void ClearProjectedFleetMovementLines();     //!< removes all projected fleet movement lines
 
+    /** Forget object with \p id.  Used for sensor ghosts. */
+    void ForgetObject(int id);
+
     void ResetEmpireShown();                     //!< auto-resets the shown empire in any contained Wnds, to the current client's empire (if any)
 
     void RegisterPopup(const std::shared_ptr<MapWndPopup>& popup);              //!< registers a MapWndPopup, which can be cleaned up with a call to DeleteAllPopups( )

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -1746,7 +1746,7 @@ void Universe::ForgetKnownObject(int empire_id, int object_id) {
         ForgetKnownObject(empire_id, child_id);
 
     if (int container_id = obj->ContainerObjectID() != INVALID_OBJECT_ID) {
-        if (std::shared_ptr<UniverseObject> container = objects.Object(container_id)) {
+        if (auto container = objects.Object(container_id)) {
             if (auto system = std::dynamic_pointer_cast<System>(container))
                 system->Remove(object_id);
             else if (auto planet = std::dynamic_pointer_cast<Planet>(container))

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -1751,8 +1751,11 @@ void Universe::ForgetKnownObject(int empire_id, int object_id) {
                 system->Remove(object_id);
             else if (auto planet = std::dynamic_pointer_cast<Planet>(container))
                 planet->RemoveBuilding(object_id);
-            else if (auto fleet = std::dynamic_pointer_cast<Fleet>(container))
+            else if (auto fleet = std::dynamic_pointer_cast<Fleet>(container)) {
                 fleet->RemoveShip(object_id);
+                if (fleet->Empty())
+                    objects.Remove(fleet->ID());
+            }
         }
     }
 

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -1740,7 +1740,7 @@ void Universe::ForgetKnownObject(int empire_id, int object_id) {
         return;
     }
 
-    // Remove all contain objects to avoid breaking fleet+ship, system+planet invariants
+    // Remove all contained objects to avoid breaking fleet+ship, system+planet invariants
     auto contained_ids = obj->ContainedObjectIDs();
     for (int child_id : contained_ids)
         ForgetKnownObject(empire_id, child_id);

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -1740,10 +1740,10 @@ void Universe::ForgetKnownObject(int empire_id, int object_id) {
         return;
     }
 
-    for (int child_id : obj->VisibleContainedObjectIDs(empire_id)) {
-        if (std::shared_ptr<UniverseObject> child = objects.Object(child_id))
-            ForgetKnownObject(empire_id, child->ID());
-    }
+    // Remove all contain objects to avoid breaking fleet+ship, system+planet invariants
+    auto contained_ids = obj->ContainedObjectIDs();
+    for (int child_id : contained_ids)
+        ForgetKnownObject(empire_id, child_id);
 
     if (int container_id = obj->ContainerObjectID() != INVALID_OBJECT_ID) {
         if (std::shared_ptr<UniverseObject> container = objects.Object(container_id)) {


### PR DESCRIPTION
This PR depends on the changes in #1819.

It generalizes dismiss ghost.

- It adds `MapWnd::ForgetObject()` as a general purpose forget object function.  
- It then replaces the exising uses on the `MapWnd` and the fleets section of the `FleetWnd` with the call to `MapWnd::ForgetObject()`.  
- It adds a dismiss ghost option to the ship portion of the `FleetWnd` so that all locations where a player can see a ghost they can also dismiss it.

