### PR TITLE
Boost 1.61.0, 1.62.0 - Resolve logging of const char ternary result

### DIFF
--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -1605,7 +1605,7 @@ namespace {
             return;
 
         DebugLogger() << "Populating pre-defined ships with "
-                      << (are_monsters ? "monster":"ship") << " designs.";
+                      << std::string(are_monsters ? "monster" : "ship") << " designs.";
 
         FillDesignsOrderingAndNameTables(
             *parsed, designs, ordering, name_to_uuid);


### PR DESCRIPTION
Workaround for boost versions 1.61.0 and 1.62.0 (and possibly 1.60.0).
Not an issue with boost versions 1.59.0, 1.63.0, 1.64.0

Assume this is due to use within template, as other similar (non-template) uses work as expected.

Resolves #1889