### PR TITLE
Improve DesignWnd, allow rename in MainPanel

### DIFF
--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -3793,8 +3793,8 @@ public:
     boost::optional<int>                GetReplacedDesignID() const;//!< returns ID of completed design selected to be replaced.
 
     /** If a design with the same hull and parts is registered with the empire then return the
-        design name, otherwise return boost::none. */
-    boost::optional<std::string>        CurrentDesignIsRegistered();
+        design, otherwise return boost::none. */
+    boost::optional<const ShipDesign*>        CurrentDesignIsRegistered();
     //@}
 
     /** \name Mutators */ //@{
@@ -4081,7 +4081,7 @@ std::shared_ptr<const ShipDesign> DesignWnd::MainPanel::GetIncompleteDesign() co
 boost::optional<int> DesignWnd::MainPanel::GetReplacedDesignID() const
 { return m_replaced_design_id; }
 
-boost::optional<std::string> DesignWnd::MainPanel::CurrentDesignIsRegistered() {
+boost::optional<const ShipDesign*> DesignWnd::MainPanel::CurrentDesignIsRegistered() {
     int empire_id = HumanClientApp::GetApp()->EmpireID();
     const auto empire = GetEmpire(empire_id);
     if (!empire) {
@@ -4091,9 +4091,9 @@ boost::optional<std::string> DesignWnd::MainPanel::CurrentDesignIsRegistered() {
 
     if (const auto& cur_design = GetIncompleteDesign()) {
         for (const auto design_id : empire->ShipDesigns()) {
-            const auto& ship_design = *GetShipDesign(design_id);
-            if (ship_design == *cur_design.get())
-                return ship_design.Name();
+            const auto ship_design = GetShipDesign(design_id);
+            if (*ship_design == *cur_design.get())
+                return ship_design;
         }
     }
     return boost::none;
@@ -4590,7 +4590,7 @@ void DesignWnd::MainPanel::DesignChanged() {
     bool producible = cur_design->Producible();
 
     // Current designs can not duplicate other designs, be already registered.
-    const auto existing_design_name = CurrentDesignIsRegistered();
+    const auto existing_design = CurrentDesignIsRegistered();
 
     const auto& replaced_saved_design = EditingSavedDesign();
 
@@ -4613,7 +4613,7 @@ void DesignWnd::MainPanel::DesignChanged() {
     }
 
     if (producible && replaced_current_design) {
-        if (!existing_design_name) {
+        if (!existing_design) {
             // A current design can be replaced if it doesn't duplicate an existing design
             m_replace_button->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
                 UserString("DESIGN_WND_UPDATE_FINISHED"),
@@ -4626,7 +4626,7 @@ void DesignWnd::MainPanel::DesignChanged() {
             m_replace_button->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
                 UserString("DESIGN_WND_KNOWN"),
                 boost::io::str(FlexibleFormat(UserString("DESIGN_WND_KNOWN_DETAIL"))
-                               % *existing_design_name)));
+                               % (*existing_design)->Name())));
         }
     }
 
@@ -4643,7 +4643,7 @@ void DesignWnd::MainPanel::DesignChanged() {
                                % new_design_name)));
         m_confirm_button->Disable(false);
     } else if (producible) {
-        if (!existing_design_name) {
+        if (!existing_design) {
             // A new current can be added if it does not duplicate an existing design.
             m_confirm_button->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
                 UserString("DESIGN_WND_ADD_FINISHED"),
@@ -4656,7 +4656,7 @@ void DesignWnd::MainPanel::DesignChanged() {
             m_confirm_button->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
                 UserString("DESIGN_WND_KNOWN"),
                 boost::io::str(FlexibleFormat(UserString("DESIGN_WND_KNOWN_DETAIL"))
-                               % *existing_design_name)));
+                               % (*existing_design)->Name())));
         }
     }
 }

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -3922,7 +3922,8 @@ private:
     std::shared_ptr<GG::Button>         m_replace_button;
     std::shared_ptr<GG::Button>         m_confirm_button;
     std::shared_ptr<GG::Button>         m_clear_button;
-    bool                m_disabled_by_name; // if the design confirm button is currently disabled due to empty name
+    /// is the design confirmation disabled with an invalid or identical name
+    bool                m_disabled_by_name = false;
     bool                m_disabled_by_part_conflict;
 
     boost::signals2::connection             m_empire_designs_changed_signal;
@@ -3946,7 +3947,6 @@ DesignWnd::MainPanel::MainPanel(const std::string& config_name) :
     m_replace_button(nullptr),
     m_confirm_button(nullptr),
     m_clear_button(nullptr),
-    m_disabled_by_name(false),
     m_disabled_by_part_conflict(false)
 {}
 
@@ -4612,8 +4612,31 @@ void DesignWnd::MainPanel::DesignChanged() {
         }
     }
 
