### PR TITLE
Improve DesignWnd obsolete part flicker behavior

### DIFF
--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -799,7 +799,7 @@ namespace {
             latest_obsolete_event = std::max(latest_obsolete_event, *maybe_hull_obsolete);
 
         for (const auto& part: design->Parts()) {
-            if(const auto maybe_part_obsolete = IsPartObsolete(part))
+            if (const auto maybe_part_obsolete = IsPartObsolete(part))
                 latest_obsolete_event = std::max(latest_obsolete_event, *maybe_part_obsolete);
         }
 
@@ -1131,7 +1131,7 @@ void ShipDesignManager::StartGame(int empire_id, bool is_new_game) {
     }
 
     // If requested initialize the current designs to all designs known by the empire
-    if(GetOptionsDB().Get<bool>("resource.shipdesign.default.enabled")) {
+    if (GetOptionsDB().Get<bool>("resource.shipdesign.default.enabled")) {
 
         // Assume that on new game start the server assigns the ids in an order
         // that makes sense for the UI.

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -235,6 +235,8 @@ private:
     friend class boost::serialization::access;
     template <class Archive>
     void serialize(Archive& ar, const unsigned int version);
+    template <class Archive>
+    void legacy_serialize(Archive& ar, const unsigned int version);
 };
 
 BOOST_CLASS_VERSION(SaveGameUIData, 2);

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -225,9 +225,11 @@ struct FO_COMMON_API SaveGameUIData {
     double  map_zoom_steps_in;
     std::set<int> fleets_exploring;
 
-    std::vector<std::pair<int, boost::optional<bool>>> ordered_ship_design_ids_and_obsolete;
-    std::vector<std::pair<std::string, bool>> ordered_ship_hull_and_obsolete;
-    std::unordered_set<std::string> obsolete_ship_parts;
+    // See DesignWnd.cpp for the usage of the following variables.
+    int obsolete_ui_event_count;
+    std::vector<std::pair<int, boost::optional<std::pair<bool, int>>>> ordered_ship_design_ids_and_obsolete;
+    std::vector<std::pair<std::string, std::pair<bool, int>>> ordered_ship_hull_and_obsolete;
+    std::unordered_map<std::string, int> obsolete_ship_parts;
 
 private:
     friend class boost::serialization::access;
@@ -235,7 +237,7 @@ private:
     void serialize(Archive& ar, const unsigned int version);
 };
 
-BOOST_CLASS_VERSION(SaveGameUIData, 1);
+BOOST_CLASS_VERSION(SaveGameUIData, 2);
 
 extern template FO_COMMON_API void SaveGameUIData::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, const unsigned int);
 extern template FO_COMMON_API void SaveGameUIData::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, const unsigned int);

--- a/util/SerializeMultiplayerCommon.cpp
+++ b/util/SerializeMultiplayerCommon.cpp
@@ -53,22 +53,72 @@ void SaveGameUIData::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(map_zoom_steps_in)
         & BOOST_SERIALIZATION_NVP(fleets_exploring);
 
