### PR TITLE
[wrapper] Remove duplicated declaration

### DIFF
--- a/python/server/ServerWrapper.cpp
+++ b/python/server/ServerWrapper.cpp
@@ -1296,7 +1296,6 @@ namespace FreeOrionPython {
         def("user_string",                          make_function(&UserString,      return_value_policy<copy_const_reference>()));
         def("roman_number",                         RomanNumber);
         def("get_resource_dir",                     GetResourceDirWrapper);
-        def("get_user_config_dir",                  GetUserConfigDirWrapper);
 
         def("all_empires",                          AllEmpires);
         def("invalid_object",                       InvalidObjectID);


### PR DESCRIPTION
The second copy of the method was introduced in the commit.
https://github.com/freeorion/freeorion/commit/d8088cd82c25aba17827461bcfe856b5843de137#diff-058ed30f9c557ea7d8387a675bb3ce01R53



