### PR TITLE
Planet habitable size

### DIFF
--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -207,6 +207,7 @@ namespace {
             col_types[{UserStringNop("PREFERRED_FOCUS"),            UserStringNop("PLANETS_SUBMENU")}]= UserStringValueRef("PreferredFocus");
             col_types[{UserStringNop("TURNS_SINCE_FOCUS_CHANGE"),   UserStringNop("PLANETS_SUBMENU")}]= StringCastedValueRef<int>("TurnsSinceFocusChange");
             col_types[{UserStringNop("SIZE_AS_DOUBLE"),             UserStringNop("PLANETS_SUBMENU")}]= StringCastedValueRef<double>("SizeAsDouble");
+            col_types[{UserStringNop("HABITABLE_SIZE"),             UserStringNop("PLANETS_SUBMENU")}]= StringCastedValueRef<double>("HabitableSize");
             col_types[{UserStringNop("DISTANCE_FROM_ORIGINAL_TYPE"),UserStringNop("PLANETS_SUBMENU")}]= StringCastedValueRef<double>("DistanceFromOriginalType");
             col_types[{UserStringNop("PLANET_TYPE"),                UserStringNop("PLANETS_SUBMENU")}]= UserStringCastedValueRef<PlanetType>("PlanetType");
             col_types[{UserStringNop("ORIGINAL_TYPE"),              UserStringNop("PLANETS_SUBMENU")}]= UserStringCastedValueRef<PlanetType>("OriginalType");

--- a/default/python/AI/AIDependencies.py
+++ b/default/python/AI/AIDependencies.py
@@ -65,23 +65,6 @@ supply_by_size = {
     fo.planetSize.gasGiant: -1,
 }
 
-# Planet Size as Int
-# should be kept in sync with Planet::SizeAsInt() in universe/planet.cpp
-planet_size_map = {
-    fo.planetSize.gasGiant: 6,
-    fo.planetSize.huge: 5,
-    fo.planetSize.large: 4,
-    fo.planetSize.medium: 3,
-    fo.planetSize.asteroids: 3,
-    fo.planetSize.small: 2,
-    fo.planetSize.tiny: 1,
-}
-
-
-def planet_size_as_int(planet_size):
-    return planet_size_map.get(planet_size) or 0
-
-
 # Drydock repair details
 DRYDOCK_HAPPINESS_THRESHOLD = 5
 

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -59,7 +59,7 @@ def outpod_pod_cost():
 
 
 def calc_max_pop(planet, species, detail):
-    planet_size = AIDependencies.planet_size_as_int(planet.size)
+    planet_size = planet.habitableSize
     planet_env = species.getPlanetEnvironment(planet.type)
     if planet_env == fo.planetEnvironment.uninhabitable:
         detail.append("Uninhabitable.")
@@ -241,8 +241,7 @@ def survey_universe():
                 if planet_population > 0.0 and this_spec:
                     empire_has_qualifying_planet = True
                     for metab in [tag for tag in this_spec.tags if tag in AIDependencies.metabolismBoostMap]:
-                        empire_metabolisms[metab] = (empire_metabolisms.get(metab, 0.0) +
-                                                     AIDependencies.planet_size_as_int(planet.size))
+                        empire_metabolisms[metab] = (empire_metabolisms.get(metab, 0.0) + planet.habitableSize)
                     if this_spec.canProduceShips:
                         pilot_val = rate_piloting_tag(list(this_spec.tags))
                         if spec_name == "SP_ACIREMA":

--- a/default/python/AI/ResourcesAI.py
+++ b/default/python/AI/ResourcesAI.py
@@ -434,7 +434,7 @@ def set_planet_growth_specials(focus_manager):
             # the increased population on the planet using this growth focus
             # is mostly wasted, so ignore it for now.
             pop = planet.currentMeterValue(fo.meterType.population)
-            pop_gain = potential_pop_increase - AIDependencies.planet_size_as_int(planet.size)
+            pop_gain = potential_pop_increase - planet.habitableSize
             if pop > pop_gain:
                 _print_evaluation("would lose more pop (%.1f) than gain everywhere else (%.1f)." % (pop, pop_gain))
                 continue

--- a/default/scripting/buildings/ART_FACTORY_PLANET.focs.txt
+++ b/default/scripting/buildings/ART_FACTORY_PLANET.focs.txt
@@ -1,7 +1,7 @@
 BuildingType
     name = "BLD_ART_FACTORY_PLANET"
     description = "BLD_ART_FACTORY_PLANET_DESC"
-    buildcost = 200 * Target.SizeAsDouble + ( 70 * [[COLONY_UPKEEP_MULTIPLICATOR]] * [[BUILDING_COST_MULTIPLIER]])
+    buildcost = 200 * Target.HabitableSize + ( 70 * [[COLONY_UPKEEP_MULTIPLICATOR]] * [[BUILDING_COST_MULTIPLIER]])
     buildtime = 12
     location = And [
         Planet

--- a/default/scripting/buildings/ART_PARADISE_PLANET.focs.txt
+++ b/default/scripting/buildings/ART_PARADISE_PLANET.focs.txt
@@ -1,7 +1,7 @@
 BuildingType
     name = "BLD_ART_PARADISE_PLANET"
     description = "BLD_ART_PARADISE_PLANET_DESC"
-    buildcost = (200 * Target.SizeAsDouble + 300) * [[BUILDING_COST_MULTIPLIER]]
+    buildcost = (200 * Target.HabitableSize + 300) * [[BUILDING_COST_MULTIPLIER]]
     buildtime = 10
     location = And [
         Planet

--- a/default/scripting/buildings/ART_PLANET.focs.txt
+++ b/default/scripting/buildings/ART_PLANET.focs.txt
@@ -1,7 +1,7 @@
 BuildingType
     name = "BLD_ART_PLANET"
     description = "BLD_ART_PLANET_DESC"
-    buildcost = 200 * Target.SizeAsDouble * [[BUILDING_COST_MULTIPLIER]]
+    buildcost = 200 * Target.HabitableSize * [[BUILDING_COST_MULTIPLIER]]
     buildtime = 8
     location = And [
         Planet

--- a/default/scripting/buildings/GAIA_TRANS.focs.txt
+++ b/default/scripting/buildings/GAIA_TRANS.focs.txt
@@ -1,7 +1,7 @@
 BuildingType
     name = "BLD_GAIA_TRANS"
     description = "BLD_GAIA_TRANS_DESC"
-    buildcost = 200 * Target.SizeAsDouble * [[BUILDING_COST_MULTIPLIER]]
+    buildcost = 200 * Target.HabitableSize * [[BUILDING_COST_MULTIPLIER]]
     buildtime = 12
     location = And [
         Planet

--- a/default/scripting/buildings/HYPER_DAM.focs.txt
+++ b/default/scripting/buildings/HYPER_DAM.focs.txt
@@ -43,7 +43,7 @@ BuildingType
             activation = Source
             stackinggroup = "BLD_HYPER_DAM_MALUS"
             priority = [[EARLY_TARGET_POPULATION_PRIORITY]]
-            effects = SetTargetPopulation value = Value - Target.SizeAsDouble
+            effects = SetTargetPopulation value = Value - Target.HabitableSize
     ]
     icon = "icons/building/blackhole.png"
 

--- a/default/scripting/buildings/TERRAFORM.focs.txt
+++ b/default/scripting/buildings/TERRAFORM.focs.txt
@@ -1,7 +1,7 @@
 BuildingType
     name = "BLD_TERRAFORM"
     description = "BLD_TERRAFORM_DESC"
-    buildcost = 100 * (Target.SizeAsDouble * (1 + Target.DistanceFromOriginalType) ) * [[BUILDING_COST_MULTIPLIER]]
+    buildcost = 100 * (Target.HabitableSize * (1 + Target.DistanceFromOriginalType) ) * [[BUILDING_COST_MULTIPLIER]]
     buildtime = 8
     location = And [
         Planet

--- a/default/scripting/game_rules.focs.txt
+++ b/default/scripting/game_rules.focs.txt
@@ -56,3 +56,66 @@ GameRule
     type = String
     default = "PLAYER"
     allowed = ["MODERATOR" "OBSERVER" "PLAYER" "AI_PLAYER"]
+
+GameRule
+    name = "RULE_HABITABLE_SIZE_TINY"
+    description = "RULE_HABITABLE_SIZE_DESC"
+    category = "PLANET_SIZE"
+    type = Integer
+    default = 1
+    min = 0
+    max = 999
+
+GameRule
+    name = "RULE_HABITABLE_SIZE_SMALL"
+    description = "RULE_HABITABLE_SIZE_DESC"
+    category = "PLANET_SIZE"
+    type = Integer
+    default = 2
+    min = 0
+    max = 999
+
+GameRule
+    name = "RULE_HABITABLE_SIZE_MEDIUM"
+    description = "RULE_HABITABLE_SIZE_DESC"
+    category = "PLANET_SIZE"
+    type = Integer
+    default = 3
+    min = 0
+    max = 999
+
+GameRule
+    name = "RULE_HABITABLE_SIZE_LARGE"
+    description = "RULE_HABITABLE_SIZE_DESC"
+    category = "PLANET_SIZE"
+    type = Integer
+    default = 4
+    min = 0
+    max = 999
+
+GameRule
+    name = "RULE_HABITABLE_SIZE_HUGE"
+    description = "RULE_HABITABLE_SIZE_DESC"
+    category = "PLANET_SIZE"
+    type = Integer
+    default = 5
+    min = 0
+    max = 999
+
+GameRule
+    name = "RULE_HABITABLE_SIZE_ASTEROIDS"
+    description = "RULE_HABITABLE_SIZE_DESC"
+    category = "PLANET_SIZE"
+    type = Integer
+    default = 3
+    min = 0
+    max = 999
+
+GameRule
+    name = "RULE_HABITABLE_SIZE_GASGIANT"
+    description = "RULE_HABITABLE_SIZE_DESC"
+    category = "PLANET_SIZE"
+    type = Integer
+    default = 6
+    min = 0
+    max = 999

--- a/default/scripting/specials/planet/GAIA.focs.txt
+++ b/default/scripting/specials/planet/GAIA.focs.txt
@@ -50,7 +50,7 @@ Special
             ]
             priority = [[EARLY_TARGET_POPULATION_PRIORITY]]
             effects = [
-                SetTargetPopulation value = Value + 3 * Target.SizeAsDouble accountinglabel = "GAIA_LABEL"
+                SetTargetPopulation value = Value + 3 * Target.HabitableSize accountinglabel = "GAIA_LABEL"
                 SetTargetHappiness value = Value + 5 accountinglabel = "GAIA_LABEL"
             ]
 

--- a/default/scripting/specials/planet/TEMPORAL_ANOMOLY.focs.txt
+++ b/default/scripting/specials/planet/TEMPORAL_ANOMOLY.focs.txt
@@ -21,7 +21,7 @@ Special
         EffectsGroup
             scope = Object id = Source.PlanetID
             priority = [[EARLY_TARGET_POPULATION_PRIORITY]]
-            effects = SetTargetPopulation value = Value - 5 * Target.SizeAsDouble accountinglabel = "TEMPORAL_ANOMALY_SPECIAL"
+            effects = SetTargetPopulation value = Value - 5 * Target.HabitableSize accountinglabel = "TEMPORAL_ANOMALY_SPECIAL"
     ]
     graphic = "icons/specials_huge/temporal_anomaly.png"
 

--- a/default/scripting/specials/planet/TIDAL_LOCK.focs.txt
+++ b/default/scripting/specials/planet/TIDAL_LOCK.focs.txt
@@ -22,7 +22,7 @@ Special
         EffectsGroup
             scope = Object id = Source.PlanetID
             priority = [[EARLY_TARGET_POPULATION_PRIORITY]]
-            effects = SetTargetPopulation value = Value - 1 * Target.SizeAsDouble accountinglabel = "TIDAL_LOCK_LABEL"
+            effects = SetTargetPopulation value = Value - 1 * Target.HabitableSize accountinglabel = "TIDAL_LOCK_LABEL"
     ]
     graphic = "icons/specials_huge/tidal_lock.png"
 

--- a/default/scripting/specials/planet/growth/growth.macros
+++ b/default/scripting/specials/planet/growth/growth.macros
@@ -41,7 +41,7 @@ POPULATION_BOOST_ORGANIC
             stackinggroup = "@1@_STACK"
             accountinglabel = "GROWTH_SPECIAL_LABEL"
             priority = [[EARLY_TARGET_POPULATION_PRIORITY]]
-            effects = SetTargetPopulation value = Value + 1 * Target.SizeAsDouble
+            effects = SetTargetPopulation value = Value + 1 * Target.HabitableSize
 
         EffectsGroup
             description = "GROWTH_SPECIAL_POPULATION_ORGANIC_INCREASE"
@@ -51,7 +51,7 @@ POPULATION_BOOST_ORGANIC
             ]
             stackinggroup = "@1@_STACK"
             priority = [[EARLY_TARGET_POPULATION_PRIORITY]]
-            effects = SetTargetPopulation value = Value + 1 * Target.SizeAsDouble  // Provides the bonus locally, no matter the focus
+            effects = SetTargetPopulation value = Value + 1 * Target.HabitableSize  // Provides the bonus locally, no matter the focus
 '''
 
 // argument 1 is the name of the used stacking group
@@ -68,7 +68,7 @@ POPULATION_BOOST_ROBOTIC
             stackinggroup = "@1@_STACK"
             accountinglabel = "GROWTH_SPECIAL_LABEL"
             priority = [[EARLY_TARGET_POPULATION_PRIORITY]]
-            effects = SetTargetPopulation value = Value + 1 * Target.SizeAsDouble
+            effects = SetTargetPopulation value = Value + 1 * Target.HabitableSize
 
         EffectsGroup
             description = "GROWTH_SPECIAL_POPULATION_ROBOTIC_INCREASE"
@@ -78,7 +78,7 @@ POPULATION_BOOST_ROBOTIC
             ]
             stackinggroup = "@1@_STACK"
             priority = [[EARLY_TARGET_POPULATION_PRIORITY]]
-            effects = SetTargetPopulation value = Value + 1 * Target.SizeAsDouble  // Provides the bonus locally, no matter the focus
+            effects = SetTargetPopulation value = Value + 1 * Target.HabitableSize  // Provides the bonus locally, no matter the focus
 '''
 
 // argument 1 is the name of the used stacking group
@@ -95,7 +95,7 @@ POPULATION_BOOST_LITHIC
             stackinggroup = "@1@_STACK"
             accountinglabel = "GROWTH_SPECIAL_LABEL"
             priority = [[EARLY_TARGET_POPULATION_PRIORITY]]
-            effects = SetTargetPopulation value = Value + 1 * Target.SizeAsDouble
+            effects = SetTargetPopulation value = Value + 1 * Target.HabitableSize
 
         EffectsGroup
             description = "GROWTH_SPECIAL_POPULATION_LITHIC_INCREASE"
@@ -105,7 +105,7 @@ POPULATION_BOOST_LITHIC
             ]
             stackinggroup = "@1@_STACK"
             priority = [[VERY_LATE_PRIORITY]]
