### PR TITLE
Introduce part-based upkeep enabled via game rule.

### DIFF
--- a/default/scripting/common/upkeep.macros
+++ b/default/scripting/common/upkeep.macros
@@ -2,7 +2,13 @@ COLONY_UPKEEP_MULTIPLICATOR
 '''(1 + 0.06 * SpeciesColoniesOwned empire = Source.Owner)'''
 
 FLEET_UPKEEP_MULTIPLICATOR
-'''(1 + 0.01 * ShipDesignsOwned empire = Source.Owner)'''
+'''(1 +
+    (1 - (GameRule name = "RULE_SHIP_PART_BASED_UPKEEP")) * 0.01 * ShipDesignsOwned empire = Source.Owner +
+    (GameRule name = "RULE_SHIP_PART_BASED_UPKEEP") * ((0.002 * ShipPartsOwned empire =
+        Source.Owner class = ShortRange) + (0.002 * ShipPartsOwned empire = Source.Owner class =
+        FighterHangar) + (0.002 * ShipPartsOwned empire = Source.Owner class = Armour) + (0.002 *
+        ShipPartsOwned empire = Source.Owner class = Troops) + (0.002 * ShipDesignsOwned empire =
+        Source.Owner)))'''
 
 SHIP_HULL_COST_MULTIPLIER
 '''(GameRule name = "RULE_SHIP_HULL_COST_FACTOR")'''

--- a/default/scripting/game_rules.focs.txt
+++ b/default/scripting/game_rules.focs.txt
@@ -151,3 +151,10 @@ GameRule
     default = 1
     min = 0
     max = 9999
+
+GameRule
+    name = "RULE_SHIP_PART_BASED_UPKEEP"
+    description = "RULE_SHIP_PART_BASED_UPKEEP_DESC"
+    category = "BALANCE"
+    type = Toggle
+    default = Off

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1190,6 +1190,11 @@ Only allied players win
 RULE_ONLY_ALLIANCE_WIN_DESC
 Allied players could win together if the number of human players in their alliance is no large than the maximum human player winners and there are no other human player survivors.
 
+RULE_SHIP_PART_BASED_UPKEEP
+Use part-based upkeep
+
+RULE_SHIP_PART_BASED_UPKEEP_DESC
+Calculate upkeep based on ship parts instead of ships themselves.
 
 ##
 ## Command-line and options database entries


### PR DESCRIPTION
This PR adds game rule `RULE_SHIP_PART_BASED_UPKEEP` which switch from ship-based upkeep to part-based upkeep.

Implementation taken from @Voker57 fork: https://github.com/Voker57/freeorion/commit/601a2f8b79d79e49334a681409d9bcac9fa2bb1a (upd: looks like parameters are from here https://github.com/freeorion/freeorion/pull/1209)

Related topics: http://freeorion.org/forum/viewtopic.php?f=25&t=10945
http://freeorion.org/forum/viewtopic.php?p=88527#p88527