### PR TITLE
Ai military and invasion stealth adjustments

### DIFF
--- a/default/python/AI/AIFleetMission.py
+++ b/default/python/AI/AIFleetMission.py
@@ -2,7 +2,9 @@ from logging import debug, info, warn
 
 import freeOrionAIInterface as fo  # pylint: disable=import-error
 
-from fleet_orders import AIFleetOrder, OrderMove, OrderOutpost, OrderColonize, OrderMilitary, OrderInvade, OrderDefend
+# the following import is used for type hinting, which pylint seems not to recognize
+from fleet_orders import AIFleetOrder  # pylint: disable=unused-import
+from fleet_orders import OrderMove, OrderOutpost, OrderColonize, OrderMilitary, OrderInvade, OrderDefend
 import AIstate
 import EspionageAI
 import FleetUtilsAI

--- a/default/python/AI/AIFleetMission.py
+++ b/default/python/AI/AIFleetMission.py
@@ -1,9 +1,10 @@
-from logging import info, warn
+from logging import debug, info, warn
 
 import freeOrionAIInterface as fo  # pylint: disable=import-error
 
 from fleet_orders import OrderMove, OrderOutpost, OrderColonize, OrderMilitary, OrderInvade, OrderDefend
 import AIstate
+import EspionageAI
 import FleetUtilsAI
 import FreeOrionAI as foAI
 import MoveUtilsAI
@@ -258,7 +259,9 @@ class AIFleetMission(object):
         """ checks if current mission (targeting a planet) should be aborted"""
         if fleet_order.target and isinstance(fleet_order.target, Planet):
             planet = fleet_order.target.get_object()
-            if isinstance(fleet_order, OrderColonize):
+            if not EspionageAI.colony_detectable_by_empire(planet.id, empire_id = fo.empireID()):
+                debug("EspionageAI predicts we can no longer detect %s, will abort mission" % fleet_order.target)
+            elif isinstance(fleet_order, OrderColonize):
                 if (planet.initialMeterValue(fo.meterType.population) == 0 and
                         (planet.ownedBy(fo.empireID()) or planet.unowned)):
                     return False
@@ -271,8 +274,8 @@ class AIFleetMission(object):
                 return False
 
         # canceling fleet orders
-        print "   %s" % fleet_order
-        print "Fleet %d had a target planet that is no longer valid for this mission; aborting." % self.fleet.id
+        debug("   %s" % fleet_order)
+        debug("Fleet %d had a target planet that is no longer valid for this mission; aborting." % self.fleet.id)
         self.clear_fleet_orders()
         self.clear_target()
         FleetUtilsAI.split_fleet(self.fleet.id)
@@ -384,6 +387,11 @@ class AIFleetMission(object):
             self._check_retarget_invasion()
         just_issued_move_order = False
         last_move_target_id = INVALID_ID
+        # Note: the following abort check somewhat assumes only one major mission type
+        for fleet_order in self.orders:
+            if (isinstance(fleet_order, (OrderColonize, OrderOutpost, OrderInvade)) and
+                    self._check_abort_mission(fleet_order)):
+                return
         for fleet_order in self.orders:
             if just_issued_move_order and self.fleet.get_object().systemID != last_move_target_id:
                 # having just issued a move order, we will normally stop issuing orders this turn, except that if there
@@ -392,10 +400,6 @@ class AIFleetMission(object):
                         self.need_to_pause_movement(last_move_target_id, fleet_order)):
                     break
             print "Checking order: %s" % fleet_order
-            if isinstance(fleet_order, (OrderColonize, OrderOutpost, OrderInvade)):  # TODO: invasion?
-                if self._check_abort_mission(fleet_order):
-                    print "Aborting fleet order %s" % fleet_order
-                    return
             self.check_mergers(context=str(fleet_order))
             if fleet_order.can_issue_order(verbose=False):
                 if isinstance(fleet_order, OrderMove) and order_completed:  # only move if all other orders completed

--- a/default/python/AI/AIFleetMission.py
+++ b/default/python/AI/AIFleetMission.py
@@ -259,7 +259,7 @@ class AIFleetMission(object):
         """ checks if current mission (targeting a planet) should be aborted"""
         if fleet_order.target and isinstance(fleet_order.target, Planet):
             planet = fleet_order.target.get_object()
