### PR TITLE
Improve savegame_codec behavior during unit test

### DIFF
--- a/default/python/AI/savegame_codec/_definitions.py
+++ b/default/python/AI/savegame_codec/_definitions.py
@@ -1,5 +1,10 @@
 # a list of trusted classes - other classes will not be loaded
-try:
+import sys
+if 'pytest' in sys.modules:
+    # this was imported for a unit test - failure to import
+    # real AI modules is expected in this case.
+    trusted_classes = {}
+else:
     import AIFleetMission
     import fleet_orders
     import character.character_module
@@ -24,9 +29,6 @@ try:
         ColonisationAI.OrbitalColonizationManager,
         ColonisationAI.OrbitalColonizationPlan,
     ]}
-except RuntimeError:
-    # unit test throws this at the moment during imports  TODO handle cleaner
-    trusted_classes = {}
 
 # prefixes to encode types not supported by json
 # or not fully supported as dictionary key


### PR DESCRIPTION
With #2070, the hacky fix for the import errors during unit tests showed its limits.

The revised version detects if the module is imported during a unit test and does not try to import AI modules in that case.

@Vezzra This is a change in the AI code base but strictly related to and only impacting unit tests (which would seem to imply infrastructure label). Not sure how to label stuff like this, so leaving it blank for now...