### PR TITLE
Move some Python interface functions from AI to common wrappers

### DIFF
--- a/msvc2015/FreeOrionCA/FreeOrionCA.vcxproj
+++ b/msvc2015/FreeOrionCA/FreeOrionCA.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -206,6 +206,7 @@
     <ClCompile Include="..\..\python\AI\AIFramework.cpp" />
     <ClCompile Include="..\..\python\AI\AIWrapper.cpp" />
     <ClCompile Include="..\..\python\CommonFramework.cpp" />
+    <ClCompile Include="..\..\python\ConfigWrapper.cpp" />
     <ClCompile Include="..\..\python\EmpireWrapper.cpp" />
     <ClCompile Include="..\..\python\EnumWrapper.cpp" />
     <ClCompile Include="..\..\python\LoggingWrapper.cpp" />

--- a/msvc2015/FreeOrionCA/FreeOrionCA.vcxproj.filters
+++ b/msvc2015/FreeOrionCA/FreeOrionCA.vcxproj.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
@@ -294,6 +294,9 @@
     </ClCompile>
     <ClCompile Include="..\..\util\DependencyVersions.cpp">
       <Filter>Source Files</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\python\ConfigWrapper.cpp">
+      <Filter>Source Files\python</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/msvc2015/FreeOrionD/FreeOrionD.vcxproj
+++ b/msvc2015/FreeOrionD/FreeOrionD.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="14.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -197,6 +197,7 @@
     <ClCompile Include="..\..\combat\CombatSystem.cpp" />
     <ClCompile Include="..\..\network\ServerNetworking.cpp" />
     <ClCompile Include="..\..\python\CommonFramework.cpp" />
+    <ClCompile Include="..\..\python\ConfigWrapper.cpp" />
     <ClCompile Include="..\..\python\EmpireWrapper.cpp" />
     <ClCompile Include="..\..\python\EnumWrapper.cpp" />
     <ClCompile Include="..\..\python\LoggingWrapper.cpp" />

--- a/msvc2015/FreeOrionD/FreeOrionD.vcxproj.filters
+++ b/msvc2015/FreeOrionD/FreeOrionD.vcxproj.filters
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
     <Filter Include="Source Files">
@@ -285,6 +285,9 @@
     </ClCompile>
     <ClCompile Include="..\..\util\DependencyVersions.cpp">
       <Filter>Source Files\util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\python\ConfigWrapper.cpp">
+      <Filter>Source Files\python</Filter>
     </ClCompile>
   </ItemGroup>
 </Project>

--- a/python/AI/AIFramework.cpp
+++ b/python/AI/AIFramework.cpp
@@ -71,6 +71,11 @@ BOOST_PYTHON_MODULE(freeOrionAIInterface)
     ///////////////////
     FreeOrionPython::WrapGameStateEnums();
 
+    ///////////////////
+    //     Config    //
+    ///////////////////
+    FreeOrionPython::WrapConfig();
+
     ////////////////////
     // STL Containers //
     ////////////////////

--- a/python/AI/AIWrapper.cpp
+++ b/python/AI/AIWrapper.cpp
@@ -82,18 +82,6 @@ namespace {
         return ret_list;
     }
 
-    boost::python::object GetOptionsDBOptionStr(std::string const &option)
-    { return GetOptionsDB().OptionExists(option) ? boost::python::str(GetOptionsDB().Get<std::string>(option)) : boost::python::str(); }
-
-    boost::python::object GetOptionsDBOptionInt(std::string const &option)
-    { return GetOptionsDB().OptionExists(option) ? boost::python::object(GetOptionsDB().Get<int>(option)) : boost::python::object(); }
-
-    boost::python::object GetOptionsDBOptionBool(std::string const &option)
-    { return GetOptionsDB().OptionExists(option) ? boost::python::object(GetOptionsDB().Get<bool>(option)) : boost::python::object(); }
-
-    boost::python::object GetOptionsDBOptionDouble(std::string const &option)
-    { return GetOptionsDB().OptionExists(option) ? boost::python::object(GetOptionsDB().Get<double>(option)) : boost::python::object(); }
-
     //! Return the canonical AI directory path
     //!
     //! The value depends on the ::OptionsDB `resource.path` and `ai-path` keys.
