### PR TITLE
Fix make Pending explicitly non copyable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,7 +59,6 @@ DerivedData
 /util/Version.cpp
 /Installer/FreeOrion_Install_Script.nsi
 /doc/apidoc-commit-message
-/xcode_dummy.cpp
 
 # FreeOrion Xcode project
 /Xcode/dep/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -297,13 +297,6 @@ target_compile_options(freeorioncommon
         $<$<CXX_COMPILER_ID:AppleClang>:-ftemplate-depth=512>
 )
 
-if(APPLE)
-    set_target_properties(freeorioncommon
-        PROPERTIES
-        LINK_FLAGS "-undefined dynamic_lookup"
-    )
-endif()
-
 target_compile_definitions(freeorioncommon
     PRIVATE
     -DFREEORION_BUILD_COMMON
@@ -335,27 +328,20 @@ target_link_libraries(freeorioncommon
 add_dependencies(freeorioncommon freeorionversion)
 
 
-add_library(freeorionparseobj OBJECT "")
+add_library(freeorionparse OBJECT "")
 
-target_include_directories(freeorionparseobj SYSTEM
+target_include_directories(freeorionparse SYSTEM
     PRIVATE
         ${Boost_INCLUDE_DIRS}
         ${PROJECT_SOURCE_DIR}/GG
 )
 
-set_property(TARGET freeorionparseobj
+set_property(TARGET freeorionparse
     PROPERTY
     POSITION_INDEPENDENT_CODE ON
 )
 
-if(WIN32)
-    set_property(TARGET freeorionparse
-        PROPERTY
-        OUTPUT_NAME Parsers
-    )
-endif()
-
-target_compile_options(freeorionparseobj
+target_compile_options(freeorionparse
     PRIVATE
         $<$<CXX_COMPILER_ID:GNU>:-fvisibility=hidden>
         $<$<CXX_COMPILER_ID:Clang>:-fvisibility=hidden>
@@ -365,38 +351,16 @@ target_compile_options(freeorionparseobj
         $<$<AND:$<NOT:$<BOOL:${BUILD_TESTING}>>,$<CXX_COMPILER_ID:GNU>>:-O3>
 )
 
-target_compile_definitions(freeorionparseobj
+target_compile_definitions(freeorionparse
     PRIVATE
         -DNDEBUG
-        -DFREEORION_BUILD_PARSE
+        -DFREEORION_BUILD_COMMON
 )
 
-
-add_library(freeorionparse $<TARGET_OBJECTS:freeorionparseobj>)
-
-target_compile_options(freeorionparse
+target_sources(freeorioncommon
     PRIVATE
-        $<$<CXX_COMPILER_ID:GNU>:-fvisibility=hidden>
-        $<$<CXX_COMPILER_ID:Clang>:-fvisibility=hidden>
-        $<$<CXX_COMPILER_ID:AppleClang>:-fvisibility=hidden>
+        $<TARGET_OBJECTS:freeorionparse>
 )
-
-if(APPLE)
-    # Xcode doesn't build freeorionparse because it doesn't have any
-    # source code files associated and only links the freeorionparselib
-    # objects into a shared library.  Adding an empty file fixes this.
-    # https://cmake.org/cmake/help/v3.0/command/add_library.html
-    file(WRITE xcode_dummy.cpp "")
-    target_sources(freeorionparse
-        PRIVATE
-            xcode_dummy.cpp
-    )
-
-    set_target_properties(freeorionparse
-        PROPERTIES
-        LINK_FLAGS "-undefined dynamic_lookup"
-    )
-endif()
 
 
 add_executable(freeoriond "")
@@ -430,7 +394,6 @@ target_include_directories(freeoriond SYSTEM
 
 target_link_libraries(freeoriond
     freeorioncommon
-    freeorionparse
     ${PYTHON_LIBRARIES}
     ${Boost_PYTHON_LIBRARY}
     ${Boost_LOG_LIBRARY}
@@ -473,7 +436,6 @@ target_include_directories(freeorionca SYSTEM
 
 target_link_libraries(freeorionca
     freeorioncommon
-    freeorionparse
     ${PYTHON_LIBRARIES}
     ${Boost_PYTHON_LIBRARY}
     ${Boost_LOG_LIBRARY}
@@ -575,7 +537,6 @@ if(NOT BUILD_HEADLESS)
 
     target_link_libraries(freeorion
         freeorioncommon
-        freeorionparse
         GiGi
         GiGiSDL
         ${OPENGL_gl_LIBRARY}
@@ -608,8 +569,6 @@ if(APPLE)
             ${CMAKE_COMMAND} -E make_directory "$<TARGET_FILE_DIR:freeorion>/../SharedSupport"
         COMMAND
             ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:freeorioncommon>" "$<TARGET_FILE_DIR:freeorion>/../SharedSupport"
-        COMMAND
-            ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:freeorionparse>" "$<TARGET_FILE_DIR:freeorion>/../SharedSupport"
         COMMAND
             ${CMAKE_COMMAND} -E copy_if_different "$<TARGET_FILE:GiGi>" "$<TARGET_FILE_DIR:freeorion>/../SharedSupport"
         COMMAND
@@ -689,7 +648,6 @@ if(UNIX AND NOT APPLE)
     install(
         TARGETS
             freeorioncommon
-            freeorionparse
         LIBRARY DESTINATION ${FreeOrion_INSTALL_LIBDIR}
         RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
     )

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,11 @@ os: Visual Studio 2015
 
 version: ci-{build}
 
+environment:
+  matrix:
+    - BUILD_SYSTEM: MSVC
+    - BUILD_SYSTEM: CMAKE
+
 init:
   - git config --global core.eol native
   - git config --global core.autocrlf true
@@ -19,9 +24,22 @@ install:
   - cd freeorion
 
 before_build:
-  - cd msvc2015
+  - if "%BUILD_SYSTEM%" == "MSVC" (
+      cd msvc2015
+    )
+  - if "%BUILD_SYSTEM%" == "CMAKE" (
+      mkdir build
+    )
 
 build_script:
-    - msbuild FreeOrion.sln /property:Configuration=Release-XP /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /verbosity:minimal
+  - if "%BUILD_SYSTEM%" == "MSVC" (
+      msbuild FreeOrion.sln /property:Configuration=Release-XP /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /verbosity:minimal
+    )
+  - if "%BUILD_SYSTEM%" == "CMAKE" (
+      pushd build &&
+      cmake -G "Visual Studio 14 2015" .. &&
+      cmake --build . --config "Release" -- /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" &&
+      popd
+    )
 
 test: off

--- a/parse/CMakeLists.txt
+++ b/parse/CMakeLists.txt
@@ -1,4 +1,4 @@
-target_sources(freeorionparseobj
+target_sources(freeorionparse
     PUBLIC
         ${CMAKE_CURRENT_LIST_DIR}/Parse.h
     PRIVATE

--- a/parse/Parse.h
+++ b/parse/Parse.h
@@ -1,12 +1,8 @@
 #ifndef _Parse_h_
 #define _Parse_h_
 
-#if FREEORION_BUILD_PARSE && __GNUC__
-#   define FO_PARSE_API __attribute__((__visibility__("default")))
-#else
-#   define FO_PARSE_API
-#endif
-
+#include "../util/Export.h"
+#include "../universe/Tech.h"
 #include "../universe/ValueRefFwd.h"
 
 #include <boost/filesystem/path.hpp>
@@ -30,26 +26,26 @@ class GameRules;
 struct ItemSpec;
 
 namespace parse {
-    FO_PARSE_API std::map<std::string, std::unique_ptr<BuildingType>> buildings(const boost::filesystem::path& path);
+    FO_COMMON_API std::map<std::string, std::unique_ptr<BuildingType>> buildings(const boost::filesystem::path& path);
 
-    FO_PARSE_API std::map<std::string, std::unique_ptr<FieldType>> fields(const boost::filesystem::path& path);
+    FO_COMMON_API std::map<std::string, std::unique_ptr<FieldType>> fields(const boost::filesystem::path& path);
 
-    FO_PARSE_API std::map<std::string, std::unique_ptr<Special>> specials(const boost::filesystem::path& path);
+    FO_COMMON_API std::map<std::string, std::unique_ptr<Special>> specials(const boost::filesystem::path& path);
 
-    FO_PARSE_API std::map<std::string, std::unique_ptr<Species>> species(const boost::filesystem::path& path);
+    FO_COMMON_API std::map<std::string, std::unique_ptr<Species>> species(const boost::filesystem::path& path);
 
     /* T in techs<T> can only be TechManager::TechParseTuple.  This decouples
        Parse.h from Tech.h so that all parsers are not recompiled when Tech.h changes.*/
     template <typename T>
-    FO_PARSE_API T techs(const boost::filesystem::path& path);
+    FO_COMMON_API T techs(const boost::filesystem::path& path);
 
-    FO_PARSE_API std::vector<ItemSpec> items(const boost::filesystem::path& path);
+    FO_COMMON_API std::vector<ItemSpec> items(const boost::filesystem::path& path);
 
-    FO_PARSE_API std::vector<ItemSpec> starting_buildings(const boost::filesystem::path& path);
+    FO_COMMON_API std::vector<ItemSpec> starting_buildings(const boost::filesystem::path& path);
 
-    FO_PARSE_API std::map<std::string, std::unique_ptr<PartType>> ship_parts(const boost::filesystem::path& path);
+    FO_COMMON_API std::map<std::string, std::unique_ptr<PartType>> ship_parts(const boost::filesystem::path& path);
 
-    FO_PARSE_API std::map<std::string, std::unique_ptr<HullType>> ship_hulls(const boost::filesystem::path& path);
+    FO_COMMON_API std::map<std::string, std::unique_ptr<HullType>> ship_hulls(const boost::filesystem::path& path);
 
     /** Parse all ship designs in directory \p path, store them with their filename in \p
         design_and_path. If a file exists called ShipDesignOrdering.focs.txt, parse it and
@@ -58,29 +54,29 @@ namespace parse {
         std::vector<std::pair<std::unique_ptr<ParsedShipDesign>, boost::filesystem::path>>, // designs_and_paths,
         std::vector<boost::uuids::uuid> // ordering
         >;
-    FO_PARSE_API ship_designs_type ship_designs(const boost::filesystem::path& path);
+    FO_COMMON_API ship_designs_type ship_designs(const boost::filesystem::path& path);
 
-    FO_PARSE_API std::vector<std::unique_ptr<FleetPlan>> fleet_plans(const boost::filesystem::path& path);
+    FO_COMMON_API std::vector<std::unique_ptr<FleetPlan>> fleet_plans(const boost::filesystem::path& path);
 
-    FO_PARSE_API std::vector<std::unique_ptr<MonsterFleetPlan>> monster_fleet_plans(const boost::filesystem::path& path);
+    FO_COMMON_API std::vector<std::unique_ptr<MonsterFleetPlan>> monster_fleet_plans(const boost::filesystem::path& path);
 
-    FO_PARSE_API std::map<std::string, std::unique_ptr<ValueRef::ValueRefBase<double>>> statistics(const boost::filesystem::path& path);
+    FO_COMMON_API std::map<std::string, std::unique_ptr<ValueRef::ValueRefBase<double>>> statistics(const boost::filesystem::path& path);
 
-    FO_PARSE_API std::map<std::string, std::vector<EncyclopediaArticle>> encyclopedia_articles(const boost::filesystem::path& path);
+    FO_COMMON_API std::map<std::string, std::vector<EncyclopediaArticle>> encyclopedia_articles(const boost::filesystem::path& path);
 
-    FO_PARSE_API std::map<std::string, std::map<int, int>> keymaps(const boost::filesystem::path& path);
+    FO_COMMON_API std::map<std::string, std::map<int, int>> keymaps(const boost::filesystem::path& path);
 
-    FO_PARSE_API GameRules game_rules(const boost::filesystem::path& path);
+    FO_COMMON_API GameRules game_rules(const boost::filesystem::path& path);
 
-    FO_PARSE_API bool read_file(const boost::filesystem::path& path, std::string& file_contents);
+    FO_COMMON_API bool read_file(const boost::filesystem::path& path, std::string& file_contents);
 
     /** Find all FOCS scripts (files with .focs.txt suffix) in \p path.  If \p allow_permissive =
         true then if \p path is not empty and there are no .focs.txt files allow all files to qualify.*/
-    FO_PARSE_API std::vector< boost::filesystem::path > ListScripts(const boost::filesystem::path& path, bool permissive = false);
+    FO_COMMON_API std::vector< boost::filesystem::path > ListScripts(const boost::filesystem::path& path, bool permissive = false);
 
-    FO_PARSE_API void file_substitution(std::string& text, const boost::filesystem::path& file_search_path);
+    FO_COMMON_API void file_substitution(std::string& text, const boost::filesystem::path& file_search_path);
 
-    FO_PARSE_API void process_include_substitutions(std::string& text, 
+    FO_COMMON_API void process_include_substitutions(std::string& text,
                                                     const boost::filesystem::path& file_search_path, 
                                                     std::set<boost::filesystem::path>& files_included);
 }

--- a/parse/TechsParser.cpp
+++ b/parse/TechsParser.cpp
@@ -292,4 +292,4 @@ namespace parse {
 // explicitly instantiate techs.
 // This allows Tech.h to only be included in this .cpp file and not Parse.h
 // which recompiles all parsers if Tech.h changes.
-template FO_PARSE_API TechManager::TechParseTuple parse::techs<TechManager::TechParseTuple>(const boost::filesystem::path& path);
+template FO_COMMON_API TechManager::TechParseTuple parse::techs<TechManager::TechParseTuple>(const boost::filesystem::path& path);

--- a/test/parse/CMakeLists.txt
+++ b/test/parse/CMakeLists.txt
@@ -3,7 +3,7 @@ find_package(Boost ${MINIMUM_BOOST_VERSION} COMPONENTS unit_test_framework REQUI
 add_executable(fo_unittest_parse
     main.cpp
     CommonTest.cpp
-    $<TARGET_OBJECTS:freeorionparseobj>
+    $<TARGET_OBJECTS:freeorionparse>
 )
 
 target_compile_definitions(fo_unittest_parse

--- a/universe/Encyclopedia.h
+++ b/universe/Encyclopedia.h
@@ -43,9 +43,9 @@ public:
     unsigned int GetCheckSum() const;
 
     /** Sets articles to the value of \p future. */
-    FO_COMMON_API void SetArticles(Pending::Pending<ArticleMap>&& future);
+    void SetArticles(Pending::Pending<ArticleMap>&& future);
 
-    FO_COMMON_API const ArticleMap& Articles() const;
+    const ArticleMap& Articles() const;
 
     const EncyclopediaArticle                               empty_article;
 private:

--- a/universe/ShipDesign.h
+++ b/universe/ShipDesign.h
@@ -193,7 +193,7 @@ public:
     //@}
 
     /** Sets part types to the future value of \p pending_part_types. */
-    FO_COMMON_API void SetPartTypes(Pending::Pending<PartTypeMap>&& pending_part_types);
+    void SetPartTypes(Pending::Pending<PartTypeMap>&& pending_part_types);
 
 private:
     PartTypeManager();
@@ -391,7 +391,7 @@ public:
     //@}
 
     /** Sets hull types to the future value of \p pending_hull_types. */
-    FO_COMMON_API void SetHullTypes(Pending::Pending<HullTypeMap>&& pending_hull_types);
+    void SetHullTypes(Pending::Pending<HullTypeMap>&& pending_hull_types);
 
 private:
     HullTypeManager();
@@ -690,11 +690,11 @@ public:
 
     /** Sets ship design types to the future value of \p pending_designs
         found in \p subdir. */
-    FO_COMMON_API void SetShipDesignTypes(Pending::Pending<ParsedShipDesignsType>&& pending_designs);
+    void SetShipDesignTypes(Pending::Pending<ParsedShipDesignsType>&& pending_designs);
 
     /** Sets monster design types to the future value of \p
         pending_design_types found in \p subdir. */
-    FO_COMMON_API void SetMonsterDesignTypes(Pending::Pending<ParsedShipDesignsType>&& pending_designs);
+    void SetMonsterDesignTypes(Pending::Pending<ParsedShipDesignsType>&& pending_designs);
 
 private:
     PredefinedShipDesignManager();

--- a/universe/Special.h
+++ b/universe/Special.h
@@ -124,7 +124,7 @@ public:
     unsigned int GetCheckSum() const;
 
     /** Sets types to the value of \p future. */
-    FO_COMMON_API void SetSpecialsTypes(Pending::Pending<SpecialsTypeMap>&& future);
+    void SetSpecialsTypes(Pending::Pending<SpecialsTypeMap>&& future);
 
 private:
     /** Assigns any m_pending_types to m_specials. */

--- a/universe/Species.h
+++ b/universe/Species.h
@@ -324,7 +324,7 @@ public:
     std::map<std::string, std::map<std::string, int>>&  SpeciesShipsDestroyed(int encoding_empire = ALL_EMPIRES);
 
     /** Sets species types to the value of \p future. */
-    FO_COMMON_API void SetSpeciesTypes(Pending::Pending<SpeciesTypeMap>&& future);
+    void SetSpeciesTypes(Pending::Pending<SpeciesTypeMap>&& future);
 
     //@}
 

--- a/universe/Tech.h
+++ b/universe/Tech.h
@@ -267,7 +267,7 @@ public:
         std::set<std::string> // categories_seen
         >;
     /** Sets types to the value of \p future. */
-    FO_COMMON_API void SetTechs(Pending::Pending<TechParseTuple>&& future);
+    void SetTechs(Pending::Pending<TechParseTuple>&& future);
 
 
     /** returns the instance of this singleton class; you should use the free function GetTechManager() instead */

--- a/universe/UniverseGenerator.h
+++ b/universe/UniverseGenerator.h
@@ -15,7 +15,7 @@ struct PlayerSetupData;
  * ShipDesign names refer to designs listed in default/scripting/ship_designs.
  * Useful for saving or specifying prearranged combinations of prearranged
  * ShipDesigns to automatically put together, such as during universe creation.*/
-class FleetPlan {
+class FO_COMMON_API FleetPlan {
 public:
     FleetPlan(const std::string& fleet_name, const std::vector<std::string>& ship_design_names,
               bool lookup_name_userstring = false) :

--- a/util/Export.h
+++ b/util/Export.h
@@ -3,6 +3,10 @@
 
 #if FREEORION_BUILD_COMMON && __GNUC__
 #   define FO_COMMON_API __attribute__((__visibility__("default")))
+#elif FREEORION_BUILD_COMMON && _MSC_VER
+#   define FO_COMMON_API __declspec(dllexport)
+#elif _MSC_VER
+#   define FO_COMMON_API __declspec(dllimport)
 #else
 #   define FO_COMMON_API
 #endif

--- a/util/Pending.h
+++ b/util/Pending.h
@@ -24,16 +24,9 @@ namespace Pending {
             filename(name_)
         {}
 
-        Pending(Pending&& other) :
-            pending(std::move(other.pending)),
-            filename(std::move(other.filename))
-        {}
+        Pending(Pending&& other) = default;
 
-        Pending& operator=(Pending&& other) {
-            pending = std::move(other.pending);
-            filename = std::move(other.filename);
-            return *this;
-        }
+        Pending& operator=(Pending&& other) = default;
 
         boost::optional<std::future<T>> pending = boost::none;
         std::string filename;

--- a/util/Pending.h
+++ b/util/Pending.h
@@ -28,6 +28,12 @@ namespace Pending {
 
         Pending& operator=(Pending&& other) = default;
 
+        /** Pending is non-copyable because std::shared<T> is non-copyable*/
+        Pending(const Pending&) = delete;
+
+        /** Pending is non-copyable because std::shared<T> is non-copyable*/
+        Pending& operator=(const Pending&) = delete;
+
         boost::optional<std::future<T>> pending = boost::none;
         std::string filename;
     };


### PR DESCRIPTION
This PR is an extension to #1416 to check if making Pending explicitly non-copyable will force MSVC to chose the move constructor in the cmake build.

