### PR TITLE
Productionqueue quantityselector fix

### DIFF
--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -115,7 +115,6 @@ namespace {
             blocksize(build.blocksize),
             prevBlocksize(build.blocksize),
             amBlockType(amBlockType_),
-            amOn(false),
             h(h_)
         {
             MoveTo(GG::Pt(xoffset, yoffset));
@@ -155,8 +154,6 @@ namespace {
         }
 
         void SelectionChanged(GG::DropDownList::iterator it) {
-            amOn = false;
-
             DebugLogger() << "QuantSelector:  selection made ";
             if (it != end()) {
                 int quant = boost::polymorphic_downcast<const QuantRow*>(it->get())->Quant();
@@ -177,16 +174,9 @@ namespace {
         int     blocksize;
         int     prevBlocksize;
         bool    amBlockType;
-        bool    amOn;
         GG::Y   h;
 
-        void LosingFocus() override {
-            amOn = false;
-            DropDownList::LosingFocus();
-        }
-
         void LButtonDown(const GG::Pt&  pt, GG::Flags<GG::ModKey> mod_keys) override {
-            amOn = !amOn;
             if (this->Disabled())
                 return;
 

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -187,14 +187,10 @@ namespace {
 
         void LButtonDown(const GG::Pt&  pt, GG::Flags<GG::ModKey> mod_keys) override {
             amOn = !amOn;
-            DropDownList::LButtonDown(pt, mod_keys);
-        }
-
-        void LClick(const GG::Pt& pt, GG::Flags<GG::ModKey> mod_keys) override {
             if (this->Disabled())
                 return;
 
-            DropDownList::LClick(pt, mod_keys);
+            DropDownList::LButtonDown(pt, mod_keys);
             if ( (quantity != prevQuant) || (blocksize != prevBlocksize) )
                 QuantChangedSignal(quantity, blocksize);
         }


### PR DESCRIPTION
As noted in #2097, some recent changes to DropDownList broke the ProductionQueue QuantitySelector used for blocksize & repeat.

Although the QuantitySelectors had been overriding both DropDownList::LClick and DropDownList::LButtonDown; it seems to me that the former QuantitySelector::LButtonDown code can just be jettisoned and essentially replaced with the former LClick code. Most/all of the small bit of jettisoned code seems to be a useless remnant from some older code anyways, but it's been long enough since I've done anything with that that I thought I should put it up as a PR for some review/testing rather than just commit it directly.

Resolves #2097 