### PR TITLE
Census Report

### DIFF
--- a/UI/CensusBrowseWnd.cpp
+++ b/UI/CensusBrowseWnd.cpp
@@ -24,28 +24,27 @@ namespace {
     const GG::Y     ICON_BROWSE_ICON_HEIGHT(64);
 
     const GG::X BrowseTextWidth() {
-        return GG::X(FontBasedUpscale(200));
+        return GG::X(FontBasedUpscale(230));
     }
 }
 
 class CensusRowPanel : public GG::Control {
 public:
-    CensusRowPanel(GG::X w, GG::Y h, const std::string& name, double census_val, bool show_icon) :
+    CensusRowPanel(GG::X w, GG::Y h, const std::string& name, double census_val, int worlds, bool show_icon) :
         GG::Control(GG::X0, GG::Y0, w, h, GG::NO_WND_FLAGS),
         m_icon(nullptr),
         m_name(nullptr),
         m_census_val(nullptr),
+        m_worlds(nullptr),
         m_show_icon(show_icon)
     {
         if (m_show_icon)
             m_icon = GG::Wnd::Create<GG::StaticGraphic>(ClientUI::SpeciesIcon(name), GG::GRAPHIC_FITGRAPHIC);
 
         m_name = GG::Wnd::Create<CUILabel>(UserString(name), GG::FORMAT_RIGHT);
+        m_census_val = GG::Wnd::Create<CUILabel>(census_val < 100 ? DoubleToString(census_val, 2, false) : std::to_string((int)round(census_val)), GG::FORMAT_RIGHT);
 
-        int num_digits = census_val < 10 ? 1 : 2; // this allows the decimal point to line up when there number above and below 10.
-        num_digits =    census_val < 100 ? num_digits : 3; // this allows the decimal point to line up when there number above and below 100.
-        num_digits =   census_val < 1000 ? num_digits : 4; // this allows the decimal point to line up when there number above and below 1000.
-        m_census_val = GG::Wnd::Create<CUILabel>(DoubleToString(census_val, num_digits, false), GG::FORMAT_RIGHT);
+        m_worlds = GG::Wnd::Create<CUILabel>(std::to_string(worlds), GG::FORMAT_RIGHT);
     }
 
     void CompleteConstruction() override {
@@ -58,6 +57,7 @@ public:
 
         AttachChild(m_name);
         AttachChild(m_census_val);
+        AttachChild(m_worlds);
 
         DoLayout();
     }
@@ -87,6 +87,7 @@ private:
     void DoLayout() {
         const GG::X SPECIES_NAME_WIDTH(ClientUI::Pts() * 9);
         const GG::X SPECIES_CENSUS_WIDTH(ClientUI::Pts() * 5);
+        const GG::X SPECIES_WORLDS_WIDTH(ClientUI::Pts() * 3);
 
         GG::X left(GG::X0);
         GG::Y bottom(MeterIconSize().y - GG::Y(EDGE_PAD));
@@ -100,6 +101,9 @@ private:
 
         m_census_val->SizeMove(GG::Pt(left, GG::Y0), GG::Pt(left + SPECIES_CENSUS_WIDTH, bottom));
         left += SPECIES_CENSUS_WIDTH;
+
+        m_worlds->SizeMove(GG::Pt(left, GG::Y0), GG::Pt(left + SPECIES_WORLDS_WIDTH, bottom));
+        left += SPECIES_WORLDS_WIDTH;
 
         InitBuffer();
     }
@@ -119,20 +123,29 @@ private:
     std::shared_ptr<GG::StaticGraphic>  m_icon;
     std::shared_ptr<GG::Label>          m_name;
     std::shared_ptr<GG::Label>          m_census_val;
+    std::shared_ptr<GG::Label>          m_worlds;
     bool                                m_show_icon;
 };
 
