### PR TITLE
Fix AI fighter calculations

### DIFF
--- a/default/python/AI/AIFleetMission.py
+++ b/default/python/AI/AIFleetMission.py
@@ -543,6 +543,7 @@ class AIFleetMission(object):
                             debug("Can not release fleet yet due to large threat.")
                         elif fleet_portion_to_remain > 0:
                             debug("Not all ships are needed here - considering releasing a few")
+                            # TODO: Rate against specific enemy threat cause
                             fleet_remaining_rating = CombatRatingsAI.get_fleet_rating(fleet_id)
                             fleet_min_rating = fleet_portion_to_remain * fleet_remaining_rating
                             debug("Starting rating: %.1f, Target rating: %.1f",
@@ -620,6 +621,7 @@ class AIFleetMission(object):
         safety_factor = aistate.character.military_safety_factor()
         potential_threat *= safety_factor
 
+        # TODO: Rate against specific threat here
         fleet_rating = CombatRatingsAI.get_fleet_rating(self.fleet.id)
         return CombatRatingsAI.rating_needed(potential_threat, local_defenses) / float(fleet_rating)
 
@@ -736,6 +738,7 @@ class AIFleetMission(object):
         # TODO: Also check fleet rating vs planets in decision making below not only vs fleets
         universe = fo.getUniverse()
         primary_objective = self.target.id
+        # TODO: Rate against specific threats
         fleet_rating = CombatRatingsAI.get_fleet_rating(self.fleet.id)
         debug("%s finding target for protection mission (primary target %s). Fleet Rating: %.1f",
               self.fleet, self.target, fleet_rating)

--- a/default/python/AI/AIstate.py
+++ b/default/python/AI/AIstate.py
@@ -861,7 +861,7 @@ class AIstate(object):
         # need to loop over a copy as entries are deleted in loop
         for fleet_id in list(self.__fleetRoleByID):
             fleet_status = self.fleetStatus.setdefault(fleet_id, {})
-            rating = CombatRatingsAI.get_fleet_rating(fleet_id, self.get_standard_enemy())
+            rating = CombatRatingsAI.get_fleet_rating(fleet_id)
             old_sys_id = fleet_status.get('sysID', -2)  # TODO: Introduce helper function instead
             fleet = universe.getFleet(fleet_id)
             if fleet:

--- a/default/python/AI/CombatRatingsAI.py
+++ b/default/python/AI/CombatRatingsAI.py
@@ -3,6 +3,7 @@ from logging import warn
 
 import freeOrionAIInterface as fo
 import FleetUtilsAI
+from aistate_interface import get_aistate
 from EnumsAI import MissionType
 from freeorion_tools import get_ai_tag_grade, dict_to_tuple, tuple_to_dict, cache_by_session
 from ShipDesignAI import get_part_type
@@ -167,7 +168,9 @@ class ShipCombatStats(object):
     def get_rating(self, enemy_stats=None, ignore_fighters=False):
         """Calculate a rating against specified enemy.
 
-        :param enemy_stats: Enemy stats to be rated against
+        If no enemy is specified, will rate against the empire standard enemy
+
+        :param enemy_stats: Enemy stats to be rated against - if None
         :type enemy_stats: ShipCombatStats
         :param ignore_fighters: If True, acts as if fighters are not launched
         :type ignore_fighters: bool
@@ -177,6 +180,10 @@ class ShipCombatStats(object):
         # adjust base stats according to enemy stats
         def _rating():
             return my_total_attack * my_structure
+
+        # The fighter rating calculations are heavily based upon the enemy stats.
+        # So, for now, we compare at least against a certain standard enemy.
+        enemy_stats = enemy_stats or get_aistate().get_standard_enemy()
 
         my_attacks, my_structure, my_shields = self.get_basic_stats()
         e_avg_attack = 1

--- a/default/python/AI/CombatRatingsAI.py
+++ b/default/python/AI/CombatRatingsAI.py
@@ -138,7 +138,7 @@ class ShipCombatStats(object):
                 elif pc == fo.shipPartClass.fighterBay:
                     fighter_launch_rate += ship.currentPartMeterValue(fo.meterType.capacity, partname)
                 elif pc == fo.shipPartClass.fighterHangar:
-                    fighter_capacity += ship.currentPartMeterValue(meter_choice, partname)
+                    fighter_capacity = ship.currentPartMeterValue(meter_choice, partname)
                     part_damage = ship.currentPartMeterValue(fo.meterType.secondaryStat, partname)
                     if part_damage != fighter_damage and fighter_damage > 0:
                         # the C++ code fails also in this regard, so FOCS content *should* not allow this.

--- a/default/python/AI/CombatRatingsAI.py
+++ b/default/python/AI/CombatRatingsAI.py
@@ -138,6 +138,7 @@ class ShipCombatStats(object):
                 elif pc == fo.shipPartClass.fighterBay:
                     fighter_launch_rate += ship.currentPartMeterValue(fo.meterType.capacity, partname)
                 elif pc == fo.shipPartClass.fighterHangar:
+                    # for hangars, capacity meter is already counting contributions from ALL hangars.
                     fighter_capacity = ship.currentPartMeterValue(meter_choice, partname)
                     part_damage = ship.currentPartMeterValue(fo.meterType.secondaryStat, partname)
                     if part_damage != fighter_damage and fighter_damage > 0:

--- a/default/python/AI/CombatRatingsAI.py
+++ b/default/python/AI/CombatRatingsAI.py
@@ -77,13 +77,10 @@ class ShipCombatStats(object):
 
     class FighterStats(object):
         """ Stores fighter-related stats """
-        def __init__(self, stat_tuple=None, capacity=0, launch_rate=0, damage=0):
-            if stat_tuple and isinstance(stat_tuple, tuple):
-                self.capacity, self.launch_rate, self.damage = stat_tuple
-            else:
-                self.capacity = capacity
-                self.launch_rate = launch_rate
-                self.damage = damage
+        def __init__(self, capacity, launch_rate, damage):
+            self.capacity = capacity
+            self.launch_rate = launch_rate
+            self.damage = damage
 
         def __str__(self):
             return str(self.get_stats())

--- a/default/python/AI/FleetUtilsAI.py
+++ b/default/python/AI/FleetUtilsAI.py
@@ -275,6 +275,8 @@ def merge_fleet_a_into_b(fleet_a_id, fleet_b_id, leave_rating=0, need_rating=0, 
     system_id = fleet_a.systemID
     if fleet_b.systemID != system_id:
         return 0
+
+    # TODO: Should this rate against specific enemy?
     remaining_rating = CombatRatingsAI.get_fleet_rating(fleet_a_id)
     transferred_rating = 0
     for ship_id in fleet_a.shipIDs:

--- a/default/python/AI/fleet_orders.py
+++ b/default/python/AI/fleet_orders.py
@@ -185,6 +185,7 @@ class OrderMove(AIFleetOrder):
         aistate = get_aistate()
         main_fleet_mission = aistate.get_fleet_mission(self.fleet.id)
 
+        # TODO: Rate against specific enemies here
         fleet_rating = CombatRatingsAI.get_fleet_rating(self.fleet.id)
         fleet_rating_vs_planets = CombatRatingsAI.get_fleet_rating_against_planets(self.fleet.id)
         target_sys_status = aistate.systemStatus.get(self.target.id, {})


### PR DESCRIPTION
First commit fixes a bug where all parameters were offset by 1. Implying AI always considered fighter damage to be zero, the launch rate to be equal the actual damage and the capacity to be equal to the launch rate.

Second commit fixes a bug where the wrong capacity was calculated: The currentPartMeterValue for hangar capacity already returns the sum of all parts. Summing N parts up in AI code will then result in N times the actual capacity...