### PR TITLE
enable precompiled headers for FreeOrion VS 2017 compilation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,7 @@ contents.xcworkspacedata
 
 # vim
 .*.sw?
+
+
+# Visual Studio
+.vs/

--- a/.gitignore
+++ b/.gitignore
@@ -97,3 +97,4 @@ contents.xcworkspacedata
 
 # Visual Studio
 .vs/
+.vscode/

--- a/msvc2017/Common/Common.vcxproj
+++ b/msvc2017/Common/Common.vcxproj
@@ -70,10 +70,11 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
+      <PrecompiledHeader>Use</PrecompiledHeader>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
+      <ForcedIncludeFiles>StdAfx.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -82,7 +83,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeader>Use</PrecompiledHeader>
       <Optimization>Full</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
@@ -90,10 +91,9 @@
       <AdditionalIncludeDirectories>../../../include/;../../GG/;../../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <WholeProgramOptimization>false</WholeProgramOptimization>
-      <PrecompiledHeaderFile>
-      </PrecompiledHeaderFile>
-      <PrecompiledHeaderOutputFile>
-      </PrecompiledHeaderOutputFile>
+      <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>$(IntDir)$(TargetName).pch</PrecompiledHeaderOutputFile>
+      <ForcedIncludeFiles>StdAfx.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -104,7 +104,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release-XP|Win32'">
     <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeader>Use</PrecompiledHeader>
       <Optimization>Full</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
@@ -112,10 +112,9 @@
       <AdditionalIncludeDirectories>../../../include/;../../GG/;../../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <WholeProgramOptimization>false</WholeProgramOptimization>
-      <PrecompiledHeaderFile>
-      </PrecompiledHeaderFile>
-      <PrecompiledHeaderOutputFile>
-      </PrecompiledHeaderOutputFile>
+      <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>$(IntDir)$(TargetName).pch</PrecompiledHeaderOutputFile>
+      <ForcedIncludeFiles>StdAfx.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -216,6 +215,7 @@
     <ClInclude Include="..\..\util\VarText.h" />
     <ClInclude Include="..\..\util\Version.h" />
     <ClInclude Include="..\..\util\XMLDoc.h" />
+    <ClInclude Include="StdAfx.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\combat\CombatEvent.cpp" />
@@ -284,6 +284,11 @@
     <ClCompile Include="..\..\util\XMLDoc.cpp" />
     <ClCompile Include="..\..\util\VarText.cpp" />
     <ClCompile Include="..\..\util\Version.cpp" />
+    <ClCompile Include="StdAfx.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release-XP|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+    </ClCompile>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/msvc2017/Common/Common.vcxproj.filters
+++ b/msvc2017/Common/Common.vcxproj.filters
@@ -250,6 +250,7 @@
     <ClInclude Include="..\..\util\CheckSums.h">
       <Filter>Header Files\util</Filter>
     </ClInclude>
+    <ClInclude Include="StdAfx.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\network\MessageQueue.cpp">
@@ -450,6 +451,7 @@
     <ClCompile Include="..\..\util\CheckSums.cpp">
       <Filter>Source Files\util</Filter>
     </ClCompile>
+    <ClCompile Include="StdAfx.cpp" />
   </ItemGroup>
   <ItemGroup>
     <CustomBuild Include="..\..\util\Version.cpp.in">

--- a/msvc2017/Common/StdAfx.cpp
+++ b/msvc2017/Common/StdAfx.cpp
@@ -1,0 +1,1 @@
+#include "StdAfx.h"

--- a/msvc2017/Common/StdAfx.h
+++ b/msvc2017/Common/StdAfx.h
@@ -1,0 +1,68 @@
+#pragma once
+
+// I generously include all external headers I found in the project header files,
+// including std and boost. Possibly some of the lesser used can be removed.
+
+// https://hownot2code.com/2016/08/16/stdafx-h/
+
+#include <bitset>
+#include <cmath>
+#include <deque>
+#include <functional>
+#include <initializer_list>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <queue>
+#include <set>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <boost/any.hpp>
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+#include <boost/archive/xml_iarchive.hpp>
+#include <boost/archive/xml_oarchive.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/date_time/posix_time/posix_time_types.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/filesystem/fstream.hpp>
+#include <boost/filesystem/operations.hpp>
+#include <boost/filesystem/path.hpp>
+#include <boost/functional/hash.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/log/expressions/keyword.hpp>
+#include <boost/log/sinks/sync_frontend.hpp>
+#include <boost/log/sinks/text_file_backend.hpp>
+#include <boost/log/sources/global_logger_storage.hpp>
+#include <boost/log/sources/severity_channel_logger.hpp>
+#include <boost/log/utility/manipulators/add_value.hpp>
+#include <boost/optional/optional.hpp>
+#include <boost/optional/optional_fwd.hpp>
+#include <boost/preprocessor/seq/for_each.hpp>
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/random/normal_distribution.hpp>
+#include <boost/random/uniform_01.hpp>
+#include <boost/random/uniform_int.hpp>
+#include <boost/random/uniform_real.hpp>
+#include <boost/random/uniform_smallint.hpp>
+#include <boost/random/variate_generator.hpp>
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/nvp.hpp>
+#include <boost/shared_array.hpp>
+#include <boost/signals2/signal.hpp>
+#include <boost/statechart/event.hpp>
+#include <boost/thread/condition.hpp>
+#include <boost/thread/mutex.hpp>
+#include <boost/unordered_map.hpp>
+#include <boost/uuid/uuid.hpp>
+
+// Note: The is a workaround for Visual C++ non-conformant pre-processor
+// handling of empty macro arguments.
+#include <boost/preprocessor/control/if.hpp>
+#include <boost/preprocessor/facilities/is_empty_variadic.hpp>
+
+#include <GG/Clr.h>

--- a/msvc2017/Common/StdAfx.h
+++ b/msvc2017/Common/StdAfx.h
@@ -1,38 +1,52 @@
+
 #pragma once
 
-// I generously include all external headers I found in the project header files,
-// including std and boost. Possibly some of the lesser used can be removed.
+// We include all external headers used in any of the header files,
+// plus external headers used in at least five .cpp files.
 
-// https://hownot2code.com/2016/08/16/stdafx-h/
+// https://hownot2code.com/2016/08/16/stdafx-h/ 
 
+// ----------------
+// includes from .h
+
+// Common
+#include <array>
 #include <bitset>
+#include <chrono>
 #include <cmath>
+#include <ctime>
 #include <deque>
-#include <functional>
-#include <initializer_list>
+#include <future>
 #include <iostream>
+#include <iterator>
+#include <list>
 #include <map>
 #include <memory>
-#include <queue>
+#include <mutex>
+#include <random>
 #include <set>
+#include <stdexcept>
 #include <string>
 #include <tuple>
+#include <typeinfo>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
+#include <boost/algorithm/string/case_conv.hpp>
 #include <boost/any.hpp>
 #include <boost/archive/binary_iarchive.hpp>
 #include <boost/archive/binary_oarchive.hpp>
 #include <boost/archive/xml_iarchive.hpp>
 #include <boost/archive/xml_oarchive.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
+#include <boost/format.hpp>
 #include <boost/functional/hash.hpp>
+#include <boost/iterator/filter_iterator.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/log/expressions/keyword.hpp>
 #include <boost/log/sinks/sync_frontend.hpp>
@@ -40,9 +54,12 @@
 #include <boost/log/sources/global_logger_storage.hpp>
 #include <boost/log/sources/severity_channel_logger.hpp>
 #include <boost/log/utility/manipulators/add_value.hpp>
+#include <boost/multi_index/key_extractors.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index_container.hpp>
 #include <boost/optional/optional.hpp>
 #include <boost/optional/optional_fwd.hpp>
-#include <boost/preprocessor/seq/for_each.hpp>
+#include <boost/python/detail/destroy.hpp>
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random/normal_distribution.hpp>
 #include <boost/random/uniform_01.hpp>
@@ -51,18 +68,31 @@
 #include <boost/random/uniform_smallint.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <boost/serialization/access.hpp>
+#include <boost/serialization/export.hpp>
 #include <boost/serialization/nvp.hpp>
+#include <boost/serialization/split_member.hpp>
+#include <boost/serialization/version.hpp>
 #include <boost/shared_array.hpp>
+#include <boost/signals2/optional_last_value.hpp>
 #include <boost/signals2/signal.hpp>
-#include <boost/statechart/event.hpp>
 #include <boost/thread/condition.hpp>
 #include <boost/thread/mutex.hpp>
+#include <boost/thread/shared_mutex.hpp>
+#include <boost/type_traits/remove_const.hpp>
 #include <boost/unordered_map.hpp>
