### PR TITLE
Add options to manage cookies expire time.

### DIFF
--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1365,6 +1365,9 @@ Set the minimum number of human players required to start a multiplayer game.
 OPTIONS_DB_MP_HUMAN_MAX
 Limit the number of human players allowed in a multiplayer game. Set to -1 for unlimited.
 
+OPTIONS_DB_COOKIES_EXPIRE
+Count of minutes after the cookie record will be considered expired.
+
 OPTIONS_DB_UI_MAIN_MENU_X
 Position of the center of the intro screen main menu, as a portion of the application's total width.
 

--- a/network/ServerNetworking.cpp
+++ b/network/ServerNetworking.cpp
@@ -619,7 +619,8 @@ void ServerNetworking::UpdateCookie(boost::uuids::uuid cookie) {
 
     auto it = m_cookies.find(cookie);
     if (it != m_cookies.end()) {
-        it->second.expired = boost::posix_time::second_clock::local_time() + boost::posix_time::minutes(15);
+        it->second.expired = boost::posix_time::second_clock::local_time() +
+            boost::posix_time::minutes(GetOptionsDB().Get<int>("network.server.cookies.expire-minutes"));
     }
 }
 

--- a/server/dmain.cpp
+++ b/server/dmain.cpp
@@ -60,6 +60,7 @@ int wmain(int argc, wchar_t* argv[], wchar_t* envp[]) {
         GetOptionsDB().Add<int>("network.server.ai.max", UserStringNop("OPTIONS_DB_MP_AI_MAX"), -1, Validator<int>());
         GetOptionsDB().Add<int>("network.server.human.min", UserStringNop("OPTIONS_DB_MP_HUMAN_MIN"), 0, Validator<int>());
         GetOptionsDB().Add<int>("network.server.human.max", UserStringNop("OPTIONS_DB_MP_HUMAN_MAX"), -1, Validator<int>());
+        GetOptionsDB().Add<int>("network.server.cookies.expire-minutes", UserStringNop("OPTIONS_DB_COOKIES_EXPIRE"), 15, Validator<int>());
 
         // if config.xml and persistent_config.xml are present, read and set options entries
         GetOptionsDB().SetFromFile(GetConfigPath(), FreeOrionVersionString());


### PR DESCRIPTION
Adds server option `network.server.cookies.expire-minutes` to set expire time for cookies.