### PR TITLE
Give more correct descriptions of negated And conditions

### DIFF
--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -10040,13 +10040,13 @@ DESC_ORDERED_BOMBARDED_NOT
 ''' that is not being bombarded by an object %1%'''
 
 DESC_AND_BEFORE_OPERANDS
-''''''
+'''['''
 
 DESC_AND_BETWEEN_OPERANDS
 ''' and'''
 
 DESC_AND_AFTER_OPERANDS
-''''''
+''']'''
 
 DESC_AND_BEFORE_SINGLE_OPERAND
 ''''''
@@ -10054,26 +10054,67 @@ DESC_AND_BEFORE_SINGLE_OPERAND
 DESC_AND_AFTER_SINGLE_OPERAND
 ''''''
 
+# NOT AND Descriptions for expressions  ( not ( A and B and C ) )
+# We actually describe the the logically equivalent expression ( (not A) or (not B) or (not C) )
+# Describes the '( (not A) or' part
 DESC_NOT_AND_BEFORE_OPERANDS
-''' (not'''
+''' (either not'''
 
+# Describes the 'or (not B)' and 'or (not C)' parts
 DESC_NOT_AND_BETWEEN_OPERANDS
-'''[[DESC_OR_NOT_BETWEEN_OPERANDS]]'''
+''', or not'''
 
+# Describes the ')' part
 DESC_NOT_AND_AFTER_OPERANDS
 ''' )'''
 
+# Describes 'not ( AND [ A ] )' before A
 DESC_NOT_AND_BEFORE_SINGLE_OPERAND
 ''' not'''
 
+# Describes 'not ( AND [ A ] )' after A
 DESC_NOT_AND_AFTER_SINGLE_OPERAND
 ''''''
 
-DESC_OR_BETWEEN_OPERANDS
-''' or'''
 
-DESC_OR_NOT_BETWEEN_OPERANDS
-''' or not'''
+#### Describes the 'and (not ..)' in the expression ( (not A) and (not B) )
+###DESC_AND_NOT_BETWEEN_OPERANDS
+###''' and not'''
+
+DESC_OR_BEFORE_OPERANDS
+''' (either'''
+
+DESC_OR_BETWEEN_OPERANDS
+''', or'''
+
+DESC_OR_AFTER_OPERANDS
+''' )'''
+
+DESC_OR_BEFORE_SINGLE_OPERAND
+''''''
+
+DESC_OR_AFTER_SINGLE_OPERAND
+''''''
+
+# NOT OR Descriptions
+# Describes the 'not ( ' in the expression ( not ( A or B ) )
+# We actually describe the ' in the logically equivalent expression ( (not A) and (not B) )
+
+DESC_NOT_OR_BEFORE_OPERANDS
+''' [neither'''
+
+DESC_NOT_OR_BETWEEN_OPERANDS
+''', nor'''
+
+DESC_NOT_OR_AFTER_OPERANDS
+''' ]'''
+
+DESC_NOT_OR_BEFORE_SINGLE_OPERAND
+''' not'''
+
+DESC_NOT_OR_AFTER_SINGLE_OPERAND
+''''''
+
 
 # %1% textual description of the lower turn limit.
 # %2% textual description of the upper turn limit.

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -10039,11 +10039,41 @@ DESC_ORDERED_BOMBARDED
 DESC_ORDERED_BOMBARDED_NOT
 ''' that is not being bombarded by an object %1%'''
 
+DESC_AND_BEFORE_OPERANDS
+''''''
+
 DESC_AND_BETWEEN_OPERANDS
 ''' and'''
 
+DESC_AND_AFTER_OPERANDS
+''''''
+
+DESC_AND_BEFORE_SINGLE_OPERAND
+''''''
+
+DESC_AND_AFTER_SINGLE_OPERAND
+''''''
+
+DESC_NOT_AND_BEFORE_OPERANDS
+''' (not'''
+
+DESC_NOT_AND_BETWEEN_OPERANDS
+'''[[DESC_OR_NOT_BETWEEN_OPERANDS]]'''
+
+DESC_NOT_AND_AFTER_OPERANDS
+''' )'''
+
+DESC_NOT_AND_BEFORE_SINGLE_OPERAND
+''' not'''
+
+DESC_NOT_AND_AFTER_SINGLE_OPERAND
+''''''
+
 DESC_OR_BETWEEN_OPERANDS
 ''' or'''
