### PR TITLE
Fix stockpile transfer description

### DIFF
--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -339,14 +339,14 @@ PROJECT_BT_STOCKPILE_SHORT_DESC
 Transfers PP into the imperial stockpile
 
 PROJECT_BT_STOCKPILE_DESC
-'''Transfers PP at the planet where this project is enqueued to the imperial stockpile. The amount to transfer and how often the transfer should occur can be specified. PP spent on the transfer are added to the imperial stockpile.
+'''Transfers PP at the planet where this project is enqueued to the imperial stockpile. The amount to transfer and how many times the transfer should repeat can be specified. PP allocated to the transfer are added to the imperial stockpile.
 
-Only uses PP that are produced in the same supply-group. No PP from the imperial stockpile are used.
+Only PP that are produced in the same supply-group are allocated to the stockpile transfer project. PP already in the imperial stockpile are not allocated to the stockpile transfer project.
 
-Surplus PP (PP not allocated to anything on the queue) at this or any other location will be transferred to the stockpile with or without a stockpile transfer project on the queue. PP used for stockpile transfer are not available for items on the build queue below it.
+Surplus PP (PP not allocated to anything on the queue) at this or any other location will be transferred to the stockpile with or without a stockpile transfer project on the queue. PP allocated to stockpile transfer are transferred to the stockpile, and not allocated to items lower in the production queue.
 
-For example: An empire wants to draw PP from the stockpile in a secondary supply-group. For this the stockpile needs to be filled from the primary supply-group. The empire has 100 PP industry in the primary supply-group and its stockpile use limit is 10 PP. To make sure that 10 PP are always available in the stockpile, one adds to the top of build queue a 10x Stockpile Transfer project on a planet in the primary supply-group.
-The Stockpile Transfer project is above other primary supply-group projects in the build queue. So it is fully funded and will increase the stockpile by 10 PP next turn. In order for a lasting effect one sets the repetition to 99 times.'''
+For example: An empire wants to draw PP from the stockpile in a secondary supply-group. For this the stockpile needs to be filled from the primary supply-group. The empire has 100 PP industry in the primary supply-group, its stockpile use limit is 10 PP and wants that 10 PP are always available in the stockpile. For this, the empire adds to the top of the queue a 10x Stockpile Transfer project on a planet in the primary supply-group.
+Because the Stockpile Transfer project is above other primary supply-group projects in the build queue, it is fully funded and will increase the stockpile by 10 PP next turn. To ensure a continuing transfer each turn, the repetition of the project is set to 99 times.'''
 
 
 ##

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -343,11 +343,11 @@ PROJECT_BT_STOCKPILE_DESC
 
 Only PP that are produced in the same supply-group (and none from the imperial stockpile) are allocated to the stockpile transfer project.
 
-Surplus PP (PP not allocated to anything on the queue) at this or any other location will be transferred to the stockpile with or without a stockpile transfer project on the queue. PP allocated to a stockpile transfer are not allocated to items lower in the production queue.
+Surplus PP (PP not allocated to anything on the queue) at this or any other location will be transferred to the stockpile with or without a stockpile transfer project on the queue. PP allocated to a stockpile transfer are sent to the stockpile, even if there are additional items later in the production queue.
 
-For example: An empire wants to draw PP from the stockpile in a secondary supply-group, in which there is insufficient PP being generated. To do this the stockpile needs to be filled from the primary supply-group. The empire has 100 PP industry in the primary supply-group, its stockpile use limit is 10 PP and wants that 10 PP are always available in the stockpile. The build queue contains items on planets in the primary supply-group which need 120 PP per turn, so all available PP would be used.
+For example: An empire wants to draw PP from the stockpile in a secondary supply-group, in which there is insufficient PP being generated. To do this, the stockpile needs to be filled from the primary supply-group. The empire has 100 PP industry in the primary supply-group, its stockpile use limit is 10 PP and it wants to have 10 PP always available in the stockpile. The build queue contains items on planets in the primary supply-group which need 120 PP per turn, so all available PP would be used.
 To be able to use the PP in the secondary supply-group, the empire adds to the top of the queue a 10x Stockpile Transfer project on a planet in the primary supply-group.
-Because the Stockpile Transfer project is above other primary supply-group projects in the build queue, it is fully funded and will increase the stockpile by 10 PP next turn. To ensure a continuing transfer each turn, the repetition of the project is set to 99 times.'''
+Because the Stockpile Transfer project is above other primary supply-group projects in the build queue, it is fully funded and will increase the stockpile by 10 PP on the next turn. To ensure a continuing transfer each turn, the repetition of the project is set to 99 times.'''
 
 
 ##

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -339,13 +339,14 @@ PROJECT_BT_STOCKPILE_SHORT_DESC
 Transfers PP into the imperial stockpile
 
 PROJECT_BT_STOCKPILE_DESC
