### PR TITLE
Fix hang (one possible choice) after an empire is defeated

### DIFF
--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -70,6 +70,15 @@ namespace {
     }
 };
 
+namespace {
+    /** Returns true if \a empire has been eliminated by the applicable
+      * definition of elimination.  As of this writing, elimination means
+      * having no ships and no planets. */
+    bool EmpireEliminated(int empire_id) {
+          return (Objects().FindObjects(OwnedVisitor<Planet>(empire_id)).empty() &&    // no planets
+                  Objects().FindObjects(OwnedVisitor<Ship>(empire_id)).empty());      // no ship
+      }
+}
 
 ////////////////////////////////////////////////
 // ServerApp
@@ -1818,7 +1827,9 @@ bool ServerApp::AllOrdersReceived() {
     DebugLogger() << "ServerApp::AllOrdersReceived for turn: " << m_current_turn;
     bool all_orders_received = true;
     for (const auto& empire_orders : m_turn_sequence) {
-        if (!empire_orders.second.second) {
+        if (EmpireEliminated(empire_orders.first)) {
+            DebugLogger() << " ... eliminated empire id: " << empire_orders.first;
+        } else if (!empire_orders.second.second) {
             DebugLogger() << " ... no orders from empire id: " << empire_orders.first;
             all_orders_received = false;
         } else if (!empire_orders.second.first) {
@@ -1832,14 +1843,6 @@ bool ServerApp::AllOrdersReceived() {
 }
 
 namespace {
-    /** Returns true if \a empire has been eliminated by the applicable
-      * definition of elimination.  As of this writing, elimination means
-      * having no ships and no planets. */
-    bool EmpireEliminated(int empire_id) {
-          return (Objects().FindObjects(OwnedVisitor<Planet>(empire_id)).empty() &&    // no planets
-                  Objects().FindObjects(OwnedVisitor<Ship>(empire_id)).empty());      // no ship
-      }
-
     /** Compiles and return set of ids of empires that are controlled by a
       * human player.*/
     std::set<int> HumanControlledEmpires(const ServerApp* server_app,


### PR DESCRIPTION
This narrowly resolves the hang #2302 (for me at least; I couldn't get the savegame posted in that issue to load for me).  But I hold off from committing this as-is because this still leaves a problem from #2284 (which is the first bad commit with the hang) and either worsens or creates another problem  -- specifically, this fixes the problem of the game hanging when one attempts to progress past a turn in which an AI (or any empire in multiplayer I suppose) is eliminated, however, if in a single player game the human player is eliminated (not merely defeated) then (i) because of the timing involved the human client never even gets a final sitrep saying that they have been eliminated (if they lose their last planet before losing their last ship, then they get a message about being defeated when they lost the planet, but on the turn they lose the last of their joint ships and planets they get no final sitrep saying such), and (ii) then the game just goes into full spin mode, with the AI(s) zipping through turns and the human client not even getting an update.  

Having written this and explored the remaining problems, I think that a better fix is just to revert a portion of #2284 -- the ServerApp parts that refrain from asking for orders from an eliminated client.   That may seem very slightly wasteful, but I have now tested it also and it seems to me to have none of the problems of this fix / partial-fix.  I'll still post this for reference though, in case @o01eg  wants to work on a solution that keeps the code my other solution reverts (and so I include another test file below in case the one from 2302 likewise did not load for o)leg).

[test_defeated_ai_hang.sav.zip](https://github.com/freeorion/freeorion/files/2574844/test_defeated_ai_hang.sav.zip)

Once someone agrees that the other solution is preferable, we can mark this as superseded and close.

