### PR TITLE
Fix supply update handling of new fleets

### DIFF
--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -257,10 +257,10 @@ public:
     void UpdateSystemSupplyRanges();
     /** Calculates systems that can propagate supply (fleet or resource) using
       * the specified set of \a known_systems */
-    void UpdateSupplyUnobstructedSystems(const std::set<int>& known_systems);
+    void UpdateSupplyUnobstructedSystems(const std::set<int>& known_systems, bool precombat=false);
     /** Calculates systems that can propagate supply using this empire's own /
       * internal list of explored systems. */
-    void UpdateSupplyUnobstructedSystems();
+    void UpdateSupplyUnobstructedSystems(bool precombat=false);
     /** Updates fleet ArrivalStarlane to flag fleets of this empire that are not blockaded post-combat 
      *  must be done after *all* noneliminated empires have updated their unobstructed systems* */
     void UpdateUnobstructedFleets();

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -590,7 +590,7 @@ void ServerApp::NewMPGameInit(const MultiplayerLobbyData& multiplayer_lobby_data
         SendNewGameStartMessages();
 }
 
-void UpdateEmpireSupply() {
+void UpdateEmpireSupply(bool precombat=false) {
     EmpireManager& empires = Empires();
 
     // Determine initial supply distribution and exchanging and resource pools for empires
@@ -599,7 +599,7 @@ void UpdateEmpireSupply() {
         if (empire->Eliminated())
             continue;   // skip eliminated empires.  presumably this shouldn't be an issue when initializing a new game, but apparently I thought this was worth checking for...
 
-        empire->UpdateSupplyUnobstructedSystems();  // determines which systems can propagate fleet and resource (same for both)
+        empire->UpdateSupplyUnobstructedSystems(precombat);  // determines which systems can propagate fleet and resource (same for both)
         empire->UpdateSystemSupplyRanges();         // sets range systems can propagate fleet and resourse supply (separately)
     }
 
@@ -3306,7 +3306,7 @@ void ServerApp::PostCombatProcessTurns() {
 
 
     // Re-determine supply distribution and exchanging and resource pools for empires
-    UpdateEmpireSupply();
+    UpdateEmpireSupply(true);
 
     // copy latest visible gamestate to each empire's known object state
     m_universe.UpdateEmpireLatestKnownObjectsAndVisibilityTurns();

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1229,7 +1229,7 @@ void ServerApp::LoadGameInit(const std::vector<PlayerSaveGameData>& player_save_
     // so need to be reinitialized when loading based on the gamestate
     m_universe.InitializeSystemGraph();
 
-    UpdateEmpireSupply();
+    UpdateEmpireSupply(true);  // precombat type supply update
 
     std::map<int, PlayerInfo> player_info_map = GetPlayerInfoMap();
 


### PR DESCRIPTION
Needed since there is now a pre-combat supply update being done.

In #1968 I had proposed, and in #2051 implemented, that monsters would not create supply blockades on the turn of their creation.

The particular fleet age check done in that implementation was explicitly dependent on the fact that all our supply updates at that time were done post-combat, relative to turn-update.

Somewhat more recently we wound up adding a post-turn-increment but pre-combat supply update, due to other issues, but at that time no one remembered about the relationship to monster blockades, and so new monsters were again able to create blockades on their first turn of creation and before surviving any combat round.

This PR fixes that by making the age check dependent on whether the supply update is being done precombat or not.

The following test file can be used to assess with and without this fix.
[monster_blockade_check.sav.zip](https://github.com/freeorion/freeorion/files/2065530/monster_blockade_check.sav.zip)
In that file there is a floater (not currently visible) that will arrive at system Sitter Alpha on turn 63.  To ensure that it spawns a Dyson Tree to test out this blockade issue, it may be helpful to first make the following change:
```diff
diff --git a/default/scripting/ship_hulls/monster/SH_FLOATER.focs.txt b/default/scripting/ship_hulls/monster/SH_FLOATER.focs.txt
index 0edd22b..b3e0c34 100644
--- a/default/scripting/ship_hulls/monster/SH_FLOATER.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_FLOATER.focs.txt
@@ -34,7 +34,6 @@ Hull
             activation = And [
                 Turn low = Source.LastTurnActiveInBattle + 1
                 InSystem
-                Random probability = 0.1
             ]
             stackinggroup = "TREE_GROWTH"
             effects = [
```