### PR TITLE
Add option to start hostless server from saved game

### DIFF
--- a/client/human/chmain.cpp
+++ b/client/human/chmain.cpp
@@ -135,8 +135,6 @@ int mainConfigOptionsSetup(const std::vector<std::string>& args) {
         GetOptionsDB().AddFlag("auto-quit",                         UserStringNop("OPTIONS_DB_AUTO_QUIT"),              false);
         GetOptionsDB().Add<int>("auto-advance-n-turns",             UserStringNop("OPTIONS_DB_AUTO_N_TURNS"),           0,
                                 RangedValidator<int>(0, 400),                                                           false);
-        GetOptionsDB().Add<std::string>("load",                     UserStringNop("OPTIONS_DB_LOAD"),                   "",
-                                        Validator<std::string>(),                                                       false);
         GetOptionsDB().Add("audio.music.enabled",                   UserStringNop("OPTIONS_DB_MUSIC_ON"),               true);
         GetOptionsDB().Add("audio.effects.enabled",                 UserStringNop("OPTIONS_DB_SOUND_ON"),               true);
         GetOptionsDB().Add<std::string>("version.string",           UserStringNop("OPTIONS_DB_VERSION_STRING"),         FreeOrionVersionString(),

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1262,6 +1262,9 @@ Start server in single player host mode. This only allows clients on localhost t
 OPTIONS_DB_HOSTLESS
 Start server in hostless mode. Server accepts players in the multiplayer lobby, and returns to the lobby after the game session ends.
 
+OPTIONS_DB_HOSTLESS_AUTOSTART_LOAD
+Start server in hostless mode and load and start game from provided save file. Server accepts players in the playing game, and returns to the lobby after the game session ends.
+
 OPTIONS_DB_SKIP_CHECKSUM
 Skip comparing the resource directory checksums.  This allows faster startup when client and server are on the same machine, using the same resource directory.
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1262,9 +1262,6 @@ Start server in single player host mode. This only allows clients on localhost t
 OPTIONS_DB_HOSTLESS
 Start server in hostless mode. Server accepts players in the multiplayer lobby, and returns to the lobby after the game session ends.
 
-OPTIONS_DB_HOSTLESS_AUTOSTART_LOAD
-Start server in hostless mode and load and start game from provided save file. Server accepts players in the playing game, and returns to the lobby after the game session ends.
-
 OPTIONS_DB_SKIP_CHECKSUM
 Skip comparing the resource directory checksums.  This allows faster startup when client and server are on the same machine, using the same resource directory.
 
@@ -1931,7 +1928,7 @@ OPTIONS_DB_UI_SITREP_ICONSIZE
 Sets the sitrep icon width and height; default 16 (min 12, max 64).
 
 OPTIONS_DB_LOAD
-Loads the specified single-player save game.
+Loads and starts the specified single-player or multi-player save game.
 
 OPTIONS_DB_EFFECTS_THREADS_UI_DESC
 Specifies number of threads to use for effects processing in the user interface. More than one thread may lead to unpredictable crashes.

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1928,7 +1928,7 @@ OPTIONS_DB_UI_SITREP_ICONSIZE
 Sets the sitrep icon width and height; default 16 (min 12, max 64).
 
 OPTIONS_DB_LOAD
-Loads and starts the specified single-player or multi-player save game. In a multi-player it requires hostless mode and no restrictions on a number of connected players because server will start without one.
+Loads and starts the specified single-player or multi-player save game. In multi-player, it requires hostless mode and no restriction on the minimum number of connected players, because the server will start with no connected players.
 
 OPTIONS_DB_EFFECTS_THREADS_UI_DESC
 Specifies number of threads to use for effects processing in the user interface. More than one thread may lead to unpredictable crashes.

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1928,7 +1928,7 @@ OPTIONS_DB_UI_SITREP_ICONSIZE
 Sets the sitrep icon width and height; default 16 (min 12, max 64).
 
 OPTIONS_DB_LOAD
-Loads and starts the specified single-player or multi-player save game.
+Loads and starts the specified single-player or multi-player save game. In a multi-player it requires hostless mode and no restrictions on a number of connected players because server will start without one.
 
 OPTIONS_DB_EFFECTS_THREADS_UI_DESC
 Specifies number of threads to use for effects processing in the user interface. More than one thread may lead to unpredictable crashes.

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -104,10 +104,11 @@ ServerApp::ServerApp() :
     InfoLogger() << FreeOrionVersionString();
     LogDependencyVersions();
 
-    m_fsm->initiate();
-
-    // Start parsing content
+    // Start parsing content before FSM initialization
+    // to have data initialized before autostart execution
     StartBackgroundParsing();
+
+    m_fsm->initiate();
 
     Empires().DiplomaticStatusChangedSignal.connect(
         boost::bind(&ServerApp::HandleDiplomaticStatusChange, this, _1, _2));

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -629,7 +629,7 @@ sc::result Idle::react(const Hostless&) {
         return transit<MPLobby>();
 
     if (GetOptionsDB().Get<int>("network.server.conn-human-empire-players.min") > 0) {
-        throw std::invalid_argument("Autostart load file was choosed but the server wasn't allowed to play game without connected players");
+        throw std::invalid_argument("A save file to load and autostart in hostless mode was specified, but the server has a non-zero minimum number of connected players, so cannot be started without a connected player.");
     }
     std::shared_ptr<ServerSaveGameData> server_save_game_data(new ServerSaveGameData());
     std::vector<PlayerSaveGameData> player_save_game_data;

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -513,9 +513,10 @@ Idle::Idle(my_context c) :
     my_base(c)
 {
     TraceLogger(FSM) << "(ServerFSM) Idle";
-    if (Server().IsHostless()) {
+    if (Server().IsHostless())
         post_event(Hostless());
-    }
+    else if (!GetOptionsDB().Get<std::string>("load").empty())
+        throw std::invalid_argument("Autostart load file was choosed but the server wasn't started in a hostless mode");
 }
 
 Idle::~Idle()
@@ -622,60 +623,63 @@ sc::result Idle::react(const Error& msg) {
 }
 
 sc::result Idle::react(const Hostless&) {
+    TraceLogger(FSM) << "(ServerFSM) Idle.Hostless";
     std::string autostart_load_filename = GetOptionsDB().Get<std::string>("load");
-    if (!autostart_load_filename.empty()) {
-        if (GetOptionsDB().Get<int>("network.server.conn-human-empire-players.min") > 0) {
-            throw std::invalid_argument("Autostart load file was choosed but the server wasn't allowed to play game without connected players");
-        }
-        std::shared_ptr<ServerSaveGameData> server_save_game_data(new ServerSaveGameData());
-        std::vector<PlayerSaveGameData> player_save_game_data;
+    if (autostart_load_filename.empty())
+        return transit<MPLobby>();
 
-        try {
-            ServerApp& server = Server();
-
-            LoadGame(autostart_load_filename,   *server_save_game_data,
-                     player_save_game_data,     GetUniverse(),
-                     Empires(),                 GetSpeciesManager(),
-                     GetCombatLogManager(),     server.m_galaxy_setup_data);
-            int seed = 0;
-            try {
-                seed = boost::lexical_cast<unsigned int>(server.m_galaxy_setup_data.m_seed);
-            } catch (...) {
-                try {
-                    boost::hash<std::string> string_hash;
-                    std::size_t h = string_hash(server.m_galaxy_setup_data.m_seed);
-                    seed = static_cast<unsigned int>(h);
-                } catch (...) {}
-            }
-            DebugLogger(FSM) << "Seeding with loaded galaxy seed: " << server.m_galaxy_setup_data.m_seed << "  interpreted as actual seed: " << seed;
-            Seed(seed);
-
-            std::shared_ptr<MultiplayerLobbyData> lobby_data(new MultiplayerLobbyData());
-            // fill lobby data with AI to start them with server
-            int ai_next_index = 1;
-            for (const auto& psgd : player_save_game_data) {
-                if (psgd.m_client_type != Networking::CLIENT_TYPE_AI_PLAYER)
-                    continue;
-                PlayerSetupData player_setup_data;
-                player_setup_data.m_player_id =     Networking::INVALID_PLAYER_ID;
-                player_setup_data.m_player_name =   UserString("AI_PLAYER") + "_" + std::to_string(ai_next_index++);
-                player_setup_data.m_client_type =   Networking::CLIENT_TYPE_AI_PLAYER;
-                player_setup_data.m_save_game_empire_id = psgd.m_empire_id;
-                lobby_data->m_players.push_back({Networking::INVALID_PLAYER_ID, player_setup_data});
-            }
-
-            // copy locally stored data to common server fsm context so it can be
-            // retreived in WaitingForMPGameJoiners
-            context<ServerFSM>().m_lobby_data = lobby_data;
-            context<ServerFSM>().m_player_save_game_data = player_save_game_data;
-            context<ServerFSM>().m_server_save_game_data = server_save_game_data;
-        } catch (const std::exception& e) {
-            throw e;
-        }
-
-        return transit<WaitingForMPGameJoiners>();
+    if (GetOptionsDB().Get<int>("network.server.conn-human-empire-players.min") > 0) {
+        throw std::invalid_argument("Autostart load file was choosed but the server wasn't allowed to play game without connected players");
     }
-    return transit<MPLobby>();
+    std::shared_ptr<ServerSaveGameData> server_save_game_data(new ServerSaveGameData());
+    std::vector<PlayerSaveGameData> player_save_game_data;
+
+    DebugLogger(FSM) << "Loading file " << autostart_load_filename;
+
+    try {
+        ServerApp& server = Server();
+
+        LoadGame(autostart_load_filename,   *server_save_game_data,
+                 player_save_game_data,     GetUniverse(),
+                 Empires(),                 GetSpeciesManager(),
+                 GetCombatLogManager(),     server.m_galaxy_setup_data);
+        int seed = 0;
+        try {
+            seed = boost::lexical_cast<unsigned int>(server.m_galaxy_setup_data.m_seed);
+        } catch (...) {
+            try {
+                boost::hash<std::string> string_hash;
+                std::size_t h = string_hash(server.m_galaxy_setup_data.m_seed);
+                seed = static_cast<unsigned int>(h);
+            } catch (...) {}
+        }
+        DebugLogger(FSM) << "Seeding with loaded galaxy seed: " << server.m_galaxy_setup_data.m_seed << "  interpreted as actual seed: " << seed;
+        Seed(seed);
+
+        std::shared_ptr<MultiplayerLobbyData> lobby_data(new MultiplayerLobbyData());
+        // fill lobby data with AI to start them with server
+        int ai_next_index = 1;
+        for (const auto& psgd : player_save_game_data) {
+            if (psgd.m_client_type != Networking::CLIENT_TYPE_AI_PLAYER)
+                continue;
+            PlayerSetupData player_setup_data;
+            player_setup_data.m_player_id =     Networking::INVALID_PLAYER_ID;
+            player_setup_data.m_player_name =   UserString("AI_PLAYER") + "_" + std::to_string(ai_next_index++);
+            player_setup_data.m_client_type =   Networking::CLIENT_TYPE_AI_PLAYER;
+            player_setup_data.m_save_game_empire_id = psgd.m_empire_id;
+            lobby_data->m_players.push_back({Networking::INVALID_PLAYER_ID, player_setup_data});
+        }
+
+        // copy locally stored data to common server fsm context so it can be
+        // retreived in WaitingForMPGameJoiners
+        context<ServerFSM>().m_lobby_data = lobby_data;
+        context<ServerFSM>().m_player_save_game_data = player_save_game_data;
+        context<ServerFSM>().m_server_save_game_data = server_save_game_data;
+    } catch (const std::exception& e) {
+        throw e;
+    }
+
+    return transit<WaitingForMPGameJoiners>();
 }
 
 ////////////////////////////////////////////////////////////

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -622,7 +622,7 @@ sc::result Idle::react(const Error& msg) {
 }
 
 sc::result Idle::react(const Hostless&) {
-    std::string autostart_load_filename = GetOptionsDB().Get<std::string>("hostless.autostart.load");
+    std::string autostart_load_filename = GetOptionsDB().Get<std::string>("load");
     if (!autostart_load_filename.empty()) {
         if (GetOptionsDB().Get<int>("network.server.conn-human-empire-players.min") > 0) {
             throw std::invalid_argument("Autostart load file was choosed but the server wasn't allowed to play game without connected players");

--- a/server/dmain.cpp
+++ b/server/dmain.cpp
@@ -65,7 +65,6 @@ int wmain(int argc, wchar_t* argv[], wchar_t* envp[]) {
         GetOptionsDB().Add<int>("network.server.cookies.expire-minutes", UserStringNop("OPTIONS_DB_COOKIES_EXPIRE"), 15, Validator<int>());
         GetOptionsDB().Add<bool>("network.server.publish-statistics", UserStringNop("OPTIONS_DB_PUBLISH_STATISTICS"), true, Validator<bool>());
         GetOptionsDB().Add("network.server.binary.enabled", UserStringNop("OPTIONS_DB_SERVER_BINARY_SERIALIZATION"), true);
-        GetOptionsDB().Add<std::string>("hostless.autostart.load", UserStringNop("OPTIONS_DB_HOSTLESS_AUTOSTART_LOAD"), std::string());
 
         // if config.xml and persistent_config.xml are present, read and set options entries
         GetOptionsDB().SetFromFile(GetConfigPath(), FreeOrionVersionString());

--- a/server/dmain.cpp
+++ b/server/dmain.cpp
@@ -65,6 +65,7 @@ int wmain(int argc, wchar_t* argv[], wchar_t* envp[]) {
         GetOptionsDB().Add<int>("network.server.cookies.expire-minutes", UserStringNop("OPTIONS_DB_COOKIES_EXPIRE"), 15, Validator<int>());
         GetOptionsDB().Add<bool>("network.server.publish-statistics", UserStringNop("OPTIONS_DB_PUBLISH_STATISTICS"), true, Validator<bool>());
         GetOptionsDB().Add("network.server.binary.enabled", UserStringNop("OPTIONS_DB_SERVER_BINARY_SERIALIZATION"), true);
+        GetOptionsDB().Add<std::string>("hostless.autostart.load", UserStringNop("OPTIONS_DB_HOSTLESS_AUTOSTART_LOAD"), std::string());
 
         // if config.xml and persistent_config.xml are present, read and set options entries
         GetOptionsDB().SetFromFile(GetConfigPath(), FreeOrionVersionString());

--- a/util/MultiplayerCommon.cpp
+++ b/util/MultiplayerCommon.cpp
@@ -35,6 +35,7 @@ namespace {
         db.Add("save.format.xml.zlib.enabled",              UserStringNop("OPTIONS_DB_XML_ZLIB_SERIALIZATION"), true);
         db.Add("save.auto.hostless.enabled",                UserStringNop("OPTIONS_DB_AUTOSAVE_HOSTLESS"),      true);
         db.Add<int>("save.auto.interval",                   UserStringNop("OPTIONS_DB_AUTOSAVE_INTERVAL"),      0, Validator<int>());
+        db.Add<std::string>("load",                         UserStringNop("OPTIONS_DB_LOAD"),                   "", Validator<std::string>(), false);
 
         // AI Testing options-- the following options are to facilitate AI testing and do not currently have an options page widget;
         // they are intended to be changed via the command line and are not currently storable in the configuration file.


### PR DESCRIPTION
Add option `load` to start hostless server from saved game. Starts game without any human players connected so requires to have zero minimum of connected human player.
Supposed to be part of script which choose latest save file and re-launches freeoriond if it stopped.

Changes order of FSM initialization and background parsing. Without it `LoadGame` fails on `SpeciesManager`.