### PR TITLE
Ship part meter value ref

### DIFF
--- a/parse/ConditionParser4.cpp
+++ b/parse/ConditionParser4.cpp
@@ -55,7 +55,7 @@ namespace parse { namespace detail {
             =   (
                 omit_[tok.ShipPartMeter_]
                 >   label(tok.Part_)    >   string_grammar
-                >   ship_part_meter_type_enum
+                >   label(tok.Meter_)   >   ship_part_meter_type_enum
                 >  -(label(tok.Low_)    >   double_rules.expr)
                 >  -(label(tok.High_)   >   double_rules.expr)
             ) [ _val = construct_movable_(new_<Condition::ShipPartMeterValue>(

--- a/parse/DoubleComplexValueRefParser.cpp
+++ b/parse/DoubleComplexValueRefParser.cpp
@@ -2,7 +2,7 @@
 
 #include "MovableEnvelope.h"
 #include "../universe/ValueRef.h"
-
+//#include "EnumParser.h"
 #include <boost/spirit/include/phoenix.hpp>
 
 namespace parse {
@@ -14,6 +14,8 @@ namespace parse {
     ) :
         double_complex_parser_grammar::base_type(start, "double_complex_parser_grammar"),
         simple_int_rules(tok)
+        //        ,
+        //        ship_part_meter_type_enum(tok)
     {
         namespace phoenix = boost::phoenix;
         namespace qi = boost::spirit::qi;
@@ -24,6 +26,7 @@ namespace parse {
         qi::_1_type _1;
         qi::_2_type _2;
         qi::_3_type _3;
+        qi::_4_type _4;
         qi::_val_type _val;
         qi::_pass_type _pass;
         qi::omit_type omit_;
@@ -122,6 +125,22 @@ namespace parse {
                 deconstruct_movable_(_2, _pass))) ]
             ;
 
+        part_meter
+            = ( tok.ShipPartMeter_
+                >   label(tok.Part_)    >   string_grammar
+                > label(tok.Name_) > string_grammar
+                //>   ship_part_meter_type_enum // probably Meter type
+                >> label(tok.Object_)
+                >  simple_int
+               ) [ _val = construct_movable_(new_<ValueRef::ComplexVariable<double>>(
+                _1,
+                deconstruct_movable_(_4, _pass),
+                nullptr,
+                nullptr,
+                deconstruct_movable_(_2, _pass),
+                deconstruct_movable_(_3, _pass) ))]
+            ;
+
         special_capacity
             = ( tok.SpecialCapacity_
                 >  label(tok.Name_) > string_grammar
@@ -143,16 +162,18 @@ namespace parse {
             |   shortest_path
             |   species_empire_opinion
             |   species_species_opinion
+            |   part_meter
             |   special_capacity
             ;
 
-        name_property_rule.name("GameRule; Hull Fuel, Stealth, Structure, or Speed; or PartCapacity");
+        name_property_rule.name("GameRule; Hull Fuel, Stealth, Structure, or Speed; or PartCapacity or PartSecondaryStat");
         empire_meter_value.name("EmpireMeterValue");
         direct_distance.name("DirectDistanceBetween");
         shortest_path.name("ShortestPathBetween");
         species_empire_opinion.name("SpeciesOpinion (of empire)");
         species_species_opinion.name("SpeciesOpinion (of species)");
         special_capacity.name("SpecialCapacity");
+        part_meter.name("ShipPartMeter");
 
 #if DEBUG_DOUBLE_COMPLEX_PARSERS
         debug(name_property_rule);
@@ -162,6 +183,7 @@ namespace parse {
         debug(species_empire_opinion);
         debug(species_species_opinion);
         debug(special_capacity);
+        debug(part_meter);
 #endif
     }
 }

--- a/parse/DoubleComplexValueRefParser.cpp
+++ b/parse/DoubleComplexValueRefParser.cpp
@@ -2,10 +2,13 @@
 
 #include "MovableEnvelope.h"
 #include "../universe/ValueRef.h"
-//#include "EnumParser.h"
+#include "EnumParser.h"
 #include <boost/spirit/include/phoenix.hpp>
 
 namespace parse {
+
+    BOOST_PHOENIX_ADAPT_FUNCTION(std::string, MeterToName_, ValueRef::MeterToName, 1)
+
     double_complex_parser_grammar::double_complex_parser_grammar(
         const lexer& tok,
         detail::Labeller& label,
@@ -13,9 +16,8 @@ namespace parse {
         const detail::value_ref_grammar<std::string>& string_grammar
     ) :
         double_complex_parser_grammar::base_type(start, "double_complex_parser_grammar"),
-        simple_int_rules(tok)
-        //        ,
-        //        ship_part_meter_type_enum(tok)
+        simple_int_rules(tok),
+        ship_part_meter_type_enum(tok)
     {
         namespace phoenix = boost::phoenix;
         namespace qi = boost::spirit::qi;
@@ -30,6 +32,7 @@ namespace parse {
         qi::_val_type _val;
         qi::_pass_type _pass;
         qi::omit_type omit_;
+
         const boost::phoenix::function<detail::construct_movable> construct_movable_;
         const boost::phoenix::function<detail::deconstruct_movable> deconstruct_movable_;
 
@@ -128,17 +131,17 @@ namespace parse {
         part_meter
             = ( tok.ShipPartMeter_
                 >   label(tok.Part_)    >   string_grammar
-                > label(tok.Name_) > string_grammar
-                //>   ship_part_meter_type_enum // probably Meter type
+                > label(tok.Meter_)
+                >   ship_part_meter_type_enum
                 >> label(tok.Object_)
                 >  simple_int
-               ) [ _val = construct_movable_(new_<ValueRef::ComplexVariable<double>>(
+              ) [ _val = construct_movable_(new_<ValueRef::ComplexVariable<double>>(
                 _1,
                 deconstruct_movable_(_4, _pass),
                 nullptr,
                 nullptr,
                 deconstruct_movable_(_2, _pass),
-                deconstruct_movable_(_3, _pass) ))]
+                deconstruct_movable_(construct_movable_(new_<ValueRef::Constant<std::string>>(MeterToName_(_3))), _pass) ))]
             ;
 
         special_capacity

--- a/parse/EnumParser.cpp
+++ b/parse/EnumParser.cpp
@@ -111,7 +111,6 @@ namespace parse {
             |   tok.TargetResearch_         [ _val = METER_TARGET_RESEARCH ]
             |   tok.TargetTrade_            [ _val = METER_TARGET_TRADE ]
             |   tok.TargetHappiness_        [ _val = METER_TARGET_HAPPINESS ]
-
             |   tok.MaxDefense_             [ _val = METER_MAX_DEFENSE ]
             |   tok.MaxFuel_                [ _val = METER_MAX_FUEL ]
             |   tok.MaxShield_              [ _val = METER_MAX_SHIELD ]
@@ -152,6 +151,8 @@ namespace parse {
             |   tok.MaxDamage_              [ _val = METER_MAX_CAPACITY ]
             |   tok.Capacity_               [ _val = METER_CAPACITY ]
             |   tok.Damage_                 [ _val = METER_CAPACITY ]
+            |   tok.SecondaryStat_          [ _val = METER_SECONDARY_STAT ]
+            |   tok.MaxSecondaryStat_       [ _val = METER_MAX_SECONDARY_STAT ]
             ;
     }
 

--- a/parse/Tokens.h
+++ b/parse/Tokens.h
@@ -215,6 +215,7 @@
     (MaxDefense)                                \
     (MaxFuel)                                   \
     (MaximumNumberOf)                           \
+    (MaxSecondaryStat)                          \
     (MaxShield)                                 \
     (MaxStockpile)                              \
     (MaxStructure)                              \
@@ -356,7 +357,8 @@
     (RMS)                                       \
     (RootCandidate)                             \
     (Round)                                     \
-    (Scope)
+    (Scope)                                     \
+    (SecondaryStat)
 
 #define TOKEN_SEQ_11                            \
     (SetAggressive)                             \

--- a/parse/ValueRefParser.h
+++ b/parse/ValueRefParser.h
@@ -265,7 +265,9 @@ namespace parse {
         detail::complex_variable_rule<double>   species_empire_opinion;
         detail::complex_variable_rule<double>   species_species_opinion;
         detail::complex_variable_rule<double>   special_capacity;
+        detail::complex_variable_rule<double>   part_meter;
         detail::complex_variable_rule<double>   start;
+        //        parse::ship_part_meter_enum_grammar     ship_part_meter_type_enum;
     };
 
     struct double_parser_rules : public detail::arithmetic_rules<double> {

--- a/parse/ValueRefParser.h
+++ b/parse/ValueRefParser.h
@@ -267,7 +267,7 @@ namespace parse {
         detail::complex_variable_rule<double>   special_capacity;
         detail::complex_variable_rule<double>   part_meter;
         detail::complex_variable_rule<double>   start;
-        //        parse::ship_part_meter_enum_grammar     ship_part_meter_type_enum;
+        parse::ship_part_meter_enum_grammar     ship_part_meter_type_enum;
     };
 
     struct double_parser_rules : public detail::arithmetic_rules<double> {

--- a/universe/ValueRef.cpp
+++ b/universe/ValueRef.cpp
@@ -2258,8 +2258,13 @@ double ComplexVariable<double>::Eval(const ScriptingContext& context) const
             return 0.0;
 
         MeterType meter_type = ValueRef::NameToMeter(meter_name);
+        if (meter_type != INVALID_METER_TYPE) {
+            if (m_return_immediate_value)
+                return ship->CurrentPartMeterValue(meter_type, part_name);
+            else
+                return ship->InitialPartMeterValue(meter_type, part_name);
+        }
 
-        return ship->CurrentPartMeterValue(meter_type, part_name);
     }
 
     return 0.0;

--- a/universe/ValueRef.cpp
+++ b/universe/ValueRef.cpp
@@ -2234,6 +2234,38 @@ double ComplexVariable<double>::Eval(const ScriptingContext& context) const
             return 0.0;
 
         return object->SpecialCapacity(special_name);
+    } else if (variable_name == "ShipPartMeter") {
+        int object_id = INVALID_OBJECT_ID;
+        if (m_int_ref1)
+            object_id = m_int_ref1->Eval(context);
+        auto object = GetUniverseObject(object_id);
+        if (!object)
+            return 0.0;
+        auto ship = std::dynamic_pointer_cast<const Ship>(object);
+        if (!ship)
+            return 0.0;
+
+        std::string part_name;
+        if (m_string_ref1)
+            part_name = m_string_ref1->Eval(context);
+        if (part_name.empty())
+            return 0.0;
+
+        std::string meter_name;
+        if (m_string_ref2)
+            meter_name = m_string_ref2->Eval(context);
+        if (meter_name.empty())
+            return 0.0;
+
+        MeterType meter_type;
+        if (meter_name.compare("MaxCapacity") == 0) {
+            meter_type = METER_MAX_CAPACITY;
+        }
+        meter_type = METER_CAPACITY;
+        //meter_type = METER_MAX_CAPACITY:
+        //METER_MAX_SECONDARY_STAT:
+
+        return ship->CurrentPartMeterValue(meter_type, part_name);
     }
 
     return 0.0;

--- a/universe/ValueRef.cpp
+++ b/universe/ValueRef.cpp
@@ -2257,13 +2257,7 @@ double ComplexVariable<double>::Eval(const ScriptingContext& context) const
         if (meter_name.empty())
             return 0.0;
 
-        MeterType meter_type;
-        if (meter_name.compare("MaxCapacity") == 0) {
-            meter_type = METER_MAX_CAPACITY;
-        }
-        meter_type = METER_CAPACITY;
-        //meter_type = METER_MAX_CAPACITY:
-        //METER_MAX_SECONDARY_STAT:
+        MeterType meter_type = ValueRef::NameToMeter(meter_name);
 
         return ship->CurrentPartMeterValue(meter_type, part_name);
     }


### PR DESCRIPTION
This PR is needs feedback in order to be finished.

This PR provides fixes two holes in FOCS:


Makes (Max)SecondaryStat ship part meters available in ShipPartMeter condition like in:
activation =  ShipPartMeter part = "SR_WEAPON_1_1" meter = SecondaryStat low = 1 high = 6


Provides ValueRef for ShipPartMeter like in:
effects =  ShipPartMeter part = "SR_WEAPON_1_1" meter = "Capacity" object = Source.ID

Questions (Answered):
* Q: should the condition also use a 'name = ' before the MeterType Enum? - A: Should use 'meter ='
* Q: should the valueref also use the MeterType Enum or is the string enough? I probably would need to add a MeterType member to ValueRef::ComplexVariable in order to use the enum - A: it should use the enum

