### PR TITLE
Fix the CombatReport log window initial scrollbar layout

### DIFF
--- a/UI/CombatReport/CombatReportWnd.cpp
+++ b/UI/CombatReport/CombatReportWnd.cpp
@@ -74,6 +74,10 @@ public:
         if (GraphicalSummaryWnd* graphical_wnd =
                dynamic_cast<GraphicalSummaryWnd*>(m_tabs->CurrentWnd())) {
             graphical_wnd->DoLayout();
+        } else if (auto log_wnd = dynamic_cast<GG::ScrollPanel*>(m_tabs->CurrentWnd())) {
+            log_wnd->SizeMove(GG::Pt(GG::X0, GG::Y0),
+                         GG::Pt(m_wnd.ClientWidth(),
+                                m_wnd.ClientHeight() - GG::Y(INNER_BORDER_ANGLE_OFFSET)));
         }
     }
 


### PR DESCRIPTION
Prior to this, when the CombatReport log window was first displayed in a game,
the scrollbar button would not be visible/accessible even though the
full log could not fit within the displayed vertical space, nor would
mousescrolling work. Resizing the log window had been necessary to
enable scrolling.  With this fix, scrolling is enabled and the scrollbar
button is displayed from the outset.

Although it would be a more parallel structure to use a ```DoLayout``` call 
for the second window type, like the first, there does not appear to be a
suitable one publicly available, so I used ```SizeMove``` to trigger the same.