### PR TITLE
Adjustments to early ai shipbuilding

### DIFF
--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -229,11 +229,14 @@ def generate_production_orders():
             claimed_stars.setdefault(t_sys.starType, []).append(sys_id)
 
     if current_turn == 1 and len(AIstate.opponentPlanetIDs) == 0 and len(production_queue) == 0:
-        best_design_id, _, build_choices = get_best_ship_info(PriorityType.PRODUCTION_EXPLORATION)
-        if best_design_id is not None:
-            for _ in range(3):
-                fo.issueEnqueueShipProductionOrder(best_design_id, build_choices[0])
-            fo.updateProductionQueue()
+        init_build_nums = [(PriorityType.PRODUCTION_EXPLORATION, 3),
+                           ]
+        for ship_type, num_ships in init_build_nums:
+            best_design_id, _, build_choices = get_best_ship_info(ship_type)
+            if best_design_id is not None:
+                for _ in range(num_ships):
+                    fo.issueEnqueueShipProductionOrder(best_design_id, build_choices[0])
+                fo.updateProductionQueue()
 
     building_expense = 0.0
     building_ratio = foAI.foAIstate.character.preferred_building_ratio([0.4, 0.35, 0.30])

--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -229,7 +229,7 @@ def generate_production_orders():
             claimed_stars.setdefault(t_sys.starType, []).append(sys_id)
 
     if current_turn == 1 and len(AIstate.opponentPlanetIDs) == 0 and len(production_queue) == 0:
-        init_build_nums = [(PriorityType.PRODUCTION_EXPLORATION, 3),
+        init_build_nums = [(PriorityType.PRODUCTION_EXPLORATION, 2),
                            ]
         for ship_type, num_ships in init_build_nums:
             best_design_id, _, build_choices = get_best_ship_info(ship_type)

--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -230,6 +230,7 @@ def generate_production_orders():
 
     if current_turn == 1 and len(AIstate.opponentPlanetIDs) == 0 and len(production_queue) == 0:
         init_build_nums = [(PriorityType.PRODUCTION_EXPLORATION, 2),
+                           (PriorityType.PRODUCTION_OUTPOST, 1),
                            ]
         for ship_type, num_ships in init_build_nums:
             best_design_id, _, build_choices = get_best_ship_info(ship_type)


### PR DESCRIPTION
Generalizes the code for the AI's initial automatic ship builds, reduces number of initial scouts from 3 to 2, adds an outpost ship.

I think that most often simply 2 additional scouts are sufficient, and any more the AI can use its regular code to decide on later on.  The outpost ship is handy enough I want to make sure it gets onto the initial queue (even though it's likely to be delayed by other things such as the history analyzer). 