### PR TITLE
Fix AI considerations re lost fleets

### DIFF
--- a/default/python/AI/AIstate.py
+++ b/default/python/AI/AIstate.py
@@ -588,8 +588,11 @@ class AIstate(object):
                 # does NOT include mobile monsters
                 sys_status['enemy_threat'] = max(enemy_rating, 2*lost_fleet_rating - monster_rating)
                 sys_status['monsterThreat'] = monster_rating
-                sys_status['totalThreat'] = CombatRatingsAI.combine_ratings_list(
-                    [enemy_rating, mob_rating, monster_rating, pattack * phealth])
+                sys_status['totalThreat'] = CombatRatingsAI.combine_ratings_list([
+                    sys_status['fleetThreat'],
+                    sys_status['monsterThreat'],
+                    pattack * phealth,
+                ])
             sys_status['regional_fleet_threats'] = sys_status['local_fleet_threats'].copy()
             sys_status['fleetThreat'] = max(sys_status['fleetThreat'], sys_status.get('nest_threat', 0))
             sys_status['totalThreat'] = max(sys_status['totalThreat'], sys_status.get('nest_threat', 0))


### PR DESCRIPTION
The AI did not consider lost fleets due to a combination of bugs:

1) systemStatus['totalThreat'] not considering lost ratings at all
2) lost fleets not being detected at all
3) considering current turn's fleet rating of the lost fleet (which equals 0 for obvious reasons)

This PR fixes these bugs and consequently improves AI assessment regarding stealthed enemies.