### PR TITLE
Fix monster shield regeneration (#2325)

### DIFF
--- a/default/scripting/ship_hulls/monster/SH_BLACK_KRAKEN_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_BLACK_KRAKEN_BODY.focs.txt
@@ -22,6 +22,7 @@ Hull
         [[MONSTER_MOVE_ALWAYS]]
         [[EXCELLENT_VISION]]
         [[INFINITE_FUEL]]
+        [[MONSTER_SHIELD_REGENERATION]]
     ]
     icon = ""
     graphic = "icons/monsters/kraken-4.png"

--- a/default/scripting/ship_hulls/monster/SH_BLOATED_JUGGERNAUT_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_BLOATED_JUGGERNAUT_BODY.focs.txt
@@ -24,6 +24,7 @@ Hull
         [[MONSTER_MOVE_ALWAYS]]
         [[EXCELLENT_VISION]]
         [[INFINITE_FUEL]]
+        [[MONSTER_SHIELD_REGENERATION]]
     ]
     icon = ""
     graphic = "icons/monsters/juggernaut-4.png"

--- a/default/scripting/ship_hulls/monster/SH_COSMIC_DRAGON_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_COSMIC_DRAGON_BODY.focs.txt
@@ -20,6 +20,7 @@ Hull
         [[HUNT_PLANETS]]
         [[MONSTER_MOVE_ALWAYS]]
         [[INFINITE_FUEL]]
