### PR TITLE
Orbital outposting fixes

### DIFF
--- a/default/python/AI/AIstate.py
+++ b/default/python/AI/AIstate.py
@@ -936,11 +936,24 @@ class AIstate(object):
             # in current system, orig new fleet will not yet have been assigned a role
             # self.remove_fleet_role(fleet_id)
 
+    def __cleanup_qualifiying_base_targets(self):
+        """Cleanup invalid entries in qualifying base targets."""
+        universe = fo.getUniverse()
+        empire_id = fo.empireID()
+        for dct in [self.qualifyingTroopBaseTargets,
+                    self.qualifyingColonyBaseTargets,
+                    self.qualifyingOutpostBaseTargets]:
+            for pid in dct.keys():
+                planet = universe.getPlanet(pid)
+                if planet and planet.ownedBy(empire_id):
+                    del dct[pid]
+
     def prepare_for_new_turn(self):
         self.__report_last_turn_fleet_missions()
         self.__split_new_fleets()
         self.__refresh()  # TODO: Use turn_state instead
         self.__border_exploration_update()
+        self.__cleanup_qualifiying_base_targets()
         self.__clean_fleet_roles()
         self.__clean_fleet_missions()
         print "Fleets lost by system: %s" % fleetsLostBySystem

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -446,7 +446,7 @@ def get_colony_fleets():
                                        - set(outpost_targeted_planet_ids)
                                        - set(colony_targeted_planet_ids))
     if tech_is_complete(AIDependencies.OUTPOSTING_TECH) and considered_outpost_base_targets:
-        print "Considering to build outpost bases for %s" % reserved_outpost_base_targets
+        print "Considering to build outpost bases for %s" % considered_outpost_base_targets
         for pid in considered_outpost_base_targets:
             if len(queued_outpost_bases) >= max_queued_outpost_bases:
                 print "Too many queued outpost bases to build any more now"
@@ -460,16 +460,14 @@ def get_colony_fleets():
             for species in empire_colonizers:
                 this_score = max(this_score, evaluate_planet(pid, MissionType.COLONISATION, species, []))
             planet = universe.getPlanet(pid)
-            if this_score == 0:
-                # print "Potential outpost base (rejected) for %s to be built at planet id(%d); outpost score %.1f" % (
-                # ((planet and planet.name) or "unknown"), loc, this_score)
+            if this_score <= 0:
                 continue
-            print "Potential outpost base for %s to be built at planet id(%d); outpost score %.1f" % (
-                ((planet and planet.name) or "unknown"), loc, this_score)
-            if this_score < 100:
-                print "Potential outpost base (rejected) for %s to be built at planet id(%d); outpost score %.1f" % (
-                    ((planet and planet.name) or "unknown"), loc, this_score)
+            elif this_score < 100:
+                print "Potential outpost base (rejected) for %s to be built at planet %s; outpost score %.1f" % (
+                    (planet, universe.getPlanet(loc), this_score))
                 continue
+            print "Potential outpost base for %s to be built at planet %s; outpost score %.1f" % (
+                (planet, universe.getPlanet(loc), this_score))
             best_ship, col_design, build_choices = ProductionAI.get_best_ship_info(
                 PriorityType.PRODUCTION_ORBITAL_OUTPOST, loc)
             if best_ship is None:

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -442,7 +442,9 @@ def get_colony_fleets():
 
     reserved_outpost_base_targets = foAI.foAIstate.qualifyingOutpostBaseTargets.keys()
     max_queued_outpost_bases = max(1, int(2 * empire.productionPoints / outpost_cost))
-    considered_outpost_base_targets = (set(reserved_outpost_base_targets) - set(outpost_targeted_planet_ids))
+    considered_outpost_base_targets = (set(reserved_outpost_base_targets)
+                                       - set(outpost_targeted_planet_ids)
+                                       - set(colony_targeted_planet_ids))
     if tech_is_complete(AIDependencies.OUTPOSTING_TECH) and considered_outpost_base_targets:
         print "Considering to build outpost bases for %s" % reserved_outpost_base_targets
         for pid in considered_outpost_base_targets:

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -400,25 +400,16 @@ def get_colony_fleets():
         avail_pp_by_sys.update([(sys_id, available_pp[p_set]) for sys_id in set(PlanetUtilsAI.get_systems(p_set))])
     colony_cost = colony_pod_cost()
     outpost_cost = outpod_pod_cost()
