### PR TITLE
Download MacOSX FreeOrionSDK during build environment setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,8 +61,6 @@ DerivedData
 /doc/apidoc-commit-message
 
 # FreeOrion Xcode project
-/Xcode/dep/
-/Xcode/build/
 /Xcode/Info.plist
 contents.xcworkspacedata
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -118,11 +118,6 @@ jobs:
           function cmake {
               /usr/local/bin/gtimeout 40m /usr/local/bin/cmake $@
           }
-      install:
-        - wget --output-document=FreeOrionSDK.dmg https://github.com/freeorion/freeorion-sdk/releases/download/v8/FreeOrionSDK_8_Clang-MacOSX-10.9-x86_64.dmg
-        - hdiutil attach FreeOrionSDK.dmg
-        - tar -xjf /Volumes/FreeOrionSDK/dep.tar.bz2 -C Xcode
-        - hdiutil detach /Volumes/FreeOrionSDK
       before_script:
         - mkdir build
         - cd build

--- a/BUILD.md
+++ b/BUILD.md
@@ -57,8 +57,11 @@ manager or compiling from source).
 
 Step by step procedure:
 
- * On Windows or Mac OS X:
+ * On Windows:
    * Download the [FreeOrionSDK v8] from the FreeOrionSDK respository releases.
+ * On Mac OS X:
+   * The [FreeOrionSDK v8] is downloaded automatically when CMake creates the
+     build environment.
  * Linux and other Operating Systems:
    * Install build and runtime dependencies by the preferred way for the
      respective OS.
@@ -67,13 +70,7 @@ Step by step procedure:
    * Unzip the SDK archive contents into the project directory.
    * Execute the `bootstrap.bat` within the project directory. This will clone
      the FreeOrion repository and place the dependencies at the correct place.
- * On Mac OS X:
-   * Mount the SDK DMG image.
-   * Copy the contents of the mounted image into the project directory.
-   * Execute the `bootstrap.command` within the project directory. This will
-     clone the FreeOrion repository and place the dependencies at the correct
-     place.
- * On Linux and other Operating Systems:
+ * On Max OS X, Linux and other Operating Systems:
    * Navigate into the project directory.
    * Clone the project via Git:
      ```
@@ -84,8 +81,8 @@ This will leave you with the latest development branch `master` and the
 FreeOrion source code in:
 
  * `freeorion-project/FreeOrion/` on Windows.
- * `freeorion-project/` on Mac OS X.
- * `freeorion-project/freeorion/` on Linux and other Operating Systems.
+ * `freeorion-project/freeorion/` on Mac OS X, Linux and other Operating
+   Systems.
 
 This directory will be referred to as _source directory_ in the rest of the
 document.
@@ -123,7 +120,7 @@ Step by step procedure:
      ```
      cmake -GXcode ..
      ```
-   * Open `FreeOrion.xcodeproj` with Visual Studio
+   * Open `FreeOrion.xcodeproj` with Xcode.
    * Compile the whole project by selecting the `ALL_BUILD` scheme and
      pressing 'Command' + 'B'.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,9 +75,29 @@ if(WIN32)
 endif()
 
 if(APPLE)
+    set(FreeOrionSDK_VERSION 8)
+    set(FreeOrionSDK_FILE "FreeOrionSDK_${FreeOrionSDK_VERSION}_Clang-MacOSX-10.9-x86_64.dmg")
+    if(NOT EXISTS "${CMAKE_BINARY_DIR}/${FreeOrionSDK_FILE}")
+	file(DOWNLOAD
+            "https://github.com/freeorion/freeorion-sdk/releases/download/v${FreeOrionSDK_VERSION}/${FreeOrionSDK_FILE}"
+            "${CMAKE_BINARY_DIR}/${FreeOrionSDK_FILE}"
+            SHOW_PROGRESS
+        )
+    endif()
+    set(FreeOrionSDK_INSTALL_VERSION 0)
+    if(EXISTS "${CMAKE_BINARY_DIR}/dep/sdkversion")
+        file(READ "${CMAKE_BINARY_DIR}/dep/sdkversion" FreeOrionSDK_INSTALL_VERSION)
+    endif()
+    if(NOT "${FreeOrionSDK_VERSION}" EQUAL "${FreeOrionSDK_INSTALL_VERSION}")
+        file(REMOVE_RECURSE "${CMAKE_BINARY_DIR}/dep")
+        execute_process(COMMAND /usr/bin/hdiutil attach "${CMAKE_BINARY_DIR}/${FreeOrionSDK_FILE}")
+        execute_process(COMMAND ${CMAKE_COMMAND} -E tar xfj /Volumes/FreeOrionSDK/dep.tar.bz2 WORKING_DIRECTORY "${CMAKE_BINARY_DIR}")
+        execute_process(COMMAND /usr/bin/hdiutil detach "/Volumes/FreeOrionSDK")
+        file(WRITE "${CMAKE_BINARY_DIR}/dep/sdkversion" "${FreeOrionSDK_VERSION}")
+    endif()
     # Location of the FreeOrionSDK root
-    set(CMAKE_PREFIX_PATH "${CMAKE_SOURCE_DIR}/Xcode/dep/")
-    set(CMAKE_FRAMEWORK_PATH "${CMAKE_SOURCE_DIR}/Xcode/dep/Frameworks")
+    set(CMAKE_PREFIX_PATH "${CMAKE_BINARY_DIR}/dep/")
+    set(CMAKE_FRAMEWORK_PATH "${CMAKE_BINARY_DIR}/dep/Frameworks")
     set(CMAKE_PROGRAM_PATH "${CMAKE_FRAMEWORK_PATH}/Python.framework/Versions/Current/bin")
 endif()
 


### PR DESCRIPTION
Download and unpack the FreeOrionSDK on MacOSX when creating a build
environment via CMake.  The FreeOrionSDK is downloaded only when the
archive does not exist and unpacked only when the unpacked version
doesn't match the configured version in the CMakeLists.txt