### PR TITLE
Fix broken pedia link

### DIFF
--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -10595,7 +10595,7 @@ PRO_VOID_PREDICTION_DESC
 For the imperial stockpile service, void prediction is the quintessential tool to deliver the right goods even before the need occurs.
 
 This is an upgrade technology for the imperial stockpile. The [[metertype METER_STOCKPILE]] is increased by 0.2 per population.
-These improvements are cumulative with those provided by [[tech PRO_PREDICTIVE_STOCKPILING]], [[tech PRO_GENERIC_SUPPLIES]] and [[tech PRO_INTERSTELLAR_ENTANGLEMENT_FACTORY].'''
+These improvements are cumulative with those provided by [[tech PRO_PREDICTIVE_STOCKPILING]], [[tech PRO_GENERIC_SUPPLIES]] and [[tech PRO_INTERSTELLAR_ENTANGLEMENT_FACTORY]].'''
 
 PRO_MICROGRAV_MAN
 Microgravity Industry


### PR DESCRIPTION
Missing 2nd closed bracket for [[tech PRO_INTERSTELLAR_ENTANGLEMENT_FACTORY]] in Void Prediction article.