### PR TITLE
Transfer player connection to async handlers by shared pointer instead of raw pointer

### DIFF
--- a/network/ServerNetworking.cpp
+++ b/network/ServerNetworking.cpp
@@ -393,14 +393,14 @@ bool PlayerConnection::SyncWriteMessage(const Message& message) {
         ErrorLogger(network) << "PlayerConnection::WriteMessage(): player id = " << m_ID
                              << " error #" << error.value() << " \"" << error.message();
         boost::asio::high_resolution_timer t(m_service);
-        t.async_wait(boost::bind(&PlayerConnection::AsyncErrorHandler, this, error, boost::asio::placeholders::error));
+        t.async_wait(boost::bind(&PlayerConnection::AsyncErrorHandler, shared_from_this(), error, boost::asio::placeholders::error));
     }
 
     return (!error);
 }
 
-void PlayerConnection::AsyncErrorHandler(boost::system::error_code handled_error, boost::system::error_code error) {
-    EventSignal(boost::bind(m_disconnected_callback, shared_from_this()));
+void PlayerConnection::AsyncErrorHandler(PlayerConnectionPtr self, boost::system::error_code handled_error, boost::system::error_code error) {
+    self->EventSignal(boost::bind(self->m_disconnected_callback, self));
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/network/ServerNetworking.h
+++ b/network/ServerNetworking.h
@@ -296,7 +296,7 @@ private:
     void HandleMessageHeaderRead(boost::system::error_code error, std::size_t bytes_transferred);
     void AsyncReadMessage();
     bool SyncWriteMessage(const Message& message);
-    void AsyncErrorHandler(boost::system::error_code handled_error, boost::system::error_code error);
+    static void AsyncErrorHandler(PlayerConnectionPtr self, boost::system::error_code handled_error, boost::system::error_code error);
 
     boost::asio::io_service&        m_service;
     boost::asio::ip::tcp::socket    m_socket;


### PR DESCRIPTION
Prevent player connection object from being destructed before processed in async handlers.

Fix #2216 