### PR TITLE
Add dedicated module to interface the singleton aistate

### DIFF
--- a/default/python/AI/AIFleetMission.py
+++ b/default/python/AI/AIFleetMission.py
@@ -8,11 +8,11 @@ from fleet_orders import OrderMove, OrderPause, OrderOutpost, OrderColonize, Ord
 import AIstate
 import EspionageAI
 import FleetUtilsAI
-import FreeOrionAI as foAI
 import MoveUtilsAI
 import MilitaryAI
 import InvasionAI
 import CombatRatingsAI
+from aistate_interface import get_aistate
 from universe_object import System, Fleet, Planet
 from EnumsAI import MissionType
 from AIDependencies import INVALID_ID
@@ -153,7 +153,7 @@ class AIFleetMission(object):
         system_id = main_fleet.systemID
         if system_id == INVALID_ID:
             return  # can't merge fleets in middle of starlane
-        system_status = foAI.foAIstate.systemStatus[system_id]
+        system_status = get_aistate().systemStatus[system_id]
 
         # if a combat mission, and only have final order (so must be at final target), don't try
         # merging if there is no local threat (it tends to lead to fleet object churn)
@@ -166,9 +166,9 @@ class AIFleetMission(object):
             return
 
         target_id = self.target.id if self.target else None
-        main_fleet_role = foAI.foAIstate.get_fleet_role(fleet_id)
+        main_fleet_role = get_aistate().get_fleet_role(fleet_id)
         for fid in other_fleets_here:
-            fleet_role = foAI.foAIstate.get_fleet_role(fid)
+            fleet_role = get_aistate().get_fleet_role(fid)
             if fleet_role not in COMPATIBLE_ROLES_MAP[main_fleet_role]:
                 continue
             fleet = universe.getFleet(fid)
@@ -177,7 +177,7 @@ class AIFleetMission(object):
                 continue
             if not (fleet.speed > 0 or main_fleet.speed == 0):  # TODO(Cjkjvfnby) Check this condition
                 continue
-            fleet_mission = foAI.foAIstate.get_fleet_mission(fid)
+            fleet_mission = get_aistate().get_fleet_mission(fid)
             do_merge = False
             need_left = 0
             if (main_fleet_role == MissionType.ORBITAL_DEFENSE) or (fleet_role == MissionType.ORBITAL_DEFENSE):
@@ -199,10 +199,10 @@ class AIFleetMission(object):
                         # TODO: should probably ensure that fleetA has aggression on now
                         do_merge = float(min(main_fleet.speed, fleet.speed))/max(main_fleet.speed, fleet.speed) >= 0.6
                     elif main_fleet.speed > 0:
-                        neighbors = foAI.foAIstate.systemStatus.get(system_id, {}).get('neighbors', [])
+                        neighbors = get_aistate().systemStatus.get(system_id, {}).get('neighbors', [])
                         if target == system_id and target_id in neighbors and self.type == MissionType.SECURE:
                             # consider 'borrowing' for work in neighbor system  # TODO check condition
-                            need_left = 1.5 * sum(foAI.foAIstate.systemStatus.get(nid, {}).get('fleetThreat', 0)
+                            need_left = 1.5 * sum(get_aistate().systemStatus.get(nid, {}).get('fleetThreat', 0)
                                                   for nid in neighbors if nid != target_id)
                             fleet_rating = CombatRatingsAI.get_fleet_rating(fid)
                             if need_left < fleet_rating:
@@ -316,7 +316,7 @@ class AIFleetMission(object):
         open_targets = []
         already_targeted = InvasionAI.get_invasion_targeted_planet_ids(system.planetIDs, MissionType.INVASION)
         for pid in system.planetIDs:
-            if pid in already_targeted or (pid in foAI.foAIstate.qualifyingTroopBaseTargets):
+            if pid in already_targeted or (pid in get_aistate().qualifyingTroopBaseTargets):
                 continue
             planet = universe.getPlanet(pid)
             if planet.unowned or (planet.owner == empire_id):
@@ -443,7 +443,7 @@ class AIFleetMission(object):
                 print "CAN'T issue fleet order %s" % fleet_order
                 if isinstance(fleet_order, OrderMove):
                     this_system_id = fleet_order.target.id
-                    this_status = foAI.foAIstate.systemStatus.setdefault(this_system_id, {})
+                    this_status = get_aistate().systemStatus.setdefault(this_system_id, {})
                     threat_threshold = fo.currentTurn() * MilitaryAI.cur_best_mil_ship_rating() / 4.0
                     if this_status.get('monsterThreat', 0) > threat_threshold:
                         # if this move order is not this mil fleet's final destination, and blocked by Big Monster,
@@ -451,7 +451,7 @@ class AIFleetMission(object):
                         if (self.type not in (MissionType.MILITARY, MissionType.SECURE) or
                                 fleet_order != self.orders[-1]):
                             print "Aborting mission due to being blocked by Big Monster at system %d, threat %d" % (
-                                this_system_id, foAI.foAIstate.systemStatus[this_system_id]['monsterThreat'])
+                                this_system_id, get_aistate().systemStatus[this_system_id]['monsterThreat'])
                             print "Full set of orders were:"
                             for this_order in self.orders:
                                 print " - %s" % this_order
@@ -514,8 +514,7 @@ class AIFleetMission(object):
                             print "\t\t %s" % this_order
                         self.clear_fleet_orders()
                         self.clear_target()
-                        if foAI.foAIstate.get_fleet_role(fleet_id) in (MissionType.MILITARY,
-                                                                       MissionType.SECURE):
+                        if get_aistate().get_fleet_role(fleet_id) in (MissionType.MILITARY, MissionType.SECURE):
                             allocations = MilitaryAI.get_military_fleets(mil_fleets_ids=[fleet_id],
                                                                          try_reset=False,
                                                                          thisround="Fleet %d Reassignment" % fleet_id)
@@ -526,7 +525,7 @@ class AIFleetMission(object):
                         print "No Current Orders"
                 else:
                     # TODO: evaluate releasing a smaller portion or none of the ships
-                    system_status = foAI.foAIstate.systemStatus.setdefault(last_sys_target, {})
+                    system_status = get_aistate().systemStatus.setdefault(last_sys_target, {})
                     new_fleets = []
                     threat_present = system_status.get('totalThreat', 0) + system_status.get('neighborThreat', 0) > 0
                     target_system = universe.getSystem(last_sys_target)
@@ -547,7 +546,7 @@ class AIFleetMission(object):
                         print "Threat remains in target system; NOT releasing any ships."
                     new_military_fleets = []
                     for fleet_id in new_fleets:
-                        if foAI.foAIstate.get_fleet_role(fleet_id) in COMBAT_MISSION_TYPES:
+                        if get_aistate().get_fleet_role(fleet_id) in COMBAT_MISSION_TYPES:
                             new_military_fleets.append(fleet_id)
                     allocations = []
                     if new_military_fleets:
@@ -567,7 +566,7 @@ class AIFleetMission(object):
         fleet = universe.getFleet(fleet_id)
         if (not fleet) or fleet.empty or (fleet_id in universe.destroyedObjectIDs(fo.empireID())):
             # fleet was probably merged into another or was destroyed
-            foAI.foAIstate.delete_fleet_info(fleet_id)
+            get_aistate().delete_fleet_info(fleet_id)
             return
 
         # TODO: priority
@@ -627,7 +626,7 @@ class AIFleetMission(object):
         if nearest_dock == system.id:
             repair_limit = 0.99
         # if combat fleet, use military repair check
-        if foAI.foAIstate.get_fleet_role(fleet_id) in COMBAT_MISSION_TYPES:
+        if get_aistate().get_fleet_role(fleet_id) in COMBAT_MISSION_TYPES:
             return fleet_id in MilitaryAI.avail_mil_needing_repair([fleet_id], on_mission=bool(self.orders),
                                                                    repair_limit=repair_limit)[0]
         # TODO: Allow to split fleet to send only damaged ships to repair

--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -8,12 +8,12 @@ import universe_object
 import AIstate
 import EspionageAI
 import FleetUtilsAI
-import FreeOrionAI as foAI
 import InvasionAI
 import PlanetUtilsAI
 import PriorityAI
 import ProductionAI
 import MilitaryAI
+from aistate_interface import get_aistate
 from turn_state import state
 from EnumsAI import MissionType, FocusType, EmpireProductionTypes, ShipRoleType, PriorityType
 from freeorion_tools import tech_is_complete, get_ai_tag_grade, cache_by_turn, AITimer, get_partial_visibility_turn
@@ -251,7 +251,7 @@ def survey_universe():
             planet = universe.getPlanet(pid)
             if not planet:
                 continue
-            if pid in foAI.foAIstate.colonisablePlanetIDs:
+            if pid in get_aistate().colonisablePlanetIDs:
                 empire_has_qualifying_planet = True
             if planet.size == fo.planetSize.asteroids:
                 local_ast = True
@@ -301,7 +301,7 @@ def survey_universe():
                             active_growth_specials.setdefault(special, []).append(pid)
             elif owner_id != -1:
                 if get_partial_visibility_turn(pid) >= current_turn - 1:  # only interested in immediately recent data
-                    foAI.foAIstate.misc.setdefault('enemies_sighted', {}).setdefault(current_turn, []).append(pid)
+                    get_aistate().misc.setdefault('enemies_sighted', {}).setdefault(current_turn, []).append(pid)
 
         if empire_has_qualifying_planet:
             if local_ast:
@@ -311,7 +311,7 @@ def survey_universe():
 
         if sys_id in state.get_empire_planets_by_system():
             AIstate.empireStars.setdefault(system.starType, []).append(sys_id)
-            sys_status = foAI.foAIstate.systemStatus.setdefault(sys_id, {})
+            sys_status = get_aistate().systemStatus.setdefault(sys_id, {})
             if sys_status.get('fleetThreat', 0) > 0:
                 colony_status['colonies_under_attack'].append(sys_id)
             if sys_status.get('neighborThreat', 0) > 0:
@@ -335,7 +335,7 @@ def survey_universe():
     # tSys = universe.getSystem(sysID)
     # if not tSys: continue
     # claimedStars.setdefault( tSys.starType, []).append(sysID)
-    # foAI.foAIstate.misc['claimedStars'] = claimedStars
+    # get_aistate().misc['claimedStars'] = claimedStars
     colonization_timer.stop()
 
 
@@ -383,7 +383,7 @@ def get_colony_fleets():
     evaluated_colony_planet_ids = list(state.get_unowned_empty_planets().union(state.get_empire_outposts()) - set(
         colony_targeted_planet_ids))  # places for possible colonyBase
 
-    outpost_base_manager = foAI.foAIstate.orbital_colonization_manager
+    outpost_base_manager = get_aistate().orbital_colonization_manager
 
     for pid in evaluated_colony_planet_ids:  # TODO: reorganize
         planet = universe.getPlanet(pid)
@@ -422,8 +422,8 @@ def get_colony_fleets():
 
     sorted_planets = [(planet_id, score[:2]) for planet_id, score in sorted_planets if score[0] > 0]
     # export planets for other AI modules
-    foAI.foAIstate.colonisablePlanetIDs.clear()
-    foAI.foAIstate.colonisablePlanetIDs.update(sorted_planets)
+    get_aistate().colonisablePlanetIDs.clear()
+    get_aistate().colonisablePlanetIDs.update(sorted_planets)
 
     evaluated_outpost_planets = assign_colonisation_values(evaluated_outpost_planet_ids, MissionType.OUTPOST, None)
     # if outposted planet would be in supply range, let outpost value be best of outpost value or colonization value
@@ -441,8 +441,8 @@ def get_colony_fleets():
 
     sorted_outposts = [(planet_id, score[:2]) for planet_id, score in sorted_outposts if score[0] > 0]
     # export outposts for other AI modules
-    foAI.foAIstate.colonisableOutpostIDs.clear()
-    foAI.foAIstate.colonisableOutpostIDs.update(sorted_outposts)
+    get_aistate().colonisableOutpostIDs.clear()
+    get_aistate().colonisableOutpostIDs.update(sorted_outposts)
     colonization_timer.stop_print_and_clear()
 
 
@@ -578,7 +578,7 @@ def evaluate_planet(planet_id, mission_type, spec_name, detail=None):
     if detail is None:
         detail = []
     retval = 0
-    character = foAI.foAIstate.character
+    character = get_aistate().character
     discount_multiplier = character.preferred_discount_multiplier([30.0, 40.0])
     species = fo.getSpecies(spec_name or "")  # in case None is passed as specName
     species_foci = [] and species and list(species.foci)
@@ -1086,7 +1086,7 @@ def revise_threat_factor(threat_factor, planet_value, system_id, min_planet_valu
 
     # the default value below for fleetThreat shouldn't come in to play, but is just to be absolutely sure we don't
     # send colony ships into some system for which we have not evaluated fleetThreat
-    system_status = foAI.foAIstate.systemStatus.get(system_id, {})
+    system_status = get_aistate().systemStatus.get(system_id, {})
     system_fleet_treat = system_status.get('fleetThreat', 1000)
     # TODO: consider taking area threat into account here.  Arguments can be made both ways, see discussion in PR2069
     sys_total_threat = system_fleet_treat + system_status.get('monsterThreat', 0) + system_status.get('planetThreat', 0)
@@ -1101,7 +1101,7 @@ def determine_colony_threat_factor(planet_id, spec_name, existing_presence):
     if not planet:  # should have been checked previously, but belt-and-suspenders
         error("Can't retrieve planet ID %d" % planet_id)
         return 0
-    sys_status = foAI.foAIstate.systemStatus.get(planet.systemID, {})
+    sys_status = get_aistate().systemStatus.get(planet.systemID, {})
     cur_best_mil_ship_rating = max(MilitaryAI.cur_best_mil_ship_rating(), 0.001)
     local_defenses = sys_status.get('all_local_defenses', 0)
     local_threat = sys_status.get('fleetThreat', 0) + sys_status.get('monsterThreat', 0)
@@ -1112,7 +1112,7 @@ def determine_colony_threat_factor(planet_id, spec_name, existing_presence):
     # TODO: evaluate detectability by specific source of area threat, also consider if the subject AI already has
     # researched techs that would grant a stealth bonus
     local_enemies = sys_status.get("enemies_nearly_supplied", [])
-    # could more conservatively base detection on foAI.foAIstate.misc.get("observed_empires")
+    # could more conservatively base detection on get_aistate().misc.get("observed_empires")
     if not EspionageAI.colony_detectable_by_empire(planet_id, spec_name, empire=local_enemies, default_result=True):
         area_threat *= 0.05
     net_threat = max(0, local_threat + area_threat - local_defenses)
@@ -1148,18 +1148,18 @@ def get_claimed_stars():
 
 def assign_colony_fleets_to_colonise():
 
-    foAI.foAIstate.orbital_colonization_manager.assign_bases_to_colonize()
+    get_aistate().orbital_colonization_manager.assign_bases_to_colonize()
 
     # assign fleet targets to colonisable planets
     all_colony_fleet_ids = FleetUtilsAI.get_empire_fleet_ids_by_role(MissionType.COLONISATION)
     send_colony_ships(FleetUtilsAI.extract_fleet_ids_without_mission_types(all_colony_fleet_ids),
-                      foAI.foAIstate.colonisablePlanetIDs.items(),
+                      get_aistate().colonisablePlanetIDs.items(),
                       MissionType.COLONISATION)
 
     # assign fleet targets to colonisable outposts
     all_outpost_fleet_ids = FleetUtilsAI.get_empire_fleet_ids_by_role(MissionType.OUTPOST)
     send_colony_ships(FleetUtilsAI.extract_fleet_ids_without_mission_types(all_outpost_fleet_ids),
-                      foAI.foAIstate.colonisableOutpostIDs.items(),
+                      get_aistate().colonisableOutpostIDs.items(),
                       MissionType.OUTPOST)
 
 
@@ -1221,10 +1221,10 @@ def send_colony_ships(colony_fleet_ids, evaluated_planets, mission_type):
             continue
         planet = universe.getPlanet(planet_id)
         sys_id = planet.systemID
-        if foAI.foAIstate.systemStatus.setdefault(sys_id, {}).setdefault('monsterThreat', 0) > 2000 \
-                or fo.currentTurn() < 20 and foAI.foAIstate.systemStatus[sys_id]['monsterThreat'] > 200:
+        if get_aistate().systemStatus.setdefault(sys_id, {}).setdefault('monsterThreat', 0) > 2000 \
+                or fo.currentTurn() < 20 and get_aistate().systemStatus[sys_id]['monsterThreat'] > 200:
             print "Skipping colonization of system %s due to Big Monster, threat %d" % (
-                universe.getSystem(sys_id), foAI.foAIstate.systemStatus[sys_id]['monsterThreat'])
+                universe.getSystem(sys_id), get_aistate().systemStatus[sys_id]['monsterThreat'])
             already_targeted.append(planet_id)
             continue
         this_spec = target[1][1]
@@ -1242,7 +1242,7 @@ def send_colony_ships(colony_fleet_ids, evaluated_planets, mission_type):
         fleet_id = this_fleet_list[0]
         already_targeted.append(planet_id)
         ai_target = universe_object.Planet(planet_id)
-        foAI.foAIstate.get_fleet_mission(fleet_id).set_target(mission_type, ai_target)
+        get_aistate().get_fleet_mission(fleet_id).set_target(mission_type, ai_target)
 
 
 def _print_empire_species_roster():
@@ -1344,7 +1344,7 @@ class OrbitalColonizationPlan(object):
             return False
         # give orders to perform the mission
         target = universe_object.Planet(self.target)
-        fleet_mission = foAI.foAIstate.get_fleet_mission(fleet_id)
+        fleet_mission = get_aistate().get_fleet_mission(fleet_id)
         fleet_mission.set_target(MissionType.ORBITAL_OUTPOST, target)
         self.fleet_id = fleet_id
         return True
@@ -1493,7 +1493,7 @@ class OrbitalColonizationManager(object):
             if element.buildType != EmpireProductionTypes.BT_SHIP or element.turnsLeft == -1:
                 continue
 
-            role = foAI.foAIstate.get_ship_role(element.designID)
+            role = get_aistate().get_ship_role(element.designID)
             if role != ShipRoleType.BASE_OUTPOST:
                 continue
 

--- a/default/python/AI/DiplomaticCorp.py
+++ b/default/python/AI/DiplomaticCorp.py
@@ -34,12 +34,13 @@ class DiplomaticCorp(object):
         # TODO: remove the following early return once proper support for third party diplomatic history is added
         if message.recipient != fo.empireID():
             return
+        aistate = get_aistate()
         if message.type == fo.diplomaticMessageType.peaceProposal:
-            get_aistate().log_peace_request(message.sender, message.recipient)
+            aistate.log_peace_request(message.sender, message.recipient)
             proposal_sender_player = fo.empirePlayerID(message.sender)
-            attitude = get_aistate().character.attitude_to_empire(message.sender, get_aistate().diplomatic_logs)
+            attitude = aistate.character.attitude_to_empire(message.sender, aistate.diplomatic_logs)
             possible_acknowledgments = []
-            aggression = get_aistate().character.get_trait(Aggression)
+            aggression = aistate.character.get_trait(Aggression)
             if aggression.key <= fo.aggression.typical:
                 possible_acknowledgments = UserStringList("AI_PEACE_PROPOSAL_ACKNOWLEDGEMENTS_MILD_LIST")
                 if attitude > 0:
@@ -68,7 +69,7 @@ class DiplomaticCorp(object):
         elif message.type == fo.diplomaticMessageType.warDeclaration:
             # note: apparently this is currently (normally?) sent not as a warDeclaration,
             # but as a simple diplomatic_status_update to war
-            get_aistate().log_war_declaration(message.sender, message.recipient)
+            aistate.log_war_declaration(message.sender, message.recipient)
 
     @staticmethod
     def get_first_turn_greet_message():

--- a/default/python/AI/DiplomaticCorp.py
+++ b/default/python/AI/DiplomaticCorp.py
@@ -2,10 +2,10 @@
 import random
 
 import freeOrionAIInterface as fo
-import FreeOrionAI as foAI
 from character.character_module import Aggression
 from character.character_strings_module import possible_greetings
 from freeorion_tools import UserStringList
+from aistate_interface import get_aistate
 
 
 def handle_pregame_chat(sender_player_id, message_txt):
@@ -35,11 +35,11 @@ class DiplomaticCorp(object):
         if message.recipient != fo.empireID():
             return
         if message.type == fo.diplomaticMessageType.peaceProposal:
-            foAI.foAIstate.log_peace_request(message.sender, message.recipient)
+            get_aistate().log_peace_request(message.sender, message.recipient)
             proposal_sender_player = fo.empirePlayerID(message.sender)
-            attitude = foAI.foAIstate.character.attitude_to_empire(message.sender, foAI.foAIstate.diplomatic_logs)
+            attitude = get_aistate().character.attitude_to_empire(message.sender, get_aistate().diplomatic_logs)
             possible_acknowledgments = []
-            aggression = foAI.foAIstate.character.get_trait(Aggression)
+            aggression = get_aistate().character.get_trait(Aggression)
             if aggression.key <= fo.aggression.typical:
                 possible_acknowledgments = UserStringList("AI_PEACE_PROPOSAL_ACKNOWLEDGEMENTS_MILD_LIST")
                 if attitude > 0:
@@ -68,11 +68,11 @@ class DiplomaticCorp(object):
         elif message.type == fo.diplomaticMessageType.warDeclaration:
             # note: apparently this is currently (normally?) sent not as a warDeclaration,
             # but as a simple diplomatic_status_update to war
-            foAI.foAIstate.log_war_declaration(message.sender, message.recipient)
+            get_aistate().log_war_declaration(message.sender, message.recipient)
 
     @staticmethod
     def get_first_turn_greet_message():
-        greets = possible_greetings(foAI.foAIstate.character)
+        greets = possible_greetings(get_aistate().character)
         # no such entry
         if len(greets) == 1 and greets[0] == '?':
             greets = UserStringList("AI_FIRST_TURN_GREETING_BEGINNER")
@@ -84,7 +84,7 @@ class DiplomaticCorp(object):
         print "Received diplomatic status update to %s about empire %s and empire %s" % (
             status_update.status, status_update.empire1, status_update.empire2)
         if status_update.empire2 == fo.empireID() and status_update.status == fo.diplomaticStatus.war:
-            foAI.foAIstate.log_war_declaration(status_update.empire1, status_update.empire2)
+            get_aistate().log_war_declaration(status_update.empire1, status_update.empire2)
 
     def handle_midgame_chat(self, sender_player_id, message_txt):
         print "Midgame chat received from player %d, message: %s" % (sender_player_id, message_txt)

--- a/default/python/AI/ExplorationAI.py
+++ b/default/python/AI/ExplorationAI.py
@@ -19,8 +19,9 @@ def get_current_exploration_info():
     fleet_ids = FleetUtilsAI.get_empire_fleet_ids_by_role(MissionType.EXPLORATION)
     available_scouts = []
     already_covered = set()
+    aistate = get_aistate()
     for fleet_id in fleet_ids:
-        fleet_mission = get_aistate().get_fleet_mission(fleet_id)
+        fleet_mission = aistate.get_fleet_mission(fleet_id)
         if not fleet_mission.type:
             available_scouts.append(fleet_id)
         else:
@@ -51,10 +52,11 @@ def assign_scouts_to_explore_systems():
 
     print "Explorable system IDs: %s" % explore_list
     print "Already targeted: %s" % already_covered
-    needs_vis = get_aistate().misc.setdefault('needs_vis', [])
-    check_list = get_aistate().needsEmergencyExploration + needs_vis + explore_list
+    aistate = get_aistate()
+    needs_vis = aistate.misc.setdefault('needs_vis', [])
+    check_list = aistate.needsEmergencyExploration + needs_vis + explore_list
     if INVALID_ID in check_list:  # shouldn't normally happen, unless due to bug elsewhere
