### PR TITLE
Refix stale objects and sensor ghosts

### DIFF
--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -3009,6 +3009,7 @@ void ServerApp::PreCombatProcessTurns() {
     // post-movement visibility update
     m_universe.UpdateEmpireObjectVisibilities();
     m_universe.UpdateEmpireLatestKnownObjectsAndVisibilityTurns();
+    m_universe.UpdateEmpireStaleObjectKnowledge();
 
     // SitRep for fleets having arrived at destinations
     for (auto& fleet : fleets) {
@@ -3089,7 +3090,10 @@ void ServerApp::ProcessCombats() {
     DisseminateSystemCombatInfo(combats);
     // update visibilities with any new info gleaned during combat
     m_universe.UpdateEmpireLatestKnownObjectsAndVisibilityTurns();
-
+    // update stale object info based on any mid- combat glimpses
+    // before visibiity is totally recalculated in the post combat processing
+    m_universe.UpdateEmpireStaleObjectKnowledge();
+    
     CreateCombatSitReps(combats);
 
     //CleanupSystemCombatInfo(combats); - NOTE: No longer needed since ObjectMap.Clear doesn't release any resources that aren't released in the destructor.

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -2562,8 +2562,15 @@ void Universe::UpdateEmpireStaleObjectKnowledge() {
         std::set<int>& stale_set = m_empire_stale_knowledge_object_ids[empire_id];
         const std::set<int>& destroyed_set = m_empire_known_destroyed_object_ids[empire_id];
 
-        // clear previous staleness determinations
-        stale_set.clear();
+        // remove stale marking for any known destroyed or currently visible objects
+        for (auto stale_it = stale_set.begin(); stale_it != stale_set.end();) {
+            int object_id = *stale_it;
+            if (vis_map.count(object_id) || destroyed_set.count(object_id))
+                stale_set.erase(stale_it++);
+            else
+                ++stale_it;
+        }
+
 
         // get empire latest known objects that are potentially detectable
         auto empires_latest_known_objects_that_should_be_detectable =

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -2566,7 +2566,7 @@ void Universe::UpdateEmpireStaleObjectKnowledge() {
         for (auto stale_it = stale_set.begin(); stale_it != stale_set.end();) {
             int object_id = *stale_it;
             if (vis_map.count(object_id) || destroyed_set.count(object_id))
-                stale_set.erase(stale_it++);
+                stale_it = stale_set.erase(stale_it);
             else
                 ++stale_it;
         }


### PR DESCRIPTION
#2147  fixed a problem with missing sensor ghosts.  In it I had discussed two possible solution approaches; unfortunately, the approach I chose to use there (de novo determination each turn) introduced a new problem with sensor ghosts failing to be marked stale when they should.  The alternative approach, which uses multiple updates to stale object info each turn, is implemented here.  I have two test cases below.  

The first one failed pre-#2147 but worked with it (and works here).  Advance one turn and a scout arrives at Ares and is killed, and there should be a sensor ghost remaining of the fleet that killed it (and of a nearby fleet). 
 [combat_vis_ghost_test.sav.zip](https://github.com/freeorion/freeorion/files/2108766/combat_vis_ghost_test.sav.zip)

The second one is a situation that had worked fine pre-#2147, but then was broken by #2147 (and again works fine here).  In the system to the SW of Stern Beta the client has knowledge an enemy scout was previously seen, but it is currently (and rightly) marked stale and is suppressed.  Advance one turn for the Frigate to move to Stern Beta.  After #2147 but before this PR, the enemy scout would no longer be recognized as stale and would appear as a sensor ghost.
 [let_scout_SW_from_Stern_stay_stale.sav.zip](https://github.com/freeorion/freeorion/files/2108772/let_scout_SW_from_Stern_stay_stale.sav.zip)

