### PR TITLE
Use default logging

### DIFF
--- a/default/python/AI/AIDependencies.py
+++ b/default/python/AI/AIDependencies.py
@@ -20,8 +20,6 @@ Example usage:
     my_industry = AIDependencies.INDUSTRY_PER_POP * my_population
 """
 import freeOrionAIInterface as fo  # interface used to interact with FreeOrion AI client  # pylint: disable=import-error
-from common.configure_logging import convenience_function_references_for_logger
-(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
 
 # Note re common dictionary lookup structure, "PlanetSize-Dependent-Lookup":
 # Many dictionaries herein (a prime example being the building_supply dictionary) have a primary key (such as

--- a/default/python/AI/AIFleetMission.py
+++ b/default/python/AI/AIFleetMission.py
@@ -1,3 +1,5 @@
+from logging import info, warn
+
 import freeOrionAIInterface as fo  # pylint: disable=import-error
 
 from fleet_orders import OrderMove, OrderOutpost, OrderColonize, OrderMilitary, OrderInvade, OrderDefend
@@ -13,8 +15,6 @@ from EnumsAI import MissionType
 from AIDependencies import INVALID_ID
 from freeorion_tools import get_partial_visibility_turn
 
-from common.configure_logging import convenience_function_references_for_logger
-(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
 
 ORDERS_FOR_MISSION = {
     MissionType.EXPLORATION: OrderMove,

--- a/default/python/AI/AIstate.py
+++ b/default/python/AI/AIstate.py
@@ -1,5 +1,6 @@
 import copy
 from collections import Counter, OrderedDict as odict
+from logging import error, info, warn
 from operator import itemgetter
 from time import time
 
@@ -18,10 +19,6 @@ from freeorion_tools import get_partial_visibility_turn
 from universe_object import System
 from AIDependencies import INVALID_ID
 from character.character_module import create_character, Aggression
-
-from common.configure_logging import convenience_function_references_for_logger
-(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
-
 
 # moving ALL or NEARLY ALL 'global' variables into AIState object rather than module
 # in general, leaving items as a module attribute if they are recalculated each turn without reference to prior values

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -1,3 +1,4 @@
+from logging import debug, warn, error, info
 from operator import itemgetter
 
 import freeOrionAIInterface as fo  # pylint: disable=import-error
@@ -16,9 +17,6 @@ from EnumsAI import MissionType, FocusType, EmpireProductionTypes, ShipRoleType,
 from freeorion_tools import tech_is_complete, get_ai_tag_grade, cache_by_turn, AITimer, get_partial_visibility_turn
 from AIDependencies import (INVALID_ID, OUTPOSTING_TECH, POP_CONST_MOD_MAP, POP_SIZE_MOD_MAP_MODIFIED_BY_SPECIES,
                             POP_SIZE_MOD_MAP_NOT_MODIFIED_BY_SPECIES)
-
-from common.configure_logging import convenience_function_references_for_logger
-(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
 
 colonization_timer = AITimer('getColonyFleets()')
 

--- a/default/python/AI/CombatRatingsAI.py
+++ b/default/python/AI/CombatRatingsAI.py
@@ -1,4 +1,5 @@
 from collections import Counter
+from logging import warn
 
 import freeOrionAIInterface as fo
 import FleetUtilsAI
@@ -6,9 +7,6 @@ from EnumsAI import MissionType
 from freeorion_tools import get_ai_tag_grade, dict_to_tuple, tuple_to_dict, cache_by_session
 from ShipDesignAI import get_part_type
 from AIDependencies import INVALID_ID
-
-from common.configure_logging import convenience_function_references_for_logger
-(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
 
 
 def get_empire_standard_fighter():

--- a/default/python/AI/DiplomaticCorp.py
+++ b/default/python/AI/DiplomaticCorp.py
@@ -7,9 +7,6 @@ from character.character_module import Aggression
 from character.character_strings_module import possible_greetings
 from freeorion_tools import UserStringList
 
-from common.configure_logging import convenience_function_references_for_logger
-(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
-
 
 def handle_pregame_chat(sender_player_id, message_txt):
     if fo.playerIsAI(sender_player_id):

--- a/default/python/AI/ExplorationAI.py
+++ b/default/python/AI/ExplorationAI.py
@@ -1,3 +1,5 @@
+from logging import error
+
 import freeOrionAIInterface as fo  # interface used to interact with FreeOrion AI client # pylint: disable=import-error
 import FreeOrionAI as foAI
 import FleetUtilsAI
@@ -7,10 +9,6 @@ import MoveUtilsAI
 import PlanetUtilsAI
 from AIDependencies import INVALID_ID
 from freeorion_tools import get_partial_visibility_turn
-
-from common.configure_logging import convenience_function_references_for_logger
-(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
-
 
 graph_flags = set()
 border_unexplored_system_ids = set()

--- a/default/python/AI/FleetUtilsAI.py
+++ b/default/python/AI/FleetUtilsAI.py
@@ -1,4 +1,5 @@
 import math
+from logging import error, warn
 
 import freeOrionAIInterface as fo  # pylint: disable=import-error
 import FreeOrionAI as foAI
@@ -8,8 +9,6 @@ from universe_object import Planet
 from ShipDesignAI import get_part_type
 from AIDependencies import INVALID_ID
 import AIDependencies
-from common.configure_logging import convenience_function_references_for_logger
-(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
 
 
 def stats_meet_reqs(stats, requirements):

--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -1,10 +1,11 @@
 """The FreeOrionAI module contains the methods which can be made by the C AIInterface;
 these methods in turn activate other portions of the python AI code."""
-from common.configure_logging import redirect_logging_to_freeorion_logger, convenience_function_references_for_logger
+from logging import debug, info, error
+
+from common.configure_logging import redirect_logging_to_freeorion_logger
 
 # Logging is redirected before other imports so that import errors appear in log files.
 redirect_logging_to_freeorion_logger()
-(debug, info, warn, error, fatal) = convenience_function_references_for_logger()
 
 import sys
 import random

--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -1,4 +1,5 @@
 import math
+from logging import warn, info
 
 from turn_state import state
 import freeOrionAIInterface as fo
@@ -17,9 +18,6 @@ from EnumsAI import MissionType, PriorityType
 import CombatRatingsAI
 from freeorion_tools import tech_is_complete, AITimer, get_partial_visibility_turn
 from AIDependencies import INVALID_ID
-
-from common.configure_logging import convenience_function_references_for_logger
-(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
 
 MAX_BASE_TROOPERS_GOOD_INVADERS = 20
 MAX_BASE_TROOPERS_POOR_INVADERS = 10

--- a/default/python/AI/MilitaryAI.py
+++ b/default/python/AI/MilitaryAI.py
@@ -11,9 +11,7 @@ import ProductionAI
 import CombatRatingsAI
 from freeorion_tools import cache_by_turn
 from AIDependencies import INVALID_ID
-from common.configure_logging import convenience_function_references_for_logger
 from turn_state import state
-(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
 
 MinThreat = 10  # the minimum threat level that will be ascribed to an unknown threat capable of killing scouts
 _military_allocations = []

--- a/default/python/AI/MoveUtilsAI.py
+++ b/default/python/AI/MoveUtilsAI.py
@@ -1,3 +1,5 @@
+from logging import warn, debug
+
 import freeOrionAIInterface as fo  # pylint: disable=import-error
 import FreeOrionAI as foAI
 import AIstate
@@ -7,9 +9,6 @@ import PlanetUtilsAI
 import pathfinding
 from AIDependencies import INVALID_ID, DRYDOCK_HAPPINESS_THRESHOLD
 from turn_state import state
-
-from common.configure_logging import convenience_function_references_for_logger
-(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
 
 
 def create_move_orders_to_system(fleet, target):

--- a/default/python/AI/PlanetUtilsAI.py
+++ b/default/python/AI/PlanetUtilsAI.py
@@ -1,11 +1,10 @@
+from logging import error
+
 import freeOrionAIInterface as fo  # pylint: disable=import-error
 import ColonisationAI
 from AIDependencies import INVALID_ID
 
 from freeorion_tools import ppstring
-
-from common.configure_logging import convenience_function_references_for_logger
-(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
 
 
 def safe_name(univ_object):

--- a/default/python/AI/PriorityAI.py
+++ b/default/python/AI/PriorityAI.py
@@ -16,8 +16,6 @@ from turn_state import state
 from EnumsAI import PriorityType, MissionType, EmpireProductionTypes, get_priority_production_types, ShipRoleType
 from freeorion_tools import AITimer, tech_is_complete
 from AIDependencies import INVALID_ID
-from common.configure_logging import convenience_function_references_for_logger
-(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
 
 prioritiees_timer = AITimer('calculate_priorities()')
 

--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -1,9 +1,9 @@
 import math
 import random
 import sys
+from logging import info, warn, error
 
 import freeOrionAIInterface as fo  # pylint: disable=import-error
-from common.configure_logging import convenience_function_references_for_logger
 from common.print_utils import Sequence, Table, Text
 
 import AIDependencies
@@ -22,8 +22,6 @@ from EnumsAI import (EmpireProductionTypes, FocusType, MissionType, PriorityType
 from character.character_module import Aggression
 from freeorion_tools import AITimer, chat_human, ppstring, tech_is_complete
 from turn_state import state
-
-(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
 
 _best_military_design_rating_cache = {}  # indexed by turn, values are rating of the military design of the turn
 _design_cost_cache = {0: {(-1, -1): 0}}  # outer dict indexed by cur_turn (currently only one turn kept); inner dict indexed by (design_id, pid)

--- a/default/python/AI/ResearchAI.py
+++ b/default/python/AI/ResearchAI.py
@@ -1,9 +1,9 @@
 import math
 import random
 from functools import partial
+from logging import warn
 
 import freeOrionAIInterface as fo  # pylint: disable=import-error
-from common.configure_logging import convenience_function_references_for_logger
 from common.print_utils import print_in_columns
 
 import AIDependencies as Dep
@@ -14,8 +14,6 @@ import ShipDesignAI
 import TechsListsAI
 from freeorion_tools import chat_human, get_ai_tag_grade, tech_is_complete
 from turn_state import state
-
-(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
 
 inProgressTechs = {}
 

--- a/default/python/AI/ResourcesAI.py
+++ b/default/python/AI/ResourcesAI.py
@@ -9,6 +9,8 @@ have their future focus decided.
 """
 # Note: The algorithm is not stable with respect to pid order.  i.e. Two empire with
 #       exactly the same colonies, but different pids may make different choices.