-        for sys_list, name in [(get_aistate().needsEmergencyExploration, "get_aistate().needsEmergencyExploration"),
+        for sys_list, name in [(aistate.needsEmergencyExploration, "aistate.needsEmergencyExploration"),
                                (needs_vis, "needs_vis"), (explore_list, "explore_list")]:
             if INVALID_ID in sys_list:
                 error("INVALID_ID found in " + name, exc_info=True)
@@ -63,7 +65,7 @@ def assign_scouts_to_explore_systems():
     needs_coverage = [sys_id for sys_id in check_list if sys_id not in already_covered and sys_id != INVALID_ID]
     print "Needs coverage: %s" % needs_coverage
 
-    print "Available scouts & AIstate locs: %s" % [(x, get_aistate().fleetStatus.get(x, {}).get('sysID', INVALID_ID))
+    print "Available scouts & AIstate locs: %s" % [(x, aistate.fleetStatus.get(x, {}).get('sysID', INVALID_ID))
                                                    for x in available_scouts]
     print "Available scouts & universe locs: %s" % [(x, universe.getFleet(x).systemID) for x in available_scouts]
     if not needs_coverage or not available_scouts:
@@ -76,19 +78,19 @@ def assign_scouts_to_explore_systems():
                 # already got visibility; remove from visit lists and skip
                 if sys_id in needs_vis:
                     del needs_vis[needs_vis.index(sys_id)]
-                if sys_id in get_aistate().needsEmergencyExploration:
-                    del get_aistate().needsEmergencyExploration[
-                        get_aistate().needsEmergencyExploration.index(sys_id)]
+                if sys_id in aistate.needsEmergencyExploration:
+                    del aistate.needsEmergencyExploration[
+                        aistate.needsEmergencyExploration.index(sys_id)]
                 print "system id %d already currently visible; skipping exploration" % sys_id
                 needs_coverage.remove(sys_id)
                 continue
 
         # skip systems threatened by monsters
-        sys_status = get_aistate().systemStatus.setdefault(sys_id, {})
-        if (not get_aistate().character.may_explore_system(sys_status.setdefault('monsterThreat', 0)) or (
-                fo.currentTurn() < 20 and get_aistate().systemStatus[sys_id]['monsterThreat'] > 0)):
+        sys_status = aistate.systemStatus.setdefault(sys_id, {})
+        if (not aistate.character.may_explore_system(sys_status.setdefault('monsterThreat', 0)) or (
+                fo.currentTurn() < 20 and aistate.systemStatus[sys_id]['monsterThreat'] > 0)):
             print "Skipping exploration of system %d due to Big Monster, threat %d" % (
-                sys_id, get_aistate().systemStatus[sys_id]['monsterThreat'])
+                sys_id, aistate.systemStatus[sys_id]['monsterThreat'])
             needs_coverage.remove(sys_id)
             continue
 
@@ -96,7 +98,7 @@ def assign_scouts_to_explore_systems():
     options = []
     available_scouts = set(available_scouts)
     for fleet_id in available_scouts:
-        fleet_mission = get_aistate().get_fleet_mission(fleet_id)
+        fleet_mission = aistate.get_fleet_mission(fleet_id)
         start = fleet_mission.get_location_target()
         for sys_id in needs_coverage:
             target = universe_object.System(sys_id)
@@ -114,7 +116,7 @@ def assign_scouts_to_explore_systems():
     while options:
         debug("Remaining options: %s" % options)
         _, fleet_id, sys_id = options[0]
-        fleet_mission = get_aistate().get_fleet_mission(fleet_id)
+        fleet_mission = aistate.get_fleet_mission(fleet_id)
         target = universe_object.System(sys_id)
         info("Sending fleet %d to explore %s" % (fleet_id, target))
         fleet_mission.set_target(MissionType.EXPLORATION, target)
@@ -131,15 +133,16 @@ def follow_vis_system_connections(start_system_id, home_system_id):
     universe = fo.getUniverse()
     empire_id = fo.empireID()
     exploration_list = [start_system_id]
+    aistate = get_aistate()
     while exploration_list:
         cur_system_id = exploration_list.pop()
         if cur_system_id in graph_flags:
             continue
         graph_flags.add(cur_system_id)
         system = universe.getSystem(cur_system_id)
-        if cur_system_id in get_aistate().visBorderSystemIDs:
+        if cur_system_id in aistate.visBorderSystemIDs:
             pre_vis = "a border system"
-        elif cur_system_id in get_aistate().visInteriorSystemIDs:
+        elif cur_system_id in aistate.visInteriorSystemIDs:
             pre_vis = "an interior system"
         else:
             pre_vis = "an unknown system"
@@ -158,18 +161,18 @@ def follow_vis_system_connections(start_system_id, home_system_id):
         status_info.append("    -- is%s partially visible" % ("" if has_been_visible else " not"))
         status_info.append("    -- is%s visibly connected to homesystem" % ("" if is_connected else " not"))
         if has_been_visible:
-            sys_status = get_aistate().systemStatus.setdefault(cur_system_id, {})
-            get_aistate().visInteriorSystemIDs.add(cur_system_id)
-            get_aistate().visBorderSystemIDs.discard(cur_system_id)
+            sys_status = aistate.systemStatus.setdefault(cur_system_id, {})
+            aistate.visInteriorSystemIDs.add(cur_system_id)
+            aistate.visBorderSystemIDs.discard(cur_system_id)
             neighbors = set(universe.getImmediateNeighbors(cur_system_id, empire_id))
             sys_status.setdefault('neighbors', set()).update(neighbors)
             if neighbors:
                 status_info.append(" -- has neighbors %s" % sorted(neighbors))
                 for sys_id in neighbors:
-                    if sys_id not in get_aistate().exploredSystemIDs:
-                        get_aistate().unexploredSystemIDs.add(sys_id)
-                    if (sys_id not in graph_flags) and (sys_id not in get_aistate().visInteriorSystemIDs):
-                        get_aistate().visBorderSystemIDs.add(sys_id)
+                    if sys_id not in aistate.exploredSystemIDs:
+                        aistate.unexploredSystemIDs.add(sys_id)
+                    if (sys_id not in graph_flags) and (sys_id not in aistate.visInteriorSystemIDs):
+                        aistate.visBorderSystemIDs.add(sys_id)
                         exploration_list.append(sys_id)
         if fo.currentTurn() < 50:
             print '\n'.join(status_info)
@@ -188,12 +191,13 @@ def update_explored_systems():
     empire_id = fo.empireID()
     newly_explored = []
     still_unexplored = []
-    for sys_id in list(get_aistate().unexploredSystemIDs):
+    aistate = get_aistate()
+    for sys_id in list(aistate.unexploredSystemIDs):
         # consider making determination according to visibility rather than actual visit,
         # which I think is what empire.hasExploredSystem covers (Dilvish-fo)
         if empire.hasExploredSystem(sys_id):
-            get_aistate().unexploredSystemIDs.discard(sys_id)
-            get_aistate().exploredSystemIDs.add(sys_id)
+            aistate.unexploredSystemIDs.discard(sys_id)
+            aistate.exploredSystemIDs.add(sys_id)
             system = universe.getSystem(sys_id)
             print "Moved system %s from unexplored list to explored list" % system
             border_unexplored_system_ids.discard(sys_id)
@@ -208,11 +212,11 @@ def update_explored_systems():
             neighbors = list(universe.getImmediateNeighbors(sys_id, empire_id))
             for neighbor_id in neighbors:
                 # when it matters, unexplored will be smaller than explored
-                if neighbor_id not in get_aistate().unexploredSystemIDs:
+                if neighbor_id not in aistate.unexploredSystemIDs:
                     next_list.append(neighbor_id)
 
     for sys_id in still_unexplored:
         neighbors = list(universe.getImmediateNeighbors(sys_id, empire_id))
-        if any(nid in get_aistate().exploredSystemIDs for nid in neighbors):
+        if any(nid in aistate.exploredSystemIDs for nid in neighbors):
             border_unexplored_system_ids.add(sys_id)
     return newly_explored

--- a/default/python/AI/ExplorationAI.py
+++ b/default/python/AI/ExplorationAI.py
@@ -1,7 +1,6 @@
 from logging import debug, error, info
 
 import freeOrionAIInterface as fo  # interface used to interact with FreeOrion AI client # pylint: disable=import-error
-import FreeOrionAI as foAI
 import FleetUtilsAI
 from EnumsAI import MissionType
 import universe_object
@@ -9,6 +8,7 @@ import MoveUtilsAI
 import PlanetUtilsAI
 from AIDependencies import INVALID_ID
 from freeorion_tools import get_partial_visibility_turn
+from aistate_interface import get_aistate
 
 graph_flags = set()
 border_unexplored_system_ids = set()
@@ -20,7 +20,7 @@ def get_current_exploration_info():
     available_scouts = []
     already_covered = set()
     for fleet_id in fleet_ids:
-        fleet_mission = foAI.foAIstate.get_fleet_mission(fleet_id)
+        fleet_mission = get_aistate().get_fleet_mission(fleet_id)
         if not fleet_mission.type:
             available_scouts.append(fleet_id)
         else:
@@ -51,10 +51,10 @@ def assign_scouts_to_explore_systems():
 
     print "Explorable system IDs: %s" % explore_list
     print "Already targeted: %s" % already_covered
-    needs_vis = foAI.foAIstate.misc.setdefault('needs_vis', [])
-    check_list = foAI.foAIstate.needsEmergencyExploration + needs_vis + explore_list
+    needs_vis = get_aistate().misc.setdefault('needs_vis', [])
+    check_list = get_aistate().needsEmergencyExploration + needs_vis + explore_list
     if INVALID_ID in check_list:  # shouldn't normally happen, unless due to bug elsewhere
-        for sys_list, name in [(foAI.foAIstate.needsEmergencyExploration, "foAI.foAIstate.needsEmergencyExploration"),
+        for sys_list, name in [(get_aistate().needsEmergencyExploration, "get_aistate().needsEmergencyExploration"),
                                (needs_vis, "needs_vis"), (explore_list, "explore_list")]:
             if INVALID_ID in sys_list:
                 error("INVALID_ID found in " + name, exc_info=True)
@@ -63,7 +63,7 @@ def assign_scouts_to_explore_systems():
     needs_coverage = [sys_id for sys_id in check_list if sys_id not in already_covered and sys_id != INVALID_ID]
     print "Needs coverage: %s" % needs_coverage
 
-    print "Available scouts & AIstate locs: %s" % [(x, foAI.foAIstate.fleetStatus.get(x, {}).get('sysID', INVALID_ID))
+    print "Available scouts & AIstate locs: %s" % [(x, get_aistate().fleetStatus.get(x, {}).get('sysID', INVALID_ID))
                                                    for x in available_scouts]
     print "Available scouts & universe locs: %s" % [(x, universe.getFleet(x).systemID) for x in available_scouts]
     if not needs_coverage or not available_scouts:
@@ -76,19 +76,19 @@ def assign_scouts_to_explore_systems():
                 # already got visibility; remove from visit lists and skip
                 if sys_id in needs_vis:
                     del needs_vis[needs_vis.index(sys_id)]
-                if sys_id in foAI.foAIstate.needsEmergencyExploration:
-                    del foAI.foAIstate.needsEmergencyExploration[
-                        foAI.foAIstate.needsEmergencyExploration.index(sys_id)]
+                if sys_id in get_aistate().needsEmergencyExploration:
+                    del get_aistate().needsEmergencyExploration[
+                        get_aistate().needsEmergencyExploration.index(sys_id)]
                 print "system id %d already currently visible; skipping exploration" % sys_id
                 needs_coverage.remove(sys_id)
                 continue
 
         # skip systems threatened by monsters
-        sys_status = foAI.foAIstate.systemStatus.setdefault(sys_id, {})
-        if (not foAI.foAIstate.character.may_explore_system(sys_status.setdefault('monsterThreat', 0)) or (
-                fo.currentTurn() < 20 and foAI.foAIstate.systemStatus[sys_id]['monsterThreat'] > 0)):
+        sys_status = get_aistate().systemStatus.setdefault(sys_id, {})
+        if (not get_aistate().character.may_explore_system(sys_status.setdefault('monsterThreat', 0)) or (
+                fo.currentTurn() < 20 and get_aistate().systemStatus[sys_id]['monsterThreat'] > 0)):
             print "Skipping exploration of system %d due to Big Monster, threat %d" % (
-                sys_id, foAI.foAIstate.systemStatus[sys_id]['monsterThreat'])
+                sys_id, get_aistate().systemStatus[sys_id]['monsterThreat'])
             needs_coverage.remove(sys_id)
             continue
 
@@ -96,7 +96,7 @@ def assign_scouts_to_explore_systems():
     options = []
     available_scouts = set(available_scouts)
     for fleet_id in available_scouts:
-        fleet_mission = foAI.foAIstate.get_fleet_mission(fleet_id)
+        fleet_mission = get_aistate().get_fleet_mission(fleet_id)
         start = fleet_mission.get_location_target()
         for sys_id in needs_coverage:
             target = universe_object.System(sys_id)
@@ -114,7 +114,7 @@ def assign_scouts_to_explore_systems():
     while options:
         debug("Remaining options: %s" % options)
         _, fleet_id, sys_id = options[0]
-        fleet_mission = foAI.foAIstate.get_fleet_mission(fleet_id)
+        fleet_mission = get_aistate().get_fleet_mission(fleet_id)
         target = universe_object.System(sys_id)
         info("Sending fleet %d to explore %s" % (fleet_id, target))
         fleet_mission.set_target(MissionType.EXPLORATION, target)
@@ -137,9 +137,9 @@ def follow_vis_system_connections(start_system_id, home_system_id):
             continue
         graph_flags.add(cur_system_id)
         system = universe.getSystem(cur_system_id)
-        if cur_system_id in foAI.foAIstate.visBorderSystemIDs:
+        if cur_system_id in get_aistate().visBorderSystemIDs:
             pre_vis = "a border system"
-        elif cur_system_id in foAI.foAIstate.visInteriorSystemIDs:
+        elif cur_system_id in get_aistate().visInteriorSystemIDs:
             pre_vis = "an interior system"
         else:
             pre_vis = "an unknown system"
@@ -158,18 +158,18 @@ def follow_vis_system_connections(start_system_id, home_system_id):
         status_info.append("    -- is%s partially visible" % ("" if has_been_visible else " not"))
         status_info.append("    -- is%s visibly connected to homesystem" % ("" if is_connected else " not"))
         if has_been_visible:
-            sys_status = foAI.foAIstate.systemStatus.setdefault(cur_system_id, {})
-            foAI.foAIstate.visInteriorSystemIDs.add(cur_system_id)
-            foAI.foAIstate.visBorderSystemIDs.discard(cur_system_id)
+            sys_status = get_aistate().systemStatus.setdefault(cur_system_id, {})
+            get_aistate().visInteriorSystemIDs.add(cur_system_id)
+            get_aistate().visBorderSystemIDs.discard(cur_system_id)
             neighbors = set(universe.getImmediateNeighbors(cur_system_id, empire_id))
             sys_status.setdefault('neighbors', set()).update(neighbors)
             if neighbors:
                 status_info.append(" -- has neighbors %s" % sorted(neighbors))
                 for sys_id in neighbors:
-                    if sys_id not in foAI.foAIstate.exploredSystemIDs:
-                        foAI.foAIstate.unexploredSystemIDs.add(sys_id)
-                    if (sys_id not in graph_flags) and (sys_id not in foAI.foAIstate.visInteriorSystemIDs):
-                        foAI.foAIstate.visBorderSystemIDs.add(sys_id)
+                    if sys_id not in get_aistate().exploredSystemIDs:
+                        get_aistate().unexploredSystemIDs.add(sys_id)
+                    if (sys_id not in graph_flags) and (sys_id not in get_aistate().visInteriorSystemIDs):
+                        get_aistate().visBorderSystemIDs.add(sys_id)
                         exploration_list.append(sys_id)
         if fo.currentTurn() < 50:
             print '\n'.join(status_info)
@@ -188,12 +188,12 @@ def update_explored_systems():
     empire_id = fo.empireID()
     newly_explored = []
     still_unexplored = []
-    for sys_id in list(foAI.foAIstate.unexploredSystemIDs):
+    for sys_id in list(get_aistate().unexploredSystemIDs):
         # consider making determination according to visibility rather than actual visit,
         # which I think is what empire.hasExploredSystem covers (Dilvish-fo)
         if empire.hasExploredSystem(sys_id):
-            foAI.foAIstate.unexploredSystemIDs.discard(sys_id)
-            foAI.foAIstate.exploredSystemIDs.add(sys_id)
+            get_aistate().unexploredSystemIDs.discard(sys_id)
+            get_aistate().exploredSystemIDs.add(sys_id)
             system = universe.getSystem(sys_id)
             print "Moved system %s from unexplored list to explored list" % system
             border_unexplored_system_ids.discard(sys_id)
@@ -208,11 +208,11 @@ def update_explored_systems():
             neighbors = list(universe.getImmediateNeighbors(sys_id, empire_id))
             for neighbor_id in neighbors:
                 # when it matters, unexplored will be smaller than explored
-                if neighbor_id not in foAI.foAIstate.unexploredSystemIDs:
+                if neighbor_id not in get_aistate().unexploredSystemIDs:
                     next_list.append(neighbor_id)
 
     for sys_id in still_unexplored:
         neighbors = list(universe.getImmediateNeighbors(sys_id, empire_id))
-        if any(nid in foAI.foAIstate.exploredSystemIDs for nid in neighbors):
+        if any(nid in get_aistate().exploredSystemIDs for nid in neighbors):
             border_unexplored_system_ids.add(sys_id)
     return newly_explored

--- a/default/python/AI/FleetUtilsAI.py
+++ b/default/python/AI/FleetUtilsAI.py
@@ -106,11 +106,12 @@ def get_fleets_for_mission(target_stats, min_stats, cur_stats, starting_system,
     systems_enqueued = [starting_system]
     systems_visited = []
     # loop over systems in a breadth-first-search trying to find nearby suitable ships in fleet_pool_set
+    aistate = get_aistate()
     while systems_enqueued and fleet_pool_set:
         this_system_id = systems_enqueued.pop(0)
         this_system_obj = universe_object.System(this_system_id)
         systems_visited.append(this_system_id)
-        accessible_fleets = get_aistate().systemStatus.get(this_system_id, {}).get('myFleetsAccessible', [])
+        accessible_fleets = aistate.systemStatus.get(this_system_id, {}).get('myFleetsAccessible', [])
         fleets_here = [fid for fid in accessible_fleets if fid in fleet_pool_set]
         # loop over all fleets in the system, split them if possible and select suitable ships
         while fleets_here:
@@ -128,7 +129,7 @@ def get_fleets_for_mission(target_stats, min_stats, cur_stats, starting_system,
             if species:
                 for ship_id in fleet.shipIDs:
                     ship = universe.getShip(ship_id)
-                    if (ship and get_aistate().get_ship_role(ship.design.id) in colonization_roles and
+                    if (ship and aistate.get_ship_role(ship.design.id) in colonization_roles and
                             species == ship.speciesName):
                         break
                 else:  # no suitable species found
@@ -146,7 +147,7 @@ def get_fleets_for_mission(target_stats, min_stats, cur_stats, starting_system,
             # check if we need additional rating vs planets
             this_rating_vs_planets = 0
             if 'ratingVsPlanets' in target_stats:
-                this_rating_vs_planets = get_aistate().get_rating(fleet_id, against_planets=True)
+                this_rating_vs_planets = aistate.get_rating(fleet_id, against_planets=True)
                 if this_rating_vs_planets <= 0 and cur_stats.get('rating', 0) >= target_stats.get('rating', 0):
                     # we already have enough general rating, so do not add any more warships useless against planets
                     continue
@@ -159,7 +160,7 @@ def get_fleets_for_mission(target_stats, min_stats, cur_stats, starting_system,
                 continue
             fleet_list.append(fleet_id)
 
-            this_rating = get_aistate().get_rating(fleet_id)
+            this_rating = aistate.get_rating(fleet_id)
             cur_stats['rating'] = CombatRatingsAI.combine_ratings(cur_stats.get('rating', 0), this_rating)
             if 'ratingVsPlanets' in target_stats:
                 cur_stats['ratingVsPlanets'] = CombatRatingsAI.combine_ratings(cur_stats.get('ratingVsPlanets', 0),
@@ -176,7 +177,7 @@ def get_fleets_for_mission(target_stats, min_stats, cur_stats, starting_system,
             if all((
                     neighbor_id not in systems_visited,
                     neighbor_id not in systems_enqueued,
-                    neighbor_id in get_aistate().exploredSystemIDs
+                    neighbor_id in aistate.exploredSystemIDs
             )):
                 systems_enqueued.append(neighbor_id)
     # we ran out of systems or fleets to check but did not meet requirements yet.
@@ -207,6 +208,7 @@ def split_fleet(fleet_id):
     if len(list(fleet.shipIDs)) <= 1:  # fleet with only one ship cannot be split
         return []
     ship_ids = list(fleet.shipIDs)
+    aistate = get_aistate()
     for ship_id in ship_ids[1:]:
         new_fleet_id = fo.issueNewFleetOrder("Fleet %4d" % ship_id, ship_id)
         if new_fleet_id:
@@ -215,9 +217,9 @@ def split_fleet(fleet_id):
                 warn("Newly split fleet %d not available from universe" % new_fleet_id)
             fo.issueRenameOrder(new_fleet_id, "Fleet %4d" % new_fleet_id)  # to ease review of debugging logs
             fo.issueAggressionOrder(new_fleet_id, True)
-            get_aistate().update_fleet_rating(new_fleet_id)
+            aistate.update_fleet_rating(new_fleet_id)
             newfleets.append(new_fleet_id)
-            get_aistate().newlySplitFleets[new_fleet_id] = True
+            aistate.newlySplitFleets[new_fleet_id] = True
         else:
             if fleet.systemID == INVALID_ID:
                 warn("Tried to split ship id (%d) from fleet %d when fleet is in starlane" % (
@@ -225,10 +227,10 @@ def split_fleet(fleet_id):
             else:
                 warn("Got no fleet ID back after trying to split ship id (%d) from fleet %d" % (
                     ship_id, fleet_id))
-    get_aistate().get_fleet_role(fleet_id, force_new=True)
-    get_aistate().update_fleet_rating(fleet_id)
+    aistate.get_fleet_role(fleet_id, force_new=True)
+    aistate.update_fleet_rating(fleet_id)
     if newfleets:
-        get_aistate().ensure_have_fleet_missions(newfleets)
+        aistate.ensure_have_fleet_missions(newfleets)
     return newfleets
 
 
@@ -260,9 +262,10 @@ def merge_fleet_a_into_b(fleet_a_id, fleet_b_id, leave_rating=0, need_rating=0, 
         if need_rating != 0 and need_rating <= transferred_rating:
             break
     fleet_a = universe.getFleet(fleet_a_id)
+    aistate = get_aistate()
     if not fleet_a or fleet_a.empty or fleet_a_id in universe.destroyedObjectIDs(fo.empireID()):
-        get_aistate().delete_fleet_info(fleet_a_id)
-    get_aistate().update_fleet_rating(fleet_b_id)
+        aistate.delete_fleet_info(fleet_a_id)
+    aistate.update_fleet_rating(fleet_b_id)
 
 
 def fleet_has_ship_with_role(fleet_id, ship_role):
@@ -272,9 +275,10 @@ def fleet_has_ship_with_role(fleet_id, ship_role):
 
     if fleet is None:
         return False
+    aistate = get_aistate()
     for ship_id in fleet.shipIDs:
         ship = universe.getShip(ship_id)
-        if get_aistate().get_ship_role(ship.design.id) == ship_role:
+        if aistate.get_ship_role(ship.design.id) == ship_role:
             return True
     return False
 
@@ -289,10 +293,11 @@ def get_ship_id_with_role(fleet_id, ship_role, verbose=True):
 
     universe = fo.getUniverse()
     fleet = universe.getFleet(fleet_id)
+    aistate = get_aistate()
 
     for ship_id in fleet.shipIDs:
         ship = universe.getShip(ship_id)
-        if get_aistate().get_ship_role(ship.design.id) == ship_role:
+        if aistate.get_ship_role(ship.design.id) == ship_role:
             return ship_id
 
 
@@ -315,8 +320,9 @@ def get_empire_fleet_ids_by_role(fleet_role):
     """Returns a list with fleet_ids that have the specified role."""
     fleet_ids = get_empire_fleet_ids()
     fleet_ids_with_role = []
+    aistate = get_aistate()
     for fleet_id in fleet_ids:
-        if get_aistate().get_fleet_role(fleet_id) != fleet_role:
+        if aistate.get_fleet_role(fleet_id) != fleet_role:
             continue
         fleet_ids_with_role.append(fleet_id)
     return fleet_ids_with_role
@@ -324,7 +330,8 @@ def get_empire_fleet_ids_by_role(fleet_role):
 
 def extract_fleet_ids_without_mission_types(fleets_ids):
     """Extracts a list with fleetIDs that have no mission."""
-    return [fleet_id for fleet_id in fleets_ids if not get_aistate().get_fleet_mission(fleet_id).type]
+    aistate = get_aistate()
+    return [fleet_id for fleet_id in fleets_ids if not aistate.get_fleet_mission(fleet_id).type]
 
 
 def assess_fleet_role(fleet_id):
@@ -340,10 +347,11 @@ def assess_fleet_role(fleet_id):
         return ShipRoleType.INVALID
 
     # count ship_roles
+    aistate = get_aistate()
     for ship_id in fleet.shipIDs:
         ship = universe.getShip(ship_id)
         if ship.design:
-            role = get_aistate().get_ship_role(ship.design.id)
+            role = aistate.get_ship_role(ship.design.id)
         else:
             role = ShipRoleType.INVALID
 
@@ -435,15 +443,16 @@ def generate_fleet_orders_for_fleet_missions():
     print "Securing Fleets: %s  (currently FLEET_MISSION_MILITARY should be used instead of this Role)" % (
         get_empire_fleet_ids_by_role(MissionType.SECURE))
 
+    aistate = get_aistate()
     if fo.currentTurn() < 50:
         print
         print "Explored systems:"
-        _print_systems_and_supply(get_aistate().get_explored_system_ids())
+        _print_systems_and_supply(aistate.get_explored_system_ids())
         print "Unexplored systems:"
-        _print_systems_and_supply(get_aistate().get_unexplored_system_ids())
+        _print_systems_and_supply(aistate.get_unexplored_system_ids())
         print
 
-    exploration_fleet_missions = get_aistate().get_fleet_missions_with_any_mission_types([MissionType.EXPLORATION])
+    exploration_fleet_missions = aistate.get_fleet_missions_with_any_mission_types([MissionType.EXPLORATION])
     if exploration_fleet_missions:
         print "Exploration targets:"
         for explorationAIFleetMission in exploration_fleet_missions:
@@ -451,7 +460,7 @@ def generate_fleet_orders_for_fleet_missions():
     else:
         print "Exploration targets: None"
 
-    colonisation_fleet_missions = get_aistate().get_fleet_missions_with_any_mission_types([MissionType.COLONISATION])
+    colonisation_fleet_missions = aistate.get_fleet_missions_with_any_mission_types([MissionType.COLONISATION])
     if colonisation_fleet_missions:
         print "Colonization targets: "
     else:
@@ -459,7 +468,7 @@ def generate_fleet_orders_for_fleet_missions():
     for colonisation_fleet_mission in colonisation_fleet_missions:
         print "    %s" % colonisation_fleet_mission
 
-    outpost_fleet_missions = get_aistate().get_fleet_missions_with_any_mission_types([MissionType.OUTPOST])
+    outpost_fleet_missions = aistate.get_fleet_missions_with_any_mission_types([MissionType.OUTPOST])
     if outpost_fleet_missions:
         print "Outpost targets: "
     else:
@@ -467,7 +476,7 @@ def generate_fleet_orders_for_fleet_missions():
     for outpost_fleet_mission in outpost_fleet_missions:
         print "    %s" % outpost_fleet_mission
 
-    outpost_base_fleet_missions = get_aistate().get_fleet_missions_with_any_mission_types(
+    outpost_base_fleet_missions = aistate.get_fleet_missions_with_any_mission_types(
         [MissionType.ORBITAL_OUTPOST])
     if outpost_base_fleet_missions:
         print "Outpost Base targets (must have been interrupted by combat): "
@@ -476,7 +485,7 @@ def generate_fleet_orders_for_fleet_missions():
     for outpost_fleet_mission in outpost_base_fleet_missions:
         print "    %s" % outpost_fleet_mission
 
-    invasion_fleet_missions = get_aistate().get_fleet_missions_with_any_mission_types([MissionType.INVASION])
+    invasion_fleet_missions = aistate.get_fleet_missions_with_any_mission_types([MissionType.INVASION])
     if invasion_fleet_missions:
         print "Invasion targets: "
     else:
@@ -484,7 +493,7 @@ def generate_fleet_orders_for_fleet_missions():
     for invasion_fleet_mission in invasion_fleet_missions:
         print "    %s" % invasion_fleet_mission
 
-    troop_base_fleet_missions = get_aistate().get_fleet_missions_with_any_mission_types([MissionType.ORBITAL_INVASION])
+    troop_base_fleet_missions = aistate.get_fleet_missions_with_any_mission_types([MissionType.ORBITAL_INVASION])
     if troop_base_fleet_missions:
         print "Invasion Base targets (must have been interrupted by combat): "
     else:
@@ -492,7 +501,7 @@ def generate_fleet_orders_for_fleet_missions():
     for invasion_fleet_mission in troop_base_fleet_missions:
         print "    %s" % invasion_fleet_mission
 
-    military_fleet_missions = get_aistate().get_fleet_missions_with_any_mission_types([MissionType.MILITARY])
+    military_fleet_missions = aistate.get_fleet_missions_with_any_mission_types([MissionType.MILITARY])
     if military_fleet_missions:
         print "General Military targets: "
     else:
@@ -500,7 +509,7 @@ def generate_fleet_orders_for_fleet_missions():
     for military_fleet_mission in military_fleet_missions:
         print "    %s" % military_fleet_mission
 
-    secure_fleet_missions = get_aistate().get_fleet_missions_with_any_mission_types([MissionType.SECURE])
+    secure_fleet_missions = aistate.get_fleet_missions_with_any_mission_types([MissionType.SECURE])
     if secure_fleet_missions:
         print "Secure targets: "
     else:
@@ -508,7 +517,7 @@ def generate_fleet_orders_for_fleet_missions():
     for secure_fleet_mission in secure_fleet_missions:
         print "    %s" % secure_fleet_mission
 
-    orb_defense_fleet_missions = get_aistate().get_fleet_missions_with_any_mission_types([MissionType.ORBITAL_DEFENSE])
+    orb_defense_fleet_missions = aistate.get_fleet_missions_with_any_mission_types([MissionType.ORBITAL_DEFENSE])
     if orb_defense_fleet_missions:
         print "Orbital Defense targets: "
     else:
@@ -516,7 +525,7 @@ def generate_fleet_orders_for_fleet_missions():
     for orb_defence_fleet_mission in orb_defense_fleet_missions:
         print "    %s" % orb_defence_fleet_mission
 
-    fleet_missions = get_aistate().get_all_fleet_missions()
+    fleet_missions = aistate.get_all_fleet_missions()
 
     for mission in fleet_missions:
         mission.generate_fleet_orders()
@@ -526,7 +535,8 @@ def issue_fleet_orders_for_fleet_missions():
     """Issues fleet orders."""
     print
     universe = fo.getUniverse()
-    fleet_missions = get_aistate().get_all_fleet_missions()
+    aistate = get_aistate()
+    fleet_missions = aistate.get_all_fleet_missions()
     thisround = 0
     while thisround < 3:
         thisround += 1
@@ -538,8 +548,8 @@ def issue_fleet_orders_for_fleet_missions():
             if not fleet or not fleet.shipIDs or fleet_id in universe.destroyedObjectIDs(fo.empireID()):
                 continue
             mission.issue_fleet_orders()
-        fleet_missions = get_aistate().misc.get('ReassignedFleetMissions', [])
-        get_aistate().misc['ReassignedFleetMissions'] = []
+        fleet_missions = aistate.misc.get('ReassignedFleetMissions', [])
+        aistate.misc['ReassignedFleetMissions'] = []
     print
 
 

--- a/default/python/AI/FleetUtilsAI.py
+++ b/default/python/AI/FleetUtilsAI.py
@@ -5,10 +5,10 @@ import freeOrionAIInterface as fo  # pylint: disable=import-error
 
 import AIDependencies
 import CombatRatingsAI
-import FreeOrionAI as foAI
 import MoveUtilsAI
 import universe_object
 from AIDependencies import INVALID_ID
+from aistate_interface import get_aistate
 from EnumsAI import MissionType, ShipRoleType
 from ShipDesignAI import get_part_type
 from universe_object import Planet, Fleet
@@ -59,7 +59,7 @@ def get_targeted_planet_ids(planet_ids, mission_type):
     :return: Subset of *planet_ids* targeted by *mission_type*
     :rtype: list[int]
     """
-    selected_fleet_missions = foAI.foAIstate.get_fleet_missions_with_any_mission_types([mission_type])
+    selected_fleet_missions = get_aistate().get_fleet_missions_with_any_mission_types([mission_type])
     targeted_planets = []
     for planet_id in planet_ids:
         # add planets that are target of a mission
@@ -110,7 +110,7 @@ def get_fleets_for_mission(target_stats, min_stats, cur_stats, starting_system,
         this_system_id = systems_enqueued.pop(0)
         this_system_obj = universe_object.System(this_system_id)
         systems_visited.append(this_system_id)
-        accessible_fleets = foAI.foAIstate.systemStatus.get(this_system_id, {}).get('myFleetsAccessible', [])
+        accessible_fleets = get_aistate().systemStatus.get(this_system_id, {}).get('myFleetsAccessible', [])
         fleets_here = [fid for fid in accessible_fleets if fid in fleet_pool_set]
         # loop over all fleets in the system, split them if possible and select suitable ships
         while fleets_here:
@@ -128,7 +128,7 @@ def get_fleets_for_mission(target_stats, min_stats, cur_stats, starting_system,
             if species:
                 for ship_id in fleet.shipIDs:
                     ship = universe.getShip(ship_id)
-                    if (ship and foAI.foAIstate.get_ship_role(ship.design.id) in colonization_roles and
+                    if (ship and get_aistate().get_ship_role(ship.design.id) in colonization_roles and
                             species == ship.speciesName):
                         break
                 else:  # no suitable species found
@@ -146,7 +146,7 @@ def get_fleets_for_mission(target_stats, min_stats, cur_stats, starting_system,
             # check if we need additional rating vs planets
             this_rating_vs_planets = 0
             if 'ratingVsPlanets' in target_stats:
-                this_rating_vs_planets = foAI.foAIstate.get_rating(fleet_id, against_planets=True)
+                this_rating_vs_planets = get_aistate().get_rating(fleet_id, against_planets=True)
                 if this_rating_vs_planets <= 0 and cur_stats.get('rating', 0) >= target_stats.get('rating', 0):
                     # we already have enough general rating, so do not add any more warships useless against planets
                     continue
@@ -159,7 +159,7 @@ def get_fleets_for_mission(target_stats, min_stats, cur_stats, starting_system,
                 continue
             fleet_list.append(fleet_id)
 
-            this_rating = foAI.foAIstate.get_rating(fleet_id)
+            this_rating = get_aistate().get_rating(fleet_id)
             cur_stats['rating'] = CombatRatingsAI.combine_ratings(cur_stats.get('rating', 0), this_rating)
             if 'ratingVsPlanets' in target_stats:
                 cur_stats['ratingVsPlanets'] = CombatRatingsAI.combine_ratings(cur_stats.get('ratingVsPlanets', 0),
@@ -176,7 +176,7 @@ def get_fleets_for_mission(target_stats, min_stats, cur_stats, starting_system,
             if all((
                     neighbor_id not in systems_visited,
                     neighbor_id not in systems_enqueued,
-                    neighbor_id in foAI.foAIstate.exploredSystemIDs
+                    neighbor_id in get_aistate().exploredSystemIDs
             )):
                 systems_enqueued.append(neighbor_id)
     # we ran out of systems or fleets to check but did not meet requirements yet.
@@ -215,9 +215,9 @@ def split_fleet(fleet_id):
                 warn("Newly split fleet %d not available from universe" % new_fleet_id)
             fo.issueRenameOrder(new_fleet_id, "Fleet %4d" % new_fleet_id)  # to ease review of debugging logs
             fo.issueAggressionOrder(new_fleet_id, True)
-            foAI.foAIstate.update_fleet_rating(new_fleet_id)
+            get_aistate().update_fleet_rating(new_fleet_id)
             newfleets.append(new_fleet_id)
-            foAI.foAIstate.newlySplitFleets[new_fleet_id] = True
+            get_aistate().newlySplitFleets[new_fleet_id] = True
         else:
             if fleet.systemID == INVALID_ID:
                 warn("Tried to split ship id (%d) from fleet %d when fleet is in starlane" % (
@@ -225,10 +225,10 @@ def split_fleet(fleet_id):
             else:
                 warn("Got no fleet ID back after trying to split ship id (%d) from fleet %d" % (
                     ship_id, fleet_id))
-    foAI.foAIstate.get_fleet_role(fleet_id, force_new=True)
-    foAI.foAIstate.update_fleet_rating(fleet_id)
+    get_aistate().get_fleet_role(fleet_id, force_new=True)
+    get_aistate().update_fleet_rating(fleet_id)
     if newfleets:
-        foAI.foAIstate.ensure_have_fleet_missions(newfleets)
+        get_aistate().ensure_have_fleet_missions(newfleets)
     return newfleets
 
 
@@ -261,8 +261,8 @@ def merge_fleet_a_into_b(fleet_a_id, fleet_b_id, leave_rating=0, need_rating=0, 
             break
     fleet_a = universe.getFleet(fleet_a_id)
     if not fleet_a or fleet_a.empty or fleet_a_id in universe.destroyedObjectIDs(fo.empireID()):
-        foAI.foAIstate.delete_fleet_info(fleet_a_id)
-    foAI.foAIstate.update_fleet_rating(fleet_b_id)
+        get_aistate().delete_fleet_info(fleet_a_id)
+    get_aistate().update_fleet_rating(fleet_b_id)
 
 
 def fleet_has_ship_with_role(fleet_id, ship_role):
@@ -274,7 +274,7 @@ def fleet_has_ship_with_role(fleet_id, ship_role):
         return False
     for ship_id in fleet.shipIDs:
         ship = universe.getShip(ship_id)
-        if foAI.foAIstate.get_ship_role(ship.design.id) == ship_role:
+        if get_aistate().get_ship_role(ship.design.id) == ship_role:
             return True
     return False
 
@@ -292,7 +292,7 @@ def get_ship_id_with_role(fleet_id, ship_role, verbose=True):
 
     for ship_id in fleet.shipIDs:
         ship = universe.getShip(ship_id)
-        if foAI.foAIstate.get_ship_role(ship.design.id) == ship_role:
+        if get_aistate().get_ship_role(ship.design.id) == ship_role:
             return ship_id
 
 
@@ -302,7 +302,7 @@ def get_empire_fleet_ids():
     universe = fo.getUniverse()
     empire_fleet_ids = []
     destroyed_object_ids = universe.destroyedObjectIDs(empire_id)
-    for fleet_id in set(list(universe.fleetIDs) + list(foAI.foAIstate.newlySplitFleets)):
+    for fleet_id in set(list(universe.fleetIDs) + list(get_aistate().newlySplitFleets)):
         fleet = universe.getFleet(fleet_id)
         if fleet is None:
             continue
@@ -316,7 +316,7 @@ def get_empire_fleet_ids_by_role(fleet_role):
     fleet_ids = get_empire_fleet_ids()
     fleet_ids_with_role = []
     for fleet_id in fleet_ids:
-        if foAI.foAIstate.get_fleet_role(fleet_id) != fleet_role:
+        if get_aistate().get_fleet_role(fleet_id) != fleet_role:
             continue
         fleet_ids_with_role.append(fleet_id)
     return fleet_ids_with_role
@@ -324,7 +324,7 @@ def get_empire_fleet_ids_by_role(fleet_role):
 
 def extract_fleet_ids_without_mission_types(fleets_ids):
     """Extracts a list with fleetIDs that have no mission."""
-    return [fleet_id for fleet_id in fleets_ids if not foAI.foAIstate.get_fleet_mission(fleet_id).type]
+    return [fleet_id for fleet_id in fleets_ids if not get_aistate().get_fleet_mission(fleet_id).type]
 
 
 def assess_fleet_role(fleet_id):
@@ -343,7 +343,7 @@ def assess_fleet_role(fleet_id):
     for ship_id in fleet.shipIDs:
         ship = universe.getShip(ship_id)
         if ship.design:
-            role = foAI.foAIstate.get_ship_role(ship.design.id)
+            role = get_aistate().get_ship_role(ship.design.id)
         else:
             role = ShipRoleType.INVALID
 
@@ -438,12 +438,12 @@ def generate_fleet_orders_for_fleet_missions():
     if fo.currentTurn() < 50:
         print
         print "Explored systems:"
-        _print_systems_and_supply(foAI.foAIstate.get_explored_system_ids())
+        _print_systems_and_supply(get_aistate().get_explored_system_ids())
         print "Unexplored systems:"
-        _print_systems_and_supply(foAI.foAIstate.get_unexplored_system_ids())
+        _print_systems_and_supply(get_aistate().get_unexplored_system_ids())
         print
 
-    exploration_fleet_missions = foAI.foAIstate.get_fleet_missions_with_any_mission_types([MissionType.EXPLORATION])
+    exploration_fleet_missions = get_aistate().get_fleet_missions_with_any_mission_types([MissionType.EXPLORATION])
     if exploration_fleet_missions:
         print "Exploration targets:"
         for explorationAIFleetMission in exploration_fleet_missions:
@@ -451,7 +451,7 @@ def generate_fleet_orders_for_fleet_missions():
     else:
         print "Exploration targets: None"
 
-    colonisation_fleet_missions = foAI.foAIstate.get_fleet_missions_with_any_mission_types([MissionType.COLONISATION])
+    colonisation_fleet_missions = get_aistate().get_fleet_missions_with_any_mission_types([MissionType.COLONISATION])
     if colonisation_fleet_missions:
         print "Colonization targets: "
     else:
@@ -459,7 +459,7 @@ def generate_fleet_orders_for_fleet_missions():
     for colonisation_fleet_mission in colonisation_fleet_missions:
         print "    %s" % colonisation_fleet_mission
 
-    outpost_fleet_missions = foAI.foAIstate.get_fleet_missions_with_any_mission_types([MissionType.OUTPOST])
+    outpost_fleet_missions = get_aistate().get_fleet_missions_with_any_mission_types([MissionType.OUTPOST])
     if outpost_fleet_missions:
         print "Outpost targets: "
     else:
@@ -467,7 +467,7 @@ def generate_fleet_orders_for_fleet_missions():
     for outpost_fleet_mission in outpost_fleet_missions:
         print "    %s" % outpost_fleet_mission
 
-    outpost_base_fleet_missions = foAI.foAIstate.get_fleet_missions_with_any_mission_types(
+    outpost_base_fleet_missions = get_aistate().get_fleet_missions_with_any_mission_types(
         [MissionType.ORBITAL_OUTPOST])
     if outpost_base_fleet_missions:
         print "Outpost Base targets (must have been interrupted by combat): "
@@ -476,7 +476,7 @@ def generate_fleet_orders_for_fleet_missions():
     for outpost_fleet_mission in outpost_base_fleet_missions:
         print "    %s" % outpost_fleet_mission
 
-    invasion_fleet_missions = foAI.foAIstate.get_fleet_missions_with_any_mission_types([MissionType.INVASION])
+    invasion_fleet_missions = get_aistate().get_fleet_missions_with_any_mission_types([MissionType.INVASION])
     if invasion_fleet_missions:
         print "Invasion targets: "
     else:
@@ -484,7 +484,7 @@ def generate_fleet_orders_for_fleet_missions():
     for invasion_fleet_mission in invasion_fleet_missions:
         print "    %s" % invasion_fleet_mission
 
-    troop_base_fleet_missions = foAI.foAIstate.get_fleet_missions_with_any_mission_types([MissionType.ORBITAL_INVASION])
+    troop_base_fleet_missions = get_aistate().get_fleet_missions_with_any_mission_types([MissionType.ORBITAL_INVASION])
     if troop_base_fleet_missions:
         print "Invasion Base targets (must have been interrupted by combat): "
     else:
@@ -492,7 +492,7 @@ def generate_fleet_orders_for_fleet_missions():
     for invasion_fleet_mission in troop_base_fleet_missions:
         print "    %s" % invasion_fleet_mission
 
-    military_fleet_missions = foAI.foAIstate.get_fleet_missions_with_any_mission_types([MissionType.MILITARY])
+    military_fleet_missions = get_aistate().get_fleet_missions_with_any_mission_types([MissionType.MILITARY])
     if military_fleet_missions:
         print "General Military targets: "
     else:
@@ -500,7 +500,7 @@ def generate_fleet_orders_for_fleet_missions():
     for military_fleet_mission in military_fleet_missions:
         print "    %s" % military_fleet_mission
 
-    secure_fleet_missions = foAI.foAIstate.get_fleet_missions_with_any_mission_types([MissionType.SECURE])
+    secure_fleet_missions = get_aistate().get_fleet_missions_with_any_mission_types([MissionType.SECURE])
     if secure_fleet_missions:
         print "Secure targets: "
     else:
@@ -508,7 +508,7 @@ def generate_fleet_orders_for_fleet_missions():
     for secure_fleet_mission in secure_fleet_missions:
         print "    %s" % secure_fleet_mission
 
-    orb_defense_fleet_missions = foAI.foAIstate.get_fleet_missions_with_any_mission_types([MissionType.ORBITAL_DEFENSE])
+    orb_defense_fleet_missions = get_aistate().get_fleet_missions_with_any_mission_types([MissionType.ORBITAL_DEFENSE])
     if orb_defense_fleet_missions:
         print "Orbital Defense targets: "
     else:
@@ -516,7 +516,7 @@ def generate_fleet_orders_for_fleet_missions():
     for orb_defence_fleet_mission in orb_defense_fleet_missions:
         print "    %s" % orb_defence_fleet_mission
 
-    fleet_missions = foAI.foAIstate.get_all_fleet_missions()
+    fleet_missions = get_aistate().get_all_fleet_missions()
 
     for mission in fleet_missions:
         mission.generate_fleet_orders()
@@ -526,7 +526,7 @@ def issue_fleet_orders_for_fleet_missions():
     """Issues fleet orders."""
     print
     universe = fo.getUniverse()
-    fleet_missions = foAI.foAIstate.get_all_fleet_missions()
+    fleet_missions = get_aistate().get_all_fleet_missions()
     thisround = 0
     while thisround < 3:
         thisround += 1
@@ -538,8 +538,8 @@ def issue_fleet_orders_for_fleet_missions():
             if not fleet or not fleet.shipIDs or fleet_id in universe.destroyedObjectIDs(fo.empireID()):
                 continue
             mission.issue_fleet_orders()
-        fleet_missions = foAI.foAIstate.misc.get('ReassignedFleetMissions', [])
-        foAI.foAIstate.misc['ReassignedFleetMissions'] = []
+        fleet_missions = get_aistate().misc.get('ReassignedFleetMissions', [])
+        get_aistate().misc['ReassignedFleetMissions'] = []
     print
 
 
@@ -605,7 +605,7 @@ def get_max_fuel(fleet_id):
 
 def get_fleet_upkeep():
     # TODO: Use new upkeep calculation
-    return 1 + AIDependencies.SHIP_UPKEEP * foAI.foAIstate.shipCount
+    return 1 + AIDependencies.SHIP_UPKEEP * get_aistate().shipCount
 
 
 def calculate_estimated_time_of_arrival(fleet_id, target_system_id):

--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -19,7 +19,6 @@ parse_config(fo.getOptionsDBOptionStr("ai-config"), fo.getUserConfigDir())
 from freeorion_tools import patch_interface
 patch_interface()
 
-import AIstate
 import ColonisationAI
 import ExplorationAI
 import DiplomaticCorp
@@ -33,6 +32,7 @@ import ResearchAI
 import ResourcesAI
 import TechsListsAI
 import turn_state
+from aistate_interface import create_new_aistate, load_aistate, get_aistate
 from AIDependencies import INVALID_ID
 from freeorion_tools import handle_debug_chat, AITimer, init_handlers
 from common.listeners import listener
@@ -56,14 +56,6 @@ debug("Path to folder for user specific data: %s" % user_dir)
 debug('Python paths %s' % sys.path)
 
 
-# Mock to have proper inspection and autocomplete for this variable
-class AIStateMock(AIstate.AIstate):
-    def __init__(self):
-        pass
-
-
-# AIstate
-foAIstate = AIStateMock()
 diplomatic_corp = None
 
 
@@ -82,20 +74,19 @@ def startNewGame(aggression_input=fo.aggression.aggressive):  # pylint: disable=
     turn_timer.start("Server Processing")
 
     # initialize AIstate
-    global foAIstate
-    debug("Initializing foAIstate...")
-    foAIstate = AIstate.AIstate(aggression_input)
-    aggression_trait = foAIstate.character.get_trait(Aggression)
+    debug("Initializing AI state...")
+    create_new_aistate(aggression_input)
+    aggression_trait = get_aistate().character.get_trait(Aggression)
     debug("New game started, AI Aggression level %d (%s)" % (
-        aggression_trait.key, get_trait_name_aggression(foAIstate.character)))
-    foAIstate.session_start_cleanup()
-    debug("Initialization of foAIstate complete!")
+        aggression_trait.key, get_trait_name_aggression(get_aistate().character)))
+    get_aistate().session_start_cleanup()
+    debug("Initialization of AI state complete!")
     debug("Trying to rename our homeworld...")
     planet_id = PlanetUtilsAI.get_capital()
     universe = fo.getUniverse()
     if planet_id is not None and planet_id != INVALID_ID:
         planet = universe.getPlanet(planet_id)
-        new_name = " ".join([random.choice(possible_capitals(foAIstate.character)).strip(), planet.name])
+        new_name = " ".join([random.choice(possible_capitals(get_aistate().character)).strip(), planet.name])
         debug("    Renaming to %s..." % new_name)
         res = fo.issueRenameOrder(planet_id, new_name)
         debug("    Result: %d; Planet is now named %s" % (res, planet.name))
@@ -118,29 +109,27 @@ def resumeLoadedGame(saved_state_string):  # pylint: disable=invalid-name
         return
     turn_timer.start("Server Processing")
 
-    global foAIstate
     print "Resuming loaded game"
     if not saved_state_string:
         error("AI given empty state-string to resume from; this is expected if the AI is assigned to an empire "
               "previously run by a human, but is otherwise an error. AI will be set to Aggressive.")
-        foAIstate = AIstate.AIstate(fo.aggression.aggressive)
-        foAIstate.session_start_cleanup()
+        create_new_aistate(fo.aggression.aggressive)
+        get_aistate().session_start_cleanup()
     else:
-        import savegame_codec
         try:
             # loading saved state
-            foAIstate = savegame_codec.load_savegame_string(saved_state_string)
+            load_aistate(saved_state_string)
         except Exception as e:
             # assigning new state
-            foAIstate = AIstate.AIstate(fo.aggression.aggressive)
-            foAIstate.session_start_cleanup()
+            create_new_aistate(fo.aggression.aggressive)
+            get_aistate().session_start_cleanup()
             error("Failed to load the AIstate from the savegame. The AI will"
                   " play with a fresh AIstate instance with aggression level set"
                   " to 'aggressive'. The behaviour of the AI may be different"
                   " than in the original session. The error raised was: %s"
                   % e, exc_info=True)
 
-    aggression_trait = foAIstate.character.get_trait(Aggression)
+    aggression_trait = get_aistate().character.get_trait(Aggression)
     diplomatic_corp_configs = {fo.aggression.beginner: DiplomaticCorp.BeginnerDiplomaticCorp,
                                fo.aggression.maniacal: DiplomaticCorp.ManiacalDiplomaticCorp}
     global diplomatic_corp
@@ -272,9 +261,9 @@ def generateOrders():  # pylint: disable=invalid-name
     fo.updateResourcePools()
 
     turn = fo.currentTurn()
-    turn_uid = foAIstate.set_turn_uid()
+    turn_uid = get_aistate().set_turn_uid()
     debug("\n\n\n" + "=" * 20)
-    debug("Starting turn %s (%s) of game: %s" % (turn, turn_uid, foAIstate.uid))
+    debug("Starting turn %s (%s) of game: %s" % (turn, turn_uid, get_aistate().uid))
     debug("=" * 20 + "\n")
 
     turn_timer.start("AI planning")
@@ -289,7 +278,7 @@ def generateOrders():  # pylint: disable=invalid-name
     planet = None
     if planet_id is not None:
         planet = universe.getPlanet(planet_id)
-    aggression_name = get_trait_name_aggression(foAIstate.character)
+    aggression_name = get_trait_name_aggression(get_aistate().character)
     print "***************************************************************************"
     print "*******  Log info for AI progress chart script. Do not modify.   **********"
     print ("Generating Orders")
@@ -313,7 +302,7 @@ def generateOrders():  # pylint: disable=invalid-name
     # new orders after a game load. Note that the orders from the original savegame are
     # still being issued and the AIstate was saved after those orders were issued.
     # TODO: Consider adding an option to clear AI orders after load (must save AIstate at turn start then)
-    if fo.currentTurn() == foAIstate.last_turn_played:
+    if fo.currentTurn() == get_aistate().last_turn_played:
         info("The AIstate indicates that this turn was already played.")
         if not check_bool(get_option_dict().get('replay_turn_after_load', 'False')):
             info("Aborting new order generation. Orders from savegame will still be issued.")
@@ -329,9 +318,9 @@ def generateOrders():  # pylint: disable=invalid-name
         human_player = fo.empirePlayerID(1)
         greet = diplomatic_corp.get_first_turn_greet_message()
         fo.sendChatMessage(human_player,
-                           '%s (%s): [[%s]]' % (empire.name, get_trait_name_aggression(foAIstate.character), greet))
+                           '%s (%s): [[%s]]' % (empire.name, get_trait_name_aggression(get_aistate().character), greet))
 
-    foAIstate.prepare_for_new_turn()
+    get_aistate().prepare_for_new_turn()
     turn_state.state.update()
     debug("Calling AI Modules")
     # call AI modules
@@ -368,7 +357,7 @@ def generateOrders():  # pylint: disable=invalid-name
     except Exception as e:
         error("Exception %s while trying doneTurn()" % e, exc_info=True)  # TODO move it to cycle above
     finally:
-        foAIstate.last_turn_played = fo.currentTurn()
+        get_aistate().last_turn_played = fo.currentTurn()
 
     if using_statprof:
         try:

--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -3,13 +3,13 @@ from logging import debug, info, warn
 
 import freeOrionAIInterface as fo
 
+from aistate_interface import get_aistate
 import AIDependencies
 import AIstate
 import ColonisationAI
 import CombatRatingsAI
 import EspionageAI
 import FleetUtilsAI
-import FreeOrionAI as foAI
 import MilitaryAI
 import PlanetUtilsAI
 import ProductionAI
@@ -35,7 +35,7 @@ def get_invasion_fleets():
     empire_id = fo.empireID()
 
     home_system_id = PlanetUtilsAI.get_capital_sys_id()
-    visible_system_ids = list(foAI.foAIstate.visInteriorSystemIDs) + list(foAI.foAIstate.visBorderSystemIDs)
+    visible_system_ids = list(get_aistate().visInteriorSystemIDs) + list(get_aistate().visBorderSystemIDs)
 
     if home_system_id != INVALID_ID:
         accessible_system_ids = [sys_id for sys_id in visible_system_ids if
@@ -67,7 +67,7 @@ def get_invasion_fleets():
 
     invasion_timer.start("planning troop base production")
     reserved_troop_base_targets = []
-    if foAI.foAIstate.character.may_invade_with_bases():
+    if get_aistate().character.may_invade_with_bases():
         available_pp = {}
         for el in empire.planetsWithAvailablePP:  # keys are sets of ints; data is doubles
             avail_pp = el.data()
@@ -84,7 +84,7 @@ def get_invasion_fleets():
         # we lost our base trooper source planet since it was first added to list).
         #
         # For planning and tracking base troopers under construction, we use a dictionary store in
-        # foAI.foAIstate.qualifyingTroopBaseTargets, keyed by the invasion target planet ID.  We only store values
+        # get_aistate().qualifyingTroopBaseTargets, keyed by the invasion target planet ID.  We only store values
         # for invasion targets that appear likely to be suitable for base trooper use, and store a 2-item list.
         # The first item in this list is the ID of the planet where we expect to build the base troopers, and the second
         # entry initially is set to INVALID_ID (-1).  The presence of this entry in qualifyingTroopBaseTargets
@@ -94,13 +94,12 @@ def get_invasion_fleets():
         # same as the source planet originally identified, but we could consider reevaluating that, or use that second
         # value to instead record how many base troopers have been queued, so that on later turns we can assess if the
         # process got delayed & perhaps more troopers need to be queued).
-
-        secure_ai_fleet_missions = foAI.foAIstate.get_fleet_missions_with_any_mission_types([MissionType.SECURE,
-                                                                                             MissionType.MILITARY])
+        secure_ai_fleet_missions = get_aistate().get_fleet_missions_with_any_mission_types([MissionType.SECURE,
+                                                                                            MissionType.MILITARY])
 
         # Pass 1: identify qualifying base troop invasion targets
         for pid in invadable_planet_ids:  # TODO: reorganize
-            if pid in foAI.foAIstate.qualifyingTroopBaseTargets:
+            if pid in get_aistate().qualifyingTroopBaseTargets:
                 continue
             planet = universe.getPlanet(pid)
             if not planet:
@@ -131,19 +130,19 @@ def get_invasion_fleets():
                     best_base_planet = pid2
                     best_trooper_count = troops_per_ship
             if best_base_planet != INVALID_ID:
-                foAI.foAIstate.qualifyingTroopBaseTargets.setdefault(pid, [best_base_planet, INVALID_ID])
+                get_aistate().qualifyingTroopBaseTargets.setdefault(pid, [best_base_planet, INVALID_ID])
 
         # Pass 2: for each target previously identified for base troopers, check that still qualifies and
         # check how many base troopers would be needed; if reasonable then queue up the troops and record this in
-        # foAI.foAIstate.qualifyingTroopBaseTargets
-        for pid in foAI.foAIstate.qualifyingTroopBaseTargets.keys():
+        # get_aistate().qualifyingTroopBaseTargets
+        for pid in get_aistate().qualifyingTroopBaseTargets.keys():
             planet = universe.getPlanet(pid)
             if planet and planet.owner == empire_id:
-                del foAI.foAIstate.qualifyingTroopBaseTargets[pid]
+                del get_aistate().qualifyingTroopBaseTargets[pid]
                 continue
             if pid in invasion_targeted_planet_ids:  # TODO: consider overriding standard invasion mission
                 continue
-            if foAI.foAIstate.qualifyingTroopBaseTargets[pid][1] != -1:
+            if get_aistate().qualifyingTroopBaseTargets[pid][1] != -1:
                 reserved_troop_base_targets.append(pid)
                 if planet:
                     all_invasion_targeted_system_ids.add(planet.systemID)
@@ -151,12 +150,12 @@ def get_invasion_fleets():
                 continue  # already building for here
             _, planet_troops = evaluate_invasion_planet(pid, secure_ai_fleet_missions, True)
             sys_id = planet.systemID
-            this_sys_status = foAI.foAIstate.systemStatus.get(sys_id, {})
+            this_sys_status = get_aistate().systemStatus.get(sys_id, {})
             troop_tally = 0
             for _fid in this_sys_status.get('myfleets', []):
                 troop_tally += FleetUtilsAI.count_troops_in_fleet(_fid)
             if troop_tally > planet_troops:  # base troopers appear unneeded
-                del foAI.foAIstate.qualifyingTroopBaseTargets[pid]
+                del get_aistate().qualifyingTroopBaseTargets[pid]
                 continue
             if (planet.currentMeterValue(fo.meterType.shield) > 0 and
                     (this_sys_status.get('myFleetRating', 0) < 0.8 * this_sys_status.get('totalThreat', 0) or
@@ -164,7 +163,7 @@ def get_invasion_fleets():
                 # this system not secured, so ruling out invasion base troops for now
                 # don't immediately delete from qualifyingTroopBaseTargets or it will be opened up for regular troops
                 continue
-            loc = foAI.foAIstate.qualifyingTroopBaseTargets[pid][0]
+            loc = get_aistate().qualifyingTroopBaseTargets[pid][0]
             best_base_trooper_here = ProductionAI.get_best_ship_info(PriorityType.PRODUCTION_ORBITAL_INVASION, loc)[1]
             loc_planet = universe.getPlanet(loc)
             if best_base_trooper_here is None:  # shouldn't be possible at this point, but just to be safe
@@ -193,7 +192,7 @@ def get_invasion_fleets():
             if (n_bases > MAX_BASE_TROOPERS_POOR_INVADERS or
                     (troops_per_ship > 1 and n_bases > MAX_BASE_TROOPERS_GOOD_INVADERS)):
                 print "ruling out base invasion troopers for %s due to high number (%d) required." % (planet, n_bases)
-                del foAI.foAIstate.qualifyingTroopBaseTargets[pid]
+                del get_aistate().qualifyingTroopBaseTargets[pid]
                 continue
             print "Invasion base planning, need %d troops at %d pership, will build %d ships." % (
                 (planet_troops + 1), troops_per_ship, n_bases)
@@ -203,7 +202,7 @@ def get_invasion_fleets():
             if retval != 0:
                 all_invasion_targeted_system_ids.add(planet.systemID)
                 reserved_troop_base_targets.append(pid)
-                foAI.foAIstate.qualifyingTroopBaseTargets[pid][1] = loc
+                get_aistate().qualifyingTroopBaseTargets[pid][1] = loc
                 fo.issueChangeProductionQuantityOrder(empire.productionQueue.size - 1, 1, int(n_bases))
                 fo.issueRequeueProductionOrder(empire.productionQueue.size - 1, 0)
 
@@ -242,7 +241,7 @@ def get_invasion_fleets():
 
 
 def get_invasion_targeted_planet_ids(planet_ids, mission_type):
-    invasion_feet_missions = foAI.foAIstate.get_fleet_missions_with_any_mission_types([mission_type])
+    invasion_feet_missions = get_aistate().get_fleet_missions_with_any_mission_types([mission_type])
     targeted_planets = []
     for pid in planet_ids:
         # add planets that are target of a mission
@@ -269,8 +268,8 @@ def assign_invasion_values(planet_ids):
     neighbor_values = {}
     neighbor_val_ratio = .95
     universe = fo.getUniverse()
-    secure_missions = foAI.foAIstate.get_fleet_missions_with_any_mission_types([MissionType.SECURE,
-                                                                                MissionType.MILITARY])
+    secure_missions = get_aistate().get_fleet_missions_with_any_mission_types([MissionType.SECURE,
+                                                                               MissionType.MILITARY])
     for pid in planet_ids:
         planet_values[pid] = neighbor_values.setdefault(pid, evaluate_invasion_planet(pid, secure_missions))
         print "planet %d, values %s" % (pid, planet_values[pid])
@@ -400,14 +399,14 @@ def evaluate_invasion_planet(planet_id, secure_fleet_missions, verbose=True):
         if homeworld and homeworld.systemID != INVALID_ID and system_id != INVALID_ID:
             least_jumps_path = list(universe.leastJumpsPath(homeworld.systemID, system_id, empire_id))
             max_jumps = len(least_jumps_path)
-    system_status = foAI.foAIstate.systemStatus.get(system_id, {})
+    system_status = get_aistate().systemStatus.get(system_id, {})
     system_fleet_treat = system_status.get('fleetThreat', 1000)
     system_monster_threat = system_status.get('monsterThreat', 0)
     sys_total_threat = system_fleet_treat + system_monster_threat + system_status.get('planetThreat', 0)
     max_path_threat = system_fleet_treat
     mil_ship_rating = MilitaryAI.cur_best_mil_ship_rating()
     for path_sys_id in least_jumps_path:
-        path_leg_status = foAI.foAIstate.systemStatus.get(path_sys_id, {})
+        path_leg_status = get_aistate().systemStatus.get(path_sys_id, {})
         path_leg_threat = path_leg_status.get('fleetThreat', 1000) + path_leg_status.get('monsterThreat', 0)
         if path_leg_threat > 0.5 * mil_ship_rating:
             clear_path = False
@@ -542,7 +541,7 @@ def send_invasion_fleets(fleet_ids, evaluated_planets, mission_type):
         target = universe_object.Planet(planet_id)
         print "assigning invasion fleets %s to target %s" % (these_fleets, target)
         for fleetID in these_fleets:
-            fleet_mission = foAI.foAIstate.get_fleet_mission(fleetID)
+            fleet_mission = get_aistate().get_fleet_mission(fleetID)
             fleet_mission.clear_fleet_orders()
             fleet_mission.clear_target()
             fleet_mission.set_target(mission_type, target)
@@ -562,15 +561,15 @@ def assign_invasion_bases():
             continue
         sys_id = fleet.systemID
         system = universe.getSystem(sys_id)
-        available_planets = set(system.planetIDs).intersection(set(foAI.foAIstate.qualifyingTroopBaseTargets.keys()))
+        available_planets = set(system.planetIDs).intersection(set(get_aistate().qualifyingTroopBaseTargets.keys()))
         print "Considering Base Troopers in %s, found planets %s and registered targets %s with status %s" % (
             system.name, list(system.planetIDs), available_planets,
-            [(pid, foAI.foAIstate.qualifyingTroopBaseTargets[pid]) for pid in available_planets])
-        targets = [pid for pid in available_planets if foAI.foAIstate.qualifyingTroopBaseTargets[pid][1] != -1]
+            [(pid, get_aistate().qualifyingTroopBaseTargets[pid]) for pid in available_planets])
+        targets = [pid for pid in available_planets if get_aistate().qualifyingTroopBaseTargets[pid][1] != -1]
         if not targets:
             print "Failure: found no valid target for troop base in system %s" % system
             continue
-        status = foAI.foAIstate.systemStatus.get(sys_id, {})
+        status = get_aistate().systemStatus.get(sys_id, {})
         local_base_troops = set(status.get('myfleets', [])).intersection(available_troopbase_fleet_ids)
 
         target_id = INVALID_ID
@@ -597,9 +596,9 @@ def assign_invasion_bases():
             FleetUtilsAI.merge_fleet_a_into_b(fid2, fid)
             available_troopbase_fleet_ids.discard(fid2)
         available_troopbase_fleet_ids.discard(fid)
-        foAI.foAIstate.qualifyingTroopBaseTargets[target_id][1] = -1  # TODO: should probably delete
+        get_aistate().qualifyingTroopBaseTargets[target_id][1] = -1  # TODO: should probably delete
         target = universe_object.Planet(target_id)
-        fleet_mission = foAI.foAIstate.get_fleet_mission(fid)
+        fleet_mission = get_aistate().get_fleet_mission(fid)
         fleet_mission.set_target(MissionType.ORBITAL_INVASION, target)
 
 
@@ -613,5 +612,5 @@ def assign_invasion_fleets_to_invade():
     send_invasion_fleets(invasion_fleet_ids, AIstate.invasionTargets, MissionType.INVASION)
     all_invasion_fleet_ids = FleetUtilsAI.get_empire_fleet_ids_by_role(MissionType.INVASION)
     for fid in FleetUtilsAI.extract_fleet_ids_without_mission_types(all_invasion_fleet_ids):
-        this_mission = foAI.foAIstate.get_fleet_mission(fid)
+        this_mission = get_aistate().get_fleet_mission(fid)
         this_mission.check_mergers(context="Post-send consolidation of unassigned troops")

--- a/default/python/AI/MilitaryAI.py
+++ b/default/python/AI/MilitaryAI.py
@@ -1,16 +1,15 @@
 import freeOrionAIInterface as fo  # pylint: disable=import-error
-
 import AIstate
 import CombatRatingsAI
 import EspionageAI
 import FleetUtilsAI
-import FreeOrionAI as foAI
 import InvasionAI
 import PlanetUtilsAI
 import PriorityAI
 import ProductionAI
 import universe_object
 from AIDependencies import INVALID_ID
+from aistate_interface import get_aistate
 from CombatRatingsAI import combine_ratings, combine_ratings_list, rating_difference
 from EnumsAI import MissionType
 from freeorion_tools import cache_by_turn
@@ -40,7 +39,7 @@ def cur_best_mil_ship_rating(include_designs=False):
     for fleet_id in FleetUtilsAI.get_empire_fleet_ids_by_role(MissionType.MILITARY):
         fleet = universe.getFleet(fleet_id)
         for ship_id in fleet.shipIDs:
-            ship_rating = CombatRatingsAI.ShipCombatStats(ship_id).get_rating(enemy_stats=foAI.foAIstate.get_standard_enemy())
+            ship_rating = CombatRatingsAI.ShipCombatStats(ship_id).get_rating(enemy_stats=get_aistate().get_standard_enemy())
             best_rating = max(best_rating, ship_rating)
     _best_ship_rating_cache[current_turn] = best_rating
     if include_designs:
@@ -91,7 +90,7 @@ def get_preferred_max_military_portion_for_single_battle():
 def try_again(mil_fleet_ids, try_reset=False, thisround=""):
     """Clear targets and orders for all specified fleets then call get_military_fleets again."""
     for fid in mil_fleet_ids:
-        mission = foAI.foAIstate.get_fleet_mission(fid)
+        mission = get_aistate().get_fleet_mission(fid)
         mission.clear_fleet_orders()
         mission.clear_target()
     get_military_fleets(try_reset=try_reset, thisround=thisround)
@@ -117,7 +116,7 @@ def avail_mil_needing_repair(mil_fleet_ids, split_ships=False, on_mission=False,
             ships_max_health[ship_ok] += max_struc
         this_sys_id = fleet.systemID if fleet.nextSystemID == INVALID_ID else fleet.nextSystemID
         fleet_ok = (sum(ships_cur_health) >= cutoff * sum(ships_max_health))
-        local_status = foAI.foAIstate.systemStatus.get(this_sys_id, {})
+        local_status = get_aistate().systemStatus.get(this_sys_id, {})
         my_local_rating = combine_ratings(local_status.get('mydefenses', {}).get('overall', 0), local_status.get('myFleetRating', 0))
         my_local_rating_vs_planets = local_status.get('myFleetRatingVsPlanets', 0)
         combat_trigger = bool(local_status.get('fleetThreat', 0) or local_status.get('monsterThreat', 0))
@@ -164,7 +163,7 @@ class AllocationHelper(object):
         self._remaining_rating = available_rating
 
         self.threat_bias = 0.
-        self.safety_factor = foAI.foAIstate.character.military_safety_factor()
+        self.safety_factor = get_aistate().character.military_safety_factor()
 
         self.already_assigned_rating = dict(already_assigned_rating)
         self.already_assigned_rating_vs_planets = dict(already_assigned_rating_vs_planets)
@@ -399,7 +398,7 @@ class Allocator(object):
         return get_system_planetary_threat(self.sys_id)
 
     def _enemy_ship_count(self):
-        return foAI.foAIstate.systemStatus.get(self.sys_id, {}).get('enemy_ship_count', 0.)
+        return get_aistate().systemStatus.get(self.sys_id, {}).get('enemy_ship_count', 0.)
 
 
 class CapitalDefenseAllocator(Allocator):
@@ -525,7 +524,7 @@ class LocalThreatAllocator(Allocator):
 
     def _calculate_threat(self):
 
-        systems_status = foAI.foAIstate.systemStatus.get(self.sys_id, {})
+        systems_status = get_aistate().systemStatus.get(self.sys_id, {})
         threat = self.safety_factor * CombatRatingsAI.combine_ratings(systems_status.get('fleetThreat', 0),
                                                                       systems_status.get('monsterThreat', 0) +
                                                                       + systems_status.get('planetThreat', 0))
@@ -580,40 +579,40 @@ class ReleaseMilitaryException(Exception):
 
 # TODO: May want to move these functions into AIstate class
 def get_system_local_threat(sys_id):
-    return foAI.foAIstate.systemStatus.get(sys_id, {}).get('totalThreat', 0.)
+    return get_aistate().systemStatus.get(sys_id, {}).get('totalThreat', 0.)
 
 
 def get_system_jump2_threat(sys_id):
-    return foAI.foAIstate.systemStatus.get(sys_id, {}).get('jump2_threat', 0.)
+    return get_aistate().systemStatus.get(sys_id, {}).get('jump2_threat', 0.)
 
 
 def get_system_neighbor_support(sys_id):
-    return foAI.foAIstate.systemStatus.get(sys_id, {}).get('my_neighbor_rating', 0.)
+    return get_aistate().systemStatus.get(sys_id, {}).get('my_neighbor_rating', 0.)
 
 
 def get_system_neighbor_threat(sys_id):
-    return foAI.foAIstate.systemStatus.get(sys_id, {}).get('neighborThreat', 0.)
+    return get_aistate().systemStatus.get(sys_id, {}).get('neighborThreat', 0.)
 
 
 def get_system_regional_threat(sys_id):
-    return foAI.foAIstate.systemStatus.get(sys_id, {}).get('regional_threat', 0.)
+    return get_aistate().systemStatus.get(sys_id, {}).get('regional_threat', 0.)
 
 
 def get_system_planetary_threat(sys_id):
-    return foAI.foAIstate.systemStatus.get(sys_id, {}).get('planetThreat', 0.)
+    return get_aistate().systemStatus.get(sys_id, {}).get('planetThreat', 0.)
 
 
 def enemy_rating():
     """:rtype: float"""
-    return foAI.foAIstate.empire_standard_enemy_rating
+    return get_aistate().empire_standard_enemy_rating
 
 
 def get_my_defense_rating_in_system(sys_id):
-    return foAI.foAIstate.systemStatus.get(sys_id, {}).get('mydefenses', {}).get('overall')
+    return get_aistate().systemStatus.get(sys_id, {}).get('mydefenses', {}).get('overall')
 
 
 def enemies_nearly_supplying_system(sys_id):
-    return foAI.foAIstate.systemStatus.get(sys_id, {}).get('enemies_nearly_supplied', [])
+    return get_aistate().systemStatus.get(sys_id, {}).get('enemies_nearly_supplied', [])
 
 
 def get_military_fleets(mil_fleets_ids=None, try_reset=True, thisround="Main"):
@@ -643,14 +642,14 @@ def get_military_fleets(mil_fleets_ids=None, try_reset=True, thisround="Main"):
     # for each system, get total rating of fleets assigned to it
     already_assigned_rating = {}
     already_assigned_rating_vs_planets = {}
-    systems_status = foAI.foAIstate.systemStatus
+    systems_status = get_aistate().systemStatus
     enemy_sup_factor = {}  # enemy supply
     for sys_id in universe.systemIDs:
         already_assigned_rating[sys_id] = 0
         already_assigned_rating_vs_planets[sys_id] = 0
         enemy_sup_factor[sys_id] = min(2, len(systems_status.get(sys_id, {}).get('enemies_nearly_supplied', [])))
     for fleet_id in [fid for fid in all_military_fleet_ids if fid not in mil_fleets_ids]:
-        ai_fleet_mission = foAI.foAIstate.get_fleet_mission(fleet_id)
+        ai_fleet_mission = get_aistate().get_fleet_mission(fleet_id)
         if not ai_fleet_mission.target:  # shouldn't really be possible
             continue
         last_sys = ai_fleet_mission.target.get_system().id  # will count this fleet as assigned to last system in target list  # TODO last_sys or target sys?
@@ -680,7 +679,7 @@ def get_military_fleets(mil_fleets_ids=None, try_reset=True, thisround="Main"):
         capital_sys_id = None  # unless we can find one to use
         system_dict = {}
         for fleet_id in all_military_fleet_ids:
-            status = foAI.foAIstate.fleetStatus.get(fleet_id, None)
+            status = get_aistate().fleetStatus.get(fleet_id, None)
             if status is not None:
                 system_id = status['sysID']
                 if not list(universe.getSystem(system_id).planetIDs):
@@ -691,23 +690,24 @@ def get_military_fleets(mil_fleets_ids=None, try_reset=True, thisround="Main"):
             capital_sys_id = ranked_systems[-1][-1]
         else:
             try:
-                capital_sys_id = foAI.foAIstate.fleetStatus.items()[0][1]['sysID']
+                capital_sys_id = get_aistate().fleetStatus.items()[0][1]['sysID']
             except:
                 pass
 
     num_targets = max(10, PriorityAI.allotted_outpost_targets)
     top_target_planets = ([pid for pid, pscore, trp in AIstate.invasionTargets[:PriorityAI.allotted_invasion_targets()]
                            if pscore > InvasionAI.MIN_INVASION_SCORE] +
-                          [pid for pid, (pscore, spec) in foAI.foAIstate.colonisableOutpostIDs.items()[:num_targets]
+                          [pid for pid, (pscore, spec) in get_aistate().colonisableOutpostIDs.items()[:num_targets]
                            if pscore > InvasionAI.MIN_INVASION_SCORE] +
-                          [pid for pid, (pscore, spec) in foAI.foAIstate.colonisablePlanetIDs.items()[:num_targets]
+                          [pid for pid, (pscore, spec) in get_aistate().colonisablePlanetIDs.items()[:num_targets]
                            if pscore > InvasionAI.MIN_INVASION_SCORE])
-    top_target_planets.extend(foAI.foAIstate.qualifyingTroopBaseTargets.keys())
+    top_target_planets.extend(get_aistate().qualifyingTroopBaseTargets.keys())
+
     base_col_target_systems = PlanetUtilsAI.get_systems(top_target_planets)
     top_target_systems = []
     for sys_id in AIstate.invasionTargetedSystemIDs + base_col_target_systems:
         if sys_id not in top_target_systems:
-            if foAI.foAIstate.systemStatus[sys_id]['totalThreat'] > get_tot_mil_rating():
+            if get_aistate().systemStatus[sys_id]['totalThreat'] > get_tot_mil_rating():
                 continue
             top_target_systems.append(sys_id)  # doing this rather than set, to preserve order
 
@@ -754,7 +754,7 @@ def get_military_fleets(mil_fleets_ids=None, try_reset=True, thisround="Main"):
         # TODO Exploration targets
 
         # border protections
-        visible_system_ids = foAI.foAIstate.visInteriorSystemIDs | foAI.foAIstate.visBorderSystemIDs
+        visible_system_ids = get_aistate().visInteriorSystemIDs | get_aistate().visBorderSystemIDs
         accessible_system_ids = ([sys_id for sys_id in visible_system_ids if
                                  universe.systemsConnected(sys_id, home_system_id, empire_id)]
                                  if home_system_id != INVALID_ID else [])
@@ -819,7 +819,7 @@ def assign_military_fleets_to_systems(use_fleet_id_list=None, allocations=None, 
 
     doing_main = (use_fleet_id_list is None)
     if doing_main:
-        foAI.foAIstate.misc['ReassignedFleetMissions'] = []
+        get_aistate().misc['ReassignedFleetMissions'] = []
         base_defense_ids = FleetUtilsAI.get_empire_fleet_ids_by_role(MissionType.ORBITAL_DEFENSE)
         unassigned_base_defense_ids = FleetUtilsAI.extract_fleet_ids_without_mission_types(base_defense_ids)
         for fleet_id in unassigned_base_defense_ids:
@@ -828,7 +828,7 @@ def assign_military_fleets_to_systems(use_fleet_id_list=None, allocations=None, 
                 continue
             sys_id = fleet.systemID
             target = universe_object.System(sys_id)
-            fleet_mission = foAI.foAIstate.get_fleet_mission(fleet_id)
+            fleet_mission = get_aistate().get_fleet_mission(fleet_id)
             fleet_mission.clear_fleet_orders()
             fleet_mission.clear_target()
             mission_type = MissionType.ORBITAL_DEFENSE
@@ -877,7 +877,7 @@ def assign_military_fleets_to_systems(use_fleet_id_list=None, allocations=None, 
         target = universe_object.System(sys_id)
         for fleet_id in these_fleets:
             fo.issueAggressionOrder(fleet_id, True)
-            fleet_mission = foAI.foAIstate.get_fleet_mission(fleet_id)
+            fleet_mission = get_aistate().get_fleet_mission(fleet_id)
             fleet_mission.clear_fleet_orders()
             fleet_mission.clear_target()
             if sys_id in set(AIstate.colonyTargetedSystemIDs + AIstate.outpostTargetedSystemIDs + AIstate.invasionTargetedSystemIDs):
@@ -887,7 +887,7 @@ def assign_military_fleets_to_systems(use_fleet_id_list=None, allocations=None, 
             fleet_mission.set_target(mission_type, target)
             fleet_mission.generate_fleet_orders()
             if not doing_main:
-                foAI.foAIstate.misc.setdefault('ReassignedFleetMissions', []).append(fleet_mission)
+                get_aistate().misc.setdefault('ReassignedFleetMissions', []).append(fleet_mission)
 
     if doing_main:
         print "---------------------------------"
@@ -933,14 +933,14 @@ def get_concentrated_tot_mil_rating():
 
 @cache_by_turn
 def get_num_military_ships():
-    return sum(foAI.foAIstate.fleetStatus.get(fid, {}).get('nships', 0)
+    return sum(get_aistate().fleetStatus.get(fid, {}).get('nships', 0)
                for fid in FleetUtilsAI.get_empire_fleet_ids_by_role(MissionType.MILITARY))
 
 
 def get_military_fleets_with_target_system(target_system_id):
     military_mission_types = [MissionType.MILITARY,  MissionType.SECURE]
     found_fleets = []
-    for fleet_mission in foAI.foAIstate.get_fleet_missions_with_any_mission_types(military_mission_types):
+    for fleet_mission in get_aistate().get_fleet_missions_with_any_mission_types(military_mission_types):
         if fleet_mission.target and fleet_mission.target.id == target_system_id:
             found_fleets.append(fleet_mission.fleet.id)
     return found_fleets

--- a/default/python/AI/MilitaryAI.py
+++ b/default/python/AI/MilitaryAI.py
@@ -36,10 +36,11 @@ def cur_best_mil_ship_rating(include_designs=False):
         return best_rating
     best_rating = 0.001
     universe = fo.getUniverse()
+    aistate = get_aistate()
     for fleet_id in FleetUtilsAI.get_empire_fleet_ids_by_role(MissionType.MILITARY):
         fleet = universe.getFleet(fleet_id)
         for ship_id in fleet.shipIDs:
-            ship_rating = CombatRatingsAI.ShipCombatStats(ship_id).get_rating(enemy_stats=get_aistate().get_standard_enemy())
+            ship_rating = CombatRatingsAI.ShipCombatStats(ship_id).get_rating(enemy_stats=aistate.get_standard_enemy())
             best_rating = max(best_rating, ship_rating)
     _best_ship_rating_cache[current_turn] = best_rating
     if include_designs:
@@ -89,8 +90,9 @@ def get_preferred_max_military_portion_for_single_battle():
 
 def try_again(mil_fleet_ids, try_reset=False, thisround=""):
     """Clear targets and orders for all specified fleets then call get_military_fleets again."""
+    aistate = get_aistate()
     for fid in mil_fleet_ids:
-        mission = get_aistate().get_fleet_mission(fid)
+        mission = aistate.get_fleet_mission(fid)
         mission.clear_fleet_orders()
         mission.clear_target()
     get_military_fleets(try_reset=try_reset, thisround=thisround)
@@ -101,6 +103,7 @@ def avail_mil_needing_repair(mil_fleet_ids, split_ships=False, on_mission=False,
     fleet_buckets = [[], []]
     universe = fo.getUniverse()
     cutoff = [repair_limit, 0.25][on_mission]
+    aistate = get_aistate()
     for fleet_id in mil_fleet_ids:
         fleet = universe.getFleet(fleet_id)
         ship_buckets = [[], []]
@@ -116,7 +119,7 @@ def avail_mil_needing_repair(mil_fleet_ids, split_ships=False, on_mission=False,
             ships_max_health[ship_ok] += max_struc
         this_sys_id = fleet.systemID if fleet.nextSystemID == INVALID_ID else fleet.nextSystemID
         fleet_ok = (sum(ships_cur_health) >= cutoff * sum(ships_max_health))
-        local_status = get_aistate().systemStatus.get(this_sys_id, {})
+        local_status = aistate.systemStatus.get(this_sys_id, {})
         my_local_rating = combine_ratings(local_status.get('mydefenses', {}).get('overall', 0), local_status.get('myFleetRating', 0))
         my_local_rating_vs_planets = local_status.get('myFleetRatingVsPlanets', 0)
         combat_trigger = bool(local_status.get('fleetThreat', 0) or local_status.get('monsterThreat', 0))
@@ -642,14 +645,15 @@ def get_military_fleets(mil_fleets_ids=None, try_reset=True, thisround="Main"):
     # for each system, get total rating of fleets assigned to it
     already_assigned_rating = {}
     already_assigned_rating_vs_planets = {}
-    systems_status = get_aistate().systemStatus
+    aistate = get_aistate()
+    systems_status = aistate.systemStatus
     enemy_sup_factor = {}  # enemy supply
     for sys_id in universe.systemIDs:
         already_assigned_rating[sys_id] = 0
         already_assigned_rating_vs_planets[sys_id] = 0
         enemy_sup_factor[sys_id] = min(2, len(systems_status.get(sys_id, {}).get('enemies_nearly_supplied', [])))
     for fleet_id in [fid for fid in all_military_fleet_ids if fid not in mil_fleets_ids]:
-        ai_fleet_mission = get_aistate().get_fleet_mission(fleet_id)
+        ai_fleet_mission = aistate.get_fleet_mission(fleet_id)
         if not ai_fleet_mission.target:  # shouldn't really be possible
             continue
         last_sys = ai_fleet_mission.target.get_system().id  # will count this fleet as assigned to last system in target list  # TODO last_sys or target sys?
@@ -679,7 +683,7 @@ def get_military_fleets(mil_fleets_ids=None, try_reset=True, thisround="Main"):
         capital_sys_id = None  # unless we can find one to use
         system_dict = {}
         for fleet_id in all_military_fleet_ids:
-            status = get_aistate().fleetStatus.get(fleet_id, None)
+            status = aistate.fleetStatus.get(fleet_id, None)
             if status is not None:
                 system_id = status['sysID']
                 if not list(universe.getSystem(system_id).planetIDs):
@@ -690,24 +694,24 @@ def get_military_fleets(mil_fleets_ids=None, try_reset=True, thisround="Main"):
             capital_sys_id = ranked_systems[-1][-1]
         else:
             try:
-                capital_sys_id = get_aistate().fleetStatus.items()[0][1]['sysID']
+                capital_sys_id = aistate.fleetStatus.items()[0][1]['sysID']
             except:
                 pass
 
     num_targets = max(10, PriorityAI.allotted_outpost_targets)
     top_target_planets = ([pid for pid, pscore, trp in AIstate.invasionTargets[:PriorityAI.allotted_invasion_targets()]
                            if pscore > InvasionAI.MIN_INVASION_SCORE] +
-                          [pid for pid, (pscore, spec) in get_aistate().colonisableOutpostIDs.items()[:num_targets]
+                          [pid for pid, (pscore, spec) in aistate.colonisableOutpostIDs.items()[:num_targets]
                            if pscore > InvasionAI.MIN_INVASION_SCORE] +
-                          [pid for pid, (pscore, spec) in get_aistate().colonisablePlanetIDs.items()[:num_targets]
+                          [pid for pid, (pscore, spec) in aistate.colonisablePlanetIDs.items()[:num_targets]
                            if pscore > InvasionAI.MIN_INVASION_SCORE])
-    top_target_planets.extend(get_aistate().qualifyingTroopBaseTargets.keys())
+    top_target_planets.extend(aistate.qualifyingTroopBaseTargets.keys())
 
     base_col_target_systems = PlanetUtilsAI.get_systems(top_target_planets)
     top_target_systems = []
     for sys_id in AIstate.invasionTargetedSystemIDs + base_col_target_systems:
         if sys_id not in top_target_systems:
-            if get_aistate().systemStatus[sys_id]['totalThreat'] > get_tot_mil_rating():
+            if aistate.systemStatus[sys_id]['totalThreat'] > get_tot_mil_rating():
                 continue
             top_target_systems.append(sys_id)  # doing this rather than set, to preserve order
 
@@ -754,7 +758,7 @@ def get_military_fleets(mil_fleets_ids=None, try_reset=True, thisround="Main"):
         # TODO Exploration targets
 
         # border protections
-        visible_system_ids = get_aistate().visInteriorSystemIDs | get_aistate().visBorderSystemIDs
+        visible_system_ids = aistate.visInteriorSystemIDs | aistate.visBorderSystemIDs
         accessible_system_ids = ([sys_id for sys_id in visible_system_ids if
                                  universe.systemsConnected(sys_id, home_system_id, empire_id)]
                                  if home_system_id != INVALID_ID else [])
@@ -818,8 +822,9 @@ def assign_military_fleets_to_systems(use_fleet_id_list=None, allocations=None, 
         allocations = []
 
     doing_main = (use_fleet_id_list is None)
+    aistate = get_aistate()
     if doing_main:
-        get_aistate().misc['ReassignedFleetMissions'] = []
+        aistate.misc['ReassignedFleetMissions'] = []
         base_defense_ids = FleetUtilsAI.get_empire_fleet_ids_by_role(MissionType.ORBITAL_DEFENSE)
         unassigned_base_defense_ids = FleetUtilsAI.extract_fleet_ids_without_mission_types(base_defense_ids)
         for fleet_id in unassigned_base_defense_ids:
@@ -828,7 +833,7 @@ def assign_military_fleets_to_systems(use_fleet_id_list=None, allocations=None, 
                 continue
             sys_id = fleet.systemID
             target = universe_object.System(sys_id)
-            fleet_mission = get_aistate().get_fleet_mission(fleet_id)
+            fleet_mission = aistate.get_fleet_mission(fleet_id)
             fleet_mission.clear_fleet_orders()
             fleet_mission.clear_target()
             mission_type = MissionType.ORBITAL_DEFENSE
@@ -877,7 +882,7 @@ def assign_military_fleets_to_systems(use_fleet_id_list=None, allocations=None, 
         target = universe_object.System(sys_id)
         for fleet_id in these_fleets:
             fo.issueAggressionOrder(fleet_id, True)
-            fleet_mission = get_aistate().get_fleet_mission(fleet_id)
+            fleet_mission = aistate.get_fleet_mission(fleet_id)
             fleet_mission.clear_fleet_orders()
             fleet_mission.clear_target()
             if sys_id in set(AIstate.colonyTargetedSystemIDs + AIstate.outpostTargetedSystemIDs + AIstate.invasionTargetedSystemIDs):
@@ -887,7 +892,7 @@ def assign_military_fleets_to_systems(use_fleet_id_list=None, allocations=None, 
             fleet_mission.set_target(mission_type, target)
             fleet_mission.generate_fleet_orders()
             if not doing_main:
-                get_aistate().misc.setdefault('ReassignedFleetMissions', []).append(fleet_mission)
+                aistate.misc.setdefault('ReassignedFleetMissions', []).append(fleet_mission)
 
     if doing_main:
         print "---------------------------------"
@@ -933,7 +938,8 @@ def get_concentrated_tot_mil_rating():
 
 @cache_by_turn
 def get_num_military_ships():
-    return sum(get_aistate().fleetStatus.get(fid, {}).get('nships', 0)
+    fleet_status = get_aistate().fleetStatus
+    return sum(fleet_status.get(fid, {}).get('nships', 0)
                for fid in FleetUtilsAI.get_empire_fleet_ids_by_role(MissionType.MILITARY))
 
 

--- a/default/python/AI/MoveUtilsAI.py
+++ b/default/python/AI/MoveUtilsAI.py
@@ -1,7 +1,7 @@
 from logging import warn, debug
 
 import freeOrionAIInterface as fo  # pylint: disable=import-error
-import FreeOrionAI as foAI
+from aistate_interface import get_aistate
 import AIstate
 import universe_object
 import fleet_orders
@@ -60,7 +60,7 @@ def can_travel_to_system(fleet_id, start, target, ensure_return=False):
     target_distance_from_supply = -min(state.get_system_supply(target.id), 0)
 
     # low-aggression AIs may not travel far from supply
-    if not foAI.foAIstate.character.may_travel_beyond_supply(target_distance_from_supply):
+    if not get_aistate().character.may_travel_beyond_supply(target_distance_from_supply):
         debug("May not move %d out of supply" % target_distance_from_supply)
         return []
 
@@ -136,12 +136,12 @@ def get_best_drydock_system_id(start_system_id, fleet_id):
     sys_distances = sorted([(universe.jumpDistance(start_system_id, sys_id), sys_id)
                             for sys_id in drydock_system_ids])
 
-    fleet_rating = foAI.foAIstate.get_rating(fleet_id)
+    fleet_rating = get_aistate().get_rating(fleet_id)
     for _, dock_sys_id in sys_distances:
         dock_system = universe_object.System(dock_sys_id)
         path = can_travel_to_system(fleet_id, start_system, dock_system)
 
-        path_rating = sum([foAI.foAIstate.systemStatus[path_sys.id]['totalThreat']
+        path_rating = sum([get_aistate().systemStatus[path_sys.id]['totalThreat']
                            for path_sys in path])
 
         SAFETY_MARGIN = 10

--- a/default/python/AI/MoveUtilsAI.py
+++ b/default/python/AI/MoveUtilsAI.py
@@ -136,12 +136,13 @@ def get_best_drydock_system_id(start_system_id, fleet_id):
     sys_distances = sorted([(universe.jumpDistance(start_system_id, sys_id), sys_id)
                             for sys_id in drydock_system_ids])
 
-    fleet_rating = get_aistate().get_rating(fleet_id)
+    aistate = get_aistate()
+    fleet_rating = aistate.get_rating(fleet_id)
     for _, dock_sys_id in sys_distances:
         dock_system = universe_object.System(dock_sys_id)
         path = can_travel_to_system(fleet_id, start_system, dock_system)
 
-        path_rating = sum([get_aistate().systemStatus[path_sys.id]['totalThreat']
+        path_rating = sum([aistate.systemStatus[path_sys.id]['totalThreat']
                            for path_sys in path])
 
         SAFETY_MARGIN = 10

--- a/default/python/AI/PriorityAI.py
+++ b/default/python/AI/PriorityAI.py
@@ -7,7 +7,7 @@ import AIstate
 import ColonisationAI
 import ExplorationAI
 import FleetUtilsAI
-import FreeOrionAI as foAI
+from aistate_interface import get_aistate
 import InvasionAI
 import MilitaryAI
 import PlanetUtilsAI
@@ -29,15 +29,15 @@ def calculate_priorities():
     """Calculates the priorities of the AI player."""
     print "\n", 10 * "=", "Preparing to Calculate Priorities", 10 * "="
     prioritiees_timer.start('setting Production Priority')
-    foAI.foAIstate.set_priority(PriorityType.RESOURCE_PRODUCTION, 50)  # let this one stay fixed & just adjust Research
+    get_aistate().set_priority(PriorityType.RESOURCE_PRODUCTION, 50)  # let this one stay fixed & just adjust Research
 
     print "\n*** Calculating Research Priority ***\n"
     prioritiees_timer.start('setting Research Priority')
-    foAI.foAIstate.set_priority(PriorityType.RESOURCE_RESEARCH, _calculate_research_priority())  # TODO: do univ _survey before this
+    get_aistate().set_priority(PriorityType.RESOURCE_RESEARCH, _calculate_research_priority())  # TODO: do univ _survey before this
 
     print "\n*** Updating Colonization Status ***\n"
     prioritiees_timer.start('Evaluating Colonization Status')
-    ColonisationAI.get_colony_fleets()  # sets foAI.foAIstate.colonisablePlanetIDs and many other values used by other modules
+    ColonisationAI.get_colony_fleets()  # sets get_aistate().colonisablePlanetIDs and many other values used by other modules
 
     print "\n*** Updating Invasion Status ***\n"
     prioritiees_timer.start('Evaluating Invasion Status')
@@ -52,20 +52,20 @@ def calculate_priorities():
     _calculate_industry_priority()  # purely for reporting purposes
     prioritiees_timer.start('setting Exploration Priority')
 
-    foAI.foAIstate.set_priority(PriorityType.RESOURCE_TRADE, 0)
-    foAI.foAIstate.set_priority(PriorityType.RESOURCE_CONSTRUCTION, 0)
+    get_aistate().set_priority(PriorityType.RESOURCE_TRADE, 0)
+    get_aistate().set_priority(PriorityType.RESOURCE_CONSTRUCTION, 0)
 
-    foAI.foAIstate.set_priority(PriorityType.PRODUCTION_EXPLORATION, _calculate_exploration_priority())
+    get_aistate().set_priority(PriorityType.PRODUCTION_EXPLORATION, _calculate_exploration_priority())
     prioritiees_timer.start('setting Colony Priority')
-    foAI.foAIstate.set_priority(PriorityType.PRODUCTION_COLONISATION, _calculate_colonisation_priority())
+    get_aistate().set_priority(PriorityType.PRODUCTION_COLONISATION, _calculate_colonisation_priority())
     prioritiees_timer.start('setting Outpost Priority')
-    foAI.foAIstate.set_priority(PriorityType.PRODUCTION_OUTPOST, _calculate_outpost_priority())
+    get_aistate().set_priority(PriorityType.PRODUCTION_OUTPOST, _calculate_outpost_priority())
     prioritiees_timer.start('setting Invasion Priority')
-    foAI.foAIstate.set_priority(PriorityType.PRODUCTION_INVASION, _calculate_invasion_priority())
+    get_aistate().set_priority(PriorityType.PRODUCTION_INVASION, _calculate_invasion_priority())
     prioritiees_timer.start('setting Military Priority')
-    foAI.foAIstate.set_priority(PriorityType.PRODUCTION_MILITARY, _calculate_military_priority())
+    get_aistate().set_priority(PriorityType.PRODUCTION_MILITARY, _calculate_military_priority())
     prioritiees_timer.start('setting other priorities')
-    foAI.foAIstate.set_priority(PriorityType.PRODUCTION_BUILDINGS, 25)
+    get_aistate().set_priority(PriorityType.PRODUCTION_BUILDINGS, 25)
 
     prioritiees_timer.stop_print_and_clear()
 
@@ -81,7 +81,7 @@ def _calculate_industry_priority():  # currently only used to print status
     target_pp = sum(map(lambda x: x.currentMeterValue(fo.meterType.targetIndustry), planets))
 
     # currently, previously set to 50 in calculatePriorities(), this is just for reporting
-    industry_priority = foAI.foAIstate.get_priority(PriorityType.RESOURCE_PRODUCTION)
+    industry_priority = get_aistate().get_priority(PriorityType.RESOURCE_PRODUCTION)
 
     print
     print "Industry Production (current/target) : ( %.1f / %.1f ) at turn %s" % (industry_production, target_pp, fo.currentTurn())
@@ -94,10 +94,10 @@ def _calculate_research_priority():
     universe = fo.getUniverse()
     empire = fo.getEmpire()
     current_turn = fo.currentTurn()
-    enemies_sighted = foAI.foAIstate.misc.get('enemies_sighted', {})
+    enemies_sighted = get_aistate().misc.get('enemies_sighted', {})
     recent_enemies = [x for x in enemies_sighted if x > current_turn - 8]
 
-    industry_priority = foAI.foAIstate.get_priority(PriorityType.RESOURCE_PRODUCTION)
+    industry_priority = get_aistate().get_priority(PriorityType.RESOURCE_PRODUCTION)
 
     got_algo = tech_is_complete(AIDependencies.LRN_ALGO_ELEGANCE)
     got_quant = tech_is_complete(AIDependencies.LRN_QUANT_NET)
@@ -114,7 +114,7 @@ def _calculate_research_priority():
 
     total_pp = empire.productionPoints
     total_rp = empire.resourceProduction(fo.resourceType.research)
-    industry_surge = (foAI.foAIstate.character.may_surge_industry(total_pp, total_rp) and
+    industry_surge = (get_aistate().character.may_surge_industry(total_pp, total_rp) and
                       (((orb_gen_tech in research_queue_list[:2] or got_orb_gen) and state.have_gas_giant) or
                        ((mgrav_prod_tech in research_queue_list[:2] or got_mgrav_prod) and state.have_asteroids)) and
                       (state.get_number_of_colonies() < 12))
@@ -123,10 +123,10 @@ def _calculate_research_priority():
     planets = map(universe.getPlanet, owned_planet_ids)
     target_rp = sum(map(lambda _x: _x.currentMeterValue(fo.meterType.targetResearch), planets))
     galaxy_is_sparse = ColonisationAI.galaxy_is_sparse()
-    enemies_sighted = foAI.foAIstate.misc.get('enemies_sighted', {})
+    enemies_sighted = get_aistate().misc.get('enemies_sighted', {})
 
-    style_index = foAI.foAIstate.character.preferred_research_cutoff([0, 1])
-    if foAI.foAIstate.character.may_maximize_research():
+    style_index = get_aistate().character.preferred_research_cutoff([0, 1])
+    if get_aistate().character.may_maximize_research():
         style_index += 1
 
     cutoff_sets = [[25, 45, 70, 110], [30, 45, 70, 150], [25, 40, 80, 160]]
@@ -181,14 +181,14 @@ def _calculate_exploration_priority():
     """Calculates the demand for scouts by unexplored systems."""
     empire = fo.getEmpire()
     num_unexplored_systems = len(ExplorationAI.border_unexplored_system_ids)
-    num_scouts = sum([foAI.foAIstate.fleetStatus.get(fid, {}).get('nships', 0) for fid in FleetUtilsAI.get_empire_fleet_ids_by_role(
+    num_scouts = sum([get_aistate().fleetStatus.get(fid, {}).get('nships', 0) for fid in FleetUtilsAI.get_empire_fleet_ids_by_role(
         MissionType.EXPLORATION)])
     production_queue = empire.productionQueue
     queued_scout_ships = 0
     for queue_index in range(0, len(production_queue)):
         element = production_queue[queue_index]
         if element.buildType == EmpireProductionTypes.BT_SHIP:
-            if foAI.foAIstate.get_ship_role(element.designID) == ShipRoleType.CIVILIAN_EXPLORATION:
+            if get_aistate().get_ship_role(element.designID) == ShipRoleType.CIVILIAN_EXPLORATION:
                 queued_scout_ships += element.remaining * element.blocksize
 
     mil_ships = MilitaryAI.get_num_military_ships()
@@ -214,21 +214,21 @@ def _calculate_exploration_priority():
 def _calculate_colonisation_priority():
     """Calculates the demand for colony ships by colonisable planets."""
     global allottedColonyTargets
-    enemies_sighted = foAI.foAIstate.misc.get('enemies_sighted', {})
+    enemies_sighted = get_aistate().misc.get('enemies_sighted', {})
     galaxy_is_sparse = ColonisationAI.galaxy_is_sparse()
     total_pp = fo.getEmpire().productionPoints
     num_colonies = state.get_number_of_colonies()
-    colony_growth_barrier = foAI.foAIstate.character.max_number_colonies()
+    colony_growth_barrier = get_aistate().character.max_number_colonies()
     if num_colonies > colony_growth_barrier:
         return 0.0
     colony_cost = AIDependencies.COLONY_POD_COST * (1 + AIDependencies.COLONY_POD_UPKEEP * num_colonies)
     turns_to_build = 8  # TODO: check for susp anim pods, build time 10
-    mil_prio = foAI.foAIstate.get_priority(PriorityType.PRODUCTION_MILITARY)
+    mil_prio = get_aistate().get_priority(PriorityType.PRODUCTION_MILITARY)
     allotted_portion = ([[[0.6, 0.8], [0.3, 0.4]], [[0.8, 0.9], [0.4, 0.6]]][galaxy_is_sparse]
                         [any(enemies_sighted)])
-    allotted_portion = foAI.foAIstate.character.preferred_colonization_portion(allotted_portion)
-    # if ( foAI.foAIstate.get_priority(AIPriorityType.PRIORITY_PRODUCTION_COLONISATION)
-    # > 2 * foAI.foAIstate.get_priority(AIPriorityType.PRIORITY_PRODUCTION_MILITARY)):
+    allotted_portion = get_aistate().character.preferred_colonization_portion(allotted_portion)
+    # if ( get_aistate().get_priority(AIPriorityType.PRIORITY_PRODUCTION_COLONISATION)
+    # > 2 * get_aistate().get_priority(AIPriorityType.PRIORITY_PRODUCTION_MILITARY)):
     # allotted_portion *= 1.5
     if mil_prio < 100:
         allotted_portion *= 2
@@ -238,7 +238,7 @@ def _calculate_colonisation_priority():
         allotted_portion *= 0.75 ** (num_colonies / 10.0)
     # allottedColonyTargets = 1+ int(fo.currentTurn()/50)
     allottedColonyTargets = 1 + int(total_pp * turns_to_build * allotted_portion / colony_cost)
-    outpost_prio = foAI.foAIstate.get_priority(PriorityType.PRODUCTION_OUTPOST)
+    outpost_prio = get_aistate().get_priority(PriorityType.PRODUCTION_OUTPOST)
 
     # if have no SP_SLY, and have any outposts to build, don't build colony ships TODO: make more complex assessment
     colonizers = list(ColonisationAI.empire_colonizers)
@@ -246,9 +246,9 @@ def _calculate_colonisation_priority():
         return 0.0
     min_score = ColonisationAI.MINIMUM_COLONY_SCORE
     minimal_top = min_score + 2  # one more than the conditional floor set by ColonisationAI.revise_threat_factor()
-    minimal_opportunities = [species_name for (_, (score, species_name)) in foAI.foAIstate.colonisablePlanetIDs.items()
+    minimal_opportunities = [species_name for (_, (score, species_name)) in get_aistate().colonisablePlanetIDs.items()
                              if min_score < score <= minimal_top]
-    decent_opportunities = [species_name for (_, (score, species_name)) in foAI.foAIstate.colonisablePlanetIDs.items()
+    decent_opportunities = [species_name for (_, (score, species_name)) in get_aistate().colonisablePlanetIDs.items()
                             if score > minimal_top]
     minimal_planet_factor = 0.2  # count them for something, but not much
     num_colonisable_planet_ids = len(decent_opportunities) + minimal_planet_factor * len(minimal_opportunities)
@@ -280,13 +280,13 @@ def _calculate_outpost_priority():
     global allotted_outpost_targets
     base_outpost_cost = AIDependencies.OUTPOST_POD_COST
 
-    enemies_sighted = foAI.foAIstate.misc.get('enemies_sighted', {})
+    enemies_sighted = get_aistate().misc.get('enemies_sighted', {})
     galaxy_is_sparse = ColonisationAI.galaxy_is_sparse()
     total_pp = fo.getEmpire().productionPoints
-    colony_growth_barrier = foAI.foAIstate.character.max_number_colonies()
+    colony_growth_barrier = get_aistate().character.max_number_colonies()
     if state.get_number_of_colonies() > colony_growth_barrier:
         return 0.0
-    mil_prio = foAI.foAIstate.get_priority(PriorityType.PRODUCTION_MILITARY)
+    mil_prio = get_aistate().get_priority(PriorityType.PRODUCTION_MILITARY)
 
     not_sparse, enemy_unseen = 0, 0
     is_sparse, enemy_seen = 1, 1
@@ -296,14 +296,14 @@ def _calculate_outpost_priority():
         (is_sparse, enemy_unseen): (0.8, 0.9),
         (is_sparse, enemy_seen): (0.3, 0.4),
     }[(galaxy_is_sparse, any(enemies_sighted))]
-    allotted_portion = foAI.foAIstate.character.preferred_outpost_portion(allotted_portion)
+    allotted_portion = get_aistate().character.preferred_outpost_portion(allotted_portion)
     if mil_prio < 100:
         allotted_portion *= 2
     elif mil_prio < 200:
         allotted_portion *= 1.5
     allotted_outpost_targets = 1 + int(total_pp * 3 * allotted_portion / base_outpost_cost)
 
-    num_outpost_targets = len([pid for (pid, (score, specName)) in foAI.foAIstate.colonisableOutpostIDs.items()
+    num_outpost_targets = len([pid for (pid, (score, specName)) in get_aistate().colonisableOutpostIDs.items()
                                if score > max(1.0 * base_outpost_cost / 3.0, ColonisationAI.MINIMUM_COLONY_SCORE)]
                               [:allotted_outpost_targets])
     if num_outpost_targets == 0 or not tech_is_complete(AIDependencies.OUTPOSTING_TECH):
@@ -331,18 +331,18 @@ def _calculate_outpost_priority():
 def _calculate_invasion_priority():
     """Calculates the demand for troop ships by opponent planets."""
 
-    if not foAI.foAIstate.character.may_invade():
+    if not get_aistate().character.may_invade():
         return 0
 
     empire = fo.getEmpire()
-    enemies_sighted = foAI.foAIstate.misc.get('enemies_sighted', {})
+    enemies_sighted = get_aistate().misc.get('enemies_sighted', {})
     multiplier = 1
-    colony_growth_barrier = foAI.foAIstate.character.max_number_colonies()
+    colony_growth_barrier = get_aistate().character.max_number_colonies()
     if state.get_number_of_colonies() > colony_growth_barrier:
         return 0.0
 
-    if len(foAI.foAIstate.colonisablePlanetIDs) > 0:
-        best_colony_score = max(2, foAI.foAIstate.colonisablePlanetIDs.items()[0][1][0])
+    if len(get_aistate().colonisablePlanetIDs) > 0:
+        best_colony_score = max(2, get_aistate().colonisablePlanetIDs.items()[0][1][0])
     else:
         best_colony_score = 2
 
@@ -364,8 +364,8 @@ def _calculate_invasion_priority():
     for queue_index in range(0, len(production_queue)):
         element = production_queue[queue_index]
         if element.buildType == EmpireProductionTypes.BT_SHIP:
-            if foAI.foAIstate.get_ship_role(element.designID) in [ShipRoleType.MILITARY_INVASION,
-                                                                  ShipRoleType.BASE_INVASION]:
+            if get_aistate().get_ship_role(element.designID) in [ShipRoleType.MILITARY_INVASION,
+                                                                 ShipRoleType.BASE_INVASION]:
                 design = fo.getShipDesign(element.designID)
                 queued_troop_capacity += element.remaining * element.blocksize * design.troopCapacity
     _, best_design, _ = ProductionAI.get_best_ship_info(PriorityType.PRODUCTION_INVASION)
@@ -395,7 +395,7 @@ def _calculate_invasion_priority():
     if invasion_priority < 0:
         return 0
 
-    return invasion_priority * foAI.foAIstate.character.invasion_priority_scaling()
+    return invasion_priority * get_aistate().character.invasion_priority_scaling()
 
 
 def allotted_invasion_targets():
@@ -417,11 +417,11 @@ def _calculate_military_priority():
                      tech_is_complete("SHP_WEAPON_4_1"))
     have_l2_weaps = (tech_is_complete("SHP_WEAPON_2_3") or
                      tech_is_complete("SHP_WEAPON_4_1"))
-    enemies_sighted = foAI.foAIstate.misc.get('enemies_sighted', {})
+    enemies_sighted = get_aistate().misc.get('enemies_sighted', {})
 
     target_planet_ids = ([pid for pid, pscore, trp in AIstate.invasionTargets[:allotted_invasion_targets()]] +
-                         [pid for pid, pscore in foAI.foAIstate.colonisablePlanetIDs.items()[:allottedColonyTargets]] +
-                         [pid for pid, pscore in foAI.foAIstate.colonisableOutpostIDs.items()[:allottedColonyTargets]])
+                         [pid for pid, pscore in get_aistate().colonisablePlanetIDs.items()[:allottedColonyTargets]] +
+                         [pid for pid, pscore in get_aistate().colonisableOutpostIDs.items()[:allottedColonyTargets]])
 
     my_systems = set(state.get_empire_planets_by_system())
     target_systems = set(PlanetUtilsAI.get_systems(target_planet_ids))
@@ -432,7 +432,7 @@ def _calculate_military_priority():
     defense_ships_needed = 0
     ships_needed_allocation = []
     for sys_id in my_systems.union(target_systems):
-        status = foAI.foAIstate.systemStatus.get(sys_id, {})
+        status = get_aistate().systemStatus.get(sys_id, {})
         my_rating = status.get('myFleetRating', 0)
         my_defenses = status.get('mydefenses', {}).get('overall', 0)
         base_monster_threat = status.get('monsterThreat', 0)
@@ -470,7 +470,7 @@ def _calculate_military_priority():
     print fmt_string % (military_priority, ships_needed, defense_ships_needed, cur_ship_rating, have_l1_weaps, enemies_sighted)
     print "Source of milship demand: ", ships_needed_allocation
 
-    military_priority *= foAI.foAIstate.character.military_priority_scaling()
+    military_priority *= get_aistate().character.military_priority_scaling()
     return max(military_priority, 0)
 
 
@@ -478,7 +478,7 @@ def _calculate_top_production_queue_priority():
     """Calculates the top production queue priority."""
     production_queue_priorities = {}
     for priorityType in get_priority_production_types():
-        production_queue_priorities[priorityType] = foAI.foAIstate.get_priority(priorityType)
+        production_queue_priorities[priorityType] = get_aistate().get_priority(priorityType)
 
     sorted_priorities = production_queue_priorities.items()
     sorted_priorities.sort(lambda x, y: cmp(x[1], y[1]), reverse=True)

--- a/default/python/AI/PriorityAI.py
+++ b/default/python/AI/PriorityAI.py
@@ -29,15 +29,16 @@ def calculate_priorities():
     """Calculates the priorities of the AI player."""
     print "\n", 10 * "=", "Preparing to Calculate Priorities", 10 * "="
     prioritiees_timer.start('setting Production Priority')
-    get_aistate().set_priority(PriorityType.RESOURCE_PRODUCTION, 50)  # let this one stay fixed & just adjust Research
+    aistate = get_aistate()
+    aistate.set_priority(PriorityType.RESOURCE_PRODUCTION, 50)  # let this one stay fixed & just adjust Research
 
     print "\n*** Calculating Research Priority ***\n"
     prioritiees_timer.start('setting Research Priority')
-    get_aistate().set_priority(PriorityType.RESOURCE_RESEARCH, _calculate_research_priority())  # TODO: do univ _survey before this
+    aistate.set_priority(PriorityType.RESOURCE_RESEARCH, _calculate_research_priority())  # TODO: do univ _survey before this
 
     print "\n*** Updating Colonization Status ***\n"
     prioritiees_timer.start('Evaluating Colonization Status')
-    ColonisationAI.get_colony_fleets()  # sets get_aistate().colonisablePlanetIDs and many other values used by other modules
+    ColonisationAI.get_colony_fleets()  # sets aistate.colonisablePlanetIDs and many other values used by other modules
 
     print "\n*** Updating Invasion Status ***\n"
     prioritiees_timer.start('Evaluating Invasion Status')
@@ -52,20 +53,20 @@ def calculate_priorities():
     _calculate_industry_priority()  # purely for reporting purposes
     prioritiees_timer.start('setting Exploration Priority')
 
-    get_aistate().set_priority(PriorityType.RESOURCE_TRADE, 0)
-    get_aistate().set_priority(PriorityType.RESOURCE_CONSTRUCTION, 0)
+    aistate.set_priority(PriorityType.RESOURCE_TRADE, 0)
+    aistate.set_priority(PriorityType.RESOURCE_CONSTRUCTION, 0)
 
-    get_aistate().set_priority(PriorityType.PRODUCTION_EXPLORATION, _calculate_exploration_priority())
+    aistate.set_priority(PriorityType.PRODUCTION_EXPLORATION, _calculate_exploration_priority())
     prioritiees_timer.start('setting Colony Priority')
-    get_aistate().set_priority(PriorityType.PRODUCTION_COLONISATION, _calculate_colonisation_priority())
+    aistate.set_priority(PriorityType.PRODUCTION_COLONISATION, _calculate_colonisation_priority())
     prioritiees_timer.start('setting Outpost Priority')
-    get_aistate().set_priority(PriorityType.PRODUCTION_OUTPOST, _calculate_outpost_priority())
+    aistate.set_priority(PriorityType.PRODUCTION_OUTPOST, _calculate_outpost_priority())
     prioritiees_timer.start('setting Invasion Priority')
-    get_aistate().set_priority(PriorityType.PRODUCTION_INVASION, _calculate_invasion_priority())
+    aistate.set_priority(PriorityType.PRODUCTION_INVASION, _calculate_invasion_priority())
     prioritiees_timer.start('setting Military Priority')
-    get_aistate().set_priority(PriorityType.PRODUCTION_MILITARY, _calculate_military_priority())
+    aistate.set_priority(PriorityType.PRODUCTION_MILITARY, _calculate_military_priority())
     prioritiees_timer.start('setting other priorities')
-    get_aistate().set_priority(PriorityType.PRODUCTION_BUILDINGS, 25)
+    aistate.set_priority(PriorityType.PRODUCTION_BUILDINGS, 25)
 
     prioritiees_timer.stop_print_and_clear()
 
@@ -94,10 +95,11 @@ def _calculate_research_priority():
     universe = fo.getUniverse()
     empire = fo.getEmpire()
     current_turn = fo.currentTurn()
-    enemies_sighted = get_aistate().misc.get('enemies_sighted', {})
+    aistate = get_aistate()
+    enemies_sighted = aistate.misc.get('enemies_sighted', {})
     recent_enemies = [x for x in enemies_sighted if x > current_turn - 8]
 
-    industry_priority = get_aistate().get_priority(PriorityType.RESOURCE_PRODUCTION)
+    industry_priority = aistate.get_priority(PriorityType.RESOURCE_PRODUCTION)
 
     got_algo = tech_is_complete(AIDependencies.LRN_ALGO_ELEGANCE)
     got_quant = tech_is_complete(AIDependencies.LRN_QUANT_NET)
@@ -114,7 +116,7 @@ def _calculate_research_priority():
 
     total_pp = empire.productionPoints
     total_rp = empire.resourceProduction(fo.resourceType.research)
-    industry_surge = (get_aistate().character.may_surge_industry(total_pp, total_rp) and
+    industry_surge = (aistate.character.may_surge_industry(total_pp, total_rp) and
                       (((orb_gen_tech in research_queue_list[:2] or got_orb_gen) and state.have_gas_giant) or
                        ((mgrav_prod_tech in research_queue_list[:2] or got_mgrav_prod) and state.have_asteroids)) and
                       (state.get_number_of_colonies() < 12))
@@ -123,10 +125,10 @@ def _calculate_research_priority():
     planets = map(universe.getPlanet, owned_planet_ids)
     target_rp = sum(map(lambda _x: _x.currentMeterValue(fo.meterType.targetResearch), planets))
     galaxy_is_sparse = ColonisationAI.galaxy_is_sparse()
-    enemies_sighted = get_aistate().misc.get('enemies_sighted', {})
+    enemies_sighted = aistate.misc.get('enemies_sighted', {})
 
-    style_index = get_aistate().character.preferred_research_cutoff([0, 1])
-    if get_aistate().character.may_maximize_research():
+    style_index = aistate.character.preferred_research_cutoff([0, 1])
+    if aistate.character.may_maximize_research():
         style_index += 1
 
     cutoff_sets = [[25, 45, 70, 110], [30, 45, 70, 150], [25, 40, 80, 160]]
@@ -181,14 +183,15 @@ def _calculate_exploration_priority():
     """Calculates the demand for scouts by unexplored systems."""
     empire = fo.getEmpire()
     num_unexplored_systems = len(ExplorationAI.border_unexplored_system_ids)
-    num_scouts = sum([get_aistate().fleetStatus.get(fid, {}).get('nships', 0) for fid in FleetUtilsAI.get_empire_fleet_ids_by_role(
+    aistate = get_aistate()
+    num_scouts = sum([aistate.fleetStatus.get(fid, {}).get('nships', 0) for fid in FleetUtilsAI.get_empire_fleet_ids_by_role(
         MissionType.EXPLORATION)])
     production_queue = empire.productionQueue
     queued_scout_ships = 0
     for queue_index in range(0, len(production_queue)):
         element = production_queue[queue_index]
         if element.buildType == EmpireProductionTypes.BT_SHIP:
-            if get_aistate().get_ship_role(element.designID) == ShipRoleType.CIVILIAN_EXPLORATION:
+            if aistate.get_ship_role(element.designID) == ShipRoleType.CIVILIAN_EXPLORATION:
                 queued_scout_ships += element.remaining * element.blocksize
 
     mil_ships = MilitaryAI.get_num_military_ships()
@@ -214,19 +217,20 @@ def _calculate_exploration_priority():
 def _calculate_colonisation_priority():
     """Calculates the demand for colony ships by colonisable planets."""
     global allottedColonyTargets
-    enemies_sighted = get_aistate().misc.get('enemies_sighted', {})
+    aistate = get_aistate()
+    enemies_sighted = aistate.misc.get('enemies_sighted', {})
     galaxy_is_sparse = ColonisationAI.galaxy_is_sparse()
     total_pp = fo.getEmpire().productionPoints
     num_colonies = state.get_number_of_colonies()
-    colony_growth_barrier = get_aistate().character.max_number_colonies()
+    colony_growth_barrier = aistate.character.max_number_colonies()
     if num_colonies > colony_growth_barrier:
         return 0.0
     colony_cost = AIDependencies.COLONY_POD_COST * (1 + AIDependencies.COLONY_POD_UPKEEP * num_colonies)
     turns_to_build = 8  # TODO: check for susp anim pods, build time 10
-    mil_prio = get_aistate().get_priority(PriorityType.PRODUCTION_MILITARY)
+    mil_prio = aistate.get_priority(PriorityType.PRODUCTION_MILITARY)
     allotted_portion = ([[[0.6, 0.8], [0.3, 0.4]], [[0.8, 0.9], [0.4, 0.6]]][galaxy_is_sparse]
                         [any(enemies_sighted)])
-    allotted_portion = get_aistate().character.preferred_colonization_portion(allotted_portion)
+    allotted_portion = aistate.character.preferred_colonization_portion(allotted_portion)
     # if ( get_aistate().get_priority(AIPriorityType.PRIORITY_PRODUCTION_COLONISATION)
     # > 2 * get_aistate().get_priority(AIPriorityType.PRIORITY_PRODUCTION_MILITARY)):
     # allotted_portion *= 1.5
@@ -238,7 +242,7 @@ def _calculate_colonisation_priority():
         allotted_portion *= 0.75 ** (num_colonies / 10.0)
     # allottedColonyTargets = 1+ int(fo.currentTurn()/50)
     allottedColonyTargets = 1 + int(total_pp * turns_to_build * allotted_portion / colony_cost)
-    outpost_prio = get_aistate().get_priority(PriorityType.PRODUCTION_OUTPOST)
+    outpost_prio = aistate.get_priority(PriorityType.PRODUCTION_OUTPOST)
 
     # if have no SP_SLY, and have any outposts to build, don't build colony ships TODO: make more complex assessment
     colonizers = list(ColonisationAI.empire_colonizers)
@@ -246,9 +250,9 @@ def _calculate_colonisation_priority():
         return 0.0
     min_score = ColonisationAI.MINIMUM_COLONY_SCORE
     minimal_top = min_score + 2  # one more than the conditional floor set by ColonisationAI.revise_threat_factor()
-    minimal_opportunities = [species_name for (_, (score, species_name)) in get_aistate().colonisablePlanetIDs.items()
+    minimal_opportunities = [species_name for (_, (score, species_name)) in aistate.colonisablePlanetIDs.items()
                              if min_score < score <= minimal_top]
-    decent_opportunities = [species_name for (_, (score, species_name)) in get_aistate().colonisablePlanetIDs.items()
+    decent_opportunities = [species_name for (_, (score, species_name)) in aistate.colonisablePlanetIDs.items()
                             if score > minimal_top]
     minimal_planet_factor = 0.2  # count them for something, but not much
     num_colonisable_planet_ids = len(decent_opportunities) + minimal_planet_factor * len(minimal_opportunities)
@@ -280,13 +284,14 @@ def _calculate_outpost_priority():
     global allotted_outpost_targets
     base_outpost_cost = AIDependencies.OUTPOST_POD_COST
 
-    enemies_sighted = get_aistate().misc.get('enemies_sighted', {})
+    aistate = get_aistate()
+    enemies_sighted = aistate.misc.get('enemies_sighted', {})
     galaxy_is_sparse = ColonisationAI.galaxy_is_sparse()
     total_pp = fo.getEmpire().productionPoints
-    colony_growth_barrier = get_aistate().character.max_number_colonies()
+    colony_growth_barrier = aistate.character.max_number_colonies()
     if state.get_number_of_colonies() > colony_growth_barrier:
         return 0.0
-    mil_prio = get_aistate().get_priority(PriorityType.PRODUCTION_MILITARY)
+    mil_prio = aistate.get_priority(PriorityType.PRODUCTION_MILITARY)
 
     not_sparse, enemy_unseen = 0, 0
     is_sparse, enemy_seen = 1, 1
@@ -296,14 +301,14 @@ def _calculate_outpost_priority():
         (is_sparse, enemy_unseen): (0.8, 0.9),
         (is_sparse, enemy_seen): (0.3, 0.4),
     }[(galaxy_is_sparse, any(enemies_sighted))]
-    allotted_portion = get_aistate().character.preferred_outpost_portion(allotted_portion)
+    allotted_portion = aistate.character.preferred_outpost_portion(allotted_portion)
     if mil_prio < 100:
         allotted_portion *= 2
     elif mil_prio < 200:
         allotted_portion *= 1.5
     allotted_outpost_targets = 1 + int(total_pp * 3 * allotted_portion / base_outpost_cost)
 
-    num_outpost_targets = len([pid for (pid, (score, specName)) in get_aistate().colonisableOutpostIDs.items()
+    num_outpost_targets = len([pid for (pid, (score, specName)) in aistate.colonisableOutpostIDs.items()
                                if score > max(1.0 * base_outpost_cost / 3.0, ColonisationAI.MINIMUM_COLONY_SCORE)]
                               [:allotted_outpost_targets])
     if num_outpost_targets == 0 or not tech_is_complete(AIDependencies.OUTPOSTING_TECH):
@@ -331,18 +336,19 @@ def _calculate_outpost_priority():
 def _calculate_invasion_priority():
     """Calculates the demand for troop ships by opponent planets."""
 
-    if not get_aistate().character.may_invade():
+    aistate = get_aistate()
+    if not aistate.character.may_invade():
         return 0
 
     empire = fo.getEmpire()
-    enemies_sighted = get_aistate().misc.get('enemies_sighted', {})
+    enemies_sighted = aistate.misc.get('enemies_sighted', {})
     multiplier = 1
-    colony_growth_barrier = get_aistate().character.max_number_colonies()
+    colony_growth_barrier = aistate.character.max_number_colonies()
     if state.get_number_of_colonies() > colony_growth_barrier:
         return 0.0
 
-    if len(get_aistate().colonisablePlanetIDs) > 0:
-        best_colony_score = max(2, get_aistate().colonisablePlanetIDs.items()[0][1][0])
+    if len(aistate.colonisablePlanetIDs) > 0:
+        best_colony_score = max(2, aistate.colonisablePlanetIDs.items()[0][1][0])
     else:
         best_colony_score = 2
 
@@ -364,8 +370,8 @@ def _calculate_invasion_priority():
     for queue_index in range(0, len(production_queue)):
         element = production_queue[queue_index]
         if element.buildType == EmpireProductionTypes.BT_SHIP:
-            if get_aistate().get_ship_role(element.designID) in [ShipRoleType.MILITARY_INVASION,
-                                                                 ShipRoleType.BASE_INVASION]:
+            if aistate.get_ship_role(element.designID) in [ShipRoleType.MILITARY_INVASION,
+                                                           ShipRoleType.BASE_INVASION]:
                 design = fo.getShipDesign(element.designID)
                 queued_troop_capacity += element.remaining * element.blocksize * design.troopCapacity
     _, best_design, _ = ProductionAI.get_best_ship_info(PriorityType.PRODUCTION_INVASION)
@@ -395,7 +401,7 @@ def _calculate_invasion_priority():
     if invasion_priority < 0:
         return 0
 
-    return invasion_priority * get_aistate().character.invasion_priority_scaling()
+    return invasion_priority * aistate.character.invasion_priority_scaling()
 
 
 def allotted_invasion_targets():
@@ -417,11 +423,12 @@ def _calculate_military_priority():
                      tech_is_complete("SHP_WEAPON_4_1"))
     have_l2_weaps = (tech_is_complete("SHP_WEAPON_2_3") or
                      tech_is_complete("SHP_WEAPON_4_1"))
-    enemies_sighted = get_aistate().misc.get('enemies_sighted', {})
+    aistate = get_aistate()
+    enemies_sighted = aistate.misc.get('enemies_sighted', {})
 
     target_planet_ids = ([pid for pid, pscore, trp in AIstate.invasionTargets[:allotted_invasion_targets()]] +
-                         [pid for pid, pscore in get_aistate().colonisablePlanetIDs.items()[:allottedColonyTargets]] +
-                         [pid for pid, pscore in get_aistate().colonisableOutpostIDs.items()[:allottedColonyTargets]])
+                         [pid for pid, pscore in aistate.colonisablePlanetIDs.items()[:allottedColonyTargets]] +
+                         [pid for pid, pscore in aistate.colonisableOutpostIDs.items()[:allottedColonyTargets]])
 
     my_systems = set(state.get_empire_planets_by_system())
     target_systems = set(PlanetUtilsAI.get_systems(target_planet_ids))
@@ -432,7 +439,7 @@ def _calculate_military_priority():
     defense_ships_needed = 0
     ships_needed_allocation = []
     for sys_id in my_systems.union(target_systems):
-        status = get_aistate().systemStatus.get(sys_id, {})
+        status = aistate.systemStatus.get(sys_id, {})
         my_rating = status.get('myFleetRating', 0)
         my_defenses = status.get('mydefenses', {}).get('overall', 0)
         base_monster_threat = status.get('monsterThreat', 0)
@@ -470,15 +477,16 @@ def _calculate_military_priority():
     print fmt_string % (military_priority, ships_needed, defense_ships_needed, cur_ship_rating, have_l1_weaps, enemies_sighted)
     print "Source of milship demand: ", ships_needed_allocation
 
-    military_priority *= get_aistate().character.military_priority_scaling()
+    military_priority *= aistate.character.military_priority_scaling()
     return max(military_priority, 0)
 
 
 def _calculate_top_production_queue_priority():
     """Calculates the top production queue priority."""
     production_queue_priorities = {}
+    aistate = get_aistate()
     for priorityType in get_priority_production_types():
-        production_queue_priorities[priorityType] = get_aistate().get_priority(priorityType)
+        production_queue_priorities[priorityType] = aistate.get_priority(priorityType)
 
     sorted_priorities = production_queue_priorities.items()
     sorted_priorities.sort(lambda x, y: cmp(x[1], y[1]), reverse=True)

--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -11,7 +11,7 @@ import AIstate
 import ColonisationAI
 import CombatRatingsAI
 import FleetUtilsAI
-import FreeOrionAI as foAI
+from aistate_interface import get_aistate
 import MilitaryAI
 import PlanetUtilsAI
 import PriorityAI
@@ -216,7 +216,7 @@ def generate_production_orders():
     print
     print "  Total Available Production Points: %s" % total_pp
 
-    claimed_stars = foAI.foAIstate.misc.get('claimedStars', {})
+    claimed_stars = get_aistate().misc.get('claimedStars', {})
     if claimed_stars == {}:
         for sType in AIstate.empireStars:
             claimed_stars[sType] = list(AIstate.empireStars[sType])
@@ -240,7 +240,7 @@ def generate_production_orders():
                 fo.updateProductionQueue()
 
     building_expense = 0.0
-    building_ratio = foAI.foAIstate.character.preferred_building_ratio([0.4, 0.35, 0.30])
+    building_ratio = get_aistate().character.preferred_building_ratio([0.4, 0.35, 0.30])
     print "Buildings present on all owned planets:"
     for pid in state.get_all_empire_planets():
         planet = universe.getPlanet(pid)
@@ -369,15 +369,15 @@ def generate_production_orders():
 
     print "best_pilot_facilities: \n %s" % best_pilot_facilities
 
-    max_defense_portion = foAI.foAIstate.character.max_defense_portion()
-    if foAI.foAIstate.character.check_orbital_production():
+    max_defense_portion = get_aistate().character.max_defense_portion()
+    if get_aistate().character.check_orbital_production():
         sys_orbital_defenses = {}
         queued_defenses = {}
         defense_allocation = 0.0
-        target_orbitals = foAI.foAIstate.character.target_number_of_orbitals()
+        target_orbitals = get_aistate().character.target_number_of_orbitals()
         print "Orbital Defense Check -- target Defense Orbitals: ", target_orbitals
         for element in production_queue:
-            if (element.buildType == EmpireProductionTypes.BT_SHIP) and (foAI.foAIstate.get_ship_role(element.designID) == ShipRoleType.BASE_DEFENSE):
+            if (element.buildType == EmpireProductionTypes.BT_SHIP) and (get_aistate().get_ship_role(element.designID) == ShipRoleType.BASE_DEFENSE):
                 planet = universe.getPlanet(element.locationID)
                 if not planet:
                     print >> sys.stderr, "Problem getting Planet for build loc %s" % element.locationID
@@ -388,17 +388,17 @@ def generate_production_orders():
         print "Queued Defenses:", ppstring([(str(universe.getSystem(sid)), num)
                                             for sid, num in queued_defenses.items()])
         for sys_id, pids in state.get_empire_planets_by_system(include_outposts=False).items():
-            if foAI.foAIstate.systemStatus.get(sys_id, {}).get('fleetThreat', 1) > 0:
+            if get_aistate().systemStatus.get(sys_id, {}).get('fleetThreat', 1) > 0:
                 continue  # don't build orbital shields if enemy fleet present
             if defense_allocation > max_defense_portion * total_pp:
                 break
             sys_orbital_defenses[sys_id] = 0
-            fleets_here = foAI.foAIstate.systemStatus.get(sys_id, {}).get('myfleets', [])
+            fleets_here = get_aistate().systemStatus.get(sys_id, {}).get('myfleets', [])
             for fid in fleets_here:
-                if foAI.foAIstate.get_fleet_role(fid) == MissionType.ORBITAL_DEFENSE:
+                if get_aistate().get_fleet_role(fid) == MissionType.ORBITAL_DEFENSE:
                     print "Found %d existing Orbital Defenses in %s :" % (
-                        foAI.foAIstate.fleetStatus.get(fid, {}).get('nships', 0), universe.getSystem(sys_id))
-                    sys_orbital_defenses[sys_id] += foAI.foAIstate.fleetStatus.get(fid, {}).get('nships', 0)
+                        get_aistate().fleetStatus.get(fid, {}).get('nships', 0), universe.getSystem(sys_id))
+                    sys_orbital_defenses[sys_id] += get_aistate().fleetStatus.get(fid, {}).get('nships', 0)
             for pid in pids:
                 sys_orbital_defenses[sys_id] += queued_defenses.get(pid, 0)
             if sys_orbital_defenses[sys_id] < target_orbitals:
@@ -556,7 +556,7 @@ def generate_production_orders():
 
     shipyard_type = fo.getBuildingType("BLD_SHIPYARD_BASE")
     building_name = "BLD_SHIPYARD_AST"
-    if empire.buildingTypeAvailable(building_name) and foAI.foAIstate.character.may_build_building(building_name):
+    if empire.buildingTypeAvailable(building_name) and get_aistate().character.may_build_building(building_name):
         queued_building_locs = [element.locationID for element in production_queue if (element.name == building_name)]
         if not queued_building_locs:
             building_type = fo.getBuildingType(building_name)
@@ -642,7 +642,7 @@ def generate_production_orders():
 
     building_name = "BLD_GAS_GIANT_GEN"
     max_gggs = 1
-    if empire.buildingTypeAvailable(building_name) and foAI.foAIstate.character.may_build_building(building_name):
+    if empire.buildingTypeAvailable(building_name) and get_aistate().character.may_build_building(building_name):
         queued_building_locs = [element.locationID for element in production_queue if (element.name == building_name)]
         building_type = fo.getBuildingType(building_name)
         for pid in state.get_all_empire_planets():  # TODO: check to ensure that a resource center exists in system, or GGG would be wasted
@@ -669,7 +669,7 @@ def generate_production_orders():
                         print "Enqueueing %s at planet %d (%s) , with result %d" % (building_name, pid, universe.getPlanet(pid).name, res)
 
     building_name = "BLD_SOL_ORB_GEN"
-    if empire.buildingTypeAvailable(building_name) and foAI.foAIstate.character.may_build_building(building_name):
+    if empire.buildingTypeAvailable(building_name) and get_aistate().character.may_build_building(building_name):
         already_got_one = 99
         for pid in state.get_all_empire_planets():
             planet = universe.getPlanet(pid)
@@ -731,7 +731,7 @@ def generate_production_orders():
     building_name = "BLD_ART_BLACK_HOLE"
     if (
         empire.buildingTypeAvailable(building_name) and
-        foAI.foAIstate.character.may_build_building(building_name) and
+        get_aistate().character.may_build_building(building_name) and
         len(AIstate.empireStars.get(fo.starType.red, [])) > 0
     ):
         already_got_one = False
@@ -781,7 +781,7 @@ def generate_production_orders():
                     print "problem queueing %s at planet %s" % (building_name, planet_used)
 
     building_name = "BLD_BLACK_HOLE_POW_GEN"
-    if empire.buildingTypeAvailable(building_name) and foAI.foAIstate.character.may_build_building(building_name):
+    if empire.buildingTypeAvailable(building_name) and get_aistate().character.may_build_building(building_name):
         already_got_one = False
         for pid in state.get_all_empire_planets():
             planet = universe.getPlanet(pid)
@@ -917,7 +917,7 @@ def generate_production_orders():
             continue
         for shipID in fleet.shipIDs:
             ship = universe.getShip(shipID)
-            if ship and (foAI.foAIstate.get_ship_role(ship.design.id) == ShipRoleType.CIVILIAN_COLONISATION):
+            if ship and (get_aistate().get_ship_role(ship.design.id) == ShipRoleType.CIVILIAN_COLONISATION):
                 colony_ship_map.setdefault(ship.speciesName, []).append(1)
 
     building_name = "BLD_CONC_CAMP"
@@ -948,7 +948,7 @@ def generate_production_orders():
                 if universe.getBuilding(bldg).buildingTypeName == building_name:
                     res = fo.issueScrapOrder(bldg)
                     print "Tried scrapping %s at planet %s, got result %d" % (building_name, planet.name, res)
-        elif foAI.foAIstate.character.may_build_building(building_name) and can_build_camp and (t_pop >= 36):
+        elif get_aistate().character.may_build_building(building_name) and can_build_camp and (t_pop >= 36):
             if (planet.focus == FocusType.FOCUS_GROWTH) or (AIDependencies.COMPUTRONIUM_SPECIAL in planet.specials) or (pid == capital_id):
                 continue
                 # pass  # now that focus setting takes these into account, probably works ok to have conc camp, but let's not push it
@@ -1090,7 +1090,7 @@ def generate_production_orders():
     queued_clny_bld_locs = [element.locationID for element in production_queue
                             if (element.name.startswith('BLD_COL_') and
                                 empire_has_colony_bld_species(element.name))]
-    colony_bldg_entries = [entry for entry in foAI.foAIstate.colonisablePlanetIDs.items() if
+    colony_bldg_entries = [entry for entry in get_aistate().colonisablePlanetIDs.items() if
                            entry[1][0] > 60 and
                            entry[0] not in queued_clny_bld_locs and
                            entry[0] in state.get_empire_outposts() and
@@ -1161,7 +1161,7 @@ def generate_production_orders():
             else:
                 print "element %s is projected to never be completed as currently stands, but will remain on queue " % element.name
         elif element.buildType == EmpireProductionTypes.BT_SHIP:
-            this_role = foAI.foAIstate.get_ship_role(element.designID)
+            this_role = get_aistate().get_ship_role(element.designID)
             if this_role == ShipRoleType.CIVILIAN_COLONISATION:
                 this_spec = universe.getPlanet(element.locationID).speciesName
                 queued_colony_ships[this_spec] = queued_colony_ships.get(this_spec, 0) + element.remaining * element.blocksize
@@ -1183,18 +1183,18 @@ def generate_production_orders():
         fo.issueDequeueProductionOrder(queue_index)
 
     all_military_fleet_ids = FleetUtilsAI.get_empire_fleet_ids_by_role(MissionType.MILITARY)
-    total_military_ships = sum([foAI.foAIstate.fleetStatus.get(fid, {}).get('nships', 0) for fid in all_military_fleet_ids])
+    total_military_ships = sum([get_aistate().fleetStatus.get(fid, {}).get('nships', 0) for fid in all_military_fleet_ids])
     all_troop_fleet_ids = FleetUtilsAI.get_empire_fleet_ids_by_role(MissionType.INVASION)
-    total_troop_ships = sum([foAI.foAIstate.fleetStatus.get(fid, {}).get('nships', 0) for fid in all_troop_fleet_ids])
+    total_troop_ships = sum([get_aistate().fleetStatus.get(fid, {}).get('nships', 0) for fid in all_troop_fleet_ids])
     avail_troop_fleet_ids = list(FleetUtilsAI.extract_fleet_ids_without_mission_types(all_troop_fleet_ids))
-    total_available_troops = sum([foAI.foAIstate.fleetStatus.get(fid, {}).get('nships', 0) for fid in avail_troop_fleet_ids])
+    total_available_troops = sum([get_aistate().fleetStatus.get(fid, {}).get('nships', 0) for fid in avail_troop_fleet_ids])
     print "Trooper Status turn %d: %d total, with %d unassigned. %d queued, compared to %d total Military Attack Ships" % (current_turn, total_troop_ships,
                                                                                                                            total_available_troops, queued_troop_ships, total_military_ships)
     if (
         capital_id is not None and
         (current_turn >= 40 or can_prioritize_troops) and
-        foAI.foAIstate.systemStatus.get(capital_system_id, {}).get('fleetThreat', 0) == 0 and
-        foAI.foAIstate.systemStatus.get(capital_system_id, {}).get('neighborThreat', 0) == 0
+        get_aistate().systemStatus.get(capital_system_id, {}).get('fleetThreat', 0) == 0 and
+        get_aistate().systemStatus.get(capital_system_id, {}).get('neighborThreat', 0) == 0
     ):
         best_design_id, best_design, build_choices = get_best_ship_info(PriorityType.PRODUCTION_INVASION)
         if build_choices is not None and len(build_choices) > 0:
@@ -1204,7 +1204,7 @@ def generate_production_orders():
             troopers_needed = max(0, int(min(0.99 + (current_turn/20.0 - total_available_troops)/max(2, prod_time - 1), total_military_ships/3 - total_troop_ships)))
             ship_number = troopers_needed
             per_turn_cost = (float(prod_cost) / prod_time)
-            if troopers_needed > 0 and total_pp > 3*per_turn_cost*queued_troop_ships and foAI.foAIstate.character.may_produce_troops():
+            if troopers_needed > 0 and total_pp > 3*per_turn_cost*queued_troop_ships and get_aistate().character.may_produce_troops():
                 retval = fo.issueEnqueueShipProductionOrder(best_design_id, loc)
                 if retval != 0:
                     print "forcing %d new ship(s) to production queue: %s; per turn production cost %.1f" % (ship_number, best_design.name, ship_number*per_turn_cost)
@@ -1220,7 +1220,7 @@ def generate_production_orders():
     # get the highest production priorities
     production_priorities = {}
     for priority_type in get_priority_production_types():
-        production_priorities[priority_type] = int(max(0, (foAI.foAIstate.get_priority(priority_type)) ** 0.5))
+        production_priorities[priority_type] = int(max(0, (get_aistate().get_priority(priority_type)) ** 0.5))
 
     sorted_priorities = production_priorities.items()
     sorted_priorities.sort(lambda x, y: cmp(x[1], y[1]), reverse=True)
@@ -1291,7 +1291,7 @@ def generate_production_orders():
             this_spec = universe.getPlanet(loc).speciesName
             species_map.setdefault(this_spec, []).append(loc)
         colony_build_choices = []
-        for pid, (score, this_spec) in foAI.foAIstate.colonisablePlanetIDs.items():
+        for pid, (score, this_spec) in get_aistate().colonisablePlanetIDs.items():
             colony_build_choices.extend(int(math.ceil(score))*[pid_ for pid_ in species_map.get(this_spec, []) if pid_ in planet_set])
 
         local_priorities = {}
@@ -1473,7 +1473,7 @@ def build_ship_facilities(bld_name, best_pilot_facilities, top_locs=None):
     empire = fo.getEmpire()
     total_pp = empire.productionPoints
     __, prereq_bldg, this_cost, time = AIDependencies.SHIP_FACILITIES.get(bld_name, (None, '', -1, -1))
-    if not foAI.foAIstate.character.may_build_building(bld_name):
+    if not get_aistate().character.may_build_building(bld_name):
         return
     bld_type = fo.getBuildingType(bld_name)
     if not empire.buildingTypeAvailable(bld_name):
@@ -1570,7 +1570,7 @@ def find_automatic_historic_analyzer_candidates():
         fo.aggression.maniacal: (8, 5, 30)
     }
 
-    min_pp, turn_trigger, min_pp_per_additional = conditions.get(foAI.foAIstate.character.get_trait(Aggression).key,
+    min_pp, turn_trigger, min_pp_per_additional = conditions.get(get_aistate().character.get_trait(Aggression).key,
                                                                  (ARB_LARGE_NUMBER, ARB_LARGE_NUMBER, ARB_LARGE_NUMBER))
     max_enqueued = 1 if total_pp > min_pp or fo.currentTurn() > turn_trigger else 0
     max_enqueued += int(total_pp / min_pp_per_additional)
@@ -1605,12 +1605,11 @@ def get_number_of_queued_outpost_and_colony_ships():
     :rtype: int
     """
     num_ships = 0
+    considered_ship_roles = (ShipRoleType.CIVILIAN_OUTPOST, ShipRoleType.BASE_OUTPOST,
+                             ShipRoleType.BASE_COLONISATION, ShipRoleType.CIVILIAN_COLONISATION)
     for element in fo.getEmpire().productionQueue:
         if element.turnsLeft >= 0 and element.buildType == EmpireProductionTypes.BT_SHIP:
-            if foAI.foAIstate.get_ship_role(element.designID) in (ShipRoleType.CIVILIAN_OUTPOST,
-                                                                  ShipRoleType.BASE_OUTPOST,
-                                                                  ShipRoleType.BASE_COLONISATION,
-                                                                  ShipRoleType.CIVILIAN_COLONISATION):
+            if get_aistate().get_ship_role(element.designID) in considered_ship_roles:
                 num_ships += element.blocksize
     return num_ships
 

--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -216,7 +216,8 @@ def generate_production_orders():
     print
     print "  Total Available Production Points: %s" % total_pp
 
-    claimed_stars = get_aistate().misc.get('claimedStars', {})
+    aistate = get_aistate()
+    claimed_stars = aistate.misc.get('claimedStars', {})
     if claimed_stars == {}:
         for sType in AIstate.empireStars:
             claimed_stars[sType] = list(AIstate.empireStars[sType])
@@ -240,7 +241,7 @@ def generate_production_orders():
                 fo.updateProductionQueue()
 
     building_expense = 0.0
-    building_ratio = get_aistate().character.preferred_building_ratio([0.4, 0.35, 0.30])
+    building_ratio = aistate.character.preferred_building_ratio([0.4, 0.35, 0.30])
     print "Buildings present on all owned planets:"
     for pid in state.get_all_empire_planets():
         planet = universe.getPlanet(pid)
@@ -369,15 +370,16 @@ def generate_production_orders():
 
     print "best_pilot_facilities: \n %s" % best_pilot_facilities
 
-    max_defense_portion = get_aistate().character.max_defense_portion()
-    if get_aistate().character.check_orbital_production():
+    max_defense_portion = aistate.character.max_defense_portion()
+    if aistate.character.check_orbital_production():
         sys_orbital_defenses = {}
         queued_defenses = {}
         defense_allocation = 0.0
-        target_orbitals = get_aistate().character.target_number_of_orbitals()
+        target_orbitals = aistate.character.target_number_of_orbitals()
         print "Orbital Defense Check -- target Defense Orbitals: ", target_orbitals
         for element in production_queue:
-            if (element.buildType == EmpireProductionTypes.BT_SHIP) and (get_aistate().get_ship_role(element.designID) == ShipRoleType.BASE_DEFENSE):
+            if (element.buildType == EmpireProductionTypes.BT_SHIP) and (
+                    aistate.get_ship_role(element.designID) == ShipRoleType.BASE_DEFENSE):
                 planet = universe.getPlanet(element.locationID)
                 if not planet:
                     print >> sys.stderr, "Problem getting Planet for build loc %s" % element.locationID
@@ -388,17 +390,17 @@ def generate_production_orders():
         print "Queued Defenses:", ppstring([(str(universe.getSystem(sid)), num)
                                             for sid, num in queued_defenses.items()])
         for sys_id, pids in state.get_empire_planets_by_system(include_outposts=False).items():
-            if get_aistate().systemStatus.get(sys_id, {}).get('fleetThreat', 1) > 0:
+            if aistate.systemStatus.get(sys_id, {}).get('fleetThreat', 1) > 0:
                 continue  # don't build orbital shields if enemy fleet present
             if defense_allocation > max_defense_portion * total_pp:
                 break
             sys_orbital_defenses[sys_id] = 0
-            fleets_here = get_aistate().systemStatus.get(sys_id, {}).get('myfleets', [])
+            fleets_here = aistate.systemStatus.get(sys_id, {}).get('myfleets', [])
             for fid in fleets_here:
-                if get_aistate().get_fleet_role(fid) == MissionType.ORBITAL_DEFENSE:
+                if aistate.get_fleet_role(fid) == MissionType.ORBITAL_DEFENSE:
                     print "Found %d existing Orbital Defenses in %s :" % (
-                        get_aistate().fleetStatus.get(fid, {}).get('nships', 0), universe.getSystem(sys_id))
-                    sys_orbital_defenses[sys_id] += get_aistate().fleetStatus.get(fid, {}).get('nships', 0)
+                        aistate.fleetStatus.get(fid, {}).get('nships', 0), universe.getSystem(sys_id))
+                    sys_orbital_defenses[sys_id] += aistate.fleetStatus.get(fid, {}).get('nships', 0)
             for pid in pids:
                 sys_orbital_defenses[sys_id] += queued_defenses.get(pid, 0)
             if sys_orbital_defenses[sys_id] < target_orbitals:
@@ -556,7 +558,7 @@ def generate_production_orders():
 
     shipyard_type = fo.getBuildingType("BLD_SHIPYARD_BASE")
     building_name = "BLD_SHIPYARD_AST"
-    if empire.buildingTypeAvailable(building_name) and get_aistate().character.may_build_building(building_name):
+    if empire.buildingTypeAvailable(building_name) and aistate.character.may_build_building(building_name):
         queued_building_locs = [element.locationID for element in production_queue if (element.name == building_name)]
         if not queued_building_locs:
             building_type = fo.getBuildingType(building_name)
@@ -642,7 +644,7 @@ def generate_production_orders():
 
     building_name = "BLD_GAS_GIANT_GEN"
     max_gggs = 1
-    if empire.buildingTypeAvailable(building_name) and get_aistate().character.may_build_building(building_name):
+    if empire.buildingTypeAvailable(building_name) and aistate.character.may_build_building(building_name):
         queued_building_locs = [element.locationID for element in production_queue if (element.name == building_name)]
         building_type = fo.getBuildingType(building_name)
         for pid in state.get_all_empire_planets():  # TODO: check to ensure that a resource center exists in system, or GGG would be wasted
@@ -669,7 +671,7 @@ def generate_production_orders():
                         print "Enqueueing %s at planet %d (%s) , with result %d" % (building_name, pid, universe.getPlanet(pid).name, res)
 
     building_name = "BLD_SOL_ORB_GEN"
-    if empire.buildingTypeAvailable(building_name) and get_aistate().character.may_build_building(building_name):
+    if empire.buildingTypeAvailable(building_name) and aistate.character.may_build_building(building_name):
         already_got_one = 99
         for pid in state.get_all_empire_planets():
             planet = universe.getPlanet(pid)
@@ -731,7 +733,7 @@ def generate_production_orders():
     building_name = "BLD_ART_BLACK_HOLE"
     if (
         empire.buildingTypeAvailable(building_name) and
-        get_aistate().character.may_build_building(building_name) and
+        aistate.character.may_build_building(building_name) and
         len(AIstate.empireStars.get(fo.starType.red, [])) > 0
     ):
         already_got_one = False
@@ -781,7 +783,7 @@ def generate_production_orders():
                     print "problem queueing %s at planet %s" % (building_name, planet_used)
 
     building_name = "BLD_BLACK_HOLE_POW_GEN"
-    if empire.buildingTypeAvailable(building_name) and get_aistate().character.may_build_building(building_name):
+    if empire.buildingTypeAvailable(building_name) and aistate.character.may_build_building(building_name):
         already_got_one = False
         for pid in state.get_all_empire_planets():
             planet = universe.getPlanet(pid)
@@ -917,7 +919,7 @@ def generate_production_orders():
             continue
         for shipID in fleet.shipIDs:
             ship = universe.getShip(shipID)
-            if ship and (get_aistate().get_ship_role(ship.design.id) == ShipRoleType.CIVILIAN_COLONISATION):
+            if ship and (aistate.get_ship_role(ship.design.id) == ShipRoleType.CIVILIAN_COLONISATION):
                 colony_ship_map.setdefault(ship.speciesName, []).append(1)
 
     building_name = "BLD_CONC_CAMP"
@@ -948,7 +950,7 @@ def generate_production_orders():
                 if universe.getBuilding(bldg).buildingTypeName == building_name:
                     res = fo.issueScrapOrder(bldg)
                     print "Tried scrapping %s at planet %s, got result %d" % (building_name, planet.name, res)
-        elif get_aistate().character.may_build_building(building_name) and can_build_camp and (t_pop >= 36):
+        elif aistate.character.may_build_building(building_name) and can_build_camp and (t_pop >= 36):
             if (planet.focus == FocusType.FOCUS_GROWTH) or (AIDependencies.COMPUTRONIUM_SPECIAL in planet.specials) or (pid == capital_id):
                 continue
                 # pass  # now that focus setting takes these into account, probably works ok to have conc camp, but let's not push it
@@ -1090,7 +1092,7 @@ def generate_production_orders():
     queued_clny_bld_locs = [element.locationID for element in production_queue
                             if (element.name.startswith('BLD_COL_') and
                                 empire_has_colony_bld_species(element.name))]
-    colony_bldg_entries = [entry for entry in get_aistate().colonisablePlanetIDs.items() if
+    colony_bldg_entries = [entry for entry in aistate.colonisablePlanetIDs.items() if
                            entry[1][0] > 60 and
                            entry[0] not in queued_clny_bld_locs and
                            entry[0] in state.get_empire_outposts() and
@@ -1161,7 +1163,7 @@ def generate_production_orders():
             else:
                 print "element %s is projected to never be completed as currently stands, but will remain on queue " % element.name
         elif element.buildType == EmpireProductionTypes.BT_SHIP:
-            this_role = get_aistate().get_ship_role(element.designID)
+            this_role = aistate.get_ship_role(element.designID)
             if this_role == ShipRoleType.CIVILIAN_COLONISATION:
                 this_spec = universe.getPlanet(element.locationID).speciesName
                 queued_colony_ships[this_spec] = queued_colony_ships.get(this_spec, 0) + element.remaining * element.blocksize
@@ -1183,18 +1185,18 @@ def generate_production_orders():
         fo.issueDequeueProductionOrder(queue_index)
 
     all_military_fleet_ids = FleetUtilsAI.get_empire_fleet_ids_by_role(MissionType.MILITARY)
-    total_military_ships = sum([get_aistate().fleetStatus.get(fid, {}).get('nships', 0) for fid in all_military_fleet_ids])
+    total_military_ships = sum([aistate.fleetStatus.get(fid, {}).get('nships', 0) for fid in all_military_fleet_ids])
     all_troop_fleet_ids = FleetUtilsAI.get_empire_fleet_ids_by_role(MissionType.INVASION)
-    total_troop_ships = sum([get_aistate().fleetStatus.get(fid, {}).get('nships', 0) for fid in all_troop_fleet_ids])
+    total_troop_ships = sum([aistate.fleetStatus.get(fid, {}).get('nships', 0) for fid in all_troop_fleet_ids])
     avail_troop_fleet_ids = list(FleetUtilsAI.extract_fleet_ids_without_mission_types(all_troop_fleet_ids))
-    total_available_troops = sum([get_aistate().fleetStatus.get(fid, {}).get('nships', 0) for fid in avail_troop_fleet_ids])
+    total_available_troops = sum([aistate.fleetStatus.get(fid, {}).get('nships', 0) for fid in avail_troop_fleet_ids])
     print "Trooper Status turn %d: %d total, with %d unassigned. %d queued, compared to %d total Military Attack Ships" % (current_turn, total_troop_ships,
                                                                                                                            total_available_troops, queued_troop_ships, total_military_ships)
     if (
         capital_id is not None and
         (current_turn >= 40 or can_prioritize_troops) and
-        get_aistate().systemStatus.get(capital_system_id, {}).get('fleetThreat', 0) == 0 and
-        get_aistate().systemStatus.get(capital_system_id, {}).get('neighborThreat', 0) == 0
+        aistate.systemStatus.get(capital_system_id, {}).get('fleetThreat', 0) == 0 and
+        aistate.systemStatus.get(capital_system_id, {}).get('neighborThreat', 0) == 0
     ):
         best_design_id, best_design, build_choices = get_best_ship_info(PriorityType.PRODUCTION_INVASION)
         if build_choices is not None and len(build_choices) > 0:
@@ -1204,7 +1206,7 @@ def generate_production_orders():
             troopers_needed = max(0, int(min(0.99 + (current_turn/20.0 - total_available_troops)/max(2, prod_time - 1), total_military_ships/3 - total_troop_ships)))
             ship_number = troopers_needed
             per_turn_cost = (float(prod_cost) / prod_time)
-            if troopers_needed > 0 and total_pp > 3*per_turn_cost*queued_troop_ships and get_aistate().character.may_produce_troops():
+            if troopers_needed > 0 and total_pp > 3*per_turn_cost*queued_troop_ships and aistate.character.may_produce_troops():
                 retval = fo.issueEnqueueShipProductionOrder(best_design_id, loc)
                 if retval != 0:
                     print "forcing %d new ship(s) to production queue: %s; per turn production cost %.1f" % (ship_number, best_design.name, ship_number*per_turn_cost)
@@ -1220,7 +1222,7 @@ def generate_production_orders():
     # get the highest production priorities
     production_priorities = {}
     for priority_type in get_priority_production_types():
-        production_priorities[priority_type] = int(max(0, (get_aistate().get_priority(priority_type)) ** 0.5))
+        production_priorities[priority_type] = int(max(0, (aistate.get_priority(priority_type)) ** 0.5))
 
     sorted_priorities = production_priorities.items()
     sorted_priorities.sort(lambda x, y: cmp(x[1], y[1]), reverse=True)
@@ -1291,7 +1293,7 @@ def generate_production_orders():
             this_spec = universe.getPlanet(loc).speciesName
             species_map.setdefault(this_spec, []).append(loc)
         colony_build_choices = []
-        for pid, (score, this_spec) in get_aistate().colonisablePlanetIDs.items():
+        for pid, (score, this_spec) in aistate.colonisablePlanetIDs.items():
             colony_build_choices.extend(int(math.ceil(score))*[pid_ for pid_ in species_map.get(this_spec, []) if pid_ in planet_set])
 
         local_priorities = {}

--- a/default/python/AI/ResearchAI.py
+++ b/default/python/AI/ResearchAI.py
@@ -615,7 +615,8 @@ def generate_classic_research_orders():
     report_adjustments = False
     empire = fo.getEmpire()
     empire_id = empire.empireID
-    enemies_sighted = get_aistate().misc.get('enemies_sighted', {})
+    aistate = get_aistate()
+    enemies_sighted = aistate.misc.get('enemies_sighted', {})
     galaxy_is_sparse = ColonisationAI.galaxy_is_sparse()
     print "Research Queue Management:"
     resource_production = empire.resourceProduction(fo.resourceType.research)
@@ -713,21 +714,21 @@ def generate_classic_research_orders():
             research_queue_list = get_research_queue_techs()
             def_techs = TechsListsAI.defense_techs_1()
             for def_tech in def_techs:
-                if (get_aistate().character.may_research_tech_classic(def_tech)
+                if (aistate.character.may_research_tech_classic(def_tech)
                         and def_tech not in research_queue_list[:5] and not tech_is_complete(def_tech)):
                     res = fo.issueEnqueueTechOrder(def_tech, min(3, len(research_queue_list)))
                     print "Empire is very defensive, so attempted to fast-track %s, got result %d" % (def_tech, res)
         if False:  # with current stats of Conc Camps, disabling this fast-track
             research_queue_list = get_research_queue_techs()
-            if "CON_CONC_CAMP" in research_queue_list and get_aistate().character.may_research_tech_classic("CON_CONC_CAMP"):
+            if "CON_CONC_CAMP" in research_queue_list and aistate.character.may_research_tech_classic("CON_CONC_CAMP"):
                 insert_idx = min(40, research_queue_list.index("CON_CONC_CAMP"))
             else:
                 insert_idx = max(0, min(40, len(research_queue_list) - 10))
-            if "SHP_DEFLECTOR_SHIELD" in research_queue_list and get_aistate().character.may_research_tech_classic("SHP_DEFLECTOR_SHIELD"):
+            if "SHP_DEFLECTOR_SHIELD" in research_queue_list and aistate.character.may_research_tech_classic("SHP_DEFLECTOR_SHIELD"):
                 insert_idx = min(insert_idx, research_queue_list.index("SHP_DEFLECTOR_SHIELD"))
             for cc_tech in ["CON_ARCH_PSYCH", "CON_CONC_CAMP"]:
                 if (cc_tech not in research_queue_list[:insert_idx + 1] and not tech_is_complete(cc_tech)
-                        and get_aistate().character.may_research_tech_classic(cc_tech)):
+                        and aistate.character.may_research_tech_classic(cc_tech)):
                     res = fo.issueEnqueueTechOrder(cc_tech, insert_idx)
                     msg = "Empire is very aggressive, so attempted to fast-track %s, got result %d" % (cc_tech, res)
                     if report_adjustments:
@@ -774,14 +775,14 @@ def generate_classic_research_orders():
     #
     # Supply range and detection range
     if False:  # disabled for now, otherwise just to help with cold-folding / organization
-        if len(get_aistate().colonisablePlanetIDs) == 0:
+        if len(aistate.colonisablePlanetIDs) == 0:
             best_colony_site_score = 0
         else:
-            best_colony_site_score = get_aistate().colonisablePlanetIDs.items()[0][1]
-        if len(get_aistate().colonisableOutpostIDs) == 0:
+            best_colony_site_score = aistate.colonisablePlanetIDs.items()[0][1]
+        if len(aistate.colonisableOutpostIDs) == 0:
             best_outpost_site_score = 0
         else:
-            best_outpost_site_score = get_aistate().colonisableOutpostIDs.items()[0][1]
+            best_outpost_site_score = aistate.colonisableOutpostIDs.items()[0][1]
         need_improved_scouting = (best_colony_site_score < 150 or best_outpost_site_score < 200)
 
         if need_improved_scouting:
@@ -840,7 +841,7 @@ def generate_classic_research_orders():
     # check to accelerate xeno_arch
     if True:  # just to help with cold-folding /  organization
         if (state.have_ruins and not tech_is_complete("LRN_XENOARCH")
-                and get_aistate().character.may_research_tech_classic("LRN_XENOARCH")):
+                and aistate.character.may_research_tech_classic("LRN_XENOARCH")):
             if artif_minds in research_queue_list:
                 insert_idx = 7 + research_queue_list.index(artif_minds)
             elif "GRO_SYMBIOTIC_BIO" in research_queue_list:
@@ -947,7 +948,7 @@ def generate_classic_research_orders():
                 insert_idx = num_techs_accelerated
                 for xg_tech in ["GRO_XENO_GENETICS", "GRO_GENETIC_ENG"]:
                     if (xg_tech not in research_queue_list[:1 + num_techs_accelerated] and not tech_is_complete(xg_tech)
-                            and get_aistate().character.may_research_tech_classic(xg_tech)):
+                            and aistate.character.may_research_tech_classic(xg_tech)):
                         res = fo.issueEnqueueTechOrder(xg_tech, insert_idx)
                         num_techs_accelerated += 1
                         msg = "Empire has poor colonizers, so attempted to fast-track %s, got result %d" % (xg_tech, res)
@@ -970,7 +971,7 @@ def generate_classic_research_orders():
                 insert_idx = num_techs_accelerated
                 for dt_ech in ["LRN_PHYS_BRAIN", "LRN_TRANSLING_THT", "LRN_PSIONICS", "LRN_DISTRIB_THOUGHT"]:
                     if (dt_ech not in research_queue_list[:insert_idx + 2] and not tech_is_complete(dt_ech)
-                            and get_aistate().character.may_research_tech_classic(dt_ech)):
+                            and aistate.character.may_research_tech_classic(dt_ech)):
                         res = fo.issueEnqueueTechOrder(dt_ech, insert_idx)
                         num_techs_accelerated += 1
                         insert_idx += 1
@@ -984,7 +985,7 @@ def generate_classic_research_orders():
     #
     # check to accelerate quant net
     if False:  # disabled for now, otherwise just to help with cold-folding / organization
-        if get_aistate().character.may_research_tech_classic("LRN_QUANT_NET") and (state.population_with_research_focus() >= 40):
+        if aistate.character.may_research_tech_classic("LRN_QUANT_NET") and (state.population_with_research_focus() >= 40):
             if not tech_is_complete("LRN_QUANT_NET"):
                 insert_idx = num_techs_accelerated  # TODO determine min target slot if reenabling
                 for qnTech in ["LRN_NDIM_SUBSPACE", "LRN_QUANT_NET"]:
@@ -1002,7 +1003,7 @@ def generate_classic_research_orders():
     # if we own a blackhole, accelerate sing_gen and conc camp
     if True:  # just to help with cold-folding / organization
         if (fo.currentTurn() > 50 and len(AIstate.empireStars.get(fo.starType.blackHole, [])) != 0 and
-                get_aistate().character.may_research_tech_classic("PRO_SINGULAR_GEN") and not tech_is_complete(Dep.PRO_SINGULAR_GEN) and
+                aistate.character.may_research_tech_classic("PRO_SINGULAR_GEN") and not tech_is_complete(Dep.PRO_SINGULAR_GEN) and
                 tech_is_complete(Dep.PRO_SOL_ORB_GEN)):
             # sing_tech_list = [ "LRN_GRAVITONICS" , "PRO_SINGULAR_GEN"]  # formerly also "CON_ARCH_PSYCH", "CON_CONC_CAMP",
             sing_gen_tech = fo.getTech(Dep.PRO_SINGULAR_GEN)

--- a/default/python/AI/ResearchAI.py
+++ b/default/python/AI/ResearchAI.py
@@ -9,7 +9,7 @@ from common.print_utils import print_in_columns
 import AIDependencies as Dep
 import AIstate
 import ColonisationAI
-import FreeOrionAI as foAI
+from aistate_interface import get_aistate
 import ShipDesignAI
 import TechsListsAI
 from freeorion_tools import chat_human, get_ai_tag_grade, tech_is_complete
@@ -58,11 +58,11 @@ HIGH = 42
 
 # TODO research AI no longer use this method, rename and move this method elsewhere
 def get_research_index():
-    return foAI.foAIstate.character.get_research_index()
+    return get_aistate().character.get_research_index()
 
 
 def has_low_aggression():
-    return foAI.foAIstate.character.prefer_research_low_aggression()
+    return get_aistate().character.prefer_research_low_aggression()
 
 
 def conditional_priority(func_if_true, func_if_false, cond_func):
@@ -120,7 +120,7 @@ def has_star(star_type):
 def if_enemies(true_val, false_val):
     return conditional_priority(true_val,
                                 false_val,
-                                cond_func=lambda: foAI.foAIstate.misc.get('enemies_sighted', {}))
+                                cond_func=lambda: get_aistate().misc.get('enemies_sighted', {}))
 
 
 def if_dict(this_dict, this_key, true_val, false_val):
@@ -219,7 +219,7 @@ def get_stealth_priority(tech_name=""):
 
 
 def get_xeno_genetics_priority(tech_name=""):
-    if not foAI.foAIstate.character.may_research_xeno_genetics_variances():
+    if not get_aistate().character.may_research_xeno_genetics_variances():
         return get_population_boost_priority()
     if has_only_bad_colonizers():
         # Empire only have lousy colonisers, xeno-genetics are really important for them
@@ -271,7 +271,7 @@ def get_hull_priority(tech_name):
         get_ship_tech_usefulness(tech_name, ShipDesignAI.StandardTroopShipDesigner()),
         get_ship_tech_usefulness(tech_name, ShipDesignAI.StandardColonisationShipDesigner()))
 
-    if foAI.foAIstate.misc.get('enemies_sighted', {}):
+    if get_aistate().misc.get('enemies_sighted', {}):
         aggression = 1
     else:
         aggression = 0.1
@@ -348,7 +348,7 @@ def init():
     """
     choices.init()
     # prefixes for tech search. Check for prefix will be applied in same order as they defined
-    defensive = foAI.foAIstate.character.prefer_research_defensive()
+    defensive = get_aistate().character.prefer_research_defensive()
     prefixes = [
         (Dep.DEFENSE_TECHS_PREFIX, 2.0 if defensive else if_enemies(1.0, 0.2)),
         (Dep.WEAPON_PREFIX, ship_usefulness(if_enemies(1.0, 0.2), MIL_IDX))
@@ -605,7 +605,7 @@ def get_research_queue_techs():
 
 
 def exclude_tech(tech_name):
-    return ((not foAI.foAIstate.character.may_research_tech(tech_name))
+    return ((not get_aistate().character.may_research_tech(tech_name))
             or tech_name in TechsListsAI.unusable_techs()
             or tech_name in Dep.UNRESEARCHABLE_TECHS)
 
@@ -615,7 +615,7 @@ def generate_classic_research_orders():
     report_adjustments = False
     empire = fo.getEmpire()
     empire_id = empire.empireID
-    enemies_sighted = foAI.foAIstate.misc.get('enemies_sighted', {})
+    enemies_sighted = get_aistate().misc.get('enemies_sighted', {})
     galaxy_is_sparse = ColonisationAI.galaxy_is_sparse()
     print "Research Queue Management:"
     resource_production = empire.resourceProduction(fo.resourceType.research)
@@ -713,21 +713,21 @@ def generate_classic_research_orders():
             research_queue_list = get_research_queue_techs()
             def_techs = TechsListsAI.defense_techs_1()
             for def_tech in def_techs:
-                if (foAI.foAIstate.character.may_research_tech_classic(def_tech)
+                if (get_aistate().character.may_research_tech_classic(def_tech)
                         and def_tech not in research_queue_list[:5] and not tech_is_complete(def_tech)):
                     res = fo.issueEnqueueTechOrder(def_tech, min(3, len(research_queue_list)))
                     print "Empire is very defensive, so attempted to fast-track %s, got result %d" % (def_tech, res)
         if False:  # with current stats of Conc Camps, disabling this fast-track
             research_queue_list = get_research_queue_techs()
-            if "CON_CONC_CAMP" in research_queue_list and foAI.foAIstate.character.may_research_tech_classic("CON_CONC_CAMP"):
+            if "CON_CONC_CAMP" in research_queue_list and get_aistate().character.may_research_tech_classic("CON_CONC_CAMP"):
                 insert_idx = min(40, research_queue_list.index("CON_CONC_CAMP"))
             else:
                 insert_idx = max(0, min(40, len(research_queue_list) - 10))
-            if "SHP_DEFLECTOR_SHIELD" in research_queue_list and foAI.foAIstate.character.may_research_tech_classic("SHP_DEFLECTOR_SHIELD"):
+            if "SHP_DEFLECTOR_SHIELD" in research_queue_list and get_aistate().character.may_research_tech_classic("SHP_DEFLECTOR_SHIELD"):
                 insert_idx = min(insert_idx, research_queue_list.index("SHP_DEFLECTOR_SHIELD"))
             for cc_tech in ["CON_ARCH_PSYCH", "CON_CONC_CAMP"]:
                 if (cc_tech not in research_queue_list[:insert_idx + 1] and not tech_is_complete(cc_tech)
-                        and foAI.foAIstate.character.may_research_tech_classic(cc_tech)):
+                        and get_aistate().character.may_research_tech_classic(cc_tech)):
                     res = fo.issueEnqueueTechOrder(cc_tech, insert_idx)
                     msg = "Empire is very aggressive, so attempted to fast-track %s, got result %d" % (cc_tech, res)
                     if report_adjustments:
@@ -774,14 +774,14 @@ def generate_classic_research_orders():
     #
     # Supply range and detection range
     if False:  # disabled for now, otherwise just to help with cold-folding / organization
-        if len(foAI.foAIstate.colonisablePlanetIDs) == 0:
+        if len(get_aistate().colonisablePlanetIDs) == 0:
             best_colony_site_score = 0
         else:
-            best_colony_site_score = foAI.foAIstate.colonisablePlanetIDs.items()[0][1]
-        if len(foAI.foAIstate.colonisableOutpostIDs) == 0:
+            best_colony_site_score = get_aistate().colonisablePlanetIDs.items()[0][1]
+        if len(get_aistate().colonisableOutpostIDs) == 0:
             best_outpost_site_score = 0
         else:
-            best_outpost_site_score = foAI.foAIstate.colonisableOutpostIDs.items()[0][1]
+            best_outpost_site_score = get_aistate().colonisableOutpostIDs.items()[0][1]
         need_improved_scouting = (best_colony_site_score < 150 or best_outpost_site_score < 200)
 
         if need_improved_scouting:
@@ -840,7 +840,7 @@ def generate_classic_research_orders():
     # check to accelerate xeno_arch
     if True:  # just to help with cold-folding /  organization
         if (state.have_ruins and not tech_is_complete("LRN_XENOARCH")
-                and foAI.foAIstate.character.may_research_tech_classic("LRN_XENOARCH")):
+                and get_aistate().character.may_research_tech_classic("LRN_XENOARCH")):
             if artif_minds in research_queue_list:
                 insert_idx = 7 + research_queue_list.index(artif_minds)
             elif "GRO_SYMBIOTIC_BIO" in research_queue_list:
@@ -947,7 +947,7 @@ def generate_classic_research_orders():
                 insert_idx = num_techs_accelerated
                 for xg_tech in ["GRO_XENO_GENETICS", "GRO_GENETIC_ENG"]:
                     if (xg_tech not in research_queue_list[:1 + num_techs_accelerated] and not tech_is_complete(xg_tech)
-                            and foAI.foAIstate.character.may_research_tech_classic(xg_tech)):
+                            and get_aistate().character.may_research_tech_classic(xg_tech)):
                         res = fo.issueEnqueueTechOrder(xg_tech, insert_idx)
                         num_techs_accelerated += 1
                         msg = "Empire has poor colonizers, so attempted to fast-track %s, got result %d" % (xg_tech, res)
@@ -970,7 +970,7 @@ def generate_classic_research_orders():
                 insert_idx = num_techs_accelerated
                 for dt_ech in ["LRN_PHYS_BRAIN", "LRN_TRANSLING_THT", "LRN_PSIONICS", "LRN_DISTRIB_THOUGHT"]:
                     if (dt_ech not in research_queue_list[:insert_idx + 2] and not tech_is_complete(dt_ech)
-                            and foAI.foAIstate.character.may_research_tech_classic(dt_ech)):
+                            and get_aistate().character.may_research_tech_classic(dt_ech)):
                         res = fo.issueEnqueueTechOrder(dt_ech, insert_idx)
                         num_techs_accelerated += 1
                         insert_idx += 1
@@ -984,7 +984,7 @@ def generate_classic_research_orders():
     #
     # check to accelerate quant net
     if False:  # disabled for now, otherwise just to help with cold-folding / organization
-        if foAI.foAIstate.character.may_research_tech_classic("LRN_QUANT_NET") and (state.population_with_research_focus() >= 40):
+        if get_aistate().character.may_research_tech_classic("LRN_QUANT_NET") and (state.population_with_research_focus() >= 40):
             if not tech_is_complete("LRN_QUANT_NET"):
                 insert_idx = num_techs_accelerated  # TODO determine min target slot if reenabling
                 for qnTech in ["LRN_NDIM_SUBSPACE", "LRN_QUANT_NET"]:
@@ -1002,7 +1002,7 @@ def generate_classic_research_orders():
     # if we own a blackhole, accelerate sing_gen and conc camp
     if True:  # just to help with cold-folding / organization
         if (fo.currentTurn() > 50 and len(AIstate.empireStars.get(fo.starType.blackHole, [])) != 0 and
-                foAI.foAIstate.character.may_research_tech_classic("PRO_SINGULAR_GEN") and not tech_is_complete(Dep.PRO_SINGULAR_GEN) and
+                get_aistate().character.may_research_tech_classic("PRO_SINGULAR_GEN") and not tech_is_complete(Dep.PRO_SINGULAR_GEN) and
                 tech_is_complete(Dep.PRO_SOL_ORB_GEN)):
             # sing_tech_list = [ "LRN_GRAVITONICS" , "PRO_SINGULAR_GEN"]  # formerly also "CON_ARCH_PSYCH", "CON_CONC_CAMP",
             sing_gen_tech = fo.getTech(Dep.PRO_SINGULAR_GEN)

--- a/default/python/AI/ResourcesAI.py
+++ b/default/python/AI/ResourcesAI.py
@@ -12,7 +12,7 @@ have their future focus decided.
 from logging import info, warn, debug
 
 import freeOrionAIInterface as fo  # pylint: disable=import-error
-import FreeOrionAI as foAI
+from aistate_interface import get_aistate
 from EnumsAI import PriorityType, get_priority_resource_types, FocusType
 import PlanetUtilsAI
 import ColonisationAI
@@ -258,7 +258,7 @@ class Reporter(object):
         print "Resource Priorities:"
         resource_priorities = {}
         for priority_type in get_priority_resource_types():
-            resource_priorities[priority_type] = foAI.foAIstate.get_priority(priority_type)
+            resource_priorities[priority_type] = get_aistate().get_priority(priority_type)
 
         sorted_priorities = resource_priorities.items()
         sorted_priorities.sort(lambda x, y: cmp(x[1], y[1]), reverse=True)
@@ -311,8 +311,8 @@ def weighted_sum_output(outputs):
 def assess_protection_focus(pinfo):
     """Return True if planet should use Protection Focus."""
     this_planet = pinfo.planet
-    sys_status = foAI.foAIstate.systemStatus.get(this_planet.systemID, {})
-    threat_from_supply = (0.25 * foAI.foAIstate.empire_standard_enemy_rating *
+    sys_status = get_aistate().systemStatus.get(this_planet.systemID, {})
+    threat_from_supply = (0.25 * get_aistate().empire_standard_enemy_rating *
                           min(2, len(sys_status.get('enemies_nearly_supplied', []))))
     print "%s has regional+supply threat of %.1f" % (this_planet, threat_from_supply)
     regional_threat = sys_status.get('regional_threat', 0) + threat_from_supply
@@ -399,7 +399,7 @@ def assess_protection_focus(pinfo):
 
 def set_planet_growth_specials(focus_manager):
     """set resource foci of planets with potentially useful growth factors. Remove planets from list of candidates."""
-    if not foAI.foAIstate.character.may_use_growth_focus():
+    if not get_aistate().character.may_use_growth_focus():
         return
 
     # TODO Consider actual resource output of the candidate locations rather than only population
@@ -595,7 +595,7 @@ def set_planet_industry_and_research_foci(focus_manager, priority_ratio):
                 # TODO: add similar decision points by which research-rich planets
                 # might possibly choose to dither for industry points
                 if any((has_force,
-                        not foAI.foAIstate.character.may_dither_focus_to_gain_research(),
+                        not get_aistate().character.may_dither_focus_to_gain_research(),
                         target_rp >= priority_ratio * cumulative_pp)):
                     continue
 
@@ -647,7 +647,7 @@ def set_planet_industry_and_research_foci(focus_manager, priority_ratio):
     got_algo = tech_is_complete("LRN_ALGO_ELEGANCE")
     for ratio, pid, pinfo in ratios:
         if priority_ratio < (target_rp / (target_pp + 0.0001)):  # we have enough RP
-            if ratio < 1.1 and foAI.foAIstate.character.may_research_heavily():
+            if ratio < 1.1 and get_aistate().character.may_research_heavily():
                 # but wait, RP is still super cheap relative to PP, maybe will take more RP
                 if priority_ratio < 1.5 * (target_rp / (target_pp + 0.0001)):
                     # yeah, really a glut of RP, stop taking RP
@@ -695,8 +695,8 @@ def set_planet_resource_foci():
     Reporter.print_resource_ai_header()
     resource_timer.start("Priority")
     # TODO: take into acct splintering of resource groups
-    production_priority = foAI.foAIstate.get_priority(PriorityType.RESOURCE_PRODUCTION)
-    research_priority = foAI.foAIstate.get_priority(PriorityType.RESOURCE_RESEARCH)
+    production_priority = get_aistate().get_priority(PriorityType.RESOURCE_PRODUCTION)
+    research_priority = get_aistate().get_priority(PriorityType.RESOURCE_RESEARCH)
     priority_ratio = float(research_priority) / (production_priority + 0.0001)
 
     focus_manager = PlanetFocusManager()

--- a/default/python/AI/ResourcesAI.py
+++ b/default/python/AI/ResourcesAI.py
@@ -257,8 +257,9 @@ class Reporter(object):
         empire_planet_ids = PlanetUtilsAI.get_owned_planets_by_empire(universe.planetIDs)
         print "Resource Priorities:"
         resource_priorities = {}
+        aistate = get_aistate()
         for priority_type in get_priority_resource_types():
-            resource_priorities[priority_type] = get_aistate().get_priority(priority_type)
+            resource_priorities[priority_type] = aistate.get_priority(priority_type)
 
         sorted_priorities = resource_priorities.items()
         sorted_priorities.sort(lambda x, y: cmp(x[1], y[1]), reverse=True)
@@ -311,8 +312,9 @@ def weighted_sum_output(outputs):
 def assess_protection_focus(pinfo):
     """Return True if planet should use Protection Focus."""
     this_planet = pinfo.planet
-    sys_status = get_aistate().systemStatus.get(this_planet.systemID, {})
-    threat_from_supply = (0.25 * get_aistate().empire_standard_enemy_rating *
+    aistate = get_aistate()
+    sys_status = aistate.systemStatus.get(this_planet.systemID, {})
+    threat_from_supply = (0.25 * aistate.empire_standard_enemy_rating *
                           min(2, len(sys_status.get('enemies_nearly_supplied', []))))
     print "%s has regional+supply threat of %.1f" % (this_planet, threat_from_supply)
     regional_threat = sys_status.get('regional_threat', 0) + threat_from_supply
@@ -567,6 +569,7 @@ def set_planet_industry_and_research_foci(focus_manager, priority_ratio):
     # smallest possible ratio of research to industry with an all industry focus
     maxi_ratio = cumulative_rp / max(0.01, cumulative_pp)
 
+    aistate = get_aistate()
     for adj_round in [1, 2, 3, 4]:
         for pid, pinfo in focus_manager.raw_planet_info.items():
             ii, tr = pinfo.possible_output[INDUSTRY]
@@ -595,7 +598,7 @@ def set_planet_industry_and_research_foci(focus_manager, priority_ratio):
                 # TODO: add similar decision points by which research-rich planets
                 # might possibly choose to dither for industry points
                 if any((has_force,
-                        not get_aistate().character.may_dither_focus_to_gain_research(),
+                        not aistate.character.may_dither_focus_to_gain_research(),
                         target_rp >= priority_ratio * cumulative_pp)):
                     continue
 
@@ -647,7 +650,7 @@ def set_planet_industry_and_research_foci(focus_manager, priority_ratio):
     got_algo = tech_is_complete("LRN_ALGO_ELEGANCE")
     for ratio, pid, pinfo in ratios:
         if priority_ratio < (target_rp / (target_pp + 0.0001)):  # we have enough RP
-            if ratio < 1.1 and get_aistate().character.may_research_heavily():
+            if ratio < 1.1 and aistate.character.may_research_heavily():
                 # but wait, RP is still super cheap relative to PP, maybe will take more RP
                 if priority_ratio < 1.5 * (target_rp / (target_pp + 0.0001)):
                     # yeah, really a glut of RP, stop taking RP
@@ -695,8 +698,9 @@ def set_planet_resource_foci():
     Reporter.print_resource_ai_header()
     resource_timer.start("Priority")
     # TODO: take into acct splintering of resource groups
-    production_priority = get_aistate().get_priority(PriorityType.RESOURCE_PRODUCTION)
-    research_priority = get_aistate().get_priority(PriorityType.RESOURCE_RESEARCH)
+    aistate = get_aistate()
+    production_priority = aistate.get_priority(PriorityType.RESOURCE_PRODUCTION)
+    research_priority = aistate.get_priority(PriorityType.RESOURCE_RESEARCH)
     priority_ratio = float(research_priority) / (production_priority + 0.0001)
 
     focus_manager = PlanetFocusManager()

--- a/default/python/AI/ShipDesignAI.py
+++ b/default/python/AI/ShipDesignAI.py
@@ -48,7 +48,7 @@ from collections import Counter, defaultdict
 from logging import debug, info, warn, error
 
 import freeOrionAIInterface as fo
-import FreeOrionAI as foAI
+from aistate_interface import get_aistate
 import AIDependencies
 import CombatRatingsAI
 import FleetUtilsAI
@@ -639,7 +639,7 @@ class AdditionalSpecifications(object):
         else:
             self.enemy_mine_dmg = 14
         self.enemy = None
-        self.update_enemy(foAI.foAIstate.get_standard_enemy())
+        self.update_enemy(get_aistate().get_standard_enemy())
 
     def update_enemy(self, enemy):
         """Read out the enemies stats and save them.
@@ -1615,7 +1615,7 @@ class MilitaryShipDesignerBaseClass(ShipDesigner):
     def _adjusted_production_cost(self):
         # as military ships are grouped up in fleets, their power rating scales quadratic in numbers.
         # To account for this, we need to maximize rating/cost_squared not rating/cost as usual.
-        exponent = foAI.foAIstate.character.warship_adjusted_production_cost_exponent()
+        exponent = get_aistate().character.warship_adjusted_production_cost_exponent()
         return super(MilitaryShipDesignerBaseClass, self)._adjusted_production_cost()**exponent
 
     def _effective_structure(self):

--- a/default/python/AI/aistate_interface.py
+++ b/default/python/AI/aistate_interface.py
@@ -1,0 +1,37 @@
+"""
+This module provides an interface for a quasi-singleton AIstate instance.
+
+The AIstate must be initialized after module imports using either
+   * create_new_aistate
+   * load_aistate
+This should happen only once per session and be triggered by the game client.
+
+Access to the AIstate is provided via get_aistate().
+
+Example usage:
+    from aistate_interface import get_aistate()
+    get_aistate().get_all_fleet_missions()
+
+"""
+_aistate = None
+
+
+def create_new_aistate(*args, **kwargs):
+    import AIstate
+    global _aistate
+    _aistate = AIstate.AIstate(*args, **kwargs)
+    return _aistate
+
+
+def load_aistate(savegame_string):
+    import savegame_codec
+    global _aistate
+    _aistate = savegame_codec.load_savegame_string(savegame_string)
+    return _aistate
+
+
+def get_aistate():
+    """
+    :rtype: AIstate.AIstate
+    """
+    return _aistate

--- a/default/python/AI/fleet_orders.py
+++ b/default/python/AI/fleet_orders.py
@@ -4,7 +4,7 @@ from EnumsAI import ShipRoleType, MissionType
 import EspionageAI
 import FleetUtilsAI
 import freeOrionAIInterface as fo  # pylint: disable=import-error
-import FreeOrionAI as foAI
+from aistate_interface import get_aistate
 import MilitaryAI
 import MoveUtilsAI
 import CombatRatingsAI
@@ -130,7 +130,7 @@ class AIFleetOrder(object):
 
         if verbose:
             sys1 = self.fleet.get_system()
-            main_fleet_mission = foAI.foAIstate.get_fleet_mission(self.fleet.id)
+            main_fleet_mission = get_aistate().get_fleet_mission(self.fleet.id)
             print "  Can issue %s - Mission Type %s (%s), current loc sys %d - %s" % (
                 self, main_fleet_mission.type,
                 main_fleet_mission.type, self.fleet.id, sys1)
@@ -174,24 +174,24 @@ class OrderMove(AIFleetOrder):
         #                                        MissionType.SECURE,
         #                                        MissionType.HIT_AND_RUN,
         #                                        MissionType.EXPLORATION]:
-        #     if not universe.getVisibility(target_id, foAI.foAIstate.empireID) >= fo.visibility.partial:
+        #     if not universe.getVisibility(target_id, get_aistate().empireID) >= fo.visibility.partial:
         #         #if not target_id in interior systems
-        #         foAI.foAIstate.needsEmergencyExploration.append(fleet.systemID)
+        #         get_aistate().needsEmergencyExploration.append(fleet.systemID)
         #         return False
         system_id = self.fleet.get_system().id
         if system_id == self.target.get_system().id:
             return True  # TODO: already there, but could consider retreating
 
-        main_fleet_mission = foAI.foAIstate.get_fleet_mission(self.fleet.id)
+        main_fleet_mission = get_aistate().get_fleet_mission(self.fleet.id)
 
         fleet_rating = CombatRatingsAI.get_fleet_rating(self.fleet.id)
         fleet_rating_vs_planets = CombatRatingsAI.get_fleet_rating_against_planets(self.fleet.id)
-        target_sys_status = foAI.foAIstate.systemStatus.get(self.target.id, {})
+        target_sys_status = get_aistate().systemStatus.get(self.target.id, {})
         f_threat = target_sys_status.get('fleetThreat', 0)
         m_threat = target_sys_status.get('monsterThreat', 0)
         p_threat = target_sys_status.get('planetThreat', 0)
         threat = f_threat + m_threat + p_threat
-        safety_factor = foAI.foAIstate.character.military_safety_factor()
+        safety_factor = get_aistate().character.military_safety_factor()
         universe = fo.getUniverse()
         if main_fleet_mission.type == MissionType.INVASION and not trooper_move_reqs_met(main_fleet_mission,
                                                                                          self, verbose):
@@ -206,10 +206,10 @@ class OrderMove(AIFleetOrder):
             target_system = self.target.get_system()
             target_system_name = (target_system and target_system.get_object().name) or "unknown"
             # TODO: adjust calc for any departing fleets
-            my_other_fleet_rating = foAI.foAIstate.systemStatus.get(self.target.id, {}).get('myFleetRating', 0)
-            my_other_fleet_rating_vs_planets = foAI.foAIstate.systemStatus.get(self.target.id, {}).get(
+            my_other_fleet_rating = get_aistate().systemStatus.get(self.target.id, {}).get('myFleetRating', 0)
+            my_other_fleet_rating_vs_planets = get_aistate().systemStatus.get(self.target.id, {}).get(
                 'myFleetRatingVsPlanets', 0)
-            is_military = foAI.foAIstate.get_fleet_role(self.fleet.id) == MissionType.MILITARY
+            is_military = get_aistate().get_fleet_role(self.fleet.id) == MissionType.MILITARY
 
             total_rating = CombatRatingsAI.combine_ratings(my_other_fleet_rating, fleet_rating)
             total_rating_vs_planets = CombatRatingsAI.combine_ratings(my_other_fleet_rating_vs_planets,
@@ -235,7 +235,7 @@ class OrderMove(AIFleetOrder):
                     print ("\tHolding fleet %d (rating %d) at system %d (%s) "
                            "before travelling to system %d (%s) with threat %d") % (
                         self.fleet.id, fleet_rating, system_id, sys1_name, self.target.id, target_system_name, threat)
-                needs_vis = foAI.foAIstate.misc.setdefault('needs_vis', [])
+                needs_vis = get_aistate().misc.setdefault('needs_vis', [])
                 if self.target.id not in needs_vis:
                     needs_vis.append(self.target.id)
                 return False
@@ -251,9 +251,9 @@ class OrderMove(AIFleetOrder):
             fo.issueFleetMoveOrder(fleet_id, dest_id)
             print "Order issued: %s fleet: %s target: %s" % (self.ORDER_NAME, self.fleet, self.target)
         if system_id == fleet.systemID:
-            if foAI.foAIstate.get_fleet_role(fleet_id) == MissionType.EXPLORATION:
-                if system_id in foAI.foAIstate.needsEmergencyExploration:
-                    foAI.foAIstate.needsEmergencyExploration.remove(system_id)
+            if get_aistate().get_fleet_role(fleet_id) == MissionType.EXPLORATION:
+                if system_id in get_aistate().needsEmergencyExploration:
+                    get_aistate().needsEmergencyExploration.remove(system_id)
         return True
 
 
@@ -290,9 +290,9 @@ class OrderResupply(AIFleetOrder):
         system_id = self.target.get_system().id
         fleet = self.fleet.get_object()
         if system_id == fleet.systemID:
-            if foAI.foAIstate.get_fleet_role(fleet_id) == MissionType.EXPLORATION:
-                if system_id in foAI.foAIstate.needsEmergencyExploration:
-                    foAI.foAIstate.needsEmergencyExploration.remove(system_id)
+            if get_aistate().get_fleet_role(fleet_id) == MissionType.EXPLORATION:
+                if system_id in get_aistate().needsEmergencyExploration:
+                    get_aistate().needsEmergencyExploration.remove(system_id)
             return True
         if system_id != fleet.nextSystemID:
             self.executed = False
@@ -465,7 +465,7 @@ class OrderInvade(AIFleetOrder):
         result = False
         for ship_id in fleet.shipIDs:
             ship = universe.getShip(ship_id)
-            role = foAI.foAIstate.get_ship_role(ship.design.id)
+            role = get_aistate().get_ship_role(ship.design.id)
             if role not in invasion_roles:
                 continue
 
@@ -478,10 +478,10 @@ class OrderInvade(AIFleetOrder):
                 warn("Invasion order failed!")
                 debug(" -- planet has %.1f stealth, shields %.1f, %.1f population and "
                       "is owned by empire %d" % (planet_stealth, shields, pop, planet.owner))
-                if 'needsEmergencyExploration' not in dir(foAI.foAIstate):
-                    foAI.foAIstate.needsEmergencyExploration = []
-                if fleet.systemID not in foAI.foAIstate.needsEmergencyExploration:
-                    foAI.foAIstate.needsEmergencyExploration.append(fleet.systemID)
+                if 'needsEmergencyExploration' not in dir(get_aistate()):
+                    get_aistate().needsEmergencyExploration = []
+                if fleet.systemID not in get_aistate().needsEmergencyExploration:
+                    get_aistate().needsEmergencyExploration.append(fleet.systemID)
                     debug("Due to trouble invading, adding system %d to Emergency Exploration List" % fleet.systemID)
                 self.executed = False
                 # debug(universe.getPlanet(planet_id).dump())  # TODO: fix fo.UniverseObject.dump()
@@ -519,7 +519,7 @@ class OrderMilitary(AIFleetOrder):
             return False
         target_sys_id = self.target.id
         fleet = self.target.get_object()
-        system_status = foAI.foAIstate.systemStatus.get(target_sys_id, {})
+        system_status = get_aistate().systemStatus.get(target_sys_id, {})
         total_threat = sum(system_status.get(threat, 0) for threat in ('fleetThreat', 'planetThreat', 'monsterThreat'))
         combat_trigger = system_status.get('fleetThreat', 0) or system_status.get('monsterThreat', 0)
         if not combat_trigger and system_status.get('planetThreat', 0):
@@ -561,9 +561,9 @@ class OrderRepair(AIFleetOrder):
         system_id = self.target.get_system().id
         fleet = self.fleet.get_object()  # type: fo.fleet
         if system_id == fleet.systemID:
-            if foAI.foAIstate.get_fleet_role(fleet_id) == MissionType.EXPLORATION:
-                if system_id in foAI.foAIstate.needsEmergencyExploration:
-                    foAI.foAIstate.needsEmergencyExploration.remove(system_id)
+            if get_aistate().get_fleet_role(fleet_id) == MissionType.EXPLORATION:
+                if system_id in get_aistate().needsEmergencyExploration:
+                    get_aistate().needsEmergencyExploration.remove(system_id)
         elif system_id != fleet.nextSystemID:
             fo.issueAggressionOrder(fleet_id, False)
             start_id = FleetUtilsAI.get_fleet_system(fleet)

--- a/default/python/AI/fleet_orders.py
+++ b/default/python/AI/fleet_orders.py
@@ -182,16 +182,17 @@ class OrderMove(AIFleetOrder):
         if system_id == self.target.get_system().id:
             return True  # TODO: already there, but could consider retreating
 
-        main_fleet_mission = get_aistate().get_fleet_mission(self.fleet.id)
+        aistate = get_aistate()
+        main_fleet_mission = aistate.get_fleet_mission(self.fleet.id)
 
         fleet_rating = CombatRatingsAI.get_fleet_rating(self.fleet.id)
         fleet_rating_vs_planets = CombatRatingsAI.get_fleet_rating_against_planets(self.fleet.id)
-        target_sys_status = get_aistate().systemStatus.get(self.target.id, {})
+        target_sys_status = aistate.systemStatus.get(self.target.id, {})
         f_threat = target_sys_status.get('fleetThreat', 0)
         m_threat = target_sys_status.get('monsterThreat', 0)
         p_threat = target_sys_status.get('planetThreat', 0)
         threat = f_threat + m_threat + p_threat
-        safety_factor = get_aistate().character.military_safety_factor()
+        safety_factor = aistate.character.military_safety_factor()
         universe = fo.getUniverse()
         if main_fleet_mission.type == MissionType.INVASION and not trooper_move_reqs_met(main_fleet_mission,
                                                                                          self, verbose):
@@ -206,10 +207,10 @@ class OrderMove(AIFleetOrder):
             target_system = self.target.get_system()
             target_system_name = (target_system and target_system.get_object().name) or "unknown"
             # TODO: adjust calc for any departing fleets
-            my_other_fleet_rating = get_aistate().systemStatus.get(self.target.id, {}).get('myFleetRating', 0)
-            my_other_fleet_rating_vs_planets = get_aistate().systemStatus.get(self.target.id, {}).get(
+            my_other_fleet_rating = aistate.systemStatus.get(self.target.id, {}).get('myFleetRating', 0)
+            my_other_fleet_rating_vs_planets = aistate.systemStatus.get(self.target.id, {}).get(
                 'myFleetRatingVsPlanets', 0)
-            is_military = get_aistate().get_fleet_role(self.fleet.id) == MissionType.MILITARY
+            is_military = aistate.get_fleet_role(self.fleet.id) == MissionType.MILITARY
 
             total_rating = CombatRatingsAI.combine_ratings(my_other_fleet_rating, fleet_rating)
             total_rating_vs_planets = CombatRatingsAI.combine_ratings(my_other_fleet_rating_vs_planets,
@@ -235,7 +236,7 @@ class OrderMove(AIFleetOrder):
                     print ("\tHolding fleet %d (rating %d) at system %d (%s) "
                            "before travelling to system %d (%s) with threat %d") % (
                         self.fleet.id, fleet_rating, system_id, sys1_name, self.target.id, target_system_name, threat)
-                needs_vis = get_aistate().misc.setdefault('needs_vis', [])
+                needs_vis = aistate.misc.setdefault('needs_vis', [])
                 if self.target.id not in needs_vis:
                     needs_vis.append(self.target.id)
                 return False
@@ -250,10 +251,11 @@ class OrderMove(AIFleetOrder):
             dest_id = system_id
             fo.issueFleetMoveOrder(fleet_id, dest_id)
             print "Order issued: %s fleet: %s target: %s" % (self.ORDER_NAME, self.fleet, self.target)
+        aistate = get_aistate()
         if system_id == fleet.systemID:
-            if get_aistate().get_fleet_role(fleet_id) == MissionType.EXPLORATION:
-                if system_id in get_aistate().needsEmergencyExploration:
-                    get_aistate().needsEmergencyExploration.remove(system_id)
+            if aistate.get_fleet_role(fleet_id) == MissionType.EXPLORATION:
+                if system_id in aistate.needsEmergencyExploration:
+                    aistate.needsEmergencyExploration.remove(system_id)
         return True
 
 
@@ -289,10 +291,11 @@ class OrderResupply(AIFleetOrder):
         fleet_id = self.fleet.id
         system_id = self.target.get_system().id
         fleet = self.fleet.get_object()
+        aistate = get_aistate()
         if system_id == fleet.systemID:
-            if get_aistate().get_fleet_role(fleet_id) == MissionType.EXPLORATION:
-                if system_id in get_aistate().needsEmergencyExploration:
-                    get_aistate().needsEmergencyExploration.remove(system_id)
+            if aistate.get_fleet_role(fleet_id) == MissionType.EXPLORATION:
+                if system_id in aistate.needsEmergencyExploration:
+                    aistate.needsEmergencyExploration.remove(system_id)
             return True
         if system_id != fleet.nextSystemID:
             self.executed = False
@@ -463,9 +466,10 @@ class OrderInvade(AIFleetOrder):
         debug("Issuing order: %s fleet: %s target: %s" % (self.ORDER_NAME, self.fleet, self.target))
         # will track if at least one invasion troops successfully deployed
         result = False
+        aistate = get_aistate()
         for ship_id in fleet.shipIDs:
             ship = universe.getShip(ship_id)
-            role = get_aistate().get_ship_role(ship.design.id)
+            role = aistate.get_ship_role(ship.design.id)
             if role not in invasion_roles:
                 continue
 
@@ -478,10 +482,10 @@ class OrderInvade(AIFleetOrder):
                 warn("Invasion order failed!")
                 debug(" -- planet has %.1f stealth, shields %.1f, %.1f population and "
                       "is owned by empire %d" % (planet_stealth, shields, pop, planet.owner))
-                if 'needsEmergencyExploration' not in dir(get_aistate()):
-                    get_aistate().needsEmergencyExploration = []
-                if fleet.systemID not in get_aistate().needsEmergencyExploration:
-                    get_aistate().needsEmergencyExploration.append(fleet.systemID)
+                if 'needsEmergencyExploration' not in dir(aistate):
+                    aistate.needsEmergencyExploration = []
+                if fleet.systemID not in aistate.needsEmergencyExploration:
+                    aistate.needsEmergencyExploration.append(fleet.systemID)
                     debug("Due to trouble invading, adding system %d to Emergency Exploration List" % fleet.systemID)
                 self.executed = False
                 # debug(universe.getPlanet(planet_id).dump())  # TODO: fix fo.UniverseObject.dump()
@@ -561,9 +565,10 @@ class OrderRepair(AIFleetOrder):
         system_id = self.target.get_system().id
         fleet = self.fleet.get_object()  # type: fo.fleet
         if system_id == fleet.systemID:
-            if get_aistate().get_fleet_role(fleet_id) == MissionType.EXPLORATION:
-                if system_id in get_aistate().needsEmergencyExploration:
-                    get_aistate().needsEmergencyExploration.remove(system_id)
+            aistate = get_aistate()
+            if aistate.get_fleet_role(fleet_id) == MissionType.EXPLORATION:
+                if system_id in aistate.needsEmergencyExploration:
+                    aistate.needsEmergencyExploration.remove(system_id)
         elif system_id != fleet.nextSystemID:
             fo.issueAggressionOrder(fleet_id, False)
             start_id = FleetUtilsAI.get_fleet_system(fleet)

--- a/default/python/AI/freeorion_tools/_freeorion_tools.py
+++ b/default/python/AI/freeorion_tools/_freeorion_tools.py
@@ -189,14 +189,14 @@ def cache_by_turn(func):
     Cache result is stored in savegame, will crash with picle error if result contains any boost object.
     """
     # avoid circular import
-    import FreeOrionAI as foAI
+    from aistate_interface import get_aistate
 
     @wraps(func)
     def wrapper():
-        if foAI.foAIstate is None:
+        if get_aistate() is None:
             return func()
         else:
-            cache = foAI.foAIstate.misc.setdefault('caches', {}).setdefault(func.__name__, {})
+            cache = get_aistate().misc.setdefault('caches', {}).setdefault(func.__name__, {})
             this_turn = fo.currentTurn()
             return cache[this_turn] if this_turn in cache else cache.setdefault(this_turn, func())
     return wrapper

--- a/default/python/AI/freeorion_tools/interactive_shell.py
+++ b/default/python/AI/freeorion_tools/interactive_shell.py
@@ -49,12 +49,12 @@ def handle_debug_chat(sender, message):
             debug_mode = True
 
             initial_code = [
-                'import FreeOrionAI as foAI',
+                'from aistate_interface import get_aistate',
             ]
 
             # add some variables to scope: (name, help text, value)
             scopes_variable = (
-                ('ai', 'aistate', 'foAI.foAIstate'),
+                ('ai', 'aistate', 'get_aistate()'),
                 ('u', 'universe', 'fo.getUniverse()'),
                 ('e', 'empire', 'fo.getEmpire()'),
             )

--- a/default/python/AI/pathfinding.py
+++ b/default/python/AI/pathfinding.py
@@ -2,7 +2,7 @@ from heapq import heappush, heappop
 from collections import namedtuple
 from logging import warn, error
 
-import FreeOrionAI as foAI
+from aistate_interface import get_aistate
 import freeOrionAIInterface as fo
 import PlanetUtilsAI
 
@@ -102,7 +102,7 @@ def find_path_with_resupply(start, target, fleet_id, minimum_fuel_at_target=0, m
         return None
 
     mission_type = (mission_type_override if mission_type_override is not None else
-                    foAI.foAIstate.get_fleet_mission(fleet_id))
+                    get_aistate().get_fleet_mission(fleet_id))
     may_travel_starlane_func = _STARLANE_TRAVEL_FUNC_MAP.get(mission_type, _more_careful_travel_starlane_func)
 
     path_info = find_path_with_resupply_generic(start, target, start_fuel, fleet.maxFuel,

--- a/default/python/AI/savegame_codec/_definitions.py
+++ b/default/python/AI/savegame_codec/_definitions.py
@@ -1,35 +1,29 @@
 # a list of trusted classes - other classes will not be loaded
-import sys
-if 'pytest' in sys.modules:
-    # this was imported for a unit test - failure to import
-    # real AI modules is expected in this case.
-    trusted_classes = {}
-else:
-    import AIFleetMission
-    import fleet_orders
-    import character.character_module
-    import AIstate
-    import ColonisationAI
-    trusted_classes = {"%s.%s" % (cls.__module__, cls.__name__): cls for cls in [
-        AIFleetMission.AIFleetMission,
-        fleet_orders.AIFleetOrder,
-        fleet_orders.OrderMilitary,
-        fleet_orders.OrderDefend,
-        fleet_orders.OrderColonize,
-        fleet_orders.OrderOutpost,
-        fleet_orders.OrderPause,
-        fleet_orders.OrderInvade,
-        fleet_orders.OrderMove,
-        fleet_orders.OrderRepair,
-        fleet_orders.OrderResupply,
-        character.character_module.Trait,
-        character.character_module.Aggression,
-        character.character_module.EmpireIDTrait,
-        character.character_module.Character,
-        AIstate.AIstate,
-        ColonisationAI.OrbitalColonizationManager,
-        ColonisationAI.OrbitalColonizationPlan,
-    ]}
+import AIFleetMission
+import fleet_orders
+import character.character_module
+import AIstate
+import ColonisationAI
+trusted_classes = {"%s.%s" % (cls.__module__, cls.__name__): cls for cls in [
+    AIFleetMission.AIFleetMission,
+    fleet_orders.AIFleetOrder,
+    fleet_orders.OrderMilitary,
+    fleet_orders.OrderDefend,
+    fleet_orders.OrderColonize,
+    fleet_orders.OrderOutpost,
+    fleet_orders.OrderPause,
+    fleet_orders.OrderInvade,
+    fleet_orders.OrderMove,
+    fleet_orders.OrderRepair,
+    fleet_orders.OrderResupply,
+    character.character_module.Trait,
+    character.character_module.Aggression,
+    character.character_module.EmpireIDTrait,
+    character.character_module.Character,
+    AIstate.AIstate,
+    ColonisationAI.OrbitalColonizationManager,
+    ColonisationAI.OrbitalColonizationPlan,
+]}
 
 # prefixes to encode types not supported by json
 # or not fully supported as dictionary key

--- a/default/python/AI/savegame_codec/_encoder.py
+++ b/default/python/AI/savegame_codec/_encoder.py
@@ -34,8 +34,8 @@ def build_savegame_string(use_compression=True):
     :return: compressed savegame string
     :rtype: str
     """
-    import FreeOrionAI as foAI
-    savegame_string = encode(foAI.foAIstate)
+    from aistate_interface import get_aistate
+    savegame_string = encode(get_aistate())
     if use_compression:
         import base64
         import zlib

--- a/default/python/AI/turn_state.py
+++ b/default/python/AI/turn_state.py
@@ -142,7 +142,7 @@ class State(object):
 
         :rtype: ReadOnlyDict[int, list[int]]
         """
-        # TODO: as currently used, is duplicative with combo of foAI.foAIstate.popCtrSystemIDs
+        # TODO: as currently used, is duplicative with combo of get_aistate().popCtrSystemIDs
         if include_outposts not in self.__empire_planets_by_system:
             empire_id = fo.empireID()
             empire_planets = (x for x in self.__planet_info.itervalues()

--- a/default/python/common/profiling.py
+++ b/default/python/common/profiling.py
@@ -14,7 +14,7 @@ def profile(save_path, sort_by='cumulative'):
     Result stored in user directory in profile catalog. See lne in logs for exact position.
 
     :param save_path: path to save profile, for example:
-        os.path.join(fo.getUserDataDir(), 'profiling', base_path, foAI.foAIstate.uid)
+        os.path.join(fo.getUserDataDir(), 'profiling', base_path, get_aistate().uid)
     :type save_path: str
     :param sort_by: sort stats https://docs.python.org/2/library/profile.html#pstats.Stats.sort_stats
     :type sort_by: str


### PR DESCRIPTION
Currently, AIstate is stored in FreeOrionAI which is pretty bad from a design perspective considering it is required by most AI modules:

1) It introduces hard to follow circular imports (eventhough these are currently resolved)
2) FreeOrionAI.py has various side-effects on module load (parsing config, configuring logging...) which require a running AI client and may cause unit tests to fail if they indirectly import it.
3) FreeOrionAI.py is generally only imported for the AIstate

The PR proposes a cleaner design pattern by introducing a dedicated module through which the AIstate quasi-singleton is interfaced. It has no baseline dependencies on other modules but manages the creation of the AIstate from scratch or based on a savegame string by using lazy imports.

The resulting code changes are trivial:
```
- import FreeOrionAI as foAI
+ from aistate_interface import get_aistate()

- *foAI.foAIstate*
+ *get_aistate()*
```
and some different trivial stuff in FreeOrionAI considering its previous ownership of the AI state.

Finally, the workaround to make unit tests work with the savegame codec package is no longer required.