### PR TITLE
Fix python re-declaring snprinf for MSVC already supports it

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,15 @@ set_property(DIRECTORY APPEND
         $<$<PLATFORM_ID:OpenBSD>:FREEORION_OPENBSD>
 )
 
+if(WIN32 AND MSVC AND MSVC_VERSION GREATER_EQUAL 1900) # _MSC_VER >= 1900
+    # fix https://bugs.python.org/issue36020
+    # ToDo: remove after fix will be applied in python-cmake
+    set_property(DIRECTORY APPEND
+        PROPERTY COMPILE_DEFINITIONS
+        HAVE_SNPRINTF
+    )
+endif()
+
 if(WIN32 AND MSVC)
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} /NODEFAULTLIB:LIBCMT")
     set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} /NODEFAULTLIB:LIBCMT")


### PR DESCRIPTION
See https://bugs.python.org/issue36020
Alternative way to fix it while https://github.com/python-cmake-buildsystem/python-cmake-buildsystem/pull/251 is stalled
Allows to update boost to 1.69 https://github.com/freeorion/freeorion-sdk/pull/49