### PR TITLE
Cookie system

### DIFF
--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -49,6 +49,7 @@
 #include <boost/serialization/vector.hpp>
 #include <boost/algorithm/string.hpp>
 #include <boost/uuid/nil_generator.hpp>
+#include <boost/uuid/string_generator.hpp>
 
 #include <chrono>
 #include <thread>
@@ -662,9 +663,22 @@ void HumanClientApp::MultiPlayerGame() {
         m_networking->SendMessage(HostMPGameMessage(server_connect_wnd->GetResult().player_name));
         m_fsm->process_event(HostMPGameRequested());
     } else {
+        boost::uuids::uuid cookie = boost::uuids::nil_uuid();
+        try {
+            if (!GetOptionsDB().OptionExists("network.server.cookie." + server_dest))
+                GetOptionsDB().Add<std::string>("network.server.cookie." + server_dest, "OPTIONS_DB_SERVER_COOKIE", "");
+            std::string cookie_str = GetOptionsDB().Get<std::string>("network.server.cookie." + server_dest);
+            boost::uuids::string_generator gen;
+            cookie = gen(cookie_str);
+        } catch(const std::exception& err) {
+            WarnLogger() << "Cann't get cookie for server " << server_dest << ". Get error message"
+                         << err.what();
+            // ignore
+        }
+
         m_networking->SendMessage(JoinGameMessage(server_connect_wnd->GetResult().player_name,
                                                   server_connect_wnd->GetResult().type,
-                                                  boost::uuids::nil_uuid()));
+                                                  cookie));
         m_fsm->process_event(JoinMPGameRequested());
     }
 }

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -48,6 +48,7 @@
 #include <boost/optional/optional.hpp>
 #include <boost/serialization/vector.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/uuid/nil_generator.hpp>
 
 #include <chrono>
 #include <thread>
@@ -661,7 +662,9 @@ void HumanClientApp::MultiPlayerGame() {
         m_networking->SendMessage(HostMPGameMessage(server_connect_wnd->GetResult().player_name));
         m_fsm->process_event(HostMPGameRequested());
     } else {
-        m_networking->SendMessage(JoinGameMessage(server_connect_wnd->GetResult().player_name, server_connect_wnd->GetResult().type));
+        m_networking->SendMessage(JoinGameMessage(server_connect_wnd->GetResult().player_name,
+                                                  server_connect_wnd->GetResult().type,
+                                                  boost::uuids::nil_uuid()));
         m_fsm->process_event(JoinMPGameRequested());
     }
 }

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -18,6 +18,7 @@
 #include "../../UI/MapWnd.h"
 
 #include <boost/format.hpp>
+#include <boost/uuid/uuid_io.hpp>
 #include <thread>
 
 /** \page statechart_notes Notes on Boost Statechart transitions
@@ -340,6 +341,19 @@ boost::statechart::result WaitingForMPJoinAck::react(const JoinGame& msg) {
         int player_id;
         boost::uuids::uuid cookie;
         ExtractJoinAckMessageData(msg.m_message, player_id, cookie);
+
+        if (!cookie.is_nil()) {
+            try {
+                std::string cookie_option = "network.server.cookie." + Client().Networking().Destination();
+                GetOptionsDB().Remove(cookie_option);
+                GetOptionsDB().Add(cookie_option, "OPTIONS_DB_SERVER_COOKIE", boost::uuids::to_string(cookie));
+                GetOptionsDB().Commit();
+            } catch(const std::exception& err) {
+                WarnLogger() << "Cann't save cookie for server " << Client().Networking().Destination() << ": "
+                             << err.what();
+                // ignore
+            }
+        }
 
         Client().Networking().SetPlayerID(player_id);
 

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -337,7 +337,9 @@ boost::statechart::result WaitingForMPJoinAck::react(const JoinGame& msg) {
     TraceLogger(FSM) << "(HumanClientFSM) WaitingForMPJoinAck.JoinGame";
 
     try {
-        int player_id = boost::lexical_cast<int>(msg.m_message.Text());
+        int player_id;
+        boost::uuids::uuid cookie;
+        ExtractJoinAckMessageData(msg.m_message, player_id, cookie);
 
         Client().Networking().SetPlayerID(player_id);
 

--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -166,6 +166,9 @@ public:
 
     /** Checks if the client has some authorization \a role. */
     bool HasAuthRole(Networking::RoleType role) const;
