### PR TITLE
Clean orders only on turn update

### DIFF
--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -328,6 +328,7 @@ void AIClientApp::HandleMessage(const Message& msg) {
         break;
 
     case Message::TURN_UPDATE: {
+        m_orders.Reset();
         //DebugLogger() << "AIClientApp::HandleMessage : extracting turn update message data";
         ExtractTurnUpdateMessageData(msg,                     m_empire_id,        m_current_turn,
                                      m_empires,               m_universe,         GetSpeciesManager(),

--- a/client/ClientApp.cpp
+++ b/client/ClientApp.cpp
@@ -130,23 +130,6 @@ void ClientApp::SendPartialOrders() {
 }
 
 void ClientApp::HandleTurnPhaseUpdate(Message::TurnProgressPhase phase_id) {
-    switch (phase_id) {
-    case Message::WAITING_FOR_PLAYERS:
-        // Orders have been received by server, so clear the orders.
-        m_orders.Reset();
-        break;
-    case Message::FLEET_MOVEMENT:
-    case Message::COMBAT:
-    case Message::EMPIRE_PRODUCTION:
-    case Message::PROCESSING_ORDERS:
-    case Message::COLONIZE_AND_SCRAP:
-    case Message::DOWNLOADING:
-    case Message::LOADING_GAME:
-    case Message::GENERATING_UNIVERSE:
-    case Message::STARTING_AIS:
-    default:
-        break;
-    }
 }
 
 OrderSet& ClientApp::Orders()

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -895,6 +895,7 @@ boost::statechart::result WaitingForTurnData::react(const TurnUpdate& msg) {
     TraceLogger(FSM) << "(HumanClientFSM) PlayingGame.TurnUpdate";
 
     int current_turn = INVALID_GAME_TURN;
+    Client().Orders().Reset();
 
     try {
         ExtractTurnUpdateMessageData(msg.m_message,           Client().EmpireID(),    current_turn,

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -3006,7 +3006,8 @@ sc::result WaitingForTurnEnd::react(const TurnOrders& msg) {
             }
         }
 
-        TraceLogger(FSM) << "WaitingForTurnEnd.TurnOrders : Received orders from player " << player_id;
+        DebugLogger(FSM) << "WaitingForTurnEnd.TurnOrders : Received orders from player " << player_id
+                         << " for empire " << empire_id << " count of " << order_set->size();
 
         server.SetEmpireSaveGameData(empire_id, boost::make_unique<PlayerSaveGameData>(sender->PlayerName(), empire_id,
                                      order_set, ui_data, save_state_string,


### PR DESCRIPTION
Fixes repeated use of Revise Orders.

Fixes #2451 