### PR TITLE
Release: Use future boost::gil 1.68 IO extensions instead of homegrown hack

### DIFF
--- a/GG/CMakeLists.txt
+++ b/GG/CMakeLists.txt
@@ -144,6 +144,16 @@ if(USE_STATIC_LIBS)
     )
 endif()
 
+target_compile_definitions(GiGi
+    PRIVATE
+
+        # Starting with boost 1.68 boost::gil integrates support for
+        # grayscale-alpha png images, so prefer their implementation
+        # instead of our hacky gilext code.
+        $<$<VERSION_LESS:${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION},1.68>:GIGI_CONFIG_USE_OLD_IMPLEMENTATION_OF_GIL_PNG_IO>
+        $<$<VERSION_GREATER:${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION},1.67>:BOOST_GIL_IO_ENABLE_GRAY_ALPHA>
+)
+
 target_include_directories(GiGi SYSTEM
     PRIVATE
         ${Boost_INCLUDE_DIRS}

--- a/GG/src/GUI.cpp
+++ b/GG/src/GUI.cpp
@@ -37,13 +37,18 @@
 #include <GG/ZList.h>
 
 #if GG_HAVE_LIBPNG
-# if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ > 7)
-#  pragma GCC diagnostic push
-#  pragma GCC diagnostic ignored "-Wunused-local-typedefs"
-# endif
-# include "gilext/io/png_io.hpp"
-# if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ > 7)
-#  pragma GCC diagnostic pop
+# if GIGI_CONFIG_USE_OLD_IMPLEMENTATION_OF_GIL_PNG_IO
+#  if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ > 7)
+#   pragma GCC diagnostic push
+#   pragma GCC diagnostic ignored "-Wunused-local-typedefs"
+#  endif
+#  include "gilext/io/png_io.hpp"
+#  include "gilext/io/png_io_v2_compat.hpp"
+#  if __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ > 7)
+#   pragma GCC diagnostic pop
+#  endif
+# else
+#  include <boost/gil/extension/io/png.hpp>
 # endif
 #endif
 
@@ -132,12 +137,15 @@ namespace {
         glPopClientAttrib();
 
         using namespace boost::gil;
-        png_write_view(filename,
-                       flipped_up_down_view(
-                           interleaved_view(Value(size.x),
-                                            Value(size.y),
-                                            static_cast<rgba8_pixel_t*>(static_cast<void*>(&bytes[0])),
-                                            Value(size.x) * sizeof(rgba8_pixel_t))));
+        write_view(
+            filename,
+            flipped_up_down_view(
+                interleaved_view(
+                    Value(size.x),
+                    Value(size.y),
+                    static_cast<rgba8_pixel_t*>(static_cast<void*>(&bytes[0])),
+                    Value(size.x) * sizeof(rgba8_pixel_t))),
+            png_tag());
 #endif
     }
 }

--- a/GG/src/Texture.cpp
+++ b/GG/src/Texture.cpp
@@ -36,7 +36,12 @@
 #include <boost/algorithm/string/case_conv.hpp>
 
 #if GG_HAVE_LIBPNG
-# include "gilext/io/png_dynamic_io.hpp"
+# if GIGI_CONFIG_USE_OLD_IMPLEMENTATION_OF_GIL_PNG_IO
+#  include "gilext/io/png_dynamic_io.hpp"
+#  include "gilext/io/png_io_v2_compat.hpp"
+# else
+#  include <boost/gil/extension/io/png.hpp>
+# endif
 #endif
 
 #include <iostream>
@@ -241,12 +246,12 @@ void Texture::Load(const boost::filesystem::path& path, bool mipmap/* = false*/)
         // formats above.
 #if GG_HAVE_LIBPNG
         if (extension == ".png")
-            gil::png_read_image(path, image);
+            gil::read_image(filename, image, gil::image_read_settings<gil::png_tag>());
         else
 #endif
 #if GG_HAVE_LIBTIFF
         if (extension == ".tif" || extension == ".tiff")
-            gil::tiff_read_image(filename, image);
+            gil::read_image(filename, image, gil::image_read_settings<gil::tiff_tag>());
         else
 #endif
             throw BadFile("Texture file \"" + filename + "\" does not have a supported file extension");