+#include <boost/uuid/nil_generator.hpp>
 #include <boost/uuid/uuid.hpp>
+#include <boost/variant.hpp>
 
-// Note: The is a workaround for Visual C++ non-conformant pre-processor
+// ------------------
+// includes from .cpp
+#include <sstream>
+
+#include <boost/smart_ptr/make_unique.hpp>
+
+#ifdef _MSC_VER
+// Note: This is a workaround for Visual C++ non-conformant pre-processor
 // handling of empty macro arguments.
 #include <boost/preprocessor/control/if.hpp>
 #include <boost/preprocessor/facilities/is_empty_variadic.hpp>
-
-#include <GG/Clr.h>
+#endif

--- a/msvc2017/FreeOrion/FreeOrion.vcxproj
+++ b/msvc2017/FreeOrion/FreeOrion.vcxproj
@@ -73,10 +73,11 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
+      <PrecompiledHeader>Use</PrecompiledHeader>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
+      <ForcedIncludeFiles>StdAfx.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -85,19 +86,18 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeader>Use</PrecompiledHeader>
       <Optimization>Full</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;FREEORION_BUILD_HUMAN;FREEORION_WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../../../include/;../../GG/;../include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PrecompiledHeaderFile>
-      </PrecompiledHeaderFile>
-      <PrecompiledHeaderOutputFile>
-      </PrecompiledHeaderOutputFile>
+      <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>$(IntDir)$(TargetName).pch</PrecompiledHeaderOutputFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <WholeProgramOptimization>false</WholeProgramOptimization>
+      <ForcedIncludeFiles>StdAfx.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -114,19 +114,18 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release-XP|Win32'">
     <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeader>Use</PrecompiledHeader>
       <Optimization>Full</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;FREEORION_BUILD_HUMAN;FREEORION_WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../../../include/;../../GG/;../include/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PrecompiledHeaderFile>
-      </PrecompiledHeaderFile>
-      <PrecompiledHeaderOutputFile>
-      </PrecompiledHeaderOutputFile>
+      <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>$(IntDir)$(TargetName).pch</PrecompiledHeaderOutputFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <WholeProgramOptimization>false</WholeProgramOptimization>
+      <ForcedIncludeFiles>StdAfx.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -258,6 +257,7 @@
     <ClInclude Include="..\..\util\VarText.h" />
     <ClInclude Include="..\..\util\Version.h" />
     <ClInclude Include="..\..\util\XMLDoc.h" />
+    <ClInclude Include="StdAfx.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\FreeOrion.ico" />
@@ -283,6 +283,11 @@
     <ClCompile Include="..\..\UI\CUIControls.cpp" />
     <ClCompile Include="..\..\UI\CUIDrawUtil.cpp" />
     <ClCompile Include="..\..\UI\CUILinkTextBlock.cpp" />
+    <ClCompile Include="StdAfx.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release-XP|Win32'">Create</PrecompiledHeader>
+    </ClCompile>
     <ClInclude Include="..\..\UI\CUILinkTextBlock.h" />
     <ClCompile Include="..\..\UI\CUIStyle.cpp" />
     <ClCompile Include="..\..\UI\CUIWnd.cpp" />

--- a/msvc2017/FreeOrion/FreeOrion.vcxproj.filters
+++ b/msvc2017/FreeOrion/FreeOrion.vcxproj.filters
@@ -408,9 +408,7 @@
     <ClInclude Include="..\..\UI\PasswordEnterWnd.h">
       <Filter>Header Files\UI</Filter>
     </ClInclude>
-    <ClInclude Include="StdAfx.h">
-      <Filter>Header Files</Filter>
-    </ClInclude>
+    <ClInclude Include="StdAfx.h" />
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\FreeOrion.ico">
@@ -616,9 +614,7 @@
     <ClCompile Include="..\..\UI\PasswordEnterWnd.cpp">
       <Filter>Source Files\UI</Filter>
     </ClCompile>
-    <ClCompile Include="StdAfx.cpp">
-      <Filter>Header Files</Filter>
-    </ClCompile>
+    <ClCompile Include="StdAfx.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ResourceCompile Include="..\..\client\human\FreeOrion.rc">

--- a/msvc2017/FreeOrion/FreeOrion.vcxproj.filters
+++ b/msvc2017/FreeOrion/FreeOrion.vcxproj.filters
@@ -408,6 +408,9 @@
     <ClInclude Include="..\..\UI\PasswordEnterWnd.h">
       <Filter>Header Files\UI</Filter>
     </ClInclude>
+    <ClInclude Include="StdAfx.h">
+      <Filter>Header Files</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <None Include="..\..\FreeOrion.ico">
@@ -612,6 +615,9 @@
     </ClCompile>
     <ClCompile Include="..\..\UI\PasswordEnterWnd.cpp">
       <Filter>Source Files\UI</Filter>
+    </ClCompile>
+    <ClCompile Include="StdAfx.cpp">
+      <Filter>Header Files</Filter>
     </ClCompile>
   </ItemGroup>
   <ItemGroup>

--- a/msvc2017/FreeOrion/StdAfx.cpp
+++ b/msvc2017/FreeOrion/StdAfx.cpp
@@ -1,0 +1,1 @@
+#include "StdAfx.h"

--- a/msvc2017/FreeOrion/StdAfx.h
+++ b/msvc2017/FreeOrion/StdAfx.h
@@ -1,0 +1,104 @@
+#pragma once
+
+// I generously include all external headers I found in the project header files,
+// including std, boost and GG headers.
+
+// https://hownot2code.com/2016/08/16/stdafx-h/
+
+
+#include <bitset>
+#include <cmath>
+#include <deque>
+#include <functional>
+#include <initializer_list>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <queue>
+#include <set>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <boost/any.hpp>
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+#include <boost/archive/xml_iarchive.hpp>
+#include <boost/archive/xml_oarchive.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/date_time/posix_time/posix_time_types.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/filesystem/fstream.hpp>
+#include <boost/filesystem/operations.hpp>
+#include <boost/filesystem/path.hpp>
+#include <boost/functional/hash.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/log/expressions/keyword.hpp>
+#include <boost/log/sinks/sync_frontend.hpp>
+#include <boost/log/sinks/text_file_backend.hpp>
+#include <boost/log/sources/global_logger_storage.hpp>
+#include <boost/log/sources/severity_channel_logger.hpp>
+#include <boost/log/utility/manipulators/add_value.hpp>
+#include <boost/optional/optional.hpp>
+#include <boost/optional/optional_fwd.hpp>
+#include <boost/preprocessor/seq/for_each.hpp>
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/random/normal_distribution.hpp>
+#include <boost/random/uniform_01.hpp>
+#include <boost/random/uniform_int.hpp>
+#include <boost/random/uniform_real.hpp>
+#include <boost/random/uniform_smallint.hpp>
+#include <boost/random/variate_generator.hpp>
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/nvp.hpp>
+#include <boost/shared_array.hpp>
+#include <boost/signals2/signal.hpp>
+#include <boost/statechart/event.hpp>
+#include <boost/thread/condition.hpp>
+#include <boost/thread/mutex.hpp>
+#include <boost/unordered_map.hpp>
+#include <boost/uuid/uuid.hpp>
+
+// Note: The is a workaround for Visual C++ non-conformant pre-processor
+// handling of empty macro arguments.
+#include <boost/preprocessor/control/if.hpp>
+#include <boost/preprocessor/facilities/is_empty_variadic.hpp>
+
+
+#include <GG/GGFwd.h>
+#include <GG/Base.h>
+#include <GG/BrowseInfoWnd.h>
+#include <GG/Button.h>
+#include <GG/Clr.h>
+#include <GG/Control.h>
+#include <GG/DropDownList.h>
+#include <GG/DynamicGraphic.h>
+#include <GG/Edit.h>
+#include <GG/Enum.h>
+#include <GG/GGFwd.h>
+#include <GG/GLClientAndServerBuffer.h>
+#include <GG/GUI.h>
+#include <GG/Layout.h>
+#include <GG/ListBox.h>
+#include <GG/ListBox.h>
+#include <GG/Menu.h>
+#include <GG/MultiEdit.h>
+#include <GG/PtRect.h>
+#include <GG/PtRect.h>
+#include <GG/RichText/BlockControl.h>
+#include <GG/RichText/RichText.h>
+#include <GG/SDL/SDLGUI.h>
+#include <GG/Scroll.h>
+#include <GG/Slider.h>
+#include <GG/Slider.h>
+#include <GG/Spin.h>
+#include <GG/StaticGraphic.h>
+#include <GG/StyleFactory.h>
+#include <GG/TabWnd.h>
+#include <GG/Texture.h>
+#include <GG/Wnd.h>
+#include <GG/Wnd.h>
+#include <GG/WndEvent.h>
+#include <GG/dialogs/FileDlg.h>

