### PR TITLE
Let Interspecies academy research boost change target research

### DIFF
--- a/default/scripting/buildings/INTERSPECIES_ACADEMY.focs.txt
+++ b/default/scripting/buildings/INTERSPECIES_ACADEMY.focs.txt
@@ -91,7 +91,7 @@ BuildingType
             activation = Source
             accountinglabel = "INTERSPECIES_ACADEMY_LABEL"
             priority = [[LATE_PRIORITY]]
-            effects = SetResearch value = Value + 5
+            effects = SetTargetResearch value = Value + 5
             
     ]
     icon = "icons/building/science-institute.png"


### PR DESCRIPTION
This is a bugfix. Research boost form interspecies academy should affect target research (+5 if research focus), not the change rate of research.