### PR TITLE
Initial turn timeout implementation

### DIFF
--- a/UI/MapWnd.h
+++ b/UI/MapWnd.h
@@ -13,6 +13,7 @@
 #include <boost/unordered_map.hpp>
 #include <boost/functional/hash.hpp>
 
+#include <chrono>
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -128,6 +129,7 @@ public:
     void MouseWheel(const GG::Pt& pt, int move, GG::Flags<GG::ModKey> mod_keys) override;
     void KeyPress(GG::Key key, std::uint32_t key_code_point, GG::Flags<GG::ModKey> mod_keys) override;
     void KeyRelease(GG::Key key, std::uint32_t key_code_point, GG::Flags<GG::ModKey> mod_keys) override;
+    void TimerFiring(unsigned int ticks, GG::Timer* timer) override;
 
     void DoLayout();
 
@@ -200,6 +202,7 @@ public:
     void RegisterPopup(const std::shared_ptr<MapWndPopup>& popup);              //!< registers a MapWndPopup, which can be cleaned up with a call to DeleteAllPopups( )
     void RemovePopup(MapWndPopup* popup);        //!< removes a MapWndPopup from the list cleaned up on a call to DeleteAllPopups( )
     void Sanitize();                             //!< sanitizes the MapWnd after a game
+    void ResetTimeoutClock(int timeout);         //!< start count down \a timeout seconds
     //!@}
 
     void SetFleetExploring(const int fleet_id);
@@ -560,6 +563,8 @@ private:
     std::shared_ptr<GG::Button>     m_btn_auto_turn = nullptr;  //!< button that toggles whether to automatically end turns;
     bool                            m_auto_end_turn = false;    //!< should turns be ended automatically by this client?
     bool                            m_ready_turn = false;       //!< is turn orders are ready and sent to server?
+    std::shared_ptr<GG::Label>      m_timeout_remain = nullptr; //!< label to show remaining time
+    GG::Timer                       m_timeout_clock{1000};      //!< clock to update remaining time
     std::list<std::weak_ptr<MapWndPopup>> m_popups;             //!< list of currently active popup windows
     bool                            m_menu_showing = false;     //!< set during ShowMenu() to prevent reentrency
     int                             m_current_owned_system;
@@ -586,6 +591,9 @@ private:
 
     /// indicates that refresh fleet button work should be done before rendering.
     bool                            m_deferred_refresh_fleet_buttons = false;
+
+    std::chrono::time_point<std::chrono::high_resolution_clock>
+                                    m_timeout_time;
 
     friend struct IntroMenu;
     friend struct WaitingForGameStart;

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -398,6 +398,9 @@ void AIClientApp::HandleMessage(const Message& msg) {
         break;
     }
 
