### PR TITLE
Fleet order adjustments part 1

### DIFF
--- a/default/python/AI/AIFleetMission.py
+++ b/default/python/AI/AIFleetMission.py
@@ -619,7 +619,6 @@ class AIFleetMission(object):
          :rtype: bool
         """
         # TODO: More complex evaluation if fleet needs repair (consider self-repair, distance, threat, mission...)
-        universe = fo.getUniverse()
         fleet_id = self.fleet.id
         # if we are already at a system where we can repair, make sure we use it...
         system = self.fleet.get_system()

--- a/default/python/AI/AIFleetMission.py
+++ b/default/python/AI/AIFleetMission.py
@@ -632,13 +632,7 @@ class AIFleetMission(object):
             return fleet_id in MilitaryAI.avail_mil_needing_repair([fleet_id], on_mission=bool(self.orders),
                                                                    repair_limit=repair_limit)[0]
         # TODO: Allow to split fleet to send only damaged ships to repair
-        fleet = universe.getFleet(fleet_id)
-        ships_cur_health = 0
-        ships_max_health = 0
-        for ship_id in fleet.shipIDs:
-            this_ship = universe.getShip(ship_id)
-            ships_cur_health += this_ship.initialMeterValue(fo.meterType.structure)
-            ships_max_health += this_ship.initialMeterValue(fo.meterType.maxStructure)
+        ships_cur_health, ships_max_health = FleetUtilsAI.get_current_and_max_structure(fleet_id)
         return ships_cur_health < repair_limit * ships_max_health
 
     def get_location_target(self):

--- a/default/python/AI/AIFleetMission.py
+++ b/default/python/AI/AIFleetMission.py
@@ -4,7 +4,7 @@ import freeOrionAIInterface as fo  # pylint: disable=import-error
 
 # the following import is used for type hinting, which pylint seems not to recognize
 from fleet_orders import AIFleetOrder  # pylint: disable=unused-import # noqa: F401
-from fleet_orders import OrderMove, OrderOutpost, OrderColonize, OrderMilitary, OrderInvade, OrderDefend
+from fleet_orders import OrderMove, OrderPause, OrderOutpost, OrderColonize, OrderMilitary, OrderInvade, OrderDefend
 import AIstate
 import EspionageAI
 import FleetUtilsAI
@@ -20,7 +20,7 @@ from freeorion_tools import get_partial_visibility_turn
 
 
 ORDERS_FOR_MISSION = {
-    MissionType.EXPLORATION: OrderMove,
+    MissionType.EXPLORATION: OrderPause,
     MissionType.OUTPOST: OrderOutpost,
     MissionType.COLONISATION: OrderColonize,
     MissionType.INVASION: OrderInvade,

--- a/default/python/AI/AIFleetMission.py
+++ b/default/python/AI/AIFleetMission.py
@@ -429,12 +429,15 @@ class AIFleetMission(object):
                 else:
                     print "NOT issuing (even though can_issue) fleet order %s" % fleet_order
                 print "Order issued: %s" % fleet_order.order_issued
-                if not fleet_order.order_issued:
+                if not fleet_order.executed:
                     order_completed = False
             else:  # check that we're not held up by a Big Monster
                 if fleet_order.order_issued:
-                    # It's unclear why we'd really get to this spot, but it has been observed to happen, perhaps due to
-                    # game being reloaded after code changes.
+                    # A previously issued order that wasn't instantly executed must have had cirumstances change so that
+                    # the order can't currently be reissued (or perhaps simply a savegame has been reloaded on the same
+                    # turn the order was issued).
+                    if not fleet_order.executed:
+                        order_completed = False
                     # Go on to the next order.
                     continue
                 print "CAN'T issue fleet order %s" % fleet_order

--- a/default/python/AI/ExplorationAI.py
+++ b/default/python/AI/ExplorationAI.py
@@ -83,7 +83,7 @@ def assign_scouts_to_explore_systems():
                 continue
         # TODO: if blocked byu monster, try to find nearby system from which to see this system
         if (not foAI.foAIstate.character.may_explore_system(sys_status.setdefault('monsterThreat', 0)) or (
-                fo.currentTurn() < 20 and foAI.foAIstate.systemStatus[this_sys_id]['monsterThreat'] > 200)):
+                fo.currentTurn() < 20 and foAI.foAIstate.systemStatus[this_sys_id]['monsterThreat'] > 0)):
             print "Skipping exploration of system %d due to Big Monster, threat %d" % (
                 this_sys_id, foAI.foAIstate.systemStatus[this_sys_id]['monsterThreat'])
             continue

--- a/default/python/AI/FleetUtilsAI.py
+++ b/default/python/AI/FleetUtilsAI.py
@@ -5,7 +5,7 @@ import freeOrionAIInterface as fo  # pylint: disable=import-error
 import FreeOrionAI as foAI
 from EnumsAI import MissionType, ShipRoleType
 import CombatRatingsAI
-from universe_object import Planet
+from universe_object import Planet, Fleet
 from ShipDesignAI import get_part_type
 from AIDependencies import INVALID_ID
 import AIDependencies
@@ -621,3 +621,33 @@ def get_fleet_system(fleet):
     if isinstance(fleet, int):
         fleet = fo.getUniverse().getFleet(fleet)
     return fleet.systemID if fleet.systemID != INVALID_ID else fleet.nextSystemID
+
+
+def get_current_and_max_structure(fleet):
+    """Return a 2-tuple of the sums of structure and maxStructure meters of all ships in the fleet
+
+    :param fleet:
+    :type fleet: int | universe_object.Fleet | fo.Fleet
+    :return: tuple of sums of structure and maxStructure meters of all ships in the fleet
+    :rtype: (float, float)
+    """
+
+    universe = fo.getUniverse()
+    destroyed_ids = universe.destroyedObjectIDs(fo.empireID())
+    if isinstance(fleet, int):
+        fleet = universe.getFleet(fleet)
+    elif isinstance(fleet, Fleet):
+        fleet = fleet.get_object()
+    if not fleet:
+        return (0.0, 0.0)
+    ships_cur_health = 0
+    ships_max_health = 0
+    for ship_id in fleet.shipIDs:
+        # Check if we have see this ship get destroyed in a different fleet since the last time we saw the subject fleet
+        if ship_id in destroyed_ids:
+            continue
+        this_ship = universe.getShip(ship_id)
+        ships_cur_health += this_ship.initialMeterValue(fo.meterType.structure)
+        ships_max_health += this_ship.initialMeterValue(fo.meterType.maxStructure)
+
+    return ships_cur_health, ships_max_health

--- a/default/python/AI/FleetUtilsAI.py
+++ b/default/python/AI/FleetUtilsAI.py
@@ -644,9 +644,14 @@ def get_current_and_max_structure(fleet):
     ships_max_health = 0
     for ship_id in fleet.shipIDs:
         # Check if we have see this ship get destroyed in a different fleet since the last time we saw the subject fleet
+        # this may be redundant with the new fleet assignment check made below, but for its limited scope it may be more
+        # reliable, in that it does not rely on any particular handling of post-destruction stats
         if ship_id in destroyed_ids:
             continue
         this_ship = universe.getShip(ship_id)
+        # check that the ship has not been seen in a new fleet since this current fleet was last observed
+        if not (this_ship and this_ship.fleetID == fleet.id):
+            continue
         ships_cur_health += this_ship.initialMeterValue(fo.meterType.structure)
         ships_max_health += this_ship.initialMeterValue(fo.meterType.maxStructure)
 

--- a/default/python/AI/fleet_orders.py
+++ b/default/python/AI/fleet_orders.py
@@ -67,6 +67,8 @@ class AIFleetOrder(object):
     """Stores information about orders which can be executed."""
     TARGET_TYPE = None
     ORDER_NAME = ''
+    fleet = None  # type: fo.fleet
+    target = None  # type: universe_object.UniverseObject
 
     def __init__(self, fleet, target):
         """