+
+DESC_OR_NOT_BETWEEN_OPERANDS
+''' or not'''
 
 # %1% textual description of the lower turn limit.
 # %2% textual description of the upper turn limit.

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -10039,14 +10039,16 @@ DESC_ORDERED_BOMBARDED
 DESC_ORDERED_BOMBARDED_NOT
 ''' that is not being bombarded by an object %1%'''
 
+
+# AND Descriptions for expressions 'AND [ A B C ]'
 DESC_AND_BEFORE_OPERANDS
-'''['''
+''' ['''
 
 DESC_AND_BETWEEN_OPERANDS
-''' and'''
+''', and'''
 
 DESC_AND_AFTER_OPERANDS
-''']'''
+''' ]'''
 
 DESC_AND_BEFORE_SINGLE_OPERAND
 ''''''
@@ -10054,33 +10056,29 @@ DESC_AND_BEFORE_SINGLE_OPERAND
 DESC_AND_AFTER_SINGLE_OPERAND
 ''''''
 
-# NOT AND Descriptions for expressions  ( not ( A and B and C ) )
+# NOT AND Descriptions for expressions  'NOT AND [ A B C ]'
 # We actually describe the the logically equivalent expression ( (not A) or (not B) or (not C) )
-# Describes the '( (not A) or' part
+# Note: the operands (not A), (not B).. are handled in the descriptions of A, B.. respectively
 DESC_NOT_AND_BEFORE_OPERANDS
-''' (either not'''
+'''[[DESC_NOT_OR_BEFORE_OPERANDS]]'''
 
-# Describes the 'or (not B)' and 'or (not C)' parts
 DESC_NOT_AND_BETWEEN_OPERANDS
-''', or not'''
+'''[[DESC_NOT_OR_BETWEEN_OPERANDS]]'''
 
-# Describes the ')' part
 DESC_NOT_AND_AFTER_OPERANDS
-''' )'''
+'''[[DESC_NOT_OR_AFTER_OPERANDS]]'''
 
-# Describes 'not ( AND [ A ] )' before A
+
+# Description for 'not ( AND [ A ] )' expressions
+# Actually instead we describe 'OR [ not A ]' and leave the description of negation to A
 DESC_NOT_AND_BEFORE_SINGLE_OPERAND
-''' not'''
+'''[[DESC_OR_BEFORE_SINGLE_OPERAND]]'''
 
-# Describes 'not ( AND [ A ] )' after A
 DESC_NOT_AND_AFTER_SINGLE_OPERAND
-''''''
+'''[[DESC_OR_AFTER_SINGLE_OPERAND]]'''
 
 
-#### Describes the 'and (not ..)' in the expression ( (not A) and (not B) )
-###DESC_AND_NOT_BETWEEN_OPERANDS
-###''' and not'''
-
+# OR Descriptions: for expressions of the form ( A or B or C )
 DESC_OR_BEFORE_OPERANDS
 ''' (either'''
 
@@ -10096,24 +10094,26 @@ DESC_OR_BEFORE_SINGLE_OPERAND
 DESC_OR_AFTER_SINGLE_OPERAND
 ''''''
 
-# NOT OR Descriptions
-# Describes the 'not ( ' in the expression ( not ( A or B ) )
-# We actually describe the ' in the logically equivalent expression ( (not A) and (not B) )
 
+# NOT OR Descriptions; for expressions of the form 'NOT OR [ A B C ]'
+# We actually describe the logically equivalent expression 'AND [ (NOT A) (NOT B) (NOT C) ]'
+# Note: (NOT A), (NOT B).. are handled in the descriptions of A, B.. respectively
 DESC_NOT_OR_BEFORE_OPERANDS
-''' [neither'''
+'''[[DESC_AND_BEFORE_OPERANDS]]'''
 
 DESC_NOT_OR_BETWEEN_OPERANDS
