### PR TITLE
Cleanup ship design creation

### DIFF
--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -414,11 +414,11 @@ namespace {
     void DeleteFromDisplayedDesigns(const int design_id) {
         auto& manager = GetDisplayedDesignsManager();
 
-        //const auto empire_id = HumanClientApp::GetApp()->EmpireID();
-        //const auto maybe_obsolete = manager.IsObsolete(design_id);
-        //if (maybe_obsolete && !*maybe_obsolete)
-        //    HumanClientApp::GetApp()->Orders().IssueOrder(
-        //        std::make_shared<ShipDesignOrder>(empire_id, design_id, true));
+        const auto empire_id = HumanClientApp::GetApp()->EmpireID();
+        const auto maybe_obsolete = manager.IsObsolete(design_id);
+        if (maybe_obsolete && !*maybe_obsolete)
+            HumanClientApp::GetApp()->Orders().IssueOrder(
+                std::make_shared<ShipDesignOrder>(empire_id, design_id, true));
         manager.Remove(design_id);
     }
 

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -2161,6 +2161,7 @@ public:
     //@}
 
     mutable boost::signals2::signal<void (int)>                 DesignSelectedSignal;
+    mutable boost::signals2::signal<void (int)>                 DesignUpdatedSignal;
     mutable boost::signals2::signal<void (const std::string&, const std::vector<std::string>&)>
                                                                 DesignComponentsSelectedSignal;
     mutable boost::signals2::signal<void (const boost::uuids::uuid&)>  SavedDesignSelectedSignal;
@@ -3060,6 +3061,7 @@ void CompletedDesignsListBox::BaseRightClicked(GG::ListBox::iterator it, const G
     auto delete_design_action = [&design_id, this]() {
         DeleteFromDisplayedDesigns(design_id);
         Populate();
+        DesignUpdatedSignal(design_id);
     };
 
     auto rename_design_action = [&empire_id, &design_id, design, &design_row]() {
@@ -3337,6 +3339,7 @@ public:
     //@}
 
     mutable boost::signals2::signal<void (int)>                         DesignSelectedSignal;
+    mutable boost::signals2::signal<void (int)>                         DesignUpdatedSignal;
     mutable boost::signals2::signal<void (const std::string&, const std::vector<std::string>&)>
                                                                         DesignComponentsSelectedSignal;
     mutable boost::signals2::signal<void (const boost::uuids::uuid&)>   SavedDesignSelectedSignal;
@@ -3410,6 +3413,7 @@ void DesignWnd::BaseSelector::CompleteConstruction() {
     m_designs_list->Resize(GG::Pt(GG::X(10), GG::Y(10)));
     m_tabs->AddWnd(m_designs_list, UserString("DESIGN_WND_FINISHED_DESIGNS"));
     m_designs_list->DesignSelectedSignal.connect(DesignWnd::BaseSelector::DesignSelectedSignal);
+    m_designs_list->DesignUpdatedSignal.connect(DesignWnd::BaseSelector::DesignUpdatedSignal);
     m_designs_list->DesignClickedSignal.connect(DesignWnd::BaseSelector::DesignClickedSignal);
 
     m_saved_designs_list = GG::Wnd::Create<SavedDesignsListBox>(m_availabilities_state, SAVED_DESIGN_ROW_DROP_STRING);
@@ -3936,6 +3940,9 @@ public:
                              const std::string& name,
                              const std::string& desc);
 
+    /** Responds to the design being changed **/
+    void DesignChanged();
+
     /** Add a design. */
     std::pair<int, boost::uuids::uuid> AddDesign();
 
@@ -3980,7 +3987,6 @@ protected:
 private:
     void            Populate();                         //!< creates and places SlotControls for current hull
     void            DoLayout();                         //!< positions buttons, text entry boxes and SlotControls
-    void            DesignChanged();                    //!< responds to the design being changed
     void            DesignNameChanged();                //!< responds to the design name being changed
     void            RefreshIncompleteDesign() const;
     std::string     GetCleanDesignDump(const ShipDesign* ship_design);  //!< similar to ship design dump but without 'lookup_strings', icon and model entries
@@ -5013,6 +5019,8 @@ void DesignWnd::CompleteConstruction() {
 
     m_base_selector->DesignSelectedSignal.connect(
         boost::bind(static_cast<void (MainPanel::*)(int)>(&MainPanel::SetDesign), m_main_panel, _1));
+    m_base_selector->DesignUpdatedSignal.connect(
+        boost::bind(static_cast<void (MainPanel::*)()>(&MainPanel::DesignChanged), m_main_panel));
     m_base_selector->DesignComponentsSelectedSignal.connect(
         boost::bind(&MainPanel::SetDesignComponents, m_main_panel, _1, _2));
     m_base_selector->SavedDesignSelectedSignal.connect(

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -1140,7 +1140,7 @@ void ShipDesignManager::StartGame(int empire_id, bool is_new_game) {
         std::set<int> ordered_ids(ids.begin(), ids.end());
 
         displayed_designs->InsertOrderedIDs(ordered_ids);
-    }/* else {
+    } else {
         // Remove the default designs from the empire's current designs.
         DebugLogger() << "Remove default designs from empire";
         const auto ids = empire->ShipDesigns();
@@ -1148,7 +1148,7 @@ void ShipDesignManager::StartGame(int empire_id, bool is_new_game) {
             HumanClientApp::GetApp()->Orders().IssueOrder(
                 std::make_shared<ShipDesignOrder>(empire_id, design_id, true));
         }
-    }*/
+    }
 }
 
 void ShipDesignManager::Save(SaveGameUIData& data) const {


### PR DESCRIPTION
First commit alone Resolves #2107 (unable to create a design identical to a default ship design, when default designs were excluded).

Second commit Resolves #2322 (unable to recreate a deleted finished design).
Third commit updates the add/replace buttons when a finished design is deleted.

Set to same PR as they both stem from same commit and may be relevant if there are multiplayer issues (#2099).