### PR TITLE
Add options to restrict number of AI and number of human players.

### DIFF
--- a/UI/MultiplayerLobbyWnd.cpp
+++ b/UI/MultiplayerLobbyWnd.cpp
@@ -1010,11 +1010,10 @@ bool MultiPlayerLobbyWnd::PopulatePlayerList() {
     // set ready button state
     if (m_lobby_data.m_start_locked) {
         m_ready_bn->Disable(true);
-        m_ready_bn->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
-        m_ready_bn->SetBrowseText(m_lobby_data.m_start_lock_cause);
+        m_start_conditions_text->SetText(UserString(m_lobby_data.m_start_lock_cause));
     } else {
         m_ready_bn->Disable(false);
-        m_ready_bn->SetBrowseText("");
+        m_start_conditions_text->SetText(UserString("MULTIPLAYER_GAME_START_CONDITIONS"));
     }
 
     Refresh();

--- a/UI/MultiplayerLobbyWnd.cpp
+++ b/UI/MultiplayerLobbyWnd.cpp
@@ -1007,6 +1007,16 @@ bool MultiPlayerLobbyWnd::PopulatePlayerList() {
     else
         m_ready_bn->SetText(UserString("READY_BN"));
 
+    // set ready button state
+    if (m_lobby_data.m_start_locked) {
+        m_ready_bn->Disable(true);
+        m_ready_bn->SetBrowseModeTime(GetOptionsDB().Get<int>("UI.tooltip-delay"));
+        m_ready_bn->SetBrowseText(m_lobby_data.m_start_lock_cause);
+    } else {
+        m_ready_bn->Disable(false);
+        m_ready_bn->SetBrowseText("");
+    }
+
     Refresh();
 
     // This PreRender forces an 'extra' prerender to make the nested

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1107,6 +1107,12 @@ Start server in hostless mode. Server accepts players in the multiplayer lobby, 
 OPTIONS_DB_SKIP_CHECKSUM
 Skip comparing the resource directory checksums.  This allows faster startup when client and server are on the same machine, using the same resource directory.
 
+OPTIONS_DB_MPLOBBY_MAX_AI
+Restrict upper bound for number of AI could be in multiplayer game. Set to -1 for unbounded.
+
+OPTIONS_DB_MPLOBBY_MIN_HUMAN
+Restrict lower bound for number of human players could start the game.
+
 OPTIONS_DB_GENERATE_CONFIG_XML
 Uses default settings, settings from any existing config.xml file, and settings given on the command line to generate a config.xml file. This will overwrite the current config.xml file, if it exists.
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1111,7 +1111,7 @@ OPTIONS_DB_MPLOBBY_MAX_AI
 Limit the number of AIs allowed in a multiplayer game. Set to -1 for unlimited.
 
 OPTIONS_DB_MPLOBBY_MIN_HUMAN
-Restrict lower bound for number of human players could start the game.
+Set the minimum number of human players required to start a multiplayer game.
 
 OPTIONS_DB_GENERATE_CONFIG_XML
 Uses default settings, settings from any existing config.xml file, and settings given on the command line to generate a config.xml file. This will overwrite the current config.xml file, if it exists.

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -977,6 +977,9 @@ Player name %1% already in use.
 ERROR_WRONG_PASSWORD
 Password wrong for player name %1%.
 
+ERROR_NOT_ENOUGH_HUMAN_PLAYERS
+Not enough human players.
+
 ERROR_CONNECTION_WAS_REPLACED
 Your connection was replaced.
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1108,7 +1108,7 @@ OPTIONS_DB_SKIP_CHECKSUM
 Skip comparing the resource directory checksums.  This allows faster startup when client and server are on the same machine, using the same resource directory.
 
 OPTIONS_DB_MPLOBBY_MAX_AI
-Restrict upper bound for number of AI could be in multiplayer game. Set to -1 for unbounded.
+Limit the number of AIs allowed in a multiplayer game. Set to -1 for unlimited.
 
 OPTIONS_DB_MPLOBBY_MIN_HUMAN
 Restrict lower bound for number of human players could start the game.

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -904,15 +904,18 @@ sc::result MPLobby::react(const LobbyUpdate& msg) {
                 case Networking::CLIENT_TYPE_HUMAN_PLAYER:
                     human_count++;
                     break;
+                default: // do nothing
+                    break;
                 }
             }
 
-            // restrict count of AI
+            // limit count of AI
             if (ai_count <= GetOptionsDB().Get<int>("mplobby-max-ai") || GetOptionsDB().Get<int>("mplobby-max-ai") < 0) {
                 m_lobby_data->m_players    = incoming_lobby_data.m_players;
             } else {
                 has_important_changes = true;
             }
+            // restrict minimun of human
             if (human_count < GetOptionsDB().Get<int>("mplobby-min-human")) {
                 has_important_changes = true;
             }

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -915,7 +915,7 @@ sc::result MPLobby::react(const LobbyUpdate& msg) {
             } else {
                 has_important_changes = true;
             }
-            // restrict minimun of human
+            // restrict minimun number of human players
             if (human_count < GetOptionsDB().Get<int>("mplobby-min-human")) {
                 has_important_changes = true;
             }

--- a/server/ServerFSM.h
+++ b/server/ServerFSM.h
@@ -203,6 +203,7 @@ private:
                          const std::string& player_name,
                          Networking::ClientType client_type,
                          const std::string& client_version_string);
+    void TestHumanPlayers();
 
     SERVER_ACCESSOR
 };

