### PR TITLE
Reformat files with the Black  [Not for merge]

### DIFF
--- a/default/python/tests/AI/character_test/character_strings_test.py
+++ b/default/python/tests/AI/character_test/character_strings_test.py
@@ -1,8 +1,5 @@
 from character.character_module import Trait, Character, Aggression
-from character.character_strings_module import (
-    _make_aggression_based_function,
-    get_trait_name_aggression,
-)
+from character.character_strings_module import _make_aggression_based_function, get_trait_name_aggression
 
 
 def test_make_aggression_based_function():
@@ -40,7 +37,4 @@ def test_get_trait_name_aggression():
     assert get_trait_name_aggression(character) == "UserString GSETUP_TURTLE"
 
     nonaggressive_character = Character([UnknownTrait()])
-    assert (
-        get_trait_name_aggression(nonaggressive_character)
-        == "UserString UNKNOWN_VALUE_SYMBOL"
-    )
+    assert get_trait_name_aggression(nonaggressive_character) == "UserString UNKNOWN_VALUE_SYMBOL"

--- a/default/python/tests/AI/character_test/character_strings_test.py
+++ b/default/python/tests/AI/character_test/character_strings_test.py
@@ -1,5 +1,8 @@
 from character.character_module import Trait, Character, Aggression
-from character.character_strings_module import _make_aggression_based_function, get_trait_name_aggression
+from character.character_strings_module import (
+    _make_aggression_based_function,
+    get_trait_name_aggression,
+)
 
 
 def test_make_aggression_based_function():
@@ -37,4 +40,7 @@ def test_get_trait_name_aggression():
     assert get_trait_name_aggression(character) == "UserString GSETUP_TURTLE"
 
     nonaggressive_character = Character([UnknownTrait()])
-    assert get_trait_name_aggression(nonaggressive_character) == "UserString UNKNOWN_VALUE_SYMBOL"
+    assert (
+        get_trait_name_aggression(nonaggressive_character)
+        == "UserString UNKNOWN_VALUE_SYMBOL"
+    )

--- a/default/python/tests/AI/character_test/character_test.py
+++ b/default/python/tests/AI/character_test/character_test.py
@@ -9,9 +9,7 @@ class LeftTrait(Trait):
 class RightTrait(Trait):
     """A test Trait that injects values to be found by combiners"""
 
-    def may_explore_system(
-        self, monster_threat
-    ):  # pylint: disable=no-self-use,unused-argument
+    def may_explore_system(self, monster_threat):  # pylint: disable=no-self-use,unused-argument
         """Always reject. 1 parameter"""
         return False
 
@@ -19,9 +17,7 @@ class RightTrait(Trait):
         """Always reject. 0 parameters"""
         return False
 
-    def preferred_research_cutoff(
-        self, alternatives
-    ):  # pylint: disable=no-self-use,unused-argument
+    def preferred_research_cutoff(self, alternatives):  # pylint: disable=no-self-use,unused-argument
         """Pick 1st"""
         return alternatives[1]
 
@@ -79,10 +75,6 @@ class TestCharacter(object):
         assert rejection_character.preferred_research_cutoff([10, 11, 12]) == 11
 
     def test_character_must_be_composed_of_traits(self):
-        with pytest.raises(
-            TypeError,
-            message="Expect TypeError",
-            match="All traits must be sub-classes of Trait",
-        ):
+        with pytest.raises(TypeError, message="Expect TypeError", match="All traits must be sub-classes of Trait"):
             not_a_trait = int(1)
             Character([LeftTrait, not_a_trait])

--- a/default/python/tests/AI/character_test/character_test.py
+++ b/default/python/tests/AI/character_test/character_test.py
@@ -9,7 +9,9 @@ class LeftTrait(Trait):
 class RightTrait(Trait):
     """A test Trait that injects values to be found by combiners"""
 
-    def may_explore_system(self, monster_threat):  # pylint: disable=no-self-use,unused-argument
+    def may_explore_system(
+        self, monster_threat
+    ):  # pylint: disable=no-self-use,unused-argument
         """Always reject. 1 parameter"""
         return False
 
@@ -17,7 +19,9 @@ class RightTrait(Trait):
         """Always reject. 0 parameters"""
         return False
 
-    def preferred_research_cutoff(self, alternatives):  # pylint: disable=no-self-use,unused-argument
+    def preferred_research_cutoff(
+        self, alternatives
+    ):  # pylint: disable=no-self-use,unused-argument
         """Pick 1st"""
         return alternatives[1]
 
