### PR TITLE
Don't save AI messages in the chat history.

### DIFF
--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -1183,7 +1183,9 @@ sc::result MPLobby::react(const PlayerChat& msg) {
 
     boost::posix_time::ptime timestamp = boost::posix_time::second_clock::universal_time();
 
-    server.PushChatMessage(timestamp, sender->PlayerName(), data);
+    if (sender->GetClientType() != Networking::CLIENT_TYPE_AI_PLAYER) {
+        server.PushChatMessage(timestamp, sender->PlayerName(), data);
+    }
 
     if (receiver == Networking::INVALID_PLAYER_ID) { // the receiver is everyone
         for (auto it = server.m_networking.established_begin(); it != server.m_networking.established_end(); ++it) {
@@ -1812,7 +1814,9 @@ sc::result PlayingGame::react(const PlayerChat& msg) {
 
     boost::posix_time::ptime timestamp = boost::posix_time::second_clock::universal_time();
 
-    server.PushChatMessage(timestamp, sender->PlayerName(), data);
+    if (sender->GetClientType() != Networking::CLIENT_TYPE_AI_PLAYER) {
+        server.PushChatMessage(timestamp, sender->PlayerName(), data);
+    }
 
     for (auto it = server.m_networking.established_begin();
          it != server.m_networking.established_end(); ++it)


### PR DESCRIPTION
Disable saving AI chat message in history buffer so they won't appear in multiplayer lobby.