--- a/server/dmain.cpp
+++ b/server/dmain.cpp
@@ -53,7 +53,7 @@ int wmain(int argc, wchar_t* argv[], wchar_t* envp[]) {
         GetOptionsDB().AddFlag("hostless",           UserStringNop("OPTIONS_DB_HOSTLESS"),          false);
         GetOptionsDB().AddFlag("skip-checksum",      UserStringNop("OPTIONS_DB_SKIP_CHECKSUM"),     false);
         GetOptionsDB().Add<int>("mplobby-max-ai",    UserStringNop("OPTIONS_DB_MPLOBBY_MAX_AI"),   -1, Validator<int>());
-        GetOptionsDB().Add<int>("mplobby-min-human", UserStringNop("OPTIONS_DB_MPLOBBY_MIN_HUMAN"), 1, Validator<int>());
+        GetOptionsDB().Add<int>("mplobby-min-human", UserStringNop("OPTIONS_DB_MPLOBBY_MIN_HUMAN"), 0, Validator<int>());
 
         // if config.xml and persistent_config.xml are present, read and set options entries
         GetOptionsDB().SetFromFile(GetConfigPath(), FreeOrionVersionString());

--- a/server/dmain.cpp
+++ b/server/dmain.cpp
@@ -47,11 +47,13 @@ int wmain(int argc, wchar_t* argv[], wchar_t* envp[]) {
 #ifndef FREEORION_DMAIN_KEEP_STACKTRACE
     try {
 #endif
-        GetOptionsDB().AddFlag('h', "help",         UserStringNop("OPTIONS_DB_HELP"),         false);
-        GetOptionsDB().AddFlag('v', "version",      UserStringNop("OPTIONS_DB_VERSION"),      false);
-        GetOptionsDB().AddFlag('s', "singleplayer", UserStringNop("OPTIONS_DB_SINGLEPLAYER"), false);
-        GetOptionsDB().AddFlag("hostless",          UserStringNop("OPTIONS_DB_HOSTLESS"),     false);
-        GetOptionsDB().AddFlag("skip-checksum",     UserStringNop("OPTIONS_DB_SKIP_CHECKSUM"), false);
+        GetOptionsDB().AddFlag('h', "help",          UserStringNop("OPTIONS_DB_HELP"),              false);
+        GetOptionsDB().AddFlag('v', "version",       UserStringNop("OPTIONS_DB_VERSION"),           false);
+        GetOptionsDB().AddFlag('s', "singleplayer",  UserStringNop("OPTIONS_DB_SINGLEPLAYER"),      false);
+        GetOptionsDB().AddFlag("hostless",           UserStringNop("OPTIONS_DB_HOSTLESS"),          false);
+        GetOptionsDB().AddFlag("skip-checksum",      UserStringNop("OPTIONS_DB_SKIP_CHECKSUM"),     false);
+        GetOptionsDB().Add<int>("mplobby-max-ai",    UserStringNop("OPTIONS_DB_MPLOBBY_MAX_AI"),   -1, Validator<int>());
+        GetOptionsDB().Add<int>("mplobby-min-human", UserStringNop("OPTIONS_DB_MPLOBBY_MIN_HUMAN"), 1, Validator<int>());
 
         // if config.xml and persistent_config.xml are present, read and set options entries
         GetOptionsDB().SetFromFile(GetConfigPath(), FreeOrionVersionString());

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -332,6 +332,7 @@ struct FO_COMMON_API MultiplayerLobbyData : public GalaxySetupData {
     MultiplayerLobbyData() :
         m_any_can_edit(false),
         m_new_game(true),
+        m_start_locked(false),
         m_players(),
         m_save_game(),
         m_save_game_empire_data()
@@ -341,6 +342,7 @@ struct FO_COMMON_API MultiplayerLobbyData : public GalaxySetupData {
         GalaxySetupData(std::move(base)),
         m_any_can_edit(false),
         m_new_game(true),
+        m_start_locked(false),
         m_players(),
         m_save_game(),
         m_save_game_empire_data()
@@ -351,12 +353,15 @@ struct FO_COMMON_API MultiplayerLobbyData : public GalaxySetupData {
 
     bool                                        m_any_can_edit;
     bool                                        m_new_game;
+    bool                                        m_start_locked;
     // TODO: Change from a list<(player_id, PlayerSetupData)> where
     // PlayerSetupData contain player_id to a vector of PlayerSetupData
     std::list<std::pair<int, PlayerSetupData>>  m_players;              // <player_id, PlayerSetupData>
 
     std::string                                 m_save_game;            //< File name of a save file
     std::map<int, SaveGameEmpireData>           m_save_game_empire_data;// indexed by empire_id
+
+    std::string                                 m_start_lock_cause;
 
 private:
     friend class boost::serialization::access;

--- a/util/SerializeMultiplayerCommon.cpp
+++ b/util/SerializeMultiplayerCommon.cpp
@@ -99,7 +99,9 @@ void MultiplayerLobbyData::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_players)
         & BOOST_SERIALIZATION_NVP(m_save_game)
         & BOOST_SERIALIZATION_NVP(m_save_game_empire_data)
-        & BOOST_SERIALIZATION_NVP(m_any_can_edit);
+        & BOOST_SERIALIZATION_NVP(m_any_can_edit)
+        & BOOST_SERIALIZATION_NVP(m_start_locked)
+        & BOOST_SERIALIZATION_NVP(m_start_lock_cause);
 }
 
 template void MultiplayerLobbyData::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, const unsigned int);


### PR DESCRIPTION
Adds option `mplobby-max-ai` which restrict upper bound of AI count could be set in the multiplayer game.
Adds option `mplobby-min-humar` which restrict lower bound of human player count which could be start the game.