### PR TITLE
Improve certain ai colony valuations

### DIFF
--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -882,7 +882,7 @@ def evaluate_planet(planet_id, mission_type, spec_name, detail=None):
                             ast_val = 0
                             break
                     elif other_planet.speciesName:
-                        if other_planet.owner==empire.empireID:
+                        if other_planet.owner == empire.empireID:
                             ownership_factor = 1.0
                         elif pid in prospective_invasion_targets:
                             ownership_factor = character.secondary_valuation_factor_for_invasion_targets()
@@ -911,7 +911,7 @@ def evaluate_planet(planet_id, mission_type, spec_name, detail=None):
                     elif other_planet.speciesName:
                         other_species = fo.getSpecies(other_planet.speciesName)
                         if other_species and other_species.canProduceShips:
-                            if other_planet.owner==empire.empireID:
+                            if other_planet.owner == empire.empireID:
                                 ownership_factor = 1.0
                             elif pid in prospective_invasion_targets:
                                 ownership_factor = character.secondary_valuation_factor_for_invasion_targets()
@@ -1007,7 +1007,7 @@ def evaluate_planet(planet_id, mission_type, spec_name, detail=None):
                 p2 = universe.getPlanet(pid)
                 if p2:
                     if p2.size == fo.planetSize.asteroids:
-                        if p2.owner==empire.empireID:
+                        if p2.owner == empire.empireID:
                             asteroid_factor = 1.0
                         elif p2.unowned:
                             asteroid_factor = 0.5
@@ -1017,7 +1017,7 @@ def evaluate_planet(planet_id, mission_type, spec_name, detail=None):
                             asteroid_factor = 0.0
                         ast_shipyard_name = p2.name
                     if p2.size == fo.planetSize.gasGiant:
-                        if p2.owner==empire.empireID:
+                        if p2.owner == empire.empireID:
                             gg_factor = 1.0
                         elif p2.unowned:
                             gg_factor = 0.5

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -8,6 +8,7 @@ import AIstate
 import FleetUtilsAI
 import FreeOrionAI as foAI
 import PlanetUtilsAI
+import PriorityAI
 import ProductionAI
 import MilitaryAI
 from turn_state import state
@@ -624,13 +625,18 @@ def get_defense_value(species_name):
         return get_base_outpost_defense_value()
 
 
+def base_asteroid_mining_val():
+    return 5 if tech_is_complete("PRO_MICROGRAV_MAN") else 3
+
+
 def evaluate_planet(planet_id, mission_type, spec_name, detail=None):
     """returns the colonisation value of a planet"""
     empire = fo.getEmpire()
     if detail is None:
         detail = []
     retval = 0
-    discount_multiplier = foAI.foAIstate.character.preferred_discount_multiplier([30.0, 40.0])
+    character = foAI.foAIstate.character
+    discount_multiplier = character.preferred_discount_multiplier([30.0, 40.0])
     species = fo.getSpecies(spec_name or "")  # in case None is passed as specName
     species_foci = [] and species and list(species.foci)
     tag_list = list(species.tags) if species else []
@@ -654,6 +660,8 @@ def evaluate_planet(planet_id, mission_type, spec_name, detail=None):
     capital_id = PlanetUtilsAI.get_capital()
     homeworld = universe.getPlanet(capital_id)
     planet = universe.getPlanet(planet_id)
+    prospective_invasion_targets = [pid for pid, pscore, trp in
+                                    AIstate.invasionTargets[:PriorityAI.allottedInvasionTargets] if pscore > 20]
 
     if spec_name != planet.speciesName and planet.speciesName and mission_type != MissionType.INVASION:
         return 0
@@ -864,10 +872,6 @@ def evaluate_planet(planet_id, mission_type, spec_name, detail=None):
                 detail.append("%s %.1f" % (special, honey_val))
         if planet.size == fo.planetSize.asteroids:
             ast_val = 0
-            if tech_is_complete("PRO_MICROGRAV_MAN"):
-                per_ast = 5
-            else:
-                per_ast = 3
             if system:
                 for pid in system.planetIDs:
                     other_planet = universe.getPlanet(pid)
@@ -877,8 +881,14 @@ def evaluate_planet(planet_id, mission_type, spec_name, detail=None):
                         elif pid < planet_id and planet.unowned:
                             ast_val = 0
                             break
