### PR TITLE
Add EncyclopediaDetailPage.

### DIFF
--- a/UI/EncyclopediaDetailPanel.h
+++ b/UI/EncyclopediaDetailPanel.h
@@ -22,6 +22,7 @@ class UniverseObject;
 class Empire;
 class ShipDesign;
 class GraphControl;
+struct EncyclopediaDetailPage;
 
 
 /** UI class that displays in-game encyclopedic information about game
@@ -107,9 +108,8 @@ private:
 
     bool EventFilter(GG::Wnd* w, const GG::WndEvent& event) override;
 
-    static std::list<std::pair <std::string, std::string>>              m_items;    // stores all items which have been observed in the past
-                                                                                    // .first == item type; .second == item.name
-    static std::list<std::pair <std::string, std::string>>::iterator    m_items_it; // stores actual position within m_items
+    static std::list<EncyclopediaDetailPage>            m_items;    // stores all items which have been observed in the past
+    static std::list<EncyclopediaDetailPage>::iterator  m_items_it; // stores actual position within m_items
 
     std::weak_ptr<const ShipDesign> m_incomplete_design;
 


### PR DESCRIPTION
This is a refactoring PR.

I used "page" instead of "item" in the name because it's clearer.
Q1: Should I change other comments, variables, and function names that refer to a page as an item?

Originally I made these changes so that I could introduce async loading during or after #2219, but I realized that async loading won't be needed in most cases. Selective refresh should be enough to prevent most freeze times caused by the encyclopedia, and the turn number appears to be a good reference.

Q2: Is there anything you can do during a turn that should force a page to immediately refresh?  I'm not sure, but I have a feeling everything you do during your turn only takes effect (forces a page refresh) after you are done with the turn.