### PR TITLE
Remove Phototrophic min pop requirement on blue and white stars

### DIFF
--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -154,7 +154,7 @@ def calc_max_pop(planet, species, detail):
         base_pop = base_pop_not_modified_by_species + base_pop_modified_by_species + species_effect
         return planet_size * base_pop + pop_const_mod
 
-    if "PHOTOTROPHIC" in tag_list and max_pop_size() > 0:
+    if "PHOTOTROPHIC" in tag_list:
         star_type = fo.getUniverse().getSystem(planet.systemID).starType
         star_pop_mod = AIDependencies.POP_MOD_PHOTOTROPHIC_STAR_MAP.get(star_type, 0)
         base_pop_not_modified_by_species += star_pop_mod

--- a/default/scripting/species/common/population.macros
+++ b/default/scripting/species/common/population.macros
@@ -154,7 +154,6 @@ PHOTOTROPHIC_BONUS
                 Planet
                 HasTag name = "PHOTOTROPHIC"
                 Star type = [Blue]
-                TargetPopulation low = 0
             ]
             accountinglabel = "VERY_BRIGHT_STAR"
             priority = [[LATEST_GROWTH_PRIORITY]]
@@ -166,7 +165,6 @@ PHOTOTROPHIC_BONUS
                 Planet
                 HasTag name = "PHOTOTROPHIC"
                 Star type = [White]
-                TargetPopulation low = 0
             ]
             accountinglabel = "BRIGHT_STAR"
             priority = [[LATEST_GROWTH_PRIORITY]]


### PR DESCRIPTION
Removes the minimum pop restriction for phototrophic pop bonus on white or blue stars.

Workaround for issue #1619, in event a suitable fix is not implemented before 0.4.8rc.