### PR TITLE
Update TravisCI configuration to use build stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -100,6 +100,8 @@ matrix:
     - os: osx
       osx_image: xcode8.3
       compiler: clang
+      env:
+        - NAME="Build FreeOrion"
       install:
         - wget --output-document=FreeOrionSDK.dmg https://github.com/freeorion/freeorion-sdk/releases/download/v8/FreeOrionSDK_8_Clang-MacOSX-10.9-x86_64.dmg
         - hdiutil attach FreeOrionSDK.dmg

--- a/.travis.yml
+++ b/.travis.yml
@@ -78,27 +78,11 @@ before_script:
       echo -e "url=https://freeorion-bot:${FreeOrion_AUTH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git\n" | git credential approve
     fi
   # Setup ccache
-  - |
-    # Make certain ~/.ccache exists
-    mkdir -p $HOME/.ccache;
-
-    if [ -e /Users/travis/.ccache/ccache.conf ]; then
-       echo "Show global /Users/travis/.ccache/ccache.conf"
-       more /Users/travis/.ccache/ccache.conf
-    else
-       echo "Missing global /Users/travis/.ccache/ccache.conf"
-    fi;
-
-    if [ -e $HOME/.ccache/ccache.conf ]; then
-       echo "Show local $HOME/.ccache/ccache.conf"
-       more $HOME/.ccache/ccache.conf
-    else
-       echo "Missing local $HOME/.ccache/ccache.conf"
-    fi;
-    # Allow ccache to account for __FILE__ macro
-    echo sloppiness = file_macro > $HOME/.ccache/ccache.conf
-    ccache --version
-    ccache --show-stats
+  - mkdir -p $HOME/.ccache;
+  # Allow ccache to account for __FILE__ macro
+  - echo sloppiness = file_macro > $HOME/.ccache/ccache.conf
+  - ccache --version
+  - ccache --show-stats
   - >
     if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
       # Add transparent cmake function to allow possible cross platform use of

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ stages:
   - build
   - test
 
-language: cpp
-
 # ccache caches obj files between builds
 cache: ccache
 
@@ -12,6 +10,7 @@ jobs:
   include:
     - stage: build
       os: linux
+      language: cpp
       services:
         - docker
       env:
@@ -77,6 +76,7 @@ jobs:
         - NAME="Lint Python script"
     - stage: build
       os: linux
+      language: cpp
       services:
         - docker
       env:
@@ -109,6 +109,7 @@ jobs:
         - ccache --show-stats
     - stage: build
       os: osx
+      language: cpp
       osx_image: xcode8.3
       compiler: clang
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+stages:
+  - build
+
 language: cpp
 
 # ccache caches obj files between builds
@@ -111,33 +114,41 @@ before_script:
 before_cache:
   # Check ccache
   - ccache --show-stats
-script:
-  - >
-    if [[ "${BUILD_APIDOC}" == "true" && "${TRAVIS_BRANCH}" == "master" ]]; then
-      cmake ..
-      cmake --build . --target cpp-apidoc
 
