### PR TITLE
Add async threads

### DIFF
--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -1044,8 +1044,7 @@ std::vector<std::shared_ptr<GG::Texture>> ClientUI::GetPrefixedTextures(const bo
     return prefixed_textures_and_dist.first;
 }
 
-bool ClientUI::PushWork(std::function<void()> work)
-{
+bool ClientUI::PushWork(std::function<void()> work) {
     if (!work)
         return false;
     {
@@ -1055,8 +1054,7 @@ bool ClientUI::PushWork(std::function<void()> work)
     return true;
 }
 
-bool ClientUI::PopWork(std::function<void()>& work)
-{
+bool ClientUI::PopWork(std::function<void()>& work) {
     {
         std::lock_guard<std::mutex> guard(m_work_mutex);
         if (m_work_queue.empty())

--- a/UI/ClientUI.h
+++ b/UI/ClientUI.h
@@ -13,6 +13,8 @@
 
 #include <map>
 #include <memory>
+#include <mutex>
+#include <queue>
 
 
 class Fleet;
@@ -114,6 +116,12 @@ public:
     std::vector<std::shared_ptr<GG::Texture>> GetPrefixedTextures(const boost::filesystem::path& dir,
                                                                   const std::string& prefix,
                                                                   bool mipmap = false);
+
+    /** Add work for the GUI thread. */
+    bool PushWork(std::function<void()> work);
+
+    /** Get and remove work for the GUI thread. */
+    bool PopWork(std::function<void()>& work);
     //!@}
 
     static ClientUI* GetClientUI();     //!< returns a pointer to the singleton ClientUI class
@@ -231,6 +239,9 @@ private:
     std::shared_ptr<MultiPlayerLobbyWnd>    m_multiplayer_lobby_wnd;//!< the multiplayer lobby
     std::shared_ptr<SaveFileDialog>         m_savefile_dialog = nullptr;
     std::shared_ptr<PasswordEnterWnd>       m_password_enter_wnd;   //!< the authentication window
+
+    std::mutex                              m_work_mutex;           //!< guards access to the work queue
+    std::queue<std::function<void()>>       m_work_queue;           //!< FIFO queue of work for the GUI thread
 
     PrefixedTextures                        m_prefixed_textures;
 

--- a/UI/ClientUI.h
+++ b/UI/ClientUI.h
@@ -117,10 +117,13 @@ public:
                                                                   const std::string& prefix,
                                                                   bool mipmap = false);
 
-    /** Add work for the GUI thread. */
+    /** Adds the function \a work to the internal FIFO queue.
+      * Returns \c true if the function was added and \c false if the function was invalid. */
     bool PushWork(std::function<void()> work);
 
-    /** Get and remove work for the GUI thread. */
+    /** Moves the next function from the internal FIFO queue into \a work.
+      * The function placed in \a work is expected to be executed exactly once by the calling code.
+      * Returns \c true if a function was placed in \a work, returns \c false otherwise. */
     bool PopWork(std::function<void()>& work);
     //!@}
 

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -945,6 +945,7 @@ void HumanClientApp::HandleTurnPhaseUpdate(Message::TurnProgressPhase phase_id) 
 }
 
 void HumanClientApp::HandleSystemEvents() {
+    // this function is called in the GUI thread before rendering each frame
     try {
         SDLGUI::HandleSystemEvents();
     } catch (const utf8::invalid_utf8& e) {
@@ -956,6 +957,7 @@ void HumanClientApp::HandleSystemEvents() {
     } else if (auto msg = Networking().GetMessage()) {
         HandleMessage(*msg);
     }
+    // execute ClientUI work that is awaiting execution
     std::function<void()> work;
     while (GetClientUI().PopWork(work))
         work();

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -956,6 +956,9 @@ void HumanClientApp::HandleSystemEvents() {
     } else if (auto msg = Networking().GetMessage()) {
         HandleMessage(*msg);
     }
+    std::function<void()> work;
+    while (GetClientUI().PopWork(work))
+        work();
 }
 
 void HumanClientApp::RenderBegin() {

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -782,8 +782,7 @@ WaitingForGameStart::WaitingForGameStart(my_context ctx) :
     Client().GetClientUI().GetMapWnd()->EnableOrderIssuing(false);
 }
 
-WaitingForGameStart::~WaitingForGameStart()
-{
+WaitingForGameStart::~WaitingForGameStart() {
     TraceLogger(FSM) << "(HumanClientFSM) ~WaitingForGameStart";
     if (is_loading)
         WarnLogger(FSM) << "WaitingForGameStart did not finish loading";

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -772,7 +772,8 @@ boost::statechart::result PlayingGame::react(const LobbyUpdate& msg) {
 // WaitingForGameStart
 ////////////////////////////////////////////////////////////
 WaitingForGameStart::WaitingForGameStart(my_context ctx) :
-    Base(ctx)
+    Base(ctx),
+    is_loading(false)
 {
     TraceLogger(FSM) << "(HumanClientFSM) WaitingForGameStart";
 

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -797,6 +797,8 @@ boost::statechart::result WaitingForGameStart::react(const DoneLoading& msg) {
         return discard_event();
     }
 
+    is_loading = false;
+
     return transit<PlayingTurn>();
 }
 
@@ -864,7 +866,6 @@ void WaitingForGameStart::ProcessUI(bool is_new_game, const SaveGameUIData& ui_d
 
     Client().GetClientUI().GetPlayerListWnd()->Refresh();
 
-    is_loading = false;
     context<HumanClientFSM>().process_event(DoneLoading());
 }
 

--- a/client/human/HumanClientFSM.h
+++ b/client/human/HumanClientFSM.h
@@ -310,6 +310,7 @@ struct WaitingForGameStart : boost::statechart::state<WaitingForGameStart, Playi
 
     CLIENT_ACCESSOR
 
+private:
     //! Load data in an asyc thread to avoid freezing the UI.
     void ProcessData(const Message& message);
 

--- a/client/human/HumanClientFSM.h
+++ b/client/human/HumanClientFSM.h
@@ -314,7 +314,7 @@ struct WaitingForGameStart : boost::statechart::state<WaitingForGameStart, Playi
     //! Update UI in the GUI thread.
     void ProcessUI(bool is_new_game, const SaveGameUIData& ui_data);
 
-    bool is_loading = false;  //!< true from GameStart to DoneLoading
+    volatile bool is_loading = false;  //!< true from GameStart to DoneLoading
 };
 
 

--- a/client/human/HumanClientFSM.h
+++ b/client/human/HumanClientFSM.h
@@ -10,6 +10,7 @@
 #include <boost/statechart/state.hpp>
 #include <boost/statechart/state_machine.hpp>
 
+#include <atomic>
 #include <chrono>
 
 // Human client-specific events not already defined in ClientFSMEvents.h
@@ -314,7 +315,7 @@ struct WaitingForGameStart : boost::statechart::state<WaitingForGameStart, Playi
     //! Update UI in the GUI thread.
     void ProcessUI(bool is_new_game, const SaveGameUIData& ui_data);
 
-    volatile bool is_loading = false;  //!< true from GameStart to DoneLoading
+    std::atomic<bool> is_loading;  //!< true from GameStart to DoneLoading
 };
 
 

--- a/client/human/HumanClientFSM.h
+++ b/client/human/HumanClientFSM.h
@@ -38,6 +38,7 @@ struct TurnEnded : boost::statechart::event<TurnEnded> {};
 struct AdvanceTurn : boost::statechart::event<AdvanceTurn> {};
 
 // Indicates that everything has been loaded.
+// What was loaded is determined by the current FSM state.
 struct DoneLoading : boost::statechart::event<DoneLoading> {};
 
 /** The set of events used by the QuittingGame state. */
@@ -309,7 +310,7 @@ struct WaitingForGameStart : boost::statechart::state<WaitingForGameStart, Playi
 
     CLIENT_ACCESSOR
 
-    //! Load data in an asyc thread.
+    //! Load data in an asyc thread to avoid freezing the UI.
     void ProcessData(const Message& message);
 
     //! Update UI in the GUI thread.

--- a/util/launch_async.h
+++ b/util/launch_async.h
@@ -1,0 +1,25 @@
+#ifndef _launch_async_h_
+#define _launch_async_h_
+
+#include "Logger.h"
+
+#include <future>
+
+
+// FIXME avoid unnecessary copies/moves
+
+
+//! Execute a callable in an async thread.
+template <typename Fn>
+void launch_async(Fn fn)
+{
+    std::async(std::launch::async, [fn] () {
+        try {
+            fn();
+        } catch (const std::exception& ex) {
+            ErrorLogger() << "Exception in async thread: " << ex.what();
+        }
+    });
+}
+
+#endif // _launch_async_h_


### PR DESCRIPTION
This PR introduces a way to split loading/processing stuff and GUI stuff.

An example split is done in the WaitingForGameStart state of the human client.
The data is loaded in an async thread. When done it adds the UI updates to the GUI work queue, which is executed before the next frame is rendered.
As a consequence, when you continue a game from the intro menu, instead of being frozen you will be able to move the mouse during the initial load (before the PlayingTurn state).

Topic: http://www.freeorion.org/forum/viewtopic.php?f=9&t=11009