### PR TITLE
Fix AI being kicked out from multiplayer lobby.

### DIFF
--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -609,6 +609,10 @@ sc::result MPLobby::react(const Disconnection& d) {
     // if the disconnected player wasn't in the lobby, don't need to do anything more.
     // if player is in lobby, need to remove it
     int id = player_connection->PlayerID();
+    if (id == Networking::INVALID_PLAYER_ID) {
+        DebugLogger(FSM) << "MPLobby.Disconnection : Disconnecting player (" << id << ") was not established";
+        return discard_event();
+    }
     bool player_was_in_lobby = false;
     for (auto it = m_lobby_data->m_players.begin();
          it != m_lobby_data->m_players.end(); ++it)

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -609,7 +609,7 @@ sc::result MPLobby::react(const Disconnection& d) {
     // if the disconnected player wasn't in the lobby, don't need to do anything more.
     // if player is in lobby, need to remove it
     int id = player_connection->PlayerID();
-    // if player was not etablished disconnect him as AI also have player_id is Networking::INVALID_PLAYER_ID
+    // Non-established player shouldn't be processed because it wasn't in lobby and AI entries have same id (INVALID_PLAYER_ID).
     if (id == Networking::INVALID_PLAYER_ID) {
         DebugLogger(FSM) << "MPLobby.Disconnection : Disconnecting player (" << id << ") was not established";
         return discard_event();

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -609,6 +609,7 @@ sc::result MPLobby::react(const Disconnection& d) {
     // if the disconnected player wasn't in the lobby, don't need to do anything more.
     // if player is in lobby, need to remove it
     int id = player_connection->PlayerID();
+    // if player was not etablished disconnect him as AI also have player_id is Networking::INVALID_PLAYER_ID
     if (id == Networking::INVALID_PLAYER_ID) {
         DebugLogger(FSM) << "MPLobby.Disconnection : Disconnecting player (" << id << ") was not established";
         return discard_event();


### PR DESCRIPTION
When multiplayer lobby kick out a player before he will be established e.g. for insufficient roles the server also kick out all AI from lobby because them have same player id (-1).