+
+    /** Returns destination address of server. */
+    const std::string& Destination() const;
     //@}
 
     /** \name Mutators */ //@{
@@ -248,6 +251,8 @@ private:
     Message::HeaderBuffer           m_incoming_header;
     Message                         m_incoming_message;
     Message::HeaderBuffer           m_outgoing_header;
+
+    std::string                     m_destination;
 };
 
 
@@ -305,6 +310,9 @@ ClientNetworking::ServerNames ClientNetworking::Impl::DiscoverLANServerNames() {
     }
     return names;
 }
+
+const std::string& ClientNetworking::Impl::Destination() const
+{ return m_destination; }
 
 bool ClientNetworking::Impl::ConnectToServer(
     const ClientNetworking* const self,
@@ -394,6 +402,8 @@ bool ClientNetworking::Impl::ConnectToServer(
         ErrorLogger(network) << "ConnectToServer() : unable to connect to server at "
                              << ip_address << " due to exception: " << e.what();
     }
+    if (IsConnected())
+        m_destination = ip_address;
     return IsConnected();
 }
 
@@ -668,6 +678,9 @@ bool ClientNetworking::PlayerIsHost(int player_id) const
 
 bool ClientNetworking::HasAuthRole(Networking::RoleType role) const
 { return m_impl->HasAuthRole(role); }
+
+const std::string& ClientNetworking::Destination() const
+{ return m_impl->Destination(); }
 
 ClientNetworking::ServerNames ClientNetworking::DiscoverLANServerNames()
 { return m_impl->DiscoverLANServerNames(); }

--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -68,7 +68,7 @@ public:
     /** Checks if the client has some authorization \a role. */
     bool HasAuthRole(Networking::RoleType role) const;
 
-    /** Returns destination address of server. */
+    /** Returns address of multiplayer server entered by player. */
     const std::string& Destination() const;
     //@}
 

--- a/network/ClientNetworking.h
+++ b/network/ClientNetworking.h
@@ -67,6 +67,9 @@ public:
 
     /** Checks if the client has some authorization \a role. */
     bool HasAuthRole(Networking::RoleType role) const;
+
+    /** Returns destination address of server. */
+    const std::string& Destination() const;
     //@}
 
     /** \name Mutators */ //@{

--- a/network/Message.h
+++ b/network/Message.h
@@ -7,6 +7,7 @@
 
 #include <boost/shared_array.hpp>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
+#include <boost/uuid/uuid.hpp>
 
 #if defined(_MSC_VER) && defined(int64_t)
 #undef int64_t
@@ -191,8 +192,10 @@ FO_COMMON_API Message HostSPGameMessage(const SinglePlayerSetupData& setup_data)
 /** creates a minimal HOST_MP_GAME message used to initiate multiplayer "lobby" setup*/
 FO_COMMON_API Message HostMPGameMessage(const std::string& host_player_name);
 
-/** creates a JOIN_GAME message.  The sender's player name and client type are sent in the message.*/
-FO_COMMON_API Message JoinGameMessage(const std::string& player_name, Networking::ClientType client_type);
+/** creates a JOIN_GAME message.  The sender's player name, client type and cookie are sent in the message.*/
+FO_COMMON_API Message JoinGameMessage(const std::string& player_name,
+                                      Networking::ClientType client_type,
+                                      boost::uuids::uuid cookie);
 
 /** creates a HOST_ID message.  The player ID of the host is sent in the message. */
 FO_COMMON_API Message HostIDMessage(int host_player_id);
@@ -233,8 +236,9 @@ FO_COMMON_API Message HostSPAckMessage(int player_id);
 FO_COMMON_API Message HostMPAckMessage(int player_id);
 
 /** creates a JOIN_GAME acknowledgement message.  The \a player_id is the ID of
-  * the receiving player.  This message should only be sent by the server.*/
-FO_COMMON_API Message JoinAckMessage(int player_id);
+  * the receiving player and \a cookie is a token to quickly authenticate player.
+  * This message should only be sent by the server.*/
+FO_COMMON_API Message JoinAckMessage(int player_id, boost::uuids::uuid cookie);
 
 /** creates a TURN_ORDERS message. */
 FO_COMMON_API Message TurnOrdersMessage(const OrderSet& orders);