-''', nor'''
+'''[[DESC_AND_BETWEEN_OPERANDS]]'''
 
 DESC_NOT_OR_AFTER_OPERANDS
-''' ]'''
+'''[[DESC_AND_AFTER_OPERANDS]]'''
 
+# for expressions of the form 'NOT OR [ A ]' we describe instead 'AND [ NOT A ]'
+# Note: (NOT A) is handled in the description of A
 DESC_NOT_OR_BEFORE_SINGLE_OPERAND
-''' not'''
+'''[[DESC_AND_BEFORE_SINGLE_OPERAND]]'''
 
 DESC_NOT_OR_AFTER_SINGLE_OPERAND
-''''''
+'''[[DESC_AND_AFTER_SINGLE_OPERAND]]'''
 
 
 # %1% textual description of the lower turn limit.

--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -9344,19 +9344,33 @@ bool And::SourceInvariant() const {
 }
 
 std::string And::Description(bool negated/* = false*/) const {
+    std::string values_str;
     if (m_operands.size() == 1) {
-        return m_operands[0]->Description();
+        values_str += (!negated)
+            ? UserString("DESC_AND_BEFORE_SINGLE_OPERAND")
+            : UserString("DESC_NOT_AND_BEFORE_SINGLE_OPERAND");
+        values_str += m_operands[0]->Description();
+        values_str += (!negated)
+            ? UserString("DESC_AND_AFTER_SINGLE_OPERAND")
+            : UserString("DESC_NOT_AND_AFTER_SINGLE_OPERAND");
     } else {
         // TODO: use per-operand-type connecting language
-        std::string values_str;
+        values_str += (!negated)
+            ? UserString("DESC_AND_BEFORE_OPERANDS")
+            : UserString("DESC_NOT_AND_BEFORE_OPERANDS");
         for (unsigned int i = 0; i < m_operands.size(); ++i) {
             values_str += m_operands[i]->Description();
             if (i != m_operands.size() - 1) {
-                values_str += UserString("DESC_AND_BETWEEN_OPERANDS");
+                values_str += (!negated)
+                    ? UserString("DESC_AND_BETWEEN_OPERANDS")
+                    : UserString("DESC_NOT_AND_BETWEEN_OPERANDS");
             }
         }
-        return values_str;
+        values_str += (!negated)
+            ? UserString("DESC_AND_AFTER_OPERANDS")
+            : UserString("DESC_NOT_AND_AFTER_OPERANDS");
     }
+    return values_str;
 }
 
 std::string And::Dump(unsigned short ntabs) const {

--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -9533,19 +9533,33 @@ bool Or::SourceInvariant() const {
 }
 
 std::string Or::Description(bool negated/* = false*/) const {
+    std::string values_str;
     if (m_operands.size() == 1) {
-        return m_operands[0]->Description();
+        values_str += (!negated)
+            ? UserString("DESC_OR_BEFORE_SINGLE_OPERAND")
+            : UserString("DESC_NOT_OR_BEFORE_SINGLE_OPERAND");
+        values_str += m_operands[0]->Description();
+        values_str += (!negated)
+            ? UserString("DESC_OR_AFTER_SINGLE_OPERAND")
+            : UserString("DESC_NOT_OR_AFTER_SINGLE_OPERAND");
     } else {
         // TODO: use per-operand-type connecting language
-        std::string values_str;
+        values_str += (!negated)
+            ? UserString("DESC_OR_BEFORE_OPERANDS")
+            : UserString("DESC_NOT_OR_BEFORE_OPERANDS");
         for (unsigned int i = 0; i < m_operands.size(); ++i) {
             values_str += m_operands[i]->Description();
             if (i != m_operands.size() - 1) {
-                values_str += UserString("DESC_OR_BETWEEN_OPERANDS");
+                values_str += (!negated)
+                    ? UserString("DESC_OR_BETWEEN_OPERANDS")
+                    : UserString("DESC_NOT_OR_BETWEEN_OPERANDS");
             }
         }
-        return values_str;
+        values_str += (!negated)
+            ? UserString("DESC_OR_AFTER_OPERANDS")
+            : UserString("DESC_NOT_OR_AFTER_OPERANDS");
     }
+    return values_str;
 }
 
 std::string Or::Dump(unsigned short ntabs) const {
@@ -9637,7 +9651,7 @@ bool Not::SourceInvariant() const {
 }
 
 std::string Not::Description(bool negated/* = false*/) const
-{ return m_operand->Description(true); }
+{ return m_operand->Description(!negated); }
 
 std::string Not::Dump(unsigned short ntabs) const {
     std::string retval = DumpIndent(ntabs) + "Not\n";

--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -9349,17 +9349,18 @@ std::string And::Description(bool negated/* = false*/) const {
         values_str += (!negated)
             ? UserString("DESC_AND_BEFORE_SINGLE_OPERAND")
             : UserString("DESC_NOT_AND_BEFORE_SINGLE_OPERAND");
-        values_str += m_operands[0]->Description();
+        // Pushing the negation to the enclosed conditions
+        values_str += m_operands[0]->Description(negated);
         values_str += (!negated)
             ? UserString("DESC_AND_AFTER_SINGLE_OPERAND")
             : UserString("DESC_NOT_AND_AFTER_SINGLE_OPERAND");
     } else {
-        // TODO: use per-operand-type connecting language
         values_str += (!negated)
             ? UserString("DESC_AND_BEFORE_OPERANDS")
             : UserString("DESC_NOT_AND_BEFORE_OPERANDS");
         for (unsigned int i = 0; i < m_operands.size(); ++i) {
-            values_str += m_operands[i]->Description();
+            // Pushing the negation to the enclosed conditions
+            values_str += m_operands[i]->Description(negated);
             if (i != m_operands.size() - 1) {
                 values_str += (!negated)
                     ? UserString("DESC_AND_BETWEEN_OPERANDS")
@@ -9538,7 +9539,8 @@ std::string Or::Description(bool negated/* = false*/) const {
         values_str += (!negated)
             ? UserString("DESC_OR_BEFORE_SINGLE_OPERAND")
             : UserString("DESC_NOT_OR_BEFORE_SINGLE_OPERAND");
-        values_str += m_operands[0]->Description();
+        // Pushing the negation to the enclosed conditions
+        values_str += m_operands[0]->Description(negated);
         values_str += (!negated)
             ? UserString("DESC_OR_AFTER_SINGLE_OPERAND")
             : UserString("DESC_NOT_OR_AFTER_SINGLE_OPERAND");
@@ -9548,7 +9550,8 @@ std::string Or::Description(bool negated/* = false*/) const {
             ? UserString("DESC_OR_BEFORE_OPERANDS")
             : UserString("DESC_NOT_OR_BEFORE_OPERANDS");
         for (unsigned int i = 0; i < m_operands.size(); ++i) {
-            values_str += m_operands[i]->Description();
+            // Pushing the negation to the enclosed conditions
+            values_str += m_operands[i]->Description(negated);
             if (i != m_operands.size() - 1) {
                 values_str += (!negated)
                     ? UserString("DESC_OR_BETWEEN_OPERANDS")


### PR DESCRIPTION
The ::description() of FOCS And conditions gave the same output no matter if the condition is negated or not.

This PR handles uses de morgans law for transformation in the Condition.cpp, describing NOT AND as an OR and pushing the negation to the operands. Same goes for NOT OR which gets transformed to AND.

```
Not And [  DesignHasHull name ="SH_COLONY_BASE"     ( PartsInShipDesign design = LocalCandidate.DesignID < 1 ) ]
(either not that contains the hull Colony Base Hull, or not when PartsInShipDesign < 1 )
```

Also NOT NOT nullifies itself now by negation switching.

A previous commit used de morgans law directly on the stringtable level, which allowed to use 'neither'/'nor' in english, but as it prevented negative operands to cancel the negation out i found that to be less clear in the end. 

Also note that one could pull up AND conditions inside of AND conditions and OR conditions inside of OR condition, making the description more clear. But probably in those cases one should fix the condition instead of the description, so its actually good to keep it smelly like it is.