### PR TITLE
Fix collision counter in case some player names are reserved with cookies

### DIFF
--- a/network/ServerNetworking.cpp
+++ b/network/ServerNetworking.cpp
@@ -529,6 +529,9 @@ bool ServerNetworking::CheckCookie(boost::uuids::uuid cookie,
     return false;
 }
 
+int ServerNetworking::GetCookiesSize() const
+{ return m_cookies.size(); }
+
 bool ServerNetworking::SendMessageAll(const Message& message) {
     bool success = true;
     for (auto player_it = established_begin();

--- a/network/ServerNetworking.h
+++ b/network/ServerNetworking.h
@@ -115,6 +115,9 @@ public:
                      const std::string& player_name,
                      Networking::AuthRoles& roles,
                      bool& authenticated) const;
+
+    /** Returns count of stored cookies so we don't collide with reserved player names. */
+    int GetCookiesSize() const;
     //@}
 
     /** \name Mutators */ //@{

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -852,7 +852,9 @@ sc::result MPLobby::react(const JoinGame& msg) {
 
         bool collision = true;
         std::size_t t = 1;
-        while (t <= m_lobby_data->m_players.size() + 1 && collision) {
+        while (t <= m_lobby_data->m_players.size() + server.Networking().GetCookiesSize() + 1 &&
+            collision)
+        {
             collision = false;
             roles.Clear();
             if (!server.IsAvailableName(new_player_name) || server.IsAuthRequiredOrFillRoles(new_player_name, roles)) {
@@ -1855,7 +1857,9 @@ sc::result WaitingForMPGameJoiners::react(const JoinGame& msg) {
 
             bool collision = true;
             std::size_t t = 1;
-            while (t <= m_lobby_data->m_players.size() + 1 && collision) {
+            while (t <= m_lobby_data->m_players.size() + server.Networking().GetCookiesSize() + 1 &&
+                collision)
+            {
                 collision = false;
                 roles.Clear();
                 if (!server.IsAvailableName(new_player_name) || server.IsAuthRequiredOrFillRoles(new_player_name, roles)) {
@@ -2242,7 +2246,9 @@ sc::result PlayingGame::react(const JoinGame& msg) {
 
         bool collision = true;
         std::size_t t = 1;
-        while (t <= server.Networking().NumEstablishedPlayers() + 1 && collision) {
+        while (t <= server.Networking().NumEstablishedPlayers() + server.Networking().GetCookiesSize() + 1 &&
+            collision)
+        {
             collision = false;
             roles.Clear();
             if (!server.IsAvailableName(new_player_name) || server.IsAuthRequiredOrFillRoles(new_player_name, roles)) {

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -852,8 +852,8 @@ sc::result MPLobby::react(const JoinGame& msg) {
 
         bool collision = true;
         std::size_t t = 1;
-        while (t <= m_lobby_data->m_players.size() + server.Networking().GetCookiesSize() + 1 &&
-            collision)
+        while (collision &&
+               t <= m_lobby_data->m_players.size() + server.Networking().GetCookiesSize() + 1)
         {
             collision = false;
             roles.Clear();
@@ -1857,8 +1857,8 @@ sc::result WaitingForMPGameJoiners::react(const JoinGame& msg) {
 
             bool collision = true;
             std::size_t t = 1;
-            while (t <= m_lobby_data->m_players.size() + server.Networking().GetCookiesSize() + 1 &&
-                collision)
+            while (collision &&
+                   t <= m_lobby_data->m_players.size() + server.Networking().GetCookiesSize() + 1)
             {
                 collision = false;
                 roles.Clear();
@@ -2246,8 +2246,8 @@ sc::result PlayingGame::react(const JoinGame& msg) {
 
         bool collision = true;
         std::size_t t = 1;
-        while (t <= server.Networking().NumEstablishedPlayers() + server.Networking().GetCookiesSize() + 1 &&
-            collision)
+        while (collision &&
+               t <= server.Networking().NumEstablishedPlayers() + server.Networking().GetCookiesSize() + 1)
         {
             collision = false;
             roles.Clear();


### PR DESCRIPTION
`ServerApp::IsAvailableName` checks names in cookies as well so it possible loop doesn't find available name if counter use only player from lobby data. PR defines addition tries depending on size of stored cookie.

This PR fixes issue in v0.4.8 so should be cherry-picked there.