### PR TITLE
Dont show GASEOUS_DESC for all species

### DIFF
--- a/default/scripting/species/SP_SLY.focs.txt
+++ b/default/scripting/species/SP_SLY.focs.txt
@@ -40,6 +40,7 @@ Species
 
         // Extra refueling on gas giants
         EffectsGroup
+            description="GASEOUS_DESC"
             scope = Source
             activation = And [
                 Ship

--- a/default/scripting/species/SP_SLY.focs.txt
+++ b/default/scripting/species/SP_SLY.focs.txt
@@ -40,7 +40,7 @@ Species
 
         // Extra refueling on gas giants
         EffectsGroup
-            description="GASEOUS_DESC"
+            description = "GASEOUS_DESC"
             scope = Source
             activation = And [
                 Ship

--- a/default/scripting/species/common/population.macros
+++ b/default/scripting/species/common/population.macros
@@ -213,7 +213,6 @@ PHOTOTROPHIC_BONUS
 
 GASEOUS_BONUS
 '''     EffectsGroup
-            description = "GASEOUS_DESC"
             scope = Source
             activation = And [
                 Planet type = GasGiant


### PR DESCRIPTION
This PR moves the GASEOUS_DESC to an effect which is in the SP_SLY, before the sly boni were shown for all species