### PR TITLE
Ingame multiplayer lobby

### DIFF
--- a/UI/ChatWnd.cpp
+++ b/UI/ChatWnd.cpp
@@ -402,7 +402,7 @@ void MessageWnd::HandlePlayerChatMessage(const std::string& text,
 void MessageWnd::HandlePlayerStatusUpdate(Message::PlayerStatus player_status, int about_player_id)
 {}
 
-void MessageWnd::HandleTurnPhaseUpdate(Message::TurnProgressPhase phase_id) {
+void MessageWnd::HandleTurnPhaseUpdate(Message::TurnProgressPhase phase_id, bool prefixed /*= false*/) {
     std::string phase_str;
     switch (phase_id) {
     case Message::FLEET_MOVEMENT:
@@ -441,7 +441,10 @@ void MessageWnd::HandleTurnPhaseUpdate(Message::TurnProgressPhase phase_id) {
         break;
     }
 
-    *m_display += phase_str + "\n";
+    if (prefixed)
+        *m_display += boost::str(FlexibleFormat(UserString("PLAYING_GAME")) % phase_str) + "\n";
+    else
+        *m_display += phase_str + "\n";
     m_display_show_time = GG::GUI::GetGUI()->Ticks();
 }
 

--- a/UI/ChatWnd.h
+++ b/UI/ChatWnd.h
@@ -29,7 +29,7 @@ public:
                                             const boost::posix_time::ptime& timestamp,
                                             int recipient_player_id);
     void            HandlePlayerStatusUpdate(Message::PlayerStatus player_status, int about_player_id);
-    void            HandleTurnPhaseUpdate(Message::TurnProgressPhase phase_id);
+    void            HandleTurnPhaseUpdate(Message::TurnProgressPhase phase_id, bool prefixed = false);
     void            HandleGameStatusUpdate(const std::string& text);
     void            HandleLogMessage(const std::string& text);
     void            Clear();

--- a/UI/MultiplayerLobbyWnd.cpp
+++ b/UI/MultiplayerLobbyWnd.cpp
@@ -754,6 +754,9 @@ void MultiPlayerLobbyWnd::ChatMessage(const std::string& message_text,
                                         HumanClientApp::GetApp()->PlayerID());
 }
 
+void MultiPlayerLobbyWnd::TurnPhaseUpdate(Message::TurnProgressPhase phase_id)
+{ m_chat_wnd->HandleTurnPhaseUpdate(phase_id, true); }
+
 namespace {
     void LogPlayerSetupData(const std::list<std::pair<int, PlayerSetupData>>& psd) {
         DebugLogger() << "PlayerSetupData:";

--- a/UI/MultiplayerLobbyWnd.h
+++ b/UI/MultiplayerLobbyWnd.h
@@ -40,6 +40,7 @@ public:
                                 const std::string& player_name,
                                 GG::Clr text_color,
                                 const boost::posix_time::ptime& timestamp);
+    void            TurnPhaseUpdate(Message::TurnProgressPhase phase_id);
     void            LobbyUpdate(const MultiplayerLobbyData& lobby_data);
     void            Refresh();
     void            CleanupChat();

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -578,6 +578,31 @@ boost::statechart::result MPLobby::react(const ChatHistory& msg) {
     return discard_event();
 }
 
+boost::statechart::result MPLobby::react(const PlayerStatus& msg) {
+    TraceLogger(FSM) << "(HumanClientFSM) PlayerStatus.";
+    // ToDo: show it in player ready status
+
+    return discard_event();
+}
+
+boost::statechart::result MPLobby::react(const SaveGameComplete& msg) {
+    TraceLogger(FSM) << "(HumanClientFSM) SaveGameComplete.";
+    // ignore it
+
+    return discard_event();
+}
+
+boost::statechart::result MPLobby::react(const TurnProgress& msg) {
+    TraceLogger(FSM) << "(HumanClientFSM) TurnProgress.";
+
+    Message::TurnProgressPhase phase_id;
+    ExtractTurnProgressMessageData(msg.m_message, phase_id);
+    const auto& wnd = Client().GetClientUI().GetMultiPlayerLobbyWnd();
+    wnd->TurnPhaseUpdate(phase_id);
+
+    return discard_event();
+}
+
 
 ////////////////////////////////////////////////////////////
 // PlayingGame

--- a/client/human/HumanClientFSM.h
+++ b/client/human/HumanClientFSM.h
@@ -224,7 +224,10 @@ struct MPLobby : boost::statechart::state<MPLobby, HumanClientFSM> {
         boost::statechart::custom_reaction<StartQuittingGame>,
         boost::statechart::custom_reaction<Error>,
         boost::statechart::custom_reaction<CheckSum>,
-        boost::statechart::custom_reaction<ChatHistory>
+        boost::statechart::custom_reaction<ChatHistory>,
+        boost::statechart::custom_reaction<PlayerStatus>,
+        boost::statechart::custom_reaction<SaveGameComplete>,
+        boost::statechart::custom_reaction<TurnProgress>
     > reactions;
 
     MPLobby(my_context ctx);
@@ -241,6 +244,9 @@ struct MPLobby : boost::statechart::state<MPLobby, HumanClientFSM> {
     boost::statechart::result react(const Error& msg);
     boost::statechart::result react(const CheckSum& msg);
     boost::statechart::result react(const ChatHistory& msg);
+    boost::statechart::result react(const PlayerStatus& msg);
+    boost::statechart::result react(const SaveGameComplete& msg);
+    boost::statechart::result react(const TurnProgress& msg);
 
     CLIENT_ACCESSOR
 };

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -2276,6 +2276,9 @@ Accept
 NOT_READY_BN
 Decline
 
+# %1% is a turn progress phase
+PLAYING_GAME
+Playing game: %1%
 
 ##
 ## Galaxy Setup Screen

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -262,6 +262,10 @@ void ServerFSM::HandleNonLobbyDisconnection(const Disconnection& d) {
                 // player abnormally disconnected during a regular game
                 ErrorLogger(FSM) << "Player #" << id << ", named \""
                                  << player_connection->PlayerName() << "\"quit before empire was eliminated.";
+            } else if (player_connection->GetClientType() == Networking::CLIENT_TYPE_HUMAN_PLAYER && !empire) {
+                // should be in ingame lobby
+                // update ingame lobby
+                UpdateIngameLobby();
             }
         }
     } else {
@@ -284,6 +288,43 @@ void ServerFSM::HandleNonLobbyDisconnection(const Disconnection& d) {
             m_server.m_fsm->process_event(Hostless());
         } else {
             m_server.m_fsm->process_event(ShutdownServer());
+        }
+    }
+}
+
+void ServerFSM::UpdateIngameLobby() {
+    GalaxySetupData galaxy_data = m_server.GetGalaxySetupData();
+    MultiplayerLobbyData dummy_lobby_data(std::move(galaxy_data));
+    dummy_lobby_data.m_any_can_edit = false;
+    dummy_lobby_data.m_new_game = false;
+    dummy_lobby_data.m_start_locked = true;
+    for (auto player_it = m_server.m_networking.established_begin();
+        player_it != m_server.m_networking.established_end(); ++player_it)
+    {
+        PlayerSetupData player_setup_data;
+        int player_id = (*player_it)->PlayerID();
+        player_setup_data.m_player_id =   player_id;
+        player_setup_data.m_player_name = (*player_it)->PlayerName();
+        player_setup_data.m_client_type = (*player_it)->GetClientType();
+        if (const Empire* empire = GetEmpire(m_server.PlayerEmpireID(player_id))) {
+            player_setup_data.m_empire_name = empire->Name();
+            player_setup_data.m_empire_color = empire->Color();
+        } else {
+            player_setup_data.m_empire_color = GG::Clr(255, 255, 255, 255);
+        }
+        dummy_lobby_data.m_players.push_back({player_id, player_setup_data});
+    }
+    dummy_lobby_data.m_start_lock_cause = UserStringNop("SERVER_ALREADY_PLAYING_GAME");
+
+    // send it to all those without empire
+    // and who are CLIENT_TYPE_HUMAN_PLAYER
+    for (auto player_it = m_server.m_networking.established_begin();
+        player_it != m_server.m_networking.established_end(); ++player_it)
+    {
+        if ((*player_it)->GetClientType() == Networking::CLIENT_TYPE_HUMAN_PLAYER &&
+            !GetEmpire(m_server.PlayerEmpireID((*player_it)->PlayerID())))
+        {
+            (*player_it)->SendMessage(ServerLobbyUpdateMessage(dummy_lobby_data));
         }
     }
 }
