### PR TITLE
Fix Boost auto-linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -254,9 +254,9 @@ set_property(DIRECTORY APPEND
     PROPERTY COMPILE_DEFINITIONS
         # Disable Boost auto-linking
         # http://www.boost.org/doc/libs/1_59_0/libs/config/doc/html/index.html#boost_config.configuring_boost_for_your_platform.user_settable_options
-        BOOST_ALL_NO_LINK
+        BOOST_ALL_NO_LIB
 
-        # Boost iostreams doesn't honor BOOST_ALL_NO_LINK when linking zlib.
+        # Boost iostreams doesn't honor BOOST_ALL_NO_LIB when linking zlib.
         # It also tries to link by default to the boost in-source zlib librar,
         # which we don't want.
         # http://www.boost.org/doc/libs/1_59_0/boost/iostreams/detail/config/zlib.hpp

--- a/GG/CMakeLists.txt
+++ b/GG/CMakeLists.txt
@@ -84,9 +84,9 @@ set(MINIMUM_BOOST_VERSION 1.58.0)
 
 if(NOT USE_STATIC_LIBS)
     add_definitions(
-        -DBOOST_ALL_NO_LINK
+        -DBOOST_ALL_NO_LIB
         -DBOOST_ALL_DYN_LINK
-        -DBOOST_LOG_NO_LINK
+        -DBOOST_LOG_NO_LIB
         -DBOOST_LOG_DYN_LINK
     )
 endif()

--- a/GG/test/unit/CMakeLists.txt
+++ b/GG/test/unit/CMakeLists.txt
@@ -32,7 +32,7 @@ add_executable(gg_unittest
 target_compile_definitions(gg_unittest
     PRIVATE
         -DBOOST_TEST_DYN_LINK
-        -DBOOST_TEST_NO_LINK
+        -DBOOST_TEST_NO_LIB
 )
 
 target_link_libraries(gg_unittest

--- a/test/parse/CMakeLists.txt
+++ b/test/parse/CMakeLists.txt
@@ -10,7 +10,7 @@ target_compile_definitions(fo_unittest_parse
     PRIVATE
         -DFREEORION_BUILD_SERVER
         -DBOOST_TEST_DYN_LINK
-        -DBOOST_TEST_NO_LINK
+        -DBOOST_TEST_NO_LIB
 )
 
 target_include_directories(fo_unittest_parse

--- a/test/system/CMakeLists.txt
+++ b/test/system/CMakeLists.txt
@@ -14,9 +14,9 @@ target_compile_definitions(fo_systemtest_game
     PRIVATE
         -DFREEORION_BUILD_HUMAN
         -DBOOST_TEST_DYN_LINK
-        -DBOOST_TEST_NO_LINK
+        -DBOOST_TEST_NO_LIB
         -DBOOST_LOG_DYN_LINK
-        -DBOOST_LOG_NO_LINK
+        -DBOOST_LOG_NO_LIB
         -DBOOST_TEST_IGNORE_SIGCHLD
 )
 

--- a/test/util/CMakeLists.txt
+++ b/test/util/CMakeLists.txt
@@ -7,7 +7,7 @@ add_executable(fo_unittest_util
 target_compile_definitions(fo_unittest_util
     PRIVATE
         -DBOOST_TEST_DYN_LINK
-        -DBOOST_TEST_NO_LINK
+        -DBOOST_TEST_NO_LIB
 )
 
 target_include_directories(fo_unittest_util


### PR DESCRIPTION
Follow up  #2377. Correctly disables boost auto-linking on windows.