-            if not EspionageAI.colony_detectable_by_empire(planet.id, empire_id = fo.empireID()):
+            if not EspionageAI.colony_detectable_by_empire(planet.id, empire_id=fo.empireID()):
                 debug("EspionageAI predicts we can no longer detect %s, will abort mission" % fleet_order.target)
             elif isinstance(fleet_order, OrderColonize):
                 if (planet.initialMeterValue(fo.meterType.population) == 0 and

--- a/default/python/AI/AIFleetMission.py
+++ b/default/python/AI/AIFleetMission.py
@@ -2,7 +2,7 @@ from logging import debug, info, warn
 
 import freeOrionAIInterface as fo  # pylint: disable=import-error
 
-from fleet_orders import OrderMove, OrderOutpost, OrderColonize, OrderMilitary, OrderInvade, OrderDefend
+from fleet_orders import AIFleetOrder, OrderMove, OrderOutpost, OrderColonize, OrderMilitary, OrderInvade, OrderDefend
 import AIstate
 import EspionageAI
 import FleetUtilsAI
@@ -55,6 +55,7 @@ COMPATIBLE_ROLES_MAP = {
 class AIFleetMission(object):
     """
     Stores information about AI mission. Every mission has fleetID and AI targets depending upon AI fleet mission type.
+    :type orders: list[AIFleetOrder]
     :type target: universe_object.UniverseObject | None
     """
 
@@ -407,6 +408,8 @@ class AIFleetMission(object):
             if just_issued_move_order and self.fleet.get_object().systemID != last_move_target_id:
                 # having just issued a move order, we will normally stop issuing orders this turn, except that if there
                 # are consecutive move orders we will consider moving through the first destination rather than stopping
+                # Without the below noinspection directive, PyCharm is concerned about the 2nd part of the test
+                # noinspection PyTypeChecker
                 if (not isinstance(fleet_order, OrderMove) or
                         self.need_to_pause_movement(last_move_target_id, fleet_order)):
                     break

--- a/default/python/AI/AIFleetMission.py
+++ b/default/python/AI/AIFleetMission.py
@@ -3,7 +3,7 @@ from logging import debug, info, warn
 import freeOrionAIInterface as fo  # pylint: disable=import-error
 
 # the following import is used for type hinting, which pylint seems not to recognize
-from fleet_orders import AIFleetOrder  # pylint: disable=unused-import
+from fleet_orders import AIFleetOrder  # pylint: disable=unused-import # noqa: F401
 from fleet_orders import OrderMove, OrderOutpost, OrderColonize, OrderMilitary, OrderInvade, OrderDefend
 import AIstate
 import EspionageAI

--- a/default/python/AI/EspionageAI.py
+++ b/default/python/AI/EspionageAI.py
@@ -53,6 +53,10 @@ def colony_detectable_by_empire(planet_id, species_name=None, empire_id=ALL_EMPI
     if species_name is None:
         species_name = planet.speciesName
 
+    # in case we are checking about aborting a colonization mission
+    if empire_id == fo.empireID() and planet.ownedBy(empire_id):
+        return True
+
     species = fo.getSpecies(species_name)
     if species:
         species_tags = species.tags

--- a/default/python/AI/MilitaryAI.py
+++ b/default/python/AI/MilitaryAI.py
@@ -119,7 +119,7 @@ def avail_mil_needing_repair(mil_fleet_ids, split_ships=False, on_mission=False,
         local_status = foAI.foAIstate.systemStatus.get(this_sys_id, {})
         my_local_rating = combine_ratings(local_status.get('mydefenses', {}).get('overall', 0), local_status.get('myFleetRating', 0))
         my_local_rating_vs_planets = local_status.get('myFleetRatingVsPlanets', 0)
-        combat_trigger = local_status.get('fleetThreat', 0) or  local_status.get('monsterThreat', 0)
+        combat_trigger = local_status.get('fleetThreat', 0) or local_status.get('monsterThreat', 0)
         if not combat_trigger and local_status.get('planetThreat', 0):
             universe = fo.getUniverse()
             system = universe.getSystem(this_sys_id)

--- a/default/python/AI/fleet_orders.py
+++ b/default/python/AI/fleet_orders.py
@@ -67,6 +67,7 @@ def trooper_move_reqs_met(main_fleet_mission, order, verbose):
 class AIFleetOrder(object):
     """Stores information about orders which can be executed."""
     TARGET_TYPE = None
+    ORDER_NAME = ''
 
     def __init__(self, fleet, target):
         """

--- a/default/python/AI/fleet_orders.py
+++ b/default/python/AI/fleet_orders.py
@@ -9,7 +9,6 @@ import MilitaryAI
 import MoveUtilsAI
 import CombatRatingsAI
 from universe_object import Fleet, System, Planet
-from freeorion_tools import get_partial_visibility_turn
 
 
 def trooper_move_reqs_met(main_fleet_mission, order, verbose):
@@ -298,9 +297,7 @@ class OrderOutpost(AIFleetOrder):
         if not super(OrderOutpost, self).is_valid():
             return False
         planet = self.target.get_object()
-        sys_partial_vis_turn = get_partial_visibility_turn(planet.systemID)
-        planet_partial_vis_turn = get_partial_visibility_turn(planet.id)
-        if not (planet_partial_vis_turn == sys_partial_vis_turn and planet.unowned):
+        if not planet.unowned:
             # terminate early
             self.executed = True
             self.order_issued = True
@@ -361,11 +358,7 @@ class OrderColonize(AIFleetOrder):
         if not super(OrderColonize, self).is_valid():
             return False
         planet = self.target.get_object()
-
-        sys_partial_vis_turn = get_partial_visibility_turn(planet.systemID)
-        planet_partial_vis_turn = get_partial_visibility_turn(planet.id)
-        if (planet_partial_vis_turn == sys_partial_vis_turn and planet.unowned or
-                (planet.ownedBy(fo.empireID()) and not planet.currentMeterValue(fo.meterType.population))):
+        if (planet.unowned or planet.ownedBy(fo.empireID())) and not planet.currentMeterValue(fo.meterType.population):
             return self.fleet.get_object().hasColonyShips
         # Otherwise, terminate early
         self.executed = True

--- a/default/python/AI/fleet_orders.py
+++ b/default/python/AI/fleet_orders.py
@@ -301,6 +301,7 @@ class OrderOutpost(AIFleetOrder):
         sys_partial_vis_turn = get_partial_visibility_turn(planet.systemID)
         planet_partial_vis_turn = get_partial_visibility_turn(planet.id)
         if not (planet_partial_vis_turn == sys_partial_vis_turn and planet.unowned):
+            # terminate early
             self.executed = True
             self.order_issued = True
             return False
@@ -366,6 +367,7 @@ class OrderColonize(AIFleetOrder):
         if (planet_partial_vis_turn == sys_partial_vis_turn and planet.unowned or
                 (planet.ownedBy(fo.empireID()) and not planet.currentMeterValue(fo.meterType.population))):
             return self.fleet.get_object().hasColonyShips
+        # Otherwise, terminate early
         self.executed = True
         self.order_issued = True
         return False
@@ -404,6 +406,7 @@ class OrderInvade(AIFleetOrder):
         if planet.unowned and not planet_population:
             print "\t\t invasion order not valid due to target planet status-- owned: %s and population %.1f" % (
                 not planet.unowned, planet_population)
+            # terminate early
             self.executed = True
             self.order_issued = True
             return False

--- a/default/python/AI/fleet_orders.py
+++ b/default/python/AI/fleet_orders.py
@@ -205,16 +205,14 @@ class OrderMove(AIFleetOrder):
                 'myFleetRatingVsPlanets', 0)
             is_military = foAI.foAIstate.get_fleet_role(self.fleet.id) == MissionType.MILITARY
 
-            # TODO(Morlic): Is there any reason to add this linearly instead of using CombineRatings?
-            total_rating = my_other_fleet_rating + fleet_rating
-            total_rating_vs_planets = my_other_fleet_rating_vs_planets + fleet_rating_vs_planets
+            total_rating = CombatRatingsAI.combine_ratings(my_other_fleet_rating, fleet_rating)
+            total_rating_vs_planets = CombatRatingsAI.combine_ratings(my_other_fleet_rating_vs_planets,
+                                                                      fleet_rating_vs_planets)
             if (my_other_fleet_rating > 3 * safety_factor * threat or
                     (is_military and total_rating_vs_planets > 2.5*p_threat and total_rating > safety_factor * threat)):
-                if verbose:
-                    print ("\tAdvancing fleet %d (rating %d) at system %d (%s) "
-                           "into system %d (%s) with threat %d because of "
-                           "sufficient empire fleet strength already at destination") % (
-                        self.fleet.id, fleet_rating, system_id, sys1_name, self.target.id, target_system_name, threat)
+                debug(("\tAdvancing fleet %d (rating %d) at system %d (%s) into system %d (%s) with threat %d"
+                       " because of sufficient empire fleet strength already at destination") %
+                      (self.fleet.id, fleet_rating, system_id, sys1_name, self.target.id, target_system_name, threat))
                 return True
             elif (threat == p_threat and
                   not self.fleet.get_object().aggressive and

--- a/default/python/AI/fleet_orders.py
+++ b/default/python/AI/fleet_orders.py
@@ -496,7 +496,7 @@ class OrderMilitary(AIFleetOrder):
         fleet = self.target.get_object()
         system_status = foAI.foAIstate.systemStatus.get(target_sys_id, {})
         total_threat = sum(system_status.get(threat, 0) for threat in ('fleetThreat', 'planetThreat', 'monsterThreat'))
-        combat_trigger = system_status.get('fleetThreat', 0) or  system_status.get('monsterThreat', 0)
+        combat_trigger = system_status.get('fleetThreat', 0) or system_status.get('monsterThreat', 0)
         if not combat_trigger and system_status.get('planetThreat', 0):
             universe = fo.getUniverse()
             system = universe.getSystem(target_sys_id)


### PR DESCRIPTION
This third PR primarily builds on the stealth/detection code added in #2069 and applies that in some military and invasion contexts-- having the AI abort Invasion missions (and also colony and outpost missions) if it no longer expects it can detect the target, and then some adjustments aimed at releasing military ships that currently can have a tendency to get stuck over a stealthed target that had at one point been visible to them.