### PR TITLE
Change g_indent into ntabs parameter of Dump(unsigned int ntabs)

### DIFF
--- a/universe/Building.cpp
+++ b/universe/Building.cpp
@@ -204,58 +204,46 @@ void BuildingType::Init() {
 
 std::string BuildingType::Dump(unsigned short ntabs) const {
     std::string retval = DumpIndent(ntabs) + "BuildingType\n";
-    ++ntabs;
-    retval += DumpIndent(ntabs) + "name = \"" + m_name + "\"\n";
-    retval += DumpIndent(ntabs) + "description = \"" + m_description + "\"\n";
+    retval += DumpIndent(ntabs+1) + "name = \"" + m_name + "\"\n";
+    retval += DumpIndent(ntabs+1) + "description = \"" + m_description + "\"\n";
     if (m_production_cost)
-        retval += DumpIndent(ntabs) + "buildcost = " + m_production_cost->Dump(ntabs) + "\n";
+        retval += DumpIndent(ntabs+1) + "buildcost = " + m_production_cost->Dump(ntabs+1) + "\n";
     if (m_production_time)
-        retval += DumpIndent(ntabs) + "buildtime = " + m_production_time->Dump(ntabs) + "\n";
-    retval += DumpIndent(ntabs) + (m_producible ? "Producible" : "Unproducible") + "\n";
-    retval += DumpIndent(ntabs) + "captureresult = " +
+        retval += DumpIndent(ntabs+1) + "buildtime = " + m_production_time->Dump(ntabs+1) + "\n";
+    retval += DumpIndent(ntabs+1) + (m_producible ? "Producible" : "Unproducible") + "\n";
+    retval += DumpIndent(ntabs+1) + "captureresult = " +
         boost::lexical_cast<std::string>(m_capture_result) + "\n";
 
     if (!m_tags.empty()) {
         if (m_tags.size() == 1) {
-            retval += DumpIndent(ntabs) + "tags = \"" + *m_tags.begin() + "\"\n";
+            retval += DumpIndent(ntabs+1) + "tags = \"" + *m_tags.begin() + "\"\n";
         } else {
-            retval += DumpIndent(ntabs) + "tags = [ ";
-            for (const std::string& tag : m_tags) {
+            retval += DumpIndent(ntabs+1) + "tags = [ ";
+            for (const std::string& tag : m_tags)
                retval += "\"" + tag + "\" ";
-            }
             retval += " ]\n";
         }
     }
 
     if (m_location) {
-        retval += DumpIndent(ntabs) + "location = \n";
-        ++ntabs;
-            retval += m_location->Dump(ntabs);
-        --ntabs;
+        retval += DumpIndent(ntabs+1) + "location = \n";
+        retval += m_location->Dump(ntabs+2);
     }
     if (m_enqueue_location) {
-        retval += DumpIndent(ntabs) + "enqueue location = \n";
-        ++ntabs;
-            retval += m_enqueue_location->Dump(ntabs);
-        --ntabs;
+        retval += DumpIndent(ntabs+1) + "enqueue location = \n";
+        retval += m_enqueue_location->Dump(ntabs+2);
     }
 
     if (m_effects.size() == 1) {
-        retval += DumpIndent(ntabs) + "effectsgroups =\n";
-        ++ntabs;
-        retval += m_effects[0]->Dump(ntabs);
-        --ntabs;
+        retval += DumpIndent(ntabs+1) + "effectsgroups =\n";
+        retval += m_effects[0]->Dump(ntabs+2);
     } else {
-        retval += DumpIndent(ntabs) + "effectsgroups = [\n";
-        ++ntabs;
-        for (auto& effect : m_effects) {
-            retval += effect->Dump(ntabs);
-        }
-        --ntabs;
-        retval += DumpIndent(ntabs) + "]\n";
+        retval += DumpIndent(ntabs+1) + "effectsgroups = [\n";
+        for (auto& effect : m_effects)
+            retval += effect->Dump(ntabs+2);
+        retval += DumpIndent(ntabs+1) + "]\n";
     }
-    retval += DumpIndent(ntabs) + "icon = \"" + m_icon + "\"\n";
-    --ntabs;
+    retval += DumpIndent(ntabs+1) + "icon = \"" + m_icon + "\"\n";
     return retval;
 }
 

--- a/universe/Building.cpp
+++ b/universe/Building.cpp
@@ -117,12 +117,12 @@ bool Building::ContainedBy(int object_id) const {
             ||  object_id == this->SystemID());
 }
 
-std::string Building::Dump() const {
+std::string Building::Dump(unsigned short ntabs) const {
     std::stringstream os;
-    os << UniverseObject::Dump();
+    os << UniverseObject::Dump(ntabs);
     os << " building type: " << m_building_type
        << " produced by empire id: " << m_produced_by_empire_id
-       << " \n characteristics " << GetBuildingType(m_building_type)->Dump();
+       << " \n characteristics " << GetBuildingType(m_building_type)->Dump(ntabs);
     return os.str();
 }
 
@@ -202,24 +202,24 @@ void BuildingType::Init() {
     }
 }
 
