### PR TITLE
[python wrappers] Add user config and data dirs

### DIFF
--- a/python/UniverseWrapper.cpp
+++ b/python/UniverseWrapper.cpp
@@ -18,6 +18,7 @@
 #include "../util/Directories.h"
 #include "../util/Logger.h"
 #include "../util/MultiplayerCommon.h"
+#include "../util/OptionsDB.h"
 #include "../util/GameRules.h"
 
 #include <boost/mpl/vector.hpp>
@@ -241,6 +242,17 @@ namespace {
     bool RuleExistsWithType(const GameRules& rules, const std::string& name, GameRules::Type type)
     { return rules.RuleExists(name, type); }
 
+    boost::python::object GetOptionsDBOptionStr(std::string const &option)
+    { return GetOptionsDB().OptionExists(option) ? boost::python::str(GetOptionsDB().Get<std::string>(option)) : boost::python::str(); }
+
+    boost::python::object GetOptionsDBOptionInt(std::string const &option)
+    { return GetOptionsDB().OptionExists(option) ? boost::python::object(GetOptionsDB().Get<int>(option)) : boost::python::object(); }
+
+    boost::python::object GetOptionsDBOptionBool(std::string const &option)
+    { return GetOptionsDB().OptionExists(option) ? boost::python::object(GetOptionsDB().Get<bool>(option)) : boost::python::object(); }
+
+    boost::python::object GetOptionsDBOptionDouble(std::string const &option)
+    { return GetOptionsDB().OptionExists(option) ? boost::python::object(GetOptionsDB().Get<double>(option)) : boost::python::object(); }
      boost::python::str GetUserConfigDirWrapper()
     { return boost::python::str(PathToString(GetUserConfigDir())); }
 
@@ -766,6 +778,12 @@ namespace FreeOrionPython {
         /////////////////
         //   Configs   //
         /////////////////
+        def("getOptionsDBOptionStr",    GetOptionsDBOptionStr,     return_value_policy<return_by_value>(), "Returns the string value of option in OptionsDB or None if the option does not exist.");
+        def("getOptionsDBOptionInt",    GetOptionsDBOptionInt,     return_value_policy<return_by_value>(), "Returns the integer value of option in OptionsDB or None if the option does not exist.");
+        def("getOptionsDBOptionBool",   GetOptionsDBOptionBool,    return_value_policy<return_by_value>(), "Returns the bool value of option in OptionsDB or None if the option does not exist.");
+        def("getOptionsDBOptionDouble", GetOptionsDBOptionDouble,  return_value_policy<return_by_value>(), "Returns the double value of option in OptionsDB or None if the option does not exist.");
+
+
         def("getUserConfigDir",         GetUserConfigDirWrapper,        /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific configuration.");
         def("getUserDataDir",           GetUserDataDirWrapper,          /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific data (saves, etc.).");
     }

--- a/python/UniverseWrapper.cpp
+++ b/python/UniverseWrapper.cpp
@@ -15,6 +15,7 @@
 #include "../universe/Enums.h"
 #include "../universe/EffectAccounting.h"
 #include "../universe/Predicates.h"
+#include "../util/Directories.h"
 #include "../util/Logger.h"
 #include "../util/MultiplayerCommon.h"
 #include "../util/GameRules.h"
@@ -239,6 +240,12 @@ namespace {
     { return rules.RuleExists(name); }
     bool RuleExistsWithType(const GameRules& rules, const std::string& name, GameRules::Type type)
     { return rules.RuleExists(name, type); }
+
+     boost::python::str GetUserConfigDirWrapper()
+    { return boost::python::str(PathToString(GetUserConfigDir())); }
+
+    boost::python::str GetUserDataDirWrapper()
+    { return boost::python::str(PathToString(GetUserDataDir())); }
 }
 
 namespace FreeOrionPython {
@@ -755,6 +762,12 @@ namespace FreeOrionPython {
             .add_property("dump",               &Species::Dump)
         ;
         def("getSpecies",                       &GetSpecies,                            return_value_policy<reference_existing_object>(), "Returns the species (Species) with the indicated name (string).");
+
+        /////////////////
+        //   Configs   //
+        /////////////////
+        def("getUserConfigDir",         GetUserConfigDirWrapper,        /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific configuration.");
+        def("getUserDataDir",           GetUserDataDirWrapper,          /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific data (saves, etc.).");
     }
 
     void WrapGalaxySetupData() {

--- a/python/UniverseWrapper.cpp
+++ b/python/UniverseWrapper.cpp
@@ -242,18 +242,19 @@ namespace {
     bool RuleExistsWithType(const GameRules& rules, const std::string& name, GameRules::Type type)
     { return rules.RuleExists(name, type); }
 
-    boost::python::object GetOptionsDBOptionStr(std::string const &option)
+    boost::python::object GetOptionsDBOptionStr(const std::string &option)
     { return GetOptionsDB().OptionExists(option) ? boost::python::str(GetOptionsDB().Get<std::string>(option)) : boost::python::str(); }
 
-    boost::python::object GetOptionsDBOptionInt(std::string const &option)
+    boost::python::object GetOptionsDBOptionInt(const std::string &option)
     { return GetOptionsDB().OptionExists(option) ? boost::python::object(GetOptionsDB().Get<int>(option)) : boost::python::object(); }
 
-    boost::python::object GetOptionsDBOptionBool(std::string const &option)
+    boost::python::object GetOptionsDBOptionBool(const std::string &option)
     { return GetOptionsDB().OptionExists(option) ? boost::python::object(GetOptionsDB().Get<bool>(option)) : boost::python::object(); }
 
-    boost::python::object GetOptionsDBOptionDouble(std::string const &option)
+    boost::python::object GetOptionsDBOptionDouble(const std::string &option)
     { return GetOptionsDB().OptionExists(option) ? boost::python::object(GetOptionsDB().Get<double>(option)) : boost::python::object(); }
-     boost::python::str GetUserConfigDirWrapper()
+
+    boost::python::str GetUserConfigDirWrapper()
     { return boost::python::str(PathToString(GetUserConfigDir())); }
 
     boost::python::str GetUserDataDirWrapper()

--- a/python/UniverseWrapper.cpp
+++ b/python/UniverseWrapper.cpp
@@ -15,10 +15,8 @@
 #include "../universe/Enums.h"
 #include "../universe/EffectAccounting.h"
 #include "../universe/Predicates.h"
-#include "../util/Directories.h"
 #include "../util/Logger.h"
 #include "../util/MultiplayerCommon.h"
-#include "../util/OptionsDB.h"
 #include "../util/GameRules.h"
 
 #include <boost/mpl/vector.hpp>
@@ -241,24 +239,6 @@ namespace {
     { return rules.RuleExists(name); }
     bool RuleExistsWithType(const GameRules& rules, const std::string& name, GameRules::Type type)
     { return rules.RuleExists(name, type); }
-
-    boost::python::object GetOptionsDBOptionStr(const std::string &option)
-    { return GetOptionsDB().OptionExists(option) ? boost::python::str(GetOptionsDB().Get<std::string>(option)) : boost::python::str(); }
-
-    boost::python::object GetOptionsDBOptionInt(const std::string &option)
-    { return GetOptionsDB().OptionExists(option) ? boost::python::object(GetOptionsDB().Get<int>(option)) : boost::python::object(); }
-
-    boost::python::object GetOptionsDBOptionBool(const std::string &option)
-    { return GetOptionsDB().OptionExists(option) ? boost::python::object(GetOptionsDB().Get<bool>(option)) : boost::python::object(); }
-
-    boost::python::object GetOptionsDBOptionDouble(const std::string &option)
-    { return GetOptionsDB().OptionExists(option) ? boost::python::object(GetOptionsDB().Get<double>(option)) : boost::python::object(); }
-
-    boost::python::str GetUserConfigDirWrapper()
-    { return boost::python::str(PathToString(GetUserConfigDir())); }
-
-    boost::python::str GetUserDataDirWrapper()
-    { return boost::python::str(PathToString(GetUserDataDir())); }
 }
 
 namespace FreeOrionPython {
@@ -775,18 +755,6 @@ namespace FreeOrionPython {
             .add_property("dump",               &Species::Dump)
         ;
         def("getSpecies",                       &GetSpecies,                            return_value_policy<reference_existing_object>(), "Returns the species (Species) with the indicated name (string).");
-
-        /////////////////
-        //   Configs   //
-        /////////////////
-        def("getOptionsDBOptionStr",    GetOptionsDBOptionStr,     return_value_policy<return_by_value>(), "Returns the string value of option in OptionsDB or None if the option does not exist.");
-        def("getOptionsDBOptionInt",    GetOptionsDBOptionInt,     return_value_policy<return_by_value>(), "Returns the integer value of option in OptionsDB or None if the option does not exist.");
-        def("getOptionsDBOptionBool",   GetOptionsDBOptionBool,    return_value_policy<return_by_value>(), "Returns the bool value of option in OptionsDB or None if the option does not exist.");
-        def("getOptionsDBOptionDouble", GetOptionsDBOptionDouble,  return_value_policy<return_by_value>(), "Returns the double value of option in OptionsDB or None if the option does not exist.");
-
-
-        def("getUserConfigDir",         GetUserConfigDirWrapper,        /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific configuration.");
-        def("getUserDataDir",           GetUserDataDirWrapper,          /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific data (saves, etc.).");
     }
 
     void WrapGalaxySetupData() {

--- a/python/server/ServerWrapper.cpp
+++ b/python/server/ServerWrapper.cpp
@@ -1269,19 +1269,19 @@ namespace {
         return object(planet->CardinalSuffix());
     }
 
-    boost::python::object GetOptionsDBOptionStr(std::string const &option)
+    boost::python::object GetOptionsDBOptionStr(const std::string &option)
     { return GetOptionsDB().OptionExists(option) ? boost::python::str(GetOptionsDB().Get<std::string>(option)) : boost::python::str(); }
 
-    boost::python::object GetOptionsDBOptionInt(std::string const &option)
+    boost::python::object GetOptionsDBOptionInt(const std::string &option)
     { return GetOptionsDB().OptionExists(option) ? boost::python::object(GetOptionsDB().Get<int>(option)) : boost::python::object(); }
 
-    boost::python::object GetOptionsDBOptionBool(std::string const &option)
+    boost::python::object GetOptionsDBOptionBool(const std::string &option)
     { return GetOptionsDB().OptionExists(option) ? boost::python::object(GetOptionsDB().Get<bool>(option)) : boost::python::object(); }
 
-    boost::python::object GetOptionsDBOptionDouble(std::string const &option)
+    boost::python::object GetOptionsDBOptionDouble(const std::string &option)
     { return GetOptionsDB().OptionExists(option) ? boost::python::object(GetOptionsDB().Get<double>(option)) : boost::python::object(); }
 
-     boost::python::str GetUserConfigDirWrapper()
+    boost::python::str GetUserConfigDirWrapper()
     { return boost::python::str(PathToString(GetUserConfigDir())); }
 
     boost::python::str GetUserDataDirWrapper()
@@ -1315,7 +1315,6 @@ namespace FreeOrionPython {
         def("roman_number",                         RomanNumber);
         def("get_resource_dir",                     GetResourceDirWrapper);
         def("get_user_config_dir",                  GetUserConfigDirWrapper);
-
         def("all_empires",                          AllEmpires);
         def("invalid_object",                       InvalidObjectID);
         def("large_meter_value",                    LargeMeterValue);
@@ -1414,10 +1413,10 @@ namespace FreeOrionPython {
         /////////////////
         //   Configs   //
         /////////////////
-        def("getOptionsDBOptionStr",    GetOptionsDBOptionStr,     return_value_policy<return_by_value>(), "Returns the string value of option in OptionsDB or None if the option does not exist.");
-        def("getOptionsDBOptionInt",    GetOptionsDBOptionInt,     return_value_policy<return_by_value>(), "Returns the integer value of option in OptionsDB or None if the option does not exist.");
-        def("getOptionsDBOptionBool",   GetOptionsDBOptionBool,    return_value_policy<return_by_value>(), "Returns the bool value of option in OptionsDB or None if the option does not exist.");
-        def("getOptionsDBOptionDouble", GetOptionsDBOptionDouble,  return_value_policy<return_by_value>(), "Returns the double value of option in OptionsDB or None if the option does not exist.");
+        def("get_options_db_option_str",    GetOptionsDBOptionStr,     return_value_policy<return_by_value>(), "Returns the string value of option in OptionsDB or None if the option does not exist.");
+        def("get_options_db_option_int",    GetOptionsDBOptionInt,     return_value_policy<return_by_value>(), "Returns the integer value of option in OptionsDB or None if the option does not exist.");
+        def("get_options_db_option_bool",   GetOptionsDBOptionBool,    return_value_policy<return_by_value>(), "Returns the bool value of option in OptionsDB or None if the option does not exist.");
+        def("get_options_db_option_double", GetOptionsDBOptionDouble,  return_value_policy<return_by_value>(), "Returns the double value of option in OptionsDB or None if the option does not exist.");
 
         def("get_user_config_dir",         GetUserConfigDirWrapper,        /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific configuration.");
         def("get_user_data_dir",           GetUserDataDirWrapper,          /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific data (saves, etc.).");

--- a/python/server/ServerWrapper.cpp
+++ b/python/server/ServerWrapper.cpp
@@ -1268,6 +1268,12 @@ namespace {
 
         return object(planet->CardinalSuffix());
     }
+
+     boost::python::str GetUserConfigDirWrapper()
+    { return boost::python::str(PathToString(GetUserConfigDir())); }
+
+    boost::python::str GetUserDataDirWrapper()
+    { return boost::python::str(PathToString(GetUserDataDir())); }
 }
 
 namespace FreeOrionPython {
@@ -1392,4 +1398,10 @@ namespace FreeOrionPython {
         def("planet_make_colony",                   PlanetMakeColony);
         def("planet_cardinal_suffix",               PlanetCardinalSuffix);
     }
+
+        /////////////////
+        //   Configs   //
+        /////////////////
+        def("get_user_config_dir",         GetUserConfigDirWrapper,        /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific configuration.");
+        def("get_user_data_dir",           GetUserDataDirWrapper,          /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific data (saves, etc.).");
 }

--- a/python/server/ServerWrapper.cpp
+++ b/python/server/ServerWrapper.cpp
@@ -1269,6 +1269,18 @@ namespace {
         return object(planet->CardinalSuffix());
     }
 
+    boost::python::object GetOptionsDBOptionStr(std::string const &option)
+    { return GetOptionsDB().OptionExists(option) ? boost::python::str(GetOptionsDB().Get<std::string>(option)) : boost::python::str(); }
+
+    boost::python::object GetOptionsDBOptionInt(std::string const &option)
+    { return GetOptionsDB().OptionExists(option) ? boost::python::object(GetOptionsDB().Get<int>(option)) : boost::python::object(); }
+
+    boost::python::object GetOptionsDBOptionBool(std::string const &option)
+    { return GetOptionsDB().OptionExists(option) ? boost::python::object(GetOptionsDB().Get<bool>(option)) : boost::python::object(); }
+
+    boost::python::object GetOptionsDBOptionDouble(std::string const &option)
+    { return GetOptionsDB().OptionExists(option) ? boost::python::object(GetOptionsDB().Get<double>(option)) : boost::python::object(); }
+
      boost::python::str GetUserConfigDirWrapper()
     { return boost::python::str(PathToString(GetUserConfigDir())); }
 
@@ -1402,6 +1414,11 @@ namespace FreeOrionPython {
         /////////////////
         //   Configs   //
         /////////////////
+        def("getOptionsDBOptionStr",    GetOptionsDBOptionStr,     return_value_policy<return_by_value>(), "Returns the string value of option in OptionsDB or None if the option does not exist.");
+        def("getOptionsDBOptionInt",    GetOptionsDBOptionInt,     return_value_policy<return_by_value>(), "Returns the integer value of option in OptionsDB or None if the option does not exist.");
+        def("getOptionsDBOptionBool",   GetOptionsDBOptionBool,    return_value_policy<return_by_value>(), "Returns the bool value of option in OptionsDB or None if the option does not exist.");
+        def("getOptionsDBOptionDouble", GetOptionsDBOptionDouble,  return_value_policy<return_by_value>(), "Returns the double value of option in OptionsDB or None if the option does not exist.");
+
         def("get_user_config_dir",         GetUserConfigDirWrapper,        /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific configuration.");
         def("get_user_data_dir",           GetUserDataDirWrapper,          /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific data (saves, etc.).");
 }


### PR DESCRIPTION
Add the config directory and option access. I need this code to have the way to generate AI stubs for that interfaces like it is done for  [AI](https://github.com/freeorion/freeorion/blob/master/default/python/AI/freeOrionAIInterface.pyi#L1)

I know a little about C++ and don't compile code at all. 

@o01eg  can you take care of this PR?