### PR TITLE
Join playing game as Observer or Moderator

### DIFF
--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1630,7 +1630,7 @@ void ServerApp::AddObserverPlayerIntoGame(const PlayerConnectionPtr& player_conn
     if (client_type == Networking::CLIENT_TYPE_HUMAN_OBSERVER ||
         client_type == Networking::CLIENT_TYPE_HUMAN_MODERATOR)
     {
-
+        // simply sends GAME_START message so established player will known he is in the game now
         player_connection->SendMessage(GameStartMessage(m_single_player_game, ALL_EMPIRES,
                                                         m_current_turn, m_empires, m_universe,
                                                         GetSpeciesManager(), GetCombatLogManager(),

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1621,6 +1621,28 @@ bool ServerApp::IsAuthSuccessAndFillRoles(const std::string& player_name, const 
     return result;
 }
 
+void ServerApp::AddObserverPlayerIntoGame(const PlayerConnectionPtr& player_connection) {
+    std::map<int, PlayerInfo> player_info_map = GetPlayerInfoMap();
+
+    Networking::ClientType client_type = player_connection->GetClientType();
+    bool use_binary_serialization = player_connection->ClientVersionStringMatchesThisServer();
+
+    if (client_type == Networking::CLIENT_TYPE_HUMAN_OBSERVER ||
+        client_type == Networking::CLIENT_TYPE_HUMAN_MODERATOR)
+    {
+
+        player_connection->SendMessage(GameStartMessage(m_single_player_game, ALL_EMPIRES,
+                                                        m_current_turn, m_empires, m_universe,
+                                                        GetSpeciesManager(), GetCombatLogManager(),
+                                                        GetSupplyManager(), player_info_map,
+                                                        m_galaxy_setup_data, use_binary_serialization));
+    } else {
+        ErrorLogger() << "ServerApp::CommonGameInit unsupported client type: skipping game start message.";
+    }
+
+    // TODO: notify other players
+}
+
 bool ServerApp::IsHostless() const
 { return GetOptionsDB().Get<bool>("hostless"); }
 

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -216,7 +216,8 @@ public:
     /** Checks if \a auth match \a player_name and fill \a roles if successed. */
     bool IsAuthSuccessAndFillRoles(const std::string& player_name, const std::string& auth, Networking::AuthRoles& roles);
 
-    /** Add new observing player to running game. */
+    /** Adds new observing player to running game.
+      * Simply sends GAME_START message so established player knows he is in the game. */
     void AddObserverPlayerIntoGame(const PlayerConnectionPtr& player_connection);
     //@}
 

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -215,6 +215,9 @@ public:
 
     /** Checks if \a auth match \a player_name and fill \a roles if successed. */
     bool IsAuthSuccessAndFillRoles(const std::string& player_name, const std::string& auth, Networking::AuthRoles& roles);
+
+    /** Add new observing player to running game. */
+    void AddObserverPlayerIntoGame(const PlayerConnectionPtr& player_connection);
     //@}
 
     void UpdateSavePreviews(const Message& msg, PlayerConnectionPtr player_connection);

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -291,7 +291,7 @@ bool ServerFSM::EstablishPlayer(const PlayerConnectionPtr& player_connection,
 
     if (player_connection->IsAuthenticated()) {
         // drop other connection with same name
-        for (ServerNetworking::const_established_iterator it = m_server.m_networking.established_begin();
+        for (auto it = m_server.m_networking.established_begin();
              it != m_server.m_networking.established_end(); ++it)
         {
             if ((*it)->PlayerName() == player_name && player_connection != (*it)) {

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -281,10 +281,11 @@ void ServerFSM::HandleNonLobbyDisconnection(const Disconnection& d) {
     }
 }
 
-void ServerFSM::EstablishPlayer(const PlayerConnectionPtr& player_connection,
+bool ServerFSM::EstablishPlayer(const PlayerConnectionPtr& player_connection,
                                 const std::string& player_name,
                                 Networking::ClientType client_type,
-                                const std::string& client_version_string)
+                                const std::string& client_version_string,
+                                const Networking::AuthRoles& roles)
 {
     std::list<PlayerConnectionPtr> to_disconnect;
 
@@ -300,36 +301,62 @@ void ServerFSM::EstablishPlayer(const PlayerConnectionPtr& player_connection,
         }
     }
 
-    // assign unique player ID to newly connected player
-    int player_id = m_server.m_networking.NewPlayerID();
-    DebugLogger() << "ServerFSM.EstablishPlayer Assign new player id " << player_id;
+    // set and test roles
+    player_connection->SetAuthRoles(roles);
 
-    // establish player with requested client type and acknowldge via connection
-    player_connection->EstablishPlayer(player_id, player_name, client_type, client_version_string);
-    player_connection->SendMessage(JoinAckMessage(player_id));
-    if (!GetOptionsDB().Get<bool>("skip-checksum"))
-        player_connection->SendMessage(ContentCheckSumMessage());
-
-    // inform player of host
-    player_connection->SendMessage(HostIDMessage(m_server.m_networking.HostPlayerID()));
-
-    // send chat history
-    if (client_type == Networking::CLIENT_TYPE_HUMAN_MODERATOR ||
-        client_type == Networking::CLIENT_TYPE_HUMAN_OBSERVER ||
-        client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER)
+    if (client_type == Networking::CLIENT_TYPE_HUMAN_OBSERVER &&
+        !player_connection->HasAuthRole(Networking::ROLE_CLIENT_TYPE_OBSERVER))
     {
-        std::vector<std::reference_wrapper<const ChatHistoryEntity>> chat_history;
-        for (const auto& elem : m_server.GetChatHistory()) {
-            chat_history.push_back(std::cref(elem));
-        }
-        if (chat_history.size() > 0) {
-            player_connection->SendMessage(ChatHistoryMessage(chat_history));
+        client_type = Networking::INVALID_CLIENT_TYPE;
+    }
+    if (client_type == Networking::CLIENT_TYPE_HUMAN_MODERATOR &&
+        !player_connection->HasAuthRole(Networking::ROLE_CLIENT_TYPE_MODERATOR))
+    {
+        client_type = Networking::INVALID_CLIENT_TYPE;
+    }
+    if (client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER &&
+        !player_connection->HasAuthRole(Networking::ROLE_CLIENT_TYPE_PLAYER))
+    {
+        client_type = Networking::INVALID_CLIENT_TYPE;
+    }
+
+    if (client_type == Networking::INVALID_CLIENT_TYPE) {
+        player_connection->SendMessage(ErrorMessage(UserStringNop("ERROR_CLIENT_TYPE_NOT_ALLOWED"), true));
+        to_disconnect.push_back(player_connection);
+    } else {
+        // assign unique player ID to newly connected player
+        int player_id = m_server.m_networking.NewPlayerID();
+        DebugLogger() << "ServerFSM.EstablishPlayer Assign new player id " << player_id;
+
+        // establish player with requested client type and acknowldge via connection
+        player_connection->EstablishPlayer(player_id, player_name, client_type, client_version_string);
+        player_connection->SendMessage(JoinAckMessage(player_id));
+        if (!GetOptionsDB().Get<bool>("skip-checksum"))
+            player_connection->SendMessage(ContentCheckSumMessage());
+
+        // inform player of host
+        player_connection->SendMessage(HostIDMessage(m_server.m_networking.HostPlayerID()));
+
+        // send chat history
+        if (client_type == Networking::CLIENT_TYPE_HUMAN_MODERATOR ||
+            client_type == Networking::CLIENT_TYPE_HUMAN_OBSERVER ||
+            client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER)
+        {
+            std::vector<std::reference_wrapper<const ChatHistoryEntity>> chat_history;
+            for (const auto& elem : m_server.GetChatHistory()) {
+                chat_history.push_back(std::cref(elem));
+            }
+            if (chat_history.size() > 0) {
+                player_connection->SendMessage(ChatHistoryMessage(chat_history));
+            }
         }
     }
 
     // disconnect "ghost" connection after establishing new
     for (const auto& conn : to_disconnect)
     { m_server.Networking().Disconnect(conn); }
+
+    return client_type != Networking::INVALID_CLIENT_TYPE;
 }
 
 ////////////////////////////////////////////////////////////
@@ -701,68 +728,49 @@ void MPLobby::EstablishPlayer(const PlayerConnectionPtr& player_connection,
     ServerApp& server = Server();
     const SpeciesManager& sm = GetSpeciesManager();
 
-    player_connection->SetAuthRoles(roles);
-
-    // check client types and roles
-    if (client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER &&
-        !player_connection->HasAuthRole(Networking::ROLE_CLIENT_TYPE_PLAYER))
+    if (context<ServerFSM>().EstablishPlayer(player_connection,
+                                             player_name,
+                                             client_type,
+                                             client_version_string,
+                                             roles))
     {
-        client_type = Networking::INVALID_CLIENT_TYPE;
-    }
-    if (client_type == Networking::CLIENT_TYPE_HUMAN_OBSERVER &&
-        !player_connection->HasAuthRole(Networking::ROLE_CLIENT_TYPE_OBSERVER))
-    {
-        client_type = Networking::INVALID_CLIENT_TYPE;
-    }
-    if (client_type == Networking::CLIENT_TYPE_HUMAN_MODERATOR &&
-        !player_connection->HasAuthRole(Networking::ROLE_CLIENT_TYPE_MODERATOR))
-    {
-        client_type = Networking::INVALID_CLIENT_TYPE;
-    }
+        int player_id = player_connection->PlayerID();
 
-    if (client_type == Networking::INVALID_CLIENT_TYPE) {
-        player_connection->SendMessage(ErrorMessage(UserStringNop("ERROR_CLIENT_TYPE_NOT_ALLOWED"), true));
-        server.Networking().Disconnect(player_connection);
-        return;
-    }
+        // Inform AI of logging configuration.
+        if (client_type == Networking::CLIENT_TYPE_AI_PLAYER)
+            player_connection->SendMessage(
+                LoggerConfigMessage(Networking::INVALID_PLAYER_ID, LoggerOptionsLabelsAndLevels(LoggerTypes::both)));
 
-    context<ServerFSM>().EstablishPlayer(player_connection, player_name, client_type, client_version_string);
-    int player_id = player_connection->PlayerID();
+        // assign player info from defaults or from connection to lobby data players list
+        PlayerSetupData player_setup_data;
+        player_setup_data.m_player_name =   player_name;
+        player_setup_data.m_client_type =   client_type;
+        player_setup_data.m_empire_name =   (client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER) ? player_name : GenerateEmpireName(player_name, m_lobby_data->m_players);
+        player_setup_data.m_empire_color =  GetUnusedEmpireColour(m_lobby_data->m_players);
+        if (m_lobby_data->m_seed != "")
+            player_setup_data.m_starting_species_name = sm.RandomPlayableSpeciesName();
+        else
+            player_setup_data.m_starting_species_name = sm.SequentialPlayableSpeciesName(player_id);
 
-    // Inform AI of logging configuration.
-    if (client_type == Networking::CLIENT_TYPE_AI_PLAYER)
-        player_connection->SendMessage(
-            LoggerConfigMessage(Networking::INVALID_PLAYER_ID, LoggerOptionsLabelsAndLevels(LoggerTypes::both)));
+        // after setting all details, push into lobby data
+        m_lobby_data->m_players.push_back(std::make_pair(player_id, player_setup_data));
 
-    // assign player info from defaults or from connection to lobby data players list
-    PlayerSetupData player_setup_data;
-    player_setup_data.m_player_name =   player_name;
-    player_setup_data.m_client_type =   client_type;
-    player_setup_data.m_empire_name =   (client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER) ? player_name : GenerateEmpireName(player_name, m_lobby_data->m_players);
-    player_setup_data.m_empire_color =  GetUnusedEmpireColour(m_lobby_data->m_players);
-    if (m_lobby_data->m_seed != "")
-        player_setup_data.m_starting_species_name = sm.RandomPlayableSpeciesName();
-    else
-        player_setup_data.m_starting_species_name = sm.SequentialPlayableSpeciesName(player_id);
+        // drop ready player flag at new player
+        for (std::pair<int, PlayerSetupData>& plr : m_lobby_data->m_players) {
+            if (plr.second.m_empire_name == player_name) {
+                // change empire name
+                plr.second.m_empire_name = (plr.second.m_client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER) ? plr.second.m_player_name : GenerateEmpireName(plr.second.m_player_name, m_lobby_data->m_players);
+            }
 
-    // after setting all details, push into lobby data
-    m_lobby_data->m_players.push_back(std::make_pair(player_id, player_setup_data));
-
-    // drop ready player flag at new player
-    for (std::pair<int, PlayerSetupData>& plr : m_lobby_data->m_players) {
-        if (plr.second.m_empire_name == player_name) {
-            // change empire name
-            plr.second.m_empire_name = (plr.second.m_client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER) ? plr.second.m_player_name : GenerateEmpireName(plr.second.m_player_name, m_lobby_data->m_players);
+            plr.second.m_player_ready = false;
         }
 
-        plr.second.m_player_ready = false;
+        ValidateClientLimits();
+
+        for (auto it = server.m_networking.established_begin();
+             it != server.m_networking.established_end(); ++it)
+        { (*it)->SendMessage(ServerLobbyUpdateMessage(*m_lobby_data)); }
     }
-
-    ValidateClientLimits();
-
-    for (auto it = server.m_networking.established_begin();
-         it != server.m_networking.established_end(); ++it)
-    { (*it)->SendMessage(ServerLobbyUpdateMessage(*m_lobby_data)); }
 }
 
 sc::result MPLobby::react(const JoinGame& msg) {
@@ -1796,7 +1804,7 @@ sc::result WaitingForMPGameJoiners::react(const JoinGame& msg) {
                 return discard_event();
             }
 
-            fsm.EstablishPlayer(player_connection, new_player_name, client_type, client_version_string);
+            fsm.EstablishPlayer(player_connection, new_player_name, client_type, client_version_string, roles);
         }
     } else {
         ErrorLogger(FSM) << "WaitingForMPGameJoiners::react(const JoinGame& msg): Received JoinGame message with invalid client type: " << client_type;
@@ -1866,7 +1874,11 @@ sc::result WaitingForMPGameJoiners::react(const AuthResponse& msg) {
                 return discard_event();
             }
 
-            fsm.EstablishPlayer(player_connection, player_name, client_type, player_connection->ClientVersionString());
+            fsm.EstablishPlayer(player_connection,
+                                player_name,
+                                client_type,
+                                player_connection->ClientVersionString(),
+                                roles);
         }
     } else {
         // non-human player
@@ -2050,52 +2062,40 @@ void PlayingGame::EstablishPlayer(const PlayerConnectionPtr& player_connection,
     // to MPLobby or ShuttingDownServer gets context before disconnection
     ServerFSM& fsm = context<ServerFSM>();
 
-    player_connection->SetAuthRoles(roles);
-
-    if (client_type == Networking::CLIENT_TYPE_HUMAN_OBSERVER &&
-        !player_connection->HasAuthRole(Networking::ROLE_CLIENT_TYPE_OBSERVER))
+    if (fsm.EstablishPlayer(player_connection,
+                            player_name,
+                            client_type,
+                            player_connection->ClientVersionString(),
+                            roles))
     {
-        client_type = Networking::INVALID_CLIENT_TYPE;
-    }
-    if (client_type == Networking::CLIENT_TYPE_HUMAN_MODERATOR &&
-        !player_connection->HasAuthRole(Networking::ROLE_CLIENT_TYPE_MODERATOR))
-    {
-        client_type = Networking::INVALID_CLIENT_TYPE;
-    }
-    if (client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER &&
-        !player_connection->HasAuthRole(Networking::ROLE_CLIENT_TYPE_PLAYER))
-    {
-        client_type = Networking::INVALID_CLIENT_TYPE;
-    }
+        // it possible to be not in PlayingGame here
+        bool is_in_mplobby = false;
+        std::stringstream ss;
+        for (auto leaf_state_it = fsm.state_begin(); leaf_state_it != fsm.state_end();) {
+            // The following use of typeid assumes that
+            // BOOST_STATECHART_USE_NATIVE_RTTI is defined
+            const auto& leaf_state = *leaf_state_it;
+            ss << typeid(leaf_state).name();
+            if (typeid(leaf_state) == typeid(MPLobby))
+                is_in_mplobby = true;
+            ++leaf_state_it;
+            if (leaf_state_it != fsm.state_end())
+                ss << ", ";
+        }
+        ss << "]";
+        DebugLogger(FSM) << "(ServerFSM) PlayingGame.EstablishPlayer at " << ss.str();
 
-    if (client_type == Networking::INVALID_CLIENT_TYPE) {
-        player_connection->SendMessage(ErrorMessage(UserStringNop("ERROR_CLIENT_TYPE_NOT_ALLOWED"), true));
-        server.Networking().Disconnect(player_connection);
-        return;
-    }
-
-    fsm.EstablishPlayer(player_connection, player_name, client_type, player_connection->ClientVersionString());
-
-    // it possible to be not in PlayingGame here
-    bool is_in_mplobby = false;
-    std::stringstream ss;
-    for (auto leaf_state_it = fsm.state_begin(); leaf_state_it != fsm.state_end();) {
-        // The following use of typeid assumes that
-        // BOOST_STATECHART_USE_NATIVE_RTTI is defined
-        const auto& leaf_state = *leaf_state_it;
-        ss << typeid(leaf_state).name();
-        if (typeid(leaf_state) == typeid(MPLobby))
-            is_in_mplobby = true;
-        ++leaf_state_it;
-        if (leaf_state_it != fsm.state_end())
-            ss << ", ";
-    }
-    ss << "]";
-    DebugLogger(FSM) << "(ServerFSM) PlayingGame.EstablishPlayer at " << ss.str();
-
-    if (!is_in_mplobby) {
-        // send playing game
-        server.AddObserverPlayerIntoGame(player_connection);
+        if (!is_in_mplobby) {
+            if (client_type == Networking::CLIENT_TYPE_HUMAN_OBSERVER ||
+                client_type == Networking::CLIENT_TYPE_HUMAN_MODERATOR)
+            {
+                // send playing game
+                server.AddObserverPlayerIntoGame(player_connection);
+            } else {
+                player_connection->SendMessage(ErrorMessage(UserStringNop("SERVER_ALREADY_PLAYING_GAME")));
+                server.Networking().Disconnect(player_connection);
+            }
+        }
     }
 }
 
@@ -2110,19 +2110,19 @@ sc::result PlayingGame::react(const JoinGame& msg) {
     std::string client_version_string;
     ExtractJoinGameMessageData(message, player_name, client_type, client_version_string);
 
-    if (client_type != Networking::CLIENT_TYPE_HUMAN_OBSERVER &&
-        client_type != Networking::CLIENT_TYPE_HUMAN_MODERATOR)
-    {
-        msg.m_player_connection->SendMessage(ErrorMessage(UserStringNop("SERVER_ALREADY_PLAYING_GAME")));
-        Server().Networking().Disconnect(msg.m_player_connection);
-        return discard_event();
-    }
-
     Networking::AuthRoles roles;
     if (server.IsAuthRequiredOrFillRoles(player_name, roles)) {
         // send authentication request
         player_connection->AwaitPlayer(client_type, client_version_string);
         player_connection->SendMessage(AuthRequestMessage(player_name, "PLAIN-TEXT"));
+        return discard_event();
+    }
+
+    if (client_type != Networking::CLIENT_TYPE_HUMAN_OBSERVER &&
+        client_type != Networking::CLIENT_TYPE_HUMAN_MODERATOR)
+    {
+        msg.m_player_connection->SendMessage(ErrorMessage(UserStringNop("SERVER_ALREADY_PLAYING_GAME")));
+        Server().Networking().Disconnect(msg.m_player_connection);
         return discard_event();
     }
 

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -286,6 +286,21 @@ void ServerFSM::EstablishPlayer(const PlayerConnectionPtr& player_connection,
                                 Networking::ClientType client_type,
                                 const std::string& client_version_string)
 {
+    if (player_connection->IsAuthenticated()) {
+        // drop other connection with same name
+        std::list<PlayerConnectionPtr> to_disconnect;
+        for (ServerNetworking::const_established_iterator it = m_server.m_networking.established_begin();
+             it != m_server.m_networking.established_end(); ++it)
+        {
+            if ((*it)->PlayerName() == player_name && player_connection != (*it)) {
+                (*it)->SendMessage(ErrorMessage(UserString("ERROR_CONNECTION_WAS_REPLACED"), true));
+                to_disconnect.push_back(*it);
+            }
+        }
+        for (const auto& conn : to_disconnect)
+        { m_server.Networking().Disconnect(conn); }
+    }
+
     // assign unique player ID to newly connected player
     int player_id = m_server.m_networking.NewPlayerID();
     DebugLogger() << "ServerFSM.EstablishPlayer Assign new player id " << player_id;
@@ -708,17 +723,8 @@ void MPLobby::EstablishPlayer(const PlayerConnectionPtr& player_connection,
         return;
     }
 
-    // assign unique player ID to newly connected player
-    int player_id = server.m_networking.NewPlayerID();
-
-    // establish player with requested client type and acknowldge via connection
-    player_connection->EstablishPlayer(player_id, player_name, client_type, client_version_string);
-    player_connection->SendMessage(JoinAckMessage(player_id));
-    if (!GetOptionsDB().Get<bool>("skip-checksum"))
-        player_connection->SendMessage(ContentCheckSumMessage());
-
-    // inform player of host
-    player_connection->SendMessage(HostIDMessage(server.m_networking.HostPlayerID()));
+    context<ServerFSM>().EstablishPlayer(player_connection, player_name, client_type, client_version_string);
+    int player_id = player_connection->PlayerID();
 
     // Inform AI of logging configuration.
     if (client_type == Networking::CLIENT_TYPE_AI_PLAYER)
@@ -749,40 +755,11 @@ void MPLobby::EstablishPlayer(const PlayerConnectionPtr& player_connection,
         plr.second.m_player_ready = false;
     }
 
-    if (player_connection->IsAuthenticated()) {
-        // drop other connection with same name
-        std::list<PlayerConnectionPtr> to_disconnect;
-        for (ServerNetworking::const_established_iterator it = server.m_networking.established_begin();
-             it != server.m_networking.established_end(); ++it)
-        {
-            if ((*it)->PlayerName() == player_name && player_connection != (*it)) {
-                (*it)->SendMessage(ErrorMessage(UserString("ERROR_CONNECTION_WAS_REPLACED"), true));
-                to_disconnect.push_back(*it);
-            }
-        }
-        for (const auto& conn : to_disconnect)
-        { server.Networking().Disconnect(conn); }
-    }
-
     ValidateClientLimits();
 
     for (auto it = server.m_networking.established_begin();
          it != server.m_networking.established_end(); ++it)
     { (*it)->SendMessage(ServerLobbyUpdateMessage(*m_lobby_data)); }
-
-    // send chat history
-    if (client_type == Networking::CLIENT_TYPE_HUMAN_MODERATOR ||
-        client_type == Networking::CLIENT_TYPE_HUMAN_OBSERVER ||
-        client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER)
-    {
-        std::vector<std::reference_wrapper<const ChatHistoryEntity>> chat_history;
-        for (const auto& elem : server.GetChatHistory()) {
-            chat_history.push_back(std::cref(elem));
-        }
-        if (chat_history.size() > 0) {
-            player_connection->SendMessage(ChatHistoryMessage(chat_history));
-        }
-    }
 }
 
 sc::result MPLobby::react(const JoinGame& msg) {
@@ -1858,7 +1835,7 @@ sc::result WaitingForMPGameJoiners::react(const AuthResponse& msg) {
     Networking::ClientType client_type = player_connection->GetClientType();
 
     if (client_type == Networking::CLIENT_TYPE_HUMAN_PLAYER) {
-        // drop other connection with same name
+        // drop other connection with same name before checks for expected players
         std::list<PlayerConnectionPtr> to_disconnect;
         for (ServerNetworking::const_established_iterator it = server.m_networking.established_begin();
              it != server.m_networking.established_end(); ++it)
@@ -2094,21 +2071,6 @@ void PlayingGame::EstablishPlayer(const PlayerConnectionPtr& player_connection,
         return;
     }
 
-    if (player_connection->IsAuthenticated()) {
-        // drop other connection with same name
-        std::list<PlayerConnectionPtr> to_disconnect;
-        for (ServerNetworking::const_established_iterator it = server.m_networking.established_begin();
-             it != server.m_networking.established_end(); ++it)
-        {
-            if ((*it)->PlayerName() == player_name && player_connection != (*it)) {
-                (*it)->SendMessage(ErrorMessage(UserString("ERROR_CONNECTION_WAS_REPLACED"), true));
-                to_disconnect.push_back(*it);
-            }
-        }
-        for (const auto& conn : to_disconnect)
-        { server.Networking().Disconnect(conn); }
-    }
-
     fsm.EstablishPlayer(player_connection, player_name, client_type, player_connection->ClientVersionString());
 
     // send playing game
@@ -2179,9 +2141,7 @@ sc::result PlayingGame::react(const JoinGame& msg) {
         return discard_event();
     }
 
-    player_name = new_player_name;
-
-    EstablishPlayer(player_connection, player_name, client_type,
+    EstablishPlayer(player_connection, new_player_name, client_type,
                     client_version_string, roles);
 
     return discard_event();

--- a/server/ServerFSM.h
+++ b/server/ServerFSM.h
@@ -129,6 +129,10 @@ struct ServerFSM : sc::state_machine<ServerFSM, Idle> {
     void unconsumed_event(const sc::event_base &event);
     ServerApp& Server();
     void HandleNonLobbyDisconnection(const Disconnection& d);
+    void EstablishPlayer(const PlayerConnectionPtr& player_connection,
+                         const std::string& player_name,
+                         Networking::ClientType client_type,
+                         const std::string& client_version_string);
 
     std::shared_ptr<MultiplayerLobbyData>   m_lobby_data;
     std::shared_ptr<SinglePlayerSetupData>  m_single_player_setup_data;

--- a/server/ServerFSM.h
+++ b/server/ServerFSM.h
@@ -308,6 +308,12 @@ struct PlayingGame : sc::state<PlayingGame, ServerFSM, WaitingForTurnEnd> {
     sc::result react(const AuthResponse& msg);
     sc::result react(const Error& msg);
 
+    void EstablishPlayer(const PlayerConnectionPtr& player_connection,
+                         const std::string& player_name,
+                         Networking::ClientType client_type,
+                         const std::string& client_version_string,
+                         const Networking::AuthRoles& roles);
+
     SERVER_ACCESSOR
 };
 

--- a/server/ServerFSM.h
+++ b/server/ServerFSM.h
@@ -291,6 +291,7 @@ struct PlayingGame : sc::state<PlayingGame, ServerFSM, WaitingForTurnEnd> {
         sc::custom_reaction<ShutdownServer>,
         sc::custom_reaction<Hostless>,
         sc::custom_reaction<JoinGame>,
+        sc::custom_reaction<AuthResponse>,
         sc::custom_reaction<Error>
     > reactions;
 
@@ -304,6 +305,7 @@ struct PlayingGame : sc::state<PlayingGame, ServerFSM, WaitingForTurnEnd> {
     sc::result react(const Hostless& u);
     sc::result react(const RequestCombatLogs& msg);
     sc::result react(const JoinGame& msg);
+    sc::result react(const AuthResponse& msg);
     sc::result react(const Error& msg);
 
     SERVER_ACCESSOR

--- a/server/ServerFSM.h
+++ b/server/ServerFSM.h
@@ -129,10 +129,11 @@ struct ServerFSM : sc::state_machine<ServerFSM, Idle> {
     void unconsumed_event(const sc::event_base &event);
     ServerApp& Server();
     void HandleNonLobbyDisconnection(const Disconnection& d);
-    void EstablishPlayer(const PlayerConnectionPtr& player_connection,
+    bool EstablishPlayer(const PlayerConnectionPtr& player_connection,
                          const std::string& player_name,
                          Networking::ClientType client_type,
-                         const std::string& client_version_string);
+                         const std::string& client_version_string,
+                         const Networking::AuthRoles& roles);
 
     std::shared_ptr<MultiplayerLobbyData>   m_lobby_data;
     std::shared_ptr<SinglePlayerSetupData>  m_single_player_setup_data;


### PR DESCRIPTION
Second try to allow Observers and Moderators join into playing game and preparatory step to allow Player enter/leave to playing game (like Freeciv).

It check roles so the server could be protected by removing `ROLE_CLIENT_TYPE_OBSERVER` and `ROLE_CLIENT_TYPE_MODERATOR` from all users if needed.

New login kick out other connections with same name.

New observers and moderators appears only on new turn when server sends `PlayerInfo` objects in TURN_UPDATE message with them.