### PR TITLE
Two effective fuel for robo hull

### DIFF
--- a/default/scripting/ship_hulls/robotic/SH_ROBOTIC.focs.txt
+++ b/default/scripting/ship_hulls/robotic/SH_ROBOTIC.focs.txt
@@ -2,7 +2,7 @@ Hull
     name = "SH_ROBOTIC"
     description = "SH_ROBOTIC_DESC"
     speed = 75
-    fuel = 1.5
+    fuel = 2
     stealth = 5
     structure = 25
     slots = [


### PR DESCRIPTION
Balance: robo hulls are considered UP. Slight buff to 2 effective fuel (+0.5 base fuel)
    
Following the [conclusion of discussion](https://www.freeorion.org/forum/viewtopic.php?f=28&t=11321&start=15#p97269)