-    production_queue = empire.productionQueue
-    queued_outpost_bases = []
-    queued_colony_bases = []
-    for queue_index in range(0, len(production_queue)):
-        element = production_queue[queue_index]
-        if element.buildType == EmpireProductionTypes.BT_SHIP and element.turnsLeft != -1:
-            if foAI.foAIstate.get_ship_role(element.designID) in [ShipRoleType.BASE_OUTPOST]:
-                build_planet = universe.getPlanet(element.locationID)
-                queued_outpost_bases.append(build_planet.systemID)
-            elif foAI.foAIstate.get_ship_role(element.designID) in [ShipRoleType.BASE_COLONISATION]:
-                build_planet = universe.getPlanet(element.locationID)
-                queued_colony_bases.append(build_planet.systemID)
+
+    colony_base_manager = OrbitalColonyBaseManager()
+    colony_base_manager.handle_bases_in_production_queue()
+
+    outpost_base_manager = OrbitalOutpostBaseManager()
+    outpost_base_manager.handle_bases_in_production_queue()
 
     evaluated_colony_planet_ids = list(state.get_unowned_empty_planets().union(state.get_empire_outposts()) - set(
         colony_targeted_planet_ids))  # places for possible colonyBase
 
-    # don't want to lose the info by clearing, but #TODO: should double check if still own colonizer planet
-    # foAI.foAIstate.qualifyingOutpostBaseTargets.clear()
-    # foAI.foAIstate.qualifyingColonyBaseTargets.clear()
     cost_ratio = 120  # TODO: temp ratio; reest to 12 *; consider different ratio
     for pid in evaluated_colony_planet_ids:  # TODO: reorganize
         planet = universe.getPlanet(pid)
@@ -429,33 +420,32 @@ def get_colony_fleets():
             planet2 = universe.getPlanet(pid2)
             if not (planet2 and planet2.speciesName in empire_colonizers):
                 continue
