### PR TITLE
Add testing and RelWithDebugInfo for cmake for windows

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -70,6 +70,9 @@ Step by step procedure:
    * Unzip the SDK archive contents into the project directory.
    * Execute the `bootstrap.bat` within the project directory. This will clone
      the FreeOrion repository and place the dependencies at the correct place.
+   * If you want to create an out-of-source build using CMake, you should run 
+     `git clone https://github.com/freeorion/freeorion.git FreeOrion` in the 
+     `freeorion-project` directory, instead of running `bootstrap.bat`.
  * On Max OS X, Linux and other Operating Systems:
    * Navigate into the project directory.
    * Clone the project via Git:
@@ -111,6 +114,22 @@ Step by step procedure:
    * Compile the whole project by selecting the `Build` -> `Build Solution`
      menu entry.
 
+ * On Windows (cmake):
+   * Change into the `Freeorion` directory.
+   * Create a `build` directory, which will contain all compile FreeOrion
+     build artifacs.
+   * Change into the `build` directory on the command line.
+   * Execute cmake to generate Makefiles:
+
+     ```
+     cmake .. -G "Visual Studio 15 2017"
+     ```
+   * Compile the whole project by calling `MSBuild.exe -p:Configuration=Release FreeOrion.sln`
+     within the build directory. In case you want to utilize multiple CPU
+     cores, you can add the `-m` option to the command.
+   * Alternatively, you can compile the project by the Visual Studio GUI.
+
+
  * On Mac OS X:
    * Create a `build` directory, which will contain all compile FreeOrion
      build artifacs.
@@ -140,12 +159,17 @@ Step by step procedure:
      by invoking:
 
      ```
-     ln -s ../freeorion/default .
+     ln -s ../default .
      ```
 
 This will leave you with a build of FreeOrion executables.
 
