### PR TITLE
Remove second exit path for HumanClientApp.

### DIFF
--- a/GG/GG/GUI.h
+++ b/GG/GG/GUI.h
@@ -245,7 +245,7 @@ public:
 
     /** \name Mutators */ ///@{
     void            operator()();                 ///< external interface to Run()
-    virtual void    Exit(int code) = 0;           ///< does basic clean-up, then calls exit(); callable from anywhere in user code via GetGUI()
+    virtual void    ExitApp(int code = 0) = 0;           ///< does basic clean-up, then calls exit(); callable from anywhere in user code via GetGUI()
 
     /** Handles all waiting system events (from SDL, DirectInput, etc.).  This
         function should only be called from custom EventPump event

--- a/GG/GG/SDL/SDLGUI.h
+++ b/GG/GG/SDL/SDLGUI.h
@@ -63,7 +63,7 @@ class Framebuffer;
     <p>To do this, the user needs only to override the Initialize() and
     FinalCleanup() methods, and ensure that the program does not terminate
     abnormally; this ensures FinalCleanup() is called when gui's destructor is
-    invoked. Exit() can also perform cleanup and terminate the application
+    invoked. ExitApp() can also perform cleanup and terminate the application
     cleanly.
 
     <p>Most of the member methods of SDLGUI have been declared virtual, to
@@ -106,7 +106,7 @@ public:
     //@}
 
     /** \name Mutators */ ///@{
-    void Exit(int code) override;
+    void ExitApp(int code = 0) override;
     bool SetClipboardText(const std::string& text) override;
 
     void Enter2DMode() override;

--- a/GG/src/SDL/SDLGUI.cpp
+++ b/GG/src/SDL/SDLGUI.cpp
@@ -526,7 +526,7 @@ std::string SDLGUI::ClipboardText() const {
 void SDLGUI::operator()()
 { GUI::operator()(); }
 
-void SDLGUI::Exit(int code)
+void SDLGUI::ExitApp(int code)
 { throw QuitSignal(code); }
 
 void SDLGUI::SetWindowTitle(const std::string& title)
@@ -651,7 +651,7 @@ void SDLGUI::SDLInit()
         SDL_ShowSimpleMessageBox(
             SDL_MESSAGEBOX_ERROR, "OpenGL initialization error", msg.c_str(), nullptr);
         std::cerr << msg << std::endl;
-        Exit(1);
+        ExitApp(1);
     }
 
     SDL_ShowWindow(m_window);
@@ -882,7 +882,7 @@ void SDLGUI::Run()
             throw;
 
         // This is the normal exit path from Run()
-        // Do not put exit(0) or Exit(0) here.
+        // Do not put exit(0) or ExitApp(0) here.
         return;
     }
 }

--- a/GG/src/SDL/SDLGUI.cpp
+++ b/GG/src/SDL/SDLGUI.cpp
@@ -359,13 +359,10 @@ namespace {
         glTexEnvf(GL_TEXTURE_ENV, GL_TEXTURE_ENV_MODE, GL_MODULATE);
     }
 
