### PR TITLE
Sets launch capacity of FT_BAY_1 to 4 if FT_HANGAR_1 is aboard.

### DIFF
--- a/default/python/AI/AIDependencies.py
+++ b/default/python/AI/AIDependencies.py
@@ -646,9 +646,9 @@ PILOT_FIGHTER_CAPACITY_MODIFIER_DICT = {
     "ULTIMATE": {},
 }
 
-LAUNCH_BAY_BASE_CAPACITY = 2
 HANGAR_LAUNCH_CAPACITY_MODIFIER_DICT = {
-    "FT_HANGAR_1": 2,
+    # hangar_name: {bay_name: effect, bay_name2: effect, ...}
+    "FT_HANGAR_1": {"FT_BAY_1": 2},
 }
 # </editor-fold>
 

--- a/default/python/AI/AIDependencies.py
+++ b/default/python/AI/AIDependencies.py
@@ -645,6 +645,11 @@ PILOT_FIGHTER_CAPACITY_MODIFIER_DICT = {
     "GREAT":    {},
     "ULTIMATE": {},
 }
+
+LAUNCH_BAY_BASE_CAPACITY = 2
+HANGAR_LAUNCH_CAPACITY_MODIFIER_DICT = {
+    "FT_HANGAR_1": 2,
+}
 # </editor-fold>
 
 # <editor-fold desc="Extraordinary Species Rules">

--- a/default/python/AI/ShipDesignAI.py
+++ b/default/python/AI/ShipDesignAI.py
@@ -694,7 +694,7 @@ class DesignStats(object):
         self.solar_stealth = 0
         self.fighter_capacity = 0
         self.fighter_launch_bays = 0
-        self.fighter_launch_bay_rate = 0
+        self.fighter_launch_bay_rate = AIDependencies.LAUNCH_BAY_BASE_CAPACITY
         self.fighter_damage = 0
 
     @property
@@ -918,7 +918,7 @@ class ShipDesigner(object):
                 else:
                     self.design_stats.fighter_capacity += self._calculate_hangar_capacity(part)
                     self.design_stats.fighter_damage = self._calculate_hangar_damage(part)
-                    self.design_stats.fighter_launch_bay_rate += self._calculate_fighter_launch_bay_rate(part)
+                    self.design_stats.fighter_launch_bay_rate = self._calculate_fighter_launch_bay_rate(part)
 
         self._apply_hardcoded_effects()
 

--- a/default/python/AI/ShipDesignAI.py
+++ b/default/python/AI/ShipDesignAI.py
@@ -1567,11 +1567,12 @@ class ShipDesigner(object):
         return base + species_modifier + tech_bonus
 
     def _calculate_fighter_launch_rate(self, bay_parts, hangar_part_name):
-        hangar_bonus = AIDependencies.HANGAR_LAUNCH_CAPACITY_MODIFIER_DICT.get(hangar_part_name, 0)
-        bay_parts_capacity = 0
+        launch_rate = 0
+        bays_bonus = AIDependencies.HANGAR_LAUNCH_CAPACITY_MODIFIER_DICT.get(hangar_part_name, {})
         for bay_part in bay_parts:
-            bay_parts_capacity += bay_part.capacity
-        return bay_parts_capacity + ( len(bay_parts) * hangar_bonus )
+            launch_rate += bay_part.capacity
+            launch_rate += bays_bonus.get(bay_part.name, 0)
+        return launch_rate
 
     def _calculate_hangar_damage(self, hangar_part, ignore_species=False):
         hangar_name = hangar_part.name

--- a/default/python/AI/ShipDesignAI.py
+++ b/default/python/AI/ShipDesignAI.py
@@ -919,7 +919,7 @@ class ShipDesigner(object):
         if len(bay_parts) > 0:
             hangar_part_name = None
             for hangar_part_name in hangar_part_names:
-                break;
+                break
             self.design_stats.fighter_launch_rate = self._calculate_fighter_launch_rate(bay_parts, hangar_part_name)
 
         self._apply_hardcoded_effects()

