### PR TITLE
Options game rules

### DIFF
--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -1325,7 +1325,8 @@ sc::result MPLobby::react(const LobbyUpdate& msg) {
             m_lobby_data->m_native_freq    = incoming_lobby_data.m_native_freq;
             m_lobby_data->m_ai_aggr        = incoming_lobby_data.m_ai_aggr;
 
-            // copy only allowed rules
+            // copy rules from incoming lobby data to server lobby data, only if those rules are
+            // not locked by the server
             for (const auto& incoming_rule : incoming_lobby_data.m_game_rules) {
                 if (GetOptionsDB().OptionExists("setup.rules.server-locked." + incoming_rule.first) &&
                     !GetOptionsDB().Get<bool>("setup.rules.server-locked." + incoming_rule.first))

--- a/util/GameRules.h
+++ b/util/GameRules.h
@@ -90,9 +90,9 @@ public:
     //@}
 
     /** \name Mutators */ //@{
-    /** adds a rule, optionally with a custom validator.
-        Register option setup.rules.{NAME} to override default value and
-        option setup.rules.server-locked.{NAME} to block rule changes from players */
+    /** Adds a rule, optionally with a custom validator.
+        Adds option setup.rules.{RULE_NAME} to override default value and
+        option setup.rules.server-locked.{RULE_NAME} to block rule changes from players */
     template <class T>
     void    Add(const std::string& name, const std::string& description,
                 const std::string& category, T default_value,


### PR DESCRIPTION
For each game rule creates two options:

- `setup.rules.{NAME}` - value of the same type to override default in `game_rules.focs.txt`
- `setup.rules.server-locked.{NAME}` - if the rule locked on the server
