### PR TITLE
Don't let new ships/monsters blockade

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -782,7 +782,15 @@ void Empire::UpdateSupplyUnobstructedSystems(const std::set<int>& known_systems)
                 }
             } else if (fleet->NextSystemID() == INVALID_OBJECT_ID || fleet->NextSystemID() == fleet->SystemID()) {
                 int fleet_owner = fleet->Owner();
-                if (fleet_owner == ALL_EMPIRES || Empires().GetDiplomaticStatus(m_id, fleet_owner) == DIPLO_WAR) {
+                bool fleet_at_war = fleet_owner == ALL_EMPIRES || Empires().GetDiplomaticStatus(m_id, fleet_owner) == DIPLO_WAR;
+                // newly created ships are not allowed to block supply since they have not even potentially gone
+                // through a combat round at the present location.  Potential sources for such new ships are monsters
+                // created via Effect.  (Ships/fleets constructed by empires are currently created at a later stage of
+                // turn processing, but even if such were moved forward they should be similarly restricted.)  Because
+                // supply blocks are determined prior to turn advancement, we check against age zero here.  Because the
+                // fleets themselves may be created and/or destroyed purely as organizational matters, we check ship
+                // age not fleet age.
+                if (fleet_at_war && fleet->MaxShipAgeInTurns() > 0) {
                     systems_containing_obstructing_objects.insert(system_id);
                     if (fleet->ArrivalStarlane() == system_id)
                         unrestricted_obstruction_systems.insert(system_id);

--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -201,6 +201,27 @@ const std::string& Fleet::PublicName(int empire_id) const {
         return UserString("OBJ_FLEET");
 }
 
+int Fleet::MaxShipAgeInTurns() const {
+    if (m_ships.empty())
+        return INVALID_OBJECT_AGE;
+
+    bool fleet_is_scrapped = true;
+    int retval = 0;
+    for (int ship_id : m_ships) {
+        auto ship = GetShip(ship_id);
+        if (!ship || ship->OrderedScrapped())
+            continue;
+        if (ship->AgeInTurns() > retval)
+            retval = ship->AgeInTurns();
+        fleet_is_scrapped = false;
+    }
+
+    if (fleet_is_scrapped)
+        retval = 0;
+
+    return retval;
+}
+
 const std::list<int>& Fleet::TravelRoute() const
 { return m_travel_route; }
 

--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -1256,7 +1256,15 @@ bool Fleet::BlockadedAtSystem(int start_system_id, int dest_system_id) const {
         bool aggressive = (fleet->Aggressive() || fleet->Unowned());
         if (!aggressive)
             continue;
-
+        // Newly created ships/monsters are not allowed to block other fleet movement since they have not even
+        // potentially gone through a combat round at the present location.  Potential sources for such new ships are
+        // monsters created via Effect and Ships/fleets newly constructed by empires.  We check ship ages not fleet
+        // ageas since fleets can be created/destroyed as purely organizational matters.  Since these checks are
+        // pertinent just during those stages of turn processing immediately following turn number advancement,
+        // whereas the new ships were created just prior to turn advamcenemt, we require age greater than 1.
+        // 
+        if (fleet->MaxShipAgeInTurns() <= 1)
+            continue;
         // These are the most costly checks.  Do them last
         if (!fleet->HasArmedShips() && !fleet->HasFighterShips())
             continue;

--- a/universe/Fleet.h
+++ b/universe/Fleet.h
@@ -49,6 +49,7 @@ public:
     std::shared_ptr<UniverseObject>Accept(const UniverseObjectVisitor& visitor) const override;
 
     const std::set<int>&                ShipIDs() const     { return m_ships; }         ///< returns set of IDs of ships in fleet.
+    int                                 MaxShipAgeInTurns() const;                      ///< Returns the age of the oldest ship in the fleet
 
     /** Returns the list of systems that this fleet will move through en route
       * to its destination (may be empty).  If this fleet is currently at a


### PR DESCRIPTION
As noted in #1968 newly created ships/monsters should not create blockades, since they have not gone through even a potential combat cycle and thus may not be possible to defend against yet.  The most common culprits are Floaters transforming into Dyson Trees, and various other maturing monsters.

The first commit focuses on Supply blocks.  That generally also resolves the fleet movement blockade issue, but I think there were still some potential cases that needed to be dealt with, such as when supply is rightly being blocked by a long-existing but relatively blind ship (so blind it couldn't block the fleet movement of concern) in the same system as in which a differently owned ship is newly created. 

I have done some limited testing and this PR appears to work fine, although my testing was really all directed to the subject of the first commit, the situations the second commit are be directed to would be quite a bit trickier to get set up.

Resolves #1968 