-      git clone --depth=1 --branch=master https://github.com/freeorion/freeorion.github.io.git apidoc-deploy.git
-      pushd apidoc-deploy.git
-      rm -rf cppapi/master
-      mkdir -p cppapi/master
-      cp -R ../doc/cpp-apidoc/html cppapi/master
-      git add -A cppapi/master
-      git commit -m "Update FreeOrion API documentation to match commit \`$(date --iso-8601).${TRAVIS_COMMIT:0:8}\`"
-      git push https://github.com/freeorion/freeorion.github.io.git master:master
-      popd
-    fi
-  - >
-    if [[ "${TRAVIS_OS_NAME}" == "linux" && "${BUILD_UNITTEST}" == "true" ]]; then
-      cmake -DBUILD_TESTING=ON ..
-      cmake --build . -- -j 2 &&
-      cmake --build . --target unittest &&
-      cd ../default &&
-      python -m compileall -q .
-    fi
-  - >
-    if [[ "${TRAVIS_OS_NAME}" == "osx" && -z "${BUILD_APIDOC}" ]]; then
-      cmake -GXcode ..
-      # timeout before Travis kills jobs so that ccache is always at least partially populated
-      gtimeout 40m cmake --build . --config Release -- -parallelizeTargets -jobs $(sysctl hw.ncpu | awk '{print $2}')
-    fi
+jobs:
+  include:
+    - stage: build
+      script:
+        - >
+          if [[ "${BUILD_APIDOC}" == "true" && "${TRAVIS_BRANCH}" == "master" ]]; then
+            cmake ..
+            cmake --build . --target cpp-apidoc
+
+            git clone --depth=1 --branch=master https://github.com/freeorion/freeorion.github.io.git apidoc-deploy.git
+            pushd apidoc-deploy.git
+            rm -rf cppapi/master
+            mkdir -p cppapi/master
+            cp -R ../doc/cpp-apidoc/html cppapi/master
+            git add -A cppapi/master
+            git commit -m "Update FreeOrion API documentation to match commit \`$(date --iso-8601).${TRAVIS_COMMIT:0:8}\`"
+            git push https://github.com/freeorion/freeorion.github.io.git master:master
+            popd
+          fi
+    - stage: build
+      script:
+        - >
+          if [[ "${TRAVIS_OS_NAME}" == "linux" && "${BUILD_UNITTEST}" == "true" ]]; then
+            cmake -DBUILD_TESTING=ON ..
+            cmake --build . -- -j 2 &&
+            cmake --build . --target unittest &&
+            cd ../default &&
+            python -m compileall -q .
+          fi
+    - stage: build
+      script:
+        - >
+          if [[ "${TRAVIS_OS_NAME}" == "osx" && -z "${BUILD_APIDOC}" ]]; then
+            cmake -GXcode ..
+            # timeout before Travis kills jobs so that ccache is always at least partially populated
+            gtimeout 40m cmake --build . --config Release -- -parallelizeTargets -jobs $(sysctl hw.ncpu | awk '{print $2}')
+          fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,3 @@
-stages:
-  - build
-
 language: cpp
 
 # ccache caches obj files between builds

--- a/.travis.yml
+++ b/.travis.yml
@@ -69,10 +69,9 @@ jobs:
       env:
         - NAME="Build FreeOrion"
       before_install:
-        # Setup ccache
         - mkdir -p $HOME/.ccache;
-        # Allow ccache to account for __FILE__ macro
         - echo sloppiness = file_macro > $HOME/.ccache/ccache.conf
+        - echo max_size = 200M >> $HOME/.ccache/ccache.conf
         - ccache --version
         - ccache --show-stats
         - docker pull freeorion/freeorion-travis-build
@@ -92,7 +91,7 @@ jobs:
         - cmake --build . -- -j 2
         - cmake --build . --target unittest
       before_cache:
-        # Check ccache
+        - ccache --clean
         - ccache --show-stats
     - stage: build
       os: osx
@@ -105,10 +104,9 @@ jobs:
       before_install:
         - brew install ccache
         - export PATH="/usr/local/opt/ccache/libexec:$PATH"
-        # Setup ccache
         - mkdir -p $HOME/.ccache;
-        # Allow ccache to account for __FILE__ macro
         - echo sloppiness = file_macro > $HOME/.ccache/ccache.conf
+        - echo max_size = 200M >> $HOME/.ccache/ccache.conf
         - ccache --version
         - ccache --show-stats
         # Add transparent cmake function to allow possible cross platform use of
@@ -131,7 +129,7 @@ jobs:
         - cmake -GXcode ..
         - cmake --build . --config Release -- -parallelizeTargets -jobs $(sysctl hw.ncpu | awk '{print $2}')
       before_cache:
-        # Check ccache
+        - ccache --clean
         - ccache --show-stats
     - stage: test
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ jobs:
         - NAME="Lint Python script"
     - stage: build
       os: linux
-      language: cpp
+      language: shell
       services:
         - docker
       env:
@@ -62,7 +62,7 @@ jobs:
           branch: master
     - stage: build
       os: linux
-      language: cpp
+      language: shell
       services:
         - docker
       cache: ccache

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,11 +25,9 @@ jobs:
         - echo -e "url=https://freeorion-bot:${FreeOrion_AUTH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git\n" | git credential approve
         # Add transparent cmake function to allow possible cross platform use of
         # build sections.
