### PR TITLE
Save and load readiness status

### DIFF
--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1345,9 +1345,9 @@ void ServerApp::LoadGameInit(const std::vector<PlayerSaveGameData>& player_save_
             ErrorLogger() << "LoadGameInit got inconsistent empire ids between player save game data and result of PlayerEmpireID";
         }
 
-        // Revoke readiness only for online players so them could re-make orders of current turn.
-        // Without it server would advance turn because saves are made when all players sent orders
-        // and became ready.
+        // Revoke readiness only for online players so they can redo orders for the current turn.
+        // Without doing it, server would immediatly advance the turn because saves are made when
+        // all players sent orders and became ready.
         RevokeEmpireTurnReadyness(empire_id);
 
         // restore saved orders.  these will be re-executed on client and

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1390,6 +1390,20 @@ void ServerApp::LoadGameInit(const std::vector<PlayerSaveGameData>& player_save_
             ErrorLogger() << "ServerApp::CommonGameInit unsupported client type: skipping game start message.";
         }
     }
+
+    for (auto player_connection_it = m_networking.established_begin();
+         player_connection_it != m_networking.established_end(); ++player_connection_it)
+    {
+        // send other empires' statuses
+        for (const auto& empire : Empires()) {
+            auto other_orders_it = m_turn_sequence.find(empire.first);
+            bool ready = other_orders_it == m_turn_sequence.end() ||
+                    (other_orders_it->second && other_orders_it->second->m_ready);
+            (*player_connection_it)->SendMessage(PlayerStatusMessage(EmpirePlayerID(empire.first),
+                                                                     ready ? Message::WAITING : Message::PLAYING_TURN,
+                                                                     empire.first));
+        }
+    }
 }
 
 void ServerApp::GenerateUniverse(std::map<int, PlayerSetupData>& player_setup_data) {

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -315,10 +315,10 @@ private:
     /** Turn sequence map is used for turn processing. Each empire is added at
       * the start of a game or reload and then the map maintains OrderSets for
       * that turn.
-      * The map contains ready state which should be true to advance turn and
-      * pointer to orders from empire.
+      * The map contains pointer to orders from empire with ready state which should be true
+      * to advance turn.
       * */
-    std::map<int, std::pair<bool, std::unique_ptr<PlayerSaveGameData>>>  m_turn_sequence;
+    std::map<int, std::unique_ptr<PlayerSaveGameData>>  m_turn_sequence;
 
     // Give FSM and its states direct access.  We are using the FSM code as a
     // control-flow mechanism; it is all notionally part of this class.

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -2726,7 +2726,7 @@ sc::result WaitingForTurnEnd::react(const TurnOrders& msg) {
 
         server.SetEmpireSaveGameData(empire_id, boost::make_unique<PlayerSaveGameData>(sender->PlayerName(), empire_id,
                                      order_set, ui_data, save_state_string,
-                                     client_type));
+                                     client_type, true));
 
         // notify other player that this empire submitted orders
         for (auto player_it = server.m_networking.established_begin();

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -169,29 +169,35 @@ struct FO_COMMON_API PlayerSaveGameData : public PlayerSaveHeaderData {
         PlayerSaveHeaderData(),
         m_orders(),
         m_ui_data(),
-        m_save_state_string()
+        m_save_state_string(),
+        m_ready(false)
     {}
 
     PlayerSaveGameData(const std::string& name, int empire_id,
                        const std::shared_ptr<OrderSet>& orders,
                        const std::shared_ptr<SaveGameUIData>& ui_data,
                        const std::string& save_state_string,
-                       Networking::ClientType client_type) :
+                       Networking::ClientType client_type,
+                       bool ready) :
         PlayerSaveHeaderData(name, empire_id, client_type),
         m_orders(orders),
         m_ui_data(ui_data),
-        m_save_state_string(save_state_string)
+        m_save_state_string(save_state_string),
+        m_ready(ready)
     {}
 
     std::shared_ptr<OrderSet>       m_orders;
     std::shared_ptr<SaveGameUIData> m_ui_data;
     std::string                     m_save_state_string;
+    bool                            m_ready;
 
 private:
     friend class boost::serialization::access;
     template <class Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
+
+BOOST_CLASS_VERSION(PlayerSaveGameData, 1);
 
 /** Data that must be retained by the server when saving and loading a
   * game that isn't player data or the universe */

--- a/util/SerializeMultiplayerCommon.cpp
+++ b/util/SerializeMultiplayerCommon.cpp
@@ -120,6 +120,9 @@ void PlayerSaveGameData::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_ui_data)
         & BOOST_SERIALIZATION_NVP(m_save_state_string)
         & BOOST_SERIALIZATION_NVP(m_client_type);
+    if (version >= 1) {
+        ar & BOOST_SERIALIZATION_NVP(m_ready);
+    }
 }
 
 template void PlayerSaveGameData::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, const unsigned int);


### PR DESCRIPTION
Save readiness status. Revoke it on load for online players so server wouldn't advance turn because saves are made when all players sent orders and became ready.
Fixes #2243.
Updates save game format.