### PR TITLE
Augment ai cache cleanup

### DIFF
--- a/default/python/AI/ShipDesignAI.py
+++ b/default/python/AI/ShipDesignAI.py
@@ -384,6 +384,10 @@ class ShipDesignCache(object):
                     corrupted.append(designname)
         for corrupted_entry in corrupted:
             del self.design_id_by_name[corrupted_entry]
+            bad_ref = next(iter([_key for _key, _val in self.map_reference_design_name.iteritems()
+                                 if _val == corrupted_entry]), None)
+            if bad_ref is not None:
+                del self.map_reference_design_name[bad_ref]
 
     def _update_buildable_items_this_turn(self, verbose=False):
         """Calculate which parts and hulls can be built on each planet this turn.

--- a/default/python/AI/ShipDesignAI.py
+++ b/default/python/AI/ShipDesignAI.py
@@ -1009,7 +1009,7 @@ class ShipDesigner(object):
             if tech_is_complete(tech):
                 parse_tokens(AIDependencies.TECH_EFFECTS[tech])
 
-    def add_design(self, verbose=False):
+    def add_design(self, verbose=True):
         """Add a real (i.e. gameobject) ship design of the current configuration.
 
         :param verbose: toggles detailed debugging output


### PR DESCRIPTION
This augments the cleanup performed by the AI when it discovers problems in its ShipDesign cache following a game load.  The extra cleanup in this PR results in preventing some errors from being reported to the user in-game and to logfile, but does not identify or fix the cause of the cache corruption, and leaves the related warn logging in place, as discussed in #2092 

For now I am leaving "On" some extra verbose debug logging for a key AI ship design process, because it was helpful for identifying the need for this bit of cleanup and I think it might still be helpful towards casting more light on the underlying problem and I don't think it adds all that much bulk to the log files). 

An example  of the related logging before this PR is 
```
14:33:01.392519 [info] python : ShipDesignAI.py:150 - ==========Updating ShipDesignCache for new turn==========
14:33:01.392519 [debug] python : ShipDesignAI.py:349 - Checking persistent cache for consistency...
14:33:01.393020 [warn] python : ShipDesignAI.py:370 - ShipID cache corrupted. Expected: EY Cerberus Mk. 5, got: AI_TESTDESIGN_PART_SH_DEFENSE_GRID_SH_COLONY_BASE.
14:33:01.395021 [debug] python : ShipDesignAI.py:477 - Updating Testdesigns for hulls...
14:33:01.395021 [debug] python : ShipDesignAI.py:490 - Caching buildable hulls per planet...
14:33:01.395522 [debug] python : ShipDesignAI.py:510 - Updating test designs for ship parts...
14:33:01.396522 [debug] python : ShipDesignAI.py:566 - Caching buildable ship parts per planet...
14:33:01.452562 [debug] python : ShipDesignAI.py:2208 - Shipdesign EY Cerberus Mk. 5 seems not to exist: Caching as invalid design.
14:33:01.454563 [error] python : ShipDesignAI.py:1038 - SH_ROBOTIC-AR_ZORTRIUM_PLATE-SH_DEFENSE_GRID-SR_WEAPON_1_1-SR_WEAPON_1_1-SR_WEAPON_1_1 maps to EY Cerberus Mk. 5 in Cache.map_reference_design_name. But the design seems not to exist...
14:33:01.454563 [error] python : ShipDesignAI.py:1038 - Traceback (most recent call last):
14:33:01.454563 [error] python : ShipDesignAI.py:1038 -   File "C:/Users\Public\Documents\Development\FreeOrion\default\python\AI\ShipDesignAI.py", line 1034, in add_design
14:33:01.454563 [error] python : ShipDesignAI.py:1038 -     return _get_design_by_name(Cache.map_reference_design_name[reference_name]).id
14:33:01.454563 [error] python : ShipDesignAI.py:1038 - AttributeError: 'NoneType' object has no attribute 'id'
14:33:01.455064 [error] python : ShipDesignAI.py:1187 - The best design for WarShipDesigner on planet 1918 could not be added.
14:33:01.484085 [error] python : ShipDesignAI.py:1038 - SH_ROBOTIC-AR_ZORTRIUM_PLATE-SH_DEFENSE_GRID-SR_WEAPON_1_1-SR_WEAPON_1_1-SR_WEAPON_1_1 maps to EY Cerberus Mk. 5 in Cache.map_reference_design_name. But the design seems not to exist...
14:33:01.484085 [error] python : ShipDesignAI.py:1038 - Traceback (most recent call last):
14:33:01.484085 [error] python : ShipDesignAI.py:1038 -   File "C:/Users\Public\Documents\Development\FreeOrion\default\python\AI\ShipDesignAI.py", line 1034, in add_design
14:33:01.484085 [error] python : ShipDesignAI.py:1038 -     return _get_design_by_name(Cache.map_reference_design_name[reference_name]).id
14:33:01.484085 [error] python : ShipDesignAI.py:1038 - AttributeError: 'NoneType' object has no attribute 'id'
14:33:01.485084 [error] python : ShipDesignAI.py:1187 - The best design for WarShipDesigner on planet 8302 could not be added.
```

This PR prevents the error logging in the above, and associated in-game messages.