-        # mount ccache dir and set its environment variable
-        # timeout before Travis kills jobs so that ccache is always at least partially populated
         - >
           function cmake {
-              docker run -v "${TRAVIS_BUILD_DIR}:/freeorion"  -v "${HOME}/.ccache:/ccache_dir" -e CCACHE_DIR='/ccache_dir' -w /freeorion/build freeorion/freeorion-travis-build timeout 40m /usr/bin/cmake $@
+              docker run -v "${TRAVIS_BUILD_DIR}:/freeorion"  -w /freeorion/build freeorion/freeorion-travis-build timeout 40m /usr/bin/cmake $@
           }
         - mkdir build
         - cd build

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,6 @@ stages:
   - build
   - test
 
-# ccache caches obj files between builds
-cache: ccache
-
 jobs:
   include:
     - stage: build
@@ -79,6 +76,7 @@ jobs:
       language: cpp
       services:
         - docker
+      cache: ccache
       env:
         - NAME="Build FreeOrion"
       install:
@@ -112,6 +110,7 @@ jobs:
       language: cpp
       osx_image: xcode8.3
       compiler: clang
+      cache: ccache
       env:
         - NAME="Build FreeOrion"
       install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -62,7 +62,7 @@ jobs:
           branch: master
     - stage: build
       os: linux
-      language: shell
+      language: cpp
       services:
         - docker
       cache: ccache

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,19 @@ stages:
 
 jobs:
   include:
+    - stage: lint
+      os: linux
+      language: python
+      python: 2.7.14
+      before_install:
+        - pip install flake8-putty==0.4.0
+      before_script:
+        - cd default/python
+      script:
+        - flake8
+        - python -m compileall -q .
+      env:
+        - NAME="Lint Python script"
     - stage: build
       os: linux
       language: cpp
@@ -47,29 +60,6 @@ jobs:
         script: git push https://github.com/freeorion/freeorion.github.io.git master:master
         on:
           branch: master
-    - stage: test
-      os: linux
-      language: python
-      python: 2.7.14
-      before_install:
-        - pip install pytest==3.4.0
-      script:
-        - pytest
-      env:
-        - NAME="Pytest"
-    - stage: lint
-      os: linux
-      language: python
-      python: 2.7.14
-      before_install:
-        - pip install flake8-putty==0.4.0
-      before_script:
-        - cd default/python
-      script:
-        - flake8
-        - python -m compileall -q .
-      env:
-        - NAME="Lint Python script"
     - stage: build
       os: linux
       language: cpp
@@ -143,6 +133,16 @@ jobs:
       before_cache:
         # Check ccache
         - ccache --show-stats
+    - stage: test
+      os: linux
+      language: python
+      python: 2.7.14
+      before_install:
+        - pip install pytest==3.4.0
+      script:
+        - pytest
+      env:
+        - NAME="Pytest"
   allow_failures:
     - env:
       - NAME="Build C++ API documentation"

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,6 +34,7 @@ matrix:
       script:
         - cmake ..
         - cmake --build . --target cpp-apidoc
+      before_deploy:
         - git clone --depth=1 --branch=master https://github.com/freeorion/freeorion.github.io.git apidoc-deploy.git
         - pushd apidoc-deploy.git
         - rm -rf cppapi/master
@@ -41,8 +42,11 @@ matrix:
         - cp -R ../doc/cpp-apidoc/html cppapi/master
         - git add -A cppapi/master
         - git commit -m "Update FreeOrion API documentation to match commit \`$(date --iso-8601).${TRAVIS_COMMIT:0:8}\`"
-        - git push https://github.com/freeorion/freeorion.github.io.git master:master
-        - popd
+      deploy:
+        provider: script
+        script: git push https://github.com/freeorion/freeorion.github.io.git master:master
+        on:
+          branch: master
     - os: linux
       language: python
       python: 2.7.14

--- a/.travis.yml
+++ b/.travis.yml
@@ -117,12 +117,19 @@ matrix:
         - echo sloppiness = file_macro > $HOME/.ccache/ccache.conf
         - ccache --version
         - ccache --show-stats
