### PR TITLE
AI military adjustments re preferred max battle size

### DIFF
--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -17,6 +17,7 @@ from EnumsAI import MissionType, FocusType, EmpireProductionTypes, ShipRoleType,
 from freeorion_tools import tech_is_complete, get_ai_tag_grade, cache_by_turn, AITimer, get_partial_visibility_turn
 from AIDependencies import (INVALID_ID, OUTPOSTING_TECH, POP_CONST_MOD_MAP, POP_SIZE_MOD_MAP_MODIFIED_BY_SPECIES,
                             POP_SIZE_MOD_MAP_NOT_MODIFIED_BY_SPECIES)
+from InvasionAI import MIN_INVASION_SCORE
 
 colonization_timer = AITimer('getColonyFleets()')
 
@@ -579,7 +580,8 @@ def evaluate_planet(planet_id, mission_type, spec_name, detail=None):
     homeworld = universe.getPlanet(capital_id)
     planet = universe.getPlanet(planet_id)
     prospective_invasion_targets = [pid for pid, pscore, trp in
-                                    AIstate.invasionTargets[:PriorityAI.allotted_invasion_targets()] if pscore > 20]
+                                    AIstate.invasionTargets[:PriorityAI.allotted_invasion_targets()]
+                                    if pscore > MIN_INVASION_SCORE]
 
     if spec_name != planet.speciesName and planet.speciesName and mission_type != MissionType.INVASION:
         return 0

--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -468,6 +468,13 @@ def evaluate_invasion_planet(planet_id, secure_fleet_missions, verbose=True):
     cost_score = (normalized_cost**2 / 50.0) * troop_cost
 
     base_score = colony_base_value + bld_tally + tech_tally + enemy_val - cost_score
+    # If the AI does have enough total miltary to attack this target, and the target is more than minimally valuable,
+    # don't let the threat_factor discount the adjusted value below MIN_INVASION_SCORE +1, so that if there are no
+    # other targets the AI could still pursue this one.  Otherwise, scoring pressure from
+    # MilitaryAI.get_preferred_max_military_portion_for_single_battle might prevent the AI from attacking heavily
+    # defended but still defeatable targets even if it has no softer targets available.
+    if total_max_mil_rating > sys_total_threat and base_score > 2 * MIN_INVASION_SCORE:
+        threat_factor = max(threat_factor, (MIN_INVASION_SCORE + 1)/base_score)
     planet_score = retaliation_risk_factor(planet.owner) * threat_factor * max(0, base_score)
     if clear_path:
         planet_score *= 1.5

--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -22,6 +22,7 @@ from AIDependencies import INVALID_ID
 MAX_BASE_TROOPERS_GOOD_INVADERS = 20
 MAX_BASE_TROOPERS_POOR_INVADERS = 10
 _TROOPS_SAFETY_MARGIN = 1  # try to send this amount of additional troops to account for uncertainties in calculation
+MIN_INVASION_SCORE = 20
 
 invasion_timer = AITimer('get_invasion_fleets()', write_log=False)
 

--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -436,7 +436,8 @@ def evaluate_invasion_planet(planet_id, secure_fleet_missions, verbose=True):
                           2*planet.currentMeterValue(fo.meterType.targetResearch))
 
     # devalue invasions that would require too much military force
-    threat_factor = min(1, 0.2*MilitaryAI.get_tot_mil_rating()/(sys_total_threat+0.001))**2
+    threat_factor = min(1, MilitaryAI.get_preferred_max_military_portion_for_single_battle() *
+                        MilitaryAI.get_concentrated_tot_mil_rating()/(sys_total_threat+0.001))**2
 
     design_id, _, locs = ProductionAI.get_best_ship_info(PriorityType.PRODUCTION_INVASION)
     if not locs or not universe.getPlanet(locs[0]):
