### PR TITLE
Add a context manager and decorator to switch between python log levels

### DIFF
--- a/default/python/AI/freeorion_tools/_freeorion_tools.py
+++ b/default/python/AI/freeorion_tools/_freeorion_tools.py
@@ -324,7 +324,7 @@ class LogLevelSwitcher(object):
         logging.getLogger().setLevel(self.old_log_level)
 
 
-def log_with_specic_log_level(log_level):
+def log_with_specific_log_level(log_level):
     """Set the logging level for this function call to a specific level.
 
     This decorator is useful to selectively activate debugging for a specific function

--- a/default/python/AI/freeorion_tools/_freeorion_tools.py
+++ b/default/python/AI/freeorion_tools/_freeorion_tools.py
@@ -298,3 +298,52 @@ def dump_universe():
             dump_universe.last_dump < cur_turn):
         dump_universe.last_dump = cur_turn
         print fo.universe().dump()
+
+
+class LogLevelSwitcher(object):
+    """A context manager class which controls the log level within its scope.
+
+    Example usage:
+    logging.getLogger().setLevel(logging.INFO)
+
+    debug("Some message")  # not printed because of log level
+    with LogLevelSwitcher(logging.DEBUG):
+        debug("foo")  # printed because we set to DEBUG level
+
+    debug("baz")  # not printed, we are back to INFO level
+    """
+    def __init__(self, log_level):
+        self.target_log_level = log_level
+        self.old_log_level = 0
+
+    def __enter__(self):
+        self.old_log_level = logging.getLogger().level
+        logging.getLogger().setLevel(self.target_log_level)
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        logging.getLogger().setLevel(self.old_log_level)
+
+
+def log_with_specic_log_level(log_level):
+    """Set the logging level for this function call to a specific level.
+
+    This decorator is useful to selectively activate debugging for a specific function
+    while the rest of the code base only logs at a higher level.
+
+    If functions are called within the decorated function, then those will be
+    executed with the same logging level. However, if those functions use this
+    decorator as well, then that logging level will be respected for its scope.
+
+    Example usage:
+    @log_with_specific_log_level(logging.DEBUG)
+    def foo():
+        debug("debug stuff")
+    """
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            with LogLevelSwitcher(log_level):
+                return func(*args, **kwargs)
+
+        return wrapper
+    return decorator

--- a/default/python/AI/freeorion_tools/_freeorion_tools.py
+++ b/default/python/AI/freeorion_tools/_freeorion_tools.py
@@ -324,8 +324,8 @@ class LogLevelSwitcher(object):
         logging.getLogger().setLevel(self.old_log_level)
 
 
-def log_with_specific_log_level(log_level):
-    """Set the logging level for this function call to a specific level.
+def with_log_level(log_level):
+    """A decorator to set a specific logging level for the function call.
 
     This decorator is useful to selectively activate debugging for a specific function
     while the rest of the code base only logs at a higher level.


### PR DESCRIPTION
This PR introduces a context manager which sets the logging level in its scope:

```
logging.getLogger().setLevel(logging.INFO)
info("We generally log on info level")
debug("So this isn't logged.")
with LogLevelSwitcher(logging.DEBUG):
    debug("But this is - in this scope we have actual debug output!")
info("and we're back to the original logging level.")
debug("So this isn't logged.")
```

Alternatively, the logging level can be set for the duration of an entire function (including nested function calls) using a decorato. However, if e.g. a function called within the decorated function call alters the log level, then that log level will be respected within its scope.

```
@log_with_specific_log_level(logging.INFO)
def foo():
    bar()

def bar():
    debug("Is this logged?")

@log_with_specific_log_level(logging.DEBUG)
def some_function():
    debug("We have debugging output here!")
    with LogLevelSwitcher(logging.INFO):
        debug("Only info level here")
    debug("Back at debugging")
    bar()  # respects our debug level, message gets logged
    foo()  # info level within that scope, message not logged
```


This specific implementation relies on the changes in #2016 as it expects having a single logger. So if you want to test this in actual AI code, make sure to 
a) cherry-pick #2016
or
b) make sure to call ```convenience_function_references_for_logger()``` but not ```convenience_function_references_for_logger(__name__)```