+        # Add transparent cmake function to allow possible cross platform use of
+        # build sections.
+        # mount ccache dir and set its environment variable
+        # timeout before Travis kills jobs so that ccache is always at least partially populated
+        - >
+          function cmake {
+              /usr/local/bin/gtimeout 40m /usr/local/bin/cmake $@
+          }
         - mkdir build
         - cd build
       script:
         - cmake -GXcode ..
-        # timeout before Travis kills jobs so that ccache is always at least partially populated
-        - gtimeout 40m cmake --build . --config Release -- -parallelizeTargets -jobs $(sysctl hw.ncpu | awk '{print $2}')
+        - cmake --build . --config Release -- -parallelizeTargets -jobs $(sysctl hw.ncpu | awk '{print $2}')
       before_cache:
         # Check ccache
         - ccache --show-stats

--- a/.travis.yml
+++ b/.travis.yml
@@ -143,7 +143,3 @@ jobs:
         - pytest
       env:
         - NAME="Pytest"
-  allow_failures:
-    - env:
-      - NAME="Build C++ API documentation"
-      - secure: "JKeXk8p65hodb12PVRST6A90swsNubc+46EbSJGSghldIxbFWLBAlwU+KLeOMO4V0veu6k4lnMa50V0UYFZmoUsS6W0aL5Ybo98SpzXHiNLOmOluoqJoF9TBsOTCCRFbWbccgJyVEtulgRcdml96naS51lq9Sw/VO/N3Z472304="

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,12 +17,6 @@ jobs:
       install:
         - docker pull freeorion/freeorion-travis-build
       before_script:
-        # Configure git to use the identity of FreeOrion Build Bot and
-        # load credentials
-        - git config --global user.email "freeorionorg@gmail.com"
-        - git config --global user.name "FreeOrion Build Bot"
-        - git config --global credential.helper "cache --timeout=300"
-        - echo -e "url=https://freeorion-bot:${FreeOrion_AUTH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git\n" | git credential approve
         # Add transparent cmake function to allow possible cross platform use of
         # build sections.
         - >
@@ -35,6 +29,12 @@ jobs:
         - cmake ..
         - cmake --build . --target cpp-apidoc
       before_deploy:
+        # Configure git to use the identity of FreeOrion Build Bot and
+        # load credentials
+        - git config --global user.email "freeorionorg@gmail.com"
+        - git config --global user.name "FreeOrion Build Bot"
+        - git config --global credential.helper "cache --timeout=300"
+        - echo -e "url=https://freeorion-bot:${FreeOrion_AUTH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git\n" | git credential approve
         - git clone --depth=1 --branch=master https://github.com/freeorion/freeorion.github.io.git apidoc-deploy.git
         - pushd apidoc-deploy.git
         - rm -rf cppapi/master

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,8 @@ matrix:
         - BUILD_APIDOC=true
         # Auth token to push API documentation
         - secure: "JKeXk8p65hodb12PVRST6A90swsNubc+46EbSJGSghldIxbFWLBAlwU+KLeOMO4V0veu6k4lnMa50V0UYFZmoUsS6W0aL5Ybo98SpzXHiNLOmOluoqJoF9TBsOTCCRFbWbccgJyVEtulgRcdml96naS51lq9Sw/VO/N3Z472304="
+      install:
+        - docker pull freeorion/freeorion-travis-build
     - os: linux
       language: python
       python: 2.7.14
@@ -42,31 +44,22 @@ matrix:
         - docker
       env:
         - BUILD_UNITTEST=true
+      install:
+        - docker pull freeorion/freeorion-travis-build
     - os: osx
       osx_image: xcode8.3
       compiler: clang
