### PR TITLE
Revision of AI initial vs current meter usage

### DIFF
--- a/default/python/AI/AIFleetMission.py
+++ b/default/python/AI/AIFleetMission.py
@@ -510,16 +510,10 @@ class AIFleetMission(object):
                     if not threat_present and target_system:
                         for pid in target_system.planetIDs:
                             planet = universe.getPlanet(pid)
-                            if (planet and
-                                    planet.owner != fo.empireID() and
-                                    # Defense meters will in general always regenerate so currentMeterValue
-                                    # will always be greater than 0 as long as planet has some target defense.
-                                    # If we shot all the planets pretty much down and the regeneration is small,
-                                    # then we actually do want to release a few ships rather than having a fleet
-                                    # of possibly hundreds of ships stay idle at a system that has negligibly small
-                                    # threat.
-                                    # TODO: Check initialMeterValue here or actually estimate next turn threat
-                                    planet.currentMeterValue(fo.meterType.maxDefense) > 0):
+                            # using current meter here as we are checking if the planet could
+                            # possibly be a threat in the future. So use best prediction for that.
+                            is_potential_threat = planet.currentMeterValue(fo.meterType.maxDefense) > 0
+                            if planet and not planet.ownedBy(fo.empireID()) and is_potential_threat:
                                 threat_present = True
                                 break
                     if not threat_present:
@@ -621,7 +615,7 @@ class AIFleetMission(object):
         ships_max_health = 0
         for ship_id in fleet.shipIDs:
             this_ship = universe.getShip(ship_id)
-            # TODO: Should this check currentMeterValue to account for hull's regeneration?
+            # TODO: Predict if the ship will fight next turn. If not, use currentMeterValue to account for regeneration
             ships_cur_health += this_ship.initialMeterValue(fo.meterType.structure)
             ships_max_health += this_ship.initialMeterValue(fo.meterType.maxStructure)
         return ships_cur_health < repair_limit * ships_max_health

--- a/default/python/AI/AIFleetMission.py
+++ b/default/python/AI/AIFleetMission.py
@@ -512,6 +512,13 @@ class AIFleetMission(object):
                             planet = universe.getPlanet(pid)
                             if (planet and
                                     planet.owner != fo.empireID() and
+                                    # Defense meters will in general always regenerate so currentMeterValue
+                                    # will always be greater than 0 as long as planet has some target defense.
+                                    # If we shot all the planets pretty much down and the regeneration is small,
+                                    # then we actually do want to release a few ships rather than having a fleet
+                                    # of possibly hundreds of ships stay idle at a system that has negligibly small
+                                    # threat.
+                                    # TODO: Check initialMeterValue here or actually estimate next turn threat
                                     planet.currentMeterValue(fo.meterType.maxDefense) > 0):
                                 threat_present = True
                                 break
@@ -614,6 +621,7 @@ class AIFleetMission(object):
         ships_max_health = 0
         for ship_id in fleet.shipIDs:
             this_ship = universe.getShip(ship_id)
+            # TODO: Should this check currentMeterValue to account for hull's regeneration?
             ships_cur_health += this_ship.initialMeterValue(fo.meterType.structure)
             ships_max_health += this_ship.initialMeterValue(fo.meterType.maxStructure)
         return ships_cur_health < repair_limit * ships_max_health

--- a/default/python/AI/AIstate.py
+++ b/default/python/AI/AIstate.py
@@ -336,7 +336,7 @@ class AIstate(object):
         max_shields = planet.currentMeterValue(fo.meterType.maxShield)
         current_defense = planet.currentMeterValue(fo.meterType.defense)
         max_defense = planet.currentMeterValue(fo.meterType.maxDefense)
-        # TODO: Consider using current vs initial meter difference for regen estimate
+        # TODO: Use current vs initial meter difference for regen estimate
         shields = min(max_shields, current_shields + 2 * sighting_age)  # TODO: base off regen tech
         defense = min(max_defense, current_defense + 2 * sighting_age)  # TODO: base off regen tech
         return {'overall': defense * (defense + shields), 'attack': defense, 'health': (defense + shields)}

--- a/default/python/AI/AIstate.py
+++ b/default/python/AI/AIstate.py
@@ -336,6 +336,7 @@ class AIstate(object):
         max_shields = planet.currentMeterValue(fo.meterType.maxShield)
         current_defense = planet.currentMeterValue(fo.meterType.defense)
         max_defense = planet.currentMeterValue(fo.meterType.maxDefense)
+        # TODO: Consider using current vs initial meter difference for regen estimate
         shields = min(max_shields, current_shields + 2 * sighting_age)  # TODO: base off regen tech
         defense = min(max_defense, current_defense + 2 * sighting_age)  # TODO: base off regen tech
         return {'overall': defense * (defense + shields), 'attack': defense, 'health': (defense + shields)}

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -237,6 +237,7 @@ def survey_universe():
             spec_name = planet.speciesName
             this_spec = fo.getSpecies(spec_name)
             owner_id = planet.owner
