### PR TITLE
Allow random as setup seed option

### DIFF
--- a/UI/GalaxySetupWnd.cpp
+++ b/UI/GalaxySetupWnd.cpp
@@ -764,18 +764,8 @@ void GalaxySetupPanel::CompleteConstruction() {
     SettingsChangedSignal();
 }
 
-namespace {
-    // set of characters from which to generate random seed that excludes some ambiguous letter/number pairs
-    static char alphanum[] = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
-}
-
 void GalaxySetupPanel::RandomClicked() {
-    std::string s;
-    ClockSeed(); // to ensure we don't always get the same sequence of seeds
-    for (int i = 0; i < 8; ++i)
-        s += alphanum[ RandSmallInt(0, (sizeof(alphanum) - 2))];
-    m_seed_edit->SetText(s);
-    //std::cout << "GalaxySetupPanel::RandomClicked() new seed: " << s << std::endl;
+    m_seed_edit->SetText("");
     SettingChanged();
 }
 
@@ -929,7 +919,7 @@ void GalaxySetupPanel::SetFromSetupData(const GalaxySetupData& setup_data) {
 }
 
 void GalaxySetupPanel::GetSetupData(GalaxySetupData& setup_data) const {
-    setup_data.m_seed =             GetSeed();
+    setup_data.SetSeed(GetSeed());
     setup_data.m_size =             Systems();
     setup_data.m_shape =            GetShape();
     setup_data.m_age =              GetAge();

--- a/UI/GalaxySetupWnd.cpp
+++ b/UI/GalaxySetupWnd.cpp
@@ -765,7 +765,7 @@ void GalaxySetupPanel::CompleteConstruction() {
 }
 
 void GalaxySetupPanel::RandomClicked() {
-    m_seed_edit->SetText("");
+    m_seed_edit->SetText("RANDOM");
     SettingChanged();
 }
 

--- a/UI/GalaxySetupWnd.cpp
+++ b/UI/GalaxySetupWnd.cpp
@@ -557,10 +557,12 @@ void GalaxySetupPanel::CompleteConstruction() {
     m_seed_label->SetBrowseModeTime(GetOptionsDB().Get<int>("ui.tooltip.delay"));
     m_seed_label->SetBrowseText(UserString(GetOptionsDB().GetDescription("setup.seed")));
     m_seed = GetOptionsDB().Get<std::string>("setup.seed");
-    if (m_seed == "RANDOM")
+    if (m_seed == "RANDOM" || m_seed.empty()) {
+        m_seed = "RANDOM";
         m_seed_edit = GG::Wnd::Create<CUIEdit>(UserString("GSETUP_RANDOM"));
-    else
+    } else {
         m_seed_edit = GG::Wnd::Create<CUIEdit>(m_seed);
+    }
 
     boost::filesystem::path button_texture_dir = ClientUI::ArtDir() / "icons" / "buttons";
 
@@ -662,7 +664,7 @@ void GalaxySetupPanel::CompleteConstruction() {
     m_random->LeftClickedSignal.connect(
         boost::bind(&GalaxySetupPanel::RandomClicked, this));
     m_seed_edit->FocusUpdateSignal.connect(
-        boost::bind(&GalaxySetupPanel::SettingChanged, this));
+        boost::bind(&GalaxySetupPanel::SetSeed, this, _1, false));
     m_stars_spin->ValueChangedSignal.connect(
         boost::bind(&GalaxySetupPanel::SettingChanged, this));
     m_galaxy_shapes_list->SelChangedSignal.connect(
@@ -754,6 +756,7 @@ void GalaxySetupPanel::CompleteConstruction() {
 
     // initial settings from stored results or defaults
     SetSeed(GetOptionsDB().Get<std::string>("setup.seed"), true);
+    m_seed_edit->Disable(GetSeed() == "RANDOM");
     m_stars_spin->SetValue(GetOptionsDB().Get<int>("setup.star.count"));
     m_galaxy_shapes_list->Select(GetOptionsDB().Get<Shape>("setup.galaxy.shape"));
     ShapeChanged(m_galaxy_shapes_list->CurrentItem());
@@ -779,11 +782,15 @@ const std::string& GalaxySetupPanel::GetSeed() const
 { return m_seed; }
 
 void GalaxySetupPanel::SetSeed(const std::string& seed, bool inhibit_signal) {
-    m_seed = seed;
-    if (m_seed == "RANDOM" || m_seed.empty())
+    if (seed == "RANDOM" || seed.empty()) {
+        m_seed = "RANDOM";
         m_seed_edit->SetText(UserString("GSETUP_RANDOM"));
-    else
+        m_seed_edit->Disable();
+    } else {
+        m_seed = seed;
         m_seed_edit->SetText(m_seed);
+        m_seed_edit->Disable(false);
+    }
 
     if (!inhibit_signal)
         SettingChanged();

--- a/UI/GalaxySetupWnd.h
+++ b/UI/GalaxySetupWnd.h
@@ -98,6 +98,7 @@ public:
     void Disable(bool b = true) override;
     void SetFromSetupData(const GalaxySetupData& setup_data); ///< sets the controls from a GalaxySetupData
     void GetSetupData(GalaxySetupData& setup_data) const;     ///< fills values in \a setup_data from the panel's current state
+    void SetSeed(const std::string& seed, bool inhibit_single = false);
     //!@}
 
 private:
@@ -108,6 +109,7 @@ private:
 
     std::shared_ptr<GG::Label>          m_seed_label;
     std::shared_ptr<GG::Edit>           m_seed_edit;            //!< The seed used in the generation of the galaxy;
+    std::string                         m_seed;
     std::shared_ptr<GG::Button>         m_random;               //!< Random seed button;
     std::shared_ptr<GG::Label>          m_stars_label;
     std::shared_ptr<GG::Spin<int>>      m_stars_spin;           //!< The number of stars to include in the galaxy;

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -539,7 +539,7 @@ void HumanClientApp::NewSinglePlayerGame(bool quickstart) {
         // from just having run GalaxySetupWnd
 
         // GalaxySetupData
-        setup_data.m_seed = GetOptionsDB().Get<std::string>("setup.seed");
+        setup_data.SetSeed(GetOptionsDB().Get<std::string>("setup.seed"));
         setup_data.m_size = GetOptionsDB().Get<int>("setup.star.count");
         setup_data.m_shape = GetOptionsDB().Get<Shape>("setup.galaxy.shape");
         setup_data.m_age = GetOptionsDB().Get<GalaxySetupOption>("setup.galaxy.age");

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -2187,7 +2187,7 @@ GSETUP_SEED
 Seed
 
 GSETUP_RANDOM_SEED
-Generate a random seed
+Toggle generation of a random seed
 
 GSETUP_STARS
 Systems

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1380,7 +1380,7 @@ void ServerApp::GenerateUniverse(std::map<int, PlayerSetupData>& player_setup_da
             seed = static_cast<unsigned int>(h);
         } catch (...) {}
     }
-    if (GetGalaxySetupData().m_seed.empty()) {
+    if (GetGalaxySetupData().GetSeed().empty() || GetGalaxySetupData().GetSeed() == "RANDOM") {
         //ClockSeed();
         // replicate ClockSeed code here so can log the seed used
         boost::posix_time::ptime ltime = boost::posix_time::microsec_clock::local_time();
@@ -1390,7 +1390,7 @@ void ServerApp::GenerateUniverse(std::map<int, PlayerSetupData>& player_setup_da
         DebugLogger() << "GenerateUniverse using clock for seed:" << new_seed;
         seed = static_cast<unsigned int>(h);
         // store seed in galaxy setup data
-        ServerApp::GetApp()->GetGalaxySetupData().m_seed = std::to_string(seed);
+        ServerApp::GetApp()->GetGalaxySetupData().SetSeed(std::to_string(seed));
     }
     Seed(seed);
     DebugLogger() << "GenerateUniverse with seed: " << seed;

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -997,7 +997,7 @@ sc::result MPLobby::react(const LobbyUpdate& msg) {
             }
 
             // GalaxySetupData
-            m_lobby_data->m_seed           = incoming_lobby_data.m_seed;
+            m_lobby_data->SetSeed(incoming_lobby_data.m_seed);
             m_lobby_data->m_size           = incoming_lobby_data.m_size;
             m_lobby_data->m_shape          = incoming_lobby_data.m_shape;
             m_lobby_data->m_age            = incoming_lobby_data.m_age;

--- a/util/MultiplayerCommon.cpp
+++ b/util/MultiplayerCommon.cpp
@@ -253,6 +253,8 @@ namespace {
                       << " from 0 to " << static_cast<int>(enum_vals_count) - 1;
         return hash_value % static_cast<int>(enum_vals_count);
     }
+
+    static char alphanum[] = "123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz";
 }
 
 GalaxySetupData::GalaxySetupData() :
@@ -280,7 +282,7 @@ GalaxySetupData::GalaxySetupData(GalaxySetupData&& base) :
     m_native_freq(base.m_native_freq),
     m_ai_aggr(base.m_ai_aggr),
     m_game_rules(std::move(base.m_game_rules))
-{}
+{ SetSeed(m_seed); }
 
 const std::string& GalaxySetupData::GetSeed() const
 { return m_seed; }
@@ -336,6 +338,18 @@ Aggression GalaxySetupData::GetAggression() const
 
 const std::vector<std::pair<std::string, std::string>>& GalaxySetupData::GetGameRules() const
 { return m_game_rules; }
+
+void GalaxySetupData::SetSeed(const std::string& seed) {
+    std::string new_seed = seed;
+    if (new_seed.empty() || new_seed == "RANDOM") {
+        ClockSeed();
+        new_seed.clear();
+        for (int i = 0; i < 8; ++i)
+            new_seed += alphanum[RandSmallInt(0, (sizeof(alphanum) - 2))];
+        DebugLogger() << "Set empty or requested random seed to " << new_seed;
+    }
+    m_seed = new_seed;
+}
 
 /////////////////////////////////////////////////////
 // PlayerSetupData

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -185,6 +185,10 @@ struct FO_COMMON_API GalaxySetupData {
                         GetGameRules() const;
     //@}
 
+    /** \name Mutators */ //@{
+    void                SetSeed(const std::string& seed);
+    //@}
+
     GalaxySetupData& operator=(const GalaxySetupData&) = default;
 
     std::string         m_seed;


### PR DESCRIPTION
Supports setting setup.seed config option to RANDOM, to generate different seeds on new game.