@@ -2233,14 +2274,10 @@ void PlayingGame::EstablishPlayer(const PlayerConnectionPtr& player_connection,
                 // previous connection was dropped
                 // set empire link to new connection by name
                 // send playing game
-                if (!server.AddPlayerIntoGame(player_connection)) {
-                    player_connection->SendMessage(ErrorMessage(UserStringNop("SERVER_ALREADY_PLAYING_GAME")));
-                    server.Networking().Disconnect(player_connection);
-                }
-            } else {
-                player_connection->SendMessage(ErrorMessage(UserStringNop("SERVER_ALREADY_PLAYING_GAME")));
-                server.Networking().Disconnect(player_connection);
+                server.AddPlayerIntoGame(player_connection);
+                // In both cases update ingame lobby
             }
+            fsm.UpdateIngameLobby();
         }
     }
 }
@@ -2271,14 +2308,6 @@ sc::result PlayingGame::react(const JoinGame& msg) {
             // send authentication request
             player_connection->AwaitPlayer(client_type, client_version_string);
             player_connection->SendMessage(AuthRequestMessage(player_name, "PLAIN-TEXT"));
-            return discard_event();
-        }
-
-        if (client_type != Networking::CLIENT_TYPE_HUMAN_OBSERVER &&
-            client_type != Networking::CLIENT_TYPE_HUMAN_MODERATOR)
-        {
-            msg.m_player_connection->SendMessage(ErrorMessage(UserStringNop("SERVER_ALREADY_PLAYING_GAME")));
-            Server().Networking().Disconnect(msg.m_player_connection);
             return discard_event();
         }
 