+      install:
+        - wget --output-document=FreeOrionSDK.dmg https://github.com/freeorion/freeorion-sdk/releases/download/v8/FreeOrionSDK_8_Clang-MacOSX-10.9-x86_64.dmg
+        - hdiutil attach FreeOrionSDK.dmg
+        - tar -xjf /Volumes/FreeOrionSDK/dep.tar.bz2 -C Xcode
+        - hdiutil detach /Volumes/FreeOrionSDK
+        - brew install ccache
+        - export PATH="/usr/local/opt/ccache/libexec:$PATH"
   allow_failures:
     - env:
       - BUILD_APIDOC=true
       - secure: "JKeXk8p65hodb12PVRST6A90swsNubc+46EbSJGSghldIxbFWLBAlwU+KLeOMO4V0veu6k4lnMa50V0UYFZmoUsS6W0aL5Ybo98SpzXHiNLOmOluoqJoF9TBsOTCCRFbWbccgJyVEtulgRcdml96naS51lq9Sw/VO/N3Z472304="
-install:
-  - >
-    if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-      # Download build environment in a docker container
-      docker pull freeorion/freeorion-travis-build
-    fi
-  - >
-    if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
-      wget --output-document=FreeOrionSDK.dmg https://github.com/freeorion/freeorion-sdk/releases/download/v8/FreeOrionSDK_8_Clang-MacOSX-10.9-x86_64.dmg
-      hdiutil attach FreeOrionSDK.dmg
-      tar -xjf /Volumes/FreeOrionSDK/dep.tar.bz2 -C Xcode
-      hdiutil detach /Volumes/FreeOrionSDK
-
-      # download and setup ccache
-      brew install ccache
-      export PATH="/usr/local/opt/ccache/libexec:$PATH"
-
-    fi
 before_script:
   # Configure git to use the identity of FreeOrion Build Bot and
   # load credentials

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,15 +14,15 @@ jobs:
         - NAME="Build C++ API documentation"
         # Auth token to push API documentation
         - secure: "JKeXk8p65hodb12PVRST6A90swsNubc+46EbSJGSghldIxbFWLBAlwU+KLeOMO4V0veu6k4lnMa50V0UYFZmoUsS6W0aL5Ybo98SpzXHiNLOmOluoqJoF9TBsOTCCRFbWbccgJyVEtulgRcdml96naS51lq9Sw/VO/N3Z472304="
-      install:
+      before_install:
         - docker pull freeorion/freeorion-travis-build
-      before_script:
         # Add transparent cmake function to allow possible cross platform use of
         # build sections.
         - >
           function cmake {
               docker run -v "${TRAVIS_BUILD_DIR}:/freeorion"  -w /freeorion/build freeorion/freeorion-travis-build timeout 40m /usr/bin/cmake $@
           }
+      before_script:
         - mkdir build
         - cd build
       script:
@@ -51,7 +51,7 @@ jobs:
       os: linux
       language: python
       python: 2.7.14
-      install:
+      before_install:
         - pip install pytest==3.4.0
       script:
         - pytest
@@ -61,10 +61,11 @@ jobs:
       os: linux
       language: python
       python: 2.7.14
-      install:
+      before_install:
         - pip install flake8-putty==0.4.0
-      script:
+      before_script:
         - cd default/python
+      script:
         - flake8
         - python -m compileall -q .
       env:
@@ -77,15 +78,14 @@ jobs:
       cache: ccache
       env:
         - NAME="Build FreeOrion"
-      install:
-        - docker pull freeorion/freeorion-travis-build
-      before_script:
+      before_install:
         # Setup ccache
         - mkdir -p $HOME/.ccache;
         # Allow ccache to account for __FILE__ macro
         - echo sloppiness = file_macro > $HOME/.ccache/ccache.conf
         - ccache --version
         - ccache --show-stats
+        - docker pull freeorion/freeorion-travis-build
         # Add transparent cmake function to allow possible cross platform use of
         # build sections.
         # mount ccache dir and set its environment variable
@@ -94,6 +94,7 @@ jobs:
           function cmake {
               docker run -v "${TRAVIS_BUILD_DIR}:/freeorion"  -v "${HOME}/.ccache:/ccache_dir" -e CCACHE_DIR='/ccache_dir' -w /freeorion/build freeorion/freeorion-travis-build timeout 40m /usr/bin/cmake $@
           }
+      before_script:
         - mkdir build
         - cd build
       script:
@@ -111,14 +112,9 @@ jobs:
       cache: ccache
       env:
         - NAME="Build FreeOrion"
