### PR TITLE
OSX CMake: Fix DMG package generation on OSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -671,7 +671,9 @@ add_subdirectory(doc)
 ## Install targets and package project.
 ##
 
-if(UNIX AND NOT APPLE)
+if(APPLE)
+    install(TARGETS freeorion BUNDLE DESTINATION .)
+elseif(UNIX)
     install(
         TARGETS
             freeorioncommon


### PR DESCRIPTION
*Attention:* This PR is for the osx-cmake branch!

In order for the FO app bundle to actually get copied into the DMG file CPack generates, a proper install statement needs to be issued for the OSX platform.