### PR TITLE
Allow player to revoke and change his order

### DIFF
--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -1041,7 +1041,10 @@ void MapWnd::CompleteConstruction() {
     // turn button
     // determine size from the text that will go into the button, using a test year string
     std::string turn_button_longest_reasonable_text =  boost::io::str(FlexibleFormat(UserString("MAP_BTN_TURN_UPDATE")) % "99999"); // it is unlikely a game will go over 100000 turns
-    m_btn_turn = Wnd::Create<CUIButton>(turn_button_longest_reasonable_text);
+    std::string unready_button_longest_reasonable_text =  boost::io::str(FlexibleFormat(UserString("MAP_BTN_TURN_UNREADY")) % "99999");
+    m_btn_turn = Wnd::Create<CUIButton>(turn_button_longest_reasonable_text.size() > unready_button_longest_reasonable_text.size() ?
+                                        turn_button_longest_reasonable_text :
+                                        unready_button_longest_reasonable_text);
     m_btn_turn->Resize(m_btn_turn->MinUsableSize());
     m_btn_turn->LeftClickedSignal.connect(
         boost::bind(&MapWnd::EndTurn, this));

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -6126,6 +6126,7 @@ bool MapWnd::ReturnToMap() {
 
 bool MapWnd::EndTurn() {
     if (m_ready_turn) {
+        HumanClientApp::GetApp()->UnreadyTurn();
     } else {
         HumanClientApp::GetApp()->StartTurn();
     }

--- a/UI/MapWnd.h
+++ b/UI/MapWnd.h
@@ -372,7 +372,7 @@ private:
     void FleetButtonRightClicked(const FleetButton* fleet_btn);
     void FleetRightClicked(int fleet_id);
     void FleetsRightClicked(const std::vector<int>& fleet_ids);
-    
+
     void ShipRightClicked(int fleet_id);
     void ShipsRightClicked(const std::vector<int>& fleet_ids);
 
@@ -559,6 +559,7 @@ private:
     std::shared_ptr<GG::Button>     m_btn_turn = nullptr;       //!< button that updates player's turn;
     std::shared_ptr<GG::Button>     m_btn_auto_turn = nullptr;  //!< button that toggles whether to automatically end turns;
     bool                            m_auto_end_turn = false;    //!< should turns be ended automatically by this client?
+    bool                            m_ready_turn = false;       //!< is turn orders are ready and sent to server?
     std::list<std::weak_ptr<MapWndPopup>> m_popups;             //!< list of currently active popup windows
     bool                            m_menu_showing = false;     //!< set during ShowMenu() to prevent reentrency
     int                             m_current_owned_system;

--- a/client/ClientFSMEvents.h
+++ b/client/ClientFSMEvents.h
@@ -34,6 +34,7 @@ struct MessageEventBase {
     (TurnUpdate)                               \
     (TurnPartialUpdate)                        \
     (TurnProgress)                             \
+    (TurnRevoked)                              \
     (PlayerStatus)                             \
     (PlayerChat)                               \
     (Diplomacy)                                \

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -933,6 +933,10 @@ void HumanClientApp::StartTurn() {
     m_fsm->process_event(TurnEnded());
 }
 
+void HumanClientApp::UnreadyTurn() {
+    m_networking->SendMessage(UnreadyMessage());
+}
+
 void HumanClientApp::HandleTurnPhaseUpdate(Message::TurnProgressPhase phase_id) {
     ClientApp::HandleTurnPhaseUpdate(phase_id);
 
@@ -977,6 +981,7 @@ void HumanClientApp::HandleMessage(Message& msg) {
     case Message::TURN_UPDATE:              m_fsm->process_event(TurnUpdate(msg));              break;
     case Message::TURN_PARTIAL_UPDATE:      m_fsm->process_event(TurnPartialUpdate(msg));       break;
     case Message::TURN_PROGRESS:            m_fsm->process_event(TurnProgress(msg));            break;
+    case Message::UNREADY:                  m_fsm->process_event(TurnRevoked(msg));             break;
     case Message::PLAYER_STATUS:            m_fsm->process_event(::PlayerStatus(msg));          break;
     case Message::PLAYER_CHAT:              m_fsm->process_event(PlayerChat(msg));              break;
     case Message::DIPLOMACY:                m_fsm->process_event(Diplomacy(msg));               break;

--- a/client/human/HumanClientApp.h
+++ b/client/human/HumanClientApp.h
@@ -53,6 +53,7 @@ public:
     /** \name Mutators */ //@{
     void HandleTurnUpdate() override;           ///< Handle background events that need starting when the turn updates
     void StartTurn() override;
+    void UnreadyTurn();                         ///< Revoke ready state of turn orders.
 
     /** \brief Handle UI and state updates with changes in turn phase. */
     void HandleTurnPhaseUpdate(Message::TurnProgressPhase phase_id) override;

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -824,6 +824,8 @@ boost::statechart::result WaitingForGameStart::react(const GameStart& msg) {
     if (is_new_game && Client().Networking().PlayerIsHost(Client().PlayerID()))
         Client().Autosave();
 
+    Client().GetClientUI().GetPlayerListWnd()->Refresh();
+
     return transit<PlayingTurn>();
 }
 
@@ -888,6 +890,8 @@ boost::statechart::result WaitingForTurnData::react(const TurnUpdate& msg) {
 
     Client().HandleTurnUpdate();
 
+    Client().GetClientUI().GetPlayerListWnd()->Refresh();
+
     return transit<PlayingTurn>();
 }
 
@@ -919,7 +923,6 @@ PlayingTurn::PlayingTurn(my_context ctx) :
     Client().GetClientUI().GetMessageWnd()->HandleGameStatusUpdate(
         boost::io::str(FlexibleFormat(UserString("TURN_BEGIN")) % CurrentTurn()) + "\n");
     Client().GetClientUI().GetMessageWnd()->HandlePlayerStatusUpdate(Message::PLAYING_TURN, Client().PlayerID());
-    Client().GetClientUI().GetPlayerListWnd()->Refresh();
     Client().GetClientUI().GetPlayerListWnd()->HandlePlayerStatusUpdate(Message::PLAYING_TURN, Client().PlayerID());
 
     if (Client().GetApp()->GetClientType() != Networking::CLIENT_TYPE_HUMAN_OBSERVER)

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -891,6 +891,13 @@ boost::statechart::result WaitingForTurnData::react(const TurnUpdate& msg) {
     return transit<PlayingTurn>();
 }
 
+boost::statechart::result WaitingForTurnData::react(const TurnRevoked& msg) {
+    TraceLogger(FSM) << "(HumanClientFSM) PlayingGame.TurnRevoked";
+
+    // Allow player to change orders
+    return transit<PlayingTurn>();
+}
+
 boost::statechart::result WaitingForTurnData::react(const DispatchCombatLogs& msg) {
     DebugLogger(FSM) << "(PlayerFSM) WaitingForTurnData::DispatchCombatLogs message received";
     Client().UpdateCombatLogs(msg.m_message);

--- a/client/human/HumanClientFSM.h
+++ b/client/human/HumanClientFSM.h
@@ -312,6 +312,7 @@ struct WaitingForTurnData : boost::statechart::state<WaitingForTurnData, Playing
         boost::statechart::custom_reaction<SaveGameDataRequest>,
         boost::statechart::custom_reaction<SaveGameComplete>,
         boost::statechart::custom_reaction<TurnUpdate>,
+        boost::statechart::custom_reaction<TurnRevoked>,
         boost::statechart::custom_reaction<DispatchCombatLogs>
     > reactions;
 
@@ -321,6 +322,7 @@ struct WaitingForTurnData : boost::statechart::state<WaitingForTurnData, Playing
     boost::statechart::result react(const SaveGameDataRequest& d);
     boost::statechart::result react(const SaveGameComplete& d);
     boost::statechart::result react(const TurnUpdate& msg);
+    boost::statechart::result react(const TurnRevoked& msg);
     boost::statechart::result react(const DispatchCombatLogs& msg);
 
     CLIENT_ACCESSOR

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -3073,7 +3073,7 @@ Turn %1%
 
 # %1% current turn number.
 MAP_BTN_TURN_UNREADY
-Unready %1%
+Revise Orders %1%
 
 # %1% number of frames currently displayed per second.
 MAP_INDICATOR_FPS

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -3071,6 +3071,10 @@ Unable to create persistent_config.xml, check log file for details.
 MAP_BTN_TURN_UPDATE
 Turn %1%
 
+# %1% current turn number.
+MAP_BTN_TURN_UNREADY
+Unready %1%
+
 # %1% number of frames currently displayed per second.
 MAP_INDICATOR_FPS
 %1% FPS

--- a/network/Message.cpp
+++ b/network/Message.cpp
@@ -689,6 +689,9 @@ Message SetAuthorizationRolesMessage(const Networking::AuthRoles& roles)
 Message EliminateSelfMessage()
 { return Message(Message::ELIMINATE_SELF, DUMMY_EMPTY_MESSAGE); }
 
+Message UnreadyMessage()
+{ return Message(Message::UNREADY, DUMMY_EMPTY_MESSAGE); }
+
 ////////////////////////////////////////////////
 // Message data extractors
 ////////////////////////////////////////////////

--- a/network/Message.h
+++ b/network/Message.h
@@ -103,7 +103,8 @@ public:
         AUTH_RESPONSE,          ///< sent by client to server to provide password or other credentials
         CHAT_HISTORY,           ///< sent by server to client to show previous messages
         SET_AUTH_ROLES,         ///< sent by server to client to set authorization roles
-        ELIMINATE_SELF          ///< sent by client to server if the player wants to resign
+        ELIMINATE_SELF,         ///< sent by client to server if the player wants to resign
+        UNREADY                 ///< sent by client to server to revoke ready state of turn orders and sent by server to client to acknowledge it
     )
 
     GG_CLASS_ENUM(TurnProgressPhase,
@@ -363,6 +364,9 @@ FO_COMMON_API Message SetAuthorizationRolesMessage(const Networking::AuthRoles& 
 
 /** creates a ELIMINATE_SELF message to resign from the game. */
 FO_COMMON_API Message EliminateSelfMessage();
+
+/** creates a UNREADY message to revoke ready state of turn orders or acknowledge it */
+FO_COMMON_API Message UnreadyMessage();
 
 ////////////////////////////////////////////////
 // Message data extractors

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1711,7 +1711,10 @@ bool ServerApp::AddPlayerIntoGame(const PlayerConnectionPtr& player_connection) 
             m_player_empire_ids[player_connection->PlayerID()] = empire.first;
 
             const OrderSet dummy;
-            const OrderSet& orders = orders_it->second ? *orders_it->second : dummy;
+            const OrderSet& orders = orders_it->second.second ? *orders_it->second.second : dummy;
+
+            // drop ready status
+            orders_it->second.first = false;
 
             auto player_info_map = GetPlayerInfoMap();
             bool use_binary_serialization = player_connection->ClientVersionStringMatchesThisServer();
@@ -1755,38 +1758,42 @@ int ServerApp::EffectsProcessingThreads() const
 { return GetOptionsDB().Get<int>("effects.server.threads"); }
 
 void ServerApp::AddEmpireTurn(int empire_id)
-{ m_turn_sequence[empire_id].reset(nullptr); }
+{
+    m_turn_sequence[empire_id].second.reset(nullptr);
+    m_turn_sequence[empire_id].first = false;
+}
 
 void ServerApp::RemoveEmpireTurn(int empire_id)
 { m_turn_sequence.erase(empire_id); }
 
 void ServerApp::ClearEmpireTurnOrders() {
     for (auto& order : m_turn_sequence) {
-        if (order.second) {
-            order.second.reset(nullptr);
+        order.second.first = false;
+        if (order.second.second) {
+            order.second.second.reset(nullptr);
         }
     }
 }
 
 void ServerApp::SetEmpireTurnOrders(int empire_id, std::unique_ptr<OrderSet>&& order_set)
-{ m_turn_sequence[empire_id] = std::move(order_set); }
+{ m_turn_sequence[empire_id] = std::make_pair(true, std::move(order_set)); }
 
 bool ServerApp::AllOrdersReceived() {
     // debug output
     DebugLogger() << "ServerApp::AllOrdersReceived for turn: " << m_current_turn;
+    bool all_orders_received = true;
     for (const auto& empire_orders : m_turn_sequence) {
-        if (!empire_orders.second)
+        if (!empire_orders.second.second) {
             DebugLogger() << " ... no orders from empire id: " << empire_orders.first;
-        else
+            all_orders_received = false;
+        } else if (!empire_orders.second.first) {
+            DebugLogger() << " ... not ready empire id: " << empire_orders.first;
+            all_orders_received = false;
+        } else {
             DebugLogger() << " ... have orders from empire id: " << empire_orders.first;
+        }
     }
-
-    // Loop through to find empire ID and check for valid orders pointer
-    for (const auto& empire_orders : m_turn_sequence) {
-        if (!empire_orders.second)
-            return false;
-    }
-    return true;
+    return all_orders_received;
 }
 
 namespace {
@@ -2978,11 +2985,11 @@ void ServerApp::PreCombatProcessTurns() {
     // execute orders
     for (const auto& empire_orders : m_turn_sequence) {
         auto& order_set = empire_orders.second;
-        if (!order_set) {
+        if (!order_set.second) {
             DebugLogger() << "No OrderSet for empire " << empire_orders.first;
             continue;
         }
-        for (const auto& id_and_order : *order_set)
+        for (const auto& id_and_order : *order_set.second)
             id_and_order.second->Execute();
     }
 

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -420,6 +420,7 @@ void ServerApp::HandleMessage(const Message& msg, PlayerConnectionPtr player_con
     case Message::LOBBY_UPDATE:             m_fsm->process_event(LobbyUpdate(msg, player_connection));      break;
     case Message::SAVE_GAME_INITIATE:       m_fsm->process_event(SaveGameRequest(msg, player_connection));  break;
     case Message::TURN_ORDERS:              m_fsm->process_event(TurnOrders(msg, player_connection));       break;
+    case Message::UNREADY:                  m_fsm->process_event(RevokeReadiness(msg, player_connection));  break;
     case Message::CLIENT_SAVE_DATA:         m_fsm->process_event(ClientSaveData(msg, player_connection));   break;
     case Message::PLAYER_CHAT:              m_fsm->process_event(PlayerChat(msg, player_connection));       break;
     case Message::DIPLOMACY:                m_fsm->process_event(Diplomacy(msg, player_connection));        break;
@@ -1777,6 +1778,9 @@ void ServerApp::ClearEmpireTurnOrders() {
 
 void ServerApp::SetEmpireTurnOrders(int empire_id, std::unique_ptr<OrderSet>&& order_set)
 { m_turn_sequence[empire_id] = std::make_pair(true, std::move(order_set)); }
+
+void ServerApp::RevokeEmpireTurnReadyness(int empire_id)
+{ m_turn_sequence[empire_id].first = false; }
 
 bool ServerApp::AllOrdersReceived() {
     // debug output

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -163,6 +163,9 @@ public:
       * will be freed when all processing is done for the turn */
     void    SetEmpireTurnOrders(int empire_id, std::unique_ptr<OrderSet>&& order_set);
 
+    /** Revokes turn order's ready state for the given empire. */
+    void    RevokeEmpireTurnReadyness(int empire_id);
+
     /** Sets all empire turn orders to an empty set. */
     void    ClearEmpireTurnOrders();
 

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -351,8 +351,11 @@ private:
 
     /** Turn sequence map is used for turn processing. Each empire is added at
       * the start of a game or reload and then the map maintains OrderSets for
-      * that turn. */
-    std::map<int, std::unique_ptr<OrderSet>>         m_turn_sequence;
+      * that turn.
+      * The map contains ready state which should be true to advance turn and
+      * pointer to orders from empire.
+      * */
+    std::map<int, std::pair<bool, std::unique_ptr<OrderSet>>>      m_turn_sequence;
 
     // Give FSM and its states direct access.  We are using the FSM code as a
     // control-flow mechanism; it is all notionally part of this class.

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -2546,7 +2546,7 @@ sc::result WaitingForSaveData::react(const ClientSaveData& msg) {
     // received orders are ignored if there are already existing orders?
     std::shared_ptr<OrderSet> order_set;
     if (const Empire* empire = GetEmpire(server.PlayerEmpireID(player_id))) {
-        const auto& existing_orders = server.m_turn_sequence[empire->EmpireID()];
+        const auto& existing_orders = server.m_turn_sequence[empire->EmpireID()].second;
         if (existing_orders)
             order_set.reset(new OrderSet(*existing_orders));
         else

--- a/server/ServerFSM.h
+++ b/server/ServerFSM.h
@@ -78,6 +78,7 @@ struct MessageEventBase {
     (LeaveGame)                             \
     (SaveGameRequest)                       \
     (TurnOrders)                            \
+    (RevokeReadiness)                       \
     (CombatTurnOrders)                      \
     (ClientSaveData)                        \
     (RequestCombatLogs)                     \
@@ -332,6 +333,7 @@ struct PlayingGame : sc::state<PlayingGame, ServerFSM, WaitingForTurnEnd> {
 struct WaitingForTurnEnd : sc::state<WaitingForTurnEnd, PlayingGame, WaitingForTurnEndIdle> {
     typedef boost::mpl::list<
         sc::custom_reaction<TurnOrders>,
+        sc::custom_reaction<RevokeReadiness>,
         sc::custom_reaction<CheckTurnEndConditions>
     > reactions;
 
@@ -339,6 +341,7 @@ struct WaitingForTurnEnd : sc::state<WaitingForTurnEnd, PlayingGame, WaitingForT
     ~WaitingForTurnEnd();
 
     sc::result react(const TurnOrders& msg);
+    sc::result react(const RevokeReadiness& msg);
     sc::result react(const CheckTurnEndConditions& c);
 
     std::string m_save_filename;
@@ -370,6 +373,7 @@ struct WaitingForSaveData : sc::state<WaitingForSaveData, WaitingForTurnEnd> {
         sc::custom_reaction<ClientSaveData>,
         sc::deferral<SaveGameRequest>,
         sc::deferral<TurnOrders>,
+        sc::deferral<RevokeReadiness>,
         sc::deferral<PlayerChat>,
         sc::deferral<Diplomacy>
     > reactions;
@@ -397,6 +401,7 @@ struct ProcessingTurn : sc::state<ProcessingTurn, PlayingGame> {
         sc::custom_reaction<ProcessTurn>,
         sc::deferral<SaveGameRequest>,
         sc::deferral<TurnOrders>,
+        sc::deferral<RevokeReadiness>,
         sc::deferral<Diplomacy>,
         sc::custom_reaction<CheckTurnEndConditions>
     > reactions;


### PR DESCRIPTION
This PR allows player to prevent turn advance and change his orders.
It introduces `UNREADY` message client sends to revoke his orders and server sends to acknowledge revoking.
In multiplayer game "Turn" button renames to "Revise Orders" and revokes turn orders.
The server stores ready status and unset it when this message accepted. Turn orders remains and could be saved.

Forum thread: http://www.freeorion.org/forum/viewtopic.php?f=6&t=10915