### PR TITLE
Do not let AI issue new orders after loading a game

### DIFF
--- a/default/python/AI/AIstate.py
+++ b/default/python/AI/AIstate.py
@@ -70,6 +70,9 @@ def convert_to_version(state, version):
         del state['qualifyingColonyBaseTargets']
         state['orbital_colonization_manager'] = ColonisationAI.OrbitalColonizationManager()
 
+    if version == 5:
+        state['last_turn_played'] = 0
+
     #   state["some_new_member"] = some_default_value
     #   del state["some_removed_member"]
     #   state["list_changed_to_set"] = set(state["list_changed_to_set"])
@@ -97,7 +100,7 @@ class AIstate(object):
     via boost. If desiring to store a reference to a UniverseObject store its
     object id instead; for enum values store their int conversion value.
     """
-    version = 4
+    version = 5
 
     def __init__(self, aggression):
         # Do not allow to create AIstate instances with an invalid version number.
@@ -163,6 +166,7 @@ class AIstate(object):
         self.__empire_standard_enemy = CombatRatingsAI.default_ship_stats().get_stats(hashable=True)
         self.empire_standard_enemy_rating = 0  # TODO: track on a per-empire basis
         self.character = create_character(aggression, self.empireID)
+        self.last_turn_played = 0
 
     def __setstate__(self, state):
         try:

--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -13,7 +13,7 @@ import random
 import freeOrionAIInterface as fo  # interface used to interact with FreeOrion AI client  # pylint: disable=import-error
 
 
-from common.option_tools import parse_config, get_option_dict
+from common.option_tools import parse_config, get_option_dict, check_bool
 parse_config(fo.getOptionsDBOptionStr("ai-config"), fo.getUserConfigDir())
 
 from freeorion_tools import patch_interface
@@ -313,8 +313,8 @@ def generateOrders():  # pylint: disable=invalid-name
     # TODO: Consider adding an option to clear AI orders after load (must save AIstate at turn start then)
     if fo.currentTurn() == foAIstate.last_turn_played:
         info("The AIstate indicates that this turn was already played.")
-        if not get_option_dict().get('replay_turn_after_load', False):
-            info("Aborting order generation. Orders from savegame will still be issued.")
+        if not check_bool(get_option_dict().get('replay_turn_after_load', 'False')):
+            info("Aborting new order generation. Orders from savegame will still be issued.")
             try:
                 fo.doneTurn()
             except Exception as e:

--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -232,7 +232,6 @@ def generateOrders():  # pylint: disable=invalid-name
     """Called once per turn to tell the Python AI to generate and issue orders to control its empire.
     at end of this function, fo.doneTurn() should be called to indicate to the client that orders are finished
     and can be sent to the server for processing."""
-
     rules = fo.getGameRules()
     print "Defined game rules:"
     for rule in rules.getRulesAsStrings:
@@ -305,6 +304,25 @@ def generateOrders():  # pylint: disable=invalid-name
     print "***************************************************************************"
     print "***************************************************************************"
 
+    # When loading a savegame, the AI will already have issued orders for this turn.
+    # To avoid duplicate orders, generally try not to replay turns. However, for debugging
+    # purposes it is often useful to replay the turn and observe varying results after
+    # code changes. Set the replay_after_load flag in the AI config to let the AI issue
+    # new orders after a game load. Note that the orders from the original savegame are
+    # still being issued and the AIstate was saved after those orders were issued.
+    # TODO: Consider adding an option to clear AI orders after load (must save AIstate at turn start then)
+    if fo.currentTurn() == foAIstate.last_turn_played:
+        info("The AIstate indicates that this turn was already played.")
+        if not get_option_dict().get('replay_turn_after_load', False):
+            info("Aborting order generation. Orders from savegame will still be issued.")
+            try:
+                fo.doneTurn()
+            except Exception as e:
+                error("Exception %s while trying doneTurn()" % e, exc_info=True)
+            return
+        else:
+            info("Issuing new orders anyway.")
+
     if turn == 1:
         declare_war_on_all()
         human_player = fo.empirePlayerID(1)
@@ -345,6 +363,8 @@ def generateOrders():  # pylint: disable=invalid-name
         fo.doneTurn()
     except Exception as e:
         error("Exception %s while trying doneTurn()" % e, exc_info=True)  # TODO move it to cycle above
+    finally:
+        foAIstate.last_turn_played = fo.currentTurn()
 
     if using_statprof:
         try:

--- a/default/python/AI/ai_debug_config.ini
+++ b/default/python/AI/ai_debug_config.ini
@@ -1,2 +1,3 @@
 [main]
 allow_debug_chat=1
+replay_turn_after_load=1


### PR DESCRIPTION
This PR suggests one way to resolve #1837.

By storing the last played turn in the AIstate, we can detect if we already issued orders for a given turn (i.e. after loading the game). By default, the AI will not try to issue orders a second time in that case but use the orders in the savegame instead.

As discussed in #1837, for debugging work it is often useful to be able to load a savegame and replay the turn to check the effect of code changes. For this purpose, the flag ```replay_turn_after_load``` can be set in the AI config file.