-    struct QuitSignal : public std::exception {
+    struct QuitSignal {
         QuitSignal(int exit_code_) :
-            std::exception(), exit_code(exit_code_)
+            exit_code(exit_code_)
         {}
-
-        const char* what() const noexcept override
-        { return  exit_code ? "Quitting SDLGUI with error." : "Quitting SDLGUI normally."; }
 
         int exit_code;
     };
@@ -880,7 +877,7 @@ void SDLGUI::Run()
         Initialize();
         ModalEventPump pump(m_done);
         pump();
-    } catch (QuitSignal& e) {
+    } catch (const QuitSignal& e) {
         if (e.exit_code != 0)
             throw;
 

--- a/GG/test/unit/TestButton.cpp
+++ b/GG/test/unit/TestButton.cpp
@@ -21,7 +21,7 @@ public:
     GG::Y AppHeight() const override
     { return GG::Y(600); }
 
-    void Exit(int code) override
+    void ExitApp(int code = 0) override
     {}
 
     void Enter2DMode() override

--- a/UI/IntroScreen.cpp
+++ b/UI/IntroScreen.cpp
@@ -381,7 +381,7 @@ void IntroScreen::OnCredits() {
 }
 
 void IntroScreen::OnExitGame() {
-    GG::GUI::GetGUI()->Exit(0);
+    GG::GUI::GetGUI()->ExitApp(0);
 }
 
 void IntroScreen::KeyPress(GG::Key key, std::uint32_t key_code_point, GG::Flags<GG::ModKey> mod_keys) {

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -81,7 +81,7 @@ AIClientApp::AIClientApp(const std::vector<std::string>& args) :
 {
     if (args.size() < 2) {
         std::cerr << "The AI client should not be executed directly!  Run freeorion to start the game.";
-        Exit(1);
+        ExitApp(1);
     }
 
     // read command line args
@@ -117,7 +117,7 @@ AIClientApp::~AIClientApp() {
 void AIClientApp::operator()()
 { Run(); }
 
-void AIClientApp::Exit(int code) {
+void AIClientApp::ExitApp(int code) {
     DebugLogger() << "Initiating Exit (code " << code << " - " << (code ? "error" : "normal") << " termination)";
     if (code)
         exit(code);
@@ -175,7 +175,7 @@ void AIClientApp::Run() {
 
 void AIClientApp::ConnectToServer() {
     if (!Networking().ConnectToLocalHostServer())
-        Exit(1);
+        ExitApp(1);
 }
 
 void AIClientApp::StartPythonAI() {
@@ -362,7 +362,7 @@ void AIClientApp::HandleMessage(const Message& msg) {
         DebugLogger() << "Message::END_GAME : Exiting";
         DebugLogger() << "Acknowledge server shutdown message.";
         Networking().SendMessage(AIEndGameAcknowledgeMessage());
-        Exit(0);
+        ExitApp(0);
         break;
     }
 

--- a/client/AI/AIClientApp.h
+++ b/client/AI/AIClientApp.h
@@ -20,7 +20,7 @@ public:
 
     /** \name Mutators */ //@{
     void                operator()();   ///< external interface to Run()
-    void                Exit(int code); ///< does basic clean-up, then calls exit(); callable from anywhere in user code via GetApp()
+    void                ExitApp(int code = 0); ///< does basic clean-up, then calls exit(); callable from anywhere in user code via GetApp()
     void                SetPlayerName(const std::string& player_name) { m_player_name = player_name; }
     //@}
 

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -1408,7 +1408,15 @@ void HumanClientApp::ResetOrExitApp(bool reset, bool skip_savegame, int exit_cod
         }
     }
 
-    m_fsm->process_event(StartQuittingGame(reset, m_server_process, exit_code));
+    // Create an action to reset to intro or quit the app as appropriate.
+    std::function<void()> after_server_shutdown_action;
+    if (reset)
+        after_server_shutdown_action = std::bind(&HumanClientApp::ResetClientData, this, false);
+    else
+        // This throws to exit the GUI
+        after_server_shutdown_action = std::bind(&HumanClientApp::ExitSDL, this, exit_code);
+
+    m_fsm->process_event(StartQuittingGame(m_server_process, std::move(after_server_shutdown_action)));
 }
 
 void HumanClientApp::InitAutoTurns(int auto_turns) {

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -1084,7 +1084,7 @@ void HumanClientApp::HandleFocusChange(bool gained_focus) {
 
 void HumanClientApp::HandleAppQuitting() {
     DebugLogger() << "HumanClientApp::HandleAppQuitting()";
-    ExitApp();
+    Exit(0);
 }
 
 bool HumanClientApp::HandleHotkeyResetGame() {
@@ -1384,10 +1384,13 @@ namespace {
 void HumanClientApp::ResetToIntro(bool skip_savegame)
 { ResetOrExitApp(true, skip_savegame); }
 
-void HumanClientApp::ExitApp()
-{ ResetOrExitApp(false, false); }
+void HumanClientApp::Exit(int exit_code)
+{ ResetOrExitApp(false, false, exit_code); }
 
-void HumanClientApp::ResetOrExitApp(bool reset, bool skip_savegame) {
+void HumanClientApp::ExitSDL(int exit_code)
+{ SDLGUI::Exit(exit_code); }
+
+void HumanClientApp::ResetOrExitApp(bool reset, bool skip_savegame, int exit_code /* = 0*/) {
     DebugLogger() << (reset ? "HumanClientApp::ResetToIntro" : "HumanClientApp::ExitApp");
 
     auto was_playing = m_game_started;
@@ -1405,7 +1408,7 @@ void HumanClientApp::ResetOrExitApp(bool reset, bool skip_savegame) {
         }
     }
 
-    m_fsm->process_event(StartQuittingGame(reset, m_server_process));
+    m_fsm->process_event(StartQuittingGame(reset, m_server_process, exit_code));
 }
 
 void HumanClientApp::InitAutoTurns(int auto_turns) {

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -1084,7 +1084,7 @@ void HumanClientApp::HandleFocusChange(bool gained_focus) {
 
 void HumanClientApp::HandleAppQuitting() {
     DebugLogger() << "HumanClientApp::HandleAppQuitting()";
-    Exit(0);
+    ExitApp(0);
 }
 
 bool HumanClientApp::HandleHotkeyResetGame() {
@@ -1384,11 +1384,11 @@ namespace {
 void HumanClientApp::ResetToIntro(bool skip_savegame)
 { ResetOrExitApp(true, skip_savegame); }
 
-void HumanClientApp::Exit(int exit_code)
+void HumanClientApp::ExitApp(int exit_code)
 { ResetOrExitApp(false, false, exit_code); }
 
 void HumanClientApp::ExitSDL(int exit_code)
-{ SDLGUI::Exit(exit_code); }
+{ SDLGUI::ExitApp(exit_code); }
 
 void HumanClientApp::ResetOrExitApp(bool reset, bool skip_savegame, int exit_code /* = 0*/) {
     DebugLogger() << (reset ? "HumanClientApp::ResetToIntro" : "HumanClientApp::ExitApp");

--- a/client/human/HumanClientApp.h
+++ b/client/human/HumanClientApp.h
@@ -72,7 +72,7 @@ public:
     void                ResetToIntro(bool skip_savegame);
 
     /** Exit the App with \p exit_code. */
-    void                Exit(int exit_code) override;
+    void                ExitApp(int exit_code = 0) override;
     /** Exit SDL. (Called by FSM) */
     void                ExitSDL(int exit_code);
 

--- a/client/human/HumanClientApp.h
+++ b/client/human/HumanClientApp.h
@@ -22,8 +22,6 @@ class HumanClientApp :
     public GG::SDLGUI
 {
 public:
-    class CleanQuit : public std::exception {};
-
     typedef boost::signals2::signal<void (bool)> FullscreenSwitchSignalType;
     typedef boost::signals2::signal<void ()>     RepositionWindowsSignalType;
 
@@ -72,7 +70,12 @@ public:
     void                ChangeLoggerThreshold(const std::string& option_name, LogLevel option_value);
 
     void                ResetToIntro(bool skip_savegame);
-    void                ExitApp();
+
+    /** Exit the App with \p exit_code. */
+    void                Exit(int exit_code) override;
+    /** Exit SDL. (Called by FSM) */
+    void                ExitSDL(int exit_code);
+
     void                ResetClientData(bool save_connection = false);
     void                LoadSinglePlayerGame(std::string filename = "");
     /** Requests the savegame previews from the server in \p relative_directory
@@ -159,8 +162,9 @@ private:
     void            DisconnectedFromServer();           ///< called by ClientNetworking when the TCP connection to the server is lost
 
     /** Either reset to IntroMenu (\p reset is true), or exit the
-        application.  If \p skip_savegame is true abort in progress save games.*/
-    void            ResetOrExitApp(bool reset, bool skip_savegame);
+        application.  If \p skip_savegame is true abort in progress save
+        games. \p exit_code is the exit code. */
+    void            ResetOrExitApp(bool reset, bool skip_savegame, int exit_code = 0);
 
     std::unique_ptr<HumanClientFSM> m_fsm;
 

--- a/client/human/HumanClientApp.h
+++ b/client/human/HumanClientApp.h
@@ -73,8 +73,6 @@ public:
 
     /** Exit the App with \p exit_code. */
     void                ExitApp(int exit_code = 0) override;
-    /** Exit SDL. (Called by FSM) */
-    void                ExitSDL(int exit_code);
 
     void                ResetClientData(bool save_connection = false);
     void                LoadSinglePlayerGame(std::string filename = "");
@@ -160,6 +158,9 @@ private:
     void            HandleResoureDirChange();
 
     void            DisconnectedFromServer();           ///< called by ClientNetworking when the TCP connection to the server is lost
+
+    /** ExitSDL is bound by ResetOrExitApp() to exit the application. */
+    void            ExitSDL(int exit_code);
 
     /** Either reset to IntroMenu (\p reset is true), or exit the
         application.  If \p skip_savegame is true abort in progress save

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -939,7 +939,7 @@ boost::statechart::result PlayingTurn::react(const SaveGameComplete& msg) {
         && GetOptionsDB().Get<bool>("auto-quit"))
     {
         DebugLogger(FSM) << "auto-quit save completed, ending game.";
-        Client().Exit(0);
+        Client().ExitApp(0);
     }
 
     return discard_event();

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -939,7 +939,7 @@ boost::statechart::result PlayingTurn::react(const SaveGameComplete& msg) {
         && GetOptionsDB().Get<bool>("auto-quit"))
     {
         DebugLogger(FSM) << "auto-quit save completed, ending game.";
-        Client().ExitApp();
+        Client().Exit(0);
     }
 
     return discard_event();
@@ -1041,6 +1041,7 @@ boost::statechart::result QuittingGame::react(const StartQuittingGame& u) {
 
     m_reset_to_intro = u.m_reset_to_intro;
     m_server_process = &u.m_server;
+    m_exit_code = u.m_exit_code;
 
     post_event(ShutdownServer());
     return discard_event();
@@ -1129,8 +1130,12 @@ boost::statechart::result QuittingGame::react(const TerminateServer& u) {
         Client().ResetClientData();
         return transit<IntroMenu>();
     } else {
-        TraceLogger(FSM) << "QuittingGame throwing CleanQuit.";
-        throw HumanClientApp::CleanQuit();
+        TraceLogger(FSM) << "QuittingGame quitting";
+        // This line throws to exit the GUI
+        Client().ExitSDL(m_exit_code);
+
+        // This line will never be reached
+        return transit<IntroMenu>();
     }
 }
 

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -1022,9 +1022,7 @@ boost::statechart::result PlayingTurn::react(const DispatchCombatLogs& msg) {
 /** The QuittingGame state expects to start with a StartQuittingGame message posted. */
 QuittingGame::QuittingGame(my_context c) :
     my_base(c),
-    m_start_time(Clock::now()),
-    m_reset_to_intro(true),
-    m_server_process(nullptr)
+    m_start_time(Clock::now())
 {
     // Quit the game by sending a shutdown message to the server and waiting for
     // the disconnection event.  Free the server if it starts an orderly
@@ -1037,11 +1035,10 @@ QuittingGame::~QuittingGame()
 { TraceLogger(FSM) << "(HumanClientFSM) ~QuittingGame"; }
 
 boost::statechart::result QuittingGame::react(const StartQuittingGame& u) {
-    TraceLogger(FSM) << "(HumanClientFSM) QuittingGame reset to intro is " << u.m_reset_to_intro;
+    TraceLogger(FSM) << "(HumanClientFSM) QuittingGame";
 
-    m_reset_to_intro = u.m_reset_to_intro;
     m_server_process = &u.m_server;
-    m_exit_code = u.m_exit_code;
+    m_after_server_shutdown_action = u.m_after_server_shutdown_action;
 
     post_event(ShutdownServer());
     return discard_event();
@@ -1124,18 +1121,8 @@ boost::statechart::result QuittingGame::react(const TerminateServer& u) {
         m_server_process->RequestTermination();
     }
 
-    // Reset the game or quit the app as appropriate
-    if (m_reset_to_intro) {
-        TraceLogger(FSM) << "QuittingGame resetting to intro.";
-        Client().ResetClientData();
-        return transit<IntroMenu>();
-    } else {
-        TraceLogger(FSM) << "QuittingGame quitting";
-        // This line throws to exit the GUI
-        Client().ExitSDL(m_exit_code);
+    m_after_server_shutdown_action();
 
-        // This line will never be reached
-        return transit<IntroMenu>();
-    }
+    // If m_after_server_shutdown_action() exits the app, this line will never be reached
+    return transit<IntroMenu>();
 }
-

--- a/client/human/HumanClientFSM.h
+++ b/client/human/HumanClientFSM.h
@@ -39,13 +39,13 @@ struct AdvanceTurn : boost::statechart::event<AdvanceTurn> {};
 /** The set of events used by the QuittingGame state. */
 class Process;
 struct StartQuittingGame : boost::statechart::event<StartQuittingGame> {
-    StartQuittingGame(bool _r, Process& _s, int _exit_code) :
-        m_reset_to_intro(_r), m_server(_s), m_exit_code(_exit_code)
+    StartQuittingGame(Process& server_, std::function<void()>&& after_server_shutdown_action_) :
+        m_server(server_), m_after_server_shutdown_action(std::move(after_server_shutdown_action_))
     {}
 
-    bool m_reset_to_intro;  ///< Determines if on completion it resets to intro (true) or exits app (false).
     Process& m_server;
-    int m_exit_code;
+    /// An action to be completed after disconnecting from the server
+    std::function<void()> m_after_server_shutdown_action;
 };
 
 struct ShutdownServer : boost::statechart::event<ShutdownServer> {};
@@ -375,11 +375,9 @@ struct QuittingGame : boost::statechart::state<QuittingGame, HumanClientFSM> {
 
     std::chrono::steady_clock::time_point m_start_time;
 
-    // if m_reset_to_intro is true QuittingGame transits to the Intro menu, otherwise it
-    // exits the app.
-    bool m_reset_to_intro;
-    Process* m_server_process;
-    int m_exit_code;
+    Process* m_server_process = nullptr;
+    /// An action to be completed after disconnecting from the server
+    std::function<void()> m_after_server_shutdown_action = std::function<void()>();
 
     CLIENT_ACCESSOR
 };

--- a/client/human/HumanClientFSM.h
+++ b/client/human/HumanClientFSM.h
@@ -39,10 +39,13 @@ struct AdvanceTurn : boost::statechart::event<AdvanceTurn> {};
 /** The set of events used by the QuittingGame state. */
 class Process;
 struct StartQuittingGame : boost::statechart::event<StartQuittingGame> {
-    StartQuittingGame(bool _r, Process& _s) : m_reset_to_intro(_r), m_server(_s) {}
+    StartQuittingGame(bool _r, Process& _s, int _exit_code) :
+        m_reset_to_intro(_r), m_server(_s), m_exit_code(_exit_code)
+    {}
 
     bool m_reset_to_intro;  ///< Determines if on completion it resets to intro (true) or exits app (false).
     Process& m_server;
+    int m_exit_code;
 };
 
 struct ShutdownServer : boost::statechart::event<ShutdownServer> {};
@@ -376,6 +379,7 @@ struct QuittingGame : boost::statechart::state<QuittingGame, HumanClientFSM> {
     // exits the app.
     bool m_reset_to_intro;
     Process* m_server_process;
+    int m_exit_code;
 
     CLIENT_ACCESSOR
 };

--- a/client/human/chmain.cpp
+++ b/client/human/chmain.cpp
@@ -209,7 +209,9 @@ int mainConfigOptionsSetup(const std::vector<std::string>& args) {
 
 
 int mainSetupAndRun() {
+#ifndef FREEORION_CHMAIN_KEEP_STACKTRACE
     try {
+#endif
         RegisterOptions(&HumanClientApp::AddWindowSizeOptionsAfterMainStart);
 
         bool fullscreen = GetOptionsDB().Get<bool>("fullscreen");
@@ -260,11 +262,8 @@ int mainSetupAndRun() {
         // run rendering loop
         app();  // calls GUI::operator() which calls SDLGUI::Run() which starts rendering loop
 
-    } catch (const HumanClientApp::CleanQuit&) {
-        // do nothing
-    }
 #ifndef FREEORION_CHMAIN_KEEP_STACKTRACE
-    catch (const std::invalid_argument& e) {
+    } catch (const std::invalid_argument& e) {
         ErrorLogger() << "main() caught exception(std::invalid_argument): " << e.what();
         std::cerr << "main() caught exception(std::invalid_arg): " << e.what() << std::endl;
         return 1;


### PR DESCRIPTION
The HumanClientApp used HummanClientApp::CleanQuit to exit sometimes and
SDLGUI::QuitSignal at other times.

In this commit HumanClientApp now overrides SDLGUI::Exit and has a
single exit mechanic.