-            effects = SetTargetPopulation value = Value + 1 * Target.SizeAsDouble  // Provides the bonus locally, no matter the focus
+            effects = SetTargetPopulation value = Value + 1 * Target.HabitableSize  // Provides the bonus locally, no matter the focus
 '''
 
 #include "/scripting/common/base_prod.macros"

--- a/default/scripting/species/SP_BANFORO.focs.txt
+++ b/default/scripting/species/SP_BANFORO.focs.txt
@@ -37,7 +37,7 @@ Species
             ]
             accountinglabel = "VERY_BRIGHT_STAR"
             priority = [[EARLY_TARGET_POPULATION_PRIORITY]]
-            effects = SetTargetPopulation value = Value - 2 * Source.SizeAsDouble
+            effects = SetTargetPopulation value = Value - 2 * Source.HabitableSize
 
         EffectsGroup
             scope = Source
@@ -47,7 +47,7 @@ Species
             ]
             accountinglabel = "BRIGHT_STAR"
             priority = [[EARLY_TARGET_POPULATION_PRIORITY]]
-            effects = SetTargetPopulation value = Value - Source.SizeAsDouble
+            effects = SetTargetPopulation value = Value - Source.HabitableSize
 
         // not for description
         [[AVERAGE_PLANETARY_SHIELDS]]

--- a/default/scripting/species/common/population.macros
+++ b/default/scripting/species/common/population.macros
@@ -76,7 +76,7 @@ ENVIRONMENT_MODIFIER
                 Planet environment = Hostile
             ]
             priority = [[EARLY_PRIORITY]]
-            effects = SetTargetPopulation value = Value - 4 * Source.SizeAsDouble accountinglabel = "HOSTILE_ENVIRONMENT_LABEL"
+            effects = SetTargetPopulation value = Value - 4 * Source.HabitableSize accountinglabel = "HOSTILE_ENVIRONMENT_LABEL"
 
         EffectsGroup
             scope = Source
@@ -85,7 +85,7 @@ ENVIRONMENT_MODIFIER
                 Planet environment = Poor
             ]
             priority = [[EARLY_PRIORITY]]
-            effects = SetTargetPopulation value = Value - 2 * Source.SizeAsDouble accountinglabel = "POOR_ENVIRONMENT_LABEL"
+            effects = SetTargetPopulation value = Value - 2 * Source.HabitableSize accountinglabel = "POOR_ENVIRONMENT_LABEL"
 
 /*        EffectsGroup
             scope = Source
@@ -93,14 +93,14 @@ ENVIRONMENT_MODIFIER
                 Planet
                 Planet environment = Adequate
             ]
-            effects = SetTargetPopulation value = Value + 0 * Source.SizeAsDouble accountinglabel = "ADEQUATE_ENVIRONMENT_LABEL"
+            effects = SetTargetPopulation value = Value + 0 * Source.HabitableSize accountinglabel = "ADEQUATE_ENVIRONMENT_LABEL"
 */
 
         EffectsGroup
             scope = Source
             activation = Planet environment = Good
             priority = [[EARLY_PRIORITY]]
-            effects = SetTargetPopulation value = Value + 3 * Target.SizeAsDouble accountinglabel = "GOOD_ENVIRONMENT_LABEL"
+            effects = SetTargetPopulation value = Value + 3 * Target.HabitableSize accountinglabel = "GOOD_ENVIRONMENT_LABEL"
 '''
 
 HOMEWORLD_BONUS_POPULATION
