### PR TITLE
Add ValueRef include to ConditionParser.cpp

### DIFF
--- a/parse/ConditionParser.cpp
+++ b/parse/ConditionParser.cpp
@@ -9,6 +9,7 @@
 #include "ConditionParser7.h"
 
 #include "../universe/Condition.h"
+#include "../universe/ValueRef.h"
 
 //TODO: replace with std::make_unique when transitioning to C++14
 #include <boost/smart_ptr/make_unique.hpp>


### PR DESCRIPTION
This fixes issue #1890 clang implicit instantiation of undefined
template 'ValueRef::ValueRefBase<int>'

@spikethehobbitmage could you test this PR?  Thanks.