### PR TITLE
[python] Use print function in common modules

### DIFF
--- a/default/python/common/configure_logging.py
+++ b/default/python/common/configure_logging.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 """configure_logging redirects print and the logger to use the freeorion server.
 
 Output redirected to the freeorion server prints in the appropriate log:
@@ -86,23 +88,23 @@ except ImportError as e:
         """A stub freeorion_logger for testing"""
         @staticmethod
         def debug(msg, *args):
-            print msg
+            print(msg)
 
         @staticmethod
         def info(msg, *args):
-            print msg
+            print(msg)
 
         @staticmethod
         def warn(msg, *args):
-            print msg
+            print(msg)
 
         @staticmethod
         def error(msg, *args):
-            print >> sys.stderr, msg
+            print(msg, file=sys.stderr)
 
         @staticmethod
         def fatal(msg, *args):
-            print >> sys.stderr, msg
+            print(msg, file=sys.stderr)
 
     freeorion_logger = _FreeOrionLoggerForTest()
 
@@ -203,7 +205,7 @@ def redirect_logging_to_freeorion_logger(initial_log_level=logging.DEBUG):
     if not hasattr(redirect_logging_to_freeorion_logger, "only_redirect_once"):
         sys.stdout = _stdXLikeStream(logging.DEBUG)
         sys.stderr = _stdXLikeStream(logging.ERROR)
-        print 'Python stdout and stderr are redirected to ai process.'
+        print('Python stdout and stderr are redirected to ai process.')
 
         logger = logging.getLogger()
         logger.addHandler(_create_narrow_handler(logging.DEBUG))

--- a/default/python/common/listeners.py
+++ b/default/python/common/listeners.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from functools import wraps
 
 handlers = {
@@ -10,11 +12,11 @@ handlers = {
 
 def _register(function_name, handler, is_post_handler):
     handlers.setdefault(function_name, [[], []])[is_post_handler].append(handler)
-    print 'Register "%s" %s "%s" execution' % (
+    print('Register "%s" %s "%s" execution' % (
         handler.__name__,
         'after' if is_post_handler else 'before',
         function_name
-    )
+    ))
 
 
 def register_pre_handler(function_name, handler):

--- a/default/python/common/option_tools.py
+++ b/default/python/common/option_tools.py
@@ -107,7 +107,7 @@ def parse_config(option_string, config_dir):
 
     if option_string is not None and not isinstance(option_string, str):
         # probably called by unit test
-        print( "Specified option string is not a string: ", option_string, file=sys.stderr)
+        print("Specified option string is not a string: ", option_string, file=sys.stderr)
         return
 
     # get defaults; check if don't already exist and can write

--- a/default/python/common/option_tools.py
+++ b/default/python/common/option_tools.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import os
 import sys
 from ConfigParser import SafeConfigParser
@@ -75,7 +77,7 @@ def _create_default_config_file(path):
         try:
             with open(unicode(path, 'utf-8'), 'w') as configfile:
                 config.write(configfile)
-            print "default config is dumped to %s" % path
+            print("default config is dumped to %s" % path)
         except IOError:
             sys.stderr.write("AI Config Error: could not write default config %s\n" % path)
     return config
@@ -105,7 +107,7 @@ def parse_config(option_string, config_dir):
 
     if option_string is not None and not isinstance(option_string, str):
         # probably called by unit test
-        print >> sys.stderr, "Specified option string is not a string: ", option_string
+        print( "Specified option string is not a string: ", option_string, file=sys.stderr)
         return
 
     # get defaults; check if don't already exist and can write
@@ -124,7 +126,7 @@ def parse_config(option_string, config_dir):
     if option_string:
         config_files = [option_string]
         configs_read = config.read(config_files)
-        print "AI Config read config file(s): %s" % configs_read
+        print("AI Config read config file(s): %s" % configs_read)
         if len(configs_read) != len(config_files):
             sys.stderr.write("AI Config Error; could NOT read config file(s): %s\n"
                              % list(set(config_files).difference(configs_read)))

--- a/default/python/common/print_utils.py
+++ b/default/python/common/print_utils.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 """
 Print utils.
 
@@ -9,7 +11,7 @@ from itertools import izip_longest
 from math import ceil
 
 
-def print_in_columns(items, columns=2):
+def print_in_columns(items, columns=2, printer=print):
     """
     Prints collection as columns.
 
@@ -21,6 +23,8 @@ def print_in_columns(items, columns=2):
     :type items: list|tuple
     :param columns: number of columns
     :type columns: int
+    :param printer: function to print result
+    :type printer: (str) -> None
     :return None:
     """
     row_count = int(ceil((float(len(items)) / columns)))