@@ -387,7 +391,11 @@ FO_COMMON_API void ExtractGameStartMessageData(const Message& msg, bool& single_
 
 FO_COMMON_API void ExtractJoinGameMessageData(const Message& msg, std::string& player_name,
                                               Networking::ClientType& client_type,
-                                              std::string& version_string);
+                                              std::string& version_string,
+                                              boost::uuids::uuid& cookie);
+
+FO_COMMON_API void ExtractJoinAckMessageData(const Message& msg, int& player_id,
+                                             boost::uuids::uuid& cookie);
 
 FO_COMMON_API void ExtractTurnOrdersMessageData(const Message& msg, OrderSet& orders);
 

--- a/network/Message.h
+++ b/network/Message.h
@@ -192,7 +192,7 @@ FO_COMMON_API Message HostSPGameMessage(const SinglePlayerSetupData& setup_data)
 /** creates a minimal HOST_MP_GAME message used to initiate multiplayer "lobby" setup*/
 FO_COMMON_API Message HostMPGameMessage(const std::string& host_player_name);
 
-/** creates a JOIN_GAME message.  The sender's player name, client type and cookie are sent in the message.*/
+/** creates a JOIN_GAME message.  The sender's player name, client type, and cookie are sent in the message.*/
 FO_COMMON_API Message JoinGameMessage(const std::string& player_name,
                                       Networking::ClientType client_type,
                                       boost::uuids::uuid cookie);

--- a/network/ServerNetworking.cpp
+++ b/network/ServerNetworking.cpp
@@ -511,7 +511,8 @@ bool ServerNetworking::IsAvailableNameInCookies(const std::string& player_name) 
 
 bool ServerNetworking::CheckCookie(boost::uuids::uuid cookie,
                                    const std::string& player_name,
-                                   Networking::AuthRoles& roles) const
+                                   Networking::AuthRoles& roles,
+                                   bool& authenticated) const
 {
     if (cookie.is_nil())
         return false;
@@ -521,6 +522,7 @@ bool ServerNetworking::CheckCookie(boost::uuids::uuid cookie,
         boost::posix_time::ptime now = boost::posix_time::second_clock::local_time();
         if (it->second.expired >= now) {
             roles = it->second.roles;
+            authenticated = it->second.authenticated;
             return true;
         }
     }
@@ -599,13 +601,15 @@ void ServerNetworking::SetHostPlayerID(int host_player_id)
 { m_host_player_id = host_player_id; }
 
 boost::uuids::uuid ServerNetworking::GenerateCookie(const std::string& player_name,
-                                                    const Networking::AuthRoles& roles)
+                                                    const Networking::AuthRoles& roles,
+                                                    bool authenticated)
 {
     boost::uuids::uuid cookie = boost::uuids::random_generator()();
     m_cookies.erase(cookie); // remove previous cookie if exists
     m_cookies.emplace(cookie, CookieData(player_name,
                                          boost::posix_time::second_clock::local_time() + boost::posix_time::minutes(15),
-                                         roles));
+                                         roles,
+                                         authenticated));
     return cookie;
 }
 

--- a/network/ServerNetworking.cpp
+++ b/network/ServerNetworking.cpp
@@ -6,6 +6,8 @@
 
 #include <boost/iterator/filter_iterator.hpp>
 #include <boost/asio/high_resolution_timer.hpp>
+#include <boost/uuid/nil_generator.hpp>
+#include <boost/uuid/random_generator.hpp>
 
 #include <thread>
 
