### PR TITLE
Implement game rule to limits count of alive human players considered winners.

### DIFF
--- a/default/scripting/game_rules.focs.txt
+++ b/default/scripting/game_rules.focs.txt
@@ -119,3 +119,12 @@ GameRule
     default = 6
     min = 0
     max = 999
+
+GameRule
+    name = "RULE_THRESHOLD_HUMAN_PLAYER_WIN"
+    description = "RULE_THRESHOLD_HUMAN_PLAYER_WIN_DESC"
+    category = "BALANCE"
+    type = Integer
+    default = 0
+    min = 0
+    max = 999

--- a/default/scripting/game_rules.focs.txt
+++ b/default/scripting/game_rules.focs.txt
@@ -128,3 +128,10 @@ GameRule
     default = 0
     min = 0
     max = 999
+
+GameRule
+    name = "RULE_ONLY_ALLIANCE_WIN"
+    description = "RULE_ONLY_ALLIANCE_WIN_DESC"
+    category = "BALANCE"
+    type = Toggle
+    default = On

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1153,6 +1153,12 @@ Threshold for human player winners
 RULE_THRESHOLD_HUMAN_PLAYER_WIN_DESC
 Threshold for count of alive human players for them to be considered winners. Not active for single-player.
 
+RULE_ONLY_ALLIANCE_WIN
+Only alliance wins
+
+RULE_ONLY_ALLIANCE_WIN_DESC
+Only alliance of human players could win. Not active for single-player.
+
 
 ##
 ## Command-line and options database entries

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1148,16 +1148,16 @@ RULE_HABITABLE_SIZE_DESC
 Value used to adjust for [[encyclopedia POPULATION_TITLE_SHORT_DESC]] changes on a planet of this size.
 
 RULE_THRESHOLD_HUMAN_PLAYER_WIN
-Threshold for human player winners
+Max human player winners
 
 RULE_THRESHOLD_HUMAN_PLAYER_WIN_DESC
-Threshold for count of alive human players for them to be considered winners. Not active for single-player.
+Maximum number of human players that could win together in multiplayer games if there are no other human player survivors.
 
 RULE_ONLY_ALLIANCE_WIN
-Only alliance wins
+Only allied players win
 
 RULE_ONLY_ALLIANCE_WIN_DESC
-Only alliance of human players could win. Not active for single-player.
+Allied players could win together if the number of human players in their alliance is no large than the maximum human player winners and there are no other human player survivors.
 
 
 ##
@@ -6849,7 +6849,7 @@ VICTORY_ALL_ENEMIES_ELIMINATED
 VICTORY! The %empire% is the last surviving empire.
 
 VICTORY_FEW_HUMANS_ALIVE
-VICTORY! The %empire% is one of the last surviving empire ruled by humans.
+VICTORY! The %empire% is one of the last surviving empires controlled by a human player.
 
 VICTORY_EXPERIMENTOR_CAPTURE
 VICTORY! The %empire% has captured the powerful Experimentors and ended the fearsome threat plaguing the galaxy.

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1147,6 +1147,12 @@ Gas Giants Habitable size
 RULE_HABITABLE_SIZE_DESC
 Value used to adjust for [[encyclopedia POPULATION_TITLE_SHORT_DESC]] changes on a planet of this size.
 
+RULE_THRESHOLD_HUMAN_PLAYER_WIN
+Threshold for human player winners
+
+RULE_THRESHOLD_HUMAN_PLAYER_WIN_DESC
+Threshold for count of alive human players for them to be considered winners. Not active for single-player.
+
 
 ##
 ## Command-line and options database entries
@@ -6835,6 +6841,9 @@ VICTORY! The %empire% has transcended our reality and wins a technological victo
 
 VICTORY_ALL_ENEMIES_ELIMINATED
 VICTORY! The %empire% is the last surviving empire.
+
+VICTORY_FEW_HUMANS_ALIVE
+VICTORY! The %empire% is one of the last surviving empire ruled by humans.
 
 VICTORY_EXPERIMENTOR_CAPTURE
 VICTORY! The %empire% has captured the powerful Experimentors and ended the fearsome threat plaguing the galaxy.

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -3373,8 +3373,9 @@ void ServerApp::CheckForEmpireElimination() {
     if (surviving_empires.size() == 1) // last man standing
         (*surviving_empires.begin())->Win(UserStringNop("VICTORY_ALL_ENEMIES_ELIMINATED"));
     else if (!m_single_player_game &&
-        static_cast<int>(surviving_human_empires.size()) <= GetGameRules().Get<int>("RULE_THRESHOLD_HUMAN_PLAYER_WIN"))
-    { // human victory threshold
+             static_cast<int>(surviving_human_empires.size()) <= GetGameRules().Get<int>("RULE_THRESHOLD_HUMAN_PLAYER_WIN"))
+    {
+        // human victory threshold
         if (GetGameRules().Get<bool>("RULE_ONLY_ALLIANCE_WIN")) {
             for (auto emp1_it = surviving_human_empires.begin();
                  emp1_it != surviving_human_empires.end(); ++emp1_it)

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -3375,6 +3375,19 @@ void ServerApp::CheckForEmpireElimination() {
     else if (!m_single_player_game &&
         static_cast<int>(surviving_human_empires.size()) <= GetGameRules().Get<int>("RULE_THRESHOLD_HUMAN_PLAYER_WIN"))
     { // human victory threshold
+        if (GetGameRules().Get<bool>("RULE_ONLY_ALLIANCE_WIN")) {
+            for (auto emp1_it = surviving_human_empires.begin();
+                 emp1_it != surviving_human_empires.end(); ++emp1_it)
+            {
+                auto emp2_it = emp1_it;
+                ++emp2_it;
+                for (; emp2_it != surviving_human_empires.end(); ++emp2_it) {
+                    if (Empires().GetDiplomaticStatus((*emp1_it)->EmpireID(), (*emp2_it)->EmpireID()) != DIPLO_ALLIED)
+                        return;
+                }
+            }
+        }
+
         for (auto& empire : surviving_human_empires) {
             empire->Win(UserStringNop("VICTORY_FEW_HUMANS_ALIVE"));
         }


### PR DESCRIPTION
Adds new victory type `VICTORY_FEW_HUMANS_ALIVE` for alive human players if their count are less or equal some threshold and adds new game rule `RULE_THRESHOLD_HUMAN_PLAYER_WIN` with that value and game rule `RULE_ONLY_ALLIANCE_WIN` to require winners to be in one alliance.

Victory type active only for multiplayer game. Default value of threshold is 0 (no one will get this victory).

Forum thread: http://freeorion.org/forum/viewtopic.php?f=6&t=10894