### PR TITLE
Match nothing in OrderedAlternativesOf if no operand condition applied

### DIFF
--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -10057,7 +10057,7 @@ void OrderedAlternativesOf::Eval(const ScriptingContext& parent_context,
             // try the next operand
         }
 
-        // No operand condition was selected. State is restored...
+        // No operand condition was selected. State is restored. Nothing should be moved to matches input set
     } else /*(search_domain == MATCHES)*/ {
         // Check each operand condition on objects in the input matches and non_matches sets, until an operand condition matches an object.
         // If an operand condition is selected, apply it to the input matches set, moving non-matching candidates to non_matches.
@@ -10092,11 +10092,10 @@ void OrderedAlternativesOf::Eval(const ScriptingContext& parent_context,
             FCMoveContent(temp_objects, matches);
         }
 
-        // No operand condition was selected. State is restored...
+        // No operand condition was selected. Objects in matches input set do not match, so move those to non_matches input set.
+        non_matches.reserve(matches.size() + non_matches.size());
+        FCMoveContent(matches, non_matches);
     }
-    // ...  Nothing should match, so move all to non_matches input set.
-    non_matches.reserve(matches.size() + non_matches.size());
-    FCMoveContent(matches, non_matches);
 }
 
 bool OrderedAlternativesOf::RootCandidateInvariant() const {

--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -10057,7 +10057,7 @@ void OrderedAlternativesOf::Eval(const ScriptingContext& parent_context,
             // try the next operand
         }
 
-        // No operand condition was selected, nothing changed, done.
+        // No operand condition was selected. State is restored...
     } else /*(search_domain == MATCHES)*/ {
         // Check each operand condition on objects in the input matches and non_matches sets, until an operand condition matches an object.
         // If an operand condition is selected, apply it to the input matches set, moving non-matching candidates to non_matches.
@@ -10092,8 +10092,11 @@ void OrderedAlternativesOf::Eval(const ScriptingContext& parent_context,
             FCMoveContent(temp_objects, matches);
         }
 
-        // No operand condition was selected. Nothing needed to be applied. State is restored. Done.
+        // No operand condition was selected. State is restored...
     }
+    // ...  Nothing should match, so move all to non_matches input set.
+    non_matches.reserve(matches.size() + non_matches.size());
+    FCMoveContent(matches, non_matches);
 }
 
 bool OrderedAlternativesOf::RootCandidateInvariant() const {


### PR DESCRIPTION
Oberlus found a bug which manifested because of the species target condition matching:
[Traitor fighter attacks its fleet](https://www.freeorion.org/forum/viewtopic.php?f=28&t=11232&p=95060#p95060)

Somewhere along the way the OrderedAlternativesOf condition left the matching state untouched if no operand condition matched. It should actually move all matches to non_matches in this case.