### PR TITLE
Object List Type Filter

### DIFF
--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -26,6 +26,9 @@
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/st_connected.hpp>
 
+//TODO: replace with std::make_unique when transitioning to C++14
+#include <boost/smart_ptr/make_unique.hpp>
+
 using boost::io::str;
 
 FO_COMMON_API extern const int INVALID_DESIGN_ID;
@@ -1812,6 +1815,11 @@ unsigned int Armed::GetCheckSum() const {
 Type::Type(std::unique_ptr<ValueRef::ValueRefBase<UniverseObjectType>>&& type) :
     ConditionBase(),
     m_type(std::move(type))
+{}
+
+Type::Type(UniverseObjectType type) :
+    ConditionBase(),
+    m_type(boost::make_unique<ValueRef::Constant<UniverseObjectType>>(type))
 {}
 
 bool Type::operator==(const ConditionBase& rhs) const {

--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -9272,6 +9272,14 @@ And::And(std::vector<std::unique_ptr<ConditionBase>>&& operands) :
     m_operands(std::move(operands))
 {}
 
+And::And(std::unique_ptr<ConditionBase>&& operand1, std::unique_ptr<ConditionBase>&& operand2) :
+    ConditionBase()
+{
+    // would prefer to initialize the vector m_operands in the initializer list, but this is difficult with non-copyable unique_ptr parameters
+    m_operands.push_back(std::move(operand1));
+    m_operands.push_back(std::move(operand2));
+}
+
 bool And::operator==(const ConditionBase& rhs) const {
     if (this == &rhs)
         return true;

--- a/universe/Condition.h
+++ b/universe/Condition.h
@@ -1859,6 +1859,7 @@ private:
 /** Matches all objects that match every Condition in \a operands. */
 struct FO_COMMON_API And final : public ConditionBase {
     explicit And(std::vector<std::unique_ptr<ConditionBase>>&& operands);
+    And(std::unique_ptr<ConditionBase>&& operand1, std::unique_ptr<ConditionBase>&& operand2);
 
     bool operator==(const ConditionBase& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,

--- a/universe/Condition.h
+++ b/universe/Condition.h
@@ -543,6 +543,7 @@ private:
 /** Matches all objects that are of UniverseObjectType \a type. */
 struct FO_COMMON_API Type final : public ConditionBase {
     explicit Type(std::unique_ptr<ValueRef::ValueRefBase<UniverseObjectType>>&& type);
+    explicit Type(UniverseObjectType type);
 
     bool operator==(const ConditionBase& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
@@ -1748,7 +1749,7 @@ private:
 /** Matches the objects that have been targeted for bombardment by at least one
   * object that matches \a m_by_object_condition. */
 struct FO_COMMON_API OrderedBombarded final : public ConditionBase {
-    OrderedBombarded(std::unique_ptr<ConditionBase>&& by_object_condition);
+    explicit OrderedBombarded(std::unique_ptr<ConditionBase>&& by_object_condition);
 
     bool operator==(const ConditionBase& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
@@ -1857,7 +1858,7 @@ private:
 
 /** Matches all objects that match every Condition in \a operands. */
 struct FO_COMMON_API And final : public ConditionBase {
-    And(std::vector<std::unique_ptr<ConditionBase>>&& operands);
+    explicit And(std::vector<std::unique_ptr<ConditionBase>>&& operands);
 
     bool operator==(const ConditionBase& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
@@ -1883,7 +1884,7 @@ private:
 
 /** Matches all objects that match at least one Condition in \a operands. */
 struct FO_COMMON_API Or final : public ConditionBase {
-    Or(std::vector<std::unique_ptr<ConditionBase>>&& operands);
+    explicit Or(std::vector<std::unique_ptr<ConditionBase>>&& operands);
 
     bool operator==(const ConditionBase& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
@@ -1906,7 +1907,7 @@ private:
 
 /** Matches all objects that do not match the Condition \a operand. */
 struct FO_COMMON_API Not final : public ConditionBase {
-    Not(std::unique_ptr<ConditionBase>&& operand);
+    explicit Not(std::unique_ptr<ConditionBase>&& operand);
 
     bool operator==(const ConditionBase& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,


### PR DESCRIPTION
Adds an object-type filter to C++ implemented ValueRefs used as object's list columns for "Species". This prevents error messages from appearing in the client log when the "Species" property is evaluated on objects that don't have that property (ie. non-ship and non-planets).