@@ -533,7 +535,7 @@ class OrderRepair(AIFleetOrder):
             return
         fleet_id = self.fleet.id
         system_id = self.target.get_system().id
-        fleet = self.fleet.get_object()
+        fleet = self.fleet.get_object()  # type: fo.fleet
         if system_id == fleet.systemID:
             if foAI.foAIstate.get_fleet_role(fleet_id) == MissionType.EXPLORATION:
                 if system_id in foAI.foAIstate.needsEmergencyExploration:

--- a/default/python/AI/fleet_orders.py
+++ b/default/python/AI/fleet_orders.py
@@ -257,6 +257,23 @@ class OrderMove(AIFleetOrder):
         return True
 
 
+class OrderPause(AIFleetOrder):
+    """Ensure Fleet at least temporarily halts movemenet at the target system."""
+    ORDER_NAME = 'pause'
+    TARGET_TYPE = System
+
+    def is_valid(self):
+        if not super(OrderPause, self).is_valid():
+            return False
+        return bool(self.target.get_system().get_object())
+
+    def issue_order(self):
+        if not super(OrderPause, self).issue_order():
+            return False
+        # not executed until actually arrives at target system
+        self.excuted = self.fleet.get_current_system_id() == self.target.get_system().id
+
+
 class OrderResupply(AIFleetOrder):
     ORDER_NAME = 'resupply'
     TARGET_TYPE = System

--- a/default/python/AI/fleet_orders.py
+++ b/default/python/AI/fleet_orders.py
@@ -258,7 +258,7 @@ class OrderMove(AIFleetOrder):
 
 
 class OrderPause(AIFleetOrder):
-    """Ensure Fleet at least temporarily halts movemenet at the target system."""
+    """Ensure Fleet at least temporarily halts movement at the target system."""
     ORDER_NAME = 'pause'
     TARGET_TYPE = System
 

