### PR TITLE
Fix bug #1732 pathfinder not cleared in universe clear

### DIFF
--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1391,7 +1391,7 @@ void ServerApp::GenerateUniverse(std::map<int, PlayerSetupData>& player_setup_da
     DebugLogger() << "GenerateUniverse with seed: " << seed;
 
     // Reset the universe object for a new universe
-    universe.ResetUniverse();
+    universe.Clear();
 
     // Reset the object id manager for the new empires.
     std::vector<int> empire_ids(player_setup_data.size());

--- a/universe/ObjectMap.cpp
+++ b/universe/ObjectMap.cpp
@@ -30,11 +30,8 @@
 ObjectMap::ObjectMap()
 {}
 
-ObjectMap::~ObjectMap() {
-    // Make sure to call ObjectMap::Clear() before destruction somewhere if
-    // this ObjectMap contains any unique pointers to UniverseObject objects.
-    // Otherwise, the pointed-to UniverseObjects will be leaked memory...
-}
+ObjectMap::~ObjectMap()
+{}
 
 void ObjectMap::Copy(const ObjectMap& copied_map, int empire_id/* = ALL_EMPIRES*/) {
     if (&copied_map == this)

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -92,7 +92,7 @@ extern FO_COMMON_API const int ALL_EMPIRES            = -1;
 // class Universe
 /////////////////////////////////////////////
 Universe::Universe() :
-    m_pathfinder(new Pathfinder),
+    m_pathfinder(std::make_shared<Pathfinder>()),
     m_universe_width(1000.0),
     m_inhibit_universe_object_signals(false),
     m_encoding_empire(ALL_EMPIRES),
@@ -138,6 +138,8 @@ void Universe::Clear() {
     m_stat_records.clear();
 
     m_universe_width = 1000.0;
+
+    m_pathfinder = std::make_shared<Pathfinder>();
 }
 
 void Universe::ResetAllIDAllocation(const std::vector<int>& empire_ids) {

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -109,33 +109,35 @@ Universe::~Universe()
 void Universe::Clear() {
     // empty object maps
     m_objects.Clear();
-    for (auto& entry : m_empire_latest_known_objects)
-        entry.second.Clear();
-    m_empire_latest_known_objects.clear();
+
+    ResetAllIDAllocation();
+
+    m_marked_destroyed.clear();
+    m_destroyed_object_ids.clear();
 
     // clean up ship designs
     for (auto& entry : m_ship_designs)
         delete entry.second;
     m_ship_designs.clear();
 
-    m_destroyed_object_ids.clear();
-
     m_empire_object_visibility.clear();
     m_empire_object_visibility_turns.clear();
-
     m_empire_object_visible_specials.clear();
+
+    m_empire_known_destroyed_object_ids.clear();
+    m_empire_latest_known_objects.clear();
+    m_empire_stale_knowledge_object_ids.clear();
+    m_empire_known_ship_design_ids.clear();
 
     m_effect_accounting_map.clear();
     m_effect_discrepancy_map.clear();
+    m_effect_specified_empire_object_visibilities.clear();
 
-    ResetAllIDAllocation();
+    GetSpeciesManager().ClearSpeciesHomeworlds();
 
-    m_empire_known_destroyed_object_ids.clear();
-    m_empire_stale_knowledge_object_ids.clear();
+    m_stat_records.clear();
 
-    m_empire_known_ship_design_ids.clear();
-
-    m_marked_destroyed.clear();
+    m_universe_width = 1000.0;
 }
 
 void Universe::ResetAllIDAllocation(const std::vector<int>& empire_ids) {
@@ -3082,30 +3084,6 @@ void Universe::GetEmpireStaleKnowledgeObjects(ObjectKnowledgeMap& empire_stale_k
     auto it = m_empire_stale_knowledge_object_ids.find(encoding_empire);
     if (it != m_empire_stale_knowledge_object_ids.end())
         empire_stale_knowledge_object_ids[encoding_empire] = it->second;
-}
-
-void Universe::ResetUniverse() {
-    m_objects.Clear();  // wipe out anything present in the object map
-
-    m_empire_known_destroyed_object_ids.clear();
-    m_empire_known_ship_design_ids.clear();
-    m_empire_latest_known_objects.clear();
-    m_effect_accounting_map.clear();
-    m_empire_object_visibility.clear();
-    m_empire_object_visibility_turns.clear();
-    m_empire_object_visible_specials.clear();
-    m_effect_accounting_map.clear();
-    m_effect_discrepancy_map.clear();
-    m_marked_destroyed.clear();
-    m_effect_specified_empire_object_visibilities.clear();
-    m_destroyed_object_ids.clear();
-    m_ship_designs.clear();
-    m_stat_records.clear();
-    m_universe_width = 1000.0;
-
-    ResetAllIDAllocation();
-
-    GetSpeciesManager().ClearSpeciesHomeworlds();
 }
 
 std::map<std::string, unsigned int> CheckSumContent() {

--- a/universe/Universe.h
+++ b/universe/Universe.h
@@ -436,7 +436,7 @@ public:
 private:
     /* Pathfinder setup for the viewing empire
      */
-    std::shared_ptr<Pathfinder> const m_pathfinder;
+    std::shared_ptr<Pathfinder> m_pathfinder;
 
     /** Generates an object ID for a future object. Usually used by the server
       * to service new ID requests. */

--- a/universe/Universe.h
+++ b/universe/Universe.h
@@ -203,9 +203,6 @@ public:
       * Universe gains ownership of \a ship_design once inserted. */
     bool            InsertShipDesignID(ShipDesign* ship_design, boost::optional<int> empire_id, int id);
     
-    // Resets the universe object to prepare for generation of a new universe
-    void            ResetUniverse();
-
    /** Reset object and ship design id allocation for a new game. */
     void ResetAllIDAllocation(const std::vector<int>& empire_ids = std::vector<int>());
 


### PR DESCRIPTION
This PR may fix bug #1732.  I was not able to replicate the bug, but I think that I understand it from the AddressSantizer dump in the bug report.

The problem is that the hostless improvement violates assumptions in the server code about the persistence of objects, in this specific case the `Pathfinder`.  While the new universe is being created the pathfinder is used with references to the old galaxy topology.

This PR:
- merges `Universe::ResetUniverse()` into `Universe::Clear()`
- adds creation of a new `Pathfinder` to `Clear()`

This PR will need to be tested by someone who can replicate the problem, preferably with a back trace if it crashes. I suspect that there are other bugs with the same symptom, crashing when starting a second hostless game, because a universe sub object is assuming a persistence that the hostless modification has removed.  The backtrace will determine if it is causes by the `Pathfinder` or some other component.  


