### PR TITLE
Bandaid-fix for random AI CI errors

### DIFF
--- a/default/python/common/handlers.py
+++ b/default/python/common/handlers.py
@@ -8,7 +8,11 @@ from common.option_tools import get_option_dict, HANDLERS
 
 
 def init_handlers(config_str, search_dir):
-    handlers = split(get_option_dict()[HANDLERS])
+    try:
+        handlers = split(get_option_dict()[HANDLERS])
+    except KeyError:
+        error("Missing key in option dict: %s", HANDLERS)
+        handlers = []
 
     for handler in handlers:
         module = os.path.basename(handler)[:-3]


### PR DESCRIPTION
We keep seeing the apparently random error reported in #2372 which breaks CI builds but hasn't been observed outside of it.
So, while a proper fix would be preferable, handling the uncaught exception should be sufficient as interim solution.