### PR TITLE
Fix GOOD_POPULATION priority

### DIFF
--- a/default/scripting/species/common/population.macros
+++ b/default/scripting/species/common/population.macros
@@ -52,7 +52,7 @@ GOOD_POPULATION
             description = "GOOD_POPULATION_DESC"
             scope = Source
             activation = Planet
-            priority = [[EARLY_TARGET_POPULATION_SCALING_PRIORITY]]
+            priority = [[DEFAULT_PRIORITY]]
             effects = SetTargetPopulation value = Value +0.25*abs(Value) accountinglabel = "GOOD_POPULATION_LABEL"
 '''
 


### PR DESCRIPTION
- had been changed without comment during the transition to effects based meter growth
- this reverts the priority back to what it had been before that, putting it back into
  the same priority tier as BAD_POPULATION, which is where the AI expects it.

Fixes #2153 