### PR TITLE
Use correct auto aggression icon for new fleet aggression button tooltip

### DIFF
--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -1748,7 +1748,7 @@ void FleetDataPanel::UpdateAggressionToggle() {
         m_aggression_toggle->SetPressedGraphic  (GG::SubTexture(FleetAggressiveIcon()));
         m_aggression_toggle->SetRolloverGraphic (GG::SubTexture(FleetAutoMouseoverIcon()));
         m_aggression_toggle->SetBrowseInfoWnd(GG::Wnd::Create<IconTextBrowseWnd>(
-            FleetPassiveIcon(), UserString("FW_AUTO"), UserString("FW_AUTO_DESC")));
+            FleetAutoIcon(), UserString("FW_AUTO"), UserString("FW_AUTO_DESC")));
     }
 }
 


### PR DESCRIPTION
Works for me, tested by looking at default and cycling through aggression options.

Fixes #1759