### PR TITLE
Combine overlapping moving fleet buttons into a single FleetWnd

### DIFF
--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -3094,27 +3094,26 @@ void FleetWnd::Refresh() {
 
     // Determine FleetWnd location.
 
-    // Are all fleets in one location?  Use that location.
-    // Otherwise, are all selected fleets in one location?  Use that location.
-    // Otherwise, is the current location a system?  Use that location.
+    // Are all fleets in one system?  Use that location.
+    // Otherwise, are all selected fleets in one system?  Use that location.
     // Otherwise, are all the moving fleets clustered within m_bounding_box of each other?
     // Otherwise, are all the selected fleets clustered within m_bounding_box of each other?
+    // Otherwise, is the current location a system?  Use that location.
     // Otherwise remove all fleets as all fleets have gone in separate directions.
 
     std::pair<int, GG::Pt> location{INVALID_OBJECT_ID, GG::Pt(GG::X0, GG::Y0)};
     if (!fleet_locations_ids.empty()
+        && fleet_locations_ids.begin()->first.first != INVALID_OBJECT_ID
         && (fleet_locations_ids.count(fleet_locations_ids.begin()->first) == fleet_locations_ids.size()))
     {
         location = fleet_locations_ids.begin()->first;
 
     } else if (!selected_fleet_locations_ids.empty()
+               && selected_fleet_locations_ids.begin()->first.first != INVALID_OBJECT_ID
                && (selected_fleet_locations_ids.count(selected_fleet_locations_ids.begin()->first)
                    == selected_fleet_locations_ids.size()))
     {
         location = selected_fleet_locations_ids.begin()->first;
-
-    } else if (auto system = GetSystem(m_system_id)) {
-        location = {m_system_id, GG::Pt(GG::X(system->X()), GG::Y(system->Y()))};
 
     } else if (!fleet_locations_ids.empty()
                && SmallerOrEqual(fleets_bounding_box, m_bounding_box))
@@ -3140,6 +3139,9 @@ void FleetWnd::Refresh() {
                 fleets_near_enough.insert({location, loc_and_id.second});
         }
         fleet_locations_ids.swap(fleets_near_enough);
+    } else if (auto system = GetSystem(m_system_id)) {
+        location = {m_system_id, GG::Pt(GG::X(system->X()), GG::Y(system->Y()))};
+
     } else {
         fleet_locations_ids.clear();
         selected_fleet_locations_ids.clear();

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -3824,10 +3824,11 @@ void FleetWnd::ShipSelectionChanged(const GG::ListBox::SelectionSet& rows)
 { SelectedShipsChangedSignal(); }
 
 void FleetWnd::UniverseObjectDeleted(std::shared_ptr<const UniverseObject> obj) {
-    // check if deleted object was a fleet.  if not, abort.
+    // check if deleted object was a fleet.  The universe signals for all
+    // object types, not just fleets.
     std::shared_ptr<const Fleet> deleted_fleet = std::dynamic_pointer_cast<const Fleet>(obj);
     if (!deleted_fleet)
-        return; // TODO: Why exactly does this function not just take a Fleet instead of a UniverseObject?  Maybe rename to FleetDeleted?
+        return;
 
     // if detail panel is showing the deleted fleet, reset to show nothing
     if (GetFleet(m_fleet_detail_panel->FleetID()) == deleted_fleet)

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -2784,9 +2784,9 @@ namespace {
                 std::max(box.Bottom(),  pt.y));
     }
 
-    /** Is \p rr larger or equal to the size of \p ll? */
-    bool LessThanOrEqual(GG::Rect ll, GG::Rect rr) {
-        return (rr.Width() >= ll.Width() && rr.Height() >= ll.Height());
+    /** Is \p ll smaller or equal to the size of \p rr? */
+    bool SmallerOrEqual(GG::Rect ll, GG::Rect rr) {
+        return (ll.Width() <= rr.Width() && ll.Height() <= rr.Height());
     }
 }
 
@@ -3100,7 +3100,7 @@ void FleetWnd::Refresh() {
         location = {m_system_id, GG::Pt(GG::X(system->X()), GG::Y(system->Y()))};
 
     } else if (!fleet_locations_ids.empty()
-               && LessThanOrEqual(fleets_bounding_box, m_bounding_box))
+               && SmallerOrEqual(fleets_bounding_box, m_bounding_box))
     {
         location = {INVALID_OBJECT_ID, bounding_box_center};
         boost::unordered_multimap<std::pair<int, GG::Pt>, int> fleets_near_enough;
@@ -3109,7 +3109,7 @@ void FleetWnd::Refresh() {
         fleet_locations_ids.swap(fleets_near_enough);
 
     } else if (!selected_fleet_locations_ids.empty()
-               && LessThanOrEqual(selected_fleets_bounding_box, m_bounding_box))
+               && SmallerOrEqual(selected_fleets_bounding_box, m_bounding_box))
     {
         location = {INVALID_OBJECT_ID, selected_bounding_box_center};
         boost::unordered_multimap<std::pair<int, GG::Pt>, int> fleets_near_enough;

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -3054,7 +3054,7 @@ void FleetWnd::Refresh() {
         fleet_locations_ids.insert({{fleet->SystemID(), fleet_loc}, fleet_id});
 
     }
-    GG::Pt bounding_box_center{fleets_bounding_box.MidX(), fleets_bounding_box.MidY()};
+    auto bounding_box_center = GG::Pt(fleets_bounding_box.MidX(), fleets_bounding_box.MidY());
 
     // Filter initially selected fleets according to existing fleets
     GG::Rect selected_fleets_bounding_box;
@@ -3073,8 +3073,7 @@ void FleetWnd::Refresh() {
             selected_fleet_locations_ids.empty(), selected_fleets_bounding_box, fleet_loc);
         selected_fleet_locations_ids.insert({{fleet->SystemID(), fleet_loc}, fleet_id});
     }
