### PR TITLE
Don't use BOOST_OPTIONAL_CONFIG_USE_OLD_IMPLEMENTATION_OF_OPTIONAL with Boost >= 1.67

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,7 +262,7 @@ set_property(DIRECTORY APPEND
         # boost::spirit relies on some API the old implementation provided.
         # This define enables the usage of the old boost::optional
         # implementation.  Boost upstream tracks this bug as #12349
-        $<$<VERSION_GREATER:${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION},1.60>:BOOST_OPTIONAL_CONFIG_USE_OLD_IMPLEMENTATION_OF_OPTIONAL>
+        $<$<AND:$<VERSION_GREATER:${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION},1.60>,$<VERSION_LESS:${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION},1.67>>:BOOST_OPTIONAL_CONFIG_USE_OLD_IMPLEMENTATION_OF_OPTIONAL>
 
         # We don't need localized output of Boost date_time and not setting
         # the define causes the inclusion of code, which contains std::tolower.


### PR DESCRIPTION
[boost#12349](https://svn.boost.org/trac10/ticket/12349) is fixed, so the workaround can go away. According to [Repology](https://repology.org/metapackage/boost/versions) many distros still ship Boost >= 1.60, < 1.67.

FreeOrion 0.4.8-rc1 with the patch here build logs:
- [Boost 1.66](https://ptpb.pw/jQx2)
- [Boost 1.67](https://ptpb.pw/hafe)