--- a/default/python/AI/ShipDesignAI.py
+++ b/default/python/AI/ShipDesignAI.py
@@ -693,13 +693,8 @@ class DesignStats(object):
         self.asteroid_stealth = 0
         self.solar_stealth = 0
         self.fighter_capacity = 0
-        self.fighter_launch_bays = 0
-        self.fighter_launch_bay_rate = AIDependencies.LAUNCH_BAY_BASE_CAPACITY
+        self.fighter_launch_rate = 0
         self.fighter_damage = 0
-
-    @property
-    def fighter_launch_rate(self):
-        return self.fighter_launch_bay_rate * self.fighter_launch_bays
 
     def convert_to_combat_stats(self):
         """Return a tuple as expected by CombatRatingsAI"""
@@ -861,7 +856,8 @@ class ShipDesigner(object):
 
         # read out part stats
         shield_counter = cloak_counter = detection_counter = colonization_counter = engine_counter = 0  # to deal with Non-stacking parts
-        hangar_parts = set()
+        hangar_part_names = set()
+        bay_parts = list()
         for part in self.parts:
             self.production_cost += local_cost_cache.get(part.name, part.productionCost(fo.empireID(), self.pid))
             self.production_time = max(self.production_time,
@@ -908,17 +904,22 @@ class ShipDesigner(object):
                 else:
                     self.design_stats.stealth = 0
             elif partclass in FIGHTER_BAY:
-                self.design_stats.fighter_launch_bays += 1
+                bay_parts.append(part)
             elif partclass in FIGHTER_HANGAR:
-                hangar_parts.add(part.name)
-                if len(hangar_parts) > 1:
+                hangar_part_names.add(part.name)
+                if len(hangar_part_names) > 1:
                     # enforce only one hangar part per design
                     self.design_stats.fighter_capacity = 0
                     self.design_stats.fighter_damage = 0
+                    self.design_stats.fighter_launch_rate = 0
                 else:
                     self.design_stats.fighter_capacity += self._calculate_hangar_capacity(part)
                     self.design_stats.fighter_damage = self._calculate_hangar_damage(part)
-                    self.design_stats.fighter_launch_bay_rate = self._calculate_fighter_launch_bay_rate(part)
+
+        if len(hangar_part_names) == 1 :
+            for hangar_part_name in hangar_part_names:
+                break;
+            self.design_stats.fighter_launch_rate = self._calculate_fighter_launch_rate(bay_parts, hangar_part_name)
 
         self._apply_hardcoded_effects()
 
@@ -1564,11 +1565,12 @@ class ShipDesigner(object):
             species_modifier = 0
         return base + species_modifier + tech_bonus
 
-    def _calculate_fighter_launch_bay_rate(self, hangar_part):
-        hangar_name = hangar_part.name
-        base = AIDependencies.LAUNCH_BAY_BASE_CAPACITY
-        hangar_bonus = AIDependencies.HANGAR_LAUNCH_CAPACITY_MODIFIER_DICT.get(hangar_name, 0)
-        return base + hangar_bonus
+    def _calculate_fighter_launch_rate(self, bay_parts, hangar_part_name):
+        hangar_bonus = AIDependencies.HANGAR_LAUNCH_CAPACITY_MODIFIER_DICT.get(hangar_part_name, 0)
+        bay_parts_capacity = 0
+        for bay_part in bay_parts:
+            bay_parts_capacity += bay_part.capacity
+        return bay_parts_capacity + ( len(bay_parts) * hangar_bonus )
 
     def _calculate_hangar_damage(self, hangar_part, ignore_species=False):
         hangar_name = hangar_part.name

--- a/default/python/AI/ShipDesignAI.py
+++ b/default/python/AI/ShipDesignAI.py
@@ -818,7 +818,6 @@ class ShipDesigner(object):
 
         :param partname_list: contains partnames as strings
         :type partname_list: list"""
-        warn("update_parts %s" % partname_list)
         self.partnames = partname_list
         self.parts = [get_part_type(part) for part in partname_list if part]
 
@@ -838,7 +837,6 @@ class ShipDesigner(object):
         :param ignore_species: toggles whether species piloting grades are considered in the stats.
         :type ignore_species: bool
         """
-        warn("update_stats")
         self._set_stats_to_default()
 
         if not self.hull:
@@ -906,14 +904,11 @@ class ShipDesigner(object):
                 else:
                     self.design_stats.stealth = 0
             elif partclass in FIGHTER_BAY:
-                warn("Append %s" % part.name)
                 bay_parts.append(part)
             elif partclass in FIGHTER_HANGAR:
-                warn("Found %s" % part.name)
                 hangar_part_names.add(part.name)
                 if len(hangar_part_names) > 1:
                     # enforce only one hangar part per design
-                    warn("ALREADY HANGARS %s" % hangar_part_names)
                     self.design_stats.fighter_capacity = 0
                     self.design_stats.fighter_damage = 0
                     self.design_stats.fighter_launch_rate = 0
@@ -922,11 +917,9 @@ class ShipDesigner(object):
                     self.design_stats.fighter_damage = self._calculate_hangar_damage(part)
 
         if len(bay_parts) > 0:
-            warn("HI")
             hangar_part_name = None
             for hangar_part_name in hangar_part_names:
                 break;
-            warn("HO %s %s" % (hangar_part_name, bay_parts))
             self.design_stats.fighter_launch_rate = self._calculate_fighter_launch_rate(bay_parts, hangar_part_name)
 
         self._apply_hardcoded_effects()
@@ -1578,7 +1571,6 @@ class ShipDesigner(object):
         bay_parts_capacity = 0
         for bay_part in bay_parts:
             bay_parts_capacity += bay_part.capacity
-        warn("bay_parts_capacity: %s  bay_parts_len: %s  hangar_bonus: %s  %s" % ( bay_parts_capacity, len(bay_parts), hangar_bonus, hangar_part_name) )
         return bay_parts_capacity + ( len(bay_parts) * hangar_bonus )
 
     def _calculate_hangar_damage(self, hangar_part, ignore_species=False):
@@ -1765,7 +1757,7 @@ class CarrierShipDesigner(MilitaryShipDesignerBaseClass):
 
     def _rating_function(self):
         if self.design_stats.fighter_capacity < 1:
-            return -996
+            return INVALID_DESIGN_RATING
         combat_rating = self._combat_rating()
         speed_factor = self._speed_factor()
         fuel_factor = self._fuel_factor()
@@ -1773,7 +1765,7 @@ class CarrierShipDesigner(MilitaryShipDesignerBaseClass):
 
     # TODO Implement _starting_guess() for faster convergence
 
-    def _filling_algorithm(self, available_parts, verbose=True):
+    def _filling_algorithm(self, available_parts, verbose=False):
         # Currently, only one type of hangar part is allowed due to game mechanics.
         # However, in the generic _filling_algorithm(), only one part is exchanged per time.
         # Therefore, after using (multiple) entries of one hangar part, the algorithm won't consider different parts.
@@ -1792,7 +1784,7 @@ class CarrierShipDesigner(MilitaryShipDesignerBaseClass):
             debug("Found the following hangar parts: %s" % hangar_parts)
 
         # now, call the standard-algorithm with only one hangar part at a time and choose the best rated one.
-        best_rating = -998
+        best_rating = INVALID_DESIGN_RATING
         best_partlist = [""] * len(self.hull.slots)
         for this_hangar_part in hangar_parts:
             current_available_parts = {}

--- a/default/python/AI/ShipDesignAI.py
+++ b/default/python/AI/ShipDesignAI.py
@@ -818,6 +818,7 @@ class ShipDesigner(object):
 
         :param partname_list: contains partnames as strings
         :type partname_list: list"""
+        warn("update_parts %s" % partname_list)
         self.partnames = partname_list
         self.parts = [get_part_type(part) for part in partname_list if part]
 
@@ -837,6 +838,7 @@ class ShipDesigner(object):
         :param ignore_species: toggles whether species piloting grades are considered in the stats.
         :type ignore_species: bool
         """
+        warn("update_stats")
         self._set_stats_to_default()
 
         if not self.hull:
@@ -904,11 +906,14 @@ class ShipDesigner(object):
                 else:
                     self.design_stats.stealth = 0
             elif partclass in FIGHTER_BAY:
+                warn("Append %s" % part.name)
                 bay_parts.append(part)
             elif partclass in FIGHTER_HANGAR:
+                warn("Found %s" % part.name)
                 hangar_part_names.add(part.name)
                 if len(hangar_part_names) > 1:
                     # enforce only one hangar part per design
+                    warn("ALREADY HANGARS %s" % hangar_part_names)
                     self.design_stats.fighter_capacity = 0
                     self.design_stats.fighter_damage = 0
                     self.design_stats.fighter_launch_rate = 0
@@ -916,9 +921,12 @@ class ShipDesigner(object):
                     self.design_stats.fighter_capacity += self._calculate_hangar_capacity(part)
                     self.design_stats.fighter_damage = self._calculate_hangar_damage(part)
 
-        if len(hangar_part_names) == 1 :
+        if len(bay_parts) > 0:
+            warn("HI")
+            hangar_part_name = None
             for hangar_part_name in hangar_part_names:
                 break;
+            warn("HO %s %s" % (hangar_part_name, bay_parts))
             self.design_stats.fighter_launch_rate = self._calculate_fighter_launch_rate(bay_parts, hangar_part_name)
 
         self._apply_hardcoded_effects()
@@ -1570,6 +1578,7 @@ class ShipDesigner(object):
         bay_parts_capacity = 0
         for bay_part in bay_parts:
             bay_parts_capacity += bay_part.capacity
+        warn("bay_parts_capacity: %s  bay_parts_len: %s  hangar_bonus: %s  %s" % ( bay_parts_capacity, len(bay_parts), hangar_bonus, hangar_part_name) )
         return bay_parts_capacity + ( len(bay_parts) * hangar_bonus )
 
     def _calculate_hangar_damage(self, hangar_part, ignore_species=False):
@@ -1756,7 +1765,7 @@ class CarrierShipDesigner(MilitaryShipDesignerBaseClass):
 
     def _rating_function(self):
         if self.design_stats.fighter_capacity < 1:
-            return INVALID_DESIGN_RATING
+            return -996
         combat_rating = self._combat_rating()
         speed_factor = self._speed_factor()
         fuel_factor = self._fuel_factor()
@@ -1764,7 +1773,7 @@ class CarrierShipDesigner(MilitaryShipDesignerBaseClass):
 
     # TODO Implement _starting_guess() for faster convergence
 
-    def _filling_algorithm(self, available_parts, verbose=False):
+    def _filling_algorithm(self, available_parts, verbose=True):
         # Currently, only one type of hangar part is allowed due to game mechanics.
         # However, in the generic _filling_algorithm(), only one part is exchanged per time.
         # Therefore, after using (multiple) entries of one hangar part, the algorithm won't consider different parts.
@@ -1783,7 +1792,7 @@ class CarrierShipDesigner(MilitaryShipDesignerBaseClass):
             debug("Found the following hangar parts: %s" % hangar_parts)
 
         # now, call the standard-algorithm with only one hangar part at a time and choose the best rated one.
-        best_rating = INVALID_DESIGN_RATING
+        best_rating = -998
         best_partlist = [""] * len(self.hull.slots)
         for this_hangar_part in hangar_parts:
             current_available_parts = {}

--- a/default/python/AI/ShipDesignAI.py
+++ b/default/python/AI/ShipDesignAI.py
@@ -693,8 +693,13 @@ class DesignStats(object):
         self.asteroid_stealth = 0
         self.solar_stealth = 0
         self.fighter_capacity = 0
-        self.fighter_launch_rate = 0
+        self.fighter_launch_bays = 0
+        self.fighter_launch_bay_rate = 0
         self.fighter_damage = 0
+
+    @property
+    def fighter_launch_rate(self):
+        return self.fighter_launch_bay_rate * self.fighter_launch_bays
 
     def convert_to_combat_stats(self):
         """Return a tuple as expected by CombatRatingsAI"""
@@ -903,7 +908,7 @@ class ShipDesigner(object):
                 else:
                     self.design_stats.stealth = 0
             elif partclass in FIGHTER_BAY:
-                self.design_stats.fighter_launch_rate += capacity
+                self.design_stats.fighter_launch_bays += 1
             elif partclass in FIGHTER_HANGAR:
                 hangar_parts.add(part.name)
                 if len(hangar_parts) > 1:
@@ -913,6 +918,7 @@ class ShipDesigner(object):
                 else:
                     self.design_stats.fighter_capacity += self._calculate_hangar_capacity(part)
                     self.design_stats.fighter_damage = self._calculate_hangar_damage(part)
+                    self.design_stats.fighter_launch_bay_rate += self._calculate_fighter_launch_bay_rate(part)
 
         self._apply_hardcoded_effects()
 
@@ -1557,6 +1563,12 @@ class ShipDesigner(object):
         else:
             species_modifier = 0
         return base + species_modifier + tech_bonus
+
+    def _calculate_fighter_launch_bay_rate(self, hangar_part):
+        hangar_name = hangar_part.name
+        base = AIDependencies.LAUNCH_BAY_BASE_CAPACITY
+        hangar_bonus = AIDependencies.HANGAR_LAUNCH_CAPACITY_MODIFIER_DICT.get(hangar_name, 0)
+        return base + hangar_bonus
 
     def _calculate_hangar_damage(self, hangar_part, ignore_species=False):
         hangar_name = hangar_part.name

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_1.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_1.focs.txt
@@ -14,9 +14,10 @@ Part
         EffectsGroup
             scope = [[EMPIRE_OWNED_SHIP_WITH_PART(FT_BAY_1)]]
             activation = Source
+            stackinggroup = "INTERCEPTOR_FAST_LAUNCH_EFFECT"
             effects = [
-                SetCapacity partname = "FT_BAY_1" value = 4
-                SetMaxCapacity partname = "FT_BAY_1" value = 4
+                SetCapacity partname = "FT_BAY_1" value = Value + 2
+                SetMaxCapacity partname = "FT_BAY_1" value = Value + 2
             ]
     ]
     icon = "icons/ship_parts/fighter06.png"

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_1.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_1.focs.txt
@@ -10,6 +10,16 @@ Part
     buildtime = 1
     tags = [ "PEDIA_PC_FIGHTER_HANGAR" ]
     location = OwnedBy empire = Source.Owner
