### PR TITLE
in 0.4.8 Use 'Unknown Design' for unknown shipdesigns in Sitreps

### DIFF
--- a/util/VarText.cpp
+++ b/util/VarText.cpp
@@ -93,8 +93,12 @@ namespace {
             return boost::none;
         }
         T* object = GetByID(id);
-        if (!object)
-            return boost::none;
+        if (!object) {
+            if (std::is_same<T, const ShipDesign>::value)
+                return UserString("FW_UNKNOWN_DESIGN_NAME");
+            else
+                return boost::none;
+        }
 
         return WithTags(object->Name(), tag, data);
     }


### PR DESCRIPTION
- rather than having it display 'Error'
- it is expected that this will happen for ships that have never been glimpsed with
  better than Basic Visibility

This Pull Request is a somewhat more focused version of #2163,  specifically for release-v0.4.8
to provide a reasonable handling for #2157 in 0.4.8 while we continue to determine the more 
precise cause of the problem behavior in #2157 so as to possibly provide an even more finely tailored fix for master.
