### PR TITLE
Remove duplicate supply considerations in InvasionAI

### DIFF
--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -29,7 +29,6 @@ empire_shipyards = {}
 available_growth_specials = {}
 active_growth_specials = {}
 empire_metabolisms = {}
-annexable_system_ids = set()
 planet_supply_cache = {}  # includes system supply
 all_colony_opportunities = {}
 
@@ -201,36 +200,7 @@ def get_supply_tech_range():
     return sum(_range for _tech, _range in AIDependencies.supply_range_techs.iteritems() if tech_is_complete(_tech))
 
 
-def check_supply():
-    print "\n", 10 * "=", "Supply calculations", 10 * "=", "\n"
-    empire = fo.getEmpire()
-
-    colonization_timer.start('Getting Empire Supply Info')
-    print "Base Supply:", dict_from_map(empire.systemSupplyRanges)
-    for i in range(-3, 1):
-        print "Systems %d jumps away from supply:", ', '.join(
-                PlanetUtilsAI.sys_name_ids(state.get_systems_by_supply_tier(i)))
-
-    colonization_timer.start('Determining Annexable Systems')
-    annexable_system_ids.clear()  # TODO: distinguish colony-annexable systems and outpost-annexable systems
-
-    supply_distance = get_supply_tech_range()
-    # extra potential supply contributions:
-    # 3 for up to Ultimate supply species
-    # 2 for possible tiny planets
-    # 1 for World Tree
-    # TODO: +3 to consider capturing planets with Elevators
-    # TODO consider that this should not be more then maximal value in empire.systemSupplyRanges
-    supply_distance += 6  # should not be more than max value in supplyProjections
-
-    # we should not rely on constant here, for system, supply in supplyProjections need to add systems in supply range
-    for jumps in range(-supply_distance, 1):  # [-supply_distance, ..., -2, -1, 0]
-        annexable_system_ids.update(state.get_systems_by_supply_tier(jumps))
-    colonization_timer.stop()
-
-
 def survey_universe():
-    check_supply()
     colonization_timer.start("Categorizing Visible Planets")
     universe = fo.getUniverse()
     empire_id = fo.empireID()

--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -432,24 +432,10 @@ def evaluate_invasion_planet(planet_id, secure_fleet_missions, verbose=True):
                " - sysMonsterThreat: %.1f") % (
             planet, planet.currentMeterValue(fo.meterType.maxShield), system_fleet_treat,
             system_monster_threat)
-    supply_val = 0
     enemy_val = 0
     if planet.owner != -1:  # value in taking this away from an enemy
         enemy_val = 20 * (planet.currentMeterValue(fo.meterType.targetIndustry) +
                           2*planet.currentMeterValue(fo.meterType.targetResearch))
-    if system_id in ColonisationAI.annexable_system_ids:  # TODO: extend to rings
-        supply_val = 100
-    elif system_id in state.get_systems_by_supply_tier(-1):
-        supply_val = 200
-    elif system_id in state.get_systems_by_supply_tier(-2):
-        supply_val = 300
-    elif system_id in state.get_systems_by_supply_tier(-3):
-        supply_val = 400
-    if max_path_threat > 0.5 * mil_ship_rating:
-        if max_path_threat < 3 * mil_ship_rating:
-            supply_val *= 0.5
-        else:
-            supply_val *= 0.2
 
     # devalue invasions that would require too much military force
     threat_factor = min(1, 0.2*MilitaryAI.get_tot_mil_rating()/(sys_total_threat+0.001))**2
@@ -479,7 +465,7 @@ def evaluate_invasion_planet(planet_id, secure_fleet_missions, verbose=True):
     normalized_cost = max(1., normalized_cost)
     cost_score = (normalized_cost**2 / 50.0) * troop_cost
 
-    base_score = colony_base_value + supply_val + bld_tally + tech_tally + enemy_val - cost_score
+    base_score = colony_base_value + bld_tally + tech_tally + enemy_val - cost_score
     planet_score = retaliation_risk_factor(planet.owner) * threat_factor * max(0, base_score)
     if clear_path:
         planet_score *= 1.5
@@ -490,10 +476,9 @@ def evaluate_invasion_planet(planet_id, secure_fleet_missions, verbose=True):
                ' - threat factor: %s\n'
                ' - planet detail: %s\n'
                ' - popval: %.1f\n'
-               ' - supplyval: %.1f\n'
                ' - bldval: %s\n'
                ' - enemyval: %s') % (planet_score, planned_troops, troop_cost,
-                                     threat_factor, detail, colony_base_value, supply_val, bld_tally, enemy_val)
+                                     threat_factor, detail, colony_base_value, bld_tally, enemy_val)
     return [planet_score, planned_troops]
 
 


### PR DESCRIPTION
Resolves #1793.

The supply considerations in InvasionAI are meaningless: Pretty much any system will be in annexable systems - every planet will get the same bonus score.

As far as the general thought is concerned: The relevant ColonizationAI functions already deal with the actual supply rather than some arbitrary guesstimation which happens in annexable_system_ids.

In consequence, the outdated code may be dropped.