+    effectsgroups = [
+        EffectsGroup
+            scope = [[EMPIRE_OWNED_SHIP_WITH_PART(FT_BAY_1)]]
+            activation = Source
+            effects = [
+                SetCapacity partname = "FT_BAY_1" value = 4
+                SetMaxCapacity partname = "FT_BAY_1" value = 4
+            ]
+    ]
     icon = "icons/ship_parts/fighter06.png"
 
 #include "/scripting/common/upkeep.macros"
+#include "/scripting/techs/techs.macros"

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_1.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_1.focs.txt
@@ -16,7 +16,6 @@ Part
             activation = Source
             stackinggroup = "INTERCEPTOR_FAST_LAUNCH_EFFECT"
             effects = [
-                SetCapacity partname = "FT_BAY_1" value = Value + 2
                 SetMaxCapacity partname = "FT_BAY_1" value = Value + 2
             ]
     ]


### PR DESCRIPTION
To make interceptors a bit more useful, let them launch faster

Forum discussion: [Let 4 interceptors launch per bay (stopgap)](http://www.freeorion.org/forum/viewtopic.php?f=15&t=10968)

Implementation: The interceptor hangar sets the capacity of the launch bay in the ship to 4.

* @Dilvish-fo  probably will need AI adjustments? (forgot again which tag to use for AI)
* TODO: also in need of stringtable change