-      install:
-        - wget --output-document=FreeOrionSDK.dmg https://github.com/freeorion/freeorion-sdk/releases/download/v8/FreeOrionSDK_8_Clang-MacOSX-10.9-x86_64.dmg
-        - hdiutil attach FreeOrionSDK.dmg
-        - tar -xjf /Volumes/FreeOrionSDK/dep.tar.bz2 -C Xcode
-        - hdiutil detach /Volumes/FreeOrionSDK
+      before_install:
         - brew install ccache
         - export PATH="/usr/local/opt/ccache/libexec:$PATH"
-      before_script:
         # Setup ccache
         - mkdir -p $HOME/.ccache;
         # Allow ccache to account for __FILE__ macro
@@ -133,6 +129,12 @@ jobs:
           function cmake {
               /usr/local/bin/gtimeout 40m /usr/local/bin/cmake $@
           }
+      install:
+        - wget --output-document=FreeOrionSDK.dmg https://github.com/freeorion/freeorion-sdk/releases/download/v8/FreeOrionSDK_8_Clang-MacOSX-10.9-x86_64.dmg
+        - hdiutil attach FreeOrionSDK.dmg
+        - tar -xjf /Volumes/FreeOrionSDK/dep.tar.bz2 -C Xcode
+        - hdiutil detach /Volumes/FreeOrionSDK
+      before_script:
         - mkdir build
         - cd build
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,17 @@
+stages:
+  - lint
+  - build
+  - test
+
 language: cpp
 
 # ccache caches obj files between builds
 cache: ccache
 
-matrix:
+jobs:
   include:
-    - os: linux
+    - stage: build
+      os: linux
       services:
         - docker
       env:
@@ -47,7 +53,8 @@ matrix:
         script: git push https://github.com/freeorion/freeorion.github.io.git master:master
         on:
           branch: master
-    - os: linux
+    - stage: test
+      os: linux
       language: python
       python: 2.7.14
       install:
@@ -56,7 +63,8 @@ matrix:
         - pytest
       env:
         - NAME="Pytest"
-    - os: linux
+    - stage: lint
+      os: linux
       language: python
       python: 2.7.14
       install:
@@ -67,7 +75,8 @@ matrix:
         - python -m compileall -q .
       env:
         - NAME="Lint Python script"
-    - os: linux
+    - stage: build
+      os: linux
       services:
         - docker
       env:
@@ -98,7 +107,8 @@ matrix:
       before_cache:
         # Check ccache
         - ccache --show-stats
-    - os: osx
+    - stage: build
+      os: osx
       osx_image: xcode8.3
       compiler: clang
       env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,11 +12,40 @@ matrix:
       services:
         - docker
       env:
-        - BUILD_APIDOC=true
+        - NAME="Build C++ API documentation"
         # Auth token to push API documentation
         - secure: "JKeXk8p65hodb12PVRST6A90swsNubc+46EbSJGSghldIxbFWLBAlwU+KLeOMO4V0veu6k4lnMa50V0UYFZmoUsS6W0aL5Ybo98SpzXHiNLOmOluoqJoF9TBsOTCCRFbWbccgJyVEtulgRcdml96naS51lq9Sw/VO/N3Z472304="
       install:
         - docker pull freeorion/freeorion-travis-build
+      before_script:
+        # Configure git to use the identity of FreeOrion Build Bot and
+        # load credentials
+        - git config --global user.email "freeorionorg@gmail.com"
+        - git config --global user.name "FreeOrion Build Bot"
+        - git config --global credential.helper "cache --timeout=300"
+        - echo -e "url=https://freeorion-bot:${FreeOrion_AUTH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git\n" | git credential approve
+        # Add transparent cmake function to allow possible cross platform use of
+        # build sections.
+        # mount ccache dir and set its environment variable
+        # timeout before Travis kills jobs so that ccache is always at least partially populated
+        - >
+          function cmake {
+              docker run -v "${TRAVIS_BUILD_DIR}:/freeorion"  -v "${HOME}/.ccache:/ccache_dir" -e CCACHE_DIR='/ccache_dir' -w /freeorion/build freeorion/freeorion-travis-build timeout 40m /usr/bin/cmake $@
+          }
+        - mkdir build
+        - cd build
+      script:
+        - cmake ..
+        - cmake --build . --target cpp-apidoc
+        - git clone --depth=1 --branch=master https://github.com/freeorion/freeorion.github.io.git apidoc-deploy.git
+        - pushd apidoc-deploy.git
+        - rm -rf cppapi/master
+        - mkdir -p cppapi/master
+        - cp -R ../doc/cpp-apidoc/html cppapi/master
+        - git add -A cppapi/master
+        - git commit -m "Update FreeOrion API documentation to match commit \`$(date --iso-8601).${TRAVIS_COMMIT:0:8}\`"
+        - git push https://github.com/freeorion/freeorion.github.io.git master:master
+        - popd
     - os: linux
       language: python
       python: 2.7.14