-    if (version >= 1) {
+    if (version >= 2) {
+        ar & BOOST_SERIALIZATION_NVP(obsolete_ui_event_count);
         ar & BOOST_SERIALIZATION_NVP(ordered_ship_design_ids_and_obsolete);
         ar & BOOST_SERIALIZATION_NVP(ordered_ship_hull_and_obsolete);
         ar & BOOST_SERIALIZATION_NVP(obsolete_ship_parts);
-    } else {
-        if (Archive::is_loading::value) {
-            std::vector<std::pair<int, bool>> dummy_ordered_ship_design_ids_and_obsolete;
-            ar & boost::serialization::make_nvp(
-                "ordered_ship_design_ids_and_obsolete", dummy_ordered_ship_design_ids_and_obsolete);
-            ordered_ship_design_ids_and_obsolete.clear();
-            ordered_ship_design_ids_and_obsolete.reserve(dummy_ordered_ship_design_ids_and_obsolete.size());
-            for (auto id_and_obsolete : dummy_ordered_ship_design_ids_and_obsolete) {
-                ordered_ship_design_ids_and_obsolete.push_back(
-                    {id_and_obsolete.first, (id_and_obsolete.second ? boost::optional<bool>(true) : boost::none)});
-            }
+    }
+
+    // Only workarounds for old versions follow
+    if (version >= 2)
+        return;
+
+    if (!Archive::is_loading::value)
+        return;
+
+    if (version == 1) {
+        obsolete_ui_event_count = 1;
+
+        std::vector<std::pair<int, boost::optional<bool>>> dummy_ordered_ship_design_ids_and_obsolete;
+        ar & boost::serialization::make_nvp(
+            "ordered_ship_design_ids_and_obsolete", dummy_ordered_ship_design_ids_and_obsolete);
+
+        std::vector<std::pair<std::string, bool>> dummy_ordered_ship_hull_and_obsolete;
+        ar & boost::serialization::make_nvp(
+            "ordered_ship_hull_and_obsolete", dummy_ordered_ship_hull_and_obsolete);
+        ordered_ship_hull_and_obsolete.clear();
+        ordered_ship_hull_and_obsolete.reserve(dummy_ordered_ship_hull_and_obsolete.size());
+        for (auto name_and_obsolete : dummy_ordered_ship_hull_and_obsolete) {
+            ordered_ship_hull_and_obsolete.push_back(
+                {name_and_obsolete.first, {name_and_obsolete.second, ++obsolete_ui_event_count}});
         }
+
+        std::unordered_set<std::string> dummy_obsolete_ship_parts;
+        ar & boost::serialization::make_nvp(
+            "obsolete_ship_parts", dummy_obsolete_ship_parts);
+        obsolete_ship_parts.clear();
+        obsolete_ship_parts.reserve(dummy_obsolete_ship_parts.size());
+        for (auto part : dummy_obsolete_ship_parts) {
+            obsolete_ship_parts.insert({part, ++obsolete_ui_event_count});
+        }
+
+        // Insert designs last to preserve version 1 behavior
+        ordered_ship_design_ids_and_obsolete.clear();
+        ordered_ship_design_ids_and_obsolete.reserve(dummy_ordered_ship_design_ids_and_obsolete.size());
+        for (auto id_and_obsolete : dummy_ordered_ship_design_ids_and_obsolete) {
+            ordered_ship_design_ids_and_obsolete.push_back(
+                std::make_pair(id_and_obsolete.first,
+                               (id_and_obsolete.second
+                                ? boost::optional<std::pair<bool, int>>({true, ++obsolete_ui_event_count})
+                                : boost::none)));
+        }
+    } else {
+        std::vector<std::pair<int, bool>> dummy_ordered_ship_design_ids_and_obsolete;
+        ar & boost::serialization::make_nvp(
+            "ordered_ship_design_ids_and_obsolete", dummy_ordered_ship_design_ids_and_obsolete);
+
+        ordered_ship_design_ids_and_obsolete.clear();
+        ordered_ship_design_ids_and_obsolete.reserve(dummy_ordered_ship_design_ids_and_obsolete.size());
+        for (auto id_and_obsolete : dummy_ordered_ship_design_ids_and_obsolete) {
+            ordered_ship_design_ids_and_obsolete.push_back(
+                std::make_pair(id_and_obsolete.first,
+                               (id_and_obsolete.second
+                                ? boost::optional<std::pair<bool, int>>({true, ++obsolete_ui_event_count})
+                                : boost::none)));
+        }
+        ordered_ship_hull_and_obsolete.clear();
+        obsolete_ship_parts.clear();
     }
 }
 

--- a/util/SerializeMultiplayerCommon.cpp
+++ b/util/SerializeMultiplayerCommon.cpp
@@ -64,6 +64,12 @@ void SaveGameUIData::serialize(Archive& ar, const unsigned int version)
     if (version >= 2)
         return;
 
+    legacy_serialize(ar, version);
+}
+
+template <class Archive>
+void SaveGameUIData::legacy_serialize(Archive& ar, const unsigned int version)
+{
     if (!Archive::is_loading::value)
         return;
 


### PR DESCRIPTION
In #1972 @dbenage-cx reported that un-obsoleting a design will override hull/part obsolete conditions.

The problem is that the DesignWnd does not remember the sequence of UI events involved in obsoleting a design and its hull and parts.  

This PR gives each UI obsoleting event a number so that the order can be checked and the last obsoleting instruction given by the player takes precedence.