@@ -2315,6 +2344,7 @@ sc::result PlayingGame::react(const JoinGame& msg) {
         }
 
         if (collision) {
+            WarnLogger() << "Reject player " << original_player_name;
             player_connection->SendMessage(ErrorMessage(str(FlexibleFormat(UserString("ERROR_PLAYER_NAME_ALREADY_USED")) % original_player_name),
                                                         true));
             server.Networking().Disconnect(player_connection);
@@ -2389,6 +2419,19 @@ sc::result PlayingGame::react(const Error& msg) {
         DebugLogger(FSM) << "Fatal received.";
         return transit<ShuttingDownServer>();
     }
+    return discard_event();
+}
+
+sc::result PlayingGame::react(const LobbyUpdate& msg) {
+    TraceLogger(FSM) << "(ServerFSM) MPLobby.LobbyUpdate";
+    ServerApp& server = Server();
+    const Message& message = msg.m_message;
+    const PlayerConnectionPtr& sender = msg.m_player_connection;
+
+    // ignore data
+    sender->SendMessage(ErrorMessage(UserStringNop("SERVER_ALREADY_PLAYING_GAME")));
+    server.Networking().Disconnect(sender);
+
     return discard_event();
 }
 

--- a/server/ServerFSM.h
+++ b/server/ServerFSM.h
@@ -131,6 +131,7 @@ struct ServerFSM : sc::state_machine<ServerFSM, Idle> {
     void unconsumed_event(const sc::event_base &event);
     ServerApp& Server();
     void HandleNonLobbyDisconnection(const Disconnection& d);
+    void UpdateIngameLobby();
     bool EstablishPlayer(const PlayerConnectionPtr& player_connection,
                          const std::string& player_name,
                          Networking::ClientType client_type,
@@ -300,7 +301,8 @@ struct PlayingGame : sc::state<PlayingGame, ServerFSM, WaitingForTurnEnd> {
         sc::custom_reaction<JoinGame>,
         sc::custom_reaction<AuthResponse>,
         sc::custom_reaction<EliminateSelf>,
-        sc::custom_reaction<Error>
+        sc::custom_reaction<Error>,
+        sc::custom_reaction<LobbyUpdate>
     > reactions;
 
     PlayingGame(my_context c);
@@ -316,6 +318,7 @@ struct PlayingGame : sc::state<PlayingGame, ServerFSM, WaitingForTurnEnd> {
     sc::result react(const AuthResponse& msg);
     sc::result react(const EliminateSelf& msg);
     sc::result react(const Error& msg);
+    sc::result react(const LobbyUpdate& msg);
 
     void EstablishPlayer(const PlayerConnectionPtr& player_connection,
                          const std::string& player_name,


### PR DESCRIPTION
Players who cann't replace connection in playing game go into ingame multipayer lobby where they have an access to chat.
If they try to change something in lobby they get error.
If playing game will be stopped they go to pregame multiplayer lobby.
They don't get turn update and turn partial update to don't disclosure ingame information.

Player (o01eg):
![fo-player](https://user-images.githubusercontent.com/397177/45716612-208be280-bba0-11e8-8961-828c72a28d9e.png)

Ingame lobby (o03eg):
![fo-lobby](https://user-images.githubusercontent.com/397177/45716632-2b467780-bba0-11e8-8ffa-652321f6f388.png)

Forum thread: https://freeorion.org/forum/viewtopic.php?f=6&t=11068

P.S. This PR is compatible with 0.4.8 so I prefer to don't add here client or default modification.