### PR TITLE
Add missing line to laenfa file

### DIFF
--- a/default/scripting/species/SP_LAENFA.focs.txt
+++ b/default/scripting/species/SP_LAENFA.focs.txt
@@ -34,6 +34,7 @@ Species
         [[AVERAGE_PLANETARY_SHIELDS]]
         [[AVERAGE_PLANETARY_DEFENSE]]
         [[LARGE_PLANET]]
+        [[BROAD_EP]]		
         [[STANDARD_SHIP_SHIELDS]]
     ]
 


### PR DESCRIPTION
A line was missing, which caused the pedia not to display Laenfa's broad tolerance.