### PR TITLE
Load players list from AuthProvider python API.

### DIFF
--- a/default/python/auth/auth.py
+++ b/default/python/auth/auth.py
@@ -62,3 +62,15 @@ class AuthProvider:
             return auth_data[1]
         else:
             return False
+
+    def list_players(self):
+        """Returns list of PlayerSetupData to use in quickstart"""
+        players = []
+        for player_name, auth_data in self.logins.iteritems():
+            if fo.roleType.clientTypePlayer in auth_data[1]:
+                psd = fo.PlayerSetupData()
+                psd.player_name = player_name
+                psd.empire_name = player_name
+                psd.starting_species = "RANDOM"
+                players.append(psd)
+        return players

--- a/python/server/ServerFramework.h
+++ b/python/server/ServerFramework.h
@@ -18,6 +18,7 @@ public:
     bool ExecuteTurnEvents();    // Wraps call to the main Python turn events function
     bool IsRequireAuthOrReturnRoles(const std::string& player_name, bool &result, Networking::AuthRoles& roles) const; // Wraps call to AuthProvider's method is_require_auth
     bool IsSuccessAuthAndReturnRoles(const std::string& player_name, const std::string& auth, bool &result, Networking::AuthRoles& roles) const; // Wraps call to AuthProvider's method is_success_auth
+    bool FillListPlayers(std::list<PlayerSetupData>& players) const; // Wraps call to AuthProvider's method list_player
     bool LoadChatHistory(boost::circular_buffer<ChatHistoryEntity>& chat_history); // Wraps call to ChatProvider's method load_history
     bool PutChatHistoryEntity(const ChatHistoryEntity& chat_history_entity); // Wraps call to ChatProvider's method put_history_entity
 

--- a/python/server/ServerWrapper.cpp
+++ b/python/server/ServerWrapper.cpp
@@ -1273,10 +1273,10 @@ namespace {
 namespace FreeOrionPython {
     void WrapServer() {
         class_<PlayerSetupData>("PlayerSetupData")
-            .def_readonly("player_name",        &PlayerSetupData::m_player_name)
-            .def_readonly("empire_name",        &PlayerSetupData::m_empire_name)
-            .def_readonly("empire_color",       &PlayerSetupData::m_empire_color)
-            .def_readonly("starting_species",   &PlayerSetupData::m_starting_species_name);
+            .def_readwrite("player_name",        &PlayerSetupData::m_player_name)
+            .def_readwrite("empire_name",        &PlayerSetupData::m_empire_name)
+            .def_readonly("empire_color",        &PlayerSetupData::m_empire_color)
+            .def_readwrite("starting_species",   &PlayerSetupData::m_starting_species_name);
 
         class_<FleetPlanWrapper>("FleetPlan", init<const std::string&, const list&>())
             .def("name",            &FleetPlanWrapper::Name)

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1671,6 +1671,34 @@ bool ServerApp::IsAuthSuccessAndFillRoles(const std::string& player_name, const 
     return result;
 }
 
+std::list<PlayerSetupData> ServerApp::FillListPlayers() {
+    std::list<PlayerSetupData> result;
+    bool success = false;
+    try {
+        m_python_server.SetCurrentDir(GetPythonAuthDir());
+        success = m_python_server.FillListPlayers(result);
+    } catch (const boost::python::error_already_set& err) {
+        success = false;
+        m_python_server.HandleErrorAlreadySet();
+        if (!m_python_server.IsPythonRunning()) {
+            ErrorLogger() << "Python interpreter is no longer running.  Attempting to restart.";
+            if (m_python_server.Initialize()) {
+                ErrorLogger() << "Python interpreter successfully restarted.";
+            } else {
+                ErrorLogger() << "Python interpreter failed to restart.  Exiting.";
+                m_fsm->process_event(ShutdownServer());
+            }
+        }
+    }
+
+    if (!success) {
+        ErrorLogger() << "Python scripted player list failed.";
+        ServerApp::GetApp()->Networking().SendMessageAll(ErrorMessage(UserStringNop("SERVER_TURN_EVENTS_ERRORS"),
+                                                                      false));
+    }
+    return result;
+}
+
 void ServerApp::AddObserverPlayerIntoGame(const PlayerConnectionPtr& player_connection) {
     std::map<int, PlayerInfo> player_info_map = GetPlayerInfoMap();
 

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -174,6 +174,9 @@ public:
     /** Checks if \a auth match \a player_name and fill \a roles if successed. */
     bool IsAuthSuccessAndFillRoles(const std::string& player_name, const std::string& auth, Networking::AuthRoles& roles);
 
+    /** Returns list of player for multiplayer quickstart*/
+    std::list<PlayerSetupData> FillListPlayers();
+
     /** Adds new observing player to running game.
       * Simply sends GAME_START message so established player knows he is in the game. */
     void AddObserverPlayerIntoGame(const PlayerConnectionPtr& player_connection);


### PR DESCRIPTION
Extracted part of #2417
Adds python API to get list of all players with player role.