### PR TITLE
Add single or bracketed repeat parser

### DIFF
--- a/parse/CommonParams.h
+++ b/parse/CommonParams.h
@@ -79,6 +79,7 @@ namespace parse { namespace detail {
         producible_rule                         producible;
         condition_parser_rule                   location;
         condition_parser_rule                   enqueue_location;
+        single_or_repeated_string<std::set<std::string>> repeated_string;
         exclusions_rule                         exclusions;
         more_common_params_rule                 more_common;
         common_params_rule                      common;

--- a/parse/CommonParamsParser.cpp
+++ b/parse/CommonParamsParser.cpp
@@ -41,7 +41,8 @@ namespace parse { namespace detail {
         castable_int_rules(tok, labeller, condition_parser, string_grammar),
         double_rules(tok, labeller, condition_parser, string_grammar),
         effects_group_grammar(tok, labeller, condition_parser, string_grammar),
-        non_ship_part_meter_type_enum(tok)
+        non_ship_part_meter_type_enum(tok),
+        repeated_string(tok)
     {
         namespace qi = boost::spirit::qi;
 
@@ -85,13 +86,11 @@ namespace parse { namespace detail {
             ;
 
         exclusions
-            =  -(
+            =
+            -(
                 labeller.rule(Exclusions_token)
-                >>  (
-                    ('[' > +tok.string [ insert(_r1, _1) ] > ']')
-                    |   tok.string [ insert(_r1, _1) ]
-                )
-            )
+                >> repeated_string
+            ) [_r1 = _1]
             ;
 
         more_common
@@ -107,7 +106,7 @@ namespace parse { namespace detail {
             (   labeller.rule(BuildCost_token)  > double_rules.expr [ _a = _1 ]
                 >   labeller.rule(BuildTime_token)  > castable_int_rules.flexible_int [ _b = _1 ]
                 >   producible                                          [ _c = _1 ]
-                >   tags_parser(_d)
+                >   tags_parser [ _d = _1 ]
                 >   location [_e = _1]
                 >   enqueue_location [_i = _1]
                 >  -consumption(_g, _h)

--- a/parse/ConditionParser6.cpp
+++ b/parse/ConditionParser6.cpp
@@ -30,15 +30,18 @@ namespace parse { namespace detail {
         const value_ref_grammar<std::string>& string_grammar
     ) :
         condition_parser_rules_6::base_type(start, "condition_parser_rules_6"),
+        one_or_more_string_values(string_grammar),
         universe_object_type_rules(tok, labeller, condition_parser),
         planet_type_rules(tok, labeller, condition_parser),
         planet_size_rules(tok, labeller, condition_parser),
-        planet_environment_rules(tok, labeller, condition_parser)
+        planet_environment_rules(tok, labeller, condition_parser),
+        one_or_more_planet_types(planet_type_rules.expr),
+        one_or_more_planet_sizes(planet_size_rules.expr),
+        one_or_more_planet_environments(planet_environment_rules.expr)
   {
         qi::_1_type _1;
         qi::_a_type _a;
         qi::_b_type _b;
-        qi::_r1_type _r1;
         qi::_val_type _val;
         qi::eps_type eps;
         qi::_pass_type _pass;
@@ -50,15 +53,10 @@ namespace parse { namespace detail {
         using phoenix::push_back;
         using phoenix::construct;
 
-        string_ref_vec
-            =   ('[' > +string_grammar [ emplace_back_1_(_r1, _1) ] > ']')
-            |    string_grammar [ emplace_back_1_(_r1, _1) ]
-            ;
-
         homeworld
             =   tok.Homeworld_
             >   (
-                (labeller.rule(Name_token) > string_ref_vec(_a) [ _val = construct_movable_(new_<Condition::Homeworld>(deconstruct_movable_vector_(_a, _pass))) ])
+                (labeller.rule(Name_token) > one_or_more_string_values [ _a = _1, _val = construct_movable_(new_<Condition::Homeworld>(deconstruct_movable_vector_(_a, _pass))) ])
                 |    eps [ _val = construct_movable_(new_<Condition::Homeworld>()) ]
             )
             ;
@@ -66,7 +64,7 @@ namespace parse { namespace detail {
         building
             =   (
                 tok.Building_
-                >  -(labeller.rule(Name_token) > string_ref_vec(_a))
+                >  -(labeller.rule(Name_token) > one_or_more_string_values [ _a = _1 ])
             )
             [ _val = construct_movable_(new_<Condition::Building>(deconstruct_movable_vector_(_a, _pass))) ]
             ;
@@ -74,7 +72,7 @@ namespace parse { namespace detail {
         species
             =   tok.Species_
             >   (
-                (labeller.rule(Name_token) > string_ref_vec(_a) [ _val = construct_movable_(new_<Condition::Species>(deconstruct_movable_vector_(_a, _pass))) ])
+                (labeller.rule(Name_token) > one_or_more_string_values [ _a = _1, _val = construct_movable_(new_<Condition::Species>(deconstruct_movable_vector_(_a, _pass))) ])
                 |    eps [ _val = construct_movable_(new_<Condition::Species>()) ]
             )
             ;
@@ -82,7 +80,7 @@ namespace parse { namespace detail {
         focus_type
             =   tok.Focus_
             >   (
-                (labeller.rule(Type_token) > string_ref_vec(_a) [ _val = construct_movable_(new_<Condition::FocusType>(deconstruct_movable_vector_(_a, _pass))) ])
+                (labeller.rule(Type_token) > one_or_more_string_values [ _a = _1, _val = construct_movable_(new_<Condition::FocusType>(deconstruct_movable_vector_(_a, _pass))) ])
                 | eps [ _val = construct_movable_(new_<Condition::FocusType>(deconstruct_movable_vector_(_a, _pass))) ]
             )
             ;
@@ -91,32 +89,23 @@ namespace parse { namespace detail {
             =   (tok.Planet_
                  >>  labeller.rule(Type_token)
                 )
-            >   (
-                ('[' > +planet_type_rules.expr [ emplace_back_1_(_a, _1) ] > ']')
-                |    planet_type_rules.expr [ emplace_back_1_(_a, _1) ]
-            )
-            [ _val = construct_movable_(new_<Condition::PlanetType>(deconstruct_movable_vector_(_a, _pass))) ]
+            >   one_or_more_planet_types
+            [ _val = construct_movable_(new_<Condition::PlanetType>(deconstruct_movable_vector_(_1, _pass))) ]
             ;
 
         planet_size
             =   (tok.Planet_
                  >>  labeller.rule(Size_token)
                 )
-            >   (
-                ('[' > +planet_size_rules.expr [ emplace_back_1_(_a, _1) ] > ']')
-                |    planet_size_rules.expr [ emplace_back_1_(_a, _1) ]
-            )
-            [ _val = construct_movable_(new_<Condition::PlanetSize>(deconstruct_movable_vector_(_a, _pass))) ]
+            >   one_or_more_planet_sizes
+            [ _val = construct_movable_(new_<Condition::PlanetSize>(deconstruct_movable_vector_(_1, _pass))) ]
             ;
 
         planet_environment
             =   ((tok.Planet_
                   >>  labeller.rule(Environment_token)
                  )
-                 >   (
-                     ('[' > +planet_environment_rules.expr [ emplace_back_1_(_a, _1) ] > ']')
-                     |    planet_environment_rules.expr [ emplace_back_1_(_a, _1) ]
-                 )
+                 >   one_or_more_planet_environments [ _a = _1 ]
                  >  -(labeller.rule(Species_token)        >  string_grammar [_b = _1]))
             [ _val = construct_movable_(new_<Condition::PlanetEnvironment>(
                     deconstruct_movable_vector_(_a, _pass),
@@ -148,7 +137,7 @@ namespace parse { namespace detail {
             |   object_type
             ;
 
-        string_ref_vec.name("sequence of string expressions");
+        one_or_more_string_values.name("sequence of string expressions");
         homeworld.name("Homeworld");
         building.name("Building");
         species.name("Species");
@@ -159,7 +148,7 @@ namespace parse { namespace detail {
         object_type.name("ObjectType");
 
 #if DEBUG_CONDITION_PARSERS
-        debug(string_ref_vec);
+        debug(one_or_more_string_values);
         debug(homeworld);
         debug(building);
         debug(species);

--- a/parse/ConditionParser6.h
+++ b/parse/ConditionParser6.h
@@ -37,7 +37,7 @@ namespace parse { namespace detail {
             >
         > planet_environment_rule;
 
-        string_ref_vec_rule               string_ref_vec;
+        single_or_bracketed_repeat<value_ref_grammar<std::string>> one_or_more_string_values;
         building_focus_species_rule       homeworld;
         building_focus_species_rule       building;
         building_focus_species_rule       species;
@@ -51,6 +51,9 @@ namespace parse { namespace detail {
         planet_type_parser_rules          planet_type_rules;
         planet_size_parser_rules          planet_size_rules;
         planet_environment_parser_rules   planet_environment_rules;
+        single_or_bracketed_repeat<value_ref_rule<PlanetType>> one_or_more_planet_types;
+        single_or_bracketed_repeat<value_ref_rule<PlanetSize>> one_or_more_planet_sizes;
+        single_or_bracketed_repeat<value_ref_rule<PlanetEnvironment>> one_or_more_planet_environments;
     };
 
     }

--- a/parse/ConditionParser7.cpp
+++ b/parse/ConditionParser7.cpp
@@ -25,7 +25,8 @@ namespace parse { namespace detail {
         const value_ref_grammar<std::string>& string_grammar
     ) :
         condition_parser_rules_7::base_type(start, "condition_parser_rules_7"),
-        star_type_rules(tok, labeller, condition_parser)
+        star_type_rules(tok, labeller, condition_parser),
+        one_or_more_star_types(star_type_rules.expr)
     {
         qi::_1_type _1;
         qi::_a_type _a;
@@ -62,11 +63,8 @@ namespace parse { namespace detail {
         star_type
             =    tok.Star_
             >    labeller.rule(Type_token)
-            >    (
-                ('[' > +star_type_rules.expr [ push_back(_a, _1) ] > ']')
-                |    star_type_rules.expr [ push_back(_a, _1) ]
-            )
-            [ _val = construct_movable_(new_<Condition::StarType>(deconstruct_movable_vector_(_a, _pass))) ]
+            >    one_or_more_star_types
+            [ _val = construct_movable_(new_<Condition::StarType>(deconstruct_movable_vector_(_1, _pass))) ]
             ;
 
         location

--- a/parse/ConditionParser7.h
+++ b/parse/ConditionParser7.h
@@ -10,10 +10,7 @@ namespace parse { namespace detail {
                                  const condition_parser_grammar& condition_parser,
                                  const value_ref_grammar<std::string>& string_grammar);
 
-        typedef rule<
-            condition_signature,
-            boost::spirit::qi::locals<std::vector<value_ref_payload<StarType>>>
-        > star_type_vec_rule;
+        using star_type_vec_rule = rule<condition_signature>;
 
         typedef rule<
             condition_signature,
@@ -32,6 +29,7 @@ namespace parse { namespace detail {
         condition_parser_rule  owner_has_shippart_available;
         condition_parser_rule  start;
         star_type_parser_rules star_type_rules;
+        single_or_bracketed_repeat<value_ref_rule<StarType>> one_or_more_star_types;
     };
 
     }

--- a/parse/EffectParser.h
+++ b/parse/EffectParser.h
@@ -51,7 +51,6 @@ namespace parse {
                 parse::detail::condition_payload,
                 parse::detail::condition_payload,
                 std::string,
-                std::vector<detail::effect_payload>,
                 std::string,
                 int,
                 std::string
@@ -59,7 +58,9 @@ namespace parse {
         > effect_group_rule;
 
         effects_parser_grammar effects_grammar;
+        detail::single_or_bracketed_repeat<effects_parser_grammar> one_or_more_effects;
         effect_group_rule effects_group;
+        detail::single_or_bracketed_repeat<effect_group_rule> one_or_more_groups;
         effects_group_rule start;
     };
 

--- a/parse/EffectParser1.cpp
+++ b/parse/EffectParser1.cpp
@@ -92,7 +92,8 @@ namespace parse { namespace detail {
         effect_parser_rules_1::base_type(start, "effect_parser_rules_1"),
         int_rules(tok, labeller, condition_parser, string_grammar),
         double_rules(tok, labeller, condition_parser, string_grammar),
-        empire_affiliation_type_enum(tok)
+        empire_affiliation_type_enum(tok),
+        one_or_more_string_and_string_ref_pair(string_and_string_ref)
     {
         qi::_1_type _1;
         qi::_a_type _a;
@@ -162,7 +163,7 @@ namespace parse { namespace detail {
                 | eps [ _f = true ]
             )
             >  -(labeller.rule(Icon_token)       >  tok.string [ _b = _1 ] )
-            >  -(labeller.rule(Parameters_token) >  string_and_string_ref_vector [_c = _1] )
+            >  -(labeller.rule(Parameters_token) >  one_or_more_string_and_string_ref_pair [_c = _1] )
             >   (
                 (   // empire id specified, optionally with an affiliation type:
                     // useful to specify a single recipient empire, or the allies
@@ -222,11 +223,6 @@ namespace parse { namespace detail {
             [_val = construct<string_and_string_ref_pair>(_a, _b)]
             ;
 
-        string_and_string_ref_vector
-            =    ('[' > *string_and_string_ref [ push_back(_val, _1) ] > ']')
-            |     string_and_string_ref [ push_back(_val, _1) ]
-            ;
-
         start
             =    set_empire_meter_1
             |    set_empire_meter_2
@@ -243,7 +239,6 @@ namespace parse { namespace detail {
         generate_sitrep_message.name("GenerateSitrepMessage");
         set_overlay_texture.name("SetOverlayTexture");
         string_and_string_ref.name("Tag and Data (string reference)");
-        string_and_string_ref_vector.name("List of Tags and Data");
 
 
 #if DEBUG_EFFECT_PARSERS

--- a/parse/EffectParser1.h
+++ b/parse/EffectParser1.h
@@ -67,7 +67,7 @@ namespace parse { namespace detail {
         generate_sitrep_message_rule        generate_sitrep_message;
         string_and_intref_and_intref_rule   set_overlay_texture;
         string_and_string_ref_rule          string_and_string_ref;
-        string_and_string_ref_vector_rule   string_and_string_ref_vector;
+        single_or_bracketed_repeat<string_and_string_ref_rule> one_or_more_string_and_string_ref_pair;
         effect_parser_rule   start;
     };
 

--- a/parse/EffectParser4.cpp
+++ b/parse/EffectParser4.cpp
@@ -21,7 +21,8 @@ namespace parse { namespace detail {
         double_rules(tok, labeller, condition_parser, string_grammar),
         star_type_rules(tok, labeller, condition_parser),
         planet_type_rules(tok, labeller, condition_parser),
-        planet_size_rules(tok, labeller, condition_parser)
+        planet_size_rules(tok, labeller, condition_parser),
+        one_or_more_effects(effect_parser)
     {
         qi::_1_type _1;
         qi::_a_type _a;
@@ -46,12 +47,7 @@ namespace parse { namespace detail {
                         >   labeller.rule(Type_token)        >   planet_type_rules.expr [ _a = _1 ]
                         >   labeller.rule(PlanetSize_token)  >   planet_size_rules.expr [ _b = _1 ]
                         > -(labeller.rule(Name_token)        >   string_grammar      [ _c = _1 ])
-                        > -(labeller.rule(Effects_token)
-                            >   (
-                                ('[' > +effect_parser [ emplace_back_1_(_d, _1) ] > ']')
-                                |    effect_parser [ emplace_back_1_(_d, _1) ]
-                            )
-                           )
+                        > -(labeller.rule(Effects_token) > one_or_more_effects [ _d = _1 ])
                 ) [ _val = construct_movable_(new_<Effect::CreatePlanet>(
                     deconstruct_movable_(_a, _pass),
                     deconstruct_movable_(_b, _pass),
@@ -63,12 +59,7 @@ namespace parse { namespace detail {
             =   (       tok.CreateBuilding_
                         >   labeller.rule(Type_token)        >   string_grammar [ _a = _1 ]
                         > -(labeller.rule(Name_token)        >   string_grammar [ _b = _1 ])
-                        > -(labeller.rule(Effects_token)
-                            >   (
-                                ('[' > +effect_parser [ emplace_back_1_(_c, _1) ] > ']')
-                                |    effect_parser [ emplace_back_1_(_c, _1) ]
-                            )
-                           )
+                        > -(labeller.rule(Effects_token) > one_or_more_effects [ _c = _1 ])
                 ) [ _val = construct_movable_(new_<Effect::CreateBuilding>(
                     deconstruct_movable_(_a, _pass),
                     deconstruct_movable_(_b, _pass),
@@ -82,12 +73,7 @@ namespace parse { namespace detail {
                  > -(labeller.rule(Empire_token)      >   int_rules.expr    [ _c = _1 ])
                  > -(labeller.rule(Species_token)     >   string_grammar [ _d = _1 ])
                  > -(labeller.rule(Name_token)        >   string_grammar [ _e = _1 ])
-                 > -(labeller.rule(Effects_token)
-                     >   (
-                         ('[' > +effect_parser [ emplace_back_1_(_f, _1) ] > ']')
-                         |    effect_parser [ emplace_back_1_(_f, _1) ]
-                     )
-                    )
+                 > -(labeller.rule(Effects_token)     >   one_or_more_effects [ _f = _1 ])
                 ) [ _val = construct_movable_(new_<Effect::CreateShip>(
                     deconstruct_movable_(_b, _pass),
                     deconstruct_movable_(_c, _pass),
@@ -103,12 +89,7 @@ namespace parse { namespace detail {
                  > -(labeller.rule(Empire_token)      >   int_rules.expr    [ _c = _1 ])
                  > -(labeller.rule(Species_token)     >   string_grammar [ _d = _1 ])
                  > -(labeller.rule(Name_token)        >   string_grammar [ _e = _1 ])
-                 > -(labeller.rule(Effects_token)
-                     >   (
-                         ('[' > +effect_parser [ emplace_back_1_(_f, _1) ] > ']')
-                         |    effect_parser [ emplace_back_1_(_f, _1) ]
-                     )
-                    )
+                 > -(labeller.rule(Effects_token)     >   one_or_more_effects [ _f = _1 ])
                 ) [ _val = construct_movable_(new_<Effect::CreateShip>(
                     deconstruct_movable_(_a, _pass),
                     deconstruct_movable_(_c, _pass),
@@ -124,13 +105,7 @@ namespace parse { namespace detail {
                  )
                  >   double_rules.expr [ _b = _1 ]
                  > -(labeller.rule(Name_token)    >   string_grammar [ _d = _1 ])
-                 > -(labeller.rule(Effects_token)
-                     >
-                     (
-                         ('[' > +effect_parser [ emplace_back_1_(_f, _1) ] > ']')
-                         |    effect_parser [ emplace_back_1_(_f, _1) ]
-                     )
-                    )
+                 > -(labeller.rule(Effects_token) > one_or_more_effects [ _f = _1 ])
                 ) [ _val = construct_movable_(new_<Effect::CreateField>(
                     deconstruct_movable_(_a, _pass),
                     deconstruct_movable_(_b, _pass),
@@ -147,13 +122,7 @@ namespace parse { namespace detail {
                  >   labeller.rule(Y_token)       >   double_rules.expr [ _c = _1 ]
                  >   labeller.rule(Size_token)    >   double_rules.expr [ _e = _1 ]
                  > -(labeller.rule(Name_token)    >   string_grammar [ _d = _1 ])
-                 > -(labeller.rule(Effects_token)
-                     >
-                     (
-                         ('[' > +effect_parser [ emplace_back_1_(_f, _1) ] > ']')
-                         |    effect_parser [ emplace_back_1_(_f, _1) ]
-                     )
-                    )
+                 > -(labeller.rule(Effects_token) > one_or_more_effects [ _f = _1 ])
                 ) [ _val = construct_movable_(new_<Effect::CreateField>(
                     deconstruct_movable_(_a, _pass),
                     deconstruct_movable_(_b, _pass),
@@ -171,13 +140,7 @@ namespace parse { namespace detail {
                  >   labeller.rule(X_token)       >   double_rules.expr    [ _b = _1 ]
                  >   labeller.rule(Y_token)       >   double_rules.expr    [ _c = _1 ]
                  > -(labeller.rule(Name_token)    >   string_grammar    [ _d = _1 ])
-                 > -(labeller.rule(Effects_token)
-                     >
-                     (
-                         ('[' > +effect_parser [ emplace_back_1_(_e, _1) ] > ']')
-                         |    effect_parser [ emplace_back_1_(_e, _1) ]
-                     )
-                    )
+                 > -(labeller.rule(Effects_token) > one_or_more_effects [ _e = _1 ])
                 ) [ _val = construct_movable_(new_<Effect::CreateSystem>(
                     deconstruct_movable_(_a, _pass),
                     deconstruct_movable_(_b, _pass),
@@ -193,13 +156,7 @@ namespace parse { namespace detail {
                  >   double_rules.expr [ _b = _1 ]
                  >   labeller.rule(Y_token)       >   double_rules.expr [ _c = _1 ]
                  > -(labeller.rule(Name_token)    >   string_grammar [ _d = _1 ])
-                 > -(labeller.rule(Effects_token)
-                     >
-                     (
-                         ('[' > +effect_parser [ emplace_back_1_(_e, _1) ] > ']')
-                         |    effect_parser [ emplace_back_1_(_e, _1) ]
-                     )
-                    )
+                 > -(labeller.rule(Effects_token) > one_or_more_effects [ _e = _1 ])
                 ) [ _val = construct_movable_(new_<Effect::CreateSystem>(
                     deconstruct_movable_(_b, _pass),
                     deconstruct_movable_(_c, _pass),

--- a/parse/EffectParser4.h
+++ b/parse/EffectParser4.h
@@ -79,6 +79,7 @@ namespace parse { namespace detail {
         star_type_parser_rules   star_type_rules;
         planet_type_parser_rules planet_type_rules;
         planet_size_parser_rules planet_size_rules;
+        single_or_bracketed_repeat<effect_parser_grammar> one_or_more_effects;
     };
     }
 }

--- a/parse/EffectParser5.h
+++ b/parse/EffectParser5.h
@@ -10,16 +10,17 @@
                               Labeller& labeller,
                               const condition_parser_grammar& condition_parser);
 
-        typedef rule<
+        using conditional_rule = rule<
             effect_signature,
             boost::spirit::qi::locals<
                 condition_payload,
                 std::vector<effect_payload>,
                 std::vector<effect_payload>
                 >
-            > conditional_rule;
+            >;
 
-        conditional_rule   conditional;
+        single_or_bracketed_repeat<effect_parser_grammar> one_or_more_effects;
+        conditional_rule conditional;
         effect_parser_rule start;
     };
     }

--- a/parse/FieldsParser.cpp
+++ b/parse/FieldsParser.cpp
@@ -76,7 +76,7 @@ namespace {
                 >   tok.string        [ _pass = is_unique_(_r1, FieldType_token, _1), _a = _1 ]
                 >   labeller.rule(Description_token)         > tok.string [ _b = _1 ]
                 >   labeller.rule(Stealth_token)             > double_rule [ _c = _1]
-                >   tags_parser(_d)
+                >   tags_parser [ _d = _1]
                 > -(labeller.rule(EffectsGroups_token)       > effects_group_grammar [ _e = _1 ])
                 >   labeller.rule(Graphic_token)             > tok.string
                 [ insert_fieldtype_(_r1, _a, _b, _c, _d, _e, _1, _pass) ]

--- a/parse/FleetPlansParser.cpp
+++ b/parse/FleetPlansParser.cpp
@@ -39,7 +39,8 @@ namespace {
                 const std::string& filename,
                 const parse::text_iterator& first, const parse::text_iterator& last) :
             grammar::base_type(start),
-            labeller(tok)
+            labeller(tok),
+            one_or_more_string_tokens(tok)
         {
             namespace phoenix = boost::phoenix;
             namespace qi = boost::spirit::qi;
@@ -52,18 +53,14 @@ namespace {
             qi::_3_type _3;
             qi::_4_type _4;
             qi::_a_type _a;
-            qi::_b_type _b;
             qi::_r1_type _r1;
 
             fleet_plan
                 =    tok.Fleet_
                 >    labeller.rule(Name_token) > tok.string [ _a = _1 ]
                 >    labeller.rule(Ships_token)
-                >    (
-                            ('[' > +tok.string [ push_back(_b, _1) ] > ']')
-                        |    tok.string [ push_back(_b, _1) ]
-                     )
-                [ insert_fleet_plan_(_r1, _a, _b, phoenix::val(true)) ]
+                >    one_or_more_string_tokens
+                [ insert_fleet_plan_(_r1, _a, _1, phoenix::val(true)) ]
                 ;
 
             start
@@ -81,14 +78,14 @@ namespace {
         using  fleet_plan_rule = parse::detail::rule<
             start_rule_signature,
             boost::spirit::qi::locals<
-                std::string,
-                std::vector<std::string>
+                std::string
                 >
             >;
 
         using start_rule = parse::detail::rule<start_rule_signature>;
 
         parse::detail::Labeller labeller;
+        parse::detail::single_or_repeated_string<std::vector<std::string>> one_or_more_string_tokens;
         fleet_plan_rule fleet_plan;
         start_rule start;
     };

--- a/parse/GameRulesParser.cpp
+++ b/parse/GameRulesParser.cpp
@@ -83,6 +83,7 @@ namespace {
                 const parse::text_iterator& first, const parse::text_iterator& last) :
             grammar::base_type(start),
             labeller(tok),
+            one_or_more_string_tokens(tok),
             double_rule(tok),
             int_rule(tok)
         {
@@ -108,6 +109,7 @@ namespace {
             qi::_j_type _j;
             qi::_r1_type _r1;
             qi::eps_type eps;
+            boost::spirit::qi::repeat_type repeat_;
 
             game_rule_bool
                 =   (tok.GameRule_
@@ -160,13 +162,7 @@ namespace {
                     >>  labeller.rule(Type_token) >>         tok.String_
                     )
                 >   labeller.rule(Default_token) >       tok.string [ _e = _1 ]
-                >  -( (labeller.rule(Allowed_token)
-                       > '['
-                       > +tok.string [ insert(_h, _1) ]
-                       > ']'
-                      )
-                      |tok.string [ insert(_h, _1) ]
-                    )
+                >  -( labeller.rule(Allowed_token) > one_or_more_string_tokens [_h = _1])
                   [ add_rule(_r1, _a, _b, _j, _e, _h) ]
                 ;
 
@@ -219,6 +215,7 @@ namespace {
         using start_rule = parse::detail::rule<start_rule_signature>;
 
         parse::detail::Labeller labeller;
+        parse::detail::single_or_repeated_string<std::set<std::string>> one_or_more_string_tokens;
         parse::detail::double_grammar double_rule;
         parse::detail::int_grammar int_rule;
         game_rule_rule  game_rule_bool;

--- a/parse/MonsterFleetPlansParser.cpp
+++ b/parse/MonsterFleetPlansParser.cpp
@@ -46,13 +46,11 @@ namespace {
             condition_parser(tok, labeller),
             string_grammar(tok, labeller, condition_parser),
             double_rule(tok),
-            int_rule(tok)
+            int_rule(tok),
+            one_or_more_string_tokens(tok)
         {
             namespace phoenix = boost::phoenix;
             namespace qi = boost::spirit::qi;
-
-            using phoenix::clear;
-            using phoenix::push_back;
 
             qi::_1_type _1;
             qi::_2_type _2;
@@ -70,12 +68,7 @@ namespace {
                 ;
 
             ships
-                =    labeller.rule(Ships_token)
-                >    eps [ clear(phoenix::ref(_b)) ]
-                >    (
-                            ('[' > +tok.string [ push_back(phoenix::ref(_b), _1) ] > ']')
-                        |    tok.string [ push_back(phoenix::ref(_b), _1) ]
-                     )
+                =    labeller.rule(Ships_token) > one_or_more_string_tokens [ phoenix::ref(_b) = _1]
                 ;
 
             spawns
@@ -131,6 +124,7 @@ namespace {
         const parse::string_parser_grammar string_grammar;
         parse::detail::double_grammar double_rule;
         parse::detail::int_grammar int_rule;
+        parse::detail::single_or_repeated_string<std::vector<std::string>> one_or_more_string_tokens;
         generic_rule            monster_fleet_plan_prefix;
         generic_rule            ships;
         generic_rule            spawns;

--- a/parse/Parse.cpp
+++ b/parse/Parse.cpp
@@ -435,23 +435,18 @@ namespace parse {
 
     tags_grammar::tags_grammar(const parse::lexer& tok,
                                Labeller& labeller) :
-        tags_grammar::base_type(start, "tags_grammar")
+        tags_grammar::base_type(start, "tags_grammar"),
+        one_or_more_string_tokens(tok)
     {
         namespace phoenix = boost::phoenix;
         namespace qi = boost::spirit::qi;
 
         using phoenix::insert;
 
-        qi::_1_type _1;
-        qi::_r1_type _r1;
-
-        start
-            =  -(
+        start %=
+            -(
                 labeller.rule(Tags_token)
-                >>  (
-                    ('[' > +tok.string [ insert(_r1, _1) ] > ']')
-                    |   tok.string [ insert(_r1, _1) ]
-                )
+                >>  one_or_more_string_tokens
             )
             ;
 

--- a/parse/ParseImpl.h
+++ b/parse/ParseImpl.h
@@ -64,6 +64,50 @@ namespace parse { namespace detail {
         locals
     >;
 
+    template <typename Signature>
+    struct BracketedParserSignature;
+    template <typename Synthesized, typename... Inherited>
+    struct BracketedParserSignature<Synthesized (Inherited...)> {
+        using Synthesized_t = Synthesized;
+        using Signature_t = std::vector<Synthesized_t>(Inherited...);
+    };
+
+      /** single_or_bracketed_repeat uses \p Parser to parser expressions with
+        either a single element or repeated elements within square brackets. */
+    template <typename Parser>
+    struct single_or_bracketed_repeat : public grammar<
+        typename BracketedParserSignature<typename Parser::sig_type>::Signature_t
+        >
+    {
+        single_or_bracketed_repeat(const Parser& repeated_parser)
+            : single_or_bracketed_repeat::base_type(start)
+        {
+            boost::spirit::qi::repeat_type repeat_;
+            start
+                =    ('[' > +repeated_parser > ']')
+                |    repeat_(1)[repeated_parser]
+                ;
+
+            this->name("List of " + repeated_parser.name());
+        }
+
+        rule<typename BracketedParserSignature<typename Parser::sig_type>::Signature_t> start;
+    };
+
+    template <typename SynthesizedContainer = std::vector<std::string>>
+    struct single_or_repeated_string : public grammar<SynthesizedContainer ()> {
+        single_or_repeated_string(const parse::lexer& tok) : single_or_repeated_string::base_type(start) {
+            boost::spirit::qi::repeat_type repeat_;
+            start
+                =    ('[' > +tok.string > ']')
+                |    repeat_(1)[tok.string]
+                ;
+
+            this->name("List of strings");
+        }
+
+        rule<SynthesizedContainer ()> start;
+    };
 
     struct double_grammar : public grammar<double()> {
         double_grammar(const parse::lexer& tok);

--- a/parse/ParseImpl.h
+++ b/parse/ParseImpl.h
@@ -137,13 +137,14 @@ namespace parse { namespace detail {
     template <typename T>
     using enum_grammar = grammar<T ()>;
 
-    using tags_rule_type    = rule<void (std::set<std::string>&)>;
-    using tags_grammar_type = grammar<void (std::set<std::string>&)>;
+    using tags_rule_type    = rule<std::set<std::string> ()>;
+    using tags_grammar_type = grammar<std::set<std::string> ()>;
 
     struct tags_grammar : public tags_grammar_type {
         tags_grammar(const parse::lexer& tok,
                      Labeller& labeller);
         tags_rule_type start;
+        single_or_repeated_string<std::set<std::string>> one_or_more_string_tokens;
     };
 
     using color_parser_signature = GG::Clr ();

--- a/parse/ShipDesignsParser.cpp
+++ b/parse/ShipDesignsParser.cpp
@@ -73,7 +73,8 @@ namespace {
                 const std::string& filename,
                 const parse::text_iterator& first, const parse::text_iterator& last) :
             grammar::base_type(start),
-            labeller(tok)
+            labeller(tok),
+            one_or_more_string_tokens(tok)
         {
             namespace phoenix = boost::phoenix;
             namespace qi = boost::spirit::qi;
@@ -118,10 +119,7 @@ namespace {
             design
                 =    design_prefix(_a, _b, _c, _f, _g)
                 >    labeller.rule(Parts_token)
-                >    (
-                            ('[' > +tok.string [ push_back(_d, _1) ] > ']')
-                        |    tok.string [ push_back(_d, _1) ]
-                     )
+                >    one_or_more_string_tokens [ _d = _1 ]
                 >   -(
                         labeller.rule(Icon_token)     > tok.string [ _e = _1 ]
                      )
@@ -163,6 +161,7 @@ namespace {
         using start_rule = parse::detail::rule<start_rule_signature>;
 
         parse::detail::Labeller labeller;
+        parse::detail::single_or_repeated_string<> one_or_more_string_tokens;
         design_prefix_rule design_prefix;
         design_rule design;
         start_rule start;

--- a/parse/ShipHullsParser.cpp
+++ b/parse/ShipHullsParser.cpp
@@ -61,13 +61,13 @@ namespace {
             tags_parser(tok, labeller),
             common_rules(tok, labeller, condition_parser, string_grammar, tags_parser),
             ship_slot_type_enum(tok),
-            double_rule(tok)
+            double_rule(tok),
+            one_or_more_slots(slot)
         {
             namespace phoenix = boost::phoenix;
             namespace qi = boost::spirit::qi;
 
             using phoenix::construct;
-            using phoenix::push_back;
 
             qi::_1_type _1;
             qi::_2_type _2;
@@ -103,13 +103,7 @@ namespace {
                 ;
 
             slots
-                =  -(
-                        labeller.rule(Slots_token)
-                    >   (
-                                ('[' > +slot [ push_back(_r1, _1) ] > ']')
-                            |    slot [ push_back(_r1, _1) ]
-                        )
-                     )
+                =  -(labeller.rule(Slots_token) > one_or_more_slots [_r1 = _1 ])
                 ;
 
             hull
@@ -192,6 +186,7 @@ namespace {
         parse::detail::double_grammar double_rule;
         hull_stats_rule                             hull_stats;
         slot_rule                                   slot;
+        parse::detail::single_or_bracketed_repeat<slot_rule> one_or_more_slots;
         slots_rule                                  slots;
         hull_rule                                   hull;
         start_rule                                  start;

--- a/parse/ShipPartsParser.cpp
+++ b/parse/ShipPartsParser.cpp
@@ -66,12 +66,12 @@ namespace {
             common_rules(tok, labeller, condition_parser, string_grammar, tags_parser),
             ship_slot_type_enum(tok),
             ship_part_class_enum(tok),
-            double_rule(tok)
+            double_rule(tok),
+            one_or_more_slots(ship_slot_type_enum)
         {
             namespace phoenix = boost::phoenix;
             namespace qi = boost::spirit::qi;
 
-            using phoenix::push_back;
             using phoenix::construct;
 
             qi::_1_type _1;
@@ -94,11 +94,8 @@ namespace {
             slots
                 =  -(
                         labeller.rule(MountableSlotTypes_token)
-                    >   (
-                            ('[' > +ship_slot_type_enum [ push_back(_r1, _1) ] > ']')
-                        |    ship_slot_type_enum [ push_back(_r1, _1) ]
-                        )
-                     )
+                    >   one_or_more_slots [ _r1 = _1 ]
+                    )
                 ;
 
             part_type
@@ -169,6 +166,7 @@ namespace {
         parse::ship_part_class_enum_grammar ship_part_class_enum;
         parse::detail::double_grammar double_rule;
         slots_rule                         slots;
+        parse::detail::single_or_bracketed_repeat<parse::ship_slot_enum_grammar> one_or_more_slots;
         part_type_rule                     part_type;
         start_rule                         start;
     };

--- a/parse/SpeciesParser.cpp
+++ b/parse/SpeciesParser.cpp
@@ -68,6 +68,7 @@ namespace {
             string_grammar(tok, labeller, condition_parser),
             tags_parser(tok, labeller),
             effects_group_grammar(tok, labeller, condition_parser, string_grammar),
+            one_or_more_foci(focus_type),
             planet_type_rules(tok, labeller, condition_parser),
             planet_environment_rules(tok, labeller, condition_parser)
         {
@@ -107,10 +108,7 @@ namespace {
 
             foci
                 =    labeller.rule(Foci_token)
-                >    (
-                            ('[' > +focus_type [ push_back(_r1, _1) ] > ']')
-                        |    focus_type [ push_back(_r1, _1) ]
-                     )
+                >    one_or_more_foci
                 ;
 
             effects
@@ -152,8 +150,8 @@ namespace {
                 =    tok.Species_
                 >    species_strings(_r1) [ _a = _1 ]
                 >    species_params [ _b = _1]
-                >    tags_parser(_c)
-                >   -foci(_d)
+                >    tags_parser [ _c= _1]
+                >   -foci [_d = _1]
                 >   -(labeller.rule(PreferredFocus_token)        >> tok.string [ _g = _1 ])
                 >   -effects(_e)
                 >   -environments(_f)
@@ -203,7 +201,7 @@ namespace {
         > focus_type_rule;
 
         typedef parse::detail::rule<
-            void (std::vector<FocusType>&)
+            std::vector<FocusType> ()
         > foci_rule;
 
         typedef parse::detail::rule<
@@ -265,6 +263,7 @@ namespace {
         parse::effects_group_grammar effects_group_grammar;
         foci_rule                       foci;
         focus_type_rule                 focus_type;
+        parse::detail::single_or_bracketed_repeat<focus_type_rule> one_or_more_foci;
         effects_rule                    effects;
         environment_map_element_rule    environment_map_element;
         environment_map_rule            environment_map;


### PR DESCRIPTION
This PR adds a templated parser `single_or_bracketed_repeat<SomeParser>`  which abstracts the FOCS repeatedly used grammar which accepts "a_single_thing" or "[thing1 thing2 thing3 ...]" as a list of one or more things.