### PR TITLE
Send status based on empire instead of player

### DIFF
--- a/UI/ChatWnd.cpp
+++ b/UI/ChatWnd.cpp
@@ -399,9 +399,6 @@ void MessageWnd::HandlePlayerChatMessage(const std::string& text,
     m_display_show_time = GG::GUI::GetGUI()->Ticks();
 }
 
-void MessageWnd::HandlePlayerStatusUpdate(Message::PlayerStatus player_status, int about_player_id)
-{}
-
 void MessageWnd::HandleTurnPhaseUpdate(Message::TurnProgressPhase phase_id, bool prefixed /*= false*/) {
     std::string phase_str;
     switch (phase_id) {

--- a/UI/ChatWnd.h
+++ b/UI/ChatWnd.h
@@ -28,7 +28,6 @@ public:
                                             GG::Clr text_color,
                                             const boost::posix_time::ptime& timestamp,
                                             int recipient_player_id);
-    void            HandlePlayerStatusUpdate(Message::PlayerStatus player_status, int about_player_id);
     void            HandleTurnPhaseUpdate(Message::TurnProgressPhase phase_id, bool prefixed = false);
     void            HandleGameStatusUpdate(const std::string& text);
     void            HandleLogMessage(const std::string& text);

--- a/UI/PlayerListWnd.cpp
+++ b/UI/PlayerListWnd.cpp
@@ -597,7 +597,7 @@ void PlayerListWnd::HandleEmpireStatusUpdate(Message::PlayerStatus player_status
     for (auto& row : *m_player_list) {
         if (PlayerRow* player_row = dynamic_cast<PlayerRow*>(row.get())) {
             if (about_empire_id == ALL_EMPIRES) {
-                player_row->SetStatus(player_status);
+                WarnLogger() << "PlayerListWnd::HandleEmpireStatusUpdate got no empire";
             } else if (player_row->EmpireID() == about_empire_id) {
                 player_row->SetStatus(player_status);
                 return;

--- a/UI/PlayerListWnd.cpp
+++ b/UI/PlayerListWnd.cpp
@@ -593,12 +593,12 @@ std::set<int> PlayerListWnd::SelectedPlayerIDs() const {
     return retval;
 }
 
-void PlayerListWnd::HandlePlayerStatusUpdate(Message::PlayerStatus player_status, int about_player_id) {
+void PlayerListWnd::HandleEmpireStatusUpdate(Message::PlayerStatus player_status, int about_empire_id) {
     for (auto& row : *m_player_list) {
         if (PlayerRow* player_row = dynamic_cast<PlayerRow*>(row.get())) {
-            if (about_player_id == Networking::INVALID_PLAYER_ID) {
+            if (about_empire_id == ALL_EMPIRES) {
                 player_row->SetStatus(player_status);
-            } else if (player_row->PlayerID() == about_player_id) {
+            } else if (player_row->EmpireID() == about_empire_id) {
                 player_row->SetStatus(player_status);
                 return;
             }

--- a/UI/PlayerListWnd.h
+++ b/UI/PlayerListWnd.h
@@ -21,7 +21,7 @@ public:
     //! \name Mutators //@{
     void SizeMove(const GG::Pt& ul, const GG::Pt& lr) override;
 
-    void            HandlePlayerStatusUpdate(Message::PlayerStatus player_status, int about_player_id);
+    void            HandleEmpireStatusUpdate(Message::PlayerStatus player_status, int about_empire_id);
     void            Update();
     void            Refresh();
     void            Clear();

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -248,7 +248,7 @@ void AIClientApp::HandleMessage(const Message& msg) {
         SaveGameUIData ui_data;         // ignored
         bool state_string_available;    // ignored, as save_state_string is sent even if not set by ExtractMessageData
         std::string save_state_string;
-        m_player_status.clear();
+        m_empire_status.clear();
 
         ExtractGameStartMessageData(msg,                     single_player_game,     m_empire_id,
                                     m_current_turn,          m_empires,              m_universe,

--- a/client/ClientApp.cpp
+++ b/client/ClientApp.cpp
@@ -45,6 +45,9 @@ const GalaxySetupData& ClientApp::GetGalaxySetupData() const
 EmpireManager& ClientApp::Empires()
 { return m_empires; }
 
+const EmpireManager& ClientApp::Empires() const
+{ return m_empires; }
+
 Empire* ClientApp::GetEmpire(int empire_id)
 { return m_empires.GetEmpire(empire_id); }
 
@@ -101,16 +104,16 @@ const std::map<int, PlayerInfo>& ClientApp::Players() const
 std::map<int, PlayerInfo>& ClientApp::Players()
 { return m_player_info; }
 
-const std::map<int, Message::PlayerStatus>& ClientApp::PlayerStatus() const
-{ return m_player_status; }
+const std::map<int, Message::PlayerStatus>& ClientApp::EmpireStatus() const
+{ return m_empire_status; }
 
-std::map<int, Message::PlayerStatus>& ClientApp::PlayerStatus()
-{ return m_player_status; }
+std::map<int, Message::PlayerStatus>& ClientApp::EmpireStatus()
+{ return m_empire_status; }
 
-void ClientApp::SetPlayerStatus(int player_id, Message::PlayerStatus status) {
-    if (player_id == Networking::INVALID_PLAYER_ID)
+void ClientApp::SetEmpireStatus(int empire_id, Message::PlayerStatus status) {
+    if (empire_id == ALL_EMPIRES)
         return;
-    m_player_status[player_id] = status;
+    m_empire_status[empire_id] = status;
 }
 
 void ClientApp::StartTurn()

--- a/client/ClientApp.h
+++ b/client/ClientApp.h
@@ -71,14 +71,14 @@ public:
     const std::map<int, PlayerInfo>& Players() const;
     /** @} */
 
-    /** @brief Return the player statuses in game
+    /** @brief Return the empire statuses in game
      *
      * @return Return a map containing PlayerStatus instances as value and
-     *      their player identifier as key.
+     *      their empire identifier as key.
      *
      * @{ */
-    std::map<int, Message::PlayerStatus>& PlayerStatus();
-    const std::map<int, Message::PlayerStatus>& PlayerStatus() const;
+    std::map<int, Message::PlayerStatus>& EmpireStatus();
+    const std::map<int, Message::PlayerStatus>& EmpireStatus() const;
     /** @} */
 
     /** @brief Return the ::Universe known to this client
@@ -172,8 +172,10 @@ public:
      *
      * @return The EmpireManager instance in charge of maintaining the Empire
      *      object instances.
-     */
+     * @{ */
     EmpireManager& Empires() override;
+    const EmpireManager& Empires() const;
+    /** @} */
 
     /** @brief Return the Empire identified by @a empire_id
      *
@@ -232,13 +234,13 @@ public:
      */
     void SetSinglePlayerGame(bool single_player = true);
 
-    /** @brief Set the Message::PlayerStatus @a status for @a player_id
+    /** @brief Set the Message::PlayerStatus @a status for @a empire_id
      *
-     * @param player_id A player identifier.
+     * @param player_id A empire identifier.
      * @param status The new Message::PlayerStatus of the player identified by
-     *      @a player_id.
+     *      @a empire_id.
      */
-    void SetPlayerStatus(int player_id, Message::PlayerStatus status);
+    void SetEmpireStatus(int empire_id, Message::PlayerStatus status);
 
     /** @brief Return the singleton instance of this Application
      *
@@ -264,11 +266,11 @@ protected:
     /** Indexed by player id, contains info about all players in the game */
 
     std::map<int, PlayerInfo>   m_player_info;
-    /** Indexed by player id, contains the last known PlayerStatus for each
-     *      player.
+    /** Indexed by empire id, contains the last known PlayerStatus for each
+     *      empire.
      */
     std::map<int, Message::PlayerStatus>
-                                m_player_status;
+                                m_empire_status;
 };
 
 #endif // _ClientApp_h_

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -388,14 +388,13 @@ bool HumanClientApp::CanSaveNow() const {
         return false;
 
     // can't save while AIs are playing their turns...
-    for (const auto& entry : m_player_info) {
-        const PlayerInfo& info = entry.second;
-        if (info.client_type != Networking::CLIENT_TYPE_AI_PLAYER)
+    for (const auto& entry : Empires()) {
+        if (GetEmpireClientType(entry.first) != Networking::CLIENT_TYPE_AI_PLAYER)
             continue;   // only care about AIs
 
-        auto status_it = m_player_status.find(entry.first);
+        auto status_it = m_empire_status.find(entry.first);
 
-        if (status_it == this->m_player_status.end()) {
+        if (status_it == this->m_empire_status.end()) {
             return false;  // missing status for AI; can't assume it's ready
         }
         if (status_it->second != Message::WAITING) {

--- a/network/Message.cpp
+++ b/network/Message.cpp
@@ -374,12 +374,16 @@ Message TurnProgressMessage(Message::TurnProgressPhase phase_id) {
     return Message(Message::TURN_PROGRESS, os.str());
 }
 
-Message PlayerStatusMessage(int about_player_id, Message::PlayerStatus player_status) {
+Message PlayerStatusMessage(int about_player_id,
+                            Message::PlayerStatus player_status,
+                            int about_empire_id)
+{
     std::ostringstream os;
     {
         freeorion_xml_oarchive oa(os);
         oa << BOOST_SERIALIZATION_NVP(about_player_id)
-           << BOOST_SERIALIZATION_NVP(player_status);
+           << BOOST_SERIALIZATION_NVP(player_status)
+           << BOOST_SERIALIZATION_NVP(about_empire_id);
     }
     return Message(Message::PLAYER_STATUS, os.str());
 }
@@ -1076,12 +1080,16 @@ void ExtractTurnProgressMessageData(const Message& msg, Message::TurnProgressPha
     }
 }
 
-void ExtractPlayerStatusMessageData(const Message& msg, int& about_player_id, Message::PlayerStatus& status) {
+void ExtractPlayerStatusMessageData(const Message& msg,
+                                    int& about_player_id,
+                                    Message::PlayerStatus& status,
+                                    int& about_empire_id) {
     try {
         std::istringstream is(msg.Text());
         freeorion_xml_iarchive ia(is);
         ia >> BOOST_SERIALIZATION_NVP(about_player_id)
-           >> BOOST_SERIALIZATION_NVP(status);
+           >> BOOST_SERIALIZATION_NVP(status)
+           >> BOOST_SERIALIZATION_NVP(about_empire_id);
 
     } catch (const std::exception& err) {
         ErrorLogger() << "ExtractPlayerStatusMessageData(const Message& msg, int& about_player_id, Message::PlayerStatus&) failed!  Message:\n"

--- a/network/Message.h
+++ b/network/Message.h
@@ -120,9 +120,10 @@ public:
         STARTING_AIS            ///< creating AI clients
     )
 
+    /// \todo change to EmpireStatus on compatibility breakage
     GG_CLASS_ENUM(PlayerStatus,
-        PLAYING_TURN,           ///< player is playing a turn, on the galax map
-        WAITING                 ///< player is waiting for others to submit orders, to resolve combats, or for turn processing to complete
+        PLAYING_TURN,           ///< empire is playing a turn, on the galax map
+        WAITING                 ///< empire is waiting for others to submit orders, to resolve combats, or for turn processing to complete
     )
 
     GG_CLASS_ENUM(EndGameReason,
@@ -248,7 +249,9 @@ FO_COMMON_API Message TurnOrdersMessage(const OrderSet& orders);
 FO_COMMON_API Message TurnProgressMessage(Message::TurnProgressPhase phase_id);
 
 /** creates a PLAYER_STATUS message. */
-FO_COMMON_API Message PlayerStatusMessage(int about_player_id, Message::PlayerStatus player_status);
+FO_COMMON_API Message PlayerStatusMessage(int about_player_id,
+                                          Message::PlayerStatus player_status,
+                                          int about_empire_id);
 
 /** creates a TURN_UPDATE message. */
 FO_COMMON_API Message TurnUpdateMessage(int empire_id, int current_turn,
@@ -419,7 +422,10 @@ FO_COMMON_API void ExtractClientSaveDataMessageData(const Message& msg, OrderSet
 
 FO_COMMON_API void ExtractTurnProgressMessageData(const Message& msg, Message::TurnProgressPhase& phase_id);
 
-FO_COMMON_API void ExtractPlayerStatusMessageData(const Message& msg, int& about_player_id, Message::PlayerStatus& status);
+FO_COMMON_API void ExtractPlayerStatusMessageData(const Message& msg,
+                                                  int& about_player_id,
+                                                  Message::PlayerStatus& status,
+                                                  int& about_empire_id);
 
 FO_COMMON_API void ExtractHostSPGameMessageData(const Message& msg, SinglePlayerSetupData& setup_data, std::string& client_version_string);
 

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1653,6 +1653,16 @@ void ServerApp::AddObserverPlayerIntoGame(const PlayerConnectionPtr& player_conn
                                                         GetSpeciesManager(), GetCombatLogManager(),
                                                         GetSupplyManager(), player_info_map,
                                                         m_galaxy_setup_data, use_binary_serialization));
+
+        // send other empires' statuses
+        for (const auto& empire : Empires()) {
+            auto other_orders_it = m_turn_sequence.find(empire.first);
+            bool ready = other_orders_it == m_turn_sequence.end() ||
+                    (other_orders_it->second.second && other_orders_it->second.first);
+            player_connection->SendMessage(PlayerStatusMessage(EmpirePlayerID(empire.first),
+                                                               ready ? Message::WAITING : Message::PLAYING_TURN,
+                                                               empire.first));
+        }
     } else {
         ErrorLogger() << "ServerApp::CommonGameInit unsupported client type: skipping game start message.";
     }

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1728,42 +1728,59 @@ bool ServerApp::EliminatePlayer(const PlayerConnectionPtr& player_connection) {
 void ServerApp::DropPlayerEmpireLink(int player_id)
 { m_player_empire_ids.erase(player_id); }
 
-bool ServerApp::AddPlayerIntoGame(const PlayerConnectionPtr& player_connection) {
+int ServerApp::AddPlayerIntoGame(const PlayerConnectionPtr& player_connection) {
+    int empire_id = ALL_EMPIRES;
     // search empire by player name
     for (auto empire : Empires()) {
         if (empire.second->PlayerName() == player_connection->PlayerName()) {
-            auto orders_it = m_turn_sequence.find(empire.first);
-            if (orders_it == m_turn_sequence.end()) {
-                WarnLogger() << "ServerApp::AddPlayerIntoGame empire " << empire.first
-                             << " for \"" << player_connection->PlayerName()
-                             << "\" doesn't wait for orders";
-                return false;
-            }
-            // make a link to new connection
-            m_player_empire_ids[player_connection->PlayerID()] = empire.first;
-
-            const OrderSet dummy;
-            const OrderSet& orders = orders_it->second.second ? *orders_it->second.second : dummy;
-
-            // drop ready status
-            orders_it->second.first = false;
-
-            auto player_info_map = GetPlayerInfoMap();
-            bool use_binary_serialization = player_connection->IsBinarySerializationUsed();
-
-            player_connection->SendMessage(GameStartMessage(
-                m_single_player_game, empire.first,
-                m_current_turn, m_empires, m_universe,
-                GetSpeciesManager(), GetCombatLogManager(),
-                GetSupplyManager(),  player_info_map, orders,
-                static_cast<const SaveGameUIData*>(nullptr),
-                m_galaxy_setup_data,
-                use_binary_serialization));
-
-            return true;
+            empire_id = empire.first;
+            break;
         }
     }
-    return false;
+
+    if (empire_id == ALL_EMPIRES)
+        return false;
+
+    auto orders_it = m_turn_sequence.find(empire_id);
+    if (orders_it == m_turn_sequence.end()) {
+        WarnLogger() << "ServerApp::AddPlayerIntoGame empire " << empire_id
+                     << " for \"" << player_connection->PlayerName()
+                     << "\" doesn't wait for orders";
+        return false;
+    }
+
+    // make a link to new connection
+    m_player_empire_ids[player_connection->PlayerID()] = empire_id;
+
+    const OrderSet dummy;
+    const OrderSet& orders = orders_it->second.second ? *orders_it->second.second : dummy;
+
+    // drop ready status
+    orders_it->second.first = false;
+
+    auto player_info_map = GetPlayerInfoMap();
+    bool use_binary_serialization = player_connection->IsBinarySerializationUsed();
+
+    player_connection->SendMessage(GameStartMessage(
+        m_single_player_game, empire_id,
+        m_current_turn, m_empires, m_universe,
+        GetSpeciesManager(), GetCombatLogManager(),
+        GetSupplyManager(),  player_info_map, orders,
+        static_cast<const SaveGameUIData*>(nullptr),
+        m_galaxy_setup_data,
+        use_binary_serialization));
+
+    // send other empires' statuses
+    for (const auto& empire : Empires()) {
+        auto other_orders_it = m_turn_sequence.find(empire.first);
+        bool ready = other_orders_it == m_turn_sequence.end() ||
+                (other_orders_it->second.second && other_orders_it->second.first);
+        player_connection->SendMessage(PlayerStatusMessage(EmpirePlayerID(empire.first),
+                                                           ready ? Message::WAITING : Message::PLAYING_TURN,
+                                                           empire.first));
+    }
+
+    return true;
 }
 
 bool ServerApp::IsHostless() const

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -186,9 +186,10 @@ public:
     void DropPlayerEmpireLink(int planet_id);
 
     /** Adds new player to running game.
-      * Search empire by player's name and return true if success and false if no empire found.
-      * Simply sends GAME_START message so established player knows he is in the game. */
-    bool AddPlayerIntoGame(const PlayerConnectionPtr& player_connection);
+      * Search empire by player's name and return empire id if success and ALL_EMPIRES if no empire found.
+      * Simply sends GAME_START message so established player knows he is in the game.
+      * Notificates the player about statuses of other empires. */
+    int AddPlayerIntoGame(const PlayerConnectionPtr& player_connection);
     //@}
 
     void UpdateSavePreviews(const Message& msg, PlayerConnectionPtr player_connection);

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -2530,15 +2530,17 @@ sc::result WaitingForTurnEnd::react(const TurnOrders& msg) {
             return discard_event();
         }
 
+        int empire_id = empire->EmpireID();
+
         for (const auto& id_and_order : *order_set) {
             auto& order = id_and_order.second;
             if (!order) {
                 ErrorLogger(FSM) << "WaitingForTurnEnd::react(TurnOrders&) couldn't get order from order set!";
                 continue;
             }
-            if (empire->EmpireID() != order->EmpireID()) {
+            if (empire_id != order->EmpireID()) {
                 ErrorLogger(FSM) << "WaitingForTurnEnd::react(TurnOrders&) received orders from player " << empire->PlayerName() << "(id: "
-                                 << player_id << ") who controls empire " << empire->EmpireID()
+                                 << player_id << ") who controls empire " << empire_id
                                  << " but those orders were for empire " << order->EmpireID() << ".  Orders being ignored.";
                 sender->SendMessage(ErrorMessage(UserStringNop("ORDERS_FOR_WRONG_EMPIRE"), false));
                 return discard_event();
@@ -2547,16 +2549,15 @@ sc::result WaitingForTurnEnd::react(const TurnOrders& msg) {
 
         TraceLogger(FSM) << "WaitingForTurnEnd.TurnOrders : Received orders from player " << player_id;
 
-        server.SetEmpireTurnOrders(empire->EmpireID(), std::move(order_set));
-    }
+        server.SetEmpireTurnOrders(empire_id, std::move(order_set));
 
-
-    // notify other player that this player submitted orders
-    for (auto player_it = server.m_networking.established_begin();
-         player_it != server.m_networking.established_end(); ++player_it)
-    {
-        PlayerConnectionPtr player_ctn = *player_it;
-        player_ctn->SendMessage(PlayerStatusMessage(player_id, Message::WAITING));
+        // notify other player that this empire submitted orders
+        for (auto player_it = server.m_networking.established_begin();
+             player_it != server.m_networking.established_end(); ++player_it)
+        {
+            PlayerConnectionPtr player_ctn = *player_it;
+            player_ctn->SendMessage(PlayerStatusMessage(player_id, Message::WAITING, empire_id));
+        }
     }
 
     // inform player who just submitted of their new status.  Note: not sure why
@@ -2599,20 +2600,22 @@ sc::result WaitingForTurnEnd::react(const RevokeReadiness& msg) {
             return discard_event();
         }
 
+        int empire_id = empire->EmpireID();
+
         TraceLogger(FSM) << "WaitingForTurnEnd.RevokeReadiness : Revoke orders from player " << player_id;
 
-        server.RevokeEmpireTurnReadyness(empire->EmpireID());
-    }
+        server.RevokeEmpireTurnReadyness(empire_id);
 
-    // inform player who just submitted of acknowledge revoking status.
-    sender->SendMessage(msg.m_message);
+        // inform player who just submitted of acknowledge revoking status.
+        sender->SendMessage(msg.m_message);
 
-    // notify other player that this player revoked orders
-    for (auto player_it = server.m_networking.established_begin();
-         player_it != server.m_networking.established_end(); ++player_it)
-    {
-        PlayerConnectionPtr player_ctn = *player_it;
-        player_ctn->SendMessage(PlayerStatusMessage(player_id, Message::PLAYING_TURN));
+        // notify other player that this empire revoked orders
+        for (auto player_it = server.m_networking.established_begin();
+             player_it != server.m_networking.established_end(); ++player_it)
+        {
+            PlayerConnectionPtr player_ctn = *player_it;
+            player_ctn->SendMessage(PlayerStatusMessage(player_id, Message::PLAYING_TURN, empire_id));
+        }
     }
 
     return discard_event();
@@ -2808,26 +2811,20 @@ sc::result ProcessingTurn::react(const ProcessTurn& u) {
     server.ProcessCombats();
     server.PostCombatProcessTurns();
 
-    // update players that other players are now playing their turn
-    for (auto player_it = server.m_networking.established_begin();
-         player_it != server.m_networking.established_end();
-         ++player_it)
+    // update players that other empires are now playing their turn
+    for (const auto& empire : server.Empires())
     {
-        PlayerConnectionPtr player_ctn = *player_it;
-        if (player_ctn->GetClientType() == Networking::CLIENT_TYPE_AI_PLAYER ||
-            player_ctn->GetClientType() == Networking::CLIENT_TYPE_HUMAN_PLAYER ||
-            player_ctn->GetClientType() == Networking::CLIENT_TYPE_HUMAN_OBSERVER ||
-            player_ctn->GetClientType() == Networking::CLIENT_TYPE_HUMAN_MODERATOR)
+        // inform all players that this empire is playing a turn
+        for (auto recipient_player_it = server.m_networking.established_begin();
+            recipient_player_it != server.m_networking.established_end();
+            ++recipient_player_it)
         {
-            // inform all players that this player is playing a turn
-            for (auto recipient_player_it = server.m_networking.established_begin();
-                recipient_player_it != server.m_networking.established_end();
-                ++recipient_player_it)
-            {
-                const PlayerConnectionPtr& recipient_player_ctn = *recipient_player_it;
-                recipient_player_ctn->SendMessage(PlayerStatusMessage(player_ctn->PlayerID(),
-                                                                      Message::PLAYING_TURN));
-            }
+            const PlayerConnectionPtr& recipient_player_ctn = *recipient_player_it;
+            recipient_player_ctn->SendMessage(PlayerStatusMessage(server.EmpirePlayerID(empire.first),
+                                                                  empire.second->Eliminated() ?
+                                                                      Message::WAITING :
+                                                                      Message::PLAYING_TURN,
+                                                                  empire.first));
         }
     }
 

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -2812,8 +2812,7 @@ sc::result ProcessingTurn::react(const ProcessTurn& u) {
     server.PostCombatProcessTurns();
 
     // update players that other empires are now playing their turn
-    for (const auto& empire : server.Empires())
-    {
+    for (const auto& empire : server.Empires()) {
         // inform all players that this empire is playing a turn
         for (auto recipient_player_it = server.m_networking.established_begin();
             recipient_player_it != server.m_networking.established_end();

--- a/test/system/ClientAppFixture.cpp
+++ b/test/system/ClientAppFixture.cpp
@@ -181,11 +181,11 @@ bool ClientAppFixture::HandleMessage(Message& msg) {
 
         InfoLogger() << "Extracted GameStart message for turn: " << m_current_turn << " with empire: " << m_empire_id;
 
-        for (const auto& player : Players()) {
-            if (player.second.client_type == Networking::CLIENT_TYPE_AI_PLAYER)
-                m_ai_players.insert(player.first);
+        for (const auto& empire : Empires()) {
+            if (GetEmpireClientType(empire.first) == Networking::CLIENT_TYPE_AI_PLAYER)
+                m_ai_empires.insert(empire.first);
         }
-        m_ai_waiting = m_ai_players;
+        m_ai_waiting = m_ai_empires;
 
         m_game_started = true;
         return true;

--- a/test/system/ClientAppFixture.cpp
+++ b/test/system/ClientAppFixture.cpp
@@ -170,7 +170,7 @@ bool ClientAppFixture::HandleMessage(Message& msg) {
         SaveGameUIData ui_data;      // ignored
         bool state_string_available; // ignored
         std::string save_state_string;
-        m_player_status.clear();
+        m_empire_status.clear();
 
         ExtractGameStartMessageData(msg,                     single_player_game,     m_empire_id,
                                     m_current_turn,          m_empires,              m_universe,
@@ -195,12 +195,13 @@ bool ClientAppFixture::HandleMessage(Message& msg) {
     case Message::CHAT_HISTORY:
         return true; // ignore
     case Message::PLAYER_STATUS: {
-        int about_player_id;
+        int ignore_about_player_id;
+        int about_empire_id;
         Message::PlayerStatus status;
-        ExtractPlayerStatusMessageData(msg, about_player_id, status);
+        ExtractPlayerStatusMessageData(msg, ignore_about_player_id, status, about_empire_id);
 
         if (status == Message::WAITING) {
-            m_ai_waiting.erase(about_player_id);
+            m_ai_waiting.erase(ignore_about_player_id);
         }
         return true;
     }

--- a/test/system/ClientAppFixture.h
+++ b/test/system/ClientAppFixture.h
@@ -26,8 +26,8 @@ public:
     int EffectsProcessingThreads() const override;
 protected:
     bool                 m_game_started;   ///< Is server started the game?
-    std::set<int>        m_ai_players;     ///< Ids of AI players in game.
-    std::set<int>        m_ai_waiting;     ///< Ids of AI players not yet send orders.
+    std::set<int>        m_ai_empires;     ///< Ids of AI empires in game.
+    std::set<int>        m_ai_waiting;     ///< Ids of AI empires not yet send orders.
     bool                 m_turn_done;      ///< Is server processed turn?
     bool                 m_save_completed; ///< Is server saved game?
     boost::uuids::uuid   m_cookie;         ///< Cookie from server login.

--- a/test/system/SmokeTestGame.cpp
+++ b/test/system/SmokeTestGame.cpp
@@ -118,7 +118,7 @@ BOOST_AUTO_TEST_CASE(host_server) {
         BOOST_REQUIRE(ProcessMessages(start_time, MAX_WAITING_SEC));
     }
 
-    BOOST_REQUIRE_EQUAL(m_ai_players.size(), num_AIs);
+    BOOST_REQUIRE_EQUAL(m_ai_empires.size(), num_AIs);
 
     BOOST_TEST_MESSAGE("Game started. Waiting AI for turns...");
 
@@ -131,7 +131,7 @@ BOOST_AUTO_TEST_CASE(host_server) {
         SendTurnOrders();
 
         m_turn_done = false;
-        m_ai_waiting = m_ai_players;
+        m_ai_waiting = m_ai_empires;
 
         BOOST_TEST_MESSAGE("Turn done. Waiting server for update...");
         start_time = boost::posix_time::microsec_clock::local_time();

--- a/test/system/SmokeTestHostless.cpp
+++ b/test/system/SmokeTestHostless.cpp
@@ -179,7 +179,7 @@ BOOST_AUTO_TEST_CASE(hostless_server) {
             BOOST_REQUIRE(ProcessMessages(start_time, MAX_WAITING_SEC));
         }
 
-        BOOST_REQUIRE_EQUAL(m_ai_players.size(), num_AIs);
+        BOOST_REQUIRE_EQUAL(m_ai_empires.size(), num_AIs);
 
         start_time = boost::posix_time::microsec_clock::local_time();
         while (! m_ai_waiting.empty()) {
@@ -190,7 +190,7 @@ BOOST_AUTO_TEST_CASE(hostless_server) {
             SendTurnOrders();
 
             m_turn_done = false;
-            m_ai_waiting = m_ai_players;
+            m_ai_waiting = m_ai_empires;
 
             BOOST_TEST_MESSAGE("Turn done. Waiting server for update...");
             start_time = boost::posix_time::microsec_clock::local_time();


### PR DESCRIPTION
Next step of  #2243

`PlayerStatus` actually mean status of empire if it have orders to execute. This PR changes base of `PlayerStatus` from player to empire.
This allows player to reconnect and make turns so other player will see his empire makes turn even if them don't know his new player id.