### PR TITLE
String table thread safety

### DIFF
--- a/util/StringTable.cpp
+++ b/util/StringTable.cpp
@@ -11,41 +11,61 @@
 #include <iostream>
 
 
-// static(s)
-const std::string StringTable_::S_DEFAULT_FILENAME = "en.txt";
-const std::string StringTable_::S_ERROR_STRING = "ERROR: ";
+namespace {
+    const std::string DEFAULT_FILENAME = "en.txt";
+    const std::string ERROR_STRING = "ERROR: ";
+}
 
 // StringTable
 StringTable_::StringTable_():
-    m_filename(S_DEFAULT_FILENAME)
+    m_filename(DEFAULT_FILENAME)
 { Load(); }
 
-StringTable_::StringTable_(const std::string& filename, const StringTable_* lookups_fallback_table /* = 0 */):
+StringTable_::StringTable_(const std::string& filename, const StringTable_* lookups_fallback_table):
     m_filename(filename)
 { Load(lookups_fallback_table); }
 
 StringTable_::~StringTable_()
 {}
 
-bool StringTable_::StringExists(const std::string& index) const
-{ return m_strings.count(index); }
-
-bool StringTable_::Empty() const
-{ return m_strings.empty(); }
-
-const std::string& StringTable_::operator[] (const std::string& index) const {
-    static std::string error_retval;
-    auto it = m_strings.find(index);
-    return it == m_strings.end() ? error_retval = S_ERROR_STRING + index : it->second;
+bool StringTable_::StringExists(const std::string& index) const {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_strings.count(index);
 }
 
-void StringTable_::Load(const StringTable_* lookups_fallback_table /* = 0 */) {
+bool StringTable_::Empty() const {
+    std::lock_guard<std::mutex> lock(m_mutex);
+    return m_strings.empty();
+}
+
+const std::string& StringTable_::operator[] (const std::string& index) const {
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    auto it = m_strings.find(index);
+    if (it != m_strings.end())
+        return it->second;
+
+    auto error = m_error_strings.insert(ERROR_STRING + index);
+    return *(error.first);
+}
+
+void StringTable_::Load(const StringTable_* lookups_fallback_table) {
+    std::lock_guard<std::mutex> lock(m_mutex);
+
+    if (lookups_fallback_table && !lookups_fallback_table->m_initialized) {
+        // this prevents deadlock if two stringtables were to be loaded
+        // simultaneously with eachother as fallback tables
+        ErrorLogger() << "StringTable_::Load given uninitialized stringtable as fallback. Ignoring.";
+        lookups_fallback_table = nullptr;
+    }
+
     auto path = FilenameToPath(m_filename);
     std::string file_contents;
 
     bool read_success = parse::read_file(path, file_contents);
     if (!read_success) {
         ErrorLogger() << "StringTable_::Load failed to read file at path: " << path.string();
+        //m_initialized intentionally left false
         return;
     }
     // add newline at end to avoid errors when one is left out, but is expected by parsers
@@ -56,8 +76,9 @@ void StringTable_::Load(const StringTable_* lookups_fallback_table /* = 0 */) {
     std::map<std::string, std::string> fallback_lookup_strings;
     std::string fallback_table_file;
     if (lookups_fallback_table) {
+        std::lock_guard<std::mutex> fallback_lock(lookups_fallback_table->m_mutex);
         fallback_table_file = lookups_fallback_table->Filename();
-        fallback_lookup_strings.insert(lookups_fallback_table->GetStrings().begin(), lookups_fallback_table->GetStrings().end());
+        fallback_lookup_strings.insert(lookups_fallback_table->m_strings.begin(), lookups_fallback_table->m_strings.end());
     }
 
     using namespace boost::xpressive;
@@ -135,6 +156,7 @@ void StringTable_::Load(const StringTable_* lookups_fallback_table /* = 0 */) {
         ErrorLogger() << "Last and prior keys matched: " << key << ", " << prev_key;
         std::cerr << "Exception caught regex parsing Stringtable: " << e.what() << std::endl;
         std::cerr << "Last and prior keys matched: " << key << ", " << prev_key << std::endl;
+        m_initialized = true;
         return;
     }
 
@@ -153,7 +175,8 @@ void StringTable_::Load(const StringTable_* lookups_fallback_table /* = 0 */) {
                 position += match.position();
                 //DebugLogger() << "checking next internal keyword match: " << match[1] << " with matchlen " << match.length();
                 if (match[1].length() != match.length() - 4)
-                    ErrorLogger() << "Positional error in key expansion: " << match[1] << " with length: " << match[1].length() << "and matchlen: " << match.length();
+                    ErrorLogger() << "Positional error in key expansion: " << match[1] << " with length: "
+                                  << match[1].length() << "and matchlen: " << match.length();
                 // clear out any keywords that have been fully processed
                 for (auto ref_check_it = cyclic_reference_check.begin(); 
                      ref_check_it != cyclic_reference_check.end(); )
@@ -177,9 +200,9 @@ void StringTable_::Load(const StringTable_* lookups_fallback_table /* = 0 */) {
                     cyclic_reference_check[match[1]] = position + match.length();
                     auto map_lookup_it = m_strings.find(match[1]);
                     bool foundmatch = map_lookup_it != m_strings.end();
-                    if (!foundmatch && lookups_fallback_table) {
-                        DebugLogger() << "Key expansion: " << match[1] << " not found in primary stringtable: " << m_filename 
-                                      << "; checking in fallback file" << fallback_table_file;
+                    if (!foundmatch && !fallback_lookup_strings.empty()) {
+                        DebugLogger() << "Key expansion: " << match[1] << " not found in primary stringtable: " << m_filename
+                                      << "; checking in fallback file: " << fallback_table_file;
                         map_lookup_it = fallback_lookup_strings.find(match[1]);
                         foundmatch = map_lookup_it != fallback_lookup_strings.end();
                     }
@@ -215,7 +238,7 @@ void StringTable_::Load(const StringTable_* lookups_fallback_table /* = 0 */) {
                 position += match.position();
                 auto map_lookup_it = m_strings.find(match[2]);
                 bool foundmatch = map_lookup_it != m_strings.end();
-                if (!foundmatch && lookups_fallback_table) {
+                if (!foundmatch && !fallback_lookup_strings.empty()) {
                     DebugLogger() << "Key reference: " << match[2] << " not found in primary stringtable: " << m_filename 
                                   << "; checking in fallback file" << fallback_table_file;
                     map_lookup_it = fallback_lookup_strings.find(match[2]);
@@ -235,4 +258,6 @@ void StringTable_::Load(const StringTable_* lookups_fallback_table /* = 0 */) {
     } else {
         ErrorLogger() << "StringTable file \"" << m_filename << "\" is malformed around line " << std::count(file_contents.begin(), it, '\n');
     }
+
+    m_initialized = true;
 }

--- a/util/StringTable.cpp
+++ b/util/StringTable.cpp
@@ -21,7 +21,7 @@ StringTable_::StringTable_():
     m_filename(DEFAULT_FILENAME)
 { Load(); }
 
-StringTable_::StringTable_(const std::string& filename, const StringTable_* lookups_fallback_table):
+StringTable_::StringTable_(const std::string& filename, std::shared_ptr<const StringTable_> lookups_fallback_table):
     m_filename(filename)
 { Load(lookups_fallback_table); }
 
@@ -49,7 +49,7 @@ const std::string& StringTable_::operator[] (const std::string& index) const {
     return *(error.first);
 }
 
-void StringTable_::Load(const StringTable_* lookups_fallback_table) {
+void StringTable_::Load(std::shared_ptr<const StringTable_> lookups_fallback_table) {
     std::lock_guard<std::mutex> lock(m_mutex);
 
     if (lookups_fallback_table && !lookups_fallback_table->m_initialized) {

--- a/util/StringTable.h
+++ b/util/StringTable.h
@@ -5,6 +5,7 @@
 #include <map>
 #include <unordered_set>
 #include <mutex>
+#include <memory>
 
 // HACK! StringTable is renamed to StringTable_ because freeimage defines
 // a class StringTable too. If both are named identically, static linking

--- a/util/StringTable.h
+++ b/util/StringTable.h
@@ -3,6 +3,8 @@
 
 #include <string>
 #include <map>
+#include <unordered_set>
+#include <mutex>
 
 // HACK! StringTable is renamed to StringTable_ because freeimage defines
 // a class StringTable too. If both are named identically, static linking
@@ -47,14 +49,14 @@ class StringTable_ {
 public:
     //! \name Structors
     //!@{
-    StringTable_();  //!< default construction, uses S_DEFAULT_FILENAME
+    StringTable_();  //!< default construction, uses default stringtable filename
 
     //! construct a StringTable_ from the given filename
     //! @param filename A file containing the data for this StringTable_
     //! @param lookups_fallback_table A StringTable_ to be used as fallback expansions lookup
     StringTable_(const std::string& filename, const StringTable_* lookups_fallback_table = nullptr);
 
-    ~StringTable_();                             //!< default destructor
+    ~StringTable_();
     //!@}
 
     //! \name Accessors
@@ -65,22 +67,16 @@ public:
 
     //! @param index The index of the string to check for
     //! @return true iff a string exists with that index, false otherwise
-    bool StringExists(const std::string& index) const;              //!< Looks up a string at index and returns if the string is present.
+    bool StringExists(const std::string& index) const;
 
     //! @return true iff this stringtable contain no entries
-    bool Empty() const;                                             //!< Checks if this stringtable contains any entries
+    bool Empty() const;
 
     //! @param index The index of the string to lookup
     //! @return The string found at index in the table
     inline const std::string& String(const std::string& index) const { return operator[] (index); } //!< Interface to operator() \see StringTable_::operator[]
-    inline const std::string& Language() const {return m_language;} //!< Returns the language of this StringTable_
-    inline const std::string& Filename() const {return m_filename;} //!< accessor to the filename
-    //!@}
-
-    //! \name Constants
-    //!@{
-    static const std::string S_DEFAULT_FILENAME; //!< the default file used if none specified
-    static const std::string S_ERROR_STRING;     //!< A string that gets returned when invalid indices are used
+    inline const std::string& Language() const { return m_language; } //!< Returns the language of this StringTable_
+    inline const std::string& Filename() const { return m_filename; } //!< accessor to the filename
     //!@}
 
 private:
@@ -89,16 +85,16 @@ private:
     //! Loads the String table file from m_filename
     //! @param lookups_fallback_table A StringTable_ to be used as fallback expansions lookup
     void Load(const StringTable_* lookups_fallback_table = nullptr);
-
-    const std::map<std::string, std::string>& GetStrings() const {return m_strings;}    //!< returns a const reference to the strings in this table
-
     //!@}
 
     //! \name Data Members
     //!@{
-    std::string m_filename;    //!< the name of the file this StringTable_ was constructed with
-    std::string m_language;    //!< A string containing the name of the language used
-    std::map<std::string, std::string> m_strings;  //!< The strings in the table
+    std::string                             m_filename = "";    //!< the name of the file this StringTable_ was constructed with
+    std::string                             m_language = "";    //!< A string containing the name of the language used
+    std::map<std::string, std::string>      m_strings;
+    mutable std::unordered_set<std::string> m_error_strings;
+    mutable std::mutex                      m_mutex;
+    bool                                    m_initialized = false;
     //!@}
 };
 

--- a/util/StringTable.h
+++ b/util/StringTable.h
@@ -54,7 +54,7 @@ public:
     //! construct a StringTable_ from the given filename
     //! @param filename A file containing the data for this StringTable_
     //! @param lookups_fallback_table A StringTable_ to be used as fallback expansions lookup
-    StringTable_(const std::string& filename, const StringTable_* lookups_fallback_table = nullptr);
+    StringTable_(const std::string& filename, std::shared_ptr<const StringTable_> lookups_fallback_table = nullptr);
 
     ~StringTable_();
     //!@}
@@ -84,7 +84,7 @@ private:
     //!@{
     //! Loads the String table file from m_filename
     //! @param lookups_fallback_table A StringTable_ to be used as fallback expansions lookup
-    void Load(const StringTable_* lookups_fallback_table = nullptr);
+    void Load(std::shared_ptr<const StringTable_> lookups_fallback_table = nullptr);
     //!@}
 
     //! \name Data Members


### PR DESCRIPTION
Hopefully makes stringtable use more (but not completely and foolproof) thread safe. Makes error strings, which are returned by reference, persistent, so that another thread requesting a missing string won't invalidate previously returned references to error strings. Also adds mutexes and locks for accessing a stringtable. Stores loaded strings in shared pointers instead of raw pointers, which may avoid leaking memory when flushing stringtables. Prevents uninitialized stringtables from being used as fallback stringtables for a second stringtable, which could prevent weird results when the second tries to use the uninitialized contents on the first to set its backup info.