### PR TITLE
Ensure that no hull has less than 1 fuel

### DIFF
--- a/default/scripting/ship_hulls/asteroid/SH_HEAVY_ASTEROID.focs.txt
+++ b/default/scripting/ship_hulls/asteroid/SH_HEAVY_ASTEROID.focs.txt
@@ -2,17 +2,16 @@ Hull
     name = "SH_HEAVY_ASTEROID"
     description = "SH_HEAVY_ASTEROID_DESC"
     speed = 60
-    fuel = 1
+    fuel = 2
     stealth = 5
     structure = 50
     slots = [
-        Slot type = External position = (0.30, 0.25)
         Slot type = External position = (0.45, 0.25)
         Slot type = External position = (0.60, 0.25)
+        Slot type = External position = (0.30, 0.50)
         Slot type = External position = (0.75, 0.50)
         Slot type = External position = (0.52, 0.75)
         Slot type = External position = (0.68, 0.75)
-        Slot type = Internal position = (0.30, 0.50)
         Slot type = Internal position = (0.45, 0.50)
         Slot type = Internal position = (0.60, 0.50)
     ]

--- a/default/scripting/ship_hulls/robotic/SH_LOGITICS_FACILITATOR.focs.txt
+++ b/default/scripting/ship_hulls/robotic/SH_LOGITICS_FACILITATOR.focs.txt
@@ -2,13 +2,12 @@ Hull
     name = "SH_LOGISTICS_FACILITATOR"
     description = "SH_LOGISTICS_FACILITATOR_DESC"
     speed = 80
-    fuel = 1.5
+    fuel = 2
     stealth = 5
     structure = 110
     slots = [
         Slot type = External position = (0.10, 0.15)
-        Slot type = External position = (0.22, 0.15)
-        Slot type = External position = (0.34, 0.15)
+        Slot type = External position = (0.28, 0.15)
         Slot type = External position = (0.46, 0.15)
         Slot type = External position = (0.58, 0.15)
         Slot type = External position = (0.70, 0.15)

--- a/default/scripting/ship_hulls/robotic/SH_SELF_GRAVITATING.focs.txt
+++ b/default/scripting/ship_hulls/robotic/SH_SELF_GRAVITATING.focs.txt
@@ -2,14 +2,13 @@ Hull
     name = "SH_SELF_GRAVITATING"
     description = "SH_SELF_GRAVITATING_DESC"
     speed = 80
-    fuel = 1.5
+    fuel = 2
     stealth = -5
     structure = 100
     slots = [
         Slot type = External position = (0.20, 0.15)
         Slot type = External position = (0.35, 0.15)
         Slot type = External position = (0.50, 0.15)
-        Slot type = External position = (0.65, 0.15)
         Slot type = External position = (0.40, 0.80)
         Slot type = Core     position = (0.50, 0.50)
         Slot type = External position = (0.80, 0.50)


### PR DESCRIPTION
This implements a solution to #2521 - [forum post](https://www.freeorion.org/forum/viewtopic.php?f=28&t=11321&p=96805#p96860); with this fix all hulls have more than 1 effective fuel so it is impossible to get ships completely stranded
* heavy asteroid hull looses one internal slot and gains 0.6 effective fuel
* logistics facilitator looses one external slot and gains 0.3 effective fuel
* self gravitating hull looses one external slot and gains 0.3 effective fuel