-std::string BuildingType::Dump() const {
-    std::string retval = DumpIndent() + "BuildingType\n";
-    ++g_indent;
-    retval += DumpIndent() + "name = \"" + m_name + "\"\n";
-    retval += DumpIndent() + "description = \"" + m_description + "\"\n";
+std::string BuildingType::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "BuildingType\n";
+    ++ntabs;
+    retval += DumpIndent(ntabs) + "name = \"" + m_name + "\"\n";
+    retval += DumpIndent(ntabs) + "description = \"" + m_description + "\"\n";
     if (m_production_cost)
-        retval += DumpIndent() + "buildcost = " + m_production_cost->Dump() + "\n";
+        retval += DumpIndent(ntabs) + "buildcost = " + m_production_cost->Dump(ntabs) + "\n";
     if (m_production_time)
-        retval += DumpIndent() + "buildtime = " + m_production_time->Dump() + "\n";
-    retval += DumpIndent() + (m_producible ? "Producible" : "Unproducible") + "\n";
-    retval += DumpIndent() + "captureresult = " +
+        retval += DumpIndent(ntabs) + "buildtime = " + m_production_time->Dump(ntabs) + "\n";
+    retval += DumpIndent(ntabs) + (m_producible ? "Producible" : "Unproducible") + "\n";
+    retval += DumpIndent(ntabs) + "captureresult = " +
         boost::lexical_cast<std::string>(m_capture_result) + "\n";
 
     if (!m_tags.empty()) {
         if (m_tags.size() == 1) {
-            retval += DumpIndent() + "tags = \"" + *m_tags.begin() + "\"\n";
+            retval += DumpIndent(ntabs) + "tags = \"" + *m_tags.begin() + "\"\n";
         } else {
-            retval += DumpIndent() + "tags = [ ";
+            retval += DumpIndent(ntabs) + "tags = [ ";
             for (const std::string& tag : m_tags) {
                retval += "\"" + tag + "\" ";
             }
@@ -228,34 +228,34 @@ std::string BuildingType::Dump() const {
     }
 
     if (m_location) {
-        retval += DumpIndent() + "location = \n";
-        ++g_indent;
-            retval += m_location->Dump();
-        --g_indent;
+        retval += DumpIndent(ntabs) + "location = \n";
+        ++ntabs;
+            retval += m_location->Dump(ntabs);
+        --ntabs;
     }
     if (m_enqueue_location) {
-        retval += DumpIndent() + "enqueue location = \n";
-        ++g_indent;
-            retval += m_enqueue_location->Dump();
-        --g_indent;
+        retval += DumpIndent(ntabs) + "enqueue location = \n";
+        ++ntabs;
+            retval += m_enqueue_location->Dump(ntabs);
+        --ntabs;
     }
 
     if (m_effects.size() == 1) {
-        retval += DumpIndent() + "effectsgroups =\n";
-        ++g_indent;
-        retval += m_effects[0]->Dump();
-        --g_indent;
+        retval += DumpIndent(ntabs) + "effectsgroups =\n";
+        ++ntabs;
+        retval += m_effects[0]->Dump(ntabs);
+        --ntabs;
     } else {
-        retval += DumpIndent() + "effectsgroups = [\n";
-        ++g_indent;
+        retval += DumpIndent(ntabs) + "effectsgroups = [\n";
+        ++ntabs;
         for (auto& effect : m_effects) {
-            retval += effect->Dump();
+            retval += effect->Dump(ntabs);
         }
-        --g_indent;
-        retval += DumpIndent() + "]\n";
+        --ntabs;
+        retval += DumpIndent(ntabs) + "]\n";
     }
-    retval += DumpIndent() + "icon = \"" + m_icon + "\"\n";
-    --g_indent;
+    retval += DumpIndent(ntabs) + "icon = \"" + m_icon + "\"\n";
+    --ntabs;
     return retval;
 }
 

--- a/universe/Building.h
+++ b/universe/Building.h
@@ -29,7 +29,7 @@ public:
 
     UniverseObjectType ObjectType() const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     int ContainerObjectID() const override
     { return m_planet_id; }
@@ -109,7 +109,7 @@ public:
     /** \name Accessors */ //@{
     const std::string&              Name() const            { return m_name; }              ///< returns the unique name for this type of building
     const std::string&              Description() const     { return m_description; }       ///< returns a text description of this type of building
-    std::string                     Dump() const;                                           ///< returns a data file format representation of this object
+    std::string                     Dump(unsigned short ntabs = 0) const;                                           ///< returns a data file format representation of this object
 
     bool                            ProductionCostTimeLocationInvariant() const;            ///< returns true if the production cost and time are invariant (does not depend on) the location
     float                           ProductionCost(int empire_id, int location_id) const;   ///< returns the number of production points required to build this building at this location by this empire

--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -363,9 +363,7 @@ std::string Number::Dump(unsigned short ntabs) const {
     if (m_high)
         retval += " high = " + m_high->Dump(ntabs);
     retval += " condition =\n";
-    ++ntabs;
-        retval += m_condition->Dump(ntabs);
-    --ntabs;
+    retval += m_condition->Dump(ntabs+1);
     return retval;
 }
 
@@ -1015,9 +1013,7 @@ std::string SortedNumberOf::Dump(unsigned short ntabs) const {
          retval += " sortby = " + m_sort_key->Dump(ntabs);
 
     retval += " condition =\n";
-    ++ntabs;
-        retval += m_condition->Dump(ntabs);
-    --ntabs;
+    retval += m_condition->Dump(ntabs+1);
 
     return retval;
 }
@@ -2889,9 +2885,7 @@ std::string Contains::Description(bool negated/* = false*/) const {
 
 std::string Contains::Dump(unsigned short ntabs) const {
     std::string retval = DumpIndent(ntabs) + "Contains condition =\n";
-    ++ntabs;
-    retval += m_condition->Dump(ntabs);
-    --ntabs;
+    retval += m_condition->Dump(ntabs+1);
     return retval;
 }
 
@@ -3108,9 +3102,7 @@ std::string ContainedBy::Description(bool negated/* = false*/) const {
 
 std::string ContainedBy::Dump(unsigned short ntabs) const {
     std::string retval = DumpIndent(ntabs) + "ContainedBy condition =\n";
-    ++ntabs;
-        retval += m_condition->Dump(ntabs);
-    --ntabs;
+    retval += m_condition->Dump(ntabs+1);
     return retval;
 }
 
@@ -7349,9 +7341,7 @@ std::string WithinDistance::Description(bool negated/* = false*/) const {
 
 std::string WithinDistance::Dump(unsigned short ntabs) const {
     std::string retval = DumpIndent(ntabs) + "WithinDistance distance = " + m_distance->Dump(ntabs) + " condition =\n";
-    ++ntabs;
-    retval += m_condition->Dump(ntabs);
-    --ntabs;
+    retval += m_condition->Dump(ntabs+1);
     return retval;
 }
 
@@ -7460,9 +7450,7 @@ std::string WithinStarlaneJumps::Description(bool negated/* = false*/) const {
 
 std::string WithinStarlaneJumps::Dump(unsigned short ntabs) const {
     std::string retval = DumpIndent(ntabs) + "WithinStarlaneJumps jumps = " + m_jumps->Dump(ntabs) + " condition =\n";
-    ++ntabs;
-    retval += m_condition->Dump(ntabs);
-    --ntabs;
+    retval += m_condition->Dump(ntabs+1);
     return retval;
 }
 
@@ -7922,9 +7910,7 @@ std::string CanAddStarlaneConnection::Description(bool negated/* = false*/) cons
 
 std::string CanAddStarlaneConnection::Dump(unsigned short ntabs) const {
     std::string retval = DumpIndent(ntabs) + "CanAddStarlanesTo condition =\n";
-    ++ntabs;
-        retval += m_condition->Dump(ntabs);
-    --ntabs;
+    retval += m_condition->Dump(ntabs+1);
     return retval;
 }
 
@@ -8439,11 +8425,9 @@ std::string ResourceSupplyConnectedByEmpire::Description(bool negated/* = false*
 }
 
 std::string ResourceSupplyConnectedByEmpire::Dump(unsigned short ntabs) const {
-    std::string retval = DumpIndent(ntabs) + "ResourceSupplyConnectedBy empire_id = " + m_empire_id->Dump(ntabs) +
-                                        " condition = \n";
-    ++ntabs;
-    retval += m_condition->Dump(ntabs);
-    --ntabs;
+    std::string retval = DumpIndent(ntabs) + "ResourceSupplyConnectedBy empire_id = "
+        + m_empire_id->Dump(ntabs) + " condition = \n";
+    retval += m_condition->Dump(ntabs+1);
     return retval;
 }
 
@@ -9491,11 +9475,8 @@ std::string And::Description(bool negated/* = false*/) const {
 
 std::string And::Dump(unsigned short ntabs) const {
     std::string retval = DumpIndent(ntabs) + "And [\n";
-    ++ntabs;
-    for (auto& operand : m_operands) {
-        retval += operand->Dump(ntabs);
-    }
-    --ntabs;
+    for (auto& operand : m_operands)
+        retval += operand->Dump(ntabs+1);
     retval += DumpIndent(ntabs) + "]\n";
     return retval;
 }
@@ -9671,11 +9652,8 @@ std::string Or::Description(bool negated/* = false*/) const {
 
 std::string Or::Dump(unsigned short ntabs) const {
     std::string retval = DumpIndent(ntabs) + "Or [\n";
-    ++ntabs;
-    for (auto& operand : m_operands) {
-        retval += operand->Dump(ntabs);
-    }
-    --ntabs;
+    for (auto& operand : m_operands)
+        retval += operand->Dump(ntabs+1);
     retval += "\n" + DumpIndent(ntabs) + "]\n";
     return retval;
 }
@@ -9768,9 +9746,7 @@ std::string Not::Description(bool negated/* = false*/) const
 
 std::string Not::Dump(unsigned short ntabs) const {
     std::string retval = DumpIndent(ntabs) + "Not\n";
-    ++ntabs;
-    retval += m_operand->Dump(ntabs);
-    --ntabs;
+    retval += m_operand->Dump(ntabs+1);
     return retval;
 }
 

--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -28,7 +28,6 @@
 
 using boost::io::str;
 
-extern int g_indent;
 FO_COMMON_API extern const int INVALID_DESIGN_ID;
 
 bool UserStringExists(const std::string& str);
@@ -303,7 +302,7 @@ void ConditionBase::GetDefaultInitialCandidateObjects(const ScriptingContext& pa
 std::string ConditionBase::Description(bool negated/* = false*/) const
 { return ""; }
 
-std::string ConditionBase::Dump() const
+std::string ConditionBase::Dump(unsigned short ntabs) const
 { return ""; }
 
 bool ConditionBase::Match(const ScriptingContext& local_context) const
@@ -357,16 +356,16 @@ std::string Number::Description(bool negated/* = false*/) const {
                % m_condition->Description());
 }
 
-std::string Number::Dump() const {
-    std::string retval = DumpIndent() + "Number";
+std::string Number::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "Number";
     if (m_low)
-        retval += " low = " + m_low->Dump();
+        retval += " low = " + m_low->Dump(ntabs);
     if (m_high)
-        retval += " high = " + m_high->Dump();
+        retval += " high = " + m_high->Dump(ntabs);
     retval += " condition =\n";
-    ++g_indent;
-        retval += m_condition->Dump();
-    --g_indent;
+    ++ntabs;
+        retval += m_condition->Dump(ntabs);
+    --ntabs;
     return retval;
 }
 
@@ -603,12 +602,12 @@ std::string Turn::Description(bool negated/* = false*/) const {
     }
 }
 
-std::string Turn::Dump() const {
-    std::string retval = DumpIndent() + "Turn";
+std::string Turn::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "Turn";
     if (m_low)
-        retval += " low = " + m_low->Dump();
+        retval += " low = " + m_low->Dump(ntabs);
     if (m_high)
-        retval += " high = " + m_high->Dump();
+        retval += " high = " + m_high->Dump(ntabs);
     retval += "\n";
     return retval;
 }
@@ -995,8 +994,8 @@ std::string SortedNumberOf::Description(bool negated/* = false*/) const {
     }
 }
 
-std::string SortedNumberOf::Dump() const {
-    std::string retval = DumpIndent();
+std::string SortedNumberOf::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs);
     switch (m_sorting_method) {
     case SORT_RANDOM:
         retval += "NumberOf";   break;
@@ -1010,15 +1009,15 @@ std::string SortedNumberOf::Dump() const {
         retval += "??NumberOf??"; break;
     }
 
-    retval += " number = " + m_number->Dump();
+    retval += " number = " + m_number->Dump(ntabs);
 
     if (m_sort_key)
-         retval += " sortby = " + m_sort_key->Dump();
+         retval += " sortby = " + m_sort_key->Dump(ntabs);
 
     retval += " condition =\n";
-    ++g_indent;
-        retval += m_condition->Dump();
-    --g_indent;
+    ++ntabs;
+        retval += m_condition->Dump(ntabs);
+    --ntabs;
 
     return retval;
 }
@@ -1080,8 +1079,8 @@ std::string All::Description(bool negated/* = false*/) const {
         : UserString("DESC_ALL_NOT");
 }
 
-std::string All::Dump() const
-{ return DumpIndent() + "All\n"; }
+std::string All::Dump(unsigned short ntabs) const
+{ return DumpIndent(ntabs) + "All\n"; }
 
 unsigned int All::GetCheckSum() const {
     unsigned int retval{0};
@@ -1116,8 +1115,8 @@ std::string None::Description(bool negated/* = false*/) const {
         : UserString("DESC_NONE_NOT");
 }
 
-std::string None::Dump() const
-{ return DumpIndent() + "None\n"; }
+std::string None::Dump(unsigned short ntabs) const
+{ return DumpIndent(ntabs) + "None\n"; }
 
 unsigned int None::GetCheckSum() const {
     unsigned int retval{0};
@@ -1296,12 +1295,12 @@ std::string EmpireAffiliation::Description(bool negated/* = false*/) const {
     }
 }
 
-std::string EmpireAffiliation::Dump() const {
-    std::string retval = DumpIndent();
+std::string EmpireAffiliation::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs);
     if (m_affiliation == AFFIL_SELF) {
         retval += "OwnedBy";
         if (m_empire_id)
-            retval += " empire = " + m_empire_id->Dump();
+            retval += " empire = " + m_empire_id->Dump(ntabs);
 
     } else if (m_affiliation == AFFIL_ANY) {
         retval += "OwnedBy affiliation = AnyEmpire";
@@ -1312,12 +1311,12 @@ std::string EmpireAffiliation::Dump() const {
     } else if (m_affiliation == AFFIL_ENEMY) {
         retval += "OwnedBy affilition = EnemyOf";
         if (m_empire_id)
-            retval += " empire = " + m_empire_id->Dump();
+            retval += " empire = " + m_empire_id->Dump(ntabs);
 
     } else if (m_affiliation == AFFIL_ALLY) {
         retval += "OwnedBy affiliation = AllyOf";
         if (m_empire_id)
-            retval += " empire = " + m_empire_id->Dump();
+            retval += " empire = " + m_empire_id->Dump(ntabs);
 
     } else if (m_affiliation == AFFIL_CAN_SEE) {
         retval += "OwnedBy affiliation = CanSee";
@@ -1373,8 +1372,8 @@ std::string Source::Description(bool negated/* = false*/) const {
         : UserString("DESC_SOURCE_NOT");
 }
 
-std::string Source::Dump() const
-{ return DumpIndent() + "Source\n"; }
+std::string Source::Dump(unsigned short ntabs) const
+{ return DumpIndent(ntabs) + "Source\n"; }
 
 bool Source::Match(const ScriptingContext& local_context) const {
     if (!local_context.source)
@@ -1411,8 +1410,8 @@ std::string RootCandidate::Description(bool negated/* = false*/) const {
         : UserString("DESC_ROOT_CANDIDATE_NOT");
 }
 
-std::string RootCandidate::Dump() const
-{ return DumpIndent() + "RootCandidate\n"; }
+std::string RootCandidate::Dump(unsigned short ntabs) const
+{ return DumpIndent(ntabs) + "RootCandidate\n"; }
 
 bool RootCandidate::Match(const ScriptingContext& local_context) const {
     if (!local_context.condition_root_candidate)
@@ -1441,8 +1440,8 @@ std::string Target::Description(bool negated/* = false*/) const {
         : UserString("DESC_TARGET_NOT");
 }
 
-std::string Target::Dump() const
-{ return DumpIndent() + "Target\n"; }
+std::string Target::Dump(unsigned short ntabs) const
+{ return DumpIndent(ntabs) + "Target\n"; }
 
 bool Target::Match(const ScriptingContext& local_context) const {
     if (!local_context.effect_target)
@@ -1620,14 +1619,14 @@ std::string Homeworld::Description(bool negated/* = false*/) const {
         % values_str);
 }
 
-std::string Homeworld::Dump() const {
-    std::string retval = DumpIndent() + "HomeWorld";
+std::string Homeworld::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "HomeWorld";
     if (m_names.size() == 1) {
-        retval += " name = " + m_names[0]->Dump();
+        retval += " name = " + m_names[0]->Dump(ntabs);
     } else if (!m_names.empty()) {
         retval += " name = [ ";
         for (auto& name : m_names) {
-            retval += name->Dump() + " ";
+            retval += name->Dump(ntabs) + " ";
         }
         retval += "]";
     }
@@ -1711,8 +1710,8 @@ std::string Capital::Description(bool negated/* = false*/) const {
         : UserString("DESC_CAPITAL_NOT");
 }
 
-std::string Capital::Dump() const
-{ return DumpIndent() + "Capital\n"; }
+std::string Capital::Dump(unsigned short ntabs) const
+{ return DumpIndent(ntabs) + "Capital\n"; }
 
 bool Capital::Match(const ScriptingContext& local_context) const {
     auto candidate = local_context.condition_local_candidate;
@@ -1755,8 +1754,8 @@ std::string Monster::Description(bool negated/* = false*/) const {
         : UserString("DESC_MONSTER_NOT");
 }
 
-std::string Monster::Dump() const
-{ return DumpIndent() + "Monster\n"; }
+std::string Monster::Dump(unsigned short ntabs) const
+{ return DumpIndent(ntabs) + "Monster\n"; }
 
 bool Monster::Match(const ScriptingContext& local_context) const {
     auto candidate = local_context.condition_local_candidate;
@@ -1797,8 +1796,8 @@ std::string Armed::Description(bool negated/* = false*/) const {
         : UserString("DESC_ARMED_NOT");
 }
 
-std::string Armed::Dump() const
-{ return DumpIndent() + "Armed\n"; }
+std::string Armed::Dump(unsigned short ntabs) const
+{ return DumpIndent(ntabs) + "Armed\n"; }
 
 bool Armed::Match(const ScriptingContext& local_context) const {
     auto candidate = local_context.condition_local_candidate;
@@ -1917,8 +1916,8 @@ std::string Type::Description(bool negated/* = false*/) const {
            % value_str);
 }
 
-std::string Type::Dump() const {
-    std::string retval = DumpIndent();
+std::string Type::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs);
     if (dynamic_cast<ValueRef::Constant<UniverseObjectType>*>(m_type.get())) {
         switch (m_type->Eval()) {
         case OBJ_BUILDING:    retval += "Building\n"; break;
@@ -1932,7 +1931,7 @@ std::string Type::Dump() const {
         default: retval += "?\n"; break;
         }
     } else {
-        retval += "ObjectType type = " + m_type->Dump() + "\n";
+        retval += "ObjectType type = " + m_type->Dump(ntabs) + "\n";
     }
     return retval;
 }
@@ -2137,14 +2136,14 @@ std::string Building::Description(bool negated/* = false*/) const {
            % values_str);
 }
 
-std::string Building::Dump() const {
-    std::string retval = DumpIndent() + "Building name = ";
+std::string Building::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "Building name = ";
     if (m_names.size() == 1) {
-        retval += m_names[0]->Dump() + "\n";
+        retval += m_names[0]->Dump(ntabs) + "\n";
     } else {
         retval += "[ ";
         for (auto& name : m_names) {
-            retval += name->Dump() + " ";
+            retval += name->Dump(ntabs) + " ";
         }
         retval += "]\n";
     }
@@ -2403,22 +2402,22 @@ std::string HasSpecial::Description(bool negated/* = false*/) const {
                 % name_str);
 }
 
-std::string HasSpecial::Dump() const {
-    std::string name_str = (m_name ? m_name->Dump() : "");
+std::string HasSpecial::Dump(unsigned short ntabs) const {
+    std::string name_str = (m_name ? m_name->Dump(ntabs) : "");
 
     if (m_since_turn_low || m_since_turn_high) {
-        std::string low_dump = (m_since_turn_low ? m_since_turn_low->Dump() : std::to_string(BEFORE_FIRST_TURN));
-        std::string high_dump = (m_since_turn_high ? m_since_turn_high->Dump() : std::to_string(IMPOSSIBLY_LARGE_TURN));
-        return DumpIndent() + "HasSpecialSinceTurn name = \"" + name_str + "\" low = " + low_dump + " high = " + high_dump;
+        std::string low_dump = (m_since_turn_low ? m_since_turn_low->Dump(ntabs) : std::to_string(BEFORE_FIRST_TURN));
+        std::string high_dump = (m_since_turn_high ? m_since_turn_high->Dump(ntabs) : std::to_string(IMPOSSIBLY_LARGE_TURN));
+        return DumpIndent(ntabs) + "HasSpecialSinceTurn name = \"" + name_str + "\" low = " + low_dump + " high = " + high_dump;
     }
 
     if (m_capacity_low || m_capacity_high) {
-        std::string low_dump = (m_capacity_low ? m_capacity_low->Dump() : std::to_string(-FLT_MAX));
-        std::string high_dump = (m_capacity_high ? m_capacity_high->Dump() : std::to_string(FLT_MAX));
-        return DumpIndent() + "HasSpecialCapacity name = \"" + name_str + "\" low = " + low_dump + " high = " + high_dump;
+        std::string low_dump = (m_capacity_low ? m_capacity_low->Dump(ntabs) : std::to_string(-FLT_MAX));
+        std::string high_dump = (m_capacity_high ? m_capacity_high->Dump(ntabs) : std::to_string(FLT_MAX));
+        return DumpIndent(ntabs) + "HasSpecialCapacity name = \"" + name_str + "\" low = " + low_dump + " high = " + high_dump;
     }
 
-    return DumpIndent() + "HasSpecial name = \"" + name_str + "\"\n";
+    return DumpIndent(ntabs) + "HasSpecial name = \"" + name_str + "\"\n";
 }
 
 bool HasSpecial::Match(const ScriptingContext& local_context) const {
@@ -2569,10 +2568,10 @@ std::string HasTag::Description(bool negated/* = false*/) const {
         % name_str);
 }
 
-std::string HasTag::Dump() const {
-    std::string retval = DumpIndent() + "HasTag";
+std::string HasTag::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "HasTag";
     if (m_name)
-        retval += " name = " + m_name->Dump();
+        retval += " name = " + m_name->Dump(ntabs);
     retval += "\n";
     return retval;
 }
@@ -2695,12 +2694,12 @@ std::string CreatedOnTurn::Description(bool negated/* = false*/) const {
                % high_str);
 }
 
-std::string CreatedOnTurn::Dump() const {
-    std::string retval = DumpIndent() + "CreatedOnTurn";
+std::string CreatedOnTurn::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "CreatedOnTurn";
     if (m_low)
-        retval += " low = " + m_low->Dump();
+        retval += " low = " + m_low->Dump(ntabs);
     if (m_high)
-        retval += " high = " + m_high->Dump();
+        retval += " high = " + m_high->Dump(ntabs);
     retval += "\n";
     return retval;
 }
@@ -2888,11 +2887,11 @@ std::string Contains::Description(bool negated/* = false*/) const {
         % m_condition->Description());
 }
 
-std::string Contains::Dump() const {
-    std::string retval = DumpIndent() + "Contains condition =\n";
-    ++g_indent;
-    retval += m_condition->Dump();
-    --g_indent;
+std::string Contains::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "Contains condition =\n";
+    ++ntabs;
+    retval += m_condition->Dump(ntabs);
+    --ntabs;
     return retval;
 }
 
@@ -3107,11 +3106,11 @@ std::string ContainedBy::Description(bool negated/* = false*/) const {
         % m_condition->Description());
 }
 
-std::string ContainedBy::Dump() const {
-    std::string retval = DumpIndent() + "ContainedBy condition =\n";
-    ++g_indent;
-        retval += m_condition->Dump();
-    --g_indent;
+std::string ContainedBy::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "ContainedBy condition =\n";
+    ++ntabs;
+        retval += m_condition->Dump(ntabs);
+    --ntabs;
     return retval;
 }
 
@@ -3256,10 +3255,10 @@ std::string InSystem::Description(bool negated/* = false*/) const {
     return str(FlexibleFormat(description_str) % system_str);
 }
 
-std::string InSystem::Dump() const {
-    std::string retval = DumpIndent() + "InSystem";
+std::string InSystem::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "InSystem";
     if (m_system_id)
-        retval += " id = " + m_system_id->Dump();
+        retval += " id = " + m_system_id->Dump(ntabs);
     retval += "\n";
     return retval;
 }
@@ -3410,8 +3409,8 @@ std::string ObjectID::Description(bool negated/* = false*/) const {
                % object_str);
 }
 
-std::string ObjectID::Dump() const
-{ return DumpIndent() + "Object id = " + m_object_id->Dump() + "\n"; }
+std::string ObjectID::Dump(unsigned short ntabs) const
+{ return DumpIndent(ntabs) + "Object id = " + m_object_id->Dump(ntabs) + "\n"; }
 
 void ObjectID::GetDefaultInitialCandidateObjects(const ScriptingContext& parent_context,
                                                  ObjectSet& condition_non_targets) const
@@ -3591,14 +3590,14 @@ std::string PlanetType::Description(bool negated/* = false*/) const {
         % values_str);
 }
 
-std::string PlanetType::Dump() const {
-    std::string retval = DumpIndent() + "Planet type = ";
+std::string PlanetType::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "Planet type = ";
     if (m_types.size() == 1) {
-        retval += m_types[0]->Dump() + "\n";
+        retval += m_types[0]->Dump(ntabs) + "\n";
     } else {
         retval += "[ ";
         for (auto& type : m_types) {
-            retval += type->Dump() + " ";
+            retval += type->Dump(ntabs) + " ";
         }
         retval += "]\n";
     }
@@ -3780,14 +3779,14 @@ std::string PlanetSize::Description(bool negated/* = false*/) const {
         % values_str);
 }
 
-std::string PlanetSize::Dump() const {
-    std::string retval = DumpIndent() + "Planet size = ";
+std::string PlanetSize::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "Planet size = ";
     if (m_sizes.size() == 1) {
-        retval += m_sizes[0]->Dump() + "\n";
+        retval += m_sizes[0]->Dump(ntabs) + "\n";
     } else {
         retval += "[ ";
         for (auto& size : m_sizes) {
-            retval += size->Dump() + " ";
+            retval += size->Dump(ntabs) + " ";
         }
         retval += "]\n";
     }
@@ -3995,19 +3994,19 @@ std::string PlanetEnvironment::Description(bool negated/* = false*/) const {
         % species_str);
 }
 
-std::string PlanetEnvironment::Dump() const {
-    std::string retval = DumpIndent() + "Planet environment = ";
+std::string PlanetEnvironment::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "Planet environment = ";
     if (m_environments.size() == 1) {
-        retval += m_environments[0]->Dump();
+        retval += m_environments[0]->Dump(ntabs);
     } else {
         retval += "[ ";
         for (auto& environment : m_environments) {
-            retval += environment->Dump() + " ";
+            retval += environment->Dump(ntabs) + " ";
         }
         retval += "]";
     }
     if (m_species_name)
-        retval += " species = " + m_species_name->Dump();
+        retval += " species = " + m_species_name->Dump(ntabs);
     retval += "\n";
     return retval;
 }
@@ -4210,16 +4209,16 @@ std::string Species::Description(bool negated/* = false*/) const {
         % values_str);
 }
 
-std::string Species::Dump() const {
-    std::string retval = DumpIndent() + "Species";
+std::string Species::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "Species";
     if (m_names.empty()) {
         // do nothing else
     } else if (m_names.size() == 1) {
-        retval += " name = " + m_names[0]->Dump() + "\n";
+        retval += " name = " + m_names[0]->Dump(ntabs) + "\n";
     } else {
         retval += " name = [ ";
         for (auto& name : m_names) {
-            retval += name->Dump() + " ";
+            retval += name->Dump(ntabs) + " ";
         }
         retval += "]\n";
     }
@@ -4551,26 +4550,26 @@ std::string Enqueued::Description(bool negated/* = false*/) const {
                % what_str);
 }
 
-std::string Enqueued::Dump() const {
-    std::string retval = DumpIndent() + "Enqueued";
+std::string Enqueued::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "Enqueued";
 
     if (m_build_type == BT_BUILDING) {
         retval += " type = Building";
         if (m_name)
-            retval += " name = " + m_name->Dump();
+            retval += " name = " + m_name->Dump(ntabs);
     } else if (m_build_type == BT_SHIP) {
         retval += " type = Ship";
         if (m_name)
-            retval += " design = " + m_name->Dump();
+            retval += " design = " + m_name->Dump(ntabs);
         else if (m_design_id)
-            retval += " design = " + m_design_id->Dump();
+            retval += " design = " + m_design_id->Dump(ntabs);
     }
     if (m_empire_id)
-        retval += " empire = " + m_empire_id->Dump();
+        retval += " empire = " + m_empire_id->Dump(ntabs);
     if (m_low)
-        retval += " low = " + m_low->Dump();
+        retval += " low = " + m_low->Dump(ntabs);
     if (m_high)
-        retval += " high = " + m_high->Dump();
+        retval += " high = " + m_high->Dump(ntabs);
     retval += "\n";
     return retval;
 }
@@ -4750,14 +4749,14 @@ std::string FocusType::Description(bool negated/* = false*/) const {
         % values_str);
 }
 
-std::string FocusType::Dump() const {
-    std::string retval = DumpIndent() + "Focus name = ";
+std::string FocusType::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "Focus name = ";
     if (m_names.size() == 1) {
-        retval += m_names[0]->Dump() + "\n";
+        retval += m_names[0]->Dump(ntabs) + "\n";
     } else {
         retval += "[ ";
         for (auto& name : m_names) {
-            retval += name->Dump() + " ";
+            retval += name->Dump(ntabs) + " ";
         }
         retval += "]\n";
     }
@@ -4931,14 +4930,14 @@ std::string StarType::Description(bool negated/* = false*/) const {
         % values_str);
 }
 
-std::string StarType::Dump() const {
-    std::string retval = DumpIndent() + "Star type = ";
+std::string StarType::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "Star type = ";
     if (m_types.size() == 1) {
-        retval += m_types[0]->Dump() + "\n";
+        retval += m_types[0]->Dump(ntabs) + "\n";
     } else {
         retval += "[ ";
         for (auto& type : m_types) {
-            retval += type->Dump() + " ";
+            retval += type->Dump(ntabs) + " ";
         }
         retval += "]\n";
     }
@@ -5069,10 +5068,10 @@ std::string DesignHasHull::Description(bool negated/* = false*/) const {
         % name_str);
 }
 
-std::string DesignHasHull::Dump() const {
-    std::string retval = DumpIndent() + "DesignHasHull";
+std::string DesignHasHull::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "DesignHasHull";
     if (m_name)
-        retval += " name = " + m_name->Dump();
+        retval += " name = " + m_name->Dump(ntabs);
     retval += "\n";
     return retval;
 }
@@ -5240,14 +5239,14 @@ std::string DesignHasPart::Description(bool negated/* = false*/) const {
         % name_str);
 }
 
-std::string DesignHasPart::Dump() const {
-    std::string retval = DumpIndent() + "DesignHasPart";
+std::string DesignHasPart::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "DesignHasPart";
     if (m_low)
-        retval += "low = " + m_low->Dump();
+        retval += "low = " + m_low->Dump(ntabs);
     if (m_high)
-        retval += " high = " + m_high->Dump();
+        retval += " high = " + m_high->Dump(ntabs);
     if (m_name)
-        retval += " name = " + m_name->Dump();
+        retval += " name = " + m_name->Dump(ntabs);
     retval += "\n";
     return retval;
 }
@@ -5412,12 +5411,12 @@ std::string DesignHasPartClass::Description(bool negated/* = false*/) const {
                % UserString(boost::lexical_cast<std::string>(m_class)));
 }
 
-std::string DesignHasPartClass::Dump() const {
-    std::string retval = DumpIndent() + "DesignHasPartClass";
+std::string DesignHasPartClass::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "DesignHasPartClass";
     if (m_low)
-        retval += " low = " + m_low->Dump();
+        retval += " low = " + m_low->Dump(ntabs);
     if (m_high)
-        retval += " high = " + m_high->Dump();
+        retval += " high = " + m_high->Dump(ntabs);
     retval += " class = " + UserString(boost::lexical_cast<std::string>(m_class));
     retval += "\n";
     return retval;
@@ -5571,10 +5570,10 @@ std::string PredefinedShipDesign::Description(bool negated/* = false*/) const {
         % name_str);
 }
 
-std::string PredefinedShipDesign::Dump() const {
-    std::string retval = DumpIndent() + "PredefinedShipDesign";
+std::string PredefinedShipDesign::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "PredefinedShipDesign";
     if (m_name)
-        retval += " name = " + m_name->Dump();
+        retval += " name = " + m_name->Dump(ntabs);
     retval += "\n";
     return retval;
 }
@@ -5691,8 +5690,8 @@ std::string NumberedShipDesign::Description(bool negated/* = false*/) const {
                % id_str);
 }
 
-std::string NumberedShipDesign::Dump() const
-{ return DumpIndent() + "NumberedShipDesign design_id = " + m_design_id->Dump(); }
+std::string NumberedShipDesign::Dump(unsigned short ntabs) const
+{ return DumpIndent(ntabs) + "NumberedShipDesign design_id = " + m_design_id->Dump(ntabs); }
 
 bool NumberedShipDesign::Match(const ScriptingContext& local_context) const {
     auto candidate = local_context.condition_local_candidate;
@@ -5808,8 +5807,8 @@ std::string ProducedByEmpire::Description(bool negated/* = false*/) const {
                % empire_str);
 }
 
-std::string ProducedByEmpire::Dump() const
-{ return DumpIndent() + "ProducedByEmpire empire_id = " + m_empire_id->Dump(); }
+std::string ProducedByEmpire::Dump(unsigned short ntabs) const
+{ return DumpIndent(ntabs) + "ProducedByEmpire empire_id = " + m_empire_id->Dump(ntabs); }
 
 bool ProducedByEmpire::Match(const ScriptingContext& local_context) const {
     auto candidate = local_context.condition_local_candidate;
@@ -5915,8 +5914,8 @@ std::string Chance::Description(bool negated/* = false*/) const {
     }
 }
 
-std::string Chance::Dump() const
-{ return DumpIndent() + "Random probability = " + m_chance->Dump() + "\n"; }
+std::string Chance::Dump(unsigned short ntabs) const
+{ return DumpIndent(ntabs) + "Random probability = " + m_chance->Dump(ntabs) + "\n"; }
 
 bool Chance::Match(const ScriptingContext& local_context) const {
     float chance = std::max(0.0, std::min(m_chance->Eval(local_context), 1.0));
@@ -6086,13 +6085,13 @@ std::string MeterValue::Description(bool negated/* = false*/) const {
     }
 }
 
-std::string MeterValue::Dump() const {
-    std::string retval = DumpIndent();
+std::string MeterValue::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs);
     retval += MeterTypeDumpString(m_meter);
     if (m_low)
-        retval += " low = " + m_low->Dump();
+        retval += " low = " + m_low->Dump(ntabs);
     if (m_high)
-        retval += " high = " + m_high->Dump();
+        retval += " high = " + m_high->Dump(ntabs);
     retval += "\n";
     return retval;
 }
@@ -6260,15 +6259,15 @@ std::string ShipPartMeterValue::Description(bool negated/* = false*/) const {
                % high_str);
 }
 
-std::string ShipPartMeterValue::Dump() const {
-    std::string retval = DumpIndent();
+std::string ShipPartMeterValue::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs);
     retval += MeterTypeDumpString(m_meter);
     if (m_part_name)
-        retval += " part = " + m_part_name->Dump();
+        retval += " part = " + m_part_name->Dump(ntabs);
     if (m_low)
-        retval += " low = " + m_low->Dump();
+        retval += " low = " + m_low->Dump(ntabs);
     if (m_high)
-        retval += " high = " + m_high->Dump();
+        retval += " high = " + m_high->Dump(ntabs);
     retval += "\n";
     return retval;
 }
@@ -6450,15 +6449,15 @@ std::string EmpireMeterValue::Description(bool negated/* = false*/) const {
                % empire_str);
 }
 
-std::string EmpireMeterValue::Dump() const {
-    std::string retval = DumpIndent() + "EmpireMeterValue";
+std::string EmpireMeterValue::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "EmpireMeterValue";
     if (m_empire_id)
-        retval += " empire = " + m_empire_id->Dump();
+        retval += " empire = " + m_empire_id->Dump(ntabs);
     retval += " meter = " + m_meter;
     if (m_low)
-        retval += " low = " + m_low->Dump();
+        retval += " low = " + m_low->Dump(ntabs);
     if (m_high)
-        retval += " high = " + m_high->Dump();
+        retval += " high = " + m_high->Dump(ntabs);
     retval += "\n";
     return retval;
 }
@@ -6606,15 +6605,15 @@ std::string EmpireStockpileValue::Description(bool negated/* = false*/) const {
                % high_str);
 }
 
-std::string EmpireStockpileValue::Dump() const {
-    std::string retval = DumpIndent();
+std::string EmpireStockpileValue::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs);
     switch (m_stockpile) {
     case RE_TRADE:      retval += "OwnerTradeStockpile";    break;
     case RE_RESEARCH:   retval += "OwnerResearchStockpile"; break;
     case RE_INDUSTRY:   retval += "OwnerIndustryStockpile"; break;
     default: retval += "?"; break;
     }
-    retval += " low = " + m_low->Dump() + " high = " + m_high->Dump() + "\n";
+    retval += " low = " + m_low->Dump(ntabs) + " high = " + m_high->Dump(ntabs) + "\n";
     return retval;
 }
 
@@ -6736,10 +6735,10 @@ std::string OwnerHasTech::Description(bool negated/* = false*/) const {
         % name_str);
 }
 
-std::string OwnerHasTech::Dump() const {
-    std::string retval = DumpIndent() + "OwnerHasTech";
+std::string OwnerHasTech::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "OwnerHasTech";
     if (m_name)
-        retval += " name = " + m_name->Dump();
+        retval += " name = " + m_name->Dump(ntabs);
     retval += "\n";
     return retval;
 }
@@ -6858,10 +6857,10 @@ std::string OwnerHasBuildingTypeAvailable::Description(bool negated/* = false*/)
         : UserString("DESC_OWNER_HAS_BUILDING_TYPE_NOT");
 }
 
-std::string OwnerHasBuildingTypeAvailable::Dump() const {
-    std::string retval= DumpIndent() + "OwnerHasBuildingTypeAvailable";
+std::string OwnerHasBuildingTypeAvailable::Dump(unsigned short ntabs) const {
+    std::string retval= DumpIndent(ntabs) + "OwnerHasBuildingTypeAvailable";
     if (m_name)
-        retval += " name = " + m_name->Dump();
+        retval += " name = " + m_name->Dump(ntabs);
     retval += "\n";
     return retval;
 }
@@ -6980,10 +6979,10 @@ std::string OwnerHasShipDesignAvailable::Description(bool negated/* = false*/) c
         : UserString("DESC_OWNER_HAS_SHIP_DESIGN_NOT");
 }
 
-std::string OwnerHasShipDesignAvailable::Dump() const {
-    std::string retval = DumpIndent() + "OwnerHasShipDesignAvailable";
+std::string OwnerHasShipDesignAvailable::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "OwnerHasShipDesignAvailable";
     if (m_id)
-        retval += " id = " + m_id->Dump();
+        retval += " id = " + m_id->Dump(ntabs);
     retval += "\n";
     return retval;
 }
