### PR TITLE
Allow the FleetMoveOrder destination to be the current/next system.

### DIFF
--- a/util/Order.cpp
+++ b/util/Order.cpp
@@ -301,11 +301,6 @@ bool FleetMoveOrder::Check(int empire_id, int fleet_id, int dest_system_id, bool
         return false;
     }
 
-    if (dest_system_id != INVALID_OBJECT_ID && dest_system_id == start_system) {
-        DebugLogger() << "AIInterface::IssueFleetMoveOrder : pass destination system id (" << dest_system_id << ") that fleet is already in";
-        return false;
-    }
-
     // verify fleet route first system
     if (append && !fleet->TravelRoute().empty()) {
         // We should append and there is something to append to


### PR DESCRIPTION
Fixes the 2nd part of #2222

Note that this change is dubious... considering code design, how should a "stay in the current system" order be represented in the code? and how would the AI issue it?

If a "move fleet to this system" order is an acceptable representation, then this change is probably ok.