--- a/msvc2017/FreeOrion/StdAfx.h
+++ b/msvc2017/FreeOrion/StdAfx.h
@@ -1,39 +1,52 @@
+
 #pragma once
 
-// I generously include all external headers I found in the project header files,
-// including std, boost and GG headers.
+// We include all external headers used in any of the header files,
+// plus external headers used in at least five .cpp files.
 
-// https://hownot2code.com/2016/08/16/stdafx-h/
+// https://hownot2code.com/2016/08/16/stdafx-h/ 
 
+// ----------------
+// includes from .h
 
+// Common
+#include <array>
 #include <bitset>
+#include <chrono>
 #include <cmath>
+#include <ctime>
 #include <deque>
-#include <functional>
-#include <initializer_list>
+#include <future>
 #include <iostream>
+#include <iterator>
+#include <list>
 #include <map>
 #include <memory>
-#include <queue>
+#include <mutex>
+#include <random>
 #include <set>
+#include <stdexcept>
 #include <string>
 #include <tuple>
+#include <typeinfo>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
+#include <boost/algorithm/string/case_conv.hpp>
 #include <boost/any.hpp>
 #include <boost/archive/binary_iarchive.hpp>
 #include <boost/archive/binary_oarchive.hpp>
 #include <boost/archive/xml_iarchive.hpp>
 #include <boost/archive/xml_oarchive.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
+#include <boost/format.hpp>
 #include <boost/functional/hash.hpp>
+#include <boost/iterator/filter_iterator.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/log/expressions/keyword.hpp>
 #include <boost/log/sinks/sync_frontend.hpp>
@@ -41,9 +54,12 @@
 #include <boost/log/sources/global_logger_storage.hpp>
 #include <boost/log/sources/severity_channel_logger.hpp>
 #include <boost/log/utility/manipulators/add_value.hpp>
+#include <boost/multi_index/key_extractors.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index_container.hpp>
 #include <boost/optional/optional.hpp>
 #include <boost/optional/optional_fwd.hpp>
-#include <boost/preprocessor/seq/for_each.hpp>
+#include <boost/python/detail/destroy.hpp>
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random/normal_distribution.hpp>
 #include <boost/random/uniform_01.hpp>
@@ -52,53 +68,69 @@
 #include <boost/random/uniform_smallint.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <boost/serialization/access.hpp>
+#include <boost/serialization/export.hpp>
 #include <boost/serialization/nvp.hpp>
+#include <boost/serialization/split_member.hpp>
+#include <boost/serialization/version.hpp>
 #include <boost/shared_array.hpp>
+#include <boost/signals2/optional_last_value.hpp>
 #include <boost/signals2/signal.hpp>
-#include <boost/statechart/event.hpp>
 #include <boost/thread/condition.hpp>
 #include <boost/thread/mutex.hpp>
+#include <boost/thread/shared_mutex.hpp>
+#include <boost/type_traits/remove_const.hpp>
 #include <boost/unordered_map.hpp>
+#include <boost/uuid/nil_generator.hpp>
 #include <boost/uuid/uuid.hpp>
+#include <boost/variant.hpp>
 
-// Note: The is a workaround for Visual C++ non-conformant pre-processor
+// GiGi
+#include <cassert>
+#include <climits>
+#include <cstdint>
+#include <cstdlib>
+#include <functional>
+#include <iosfwd>
+#include <limits>
+#include <sstream>
+#include <stack>
+
+#include <GL/glew.h>
+
+#include <boost/algorithm/string/trim.hpp>
+#include <boost/function.hpp>
+#include <boost/graph/graph_concepts.hpp>
+#include <boost/mpl/assert.hpp>
+#include <boost/signals2/trackable.hpp>
+#include <boost/static_assert.hpp>
+#include <boost/type_traits/is_integral.hpp>
+#include <boost/utility/enable_if.hpp>
+
+// FreeOrion
+#include <initializer_list>
+#include <queue>
+#include <utility>
+
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/preprocessor/seq/for_each.hpp>
+#include <boost/signals2/shared_connection_block.hpp>
+#include <boost/statechart/custom_reaction.hpp>
+#include <boost/statechart/deferral.hpp>
+#include <boost/statechart/event.hpp>
+#include <boost/statechart/simple_state.hpp>
+#include <boost/statechart/state.hpp>
+#include <boost/statechart/state_machine.hpp>
+
+// ------------------
+// includes from .cpp
+#include <algorithm>
+
+#include <boost/algorithm/string/predicate.hpp>
+#include <boost/cast.hpp>
+
+#ifdef _MSC_VER
+// Note: This is a workaround for Visual C++ non-conformant pre-processor
 // handling of empty macro arguments.
 #include <boost/preprocessor/control/if.hpp>
 #include <boost/preprocessor/facilities/is_empty_variadic.hpp>
-
-
-#include <GG/GGFwd.h>
-#include <GG/Base.h>
-#include <GG/BrowseInfoWnd.h>
-#include <GG/Button.h>
-#include <GG/Clr.h>
-#include <GG/Control.h>
-#include <GG/DropDownList.h>
-#include <GG/DynamicGraphic.h>
-#include <GG/Edit.h>
-#include <GG/Enum.h>
-#include <GG/GGFwd.h>
-#include <GG/GLClientAndServerBuffer.h>
-#include <GG/GUI.h>
-#include <GG/Layout.h>
-#include <GG/ListBox.h>
-#include <GG/ListBox.h>
-#include <GG/Menu.h>
-#include <GG/MultiEdit.h>
-#include <GG/PtRect.h>
-#include <GG/PtRect.h>
-#include <GG/RichText/BlockControl.h>
-#include <GG/RichText/RichText.h>
-#include <GG/SDL/SDLGUI.h>
-#include <GG/Scroll.h>
-#include <GG/Slider.h>
-#include <GG/Slider.h>
-#include <GG/Spin.h>
-#include <GG/StaticGraphic.h>
-#include <GG/StyleFactory.h>
-#include <GG/TabWnd.h>
-#include <GG/Texture.h>
-#include <GG/Wnd.h>
-#include <GG/Wnd.h>
-#include <GG/WndEvent.h>
-#include <GG/dialogs/FileDlg.h>
+#endif

--- a/msvc2017/FreeOrionCA/FreeOrionCA.vcxproj
+++ b/msvc2017/FreeOrionCA/FreeOrionCA.vcxproj
@@ -66,10 +66,11 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
+      <PrecompiledHeader>Use</PrecompiledHeader>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
+      <ForcedIncludeFiles>StdAfx.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -78,19 +79,18 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeader>Use</PrecompiledHeader>
       <Optimization>Full</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;FREEORION_BUILD_AI;FREEORION_WIN32;GiGi_EXPORTS;_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../../../include/;../../GG/;../../../include/python2.7/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PrecompiledHeaderFile>
-      </PrecompiledHeaderFile>
-      <PrecompiledHeaderOutputFile>
-      </PrecompiledHeaderOutputFile>
+      <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>$(IntDir)$(TargetName).pch</PrecompiledHeaderOutputFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <ForcedIncludeFiles>StdAfx.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -106,19 +106,18 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release-XP|Win32'">
     <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeader>Use</PrecompiledHeader>
       <Optimization>Full</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;FREEORION_BUILD_AI;FREEORION_WIN32;GiGi_EXPORTS;_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../../../include/;../../GG/;../../../include/python2.7/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PrecompiledHeaderFile>
-      </PrecompiledHeaderFile>
-      <PrecompiledHeaderOutputFile>
-      </PrecompiledHeaderOutputFile>
+      <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>$(IntDir)$(TargetName).pch</PrecompiledHeaderOutputFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <ForcedIncludeFiles>StdAfx.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -196,6 +195,7 @@
     <ClInclude Include="..\..\util\VarText.h" />
     <ClInclude Include="..\..\util\Version.h" />
     <ClInclude Include="..\..\util\XMLDoc.h" />
+    <ClInclude Include="StdAfx.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\AI\AIInterface.cpp" />
@@ -213,6 +213,11 @@
     <ClCompile Include="..\..\python\LoggingWrapper.cpp" />
     <ClCompile Include="..\..\python\UniverseWrapper.cpp" />
     <ClCompile Include="..\..\util\DependencyVersions.cpp" />
+    <ClCompile Include="StdAfx.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release-XP|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+    </ClCompile>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/msvc2017/FreeOrionCA/FreeOrionCA.vcxproj.filters
+++ b/msvc2017/FreeOrionCA/FreeOrionCA.vcxproj.filters
@@ -251,6 +251,7 @@
     <ClInclude Include="..\..\python\CommonFramework.h">
       <Filter>Header Files\python</Filter>
     </ClInclude>
