### PR TITLE
Try to fix Bad file descriptor error in CI

### DIFF
--- a/network/ClientNetworking.cpp
+++ b/network/ClientNetworking.cpp
@@ -356,7 +356,12 @@ bool ClientNetworking::Impl::ConnectToServer(
     try {
         while(!IsConnected() && Clock::now() < deadline) {
             for (tcp::resolver::iterator it = resolver.resolve(query); it != end_it; ++it) {
-                m_socket.close();
+                try {
+                    m_socket.close();
+                } catch (const std::exception& e) {
+                    ErrorLogger(network) << "ConnectToServer() : unable to close socket due to exception: " << e.what();
+                    m_socket = boost::asio::ip::tcp::socket(m_io_context);
+                }
 
                 m_socket.async_connect(*it, boost::bind(&ClientNetworking::Impl::HandleConnection, this,
                                                         &it,


### PR DESCRIPTION
Fixes CI faliure:
```
15:39:25.175479 [error] network : ClientNetworking.cpp:416 : ConnectToServer() : unable to connect to server at localhost due to exception: close: Bad file descriptor
/freeorion/test/system/SmokeTestHostless.cpp:142: error: fatal error in "hostless_server": critical check ConnectToServer("localhost") failed
```

It simply initializes new socket instead of failed one.