### PR TITLE
Fix AI debug chat when logging framework is used

### DIFF
--- a/default/python/AI/freeorion_tools/interactive_shell.py
+++ b/default/python/AI/freeorion_tools/interactive_shell.py
@@ -2,6 +2,7 @@ import freeOrionAIInterface as fo
 from freeorion_tools import chat_human
 from code import InteractiveInterpreter
 from cStringIO import StringIO
+import logging
 import sys
 
 
@@ -88,7 +89,12 @@ def shell(msg):
 
     sys.stdout = StringIO()
     sys.stderr = StringIO()
+    handler = logging.StreamHandler(sys.stdout)
+    logging.getLogger().addHandler(handler)
+
     interpreter.runsource(msg)
+
+    logging.getLogger().removeHandler(handler)
 
     sys.stdout.seek(0)
     out = sys.stdout.read()


### PR DESCRIPTION
Before this PR, only ```print``` statements were displayed in the ingame chat window when AI debug mode was activated. Logging calls were not.

The PR adresses this by temporarily redirecting all logging output from unnamed loggers. Named loggers don't work  at the moment but pending #2016 effectively removes those.

Minimum example chat with this PR:
```
[07 Mrz 23:39:19] Menschlicher_Spieler: start 2
[07 Mrz 23:39:19] AI_1: Entering debug mode
Print 'stop' to exit.
Local variables:
  ai  aistate
  u   universe
  e   empire
[07 Mrz 23:39:25] Menschlicher_Spieler: import logging
[07 Mrz 23:39:28] Menschlicher_Spieler: logging.debug(2)
[07 Mrz 23:39:28] AI_1: 2
```

Without this PR, the AI wouldn't answer.