+            # TODO: Shouldn't this be initial population meter?
             planet_population = planet.currentMeterValue(fo.meterType.population)
             buildings_here = [universe.getBuilding(bldg).buildingTypeName for bldg in planet.buildingIDs]
             ship_facilities = set(AIDependencies.SHIP_FACILITIES).intersection(buildings_here)
@@ -258,6 +259,9 @@ def survey_universe():
                             empire_ship_builders.setdefault(spec_name, []).append(pid)
                             empire_shipyards[pid] = pilot_val
                             yard_here = [pid]
+                        # TODO: Shouldn't this be initial meter?
+                        # If the population is >= only in the next turn but not now,
+                        # then we haven't reached colonization threshold yet...
                         if this_spec.canColonize and planet.currentMeterValue(fo.meterType.targetPopulation) >= 3:
                             empire_colonizers.setdefault(spec_name, []).extend(yard_here)
 
@@ -1012,6 +1016,10 @@ def evaluate_planet(planet_id, mission_type, spec_name, detail=None):
                 ind_mult += 1
             max_ind_factor += AIDependencies.INDUSTRY_PER_POP * mining_bonus
             max_ind_factor += AIDependencies.INDUSTRY_PER_POP * ind_mult
+
+        # using current over initial meter here to be consistent with the
+        # basically next-turn estimate that is the 1.0 (3.0) population
+        # estimate that would be given on the next turn after colonization
         cur_pop = 1.0  # assume an initial colonization value
         if planet.speciesName != "":
             cur_pop = planet.currentMeterValue(fo.meterType.population)

--- a/default/python/AI/CombatRatingsAI.py
+++ b/default/python/AI/CombatRatingsAI.py
@@ -120,10 +120,15 @@ class ShipCombatStats(object):
         if not ship:
             return  # TODO: Add some estimate for stealthed ships
 
+
         if self._consider_refuel:
+            # TODO: Shouldn't we use current meter here?
+            # We make a prediction into the future anyway, so probably should
+            # take the most accurate guess into the account...
             structure = ship.initialMeterValue(fo.meterType.maxStructure)
             shields = ship.initialMeterValue(fo.meterType.maxShield)
         else:
+            # We use initial meters here because they do not grow before combat
             structure = ship.initialMeterValue(fo.meterType.structure)
             shields = ship.initialMeterValue(fo.meterType.shield)
         attacks = {}
@@ -137,6 +142,7 @@ class ShipCombatStats(object):
                 if not partname:
                     continue
                 pc = get_part_type(partname).partClass
+                # TODO: Why are we using current and not initial meter in the following?
                 if pc == fo.shipPartClass.shortRange:
                     damage = ship.currentPartMeterValue(meter_choice, partname)
                     attacks[damage] = attacks.get(damage, 0) + 1

--- a/default/python/AI/FleetUtilsAI.py
+++ b/default/python/AI/FleetUtilsAI.py
@@ -568,6 +568,7 @@ def get_fighter_capacity_of_fleet(fleet_id):
         for partname in design_parts:
             part = get_part_type(partname)
             if part and part.partClass == fo.shipPartClass.fighterHangar:
+                # TODO: Shouldn't this be initial meter values to reflect this turn's values?
                 cur_capacity += ship.currentPartMeterValue(fo.meterType.capacity, partname)
                 max_capacity += ship.currentPartMeterValue(fo.meterType.maxCapacity, partname)
     return cur_capacity, max_capacity

--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -157,6 +157,7 @@ def get_invasion_fleets():
             if troop_tally > planet_troops:  # base troopers appear unneeded
                 del foAI.foAIstate.qualifyingTroopBaseTargets[pid]
                 continue
+            # TODO: Why use current meter here?
             if (planet.currentMeterValue(fo.meterType.shield) > 0 and
                     (this_sys_status.get('myFleetRating', 0) < 0.8 * this_sys_status.get('totalThreat', 0) or
                      this_sys_status.get('myFleetRatingVsPlanets', 0) < this_sys_status.get('planetThreat', 0))):
@@ -400,8 +401,10 @@ def evaluate_invasion_planet(planet_id, secure_fleet_missions, verbose=True):
             if path_leg_threat > max_path_threat:
                 max_path_threat = path_leg_threat
 
+    # TODO: Shouldn't this consider pop initial meter values to be consistent with calculation in assign_invasion_values()?
     pop = planet.currentMeterValue(fo.meterType.population)
     target_pop = planet.currentMeterValue(fo.meterType.targetPopulation)
+    # TODO: The code below seems to assume initial meter value, not current here
     troops = planet.currentMeterValue(fo.meterType.troops)
     max_troops = planet.currentMeterValue(fo.meterType.maxTroops)
     # TODO: refactor troop determination into function for use in mid-mission updates and also consider defender techs
@@ -429,10 +432,12 @@ def evaluate_invasion_planet(planet_id, secure_fleet_missions, verbose=True):
                " - maxShields: %.1f\n"
                " - sysFleetThreat: %.1f\n"
                " - sysMonsterThreat: %.1f") % (
+            # TODO: why current over initial?
             planet, planet.currentMeterValue(fo.meterType.maxShield), system_fleet_treat,
             system_monster_threat)
     enemy_val = 0
     if planet.owner != -1:  # value in taking this away from an enemy
