### PR TITLE
Move game UID generation into C++ code

### DIFF
--- a/default/python/universe_generation/universe_generator.py
+++ b/default/python/universe_generation/universe_generator.py
@@ -37,6 +37,7 @@ class PyGalaxySetupData:
         self.monster_frequency = galaxy_setup_data.monsterFrequency
         self.native_frequency = galaxy_setup_data.nativeFrequency
         self.max_ai_aggression = galaxy_setup_data.maxAIAggression
+        self.game_uid = galaxy_setup_data.gameUID
 
     def dump(self):
         print "Galaxy Setup Data:"
@@ -50,6 +51,7 @@ class PyGalaxySetupData:
         print "...Monster Frequency:", self.monster_frequency
         print "...Native Frequency:", self.native_frequency
         print "...Max AI Aggression:", self.max_ai_aggression
+        print "...Game UID:", self.game_uid
 
 
 def error_report():
@@ -142,19 +144,6 @@ def create_universe(psd_map):
     print "Distributing Starting Specials"
     seed_rng(seed_pool.pop())
     distribute_specials(gsd.specials_frequency, fo.get_all_objects())
-
-    # set game uid
-    empire_names = []
-    for psd in psd_map.values():
-        empire_names.append(psd.empire_name)
-
-    empire_names.sort()
-    for i, v in enumerate(empire_names):
-        empire_names[i] = v.capitalize()[:2]
-
-    fo.get_galaxy_setup_data().gameUID = "".join(empire_names) + str(random.randint(0, 999)).zfill(3)
-
-    print "Game UID %s" % fo.get_galaxy_setup_data().gameUID
 
     # finally, write some statistics to the log file
     print "############################################################"

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -41,7 +41,8 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/functional/hash.hpp>
 #include <boost/date_time/posix_time/time_formatters.hpp>
-#include <boost/format.hpp>
+#include <boost/uuid/random_generator.hpp>
+#include <boost/uuid/uuid_io.hpp>
 
 #include <ctime>
 #include <thread>
@@ -1379,8 +1380,7 @@ void ServerApp::GenerateUniverse(std::map<int, PlayerSetupData>& player_setup_da
     // Set game UID. Needs to be done first so we can use ClockSeed to
     // prevent reproducible UIDs.
     ClockSeed();
-    GetGalaxySetupData().SetGameUID(GetGalaxySetupData().GetSeed() +
-                                    (boost::format("%09i") % RandInt(0, 999999999)).str());
+    GetGalaxySetupData().SetGameUID(boost::uuids::to_string(boost::uuids::random_generator()()));
 
     // Initialize RNG with provided seed to get reproducible universes
     int seed = 0;

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -41,6 +41,7 @@
 #include <boost/lexical_cast.hpp>
 #include <boost/functional/hash.hpp>
 #include <boost/date_time/posix_time/time_formatters.hpp>
+#include <boost/format.hpp>
 
 #include <ctime>
 #include <thread>
@@ -1374,6 +1375,12 @@ void ServerApp::LoadGameInit(const std::vector<PlayerSaveGameData>& player_save_
 
 void ServerApp::GenerateUniverse(std::map<int, PlayerSetupData>& player_setup_data) {
     Universe& universe = GetUniverse();
+
+    // Set game UID. Needs to be done first so we can use ClockSeed to
+    // prevent reproducible UIDs.
+    ClockSeed();
+    GetGalaxySetupData().SetGameUID(GetGalaxySetupData().GetSeed() +
+                                    (boost::format("%09i") % RandInt(0, 999999999)).str());
 
     // Initialize RNG with provided seed to get reproducible universes
     int seed = 0;


### PR DESCRIPTION
Correct generation  of the game UID should not depend on user customizable scripts, therefore moved game UID generation from the universe generation Python scripts to the C++ code (`ServerApp::GenerateUniverse`).

See [this discussion](https://github.com/freeorion/freeorion/pull/1997#discussion_r215929419) in the comment section of #1997.