### PR TITLE
add CUIWnd::Flash

### DIFF
--- a/UI/CUIWnd.cpp
+++ b/UI/CUIWnd.cpp
@@ -318,14 +318,13 @@ void CUIWnd::Render() {
         glDrawArrays(GL_LINE_LOOP,      m_buffer_indices[0].first, m_buffer_indices[0].second);
 
     } else {
-        if (m_flashing && GG::GUI::GetGUI()->Ticks() % (m_flash_duration * 2) > m_flash_duration)
-            glColor(GG::LightColor(ClientUI::WndColor()));
-        else
-            glColor(ClientUI::WndColor());
+        bool flashing = m_flashing && GG::GUI::GetGUI()->Ticks() % (m_flash_duration * 2) > m_flash_duration;
+
+        flashing ? glColor(GG::LightColor(ClientUI::WndColor())) : glColor(ClientUI::WndColor());
         glDrawArrays(GL_TRIANGLE_FAN,   m_buffer_indices[1].first, m_buffer_indices[1].second);
-        glColor(ClientUI::WndOuterBorderColor());
+        flashing ? glColor(GG::LightColor(ClientUI::WndOuterBorderColor())) : glColor(ClientUI::WndOuterBorderColor());
         glDrawArrays(GL_LINE_LOOP,      m_buffer_indices[1].first, m_buffer_indices[1].second);
-        glColor(ClientUI::WndInnerBorderColor());
+        flashing ? glColor(GG::LightColor(ClientUI::WndInnerBorderColor())) : glColor(ClientUI::WndInnerBorderColor());
         glDrawArrays(GL_LINE_LOOP,      m_buffer_indices[2].first, m_buffer_indices[2].second);
 
         if (m_resizable) {

--- a/UI/CUIWnd.cpp
+++ b/UI/CUIWnd.cpp
@@ -318,7 +318,10 @@ void CUIWnd::Render() {
         glDrawArrays(GL_LINE_LOOP,      m_buffer_indices[0].first, m_buffer_indices[0].second);
 
     } else {
-        glColor(ClientUI::WndColor());
+        if (m_flashing && GG::GUI::GetGUI()->Ticks() % (m_flash_duration * 2) > m_flash_duration)
+            glColor(GG::LightColor(ClientUI::WndColor()));
+        else
+            glColor(ClientUI::WndColor());
         glDrawArrays(GL_TRIANGLE_FAN,   m_buffer_indices[1].first, m_buffer_indices[1].second);
         glColor(ClientUI::WndOuterBorderColor());
         glDrawArrays(GL_LINE_LOOP,      m_buffer_indices[1].first, m_buffer_indices[1].second);

--- a/UI/CUIWnd.h
+++ b/UI/CUIWnd.h
@@ -142,6 +142,12 @@ public:
 
     void Show() override;
 
+    void Flash() { m_flashing = true; };
+
+    void StopFlash() { m_flashing = false; };
+
+    void SetFlashDuration(int ms) { m_flash_duration = ms; }
+
     void            ToggleMinimized() { MinimizeClicked(); }
     void            Close()           { CloseClicked(); }
     void            ValidatePosition();                                 //!< calls SizeMove() to trigger position-checking and position the window entirely within the parent window/app window
@@ -203,6 +209,9 @@ protected:
     bool                    m_minimized = false;    //!< true if the window is currently minimized
     bool                    m_pinable;              //!< true if the window is able to be pinned
     bool                    m_pinned = false;       //!< true if the window is currently pinned
+    bool                    m_flashing = false;     //!< true if the window is currently flashing
+
+    int                     m_flash_duration = 1000;//!< time in milliseconds to switch between bright and dark
 
     GG::Pt                  m_drag_offset;          //!< offset from the lower-right corner of the point being used to drag-resize
     GG::Pt                  m_original_size;        //!< keeps track of the size of the window before resizing


### PR DESCRIPTION
If Flash() is called, the window will periodically brighten up. The duration of the period is specified by SetFlashDuration(). The purpose of this is to have a method to draw the player's attention to a window, e. g. to the message window if a message is received.
In preparation of diplomacy UI changes.