### PR TITLE
Make GeneralizedLocation report no location for fields and temp objs

### DIFF
--- a/universe/Pathfinder.cpp
+++ b/universe/Pathfinder.cpp
@@ -839,7 +839,7 @@ namespace {
         if (fleet)
             return std::make_pair(fleet->PreviousSystemID(), fleet->NextSystemID());
 
-        if (auto field = std::dynamic_pointer_cast<const Field>(obj))
+        if (std::dynamic_pointer_cast<const Field>(obj))
             return nullptr;
 
         // Don't generate an error message for temporary objects.

--- a/universe/Pathfinder.cpp
+++ b/universe/Pathfinder.cpp
@@ -3,6 +3,7 @@
 #include "../util/Logger.h"
 #include "../util/ScopedTimer.h"
 #include "../Empire/EmpireManager.h"
+#include "Field.h"
 #include "Fleet.h"
 #include "Ship.h"
 #include "System.h"
@@ -837,6 +838,13 @@ namespace {
         auto fleet = FleetFromObject(obj);
         if (fleet)
             return std::make_pair(fleet->PreviousSystemID(), fleet->NextSystemID());
+
+        if (auto field = std::dynamic_pointer_cast<const Field>(obj))
+            return nullptr;
+
+        // Don't generate an error message for temporary objects.
+        if (obj->ID() == TEMPORARY_OBJECT_ID)
+            return nullptr;
 
         ErrorLogger() << "GeneralizedLocationType unable to locate " << obj->Name() << "(" << obj->ID() << ")";
         return nullptr;


### PR DESCRIPTION
`GeneralizedLocation` always reported no location (system id) with an error message for types of objects that it does not know about.  

This PR make fields a known type that has no location, because it is not centered on a system.  
This fixes error messages that started up later in the game when the Experimentors start adding/removing starlanes.

It also make temporary objects that are not located in a system, or fleets return no location and not produce an error message.  The error message was being triggered by temporary objects created by the pedia.