### PR TITLE
Save game when playing game went to shutdown

### DIFF
--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -103,7 +103,6 @@ namespace {
         db.Add("save.auto.turn.interval",                   UserStringNop("OPTIONS_DB_AUTOSAVE_TURNS"),                     1,                  RangedValidator<int>(1, 50));
         db.Add("save.auto.file.limit",                      UserStringNop("OPTIONS_DB_AUTOSAVE_LIMIT"),                     10,                 RangedValidator<int>(1, 10000));
         db.Add("save.auto.initial.enabled",                 UserStringNop("OPTIONS_DB_AUTOSAVE_GALAXY_CREATION"),           true,               Validator<bool>());
-        db.Add("save.auto.exit.enabled",                    UserStringNop("OPTIONS_DB_AUTOSAVE_GAME_CLOSE"),                true,               Validator<bool>());
         db.Add("ui.input.mouse.button.swap.enabled",        UserStringNop("OPTIONS_DB_UI_MOUSE_LR_SWAP"),                   false);
         db.Add("ui.input.keyboard.repeat.delay",            UserStringNop("OPTIONS_DB_KEYPRESS_REPEAT_DELAY"),              360,                RangedValidator<int>(0, 1000));
         db.Add("ui.input.keyboard.repeat.interval",         UserStringNop("OPTIONS_DB_KEYPRESS_REPEAT_INTERVAL"),           20,                 RangedValidator<int>(0, 1000));

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1904,7 +1904,7 @@ OPTIONS_DB_AUTOSAVE_GALAXY_CREATION
 Enable autosave after the galaxy is created before any game play.
 
 OPTIONS_DB_AUTOSAVE_GAME_CLOSE
-Enable autosave when resigning or closing the game.
+Enable autosave when resigning or closing the game. In multiplayer hostless mode, enable autosaves when the server closes a game due to player disconnection or when the server is terminated.
 
 OPTIONS_DB_AUTOSAVE_HOSTLESS
 Enable autosave in hostless mode.

--- a/util/MultiplayerCommon.cpp
+++ b/util/MultiplayerCommon.cpp
@@ -36,6 +36,7 @@ namespace {
         db.Add("save.auto.hostless.enabled",                UserStringNop("OPTIONS_DB_AUTOSAVE_HOSTLESS"),      true);
         db.Add<int>("save.auto.interval",                   UserStringNop("OPTIONS_DB_AUTOSAVE_INTERVAL"),      0);
         db.Add<std::string>("load",                         UserStringNop("OPTIONS_DB_LOAD"),                   "", Validator<std::string>(), false);
+        db.Add("save.auto.exit.enabled",                    UserStringNop("OPTIONS_DB_AUTOSAVE_GAME_CLOSE"),    true, Validator<bool>());
 
         // AI Testing options-- the following options are to facilitate AI testing and do not currently have an options page widget;
         // they are intended to be changed via the command line and are not currently storable in the configuration file.


### PR DESCRIPTION
Allows to save playing game on SIGINT and SIGTERM.
Makes `save.auto.exit.enabled` option common.