@@ -112,7 +112,7 @@ HOMEWORLD_BONUS_POPULATION
             activation = Planet
             stackinggroup = "HOMEWORLD_STACK"
             priority = [[VERY_LATE_PRIORITY]]
-            effects = SetTargetPopulation value = Value + 2 * Target.SizeAsDouble accountinglabel = "HOMEWORLD_BONUS"
+            effects = SetTargetPopulation value = Value + 2 * Target.HabitableSize accountinglabel = "HOMEWORLD_BONUS"
 '''
 
 HOMEWORLD_GROWTH_FOCUS_BOOST
@@ -131,7 +131,7 @@ HOMEWORLD_GROWTH_FOCUS_BOOST
             ]
             stackinggroup = "HOMEWORLD_STACK"
             priority = [[VERY_LATE_PRIORITY]]
-            effects = SetTargetPopulation value = Value + 1 * Target.SizeAsDouble accountinglabel = "HOMEWORLD_SUPPLY"
+            effects = SetTargetPopulation value = Value + 1 * Target.HabitableSize accountinglabel = "HOMEWORLD_SUPPLY"
 '''
 
 // This is dependent on current placement in population effects calc,
@@ -145,7 +145,7 @@ SELF_SUSTAINING_BONUS
             ]
             accountinglabel = "SELF_SUSTAINING_LABEL"
             priority = [[VERY_LATE_PRIORITY]]
