### PR TITLE
Fix Uncommon blockade glitch

### DIFF
--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -269,10 +269,10 @@ std::list<MovePathNode> Fleet::MovePath(const std::list<int>& route, bool flag_b
     }
 
     // blockade debug logging
-    //DebugLogger() << "Fleet::MovePath for fleet " << this->Name() << " ID(" << this->ID() <<") and route:";
-    //for (int waypoint : route)
-    //    DebugLogger() << "Fleet::MovePath ... " << waypoint;
-    //DebugLogger() << "Fleet::MovePath END of Route ";
+    DebugLogger() << "Fleet::MovePath for fleet " << this->Name() << " ID(" << this->ID() <<") and route:";
+    for (int waypoint : route)
+        DebugLogger() << "Fleet::MovePath ... " << waypoint;
+    DebugLogger() << "Fleet::MovePath END of Route ";
 
     // get iterator pointing to std::shared_ptr<System> on route that is the first after where this fleet is currently.
     // if this fleet is in a system, the iterator will point to the system after the current in the route
@@ -293,27 +293,29 @@ std::list<MovePathNode> Fleet::MovePath(const std::list<int>& route, bool flag_b
         return retval;
     }
 
-    //DebugLogger() << "initial cur system: " << (cur_system ? cur_system->Name() : "(none)") <<
-    //                          "  prev system: " << (prev_system ? prev_system->Name() : "(none)") <<
-    //                          "  next system: " << (next_system ? next_system->Name() : "(none)");
+    DebugLogger() << "initial cur system: " << (cur_system ? cur_system->Name() : "(none)") <<
+                              "  prev system: " << (prev_system ? prev_system->Name() : "(none)") <<
+                              "  next system: " << (next_system ? next_system->Name() : "(none)");
 
 
     bool is_post_blockade = false;
     if (cur_system) {
         //DebugLogger() << "Fleet::MovePath starting in system "<< SystemID();
-        if (flag_blockades && next_system->ID() != m_arrival_starlane &&
-            !unobstructed_systems.count(cur_system->ID()))
+        if (flag_blockades)
         {
-            //DebugLogger() << "Fleet::MovePath checking blockade from "<< cur_system->ID() << " to "<< next_system->ID();
             if (BlockadedAtSystem(cur_system->ID(), next_system->ID())){
                 // blockade debug logging
-                //DebugLogger() <<   "Fleet::MovePath finds system " <<cur_system->Name() << " (" <<cur_system->ID() <<
-                //                            ") blockaded for fleet " << this->Name();
+                DebugLogger() << "Fleet::MovePath checking blockade from "<< cur_system->ID() << " to "<< next_system->ID();
+                DebugLogger() << "Fleet::MovePath finds system " <<cur_system->Name() << " (" <<cur_system->ID() <<
+                                            ") blockaded for fleet " << this->Name();
                 is_post_blockade = true;
             } else {
-                // blockade debug logging
-                //DebugLogger() <<   "Fleet::MovePath finds system " << cur_system->Name() << " (" << cur_system->ID() <<
-                //                            ") NOT blockaded for fleet " << this->Name();
+                // blockade debug logging, but only for the more complex situations
+                if (next_system->ID() != m_arrival_starlane && !unobstructed_systems.count(cur_system->ID())) {
+                    DebugLogger() << "Fleet::MovePath checking blockade from "<< cur_system->ID() << " to " << next_system->ID();
+                    DebugLogger() << "Fleet::MovePath finds system " << cur_system->Name() << " (" << cur_system->ID()
+                                  << ") NOT blockaded for fleet " << this->Name();
+                }
             }
         }
     }