@@ -7103,10 +7102,10 @@ std::string OwnerHasShipPartAvailable::Description(bool negated/* = false*/) con
         : UserString("DESC_OWNER_HAS_SHIP_PART_NOT");
 }
 
-std::string OwnerHasShipPartAvailable::Dump() const {
-    std::string retval = DumpIndent() + "OwnerHasShipPartAvailable";
+std::string OwnerHasShipPartAvailable::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "OwnerHasShipPartAvailable";
     if (m_name)
-        retval += " name = " + m_name->Dump();
+        retval += " name = " + m_name->Dump(ntabs);
     retval += "\n";
     return retval;
 }
@@ -7222,8 +7221,8 @@ std::string VisibleToEmpire::Description(bool negated/* = false*/) const {
                % empire_str);
 }
 
-std::string VisibleToEmpire::Dump() const
-{ return DumpIndent() + "VisibleToEmpire empire_id = " + m_empire_id->Dump() + "\n"; }
+std::string VisibleToEmpire::Dump(unsigned short ntabs) const
+{ return DumpIndent(ntabs) + "VisibleToEmpire empire_id = " + m_empire_id->Dump(ntabs) + "\n"; }
 
 bool VisibleToEmpire::Match(const ScriptingContext& local_context) const {
     auto candidate = local_context.condition_local_candidate;
@@ -7348,11 +7347,11 @@ std::string WithinDistance::Description(bool negated/* = false*/) const {
                % m_condition->Description());
 }
 
-std::string WithinDistance::Dump() const {
-    std::string retval = DumpIndent() + "WithinDistance distance = " + m_distance->Dump() + " condition =\n";
-    ++g_indent;
-    retval += m_condition->Dump();
-    --g_indent;
+std::string WithinDistance::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "WithinDistance distance = " + m_distance->Dump(ntabs) + " condition =\n";
+    ++ntabs;
+    retval += m_condition->Dump(ntabs);
+    --ntabs;
     return retval;
 }
 
@@ -7459,11 +7458,11 @@ std::string WithinStarlaneJumps::Description(bool negated/* = false*/) const {
                % m_condition->Description());
 }
 
-std::string WithinStarlaneJumps::Dump() const {
-    std::string retval = DumpIndent() + "WithinStarlaneJumps jumps = " + m_jumps->Dump() + " condition =\n";
-    ++g_indent;
-    retval += m_condition->Dump();
-    --g_indent;
+std::string WithinStarlaneJumps::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "WithinStarlaneJumps jumps = " + m_jumps->Dump(ntabs) + " condition =\n";
+    ++ntabs;
+    retval += m_condition->Dump(ntabs);
+    --ntabs;
     return retval;
 }
 
@@ -7921,11 +7920,11 @@ std::string CanAddStarlaneConnection::Description(bool negated/* = false*/) cons
         % m_condition->Description());
 }
 
-std::string CanAddStarlaneConnection::Dump() const {
-    std::string retval = DumpIndent() + "CanAddStarlanesTo condition =\n";
-    ++g_indent;
-        retval += m_condition->Dump();
-    --g_indent;
+std::string CanAddStarlaneConnection::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "CanAddStarlanesTo condition =\n";
+    ++ntabs;
+        retval += m_condition->Dump(ntabs);
+    --ntabs;
     return retval;
 }
 
@@ -8047,8 +8046,8 @@ std::string ExploredByEmpire::Description(bool negated/* = false*/) const {
                % empire_str);
 }
 
-std::string ExploredByEmpire::Dump() const
-{ return DumpIndent() + "ExploredByEmpire empire_id = " + m_empire_id->Dump(); }
+std::string ExploredByEmpire::Dump(unsigned short ntabs) const
+{ return DumpIndent(ntabs) + "ExploredByEmpire empire_id = " + m_empire_id->Dump(ntabs); }
 
 bool ExploredByEmpire::Match(const ScriptingContext& local_context) const {
     auto candidate = local_context.condition_local_candidate;
@@ -8087,8 +8086,8 @@ std::string Stationary::Description(bool negated/* = false*/) const {
         : UserString("DESC_STATIONARY_NOT");
 }
 
-std::string Stationary::Dump() const
-{ return DumpIndent() + "Stationary\n"; }
+std::string Stationary::Dump(unsigned short ntabs) const
+{ return DumpIndent(ntabs) + "Stationary\n"; }
 
 bool Stationary::Match(const ScriptingContext& local_context) const {
     auto candidate = local_context.condition_local_candidate;
@@ -8145,8 +8144,8 @@ std::string Aggressive::Description(bool negated/* = false*/) const {
             : UserString("DESC_PASSIVE_NOT");
 }
 
-std::string Aggressive::Dump() const
-{ return DumpIndent() + (m_aggressive ? "Aggressive\n" : "Passive\n"); }
+std::string Aggressive::Dump(unsigned short ntabs) const
+{ return DumpIndent(ntabs) + (m_aggressive ? "Aggressive\n" : "Passive\n"); }
 
 bool Aggressive::Match(const ScriptingContext& local_context) const {
     auto candidate = local_context.condition_local_candidate;
@@ -8274,8 +8273,8 @@ std::string FleetSupplyableByEmpire::Description(bool negated/* = false*/) const
                % empire_str);
 }
 
-std::string FleetSupplyableByEmpire::Dump() const
-{ return DumpIndent() + "ResupplyableBy empire_id = " + m_empire_id->Dump(); }
+std::string FleetSupplyableByEmpire::Dump(unsigned short ntabs) const
+{ return DumpIndent(ntabs) + "ResupplyableBy empire_id = " + m_empire_id->Dump(ntabs); }
 
 bool FleetSupplyableByEmpire::Match(const ScriptingContext& local_context) const {
     auto candidate = local_context.condition_local_candidate;
@@ -8439,12 +8438,12 @@ std::string ResourceSupplyConnectedByEmpire::Description(bool negated/* = false*
                % m_condition->Description());
 }
 
-std::string ResourceSupplyConnectedByEmpire::Dump() const {
-    std::string retval = DumpIndent() + "ResourceSupplyConnectedBy empire_id = " + m_empire_id->Dump() +
+std::string ResourceSupplyConnectedByEmpire::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "ResourceSupplyConnectedBy empire_id = " + m_empire_id->Dump(ntabs) +
                                         " condition = \n";
-    ++g_indent;
-    retval += m_condition->Dump();
-    --g_indent;
+    ++ntabs;
+    retval += m_condition->Dump(ntabs);
+    --ntabs;
     return retval;
 }
 
@@ -8478,8 +8477,8 @@ std::string CanColonize::Description(bool negated/* = false*/) const {
         : UserString("DESC_CAN_COLONIZE_NOT")));
 }
 
-std::string CanColonize::Dump() const
-{ return DumpIndent() + "CanColonize\n"; }
+std::string CanColonize::Dump(unsigned short ntabs) const
+{ return DumpIndent(ntabs) + "CanColonize\n"; }
 
 bool CanColonize::Match(const ScriptingContext& local_context) const {
     auto candidate = local_context.condition_local_candidate;
@@ -8551,8 +8550,8 @@ std::string CanProduceShips::Description(bool negated/* = false*/) const {
         : UserString("DESC_CAN_PRODUCE_SHIPS_NOT")));
 }
 
-std::string CanProduceShips::Dump() const
-{ return DumpIndent() + "CanColonize\n"; }
+std::string CanProduceShips::Dump(unsigned short ntabs) const
+{ return DumpIndent(ntabs) + "CanColonize\n"; }
 
 bool CanProduceShips::Match(const ScriptingContext& local_context) const {
     auto candidate = local_context.condition_local_candidate;
@@ -8710,8 +8709,8 @@ std::string OrderedBombarded::Description(bool negated/* = false*/) const {
                % by_str);
 }
 