-    if (producible && replaced_current_design) {
-        if (!existing_design) {
+    if (producible) {
+        if (existing_design
+            && m_type_to_create == DesignWnd::BaseSelector::BaseSelectorTab::Current)
+        {
+            // Rename duplicate finished designs
+            if ((*existing_design)->Name() != new_design_name) {
+                m_replace_button->SetText(UserString("DESIGN_WND_RENAME_FINISHED"));
+                m_replace_button->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
+                    UserString("DESIGN_WND_RENAME_FINISHED"),
+                    boost::io::str(FlexibleFormat(UserString("DESIGN_WND_RENAME_FINISHED_DETAIL"))
+                                   % ((*existing_design)->Name())
+                                   % new_design_name)));
+                m_replace_button->Disable(false);
+
+            // Otherwise mark it as known.
+            } else {
+                m_disabled_by_name = true;
+                m_replace_button->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
+                    UserString("DESIGN_WND_KNOWN"),
+                    boost::io::str(FlexibleFormat(UserString("DESIGN_WND_KNOWN_DETAIL"))
+                                   % (*existing_design)->Name())));
+            }
+
+
+        } else if (replaced_current_design) {
             // A current design can be replaced if it doesn't duplicate an existing design
             m_replace_button->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
                 UserString("DESIGN_WND_UPDATE_FINISHED"),
@@ -4621,12 +4644,6 @@ void DesignWnd::MainPanel::DesignChanged() {
                                % (*replaced_current_design)->Name()
                                % new_design_name)));
             m_replace_button->Disable(false);
-        } else {
-            // Otherwise mark it as known.
-            m_replace_button->SetBrowseInfoWnd(GG::Wnd::Create<TextBrowseWnd>(
-                UserString("DESIGN_WND_KNOWN"),
-                boost::io::str(FlexibleFormat(UserString("DESIGN_WND_KNOWN_DETAIL"))
-                               % (*existing_design)->Name())));
         }
     }
 
@@ -4835,28 +4852,33 @@ void DesignWnd::MainPanel::ReplaceDesign() {
         // Update the replaced design on the bench
         SetDesign(manager.GetDesign(new_uuid));
 
-    } else if (const auto current_maybe_design = EditingCurrentDesign()) {
-        auto& manager = GetCurrentDesignsManager();
-        int empire_id = HumanClientApp::GetApp()->EmpireID();
-        int replaced_id = (*current_maybe_design)->ID();
+    } else {
+        // If replacing or renaming a currect design
+        const auto current_maybe_design = EditingCurrentDesign();
+        const auto existing_design = CurrentDesignIsRegistered();
+        if (current_maybe_design || existing_design) {
+            auto& manager = GetCurrentDesignsManager();
+            int empire_id = HumanClientApp::GetApp()->EmpireID();
+            int replaced_id = (*(current_maybe_design ? current_maybe_design : existing_design))->ID();
 
-        if (new_design_id == INVALID_DESIGN_ID) return;
+            if (new_design_id == INVALID_DESIGN_ID) return;
 
-        // Remove the old id from the Empire.
-        const auto maybe_obsolete = manager.IsObsolete(replaced_id);
-        bool is_obsolete = maybe_obsolete && *maybe_obsolete;
-        if (!is_obsolete)
-            HumanClientApp::GetApp()->Orders().IssueOrder(
-                std::make_shared<ShipDesignOrder>(empire_id, replaced_id, true));
+            // Remove the old id from the Empire.
+            const auto maybe_obsolete = manager.IsObsolete(replaced_id);
+            bool is_obsolete = maybe_obsolete && *maybe_obsolete;
+            if (!is_obsolete)
+                HumanClientApp::GetApp()->Orders().IssueOrder(
+                    std::make_shared<ShipDesignOrder>(empire_id, replaced_id, true));
 
-        // Replace the old id in the manager.
-        manager.MoveBefore(new_design_id, replaced_id);
-        manager.Remove(replaced_id);
+            // Replace the old id in the manager.
+            manager.MoveBefore(new_design_id, replaced_id);
+            manager.Remove(replaced_id);
 
-        // Update the replaced design on the bench
-        SetDesign(new_design_id);
+            // Update the replaced design on the bench
+            SetDesign(new_design_id);
 
-        DebugLogger() << "Replaced design #" << replaced_id << " with #" << new_design_id ;
+            DebugLogger() << "Replaced design #" << replaced_id << " with #" << new_design_id ;
+        }
     }
 
     DesignChangedSignal();

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -4330,6 +4330,17 @@ Duplicates Existing Design
 DESIGN_WND_KNOWN_DETAIL
 This design is a duplicate of "%1%".
 
+DESIGN_WND_RENAME_FINISHED
+Rename Finished Design
+
+# %1% name of the equivalent ship design.
+# %2% new name of the ship design.
+DESIGN_WND_RENAME_FINISHED_DETAIL
+'''Rename Finished design from
+"%1%"
+to 
+"%2%"'''
+
 DESIGN_WND_COMPONENT_CONFLICT
 Conflicting Design
 


### PR DESCRIPTION
This PR should be applied after #2011 

This PR allows renaming finished and saved designs directly from the MainPanel.

This partially address inconsistencies with renaming in the DesignWnd.  It does not fix the problem that renaming from the context menu only works on the turn that a design is created.