+    <ClInclude Include="StdAfx.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\client\ClientApp.cpp">
@@ -298,5 +299,6 @@
     <ClCompile Include="..\..\python\ConfigWrapper.cpp">
       <Filter>Source Files\python</Filter>
     </ClCompile>
+    <ClCompile Include="StdAfx.cpp" />
   </ItemGroup>
 </Project>

--- a/msvc2017/FreeOrionCA/StdAfx.cpp
+++ b/msvc2017/FreeOrionCA/StdAfx.cpp
@@ -1,0 +1,1 @@
+#include "StdAfx.h"

--- a/msvc2017/FreeOrionCA/StdAfx.h
+++ b/msvc2017/FreeOrionCA/StdAfx.h
@@ -1,0 +1,69 @@
+#pragma once
+
+// I generously include all external headers I found in the project header files,
+// including std and boost. Possibly some of the lesser used can be removed.
+
+// https://hownot2code.com/2016/08/16/stdafx-h/
+
+#include <bitset>
+#include <cmath>
+#include <deque>
+#include <functional>
+#include <initializer_list>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <queue>
+#include <set>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <boost/any.hpp>
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+#include <boost/archive/xml_iarchive.hpp>
+#include <boost/archive/xml_oarchive.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/date_time/posix_time/posix_time_types.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/filesystem/fstream.hpp>
+#include <boost/filesystem/operations.hpp>
+#include <boost/filesystem/path.hpp>
+#include <boost/functional/hash.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/log/expressions/keyword.hpp>
+#include <boost/log/sinks/sync_frontend.hpp>
+#include <boost/log/sinks/text_file_backend.hpp>
+#include <boost/log/sources/global_logger_storage.hpp>
+#include <boost/log/sources/severity_channel_logger.hpp>
+#include <boost/log/utility/manipulators/add_value.hpp>
+#include <boost/optional/optional.hpp>
+#include <boost/optional/optional_fwd.hpp>
+#include <boost/preprocessor/seq/for_each.hpp>
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/random/normal_distribution.hpp>
+#include <boost/random/uniform_01.hpp>
+#include <boost/random/uniform_int.hpp>
+#include <boost/random/uniform_real.hpp>
+#include <boost/random/uniform_smallint.hpp>
+#include <boost/random/variate_generator.hpp>
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/nvp.hpp>
+#include <boost/shared_array.hpp>
+#include <boost/signals2/signal.hpp>
+#include <boost/statechart/event.hpp>
+#include <boost/thread/condition.hpp>
+#include <boost/thread/mutex.hpp>
+#include <boost/unordered_map.hpp>
+#include <boost/uuid/uuid.hpp>
+
+// Note: The is a workaround for Visual C++ non-conformant pre-processor
+// handling of empty macro arguments.
+#include <boost/preprocessor/control/if.hpp>
+#include <boost/preprocessor/facilities/is_empty_variadic.hpp>
+
+#include <GG/Clr.h>
+

--- a/msvc2017/FreeOrionCA/StdAfx.h
+++ b/msvc2017/FreeOrionCA/StdAfx.h
@@ -1,38 +1,52 @@
+
 #pragma once
 
-// I generously include all external headers I found in the project header files,
-// including std and boost. Possibly some of the lesser used can be removed.
+// We include all external headers used in any of the header files,
+// plus external headers used in at least five .cpp files.
 
-// https://hownot2code.com/2016/08/16/stdafx-h/
+// https://hownot2code.com/2016/08/16/stdafx-h/ 
 
+// ----------------
+// includes from .h
+
+// Common
+#include <array>
 #include <bitset>
+#include <chrono>
 #include <cmath>
+#include <ctime>
 #include <deque>
-#include <functional>
-#include <initializer_list>
+#include <future>
 #include <iostream>
+#include <iterator>
+#include <list>
 #include <map>
 #include <memory>
-#include <queue>
+#include <mutex>
+#include <random>
 #include <set>
+#include <stdexcept>
 #include <string>
 #include <tuple>
+#include <typeinfo>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
+#include <boost/algorithm/string/case_conv.hpp>
 #include <boost/any.hpp>
 #include <boost/archive/binary_iarchive.hpp>
 #include <boost/archive/binary_oarchive.hpp>
 #include <boost/archive/xml_iarchive.hpp>
 #include <boost/archive/xml_oarchive.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
+#include <boost/format.hpp>
 #include <boost/functional/hash.hpp>
+#include <boost/iterator/filter_iterator.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/log/expressions/keyword.hpp>
 #include <boost/log/sinks/sync_frontend.hpp>
@@ -40,9 +54,12 @@
 #include <boost/log/sources/global_logger_storage.hpp>
 #include <boost/log/sources/severity_channel_logger.hpp>
 #include <boost/log/utility/manipulators/add_value.hpp>
+#include <boost/multi_index/key_extractors.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index_container.hpp>
 #include <boost/optional/optional.hpp>
 #include <boost/optional/optional_fwd.hpp>
-#include <boost/preprocessor/seq/for_each.hpp>
+#include <boost/python/detail/destroy.hpp>
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random/normal_distribution.hpp>
 #include <boost/random/uniform_01.hpp>
@@ -51,19 +68,34 @@
 #include <boost/random/uniform_smallint.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <boost/serialization/access.hpp>
+#include <boost/serialization/export.hpp>
 #include <boost/serialization/nvp.hpp>
+#include <boost/serialization/split_member.hpp>
+#include <boost/serialization/version.hpp>
 #include <boost/shared_array.hpp>
+#include <boost/signals2/optional_last_value.hpp>
 #include <boost/signals2/signal.hpp>
-#include <boost/statechart/event.hpp>
 #include <boost/thread/condition.hpp>
 #include <boost/thread/mutex.hpp>
+#include <boost/thread/shared_mutex.hpp>
+#include <boost/type_traits/remove_const.hpp>
 #include <boost/unordered_map.hpp>
+#include <boost/uuid/nil_generator.hpp>
 #include <boost/uuid/uuid.hpp>
+#include <boost/variant.hpp>
 
-// Note: The is a workaround for Visual C++ non-conformant pre-processor
+// FreeOrionCA
+#include <sstream>
+
+#include <boost/preprocessor/seq/for_each.hpp>
+#include <boost/python.hpp>
+#include <boost/python/dict.hpp>
+#include <boost/python/str.hpp>
+#include <boost/statechart/event.hpp>
+
+#ifdef _MSC_VER
+// Note: This is a workaround for Visual C++ non-conformant pre-processor
 // handling of empty macro arguments.
 #include <boost/preprocessor/control/if.hpp>
 #include <boost/preprocessor/facilities/is_empty_variadic.hpp>
-
-#include <GG/Clr.h>
-
+#endif

--- a/msvc2017/FreeOrionD/FreeOrionD.vcxproj
+++ b/msvc2017/FreeOrionD/FreeOrionD.vcxproj
@@ -66,10 +66,11 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
+      <PrecompiledHeader>Use</PrecompiledHeader>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
+      <ForcedIncludeFiles>StdAfx.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -78,19 +79,18 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeader>Use</PrecompiledHeader>
       <Optimization>Full</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;FREEORION_BUILD_SERVER;FREEORION_WIN32;GiGi_EXPORTS;_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../../../include/;../../GG/;../../../include/python2.7/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PrecompiledHeaderFile>
-      </PrecompiledHeaderFile>
-      <PrecompiledHeaderOutputFile>
-      </PrecompiledHeaderOutputFile>
+      <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>$(IntDir)$(TargetName).pch</PrecompiledHeaderOutputFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <ForcedIncludeFiles>StdAfx.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -106,19 +106,18 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release-XP|Win32'">
     <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeader>Use</PrecompiledHeader>
       <Optimization>Full</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;FREEORION_BUILD_SERVER;FREEORION_WIN32;GiGi_EXPORTS;_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../../../include/;../../GG/;../../../include/python2.7/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
-      <PrecompiledHeaderFile>
-      </PrecompiledHeaderFile>
-      <PrecompiledHeaderOutputFile>
-      </PrecompiledHeaderOutputFile>
+      <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>$(IntDir)$(TargetName).pch</PrecompiledHeaderOutputFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <WholeProgramOptimization>true</WholeProgramOptimization>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <ForcedIncludeFiles>StdAfx.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -193,6 +192,7 @@
     <ClInclude Include="..\..\util\VarText.h" />
     <ClInclude Include="..\..\util\Version.h" />
     <ClInclude Include="..\..\util\XMLDoc.h" />
