### PR TITLE
Don't break game if UI data corrupted

### DIFF
--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -1038,6 +1038,7 @@ std::vector<std::shared_ptr<GG::Texture>> ClientUI::GetPrefixedTextures(const bo
 
 void ClientUI::RestoreFromSaveData(const SaveGameUIData& ui_data) {
     GetMapWnd()->RestoreFromSaveData(ui_data);
+    TraceLogger() << "Restore ship designs from UI data";
     m_ship_designs->Load(ui_data);
 }
 

--- a/client/AI/AIClientApp.cpp
+++ b/client/AI/AIClientApp.cpp
@@ -247,6 +247,7 @@ void AIClientApp::HandleMessage(const Message& msg) {
         bool loaded_game_data;
         bool ui_data_available;         // ignored
         SaveGameUIData ui_data;         // ignored
+        bool ui_data_failed;            // ignored
         bool state_string_available;    // ignored, as save_state_string is sent even if not set by ExtractMessageData
         std::string save_state_string;
         m_empire_status.clear();
@@ -255,8 +256,8 @@ void AIClientApp::HandleMessage(const Message& msg) {
                                     m_current_turn,          m_empires,              m_universe,
                                     GetSpeciesManager(),     GetCombatLogManager(),  GetSupplyManager(),
                                     m_player_info,           m_orders,               loaded_game_data,
-                                    ui_data_available,       ui_data,                state_string_available,
-                                    save_state_string,       m_galaxy_setup_data);
+                                    ui_data_available,       ui_data,                ui_data_failed,
+                                    state_string_available,  save_state_string,      m_galaxy_setup_data);
 
         DebugLogger() << "Extracted GameStart message for turn: " << m_current_turn << " with empire: " << m_empire_id;
 

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -835,6 +835,7 @@ boost::statechart::result WaitingForGameStart::react(const GameStart& msg) {
     bool loaded_game_data;
     bool ui_data_available;
     SaveGameUIData ui_data;
+    bool ui_data_failed;
     bool save_state_string_available;
     std::string save_state_string; // ignored - used by AI but not by human client
     OrderSet orders;
@@ -844,12 +845,12 @@ boost::statechart::result WaitingForGameStart::react(const GameStart& msg) {
     Client().EmpireStatus().clear();
     Client().Orders().Reset();
 
-    ExtractGameStartMessageData(msg.m_message,       single_player_game,             empire_id,
-                                current_turn,        Empires(),                      GetUniverse(),
-                                GetSpeciesManager(), GetCombatLogManager(),          GetSupplyManager(),
-                                Client().Players(),  Client().Orders(),              loaded_game_data,
-                                ui_data_available,   ui_data,                        save_state_string_available,
-                                save_state_string,   Client().GetGalaxySetupData());
+    ExtractGameStartMessageData(msg.m_message,               single_player_game,    empire_id,
+                                current_turn,                Empires(),             GetUniverse(),
+                                GetSpeciesManager(),         GetCombatLogManager(), GetSupplyManager(),
+                                Client().Players(),          Client().Orders(),     loaded_game_data,
+                                ui_data_available,           ui_data,               ui_data_failed,
+                                save_state_string_available, save_state_string,     Client().GetGalaxySetupData());
 
     DebugLogger(FSM) << "Extracted GameStart message for turn: " << current_turn << " with empire: " << empire_id;
 

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -872,7 +872,7 @@ boost::statechart::result WaitingForGameStart::react(const GameStart& msg) {
             Client().GetClientUI().RestoreFromSaveData(ui_data);
             TraceLogger(FSM) << "UI data from save data restored";
         } catch (const std::exception& err) {
-            ErrorLogger(FSM) << "Cann't restore UI data" << err.what();
+            ErrorLogger(FSM) << "Can't restore UI data" << err.what();
             ClientUI::MessageBox(UserString("ERROR_UI_DATA_CORRUPTED"), false);
         }
     }

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1049,6 +1049,9 @@ Cannot concede from a game with only one human player.
 ERROR_INCOMPATIBLE_VERSION
 Server cannot properly read messages from your client, most likely due to incompatible game versions.
 
+ERROR_UI_DATA_CORRUPTED
+Client cann't restore UI data from the game. Game can start, but interface options and ship desings was lost.
+
 ##
 ## Game Rules
 ##

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1050,7 +1050,7 @@ ERROR_INCOMPATIBLE_VERSION
 Server cannot properly read messages from your client, most likely due to incompatible game versions.
 
 ERROR_UI_DATA_CORRUPTED
-Cann't restore UI data from the game. Game can start, but interface options and ship desings was lost.
+Can't restore UI data from the game. Game can start, but interface options and ship desings was lost.
 
 ##
 ## Game Rules

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1050,7 +1050,7 @@ ERROR_INCOMPATIBLE_VERSION
 Server cannot properly read messages from your client, most likely due to incompatible game versions.
 
 ERROR_UI_DATA_CORRUPTED
-Client cann't restore UI data from the game. Game can start, but interface options and ship desings was lost.
+Cann't restore UI data from the game. Game can start, but interface options and ship desings was lost.
 
 ##
 ## Game Rules

--- a/network/Message.cpp
+++ b/network/Message.cpp
@@ -864,10 +864,12 @@ void ExtractGameStartMessageData(const Message& msg, bool& single_player_game, i
             Deserialize(ia, universe);
             DebugLogger() << "ExtractGameStartMessage universe deserialization time " << (deserialize_timer.elapsed() * 1000.0);
 
-            ia >> BOOST_SERIALIZATION_NVP(players)
-               >> BOOST_SERIALIZATION_NVP(galaxy_setup_data)
-               >> BOOST_SERIALIZATION_NVP(loaded_game_data);
-            TraceLogger() << "ExtractGameStartMessage players, galaxy setup and loaded_game_data=" << loaded_game_data << " deserialization time " << (deserialize_timer.elapsed() * 1000.0);
+            ia >> BOOST_SERIALIZATION_NVP(players);
+            TraceLogger() << "ExtractGameStartMessage players deserialization time " << (deserialize_timer.elapsed() * 1000.0);
+            ia >> BOOST_SERIALIZATION_NVP(galaxy_setup_data);
+            TraceLogger() << "ExtractGameStartMessage galaxy setup deserialization time " << (deserialize_timer.elapsed() * 1000.0);
+            ia >> BOOST_SERIALIZATION_NVP(loaded_game_data);
+            TraceLogger() << "ExtractGameStartMessage loaded_game_data=" << loaded_game_data << " deserialization time " << (deserialize_timer.elapsed() * 1000.0);
             if (loaded_game_data) {
                 Deserialize(ia, orders);
                 TraceLogger() << "ExtractGameStartMessage orders deserialization time " << (deserialize_timer.elapsed() * 1000.0);
@@ -896,7 +898,6 @@ void ExtractGameStartMessageData(const Message& msg, bool& single_player_game, i
                 save_state_string_available = false;
             }
         }
-
     } catch (const std::exception& err) {
         ErrorLogger() << "ExtractGameStartMessageData(...) failed!  Message probably long, so not outputting to log.\n"
                       << "Error: " << err.what();

--- a/network/Message.cpp
+++ b/network/Message.cpp
@@ -198,8 +198,8 @@ Message GameStartMessage(bool single_player_game, int empire_id,
             Serialize(oa, universe);
             bool loaded_game_data = false;
             oa << BOOST_SERIALIZATION_NVP(players)
+               << BOOST_SERIALIZATION_NVP(galaxy_setup_data)
                << BOOST_SERIALIZATION_NVP(loaded_game_data);
-            oa << BOOST_SERIALIZATION_NVP(galaxy_setup_data);
         } else {
             freeorion_xml_oarchive oa(os);
             oa << BOOST_SERIALIZATION_NVP(single_player_game)
@@ -213,8 +213,8 @@ Message GameStartMessage(bool single_player_game, int empire_id,
             Serialize(oa, universe);
             bool loaded_game_data = false;
             oa << BOOST_SERIALIZATION_NVP(players)
+               << BOOST_SERIALIZATION_NVP(galaxy_setup_data)
                << BOOST_SERIALIZATION_NVP(loaded_game_data);
-            oa << BOOST_SERIALIZATION_NVP(galaxy_setup_data);
         }
     }
     return Message(Message::GAME_START, os.str());
@@ -244,6 +244,7 @@ Message GameStartMessage(bool single_player_game, int empire_id,
             Serialize(oa, universe);
             bool loaded_game_data = true;
             oa << BOOST_SERIALIZATION_NVP(players)
+               << BOOST_SERIALIZATION_NVP(galaxy_setup_data)
                << BOOST_SERIALIZATION_NVP(loaded_game_data);
             Serialize(oa, orders);
             bool ui_data_available = (ui_data != nullptr);
@@ -252,7 +253,6 @@ Message GameStartMessage(bool single_player_game, int empire_id,
                 oa << boost::serialization::make_nvp("ui_data", *ui_data);
             bool save_state_string_available = false;
             oa << BOOST_SERIALIZATION_NVP(save_state_string_available);
-            oa << BOOST_SERIALIZATION_NVP(galaxy_setup_data);
         } else {
             freeorion_xml_oarchive oa(os);
             oa << BOOST_SERIALIZATION_NVP(single_player_game)
@@ -266,6 +266,7 @@ Message GameStartMessage(bool single_player_game, int empire_id,
             Serialize(oa, universe);
             bool loaded_game_data = true;
             oa << BOOST_SERIALIZATION_NVP(players)
+               << BOOST_SERIALIZATION_NVP(galaxy_setup_data)
                << BOOST_SERIALIZATION_NVP(loaded_game_data);
             Serialize(oa, orders);
             bool ui_data_available = (ui_data != nullptr);
@@ -274,7 +275,6 @@ Message GameStartMessage(bool single_player_game, int empire_id,
                 oa << boost::serialization::make_nvp("ui_data", *ui_data);
             bool save_state_string_available = false;
             oa << BOOST_SERIALIZATION_NVP(save_state_string_available);
-            oa << BOOST_SERIALIZATION_NVP(galaxy_setup_data);
         }
     }
     return Message(Message::GAME_START, os.str());
@@ -304,6 +304,7 @@ Message GameStartMessage(bool single_player_game, int empire_id,
             Serialize(oa, universe);
             bool loaded_game_data = true;
             oa << BOOST_SERIALIZATION_NVP(players)
+               << BOOST_SERIALIZATION_NVP(galaxy_setup_data)
                << BOOST_SERIALIZATION_NVP(loaded_game_data);
             Serialize(oa, orders);
             bool ui_data_available = false;
@@ -312,7 +313,6 @@ Message GameStartMessage(bool single_player_game, int empire_id,
             oa << BOOST_SERIALIZATION_NVP(save_state_string_available);
             if (save_state_string_available)
                 oa << boost::serialization::make_nvp("save_state_string", *save_state_string);
-            oa << BOOST_SERIALIZATION_NVP(galaxy_setup_data);
         } else {
             freeorion_xml_oarchive oa(os);
             oa << BOOST_SERIALIZATION_NVP(single_player_game)
@@ -326,6 +326,7 @@ Message GameStartMessage(bool single_player_game, int empire_id,
             Serialize(oa, universe);
             bool loaded_game_data = true;
             oa << BOOST_SERIALIZATION_NVP(players)
+               << BOOST_SERIALIZATION_NVP(galaxy_setup_data)
                << BOOST_SERIALIZATION_NVP(loaded_game_data);
             Serialize(oa, orders);
             bool ui_data_available = false;
@@ -334,7 +335,6 @@ Message GameStartMessage(bool single_player_game, int empire_id,
             oa << BOOST_SERIALIZATION_NVP(save_state_string_available);
             if (save_state_string_available)
                 oa << boost::serialization::make_nvp("save_state_string", *save_state_string);
-            oa << BOOST_SERIALIZATION_NVP(galaxy_setup_data);
         }
     }
     return Message(Message::GAME_START, os.str());
@@ -820,6 +820,7 @@ void ExtractGameStartMessageData(const Message& msg, bool& single_player_game, i
 
 
                 ia >> BOOST_SERIALIZATION_NVP(players)
+                   >> BOOST_SERIALIZATION_NVP(galaxy_setup_data)
                    >> BOOST_SERIALIZATION_NVP(loaded_game_data);
                 if (loaded_game_data) {
                     Deserialize(ia, orders);
@@ -833,7 +834,6 @@ void ExtractGameStartMessageData(const Message& msg, bool& single_player_game, i
                     ui_data_available = false;
                     save_state_string_available = false;
                 }
-                ia >> BOOST_SERIALIZATION_NVP(galaxy_setup_data);
             } catch (...) {
                 try_xml = true;
             }
@@ -865,8 +865,9 @@ void ExtractGameStartMessageData(const Message& msg, bool& single_player_game, i
 
 
             ia >> BOOST_SERIALIZATION_NVP(players)
+               >> BOOST_SERIALIZATION_NVP(galaxy_setup_data)
                >> BOOST_SERIALIZATION_NVP(loaded_game_data);
-            TraceLogger() << "ExtractGameStartMessage players and loaded_game_data=" << loaded_game_data << " deserialization time " << (deserialize_timer.elapsed() * 1000.0);
+            TraceLogger() << "ExtractGameStartMessage players, galaxy setup and loaded_game_data=" << loaded_game_data << " deserialization time " << (deserialize_timer.elapsed() * 1000.0);
             if (loaded_game_data) {
                 Deserialize(ia, orders);
                 TraceLogger() << "ExtractGameStartMessage orders deserialization time " << (deserialize_timer.elapsed() * 1000.0);
@@ -882,8 +883,6 @@ void ExtractGameStartMessageData(const Message& msg, bool& single_player_game, i
                 ui_data_available = false;
                 save_state_string_available = false;
             }
-            ia >> BOOST_SERIALIZATION_NVP(galaxy_setup_data);
-            TraceLogger() << "ExtractGameStartMessage galaxy setup data deserialization time " << (deserialize_timer.elapsed() * 1000.0);
         }
 
     } catch (const std::exception& err) {

--- a/network/Message.h
+++ b/network/Message.h
@@ -408,6 +408,7 @@ FO_COMMON_API void ExtractTurnOrdersMessageData(const Message& msg,
                                                 OrderSet& orders,
                                                 bool& ui_data_available,
                                                 SaveGameUIData& ui_data,
+                                                bool& ui_data_failed,
                                                 bool& save_state_string_available,
                                                 std::string& save_state_string);
 

--- a/network/Message.h
+++ b/network/Message.h
@@ -392,8 +392,9 @@ FO_COMMON_API void ExtractGameStartMessageData(const Message& msg, bool& single_
                                                SupplyManager& supply,
                                                std::map<int, PlayerInfo>& players, OrderSet& orders,
                                                bool& loaded_game_data, bool& ui_data_available,
-                                               SaveGameUIData& ui_data, bool& save_state_string_available,
-                                               std::string& save_state_string, GalaxySetupData& galaxy_setup_data);
+                                               SaveGameUIData& ui_data, bool& ui_data_failed,
+                                               bool& save_state_string_available, std::string& save_state_string,
+                                               GalaxySetupData& galaxy_setup_data);
 
 FO_COMMON_API void ExtractJoinGameMessageData(const Message& msg, std::string& player_name,
                                               Networking::ClientType& client_type,

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -2937,16 +2937,20 @@ sc::result WaitingForTurnEnd::react(const TurnOrders& msg) {
     auto order_set = std::make_shared<OrderSet>();
     auto ui_data = std::make_shared<SaveGameUIData>();
     bool ui_data_available = false;
+    bool ui_data_failed = false;
     std::string save_state_string;
     bool save_state_string_available = false;
     try {
-        ExtractTurnOrdersMessageData(message, *order_set, ui_data_available, *ui_data, save_state_string_available, save_state_string);
+        ExtractTurnOrdersMessageData(message, *order_set, ui_data_available, *ui_data, ui_data_failed, save_state_string_available, save_state_string);
     } catch (const std::exception& err) {
         // incorrect turn orders. disconnect player with wrong client.
         sender->SendMessage(ErrorMessage(UserStringNop("ERROR_INCOMPATIBLE_VERSION")));
         server.Networking().Disconnect(sender);
         return discard_event();
     }
+
+    if (ui_data_failed)
+        sender->SendMessage(ErrorMessage(UserStringNop("ERROR_UI_DATA_CORRUPTED"), false));
 
     int player_id = sender->PlayerID();
     Networking::ClientType client_type = sender->GetClientType();

--- a/test/system/ClientAppFixture.cpp
+++ b/test/system/ClientAppFixture.cpp
@@ -169,6 +169,7 @@ bool ClientAppFixture::HandleMessage(Message& msg) {
         bool loaded_game_data;       // ignored
         bool ui_data_available;      // ignored
         SaveGameUIData ui_data;      // ignored
+        bool ui_data_failure;        // ignored
         bool state_string_available; // ignored
         std::string save_state_string;
         m_empire_status.clear();
@@ -177,8 +178,8 @@ bool ClientAppFixture::HandleMessage(Message& msg) {
                                     m_current_turn,          m_empires,              m_universe,
                                     GetSpeciesManager(),     GetCombatLogManager(),  GetSupplyManager(),
                                     m_player_info,           m_orders,               loaded_game_data,
-                                    ui_data_available,       ui_data,                state_string_available,
-                                    save_state_string,       m_galaxy_setup_data);
+                                    ui_data_available,       ui_data,                ui_data_failure,
+                                    state_string_available,  save_state_string,      m_galaxy_setup_data);
 
         InfoLogger() << "Extracted GameStart message for turn: " << m_current_turn << " with empire: " << m_empire_id;
 


### PR DESCRIPTION
Fixes #2475 
Breaks compatibility due reordering game start message fields.
Shows non-fatal error to user if UI data corrupted instead of crash.