+        [[MONSTER_SHIELD_REGENERATION]]
 
         EffectsGroup
             scope = NumberOf number = 1 condition = And [

--- a/default/scripting/ship_hulls/monster/SH_DAMPENING_CLOUD_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_DAMPENING_CLOUD_BODY.focs.txt
@@ -15,6 +15,7 @@ Hull
     location = All
     effectsgroups = [
         [[INFINITE_FUEL]]
+        [[MONSTER_SHIELD_REGENERATION]]
         [[MONSTER_MOVE_PRE]]0.10[[MONSTER_MOVE_POST_NOT_OWNED]]
         EffectsGroup
             scope = NumberOf number = 1 condition = And [

--- a/default/scripting/ship_hulls/monster/SH_DRONE_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_DRONE_BODY.focs.txt
@@ -19,6 +19,7 @@ Hull
         [[MONSTER_MOVE_ALWAYS]]
         [[INFINITE_FUEL]]
         [[MODERATE_VISION]]
+        [[MONSTER_SHIELD_REGENERATION]]
     ]
     icon = ""
     graphic = "icons/monsters/drone.png"

--- a/default/scripting/ship_hulls/monster/SH_FLOATER.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_FLOATER.focs.txt
@@ -19,6 +19,7 @@ Hull
         [[MONSTER_MOVE_ALWAYS]]
         [[INFINITE_FUEL]]
         [[MODERATE_VISION]]
+        [[MONSTER_SHIELD_REGENERATION]]
 
         EffectsGroup    // in systems with no other monsters, spawn trees
             scope = And [

--- a/default/scripting/ship_hulls/monster/SH_GUARD_0_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_GUARD_0_BODY.focs.txt
@@ -16,9 +16,11 @@ Hull
     tags = [ "UNOWNED_FRIENDLY" "PEDIA_HULL_MONSTER_GUARD" ]
     location = All
     effectsgroups = [
+        [[MONSTER_SHIELD_REGENERATION]]
         [[UNOWNED_OWNED_VISION_BONUS(WEAK,10,10)]]
     ]
     icon = ""
     graphic = "icons/monsters/maintenance_ship.png"
 
 #include "../ship_hulls.macros"
+#include "monster.macros"

--- a/default/scripting/ship_hulls/monster/SH_GUARD_1_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_GUARD_1_BODY.focs.txt
@@ -16,9 +16,11 @@ Hull
     tags = [ "UNOWNED_FRIENDLY" "PEDIA_HULL_MONSTER_GUARD" ]
     location = All
     effectsgroups = [
+        [[MONSTER_SHIELD_REGENERATION]]
         [[UNOWNED_OWNED_VISION_BONUS(POOR,20,20)]]
     ]
     icon = ""
     graphic = "icons/monsters/sentry.png"
 
 #include "../ship_hulls.macros"
+#include "monster.macros"

--- a/default/scripting/ship_hulls/monster/SH_GUARD_3_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_GUARD_3_BODY.focs.txt
@@ -21,6 +21,7 @@ Hull
     tags = [ "UNOWNED_FRIENDLY" "PEDIA_HULL_MONSTER_GUARD" ]
     location = All
     effectsgroups = [
+        [[MONSTER_SHIELD_REGENERATION]]
         [[UNOWNED_OWNED_VISION_BONUS(GOOD,50,50)]]
         EffectsGroup
             scope = Source
@@ -36,3 +37,4 @@ Hull
     graphic = "icons/monsters/warden.png"
 
 #include "../ship_hulls.macros"
+#include "monster.macros"

--- a/default/scripting/ship_hulls/monster/SH_GUARD_MONSTER_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_GUARD_MONSTER_BODY.focs.txt
@@ -18,6 +18,7 @@ Hull
     tags = [ "UNOWNED_FRIENDLY" "PEDIA_HULL_MONSTER_GUARD" ]
     location = All
     effectsgroups = [
+        [[MONSTER_SHIELD_REGENERATION]]
         [[UNOWNED_OWNED_VISION_BONUS(MODERATE,40,30)]]
         EffectsGroup
             scope = Source

--- a/default/scripting/ship_hulls/monster/SH_IMMOBILE_FACTOR.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_IMMOBILE_FACTOR.focs.txt
@@ -16,6 +16,7 @@ Hull
     tags = [ "PEDIA_HULL_MONSTER_GUARD" ]
     location = All
     effectsgroups = [
+        [[MONSTER_SHIELD_REGENERATION]]
         [[UNOWNED_OWNED_VISION_BONUS(WEAK,10,10)]]
         EffectsGroup
             scope = Source

--- a/default/scripting/ship_hulls/monster/SH_JUGGERNAUT_1_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_JUGGERNAUT_1_BODY.focs.txt
@@ -43,6 +43,7 @@ Hull
 
         [[MONSTER_MOVE_ALWAYS]]
         [[INFINITE_FUEL]]
+        [[MONSTER_SHIELD_REGENERATION]]
 
         EffectsGroup
             scope = And [

--- a/default/scripting/ship_hulls/monster/SH_JUGGERNAUT_2_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_JUGGERNAUT_2_BODY.focs.txt
@@ -19,6 +19,7 @@ Hull
     effectsgroups = [
         [[MONSTER_MOVE_ALWAYS]]
         [[INFINITE_FUEL]]
+        [[MONSTER_SHIELD_REGENERATION]]
 
         EffectsGroup
             scope = And [

--- a/default/scripting/ship_hulls/monster/SH_JUGGERNAUT_3_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_JUGGERNAUT_3_BODY.focs.txt
@@ -19,6 +19,7 @@ Hull
     effectsgroups = [
         [[MONSTER_MOVE_ALWAYS]]
         [[INFINITE_FUEL]]
+        [[MONSTER_SHIELD_REGENERATION]]
          EffectsGroup
             scope = Source
             activation = Source

--- a/default/scripting/ship_hulls/monster/SH_KRAKEN_1_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_KRAKEN_1_BODY.focs.txt
@@ -41,6 +41,7 @@ Hull
 
         [[MONSTER_MOVE_ALWAYS]]
         [[INFINITE_FUEL]]
+        [[MONSTER_SHIELD_REGENERATION]]
 
         EffectsGroup
             scope = And [

--- a/default/scripting/ship_hulls/monster/SH_KRAKEN_2_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_KRAKEN_2_BODY.focs.txt
@@ -19,6 +19,7 @@ Hull
     effectsgroups = [
         [[MONSTER_MOVE_ALWAYS]]
         [[INFINITE_FUEL]]
+        [[MONSTER_SHIELD_REGENERATION]]
 
         EffectsGroup
             scope = And [

--- a/default/scripting/ship_hulls/monster/SH_KRAKEN_3_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_KRAKEN_3_BODY.focs.txt
@@ -19,6 +19,7 @@ Hull
     effectsgroups = [
         [[MONSTER_MOVE_ALWAYS]]
         [[INFINITE_FUEL]]
+        [[MONSTER_SHIELD_REGENERATION]]
          EffectsGroup
             scope = Source
             activation = Source

--- a/default/scripting/ship_hulls/monster/SH_KRILL_1_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_KRILL_1_BODY.focs.txt
@@ -82,6 +82,7 @@ Hull
         [[MONSTER_MOVE_ALWAYS]]
         [[INFINITE_FUEL]]
         [[WEAK_VISION]]
+        [[MONSTER_SHIELD_REGENERATION]]
 
         EffectsGroup
             scope = And [

--- a/default/scripting/ship_hulls/monster/SH_KRILL_2_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_KRILL_2_BODY.focs.txt
@@ -91,6 +91,7 @@ Hull
         [[MONSTER_MOVE_ALWAYS]]
         [[INFINITE_FUEL]]
         [[MODERATE_VISION]]
+        [[MONSTER_SHIELD_REGENERATION]]
 
         EffectsGroup
             scope = And [

--- a/default/scripting/ship_hulls/monster/SH_KRILL_3_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_KRILL_3_BODY.focs.txt
@@ -93,6 +93,7 @@ Hull
         [[MONSTER_MOVE_ALWAYS]]
         [[INFINITE_FUEL]]
         [[GOOD_VISION]]
+        [[MONSTER_SHIELD_REGENERATION]]
 
         EffectsGroup
             scope = And [

--- a/default/scripting/ship_hulls/monster/SH_KRILL_4_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_KRILL_4_BODY.focs.txt
@@ -43,6 +43,7 @@ Hull
 
         [[MONSTER_MOVE_ALWAYS]]
         [[INFINITE_FUEL]]
+        [[MONSTER_SHIELD_REGENERATION]]
         [[GOOD_VISION]]
     ]
     icon = ""

--- a/default/scripting/ship_hulls/monster/SH_NEBULOUS.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_NEBULOUS.focs.txt
@@ -16,6 +16,7 @@ Hull
     location = All
     effectsgroups = [
         [[INFINITE_FUEL]]
+        [[MONSTER_SHIELD_REGENERATION]]
 
         [[MONSTER_MOVE_PRE]]1[[MONSTER_MOVE_POST]]
     ]

--- a/default/scripting/ship_hulls/monster/SH_PSIONIC_SNOWFLAKE_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_PSIONIC_SNOWFLAKE_BODY.focs.txt
@@ -20,6 +20,7 @@ Hull
         [[HUNT_SHIPS]]
         [[MONSTER_MOVE_ALWAYS]]
         [[INFINITE_FUEL]]
+        [[MONSTER_SHIELD_REGENERATION]]
         [[EXCELLENT_VISION]]
 
         EffectsGroup

--- a/default/scripting/ship_hulls/monster/SH_SNOWFLAKE_1_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_SNOWFLAKE_1_BODY.focs.txt
@@ -44,6 +44,7 @@ Hull
 
         [[MONSTER_MOVE_ALWAYS]]
         [[INFINITE_FUEL]]
+        [[MONSTER_SHIELD_REGENERATION]]
 
         EffectsGroup
             scope = And [

--- a/default/scripting/ship_hulls/monster/SH_SNOWFLAKE_2_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_SNOWFLAKE_2_BODY.focs.txt
@@ -19,6 +19,7 @@ Hull
     effectsgroups = [
         [[MONSTER_MOVE_ALWAYS]]
         [[INFINITE_FUEL]]
+        [[MONSTER_SHIELD_REGENERATION]]
 
         EffectsGroup
             scope = And [

--- a/default/scripting/ship_hulls/monster/SH_SNOWFLAKE_3_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_SNOWFLAKE_3_BODY.focs.txt
@@ -19,6 +19,7 @@ Hull
     effectsgroups = [
         [[MONSTER_MOVE_ALWAYS]]
         [[INFINITE_FUEL]]
+        [[MONSTER_SHIELD_REGENERATION]]
         EffectsGroup
             scope = Source
             activation = Source

--- a/default/scripting/ship_hulls/monster/SH_STRONG_MONSTER_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_STRONG_MONSTER_BODY.focs.txt
@@ -21,6 +21,7 @@ Hull
         [[MONSTER_MOVE_ALWAYS]]
         [[INFINITE_FUEL]]
         [[GOOD_VISION]]
+        [[MONSTER_SHIELD_REGENERATION]]
     ]
     icon = ""
     graphic = "icons/monsters/dragon-1.png"

--- a/default/scripting/ship_hulls/monster/SH_TREE_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_TREE_BODY.focs.txt
@@ -13,6 +13,7 @@ Hull
     location = All
     effectsgroups = [
         [[MODERATE_VISION]]
+        [[MONSTER_SHIELD_REGENERATION]]
 
         EffectsGroup    // remove self and recreate on first turn, so that trees start with age 0, and thus low initial health, instead of having thousands of structure at start of game
             scope = Source

--- a/default/scripting/ship_hulls/monster/SH_WHITE_KRAKEN_BODY.focs.txt
+++ b/default/scripting/ship_hulls/monster/SH_WHITE_KRAKEN_BODY.focs.txt
@@ -20,6 +20,7 @@ Hull
     effectsgroups = [
         [[GOOD_VISION]]
         [[INFINITE_FUEL]]
+        [[MONSTER_SHIELD_REGENERATION]]
     ]
     icon = ""
     graphic = "icons/monsters/kraken-5.png"

--- a/default/scripting/ship_hulls/monster/monster.macros
+++ b/default/scripting/ship_hulls/monster/monster.macros
@@ -1,3 +1,11 @@
+MONSTER_SHIELD_REGENERATION
+'''EffectsGroup  // Increase shields to max when not in battle
+            scope = Source
+            activation = (Source.LastTurnActiveInBattle < CurrentTurn)
+            priority = [[AFTER_ALL_TARGET_MAX_METERS_PRIORITY]]
+            effects = SetShield value = Target.MaxShield
+'''
+
 MONSTER_MOVE_ALWAYS
 '''EffectsGroup
             scope = And [

--- a/default/scripting/ship_hulls/monster/monster.macros
+++ b/default/scripting/ship_hulls/monster/monster.macros
@@ -2,6 +2,7 @@ MONSTER_SHIELD_REGENERATION
 '''EffectsGroup  // Increase shields to max when not in battle
             scope = Source
             activation = (Source.LastTurnActiveInBattle < CurrentTurn)
+            stackinggroup = "SHIELD_REGENERATION_EFFECT"
             priority = [[AFTER_ALL_TARGET_MAX_METERS_PRIORITY]]
             effects = SetShield value = Target.MaxShield
 '''

--- a/default/scripting/species/common/shields.macros
+++ b/default/scripting/species/common/shields.macros
@@ -16,6 +16,7 @@ STANDARD_SHIP_SHIELDS
                 Ship
                 (Source.LastTurnActiveInBattle < CurrentTurn)
             ]
+            stackinggroup = "SHIELD_REGENERATION_EFFECT"
             priority = [[AFTER_ALL_TARGET_MAX_METERS_PRIORITY]]
             effects = SetShield value = Target.MaxShield
 '''


### PR DESCRIPTION
Attempts to fix #2325: After moving the ship shield growth from C++ to a FOCS species effect, monster ships did not regenerate shields as they generally do not have a species.

If we provide a bugfix release, we probably want to include this patch.