- * `freeorion-project/FreeOrion` on Windows.
+ * `freeorion-project/FreeOrion` on Windows if you compile it with the 
+    standalone msvc project.
+ * `freeorion-project/Freeorion/build/Release` on Windows if you compile it 
+    with CMake. To run the executable without creating the symbolic link, you
+    can first change the directory to `freeorion-project/Freeorion`, then run
+    `./build/Release/FreeOrion.exe`.
  * `freeorion-project/build/Release` on Mac OS X.
  * `freeorion-project/freeorion/build` on Linux and other Operating Systems.
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,7 +170,8 @@ set_property(DIRECTORY APPEND
     PROPERTY COMPILE_DEFINITIONS
         # Set minimum Windows target version to WindowsXP or Vista depending on toolset
         # https://msdn.microsoft.com/en-us/library/aa383745.aspx
-        $<$<PLATFORM_ID:Windows>:_WIN32_WINNT=$<IF:$<STREQUAL:${_VS_PLATFORM_TOOLSET_TARGET},_xp>,_WIN32_WINNT_WINXP,_WIN32_WINNT_VISTA>>
+        # Use numeric to correctly compare it in <boost\log\detail\config.hpp>
+        $<$<PLATFORM_ID:Windows>:_WIN32_WINNT=$<IF:$<STREQUAL:${_VS_PLATFORM_TOOLSET_TARGET},_xp>,0x0501,0x0600>>
         # Default to unicode variants when using Win32 API
         # https://msdn.microsoft.com/en-us/library/dybsewaf.aspx
         $<$<PLATFORM_ID:Windows>:_UNICODE>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -394,6 +394,14 @@ target_link_libraries(freeorioncommon
     ${CORE_FOUNDATION_LIBRARY}
 )
 
+if(WIN32 AND ${Boost_VERSION} GREATER 106699) # boost >= 1.67
+    # fix https://github.com/boostorg/uuid/issues/68
+    find_library(BCRYPT_LIBRARY bcrypt)
+    target_link_libraries(freeorioncommon
+        ${BCRYPT_LIBRARY}
+    )
+endif()
+
 add_dependencies(freeorioncommon freeorionversion)
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -157,11 +157,17 @@ add_compile_options(
     $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<CONFIG:DEBUG>>:/MD>
 )
 
+# Determine minimum Windows target (see FreeOrion SDK)
+if(WIN32)
+    string(REGEX REPLACE "^v([1-9][0-9]*)(.*)$" "\\1;\\2" _VS_PLATFORM_TOOLSET "${CMAKE_VS_PLATFORM_TOOLSET}")
+    list(GET _VS_PLATFORM_TOOLSET 1 _VS_PLATFORM_TOOLSET_TARGET)
+endif()
+
 set_property(DIRECTORY APPEND
     PROPERTY COMPILE_DEFINITIONS
-        # Set minimum Windows target version to WindowsXP
+        # Set minimum Windows target version to WindowsXP or Vista depending on toolset
         # https://msdn.microsoft.com/en-us/library/aa383745.aspx
-        $<$<PLATFORM_ID:Windows>:_WIN32_WINNT=_WIN32_WINNT_WINXP>
+        $<$<PLATFORM_ID:Windows>:_WIN32_WINNT=$<IF:$<STREQUAL:${_VS_PLATFORM_TOOLSET_TARGET},"_xp">,_WIN32_WINNT_WINXP,_WIN32_WINNT_VISTA>>
         # Default to unicode variants when using Win32 API
         # https://msdn.microsoft.com/en-us/library/dybsewaf.aspx
         $<$<PLATFORM_ID:Windows>:_UNICODE>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,14 +160,16 @@ add_compile_options(
 # Determine minimum Windows target (see FreeOrion SDK)
 if(WIN32)
     string(REGEX REPLACE "^v([1-9][0-9]*)(.*)$" "\\1;\\2" _VS_PLATFORM_TOOLSET "${CMAKE_VS_PLATFORM_TOOLSET}")
+    message( STATUS "Toolset ${CMAKE_VS_PLATFORM_TOOLSET} regex ${_VS_PLATFORM_TOOLSET}")
     list(GET _VS_PLATFORM_TOOLSET 1 _VS_PLATFORM_TOOLSET_TARGET)
+    message( STATUS "Target ${_VS_PLATFORM_TOOLSET_TARGET}")
 endif()
 
 set_property(DIRECTORY APPEND
     PROPERTY COMPILE_DEFINITIONS
         # Set minimum Windows target version to WindowsXP or Vista depending on toolset
         # https://msdn.microsoft.com/en-us/library/aa383745.aspx
-        $<$<PLATFORM_ID:Windows>:_WIN32_WINNT=$<IF:$<STREQUAL:${_VS_PLATFORM_TOOLSET_TARGET},"_xp">,_WIN32_WINNT_WINXP,_WIN32_WINNT_VISTA>>
+        $<$<PLATFORM_ID:Windows>:_WIN32_WINNT=$<IF:$<STREQUAL:${_VS_PLATFORM_TOOLSET_TARGET},_xp>,_WIN32_WINNT_WINXP,_WIN32_WINNT_VISTA>>
         # Default to unicode variants when using Win32 API
         # https://msdn.microsoft.com/en-us/library/dybsewaf.aspx
         $<$<PLATFORM_ID:Windows>:_UNICODE>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,7 +56,7 @@ if(BUILD_TESTING)
 
     if(NOT TARGET unittest)
         add_custom_target(unittest
-            COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
+            COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure --build-config $<CONFIG>
             COMMENT "Run tests for ${CMAKE_PROJECT_NAME}"
         )
     endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,7 @@ endif()
 if(MSVC)
     # Remove default debug flags /Zi and /MDd to allow project-specific debug flag
     STRING(REGEX REPLACE " /Zi" "" CMAKE_CXX_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG})
+    STRING(REGEX REPLACE " /Zi" "" CMAKE_CXX_FLAGS_RELWITHDEBINFO ${CMAKE_CXX_FLAGS_RELWITHDEBINFO})
     STRING(REGEX REPLACE " /MDd" "" CMAKE_CXX_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG})
 endif()
 
@@ -150,8 +151,8 @@ add_compile_options(
     # Fix Fatal Error C1128: number of sections exceeded object file format limit : compile with /bigobj on SerializeEmpire.cpp
     $<$<CXX_COMPILER_ID:MSVC>:/bigobj>
 
-    # Produce pdb files in Debug configuration
-    $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<CONFIG:DEBUG>>:/Zi>
+    # Produce pdb files in Debug and RelWithDebInfo configuration
+    $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<OR:$<CONFIG:DEBUG>,$<CONFIG:RELWITHDEBINFO>>>:/Zi>
  
     # Use the multithread-specific and DLL-specific version of the run-time library in Debug Configuration
     $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<CONFIG:DEBUG>>:/MD>
@@ -453,7 +454,7 @@ if(MSVC)
     # The debug information produced in this project is over the MSVC linking limit, remove it
     get_target_property(PARSE_COMPILE_OPTIONS freeorionparse COMPILE_OPTIONS)
     list(REMOVE_ITEM PARSE_COMPILE_OPTIONS 
-        "$<$<AND:$<CXX_COMPILER_ID:MSVC>,$<CONFIG:DEBUG>>:/Zi>"
+        "$<$<AND:$<CXX_COMPILER_ID:MSVC>,$<OR:$<CONFIG:DEBUG>,$<CONFIG:RELWITHDEBINFO>>>:/Zi>"
     )
     set_target_properties(freeorionparse
         PROPERTIES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,7 @@ message(STATUS "Build type CMAKE_BUILD_TYPE set to ${CMAKE_BUILD_TYPE}")
 include(UseCompilerCache)
 find_compiler_cache(PROGRAM ccache)
 
+
 ##
 ## Global project configuration
 ##
@@ -161,6 +162,9 @@ set_property(DIRECTORY APPEND
         # Disable '<func>': The POSIX name for this item is deprecated." warning
         # https://msdn.microsoft.com/en-us/library/ttcz0bys.aspx
         $<$<PLATFORM_ID:Windows>:_CRT_NONSTDC_NO_WARNINGS>
+
+        # Suppress "Boost.Config is older than your compiler version" warning
+        $<$<PLATFORM_ID:Windows>:BOOST_CONFIG_SUPPRESS_OUTDATED_MESSAGE>
 
         # Define platform specific macros
         $<$<PLATFORM_ID:Windows>:FREEORION_WIN32>
@@ -310,10 +314,14 @@ if(Apple)
     )
 endif()
 
+if(NOT WIN32)
+    add_library(freeorioncommon "")
+endif()
 
-add_library(freeorioncommon "")
 
 if(WIN32)
+    add_library(freeorioncommon STATIC "")
+
     set_property(TARGET freeorioncommon
         PROPERTY
         OUTPUT_NAME Common
@@ -380,13 +388,6 @@ set_property(TARGET freeorionparseobj
     POSITION_INDEPENDENT_CODE ON
 )
 
-if(WIN32)
-    set_property(TARGET freeorionparseobj
-        PROPERTY
-        OUTPUT_NAME Parsers
-    )
-endif()
-
 target_compile_options(freeorionparseobj
     PRIVATE
         $<$<CXX_COMPILER_ID:GNU>:-fvisibility=hidden>
@@ -403,8 +404,18 @@ target_compile_definitions(freeorionparseobj
         -DFREEORION_BUILD_PARSE
 )
 
+if(NOT WIN32)
+    add_library(freeorionparse $<TARGET_OBJECTS:freeorionparseobj>)
+endif()
 
-add_library(freeorionparse $<TARGET_OBJECTS:freeorionparseobj>)
+if(WIN32)
+    add_library(freeorionparse STATIC $<TARGET_OBJECTS:freeorionparseobj>)
+
+    set_property(TARGET freeorionparse
+        PROPERTY
+        OUTPUT_NAME Parsers
+    )
+endif()
 
 target_compile_options(freeorionparse
     PRIVATE
@@ -472,7 +483,6 @@ target_link_libraries(freeoriond
 
 target_dependencies_copy_to_build(freeoriond)
 target_dependent_data_symlink_to_build(freeoriond ${PROJECT_SOURCE_DIR}/default)
-
 
 add_executable(freeorionca "")
 
@@ -626,6 +636,15 @@ if(NOT BUILD_HEADLESS)
 
     target_dependencies_copy_to_build(freeorion)
     target_dependent_data_symlink_to_build(freeorion ${PROJECT_SOURCE_DIR}/default)
+endif()
+
+if(WIN32)
+    add_custom_command(TARGET freeorion POST_BUILD
+        COMMAND
+            ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_PREFIX_PATH}/bin/python27.dll" "$<TARGET_FILE_DIR:freeorion>"
+        COMMAND
+            ${CMAKE_COMMAND} -E copy_if_different "${CMAKE_PREFIX_PATH}/bin/python27.zip" "$<TARGET_FILE_DIR:freeorion>" 
+    )
 endif()
 
 if(APPLE)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,7 @@ set(CMAKE_OSX_ARCHITECTURES x86_64 CACHE STRING "Set the architecture the univer
 IF(CMAKE_GENERATOR STREQUAL "Xcode")
   set(CMAKE_CONFIGURATION_TYPES Release)
 ELSE()
-  set(CMAKE_CONFIGURATION_TYPES Debug Release)
+  set(CMAKE_CONFIGURATION_TYPES Debug RelWithDebInfo Release)
 ENDIF()
 IF(NOT CMAKE_BUILD_TYPE)
   MESSAGE(STATUS "Setting build type to 'Release' as none was specified.")
@@ -410,7 +410,7 @@ if(MSVC)
     # The debug information produced in this project is over the MSVC linking limit, remove it
     get_target_property(PARSEOBJ_COMPILE_OPTIONS freeorionparseobj COMPILE_OPTIONS)
     list(REMOVE_ITEM PARSEOBJ_COMPILE_OPTIONS 
-        "$<$<AND:$<CXX_COMPILER_ID:MSVC>,$<CONFIG:DEBUG>>:/Zi>"
+        "$<$<AND:$<CXX_COMPILER_ID:MSVC>,$<OR:$<CONFIG:DEBUG>,$<CONFIG:RELWITHDEBINFO>>>:/Zi>"
     )
     set_target_properties(freeorionparseobj 
         PROPERTIES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -118,6 +118,12 @@ if(NOT APPLE)
     set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 endif()
 
+if(MSVC)
+    # Remove default debug flags /Zi and /MDd to allow project-specific debug flag
+    STRING(REGEX REPLACE " /Zi" "" CMAKE_CXX_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG})
+    STRING(REGEX REPLACE " /MDd" "" CMAKE_CXX_FLAGS_DEBUG ${CMAKE_CXX_FLAGS_DEBUG})
+endif()
+
 add_compile_options(
     # Enable (almost) all warnings on compilers
     # https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wall-316
@@ -143,6 +149,12 @@ add_compile_options(
 
     # Fix Fatal Error C1128: number of sections exceeded object file format limit : compile with /bigobj on SerializeEmpire.cpp
     $<$<CXX_COMPILER_ID:MSVC>:/bigobj>
+
+    # Produce pdb files in Debug configuration
+    $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<CONFIG:DEBUG>>:/Zi>
+ 
+    # Use the multithread-specific and DLL-specific version of the run-time library in Debug Configuration
+    $<$<AND:$<CXX_COMPILER_ID:MSVC>,$<CONFIG:DEBUG>>:/MD>
 )
 
 set_property(DIRECTORY APPEND
@@ -388,6 +400,18 @@ set_property(TARGET freeorionparseobj
     POSITION_INDEPENDENT_CODE ON
 )
 
+if(MSVC)
+    # The debug information produced in this project is over the MSVC linking limit, remove it
+    get_target_property(PARSEOBJ_COMPILE_OPTIONS freeorionparseobj COMPILE_OPTIONS)
+    list(REMOVE_ITEM PARSEOBJ_COMPILE_OPTIONS 
+        "$<$<AND:$<CXX_COMPILER_ID:MSVC>,$<CONFIG:DEBUG>>:/Zi>"
+    )
+    set_target_properties(freeorionparseobj 
+        PROPERTIES
+        COMPILE_OPTIONS "${PARSEOBJ_COMPILE_OPTIONS}"
+    )
+endif()
+
 target_compile_options(freeorionparseobj
     PRIVATE
         $<$<CXX_COMPILER_ID:GNU>:-fvisibility=hidden>
@@ -414,6 +438,18 @@ if(WIN32)
     set_property(TARGET freeorionparse
         PROPERTY
         OUTPUT_NAME Parsers
+    )
+endif()
+
+if(MSVC)
+    # The debug information produced in this project is over the MSVC linking limit, remove it
+    get_target_property(PARSE_COMPILE_OPTIONS freeorionparse COMPILE_OPTIONS)
+    list(REMOVE_ITEM PARSE_COMPILE_OPTIONS 
+        "$<$<AND:$<CXX_COMPILER_ID:MSVC>,$<CONFIG:DEBUG>>:/Zi>"
+    )
+    set_target_properties(freeorionparse
+        PROPERTIES
+        COMPILE_OPTIONS "${PARSEOBJ_COMPILE_OPTIONS}"
     )
 endif()
 

--- a/GG/test/unit/CMakeLists.txt
+++ b/GG/test/unit/CMakeLists.txt
@@ -35,6 +35,11 @@ target_compile_definitions(gg_unittest
         -DBOOST_TEST_NO_LIB
 )
 
+target_include_directories(gg_unittest
+    PRIVATE
+        ${Boost_INCLUDE_DIRS}
+)
+
 target_link_libraries(gg_unittest
     GiGi
     ${Boost_UNIT_TEST_FRAMEWORK_LIBRARIES}

--- a/GG/test/unit/CMakeLists.txt
+++ b/GG/test/unit/CMakeLists.txt
@@ -33,6 +33,8 @@ target_compile_definitions(gg_unittest
     PRIVATE
         -DBOOST_TEST_DYN_LINK
         -DBOOST_TEST_NO_LIB
+        -DBOOST_ALL_DYN_LINK
+        -DBOOST_ALL_NO_LIB
 )
 
 target_include_directories(gg_unittest

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,6 +2,11 @@ os: Visual Studio 2017
 
 version: ci-{build}
 
+environment:
+  matrix:
+    - BUILD_SYSTEM: CMAKE
+    - BUILD_SYSTEM: MSVC
+
 init:
   - git config --global core.eol native
   - git config --global core.autocrlf true
@@ -24,9 +29,22 @@ install:
   - cd freeorion
 
 before_build:
-  - cd msvc2017
+  - if "%BUILD_SYSTEM%" == "MSVC" (
+      cd msvc2017
+    )
+  - if "%BUILD_SYSTEM%" == "CMAKE" (
+      mkdir build
+    )
 
 build_script:
-    - msbuild FreeOrion.sln /maxcpucount /property:BuildInParallel=true /property:CL_MPCount=2 /property:PlatformToolset=v140_xp /property:Configuration=Release-XP /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /verbosity:minimal
+  - if "%BUILD_SYSTEM%" == "MSVC" (
+      msbuild FreeOrion.sln /maxcpucount /property:BuildInParallel=true /property:CL_MPCount=2 /property:PlatformToolset=v140_xp /property:Configuration=Release-XP /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" /verbosity:minimal
+    )
+  - if "%BUILD_SYSTEM%" == "CMAKE" (
+      pushd build &&
+      cmake -G "Visual Studio 15 2017" -T v140_xp .. &&
+      cmake --build . --config "Release" -- /maxcpucount /property:BuildInParallel=true /property:CL_MPCount=2 /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" &&
+      popd
+    )
 
 test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -47,9 +47,4 @@ build_script:
       popd
     )
 
-test_script:
-  - if "%BUILD_SYSTEM%" == "CMAKE" (
-      pushd build &&
-      cmake --build . --target unittest --config "Release" -- /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" &&
-      popd
-    )
+test: off

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -42,7 +42,7 @@ build_script:
     )
   - if "%BUILD_SYSTEM%" == "CMAKE" (
       pushd build &&
-      cmake -G "Visual Studio 15 2017" -T v140_xp .. &&
+      cmake -G "Visual Studio 15 2017" -T v140_xp -DBUILD_TESTING=On .. &&
       cmake --build . --config "Release" -- /maxcpucount /property:BuildInParallel=true /property:CL_MPCount=2 /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" &&
       popd
     )

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,8 +44,12 @@ build_script:
       pushd build &&
       cmake -G "Visual Studio 15 2017" -T v140_xp -DBUILD_TESTING=On .. &&
       cmake --build . --config "Release" -- /maxcpucount /property:BuildInParallel=true /property:CL_MPCount=2 /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" &&
-      cmake --build . --target unittest --config "Release" -- /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" &&
       popd
     )
 
-test: off
+test_script:
+  - if "%BUILD_SYSTEM%" == "CMAKE" (
+      pushd build &&
+      cmake --build . --target unittest --config "Release" -- /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" &&
+      popd
+    )

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -44,6 +44,7 @@ build_script:
       pushd build &&
       cmake -G "Visual Studio 15 2017" -T v140_xp -DBUILD_TESTING=On .. &&
       cmake --build . --config "Release" -- /maxcpucount /property:BuildInParallel=true /property:CL_MPCount=2 /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" &&
+      cmake --build . --target unittest --config "Release" -- /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll" &&
       popd
     )
 

--- a/test/parse/CMakeLists.txt
+++ b/test/parse/CMakeLists.txt
@@ -11,8 +11,8 @@ target_compile_definitions(fo_unittest_parse
         -DFREEORION_BUILD_SERVER
         -DBOOST_TEST_DYN_LINK
         -DBOOST_TEST_NO_LIB
-        -DBOOST_LOG_DYN_LINK
-        -DBOOST_LOG_NO_LIB
+        -DBOOST_ALL_DYN_LINK
+        -DBOOST_ALL_NO_LIB
 )
 
 target_include_directories(fo_unittest_parse

--- a/test/parse/CMakeLists.txt
+++ b/test/parse/CMakeLists.txt
@@ -11,6 +11,8 @@ target_compile_definitions(fo_unittest_parse
         -DFREEORION_BUILD_SERVER
         -DBOOST_TEST_DYN_LINK
         -DBOOST_TEST_NO_LIB
+        -DBOOST_LOG_DYN_LINK
+        -DBOOST_LOG_NO_LIB
 )
 
 target_include_directories(fo_unittest_parse

--- a/test/system/CMakeLists.txt
+++ b/test/system/CMakeLists.txt
@@ -3,6 +3,7 @@ find_package(Boost ${MINIMUM_BOOST_VERSION}
         unit_test_framework
         log
         log_setup
+        thread
     REQUIRED)
 
 add_executable(fo_systemtest_game
@@ -33,6 +34,7 @@ target_link_libraries(fo_systemtest_game
     ${Boost_UNIT_TEST_FRAMEWORK_LIBRARIES}
     ${Boost_LOG_LIBRARY}
     ${Boost_LOG_SETUP_LIBRARY}
+    ${Boost_THREAD_LIBRARY}
     ${CMAKE_THREAD_LIBS_INIT}
 )
 

--- a/test/system/CMakeLists.txt
+++ b/test/system/CMakeLists.txt
@@ -15,8 +15,8 @@ target_compile_definitions(fo_systemtest_game
         -DFREEORION_BUILD_HUMAN
         -DBOOST_TEST_DYN_LINK
         -DBOOST_TEST_NO_LIB
-        -DBOOST_LOG_DYN_LINK
-        -DBOOST_LOG_NO_LIB
+        -DBOOST_ALL_DYN_LINK
+        -DBOOST_ALL_NO_LIB
         -DBOOST_TEST_IGNORE_SIGCHLD
 )
 

--- a/test/system/ClientAppFixture.cpp
+++ b/test/system/ClientAppFixture.cpp
@@ -11,6 +11,7 @@
 
 #include <boost/format.hpp>
 #include <boost/uuid/nil_generator.hpp>
+#include <boost/thread/thread.hpp>
 
 ClientAppFixture::ClientAppFixture() :
     m_game_started(false),

--- a/test/util/CMakeLists.txt
+++ b/test/util/CMakeLists.txt
@@ -8,6 +8,8 @@ target_compile_definitions(fo_unittest_util
     PRIVATE
         -DBOOST_TEST_DYN_LINK
         -DBOOST_TEST_NO_LIB
+        -DBOOST_ALL_DYN_LINK
+        -DBOOST_ALL_NO_LIB
 )
 
 target_include_directories(fo_unittest_util


### PR DESCRIPTION
Yet another try to fix Cmake for Windows MS VS made on top @dlshcbmuipmam's #2388
Adds RelWithDebugInfo configuration and fix test compilation

Tests with standard sources layout in FreeOrion SDK x64 v141
```
cmake -DBUILD_TESTING=On -DCMAKE_BUILD_TYPE=RelWithDebInfo -G "Visual Studio 15 2017 Win64" -T v141,host=x64 -DPYTHON_EXECUTABLE=..\python.exe ..
cmake --build . --config RelWithDebInfo
```