### PR TITLE
Improve UpdateMeterEstimates() invalid id error message.

### DIFF
--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -694,14 +694,16 @@ void Universe::UpdateMeterEstimates(int object_id, bool is_update_contained_obje
     // ids of the object and all valid contained objects
     std::unordered_set<int> all_ids;
 
-    // collect objects to update meter for.  this may be a single object, a group of related objects, or all objects
-    // in the (known) universe.  also clear effect accounting for meters that are to be updated.
-    std::function<void (int, std::unordered_set<int>&, int)> update_obj_and_contained_objs =
+    // Collect objects to update meter for.  this may be a single object, a group of related
+    // objects, or all objects in the (known) universe.  also clear effect accounting for meters
+    // that are to be updated. Return true on success (all_ids is valid).
+    std::function<bool (int, int)> update_obj_and_contained_objs =
         [this, &all_ids, is_update_contained_objects, &update_obj_and_contained_objs]
-        (int cur_id, std::unordered_set<int>& all_ids_, int container_id)
+        (int cur_id, int container_id)
     {
-        if (all_ids_.count(cur_id))
-            return;
+        // Ignore if already in the set
+        if (all_ids.count(cur_id))
+            return true;
 
         auto cur_object = m_objects.Object(cur_id);
         if (!cur_object) {
@@ -709,27 +711,32 @@ void Universe::UpdateMeterEstimates(int object_id, bool is_update_contained_obje
                           << " in container " << container_id
                           << ". All meter estimates will be updated.";
             UpdateMeterEstimates();
-            return;
+            return false;
         }
 
         // add object and clear effect accounting for all its meters
-        all_ids_.insert(cur_id);
+        all_ids.insert(cur_id);
         m_effect_accounting_map[cur_id].clear();
 
         // add contained objects to list of objects to process, if requested.
         if (is_update_contained_objects)
             for (const auto& contained_id : cur_object->ContainedObjectIDs())
-                update_obj_and_contained_objs(contained_id, all_ids_, cur_id);
+                if (!update_obj_and_contained_objs(contained_id, cur_id))
+                    return false;
+        return true;
     };
 
-    update_obj_and_contained_objs(object_id, all_ids, INVALID_OBJECT_ID);
+    if (!update_obj_and_contained_objs(object_id, INVALID_OBJECT_ID))
+        return;
+
+    if (all_ids.empty())
+        return;
 
     // Convert to a vector
     std::vector<int> objects_vec;
     objects_vec.reserve(all_ids.size());
     std::copy(all_ids.begin(), all_ids.end(), std::back_inserter(objects_vec));
-    if (!objects_vec.empty())
-        UpdateMeterEstimatesImpl(objects_vec);
+    UpdateMeterEstimatesImpl(objects_vec);
 }
 
 void Universe::UpdateMeterEstimates(const std::vector<int>& objects_vec) {


### PR DESCRIPTION
Refactor `UpdateMeterEstimates()` so that ~~large numbers of contained object
ids can't resize `objects_list` vector while being iterated and cause a
crash.~~ the error message includes the invalid id and its valid container, rather than the less helpful "Universe::UpdateMeterEstimates tried to get an invalid object..."