-            effects = SetTargetPopulation value = Value + 3 * Target.SizeAsDouble  // Gets the same bonus as three growth specials
+            effects = SetTargetPopulation value = Value + 3 * Target.HabitableSize  // Gets the same bonus as three growth specials
 '''
 
 PHOTOTROPHIC_BONUS
@@ -173,7 +173,7 @@ PHOTOTROPHIC_BONUS
             ]
             accountinglabel = "VERY_BRIGHT_STAR"
             priority = [[EARLY_POPULATION_PRIORITY]]
-            effects = SetTargetPopulation value = Value + 3 * Source.SizeAsDouble
+            effects = SetTargetPopulation value = Value + 3 * Source.HabitableSize
 
         EffectsGroup
             scope = Source
@@ -185,7 +185,7 @@ PHOTOTROPHIC_BONUS
             ]
             accountinglabel = "BRIGHT_STAR"
             priority = [[EARLY_POPULATION_PRIORITY]]
-            effects = SetTargetPopulation value = Value + 1.5 * Source.SizeAsDouble
+            effects = SetTargetPopulation value = Value + 1.5 * Source.HabitableSize
 
         EffectsGroup
             scope = Source
@@ -196,7 +196,7 @@ PHOTOTROPHIC_BONUS
             ]
             accountinglabel = "DIM_STAR"
             priority = [[EARLY_TARGET_POPULATION_PRIORITY]]
-            effects = SetTargetPopulation value = Value - 1 * Source.SizeAsDouble
+            effects = SetTargetPopulation value = Value - 1 * Source.HabitableSize
 
         EffectsGroup
             scope = Source
@@ -207,7 +207,7 @@ PHOTOTROPHIC_BONUS
             ]
             accountinglabel = "NO_STAR"
             priority = [[EARLY_POPULATION_PRIORITY]]
-            effects = SetTargetPopulation value = Value - 10 * Source.SizeAsDouble
+            effects = SetTargetPopulation value = Value - 10 * Source.HabitableSize
 '''
 
 // @1@ Species key

