### PR TITLE
Limit AI periodic resetting of military missions

### DIFF
--- a/default/python/AI/MilitaryAI.py
+++ b/default/python/AI/MilitaryAI.py
@@ -631,7 +631,15 @@ def get_military_fleets(mil_fleets_ids=None, try_reset=True, thisround="Main"):
     all_military_fleet_ids = (mil_fleets_ids if mil_fleets_ids is not None
                               else FleetUtilsAI.get_empire_fleet_ids_by_role(MissionType.MILITARY))
 
-    if try_reset and (fo.currentTurn() + empire_id) % 30 == 0 and thisround == "Main":
+    # Todo: This block had been originally added to address situations where fleet missions were not properly
+    #  terminating, leaving fleets stuck in stale deployments. Assess if this block is still needed at all; delete
+    #  if not, otherwise restructure the following code so that in event a reset is occurring greater priority is given
+    #  to providing military support to locations where a necessary Secure mission might have just been released (i.e.,
+    #  at invasion and colony/outpost targets where the troopships and colony ships are on their way), or else allow
+    #  only a partial reset which does not reset Secure missions.
+    enable_periodic_mission_reset = False
+    if enable_periodic_mission_reset and try_reset and (fo.currentTurn() + empire_id) % 30 == 0 and thisround == "Main":
+        debug("Resetting all Military missions as part of an automatic periodic reset to clear stale missions.")
         try_again(all_military_fleet_ids, try_reset=False, thisround=thisround + " Reset")
         return
 


### PR DESCRIPTION
In the past, AI military fleets would sometimes get 'stuck' in a deployment that was not properly getting marked as completed; as a partial workaround for that a periodic (every 30 turns) reset of military missions was put into place.   The hope had been that generally the fleets would still get reassigned to their same mission when appropriate (due to proximity), but many times that is not the case and a fleet that was in the middle of an important task will instead get sent off on some other mission (sometimes leaving related unarmed fleets vulnerable).

I think we've made good progress in clearing up those situations where fleet missions would not properly terminate and probably no longer need this automatic periodic reset.  This PR stops that by adding a boolean gate for these resets, which defaults to off, the idea being that we would take a period of time to assess whether this code is truly unneeded now.  (But I could just as easily see us as ready to simply delete this block of code right now.)