### PR TITLE
Fix compatibility with boost 1.67.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -204,11 +204,17 @@ find_package(Boost ${MINIMUM_BOOST_VERSION}
         log_setup
         regex
         serialization
-        python
         signals
         system
         thread
     REQUIRED)
+if(${Boost_VERSION} GREATER 106699) # boost >= 1.67
+    find_package(Boost COMPONENTS python27 REQUIRED)
+    set(Boost_PYTHON_LIBRARY ${Boost_PYTHON27_LIBRARY})
+else()
+    find_package(Boost COMPONENTS python REQUIRED)
+endif()
+
 find_package(ZLIB REQUIRED)
 if(NOT BUILD_HEADLESS)
     find_package(Freetype REQUIRED)


### PR DESCRIPTION
From cmake's FindBoost.cmake:

    # Note that Boost Python components require a Python version suffix
    # (Boost 1.67 and later), e.g. ``python36`` or ``python27`` for the
    # versions built against Python 3.6 and 2.7, respectively.  This also
    # applies to additional components using Python including
    # ``mpi_python`` and ``numpy``.  Earlier Boost releases may use
    # distribution-specific suffixes such as ``2``, ``3`` or ``2.7``.
    # These may also be used as suffixes, but note that they are not
    # portable.

---

Note that this can break compatibility with earlier versions of boost, and probably requires some conditions to be implemented properly. However, without some form of this patch the game won't build with recent boost which is already quite wide spread among the distributions:

[![Boost versions in different repositories](https://repology.org/badge/vertical-allrepos/boost.svg)](https://repology.org/metapackage/boost)