@@ -445,7 +447,7 @@ std::list<MovePathNode> Fleet::MovePath(const std::list<int>& route, bool flag_b
             cur_x = cur_system->X();    // update positions to ensure no round-off-errors
             cur_y = cur_system->Y();
 
-            //DebugLogger() << " ... arrived at system: " << cur_system->Name();
+            DebugLogger() << " ... arrived at system: " << cur_system->Name();
 
             bool clear_exit = cur_system->ID() == m_arrival_starlane; //just part of the test for the moment
             // attempt to get next system on route, to update next system.  if new current
@@ -455,22 +457,23 @@ std::list<MovePathNode> Fleet::MovePath(const std::list<int>& route, bool flag_b
                 // update next system on route and distance to it from current position
                 next_system = GetEmpireKnownSystem(*route_it, this->Owner());
                 if (next_system) {
-                    //DebugLogger() << "Fleet::MovePath checking unrestriced lane travel";
+                    DebugLogger() << "Fleet::MovePath checking unrestriced lane travel from Sys("
+                                  <<  cur_system->ID() << ") to Sys(" << (next_system && next_system->ID()) << ")";
                     clear_exit = clear_exit || (next_system && next_system->ID() == m_arrival_starlane) ||
                     (empire && empire->PreservedLaneTravel(cur_system->ID(), next_system->ID()));
                 }
             }
             if (flag_blockades && !clear_exit) {
-                //DebugLogger() << "Fleet::MovePath checking blockades at system " << cur_system->Name() << " (" << cur_system->ID() <<
-                //                 ") for fleet " << this->Name() << " travelling to system " << (*route_it);
+                DebugLogger() << "Fleet::MovePath checking blockades at system " << cur_system->Name() << " (" << cur_system->ID() <<
+                                 ") for fleet " << this->Name() << " travelling to system " << (*route_it);
                 if (cur_system && next_system && BlockadedAtSystem(cur_system->ID(), next_system->ID())) {
                     // blockade debug logging
-                    //DebugLogger() << "Fleet::MovePath finds system " << cur_system->Name() << " (" << cur_system->ID() <<
-                    //                 ") blockaded for fleet " << this->Name();
+                    DebugLogger() << "Fleet::MovePath finds system " << cur_system->Name() << " (" << cur_system->ID() <<
+                                     ") blockaded for fleet " << this->Name();
                     is_post_blockade = true;
                 } else {
-                    //DebugLogger() << "Fleet::MovePath finds system " << cur_system->Name() << " (" << cur_system->ID() <<
-                    //                 ") NOT blockaded for fleet " << this->Name();
+                    DebugLogger() << "Fleet::MovePath finds system " << cur_system->Name() << " (" << cur_system->ID() <<
+                                     ") NOT blockaded for fleet " << this->Name();
                 }
             }
 
@@ -501,9 +504,9 @@ std::list<MovePathNode> Fleet::MovePath(const std::list<int>& route, bool flag_b
         }
 
         // blockade debug logging
-        //DebugLogger() << "Fleet::MovePath for fleet " << this->Name() << " id " << this->ID() << " adding node at sysID " <<
-        //                        (cur_system ? cur_system->ID() : INVALID_OBJECT_ID) << " with post blockade status " << is_post_blockade <<
-        //                        " and ETA " << turns_taken;
+        DebugLogger() << "Fleet::MovePath for fleet " << this->Name() << " id " << this->ID() << " adding node at sysID " 
+                      << (cur_system ? cur_system->ID() : INVALID_OBJECT_ID) << " with post blockade status " 
+                      << is_post_blockade << " and ETA " << turns_taken;
 
         // add MovePathNode for current position (end of turn position and/or system location)
         retval.emplace_back(cur_x, cur_y, end_turn_at_cur_position, turns_taken,
@@ -528,9 +531,9 @@ std::list<MovePathNode> Fleet::MovePath(const std::list<int>& route, bool flag_b
     if (turns_taken == TOO_LONG)
         turns_taken = ETA_NEVER;
     // blockade debug logging
-    //DebugLogger() << "Fleet::MovePath for fleet " << this->Name()<<" id "<<this->ID()<<" adding node at sysID "<<
-    //                    (cur_system  ? cur_system->ID()  : INVALID_OBJECT_ID) << " with post blockade status " << is_post_blockade <<
-    //                    " and ETA " << turns_taken;
+    DebugLogger() << "Fleet::MovePath for fleet " << this->Name()<<" id "<<this->ID()<<" adding node at sysID "<<
+                        (cur_system  ? cur_system->ID()  : INVALID_OBJECT_ID) << " with post blockade status " << is_post_blockade <<
+                        " and ETA " << turns_taken;
 
     retval.emplace_back(cur_x, cur_y, true, turns_taken,
                         (cur_system  ? cur_system->ID()  : INVALID_OBJECT_ID),
@@ -1180,6 +1183,9 @@ bool Fleet::BlockadedAtSystem(int start_system_id, int dest_system_id) const {
         return false;
     }
     bool not_yet_in_system = SystemID() != start_system_id;
+    
+    if (!not_yet_in_system && m_arrival_starlane == dest_system_id)
+        return false;
 
     // find which empires have blockading aggressive armed ships in system;
     // fleets that just arrived do not blockade by themselves, but may
@@ -1198,7 +1204,7 @@ bool Fleet::BlockadedAtSystem(int start_system_id, int dest_system_id) const {
         if (empire->PreservedLaneTravel(start_system_id, dest_system_id)) {
             return false;
         } else {
-            //DebugLogger() << "Fleet::BlockadedAtSystem fleet " << ID() << " considering travel from system (" << start_system_id << ") to system (" << dest_system_id << ")";
+            DebugLogger() << "Fleet::BlockadedAtSystem fleet " << ID() << " considering travel from system (" << start_system_id << ") to system (" << dest_system_id << ")";
         }
     }
 


### PR DESCRIPTION
 - if a fleet was trying to move through a system but got blockaded,
   its exit route was not being properly saved and the fleet would not be able to retreat the 
  next turn along its arrival lane; this fixes that
 - Re-enable blockade debugging output
 - Centralize blockade check for arrival lane