### PR TITLE
Only select fleets with sufficient fuel for a mission

### DIFF
--- a/default/python/AI/FleetUtilsAI.py
+++ b/default/python/AI/FleetUtilsAI.py
@@ -72,7 +72,7 @@ def get_targeted_planet_ids(planet_ids, mission_type):
 # TODO: Avoid mutable arguments and use return values instead
 # TODO: Use Dijkstra's algorithm instead of BFS to consider starlane length
 def get_fleets_for_mission(target_stats, min_stats, cur_stats, starting_system,
-                           fleet_pool_set, fleet_list, species=""):
+                           fleet_pool_set, fleet_list, species="", ensure_return=False):
     """Get fleets for a mission.
 
     Implements breadth-first search through systems starting at the **starting_sytem**.
@@ -97,6 +97,7 @@ def get_fleets_for_mission(target_stats, min_stats, cur_stats, starting_system,
     :type fleet_list: list[int]
     :param species: species for colonization mission
     :type species: str
+    :param bool ensure_return: If true, fleet must have sufficient fuel to return into supply after mission
     :return: List of selected fleet_ids or empty list if couldn't meet minimum requirements.
     :rtype: list[int]
     """
@@ -124,6 +125,13 @@ def get_fleets_for_mission(target_stats, min_stats, cur_stats, starting_system,
                 new_fleets = split_fleet(fleet_id)
                 fleet_pool_set.update(new_fleets)
                 fleets_here.extend(new_fleets)
+
+            if ('target_system' in target_stats and
+                    not MoveUtilsAI.can_travel_to_system(fleet_id, this_system_obj,
+                                                         target_stats['target_system'],
+                                                         ensure_return=ensure_return)):
+                    continue
+
             # check species for colonization missions
             if species:
                 for ship_id in fleet.shipIDs:
@@ -139,9 +147,6 @@ def get_fleets_for_mission(target_stats, min_stats, cur_stats, starting_system,
                 troop_capacity = count_troops_in_fleet(fleet_id)
                 if troop_capacity <= 0:
                     continue
-                if 'target_system' in target_stats:
-                    if not MoveUtilsAI.can_travel_to_system(fleet_id, this_system_obj, target_stats['target_system']):
-                        continue
 
             # check if we need additional rating vs planets
             this_rating_vs_planets = 0

--- a/default/python/AI/MilitaryAI.py
+++ b/default/python/AI/MilitaryAI.py
@@ -866,10 +866,14 @@ def assign_military_fleets_to_systems(use_fleet_id_list=None, allocations=None, 
             break
         found_fleets = []
         found_stats = {}
-        these_fleets = FleetUtilsAI.get_fleets_for_mission({'rating': alloc, 'ratingVsPlanets': rvp},
-                                                           {'rating': minalloc, 'ratingVsPlanets': rvp}, found_stats,
-                                                           starting_system=sys_id, fleet_pool_set=avail_mil_fleet_ids,
-                                                           fleet_list=found_fleets)
+        ensure_return = sys_id not in set(AIstate.colonyTargetedSystemIDs
+                                          + AIstate.outpostTargetedSystemIDs
+                                          + AIstate.invasionTargetedSystemIDs)
+        these_fleets = FleetUtilsAI.get_fleets_for_mission(
+            target_stats={'rating': alloc, 'ratingVsPlanets': rvp, 'target_system': TargetSystem(sys_id)},
+            min_stats={'rating': minalloc, 'ratingVsPlanets': rvp, 'target_system': TargetSystem(sys_id)},
+            cur_stats=found_stats, starting_system=sys_id, fleet_pool_set=avail_mil_fleet_ids,
+            fleet_list=found_fleets, ensure_return=ensure_return)
         if not these_fleets:
             if not found_fleets or not (FleetUtilsAI.stats_meet_reqs(found_stats, {'rating': minalloc}) or takeAny):
                 if doing_main:
@@ -880,7 +884,8 @@ def assign_military_fleets_to_systems(use_fleet_id_list=None, allocations=None, 
             else:
                 these_fleets = found_fleets
         elif doing_main and _verbose_mil_reporting:
-            debug("FULL+ military allocation for system %d ( %s ) -- requested allocation %8d, got %8d with fleets %s" % (sys_id, universe.getSystem(sys_id).name, alloc, found_stats.get('rating', 0), these_fleets))
+            debug("FULL+ military allocation for system %d ( %s ) -- requested allocation %8d, got %8d with fleets %s"
+                  % (sys_id, universe.getSystem(sys_id).name, alloc, found_stats.get('rating', 0), these_fleets))
         target = TargetSystem(sys_id)
         for fleet_id in these_fleets:
             fo.issueAggressionOrder(fleet_id, True)


### PR DESCRIPTION
The AI currently may allocate fleets which have insufficient fuel for a mission, sometimes only with insufficient fuel for return. In particularly, I noticed this with military fleets. 

Such a fleet will refuse to move as the pathfinding actually detects that it has insufficient supply but the mission isn't released. The fleet is subsequently stuck until supply reach of the empire expands or it is released from its mission externally.

The proposed solution in this PR is to only select fleets for a mission that have the fuel requirements as determined by AI pathfinding algorithm. 

This is an incomplete solution as if supply situation changes later on, the fleet may still be stuck. 
There is an existing TODO comment in the move order generation to release the fleet from its mission if it has insufficient fuel. So, that one is still open.