### PR TITLE
disable issuing fleet movement orders after turn button has been pressed

### DIFF
--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -5436,7 +5436,7 @@ void MapWnd::SystemRightClicked(int system_id, GG::Flags<GG::ModKey> mod_keys) {
         if (system_id == INVALID_OBJECT_ID)
             ClearProjectedFleetMovementLines();
         else
-            PlotFleetMovement(system_id, true, mod_keys &  GG::MOD_KEY_SHIFT);
+            PlotFleetMovement(system_id, !m_ready_turn, mod_keys &  GG::MOD_KEY_SHIFT);
         SystemRightClickedSignal(system_id);
     }
 }


### PR DESCRIPTION
In multiplayer, it is currently possible to issue fleet movement orders after pressing the turn button, which do get executed despite that the turn has ended. However, this is inconsistent with other UI elements and has the player confused if his fleet movement orders will be executed or not. For that reason I would suggest to disallow giving fleet movement orders after the turn buttons has been pressed.