-                    elif other_planet.speciesName:  # and otherPlanet.owner==empire.empireID
-                        ast_val += per_ast * discount_multiplier
+                    elif other_planet.speciesName:
+                        if other_planet.owner==empire.empireID:
+                            ownership_factor = 1.0
+                        elif pid in prospective_invasion_targets:
+                            ownership_factor = character.secondary_valuation_factor_for_invasion_targets()
+                        else:
+                            ownership_factor = 0.0
+                        ast_val += ownership_factor * base_asteroid_mining_val() * discount_multiplier
                 retval += ast_val
                 if ast_val > 0:
                     detail.append("AsteroidMining %.1f" % ast_val)
@@ -898,10 +908,16 @@ def evaluate_planet(planet_id, mission_type, spec_name, detail=None):
                         elif pid < planet_id and planet.unowned:
                             ast_val = 0
                             break
-                    elif other_planet.speciesName:  # and otherPlanet.owner==empire.empireID
+                    elif other_planet.speciesName:
                         other_species = fo.getSpecies(other_planet.speciesName)
                         if other_species and other_species.canProduceShips:
-                            ast_val += per_ast * discount_multiplier
+                            if other_planet.owner==empire.empireID:
+                                ownership_factor = 1.0
+                            elif pid in prospective_invasion_targets:
+                                ownership_factor = character.secondary_valuation_factor_for_invasion_targets()
+                            else:
+                                ownership_factor = 0.0
+                            ast_val += ownership_factor * per_ast * discount_multiplier
                 retval += ast_val
                 if ast_val > 0:
                     detail.append("AsteroidShipBuilding %.1f" % ast_val)
@@ -983,46 +999,46 @@ def evaluate_planet(planet_id, mission_type, spec_name, detail=None):
         mining_bonus = 0
         per_ggg = 10
 
-        got_asteroids = False
-        got_owned_asteroids = False
-        local_gg = False
-        got_owned_gg = False
+        asteroid_factor = 0.0
+        gg_factor = 0.0
         ast_shipyard_name = ""
         if system and FocusType.FOCUS_INDUSTRY in species.foci:
             for pid in [temp_id for temp_id in system.planetIDs if temp_id != planet_id]:
                 p2 = universe.getPlanet(pid)
                 if p2:
                     if p2.size == fo.planetSize.asteroids:
-                        got_asteroids = True
+                        if p2.owner==empire.empireID:
+                            asteroid_factor = 1.0
+                        elif p2.unowned:
+                            asteroid_factor = 0.5
+                        elif pid in prospective_invasion_targets:
+                            asteroid_factor = character.secondary_valuation_factor_for_invasion_targets()
+                        else:
+                            asteroid_factor = 0.0
                         ast_shipyard_name = p2.name
-                        if p2.owner != -1:
-                            got_owned_asteroids = True
                     if p2.size == fo.planetSize.gasGiant:
-                        local_gg = True
-                        if p2.owner != -1:
-                            got_owned_gg = True
-        if got_asteroids:
+                        if p2.owner==empire.empireID:
+                            gg_factor = 1.0
+                        elif p2.unowned:
+                            gg_factor = 0.5
+                        elif pid in prospective_invasion_targets:
+                            gg_factor = character.secondary_valuation_factor_for_invasion_targets()
+                        else:
+                            gg_factor = 0.0
+        if asteroid_factor > 0.0:
             if tech_is_complete("PRO_MICROGRAV_MAN") or "PRO_MICROGRAV_MAN" in empire_research_list[:10]:
-                if got_owned_asteroids:  # can be quickly captured
-                    flat_industry += 5  # will go into detailed industry projection
-                    detail.append("Asteroid mining ~ %.1f" % (5 * discount_multiplier))
-                else:  # uncertain when can be outposted
-                    asteroid_bonus = 2.5 * discount_multiplier  # give partial value
-                    detail.append("Asteroid mining %.1f" % (5 * discount_multiplier))
+                flat_industry += 5 * asteroid_factor  # will go into detailed industry projection
+                detail.append("Asteroid mining ~ %.1f" % (5 * asteroid_factor * discount_multiplier))
             if tech_is_complete("SHP_ASTEROID_HULLS") or "SHP_ASTEROID_HULLS" in empire_research_list[:11]:
                 if species and species.canProduceShips:
-                    asteroid_bonus += 30 * discount_multiplier * pilot_val
+                    asteroid_bonus = 30 * discount_multiplier * pilot_val
                     detail.append(
                         "Asteroid ShipBuilding from %s %.1f" % (
-                            ast_shipyard_name, discount_multiplier * 20 * pilot_val))
-        if local_gg:
+                            ast_shipyard_name, discount_multiplier * 30 * pilot_val))
+        if gg_factor > 0.0:
             if tech_is_complete("PRO_ORBITAL_GEN") or "PRO_ORBITAL_GEN" in empire_research_list[:5]:
-                if got_owned_gg:
-                    flat_industry += per_ggg  # will go into detailed industry projection
-                    detail.append("GGG ~ %.1f" % (per_ggg * discount_multiplier))
-                else:
-                    gas_giant_bonus = 0.5 * per_ggg * discount_multiplier
-                    detail.append("GGG %.1f" % (0.5 * per_ggg * discount_multiplier))
+                flat_industry += per_ggg * gg_factor  # will go into detailed industry projection
+                detail.append("GGG ~ %.1f" % (per_ggg * gg_factor * discount_multiplier))
 
         # calculate the maximum population of the species on that planet.
         if planet.speciesName not in AIDependencies.SPECIES_FIXED_POPULATION:

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -661,7 +661,7 @@ def evaluate_planet(planet_id, mission_type, spec_name, detail=None):
     homeworld = universe.getPlanet(capital_id)
     planet = universe.getPlanet(planet_id)
     prospective_invasion_targets = [pid for pid, pscore, trp in
-                                    AIstate.invasionTargets[:PriorityAI.allottedInvasionTargets] if pscore > 20]
+                                    AIstate.invasionTargets[:PriorityAI.allotted_invasion_targets()] if pscore > 20]
 
     if spec_name != planet.speciesName and planet.speciesName and mission_type != MissionType.INVASION:
         return 0

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -1007,24 +1007,23 @@ def evaluate_planet(planet_id, mission_type, spec_name, detail=None):
                 p2 = universe.getPlanet(pid)
                 if p2:
                     if p2.size == fo.planetSize.asteroids:
+                        this_factor = 0.0
                         if p2.owner == empire.empireID:
-                            asteroid_factor = 1.0
+                            this_factor = 1.0
                         elif p2.unowned:
-                            asteroid_factor = 0.5
+                            this_factor = 0.5
                         elif pid in prospective_invasion_targets:
-                            asteroid_factor = character.secondary_valuation_factor_for_invasion_targets()
-                        else:
-                            asteroid_factor = 0.0
-                        ast_shipyard_name = p2.name
+                            this_factor = character.secondary_valuation_factor_for_invasion_targets()
+                        if this_factor > asteroid_factor:
+                            asteroid_factor = this_factor
+                            ast_shipyard_name = p2.name
                     if p2.size == fo.planetSize.gasGiant:
                         if p2.owner == empire.empireID:
-                            gg_factor = 1.0
+                            gg_factor = max(gg_factor, 1.0)
                         elif p2.unowned:
-                            gg_factor = 0.5
+                            gg_factor = max(gg_factor, 0.5)
                         elif pid in prospective_invasion_targets:
-                            gg_factor = character.secondary_valuation_factor_for_invasion_targets()
-                        else:
-                            gg_factor = 0.0
+                            gg_factor = max(gg_factor, character.secondary_valuation_factor_for_invasion_targets())
         if asteroid_factor > 0.0:
             if tech_is_complete("PRO_MICROGRAV_MAN") or "PRO_MICROGRAV_MAN" in empire_research_list[:10]:
                 flat_industry += 5 * asteroid_factor  # will go into detailed industry projection

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -625,7 +625,7 @@ def get_defense_value(species_name):
         return get_base_outpost_defense_value()
 
 
-def base_asteroid_mining_val():
+def _base_asteroid_mining_val():
     return 5 if tech_is_complete("PRO_MICROGRAV_MAN") else 3
 
 
@@ -888,7 +888,7 @@ def evaluate_planet(planet_id, mission_type, spec_name, detail=None):
                             ownership_factor = character.secondary_valuation_factor_for_invasion_targets()
                         else:
                             ownership_factor = 0.0
-                        ast_val += ownership_factor * base_asteroid_mining_val() * discount_multiplier
+                        ast_val += ownership_factor * _base_asteroid_mining_val() * discount_multiplier
                 retval += ast_val
                 if ast_val > 0:
                     detail.append("AsteroidMining %.1f" % ast_val)

--- a/default/python/AI/MilitaryAI.py
+++ b/default/python/AI/MilitaryAI.py
@@ -639,7 +639,7 @@ def get_military_fleets(mil_fleets_ids=None, try_reset=True, thisround="Main"):
                 pass
 
     num_targets = max(10, PriorityAI.allotted_outpost_targets)
