### PR TITLE
Output python exceptions to logger

### DIFF
--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -168,6 +168,7 @@ void AIClientApp::Run() {
     } catch (const NormalExitException&) {
         // intentionally empty.
     } catch (const boost::python::error_already_set&) {
+        m_AI->HandleErrorAlreadySet();
         HandlePythonAICrash();
     }
 

--- a/python/AI/AIFramework.cpp
+++ b/python/AI/AIFramework.cpp
@@ -146,7 +146,7 @@ void PythonAI::GenerateOrders() {
         object generateOrdersPythonFunction = m_python_module_ai.attr("generateOrders");
         //DebugLogger() << "PythonAI::GenerateOrders : generating orders";
         generateOrdersPythonFunction();
-    } catch (error_already_set err) {
+    } catch (const error_already_set& err) {
         HandleErrorAlreadySet();
         if (!IsPythonRunning())
             throw;

--- a/python/AI/AIWrapper.cpp
+++ b/python/AI/AIWrapper.cpp
@@ -41,7 +41,6 @@ using boost::python::map_indexing_suite;
 
 using boost::python::object;
 using boost::python::import;
-using boost::python::error_already_set;
 using boost::python::exec;
 using boost::python::dict;
 using boost::python::list;

--- a/python/CommonFramework.cpp
+++ b/python/CommonFramework.cpp
@@ -102,7 +102,7 @@ bool PythonBase::Initialize()
             ErrorLogger() << "Unable to initialize FreeOrion Python modules";
             return false;
         }
-    } catch (error_already_set& err) {
+    } catch (const error_already_set& err) {
         HandleErrorAlreadySet();
         return false;
     }
@@ -191,7 +191,7 @@ std::vector<std::string> PythonBase::ErrorReport() {
 
         list py_err_list;
         try { py_err_list = extract<list>(f()); }
-        catch (error_already_set err) {
+        catch (const error_already_set& err) {
             HandleErrorAlreadySet();
             return err_list;
         }

--- a/python/server/ServerFramework.cpp
+++ b/python/server/ServerFramework.cpp
@@ -20,7 +20,6 @@
 using boost::python::object;
 using boost::python::class_;
 using boost::python::import;
-using boost::python::error_already_set;
 using boost::python::dict;
 using boost::python::list;
 using boost::python::vector_indexing_suite;

--- a/python/server/ServerWrapper.cpp
+++ b/python/server/ServerWrapper.cpp
@@ -59,7 +59,6 @@ using boost::python::return_internal_reference;
 
 using boost::python::object;
 using boost::python::import;
-using boost::python::error_already_set;
 using boost::python::exec;
 using boost::python::dict;
 using boost::python::list;


### PR DESCRIPTION
Adds missing exception print.
Fixes usage of `boost::python::error_already_set`.
Redirect exception print to logger (see https://stackoverflow.com/questions/24386818/how-can-i-get-output-of-pyerr-print-in-windows-or-save-it-as-a-string).
Should help when moving to python3.