+from logging import info, warn, debug
+
 import freeOrionAIInterface as fo  # pylint: disable=import-error
 import FreeOrionAI as foAI
 from EnumsAI import PriorityType, get_priority_resource_types, FocusType
@@ -18,8 +20,6 @@ import AIDependencies
 import CombatRatingsAI
 from common.print_utils import Table, Text
 from freeorion_tools import tech_is_complete, AITimer
-from common.configure_logging import convenience_function_references_for_logger
-(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
 
 resource_timer = AITimer('timer_bucket')
 

--- a/default/python/AI/ShipDesignAI.py
+++ b/default/python/AI/ShipDesignAI.py
@@ -45,6 +45,7 @@ global variables:
 import copy
 import math
 from collections import Counter, defaultdict
+from logging import warn, error
 
 import freeOrionAIInterface as fo
 import FreeOrionAI as foAI
@@ -54,9 +55,6 @@ import FleetUtilsAI
 from AIDependencies import INVALID_ID
 from freeorion_tools import UserString, tech_is_complete
 from turn_state import state
-
-from common.configure_logging import convenience_function_references_for_logger
-(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
 
 # Define meta classes for the ship parts  TODO storing as set may not be needed anymore
 ARMOUR = frozenset({fo.shipPartClass.armour})

--- a/default/python/AI/TechsListsAI.py
+++ b/default/python/AI/TechsListsAI.py
@@ -3,10 +3,9 @@ The TechsListAI module provides functions that describes dependencies between
 various technologies to help the AI decide which technologies should be
 researched next.
 """
-import freeOrionAIInterface as fo  # pylint: disable=import-error
+from logging import warn
 
-from common.configure_logging import convenience_function_references_for_logger
-(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
+import freeOrionAIInterface as fo  # pylint: disable=import-error
 
 
 def unusable_techs():

--- a/default/python/AI/character/character_module.py
+++ b/default/python/AI/character/character_module.py
@@ -87,10 +87,9 @@ import abc
 from collections import Counter
 import math
 import random
+from logging import warn
 
 import freeOrionAIInterface as fo  # pylint: disable=import-error
-from common.configure_logging import convenience_function_references_for_logger
-(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
 
 
 class Trait(object):

--- a/default/python/AI/character/character_strings_module.py
+++ b/default/python/AI/character/character_strings_module.py
@@ -24,8 +24,6 @@ possible_capitals(Character([Aggression(0)])) returns ['Royal', 'Imperial'].
 
 import character as character_package
 import freeOrionAIInterface as fo  # pylint: disable=import-error
-from common.configure_logging import convenience_function_references_for_logger
-(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
 
 
 class _CharacterTableFunction(object):

--- a/default/python/AI/fleet_orders.py
+++ b/default/python/AI/fleet_orders.py
@@ -1,3 +1,5 @@
+from logging import error, warn
+
 from EnumsAI import ShipRoleType, MissionType
 import FleetUtilsAI
 import freeOrionAIInterface as fo  # pylint: disable=import-error
@@ -7,9 +9,6 @@ import MoveUtilsAI
 import CombatRatingsAI
 from universe_object import Fleet, System, Planet
 from freeorion_tools import get_partial_visibility_turn, dump_universe
-
-from common.configure_logging import convenience_function_references_for_logger
-(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
 
 
 def trooper_move_reqs_met(main_fleet_mission, order, verbose):
@@ -464,7 +463,7 @@ class OrderInvade(AIFleetOrder):
                     foAI.foAIstate.needsEmergencyExploration.append(fleet.systemID)
                     print "Due to trouble invading, adding system %d to Emergency Exploration List" % fleet.systemID
                     self.executed = False
-                
+
                 if shields > 0 and planet.unowned:
                     dump_universe()
                 break

--- a/default/python/AI/pathfinding.py
+++ b/default/python/AI/pathfinding.py
@@ -1,5 +1,6 @@
 from heapq import heappush, heappop
 from collections import namedtuple
+from logging import warn, error
 
 import FreeOrionAI as foAI
 import freeOrionAIInterface as fo
@@ -8,11 +9,8 @@ import PlanetUtilsAI
 from AIDependencies import INVALID_ID
 from EnumsAI import MissionType
 from turn_state import state
-from common.configure_logging import convenience_function_references_for_logger
 from freeorion_tools import cache_by_session_with_turnwise_update, chat_human, get_partial_visibility_turn
 
-
-(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
 _DEBUG_CHAT = False
 _ACCEPTABLE_DETOUR_LENGTH = 2000
 path_information = namedtuple('path_information', ['distance', 'fuel', 'path'])

--- a/default/python/AI/turn_state.py
+++ b/default/python/AI/turn_state.py
@@ -1,4 +1,6 @@
 from collections import namedtuple
+from logging import warn
+
 from freeorion_tools import ReadOnlyDict
 
 import freeOrionAIInterface as fo
@@ -6,8 +8,6 @@ import freeOrionAIInterface as fo
 import AIDependencies
 from AIDependencies import INVALID_ID
 from EnumsAI import FocusType
-from common.configure_logging import convenience_function_references_for_logger
-(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
 
 PlanetInfo = namedtuple('PlanetInfo', ['pid', 'species_name', 'owner', 'system_id'])
 

--- a/default/python/AI/universe_object.py
+++ b/default/python/AI/universe_object.py
@@ -1,8 +1,7 @@
+from logging import warn
+
 import freeOrionAIInterface as fo  # pylint: disable=import-error
 from AIDependencies import INVALID_ID
-
-from common.configure_logging import convenience_function_references_for_logger
-(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
 
 
 class UniverseObject(object):

--- a/default/python/auth/auth.py
+++ b/default/python/auth/auth.py
@@ -1,8 +1,9 @@
-from common.configure_logging import convenience_function_references_for_logger, redirect_logging_to_freeorion_logger
+from logging import warn, info
+
+from common.configure_logging import redirect_logging_to_freeorion_logger
 
 # Logging is redirected before other imports so that import errors appear in log files.
 redirect_logging_to_freeorion_logger()
-(debug, info, warn, error, fatal) = convenience_function_references_for_logger()
 
 import sys
 

--- a/default/python/common/configure_logging.py
+++ b/default/python/common/configure_logging.py
@@ -7,9 +7,8 @@ logging messages of levels warning and above are decorated with module name, fil
 
 Usage:
 
-from common.configure_logging import redirect_logging_to_freeorion_logger, convenience_function_references_for_logger
+from common.configure_logging import redirect_logging_to_freeorion_logger
 redirect_logging_to_freeorion_logger(log_level)
-(debug, info, warn, error, fatal) = convenience_function_references_for_logger()
 
 Then use python logging or print and have it re-directed appropriately.
 
@@ -36,7 +35,7 @@ logging.getLogger().isEnableFor(logging.WARN)
 
 * One strength of the python standard logging library is the ability to create
   arbitrary hierarchical loggers.  Loggers are created globally when getLogger()
-  is called with any string.  The hierarchical levels are dot seperated.  The
+  is called with any string.  The hierarchical levels are dot separated.  The
   root logger is the empty string.  The following creates a logger:
 
 logging.getLogger("toplevel.2ndlevel")
@@ -72,12 +71,6 @@ DEBUG   - used for low-level implementation or calculation details.
 
 For more information about the python standard library logger see
 https://docs.python.org/2/howto/logging.html
-
-The function convenience_function_references_for_logger(name) returns the
-specific logging functions from the logger ''name'' which can be bound to
-convenient local functions, to avoid calling name.error() to produce an error
-log.
-
 """
 import sys
 import logging
@@ -228,9 +221,3 @@ def redirect_logging_to_freeorion_logger(initial_log_level=logging.DEBUG):
                     logging.getLevelName(logger.getEffectiveLevel()))
 
         redirect_logging_to_freeorion_logger.only_redirect_once = True
-
-
-def convenience_function_references_for_logger(name=""):
-    """Return a tuple (debug, info, warn, error, fatal) of the ''name'' logger's convenience functions."""
-    logger = logging.getLogger(name)
-    return (logger.debug, logger.info, logger.warning, logger.error, logger.critical)

--- a/default/python/stub_generator/generate_stub.py
+++ b/default/python/stub_generator/generate_stub.py
@@ -1,9 +1,7 @@
+from logging import warn, error
 from operator import itemgetter
 
 from parse_docs import Docs
-
-from common.configure_logging import convenience_function_references_for_logger
-(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
 
 
 def handle_class(info):

--- a/default/python/stub_generator/interface_inspector.py
+++ b/default/python/stub_generator/interface_inspector.py
@@ -1,9 +1,8 @@
 import os
 from inspect import getdoc, isroutine
-from generate_stub import make_stub
+from logging import warn, error, debug
 
-from common.configure_logging import convenience_function_references_for_logger
-(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
+from generate_stub import make_stub
 
 
 def get_member_info(member):

--- a/default/python/stub_generator/parse_docs.py
+++ b/default/python/stub_generator/parse_docs.py
@@ -1,7 +1,5 @@
+from logging import error
 import re
-
-from common.configure_logging import convenience_function_references_for_logger
-(debug, info, warn, error, fatal) = convenience_function_references_for_logger(__name__)
 
 
 normalization_dict = {

--- a/default/python/turn_events/turn_events.py
+++ b/default/python/turn_events/turn_events.py
@@ -1,8 +1,7 @@
-from common.configure_logging import redirect_logging_to_freeorion_logger, convenience_function_references_for_logger
+from common.configure_logging import redirect_logging_to_freeorion_logger
 
 # Logging is redirected before other imports so that import errors appear in log files.
 redirect_logging_to_freeorion_logger()
-(debug, info, warn, error, fatal) = convenience_function_references_for_logger()
 
 import sys
 from random import random, uniform, choice

--- a/default/python/universe_generation/universe_generator.py
+++ b/default/python/universe_generation/universe_generator.py
@@ -1,8 +1,7 @@
-from common.configure_logging import convenience_function_references_for_logger, redirect_logging_to_freeorion_logger
+from common.configure_logging import redirect_logging_to_freeorion_logger
 
 # Logging is redirected before other imports so that import errors appear in log files.
 redirect_logging_to_freeorion_logger()
-(debug, info, warn, error, fatal) = convenience_function_references_for_logger()
 
 import random
 


### PR DESCRIPTION
This works on win7 because name is ignored for my case , can you test it on other platforms?

@Dilvish-fo , @Vezzra 

If this work we can get rid of the `convenience_function_references_for_logger` and make code more elegant.

- [x] win7
- [ ] win8
- [x] win10
- [x] linux
- [x] macosx