### PR TITLE
UDP FOCS

### DIFF
--- a/client/ClientApp.cpp
+++ b/client/ClientApp.cpp
@@ -15,7 +15,6 @@
 
 ClientApp::ClientApp() :
     IApp(),
-    m_universe(),
     m_networking(std::make_shared<ClientNetworking>()),
     m_empire_id(ALL_EMPIRES),
     m_current_turn(INVALID_GAME_TURN)

--- a/network/ServerNetworking.h
+++ b/network/ServerNetworking.h
@@ -183,9 +183,9 @@ public:
 
 private:
     void Init();
-    void AcceptNextConnection();
-    void AcceptConnection(PlayerConnectionPtr player_connection,
-                          const boost::system::error_code& error);
+    void AcceptNextMessagingConnection();
+    void AcceptPlayerMessagingConnection(PlayerConnectionPtr player_connection,
+                                         const boost::system::error_code& error);
     void DisconnectImpl(PlayerConnectionPtr player_connection);
     void EnqueueEvent(const NullaryFn& fn);
 

--- a/parse/BuildingsParser.cpp
+++ b/parse/BuildingsParser.cpp
@@ -48,7 +48,8 @@ namespace {
     struct grammar : public parse::detail::grammar<start_rule_signature> {
         grammar(const parse::lexer& tok,
                 const std::string& filename,
-                const parse::text_iterator& first, const parse::text_iterator& last) :
+                const parse::text_iterator& first,
+                const parse::text_iterator& last) :
             grammar::base_type(start),
             condition_parser(tok, label),
             string_grammar(tok, label, condition_parser),

--- a/parse/DoubleValueRefParser.cpp
+++ b/parse/DoubleValueRefParser.cpp
@@ -1,5 +1,6 @@
 #include "ValueRefParser.h"
 
+#include "Parse.h"
 #include "MovableEnvelope.h"
 #include "../universe/ValueRef.h"
 

--- a/parse/DoubleValueRefParser.cpp
+++ b/parse/DoubleValueRefParser.cpp
@@ -145,3 +145,20 @@ parse::double_parser_rules::double_parser_rules(
     debug(double_complex_variable);
 #endif
 }
+
+namespace parse {
+    bool double_free_variable(std::string& text) {
+        const lexer tok;
+        boost::spirit::qi::in_state_type in_state;
+        parse::detail::simple_double_parser_rules simple_double_rules(tok);
+
+        text_iterator first = text.begin();
+        text_iterator last = text.end();
+        token_iterator it = tok.begin(first, last);
+
+        bool success = boost::spirit::qi::phrase_parse(
+            it, tok.end(), simple_double_rules.free_variable_name, in_state("WS")[tok.self]);
+
+        return success;
+    }
+}

--- a/parse/EffectParser.cpp
+++ b/parse/EffectParser.cpp
@@ -42,7 +42,7 @@ namespace parse {
     /** effects_parser_grammar::Impl holds the rules for
         effects_parser_grammar. */
     struct effects_parser_grammar::Impl {
-        Impl (const effects_parser_grammar& effects_parser_grammar,
+        Impl(const effects_parser_grammar& effects_parser_grammar,
             const lexer& tok,
             detail::Labeller& label,
             const detail::condition_parser_grammar& condition_parser,

--- a/parse/EffectParser1.cpp
+++ b/parse/EffectParser1.cpp
@@ -217,7 +217,7 @@ namespace parse { namespace detail {
             (
                 label(tok.Tag_)  >  tok.string [ _a = _1 ] >
                 label(tok.Data_)
-                >  ( int_rules.expr      [ _b = construct_movable_(new_<ValueRef::StringCast<int>>(deconstruct_movable_(_1, _pass))) ]
+                >  (   int_rules.expr    [ _b = construct_movable_(new_<ValueRef::StringCast<int>>(deconstruct_movable_(_1, _pass))) ]
                      | double_rules.expr [ _b = construct_movable_(new_<ValueRef::StringCast<double>>(deconstruct_movable_(_1, _pass))) ]
                      | tok.string        [ _b = construct_movable_(new_<ValueRef::Constant<std::string>>(_1)) ]
                      | string_grammar    [ _b = _1 ]

--- a/parse/EncyclopediaParser.cpp
+++ b/parse/EncyclopediaParser.cpp
@@ -72,7 +72,7 @@ namespace {
             qi::on_error<qi::fail>(start, parse::report_error(filename, first, last, _1, _2, _3, _4));
         }
 
-        using  strings_rule = parse::detail::rule<void (ArticleMap&)>;
+        using strings_rule = parse::detail::rule<void (ArticleMap&)>;
 
         using start_rule = parse::detail::rule<start_rule_signature>;
 

--- a/parse/IntValueRefParser.cpp
+++ b/parse/IntValueRefParser.cpp
@@ -1,5 +1,6 @@
 #include "ValueRefParser.h"
 
+#include "Parse.h"
 #include "MovableEnvelope.h"
 #include "../universe/ValueRef.h"
 

--- a/parse/IntValueRefParser.cpp
+++ b/parse/IntValueRefParser.cpp
@@ -129,3 +129,20 @@ parse::int_arithmetic_rules::int_arithmetic_rules(
         |   int_complex_grammar
         ;
 }
+
+namespace parse {
+    bool int_free_variable(std::string& text) {
+        const lexer tok;
+        boost::spirit::qi::in_state_type in_state;
+        parse::detail::simple_int_parser_rules simple_int_rules(tok);
+
+        text_iterator first = text.begin();
+        text_iterator last = text.end();
+        token_iterator it = tok.begin(first, last);
+
+        bool success = boost::spirit::qi::phrase_parse(
+            it, tok.end(), simple_int_rules.free_variable_name, in_state("WS")[tok.self]);
+
+        return success;
+    }
+}

--- a/parse/Parse.h
+++ b/parse/Parse.h
@@ -72,12 +72,16 @@ namespace parse {
 
     /** Find all FOCS scripts (files with .focs.txt suffix) in \p path.  If \p allow_permissive =
         true then if \p path is not empty and there are no .focs.txt files allow all files to qualify.*/
-    FO_PARSE_API std::vector< boost::filesystem::path > ListScripts(const boost::filesystem::path& path, bool permissive = false);
+    FO_PARSE_API std::vector<boost::filesystem::path> ListScripts(const boost::filesystem::path& path, bool permissive = false);
 
     FO_PARSE_API void file_substitution(std::string& text, const boost::filesystem::path& file_search_path);
-    FO_PARSE_API void process_include_substitutions(std::string& text, 
-                                                    const boost::filesystem::path& file_search_path, 
+    FO_PARSE_API void process_include_substitutions(std::string& text,
+                                                    const boost::filesystem::path& file_search_path,
                                                     std::set<boost::filesystem::path>& files_included);
+
+    FO_PARSE_API bool int_free_variable(std::string& text);
+    FO_PARSE_API bool double_free_variable(std::string& text);
+    FO_PARSE_API bool string_free_variable(std::string& text);
 }
 
 #endif

--- a/parse/StringComplexValueRefParser.cpp
+++ b/parse/StringComplexValueRefParser.cpp
@@ -73,7 +73,7 @@ namespace parse { namespace detail {
             ;
 
         start
-            %=   game_rule
+            %=  game_rule
             |   empire_ref
             |   empire_empire_ref
             ;

--- a/parse/StringValueRefParser.cpp
+++ b/parse/StringValueRefParser.cpp
@@ -1,5 +1,6 @@
 #include "ValueRefParser.h"
 
+#include "Parse.h"
 #include "ConditionParserImpl.h"
 #include "EnumValueRefRules.h"
 #include "MovableEnvelope.h"

--- a/parse/StringValueRefParser.cpp
+++ b/parse/StringValueRefParser.cpp
@@ -1,5 +1,6 @@
 #include "ValueRefParser.h"
 
+#include "ConditionParserImpl.h"
 #include "EnumValueRefRules.h"
 #include "MovableEnvelope.h"
 #include "../universe/ValueRef.h"
@@ -161,4 +162,19 @@ namespace parse {
     detail::value_ref_rule<std::string> primary_expr;
     detail::reference_token_rule variable_scope_rule;
     detail::name_token_rule container_type_rule;
-};
+
+
+    bool string_free_variable(std::string& text) {
+        const lexer tok;
+        boost::spirit::qi::in_state_type in_state;
+
+        text_iterator first = text.begin();
+        text_iterator last = text.end();
+        token_iterator it = tok.begin(first, last);
+
+        bool success = boost::spirit::qi::phrase_parse(
+            it, tok.end(), tok.GalaxySeed_, in_state("WS")[tok.self]);
+
+        return success;
+    }
+}

--- a/parse/ValueRefParser.h
+++ b/parse/ValueRefParser.h
@@ -246,7 +246,7 @@ namespace parse {
             detail::Labeller& label,
             const detail::condition_parser_grammar& condition_parser,
             const detail::value_ref_grammar<std::string>& string_grammar);
-        detail::simple_int_parser_rules  simple_int_rules;
+        detail::simple_int_parser_rules simple_int_rules;
         int_complex_parser_grammar int_complex_grammar;
     };
 

--- a/universe/ValueRef.cpp
+++ b/universe/ValueRef.cpp
@@ -1110,7 +1110,7 @@ std::vector<std::string> Variable<std::vector<std::string>>::Eval(
     IF_CURRENT_VALUE(std::vector<std::string>)
 
     if (m_ref_type == NON_OBJECT_REFERENCE) {
-        // add more non-object reference int functions here
+        // add more non-object reference string vector functions here
         ErrorLogger() << "std::vector<std::string>::Eval unrecognized non-object property: " << TraceReference(m_property_name, m_ref_type, context);
         if (context.source)
             ErrorLogger() << "source: " << context.source->ObjectType() << " "
@@ -1177,6 +1177,7 @@ std::string Variable<std::string>::Eval(const ScriptingContext& context) const
         if (property_name == "GalaxySeed")
             return GetGalaxySetupData().GetSeed();
 
+        // add more non-object reference string functions here
         ErrorLogger() << "Variable<std::string>::Eval unrecognized non-object property: " << TraceReference(m_property_name, m_ref_type, context);
         if (context.source)
             ErrorLogger() << "source: " << context.source->ObjectType() << " "


### PR DESCRIPTION
Allows UDP messages to server to provide more information than just whether the server can host a game. Simple context-free FOCS queries are parsed and evaluated and returned by UDP message to the sender.