### PR TITLE
UI improvements

### DIFF
--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -3074,14 +3074,12 @@ void CompletedDesignsListBox::BaseRightClicked(GG::ListBox::iterator it, const G
     };
 
     auto movetotop_design_action = [&design, this]() {
-        auto saved_design = *design;
-        GetDisplayedDesignsManager().MoveBefore(saved_design.ID(), *GetDisplayedDesignsManager().OrderedIDs().begin());
+        GetDisplayedDesignsManager().MoveBefore(design->ID(), *GetDisplayedDesignsManager().OrderedIDs().begin());
         Populate();
     };
 
     auto movetobottom_design_action = [&design, this]() {
-        auto saved_design = *design;
-        GetDisplayedDesignsManager().MoveBefore(saved_design.ID(), INVALID_DESIGN_ID);
+        GetDisplayedDesignsManager().MoveBefore(design->ID(), INVALID_DESIGN_ID);
         Populate();
     };
 
@@ -3174,7 +3172,7 @@ void SavedDesignsListBox::BaseRightClicked(GG::ListBox::iterator it, const GG::P
     // add all saved designs
     auto add_all_saved_designs_action = [&manager, &empire_id]() {
         DebugLogger() << "BasesListBox::BaseRightClicked AddAllSavedDesignsToDisplayedDesigns";
-        // add the items to the end of the existing list, int correct order
+        // add the items to the end of the existing list, in correct order
         // TODO: think about adding them at the front.
         auto design_uuids = manager.OrderedDesignUUIDs();
         for (auto it = design_uuids.rbegin(); it != design_uuids.rend(); ++it)
@@ -3191,15 +3189,15 @@ void SavedDesignsListBox::BaseRightClicked(GG::ListBox::iterator it, const GG::P
     // create popup menu with a commands in it
     auto popup = GG::Wnd::Create<CUIPopupMenu>(pt.x, pt.y);
     if (design->Producible() && CanAddDesignToDisplayedDesigns(design))
-        popup->AddMenuItem(GG::MenuItem(UserString("DESIGN_ADD"),                   false, false, add_design_action));
-    popup->AddMenuItem(GG::MenuItem(UserString("DESIGN_WND_ADD_ALL_SAVED_NOW"),     false, false, add_all_saved_designs_action));
+        popup->AddMenuItem(GG::MenuItem(UserString("DESIGN_ADD"),                 false, false, add_design_action));
+    popup->AddMenuItem(GG::MenuItem(UserString("DESIGN_WND_ADD_ALL_SAVED_NOW"),   false, false, add_all_saved_designs_action));
     popup->AddMenuItem(GG::MenuItem(true)); // separator
-    popup->AddMenuItem(GG::MenuItem(UserString("DESIGN_WND_DELETE_SAVED"),          false, false, delete_saved_design_action));
+    popup->AddMenuItem(GG::MenuItem(UserString("DESIGN_WND_DELETE_SAVED"),        false, false, delete_saved_design_action));
     popup->AddMenuItem(GG::MenuItem(true)); // separator
-    popup->AddMenuItem(GG::MenuItem(UserString("MOVE_UP_QUEUE_ITEM"), false, false, movetotop_design_action));
-    popup->AddMenuItem(GG::MenuItem(UserString("MOVE_DOWN_QUEUE_ITEM"), false, false, movetobottom_design_action));
+    popup->AddMenuItem(GG::MenuItem(UserString("MOVE_UP_LIST_ITEM"),              false, false, movetotop_design_action));
+    popup->AddMenuItem(GG::MenuItem(UserString("MOVE_DOWN_LIST_ITEM"),            false, false, movetobottom_design_action));
     popup->AddMenuItem(GG::MenuItem(true)); // separator
-    popup->AddMenuItem(GG::MenuItem(UserString("DESIGN_WND_ADD_ALL_SAVED_START"),   false, add_all,
+    popup->AddMenuItem(GG::MenuItem(UserString("DESIGN_WND_ADD_ALL_SAVED_START"), false, add_all,
                                    toggle_add_all_saved_game_start_action));
 
     popup->Run();

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -520,8 +520,10 @@ namespace {
         if (GetOptionsDB().Get<bool>("resource.shipdesign.saved.enabled")) {
             const auto empire_id = HumanClientApp::GetApp()->EmpireID();
             TraceLogger() << "Adding saved designs to empire.";
+            // assume the saved designs are preferred by the user: add them to the front.
+            // note that this also ensures correct ordering.
             for (const auto& uuid : m_ordered_uuids)
-                AddSavedDesignToDisplayedDesigns(uuid, empire_id, false);
+                AddSavedDesignToDisplayedDesigns(uuid, empire_id, true); 
         }
     }
 
@@ -3071,6 +3073,18 @@ void CompletedDesignsListBox::BaseRightClicked(GG::ListBox::iterator it, const G
         }
     };
 
+    auto movetotop_design_action = [&design, this]() {
+        auto saved_design = *design;
+        GetDisplayedDesignsManager().MoveBefore(saved_design.ID(), *GetDisplayedDesignsManager().OrderedIDs().begin());
+        Populate();
+    };
+
+    auto movetobottom_design_action = [&design, this]() {
+        auto saved_design = *design;
+        GetDisplayedDesignsManager().MoveBefore(saved_design.ID(), INVALID_DESIGN_ID);
+        Populate();
+    };
+
     auto save_design_action = [&design]() {
         auto saved_design = *design;
         saved_design.SetUUID(boost::uuids::random_generator()());
@@ -3104,6 +3118,11 @@ void CompletedDesignsListBox::BaseRightClicked(GG::ListBox::iterator it, const G
 
     // save design
     popup->AddMenuItem(GG::MenuItem(UserString("DESIGN_SAVE"), false, false, save_design_action));
+
+    // move design
+    popup->AddMenuItem(GG::MenuItem(true)); // separator
+    popup->AddMenuItem(GG::MenuItem(UserString("MOVE_UP_QUEUE_ITEM"),   false, false, movetotop_design_action));
+    popup->AddMenuItem(GG::MenuItem(UserString("MOVE_DOWN_QUEUE_ITEM"), false, false, movetobottom_design_action));
 
     popup->AddMenuItem(GG::MenuItem(true)); // separator
     popup->AddMenuItem(GG::MenuItem(UserString("DESIGN_WND_ADD_ALL_DEFAULT_START"), false, add_defaults,
@@ -3142,11 +3161,24 @@ void SavedDesignsListBox::BaseRightClicked(GG::ListBox::iterator it, const GG::P
         Populate();
     };
 
+    auto movetotop_design_action = [&design, this]() {
+        GetSavedDesignsManager().MoveBefore(design->UUID(), *GetSavedDesignsManager().OrderedDesignUUIDs().begin());
+        Populate();
+    };
+
+    auto movetobottom_design_action = [&design, this]() {
+        GetSavedDesignsManager().MoveBefore(design->UUID(), boost::uuids::uuid{{0}});
+        Populate();
+    };
+
     // add all saved designs
     auto add_all_saved_designs_action = [&manager, &empire_id]() {
         DebugLogger() << "BasesListBox::BaseRightClicked AddAllSavedDesignsToDisplayedDesigns";
-        for (const auto& uuid : manager.OrderedDesignUUIDs())
-            AddSavedDesignToDisplayedDesigns(uuid, empire_id);
+        // add the items to the end of the existing list, int correct order
+        // TODO: think about adding them at the front.
+        auto design_uuids = manager.OrderedDesignUUIDs();
+        for (auto it = design_uuids.rbegin(); it != design_uuids.rend(); ++it)
+            AddSavedDesignToDisplayedDesigns(*it, empire_id);
     };
 
     // toggle the option to add all saved designs at game start.
@@ -3163,6 +3195,9 @@ void SavedDesignsListBox::BaseRightClicked(GG::ListBox::iterator it, const GG::P
     popup->AddMenuItem(GG::MenuItem(UserString("DESIGN_WND_ADD_ALL_SAVED_NOW"),     false, false, add_all_saved_designs_action));
     popup->AddMenuItem(GG::MenuItem(true)); // separator
     popup->AddMenuItem(GG::MenuItem(UserString("DESIGN_WND_DELETE_SAVED"),          false, false, delete_saved_design_action));
+    popup->AddMenuItem(GG::MenuItem(true)); // separator
+    popup->AddMenuItem(GG::MenuItem(UserString("MOVE_UP_QUEUE_ITEM"), false, false, movetotop_design_action));
+    popup->AddMenuItem(GG::MenuItem(UserString("MOVE_DOWN_QUEUE_ITEM"), false, false, movetobottom_design_action));
     popup->AddMenuItem(GG::MenuItem(true)); // separator
     popup->AddMenuItem(GG::MenuItem(UserString("DESIGN_WND_ADD_ALL_SAVED_START"),   false, add_all,
                                    toggle_add_all_saved_game_start_action));

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -4476,6 +4476,7 @@ void MapWnd::SelectSystem(int system_id) {
     } else {
         // selected a valid system, show sidepanel
         m_side_panel->Show();
+        GG::GUI::GetGUI()->MoveUp(m_side_panel);
         PushWndStack(m_side_panel);
     }
 }
@@ -4543,15 +4544,9 @@ void MapWnd::SelectFleet(std::shared_ptr<Fleet> fleet) {
 
     //std::cout << "MapWnd::SelectFleet " << fleet->ID() << std::endl;
 
-
-    // if indicated fleet is already the only selected fleet in the active FleetWnd, don't need to do anything
-    if (m_selected_fleet_ids.size() == 1 &&
-            m_selected_fleet_ids.count(fleet->ID()))
-        return;
-
     // find if there is a FleetWnd for this fleet already open.
     auto fleet_wnd = manager.WndForFleetID(fleet->ID());
-
+    
     // if there isn't a FleetWnd for this fleet open, need to open one
     if (!fleet_wnd) {
         // Add any overlapping fleet buttons for moving or offroad fleets.
@@ -4570,14 +4565,16 @@ void MapWnd::SelectFleet(std::shared_ptr<Fleet> fleet) {
         FleetButton::PlayFleetButtonOpenSound();
     }
 
-
     // make sure selected fleet's FleetWnd is active
     manager.SetActiveFleetWnd(fleet_wnd);
     GG::GUI::GetGUI()->MoveUp(fleet_wnd);
     PushWndStack(fleet_wnd);
 
-
-
+    // if indicated fleet is already the only selected fleet in the active FleetWnd, 
+    // nothing to do.
+    if (m_selected_fleet_ids.size() == 1 && m_selected_fleet_ids.count(fleet->ID())){
+        return;
+    }
     // select fleet in FleetWnd.  this deselects all other fleets in the FleetWnd.
     // this->m_selected_fleet_ids will be updated by ActiveFleetWndSelectedFleetsChanged or ActiveFleetWndChanged
     // signals being emitted and connected to MapWnd::SelectedFleetsChanged

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -4570,11 +4570,10 @@ void MapWnd::SelectFleet(std::shared_ptr<Fleet> fleet) {
     GG::GUI::GetGUI()->MoveUp(fleet_wnd);
     PushWndStack(fleet_wnd);
 
-    // if indicated fleet is already the only selected fleet in the active FleetWnd, 
-    // nothing to do.
-    if (m_selected_fleet_ids.size() == 1 && m_selected_fleet_ids.count(fleet->ID())){
+    // if indicated fleet is already the only selected fleet in the active FleetWnd, nothing to do.
+    if (m_selected_fleet_ids.size() == 1 && m_selected_fleet_ids.count(fleet->ID()))
         return;
-    }
+    
     // select fleet in FleetWnd.  this deselects all other fleets in the FleetWnd.
     // this->m_selected_fleet_ids will be updated by ActiveFleetWndSelectedFleetsChanged or ActiveFleetWndChanged
     // signals being emitted and connected to MapWnd::SelectedFleetsChanged

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -3411,18 +3411,11 @@ Latest known [[metertype METER_STEALTH]] is out of date. Actual stealth exceeds 
 MENUITEM_SET_FOCUS
 Set focus
 
-MENUITEM_ENQUEUE_BUILDING_TOP
-Queue Building (top)
+MENUITEM_ENQUEUE_SHIPDESIGN
+Queue Ship
 
-MENUITEM_ENQUEUE_BUILDING_BOTTOM
-Queue Building (bottom)
-
-MENUITEM_ENQUEUE_SHIPDESIGN_TOP
-Queue Ship (top)
-
-MENUITEM_ENQUEUE_SHIPDESIGN_BOTTOM
-Queue Ship (bottom)
-
+MENUITEM_ENQUEUE_BUILDING
+Queue Building
 
 ##
 ## Side panel/Resources panel
@@ -4290,6 +4283,13 @@ Move to Queue Top
 
 MOVE_DOWN_QUEUE_ITEM
 Move to Queue Bottom
+
+MOVE_UP_LIST_ITEM
+Move to Top
+
+MOVE_DOWN_LIST_ITEM
+Move to Bottom
+
 
 SPLIT_INCOMPLETE
 Separate Current Repetition

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -3411,11 +3411,17 @@ Latest known [[metertype METER_STEALTH]] is out of date. Actual stealth exceeds 
 MENUITEM_SET_FOCUS
 Set focus
 
-MENUITEM_ENQUEUE_BUILDING
-Queue Building
+MENUITEM_ENQUEUE_BUILDING_TOP
+Queue Building (top)
 
-MENUITEM_ENQUEUE_SHIPDESIGN
-Queue Ship
+MENUITEM_ENQUEUE_BUILDING_BOTTOM
+Queue Building (bottom)
+
+MENUITEM_ENQUEUE_SHIPDESIGN_TOP
+Queue Ship (top)
+
+MENUITEM_ENQUEUE_SHIPDESIGN_BOTTOM
+Queue Ship (bottom)
 
 
 ##


### PR DESCRIPTION
I would like to proprose four small UI Improvements with this PR.

1. When on the map window, bring FleetWindows to the top of the Window Stack, even when the same fleet has be re-selected. At the moment, FleetWindow will stay hidden behind other windows, when clicking on the same fleet again (after interacting with other windows, e.g. the Pedia, which might have overlapped the fleet window).
2. When selecting a Planet, always bring the SidePanel - when it is visible - to the top of the Window Stack. At the moment the SidePanel will stay behind other windows, e.g. the Pedia. This makes overlapping windows on the screen tedious.

3. Add commands "bring to top/bring to bottom" to the Ship Design Window. 

4. When adding all Ship Designs from the saved folder, retain their relative position. At the moment, the Designs are added in reverse order to the available ship designs.