### PR TITLE
Sit rep sensor upgrades

### DIFF
--- a/default/scripting/techs/spy/DETECT_1.focs.txt
+++ b/default/scripting/techs/spy/DETECT_1.focs.txt
@@ -14,20 +14,22 @@ Tech
                 OwnedBy empire = Source.Owner
             ]
             activation = And [
-                Not OwnerHasTech name = "SPY_DETECT_2"
-                Not OwnerHasTech name = "SPY_DETECT_3"
-                Not OwnerHasTech name = "SPY_DETECT_4"
-                Not OwnerHasTech name = "SPY_DETECT_5"
+                [[NOT_OWNER_HAS_TECH_EFFECTIVE(SPY_DETECT_2)]]
+                [[NOT_OWNER_HAS_TECH_EFFECTIVE(SPY_DETECT_3)]]
+                [[NOT_OWNER_HAS_TECH_EFFECTIVE(SPY_DETECT_4)]]
+                [[NOT_OWNER_HAS_TECH_EFFECTIVE(SPY_DETECT_5)]]
             ]
             effects = SetDetection value = Value + 50
 
         EffectsGroup
             scope = Source
             activation = And [
-                Not OwnerHasTech name = "SPY_DETECT_2"
-                Not OwnerHasTech name = "SPY_DETECT_3"
-                Not OwnerHasTech name = "SPY_DETECT_4"
-                Not OwnerHasTech name = "SPY_DETECT_5"
+                [[NOT_OWNER_HAS_TECH_EFFECTIVE(SPY_DETECT_2)]]
+                [[NOT_OWNER_HAS_TECH_EFFECTIVE(SPY_DETECT_3)]]
+                [[NOT_OWNER_HAS_TECH_EFFECTIVE(SPY_DETECT_4)]]
+                [[NOT_OWNER_HAS_TECH_EFFECTIVE(SPY_DETECT_5)]]
             ]
             effects = SetEmpireMeter empire = Source.Owner meter = "METER_DETECTION_STRENGTH" value = Value + 10
     ]
+
+#include "/scripting/techs/techs.macros"

--- a/default/scripting/techs/spy/DETECT_2.focs.txt
+++ b/default/scripting/techs/spy/DETECT_2.focs.txt
@@ -18,21 +18,44 @@ Tech
                 OwnedBy empire = Source.Owner
             ]
             activation = And [
-                Not OwnerHasTech name = "SPY_DETECT_3"
-                Not OwnerHasTech name = "SPY_DETECT_4"
-                Not OwnerHasTech name = "SPY_DETECT_5"
+                [[NOT_OWNER_HAS_TECH_EFFECTIVE(SPY_DETECT_3)]]
+                [[NOT_OWNER_HAS_TECH_EFFECTIVE(SPY_DETECT_4)]]
+                [[NOT_OWNER_HAS_TECH_EFFECTIVE(SPY_DETECT_5)]]
+                [[OWNER_HAS_TECH_EFFECTIVE(SPY_DETECT_2)]]
             ]
             effects = SetDetection value = Value + 75
 
         EffectsGroup
             scope = Source
             activation = And [
-                Not OwnerHasTech name = "SPY_DETECT_3"
-                Not OwnerHasTech name = "SPY_DETECT_4"
-                Not OwnerHasTech name = "SPY_DETECT_5"
+                [[NOT_OWNER_HAS_TECH_EFFECTIVE(SPY_DETECT_3)]]
+                [[NOT_OWNER_HAS_TECH_EFFECTIVE(SPY_DETECT_4)]]
+                [[NOT_OWNER_HAS_TECH_EFFECTIVE(SPY_DETECT_5)]]
+                [[OWNER_HAS_TECH_EFFECTIVE(SPY_DETECT_2)]]
             ]
             effects = SetEmpireMeter empire = Source.Owner meter = "METER_DETECTION_STRENGTH" value = Value + 30
+
+        EffectsGroup
+            scope = And [
+                Capital
+                Not OwnedBy empire = Source.Owner
+                Number low = 1 condition = And [
+                    OwnedBy empire = Source.Owner
+                    VisibleToEmpire empire = RootCandidate.Owner
+                ]
+            ]
+            activation = (CurrentTurn < 2 + TurnTechResearched empire = Source.Owner name = "SPY_DETECT_2")
+            effects = GenerateSitRepMessage
+                message = "SITREP_EMPIRE_TECH_RESEARCHED_DETECTION"
+                label = "SITREP_EMPIRE_TECH_RESEARCHED_DETECTION_LABEL"
+                icon = "icons/tech/active_radar.png"
+                parameters = [
+                    tag = "empire"  data = Source.Owner
+                ]
+                empire = Target.Owner
+
     ]
     graphic = "icons/tech/active_radar.png"
 
 #include "/scripting/common/base_prod.macros"
