### PR TITLE
BT_STOCKPILE

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -233,6 +233,7 @@ namespace {
       * Also checks if elements will be completed this turn. */
     void SetProdQueueElementSpending(
         std::map<std::set<int>, float> available_pp, float available_stockpile,
+        float& stockpile_transfer,
         const std::vector<std::set<int>>& queue_element_resource_sharing_object_groups,
         const std::map<std::pair<ProductionQueue::ProductionItem, int>,
                        std::pair<float, int>>& queue_item_costs_and_times,
@@ -347,14 +348,17 @@ namespace {
             // record allocation from group
             float group_drawdown = std::min(allocation, group_pp_available);
             allocated_pp[group] += group_drawdown;  // relies on default initial mapped value of 0.0f
+            if (queue_element.item.build_type == BT_STOCKPILE) {
+                stockpile_transfer += group_drawdown;
+            }
             group_pp_available -= group_drawdown;
 
-            float stockpile_drawdown = allocation <= group_drawdown ?  0.0f : (allocation - group_drawdown);
-                                       // 0.0f : (allocation - group_drawdown) / stockpile_conversion_rate;
+            float stockpile_drawdown = allocation <= group_drawdown ? 0.0f : (allocation - group_drawdown);
             TraceLogger() << "allocation: " << allocation
                           << "  to: " << queue_element.item.name
                           << "  from group: " << group_drawdown
                           << "  from stockpile: " << stockpile_drawdown
+                          << "  to stockpile:" << stockpile_transfer
                           << "  group remaining: " << group_pp_available;
 
             // record allocation from stockpile
@@ -365,7 +369,6 @@ namespace {
                 allocated_stockpile_pp[group] += stockpile_drawdown;
                 available_stockpile -= stockpile_drawdown;
             }
-
 
             // check for completion
             float block_cost = item_cost * queue_element.blocksize;
@@ -670,6 +673,11 @@ ProductionQueue::ProductionItem::ProductionItem() :
     build_type(INVALID_BUILD_TYPE)
 {}
 
+ProductionQueue::ProductionItem::ProductionItem(BuildType build_type_) :
+    build_type(build_type_),
+    name("PROJECT_BT_STOCKPILE")
+{}
+
 ProductionQueue::ProductionItem::ProductionItem(BuildType build_type_, std::string name_) :
     build_type(build_type_),
     name(name_)
@@ -699,6 +707,9 @@ bool ProductionQueue::ProductionItem::CostIsProductionLocationInvariant() const 
         if (!design)
             return true;
         return design->ProductionCostTimeLocationInvariant();
+
+    } else if (build_type == BT_STOCKPILE) {
+        return true;
     }
     return false;
 }
@@ -718,6 +729,7 @@ bool ProductionQueue::ProductionItem::EnqueueConditionPassedAt(int location_id) 
         break;
     }
     case BT_SHIP:   // ships don't have enqueue location conditions
+    case BT_STOCKPILE:  // stockpile can always be enqueued 
     default:
         return true;
     }
@@ -794,6 +806,7 @@ ProductionQueue::ProductionItem::CompletionSpecialConsumption(int location_id) c
         break;
     }
     case BT_PROJECT:    // TODO
+    case BT_STOCKPILE:  // stockpile transfer consumes no special
     default:
         break;
     }
@@ -847,6 +860,7 @@ ProductionQueue::ProductionItem::CompletionMeterConsumption(int location_id) con
         break;
     }
     case BT_PROJECT:    // TODO
+    case BT_STOCKPILE:  // stockpile transfer happens before completion - nothing to do
     default:
         break;
     }
