### PR TITLE
Add option to enable/disable network binary serialization

### DIFF
--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1915,6 +1915,9 @@ Automatically quits once any turns specified by --auto-advance-n-turns are compl
 OPTIONS_DB_BINARY_SERIALIZATION
 Use Binary serialization for saving games. Binary serialization is faster to save and load, but may not be possible to load on a different operating system.
 
+OPTIONS_DB_SERVER_BINARY_SERIALIZATION
+The server will use Binary serialization for client-server interaction if the client's version matches the server's version. Binary serialization is faster to transfer, but may not be compatible between different operating systems and architectures.
+
 OPTIONS_DB_XML_ZLIB_SERIALIZATION
 When saving games with XML serialization, compress most of the XML before writing the file. Compression substantially reduces save file sizes, but may make saves unloadable due to memory requirements to decompress the save data.
 

--- a/network/ServerNetworking.cpp
+++ b/network/ServerNetworking.cpp
@@ -212,7 +212,7 @@ void PlayerConnection::SetCookie(boost::uuids::uuid cookie)
 const std::string& PlayerConnection::ClientVersionString() const
 { return m_client_version_string; }
 
-bool PlayerConnection::IsBinarySerializationEnabled() const {
+bool PlayerConnection::IsBinarySerializationUsed() const {
     return GetOptionsDB().Get<bool>("network.server.binary.enabled")
         && !m_client_version_string.empty()
         && m_client_version_string == FreeOrionVersionString();

--- a/network/ServerNetworking.cpp
+++ b/network/ServerNetworking.cpp
@@ -212,8 +212,11 @@ void PlayerConnection::SetCookie(boost::uuids::uuid cookie)
 const std::string& PlayerConnection::ClientVersionString() const
 { return m_client_version_string; }
 
-bool PlayerConnection::ClientVersionStringMatchesThisServer() const
-{ return !m_client_version_string.empty() && m_client_version_string == FreeOrionVersionString(); }
+bool PlayerConnection::ClientVersionStringMatchesThisServer() const {
+    return GetOptionsDB().Get<bool>("network.server.binary.enabled")
+        && !m_client_version_string.empty()
+        && m_client_version_string == FreeOrionVersionString();
+}
 
 PlayerConnectionPtr PlayerConnection::NewConnection(boost::asio::io_service& io_service,
                                                     MessageAndConnectionFn nonplayer_message_callback,

--- a/network/ServerNetworking.cpp
+++ b/network/ServerNetworking.cpp
@@ -212,7 +212,7 @@ void PlayerConnection::SetCookie(boost::uuids::uuid cookie)
 const std::string& PlayerConnection::ClientVersionString() const
 { return m_client_version_string; }
 
-bool PlayerConnection::ClientVersionStringMatchesThisServer() const {
+bool PlayerConnection::IsBinarySerializationEnabled() const {
     return GetOptionsDB().Get<bool>("network.server.binary.enabled")
         && !m_client_version_string.empty()
         && m_client_version_string == FreeOrionVersionString();

--- a/network/ServerNetworking.h
+++ b/network/ServerNetworking.h
@@ -229,7 +229,7 @@ public:
     /** Returns true iff the client's specified version string matches the
       * version string of this server process so the server will enable binary serialization if it
       * is allowed. */
-    bool ClientVersionStringMatchesThisServer() const;
+    bool IsBinarySerializationEnabled() const;
 
     /** Checks if client associated with this connection runs on the same
         physical machine as the server */

--- a/network/ServerNetworking.h
+++ b/network/ServerNetworking.h
@@ -227,7 +227,8 @@ public:
     const std::string& ClientVersionString() const;
 
     /** Returns true iff the client's specified version string matches the
-      * version string of this server process. */
+      * version string of this server process so the server will enable binary serialization if it
+      * is allowed. */
     bool ClientVersionStringMatchesThisServer() const;
 
     /** Checks if client associated with this connection runs on the same

--- a/network/ServerNetworking.h
+++ b/network/ServerNetworking.h
@@ -226,10 +226,8 @@ public:
     /** Returns the version string the client provided when joining. */
     const std::string& ClientVersionString() const;
 
-    /** Returns true iff the client's specified version string matches the
-      * version string of this server process so the server will enable binary serialization if it
-      * is allowed. */
-    bool IsBinarySerializationEnabled() const;
+    /** Checks if the server will enable binary serialization for this client's connection. */
+    bool IsBinarySerializationUsed() const;
 
     /** Checks if client associated with this connection runs on the same
         physical machine as the server */

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -798,7 +798,7 @@ void ServerApp::SendNewGameStartMessages() {
         const PlayerConnectionPtr player_connection = *player_connection_it;
         int player_id = player_connection->PlayerID();
         int empire_id = PlayerEmpireID(player_id);
-        bool use_binary_serialization = player_connection->IsBinarySerializationEnabled();
+        bool use_binary_serialization = player_connection->IsBinarySerializationUsed();
         player_connection->SendMessage(GameStartMessage(m_single_player_game,    empire_id,
                                                         m_current_turn,          m_empires,
                                                         m_universe,              GetSpeciesManager(),
@@ -1337,7 +1337,7 @@ void ServerApp::LoadGameInit(const std::vector<PlayerSaveGameData>& player_save_
         // when they end their turn
         auto orders = psgd.m_orders;
 
-        bool use_binary_serialization = player_connection->IsBinarySerializationEnabled();
+        bool use_binary_serialization = player_connection->IsBinarySerializationUsed();
 
         if (client_type == Networking::CLIENT_TYPE_AI_PLAYER) {
             // get save state string
@@ -1642,7 +1642,7 @@ void ServerApp::AddObserverPlayerIntoGame(const PlayerConnectionPtr& player_conn
     std::map<int, PlayerInfo> player_info_map = GetPlayerInfoMap();
 
     Networking::ClientType client_type = player_connection->GetClientType();
-    bool use_binary_serialization = player_connection->IsBinarySerializationEnabled();
+    bool use_binary_serialization = player_connection->IsBinarySerializationUsed();
 
     if (client_type == Networking::CLIENT_TYPE_HUMAN_OBSERVER ||
         client_type == Networking::CLIENT_TYPE_HUMAN_MODERATOR)
@@ -1749,7 +1749,7 @@ bool ServerApp::AddPlayerIntoGame(const PlayerConnectionPtr& player_connection) 
             orders_it->second.first = false;
 
             auto player_info_map = GetPlayerInfoMap();
-            bool use_binary_serialization = player_connection->IsBinarySerializationEnabled();
+            bool use_binary_serialization = player_connection->IsBinarySerializationUsed();
 
             player_connection->SendMessage(GameStartMessage(
                 m_single_player_game, empire.first,
@@ -3120,7 +3120,7 @@ void ServerApp::PreCombatProcessTurns() {
             player->GetClientType() == Networking::CLIENT_TYPE_HUMAN_MODERATOR ||
             player->GetClientType() == Networking::CLIENT_TYPE_HUMAN_OBSERVER)
         {
-            bool use_binary_serialization = player->IsBinarySerializationEnabled();
+            bool use_binary_serialization = player->IsBinarySerializationUsed();
             player->SendMessage(TurnPartialUpdateMessage(PlayerEmpireID(player->PlayerID()),
                                                          m_universe, use_binary_serialization));
         }
@@ -3451,7 +3451,7 @@ void ServerApp::PostCombatProcessTurns() {
             player->GetClientType() == Networking::CLIENT_TYPE_HUMAN_MODERATOR ||
             player->GetClientType() == Networking::CLIENT_TYPE_HUMAN_OBSERVER)
         {
-            bool use_binary_serialization = player->IsBinarySerializationEnabled();
+            bool use_binary_serialization = player->IsBinarySerializationUsed();
             player->SendMessage(TurnUpdateMessage(empire_id, m_current_turn,
                                                   m_empires,                          m_universe,
                                                   GetSpeciesManager(),                GetCombatLogManager(),

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -798,7 +798,7 @@ void ServerApp::SendNewGameStartMessages() {
         const PlayerConnectionPtr player_connection = *player_connection_it;
         int player_id = player_connection->PlayerID();
         int empire_id = PlayerEmpireID(player_id);
-        bool use_binary_serialization = player_connection->ClientVersionStringMatchesThisServer();
+        bool use_binary_serialization = player_connection->IsBinarySerializationEnabled();
         player_connection->SendMessage(GameStartMessage(m_single_player_game,    empire_id,
                                                         m_current_turn,          m_empires,
                                                         m_universe,              GetSpeciesManager(),
@@ -1337,7 +1337,7 @@ void ServerApp::LoadGameInit(const std::vector<PlayerSaveGameData>& player_save_
         // when they end their turn
         auto orders = psgd.m_orders;
 
-        bool use_binary_serialization = player_connection->ClientVersionStringMatchesThisServer();
+        bool use_binary_serialization = player_connection->IsBinarySerializationEnabled();
 
         if (client_type == Networking::CLIENT_TYPE_AI_PLAYER) {
             // get save state string
@@ -1642,7 +1642,7 @@ void ServerApp::AddObserverPlayerIntoGame(const PlayerConnectionPtr& player_conn
     std::map<int, PlayerInfo> player_info_map = GetPlayerInfoMap();
 
     Networking::ClientType client_type = player_connection->GetClientType();
-    bool use_binary_serialization = player_connection->ClientVersionStringMatchesThisServer();
+    bool use_binary_serialization = player_connection->IsBinarySerializationEnabled();
 
     if (client_type == Networking::CLIENT_TYPE_HUMAN_OBSERVER ||
         client_type == Networking::CLIENT_TYPE_HUMAN_MODERATOR)
@@ -1749,7 +1749,7 @@ bool ServerApp::AddPlayerIntoGame(const PlayerConnectionPtr& player_connection) 
             orders_it->second.first = false;
 
             auto player_info_map = GetPlayerInfoMap();
-            bool use_binary_serialization = player_connection->ClientVersionStringMatchesThisServer();
+            bool use_binary_serialization = player_connection->IsBinarySerializationEnabled();
 
             player_connection->SendMessage(GameStartMessage(
                 m_single_player_game, empire.first,
@@ -3120,7 +3120,7 @@ void ServerApp::PreCombatProcessTurns() {
             player->GetClientType() == Networking::CLIENT_TYPE_HUMAN_MODERATOR ||
             player->GetClientType() == Networking::CLIENT_TYPE_HUMAN_OBSERVER)
         {
-            bool use_binary_serialization = player->ClientVersionStringMatchesThisServer();
+            bool use_binary_serialization = player->IsBinarySerializationEnabled();
             player->SendMessage(TurnPartialUpdateMessage(PlayerEmpireID(player->PlayerID()),
                                                          m_universe, use_binary_serialization));
         }
@@ -3451,7 +3451,7 @@ void ServerApp::PostCombatProcessTurns() {
             player->GetClientType() == Networking::CLIENT_TYPE_HUMAN_MODERATOR ||
             player->GetClientType() == Networking::CLIENT_TYPE_HUMAN_OBSERVER)
         {
-            bool use_binary_serialization = player->ClientVersionStringMatchesThisServer();
+            bool use_binary_serialization = player->IsBinarySerializationEnabled();
             player->SendMessage(TurnUpdateMessage(empire_id, m_current_turn,
                                                   m_empires,                          m_universe,
                                                   GetSpeciesManager(),                GetCombatLogManager(),

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -2187,7 +2187,7 @@ sc::result PlayingGame::react(const ModeratorAct& msg) {
         action->Execute();
 
         // update player(s) of changed gamestate as result of action
-        bool use_binary_serialization = sender->IsBinarySerializationEnabled();
+        bool use_binary_serialization = sender->IsBinarySerializationUsed();
         sender->SendMessage(TurnProgressMessage(Message::DOWNLOADING));
         sender->SendMessage(TurnPartialUpdateMessage(server.PlayerEmpireID(player_id),
                                                      GetUniverse(), use_binary_serialization));

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -2187,7 +2187,7 @@ sc::result PlayingGame::react(const ModeratorAct& msg) {
         action->Execute();
 
         // update player(s) of changed gamestate as result of action
-        bool use_binary_serialization = sender->ClientVersionStringMatchesThisServer();
+        bool use_binary_serialization = sender->IsBinarySerializationEnabled();
         sender->SendMessage(TurnProgressMessage(Message::DOWNLOADING));
         sender->SendMessage(TurnPartialUpdateMessage(server.PlayerEmpireID(player_id),
                                                      GetUniverse(), use_binary_serialization));

--- a/server/dmain.cpp
+++ b/server/dmain.cpp
@@ -62,6 +62,7 @@ int wmain(int argc, wchar_t* argv[], wchar_t* envp[]) {
         GetOptionsDB().Add<int>("network.server.human.max", UserStringNop("OPTIONS_DB_MP_HUMAN_MAX"), -1, Validator<int>());
         GetOptionsDB().Add<int>("network.server.cookies.expire-minutes", UserStringNop("OPTIONS_DB_COOKIES_EXPIRE"), 15, Validator<int>());
         GetOptionsDB().Add<bool>("network.server.publish-statistics", UserStringNop("OPTIONS_DB_PUBLISH_STATISTICS"), true, Validator<bool>());
+        GetOptionsDB().Add("network.server.binary.enabled", UserStringNop("OPTIONS_DB_SERVER_BINARY_SERIALIZATION"), true);
 
         // if config.xml and persistent_config.xml are present, read and set options entries
         GetOptionsDB().SetFromFile(GetConfigPath(), FreeOrionVersionString());


### PR DESCRIPTION
This PR adds option `network.server.binary.enabled` same as `save.format.binary.enabled`. Useful for debugging when client and server have a same version but it need to view serialized message or for public server when client could have same version string but on a different CPU architecture.