### PR TITLE
Utilize MessageWnd for MultiPlayerLobbyWnd chat

### DIFF
--- a/UI/ChatWnd.cpp
+++ b/UI/ChatWnd.cpp
@@ -314,10 +314,8 @@ bool MessageWndEdit::CompleteWord(const std::set<std::string>& names, const std:
 ////////////////////
 //   MessageWnd   //
 ////////////////////
-MessageWnd::MessageWnd(const std::string& config_name) :
-    CUIWnd(UserString("MESSAGES_PANEL_TITLE"),
-           GG::INTERACTIVE | GG::DRAGABLE | GG::ONTOP | GG::RESIZABLE | CLOSABLE | PINABLE,
-           config_name),
+MessageWnd::MessageWnd(GG::Flags<GG::WndFlag> flags, const std::string& config_name) :
+    CUIWnd(UserString("MESSAGES_PANEL_TITLE"), flags, config_name),
     m_display(nullptr),
     m_edit(nullptr),
     m_display_show_time(0),

--- a/UI/ChatWnd.cpp
+++ b/UI/ChatWnd.cpp
@@ -377,39 +377,19 @@ void MessageWnd::PreRender() {
 }
 
 void MessageWnd::HandlePlayerChatMessage(const std::string& text,
-                                         int sender_player_id,
+                                         const std::string& player_name,
+                                         GG::Clr text_color,
                                          const boost::posix_time::ptime& timestamp,
                                          int recipient_player_id)
 {
-    const ClientApp* app = ClientApp::GetApp();
-    if (!app) {
-        ErrorLogger() << "MessageWnd::HandlePlayerChatMessage couldn't get client app!";
-        return;
-    }
-
-    const std::map<int, PlayerInfo>& players = app->Players();
-    auto player_it = players.find(sender_player_id);
-    if (player_it == players.end()) {
-        ErrorLogger() << "MessageWnd::HandlePlayerChatMessage couldn't message sending player with id: " << sender_player_id;
-        return;
-    }
-
-    const std::string& sender_name = player_it->second.name;
-    const int& sender_empire_id = player_it->second.empire_id;
-
-    GG::Clr sender_colour(ClientUI::TextColor());
-    if (const Empire* sender_empire = GetEmpire(sender_empire_id))
-        sender_colour = sender_empire->Color();
-
     std::string filtered_message = StringtableTextSubstitute(text);
-    std::string wrapped_text = RgbaTag(sender_colour);
+    std::string wrapped_text = RgbaTag(text_color);
     const std::string&& formatted_timestamp = ClientUI::FormatTimestamp(timestamp);
     if (IsValidUTF8(formatted_timestamp))
         wrapped_text += formatted_timestamp;
-    wrapped_text += sender_name + ": " + filtered_message + "</rgba>";
-    TraceLogger() << "HandlePlayerChatMessage sender: " << sender_name
-                  << "  sender empire id: " << sender_empire_id
-                  << "  sender colour rgba tag: " << RgbaTag(sender_colour)
+    wrapped_text += player_name + ": " + filtered_message + "</rgba>";
+    TraceLogger() << "HandlePlayerChatMessage sender: " << player_name
+                  << "  sender colour rgba tag: " << RgbaTag(text_color)
                   << "  filtered message: " << filtered_message
                   << "  timestamp text: " << ClientUI::FormatTimestamp(timestamp)
                   << "  wrapped text: " << wrapped_text;

--- a/UI/ChatWnd.h
+++ b/UI/ChatWnd.h
@@ -14,7 +14,7 @@ class MessageWndEdit;
 
 class MessageWnd : public CUIWnd {
 public:
-    MessageWnd(const std::string& config_name = "");
+    MessageWnd(GG::Flags<GG::WndFlag> flags, const std::string& config_name = "");
     void CompleteConstruction() override;
     //@}
 

--- a/UI/ChatWnd.h
+++ b/UI/ChatWnd.h
@@ -24,7 +24,8 @@ public:
     void PreRender() override;
 
     void            HandlePlayerChatMessage(const std::string& text,
-                                            int sender_player_id,
+                                            const std::string& player_name,
+                                            GG::Clr text_color,
                                             const boost::posix_time::ptime& timestamp,
                                             int recipient_player_id);
     void            HandlePlayerStatusUpdate(Message::PlayerStatus player_status, int about_player_id);

--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -624,7 +624,8 @@ ClientUI::ClientUI() :
     if (GetOptionsDB().Get<bool>("window-reset"))
         CUIWnd::InvalidateUnusedOptions();
 
-    m_message_wnd = GG::Wnd::Create<MessageWnd>(MESSAGE_WND_NAME);
+    m_message_wnd = GG::Wnd::Create<MessageWnd>(GG::INTERACTIVE | GG::DRAGABLE | GG::ONTOP | GG::RESIZABLE |
+                                                CLOSABLE | PINABLE, MESSAGE_WND_NAME);
     m_player_list_wnd = GG::Wnd::Create<PlayerListWnd>(PLAYER_LIST_WND_NAME);
     InitializeWindows();
 

--- a/UI/MultiplayerLobbyWnd.cpp
+++ b/UI/MultiplayerLobbyWnd.cpp
@@ -831,10 +831,8 @@ void MultiPlayerLobbyWnd::DoLayout() {
     g_preview_ul = GG::Pt(ClientWidth() - PREVIEW_SZ.x - CONTROL_MARGIN - PREVIEW_MARGIN, GG::Y(CONTROL_MARGIN + PREVIEW_MARGIN));
     m_preview_image->SizeMove(g_preview_ul, g_preview_ul + PREVIEW_SZ);
 
-    x = CHAT_WIDTH + CONTROL_MARGIN;
-    GG::Y y = std::max(m_save_file_text->RelativeLowerRight().y, m_preview_image->RelativeLowerRight().y) + 7*CONTROL_MARGIN;
-
-    GG::Pt any_can_edit_ul(x, y);
+    GG::Pt any_can_edit_ul(m_preview_image->RelativeUpperLeft().x + CONTROL_MARGIN,
+                           m_preview_image->RelativeLowerRight().y + CONTROL_MARGIN);
     GG::Pt any_can_edit_lr = any_can_edit_ul + GG::Pt(GALAXY_SETUP_PANEL_WIDTH, RADIO_BN_HT);
     m_any_can_edit->SizeMove(any_can_edit_ul, any_can_edit_lr);
 
@@ -847,8 +845,9 @@ void MultiPlayerLobbyWnd::DoLayout() {
     m_ready_bn->MoveTo(GG::Pt(m_cancel_bn->RelativeUpperLeft().x - CONTROL_MARGIN - m_ready_bn->Width(),
                               ClientHeight() - m_cancel_bn->Height() - CONTROL_MARGIN));
 
-    y += CONTROL_MARGIN + RADIO_BN_HT;
-    GG::Pt players_lb_ul(x, y);
+    x = CHAT_WIDTH + CONTROL_MARGIN;
+    GG::Y y(std::max(m_save_file_text->RelativeLowerRight().y, m_browse_saves_btn->RelativeLowerRight().y));
+    GG::Pt players_lb_ul(x, std::max(y, m_any_can_edit->RelativeLowerRight().y) + CONTROL_MARGIN);
     GG::Pt players_lb_lr(ClientWidth() - CONTROL_MARGIN, m_cancel_bn->RelativeUpperLeft().y - CONTROL_MARGIN);
     m_players_lb->SizeMove(players_lb_ul, players_lb_lr);
     std::vector<GG::X> players_lb_col_widths = PlayerRowColWidths(players_lb_lr.x - players_lb_ul.x);

--- a/UI/MultiplayerLobbyWnd.cpp
+++ b/UI/MultiplayerLobbyWnd.cpp
@@ -544,8 +544,7 @@ namespace {
 MultiPlayerLobbyWnd::MultiPlayerLobbyWnd() :
     CUIWnd(UserString("MPLOBBY_WINDOW_TITLE"),
            GG::ONTOP | GG::INTERACTIVE | GG::RESIZABLE),
-    m_chat_box(nullptr),
-    m_chat_input_edit(nullptr),
+    m_chat_wnd(nullptr),
     m_any_can_edit(nullptr),
     m_new_load_game_buttons(nullptr),
     m_galaxy_setup_panel(nullptr),
@@ -561,9 +560,7 @@ MultiPlayerLobbyWnd::MultiPlayerLobbyWnd() :
 void MultiPlayerLobbyWnd::CompleteConstruction() {
     Sound::TempUISoundDisabler sound_disabler;
 
-    m_chat_input_edit = GG::Wnd::Create<CUIEdit>("");
-    m_chat_box = GG::Wnd::Create<CUIMultiEdit>("", GG::MULTI_LINEWRAP | GG::MULTI_READ_ONLY | GG::MULTI_TERMINAL_STYLE);
-    m_chat_box->SetMaxLinesOfHistory(250);
+    m_chat_wnd = GG::Wnd::Create<MessageWnd>("mplobby.chat");
 
     m_any_can_edit = GG::Wnd::Create<CUIStateButton>(UserString("EDITABLE_GALAXY_SETTINGS"), GG::FORMAT_LEFT, std::make_shared<CUICheckBoxRepresenter>());
     m_any_can_edit->SetBrowseModeTime(GetOptionsDB().Get<int>("ui.tooltip.delay"));
@@ -602,8 +599,7 @@ void MultiPlayerLobbyWnd::CompleteConstruction() {
 
     m_start_conditions_text = GG::Wnd::Create<CUILabel>(UserString("MULTIPLAYER_GAME_START_CONDITIONS"), GG::FORMAT_LEFT);
 
-    AttachChild(m_chat_box);
-    AttachChild(m_chat_input_edit);
+    AttachChild(m_chat_wnd);
     AttachChild(m_any_can_edit);
     AttachChild(m_new_load_game_buttons);
     AttachChild(m_galaxy_setup_panel);
@@ -723,13 +719,7 @@ void MultiPlayerLobbyWnd::Render() {
 }
 
 void MultiPlayerLobbyWnd::KeyPress(GG::Key key, std::uint32_t key_code_point, GG::Flags<GG::ModKey> mod_keys) {
-    if ((key == GG::GGK_RETURN || key == GG::GGK_KP_ENTER) &&
-         GG::GUI::GetGUI()->FocusWnd() == m_chat_input_edit)
-    {
-        std::string text = m_chat_input_edit->Text();   // copy, so subsequent clearing doesn't affect typed message that is used later...
-        HumanClientApp::GetApp()->Networking().SendMessage(PlayerChatMessage(text));
-        m_chat_input_edit->SetText("");
-    } else if (m_ready_bn && (key == GG::GGK_RETURN || key == GG::GGK_KP_ENTER)) {
+    if (m_ready_bn && (key == GG::GGK_RETURN || key == GG::GGK_KP_ENTER)) {
         m_ready_bn->LeftClickedSignal();
     } else if (key == GG::GGK_ESCAPE) {
         m_cancel_bn->LeftClickedSignal();
@@ -738,23 +728,25 @@ void MultiPlayerLobbyWnd::KeyPress(GG::Key key, std::uint32_t key_code_point, GG
 
 void MultiPlayerLobbyWnd::ChatMessage(int player_id, const boost::posix_time::ptime& timestamp, const std::string& msg) {
     // look up player name by ID
-    std::string player_name;
+    std::string player_name{UserString("PLAYER") + " " + std::to_string(player_id)};
+    GG::Clr text_color{ClientUI::GetClientUI()->TextColor()};
     for (std::pair<int, PlayerSetupData>& entry : m_lobby_data.m_players) {
-        if (entry.first == player_id && entry.first != Networking::INVALID_PLAYER_ID) {
-            player_name = entry.second.m_player_name;
-            break;
-        }
+        if (entry.first != player_id || entry.first == Networking::INVALID_PLAYER_ID)
+            continue;
+        player_name = entry.second.m_player_name;
+        text_color = entry.second.m_empire_color;
     }
 
-    ChatMessage(player_name, timestamp, msg);
+    m_chat_wnd->HandlePlayerChatMessage(msg, player_name, text_color, timestamp, HumanClientApp::GetApp()->PlayerID());
 }
 
-void MultiPlayerLobbyWnd::ChatMessage(const std::string& player_name,
-                                      const boost::posix_time::ptime& timestamp,
-                                      const std::string& msg)
+void MultiPlayerLobbyWnd::ChatMessage(const std::string& message_text,
+                                      const std::string& player_name,
+                                      GG::Clr text_color,
+                                      const boost::posix_time::ptime& timestamp)
 {
-    // show message with player name in chat box
-    *m_chat_box += ClientUI::FormatTimestamp(timestamp) + player_name + ": " + msg + '\n';
+    m_chat_wnd->HandlePlayerChatMessage(message_text, player_name, text_color, timestamp,
+                                        HumanClientApp::GetApp()->PlayerID());
 }
 
 namespace {
@@ -806,7 +798,7 @@ void MultiPlayerLobbyWnd::Refresh() {
 }
 
 void MultiPlayerLobbyWnd::CleanupChat()
-{ m_chat_box->SetText(""); }
+{ m_chat_wnd->Clear(); }
 
 GG::Pt MultiPlayerLobbyWnd::MinUsableSize() const
 { return GG::Pt(LOBBY_WND_WIDTH, LOBBY_WND_HEIGHT); }
@@ -814,13 +806,9 @@ GG::Pt MultiPlayerLobbyWnd::MinUsableSize() const
 void MultiPlayerLobbyWnd::DoLayout() {
     GG::X x(CONTROL_MARGIN);
 
-    GG::Pt chat_input_ul(x, ClientHeight() - (ClientUI::Pts() + 10) - 2 * CONTROL_MARGIN);
-    GG::Pt chat_input_lr = chat_input_ul + GG::Pt(CHAT_WIDTH - x, m_chat_input_edit->MinUsableSize().y);
-    m_chat_input_edit->SizeMove(chat_input_ul, chat_input_lr);
-
     GG::Pt chat_box_ul(x, GG::Y(CONTROL_MARGIN));
-    GG::Pt chat_box_lr(CHAT_WIDTH, m_chat_input_edit->RelativeUpperLeft().y - CONTROL_MARGIN);
-    m_chat_box->SizeMove(chat_box_ul, chat_box_lr);
+    GG::Pt chat_box_lr(CHAT_WIDTH, ClientHeight() - CONTROL_MARGIN);
+    m_chat_wnd->SizeMove(chat_box_ul, chat_box_lr);
 
     const GG::Y RADIO_BN_HT(ClientUI::Pts() + 4);
 
@@ -852,22 +840,22 @@ void MultiPlayerLobbyWnd::DoLayout() {
 
     const GG::Y TEXT_HEIGHT = GG::Y(ClientUI::Pts() * 3/2);
 
-    y += CONTROL_MARGIN + RADIO_BN_HT;
-    GG::Pt players_lb_ul(x, y);
-    GG::Pt players_lb_lr = players_lb_ul + GG::Pt(ClientWidth() - CONTROL_MARGIN - x, m_chat_input_edit->RelativeUpperLeft().y - CONTROL_MARGIN - y);
-    m_players_lb->SizeMove(players_lb_ul, players_lb_lr);
-    std::vector<GG::X> players_lb_col_widths = PlayerRowColWidths(players_lb_lr.x - players_lb_ul.x);
-    m_players_lb_headers->SetColWidths(players_lb_col_widths);
-    for (unsigned int i = 0; i < players_lb_col_widths.size(); ++i)
-        m_players_lb->SetColWidth(i, players_lb_col_widths[i]);
-    m_players_lb->RequirePreRender();
-
     m_ready_bn->SizeMove(GG::Pt(GG::X0, GG::Y0), GG::Pt(GG::X(125), m_ready_bn->MinUsableSize().y));
     m_cancel_bn->SizeMove(GG::Pt(GG::X0, GG::Y0), GG::Pt(GG::X(125), m_ready_bn->MinUsableSize().y));
     m_cancel_bn->MoveTo(GG::Pt(ClientWidth() - m_cancel_bn->Width() - CONTROL_MARGIN,
                                ClientHeight() - m_cancel_bn->Height() - CONTROL_MARGIN));
     m_ready_bn->MoveTo(GG::Pt(m_cancel_bn->RelativeUpperLeft().x - CONTROL_MARGIN - m_ready_bn->Width(),
                               ClientHeight() - m_cancel_bn->Height() - CONTROL_MARGIN));
+
+    y += CONTROL_MARGIN + RADIO_BN_HT;
+    GG::Pt players_lb_ul(x, y);
+    GG::Pt players_lb_lr(ClientWidth() - CONTROL_MARGIN, m_cancel_bn->RelativeUpperLeft().y - CONTROL_MARGIN);
+    m_players_lb->SizeMove(players_lb_ul, players_lb_lr);
+    std::vector<GG::X> players_lb_col_widths = PlayerRowColWidths(players_lb_lr.x - players_lb_ul.x);
+    m_players_lb_headers->SetColWidths(players_lb_col_widths);
+    for (unsigned int i = 0; i < players_lb_col_widths.size(); ++i)
+        m_players_lb->SetColWidth(i, players_lb_col_widths[i]);
+    m_players_lb->RequirePreRender();
 
     GG::Pt start_conditions_text_ul(x, ClientHeight() - m_cancel_bn->Height() - CONTROL_MARGIN);
     GG::Pt start_conditions_text_lr = start_conditions_text_ul + GG::Pt(m_cancel_bn->RelativeUpperLeft().x - x, TEXT_HEIGHT);

--- a/UI/MultiplayerLobbyWnd.cpp
+++ b/UI/MultiplayerLobbyWnd.cpp
@@ -560,7 +560,7 @@ MultiPlayerLobbyWnd::MultiPlayerLobbyWnd() :
 void MultiPlayerLobbyWnd::CompleteConstruction() {
     Sound::TempUISoundDisabler sound_disabler;
 
-    m_chat_wnd = GG::Wnd::Create<MessageWnd>("mplobby.chat");
+    m_chat_wnd = GG::Wnd::Create<MessageWnd>(GG::INTERACTIVE, "mplobby.chat");
 
     m_any_can_edit = GG::Wnd::Create<CUIStateButton>(UserString("EDITABLE_GALAXY_SETTINGS"), GG::FORMAT_LEFT, std::make_shared<CUICheckBoxRepresenter>());
     m_any_can_edit->SetBrowseModeTime(GetOptionsDB().Get<int>("ui.tooltip.delay"));

--- a/UI/MultiplayerLobbyWnd.h
+++ b/UI/MultiplayerLobbyWnd.h
@@ -4,6 +4,7 @@
 #include <vector>
 #include <GG/GGFwd.h>
 
+#include "ChatWnd.h"
 #include "CUIWnd.h"
 #include "CUIControls.h"
 #include "GalaxySetupWnd.h"
@@ -35,9 +36,10 @@ public:
     void KeyPress(GG::Key key, std::uint32_t key_code_point, GG::Flags<GG::ModKey> mod_keys) override;
 
     void            ChatMessage(int player_id, const boost::posix_time::ptime& timestamp, const std::string& msg);
-    void            ChatMessage(const std::string& player_name,
-                                const boost::posix_time::ptime& timestamp,
-                                const std::string& msg);
+    void            ChatMessage(const std::string& message_text,
+                                const std::string& player_name,
+                                GG::Clr text_color,
+                                const boost::posix_time::ptime& timestamp);
     void            LobbyUpdate(const MultiplayerLobbyData& lobby_data);
     void            Refresh();
     void            CleanupChat();
@@ -75,8 +77,7 @@ private:
 
     MultiplayerLobbyData    m_lobby_data;   ///< a copy of the most recently received lobby update
 
-    std::shared_ptr<GG::MultiEdit>          m_chat_box;
-    std::shared_ptr<GG::Edit>               m_chat_input_edit;
+    std::shared_ptr<MessageWnd>             m_chat_wnd;
     std::shared_ptr<CUIStateButton>         m_any_can_edit;
     std::shared_ptr<GG::RadioButtonGroup>   m_new_load_game_buttons;
     std::shared_ptr<GalaxySetupPanel>       m_galaxy_setup_panel;

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -606,7 +606,17 @@ boost::statechart::result PlayingGame::react(const PlayerChat& msg) {
     boost::posix_time::ptime timestamp;
     ExtractServerPlayerChatMessageData(msg.m_message, sending_player_id, timestamp, text);
 
-    Client().GetClientUI().GetMessageWnd()->HandlePlayerChatMessage(text, sending_player_id, timestamp, Client().PlayerID());
+    std::string player_name{UserString("PLAYER") + " " + std::to_string(sending_player_id)};
+    GG::Clr text_color{Client().GetClientUI().TextColor()};
+    auto players = Client().Players();
+    auto player_it = players.find(sending_player_id);
+    if (player_it != players.end()) {
+        player_name = player_it->second.name;
+        if (auto empire = GetEmpire(player_it->second.empire_id))
+            text_color = empire->Color();
+    }
+
+    Client().GetClientUI().GetMessageWnd()->HandlePlayerChatMessage(text, player_name, text_color, timestamp, Client().PlayerID());
 
     return discard_event();
 }

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -553,9 +553,8 @@ boost::statechart::result MPLobby::react(const ChatHistory& msg) {
     ExtractChatHistoryMessage(msg.m_message, chat_history);
 
     const auto& wnd = Client().GetClientUI().GetMultiPlayerLobbyWnd();
-    for (const auto& elem : chat_history) {
-        wnd->ChatMessage(elem.m_player_name, elem.m_timestamp, elem.m_text);
-    }
+    for (const auto& elem : chat_history)
+        wnd->ChatMessage(elem.m_text, elem.m_player_name, elem.m_text_color, elem.m_timestamp);
 
     return discard_event();
 }

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -981,14 +981,16 @@ void ServerApp::UpdateCombatLogs(const Message& msg, PlayerConnectionPtr player_
     player_connection->SendMessage(DispatchCombatLogsMessage(logs));
 }
 
-void ServerApp::PushChatMessage(const boost::posix_time::ptime& timestamp,
+void ServerApp::PushChatMessage(const std::string& text,
                                 const std::string& player_name,
-                                const std::string& msg)
+                                GG::Clr text_color,
+                                const boost::posix_time::ptime& timestamp)
 {
     ChatHistoryEntity chat;
     chat.m_timestamp = timestamp;
     chat.m_player_name = player_name;
-    chat.m_text = msg;
+    chat.m_text_color = text_color;
+    chat.m_text = text;
     m_chat_history.push_back(chat);
 }
 

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -241,9 +241,10 @@ public:
     /** Send the requested combat logs to the client.*/
     void UpdateCombatLogs(const Message& msg, PlayerConnectionPtr player_connection);
 
-    void PushChatMessage(const boost::posix_time::ptime& timestamp,
+    void PushChatMessage(const std::string& text,
                          const std::string& player_name,
-                         const std::string& msg);
+                         GG::Clr text_color,
+                         const boost::posix_time::ptime& timestamp);
 
     ServerNetworking&           Networking();     ///< returns the networking object for the server
 

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -1326,7 +1326,13 @@ sc::result MPLobby::react(const PlayerChat& msg) {
     boost::posix_time::ptime timestamp = boost::posix_time::second_clock::universal_time();
 
     if (sender->GetClientType() != Networking::CLIENT_TYPE_AI_PLAYER) {
-        server.PushChatMessage(timestamp, sender->PlayerName(), data);
+        GG::Clr text_color(255, 255, 255, 0);
+        for (const auto& player : m_lobby_data->m_players) {
+            if (player.first != sender->PlayerID())
+                continue;
+            text_color = player.second.m_empire_color;
+        }
+        server.PushChatMessage(data, sender->PlayerName(), text_color, timestamp);
     }
 
     if (receiver == Networking::INVALID_PLAYER_ID) { // the receiver is everyone
@@ -1975,7 +1981,11 @@ sc::result PlayingGame::react(const PlayerChat& msg) {
     boost::posix_time::ptime timestamp = boost::posix_time::second_clock::universal_time();
 
     if (sender->GetClientType() != Networking::CLIENT_TYPE_AI_PLAYER) {
-        server.PushChatMessage(timestamp, sender->PlayerName(), data);
+        GG::Clr text_color(255, 255, 255, 0);
+        if (auto empire = GetEmpire(sender->PlayerID()))
+            text_color = empire->Color();
+
+        server.PushChatMessage(data, sender->PlayerName(), text_color, timestamp);
     }
 
     for (auto it = server.m_networking.established_begin();

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -266,6 +266,8 @@ private:
     void serialize(Archive& ar, const unsigned int version);
 };
 
+BOOST_CLASS_VERSION(ChatHistoryEntity, 1);
+
 /** Information about one player that other players are informed of.  Assembled by server and sent to players. */
 struct PlayerInfo {
     PlayerInfo() :

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -258,6 +258,7 @@ struct FO_COMMON_API ChatHistoryEntity {
     boost::posix_time::ptime m_timestamp;
     std::string m_player_name;
     std::string m_text;
+    GG::Clr m_text_color;
 
 private:
     friend class boost::serialization::access;

--- a/util/SerializeMultiplayerCommon.cpp
+++ b/util/SerializeMultiplayerCommon.cpp
@@ -199,9 +199,10 @@ template void MultiplayerLobbyData::serialize<freeorion_xml_iarchive>(freeorion_
 template <class Archive>
 void ChatHistoryEntity::serialize(Archive& ar, const unsigned int version)
 {
-    ar  & BOOST_SERIALIZATION_NVP(m_timestamp)
+    ar  & BOOST_SERIALIZATION_NVP(m_text)
         & BOOST_SERIALIZATION_NVP(m_player_name)
-        & BOOST_SERIALIZATION_NVP(m_text);
+        & BOOST_SERIALIZATION_NVP(m_text_color)
+        & BOOST_SERIALIZATION_NVP(m_timestamp);
 }
 
 template void ChatHistoryEntity::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, const unsigned int);

--- a/util/SerializeMultiplayerCommon.cpp
+++ b/util/SerializeMultiplayerCommon.cpp
@@ -199,10 +199,16 @@ template void MultiplayerLobbyData::serialize<freeorion_xml_iarchive>(freeorion_
 template <class Archive>
 void ChatHistoryEntity::serialize(Archive& ar, const unsigned int version)
 {
-    ar  & BOOST_SERIALIZATION_NVP(m_text)
-        & BOOST_SERIALIZATION_NVP(m_player_name)
-        & BOOST_SERIALIZATION_NVP(m_text_color)
-        & BOOST_SERIALIZATION_NVP(m_timestamp);
+    if (version < 1) {
+        ar  & BOOST_SERIALIZATION_NVP(m_timestamp)
+            & BOOST_SERIALIZATION_NVP(m_player_name)
+            & BOOST_SERIALIZATION_NVP(m_text);
+    } else {
+        ar  & BOOST_SERIALIZATION_NVP(m_text)
+            & BOOST_SERIALIZATION_NVP(m_player_name)
+            & BOOST_SERIALIZATION_NVP(m_text_color)
+            & BOOST_SERIALIZATION_NVP(m_timestamp);
+    }
 }
 
 template void ChatHistoryEntity::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, const unsigned int);


### PR DESCRIPTION
Replaces chat controls in MultiPlayerLobbyWnd with MessageWnd

Resolves #1995
Toggling chat window open/shown reserved for [rework of lobby layout](http://freeorion.org/forum/viewtopic.php?f=6&t=10408).