### PR TITLE
Add Game UID universe property.

### DIFF
--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -1212,7 +1212,8 @@ namespace {
                 % TextForGalaxySetupSetting(gsd.m_specials_freq)
                 % TextForGalaxySetupSetting(gsd.m_monster_freq)
                 % TextForGalaxySetupSetting(gsd.m_native_freq)
-                % TextForAIAggression(gsd.m_ai_aggr));
+                % TextForAIAggression(gsd.m_ai_aggr)
+                % gsd.m_game_uid);
 
             return;
         } else if (item_name == "ENC_GAME_RULES") {

--- a/default/python/universe_generation/universe_generator.py
+++ b/default/python/universe_generation/universe_generator.py
@@ -144,6 +144,19 @@ def create_universe(psd_map):
     seed_rng(seed_pool.pop())
     distribute_specials(gsd.specials_frequency, fo.get_all_objects())
 
+    # set game uid
+    empire_names = []
+    for psd in psd_map.values():
+        empire_names.append(psd.empire_name)
+
+    empire_names.sort()
+    for i, v in enumerate(empire_names):
+        empire_names[i] = v.capitalize()[:2]
+
+    fo.get_galaxy_setup_data().gameUID = "".join(empire_names) + str(random.randint(0,999)).zfill(3)
+
+    print "Game UID %s" % fo.get_galaxy_setup_data().gameUID
+
     # finally, write some statistics to the log file
     print "############################################################"
     print "##             Universe generation statistics             ##"

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -4497,6 +4497,7 @@ ENC_GALAXY_SETUP
 # %8% monster frequency in the current galaxy.
 # %9% natives frequency in the current galaxy.
 # %10% upper AI aggression level in this galaxy.
+# %11% game UID
 ENC_GALAXY_SETUP_SETTINGS
 '''Seed: %1%
 Number of Systems: %2%
@@ -4508,6 +4509,7 @@ Specials: %7%
 Monsters: %8%
 Natives: %9%
 AI Max Aggression: %10%
+Game UID: %11%
 '''
 
 ENC_GAME_RULES

--- a/default/stringtables/ru.txt
+++ b/default/stringtables/ru.txt
@@ -3782,6 +3782,7 @@ ENC_GALAXY_SETUP
 # %8% monster frequency in the current galaxy.
 # %9% natives frequency in the current galaxy.
 # %10% upper AI aggression level in this galaxy.
+# %11% game UID
 ENC_GALAXY_SETUP_SETTINGS
 '''Семя: %1%
 Количество систем: %2%
@@ -3793,6 +3794,7 @@ ENC_GALAXY_SETUP_SETTINGS
 Монстры: %8%
 Аборигены: %9%
 Макс. агрессивность ИИ: %10%
+Идентификатор игры: %11%
 '''
 
 ENC_SHIP_PART

--- a/python/UniverseWrapper.cpp
+++ b/python/UniverseWrapper.cpp
@@ -767,7 +767,9 @@ namespace FreeOrionPython {
             .add_property("specialsFrequency",  make_function(&GalaxySetupData::GetSpecialsFreq,    return_value_policy<return_by_value>()))
             .add_property("monsterFrequency",   make_function(&GalaxySetupData::GetMonsterFreq,     return_value_policy<return_by_value>()))
             .add_property("nativeFrequency",    make_function(&GalaxySetupData::GetNativeFreq,      return_value_policy<return_by_value>()))
-            .add_property("maxAIAggression",    make_function(&GalaxySetupData::GetAggression,      return_value_policy<return_by_value>()));
+            .add_property("maxAIAggression",    make_function(&GalaxySetupData::GetAggression,      return_value_policy<return_by_value>()))
+            .add_property("gameUID",            make_function(&GalaxySetupData::GetGameUID,         return_value_policy<return_by_value>()),
+                                                &GalaxySetupData::SetGameUID);
 
         //std::vector<std::pair<std::string, std::string>>
         class_<std::pair<std::string, std::string>>("RuleValueStringStringPair")

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -556,7 +556,7 @@ void ServerApp::NewSPGameInit(const SinglePlayerSetupData& single_player_setup_d
 
 bool ServerApp::VerifySPGameAIs(const SinglePlayerSetupData& single_player_setup_data) {
     const auto& player_setup_data = single_player_setup_data.m_players;
-    return NewGameInitVerifyJoiners(single_player_setup_data, player_setup_data);
+    return NewGameInitVerifyJoiners(player_setup_data);
 }
 
 void ServerApp::NewMPGameInit(const MultiplayerLobbyData& multiplayer_lobby_data) {
@@ -633,7 +633,7 @@ void ServerApp::NewMPGameInit(const MultiplayerLobbyData& multiplayer_lobby_data
     }
 
     NewGameInitConcurrentWithJoiners(multiplayer_lobby_data, psds);
-    if (NewGameInitVerifyJoiners(multiplayer_lobby_data, psds))
+    if (NewGameInitVerifyJoiners(psds))
         SendNewGameStartMessages();
 }
 
@@ -737,13 +737,8 @@ void ServerApp::NewGameInitConcurrentWithJoiners(
     m_universe.UpdateStatRecords();
 }
 
-bool ServerApp::NewGameInitVerifyJoiners(
-    const GalaxySetupData& galaxy_setup_data,
-    const std::vector<PlayerSetupData>& player_setup_data)
-{
+bool ServerApp::NewGameInitVerifyJoiners(const std::vector<PlayerSetupData>& player_setup_data) {
     DebugLogger() << "ServerApp::NewGameInitVerifyJoiners";
-
-    m_galaxy_setup_data = galaxy_setup_data;
 
     // associate player IDs with player setup data.  the player connection with
     // id == m_networking.HostPlayerID() should be the human player in

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -252,8 +252,7 @@ private:
                                              const std::vector<PlayerSetupData>& player_setup_data);
 
     /** Return true if player data is consistent with starting a new game. */
-    bool    NewGameInitVerifyJoiners(const GalaxySetupData& galaxy_setup_data,
-                                     const std::vector<PlayerSetupData>& player_setup_data);
+    bool    NewGameInitVerifyJoiners(const std::vector<PlayerSetupData>& player_setup_data);
 
     /** Sends out initial new game state to clients, and signals clients to start first turn. */
     void SendNewGameStartMessages();

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -2531,7 +2531,8 @@ sc::result ProcessingTurn::react(const ProcessTurn& u) {
     }
 
     if (server.IsHostless() && GetOptionsDB().Get<bool>("save.auto.hostless.enabled")) {
-        boost::filesystem::path autosave_dir_path = GetServerSaveDir() / "auto";
+        std::string subdir = GetGalaxySetupData().GetGameUID();
+        boost::filesystem::path autosave_dir_path = GetServerSaveDir() / (subdir.empty() ? "auto" : subdir);
         const auto& extension = MP_SAVE_FILE_EXTENSION;
         // Add timestamp to autosave generated files
         std::string datetime_str = FilenameTimestamp();

--- a/util/MultiplayerCommon.cpp
+++ b/util/MultiplayerCommon.cpp
@@ -282,7 +282,8 @@ GalaxySetupData::GalaxySetupData(GalaxySetupData&& base) :
     m_monster_freq(base.m_monster_freq),
     m_native_freq(base.m_native_freq),
     m_ai_aggr(base.m_ai_aggr),
-    m_game_rules(std::move(base.m_game_rules))
+    m_game_rules(std::move(base.m_game_rules)),
+    m_game_uid(std::move(base.m_game_uid))
 { SetSeed(m_seed); }
 
 const std::string& GalaxySetupData::GetSeed() const
@@ -340,6 +341,9 @@ Aggression GalaxySetupData::GetAggression() const
 const std::vector<std::pair<std::string, std::string>>& GalaxySetupData::GetGameRules() const
 { return m_game_rules; }
 
+const std::string& GalaxySetupData::GetGameUID() const
+{ return m_game_uid; }
+
 void GalaxySetupData::SetSeed(const std::string& seed) {
     std::string new_seed = seed;
     if (new_seed.empty() || new_seed == "RANDOM") {
@@ -350,6 +354,10 @@ void GalaxySetupData::SetSeed(const std::string& seed) {
         DebugLogger() << "Set empty or requested random seed to " << new_seed;
     }
     m_seed = new_seed;
+}
+
+void GalaxySetupData::SetGameUID(const std::string& game_uid) {
+    m_game_uid = game_uid;
 }
 
 /////////////////////////////////////////////////////

--- a/util/MultiplayerCommon.cpp
+++ b/util/MultiplayerCommon.cpp
@@ -356,9 +356,8 @@ void GalaxySetupData::SetSeed(const std::string& seed) {
     m_seed = new_seed;
 }
 
-void GalaxySetupData::SetGameUID(const std::string& game_uid) {
-    m_game_uid = game_uid;
-}
+void GalaxySetupData::SetGameUID(const std::string& game_uid)
+{ m_game_uid = game_uid; }
 
 /////////////////////////////////////////////////////
 // PlayerSetupData

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -183,10 +183,12 @@ struct FO_COMMON_API GalaxySetupData {
     Aggression          GetAggression() const;
     const std::vector<std::pair<std::string, std::string>>&
                         GetGameRules() const;
+    const std::string&  GetGameUID() const;
     //@}
 
     /** \name Mutators */ //@{
     void                SetSeed(const std::string& seed);
+    void                SetGameUID(const std::string& game_uid);
     //@}
 
     GalaxySetupData& operator=(const GalaxySetupData&) = default;
@@ -203,6 +205,7 @@ struct FO_COMMON_API GalaxySetupData {
     Aggression          m_ai_aggr;
     std::vector<std::pair<std::string, std::string>>
                         m_game_rules;
+    std::string         m_game_uid;
 
 private:
     friend class boost::serialization::access;
@@ -210,7 +213,7 @@ private:
     void serialize(Archive& ar, const unsigned int version);
 };
 
-BOOST_CLASS_VERSION(GalaxySetupData, 1);
+BOOST_CLASS_VERSION(GalaxySetupData, 2);
 
 extern template FO_COMMON_API void GalaxySetupData::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, const unsigned int);
 extern template FO_COMMON_API void GalaxySetupData::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, const unsigned int);

--- a/util/SerializeMultiplayerCommon.cpp
+++ b/util/SerializeMultiplayerCommon.cpp
@@ -5,7 +5,9 @@
 
 #include "Serialize.ipp"
 
+#include <random>
 #include <boost/date_time/posix_time/time_serialize.hpp>
+#include <boost/format.hpp>
 
 template <class Archive>
 void GalaxySetupData::serialize(Archive& ar, const unsigned int version)
@@ -23,6 +25,17 @@ void GalaxySetupData::serialize(Archive& ar, const unsigned int version)
 
     if (version >= 1) {
         ar & BOOST_SERIALIZATION_NVP(m_game_rules);
+    }
+
+    if (version >= 2) {
+        ar & BOOST_SERIALIZATION_NVP(m_game_uid);
+    } else {
+        if (Archive::is_loading::value) {
+            std::default_random_engine generator;
+            std::uniform_int_distribution<int> distribution(0,999);
+
+            m_game_uid = m_seed + (boost::format("%03i") % distribution(generator)).str();
+        }
     }
 }
 


### PR DESCRIPTION
This PR adds gameUID property to `Universe` class.
It allows to follow the game session in saved games and separate different game sessions.

Hostless mode uses subfolder based on gameUID instead of "auto" subfolder so it simplify find saves.

Current implementations simply uses random UUID from python on creating universe or from boost on loading legacy save files.