### PR TITLE
Fix AI fuel tank ship design

### DIFF
--- a/default/python/AI/AIDependencies.py
+++ b/default/python/AI/AIDependencies.py
@@ -340,6 +340,15 @@ DEFENSE_SHIELDS_TECHS = [
 ]
 # </editor-fold>
 
+# <editor-fold desc="Fuel techs">
+FUEL_TANK_UPGRADE_DICT = {
+    # "PARTNAME": tuple((tech_name, fuel_upgrade), (tech_name2, fuel_upgrade2), ...)
+    "FU_BASIC_TANK": (("SHP_DEUTERIUM_TANK", 1), ("SHP_ANTIMATTER_TANK", 3)),
+    "FU_RAMSCOOP": (),
+    "FU_ZERO_FUEL": (),
+}
+# </editor-fold>
+
 # <editor-fold desc="Weapon techs">
 # TODO (Morlic): Consider using only 1 dict with (capacity, secondaryStat) tuple as entries
 WEAPON_UPGRADE_DICT = {

--- a/default/python/AI/AIDependencies.py
+++ b/default/python/AI/AIDependencies.py
@@ -779,6 +779,9 @@ HULL_EFFECTS = {
     "SH_ROBOTIC": {
         REPAIR_PER_TURN: 2,
     },
+    "SH_SPACE_FLUX_BUBBLE": {
+        STEALTH_MODIFIER: -30,
+    },
     "SH_SPATIAL_FLUX": {
         STEALTH_MODIFIER: -30,
     },

--- a/default/python/AI/ShipDesignAI.py
+++ b/default/python/AI/ShipDesignAI.py
@@ -1004,7 +1004,7 @@ class ShipDesigner(object):
                 self.design_stats.detection += AIDependencies.BASE_DETECTION
 
         # TODO establish framework for conditional effects and get rid of this
-        if self.hull.name == "SH_SPATIAL_FLUX":
+        if self.hull.name in ["SH_SPATIAL_FLUX", "SH_SPACE_FLUX_BUBBLE"]:
             self.design_stats.stealth += 10
             relevant_stealth_techs = [
                 "SPY_STEALTH_PART_1", "SPY_STEALTH_PART_2",

--- a/default/python/AI/ShipDesignAI.py
+++ b/default/python/AI/ShipDesignAI.py
@@ -865,7 +865,7 @@ class ShipDesigner(object):
             partclass = part.partClass
             capacity = part.capacity if partclass not in WEAPONS else self._calculate_weapon_strength(part)
             if partclass in FUEL:
-                self.design_stats.fuel += capacity
+                self.design_stats.fuel += self._calculate_fuel_capacity(part)
             elif partclass in ENGINES:
                 engine_counter += 1
                 if engine_counter == 1:
@@ -1537,6 +1537,14 @@ class ShipDesigner(object):
         :rtype: bool
         """
         return any(part.partClass in partclass for part in self.parts)
+
+    def _calculate_fuel_capacity(self, fuel_part, ignore_species=False):
+        # base fuel
+        tank_name = fuel_part.name
+        base = fuel_part.capacity
+        tech_bonus = _get_tech_bonus(AIDependencies.FUEL_TANK_UPGRADE_DICT, tank_name)
+        # There is no per part species modifier
+        return base + tech_bonus
 
     def _calculate_weapon_strength(self, weapon_part, ignore_species=False):
         # base damage


### PR DESCRIPTION
This fixes #1747 and tells the AI about the fuel tech effects on fuel tanks.

Minor fix included: Also tells the AI that the flux bubble has the same stealth properties as the spatial flux hull.

I am not sure how to test this. I could start up without anything strange in the logs.

Thanks to @Morlic-fo for the jump start.