### PR TITLE
Display current value for troop parts in ship articles

### DIFF
--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -2150,7 +2150,7 @@ namespace {
             % ship->CurrentMeterValue(METER_STEALTH)
             % ship->CurrentMeterValue(METER_SPEED)
             % ship->CurrentMeterValue(METER_MAX_FUEL)
-            % design->ColonyCapacity()
+            % ship->SumCurrentPartMeterValuesForPartClass(METER_CAPACITY, PC_COLONY)
             % ship->SumCurrentPartMeterValuesForPartClass(METER_CAPACITY, PC_TROOPS)
             % ship->FighterMax()
             % (attack - ship->TotalWeaponsDamage(0.0f, false))

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -2151,7 +2151,7 @@ namespace {
             % ship->CurrentMeterValue(METER_SPEED)
             % ship->CurrentMeterValue(METER_MAX_FUEL)
             % design->ColonyCapacity()
-            % ship->TroopCapacity()
+            % ship->SumCurrentPartMeterValuesForPartClass(METER_CAPACITY, PC_TROOPS)
             % ship->FighterMax()
             % (attack - ship->TotalWeaponsDamage(0.0f, false))
             % ship->SumCurrentPartMeterValuesForPartClass(METER_MAX_CAPACITY, PC_FIGHTER_BAY)


### PR DESCRIPTION
Corrects display of troops in pedia articles.
master:
![fo_troop-master](https://user-images.githubusercontent.com/17205519/36359487-8da656c2-14e1-11e8-969e-904e60c0a341.png)

PR:
![fo_troop-pr](https://user-images.githubusercontent.com/17205519/36359488-90205fce-14e1-11e8-9a61-f39b3cd81df7.png)