@@ -24,28 +53,50 @@ matrix:
         - pip install pytest==3.4.0
       script:
         - pytest
-      before_script: echo ""
-      before_cache: echo ""
-      env: NAME="Pytest"
+      env:
+        - NAME="Pytest"
     - os: linux
       language: python
       python: 2.7.14
       install:
         - pip install flake8-putty==0.4.0
       script:
-        - |
-          cd default/python
-          flake8
-      before_script: echo "Code style check https://github.com/freeorion/freeorion/tree/master/default/python#code-style-check"
-      before_cache: echo ""
-      env: NAME="Python linter"
+        - cd default/python
+        - flake8
+        - python -m compileall -q .
+      env:
+        - NAME="Lint Python script"
     - os: linux
       services:
         - docker
       env:
-        - BUILD_UNITTEST=true
+        - NAME="Build FreeOrion"
       install:
         - docker pull freeorion/freeorion-travis-build
+      before_script:
+        # Setup ccache
+        - mkdir -p $HOME/.ccache;
+        # Allow ccache to account for __FILE__ macro
+        - echo sloppiness = file_macro > $HOME/.ccache/ccache.conf
+        - ccache --version
+        - ccache --show-stats
+        # Add transparent cmake function to allow possible cross platform use of
+        # build sections.
+        # mount ccache dir and set its environment variable
+        # timeout before Travis kills jobs so that ccache is always at least partially populated
+        - >
+          function cmake {
+              docker run -v "${TRAVIS_BUILD_DIR}:/freeorion"  -v "${HOME}/.ccache:/ccache_dir" -e CCACHE_DIR='/ccache_dir' -w /freeorion/build freeorion/freeorion-travis-build timeout 40m /usr/bin/cmake $@
+          }
+        - mkdir build
+        - cd build
+      script:
+        - cmake -DBUILD_TESTING=ON ..
+        - cmake --build . -- -j 2
+        - cmake --build . --target unittest
+      before_cache:
+        # Check ccache
+        - ccache --show-stats
     - os: osx
       osx_image: xcode8.3
       compiler: clang
@@ -56,76 +107,23 @@ matrix:
         - hdiutil detach /Volumes/FreeOrionSDK
         - brew install ccache
         - export PATH="/usr/local/opt/ccache/libexec:$PATH"
+      before_script:
+        # Setup ccache
+        - mkdir -p $HOME/.ccache;
+        # Allow ccache to account for __FILE__ macro
+        - echo sloppiness = file_macro > $HOME/.ccache/ccache.conf
+        - ccache --version
+        - ccache --show-stats
+        - mkdir build
+        - cd build
+      script:
+        - cmake -GXcode ..
+        # timeout before Travis kills jobs so that ccache is always at least partially populated
+        - gtimeout 40m cmake --build . --config Release -- -parallelizeTargets -jobs $(sysctl hw.ncpu | awk '{print $2}')
+      before_cache:
+        # Check ccache
+        - ccache --show-stats
   allow_failures:
     - env:
-      - BUILD_APIDOC=true
+      - NAME="Build C++ API documentation"
       - secure: "JKeXk8p65hodb12PVRST6A90swsNubc+46EbSJGSghldIxbFWLBAlwU+KLeOMO4V0veu6k4lnMa50V0UYFZmoUsS6W0aL5Ybo98SpzXHiNLOmOluoqJoF9TBsOTCCRFbWbccgJyVEtulgRcdml96naS51lq9Sw/VO/N3Z472304="
