### PR TITLE
System messages in chat

### DIFF
--- a/UI/ChatWnd.cpp
+++ b/UI/ChatWnd.cpp
@@ -385,7 +385,10 @@ void MessageWnd::HandlePlayerChatMessage(const std::string& text,
     const std::string&& formatted_timestamp = ClientUI::FormatTimestamp(timestamp);
     if (IsValidUTF8(formatted_timestamp))
         wrapped_text += formatted_timestamp;
-    wrapped_text += player_name + ": " + filtered_message + "</rgba>";
+    if (player_name.empty())
+        wrapped_text += filtered_message + "</rgba>";
+    else
+        wrapped_text += player_name + ": " + filtered_message + "</rgba>";
     TraceLogger() << "HandlePlayerChatMessage sender: " << player_name
                   << "  sender colour rgba tag: " << RgbaTag(text_color)
                   << "  filtered message: " << filtered_message

--- a/UI/MultiplayerLobbyWnd.cpp
+++ b/UI/MultiplayerLobbyWnd.cpp
@@ -731,7 +731,7 @@ void MultiPlayerLobbyWnd::ChatMessage(int player_id, const boost::posix_time::pt
     std::string player_name{UserString("PLAYER") + " " + std::to_string(player_id)};
     GG::Clr text_color{ClientUI::GetClientUI()->TextColor()};
     if (player_id != Networking::INVALID_PLAYER_ID) {
-        for (std::pair<int, PlayerSetupData>& entry : m_lobby_data.m_players) {
+        for (auto& entry : m_lobby_data.m_players) {
             if (entry.first != player_id || entry.first == Networking::INVALID_PLAYER_ID)
                 continue;
             player_name = entry.second.m_player_name;

--- a/UI/MultiplayerLobbyWnd.cpp
+++ b/UI/MultiplayerLobbyWnd.cpp
@@ -730,11 +730,16 @@ void MultiPlayerLobbyWnd::ChatMessage(int player_id, const boost::posix_time::pt
     // look up player name by ID
     std::string player_name{UserString("PLAYER") + " " + std::to_string(player_id)};
     GG::Clr text_color{ClientUI::GetClientUI()->TextColor()};
-    for (std::pair<int, PlayerSetupData>& entry : m_lobby_data.m_players) {
-        if (entry.first != player_id || entry.first == Networking::INVALID_PLAYER_ID)
-            continue;
-        player_name = entry.second.m_player_name;
-        text_color = entry.second.m_empire_color;
+    if (player_id != Networking::INVALID_PLAYER_ID) {
+        for (std::pair<int, PlayerSetupData>& entry : m_lobby_data.m_players) {
+            if (entry.first != player_id || entry.first == Networking::INVALID_PLAYER_ID)
+                continue;
+            player_name = entry.second.m_player_name;
+            text_color = entry.second.m_empire_color;
+        }
+    } else {
+        // It's a server message. Don't set player name.
+        player_name = "";
     }
 
     m_chat_wnd->HandlePlayerChatMessage(msg, player_name, text_color, timestamp, HumanClientApp::GetApp()->PlayerID());

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -623,12 +623,17 @@ boost::statechart::result PlayingGame::react(const PlayerChat& msg) {
 
     std::string player_name{UserString("PLAYER") + " " + std::to_string(sending_player_id)};
     GG::Clr text_color{Client().GetClientUI().TextColor()};
-    auto players = Client().Players();
-    auto player_it = players.find(sending_player_id);
-    if (player_it != players.end()) {
-        player_name = player_it->second.name;
-        if (auto empire = GetEmpire(player_it->second.empire_id))
-            text_color = empire->Color();
+    if (sending_player_id != Networking::INVALID_PLAYER_ID) {
+        auto players = Client().Players();
+        auto player_it = players.find(sending_player_id);
+        if (player_it != players.end()) {
+            player_name = player_it->second.name;
+            if (auto empire = GetEmpire(player_it->second.empire_id))
+                text_color = empire->Color();
+        }
+    } else {
+        // It's a server message. Don't set player name.
+        player_name = "";
     }
 
     Client().GetClientUI().GetMessageWnd()->HandlePlayerChatMessage(text, player_name, text_color, timestamp, Client().PlayerID());

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -570,7 +570,10 @@ boost::statechart::result MPLobby::react(const ChatHistory& msg) {
 
     const auto& wnd = Client().GetClientUI().GetMultiPlayerLobbyWnd();
     for (const auto& elem : chat_history)
-        wnd->ChatMessage(elem.m_text, elem.m_player_name, elem.m_text_color, elem.m_timestamp);
+        wnd->ChatMessage(elem.m_text,
+                         elem.m_player_name,
+                         elem.m_player_name.empty() ? Client().GetClientUI().TextColor() : elem.m_text_color,
+                         elem.m_timestamp);
 
     return discard_event();
 }

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1505,6 +1505,8 @@ bool ServerApp::IsLocalHumanPlayer(int player_id) {
 }
 
 bool ServerApp::IsAvailableName(const std::string& player_name) const {
+    if (player_name.empty())
+        return false;
     for (auto it = m_networking.established_begin();
          it != m_networking.established_end(); ++it)
     {
@@ -3108,7 +3110,7 @@ void ServerApp::ProcessCombats() {
     // update stale object info based on any mid- combat glimpses
     // before visibiity is totally recalculated in the post combat processing
     m_universe.UpdateEmpireStaleObjectKnowledge();
-    
+
     CreateCombatSitReps(combats);
 
     //CleanupSystemCombatInfo(combats); - NOTE: No longer needed since ObjectMap.Clear doesn't release any resources that aren't released in the destructor.


### PR DESCRIPTION
Fix #2207. Chat messages with empty player name treats as a system message. History messages treats as well.
Also adds server-side check so no one could login with empty name.

The issue was assigned to `post v0.4.8` milestone but could this PR picked to 0.4.8 too so welcome messages will be available for release?