### PR TITLE
Add option to set game UID

### DIFF
--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1768,6 +1768,9 @@ OPTIONS_DB_GAMESETUP_SEED
 '''The seed used for randomly generating the galaxy.
 Galaxies generated with the same settings and the same seed will be identical.'''
 
+OPTIONS_DB_GAMESETUP_UID
+'''The game UID for new games. Server-only option can be used for predictable game name on hostless servers.'''
+
 OPTIONS_DB_GAMESETUP_STARS
 '''The approximate number of systems in the galaxy to be generated.
 

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -112,6 +112,7 @@ ServerApp::ServerApp() :
     m_galaxy_setup_data.m_monster_freq = GetOptionsDB().Get<GalaxySetupOption>("setup.monster.frequency");
     m_galaxy_setup_data.m_native_freq = GetOptionsDB().Get<GalaxySetupOption>("setup.native.frequency");
     m_galaxy_setup_data.m_ai_aggr = GetOptionsDB().Get<Aggression>("setup.ai.aggression");
+    m_galaxy_setup_data.m_game_uid = GetOptionsDB().Get<std::string>("setup.game.uid");
 
     // Start parsing content before FSM initialization
     // to have data initialized before autostart execution
@@ -1437,7 +1438,8 @@ void ServerApp::GenerateUniverse(std::map<int, PlayerSetupData>& player_setup_da
     // Set game UID. Needs to be done first so we can use ClockSeed to
     // prevent reproducible UIDs.
     ClockSeed();
-    GetGalaxySetupData().SetGameUID(boost::uuids::to_string(boost::uuids::random_generator()()));
+    if (GetOptionsDB().Get<std::string>("setup.game.uid").empty())
+        GetGalaxySetupData().SetGameUID(boost::uuids::to_string(boost::uuids::random_generator()()));
 
     // Initialize RNG with provided seed to get reproducible universes
     int seed = 0;

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -704,7 +704,7 @@ sc::result Idle::react(const Hostless&) {
     }
 
     ServerApp& server = Server();
-    std::shared_ptr<MultiplayerLobbyData> lobby_data(new MultiplayerLobbyData(std::move(server.m_galaxy_setup_data)));
+    std::shared_ptr<MultiplayerLobbyData> lobby_data(new MultiplayerLobbyData(server.m_galaxy_setup_data));
     std::shared_ptr<ServerSaveGameData> server_save_game_data(new ServerSaveGameData());
     std::vector<PlayerSaveGameData> player_save_game_data;
     server.InitializePython();

--- a/server/dmain.cpp
+++ b/server/dmain.cpp
@@ -66,6 +66,7 @@ int wmain(int argc, wchar_t* argv[], wchar_t* envp[]) {
         GetOptionsDB().Add<std::string>("network.server.turn-timeout.first-turn-time", UserStringNop("OPTIONS_DB_FIRST_TURN_TIME"), "");
         GetOptionsDB().Add<int>("network.server.turn-timeout.max-interval", UserStringNop("OPTIONS_DB_TIMEOUT_INTERVAL"), 0);
         GetOptionsDB().Add<bool>("network.server.turn-timeout.fixed-interval", UserStringNop("OPTIONS_DB_TIMEOUT_FIXED_INTERVAL"), false);
+        GetOptionsDB().Add<std::string>("setup.game.uid", UserStringNop("OPTIONS_DB_GAMESETUP_UID"), "");
 
         // if config.xml and persistent_config.xml are present, read and set options entries
         GetOptionsDB().SetFromFile(GetConfigPath(), FreeOrionVersionString());

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -288,6 +288,16 @@ struct FO_COMMON_API MultiplayerLobbyData : public GalaxySetupData {
         m_save_game_empire_data()
     {}
 
+    MultiplayerLobbyData(const GalaxySetupData& base) :
+        GalaxySetupData(base),
+        m_any_can_edit(false),
+        m_new_game(true),
+        m_start_locked(false),
+        m_players(),
+        m_save_game(),
+        m_save_game_empire_data()
+    {}
+
     MultiplayerLobbyData(GalaxySetupData&& base) :
         GalaxySetupData(std::move(base)),
         m_any_can_edit(false),


### PR DESCRIPTION
Useful for standalone server with the only game.
Allows game UID to be accessible from python `AuthProvider.list_players` so different server with different game could share same database.