-before_script:
-  # Configure git to use the identity of FreeOrion Build Bot and
-  # load credentials
-  - >
-    if [[ "${BUILD_APIDOC}" == "true" ]]; then
-      git config --global user.email "freeorionorg@gmail.com"
-      git config --global user.name "FreeOrion Build Bot"
-      git config --global credential.helper "cache --timeout=300"
-      echo -e "url=https://freeorion-bot:${FreeOrion_AUTH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}.git\n" | git credential approve
-    fi
-  # Setup ccache
-  - mkdir -p $HOME/.ccache;
-  # Allow ccache to account for __FILE__ macro
-  - echo sloppiness = file_macro > $HOME/.ccache/ccache.conf
-  - ccache --version
-  - ccache --show-stats
-  - >
-    if [[ "${TRAVIS_OS_NAME}" == "linux" ]]; then
-      # Add transparent cmake function to allow possible cross platform use of
-      # build sections.
-      # mount ccache dir and set its environment variable
-      # timeout before Travis kills jobs so that ccache is always at least partially populated
-      function cmake {
-          docker run -v "${TRAVIS_BUILD_DIR}:/freeorion"  -v "${HOME}/.ccache:/ccache_dir" -e CCACHE_DIR='/ccache_dir' -w /freeorion/build freeorion/freeorion-travis-build timeout 40m /usr/bin/cmake $@
-      }
-    fi
-  - mkdir build
-  - cd build
-before_cache:
-  # Check ccache
-  - ccache --show-stats
-
-jobs:
-  include:
-    - stage: build
-      script:
-        - >
-          if [[ "${BUILD_APIDOC}" == "true" && "${TRAVIS_BRANCH}" == "master" ]]; then
-            cmake ..
-            cmake --build . --target cpp-apidoc
-
-            git clone --depth=1 --branch=master https://github.com/freeorion/freeorion.github.io.git apidoc-deploy.git
-            pushd apidoc-deploy.git
-            rm -rf cppapi/master
-            mkdir -p cppapi/master
-            cp -R ../doc/cpp-apidoc/html cppapi/master
-            git add -A cppapi/master
-            git commit -m "Update FreeOrion API documentation to match commit \`$(date --iso-8601).${TRAVIS_COMMIT:0:8}\`"
-            git push https://github.com/freeorion/freeorion.github.io.git master:master
-            popd
-          fi
-    - stage: build
-      script:
-        - >
-          if [[ "${TRAVIS_OS_NAME}" == "linux" && "${BUILD_UNITTEST}" == "true" ]]; then
-            cmake -DBUILD_TESTING=ON ..
-            cmake --build . -- -j 2 &&
-            cmake --build . --target unittest &&
-            cd ../default &&
-            python -m compileall -q .
-          fi
-    - stage: build
-      script:
-        - >
-          if [[ "${TRAVIS_OS_NAME}" == "osx" && -z "${BUILD_APIDOC}" ]]; then
-            cmake -GXcode ..
-            # timeout before Travis kills jobs so that ccache is always at least partially populated
-            gtimeout 40m cmake --build . --config Release -- -parallelizeTargets -jobs $(sysctl hw.ncpu | awk '{print $2}')
-          fi


### PR DESCRIPTION
This PR prepares the TravisCI configuration for the GitHub PR checks feature by adding build stages.

* Use TravisCI build stages instead of the build matrix.
* Introduce lint, build and test stages, which depend on each other.  E.g. when a lint job fails the build and test stages are not started.
  * lint build jobs should do a quick check if the sources are *sane* (valid syntax, proper formatting, ...).
  * build jobs should create the project artifacts (compile the project, generate documentation).
  * test jobs should execute tests on the generated artifacts to ensure their functionality.
* Move build steps into their corresponding section:
  * before_install: Prepare build environment
  * install: Install project dependencies
  * before_script: Setup build (create build directory, cd into it)
  * script: do actual action required for the build job
  * before_deploy: Prepare deployment of build job artifacts
  * deploy: Do deploy build artifacts
  * before_cache: Clean cache from very stale entries.
* Remove shared build steps in favor of individual build jobs steps. The previous implementation was harder to read and the different build jobs are too different to properly share their configuration.