### PR TITLE
Raise boost dep

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -34,7 +34,7 @@ FreeOrion depends on the following libraries or APIs to run:
   * OpenGL Utilities (GLU) ; usually provided by the graphic card driver or
     Operating System
   * OpenAL - It's recommended to use the [OpenAL Soft] implementation
-  * [Boost] - 1.56 or later
+  * [Boost] - 1.58 or later
   * [zlib]
   * [libpython] - 2.7.*
   * [FreeType2]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,7 @@ endif()
 ##
 
 set(MINIMUM_PYTHON_VERSION 2.7)
-set(MINIMUM_BOOST_VERSION 1.56.0)
+set(MINIMUM_BOOST_VERSION 1.58.0)
 
 find_package(Threads)
 find_package(PythonInterp ${MINIMUM_PYTHON_VERSION} REQUIRED)

--- a/GG/CMakeLists.txt
+++ b/GG/CMakeLists.txt
@@ -80,7 +80,7 @@ endif()
 ## Collect project dependencies.
 ##
 
-set(MINIMUM_BOOST_VERSION 1.56.0)
+set(MINIMUM_BOOST_VERSION 1.58.0)
 
 if(NOT USE_STATIC_LIBS)
     add_definitions(

--- a/combat/CombatLogManager.h
+++ b/combat/CombatLogManager.h
@@ -7,6 +7,7 @@
 #include "../util/Serialize.h"
 
 #include <boost/optional/optional.hpp>
+#include <boost/serialization/nvp.hpp>
 
 #include <memory>
 

--- a/combat/CombatSystem.h
+++ b/combat/CombatSystem.h
@@ -5,6 +5,8 @@
 #include "../util/AppInterface.h"
 #include "CombatEvent.h"
 
+#include <boost/serialization/nvp.hpp>
+#include <boost/serialization/split_member.hpp>
 #include <boost/serialization/version.hpp>
 
 /** Contains information about the state of a combat before or after the combat

--- a/parse/ReportParseError.cpp
+++ b/parse/ReportParseError.cpp
@@ -36,11 +36,7 @@ std::string parse::detail::info_visitor::prepare(const string& s) const {
 void parse::detail::info_visitor::print(const string& str) const
 { m_os << prepare(str); }
 
-#if BOOST_VERSION < 105600
-void parse::detail::info_visitor::operator()(boost::spirit::info::nil) const {
-#else
 void parse::detail::info_visitor::operator()(boost::spirit::info::nil_) const {
-#endif
     indent();
     print(m_tag);
 }

--- a/parse/ReportParseError.h
+++ b/parse/ReportParseError.h
@@ -15,11 +15,7 @@ namespace parse {
             void indent() const;
             std::string prepare(const string& s) const;
             void print(const string& str) const;
-#if BOOST_VERSION < 105600
-            void operator()(boost::spirit::info::nil) const;
-#else
             void operator()(boost::spirit::info::nil_) const;
-#endif
             void operator()(const string& str) const;
             void operator()(const boost::spirit::info& what) const;
             void operator()(const std::pair<boost::spirit::info, boost::spirit::info>& pair) const;

--- a/server/SaveLoad.cpp
+++ b/server/SaveLoad.cpp
@@ -35,14 +35,6 @@
 #include <boost/iostreams/stream.hpp>
 #include <boost/thread.hpp>
 
-// HACK: The following two includes work around a bug in boost 1.58,
-// which uses them without including.
-#include <boost/version.hpp>
-#if BOOST_VERSION == 105800
-#include <boost/serialization/type_info_implementation.hpp>
-#include <boost/archive/basic_archive.hpp>
-#endif
-
 #include <boost/serialization/shared_ptr.hpp>
 
 

--- a/server/SaveLoad.cpp
+++ b/server/SaveLoad.cpp
@@ -35,20 +35,10 @@
 #include <boost/iostreams/stream.hpp>
 #include <boost/thread.hpp>
 
-// HACK: The following two includes work around a bug in boost 1.56,
+// HACK: The following two includes work around a bug in boost 1.58,
 // which uses them without including.
 #include <boost/version.hpp>
-#if BOOST_VERSION == 105600
-#include <boost/serialization/singleton.hpp> // This
-#include <boost/serialization/extended_type_info.hpp> //This
-#endif
-// HACK: For a similar boost 1.57 bug
-#if BOOST_VERSION == 105700
-#include <boost/serialization/type_info_implementation.hpp> // This
-#endif
-
 #if BOOST_VERSION == 105800
-// HACK: The following two includes work around a bug in boost 1.58
 #include <boost/serialization/type_info_implementation.hpp>
 #include <boost/archive/basic_archive.hpp>
 #endif

--- a/universe/Universe.h
+++ b/universe/Universe.h
@@ -9,13 +9,6 @@
 #include "../util/Pending.h"
 
 #include <boost/signals2/signal.hpp>
-// Fix for issue #1513 (boost ticket #12978)
-// Starting with v1.64, boost::numeric::ublas was not updated for changes to
-// boost::serialization, which moved array_wrapper to separate header
-#if BOOST_VERSION >= 106400
-    #include <boost/serialization/array_wrapper.hpp>
-#endif
-#include <boost/numeric/ublas/symmetric.hpp>
 #include <boost/serialization/access.hpp>
 #include <boost/thread/shared_mutex.hpp>
 

--- a/util/Serialize.ipp
+++ b/util/Serialize.ipp
@@ -8,7 +8,6 @@
 
 #if BOOST_VERSION == 105800
 // HACK: The following two includes work around a bug in boost 1.58
-#include <boost/serialization/type_info_implementation.hpp>
 #include <boost/archive/basic_archive.hpp>
 #endif
 

--- a/util/Serialize.ipp
+++ b/util/Serialize.ipp
@@ -6,12 +6,6 @@
 #include <boost/detail/endian.hpp>
 #include <boost/version.hpp>
 
-#if BOOST_VERSION == 105600
-// HACK: The following two includes work around a bug in boost 1.56,
-#include <boost/serialization/singleton.hpp> // This
-#include <boost/serialization/extended_type_info.hpp> //This
-#endif
-
 #if BOOST_VERSION == 105800
 // HACK: The following two includes work around a bug in boost 1.58
 #include <boost/serialization/type_info_implementation.hpp>


### PR DESCRIPTION
This PR raises the boost dependency version requirement from 1.56 to 1.58.  Also it removes unneeded and wrong workarounds for older boost versions.