### PR TITLE
[codestyle] Update readme, add config

### DIFF
--- a/default/python/README.md
+++ b/default/python/README.md
@@ -28,7 +28,7 @@ We use [flake8-putty](https://pypi.python.org/pypi/flake8-putty)
 which include [flake8](https://pypi.python.org/pypi/flake8)
 which include [pycodestyle](https://pypi.python.org/pypi/pycodestyle) and other tools.
 
-`flake8-putty` is `flake8` plugin that allows to setup specific rules on certain files, see `putty-ignore` section in `tox.ini`
+`flake8-putty` is `flake8` plugin that allows one to disable rule for certain file, see `putty-ignore` section in `tox.ini`
 
 Plan is to fix all easy things (code formatting) and ignore hard things (`E722 do not use bare except`).
 Final stage is to setup automatic check to avoid adding new cases.

--- a/default/python/README.md
+++ b/default/python/README.md
@@ -24,27 +24,29 @@ planet types, planet sizes, and also other content get placed.
 
 # Code style check
 
-Code style checks are done with [pycodestyle](https://pypi.python.org/pypi/pycodestyle)
+We use [flake8-putty](https://pypi.python.org/pypi/flake8-putty)
+which include [flake8](https://pypi.python.org/pypi/flake8)
+which include [pycodestyle](https://pypi.python.org/pypi/pycodestyle) and other tools.
 
-This part is in progress.
+`flake8-putty` is `flake8` plugin that allows to setup specific rules on certain files, see `putty-ignore` section in `tox.ini`
 
 Plan is to fix all easy things (code formatting) and ignore hard things (`E722 do not use bare except`).
 Final stage is to setup automatic check to avoid adding new cases.
 
-## Why we ignore
-- `E241 multiple spaces after ':'`  this is ok only for `AIDependencies.py` because it is used as config file
-- `E501 line too long` it is ok to ignore it for `AIDependencies.py`
+## TODO section
 
-## List of check that should pass:
-`pycodestyle python/AI/AIDependencies.py --ignore=E501,E241`
-`pycodestyle python/AI/AIFleetMission.py --max-line-length=120`
-`pycodestyle python/AI/AIstate.py --max-line-length=120`
-`pycodestyle python/AI/ColonisationAI.py --max-line-length=120`
-`pycodestyle python/AI/CombatRatingsAI.py --max-line-length=120`
-`pycodestyle python/AI/DiplomaticCorp.py --max-line-length=120`
-`pycodestyle python/AI/EnumsAI.py --max-line-length=120`
-`pycodestyle python/AI/ExplorationAI.py --max-line-length=120`
-`pycodestyle python/AI/fleet_orders.py --max-line-length=120`
-`pycodestyle python/AI/FleetUtilsAI.py --max-line-length=120`
-`pycodestyle python/AI/FreeOrionAI.py --max-line-length=120 --ignore=E402,E722`
-`pycodestyle python/AI/InvasionAI.py --max-line-length=120`
+- remove all folders from excludes
+- don't ignore line length check (E501)
+
+## Install dependencies
+
+```sh
+pip install flake8-putty
+```
+
+## Run checks
+
+```sh
+cd default/python
+flake8
+```

--- a/default/python/tox.ini
+++ b/default/python/tox.ini
@@ -6,9 +6,9 @@ ignore =
     # temp ignore of the ling too long
     E501
 exclude =
+  AI/,
   auth/,
   common/,
-  handlers/,
   interface_mock/,
   tests/,
   turn_events/,

--- a/default/python/tox.ini
+++ b/default/python/tox.ini
@@ -1,0 +1,18 @@
+[flake8]
+max-line-length=120
+ignore =
+    # default pycodestyle ignores
+    E121,E123,E126,E226,E24,E704,W503,
+    # temp ignore of the ling too long
+    E501
+exclude =
+  auth/,
+  common/,
+  handlers/,
+  interface_mock/,
+  tests/,
+  turn_events/,
+  universe_generation/
+putty-ignore =
+  AI/AIDependencies.py : +E241,E501
+  AI/FreeOrionAI.py : +E402,E722

--- a/default/python/tox.ini
+++ b/default/python/tox.ini
@@ -3,7 +3,7 @@ max-line-length=120
 ignore =
     # default pycodestyle ignores
     E121,E123,E126,E226,E24,E704,W503,
-    # temp ignore of the ling too long
+    # temp ignore of the line too long
     E501
 exclude =
   AI/,


### PR DESCRIPTION
I finally find suitable tool to check code style and ignore some project specific errors.  

This PR does not affect code, just add config and readme. 

[Rendered readme](https://github.com/Cjkjvfnby/freeorion/tree/sa/flake8-putty-support/default/python#code-style-check)

Statistic with current config:
```
1       E111 indentation is not a multiple of four
2       E127 continuation line over-indented for visual indent
2       E128 continuation line under-indented for visual indent
6       E129 visually indented line with same indent as next logical line
1       E203 whitespace before ','
2       E261 at least two spaces before inline comment
2       E265 block comment should start with '# '
2       E271 multiple spaces after keyword
1       E302 expected 2 blank lines, found 1
1       E401 multiple imports on one line
2       E713 test for membership should be 'not in'
2       E731 do not assign a lambda expression, use a def
10      F401 'universe_object.UniverseObject' imported but unused
1       F403 'from _freeorion_tools import *' used; unable to detect undefined names
9       F812 list comprehension redefines '_' from line 179
2       F841 local variable '_' is assigned to but never used
```