### PR TITLE
Fix AI mock interface typehinting for getVisibilityTurnMap

### DIFF
--- a/default/python/AI/freeOrionAIInterface.pyi
+++ b/default/python/AI/freeOrionAIInterface.pyi
@@ -1566,9 +1566,9 @@ class empire(object):
 
     def supplyProjections(self):
         """
-        :rtype: IntIntMap
+        :rtype: dict[int, int]
         """
-        return IntIntMap()
+        return dict()
 
     def techResearched(self, string):
         """

--- a/default/python/AI/freeOrionAIInterface.pyi
+++ b/default/python/AI/freeOrionAIInterface.pyi
@@ -2450,7 +2450,7 @@ class universe(object):
         :type number1: int
         :param number2:
         :type number2: int
-        :rtype: VisibilityIntMap
+        :rtype: dict[int, int]
         """
         return dict()
 

--- a/default/python/stub_generator/generate_stub.py
+++ b/default/python/stub_generator/generate_stub.py
@@ -48,7 +48,7 @@ def handle_class(info):
     for rutine_name, rutine_docs in instance_methods:
         docs = Docs(rutine_docs, 2, is_class=True)
 
-        if docs.rtype == 'VisibilityIntMap':
+        if docs.rtype in ('VisibilityIntMap', 'IntIntMap'):
             docs.rtype = 'dict[int, int]'
             return_string = 'return dict()'
         elif docs.rtype == 'None':

--- a/default/python/stub_generator/generate_stub.py
+++ b/default/python/stub_generator/generate_stub.py
@@ -49,6 +49,7 @@ def handle_class(info):
         docs = Docs(rutine_docs, 2, is_class=True)
 
         if docs.rtype == 'VisibilityIntMap':
+            docs.rtype = 'dict[int, int]'
             return_string = 'return dict()'
         elif docs.rtype == 'None':
             return_string = 'return None'

--- a/default/python/stub_generator/generate_stub.py
+++ b/default/python/stub_generator/generate_stub.py
@@ -47,7 +47,7 @@ def handle_class(info):
 
     for rutine_name, rutine_docs in instance_methods:
         docs = Docs(rutine_docs, 2, is_class=True)
-
+        # TODO: Subclass map-like classes from dict (or custom class) rather than this hack
         if docs.rtype in ('VisibilityIntMap', 'IntIntMap'):
             docs.rtype = 'dict[int, int]'
             return_string = 'return dict()'


### PR DESCRIPTION
While the mock function itesel was coded to return a dict instead of a VisibilityTurnMap, the dosctring specified the VisibilityTurnMap as :rtype:. The :rtype: is subsequently used by at least some IDEs as the inferred return type.

Specific warning fixed is ```unresolved attribute reference 'get' for class VisibilityIntMap```.