### PR TITLE
Don't Continue Broken Saves

### DIFF
--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -461,7 +461,6 @@ public:
     const FullPreview m_full_preview;
 };
 
-
 class SaveFileListBox : public CUIListBox {
 public:
     SaveFileListBox() :

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -68,56 +68,6 @@ namespace {
     }
 };
 
-////////////////////////////////////////////////
-// PlayerSaveHeaderData
-////////////////////////////////////////////////
-PlayerSaveHeaderData::PlayerSaveHeaderData() :
-    m_name(),
-    m_empire_id(ALL_EMPIRES),
-    m_client_type(Networking::INVALID_CLIENT_TYPE)
-{}
-
-PlayerSaveHeaderData::PlayerSaveHeaderData(const std::string& name, int empire_id,
-                                           Networking::ClientType client_type) :
-    m_name(name),
-    m_empire_id(empire_id),
-    m_client_type(client_type)
-{}
-
-
-////////////////////////////////////////////////
-// PlayerSaveGameData
-////////////////////////////////////////////////
-PlayerSaveGameData::PlayerSaveGameData() :
-    PlayerSaveHeaderData(),
-    m_orders(),
-    m_ui_data(),
-    m_save_state_string()
-{}
-
-PlayerSaveGameData::PlayerSaveGameData(const std::string& name, int empire_id,
-                                       const std::shared_ptr<OrderSet>& orders,
-                                       const std::shared_ptr<SaveGameUIData>& ui_data,
-                                       const std::string& save_state_string,
-                                       Networking::ClientType client_type) :
-    PlayerSaveHeaderData(name, empire_id, client_type),
-    m_orders(orders),
-    m_ui_data(ui_data),
-    m_save_state_string(save_state_string)
-{}
-
-
-////////////////////////////////////////////////
-// ServerSaveGameData
-////////////////////////////////////////////////
-ServerSaveGameData::ServerSaveGameData() :
-    m_current_turn(INVALID_GAME_TURN)
-{}
-
-ServerSaveGameData::ServerSaveGameData(int current_turn) :
-    m_current_turn(current_turn)
-{}
-
 
 ////////////////////////////////////////////////
 // ServerApp

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -20,57 +20,6 @@ struct GalaxySetupData;
 struct SaveGameUIData;
 struct ServerFSM;
 
-/** Contains basic data about a player in a game. */
-struct PlayerSaveHeaderData {
-    PlayerSaveHeaderData();
-
-    PlayerSaveHeaderData(const std::string& name, int empire_id,
-                         Networking::ClientType client_type);
-
-    std::string             m_name;
-    int                     m_empire_id;
-    Networking::ClientType  m_client_type;
-
-private:
-    friend class boost::serialization::access;
-    template <class Archive>
-    void serialize(Archive& ar, const unsigned int version);
-};
-
-/** Contains data that must be saved for a single player. */
-struct PlayerSaveGameData : public PlayerSaveHeaderData {
-    PlayerSaveGameData();
-
-    PlayerSaveGameData(const std::string& name, int empire_id,
-                       const std::shared_ptr<OrderSet>& orders,
-                       const std::shared_ptr<SaveGameUIData>& ui_data,
-                       const std::string& save_state_string,
-                       Networking::ClientType client_type);
-
-    std::shared_ptr<OrderSet>       m_orders;
-    std::shared_ptr<SaveGameUIData> m_ui_data;
-    std::string                     m_save_state_string;
-
-private:
-    friend class boost::serialization::access;
-    template <class Archive>
-    void serialize(Archive& ar, const unsigned int version);
-};
-
-/** contains data that must be retained by the server when saving and loading a
-  * game that isn't player data or the universe */
-struct ServerSaveGameData {
-    ServerSaveGameData();
-    ServerSaveGameData(int current_turn);
-
-    int m_current_turn;
-
-private:
-    friend class boost::serialization::access;
-    template <class Archive>
-    void serialize(Archive& ar, const unsigned int version);
-};
-
 /** the application framework class for the FreeOrion server. */
 class ServerApp : public IApp {
 public:
@@ -368,31 +317,5 @@ private:
     friend struct ProcessingTurn;
     friend struct ShuttingDownServer;
 };
-
-// template implementations
-template <class Archive>
-void PlayerSaveHeaderData::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_NVP(m_name)
-        & BOOST_SERIALIZATION_NVP(m_empire_id)
-        & BOOST_SERIALIZATION_NVP(m_client_type);
-}
-
-template <class Archive>
-void PlayerSaveGameData::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_NVP(m_name)
-        & BOOST_SERIALIZATION_NVP(m_empire_id)
-        & BOOST_SERIALIZATION_NVP(m_orders)
-        & BOOST_SERIALIZATION_NVP(m_ui_data)
-        & BOOST_SERIALIZATION_NVP(m_save_state_string)
-        & BOOST_SERIALIZATION_NVP(m_client_type);
-}
-
-template <class Archive>
-void ServerSaveGameData::serialize(Archive& ar, const unsigned int version)
-{
-    ar  & BOOST_SERIALIZATION_NVP(m_current_turn);
-}
 
 #endif // _ServerApp_h_

--- a/util/SaveGamePreviewUtils.h
+++ b/util/SaveGamePreviewUtils.h
@@ -76,6 +76,11 @@ private:
     void serialize(Archive& ar, const unsigned int version);
 };
 
+/// Attempts to load headers of a save file.
+/// Returns true on success, false if header data could not be loaded
+/// @param path Filename to load headers of
+FO_COMMON_API bool SaveFileWithValidHeader(const boost::filesystem::path& path);
+
 /// Get the value of column name in this preview
 /// @param full FullPreview to match for column @p name
 /// \param name The name of the column


### PR DESCRIPTION
This moves around a bunch of code so that the client can test-load the headers of save files before attempting to load them with the "continue" option from the menu. If the headers can't be parsed, then it skips the save file and tries the next, instead of attempting and failing to load the newest save file and then stopping.

Addresses https://github.com/freeorion/freeorion/issues/1846