### PR TITLE
Minor fixes for Pedia regarding Imperial Stockpile

### DIFF
--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -5090,7 +5090,7 @@ Industry
 METER_INDUSTRY_VALUE_DESC
 '''Industry represents the production and modification of physical goods. It is needed to produce buildings, space ships and other projects.
 
-The Industry of a planet can be used for any production projects of [[metertype METER_SUPPLY]] line connected planets. Any un-allocated Industry is lost each turn.
+The Industry of a planet can be used for any production projects of [[metertype METER_SUPPLY]] line connected planets. Any un-allocated Industry is converted via the [[metertype METER_IMPERIAL_PP_TRANSFER_EFFICIENCY]] and added to the Imperial Stockpile.
 
 For information on the interface, see [[encyclopedia PRODUCTION_WINDOW_ARTICLE_TITLE]].
 '''

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -5108,7 +5108,7 @@ Technologies [[tech PRO_GENERIC_SUPPLIES]] and [[tech PRO_INTERSTELLAR_ENTANGLEM
 METER_IMPERIAL_PP_USE_LIMIT_VALUE_LABEL
 Imperial Stockpile Use Limit
 
-METER_IMPERIAL_PP_USE_LIMIT_VALUE
+METER_IMPERIAL_PP_USE_LIMIT_VALUE_DESC
 '''The Imperial Stockpile Use Limit represents the readyness of the imperial stockpile service to supply projects with production points.
 It gives the number of production points which may be taken per turn from the imperial stockpile to produce. 
 

--- a/default/stringtables/fr.txt
+++ b/default/stringtables/fr.txt
@@ -5108,7 +5108,7 @@ La technologie [[tech PRO_TRANS_DESIGN]] ajoute jusqu'à 0.3 de ratio. Par cons�
 METER_IMPERIAL_PP_USE_LIMIT_VALUE_LABEL
 Limite d'usage du Stock Impérial
 
-METER_IMPERIAL_PP_USE_LIMIT_VALUE
+METER_IMPERIAL_PP_USE_LIMIT_VALUE_DESC
 '''La Limite d'usage du Stock Impérial représente la compétence quantitative du Stock Impérial à approvisionner les projets avec des points de production.
 Sa valeur correspond au nombre de PP pouvant être puisés à chaque tour dans le Stock Impérial et alloués à la production. 
 

--- a/default/stringtables/fr.txt
+++ b/default/stringtables/fr.txt
@@ -5090,7 +5090,7 @@ Industrie
 METER_INDUSTRY_VALUE_DESC
 '''L'Industrie, mesurée en Points de Production (PP), représente la capacité de production et de transformation de biens matériels de l'ensemble des planètes de l'empire. Elle est nécessaire pour la construction des structures, des astronefs et tout autre projet.
 
-L'Industrie d'une planète peut participer à tout projet lancé sur les planètes qui lui sont reliées par lignes d'[[metertype METER_SUPPLY]] de l'empire. L'Industrie qui n'est affectée à aucun projet durant un tour est perdue (production gaspillée).
+L'Industrie d'une planète peut participer à tout projet lancé sur les planètes qui lui sont reliées par lignes d'[[metertype METER_SUPPLY]] de l'empire. L'Industrie qui n'est affectée à aucun projet durant un tour est convertie selon le [[metertype METER_IMPERIAL_PP_TRANSFER_EFFICIENCY]] et ajoutée au Stock Impérial.
 
 Pour davantage d'informations sur l'interface de Production, consultez l'article [[encyclopedia PRODUCTION_WINDOW_ARTICLE_TITLE]].
 '''


### PR DESCRIPTION
Fixes a typo that stopped the Imperial PP Use Limit article from displaying and alters the Industry article to account for new Stockpile mechanic.