### PR TITLE
Timed auto save

### DIFF
--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1891,6 +1891,9 @@ Enable autosave when resigning or closing the game.
 OPTIONS_DB_AUTOSAVE_HOSTLESS
 Enable autosave in hostless mode.
 
+OPTIONS_DB_AUTOSAVE_HOSTLESS_TIMEOUT
+Duration in seconds when game will be saved in hostless mode after turn started. Prevents losing player orders on server crash. 0 if disabled.
+
 OPTIONS_DB_UI_MOUSE_LR_SWAP
 Swaps results of clicking left and right mouse buttons.
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1891,7 +1891,7 @@ Enable autosave when resigning or closing the game.
 OPTIONS_DB_AUTOSAVE_HOSTLESS
 Enable autosave in hostless mode.
 
-OPTIONS_DB_AUTOSAVE_TIMEOUT
+OPTIONS_DB_AUTOSAVE_INTERVAL
 Delay in seconds after the most recent turn start or autosave until the next autosave. Prevents losing player orders on server crash. 0 if disabled.
 
 OPTIONS_DB_UI_MOUSE_LR_SWAP

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1891,8 +1891,8 @@ Enable autosave when resigning or closing the game.
 OPTIONS_DB_AUTOSAVE_HOSTLESS
 Enable autosave in hostless mode.
 