@@ -29,7 +33,7 @@ def print_in_columns(items, columns=2):
     template = '   '.join('%%-%ss' % w for w in column_widths)
 
     for row in zip(*text_columns):
-        print template % row
+        printer(template % row)
 
 
 class Base(object):

--- a/default/python/common/profiling.py
+++ b/default/python/common/profiling.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import cProfile
 import os
 import pstats
@@ -28,7 +30,7 @@ def profile(save_path, sort_by='cumulative'):
             result = function(*args, **kwargs)
             end = time.clock()
             pr.disable()
-            print "Profile %s tooks %f s, saved to %s" % (function.__name__, end - start, save_path)
+            print("Profile %s tooks %f s, saved to %s" % (function.__name__, end - start, save_path))
             s = StringIO.StringIO()
             ps = pstats.Stats(pr, stream=s).strip_dirs().sort_stats(sort_by)
             ps.print_stats()

--- a/default/python/common/timers.py
+++ b/default/python/common/timers.py
@@ -110,7 +110,7 @@ class Timer(object):
 
         for name in ordered_names:
             print(("{:<{name_width}} num: {:>6d}, mean: {:>6.2f} msec, std: {:>6.2f} msec, max: {:>6.2f} msec").
-                   format(name, number_samples[name], means[name], stds[name], maxes[name], name_width=max_header))
+                  format(name, number_samples[name], means[name], stds[name], maxes[name], name_width=max_header))
 
         print('=' * line_max_size)
 

--- a/default/python/common/timers.py
+++ b/default/python/common/timers.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from time import time
 
 
@@ -38,19 +40,19 @@ class Timer(object):
         # TODO: Convert to use table code from here /python/common/print_utils.py#L116
 
         if not time_table:
-            print "NOT Time Table"
+            print("NOT Time Table")
             return
         max_header = max(len(x[0]) for x in time_table)
         line_max_size = max_header + 14
-        print
-        print 'Timing for %s:' % self.timer_name
-        print '=' * line_max_size
+        print()
+        print('Timing for %s:' % self.timer_name)
+        print('=' * line_max_size)
 
         for name, val in time_table:
-            print "%-*s %8d msec" % (max_header, name, val)
+            print("%-*s %8d msec" % (max_header, name, val))
 
-        print '-' * line_max_size
-        print ("Total: %8d msec" % sum(x[1] for x in time_table)).rjust(line_max_size)
+        print('-' * line_max_size)
+        print(("Total: %8d msec" % sum(x[1] for x in time_table)).rjust(line_max_size))
 
     def print_flat(self):
         """
@@ -102,15 +104,15 @@ class Timer(object):
 
         max_header = max(len(x) for x in ordered_names)
         line_max_size = max_header + 70
-        print
-        print 'Timing statistics for %s:' % self.timer_name
-        print '=' * line_max_size
+        print()
+        print('Timing statistics for %s:' % self.timer_name)
+        print('=' * line_max_size)
 
         for name in ordered_names:
-            print (("{:<{name_width}} num: {:>6d}, mean: {:>6.2f} msec, std: {:>6.2f} msec, max: {:>6.2f} msec").
+            print(("{:<{name_width}} num: {:>6d}, mean: {:>6.2f} msec, std: {:>6.2f} msec, max: {:>6.2f} msec").
                    format(name, number_samples[name], means[name], stds[name], maxes[name], name_width=max_header))
 
-        print '=' * line_max_size
+        print('=' * line_max_size)
 
     def stop_and_print(self):
         """

--- a/default/python/stub_generator/parse_docs.py
+++ b/default/python/stub_generator/parse_docs.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 from logging import error
 import re
 
@@ -220,10 +222,10 @@ if __name__ == '__main__':
     # example1 = """getUserDataDir() -> str :\n    Returns path to directory where FreeOrion stores user specific data (config files, saves, etc.)."""
 
     info = Docs(example1, 1)
-    print "=" * 100
-    print "Arg string:", info.get_argument_string()
-    print "=" * 100
-    print "Doc string:\n", info.get_doc_string()
+    print("=" * 100)
+    print("Arg string:", info.get_argument_string())
+    print("=" * 100)
+    print("Doc string:\n", info.get_doc_string())
 
     # double standards
     # canBuild ['empire', 'buildType', 'str', 'int'], ['empire', 'buildType', 'int', 'int']


### PR DESCRIPTION
Add compatibility with python3 for common modules.  These modules can be imported before logging is configured so I used `print_function`