### PR TITLE
Fix potential out of bounds access in Production/ResearchQueue

### DIFF
--- a/Empire/ProductionQueue.cpp
+++ b/Empire/ProductionQueue.cpp
@@ -686,7 +686,8 @@ ProductionQueue::const_iterator ProductionQueue::find(int i) const
 { return (0 <= i && i < static_cast<int>(size())) ? (begin() + i) : end(); }
 
 const ProductionQueue::Element& ProductionQueue::operator[](int i) const {
-    assert(0 <= i && i < static_cast<int>(m_queue.size()));
+    if (i < 0 || i >= static_cast<int>(m_queue.size()))
+        throw std::out_of_range("Tried to access ProductionQueue element out of bounds");
     return m_queue[i];
 }
 
@@ -888,12 +889,14 @@ void ProductionQueue::insert(iterator it, const Element& element)
 { m_queue.insert(it, element); }
 
 void ProductionQueue::erase(int i) {
-    assert(i <= static_cast<int>(size()));
+    if (i < 0 || i >= static_cast<int>(m_queue.size()))
+        throw std::out_of_range("Tried to erase ProductionQueue item out of bounds.");
     m_queue.erase(begin() + i);
 }
 
 ProductionQueue::iterator ProductionQueue::erase(iterator it) {
-    assert(it != end());
+    if (it == end())
+        throw std::out_of_range("Tried to erase ProductionQueue item out of bounds.");
     return m_queue.erase(it);
 }
 
@@ -907,7 +910,8 @@ ProductionQueue::iterator ProductionQueue::find(int i)
 { return (0 <= i && i < static_cast<int>(size())) ? (begin() + i) : end(); }
 
 ProductionQueue::Element& ProductionQueue::operator[](int i) {
-    assert(0 <= i && i < static_cast<int>(m_queue.size()));
+    if (i < 0 || i >= static_cast<int>(m_queue.size()))
+        throw std::out_of_range("Tried to access ProductionQueue element out of bounds");
     return m_queue[i];
 }
 

--- a/Empire/ResearchQueue.cpp
+++ b/Empire/ResearchQueue.cpp
@@ -145,7 +145,8 @@ ResearchQueue::const_iterator ResearchQueue::find(const std::string& tech_name) 
 }
 
 const ResearchQueue::Element& ResearchQueue::operator[](int i) const {
-    assert(0 <= i && i < static_cast<int>(m_queue.size()));
+    if (i < 0 || i >= static_cast<int>(m_queue.size()))
+        throw std::out_of_range("Tried to access ResearchQueue element out of bounds");
     return m_queue[i];
 }
 
@@ -323,7 +324,8 @@ void ResearchQueue::insert(iterator it, const std::string& tech_name, bool pause
 { m_queue.insert(it, Element(tech_name, m_empire_id, 0.0f, -1, paused)); }
 
 void ResearchQueue::erase(iterator it) {
-    assert(it != end());
+    if (it == end())
+        throw std::out_of_range("Tried to erase ResearchQueue element out of bounds");
     m_queue.erase(it);
 }
 


### PR DESCRIPTION
It was possible to access the ProductionQueue/ResearchQueue out of bounds in Release mode. For example, following test wouldn't necessarily raise an error (but possibly crash the AI) before the fix. Now, as expected, an IndexError is raised instead.
```
[03 Mai 22:29:36] AI_1: Entering debug mode
Print 'stop' to exit.
Local variables:
  ai  aistate
  u   universe
  e   empire
[03 Mai 22:29:45] Menschlicher_Spieler: e.productionQueue[999]
[03 Mai 22:29:45] AI_1: Traceback (most recent call last):
  File "<input>", line 1, in <module>
IndexError: Tried to access ProductionQueue element out of bounds
```