@@ -75,6 +79,10 @@ class TestCharacter(object):
         assert rejection_character.preferred_research_cutoff([10, 11, 12]) == 11
 
     def test_character_must_be_composed_of_traits(self):
-        with pytest.raises(TypeError, message='Expect TypeError', match='All traits must be sub-classes of Trait'):
+        with pytest.raises(
+            TypeError,
+            message="Expect TypeError",
+            match="All traits must be sub-classes of Trait",
+        ):
             not_a_trait = int(1)
             Character([LeftTrait, not_a_trait])

--- a/default/python/tests/AI/test_parse_ai_tag_grade.py
+++ b/default/python/tests/AI/test_parse_ai_tag_grade.py
@@ -2,16 +2,16 @@ from freeorion_tools import get_ai_tag_grade
 
 
 def test_parse_weapon_tag_positive1():
-    assert 'GREAT' == get_ai_tag_grade(['GREAT_WEAPONS'], 'WEAPONS')
+    assert "GREAT" == get_ai_tag_grade(["GREAT_WEAPONS"], "WEAPONS")
 
 
 def test_parse_weapon_tag_positive2():
-    assert 'GREAT' == get_ai_tag_grade(['GREAT_MULTI_WORD_TAG'], 'MULTI_WORD_TAG')
+    assert "GREAT" == get_ai_tag_grade(["GREAT_MULTI_WORD_TAG"], "MULTI_WORD_TAG")
 
 
 def test_parse_weapon_tag_negative1():
-    assert '' == get_ai_tag_grade(['WEAPONS'], 'WEAPONS')
+    assert "" == get_ai_tag_grade(["WEAPONS"], "WEAPONS")
 
 
 def test_parse_weapon_tag_negative2():
-    assert '' == get_ai_tag_grade(['GREAT_WEAPONS'], 'WEAPON')
+    assert "" == get_ai_tag_grade(["GREAT_WEAPONS"], "WEAPON")

--- a/default/python/tests/AI/test_read_only_dict.py
+++ b/default/python/tests/AI/test_read_only_dict.py
@@ -26,11 +26,7 @@ def test_non_existing_keys():
     # check correct functionality if keys not in dict
     assert "INVALID_KEY" not in test_dict
     assert test_dict.get("INVALID_KEY", -99999) == -99999
-    with pytest.raises(
-        KeyError,
-        message="Invalid key lookup didn't raise a KeyError",
-        match="'INVALID_KEY'",
-    ):
+    with pytest.raises(KeyError, message="Invalid key lookup didn't raise a KeyError", match="'INVALID_KEY'"):
         # noinspection PyStatementEffect
         test_dict["INVALID_KEY"]
 
@@ -70,9 +66,7 @@ def test_deletion():
 def test_setitem():
     test_dict = ReadOnlyDict(dict_content)
     with pytest.raises(
-        TypeError,
-        message="Can add items to the dict.",
-        match="'ReadOnlyDict' object does not support item assignment",
+        TypeError, message="Can add items to the dict.", match="'ReadOnlyDict' object does not support item assignment"
     ):
         test_dict["INVALID_KEY"] = 1
     assert "INVALID_KEY" not in test_dict
@@ -80,9 +74,5 @@ def test_setitem():
 
 def test_nonhashable_values():
     # make sure can't store unhashable items (as heuristic for mutable items)
-    with pytest.raises(
-        TypeError,
-        message="Can store mutable items in dict",
-        match="unhashable type: 'list'",
-    ):
+    with pytest.raises(TypeError, message="Can store mutable items in dict", match="unhashable type: 'list'"):
         ReadOnlyDict({1: [1]})

--- a/default/python/tests/AI/test_read_only_dict.py
+++ b/default/python/tests/AI/test_read_only_dict.py
@@ -1,12 +1,7 @@
 import pytest
 from freeorion_tools import ReadOnlyDict
 
-dict_content = {
-    1: -1,
-    1.09: 1.1,
-    'abc': 'xyz',
-    (1, 2, 3): ('a', 1, (1, 2)),
-}
+dict_content = {1: -1, 1.09: 1.1, "abc": "xyz", (1, 2, 3): ("a", 1, (1, 2))}
 
 
 def test_dict_content():
@@ -29,11 +24,15 @@ def test_membership():
 def test_non_existing_keys():
     test_dict = ReadOnlyDict(dict_content)
     # check correct functionality if keys not in dict
