### PR TITLE
Prevent Fleet::Copy() from referencing unknown systems

### DIFF
--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -1535,7 +1535,10 @@ void FleetDataPanel::Refresh() {
             add_overlay("bombarding.png");
         }
 
-        // Moving fleets can't be gifted.
+        // Moving fleets can't be gifted.  The order will be automatically
+        // cancelled on the server.  This make the UI appear to cancel the
+        // order when the ship is moved without requiring the player to
+        // re-order the gifting if the ship is stopped.
         if (fleet->OrderedGivenToEmpire() != ALL_EMPIRES && fleet->TravelRoute().empty())
             add_overlay("gifting.png");
 

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -1534,7 +1534,9 @@ void FleetDataPanel::Refresh() {
         {
             add_overlay("bombarding.png");
         }
-        if (fleet->OrderedGivenToEmpire() != ALL_EMPIRES)
+
+        // Moving fleets can't be gifted.
+        if (fleet->OrderedGivenToEmpire() != ALL_EMPIRES && fleet->TravelRoute().empty())
             add_overlay("gifting.png");
 
         if ((fleet->GetVisibility(client_empire_id) < VIS_BASIC_VISIBILITY)
@@ -3587,6 +3589,7 @@ void FleetWnd::FleetRightClicked(GG::ListBox::iterator it, const GG::Pt& pt, con
     }
 
     if (fleet->OwnedBy(client_empire_id)
+        && fleet->TravelRoute().empty()
         && !peaceful_empires_in_system.empty()
         && !ClientPlayerIsModerator())
     {

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -2654,7 +2654,9 @@ namespace {
                 continue;
             fleet->ClearGiveToEmpire(); // in case things fail, to avoid potential inconsistent state
 
-            if (fleet->Unowned() || fleet->OwnedBy(ordered_given_to_empire_id))
+            if (fleet->Unowned()
+                || fleet->OwnedBy(ordered_given_to_empire_id)
+                || !fleet->TravelRoute().empty())
             { continue; }
 
             empire_gifted_objects[ordered_given_to_empire_id].push_back(fleet);

--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -84,7 +84,7 @@ namespace {
         system not known to the \p empire_id. */
     std::list<int> TruncateRouteToEndAtSystem(const std::list<int>& full_route, int empire_id, int last_system) {
 
-        if (full_route.empty())
+        if (full_route.empty() || (last_system == INVALID_OBJECT_ID))
             return std::list<int>();
 
         auto visible_end_it = full_route.cend();

--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -162,20 +162,18 @@ void Fleet::Copy(std::shared_ptr<const UniverseObject> copied_object, int empire
             if (Unowned())
                 m_name =                  copied_fleet->m_name;
 
-            if (vis >= VIS_FULL_VISIBILITY) {
-                m_travel_route =              copied_fleet->m_travel_route;
+            // Truncate the travel route to only systems known to empire_id
+            int moving_to = (vis >= VIS_FULL_VISIBILITY
+                             ? (!copied_fleet->m_travel_route.empty()
+                                ? copied_fleet->m_travel_route.back()
+                                : INVALID_OBJECT_ID)
+                             : m_next_system);
+
+            m_travel_route = TruncateRouteToEndAtSystem(copied_fleet->m_travel_route, empire_id, moving_to);
+
+
+            if (vis >= VIS_FULL_VISIBILITY)
                 m_ordered_given_to_empire_id =copied_fleet->m_ordered_given_to_empire_id;
-
-            } else {
-                int             moving_to =         m_next_system;
-                std::list<int>  travel_route;
-
-                if (!copied_fleet->m_travel_route.empty() && moving_to != INVALID_OBJECT_ID)
-                    travel_route.push_back(moving_to);
-                travel_route = TruncateRouteToEndAtSystem(travel_route, empire_id, moving_to);
-
-                m_travel_route = travel_route;
-            }
         }
     }
 }

--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -98,7 +98,12 @@ namespace {
             ++visible_end_it;
         }
 
-        // remove any extra systems from the route after the apparent destination
+        // Remove any extra systems from the route after the apparent destination.
+        // SystemHasNoVisibleStarlanes determines if empire_id knows about the
+        // system and/or its starlanes.  It is enforced on the server in the
+        // visibility calculations that an owning empire knows about a) the
+        // system containing a fleet, b) the starlane on which a fleet is travelling
+        // and c) both systems terminating a starlane on which a fleet is travelling.
         auto end_it = std::find_if(full_route.begin(), visible_end_it,
                                    boost::bind(&SystemHasNoVisibleStarlanes, _1, empire_id));
 

--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -122,8 +122,12 @@ void Fleet::Copy(std::shared_ptr<const UniverseObject> copied_object, int empire
     if (vis >= VIS_BASIC_VISIBILITY) {
         m_ships =                         copied_fleet->VisibleContainedObjectIDs(empire_id);
 
-        m_next_system =                   copied_fleet->m_next_system;
-        m_prev_system =                   copied_fleet->m_prev_system;
+        m_next_system = ((GetUniverse().GetObjectVisibilityByEmpire(copied_fleet->m_next_system, empire_id)
+                          >= VIS_BASIC_VISIBILITY)
+                         ? copied_fleet->m_next_system : INVALID_OBJECT_ID);
+        m_prev_system = ((GetUniverse().GetObjectVisibilityByEmpire(copied_fleet->m_prev_system, empire_id)
+                          >= VIS_BASIC_VISIBILITY)
+                         ? copied_fleet->m_prev_system : INVALID_OBJECT_ID);
         m_arrived_this_turn =             copied_fleet->m_arrived_this_turn;
         m_arrival_starlane =              copied_fleet->m_arrival_starlane;
 
@@ -138,7 +142,7 @@ void Fleet::Copy(std::shared_ptr<const UniverseObject> copied_object, int empire
                 m_ordered_given_to_empire_id =copied_fleet->m_ordered_given_to_empire_id;
 
             } else {
-                int             moving_to =         copied_fleet->m_next_system;
+                int             moving_to =         m_next_system;
                 std::list<int>  travel_route;
                 double          travel_distance =   copied_fleet->m_travel_distance;
 
@@ -148,6 +152,7 @@ void Fleet::Copy(std::shared_ptr<const UniverseObject> copied_object, int empire
                 if (!copied_fleet->m_travel_route.empty())
                     m_travel_route.push_back(moving_to);
                 ShortenRouteToEndAtSystem(travel_route, moving_to);
+
                 if (!travel_route.empty()
                     && travel_route.front() != INVALID_OBJECT_ID
                     && travel_route.size() != copied_fleet_route.size())

--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -122,11 +122,9 @@ void Fleet::Copy(std::shared_ptr<const UniverseObject> copied_object, int empire
     if (vis >= VIS_BASIC_VISIBILITY) {
         m_ships =                         copied_fleet->VisibleContainedObjectIDs(empire_id);
 
-        m_next_system = ((GetUniverse().GetObjectVisibilityByEmpire(copied_fleet->m_next_system, empire_id)
-                          >= VIS_BASIC_VISIBILITY)
+        m_next_system = ((GetEmpireKnownSystem(copied_fleet->m_next_system, empire_id))
                          ? copied_fleet->m_next_system : INVALID_OBJECT_ID);
-        m_prev_system = ((GetUniverse().GetObjectVisibilityByEmpire(copied_fleet->m_prev_system, empire_id)
-                          >= VIS_BASIC_VISIBILITY)
+        m_prev_system = ((GetEmpireKnownSystem(copied_fleet->m_prev_system, empire_id))
                          ? copied_fleet->m_prev_system : INVALID_OBJECT_ID);
         m_arrived_this_turn =             copied_fleet->m_arrived_this_turn;
         m_arrival_starlane =              copied_fleet->m_arrival_starlane;
@@ -149,7 +147,7 @@ void Fleet::Copy(std::shared_ptr<const UniverseObject> copied_object, int empire
                 const std::list<int>& copied_fleet_route = copied_fleet->m_travel_route;
 
                 m_travel_route.clear();
-                if (!copied_fleet->m_travel_route.empty())
+                if (!copied_fleet->m_travel_route.empty() && moving_to != INVALID_OBJECT_ID)
                     m_travel_route.push_back(moving_to);
                 ShortenRouteToEndAtSystem(travel_route, moving_to);
 

--- a/universe/Fleet.h
+++ b/universe/Fleet.h
@@ -178,7 +178,6 @@ private:
       * unknown.  The list may also be empty, which indicates that the fleet
       * is not planning to move. */
     std::list<int>              m_travel_route;
-    mutable double              m_travel_distance = 0.0;
 
     bool                        m_arrived_this_turn = false;
     int                         m_arrival_starlane = INVALID_OBJECT_ID; // see comment for ArrivalStarlane()
@@ -187,7 +186,5 @@ private:
     template <class Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
-
-BOOST_CLASS_VERSION(Fleet, 2)
 
 #endif // _Fleet_h_

--- a/universe/Fleet.h
+++ b/universe/Fleet.h
@@ -160,9 +160,6 @@ protected:
     //@}
 
 private:
-    ///< removes any systems on the route after the specified system
-    void                    ShortenRouteToEndAtSystem(std::list<int>& travel_route, int last_system);
-
     std::set<int>               m_ships;
 
     // these two uniquely describe the starlane graph edge the fleet is on, if it it's on one

--- a/util/SerializeUniverse.cpp
+++ b/util/SerializeUniverse.cpp
@@ -22,6 +22,7 @@ BOOST_CLASS_EXPORT(Field)
 BOOST_CLASS_EXPORT(Planet)
 BOOST_CLASS_EXPORT(Building)
 BOOST_CLASS_EXPORT(Fleet)
+BOOST_CLASS_VERSION(Fleet, 3)
 BOOST_CLASS_EXPORT(Ship)
 BOOST_CLASS_VERSION(Ship, 2)
 BOOST_CLASS_EXPORT(ShipDesign)
@@ -250,9 +251,12 @@ void Fleet::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_next_system)
         & BOOST_SERIALIZATION_NVP(m_aggressive)
         & BOOST_SERIALIZATION_NVP(m_ordered_given_to_empire_id)
-        & BOOST_SERIALIZATION_NVP(m_travel_route)
-        & BOOST_SERIALIZATION_NVP(m_travel_distance)
-        & BOOST_SERIALIZATION_NVP(m_arrived_this_turn)
+        & BOOST_SERIALIZATION_NVP(m_travel_route);
+    if (version < 3) {
+        double dummy_travel_distance;
+        ar & boost::serialization::make_nvp("m_travel_distance", dummy_travel_distance);
+    }
+    ar  & BOOST_SERIALIZATION_NVP(m_arrived_this_turn)
         & BOOST_SERIALIZATION_NVP(m_arrival_starlane);
 }
 


### PR DESCRIPTION
This PR prevents `Fleet::Copy()` from copying `m_next_system` and `m_prev_system` when the system is not visible to the referenced empire.

This was creating an error in the human client when it tried to follow a path to an invisible `m_next_system`