### PR TITLE
Tune up the stockpile 

### DIFF
--- a/default/scripting/buildings/INTERSPECIES_ACADEMY.focs.txt
+++ b/default/scripting/buildings/INTERSPECIES_ACADEMY.focs.txt
@@ -78,7 +78,7 @@ BuildingType
             priority = [[LATE_PRIORITY]]
             effects = [
                 SetEmpireMeter empire = Source.Owner meter = "METER_IMPERIAL_PP_TRANSFER_EFFICIENCY" value = min(1.0, Value + 0.05)
-                SetEmpireMeter empire = Source.Owner meter = "METER_IMPERIAL_PP_USE_LIMIT"           value = Value + 2
+                SetEmpireMeter empire = Source.Owner meter = "METER_IMPERIAL_PP_USE_LIMIT"           value = Value + 15
             ]
         // Once per academy tell the user.
         EffectsGroup

--- a/default/scripting/techs/production/GENERIC_SUPPLIES.focs.txt
+++ b/default/scripting/techs/production/GENERIC_SUPPLIES.focs.txt
@@ -5,7 +5,7 @@ Tech
     category = "PRODUCTION_CATEGORY"
     researchcost = 20 * [[TECH_COST_MULTIPLIER]]
     researchturns = 4
-	tags = [ "PEDIA_PRODUCTION_CATEGORY" ]
+    tags = [ "PEDIA_PRODUCTION_CATEGORY" ]
     prerequisites = [
         "CON_ASYMP_MATS"
         "PRO_ROBOTIC_PROD"
@@ -14,7 +14,7 @@ Tech
         EffectsGroup
             scope = Source
             effects = [
-                SetEmpireMeter empire = Source.Owner meter = "METER_IMPERIAL_PP_USE_LIMIT"           value = Value + 3
+                SetEmpireMeter empire = Source.Owner meter = "METER_IMPERIAL_PP_USE_LIMIT"           value = Value + 7
                 SetEmpireMeter empire = Source.Owner meter = "METER_IMPERIAL_PP_TRANSFER_EFFICIENCY" value = Value + 0.2
             ]
     ]

--- a/default/scripting/techs/production/INTERSTELLAR_ENTANGLEMENT_FACTORY.focs.txt
+++ b/default/scripting/techs/production/INTERSTELLAR_ENTANGLEMENT_FACTORY.focs.txt
@@ -5,7 +5,7 @@ Tech
     category = "PRODUCTION_CATEGORY"
     researchcost = 100 * [[TECH_COST_MULTIPLIER]]
     researchturns = 5
-	tags = [ "PEDIA_PRODUCTION_CATEGORY" ]
+    tags = [ "PEDIA_PRODUCTION_CATEGORY" ]
     prerequisites = [
         "PRO_SENTIENT_AUTOMATION"
         "LRN_GRAVITONICS"
@@ -14,7 +14,7 @@ Tech
         EffectsGroup
             scope = Source
             effects = [
-                SetEmpireMeter empire = Source.Owner meter = "METER_IMPERIAL_PP_USE_LIMIT"           value = Value + 5
+                SetEmpireMeter empire = Source.Owner meter = "METER_IMPERIAL_PP_USE_LIMIT"           value = Value + 15
                 SetEmpireMeter empire = Source.Owner meter = "METER_IMPERIAL_PP_TRANSFER_EFFICIENCY" value = Value + 0.2
             ]
     ]

--- a/default/scripting/techs/production/PREDICTIVE_STOCKPILING.focs.txt
+++ b/default/scripting/techs/production/PREDICTIVE_STOCKPILING.focs.txt
@@ -12,8 +12,8 @@ Tech
             scope = Source
             priority = [[VERY_EARLY_PRIORITY]]
             effects = [
-                SetEmpireMeter empire = Source.Owner meter = "METER_IMPERIAL_PP_USE_LIMIT"           value = Value + 2
-                SetEmpireMeter empire = Source.Owner meter = "METER_IMPERIAL_PP_TRANSFER_EFFICIENCY" value = Value + 0.2
+                SetEmpireMeter empire = Source.Owner meter = "METER_IMPERIAL_PP_USE_LIMIT"           value = Value + 3
+                SetEmpireMeter empire = Source.Owner meter = "METER_IMPERIAL_PP_TRANSFER_EFFICIENCY" value = Value + 0.4
             ]
     ]
 

--- a/default/scripting/techs/production/TRANS_DESIGN.focs.txt
+++ b/default/scripting/techs/production/TRANS_DESIGN.focs.txt
@@ -5,7 +5,7 @@ Tech
     category = "PRODUCTION_CATEGORY"
     researchcost = 75 * [[TECH_COST_MULTIPLIER]]
     researchturns = 5
-	tags = [ "PEDIA_PRODUCTION_CATEGORY" ]
+    tags = [ "PEDIA_PRODUCTION_CATEGORY" ]
     prerequisites = [
         "LRN_PSIONICS"
         "CON_ARCH_PSYCH"


### PR DESCRIPTION
In the forum is the consensus that the imperial stockpile is basically worthless with the current settings.
Discussion here [http://www.freeorion.org/forum/viewtopic.php?f=28&t=10810&p=90852#p90852](url)

This PR adjusts the basic values to something actually useful. I'd  like to merge this and ask for the second round of play test feedback.

* make the currently useless imperial stockpile more useful
** better transfer ratio with early techs
** higher extraction limit with later techs
* fix tabs to spaces
```
                           cost Tu  Transfer Ratio  Use Limit
Predictive Stockpiling      0RP  1   +0.2 -> +0.4   +2 ->  +3
Generic Supplies           40RP  4       +0.2       +3 ->  +7
Transcendent Design       150RP  5      +0.00          +0
Interspecies Academy (6x)  30PP  5      +0.05       +2 -> +15
Interstellar Entangle Fac 200RP  5      +0.20       +5 -> +15
```