### PR TITLE
Show player list based on empires

### DIFF
--- a/UI/PlayerListWnd.h
+++ b/UI/PlayerListWnd.h
@@ -42,6 +42,7 @@ private:
     void            PlayerDoubleClicked(GG::ListBox::iterator it, const GG::Pt& pt, const GG::Flags<GG::ModKey>& modkeys);
     void            PlayerRightClicked(GG::ListBox::iterator it, const GG::Pt& pt, const GG::Flags<GG::ModKey>& modkeys);
     int             PlayerInRow(GG::ListBox::iterator it) const;
+    int             EmpireInRow(GG::ListBox::iterator it) const;
 
     std::shared_ptr<PlayerListBox>  m_player_list;
 };


### PR DESCRIPTION
First half of first step of https://github.com/freeorion/freeorion/issues/2243

This PR shows data in player list based on empires so it could show empire without connected player such as eliminated empires.