-    assert 'INVALID_KEY' not in test_dict
-    assert test_dict.get('INVALID_KEY', -99999) == -99999
-    with pytest.raises(KeyError, message="Invalid key lookup didn't raise a KeyError", match="'INVALID_KEY'"):
+    assert "INVALID_KEY" not in test_dict
+    assert test_dict.get("INVALID_KEY", -99999) == -99999
+    with pytest.raises(
+        KeyError,
+        message="Invalid key lookup didn't raise a KeyError",
+        match="'INVALID_KEY'",
+    ):
         # noinspection PyStatementEffect
-        test_dict['INVALID_KEY']
+        test_dict["INVALID_KEY"]
 
 
 def test_str_conversion():
@@ -70,13 +69,20 @@ def test_deletion():
 
 def test_setitem():
     test_dict = ReadOnlyDict(dict_content)
-    with pytest.raises(TypeError, message='Can add items to the dict.',
-                       match="'ReadOnlyDict' object does not support item assignment"):
-        test_dict['INVALID_KEY'] = 1
-    assert 'INVALID_KEY' not in test_dict
+    with pytest.raises(
+        TypeError,
+        message="Can add items to the dict.",
+        match="'ReadOnlyDict' object does not support item assignment",
+    ):
+        test_dict["INVALID_KEY"] = 1
+    assert "INVALID_KEY" not in test_dict
 
 
 def test_nonhashable_values():
     # make sure can't store unhashable items (as heuristic for mutable items)
-    with pytest.raises(TypeError, message='Can store mutable items in dict', match="unhashable type: 'list'"):
+    with pytest.raises(
+        TypeError,
+        message="Can store mutable items in dict",
+        match="unhashable type: 'list'",
+    ):
         ReadOnlyDict({1: [1]})

--- a/default/python/tests/AI/test_savegame_manager.py
+++ b/default/python/tests/AI/test_savegame_manager.py
@@ -14,12 +14,7 @@ class DummyTestClass(object):
         self._some_private_var = "_Test"
         self.__some_more_private_var = "__Test"
         self.some_dict = {"ABC": 123.1, (1, 2.3, "ABC", "zz"): (1, (2, (3, 4)))}
-        self.some_list = [
-            self.some_int,
-            self.some_float,
-            self.some_other_float,
-            self.some_string,
-        ]
+        self.some_list = [self.some_int, self.some_float, self.some_other_float, self.some_string]
         self.some_set = set(self.some_list)
         self.some_tuple = tuple(self.some_list)
 
@@ -83,12 +78,7 @@ class OldStyleClass:
         (1, 2, 3),
         [1, 2, 3],
         {1, 2, 3},
-        {
-            "a": 1,
-            True: False,
-            (1, 2): {1, 2, 3},
-            (1, 2, (3, (4,))): [1, 2, (3, 4), {1, 2, 3}],
-        },
+        {"a": 1, True: False, (1, 2): {1, 2, 3}, (1, 2, (3, (4,))): [1, 2, (3, 4), {1, 2, 3}]},
     ],
     ids=str,
 )
@@ -171,17 +161,13 @@ def test_class_encoding():
 
 def test_getstate_call():
     with TrustedScope():
-        with pytest.raises(
-            Success, message="__getstate__ was not called during encoding."
-        ):
+        with pytest.raises(Success, message="__getstate__ was not called during encoding."):
             savegame_codec.encode(GetStateTester())
 
 
 def test_setstate_call():
     with TrustedScope():
-        with pytest.raises(
-            Success, message="__setstate__ was not called during decoding."
-        ):
+        with pytest.raises(Success, message="__setstate__ was not called during decoding."):
             savegame_codec.decode(savegame_codec.encode(SetStateTester()))
 
 

--- a/default/python/tests/common/test_print_utils.py
+++ b/default/python/tests/common/test_print_utils.py
@@ -1,5 +1,5 @@
 # coding=utf-8
-'''
+"""
 
 
 ===== Columns =====
@@ -7,15 +7,15 @@
 
 
 Process finished with exit code 0
-'''
+"""
 
 from common.print_utils import print_in_columns, Table, Text, Float, Sequence
 
-EXPECTED_COLUMNS = '''a   c
+EXPECTED_COLUMNS = """a   c
 b   d