+    <ClInclude Include="StdAfx.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\combat\CombatSystem.cpp" />
@@ -212,6 +212,11 @@
     <ClCompile Include="..\..\universe\UniverseGenerator.cpp" />
     <ClCompile Include="..\..\util\Process.cpp" />
     <ClCompile Include="..\..\util\DependencyVersions.cpp" />
+    <ClCompile Include="StdAfx.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release-XP|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+    </ClCompile>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/msvc2017/FreeOrionD/FreeOrionD.vcxproj.filters
+++ b/msvc2017/FreeOrionD/FreeOrionD.vcxproj.filters
@@ -236,6 +236,7 @@
     <ClInclude Include="..\..\python\SetWrapper.h">
       <Filter>Header Files\python</Filter>
     </ClInclude>
+    <ClInclude Include="StdAfx.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\network\ServerNetworking.cpp">
@@ -289,5 +290,6 @@
     <ClCompile Include="..\..\python\ConfigWrapper.cpp">
       <Filter>Source Files\python</Filter>
     </ClCompile>
+    <ClCompile Include="StdAfx.cpp" />
   </ItemGroup>
 </Project>

--- a/msvc2017/FreeOrionD/StdAfx.cpp
+++ b/msvc2017/FreeOrionD/StdAfx.cpp
@@ -1,0 +1,1 @@
+#include "StdAfx.h"

--- a/msvc2017/FreeOrionD/StdAfx.h
+++ b/msvc2017/FreeOrionD/StdAfx.h
@@ -1,0 +1,69 @@
+#pragma once
+
+// I generously include all external headers I found in the project header files,
+// including std and boost. Possibly some of the lesser used can be removed.
+
+// https://hownot2code.com/2016/08/16/stdafx-h/
+
+#include <bitset>
+#include <cmath>
+#include <deque>
+#include <functional>
+#include <initializer_list>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <queue>
+#include <set>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <boost/any.hpp>
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+#include <boost/archive/xml_iarchive.hpp>
+#include <boost/archive/xml_oarchive.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/date_time/posix_time/posix_time_types.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/filesystem/fstream.hpp>
+#include <boost/filesystem/operations.hpp>
+#include <boost/filesystem/path.hpp>
+#include <boost/functional/hash.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/log/expressions/keyword.hpp>
+#include <boost/log/sinks/sync_frontend.hpp>
+#include <boost/log/sinks/text_file_backend.hpp>
+#include <boost/log/sources/global_logger_storage.hpp>
+#include <boost/log/sources/severity_channel_logger.hpp>
+#include <boost/log/utility/manipulators/add_value.hpp>
+#include <boost/optional/optional.hpp>
+#include <boost/optional/optional_fwd.hpp>
+#include <boost/preprocessor/seq/for_each.hpp>
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/random/normal_distribution.hpp>
+#include <boost/random/uniform_01.hpp>
+#include <boost/random/uniform_int.hpp>
+#include <boost/random/uniform_real.hpp>
+#include <boost/random/uniform_smallint.hpp>
+#include <boost/random/variate_generator.hpp>
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/nvp.hpp>
+#include <boost/shared_array.hpp>
+#include <boost/signals2/signal.hpp>
+#include <boost/statechart/event.hpp>
+#include <boost/thread/condition.hpp>
+#include <boost/thread/mutex.hpp>
+#include <boost/unordered_map.hpp>
+#include <boost/uuid/uuid.hpp>
+
+// Note: The is a workaround for Visual C++ non-conformant pre-processor
+// handling of empty macro arguments.
+#include <boost/preprocessor/control/if.hpp>
+#include <boost/preprocessor/facilities/is_empty_variadic.hpp>
+
+#include <GG/Clr.h>
+

--- a/msvc2017/FreeOrionD/StdAfx.h
+++ b/msvc2017/FreeOrionD/StdAfx.h
@@ -1,38 +1,52 @@
+
 #pragma once
 
-// I generously include all external headers I found in the project header files,
-// including std and boost. Possibly some of the lesser used can be removed.
+// We include all external headers used in any of the header files,
+// plus external headers used in at least five .cpp files.
 
-// https://hownot2code.com/2016/08/16/stdafx-h/
+// https://hownot2code.com/2016/08/16/stdafx-h/ 
 
+// ----------------
+// includes from .h
+
+// Common
+#include <array>
 #include <bitset>
+#include <chrono>
 #include <cmath>
+#include <ctime>
 #include <deque>
-#include <functional>
-#include <initializer_list>
+#include <future>
 #include <iostream>
+#include <iterator>
+#include <list>
 #include <map>
 #include <memory>
-#include <queue>
+#include <mutex>
+#include <random>
 #include <set>
+#include <stdexcept>
 #include <string>
 #include <tuple>
+#include <typeinfo>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
 
+#include <boost/algorithm/string/case_conv.hpp>
 #include <boost/any.hpp>
 #include <boost/archive/binary_iarchive.hpp>
 #include <boost/archive/binary_oarchive.hpp>
 #include <boost/archive/xml_iarchive.hpp>
 #include <boost/archive/xml_oarchive.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/date_time/posix_time/posix_time_types.hpp>
 #include <boost/filesystem.hpp>
 #include <boost/filesystem/fstream.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/path.hpp>
+#include <boost/format.hpp>
 #include <boost/functional/hash.hpp>
+#include <boost/iterator/filter_iterator.hpp>
 #include <boost/lexical_cast.hpp>
 #include <boost/log/expressions/keyword.hpp>
 #include <boost/log/sinks/sync_frontend.hpp>
@@ -40,9 +54,12 @@
 #include <boost/log/sources/global_logger_storage.hpp>
 #include <boost/log/sources/severity_channel_logger.hpp>
 #include <boost/log/utility/manipulators/add_value.hpp>
+#include <boost/multi_index/key_extractors.hpp>
+#include <boost/multi_index/ordered_index.hpp>
+#include <boost/multi_index_container.hpp>
 #include <boost/optional/optional.hpp>
 #include <boost/optional/optional_fwd.hpp>
-#include <boost/preprocessor/seq/for_each.hpp>
+#include <boost/python/detail/destroy.hpp>
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/random/normal_distribution.hpp>
 #include <boost/random/uniform_01.hpp>
@@ -51,19 +68,43 @@
 #include <boost/random/uniform_smallint.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <boost/serialization/access.hpp>
+#include <boost/serialization/export.hpp>
 #include <boost/serialization/nvp.hpp>
+#include <boost/serialization/split_member.hpp>
+#include <boost/serialization/version.hpp>
 #include <boost/shared_array.hpp>
+#include <boost/signals2/optional_last_value.hpp>
 #include <boost/signals2/signal.hpp>
-#include <boost/statechart/event.hpp>
 #include <boost/thread/condition.hpp>
 #include <boost/thread/mutex.hpp>
+#include <boost/thread/shared_mutex.hpp>
+#include <boost/type_traits/remove_const.hpp>
 #include <boost/unordered_map.hpp>
+#include <boost/uuid/nil_generator.hpp>
 #include <boost/uuid/uuid.hpp>
+#include <boost/variant.hpp>
 
-// Note: The is a workaround for Visual C++ non-conformant pre-processor
+// FreeOrionD
+#include <queue>
+
+#include <boost/asio.hpp>
+#include <boost/asio/high_resolution_timer.hpp>
+#include <boost/circular_buffer.hpp>
+#include <boost/function.hpp>
+#include <boost/mpl/list.hpp>
+#include <boost/preprocessor/seq/for_each.hpp>
+#include <boost/python.hpp>
+#include <boost/python/dict.hpp>
+#include <boost/statechart/custom_reaction.hpp>
+#include <boost/statechart/deferral.hpp>
+#include <boost/statechart/event.hpp>
+#include <boost/statechart/in_state_reaction.hpp>
+#include <boost/statechart/state.hpp>
+#include <boost/statechart/state_machine.hpp>
+
+#ifdef _MSC_VER
+// Note: This is a workaround for Visual C++ non-conformant pre-processor
 // handling of empty macro arguments.
 #include <boost/preprocessor/control/if.hpp>
 #include <boost/preprocessor/facilities/is_empty_variadic.hpp>
-
-#include <GG/Clr.h>
-
+#endif

--- a/msvc2017/GiGi/GiGi.vcxproj
+++ b/msvc2017/GiGi/GiGi.vcxproj
@@ -68,6 +68,7 @@
     <ClInclude Include="..\..\GG\GG\Wnd.h" />
     <ClInclude Include="..\..\GG\GG\WndEvent.h" />
     <ClInclude Include="..\..\GG\GG\ZList.h" />