-CensusBrowseWnd::CensusBrowseWnd(const std::string& title_text, const std::map<std::string, float>& population_counts,
-                                 const std::map<std::string, float>& tag_counts, const std::vector<std::string>& census_order) :
+CensusBrowseWnd::CensusBrowseWnd(const std::string& title_text,
+                                 const std::map<std::string, float>& population_counts,
+                                 const std::map<std::string, int>&   population_worlds,
+                                 const std::map<std::string, float>& tag_counts,
+                                 const std::map<std::string, int>&   tag_worlds,
+                                 const std::vector<std::string>&     census_order) :
     GG::BrowseInfoWnd(GG::X0, GG::Y0, BrowseTextWidth(), GG::Y1),
     m_title_text(GG::Wnd::Create<CUILabel>(title_text, GG::FORMAT_LEFT)),
     m_species_text(GG::Wnd::Create<CUILabel>(UserString("CENSUS_SPECIES_HEADER"), GG::FORMAT_BOTTOM)),
     m_list(GG::Wnd::Create<CUIListBox>()),
     m_tags_text(GG::Wnd::Create<CUILabel>(UserString("CENSUS_TAG_HEADER"), GG::FORMAT_BOTTOM)),
     m_tags_list(GG::Wnd::Create<CUIListBox>()),
+    m_total_population(GG::Wnd::Create<CUILabel>(UserString("CENSUS_TOTAL_POPULATION"), GG::FORMAT_BOTTOM)),
+    m_total_worlds(GG::Wnd::Create<CUILabel>(UserString("CENSUS_TOTAL_WORLDS"), GG::FORMAT_BOTTOM)),
     m_offset(GG::X0, ICON_BROWSE_ICON_HEIGHT/2),
     m_population_counts(population_counts),
+    m_population_worlds(population_worlds),
     m_tag_counts(tag_counts),
+    m_tag_worlds(tag_worlds),
     m_census_order(census_order)
 {}
 