-
-    GG::Pt selected_bounding_box_center{selected_fleets_bounding_box.MidX(), selected_fleets_bounding_box.MidY()};
+    auto selected_bounding_box_center = GG::Pt(selected_fleets_bounding_box.MidX(), selected_fleets_bounding_box.MidY());
 
     // Determine FleetWnd location.
 

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -3287,10 +3287,15 @@ void FleetWnd::AddFleet(int fleet_id) {
     row->Resize(row_size);
 }
 
+void FleetWnd::DeselectAllFleets() {
+    m_fleets_lb->DeselectAll();
+    FleetSelectionChanged(m_fleets_lb->Selections());
+}
+
 void FleetWnd::SelectFleet(int fleet_id) {
     if (fleet_id == INVALID_OBJECT_ID || !(GetFleet(fleet_id))) {
-        m_fleets_lb->DeselectAll();
-        FleetSelectionChanged(m_fleets_lb->Selections());
+        ErrorLogger() << "FleetWnd::SelectFleet invalid id " << fleet_id;
+        DeselectAllFleets();
         return;
     }
 

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -2436,7 +2436,7 @@ public:
     std::set<int>   SelectedShipIDs() const;    ///< returns ids of ships selected in the detail panel's ShipsListBox
 
     void            SetFleet(int fleet_id);                         ///< sets the currently-displayed Fleet.  setting to INVALID_OBJECT_ID shows no fleet
-    void            SetSelectedShips(const std::set<int>& ship_ids);///< sets the currently-selected ships in the ships list
+    void            SelectShips(const std::set<int>& ship_ids);///< sets the currently-selected ships in the ships list
 
     void            Refresh();
 
@@ -2528,7 +2528,7 @@ void FleetDetailPanel::SetFleet(int fleet_id) {
     }
 }
 
