### PR TITLE
AI basic stockpile use

### DIFF
--- a/default/python/AI/TechsListsAI.py
+++ b/default/python/AI/TechsListsAI.py
@@ -223,6 +223,7 @@ class TechGroup1SparseC(TechGroup1):
             "LRN_FORCE_FIELD",
             "SHP_WEAPON_2_2",
             "PRO_ORBITAL_GEN",
+            "PRO_IMPERIAL_STOCKPILE_2",
             "SPY_DETECT_2",
             "SHP_SPACE_FLUX_DRIVE",
         )
@@ -237,6 +238,7 @@ class TechGroup2(TechGroup):
             "PRO_FUSION_GEN",
             "PRO_SENTIENT_AUTOMATION",
             "PRO_EXOBOTS",
+            "PRO_IMPERIAL_STOCKPILE_2",
             # "PRO_MICROGRAV_MAN",  # handled by fast-forwarding when we have asteroids
             # "PRO_ORBITAL_GEN",    # handled by fast-forwarding when we have a GG
 
@@ -282,7 +284,8 @@ class TechGroup2A(TechGroup2):
             self.weapon,
             self.weapon,
             self.weapon,
-            self.economy
+            self.economy,
+            self.economy,
         )
 
 
@@ -304,7 +307,8 @@ class TechGroup2B(TechGroup2):
             self.weapon,
             self.weapon,
             self.economy,
-            self.economy
+            self.economy,
+            self.economy,
         )
 
 
@@ -325,6 +329,7 @@ class TechGroup2SparseA(TechGroup2):
             self.weapon,
             self.defense,
             self.weapon,
+            self.economy,
             self.weapon,
             self.weapon
         )
@@ -347,6 +352,7 @@ class TechGroup2SparseB(TechGroup2):
             self.defense,
             self.armor,
             self.weapon,
+            self.economy,
             self.weapon,
             self.weapon
         )
@@ -371,6 +377,7 @@ class TechGroup3(TechGroup):
             "PRO_INDUSTRY_CENTER_II",
             "GRO_XENO_HYBRIDS",
             "CON_ORBITAL_HAB",
+            "PRO_IMPERIAL_STOCKPILE_3",
             "CON_NDIM_STRC",
             "GRO_LIFECYCLE_MAN",
         ])
@@ -446,6 +453,7 @@ class TechGroup3A(TechGroup3):
             self.defense,
             self.defense,
             self.economy,
+            self.economy,
             self.misc,
             self.economy,
             self.weapon,
@@ -498,6 +506,7 @@ class TechGroup3B(TechGroup3):
             self.defense,
             self.defense,
             self.economy,
+            self.economy,
             self.misc,
             self.economy
         )
@@ -541,6 +550,7 @@ class TechGroup3Sparse(TechGroup3):
             self.defense,
             self.defense,
             self.misc,
+            self.economy,
             self.economy,
             self.misc,
             self.defense,


### PR DESCRIPTION
Enables the AI to make basic use of the imperial stockpile.

Resolves #1879 