### PR TITLE
Improvements to the Game Options submenu in Galaxy Setup

### DIFF
--- a/GG/GG/TabWnd.h
+++ b/GG/GG/TabWnd.h
@@ -278,6 +278,9 @@ private:
     void RightClicked();
     void BringTabIntoView(std::size_t index);
 
+    /** Shows or hides the left-right buttons based on whether they are currently needed. */
+    void RecalcLeftRightButton();
+
     std::shared_ptr<RadioButtonGroup>         m_tabs;
     std::vector<std::shared_ptr<StateButton>> m_tab_buttons;
     std::shared_ptr<Font> m_font;

--- a/GG/src/TabWnd.cpp
+++ b/GG/src/TabWnd.cpp
@@ -360,6 +360,7 @@ void TabBar::DoLayout()
 {
     m_tabs->Resize(Pt(m_tabs->Size().x, LowerRight().y - UpperLeft().y));
     m_left_right_button_layout->SizeMove(Pt(), LowerRight() - UpperLeft());
+    RecalcLeftRightButton();
 }
 
 void TabBar::Render()
@@ -381,14 +382,7 @@ void TabBar::InsertTab(std::size_t index, const std::string& name)
     button->InstallEventFilter(shared_from_this());
     m_tab_buttons.insert(m_tab_buttons.begin() + index, button);
     m_tabs->InsertButton(index, m_tab_buttons[index]);
-    if (Width() < m_tabs->Width()) {
-        m_left_right_button_layout->Show();
-        m_left_button->Disable(m_first_tab_shown == 0);
-        X right_side = m_left_right_button_layout->Visible() ?
-            m_left_button->Left() :
-            Right();
-        m_right_button->Disable(m_tab_buttons.back()->Right() <= right_side);
-    }
+    RecalcLeftRightButton();
     if (m_tabs->CheckedButton() == RadioButtonGroup::NO_BUTTON)
         SetCurrentTab(0);
 }
@@ -407,10 +401,20 @@ void TabBar::RemoveTab(const std::string& name)
     m_tab_buttons[index]->RemoveEventFilter(shared_from_this());
     m_tabs->RemoveButton(m_tab_buttons[index].get());
     m_tab_buttons.erase(m_tab_buttons.begin() + index);
-    if (m_tabs->Width() <= Width())
-        m_left_right_button_layout->Hide();
+    RecalcLeftRightButton();
     if (m_tabs->CheckedButton() == RadioButtonGroup::NO_BUTTON && !m_tab_buttons.empty())
         m_tabs->SetCheck(0);
+}
+
+void TabBar::RecalcLeftRightButton()
+{
+    if (Width() < m_tabs->Width() && !m_left_right_button_layout->Visible()) {
+        m_left_right_button_layout->Show();
+        m_left_button->Disable(m_first_tab_shown == 0);
+        m_right_button->Disable(m_tab_buttons.back()->Right() <= m_left_button->Left());
+    }
+    if (m_tabs->Width() <= Width() && m_left_right_button_layout->Visible())
+        m_left_right_button_layout->Hide();
 }
 
 void TabBar::SetCurrentTab(std::size_t index)

--- a/UI/GalaxySetupWnd.cpp
+++ b/UI/GalaxySetupWnd.cpp
@@ -248,8 +248,11 @@ void GameRulesPanel::DoLayout() {
     m_tabs->SizeMove(MARGINS, ClientSize() - MARGINS);
 }
 
-void GameRulesPanel::Render()
-{ /*GG::FlatRectangle(UpperLeft(), LowerRight(), GG::CLR_CYAN, GG::CLR_GREEN, 1);*/ }
+void GameRulesPanel::Render() {
+    GG::FlatRectangle(m_tabs->CurrentWnd()->UpperLeft() - GG::Pt(GG::X(2), GG::Y0),
+                      m_tabs->CurrentWnd()->LowerRight() + GG::Pt(GG::X(2), GG::Y(2)),
+                      GG::CLR_BLACK, ClientUI::WndInnerBorderColor(), 1);
+}
 
 void GameRulesPanel::SettingChanged() {
     Sound::TempUISoundDisabler sound_disabler;

--- a/UI/GalaxySetupWnd.cpp
+++ b/UI/GalaxySetupWnd.cpp
@@ -172,10 +172,6 @@ namespace {
 ////////////////////////////////////////////////
 // GameRulesPanel
 ////////////////////////////////////////////////
-const GG::X GameRulesPanel::DefaultWidth() {
-    return GG::X(FontBasedUpscale(305));
-}
-
 GameRulesPanel::GameRulesPanel(GG::X w, GG::Y h) :
     GG::Control(GG::X0, GG::Y0, w, h, GG::NO_WND_FLAGS)
 {}

--- a/UI/GalaxySetupWnd.cpp
+++ b/UI/GalaxySetupWnd.cpp
@@ -33,7 +33,7 @@ namespace {
     { return GG::X(345 + FontBasedUpscale(300)); }
     const GG::Y GalSetupWndHeight()
     { return GG::Y(FontBasedUpscale(29) + (PANEL_CONTROL_SPACING * 6) + GAL_SETUP_PANEL_HT); }
-    const GG::Pt PREVIEW_SZ(GG::X(248), GG::Y(186));
+    const GG::Pt PREVIEW_SZ(GG::X(300), GG::Y(222));
     const bool ALLOW_NO_STARLANES = false;
 
     class RowContentsWnd : public GG::Control {

--- a/UI/GalaxySetupWnd.h
+++ b/UI/GalaxySetupWnd.h
@@ -16,8 +16,6 @@ struct GalaxySetupData;
 /** Displays game rules options */
 class GameRulesPanel : public GG::Control {
 public:
-    static const GG::X DefaultWidth();
-
     /** \name Structors*/ //!@{
     GameRulesPanel(GG::X w = GG::X(FontBasedUpscale(305)), GG::Y h = GG::Y(330));
     //!@}


### PR DESCRIPTION
It bothered me that the menu was just a bit too small to not require horizontal arrows, so I increased the size (in the second commit). I increased the galaxy type preview as well so it would still look normal, and added a border in the third commit.

Without the first commit, the left-right arrow buttons still show up. That commit also fixes the corresponding issue with the Options menu, where resizing it did not remove/bring back the left-right arrow keys until you closed and reopened it.

Before:
![image](https://user-images.githubusercontent.com/6370042/32242478-5143b678-be49-11e7-9443-3bc0b7da4860.png)
After:
![image](https://user-images.githubusercontent.com/6370042/32242490-5843c206-be49-11e7-92ed-451fabb4ab27.png)

