### PR TITLE
Consolidate GetLocale functions

### DIFF
--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -57,7 +57,6 @@
 #include <boost/optional/optional.hpp>
 #include <boost/range/numeric.hpp>
 #include <boost/range/adaptor/map.hpp>
-#include <boost/locale.hpp>
 
 #include <GG/DrawUtil.h>
 #include <GG/Layout.h>
@@ -6699,15 +6698,9 @@ bool MapWnd::ZoomToHomeSystem() {
 }
 
 namespace {
-    const std::locale& GetLocale() {
-        static boost::locale::generator gen;
-        static std::locale loc = gen("en_US.UTF-8");    // should sort accented latin letters reasonably
-        return loc;
-    }
-
     struct CustomRowCmp {
         bool operator()(const std::pair<std::string, int>& lhs, const std::pair<std::string, int>& rhs) {
-            return GetLocale().operator()(lhs.first, rhs.first);    // todo: use .second values to break ties
+            return GetLocale("en_US.UTF-8").operator()(lhs.first, rhs.first);    // todo: use .second values to break ties
         }
     };
 

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -1806,8 +1806,13 @@ namespace {
                 float rhs_val = rhs_key.empty() ? 0.0f : boost::lexical_cast<float>(rhs_key);
                 return lhs_val < rhs_val;
             } catch (...) {
+#if defined(FREEORION_MACOSX)
+                // Collate on OSX seemingly ignores greek characters, resulting in sort order: X α I, X β I, X α II
+                return lhs_key < rhs_key;
+#else
                 return GetLocale("en_US.UTF-8").operator()(static_cast<const ObjectRow&>(lhs).SortKey(column),
                                                            static_cast<const ObjectRow&>(rhs).SortKey(column));
+#endif
             }
         }
     };

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -28,7 +28,6 @@
 #include <GG/Layout.h>
 
 #include <boost/lexical_cast.hpp>
-#include <boost/locale.hpp>
 //TODO: replace with std::make_unique when transitioning to C++14
 #include <boost/smart_ptr/make_unique.hpp>
 
@@ -1796,12 +1795,6 @@ private:
 };
 
 namespace {
-    const std::locale& GetLocale() {
-        static boost::locale::generator gen;
-        static std::locale loc = gen("en_US.UTF-8");    // should sort accented latin letters reasonably
-        return loc;
-    }
-
     struct CustomRowCmp {
         bool operator()(const GG::ListBox::Row& lhs, const GG::ListBox::Row& rhs, std::size_t column) {
             const std::string& lhs_key = lhs.SortKey(column);
@@ -1813,8 +1806,8 @@ namespace {
                 float rhs_val = rhs_key.empty() ? 0.0f : boost::lexical_cast<float>(rhs_key);
                 return lhs_val < rhs_val;
             } catch (...) {
-                return GetLocale().operator()(static_cast<const ObjectRow&>(lhs).SortKey(column),
-                                              static_cast<const ObjectRow&>(rhs).SortKey(column));
+                return GetLocale("en_US.UTF-8").operator()(static_cast<const ObjectRow&>(lhs).SortKey(column),
+                                                           static_cast<const ObjectRow&>(rhs).SortKey(column));
             }
         }
     };

--- a/UI/TechTreeWnd.cpp
+++ b/UI/TechTreeWnd.cpp
@@ -30,7 +30,6 @@
 #include <algorithm>
 
 #include <boost/timer.hpp>
-#include <boost/locale.hpp>
 
 namespace {
     const std::string RES_PEDIA_WND_NAME = "research.pedia";
@@ -112,13 +111,6 @@ namespace {
 
         // all tests pass, so tech is visible
         return true;
-    }
-
-    // Duplicated in MapWnd.cpp/ObjectListWnd.cpp
-    const std::locale& GetLocale() {
-        static boost::locale::generator gen;
-        static const std::locale& loc = gen("en_US.UTF-8");  // manually sets locale
-        return loc;
     }
 }
 
@@ -1639,7 +1631,7 @@ bool TechTreeWnd::TechListBox::TechRowCmp(const GG::ListBox::Row& lhs, const GG:
         try {  // attempt compare by int
             retval = boost::lexical_cast<int>(lhs_key) < boost::lexical_cast<int>(rhs_key);
         } catch (const boost::bad_lexical_cast& e) {
-            retval = GetLocale().operator()(lhs_key, rhs_key);
+            retval = GetLocale("en_US.UTF-8").operator()(lhs_key, rhs_key);
         }
     }
 

--- a/util/i18n.h
+++ b/util/i18n.h
@@ -9,6 +9,9 @@
 
 #include "Export.h"
 
+/** Returns locale, which may be previously cached */
+FO_COMMON_API std::locale GetLocale(const std::string& name = std::string(""));
+
 /** Returns a language-specific string for the key-string \a str */
 FO_COMMON_API const std::string& UserString(const std::string& str);
 


### PR DESCRIPTION
Provides a common, more robust version of `GetLocale`, utilizing `std` backend and locale cache.

Testing requested on OSX, for suitability of `std` backend. (chat time stamps and objects list sorting should still function correctly).

As a side-effect, may improve state of #1907 (chat timestamps on windows with certain locales). At the least, it can assist troubleshooting locale related issues from info/error log.