### PR TITLE
Python API for storing and loading chat history

### DIFF
--- a/default/python/README.md
+++ b/default/python/README.md
@@ -11,6 +11,8 @@ an execute_turn_events() function returning a boolean (successful completion).
 sub-module of the resource directory and can be changed with the --ai-path flag.
 * auth/  -  Python code which manages auth information stored either in a file
 or in a database.
+* chat/  -  Python code which manages chat history stored either in a file or in
+a database.
 * common/  -  Common files for code utilized by both the AI and the server.
 * handlers/  -  see handlers/README.md
 * turn_events/  -  Python scripts that run at the beginning of every turn, and

--- a/default/python/chat/chat.py
+++ b/default/python/chat/chat.py
@@ -6,7 +6,7 @@ from common.configure_logging import redirect_logging_to_freeorion_logger
 redirect_logging_to_freeorion_logger()
 
 
-class ChatProvider:
+class ChatHistoryProvider:
     def __init__(self):
         """
         Initializes ChatProvider. Doesn't accept arguments.

--- a/default/python/chat/chat.py
+++ b/default/python/chat/chat.py
@@ -1,0 +1,22 @@
+from logging import info
+
+from common.configure_logging import redirect_logging_to_freeorion_logger
+
+# Logging is redirected before other imports so that import errors appear in log files.
+redirect_logging_to_freeorion_logger()
+
+
+class ChatProvider:
+    def __init__(self):
+        info("Chat initialized")
+
+    def load_history(self):
+        info("Loading history...")
+        # c = fo.GGColor(255, 128, 128, 255)
+        # e = (123456789012, "P1", "Test1", c)
+        # return [e]
+        return []
+
+    def put_history_entity(self, timestamp, player_name, text, text_color):
+        info("Chat %s: %s %s" % (player_name, text, text_color))
+        return True

--- a/default/python/chat/chat.py
+++ b/default/python/chat/chat.py
@@ -8,9 +8,18 @@ redirect_logging_to_freeorion_logger()
 
 class ChatProvider:
     def __init__(self):
+        """
+        Initializes ChatProvider. Doesn't accept arguments.
+        """
         info("Chat initialized")
 
     def load_history(self):
+        """
+        Loads chat history from external sources.
+
+        Returns list of tuples:
+            (unixtime timestamp, player name, text, text color of type freeorion.GGColor)
+        """
         info("Loading history...")
         # c = fo.GGColor(255, 128, 128, 255)
         # e = (123456789012, "P1", "Test1", c)
@@ -18,5 +27,16 @@ class ChatProvider:
         return []
 
     def put_history_entity(self, timestamp, player_name, text, text_color):
+        """
+        Put chat into external storage.
+
+        Return True if successfully stored. False otherwise.
+
+        Arguments:
+        timestamp -- unixtime, number of seconds from 1970-01-01 00:00:00 UTC
+        player_name -- player name
+        text -- chat text
+        text_color -- freeorion.GGColor
+        """
         info("Chat %s: %s %s" % (player_name, text, text_color))
         return True

--- a/default/python/tox.ini
+++ b/default/python/tox.ini
@@ -7,6 +7,7 @@ putty-ignore =
   AI/savegame_codec/__init__.py : +F401
   AI/freeorion_tools/__init__.py : +F401,F403
   auth/auth.py : +E402
+  chat/chat.py : +E402
   turn_events/turn_events.py : +E402
   universe_generation/universe_generator.py : +E402
   universe_generation/universe_tables.py : +E201,E122,E231

--- a/python/EmpireWrapper.cpp
+++ b/python/EmpireWrapper.cpp
@@ -515,7 +515,7 @@ namespace FreeOrionPython {
         ///////////
         // Color //
         ///////////
-        class_<GG::Clr>("GGColor", no_init)
+        class_<GG::Clr>("GGColor", init<unsigned char, unsigned char, unsigned char, unsigned char>())
             .add_property("r",                  &GG::Clr::r)
             .add_property("g",                  &GG::Clr::g)
             .add_property("b",                  &GG::Clr::b)

--- a/python/server/ServerFramework.cpp
+++ b/python/server/ServerFramework.cpp
@@ -108,7 +108,7 @@ bool PythonServer::InitModules() {
     m_python_module_chat = import("chat");
 
     // Save ChatProvider instance in chat module's namespace
-    m_python_module_chat.attr("__dict__")["chat_provider"] = m_python_module_chat.attr("ChatProvider")();
+    m_python_module_chat.attr("__dict__")["chat_history_provider"] = m_python_module_chat.attr("ChatHistoryProvider")();
 
     DebugLogger() << "Server Python modules successfully initialized!";
     return true;
@@ -167,9 +167,9 @@ bool PythonServer::IsSuccessAuthAndReturnRoles(const std::string& player_name, c
 }
 
 bool PythonServer::LoadChatHistory(boost::circular_buffer<ChatHistoryEntity>& chat_history) {
-    boost::python::object chat_provider = m_python_module_chat.attr("__dict__")["chat_provider"];
+    boost::python::object chat_provider = m_python_module_chat.attr("__dict__")["chat_history_provider"];
     if (!chat_provider) {
-        ErrorLogger() << "Unable to get Python object chat_provider";
+        ErrorLogger() << "Unable to get Python object chat_history_provider";
         return false;
     }
     boost::python::object f = chat_provider.attr("load_history");
@@ -195,9 +195,9 @@ bool PythonServer::LoadChatHistory(boost::circular_buffer<ChatHistoryEntity>& ch
 }
 
 bool PythonServer::PutChatHistoryEntity(const ChatHistoryEntity& chat_history_entity) {
-    boost::python::object chat_provider = m_python_module_chat.attr("__dict__")["chat_provider"];
+    boost::python::object chat_provider = m_python_module_chat.attr("__dict__")["chat_history_provider"];
     if (!chat_provider) {
-        ErrorLogger() << "Unable to get Python object chat_provider";
+        ErrorLogger() << "Unable to get Python object chat_history_provider";
         return false;
     }
     boost::python::object f = chat_provider.attr("put_history_entity");

--- a/python/server/ServerFramework.h
+++ b/python/server/ServerFramework.h
@@ -4,6 +4,8 @@
 #include "../CommonFramework.h"
 #include "../../util/MultiplayerCommon.h"
 
+#include <boost/circular_buffer.hpp>
+
 #include <map>
 
 
@@ -16,6 +18,8 @@ public:
     bool ExecuteTurnEvents();    // Wraps call to the main Python turn events function
     bool IsRequireAuthOrReturnRoles(const std::string& player_name, bool &result, Networking::AuthRoles& roles) const; // Wraps call to AuthProvider's method is_require_auth
     bool IsSuccessAuthAndReturnRoles(const std::string& player_name, const std::string& auth, bool &result, Networking::AuthRoles& roles) const; // Wraps call to AuthProvider's method is_success_auth
+    bool LoadChatHistory(boost::circular_buffer<ChatHistoryEntity>& chat_history); // Wraps call to ChatProvider's method load_history
+    bool PutChatHistoryEntity(const ChatHistoryEntity& chat_history_entity); // Wraps call to ChatProvider's method put_history_entity
 
 private:
     // reference to imported Python universe generator module
@@ -26,6 +30,9 @@ private:
 
     // reference to imported Python auth module
     boost::python::object m_python_module_auth;
+
+    // reference to importer Python chat module
+    boost::python::object m_python_module_chat;
 };
 
 // Returns folder containing the Python universe generator scripts
@@ -36,5 +43,8 @@ const std::string GetPythonTurnEventsDir();
 
 // Returns folder containing the Python auth scripts
 const std::string GetPythonAuthDir();
+
+// Returns folder containing the Python chat scripts
+const std::string GetPythonChatDir();
 
 #endif /* defined(__FreeOrion__Python__ServerFramework__) */

--- a/python/server/ServerWrapper.cpp
+++ b/python/server/ServerWrapper.cpp
@@ -67,6 +67,7 @@ using boost::python::tuple;
 using boost::python::make_tuple;
 using boost::python::extract;
 using boost::python::len;
+using boost::python::long_;
 
 
 FO_COMMON_API extern const int INVALID_DESIGN_ID;

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -196,6 +196,9 @@ public:
     /** Send the requested combat logs to the client.*/
     void UpdateCombatLogs(const Message& msg, PlayerConnectionPtr player_connection);
 
+    /** Loads chat history via python script. */
+    void LoadChatHistory();
+
     void PushChatMessage(const std::string& text,
                          const std::string& player_name,
                          GG::Clr text_color,

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -554,6 +554,7 @@ MPLobby::MPLobby(my_context c) :
     ClockSeed();
     ServerApp& server = Server();
     server.InitializePython();
+    server.LoadChatHistory();
     const SpeciesManager& sm = GetSpeciesManager();
     if (server.IsHostless()) {
         DebugLogger(FSM) << "(ServerFSM) MPLobby. Fill MPLobby data from the previous game.";


### PR DESCRIPTION
Introduce dummy implementation for storing and loading chat history via python script which could be altered to use an actual DBMS or so.

Introduce class `ChatProvider` implements methods `load_history` to read chat history from external source and `put_history_entity` to store it.

P.S. Example for psycopg2:
```python
from logging import info

from common.configure_logging import redirect_logging_to_freeorion_logger

# Logging is redirected before other imports so that import errors appear in log files.
redirect_logging_to_freeorion_logger()

import freeorion as fo

import psycopg2
import psycopg2.extensions
psycopg2.extensions.register_type(psycopg2.extensions.UNICODE)
psycopg2.extensions.register_type(psycopg2.extensions.UNICODEARRAY)


class ChatHistoryProvider:
    def __init__(self):
        """
        Initializes ChatProvider. Doesn't accept arguments.
        """
        dsn = ""
        with open(fo.get_user_config_dir() + "/db.txt", "r") as f:
            for line in f:
                dsn = line
                break
        self.conn = psycopg2.connect(dsn)
        info("Chat initialized")

    def load_history(self):
        """
        Loads chat history from external sources.

        Returns list of tuples:
            (unixtime timestamp, player name, text, text color of type freeorion.GGColor)
        """
        info("Loading history...")
        res = []
        with self.conn:
            with self.conn.cursor() as curs:
                curs.execute(""" SELECT date_part('epoch', ts)::int, player_name, text,
                    text_color / 256 / 256 / 256 % 256,
                    text_color / 256 / 256 % 256,
                    text_color / 256 % 256,
                    text_color % 256
                    FROM chat_history
                    ORDER BY ts
                    LIMIT 1000 """)
                for r in curs:
                    c = fo.GGColor(r[3], r[4], r[5], r[6])
                    e = (r[0], str(r[1].encode('utf-8')), str(r[2].encode('utf-8')), c)
                    res.append(e)
        return res

    def put_history_entity(self, timestamp, player_name, text, text_color):
        """
        Put chat into external storage.

        Return True if successfully stored. False otherwise.

        Arguments:
        timestamp -- unixtime, number of seconds from 1970-01-01 00:00:00 UTC
        player_name -- player name
        text -- chat text
        text_color -- freeorion.GGColor
        """
        info("Chat %s: %s %s" % (player_name, text, text_color))
        with self.conn:
            with self.conn.cursor() as curs:
                curs.execute(""" INSERT INTO chat_history (ts, player_name, text, text_color)
                    VALUES (to_timestamp(%s) at time zone 'utc', %s, %s, %s)""",
                    (timestamp, player_name, text,
                        256 * (256 * (256 * text_color.r + text_color.g) + text_color.b) + text_color.a))
        return True
```