@@ -469,7 +470,7 @@ def evaluate_invasion_planet(planet_id, secure_fleet_missions, verbose=True):
         planet_score *= 1.5
     if verbose:
         print (' - planet score: %.2f\n'
-               ' - troop score: %.2f\n'
+               ' - planned troops: %.2f\n'
                ' - projected troop cost: %.1f\n'
                ' - threat factor: %s\n'
                ' - planet detail: %s\n'

--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -436,8 +436,10 @@ def evaluate_invasion_planet(planet_id, secure_fleet_missions, verbose=True):
                           2*planet.currentMeterValue(fo.meterType.targetResearch))
 
     # devalue invasions that would require too much military force
-    threat_factor = min(1, MilitaryAI.get_preferred_max_military_portion_for_single_battle() *
-                        MilitaryAI.get_concentrated_tot_mil_rating()/(sys_total_threat+0.001))**2
+    preferred_max_portion = MilitaryAI.get_preferred_max_military_portion_for_single_battle()
+    total_max_mil_rating = MilitaryAI.get_concentrated_tot_mil_rating()
+    threat_exponent = 2  # TODO: make this a character trait; higher aggression with a lower exponent
+    threat_factor = min(1, preferred_max_portion * total_max_mil_rating/(sys_total_threat+0.001))**threat_exponent
 
     design_id, _, locs = ProductionAI.get_best_ship_info(PriorityType.PRODUCTION_INVASION)
     if not locs or not universe.getPlanet(locs[0]):

--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -493,6 +493,8 @@ def send_invasion_fleets(fleet_ids, evaluated_planets, mission_type):
     invasion_fleet_pool = set(fleet_ids)
 
     for planet_id, pscore, ptroops in evaluated_planets:
+        if pscore < MIN_INVASION_SCORE:
+            continue
         planet = universe.getPlanet(planet_id)
         if not planet:
             continue

