### PR TITLE
Don't save eliminated empres to empire data

### DIFF
--- a/server/SaveLoad.cpp
+++ b/server/SaveLoad.cpp
@@ -45,7 +45,8 @@ namespace {
     std::map<int, SaveGameEmpireData> CompileSaveGameEmpireData(const EmpireManager& empire_manager) {
         std::map<int, SaveGameEmpireData> retval;
         for (const auto& entry : Empires())
-            retval[entry.first] = SaveGameEmpireData(entry.first, entry.second->Name(), entry.second->PlayerName(), entry.second->Color(), entry.second->IsAuthenticated());
+            if (!entry.second->Eliminated())
+                retval[entry.first] = SaveGameEmpireData(entry.first, entry.second->Name(), entry.second->PlayerName(), entry.second->Color(), entry.second->IsAuthenticated());
         return retval;
     }
 


### PR DESCRIPTION
This prevents players to take on eliminated empire in the multiplayer lobby or launching AI for eliminated empire.

Prerequisite for next step of #2243 to correctly calculated limits for loaded game.