### PR TITLE
Python logging tweaks

### DIFF
--- a/default/python/AI/AIstate.py
+++ b/default/python/AI/AIstate.py
@@ -290,7 +290,7 @@ class AIstate(object):
                 sys_status.get('jump2_threat', 0.0),
                 sys_status.get('jump3_threat', 0.0),
             ])
-        threat_table.print_table()
+        info(threat_table)
 
     def __report_system_defenses(self):
         """Print a table with system defenses to the logfile."""
@@ -315,7 +315,7 @@ class AIstate(object):
                 sys_status.get('my_jump2_rating', 0.0),
                 sys_status.get('my_jump3_rating', 0.0),
             ])
-        defense_table.print_table()
+        info(defense_table)
 
     def assess_planet_threat(self, pid, sighting_age=0):
         sighting_age += 1  # play it safe
@@ -872,7 +872,7 @@ class AIstate(object):
                         m_mt0 = targets[0]
                         if isinstance(m_mt0.target_type, System):
                             fleet_status['sysID'] = m_mt0.target.id  # hmm, but might still be a fair ways from here
-        fleet_table.print_table()
+        info(fleet_table)
         # Next string used in charts. Don't modify it!
         print "Empire Ship Count: ", self.shipCount
         print "Empire standard fighter summary: ", CombatRatingsAI.get_empire_standard_fighter().get_stats()
@@ -916,7 +916,7 @@ class AIstate(object):
                     FleetUtilsAI.count_troops_in_fleet(fleet_id),
                     mission.target or "-"
                 ])
