### PR TITLE
Have ai not honor bad colony buildings

### DIFF
--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -1085,8 +1085,11 @@ def generate_production_orders():
     queued_clny_bld_locs = [element.locationID for element in production_queue
                             if (element.name.startswith('BLD_COL_') and
                                 empire_has_colony_bld_species(element.name))]
-    colony_bldg_entries = ([entry for entry in foAI.foAIstate.colonisablePlanetIDs.items() if entry[1][0] > 60 and
-                           entry[0] not in queued_clny_bld_locs and entry[0] in state.get_empire_outposts()]
+    colony_bldg_entries = ([entry for entry in foAI.foAIstate.colonisablePlanetIDs.items() if
+                                entry[1][0] > 60 and
+                                entry[0] not in queued_clny_bld_locs and
+                                entry[0] in state.get_empire_outposts() and
+                                not already_has_completed_colony_building(entry[0])]
                            [:PriorityAI.allottedColonyTargets+2])
     for entry in colony_bldg_entries:
         pid = entry[0]
@@ -1438,11 +1441,20 @@ def update_stockpile_use():
         if fo.issueAllowStockpileProductionOrder(queue_index, True):
             planets_in_stockpile_enabled_group.update(group)
 
+
 def empire_has_colony_bld_species(building_name):
     if not building_name.startswith('BLD_COL_'):
         return False
     species_name = 'SP' + building_name.split('BLD_COL_')[1]
     return species_name in ColonisationAI.empire_colonizers
+
+
+def already_has_completed_colony_building(planet_id):
+    universe = fo.getUniverse()
+    planet = universe.getPlanet(planet_id)
+    return any([building_name.startswith('BLD_COL_') for building_name in
+               [universe.getBuilding(bldg).name for bldg in planet.buildingIDs]])
+
 
 def build_ship_facilities(bld_name, best_pilot_facilities, top_locs=None):
     if top_locs is None:

--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -1445,7 +1445,7 @@ def update_stockpile_use():
 def empire_has_colony_bld_species(building_name):
     if not building_name.startswith('BLD_COL_'):
         return False
-    species_name = 'SP' + building_name.split('BLD_COL_')[1]
+    species_name = 'SP_' + building_name.split('BLD_COL_')[1]
     return species_name in ColonisationAI.empire_colonizers
 
 

--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -1443,6 +1443,9 @@ def update_stockpile_use():
 
 
 def empire_has_colony_bld_species(building_name):
+    """Checks if this building is a colony building for which this empire has the required source species available.
+    :rtype: bool
+    """
     if not building_name.startswith('BLD_COL_'):
         return False
     species_name = 'SP_' + building_name.split('BLD_COL_')[1]
@@ -1450,10 +1453,12 @@ def empire_has_colony_bld_species(building_name):
 
 
 def already_has_completed_colony_building(planet_id):
+    """Checks if a planet has an already-completed (but not yet 'hatched') colony building.
+    :rtype: bool
+    """
     universe = fo.getUniverse()
     planet = universe.getPlanet(planet_id)
-    return any([building_name.startswith('BLD_COL_') for building_name in
-               [universe.getBuilding(bldg).name for bldg in planet.buildingIDs]])
+    return any(universe.getBuilding(bldg).name.startswith('BLD_COL_') for bldg in planet.buildingIDs)
 
 
 def build_ship_facilities(bld_name, best_pilot_facilities, top_locs=None):

--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -1081,7 +1081,10 @@ def generate_production_orders():
         else:
             warn("Failed enqueueing %s at planet %s, got result %d" % (building_name, planet, res))
 
-    queued_clny_bld_locs = [element.locationID for element in production_queue if element.name.startswith('BLD_COL_')]
+    # ignore acquired-under-construction colony buildings for which our empire lacks the species
+    queued_clny_bld_locs = [element.locationID for element in production_queue
+                            if (element.name.startswith('BLD_COL_') and
+                                empire_has_colony_bld_species(element.name))]
     colony_bldg_entries = ([entry for entry in foAI.foAIstate.colonisablePlanetIDs.items() if entry[1][0] > 60 and
                            entry[0] not in queued_clny_bld_locs and entry[0] in state.get_empire_outposts()]
                            [:PriorityAI.allottedColonyTargets+2])
@@ -1435,6 +1438,11 @@ def update_stockpile_use():
         if fo.issueAllowStockpileProductionOrder(queue_index, True):
             planets_in_stockpile_enabled_group.update(group)
 
+def empire_has_colony_bld_species(building_name):
+    if not building_name.startswith('BLD_COL_'):
+        return False
+    species_name = 'SP' + building_name.split('BLD_COL_')[1]
+    return species_name in ColonisationAI.empire_colonizers
 
 def build_ship_facilities(bld_name, best_pilot_facilities, top_locs=None):
     if top_locs is None:


### PR DESCRIPTION
When the AI is considering building colony buildings at outposts, it currently first eliminates from consideration all outposts where one is already under construction.

Sometimes the AI will have invaded & acquired a planet that has a colony building under construction but which the AI does not have the requisite colonizer species, and so currently that leaves the planet tied up as an outpost even if the AI has another good colonizer for it.  And sometimes the AI loses a planet providing a key colonizer while it has colony buildings underway.  

In the future we'll probably want to do a more involved projection (in all cases) about when colonizers might become available, but in the meantime, don't lockdown a planet with an incomplete colony building that the AI can't currently build.

Also, somewhat independent but just related enough that I'm including it here, the second commit prevents the AI from squandering its allotment of colony targets considering places that already have a colony building just-completed.