### PR TITLE
Repeal save game data request

### DIFF
--- a/AI/AIInterface.cpp
+++ b/AI/AIInterface.cpp
@@ -36,7 +36,7 @@ using boost::python::str;
 namespace {
     const float DUMMY_FLOAT = 0.0f;
 }
-    
+
 //////////////////////////////////
 //          AI Base             //
 //////////////////////////////////
@@ -61,7 +61,7 @@ void AIBase::StartNewGame()
 void AIBase::ResumeLoadedGame(const std::string& save_state_string)
 {}
 
-const std::string& AIBase::GetSaveStateString() {
+const std::string& AIBase::GetSaveStateString() const {
     static std::string default_state_string("AIBase default save state string");
     DebugLogger() << "AIBase::GetSaveStateString() returning: " << default_state_string;
     return default_state_string;
@@ -377,7 +377,7 @@ namespace AIInterface {
             ErrorLogger() << "IssueChangeProductionStockpileOrder : passed queue_index outside range of items on queue.";
             return 0;
         }
-        
+
         AIClientApp::GetApp()->Orders().IssueOrder(
             std::make_shared<ProductionQueueOrder>(empire_id, queue_index, use_stockpile, DUMMY_FLOAT, DUMMY_FLOAT));
 
@@ -433,7 +433,8 @@ namespace AIInterface {
 
     void DoneTurn() {
         DebugLogger() << "AIInterface::DoneTurn()";
-        AIClientApp::GetApp()->StartTurn(); // encodes order sets and sends turn orders message.  "done" the turn for the client, but "starts" the turn for the server
+        AIClientApp* app = AIClientApp::GetApp();
+        app->StartTurn(app->GetAI()->GetSaveStateString()); // encodes order sets and sends turn orders message.  "done" the turn for the client, but "starts" the turn for the server
     }
 
     void LogOutput(const std::string& log_text)

--- a/AI/AIInterface.h
+++ b/AI/AIInterface.h
@@ -97,7 +97,7 @@ public:
      *
      * @return The serialized state information of the game running.
      */
-    virtual const std::string& GetSaveStateString();
+    virtual const std::string& GetSaveStateString() const;
 
     /** @brief Set the aggressiveness of this AI
      *

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -510,6 +510,9 @@ bool FleetUIManager::CloseAll() {
     m_active_fleet_wnd.reset();
     ActiveFleetWndChangedSignal();
 
+    // send order changes could be made on fleets
+    HumanClientApp::GetApp()->SendPartialOrders();
+
     return retval;
 }
 
@@ -529,6 +532,9 @@ void FleetUIManager::FleetWndClosing(FleetWnd* fleet_wnd) {
         m_active_fleet_wnd.reset();
         ActiveFleetWndChangedSignal();
     }
+
+    // send order changes could be made on this fleet
+    HumanClientApp::GetApp()->SendPartialOrders();
 }
 
 void FleetUIManager::FleetWndClicked(std::shared_ptr<FleetWnd> fleet_wnd) {
@@ -3491,7 +3497,7 @@ void FleetWnd::FleetRightClicked(GG::ListBox::iterator it, const GG::Pt& pt, con
 
 
     auto popup = GG::Wnd::Create<CUIPopupMenu>(pt.x, pt.y);
-    
+
     // add a fleet popup command to send the fleet exploring, and stop it from exploring
     if (system
         && !ClientUI::GetClientUI()->GetMapWnd()->IsFleetExploring(fleet->ID())

--- a/UI/InGameMenu.cpp
+++ b/UI/InGameMenu.cpp
@@ -170,6 +170,7 @@ void InGameMenu::Save() {
         return;
     }
 
+    // send order changes could be made when player decide to save game
     app->SendPartialOrders();
 
     try {

--- a/UI/InGameMenu.cpp
+++ b/UI/InGameMenu.cpp
@@ -170,6 +170,8 @@ void InGameMenu::Save() {
         return;
     }
 
+    app->SendPartialOrders();
+
     try {
         // When saving in multiplayer, you cannot see the old saves or
         // browse directories, only give a save file name.

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -6445,6 +6445,8 @@ void MapWnd::HideSidePanel() {
 void MapWnd::RestoreSidePanel() {
     if (m_sidepanel_open_before_showing_other)
         ReselectLastSystem();
+    // send order changes could be made in research, production or other windows
+    HumanClientApp::GetApp()->SendPartialOrders();
 }
 
 void MapWnd::ShowResearch() {

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -5597,7 +5597,7 @@ std::vector<int> MapWnd::FleetIDsOfFleetButtonsOverlapping(int fleet_id) const {
         int vis_turn = -1;
         if (vis_turn_map.find(VIS_BASIC_VISIBILITY) != vis_turn_map.end())
             vis_turn = vis_turn_map[VIS_BASIC_VISIBILITY];
-        ErrorLogger() << "Couldn't find a FleetButton for fleet " << fleet_id 
+        ErrorLogger() << "Couldn't find a FleetButton for fleet " << fleet_id
                       << " with last basic vis turn " << vis_turn;
         return fleet_ids;
     }
@@ -6137,7 +6137,12 @@ bool MapWnd::EndTurn() {
     if (m_ready_turn) {
         HumanClientApp::GetApp()->UnreadyTurn();
     } else {
-        HumanClientApp::GetApp()->StartTurn();
+        ClientUI* cui = ClientUI::GetClientUI();
+        if (!cui)
+            return false;
+        SaveGameUIData ui_data;
+        cui->GetSaveGameUIData(ui_data);
+        HumanClientApp::GetApp()->StartTurn(ui_data);
     }
     return true;
 }

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -6138,8 +6138,10 @@ bool MapWnd::EndTurn() {
         HumanClientApp::GetApp()->UnreadyTurn();
     } else {
         ClientUI* cui = ClientUI::GetClientUI();
-        if (!cui)
+        if (!cui) {
+            ErrorLogger() << "MapWnd::EndTurn: No client UI available";
             return false;
+        }
         SaveGameUIData ui_data;
         cui->GetSaveGameUIData(ui_data);
         HumanClientApp::GetApp()->StartTurn(ui_data);

--- a/UI/MapWnd.h
+++ b/UI/MapWnd.h
@@ -412,7 +412,7 @@ private:
     bool ShowGraphs();
 
     void HideSidePanel();
-    void RestoreSidePanel();
+    void RestoreSidePanel(); //!< restores side panel, sends to server changes made in other windows
 
     bool ToggleResearch();
     void ShowResearch();

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -2657,6 +2657,9 @@ void SidePanel::PlanetPanelContainer::SelectPlanet(int planet_id) {
             m_selected_planet_id = INVALID_OBJECT_ID;
             //std::cout << " ... no planet with requested ID found" << std::endl;
         }
+
+        // send order changes could be made on other planets
+        HumanClientApp::GetApp()->SendPartialOrders();
     }
 }
 

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -324,13 +324,6 @@ void AIClientApp::HandleMessage(const Message& msg) {
         break;
     }
 
-    case Message::SAVE_GAME_DATA_REQUEST: {
-        //DebugLogger() << "AIClientApp::HandleMessage Message::SAVE_GAME_DATA_REQUEST";
-        Networking().SendMessage(ClientSaveDataMessage(Orders(), m_AI->GetSaveStateString()));
-        //DebugLogger() << "AIClientApp::HandleMessage sent save data message";
-        break;
-    }
-
     case Message::SAVE_GAME_COMPLETE:
         break;
 

--- a/client/ClientApp.cpp
+++ b/client/ClientApp.cpp
@@ -123,7 +123,10 @@ void ClientApp::StartTurn(const std::string& save_state_string)
 { m_networking->SendMessage(TurnOrdersMessage(m_orders, save_state_string)); }
 
 void ClientApp::SendPartialOrders() {
-    m_networking->SendMessage(TurnPartialOrdersMessage(m_orders.ExtractChanges()));
+    auto changes = m_orders.ExtractChanges();
+    if (changes.first.empty() && changes.second.empty())
+        return;
+    m_networking->SendMessage(TurnPartialOrdersMessage(changes));
 }
 
 void ClientApp::HandleTurnPhaseUpdate(Message::TurnProgressPhase phase_id) {

--- a/client/ClientApp.cpp
+++ b/client/ClientApp.cpp
@@ -116,8 +116,13 @@ void ClientApp::SetEmpireStatus(int empire_id, Message::PlayerStatus status) {
     m_empire_status[empire_id] = status;
 }
 
-void ClientApp::StartTurn()
-{ m_networking->SendMessage(TurnOrdersMessage(m_orders)); }
+void ClientApp::StartTurn() {
+    if (m_ui_data) {
+        m_networking->SendMessage(TurnOrdersMessage(m_orders, *m_ui_data));
+    } else {
+        m_networking->SendMessage(TurnOrdersMessage(m_orders, m_ai_data));
+    }
+}
 
 void ClientApp::HandleTurnPhaseUpdate(Message::TurnProgressPhase phase_id) {
     switch (phase_id) {

--- a/client/ClientApp.cpp
+++ b/client/ClientApp.cpp
@@ -122,6 +122,10 @@ void ClientApp::StartTurn(const SaveGameUIData& ui_data)
 void ClientApp::StartTurn(const std::string& save_state_string)
 { m_networking->SendMessage(TurnOrdersMessage(m_orders, save_state_string)); }
 
+void ClientApp::SendPartialOrders() {
+    m_networking->SendMessage(TurnPartialOrdersMessage(m_orders.ExtractChanges()));
+}
+
 void ClientApp::HandleTurnPhaseUpdate(Message::TurnProgressPhase phase_id) {
     switch (phase_id) {
     case Message::WAITING_FOR_PLAYERS:

--- a/client/ClientApp.cpp
+++ b/client/ClientApp.cpp
@@ -116,13 +116,11 @@ void ClientApp::SetEmpireStatus(int empire_id, Message::PlayerStatus status) {
     m_empire_status[empire_id] = status;
 }
 
-void ClientApp::StartTurn() {
-    if (m_ui_data) {
-        m_networking->SendMessage(TurnOrdersMessage(m_orders, *m_ui_data));
-    } else {
-        m_networking->SendMessage(TurnOrdersMessage(m_orders, m_ai_data));
-    }
-}
+void ClientApp::StartTurn(const SaveGameUIData &ui_data)
+{ m_networking->SendMessage(TurnOrdersMessage(m_orders, ui_data)); }
+
+void ClientApp::StartTurn(const std::string& save_state_string)
+{ m_networking->SendMessage(TurnOrdersMessage(m_orders, save_state_string)); }
 
 void ClientApp::HandleTurnPhaseUpdate(Message::TurnProgressPhase phase_id) {
     switch (phase_id) {

--- a/client/ClientApp.cpp
+++ b/client/ClientApp.cpp
@@ -116,7 +116,7 @@ void ClientApp::SetEmpireStatus(int empire_id, Message::PlayerStatus status) {
     m_empire_status[empire_id] = status;
 }
 
-void ClientApp::StartTurn(const SaveGameUIData &ui_data)
+void ClientApp::StartTurn(const SaveGameUIData& ui_data)
 { m_networking->SendMessage(TurnOrdersMessage(m_orders, ui_data)); }
 
 void ClientApp::StartTurn(const std::string& save_state_string)

--- a/client/ClientApp.h
+++ b/client/ClientApp.h
@@ -161,8 +161,11 @@ public:
      */
     std::string GetVisibleObjectName(std::shared_ptr<const UniverseObject> object) override;
 
-    /** @brief Send the OrderSet to the server and start a new turn */
-    virtual void StartTurn();
+    /** @brief Send the OrderSet and UI data to the server and start a new turn */
+    virtual void StartTurn(const SaveGameUIData &ui_data);
+
+    /** @brief Send the OrderSet and AI state to the server and start a new turn */
+    virtual void StartTurn(const std::string& save_state_string);
 
     /** \brief Handle server acknowledgement of receipt of orders and clear
         the orders. */
@@ -260,8 +263,6 @@ protected:
     EmpireManager               m_empires;
     SupplyManager               m_supply_manager;
     OrderSet                    m_orders;
-    std::unique_ptr<SaveGameUIData> m_ui_data; ///< Saved UI data for non-AI players
-    std::string                 m_ai_data; ///< Saved AI state
     std::shared_ptr<ClientNetworking> m_networking;
     int                         m_empire_id;
     int                         m_current_turn;

--- a/client/ClientApp.h
+++ b/client/ClientApp.h
@@ -162,7 +162,7 @@ public:
     std::string GetVisibleObjectName(std::shared_ptr<const UniverseObject> object) override;
 
     /** @brief Send the OrderSet and UI data to the server and start a new turn */
-    virtual void StartTurn(const SaveGameUIData &ui_data);
+    virtual void StartTurn(const SaveGameUIData& ui_data);
 
     /** @brief Send the OrderSet and AI state to the server and start a new turn */
     virtual void StartTurn(const std::string& save_state_string);

--- a/client/ClientApp.h
+++ b/client/ClientApp.h
@@ -167,6 +167,9 @@ public:
     /** @brief Send the OrderSet and AI state to the server and start a new turn */
     virtual void StartTurn(const std::string& save_state_string);
 
+    /** @brief Send turn orders updates to server without starting new turn */
+    void SendPartialOrders();
+
     /** \brief Handle server acknowledgement of receipt of orders and clear
         the orders. */
     virtual void HandleTurnPhaseUpdate(Message::TurnProgressPhase phase_id);

--- a/client/ClientApp.h
+++ b/client/ClientApp.h
@@ -260,6 +260,8 @@ protected:
     EmpireManager               m_empires;
     SupplyManager               m_supply_manager;
     OrderSet                    m_orders;
+    std::unique_ptr<SaveGameUIData> m_ui_data; ///< Saved UI data for non-AI players
+    std::string                 m_ai_data; ///< Saved AI state
     std::shared_ptr<ClientNetworking> m_networking;
     int                         m_empire_id;
     int                         m_current_turn;

--- a/client/ClientFSMEvents.h
+++ b/client/ClientFSMEvents.h
@@ -28,7 +28,6 @@ struct MessageEventBase {
     (HostID)                                   \
     (LobbyUpdate)                              \
     (LobbyChat)                                \
-    (SaveGameDataRequest)                      \
     (SaveGameComplete)                         \
     (GameStart)                                \
     (TurnUpdate)                               \

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -908,7 +908,7 @@ void HumanClientApp::Reinitialize() {
 float HumanClientApp::GLVersion() const
 { return GetGLVersion(); }
 
-void HumanClientApp::StartTurn(const SaveGameUIData &ui_data) {
+void HumanClientApp::StartTurn(const SaveGameUIData& ui_data) {
     DebugLogger() << "HumanClientApp::StartTurn";
 
     if (const Empire* empire = GetEmpire(EmpireID())) {

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -908,7 +908,7 @@ void HumanClientApp::Reinitialize() {
 float HumanClientApp::GLVersion() const
 { return GetGLVersion(); }
 
-void HumanClientApp::StartTurn() {
+void HumanClientApp::StartTurn(const SaveGameUIData &ui_data) {
     DebugLogger() << "HumanClientApp::StartTurn";
 
     if (const Empire* empire = GetEmpire(EmpireID())) {
@@ -930,7 +930,7 @@ void HumanClientApp::StartTurn() {
         Autosave();
     }
 
-    ClientApp::StartTurn();
+    ClientApp::StartTurn(ui_data);
     m_fsm->process_event(TurnEnded());
 }
 

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -975,7 +975,6 @@ void HumanClientApp::HandleMessage(Message& msg) {
     case Message::JOIN_GAME:                m_fsm->process_event(JoinGame(msg));                break;
     case Message::HOST_ID:                  m_fsm->process_event(HostID(msg));                  break;
     case Message::LOBBY_UPDATE:             m_fsm->process_event(LobbyUpdate(msg));             break;
-    case Message::SAVE_GAME_DATA_REQUEST:   m_fsm->process_event(SaveGameDataRequest(msg));     break;
     case Message::SAVE_GAME_COMPLETE:       m_fsm->process_event(SaveGameComplete(msg));        break;
     case Message::CHECKSUM:                 m_fsm->process_event(CheckSum(msg));                break;
     case Message::GAME_START:               m_fsm->process_event(GameStart(msg));               break;
@@ -997,14 +996,6 @@ void HumanClientApp::HandleMessage(Message& msg) {
     default:
         ErrorLogger() << "HumanClientApp::HandleMessage : Received an unknown message type \"" << msg.Type() << "\".";
     }
-}
-
-void HumanClientApp::HandleSaveGameDataRequest() {
-    if (INSTRUMENT_MESSAGE_HANDLING)
-        std::cerr << "HumanClientApp::HandleSaveGameDataRequest(" << Message::SAVE_GAME_DATA_REQUEST << ")\n";
-    SaveGameUIData ui_data;
-    m_ui->GetSaveGameUIData(ui_data);
-    m_networking->SendMessage(ClientSaveDataMessage(Orders(), ui_data));
 }
 
 void HumanClientApp::UpdateCombatLogs(const Message& msg){

--- a/client/human/HumanClientApp.h
+++ b/client/human/HumanClientApp.h
@@ -48,7 +48,7 @@ public:
 
     /** \name Mutators */ //@{
     void HandleTurnUpdate() override;           ///< Handle background events that need starting when the turn updates
-    void StartTurn(const SaveGameUIData &ui_data) override;
+    void StartTurn(const SaveGameUIData& ui_data) override;
     void UnreadyTurn();                         ///< Revoke ready state of turn orders.
 
     /** \brief Handle UI and state updates with changes in turn phase. */

--- a/client/human/HumanClientApp.h
+++ b/client/human/HumanClientApp.h
@@ -97,7 +97,6 @@ public:
     void Reinitialize();
     float GLVersion() const;
 
-    void HandleSaveGameDataRequest();
     void UpdateCombatLogs(const Message& msg);
     /** Update any open SaveGameDialog with previews from the server. */
     void HandleSaveGamePreviews(const Message& msg);

--- a/client/human/HumanClientApp.h
+++ b/client/human/HumanClientApp.h
@@ -48,7 +48,7 @@ public:
 
     /** \name Mutators */ //@{
     void HandleTurnUpdate() override;           ///< Handle background events that need starting when the turn updates
-    void StartTurn() override;
+    void StartTurn(const SaveGameUIData &ui_data) override;
     void UnreadyTurn();                         ///< Revoke ready state of turn orders.
 
     /** \brief Handle UI and state updates with changes in turn phase. */

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -1007,7 +1007,9 @@ boost::statechart::result PlayingTurn::react(const SaveGameComplete& msg) {
 }
 
 boost::statechart::result PlayingTurn::react(const AdvanceTurn& d) {
-    Client().StartTurn();
+    SaveGameUIData ui_data;
+    Client().GetClientUI().GetSaveGameUIData(ui_data);
+    Client().StartTurn(ui_data);
     return discard_event();
 }
 

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -876,14 +876,6 @@ WaitingForTurnData::WaitingForTurnData(my_context ctx) :
 WaitingForTurnData::~WaitingForTurnData()
 { TraceLogger(FSM) << "(HumanClientFSM) ~WaitingForTurnData"; }
 
-boost::statechart::result WaitingForTurnData::react(const SaveGameDataRequest& msg) {
-    TraceLogger(FSM) << "(HumanClientFSM) WaitingForTurnData.SaveGameDataRequest";
-    DebugLogger(FSM) << "Sending Save Game Data to Server";
-    Client().GetClientUI().GetMessageWnd()->HandleGameStatusUpdate(UserString("SERVER_SAVE_INITIATE_ACK") + "\n");
-    Client().HandleSaveGameDataRequest();
-    return discard_event();
-}
-
 boost::statechart::result WaitingForTurnData::react(const SaveGameComplete& msg) {
     TraceLogger(FSM) << "(HumanClientFSM) WaitingForTurnData.SaveGameComplete";
 
@@ -989,14 +981,6 @@ PlayingTurn::PlayingTurn(my_context ctx) :
 
 PlayingTurn::~PlayingTurn()
 { TraceLogger(FSM) << "(HumanClientFSM) ~PlayingTurn"; }
-
-boost::statechart::result PlayingTurn::react(const SaveGameDataRequest& msg) {
-    TraceLogger(FSM) << "(HumanClientFSM) PlayingTurn.SaveGameDataRequest";
-    DebugLogger(FSM) << "Sending Save Game Data to Server";
-    Client().GetClientUI().GetMessageWnd()->HandleGameStatusUpdate(UserString("SERVER_SAVE_INITIATE_ACK") + "\n");
-    Client().HandleSaveGameDataRequest();
-    return discard_event();
-}
 
 boost::statechart::result PlayingTurn::react(const SaveGameComplete& msg) {
     TraceLogger(FSM) << "(HumanClientFSM) PlayingTurn.SaveGameComplete";

--- a/client/human/HumanClientFSM.h
+++ b/client/human/HumanClientFSM.h
@@ -315,7 +315,6 @@ struct WaitingForTurnData : boost::statechart::state<WaitingForTurnData, Playing
     typedef boost::statechart::state<WaitingForTurnData, PlayingGame> Base;
 
     typedef boost::mpl::list<
-        boost::statechart::custom_reaction<SaveGameDataRequest>,
         boost::statechart::custom_reaction<SaveGameComplete>,
         boost::statechart::custom_reaction<TurnUpdate>,
         boost::statechart::custom_reaction<TurnRevoked>,
@@ -325,7 +324,6 @@ struct WaitingForTurnData : boost::statechart::state<WaitingForTurnData, Playing
     WaitingForTurnData(my_context ctx);
     ~WaitingForTurnData();
 
-    boost::statechart::result react(const SaveGameDataRequest& d);
     boost::statechart::result react(const SaveGameComplete& d);
     boost::statechart::result react(const TurnUpdate& msg);
     boost::statechart::result react(const TurnRevoked& msg);
@@ -340,7 +338,6 @@ struct PlayingTurn : boost::statechart::state<PlayingTurn, PlayingGame> {
     typedef boost::statechart::state<PlayingTurn, PlayingGame> Base;
 
     typedef boost::mpl::list<
-        boost::statechart::custom_reaction<SaveGameDataRequest>,
         boost::statechart::custom_reaction<SaveGameComplete>,
         boost::statechart::custom_reaction<AdvanceTurn>,
         boost::statechart::custom_reaction<TurnUpdate>,
@@ -352,7 +349,6 @@ struct PlayingTurn : boost::statechart::state<PlayingTurn, PlayingGame> {
     PlayingTurn(my_context ctx);
     ~PlayingTurn();
 
-    boost::statechart::result react(const SaveGameDataRequest& d);
     boost::statechart::result react(const SaveGameComplete& d);
     boost::statechart::result react(const AdvanceTurn& d);
     boost::statechart::result react(const TurnUpdate& msg);

--- a/network/Message.cpp
+++ b/network/Message.cpp
@@ -384,6 +384,14 @@ Message TurnOrdersMessage(const OrderSet& orders, const std::string& save_state_
     return Message(Message::TURN_ORDERS, os.str());
 }
 
+Message TurnPartialOrdersMessage() {
+    std::ostringstream os;
+    {
+        freeorion_xml_oarchive oa(os);
+    }
+    return Message(Message::TURN_PARTIAL_ORDERS, os.str());
+}
+
 Message TurnProgressMessage(Message::TurnProgressPhase phase_id) {
     std::ostringstream os;
     {
@@ -916,9 +924,13 @@ void ExtractJoinAckMessageData(const Message& msg, int& player_id,
     }
 }
 
-void ExtractTurnOrdersMessageData(const Message& msg, OrderSet& orders, bool& ui_data_available,
-                                      SaveGameUIData& ui_data, bool& save_state_string_available,
-                                      std::string& save_state_string) {
+void ExtractTurnOrdersMessageData(const Message& msg,
+                                  OrderSet& orders,
+                                  bool& ui_data_available,
+                                  SaveGameUIData& ui_data,
+                                  bool& save_state_string_available,
+                                  std::string& save_state_string)
+{
     try {
         std::istringstream is(msg.Text());
         freeorion_xml_iarchive ia(is);
@@ -938,7 +950,19 @@ void ExtractTurnOrdersMessageData(const Message& msg, OrderSet& orders, bool& ui
         }
 
     } catch (const std::exception& err) {
-        ErrorLogger() << "ExtractTurnOrdersMessageData(const Message& msg, OrderSet& orders) failed! Message probably long, so not outputting to log.\n"
+        ErrorLogger() << "ExtractTurnOrdersMessageData(const Message& msg, ...) failed! Message probably long, so not outputting to log.\n"
+                      << "Error: " << err.what();
+        throw err;
+    }
+}
+
+void ExtractTurnPartialOrdersMessageData(const Message& msg) {
+    try {
+        std::istringstream is(msg.Text());
+        freeorion_xml_iarchive ia(is);
+        DebugLogger() << "deserializing partial orders";
+    } catch (const std::exception& err) {
+        ErrorLogger() << "ExtractTurnPartialOrdersMessageData(const Message& msg) failed! Message probably long, so not outputting to log.\n"
                       << "Error: " << err.what();
         throw err;
     }

--- a/network/Message.h
+++ b/network/Message.h
@@ -247,8 +247,8 @@ FO_COMMON_API Message TurnOrdersMessage(const OrderSet& orders, const SaveGameUI
 /** creates a TURN_ORDERS message, without UI data but with a state string. */
 FO_COMMON_API Message TurnOrdersMessage(const OrderSet& orders, const std::string& save_state_string);
 
-/** creates a TURN_PARTIAL_ORDERS message. \todo give it some data */
-FO_COMMON_API Message TurnPartialOrdersMessage();
+/** creates a TURN_PARTIAL_ORDERS message with orders changes. */
+FO_COMMON_API Message TurnPartialOrdersMessage(const std::pair<OrderSet, std::set<int>>& orders_updates);
 
 /** creates a TURN_PROGRESS message. */
 FO_COMMON_API Message TurnProgressMessage(Message::TurnProgressPhase phase_id);
@@ -405,7 +405,7 @@ FO_COMMON_API void ExtractTurnOrdersMessageData(const Message& msg,
                                                 bool& save_state_string_available,
                                                 std::string& save_state_string);
 
-FO_COMMON_API void ExtractTurnPartialOrdersMessageData(const Message& msg);
+FO_COMMON_API void ExtractTurnPartialOrdersMessageData(const Message& msg, OrderSet& added, std::set<int>& deleted);
 
 FO_COMMON_API void ExtractTurnUpdateMessageData(const Message& msg, int empire_id, int& current_turn, EmpireManager& empires,
                                                 Universe& universe, SpeciesManager& species, CombatLogManager& combat_logs,

--- a/network/Message.h
+++ b/network/Message.h
@@ -72,7 +72,6 @@ public:
         LOBBY_EXIT,             ///< sent to server by clients when a player leaves the multiplayer lobby, or by server to clients when a player leaves the multiplayer lobby
         START_MP_GAME,          ///< sent to server (by the "host" client only) when the settings in the MP lobby are satisfactory and it is time to start the game
         SAVE_GAME_INITIATE,     ///< sent to server (by the "host" client only) when a game is to be saved
-        SAVE_GAME_DATA_REQUEST, ///< sent to clients by the server when the game is being saved and the server needs save state info from clients (removed)
         SAVE_GAME_COMPLETE,     ///< sent to clients (by the "host" client only) when a game has been saved and written to disk
         LOAD_GAME,              ///< sent to server (by the "host" client only) when a game is to be loaded
         GAME_START,             ///< sent to each client before the first turn of a new or newly loaded game, instead of a TURN_UPDATE
@@ -81,7 +80,6 @@ public:
         TURN_ORDERS,            ///< sent to the server by a client that has orders to be processed at the end of a turn
         TURN_PROGRESS,          ///< sent to clients to display a turn progress message
         PLAYER_STATUS,          ///< sent to clients to inform them that a player has some status, such as having finished playing a turn and submitted orders, or is resolving combat, or is playing a turn normally
-        CLIENT_SAVE_DATA,       ///< sent to the server in response to a server request for the data needed to create a save file (removed)
         PLAYER_CHAT,            ///< sent when one player sends a chat message to another in multiplayer
         DIPLOMACY,              ///< sent by players to server or server to players to make or convey diplomatic proposals or declarations, or to accept / reject proposals from other players
         DIPLOMATIC_STATUS,      ///< sent by server to players to inform of mid-turn diplomatic status changes

--- a/network/Message.h
+++ b/network/Message.h
@@ -102,7 +102,8 @@ public:
         CHAT_HISTORY,           ///< sent by server to client to show previous messages
         SET_AUTH_ROLES,         ///< sent by server to client to set authorization roles
         ELIMINATE_SELF,         ///< sent by client to server if the player wants to resign
-        UNREADY                 ///< sent by client to server to revoke ready state of turn orders and sent by server to client to acknowledge it
+        UNREADY,                ///< sent by client to server to revoke ready state of turn orders and sent by server to client to acknowledge it
+        TURN_PARTIAL_ORDERS     ///< sent to the server by a client that has changes in orders to be stored
     )
 
     GG_CLASS_ENUM(TurnProgressPhase,
@@ -245,6 +246,9 @@ FO_COMMON_API Message TurnOrdersMessage(const OrderSet& orders, const SaveGameUI
 
 /** creates a TURN_ORDERS message, without UI data but with a state string. */
 FO_COMMON_API Message TurnOrdersMessage(const OrderSet& orders, const std::string& save_state_string);
+
+/** creates a TURN_PARTIAL_ORDERS message. \todo give it some data */
+FO_COMMON_API Message TurnPartialOrdersMessage();
 
 /** creates a TURN_PROGRESS message. */
 FO_COMMON_API Message TurnProgressMessage(Message::TurnProgressPhase phase_id);
@@ -394,9 +398,14 @@ FO_COMMON_API void ExtractJoinGameMessageData(const Message& msg, std::string& p
 FO_COMMON_API void ExtractJoinAckMessageData(const Message& msg, int& player_id,
                                              boost::uuids::uuid& cookie);
 
-FO_COMMON_API void ExtractTurnOrdersMessageData(const Message& msg, OrderSet& orders, bool& ui_data_available,
-                                                SaveGameUIData& ui_data, bool& save_state_string_available,
+FO_COMMON_API void ExtractTurnOrdersMessageData(const Message& msg,
+                                                OrderSet& orders,
+                                                bool& ui_data_available,
+                                                SaveGameUIData& ui_data,
+                                                bool& save_state_string_available,
                                                 std::string& save_state_string);
+
+FO_COMMON_API void ExtractTurnPartialOrdersMessageData(const Message& msg);
 
 FO_COMMON_API void ExtractTurnUpdateMessageData(const Message& msg, int empire_id, int& current_turn, EmpireManager& empires,
                                                 Universe& universe, SpeciesManager& species, CombatLogManager& combat_logs,

--- a/network/Message.h
+++ b/network/Message.h
@@ -72,7 +72,7 @@ public:
         LOBBY_EXIT,             ///< sent to server by clients when a player leaves the multiplayer lobby, or by server to clients when a player leaves the multiplayer lobby
         START_MP_GAME,          ///< sent to server (by the "host" client only) when the settings in the MP lobby are satisfactory and it is time to start the game
         SAVE_GAME_INITIATE,     ///< sent to server (by the "host" client only) when a game is to be saved
-        SAVE_GAME_DATA_REQUEST, ///< sent to clients by the server when the game is being saved and the server needs save state info from clients
+        //SAVE_GAME_DATA_REQUEST, ///< sent to clients by the server when the game is being saved and the server needs save state info from clients (removed)
         SAVE_GAME_COMPLETE,     ///< sent to clients (by the "host" client only) when a game has been saved and written to disk
         LOAD_GAME,              ///< sent to server (by the "host" client only) when a game is to be loaded
         GAME_START,             ///< sent to each client before the first turn of a new or newly loaded game, instead of a TURN_UPDATE
@@ -81,7 +81,7 @@ public:
         TURN_ORDERS,            ///< sent to the server by a client that has orders to be processed at the end of a turn
         TURN_PROGRESS,          ///< sent to clients to display a turn progress message
         PLAYER_STATUS,          ///< sent to clients to inform them that a player has some status, such as having finished playing a turn and submitted orders, or is resolving combat, or is playing a turn normally
-        CLIENT_SAVE_DATA,       ///< sent to the server in response to a server request for the data needed to create a save file
+        //CLIENT_SAVE_DATA,       ///< sent to the server in response to a server request for the data needed to create a save file (removed)
         PLAYER_CHAT,            ///< sent when one player sends a chat message to another in multiplayer
         DIPLOMACY,              ///< sent by players to server or server to players to make or convey diplomatic proposals or declarations, or to accept / reject proposals from other players
         DIPLOMATIC_STATUS,      ///< sent by server to players to inform of mid-turn diplomatic status changes
@@ -242,8 +242,11 @@ FO_COMMON_API Message HostMPAckMessage(int player_id);
   * This message should only be sent by the server.*/
 FO_COMMON_API Message JoinAckMessage(int player_id, boost::uuids::uuid cookie);
 
-/** creates a TURN_ORDERS message. */
-FO_COMMON_API Message TurnOrdersMessage(const OrderSet& orders);
+/** creates a TURN_ORDERS message, including UI data but without a state string. */
+FO_COMMON_API Message TurnOrdersMessage(const OrderSet& orders, const SaveGameUIData& ui_data);
+
+/** creates a TURN_ORDERS message, without UI data but with a state string. */
+FO_COMMON_API Message TurnOrdersMessage(const OrderSet& orders, const std::string& save_state_string);
 
 /** creates a TURN_PROGRESS message. */
 FO_COMMON_API Message TurnProgressMessage(Message::TurnProgressPhase phase_id);
@@ -264,23 +267,9 @@ FO_COMMON_API Message TurnUpdateMessage(int empire_id, int current_turn,
 FO_COMMON_API Message TurnPartialUpdateMessage(int empire_id, const Universe& universe,
                                                bool use_binary_serialization);
 
-/** creates a CLIENT_SAVE_DATA message, including UI data but without a state string. */
-FO_COMMON_API Message ClientSaveDataMessage(const OrderSet& orders, const SaveGameUIData& ui_data);
-
-/** creates a CLIENT_SAVE_DATA message, without UI data but with a state string. */
-FO_COMMON_API Message ClientSaveDataMessage(const OrderSet& orders, const std::string& save_state_string);
-
-/** creates a CLIENT_SAVE_DATA message, without UI data and without a state string. */
-FO_COMMON_API Message ClientSaveDataMessage(const OrderSet& orders);
-
 /** creates a SAVE_GAME_INITIATE request message.  This message should only be sent by
   * the host player.*/
 FO_COMMON_API Message HostSaveGameInitiateMessage(const std::string& filename);
-
-/** creates a SAVE_GAME_DATA_REQUEST data request message.  This message should
-    only be sent by the server to get game data from a client, or to respond to
-    the host player requesting a save be initiated. */
-FO_COMMON_API Message ServerSaveGameDataRequestMessage();
 
 /** creates a SAVE_GAME_COMPLETE complete message.  This message should only be
     sent by the server to inform clients that the last initiated save has been
@@ -407,7 +396,9 @@ FO_COMMON_API void ExtractJoinGameMessageData(const Message& msg, std::string& p
 FO_COMMON_API void ExtractJoinAckMessageData(const Message& msg, int& player_id,
                                              boost::uuids::uuid& cookie);
 
-FO_COMMON_API void ExtractTurnOrdersMessageData(const Message& msg, OrderSet& orders);
+FO_COMMON_API void ExtractTurnOrdersMessageData(const Message& msg, OrderSet& orders, bool& ui_data_available,
+                                                SaveGameUIData& ui_data, bool& save_state_string_available,
+                                                std::string& save_state_string);
 
 FO_COMMON_API void ExtractTurnUpdateMessageData(const Message& msg, int empire_id, int& current_turn, EmpireManager& empires,
                                                 Universe& universe, SpeciesManager& species, CombatLogManager& combat_logs,
@@ -415,10 +406,10 @@ FO_COMMON_API void ExtractTurnUpdateMessageData(const Message& msg, int empire_i
 
 FO_COMMON_API void ExtractTurnPartialUpdateMessageData(const Message& msg, int empire_id, Universe& universe);
 
-FO_COMMON_API void ExtractClientSaveDataMessageData(const Message& msg, OrderSet& orders,
+/*FO_COMMON_API void ExtractClientSaveDataMessageData(const Message& msg, OrderSet& orders,
                                                     bool& ui_data_available, SaveGameUIData& ui_data,
                                                     bool& save_state_string_available,
-                                                    std::string& save_state_string);
+                                                    std::string& save_state_string);*/
 
 FO_COMMON_API void ExtractTurnProgressMessageData(const Message& msg, Message::TurnProgressPhase& phase_id);
 

--- a/network/Message.h
+++ b/network/Message.h
@@ -72,7 +72,7 @@ public:
         LOBBY_EXIT,             ///< sent to server by clients when a player leaves the multiplayer lobby, or by server to clients when a player leaves the multiplayer lobby
         START_MP_GAME,          ///< sent to server (by the "host" client only) when the settings in the MP lobby are satisfactory and it is time to start the game
         SAVE_GAME_INITIATE,     ///< sent to server (by the "host" client only) when a game is to be saved
-        //SAVE_GAME_DATA_REQUEST, ///< sent to clients by the server when the game is being saved and the server needs save state info from clients (removed)
+        SAVE_GAME_DATA_REQUEST, ///< sent to clients by the server when the game is being saved and the server needs save state info from clients (removed)
         SAVE_GAME_COMPLETE,     ///< sent to clients (by the "host" client only) when a game has been saved and written to disk
         LOAD_GAME,              ///< sent to server (by the "host" client only) when a game is to be loaded
         GAME_START,             ///< sent to each client before the first turn of a new or newly loaded game, instead of a TURN_UPDATE
@@ -81,7 +81,7 @@ public:
         TURN_ORDERS,            ///< sent to the server by a client that has orders to be processed at the end of a turn
         TURN_PROGRESS,          ///< sent to clients to display a turn progress message
         PLAYER_STATUS,          ///< sent to clients to inform them that a player has some status, such as having finished playing a turn and submitted orders, or is resolving combat, or is playing a turn normally
-        //CLIENT_SAVE_DATA,       ///< sent to the server in response to a server request for the data needed to create a save file (removed)
+        CLIENT_SAVE_DATA,       ///< sent to the server in response to a server request for the data needed to create a save file (removed)
         PLAYER_CHAT,            ///< sent when one player sends a chat message to another in multiplayer
         DIPLOMACY,              ///< sent by players to server or server to players to make or convey diplomatic proposals or declarations, or to accept / reject proposals from other players
         DIPLOMATIC_STATUS,      ///< sent by server to players to inform of mid-turn diplomatic status changes

--- a/network/Message.h
+++ b/network/Message.h
@@ -406,11 +406,6 @@ FO_COMMON_API void ExtractTurnUpdateMessageData(const Message& msg, int empire_i
 
 FO_COMMON_API void ExtractTurnPartialUpdateMessageData(const Message& msg, int empire_id, Universe& universe);
 
-/*FO_COMMON_API void ExtractClientSaveDataMessageData(const Message& msg, OrderSet& orders,
-                                                    bool& ui_data_available, SaveGameUIData& ui_data,
-                                                    bool& save_state_string_available,
-                                                    std::string& save_state_string);*/
-
 FO_COMMON_API void ExtractTurnProgressMessageData(const Message& msg, Message::TurnProgressPhase& phase_id);
 
 FO_COMMON_API void ExtractPlayerStatusMessageData(const Message& msg,

--- a/network/ServerNetworking.cpp
+++ b/network/ServerNetworking.cpp
@@ -242,7 +242,7 @@ namespace {
         case Message::LOBBY_EXIT:               return "Lobby Exit";
         case Message::START_MP_GAME:            return "Start MP Game";
         case Message::SAVE_GAME_INITIATE:       return "Save Game";
-        case Message::SAVE_GAME_DATA_REQUEST:   return "Save Game";
+        //case Message::SAVE_GAME_DATA_REQUEST: return "Save Game";
         case Message::SAVE_GAME_COMPLETE:       return "Save Game";
         case Message::LOAD_GAME:                return "Load Game";
         case Message::GAME_START:               return "Game Start";
@@ -251,7 +251,7 @@ namespace {
         case Message::TURN_ORDERS:              return "Turn Orders";
         case Message::TURN_PROGRESS:            return "Turn Progress";
         case Message::PLAYER_STATUS:            return "Player Status";
-        case Message::CLIENT_SAVE_DATA:         return "Client Save Data";
+        //case Message::CLIENT_SAVE_DATA:       return "Client Save Data";
         case Message::PLAYER_CHAT:              return "Player Chat";
         case Message::DIPLOMACY:                return "Diplomacy";
         case Message::DIPLOMATIC_STATUS:        return "Diplomatic Status";

--- a/network/ServerNetworking.cpp
+++ b/network/ServerNetworking.cpp
@@ -242,7 +242,6 @@ namespace {
         case Message::LOBBY_EXIT:               return "Lobby Exit";
         case Message::START_MP_GAME:            return "Start MP Game";
         case Message::SAVE_GAME_INITIATE:       return "Save Game";
-        //case Message::SAVE_GAME_DATA_REQUEST: return "Save Game";
         case Message::SAVE_GAME_COMPLETE:       return "Save Game";
         case Message::LOAD_GAME:                return "Load Game";
         case Message::GAME_START:               return "Game Start";
@@ -251,7 +250,6 @@ namespace {
         case Message::TURN_ORDERS:              return "Turn Orders";
         case Message::TURN_PROGRESS:            return "Turn Progress";
         case Message::PLAYER_STATUS:            return "Player Status";
-        //case Message::CLIENT_SAVE_DATA:       return "Client Save Data";
         case Message::PLAYER_CHAT:              return "Player Chat";
         case Message::DIPLOMACY:                return "Diplomacy";
         case Message::DIPLOMATIC_STATUS:        return "Diplomatic Status";

--- a/python/AI/AIFramework.cpp
+++ b/python/AI/AIFramework.cpp
@@ -93,7 +93,7 @@ BOOST_PYTHON_MODULE(freeOrionAIInterface)
     FreeOrionPython::SetWrapper<int>::Wrap("IntSet");
     FreeOrionPython::SetWrapper<std::string>::Wrap("StringSet");
 }
- 
+
 //////////////////////
 //     PythonAI     //
 //////////////////////
@@ -190,7 +190,7 @@ void PythonAI::ResumeLoadedGame(const std::string& save_state_string) {
     resumeLoadedGamePythonFunction(FreeOrionPython::GetStaticSaveStateString());
 }
 
-const std::string& PythonAI::GetSaveStateString() {
+const std::string& PythonAI::GetSaveStateString() const {
     // call Python function that serializes AI state for storage in save file and sets s_save_state_string
     // to contain that string
     object prepareForSavePythonFunction = m_python_module_ai.attr("prepareForSave");

--- a/python/AI/AIFramework.h
+++ b/python/AI/AIFramework.h
@@ -19,7 +19,7 @@ public:
     void StartNewGame() override;
     void ResumeLoadedGame(const std::string& save_state_string) override;
 
-    const std::string&  GetSaveStateString() override;
+    const std::string&  GetSaveStateString() const override;
 
 private:
     // reference to imported Python AI module

--- a/server/SaveLoad.cpp
+++ b/server/SaveLoad.cpp
@@ -59,7 +59,7 @@ namespace {
         preview.number_of_empires = empire_save_game_data.size();
         preview.save_time = boost::posix_time::to_iso_extended_string(boost::posix_time::second_clock::local_time());
 
-        DebugLogger() << "player_save_game_data " << player_save_game_data.size();
+        DebugLogger() << "CompileSaveGamePreviewData(...) player_save_game_data size: " << player_save_game_data.size();
 
         if (player_save_game_data.empty()) {
             preview.main_player_name = UserString("NO_PLAYERS");

--- a/server/SaveLoad.cpp
+++ b/server/SaveLoad.cpp
@@ -59,6 +59,8 @@ namespace {
         preview.number_of_empires = empire_save_game_data.size();
         preview.save_time = boost::posix_time::to_iso_extended_string(boost::posix_time::second_clock::local_time());
 
+        DebugLogger() << "player_save_game_data " << player_save_game_data.size();
+
         if (player_save_game_data.empty()) {
             preview.main_player_name = UserString("NO_PLAYERS");
             preview.main_player_empire_name = UserString("NO_EMPIRE");

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1800,6 +1800,16 @@ bool ServerApp::IsHostless() const
 const boost::circular_buffer<ChatHistoryEntity>& ServerApp::GetChatHistory() const
 { return m_chat_history; }
 
+std::vector<PlayerSaveGameData> ServerApp::GetPlayerSaveGameData() const {
+    std::vector<PlayerSaveGameData> player_save_game_data;
+    for (const auto& m_save_data : m_turn_sequence) {
+        if (m_save_data.second.second) {
+            player_save_game_data.push_back(*m_save_data.second.second);
+        }
+    }
+    return player_save_game_data;
+}
+
 Networking::ClientType ServerApp::GetEmpireClientType(int empire_id) const
 { return GetPlayerClientType(ServerApp::EmpirePlayerID(empire_id)); }
 

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -381,7 +381,7 @@ void ServerApp::HandleMessage(const Message& msg, PlayerConnectionPtr player_con
     case Message::SAVE_GAME_INITIATE:       m_fsm->process_event(SaveGameRequest(msg, player_connection));  break;
     case Message::TURN_ORDERS:              m_fsm->process_event(TurnOrders(msg, player_connection));       break;
     case Message::UNREADY:                  m_fsm->process_event(RevokeReadiness(msg, player_connection));  break;
-    case Message::CLIENT_SAVE_DATA:         m_fsm->process_event(ClientSaveData(msg, player_connection));   break;
+    //case Message::CLIENT_SAVE_DATA:       m_fsm->process_event(ClientSaveData(msg, player_connection));   break;
     case Message::PLAYER_CHAT:              m_fsm->process_event(PlayerChat(msg, player_connection));       break;
     case Message::DIPLOMACY:                m_fsm->process_event(Diplomacy(msg, player_connection));        break;
     case Message::MODERATOR_ACTION:         m_fsm->process_event(ModeratorAct(msg, player_connection));     break;

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1297,8 +1297,7 @@ void ServerApp::LoadGameInit(const std::vector<PlayerSaveGameData>& player_save_
     for (const auto& psgd : player_save_game_data) {
         int empire_id = psgd.m_empire_id;
         // add empires to turn processing, and restore saved orders and UI data or save state data
-        Empire* empire = GetEmpire(empire_id);
-        if (empire) {
+        if (Empire* empire = GetEmpire(empire_id)) {
             if (!empire->Eliminated())
                 AddEmpireTurn(empire_id, psgd);
         } else {
@@ -1772,7 +1771,7 @@ int ServerApp::AddPlayerIntoGame(const PlayerConnectionPtr& player_connection) {
     m_player_empire_ids[player_connection->PlayerID()] = empire_id;
 
     const OrderSet dummy;
-    const OrderSet& orders = static_cast<bool>(orders_it->second.second) && static_cast<bool>(orders_it->second.second->m_orders) ? *(orders_it->second.second->m_orders) : dummy;
+    const OrderSet& orders = orders_it->second.second && orders_it->second.second->m_orders ? *(orders_it->second.second->m_orders) : dummy;
     const SaveGameUIData* ui_data = orders_it->second.second ? orders_it->second.second->m_ui_data.get() : nullptr;
 
     // drop ready status
@@ -1812,8 +1811,9 @@ const boost::circular_buffer<ChatHistoryEntity>& ServerApp::GetChatHistory() con
 std::vector<PlayerSaveGameData> ServerApp::GetPlayerSaveGameData() const {
     std::vector<PlayerSaveGameData> player_save_game_data;
     for (const auto& m_save_data : m_turn_sequence) {
-        DebugLogger() << "Empire " << m_save_data.first << " ready " << m_save_data.second.first
-            << " save_game_data " << m_save_data.second.second.get();
+        DebugLogger() << "ServerApp::GetPlayerSaveGameData() Empire " << m_save_data.first
+                      << " ready " << m_save_data.second.first
+                      << " save_game_data " << m_save_data.second.second.get();
         if (m_save_data.second.second) {
             player_save_game_data.push_back(*m_save_data.second.second);
         }

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1330,7 +1330,8 @@ void ServerApp::LoadGameInit(const std::vector<PlayerSaveGameData>& player_save_
         auto save_data_it = player_id_save_game_data.find(player_id);
         if (save_data_it != player_id_save_game_data.end()) {
             psgd = save_data_it->second;
-        } else {
+        }
+        if (!psgd.m_orders) {
             psgd.m_orders.reset(new OrderSet());    // need an empty order set pointed to for serialization in case no data is loaded but the game start message wants orders to send
         }
 

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -107,6 +107,10 @@ public:
       * \a save_game_data will be freed when all processing is done for the turn */
     void    SetEmpireSaveGameData(int empire_id, std::unique_ptr<PlayerSaveGameData>&& save_game_data);
 
+    /** Updated empire orders without changes in readiness status. Removes all \a deleted orders
+      * and insert \a added orders. */
+    void    UpdatePartialOrders(int empire_id, const OrderSet& added, const std::set<int>& deleted);
+
     /** Revokes turn order's ready state for the given empire. */
     void    RevokeEmpireTurnReadyness(int empire_id);
 

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -108,9 +108,9 @@ public:
       * an empire is eliminated from the game */
     void    RemoveEmpireTurn(int empire_id);
 
-    /** Adds turn orders for the given empire for the current turn. order_set
-      * will be freed when all processing is done for the turn */
-    void    SetEmpireTurnOrders(int empire_id, std::unique_ptr<OrderSet>&& order_set);
+    /** Adds save game data includes turn orders for the given empire for the current turn.
+      * \a save_game_data will be freed when all processing is done for the turn */
+    void    SetEmpireSaveGameData(int empire_id, std::unique_ptr<PlayerSaveGameData>&& save_game_data);
 
     /** Revokes turn order's ready state for the given empire. */
     void    RevokeEmpireTurnReadyness(int empire_id);
@@ -311,7 +311,7 @@ private:
       * The map contains ready state which should be true to advance turn and
       * pointer to orders from empire.
       * */
-    std::map<int, std::pair<bool, std::unique_ptr<OrderSet>>>      m_turn_sequence;
+    std::map<int, std::pair<bool, std::unique_ptr<PlayerSaveGameData>>>  m_turn_sequence;
 
     // Give FSM and its states direct access.  We are using the FSM code as a
     // control-flow mechanism; it is all notionally part of this class.

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -103,14 +103,6 @@ public:
     /** creates an AI client child process for each element of \a AIs*/
     void    CreateAIClients(const std::vector<PlayerSetupData>& player_setup_data, int max_aggression = 4);
 
-    /**  Adds an existing empire to turn processing. The position the empire is
-      * in the vector is it's position in the turn processing.*/
-    void    AddEmpireTurn(int empire_id);
-
-    /** Removes an empire from turn processing. This is most likely called when
-      * an empire is eliminated from the game */
-    void    RemoveEmpireTurn(int empire_id);
-
     /** Adds save game data includes turn orders for the given empire for the current turn.
       * \a save_game_data will be freed when all processing is done for the turn */
     void    SetEmpireSaveGameData(int empire_id, std::unique_ptr<PlayerSaveGameData>&& save_game_data);
@@ -291,6 +283,14 @@ private:
     /** Called when this sever's EmpireManager changes the diplmatic message
       * between two empires. Updates those empires of the change. */
     void    HandleDiplomaticMessageChange(int empire1_id, int empire2_id);
+
+    /**  Adds an existing empire to turn processing. The position the empire is
+      * in the vector is it's position in the turn processing.*/
+    void    AddEmpireTurn(int empire_id, const PlayerSaveGameData& psgd);
+
+    /** Removes an empire from turn processing. This is most likely called when
+      * an empire is eliminated from the game */
+    void    RemoveEmpireTurn(int empire_id);
 
     boost::asio::io_service m_io_service;
     boost::asio::signal_set m_signals;

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -86,6 +86,9 @@ public:
 
     /** Returns chat history buffer. */
     const boost::circular_buffer<ChatHistoryEntity>& GetChatHistory() const;
+
+    /** Extracts player save game data. */
+    std::vector<PlayerSaveGameData> GetPlayerSaveGameData() const;
     //@}
 
 

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -2568,8 +2568,8 @@ sc::result WaitingForTurnEnd::react(const TurnOrders& msg) {
         TraceLogger(FSM) << "WaitingForTurnEnd.TurnOrders : Received orders from player " << player_id;
 
         server.SetEmpireSaveGameData(empire_id, boost::make_unique<PlayerSaveGameData>(sender->PlayerName(), empire_id,
-                                                                   order_set,       ui_data,    save_state_string,
-                                                                   client_type));
+                                     order_set, ui_data, save_state_string,
+                                     client_type));
 
         // notify other player that this empire submitted orders
         for (auto player_it = server.m_networking.established_begin();
@@ -2686,7 +2686,7 @@ sc::result WaitingForTurnEndIdle::react(const SaveGameRequest& msg) {
         return discard_event();
     }
 
-    const std::string& save_filename = message.Text(); // store requested save file name in Base state context so that sibling state can retreive it
+    std::string save_filename = message.Text(); // store requested save file name in Base state context so that sibling state can retreive it
 
     ServerSaveGameData server_data(server.m_current_turn);
 
@@ -2702,7 +2702,7 @@ sc::result WaitingForTurnEndIdle::react(const SaveGameRequest& msg) {
                                  !server.m_single_player_game);
 
     } catch (const std::exception& error) {
-        ErrorLogger(FSM) << "Catch std::exception: " << error.what();
+        ErrorLogger(FSM) << "While saving, catch std::exception: " << error.what();
         SendMessageToAllPlayers(ErrorMessage(UserStringNop("UNABLE_TO_WRITE_SAVE_FILE"), false));
     }
 

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -2464,7 +2464,6 @@ sc::result PlayingGame::react(const Error& msg) {
 sc::result PlayingGame::react(const LobbyUpdate& msg) {
     TraceLogger(FSM) << "(ServerFSM) MPLobby.LobbyUpdate";
     ServerApp& server = Server();
-    const Message& message = msg.m_message;
     const PlayerConnectionPtr& sender = msg.m_player_connection;
 
     // ignore data
@@ -2508,6 +2507,10 @@ sc::result WaitingForTurnEnd::react(const TurnOrders& msg) {
 
     int player_id = sender->PlayerID();
     Networking::ClientType client_type = sender->GetClientType();
+
+    // ensure ui data availability flag is consistent with ui data
+    if (!ui_data_available)
+        ui_data.reset();
 
     if (client_type == Networking::CLIENT_TYPE_HUMAN_OBSERVER) {
         // observers cannot submit orders. ignore.
@@ -2691,11 +2694,9 @@ sc::result WaitingForTurnEndIdle::react(const SaveGameRequest& msg) {
     // set in WaitingForTurnEndIdle::react(const SaveGameRequest& msg)
     int bytes_written = 0;
 
-    std::vector<PlayerSaveGameData> player_save_game_data;
-
     // save game...
     try {
-        bytes_written = SaveGame(save_filename,     server_data,    player_save_game_data,
+        bytes_written = SaveGame(save_filename,     server_data,    server.GetPlayerSaveGameData(),
                                  GetUniverse(),     Empires(),      GetSpeciesManager(),
                                  GetCombatLogManager(),             server.m_galaxy_setup_data,
                                  !server.m_single_player_game);

--- a/server/ServerFSM.h
+++ b/server/ServerFSM.h
@@ -78,6 +78,7 @@ struct MessageEventBase {
     (LeaveGame)                             \
     (SaveGameRequest)                       \
     (TurnOrders)                            \
+    (TurnPartialOrders)                     \
     (RevokeReadiness)                       \
     (CombatTurnOrders)                      \
     (RequestCombatLogs)                     \
@@ -335,6 +336,7 @@ struct PlayingGame : sc::state<PlayingGame, ServerFSM, WaitingForTurnEnd> {
 struct WaitingForTurnEnd : sc::state<WaitingForTurnEnd, PlayingGame, WaitingForTurnEndIdle> {
     typedef boost::mpl::list<
         sc::custom_reaction<TurnOrders>,
+        sc::custom_reaction<TurnPartialOrders>,
         sc::custom_reaction<RevokeReadiness>,
         sc::custom_reaction<CheckTurnEndConditions>
     > reactions;
@@ -343,6 +345,7 @@ struct WaitingForTurnEnd : sc::state<WaitingForTurnEnd, PlayingGame, WaitingForT
     ~WaitingForTurnEnd();
 
     sc::result react(const TurnOrders& msg);
+    sc::result react(const TurnPartialOrders& msg);
     sc::result react(const RevokeReadiness& msg);
     sc::result react(const CheckTurnEndConditions& c);
 
@@ -376,6 +379,7 @@ struct ProcessingTurn : sc::state<ProcessingTurn, PlayingGame> {
         sc::custom_reaction<ProcessTurn>,
         sc::deferral<SaveGameRequest>,
         sc::deferral<TurnOrders>,
+        sc::deferral<TurnPartialOrders>,
         sc::deferral<RevokeReadiness>,
         sc::deferral<Diplomacy>,
         sc::custom_reaction<CheckTurnEndConditions>

--- a/server/ServerFSM.h
+++ b/server/ServerFSM.h
@@ -80,7 +80,6 @@ struct MessageEventBase {
     (TurnOrders)                            \
     (RevokeReadiness)                       \
     (CombatTurnOrders)                      \
-    (ClientSaveData)                        \
     (RequestCombatLogs)                     \
     (PlayerChat)                            \
     (Diplomacy)                             \
@@ -366,32 +365,6 @@ struct WaitingForTurnEndIdle : sc::state<WaitingForTurnEndIdle, WaitingForTurnEn
 
     SERVER_ACCESSOR
 };
-
-
-/** The substate of WaitingForTurnEnd in which a player has initiated a save
-  * and the server is waiting for all players to send their save data, after
-  * which the server will actually preform the save. */
-struct WaitingForSaveData : sc::state<WaitingForSaveData, WaitingForTurnEnd> {
-    typedef boost::mpl::list<
-        sc::custom_reaction<ClientSaveData>,
-        sc::deferral<SaveGameRequest>,
-        sc::deferral<TurnOrders>,
-        sc::deferral<RevokeReadiness>,
-        sc::deferral<Diplomacy>
-    > reactions;
-
-    WaitingForSaveData(my_context c);
-    ~WaitingForSaveData();
-
-    sc::result react(const ClientSaveData& msg);
-
-    std::set<int>                   m_needed_reponses;
-    std::set<int>                   m_players_responded;
-    std::vector<PlayerSaveGameData> m_player_save_game_data;
-
-    SERVER_ACCESSOR
-};
-
 
 /** The substate of PlayingGame in which the server has received turn orders
   * from players and is determining what happens between turns.  This includes

--- a/test/system/ClientAppFixture.cpp
+++ b/test/system/ClientAppFixture.cpp
@@ -219,9 +219,6 @@ bool ClientAppFixture::HandleMessage(Message& msg) {
     case Message::SAVE_GAME_COMPLETE:
         m_save_completed = true;
         return true;
-    case Message::SAVE_GAME_DATA_REQUEST:
-        m_networking->SendMessage(ClientSaveDataMessage(Orders()));
-        return true;
     case Message::JOIN_GAME: {
         int player_id;
         ExtractJoinAckMessageData(msg, player_id, m_cookie);
@@ -248,9 +245,6 @@ bool ClientAppFixture::HandleMessage(Message& msg) {
         return false;
     }
 }
-
-void ClientAppFixture::SendTurnOrders()
-{ m_networking->SendMessage(TurnOrdersMessage(OrderSet())); }
 
 void ClientAppFixture::SaveGame() {
     std::string save_filename = boost::io::str(boost::format("FreeOrionTestGame_%04d_%s%s") % CurrentTurn() % FilenameTimestamp() % SP_SAVE_FILE_EXTENSION);

--- a/test/system/ClientAppFixture.h
+++ b/test/system/ClientAppFixture.h
@@ -17,7 +17,6 @@ public:
 
     bool ProcessMessages(const boost::posix_time::ptime& start_time, int max_seconds);
     bool HandleMessage(Message& msg);
-    void SendTurnOrders();
     void SaveGame();
     void UpdateLobby();
 

--- a/test/system/SmokeTestGame.cpp
+++ b/test/system/SmokeTestGame.cpp
@@ -127,8 +127,10 @@ BOOST_AUTO_TEST_CASE(host_server) {
         BOOST_REQUIRE(ProcessMessages(start_time, MAX_WAITING_SEC));
     }
 
+    SaveGameUIData ui_data;
+
     while (m_current_turn <= num_turns) {
-        StartTurn();
+        StartTurn(ui_data);
 
         m_turn_done = false;
         m_ai_waiting = m_ai_empires;

--- a/test/system/SmokeTestGame.cpp
+++ b/test/system/SmokeTestGame.cpp
@@ -130,6 +130,8 @@ BOOST_AUTO_TEST_CASE(host_server) {
     SaveGameUIData ui_data;
 
     while (m_current_turn <= num_turns) {
+        SendPartialOrders();
+
         StartTurn(ui_data);
 
         m_turn_done = false;

--- a/test/system/SmokeTestGame.cpp
+++ b/test/system/SmokeTestGame.cpp
@@ -128,7 +128,7 @@ BOOST_AUTO_TEST_CASE(host_server) {
     }
 
     while (m_current_turn <= num_turns) {
-        SendTurnOrders();
+        StartTurn();
 
         m_turn_done = false;
         m_ai_waiting = m_ai_empires;

--- a/test/system/SmokeTestHostless.cpp
+++ b/test/system/SmokeTestHostless.cpp
@@ -190,6 +190,8 @@ BOOST_AUTO_TEST_CASE(hostless_server) {
         SaveGameUIData ui_data;
 
         while (m_current_turn <= num_turns) {
+            SendPartialOrders();
+
             StartTurn(ui_data);
 
             m_turn_done = false;

--- a/test/system/SmokeTestHostless.cpp
+++ b/test/system/SmokeTestHostless.cpp
@@ -188,7 +188,7 @@ BOOST_AUTO_TEST_CASE(hostless_server) {
         }
 
         while (m_current_turn <= num_turns) {
-            SendTurnOrders();
+            StartTurn();
 
             m_turn_done = false;
             m_ai_waiting = m_ai_empires;

--- a/test/system/SmokeTestHostless.cpp
+++ b/test/system/SmokeTestHostless.cpp
@@ -187,8 +187,10 @@ BOOST_AUTO_TEST_CASE(hostless_server) {
             BOOST_REQUIRE(ProcessMessages(start_time, MAX_WAITING_SEC));
         }
 
+        SaveGameUIData ui_data;
+
         while (m_current_turn <= num_turns) {
-            StartTurn();
+            StartTurn(ui_data);
 
             m_turn_done = false;
             m_ai_waiting = m_ai_empires;

--- a/util/OrderSet.cpp
+++ b/util/OrderSet.cpp
@@ -55,3 +55,19 @@ void OrderSet::Reset() {
     m_last_added_orders.clear();
     m_last_deleted_orders.clear();
 }
+
+std::pair<OrderSet, std::set<int>> OrderSet::ExtractChanges() {
+    OrderSet added_orders;
+    for(int added : m_last_added_orders) {
+        auto it = m_orders.find(added);
+        if (it != m_orders.end()) {
+            added_orders.m_orders.insert(*it);
+        } else {
+            m_last_deleted_orders.insert(added);
+        }
+    }
+    m_last_added_orders.clear();
+    std::set<int> deleted_orders = std::move(m_last_deleted_orders);
+    m_last_deleted_orders.clear();
+    return {added_orders, deleted_orders};
+}

--- a/util/OrderSet.cpp
+++ b/util/OrderSet.cpp
@@ -23,6 +23,7 @@ int OrderSet::IssueOrder(OrderPtr&& order) {
 
     // Insert the order into the m_orders map.  forward the rvalue to use the move constructor.
     auto inserted = m_orders.insert({retval, std::forward<OrderPtr>(order)});
+    m_last_added_orders.insert(retval);
     inserted.first->second->Execute();
 
     TraceLogger() << "OrderSetIssueOrder m_orders size: " << m_orders.size();
@@ -42,11 +43,15 @@ bool OrderSet::RescindOrder(int order) {
     if (it != m_orders.end()) {
         if (it->second->Undo()) {
             m_orders.erase(it);
+            m_last_deleted_orders.insert(it->first);
             retval = true;
         }
     }
     return retval;
 }
 
-void OrderSet::Reset()
-{ m_orders.clear(); }
+void OrderSet::Reset() {
+    m_orders.clear();
+    m_last_added_orders.clear();
+    m_last_deleted_orders.clear();
+}

--- a/util/OrderSet.h
+++ b/util/OrderSet.h
@@ -9,7 +9,7 @@
 
 #include <map>
 #include <memory>
-
+#include <set>
 
 class Order;
 
@@ -54,7 +54,7 @@ public:
     std::size_t     size() const            { return m_orders.size(); }
     bool            empty() const           { return m_orders.empty(); }
     iterator        find(const key_type& k) { return m_orders.find(k); }
-    void            erase(const key_type& k){ m_orders.erase(k); }
+    void            erase(const key_type& k){ RescindOrder(k);  }
     OrderPtr&       operator[](std::size_t i);
     key_compare     key_comp() const        { return m_orders.key_comp(); }
     //@}
@@ -77,7 +77,9 @@ public:
     //@}
 
 private:
-    OrderMap m_orders;
+    OrderMap      m_orders;
+    std::set<int> m_last_added_orders; ///< set of ids added/updated orders
+    std::set<int> m_last_deleted_orders; ///< set of ids deleted orders
 
     friend class boost::serialization::access;
     template <class Archive>
@@ -89,6 +91,10 @@ template <class Archive>
 void OrderSet::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_NVP(m_orders);
+    if (Archive::is_loading::value) {
+        m_last_added_orders.clear();
+        m_last_deleted_orders.clear();
+    }
 }
 
 #endif // _OrderSet_h_

--- a/util/OrderSet.h
+++ b/util/OrderSet.h
@@ -54,7 +54,8 @@ public:
     std::size_t     size() const            { return m_orders.size(); }
     bool            empty() const           { return m_orders.empty(); }
     iterator        find(const key_type& k) { return m_orders.find(k); }
-    void            erase(const key_type& k){ RescindOrder(k);  }
+    std::pair<iterator,bool> insert (const value_type& val) { return m_orders.insert(val); } ///< direct insert without saving changes
+    void            erase(const key_type& k){ m_orders.erase(k); } ///< direct erase without saving changes
     OrderPtr&       operator[](std::size_t i);
     key_compare     key_comp() const        { return m_orders.key_comp(); }
     //@}
@@ -74,6 +75,8 @@ public:
         set.  Return true if \p order exists and was successfully removed. */
     bool RescindOrder(int order);
     void Reset(); ///< clears all orders; should be called at the beginning of a new turn
+
+    std::pair<OrderSet, std::set<int>> ExtractChanges(); ///< extract and clear changed orders
     //@}
 
 private:


### PR DESCRIPTION
Another step of #2243. Fixes #2275.

Currently the server requests turn orders and save data from the client after get turn orders before from the client which requires the client to be online when server decide to save game.
After this PR server gets turn orders and save data together from the client so it became possible to client to disconnect after sending turn orders.

To compensate lacking server-side request the client sends partial order changes on some event.

Also allows to send UI data if client connected to playing game.

Breaks client-server compatibility!