-'''
+"""
 
-EXPECTED_SIMPLE_TABLE = '''Wooho
+EXPECTED_SIMPLE_TABLE = """Wooho
 ============================================================================
 | name*            | value*     | zzz                 | zzzzzzzzzzzzzzzzzz |
 ============================================================================
@@ -27,42 +27,51 @@ EXPECTED_SIMPLE_TABLE = '''Wooho
 | Plato III        |      21.00 | d                   | a                  |
 ----------------------------------------------------------------------------
 *name   Name for first column
-*value  VValue'''
+*value  VValue"""
 
-EXPECTED_EMPTY_TABLE = '''Wooho
+EXPECTED_EMPTY_TABLE = """Wooho
 =============================================
 | name* | value* | zzz | zzzzzzzzzzzzzzzzzz |
 =============================================
 ---------------------------------------------
 *name   Name for first column
-*value  VValue'''
+*value  VValue"""
 
 
 # https://pytest.org/latest/capture.html#accessing-captured-output-from-a-test-function
 def test_print_in_columns(capfd):
-    print_in_columns(['a', 'b', 'c', 'd'], 2)
+    print_in_columns(["a", "b", "c", "d"], 2)
     out, err = capfd.readouterr()
     assert out == EXPECTED_COLUMNS
 
 
 def test_simple_table():
     t = Table(
-        [Text('name', description='Name for first column'), Float('value', description='VValue'),
-         Sequence('zzz'), Sequence('zzzzzzzzzzzzzzzzzz')],
-        table_name='Wooho')
-    t.add_row(['hello', 144444, 'abcffff', 'a'])
-    t.add_row([u'Plato aa\u03b2 III', 21, 'de', 'a'])
-    t.add_row([u'Plato \u03b2 III', 21, 'de', 'a'])
-    t.add_row(['Plato B III', 21, 'd', 'a'])
-    t.add_row(['Plato Bddddd III', 21, 'd', 'a'])
-    t.add_row(['Plato III', 21, 'd', 'a'])
+        [
+            Text("name", description="Name for first column"),
+            Float("value", description="VValue"),
+            Sequence("zzz"),
+            Sequence("zzzzzzzzzzzzzzzzzz"),
+        ],
+        table_name="Wooho",
+    )
+    t.add_row(["hello", 144444, "abcffff", "a"])
+    t.add_row([u"Plato aa\u03b2 III", 21, "de", "a"])
+    t.add_row([u"Plato \u03b2 III", 21, "de", "a"])
+    t.add_row(["Plato B III", 21, "d", "a"])
+    t.add_row(["Plato Bddddd III", 21, "d", "a"])
+    t.add_row(["Plato III", 21, "d", "a"])
     assert t.get_table() == EXPECTED_SIMPLE_TABLE
 
 
 def test_empty_table():
     empty = Table(
-        [Text('name', description='Name for first column'), Float('value', description='VValue'),
-         Sequence('zzz'), Sequence('zzzzzzzzzzzzzzzzzz')],
-        table_name='Wooho'
+        [
+            Text("name", description="Name for first column"),
+            Float("value", description="VValue"),
+            Sequence("zzz"),
+            Sequence("zzzzzzzzzzzzzzzzzz"),
+        ],
+        table_name="Wooho",
     )
     assert empty.get_table() == EXPECTED_EMPTY_TABLE

--- a/default/python/tests/conftest.py
+++ b/default/python/tests/conftest.py
@@ -9,8 +9,8 @@ import sys
 this_dir = os.path.dirname(__file__)
 
 sys.path.append(this_dir)
-sys.path.append(os.path.join(this_dir, '..', '..', 'python', 'AI/'))
-sys.path.append(os.path.join(this_dir, '..', '..', 'python'))
+sys.path.append(os.path.join(this_dir, "..", "..", "python", "AI/"))
+sys.path.append(os.path.join(this_dir, "..", "..", "python"))
 
 # Since the 'true' freeOrionAIInterface is not available during testing, this import loads the 'mock' freeOrionInterface
 # module into memory.  For testing purposes the mock interface provides values for certain constants which various

--- a/default/python/tests/freeOrionAIInterface.py
+++ b/default/python/tests/freeOrionAIInterface.py
@@ -3,6 +3,7 @@
 
 class aggression(object):
     """Aggression enumeration."""
+
     beginner = 0
     turtle = 1
     cautious = 2
@@ -13,6 +14,7 @@ class aggression(object):
 
 class planetSize(object):
     """PlanetSize enumeration."""
+
     tiny = 1
     small = 2
     medium = 3
@@ -26,6 +28,7 @@ class planetSize(object):
 
 class starType(object):
     """StarType enumeration."""
+
     blue = 0
     white = 1
     yellow = 2
@@ -39,6 +42,7 @@ class starType(object):
 
 class visibility(object):
     """Visibility enumeration."""
+
     invalid = -1
     none = 0
     basic = 1
@@ -48,6 +52,7 @@ class visibility(object):
 
 class planetType(object):
     """PlanetType enumeration."""
+
     # this is the listing order in EnumWrapper.cpp, so keeping it the same here
     swamp = 0
     radiated = 3
@@ -65,6 +70,7 @@ class planetType(object):
 
 class planetEnvironment(object):
     """PlanetEnvironment enumeration."""
+
     uninhabitable = 0
     hostile = 1
     poor = 2
@@ -74,6 +80,7 @@ class planetEnvironment(object):
 
 class techStatus(object):
     """TechStatus enumeration."""
+
     unresearchable = 0
     partiallyUnlocked = 1
     researchable = 2
@@ -82,6 +89,7 @@ class techStatus(object):
 
 class buildType(object):
     """BuildType enumeration."""
+
     building = 0
     ship = 1
     stockpile = 2
@@ -89,6 +97,7 @@ class buildType(object):
 
 class resourceType(object):
     """ResourceType enumeration."""
+
     industry = 0
     trade = 1
     research = 2
@@ -97,6 +106,7 @@ class resourceType(object):
 
 class meterType(object):
     """MeterType enumeration."""
+
     targetPopulation = 0
     targetIndustry = 1
     targetResearch = 2
@@ -138,6 +148,7 @@ class meterType(object):
 
 class diplomaticStatus(object):
     """DiplomaticStatus enumeration."""
+
     war = 0
     peace = 1
     allied = 2
@@ -145,6 +156,7 @@ class diplomaticStatus(object):
 
 class diplomaticMessageType(object):
     """DiplomaticMessageType enumeration."""
+
     noMessage = -1
     warDeclaration = 0
     peaceProposal = 1
@@ -158,6 +170,7 @@ class diplomaticMessageType(object):
 
 class captureResult(object):
     """CaptureResult enumeration."""
+
     capture = 0
     destroy = 1
     retain = 2
@@ -165,6 +178,7 @@ class captureResult(object):
 
 class effectsCauseType(object):
     """EffectsCauseType enumeration."""
+
     invalid = -1
     unknown = 0
     inherent = 1
@@ -179,6 +193,7 @@ class effectsCauseType(object):
 
 class shipSlotType(object):
     """ShipSlotType enumeration."""
+
     external = 0
     internal = 1
     core = 2
@@ -186,6 +201,7 @@ class shipSlotType(object):
 
 class shipPartClass(object):
     """ShipPartClass enumeration."""
+
     shortRange = 0
     fighterBay = 1
     fighterHangar = 2
@@ -207,6 +223,7 @@ class shipPartClass(object):
 
 class unlockableItemType(object):
     """UnlockableItemType enumeration."""
+
     invalid = -1
     building = 0
     shipPart = 1
@@ -217,6 +234,7 @@ class unlockableItemType(object):
 
 class galaxySetupOption(object):
     """GalaxySetupOption enumeration."""
+
     invalid = -1
     none = 0
     low = 1
@@ -227,6 +245,7 @@ class galaxySetupOption(object):
 
 class galaxyShape(object):
     """GalaxyShape enumeration."""
+
     invalid = -1
     spiral2 = 0
     spiral3 = 1
@@ -242,6 +261,7 @@ class galaxyShape(object):
 
 class ruleType(object):
     """RuleType enumeration."""
+
     invalid = -1
     toggle = 0
     int = 1
@@ -251,6 +271,7 @@ class ruleType(object):
 
 class roleType(object):
     """RoleType enumeration."""
+
     host = 0
     clientTypeModerator = 1
     clientTypePlayer = 2


### PR DESCRIPTION
This PR is not for the merge, but for discussion. 

All changes were done by the external tool.    [Black](https://github.com/ambv/black)

Important feature:
```
Also, as a temporary safety measure, Black will check that the reformatted code still produces a valid AST that is equivalent to the original. This slows it down. If you're feeling confident, use --fast.
```
Formatting can be safely applied to code, without review. 

I don't like this formatting but it is ok for me to switch to it and yes it confronts some our style rules.  Good point that no need to write and follow any rules, just press the button.

So maybe we can switch to this code style for the project? 
@Dilvish-fo , @Morlic-fo , what do you think?

There is space for automation, but let's not discuss it in this thread.

PS. files with `print ` will not be reformated.