+#include "/scripting/techs/techs.macros"

--- a/default/scripting/techs/spy/DETECT_3.focs.txt
+++ b/default/scripting/techs/spy/DETECT_3.focs.txt
@@ -15,18 +15,42 @@ Tech
                 OwnedBy empire = Source.Owner
             ]
             activation = And [
-                Not OwnerHasTech name = "SPY_DETECT_4"
-                Not OwnerHasTech name = "SPY_DETECT_5"
+                [[NOT_OWNER_HAS_TECH_EFFECTIVE(SPY_DETECT_4)]]
+                [[NOT_OWNER_HAS_TECH_EFFECTIVE(SPY_DETECT_5)]]
+                [[OWNER_HAS_TECH_EFFECTIVE(SPY_DETECT_3)]]
                 ]
             effects = SetDetection value = Value + 150
 
         EffectsGroup
             scope = Source
             activation = And [
-                Not OwnerHasTech name = "SPY_DETECT_4"
-                Not OwnerHasTech name = "SPY_DETECT_5"
+                [[NOT_OWNER_HAS_TECH_EFFECTIVE(SPY_DETECT_4)]]
+                [[NOT_OWNER_HAS_TECH_EFFECTIVE(SPY_DETECT_5)]]
+                [[OWNER_HAS_TECH_EFFECTIVE(SPY_DETECT_3)]]
                 ]
             effects = SetEmpireMeter empire = Source.Owner meter = "METER_DETECTION_STRENGTH" value = Value + 50
+
+        EffectsGroup
+            scope = And [
+                Capital
+                Not OwnedBy empire = Source.Owner
+                Number low = 1 condition = And [
+                    OwnedBy empire = Source.Owner
+                    VisibleToEmpire empire = RootCandidate.Owner
+                ]
+            ]
+            activation = (CurrentTurn < 2 + TurnTechResearched empire = Source.Owner name = "SPY_DETECT_3")
+            effects = GenerateSitRepMessage
+                message = "SITREP_EMPIRE_TECH_RESEARCHED_DETECTION"
+                label = "SITREP_EMPIRE_TECH_RESEARCHED_DETECTION_LABEL"
+                icon = "icons/tech/active_radar.png"
+                parameters = [
+                    tag = "empire"  data = Source.Owner
+                ]
+                empire = Target.Owner
+
     ]
+    graphic = "icons/tech/active_radar.png"
 
 #include "/scripting/common/base_prod.macros"
+#include "/scripting/techs/techs.macros"

--- a/default/scripting/techs/spy/DETECT_4.focs.txt
+++ b/default/scripting/techs/spy/DETECT_4.focs.txt
@@ -14,13 +14,40 @@ Tech
                 Planet
                 OwnedBy empire = Source.Owner
             ]
-            activation = Not OwnerHasTech name = "SPY_DETECT_5"
+            activation = And [
+                [[NOT_OWNER_HAS_TECH_EFFECTIVE(SPY_DETECT_5)]]
+                [[OWNER_HAS_TECH_EFFECTIVE(SPY_DETECT_4)]]
+            ]
             effects = SetDetection value = Value + 200
 
         EffectsGroup
             scope = Source
-            activation = Not OwnerHasTech name = "SPY_DETECT_5"
+            activation = And [
+                [[NOT_OWNER_HAS_TECH_EFFECTIVE(SPY_DETECT_5)]]
+                [[OWNER_HAS_TECH_EFFECTIVE(SPY_DETECT_4)]]
+            ]
             effects = SetEmpireMeter empire = Source.Owner meter = "METER_DETECTION_STRENGTH" value = Value + 70
+        EffectsGroup
+            scope = And [
+                Capital
+                Not OwnedBy empire = Source.Owner
+                Number low = 1 condition = And [
+                    OwnedBy empire = Source.Owner
+                    VisibleToEmpire empire = RootCandidate.Owner
+                ]
+            ]
+            activation = (CurrentTurn < 2 + TurnTechResearched empire = Source.Owner name = "SPY_DETECT_4")
+            effects = GenerateSitRepMessage
+                message = "SITREP_EMPIRE_TECH_RESEARCHED_DETECTION"
+                label = "SITREP_EMPIRE_TECH_RESEARCHED_DETECTION_LABEL"
+                icon = "icons/tech/active_radar.png"
+                parameters = [
+                    tag = "empire"  data = Source.Owner
+                ]
+                empire = Target.Owner
+
     ]
+    graphic = "icons/tech/active_radar.png"
 
 #include "/scripting/common/base_prod.macros"
+#include "/scripting/techs/techs.macros"