@@ -60,6 +62,7 @@ PlayerConnection::PlayerConnection(boost::asio::io_service& io_service,
     m_new_connection(true),
     m_client_type(Networking::INVALID_CLIENT_TYPE),
     m_authenticated(false),
+    m_cookie(boost::uuids::nil_uuid()),
     m_nonplayer_message_callback(nonplayer_message_callback),
     m_player_message_callback(player_message_callback),
     m_disconnected_callback(disconnected_callback)
@@ -124,6 +127,9 @@ bool PlayerConnection::IsAuthenticated() const {
 bool PlayerConnection::HasAuthRole(Networking::RoleType role) const {
     return m_roles.HasRole(role);
 }
+
+boost::uuids::uuid PlayerConnection::Cookie() const
+{ return m_cookie; }
 
 void PlayerConnection::AwaitPlayer(Networking::ClientType client_type,
                                    const std::string& client_version_string)
@@ -199,6 +205,9 @@ void PlayerConnection::SetAuthRole(Networking::RoleType role, bool value) {
     m_roles.SetRole(role, value);
     SendMessage(SetAuthorizationRolesMessage(m_roles));
 }
+
+void PlayerConnection::SetCookie(boost::uuids::uuid cookie)
+{ m_cookie = cookie; }
 
 const std::string& PlayerConnection::ClientVersionString() const
 { return m_client_version_string; }
@@ -561,6 +570,44 @@ void ServerNetworking::HandleNextEvent() {
 
 void ServerNetworking::SetHostPlayerID(int host_player_id)
 { m_host_player_id = host_player_id; }
+
+boost::uuids::uuid ServerNetworking::GenerateCookie(const std::string& player_name,
+                                                    const Networking::AuthRoles& roles)
+{
+    boost::uuids::uuid cookie = boost::uuids::random_generator()();
+    m_cookies.erase(cookie); // remove previous cookie if exists
+    m_cookies.emplace(cookie, CookieData(player_name,
+                                         boost::posix_time::second_clock::local_time() + boost::posix_time::minutes(15),
+                                         roles));
+    return cookie;
+}
+
+void ServerNetworking::UpdateCookie(boost::uuids::uuid cookie) {
+    if (!cookie.is_nil()) {
+        auto it = m_cookies.find(cookie);
+        if (it != m_cookies.end()) {
+            it->second.expired = boost::posix_time::second_clock::local_time() + boost::posix_time::minutes(15);
+        }
+    }
+}
+
+void ServerNetworking::CleanupCookies() {
+    std::unordered_set<boost::uuids::uuid, boost::hash<boost::uuids::uuid>> to_delete;
+    boost::posix_time::ptime now = boost::posix_time::second_clock::local_time();
+    // clean up expired cookies
+    for (auto cookie : m_cookies) {
+        if (cookie.second.expired < now)
+            to_delete.insert(cookie.first);
+    }
+    // don't clean up cookies from active connections
+    for (auto it = established_begin();
+        it != established_end(); ++it)
+    {
+        to_delete.erase((*it)->Cookie());
+    }
+    for (auto cookie : to_delete)
+        m_cookies.erase(cookie);
+}
 
 void ServerNetworking::Init() {
     // use a dual stack (ipv6 + ipv4) socket

--- a/network/ServerNetworking.cpp
+++ b/network/ServerNetworking.cpp
@@ -513,14 +513,15 @@ bool ServerNetworking::CheckCookie(boost::uuids::uuid cookie,
                                    const std::string& player_name,
                                    Networking::AuthRoles& roles) const
 {
-    if (!cookie.is_nil()) {
-        auto it = m_cookies.find(cookie);
-        if (it != m_cookies.end() && player_name == it->second.player_name) {
-            boost::posix_time::ptime now = boost::posix_time::second_clock::local_time();
-            if (it->second.expired >= now) {
-                roles = it->second.roles;
-                return true;
-            }
+    if (cookie.is_nil())
+        return false;
+
+    auto it = m_cookies.find(cookie);
+    if (it != m_cookies.end() && player_name == it->second.player_name) {
+        boost::posix_time::ptime now = boost::posix_time::second_clock::local_time();
+        if (it->second.expired >= now) {
+            roles = it->second.roles;
+            return true;
         }
     }
     return false;
@@ -609,11 +610,12 @@ boost::uuids::uuid ServerNetworking::GenerateCookie(const std::string& player_na
 }
 
 void ServerNetworking::UpdateCookie(boost::uuids::uuid cookie) {
-    if (!cookie.is_nil()) {
-        auto it = m_cookies.find(cookie);
-        if (it != m_cookies.end()) {
-            it->second.expired = boost::posix_time::second_clock::local_time() + boost::posix_time::minutes(15);
-        }
+    if (cookie.is_nil())
+        return;
+
+    auto it = m_cookies.find(cookie);
+    if (it != m_cookies.end()) {
+        it->second.expired = boost::posix_time::second_clock::local_time() + boost::posix_time::minutes(15);
     }
 }
 

--- a/network/ServerNetworking.h
+++ b/network/ServerNetworking.h
@@ -102,6 +102,15 @@ public:
 
     /** Returns whether there are any moderators in the game. */
     bool ModeratorsInGame() const;
+
+    /** Returns whether there no non-expired cookie with this player name. */
+    bool IsAvailableNameInCookies(const std::string& player_name) const;
+
+    /** Returns whether player have non-expired cookie with this player name.
+      * Fills roles on success. */
+    bool CheckCookie(boost::uuids::uuid cookie,
+                     const std::string& player_name,
+                     Networking::AuthRoles& roles) const;
     //@}
 
     /** \name Mutators */ //@{

--- a/network/ServerNetworking.h
+++ b/network/ServerNetworking.h
@@ -28,13 +28,16 @@ struct CookieData {
     std::string player_name;
     boost::posix_time::ptime expired;
     Networking::AuthRoles roles;
+    bool authenticated;
 
     CookieData(const std::string& player_name_,
                const boost::posix_time::ptime& expired_,
-               const Networking::AuthRoles& roles_) :
+               const Networking::AuthRoles& roles_,
+               bool authenticated_) :
         player_name(player_name_),
         expired(expired_),
-        roles(roles_)
+        roles(roles_),
+        authenticated(authenticated_)
     { }
 };
 
@@ -107,10 +110,11 @@ public:
     bool IsAvailableNameInCookies(const std::string& player_name) const;
 
     /** Returns whether player have non-expired cookie with this player name.
-      * Fills roles on success. */
+      * Fills roles and authentication status on success. */
     bool CheckCookie(boost::uuids::uuid cookie,
                      const std::string& player_name,
-                     Networking::AuthRoles& roles) const;
+                     Networking::AuthRoles& roles,
+                     bool& authenticated) const;
     //@}
 
     /** \name Mutators */ //@{
@@ -151,8 +155,10 @@ public:
     /** Sets Host player ID. */
     void SetHostPlayerID(int host_player_id);
 
-    /** Generate cookies for player's name and roles. */
-    boost::uuids::uuid GenerateCookie(const std::string& player_name, const Networking::AuthRoles& roles);
+    /** Generate cookies for player's name, roles, and authentication status. */
+    boost::uuids::uuid GenerateCookie(const std::string& player_name,
+                                      const Networking::AuthRoles& roles,
+                                      bool authenticated);
 
     /** Bump cookie's expired date. */
     void UpdateCookie(boost::uuids::uuid cookie);

--- a/network/ServerNetworking.h
+++ b/network/ServerNetworking.h
@@ -7,11 +7,12 @@
 #include <boost/function.hpp>
 #include <boost/iterator/filter_iterator.hpp>
 #include <boost/signals2/signal.hpp>
+#include <boost/functional/hash.hpp>
 
 #include <memory>
 #include <queue>
 #include <set>
-
+#include <unordered_map>
 
 class DiscoveryServer;
 class PlayerConnection;
@@ -20,6 +21,22 @@ typedef std::shared_ptr<PlayerConnection> PlayerConnectionPtr;
 typedef boost::function<void (Message, PlayerConnectionPtr)> MessageAndConnectionFn;
 typedef boost::function<void (PlayerConnectionPtr)> ConnectionFn;
 typedef boost::function<void ()> NullaryFn;
+
+/** Data associated with cookie
+ */
+struct CookieData {
+    std::string player_name;
+    boost::posix_time::ptime expired;
+    Networking::AuthRoles roles;
+
+    CookieData(const std::string& player_name_,
+               const boost::posix_time::ptime& expired_,
+               const Networking::AuthRoles& roles_) :
+        player_name(player_name_),
+        expired(expired_),
+        roles(roles_)
+    { }
+};
 
 /** Encapsulates the networking facilities of the server.  This class listens
     for incoming UDP LAN server-discovery requests and TCP player connections.
@@ -124,6 +141,15 @@ public:
 
     /** Sets Host player ID. */
     void SetHostPlayerID(int host_player_id);
+
+    /** Generate cookies for player's name and roles. */
+    boost::uuids::uuid GenerateCookie(const std::string& player_name, const Networking::AuthRoles& roles);
+
+    /** Bump cookie's expired date. */
+    void UpdateCookie(boost::uuids::uuid cookie);
+
+    /** Clean up expired cookies. */
+    void CleanupCookies();
     //@}
 
 private:
@@ -140,6 +166,7 @@ private:
     boost::asio::ip::tcp::acceptor  m_player_connection_acceptor;
     PlayerConnections               m_player_connections;
     std::queue<NullaryFn>           m_event_queue;
+    std::unordered_map<boost::uuids::uuid, CookieData, boost::hash<boost::uuids::uuid>> m_cookies;
 
     MessageAndConnectionFn          m_nonplayer_message_callback;
     MessageAndConnectionFn          m_player_message_callback;
@@ -197,6 +224,9 @@ public:
 
     /** Checks if the player has a some role */
     bool HasAuthRole(Networking::RoleType role) const;
+
+    /** Get cookie associated with this connection. */
+    boost::uuids::uuid Cookie() const;
     //@}
 
     /** \name Mutators */ //@{
@@ -229,6 +259,9 @@ public:
 
     /** Sets or unset authorizaion role and send message to client. */
     void SetAuthRole(Networking::RoleType role, bool value = true);
+
+    /** Sets cookie value to this connection to update expire date. */
+    void SetCookie(boost::uuids::uuid cookie);
     //@}
 
     mutable boost::signals2::signal<void (const NullaryFn&)> EventSignal;
@@ -259,6 +292,7 @@ private:
     std::string                     m_client_version_string;
     bool                            m_authenticated;
     Networking::AuthRoles           m_roles;
+    boost::uuids::uuid              m_cookie;
 
     MessageAndConnectionFn          m_nonplayer_message_callback;
     MessageAndConnectionFn          m_player_message_callback;

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1556,7 +1556,8 @@ bool ServerApp::IsAvailableName(const std::string& player_name) const {
         if ((*it)->PlayerName() == player_name)
             return false;
     }
-    return true;
+    // check if some name reserved with cookie
+    return m_networking.IsAvailableNameInCookies(player_name);
 }
 
 bool ServerApp::IsAuthRequiredOrFillRoles(const std::string& player_name, Networking::AuthRoles& roles) {

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -412,6 +412,7 @@ void ServerApp::SetAIsProcessPriorityToLow(bool set_to_low) {
 void ServerApp::HandleMessage(const Message& msg, PlayerConnectionPtr player_connection) {
 
     //DebugLogger() << "ServerApp::HandleMessage type " << boost::lexical_cast<std::string>(msg.Type());
+    m_networking.UpdateCookie(player_connection->Cookie()); // update cookie expire date
 
     switch (msg.Type()) {
     case Message::HOST_SP_GAME:             m_fsm->process_event(HostSPGame(msg, player_connection));       break;

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -1791,12 +1791,12 @@ sc::result WaitingForMPGameJoiners::react(const JoinGame& msg) {
 
         DebugLogger() << "WaitingForMPGameJoiners.JoinGame Try to login player " << player_name << " with cookie: " << cookie;
         if (server.Networking().CheckCookie(cookie, player_name, roles)) {
-            // if player have correct and non-expired cookies simply establish him
+            // if player has correct and non-expired cookies simply establish him
             player_connection->SetCookie(cookie);
 
             // drop other connection with same name before checks for expected players
             std::list<PlayerConnectionPtr> to_disconnect;
-            for (ServerNetworking::const_established_iterator it = server.m_networking.established_begin();
+            for (auto it = server.m_networking.established_begin();
                  it != server.m_networking.established_end(); ++it)
             {
                 if ((*it)->PlayerName() == player_name && player_connection != (*it)) {


### PR DESCRIPTION
This PR implements web-like cookie system to help with network timeout issue (http://freeorion.org/forum/viewtopic.php?f=28&t=10923).

Server generates token for the client and reserves player name and roles within 15 minutes for owner of this token.
Client saves token in configure file for each server separately and uses it when joins to server.

It works both for authenticated and guest players so it improves usage of #2054 