-    top_target_planets = ([pid for pid, pscore, trp in AIstate.invasionTargets[:PriorityAI.allottedInvasionTargets] if pscore > 20] +
+    top_target_planets = ([pid for pid, pscore, trp in AIstate.invasionTargets[:PriorityAI.allotted_invasion_targets()] if pscore > 20] +
                           [pid for pid, (pscore, spec) in foAI.foAIstate.colonisableOutpostIDs.items()[:num_targets] if pscore > 20] +
                           [pid for pid, (pscore, spec) in foAI.foAIstate.colonisablePlanetIDs.items()[:num_targets] if pscore > 20])
     top_target_planets.extend(foAI.foAIstate.qualifyingTroopBaseTargets.keys())

--- a/default/python/AI/PriorityAI.py
+++ b/default/python/AI/PriorityAI.py
@@ -21,7 +21,6 @@ from common.configure_logging import convenience_function_references_for_logger
 
 prioritiees_timer = AITimer('calculate_priorities()')
 
-allottedInvasionTargets = 0
 allottedColonyTargets = 0
 allotted_outpost_targets = 0
 unmetThreat = 0
@@ -315,7 +314,6 @@ def _calculate_outpost_priority():
 def _calculate_invasion_priority():
     """Calculates the demand for troop ships by opponent planets."""
 
-    global allottedInvasionTargets
     if not foAI.foAIstate.character.may_invade():
         return 0
 
@@ -331,10 +329,9 @@ def _calculate_invasion_priority():
     else:
         best_colony_score = 2
 
-    allottedInvasionTargets = 1 + int(fo.currentTurn() / 25)
     total_val = 0
     troops_needed = 0
-    for pid, pscore, trp in AIstate.invasionTargets[:allottedInvasionTargets]:
+    for pid, pscore, trp in AIstate.invasionTargets[:allotted_invasion_targets()]:
         if pscore > best_colony_score:
             multiplier += 1
             total_val += 2 * pscore
@@ -382,6 +379,10 @@ def _calculate_invasion_priority():
         return 0
 
     return invasion_priority * foAI.foAIstate.character.invasion_priority_scaling()
+
+
+def allotted_invasion_targets():
+    return 1 + int(fo.currentTurn() / 25)
 
 
 def _calculate_military_priority():

--- a/default/python/AI/character/character_module.py
+++ b/default/python/AI/character/character_module.py
@@ -282,6 +282,12 @@ class Trait(object):
         """Return an exponent to scale the production cost of a warship in ShipDesignAI."""
         return None
 
+    def secondary_valuation_factor_for_invasion_targets(self):  # pylint: disable=no-self-use,unused-argument
+        """Return a value in range [0.0 : 1.0], used in colonization scoring calculations where subscores for a primary
+        planet depend on traits of secondary planets, for what portion of the subscore should be assigned if the secondary
+        planet would need to be acquired via invasion"""
+        return None
+
 
 class Aggression(Trait):
     """A trait that models level of difficulty and aggression."""
@@ -454,6 +460,20 @@ class Aggression(Trait):
             exponent = 1.0
         return exponent
 
+    def secondary_valuation_factor_for_invasion_targets(self):  # pylint: disable=no-self-use,unused-argument
+        """Return a value in range [0.0 : 1.0], used in colonization scoring calculations where subscores for a primary
+        planet depend on traits of secondary planets, for what portion of the subscore should be assigned if the secondary
+        planet would need to be acquired via invasion"""
+        if self.aggression == fo.aggression.maniacal:
+            factor = 0.8
+        elif self.aggression == fo.aggression.aggressive:
+            factor = 0.4
+        elif self.aggression == fo.aggression.typical:
+            factor = 0.2
+        else:
+            factor = 0.0
+        return factor
+
 
 class EmpireIDTrait(Trait):
     """A trait that models empire id influence.
@@ -585,7 +605,7 @@ def average_not_none(llin):
     return sum(ll) / float(len(ll))
 
 
-for funcname in ["attitude_to_empire"]:
+for funcname in ["attitude_to_empire", "secondary_valuation_factor_for_invasion_targets"]:
     setattr(Character, funcname, _make_single_function_combiner(funcname, average_not_none))
 
 


### PR DESCRIPTION
When valuing a primary planet, the AI takes into account whether or not some other planet can add value, like in systems with asteroids or gas giants, and whether or not it already owns that other planet.  

This PR adds an aggression based character trait for what portion of that potential added value the AI will use if it would have to invade that planet, and makes some other slight adjustments to the calculations.