### PR TITLE
Reduce AI invasion overkill/waste

### DIFF
--- a/default/python/AI/target.py
+++ b/default/python/AI/target.py
@@ -27,7 +27,7 @@ class Target(object):
 
     def get_object(self):
         """
-        Returns fo.universeObject or None.
+        :rtype:  fo.universeObject | None
         """
         return None
 


### PR DESCRIPTION
Currently, when the AI submits an invasion order, it uses all of the troopships in the respective fleet, regardless of whether they are actually currently needed; if fleets had been combined because of a common system destination or if the target planet had lost troopers since the mission was started (due to other invasions, or dropping defense focus, or whatnot) then the AI would sometimes waste a lot of troops.  This PR reduces the maximum overkill (at least in the most common situation) to 2 troopers.   This also adds some TODO's for further related improvement.