### PR TITLE
Do not send private information about empires

### DIFF
--- a/default/scripting/game_rules.focs.txt
+++ b/default/scripting/game_rules.focs.txt
@@ -158,3 +158,10 @@ GameRule
     category = "BALANCE"
     type = Toggle
     default = Off
+
+GameRule
+    name = "RULE_SHOW_DETAILED_EMPIRES_DATA"
+    description = "RULE_SHOW_DETAILED_EMPIRES_DATA_DESC"
+    category = "MULTIPLAYER"
+    type = Toggle
+    default = On

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1215,6 +1215,11 @@ Use part-based upkeep
 RULE_SHIP_PART_BASED_UPKEEP_DESC
 Calculate upkeep based on ship parts instead of ships themselves.
 
+RULE_SHOW_DETAILED_EMPIRES_DATA
+Show detailed empires data
+
+RULE_SHOW_DETAILED_EMPIRES_DATA_DESC
+Show research and production, researched buildings, parts, and hulls of all empires.
 
 ##
 ## Command-line and options database entries
@@ -1384,9 +1389,6 @@ Count of minutes after the cookie record will be considered expired.
 
 OPTIONS_DB_PUBLISH_STATISTICS
 Enable sending empire staticstics to the player.
-
-OPTIONS_DB_HIDE_DETAILED_EMPIRES_DATA
-Disable sending research and production information about enemies' empires.
 
 OPTIONS_DB_UI_MAIN_MENU_X
 Position of the center of the intro screen main menu, as a portion of the application's total width.

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1385,6 +1385,9 @@ Count of minutes after the cookie record will be considered expired.
 OPTIONS_DB_PUBLISH_STATISTICS
 Enable sending empire staticstics to the player.
 
+OPTIONS_DB_HIDE_DETAILED_EMPIRES_DATA
+Disable sending research and production information about enemies' empires.
+
 OPTIONS_DB_UI_MAIN_MENU_X
 Position of the center of the intro screen main menu, as a portion of the application's total width.
 

