### PR TITLE
Only ClearSpeciesHomeworlds in universe generation.

### DIFF
--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1392,6 +1392,7 @@ void ServerApp::GenerateUniverse(std::map<int, PlayerSetupData>& player_setup_da
 
     // Reset the universe object for a new universe
     universe.Clear();
+    GetSpeciesManager().ClearSpeciesHomeworlds();
 
     // Reset the object id manager for the new empires.
     std::vector<int> empire_ids(player_setup_data.size());

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -133,8 +133,6 @@ void Universe::Clear() {
     m_effect_discrepancy_map.clear();
     m_effect_specified_empire_object_visibilities.clear();
 
-    GetSpeciesManager().ClearSpeciesHomeworlds();
-
     m_stat_records.clear();
 
     m_universe_width = 1000.0;


### PR DESCRIPTION
This fixes issue #1920.

Commit 110ba9fbb3b5ce016b9938649b423f9e91736941 changed
GetSpeciesManager().ClearSpeciesHomeworlds() from happening only in
GenerateUniverse() into Universe::Clear() which clears the homeworld
bonus incorrectly.

This commit restores clearing the species homeworlds only in generate
universe.

Thanks @alleryn for reporting and doing the bisection for this bug.
Thanks @Vezzra for shouting me down.