### PR TITLE
Fix SmokeTestHostless on multiple games

### DIFF
--- a/test/system/SmokeTestHostless.cpp
+++ b/test/system/SmokeTestHostless.cpp
@@ -134,6 +134,7 @@ BOOST_AUTO_TEST_CASE(hostless_server) {
     }
 
     for (unsigned int g = 0; g < num_games; ++g) {
+        m_game_started = false;
         BOOST_TEST_MESSAGE("Game " << g << ". Connecting to server...");
 
         BOOST_REQUIRE(ConnectToServer("localhost"));


### PR DESCRIPTION
`SmokeTestHostless` doesn't start second and other games because it decides the game was already started.
This PR fixes it and start next games.