@@ -882,7 +896,9 @@ ProductionQueue::Element::Element(ProductionItem item_, int empire_id_, int orde
     blocksize_memory(blocksize_),
     paused(paused_),
     allowed_imperial_stockpile_use(allowed_imperial_stockpile_use_)
-{}
+{
+    ErrorLogger() << "ProductionQueue::Element::Element() : BT_STOCKPILE";
+}
 
 ProductionQueue::Element::Element(BuildType build_type, std::string name, int empire_id_, int ordered_,
                                   int remaining_, int blocksize_, int location_, bool paused_,
@@ -1099,9 +1115,10 @@ void ProductionQueue::Update() {
     for (unsigned int i = 0; i < sim_queue_original_indices.size(); ++i)
         sim_queue_original_indices[i] = i;
 
+    float transfer_to_stockpile = 0.0f;
     // allocate pp to queue elements, returning updated available pp and updated
     // allocated pp for each group of resource sharing objects
-    SetProdQueueElementSpending(available_pp, available_stockpile, queue_element_groups,
+    SetProdQueueElementSpending(available_pp, available_stockpile, transfer_to_stockpile, queue_element_groups,
                                 queue_item_costs_and_times, is_producible, m_queue,
                                 m_object_group_allocated_pp, m_object_group_allocated_stockpile_pp,
                                 m_projects_in_progress, false);
@@ -1110,6 +1127,7 @@ void ProductionQueue::Update() {
     m_expected_new_stockpile_amount = CalculateNewStockpile(
         m_empire_id, pp_in_stockpile, available_pp, m_object_group_allocated_pp,
         m_object_group_allocated_stockpile_pp);
+    m_expected_new_stockpile_amount += transfer_to_stockpile;
 
     // if at least one resource-sharing system group have available PP, simulate
     // future turns to predict when build items will be finished
@@ -1159,6 +1177,7 @@ void ProductionQueue::Update() {
     sim_time_start = boost::posix_time::ptime(boost::posix_time::microsec_clock::local_time()); 
     std::map<std::set<int>, float>  allocated_pp;
     float sim_available_stockpile = available_stockpile;
+    float sim_transfer_to_stockpile = transfer_to_stockpile;
     float sim_pp_in_stockpile = pp_in_stockpile;
     std::map<std::set<int>, float>  allocated_stockpile_pp;
     int dummy_int = 0;
@@ -1175,7 +1194,7 @@ void ProductionQueue::Update() {
         allocated_pp.clear();
         allocated_stockpile_pp.clear();
 
-        SetProdQueueElementSpending(available_pp, sim_available_stockpile, queue_element_groups,
+        SetProdQueueElementSpending(available_pp, sim_available_stockpile, sim_transfer_to_stockpile, queue_element_groups,
                                     queue_item_costs_and_times, is_producible, sim_queue,
                                     allocated_pp, allocated_stockpile_pp, dummy_int, true);
 
@@ -1202,6 +1221,7 @@ void ProductionQueue::Update() {
         sim_pp_in_stockpile = CalculateNewStockpile(m_empire_id, sim_pp_in_stockpile,
                                                     available_pp, allocated_pp,
                                                     allocated_stockpile_pp);
+        sim_pp_in_stockpile += sim_transfer_to_stockpile;
         sim_available_stockpile = std::min(sim_pp_in_stockpile, stockpile_limit);
     }
 
@@ -1660,6 +1680,8 @@ std::pair<float, int> Empire::ProductionCostAndTime(const ProductionQueue::Produ
             return std::make_pair(design->ProductionCost(m_id, location_id),
                                   design->ProductionTime(m_id, location_id));
         return std::make_pair(-1.0, -1);
+    } else if (item.build_type == BT_STOCKPILE) {
+        return std::make_pair(1.0, 1);
     }
     ErrorLogger() << "Empire::ProductionCostAndTime was passed a ProductionItem with an invalid BuildType";
     return std::make_pair(-1.0, -1);
@@ -1668,10 +1690,53 @@ std::pair<float, int> Empire::ProductionCostAndTime(const ProductionQueue::Produ
 bool Empire::HasExploredSystem(int ID) const
 { return (m_explored_systems.find(ID) != m_explored_systems.end()); }
 
+bool Empire::ProducibleItem(BuildType build_type, int location_id) const {
+    if (build_type == BT_SHIP)
+        throw std::invalid_argument("Empire::ProducibleItem was passed BuildType BT_SHIP with no further parameters, but ship designs are tracked by number");
+    
+    if (build_type == BT_BUILDING)
+        throw std::invalid_argument("Empire::ProducibleItem was passed BuildType BT_BUILDING with no further parameters, but these types are tracked by name");
+
+    auto build_location = GetUniverseObject(location_id);
+    if (!build_location)
+        return false;
+
+    if (build_type == BT_STOCKPILE) {
+        Empire* empire = GetEmpire(m_id);
+        if (!empire) {
+            DebugLogger() << "ShipDesign::ProductionLocation: Unable to get pointer to empire " << m_id;
+            return false;
+        }
+
+        // must own the production location...
+        auto location = GetUniverseObject(location_id);
+        if (!location) {
+            WarnLogger() << "ShipDesign::ProductionLocation unable to get location object with id " << location_id;
+            return false;
+        }
+        if (!location->OwnedBy(m_id))
+            return false;
+
+        auto planet = std::dynamic_pointer_cast<const Planet>(location);
+        std::shared_ptr<const Ship> ship;
+        if (!planet)
+             return false;
+
+        return true;
+    } else {
+        ErrorLogger() << "Empire::ProducibleItem was passed an invalid BuildType";
+        return false;
+    }
+
+}
+
 bool Empire::ProducibleItem(BuildType build_type, const std::string& name, int location) const {
     // special case to check for ships being passed with names, not design ids
     if (build_type == BT_SHIP)
         throw std::invalid_argument("Empire::ProducibleItem was passed BuildType BT_SHIP with a name, but ship designs are tracked by number");
+
+    if (build_type == BT_STOCKPILE)
+        throw std::invalid_argument("Empire::ProducibleItem was passed BuildType BT_STOCKPILE with a name, but the stockpile does not need an identification");
 
     if (build_type == BT_BUILDING && !BuildingTypeAvailable(name))
         return false;
@@ -1699,6 +1764,9 @@ bool Empire::ProducibleItem(BuildType build_type, int design_id, int location) c
     if (build_type == BT_BUILDING)
         throw std::invalid_argument("Empire::ProducibleItem was passed BuildType BT_BUILDING with a design id number, but these types are tracked by name");
 
+    if (build_type == BT_STOCKPILE)
+        throw std::invalid_argument("Empire::ProducibleItem was passed BuildType BT_STOCKPILE with a design id, but the stockpile does not need an identification");
+
     if (build_type == BT_SHIP && !ShipDesignAvailable(design_id))
         return false;
 
@@ -1725,6 +1793,8 @@ bool Empire::ProducibleItem(const ProductionQueue::ProductionItem& item, int loc
         return ProducibleItem(item.build_type, item.name, location);
     else if (item.build_type == BT_SHIP)
         return ProducibleItem(item.build_type, item.design_id, location);
+    else if (item.build_type == BT_STOCKPILE)
+        return ProducibleItem(item.build_type, location);
     else
         throw std::invalid_argument("Empire::ProducibleItem was passed a ProductionItem with an invalid BuildType");
     return false;
@@ -1751,10 +1821,13 @@ bool Empire::EnqueuableItem(const ProductionQueue::ProductionItem& item, int loc
         return EnqueuableItem(item.build_type, item.name, location);
     else if (item.build_type == BT_SHIP)    // ships don't have a distinction between enqueuable and producible
         return ProducibleItem(item.build_type, item.design_id, location);
+    else if (item.build_type == BT_STOCKPILE) // stockpile does not have a distinction between enqueuable and producible
+        return ProducibleItem(item.build_type, location);
     else
         throw std::invalid_argument("Empire::ProducibleItem was passed a ProductionItem with an invalid BuildType");
     return false;
 }
+
 
 int Empire::NumSitRepEntries(int turn/* = INVALID_GAME_TURN*/) const {
     if (turn == INVALID_GAME_TURN)
@@ -2231,11 +2304,11 @@ void Empire::SetTechResearchProgress(const std::string& name, float progress) {
 const unsigned int MAX_PROD_QUEUE_SIZE = 500;
 
 void Empire::PlaceProductionOnQueue(BuildType build_type, const std::string& name, int number,
-                                    int blocksize, int location, int pos/* = -1*/)
+    int blocksize, int location, int pos/* = -1*/)
 {
     if (!EnqueuableItem(build_type, name, location)) {
         ErrorLogger() << "Empire::PlaceProductionOnQueue() : Attempted to place non-enqueuable item in queue: build_type: "
-                      << boost::lexical_cast<std::string>(build_type) << "  name: " << name << "  location: " << location;
+            << boost::lexical_cast<std::string>(build_type) << "  name: " << name << "  location: " << location;
         return;
     }
 
@@ -2246,12 +2319,40 @@ void Empire::PlaceProductionOnQueue(BuildType build_type, const std::string& nam
 
     if (!ProducibleItem(build_type, name, location)) {
         ErrorLogger() << "Empire::PlaceProductionOnQueue() : Placed a non-buildable item in queue: build_type: "
-                      << boost::lexical_cast<std::string>(build_type) << "  name: " << name << "  location: " << location;
+            << boost::lexical_cast<std::string>(build_type) << "  name: " << name << "  location: " << location;
         return;
     }
 
-    ProductionQueue::Element build(build_type, name, m_id, number, number,
-                                   blocksize, location);
+    ProductionQueue::Element build(build_type, name, m_id, number, number, blocksize, location);
+    
+    if (pos < 0 || static_cast<int>(m_production_queue.size()) <= pos)
+        m_production_queue.push_back(build);
+    else
+        m_production_queue.insert(m_production_queue.begin() + pos, build);
+}
+
+void Empire::PlaceProductionOnQueue(BuildType build_type, BuildType dummy, int number,
+    int blocksize, int location, int pos/* = -1*/)
+{
+ErrorLogger() << "Empire::PlaceProductionOnQueue() : BT_STOCKPILE";
+    // no distinction between enqueuable and producible...
+
+    if (m_production_queue.size() >= MAX_PROD_QUEUE_SIZE) {
+        ErrorLogger() << "Empire::PlaceProductionOnQueue() : Maximum queue size reached. Aborting enqueue";
+        return;
+    }
+
+    if (!ProducibleItem(build_type, location)) {
+        ErrorLogger() << "Empire::PlaceProductionOnQueue() : Placed a non-buildable item in queue: build_type: "
+            << boost::lexical_cast<std::string>(build_type) << "  location: " << location;
+        return;
+    }
+
+    const bool paused = false;
+    const bool allowed_imperial_stockpile_use = false;
+    const std::string dummy_str = "BT_STOCKPILE_DUMMY_BLD_NAME";
+    ProductionQueue::Element build(build_type, dummy_str, m_id, number, number, blocksize, location, paused, allowed_imperial_stockpile_use);
+
     if (pos < 0 || static_cast<int>(m_production_queue.size()) <= pos)
         m_production_queue.push_back(build);
     else
@@ -2288,6 +2389,8 @@ void Empire::PlaceProductionOnQueue(const ProductionQueue::ProductionItem& item,
         PlaceProductionOnQueue(item.build_type, item.name, number, blocksize, location, pos);
     else if (item.build_type == BT_SHIP)
         PlaceProductionOnQueue(item.build_type, item.design_id, number, blocksize, location, pos);
+    else if (item.build_type == BT_STOCKPILE)
+        PlaceProductionOnQueue(item.build_type, item.build_type, number, blocksize, location, pos);
     else
         throw std::invalid_argument("Empire::PlaceProductionOnQueue was passed a ProductionQueue::ProductionItem with an invalid BuildType");
 }
@@ -2907,6 +3010,10 @@ void Empire::CheckProductionProgress() {
                 build_description = "Ships(s) with design id " + std::to_string(elem.item.design_id);
                 break;
             }
+            case BT_STOCKPILE: {
+                build_description = "Stockpile PP transfer";
+                break;
+            }
             default: 
                 build_description = "unknown build type";
         }
@@ -3110,6 +3217,11 @@ void Empire::CheckProductionProgress() {
                 AddSitRepEntry(CreateShipBlockBuiltSitRep(system->ID(), ship->DesignID(), elem.blocksize));
                 DebugLogger() << "New block of "<< elem.blocksize << " ships created on turn: " << ship->CreationTurn();
             }
+            break;
+        }
+
+        case BT_STOCKPILE: {
+            DebugLogger() << "Finished a transfer to stockpile";
             break;
         }
 

--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -115,6 +115,7 @@ struct FO_COMMON_API ProductionQueue {
     struct FO_COMMON_API ProductionItem {
         ProductionItem();
 
+        ProductionItem(BuildType build_type_);   ///< basic ctor for BuildTypes only have one type of item (e.g. stockpile transfer item)
         ProductionItem(BuildType build_type_, std::string name_);   ///< basic ctor for BuildTypes that use std::string to identify specific items (BuildingTypes)
         ProductionItem(BuildType build_type_, int design_id_);      ///< basic ctor for BuildTypes that use int to indentify the design of the item (ShipDesigns)
 
@@ -356,6 +357,7 @@ public:
     std::pair<float, int>   ProductionCostAndTime(const ProductionQueue::Element& element) const;
     std::pair<float, int>   ProductionCostAndTime(const ProductionQueue::ProductionItem& item, int location_id) const;
 
+    bool                    ProducibleItem(BuildType build_type, int location) const;  ///< Returns true iff this empire can produce the specified item at the specified location.
     bool                    ProducibleItem(BuildType build_type, const std::string& name, int location) const;  ///< Returns true iff this empire can produce the specified item at the specified location.
     bool                    ProducibleItem(BuildType build_type, int design_id, int location) const;            ///< Returns true iff this empire can produce the specified item at the specified location.
     bool                    ProducibleItem(const ProductionQueue::ProductionItem& item, int location) const;    ///< Returns true iff this empire can produce the specified item at the specified location.
@@ -440,6 +442,13 @@ public:
       * placed at the end of the queue. */
     void PlaceProductionOnQueue(BuildType build_type, int design_id, int number,
                                 int blocksize, int location, int pos = -1);
+    /** Adds the indicated build to the production queue, placing it before
+    * position \a pos.  If \a pos < 0 or queue.size() <= pos, the build is
+    * placed at the end of the queue.
+    * The second parameter is there for overloading resolution and gets ignored.
+    */
+    void PlaceProductionOnQueue(BuildType build_type, BuildType dummy, int number,
+        int blocksize, int location, int pos = -1);
     /** Adds the indicated build to the production queue, placing it before
       * position \a pos.  If \a pos < 0 or queue.size() <= pos, the build is
       * placed at the end of the queue. */

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -328,6 +328,15 @@ FORMAT_LIST_10_ITEMS
 FORMAT_LIST_MANY_ITEMS
 %1% %2%, %3%, %4%, %5%, %6%, %7%, %8%, %9%, %10%, %11% ...
 
+##
+## Build Projects
+##
+
+PROJECT_BT_STOCKPILE
+Stockpile Transfer Units
+
+PROJECT_BT_STOCKPILE_DESC
+Transfers PP into the imperial stockpile
 
 ##
 ## Predefined Ship Designs (located in default/scripting/ship_designs/)
@@ -8261,6 +8270,10 @@ Building
 OBJ_SHIP
 Ship
 
+# As the OBJ_SHIP and OBJ_BUILDING are used in the production window, we use OBJ_PROJECT for BT_STOCKPILING
+OBJ_PROJECT
+Project
+
 # Universe object types
 OBJ_FLEET
 Fleet
@@ -8738,6 +8751,10 @@ building
 # Build types
 BT_SHIP
 ship
+
+# Build types
+BT_STOCKPILE
+stockpiling
 
 # Resource types
 INVALID_RESOURCE_TYPE

--- a/python/EnumWrapper.cpp
+++ b/python/EnumWrapper.cpp
@@ -66,6 +66,7 @@ namespace FreeOrionPython {
         enum_<BuildType>("buildType")
             .value("building",          BT_BUILDING)
             .value("ship",              BT_SHIP)
+            .value("stockpile",         BT_STOCKPILE)
         ;
         enum_<ResourceType>("resourceType")
             .value("industry",      RE_INDUSTRY)

--- a/universe/Enums.h
+++ b/universe/Enums.h
@@ -221,6 +221,7 @@ GG_ENUM(BuildType,
     BT_BUILDING,            ///< a Building object is being built
     BT_SHIP,                ///< a Ship object is being built
     BT_PROJECT,             ///< a project may produce effects while on the queue, may or may not ever complete, and does not result in a ship or building being produced
+    BT_STOCKPILE,
     NUM_BUILD_TYPES
 )
 

--- a/util/Order.cpp
+++ b/util/Order.cpp
@@ -920,7 +920,7 @@ void ProductionQueueOrder::ExecuteImpl() const {
     auto empire = GetValidatedEmpire();
 
     try {
-        if (m_item.build_type == BT_BUILDING || m_item.build_type == BT_SHIP) {
+        if (m_item.build_type == BT_BUILDING || m_item.build_type == BT_SHIP || m_item.build_type == BT_STOCKPILE) {
             DebugLogger() << "ProductionQueueOrder place " << m_item.Dump();
             empire->PlaceProductionOnQueue(m_item, m_number, 1, m_location, m_new_index);
 


### PR DESCRIPTION
The aim of this branch to make the [stockpile "project" build item](http://www.freeorion.org/forum/viewtopic.php?f=9&t=10892) work.

State: functional. So "make it work" is done

- stockpiling projects have a quantity and a repetition count
- basic cost of a stockpiling project is 1PP and 1 turn
- stockpiling projects are not allowed to draw from the imperial stockpile and the menu option for enabling is only shown for ships and buildings
- PP spent on a stockpiling project are added to the next turns imperial stockpile
- there is nothing special happening when a stockpiling project is finished

General next steps:
* Fix issue: encyclopedia entry for stockpiling (not sure what i did wrong, help wanted); probably open a issue after merging
* code review, cleanup, squash, merge (discussion on github)
* playtesting (help wanted)
* maybe refactor build item structure (suggestions welcome)

For "make it right" - I am not completely happy with having another overloaded version of build item type on so many different levels. Open for suggestions.
