### PR TITLE
Fix bad erases

### DIFF
--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -7582,7 +7582,7 @@ void MapWnd::DispatchFleetsExploring() {
     for (auto it = m_fleets_exploring.begin(); it != m_fleets_exploring.end();) {
         auto fleet = GetFleet(*it);
         if (!fleet || destroyed_objects.count(fleet->ID())) {
-            m_fleets_exploring.erase(it++); //this fleet can't explore anymore
+            it = m_fleets_exploring.erase(it); //this fleet can't explore anymore
         } else {
              if (fleet->MovePath().empty())
                 idle_fleets.insert(fleet->ID());

--- a/util/GameRules.cpp
+++ b/util/GameRules.cpp
@@ -117,7 +117,7 @@ void GameRules::ClearExternalRules() {
     while (it != m_game_rules.end()) {
         bool engine_internal = it->second.storable; // OptionsDB::Option member used to store if this option is engine-internal
         if (!engine_internal)
-            m_game_rules.erase((it++)->first);      // note postfix operator++
+            it = m_game_rules.erase(it);
         else
             ++it;
     }

--- a/util/StringTable.cpp
+++ b/util/StringTable.cpp
@@ -183,7 +183,7 @@ void StringTable::Load(std::shared_ptr<const StringTable> lookups_fallback_table
                 {
                     if (ref_check_it->second <= position) {
                         //DebugLogger() << "Popping from cyclic ref check: " << ref_check_it->first;
-                        cyclic_reference_check.erase(ref_check_it++);
+                        ref_check_it = cyclic_reference_check.erase(ref_check_it);
                     } else if (ref_check_it->second < position + match.length()) {
                         ErrorLogger() << "Expansion error in key expansion: [[" << ref_check_it->first << "]] having end " << ref_check_it->second;
                         ErrorLogger() << "         currently at expansion text position " << position << " with match length: " << match.length();


### PR DESCRIPTION
The general issue of some preexisting bad erases came to attention in #2161 

This does not necessarily catch all such bad erases, I simply reviewed the erases where the iterator was also being incremented in the same line.

I am not entirely sure that the structure of the preexisting erase was in the third commit was necessarily bad, but I was unable to confirm that the iterator in that was not still invalidated, so I decided it's better to play it safe and restructure it.