### PR TITLE
Common galaxy options

### DIFF
--- a/UI/GalaxySetupWnd.cpp
+++ b/UI/GalaxySetupWnd.cpp
@@ -149,21 +149,10 @@ namespace {
 
     // persistant between-executions galaxy setup settings, mainly so I don't have to redo these settings to what I want every time I run FO to test something
     void AddOptions(OptionsDB& db) {
-        db.Add("setup.seed",                    UserStringNop("OPTIONS_DB_GAMESETUP_SEED"),                     std::string("0"),           Validator<std::string>());
-        db.Add("setup.star.count",              UserStringNop("OPTIONS_DB_GAMESETUP_STARS"),                    150,                        RangedValidator<int>(10, 5000));
-        db.Add("setup.galaxy.shape",            UserStringNop("OPTIONS_DB_GAMESETUP_GALAXY_SHAPE"),             DISC,                       RangedValidator<Shape>(SPIRAL_2, RANDOM));
-        db.Add("setup.galaxy.age",              UserStringNop("OPTIONS_DB_GAMESETUP_GALAXY_AGE"),               GALAXY_SETUP_MEDIUM,        RangedValidator<GalaxySetupOption>(GALAXY_SETUP_LOW, GALAXY_SETUP_RANDOM));
-        db.Add("setup.planet.density",          UserStringNop("OPTIONS_DB_GAMESETUP_PLANET_DENSITY"),           GALAXY_SETUP_MEDIUM,        RangedValidator<GalaxySetupOption>(GALAXY_SETUP_LOW, GALAXY_SETUP_RANDOM));
-        db.Add("setup.starlane.frequency",      UserStringNop("OPTIONS_DB_GAMESETUP_STARLANE_FREQUENCY"),       GALAXY_SETUP_MEDIUM,        RangedValidator<GalaxySetupOption>(GALAXY_SETUP_LOW, GALAXY_SETUP_RANDOM));
-        db.Add("setup.specials.frequency",      UserStringNop("OPTIONS_DB_GAMESETUP_SPECIALS_FREQUENCY"),       GALAXY_SETUP_MEDIUM,        RangedValidator<GalaxySetupOption>(GALAXY_SETUP_NONE, GALAXY_SETUP_RANDOM));
-        db.Add("setup.monster.frequency",       UserStringNop("OPTIONS_DB_GAMESETUP_MONSTER_FREQUENCY"),        GALAXY_SETUP_MEDIUM,        RangedValidator<GalaxySetupOption>(GALAXY_SETUP_NONE, GALAXY_SETUP_RANDOM));
-        db.Add("setup.native.frequency",        UserStringNop("OPTIONS_DB_GAMESETUP_NATIVE_FREQUENCY"),         GALAXY_SETUP_MEDIUM,        RangedValidator<GalaxySetupOption>(GALAXY_SETUP_NONE, GALAXY_SETUP_RANDOM));
         db.Add("setup.empire.name",             UserStringNop("OPTIONS_DB_GAMESETUP_EMPIRE_NAME"),              std::string(""),            Validator<std::string>());
         db.Add("setup.player.name",             UserStringNop("OPTIONS_DB_GAMESETUP_PLAYER_NAME"),              std::string(""),            Validator<std::string>());
         db.Add("setup.empire.color.index",      UserStringNop("OPTIONS_DB_GAMESETUP_EMPIRE_COLOR"),             9,                          RangedValidator<int>(0, 100));
         db.Add("setup.initial.species",         UserStringNop("OPTIONS_DB_GAMESETUP_STARTING_SPECIES_NAME"),    std::string("SP_HUMAN"),    Validator<std::string>());
-        db.Add("setup.ai.player.count",         UserStringNop("OPTIONS_DB_GAMESETUP_NUM_AI_PLAYERS"),           6,                          RangedValidator<int>(0, IApp::MAX_AI_PLAYERS()));
-        db.Add("setup.ai.aggression",           UserStringNop("OPTIONS_DB_GAMESETUP_AI_MAX_AGGRESSION"),        MANIACAL,                   RangedValidator<Aggression>(BEGINNER, MANIACAL));
     }
     bool temp_bool = RegisterOptions(&AddOptions);
 }

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -104,6 +104,17 @@ ServerApp::ServerApp() :
     InfoLogger() << FreeOrionVersionString();
     LogDependencyVersions();
 
