### PR TITLE
Fix AI enqueuing too many scouts when loading a game on turn 1

### DIFF
--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -228,7 +228,7 @@ def generate_production_orders():
                 continue
             claimed_stars.setdefault(t_sys.starType, []).append(sys_id)
 
-    if current_turn == 1 and len(AIstate.opponentPlanetIDs) == 0:
+    if current_turn == 1 and len(AIstate.opponentPlanetIDs) == 0 and len(production_queue) == 0:
         best_design_id, _, build_choices = get_best_ship_info(PriorityType.PRODUCTION_EXPLORATION)
         if best_design_id is not None:
             for _ in range(3):


### PR DESCRIPTION
The AI would enqueue a 3 scouts at game start and, once loading a game on turn 1, would add another 3 to the queue.

This PR fixes that bug by making sure the production queue is empty before enqueuing the scouts.