### PR TITLE
Fix ShipPartsOwned

### DIFF
--- a/parse/IntComplexValueRefParser.cpp
+++ b/parse/IntComplexValueRefParser.cpp
@@ -182,8 +182,8 @@ namespace parse {
             |   outposts_owned
             |   parts_in_ship_design
             |   part_class_in_ship_design
-            |   ship_parts_owned_by_name
             |   ship_parts_owned_by_class
+            |   ship_parts_owned_by_name
             |   empire_design_ref
             |   slots_in_hull
             |   slots_in_ship_design


### PR DESCRIPTION
Switch order of by_name and by_class to allow by_class to be parsed

My attempt to fix #2089