### PR TITLE
CheckResearch as is but add innovations at end of turn processing

### DIFF
--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -217,7 +217,8 @@ public:
     void ResumeProduction(int index);
     void AllowUseImperialPP(int index, bool allow=true);  ///< Allows or disallows the use of the imperial stockpile for production
 
-    void AddTech(const std::string& name);           ///< Inserts the given Tech into the Empire's list of available technologies.
+    void AddNewTech(const std::string& name);           ///< Inserts the given Tech into the Empire's list of innovations. Call ApplyAddedTech to make it effective.
+    void ApplyNewTechs();                          ///< Moves all Techs from the Empire's list of innovations into the Empire's list of available technologies.
     void UnlockItem(const ItemSpec& item);           ///< Adds a given producible item (Building, Ship Hull, Ship part) to the list of available items.
     void AddBuildingType(const std::string& name);   ///< Inserts the given BuildingType into the Empire's list of available BuldingTypes.
     void AddPartType(const std::string& name);       ///< Inserts the given ship PartType into the Empire's list of available BuldingTypes.
@@ -276,9 +277,9 @@ public:
       * but does not actually spend them).  This function spends the PP, removes
       * complete items from the queue and creates the results in the universe. */
     void CheckProductionProgress();
-    /** Checks for tech projects that have been completed, and adds them to the
-      * known techs list. */
-    void CheckResearchProgress();
+    /** Checks for tech projects that have been completed, and returns a vector
+      * of the techs that should be added to the known techs list. */
+    std::vector<std::string> CheckResearchProgress();
     /** Eventually : Will check for social projects that have been completed and
       * / or process ongoing social projects... (not sure exactly what form
       * "social projects" will take or how they will work).  Also will update
@@ -386,6 +387,7 @@ private:
     bool                            m_eliminated = false;       ///< Whether the empire has lost
     std::set<std::string>           m_victories;                ///< The ways that the empire has won, if any
 
+    std::set<std::string>           m_new_techs;                ///< names of researched but not yet effective technologies, and turns on which they were acquired.
     std::map<std::string, int>      m_techs;                    ///< names of researched technologies, and turns on which they were acquired.
     std::map<std::string, Meter>    m_meters;                   ///< empire meters, including ratings scales used by species to judge empires
 

--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -217,8 +217,8 @@ public:
     void ResumeProduction(int index);
     void AllowUseImperialPP(int index, bool allow=true);  ///< Allows or disallows the use of the imperial stockpile for production
 
-    void AddNewTech(const std::string& name);           ///< Inserts the given Tech into the Empire's list of innovations. Call ApplyAddedTech to make it effective.
-    void ApplyNewTechs();                          ///< Moves all Techs from the Empire's list of innovations into the Empire's list of available technologies.
+    void AddNewlyResearchedTechToGrantAtStartOfNextTurn(const std::string& name);    ///< Inserts the given Tech into the Empire's list of innovations. Call ApplyAddedTech to make it effective.
+    void ApplyNewTechs();                            ///< Moves all Techs from the Empire's list of innovations into the Empire's list of available technologies.
     void UnlockItem(const ItemSpec& item);           ///< Adds a given producible item (Building, Ship Hull, Ship part) to the list of available items.
     void AddBuildingType(const std::string& name);   ///< Inserts the given BuildingType into the Empire's list of available BuldingTypes.
     void AddPartType(const std::string& name);       ///< Inserts the given ship PartType into the Empire's list of available BuldingTypes.
@@ -387,7 +387,7 @@ private:
     bool                            m_eliminated = false;       ///< Whether the empire has lost
     std::set<std::string>           m_victories;                ///< The ways that the empire has won, if any
 
-    std::set<std::string>           m_new_techs;                ///< names of researched but not yet effective technologies, and turns on which they were acquired.
+    std::set<std::string>           m_newly_researched_techs;                ///< names of researched but not yet effective technologies, and turns on which they were acquired.
     std::map<std::string, int>      m_techs;                    ///< names of researched technologies, and turns on which they were acquired.
     std::map<std::string, Meter>    m_meters;                   ///< empire meters, including ratings scales used by species to judge empires
 

--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -213,9 +213,9 @@ public:
     void SetProductionRallyPoint(int index, int rally_point_id = INVALID_OBJECT_ID);  ///< Sets the rally point for ships produced by this produce, to which they are automatically ordered to move after they are produced.
     void MoveProductionWithinQueue(int index, int new_index);///< Moves \a tech from the production queue, if it is in the production queue already.
     void RemoveProductionFromQueue(int index);               ///< Removes the produce at position \a index in the production queue, if such an index exists.
-    void PauseProduction(int index);
-    void ResumeProduction(int index);
-    void AllowUseImperialPP(int index, bool allow=true);  ///< Allows or disallows the use of the imperial stockpile for production
+    void PauseProduction(int index);                         ///< Sets the production of produce at postion \a index paused, if such an index exists
+    void ResumeProduction(int index);                        ///< Sets the production of produce at postion \a index unpaused, if such an index exists
+    void AllowUseImperialPP(int index, bool allow=true);     ///< Allows or disallows the use of the imperial stockpile for production
 
     void AddNewlyResearchedTechToGrantAtStartOfNextTurn(const std::string& name);    ///< Inserts the given Tech into the Empire's list of innovations. Call ApplyAddedTech to make it effective.
     void ApplyNewTechs();                            ///< Moves all Techs from the Empire's list of innovations into the Empire's list of available technologies.

--- a/default/python/common/handlers.py
+++ b/default/python/common/handlers.py
@@ -8,7 +8,11 @@ from common.option_tools import get_option_dict, HANDLERS
 
 
 def init_handlers(config_str, search_dir):
-    handlers = split(get_option_dict()[HANDLERS])
+    try:
+        handlers = split(get_option_dict()[HANDLERS])
+    except KeyError:
+        error("Missing key in option dict: %s", HANDLERS)
+        handlers = []
 
     for handler in handlers:
         module = os.path.basename(handler)[:-3]

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1450,6 +1450,9 @@ void ServerApp::GenerateUniverse(std::map<int, PlayerSetupData>& player_setup_da
     if (!success)
         ServerApp::GetApp()->Networking().SendMessageAll(ErrorMessage(UserStringNop("SERVER_UNIVERSE_GENERATION_ERRORS"), false));
 
+    for (auto& empire : Empires()) {
+        empire.second->ApplyNewTechs();
+    }
 
     DebugLogger() << "Applying first turn effects and updating meters";
 
@@ -3371,7 +3374,9 @@ void ServerApp::PostCombatProcessTurns() {
         if (empire->Eliminated())
             continue;   // skip eliminated empires
 
-        empire->CheckResearchProgress();
+        for (const auto& tech : empire->CheckResearchProgress()) {
+            empire->AddNewTech(tech);
+        }
         empire->CheckProductionProgress();
         empire->CheckTradeSocialProgress();
     }
@@ -3403,7 +3408,6 @@ void ServerApp::PostCombatProcessTurns() {
     // store initial values of meters for this turn.
     m_universe.BackPropagateObjectMeters();
     empires.BackPropagateMeters();
-
 
     // check for loss of empire capitals
     for (auto& entry : empires) {
@@ -3470,6 +3474,14 @@ void ServerApp::PostCombatProcessTurns() {
     for (auto& entry : empires)
         entry.second->UpdateOwnedObjectCounters();
     GetSpeciesManager().UpdatePopulationCounter();
+
+
+    // apply new techs
+    for (auto& entry : empires) {
+        Empire* empire = entry.second;
+        if (empire && !empire->Eliminated())
+            empire->ApplyNewTechs();
+    }
 
 
     // indicate that the clients are waiting for their new gamestate

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -3375,7 +3375,7 @@ void ServerApp::PostCombatProcessTurns() {
             continue;   // skip eliminated empires
 
         for (const auto& tech : empire->CheckResearchProgress()) {
-            empire->AddNewTech(tech);
+            empire->AddNewlyResearchedTechToGrantAtStartOfNextTurn(tech);
         }
         empire->CheckProductionProgress();
         empire->CheckTradeSocialProgress();

--- a/universe/Effect.cpp
+++ b/universe/Effect.cpp
@@ -3111,7 +3111,7 @@ void GiveEmpireTech::Execute(const ScriptingContext& context) const {
         return;
     }
 
-    empire->AddNewTech(tech_name);
+    empire->AddNewlyResearchedTechToGrantAtStartOfNextTurn(tech_name);
 }
 
 std::string GiveEmpireTech::Dump(unsigned short ntabs) const {

--- a/universe/Effect.cpp
+++ b/universe/Effect.cpp
@@ -3111,7 +3111,7 @@ void GiveEmpireTech::Execute(const ScriptingContext& context) const {
         return;
     }
 
-    empire->AddTech(tech_name);
+    empire->AddNewTech(tech_name);
 }
 
 std::string GiveEmpireTech::Dump(unsigned short ntabs) const {


### PR DESCRIPTION
This PR relates to issue #2355 and moves the addition of newly researched techs ('innovations') to the end of turn processing while keeping the calculation of researched techs where it is (CheckResearch call in ServerApp).  This removes unnessecary complexity from effects and lessens the burden of understanding of FOCS scripters.

>  it might be possible to reduce complexity instead:
just move the tech research to the end of the turn, so that it the only effect tech makes on the research turn is the sitrep informing one that the tech was successfully researched. None of our techs really needs initialization (like ships do).
The reduction of complexity stems from the fact that currently tech is researched in the middle of turn processing, leading to two different periods inside turn processing (effect application before tech is researched and effect application after tech is researched) instead of one (effect application is always after tech is researched).

Regarding implementation: C++ gurus please check if the collection of the innovations is c++ idiomatic.