-'''Transfers PP at the planet where this project is enqueued to the imperial stockpile. The amount to transfer and how many times the transfer should repeat can be specified. PP allocated to the transfer are added to the imperial stockpile.
+'''PP allocated to the transfer project are added to the imperial stockpile. The amount to transfer and how many times the transfer should repeat can be specified.
 
-Only PP that are produced in the same supply-group are allocated to the stockpile transfer project. PP already in the imperial stockpile are not allocated to the stockpile transfer project.
+Only PP that are produced in the same supply-group (and none from the imperial stockpile) are allocated to the stockpile transfer project.
 
-Surplus PP (PP not allocated to anything on the queue) at this or any other location will be transferred to the stockpile with or without a stockpile transfer project on the queue. PP allocated to stockpile transfer are transferred to the stockpile, and not allocated to items lower in the production queue.
+Surplus PP (PP not allocated to anything on the queue) at this or any other location will be transferred to the stockpile with or without a stockpile transfer project on the queue. PP allocated to a stockpile transfer are not allocated to items lower in the production queue.
 
-For example: An empire wants to draw PP from the stockpile in a secondary supply-group. For this the stockpile needs to be filled from the primary supply-group. The empire has 100 PP industry in the primary supply-group, its stockpile use limit is 10 PP and wants that 10 PP are always available in the stockpile. For this, the empire adds to the top of the queue a 10x Stockpile Transfer project on a planet in the primary supply-group.
+For example: An empire wants to draw PP from the stockpile in a secondary supply-group, in which there is insufficient PP being generated. To do this the stockpile needs to be filled from the primary supply-group. The empire has 100 PP industry in the primary supply-group, its stockpile use limit is 10 PP and wants that 10 PP are always available in the stockpile. The build queue contains items on planets in the primary supply-group which need 120 PP per turn, so all available PP would be used.
+To be able to use the PP in the secondary supply-group, the empire adds to the top of the queue a 10x Stockpile Transfer project on a planet in the primary supply-group.
 Because the Stockpile Transfer project is above other primary supply-group projects in the build queue, it is fully funded and will increase the stockpile by 10 PP next turn. To ensure a continuing transfer each turn, the repetition of the project is set to 99 times.'''
 
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -339,14 +339,14 @@ PROJECT_BT_STOCKPILE_SHORT_DESC
 Transfers PP into the imperial stockpile
 
 PROJECT_BT_STOCKPILE_DESC
-'''Transfers PP at the planet where this project is enqueued to the imperial stockpile. One can specify the amount and repetition of the transfer. PP spent on the transfer are added to the imperial stockpile.
+'''Transfers PP at the planet where this project is enqueued to the imperial stockpile. The amount to transfer and how often the transfer should occur can be specified. PP spent on the transfer are added to the imperial stockpile.
 
 Only uses PP that are produced in the same supply-group. No PP from the imperial stockpile are used.
 
-Surplus PP (PP not allocated to anything on the queue) at this or any other location will be transferred to the stockpile with or without a stockpile transfer project on the queue.  This project is used for controlling PP allocation to the stockpile. PP used for stockpile transfer are not available for items on the build queue below it.
+Surplus PP (PP not allocated to anything on the queue) at this or any other location will be transferred to the stockpile with or without a stockpile transfer project on the queue. PP used for stockpile transfer are not available for items on the build queue below it.
 
-An example: One wants to draw PP from the stockpile in a secondary supply-group. For this the stockpile needs to be filled from the primary supply-group. Lets say one has 100PP industry in the primary supply-group and is able to draw 10PP from the stockpile. For making sure that 10PP are always available in the stockpile one adds to the top of build queue a 10x Stockpile Transfer project on a planet in the primary supply-group.
-The Stockpile Transfer project is above other primary supply-group projects in the build queue. So it is fully funded and will increase the stockpile by 10PP next turn. In order for a lasting effect one sets the repetition to 99 times.'''
+For example: An empire wants to draw PP from the stockpile in a secondary supply-group. For this the stockpile needs to be filled from the primary supply-group. The empire has 100 PP industry in the primary supply-group and its stockpile use limit is 10 PP. To make sure that 10 PP are always available in the stockpile, one adds to the top of build queue a 10x Stockpile Transfer project on a planet in the primary supply-group.
+The Stockpile Transfer project is above other primary supply-group projects in the build queue. So it is fully funded and will increase the stockpile by 10 PP next turn. In order for a lasting effect one sets the repetition to 99 times.'''
 
 
 ##
@@ -4064,8 +4064,8 @@ It also allows for some interaction with the [[encyclopedia MAP_WINDOW_ARTICLE_T
 The Production Summary panel shows available Production Points.
 If a system is selected, there are two columns shown. The left column shows production points across your entire empire. The right column gives production points for the selected system (but is absent if no system is selected).
 Available Points relates to the PP available for production. The right value are the maximum available production points for the selected system. This may be less than the total available when all of your empire's systems are not [[metertype METER_SUPPLY]] connected.
-Stockpile relates to the PP available for production using the imperial stockpile. Production items are enabled to draw from the Imperial Stockpile by default and have to be explicitly disabled from doing so.
-Generally, most excess PP will be wasted and lost, but a part of the excess will be stored in the imperial stockpile.
+Stockpile relates to the PP available for production using the imperial stockpile. Production items are enabled to use PP from the Imperial Stockpile by default and have to be explicitly disabled from doing so.
+PP not allocated to anything on the build queue will automatically be stored in the imperial stockpile.
 
 <u>Producible Items panel</u>
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -339,11 +339,13 @@ PROJECT_BT_STOCKPILE_SHORT_DESC
 Transfers PP into the imperial stockpile
 
 PROJECT_BT_STOCKPILE_DESC
-'''Transfers PP at the planet where this project is enqueued to the imperial stockpile. Anything enqueued below the transfer project at a supply-connected planet will not be allocated PP.
+'''Transfers PP at the planet where this project is enqueued to the imperial stockpile. You can specify the amount and repetition of the transfer. PP spent on the transfer are added to the imperial stockpile.
 
-Only transfers PP that are available at this planet; PP allocation on planets that are not supply-connected to here will not be affected by this project.
+Only transfers PP that are available at this planet so only PP produced in the same supply-group are used and no PP from the imperial stockpile.
 
-Surplus PP (PP not allocated to anything on the queue) at this or any other location will be transferred to the stockpile with or without a stockpile transfer project on the queue.  This project is used to transfer PP to the stockpile even if there are things on the queue below it that could have been allocated available PP.'''
+Surplus PP (PP not allocated to anything on the queue) at this or any other location will be transferred to the stockpile with or without a stockpile transfer project on the queue and may trigger a warning.  This project is used for fine-tuning allocation of PP to the stockpile even if there are items on the build queue below it that could have been allocated available PP.
+
+A fully funded transfer will be finished in a single turn so if you want to make sure you always have at least 10PP available in the stockpile, you can add a 10x Stockpile Transfer and set the repetition to 99 times.'''
 
 
 ##

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -339,13 +339,14 @@ PROJECT_BT_STOCKPILE_SHORT_DESC
 Transfers PP into the imperial stockpile
 
 PROJECT_BT_STOCKPILE_DESC
-'''Transfers PP at the planet where this project is enqueued to the imperial stockpile. You can specify the amount and repetition of the transfer. PP spent on the transfer are added to the imperial stockpile.
+'''Transfers PP at the planet where this project is enqueued to the imperial stockpile. One can specify the amount and repetition of the transfer. PP spent on the transfer are added to the imperial stockpile.
 
-Only transfers PP that are available at this planet so only PP produced in the same supply-group are used and no PP from the imperial stockpile.
+Only uses PP that are produced in the same supply-group. No PP from the imperial stockpile are used.
 
-Surplus PP (PP not allocated to anything on the queue) at this or any other location will be transferred to the stockpile with or without a stockpile transfer project on the queue and may trigger a warning.  This project is used for fine-tuning allocation of PP to the stockpile even if there are items on the build queue below it that could have been allocated available PP.
+Surplus PP (PP not allocated to anything on the queue) at this or any other location will be transferred to the stockpile with or without a stockpile transfer project on the queue.  This project is used for controlling PP allocation to the stockpile. PP used for stockpile transfer are not available for items on the build queue below it.
 
-A fully funded transfer will be finished in a single turn so if you want to make sure you always have at least 10PP available in the stockpile, you can add a 10x Stockpile Transfer and set the repetition to 99 times.'''
+An example: One wants to draw PP from the stockpile in a secondary supply-group. For this the stockpile needs to be filled from the primary supply-group. Lets say one has 100PP industry in the primary supply-group and is able to draw 10PP from the stockpile. For making sure that 10PP are always available in the stockpile one adds to the top of build queue a 10x Stockpile Transfer project on a planet in the primary supply-group.
+The Stockpile Transfer project is above other primary supply-group projects in the build queue. So it is fully funded and will increase the stockpile by 10PP next turn. In order for a lasting effect one sets the repetition to 99 times.'''
 
 
 ##


### PR DESCRIPTION
* fixed some bad information
** Wrong/misleading: Anything enqueued below the transfer project at a supply-connected planet will not be allocated PP.
* added more (hopefully) useful info