### PR TITLE
Fix cmake compatibility

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,9 +196,10 @@ set_property(DIRECTORY APPEND
         $<$<PLATFORM_ID:OpenBSD>:FREEORION_OPENBSD>
 )
 
-if(WIN32 AND MSVC AND MSVC_VERSION GREATER_EQUAL 1900) # _MSC_VER >= 1900
+if(WIN32 AND MSVC AND NOT (MSVC_VERSION LESS 1900)) # _MSC_VER >= 1900
     # fix https://bugs.python.org/issue36020
     # ToDo: remove after fix will be applied in python-cmake
+    # ToDo: use GREATER_EQUAL after updating to cmake >= 3.7
     set_property(DIRECTORY APPEND
         PROPERTY COMPILE_DEFINITIONS
         HAVE_SNPRINTF


### PR DESCRIPTION
GREATER_EQUAL was introduced in 3.7 https://stackoverflow.com/questions/16667017/cmake-express-the-greater-or-equal-statement
Freeorion still supports 3.1