@@ -168,10 +181,15 @@ void CensusBrowseWnd::CompleteConstruction() {
     { counts_species.insert({entry.second, entry.first}); }
     m_population_counts.clear();
 
+    int totalWorlds = 0;
+    float totalPopulation = 0;
+
     // add species rows
     for (auto it = counts_species.rbegin(); it != counts_species.rend(); ++it) {
+		totalPopulation += it->first;
+		totalWorlds += m_population_worlds[it->second];
         auto row = GG::Wnd::Create<GG::ListBox::Row>(m_list->Width(), ROW_HEIGHT, "Census Species Row");
-        row->push_back(GG::Wnd::Create<CensusRowPanel>(m_list->Width(), ROW_HEIGHT, it->second, it->first, true));
+        row->push_back(GG::Wnd::Create<CensusRowPanel>(m_list->Width(), ROW_HEIGHT, it->second, it->first, m_population_worlds[it->second], true));
         m_list->Insert(row);
         row->Resize(GG::Pt(m_list->Width(), ROW_HEIGHT));
         top += ROW_HEIGHT;
@@ -205,7 +223,7 @@ void CensusBrowseWnd::CompleteConstruction() {
         auto it2 = m_tag_counts.find(tag_ord);
         if (it2 != m_tag_counts.end()) {
             auto row = GG::Wnd::Create<GG::ListBox::Row>(m_list->Width(), ROW_HEIGHT, "Census Characteristics Row");
-            row->push_back(GG::Wnd::Create<CensusRowPanel>(m_tags_list->Width(), ROW_HEIGHT, it2->first, it2->second, false));
+            row->push_back(GG::Wnd::Create<CensusRowPanel>(m_tags_list->Width(), ROW_HEIGHT, it2->first, it2->second, m_tag_worlds[it2->first], false));
             m_tags_list->Insert(row);
             row->Resize(GG::Pt(m_list->Width(), ROW_HEIGHT));
             top2 += ROW_HEIGHT;
@@ -214,6 +232,23 @@ void CensusBrowseWnd::CompleteConstruction() {
     m_tag_counts.clear();
 
     m_tags_list->Resize(GG::Pt(BrowseTextWidth(), top2 -top -ROW_HEIGHT - HALF_HEIGHT + (EDGE_PAD*3)));
+
+    // only show total population and number of worlds if there is more than just one species
+    if (m_population_worlds.size() > 1) {
+        top2 += 0.5 * ROW_HEIGHT;
+        m_total_population->MoveTo(GG::Pt(GG::X(EDGE_PAD) + m_offset.x, top2 + m_offset.y));
+        m_total_population->Resize(GG::Pt(BrowseTextWidth(), ROW_HEIGHT + HALF_HEIGHT));
+        m_total_population->SetText(boost::io::str(FlexibleFormat(UserString("CENSUS_TOTAL_POPULATION")) % (int)round(totalPopulation)));
+        top2 += ROW_HEIGHT;
+
+        m_total_worlds->MoveTo(GG::Pt(GG::X(EDGE_PAD) + m_offset.x, top2 + m_offset.y));
+        m_total_worlds->Resize(GG::Pt(BrowseTextWidth(), ROW_HEIGHT + HALF_HEIGHT));
+        m_total_worlds->SetText(boost::io::str(FlexibleFormat(UserString("CENSUS_TOTAL_WORLDS")) % totalWorlds));
+        top2 += ROW_HEIGHT;
+
+        AttachChild(m_total_population);
+        AttachChild(m_total_worlds);
+    }
 
     Resize(GG::Pt(BrowseTextWidth(), top2  + (EDGE_PAD*3)));
 

--- a/UI/CensusBrowseWnd.cpp
+++ b/UI/CensusBrowseWnd.cpp
@@ -186,8 +186,8 @@ void CensusBrowseWnd::CompleteConstruction() {
 
     // add species rows
     for (auto it = counts_species.rbegin(); it != counts_species.rend(); ++it) {
-		totalPopulation += it->first;
-		totalWorlds += m_population_worlds[it->second];
+        totalPopulation += it->first;
+        totalWorlds += m_population_worlds[it->second];
         auto row = GG::Wnd::Create<GG::ListBox::Row>(m_list->Width(), ROW_HEIGHT, "Census Species Row");
         row->push_back(GG::Wnd::Create<CensusRowPanel>(m_list->Width(), ROW_HEIGHT, it->second, it->first, m_population_worlds[it->second], true));
         m_list->Insert(row);

--- a/UI/CensusBrowseWnd.h
+++ b/UI/CensusBrowseWnd.h
@@ -8,8 +8,13 @@
 /** A popup tooltop for display when mousing over in-game icons.  A title and some detail text.*/
 class CensusBrowseWnd : public GG::BrowseInfoWnd {
 public:
-    CensusBrowseWnd(const std::string& title_text, const std::map<std::string, float>& population_counts,
-                    const std::map<std::string, float>& tag_counts, const std::vector<std::string>& census_order);
+    CensusBrowseWnd(const std::string& title_text,
+                    const std::map<std::string, float>& population_counts,
+                    const std::map<std::string, int>&   population_worlds,
+                    const std::map<std::string, float>& tag_counts,
+                    const std::map<std::string, int>&   tag_worlds,
+                    const std::vector<std::string>&     census_order
+    );
 
     void CompleteConstruction() override;
     bool WndHasBrowseInfo(const Wnd* wnd, std::size_t mode) const override;
@@ -26,9 +31,13 @@ private:
     std::shared_ptr<GG::ListBox>    m_list;
     std::shared_ptr<GG::Label>      m_tags_text;
     std::shared_ptr<GG::ListBox>    m_tags_list;
+    std::shared_ptr<GG::Label>      m_total_population;
+    std::shared_ptr<GG::Label>      m_total_worlds;
     GG::Pt          m_offset;
     std::map<std::string, float>    m_population_counts;
+    std::map<std::string, int>      m_population_worlds;
     std::map<std::string, float>    m_tag_counts;
+	std::map<std::string, int>      m_tag_worlds;
     std::vector<std::string>        m_census_order;
 
     void InitRowSizes();

--- a/UI/CensusBrowseWnd.h
+++ b/UI/CensusBrowseWnd.h
@@ -37,7 +37,7 @@ private:
     std::map<std::string, float>    m_population_counts;
     std::map<std::string, int>      m_population_worlds;
     std::map<std::string, float>    m_tag_counts;
-	std::map<std::string, int>      m_tag_worlds;
+    std::map<std::string, int>      m_tag_worlds;
     std::vector<std::string>        m_census_order;
 
     void InitRowSizes();

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -6726,9 +6726,9 @@ void MapWnd::RefreshPopulationIndicator() {
 
     const auto pop_center_ids = empire->GetPopulationPool().PopCenterIDs();
     std::map<std::string, float> population_counts;
-	std::map<std::string, int>   population_worlds;
+    std::map<std::string, int>   population_worlds;
     std::map<std::string, float> tag_counts;
-	std::map<std::string, int>   tag_worlds;
+    std::map<std::string, int>   tag_worlds;
     const ObjectMap& objects = Objects();
 
     //tally up all species population counts
@@ -6743,22 +6743,22 @@ void MapWnd::RefreshPopulationIndicator() {
             continue;
         float this_pop = pc->InitialMeterValue(METER_POPULATION);
         population_counts[species_name] += this_pop;
-		population_worlds[species_name] += 1;
+        population_worlds[species_name] += 1;
         if (const Species* species = GetSpecies(species_name) ) {
             for (const std::string& tag : species->Tags()) {
                 tag_counts[tag] += this_pop;
-				tag_worlds[tag] += 1;
+                tag_worlds[tag] += 1;
             }
         }
     }
 
     m_population->SetBrowseModeTime(GetOptionsDB().Get<int>("ui.tooltip.delay"));
     m_population->SetBrowseInfoWnd(GG::Wnd::Create<CensusBrowseWnd>(
-        UserString("MAP_POPULATION_DISTRIBUTION")
-		,population_counts,population_worlds
-		,tag_counts,tag_worlds
-		,GetSpeciesManager().census_order())
-	);
+        UserString("MAP_POPULATION_DISTRIBUTION"),
+        population_counts,population_worlds,
+        tag_counts,tag_worlds,
+        GetSpeciesManager().census_order())
+    );
 }
 
 void MapWnd::UpdateSidePanelSystemObjectMetersAndResourcePools() {

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -6726,7 +6726,9 @@ void MapWnd::RefreshPopulationIndicator() {
 
     const auto pop_center_ids = empire->GetPopulationPool().PopCenterIDs();
     std::map<std::string, float> population_counts;
+	std::map<std::string, int>   population_worlds;
     std::map<std::string, float> tag_counts;
+	std::map<std::string, int>   tag_worlds;
     const ObjectMap& objects = Objects();
 
     //tally up all species population counts
@@ -6741,16 +6743,22 @@ void MapWnd::RefreshPopulationIndicator() {
             continue;
         float this_pop = pc->InitialMeterValue(METER_POPULATION);
         population_counts[species_name] += this_pop;
+		population_worlds[species_name] += 1;
         if (const Species* species = GetSpecies(species_name) ) {
             for (const std::string& tag : species->Tags()) {
                 tag_counts[tag] += this_pop;
+				tag_worlds[tag] += 1;
             }
         }
     }
 
     m_population->SetBrowseModeTime(GetOptionsDB().Get<int>("ui.tooltip.delay"));
     m_population->SetBrowseInfoWnd(GG::Wnd::Create<CensusBrowseWnd>(
-        UserString("MAP_POPULATION_DISTRIBUTION"), population_counts, tag_counts, GetSpeciesManager().census_order()));
+        UserString("MAP_POPULATION_DISTRIBUTION")
+		,population_counts,population_worlds
+		,tag_counts,tag_worlds
+		,GetSpeciesManager().census_order())
+	);
 }
 
 void MapWnd::UpdateSidePanelSystemObjectMetersAndResourcePools() {

--- a/default/stringtables/de.txt
+++ b/default/stringtables/de.txt
@@ -1950,6 +1950,12 @@ Spezies
 CENSUS_TAG_HEADER
 Merkmale
 
+CENSUS_TOTAL_POPULATION
+Gesamtbevölkerung: %1%
+
+CENSUS_TOTAL_WORLDS
+Bevölkerte Welten: %1%
+
 MAP_DETECTION_TITLE
 Imperiumsortung
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -3162,6 +3162,12 @@ Species
 CENSUS_TAG_HEADER
 Characteristics
 
+CENSUS_TOTAL_POPULATION
+Total population: %1%
+
+CENSUS_TOTAL_WORLDS
+Settled worlds: %1%
+
 MAP_DETECTION_TITLE
 Empire Detection
 


### PR DESCRIPTION
Census Report: new column with the number of settled world per species / per characteristics plus two new footer lines summarizing that information

Census Rows: Population values > 1000 were displayed as 1.234k before and are now displayed as 1234 without the k so as to better align with values < 1000

see also http://freeorion.org/forum/viewtopic.php?f=26&t=10907&p=91901#p91901

*Edit by @Vezzra:* Supersedes #2049.