### PR TITLE
Use 'Unknown Design' for unknown shipdesigns in Sitreps

### DIFF
--- a/util/VarText.cpp
+++ b/util/VarText.cpp
@@ -93,8 +93,12 @@ namespace {
             return boost::none;
         }
         T* object = GetByID(id);
-        if (!object)
-            return boost::none;
+        if (!object) {
+            if (std::is_same<T, const ShipDesign>::value)
+                return UserString("FW_UNKNOWN_DESIGN_NAME");
+            else
+                return UserString("TT_UNKNOWN");
+        }
 
         return WithTags(object->Name(), tag, data);
     }


### PR DESCRIPTION
- rather than having it display 'Error'
- the underlying method is also applicable to Empires; for an unknown empire it
  would now display 'Unknown'

The underlying problem is described in #2157 and appears as 
![image](https://user-images.githubusercontent.com/10995939/41492197-483e40ea-70b2-11e8-8f63-58c53c2ee0f7.png)

With this PR that now appears as

![supply_linkage_incomplete1](https://user-images.githubusercontent.com/10995939/41512691-a0806170-7242-11e8-8fb0-d5ffa3386695.png)

Fixes #2157