### PR TITLE
Allow to load game without all human player connected

### DIFF
--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1025,6 +1025,12 @@ Not enough human players.
 ERROR_TOO_MANY_HUMAN_PLAYERS
 Too many human players.
 
+ERROR_NOT_ENOUGH_CONNECTED_HUMAN_PLAYERS
+Not enough connected human players.
+
+ERROR_TOO_MANY_DISCONNECTED_HUMAN_PLAYERS
+Too many disconnected human players.
+
 ERROR_CONNECTION_WAS_REPLACED
 Your connection was replaced.
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1026,10 +1026,10 @@ ERROR_TOO_MANY_HUMAN_PLAYERS
 Too many human players.
 
 ERROR_NOT_ENOUGH_CONNECTED_HUMAN_PLAYERS
-Not enough connected human players.
+Not enough connected human empire players.
 
-ERROR_TOO_MANY_DISCONNECTED_HUMAN_PLAYERS
-Too many disconnected human players.
+ERROR_TOO_MANY_UNCONNECTED_HUMAN_PLAYERS
+Too many unconnected human empire players.
 
 ERROR_CONNECTION_WAS_REPLACED
 Your connection was replaced.
@@ -1393,8 +1393,8 @@ Limit the number of human players allowed in a multiplayer game. Set to -1 for u
 OPTIONS_DB_MP_CONN_HUMAN_MIN
 Minimum number of active human players, below which the server will stop the game being played.
 
-OPTIONS_DB_MP_DISCONN_HUMAN_MAX
-Maximum number of players, who control non-eliminated empires, who may be disconnected from the server before it stops the game being played. Disabled if 0, meaning the server will never stop the game due to empire-playing players being disconnected.
+OPTIONS_DB_MP_UNCONN_HUMAN_MAX
+Maximum number of players, who control non-eliminated empires, who may be unconnected from the server before it stops the game being played. Disabled if 0, meaning the server will never stop the game due to empire-playing players being unconnected.
 
 OPTIONS_DB_COOKIES_EXPIRE
 Count of minutes after the cookie record will be considered expired.

--- a/server/dmain.cpp
+++ b/server/dmain.cpp
@@ -60,8 +60,8 @@ int wmain(int argc, wchar_t* argv[], wchar_t* envp[]) {
         GetOptionsDB().Add<int>("network.server.ai.max", UserStringNop("OPTIONS_DB_MP_AI_MAX"), -1, Validator<int>());
         GetOptionsDB().Add<int>("network.server.human.min", UserStringNop("OPTIONS_DB_MP_HUMAN_MIN"), 0, Validator<int>());
         GetOptionsDB().Add<int>("network.server.human.max", UserStringNop("OPTIONS_DB_MP_HUMAN_MAX"), -1, Validator<int>());
-        GetOptionsDB().Add<int>("network.server.conn-human.min", UserStringNop("OPTIONS_DB_MP_CONN_HUMAN_MIN"), 1, Validator<int>());
-        GetOptionsDB().Add<int>("network.server.disconn-human.max", UserStringNop("OPTIONS_DB_MP_DISCONN_HUMAN_MAX"), 1, Validator<int>());
+        GetOptionsDB().Add<int>("network.server.conn-human-empire-players.min", UserStringNop("OPTIONS_DB_MP_CONN_HUMAN_MIN"), 1, Validator<int>());
+        GetOptionsDB().Add<int>("network.server.unconn-human-empire-players.max", UserStringNop("OPTIONS_DB_MP_UNCONN_HUMAN_MAX"), 1, Validator<int>());
         GetOptionsDB().Add<int>("network.server.cookies.expire-minutes", UserStringNop("OPTIONS_DB_COOKIES_EXPIRE"), 15, Validator<int>());
         GetOptionsDB().Add<bool>("network.server.publish-statistics", UserStringNop("OPTIONS_DB_PUBLISH_STATISTICS"), true, Validator<bool>());
         GetOptionsDB().Add("network.server.binary.enabled", UserStringNop("OPTIONS_DB_SERVER_BINARY_SERIALIZATION"), true);


### PR DESCRIPTION
Next step of #2243.
Make new restrictions work in lobby.
All empires considered as human if there no AI player.
It works even if Observer player launch saved game without any player.