### PR TITLE
Fix AI exploration

### DIFF
--- a/default/python/AI/ExplorationAI.py
+++ b/default/python/AI/ExplorationAI.py
@@ -1,4 +1,4 @@
-from logging import error
+from logging import debug, error
 
 import freeOrionAIInterface as fo  # interface used to interact with FreeOrion AI client # pylint: disable=import-error
 import FreeOrionAI as foAI
@@ -30,6 +30,8 @@ def get_current_exploration_info():
                     print "problem determining existing exploration target systems"
                 else:
                     print "found existing exploration target: %s" % fleet_mission.target
+    debug("Current exploration targets: %s" % already_covered)
+    debug("Available scout fleets: %s" % available_scouts)
     return list(already_covered), available_scouts
 
 
@@ -57,6 +59,7 @@ def assign_scouts_to_explore_systems():
             if INVALID_ID in sys_list:
                 error("INVALID_ID found in " + name, exc_info=True)
     # emergency coverage can be due to invasion detection trouble, etc.
+    print "Check list: %s" % check_list
     needs_coverage = [sys_id for sys_id in check_list if sys_id not in already_covered and sys_id != INVALID_ID]
     print "Needs coverage: %s" % needs_coverage
 

--- a/default/python/AI/ExplorationAI.py
+++ b/default/python/AI/ExplorationAI.py
@@ -25,7 +25,7 @@ def get_current_exploration_info():
             available_scouts.append(fleet_id)
         else:
             if fleet_mission.type == MissionType.EXPLORATION:
-                already_covered.add(fleet_mission.target)
+                already_covered.add(fleet_mission.target.id)
                 if not fleet_mission.target:
                     print "problem determining existing exploration target systems"
                 else:


### PR DESCRIPTION
This PR fixes a bug where the AI would (sometimes?) not assign new exploration targets while it has existing exploration targets but idle/available scout fleets.

While the fix is straightforward (a list of universe_object.System objects was returned rather than a list of system ids), I don't understand how the relevant list comprehension failed in the way it does:
```
needs_coverage = [sys_id for sys_id in check_list if sys_id not in already_covered and sys_id != INVALID_ID]
```

Before the fix:
22:02:04.479107 [debug] python : ExplorationAI.py:52 - Explorable system IDs: [210, 237, 192, 174]
22:02:04.479107 [debug] python : ExplorationAI.py:53 - Already targeted: [<universe_object.System object at 0x03D952D0>]
22:02:04.479107 [debug] python : ExplorationAI.py:62 - Check list: [210, 237, 192, 174]
22:02:04.479107 [debug] python : ExplorationAI.py:64 - Needs coverage: [] 

After the fix:
22:09:12.186570 [debug] python : ExplorationAI.py:52 - Explorable system IDs: [210, 237, 192, 174]
22:09:12.186570 [debug] python : ExplorationAI.py:53 - Already targeted: [237]
22:09:12.186570 [debug] python : ExplorationAI.py:62 - Check list: [210, 237, 192, 174]
22:09:12.186570 [debug] python : ExplorationAI.py:64 - Needs coverage: [210, 192, 174]