--- a/default/python/AI/fleet_orders.py
+++ b/default/python/AI/fleet_orders.py
@@ -371,8 +371,6 @@ class OrderColonize(AIFleetOrder):
         if ship_id is None:
             ship_id = FleetUtilsAI.get_ship_id_with_role(fleet_id, ShipRoleType.BASE_COLONISATION)
 
-        planet = self.target.get_object()
-        planet_name = planet and planet.name or "apparently invisible"
         if fo.issueColonizeOrder(ship_id, self.target.id):
             debug("Order issued: %s fleet: %s target: %s" % (self.ORDER_NAME, self.fleet, self.target))
             return True
@@ -579,6 +577,3 @@ class OrderRepair(AIFleetOrder):
         ships_cur_health, ships_max_health = FleetUtilsAI.get_current_and_max_structure(fleet_id)
         self.executed = (ships_cur_health == ships_max_health)
         return True
-
-
-

--- a/default/python/AI/fleet_orders.py
+++ b/default/python/AI/fleet_orders.py
@@ -351,7 +351,7 @@ class OrderOutpost(AIFleetOrder):
             return True
         else:
             self.order_issued = False
-            debug("Order issuance failed: %s fleet: %s target: %s" % (self.ORDER_NAME, self.fleet, self.target))
+            warn("Order issuance failed: %s fleet: %s target: %s" % (self.ORDER_NAME, self.fleet, self.target))
             return False
 
 
@@ -376,7 +376,7 @@ class OrderColonize(AIFleetOrder):
             return True
         else:
             self.order_issued = False
-            debug("Order issuance failed: %s fleet: %s target: %s" % (self.ORDER_NAME, self.fleet, self.target))
+            warn("Order issuance failed: %s fleet: %s target: %s" % (self.ORDER_NAME, self.fleet, self.target))
             return False
 
     def is_valid(self):

--- a/default/python/AI/fleet_orders.py
+++ b/default/python/AI/fleet_orders.py
@@ -559,6 +559,8 @@ class OrderRepair(AIFleetOrder):
                 fleet_id, self.ORDER_NAME, universe.getSystem(dest_id), universe.getSystem(system_id))
             fo.issueFleetMoveOrder(fleet_id, dest_id)
             print "Order issued: %s fleet: %s target: %s" % (self.ORDER_NAME, self.fleet, self.target)
+        ships_cur_health, ships_max_health = FleetUtilsAI.get_current_and_max_structure(fleet_id)
+        self.executed = (ships_cur_health == ships_max_health)
         return True
 
 

--- a/default/python/AI/fleet_orders.py
+++ b/default/python/AI/fleet_orders.py
@@ -565,7 +565,6 @@ class OrderRepair(AIFleetOrder):
                 if system_id in foAI.foAIstate.needsEmergencyExploration:
                     foAI.foAIstate.needsEmergencyExploration.remove(system_id)
         elif system_id != fleet.nextSystemID:
-            self.executed = False
             fo.issueAggressionOrder(fleet_id, False)
             start_id = FleetUtilsAI.get_fleet_system(fleet)
             dest_id = MoveUtilsAI.get_safe_path_leg_to_dest(fleet_id, start_id, system_id)

--- a/default/python/AI/savegame_codec/_definitions.py
+++ b/default/python/AI/savegame_codec/_definitions.py
@@ -17,6 +17,7 @@ else:
         fleet_orders.OrderDefend,
         fleet_orders.OrderColonize,
         fleet_orders.OrderOutpost,
+        fleet_orders.OrderPause,
         fleet_orders.OrderInvade,
         fleet_orders.OrderMove,
         fleet_orders.OrderRepair,

--- a/default/python/AI/universe_object.py
+++ b/default/python/AI/universe_object.py
@@ -102,4 +102,7 @@ class Fleet(UniverseObject):
         return System(system_id)
 
     def get_object(self):
+        """
+        :rtype fo.fleet:
+        """
         return fo.getUniverse().getFleet(self.id)

--- a/default/python/AI/universe_object.py
+++ b/default/python/AI/universe_object.py
@@ -78,6 +78,17 @@ class System(UniverseObject):
 class Fleet(UniverseObject):
     object_name = 'fleet'
 
+    def get_current_system_id(self):
+        """
+        Get current systemID (or INVALID_ID if on a starlane).
+
+        :rtype: int
+        """
+        universe = fo.getUniverse()
+        fleet = universe.getFleet(self.id)
+        # will also return INVALID_ID if somehow the fleet cannot be retrieved
+        return fleet.systemID if fleet else INVALID_ID
+
     def get_system(self):
         """
         Get current fleet location or target system if currently on starlane.


### PR DESCRIPTION
This PR includes some general cleanup of AI treatment of order issuance and execution tracking, along with a number of changes directed at improving AI exploration and a bit for AI repair.

I am thinking it might be helpful to restructure some of the existing order types to subclass from this new OrderPause, and also plan some other changes to hopefully help facilitate maneuvers like a military fleet Pounce or somesuch, but that is still rather nascent and would follow in a separate PR.  As it stands I think this PR makes some minor improvements, and at least my testing has not indicated it causing any trouble.