-            if pid not in foAI.foAIstate.qualifyingOutpostBaseTargets:
-                if planet.unowned:
-                    foAI.foAIstate.qualifyingOutpostBaseTargets.setdefault(pid, [pid2, -1])
-            if ((pid not in foAI.foAIstate.qualifyingColonyBaseTargets) and
-                    (colony_cost < cost_ratio * avail_pp_by_sys.get(sys_id, 0)) and
+            if planet.unowned:
+                outpost_base_manager.log_as_qualifying_target(pid, pid2)
+            if ((colony_cost < cost_ratio * avail_pp_by_sys.get(sys_id, 0)) and
                     (planet.unowned or pid in state.get_empire_outposts())):
                 # TODO: enable actual building, remove from outpostbases, check other local colonizers for better score
-                foAI.foAIstate.qualifyingColonyBaseTargets.setdefault(pid, [pid2, -1])
+                colony_base_manager.log_as_qualifying_target(pid, pid2)
 
     colonization_timer.start('Initiate outpost base construction')
 
-    reserved_outpost_base_targets = foAI.foAIstate.qualifyingOutpostBaseTargets.keys()
+    reserved_outpost_base_targets = outpost_base_manager.get_all_qualifying_targets()
     max_queued_outpost_bases = max(1, int(2 * empire.productionPoints / outpost_cost))
     considered_outpost_base_targets = (set(reserved_outpost_base_targets)
                                        - set(outpost_targeted_planet_ids)
                                        - set(colony_targeted_planet_ids))
+    debug("Current qualifyingOutpostBaseTargets: %s" % foAI.foAIstate.qualifyingOutpostBaseTargets)
     if tech_is_complete(AIDependencies.OUTPOSTING_TECH) and considered_outpost_base_targets:
         print "Considering to build outpost bases for %s" % considered_outpost_base_targets
         for pid in considered_outpost_base_targets:
-            if len(queued_outpost_bases) >= max_queued_outpost_bases:
+            if outpost_base_manager.num_enqueued_bases >= max_queued_outpost_bases:
                 print "Too many queued outpost bases to build any more now"
                 break
             if pid not in state.get_unowned_empty_planets():
                 continue
-            if foAI.foAIstate.qualifyingOutpostBaseTargets[pid][1] != -1:
-                continue  # already building for here
-            loc = foAI.foAIstate.qualifyingOutpostBaseTargets[pid][0]
+            if outpost_base_manager.is_enqueued(pid):
+                continue
+            loc = outpost_base_manager.get_building_loc(pid)
             this_score = evaluate_planet(pid, MissionType.OUTPOST, None, [])
             for species in empire_colonizers:
                 this_score = max(this_score, evaluate_planet(pid, MissionType.COLONISATION, species, []))
@@ -468,8 +458,7 @@ def get_colony_fleets():
                 continue
             print "Potential outpost base for %s to be built at planet %s; outpost score %.1f" % (
                 (planet, universe.getPlanet(loc), this_score))
-            best_ship, col_design, build_choices = ProductionAI.get_best_ship_info(
-                PriorityType.PRODUCTION_ORBITAL_OUTPOST, loc)
+            best_ship, _, _ = ProductionAI.get_best_ship_info(PriorityType.PRODUCTION_ORBITAL_OUTPOST, loc)
             if best_ship is None:
                 warn("Can't get standard best outpost base design that can be built at %s" % (
                     PlanetUtilsAI.planet_name_ids([loc])))
@@ -484,9 +473,8 @@ def get_colony_fleets():
             print "Enqueueing Outpost Base at %s for %s with result %s" % (
                 PlanetUtilsAI.planet_name_ids([loc]), PlanetUtilsAI.planet_name_ids([pid]), retval)
             if retval:
-                foAI.foAIstate.qualifyingOutpostBaseTargets[pid][1] = loc
-                queued_outpost_bases.append((planet and planet.systemID) or INVALID_ID)
-                # res=fo.issueRequeueProductionOrder(production_queue.size -1, 0) # TODO: evaluate move to front
+                outpost_base_manager.mark_as_enqueued(pid)
+                outpost_base_manager.num_enqueued_bases += 1
     colonization_timer.start('Evaluate Primary Colony Opportunities')
 
     evaluated_outpost_planet_ids = list(state.get_unowned_empty_planets() - set(outpost_targeted_planet_ids) - set(
@@ -1344,3 +1332,74 @@ def __print_candidate_table(candidates, mission):
             ])
     print
     candidate_table.print_table()
+
+
+class OrbitalBaseManager(object):
+    base_type = "INVALID"
+    role = ShipRoleType.INVALID
+
+    def __init__(self):
+        self.qualifying_targets = {}
+        self.target_candidates = {}
+        self.num_enqueued_bases = 0
+
+    def reset(self):
+        self.__init__()
+
+    def get_all_qualifying_targets(self):
+        return self.qualifying_targets.keys()
+
+    def log_as_qualifying_target(self, target, build_location):
+        if target not in self.qualifying_targets:
+            self.qualifying_targets[target] = [build_location, -1]
+
+    def mark_as_enqueued(self, target):
+        self.qualifying_targets[target][1] = self.qualifying_targets[target][0]
+
+    def is_enqueued(self, target):
+        return self.qualifying_targets[target][1] != -1
+
+    def get_building_loc(self, target):
+        return self.qualifying_targets[target][0]
+
+    def handle_bases_in_production_queue(self):
+        """Clean up and count the bases in the production queue with valid target.
+
+        If a queued base has no valid target, try to reassign it to another planet.
+        If that is not possible, delete the item from the queue to not waste PP.
+        """
+        # TODO: Consider pausing the item rather than deleting.
+        self.target_candidates = dict(self.qualifying_targets)
+        self.num_enqueued_bases = 0
+        for element in fo.getEmpire().productionQueue:
+
+            if element.buildType != EmpireProductionTypes.BT_SHIP:
+                continue
+
+            if element.turnsLeft == -1:
+                continue
+
+            if foAI.foAIstate.get_ship_role(element.designID) != self.role:
+                continue
+
+            self.num_enqueued_bases += 1
+
+
+class OrbitalOutpostBaseManager(OrbitalBaseManager):
+    base_type = "Outpost"
+    role = ShipRoleType.BASE_OUTPOST
+
+    def __init__(self):
+        super(OrbitalOutpostBaseManager, self).__init__()
+        # this intentionally does not copy the AIstate dict but modifies it.
+        self.qualifying_targets = foAI.foAIstate.qualifyingOutpostBaseTargets
+
+
+class OrbitalColonyBaseManager(OrbitalBaseManager):
+    base_type = "Colony"
+    role = ShipRoleType.BASE_COLONISATION
+
+    def __init__(self):
+        super(OrbitalColonyBaseManager, self).__init__()
+        # this intentionally does not copy the AIstate dict but modifies it.
+        self.qualifying_targets = foAI.foAIstate.qualifyingColonyBaseTargets


### PR DESCRIPTION
There are 3 (potential, probably interacting) bugs in the current code concerning orbital expansion:

1) The AI would still have planets listed as qualifying for orbital outposting that were already colonized by another mission. The first commit in this PR aims to clean up those lingering entries at turn start.

2) The AI would consider planets for orbital outposting that were already colonization-targeted.

3) If a target that was envisioned for orbital outposting was already claimed by another mission or another player, then that base would be (silently) reassigned to another planet in the system. However, the qualifyingBaseTargets would not be updated and the new target was still "open". The entry would eventually get cleaned up but not before colonization of the new target in the next turn - there was a 1 turn gap where an additional, unneeded base would be enqueued.


The PR refactors the current code and introduces helper classes that interface the qualifyingXBaseTargets dicts in the AIstate for convenience and easier usage. In the future, all orbital colonization logic will be handled by those classes.


Fixes #1886.