### PR TITLE
Fix bug in Empire.cpp location condition evaluated without context.

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -704,7 +704,8 @@ bool ProductionQueue::ProductionItem::EnqueueConditionPassedAt(int location_id) 
             const Condition::ConditionBase* c = bt->EnqueueLocation();
             if (!c)
                 return true;
-            return c->Eval(location_obj);
+            ScriptingContext context(location_obj);
+            return c->Eval(context, location_obj);
         }
         return true;
         break;


### PR DESCRIPTION
This was causing errors of the form:
"FollowReference : top level object Source not defined in scripting context",
when right clicking on some items in the ProductionQueue when trying to evaluate the location condition.