### PR TITLE
Streamline release procedure slightly to remove duplicative step

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -45,16 +45,15 @@ doing the actual release.
 * [ ] Create a new GitHub Issue from `.github/RELEASE_TEMPLATE.md` and follow
       instructions. :wink:
 * [ ] Determine initial milestones and dates for release.
+* [ ] *On master branch HEAD* - Update version number in `CMakeLists.txt` and
+      `cmake/make_versioncpp.py` to `vX.Y.Z+`.
+* [ ] Push updated master branch to GitHub.
 * [ ] Create release branch from development branch master by using:
 ```
 git checkout -b release-vX.Y.Z master
 ```
-* [ ] *On release branch HEAD* - Update version number in `CMakeLists.txt` and
-      `cmake/make_versioncpp.py` to `vX.Y.Z`, remove trailing `+` if needed.
 * [ ] *On release branch HEAD* - Remove `Super Testers` species.
-* [ ] *On master branch HEAD* - Update version number in `CMakeLists.txt` and
-      `cmake/make_versioncpp.py` to `vX.Y.Z+`.
-* [ ] Push updated release and master branch to GitHub.
+* [ ] Push release branch to GitHub.
 * [ ] Update `ChangeLog.md`.
 
 


### PR DESCRIPTION
When reviewing our new release issue #2111, It appeared to me that since we do the 'create release branch' step before the 'Update version number' step, we need to duplicate the 'Update version number' step, which we wouldn't need to do if we just reorganized the steps slightly.

I think this also reduces the risk of someone else pushing changes to master while the person creating the release branch is in the middle of steps that would be thrown off by other commits to master.

It's a minor thing, but this seems a minor improvement to me which I couldn't resist proposing...