### PR TITLE
Always store the AIstate aggression as integer

### DIFF
--- a/default/python/AI/AIstate.py
+++ b/default/python/AI/AIstate.py
@@ -114,7 +114,7 @@ class AIstate(object):
         # unique ids for turns.  {turn: uid}
         self.turn_uids = {}
 
-        self._aggression = aggression
+        self._aggression = int(aggression)
 
         # 'global' (?) variables
         self.colonisablePlanetIDs = odict()


### PR DESCRIPTION
This aims to resolve #1285:
```pickle.PicklingError: Can't pickle <type 'Boost.Python.enum'>: it's not found as Boost.Python.enum```