-void FleetDetailPanel::SetSelectedShips(const std::set<int>& ship_ids) {
+void FleetDetailPanel::SelectShips(const std::set<int>& ship_ids) {
     const GG::ListBox::SelectionSet initial_selections = m_ships_lb->Selections();
 
     m_ships_lb->DeselectAll();
@@ -2537,7 +2537,7 @@ void FleetDetailPanel::SetSelectedShips(const std::set<int>& ship_ids) {
     for (auto it = m_ships_lb->begin(); it != m_ships_lb->end(); ++it) {
         ShipRow* row = dynamic_cast<ShipRow*>(it->get());
         if (!row) {
-            ErrorLogger() << "FleetDetailPanel::SetSelectedShips couldn't cast a listbow row to ShipRow?";
+            ErrorLogger() << "FleetDetailPanel::SelectShips couldn't cast a list row to ShipRow?";
             continue;
         }
 
@@ -3169,16 +3169,16 @@ void FleetWnd::Refresh() {
 
     if (!still_present_initially_selected_fleets.empty()) {
         // reselect any previously-selected fleets
-        this->SetSelectedFleets(still_present_initially_selected_fleets);
+        SelectFleets(still_present_initially_selected_fleets);
         // reselect any previously-selected ships
-        this->SetSelectedShips(initially_selected_ships);
+        SelectShips(initially_selected_ships);
     } else if (!m_fleets_lb->Empty()) {
         // default select first fleet
         int first_fleet_id = FleetInRow(m_fleets_lb->begin());
         if (first_fleet_id != INVALID_OBJECT_ID) {
             std::set<int> fleet_id_set;
             fleet_id_set.insert(first_fleet_id);
-            this->SetSelectedFleets(fleet_id_set);
+            SelectFleets(fleet_id_set);
         }
     }
 
@@ -3308,7 +3308,7 @@ void FleetWnd::SelectFleet(int fleet_id) {
     }
 }
 
-void FleetWnd::SetSelectedFleets(const std::set<int>& fleet_ids) {
+void FleetWnd::SelectFleets(const std::set<int>& fleet_ids) {
     const GG::ListBox::SelectionSet initial_selections = m_fleets_lb->Selections();
     m_fleets_lb->DeselectAll();
 
@@ -3316,7 +3316,7 @@ void FleetWnd::SetSelectedFleets(const std::set<int>& fleet_ids) {
     for (auto it = m_fleets_lb->begin(); it != m_fleets_lb->end(); ++it) {
         FleetRow* row = dynamic_cast<FleetRow*>(it->get());
         if (!row) {
-            ErrorLogger() << "FleetWnd::SetSelectedFleets couldn't cast a listbow row to FleetRow?";
+            ErrorLogger() << "FleetWnd::SelectFleets couldn't cast a list row to FleetRow?";
             continue;
         }
 
@@ -3333,8 +3333,8 @@ void FleetWnd::SetSelectedFleets(const std::set<int>& fleet_ids) {
         FleetSelectionChanged(sels);
 }
 
-void FleetWnd::SetSelectedShips(const std::set<int>& ship_ids)
-{ m_fleet_detail_panel->SetSelectedShips(ship_ids); }
+void FleetWnd::SelectShips(const std::set<int>& ship_ids)
+{ m_fleet_detail_panel->SelectShips(ship_ids); }
 
 void FleetWnd::SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
     GG::Pt old_size = Size();
@@ -3810,7 +3810,7 @@ void FleetWnd::CreateNewFleetFromDrops(const std::vector<int>& ship_ids) {
 
     // deselect all ships so that response to fleet rearrangement doesn't attempt
     // to get the selected ships that are no longer in their old fleet.
-    m_fleet_detail_panel->SetSelectedShips(std::set<int>());
+    m_fleet_detail_panel->SelectShips(std::set<int>());
 
     CreateNewFleetFromShips(ship_ids, aggression);
 }

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -2784,10 +2784,9 @@ namespace {
                 std::max(box.Bottom(),  pt.y));
     }
 
-    /** Can \p bounds encompass \p candidate? */
-    bool CouldContain(GG::Rect bounds, GG::Rect candidate) {
-        return (bounds.Width() >= candidate.Width()
-                && bounds.Height() >= candidate.Height());
+    /** Is \p rr larger or equal to the size of \p ll? */
+    bool LessThanOrEqual(GG::Rect ll, GG::Rect rr) {
+        return (rr.Width() >= ll.Width() && rr.Height() >= ll.Height());
     }
 }
 
@@ -3102,7 +3101,7 @@ void FleetWnd::Refresh() {
         location = {m_system_id, GG::Pt(GG::X(system->X()), GG::Y(system->Y()))};
 
     } else if (!fleet_locations_ids.empty()
-             && CouldContain(m_bounding_box, fleets_bounding_box))
+               && LessThanOrEqual(fleets_bounding_box, m_bounding_box))
     {
         location = {INVALID_OBJECT_ID, bounding_box_center};
         boost::unordered_multimap<std::pair<int, GG::Pt>, int> fleets_near_enough;
@@ -3111,7 +3110,7 @@ void FleetWnd::Refresh() {
         fleet_locations_ids.swap(fleets_near_enough);
 
     } else if (!selected_fleet_locations_ids.empty()
-               && CouldContain(m_bounding_box, selected_fleets_bounding_box))
+               && LessThanOrEqual(selected_fleets_bounding_box, m_bounding_box))
     {
         location = {INVALID_OBJECT_ID, selected_bounding_box_center};
         boost::unordered_multimap<std::pair<int, GG::Pt>, int> fleets_near_enough;

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -2769,6 +2769,26 @@ int FleetDetailPanel::ShipInRow(GG::ListBox::iterator it) const {
 ////////////////////////////////////////////////
 // FleetWnd
 ////////////////////////////////////////////////
+namespace {
+    /** \p create or grow a bounding \p box from \p pt. */
+    GG::Rect CreateOrGrowBox(bool create, const GG::Rect box, const GG::Pt pt) {
+        if (create)
+            return GG::Rect(pt, pt);
+        else
+            return GG::Rect(
+                std::min(box.Left(),    pt.x),
+                std::min(box.Top(),     pt.y),
+                std::max(box.Right(),   pt.x),
+                std::max(box.Bottom(),  pt.y));
+    }
+
+    /** Can \p bounds encompass \p candidate? */
+    bool CouldContain(GG::Rect bounds, GG::Rect candidate) {
+        return (bounds.Width() >= candidate.Width()
+                && bounds.Height() >= candidate.Height());
+    }
+}
+
 FleetWnd::FleetWnd(const std::vector<int>& fleet_ids, bool order_issuing_enabled,
          int selected_fleet_id/* = INVALID_OBJECT_ID*/,
          GG::Flags<GG::WndFlag> flags/* = INTERACTIVE | DRAGABLE | ONTOP | CLOSABLE | RESIZABLE*/,

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -3081,8 +3081,8 @@ void FleetWnd::Refresh() {
     // Are all fleets in one location?  Use that location.
     // Otherwise, are all selected fleets in one location?  Use that location.
     // Otherwise, is the current location a system?  Use that location.
-    // Otherwise, would all the fleets fit within m_bounding_box.
-    // Otherwise, would all the selected fleets fit within m_bounding_box
+    // Otherwise, are all the moving fleets clustered within m_bounding_box of each other?
+    // Otherwise, are all the selected fleets clustered within m_bounding_box of each other?
     // Otherwise remove all fleets as all fleets have gone in separate directions.
 
     std::pair<int, GG::Pt> location{INVALID_OBJECT_ID, GG::Pt(GG::X0, GG::Y0)};

--- a/UI/FleetWnd.h
+++ b/UI/FleetWnd.h
@@ -123,9 +123,9 @@ public:
 
     void SizeMove(const GG::Pt& ul, const GG::Pt& lr) override;
 
-    void                    SelectFleet(int fleet_id);                          ///< deselects any selected fleets, and selects the indicated fleet, bringing it into the fleet detail window
-    void                    SetSelectedFleets(const std::set<int>& fleet_ids);  ///< deselects any selected fleets, and selects the fleets with the indicated ids
-    void                    SetSelectedShips(const std::set<int>& ship_ids);    ///< deselected any selected ships, and selects the ships with the indicated ids if they are in the selected fleet.
+    void                    SelectFleet(int fleet_id);                     ///< deselects any selected fleets, and selects the indicated fleet, bringing it into the fleet detail window
+    void                    SelectFleets(const std::set<int>& fleet_ids);  ///< deselects any selected fleets, and selects the fleets with the indicated ids
+    void                    SelectShips(const std::set<int>& ship_ids);    ///< deselected any selected ships, and selects the ships with the indicated ids if they are in the selected fleet.
 
     /** Enables, or disables if \a enable is false, issuing orders via this FleetWnd. */
     void                    EnableOrderIssuing(bool enable = true);

--- a/UI/FleetWnd.h
+++ b/UI/FleetWnd.h
@@ -123,6 +123,8 @@ public:
 
     void SizeMove(const GG::Pt& ul, const GG::Pt& lr) override;
 
+    /** Deselect all fleets. */
+    void                    DeselectAllFleets();
     void                    SelectFleet(int fleet_id);                     ///< deselects any selected fleets, and selects the indicated fleet, bringing it into the fleet detail window
     void                    SelectFleets(const std::set<int>& fleet_ids);  ///< deselects any selected fleets, and selects the fleets with the indicated ids
     void                    SelectShips(const std::set<int>& ship_ids);    ///< deselected any selected ships, and selects the ships with the indicated ids if they are in the selected fleet.

--- a/UI/FleetWnd.h
+++ b/UI/FleetWnd.h
@@ -42,6 +42,7 @@ public:
 
     //! \name Mutators //@{
     std::shared_ptr<FleetWnd> NewFleetWnd(const std::vector<int>& fleet_ids,
+                                          double allowed_bounding_box_leeway = 0,
                                           int selected_fleet_id = INVALID_OBJECT_ID,
                                           GG::Flags<GG::WndFlag> flags = GG::INTERACTIVE | GG::DRAGABLE | GG::ONTOP | CLOSABLE | GG::RESIZABLE);
 
@@ -96,6 +97,7 @@ public:
     /** \name Structors */ //@{
     FleetWnd();
     FleetWnd(const std::vector<int>& fleet_ids, bool order_issuing_enabled,
+             double allowed_bounding_box_leeway = 0,
              int selected_fleet_id = INVALID_OBJECT_ID,
              GG::Flags<GG::WndFlag> flags = GG::INTERACTIVE | GG::DRAGABLE | GG::ONTOP | CLOSABLE | GG::RESIZABLE,
              const std::string& config_name = "");
@@ -174,6 +176,8 @@ private:
     int                 m_empire_id;        ///< ID of empire whose fleets are shown in this wnd.  May be ALL_EMPIRES if this FleetWnd wasn't set to shown a particular empire's fleets.
     int                 m_system_id;        ///< ID of system whose fleets are shown in this wnd.  May be INVALID_OBJECT_ID if this FleetWnd wasn't set to show a system's fleets.
 
+    /** The size of box up to which moving fleets are still within the same fleet window.*/
+    GG::Rect            m_bounding_box;
     bool                m_order_issuing_enabled;
     bool                m_needs_refresh = false;
 

--- a/UI/FleetWnd.h
+++ b/UI/FleetWnd.h
@@ -36,6 +36,7 @@ public:
     iterator        end() const;
     FleetWnd*       ActiveFleetWnd() const;
     std::shared_ptr<FleetWnd> WndForFleetID(int fleet_id) const;
+    std::shared_ptr<FleetWnd> WndForFleetIDs(const std::vector<int>& fleet_ids_) const;
     int             SelectedShipID() const;     // if a single ship is selected in the active fleetwnd, returns that ship's ID.  Otherwise, returns INVALID_OBJECT_ID
     std::set<int>   SelectedShipIDs() const;    // returns the ids of all selected ships in the active fleetwnd
     //@}
@@ -110,6 +111,9 @@ public:
     int                     SystemID() const;                   ///< returns ID of system whose fleets are shown in this FleetWnd, which may be INVALID_OBJECT_ID if this FleetWnd isn't set to show fleets of a system
     int                     EmpireID() const;                   ///< returns ID of empire whose fleets are shown in this FleetWnd, which may be ALL_EMPIRES if this FleetWnd isn't set to show fleets of a particular empire
     bool                    ContainsFleet(int fleet_id) const;  ///< returns true if fleet with ID \a fleet_id is shown in this FleetWnd
+    /** Return true if this FleetWnd contains all \p fleet_ids. */
+    template <typename Set>
+    bool                    ContainsFleets(const Set& fleet_ids) const;
     const std::set<int>&    FleetIDs() const;                   ///< returns IDs of all fleets shown in this FleetWnd
     std::set<int>           SelectedFleetIDs() const;           ///< returns IDs of selected fleets in this FleetWnd
     std::set<int>           SelectedShipIDs() const;            ///< returns IDs of selected ships in this FleetWnd

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -5702,13 +5702,16 @@ void MapWnd::FleetButtonLeftClicked(const FleetButton* fleet_btn) {
     if (fleet_ids.empty())
         return;
 
-    // find if a FleetWnd for this FleetButton's fleet(s) is already open, and if so, if there
-    // is a single selected fleet in the window, and if so, what fleet that is
-    const auto& wnd_for_button = FleetUIManager::GetFleetUIManager().WndForFleetID(fleet_ids[0]);
     int already_selected_fleet_id = INVALID_OBJECT_ID;
-    if (wnd_for_button) {
-        // there is already FleetWnd for this button open.
 
+    // Find if a FleetWnd for this FleetButton's fleet(s) is already open, and if so, if there
+    // is a single selected fleet in the window, and if so, what fleet that
+    // is.
+
+    // Note: The shared_ptr<FleetWnd> scope is confined to this if block, so that
+    // SelectFleet below can delete the FleetWnd and re-use the CUIWnd config from
+    // OptionsDB if needed.
+    if (const auto& wnd_for_button = FleetUIManager::GetFleetUIManager().WndForFleetID(fleet_ids[0])) {
         // check which fleet(s) is/are selected in the button's FleetWnd
         auto selected_fleet_ids = wnd_for_button->SelectedFleetIDs();
 

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -4562,13 +4562,13 @@ void MapWnd::SelectFleet(std::shared_ptr<Fleet> fleet) {
         for (const auto& fwnd : manager) {
             auto wnd = fwnd.lock();
             if (wnd && wnd.get() != active_fleet_wnd)
-                wnd->SelectFleet(0);
+                wnd->DeselectAllFleets();
         }
 
         // and finally deselect active fleet wnd fleets.  this might emit a signal
         // which will update this->m_selected_Fleets
         if (active_fleet_wnd)
-            active_fleet_wnd->SelectFleet(0);
+            active_fleet_wnd->DeselectAllFleets();
 
         return;
     }

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -5065,7 +5065,8 @@ void MapWnd::DeferredRefreshFleetButtons() {
                           << ") is not stationary, departing from a system or in transit."
                           << " final dest id is " << fleet->FinalDestinationID()
                           << " travel routes is of length = " << fleet->TravelRoute().size()
-                          << " system id is "<< fleet->SystemID();
+                          << " system id is " << fleet->SystemID()
+                          << " location is (" << fleet->X() << "," <<fleet->Y() << ")";
         }
     }
 

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -4983,6 +4983,35 @@ namespace {
         return (fleet->FinalDestinationID() != INVALID_OBJECT_ID
                 && fleet->SystemID() == INVALID_OBJECT_ID);
     }
+
+    /** Return the starlane's endpoints if the \p fleet is on a starlane. */
+    boost::optional<std::pair<int, int>> IsOnStarlane(const std::shared_ptr<const Fleet>& fleet) {
+        // get endpoints of lane on screen
+        int sys1_id = fleet->PreviousSystemID();
+        int sys2_id = fleet->NextSystemID();
+
+        auto sys1 = GetSystem(sys1_id);
+        if (!sys1)
+            return boost::none;
+        if (sys1->HasStarlaneTo(sys2_id))
+            return std::make_pair(std::min(sys1_id, sys2_id), std::max(sys1_id, sys2_id));
+
+        return boost::none;
+    }
+
+    /** If the \p fleet has a valid destination, is not at a system and is
+        on a starlane, return the starlane's endpoint system ids */
+    boost::optional<std::pair<int, int>> IsMovingOnStarlane(const std::shared_ptr<const Fleet>& fleet) {
+        if (!IsMoving(fleet))
+            return boost::none;
+
+        return IsOnStarlane(fleet);
+    }
+
+    /** If the \p fleet has a valid destination and it not on a starlane, return true*/
+    bool IsOffRoad(const std::shared_ptr<const Fleet>& fleet) {
+        return (IsMoving(fleet) && !IsOnStarlane(fleet));
+    }
 }
 
 void MapWnd::RefreshFleetButtons() {

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -5535,7 +5535,7 @@ void MapWnd::PlotFleetMovement(int system_id, bool execute_move, bool append) {
 
     auto fleet_ids = FleetUIManager::GetFleetUIManager().ActiveFleetWnd()->SelectedFleetIDs();
 
-    // apply to all this-player-owned fleets in currently-active FleetWnd
+    // apply to all selected this-player-owned fleets in currently-active FleetWnd
     for (int fleet_id : fleet_ids) {
         auto fleet = GetFleet(fleet_id);
         if (!fleet) {
@@ -5704,14 +5704,14 @@ void MapWnd::FleetButtonLeftClicked(const FleetButton* fleet_btn) {
 
     int already_selected_fleet_id = INVALID_OBJECT_ID;
 
-    // Find if a FleetWnd for this FleetButton's fleet(s) is already open, and if so, if there
+    // Find if a FleetWnd for these fleet(s) is already open, and if so, if there
     // is a single selected fleet in the window, and if so, what fleet that
     // is.
 
     // Note: The shared_ptr<FleetWnd> scope is confined to this if block, so that
     // SelectFleet below can delete the FleetWnd and re-use the CUIWnd config from
     // OptionsDB if needed.
-    if (const auto& wnd_for_button = FleetUIManager::GetFleetUIManager().WndForFleetID(fleet_ids[0])) {
+    if (const auto& wnd_for_button = FleetUIManager::GetFleetUIManager().WndForFleetIDs(fleet_ids)) {
         // check which fleet(s) is/are selected in the button's FleetWnd
         auto selected_fleet_ids = wnd_for_button->SelectedFleetIDs();
 

--- a/UI/MapWnd.h
+++ b/UI/MapWnd.h
@@ -287,6 +287,12 @@ private:
 
     void DoFleetButtonsLayout();                     //!< does layout of fleet buttons
 
+    /** Return fleets ids of all fleet buttons containing or overlapping the
+        fleet button for \p fleet_id. */
+    std::vector<int> FleetIDsOfFleetButtonsOverlapping(int fleet_id) const;
+    /** Return fleets ids of all fleet buttons containing or overlapping \p fleet_btn. */
+    std::vector<int> FleetIDsOfFleetButtonsOverlapping(const FleetButton& fleet_btn) const;
+
     /** Returns position on map where a moving fleet should be displayed.  This
         is different from the fleet's actual universe position due to the
         squishing of fleets moving along a lane into the space between the
@@ -477,11 +483,26 @@ private:
     std::unordered_map<int, std::unordered_set<std::shared_ptr<FleetButton>>>
         m_departing_fleet_buttons;
 
-    /** Icons representing fleets not at a system. */
+    /** Sets of fleet ids of fleets moving on a starlane, keyed by starlane end
+        system ids. */
+    std::unordered_map<std::pair<int, int>,
+                       std::vector<int>,
+                       boost::hash<std::pair<int, int>>>
+        m_moving_fleets;
+
+    /** Icons representing fleets moving on a starlane, keyed by starlane end
+        system ids. */
+    std::unordered_map<std::pair<int, int>,
+                       std::unordered_set<std::shared_ptr<FleetButton>>,
+                       boost::hash<std::pair<int, int>>>
+        m_moving_fleet_buttons;
+
+    /** Icons representing fleets moving and not on a starlane, indexed by
+        (x,y) location. */
     std::unordered_map<std::pair<double, double>,
                        std::unordered_set<std::shared_ptr<FleetButton>>,
                        boost::hash<std::pair<double, double>>>
-        m_moving_fleet_buttons;
+        m_offroad_fleet_buttons;
 
     boost::unordered_map<int, std::shared_ptr<FleetButton>>
         m_fleet_buttons;                        //!< fleet icons, index by fleet


### PR DESCRIPTION
***Overview***
This PR changes the selection behavior of fleet buttons for moving fleets, so that when a fleet button for a moving fleet is selected it will open a `FleetWnd` with the fleets in the selected fleet button and any fleet buttons it touches.

This addresses the issue from the [forum](http://freeorion.org/forum/viewtopic.php?f=28&t=10853&sid=93a393c8b47910777b361103409bed10.), when fleet buttons are too close then it is not possible to select the underlying fleet button at any zoom level.

This PR also adds `FleetWnd` tracking behavior for moving fleets on subequent turns, when the fleets move.  If all the fleets, or all of the selected fleets remain "close" together, the the `FleetWnd` will remain open and track the pack of fleets movement. "close" is defined as about the size of the fleet button at the original zoom level that the `FleetWnd` was opened at.  

***Details to Aid reviewing***
The code make changes to `FleetWnd` and `MapWnd`.

The `FleetWnd` changes are to  add `m_bounding_box` which determines during each `Refresh()` if moving fleets would still fit within `m_bounding_box` if it were translated to their new location.  Otherwise, if closes the `FleetWnd`.

The `MapWnd` changes are in two parts:
- When the moving fleets buttons are created they are sorted and stored into two types: on starlanes and offroad.  This facilitates efficiently comparing for overlap only fleet buttons on the same starlane.
- When fleet buttons are clicked a new function `MapWnd::FleetIDsOfFleetButtonsOverlapping(fleet)`  returns fleet ids for overlapping buttons, with the categories of in system, moving on a starlane and off-road. These ids are used for opening `FleetWnds` and other actions.






