### PR TITLE
Add extra fuel Titan (-1 ext) and Scattered Ast. (-2 ext) Hulls

### DIFF
--- a/default/scripting/ship_hulls/asteroid/SH_SCATTERED_ASTEROID.focs.txt
+++ b/default/scripting/ship_hulls/asteroid/SH_SCATTERED_ASTEROID.focs.txt
@@ -2,7 +2,7 @@ Hull
     name = "SH_SCATTERED_ASTEROID"
     description = "SH_SCATTERED_ASTEROID_DESC"
     speed = 60
-    fuel = 1
+    fuel = 2
     stealth = 5
     structure = 140
     slots = [
@@ -12,7 +12,7 @@ Hull
         Slot type = External position = (0.50, 0.15)
         Slot type = External position = (0.60, 0.15)
         Slot type = External position = (0.70, 0.15)
-        Slot type = External position = (0.80, 0.15)
+        //Slot type = External position = (0.80, 0.15)
         Slot type = External position = (0.85, 0.50)
         Slot type = External position = (0.20, 0.85)
         Slot type = External position = (0.30, 0.85)
@@ -20,7 +20,7 @@ Hull
         Slot type = External position = (0.50, 0.85)
         Slot type = External position = (0.60, 0.85)
         Slot type = External position = (0.70, 0.85)
-        Slot type = External position = (0.80, 0.85)
+        //Slot type = External position = (0.80, 0.85)
         Slot type = Internal position = (0.20, 0.50)
         Slot type = Internal position = (0.30, 0.50)
         Slot type = Internal position = (0.60, 0.50)

--- a/default/scripting/ship_hulls/robotic/SH_TITANIC.focs.txt
+++ b/default/scripting/ship_hulls/robotic/SH_TITANIC.focs.txt
@@ -2,7 +2,7 @@ Hull
     name = "SH_TITANIC"
     description = "SH_TITANIC_DESC"
     speed = 80
-    fuel = 1.5
+    fuel = 2
     stealth = -35
     structure = 160
     slots = [
@@ -13,7 +13,8 @@ Hull
         Slot type = External position = (0.50, 0.15)
         Slot type = External position = (0.60, 0.15)
         Slot type = External position = (0.70, 0.15)
-        Slot type = External position = (0.80, 0.15)
+        //Slot type = External position = (0.80, 0.15)
+        Slot type = External position = (0.85, 0.50)
         Slot type = External position = (0.10, 0.85)
         Slot type = External position = (0.20, 0.85)
         Slot type = External position = (0.30, 0.85)
@@ -21,7 +22,7 @@ Hull
         Slot type = External position = (0.50, 0.85)
         Slot type = External position = (0.60, 0.85)
         Slot type = External position = (0.70, 0.85)
-        Slot type = External position = (0.80, 0.85)
+        //Slot type = External position = (0.80, 0.85)
         Slot type = Internal position = (0.30, 0.50)
         Slot type = Internal position = (0.60, 0.50)
         Slot type = Internal position = (0.70, 0.50)


### PR DESCRIPTION
In order to have at least one maximum fuel (#2521)
* Titanic Hull +0.3 effective max fuel -1 external Slot
* Scattered Asteroid Hull +0.6 effective max fuel -2 external Slots

I had a look at the efficiencies on Plasma 4/Diamond Armor level and the changes look ok to me (only slight changes to balance).