-        mission_table.print_table()
+        info(mission_table)
 
     def __split_new_fleets(self):
         """Split any new fleets.

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -1270,7 +1270,7 @@ def _print_empire_species_roster():
         this_row.append([tag for tag in species_tags if not any(s in tag for s in grade_tags) and 'PEDIA' not in tag])
         species_table.add_row(this_row)
     print
-    species_table.print_table()
+    info(species_table)
 
 
 def _print_outpost_candidate_table(candidates):
@@ -1313,5 +1313,4 @@ def __print_candidate_table(candidates, mission):
                 universe.getSystem(planet.systemID),
                 planet.specials,
             ])
-    print
-    candidate_table.print_table()
+    info(candidate_table)

--- a/default/python/AI/FleetUtilsAI.py
+++ b/default/python/AI/FleetUtilsAI.py
@@ -471,7 +471,7 @@ def generate_fleet_orders_for_fleet_missions():
     if outpost_base_fleet_missions:
         print "Outpost Base targets (must have been interrupted by combat): "
     else:
-        print "Outpost targets: None (as expected, due to expected timing of order submission and execution)"
+        print "Outpost Base targets: None (as expected, due to expected timing of order submission and execution)"
     for outpost_fleet_mission in outpost_base_fleet_missions:
         print "    %s" % outpost_fleet_mission
 

--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -227,8 +227,7 @@ def get_invasion_fleets():
             planet and planet.speciesName or "unknown",
             ptroops
         ])
-    print
-    invasion_table.print_table()
+    info(invasion_table)
 
     sorted_planets = filter(lambda x: x[1] > 0, sorted_planets)
     # export opponent planets for other AI modules

--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -269,8 +269,7 @@ def generate_production_orders():
                 building.owner
             ))
 
-        table.print_table()
-        print
+        info(table)
         capital_buildings = [universe.getBuilding(bldg).buildingTypeName for bldg in homeworld.buildingIDs]
 
         possible_building_type_ids = []
@@ -1513,7 +1512,7 @@ def _print_production_queue(after_turn=False):
             "%.1f" % element.allocation,
             "%d" % element.turnsLeft,
         ])
-    prod_queue_table.print_table()
+    info(prod_queue_table)
 
 
 def find_automatic_historic_analyzer_candidates():

--- a/default/python/AI/ResourcesAI.py
+++ b/default/python/AI/ResourcesAI.py
@@ -293,7 +293,7 @@ class Reporter(object):
                 planet.speciesName,
                 "%.1f/%.1f" % (population, max_population)
             ])
-        foci_table.print_table()
+        info(foci_table)
         print "Empire Totals:\nPopulation: %5d \nProduction: %5d\nResearch: %5d\n" % (
             empire.population(), empire.productionPoints, empire.resourceProduction(fo.resourceType.research))
         for name, (cp, mp) in warnings.iteritems():

--- a/default/python/common/configure_logging.py
+++ b/default/python/common/configure_logging.py
@@ -175,7 +175,7 @@ class _LoggerHandler(logging.Handler):
                 record.exc_info = sys.exc_info()
             traceback_msg = "".join(traceback.format_exception(*record.exc_info))
             msg += traceback_msg
-        self.logger(msg, str(record.name), str(record.filename),
+        self.logger(msg, "python", str(record.filename),
                     str(record.funcName), str(record.lineno))
 
 

--- a/default/python/common/print_utils.py
+++ b/default/python/common/print_utils.py
@@ -141,6 +141,9 @@ class Table(object):
         self.__rows = []
         self.__headers = headers
 
+    def __str__(self):
+        return self.get_table()
+
     def add_row(self, row):
         self.__rows.append(tuple(h.to_unicode(cell) for h, cell in zip(self.__headers, row)))
 
@@ -150,9 +153,6 @@ class Table(object):
                        sum(column_widthes) +
                        2
                        )
-
-    def print_table(self):
-        print self.get_table()
 
     def get_table(self):
         columns = [[len(y) for y in x] for x in zip(*self.__rows)]

--- a/default/python/universe_generation/universe_statistics.py
+++ b/default/python/universe_generation/universe_statistics.py
@@ -1,6 +1,7 @@
 import freeorion as fo
 from common.print_utils import Float, Sequence, Table, Text
 
+
 import natives
 import planets
 import universe_tables
@@ -40,7 +41,7 @@ def log_planet_count_dist(sys_list):
     )
     for planet_count, sys_count in planet_count_dist.items():
         count_distribution_table.add_row((planet_count, sys_count[0], 100.0 * sys_count[0] / len(sys_list)))
-    count_distribution_table.print_table()
+    print count_distribution_table
     print
 
     size_distribution = Table(
@@ -49,7 +50,7 @@ def log_planet_count_dist(sys_list):
     )
     for planet_size, planet_count in sorted(planet_size_dist.items()):
         size_distribution.add_row((planet_size, planet_count, 100.0 * planet_count / planet_tally))
-    size_distribution.print_table()
+    print size_distribution
     print
 
 
@@ -67,7 +68,7 @@ def log_planet_type_summary(sys_list):
 
     for planet_type, planet_count in sorted(planet_type_summary_table.items()):
         type_summary_table.add_row((planet_type.name, 100.0 * planet_count / planet_total))
-    type_summary_table.print_table()
+    print type_summary_table
     print
 
 
@@ -86,7 +87,7 @@ def log_species_summary(native_freq):
 
     for species, count in sorted(empire_species.items()):
         species_summary_table.add_row((species, count, 100.0 * count / num_empires))
-    species_summary_table.print_table()
+    print species_summary_table
     print
 
     native_chance = universe_tables.NATIVE_FREQUENCY[native_freq]
@@ -123,7 +124,7 @@ def log_species_summary(native_freq):
                  [str(p_t) for p_t in natives.planet_types_for_natives[species]]]
             )
 
-    native_table.print_table()
+    print native_table
     print
 
     native_settled_planet_total = sum(settled_native_planet_summary.values())
@@ -139,7 +140,7 @@ def log_species_summary(native_freq):
         potential_percent = 100.0 * planet_count / (1E-10 + native_potential_planet_total)
         settled_percent = 100.0 * settled_planet_count / (1E-10 + planet_count)
         type_summary_table.add_row((planet_type.name, potential_percent, settled_percent))
-    type_summary_table.print_table()
+    print type_summary_table
     print
 
 
@@ -147,7 +148,7 @@ def log_monsters_summary(monster_freq):
     monster_place_table = Table([Text('monster'), Text('count')], table_name='Monster placement')
     for monster, counter in sorted(monsters_summary):
         monster_place_table.add_row([monster, counter])
-    monster_place_table.print_table()
+    print monster_place_table
     print
 
     monster_chance = universe_tables.MONSTER_FREQUENCY[monster_freq]
@@ -163,7 +164,7 @@ def log_monsters_summary(monster_freq):
              tracked_monsters_tries[monster], tracked_monsters_summary[monster],
              tracked_monsters_location_summary[monster], tracked_nest_location_summary[monster])
         )
-    monster_table.print_table()
+    print monster_table
     print
 
 
@@ -174,7 +175,7 @@ def log_specials_summary():
     )
     for special in sorted(specials_summary):
         special_placement_count_table.add_row([special, specials_summary[special]])
-    special_placement_count_table.print_table()
+    print special_placement_count_table
     print
 
     special_placement = Table(
@@ -184,7 +185,7 @@ def log_specials_summary():
     objects_tally = sum(specials_repeat_dist.values())
     for number, tally in specials_repeat_dist.items():
         special_placement.add_row((number, tally, 100.0 * tally / (1E-10 + objects_tally)))
-    special_placement.print_table()
+    print special_placement
     print
 
 


### PR DESCRIPTION
The first commit changes the logging format so that all python loggers will always use "python" as prefix rather than the logger name (which currently is generally identical to the filename and adds no information). This better aligns the AI logs for easier readability.

```
Before:
01:02:10.428261 [debug] MoveUtilsAI : MoveUtilsAI.py:61 - Requesting path for fleet 
After:
12:15:43.770060 [debug] python : MoveUtilsAI.py:61 - Requesting path for fleet 
```

The second commit adjusts the interface of the print_utils.Table to work with our logging framework: Instead of calling ```Table.print_table()```, a ```__str__``` method is defined to provide the formatted table output. This allows printing with the correct logging level as well as correct identification of the printing file.

Before:
```
table.print_table()
01:02:10.710277 [debug] python : print_utils.py:155 - Planetary Foci Overview Turn 47
01:02:10.710277 [debug] python : print_utils.py:155 - =======================================================================================
01:02:10.710277 [debug] python : print_utils.py:155 - | Planet                      | Size     | Type     | Focus    | Species  | Pop       |
01:02:10.710277 [debug] python : print_utils.py:155 - =======================================================================================
```

After:
```
info(table)
12:15:41.465928 [info] python : ResourcesAI.py:296 - Planetary Foci Overview Turn 1
12:15:41.465928 [info] python : ResourcesAI.py:296 - =====================================================================================
12:15:41.465928 [info] python : ResourcesAI.py:296 - | Planet                        | Size  | Type   | Focus    | Species   | Pop       |
12:15:41.465928 [info] python : ResourcesAI.py:296 - =====================================================================================
```
