### PR TITLE
Topmost matches condition

### DIFF
--- a/default/scripting/buildings/ART_PARADISE_PLANET.focs.txt
+++ b/default/scripting/buildings/ART_PARADISE_PLANET.focs.txt
@@ -5,9 +5,6 @@ BuildingType
     buildtime = 10
     location = And [
         Planet
-        Not Contains Building name = "BLD_ART_PLANET"
-        Not Contains Building name = "BLD_ART_FACTORY_PLANET"
-        Not Contains Building name = "BLD_ART_PARADISE_PLANET"
         OwnedBy empire = Source.Owner
         Planet type = [Asteroids GasGiant]
         OwnerHasTech name = "GRO_GAIA_TRANS"

--- a/default/scripting/buildings/ART_PARADISE_PLANET.focs.txt
+++ b/default/scripting/buildings/ART_PARADISE_PLANET.focs.txt
@@ -5,6 +5,9 @@ BuildingType
     buildtime = 10
     location = And [
         Planet
+        Not Contains Building name = "BLD_ART_PLANET"
+        Not Contains Building name = "BLD_ART_FACTORY_PLANET"
+        Not Contains Building name = "BLD_ART_PARADISE_PLANET"
         OwnedBy empire = Source.Owner
         Planet type = [Asteroids GasGiant]
         OwnerHasTech name = "GRO_GAIA_TRANS"

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_1.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_1.focs.txt
@@ -26,7 +26,10 @@ Part
     location = OwnedBy empire = Source.Owner
     effectsgroups = [
         EffectsGroup
-            scope = [[EMPIRE_OWNED_SHIP_WITH_PART(FT_BAY_1)]]
+            scope = And [
+                Source
+                [[EMPIRE_OWNED_SHIP_WITH_PART(FT_BAY_1)]]
+            ]
             activation = Source
             stackinggroup = "INTERCEPTOR_FAST_LAUNCH_EFFECT"
             effects = [

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_1.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_1.focs.txt
@@ -12,7 +12,7 @@ Part
             MaximumNumberOf number = [[COMBAT_TARGETS_SPREAD_HANGAR]]
                 sortkey = LocalCandidate.Attack
                 condition = Fighter
-            Ship
+            [[COMBAT_TARGETS_NOT_DESTROYED_SHIP]]
         ]
     ]
     mountableSlotTypes = Internal

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_1.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_1.focs.txt
@@ -7,7 +7,13 @@ Part
     damage = 1
     combatTargets = And [
         [[COMBAT_TARGETS_VISIBLE_ENEMY]]
-        Fighter
+        // Target "Bombers" first. If there are no enemy fighters present, target Ships
+        OrderedAlternativesOf [
+            MaximumNumberOf number = [[COMBAT_TARGETS_SPREAD_HANGAR]]
+                sortkey = LocalCandidate.Attack
+                condition = Fighter
+            Ship
+        ]
     ]
     mountableSlotTypes = Internal
     buildcost = 15 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_1.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_1.focs.txt
@@ -8,19 +8,16 @@ Part
     combatTargets = And [
         // Consider only visible enemies as target
         [[COMBAT_TARGETS_VISIBLE_ENEMY]]
-        // Target "Bombers" first.
         OrderedAlternativesOf [
-            // Takes the N most dangerous enemy fighters as target
-            // N is the number of own interceptors multiplied by a spread multiplier
-            //  a higher spread ensures that interceptors rarely waste shots
-            //  a lower spread makes it more likely that the most dangerous enemies are taken down (while wasting more shots)
-            //  a spread of 1.2 has a good effectiveness
-            //  here we estimate the number of interceptors by the number of interceptor carriers (as you currently cant count the fighter objects)
-            //  estimating 4 interceptors per carrier usually will be too high in the last combat turn
-            //    we choose 3 instead, so at the beginning of the battle hitting the most dangerous targets for sure is emphasized, later spread is higher
-            MaximumNumberOf number = ( 1.2 * 3 * Statistic Count condition = [[OWN_INTERCEPTOR_CARRIER]] )
-                sortkey = LocalCandidate.Attack
-                condition = Fighter
+            // Target Bombers and Heavy Bombers first
+            And [
+                Fighter
+                Or [
+                   DesignHasPart name = "FT_HANGAR_3"
+                   DesignHasPart name = "FT_HANGAR_4"
+                ]
+            ]
+            Fighter
             // if no fighters: target enemy ships
             [[COMBAT_TARGETS_NOT_DESTROYED_SHIP]]
         ]
@@ -40,33 +37,6 @@ Part
             ]
     ]
     icon = "icons/ship_parts/fighter06.png"
-
-// Trying to consider only with the same targetting conditions (i.e. launched by the same hangar type)
-// Currently this is implemented as workaround which accepts wrong values in rare cases
-// There would be a workaround to find out the relative balance of types of own hangar parts and use that for scaling
-// But probably its better to query the launching hangar part like: DesignHasPart name = CurrentContent
-// For own interceptors it is enough to check damage for a highest bound attack.
-//   fighters are always up-to-date (as they get recreated each turn)
-//   fighter damage DOES depend on species *_WEAPONS, taking 0.6 margin makes it work for most common cases
-//     GOOD FT_HANGAR_1 NO TECH           -> 1.5 Damage
-//     GRET FT_HANGAR_1 NO TECH           -> 2   Damage
-//     BAD  FT_HANGAR_2 NO TECH           -> 2   Damage
-//     AVRG FT_HANGAR_2 NO TECH           -> 3   Damage
-//
-//     GRET FT_HANGAR_1 SHP_FIGHTERS_2    -> 4   Damage
-//     BAD  FT_HANGAR_2 SHP_FIGHTERS_2    -> 4   Damage
-//     AVRG FT_HANGAR_2 SHP_FIGHTERS_2    -> 5   Damage
-//   THIS CONDITION WILL BE WRONG FOR SOME CASES (namely if you have GREAT and BAD pilots of different carrier types in the same battle)
-//   higher tech level makes this fail for less cases
-
-OWN_INTERCEPTOR_CARRIER
-'''And [ InSystem id = RootCandidate.SystemID Ship OwnedBy empire = Source.Owner DesignHasPart name = "FT_HANGAR_1" ]'''
-
-// 2019-02-27: currently will not match anything in count condition: Statistic Count condition = Fighter
-OWN_INTERCEPTOR
-'''And [ Fighter OwnedBy empire = Source.Owner DesignHasPart name "FT_HANGAR_1" ]'''
-
-
 
 #include "/scripting/common/upkeep.macros"
 #include "/scripting/techs/techs.macros"

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_1.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_1.focs.txt
@@ -5,22 +5,19 @@ Part
     class = FighterHangar
     capacity = 4
     damage = 1
-    combatTargets = And [
-        // Consider only visible enemies as target
-        [[COMBAT_TARGETS_VISIBLE_ENEMY]]
-        OrderedAlternativesOf [
-            // Target Bombers and Heavy Bombers first
-            And [
-                Fighter
-                Or [
-                   DesignHasPart name = "FT_HANGAR_3"
-                   DesignHasPart name = "FT_HANGAR_4"
-                ]
-            ]
+    combatTargets = OrderedAlternativesOf [
+        // Target Bombers and Heavy Bombers first
+        And [
+            [[COMBAT_TARGETS_VISIBLE_ENEMY]]
             Fighter
-            // if no fighters: target enemy ships
-            [[COMBAT_TARGETS_NOT_DESTROYED_SHIP]]
+            Or [
+               DesignHasPart name = "FT_HANGAR_3"
+               DesignHasPart name = "FT_HANGAR_4"
+            ]
         ]
+        And [ [[COMBAT_TARGETS_VISIBLE_ENEMY]]  Fighter ]
+        // if no fighters: target enemy ships
+        And [ [[COMBAT_TARGETS_VISIBLE_ENEMY]]  [[COMBAT_TARGETS_NOT_DESTROYED_SHIP]] ]
     ]
     mountableSlotTypes = Internal
     buildcost = 15 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_1.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_1.focs.txt
@@ -6,12 +6,22 @@ Part
     capacity = 4
     damage = 1
     combatTargets = And [
+        // Consider only visible enemies as target
         [[COMBAT_TARGETS_VISIBLE_ENEMY]]
-        // Target "Bombers" first. If there are no enemy fighters present, target Ships
+        // Target "Bombers" first.
         OrderedAlternativesOf [
-            MaximumNumberOf number = [[COMBAT_TARGETS_SPREAD_HANGAR]]
+            // Takes the N most dangerous enemy fighters as target
+            // N is the number of own interceptors multiplied by a spread multiplier
+            //  a higher spread ensures that interceptors rarely waste shots
+            //  a lower spread makes it more likely that the most dangerous enemies are taken down (while wasting more shots)
+            //  a spread of 1.2 has a good effectiveness
+            //  here we estimate the number of interceptors by the number of interceptor carriers (as you currently cant count the fighter objects)
+            //  estimating 4 interceptors per carrier usually will be too high in the last combat turn
+            //    we choose 3 instead, so at the beginning of the battle hitting the most dangerous targets for sure is emphasized, later spread is higher
+            MaximumNumberOf number = ( 1.2 * 3 * Statistic Count condition = [[OWN_INTERCEPTOR_CARRIER]] )
                 sortkey = LocalCandidate.Attack
                 condition = Fighter
+            // if no fighters: target enemy ships
             [[COMBAT_TARGETS_NOT_DESTROYED_SHIP]]
         ]
     ]
@@ -30,6 +40,33 @@ Part
             ]
     ]
     icon = "icons/ship_parts/fighter06.png"
+
+// Trying to consider only with the same targetting conditions (i.e. launched by the same hangar type)
+// Currently this is implemented as workaround which accepts wrong values in rare cases
+// There would be a workaround to find out the relative balance of types of own hangar parts and use that for scaling
+// But probably its better to query the launching hangar part like: DesignHasPart name = CurrentContent
+// For own interceptors it is enough to check damage for a highest bound attack.
+//   fighters are always up-to-date (as they get recreated each turn)
+//   fighter damage DOES depend on species *_WEAPONS, taking 0.6 margin makes it work for most common cases
+//     GOOD FT_HANGAR_1 NO TECH           -> 1.5 Damage
+//     GRET FT_HANGAR_1 NO TECH           -> 2   Damage
+//     BAD  FT_HANGAR_2 NO TECH           -> 2   Damage
+//     AVRG FT_HANGAR_2 NO TECH           -> 3   Damage
+//
+//     GRET FT_HANGAR_1 SHP_FIGHTERS_2    -> 4   Damage
+//     BAD  FT_HANGAR_2 SHP_FIGHTERS_2    -> 4   Damage
+//     AVRG FT_HANGAR_2 SHP_FIGHTERS_2    -> 5   Damage
+//   THIS CONDITION WILL BE WRONG FOR SOME CASES (namely if you have GREAT and BAD pilots of different carrier types in the same battle)
+//   higher tech level makes this fail for less cases
+
+OWN_INTERCEPTOR_CARRIER
+'''And [ InSystem id = RootCandidate.SystemID Ship OwnedBy empire = Source.Owner DesignHasPart name = "FT_HANGAR_1" ]'''
+
+// 2019-02-27: currently will not match anything in count condition: Statistic Count condition = Fighter
+OWN_INTERCEPTOR
+'''And [ Fighter OwnedBy empire = Source.Owner DesignHasPart name "FT_HANGAR_1" ]'''
+
+
 
 #include "/scripting/common/upkeep.macros"
 #include "/scripting/techs/techs.macros"

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_3.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_3.focs.txt
@@ -5,12 +5,9 @@ Part
     class = FighterHangar
     capacity = 2
     damage = 5
-    combatTargets = And [
-        [[COMBAT_TARGETS_VISIBLE_ENEMY]]
-        OrderedAlternativesOf [
-            [[COMBAT_TARGETS_NOT_DESTROYED_SHIP]]
-            Fighter
-        ]
+    combatTargets = OrderedAlternativesOf [
+        And [ [[COMBAT_TARGETS_VISIBLE_ENEMY]]  [[COMBAT_TARGETS_NOT_DESTROYED_SHIP]] ]
+        And [ [[COMBAT_TARGETS_VISIBLE_ENEMY]]  Fighter ]
     ]
     mountableSlotTypes = Internal
     buildcost = 25 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_3.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_3.focs.txt
@@ -7,7 +7,7 @@ Part
     damage = 5
     combatTargets = And [
         [[COMBAT_TARGETS_VISIBLE_ENEMY]]
-        Or [
+        OrderedAlternativesOf [
             [[COMBAT_TARGETS_NOT_DESTROYED_SHIP]]
             Fighter
         ]

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_4.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_4.focs.txt
@@ -7,7 +7,7 @@ Part
     damage = 10
     combatTargets = And [
         [[COMBAT_TARGETS_VISIBLE_ENEMY]]
-        Or [
+        OrderedAlternativesOf [
             [[COMBAT_TARGETS_NOT_DESTROYED_SHIP]]
             Fighter
         ]

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_4.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_4.focs.txt
@@ -5,12 +5,9 @@ Part
     class = FighterHangar
     capacity = 1
     damage = 10
-    combatTargets = And [
-        [[COMBAT_TARGETS_VISIBLE_ENEMY]]
-        OrderedAlternativesOf [
-            [[COMBAT_TARGETS_NOT_DESTROYED_SHIP]]
-            Fighter
-        ]
+    combatTargets = OrderedAlternativesOf [
+        And [ [[COMBAT_TARGETS_VISIBLE_ENEMY]]  [[COMBAT_TARGETS_NOT_DESTROYED_SHIP]] ]
+        And [ [[COMBAT_TARGETS_VISIBLE_ENEMY]]  Fighter ]
     ]
     mountableSlotTypes = Internal
     buildcost = 30 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]

--- a/default/scripting/ship_parts/targeting.macros
+++ b/default/scripting/ship_parts/targeting.macros
@@ -32,15 +32,21 @@ COMBAT_TARGETS_PLANET_WITH_DEFENSE
 '''
 
 
-// This should just considers fighters with the same targetting conditions (i.e. launched by the same hangar type
-// There would be a workaround to find out the relative balance of types of own hangar parts and use that for scaling
-// But probably its better to query the launching hangar part like: LaunchedByHangar = CurrentContent
-COMBAT_TARGETS_SPREAD_HANGAR
-'''[[COMBAT_TARGETS_SPREAD(And [ Fighter OwnedBy empire = Source.Owner ])]]'''
-
-// Calculates an efficient number for NumberOf conditions based on the number of total shots of weapon of that part type used
-// MaximumNumberOf number = [[COMBAT_TARGETS_SPREAD(shooter-shots-condition)]]
-// e.g. MaximumNumberOf number = [[COMBAT_TARGETS_SPREAD(And [ Fighter OwnedBy empire = Source.Owner ])]]
-// Takes a heuristical 20% extra spread 
-COMBAT_TARGETS_SPREAD
-'''(1.2 * Statistic Count condition = @1@)'''
+// If you have a group of ships attacking another group of ships as optimisation you can select a number of primary subtargets (e.g. the most dangerous enemies)
+// If you make the number too small you will hit the same target multiple times.
+// If you make the number too high you will hit targets which you did not intend to hit primarily.
+// COMBAT_TARGETS_WEAPON_SPREAD_HIT_ONCE calculates an number for NumberOf conditions for an attack group condition (ship attackers only) for wasting almost no shots.
+//  @1@ attack group condition (Filter the universe for the same kind of targeting)
+// This is based on the number of total shots of weapon of that part type used. Usage like:
+//   MaximumNumberOf number = [[COMBAT_TARGETS_SPREAD(attack-group-condition)]]
+// e.g. MaximumNumberOf number = [[COMBAT_TARGETS_SPREAD(And [ Ship OwnedBy empire = Source.Owner ])]]
+// Takes a heuristical 20% extra spread by default
+//
+// 2019-02-27: currently will not match anything in count condition: Statistic Count condition = Fighter
+// Possible extensions:
+//   adapt Count so it can cound Fighters and implement a COMBAT_TARGETS_FIGHTER_SPREAD
+//   implement COMBAT_TARGETS_WEAPON_SPREAD_KILL ... that calculates how many hits are necessary to kill the primary targets off
+//   adapt spread to species modifiers
+COMBAT_TARGETS_WEAPON_SPREAD_HIT_ONCE
+'''( 1.2 * ShipPartMeter part = CurrentContent meter = SecondaryStat object = RootCandidate * Statistic Count condition = And [ Ship @1@ ] )'''
+//spread * shots-per-current-ship-part                                                      * count of attackers in attack-group-condition

--- a/default/scripting/ship_parts/targeting.macros
+++ b/default/scripting/ship_parts/targeting.macros
@@ -30,3 +30,17 @@ COMBAT_TARGETS_PLANET_WITH_DEFENSE
             ]
         ]
 '''
+
+
+// This should just considers fighters with the same targetting conditions (i.e. launched by the same hangar type
+// There would be a workaround to find out the relative balance of types of own hangar parts and use that for scaling
+// But probably its better to query the launching hangar part like: LaunchedByHangar = CurrentContent
+COMBAT_TARGETS_SPREAD_HANGAR
+'''[[COMBAT_TARGETS_SPREAD(And [ Fighter OwnedBy empire = Source.Owner ])]]'''
+
+// Calculates an efficient number for NumberOf conditions based on the number of total shots of weapon of that part type used
+// MaximumNumberOf number = [[COMBAT_TARGETS_SPREAD(shooter-shots-condition)]]
+// e.g. MaximumNumberOf number = [[COMBAT_TARGETS_SPREAD(And [ Fighter OwnedBy empire = Source.Owner ])]]
+// Takes a heuristical 20% extra spread 
+COMBAT_TARGETS_SPREAD
+'''(1.2 * Statistic Count condition = @1@)'''

--- a/default/scripting/ship_parts/targeting.macros
+++ b/default/scripting/ship_parts/targeting.macros
@@ -30,23 +30,3 @@ COMBAT_TARGETS_PLANET_WITH_DEFENSE
             ]
         ]
 '''
-
-
-// If you have a group of ships attacking another group of ships as optimisation you can select a number of primary subtargets (e.g. the most dangerous enemies)
-// If you make the number too small you will hit the same target multiple times.
-// If you make the number too high you will hit targets which you did not intend to hit primarily.
-// COMBAT_TARGETS_WEAPON_SPREAD_HIT_ONCE calculates an number for NumberOf conditions for an attack group condition (ship attackers only) for wasting almost no shots.
-//  @1@ attack group condition (Filter the universe for the same kind of targeting)
-// This is based on the number of total shots of weapon of that part type used. Usage like:
-//   MaximumNumberOf number = [[COMBAT_TARGETS_SPREAD(attack-group-condition)]]
-// e.g. MaximumNumberOf number = [[COMBAT_TARGETS_SPREAD(And [ Ship OwnedBy empire = Source.Owner ])]]
-// Takes a heuristical 20% extra spread by default
-//
-// 2019-02-27: currently will not match anything in count condition: Statistic Count condition = Fighter
-// Possible extensions:
-//   adapt Count so it can cound Fighters and implement a COMBAT_TARGETS_FIGHTER_SPREAD
-//   implement COMBAT_TARGETS_WEAPON_SPREAD_KILL ... that calculates how many hits are necessary to kill the primary targets off
-//   adapt spread to species modifiers
-COMBAT_TARGETS_WEAPON_SPREAD_HIT_ONCE
-'''( 1.2 * ShipPartMeter part = CurrentContent meter = SecondaryStat object = RootCandidate * Statistic Count condition = And [ Ship @1@ ] )'''
-//spread * shots-per-current-ship-part                                                      * count of attackers in attack-group-condition

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -10211,7 +10211,7 @@ DESC_NOT_OR_AFTER_SINGLE_OPERAND
 
 # OrderedAlternativesOf Descriptions for expressions 'OrderedAlternativesOf [ A B C ]'
 DESC_ORDERED_ALTERNATIVES_BEFORE_OPERANDS
-''' {'''
+'''that matches the first matching condition {'''
 
 DESC_ORDERED_ALTERNATIVES_BETWEEN_OPERANDS
 ''', else'''
@@ -10228,19 +10228,19 @@ DESC_ORDERED_ALTERNATIVES_AFTER_SINGLE_OPERAND
 # Expressions like  'NOT OrderedAlternativesOf [ A B C ]'
 # Note: returned matches rely on (NOT A), (NOT B).. and are handled in the descriptions of A, B.. respectively
 DESC_NOT_ORDERED_ALTERNATIVES_BEFORE_OPERANDS
-'''that matches the first matching conditions' non-matching candidates: n{'''
+'''that matches the first matching conditions' non-matching candidates: {'''
 
 DESC_NOT_ORDERED_ALTERNATIVES_BETWEEN_OPERANDS
 ''', else'''
 
 DESC_NOT_ORDERED_ALTERNATIVES_AFTER_OPERANDS
-''' }n'''
+''' }'''
 
 DESC_NOT_ORDERED_ALTERNATIVES_BEFORE_SINGLE_OPERAND
-'''n{'''
+'''{'''
 
 DESC_NOT_ORDERED_ALTERNATIVES_AFTER_SINGLE_OPERAND
-'''(iff it also has non-matches)}n'''
+'''(iff it also has non-matches)}'''
 
 
 # %1% textual description of the lower turn limit.

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -10208,6 +10208,41 @@ DESC_NOT_OR_AFTER_SINGLE_OPERAND
 '''[[DESC_AND_AFTER_SINGLE_OPERAND]]'''
 
 
+
+# OrderedAlternativesOf Descriptions for expressions 'OrderedAlternativesOf [ A B C ]'
+DESC_ORDERED_ALTERNATIVES_BEFORE_OPERANDS
+''' {'''
+
+DESC_ORDERED_ALTERNATIVES_BETWEEN_OPERANDS
+''', else'''
+
+DESC_ORDERED_ALTERNATIVES_AFTER_OPERANDS
+''' }'''
+
+DESC_ORDERED_ALTERNATIVES_BEFORE_SINGLE_OPERAND
+'''{'''
+
+DESC_ORDERED_ALTERNATIVES_AFTER_SINGLE_OPERAND
+'''(iff it also has non-matches)}'''
+
+# Expressions like  'NOT OrderedAlternativesOf [ A B C ]'
+# Note: returned matches rely on (NOT A), (NOT B).. and are handled in the descriptions of A, B.. respectively
+DESC_NOT_ORDERED_ALTERNATIVES_BEFORE_OPERANDS
+'''that matches the first matching conditions' non-matching candidates: n{'''
+
+DESC_NOT_ORDERED_ALTERNATIVES_BETWEEN_OPERANDS
+''', else'''
+
+DESC_NOT_ORDERED_ALTERNATIVES_AFTER_OPERANDS
+''' }n'''
+
+DESC_NOT_ORDERED_ALTERNATIVES_BEFORE_SINGLE_OPERAND
+'''n{'''
+
+DESC_NOT_ORDERED_ALTERNATIVES_AFTER_SINGLE_OPERAND
+'''(iff it also has non-matches)}n'''
+
+
 # %1% textual description of the lower turn limit.
 # %2% textual description of the upper turn limit.
 DESC_TURN

--- a/parse/ConditionParser1.cpp
+++ b/parse/ConditionParser1.cpp
@@ -144,6 +144,11 @@ namespace parse { namespace detail {
             [ _val = construct_movable_(new_<Condition::Not>(deconstruct_movable_(_1, _pass))) ]
             ;
 
+        ordered_alternatives_of
+            = ( omit_[tok.OrderedAlternativesOf_] > '[' > +condition_parser > lit(']'))
+            [ _val = construct_movable_(new_<Condition::OrderedAlternativesOf>(deconstruct_movable_vector_(_1, _pass))) ]
+            ;
+
         described
             = ( omit_[tok.Described_]
                 > label(tok.Description_) > tok.string
@@ -168,6 +173,7 @@ namespace parse { namespace detail {
             |   and_
             |   or_
             |   not_
+            |   ordered_alternatives_of
             |   described
             ;
 
@@ -187,6 +193,7 @@ namespace parse { namespace detail {
         and_.name("And");
         or_.name("Or");
         not_.name("Not");
+        ordered_alternatives_of.name("OrderedAlternativesOf");
         described.name("Described");
 
 #if DEBUG_CONDITION_PARSERS
@@ -204,6 +211,7 @@ namespace parse { namespace detail {
         debug(and_);
         debug(or_);
         debug(not_);
+        debug(ordered_alternatives_of);
         debug(described);
 #endif
     }

--- a/parse/ConditionParser1.h
+++ b/parse/ConditionParser1.h
@@ -34,6 +34,7 @@ namespace parse { namespace detail {
         condition_parser_rule                  and_;
         condition_parser_rule                  or_;
         condition_parser_rule                  not_;
+        condition_parser_rule                  ordered_alternatives_of;
         condition_parser_rule                  described;
         condition_parser_rule                  start;
     };

--- a/parse/Tokens.h
+++ b/parse/Tokens.h
@@ -521,7 +521,7 @@
     (TopPriorityEnqueuedTech)                   \
     (TopPriorityResearchableTech)               \
     (TopPriorityTransferrableTech)              \
-    (OrderedAlternativesOf)                            \
+    (OrderedAlternativesOf)                     \
     (Toxic)                                     \
     (Trade)
 

--- a/parse/Tokens.h
+++ b/parse/Tokens.h
@@ -521,6 +521,7 @@
     (TopPriorityEnqueuedTech)                   \
     (TopPriorityResearchableTech)               \
     (TopPriorityTransferrableTech)              \
+    (OrderedAlternativesOf)                            \
     (Toxic)                                     \
     (Trade)
 

--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -10075,7 +10075,8 @@ void OrderedAlternativesOf::Eval(const ScriptingContext& parent_context,
                 FCMoveContent(temp_non_matches, non_matches);
                 return;
             }
-            // Select this operand if there are matching objects in the non_matches input set. 
+            // Select this operand if there are matching objects in the non_matches input set.
+            // Note: the empty matches set is used to temporarily store matches from the non_matches input set
             operand->Eval(local_context, matches, non_matches, NON_MATCHES);
             if (!matches.empty()) {
                 // Select and apply this operand. But no matching objects exist in the matches input set,

--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -5111,20 +5111,15 @@ namespace {
             if (!candidate)
                 return false;
 
-            auto fighter = std::dynamic_pointer_cast<const ::Fighter>(candidate);
             const ShipDesign* design = nullptr;
-            if (fighter) {
+            if (auto fighter = std::dynamic_pointer_cast<const ::Fighter>(candidate)) {
                 // it is a fighter
-                auto carriers = Objects().FindObjects<Ship>( (std::vector<int> ) { fighter->LaunchedFrom() } );
-                if (carriers.empty())
-                    return false;
-                design = carriers.front()->Design();
-            } else {
-                // is it a ship?
-                auto ship = std::dynamic_pointer_cast<const ::Ship>(candidate);
-                if (!ship)
-                    return false;
+                design = Objects().Object<Ship>(fighter->LaunchedFrom())->Design();
+            } else if (auto ship = std::dynamic_pointer_cast<const ::Ship>(candidate)) {
+                // ir is a ship
                 design = ship->Design();
+            } else {
+                return false;
             }
             // with a valid design?
             if (!design)

--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -9964,10 +9964,12 @@ unsigned int Not::GetCheckSum() const {
     TraceLogger() << "GetCheckSum(Not): retval: " << retval;
     return retval;
 }
+
 ///////////////////////////////////////////////////////////
 // OrderedAlternativesOf
 ///////////////////////////////////////////////////////////
-OrderedAlternativesOf::OrderedAlternativesOf(std::vector<std::unique_ptr<ConditionBase>>&& operands) :
+OrderedAlternativesOf::OrderedAlternativesOf(
+    std::vector<std::unique_ptr<ConditionBase>>&& operands) :
     ConditionBase(),
     m_operands(std::move(operands))
 {}
@@ -9989,8 +9991,9 @@ bool OrderedAlternativesOf::operator==(const ConditionBase& rhs) const {
     return true;
 }
 
-void OrderedAlternativesOf::Eval(const ScriptingContext& parent_context, ObjectSet& matches,
-               ObjectSet& non_matches, SearchDomain search_domain/* = NON_MATCHES*/) const
+void OrderedAlternativesOf::Eval(const ScriptingContext& parent_context,
+                                 ObjectSet& matches, ObjectSet& non_matches,
+                                 SearchDomain search_domain/* = NON_MATCHES*/) const
 {
     std::shared_ptr<const UniverseObject> no_object;
     ScriptingContext local_context(parent_context, no_object);

--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -9969,11 +9969,8 @@ unsigned int Not::GetCheckSum() const {
 // OrderedAlternativesOf
 ///////////////////////////////////////////////////////////
 void FCMoveContent(Condition::ObjectSet& from_set, Condition::ObjectSet& to_set) {
-    for (auto it = from_set.begin(); it != from_set.end(); ) {
-        to_set.push_back(*it);
-        *it = from_set.back();
-        from_set.pop_back();
-    }
+    to_set.insert(to_set.end(), from_set.begin(), from_set.end());
+    from_set.clear();
 }
 
 OrderedAlternativesOf::OrderedAlternativesOf(

--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -9969,7 +9969,9 @@ unsigned int Not::GetCheckSum() const {
 // OrderedAlternativesOf
 ///////////////////////////////////////////////////////////
 void FCMoveContent(Condition::ObjectSet& from_set, Condition::ObjectSet& to_set) {
-    to_set.insert(to_set.end(), from_set.begin(), from_set.end());
+    to_set.insert(to_set.end(),
+                  std::make_move_iterator(from_set.begin()),
+                  std::make_move_iterator(from_set.end()));
     from_set.clear();
 }
 

--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -5114,9 +5114,9 @@ namespace {
             std::shared_ptr<const Ship> ship = nullptr;
             if (auto fighter = std::dynamic_pointer_cast<const ::Fighter>(candidate)) {
                 // it is a fighter
-                ship = std::move(Objects().Object<Ship>(fighter->LaunchedFrom()));
+                ship = Objects().Object<Ship>(fighter->LaunchedFrom());
             } else {
-                ship = std::move(std::dynamic_pointer_cast<const ::Ship>(candidate));
+                ship = std::dynamic_pointer_cast<const ::Ship>(candidate);
             }
 
             // is it a ship

--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -7,6 +7,7 @@
 #include "Pathfinder.h"
 #include "Universe.h"
 #include "Building.h"
+#include "Fighter.h"
 #include "Fleet.h"
 #include "Ship.h"
 #include "ObjectMap.h"
@@ -5110,12 +5111,22 @@ namespace {
             if (!candidate)
                 return false;
 
-            // is it a ship?
-            auto ship = std::dynamic_pointer_cast<const ::Ship>(candidate);
-            if (!ship)
-                return false;
+            auto fighter = std::dynamic_pointer_cast<const ::Fighter>(candidate);
+            const ShipDesign* design = nullptr;
+            if (fighter) {
+                // it is a fighter
+                auto carriers = Objects().FindObjects<Ship>( (std::vector<int> ) { fighter->LaunchedFrom() } );
+                if (carriers.empty())
+                    return false;
+                design = carriers.front()->Design();
+            } else {
+                // is it a ship?
+                auto ship = std::dynamic_pointer_cast<const ::Ship>(candidate);
+                if (!ship)
+                    return false;
+                design = ship->Design();
+            }
             // with a valid design?
-            const ShipDesign* design = ship->Design();
             if (!design)
                 return false;
 

--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -10031,41 +10031,37 @@ void OrderedAlternativesOf::Eval(const ScriptingContext& parent_context,
         // check all operand conditions on all objects in the non matches set
         // stop if the operand condition has at least one match
         // Return non-matches if there are any
-        ObjectSet temp_non_matches;
-        temp_non_matches.reserve(non_matches.size());
+        ObjectSet temp_matches;
+        temp_matches.reserve(non_matches.size());
         // try matching operand conditions until one matches
         bool found_sth = false;
         for (auto& operand : m_operands) {
-            // move those matching the current non-negated operand from non_matches to temp_non_matches
-            operand->Eval(local_context, non_matches, temp_non_matches, MATCHES);
-            if (!non_matches.empty()) {
-                // i.e. the current operand should be used negated to move
+            operand->Eval(local_context, temp_matches, non_matches, NON_MATCHES);
+            if (!temp_matches.empty()) {
+                // have selected the current operand condition to use, so apply it to the NON_MATCHES candidate set.
                 found_sth = true;
-            }
-            // recreate previous state by moving back temp_non matches to non_matches
-            FCMoveContent(temp_non_matches, non_matches);
-
-            if (!found_sth) {
-                 // Also have to look at the other local candidates if there was a match
-                ObjectSet temp_matches;
-                temp_matches.reserve(matches.size());
-                operand->Eval(local_context, temp_matches, matches, NON_MATCHES);
-                if (!temp_matches.empty()) {
-                    // i.e. the current operand should be used negated to move
-                    found_sth = true;
-                }
-                // recreate previous state
+                // in this case we alread did the application, so we use the results
                 FCMoveContent(temp_matches, matches);
-            }
-
-            if (found_sth) {
-                // descent into subcondition for NON_MATCHES
-                operand->Eval(local_context, matches, non_matches, NON_MATCHES);
                 break;
             }
+            // Also have to look at the other local candidates if there was a match
+            ObjectSet temp_non_matches;
+            temp_non_matches.reserve(matches.size());
+            operand->Eval(local_context, matches, temp_non_matches, MATCHES);
+            if (!matches.empty()) {
+                // have selected the current operand condition to use, so apply it to the NON_MATCHES candidate set.
+                found_sth = true;
+                // We already did the application before, but there were no matches. Move all objects to non_matches.
+                FCMoveContent(matches, non_matches);
+                FCMoveContent(temp_non_matches, non_matches);
+                break;
+            }
+            // recreate previous state
+            FCMoveContent(temp_non_matches, matches);
+
             // try the next operand
         }
-        // If NON_MATCHES could not find any matches it should match all
+        // If no operand condition was selected, there are no matches. Move all objects to non_matches
         if (!found_sth)
             FCMoveContent(matches, non_matches);
     } else /*(search_domain == MATCHES)*/ {

--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -10036,8 +10036,6 @@ void OrderedAlternativesOf::Eval(const ScriptingContext& parent_context,
         // try matching operand conditions until one matches
         bool found_sth = false;
         for (auto& operand : m_operands) {
-            // move those non matching the current operand to temp_non_matches
-            //            operand->Eval(local_context, matches, temp_non_matches, MATCHES);
             // move those matching the current non-negated operand from non_matches to temp_non_matches
             operand->Eval(local_context, non_matches, temp_non_matches, MATCHES);
             if (!non_matches.empty()) {

--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -10045,7 +10045,6 @@ void OrderedAlternativesOf::Eval(const ScriptingContext& parent_context,
             }
             if (found_sth) {
                 // descent into subcondition for NON_MATCHES
-                ObjectSet temp_matches;
                 operand->Eval(local_context, matches, non_matches, NON_MATCHES);
                 break;
             }
@@ -10073,6 +10072,7 @@ void OrderedAlternativesOf::Eval(const ScriptingContext& parent_context,
                 *it = temp_non_matches.back();
                 temp_non_matches.pop_back();
             }
+            // move non matches from_matches to temp_non_matches
             operand->Eval(local_context, matches, temp_non_matches, MATCHES);
             if (!matches.empty()) break;
         }

--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -10009,32 +10009,17 @@ void OrderedAlternativesOf::Eval(const ScriptingContext& parent_context,
         }
     }
 
-    // Expressions like  'NOT OrderedAlternativesOf [ A B C ]'
-    // matches all candidates which do not match the topmost condition which has matches
-    // which means the something like
-    // OrderedAlternativesOf [
-    //     And [
-    //         Number low = 1 condition = And [
-    //             Object id = OuterCandidate.ID
-    //             A
-    //         ]
-    //         Not A
-    //     ]
-    //     And [
-    //         Number low = 1 condition = And [
-    //             Object id = OuterCandidate.ID
-    //             B
-    //         ]
-    //         Not B
-    //     ]
-    //     And [
-    //         Number low = 1 condition = And [
-    //             Object id = OuterCandidate.ID
-    //             C
-    //         ]
-    //         Not C
-    //     ]
-    // ]
+    // OrderedAlternativesOf [ A B C ] matches all candidates which match the topmost condition.
+    // If any candidate matches A, then all candidates that match A are matched,
+    // or if no candidate matches A but any candidate matches B, then all candidates that match B are matched,
+    // or if no candidate matches A or B but any candidate matches C, then all candidates that match C are matched.
+    // If no candidate matches A, B, or C, then nothing is matched.
+    //
+    // Not OrderedAlternativesOf [ A B C ] finds the topmost condition which has matches and then matches its non-matches.
+    // If any candidate matches A, then all candidates that do not match A are matched,
+    // or if no candidates match A but any candidate matches B, then all candidates that do not match B are matched,
+    // or if no candidate matches A or B but any candidate matches C, then all candidates that do not match C are matched.
+    // If no candidate matches A, B, or C, then all candidates are matched.
     if (search_domain == NON_MATCHES) {
         // check all operand conditions on all objects in the non matches set
         // stop if the operand condition has at least one match

--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -5111,17 +5111,20 @@ namespace {
             if (!candidate)
                 return false;
 
-            const ShipDesign* design = nullptr;
+            std::shared_ptr<const Ship> ship = nullptr;
             if (auto fighter = std::dynamic_pointer_cast<const ::Fighter>(candidate)) {
                 // it is a fighter
-                design = Objects().Object<Ship>(fighter->LaunchedFrom())->Design();
-            } else if (auto ship = std::dynamic_pointer_cast<const ::Ship>(candidate)) {
-                // ir is a ship
-                design = ship->Design();
+                ship = std::move(Objects().Object<Ship>(fighter->LaunchedFrom()));
             } else {
-                return false;
+                ship = std::move(std::dynamic_pointer_cast<const ::Ship>(candidate));
             }
+
+            // is it a ship
+            if (!ship)
+                return false;
+
             // with a valid design?
+            const ShipDesign* design = ship->Design();
             if (!design)
                 return false;
 

--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -10039,6 +10039,7 @@ void OrderedAlternativesOf::Eval(const ScriptingContext& parent_context,
             if (!temp_objects.empty()) {
                 // Select the current operand condition. Apply it to the NON_MATCHES candidate set.
                 // We alread did the application, so we use the results
+                matches.reserve(temp_objects.size() + matches.size());
                 FCMoveContent(temp_objects, matches);
                 return;
             }

--- a/universe/Condition.h
+++ b/universe/Condition.h
@@ -1964,7 +1964,10 @@ private:
     void serialize(Archive& ar, const unsigned int version);
 };
 
-/** Matches all objects that match the first matching Condition in \a operands. */
+/** Tests conditions in \a operands in order, to find the first condition that 
+  * matches at least one candidate object. Matches all objects that match that
+  * condaition, ignoring any conditions listed later. If no candidate matches
+  * any of the conditions, it matches nothing. */
 struct FO_COMMON_API OrderedAlternativesOf final : public ConditionBase {
     explicit OrderedAlternativesOf(std::vector<std::unique_ptr<ConditionBase>>&& operands);
 

--- a/universe/Condition.h
+++ b/universe/Condition.h
@@ -1964,6 +1964,30 @@ private:
     void serialize(Archive& ar, const unsigned int version);
 };
 
+/** Matches all objects that match the first matching Condition in \a operands. */
+struct FO_COMMON_API OrderedAlternativesOf final : public ConditionBase {
+    explicit OrderedAlternativesOf(std::vector<std::unique_ptr<ConditionBase>>&& operands);
+
+    bool operator==(const ConditionBase& rhs) const override;
+    void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
+              ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
+    bool RootCandidateInvariant() const override;
+    bool TargetInvariant() const override;
+    bool SourceInvariant() const override;
+    std::string Description(bool negated = false) const override;
+    std::string Dump(unsigned short ntabs = 0) const override;
+    void SetTopLevelContent(const std::string& content_name) override;
+    const std::vector<ConditionBase*> Operands() const;
+    unsigned int GetCheckSum() const override;
+
+private:
+    std::vector<std::unique_ptr<ConditionBase>> m_operands;
+
+    friend class boost::serialization::access;
+    template <class Archive>
+    void serialize(Archive& ar, const unsigned int version);
+};
+
 /** Matches whatever its subcondition matches, but has a customized description
   * string that is returned by Description() by looking up in the stringtable. */
 struct FO_COMMON_API Described final : public ConditionBase {
@@ -2432,6 +2456,13 @@ void Not::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(ConditionBase)
         & BOOST_SERIALIZATION_NVP(m_operand);
+}
+
+template <class Archive>
+void OrderedAlternativesOf::serialize(Archive& ar, const unsigned int version)
+{
+    ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(ConditionBase)
+        & BOOST_SERIALIZATION_NVP(m_operands);
 }
 
 template <class Archive>


### PR DESCRIPTION
This PR implements a OrderedAlternativesOf (was named TopmostMatches before)  FOCS condition in order to implement the result of the  [Fighter targetting poll](https://www.freeorion.org/forum/viewtopic.php?f=6&t=11204&p=94826#p94826).

It provides matching the matches of the topmost condition which has at least one match, so one can specify tiers/a hierarchy of preferred matches.

State of PR: works, tested fighters targeting and surrounding Or, Not, And