### PR TITLE
Allow players to chat if some player hasn't yet responded client save data

### DIFF
--- a/server/ServerFSM.h
+++ b/server/ServerFSM.h
@@ -374,7 +374,6 @@ struct WaitingForSaveData : sc::state<WaitingForSaveData, WaitingForTurnEnd> {
         sc::deferral<SaveGameRequest>,
         sc::deferral<TurnOrders>,
         sc::deferral<RevokeReadiness>,
-        sc::deferral<PlayerChat>,
         sc::deferral<Diplomacy>
     > reactions;
 


### PR DESCRIPTION
Partial correction #2275 .
Don't defer `PlayerChat` event in `WaitingForSaveData` state so if it even takes long time players still can use chat.