### PR TITLE
Improve EspionageAI planetary stealth logic

### DIFF
--- a/default/python/AI/AIDependencies.py
+++ b/default/python/AI/AIDependencies.py
@@ -149,6 +149,9 @@ STEALTH_STRENGTHS_BY_SPECIES_TAG = {
     "ULTIMATE_STEALTH": PRIMARY_FOCS_STEALTH_LEVELS["HIGH_STEALTH"],
     "INFINITE_STEALTH": 500,  # used by super testers
 }
+
+FLD_ION_STORM = "FLD_ION_STORM"
+ION_STORM_STEALTH = 40
 # </editor-fold>
 
 # <editor-fold desc="Specials">

--- a/default/python/AI/EspionageAI.py
+++ b/default/python/AI/EspionageAI.py
@@ -86,6 +86,9 @@ def colony_detectable_by_empire(planet_id, species_name=None, empire=ALL_EMPIRES
         return default_result
     if species_name is None:
         species_name = planet.speciesName
+        verify_prediction = True
+    else:
+        verify_prediction = False
 
     # in case we are checking about aborting a colonization mission
     if empire == fo.empireID() and planet.ownedBy(empire):
@@ -113,6 +116,12 @@ def colony_detectable_by_empire(planet_id, species_name=None, empire=ALL_EMPIRES
 
     total_stealth = planet_stealth + sum([AIDependencies.STEALTH_STRENGTHS_BY_SPECIES_TAG.get(tag, 0)
                                           for tag in species_tags])
+
+    if verify_prediction:
+        meter_stealth = planet.currentMeterValue(fo.meterType.stealth)
+        if meter_stealth != total_stealth:
+            warn("Predicted stealth value for planet %s of %.1f but got %.1f" % (planet, total_stealth, meter_stealth))
+
     if isinstance(empire, int):
         empire_detection = get_empire_detection(empire)
     else:

--- a/default/python/AI/EspionageAI.py
+++ b/default/python/AI/EspionageAI.py
@@ -4,7 +4,7 @@ import freeOrionAIInterface as fo  # pylint: disable=import-error
 import AIDependencies
 from AIDependencies import ALL_EMPIRES
 from EnumsAI import EmpireMeters
-from freeorion_tools import cache_by_session_with_turnwise_update
+from freeorion_tools import cache_by_session_with_turnwise_update, object_is_in_ion_storm
 
 
 def default_empire_detection_strength():
@@ -119,6 +119,9 @@ def colony_detectable_by_empire(planet_id, species_name=None, empire=ALL_EMPIRES
 
     if verify_prediction:
         meter_stealth = planet.currentMeterValue(fo.meterType.stealth)
+        predicted_stealth = total_stealth
+        if object_is_in_ion_storm(planet_id):
+            predicted_stealth += AIDependencies.ION_STORM_STEALTH
         if meter_stealth != total_stealth:
             warn("Predicted stealth value for planet %s of %.1f but got %.1f" % (planet, total_stealth, meter_stealth))
 

--- a/default/python/AI/EspionageAI.py
+++ b/default/python/AI/EspionageAI.py
@@ -122,8 +122,8 @@ def colony_detectable_by_empire(planet_id, species_name=None, empire=ALL_EMPIRES
         predicted_stealth = total_stealth
         if object_is_in_ion_storm(planet_id):
             predicted_stealth += AIDependencies.ION_STORM_STEALTH
-        if meter_stealth != total_stealth:
-            warn("Predicted stealth value for planet %s of %.1f but got %.1f" % (planet, total_stealth, meter_stealth))
+        if meter_stealth != predicted_stealth:
+            warn("Predicted stealth value for planet %s of %.1f but got %.1f" % (planet, predicted_stealth, meter_stealth))
 
     if isinstance(empire, int):
         empire_detection = get_empire_detection(empire)

--- a/default/python/AI/EspionageAI.py
+++ b/default/python/AI/EspionageAI.py
@@ -122,6 +122,7 @@ def colony_detectable_by_empire(planet_id, species_name=None, empire=ALL_EMPIRES
         predicted_stealth = total_stealth
         if object_is_in_ion_storm(planet_id):
             predicted_stealth += AIDependencies.ION_STORM_STEALTH
+        predicted_stealth = max(0., predicted_stealth)
         if meter_stealth != predicted_stealth:
             warn("Predicted stealth value for planet %s of %.1f but got %.1f" % (planet, predicted_stealth, meter_stealth))
 

--- a/default/python/AI/freeorion_tools/_freeorion_tools.py
+++ b/default/python/AI/freeorion_tools/_freeorion_tools.py
@@ -9,6 +9,7 @@ from collections import Mapping
 from functools import wraps
 
 import freeOrionAIInterface as fo  # pylint: disable=import-error
+import AIDependencies
 
 # color wrappers for chat:
 RED = '<rgba 255 0 0 255>%s</rgba>'
@@ -347,3 +348,22 @@ def with_log_level(log_level):
 
         return wrapper
     return decorator
+
+
+def object_is_in_ion_storm(object_id):
+    # FIXME: This isn't working if we can not detect the ion storm
+    #        as is the case if the center of the storm is out of detection range
+    universe = fo.getUniverse()
+    universe_object = universe.getPlanet(object_id)
+    if not universe_object:
+        return False
+
+    for field_id in universe.fieldIDs:
+        field = universe.getField(field_id)
+        if field.fieldTypeName != AIDependencies.FLD_ION_STORM:
+            continue
+
+        if field.inField(universe_object):
+            return True
+
+    return False


### PR DESCRIPTION
This PR fixes some issues with the current planetary stealth prediction used by the AI:
1) Log a warning if the predicted planet stealth does not match the actual meter value to find unsupported stealth effects and to verify the calculation
~2) Bugfix: base stealth stacks with stealth specials~
~3) Make the AI aware of supertester stealth - now it won't try (and fail) to invade their planets~
4) Catch some of the discrepencies between predicted planet stealth and meter value due to ion storms by checking if the planet is in a (known) ion storm. However, the code does not work if the AI can not see the ion storm itself (because the center is not in detection range?) - looking for suggestions for a better approach here so it may actually be used in the AI logic.