### PR TITLE
Raise AI minimum fuel requirements for military ship designs to 2

### DIFF
--- a/default/python/AI/ShipDesignAI.py
+++ b/default/python/AI/ShipDesignAI.py
@@ -1635,6 +1635,8 @@ class MilitaryShipDesignerBaseClass(ShipDesigner):
 
     def __init__(self):
         super(MilitaryShipDesignerBaseClass, self).__init__()
+        self.additional_specifications.minimum_fuel = 2
+        self.additional_specifications.minimum_speed = 30
 
     def _adjusted_production_cost(self):
         # as military ships are grouped up in fleets, their power rating scales quadratic in numbers.
@@ -1678,9 +1680,7 @@ class WarShipDesigner(MilitaryShipDesignerBaseClass):
                               15000, 20000, 25000, 30000, 35000, 40000, 50000, 70000, 1000000])
 
     def __init__(self):
-        ShipDesigner.__init__(self)
-        self.additional_specifications.minimum_fuel = 1
-        self.additional_specifications.minimum_speed = 30
+        super(WarShipDesigner, self).__init__()
         self.additional_specifications.expected_turns_till_fight = 10 if fo.currentTurn() < 50 else 5
 
     def _rating_function(self):
@@ -1774,9 +1774,7 @@ class CarrierShipDesigner(MilitaryShipDesignerBaseClass):
     NAME_THRESHOLDS = sorted([0, 1000])
 
     def __init__(self):
-        ShipDesigner.__init__(self)
-        self.additional_specifications.minimum_fuel = 1
-        self.additional_specifications.minimum_speed = 30
+        super(CarrierShipDesigner, self).__init__()
         self.additional_specifications.expected_turns_till_fight = 10 if fo.currentTurn() < 50 else 5
         self.additional_specifications.minimum_fighter_launch_rate = 1
 


### PR DESCRIPTION
Playtesting of the recent fuel changes to hulls indicates that the AI currently doesn't handle fleets with low fuel capacity very well - especially considering it will generally spam only 1 type of ship. In the future, the AI should probably build a few dedicated high-fuel ships for long-range missions.

For now, require each design to have at least 2 fuel (generally easily achievable using the internal slots).