### PR TITLE
Protect empires of authenticated players

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -34,10 +34,11 @@ Empire::Empire() :
 { Init(); }
 
 Empire::Empire(const std::string& name, const std::string& player_name,
-               int empire_id, const GG::Clr& color) :
+               int empire_id, const GG::Clr& color, bool authenticated) :
     m_id(empire_id),
     m_name(name),
     m_player_name(player_name),
+    m_authenticated(authenticated),
     m_color(color),
     m_research_queue(m_id),
     m_production_queue(m_id)
@@ -67,6 +68,9 @@ const std::string& Empire::Name() const
 
 const std::string& Empire::PlayerName() const
 { return m_player_name; }
+
+bool Empire::IsAuthenticated() const
+{ return m_authenticated; }
 
 int Empire::EmpireID() const
 { return m_id; }
@@ -746,7 +750,7 @@ void Empire::UpdateSupplyUnobstructedSystems(const std::set<int>& known_systems,
     // fleets were not (meaning that the enemy fleets were continuing an existing blockade)
     // Friendly fleets can preserve available starlane accesss even if they are trying to leave the system
 
-    // Unrestricted lane access (i.e, (fleet->ArrivalStarlane() == system->ID()) ) is used as a proxy for 
+    // Unrestricted lane access (i.e, (fleet->ArrivalStarlane() == system->ID()) ) is used as a proxy for
     // order of arrival -- if an enemy has unrestricted lane access and you don't, they must have arrived
     // before you, or be in cahoots with someone who did.
     std::set<int> systems_containing_friendly_fleets;
@@ -837,7 +841,7 @@ void Empire::UpdateSupplyUnobstructedSystems(const std::set<int>& known_systems,
 
 void Empire::RecordPendingLaneUpdate(int start_system_id, int dest_system_id) {
     if (!m_supply_unobstructed_systems.count(start_system_id))
-        m_pending_system_exit_lanes[start_system_id].insert(dest_system_id); 
+        m_pending_system_exit_lanes[start_system_id].insert(dest_system_id);
     else { // if the system is unobstructed, mark all its lanes as avilable
         auto system = GetSystem(start_system_id);
         for (const auto& lane : system->StarlanesWormholes()) {
@@ -1067,7 +1071,7 @@ void Empire::PlaceProductionOnQueue(BuildType build_type, const std::string& nam
     }
 
     ProductionQueue::Element build(build_type, name, m_id, number, number, blocksize, location);
-    
+
     if (pos < 0 || static_cast<int>(m_production_queue.size()) <= pos)
         m_production_queue.push_back(build);
     else
@@ -1757,7 +1761,7 @@ void Empire::CheckProductionProgress() {
                 build_description = "Stockpile PP transfer";
                 break;
             }
-            default: 
+            default:
                 build_description = "unknown build type";
         }
 

--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -2250,6 +2250,9 @@ void Empire::UpdateOwnedObjectCounters() {
     }
 }
 
+void Empire::SetAuthenticated(bool authenticated /*= true*/)
+{ m_authenticated = authenticated; }
+
 int Empire::TotalShipsOwned() const {
     // sum up counts for each ship design owned by this empire
     // (not using species ship counts, as an empire could potentially own a

--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -328,6 +328,8 @@ public:
 
     void UpdateOwnedObjectCounters();
 
+    void SetAuthenticated(bool authenticated=true);
+
     int TotalShipsOwned() const;
     int TotalShipPartsOwned() const;    ///< Total number of parts for all owned ships in this empire
     int TotalBuildingsOwned() const;

--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -38,16 +38,17 @@ public:
     //@}
 
     /** \name Structors */ //@{
-    Empire(const std::string& name, const std::string& player_name, int ID, const GG::Clr& color);  ///< basic constructor
+    Empire(const std::string& name, const std::string& player_name, int ID, const GG::Clr& color, bool authenticated);  ///< basic constructor
     ~Empire();
     //@}
 
     /** \name Accessors */ //@{
-    const std::string&  Name() const;           ///< Returns the Empire's name
-    const std::string&  PlayerName() const;     ///< Returns the Empire's player's name
-    int                 EmpireID() const;       ///< Returns the Empire's unique numeric ID
-    const GG::Clr&      Color() const;          ///< Returns the Empire's color
-    int                 CapitalID() const;      ///< Returns the numeric ID of the empire's capital
+    const std::string&  Name() const;            ///< Returns the Empire's name
+    const std::string&  PlayerName() const;      ///< Returns the Empire's player's name
+    bool                IsAuthenticated() const; ///< Returns the Empire's player's authentication status
+    int                 EmpireID() const;        ///< Returns the Empire's unique numeric ID
+    const GG::Clr&      Color() const;           ///< Returns the Empire's color
+    int                 CapitalID() const;       ///< Returns the numeric ID of the empire's capital
 
     /** Return an object id that is owned by the empire or INVALID_OBJECT_ID. */
     int                 SourceID() const;
@@ -207,7 +208,7 @@ public:
     void PlaceProductionOnQueue(const ProductionQueue::ProductionItem& item, int number,
                                 int blocksize, int location, int pos = -1);
     void SetProductionQuantity(int index, int quantity);     ///< Changes the remaining number to produce for queue item \a index to \a quantity
-    void SetProductionQuantityAndBlocksize(int index, int quantity, int blocksize);   ///< Changes the remaining number and blocksize to produce for queue item \a index to \a quantity and \a blocksize 
+    void SetProductionQuantityAndBlocksize(int index, int quantity, int blocksize);   ///< Changes the remaining number and blocksize to produce for queue item \a index to \a quantity and \a blocksize
     void SplitIncompleteProductionItem(int index);           ///< Adds a copy of the production item at position \a index below it in the queue, with one less quantity. Sets the quantity of the production item at position \a index to 1, retaining its incomplete progress.
     void DuplicateProductionItem(int index);                 ///< Adds a copy of the production item at position \a index below it in the queue, with no progress.
     void SetProductionRallyPoint(int index, int rally_point_id = INVALID_OBJECT_ID);  ///< Sets the rally point for ships produced by this produce, to which they are automatically ordered to move after they are produced.
@@ -261,7 +262,7 @@ public:
     /** Calculates systems that can propagate supply using this empire's own /
       * internal list of explored systems. */
     void UpdateSupplyUnobstructedSystems(bool precombat=false);
-    /** Updates fleet ArrivalStarlane to flag fleets of this empire that are not blockaded post-combat 
+    /** Updates fleet ArrivalStarlane to flag fleets of this empire that are not blockaded post-combat
      *  must be done after *all* noneliminated empires have updated their unobstructed systems* */
     void UpdateUnobstructedFleets();
     /** Records, in a list of pending updates, the start_system exit lane to the specified destination as accessible to this empire*/
@@ -376,6 +377,7 @@ private:
     int                             m_id = ALL_EMPIRES;         ///< Empire's unique numeric id
     std::string                     m_name;                     ///< Empire's name
     std::string                     m_player_name;              ///< Empire's Player's name
+    bool                            m_authenticated;            ///< Empire's Player's authentication status
     GG::Clr                         m_color;                    ///< Empire's color
     int                             m_capital_id = INVALID_OBJECT_ID;  ///< the ID of the empire's capital planet
 

--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -328,7 +328,7 @@ public:
 
     void UpdateOwnedObjectCounters();
 
-    void SetAuthenticated(bool authenticated=true);
+    void SetAuthenticated(bool authenticated = true);
 
     int TotalShipsOwned() const;
     int TotalShipPartsOwned() const;    ///< Total number of parts for all owned ships in this empire
@@ -379,7 +379,9 @@ private:
     int                             m_id = ALL_EMPIRES;         ///< Empire's unique numeric id
     std::string                     m_name;                     ///< Empire's name
     std::string                     m_player_name;              ///< Empire's Player's name
-    bool                            m_authenticated;            ///< Empire's Player's authentication status
+    /** Empire's Player's authentication flag. Set if only player with empire's player's name
+        should play this empire. */
+    bool                            m_authenticated;
     GG::Clr                         m_color;                    ///< Empire's color
     int                             m_capital_id = INVALID_OBJECT_ID;  ///< the ID of the empire's capital planet
 

--- a/Empire/EmpireManager.cpp
+++ b/Empire/EmpireManager.cpp
@@ -107,9 +107,9 @@ void EmpireManager::BackPropagateMeters() {
 
 Empire* EmpireManager::CreateEmpire(int empire_id, const std::string& name,
                                     const std::string& player_name,
-                                    const GG::Clr& color)
+                                    const GG::Clr& color, bool authenticated)
 {
-    Empire* empire = new Empire(name, player_name, empire_id, color);
+    Empire* empire = new Empire(name, player_name, empire_id, color, authenticated);
     InsertEmpire(empire);
     return empire;
 }
@@ -217,7 +217,7 @@ void EmpireManager::HandleDiplomaticMessage(const DiplomaticMessage& message) {
     int recipient_empire_id = message.RecipientEmpireID();
 
     DiplomaticStatus diplo_status = GetDiplomaticStatus(sender_empire_id, recipient_empire_id);
-    bool message_from_recipient_to_sender_available = DiplomaticMessageAvailable(recipient_empire_id, sender_empire_id); 
+    bool message_from_recipient_to_sender_available = DiplomaticMessageAvailable(recipient_empire_id, sender_empire_id);
     const DiplomaticMessage& existing_message_from_recipient_to_sender = GetDiplomaticMessage(recipient_empire_id, sender_empire_id);
     //bool message_from_sender_to_recipient_available = DiplomaticMessageAvailable(sender_empire_id, recipient_empire_id);
 

--- a/Empire/EmpireManager.h
+++ b/Empire/EmpireManager.h
@@ -24,7 +24,7 @@ class UniverseObject;
 class FO_COMMON_API EmpireManager {
 public:
     /// Iterator over Empires
-    typedef std::map<int, Empire*>::iterator iterator; 
+    typedef std::map<int, Empire*>::iterator iterator;
 
     /// Const Iterator over Empires
     typedef std::map<int, Empire*>::const_iterator const_iterator;
@@ -77,7 +77,7 @@ public:
       * caller's responsibility to make sure that universe updates planet
       * ownership. */
     Empire*     CreateEmpire(int empire_id, const std::string& name, const std::string& player_name,
-                             const GG::Clr& color);
+                             const GG::Clr& color, bool authenticated);
 
     /** Removes and deletes all empires from the manager. */
     void        Clear();

--- a/server/SaveLoad.cpp
+++ b/server/SaveLoad.cpp
@@ -45,7 +45,7 @@ namespace {
     std::map<int, SaveGameEmpireData> CompileSaveGameEmpireData(const EmpireManager& empire_manager) {
         std::map<int, SaveGameEmpireData> retval;
         for (const auto& entry : Empires())
-            retval[entry.first] = SaveGameEmpireData(entry.first, entry.second->Name(), entry.second->PlayerName(), entry.second->Color());
+            retval[entry.first] = SaveGameEmpireData(entry.first, entry.second->Name(), entry.second->PlayerName(), entry.second->Color(), entry.second->IsAuthenticated());
         return retval;
     }
 

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1292,6 +1292,11 @@ void ServerApp::LoadGameInit(const std::vector<PlayerSaveGameData>& player_save_
         // the player controlling a particular empire might have a different
         // player ID than when the game was first created
         m_player_empire_ids[player_id] = empire_id;
+
+        // set actual authentication status
+        if (Empire* empire = GetEmpire(empire_id)) {
+            empire->SetAuthenticated(player_connection->IsAuthenticated());
+        }
     }
 
     for (const auto& psgd : player_save_game_data) {
@@ -1747,16 +1752,18 @@ void ServerApp::DropPlayerEmpireLink(int player_id)
 { m_player_empire_ids.erase(player_id); }
 
 int ServerApp::AddPlayerIntoGame(const PlayerConnectionPtr& player_connection) {
+    Empire* empire_ptr = nullptr;
     int empire_id = ALL_EMPIRES;
     // search empire by player name
     for (auto empire : Empires()) {
         if (empire.second->PlayerName() == player_connection->PlayerName()) {
             empire_id = empire.first;
+            empire_ptr = empire.second;
             break;
         }
     }
 
-    if (empire_id == ALL_EMPIRES)
+    if (empire_id == ALL_EMPIRES || empire_ptr == nullptr)
         return false;
 
     auto orders_it = m_turn_sequence.find(empire_id);
@@ -1769,6 +1776,7 @@ int ServerApp::AddPlayerIntoGame(const PlayerConnectionPtr& player_connection) {
 
     // make a link to new connection
     m_player_empire_ids[player_connection->PlayerID()] = empire_id;
+    empire_ptr->SetAuthenticated(player_connection->IsAuthenticated());
 
     const OrderSet dummy;
     const OrderSet& orders = orders_it->second.second && orders_it->second.second->m_orders ? *(orders_it->second.second->m_orders) : dummy;

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1752,18 +1752,18 @@ void ServerApp::DropPlayerEmpireLink(int player_id)
 { m_player_empire_ids.erase(player_id); }
 
 int ServerApp::AddPlayerIntoGame(const PlayerConnectionPtr& player_connection) {
-    Empire* empire_ptr = nullptr;
+    Empire* empire = nullptr;
     int empire_id = ALL_EMPIRES;
     // search empire by player name
-    for (auto empire : Empires()) {
-        if (empire.second->PlayerName() == player_connection->PlayerName()) {
-            empire_id = empire.first;
-            empire_ptr = empire.second;
+    for (auto e : Empires()) {
+        if (e.second->PlayerName() == player_connection->PlayerName()) {
+            empire_id = e.first;
+            empire = e.second;
             break;
         }
     }
 
-    if (empire_id == ALL_EMPIRES || empire_ptr == nullptr)
+    if (empire_id == ALL_EMPIRES || empire == nullptr)
         return false;
 
     auto orders_it = m_turn_sequence.find(empire_id);
@@ -1776,7 +1776,7 @@ int ServerApp::AddPlayerIntoGame(const PlayerConnectionPtr& player_connection) {
 
     // make a link to new connection
     m_player_empire_ids[player_connection->PlayerID()] = empire_id;
-    empire_ptr->SetAuthenticated(player_connection->IsAuthenticated());
+    empire->SetAuthenticated(player_connection->IsAuthenticated());
 
     const OrderSet dummy;
     const OrderSet& orders = orders_it->second.second && orders_it->second.second->m_orders ? *(orders_it->second.second->m_orders) : dummy;

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -319,6 +319,7 @@ void ServerFSM::UpdateIngameLobby() {
         } else {
             player_setup_data.m_empire_color = GG::Clr(255, 255, 255, 255);
         }
+        player_setup_data.m_authenticated = (*player_it)->IsAuthenticated();
         dummy_lobby_data.m_players.push_back({player_id, player_setup_data});
     }
     dummy_lobby_data.m_start_lock_cause = UserStringNop("SERVER_ALREADY_PLAYING_GAME");
@@ -644,6 +645,7 @@ MPLobby::MPLobby(my_context c) :
                     player_setup_data.m_starting_species_name = sm.RandomPlayableSpeciesName();
                 else
                     player_setup_data.m_starting_species_name = sm.SequentialPlayableSpeciesName(player_id);
+                player_setup_data.m_authenticated = player_connection->IsAuthenticated();
 
                 m_lobby_data->m_players.push_back({player_id, player_setup_data});
             } else if (player_connection->GetClientType() == Networking::CLIENT_TYPE_AI_PLAYER) {
@@ -688,6 +690,7 @@ MPLobby::MPLobby(my_context c) :
         player_setup_data.m_starting_species_name = sm.RandomPlayableSpeciesName();
         // leaving save game empire id as default
         player_setup_data.m_client_type =           player_connection->GetClientType();
+        player_setup_data.m_authenticated =         player_connection->IsAuthenticated();
 
         player_connection->SendMessage(ServerLobbyUpdateMessage(*m_lobby_data));
     }
@@ -840,6 +843,7 @@ void MPLobby::EstablishPlayer(const PlayerConnectionPtr& player_connection,
             player_setup_data.m_starting_species_name = sm.RandomPlayableSpeciesName();
         else
             player_setup_data.m_starting_species_name = sm.SequentialPlayableSpeciesName(player_id);
+        player_setup_data.m_authenticated =  player_connection->IsAuthenticated();
 
         // after setting all details, push into lobby data
         m_lobby_data->m_players.push_back({player_id, player_setup_data});
@@ -1091,6 +1095,8 @@ sc::result MPLobby::react(const LobbyUpdate& msg) {
                         WarnLogger(FSM) << "Got unallowed client types.";
                         break;
                     }
+                    // set correct authentication status
+                    player.second.m_authenticated = (*player_it)->IsAuthenticated();
                 } else {
                     // player wasn't found
                     // don't allow "ghost" records

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -1195,10 +1195,12 @@ sc::result MPLobby::react(const LobbyUpdate& msg) {
             auto max_ai = GetOptionsDB().Get<int>("network.server.ai.max");
             if (ai_count <= max_ai || max_ai < 0) {
                 if (sender->HasAuthRole(Networking::ROLE_HOST)) {
-                    // don't check host.
-                    m_lobby_data->m_players    = incoming_lobby_data.m_players;
+                    // don't check host player
+                    // treat host player as superuser or administrator
+                    m_lobby_data->m_players = incoming_lobby_data.m_players;
                 } else {
-                    // check player doesn't set protected empire to yourself
+                    // check players shouldn't set protected empire to themselves
+                    // if they don't have required player's name
                     bool incorrect_empire = false;
                     for (const auto& plr : incoming_lobby_data.m_players) {
                         if (plr.first != sender->PlayerID())
@@ -1225,8 +1227,8 @@ sc::result MPLobby::react(const LobbyUpdate& msg) {
                         has_important_changes = true;
                         player_setup_data_changed = true;
                     } else {
-                        // ToDo: non-host player could change only AI and himself
-                        m_lobby_data->m_players    = incoming_lobby_data.m_players;
+                        // ToDo: non-host player should change only AI and himself
+                        m_lobby_data->m_players = incoming_lobby_data.m_players;
                     }
                 }
             } else {

--- a/universe/UniverseGenerator.cpp
+++ b/universe/UniverseGenerator.cpp
@@ -331,7 +331,7 @@ namespace {
         // "depth" level in tree of system currently being investigated
         int curDepth;
 
-        // iterators to set of starlanes, in graph, for the current system    
+        // iterators to set of starlanes, in graph, for the current system
         std::set<int>::iterator curSysLanesSetIter, curSysLanesSetEnd;
 
         // check for simple cases for quick termination
@@ -355,7 +355,7 @@ namespace {
         while (sysListIter != sysListEnd) {
             cur_sys_id = *sysListIter;
 
-            // check that iteration hasn't reached maxLaneJumps levels deep, which would 
+            // check that iteration hasn't reached maxLaneJumps levels deep, which would
             // mean that system2 isn't within maxLaneJumps starlane jumps of system1
             curDepth = (*accessibleSystemsMap.find(cur_sys_id)).second;
 
@@ -477,7 +477,7 @@ namespace {
                     auto dest2 = *laneSetIter2;
 
                     std::pair<int, int> lane2;
-                    if (cur_sys_id < dest2) 
+                    if (cur_sys_id < dest2)
                         lane2 = {cur_sys_id, dest2};
                     else
                         lane2 = {dest2, cur_sys_id};
@@ -881,6 +881,7 @@ void InitEmpires(const std::map<int, PlayerSetupData>& player_setup_data)
         int         empire_id =     player_id;
         std::string player_name =   entry.second.m_player_name;
         GG::Clr     empire_colour = entry.second.m_empire_color;
+        bool        authenticated = entry.second.m_authenticated;
 
         // validate or generate empire colour
         // ensure no other empire gets auto-assigned this colour automatically
@@ -908,7 +909,7 @@ void InitEmpires(const std::map<int, PlayerSetupData>& player_setup_data)
                       << " for player: " << player_name << " (with player id: " << player_id << ")";
 
         // create new Empire object through empire manager
-        Empires().CreateEmpire(empire_id, empire_name, player_name, empire_colour);
+        Empires().CreateEmpire(empire_id, empire_name, player_name, empire_colour, authenticated);
     }
 
     Empires().ResetDiplomacy();

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -110,14 +110,17 @@ struct FO_COMMON_API SaveGameEmpireData {
         m_empire_id(ALL_EMPIRES),
         m_empire_name(),
         m_player_name(),
-        m_color()
+        m_color(),
+        m_authenticated(false)
     {}
     SaveGameEmpireData(int empire_id, const std::string& empire_name,
-                       const std::string& player_name, const GG::Clr& colour) :
+                       const std::string& player_name, const GG::Clr& colour,
+                       bool authenticated) :
         m_empire_id(empire_id),
         m_empire_name(empire_name),
         m_player_name(player_name),
-        m_color(colour)
+        m_color(colour),
+        m_authenticated(authenticated)
     {}
     //@}
 
@@ -125,12 +128,15 @@ struct FO_COMMON_API SaveGameEmpireData {
     std::string m_empire_name;
     std::string m_player_name;
     GG::Clr     m_color;
+    bool        m_authenticated;
 
 private:
     friend class boost::serialization::access;
     template <class Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
+
+BOOST_CLASS_VERSION(SaveGameEmpireData, 1);
 
 /** Contains basic data about a player in a game. */
 struct FO_COMMON_API PlayerSaveHeaderData {
@@ -218,7 +224,8 @@ struct PlayerSetupData {
         m_starting_species_name(),
         m_save_game_empire_id(ALL_EMPIRES),
         m_client_type(Networking::INVALID_CLIENT_TYPE),
-        m_player_ready(false)
+        m_player_ready(false),
+        m_authenticated(false)
     {}
     //@}
 
@@ -230,6 +237,7 @@ struct PlayerSetupData {
     int                     m_save_game_empire_id;  ///< when loading a game, the ID of the empire that this player will control
     Networking::ClientType  m_client_type;          ///< is this player an AI, human player or...?
     bool                    m_player_ready;         ///< if player ready to play.
+    bool                    m_authenticated;        ///< if player was authenticated
 
 private:
     friend class boost::serialization::access;
@@ -238,6 +246,8 @@ private:
 };
 bool FO_COMMON_API operator==(const PlayerSetupData& lhs, const PlayerSetupData& rhs);
 bool operator!=(const PlayerSetupData& lhs, const PlayerSetupData& rhs);
+
+BOOST_CLASS_VERSION(PlayerSetupData, 1);
 
 /** The data needed to establish a new single player game.  If \a m_new_game
   * is true, a new game is to be started, using the remaining members besides

--- a/util/SerializeEmpire.cpp
+++ b/util/SerializeEmpire.cpp
@@ -203,9 +203,15 @@ void Empire::serialize(Archive& ar, const unsigned int version)
             & BOOST_SERIALIZATION_NVP(m_building_types_produced)
             & BOOST_SERIALIZATION_NVP(m_building_types_scrapped);
     }
+
+    if (Archive::is_loading::value && version < 3) {
+        m_authenticated = false;
+    } else {
+        ar  & BOOST_SERIALIZATION_NVP(m_authenticated);
+    }
 }
 
-BOOST_CLASS_VERSION(Empire, 2)
+BOOST_CLASS_VERSION(Empire, 3)
 
 template void Empire::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, const unsigned int);
 template void Empire::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, const unsigned int);

--- a/util/SerializeMultiplayerCommon.cpp
+++ b/util/SerializeMultiplayerCommon.cpp
@@ -86,6 +86,9 @@ void SaveGameEmpireData::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_empire_name)
         & BOOST_SERIALIZATION_NVP(m_player_name)
         & BOOST_SERIALIZATION_NVP(m_color);
+    if (version >= 1) {
+        ar & BOOST_SERIALIZATION_NVP(m_authenticated);
+    }
 }
 
 template void SaveGameEmpireData::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, const unsigned int);
@@ -148,6 +151,9 @@ void PlayerSetupData::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_save_game_empire_id)
         & BOOST_SERIALIZATION_NVP(m_client_type)
         & BOOST_SERIALIZATION_NVP(m_player_ready);
+    if (version >= 1) {
+        ar & BOOST_SERIALIZATION_NVP(m_authenticated);
+    }
 }
 
 template void PlayerSetupData::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, const unsigned int);


### PR DESCRIPTION
Fix #2357 

Adds new flag to save game if player who controls empire was authenticated.
Forbids players with different player's name to choose this empire on loading.