### PR TITLE
Allow authenticated player to replace his connection without stopping the game.

### DIFF
--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -226,6 +226,14 @@ public:
     /** Adds new observing player to running game.
       * Simply sends GAME_START message so established player knows he is in the game. */
     void AddObserverPlayerIntoGame(const PlayerConnectionPtr& player_connection);
+
+    /** Drop link between player with \a player_id and his empire. */
+    void DropPlayerEmpireLink(int planet_id);
+
+    /** Adds new player to running game.
+      * Search empire by player's name and return true if success and false if no empire found.
+      * Simply sends GAME_START message so established player knows he is in the game. */
+    bool AddPlayerIntoGame(const PlayerConnectionPtr& player_connection);
     //@}
 
     void UpdateSavePreviews(const Message& msg, PlayerConnectionPtr player_connection);


### PR DESCRIPTION
Currently when authenticated player replaces his frozen connection game stops.
This PR change links between empire and player connections so old connection detaches from empire and new connection attaches to it and continue to play without requirement to restart the game.

Player turns out to the end in the empire window. Should we consider other sorting than by player id? I think it better to change sorting order in other independent PR.

This PR doesn't affect neither single player game nor multiplayer game without authentication.

P.S. Player resets his waiting state so he could send orders again. This works for loaded game, is it expected behaviour? It will allow authenticated player to ignore waiting state and fix his orders after reconnection. Also other players doesn't get he resets his waiting state. Discussion about it: http://freeorion.org/forum/viewtopic.php?f=6&t=10915