### PR TITLE
Upgrade TravisCI pytest version to 3.6.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -132,7 +132,7 @@ jobs:
       language: python
       python: 2.7.14
       before_install:
-        - pip install pytest==3.4.0
+        - pip install pytest==3.6.3
       script:
         - pytest
       env:


### PR DESCRIPTION
In currently used pytest version 3.4.0, there are some quirks with the ```match``` parameter in ```pytest.raises``` which may give unprecise error messages if the test fails. This was adressed in 3.4.1 
https://docs.pytest.org/en/latest/changelog.html#pytest-3-4-1-2018-02-20

3.6.3 is the latest version at the time of this PR.