### PR TITLE
[logger] use same format for python and cpp loggers

### DIFF
--- a/python/LoggingWrapper.cpp
+++ b/python/LoggingWrapper.cpp
@@ -101,19 +101,19 @@ namespace {
         // if that log level is disabled.
         switch (log_level) {
         case LogLevel::trace:
-            TraceLogger(python) << python_logger << " : " << filename << ":" /*<< function_name << ":"*/ << lineno << " - " << msg;
+            TraceLogger(python) << python_logger << " : " << filename << ":" /*<< function_name << ":"*/ << lineno << " : " << msg;
             break;
         case LogLevel::debug:
-            DebugLogger(python) << python_logger << " : " << filename << ":" /*<< function_name << ":"*/ << lineno << " - " << msg;
+            DebugLogger(python) << python_logger << " : " << filename << ":" /*<< function_name << ":"*/ << lineno << " : " << msg;
             break;
         case LogLevel::info:
-            InfoLogger(python)  << python_logger << " : " << filename << ":" /*<< function_name << ":"*/ << lineno << " - " << msg;
+            InfoLogger(python)  << python_logger << " : " << filename << ":" /*<< function_name << ":"*/ << lineno << " : " << msg;
             break;
         case LogLevel::warn:
-            WarnLogger(python)  << python_logger << " : " << filename << ":" /*<< function_name << ":"*/ << lineno << " - " << msg;
+            WarnLogger(python)  << python_logger << " : " << filename << ":" /*<< function_name << ":"*/ << lineno << " : " << msg;
             break;
         case LogLevel::error:
-            ErrorLogger(python) << python_logger << " : " << filename << ":" /*<< function_name << ":"*/ << lineno << " - " << msg;
+            ErrorLogger(python) << python_logger << " : " << filename << ":" /*<< function_name << ":"*/ << lineno << " : " << msg;
             break;
         }
     }


### PR DESCRIPTION
Logging example where both C++ and python logs
```
03:20:08.721918 [debug] ai : AIClientApp.cpp:318 : Message::GAME_START setting AI aggression as 5 (from rnd 51; max aggression 5)
03:20:08.721918 [debug] python : FreeOrionAI.py:86 - Initializing foAIstate...
```