### PR TITLE
Fix missing sensor ghosts

### DIFF
--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -5592,7 +5592,9 @@ std::vector<int> MapWnd::FleetIDsOfFleetButtonsOverlapping(int fleet_id) const {
 
     const auto& it = m_fleet_buttons.find(fleet_id);
     if (it == m_fleet_buttons.end()) {
-        auto vis_turn_map = GetUniverse().GetObjectVisibilityTurnMapByEmpire(fleet_id, HumanClientApp::GetApp()->EmpireID());
+        // Log that a FleetButton could not be found for the requested fleet, and include when the fleet was last seen
+        int empire_id = HumanClientApp::GetApp()->EmpireID();
+        auto vis_turn_map = GetUniverse().GetObjectVisibilityTurnMapByEmpire(fleet_id, empire_id);
         int vis_turn = -1;
         if (vis_turn_map.find(VIS_BASIC_VISIBILITY) != vis_turn_map.end())
             vis_turn = vis_turn_map[VIS_BASIC_VISIBILITY];

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -5592,7 +5592,12 @@ std::vector<int> MapWnd::FleetIDsOfFleetButtonsOverlapping(int fleet_id) const {
 
     const auto& it = m_fleet_buttons.find(fleet_id);
     if (it == m_fleet_buttons.end()) {
-        ErrorLogger() << "Couldn't find a FleetButton for fleet " << fleet_id;
+        auto vis_turn_map = GetUniverse().GetObjectVisibilityTurnMapByEmpire(fleet_id, HumanClientApp::GetApp()->EmpireID());
+        int vis_turn = -1;
+        if (vis_turn_map.find(VIS_BASIC_VISIBILITY) != vis_turn_map.end())
+            vis_turn = vis_turn_map[VIS_BASIC_VISIBILITY];
+        ErrorLogger() << "Couldn't find a FleetButton for fleet " << fleet_id 
+                      << " with last basic vis turn " << vis_turn;
         return fleet_ids;
     }
     const auto& fleet_btn = it->second;

--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -238,9 +238,9 @@ void CombatInfo::InitializeObjectVisibility()
         if (empire_id == ALL_EMPIRES)
             continue;
         empire_known_objects[empire_id].Insert(GetEmpireKnownSystem(system->ID(), empire_id));
-        empire_object_visibility[empire_id][system->ID()] = GetUniverse().GetObjectVisibilityByEmpire(empire_id, system->ID());
+        empire_object_visibility[empire_id][system->ID()] = GetUniverse().GetObjectVisibilityByEmpire(system->ID(), empire_id);
         for (int object_id : local_object_ids) {
-            Visibility obj_vis = GetUniverse().GetObjectVisibilityByEmpire(empire_id, object_id);
+            Visibility obj_vis = GetUniverse().GetObjectVisibilityByEmpire(object_id, empire_id);
             if (obj_vis > VIS_NO_VISIBILITY)  // to ensure an empire doesn't wrongly get info that an object was present
                 empire_object_visibility[empire_id][object_id] = obj_vis;
         }

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -2106,7 +2106,7 @@ namespace {
             // update visibilities.
             for (const auto& empire_vis : combat_info.empire_object_visibility) {
                 for (const auto& object_vis : empire_vis.second) {
-                    if (object_vis.second > GetUniverse().GetObjectVisibilityByEmpire(empire_vis.first, object_vis.first))
+                    if (object_vis.second > GetUniverse().GetObjectVisibilityByEmpire(object_vis.first, empire_vis.first))
                         universe.SetEmpireObjectVisibility(empire_vis.first, object_vis.first, object_vis.second);
                 }
             }

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -2562,15 +2562,8 @@ void Universe::UpdateEmpireStaleObjectKnowledge() {
         std::set<int>& stale_set = m_empire_stale_knowledge_object_ids[empire_id];
         const std::set<int>& destroyed_set = m_empire_known_destroyed_object_ids[empire_id];
 
-        // remove stale marking for any known destroyed or currently visible objects
-        for (auto stale_it = stale_set.begin(); stale_it != stale_set.end();) {
-            int object_id = *stale_it;
-            if (vis_map.count(object_id) || destroyed_set.count(object_id))
-                stale_set.erase(stale_it++);
-            else
-                ++stale_it;
-        }
-
+        // clear previous staleness determinations
+        stale_set.clear();
 
         // get empire latest known objects that are potentially detectable
         auto empires_latest_known_objects_that_should_be_detectable =


### PR DESCRIPTION
This PR addresses #2033 re combat-granted sensor ghosts being missing.  

Resolves #2033 

(edited to clean up interim work-in-progress description which is no longer applicable)