### PR TITLE
Update pytest run

### DIFF
--- a/default/python/tests/README.md
+++ b/default/python/tests/README.md
@@ -7,11 +7,9 @@ This test are supposed to be run outside the game engine.
 
 ## Run test
  - open console (`cmd` or `PowerShell` for win)
- - change dir to `freeorion\default\python\tests`
- - execute  `run_tests.py` with python
-   - `python run_tests.py` for windows
-   - `./run_tests.py` for linux and mac
+ - execute  `pytest`
 
- `run_tests.py` accepts same commandline arguments as pytest. I prefer to add `-v --tb long`
- 
- `run_tests.py` adds required directories to python path and runs pytest.  
+If you want to run specific tests see [pytest documentation](https://docs.pytest.org/en/latest/usage.html#specifying-tests-selecting-tests)
+
+If you need to test module that is not in python path, add its to  `conftest.py`,
+this file is executed before import of the test files. 

--- a/default/python/tests/conftest.py
+++ b/default/python/tests/conftest.py
@@ -1,16 +1,13 @@
-#!/usr/bin/env python2.7
+"""
+Config for tests inside this directory.
+https://docs.pytest.org/en/2.7.3/plugins.html?highlight=re#working-with-plugins-and-conftest-files
+"""
 
 import os
 import sys
-import pytest
 
 this_dir = os.path.dirname(__file__)
 
-# add path to AI
 sys.path.append(os.path.join(this_dir, '..', '..', 'python', 'AI/'))
-# path to freeOrionAIInterface mock
 sys.path.append(os.path.join(this_dir, '..', '..', 'python', 'interface_mock', 'result'))
-# add path to common tools
 sys.path.append(os.path.join(this_dir, '..', '..', 'python'))
-
-pytest.main(sys.argv[1:])


### PR DESCRIPTION
It is port of changes in pytest from https://github.com/freeorion/freeorion/pull/1970, I need this for future changes. 

This line will bacame obsolet after https://github.com/freeorion/freeorion/pull/1990, but it will not cause any harm, I will remove it later.
`sys.path.append(os.path.join(this_dir, '..', '..', 'python', 'interface_mock', 'result'))` 