+        # TODO: why current over initial? Seems inconsistent
         enemy_val = 20 * (planet.currentMeterValue(fo.meterType.targetIndustry) +
                           2*planet.currentMeterValue(fo.meterType.targetResearch))
 

--- a/default/python/AI/MilitaryAI.py
+++ b/default/python/AI/MilitaryAI.py
@@ -69,6 +69,7 @@ def avail_mil_needing_repair(mil_fleet_ids, split_ships=False, on_mission=False,
         ships_max_health = [0, 0]
         for ship_id in fleet.shipIDs:
             this_ship = universe.getShip(ship_id)
+            # TODO: Consider using current meter value here to account for self-repair
             cur_struc = this_ship.initialMeterValue(fo.meterType.structure)
             max_struc = this_ship.initialMeterValue(fo.meterType.maxStructure)
             ship_ok = cur_struc >= cutoff * max_struc

--- a/default/python/AI/MoveUtilsAI.py
+++ b/default/python/AI/MoveUtilsAI.py
@@ -129,6 +129,8 @@ def get_best_drydock_system_id(start_system_id, fleet_id):
         for pid in pids:
             planet = universe.getPlanet(pid)
             if (planet and
+                    # using current meter here to look one turn ahead is fine
+                    # the fleet may wait that one turn at target system...
                     planet.currentMeterValue(fo.meterType.happiness) >= DRYDOCK_HAPPINESS_THRESHOLD and
                     planet.currentMeterValue(fo.meterType.targetHappiness) >= DRYDOCK_HAPPINESS_THRESHOLD):
                 drydock_system_ids.add(sys_id)

--- a/default/python/AI/PriorityAI.py
+++ b/default/python/AI/PriorityAI.py
@@ -79,6 +79,7 @@ def _calculate_industry_priority():  # currently only used to print status
     industry_production = empire.resourceProduction(fo.resourceType.industry)
     owned_planet_ids = PlanetUtilsAI.get_owned_planets_by_empire(universe.planetIDs)
     planets = map(universe.getPlanet, owned_planet_ids)
+    # using current meter here to reflect potential focus changes
     target_pp = sum(map(lambda x: x.currentMeterValue(fo.meterType.targetIndustry), planets))
 
     # currently, previously set to 50 in calculatePriorities(), this is just for reporting
@@ -122,6 +123,7 @@ def _calculate_research_priority():
     # get current industry production & Target
     owned_planet_ids = PlanetUtilsAI.get_owned_planets_by_empire(universe.planetIDs)
     planets = map(universe.getPlanet, owned_planet_ids)
+    # using current meter here to reflect potential focus changes
     target_rp = sum(map(lambda x: x.currentMeterValue(fo.meterType.targetResearch), planets))
     galaxy_is_sparse = ColonisationAI.galaxy_is_sparse()
     enemies_sighted = foAI.foAIstate.misc.get('enemies_sighted', {})

--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -930,6 +930,7 @@ def generate_production_orders():
         if not planet:
             continue
         can_build_camp = building_type.canBeProduced(empire.empireID, pid) and empire.buildingTypeAvailable(building_name)
+        # TODO: Using initial meter for pop but current for industry seems incosistent
         t_pop = planet.initialMeterValue(fo.meterType.targetPopulation)
         c_pop = planet.initialMeterValue(fo.meterType.population)
         t_ind = planet.currentMeterValue(fo.meterType.targetIndustry)
@@ -967,6 +968,7 @@ def generate_production_orders():
                         old_focus = planet.focus
                         fo.issueChangeFocusOrder(pid, FocusType.FOCUS_INDUSTRY)
                         universe.updateMeterEstimates([pid])
+                        # using current meter here to reflect focus changes
                         t_ind = planet.currentMeterValue(fo.meterType.targetIndustry)
                         if c_ind >= t_ind + c_pop:
                             fo.issueChangeFocusOrder(pid, old_focus)
@@ -1011,6 +1013,7 @@ def generate_production_orders():
                 planet = universe.getPlanet(pid)
                 if not planet:
                     continue
+                # TODO: Why not initial meter value?
                 build_locs.append((planet.currentMeterValue(fo.meterType.maxTroops), pid))
             if not build_locs:
                 continue
@@ -1584,6 +1587,7 @@ def find_automatic_historic_analyzer_candidates():
     possible_locations = set()
     for pid in state.get_all_empire_planets():
         planet = universe.getPlanet(pid)
+        # using currentMeterValue here allows us to consider techs, growth specials etc. unlocked this turn
         if not planet or planet.currentMeterValue(fo.meterType.targetPopulation) < 1:
             continue
         buildings_here = [bld.buildingTypeName for bld in map(universe.getBuilding, planet.buildingIDs)]

--- a/default/python/AI/ResourcesAI.py
+++ b/default/python/AI/ResourcesAI.py
@@ -435,7 +435,8 @@ def set_planet_growth_specials(focus_manager):
 
             # the increased population on the planet using this growth focus
             # is mostly wasted, so ignore it for now.
-            # TODO: Do we want to use current meter here or initial?
+            # Using current meter here as focus will only be active next turn and because
+            # pop is more likely to grow than shrink also as the more conservative estimate.
             pop = planet.currentMeterValue(fo.meterType.population)
             pop_gain = potential_pop_increase - planet.habitableSize
             if pop > pop_gain:

--- a/default/python/AI/ResourcesAI.py
+++ b/default/python/AI/ResourcesAI.py
@@ -39,6 +39,7 @@ class PlanetFocusInfo(object):
     def __init__(self, planet):
         self.planet = planet
         self.current_focus = planet.focus
+        # TODO: Shouldn't this be initial meter values as this turn's output without focus changes?
         self.current_output = (planet.currentMeterValue(fo.meterType.industry),
                                planet.currentMeterValue(fo.meterType.research))
         self.possible_output = {}
@@ -86,6 +87,7 @@ class PlanetFocusManager(object):
             if update and pinfo.current_focus != focus:
                 universe = fo.getUniverse()
                 universe.updateMeterEstimates(self.raw_planet_info.keys())
+                # using current meter here to reflect focus changes
                 industry_target = pinfo.planet.currentMeterValue(fo.meterType.targetIndustry)
                 research_target = pinfo.planet.currentMeterValue(fo.meterType.targetResearch)
                 pinfo.possible_output[focus] = (industry_target, research_target)
@@ -107,6 +109,7 @@ class PlanetFocusManager(object):
             if INDUSTRY in planet.availableFoci and planet.focus != INDUSTRY:
                 fo.issueChangeFocusOrder(pid, INDUSTRY)  # may not be able to take, but try
 
+        # always using current meters in the following to reflect focus changes
         universe.updateMeterEstimates(unbaked_pids)
         for pid, pinfo, planet in planet_infos:
             industry_target = planet.currentMeterValue(fo.meterType.targetIndustry)
@@ -281,6 +284,7 @@ class Reporter(object):
             ], table_name="Planetary Foci Overview Turn %d" % fo.currentTurn())
         for pid in empire_planet_ids:
             planet = universe.getPlanet(pid)
