### PR TITLE
add diplomatic status indicator

### DIFF
--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -3943,8 +3943,17 @@ Diplomacy
 PEACE
 Peace
 
+AT_PEACE_WITH
+At peace with
+
 WAR
 War
+
+AT_WAR_WITH
+At war with
+
+ALLIED_WITH
+Allied with
 
 WAR_DECLARATION
 Declare War


### PR DESCRIPTION
Adds an indicator of diplomatic relations to the PlayerListWindow. There are three icons representing a diplomatic status (war, peace, allied) each followed by colored squares representing empires, like below.

![player_list_wnd](https://user-images.githubusercontent.com/12985960/59094905-80d1d880-8917-11e9-8640-9cf5f42116eb.png)

Unfortunately, I'm still not able to play with AI oponents with my own builds, so this is barely tested. There is one unresolved issue with the diplo icons being too large which I'm still looking into.