### PR TITLE
AI support for playing SLY

### DIFF
--- a/default/python/AI/PriorityAI.py
+++ b/default/python/AI/PriorityAI.py
@@ -240,9 +240,8 @@ def _calculate_colonisation_priority():
     allottedColonyTargets = 1 + int(total_pp * turns_to_build * allotted_portion / colony_cost)
     outpost_prio = foAI.foAIstate.get_priority(PriorityType.PRODUCTION_OUTPOST)
     # if have any outposts to build, don't build colony ships TODO: make more complex assessment
-    if outpost_prio > 0 or num_colonies > colony_growth_barrier:
+    if outpost_prio > 0:
         return 0.0
-
     if num_colonies > colony_growth_barrier:
         return 0.0
     num_colonisable_planet_ids = len([pid for (pid, (score, _)) in foAI.foAIstate.colonisablePlanetIDs.items()

--- a/default/python/AI/PriorityAI.py
+++ b/default/python/AI/PriorityAI.py
@@ -239,8 +239,10 @@ def _calculate_colonisation_priority():
     # allottedColonyTargets = 1+ int(fo.currentTurn()/50)
     allottedColonyTargets = 1 + int(total_pp * turns_to_build * allotted_portion / colony_cost)
     outpost_prio = foAI.foAIstate.get_priority(PriorityType.PRODUCTION_OUTPOST)
-    # if have any outposts to build, don't build colony ships TODO: make more complex assessment
-    if outpost_prio > 0:
+
+
+    # if not a purely SP_SLY empire, and have any outposts to build, don't build colony ships TODO: make more complex assessment
+    if outpost_prio > 0 and list(ColonisationAI.empire_colonizers) != ["SP_SLY"]:
         return 0.0
     if num_colonies > colony_growth_barrier:
         return 0.0
@@ -299,6 +301,11 @@ def _calculate_outpost_priority():
     outpost_ship_ids = FleetUtilsAI.get_empire_fleet_ids_by_role(MissionType.OUTPOST)
     num_outpost_ships = len(FleetUtilsAI.extract_fleet_ids_without_mission_types(outpost_ship_ids))
     outpost_priority = (50.0 * (num_outpost_targets - num_outpost_ships)) / num_outpost_targets
+
+    # discourage early outposting for SP_SLY, due to supply and stealth considerations they are best off
+    # using colony ships until they have other colonizers (and more established military)
+    if list(ColonisationAI.empire_colonizers) == ["SP_SLY"]:
+        outpost_priority /= 3.0
 
     # print
     # print "Number of Outpost Ships : " + str(num_outpost_ships)

--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -229,9 +229,11 @@ def generate_production_orders():
             claimed_stars.setdefault(t_sys.starType, []).append(sys_id)
 
     if current_turn == 1 and len(AIstate.opponentPlanetIDs) == 0 and len(production_queue) == 0:
-        init_build_nums = [(PriorityType.PRODUCTION_EXPLORATION, 2),
-                           (PriorityType.PRODUCTION_OUTPOST, 1),
-                           ]
+        init_build_nums = [(PriorityType.PRODUCTION_EXPLORATION, 2)]
+        if list(ColonisationAI.empire_colonizers) == ["SP_SLY"]:
+            init_build_nums.append((PriorityType.PRODUCTION_COLONISATION, 1))
+        else:
+            init_build_nums.append((PriorityType.PRODUCTION_OUTPOST, 1))
         for ship_type, num_ships in init_build_nums:
             best_design_id, _, build_choices = get_best_ship_info(ship_type)
             if best_design_id is not None:

--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -657,7 +657,7 @@ def generate_production_orders():
                         other_planet = universe.getPlanet(opid)
                         if other_planet.size == fo.planetSize.gasGiant:
                             gg_list.append(opid)
-                        if opid != pid and other_planet.owner == empire.empireID and (FocusType.FOCUS_INDUSTRY in list(other_planet.availableFoci) + [other_planet.focus]):
+                        if other_planet.owner == empire.empireID and (FocusType.FOCUS_INDUSTRY in list(other_planet.availableFoci) + [other_planet.focus]):
                             can_use_gg = True
                     if pid in sorted(gg_list)[:max_gggs] and can_use_gg:
                         res = fo.issueEnqueueBuildingProductionOrder(building_name, pid)


### PR DESCRIPTION
Informs the AI about the new species The Sly and related changes.  Tries to keep a starting-Sly empire in stealthy mode during the initial growth stages by reducing outposting and military priorities, currently until the empire has acquired another colonizer.  

More can be done, but this seems to be enough to make the AI fairly competent with the Sly.

Resolves #1958 