-std::string OrderedBombarded::Dump() const
-{ return DumpIndent() + "OrderedBombarded by_object = " + m_by_object_condition->Dump(); }
+std::string OrderedBombarded::Dump(unsigned short ntabs) const
+{ return DumpIndent(ntabs) + "OrderedBombarded by_object = " + m_by_object_condition->Dump(ntabs); }
 
 bool OrderedBombarded::Match(const ScriptingContext& local_context) const {
     auto candidate = local_context.condition_local_candidate;
@@ -8808,9 +8807,9 @@ ValueTest::ValueTest(std::unique_ptr<ValueRef::ValueRefBase<std::string>>&& valu
     m_compare_type1(comp1),
     m_compare_type2(comp2)
 {
-    /*DebugLogger() << "String ValueTest(" << value_ref1->Dump() << " "
+    /*DebugLogger() << "String ValueTest(" << value_ref1->Dump(ntabs) << " "
                                          << CompareTypeString(comp1) << " "
-                                         << value_ref2->Dump() << ")";*/
+                                         << value_ref2->Dump(ntabs) << ")";*/
 }
 
 ValueTest::ValueTest(std::unique_ptr<ValueRef::ValueRefBase<int>>&& value_ref1,
@@ -9011,34 +9010,34 @@ std::string ValueTest::Description(bool negated/* = false*/) const {
                % composed_comparison);
 }
 
-std::string ValueTest::Dump() const {
-    std::string retval = DumpIndent() + "(";
+std::string ValueTest::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "(";
     if (m_value_ref1)
-        retval += m_value_ref1->Dump();
+        retval += m_value_ref1->Dump(ntabs);
     else if (m_string_value_ref1)
-        retval += m_string_value_ref1->Dump();
+        retval += m_string_value_ref1->Dump(ntabs);
     else if (m_int_value_ref1)
-        retval += m_int_value_ref1->Dump();
+        retval += m_int_value_ref1->Dump(ntabs);
 
     if (m_compare_type1 != INVALID_COMPARISON)
         retval += " " + CompareTypeString(m_compare_type1);
 
     if (m_value_ref2)
-        retval += " " + m_value_ref2->Dump();
+        retval += " " + m_value_ref2->Dump(ntabs);
     else if (m_string_value_ref2)
-        retval += m_string_value_ref2->Dump();
+        retval += m_string_value_ref2->Dump(ntabs);
     else if (m_int_value_ref2)
-        retval += m_int_value_ref2->Dump();
+        retval += m_int_value_ref2->Dump(ntabs);
 
     if (m_compare_type2 != INVALID_COMPARISON)
         retval += " " + CompareTypeString(m_compare_type2);
 
     if (m_value_ref3)
-        retval += " " + m_value_ref3->Dump();
+        retval += " " + m_value_ref3->Dump(ntabs);
     else if (m_string_value_ref3)
-        retval += m_string_value_ref3->Dump();
+        retval += m_string_value_ref3->Dump(ntabs);
     else if (m_int_value_ref3)
-        retval += m_int_value_ref3->Dump();
+        retval += m_int_value_ref3->Dump(ntabs);
 
     retval += ")\n";
     return retval;
@@ -9296,8 +9295,8 @@ std::string Location::Description(bool negated/* = false*/) const {
                % name2_str);
 }
 
-std::string Location::Dump() const {
-    std::string retval = DumpIndent() + "Location content_type = ";
+std::string Location::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "Location content_type = ";
 
     switch (m_content_type) {
     case CONTENT_BUILDING:  retval += "Building";   break;
@@ -9310,9 +9309,9 @@ std::string Location::Dump() const {
     }
 
     if (m_name1)
-        retval += " name1 = " + m_name1->Dump();
+        retval += " name1 = " + m_name1->Dump(ntabs);
     if (m_name2)
-        retval += " name2 = " + m_name2->Dump();
+        retval += " name2 = " + m_name2->Dump(ntabs);
     return retval;
 }
 
@@ -9490,14 +9489,14 @@ std::string And::Description(bool negated/* = false*/) const {
     }
 }
 
-std::string And::Dump() const {
-    std::string retval = DumpIndent() + "And [\n";
-    ++g_indent;
+std::string And::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "And [\n";
+    ++ntabs;
     for (auto& operand : m_operands) {
-        retval += operand->Dump();
+        retval += operand->Dump(ntabs);
     }
-    --g_indent;
-    retval += DumpIndent() + "]\n";
+    --ntabs;
+    retval += DumpIndent(ntabs) + "]\n";
     return retval;
 }
 
@@ -9670,14 +9669,14 @@ std::string Or::Description(bool negated/* = false*/) const {
     }
 }
 
-std::string Or::Dump() const {
-    std::string retval = DumpIndent() + "Or [\n";
-    ++g_indent;
+std::string Or::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "Or [\n";
+    ++ntabs;
     for (auto& operand : m_operands) {
-        retval += operand->Dump();
+        retval += operand->Dump(ntabs);
     }
-    --g_indent;
-    retval += "\n" + DumpIndent() + "]\n";
+    --ntabs;
+    retval += "\n" + DumpIndent(ntabs) + "]\n";
     return retval;
 }
 
@@ -9767,11 +9766,11 @@ bool Not::SourceInvariant() const {
 std::string Not::Description(bool negated/* = false*/) const
 { return m_operand->Description(true); }
 
-std::string Not::Dump() const {
-    std::string retval = DumpIndent() + "Not\n";
-    ++g_indent;
-    retval += m_operand->Dump();
-    --g_indent;
+std::string Not::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "Not\n";
+    ++ntabs;
+    retval += m_operand->Dump(ntabs);
+    --ntabs;
     return retval;
 }
 

--- a/universe/Condition.h
+++ b/universe/Condition.h
@@ -144,7 +144,7 @@ struct FO_COMMON_API ConditionBase {
 
     virtual std::string Description(bool negated = false) const = 0;
 
-    virtual std::string Dump() const = 0;
+    virtual std::string Dump(unsigned short ntabs = 0) const = 0;
 
     virtual void SetTopLevelContent(const std::string& content_name) = 0;
 
@@ -189,7 +189,7 @@ struct FO_COMMON_API Number : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -227,7 +227,7 @@ struct FO_COMMON_API Turn : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -282,7 +282,7 @@ struct FO_COMMON_API SortedNumberOf : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -310,7 +310,7 @@ struct FO_COMMON_API All : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     bool RootCandidateInvariant() const override
     { return true; }
@@ -348,7 +348,7 @@ struct FO_COMMON_API None : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     bool RootCandidateInvariant() const override
     { return true; }
@@ -395,7 +395,7 @@ struct FO_COMMON_API EmpireAffiliation : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -429,7 +429,7 @@ struct FO_COMMON_API Source : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override
     {}
@@ -464,7 +464,7 @@ struct FO_COMMON_API RootCandidate : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override
     {}
@@ -502,7 +502,7 @@ struct FO_COMMON_API Target : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override
     {}
@@ -543,7 +543,7 @@ struct FO_COMMON_API Homeworld : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -579,7 +579,7 @@ struct FO_COMMON_API Capital : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override
     {}
@@ -614,7 +614,7 @@ struct FO_COMMON_API Monster : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override
     {}
@@ -646,7 +646,7 @@ struct FO_COMMON_API Armed : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override
     {}
@@ -683,7 +683,7 @@ struct FO_COMMON_API Type : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -722,7 +722,7 @@ struct FO_COMMON_API Building : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -769,7 +769,7 @@ struct FO_COMMON_API HasSpecial : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -811,7 +811,7 @@ struct FO_COMMON_API HasTag : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -847,7 +847,7 @@ struct FO_COMMON_API CreatedOnTurn : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -891,7 +891,7 @@ struct FO_COMMON_API Contains : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -934,7 +934,7 @@ struct FO_COMMON_API ContainedBy : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -972,7 +972,7 @@ struct FO_COMMON_API InSystem : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -1010,7 +1010,7 @@ struct FO_COMMON_API ObjectID : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -1050,7 +1050,7 @@ struct FO_COMMON_API PlanetType : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -1090,7 +1090,7 @@ struct FO_COMMON_API PlanetSize : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -1130,7 +1130,7 @@ struct FO_COMMON_API PlanetEnvironment : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -1173,7 +1173,7 @@ struct FO_COMMON_API Species : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -1223,7 +1223,7 @@ struct FO_COMMON_API Enqueued : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -1262,7 +1262,7 @@ struct FO_COMMON_API FocusType : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void GetDefaultInitialCandidateObjects(const ScriptingContext& parent_context,
                                            ObjectSet& condition_non_targets) const override;
@@ -1301,7 +1301,7 @@ struct FO_COMMON_API StarType : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -1339,7 +1339,7 @@ struct FO_COMMON_API DesignHasHull : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -1380,7 +1380,7 @@ struct FO_COMMON_API DesignHasPart : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -1423,7 +1423,7 @@ struct FO_COMMON_API DesignHasPartClass : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -1462,7 +1462,7 @@ struct FO_COMMON_API PredefinedShipDesign : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -1497,7 +1497,7 @@ struct FO_COMMON_API NumberedShipDesign : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -1532,7 +1532,7 @@ struct FO_COMMON_API ProducedByEmpire : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -1567,7 +1567,7 @@ struct FO_COMMON_API Chance : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -1605,7 +1605,7 @@ struct FO_COMMON_API MeterValue : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -1646,7 +1646,7 @@ struct FO_COMMON_API ShipPartMeterValue : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -1688,7 +1688,7 @@ struct FO_COMMON_API EmpireMeterValue : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -1725,7 +1725,7 @@ struct FO_COMMON_API EmpireStockpileValue : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -1762,7 +1762,7 @@ struct FO_COMMON_API OwnerHasTech : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -1799,7 +1799,7 @@ struct FO_COMMON_API OwnerHasBuildingTypeAvailable : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -1836,7 +1836,7 @@ struct FO_COMMON_API OwnerHasShipDesignAvailable : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -1873,7 +1873,7 @@ struct FO_COMMON_API OwnerHasShipPartAvailable : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -1908,7 +1908,7 @@ struct FO_COMMON_API VisibleToEmpire : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -1947,7 +1947,7 @@ struct FO_COMMON_API WithinDistance : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -1987,7 +1987,7 @@ struct FO_COMMON_API WithinStarlaneJumps : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -2031,7 +2031,7 @@ struct FO_COMMON_API CanAddStarlaneConnection :  ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -2067,7 +2067,7 @@ struct FO_COMMON_API ExploredByEmpire : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -2101,7 +2101,7 @@ struct FO_COMMON_API Stationary : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override
     {}
@@ -2141,7 +2141,7 @@ struct FO_COMMON_API Aggressive: public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override
     {}
@@ -2181,7 +2181,7 @@ struct FO_COMMON_API FleetSupplyableByEmpire : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -2219,7 +2219,7 @@ struct FO_COMMON_API ResourceSupplyConnectedByEmpire : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -2253,7 +2253,7 @@ struct FO_COMMON_API CanColonize : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override
     {}
@@ -2285,7 +2285,7 @@ struct FO_COMMON_API CanProduceShips : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override
     {}
@@ -2320,7 +2320,7 @@ struct FO_COMMON_API OrderedBombarded : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     virtual void SetTopLevelContent(const std::string& content_name) override;
 
@@ -2372,7 +2372,7 @@ struct FO_COMMON_API ValueTest : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -2422,7 +2422,7 @@ public:
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -2462,7 +2462,7 @@ struct FO_COMMON_API And : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -2497,7 +2497,7 @@ struct FO_COMMON_API Or : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     virtual void SetTopLevelContent(const std::string& content_name) override;
 
@@ -2530,7 +2530,7 @@ struct FO_COMMON_API Not : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -2568,8 +2568,8 @@ struct FO_COMMON_API Described : public ConditionBase {
 
     std::string Description(bool negated = false) const override;
 
-    std::string Dump() const override
-    { return m_condition ? m_condition->Dump() : ""; }
+    std::string Dump(unsigned short ntabs = 0) const override
+    { return m_condition ? m_condition->Dump(ntabs) : ""; }
 
     void SetTopLevelContent(const std::string& content_name) override;
 

--- a/universe/Effect.cpp
+++ b/universe/Effect.cpp
@@ -214,34 +214,24 @@ const std::string& EffectsGroup::GetDescription() const
 
 std::string EffectsGroup::Dump(unsigned short ntabs) const {
     std::string retval = DumpIndent(ntabs) + "EffectsGroup\n";
-    ++ntabs;
-    retval += DumpIndent(ntabs) + "scope =\n";
-    ++ntabs;
-    retval += m_scope->Dump(ntabs);
-    --ntabs;
+    retval += DumpIndent(ntabs+1) + "scope =\n";
+    retval += m_scope->Dump(ntabs+2);
     if (m_activation) {
-        retval += DumpIndent(ntabs) + "activation =\n";
-        ++ntabs;
-        retval += m_activation->Dump(ntabs);
-        --ntabs;
+        retval += DumpIndent(ntabs+1) + "activation =\n";
+        retval += m_activation->Dump(ntabs+2);
     }
     if (!m_stacking_group.empty())
-        retval += DumpIndent(ntabs) + "stackinggroup = \"" + m_stacking_group + "\"\n";
+        retval += DumpIndent(ntabs+1) + "stackinggroup = \"" + m_stacking_group + "\"\n";
     if (m_effects.size() == 1) {
-        retval += DumpIndent(ntabs) + "effects =\n";
-        ++ntabs;
-        retval += m_effects[0]->Dump(ntabs);
-        --ntabs;
+        retval += DumpIndent(ntabs+1) + "effects =\n";
+        retval += m_effects[0]->Dump(ntabs+2);
     } else {
-        retval += DumpIndent(ntabs) + "effects = [\n";
-        ++ntabs;
+        retval += DumpIndent(ntabs+1) + "effects = [\n";
         for (auto& effect : m_effects) {
-            retval += effect->Dump(ntabs);
+            retval += effect->Dump(ntabs+2);
         }
-        --ntabs;
-        retval += DumpIndent(ntabs) + "]\n";
+        retval += DumpIndent(ntabs+1) + "]\n";
     }
-    --ntabs;
     return retval;
 }
 
@@ -3416,22 +3406,21 @@ void GenerateSitRepMessage::Execute(const ScriptingContext& context) const {
 std::string GenerateSitRepMessage::Dump(unsigned short ntabs) const {
     std::string retval = DumpIndent(ntabs);
     retval += "GenerateSitRepMessage\n";
-    ++ntabs;
-    retval += DumpIndent(ntabs) + "message = \"" + m_message_string + "\"" + " icon = " + m_icon + "\n";
+    retval += DumpIndent(ntabs+1) + "message = \"" + m_message_string + "\"" + " icon = " + m_icon + "\n";
 
     if (m_message_parameters.size() == 1) {
-        retval += DumpIndent(ntabs) + "parameters = tag = " + m_message_parameters[0].first + " data = " + m_message_parameters[0].second->Dump(ntabs) + "\n";
+        retval += DumpIndent(ntabs+1) + "parameters = tag = " + m_message_parameters[0].first + " data = " + m_message_parameters[0].second->Dump(ntabs+1) + "\n";
     } else if (!m_message_parameters.empty()) {
-        retval += DumpIndent(ntabs) + "parameters = [ ";
+        retval += DumpIndent(ntabs+1) + "parameters = [ ";
         for (const auto& entry : m_message_parameters) {
             retval += " tag = " + entry.first
-                   + " data = " + entry.second->Dump(ntabs)
+                   + " data = " + entry.second->Dump(ntabs+1)
                    + " ";
         }
         retval += "]\n";
     }
 
-    retval += DumpIndent(ntabs) + "affiliation = ";
+    retval += DumpIndent(ntabs+1) + "affiliation = ";
     switch (m_affiliation) {
     case AFFIL_SELF:    retval += "TheEmpire";  break;
     case AFFIL_ENEMY:   retval += "EnemyOf";    break;
@@ -3443,10 +3432,9 @@ std::string GenerateSitRepMessage::Dump(unsigned short ntabs) const {
     }
 
     if (m_recipient_empire_id)
-        retval += "\n" + DumpIndent(ntabs) + "empire = " + m_recipient_empire_id->Dump(ntabs) + "\n";
+        retval += "\n" + DumpIndent(ntabs+1) + "empire = " + m_recipient_empire_id->Dump(ntabs+1) + "\n";
     if (m_condition)
-        retval += "\n" + DumpIndent(ntabs) + "condition = " + m_condition->Dump(ntabs) + "\n";
-    --ntabs;
+        retval += "\n" + DumpIndent(ntabs+1) + "condition = " + m_condition->Dump(ntabs+1) + "\n";
 
     return retval;
 }
@@ -3830,45 +3818,33 @@ void Conditional::Execute(const ScriptingContext& context,
 
 std::string Conditional::Dump(unsigned short ntabs) const {
     std::string retval = DumpIndent(ntabs) + "If\n";
-    ++ntabs;
     if (m_target_condition) {
-        retval += DumpIndent(ntabs) + "condition =\n";
-        ++ntabs;
-        retval += m_target_condition->Dump(ntabs);
-        --ntabs;
+        retval += DumpIndent(ntabs+1) + "condition =\n";
+        retval += m_target_condition->Dump(ntabs+2);
     }
 
     if (m_true_effects.size() == 1) {
-        retval += DumpIndent(ntabs) + "effects =\n";
-        ++ntabs;
-        retval += m_true_effects[0]->Dump(ntabs);
-        --ntabs;
+        retval += DumpIndent(ntabs+1) + "effects =\n";
+        retval += m_true_effects[0]->Dump(ntabs+2);
     } else {
-        retval += DumpIndent(ntabs) + "effects = [\n";
-        ++ntabs;
+        retval += DumpIndent(ntabs+1) + "effects = [\n";
         for (auto& effect : m_true_effects) {
-            retval += effect->Dump(ntabs);
+            retval += effect->Dump(ntabs+2);
         }
-        --ntabs;
-        retval += DumpIndent(ntabs) + "]\n";
+        retval += DumpIndent(ntabs+1) + "]\n";
     }
 
     if (m_false_effects.empty()) {
     } else if (m_false_effects.size() == 1) {
-        retval += DumpIndent(ntabs) + "else =\n";
-        ++ntabs;
-        retval += m_false_effects[0]->Dump(ntabs);
-        --ntabs;
+        retval += DumpIndent(ntabs+1) + "else =\n";
+        retval += m_false_effects[0]->Dump(ntabs+2);
     } else {
-        retval += DumpIndent(ntabs) + "else = [\n";
-        ++ntabs;
+        retval += DumpIndent(ntabs+1) + "else = [\n";
         for (auto& effect : m_false_effects) {
-            retval += effect->Dump(ntabs);
+            retval += effect->Dump(ntabs+2);
         }
-        --ntabs;
-        retval += DumpIndent(ntabs) + "]\n";
+        retval += DumpIndent(ntabs+1) + "]\n";
     }
-    --ntabs;
 
     return retval;
 }

--- a/universe/Effect.cpp
+++ b/universe/Effect.cpp
@@ -36,7 +36,6 @@ namespace {
 
 using boost::io::str;
 
-extern int g_indent;
 FO_COMMON_API extern const int INVALID_DESIGN_ID;
 
 namespace {
@@ -213,36 +212,36 @@ const std::vector<EffectBase*>  EffectsGroup::EffectsList() const {
 const std::string& EffectsGroup::GetDescription() const
 { return m_description; }
 
-std::string EffectsGroup::Dump() const {
-    std::string retval = DumpIndent() + "EffectsGroup\n";
-    ++g_indent;
-    retval += DumpIndent() + "scope =\n";
-    ++g_indent;
-    retval += m_scope->Dump();
-    --g_indent;
+std::string EffectsGroup::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "EffectsGroup\n";
+    ++ntabs;
+    retval += DumpIndent(ntabs) + "scope =\n";
+    ++ntabs;
+    retval += m_scope->Dump(ntabs);
+    --ntabs;
     if (m_activation) {
-        retval += DumpIndent() + "activation =\n";
-        ++g_indent;
-        retval += m_activation->Dump();
-        --g_indent;
+        retval += DumpIndent(ntabs) + "activation =\n";
+        ++ntabs;
+        retval += m_activation->Dump(ntabs);
+        --ntabs;
     }
     if (!m_stacking_group.empty())
-        retval += DumpIndent() + "stackinggroup = \"" + m_stacking_group + "\"\n";
+        retval += DumpIndent(ntabs) + "stackinggroup = \"" + m_stacking_group + "\"\n";
     if (m_effects.size() == 1) {
-        retval += DumpIndent() + "effects =\n";
-        ++g_indent;
-        retval += m_effects[0]->Dump();
-        --g_indent;
+        retval += DumpIndent(ntabs) + "effects =\n";
+        ++ntabs;
+        retval += m_effects[0]->Dump(ntabs);
+        --ntabs;
     } else {
-        retval += DumpIndent() + "effects = [\n";
-        ++g_indent;
+        retval += DumpIndent(ntabs) + "effects = [\n";
+        ++ntabs;
         for (auto& effect : m_effects) {
-            retval += effect->Dump();
+            retval += effect->Dump(ntabs);
         }
-        --g_indent;
-        retval += DumpIndent() + "]\n";
+        --ntabs;
+        retval += DumpIndent(ntabs) + "]\n";
     }
-    --g_indent;
+    --ntabs;
     return retval;
 }
 
@@ -386,8 +385,8 @@ NoOp::NoOp()
 void NoOp::Execute(const ScriptingContext& context) const
 {}
 
-std::string NoOp::Dump() const
-{ return DumpIndent() + "NoOp\n"; }
+std::string NoOp::Dump(unsigned short ntabs) const
+{ return DumpIndent(ntabs) + "NoOp\n"; }
 
 unsigned int NoOp::GetCheckSum() const {
     unsigned int retval{0};
@@ -443,7 +442,7 @@ void SetMeter::Execute(const ScriptingContext& context,
     TraceLogger(effects) << "\n\nExecute SetMeter effect: \n" << Dump();
     TraceLogger(effects) << "SetMeter execute targets before: ";
     for (const auto& target : targets)
-        TraceLogger(effects) << " ... " << target->Dump();
+        TraceLogger(effects) << " ... " << target->Dump(1);
 
     if (!accounting_map) {
         // without accounting, can do default batch execute
@@ -541,8 +540,8 @@ void SetMeter::Execute(const ScriptingContext& context, const TargetSet& targets
     EffectBase::Execute(context, targets);
 }
 
-std::string SetMeter::Dump() const {
-    std::string retval = DumpIndent() + "Set";
+std::string SetMeter::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "Set";
     switch (m_meter) {
     case METER_TARGET_POPULATION:   retval += "TargetPopulation"; break;
     case METER_TARGET_INDUSTRY:     retval += "TargetIndustry"; break;
@@ -584,7 +583,7 @@ std::string SetMeter::Dump() const {
 
     default:                        retval += "?"; break;
     }
-    retval += " value = " + m_value->Dump() + "\n";
+    retval += " value = " + m_value->Dump(ntabs) + "\n";
     return retval;
 }
 
@@ -663,13 +662,13 @@ void SetShipPartMeter::Execute(const ScriptingContext& context,
     TraceLogger(effects) << "\n\nExecute SetShipPartMeter effect: \n" << Dump();
     TraceLogger(effects) << "SetShipPartMeter execute targets before: ";
     for (auto& target : targets)
-        TraceLogger(effects) << " ... " << target->Dump();
+        TraceLogger(effects) << " ... " << target->Dump(1);
 
     Execute(context, targets);
 
     TraceLogger(effects) << "SetShipPartMeter execute targets after: ";
     for (auto& target : targets)
-        TraceLogger(effects) << " ... " << target->Dump();
+        TraceLogger(effects) << " ... " << target->Dump(1);
 }
 
 void SetShipPartMeter::Execute(const ScriptingContext& context, const TargetSet& targets) const {
@@ -745,8 +744,8 @@ void SetShipPartMeter::Execute(const ScriptingContext& context, const TargetSet&
     }
 }
 
-std::string SetShipPartMeter::Dump() const {
-    std::string retval = DumpIndent();
+std::string SetShipPartMeter::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs);
     switch (m_meter) {
         case METER_CAPACITY:            retval += "SetCapacity";        break;
         case METER_MAX_CAPACITY:        retval += "SetMaxCapacity";     break;
@@ -756,9 +755,9 @@ std::string SetShipPartMeter::Dump() const {
     }
 
     if (m_part_name)
-        retval += " partname = " + m_part_name->Dump();
+        retval += " partname = " + m_part_name->Dump(ntabs);
 
-    retval += " value = " + m_value->Dump();
+    retval += " value = " + m_value->Dump(ntabs);
 
     return retval;
 }
@@ -868,8 +867,8 @@ void SetEmpireMeter::Execute(const ScriptingContext& context, const TargetSet& t
     //EffectBase::Execute(context, targets);
 }
 
-std::string SetEmpireMeter::Dump() const
-{ return DumpIndent() + "SetEmpireMeter meter = " + m_meter + " empire = " + m_empire_id->Dump() + " value = " + m_value->Dump(); }
+std::string SetEmpireMeter::Dump(unsigned short ntabs) const
+{ return DumpIndent(ntabs) + "SetEmpireMeter meter = " + m_meter + " empire = " + m_empire_id->Dump(ntabs) + " value = " + m_value->Dump(ntabs); }
 
 void SetEmpireMeter::SetTopLevelContent(const std::string& content_name) {
     if (m_empire_id)
@@ -925,13 +924,13 @@ void SetEmpireStockpile::Execute(const ScriptingContext& context) const {
     empire->SetResourceStockpile(m_stockpile, value);
 }
 
-std::string SetEmpireStockpile::Dump() const {
-    std::string retval = DumpIndent();
+std::string SetEmpireStockpile::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs);
     switch (m_stockpile) {
     case RE_TRADE:      retval += "SetEmpireTradeStockpile"; break;
     default:            retval += "?"; break;
     }
-    retval += " empire = " + m_empire_id->Dump() + " value = " + m_value->Dump() + "\n";
+    retval += " empire = " + m_empire_id->Dump(ntabs) + " value = " + m_value->Dump(ntabs) + "\n";
     return retval;
 }
 
@@ -983,8 +982,8 @@ void SetEmpireCapital::Execute(const ScriptingContext& context) const {
     empire->SetCapitalID(planet->ID());
 }
 
-std::string SetEmpireCapital::Dump() const
-{ return DumpIndent() + "SetEmpireCapital empire = " + m_empire_id->Dump() + "\n"; }
+std::string SetEmpireCapital::Dump(unsigned short ntabs) const
+{ return DumpIndent(ntabs) + "SetEmpireCapital empire = " + m_empire_id->Dump(ntabs) + "\n"; }
 
 void SetEmpireCapital::SetTopLevelContent(const std::string& content_name) {
     if (m_empire_id)
@@ -1027,8 +1026,8 @@ void SetPlanetType::Execute(const ScriptingContext& context) const {
     }
 }
 
-std::string SetPlanetType::Dump() const
-{ return DumpIndent() + "SetPlanetType type = " + m_type->Dump() + "\n"; }
+std::string SetPlanetType::Dump(unsigned short ntabs) const
+{ return DumpIndent(ntabs) + "SetPlanetType type = " + m_type->Dump(ntabs) + "\n"; }
 
 void SetPlanetType::SetTopLevelContent(const std::string& content_name) {
     if (m_type)
@@ -1069,8 +1068,8 @@ void SetPlanetSize::Execute(const ScriptingContext& context) const {
     }
 }
 
-std::string SetPlanetSize::Dump() const
-{ return DumpIndent() + "SetPlanetSize size = " + m_size->Dump() + "\n"; }
+std::string SetPlanetSize::Dump(unsigned short ntabs) const
+{ return DumpIndent(ntabs) + "SetPlanetSize size = " + m_size->Dump(ntabs) + "\n"; }
 
 void SetPlanetSize::SetTopLevelContent(const std::string& content_name) {
     if (m_size)
@@ -1145,8 +1144,8 @@ void SetSpecies::Execute(const ScriptingContext& context) const {
     }
 }
 
-std::string SetSpecies::Dump() const
-{ return DumpIndent() + "SetSpecies name = " + m_species_name->Dump() + "\n"; }
+std::string SetSpecies::Dump(unsigned short ntabs) const
+{ return DumpIndent(ntabs) + "SetSpecies name = " + m_species_name->Dump(ntabs) + "\n"; }
 
 void SetSpecies::SetTopLevelContent(const std::string& content_name) {
     if (m_species_name)
@@ -1211,8 +1210,8 @@ void SetOwner::Execute(const ScriptingContext& context) const {
     }
 }
 
-std::string SetOwner::Dump() const
-{ return DumpIndent() + "SetOwner empire = " + m_empire_id->Dump() + "\n"; }
+std::string SetOwner::Dump(unsigned short ntabs) const
+{ return DumpIndent(ntabs) + "SetOwner empire = " + m_empire_id->Dump(ntabs) + "\n"; }
 
 void SetOwner::SetTopLevelContent(const std::string& content_name) {
     if (m_empire_id)
@@ -1266,8 +1265,8 @@ void SetSpeciesEmpireOpinion::Execute(const ScriptingContext& context) const {
     GetSpeciesManager().SetSpeciesEmpireOpinion(species_name, empire_id, opinion);
 }
 
-std::string SetSpeciesEmpireOpinion::Dump() const
-{ return DumpIndent() + "SetSpeciesEmpireOpinion empire = " + m_empire_id->Dump() + "\n"; }
+std::string SetSpeciesEmpireOpinion::Dump(unsigned short ntabs) const
+{ return DumpIndent(ntabs) + "SetSpeciesEmpireOpinion empire = " + m_empire_id->Dump(ntabs) + "\n"; }
 
 void SetSpeciesEmpireOpinion::SetTopLevelContent(const std::string& content_name) {
     if (m_empire_id)
@@ -1327,8 +1326,8 @@ void SetSpeciesSpeciesOpinion::Execute(const ScriptingContext& context) const {
     GetSpeciesManager().SetSpeciesSpeciesOpinion(opinionated_species_name, rated_species_name, opinion);
 }
 
-std::string SetSpeciesSpeciesOpinion::Dump() const
-{ return DumpIndent() + "SetSpeciesSpeciesOpinion" + "\n"; }
+std::string SetSpeciesSpeciesOpinion::Dump(unsigned short ntabs) const
+{ return DumpIndent(ntabs) + "SetSpeciesSpeciesOpinion" + "\n"; }
 
 void SetSpeciesSpeciesOpinion::SetTopLevelContent(const std::string& content_name) {
     if (m_opinionated_species_name)
@@ -1428,14 +1427,14 @@ void CreatePlanet::Execute(const ScriptingContext& context) const {
     }
 }
 
-std::string CreatePlanet::Dump() const {
-    std::string retval = DumpIndent() + "CreatePlanet";
+std::string CreatePlanet::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "CreatePlanet";
     if (m_size)
-        retval += " size = " + m_size->Dump();
+        retval += " size = " + m_size->Dump(ntabs);
     if (m_type)
-        retval += " type = " + m_type->Dump();
+        retval += " type = " + m_type->Dump(ntabs);
     if (m_name)
-        retval += " name = " + m_name->Dump();
+        retval += " name = " + m_name->Dump(ntabs);
     return retval + "\n";
 }
 
@@ -1539,12 +1538,12 @@ void CreateBuilding::Execute(const ScriptingContext& context) const {
     }
 }
 
-std::string CreateBuilding::Dump() const {
-    std::string retval = DumpIndent() + "CreateBuilding";
+std::string CreateBuilding::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "CreateBuilding";
     if (m_building_type_name)
-        retval += " type = " + m_building_type_name->Dump();
+        retval += " type = " + m_building_type_name->Dump(ntabs);
     if (m_name)
-        retval += " name = " + m_name->Dump();
+        retval += " name = " + m_name->Dump(ntabs);
     return retval + "\n";
 }
 
@@ -1705,18 +1704,18 @@ void CreateShip::Execute(const ScriptingContext& context) const {
     }
 }
 
-std::string CreateShip::Dump() const {
-    std::string retval = DumpIndent() + "CreateShip";
+std::string CreateShip::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "CreateShip";
     if (m_design_id)
-        retval += " designid = " + m_design_id->Dump();
+        retval += " designid = " + m_design_id->Dump(ntabs);
     if (m_design_name)
-        retval += " designname = " + m_design_name->Dump();
+        retval += " designname = " + m_design_name->Dump(ntabs);
     if (m_empire_id)
-        retval += " empire = " + m_empire_id->Dump();
+        retval += " empire = " + m_empire_id->Dump(ntabs);
     if (m_species_name)
-        retval += " species = " + m_species_name->Dump();
+        retval += " species = " + m_species_name->Dump(ntabs);
     if (m_name)
-        retval += " name = " + m_name->Dump();
+        retval += " name = " + m_name->Dump(ntabs);
 
     retval += "\n";
     return retval;
@@ -1859,18 +1858,18 @@ void CreateField::Execute(const ScriptingContext& context) const {
     }
 }
 
-std::string CreateField::Dump() const {
-    std::string retval = DumpIndent() + "CreateField";
+std::string CreateField::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "CreateField";
     if (m_field_type_name)
-        retval += " type = " + m_field_type_name->Dump();
+        retval += " type = " + m_field_type_name->Dump(ntabs);
     if (m_x)
-        retval += " x = " + m_x->Dump();
+        retval += " x = " + m_x->Dump(ntabs);
     if (m_y)
-        retval += " y = " + m_y->Dump();
+        retval += " y = " + m_y->Dump(ntabs);
     if (m_size)
-        retval += " size = " + m_size->Dump();
+        retval += " size = " + m_size->Dump(ntabs);
     if (m_name)
-        retval += " name = " + m_name->Dump();
+        retval += " name = " + m_name->Dump(ntabs);
     retval += "\n";
     return retval;
 }
@@ -1986,16 +1985,16 @@ void CreateSystem::Execute(const ScriptingContext& context) const {
     }
 }
 
-std::string CreateSystem::Dump() const {
-    std::string retval = DumpIndent() + "CreateSystem";
+std::string CreateSystem::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "CreateSystem";
     if (m_type)
-        retval += " type = " + m_type->Dump();
+        retval += " type = " + m_type->Dump(ntabs);
     if (m_x)
-        retval += " x = " + m_x->Dump();
+        retval += " x = " + m_x->Dump(ntabs);
     if (m_y)
-        retval += " y = " + m_y->Dump();
+        retval += " y = " + m_y->Dump(ntabs);
     if (m_name)
-        retval += " name = " + m_name->Dump();
+        retval += " name = " + m_name->Dump(ntabs);
     retval += "\n";
     return retval;
 }
@@ -2050,8 +2049,8 @@ void Destroy::Execute(const ScriptingContext& context) const {
     GetUniverse().EffectDestroy(context.effect_target->ID(), source_id);
 }
 
-std::string Destroy::Dump() const
-{ return DumpIndent() + "Destroy\n"; }
+std::string Destroy::Dump(unsigned short ntabs) const
+{ return DumpIndent(ntabs) + "Destroy\n"; }
 
 unsigned int Destroy::GetCheckSum() const {
     unsigned int retval{0};
@@ -2094,9 +2093,9 @@ void AddSpecial::Execute(const ScriptingContext& context) const {
     context.effect_target->SetSpecialCapacity(name, capacity);
 }
 
-std::string AddSpecial::Dump() const {
-    return DumpIndent() + "AddSpecial name = " +  (m_name ? m_name->Dump() : "") +
-        " capacity = " + (m_capacity ? m_capacity->Dump() : "0.0") +  "\n";
+std::string AddSpecial::Dump(unsigned short ntabs) const {
+    return DumpIndent(ntabs) + "AddSpecial name = " +  (m_name ? m_name->Dump(ntabs) : "") +
+        " capacity = " + (m_capacity ? m_capacity->Dump(ntabs) : "0.0") +  "\n";
 }
 
 void AddSpecial::SetTopLevelContent(const std::string& content_name) {
@@ -2142,8 +2141,8 @@ void RemoveSpecial::Execute(const ScriptingContext& context) const {
     context.effect_target->RemoveSpecial(name);
 }
 
-std::string RemoveSpecial::Dump() const {
-    return DumpIndent() + "RemoveSpecial name = " +  (m_name ? m_name->Dump() : "") + "\n";
+std::string RemoveSpecial::Dump(unsigned short ntabs) const {
+    return DumpIndent(ntabs) + "RemoveSpecial name = " +  (m_name ? m_name->Dump(ntabs) : "") + "\n";
 }
 
 void RemoveSpecial::SetTopLevelContent(const std::string& content_name) {
@@ -2212,8 +2211,8 @@ void AddStarlanes::Execute(const ScriptingContext& context) const {
     }
 }
 
-std::string AddStarlanes::Dump() const
-{ return DumpIndent() + "AddStarlanes endpoints = " + m_other_lane_endpoint_condition->Dump() + "\n"; }
+std::string AddStarlanes::Dump(unsigned short ntabs) const
+{ return DumpIndent(ntabs) + "AddStarlanes endpoints = " + m_other_lane_endpoint_condition->Dump(ntabs) + "\n"; }
 
 void AddStarlanes::SetTopLevelContent(const std::string& content_name) {
     if (m_other_lane_endpoint_condition)
@@ -2283,8 +2282,8 @@ void RemoveStarlanes::Execute(const ScriptingContext& context) const {
     }
 }
 
-std::string RemoveStarlanes::Dump() const
-{ return DumpIndent() + "RemoveStarlanes endpoints = " + m_other_lane_endpoint_condition->Dump() + "\n"; }
+std::string RemoveStarlanes::Dump(unsigned short ntabs) const
+{ return DumpIndent(ntabs) + "RemoveStarlanes endpoints = " + m_other_lane_endpoint_condition->Dump(ntabs) + "\n"; }
 
 void RemoveStarlanes::SetTopLevelContent(const std::string& content_name) {
     if (m_other_lane_endpoint_condition)
@@ -2323,8 +2322,8 @@ void SetStarType::Execute(const ScriptingContext& context) const {
         ErrorLogger() << "SetStarType::Execute given a non-system target";
 }
 
-std::string SetStarType::Dump() const
-{ return DumpIndent() + "SetStarType type = " + m_type->Dump() + "\n"; }
+std::string SetStarType::Dump(unsigned short ntabs) const
+{ return DumpIndent(ntabs) + "SetStarType type = " + m_type->Dump(ntabs) + "\n"; }
 
 void SetStarType::SetTopLevelContent(const std::string& content_name) {
     if (m_type)
@@ -2617,8 +2616,8 @@ void MoveTo::Execute(const ScriptingContext& context) const {
     }
 }
 
-std::string MoveTo::Dump() const
-{ return DumpIndent() + "MoveTo destination = " + m_location_condition->Dump() + "\n"; }
+std::string MoveTo::Dump(unsigned short ntabs) const
+{ return DumpIndent(ntabs) + "MoveTo destination = " + m_location_condition->Dump(ntabs) + "\n"; }
 
 void MoveTo::SetTopLevelContent(const std::string& content_name) {
     if (m_location_condition)
@@ -2752,13 +2751,13 @@ void MoveInOrbit::Execute(const ScriptingContext& context) const {
     // don't move planets or buildings, as these can't exist outside of systems
 }
 
-std::string MoveInOrbit::Dump() const {
+std::string MoveInOrbit::Dump(unsigned short ntabs) const {
     if (m_focal_point_condition)
-        return DumpIndent() + "MoveInOrbit around = " + m_focal_point_condition->Dump() + "\n";
+        return DumpIndent(ntabs) + "MoveInOrbit around = " + m_focal_point_condition->Dump(ntabs) + "\n";
     else if (m_focus_x && m_focus_y)
-        return DumpIndent() + "MoveInOrbit x = " + m_focus_x->Dump() + " y = " + m_focus_y->Dump() + "\n";
+        return DumpIndent(ntabs) + "MoveInOrbit x = " + m_focus_x->Dump(ntabs) + " y = " + m_focus_y->Dump(ntabs) + "\n";
     else
-        return DumpIndent() + "MoveInOrbit";
+        return DumpIndent(ntabs) + "MoveInOrbit";
 }
 
 void MoveInOrbit::SetTopLevelContent(const std::string& content_name) {
@@ -2912,13 +2911,13 @@ void MoveTowards::Execute(const ScriptingContext& context) const {
     // don't move planets or buildings, as these can't exist outside of systems
 }
 
-std::string MoveTowards::Dump() const {
+std::string MoveTowards::Dump(unsigned short ntabs) const {
     if (m_dest_condition)
-        return DumpIndent() + "MoveTowards destination = " + m_dest_condition->Dump() + "\n";
+        return DumpIndent(ntabs) + "MoveTowards destination = " + m_dest_condition->Dump(ntabs) + "\n";
     else if (m_dest_x && m_dest_y)
-        return DumpIndent() + "MoveTowards x = " + m_dest_x->Dump() + " y = " + m_dest_y->Dump() + "\n";
+        return DumpIndent(ntabs) + "MoveTowards x = " + m_dest_x->Dump(ntabs) + " y = " + m_dest_y->Dump(ntabs) + "\n";
     else
-        return DumpIndent() + "MoveTowards";
+        return DumpIndent(ntabs) + "MoveTowards";
 }
 
 void MoveTowards::SetTopLevelContent(const std::string& content_name) {
@@ -3012,8 +3011,8 @@ void SetDestination::Execute(const ScriptingContext& context) const {
     target_fleet->SetRoute(route_list);
 }
 
-std::string SetDestination::Dump() const
-{ return DumpIndent() + "SetDestination destination = " + m_location_condition->Dump() + "\n"; }
+std::string SetDestination::Dump(unsigned short ntabs) const
+{ return DumpIndent(ntabs) + "SetDestination destination = " + m_location_condition->Dump(ntabs) + "\n"; }
 
 void SetDestination::SetTopLevelContent(const std::string& content_name) {
     if (m_location_condition)
@@ -3054,8 +3053,8 @@ void SetAggression::Execute(const ScriptingContext& context) const {
     target_fleet->SetAggressive(m_aggressive);
 }
 
-std::string SetAggression::Dump() const
-{ return DumpIndent() + (m_aggressive ? "SetAggressive" : "SetPassive") + "\n"; }
+std::string SetAggression::Dump(unsigned short ntabs) const
+{ return DumpIndent(ntabs) + (m_aggressive ? "SetAggressive" : "SetPassive") + "\n"; }
 
 unsigned int SetAggression::GetCheckSum() const {
     unsigned int retval{0};
@@ -3086,8 +3085,8 @@ void Victory::Execute(const ScriptingContext& context) const {
         ErrorLogger() << "Trying to grant victory to a missing empire!";
 }
 
-std::string Victory::Dump() const
-{ return DumpIndent() + "Victory reason = \"" + m_reason_string + "\"\n"; }
+std::string Victory::Dump(unsigned short ntabs) const
+{ return DumpIndent(ntabs) + "Victory reason = \"" + m_reason_string + "\"\n"; }
 
 unsigned int Victory::GetCheckSum() const {
     unsigned int retval{0};
@@ -3145,14 +3144,14 @@ void SetEmpireTechProgress::Execute(const ScriptingContext& context) const {
     empire->SetTechResearchProgress(tech_name, value);
 }
 
-std::string SetEmpireTechProgress::Dump() const {
+std::string SetEmpireTechProgress::Dump(unsigned short ntabs) const {
     std::string retval = "SetEmpireTechProgress name = ";
     if (m_tech_name)
-        retval += m_tech_name->Dump();
+        retval += m_tech_name->Dump(ntabs);
     if (m_research_progress)
-        retval += " progress = " + m_research_progress->Dump();
+        retval += " progress = " + m_research_progress->Dump(ntabs);
     if (m_empire_id)
-        retval += " empire = " + m_empire_id->Dump() + "\n";
+        retval += " empire = " + m_empire_id->Dump(ntabs) + "\n";
     return retval;
 }
 
@@ -3212,14 +3211,14 @@ void GiveEmpireTech::Execute(const ScriptingContext& context) const {
     empire->AddTech(tech_name);
 }
 
-std::string GiveEmpireTech::Dump() const {
-    std::string retval = DumpIndent() + "GiveEmpireTech";
+std::string GiveEmpireTech::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "GiveEmpireTech";
 
     if (m_tech_name)
-        retval += " name = " + m_tech_name->Dump();
+        retval += " name = " + m_tech_name->Dump(ntabs);
 
     if (m_empire_id)
-        retval += " empire = " + m_empire_id->Dump();
+        retval += " empire = " + m_empire_id->Dump(ntabs);
 
     retval += "\n";
     return retval;
@@ -3414,25 +3413,25 @@ void GenerateSitRepMessage::Execute(const ScriptingContext& context) const {
     }
 }
 
-std::string GenerateSitRepMessage::Dump() const {
-    std::string retval = DumpIndent();
+std::string GenerateSitRepMessage::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs);
     retval += "GenerateSitRepMessage\n";
-    ++g_indent;
-    retval += DumpIndent() + "message = \"" + m_message_string + "\"" + " icon = " + m_icon + "\n";
+    ++ntabs;
+    retval += DumpIndent(ntabs) + "message = \"" + m_message_string + "\"" + " icon = " + m_icon + "\n";
 
     if (m_message_parameters.size() == 1) {
-        retval += DumpIndent() + "parameters = tag = " + m_message_parameters[0].first + " data = " + m_message_parameters[0].second->Dump() + "\n";
+        retval += DumpIndent(ntabs) + "parameters = tag = " + m_message_parameters[0].first + " data = " + m_message_parameters[0].second->Dump(ntabs) + "\n";
     } else if (!m_message_parameters.empty()) {
-        retval += DumpIndent() + "parameters = [ ";
+        retval += DumpIndent(ntabs) + "parameters = [ ";
         for (const auto& entry : m_message_parameters) {
             retval += " tag = " + entry.first
-                   + " data = " + entry.second->Dump()
+                   + " data = " + entry.second->Dump(ntabs)
                    + " ";
         }
         retval += "]\n";
     }
 
-    retval += DumpIndent() + "affiliation = ";
+    retval += DumpIndent(ntabs) + "affiliation = ";
     switch (m_affiliation) {
     case AFFIL_SELF:    retval += "TheEmpire";  break;
     case AFFIL_ENEMY:   retval += "EnemyOf";    break;
@@ -3444,10 +3443,10 @@ std::string GenerateSitRepMessage::Dump() const {
     }
 
     if (m_recipient_empire_id)
-        retval += "\n" + DumpIndent() + "empire = " + m_recipient_empire_id->Dump() + "\n";
+        retval += "\n" + DumpIndent(ntabs) + "empire = " + m_recipient_empire_id->Dump(ntabs) + "\n";
     if (m_condition)
-        retval += "\n" + DumpIndent() + "condition = " + m_condition->Dump() + "\n";
-    --g_indent;
+        retval += "\n" + DumpIndent(ntabs) + "condition = " + m_condition->Dump(ntabs) + "\n";
+    --ntabs;
 
     return retval;
 }
@@ -3517,10 +3516,10 @@ void SetOverlayTexture::Execute(const ScriptingContext& context) const {
         system->SetOverlayTexture(m_texture, size);
 }
 
-std::string SetOverlayTexture::Dump() const {
-    std::string retval = DumpIndent() + "SetOverlayTexture texture = " + m_texture;
+std::string SetOverlayTexture::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "SetOverlayTexture texture = " + m_texture;
     if (m_size)
-        retval += " size = " + m_size->Dump();
+        retval += " size = " + m_size->Dump(ntabs);
     retval += "\n";
     return retval;
 }
@@ -3556,8 +3555,8 @@ void SetTexture::Execute(const ScriptingContext& context) const {
         planet->SetSurfaceTexture(m_texture);
 }
 
-std::string SetTexture::Dump() const
-{ return DumpIndent() + "SetTexture texture = " + m_texture + "\n"; }
+std::string SetTexture::Dump(unsigned short ntabs) const
+{ return DumpIndent(ntabs) + "SetTexture texture = " + m_texture + "\n"; }
 
 unsigned int SetTexture::GetCheckSum() const {
     unsigned int retval{0};
@@ -3679,10 +3678,10 @@ void SetVisibility::Execute(const ScriptingContext& context) const {
     }
 }
 
-std::string SetVisibility::Dump() const {
-    std::string retval = DumpIndent();
+std::string SetVisibility::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs);
 
-    retval += DumpIndent() + "SetVisibility affiliation = ";
+    retval += DumpIndent(ntabs) + "SetVisibility affiliation = ";
     switch (m_affiliation) {
     case AFFIL_SELF:    retval += "TheEmpire";  break;
     case AFFIL_ENEMY:   retval += "EnemyOf";    break;
@@ -3694,13 +3693,13 @@ std::string SetVisibility::Dump() const {
     }
 
     if (m_empire_id)
-        retval += " empire = " + m_empire_id->Dump();
+        retval += " empire = " + m_empire_id->Dump(ntabs);
 
     if (m_vis)
-        retval += " visibility = " + m_vis->Dump();
+        retval += " visibility = " + m_vis->Dump(ntabs);
 
     if (m_condition)
-        retval += " condition = " + m_condition->Dump();
+        retval += " condition = " + m_condition->Dump(ntabs);
 
     retval += "\n";
     return retval;
@@ -3829,47 +3828,47 @@ void Conditional::Execute(const ScriptingContext& context,
     }
 }
 
-std::string Conditional::Dump() const {
-    std::string retval = DumpIndent() + "If\n";
-    ++g_indent;
+std::string Conditional::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "If\n";
+    ++ntabs;
     if (m_target_condition) {
-        retval += DumpIndent() + "condition =\n";
-        ++g_indent;
-        retval += m_target_condition->Dump();
-        --g_indent;
+        retval += DumpIndent(ntabs) + "condition =\n";
+        ++ntabs;
+        retval += m_target_condition->Dump(ntabs);
+        --ntabs;
     }
 
     if (m_true_effects.size() == 1) {
-        retval += DumpIndent() + "effects =\n";
-        ++g_indent;
-        retval += m_true_effects[0]->Dump();
-        --g_indent;
+        retval += DumpIndent(ntabs) + "effects =\n";
+        ++ntabs;
+        retval += m_true_effects[0]->Dump(ntabs);
+        --ntabs;
     } else {
-        retval += DumpIndent() + "effects = [\n";
-        ++g_indent;
+        retval += DumpIndent(ntabs) + "effects = [\n";
+        ++ntabs;
         for (auto& effect : m_true_effects) {
-            retval += effect->Dump();
+            retval += effect->Dump(ntabs);
         }
-        --g_indent;
-        retval += DumpIndent() + "]\n";
+        --ntabs;
+        retval += DumpIndent(ntabs) + "]\n";
     }
 
     if (m_false_effects.empty()) {
     } else if (m_false_effects.size() == 1) {
-        retval += DumpIndent() + "else =\n";
-        ++g_indent;
-        retval += m_false_effects[0]->Dump();
-        --g_indent;
+        retval += DumpIndent(ntabs) + "else =\n";
+        ++ntabs;
+        retval += m_false_effects[0]->Dump(ntabs);
+        --ntabs;
     } else {
-        retval += DumpIndent() + "else = [\n";
-        ++g_indent;
+        retval += DumpIndent(ntabs) + "else = [\n";
+        ++ntabs;
         for (auto& effect : m_false_effects) {
-            retval += effect->Dump();
+            retval += effect->Dump(ntabs);
         }
-        --g_indent;
-        retval += DumpIndent() + "]\n";
+        --ntabs;
+        retval += DumpIndent(ntabs) + "]\n";
     }
-    --g_indent;
+    --ntabs;
 
     return retval;
 }

--- a/universe/Effect.h
+++ b/universe/Effect.h
@@ -62,7 +62,7 @@ public:
     const std::string&              GetDescription() const;
     const std::string&              AccountingLabel() const     { return m_accounting_label; }
     int                             Priority() const            { return m_priority; }
-    std::string                     Dump() const;
+    std::string                     Dump(unsigned short ntabs = 0) const;
     bool                            HasMeterEffects() const;
     bool                            HasAppearanceEffects() const;
     bool                            HasSitrepEffects() const;
@@ -118,7 +118,7 @@ public:
                          bool include_empire_meter_effects = false,
                          bool only_generate_sitrep_effects = false) const;
 
-    virtual std::string Dump() const = 0;
+    virtual std::string Dump(unsigned short ntabs = 0) const = 0;
 
     virtual bool IsMeterEffect() const
     { return false; }
@@ -153,7 +153,7 @@ public:
 
     void Execute(const ScriptingContext& context) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override
     {}
@@ -191,7 +191,7 @@ public:
                  bool include_empire_meter_effects = false,
                  bool only_generate_sitrep_effects = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     bool IsMeterEffect() const override
     { return true; }
@@ -245,7 +245,7 @@ public:
                  bool include_empire_meter_effects = false,
                  bool only_generate_sitrep_effects = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     bool IsMeterEffect() const override
     { return true; }
@@ -295,7 +295,7 @@ public:
                  bool include_empire_meter_effects = false,
                  bool only_generate_sitrep_effects = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     bool IsMeterEffect() const override
     { return true; }
@@ -332,7 +332,7 @@ public:
 
     void Execute(const ScriptingContext& context) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -361,7 +361,7 @@ public:
 
     void Execute(const ScriptingContext& context) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -387,7 +387,7 @@ public:
 
     void Execute(const ScriptingContext& context) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -414,7 +414,7 @@ public:
 
     void Execute(const ScriptingContext& context) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -438,7 +438,7 @@ public:
 
     void Execute(const ScriptingContext& context) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -462,7 +462,7 @@ public:
 
     void Execute(const ScriptingContext& context) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -488,7 +488,7 @@ public:
 
     void Execute(const ScriptingContext& context) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -516,7 +516,7 @@ public:
 
     void Execute(const ScriptingContext& context) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -545,7 +545,7 @@ public:
 
     void Execute(const ScriptingContext& context) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -573,7 +573,7 @@ public:
 
     void Execute(const ScriptingContext& context) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -610,7 +610,7 @@ public:
 
     void Execute(const ScriptingContext& context) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -649,7 +649,7 @@ public:
 
     void Execute(const ScriptingContext& context) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -687,7 +687,7 @@ public:
 
     void Execute(const ScriptingContext& context) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -716,7 +716,7 @@ public:
 
     void Execute(const ScriptingContext& context) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override
     {}
@@ -741,7 +741,7 @@ public:
 
     void Execute(const ScriptingContext& context) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -771,7 +771,7 @@ public:
 
     void Execute(const ScriptingContext& context) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -795,7 +795,7 @@ public:
 
     void Execute(const ScriptingContext& context) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -819,7 +819,7 @@ public:
 
     void Execute(const ScriptingContext& context) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -843,7 +843,7 @@ public:
 
     void Execute(const ScriptingContext& context) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -869,7 +869,7 @@ public:
 
     void Execute(const ScriptingContext& context) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -899,7 +899,7 @@ public:
 
     void Execute(const ScriptingContext& context) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -931,7 +931,7 @@ public:
 
     void Execute(const ScriptingContext& context) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -960,7 +960,7 @@ public:
 
     void Execute(const ScriptingContext& context) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -981,7 +981,7 @@ public:
 
     void Execute(const ScriptingContext& context) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override
     {}
@@ -1004,7 +1004,7 @@ public:
 
     void Execute(const ScriptingContext& context) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override
     {}
@@ -1034,7 +1034,7 @@ public:
 
     void Execute(const ScriptingContext& context) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -1059,7 +1059,7 @@ public:
 
     void Execute(const ScriptingContext& context) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -1112,7 +1112,7 @@ public:
     bool IsSitrepEffect() const override
     { return true; }
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -1160,7 +1160,7 @@ public:
 
     void Execute(const ScriptingContext& context) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     bool IsAppearanceEffect() const override
     { return true; }
@@ -1185,7 +1185,7 @@ public:
 
     void Execute(const ScriptingContext& context) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     bool IsAppearanceEffect() const override
     { return true; }
@@ -1215,7 +1215,7 @@ public:
 
     void Execute(const ScriptingContext& context) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -1267,7 +1267,7 @@ public:
                  bool include_empire_meter_effects = false,
                  bool only_generate_sitrep_effects = false) const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     bool IsMeterEffect() const override;
 

--- a/universe/Field.cpp
+++ b/universe/Field.cpp
@@ -112,9 +112,9 @@ bool Field::HasTag(const std::string& name) const {
 UniverseObjectType Field::ObjectType() const
 { return OBJ_FIELD; }
 
-std::string Field::Dump() const {
+std::string Field::Dump(unsigned short ntabs) const {
     std::stringstream os;
-    os << UniverseObject::Dump();
+    os << UniverseObject::Dump(ntabs);
     os << " field type: " << m_type_name;
     return os.str();
 }
@@ -193,31 +193,31 @@ FieldType::FieldType(const std::string& name, const std::string& description,
 FieldType::~FieldType()
 {}
 
-std::string FieldType::Dump() const {
-    std::string retval = DumpIndent() + "FieldType\n";
-    ++g_indent;
-    retval += DumpIndent() + "name = \"" + m_name + "\"\n";
-    retval += DumpIndent() + "description = \"" + m_description + "\"\n";
-    retval += DumpIndent() + "location = \n";
-    //++g_indent;
-    //retval += m_location->Dump();
-    //--g_indent;
+std::string FieldType::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "FieldType\n";
+    ++ntabs;
+    retval += DumpIndent(ntabs) + "name = \"" + m_name + "\"\n";
+    retval += DumpIndent(ntabs) + "description = \"" + m_description + "\"\n";
+    retval += DumpIndent(ntabs) + "location = \n";
+    //++ntabs;
+    //retval += m_location->Dump(ntabs);
+    //--ntabs;
     if (m_effects.size() == 1) {
-        retval += DumpIndent() + "effectsgroups =\n";
-        ++g_indent;
-        retval += m_effects[0]->Dump();
-        --g_indent;
+        retval += DumpIndent(ntabs) + "effectsgroups =\n";
+        ++ntabs;
+        retval += m_effects[0]->Dump(ntabs);
+        --ntabs;
     } else {
-        retval += DumpIndent() + "effectsgroups = [\n";
-        ++g_indent;
+        retval += DumpIndent(ntabs) + "effectsgroups = [\n";
+        ++ntabs;
         for (auto& effect : m_effects) {
-            retval += effect->Dump();
+            retval += effect->Dump(ntabs);
         }
-        --g_indent;
-        retval += DumpIndent() + "]\n";
+        --ntabs;
+        retval += DumpIndent(ntabs) + "]\n";
     }
-    retval += DumpIndent() + "graphic = \"" + m_graphic + "\"\n";
-    --g_indent;
+    retval += DumpIndent(ntabs) + "graphic = \"" + m_graphic + "\"\n";
+    --ntabs;
     return retval;
 }
 

--- a/universe/Field.cpp
+++ b/universe/Field.cpp
@@ -195,29 +195,21 @@ FieldType::~FieldType()
 
 std::string FieldType::Dump(unsigned short ntabs) const {
     std::string retval = DumpIndent(ntabs) + "FieldType\n";
-    ++ntabs;
-    retval += DumpIndent(ntabs) + "name = \"" + m_name + "\"\n";
-    retval += DumpIndent(ntabs) + "description = \"" + m_description + "\"\n";
-    retval += DumpIndent(ntabs) + "location = \n";
-    //++ntabs;
-    //retval += m_location->Dump(ntabs);
-    //--ntabs;
+    retval += DumpIndent(ntabs+1) + "name = \"" + m_name + "\"\n";
+    retval += DumpIndent(ntabs+1) + "description = \"" + m_description + "\"\n";
+    retval += DumpIndent(ntabs+1) + "location = \n";
+    //retval += m_location->Dump(ntabs+2);
     if (m_effects.size() == 1) {
-        retval += DumpIndent(ntabs) + "effectsgroups =\n";
-        ++ntabs;
-        retval += m_effects[0]->Dump(ntabs);
-        --ntabs;
+        retval += DumpIndent(ntabs+1) + "effectsgroups =\n";
+        retval += m_effects[0]->Dump(ntabs+2);
     } else {
-        retval += DumpIndent(ntabs) + "effectsgroups = [\n";
-        ++ntabs;
+        retval += DumpIndent(ntabs+1) + "effectsgroups = [\n";
         for (auto& effect : m_effects) {
-            retval += effect->Dump(ntabs);
+            retval += effect->Dump(ntabs+2);
         }
-        --ntabs;
-        retval += DumpIndent(ntabs) + "]\n";
+        retval += DumpIndent(ntabs+1) + "]\n";
     }
-    retval += DumpIndent(ntabs) + "graphic = \"" + m_graphic + "\"\n";
-    --ntabs;
+    retval += DumpIndent(ntabs+1) + "graphic = \"" + m_graphic + "\"\n";
     return retval;
 }
 

--- a/universe/Field.h
+++ b/universe/Field.h
@@ -20,7 +20,7 @@ public:
 
     UniverseObjectType ObjectType() const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     int ContainerObjectID() const override;
 
@@ -87,7 +87,7 @@ public:
     /** \name Accessors */ //@{
     const std::string&              Name() const            { return m_name; }          ///< returns the unique name for this type of field
     const std::string&              Description() const     { return m_description; }   ///< returns a text description of this type of building
-    std::string                     Dump() const;                                       ///< returns a data file format representation of this object
+    std::string                     Dump(unsigned short ntabs = 0) const;                                       ///< returns a data file format representation of this object
     float                           Stealth() const         { return m_stealth; }       ///< returns stealth of field type
     const std::set<std::string>&    Tags() const            { return m_tags; }
 

--- a/universe/Fighter.cpp
+++ b/universe/Fighter.cpp
@@ -49,9 +49,9 @@ const std::string& Fighter::SpeciesName() const
 void Fighter::SetDestroyed(bool destroyed)
 { m_destroyed = destroyed; }
 
-std::string Fighter::Dump() const {
+std::string Fighter::Dump(unsigned short ntabs) const {
     std::stringstream os;
-    os << UniverseObject::Dump();
+    os << UniverseObject::Dump(ntabs);
     os << " (Combat Fighter) damage: " << m_damage;
     if (m_destroyed)
         os << "  (DESTROYED)";

--- a/universe/Fighter.h
+++ b/universe/Fighter.h
@@ -19,7 +19,7 @@ public:
 
     UniverseObjectType ObjectType() const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     std::shared_ptr<UniverseObject> Accept(const UniverseObjectVisitor& visitor) const override;
 

--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -180,9 +180,9 @@ bool Fleet::HostileToEmpire(int empire_id) const
 UniverseObjectType Fleet::ObjectType() const
 { return OBJ_FLEET; }
 
-std::string Fleet::Dump() const {
+std::string Fleet::Dump(unsigned short ntabs) const {
     std::stringstream os;
-    os << UniverseObject::Dump();
+    os << UniverseObject::Dump(ntabs);
     os << ( m_aggressive ? " agressive" : " passive")
        << " cur system: " << SystemID()
        << " moving to: " << FinalDestinationID()

--- a/universe/Fleet.h
+++ b/universe/Fleet.h
@@ -34,7 +34,7 @@ public:
 
     UniverseObjectType ObjectType() const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     int ContainerObjectID() const override;
 

--- a/universe/Meter.cpp
+++ b/universe/Meter.cpp
@@ -24,7 +24,7 @@ float Meter::Current() const
 float Meter::Initial() const
 { return m_initial_value; }
 
-std::string Meter::Dump() const {
+std::string Meter::Dump(unsigned short ntabs) const {
     std::ostringstream strstm;
     strstm.precision(5);
     strstm << "Cur: " << m_current_value << " Init: " << m_initial_value;

--- a/universe/Meter.h
+++ b/universe/Meter.h
@@ -34,7 +34,7 @@ public:
     float       Current() const;                    ///< returns the current value of the meter
     float       Initial() const;                    ///< returns the value of the meter as it was at the beginning of the turn
 
-    std::string Dump() const;                       ///< returns text of meter values
+    std::string Dump(unsigned short ntabs = 0) const;                       ///< returns text of meter values
     //@}
 
     /** \name Mutators */ //@{

--- a/universe/ObjectMap.cpp
+++ b/universe/ObjectMap.cpp
@@ -373,11 +373,11 @@ void ObjectMap::CopyObjectsToSpecializedMaps() {
     { FOR_EACH_SPECIALIZED_MAP(TryInsertIntoMap, it->second); }
 }
 
-std::string ObjectMap::Dump() const {
+std::string ObjectMap::Dump(unsigned short ntabs) const {
     std::ostringstream dump_stream;
     dump_stream << "ObjectMap contains UniverseObjects: " << std::endl;
     for (const_iterator<> it = const_begin(); it != const_end(); ++it)
-        dump_stream << it->Dump() << std::endl;
+        dump_stream << it->Dump(ntabs) << std::endl;
     dump_stream << std::endl;
     return dump_stream.str();
 }

--- a/universe/ObjectMap.h
+++ b/universe/ObjectMap.h
@@ -266,7 +266,7 @@ public:
     template <class T>
     const_iterator<T>       const_end() const;
 
-    std::string             Dump() const;
+    std::string             Dump(unsigned short ntabs = 0) const;
 
     /**  */
     std::shared_ptr<UniverseObject> ExistingObject(int id);

--- a/universe/Planet.cpp
+++ b/universe/Planet.cpp
@@ -169,11 +169,11 @@ bool Planet::HasTag(const std::string& name) const {
 UniverseObjectType Planet::ObjectType() const
 { return OBJ_PLANET; }
 
-std::string Planet::Dump() const {
+std::string Planet::Dump(unsigned short ntabs) const {
     std::stringstream os;
-    os << UniverseObject::Dump();
-    os << PopCenter::Dump();
-    os << ResourceCenter::Dump();
+    os << UniverseObject::Dump(ntabs);
+    os << PopCenter::Dump(ntabs);
+    os << ResourceCenter::Dump(ntabs);
     os << " type: " << m_type
        << " original type: " << m_original_type
        << " size: " << m_size

--- a/universe/Planet.h
+++ b/universe/Planet.h
@@ -24,7 +24,7 @@ public:
 
     UniverseObjectType ObjectType() const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     int ContainerObjectID() const override;
 

--- a/universe/PopCenter.cpp
+++ b/universe/PopCenter.cpp
@@ -51,7 +51,7 @@ void PopCenter::Init() {
     AddMeter(METER_TARGET_HAPPINESS);
 }
 
-std::string PopCenter::Dump() const {
+std::string PopCenter::Dump(unsigned short ntabs) const {
     std::stringstream os;
     os << " species: " << m_species_name << "  ";
     return os.str();

--- a/universe/PopCenter.h
+++ b/universe/PopCenter.h
@@ -34,7 +34,7 @@ public:
     /** \name Accessors */ //@{
     const std::string&  SpeciesName() const {return m_species_name;}        ///< returns the name of the species that populates this planet
 
-    std::string         Dump() const;
+    std::string         Dump(unsigned short ntabs = 0) const;
 
     float               NextTurnPopGrowth() const;                          ///< predicted pop growth next turn
 

--- a/universe/ResourceCenter.cpp
+++ b/universe/ResourceCenter.cpp
@@ -87,7 +87,7 @@ std::vector<std::string> ResourceCenter::AvailableFoci() const
 const std::string& ResourceCenter::FocusIcon(const std::string& focus_name) const
 { return EMPTY_STRING; }
 
-std::string ResourceCenter::Dump() const {
+std::string ResourceCenter::Dump(unsigned short ntabs) const {
     std::stringstream os;
     os << "ResourceCenter focus: " << m_focus << " last changed on turn: " << m_last_turn_focus_changed;
     return os.str();

--- a/universe/ResourceCenter.h
+++ b/universe/ResourceCenter.h
@@ -35,7 +35,7 @@ public:
     virtual std::vector<std::string>AvailableFoci() const;                          ///< focus settings available to this ResourceCenter
     virtual const std::string&      FocusIcon(const std::string& focus_name) const; ///< icon representing focus with name \a focus_name for this ResourceCenter
 
-    std::string     Dump() const;
+    std::string     Dump(unsigned short ntabs = 0) const;
 
     virtual float   InitialMeterValue(MeterType type) const = 0;            ///< implementation should return the initial value of the specified meter \a type
     virtual float   CurrentMeterValue(MeterType type) const = 0;            ///< implementation should return the current value of the specified meter \a type

--- a/universe/Ship.cpp
+++ b/universe/Ship.cpp
@@ -210,9 +210,9 @@ bool Ship::ContainedBy(int object_id) const {
             ||  object_id == this->SystemID());
 }
 
-std::string Ship::Dump() const {
+std::string Ship::Dump(unsigned short ntabs) const {
     std::stringstream os;
-    os << UniverseObject::Dump();
+    os << UniverseObject::Dump(ntabs);
     os << " design id: " << m_design_id
        << " fleet id: " << m_fleet_id
        << " species name: " << m_species_name

--- a/universe/Ship.h
+++ b/universe/Ship.h
@@ -23,7 +23,7 @@ public:
     std::set<std::string> Tags() const override;
     bool HasTag(const std::string& name) const override;
     UniverseObjectType ObjectType() const override;
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     int ContainerObjectID() const override
     { return m_fleet_id; }

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -1364,33 +1364,29 @@ void ShipDesign::BuildStatCaches() {
 
 std::string ShipDesign::Dump(unsigned short ntabs) const {
     std::string retval = DumpIndent(ntabs) + "ShipDesign\n";
-    ++ntabs;
-    retval += DumpIndent(ntabs) + "name = \"" + m_name + "\"\n";
-    retval += DumpIndent(ntabs) + "uuid = \"" + boost::uuids::to_string(m_uuid) + "\"\n";
-    retval += DumpIndent(ntabs) + "description = \"" + m_description + "\"\n";
+    retval += DumpIndent(ntabs+1) + "name = \"" + m_name + "\"\n";
+    retval += DumpIndent(ntabs+1) + "uuid = \"" + boost::uuids::to_string(m_uuid) + "\"\n";
+    retval += DumpIndent(ntabs+1) + "description = \"" + m_description + "\"\n";
 
     if (!m_name_desc_in_stringtable)
-        retval += DumpIndent(ntabs) + "NoStringtableLookup\n";
-    retval += DumpIndent(ntabs) + "hull = \"" + m_hull + "\"\n";
-    retval += DumpIndent(ntabs) + "parts = ";
+        retval += DumpIndent(ntabs+1) + "NoStringtableLookup\n";
+    retval += DumpIndent(ntabs+1) + "hull = \"" + m_hull + "\"\n";
+    retval += DumpIndent(ntabs+1) + "parts = ";
     if (m_parts.empty()) {
         retval += "[]\n";
     } else if (m_parts.size() == 1) {
         retval += "\"" + *m_parts.begin() + "\"\n";
     } else {
         retval += "[\n";
-        ++ntabs;
         for (const std::string& part_name : m_parts) {
-            retval += DumpIndent(ntabs) + "\"" + part_name + "\"\n";
+            retval += DumpIndent(ntabs+2) + "\"" + part_name + "\"\n";
         }
-        --ntabs;
-        retval += DumpIndent(ntabs) + "]\n";
+        retval += DumpIndent(ntabs+1) + "]\n";
     }
     if (!m_icon.empty())
-        retval += DumpIndent(ntabs) + "icon = \"" + m_icon + "\"\n";
-    retval += DumpIndent(ntabs) + "model = \"" + m_3D_model + "\"\n";
-    --ntabs;
-    return retval; 
+        retval += DumpIndent(ntabs+1) + "icon = \"" + m_icon + "\"\n";
+    retval += DumpIndent(ntabs+1) + "model = \"" + m_3D_model + "\"\n";
+    return retval;
 }
 
 unsigned int ShipDesign::GetCheckSum() const {

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -1362,34 +1362,34 @@ void ShipDesign::BuildStatCaches() {
     }
 }
 
-std::string ShipDesign::Dump() const {
-    std::string retval = DumpIndent() + "ShipDesign\n";
-    ++g_indent;
-    retval += DumpIndent() + "name = \"" + m_name + "\"\n";
-    retval += DumpIndent() + "uuid = \"" + boost::uuids::to_string(m_uuid) + "\"\n";
-    retval += DumpIndent() + "description = \"" + m_description + "\"\n";
+std::string ShipDesign::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "ShipDesign\n";
+    ++ntabs;
+    retval += DumpIndent(ntabs) + "name = \"" + m_name + "\"\n";
+    retval += DumpIndent(ntabs) + "uuid = \"" + boost::uuids::to_string(m_uuid) + "\"\n";
+    retval += DumpIndent(ntabs) + "description = \"" + m_description + "\"\n";
 
     if (!m_name_desc_in_stringtable)
-        retval += DumpIndent() + "NoStringtableLookup\n";
-    retval += DumpIndent() + "hull = \"" + m_hull + "\"\n";
-    retval += DumpIndent() + "parts = ";
+        retval += DumpIndent(ntabs) + "NoStringtableLookup\n";
+    retval += DumpIndent(ntabs) + "hull = \"" + m_hull + "\"\n";
+    retval += DumpIndent(ntabs) + "parts = ";
     if (m_parts.empty()) {
         retval += "[]\n";
     } else if (m_parts.size() == 1) {
         retval += "\"" + *m_parts.begin() + "\"\n";
     } else {
         retval += "[\n";
-        ++g_indent;
+        ++ntabs;
         for (const std::string& part_name : m_parts) {
-            retval += DumpIndent() + "\"" + part_name + "\"\n";
+            retval += DumpIndent(ntabs) + "\"" + part_name + "\"\n";
         }
-        --g_indent;
-        retval += DumpIndent() + "]\n";
+        --ntabs;
+        retval += DumpIndent(ntabs) + "]\n";
     }
     if (!m_icon.empty())
-        retval += DumpIndent() + "icon = \"" + m_icon + "\"\n";
-    retval += DumpIndent() + "model = \"" + m_3D_model + "\"\n";
-    --g_indent;
+        retval += DumpIndent(ntabs) + "icon = \"" + m_icon + "\"\n";
+    retval += DumpIndent(ntabs) + "model = \"" + m_3D_model + "\"\n";
+    --ntabs;
     return retval; 
 }
 

--- a/universe/ShipDesign.h
+++ b/universe/ShipDesign.h
@@ -556,7 +556,7 @@ public:
     /** returns number of parts in this ship design, indexed by ShipPartClass */
     const std::map<ShipPartClass, int>&   PartClassCount() const { return m_num_part_classes; }
 
-    std::string                     Dump() const;                                   ///< returns a data file format representation of this object
+    std::string                     Dump(unsigned short ntabs = 0) const;                                   ///< returns a data file format representation of this object
 
     /** Returns a number, calculated from the contained data, which should be
       * different for different contained data, and must be the same for

--- a/universe/Special.cpp
+++ b/universe/Special.cpp
@@ -115,48 +115,48 @@ void Special::Init() {
         m_location->SetTopLevelContent(m_name);
 }
 
-std::string Special::Dump() const {
-    std::string retval = DumpIndent() + "Special\n";
-    ++g_indent;
-    retval += DumpIndent() + "name = \"" + m_name + "\"\n";
-    retval += DumpIndent() + "description = \"" + m_description + "\"\n";
+std::string Special::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "Special\n";
+    ++ntabs;
+    retval += DumpIndent(ntabs) + "name = \"" + m_name + "\"\n";
+    retval += DumpIndent(ntabs) + "description = \"" + m_description + "\"\n";
 
     if (m_stealth)
-        retval += DumpIndent() + "stealth = " + m_stealth->Dump() + "\n";
+        retval += DumpIndent(ntabs) + "stealth = " + m_stealth->Dump(ntabs) + "\n";
 
-    retval += DumpIndent() + "spawnrate = " + std::to_string(m_spawn_rate) + "\n"
-           +  DumpIndent() + "spawnlimit = " + std::to_string(m_spawn_limit) + "\n";
+    retval += DumpIndent(ntabs) + "spawnrate = " + std::to_string(m_spawn_rate) + "\n"
+           +  DumpIndent(ntabs) + "spawnlimit = " + std::to_string(m_spawn_limit) + "\n";
 
     if (m_initial_capacity) {
-        retval += DumpIndent() + "initialcapacity = ";
-        ++g_indent;
-            retval += m_initial_capacity->Dump();
-        --g_indent;
+        retval += DumpIndent(ntabs) + "initialcapacity = ";
+        ++ntabs;
+            retval += m_initial_capacity->Dump(ntabs);
+        --ntabs;
     }
 
     if (m_location) {
-        retval += DumpIndent() + "location =\n";
-        ++g_indent;
-            retval += m_location->Dump();
-        --g_indent;
+        retval += DumpIndent(ntabs) + "location =\n";
+        ++ntabs;
+            retval += m_location->Dump(ntabs);
+        --ntabs;
     }
 
     if (m_effects.size() == 1) {
-        retval += DumpIndent() + "effectsgroups =\n";
-        ++g_indent;
-        retval += m_effects[0]->Dump();
-        --g_indent;
+        retval += DumpIndent(ntabs) + "effectsgroups =\n";
+        ++ntabs;
+        retval += m_effects[0]->Dump(ntabs);
+        --ntabs;
     } else {
-        retval += DumpIndent() + "effectsgroups = [\n";
-        ++g_indent;
+        retval += DumpIndent(ntabs) + "effectsgroups = [\n";
+        ++ntabs;
         for (auto& effect : m_effects) {
-            retval += effect->Dump();
+            retval += effect->Dump(ntabs);
         }
-        --g_indent;
-        retval += DumpIndent() + "]\n";
+        --ntabs;
+        retval += DumpIndent(ntabs) + "]\n";
     }
-    retval += DumpIndent() + "graphic = \"" + m_graphic + "\"\n";
-    --g_indent;
+    retval += DumpIndent(ntabs) + "graphic = \"" + m_graphic + "\"\n";
+    --ntabs;
     return retval;
 }
 

--- a/universe/Special.cpp
+++ b/universe/Special.cpp
@@ -117,46 +117,35 @@ void Special::Init() {
 
 std::string Special::Dump(unsigned short ntabs) const {
     std::string retval = DumpIndent(ntabs) + "Special\n";
-    ++ntabs;
-    retval += DumpIndent(ntabs) + "name = \"" + m_name + "\"\n";
-    retval += DumpIndent(ntabs) + "description = \"" + m_description + "\"\n";
+    retval += DumpIndent(ntabs+1) + "name = \"" + m_name + "\"\n";
+    retval += DumpIndent(ntabs+1) + "description = \"" + m_description + "\"\n";
 
     if (m_stealth)
-        retval += DumpIndent(ntabs) + "stealth = " + m_stealth->Dump(ntabs) + "\n";
+        retval += DumpIndent(ntabs+1) + "stealth = " + m_stealth->Dump(ntabs+1) + "\n";
 
-    retval += DumpIndent(ntabs) + "spawnrate = " + std::to_string(m_spawn_rate) + "\n"
-           +  DumpIndent(ntabs) + "spawnlimit = " + std::to_string(m_spawn_limit) + "\n";
+    retval += DumpIndent(ntabs+1) + "spawnrate = " + std::to_string(m_spawn_rate) + "\n"
+           +  DumpIndent(ntabs+1) + "spawnlimit = " + std::to_string(m_spawn_limit) + "\n";
 
     if (m_initial_capacity) {
-        retval += DumpIndent(ntabs) + "initialcapacity = ";
-        ++ntabs;
-            retval += m_initial_capacity->Dump(ntabs);
-        --ntabs;
+        retval += DumpIndent(ntabs+1) + "initialcapacity = ";
+        retval += m_initial_capacity->Dump(ntabs+2);
     }
 
     if (m_location) {
-        retval += DumpIndent(ntabs) + "location =\n";
-        ++ntabs;
-            retval += m_location->Dump(ntabs);
-        --ntabs;
+        retval += DumpIndent(ntabs+1) + "location =\n";
+        retval += m_location->Dump(ntabs+2);
     }
 
     if (m_effects.size() == 1) {
-        retval += DumpIndent(ntabs) + "effectsgroups =\n";
-        ++ntabs;
-        retval += m_effects[0]->Dump(ntabs);
-        --ntabs;
+        retval += DumpIndent(ntabs+1) + "effectsgroups =\n";
+        retval += m_effects[0]->Dump(ntabs+2);
     } else {
-        retval += DumpIndent(ntabs) + "effectsgroups = [\n";
-        ++ntabs;
-        for (auto& effect : m_effects) {
-            retval += effect->Dump(ntabs);
-        }
-        --ntabs;
-        retval += DumpIndent(ntabs) + "]\n";
+        retval += DumpIndent(ntabs+1) + "effectsgroups = [\n";
+        for (auto& effect : m_effects)
+            retval += effect->Dump(ntabs+2);
+        retval += DumpIndent(ntabs+1) + "]\n";
     }
-    retval += DumpIndent(ntabs) + "graphic = \"" + m_graphic + "\"\n";
-    --ntabs;
+    retval += DumpIndent(ntabs+1) + "graphic = \"" + m_graphic + "\"\n";
     return retval;
 }
 

--- a/universe/Special.h
+++ b/universe/Special.h
@@ -45,7 +45,7 @@ public:
     /** \name Accessors */ //@{
     const std::string&                      Name() const        { return m_name; }          ///< returns the unique name for this type of special
     std::string                             Description() const;                            ///< returns a text description of this type of special
-    std::string                             Dump() const;                                   ///< returns a data file format representation of this object
+    std::string                             Dump(unsigned short ntabs = 0) const;                                   ///< returns a data file format representation of this object
     const ValueRef::ValueRefBase<double>*   Stealth() const     { return m_stealth.get(); }       ///< returns the stealth of the special, which determines how easily it is seen by empires
 
     /** Returns the EffectsGroups that encapsulate the effects that specials of

--- a/universe/Species.cpp
+++ b/universe/Species.cpp
@@ -35,17 +35,17 @@ FocusType::FocusType(const std::string& name, const std::string& description,
 FocusType::~FocusType()
 {}
 
-std::string FocusType::Dump() const {
-    std::string retval = DumpIndent() + "FocusType\n";
-    ++g_indent;
-    retval += DumpIndent() + "name = \"" + m_name + "\"\n";
-    retval += DumpIndent() + "description = \"" + m_description + "\"\n";
-    retval += DumpIndent() + "location = \n";
-    ++g_indent;
-    retval += m_location->Dump();
-    --g_indent;
-    retval += DumpIndent() + "graphic = \"" + m_graphic + "\"\n";
-    --g_indent;
+std::string FocusType::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "FocusType\n";
+    ++ntabs;
+    retval += DumpIndent(ntabs) + "name = \"" + m_name + "\"\n";
+    retval += DumpIndent(ntabs) + "description = \"" + m_description + "\"\n";
+    retval += DumpIndent(ntabs) + "location = \n";
+    ++ntabs;
+    retval += m_location->Dump(ntabs);
+    --ntabs;
+    retval += DumpIndent(ntabs) + "graphic = \"" + m_graphic + "\"\n";
+    --ntabs;
     return retval;
 }
 
@@ -134,66 +134,66 @@ void Species::Init() {
     }
 }
 
-std::string Species::Dump() const {
-    std::string retval = DumpIndent() + "Species\n";
-    ++g_indent;
-    retval += DumpIndent() + "name = \"" + m_name + "\"\n";
-    retval += DumpIndent() + "description = \"" + m_description + "\"\n";
-    retval += DumpIndent() + "gameplay_description = \"" + m_gameplay_description + "\"\n";
+std::string Species::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "Species\n";
+    ++ntabs;
+    retval += DumpIndent(ntabs) + "name = \"" + m_name + "\"\n";
+    retval += DumpIndent(ntabs) + "description = \"" + m_description + "\"\n";
+    retval += DumpIndent(ntabs) + "gameplay_description = \"" + m_gameplay_description + "\"\n";
     if (m_playable)
-        retval += DumpIndent() + "Playable\n";
+        retval += DumpIndent(ntabs) + "Playable\n";
     if (m_native)
-        retval += DumpIndent() + "Native\n";
+        retval += DumpIndent(ntabs) + "Native\n";
     if (m_can_produce_ships)
-        retval += DumpIndent() + "CanProduceShips\n";
+        retval += DumpIndent(ntabs) + "CanProduceShips\n";
     if (m_can_colonize)
-        retval += DumpIndent() + "CanColonize\n";
+        retval += DumpIndent(ntabs) + "CanColonize\n";
     if (m_foci.size() == 1) {
-        retval += DumpIndent() + "foci =\n";
-        m_foci.begin()->Dump();
+        retval += DumpIndent(ntabs) + "foci =\n";
+        m_foci.begin()->Dump(ntabs);
     } else {
-        retval += DumpIndent() + "foci = [\n";
-        ++g_indent;
+        retval += DumpIndent(ntabs) + "foci = [\n";
+        ++ntabs;
         for (const FocusType& focus : m_foci) {
-            retval += focus.Dump();
+            retval += focus.Dump(ntabs);
         }
-        --g_indent;
-        retval += DumpIndent() + "]\n";
+        --ntabs;
+        retval += DumpIndent(ntabs) + "]\n";
     }
     if (m_effects.size() == 1) {
-        retval += DumpIndent() + "effectsgroups =\n";
-        ++g_indent;
-        retval += m_effects[0]->Dump();
-        --g_indent;
+        retval += DumpIndent(ntabs) + "effectsgroups =\n";
+        ++ntabs;
+        retval += m_effects[0]->Dump(ntabs);
+        --ntabs;
     } else {
-        retval += DumpIndent() + "effectsgroups = [\n";
-        ++g_indent;
+        retval += DumpIndent(ntabs) + "effectsgroups = [\n";
+        ++ntabs;
         for (auto& effect : m_effects) {
-            retval += effect->Dump();
+            retval += effect->Dump(ntabs);
         }
-        --g_indent;
-        retval += DumpIndent() + "]\n";
+        --ntabs;
+        retval += DumpIndent(ntabs) + "]\n";
     }
     if (m_planet_environments.size() == 1) {
-        retval += DumpIndent() + "environments =\n";
-        ++g_indent;
-        retval += DumpIndent() + "type = " + PlanetTypeToString(m_planet_environments.begin()->first)
+        retval += DumpIndent(ntabs) + "environments =\n";
+        ++ntabs;
+        retval += DumpIndent(ntabs) + "type = " + PlanetTypeToString(m_planet_environments.begin()->first)
                                + " environment = " + PlanetEnvironmentToString(m_planet_environments.begin()->second)
                                + "\n";
-        --g_indent;
+        --ntabs;
     } else {
-        retval += DumpIndent() + "environments = [\n";
-        ++g_indent;
+        retval += DumpIndent(ntabs) + "environments = [\n";
+        ++ntabs;
         for (const auto& entry : m_planet_environments) {
-            retval += DumpIndent() + "type = " + PlanetTypeToString(entry.first)
+            retval += DumpIndent(ntabs) + "type = " + PlanetTypeToString(entry.first)
                                    + " environment = " + PlanetEnvironmentToString(entry.second)
                                    + "\n";
         }
-        --g_indent;
-        retval += DumpIndent() + "]\n";
+        --ntabs;
+        retval += DumpIndent(ntabs) + "]\n";
     }
-    retval += DumpIndent() + "graphic = \"" + m_graphic + "\"\n";
-    --g_indent;
+    retval += DumpIndent(ntabs) + "graphic = \"" + m_graphic + "\"\n";
+    --ntabs;
     return retval;
 }
 

--- a/universe/Species.cpp
+++ b/universe/Species.cpp
@@ -37,15 +37,11 @@ FocusType::~FocusType()
 
 std::string FocusType::Dump(unsigned short ntabs) const {
     std::string retval = DumpIndent(ntabs) + "FocusType\n";
-    ++ntabs;
-    retval += DumpIndent(ntabs) + "name = \"" + m_name + "\"\n";
-    retval += DumpIndent(ntabs) + "description = \"" + m_description + "\"\n";
-    retval += DumpIndent(ntabs) + "location = \n";
-    ++ntabs;
-    retval += m_location->Dump(ntabs);
-    --ntabs;
-    retval += DumpIndent(ntabs) + "graphic = \"" + m_graphic + "\"\n";
-    --ntabs;
+    retval += DumpIndent(ntabs+1) + "name = \"" + m_name + "\"\n";
+    retval += DumpIndent(ntabs+1) + "description = \"" + m_description + "\"\n";
+    retval += DumpIndent(ntabs+1) + "location = \n";
+    retval += m_location->Dump(ntabs+2);
+    retval += DumpIndent(ntabs+1) + "graphic = \"" + m_graphic + "\"\n";
     return retval;
 }
 
@@ -136,64 +132,50 @@ void Species::Init() {
 
 std::string Species::Dump(unsigned short ntabs) const {
     std::string retval = DumpIndent(ntabs) + "Species\n";
-    ++ntabs;
-    retval += DumpIndent(ntabs) + "name = \"" + m_name + "\"\n";
-    retval += DumpIndent(ntabs) + "description = \"" + m_description + "\"\n";
-    retval += DumpIndent(ntabs) + "gameplay_description = \"" + m_gameplay_description + "\"\n";
+    retval += DumpIndent(ntabs+1) + "name = \"" + m_name + "\"\n";
+    retval += DumpIndent(ntabs+1) + "description = \"" + m_description + "\"\n";
+    retval += DumpIndent(ntabs+1) + "gameplay_description = \"" + m_gameplay_description + "\"\n";
     if (m_playable)
-        retval += DumpIndent(ntabs) + "Playable\n";
+        retval += DumpIndent(ntabs+1) + "Playable\n";
     if (m_native)
-        retval += DumpIndent(ntabs) + "Native\n";
+        retval += DumpIndent(ntabs+1) + "Native\n";
     if (m_can_produce_ships)
-        retval += DumpIndent(ntabs) + "CanProduceShips\n";
+        retval += DumpIndent(ntabs+1) + "CanProduceShips\n";
     if (m_can_colonize)
-        retval += DumpIndent(ntabs) + "CanColonize\n";
+        retval += DumpIndent(ntabs+1) + "CanColonize\n";
     if (m_foci.size() == 1) {
-        retval += DumpIndent(ntabs) + "foci =\n";
-        m_foci.begin()->Dump(ntabs);
+        retval += DumpIndent(ntabs+1) + "foci =\n";
+        m_foci.begin()->Dump(ntabs+1);
     } else {
-        retval += DumpIndent(ntabs) + "foci = [\n";
-        ++ntabs;
-        for (const FocusType& focus : m_foci) {
-            retval += focus.Dump(ntabs);
-        }
-        --ntabs;
-        retval += DumpIndent(ntabs) + "]\n";
+        retval += DumpIndent(ntabs+1) + "foci = [\n";
+        for (const FocusType& focus : m_foci)
+            retval += focus.Dump(ntabs+2);
+        retval += DumpIndent(ntabs+1) + "]\n";
     }
     if (m_effects.size() == 1) {
-        retval += DumpIndent(ntabs) + "effectsgroups =\n";
-        ++ntabs;
-        retval += m_effects[0]->Dump(ntabs);
-        --ntabs;
+        retval += DumpIndent(ntabs+1) + "effectsgroups =\n";
+        retval += m_effects[0]->Dump(ntabs+2);
     } else {
-        retval += DumpIndent(ntabs) + "effectsgroups = [\n";
-        ++ntabs;
-        for (auto& effect : m_effects) {
-            retval += effect->Dump(ntabs);
-        }
-        --ntabs;
-        retval += DumpIndent(ntabs) + "]\n";
+        retval += DumpIndent(ntabs+1) + "effectsgroups = [\n";
+        for (auto& effect : m_effects)
+            retval += effect->Dump(ntabs+2);
+        retval += DumpIndent(ntabs+1) + "]\n";
     }
     if (m_planet_environments.size() == 1) {
-        retval += DumpIndent(ntabs) + "environments =\n";
-        ++ntabs;
-        retval += DumpIndent(ntabs) + "type = " + PlanetTypeToString(m_planet_environments.begin()->first)
-                               + " environment = " + PlanetEnvironmentToString(m_planet_environments.begin()->second)
-                               + "\n";
-        --ntabs;
+        retval += DumpIndent(ntabs+1) + "environments =\n";
+        retval += DumpIndent(ntabs+2) + "type = " + PlanetTypeToString(m_planet_environments.begin()->first)
+            + " environment = " + PlanetEnvironmentToString(m_planet_environments.begin()->second)
+            + "\n";
     } else {
-        retval += DumpIndent(ntabs) + "environments = [\n";
-        ++ntabs;
+        retval += DumpIndent(ntabs+1) + "environments = [\n";
         for (const auto& entry : m_planet_environments) {
-            retval += DumpIndent(ntabs) + "type = " + PlanetTypeToString(entry.first)
-                                   + " environment = " + PlanetEnvironmentToString(entry.second)
-                                   + "\n";
+            retval += DumpIndent(ntabs+2) + "type = " + PlanetTypeToString(entry.first)
+                + " environment = " + PlanetEnvironmentToString(entry.second)
+                + "\n";
         }
-        --ntabs;
-        retval += DumpIndent(ntabs) + "]\n";
+        retval += DumpIndent(ntabs+1) + "]\n";
     }
-    retval += DumpIndent(ntabs) + "graphic = \"" + m_graphic + "\"\n";
-    --ntabs;
+    retval += DumpIndent(ntabs+1) + "graphic = \"" + m_graphic + "\"\n";
     return retval;
 }
 

--- a/universe/Species.h
+++ b/universe/Species.h
@@ -55,7 +55,7 @@ public:
     const std::string&              Description() const { return m_description; }   ///< returns a text description of this focus type
     const Condition::ConditionBase* Location() const    { return m_location.get(); }///< returns the condition that determines whether an UniverseObject can use this FocusType
     const std::string&              Graphic() const     { return m_graphic; }       ///< returns the name of the grapic file for this focus type
-    std::string                     Dump() const;       ///< returns a data file format representation of this object
+    std::string                     Dump(unsigned short ntabs = 0) const;       ///< returns a data file format representation of this object
 
     /** Returns a number, calculated from the contained data, which should be
       * different for different contained data, and must be the same for
@@ -143,7 +143,7 @@ public:
 
     const Condition::ConditionBase* Location() const;
 
-    std::string                     Dump() const;                                           ///< returns a data file format representation of this object
+    std::string                     Dump(unsigned short ntabs = 0) const;                                           ///< returns a data file format representation of this object
     const std::vector<FocusType>&   Foci() const            { return m_foci; }              ///< returns the focus types this species can use
     const std::string&              PreferredFocus() const  { return m_preferred_focus; }   ///< returns the name of the planetary focus this species prefers. Default for new colonies and may affect happiness if on a different focus?
     const std::map<PlanetType, PlanetEnvironment>& PlanetEnvironments() const { return m_planet_environments; } ///< returns a map from PlanetType to the PlanetEnvironment this Species has on that PlanetType

--- a/universe/System.cpp
+++ b/universe/System.cpp
@@ -159,9 +159,9 @@ void System::Copy(std::shared_ptr<const UniverseObject> copied_object, int empir
 UniverseObjectType System::ObjectType() const
 { return OBJ_SYSTEM; }
 
-std::string System::Dump() const {
+std::string System::Dump(unsigned short ntabs) const {
     std::stringstream os;
-    os << UniverseObject::Dump();
+    os << UniverseObject::Dump(ntabs);
     os << " star type: " << m_star
        << "  last combat on turn: " << m_last_turn_battle_here
        << "  total orbits: " << m_orbits.size();

--- a/universe/System.h
+++ b/universe/System.h
@@ -38,7 +38,7 @@ public:
     /** \name Accessors */ //@{
     UniverseObjectType ObjectType() const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     const std::set<int>& ContainedObjectIDs() const override;
 

--- a/universe/Tech.cpp
+++ b/universe/Tech.cpp
@@ -189,61 +189,61 @@ void Tech::Init() {
     { effect->SetTopLevelContent(m_name); }
 }
 
-std::string Tech::Dump() const {
-    std::string retval = DumpIndent() + "Tech\n";
-    ++g_indent;
-    retval += DumpIndent() + "name = \"" + m_name + "\"\n";
-    retval += DumpIndent() + "description = \"" + m_description + "\"\n";
-    retval += DumpIndent() + "shortdescription = \"" + m_short_description + "\"\n";
-    retval += DumpIndent() + "category = \"" + m_category + "\"\n";
-    retval += DumpIndent() + "researchcost = " + m_research_cost->Dump() + "\n";
-    retval += DumpIndent() + "researchturns = " + m_research_turns->Dump() + "\n";
-    retval += DumpIndent() + "prerequisites = ";
+std::string Tech::Dump(unsigned short ntabs) const {
+    std::string retval = DumpIndent(ntabs) + "Tech\n";
+    ++ntabs;
+    retval += DumpIndent(ntabs) + "name = \"" + m_name + "\"\n";
+    retval += DumpIndent(ntabs) + "description = \"" + m_description + "\"\n";
+    retval += DumpIndent(ntabs) + "shortdescription = \"" + m_short_description + "\"\n";
+    retval += DumpIndent(ntabs) + "category = \"" + m_category + "\"\n";
+    retval += DumpIndent(ntabs) + "researchcost = " + m_research_cost->Dump(ntabs) + "\n";
+    retval += DumpIndent(ntabs) + "researchturns = " + m_research_turns->Dump(ntabs) + "\n";
+    retval += DumpIndent(ntabs) + "prerequisites = ";
     if (m_prerequisites.empty()) {
         retval += "[]\n";
     } else if (m_prerequisites.size() == 1) {
         retval += "\"" + *m_prerequisites.begin() + "\"\n";
     } else {
         retval += "[\n";
-        ++g_indent;
+        ++ntabs;
         for (const std::string& prerequisite : m_prerequisites) {
-            retval += DumpIndent() + "\"" + prerequisite + "\"\n";
+            retval += DumpIndent(ntabs) + "\"" + prerequisite + "\"\n";
         }
-        --g_indent;
-        retval += DumpIndent() + "]\n";
+        --ntabs;
+        retval += DumpIndent(ntabs) + "]\n";
     }
-    retval += DumpIndent() + "unlock = ";
+    retval += DumpIndent(ntabs) + "unlock = ";
     if (m_unlocked_items.empty()) {
         retval += "[]\n";
     } else if (m_unlocked_items.size() == 1) {
         retval += m_unlocked_items[0].Dump();
     } else {
         retval += "[\n";
-        ++g_indent;
+        ++ntabs;
         for (const ItemSpec& unlocked_item : m_unlocked_items) {
-            retval += DumpIndent() + unlocked_item.Dump();
+            retval += DumpIndent(ntabs) + unlocked_item.Dump();
         }
-        --g_indent;
-        retval += DumpIndent() + "]\n";
+        --ntabs;
+        retval += DumpIndent(ntabs) + "]\n";
     }
     if (!m_effects.empty()) {
         if (m_effects.size() == 1) {
-            retval += DumpIndent() + "effectsgroups =\n";
-            ++g_indent;
-            retval += m_effects[0]->Dump();
-            --g_indent;
+            retval += DumpIndent(ntabs) + "effectsgroups =\n";
+            ++ntabs;
+            retval += m_effects[0]->Dump(ntabs);
+            --ntabs;
         } else {
-            retval += DumpIndent() + "effectsgroups = [\n";
-            ++g_indent;
+            retval += DumpIndent(ntabs) + "effectsgroups = [\n";
+            ++ntabs;
             for (auto& effect : m_effects) {
-                retval += effect->Dump();
+                retval += effect->Dump(ntabs);
             }
-            --g_indent;
-            retval += DumpIndent() + "]\n";
+            --ntabs;
+            retval += DumpIndent(ntabs) + "]\n";
         }
     }
-    retval += DumpIndent() + "graphic = \"" + m_graphic + "\"\n";
-    --g_indent;
+    retval += DumpIndent(ntabs) + "graphic = \"" + m_graphic + "\"\n";
+    --ntabs;
     return retval;
 }
 
@@ -329,7 +329,7 @@ ItemSpec::ItemSpec() :
     name()
 {}
 
-std::string ItemSpec::Dump() const {
+std::string ItemSpec::Dump(unsigned short ntabs) const {
     std::string retval = "Item type = ";
     switch (type) {
     case UIT_BUILDING:      retval += "Building";   break;

--- a/universe/Tech.cpp
+++ b/universe/Tech.cpp
@@ -191,59 +191,46 @@ void Tech::Init() {
 
 std::string Tech::Dump(unsigned short ntabs) const {
     std::string retval = DumpIndent(ntabs) + "Tech\n";
-    ++ntabs;
-    retval += DumpIndent(ntabs) + "name = \"" + m_name + "\"\n";
-    retval += DumpIndent(ntabs) + "description = \"" + m_description + "\"\n";
-    retval += DumpIndent(ntabs) + "shortdescription = \"" + m_short_description + "\"\n";
-    retval += DumpIndent(ntabs) + "category = \"" + m_category + "\"\n";
-    retval += DumpIndent(ntabs) + "researchcost = " + m_research_cost->Dump(ntabs) + "\n";
-    retval += DumpIndent(ntabs) + "researchturns = " + m_research_turns->Dump(ntabs) + "\n";
-    retval += DumpIndent(ntabs) + "prerequisites = ";
+    retval += DumpIndent(ntabs+1) + "name = \"" + m_name + "\"\n";
+    retval += DumpIndent(ntabs+1) + "description = \"" + m_description + "\"\n";
+    retval += DumpIndent(ntabs+1) + "shortdescription = \"" + m_short_description + "\"\n";
+    retval += DumpIndent(ntabs+1) + "category = \"" + m_category + "\"\n";
+    retval += DumpIndent(ntabs+1) + "researchcost = " + m_research_cost->Dump(ntabs+1) + "\n";
+    retval += DumpIndent(ntabs+1) + "researchturns = " + m_research_turns->Dump(ntabs+1) + "\n";
+    retval += DumpIndent(ntabs+1) + "prerequisites = ";
     if (m_prerequisites.empty()) {
         retval += "[]\n";
     } else if (m_prerequisites.size() == 1) {
         retval += "\"" + *m_prerequisites.begin() + "\"\n";
     } else {
         retval += "[\n";
-        ++ntabs;
-        for (const std::string& prerequisite : m_prerequisites) {
-            retval += DumpIndent(ntabs) + "\"" + prerequisite + "\"\n";
-        }
-        --ntabs;
-        retval += DumpIndent(ntabs) + "]\n";
+        for (const std::string& prerequisite : m_prerequisites)
+            retval += DumpIndent(ntabs+2) + "\"" + prerequisite + "\"\n";
+        retval += DumpIndent(ntabs+1) + "]\n";
     }
-    retval += DumpIndent(ntabs) + "unlock = ";
+    retval += DumpIndent(ntabs+1) + "unlock = ";
     if (m_unlocked_items.empty()) {
         retval += "[]\n";
     } else if (m_unlocked_items.size() == 1) {
         retval += m_unlocked_items[0].Dump();
     } else {
         retval += "[\n";
-        ++ntabs;
-        for (const ItemSpec& unlocked_item : m_unlocked_items) {
-            retval += DumpIndent(ntabs) + unlocked_item.Dump();
-        }
-        --ntabs;
-        retval += DumpIndent(ntabs) + "]\n";
+        for (const ItemSpec& unlocked_item : m_unlocked_items)
+            retval += DumpIndent(ntabs+2) + unlocked_item.Dump();
+        retval += DumpIndent(ntabs+1) + "]\n";
     }
     if (!m_effects.empty()) {
         if (m_effects.size() == 1) {
-            retval += DumpIndent(ntabs) + "effectsgroups =\n";
-            ++ntabs;
-            retval += m_effects[0]->Dump(ntabs);
-            --ntabs;
+            retval += DumpIndent(ntabs+1) + "effectsgroups =\n";
+            retval += m_effects[0]->Dump(ntabs+2);
         } else {
-            retval += DumpIndent(ntabs) + "effectsgroups = [\n";
-            ++ntabs;
-            for (auto& effect : m_effects) {
-                retval += effect->Dump(ntabs);
-            }
-            --ntabs;
-            retval += DumpIndent(ntabs) + "]\n";
+            retval += DumpIndent(ntabs+1) + "effectsgroups = [\n";
+            for (auto& effect : m_effects)
+                retval += effect->Dump(ntabs+2);
+            retval += DumpIndent(ntabs+1) + "]\n";
         }
     }
-    retval += DumpIndent(ntabs) + "graphic = \"" + m_graphic + "\"\n";
-    --ntabs;
+    retval += DumpIndent(ntabs+1) + "graphic = \"" + m_graphic + "\"\n";
     return retval;
 }
 

--- a/universe/Tech.h
+++ b/universe/Tech.h
@@ -74,7 +74,7 @@ public:
     const std::string&  Name() const                { return m_name; }              //!< returns name of this tech
     const std::string&  Description() const         { return m_description; }       //!< Returns the text description of this tech
     const std::string&  ShortDescription() const    { return m_short_description; } //!< Returns the single-line short text description of this tech
-    std::string         Dump() const;                                               //!< Returns a text representation of this object
+    std::string         Dump(unsigned short ntabs = 0) const;                                               //!< Returns a text representation of this object
     const std::string&  Category() const            { return m_category; }          //!< retursn the name of the category to which this tech belongs
     float               ResearchCost(int empire_id) const;                          //!< returns the total research cost in RPs required to research this tech
     float               PerTurnCost(int empire_id) const;                           //!< returns the maximum number of RPs per turn allowed to be spent on researching this tech
@@ -136,7 +136,7 @@ struct FO_COMMON_API ItemSpec {
         type(type_),
         name(name_)
     {}
-    std::string Dump() const;   ///< returns a data file format representation of this object
+    std::string Dump(unsigned short ntabs = 0) const;   ///< returns a data file format representation of this object
     UnlockableItemType type;    ///< the kind of item this is
     std::string        name;    ///< the exact item this is
 };

--- a/universe/UniverseObject.cpp
+++ b/universe/UniverseObject.cpp
@@ -168,7 +168,7 @@ bool UniverseObject::HasTag(const std::string& name) const
 UniverseObjectType UniverseObject::ObjectType() const
 { return INVALID_UNIVERSE_OBJECT_TYPE; }
 
-std::string UniverseObject::Dump() const {
+std::string UniverseObject::Dump(unsigned short ntabs) const {
     auto system = GetSystem(this->SystemID());
 
     std::stringstream os;
@@ -399,4 +399,3 @@ void UniverseObject::ResetPairedActiveMeters() {
 
 void UniverseObject::ClampMeters()
 { GetMeter(METER_STEALTH)->ClampCurrentToRange(); }
-

--- a/universe/UniverseObject.h
+++ b/universe/UniverseObject.h
@@ -81,8 +81,9 @@ public:
 
     virtual UniverseObjectType  ObjectType() const;
 
-    /** Outputs textual description of object to logger. */
-    virtual std::string         Dump() const;
+    /** Return human readable string description of object offset \p ntabs from
+        margin. */
+    virtual std::string         Dump(unsigned short ntabs = 0) const;
 
     /** Returns id of the object that directly contains this object, if any, or
         INVALID_OBJECT_ID if this object is not contained by any other. */
@@ -240,5 +241,10 @@ private:
     template <class Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
+
+/** A function that returns the correct amount of spacing for an indentation of
+  * \p ntabs during a dump. */
+inline std::string DumpIndent(unsigned short ntabs = 1)
+{ return std::string(ntabs * 4 /* conversion to size_t is safe */, ' '); }
 
 #endif // _UniverseObject_h_

--- a/universe/ValueRef.cpp
+++ b/universe/ValueRef.cpp
@@ -304,7 +304,7 @@ std::string Constant<std::string>::Description() const
 }
 
 template <>
-std::string Constant<PlanetSize>::Dump() const
+std::string Constant<PlanetSize>::Dump(unsigned short ntabs) const
 {
     switch (m_value) {
     case SZ_TINY:       return "Tiny";
@@ -319,7 +319,7 @@ std::string Constant<PlanetSize>::Dump() const
 }
 
 template <>
-std::string Constant<PlanetType>::Dump() const
+std::string Constant<PlanetType>::Dump(unsigned short ntabs) const
 {
     switch (m_value) {
     case PT_SWAMP:      return "Swamp";
@@ -338,7 +338,7 @@ std::string Constant<PlanetType>::Dump() const
 }
 
 template <>
-std::string Constant<PlanetEnvironment>::Dump() const
+std::string Constant<PlanetEnvironment>::Dump(unsigned short ntabs) const
 {
     switch (m_value) {
     case PE_UNINHABITABLE:  return "Uninhabitable";
@@ -351,7 +351,7 @@ std::string Constant<PlanetEnvironment>::Dump() const
 }
 
 template <>
-std::string Constant<UniverseObjectType>::Dump() const
+std::string Constant<UniverseObjectType>::Dump(unsigned short ntabs) const
 {
     switch (m_value) {
     case OBJ_BUILDING:      return "Building";
@@ -367,7 +367,7 @@ std::string Constant<UniverseObjectType>::Dump() const
 }
 
 template <>
-std::string Constant<StarType>::Dump() const
+std::string Constant<StarType>::Dump(unsigned short ntabs) const
 {
     switch (m_value) {
     case STAR_BLUE:     return "Blue";
@@ -383,7 +383,7 @@ std::string Constant<StarType>::Dump() const
 }
 
 template <>
-std::string Constant<Visibility>::Dump() const
+std::string Constant<Visibility>::Dump(unsigned short ntabs) const
 {
     switch (m_value) {
     case VIS_NO_VISIBILITY:     return "Invisible";
@@ -395,15 +395,15 @@ std::string Constant<Visibility>::Dump() const
 }
 
 template <>
-std::string Constant<int>::Dump() const
+std::string Constant<int>::Dump(unsigned short ntabs) const
 { return Description(); }
 
 template <>
-std::string Constant<double>::Dump() const
+std::string Constant<double>::Dump(unsigned short ntabs) const
 { return Description(); }
 
 template <>
-std::string Constant<std::string>::Dump() const
+std::string Constant<std::string>::Dump(unsigned short ntabs) const
 { return "\"" + Description() + "\""; }
 
 template <>
@@ -2478,23 +2478,23 @@ std::string ComplexVariable<std::string>::Eval(const ScriptingContext& context) 
 #undef IF_CURRENT_VALUE
 
 template <>
-std::string ComplexVariable<Visibility>::Dump() const
+std::string ComplexVariable<Visibility>::Dump(unsigned short ntabs) const
 {
     const std::string& variable_name = m_property_name.back();
     std::string retval = variable_name;
 
     if (variable_name == "EmpireObjectVisiblity") {
         if (m_int_ref1)
-            retval += " empire = " + m_int_ref1->Dump();
+            retval += " empire = " + m_int_ref1->Dump(ntabs);
         if (m_int_ref2)
-            retval += " object = " + m_int_ref2->Dump();
+            retval += " object = " + m_int_ref2->Dump(ntabs);
     }
 
     return retval;
 }
 
 template <>
-std::string ComplexVariable<double>::Dump() const
+std::string ComplexVariable<double>::Dump(unsigned short ntabs) const
 {
     const std::string& variable_name = m_property_name.back();
     std::string retval = variable_name;
@@ -2505,9 +2505,9 @@ std::string ComplexVariable<double>::Dump() const
         variable_name == "PropagatedSystemSupplyDistance")
     {
         if (m_int_ref1)
-            retval += " empire = " + m_int_ref1->Dump();
+            retval += " empire = " + m_int_ref1->Dump(ntabs);
         if (m_int_ref2)
-            retval += " system = " + m_int_ref2->Dump();
+            retval += " system = " + m_int_ref2->Dump(ntabs);
 
     }
     else if (variable_name == "GameRule" ||
@@ -2519,44 +2519,44 @@ std::string ComplexVariable<double>::Dump() const
              variable_name == "PartSecondaryStat")
     {
         if (!m_string_ref1)
-            retval += " name = " + m_string_ref1->Dump();
+            retval += " name = " + m_string_ref1->Dump(ntabs);
 
     }
     else if (variable_name == "EmpireMeterValue") {
         if (m_int_ref1)
-            retval += " empire = " + m_int_ref1->Dump();
+            retval += " empire = " + m_int_ref1->Dump(ntabs);
         if (m_string_ref1)
-            retval += " meter = " + m_string_ref1->Dump();
+            retval += " meter = " + m_string_ref1->Dump(ntabs);
 
     }
     else if (variable_name == "DirectDistanceBetween" ||
              variable_name == "ShortestPath")
     {
         if (m_int_ref1)
-            retval += " object = " + m_int_ref1->Dump();
+            retval += " object = " + m_int_ref1->Dump(ntabs);
         if (m_int_ref2)
-            retval += " object = " + m_int_ref2->Dump();
+            retval += " object = " + m_int_ref2->Dump(ntabs);
 
     }
     else if (variable_name == "SpeciesEmpireOpinion") {
         if (m_int_ref1)
-            retval += " empire = " + m_int_ref1->Dump();
+            retval += " empire = " + m_int_ref1->Dump(ntabs);
         if (m_string_ref1)
-            retval += " species = " + m_string_ref1->Dump();
+            retval += " species = " + m_string_ref1->Dump(ntabs);
 
     }
     else if (variable_name == "SpeciesSpeciesOpinion") {
         if (m_string_ref1)
-            retval += " species = " + m_string_ref1->Dump();
+            retval += " species = " + m_string_ref1->Dump(ntabs);
         if (m_string_ref2)
-            retval += " species = " + m_string_ref2->Dump();
+            retval += " species = " + m_string_ref2->Dump(ntabs);
 
     }
     else if (variable_name == "SpecialCapacity") {
         if (m_string_ref1)
-            retval += " name = " + m_string_ref1->Dump();
+            retval += " name = " + m_string_ref1->Dump(ntabs);
         if (m_int_ref1)
-            retval += " object = " + m_int_ref1->Dump();
+            retval += " object = " + m_int_ref1->Dump(ntabs);
 
     }
 
@@ -2564,7 +2564,7 @@ std::string ComplexVariable<double>::Dump() const
 }
 
 template <>
-std::string ComplexVariable<int>::Dump() const
+std::string ComplexVariable<int>::Dump(unsigned short ntabs) const
 {
     const std::string& variable_name = m_property_name.back();
     std::string retval = variable_name;
@@ -2573,7 +2573,7 @@ std::string ComplexVariable<int>::Dump() const
 }
 
 template <>
-std::string ComplexVariable<std::string>::Dump() const
+std::string ComplexVariable<std::string>::Dump(unsigned short ntabs) const
 {
     const std::string& variable_name = m_property_name.back();
     std::string retval = variable_name;
@@ -2750,8 +2750,8 @@ bool NameLookup::SourceInvariant() const
 std::string NameLookup::Description() const
 { return m_value_ref->Description(); }
 
-std::string NameLookup::Dump() const
-{ return m_value_ref->Dump(); }
+std::string NameLookup::Dump(unsigned short ntabs) const
+{ return m_value_ref->Dump(ntabs); }
 
 void NameLookup::SetTopLevelContent(const std::string& content_name) {
     if (m_value_ref)

--- a/universe/ValueRef.h
+++ b/universe/ValueRef.h
@@ -142,7 +142,7 @@ struct FO_COMMON_API ValueRefBase
     virtual std::string Description() const = 0;
 
     /** Returns a text description of this type of special. */
-    virtual std::string Dump() const = 0;
+    virtual std::string Dump(unsigned short ntabs = 0) const = 0;
 
     virtual void SetTopLevelContent(const std::string& content_name)
     {}
@@ -183,7 +183,7 @@ struct FO_COMMON_API Constant : public ValueRefBase<T>
 
     std::string Description() const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -222,7 +222,7 @@ struct FO_COMMON_API Variable : public ValueRefBase<T>
 
     std::string Description() const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     ReferenceType GetReferenceType() const;
 
@@ -268,7 +268,7 @@ struct FO_COMMON_API Statistic : public Variable<T>
 
     std::string Description() const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -335,7 +335,7 @@ struct FO_COMMON_API ComplexVariable : public Variable<T>
 
     std::string Description() const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -396,7 +396,7 @@ struct FO_COMMON_API StaticCast : public Variable<ToType>
 
     std::string Description() const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -439,7 +439,7 @@ struct FO_COMMON_API StringCast : public Variable<std::string>
 
     std::string Description() const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -478,7 +478,7 @@ struct FO_COMMON_API UserStringLookup : public Variable<std::string> {
 
     std::string Description() const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -521,7 +521,7 @@ struct FO_COMMON_API NameLookup : public Variable<std::string> {
 
     std::string Description() const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -579,7 +579,7 @@ struct FO_COMMON_API Operation : public ValueRefBase<T>
 
     std::string Description() const override;
 
-    std::string Dump() const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
 
     void SetTopLevelContent(const std::string& content_name) override;
 
@@ -692,31 +692,31 @@ template <>
 FO_COMMON_API std::string Constant<std::string>::Description() const;
 
 template <>
-FO_COMMON_API std::string Constant<PlanetSize>::Dump() const;
+FO_COMMON_API std::string Constant<PlanetSize>::Dump(unsigned short ntabs) const;
 
 template <>
-FO_COMMON_API std::string Constant<PlanetType>::Dump() const;
+FO_COMMON_API std::string Constant<PlanetType>::Dump(unsigned short ntabs) const;
 
 template <>
-FO_COMMON_API std::string Constant<PlanetEnvironment>::Dump() const;
+FO_COMMON_API std::string Constant<PlanetEnvironment>::Dump(unsigned short ntabs) const;
 
 template <>
-FO_COMMON_API std::string Constant<UniverseObjectType>::Dump() const;
+FO_COMMON_API std::string Constant<UniverseObjectType>::Dump(unsigned short ntabs) const;
 
 template <>
-FO_COMMON_API std::string Constant<StarType>::Dump() const;
+FO_COMMON_API std::string Constant<StarType>::Dump(unsigned short ntabs) const;
 
 template <>
-FO_COMMON_API std::string Constant<Visibility>::Dump() const;
+FO_COMMON_API std::string Constant<Visibility>::Dump(unsigned short ntabs) const;
 
 template <>
-FO_COMMON_API std::string Constant<double>::Dump() const;
+FO_COMMON_API std::string Constant<double>::Dump(unsigned short ntabs) const;
 
 template <>
-FO_COMMON_API std::string Constant<int>::Dump() const;
+FO_COMMON_API std::string Constant<int>::Dump(unsigned short ntabs) const;
 
 template <>
-FO_COMMON_API std::string Constant<std::string>::Dump() const;
+FO_COMMON_API std::string Constant<std::string>::Dump(unsigned short ntabs) const;
 
 template <>
 FO_COMMON_API std::string Constant<std::string>::Eval(const ScriptingContext& context) const;
@@ -791,7 +791,7 @@ std::string Variable<T>::Description() const
 { return FormatedDescriptionPropertyNames(m_ref_type, m_property_name); }
 
 template <class T>
-std::string Variable<T>::Dump() const
+std::string Variable<T>::Dump(unsigned short ntabs) const
 { return ReconstructName(m_property_name, m_ref_type); }
 
 template <class T>
@@ -977,7 +977,7 @@ std::string Statistic<T>::Description() const {
 }
 
 template <class T>
-std::string Statistic<T>::Dump() const
+std::string Statistic<T>::Dump(unsigned short ntabs) const
 { return Description(); }
 
 template <class T>
@@ -1411,8 +1411,8 @@ std::string ComplexVariable<T>::Description() const {
 }
 
 template <class T>
-std::string ComplexVariable<T>::Dump() const
-{ return Variable<T>::Dump(); }
+std::string ComplexVariable<T>::Dump(unsigned short ntabs) const
+{ return Variable<T>::Dump(ntabs); }
 
 template <class T>
 void ComplexVariable<T>::SetTopLevelContent(const std::string& content_name)
@@ -1472,16 +1472,16 @@ template <>
 FO_COMMON_API std::string ComplexVariable<std::string>::Eval(const ScriptingContext& context) const;
 
 template <>
-FO_COMMON_API std::string ComplexVariable<Visibility>::Dump() const;
+FO_COMMON_API std::string ComplexVariable<Visibility>::Dump(unsigned short ntabs) const;
 
 template <>
-FO_COMMON_API std::string ComplexVariable<double>::Dump() const;
+FO_COMMON_API std::string ComplexVariable<double>::Dump(unsigned short ntabs) const;
 
 template <>
-FO_COMMON_API std::string ComplexVariable<int>::Dump() const;
+FO_COMMON_API std::string ComplexVariable<int>::Dump(unsigned short ntabs) const;
 
 template <>
-FO_COMMON_API std::string ComplexVariable<std::string>::Dump() const;
+FO_COMMON_API std::string ComplexVariable<std::string>::Dump(unsigned short ntabs) const;
 
 template <class T>
 template <class Archive>
@@ -1569,8 +1569,8 @@ std::string StaticCast<FromType, ToType>::Description() const
 { return m_value_ref->Description(); }
 
 template <class FromType, class ToType>
-std::string StaticCast<FromType, ToType>::Dump() const
-{ return m_value_ref->Dump(); }
+std::string StaticCast<FromType, ToType>::Dump(unsigned short ntabs) const
+{ return m_value_ref->Dump(ntabs); }
 
 template <class FromType, class ToType>
 void StaticCast<FromType, ToType>::SetTopLevelContent(const std::string& content_name)
@@ -1693,8 +1693,8 @@ std::string StringCast<FromType>::Description() const
 { return m_value_ref->Description(); }
 
 template <class FromType>
-std::string StringCast<FromType>::Dump() const
-{ return m_value_ref->Dump(); }
+std::string StringCast<FromType>::Dump(unsigned short ntabs) const
+{ return m_value_ref->Dump(ntabs); }
 
 template <class FromType>
 void StringCast<FromType>::SetTopLevelContent(const std::string& content_name) {
@@ -1799,9 +1799,9 @@ std::string UserStringLookup<FromType>::Description() const
 }
 
 template <class FromType>
-std::string UserStringLookup<FromType>::Dump() const
+std::string UserStringLookup<FromType>::Dump(unsigned short ntabs) const
 {
-    return m_value_ref->Dump();
+    return m_value_ref->Dump(ntabs);
 }
 
 template <class FromType>
@@ -2243,7 +2243,7 @@ std::string Operation<T>::Description() const
 }
 
 template <class T>
-std::string Operation<T>::Dump() const
+std::string Operation<T>::Dump(unsigned short ntabs) const
 {
     if (m_op_type == NEGATE) {
         if (auto rhs = dynamic_cast<const Operation<T>*>(LHS())) {
@@ -2251,27 +2251,27 @@ std::string Operation<T>::Dump() const
             if (op_type == PLUS     || op_type == MINUS ||
                 op_type == TIMES    || op_type == DIVIDE ||
                 op_type == NEGATE   || op_type == EXPONENTIATE)
-            return "-(" + LHS()->Dump() + ")";
+            return "-(" + LHS()->Dump(ntabs) + ")";
         } else {
-            return "-" + LHS()->Dump();
+            return "-" + LHS()->Dump(ntabs);
         }
     }
 
     if (m_op_type == ABS)
-        return "abs(" + LHS()->Dump() + ")";
+        return "abs(" + LHS()->Dump(ntabs) + ")";
     if (m_op_type == LOGARITHM)
-        return "log(" + LHS()->Dump() + ")";
+        return "log(" + LHS()->Dump(ntabs) + ")";
     if (m_op_type == SINE)
-        return "sin(" + LHS()->Dump() + ")";
+        return "sin(" + LHS()->Dump(ntabs) + ")";
     if (m_op_type == COSINE)
-        return "cos(" + LHS()->Dump() + ")";
+        return "cos(" + LHS()->Dump(ntabs) + ")";
 
     if (m_op_type == MINIMUM) {
         std::string retval = "min(";
         for (auto it = m_operands.begin(); it != m_operands.end(); ++it) {
             if (it != m_operands.begin())
                 retval += ", ";
-            retval += (*it)->Dump();
+            retval += (*it)->Dump(ntabs);
         }
         retval += ")";
         return retval;
@@ -2281,21 +2281,21 @@ std::string Operation<T>::Dump() const
         for (auto it = m_operands.begin(); it != m_operands.end(); ++it) {
             if (it != m_operands.begin())
                 retval += ", ";
-            retval += (*it)->Dump();
+            retval += (*it)->Dump(ntabs);
         }
         retval += ")";
         return retval;
     }
 
     if (m_op_type == RANDOM_UNIFORM)
-        return "random(" + LHS()->Dump() + ", " + LHS()->Dump() + ")";
+        return "random(" + LHS()->Dump(ntabs) + ", " + LHS()->Dump(ntabs) + ")";
 
     if (m_op_type == RANDOM_PICK) {
         std::string retval = "randompick(";
         for (auto it = m_operands.begin(); it != m_operands.end(); ++it) {
             if (it != m_operands.begin())
                 retval += ", ";
-            retval += (*it)->Dump();
+            retval += (*it)->Dump(ntabs);
         }
         retval += ")";
         return retval;
@@ -2331,9 +2331,9 @@ std::string Operation<T>::Dump() const
 
     std::string retval;
     if (parenthesize_lhs)
-        retval += '(' + LHS()->Dump() + ')';
+        retval += '(' + LHS()->Dump(ntabs) + ')';
     else
-        retval += LHS()->Dump();
+        retval += LHS()->Dump(ntabs);
 
     switch (m_op_type) {
     case PLUS:          retval += " + "; break;
@@ -2345,9 +2345,9 @@ std::string Operation<T>::Dump() const
     }
 
     if (parenthesize_rhs)
-        retval += '(' + RHS()->Dump() + ')';
+        retval += '(' + RHS()->Dump(ntabs) + ')';
     else
-        retval += RHS()->Dump();
+        retval += RHS()->Dump(ntabs);
 
     return retval;
 }

--- a/util/Logger.cpp
+++ b/util/Logger.cpp
@@ -125,11 +125,6 @@ inline std::basic_istream<CharT, TraitsT >& operator>>(
     return is;
 }
 
-int g_indent = 0;
-
-std::string DumpIndent()
-{ return std::string(g_indent * 4, ' '); }
-
 namespace {
     std::string& LocalUnnamedLoggerIdentifier() {
         // Create default logger name as a static function variable to avoid static initialization fiasco

--- a/util/Logger.h
+++ b/util/Logger.h
@@ -325,10 +325,4 @@ FO_COMMON_API void ApplyConfigurationToFileSinkFrontEnd(
     const std::string& channel_name,
     const LoggerFileSinkFrontEndConfigurer& configure_front_end);
 
-extern int g_indent;
-
-/** A function that returns the correct amount of spacing for the current
-  * indentation level during a dump. */
-std::string DumpIndent();
-
 #endif // _Logger_h_


### PR DESCRIPTION
#### Problem ####
Multiple threads increment/decrement `g_indent` without any synchonization.  

I think that this leads to rare buggy behavior every few thousand turns.  It causes data corruption, log corruption and/or crashes.

#### This Solution ####
Convert `g_indent` from a global that requires synchronization to a parameter of `Dump()`