### PR TITLE
BT stockpile review changes

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -447,21 +447,17 @@ bool Empire::ProducibleItem(BuildType build_type, int location_id) const {
     if (build_type == BT_BUILDING)
         throw std::invalid_argument("Empire::ProducibleItem was passed BuildType BT_BUILDING with no further parameters, but buildings are tracked by name");
 
-    auto build_location = GetUniverseObject(location_id);
-    if (!build_location)
-        return false;
-
     // must own the production location...
     auto location = GetUniverseObject(location_id);
     if (!location) {
-        WarnLogger() << "ShipDesign::ProductionLocation unable to get location object with id " << location_id;
+        WarnLogger() << "Empire::ProducibleItem for BT_STOCKPILE unable to get location object with id " << location_id;
         return false;
     }
 
     if (!location->OwnedBy(m_id))
         return false;
 
-    if (!std::dynamic_pointer_cast<const Planet>(location))
+    if (!std::dynamic_pointer_cast<const ResourceCenter>(location))
         return false;
 
     if (build_type == BT_STOCKPILE) {

--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -451,28 +451,22 @@ bool Empire::ProducibleItem(BuildType build_type, int location_id) const {
     if (!build_location)
         return false;
 
+    // must own the production location...
+    auto location = GetUniverseObject(location_id);
+    if (!location) {
+        WarnLogger() << "ShipDesign::ProductionLocation unable to get location object with id " << location_id;
+        return false;
+    }
+
+    if (!location->OwnedBy(m_id))
+        return false;
+
+    if (!std::dynamic_pointer_cast<const Planet>(location))
+        return false;
+
     if (build_type == BT_STOCKPILE) {
-        Empire* empire = GetEmpire(m_id);
-        if (!empire) {
-            DebugLogger() << "ShipDesign::ProductionLocation: Unable to get pointer to empire " << m_id;
-            return false;
-        }
-
-        // must own the production location...
-        auto location = GetUniverseObject(location_id);
-        if (!location) {
-            WarnLogger() << "ShipDesign::ProductionLocation unable to get location object with id " << location_id;
-            return false;
-        }
-        if (!location->OwnedBy(m_id))
-            return false;
-
-        auto planet = std::dynamic_pointer_cast<const Planet>(location);
-        std::shared_ptr<const Ship> ship;
-        if (!planet)
-             return false;
-
         return true;
+
     } else {
         ErrorLogger() << "Empire::ProducibleItem was passed an invalid BuildType";
         return false;

--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -445,7 +445,7 @@ bool Empire::ProducibleItem(BuildType build_type, int location_id) const {
         throw std::invalid_argument("Empire::ProducibleItem was passed BuildType BT_SHIP with no further parameters, but ship designs are tracked by number");
     
     if (build_type == BT_BUILDING)
-        throw std::invalid_argument("Empire::ProducibleItem was passed BuildType BT_BUILDING with no further parameters, but these types are tracked by name");
+        throw std::invalid_argument("Empire::ProducibleItem was passed BuildType BT_BUILDING with no further parameters, but buildings are tracked by name");
 
     auto build_location = GetUniverseObject(location_id);
     if (!build_location)
@@ -512,7 +512,7 @@ bool Empire::ProducibleItem(BuildType build_type, const std::string& name, int l
 bool Empire::ProducibleItem(BuildType build_type, int design_id, int location) const {
     // special case to check for buildings being passed with ids, not names
     if (build_type == BT_BUILDING)
-        throw std::invalid_argument("Empire::ProducibleItem was passed BuildType BT_BUILDING with a design id number, but these types are tracked by name");
+        throw std::invalid_argument("Empire::ProducibleItem was passed BuildType BT_BUILDING with a design id number, but buildings are tracked by name");
 
     if (build_type == BT_STOCKPILE)
         throw std::invalid_argument("Empire::ProducibleItem was passed BuildType BT_STOCKPILE with a design id, but the stockpile does not need an identification");

--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -1048,11 +1048,11 @@ void Empire::SetTechResearchProgress(const std::string& name, float progress) {
 const unsigned int MAX_PROD_QUEUE_SIZE = 500;
 
 void Empire::PlaceProductionOnQueue(BuildType build_type, const std::string& name, int number,
-    int blocksize, int location, int pos/* = -1*/)
+                                    int blocksize, int location, int pos/* = -1*/)
 {
     if (!EnqueuableItem(build_type, name, location)) {
         ErrorLogger() << "Empire::PlaceProductionOnQueue() : Attempted to place non-enqueuable item in queue: build_type: "
-            << boost::lexical_cast<std::string>(build_type) << "  name: " << name << "  location: " << location;
+                      << boost::lexical_cast<std::string>(build_type) << "  name: " << name << "  location: " << location;
         return;
     }
 
@@ -1063,7 +1063,7 @@ void Empire::PlaceProductionOnQueue(BuildType build_type, const std::string& nam
 
     if (!ProducibleItem(build_type, name, location)) {
         ErrorLogger() << "Empire::PlaceProductionOnQueue() : Placed a non-buildable item in queue: build_type: "
-            << boost::lexical_cast<std::string>(build_type) << "  name: " << name << "  location: " << location;
+                      << boost::lexical_cast<std::string>(build_type) << "  name: " << name << "  location: " << location;
         return;
     }
 
@@ -1076,9 +1076,8 @@ void Empire::PlaceProductionOnQueue(BuildType build_type, const std::string& nam
 }
 
 void Empire::PlaceProductionOnQueue(BuildType build_type, BuildType dummy, int number,
-    int blocksize, int location, int pos/* = -1*/)
+                                    int blocksize, int location, int pos/* = -1*/)
 {
-ErrorLogger() << "Empire::PlaceProductionOnQueue() : BT_STOCKPILE";
     // no distinction between enqueuable and producible...
 
     if (m_production_queue.size() >= MAX_PROD_QUEUE_SIZE) {
@@ -1088,14 +1087,15 @@ ErrorLogger() << "Empire::PlaceProductionOnQueue() : BT_STOCKPILE";
 
     if (!ProducibleItem(build_type, location)) {
         ErrorLogger() << "Empire::PlaceProductionOnQueue() : Placed a non-buildable item in queue: build_type: "
-            << boost::lexical_cast<std::string>(build_type) << "  location: " << location;
+                      << boost::lexical_cast<std::string>(build_type) << "  location: " << location;
         return;
     }
 
     const bool paused = false;
     const bool allowed_imperial_stockpile_use = false;
     const std::string dummy_str = "BT_STOCKPILE_DUMMY_BLD_NAME";
-    ProductionQueue::Element build(build_type, dummy_str, m_id, number, number, blocksize, location, paused, allowed_imperial_stockpile_use);
+    ProductionQueue::Element build(build_type, dummy_str, m_id, number, number, blocksize,
+                                   location, paused, allowed_imperial_stockpile_use);
 
     if (pos < 0 || static_cast<int>(m_production_queue.size()) <= pos)
         m_production_queue.push_back(build);

--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -1089,8 +1089,8 @@ void Empire::PlaceProductionOnQueue(BuildType build_type, BuildType dummy, int n
 
     const bool paused = false;
     const bool allowed_imperial_stockpile_use = false;
-    const std::string dummy_str = "BT_STOCKPILE_DUMMY_BLD_NAME";
-    ProductionQueue::Element build(build_type, dummy_str, m_id, number, number, blocksize,
+    const std::string name = "PROJECT_BT_STOCKPILE";
+    ProductionQueue::Element build(build_type, name, m_id, number, number, blocksize,
                                    location, paused, allowed_imperial_stockpile_use);
 
     if (pos < 0 || static_cast<int>(m_production_queue.size()) <= pos)

--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -200,7 +200,7 @@ public:
     * The second parameter is there for overloading resolution and gets ignored.
     */
     void PlaceProductionOnQueue(BuildType build_type, BuildType dummy, int number,
-        int blocksize, int location, int pos = -1);
+                                int blocksize, int location, int pos = -1);
     /** Adds the indicated build to the production queue, placing it before
       * position \a pos.  If \a pos < 0 or queue.size() <= pos, the build is
       * placed at the end of the queue. */

--- a/Empire/ProductionQueue.cpp
+++ b/Empire/ProductionQueue.cpp
@@ -144,7 +144,9 @@ namespace {
       * location and the amount of minerals and industry produced in the group).
       * Elements will not receive funding if they cannot be produced by the
       * empire with the indicated \a empire_id this turn at their build location. 
-      * Also checks if elements will be completed this turn. */
+      * Also checks if elements will be completed this turn. 
+      * Returns the amount of PP which gets transferred to the stockpile using 
+      * stockpile project build items. */
     float SetProdQueueElementSpending(
         std::map<std::set<int>, float> available_pp, float available_stockpile,
         const std::vector<std::set<int>>& queue_element_resource_sharing_object_groups,
@@ -177,8 +179,8 @@ namespace {
         projects_in_progress = 0;
         allocated_pp.clear();
         allocated_stockpile_pp.clear();
-        float dummy_pp_source = 0;
-        float stockpile_transfer = 0;
+        float dummy_pp_source = 0.0f;
+        float stockpile_transfer = 0.0f;
         //DebugLogger() << "queue size: " << queue.size();
         int i = 0;
         for (auto& queue_element : queue) {
@@ -531,9 +533,7 @@ ProductionQueue::Element::Element(ProductionItem item_, int empire_id_, int orde
     blocksize_memory(blocksize_),
     paused(paused_),
     allowed_imperial_stockpile_use(allowed_imperial_stockpile_use_)
-{
-    ErrorLogger() << "ProductionQueue::Element::Element() : BT_STOCKPILE";
-}
+{}
 
 ProductionQueue::Element::Element(BuildType build_type, std::string name, int empire_id_, int ordered_,
                                   int remaining_, int blocksize_, int location_, bool paused_,
@@ -752,10 +752,11 @@ void ProductionQueue::Update() {
 
     // allocate pp to queue elements, returning updated available pp and updated
     // allocated pp for each group of resource sharing objects
-    float transfer_to_stockpile = SetProdQueueElementSpending(available_pp, available_stockpile, queue_element_groups,
-                                queue_item_costs_and_times, is_producible, m_queue,
-                                m_object_group_allocated_pp, m_object_group_allocated_stockpile_pp,
-                                m_projects_in_progress, false);
+    float transfer_to_stockpile = SetProdQueueElementSpending(
+        available_pp, available_stockpile, queue_element_groups,
+        queue_item_costs_and_times, is_producible, m_queue,
+        m_object_group_allocated_pp, m_object_group_allocated_stockpile_pp,
+        m_projects_in_progress, false);
 
     //update expected new stockpile amount
     m_expected_new_stockpile_amount = CalculateNewStockpile(
@@ -827,9 +828,10 @@ void ProductionQueue::Update() {
         allocated_pp.clear();
         allocated_stockpile_pp.clear();
 
-        float sim_transfer_to_stockpile = SetProdQueueElementSpending(available_pp, sim_available_stockpile, queue_element_groups,
-                                    queue_item_costs_and_times, is_producible, sim_queue,
-                                    allocated_pp, allocated_stockpile_pp, dummy_int, true);
+        float sim_transfer_to_stockpile = SetProdQueueElementSpending(
+            available_pp, sim_available_stockpile, queue_element_groups,
+            queue_item_costs_and_times, is_producible, sim_queue,
+            allocated_pp, allocated_stockpile_pp, dummy_int, true);
 
         // check completion status and update m_queue and sim_queue as appropriate
         for (unsigned int i = 0; i < sim_queue.size(); i++) {

--- a/Empire/ProductionQueue.cpp
+++ b/Empire/ProductionQueue.cpp
@@ -307,9 +307,11 @@ ProductionQueue::ProductionItem::ProductionItem() :
 {}
 
 ProductionQueue::ProductionItem::ProductionItem(BuildType build_type_) :
-    build_type(build_type_),
-    name("PROJECT_BT_STOCKPILE")
-{}
+    build_type(build_type_)
+{
+    if (build_type_ == BT_STOCKPILE)
+        name = "PROJECT_BT_STOCKPILE";
+}
 
 ProductionQueue::ProductionItem::ProductionItem(BuildType build_type_, std::string name_) :
     build_type(build_type_),

--- a/Empire/ProductionQueue.cpp
+++ b/Empire/ProductionQueue.cpp
@@ -312,7 +312,7 @@ ProductionQueue::ProductionItem::ProductionItem(BuildType build_type_) :
     build_type(build_type_)
 {
     if (build_type_ == BT_STOCKPILE)
-        name = "PROJECT_BT_STOCKPILE";
+        name = UserStringNop("PROJECT_BT_STOCKPILE");
 }
 
 ProductionQueue::ProductionItem::ProductionItem(BuildType build_type_, std::string name_) :

--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -137,7 +137,7 @@ namespace {
             case BT_STOCKPILE: {
                 texture = ClientUI::MeterIcon(METER_STOCKPILE);
                 desc_text = UserString("BT_STOCKPILE");
-                name_text = UserString("PROJECT_BT_STOCKPILE");
+                name_text = UserString(m_item.name);
                 break;
             }
             default:
@@ -332,7 +332,7 @@ namespace {
         // production item is a stockpiling project
         if (item.build_type == BT_STOCKPILE) {
             // create title, description, production time and cost
-            const std::string& title = UserString("PROJECT_BT_STOCKPILE");
+            const std::string& title = UserString(item.name);
             std::string main_text = UserString("PROJECT_BT_STOCKPILE_DESC");
             float total_cost = 1.0;
             int production_time = 1;

--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -331,7 +331,6 @@ namespace {
 
         // production item is a stockpiling project
         if (item.build_type == BT_STOCKPILE) {
-
             // create title, description, production time and cost
             const std::string& title = UserString("PROJECT_BT_STOCKPILE");
             std::string main_text = UserString("PROJECT_BT_STOCKPILE_DESC");
@@ -807,8 +806,8 @@ void BuildDesignatorWnd::BuildSelector::PopulateList() {
 
     // populate list with fixed projects
     {
-        auto stockpile_row = GG::Wnd::Create<ProductionItemRow>(row_size.x, row_size.y,
-            ProductionQueue::ProductionItem(BT_STOCKPILE), m_empire_id, m_production_location);
+        auto stockpile_row = GG::Wnd::Create<ProductionItemRow>(
+            row_size.x, row_size.y, ProductionQueue::ProductionItem(BT_STOCKPILE), m_empire_id, m_production_location);
         m_buildable_items->Insert(stockpile_row);
 
         // resize inserted rows and record first row to show

--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -507,6 +507,7 @@ private:
 
     void                DoLayout();
 
+    bool    BuildableItemVisible(BuildType build_type);
     bool    BuildableItemVisible(BuildType build_type, const std::string& name);
     bool    BuildableItemVisible(BuildType build_type, int design_id);
 
@@ -736,6 +737,17 @@ void BuildDesignatorWnd::BuildSelector::HideAvailability(bool available, bool re
     }
 }
 
+bool BuildDesignatorWnd::BuildSelector::BuildableItemVisible(BuildType build_type) {
+    if (build_type != BT_STOCKPILE)
+        throw std::invalid_argument("BuildableItemVisible was passed an invalid build type without id");
+
+    const Empire* empire = GetEmpire(m_empire_id);
+    if (!empire)
+        return true;
+
+    return empire->ProducibleItem(build_type, m_production_location);
+}
+
 bool BuildDesignatorWnd::BuildSelector::BuildableItemVisible(BuildType build_type,
                                                              const std::string& name)
 {
@@ -805,7 +817,7 @@ void BuildDesignatorWnd::BuildSelector::PopulateList() {
     const GG::Pt row_size = m_buildable_items->ListRowSize();
 
     // populate list with fixed projects
-    {
+    if (BuildableItemVisible(BT_STOCKPILE)) {
         auto stockpile_row = GG::Wnd::Create<ProductionItemRow>(
             row_size.x, row_size.y, ProductionQueue::ProductionItem(BT_STOCKPILE), m_empire_id, m_production_location);
         m_buildable_items->Insert(stockpile_row);

--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -262,8 +262,8 @@ namespace {
             float total_cost = building_type->ProductionCost(empire_id, candidate_object_id);
             int production_time = building_type->ProductionTime(empire_id, candidate_object_id);
 
-            main_text += "\n\n" + UserString("PRODUCTION_WND_TOOLTIP_PROD_COST") + ": " + DoubleToString(total_cost, 3, false);
-            main_text += "\n" + UserString("PRODUCTION_WND_TOOLTIP_PROD_TIME") + ": " + std::to_string(production_time);
+            main_text += "\n\n" + boost::io::str(FlexibleFormat(UserString("PRODUCTION_WND_TOOLTIP_PROD_COST")) % DoubleToString(total_cost, 3, false));
+            main_text += "\n" + boost::io::str(FlexibleFormat(UserString("PRODUCTION_WND_TOOLTIP_PROD_TIME")) % std::to_string(production_time));
 
             // show build conditions
             const std::string& enqueue_and_location_condition_failed_text = EnqueueAndLocationConditionDescription(item.name, candidate_object_id, empire_id, true);
@@ -291,8 +291,8 @@ namespace {
             float total_cost = design->ProductionCost(empire_id, candidate_object_id);
             int production_time = design->ProductionTime(empire_id, candidate_object_id);
 
-            main_text += "\n\n" + UserString("PRODUCTION_WND_TOOLTIP_PROD_COST") + ": " + DoubleToString(total_cost, 3, false);
-            main_text += "\n" + UserString("PRODUCTION_WND_TOOLTIP_PROD_TIME") + ": " + std::to_string(production_time);
+            main_text += "\n\n" + boost::io::str(FlexibleFormat(UserString("PRODUCTION_WND_TOOLTIP_PROD_COST")) % DoubleToString(total_cost, 3, false));
+            main_text += "\n" + boost::io::str(FlexibleFormat(UserString("PRODUCTION_WND_TOOLTIP_PROD_TIME")) % std::to_string(production_time));
             main_text += "\n\n" + UserString("ENC_SHIP_HULL") + ": " + UserString(design->Hull());
 
             // load ship parts, stack ship parts that are used multiple times
@@ -337,8 +337,8 @@ namespace {
             float total_cost = 1.0;
             int production_time = 1;
 
-            main_text += "\n\n" + UserString("PRODUCTION_WND_TOOLTIP_PROD_COST") + ": " + DoubleToString(total_cost, 3, false);
-            main_text += "\n" + UserString("PRODUCTION_WND_TOOLTIP_PROD_TIME") + ": " + std::to_string(production_time);
+            main_text += "\n\n" + boost::io::str(FlexibleFormat(UserString("PRODUCTION_WND_TOOLTIP_PROD_COST")) % DoubleToString(total_cost, 3, false));
+            main_text += "\n" + boost::io::str(FlexibleFormat(UserString("PRODUCTION_WND_TOOLTIP_PROD_TIME")) % std::to_string(production_time));
 
             // do not show build conditions - always buildable
 

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -749,7 +749,7 @@ namespace {
                 } else {
                     popup->AddMenuItem(GG::MenuItem(UserString("ALLOW_IMPERIAL_PP_STOCKPILE_USE"), false, false, allow_stockpile_action));
                 }
-	    default:
+            default:
                 break;
             }
 
@@ -766,7 +766,7 @@ namespace {
                 item_name = "PROJECT_BT_STOCKPILE";
                 break;
             default:
-	        break;
+                break;
             }
 
             if (UserStringExists(item_name))

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -287,7 +287,7 @@ namespace {
             max_allocation = design->PerTurnCost(elem.empire_id, elem.location) * elem.blocksize;
             icon = ClientUI::ShipDesignIcon(elem.item.design_id);
         } else if (elem.item.build_type == BT_STOCKPILE) {
-            main_text += UserString("OBJ_PROJECT") + "\n";
+            main_text += UserString("BUILD_ITEM_TYPE_PROJECT") + "\n";
 
             item_name = UserString("PROJECT_BT_STOCKPILE");
             location_ok = true;

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -460,7 +460,7 @@ namespace {
                 ErrorLogger() << "QueueProductionItemPanel unable to get design with id: " << elem.item.design_id;
         } else if (elem.item.build_type == BT_STOCKPILE) {
             graphic = ClientUI::MeterIcon(METER_STOCKPILE);
-            name_text = UserString("PROJECT_BT_STOCKPILE");
+            name_text = UserString(elem.item.name);
         } else {
             graphic = ClientUI::GetTexture(""); // get "missing texture" texture by supply intentionally bad path
             name_text = UserString("FW_UNKNOWN_DESIGN_NAME");
@@ -759,13 +759,11 @@ namespace {
             std::string item_name = "";
             switch (build_type) {
             case BT_BUILDING:
+            case BT_STOCKPILE:
                 item_name = queue_row->elem.item.name;
                 break;
             case BT_SHIP:
                 item_name = GetShipDesign(queue_row->elem.item.design_id)->Name(false);
-                break;
-            case BT_STOCKPILE:
-                item_name = "PROJECT_BT_STOCKPILE";
                 break;
             default:
                 break;

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -713,12 +713,18 @@ namespace {
                 location_passes = elem.item.EnqueueConditionPassedAt(elem.location);
             }
 
+            // Check if build type is ok. If not bail out. Note that DeleteAction does make sense in this case.
+            BuildType build_type = queue_row ? queue_row->elem.item.build_type : INVALID_BUILD_TYPE;
+            if (build_type != BT_SHIP && build_type != BT_BUILDING && build_type != BT_STOCKPILE) {
+                ErrorLogger() << "Invalid build type (" << build_type << ") for row item";
+                return;
+            }
+
             popup->AddMenuItem(GG::MenuItem(UserString("DUPLICATE"), !location_passes, false, dupe_action));
             if (remaining > 1) {
                 popup->AddMenuItem(GG::MenuItem(UserString("SPLIT_INCOMPLETE"), false, false, split_action));
             }
 
-            BuildType build_type = queue_row ? queue_row->elem.item.build_type : INVALID_BUILD_TYPE;
             if (build_type == BT_SHIP) {
                 // for ships, add a set rally point command
                 if (auto system = GetSystem(SidePanel::SystemID())) {
@@ -734,6 +740,7 @@ namespace {
                 popup->AddMenuItem(GG::MenuItem(UserString("PAUSE"),            false, false, pause_action));
             }
 
+            // stockpile use allow/disallow commands
             switch (build_type) {
             case BT_BUILDING:
             case BT_SHIP:
@@ -742,23 +749,26 @@ namespace {
                 } else {
                     popup->AddMenuItem(GG::MenuItem(UserString("ALLOW_IMPERIAL_PP_STOCKPILE_USE"), false, false, allow_stockpile_action));
                 }
-                break;
-            case BT_STOCKPILE:
+	    default:
                 break;
             }
 
             // pedia lookup
             std::string item_name = "";
-            if (build_type == BT_BUILDING) {
+            switch (build_type) {
+            case BT_BUILDING:
                 item_name = queue_row->elem.item.name;
-            } else if (build_type == BT_SHIP) {
+                break;
+            case BT_SHIP:
                 item_name = GetShipDesign(queue_row->elem.item.design_id)->Name(false);
-            } else if (build_type == BT_STOCKPILE) {
+                break;
+            case BT_STOCKPILE:
                 item_name = "PROJECT_BT_STOCKPILE";
-            } else {
-                ErrorLogger() << "Invalid build type (" << build_type << ") for row item";
-                return;
+                break;
+            default:
+	        break;
             }
+
             if (UserStringExists(item_name))
                 item_name = UserString(item_name);
             std::string popup_label = boost::io::str(FlexibleFormat(UserString("ENC_LOOKUP")) % item_name);

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -289,8 +289,10 @@ namespace {
         } else if (elem.item.build_type == BT_STOCKPILE) {
             main_text += UserString("BUILD_ITEM_TYPE_PROJECT") + "\n";
 
-            item_name = UserString("PROJECT_BT_STOCKPILE");
-            location_ok = true;
+            item_name = UserString(elem.item.name);
+            auto loc = GetUniverseObject(elem.location);
+            location_ok = loc && loc->OwnedBy(elem.empire_id) && (std::dynamic_pointer_cast<const ResourceCenter>(loc));
+
             total_cost = 1.0;
             max_allocation = total_cost * elem.blocksize;
             icon = ClientUI::MeterIcon(METER_STOCKPILE);

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -4206,10 +4206,10 @@ DUPLICATE
 Duplicate
 
 PRODUCTION_WND_TOOLTIP_PROD_COST
-Production cost
+Production cost: %1%
 
 PRODUCTION_WND_TOOLTIP_PROD_TIME
-Production time
+Production time: %1%
 
 PRODUCTION_WND_TOOLTIP_PARTS
 Ship Parts

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -8270,8 +8270,8 @@ Building
 OBJ_SHIP
 Ship
 
-# As the OBJ_SHIP and OBJ_BUILDING are used in the production window, we use OBJ_PROJECT for BT_STOCKPILING
-OBJ_PROJECT
+# Note: the OBJ_SHIP and OBJ_BUILDING entries are used for the build item type of ships and buildings.
+BUILD_ITEM_TYPE_PROJECT
 Project
 
 # Universe object types

--- a/default/stringtables/fr.txt
+++ b/default/stringtables/fr.txt
@@ -4206,10 +4206,10 @@ DUPLICATE
 Dupliquer
 
 PRODUCTION_WND_TOOLTIP_PROD_COST
-Coût production
+Coût production: %1%
 
 PRODUCTION_WND_TOOLTIP_PROD_TIME
-Temps production
+Temps production: %1%
 
 PRODUCTION_WND_TOOLTIP_PARTS
 Équipements Astronef

--- a/default/stringtables/fr.txt
+++ b/default/stringtables/fr.txt
@@ -8270,8 +8270,8 @@ Structure
 OBJ_SHIP
 Astronef
 
-# As the OBJ_SHIP and OBJ_BUILDING are used in the production window, we use OBJ_PROJECT for BT_STOCKPILING
-OBJ_PROJECT
+# Note: the OBJ_SHIP and OBJ_BUILDING entries are used for the build item type of ships and buildings.
+BUILD_ITEM_TYPE_PROJECT
 Projet
 
 # Universe object types

--- a/default/stringtables/ru.txt
+++ b/default/stringtables/ru.txt
@@ -3561,10 +3561,10 @@ MOVE_DOWN_QUEUE_ITEM
 Переместить в конец очереди
 
 PRODUCTION_WND_TOOLTIP_PROD_COST
-Стоимость производства
+Стоимость производства: %1%
 
 PRODUCTION_WND_TOOLTIP_PROD_TIME
-Время производства
+Время производства: %1%
 
 PRODUCTION_WND_TOOLTIP_PARTS
 Части корабля


### PR DESCRIPTION
These are the review changes post commit for the bt_stockpile branch.

Note that I am not completely sure if I have done the-right-thing(TM) with the switch statements in the ProductionWnd. I hoped to get rid of having to specify the default case by early check for the build types and return but the compiler does not seem to be able to infer this.

Original PR: https://github.com/freeorion/freeorion/pull/2023