+    m_galaxy_setup_data.m_seed = GetOptionsDB().Get<std::string>("setup.seed");
+    m_galaxy_setup_data.m_size = GetOptionsDB().Get<int>("setup.star.count");
+    m_galaxy_setup_data.m_shape = GetOptionsDB().Get<Shape>("setup.galaxy.shape");
+    m_galaxy_setup_data.m_age = GetOptionsDB().Get<GalaxySetupOption>("setup.galaxy.age");
+    m_galaxy_setup_data.m_starlane_freq = GetOptionsDB().Get<GalaxySetupOption>("setup.starlane.frequency");
+    m_galaxy_setup_data.m_planet_density = GetOptionsDB().Get<GalaxySetupOption>("setup.planet.density");
+    m_galaxy_setup_data.m_specials_freq = GetOptionsDB().Get<GalaxySetupOption>("setup.specials.frequency");
+    m_galaxy_setup_data.m_monster_freq = GetOptionsDB().Get<GalaxySetupOption>("setup.monster.frequency");
+    m_galaxy_setup_data.m_native_freq = GetOptionsDB().Get<GalaxySetupOption>("setup.native.frequency");
+    m_galaxy_setup_data.m_ai_aggr = GetOptionsDB().Get<Aggression>("setup.ai.aggression");
+
     // Start parsing content before FSM initialization
     // to have data initialized before autostart execution
     StartBackgroundParsing();

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -814,7 +814,7 @@ MPLobby::MPLobby(my_context c) :
                 player_setup_data.m_client_type =   Networking::CLIENT_TYPE_AI_PLAYER;
                 player_setup_data.m_empire_name =   GenerateEmpireName(player_setup_data.m_player_name, m_lobby_data->m_players);
                 player_setup_data.m_empire_color =  GetUnusedEmpireColour(m_lobby_data->m_players);
-                if (m_lobby_data->m_seed != "")
+                if (!m_lobby_data->m_seed.empty())
                     player_setup_data.m_starting_species_name = sm.RandomPlayableSpeciesName();
                 else
                     player_setup_data.m_starting_species_name = sm.SequentialPlayableSpeciesName(m_ai_next_index);

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -803,6 +803,26 @@ MPLobby::MPLobby(my_context c) :
             server.Networking().Disconnect(player_connection);
         }
 
+        // check if there weren't previous AIs
+        if (m_ai_next_index == 1) {
+            // use AI count from option
+            const int ai_count = GetOptionsDB().Get<int>("setup.ai.player.count");
+            while (m_ai_next_index <= ai_count && (m_ai_next_index <= max_ai || max_ai < 0)) {
+                PlayerSetupData player_setup_data;
+                player_setup_data.m_player_id =     Networking::INVALID_PLAYER_ID;
+                player_setup_data.m_player_name =   UserString("AI_PLAYER") + "_" + std::to_string(m_ai_next_index++);
+                player_setup_data.m_client_type =   Networking::CLIENT_TYPE_AI_PLAYER;
+                player_setup_data.m_empire_name =   GenerateEmpireName(player_setup_data.m_player_name, m_lobby_data->m_players);
+                player_setup_data.m_empire_color =  GetUnusedEmpireColour(m_lobby_data->m_players);
+                if (m_lobby_data->m_seed != "")
+                    player_setup_data.m_starting_species_name = sm.RandomPlayableSpeciesName();
+                else
+                    player_setup_data.m_starting_species_name = sm.SequentialPlayableSpeciesName(m_ai_next_index);
+
+                m_lobby_data->m_players.push_back({Networking::INVALID_PLAYER_ID, player_setup_data});
+            }
+        }
+
         ValidateClientLimits();
 
         server.Networking().SendMessageAll(ServerLobbyUpdateMessage(*m_lobby_data));