+            # TODO: Shouldn't these be initial meters?
             population = planet.currentMeterValue(fo.meterType.population)
             max_population = planet.currentMeterValue(fo.meterType.targetPopulation)
             if max_population < 1 and population > 0:
@@ -433,6 +437,7 @@ def set_planet_growth_specials(focus_manager):
 
             # the increased population on the planet using this growth focus
             # is mostly wasted, so ignore it for now.
+            # TODO: Do we want to use current meter here or initial?
             pop = planet.currentMeterValue(fo.meterType.population)
             pop_gain = potential_pop_increase - planet.habitableSize
             if pop > pop_gain:

--- a/default/python/AI/ResourcesAI.py
+++ b/default/python/AI/ResourcesAI.py
@@ -38,14 +38,14 @@ class PlanetFocusInfo(object):
     """ The current, possible and future foci and output of one planet."""
     def __init__(self, planet):
         self.planet = planet
-        self.current_focus = planet.focus
-        self.current_output = (planet.initialMeterValue(fo.meterType.industry),
+        self.initial_focus = planet.focus
+        self.initial_output = (planet.initialMeterValue(fo.meterType.industry),
                                planet.initialMeterValue(fo.meterType.research))
         self.possible_output = {}
         industry_target = planet.initialMeterValue(fo.meterType.targetIndustry)
         research_target = planet.initialMeterValue(fo.meterType.targetResearch)
-        self.possible_output[self.current_focus] = (industry_target, research_target)
-        self.future_focus = self.current_focus
+        self.possible_output[self.initial_focus] = (industry_target, research_target)
+        self.future_focus = self.initial_focus
 
 
 class PlanetFocusManager(object):
@@ -79,11 +79,11 @@ class PlanetFocusManager(object):
         """
         pinfo = self.raw_planet_info.get(pid)
         success = bool(pinfo is not None and
-                       (pinfo.current_focus == focus
+                       (pinfo.initial_focus == focus
                         or (focus in pinfo.planet.availableFoci
                             and fo.issueChangeFocusOrder(pid, focus))))
         if success:
-            if update and pinfo.current_focus != focus:
+            if update and pinfo.initial_focus != focus:
                 universe = fo.getUniverse()
                 universe.updateMeterEstimates(self.raw_planet_info.keys())
                 # using current meter here to reflect focus changes
@@ -132,8 +132,8 @@ class PlanetFocusManager(object):
             else:
                 pinfo.possible_output[RESEARCH] = (0, 0)
                 pinfo.possible_output[GROWTH] = (0, pinfo.possible_output[GROWTH])
-            if pinfo.planet.availableFoci and pinfo.current_focus != planet.focus:
-                fo.issueChangeFocusOrder(pid, pinfo.current_focus)  # put it back to what it was
+            if pinfo.planet.availableFoci and pinfo.initial_focus != planet.focus:
+                fo.issueChangeFocusOrder(pid, pinfo.initial_focus)  # put it back to what it was
 
         universe.updateMeterEstimates(unbaked_pids)
         # Protection focus will give the same off-focus Industry and Research targets as Growth Focus
@@ -181,10 +181,10 @@ class Reporter(object):
         all_research_research_target = 0
         total_changed = 0
         for pinfo in self.focus_manager.all_planet_info.values():
-            if pinfo.current_focus != pinfo.future_focus:
+            if pinfo.initial_focus != pinfo.future_focus:
                 total_changed += 1
 
-            old_pp, old_rp = pinfo.possible_output[pinfo.current_focus]
+            old_pp, old_rp = pinfo.possible_output[pinfo.initial_focus]
             current_industry_target += old_pp
             current_research_target += old_rp
 
@@ -228,9 +228,9 @@ class Reporter(object):
             id_set.sort()  # pay sort cost only when printing
             for pid in id_set:
                 pinfo = self.focus_manager.baked_planet_info[pid]
-                old_focus = pinfo.current_focus
+                old_focus = pinfo.initial_focus
                 new_focus = pinfo.future_focus
-                current_pp, curren_rp = pinfo.current_output
+                current_pp, curren_rp = pinfo.initial_output
                 ot_pp, ot_rp = pinfo.possible_output.get(old_focus, (0, 0))
                 nt_pp, nt_rp = pinfo.possible_output[new_focus]
                 print (Reporter.table_format %
@@ -320,27 +320,27 @@ def assess_protection_focus(pinfo):
     print "%s has regional+supply threat of %.1f" % (this_planet, threat_from_supply)
     regional_threat = sys_status.get('regional_threat', 0) + threat_from_supply
     if not regional_threat:  # no need for protection
-        if pinfo.current_focus == PROTECTION:
+        if pinfo.initial_focus == PROTECTION:
             print "Advising dropping Protection Focus at %s due to no regional threat" % this_planet
         return False
-    cur_prod_val = weighted_sum_output(pinfo.current_output)
+    cur_prod_val = weighted_sum_output(pinfo.initial_output)
     target_prod_val = max(map(weighted_sum_output, [pinfo.possible_output[INDUSTRY], pinfo.possible_output[RESEARCH]]))
     prot_prod_val = weighted_sum_output(pinfo.possible_output[PROTECTION])
     local_production_diff = 0.8 * cur_prod_val + 0.2 * target_prod_val - prot_prod_val
     fleet_threat = sys_status.get('fleetThreat', 0)
     # TODO: relax the below rejection once the overall determination of PFocus is better tuned
     if not fleet_threat and local_production_diff > 8:
-        if pinfo.current_focus == PROTECTION:
+        if pinfo.initial_focus == PROTECTION:
             print "Advising dropping Protection Focus at %s due to excessive productivity loss" % this_planet
         return False
     local_p_defenses = sys_status.get('mydefenses', {}).get('overall', 0)
     # TODO have adjusted_p_defenses take other in-system planets into account
-    adjusted_p_defenses = local_p_defenses * (1.0 if pinfo.current_focus != PROTECTION else 0.5)
+    adjusted_p_defenses = local_p_defenses * (1.0 if pinfo.initial_focus != PROTECTION else 0.5)
     local_fleet_rating = sys_status.get('myFleetRating', 0)
     combined_local_defenses = sys_status.get('all_local_defenses', 0)
     my_neighbor_rating = sys_status.get('my_neighbor_rating', 0)
     neighbor_threat = sys_status.get('neighborThreat', 0)
-    safety_factor = 1.2 if pinfo.current_focus == PROTECTION else 0.5
+    safety_factor = 1.2 if pinfo.initial_focus == PROTECTION else 0.5
     cur_shield = this_planet.initialMeterValue(fo.meterType.shield)
     max_shield = this_planet.initialMeterValue(fo.meterType.maxShield)
     cur_troops = this_planet.initialMeterValue(fo.meterType.troops)
@@ -351,18 +351,18 @@ def assess_protection_focus(pinfo):
     use_protection = True
     reason = ""
     if (fleet_threat and  # i.e., an enemy is sitting on us
-            (pinfo.current_focus != PROTECTION or  # too late to start protection TODO: but maybe regen worth it
+            (pinfo.initial_focus != PROTECTION or  # too late to start protection TODO: but maybe regen worth it
              # protection focus only useful here if it maintains an elevated level
              all([AIDependencies.PROT_FOCUS_MULTIPLIER * a <= b for a, b in def_meter_pairs]))):
         use_protection = False
         reason = "A"
-    elif ((pinfo.current_focus != PROTECTION and cur_shield < max_shield - 2 and
+    elif ((pinfo.initial_focus != PROTECTION and cur_shield < max_shield - 2 and
            not tech_is_complete(AIDependencies.PLANET_BARRIER_I_TECH)) and
           (cur_defense < max_defense - 2 and not tech_is_complete(AIDependencies.DEFENSE_REGEN_1_TECH)) and
           (cur_troops < max_troops - 2)):
         use_protection = False
         reason = "B1"
-    elif ((pinfo.current_focus == PROTECTION and cur_shield * AIDependencies.PROT_FOCUS_MULTIPLIER < max_shield - 2 and
+    elif ((pinfo.initial_focus == PROTECTION and cur_shield * AIDependencies.PROT_FOCUS_MULTIPLIER < max_shield - 2 and
            not tech_is_complete(AIDependencies.PLANET_BARRIER_I_TECH)) and
           (cur_defense * AIDependencies.PROT_FOCUS_MULTIPLIER < max_defense - 2 and
            not tech_is_complete(AIDependencies.DEFENSE_REGEN_1_TECH)) and
@@ -380,7 +380,7 @@ def assess_protection_focus(pinfo):
         use_protection = False
         reason = "E"
     elif (safety_factor * regional_threat <= combined_local_defenses and
-          (pinfo.current_focus != PROTECTION or
+          (pinfo.initial_focus != PROTECTION or
            (0.5 * safety_factor * regional_threat <= local_fleet_rating and
             fleet_threat == 0 and neighbor_threat < combined_local_defenses and
             local_production_diff > 5))):
@@ -392,7 +392,7 @@ def assess_protection_focus(pinfo):
           local_production_diff > 5):
         use_protection = False
         reason = "G"
-    if use_protection or pinfo.current_focus == PROTECTION:
+    if use_protection or pinfo.initial_focus == PROTECTION:
         print ("Advising %sProtection Focus (reason %s) for planet %s, with local_prod_diff of %.1f, comb. local"
                " defenses %.1f, local fleet rating %.1f and regional threat %.1f, threat sources: %s") % (
                 ["dropping ", ""][use_protection], reason, this_planet, local_production_diff, combined_local_defenses,
@@ -449,10 +449,10 @@ def set_planet_growth_specials(focus_manager):
                 continue
 
             _print_evaluation("considered (pop %.1f, growth gain %.1f, current focus %s)" % (
-                pop, pop_gain, pinfo.current_focus))
+                pop, pop_gain, pinfo.initial_focus))
 
             # add a bias to discourage switching out growth focus to avoid focus change penalties
-            if pinfo.current_focus == GROWTH:
+            if pinfo.initial_focus == GROWTH:
                 pop -= 4
 
             ranked_planets.append((pop, pid, planet))
@@ -488,12 +488,12 @@ def set_planet_production_and_research_specials(focus_manager):
             if focus_manager.bake_future_focus(pid, RESEARCH):
                 already_have_comp_moon = True
                 print "%s focus of planet %s (%d) (with Computronium Moon) at Research Focus" % (
-                    ["set", "left"][pinfo.current_focus == RESEARCH], planet.name, pid)
+                    ["set", "left"][pinfo.initial_focus == RESEARCH], planet.name, pid)
                 continue
         if "HONEYCOMB_SPECIAL" in planet.specials and INDUSTRY in planet.availableFoci:
             if focus_manager.bake_future_focus(pid, INDUSTRY):
                 print "%s focus of planet %s (%d) (with Honeycomb) at Industry Focus" % (
-                    ["set", "left"][pinfo.current_focus == INDUSTRY], planet.name, pid)
+                    ["set", "left"][pinfo.initial_focus == INDUSTRY], planet.name, pid)
                 continue
         if ((([bld.buildingTypeName for bld in map(universe.getBuilding, planet.buildingIDs) if bld.buildingTypeName in
                ["BLD_CONC_CAMP", "BLD_CONC_CAMP_REMNANT"]])
@@ -502,7 +502,7 @@ def set_planet_production_and_research_specials(focus_manager):
                 and INDUSTRY in planet.availableFoci):
             if focus_manager.bake_future_focus(pid, INDUSTRY):
                 print "%s focus of planet %s (%d) (with Concentration Camps/Remnants) at Industry Focus" % (
-                    ["set", "left"][pinfo.current_focus == INDUSTRY], planet.name, pid)
+                    ["set", "left"][pinfo.initial_focus == INDUSTRY], planet.name, pid)
                 continue
             else:
                 new_planet = universe.getPlanet(pid)
@@ -517,14 +517,14 @@ def set_planet_protection_foci(focus_manager):
     for pid, pinfo in focus_manager.raw_planet_info.items():
         planet = pinfo.planet
         if PROTECTION in planet.availableFoci and assess_protection_focus(pinfo):
-            current_focus = planet.focus
+            initial_focus = pinfo.initial_focus
             if focus_manager.bake_future_focus(pid, PROTECTION):
-                if current_focus != PROTECTION:
+                if initial_focus != PROTECTION:
                     print ("Tried setting %s for planet %s (%d) with species %s and current focus %s, "
                            "got result %d and focus %s" % (pinfo.future_focus, planet.name, pid,
-                                                           planet.speciesName, current_focus, True, planet.focus))
+                                                           planet.speciesName, initial_focus, True, planet.focus))
                 print "%s focus of planet %s (%d) at Protection(Defense) Focus" % (
-                    ["set", "left"][current_focus == PROTECTION], planet.name, pid)
+                    ["set", "left"][initial_focus == PROTECTION], planet.name, pid)
                 continue
             else:
                 newplanet = universe.getPlanet(pid)
@@ -575,8 +575,8 @@ def set_planet_industry_and_research_foci(focus_manager, priority_ratio):
         for pid, pinfo in focus_manager.raw_planet_info.items():
             ii, tr = pinfo.possible_output[INDUSTRY]
             ri, rr = pinfo.possible_output[RESEARCH]
-            ci, cr = pinfo.current_output
-            research_penalty = AIDependencies.FOCUS_CHANGE_PENALTY if (pinfo.current_focus != RESEARCH) else 0
+            ci, cr = pinfo.initial_output
+            research_penalty = AIDependencies.FOCUS_CHANGE_PENALTY if (pinfo.initial_focus != RESEARCH) else 0
             # calculate factor F at which ii + F * tr == ri + F * rr =====> F = ( ii-ri ) / (rr-tr)
             factor = (ii - ri) / max(0.01, rr - tr)
             planet = pinfo.planet
@@ -673,8 +673,8 @@ def set_planet_industry_and_research_foci(focus_manager, priority_ratio):
                                                                  " current RP/PP ", " current target RP/PP ",
                                                                  "current Focus ", "  rejectedFocus ",
                                                                  " rejected target RP/PP ", "rejected RP-PP EQF")
-            old_focus = pinfo.current_focus
-            c_pp, c_rp = pinfo.current_output
+            old_focus = pinfo.initial_focus
+            c_pp, c_rp = pinfo.initial_output
             ot_pp, ot_rp = pinfo.possible_output[old_focus]
             nt_pp, nt_rp = pinfo.possible_output[RESEARCH]
             print ("pID (%3d) %22s | c: %5.1f / %5.1f | cT: %5.1f / %5.1f"

--- a/default/python/AI/ResourcesAI.py
+++ b/default/python/AI/ResourcesAI.py
@@ -39,12 +39,11 @@ class PlanetFocusInfo(object):
     def __init__(self, planet):
         self.planet = planet
         self.current_focus = planet.focus
-        # TODO: Shouldn't this be initial meter values as this turn's output without focus changes?
-        self.current_output = (planet.currentMeterValue(fo.meterType.industry),
-                               planet.currentMeterValue(fo.meterType.research))
+        self.current_output = (planet.initialMeterValue(fo.meterType.industry),
+                               planet.initialMeterValue(fo.meterType.research))
         self.possible_output = {}
-        industry_target = planet.currentMeterValue(fo.meterType.targetIndustry)
-        research_target = planet.currentMeterValue(fo.meterType.targetResearch)
+        industry_target = planet.initialMeterValue(fo.meterType.targetIndustry)
+        research_target = planet.initialMeterValue(fo.meterType.targetResearch)
         self.possible_output[self.current_focus] = (industry_target, research_target)
         self.future_focus = self.current_focus
 

--- a/default/python/AI/ResourcesAI.py
+++ b/default/python/AI/ResourcesAI.py
@@ -283,9 +283,8 @@ class Reporter(object):
             ], table_name="Planetary Foci Overview Turn %d" % fo.currentTurn())
         for pid in empire_planet_ids:
             planet = universe.getPlanet(pid)
-            # TODO: Shouldn't these be initial meters?
-            population = planet.currentMeterValue(fo.meterType.population)
-            max_population = planet.currentMeterValue(fo.meterType.targetPopulation)
+            population = planet.initialMeterValue(fo.meterType.population)
+            max_population = planet.initialMeterValue(fo.meterType.targetPopulation)
             if max_population < 1 and population > 0:
                 warnings[planet.name] = (population, max_population)
             foci_table.add_row([

--- a/default/python/AI/fleet_orders.py
+++ b/default/python/AI/fleet_orders.py
@@ -31,8 +31,7 @@ def trooper_move_reqs_met(main_fleet_mission, order, verbose):
     supplied_systems = fo.getEmpire().fleetSupplyableSystemIDs
     # if about to leave supply lines
     if order.target.id not in supplied_systems or fo.getUniverse().jumpDistance(order.fleet.id, invasion_system.id) < 5:
-        # using current meter value here as the planet will have time to grow
-        # shields if no military fleets present there.
+        # using current meter value here as the planet will have time to grow if it is important...
         if invasion_planet.currentMeterValue(fo.meterType.maxShield):
             military_support_fleets = MilitaryAI.get_military_fleets_with_target_system(invasion_system.id)
             if not military_support_fleets:

--- a/default/python/AI/fleet_orders.py
+++ b/default/python/AI/fleet_orders.py
@@ -456,10 +456,9 @@ class OrderInvade(AIFleetOrder):
             print "Ordering troop ship %d to invade %s" % (ship_id, planet)
             result = fo.issueInvadeOrder(ship_id, planet_id) or result
             if not result:
-                # TODO: Shouldn't this be initial meter values to reflect this turn's state?
-                shields = planet.currentMeterValue(fo.meterType.shield)
-                planet_stealth = planet.currentMeterValue(fo.meterType.stealth)
-                pop = planet.currentMeterValue(fo.meterType.population)
+                shields = planet.initialMeterValue(fo.meterType.shield)
+                planet_stealth = planet.initialMeterValue(fo.meterType.stealth)
+                pop = planet.initialMeterValue(fo.meterType.population)
                 warn("Invasion order failed!")
                 print (" -- planet has %.1f stealth, shields %.1f, %.1f population and "
                        "is owned by empire %d") % (planet_stealth, shields, pop, planet.owner)

--- a/default/python/AI/fleet_orders.py
+++ b/default/python/AI/fleet_orders.py
@@ -31,6 +31,8 @@ def trooper_move_reqs_met(main_fleet_mission, order, verbose):
     supplied_systems = fo.getEmpire().fleetSupplyableSystemIDs
     # if about to leave supply lines
     if order.target.id not in supplied_systems or fo.getUniverse().jumpDistance(order.fleet.id, invasion_system.id) < 5:
+        # using current meter value here as the planet will have time to grow
+        # shields if no military fleets present there.
         if invasion_planet.currentMeterValue(fo.meterType.maxShield):
             military_support_fleets = MilitaryAI.get_military_fleets_with_target_system(invasion_system.id)
             if not military_support_fleets:
@@ -365,6 +367,7 @@ class OrderColonize(AIFleetOrder):
         sys_partial_vis_turn = get_partial_visibility_turn(planet.systemID)
         planet_partial_vis_turn = get_partial_visibility_turn(planet.id)
         if (planet_partial_vis_turn == sys_partial_vis_turn and planet.unowned or
+                # TODO: Shouldn't this be initial meter value to be consistent with AIFleetMission checks?
                 (planet.ownedBy(fo.empireID()) and not planet.currentMeterValue(fo.meterType.population))):
             return self.fleet.get_object().hasColonyShips
         self.executed = True
@@ -401,6 +404,7 @@ class OrderInvade(AIFleetOrder):
         if not super(OrderInvade, self).is_valid():
             return False
         planet = self.target.get_object()
+        # TODO: Shouldn't this be initial meter value to be consistent with AIFleetMission checks?
         planet_population = planet.currentMeterValue(fo.meterType.population)
         if planet.unowned and not planet_population:
             print "\t\t invasion order not valid due to target planet status-- owned: %s and population %.1f" % (
@@ -452,6 +456,7 @@ class OrderInvade(AIFleetOrder):
             print "Ordering troop ship %d to invade %s" % (ship_id, planet)
             result = fo.issueInvadeOrder(ship_id, planet_id) or result
             if not result:
+                # TODO: Shouldn't this be initial meter values to reflect this turn's state?
                 shields = planet.currentMeterValue(fo.meterType.shield)
                 planet_stealth = planet.currentMeterValue(fo.meterType.stealth)
                 pop = planet.currentMeterValue(fo.meterType.population)

--- a/default/python/AI/turn_state.py
+++ b/default/python/AI/turn_state.py
@@ -64,6 +64,7 @@ class State(object):
             self.__planet_info[pid] = PlanetInfo(pid, planet.speciesName, planet.owner, planet.systemID)
 
             if planet.ownedBy(empire_id):
+                # TODO: Shouldn't this be initial meter value?
                 population = planet.currentMeterValue(fo.meterType.population)
                 if AIDependencies.ANCIENT_RUINS_SPECIAL in planet.specials:
                     self.__have_ruins = True

--- a/default/python/AI/turn_state.py
+++ b/default/python/AI/turn_state.py
@@ -64,12 +64,11 @@ class State(object):
             self.__planet_info[pid] = PlanetInfo(pid, planet.speciesName, planet.owner, planet.systemID)
 
             if planet.ownedBy(empire_id):
-                # TODO: Shouldn't this be initial meter value?
-                population = planet.currentMeterValue(fo.meterType.population)
+                population = planet.initialMeterValue(fo.meterType.population)
                 if AIDependencies.ANCIENT_RUINS_SPECIAL in planet.specials:
                     self.__have_ruins = True
                 if population > 0 and AIDependencies.COMPUTRONIUM_SPECIAL in planet.specials:
-                        self.__have_computronium = True  # TODO: Check if species can set research focus
+                    self.__have_computronium = True  # TODO: Check if species can set research focus
 
                 if planet.focus == FocusType.FOCUS_INDUSTRY:
                     self.__num_industrialists += population


### PR DESCRIPTION
This PR is aimed to revise the AI usage of ```initialMeterValue``` vs ```currentMeterValue``` which I think wasn't sufficiently adressed by https://github.com/freeorion/freeorion/commit/ac323f23dc546a70ad310be2d1b0effefd3bbcb0.

For now, I only added couple of remarks and TODO comments. The todos must all be resolved before the PR is merged. The idea is to discuss and possibly resolve the relevant LOCs in this PR.

 Throughout the AI code, I propose to use ```initialMeterValue``` by default and add explanatory comments if we are ever making use of ```currentMeterValue```.

Additionally, I would strongly prefer to rename or at least to alias the interface functions to more accurately reflect their function in the AI code (something like thisTurnMeterValue and estimatedNextTurnMeterValue).