--- a/default/scripting/species/common/xenophobic.macros
+++ b/default/scripting/species/common/xenophobic.macros
@@ -56,7 +56,7 @@ XENOPHOBIC_SELF
             priority = [[LATE_PRIORITY]]
             effects = SetTargetPopulation value = Value - min(
                     max(Value, 0) * 0.4 * (1 - 0.8^[[XENOPHOBIC_SELFSUSTAINING_QUALIFYING_PLANET_COUNT]]),
-                    3 * Target.SizeAsDouble  // Cap malus at the self-sustaining bonus
+                    3 * Target.HabitableSize  // Cap malus at the self-sustaining bonus
                 )
 '''
 

--- a/default/scripting/techs/construction/N_DIMEN_STRUCT.focs.txt
+++ b/default/scripting/techs/construction/N_DIMEN_STRUCT.focs.txt
@@ -20,7 +20,7 @@ Tech
             priority = [[EARLY_TARGET_POPULATION_PRIORITY]]
             effects = [
                 SetTargetConstruction value = Value + 10
-                SetTargetPopulation value = Value + 2 * Target.SizeAsDouble
+                SetTargetPopulation value = Value + 2 * Target.HabitableSize
             ]
     ]
     graphic = "icons/tech/n-dimensional_structures.png"

--- a/default/scripting/techs/growth/CYBORG.focs.txt
+++ b/default/scripting/techs/growth/CYBORG.focs.txt
@@ -15,7 +15,7 @@ Tech
                 Planet environment = [ Hostile ]
             ]
             priority = [[EARLY_TARGET_POPULATION_PRIORITY]]
-            effects = SetTargetPopulation value = Value + 2 * Target.SizeAsDouble  accountinglabel = "GRO_CYBORG"
+            effects = SetTargetPopulation value = Value + 2 * Target.HabitableSize  accountinglabel = "GRO_CYBORG"
 
         EffectsGroup
             scope = And [

--- a/default/scripting/techs/growth/ORBITAL_HAB.focs.txt
+++ b/default/scripting/techs/growth/ORBITAL_HAB.focs.txt
@@ -14,7 +14,7 @@ Tech
                 OwnedBy empire = Source.Owner
             ]
             priority = [[EARLY_TARGET_POPULATION_PRIORITY]]
-            effects = SetTargetPopulation value = Value + 1 * Target.SizeAsDouble accountinglabel = "ORBITAL_HAB_LABEL"
+            effects = SetTargetPopulation value = Value + 1 * Target.HabitableSize accountinglabel = "ORBITAL_HAB_LABEL"
     ]
     graphic = "icons/tech/orbital_gardens.png"
 

--- a/default/scripting/techs/growth/SUBTER_HAB.focs.txt
+++ b/default/scripting/techs/growth/SUBTER_HAB.focs.txt
@@ -14,7 +14,7 @@ Tech
                 OwnedBy empire = Source.Owner
             ]
             priority = [[EARLY_TARGET_POPULATION_PRIORITY]]
-            effects = SetTargetPopulation value = Value + 1 * Target.SizeAsDouble accountinglabel = "GRO_SUBTER_HAB"
+            effects = SetTargetPopulation value = Value + 1 * Target.HabitableSize accountinglabel = "GRO_SUBTER_HAB"
     ]
     graphic = "icons/tech/subterranean_construction.png"
 

--- a/default/scripting/techs/growth/SYMBIOTIC_BIO.focs.txt
+++ b/default/scripting/techs/growth/SYMBIOTIC_BIO.focs.txt
@@ -19,7 +19,7 @@ Tech
                 ]
             ]
             priority = [[EARLY_TARGET_POPULATION_PRIORITY]]
-            effects = SetTargetPopulation value = Value + 1 * Target.SizeAsDouble accountinglabel = "GRO_SYMBIOTIC_BIO"
+            effects = SetTargetPopulation value = Value + 1 * Target.HabitableSize accountinglabel = "GRO_SYMBIOTIC_BIO"
     ]
     graphic = "icons/tech/symbiosis_biology.png"
 

--- a/default/scripting/techs/growth/XENO_GENETICS.focs.txt
+++ b/default/scripting/techs/growth/XENO_GENETICS.focs.txt
@@ -21,7 +21,7 @@ Tech
                 ]
             ]
             priority = [[EARLY_TARGET_POPULATION_PRIORITY]]
-            effects = SetTargetPopulation value = Value + 2 * Target.SizeAsDouble accountinglabel = "GRO_XENO_GENETICS"
+            effects = SetTargetPopulation value = Value + 2 * Target.HabitableSize accountinglabel = "GRO_XENO_GENETICS"
         EffectsGroup
             scope = And [
                 Planet
@@ -29,7 +29,7 @@ Tech
                 Planet environment = [ Hostile ]
             ]
             priority = [[EARLY_TARGET_POPULATION_PRIORITY]]
-            effects = SetTargetPopulation value = Value + 1 * Target.SizeAsDouble accountinglabel = "GRO_XENO_GENETICS"
+            effects = SetTargetPopulation value = Value + 1 * Target.HabitableSize accountinglabel = "GRO_XENO_GENETICS"
     ]
     graphic = "icons/tech/xenological_genetics.png"
 

--- a/default/scripting/techs/growth/XENO_HYBRIDS.focs.txt
+++ b/default/scripting/techs/growth/XENO_HYBRIDS.focs.txt
@@ -15,7 +15,7 @@ Tech
                 Planet environment = [ Poor ]
             ]
             priority = [[EARLY_TARGET_POPULATION_PRIORITY]]
-            effects = SetTargetPopulation value = Value + 1 * Target.SizeAsDouble accountinglabel = "GRO_XENO_HYBRIDS"
+            effects = SetTargetPopulation value = Value + 1 * Target.HabitableSize accountinglabel = "GRO_XENO_HYBRIDS"
 
         EffectsGroup
             scope = And [
@@ -24,7 +24,7 @@ Tech
                 Planet environment = [ Hostile ]
             ]
             priority = [[EARLY_TARGET_POPULATION_PRIORITY]]
-            effects = SetTargetPopulation value = Value + 2 * Target.SizeAsDouble accountinglabel = "GRO_XENO_HYBRIDS"
+            effects = SetTargetPopulation value = Value + 2 * Target.HabitableSize accountinglabel = "GRO_XENO_HYBRIDS"
     ]
     graphic = "icons/tech/xenological_hybridization.png"
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1102,6 +1102,30 @@ Starlanes Everywhere
 RULE_STARLANES_EVERYWHERE_DESC
 Starlanes are generated between every pair of systems, regardless of geometry. Lanes may still be removed during a game, however. Lanes are also not rendered on the galaxy map.
 
+RULE_HABITABLE_SIZE_TINY
+Tiny planets Habitable size
+
+RULE_HABITABLE_SIZE_SMALL
+Small planets Habitable size
+
+RULE_HABITABLE_SIZE_MEDIUM
+Medium planets Habitable size
+
+RULE_HABITABLE_SIZE_LARGE
+Large planets Habitable size
+
+RULE_HABITABLE_SIZE_HUGE
+Huge planets Habitable size
+
+RULE_HABITABLE_SIZE_ASTEROIDS
+Asteroids Habitable size
+
+RULE_HABITABLE_SIZE_GASGIANT
+Gas Giants Habitable size
+
+RULE_HABITABLE_SIZE_DESC
+Value used to adjust for [[encyclopedia POPULATION_TITLE_SHORT_DESC]] changes on a planet of this size.
+
 
 ##
 ## Command-line and options database entries

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -6019,6 +6019,9 @@ Arrived on Turn
 SIZE_AS_DOUBLE
 Size As Number
 
+HABITABLE_SIZE
+Habitable Size
+
 DISTANCE_FROM_ORIGINAL_TYPE
 Distance From Original Planet Type
 

--- a/parse/DoubleValueRefParser.cpp
+++ b/parse/DoubleValueRefParser.cpp
@@ -47,6 +47,7 @@ parse::detail::simple_double_parser_rules::simple_double_parser_rules(const pars
         |   tok.X_
         |   tok.Y_
         |   tok.SizeAsDouble_
+        |   tok.HabitableSize_
         |   tok.Size_
         |   tok.DistanceFromOriginalType_
         |   tok.Attack_

--- a/parse/Tokens.h
+++ b/parse/Tokens.h
@@ -153,6 +153,7 @@
     (GiveEmpireTech)                            \
     (Good)                                      \
     (Graphic)                                   \
+    (HabitableSize)                             \
     (Happiness)                                 \
     (HasSpecial)                                \
     (HasSpecialCapacity)                        \

--- a/python/UniverseWrapper.cpp
+++ b/python/UniverseWrapper.cpp
@@ -684,6 +684,7 @@ namespace FreeOrionPython {
             .add_property("LastTurnAttackedByShip",         &Planet::LastTurnAttackedByShip)
             .add_property("LastTurnConquered",              &Planet::LastTurnConquered)
             .add_property("buildingIDs",                    make_function(&Planet::BuildingIDs,     return_internal_reference<>()))
+            .add_property("habitableSize",                  &Planet::HabitableSize)
         ;
 
         //////////////////

--- a/test/parse/TestValueRefDoubleParser.cpp
+++ b/test/parse/TestValueRefDoubleParser.cpp
@@ -140,6 +140,7 @@ const std::array<std::string, 36> ValueRefDoubleFixture::attributes = {{
     "X",
     "Y",
     "SizeAsDouble",
+    "HabitableSize",
     "NextTurnPopGrowth",
     "Size",
     "DistanceFromOriginalType"

--- a/universe/Planet.cpp
+++ b/universe/Planet.cpp
@@ -11,6 +11,7 @@
 #include "ValueRef.h"
 #include "Enums.h"
 #include "../util/Logger.h"
+#include "../util/MultiplayerCommon.h"
 #include "../util/OptionsDB.h"
 #include "../util/Random.h"
 #include "../util/Directories.h"
@@ -200,15 +201,16 @@ std::string Planet::Dump(unsigned short ntabs) const {
     return os.str();
 }
 
-int Planet::SizeAsInt() const {
+int Planet::HabitableSize() const {
+    const auto& gr = GetGameRules();
     switch (m_size) {
-    case SZ_GASGIANT:   return 6;   break;
-    case SZ_HUGE:       return 5;   break;
-    case SZ_LARGE:      return 4;   break;
-    case SZ_MEDIUM:     return 3;   break;
-    case SZ_ASTEROIDS:  return 3;   break;
-    case SZ_SMALL:      return 2;   break;
-    case SZ_TINY:       return 1;   break;
+    case SZ_GASGIANT:   return gr.Get<int>("RULE_HABITABLE_SIZE_GASGIANT");   break;
+    case SZ_HUGE:       return gr.Get<int>("RULE_HABITABLE_SIZE_HUGE");   break;
+    case SZ_LARGE:      return gr.Get<int>("RULE_HABITABLE_SIZE_LARGE");   break;
+    case SZ_MEDIUM:     return gr.Get<int>("RULE_HABITABLE_SIZE_MEDIUM");   break;
+    case SZ_ASTEROIDS:  return gr.Get<int>("RULE_HABITABLE_SIZE_ASTEROIDS");   break;
+    case SZ_SMALL:      return gr.Get<int>("RULE_HABITABLE_SIZE_SMALL");   break;
+    case SZ_TINY:       return gr.Get<int>("RULE_HABITABLE_SIZE_TINY");   break;
     default:            return 0;   break;
     }
 }

--- a/universe/Planet.h
+++ b/universe/Planet.h
@@ -40,7 +40,7 @@ public:
     PlanetType          OriginalType() const                { return m_original_type; }
     int                 DistanceFromOriginalType() const    { return TypeDifference(m_type, m_original_type); }
     PlanetSize          Size() const                        { return m_size; }
-    int                 SizeAsInt() const;
+    int                 HabitableSize() const;
 
     bool                HostileToEmpire(int empire_id) const override;
 

--- a/universe/ValueRef.cpp
+++ b/universe/ValueRef.cpp
@@ -732,6 +732,10 @@ double Variable<double>::Eval(const ScriptingContext& context) const
         if (auto planet = std::dynamic_pointer_cast<const Planet>(object))
             return planet->Size();
 
+    } else if (property_name == "HabitableSize") {
+        if (auto planet = std::dynamic_pointer_cast<const Planet>(object))
+            return planet->HabitableSize();
+
     } else if (property_name == "DistanceFromOriginalType") {
         if (auto planet = std::dynamic_pointer_cast<const Planet>(object))
             return planet->DistanceFromOriginalType();

--- a/universe/ValueRef.cpp
+++ b/universe/ValueRef.cpp
@@ -730,7 +730,7 @@ double Variable<double>::Eval(const ScriptingContext& context) const
 
     } else if (property_name == "SizeAsDouble") {
         if (auto planet = std::dynamic_pointer_cast<const Planet>(object))
-            return planet->SizeAsInt();
+            return planet->Size();
 
     } else if (property_name == "DistanceFromOriginalType") {
         if (auto planet = std::dynamic_pointer_cast<const Planet>(object))


### PR DESCRIPTION
Provides `Planet::HabitableSize` defined from game rules.

Changes `SizeAsDouble` value ref to return `PlanetSize` implicitly cast to double.

Replaces existing uses of `SizeAsDouble` in FOCS definitions with new `HabitableSize`, for consistency with previous values.

Initial discussion https://github.com/freeorion/freeorion/pull/1963#discussion_r165982968

Resolves #1975 

Minor conflict with #1869 #1963

@freeorion/ai-team I've only changed the comment of planet_size_map and exposed `habitableSize`, might be worth reviewing uses of `planetSize`.