### PR TITLE
Save information if empire was eliminated or won

### DIFF
--- a/server/SaveLoad.cpp
+++ b/server/SaveLoad.cpp
@@ -45,8 +45,7 @@ namespace {
     std::map<int, SaveGameEmpireData> CompileSaveGameEmpireData(const EmpireManager& empire_manager) {
         std::map<int, SaveGameEmpireData> retval;
         for (const auto& entry : Empires())
-            if (!entry.second->Eliminated())
-                retval[entry.first] = SaveGameEmpireData(entry.first, entry.second->Name(), entry.second->PlayerName(), entry.second->Color(), entry.second->IsAuthenticated());
+            retval[entry.first] = SaveGameEmpireData(entry.first, entry.second->Name(), entry.second->PlayerName(), entry.second->Color(), entry.second->IsAuthenticated(), entry.second->Eliminated(), entry.second->Won());
         return retval;
     }
 

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -1472,7 +1472,10 @@ sc::result MPLobby::react(const LobbyUpdate& msg) {
                         if (plr.second.m_save_game_empire_id != ALL_EMPIRES) {
                             const auto empire_it = m_lobby_data->m_save_game_empire_data.find(plr.second.m_save_game_empire_id);
                             if (empire_it != m_lobby_data->m_save_game_empire_data.end()) {
-                                if (empire_it->second.m_authenticated) {
+                                if (empire_it->second.m_eliminated) {
+                                    WarnLogger(FSM) << "Trying to take over eliminated empire \"" << empire_it->second.m_empire_name << "\"";
+                                    incorrect_empire = true;
+                                } else if (empire_it->second.m_authenticated) {
                                     if (empire_it->second.m_player_name != sender->PlayerName()) {
                                         WarnLogger(FSM) << "Unauthorized access to protected empire \"" << empire_it->second.m_empire_name << "\"."
                                                         << " Expected player \"" << empire_it->second.m_player_name << "\""
@@ -1613,7 +1616,10 @@ sc::result MPLobby::react(const LobbyUpdate& msg) {
                     if (j_player.second.m_save_game_empire_id != ALL_EMPIRES) {
                         const auto empire_it = m_lobby_data->m_save_game_empire_data.find(j_player.second.m_save_game_empire_id);
                         if (empire_it != m_lobby_data->m_save_game_empire_data.end()) {
-                            if (empire_it->second.m_authenticated) {
+                            if (empire_it->second.m_eliminated) {
+                                WarnLogger(FSM) << "Trying to take over eliminated empire \"" << empire_it->second.m_empire_name << "\"";
+                                incorrect_empire = true;
+                            } else if (empire_it->second.m_authenticated) {
                                 if (empire_it->second.m_player_name != sender->PlayerName()) {
                                     WarnLogger(FSM) << "Unauthorized access to protected empire \"" << empire_it->second.m_empire_name << "\"."
                                                     << " Expected player \"" << empire_it->second.m_player_name << "\""

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -109,16 +109,20 @@ struct FO_COMMON_API SaveGameEmpireData {
         m_empire_name(),
         m_player_name(),
         m_color(),
-        m_authenticated(false)
+        m_authenticated(false),
+        m_eliminated(false),
+        m_won(false)
     {}
     SaveGameEmpireData(int empire_id, const std::string& empire_name,
                        const std::string& player_name, const GG::Clr& colour,
-                       bool authenticated) :
+                       bool authenticated, bool eliminated, bool won) :
         m_empire_id(empire_id),
         m_empire_name(empire_name),
         m_player_name(player_name),
         m_color(colour),
-        m_authenticated(authenticated)
+        m_authenticated(authenticated),
+        m_eliminated(eliminated),
+        m_won(won)
     {}
     //@}
 
@@ -127,6 +131,8 @@ struct FO_COMMON_API SaveGameEmpireData {
     std::string m_player_name;
     GG::Clr     m_color;
     bool        m_authenticated;
+    bool        m_eliminated;
+    bool        m_won;
 
 private:
     friend class boost::serialization::access;
@@ -134,7 +140,7 @@ private:
     void serialize(Archive& ar, const unsigned int version);
 };
 
-BOOST_CLASS_VERSION(SaveGameEmpireData, 1);
+BOOST_CLASS_VERSION(SaveGameEmpireData, 2);
 
 /** Contains basic data about a player in a game. */
 struct FO_COMMON_API PlayerSaveHeaderData {

--- a/util/SerializeMultiplayerCommon.cpp
+++ b/util/SerializeMultiplayerCommon.cpp
@@ -162,6 +162,10 @@ void SaveGameEmpireData::serialize(Archive& ar, const unsigned int version)
     if (version >= 1) {
         ar & BOOST_SERIALIZATION_NVP(m_authenticated);
     }
+    if (version >= 2) {
+        ar & BOOST_SERIALIZATION_NVP(m_eliminated);
+        ar & BOOST_SERIALIZATION_NVP(m_won);
+    }
 }
 
 template void SaveGameEmpireData::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, const unsigned int);


### PR DESCRIPTION
Adds new fields to `SaveGameEmpireData`.
Prevents player to choose eliminated empire.
Actually also allows to continue game if alive human players went under limit.
Prerequisite to solve #2510 