### PR TITLE
Categorize help output

### DIFF
--- a/client/AI/camain.cpp
+++ b/client/AI/camain.cpp
@@ -4,6 +4,7 @@
 #include "../../util/Directories.h"
 #include "../../util/Logger.h"
 #include "../../util/Version.h"
+#include "../../util/i18n.h"
 
 #include <GG/utf8/checked.h>
 
@@ -43,10 +44,20 @@ int wmain(int argc, wchar_t* argv[], wchar_t* envp[]) {
     InitDirs((args.empty() ? "" : *args.begin()));
 #endif
 
+    GetOptionsDB().Add<std::string>('h', "help", UserStringNop("OPTIONS_DB_HELP"), "NOOP",
+                                    Validator<std::string>(), false);
+
     // if config.xml and persistent_config.xml are present, read and set options entries
     GetOptionsDB().SetFromFile(GetConfigPath(), FreeOrionVersionString());
     GetOptionsDB().SetFromFile(GetPersistentConfigPath());
     GetOptionsDB().SetFromCommandLine(args);
+
+    auto help_arg = GetOptionsDB().Get<std::string>("help");
+    if (help_arg != "NOOP") {
+        GetOptionsDB().GetUsage(std::cerr, help_arg);
+        ShutdownLoggingSystemFileSink();
+        return 0;
+    }
 
 #ifndef FREEORION_CAMAIN_KEEP_STACKTRACE
     try {

--- a/client/human/chmain.cpp
+++ b/client/human/chmain.cpp
@@ -86,7 +86,8 @@ int wmain(int argc, wchar_t* argv[], wchar_t* envp[]) {
 #endif
 #ifndef FREEORION_MACOSX
     // did the player request help output?
-    if (GetOptionsDB().Get<bool>("help")) {
+    auto help_arg = GetOptionsDB().Get<std::string>("help");
+    if (help_arg != "NOOP") {
         ShutdownLoggingSystemFileSink();
         GetOptionsDB().GetUsage(std::cout);
         return 0;   // quit without actually starting game
@@ -119,7 +120,8 @@ int mainConfigOptionsSetup(const std::vector<std::string>& args) {
     try {
 #endif
         // add entries in options DB that have no other obvious place
-        GetOptionsDB().AddFlag('h', "help",                         UserStringNop("OPTIONS_DB_HELP"),                   false);
+        GetOptionsDB().Add<std::string>('h', "help",                UserStringNop("OPTIONS_DB_HELP"),                   "NOOP",
+                                        Validator<std::string>(),                                                       false);
         GetOptionsDB().AddFlag('v', "version",                      UserStringNop("OPTIONS_DB_VERSION"),                false);
         GetOptionsDB().AddFlag('g', "generate-config-xml",          UserStringNop("OPTIONS_DB_GENERATE_CONFIG_XML"),    false);
         GetOptionsDB().AddFlag('f', "video.fullscreen.enabled",     UserStringNop("OPTIONS_DB_FULLSCREEN"),             STORE_FULLSCREEN_FLAG);

--- a/client/human/chmain.cpp
+++ b/client/human/chmain.cpp
@@ -160,6 +160,12 @@ int mainConfigOptionsSetup(const std::vector<std::string>& args) {
         GetOptionsDB().AddSection("save", UserStringNop("OPTIONS_DB_SECTION_SAVE"));
         GetOptionsDB().AddSection("setup", UserStringNop("OPTIONS_DB_SECTION_SETUP"));
         GetOptionsDB().AddSection("ui", UserStringNop("OPTIONS_DB_SECTION_UI"));
+        GetOptionsDB().AddSection("ui.colors", UserStringNop("OPTIONS_DB_SECTION_UI_COLORS"),
+                                  [](const std::string& name)->bool {
+                                      std::string suffix { ".color" };
+                                      return name.size() > suffix.size() &&
+                                             name.substr(name.size() - suffix.size()) == suffix;
+                                  });
         GetOptionsDB().AddSection("ui.hotkeys", UserStringNop("OPTIONS_DB_SECTION_UI_HOTKEYS"),
                                   [](const std::string& name)->bool {
                                       std::string suffix { ".hotkey" };

--- a/client/human/chmain.cpp
+++ b/client/human/chmain.cpp
@@ -160,6 +160,12 @@ int mainConfigOptionsSetup(const std::vector<std::string>& args) {
         GetOptionsDB().AddSection("save", UserStringNop("OPTIONS_DB_SECTION_SAVE"));
         GetOptionsDB().AddSection("setup", UserStringNop("OPTIONS_DB_SECTION_SETUP"));
         GetOptionsDB().AddSection("ui", UserStringNop("OPTIONS_DB_SECTION_UI"));
+        GetOptionsDB().AddSection("ui.hotkeys", UserStringNop("OPTIONS_DB_SECTION_UI_HOTKEYS"),
+                                  [](const std::string& name)->bool {
+                                      std::string suffix { ".hotkey" };
+                                      return name.size() > suffix.size() &&
+                                             name.substr(name.size() - suffix.size()) == suffix;
+                                  });
         GetOptionsDB().AddSection("version", UserStringNop("OPTIONS_DB_SECTION_VERSION"));
         GetOptionsDB().AddSection("video", UserStringNop("OPTIONS_DB_SECTION_VIDEO"));
         GetOptionsDB().AddSection("video.fullscreen", UserStringNop("OPTIONS_DB_SECTION_VIDEO_FULLSCREEN"));

--- a/client/human/chmain.cpp
+++ b/client/human/chmain.cpp
@@ -89,7 +89,7 @@ int wmain(int argc, wchar_t* argv[], wchar_t* envp[]) {
     auto help_arg = GetOptionsDB().Get<std::string>("help");
     if (help_arg != "NOOP") {
         ShutdownLoggingSystemFileSink();
-        GetOptionsDB().GetUsage(std::cout, help_arg);
+        GetOptionsDB().GetUsage(std::cout, help_arg, true);
         return 0;   // quit without actually starting game
     }
 

--- a/client/human/chmain.cpp
+++ b/client/human/chmain.cpp
@@ -122,7 +122,8 @@ int mainConfigOptionsSetup(const std::vector<std::string>& args) {
         // add entries in options DB that have no other obvious place
         GetOptionsDB().Add<std::string>('h', "help",                UserStringNop("OPTIONS_DB_HELP"),                   "NOOP",
                                         Validator<std::string>(),                                                       false);
-        GetOptionsDB().AddFlag('v', "version",                      UserStringNop("OPTIONS_DB_VERSION"),                false);
+        GetOptionsDB().AddFlag('v', "version",                      UserStringNop("OPTIONS_DB_VERSION"),                false,
+                               "version");
         GetOptionsDB().AddFlag('g', "generate-config-xml",          UserStringNop("OPTIONS_DB_GENERATE_CONFIG_XML"),    false);
         GetOptionsDB().AddFlag('f', "video.fullscreen.enabled",     UserStringNop("OPTIONS_DB_FULLSCREEN"),             STORE_FULLSCREEN_FLAG);
         GetOptionsDB().Add("video.fullscreen.reset",                UserStringNop("OPTIONS_DB_RESET_FSSIZE"),           true);
@@ -141,6 +142,28 @@ int mainConfigOptionsSetup(const std::vector<std::string>& args) {
         GetOptionsDB().Add<std::string>("version.string",           UserStringNop("OPTIONS_DB_VERSION_STRING"),         FreeOrionVersionString(),
                                         Validator<std::string>(),                                                       true);
         GetOptionsDB().AddFlag('r', "render-simple",                UserStringNop("OPTIONS_DB_RENDER_SIMPLE"),          false);
+
+        // add sections for option sorting
+        GetOptionsDB().AddSection("audio", UserStringNop("OPTIONS_DB_SECTION_AUDIO"));
+        GetOptionsDB().AddSection("audio.music", UserStringNop("OPTIONS_DB_SECTION_AUDIO_MUSIC"));
+        GetOptionsDB().AddSection("audio.effects", UserStringNop("OPTIONS_DB_SECTION_AUDIO_EFFECTS"));
+        GetOptionsDB().AddSection("audio.effects.paths", UserStringNop("OPTIONS_DB_SECTION_AUDIO_EFFECTS_PATHS"),
+                                  [](const std::string& name)->bool {
+                                      std::string suffix { "sound.path" };
+                                      return name.size() > suffix.size() &&
+                                             name.substr(name.size() - suffix.size()) == suffix;
+                                  });
+        GetOptionsDB().AddSection("effects", UserStringNop("OPTIONS_DB_SECTION_EFFECTS"));
+        GetOptionsDB().AddSection("logging", UserStringNop("OPTIONS_DB_SECTION_LOGGING"));
+        GetOptionsDB().AddSection("network", UserStringNop("OPTIONS_DB_SECTION_NETWORK"));
+        GetOptionsDB().AddSection("resource", UserStringNop("OPTIONS_DB_SECTION_RESOURCE"));
+        GetOptionsDB().AddSection("save", UserStringNop("OPTIONS_DB_SECTION_SAVE"));
+        GetOptionsDB().AddSection("setup", UserStringNop("OPTIONS_DB_SECTION_SETUP"));
+        GetOptionsDB().AddSection("ui", UserStringNop("OPTIONS_DB_SECTION_UI"));
+        GetOptionsDB().AddSection("version", UserStringNop("OPTIONS_DB_SECTION_VERSION"));
+        GetOptionsDB().AddSection("video", UserStringNop("OPTIONS_DB_SECTION_VIDEO"));
+        GetOptionsDB().AddSection("video.fullscreen", UserStringNop("OPTIONS_DB_SECTION_VIDEO_FULLSCREEN"));
+        GetOptionsDB().AddSection("video.windowed", UserStringNop("OPTIONS_DB_SECTION_VIDEO_WINDOWED"));
 
         // Add the keyboard shortcuts
         Hotkey::AddOptions(GetOptionsDB());

--- a/client/human/chmain.cpp
+++ b/client/human/chmain.cpp
@@ -89,7 +89,7 @@ int wmain(int argc, wchar_t* argv[], wchar_t* envp[]) {
     auto help_arg = GetOptionsDB().Get<std::string>("help");
     if (help_arg != "NOOP") {
         ShutdownLoggingSystemFileSink();
-        GetOptionsDB().GetUsage(std::cout);
+        GetOptionsDB().GetUsage(std::cout, help_arg);
         return 0;   // quit without actually starting game
     }
 

--- a/client/human/chmain.mm
+++ b/client/human/chmain.mm
@@ -26,8 +26,8 @@ int main(int argc, char *argv[])
 
     // did the player request help output?
     auto help_arg = GetOptionsDB().Get<std::string>("help");
-    if (help_arg ! "NOOP") {
-        GetOptionsDB().GetUsage(std::cerr, help_arg);
+    if (help_arg != "NOOP") {
+        GetOptionsDB().GetUsage(std::cerr, help_arg, true);
         return 0;   // quit without actually starting game
     }
 

--- a/client/human/chmain.mm
+++ b/client/human/chmain.mm
@@ -27,7 +27,7 @@ int main(int argc, char *argv[])
     // did the player request help output?
     auto help_arg = GetOptionsDB().Get<std::string>("help");
     if (help_arg ! "NOOP") {
-        GetOptionsDB().GetUsage(std::cerr);
+        GetOptionsDB().GetUsage(std::cerr, help_arg);
         return 0;   // quit without actually starting game
     }
 

--- a/client/human/chmain.mm
+++ b/client/human/chmain.mm
@@ -25,7 +25,8 @@ int main(int argc, char *argv[])
     }
 
     // did the player request help output?
-    if (GetOptionsDB().Get<bool>("help")) {
+    auto help_arg = GetOptionsDB().Get<std::string>("help");
+    if (help_arg ! "NOOP") {
         GetOptionsDB().GetUsage(std::cerr);
         return 0;   // quit without actually starting game
     }

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1089,11 +1089,20 @@ Starlanes are generated between every pair of systems, regardless of geometry. L
 ## Command-line and options database entries
 ##
 
+COMMAND_LINE_NOT_FOUND
+'''No options or sections found matching'''
+
 COMMAND_LINE_USAGE
-'''Usage: '''
+'''Usage: -h | --help [group name | option name]'''
 
 COMMAND_LINE_DEFAULT
 '''Default'''
+
+COMMAND_LINE_SECTIONS
+'''Option Groups'''
+
+COMMAND_LINE_OPTIONS
+'''Options'''
 
 OPTIONS_DB_HELP
 Print this help message.

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1914,6 +1914,9 @@ New game starting settings
 OPTIONS_DB_SECTION_UI
 User interface
 
+OPTIONS_DB_SECTION_UI_COLORS
+Colors
+
 OPTIONS_DB_SECTION_UI_CONTROL
 Control (generic)
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1917,6 +1917,9 @@ User interface
 OPTIONS_DB_SECTION_UI_CONTROL
 Control (generic)
 
+OPTIONS_DB_SECTION_UI_HOTKEYS
+Hotkeys
+
 OPTIONS_DB_SECTION_UI_MAP
 Main map
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1855,6 +1855,83 @@ Network port to use for client-server messaging.
 
 
 ##
+## Option sections
+##
+
+OPTIONS_DB_SECTION_ALL
+All options
+
+OPTIONS_DB_SECTION_AUDIO
+Audio
+
+OPTIONS_DB_SECTION_AUDIO_MUSIC
+Background music
+
+OPTIONS_DB_SECTION_AUDIO_EFFECTS
+Sound effects
+
+OPTIONS_DB_SECTION_AUDIO_EFFECTS_PATHS
+Sound effect paths
+
+OPTIONS_DB_SECTION_EFFECTS
+Effects
+
+OPTIONS_DB_SECTION_LOGGING
+Logging
+
+OPTIONS_DB_SECTION_MISC
+Miscellaneous
+
+OPTIONS_DB_SECTION_NETWORK
+Network and server
+
+OPTIONS_DB_SECTION_RAW
+All options with only raw description keys
+
+OPTIONS_DB_SECTION_RESOURCE
+Game data resources
+
+OPTIONS_DB_SECTION_SAVE
+Save game
+
+OPTIONS_DB_SECTION_SETUP
+New game starting settings
+
+OPTIONS_DB_SECTION_UI
+User interface
+
+OPTIONS_DB_SECTION_UI_CONTROL
+Control (generic)
+
+OPTIONS_DB_SECTION_UI_MAP
+Main map
+
+OPTIONS_DB_SECTION_UI_MAP_FLEET
+Fleets (map)
+
+OPTIONS_DB_SECTION_UI_FLEET
+Fleet window
+
+OPTIONS_DB_UI_WINDOW
+Window (generic)
+
+OPTIONS_DB_SECTION_VERSION
+Version
+
+OPTIONS_DB_SECTION_VIDEO
+Video
+
+OPTIONS_DB_SECTION_VIDEO_FPS
+Frames per second
+
+OPTIONS_DB_SECTION_VIDEO_FULLSCREEN
+Fullscreen mode
+
+OPTIONS_DB_SECTION_VIDEO_WINDOWED
+Windowed mode
+
+
+##
 ## File dialog
 ##
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1105,7 +1105,12 @@ COMMAND_LINE_OPTIONS
 '''Options'''
 
 OPTIONS_DB_HELP
-Print this help message.
+'''Print this help message.
+Accepts an argument for partial or full option name.
+Special arguments are provided for:
+all - [[OPTIONS_DB_SECTION_ALL]]
+raw - [[OPTIONS_DB_SECTION_RAW]]'''
+
 
 OPTIONS_DB_VERSION
 Print version and exit.

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1093,7 +1093,7 @@ COMMAND_LINE_USAGE
 '''Usage: '''
 
 COMMAND_LINE_DEFAULT
-'''Default: '''
+'''Default'''
 
 OPTIONS_DB_HELP
 Print this help message.

--- a/server/dmain.cpp
+++ b/server/dmain.cpp
@@ -65,7 +65,7 @@ int wmain(int argc, wchar_t* argv[], wchar_t* envp[]) {
 
         auto help_arg = GetOptionsDB().Get<std::string>("help");
         if (help_arg != "NOOP") {
-            GetOptionsDB().GetUsage(std::cerr);
+            GetOptionsDB().GetUsage(std::cerr, help_arg);
             ShutdownLoggingSystemFileSink();
             return 0;
         }

--- a/server/dmain.cpp
+++ b/server/dmain.cpp
@@ -47,7 +47,8 @@ int wmain(int argc, wchar_t* argv[], wchar_t* envp[]) {
 #ifndef FREEORION_DMAIN_KEEP_STACKTRACE
     try {
 #endif
-        GetOptionsDB().AddFlag('h', "help",          UserStringNop("OPTIONS_DB_HELP"),              false);
+        GetOptionsDB().Add<std::string>('h', "help", UserStringNop("OPTIONS_DB_HELP"),              "NOOP",
+                                        Validator<std::string>(),                                   false);
         GetOptionsDB().AddFlag('v', "version",       UserStringNop("OPTIONS_DB_VERSION"),           false);
         GetOptionsDB().AddFlag('s', "singleplayer",  UserStringNop("OPTIONS_DB_SINGLEPLAYER"),      false);
         GetOptionsDB().AddFlag("hostless",           UserStringNop("OPTIONS_DB_HOSTLESS"),          false);
@@ -62,7 +63,8 @@ int wmain(int argc, wchar_t* argv[], wchar_t* envp[]) {
         // override previously-saved and default options with command line parameters and flags
         GetOptionsDB().SetFromCommandLine(args);
 
-        if (GetOptionsDB().Get<bool>("help")) {
+        auto help_arg = GetOptionsDB().Get<std::string>("help");
+        if (help_arg != "NOOP") {
             GetOptionsDB().GetUsage(std::cerr);
             ShutdownLoggingSystemFileSink();
             return 0;

--- a/util/MultiplayerCommon.cpp
+++ b/util/MultiplayerCommon.cpp
@@ -82,7 +82,7 @@ GameRules::Rule::Rule(RuleType rule_type_, const std::string& name_, const boost
                       const ValidatorBase *validator_, bool engine_internal_,
                       const std::string& category_) :
     OptionsDB::Option(static_cast<char>(0), name_, value_, default_value_,
-                      description_, validator_, engine_internal_, false, true),
+                      description_, validator_, engine_internal_, false, true, "setup.rules"),
     rule_type(rule_type_),
     category(category_)
 {}

--- a/util/OptionsDB.cpp
+++ b/util/OptionsDB.cpp
@@ -254,6 +254,9 @@ void OptionsDB::GetUsage(std::ostream& os, const std::string& command_line/* = "
         throw std::runtime_error("The longest parameter name leaves no room for a description.");
 
     for (const auto& option : m_options) {
+        if (!boost::algorithm::starts_with(option.first, command_line))
+            continue;
+
         // Ignore unrecognized options that have not been formally registered
         // with Add().
         if (!option.second.recognized)

--- a/util/OptionsDB.cpp
+++ b/util/OptionsDB.cpp
@@ -299,6 +299,9 @@ namespace {
 }
 
 void OptionsDB::GetUsage(std::ostream& os, const std::string& command_line, bool allow_unrecognized) const {
+    // Prevent logger output from garbling console display for low severity messages
+    OverrideAllLoggersThresholds(LogLevel::warn);
+
     os << UserString("COMMAND_LINE_USAGE") << command_line << "\n";
 
     for (const auto& option : m_options) {
@@ -323,6 +326,9 @@ void OptionsDB::GetUsage(std::ostream& os, const std::string& command_line, bool
         }
         os << "\n";
     }
+
+    // reset override in case this function is later repurposed
+    OverrideAllLoggersThresholds(boost::none);
 }
 
 void OptionsDB::GetXML(XMLDoc& doc, bool non_default_only) const {

--- a/util/OptionsDB.cpp
+++ b/util/OptionsDB.cpp
@@ -462,10 +462,11 @@ void OptionsDB::SetFromCommandLine(const std::vector<std::string>& args) {
 
                 if (!option.flag) { // non-flag
                     try {
-                        // ensure a parameter exists...
-                        if (i + 1 >= static_cast<unsigned int>(args.size()))
-                            throw std::runtime_error("the option \"" + option.name +
-                                                     "\" was specified, at the end of the list, with no parameter value.");
+                        // check if parameter exists...
+                        if (i + 1 >= static_cast<unsigned int>(args.size())) {
+                            m_dirty |= option.SetFromString("");
+                            continue;
+                        }
                         // get parameter value
                         std::string value_str(args[++i]);
                         StripQuotation(value_str);
@@ -511,10 +512,14 @@ void OptionsDB::SetFromCommandLine(const std::vector<std::string>& args) {
                         throw std::runtime_error("The value member of option \"--" + option.name + "\" is undefined.");
 
                     if (!option.flag) {
-                        if (j < single_char_options.size() - 1)
+                        if (j < single_char_options.size() - 1) {
                             throw std::runtime_error(std::string("Option \"-") + single_char_options[j] + "\" was given with no parameter.");
-                        else
-                            m_dirty |= option.SetFromString(args[++i]);
+                        } else {
+                            if (i + 1 >= static_cast<unsigned int>(args.size()))
+                                m_dirty |= option.SetFromString("");
+                            else
+                                m_dirty |= option.SetFromString(args[++i]);
+                        }
                     } else {
                         option.value = true;
                     }

--- a/util/OptionsDB.cpp
+++ b/util/OptionsDB.cpp
@@ -238,7 +238,7 @@ std::shared_ptr<const ValidatorBase> OptionsDB::GetValidator(const std::string& 
     return it->second.validator;
 }
 
-void OptionsDB::GetUsage(std::ostream& os, const std::string& command_line/* = ""*/) const {
+void OptionsDB::GetUsage(std::ostream& os, const std::string& command_line, bool allow_unrecognized) const {
     os << UserString("COMMAND_LINE_USAGE") << command_line << "\n";
 
     int longest_param_name = 0;
@@ -259,7 +259,7 @@ void OptionsDB::GetUsage(std::ostream& os, const std::string& command_line/* = "
 
         // Ignore unrecognized options that have not been formally registered
         // with Add().
-        if (!option.second.recognized)
+        if (!allow_unrecognized && !option.second.recognized)
             continue;
 
         if (option.second.short_name)

--- a/util/OptionsDB.h
+++ b/util/OptionsDB.h
@@ -393,6 +393,11 @@ public:
         std::function<bool (const std::string&)> option_predicate = nullptr;
     };
 
+    /** Defines an option section with a description and optionally a option predicate.
+     *  @param name Name of section, typically in the form of a left side subset of an option name.
+     *  @param description Stringtable key used for local description
+     *  @param option_predicate Functor accepting a option name in the form of a std::string const ref and
+     *                          returning a bool. Options which return true are displayed in the section for @p name */
     void AddSection(const std::string& name, const std::string& description,
                     std::function<bool (const std::string&)> option_predicate = nullptr);
 

--- a/util/OptionsDB.h
+++ b/util/OptionsDB.h
@@ -82,8 +82,8 @@ FO_COMMON_API OptionsDB& GetOptionsDB();
   * options.  All flag command-line options (specified with AddFlag()) are
   * assumed to have false as their default value.  This means that their mere
   * presence on the command line means that they indicate a value of true;
-  * they need no argument.  For example, specifying "--help" on the command
-  * line sets the option "help" in the DB to true, and leaving it out sets the
+  * they need no argument.  For example, specifying "--version" on the command
+  * line sets the option "version" in the DB to true, and leaving it out sets the
   * option to false.
   * <br><br>Long-form names should be preceded with "--", and the
   * single-character version should be preceded with "-".  An exception to this

--- a/util/OptionsDB.h
+++ b/util/OptionsDB.h
@@ -176,7 +176,7 @@ public:
     std::shared_ptr<const ValidatorBase> GetValidator(const std::string& option_name) const;
 
     /** writes a usage message to \a os */
-    void        GetUsage(std::ostream& os, const std::string& command_line = "") const;
+    void        GetUsage(std::ostream& os, const std::string& command_line = "", bool allow_unrecognized = false) const;
 
     /** @brief  Saves the contents of the options DB to the @p doc XMLDoc.
      *

--- a/util/OptionsDB.h
+++ b/util/OptionsDB.h
@@ -412,6 +412,10 @@ private:
 
     void        SetFromXMLRecursive(const XMLElement& elem, const std::string& section_name);
 
+    /** Determine known option sections and which options each contains
+     *  A special "root" section is added for determined top-level sections */
+    std::unordered_map<std::string, std::set<std::string>> OptionsBySection(bool allow_unrecognized = false) const;
+
     std::map<std::string, Option>   m_options;
     std::unordered_map<std::string, OptionSection> m_sections;
     static OptionsDB*               s_options_db;


### PR DESCRIPTION
Sorts options into sections for --help output.

Addresses the description alignment noted in #1814

`help` option value is changed to string, to support passing a group/section lookup argument, and for special values of `all` and `raw`.

`all` is similar to old help, printing all options, descriptions, and default values where set.

`raw` is similar to `all`, but only prints the stringtable key in place of description and does not print default value.  The fields are comma separated for quick import to spreadsheet or other procedural use.