### PR TITLE
extend UI to notify player about diplomatic changes

### DIFF
--- a/UI/ChatWnd.cpp
+++ b/UI/ChatWnd.cpp
@@ -487,6 +487,18 @@ void MessageWnd::HandlePlayerChatMessage(const std::string& text,
 
     *m_display += wrapped_text + "\n";
     m_display_show_time = GG::GUI::GetGUI()->Ticks();
+
+    // if client empire is target of message, show message window
+    const ClientApp* app = ClientApp::GetApp();
+    if (!app) {
+        ErrorLogger() << "MessageWnd::HandleDiplomaticStatusChange couldn't get client app!";
+        return;
+    }
+    int client_empire_id = app->EmpireID();  
+    if (recipient_player_id == client_empire_id) {
+        Flash();
+        Show();
+    }
 }
 
 void MessageWnd::HandleTurnPhaseUpdate(Message::TurnProgressPhase phase_id, bool prefixed /*= false*/) {
@@ -548,10 +560,39 @@ void MessageWnd::HandleLogMessage(const std::string& text) {
 void MessageWnd::HandleDiplomaticStatusChange(int empire1_id, int empire2_id) {
     const ClientApp* app = ClientApp::GetApp();
     if (!app) {
-        ErrorLogger() << "PlayerListWnd::PlayerRightClicked couldn't get client app!";
+        ErrorLogger() << "MessageWnd::HandleDiplomaticStatusChange couldn't get client app!";
         return;
     }
+
     int client_empire_id = app->EmpireID();
+    DiplomaticStatus status = Empires().GetDiplomaticStatus(empire1_id, empire2_id);
+    std::string text;
+
+    const Empire* empire1 = GetEmpire(empire1_id);
+    const Empire* empire2 = GetEmpire(empire2_id);
+
+    std::string empire1_str = GG::RgbaTag(empire1->Color()) + empire1->Name() + "</rgba>";
+    std::string empire2_str = GG::RgbaTag(empire2->Color()) + empire2->Name() + "</rgba>";
+
+    switch (status) {
+    case DIPLO_WAR:
+        text = boost::str(FlexibleFormat(UserString("MESSAGES_WAR_DECLARATION"))
+                   % empire1_str % empire2_str);
+        break;
+    case DIPLO_PEACE:
+        text = boost::str(FlexibleFormat(UserString("MESSAGES_PEACE_TREATY"))
+                   % empire1_str % empire2_str);
+        break;
+    case DIPLO_ALLIED:
+        text = boost::str(FlexibleFormat(UserString("MESSAGES_ALLIANCE"))
+                   % empire1_str % empire2_str);
+        break;
+    default:
+        ErrorLogger() << "MessageWnd::HandleDiplomaticStatusChange: no valid diplomatic status found.";
+    }
+
+    *m_display += text;
+    m_display_show_time = GG::GUI::GetGUI()->Ticks();
 
     // if client empire is target of diplomatic status change, show message window
     if (empire2_id == client_empire_id) {
@@ -640,6 +681,7 @@ void MessageWnd::MessageEntered() {
     }
 
     m_edit->Clear();
+    StopFlash();
 }
 
 void MessageWnd::MessageHistoryUpRequested() {

--- a/UI/ChatWnd.cpp
+++ b/UI/ChatWnd.cpp
@@ -491,7 +491,7 @@ void MessageWnd::HandlePlayerChatMessage(const std::string& text,
     // if client empire is target of message, show message window
     const ClientApp* app = ClientApp::GetApp();
     if (!app) {
-        ErrorLogger() << "MessageWnd::HandleDiplomaticStatusChange couldn't get client app!";
+        ErrorLogger() << "MessageWnd::HandlePlayerChatMessage couldn't get client app!";
         return;
     }
     int client_empire_id = app->EmpireID();  

--- a/UI/ChatWnd.cpp
+++ b/UI/ChatWnd.cpp
@@ -429,8 +429,8 @@ void MessageWnd::CompleteConstruction() {
 
     m_history.push_front("");
 
-     Empires().DiplomaticStatusChangedSignal.connect(
-         boost::bind(&MessageWnd::HandleDiplomaticStatusChange, this, _1, _2));
+    Empires().DiplomaticStatusChangedSignal.connect(
+        boost::bind(&MessageWnd::HandleDiplomaticStatusChange, this, _1, _2));
 
     DoLayout();
     SaveDefaultedOptions();
@@ -553,8 +553,8 @@ void MessageWnd::HandleDiplomaticStatusChange(int empire1_id, int empire2_id) {
     }
     int client_empire_id = app->EmpireID();
 
-    // if client empire is concerned by diplomatic status change, show message window
-    if ((empire1_id == client_empire_id) || (empire2_id == client_empire_id)) {
+    // if client empire is target of diplomatic status change, show message window
+    if (empire2_id == client_empire_id) {
         Flash();
         Show();
     }

--- a/UI/ChatWnd.cpp
+++ b/UI/ChatWnd.cpp
@@ -591,7 +591,7 @@ void MessageWnd::HandleDiplomaticStatusChange(int empire1_id, int empire2_id) {
         ErrorLogger() << "MessageWnd::HandleDiplomaticStatusChange: no valid diplomatic status found.";
     }
 
-    *m_display += text;
+    *m_display += text + "\n";
     m_display_show_time = GG::GUI::GetGUI()->Ticks();
 
     // if client empire is target of diplomatic status change, show message window

--- a/UI/ChatWnd.h
+++ b/UI/ChatWnd.h
@@ -31,6 +31,7 @@ public:
     void            HandleTurnPhaseUpdate(Message::TurnProgressPhase phase_id, bool prefixed = false);
     void            HandleGameStatusUpdate(const std::string& text);
     void            HandleLogMessage(const std::string& text);
+    void            HandleDiplomaticStatusChange(int empire1_id, int empire2_id);
     void            Clear();
     void            OpenForInput();
     //@}
@@ -44,7 +45,8 @@ public:
     mutable boost::signals2::signal<void ()> ClosingSignal;
 
 private:
-    void CloseClicked() override;
+    void            CloseClicked() override;
+    void            LClick(const GG::Pt& pt, GG::Flags<GG::ModKey> mod_keys) override;
 
     void            DoLayout();
     void            MessageEntered();

--- a/UI/PlayerListWnd.cpp
+++ b/UI/PlayerListWnd.cpp
@@ -809,7 +809,6 @@ void PlayerListWnd::HandleDiplomaticMessageChange(int empire1_id, int empire2_id
 
     if (!active_message)
         StopFlash();
-
 }
 
 

--- a/UI/PlayerListWnd.cpp
+++ b/UI/PlayerListWnd.cpp
@@ -907,6 +907,9 @@ void PlayerListWnd::CloseClicked() {
     StopFlash();
 }
 
+void PlayerListWnd::LClick(const GG::Pt& pt, GG::Flags<GG::ModKey> mod_keys)
+{ StopFlash(); }
+
 void PlayerListWnd::PlayerSelectionChanged(const GG::ListBox::SelectionSet& rows) {
     // mark as selected all PlayerDataPanel that are in \a rows and mark as not
     // selected all PlayerDataPanel that aren't in \a rows

--- a/UI/PlayerListWnd.cpp
+++ b/UI/PlayerListWnd.cpp
@@ -25,6 +25,12 @@ namespace {
         static std::shared_ptr<GG::Texture> retval = ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "ai.png");
         return retval;
     }
+
+    std::shared_ptr<GG::Texture> MessageIcon() {
+        static std::shared_ptr<GG::Texture> retval = ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "buttons" / "messages.png");
+        return retval;
+    }
+
     std::shared_ptr<GG::Texture> HumanIcon() {
         static std::shared_ptr<GG::Texture> retval = ClientUI::GetTexture(ClientUI::ArtDir() / "icons" / "human.png");
         return retval;
@@ -325,6 +331,12 @@ namespace {
                 }
             }
 
+            // render incoming diplomatic message icon, if there is one
+            const DiplomaticMessage& incoming_message_to_client =
+                Empires().GetDiplomaticMessage(m_player_id, app->PlayerID());
+            if (incoming_message_to_client.GetType() != DiplomaticMessage::INVALID_DIPLOMATIC_MESSAGE_TYPE)
+                MessageIcon()->OrthoBlit(UpperLeft() + m_diplo_msg_ul, UpperLeft() + m_diplo_msg_ul + ICON_SIZE);
+
             // render player status icon
             switch (m_player_status) {
             case Message::PLAYING_TURN:     PlayingIcon()->OrthoBlit(UpperLeft() + m_player_status_icon_ul, UpperLeft() + m_player_status_icon_ul + ICON_SIZE); break;
@@ -513,6 +525,9 @@ namespace {
             m_diplo_status_icon_ul = GG::Pt(left, top);
             left += GG::X(IconSize()) + PAD;
 
+            m_diplo_msg_ul = GG::Pt(left, top);
+            left += GG::X(IconSize());
+
             //m_player_name_text->SizeMove(GG::Pt(left, top), GG::Pt(left + PLAYER_NAME_WIDTH, bottom));
             //left += PLAYER_NAME_WIDTH;
 
@@ -587,6 +602,7 @@ namespace {
         std::shared_ptr<DiplomaticStatusIndicator> m_allied_indicator;
 
         GG::Pt                  m_diplo_status_icon_ul;
+        GG::Pt                  m_diplo_msg_ul;
         GG::Pt                  m_ship_icon_ul;
         GG::Pt                  m_planet_icon_ul;
         GG::Pt                  m_production_icon_ul;

--- a/UI/PlayerListWnd.cpp
+++ b/UI/PlayerListWnd.cpp
@@ -746,7 +746,7 @@ void PlayerListWnd::CompleteConstruction() {
     Empires().DiplomaticStatusChangedSignal.connect(
         boost::bind(&PlayerListWnd::Update, this));
     Empires().DiplomaticMessageChangedSignal.connect(
-        boost::bind(&PlayerListWnd::Update, this));
+        boost::bind(&PlayerListWnd::PlayerListWnd::HandleDiplomaticMessageChange, this, _1, _2));
     DoLayout();
 
     Refresh();
@@ -777,6 +777,21 @@ void PlayerListWnd::HandleEmpireStatusUpdate(Message::PlayerStatus player_status
         }
     }
 }
+
+void PlayerListWnd::HandleDiplomaticMessageChange(int empire1_id, int empire2_id) {
+    Update();
+
+    const ClientApp* app = ClientApp::GetApp();
+    if (!app) {
+        ErrorLogger() << "PlayerListWnd::HandleDiplomaticMessageChange couldn't get client app!";
+        return;
+    }
+
+    // only show PlayerListWnd if player is affected
+    if ((empire1_id == app->PlayerID()) || (empire2_id == app->PlayerID()))
+        Show();
+}
+
 
 void PlayerListWnd::Update() {
     for (auto& row : *m_player_list) {

--- a/UI/PlayerListWnd.h
+++ b/UI/PlayerListWnd.h
@@ -35,7 +35,8 @@ public:
     mutable boost::signals2::signal<void ()>    ClosingSignal;
 
 private:
-    void CloseClicked() override;
+    void            CloseClicked() override;
+    void            LClick(const GG::Pt& pt, GG::Flags<GG::ModKey> mod_keys) override;
 
     void            DoLayout();
 

--- a/UI/PlayerListWnd.h
+++ b/UI/PlayerListWnd.h
@@ -22,6 +22,7 @@ public:
     void SizeMove(const GG::Pt& ul, const GG::Pt& lr) override;
 
     void            HandleEmpireStatusUpdate(Message::PlayerStatus player_status, int about_empire_id);
+    void            HandleDiplomaticMessageChange(int empire1_id, int empire2_id);
     void            Update();
     void            Refresh();
     void            Clear();

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -6188,7 +6188,7 @@ MESSAGES_WAR_DECLARATION
 %1 and %2 are now at war.
 
 MESSAGES_PEACE_TREATY
-%1 and %2 have signed a peace treaty.
+%1 and %2 are now at peace.
 
 MESSAGES_ALLIANCE
 %1 and %2 have entered an alliance.

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -6184,17 +6184,17 @@ Received unexpected turn update from server.
 MESSAGES_PANEL_TITLE
 Messages
 
-# %1% and %2% are empire names
+# %1% and %2% are color coded empire names
 MESSAGES_WAR_DECLARATION
-<rgba 255 0 0 255>%1% and %2% are now at war.
+%1% and %2% are now at war.
 
-# %1% and %2% are empire names
+# %1% and %2% are color coded empire names
 MESSAGES_PEACE_TREATY
-<rgba 0 0 255 255>%1% and %2% are now at peace.
+%1% and %2% are now at peace.
 
-# %1% and %2% are empire names
+# %1% and %2% are color coded empire names
 MESSAGES_ALLIANCE
-<rgba 0 255 0 255>%1% and %2% have entered an alliance.
+%1% and %2% have entered an alliance.
 
 
 ##

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -6184,6 +6184,15 @@ Received unexpected turn update from server.
 MESSAGES_PANEL_TITLE
 Messages
 
+MESSAGES_WAR_DECLARATION
+%1 and %2 are now at war.
+
+MESSAGES_PEACE_TREATY
+%1 and %2 have signed a peace treaty.
+
+MESSAGES_ALLIANCE
+%1 and %2 have entered an alliance.
+
 
 ##
 ## Players list

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -6184,14 +6184,17 @@ Received unexpected turn update from server.
 MESSAGES_PANEL_TITLE
 Messages
 
+# %1% and %2% are empire names
 MESSAGES_WAR_DECLARATION
-%1 and %2 are now at war.
+<rgba 255 0 0 255>%1% and %2% are now at war.
 
+# %1% and %2% are empire names
 MESSAGES_PEACE_TREATY
-%1 and %2 are now at peace.
+<rgba 0 0 255 255>%1% and %2% are now at peace.
 
+# %1% and %2% are empire names
 MESSAGES_ALLIANCE
-%1 and %2 have entered an alliance.
+<rgba 0 255 0 255>%1% and %2% have entered an alliance.
 
 
 ##

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -70,16 +70,6 @@ namespace {
         }
         return ALL_EMPIRES;
     }
-
-    std::string ColorToRgbTag(const GG::Clr color) {
-        std::string color_str = "<rgba ";
-        color_str += std::to_string(color.r) + " ";
-        color_str += std::to_string(color.g) + " ";
-        color_str += std::to_string(color.b) + " ";
-        color_str += std::to_string(color.a) + ">";
-
-        return color_str;
-    }
 };
 
 
@@ -3651,42 +3641,11 @@ void ServerApp::HandleDiplomaticStatusChange(int empire1_id, int empire2_id) {
     DiplomaticStatus status = Empires().GetDiplomaticStatus(empire1_id, empire2_id);
     DiplomaticStatusUpdateInfo update(empire1_id, empire2_id, status);
 
-    boost::posix_time::ptime timestamp = boost::posix_time::second_clock::universal_time();
-    std::string text;
-
-    const Empire* empire1 = GetEmpire(empire1_id);
-    const Empire* empire2 = GetEmpire(empire2_id);
-
-    std::string empire1_clr_str = ColorToRgbTag(empire1->Color());
-    std::string empire2_clr_str = ColorToRgbTag(empire2->Color());
-    std::string white_clr_str = "<rgba 255 255 255 255>";
-
-    switch (status) {
-    case DIPLO_WAR:
-        text = "[[MESSAGES_WAR_DECLARATION,"
-            + empire1_clr_str + empire1->Name() + white_clr_str + ","
-            + empire2_clr_str + empire2->Name() + white_clr_str + "]]";
-        break;
-    case DIPLO_PEACE:
-        text = "[[MESSAGES_PEACE_TREATY,"
-            + empire1_clr_str + empire1->Name() + white_clr_str + ","
-            + empire2_clr_str + empire2->Name() + white_clr_str + "]]";
-        break;
-    case DIPLO_ALLIED:
-        text = "[[MESSAGES_ALLIANCE,"
-            + empire1_clr_str + empire1->Name() + white_clr_str + ","
-            + empire2_clr_str + empire2->Name() + white_clr_str + "]]";
-        break;
-    default:
-        ErrorLogger() << "ServerApp::HandleDiplomaticStatusChange: no valid diplomatic status found.";
-    }
-
     for (auto player_it = m_networking.established_begin();
          player_it != m_networking.established_end(); ++player_it)
     {
         PlayerConnectionPtr player = *player_it;
         player->SendMessage(DiplomaticStatusMessage(update));
-        player->SendMessage(ServerPlayerChatMessage(Networking::INVALID_PLAYER_ID, timestamp, text));
     }
 }
 

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -70,6 +70,16 @@ namespace {
         }
         return ALL_EMPIRES;
     }
+
+    std::string ColorToRgbTag(const GG::Clr color) {
+        std::string color_str = "<rgba ";
+        color_str += std::to_string(color.r) + " ";
+        color_str += std::to_string(color.g) + " ";
+        color_str += std::to_string(color.b) + " ";
+        color_str += std::to_string(color.a) + ">";
+
+        return color_str;
+    }
 };
 
 
@@ -3644,21 +3654,28 @@ void ServerApp::HandleDiplomaticStatusChange(int empire1_id, int empire2_id) {
     boost::posix_time::ptime timestamp = boost::posix_time::second_clock::universal_time();
     std::string text;
 
+    const Empire* empire1 = GetEmpire(empire1_id);
+    const Empire* empire2 = GetEmpire(empire2_id);
+
+    std::string empire1_clr_str = ColorToRgbTag(empire1->Color());
+    std::string empire2_clr_str = ColorToRgbTag(empire2->Color());
+    std::string white_clr_str = "<rgba 255 255 255 255>";
+
     switch (status) {
     case DIPLO_WAR:
         text = "[[MESSAGES_WAR_DECLARATION,"
-            + GetEmpire(empire1_id)->Name() + ","
-            + GetEmpire(empire2_id)->Name() + "]]";
+            + empire1_clr_str + empire1->Name() + white_clr_str + ","
+            + empire2_clr_str + empire2->Name() + white_clr_str + "]]";
         break;
     case DIPLO_PEACE:
         text = "[[MESSAGES_PEACE_TREATY,"
-            + GetEmpire(empire1_id)->Name() + ","
-            + GetEmpire(empire2_id)->Name() + "]]";
+            + empire1_clr_str + empire1->Name() + white_clr_str + ","
+            + empire2_clr_str + empire2->Name() + white_clr_str + "]]";
         break;
     case DIPLO_ALLIED:
         text = "[[MESSAGES_ALLIANCE,"
-            + GetEmpire(empire1_id)->Name() + ","
-            + GetEmpire(empire2_id)->Name() + "]]";
+            + empire1_clr_str + empire1->Name() + white_clr_str + ","
+            + empire2_clr_str + empire2->Name() + white_clr_str + "]]";
         break;
     default:
         ErrorLogger() << "ServerApp::HandleDiplomaticStatusChange: no valid diplomatic status found.";

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -3641,11 +3641,35 @@ void ServerApp::HandleDiplomaticStatusChange(int empire1_id, int empire2_id) {
     DiplomaticStatus status = Empires().GetDiplomaticStatus(empire1_id, empire2_id);
     DiplomaticStatusUpdateInfo update(empire1_id, empire2_id, status);
 
+    boost::posix_time::ptime timestamp = boost::posix_time::second_clock::universal_time();
+    std::string text;
+
+    switch (status) {
+    case DIPLO_WAR:
+        text = "[[" + boost::str(FlexibleFormat(UserString("MESSAGES_WAR_DECLARATION"))
+            % GetEmpire(empire1_id)->Name()
+            % GetEmpire(empire2_id)->Name()) + "]]";
+        break;
+    case DIPLO_PEACE:
+        text = "[[" + boost::str(FlexibleFormat(UserString("MESSAGES_PEACE_TREATY"))
+            % GetEmpire(empire1_id)->Name()
+            % GetEmpire(empire2_id)->Name()) + "]]";
+        break;
+    case DIPLO_ALLIED:
+        text = "[[" + boost::str(FlexibleFormat(UserString("MESSAGES_ALLIANCE"))
+            % GetEmpire(empire1_id)->Name()
+            % GetEmpire(empire2_id)->Name()) + "]]";
+        break;
+    default:
+        ErrorLogger() << "ServerApp::HandleDiplomaticStatusChange: no valid diplomatic status found.";
+    }
+
     for (auto player_it = m_networking.established_begin();
          player_it != m_networking.established_end(); ++player_it)
     {
         PlayerConnectionPtr player = *player_it;
         player->SendMessage(DiplomaticStatusMessage(update));
+        player->SendMessage(ServerPlayerChatMessage(Networking::INVALID_PLAYER_ID, timestamp, text));
     }
 }
 

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -3646,19 +3646,19 @@ void ServerApp::HandleDiplomaticStatusChange(int empire1_id, int empire2_id) {
 
     switch (status) {
     case DIPLO_WAR:
-        text = "[[" + boost::str(FlexibleFormat(UserString("MESSAGES_WAR_DECLARATION"))
-            % GetEmpire(empire1_id)->Name()
-            % GetEmpire(empire2_id)->Name()) + "]]";
+        text = "[[MESSAGES_WAR_DECLARATION,"
+            + GetEmpire(empire1_id)->Name() + ","
+            + GetEmpire(empire2_id)->Name() + "]]";
         break;
     case DIPLO_PEACE:
-        text = "[[" + boost::str(FlexibleFormat(UserString("MESSAGES_PEACE_TREATY"))
-            % GetEmpire(empire1_id)->Name()
-            % GetEmpire(empire2_id)->Name()) + "]]";
+        text = "[[MESSAGES_PEACE_TREATY,"
+            + GetEmpire(empire1_id)->Name() + ","
+            + GetEmpire(empire2_id)->Name() + "]]";
         break;
     case DIPLO_ALLIED:
-        text = "[[" + boost::str(FlexibleFormat(UserString("MESSAGES_ALLIANCE"))
-            % GetEmpire(empire1_id)->Name()
-            % GetEmpire(empire2_id)->Name()) + "]]";
+        text = "[[MESSAGES_ALLIANCE,"
+            + GetEmpire(empire1_id)->Name() + ","
+            + GetEmpire(empire2_id)->Name() + "]]";
         break;
     default:
         ErrorLogger() << "ServerApp::HandleDiplomaticStatusChange: no valid diplomatic status found.";


### PR DESCRIPTION
Features:
- adds a "mail" icon to the player list window, positioned to the right of the diplomatic status icon, if a diplomatic offer has been received (that needs answering) and
- opens PlayerListWnd that flashes until the offer has been accepted or rejected
- sends message to all players when diplomatic status between any empires has changed, and
- opens ChatWnd that flashes if client player is affected by the diplomatic status change
- opens ChatWnd that flashes if client player received a message