### PR TITLE
add /help command to message_wnd

### DIFF
--- a/UI/ChatWnd.cpp
+++ b/UI/ChatWnd.cpp
@@ -557,33 +557,38 @@ namespace {
                 net.SendMessage(PlayerChatMessage(text, recipient_id));
         }
     }
+}
 
-    void HandleTextCommand(const std::string& text) {
-        if (text.size() < 2)
-            return;
+void MessageWnd::HandleTextCommand(const std::string& text) {
+    if (text.size() < 2)
+        return;
 
-        // extract command and parameters substrings
-        std::string command, params;
-        std::string::size_type space_pos = text.find_first_of(' ');
-        command = boost::trim_copy(text.substr(1, space_pos));
-        if (command.empty())
-            return;
-        if (space_pos != std::string::npos)
-            params = boost::trim_copy(text.substr(space_pos, std::string::npos));
+    // extract command and parameters substrings
+    std::string command, params;
+    std::string::size_type space_pos = text.find_first_of(' ');
+    command = boost::trim_copy(text.substr(1, space_pos));
+    if (command.empty())
+        return;
+    if (space_pos != std::string::npos)
+        params = boost::trim_copy(text.substr(space_pos, std::string::npos));
 
-        ClientUI* client_ui = ClientUI::GetClientUI();
-        if (!client_ui)
-            return;
+    ClientUI* client_ui = ClientUI::GetClientUI();
+    if (!client_ui)
+        return;
 
-        // execute command matching understood syntax
-        if (boost::iequals(command, "zoom") && !params.empty()) {
-            client_ui->ZoomToObject(params) || client_ui->ZoomToContent(params, true);   // params came from chat, so will be localized, so should be reverse looked up to find internal name from human-readable name for zooming to content
-        } else if (boost::iequals(command, "pedia")) {
-            if (params.empty())
-                client_ui->ZoomToEncyclopediaEntry(UserStringNop("ENC_INDEX"));
-            else
-                client_ui->ZoomToContent(params, true);
-        }
+    // execute command matching understood syntax
+    if (boost::iequals(command, "zoom") && !params.empty()) {
+        client_ui->ZoomToObject(params) || client_ui->ZoomToContent(params, true);   // params came from chat, so will be localized, so should be reverse looked up to find internal name from human-readable name for zooming to content
+    }
+    else if (boost::iequals(command, "pedia")) {
+        if (params.empty())
+            client_ui->ZoomToEncyclopediaEntry(UserStringNop("ENC_INDEX"));
+        else
+            client_ui->ZoomToContent(params, true);
+    }
+    else if (boost::iequals(command, "help")) {
+        *m_display += UserString("MESSAGES_HELP_COMMAND") + "\n";
+        m_display_show_time = GG::GUI::GetGUI()->Ticks();
     }
 }
 

--- a/UI/ChatWnd.h
+++ b/UI/ChatWnd.h
@@ -47,6 +47,7 @@ private:
     void CloseClicked() override;
 
     void            DoLayout();
+    void            HandleTextCommand(const std::string& text);
     void            MessageEntered();
     void            MessageHistoryUpRequested();
     void            MessageHistoryDownRequested();

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -6184,6 +6184,11 @@ Received unexpected turn update from server.
 MESSAGES_PANEL_TITLE
 Messages
 
+MESSAGES_HELP_COMMAND
+'''/pedia [article]: open the specified article in the pedia.
+/zoom [object]: zoom to the specified universe object (system, planet, ship, fleet or building)
+'''
+
 
 ##
 ## Players list

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -6186,7 +6186,7 @@ Messages
 
 MESSAGES_HELP_COMMAND
 '''/pedia [article]: open the specified article in the pedia.
-/zoom [object]: zoom to the specified universe object (system, planet, ship, fleet or building)
+/zoom [object]: zoom to the specified universe object (system, planet, ship, fleet, or building)
 '''
 
 


### PR DESCRIPTION
Adds a /help command for the message window that gives information about available commands, which are currently /zoom and /pedia.