### PR TITLE
Add debugging helper function assertion_fails

### DIFF
--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -341,6 +341,9 @@ def generateOrders():  # pylint: disable=invalid-name
                    ResourcesAI.generate_resources_orders,
                    ]
 
+    from freeorion_tools import assertion_fails
+    print assertion_fails(False)
+    print assertion_fails(True)
     for action in action_list:
         try:
             main_timer.start(action.__name__)

--- a/default/python/AI/freeorion_tools/_freeorion_tools.py
+++ b/default/python/AI/freeorion_tools/_freeorion_tools.py
@@ -4,6 +4,7 @@ import cProfile
 import logging
 import pstats
 import re
+import traceback
 from collections import Mapping
 from functools import wraps
 from logging import debug, error
@@ -347,3 +348,28 @@ def with_log_level(log_level):
 
         return wrapper
     return decorator
+
+
+def assertion_fails(cond, msg="", logger=logging.error):
+    """
+    Check if condition fails and if so, log a traceback but raise no Exception.
+
+    This is a useful functions for generic sanity checks and may be used to
+    replace manual error logging with more context provided by the traceback.
+
+    :param bool cond: condition to be asserted
+    :param str msg: additional info to be logged
+    :param func logger: may be used to override default log level (error)
+    :return: True if assertion failed, otherwise false.
+    """
+    if cond:
+        return False
+
+    if msg:
+        header = "Assertion failed: %s." % msg
+    else:
+        header = "Assertion failed!"
+    stack = traceback.extract_stack()[:-1]  # do not log this function
+    logger("%s Traceback (most recent call last): %s", header,
+           ''.join(traceback.format_list(stack)))
+    return True

--- a/default/python/tests/AI/test_assertion_fails.py
+++ b/default/python/tests/AI/test_assertion_fails.py
@@ -1,0 +1,25 @@
+from freeorion_tools import assertion_fails
+
+
+def test_does_fail():
+    assert assertion_fails(False)
+
+
+def test_does_not_fail():
+    assert not assertion_fails(True)
+
+
+def test_message_argument():
+    assert assertion_fails(False, "")
+    assert assertion_fails(False, "Some message")
+    assert not assertion_fails(True, "")
+    assert not assertion_fails(True, "Some message")
+
+
+def test_logger_argument():
+    import logging
+    loggers = [logging.debug, logging.info, logging.warn, logging.error]
+    for logger in loggers:
+        assert assertion_fails(False, logger=logger)
+        assert assertion_fails(False, "Some message", logger=logger)
+        assert not assertion_fails(True, logger=logger)


### PR DESCRIPTION
Introduces a helper function which semi-automates error logging for sanity checks and gives context on failure by providing a traceback. It is intended to be used as a graceful alternative to the assert-statement.

An optional logging level can be specified to avoid error messages in chat.

Example usage:
```
for fleet_id in fleets_which_should_exist:
    fleet = universe.getFleet()
    # if not fleet:
    #    do some manual error logging
    #    continue
    if assertion_fails(fleet is not None):
        continue

    # do something on fleet object
```