### PR TITLE
Fix infinite loop in AI code

### DIFF
--- a/default/python/AI/AIFleetMission.py
+++ b/default/python/AI/AIFleetMission.py
@@ -771,11 +771,7 @@ class AIFleetMission(object):
                                 not planet.unowned):
                             debug("Currently no neighboring threats. "
                                   "Staying for bombardment of planet %s", planet)
-                            self.clear_fleet_orders()
-                            self.set_target(MissionType.MILITARY, TargetSystem(current_system_id))
-                            self.generate_fleet_orders()
-                            self.issue_fleet_orders()
-                            return INVALID_ID
+                            return current_system_id
 
                 # TODO consider attacking neighboring, non-military fleets
                 # - needs more careful evaluation against neighboring threats


### PR DESCRIPTION
Fixes #2520.

The infinite loop is triggered by an AI fleet that has a PROTECT_REGION mission and wants to keep bombarding a planet in a neighboring system. When switching to a MILITARY mission, the new MILITARY mission may be canceled under certain conditions. The fleet was then reassigned the PROTECT_REGION mission which is reassigning to a MILITARY mission which will be canceled again.

The fix is to just stay in the PROTECT_REGION mission and let the fleet stay in the current system.

Tested with the savegame provided in #2520.