@@ -103,12 +91,6 @@ namespace {
     //! scripts.
     std::string GetAIDir()
     { return (GetResourceDir() / GetOptionsDB().Get<std::string>("ai-path")).string(); }
-
-    boost::python::str GetUserConfigDirWrapper()
-    { return boost::python::str(PathToString(GetUserConfigDir())); }
-
-    boost::python::str GetUserDataDirWrapper()
-    { return boost::python::str(PathToString(GetUserDataDir())); }
 
     template<typename OrderType, typename... Args>
     int Issue(Args &&... args) {
@@ -212,14 +194,7 @@ namespace FreeOrionPython {
 
         def("currentTurn",              CurrentTurn,       "Returns the current game turn (int).");
 
-        def("getOptionsDBOptionStr",    GetOptionsDBOptionStr,     return_value_policy<return_by_value>(), "Returns the string value of option in OptionsDB or None if the option does not exist.");
-        def("getOptionsDBOptionInt",    GetOptionsDBOptionInt,     return_value_policy<return_by_value>(), "Returns the integer value of option in OptionsDB or None if the option does not exist.");
-        def("getOptionsDBOptionBool",   GetOptionsDBOptionBool,    return_value_policy<return_by_value>(), "Returns the bool value of option in OptionsDB or None if the option does not exist.");
-        def("getOptionsDBOptionDouble", GetOptionsDBOptionDouble,  return_value_policy<return_by_value>(), "Returns the double value of option in OptionsDB or None if the option does not exist.");
-
         def("getAIDir",                 GetAIDir,                       return_value_policy<return_by_value>());
-        def("getUserConfigDir",         GetUserConfigDirWrapper,        /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific configuration.");
-        def("getUserDataDir",           GetUserDataDirWrapper,          /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific data (saves, etc.).");
 
         def("initMeterEstimatesDiscrepancies",      AIInterface::InitMeterEstimatesAndDiscrepancies);
         def("updateMeterEstimates",                 AIInterface::UpdateMeterEstimates);

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -8,6 +8,7 @@ target_sources(freeoriond
         ${CMAKE_CURRENT_LIST_DIR}/SetWrapper.h
     PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/CommonFramework.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/ConfigWrapper.cpp
         ${CMAKE_CURRENT_LIST_DIR}/EmpireWrapper.cpp
         ${CMAKE_CURRENT_LIST_DIR}/EnumWrapper.cpp
         ${CMAKE_CURRENT_LIST_DIR}/LoggingWrapper.cpp
@@ -21,6 +22,7 @@ target_sources(freeorionca
         ${CMAKE_CURRENT_LIST_DIR}/SetWrapper.h
     PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/CommonFramework.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/ConfigWrapper.cpp
         ${CMAKE_CURRENT_LIST_DIR}/EmpireWrapper.cpp
         ${CMAKE_CURRENT_LIST_DIR}/EnumWrapper.cpp
         ${CMAKE_CURRENT_LIST_DIR}/LoggingWrapper.cpp

--- a/python/CommonWrappers.h
+++ b/python/CommonWrappers.h
@@ -8,6 +8,7 @@ namespace FreeOrionPython {
     void WrapGameStateEnums();
     void WrapEmpire();
     void WrapLogger();
+    void WrapConfig();
 }
 
 #endif

--- a/python/ConfigWrapper.cpp
+++ b/python/ConfigWrapper.cpp
@@ -1,0 +1,56 @@
+#include "../util/Directories.h"
+#include "../util/OptionsDB.h"
+
+#include <boost/python.hpp>
+
+#include <string>
+
+using boost::python::def;
+using boost::python::return_value_policy;
+using boost::python::return_by_value;
+
+namespace {
+    boost::python::object GetOptionsDBOptionStr(std::string const &option)
+    { return GetOptionsDB().OptionExists(option) ? boost::python::str(GetOptionsDB().Get<std::string>(option)) : boost::python::str(); }
+
+    boost::python::object GetOptionsDBOptionInt(std::string const &option)
+    { return GetOptionsDB().OptionExists(option) ? boost::python::object(GetOptionsDB().Get<int>(option)) : boost::python::object(); }
+
+    boost::python::object GetOptionsDBOptionBool(std::string const &option)
+    { return GetOptionsDB().OptionExists(option) ? boost::python::object(GetOptionsDB().Get<bool>(option)) : boost::python::object(); }
+
+    boost::python::object GetOptionsDBOptionDouble(std::string const &option)
+    { return GetOptionsDB().OptionExists(option) ? boost::python::object(GetOptionsDB().Get<double>(option)) : boost::python::object(); }
+
+    boost::python::str GetUserConfigDirWrapper()
+    { return boost::python::str(PathToString(GetUserConfigDir())); }
+
+    boost::python::str GetUserDataDirWrapper()
+    { return boost::python::str(PathToString(GetUserDataDir())); }
+}
+
+namespace FreeOrionPython {
+    void WrapConfig()
+    {
+        // We provide the Python wrappers both with camelCase and with snake_case names,
+        // as these wrappers are used both by the AI and the universe generation scripts.
+        // The former still uses camelCase, while the latter uses snake_case, so we need
+        // to support both styles for the time being.
+
+        def("getOptionsDBOptionStr",    GetOptionsDBOptionStr,     return_value_policy<return_by_value>(), "Returns the string value of option in OptionsDB or None if the option does not exist.");
+        def("getOptionsDBOptionInt",    GetOptionsDBOptionInt,     return_value_policy<return_by_value>(), "Returns the integer value of option in OptionsDB or None if the option does not exist.");
+        def("getOptionsDBOptionBool",   GetOptionsDBOptionBool,    return_value_policy<return_by_value>(), "Returns the bool value of option in OptionsDB or None if the option does not exist.");
+        def("getOptionsDBOptionDouble", GetOptionsDBOptionDouble,  return_value_policy<return_by_value>(), "Returns the double value of option in OptionsDB or None if the option does not exist.");
+
+        def("get_options_db_option_str",    GetOptionsDBOptionStr,     return_value_policy<return_by_value>(), "Returns the string value of option in OptionsDB or None if the option does not exist.");
+        def("get_options_db_option_int",    GetOptionsDBOptionInt,     return_value_policy<return_by_value>(), "Returns the integer value of option in OptionsDB or None if the option does not exist.");
+        def("get_options_db_option_bool",   GetOptionsDBOptionBool,    return_value_policy<return_by_value>(), "Returns the bool value of option in OptionsDB or None if the option does not exist.");
+        def("get_options_db_option_double", GetOptionsDBOptionDouble,  return_value_policy<return_by_value>(), "Returns the double value of option in OptionsDB or None if the option does not exist.");
+
+        def("getUserConfigDir",         GetUserConfigDirWrapper,        /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific configuration.");
+        def("getUserDataDir",           GetUserDataDirWrapper,          /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific data (saves, etc.).");
+
+        def("get_user_config_dir",         GetUserConfigDirWrapper,        /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific configuration.");
+        def("get_user_data_dir",           GetUserDataDirWrapper,          /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific data (saves, etc.).");
+    }
+}

--- a/python/ConfigWrapper.cpp
+++ b/python/ConfigWrapper.cpp
@@ -32,25 +32,27 @@ namespace {
 namespace FreeOrionPython {
     void WrapConfig()
     {
-        // We provide the Python wrappers both with camelCase and with snake_case names,
-        // as these wrappers are used both by the AI and the universe generation scripts.
-        // The former still uses camelCase, while the latter uses snake_case, so we need
-        // to support both styles for the time being.
-
+#ifdef FREEORION_BUILD_AI
+        // For the AI client provide function names in camelCase,
+        // as that's still the preferred style there (for the time being)
         def("getOptionsDBOptionStr",    GetOptionsDBOptionStr,     return_value_policy<return_by_value>(), "Returns the string value of option in OptionsDB or None if the option does not exist.");
         def("getOptionsDBOptionInt",    GetOptionsDBOptionInt,     return_value_policy<return_by_value>(), "Returns the integer value of option in OptionsDB or None if the option does not exist.");
         def("getOptionsDBOptionBool",   GetOptionsDBOptionBool,    return_value_policy<return_by_value>(), "Returns the bool value of option in OptionsDB or None if the option does not exist.");
         def("getOptionsDBOptionDouble", GetOptionsDBOptionDouble,  return_value_policy<return_by_value>(), "Returns the double value of option in OptionsDB or None if the option does not exist.");
 
+        def("getUserConfigDir",         GetUserConfigDirWrapper,        /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific configuration.");
+        def("getUserDataDir",           GetUserDataDirWrapper,          /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific data (saves, etc.).");
+#endif
+
+#ifdef FREEORION_BUILD_SERVER
+        // For the server, provide the function names already in snake_case
         def("get_options_db_option_str",    GetOptionsDBOptionStr,     return_value_policy<return_by_value>(), "Returns the string value of option in OptionsDB or None if the option does not exist.");
         def("get_options_db_option_int",    GetOptionsDBOptionInt,     return_value_policy<return_by_value>(), "Returns the integer value of option in OptionsDB or None if the option does not exist.");
         def("get_options_db_option_bool",   GetOptionsDBOptionBool,    return_value_policy<return_by_value>(), "Returns the bool value of option in OptionsDB or None if the option does not exist.");
         def("get_options_db_option_double", GetOptionsDBOptionDouble,  return_value_policy<return_by_value>(), "Returns the double value of option in OptionsDB or None if the option does not exist.");
 
-        def("getUserConfigDir",         GetUserConfigDirWrapper,        /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific configuration.");
-        def("getUserDataDir",           GetUserDataDirWrapper,          /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific data (saves, etc.).");
-
         def("get_user_config_dir",         GetUserConfigDirWrapper,        /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific configuration.");
         def("get_user_data_dir",           GetUserDataDirWrapper,          /* no return value policy, */ "Returns path to directory where FreeOrion stores user specific data (saves, etc.).");
+#endif
     }
 }

--- a/python/server/ServerFramework.cpp
+++ b/python/server/ServerFramework.cpp
@@ -36,6 +36,7 @@ BOOST_PYTHON_MODULE(freeorion) {
     FreeOrionPython::WrapEmpire();
     FreeOrionPython::WrapUniverseClasses();
     FreeOrionPython::WrapServer();
+    FreeOrionPython::WrapConfig();
 
     // STL Containers
     class_<std::vector<int>>("IntVec")


### PR DESCRIPTION
This PR is intended as an alternative implementation of #2264, which moves the Python wrappers from the AI wrappers to the common wrappers instead of duplicating them for the server.

If accepted, will supersede #2264.