### PR TITLE
Also target planets without defense but with shields

### DIFF
--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -356,11 +356,17 @@ namespace {
                     boost::make_unique<Condition::Type>(OBJ_FIGHTER)),
                 boost::make_unique<Condition::And>(
                     boost::make_unique<Condition::Type>(OBJ_PLANET),
-                    boost::make_unique<Condition::Not>(
-                        boost::make_unique<Condition::MeterValue>(
-                            METER_DEFENSE,
-                            nullptr,
-                            boost::make_unique<ValueRef::Constant<double>>(0.0))))));
+                    boost::make_unique<Condition::Or>(
+                        boost::make_unique<Condition::Not>(
+                            boost::make_unique<Condition::MeterValue>(
+                                METER_DEFENSE,
+                                nullptr,
+                                boost::make_unique<ValueRef::Constant<double>>(0.0))),
+                        boost::make_unique<Condition::Not>(
+                            boost::make_unique<Condition::MeterValue>(
+                                METER_SHIELD,
+                                nullptr,
+                                boost::make_unique<ValueRef::Constant<double>>(0.0)))))));
 
 
     struct PartAttackInfo {

--- a/default/scripting/ship_parts/targeting.macros
+++ b/default/scripting/ship_parts/targeting.macros
@@ -24,6 +24,9 @@ COMBAT_TARGETS_NOT_DESTROYED_SHIP
 COMBAT_TARGETS_PLANET_WITH_DEFENSE
 '''         And [
             Planet
-            Not Defense high = 0
+            Or [
+               Not Shields high = 0
+               Not Defense high = 0
+            ]
         ]
 '''


### PR DESCRIPTION
The default targeting of planets includes only planets with defense higher zero. But also planets with only a positive shield value should be attacked.