### PR TITLE
No negative waste map wnd

### DIFF
--- a/Empire/ProductionQueue.cpp
+++ b/Empire/ProductionQueue.cpp
@@ -577,6 +577,7 @@ std::string ProductionQueue::Element::Dump() const {
 ProductionQueue::ProductionQueue(int empire_id) :
     m_projects_in_progress(0),
     m_expected_new_stockpile_amount(0),
+    m_expected_transfer_to_stockpile(0),
     m_empire_id(empire_id)
 {}
 
@@ -763,6 +764,7 @@ void ProductionQueue::Update() {
         m_empire_id, pp_in_stockpile, available_pp, m_object_group_allocated_pp,
         m_object_group_allocated_stockpile_pp);
     m_expected_new_stockpile_amount += transfer_to_stockpile;
+    m_expected_transfer_to_stockpile = transfer_to_stockpile;
 
     // if at least one resource-sharing system group have available PP, simulate
     // future turns to predict when build items will be finished

--- a/Empire/ProductionQueue.cpp
+++ b/Empire/ProductionQueue.cpp
@@ -100,7 +100,7 @@ namespace {
         return retval;
     }
 
-    float CalculateNewStockpile(int empire_id, float starting_stockpile, float stockpile_transfer,
+    float CalculateNewStockpile(int empire_id, float starting_stockpile, float project_transfer_to_stockpile,
                                 const std::map<std::set<int>, float>& available_pp,
                                 const std::map<std::set<int>, float>& allocated_pp,
                                 const std::map<std::set<int>, float>& allocated_stockpile_pp)
@@ -129,11 +129,11 @@ namespace {
                           << "  to stockpile: " << new_contributions;
         }
 
-        if ((new_contributions + stockpile_transfer) > stockpile_limit &&
+        if ((new_contributions + project_transfer_to_stockpile) > stockpile_limit &&
             GetGameRules().Get<bool>("RULE_STOCKPILE_IMPORT_LIMITED"))
-        { new_contributions = stockpile_limit - stockpile_transfer; }
+        { new_contributions = stockpile_limit - project_transfer_to_stockpile; }
 
-        return starting_stockpile + new_contributions - stockpile_used;
+        return starting_stockpile + new_contributions + project_transfer_to_stockpile - stockpile_used;
     }
 
     /** Sets the allocated_pp value for each Element in the passed
@@ -772,7 +772,6 @@ void ProductionQueue::Update() {
     m_expected_new_stockpile_amount = CalculateNewStockpile(
         m_empire_id, pp_in_stockpile, project_transfer_to_stockpile, available_pp, m_object_group_allocated_pp,
         m_object_group_allocated_stockpile_pp);
-    m_expected_new_stockpile_amount += project_transfer_to_stockpile;
     m_expected_project_transfer_to_stockpile = project_transfer_to_stockpile;
 
     // if at least one resource-sharing system group have available PP, simulate
@@ -864,11 +863,9 @@ void ProductionQueue::Update() {
                 sim_queue_original_indices.erase(sim_queue_original_indices.begin() + i--);
             }
         }
-        sim_pp_in_stockpile = CalculateNewStockpile(m_empire_id, sim_pp_in_stockpile, 
-                                                    sim_project_transfer_to_stockpile,
-                                                    available_pp, allocated_pp,
-                                                    allocated_stockpile_pp);
-        sim_pp_in_stockpile += sim_project_transfer_to_stockpile;
+        sim_pp_in_stockpile = CalculateNewStockpile(
+            m_empire_id, sim_pp_in_stockpile, sim_project_transfer_to_stockpile,
+            available_pp, allocated_pp, allocated_stockpile_pp);
         sim_available_stockpile = std::min(sim_pp_in_stockpile, stockpile_limit);
     }
 

--- a/Empire/ProductionQueue.cpp
+++ b/Empire/ProductionQueue.cpp
@@ -100,7 +100,7 @@ namespace {
         return retval;
     }
 
-    float CalculateNewStockpile(int empire_id, float starting_stockpile,
+    float CalculateNewStockpile(int empire_id, float starting_stockpile, float stockpile_transfer,
                                 const std::map<std::set<int>, float>& available_pp,
                                 const std::map<std::set<int>, float>& allocated_pp,
                                 const std::map<std::set<int>, float>& allocated_stockpile_pp)
@@ -129,9 +129,9 @@ namespace {
                           << "  to stockpile: " << new_contributions;
         }
 
-        if (new_contributions > stockpile_limit &&
+        if ((new_contributions + stockpile_transfer) > stockpile_limit &&
             GetGameRules().Get<bool>("RULE_STOCKPILE_IMPORT_LIMITED"))
-        { new_contributions = stockpile_limit; }
+        { new_contributions = stockpile_limit - stockpile_transfer; }
 
         return starting_stockpile + new_contributions - stockpile_used;
     }
@@ -148,7 +148,8 @@ namespace {
       * Returns the amount of PP which gets transferred to the stockpile using 
       * stockpile project build items. */
     float SetProdQueueElementSpending(
-        std::map<std::set<int>, float> available_pp, float available_stockpile,
+        std::map<std::set<int>, float> available_pp, float available_stockpile, 
+        float stockpile_limit,
         const std::vector<std::set<int>>& queue_element_resource_sharing_object_groups,
         const std::map<std::pair<ProductionQueue::ProductionItem, int>,
                        std::pair<float, int>>& queue_item_costs_and_times,
@@ -252,6 +253,13 @@ namespace {
                 std::min(element_this_turn_limit,
                          group_pp_available + stockpile_available_for_this));
 
+            if (queue_element.item.build_type == BT_STOCKPILE) {
+                if (GetGameRules().Get<bool>("RULE_STOCKPILE_IMPORT_LIMITED")) {
+                    float unused_limit = std::max(0.0f, stockpile_limit - stockpile_transfer);
+                    allocation = std::min(allocation, unused_limit);
+                }
+            }
+
             //DebugLogger() << "element accumulated " << element_accumulated_PP << " of total cost "
             //                       << element_total_cost << " and needs " << additional_pp_to_complete_element
             //                       << " more to be completed";
@@ -262,6 +270,7 @@ namespace {
 
             // record allocation from group
             float group_drawdown = std::min(allocation, group_pp_available);
+
             allocated_pp[group] += group_drawdown;  // relies on default initial mapped value of 0.0f
             if (queue_element.item.build_type == BT_STOCKPILE) {
                 stockpile_transfer += group_drawdown;
@@ -754,14 +763,14 @@ void ProductionQueue::Update() {
     // allocate pp to queue elements, returning updated available pp and updated
     // allocated pp for each group of resource sharing objects
     float transfer_to_stockpile = SetProdQueueElementSpending(
-        available_pp, available_stockpile, queue_element_groups,
+        available_pp, available_stockpile, stockpile_limit, queue_element_groups,
         queue_item_costs_and_times, is_producible, m_queue,
         m_object_group_allocated_pp, m_object_group_allocated_stockpile_pp,
         m_projects_in_progress, false);
 
     //update expected new stockpile amount
     m_expected_new_stockpile_amount = CalculateNewStockpile(
-        m_empire_id, pp_in_stockpile, available_pp, m_object_group_allocated_pp,
+        m_empire_id, pp_in_stockpile, transfer_to_stockpile, available_pp, m_object_group_allocated_pp,
         m_object_group_allocated_stockpile_pp);
     m_expected_new_stockpile_amount += transfer_to_stockpile;
     m_expected_transfer_to_stockpile = transfer_to_stockpile;
@@ -831,7 +840,7 @@ void ProductionQueue::Update() {
         allocated_stockpile_pp.clear();
 
         float sim_transfer_to_stockpile = SetProdQueueElementSpending(
-            available_pp, sim_available_stockpile, queue_element_groups,
+            available_pp, sim_available_stockpile, stockpile_limit, queue_element_groups,
             queue_item_costs_and_times, is_producible, sim_queue,
             allocated_pp, allocated_stockpile_pp, dummy_int, true);
 
@@ -855,7 +864,8 @@ void ProductionQueue::Update() {
                 sim_queue_original_indices.erase(sim_queue_original_indices.begin() + i--);
             }
         }
-        sim_pp_in_stockpile = CalculateNewStockpile(m_empire_id, sim_pp_in_stockpile,
+        sim_pp_in_stockpile = CalculateNewStockpile(m_empire_id, sim_pp_in_stockpile, 
+                                                    sim_transfer_to_stockpile,
                                                     available_pp, allocated_pp,
                                                     allocated_stockpile_pp);
         sim_pp_in_stockpile += sim_transfer_to_stockpile;

--- a/Empire/ProductionQueue.cpp
+++ b/Empire/ProductionQueue.cpp
@@ -586,7 +586,7 @@ std::string ProductionQueue::Element::Dump() const {
 ProductionQueue::ProductionQueue(int empire_id) :
     m_projects_in_progress(0),
     m_expected_new_stockpile_amount(0),
-    m_expected_transfer_to_stockpile(0),
+    m_expected_project_transfer_to_stockpile(0),
     m_empire_id(empire_id)
 {}
 
@@ -762,7 +762,7 @@ void ProductionQueue::Update() {
 
     // allocate pp to queue elements, returning updated available pp and updated
     // allocated pp for each group of resource sharing objects
-    float transfer_to_stockpile = SetProdQueueElementSpending(
+    float project_transfer_to_stockpile = SetProdQueueElementSpending(
         available_pp, available_stockpile, stockpile_limit, queue_element_groups,
         queue_item_costs_and_times, is_producible, m_queue,
         m_object_group_allocated_pp, m_object_group_allocated_stockpile_pp,
@@ -770,10 +770,10 @@ void ProductionQueue::Update() {
 
     //update expected new stockpile amount
     m_expected_new_stockpile_amount = CalculateNewStockpile(
-        m_empire_id, pp_in_stockpile, transfer_to_stockpile, available_pp, m_object_group_allocated_pp,
+        m_empire_id, pp_in_stockpile, project_transfer_to_stockpile, available_pp, m_object_group_allocated_pp,
         m_object_group_allocated_stockpile_pp);
-    m_expected_new_stockpile_amount += transfer_to_stockpile;
-    m_expected_transfer_to_stockpile = transfer_to_stockpile;
+    m_expected_new_stockpile_amount += project_transfer_to_stockpile;
+    m_expected_project_transfer_to_stockpile = project_transfer_to_stockpile;
 
     // if at least one resource-sharing system group have available PP, simulate
     // future turns to predict when build items will be finished
@@ -839,7 +839,7 @@ void ProductionQueue::Update() {
         allocated_pp.clear();
         allocated_stockpile_pp.clear();
 
-        float sim_transfer_to_stockpile = SetProdQueueElementSpending(
+        float sim_project_transfer_to_stockpile = SetProdQueueElementSpending(
             available_pp, sim_available_stockpile, stockpile_limit, queue_element_groups,
             queue_item_costs_and_times, is_producible, sim_queue,
             allocated_pp, allocated_stockpile_pp, dummy_int, true);
@@ -865,10 +865,10 @@ void ProductionQueue::Update() {
             }
         }
         sim_pp_in_stockpile = CalculateNewStockpile(m_empire_id, sim_pp_in_stockpile, 
-                                                    sim_transfer_to_stockpile,
+                                                    sim_project_transfer_to_stockpile,
                                                     available_pp, allocated_pp,
                                                     allocated_stockpile_pp);
-        sim_pp_in_stockpile += sim_transfer_to_stockpile;
+        sim_pp_in_stockpile += sim_project_transfer_to_stockpile;
         sim_available_stockpile = std::min(sim_pp_in_stockpile, stockpile_limit);
     }
 

--- a/Empire/ProductionQueue.h
+++ b/Empire/ProductionQueue.h
@@ -131,7 +131,7 @@ struct FO_COMMON_API ProductionQueue {
 
     /** Returns the PP amount expected to be transferred via stockpiling projects to the Imperial Stockpile
     * for the next turn, based on the current ProductionQueue allocations. */
-    float ExpectedTransferToStockpile() const { return m_expected_transfer_to_stockpile; }
+    float ExpectedProjectTransferToStockpile() const { return m_expected_project_transfer_to_stockpile; }
 
     /** Returns sets of object ids that have more available than allocated PP */
     std::set<std::set<int>> ObjectsWithWastedPP(const std::shared_ptr<ResourcePool>& industry_pool) const;
@@ -175,7 +175,7 @@ private:
     std::map<std::set<int>, float>  m_object_group_allocated_pp;
     std::map<std::set<int>, float>  m_object_group_allocated_stockpile_pp;
     float                           m_expected_new_stockpile_amount = 0.0f;
-    float                           m_expected_transfer_to_stockpile = 0.0f;
+    float                           m_expected_project_transfer_to_stockpile = 0.0f;
     int                             m_empire_id = ALL_EMPIRES;
 
     friend class boost::serialization::access;

--- a/Empire/ProductionQueue.h
+++ b/Empire/ProductionQueue.h
@@ -126,8 +126,12 @@ struct FO_COMMON_API ProductionQueue {
     float StockpileCapacity() const;
 
     /** Returns the value expected for the Imperial Stockpile for the next turn, based on the current
-     * ProductionQueue allocations. */
-    float ExpectedNewStockpileAmount() const {return m_expected_new_stockpile_amount; }
+    * ProductionQueue allocations. */
+    float ExpectedNewStockpileAmount() const { return m_expected_new_stockpile_amount; }
+
+    /** Returns the PP amount expected to be transferred via stockpiling projects to the Imperial Stockpile
+    * for the next turn, based on the current ProductionQueue allocations. */
+    float ExpectedTransferToStockpile() const { return m_expected_transfer_to_stockpile; }
 
     /** Returns sets of object ids that have more available than allocated PP */
     std::set<std::set<int>> ObjectsWithWastedPP(const std::shared_ptr<ResourcePool>& industry_pool) const;
@@ -171,6 +175,7 @@ private:
     std::map<std::set<int>, float>  m_object_group_allocated_pp;
     std::map<std::set<int>, float>  m_object_group_allocated_stockpile_pp;
     float                           m_expected_new_stockpile_amount = 0.0f;
+    float                           m_expected_transfer_to_stockpile = 0.0f;
     int                             m_empire_id = ALL_EMPIRES;
 
     friend class boost::serialization::access;

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -6678,7 +6678,7 @@ void MapWnd::RefreshIndustryResourceIndicator() {
     float  expected_stockpile = empire->GetProductionQueue().ExpectedNewStockpileAmount();
 
     float  stockpile_plusminus_next_turn = expected_stockpile - stockpile;
-    double total_PP_for_stockpile_projects = empire->GetProductionQueue().ExpectedTransferToStockpile();
+    double total_PP_for_stockpile_projects = empire->GetProductionQueue().ExpectedProjectTransferToStockpile();
     double total_PP_to_stockpile = expected_stockpile - stockpile + stockpile_used;
     double total_PP_excess = total_PP_output - total_PP_spent;
     double total_PP_wasted = total_PP_output - total_PP_spent - total_PP_to_stockpile + total_PP_for_stockpile_projects;

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -6677,12 +6677,11 @@ void MapWnd::RefreshIndustryResourceIndicator() {
     float  stockpile_use_capacity = empire->GetProductionQueue().StockpileCapacity();
     float  expected_stockpile = empire->GetProductionQueue().ExpectedNewStockpileAmount();
 
-    float  stockpile_limit = empire->GetProductionQueue().StockpileCapacity();
-
     float  stockpile_plusminus_next_turn = expected_stockpile - stockpile;
+    double total_PP_for_stockpile_projects = empire->GetProductionQueue().ExpectedTransferToStockpile();
     double total_PP_to_stockpile = expected_stockpile - stockpile + stockpile_used;
     double total_PP_excess = total_PP_output - total_PP_spent;
-    double total_PP_wasted = total_PP_output - total_PP_spent - total_PP_to_stockpile;
+    double total_PP_wasted = total_PP_output - total_PP_spent - total_PP_to_stockpile + total_PP_for_stockpile_projects;
 
     m_industry->SetBrowseInfoWnd(GG::Wnd::Create<ResourceBrowseWnd>(
         UserString("MAP_PRODUCTION_TITLE"), UserString("PRODUCTION_INFO_PP"),
@@ -6707,7 +6706,7 @@ void MapWnd::RefreshIndustryResourceIndicator() {
         m_industry_wasted->SetBrowseInfoWnd(GG::Wnd::Create<WastedStockpiledResourceBrowseWnd>(
             UserString("MAP_PRODUCTION_WASTED_TITLE"), UserString("PRODUCTION_INFO_PP"),
             total_PP_output, total_PP_excess,
-            true, stockpile_limit, total_PP_to_stockpile, total_PP_wasted,
+            true, stockpile_use_capacity, total_PP_to_stockpile, total_PP_wasted,
             UserString("MAP_PROD_CLICK_TO_OPEN")));
 
     } else {


### PR DESCRIPTION
1. Fixes calculating resource allocation for stockpile transfer project when input limits are enabled.
2. fixes waste calculation for stockpile transfer projects in waste resource browse window 

See https://github.com/freeorion/freeorion/issues/2029