### PR TITLE
new line for each empire in psi tooltip

### DIFF
--- a/UI/PlayerListWnd.cpp
+++ b/UI/PlayerListWnd.cpp
@@ -171,7 +171,7 @@ namespace {
                 const Empire* empire = GetEmpire(empire_id);
                 if (!empire) continue;
 
-                tooltip_text += GG::RgbaTag(empire->Color()) + empire->Name();
+                tooltip_text += GG::RgbaTag(empire->Color()) + empire->Name() + "\n";
             }
 
             // add tooltip


### PR DESCRIPTION
Each empire is moved into its own line for the diplo status indicator tooltip. (Before it was: `At war with: Empire1Empire2Empire3`)