### PR TITLE
Fix unmoved fleet blockade issue

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -2031,7 +2031,11 @@ void Empire::CheckProductionProgress() {
                     fleet = universe.InsertNew<Fleet>("", system->X(), system->Y(), m_id);
 
                     system->Insert(fleet);
-                    fleet->SetNextAndPreviousSystems(system->ID(), system->ID());
+                    // set prev system to prevent conflicts with CalculateRouteTo used for
+                    // rally points below, but leave next system as INVALID_OBJECT_ID so
+                    // fleet won't necessarily be disqualified from making blockades if it
+                    // is left stationary
+                    fleet->SetNextAndPreviousSystems(INVALID_OBJECT_ID, system->ID());
                     // set invalid arrival starlane so that fleet won't necessarily be free from blockades
                     fleet->SetArrivalStarlane(INVALID_OBJECT_ID);
 
@@ -2043,7 +2047,11 @@ void Empire::CheckProductionProgress() {
                         fleet = universe.InsertNew<Fleet>("", system->X(), system->Y(), m_id);
 
                         system->Insert(fleet);
-                        fleet->SetNextAndPreviousSystems(system->ID(), system->ID());
+                        // set prev system to prevent conflicts with CalculateRouteTo used for
+                        // rally points below, but leave next system as INVALID_OBJECT_ID so
+                        // fleet won't necessarily be disqualified from making blockades if it
+                        // is left stationary
+                        fleet->SetNextAndPreviousSystems(INVALID_OBJECT_ID, system->ID());
                         // set invalid arrival starlane so that fleet won't necessarily be free from blockades
                         fleet->SetArrivalStarlane(INVALID_OBJECT_ID);
 


### PR DESCRIPTION
Fleets which had never been moved since their creation were unable to
enforce blockades because their starting attributes were being set in
a way that indicated they were moving (to the system they were already
in).  Those attributes would not be cleared until the fleet was given
a move order.

I think that attribute setting was added a couple years ago with the introduction of Rally points,
and was apparently chosen as a way to deal with a requirement in ```CalculateRouteTo```
regarding the value of ```m_prev_system```.  But that use by ```CalculateRouteTo``` 
appears to me to be in conflict with how m_prev_system is used elsewhere, and the only
reason this doesn't cause broader problems is because ```CalculateRouteTo``` is only used
for Rally Points.  I suspect that the better solution long term would be to adjust ```CalculateRouteTo```,
and then this setting of next/prev/arrival values for new fleets would not be necessary.  But in the meantime, with 0.4.8 wanting to get out, this is a simpler fix.

The test game below is at turn 116.  There is currently a warship at Wedge Delta, which was created with the old starting attributes and has not been given any move orders, so cannot make a blockade.  On turn 117 another warship will be created at Wedge Delta.  On turn 118 a Great Kraken will arrive at Wedge Delta.  Without this PR that Great Kraken is not blockaded; with this PR it is.

[bloackade_check_at_wedge_turn_118.sav.zip](https://github.com/freeorion/freeorion/files/2025535/bloackade_check_at_wedge_turn_118.sav.zip)
