### PR TITLE
Some fixes for MSVC projects generated by cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,9 @@ add_compile_options(
 
     # Enable C++ Exception unwind mechanics with DLL support
     $<$<CXX_COMPILER_ID:MSVC>:/EHsc>
+
+    # Fix Fatal Error C1128: number of sections exceeded object file format limit : compile with /bigobj on SerializeEmpire.cpp
+    $<$<CXX_COMPILER_ID:MSVC>:/bigobj>
 )
 
 set_property(DIRECTORY APPEND
@@ -378,7 +381,7 @@ set_property(TARGET freeorionparseobj
 )
 
 if(WIN32)
-    set_property(TARGET freeorionparse
+    set_property(TARGET freeorionparseobj
         PROPERTY
         OUTPUT_NAME Parsers
     )

--- a/GG/CMakeLists.txt
+++ b/GG/CMakeLists.txt
@@ -86,6 +86,7 @@ if(NOT USE_STATIC_LIBS)
     add_definitions(
         -DBOOST_ALL_NO_LINK
         -DBOOST_ALL_DYN_LINK
+        -DBOOST_LOG_NO_LINK
         -DBOOST_LOG_DYN_LINK
     )
 endif()

--- a/GG/test/acceptance/CMakeLists.txt
+++ b/GG/test/acceptance/CMakeLists.txt
@@ -26,6 +26,7 @@ include_directories(
     SYSTEM
     ${OPENGL_INCLUDE_DIR}
     ${SDL_INCLUDE_DIR}
+    ${GLEW_INCLUDE_DIRS}
 )
 
 add_library(gigi_acceptance_runner OBJECT

--- a/GG/test/unit/CMakeLists.txt
+++ b/GG/test/unit/CMakeLists.txt
@@ -32,6 +32,7 @@ add_executable(gg_unittest
 target_compile_definitions(gg_unittest
     PRIVATE
         -DBOOST_TEST_DYN_LINK
+        -DBOOST_TEST_NO_LINK
 )
 
 target_link_libraries(gg_unittest

--- a/test/parse/CMakeLists.txt
+++ b/test/parse/CMakeLists.txt
@@ -10,12 +10,14 @@ target_compile_definitions(fo_unittest_parse
     PRIVATE
         -DFREEORION_BUILD_SERVER
         -DBOOST_TEST_DYN_LINK
+        -DBOOST_TEST_NO_LINK
 )
 
 target_include_directories(fo_unittest_parse
     PRIVATE
         ${PROJECT_SOURCE_DIR}
         ${PROJECT_SOURCE_DIR}/GG/
+        ${Boost_INCLUDE_DIRS}
 )
 
 target_link_libraries(fo_unittest_parse

--- a/test/system/CMakeLists.txt
+++ b/test/system/CMakeLists.txt
@@ -14,7 +14,9 @@ target_compile_definitions(fo_systemtest_game
     PRIVATE
         -DFREEORION_BUILD_HUMAN
         -DBOOST_TEST_DYN_LINK
+        -DBOOST_TEST_NO_LINK
         -DBOOST_LOG_DYN_LINK
+        -DBOOST_LOG_NO_LINK
         -DBOOST_TEST_IGNORE_SIGCHLD
 )
 
@@ -22,6 +24,7 @@ target_include_directories(fo_systemtest_game
     PRIVATE
         ${PROJECT_SOURCE_DIR}
         ${PROJECT_SOURCE_DIR}/GG/
+        ${Boost_INCLUDE_DIRS}
 )
 
 target_link_libraries(fo_systemtest_game

--- a/test/util/CMakeLists.txt
+++ b/test/util/CMakeLists.txt
@@ -7,12 +7,14 @@ add_executable(fo_unittest_util
 target_compile_definitions(fo_unittest_util
     PRIVATE
         -DBOOST_TEST_DYN_LINK
+        -DBOOST_TEST_NO_LINK
 )
 
 target_include_directories(fo_unittest_util
     PRIVATE
         ${PROJECT_SOURCE_DIR}
         ${PROJECT_SOURCE_DIR}/GG/
+        ${Boost_INCLUDE_DIRS}
 )
 
 target_link_libraries(fo_unittest_util


### PR DESCRIPTION
Tried to build FreeOrion on win64 with x64 version of sdk. Command used is `cmake -DBUILD_TESTING=On -DCMAKE_BUILD_TYPE=RelWithDebInfo -G "Visual Studio 15 2017 Win64" -T v141,host=x64 -DPYTHON_EXECUTABLE=..\python.exe ..`
It still doesn't work but fixed some errors.