### PR TITLE
Stockpile focus simplification

### DIFF
--- a/default/scripting/species/common/focus.macros
+++ b/default/scripting/species/common/focus.macros
@@ -52,13 +52,7 @@ HAS_ADVANCED_FOCI
         Focus
             name = "FOCUS_STOCKPILE"
             description = "FOCUS_STOCKPILE_DESC"
-            location = And [
-                OwnerHasTech name = "PRO_GENERIC_SUPPLIES"
-                Or [
-                    Homeworld name = Source.Species
-                    Capital
-                ]
-            ]
+            location = OwnerHasTech name = "PRO_GENERIC_SUPPLIES"
             graphic = "icons/focus/stockpile.png"
 
         Focus

--- a/default/scripting/species/common/stockpile.macros
+++ b/default/scripting/species/common/stockpile.macros
@@ -56,6 +56,24 @@ STANDARD_STOCKPILE
                 min(abs(Value(Target.MaxStockpile) - Value), 1) *
                     (1 - 2*(Statistic If condition = And [Target (Value > Value(Target.MaxStockpile))]))
 
+        // increase stockpile for species if Homeworld is set to stockpile focus
+        EffectsGroup
+            scope = And [
+                ProductionCenter
+                OwnedBy empire = Source.Owner
+                Species name = Source.Species
+                Not Homeworld name = Source.Species
+            ]
+            activation = And [
+                Planet
+                Focus type = "FOCUS_STOCKPILE"
+                Homeworld
+            ]
+            stackinggroup = "HOMEWORLD_STOCKPILE_FOCUS_BONUS_LABEL"
+            accountinglabel = "HOMEWORLD_STOCKPILE_FOCUS_BONUS_LABEL"
+            priority = [[DEFAULT_PRIORITY]]
+            effects = SetMaxStockpile value = (Value +  2 * Target.Population * [[STOCKPILE_PER_POP]])
+
         // removes residual stockpile capacity from a dead planet
         EffectsGroup
             scope = Source

--- a/default/scripting/techs/production/GENERIC_SUPPLIES.focs.txt
+++ b/default/scripting/techs/production/GENERIC_SUPPLIES.focs.txt
@@ -30,10 +30,7 @@ Tech
             scope = And [
                 ProductionCenter
                 OwnedBy empire = Source.Owner
-                Or [
-                    Focus type = "FOCUS_GROWTH"
-                    Focus type = "FOCUS_STOCKPILE"
-                ]
+                Focus type = "FOCUS_STOCKPILE"
             ]
             effects = SetMaxStockpile value = Value + 3
                 accountinglabel = "GENERIC_SUPPLIES_FOCUS_BONUS_LABEL"

--- a/default/scripting/techs/production/PREDICTIVE_STOCKPILING.focs.txt
+++ b/default/scripting/techs/production/PREDICTIVE_STOCKPILING.focs.txt
@@ -12,10 +12,7 @@ Tech
             scope = And [
                 ProductionCenter
                 OwnedBy empire = Source.Owner
-                Or [
-                    Focus type = "FOCUS_GROWTH"
-                    Focus type = "FOCUS_STOCKPILE"
-                ]
+                Focus type = "FOCUS_STOCKPILE"
             ]
             effects = SetMaxStockpile value = Value + 1
     ]

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1,4 +1,4 @@
-﻿English
+English
 
 # This is the English String Table file for FreeOrion
 #
@@ -10932,7 +10932,7 @@ This task is difficult as the service has to predict when demand happens, where 
 Unused PP will automatically be transferred to the Imperial Production Stockpile.
 An item on the production queue draws automatically on the Imperial Stockpile if the item has not been explicitly disabled from doing so.
 
-This is the basic technology for the imperial stockpile, which increases the [[metertype METER_STOCKPILE]] of growth-focused and stockpile-focused planets by 1.'''
+This is the basic technology for the imperial stockpile, which increases the [[metertype METER_STOCKPILE]] of stockpile-focused planets by 1.'''
 
 PRO_GENERIC_SUPPLIES
 Generic Supplies
@@ -10945,7 +10945,7 @@ Reaching this state of sophistication, Generic Supplies can be used to construct
 
 This frees the imperial stockpile service from having to know which goods will be demanded exactly. Predicting the location and amount is enough.
 
-This is an upgrade technology for the imperial stockpile. The [[metertype METER_STOCKPILE]] is increased by 2, plus an additional 0.01 per [[metertype METER_POPULATION]], plus an additional 3 for each growth-focused and stockpiling-focused planet.
+This is an upgrade technology for the imperial stockpile. The [[metertype METER_STOCKPILE]] is increased by 2, plus an additional 0.01 per [[metertype METER_POPULATION]], plus an additional 3 for each stockpiling-focused planet.
 These improvements are cumulative with that provided by [[tech PRO_PREDICTIVE_STOCKPILING]].'''
 
 PRO_INTERSTELLAR_ENTANGLEMENT_FACTORY
@@ -12821,7 +12821,7 @@ BLD_GAS_GIANT_GEN
 Gas Giant Generator
 
 BLD_GAS_GIANT_GEN_DESC
-'''This building can only be constructed at a [[PT_GASGIANT]] and gives a +10 [[metertype METER_TARGET_INDUSTRY]] bonus to planets with the Industry focus in the same system.
+'''This building can only be constructed at a [[PT_GASGIANT]] and gives a +10 [[metertype METER_INDUSTRY]] bonus to planets with the Industry focus in the same system. If the [[BLD_GAS_GIANT_GEN]] is build on an inhabited gas giant it gives only a +5 [[metertype METER_INDUSTRY]] bonus.
 Multiple copies in the same system do not stack.
 
 A power generator designed to harvest the energy of a [[PT_GASGIANT]].'''

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -5753,6 +5753,8 @@ Stockpile Focus
 STOCKPILE_FOCUS_TEXT
 '''The Stockpile focus increases the [[metertype METER_STOCKPILE]] of a planet.
 
+A Homeworld focused on Stockpile also helps other planets of the same species and increases the [[metertype METER_STOCKPILE]] there by an additional 0.04 per population.
+
 [[METER_STOCKPILE_VALUE_DESC]]'''
 
 ARMOR_TITLE


### PR DESCRIPTION
Forum discussion: [What to do with the stockpiling techs](http://www.freeorion.org/forum/viewtopic.php?f=6&t=10932&p=92684#p92674)

* decouple GROWTH and STOCKPILE
* allow STOCKPILE FOCUS everywhere
* stockpile focus on homeworld gives species population based stockpile boost (similar to homeworld growth bonus); amount is 0.04; this makes an AVERAGE_STOCKPILE species a GOOD_STOCKPILE species.