### PR TITLE
Fix final order in PROTECT_REGION mission

### DIFF
--- a/default/python/AI/AIFleetMission.py
+++ b/default/python/AI/AIFleetMission.py
@@ -670,7 +670,9 @@ class AIFleetMission(object):
                 self.orders.append(fleet_order)
 
             # also generate appropriate final orders
-            fleet_order = self._get_fleet_order_from_target(self.type, self.target)
+            fleet_order = self._get_fleet_order_from_target(self.type,
+                                                            self.target if not self.type == MissionType.PROTECT_REGION
+                                                            else system_to_visit)
             self.orders.append(fleet_order)
 
     def _need_repair(self, repair_limit=0.70):


### PR DESCRIPTION
As the final order is a Pause order, we want to Pause in the actual target system where the fleet is moving towards - not the the primary target system.