### PR TITLE
Reroll wrong targets with possible targets condition

### DIFF
--- a/combat/CMakeLists.txt
+++ b/combat/CMakeLists.txt
@@ -4,6 +4,7 @@ target_sources(freeorioncommon
         ${CMAKE_CURRENT_LIST_DIR}/CombatEvents.h
         ${CMAKE_CURRENT_LIST_DIR}/CombatLogManager.h
         ${CMAKE_CURRENT_LIST_DIR}/CombatSystem.h
+        ${CMAKE_CURRENT_LIST_DIR}/CombatTargetting.h
     PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/CombatEvent.cpp
         ${CMAKE_CURRENT_LIST_DIR}/CombatEvents.cpp
@@ -13,16 +14,19 @@ target_sources(freeorioncommon
 target_sources(freeoriond
     PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/CombatSystem.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/CombatTargetting.cpp
 )
 
 target_sources(freeorionca
     PRIVATE
         ${CMAKE_CURRENT_LIST_DIR}/CombatSystem.cpp
+        ${CMAKE_CURRENT_LIST_DIR}/CombatTargetting.cpp
 )
 
 if(NOT BUILD_HEADLESS)
     target_sources(freeorion
         PRIVATE
             ${CMAKE_CURRENT_LIST_DIR}/CombatSystem.cpp
+            ${CMAKE_CURRENT_LIST_DIR}/CombatTargetting.cpp
     )
 endif()

--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -831,7 +831,7 @@ namespace {
 
             for (int n = 0; n < number; ++n) {
                 // create / insert fighter into combat objectmap
-                auto fighter_ptr = std::make_shared<Fighter>(owner_empire_id, from_ship_id, species, damage);
+                auto fighter_ptr = std::make_shared<Fighter>(owner_empire_id, from_ship_id, species, damage, nullptr);
                 fighter_ptr->SetID(next_fighter_id--);
                 fighter_ptr->Rename(UserString("OBJ_FIGHTER"));
                 combat_info.objects.Insert(fighter_ptr);

--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -1,5 +1,6 @@
 #include "CombatSystem.h"
 #include "CombatEvents.h"
+#include "CombatTargetting.h"
 
 #include "../universe/Universe.h"
 #include "../util/GameRules.h"
@@ -1471,7 +1472,7 @@ namespace {
 
         } else if (attack_planet) {     // treat planet defenses as direct fire weapon
             weapons.push_back(PartAttackInfo(PC_DIRECT_WEAPON, UserStringNop("DEF_DEFENSE"),
-                                             attack_planet->CurrentMeterValue(METER_DEFENSE), nullptr));
+                                             attack_planet->CurrentMeterValue(METER_DEFENSE), Targetting::PreyAsTriggerCondition(Targetting::ShipPrey)));
 
         } else if (attack_fighter) {    // treat fighter damage as direct fire weapon
             weapons.push_back(PartAttackInfo(PC_DIRECT_WEAPON, UserStringNop("FT_WEAPON_1"),

--- a/combat/CombatTargetting.cpp
+++ b/combat/CombatTargetting.cpp
@@ -1,0 +1,40 @@
+#include "CombatTargetting.h"
+
+#include "../universe/Condition.h"
+#include "../universe/ValueRef.h"
+
+#include "../universe/Enums.h"
+
+//TODO: replace with std::make_unique when transitioning to C++14
+#include <boost/smart_ptr/make_unique.hpp>
+
+#include "../util/Logger.h"
+
+const ::Condition::ConditionBase* Targetting::PreyAsTriggerCondition(const Targetting::PreyType prey)
+{
+    static std::unique_ptr<::Condition::ConditionBase> is_boat =
+        boost::make_unique<::Condition::Type>(std::unique_ptr<ValueRef::ValueRefBase<UniverseObjectType>>(new ValueRef::Constant<UniverseObjectType>(OBJ_FIGHTER)));
+    static std::unique_ptr<::Condition::ConditionBase> is_planet =
+        boost::make_unique<::Condition::Type>(std::unique_ptr<ValueRef::ValueRefBase<UniverseObjectType>>(new ValueRef::Constant<UniverseObjectType>(OBJ_PLANET)));
+    static std::unique_ptr<::Condition::ConditionBase> is_ship =
+        boost::make_unique<::Condition::Type>(std::unique_ptr<ValueRef::ValueRefBase<UniverseObjectType>>(new ValueRef::Constant<UniverseObjectType>(OBJ_SHIP)));
+    static std::unique_ptr<::Condition::ConditionBase> is_any = boost::make_unique<Condition::All>();
+    // One could support mixed values by allowing bit patterns; e.g. returning static is_boat_or_ship Condition::And({is_boat,is_ship})
+    switch (prey) {
+    case Targetting::PreyType::PlanetPrey:
+        return is_planet.get();
+    case Targetting::PreyType::BoatPrey:
+        return is_boat.get();
+    case Targetting::ShipPrey:
+        return is_ship.get();
+    case Targetting::AllPrey:
+    //case Targetting::PreyType::NoPreference:
+        return is_any.get();
+    default:
+        // error
+        ErrorLogger() << "PreyAsTriggerCondition encountered unsupported PreyType " << prey << ".";
+        return nullptr;
+    }
+}
+
+

--- a/combat/CombatTargetting.h
+++ b/combat/CombatTargetting.h
@@ -1,0 +1,19 @@
+#ifndef _CombatTargetting_h_
+#define _CombatTargetting_h_
+
+#include "../universe/Condition.h"
+
+namespace Targetting {
+    enum PreyType {
+        NoPreference = 7,
+        AllPrey = 7,
+        PlanetPrey = 1,
+        ShipPrey = 2,
+        BoatPrey = 4
+    };
+
+    /* gives access to static conditions */
+    const ::Condition::ConditionBase* PreyAsTriggerCondition(PreyType prey);
+}
+
+#endif // _CombatTargetting_h_

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_0.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_0.focs.txt
@@ -5,6 +5,9 @@ Part
     class = FighterHangar
     capacity = 2
     damage = 0
+    combatTargets = And [
+        Not Planet
+    ]
     mountableSlotTypes = Internal
     buildcost = 10 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 1

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_1.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_1.focs.txt
@@ -5,6 +5,9 @@ Part
     class = FighterHangar
     capacity = 4
     damage = 1
+    combatTargets = And [
+        Not Planet
+    ]
     mountableSlotTypes = Internal
     buildcost = 15 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 1

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_2.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_2.focs.txt
@@ -5,6 +5,9 @@ Part
     class = FighterHangar
     capacity = 3
     damage = 3
+    combatTargets = And [
+        Not Planet
+    ]
     mountableSlotTypes = Internal
     buildcost = 20 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 1

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_3.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_3.focs.txt
@@ -5,6 +5,9 @@ Part
     class = FighterHangar
     capacity = 2
     damage = 5
+    combatTargets = And [
+        Not Planet
+    ]
     mountableSlotTypes = Internal
     buildcost = 25 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 1

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_4.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_4.focs.txt
@@ -5,6 +5,9 @@ Part
     class = FighterHangar
     capacity = 1
     damage = 10
+    combatTargets = And [
+        Not Planet
+    ]
     mountableSlotTypes = Internal
     buildcost = 30 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 1

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_KRILL.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_KRILL.focs.txt
@@ -4,6 +4,9 @@ Part
     class = FighterHangar
     capacity = 30
     damage = 1
+    combatTargets = And [
+        Not Planet
+    ]
     mountableSlotTypes = Internal
     buildcost = 20 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 1

--- a/default/scripting/ship_parts/ShortRange/SR_WEAPON_0_1.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_WEAPON_0_1.focs.txt
@@ -5,6 +5,10 @@ Part
     damage = 1
     shots = 3
     NoDefaultCapacityEffect
+    combatTargets = And [
+        Not Ship
+        Not Planet
+    ]
     mountableSlotTypes = External
     buildcost = 20 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 1

--- a/default/scripting/ship_parts/ShortRange/SR_WEAPON_0_1.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_WEAPON_0_1.focs.txt
@@ -5,10 +5,7 @@ Part
     damage = 1
     shots = 3
     NoDefaultCapacityEffect
-    combatTargets = And [
-        Not Ship
-        Not Planet
-    ]
+    combatTargets = Fighter
     mountableSlotTypes = External
     buildcost = 20 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 1

--- a/msvc2015/Common/Common.vcxproj
+++ b/msvc2015/Common/Common.vcxproj
@@ -153,6 +153,7 @@
     <ClInclude Include="..\..\combat\CombatEvents.h" />
     <ClInclude Include="..\..\combat\CombatLogManager.h" />
     <ClInclude Include="..\..\combat\CombatSystem.h" />
+    <ClInclude Include="..\..\combat\CombatTargetting.h" />
     <ClInclude Include="..\..\Empire\Diplomacy.h" />
     <ClInclude Include="..\..\Empire\Empire.h" />
     <ClInclude Include="..\..\Empire\ResearchQueue.h" />

--- a/msvc2015/Common/Common.vcxproj.filters
+++ b/msvc2015/Common/Common.vcxproj.filters
@@ -223,6 +223,9 @@
     <ClInclude Include="..\..\util\ModeratorAction.h">
       <Filter>Header Files\util</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\combat\CombatTargetting.h">
+      <Filter>Header Files\combat</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\combat\CombatSystem.h">
       <Filter>Header Files\combat</Filter>
     </ClInclude>

--- a/msvc2017/Common/Common.vcxproj
+++ b/msvc2017/Common/Common.vcxproj
@@ -154,6 +154,7 @@
     <ClInclude Include="..\..\combat\CombatEvents.h" />
     <ClInclude Include="..\..\combat\CombatLogManager.h" />
     <ClInclude Include="..\..\combat\CombatSystem.h" />
+    <ClInclude Include="..\..\combat\CombatTargetting.h" />
     <ClInclude Include="..\..\Empire\Diplomacy.h" />
     <ClInclude Include="..\..\Empire\Empire.h" />
     <ClInclude Include="..\..\Empire\ResearchQueue.h" />

--- a/msvc2017/Common/Common.vcxproj.filters
+++ b/msvc2017/Common/Common.vcxproj.filters
@@ -223,6 +223,9 @@
     <ClInclude Include="..\..\util\ModeratorAction.h">
       <Filter>Header Files\util</Filter>
     </ClInclude>
+    <ClInclude Include="..\..\combat\CombatTargetting.h">
+      <Filter>Header Files\combat</Filter>
+    </ClInclude>
     <ClInclude Include="..\..\combat\CombatSystem.h">
       <Filter>Header Files\combat</Filter>
     </ClInclude>

--- a/msvc2017/FreeOrionD/FreeOrionD.vcxproj
+++ b/msvc2017/FreeOrionD/FreeOrionD.vcxproj
@@ -134,6 +134,7 @@
   </ItemDefinitionGroup>
   <ItemGroup>
     <ClInclude Include="..\..\combat\CombatSystem.h" />
+    <ClInclude Include="..\..\combat\CombatTargetting.h" />
     <ClInclude Include="..\..\Empire\Empire.h" />
     <ClInclude Include="..\..\Empire\ResearchQueue.h" />
     <ClInclude Include="..\..\Empire\ProductionQueue.h" />
@@ -195,6 +196,7 @@
     <ClInclude Include="..\..\util\XMLDoc.h" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="..\..\combat\CombatTargetting.cpp" />
     <ClCompile Include="..\..\combat\CombatSystem.cpp" />
     <ClCompile Include="..\..\network\ServerNetworking.cpp" />
     <ClCompile Include="..\..\python\CommonFramework.cpp" />

--- a/msvc2017/FreeOrionD/FreeOrionD.vcxproj.filters
+++ b/msvc2017/FreeOrionD/FreeOrionD.vcxproj.filters
@@ -59,7 +59,10 @@
     <ClInclude Include="..\..\combat\CombatSystem.h">
       <Filter>Header Files\combat</Filter>
     </ClInclude>
-    <ClInclude Include="..\..\Empire\Empire.h">
+    <ClInclude Include="..\..\combat\CombatTargetting.h">
+      <Filter>Header Files\combat</Filter>
+   </ClInclude>
+   <ClInclude Include="..\..\Empire\Empire.h">
       <Filter>Header Files\Empire</Filter>
     </ClInclude>
     <ClInclude Include="..\..\Empire\ResearchQueue.h">
@@ -255,6 +258,9 @@
     </ClCompile>
     <ClCompile Include="..\..\util\Process.cpp">
       <Filter>Source Files\util</Filter>
+    </ClCompile>
+    <ClCompile Include="..\..\combat\CombatTargetting.cpp">
+      <Filter>Source Files\combat</Filter>
     </ClCompile>
     <ClCompile Include="..\..\combat\CombatSystem.cpp">
       <Filter>Source Files\combat</Filter>

--- a/parse/Tokens.h
+++ b/parse/Tokens.h
@@ -57,6 +57,7 @@
     (ClockwiseNextPlanetType)                   \
     (Colony)                                    \
     (Colour)                                    \
+    (CombatTargets)                             \
     (Condition)                                 \
     (Construction)                              \
     (Consumption)                               \

--- a/universe/Fighter.cpp
+++ b/universe/Fighter.cpp
@@ -10,11 +10,12 @@
 Fighter::Fighter()
 {}
 
-Fighter::Fighter(int empire_id, int launched_from_id, const std::string& species_name, float damage) :
+Fighter::Fighter(int empire_id, int launched_from_id, const std::string& species_name, float damage, const ::Condition::ConditionBase* combat_targets) :
     UniverseObject(),
     m_damage(damage),
     m_launched_from_id(launched_from_id),
-    m_species_name(species_name)
+    m_species_name(species_name),
+    m_combat_targets(combat_targets)
 {
     this->SetOwner(empire_id);
     UniverseObject::Init();
@@ -33,6 +34,9 @@ bool Fighter::HostileToEmpire(int empire_id) const
 
 UniverseObjectType Fighter::ObjectType() const
 { return OBJ_FIGHTER; }
+
+const ::Condition::ConditionBase* Fighter::CombatTargets() const
+{ return m_combat_targets; }
 
 float Fighter::Damage() const
 { return m_damage; }
@@ -80,4 +84,5 @@ void Fighter::Copy(std::shared_ptr<const UniverseObject> copied_object, int empi
 
     this->m_damage = copied_fighter->m_damage;
     this->m_destroyed= copied_fighter->m_destroyed;
+    this->m_combat_targets = copied_fighter->m_combat_targets;
 }

--- a/universe/Fighter.h
+++ b/universe/Fighter.h
@@ -2,6 +2,7 @@
 #define _Fighter_h_
 
 #include "UniverseObject.h"
+#include "../universe/Condition.h"
 #include "../util/Export.h"
 
 ////////////////////////////////////////////////
@@ -11,7 +12,7 @@
   * can be stored in the same container as other combat objects. */
 class FO_COMMON_API Fighter : public UniverseObject {
 public:
-    Fighter(int empire_id, int launched_from_id, const std::string& species_name, float damage);
+    Fighter(int empire_id, int launched_from_id, const std::string& species_name, float damage, const ::Condition::ConditionBase* combat_targets);
     Fighter();
     ~Fighter();
 
@@ -25,6 +26,7 @@ public:
 
     void Copy(std::shared_ptr<const UniverseObject> copied_object, int empire_id = ALL_EMPIRES) override;
 
+    const ::Condition::ConditionBase* CombatTargets() const;
     float                       Damage() const;
     bool                        Destroyed() const;
     int                         LaunchedFrom() const;
@@ -39,6 +41,7 @@ private:
     bool        m_destroyed = false;                    // was attacked by anything -> destroyed
     int         m_launched_from_id = INVALID_OBJECT_ID; // from what object (ship?) was this fighter launched
     std::string m_species_name;
+    const ::Condition::ConditionBase* m_combat_targets;
 };
 
-#endif // _Ship_h_
+#endif // _Fighter_h_

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -305,7 +305,8 @@ PartType::PartType() :
 PartType::PartType(ShipPartClass part_class, double capacity, double stat2,
                    CommonParams& common_params, const MoreCommonParams& more_common_params,
                    std::vector<ShipSlotType> mountable_slot_types,
-                   const std::string& icon, bool add_standard_capacity_effect) :
+                   const std::string& icon, bool add_standard_capacity_effect,
+                   std::unique_ptr<const ::Condition::ConditionBase>&& combat_targets) :
     m_name(more_common_params.name),
     m_description(more_common_params.description),
     m_class(part_class),
@@ -322,7 +323,8 @@ PartType::PartType(ShipPartClass part_class, double capacity, double stat2,
     m_exclusions(more_common_params.exclusions),
     m_effects(),
     m_icon(icon),
-    m_add_standard_capacity_effect(add_standard_capacity_effect)
+    m_add_standard_capacity_effect(add_standard_capacity_effect),
+    m_combat_targets(std::move(combat_targets))
 {
     //TraceLogger() << "part type: " << m_name << " producible: " << m_producible << std::endl;
     Init(std::move(common_params.effects));

--- a/universe/ShipDesign.h
+++ b/universe/ShipDesign.h
@@ -27,6 +27,7 @@
 #include "../util/Export.h"
 #include "../util/Pending.h"
 
+
 FO_COMMON_API extern const int INVALID_OBJECT_ID;
 namespace Condition {
     struct ConditionBase;
@@ -90,7 +91,8 @@ public:
     PartType(ShipPartClass part_class, double capacity, double stat2,
              CommonParams& common_params, const MoreCommonParams& more_common_params,
              std::vector<ShipSlotType> mountable_slot_types,
-             const std::string& icon, bool add_standard_capacity_effect = true);
+             const std::string& icon, bool add_standard_capacity_effect = true,
+             std::unique_ptr<const ::Condition::ConditionBase>&& combat_targets = nullptr);
 
     ~PartType();
     //@}
@@ -104,6 +106,7 @@ public:
     float                   SecondaryStat() const;
 
     bool                    CanMountInSlotType(ShipSlotType slot_type) const;       ///< returns true if this part can be placed in a slot of the indicated type
+    const ::Condition::ConditionBase* CombatTargets() const { return m_combat_targets.get(); }          ///< returns the condition for possible targets
     const std::vector<ShipSlotType>&
                             MountableSlotTypes() const  { return m_mountable_slot_types; }
 
@@ -158,6 +161,7 @@ private:
 
     std::string     m_icon = "";
     bool            m_add_standard_capacity_effect = false;
+    std::unique_ptr<const ::Condition::ConditionBase>   m_combat_targets;
 
     friend class boost::serialization::access;
     template <class Archive>
@@ -746,7 +750,8 @@ void PartType::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_exclusions)
         & BOOST_SERIALIZATION_NVP(m_effects)
         & BOOST_SERIALIZATION_NVP(m_icon)
-        & BOOST_SERIALIZATION_NVP(m_add_standard_capacity_effect);
+        & BOOST_SERIALIZATION_NVP(m_add_standard_capacity_effect)
+        & BOOST_SERIALIZATION_NVP(m_combat_targets);
 }
 
 template <class Archive>


### PR DESCRIPTION
This is a simpler cousin of https://github.com/freeorion/freeorion/pull/2249, partly implementing possibleTargets aka combat_targets as discussed in https://www.freeorion.org/forum/viewtopic.php?f=6&t=11048&sid=c10abf0f18cbb1a3b873cf094f8dfc29&start=45#p93788

What is there: combatTargets conditions are added for planets, flak and hangars and get parsed and passed on to the PartAttackInfos in the CombatSystem.

What is missing: evaluating the conditions vs all potential targets (somewhere close or instead of ValidTargetsForAttackerType).

@geoffthemedio you take over from here, good hunting