### PR TITLE
Fix misc ai invasion bugs

### DIFF
--- a/default/python/AI/FleetUtilsAI.py
+++ b/default/python/AI/FleetUtilsAI.py
@@ -9,6 +9,7 @@ from universe_object import Planet, Fleet
 from ShipDesignAI import get_part_type
 from AIDependencies import INVALID_ID
 import AIDependencies
+import universe_object
 
 
 def stats_meet_reqs(stats, requirements):
@@ -105,6 +106,7 @@ def get_fleets_for_mission(target_stats, min_stats, cur_stats, starting_system,
     # loop over systems in a breadth-first-search trying to find nearby suitable ships in fleet_pool_set
     while systems_enqueued and fleet_pool_set:
         this_system_id = systems_enqueued.pop(0)
+        this_system_obj = universe_object.System(this_system_id)
         systems_visited.append(this_system_id)
         accessible_fleets = foAI.foAIstate.systemStatus.get(this_system_id, {}).get('myFleetsAccessible', [])
         fleets_here = [fid for fid in accessible_fleets if fid in fleet_pool_set]
@@ -135,6 +137,11 @@ def get_fleets_for_mission(target_stats, min_stats, cur_stats, starting_system,
                 troop_capacity = count_troops_in_fleet(fleet_id)
                 if troop_capacity <= 0:
                     continue
+                # providing move_path_func in this fashion rather than directly importing here, in order
+                # to avoid a circular import problem
+                if 'target_system' in target_stats and 'move_path_func' in target_stats:
+                    if not target_stats['move_path_func'](fleet_id, this_system_obj, target_stats['target_system']):
+                        continue
 
             # check if we need additional rating vs planets
             this_rating_vs_planets = 0

--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -189,8 +189,8 @@ def get_invasion_fleets():
             # For now, we assume what building base troopers is best so long as either (1) we would need no more than
             # MAX_BASE_TROOPERS_POOR_INVADERS base troop ships, or (2) our base troopers have more than 1 trooper per
             # ship and we would need no more than MAX_BASE_TROOPERS_GOOD_INVADERS base troop ships
-            if (n_bases <= MAX_BASE_TROOPERS_POOR_INVADERS or
-                    (troops_per_ship > 1 and n_bases <= MAX_BASE_TROOPERS_GOOD_INVADERS)):
+            if (n_bases > MAX_BASE_TROOPERS_POOR_INVADERS or
+                    (troops_per_ship > 1 and n_bases > MAX_BASE_TROOPERS_GOOD_INVADERS)):
                 print "ruling out base invasion troopers for %s due to high number (%d) required." % (planet, n_bases)
                 del foAI.foAIstate.qualifyingTroopBaseTargets[pid]
                 continue

--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -95,7 +95,8 @@ def get_invasion_fleets():
         # value to instead record how many base troopers have been queued, so that on later turns we can assess if the
         # process got delayed & perhaps more troopers need to be queued).
 
-        secure_ai_fleet_missions = foAI.foAIstate.get_fleet_missions_with_any_mission_types([MissionType.SECURE])
+        secure_ai_fleet_missions = foAI.foAIstate.get_fleet_missions_with_any_mission_types([MissionType.SECURE,
+                                                                                             MissionType.MILITARY])
 
         # Pass 1: identify qualifying base troop invasion targets
         for pid in invadable_planet_ids:  # TODO: reorganize
@@ -148,7 +149,7 @@ def get_invasion_fleets():
                     all_invasion_targeted_system_ids.add(planet.systemID)
                 # TODO: evaluate changes to situation, any more troops needed, etc.
                 continue  # already building for here
-            _, planet_troops = evaluate_invasion_planet(pid, secure_ai_fleet_missions, False)
+            _, planet_troops = evaluate_invasion_planet(pid, secure_ai_fleet_missions, True)
             sys_id = planet.systemID
             this_sys_status = foAI.foAIstate.systemStatus.get(sys_id, {})
             troop_tally = 0
@@ -268,7 +269,8 @@ def assign_invasion_values(planet_ids):
     neighbor_values = {}
     neighbor_val_ratio = .95
     universe = fo.getUniverse()
-    secure_missions = foAI.foAIstate.get_fleet_missions_with_any_mission_types([MissionType.SECURE])
+    secure_missions = foAI.foAIstate.get_fleet_missions_with_any_mission_types([MissionType.SECURE,
+                                                                                MissionType.MILITARY])
     for pid in planet_ids:
         planet_values[pid] = neighbor_values.setdefault(pid, evaluate_invasion_planet(pid, secure_missions))
         print "planet %d, values %s" % (pid, planet_values[pid])
@@ -430,7 +432,7 @@ def evaluate_invasion_planet(planet_id, secure_fleet_missions, verbose=True):
         s_fleet = universe.getFleet(secure_fleet_id)
         if not s_fleet or s_fleet.systemID != system_id:
             continue
-        if mission.type == MissionType.SECURE:
+        if mission.type in [MissionType.SECURE, MissionType.MILITARY]:
             target_obj = mission.target.get_object()
             if target_obj is not None and target_obj.id in secure_targets:
                 system_secured = True
@@ -501,6 +503,7 @@ def evaluate_invasion_planet(planet_id, secure_fleet_missions, verbose=True):
                ' - bldval: %s\n'
                ' - enemyval: %s') % (planet_score, planned_troops, troop_cost,
                                      threat_factor, detail, colony_base_value, bld_tally, enemy_val)
+        print (' - system secured: %s' % system_secured)
     return [planet_score, planned_troops]
 
 

--- a/default/python/AI/InvasionAI.py
+++ b/default/python/AI/InvasionAI.py
@@ -12,6 +12,7 @@ import EspionageAI
 import FleetUtilsAI
 import PlanetUtilsAI
 import universe_object
+from MoveUtilsAI import can_travel_to_system
 import ProductionAI
 import ColonisationAI
 import MilitaryAI
@@ -525,7 +526,10 @@ def send_invasion_fleets(fleet_ids, evaluated_planets, mission_type):
         found_fleets = []
         found_stats = {}
         min_stats = {'rating': 0, 'troopCapacity': ptroops}
-        target_stats = {'rating': 10, 'troopCapacity': ptroops + _TROOPS_SAFETY_MARGIN}
+        target_stats = {'rating': 10,
+                        'troopCapacity': ptroops + _TROOPS_SAFETY_MARGIN,
+                        'target_system': universe_object.System(sys_id),
+                        'move_path_func': can_travel_to_system}
         these_fleets = FleetUtilsAI.get_fleets_for_mission(target_stats, min_stats, found_stats,
                                                            starting_system=sys_id, fleet_pool_set=invasion_fleet_pool,
                                                            fleet_list=found_fleets)

--- a/default/python/AI/ShipDesignAI.py
+++ b/default/python/AI/ShipDesignAI.py
@@ -622,6 +622,7 @@ class AdditionalSpecifications(object):
         # TODO: Extend this framework according to needs of future implementations
         self.minimum_fuel = 0
         self.minimum_speed = 0
+        self.orbital = False
         self.minimum_structure = 1
         self.minimum_fighter_launch_rate = 0
         self.enemy_shields = 1  # to avoid spamming flak cannons
@@ -769,6 +770,8 @@ class ShipDesigner(object):
             max(0, self._minimum_structure() - (self.design_stats.structure + self._expected_organic_growth())),
             max(0, self._minimum_fighter_launch_rate() - self.design_stats.fighter_launch_rate)
         ])