+    case Message::TURN_TIMEOUT:
+        break;
+
     default: {
         ErrorLogger() << "AIClientApp::HandleMessage : Received unknown Message type code " << msg.Type();
         break;

--- a/client/ClientFSMEvents.h
+++ b/client/ClientFSMEvents.h
@@ -41,7 +41,8 @@ struct MessageEventBase {
     (EndGame)                                  \
     (CheckSum)                                 \
     (AuthRequest)                              \
-    (ChatHistory)
+    (ChatHistory)                              \
+    (TurnTimeout)
 
 
 #define DECLARE_MESSAGE_EVENT(r, data, name)                            \

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -992,6 +992,7 @@ void HumanClientApp::HandleMessage(Message& msg) {
     case Message::AUTH_REQUEST:             m_fsm->process_event(AuthRequest(msg));             break;
     case Message::CHAT_HISTORY:             m_fsm->process_event(ChatHistory(msg));             break;
     case Message::SET_AUTH_ROLES:           HandleSetAuthRoles(msg);                            break;
+    case Message::TURN_TIMEOUT:             m_fsm->process_event(TurnTimeout(msg));             break;
     default:
         ErrorLogger() << "HumanClientApp::HandleMessage : Received an unknown message type \"" << msg.Type() << "\".";
     }

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -857,6 +857,7 @@ boost::statechart::result WaitingForGameStart::react(const GameStart& msg) {
         Client().Autosave();
 
     Client().GetClientUI().GetPlayerListWnd()->Refresh();
+    Client().GetClientUI().GetMapWnd()->ResetTimeoutClock(0);
 
     return transit<PlayingTurn>();
 }
@@ -915,6 +916,7 @@ boost::statechart::result WaitingForTurnData::react(const TurnUpdate& msg) {
     Client().HandleTurnUpdate();
 
     Client().GetClientUI().GetPlayerListWnd()->Refresh();
+    Client().GetClientUI().GetMapWnd()->ResetTimeoutClock(0);
 
     return transit<PlayingTurn>();
 }
@@ -1081,6 +1083,7 @@ boost::statechart::result PlayingTurn::react(const TurnTimeout& msg) {
     } catch (const boost::bad_lexical_cast& ex) {
         ErrorLogger(FSM) << "PlayingGame::react(const TurnTimout& msg) could not convert \"" << text << "\" to timeout";
     }
+    Client().GetClientUI().GetMapWnd()->ResetTimeoutClock(timeout_remain);
     return discard_event();
 }
 

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -1072,6 +1072,18 @@ boost::statechart::result PlayingTurn::react(const DispatchCombatLogs& msg) {
     return discard_event();
 }
 
+boost::statechart::result PlayingTurn::react(const TurnTimeout& msg) {
+    DebugLogger(FSM) << "(PlayerFSM) PlayingGame::TurnTimeout message received: " << msg.m_message.Text();
+    const std::string& text = msg.m_message.Text();
+    int timeout_remain = 0;
+    try {
+        timeout_remain = boost::lexical_cast<int>(text);
+    } catch (const boost::bad_lexical_cast& ex) {
+        ErrorLogger(FSM) << "PlayingGame::react(const TurnTimout& msg) could not convert \"" << text << "\" to timeout";
+    }
+    return discard_event();
+}
+
 
 ////////////////////////////////////////////////////////////
 // QuittingGame

--- a/client/human/HumanClientFSM.h
+++ b/client/human/HumanClientFSM.h
@@ -343,7 +343,8 @@ struct PlayingTurn : boost::statechart::state<PlayingTurn, PlayingGame> {
         boost::statechart::custom_reaction<TurnUpdate>,
         boost::statechart::custom_reaction<TurnEnded>,
         boost::statechart::custom_reaction<PlayerStatus>,
-        boost::statechart::custom_reaction<DispatchCombatLogs>
+        boost::statechart::custom_reaction<DispatchCombatLogs>,
+        boost::statechart::custom_reaction<TurnTimeout>
     > reactions;
 
     PlayingTurn(my_context ctx);
@@ -355,6 +356,7 @@ struct PlayingTurn : boost::statechart::state<PlayingTurn, PlayingGame> {
     boost::statechart::result react(const TurnEnded& d);
     boost::statechart::result react(const PlayerStatus& msg);
     boost::statechart::result react(const DispatchCombatLogs& msg);
+    boost::statechart::result react(const TurnTimeout& msg);
 
     CLIENT_ACCESSOR
 };

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -3171,6 +3171,20 @@ Turn %1%
 MAP_BTN_TURN_UNREADY
 Revise Orders %1%
 
+# %1% number of seconds
+MAP_TIMEOUT_SECONDS
+%1% seconds
+
+# %1% number of minutes
+# %2% number of seconds
+MAP_TIMEOUT_MINS_SECS
+%1% mins %2% secs
+
+# %1% number of hours
+# %2% number of minutes
+MAP_TIMEOUT_HRS_MINS
+%1% hrs %2% mins
+
 # %1% number of frames currently displayed per second.
 MAP_INDICATOR_FPS
 %1% FPS

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1406,7 +1406,7 @@ OPTIONS_DB_FIRST_TURN_TIME
 Absolute time point in format "2019-01-20 11:59:59" in UTC. If empty, first turn advance will happen after expiring interval. Requires fixed interval to be enabled.
 
 OPTIONS_DB_TIMEOUT_INTERVAL
-Maximum interval in seconds between turn advances. If 0, turn advances by timeout are disabled, and turns will only advance once all players ended their turn.
+Maximum interval in seconds between turn advances. If 0, turn advances by timeout are disabled, and turns will only advance once all players have ended their turn.
 
 OPTIONS_DB_TIMEOUT_FIXED_INTERVAL
 Turns advance after fixed intervals, regardless of when and whether players have submitted turn orders.

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1406,7 +1406,7 @@ OPTIONS_DB_FIRST_TURN_TIME
 Absolute time point in seconds since epoch. If 0 first turn advance will happen after expiring interval.
 
 OPTIONS_DB_TIMEOUT_INTERVAL
-Interval in seconds between turn advances. If 0 turn advances by timeout are disabled.
+Maximum interval in seconds between turn advances. If 0 turn advances by timeout are disabled.
 
 OPTIONS_DB_TIMEOUT_FIXED_INTERVAL
 If enabled interval between turn advances are strictly equals, turn doesn't advance until timeout expires.

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1403,13 +1403,13 @@ OPTIONS_DB_PUBLISH_STATISTICS
 Enable sending empire staticstics to the player.
 
 OPTIONS_DB_FIRST_TURN_TIME
-Absolute time point in seconds since epoch. If 0 it isn't used.
+Absolute time point in seconds since epoch. If 0 first turn advance will happen after expiring interval.
 
 OPTIONS_DB_TIMEOUT_INTERVAL
 Interval in seconds between turn advances. If 0 turn advances by timeout are disabled.
 
 OPTIONS_DB_TIMEOUT_FIXED_INTERVAL
-Await for turn expiration even if all players are ready.
+If enabled interval between turn advances are strictly equals, turn doesn't advance until timeout expires.
 
 OPTIONS_DB_UI_MAIN_MENU_X
 Position of the center of the intro screen main menu, as a portion of the application's total width.

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1402,6 +1402,15 @@ Count of minutes after the cookie record will be considered expired.
 OPTIONS_DB_PUBLISH_STATISTICS
 Enable sending empire staticstics to the player.
 
+OPTIONS_DB_FIRST_TURN_TIME
+Absolute time point in seconds since epoch. If 0 it isn't used.
+
+OPTIONS_DB_TIMEOUT_INTERVAL
+Interval in seconds between turn advances. If 0 turn advances by timeout are disabled.
+
+OPTIONS_DB_TIMEOUT_FIXED_INTERVAL
+Await for turn expiration even if all players are ready.
+
 OPTIONS_DB_UI_MAIN_MENU_X
 Position of the center of the intro screen main menu, as a portion of the application's total width.
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1403,13 +1403,13 @@ OPTIONS_DB_PUBLISH_STATISTICS
 Enable sending empire staticstics to the player.
 
 OPTIONS_DB_FIRST_TURN_TIME
-Absolute time point in seconds since epoch. If 0 first turn advance will happen after expiring interval.
+Absolute time point in format "2019-01-20 11:59:59" in UTC. If empty, first turn advance will happen after expiring interval. Requires fixed interval to be enabled.
 
 OPTIONS_DB_TIMEOUT_INTERVAL
-Maximum interval in seconds between turn advances. If 0 turn advances by timeout are disabled.
+Maximum interval in seconds between turn advances. If 0, turn advances by timeout are disabled, and turns will only advance once all players ended their turn.
 
 OPTIONS_DB_TIMEOUT_FIXED_INTERVAL
-If enabled interval between turn advances are strictly equals, turn doesn't advance until timeout expires.
+Turns advance after fixed intervals, regardless of when and whether players have submitted turn orders.
 
 OPTIONS_DB_UI_MAIN_MENU_X
 Position of the center of the intro screen main menu, as a portion of the application's total width.

--- a/network/Message.cpp
+++ b/network/Message.cpp
@@ -395,6 +395,9 @@ Message TurnPartialOrdersMessage(const std::pair<OrderSet, std::set<int>>& order
     return Message(Message::TURN_PARTIAL_ORDERS, os.str());
 }
 
+Message TurnTimeoutMessage(int timeout_remaining)
+{ return Message(Message::TURN_TIMEOUT, std::to_string(timeout_remaining)); }
+
 Message TurnProgressMessage(Message::TurnProgressPhase phase_id) {
     std::ostringstream os;
     {

--- a/network/Message.h
+++ b/network/Message.h
@@ -103,7 +103,8 @@ public:
         SET_AUTH_ROLES,         ///< sent by server to client to set authorization roles
         ELIMINATE_SELF,         ///< sent by client to server if the player wants to resign
         UNREADY,                ///< sent by client to server to revoke ready state of turn orders and sent by server to client to acknowledge it
-        TURN_PARTIAL_ORDERS     ///< sent to the server by a client that has changes in orders to be stored
+        TURN_PARTIAL_ORDERS,    ///< sent to the server by a client that has changes in orders to be stored
+        TURN_TIMEOUT            ///< sent by server to client to notify about remaining time before turn advance
     )
 
     GG_CLASS_ENUM(TurnProgressPhase,
@@ -249,6 +250,9 @@ FO_COMMON_API Message TurnOrdersMessage(const OrderSet& orders, const std::strin
 
 /** creates a TURN_PARTIAL_ORDERS message with orders changes. */
 FO_COMMON_API Message TurnPartialOrdersMessage(const std::pair<OrderSet, std::set<int>>& orders_updates);
+
+/** creates a TURN_TIMEOUT message with remaining time \a timeout_. */
+FO_COMMON_API Message TurnTimeoutMessage(int timeout_remainig);
 
 /** creates a TURN_PROGRESS message. */
 FO_COMMON_API Message TurnProgressMessage(Message::TurnProgressPhase phase_id);

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -681,6 +681,7 @@ void ServerApp::NewGameInitConcurrentWithJoiners(
 
     // set server state info for new game
     m_current_turn = BEFORE_FIRST_TURN;
+    m_turn_expired = false;
 
     // create universe and empires for players
     DebugLogger() << "ServerApp::NewGameInitConcurrentWithJoiners: Creating Universe";
@@ -1041,6 +1042,9 @@ void ServerApp::PushChatMessage(const std::string& text,
                                                                       false));
     }
 }
+
+void ServerApp::ExpireTurn()
+{ m_turn_expired = true; }
 
 namespace {
     /** Verifies that a human player is connected with the indicated \a id. */
@@ -1965,20 +1969,31 @@ void ServerApp::RevokeEmpireTurnReadyness(int empire_id)
 
 bool ServerApp::AllOrdersReceived() {
     // debug output
-    DebugLogger() << "ServerApp::AllOrdersReceived for turn: " << m_current_turn;
+    DebugLogger() << "ServerApp::AllOrdersReceived for turn: " << m_current_turn
+                  << (m_turn_expired ? " (expired)" : "");
     bool all_orders_received = true;
     for (const auto& empire_orders : m_turn_sequence) {
+        bool empire_orders_received = true;
         if (!empire_orders.second) {
             DebugLogger() << " ... no save data from empire id: " << empire_orders.first;
-            all_orders_received = false;
+            empire_orders_received = false;
         } else if (!empire_orders.second->m_orders) {
             DebugLogger() << " ... no orders from empire id: " << empire_orders.first;
-            all_orders_received = false;
+            empire_orders_received = false;
         } else if (!empire_orders.second->m_ready) {
             DebugLogger() << " ... not ready empire id: " << empire_orders.first;
-            all_orders_received = false;
+            empire_orders_received = false;
         } else {
             DebugLogger() << " ... have orders from empire id: " << empire_orders.first;
+        }
+        if (!empire_orders_received) {
+            if (GetEmpireClientType(empire_orders.first) != Networking::CLIENT_TYPE_AI_PLAYER
+                && m_turn_expired)
+            {
+                DebugLogger() << " ...... turn expired for empire id: " << empire_orders.first;
+            } else {
+                all_orders_received = false;
+            }
         }
     }
     return all_orders_received;
@@ -3570,6 +3585,7 @@ void ServerApp::PostCombatProcessTurns() {
                                                   use_binary_serialization));
         }
     }
+    m_turn_expired = false;
     DebugLogger() << "ServerApp::PostCombatProcessTurns done";
 }
 

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1046,6 +1046,9 @@ void ServerApp::PushChatMessage(const std::string& text,
 void ServerApp::ExpireTurn()
 { m_turn_expired = true; }
 
+bool ServerApp::IsTurnExpired() const
+{ return m_turn_expired; }
+
 namespace {
     /** Verifies that a human player is connected with the indicated \a id. */
     bool HumanPlayerWithIdConnected(const ServerNetworking& sn, int id) {

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -89,6 +89,8 @@ public:
 
     /** Extracts player save game data. */
     std::vector<PlayerSaveGameData> GetPlayerSaveGameData() const;
+
+    bool IsTurnExpired() const;
     //@}
 
 
@@ -192,6 +194,9 @@ public:
       * Simply sends GAME_START message so established player knows he is in the game.
       * Notificates the player about statuses of other empires. */
     int AddPlayerIntoGame(const PlayerConnectionPtr& player_connection);
+
+    /** Sets turn expired timeout */
+    void ExpireTurn();
     //@}
 
     void UpdateSavePreviews(const Message& msg, PlayerConnectionPtr player_connection);
@@ -208,9 +213,6 @@ public:
                          const boost::posix_time::ptime& timestamp);
 
     ServerNetworking&           Networking();     ///< returns the networking object for the server
-
-    void ExpireTurn(); ///< Sets turn expired timeout
-
 private:
     void    Run();          ///< initializes app state, then executes main event handler/render loop (Poll())
 

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -209,6 +209,8 @@ public:
 
     ServerNetworking&           Networking();     ///< returns the networking object for the server
 
+    void ExpireTurn(); ///< Sets turn expired timeout
+
 private:
     void    Run();          ///< initializes app state, then executes main event handler/render loop (Poll())
 
@@ -310,6 +312,7 @@ private:
     PythonServer            m_python_server;
     std::map<int, int>      m_player_empire_ids;    ///< map from player id to empire id that the player controls.
     int                     m_current_turn;         ///< current turn number
+    bool                    m_turn_expired;         ///< true when turn exceeds its timeout
     std::vector<Process>    m_ai_client_processes;  ///< AI client child processes
     bool                    m_single_player_game;   ///< true when the game being played is single-player
     GalaxySetupData         m_galaxy_setup_data;    ///< stored setup data for the game currently being played

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -195,7 +195,7 @@ public:
       * Notificates the player about statuses of other empires. */
     int AddPlayerIntoGame(const PlayerConnectionPtr& player_connection);
 
-    /** Sets turn expired timeout */
+    /** Sets turn to be expired. Server doesn't wait for human player turns. */
     void ExpireTurn();
     //@}
 

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -2478,12 +2478,12 @@ PlayingGame::PlayingGame(my_context c) :
         m_turn_timeout.async_wait(boost::bind(&PlayingGame::TurnTimedoutHandler,
                                               this,
                                               boost::asio::placeholders::error));
-    } else if (GetOptionsDB().Get<int>("network.server.turn-timeout.interval") > 0) {
+    } else if (GetOptionsDB().Get<int>("network.server.turn-timeout.max-interval") > 0) {
         // Set turn advance after time interval
 #if BOOST_VERSION >= 106600
-        m_turn_timeout.expires_after(std::chrono::seconds(GetOptionsDB().Get<int>("network.server.turn-timeout.interval")));
+        m_turn_timeout.expires_after(std::chrono::seconds(GetOptionsDB().Get<int>("network.server.turn-timeout.max-interval")));
 #else
-        m_turn_timeout.expires_from_now(std::chrono::seconds(GetOptionsDB().Get<int>("network.server.turn-timeout.interval")));
+        m_turn_timeout.expires_from_now(std::chrono::seconds(GetOptionsDB().Get<int>("network.server.turn-timeout.max-interval")));
 #endif
         m_turn_timeout.async_wait(boost::bind(&PlayingGame::TurnTimedoutHandler,
                                               this,
@@ -2850,14 +2850,14 @@ void PlayingGame::TurnTimedoutHandler(const boost::system::error_code& error) {
     }
 
     if (GetOptionsDB().Get<bool>("network.server.turn-timeout.fixed-interval") &&
-        GetOptionsDB().Get<int>("network.server.turn-timeout.interval") > 0)
+        GetOptionsDB().Get<int>("network.server.turn-timeout.max-interval") > 0)
     {
 #if BOOST_VERSION >= 106600
         auto turn_expired_time = m_turn_timeout.expiry();
 #else
         auto turn_expired_time = m_turn_timeout.expires_at();
 #endif
-        turn_expired_time += std::chrono::seconds(GetOptionsDB().Get<int>("network.server.turn-timeout.interval"));
+        turn_expired_time += std::chrono::seconds(GetOptionsDB().Get<int>("network.server.turn-timeout.max-interval"));
         m_turn_timeout.expires_at(turn_expired_time);
         m_turn_timeout.async_wait(boost::bind(&PlayingGame::TurnTimedoutHandler,
                                               this,
@@ -2891,11 +2891,11 @@ WaitingForTurnEnd::WaitingForTurnEnd(my_context c) :
     if (!GetOptionsDB().Get<bool>("network.server.turn-timeout.fixed-interval")) {
         auto& playing_game = context<PlayingGame>();
         playing_game.m_turn_timeout.cancel();
-        if (GetOptionsDB().Get<int>("network.server.turn-timeout.interval") > 0) {
+        if (GetOptionsDB().Get<int>("network.server.turn-timeout.max-interval") > 0) {
 #if BOOST_VERSION >= 106600
-            playing_game.m_turn_timeout.expires_after(std::chrono::seconds(GetOptionsDB().Get<int>("network.server.turn-timeout.interval")));
+            playing_game.m_turn_timeout.expires_after(std::chrono::seconds(GetOptionsDB().Get<int>("network.server.turn-timeout.max-interval")));
 #else
-            playing_game.m_turn_timeout.expires_from_now(std::chrono::seconds(GetOptionsDB().Get<int>("network.server.turn-timeout.interval")));
+            playing_game.m_turn_timeout.expires_from_now(std::chrono::seconds(GetOptionsDB().Get<int>("network.server.turn-timeout.max-interval")));
 #endif
             playing_game.m_turn_timeout.async_wait(boost::bind(&PlayingGame::TurnTimedoutHandler,
                                                                &playing_game,

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -2490,11 +2490,7 @@ PlayingGame::PlayingGame(my_context c) :
 
     if (GetOptionsDB().Get<int>("network.server.turn-timeout.max-interval") > 0) {
         // Set turn advance after time interval
-#if BOOST_VERSION >= 106600
-        m_turn_timeout.expires_after(boost::posix_time::seconds(GetOptionsDB().Get<int>("network.server.turn-timeout.max-interval")));
-#else
         m_turn_timeout.expires_from_now(boost::posix_time::seconds(GetOptionsDB().Get<int>("network.server.turn-timeout.max-interval")));
-#endif
         m_turn_timeout.async_wait(boost::bind(&PlayingGame::TurnTimedoutHandler,
                                               this,
                                               boost::asio::placeholders::error));
@@ -2862,11 +2858,7 @@ void PlayingGame::TurnTimedoutHandler(const boost::system::error_code& error) {
     if (GetOptionsDB().Get<bool>("network.server.turn-timeout.fixed-interval") &&
         GetOptionsDB().Get<int>("network.server.turn-timeout.max-interval") > 0)
     {
-#if BOOST_VERSION >= 106600
-        auto turn_expired_time = m_turn_timeout.expiry();
-#else
         auto turn_expired_time = m_turn_timeout.expires_at();
-#endif
         turn_expired_time += boost::posix_time::seconds(GetOptionsDB().Get<int>("network.server.turn-timeout.max-interval"));
         m_turn_timeout.expires_at(turn_expired_time);
         m_turn_timeout.async_wait(boost::bind(&PlayingGame::TurnTimedoutHandler,
@@ -2902,11 +2894,7 @@ WaitingForTurnEnd::WaitingForTurnEnd(my_context c) :
         auto& playing_game = context<PlayingGame>();
         playing_game.m_turn_timeout.cancel();
         if (GetOptionsDB().Get<int>("network.server.turn-timeout.max-interval") > 0) {
-#if BOOST_VERSION >= 106600
-            playing_game.m_turn_timeout.expires_after(boost::posix_time::seconds(GetOptionsDB().Get<int>("network.server.turn-timeout.max-interval")));
-#else
             playing_game.m_turn_timeout.expires_from_now(boost::posix_time::seconds(GetOptionsDB().Get<int>("network.server.turn-timeout.max-interval")));
-#endif
             playing_game.m_turn_timeout.async_wait(boost::bind(&PlayingGame::TurnTimedoutHandler,
                                                                &playing_game,
                                                                boost::asio::placeholders::error));

--- a/server/ServerFSM.h
+++ b/server/ServerFSM.h
@@ -13,6 +13,7 @@
 #include <boost/statechart/state.hpp>
 #include <boost/statechart/state_machine.hpp>
 #include <boost/asio/high_resolution_timer.hpp>
+#include <boost/asio/deadline_timer.hpp>
 
 #include <memory>
 #include <set>
@@ -321,7 +322,7 @@ struct PlayingGame : sc::state<PlayingGame, ServerFSM, WaitingForTurnEnd> {
                          const Networking::AuthRoles& roles);
     void TurnTimedoutHandler(const boost::system::error_code& error);
 
-    boost::asio::high_resolution_timer m_turn_timeout;
+    boost::asio::deadline_timer m_turn_timeout;
 
     SERVER_ACCESSOR
 };

--- a/server/ServerFSM.h
+++ b/server/ServerFSM.h
@@ -319,6 +319,9 @@ struct PlayingGame : sc::state<PlayingGame, ServerFSM, WaitingForTurnEnd> {
                          Networking::ClientType client_type,
                          const std::string& client_version_string,
                          const Networking::AuthRoles& roles);
+    void TurnTimedoutHandler(const boost::system::error_code& error);
+
+    boost::asio::high_resolution_timer m_turn_timeout;
 
     SERVER_ACCESSOR
 };

--- a/server/dmain.cpp
+++ b/server/dmain.cpp
@@ -63,7 +63,7 @@ int wmain(int argc, wchar_t* argv[], wchar_t* envp[]) {
         GetOptionsDB().Add<int>("network.server.cookies.expire-minutes", UserStringNop("OPTIONS_DB_COOKIES_EXPIRE"), 15);
         GetOptionsDB().Add<bool>("network.server.publish-statistics", UserStringNop("OPTIONS_DB_PUBLISH_STATISTICS"), true);
         GetOptionsDB().Add("network.server.binary.enabled", UserStringNop("OPTIONS_DB_SERVER_BINARY_SERIALIZATION"), true);
-        GetOptionsDB().Add<long>("network.server.turn-timeout.first-turn-time", UserStringNop("OPTIONS_DB_FIRST_TURN_TIME"), 0);
+        GetOptionsDB().Add<std::string>("network.server.turn-timeout.first-turn-time", UserStringNop("OPTIONS_DB_FIRST_TURN_TIME"), "");
         GetOptionsDB().Add<int>("network.server.turn-timeout.max-interval", UserStringNop("OPTIONS_DB_TIMEOUT_INTERVAL"), 0);
         GetOptionsDB().Add<bool>("network.server.turn-timeout.fixed-interval", UserStringNop("OPTIONS_DB_TIMEOUT_FIXED_INTERVAL"), false);
 

--- a/server/dmain.cpp
+++ b/server/dmain.cpp
@@ -64,7 +64,7 @@ int wmain(int argc, wchar_t* argv[], wchar_t* envp[]) {
         GetOptionsDB().Add<bool>("network.server.publish-statistics", UserStringNop("OPTIONS_DB_PUBLISH_STATISTICS"), true);
         GetOptionsDB().Add("network.server.binary.enabled", UserStringNop("OPTIONS_DB_SERVER_BINARY_SERIALIZATION"), true);
         GetOptionsDB().Add<long>("network.server.turn-timeout.first-turn-time", UserStringNop("OPTIONS_DB_FIRST_TURN_TIME"), 0);
-        GetOptionsDB().Add<int>("network.server.turn-timeout.interval", UserStringNop("OPTIONS_DB_TIMEOUT_INTERVAL"), 0);
+        GetOptionsDB().Add<int>("network.server.turn-timeout.max-interval", UserStringNop("OPTIONS_DB_TIMEOUT_INTERVAL"), 0);
         GetOptionsDB().Add<bool>("network.server.turn-timeout.fixed-interval", UserStringNop("OPTIONS_DB_TIMEOUT_FIXED_INTERVAL"), false);
 
         // if config.xml and persistent_config.xml are present, read and set options entries

--- a/server/dmain.cpp
+++ b/server/dmain.cpp
@@ -63,6 +63,9 @@ int wmain(int argc, wchar_t* argv[], wchar_t* envp[]) {
         GetOptionsDB().Add<int>("network.server.cookies.expire-minutes", UserStringNop("OPTIONS_DB_COOKIES_EXPIRE"), 15);
         GetOptionsDB().Add<bool>("network.server.publish-statistics", UserStringNop("OPTIONS_DB_PUBLISH_STATISTICS"), true);
         GetOptionsDB().Add("network.server.binary.enabled", UserStringNop("OPTIONS_DB_SERVER_BINARY_SERIALIZATION"), true);
+        GetOptionsDB().Add<long>("network.server.turn-timeout.first-turn-time", UserStringNop("OPTIONS_DB_FIRST_TURN_TIME"), 0);
+        GetOptionsDB().Add<int>("network.server.turn-timeout.interval", UserStringNop("OPTIONS_DB_TIMEOUT_INTERVAL"), 0);
+        GetOptionsDB().Add<bool>("network.server.turn-timeout.fixed-interval", UserStringNop("OPTIONS_DB_TIMEOUT_FIXED_INTERVAL"), false);
 
         // if config.xml and persistent_config.xml are present, read and set options entries
         GetOptionsDB().SetFromFile(GetConfigPath(), FreeOrionVersionString());

--- a/test/system/ClientAppFixture.cpp
+++ b/test/system/ClientAppFixture.cpp
@@ -194,6 +194,7 @@ bool ClientAppFixture::HandleMessage(Message& msg) {
     case Message::DIPLOMATIC_STATUS:
     case Message::PLAYER_CHAT:
     case Message::CHAT_HISTORY:
+    case Message::TURN_TIMEOUT:
         return true; // ignore
     case Message::PLAYER_STATUS: {
         int about_empire_id;


### PR DESCRIPTION
This PR add three options to manage turn timeout:

* `network.server.turn-timeout.first-turn-time` - absolute time in format "2002-01-20 23:59:59" when first turn advance occured. Requires `fixed-interval` to be enabled
* `network.server.turn-timeout.max-interval` - maximum interval in seconds between two subsequent turn advances
* `network.server.turn-timeout.fixed-interval` - if enabled intervals should be strictly equals to have predicted turn advance time. Without it turn interval could be shorter if all players are ready or longer if turn processing time exceeds timeout.

Each new turn or for each new player connection it sends TURN_TIMEOUT message with seconds remaining before turn advance or 0, if disabled.

New UI control shows remain time and update it each second: ![fo-timeout](https://user-images.githubusercontent.com/397177/57274909-5fc26180-70a5-11e9-8b92-e3347b0067e2.png)

This PR doesn't allow to edit option.

Forum thread: https://freeorion.org/forum/viewtopic.php?f=9&t=11234