@@ -256,14 +261,14 @@ void Texture::Load(const boost::filesystem::path& path, bool mipmap/* = false*/)
 #if GG_HAVE_LIBPNG
         if (extension == ".png") {
             gil::rgba8_image_t rgba_image;
-            gil::png_read_and_convert_image(path, rgba_image);
+            gil::read_and_convert_image(filename, rgba_image, gil::image_read_settings<gil::png_tag>());
             image.move_in(rgba_image);
         }
 #endif
 #if GG_HAVE_LIBTIFF
         if (extension == ".tif" || extension == ".tiff") {
             gil::rgba8_image_t rgba_image;
-            gil::tiff_read_and_convert_image(filename, rgba_image);
+            gil::read_and_convert_image(filename, rgba_image, gil::image_read_settings<gil::tiff_tag>());
             image.move_in(rgba_image);
         }
 #endif

--- a/GG/src/gilext/io/png_io_v2_compat.hpp
+++ b/GG/src/gilext/io/png_io_v2_compat.hpp
@@ -1,0 +1,45 @@
+#ifndef GILEXT_PNG_IO_V2_COMPAT_H
+#define GILEXT_PNG_IO_V2_COMPAT_H
+
+namespace boost { namespace gil {
+
+struct png_tag {};
+
+template< typename Tag>
+struct image_read_settings {};
+
+template< typename String
+        , typename Image
+        , typename FormatTag
+        >
+inline
+void read_image( const String&    file_name
+               , Image&           image
+               , const FormatTag& tag
+               )
+{ boost::gil::png_read_image(file_name, image); }
+
+template< typename String
+        , typename Image
+        , typename FormatTag
+        >
+inline
+void read_and_convert_image( const String&    file_name
+                           , Image&           image
+                           , const FormatTag& tag
+                           )
+{ boost::gil::png_read_and_convert_image(file_name, image); }
+} }
+
+template< typename String
+        , typename View
+        , typename FormatTag
+        >
+inline
+void write_view( const String&    file_name
+               , const View&      view
+               , const FormatTag& tag
+               )
+{ boost::gil::png_write_view( file_name, view); }
+
+#endif

--- a/msvc2015/GiGi/GiGi.vcxproj
+++ b/msvc2015/GiGi/GiGi.vcxproj
@@ -201,7 +201,7 @@
       <Optimization>Full</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>NDEBUG;_USRDLL;_DLL;GiGi_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_USRDLL;_DLL;GiGi_EXPORTS;GIGI_CONFIG_USE_OLD_IMPLEMENTATION_OF_GIL_PNG_IO;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../include/;../../../include;../../GG/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PrecompiledHeaderFile>

--- a/msvc2015/GiGi/GiGi.vcxproj
+++ b/msvc2015/GiGi/GiGi.vcxproj
@@ -173,7 +173,7 @@
     <ClCompile>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <Optimization>Full</Optimization>
-      <PreprocessorDefinitions>NDEBUG;_USRDLL;GIGI_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_USRDLL;GIGI_CONFIG_USE_OLD_IMPLEMENTATION_OF_GIL_PNG_IO;GIGI_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../include/GG;../../../include/;../../../include/GG;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
@@ -201,7 +201,7 @@
       <Optimization>Full</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>NDEBUG;_USRDLL;_DLL;GiGi_EXPORTS;GIGI_CONFIG_USE_OLD_IMPLEMENTATION_OF_GIL_PNG_IO;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_USRDLL;GIGI_CONFIG_USE_OLD_IMPLEMENTATION_OF_GIL_PNG_IO;_DLL;GiGi_EXPORTS;GIGI_CONFIG_USE_OLD_IMPLEMENTATION_OF_GIL_PNG_IO;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../include/;../../../include;../../GG/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PrecompiledHeaderFile>
@@ -230,7 +230,7 @@
       <Optimization>Full</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
-      <PreprocessorDefinitions>NDEBUG;_USRDLL;_DLL;GiGi_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>NDEBUG;_USRDLL;GIGI_CONFIG_USE_OLD_IMPLEMENTATION_OF_GIL_PNG_IO;_DLL;GiGi_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../include/;../../../include;../../GG/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PrecompiledHeaderFile>


### PR DESCRIPTION
Based on https://github.com/freeorion/freeorion/pull/2221

Starting with boost 1.68 boost::gil integrates IO support for
grayscale-alpha png images, so prefer their implementation instead of
our hacky gilext code.