### PR TITLE
Add pedia tag to replicon

### DIFF
--- a/default/scripting/species/SP_REPLICON.focs.txt
+++ b/default/scripting/species/SP_REPLICON.focs.txt
@@ -6,7 +6,7 @@ Species
     CanProduceShips
     CanColonize
 
-    tags = [ "ROBOTIC" "GOOD_INDUSTRY" "BAD_RESEARCH" "AVERAGE_SUPPLY" ]
+    tags = [ "ROBOTIC" "GOOD_INDUSTRY" "BAD_RESEARCH" "AVERAGE_SUPPLY" "PEDIA_ROBOTIC_SPECIES_CLASS" ]
 
     foci = [
         [[HAS_INDUSTRY_FOCUS]]


### PR DESCRIPTION
Added a tag on the Replicon species so that it will now be placed in the robotic category in the pedia.