### PR TITLE
add new molecular cloud image with clearer border

### DIFF
--- a/default/scripting/fields/FLD_MOLECULAR_CLOUD.focs.txt
+++ b/default/scripting/fields/FLD_MOLECULAR_CLOUD.focs.txt
@@ -49,4 +49,4 @@ FieldType
             ]
             effects = Destroy
     ]
-    graphic = "nebulae/nebula8.png"
+    graphic = "fields/molecular_cloud.png"


### PR DESCRIPTION
Adds new graphic for molecular cloud with clearer outline.

![mol_cloud_example](https://user-images.githubusercontent.com/12985960/61945217-c0c04e00-af9f-11e9-96d8-79399406449e.jpg)