--- a/default/scripting/techs/spy/DETECT_5.focs.txt
+++ b/default/scripting/techs/spy/DETECT_5.focs.txt
@@ -13,11 +13,35 @@ Tech
                 Planet
                 OwnedBy empire = Source.Owner
             ]
+            activation = [[OWNER_HAS_TECH_EFFECTIVE(SPY_DETECT_5)]]
             effects = SetDetection value = Value + 300
 
         EffectsGroup
             scope = Source
+            activation = [[OWNER_HAS_TECH_EFFECTIVE(SPY_DETECT_5)]]
             effects = SetEmpireMeter empire = Source.Owner meter = "METER_DETECTION_STRENGTH" value = Value + 200
+
+        EffectsGroup
+            scope = And [
+                Capital
+                Not OwnedBy empire = Source.Owner
+                Number low = 1 condition = And [
+                    OwnedBy empire = Source.Owner
+                    VisibleToEmpire empire = RootCandidate.Owner
+                ]
+            ]
+            activation = (CurrentTurn < 2 + TurnTechResearched empire = Source.Owner name = "SPY_DETECT_5")
+            effects = GenerateSitRepMessage
+                message = "SITREP_EMPIRE_TECH_RESEARCHED_DETECTION"
+                label = "SITREP_EMPIRE_TECH_RESEARCHED_DETECTION_LABEL"
+                icon = "icons/tech/active_radar.png"
+                parameters = [
+                    tag = "empire"  data = Source.Owner
+                ]
+                empire = Target.Owner
+
     ]
+    graphic = "icons/tech/active_radar.png"
 
 #include "/scripting/common/base_prod.macros"
+#include "/scripting/techs/techs.macros"

--- a/default/scripting/techs/techs.macros
+++ b/default/scripting/techs/techs.macros
@@ -22,5 +22,16 @@ SHIP_PART_UPGRADE_RESUPPLY_CHECK
            ( LocalCandidate.LastTurnResupplied > TurnTechResearched empire = LocalCandidate.Owner name = @1@ )
 '''
 
+// In order to have all tech effects start in the same turn you can check
+// Usually only meter-relevant effects are applied in the turn a tech gets researched.
+OWNER_HAS_TECH_EFFECTIVE
+'''( CurrentTurn > TurnTechResearched empire = Source.Owner name = "@1@" )
+'''
+
+NOT_OWNER_HAS_TECH_EFFECTIVE
+'''
+                Or [ Not OwnerHasTech name ="@1@" (CurrentTurn == TurnTechResearched empire = Source.Owner name = "@1@") ]
+'''
+
 ARBITRARY_BIG_NUMBER_FOR_METER_TOPUP
 ''' 1000000 '''

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -6524,6 +6524,12 @@ SITREP_TECH_RESEARCHED
 SITREP_TECH_RESEARCHED_LABEL
 Tech Researched
 
+SITREP_EMPIRE_TECH_RESEARCHED_DETECTION
+The %empire% upgraded their detection technology.
+
+SITREP_EMPIRE_TECH_RESEARCHED_DETECTION_LABEL
+Enemy Tech Upgrade
+
 SITREP_TECH_UNLOCKED
 %tech% has been unlocked and can now be researched.
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -5764,7 +5764,7 @@ Detection Strength
 DETECTION_TEXT
 '''The term Detection Strength represents the technological level of an empire's sensors. An empire can only see objects that have a [[metertype METER_STEALTH]] value lower than or equal to its Detection Strength and are within [[metertype METER_DETECTION]] of a controlled space ship or planet.
 
-Empires have a Detection Strength meter.'''
+Empires have a Detection Strength meter. This Detection Strength meter increases one turn after researching detection technologies like [[tech SPY_DETECT_1]], [[tech SPY_DETECT_2]], [[tech SPY_DETECT_3]], [[tech SPY_DETECT_4]], and [[tech SPY_DETECT_5]]'''
 
 ENVIRONMENT_TITLE
 Environment


### PR DESCRIPTION
In order to help players see that their enemies increased detection level one gets a sitrep message. Forum discussion: [SitRep for enemy sensor tech advances?](https://www.freeorion.org/forum/viewtopic.php?f=6&t=11150)

In order to work, this implementation applies detection tech effects one turn after the tech was researched. 

Notes:    
    * in order to make sitrep work, the activation of detection changes is delayed one turn after the tech gets researched
    * probably needs somewhere a stringtable/encyclopedia change to document this behavior(?)
    * maybe should only tell enemy empires
    * maybe sitrep effect could be
    * agrrr/Sitrep_Sensor_Upgrades_Unshifted has a defunct version without the detection turn shift
      that one would need effects processing to be changed in order to work correctly
