### PR TITLE
Allow human players to disconnect without stopping game

### DIFF
--- a/UI/InGameMenu.cpp
+++ b/UI/InGameMenu.cpp
@@ -224,6 +224,9 @@ void InGameMenu::Concede() {
 }
 
 void InGameMenu::Resign() {
+    // send order changes could be made when player decides to disconnect
+    HumanClientApp::GetApp()->SendPartialOrders();
+
     HumanClientApp::GetApp()->ResetToIntro(false);
     CloseClicked();
 }

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1384,6 +1384,12 @@ Set the minimum number of human players required to start a multiplayer game.
 OPTIONS_DB_MP_HUMAN_MAX
 Limit the number of human players allowed in a multiplayer game. Set to -1 for unlimited.
 
+OPTIONS_DB_MP_CONN_HUMAN_MIN
+Server stop the playing game if count of active human player will be less than this value.
+
+OPTIONS_DB_MP_DISCONN_HUMAN_MAX
+Server stop the playing game if count of disconnected human player from non-eliminated empires exceeds or equals this value. Disabled if 0.
+
 OPTIONS_DB_COOKIES_EXPIRE
 Count of minutes after the cookie record will be considered expired.
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1388,7 +1388,7 @@ OPTIONS_DB_MP_CONN_HUMAN_MIN
 Minimum number of active human players, below which the server will stop the game being played.
 
 OPTIONS_DB_MP_DISCONN_HUMAN_MAX
-Maximum number of players, who control non-eliminated empires, who may disconnect from the server before it stops the game being played. Disabled if 0, meaning the server will never stop the game due to empire-playing players disconnecting.
+Maximum number of players, who control non-eliminated empires, who may be disconnected from the server before it stops the game being played. Disabled if 0, meaning the server will never stop the game due to empire-playing players being disconnected.
 
 OPTIONS_DB_COOKIES_EXPIRE
 Count of minutes after the cookie record will be considered expired.

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1385,10 +1385,10 @@ OPTIONS_DB_MP_HUMAN_MAX
 Limit the number of human players allowed in a multiplayer game. Set to -1 for unlimited.
 
 OPTIONS_DB_MP_CONN_HUMAN_MIN
-Server stop the playing game if count of active human player will be less than this value.
+Minimum number of active human players, below which the server will stop the game being played.
 
 OPTIONS_DB_MP_DISCONN_HUMAN_MAX
-Server stop the playing game if count of disconnected human player from non-eliminated empires exceeds or equals this value. Disabled if 0.
+Maximum number of players, who control non-eliminated empires, who may disconnect from the server before it stops the game being played. Disabled if 0, meaning the server will never stop the game due to empire-playing players disconnecting.
 
 OPTIONS_DB_COOKIES_EXPIRE
 Count of minutes after the cookie record will be considered expired.

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1764,14 +1764,14 @@ int ServerApp::AddPlayerIntoGame(const PlayerConnectionPtr& player_connection) {
     }
 
     if (empire_id == ALL_EMPIRES || empire == nullptr)
-        return false;
+        return ALL_EMPIRES;
 
     auto orders_it = m_turn_sequence.find(empire_id);
     if (orders_it == m_turn_sequence.end()) {
         WarnLogger() << "ServerApp::AddPlayerIntoGame empire " << empire_id
                      << " for \"" << player_connection->PlayerName()
                      << "\" doesn't wait for orders";
-        return false;
+        return ALL_EMPIRES;
     }
 
     // make a link to new connection
@@ -1807,7 +1807,7 @@ int ServerApp::AddPlayerIntoGame(const PlayerConnectionPtr& player_connection) {
                                                            empire.first));
     }
 
-    return true;
+    return empire_id;
 }
 
 bool ServerApp::IsHostless() const

--- a/server/dmain.cpp
+++ b/server/dmain.cpp
@@ -60,6 +60,8 @@ int wmain(int argc, wchar_t* argv[], wchar_t* envp[]) {
         GetOptionsDB().Add<int>("network.server.ai.max", UserStringNop("OPTIONS_DB_MP_AI_MAX"), -1, Validator<int>());
         GetOptionsDB().Add<int>("network.server.human.min", UserStringNop("OPTIONS_DB_MP_HUMAN_MIN"), 0, Validator<int>());
         GetOptionsDB().Add<int>("network.server.human.max", UserStringNop("OPTIONS_DB_MP_HUMAN_MAX"), -1, Validator<int>());
+        GetOptionsDB().Add<int>("network.server.conn-human.min", UserStringNop("OPTIONS_DB_MP_CONN_HUMAN_MIN"), 1, Validator<int>());
+        GetOptionsDB().Add<int>("network.server.disconn-human.max", UserStringNop("OPTIONS_DB_MP_DISCONN_HUMAN_MAX"), 1, Validator<int>());
         GetOptionsDB().Add<int>("network.server.cookies.expire-minutes", UserStringNop("OPTIONS_DB_COOKIES_EXPIRE"), 15, Validator<int>());
         GetOptionsDB().Add<bool>("network.server.publish-statistics", UserStringNop("OPTIONS_DB_PUBLISH_STATISTICS"), true, Validator<bool>());
         GetOptionsDB().Add("network.server.binary.enabled", UserStringNop("OPTIONS_DB_SERVER_BINARY_SERIALIZATION"), true);


### PR DESCRIPTION
Next step of #2243 

Adds two options. The first is to define minimal connected human player to don't stop playing game. The second is to define maximum disconnected human player to don't stop playing game.
Default values acts as current setting when server stops game if no human player left or any alive empire was disconnected.