### PR TITLE
Use unix path separator for python linter config

### DIFF
--- a/default/python/tox.ini
+++ b/default/python/tox.ini
@@ -7,11 +7,11 @@ putty-ignore =
   AI/savegame_codec/__init__.py : +F401
   AI/freeorion_tools/__init__.py : +F401,F403
   auth/auth.py : +E402
-  turn_events\turn_events.py : +E402
-  universe_generation\universe_generator.py : +E402
-  universe_generation\universe_tables.py : +E201,E122,E231
-  stub_generator\__init__.py : +F401
-  tests\conftest.py : +E402,F401
+  turn_events/turn_events.py : +E402
+  universe_generation/universe_generator.py : +E402
+  universe_generation/universe_tables.py : +E201,E122,E231
+  stub_generator/__init__.py : +F401
+  tests/conftest.py : +E402,F401
   # TODO: fix these warnings
   *.py : +F812 # list comprehension redefines '<variable>' from line <line_no>
   *.py : +E501 # temp ignore of the line too long


### PR DESCRIPTION
Looks like adding `[ci skip]` to each commit helps to avoid CI run.
It is documented for Travis, and work somehow for AppVeyor (I did not find that in docs)