### PR TITLE
Ignore EndGame and Disconnection events in IntroMenu

### DIFF
--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -156,6 +156,16 @@ boost::statechart::result IntroMenu::react(const StartQuittingGame& e) {
     return transit<QuittingGame>();
 }
 
+boost::statechart::result IntroMenu::react(const EndGame&) {
+    TraceLogger(FSM) << "(HumanClientFSM) IntroMenu ignoring EndGame.";
+    return discard_event();
+}
+
+boost::statechart::result IntroMenu::react(const Disconnection&) {
+    TraceLogger(FSM) << "(HumanClientFSM) IntroMenu ignoring disconnection.";
+    return discard_event();
+}
+
 
 ////////////////////////////////////////////////////////////
 // WaitingForSPHostAck

--- a/client/human/HumanClientFSM.h
+++ b/client/human/HumanClientFSM.h
@@ -109,7 +109,9 @@ struct IntroMenu : boost::statechart::state<IntroMenu, HumanClientFSM> {
         boost::statechart::custom_reaction<HostSPGameRequested>,
         boost::statechart::custom_reaction<HostMPGameRequested>,
         boost::statechart::custom_reaction<JoinMPGameRequested>,
-        boost::statechart::custom_reaction<StartQuittingGame>
+        boost::statechart::custom_reaction<StartQuittingGame>,
+        boost::statechart::custom_reaction<Disconnection>,
+        boost::statechart::custom_reaction<EndGame>
     > reactions;
 
     IntroMenu(my_context ctx);
@@ -119,6 +121,8 @@ struct IntroMenu : boost::statechart::state<IntroMenu, HumanClientFSM> {
     boost::statechart::result react(const HostMPGameRequested& a);
     boost::statechart::result react(const JoinMPGameRequested& a);
     boost::statechart::result react(const StartQuittingGame& msg);
+    boost::statechart::result react(const EndGame&);
+    boost::statechart::result react(const Disconnection&);
 
     CLIENT_ACCESSOR
 };


### PR DESCRIPTION
The events are sent by the server to all clients after the human client resigns to instruct non-host clients to return to the intro menu.  The host client will already be in the intro menu and should ignore the events.

This fixes these errors:
A EndGame event was not handled by any of these states : [9IntroMenu].  It is being ignored.
A Disconnection event was not handled by any of these states : [9IntroMenu].  It is being ignored.