+    <ClInclude Include="StdAfx.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\GG\src\AlignmentFlags.cpp" />
@@ -112,6 +113,11 @@
     <ClCompile Include="..\..\GG\src\Wnd.cpp" />
     <ClCompile Include="..\..\GG\src\WndEvent.cpp" />
     <ClCompile Include="..\..\GG\src\ZList.cpp" />
+    <ClCompile Include="StdAfx.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release-XP|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+    </ClCompile>
   </ItemGroup>
   <PropertyGroup Label="Globals">
     <ProjectGuid>{2CEC3AB3-36A0-4037-AEC2-DA0435A4DADB}</ProjectGuid>
@@ -172,7 +178,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeader>Use</PrecompiledHeader>
       <Optimization>Full</Optimization>
       <PreprocessorDefinitions>NDEBUG;_USRDLL;GIGI_EXPORTS;GIGI_CONFIG_USE_OLD_IMPLEMENTATION_OF_GIL_PNG_IO;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../include/GG;../../../include/;../../../include/GG;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
@@ -184,10 +190,9 @@
       <FloatingPointExceptions>false</FloatingPointExceptions>
       <CreateHotpatchableImage>false</CreateHotpatchableImage>
       <OpenMPSupport>false</OpenMPSupport>
-      <PrecompiledHeaderFile>
-      </PrecompiledHeaderFile>
-      <PrecompiledHeaderOutputFile>
-      </PrecompiledHeaderOutputFile>
+      <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>$(IntDir)$(TargetName).pch</PrecompiledHeaderOutputFile>
+      <ForcedIncludeFiles>StdAfx.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -198,19 +203,18 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeader>Use</PrecompiledHeader>
       <Optimization>Full</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_USRDLL;_DLL;GiGi_EXPORTS;GIGI_CONFIG_USE_OLD_IMPLEMENTATION_OF_GIL_PNG_IO;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../include/;../../../include;../../GG/;../../../include/freetype2;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <PrecompiledHeaderFile>
-      </PrecompiledHeaderFile>
-      <PrecompiledHeaderOutputFile>
-      </PrecompiledHeaderOutputFile>
+      <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>$(IntDir)$(TargetName).pch</PrecompiledHeaderOutputFile>
       <WholeProgramOptimization>false</WholeProgramOptimization>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <ForcedIncludeFiles>StdAfx.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -227,19 +231,18 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release-XP|Win32'">
     <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeader>Use</PrecompiledHeader>
       <Optimization>Full</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_USRDLL;_DLL;GiGi_EXPORTS;GIGI_CONFIG_USE_OLD_IMPLEMENTATION_OF_GIL_PNG_IO;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../include/;../../../include;../../GG/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <PrecompiledHeaderFile>
-      </PrecompiledHeaderFile>
-      <PrecompiledHeaderOutputFile>
-      </PrecompiledHeaderOutputFile>
+      <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>$(IntDir)$(TargetName).pch</PrecompiledHeaderOutputFile>
       <WholeProgramOptimization>false</WholeProgramOptimization>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <ForcedIncludeFiles>StdAfx.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/msvc2017/GiGi/GiGi.vcxproj.filters
+++ b/msvc2017/GiGi/GiGi.vcxproj.filters
@@ -185,6 +185,7 @@
     <ClInclude Include="..\..\GG\GG\DeferredLayout.h">
       <Filter>Header Files</Filter>
     </ClInclude>
+    <ClInclude Include="StdAfx.h" />
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="..\..\GG\src\dialogs\FileDlg.cpp">
@@ -313,5 +314,6 @@
     <ClCompile Include="..\..\GG\src\DeferredLayout.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="StdAfx.cpp" />
   </ItemGroup>
 </Project>

--- a/msvc2017/GiGi/StdAfx.cpp
+++ b/msvc2017/GiGi/StdAfx.cpp
@@ -1,0 +1,1 @@
+#include "StdAfx.h"

--- a/msvc2017/GiGi/StdAfx.h
+++ b/msvc2017/GiGi/StdAfx.h
@@ -1,0 +1,57 @@
+
+#pragma once
+
+// We include all external headers used in any of the header files,
+// plus external headers used in at least five .cpp files.
+
+// https://hownot2code.com/2016/08/16/stdafx-h/ 
+
+// ----------------
+// includes from .h
+
+// GiGi
+#include <cassert>
+#include <chrono>
+#include <climits>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <functional>
+#include <iosfwd>
+#include <iostream>
+#include <iterator>
+#include <limits>
+#include <list>
+#include <map>
+#include <memory>
+#include <set>
+#include <sstream>
+#include <stack>
+#include <stdexcept>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include <GL/glew.h>
+
+#include <boost/algorithm/string/trim.hpp>
+#include <boost/filesystem/path.hpp>
+#include <boost/function.hpp>
+#include <boost/functional/hash.hpp>
+#include <boost/graph/graph_concepts.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/mpl/assert.hpp>
+#include <boost/optional/optional.hpp>
+#include <boost/signals2/signal.hpp>
+#include <boost/signals2/trackable.hpp>
+#include <boost/static_assert.hpp>
+#include <boost/type_traits/is_integral.hpp>
+#include <boost/unordered_map.hpp>
+#include <boost/utility/enable_if.hpp>
+
+#ifdef _MSC_VER
+// Note: This is a workaround for Visual C++ non-conformant pre-processor
+// handling of empty macro arguments.
+#include <boost/preprocessor/control/if.hpp>
+#include <boost/preprocessor/facilities/is_empty_variadic.hpp>
+#endif

--- a/msvc2017/Parsers/Parsers.vcxproj
+++ b/msvc2017/Parsers/Parsers.vcxproj
@@ -65,10 +65,11 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>
-      <PrecompiledHeader>
-      </PrecompiledHeader>
+      <PrecompiledHeader>Use</PrecompiledHeader>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_USRDLL;PARSERS_EXPORTS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
+      <ForcedIncludeFiles>StdAfx.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -77,22 +78,21 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeader>Use</PrecompiledHeader>
       <Optimization>MinSpace</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_USRDLL;PARSERS_EXPORTS;FREEORION_WIN32;_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../../../include/;../../GG/;../../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <PrecompiledHeaderFile>
-      </PrecompiledHeaderFile>
-      <PrecompiledHeaderOutputFile>
-      </PrecompiledHeaderOutputFile>
+      <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>$(IntDir)$(TargetName).pch</PrecompiledHeaderOutputFile>
       <WholeProgramOptimization>false</WholeProgramOptimization>
       <DebugInformationFormat>
       </DebugInformationFormat>
       <FavorSizeOrSpeed>Size</FavorSizeOrSpeed>
       <AdditionalOptions>/MP4 %(AdditionalOptions)</AdditionalOptions>
+      <ForcedIncludeFiles>StdAfx.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -109,22 +109,21 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release-XP|Win32'">
     <ClCompile>
-      <PrecompiledHeader>NotUsing</PrecompiledHeader>
+      <PrecompiledHeader>Use</PrecompiledHeader>
       <Optimization>MinSpace</Optimization>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_USRDLL;PARSERS_EXPORTS;FREEORION_WIN32;_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalIncludeDirectories>../../../include/;../../GG/;../../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <PrecompiledHeaderFile>
-      </PrecompiledHeaderFile>
-      <PrecompiledHeaderOutputFile>
-      </PrecompiledHeaderOutputFile>
+      <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
+      <PrecompiledHeaderOutputFile>$(IntDir)$(TargetName).pch</PrecompiledHeaderOutputFile>
       <WholeProgramOptimization>false</WholeProgramOptimization>
       <DebugInformationFormat>
       </DebugInformationFormat>
       <FavorSizeOrSpeed>Size</FavorSizeOrSpeed>
       <AdditionalOptions>/MP2 %(AdditionalOptions)</AdditionalOptions>
+      <ForcedIncludeFiles>StdAfx.h;%(ForcedIncludeFiles)</ForcedIncludeFiles>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -142,7 +141,17 @@
   <ItemGroup>
     <ClCompile Include="..\..\parse\ArithmeticRules.cpp" />
     <ClCompile Include="..\..\parse\BuildingsParser.cpp" />
-    <ClCompile Include="..\..\parse\CommonParamsParser.cpp" />
+    <ClCompile Include="..\..\parse\CommonParamsParser.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release-XP|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+      <ForcedIncludeFiles Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+      </ForcedIncludeFiles>
+      <ForcedIncludeFiles Condition="'$(Configuration)|$(Platform)'=='Release-XP|Win32'">
+      </ForcedIncludeFiles>
+      <ForcedIncludeFiles Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+      </ForcedIncludeFiles>
+    </ClCompile>
     <ClCompile Include="..\..\parse\ConditionParser.cpp" />
     <ClCompile Include="..\..\parse\ConditionParser1.cpp" />
     <ClCompile Include="..\..\parse\ConditionParser2.cpp" />
