### PR TITLE
Fixed CMake build in Windows

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -70,6 +70,9 @@ Step by step procedure:
    * Unzip the SDK archive contents into the project directory.
    * Execute the `bootstrap.bat` within the project directory. This will clone
      the FreeOrion repository and place the dependencies at the correct place.
+   * If you want to create an out-of-source build using CMake, you should run 
+     `git clone https://github.com/freeorion/freeorion.git FreeOrion` in the 
+     `freeorion-project` directory, instead of running `bootstrap.bat`.
  * On Max OS X, Linux and other Operating Systems:
    * Navigate into the project directory.
    * Clone the project via Git:
@@ -111,6 +114,22 @@ Step by step procedure:
    * Compile the whole project by selecting the `Build` -> `Build Solution`
      menu entry.
 
+ * On Windows (cmake):
+   * Change into the `Freeorion` directory.
+   * Create a `build` directory, which will contain all compile FreeOrion
+     build artifacs.
+   * Change into the `build` directory on the command line.
+   * Execute cmake to generate Makefiles:
+
+     ```
+     cmake .. -G "Visual Studio 15 2017"
+     ```
+   * Compile the whole project by calling `MSBuild.exe -p:Configuration=Release FreeOrion.sln`
+     within the build directory. In case you want to utilize multiple CPU
+     cores, you can add the `-m` option to the command.
+   * Alternatively, you can compile the project by the Visual Studio GUI.
+
+
  * On Mac OS X:
    * Create a `build` directory, which will contain all compile FreeOrion
      build artifacs.
@@ -140,12 +159,17 @@ Step by step procedure:
      by invoking:
 
      ```
-     ln -s ../freeorion/default .
+     ln -s ../default .
      ```
 
 This will leave you with a build of FreeOrion executables.
 
- * `freeorion-project/FreeOrion` on Windows.
+ * `freeorion-project/FreeOrion` on Windows if you compile it with the 
+    standalone msvc project.
+ * `freeorion-project/Freeorion/build/Release` on Windows if you compile it 
+    with CMake. To run the executable without creating the symbolic link, you
+    can first change the directory to `freeorion-project/Freeorion`, then run
+    `./build/Release/FreeOrion.exe`.
  * `freeorion-project/build/Release` on Mac OS X.
  * `freeorion-project/freeorion/build` on Linux and other Operating Systems.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ message(STATUS "Build type CMAKE_BUILD_TYPE set to ${CMAKE_BUILD_TYPE}")
 include(UseCompilerCache)
 find_compiler_cache(PROGRAM ccache)
 
+
 ##
 ## Global project configuration
 ##
@@ -161,6 +162,9 @@ set_property(DIRECTORY APPEND
         # Disable '<func>': The POSIX name for this item is deprecated." warning
         # https://msdn.microsoft.com/en-us/library/ttcz0bys.aspx
         $<$<PLATFORM_ID:Windows>:_CRT_NONSTDC_NO_WARNINGS>
+
+        # Suppress "Boost.Config is older than your compiler version" warning
+        $<$<PLATFORM_ID:Windows>:BOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE>
 
         # Define platform specific macros
         $<$<PLATFORM_ID:Windows>:FREEORION_WIN32>
@@ -310,10 +314,14 @@ if(Apple)
     )
 endif()
 
+if(NOT WIN32)
+    add_library(freeorioncommon "")
+endif()
 
-add_library(freeorioncommon "")
 
 if(WIN32)