-OPTIONS_DB_AUTOSAVE_HOSTLESS_TIMEOUT
-Duration in seconds when game will be saved in hostless mode after turn started. Prevents losing player orders on server crash. 0 if disabled.
+OPTIONS_DB_AUTOSAVE_TIMEOUT
+Delay in seconds after the most recent turn start or autosave until the next autosave. Prevents losing player orders on server crash. 0 if disabled.
 
 OPTIONS_DB_UI_MOUSE_LR_SWAP
 Swaps results of clicking left and right mouse buttons.

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -2950,10 +2950,12 @@ void WaitingForTurnEnd::SaveTimedoutHandler(const boost::system::error_code& err
     DebugLogger() << "Save timed out.";
     PlayerConnectionPtr dummy_connection = nullptr;
     Server().m_fsm->process_event(SaveGameRequest(HostSaveGameInitiateMessage(GetAutoSaveFileName(Server().CurrentTurn())), dummy_connection));
-    m_timeout.expires_from_now(std::chrono::seconds(GetOptionsDB().Get<int>("save.auto.interval")));
-    m_timeout.async_wait(boost::bind(&WaitingForTurnEnd::SaveTimedoutHandler,
-                                     this,
-                                     boost::asio::placeholders::error));
+    if (GetOptionsDB().Get<int>("save.auto.interval") > 0) {
+        m_timeout.expires_from_now(std::chrono::seconds(GetOptionsDB().Get<int>("save.auto.interval")));
+        m_timeout.async_wait(boost::bind(&WaitingForTurnEnd::SaveTimedoutHandler,
+                                         this,
+                                         boost::asio::placeholders::error));
+    }
 }
 
 ////////////////////////////////////////////////////////////

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -2638,10 +2638,8 @@ WaitingForTurnEnd::WaitingForTurnEnd(my_context c) :
     m_timeout(Server().m_io_service)
 {
     TraceLogger(FSM) << "(ServerFSM) WaitingForTurnEnd";
-    if (Server().IsHostless() && GetOptionsDB().Get<bool>("save.auto.hostless.enabled") &&
-        GetOptionsDB().Get<int>("save.auto.hostless.timeout") > 0)
-    {
-        m_timeout.expires_from_now(std::chrono::seconds(GetOptionsDB().Get<int>("save.auto.hostless.timeout")));
+    if (GetOptionsDB().Get<int>("save.auto.timeout") > 0) {
+        m_timeout.expires_from_now(std::chrono::seconds(GetOptionsDB().Get<int>("save.auto.timeout")));
         m_timeout.async_wait(boost::bind(&WaitingForTurnEnd::SaveTimedoutHandler,
                                          this,
                                          boost::asio::placeholders::error));
@@ -2952,7 +2950,7 @@ void WaitingForTurnEnd::SaveTimedoutHandler(const boost::system::error_code& err
     DebugLogger() << "Save timed out.";
     PlayerConnectionPtr dummy_connection = nullptr;
     Server().m_fsm->process_event(SaveGameRequest(HostSaveGameInitiateMessage(GetAutoSaveFileName(Server().CurrentTurn())), dummy_connection));
-    m_timeout.expires_from_now(std::chrono::seconds(GetOptionsDB().Get<int>("save.auto.hostless.timeout")));
+    m_timeout.expires_from_now(std::chrono::seconds(GetOptionsDB().Get<int>("save.auto.timeout")));
     m_timeout.async_wait(boost::bind(&WaitingForTurnEnd::SaveTimedoutHandler,
                                      this,
                                      boost::asio::placeholders::error));

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -2638,8 +2638,8 @@ WaitingForTurnEnd::WaitingForTurnEnd(my_context c) :
     m_timeout(Server().m_io_service)
 {
     TraceLogger(FSM) << "(ServerFSM) WaitingForTurnEnd";
-    if (GetOptionsDB().Get<int>("save.auto.timeout") > 0) {
-        m_timeout.expires_from_now(std::chrono::seconds(GetOptionsDB().Get<int>("save.auto.timeout")));
+    if (GetOptionsDB().Get<int>("save.auto.interval") > 0) {
+        m_timeout.expires_from_now(std::chrono::seconds(GetOptionsDB().Get<int>("save.auto.interval")));
         m_timeout.async_wait(boost::bind(&WaitingForTurnEnd::SaveTimedoutHandler,
                                          this,
                                          boost::asio::placeholders::error));
@@ -2950,7 +2950,7 @@ void WaitingForTurnEnd::SaveTimedoutHandler(const boost::system::error_code& err
     DebugLogger() << "Save timed out.";
     PlayerConnectionPtr dummy_connection = nullptr;
     Server().m_fsm->process_event(SaveGameRequest(HostSaveGameInitiateMessage(GetAutoSaveFileName(Server().CurrentTurn())), dummy_connection));
-    m_timeout.expires_from_now(std::chrono::seconds(GetOptionsDB().Get<int>("save.auto.timeout")));
+    m_timeout.expires_from_now(std::chrono::seconds(GetOptionsDB().Get<int>("save.auto.interval")));
     m_timeout.async_wait(boost::bind(&WaitingForTurnEnd::SaveTimedoutHandler,
                                      this,
                                      boost::asio::placeholders::error));

--- a/server/ServerFSM.h
+++ b/server/ServerFSM.h
@@ -346,7 +346,10 @@ struct WaitingForTurnEnd : sc::state<WaitingForTurnEnd, PlayingGame> {
     sc::result react(const CheckTurnEndConditions& c);
     sc::result react(const SaveGameRequest& msg);
 
-    std::string m_save_filename;
+    void SaveTimedoutHandler(const boost::system::error_code& error);
+
+    std::string                        m_save_filename;
+    boost::asio::high_resolution_timer m_timeout;
 
     SERVER_ACCESSOR
 };

--- a/util/MultiplayerCommon.cpp
+++ b/util/MultiplayerCommon.cpp
@@ -34,7 +34,7 @@ namespace {
         db.Add("save.format.binary.enabled",                UserStringNop("OPTIONS_DB_BINARY_SERIALIZATION"),   false);
         db.Add("save.format.xml.zlib.enabled",              UserStringNop("OPTIONS_DB_XML_ZLIB_SERIALIZATION"), true);
         db.Add("save.auto.hostless.enabled",                UserStringNop("OPTIONS_DB_AUTOSAVE_HOSTLESS"),      true);
-        db.Add<int>("save.auto.timeout",                    UserStringNop("OPTIONS_DB_AUTOSAVE_TIMEOUT"),       0, Validator<int>());
+        db.Add<int>("save.auto.interval",                   UserStringNop("OPTIONS_DB_AUTOSAVE_INTERVAL"),      0, Validator<int>());
 
         // AI Testing options-- the following options are to facilitate AI testing and do not currently have an options page widget;
         // they are intended to be changed via the command line and are not currently storable in the configuration file.

--- a/util/MultiplayerCommon.cpp
+++ b/util/MultiplayerCommon.cpp
@@ -34,7 +34,7 @@ namespace {
         db.Add("save.format.binary.enabled",                UserStringNop("OPTIONS_DB_BINARY_SERIALIZATION"),   false);
         db.Add("save.format.xml.zlib.enabled",              UserStringNop("OPTIONS_DB_XML_ZLIB_SERIALIZATION"), true);
         db.Add("save.auto.hostless.enabled",                UserStringNop("OPTIONS_DB_AUTOSAVE_HOSTLESS"),      true);
-        db.Add<int>("save.auto.hostless.timeout",           UserStringNop("OPTIONS_DB_AUTOSAVE_HOSTLESS_TIMEOUT"), 0, Validator<int>());
+        db.Add<int>("save.auto.timeout",                    UserStringNop("OPTIONS_DB_AUTOSAVE_TIMEOUT"),       0, Validator<int>());
 
         // AI Testing options-- the following options are to facilitate AI testing and do not currently have an options page widget;
         // they are intended to be changed via the command line and are not currently storable in the configuration file.

--- a/util/MultiplayerCommon.cpp
+++ b/util/MultiplayerCommon.cpp
@@ -34,6 +34,7 @@ namespace {
         db.Add("save.format.binary.enabled",                UserStringNop("OPTIONS_DB_BINARY_SERIALIZATION"),   false);
         db.Add("save.format.xml.zlib.enabled",              UserStringNop("OPTIONS_DB_XML_ZLIB_SERIALIZATION"), true);
         db.Add("save.auto.hostless.enabled",                UserStringNop("OPTIONS_DB_AUTOSAVE_HOSTLESS"),      true);
+        db.Add<int>("save.auto.hostless.timeout",           UserStringNop("OPTIONS_DB_AUTOSAVE_HOSTLESS_TIMEOUT"), 0, Validator<int>());
 
         // AI Testing options-- the following options are to facilitate AI testing and do not currently have an options page widget;
         // they are intended to be changed via the command line and are not currently storable in the configuration file.


### PR DESCRIPTION
Follows up #2405.
Add periodic submitted orders backup support via savegame in case when turn lasts too long.