### PR TITLE
Add EXTERNAL_RESERVED messages for external applications

### DIFF
--- a/network/Message.h
+++ b/network/Message.h
@@ -104,7 +104,8 @@ public:
         ELIMINATE_SELF,         ///< sent by client to server if the player wants to resign
         UNREADY,                ///< sent by client to server to revoke ready state of turn orders and sent by server to client to acknowledge it
         TURN_PARTIAL_ORDERS,    ///< sent to the server by a client that has changes in orders to be stored
-        TURN_TIMEOUT            ///< sent by server to client to notify about remaining time before turn advance
+        TURN_TIMEOUT,           ///< sent by server to client to notify about remaining time before turn advance
+        EXTERNAL_RESERVED       ///< sent to the server by an external application for custom reaction
     )
 
     GG_CLASS_ENUM(TurnProgressPhase,

--- a/network/ServerNetworking.cpp
+++ b/network/ServerNetworking.cpp
@@ -273,6 +273,9 @@ namespace {
         case Message::SET_AUTH_ROLES:           return "Set authorization roles";
         case Message::ELIMINATE_SELF:           return "Eliminate self";
         case Message::UNREADY:                  return "Unready";
+        case Message::TURN_PARTIAL_ORDERS:      return "Partial orders";
+        case Message::TURN_TIMEOUT:             return "Turn timeout";
+        case Message::EXTERNAL_RESERVED:        return "External(reserved)";
         default:                                return std::string("Unknown Type(") + std::to_string(static_cast<int>(type)) + ")";
         };
     }

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -105,6 +105,9 @@ ServerApp::ServerApp() :
     InfoLogger() << FreeOrionVersionString();
     LogDependencyVersions();
 
+    // Output external message number value so it could be used with external applications
+    InfoLogger() << "External reserved message value: " << std::to_string(static_cast<int>(Message::EXTERNAL_RESERVED));
+
     m_galaxy_setup_data.m_seed = GetOptionsDB().Get<std::string>("setup.seed");
     m_galaxy_setup_data.m_size = GetOptionsDB().Get<int>("setup.star.count");
     m_galaxy_setup_data.m_shape = GetOptionsDB().Get<Shape>("setup.galaxy.shape");
@@ -470,6 +473,9 @@ void ServerApp::HandleNonPlayerMessage(const Message& msg, PlayerConnectionPtr p
             DebugLogger() << "ServerApp::HandleNonPlayerMessage received Message::SHUT_DOWN_SERVER from the sole "
                           << "connected player, who is local and so the request is being honored; server shutting down.";
             m_fsm->process_event(ShutdownServer());
+        } else if (player_connection->IsLocalConnection() && msg.Type() == Message::EXTERNAL_RESERVED) {
+            DebugLogger() << "ServerApp::HandleNonPlayerMessage received Message::EXTERNAL_RESERVED from local connection";
+            m_fsm->process_event(ExternalReserved(msg, player_connection));
         } else {
             ErrorLogger() << "ServerApp::HandleNonPlayerMessage : Received an invalid message type \""
                                             << msg.Type() << "\" for a non-player Message.  Terminating connection.";

--- a/server/ServerFSM.h
+++ b/server/ServerFSM.h
@@ -88,7 +88,8 @@ struct MessageEventBase {
     (ModeratorAct)                          \
     (AuthResponse)                          \
     (EliminateSelf)                         \
-    (Error)
+    (Error)                                 \
+    (ExternalReserved)
 
 
 #define DECLARE_MESSAGE_EVENT(r, data, name)                                            \


### PR DESCRIPTION
Reserves message type so other application like web-server could interact with freeoriond server without changes in the protocol.
