### PR TITLE
Tactical drones as core part

### DIFF
--- a/default/python/AI/AIDependencies.py
+++ b/default/python/AI/AIDependencies.py
@@ -377,6 +377,7 @@ FIGHTER_DAMAGE_UPGRADE_DICT = {
     "FT_HANGAR_2": (("SHP_FIGHTERS_2", 2), ("SHP_FIGHTERS_3", 3), ("SHP_FIGHTERS_4", 5)),
     "FT_HANGAR_3": (("SHP_FIGHTERS_2", 3), ("SHP_FIGHTERS_3", 4), ("SHP_FIGHTERS_4", 7)),
     "FT_HANGAR_4": (),
+    "FT_HANGAR_DRONES": (),
 }
 
 FIGHTER_CAPACITY_UPGRADE_DICT = {
@@ -385,6 +386,7 @@ FIGHTER_CAPACITY_UPGRADE_DICT = {
     "FT_HANGAR_2": (),
     "FT_HANGAR_3": (),
     "FT_HANGAR_4": (),
+    "FT_HANGAR_DRONES": (),
 }
 
 # DO NOT TOUCH THIS ENTRY BUT UPDATE WEAPON_UPGRADE_DICT INSTEAD!
@@ -652,10 +654,10 @@ PILOT_ROF_MODIFIER_DICT = {
 PILOT_FIGHTERDAMAGE_MODIFIER_DICT = {
     # TRAIT:    {hangar_name: effect, hangar_name2: effect2,...}
     "NO":       {},
-    "BAD":      {"FT_HANGAR_1": -1, "FT_HANGAR_2": -2, "FT_HANGAR_3": -3, "FT_HANGAR_4": -4},
-    "GOOD":     {"FT_HANGAR_1":  1, "FT_HANGAR_2":  2, "FT_HANGAR_3":  3, "FT_HANGAR_4": 4},
-    "GREAT":    {"FT_HANGAR_1":  2, "FT_HANGAR_2":  4, "FT_HANGAR_3":  6, "FT_HANGAR_4": 8},
-    "ULTIMATE": {"FT_HANGAR_1":  3, "FT_HANGAR_2":  6, "FT_HANGAR_3":  9, "FT_HANGAR_4": 12},
+    "BAD":      {"FT_HANGAR_1": -1, "FT_HANGAR_2": -2, "FT_HANGAR_3": -3, "FT_HANGAR_4": -4, "FT_HANGAR_DRONES": 0},
+    "GOOD":     {"FT_HANGAR_1":  1, "FT_HANGAR_2":  2, "FT_HANGAR_3":  3, "FT_HANGAR_4": 4, "FT_HANGAR_DRONES": 0},
+    "GREAT":    {"FT_HANGAR_1":  2, "FT_HANGAR_2":  4, "FT_HANGAR_3":  6, "FT_HANGAR_4": 8, "FT_HANGAR_DRONES": 0},
+    "ULTIMATE": {"FT_HANGAR_1":  3, "FT_HANGAR_2":  6, "FT_HANGAR_3":  9, "FT_HANGAR_4": 12, "FT_HANGAR_DRONES": 0},
 }
 
 PILOT_FIGHTER_CAPACITY_MODIFIER_DICT = {
@@ -670,6 +672,7 @@ PILOT_FIGHTER_CAPACITY_MODIFIER_DICT = {
 HANGAR_LAUNCH_CAPACITY_MODIFIER_DICT = {
     # hangar_name: {bay_name: effect, bay_name2: effect, ...}
     "FT_HANGAR_1": {"FT_BAY_1": 2},
+    "FT_HANGAR_DRONES": {"FT_BAY_1": 4},
 }
 # </editor-fold>
 

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_0.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_0.focs.txt
@@ -1,7 +1,7 @@
 Part
     name = "FT_HANGAR_0"
     description = "FT_HANGAR_0_DESC"
-    exclusions = [ "FT_HANGAR_1" "FT_HANGAR_2" "FT_HANGAR_3" "FT_HANGAR_4" ]
+    exclusions = [ "FT_HANGAR_1" "FT_HANGAR_2" "FT_HANGAR_3" "FT_HANGAR_4" "FT_HANGAR_DRONES"]
     class = FighterHangar
     capacity = 2
     damage = 0

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_1.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_1.focs.txt
@@ -1,7 +1,7 @@
 Part
     name = "FT_HANGAR_1"
     description = "FT_HANGAR_1_DESC"
-    exclusions = [ "FT_HANGAR_0" "FT_HANGAR_2" "FT_HANGAR_3" "FT_HANGAR_4" ]
+    exclusions = [ "FT_HANGAR_0" "FT_HANGAR_2" "FT_HANGAR_3" "FT_HANGAR_4" "FT_HANGAR_DRONES" ]
     class = FighterHangar
     capacity = 4
     damage = 1

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_2.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_2.focs.txt
@@ -1,7 +1,7 @@
 Part
     name = "FT_HANGAR_2"
     description = "FT_HANGAR_2_DESC"
-    exclusions = [ "FT_HANGAR_0" "FT_HANGAR_1" "FT_HANGAR_3" "FT_HANGAR_4" ]
+    exclusions = [ "FT_HANGAR_0" "FT_HANGAR_1" "FT_HANGAR_3" "FT_HANGAR_4" "FT_HANGAR_DRONES" ]
     class = FighterHangar
     capacity = 3
     damage = 3

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_3.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_3.focs.txt
@@ -1,7 +1,7 @@
 Part
     name = "FT_HANGAR_3"
     description = "FT_HANGAR_3_DESC"
-    exclusions = [ "FT_HANGAR_0" "FT_HANGAR_1" "FT_HANGAR_2" "FT_HANGAR_4" ]
+    exclusions = [ "FT_HANGAR_0" "FT_HANGAR_1" "FT_HANGAR_2" "FT_HANGAR_4" "FT_HANGAR_DRONES" ]
     class = FighterHangar
     capacity = 2
     damage = 5

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_4.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_4.focs.txt
@@ -1,7 +1,7 @@
 Part
     name = "FT_HANGAR_4"
     description = "FT_HANGAR_4_DESC"
-    exclusions = [ "FT_HANGAR_0" "FT_HANGAR_1" "FT_HANGAR_2" "FT_HANGAR_3" ]
+    exclusions = [ "FT_HANGAR_0" "FT_HANGAR_1" "FT_HANGAR_2" "FT_HANGAR_3" "FT_HANGAR_DRONES"]
     class = FighterHangar
     capacity = 1
     damage = 10

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_DRONES.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_DRONES.focs.txt
@@ -1,0 +1,25 @@
+Part
+    name = "FT_HANGAR_DRONES"
+    description = "FT_HANGAR_DRONES_DESC"
+    exclusions = [ "FT_HANGAR_0" "FT_HANGAR_1" "FT_HANGAR_2" "FT_HANGAR_3" "FT_HANGAR_4" ]
+    class = FighterHangar
+    capacity = 36
+    damage = 1
+    mountableSlotTypes = Core
+    buildcost = 120 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
+    buildtime = 1
+    tags = [ "PEDIA_PC_FIGHTER_HANGAR" ]
+    location = OwnedBy empire = Source.Owner
+    effectsgroups = [
+        EffectsGroup
+            scope = [[EMPIRE_OWNED_SHIP_WITH_PART(FT_BAY_1)]]
+            activation = Source
+            effects = [
+                SetCapacity partname = "FT_BAY_1" value = 6
+                SetMaxCapacity partname = "FT_BAY_1" value = 6
+            ]
+    ]
+    icon = "icons/ship_parts/fighters-1.png"
+
+#include "/scripting/common/upkeep.macros"
+#include "/scripting/techs/techs.macros"

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_DRONES.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_DRONES.focs.txt
@@ -29,5 +29,6 @@ Part
     ]
     icon = "icons/ship_parts/fighters-1.png"
 
+#include "/scripting/ship_parts/targeting.macros"
 #include "/scripting/common/upkeep.macros"
 #include "/scripting/techs/techs.macros"

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_DRONES.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_DRONES.focs.txt
@@ -5,6 +5,14 @@ Part
     class = FighterHangar
     capacity = 36
     damage = 1
+    combatTargets = And [
+        // Attacks blindly everything moving non-friendly objects
+        [[COMBAT_TARGETS_VISIBLE_ENEMY]]
+        Or [
+           [[COMBAT_TARGETS_NOT_DESTROYED_SHIP]]
+           Fighter
+        ]
+    ]
     mountableSlotTypes = Core
     buildcost = 120 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 1

--- a/default/scripting/techs/ship_weapons/fighters/SHP_DRONES.focs.txt
+++ b/default/scripting/techs/ship_weapons/fighters/SHP_DRONES.focs.txt
@@ -7,7 +7,7 @@ Tech
     researchturns = 3
     tags = [ "PEDIA_FIGHTER_TECHS" ]
     prerequisites = [
-        "FIGHTERS_1"
+        "SHP_FIGHTERS_1"
         "LRN_ARTIF_MINDS"
     ]
     unlock = [

--- a/default/scripting/techs/ship_weapons/fighters/SHP_DRONES.focs.txt
+++ b/default/scripting/techs/ship_weapons/fighters/SHP_DRONES.focs.txt
@@ -1,0 +1,18 @@
+Tech
+    name = "SHP_DRONES"
+    description = "SHP_DRONES_DESC"
+    short_description = "SHIP_WEAPON_UNLOCK_SHORT_DESC"
+    category = "SHIP_WEAPONS_CATEGORY"
+    researchcost = 6 * [[TECH_COST_MULTIPLIER]]
+    researchturns = 3
+    tags = [ "PEDIA_FIGHTER_TECHS" ]
+    prerequisites = [
+        "FIGHTERS_1"
+        "LRN_ARTIF_MINDS"
+    ]
+    unlock = [
+        Item type = ShipPart name = "FT_HANGAR_DRONES"
+    ]
+    graphic = "icons/ship_parts/fighters-1.png"
+
+#include "/scripting/common/base_prod.macros"

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -11789,6 +11789,12 @@ Death Ray Fighters
 SHP_FIGHTERS_4_DESC
 Upgrades the fighters of all carriers within [[metertype METER_SUPPLY]] to have death ray weaponry. [[encyclopedia DAMAGE_TITLE]] from fighters in a [[shippart FT_HANGAR_1]] is increased by 1, [[shippart FT_HANGAR_2]] is increased by 5 and [[shippart FT_HANGAR_3]] by 7.
 
+SHP_DRONES
+Interception Drones
+
+SHP_DRONES_DESC
+'''Enables an empire to build unmanned anti-fighter drones using Drone Hangars and Launch Bays. Drones are smaller and can be started more efficiently than manned spacecraft.'''
+
 SHP_WEAPON_1_2
 Mass Driver 2
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -11793,7 +11793,7 @@ SHP_DRONES
 Interception Drones
 
 SHP_DRONES_DESC
-'''Enables an empire to build unmanned anti-fighter drones using Drone Hangars and Launch Bays. Drones are smaller and can be started more efficiently than manned spacecraft.'''
+'''Enables an empire to build unmanned drones using Drone Hangars and Launch Bays. Drones have light weapons but are powerful enough to destroy fighters. Drones are smaller and can be started more efficiently than manned spacecraft.'''
 
 SHP_WEAPON_1_2
 Mass Driver 2
@@ -13150,7 +13150,7 @@ FT_HANGAR_DRONES
 Drone Hangar
 
 FT_HANGAR_DRONES_DESC
-Storage system for a swarm of anti-fighter drones. A launch bay is able to field six drones per turn. These drones are designed to launch independently shoot down enemy fighters and draw fire. The drones not affected by the aptness of the pilots nor available weapon technology.
+Storage system for a swarm of drones for fighting fighters. A launch bay is able to field six drones per turn. These drones are designed to autonomously launch, bring down enemy fighters and draw fire. The drones will attack all moving non-friendly objects namely enemy fighters and ships. Drones not affected by the aptness of the carrier's pilots nor available weapon technology.
 
 FT_HANGAR_KRILL
 Krill Swarm

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -13140,6 +13140,12 @@ Heavy-Bomber
 FT_HANGAR_4_DESC
 Storage system for heavily armed fighters.
 
+FT_HANGAR_DRONES
+Drone Hangar
+
+FT_HANGAR_DRONES_DESC
+Storage system for a swarm of anti-fighter drones. A launch bay is able to field six drones per turn. These drones are designed to launch independently shoot down enemy fighters and draw fire. The drones not affected by the aptness of the pilots nor available weapon technology.
+
 FT_HANGAR_KRILL
 Krill Swarm
 


### PR DESCRIPTION
Design discussion started in [Megaflak](http://www.freeorion.org/forum/viewtopic.php?f=6&t=10850#p91253).

Adds a tech and hangar core part for unmanned anti-fighter fighters.

Drones are even worse than interceptors (they always have damage 1) but are fielded really fast (6/turn/launch bay) and can be stored efficiently.