--- a/test/system/SmokeTestHostless.cpp
+++ b/test/system/SmokeTestHostless.cpp
@@ -120,6 +120,8 @@ BOOST_AUTO_TEST_CASE(hostless_server) {
         args.push_back("--hostless");
         args.push_back("--save.auto.hostless.enabled");
         args.push_back(save_game ? "1" : "0");
+        args.push_back("--setup.ai.player.count");
+        args.push_back("0");
         args.push_back("--testing");
 
 #ifdef FREEORION_LINUX

--- a/util/MultiplayerCommon.cpp
+++ b/util/MultiplayerCommon.cpp
@@ -49,7 +49,7 @@ namespace {
         db.Add("setup.monster.frequency",                   UserStringNop("OPTIONS_DB_GAMESETUP_MONSTER_FREQUENCY"), GALAXY_SETUP_MEDIUM, RangedValidator<GalaxySetupOption>(GALAXY_SETUP_NONE, GALAXY_SETUP_RANDOM));
         db.Add("setup.native.frequency",                    UserStringNop("OPTIONS_DB_GAMESETUP_NATIVE_FREQUENCY"), GALAXY_SETUP_MEDIUM, RangedValidator<GalaxySetupOption>(GALAXY_SETUP_NONE, GALAXY_SETUP_RANDOM));
         db.Add("setup.ai.player.count",                     UserStringNop("OPTIONS_DB_GAMESETUP_NUM_AI_PLAYERS"), 6, RangedValidator<int>(0, IApp::MAX_AI_PLAYERS()));
-        db.Add("setup.ai.aggression", UserStringNop("OPTIONS_DB_GAMESETUP_AI_MAX_AGGRESSION"),        MANIACAL,                   RangedValidator<Aggression>(BEGINNER, MANIACAL));
+        db.Add("setup.ai.aggression",                       UserStringNop("OPTIONS_DB_GAMESETUP_AI_MAX_AGGRESSION"), MANIACAL, RangedValidator<Aggression>(BEGINNER, MANIACAL));
 
         // AI Testing options-- the following options are to facilitate AI testing and do not currently have an options page widget;
         // they are intended to be changed via the command line and are not currently storable in the configuration file.

--- a/util/MultiplayerCommon.cpp
+++ b/util/MultiplayerCommon.cpp
@@ -38,6 +38,19 @@ namespace {
         db.Add<std::string>("load",                         UserStringNop("OPTIONS_DB_LOAD"),                   "", Validator<std::string>(), false);
         db.Add("save.auto.exit.enabled",                    UserStringNop("OPTIONS_DB_AUTOSAVE_GAME_CLOSE"),    true, Validator<bool>());
 
+        // Common galaxy settings
+        db.Add("setup.seed",                                UserStringNop("OPTIONS_DB_GAMESETUP_SEED"),         std::string("0"), Validator<std::string>());
+        db.Add("setup.star.count",                          UserStringNop("OPTIONS_DB_GAMESETUP_STARS"),        150, RangedValidator<int>(10, 5000));
+        db.Add("setup.galaxy.shape",                        UserStringNop("OPTIONS_DB_GAMESETUP_GALAXY_SHAPE"), DISC, RangedValidator<Shape>(SPIRAL_2, RANDOM));
+        db.Add("setup.galaxy.age",                          UserStringNop("OPTIONS_DB_GAMESETUP_GALAXY_AGE"),   GALAXY_SETUP_MEDIUM, RangedValidator<GalaxySetupOption>(GALAXY_SETUP_LOW, GALAXY_SETUP_RANDOM));
+        db.Add("setup.planet.density",                      UserStringNop("OPTIONS_DB_GAMESETUP_PLANET_DENSITY"), GALAXY_SETUP_MEDIUM, RangedValidator<GalaxySetupOption>(GALAXY_SETUP_LOW, GALAXY_SETUP_RANDOM));
+        db.Add("setup.starlane.frequency",                  UserStringNop("OPTIONS_DB_GAMESETUP_STARLANE_FREQUENCY"), GALAXY_SETUP_MEDIUM, RangedValidator<GalaxySetupOption>(GALAXY_SETUP_LOW, GALAXY_SETUP_RANDOM));
+        db.Add("setup.specials.frequency",                  UserStringNop("OPTIONS_DB_GAMESETUP_SPECIALS_FREQUENCY"), GALAXY_SETUP_MEDIUM, RangedValidator<GalaxySetupOption>(GALAXY_SETUP_NONE, GALAXY_SETUP_RANDOM));
+        db.Add("setup.monster.frequency",                   UserStringNop("OPTIONS_DB_GAMESETUP_MONSTER_FREQUENCY"), GALAXY_SETUP_MEDIUM, RangedValidator<GalaxySetupOption>(GALAXY_SETUP_NONE, GALAXY_SETUP_RANDOM));
+        db.Add("setup.native.frequency",                    UserStringNop("OPTIONS_DB_GAMESETUP_NATIVE_FREQUENCY"), GALAXY_SETUP_MEDIUM, RangedValidator<GalaxySetupOption>(GALAXY_SETUP_NONE, GALAXY_SETUP_RANDOM));
+        db.Add("setup.ai.player.count",                     UserStringNop("OPTIONS_DB_GAMESETUP_NUM_AI_PLAYERS"), 6, RangedValidator<int>(0, IApp::MAX_AI_PLAYERS()));
+        db.Add("setup.ai.aggression", UserStringNop("OPTIONS_DB_GAMESETUP_AI_MAX_AGGRESSION"),        MANIACAL,                   RangedValidator<Aggression>(BEGINNER, MANIACAL));
+
         // AI Testing options-- the following options are to facilitate AI testing and do not currently have an options page widget;
         // they are intended to be changed via the command line and are not currently storable in the configuration file.
         db.Add<std::string>("ai-path",                      UserStringNop("OPTIONS_DB_AI_FOLDER_PATH"),         "python/AI",


### PR DESCRIPTION
Extracted from #2417.

Moves galaxy options `setup.*` into common code.
Setup galaxy settings and fill AIs in multiplayer lobby according to options.