--- a/default/python/AI/MilitaryAI.py
+++ b/default/python/AI/MilitaryAI.py
@@ -886,6 +886,7 @@ def assign_military_fleets_to_systems(use_fleet_id_list=None, allocations=None, 
 def get_tot_mil_rating():
     """
     Give an assessment of total miltary rating considering all fleets as if distributed to separate systems.
+
     :return: a military rating value
     :rtype: float
     """
@@ -897,6 +898,7 @@ def get_tot_mil_rating():
 def get_concentrated_tot_mil_rating():
     """
     Give an assessment of total miltary rating as if all fleets were merged into a single mega-fleet.
+
     :return: a military rating value
     :rtype: float
     """

--- a/default/python/AI/MilitaryAI.py
+++ b/default/python/AI/MilitaryAI.py
@@ -46,6 +46,27 @@ def cur_best_mil_ship_rating(include_designs=False):
     return max(best_rating, 0.001)
 
 
+def get_preferred_max_military_portion_for_single_battle():
+    """
+    Determine and return the preferred max portion of military to be allocated to a single battle.  May be used to
+    downgrade various possible actions requiring military support if they would require an excessive allocation of
+    military forces.  At the beginning of the game this max portion starts as 1.0, then is slightly reduced to account
+    for desire to reserve some defenses for other locations, and then in mid to late game, as the size of the the
+    military grows, this portion is further reduced to promote pursuit of multiple battlefronts in parallel as opposed
+    to single battlefronts against heavily defended positions.
+    :return: a number in range (0:1] for preferred max portion of miltary to be allocated to a single battle
+     :rtype: float
+    """
+    # TODO: this is a roughcut first pass, needs plenty of refinement
+    if fo.currentTurn < 40:
+        return 1.0
+    best_ship_equivalents = (get_concentrated_tot_mil_rating() / cur_best_mil_ship_rating())**0.5
+    _MIN_SHIPS_TO_PURSUE_MULTIPLE_FRONTS = 3
+    if best_ship_equivalents <= _MIN_SHIPS_TO_PURSUE_MULTIPLE_FRONTS:
+        return 1.0
+    return 1.0 / (best_ship_equivalents + 1 - _MIN_SHIPS_TO_PURSUE_MULTIPLE_FRONTS)**0.25
+
+
 def try_again(mil_fleet_ids, try_reset=False, thisround=""):
     """Clear targets and orders for all specified fleets then call get_military_fleets again."""
     for fid in mil_fleet_ids:

--- a/default/python/AI/MilitaryAI.py
+++ b/default/python/AI/MilitaryAI.py
@@ -845,8 +845,24 @@ def assign_military_fleets_to_systems(use_fleet_id_list=None, allocations=None, 
 
 @cache_by_turn
 def get_tot_mil_rating():
+    """
+    Give an assessment of total miltary rating considering all fleets as if distributed to separate systems.
+    :return: a military rating value
+    :rtype: float
+    """
     return sum(CombatRatingsAI.get_fleet_rating(fleet_id)
                for fleet_id in FleetUtilsAI.get_empire_fleet_ids_by_role(MissionType.MILITARY))
+
+
+@cache_by_turn
+def get_concentrated_tot_mil_rating():
+    """
+    Give an assessment of total miltary rating as if all fleets were merged into a single mega-fleet.
+    :return: a military rating value
+    :rtype: float
+    """
+    return CombatRatingsAI.combine_ratings_list([CombatRatingsAI.get_fleet_rating(fleet_id) for fleet_id in
+                                                 FleetUtilsAI.get_empire_fleet_ids_by_role(MissionType.MILITARY)])
 
 
 @cache_by_turn

--- a/default/python/AI/MilitaryAI.py
+++ b/default/python/AI/MilitaryAI.py
@@ -11,6 +11,7 @@ import ProductionAI
 import CombatRatingsAI
 from freeorion_tools import cache_by_turn
 from AIDependencies import INVALID_ID
+from InvasionAI import MIN_INVASION_SCORE
 from turn_state import state
 
 MinThreat = 10  # the minimum threat level that will be ascribed to an unknown threat capable of killing scouts
@@ -676,9 +677,12 @@ def get_military_fleets(mil_fleets_ids=None, try_reset=True, thisround="Main"):
                 pass
 
     num_targets = max(10, PriorityAI.allotted_outpost_targets)
-    top_target_planets = ([pid for pid, pscore, trp in AIstate.invasionTargets[:PriorityAI.allotted_invasion_targets()] if pscore > 20] +
-                          [pid for pid, (pscore, spec) in foAI.foAIstate.colonisableOutpostIDs.items()[:num_targets] if pscore > 20] +
-                          [pid for pid, (pscore, spec) in foAI.foAIstate.colonisablePlanetIDs.items()[:num_targets] if pscore > 20])
+    top_target_planets = ([pid for pid, pscore, trp in AIstate.invasionTargets[:PriorityAI.allotted_invasion_targets()]
+                           if pscore > MIN_INVASION_SCORE] +
+                          [pid for pid, (pscore, spec) in foAI.foAIstate.colonisableOutpostIDs.items()[:num_targets]
+                           if pscore > MIN_INVASION_SCORE] +
+                          [pid for pid, (pscore, spec) in foAI.foAIstate.colonisablePlanetIDs.items()[:num_targets]
+                           if pscore > MIN_INVASION_SCORE])
     top_target_planets.extend(foAI.foAIstate.qualifyingTroopBaseTargets.keys())
     base_col_target_systems = PlanetUtilsAI.get_systems(top_target_planets)
     top_target_systems = []


### PR DESCRIPTION
First of a group of PRs that build on each other.  This starts by adding a new assessment of overall AI military strength.

The existing assessment sums ratings based on ships being distributed according to the current fleet lineup, considering all fleets as independent.  The new assessment better assesses true maximum military capacity by combining the ratings of all fleets as if they were all present in the same system.

The second commit makes a new function to represent the AIs preferred maximum battle size (as a proportion of the above new concentrated max military rating).   It starts out as 1.0 and then reduces as the AI builds up its military strength, to encourage the AI to be pursuing multiple weak or moderate targets rather than pursing just a single very strong target.  This would be a natural enough kind of thing to go into the AI character module, and should almost surely make its way there, but for now I wouldn't actually know how I'd want to vary it between aggression levels, and as a single function it's simpler to just put it into the MilitaryAI for now.

The third commit actually uses this new function to revise the InvasionAI threat assessment.