### PR TITLE
Implement support for alternate landscapes (#792).

### DIFF
--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -2428,7 +2428,28 @@ namespace {
         // show image of planet environment at the top of the suitability report
         std::string planet_type = boost::lexical_cast<std::string>(planet->Type());
         boost::algorithm::to_lower(planet_type);
-        detailed_description += "<img src=\"encyclopedia/planet_environments/" + planet_type + ".png\"></img>";
+
+        namespace fs = boost::filesystem;
+        std::vector<std::string> filenames;
+        fs::directory_iterator end_it;
+        for (fs::directory_iterator it(ClientUI::ArtDir() / "encyclopedia" / "planet_environments"); it != end_it; ++it) {
+            try {
+                if (fs::exists(*it) && !fs::is_directory(*it)) {
+                    auto filename = it->path().filename().string();
+                    if (boost::algorithm::starts_with(filename, planet_type)) {
+                        filenames.push_back(filename);
+                    }
+                }
+            }
+            catch (const fs::filesystem_error& e) {
+                // ignore files for which permission is denied, and rethrow other exceptions
+                if (e.code() != boost::system::posix_error::permission_denied)
+                    throw;
+            }
+        }
+        if (!filenames.empty()) {
+            detailed_description += "<img src=\"encyclopedia/planet_environments/" + filenames[planet_id % filenames.size()] + "\"></img>";
+        }
 
         std::string original_planet_species = planet->SpeciesName();
         int original_owner_id = planet->Owner();

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -2434,7 +2434,7 @@ namespace {
         fs::directory_iterator end_it;
         for (fs::directory_iterator it(ClientUI::ArtDir() / "encyclopedia" / "planet_environments"); it != end_it; ++it) {
             try {
-                if (fs::exists(*it) && !fs::is_directory(*it)) {
+                if (fs::exists(*it) && fs::is_regular_file(it->status())) {
                     auto filename = it->path().filename().string();
                     if (boost::algorithm::starts_with(filename, planet_type)) {
                         filenames.push_back(filename);

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -2432,7 +2432,7 @@ namespace {
 
         namespace fs = boost::filesystem;
         // Cache searches through the planet_environments directory
-        static std::unordered_map<PlanetType, std::vector<std::string>> filenames_by_type;
+        static std::unordered_map<int, std::vector<std::string>> filenames_by_type;
         // Only search once per execution
         if (!filenames_by_type.count(type)) {
             fs::directory_iterator end_it;


### PR DESCRIPTION
Tested in-game and was able to get both Inferno images, and it stayed the same between runs for the same planet.