### PR TITLE
Add snapcraft.yaml to enable snap build.

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,71 @@
+name: freeorion
+summary: turn-based space empire and galactic conquest (4X) computer game
+description: |
+  FreeOrion is a free, open source, turn-based space empire and galactic
+  conquest (4X) computer game being designed and built by the FreeOrion project.
+  FreeOrion is inspired by the tradition of the Master of Orion games, but is
+  not a clone or remake of that series or any other game.
+confinement: strict
+adopt-info: freeorion
+
+apps:
+    freeorion:
+        command: desktop-launch freeorion -S $SNAP_USER_COMMON/save
+        plugs: [home, pulseaudio, opengl, network, screen-inhibit-control, browser-support, x11]
+        desktop: share/applications/freeorion.desktop
+        environment:
+            LD_LIBRARY_PATH: $LD_LIBRARY_PATH:$SNAP/lib/freeorion
+            LIBGL_DRIVERS_PATH: $SNAP/usr/lib/x86_64-linux-gnu/dri
+parts:
+    freeorion:
+        source: .
+        override-build: |
+            sed -i.bak -e 's|Icon=freeorion$|Icon=${SNAP}/meta/gui/icon.png|g' ../src/freeorion.desktop
+            snapcraftctl build
+        plugin: cmake
+        override-pull: |
+            snapcraftctl pull
+            version="$(git describe --tags --always --dirty)"
+            case $version in
+                v*) version=$(echo $version | tail -c +2) ;;
+                *)  version=$(echo $version | head -c 32) ;;
+            esac
+            [ -n "$(echo $version | grep '-')" ] && grade=devel || grade=stable
+            snapcraftctl set-version "$version"
+            snapcraftctl set-grade "$grade"
+        override-prime: |
+            snapcraftctl prime
+            mkdir -p ${SNAPCRAFT_PRIME}/meta/gui
+            cp ${SNAPCRAFT_PART_SRC}/default/data/art/icons/FO_Icon_256x256.png ${SNAPCRAFT_PRIME}/meta/gui/icon.png
+        build-packages:
+            - cmake
+            - debhelper
+            - dpkg-dev
+            - libalut-dev
+            - libboost-all-dev
+            - libfreetype6-dev
+            - libgl1-mesa-dev
+            - libglew-dev
+            - libglu1-mesa-dev
+            - libjpeg-dev
+            - libogg-dev
+            - libopenal-dev
+            - libpng-dev
+            - libsdl2-dev
+            - libtiff-dev
+            - libvorbis-dev
+            - pkg-config
+            - python
+        stage-packages:
+            - mesa-utils
+            - libgl1-mesa-dri
+            - python
+        after: [ desktop-glib-only ]
+    desktop-glib-only:
+        source: https://github.com/ubuntu/snapcraft-desktop-helpers.git
+        source-subdir: glib-only
+        plugin: make
+        build-packages:
+          - libglib2.0-dev
+        stage-packages:
+          - libglib2.0-bin


### PR DESCRIPTION
Hi

This PR adds support for building a snap package of Freeorion. Snaps are cross distro Linux software packages. One snap can be installed on Ubuntu all supported LTS and non LTS releases from 14.04 onward. Additionally they can installed on Debian, Manjaro, Fedora, OpenSUSE and others. Making a snap of Freeorion enables you to provide automatic updates on your schedule to your users via the snap store.

If accepted, you can use snapcraft locally, a CI system such as travis or circle-ci, or our free build system (build.snapcraft.io) to create snaps and upload to the store (snapcraft.io/store).

To test this PR locally, I used an Ubuntu 16.04 VM, with the following steps.

    snap install snapcraft --classic
    git clone -b snapcraft https://github.com/dargad/freeorion
    cd freeorion
    snapcraft

Please note that snapcraft.yaml has been implemented in such a way it automatically picks up Freeorion version from a tag (when run on the `release-<vernum>` branch) and marks the snap as *stable*. It can be installed with:

    snap install --dangerous freeorion_amd64.snap

(the --dangerous is necessary because we’re installing an app which hasn’t gone through the snap store review process)

Once installed the command can be executed: `freeorion`

![screenshot from 2018-12-07 10-01-25](https://user-images.githubusercontent.com/468720/49637959-1cd16480-fa07-11e8-8147-66f352639e99.png)

If landed, you will need to:
* Register an account in the snap store https://snapcraft.io/account
* Register the 'freeorion' name in the store
```
snapcraft login
snapcraft register freeorion
```

* Upload a built snap to the store
```snapcraft push freeorion_amd64.snap --release edge```
* Test installing on a clean Ubuntu 16.04 machine:
```snap install freeorion --edge```

The store supports multiple risk levels as “channels” with the edge channel typically used to host the latest build from git master. Stable is where stable releases are pushed. Optionally beta and candidate channels can also be used if needed.

Once you are happy, you can push a stable release to the stable channel, update the store page, and promote the application online (we can help there).