### PR TITLE
Have AI use base64 encoding/decoding for compressed save state strings

### DIFF
--- a/default/python/AI/savegame_codec/_encoder.py
+++ b/default/python/AI/savegame_codec/_encoder.py
@@ -37,8 +37,9 @@ def build_savegame_string(use_compression=True):
     import FreeOrionAI as foAI
     savegame_string = encode(foAI.foAIstate)
     if use_compression:
+        import base64
         import zlib
-        savegame_string = zlib.compress(savegame_string)
+        savegame_string = base64.b64encode(zlib.compress(savegame_string))
     return savegame_string
 
 


### PR DESCRIPTION
- so that the final save-state string will be UTF-8 compatible
- on save, if the save-state is not to be zlib-compressed then base64
  encoding is not applied, so that the savestate will still be human-readable

Somewhat perplexingly, it seems that the base64 decode attempt will only generate an exception
for an improperly padded but otherwise validly-encoded base64 string; a general failure there is not
necessarily detected immediately.

I am categorizing this as a bugfix rather than a tweak because the zlib compression was leading to xml save files being not fully UTF-8 compatible.

Resolves #2142 