@@ -181,8 +190,28 @@
     <ClCompile Include="..\..\parse\PlanetTypeValueRefParser.cpp" />
     <ClCompile Include="..\..\parse\ReportParseError.cpp" />
     <ClCompile Include="..\..\parse\ShipDesignsParser.cpp" />
-    <ClCompile Include="..\..\parse\ShipHullsParser.cpp" />
-    <ClCompile Include="..\..\parse\ShipPartsParser.cpp" />
+    <ClCompile Include="..\..\parse\ShipHullsParser.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release-XP|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+      <ForcedIncludeFiles Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+      </ForcedIncludeFiles>
+      <ForcedIncludeFiles Condition="'$(Configuration)|$(Platform)'=='Release-XP|Win32'">
+      </ForcedIncludeFiles>
+      <ForcedIncludeFiles Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+      </ForcedIncludeFiles>
+    </ClCompile>
+    <ClCompile Include="..\..\parse\ShipPartsParser.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release-XP|Win32'">NotUsing</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">NotUsing</PrecompiledHeader>
+      <ForcedIncludeFiles Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+      </ForcedIncludeFiles>
+      <ForcedIncludeFiles Condition="'$(Configuration)|$(Platform)'=='Release-XP|Win32'">
+      </ForcedIncludeFiles>
+      <ForcedIncludeFiles Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+      </ForcedIncludeFiles>
+    </ClCompile>
     <ClCompile Include="..\..\parse\SpecialsParser.cpp" />
     <ClCompile Include="..\..\parse\SpeciesParser.cpp" />
     <ClCompile Include="..\..\parse\StarTypeValueRefParser.cpp" />
@@ -192,6 +221,11 @@
     <ClCompile Include="..\..\parse\UniverseObjectTypeValueRefParser.cpp" />
     <ClCompile Include="..\..\parse\ValueRefParser.cpp" />
     <ClCompile Include="..\..\parse\VisibilityValueRefParser.cpp" />
+    <ClCompile Include="StdAfx.cpp">
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release-XP|Win32'">Create</PrecompiledHeader>
+      <PrecompiledHeader Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Create</PrecompiledHeader>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\parse\CommonParamsParser.h" />
@@ -220,6 +254,7 @@
     <ClInclude Include="..\..\parse\ReportParseError.h" />
     <ClInclude Include="..\..\parse\Tokens.h" />
     <ClInclude Include="..\..\parse\ValueRefParser.h" />
+    <ClInclude Include="StdAfx.h" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">

--- a/msvc2017/Parsers/Parsers.vcxproj.filters
+++ b/msvc2017/Parsers/Parsers.vcxproj.filters
@@ -161,6 +161,7 @@
     <ClCompile Include="..\..\parse\VisibilityValueRefParser.cpp">
       <Filter>Source Files\parse</Filter>
     </ClCompile>
+    <ClCompile Include="StdAfx.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\..\parse\ConditionParser.h">
@@ -241,5 +242,6 @@
     <ClInclude Include="..\..\parse\CommonParamsParser.h">
       <Filter>Header Files\parse</Filter>
     </ClInclude>
+    <ClInclude Include="StdAfx.h" />
   </ItemGroup>
 </Project>

--- a/msvc2017/Parsers/StdAfx.cpp
+++ b/msvc2017/Parsers/StdAfx.cpp
@@ -1,0 +1,1 @@
+#include "StdAfx.h"

--- a/msvc2017/Parsers/StdAfx.h
+++ b/msvc2017/Parsers/StdAfx.h
@@ -1,0 +1,71 @@
+#pragma once
+
+// I generously include most external headers I found in the project header files,
+// including std and boost. Possibly some of the lesser used can be removed.
+
+// https://hownot2code.com/2016/08/16/stdafx-h/
+#include <bitset>
+#include <cmath>
+#include <deque>
+#include <functional>
+#include <initializer_list>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <queue>
+#include <set>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+#include <boost/any.hpp>
+#include <boost/archive/binary_iarchive.hpp>
+#include <boost/archive/binary_oarchive.hpp>
+#include <boost/archive/xml_iarchive.hpp>
+#include <boost/archive/xml_oarchive.hpp>
+#include <boost/date_time/posix_time/posix_time.hpp>
+#include <boost/date_time/posix_time/posix_time_types.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/filesystem/fstream.hpp>
+#include <boost/filesystem/operations.hpp>
+#include <boost/filesystem/path.hpp>
+#include <boost/functional/hash.hpp>
+#include <boost/lexical_cast.hpp>
+#include <boost/log/expressions/keyword.hpp>
+#include <boost/log/sinks/sync_frontend.hpp>
+#include <boost/log/sinks/text_file_backend.hpp>
+#include <boost/log/sources/global_logger_storage.hpp>
+#include <boost/log/sources/severity_channel_logger.hpp>
+#include <boost/log/utility/manipulators/add_value.hpp>
+#include <boost/optional/optional.hpp>
+#include <boost/optional/optional_fwd.hpp>
+#include <boost/preprocessor/seq/for_each.hpp>
+#include <boost/random/mersenne_twister.hpp>
+#include <boost/random/normal_distribution.hpp>
+#include <boost/random/uniform_01.hpp>
+#include <boost/random/uniform_int.hpp>
+#include <boost/random/uniform_real.hpp>
+#include <boost/random/uniform_smallint.hpp>
+#include <boost/random/variate_generator.hpp>
+#include <boost/serialization/access.hpp>
+#include <boost/serialization/nvp.hpp>
+#include <boost/shared_array.hpp>
+#include <boost/signals2/signal.hpp>
+#include <boost/statechart/event.hpp>
+#include <boost/thread/condition.hpp>
+#include <boost/thread/mutex.hpp>
+#include <boost/unordered_map.hpp>
+#include <boost/timer.hpp>
+#include <boost/uuid/uuid.hpp>
+
+#include <boost/spirit/include/phoenix.hpp>
+//TODO: replace with std::make_unique when transitioning to C++14
+#include <boost/smart_ptr/make_unique.hpp>
+
+// Note: The is a workaround for Visual C++ non-conformant pre-processor
+// handling of empty macro arguments.
+#include <boost/preprocessor/control/if.hpp>
+#include <boost/preprocessor/facilities/is_empty_variadic.hpp>
+

--- a/msvc2017/Parsers/StdAfx.h
+++ b/msvc2017/Parsers/StdAfx.h
@@ -1,71 +1,41 @@
+
 #pragma once
 
-// I generously include most external headers I found in the project header files,
-// including std and boost. Possibly some of the lesser used can be removed.
+// We include all external headers used in any of the header files,
+// plus external headers used in at least five .cpp files.
 
-// https://hownot2code.com/2016/08/16/stdafx-h/
-#include <bitset>
-#include <cmath>
-#include <deque>
-#include <functional>
-#include <initializer_list>
-#include <iostream>
+// https://hownot2code.com/2016/08/16/stdafx-h/ 
+
+// ----------------
+// includes from .h
+
+// Parsers
 #include <map>
 #include <memory>
-#include <queue>
 #include <set>
-#include <string>
-#include <tuple>
+#include <type_traits>
 #include <unordered_map>
-#include <unordered_set>
 #include <vector>
 
-#include <boost/any.hpp>
-#include <boost/archive/binary_iarchive.hpp>
-#include <boost/archive/binary_oarchive.hpp>
-#include <boost/archive/xml_iarchive.hpp>
-#include <boost/archive/xml_oarchive.hpp>
-#include <boost/date_time/posix_time/posix_time.hpp>
-#include <boost/date_time/posix_time/posix_time_types.hpp>
-#include <boost/filesystem.hpp>
-#include <boost/filesystem/fstream.hpp>
-#include <boost/filesystem/operations.hpp>
+#include <boost/algorithm/string/case_conv.hpp>
 #include <boost/filesystem/path.hpp>
-#include <boost/functional/hash.hpp>
-#include <boost/lexical_cast.hpp>
-#include <boost/log/expressions/keyword.hpp>
-#include <boost/log/sinks/sync_frontend.hpp>
-#include <boost/log/sinks/text_file_backend.hpp>
-#include <boost/log/sources/global_logger_storage.hpp>
-#include <boost/log/sources/severity_channel_logger.hpp>
-#include <boost/log/utility/manipulators/add_value.hpp>
-#include <boost/optional/optional.hpp>
-#include <boost/optional/optional_fwd.hpp>
+#include <boost/preprocessor/cat.hpp>
 #include <boost/preprocessor/seq/for_each.hpp>