+        if self._orbital() and self.design_stats.speed > 0:
+            rating = min(-100, rating - 99999)
         return rating if rating < 0 else self._rating_function()
 
     def _minimum_fuel(self):
@@ -776,6 +779,9 @@ class ShipDesigner(object):
 
     def _minimum_speed(self):
         return self.additional_specifications.minimum_speed
+
+    def _orbital(self):
+        return self.additional_specifications.orbital
 
     def _minimum_structure(self):
         return self.additional_specifications.minimum_structure
@@ -1846,6 +1852,9 @@ class OrbitalTroopShipDesigner(TroopShipDesignerBaseClass):
         TroopShipDesignerBaseClass.__init__(self)
         self.additional_specifications.minimum_speed = 0
         self.additional_specifications.minimum_fuel = 0
+        # require that the orbital trooper base have zero speed, otherwise once completed it won't be recognized as an
+        # orbital trooper base
+        self.additional_specifications.orbital = True
 
 
 class StandardTroopShipDesigner(TroopShipDesignerBaseClass):


### PR DESCRIPTION
Each of these 4 commits is directed to a separate (albeit somewhat interacting) bug.

The second one, about having AI invasion planning to also consider a Military type mission to be sufficient to count as securing a system (whereas before it was only counting Secure type missions for that purpose, because they will more reliably remain at the target system until the invasion is complete) is responsive to situations where the AI was thinking it needed to build substantially more troopships than it really did, which can significantly delay invasion operations.  This current adjustment might possibly be on the more permissive side of what is really optimal, and further changes might be warranted, but I feel that this change is still an improvement over the previous handling (and made a significant improvement in a couple of test cases I had).

@Morlic-fo, I am feeling confident enough of these fixes being worthwhile that I might go ahead and merge this to get this into RC1, but I'd still like your review and comments

The one about the move path requirement is that without it, troop ships could be assigned to a mission but then be stuck in place, leaving the mission incomplete when other troop ships could have instead been chosen and would have been able to complete the invasion.