### PR TITLE
Target infrastructure by ShortRange weapons and ensure combat

### DIFF
--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -341,6 +341,11 @@ namespace {
                             boost::make_unique<Condition::MeterValue>(
                                 METER_SHIELD,
                                 nullptr,
+                                boost::make_unique<ValueRef::Constant<double>>(0.0))),
+                        boost::make_unique<Condition::Not>(
+                            boost::make_unique<Condition::MeterValue>(
+                                METER_CONSTRUCTION,
+                                nullptr,
                                 boost::make_unique<ValueRef::Constant<double>>(0.0)))))));
 
     const std::unique_ptr<Condition::ConditionBase> if_source_is_planet_then_ships_else_all =

--- a/default/scripting/species/common/general.macros
+++ b/default/scripting/species/common/general.macros
@@ -47,6 +47,13 @@ STANDARD_CONSTRUCTION
             ]
             priority = [[AFTER_ALL_TARGET_MAX_METERS_PRIORITY]]
             effects = SetConstruction value = Value + min(max(Value(Target.TargetConstruction) - Value, -1), 1)
+
+        EffectsGroup    // always ensure minimum value of one, as this is necessary for being attacked
+            scope = Source
+            activation = Planet
+            // has to happen after e.g. FORCE_ENERGY_STRC effects which also happens at AFTER_ALL_TARGET_MAX_METERS_PRIORITY
+            priority = [[METER_OVERRIDE_PRIORITY]]
+            effects = SetConstruction value = max(Value, 1)
 '''
 
 FOCUS_CHANGE_PENALTY


### PR DESCRIPTION
…happens so planets may be invaded

Intended as Fix for #2488 

Infrastructure (construction) boosts planetary defense so ship weapons should target all planets which have infrastructure left.

Enforcing a minimal value of one for construction via FOCS is KISS and re-triggers combat every turn which allows troops to invade the planet.
Only a single bout is wasted on "already defeated" planets, which is acceptable.

I tested that construction one always is set and after attacking a shield-less defense-less planet one can invade every turn. 
Somebody probably should have a look what happens with monsters and test with force energy structures.