-#include <boost/random/mersenne_twister.hpp>
-#include <boost/random/normal_distribution.hpp>
-#include <boost/random/uniform_01.hpp>
-#include <boost/random/uniform_int.hpp>
-#include <boost/random/uniform_real.hpp>
-#include <boost/random/uniform_smallint.hpp>
-#include <boost/random/variate_generator.hpp>
-#include <boost/serialization/access.hpp>
-#include <boost/serialization/nvp.hpp>
-#include <boost/shared_array.hpp>
-#include <boost/signals2/signal.hpp>
-#include <boost/statechart/event.hpp>
-#include <boost/thread/condition.hpp>
-#include <boost/thread/mutex.hpp>
-#include <boost/unordered_map.hpp>
+#include <boost/spirit/include/lex_lexertl.hpp>
+#include <boost/spirit/include/lex_lexertl_position_token.hpp>
+#include <boost/spirit/include/phoenix.hpp>
+#include <boost/spirit/include/qi.hpp>
+#include <boost/spirit/include/support_argument.hpp>
 #include <boost/timer.hpp>
 #include <boost/uuid/uuid.hpp>
 
-#include <boost/spirit/include/phoenix.hpp>
-//TODO: replace with std::make_unique when transitioning to C++14
+// ------------------
+// includes from .cpp
 #include <boost/smart_ptr/make_unique.hpp>
 
-// Note: The is a workaround for Visual C++ non-conformant pre-processor
+#ifdef _MSC_VER
+// Note: This is a workaround for Visual C++ non-conformant pre-processor
 // handling of empty macro arguments.
 #include <boost/preprocessor/control/if.hpp>
 #include <boost/preprocessor/facilities/is_empty_variadic.hpp>
-
+#endif

--- a/msvc2017/update_stdafx.py
+++ b/msvc2017/update_stdafx.py
@@ -1,0 +1,152 @@
+#!/usr/bin/env python2
+
+import sys
+import os
+import re
+
+MIN_CPP_INCLUDE_COUNT = 5
+EXCLUDE_LIBS          = ["GG"]
+IGNORE_INCLUDES       = ["StdAfx.h", "stdafx.h"]
+
+PREAMBLE = """
+#pragma once
+
+// We include all external headers used in any of the header files,
+// plus external headers used in at least five .cpp files.
+
+// https://hownot2code.com/2016/08/16/stdafx-h/ 
+
+"""
+
+POSTAMBLE = """
+
+#ifdef _MSC_VER
+// Note: This is a workaround for Visual C++ non-conformant pre-processor
+// handling of empty macro arguments.
+#include <boost/preprocessor/control/if.hpp>
+#include <boost/preprocessor/facilities/is_empty_variadic.hpp>
+#endif
+"""
+
+
+def find_files_from_vcxproj(vcxproj, includetype, fileextension):
+    pattern         = "^\s*<" + includetype + "\s+Include=\"(?P<include>[^\"]+" + fileextension + ")\"\s*/>"
+    vcxproj_pattern = re.compile(pattern)
+    base_path       = os.path.dirname(vcxproj)
+
+    with open(vcxproj) as f:
+        for i, line in enumerate(f):
+            match = vcxproj_pattern.match(line)
+            if match and match.group('include') not in IGNORE_INCLUDES:
+                yield os.path.join(base_path, match.group('include'))
+
+include_pattern = re.compile("^#include[ \t]+<(?P<include>(?:(?P<lib>[^/>]+)/)?[^>]+)>")
+ifdef_pattern = re.compile("^\s*#if(?:def)?\s")
+endif_pattern = re.compile("^\s*#endif")
+
+def find_includes_from_cpp_or_h(filename): 
+    if_nesting_level = 0
+    with open(filename) as f:
+        for i, line in enumerate(f):
+            if  ifdef_pattern.match(line):
+                if_nesting_level += 1
+            elif endif_pattern.match(line):
+                if_nesting_level -= 1
+            elif if_nesting_level == 0:
+                match = include_pattern.match(line)
+                if match and match.group('include') not in IGNORE_INCLUDES:
+                    yield (match.group('include'), match.group('lib'))
+
+def assemble_precompile_header_includes(headeronly_vcxproj_files, vcxproj_files):
+    headers_includes = { }
+    cpp_includes     = { }
+
+    index = -1
+    for vcxproj in (headeronly_vcxproj_files + vcxproj_files):
+        index = index + 1
+        for include_file in find_files_from_vcxproj(vcxproj, "ClInclude", ".h"):
+            for include, lib in find_includes_from_cpp_or_h(include_file):
+                if include in headers_includes: 
+                    continue
+                headers_includes[include] = (index, vcxproj, lib)
+
+    index = -1
+    for vcxproj in vcxproj_files:
+        index = index + 1
+        for include_file in find_files_from_vcxproj(vcxproj, "ClCompile", ".cpp"):
+            for include, lib in find_includes_from_cpp_or_h(include_file):
+                if not include in cpp_includes: 
+                    cpp_includes[include]    = [index, vcxproj, lib, 1]
+                else:
+                    cpp_includes[include][3] = cpp_includes[include][3] + 1
+
+    headers = [('includes from .h',
+                headers_includes[include][0],
+                headers_includes[include][1],
+                headers_includes[include][2],
+                include, 
+                0) for include in headers_includes]   
+    headers.sort()
+
+    cpps   = [('includes from .cpp', 
+                cpp_includes[include][0],
+                cpp_includes[include][1],
+                cpp_includes[include][2],
+                include,
+                cpp_includes[include][3]
+                ) for include in cpp_includes
+                         if not include in headers_includes 
+                            and cpp_includes[include][3] >= MIN_CPP_INCLUDE_COUNT
+            ]
+    cpps.sort()
+
+    return headers + cpps
+
+def update_stdafx_h(stdafx_h_filename, header_only_vcxproj_files, vcxproj_files):
+    last_type = ""
+    last_proj = ""
+    last_lib  = None
+
+    lines = []
+
+    for type, index, proj, lib, include, count in assemble_precompile_header_includes(header_only_vcxproj_files, vcxproj_files):
+        
+        if lib in EXCLUDE_LIBS:
+            continue
+        if type != last_type:
+            if last_type:
+                lines.append("")
+            lines.append("// " + '-' * len(type)) 
+            lines.append("// " + type) 
+            last_type = type
+        if last_proj != proj:
+            lines.append("") 
+            lines.append("// " + os.path.splitext(os.path.basename(proj))[0])
+            last_proj = proj
+        if last_lib != lib:
+            if lib:
+                lines.append("") 
+            last_lib = lib
+
+        include_directive = "#include <" + include + ">"
+        #if count > 0:
+        #    include_directive += ' ' * max(50 - len(include_directive), 0)
+        #    include_directive += " // included in " + str(count) + " .cpp files"
+
+        lines.append(include_directive)
+
+    with open(stdafx_h_filename, 'w') as f:
+        f.write(PREAMBLE)
+        f.write("\n".join(lines))
+        f.write(POSTAMBLE)
+
+update_stdafx_h("Parsers/StdAfx.h",    [], ["Parsers/Parsers.vcxproj"])
+update_stdafx_h("Common/StdAfx.h",     [], ["Common/Common.vcxproj"])
+
+update_stdafx_h("FreeOrion/StdAfx.h",  ["Common/Common.vcxproj", "GiGi/GiGi.vcxproj"],
+                                       ["FreeOrion/FreeOrion.vcxproj"])
+update_stdafx_h("FreeOrionD/StdAfx.h", ["Common/Common.vcxproj"],   ["FreeOrionD/FreeOrionD.vcxproj"])
+update_stdafx_h("FreeOrionCA/StdAfx.h",["Common/Common.vcxproj"],   ["FreeOrionCA/FreeOrionCA.vcxproj"])
+
+update_stdafx_h("GiGi/StdAfx.h",       [],                    ["GiGi/GiGi.vcxproj"])
+#update_stdafx_h("GiGiSDL/StdAfx.h",    ["GiGi/GiGi.vcxproj"], ["GiGiSDL/GiGiSDL.vcxproj"])


### PR DESCRIPTION
As per issue #2340, compiling FreeOrion under Windows with VS 2017 takes a lot of time, also on incremental updates. 

This PR improves that issue, reducing compilation time by 2/3 or something. 

This PR  forces the usage of precompiled headers in the projects Common,Parsers,FreeOrion,FreeOrionD and FreeOrionCA when using VS 2017, without altering any source files.

I believe in the long run it might be better to proactively use precompiled headers, i.e. by including 
 "StdAfx.h" in all source files. This could allow using precompiled headers with other compilers, though I am no expert on this. 

Note that 3 source files in the parser project are excluded from using precompiled headers, since they define some boost macros before including other headers.