--- a/server/dmain.cpp
+++ b/server/dmain.cpp
@@ -63,6 +63,7 @@ int wmain(int argc, wchar_t* argv[], wchar_t* envp[]) {
         GetOptionsDB().Add<int>("network.server.cookies.expire-minutes", UserStringNop("OPTIONS_DB_COOKIES_EXPIRE"), 15, Validator<int>());
         GetOptionsDB().Add<bool>("network.server.publish-statistics", UserStringNop("OPTIONS_DB_PUBLISH_STATISTICS"), true, Validator<bool>());
         GetOptionsDB().Add("network.server.binary.enabled", UserStringNop("OPTIONS_DB_SERVER_BINARY_SERIALIZATION"), true);
+        GetOptionsDB().Add<bool>("network.server.hide-detailed-empires-data", UserStringNop("OPTIONS_DB_HIDE_DETAILED_EMPIRES_DATA"), false, Validator<bool>());
 
         // if config.xml and persistent_config.xml are present, read and set options entries
         GetOptionsDB().SetFromFile(GetConfigPath(), FreeOrionVersionString());

--- a/server/dmain.cpp
+++ b/server/dmain.cpp
@@ -63,7 +63,6 @@ int wmain(int argc, wchar_t* argv[], wchar_t* envp[]) {
         GetOptionsDB().Add<int>("network.server.cookies.expire-minutes", UserStringNop("OPTIONS_DB_COOKIES_EXPIRE"), 15, Validator<int>());
         GetOptionsDB().Add<bool>("network.server.publish-statistics", UserStringNop("OPTIONS_DB_PUBLISH_STATISTICS"), true, Validator<bool>());
         GetOptionsDB().Add("network.server.binary.enabled", UserStringNop("OPTIONS_DB_SERVER_BINARY_SERIALIZATION"), true);
-        GetOptionsDB().Add<bool>("network.server.hide-detailed-empires-data", UserStringNop("OPTIONS_DB_HIDE_DETAILED_EMPIRES_DATA"), false, Validator<bool>());
 
         // if config.xml and persistent_config.xml are present, read and set options entries
         GetOptionsDB().SetFromFile(GetConfigPath(), FreeOrionVersionString());

--- a/util/SerializeEmpire.cpp
+++ b/util/SerializeEmpire.cpp
@@ -8,7 +8,7 @@
 #include "../Empire/Diplomacy.h"
 #include "../universe/Universe.h"
 
-#include "OptionsDB.h"
+#include "GameRules.h"
 
 #include "Serialize.ipp"
 #include <boost/serialization/version.hpp>
@@ -120,7 +120,7 @@ void Empire::serialize(Archive& ar, const unsigned int version)
         m_techs.clear();
         for (auto& entry : temp_stringset)
             m_techs[entry] = BEFORE_FIRST_TURN;
-    } else if (Archive::is_saving::value && !visible && GetOptionsDB().Get<bool>("network.server.hide-detailed-empires-data")) {
+    } else if (Archive::is_saving::value && !visible && !GetGameRules().Get<bool>("RULE_SHOW_DETAILED_EMPIRES_DATA")) {
         std::map<std::string, int> dummy_string_int_map;
         // show only known tech without disclosure turn
         const Empire* encoding_empire = Empires().GetEmpire(GetUniverse().EncodingEmpire());
@@ -138,7 +138,7 @@ void Empire::serialize(Archive& ar, const unsigned int version)
     }
 
     ar  & BOOST_SERIALIZATION_NVP(m_meters);
-    if (Archive::is_saving::value && !visible && GetOptionsDB().Get<bool>("network.server.hide-detailed-empires-data")) {
+    if (Archive::is_saving::value && !visible && !GetGameRules().Get<bool>("RULE_SHOW_DETAILED_EMPIRES_DATA")) {
         ResearchQueue empty_research_queue(m_id);
         std::map<std::string, float> empty_research_progress;
         ProductionQueue empty_production_queue(m_id);

--- a/util/SerializeEmpire.cpp
+++ b/util/SerializeEmpire.cpp
@@ -121,8 +121,18 @@ void Empire::serialize(Archive& ar, const unsigned int version)
         for (auto& entry : temp_stringset)
             m_techs[entry] = BEFORE_FIRST_TURN;
     } else if (Archive::is_saving::value && !visible && GetOptionsDB().Get<bool>("network.server.hide-detailed-empires-data")) {
-        std::map<std::string, int> empty_string_int_map;
-        ar  & boost::serialization::make_nvp("m_techs", empty_string_int_map);
+        std::map<std::string, int> dummy_string_int_map;
+        // show only known tech without disclosure turn
+        const Empire* encoding_empire = Empires().GetEmpire(GetUniverse().EncodingEmpire());
+        if (encoding_empire) {
+            for (const auto& tech : encoding_empire->m_techs) {
+                const auto it = m_techs.find(tech.first);
+                if (it != m_techs.end()) {
+                    dummy_string_int_map.emplace(tech.first, BEFORE_FIRST_TURN);
+                }
+            }
+        }
+        ar  & boost::serialization::make_nvp("m_techs", dummy_string_int_map);
     } else {
         ar  & BOOST_SERIALIZATION_NVP(m_techs);
     }

--- a/util/SerializeEmpire.cpp
+++ b/util/SerializeEmpire.cpp
@@ -8,6 +8,8 @@
 #include "../Empire/Diplomacy.h"
 #include "../universe/Universe.h"
 
+#include "OptionsDB.h"
+
 #include "Serialize.ipp"
 #include <boost/serialization/version.hpp>
 
@@ -107,6 +109,10 @@ void Empire::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_eliminated)
         & BOOST_SERIALIZATION_NVP(m_victories);
 
+    bool visible = GetUniverse().AllObjectsVisible() ||
+        GetUniverse().EncodingEmpire() == ALL_EMPIRES ||
+        m_id == GetUniverse().EncodingEmpire();
+
     if (Archive::is_loading::value && version < 1) {
         // adapt set to map
         std::set<std::string> temp_stringset;
@@ -114,24 +120,39 @@ void Empire::serialize(Archive& ar, const unsigned int version)
         m_techs.clear();
         for (auto& entry : temp_stringset)
             m_techs[entry] = BEFORE_FIRST_TURN;
+    } else if (Archive::is_saving::value && !visible && GetOptionsDB().Get<bool>("network.server.hide-detailed-empires-data")) {
+        std::map<std::string, int> empty_string_int_map;
+        ar  & boost::serialization::make_nvp("m_techs", empty_string_int_map);
     } else {
         ar  & BOOST_SERIALIZATION_NVP(m_techs);
     }
 
-    ar  & BOOST_SERIALIZATION_NVP(m_meters)
-        & BOOST_SERIALIZATION_NVP(m_research_queue)
-        & BOOST_SERIALIZATION_NVP(m_research_progress)
-        & BOOST_SERIALIZATION_NVP(m_production_queue)
-        & BOOST_SERIALIZATION_NVP(m_available_building_types)
-        & BOOST_SERIALIZATION_NVP(m_available_part_types)
-        & BOOST_SERIALIZATION_NVP(m_available_hull_types)
-        & BOOST_SERIALIZATION_NVP(m_supply_system_ranges)
+    ar  & BOOST_SERIALIZATION_NVP(m_meters);
+    if (Archive::is_saving::value && !visible && GetOptionsDB().Get<bool>("network.server.hide-detailed-empires-data")) {
+        ResearchQueue empty_research_queue(m_id);
+        std::map<std::string, float> empty_research_progress;
+        ProductionQueue empty_production_queue(m_id);
+        std::set<std::string> empty_string_set;
+        ar  & boost::serialization::make_nvp("m_research_queue", empty_research_queue)
+            & boost::serialization::make_nvp("m_research_progress", empty_research_progress)
+            & boost::serialization::make_nvp("m_production_queue", empty_production_queue)
+            & boost::serialization::make_nvp("m_available_building_types", empty_string_set)
+            & boost::serialization::make_nvp("m_available_part_types", empty_string_set)
+            & boost::serialization::make_nvp("m_available_hull_types", empty_string_set);
+    } else {
+        ar  & BOOST_SERIALIZATION_NVP(m_research_queue)
+            & BOOST_SERIALIZATION_NVP(m_research_progress)
+            & BOOST_SERIALIZATION_NVP(m_production_queue)
+            & BOOST_SERIALIZATION_NVP(m_available_building_types)
+            & BOOST_SERIALIZATION_NVP(m_available_part_types)
+            & BOOST_SERIALIZATION_NVP(m_available_hull_types);
+    }
+
+    ar  & BOOST_SERIALIZATION_NVP(m_supply_system_ranges)
         & BOOST_SERIALIZATION_NVP(m_supply_unobstructed_systems)
         & BOOST_SERIALIZATION_NVP(m_preserved_system_exit_lanes);
 
-    if (GetUniverse().AllObjectsVisible() ||
-        GetUniverse().EncodingEmpire() == ALL_EMPIRES ||
-        m_id == GetUniverse().EncodingEmpire())
+    if (visible)
     {
         ar  & boost::serialization::make_nvp("m_ship_designs", m_known_ship_designs);
         ar  & BOOST_SERIALIZATION_NVP(m_sitrep_entries)


### PR DESCRIPTION
One of the solutions fixes https://github.com/freeorion/freeorion/issues/2324

Sends empty data instead actual production and research queue if enabled. Sends only subset of techs known by both receiving and serializing empires.
Same implementation I use in my server.