### PR TITLE
Set stringtable filename from system locale

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,6 +321,7 @@ target_link_libraries(freeorioncommon
     ${Boost_DATE_TIME_LIBRARY}
     ${Boost_FILESYSTEM_LIBRARY}
     ${Boost_IOSTREAMS_LIBRARY}
+    ${Boost_LOCALE_LIBRARY}
     ${Boost_LOG_LIBRARY}
     ${Boost_LOG_SETUP_LIBRARY}
     ${Boost_REGEX_LIBRARY}

--- a/util/Directories.cpp
+++ b/util/Directories.cpp
@@ -635,3 +635,14 @@ fs::path GetPath(const std::string& path_string) {
     }
     return GetPath(path_type);
 }
+
+bool IsExistingFile(const fs::path& path) {
+    try {
+        auto stat = fs::status(path);
+        return fs::exists(stat) && fs::is_regular_file(stat);
+    } catch(boost::filesystem::filesystem_error& ec) {
+        ErrorLogger() << "Filesystem error during stat of " << PathToString(path) << " : " << ec.what();
+    }
+
+    return false;
+}

--- a/util/Directories.h
+++ b/util/Directories.h
@@ -108,5 +108,8 @@ FO_COMMON_API boost::filesystem::path GetPath(PathType path_type);
 /** Returns path for path type cast from @p path_string */
 FO_COMMON_API boost::filesystem::path GetPath(const std::string& path_string);
 
+/** Returns if path exists and is a regular file */
+FO_COMMON_API bool IsExistingFile(const boost::filesystem::path& path);
+
 
 #endif

--- a/util/MultiplayerCommon.cpp
+++ b/util/MultiplayerCommon.cpp
@@ -29,7 +29,8 @@ namespace {
                             OrValidator<std::string>(LogLevelValidator(), DiscreteValidator<std::string>("")), false);
         db.Add<std::string>("log-file",             UserStringNop("OPTIONS_DB_LOG_FILE"),              "",
                             Validator<std::string>() , false);
-        db.Add<std::string>("stringtable-filename", UserStringNop("OPTIONS_DB_STRINGTABLE_FILENAME"),  PathToString(GetRootDataDir() / "default" / "stringtables" / "en.txt"));
+        // Default stringtable filename is deferred to i18n.cpp::InitStringtableFileName to determine if user specified
+        db.Add<std::string>("stringtable-filename", UserStringNop("OPTIONS_DB_STRINGTABLE_FILENAME"),  "");
         db.Add("binary-serialization",              UserStringNop("OPTIONS_DB_BINARY_SERIALIZATION"),  false);
         db.Add("xml-zlib-serialization",            UserStringNop("OPTIONS_DB_XML_ZLIB_SERIALIZATION"),true);
 

--- a/util/i18n.cpp
+++ b/util/i18n.cpp
@@ -24,7 +24,13 @@ namespace {
 
         stringtable_filename_init = true;
 
+        bool was_specified = false;
         if (!GetOptionsDB().IsDefaultValue("stringtable-filename"))
+            was_specified = true;
+
+        // Set the english stingtable as the default option
+        GetOptionsDB().SetDefault("stringtable-filename", PathToString(GetResourceDir() / "stringtables/en.txt"));
+        if (was_specified)
             return;
 
         boost::locale::generator gen;


### PR DESCRIPTION
Attempts to determine preferred language from system locale.
Check is only performed when the `stringtable-filename` option is at default value.

Resolves #1811