+    add_library(freeorioncommon STATIC "")
+
     set_property(TARGET freeorioncommon
         PROPERTY
         OUTPUT_NAME Common
@@ -380,13 +388,6 @@ set_property(TARGET freeorionparseobj
     POSITION_INDEPENDENT_CODE ON
 )
 
-if(WIN32)
-    set_property(TARGET freeorionparseobj
-        PROPERTY
-        OUTPUT_NAME Parsers
-    )
-endif()
-
 target_compile_options(freeorionparseobj
     PRIVATE
         $<$<CXX_COMPILER_ID:GNU>:-fvisibility=hidden>
@@ -403,8 +404,18 @@ target_compile_definitions(freeorionparseobj
         -DFREEORION_BUILD_PARSE
 )
 
+if(NOT WIN32)
+    add_library(freeorionparse $<TARGET_OBJECTS:freeorionparseobj>)
+endif()
 
-add_library(freeorionparse $<TARGET_OBJECTS:freeorionparseobj>)
+if(WIN32)
+    add_library(freeorionparse STATIC $<TARGET_OBJECTS:freeorionparseobj>)
+
+    set_property(TARGET freeorionparse
+        PROPERTY
+        OUTPUT_NAME Parsers
+    )
+endif()
 
 target_compile_options(freeorionparse
     PRIVATE
@@ -472,7 +483,6 @@ target_link_libraries(freeoriond
 
 target_dependencies_copy_to_build(freeoriond)
 target_dependent_data_symlink_to_build(freeoriond ${PROJECT_SOURCE_DIR}/default)
-
 
 add_executable(freeorionca "")
 
@@ -626,6 +636,15 @@ if(NOT BUILD_HEADLESS)
 
     target_dependencies_copy_to_build(freeorion)
     target_dependent_data_symlink_to_build(freeorion ${PROJECT_SOURCE_DIR}/default)
+endif()
+
+if(WIN32)
+    add_custom_command(TARGET freeorion POST_BUILD
+        COMMAND
+            ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_PREFIX_PATH}/bin/python27.dll" "$<TARGET_FILE_DIR:freeorion>"
+        COMMAND
+            ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_PREFIX_PATH}/bin/python27.zip" "$<TARGET_FILE_DIR:freeorion>" 
+    )
 endif()
 
 if(APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,12 @@ if(NOT APPLE)
     set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 endif()
 
+if(MSVC)
+    # Remove default debug flags /Zi and /MDd to allow project-specific debug flag
+    STRING(REGEX REPLACE " /Zi" "" CMAKE_CXX_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG})
+    STRING(REGEX REPLACE " /MDd" "" CMAKE_CXX_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG})
+endif()
+
 add_compile_options(
     # Enable (almost) all warnings on compilers
     # https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wall-316
@@ -143,6 +149,12 @@ add_compile_options(
 
     # Fix Fatal Error C1128: number of sections exceeded object file format limit : compile with /bigobj on SerializeEmpire.cpp
     $<$<CXX_COMPILER_ID:MSVC>:/bigobj>
+
+    # Produce pdb files in Debug configuration
+    $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<CONFIG:DEBUG>>:/Zi>
+ 
+    # Use the multithread-specific and DLL-specific version of the run-time library in Debug Configuration
+    $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<CONFIG:DEBUG>>:/MD>
 )
 
 set_property(DIRECTORY APPEND
@@ -388,6 +400,18 @@ set_property(TARGET freeorionparseobj
     POSITION_INDEPENDENT_CODE ON
 )
 
+if(MSVC)
+    # The debug information produced in this project is over the MSVC linking limit, remove it
+    get_target_property(PARSEOBJ_COMPILE_OPTIONS freeorionparseobj COMPILE_OPTIONS)
+    list(REMOVE_ITEM PARSEOBJ_COMPILE_OPTIONS 
+        "$<$<AND:$<CXX_COMPILER_ID:MSVC>,$<CONFIG:DEBUG>>:/Zi>"
+    )
+    set_target_properties(freeorionparseobj 
+        PROPERTIES
+        COMPILE_OPTIONS "${PARSEOBJ_COMPILE_OPTIONS}"
+    )
+endif()
+
 target_compile_options(freeorionparseobj
     PRIVATE
         $<$<CXX_COMPILER_ID:GNU>:-fvisibility=hidden>
@@ -414,6 +438,18 @@ if(WIN32)
     set_property(TARGET freeorionparse
         PROPERTY
         OUTPUT_NAME Parsers
+    )
+endif()
+
+if(MSVC)
+    # The debug information produced in this project is over the MSVC linking limit, remove it
+    get_target_property(PARSE_COMPILE_OPTIONS freeorionparse COMPILE_OPTIONS)
+    list(REMOVE_ITEM PARSE_COMPILE_OPTIONS 
+        "$<$<AND:$<CXX_COMPILER_ID:MSVC>,$<CONFIG:DEBUG>>:/Zi>"
+    )
+    set_target_properties(freeorionparse
+        PROPERTIES
+        COMPILE_OPTIONS "${PARSEOBJ_COMPILE_OPTIONS}"
     )
 endif()
 


### PR DESCRIPTION
As discussed in the forum ([https://www.freeorion.org/forum/viewtopic.php?f=9&t=11208](url)), here is a fix on the CMake build in Windows. It can be built by Visual Studio 17. 

However, I get the error "Timed out while attempting to connect to server" when I click "Single Player" and "OK". Different from the MINGW build, now the FreeOrionD.exe doesn't crash. 