### PR TITLE
Fix fleet movement bug when fleet is temporarily blockaded.

### DIFF
--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -992,7 +992,7 @@ void Fleet::MovementPhase() {
                 }
 
                 // Add current system to the start of any existing route for next turn
-                if (!m_travel_route.empty())
+                if (!m_travel_route.empty() && m_travel_route.front() != SystemID())
                     m_travel_route.push_front(SystemID());
 
                 break;

--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -990,6 +990,11 @@ void Fleet::MovementPhase() {
                 if (supply_unobstructed_systems.find(SystemID()) != supply_unobstructed_systems.end()) {
                     m_arrival_starlane = SystemID();//allows departure via any starlane
                 }
+
+                // Add current system to the start of any existing route for next turn
+                if (!m_travel_route.empty())
+                    m_travel_route.push_front(SystemID());
+
                 break;
 
             } else {


### PR DESCRIPTION
When a fleet is blockaded by another fleet that immediately moves to
another system and the original fleet continues to its destination the
system at which the blockade occurs is removed from m_travel_route.
This causes an error message on the subsequent turn, because
MovementPhase() expects m_travel_route to contain the starting system.

This commit adds the expected starting system to m_travel_route when
such a blockade happens.