### PR TITLE
Add option to enable/disable empire statistics.

### DIFF
--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1372,6 +1372,9 @@ Limit the number of human players allowed in a multiplayer game. Set to -1 for u
 OPTIONS_DB_COOKIES_EXPIRE
 Count of minutes after the cookie record will be considered expired.
 
+OPTIONS_DB_PUBLISH_STATISTICS
+Enable sending empire staticstics to the player.
+
 OPTIONS_DB_UI_MAIN_MENU_X
 Position of the center of the intro screen main menu, as a portion of the application's total width.
 

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -113,8 +113,6 @@ ServerApp::ServerApp() :
         boost::bind(&ServerApp::HandleDiplomaticMessageChange,this, _1, _2));
 
     m_signals.async_wait(boost::bind(&ServerApp::SignalHandler, this, _1, _2));
-
-    m_universe.SetStatRecordsPublish(GetOptionsDB().Get<bool>("network.server.publish-statistics"));
 }
 
 ServerApp::~ServerApp() {

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -113,6 +113,8 @@ ServerApp::ServerApp() :
         boost::bind(&ServerApp::HandleDiplomaticMessageChange,this, _1, _2));
 
     m_signals.async_wait(boost::bind(&ServerApp::SignalHandler, this, _1, _2));
+
+    m_universe.SetStatRecordsPublish(GetOptionsDB().Get<bool>("network.server.publish-statistics"));
 }
 
 ServerApp::~ServerApp() {

--- a/server/dmain.cpp
+++ b/server/dmain.cpp
@@ -61,6 +61,7 @@ int wmain(int argc, wchar_t* argv[], wchar_t* envp[]) {
         GetOptionsDB().Add<int>("network.server.human.min", UserStringNop("OPTIONS_DB_MP_HUMAN_MIN"), 0, Validator<int>());
         GetOptionsDB().Add<int>("network.server.human.max", UserStringNop("OPTIONS_DB_MP_HUMAN_MAX"), -1, Validator<int>());
         GetOptionsDB().Add<int>("network.server.cookies.expire-minutes", UserStringNop("OPTIONS_DB_COOKIES_EXPIRE"), 15, Validator<int>());
+        GetOptionsDB().Add<bool>("network.server.publish-statistics", UserStringNop("OPTIONS_DB_PUBLISH_STATISTICS"), true, Validator<bool>());
 
         // if config.xml and persistent_config.xml are present, read and set options entries
         GetOptionsDB().SetFromFile(GetConfigPath(), FreeOrionVersionString());

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -1098,7 +1098,7 @@ namespace {
                                      " cause: " + m_specific_cause_name);
 
             // skip inactive sources
-            // FIXME: is it safe to move this out of the loop? 
+            // FIXME: is it safe to move this out of the loop?
             // Activation condition must not contain "Source" subconditions in that case
             const auto* activation = m_effects_group->Activation();
             if (activation && !activation->Eval(source_context, source))
@@ -1578,7 +1578,7 @@ void Universe::ExecuteEffects(const Effect::TargetsCauses& targets_causes,
                     Effect::TargetsAndCause& targets_and_cause = targets_it->second;
                     Effect::TargetSet& targets = targets_and_cause.target_set;
 
-                    // this is a set difference/union algorithm: 
+                    // this is a set difference/union algorithm:
                     // targets              -= non_stacking_targets
                     // non_stacking_targets += targets
                     for (auto object_it = targets.begin();
@@ -2262,7 +2262,7 @@ namespace {
 
                         // special case for fleets: grant partial visibility if
                         // visible contained object is partially or better visible
-                        // this way fleet ownership is known to players who can 
+                        // this way fleet ownership is known to players who can
                         // see ships with partial or better visibility (and thus
                         // know the owner of the ships and thus should know the
                         // owners of the fleet)
@@ -2412,7 +2412,7 @@ namespace {
                                        Universe::EmpireObjectSpecialsMap& empire_object_visible_specials)
     {
         // make copy of input vis map, iterate over that, not the output as
-        // iterating over the output while modifying it would result in 
+        // iterating over the output while modifying it would result in
         // second-order visibility sharing (but only through allies with lower
         // empire id)
         auto input_eov_copy = empire_object_visibility;
@@ -2952,6 +2952,9 @@ void Universe::UpdateStatRecords() {
         }
     }
 }
+
+void Universe::SetStatRecordsPublish(bool publish /*= true*/)
+{ m_stat_records_publish = publish; }
 
 void Universe::GetShipDesignsToSerialize(ShipDesignMap& designs_to_serialize,
                                          int encoding_empire) const

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -2953,9 +2953,6 @@ void Universe::UpdateStatRecords() {
     }
 }
 
-void Universe::SetStatRecordsPublish(bool publish /*= true*/)
-{ m_stat_records_publish = publish; }
-
 void Universe::GetShipDesignsToSerialize(ShipDesignMap& designs_to_serialize,
                                          int encoding_empire) const
 {

--- a/universe/Universe.h
+++ b/universe/Universe.h
@@ -351,9 +351,6 @@ public:
     void InhibitUniverseObjectSignals(bool inhibit = true);
 
     void UpdateStatRecords();
-
-    /** Sets whether to publish empire statistics to the players. */
-    void SetStatRecordsPublish(bool publish = true);
     //@}
 
     /** Returns true if UniverseOjbectSignals are inhibited, false otherwise. */
@@ -523,7 +520,6 @@ private:
 
     std::map<std::string, std::map<int, std::map<int, double>>>
                                     m_stat_records;                     ///< storage for statistics calculated for empires. Indexed by stat name (string), contains a map indexed by empire id, contains a map from turn number (int) to stat value (double).
-    bool                            m_stat_records_publish;             ///< send empire statistics to the players.
 
     /** @name Parsed items
         Various unlocked items are kept as a Pending::Pending while being parsed and

--- a/universe/Universe.h
+++ b/universe/Universe.h
@@ -351,6 +351,9 @@ public:
     void InhibitUniverseObjectSignals(bool inhibit = true);
 
     void UpdateStatRecords();
+
+    /** Sets whether to publish empire statistics to the players. */
+    void SetStatRecordsPublish(bool publish = true);
     //@}
 
     /** Returns true if UniverseOjbectSignals are inhibited, false otherwise. */
@@ -464,7 +467,7 @@ private:
 
     /** Removes entries in \a targets_causes about effects groups acting
       * on objects in \a target_objects, and then repopulates for EffectsGroups
-      * that act on at least one of the objects in \a target_objects. If 
+      * that act on at least one of the objects in \a target_objects. If
       * \a target_objects is empty then default target candidates will be used. */
     void GetEffectsAndTargets(Effect::TargetsCauses& targets_causes,
                               const std::vector<int>& target_objects);
@@ -486,7 +489,7 @@ private:
 
     /** Does actual updating of meter estimates after the public function have
       * processed objects_vec or whatever they were passed and cleared the
-      * relevant effect accounting for those objects and meters. If an empty 
+      * relevant effect accounting for those objects and meters. If an empty
       * vector is passed, it will instead update all existing objects. */
     void UpdateMeterEstimatesImpl(const std::vector<int>& objects_vec, bool do_accounting);
 
@@ -520,6 +523,7 @@ private:
 
     std::map<std::string, std::map<int, std::map<int, double>>>
                                     m_stat_records;                     ///< storage for statistics calculated for empires. Indexed by stat name (string), contains a map indexed by empire id, contains a map from turn number (int) to stat value (double).
+    bool                            m_stat_records_publish;             ///< send empire statistics to the players.
 
     /** @name Parsed items
         Various unlocked items are kept as a Pending::Pending while being parsed and

--- a/util/SerializeUniverse.cpp
+++ b/util/SerializeUniverse.cpp
@@ -151,7 +151,7 @@ void Universe::serialize(Archive& ar, const unsigned int version)
         }
     }
 
-    if (Archive::is_saving::value && (!m_stat_records_publish)) {
+    if (Archive::is_saving::value && (!m_stat_records_publish) && m_encoding_empire != ALL_EMPIRES) {
         std::map<std::string, std::map<int, std::map<int, double>>> dummy_stat_records;
         ar  & boost::serialization::make_nvp("m_stat_records", dummy_stat_records);
     } else {

--- a/util/SerializeUniverse.cpp
+++ b/util/SerializeUniverse.cpp
@@ -151,8 +151,13 @@ void Universe::serialize(Archive& ar, const unsigned int version)
         }
     }
 
-    ar  & BOOST_SERIALIZATION_NVP(m_stat_records);
-    DebugLogger() << "Universe::serialize : " << serializing_label << " " << m_stat_records.size() << " types of statistic";
+    if (Archive::is_saving::value && (!m_stat_records_publish)) {
+        std::map<std::string, std::map<int, std::map<int, double>>> dummy_stat_records;
+        ar  & boost::serialization::make_nvp("m_stat_records", dummy_stat_records);
+    } else {
+        ar  & BOOST_SERIALIZATION_NVP(m_stat_records);
+        DebugLogger() << "Universe::serialize : " << serializing_label << " " << m_stat_records.size() << " types of statistic";
+    }
 
     DebugLogger() << "Universe::serialize : " << serializing_label << " done";
 

--- a/util/SerializeUniverse.cpp
+++ b/util/SerializeUniverse.cpp
@@ -14,6 +14,8 @@
 #include "../universe/Field.h"
 #include "../universe/Universe.h"
 
+#include "OptionsDB.h"
+
 #include <boost/lexical_cast.hpp>
 #include <boost/uuid/nil_generator.hpp>
 
@@ -151,7 +153,7 @@ void Universe::serialize(Archive& ar, const unsigned int version)
         }
     }
 
-    if (Archive::is_saving::value && (!m_stat_records_publish) && m_encoding_empire != ALL_EMPIRES) {
+    if (Archive::is_saving::value && (!GetOptionsDB().Get<bool>("network.server.publish-statistics")) && m_encoding_empire != ALL_EMPIRES) {
         std::map<std::string, std::map<int, std::map<int, double>>> dummy_stat_records;
         ar  & boost::serialization::make_nvp("m_stat_records", dummy_stat_records);
     } else {


### PR DESCRIPTION
First way to solve disclosure empire statistics in multiplayer game. Adds server option `network.server.publish-statistics` to overall on/off empire statistics.

Forum thread: https://freeorion.org/forum/viewtopic.php?f=6&t=11069