### PR TITLE
Try to find suffixed boost_python

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -237,10 +237,22 @@ find_package(Boost ${MINIMUM_BOOST_VERSION}
         thread
     REQUIRED)
 if(${Boost_VERSION} GREATER 106699) # boost >= 1.67
-    find_package(Boost COMPONENTS python27 REQUIRED)
-    set(Boost_PYTHON_LIBRARY ${Boost_PYTHON27_LIBRARY})
+    find_package(Boost COMPONENTS python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR} REQUIRED)
+    set(Boost_PYTHON_LIBRARY ${Boost_PYTHON${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}_LIBRARY})
 else()
-    find_package(Boost COMPONENTS python REQUIRED)
+    # boost python suffixes are determined by distributives
+    # try different alternatives
+    find_package(Boost OPTIONAL_COMPONENTS python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR})
+    if(Boost_PYTHON${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}_FOUND)
+        set(Boost_PYTHON_LIBRARY ${Boost_PYTHON${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}_LIBRARY})
+    else()
+        find_package(Boost OPTIONAL_COMPONENTS python-py${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR})
+        if(Boost_PYTHON-PY${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}_FOUND)
+            set(Boost_PYTHON_LIBRARY ${Boost_PYTHON-PY${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}_LIBRARY})
+        else()
+            find_package(Boost COMPONENTS python REQUIRED)
+        endif()
+    endif()
 endif()
 
 find_package(ZLIB REQUIRED)


### PR DESCRIPTION
Some Linux distributives switched to suffixed boost python for versions <= 1.66.
Use major and minor python version from used python.

See https://bugs.gentoo.org/652446 and https://bugs.gentoo.org/652446