### PR TITLE
appveyor: Setup skip options

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,7 @@ skip_commits:
       - '**/*.md'
       - '**/*.xml'
       - '**/COPYING'
-  message: /.*\[skip appveyor\].*/
+  message: /.*\[(skip appveyor)|(appveyor skip)\].*/
 
 install:
   # Remove the VS Xamarin targets to reduce AppVeyor specific noise in build

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,6 +8,14 @@ init:
 
 clone_depth: 50
 
+skip_commits:
+  files:
+      - default/
+      - '**/*.md'
+      - '**/*.xml'
+      - '**/COPYING'
+  message: /.*\[skip appveyor\].*/
+
 install:
   # Remove the VS Xamarin targets to reduce AppVeyor specific noise in build
   # logs.  See also http://help.appveyor.com/discussions/problems/4569


### PR DESCRIPTION
It is reworked example of changes suggested by @dbenage-cx  on [forum](http://www.freeorion.org/forum/viewtopic.php?f=9&p=88852#p88852)   

[AppVeyor docs](https://www.appveyor.com/docs/how-to/filtering-commits/#skip-commits-2)

I have tested this PR over different cases, it works.
I think we can setup more precise exclusion schema, but I don know a lot about project compiling.

I have added `[skip appveyor]` and `[appveyor skip]` to match `[ci skip]` and `[skip ci]`  (that skips both Travis and Appveyor) 