### PR TITLE
Make Scylior BAD_SUPPLY and BAD_FUEL

### DIFF
--- a/default/scripting/species/SP_SCYLIOR.focs.txt
+++ b/default/scripting/species/SP_SCYLIOR.focs.txt
@@ -7,7 +7,7 @@ Species
     CanProduceShips
     CanColonize
 
-    tags = [ "ORGANIC" "GREAT_RESEARCH" "GOOD_POPULATION" "AVERAGE_SUPPLY" "PEDIA_ORGANIC_SPECIES_CLASS" ]
+    tags = [ "ORGANIC" "GREAT_RESEARCH" "GOOD_POPULATION" "BAD_SUPPLY" "PEDIA_ORGANIC_SPECIES_CLASS" ]
 
     foci = [
         [[HAS_INDUSTRY_FOCUS]]
@@ -25,8 +25,10 @@ Species
 
         [[GOOD_POPULATION]]
         [[AVERAGE_HAPPINESS]]
-        [[AVERAGE_SUPPLY]]
+        [[BAD_SUPPLY]]
         [[AVERAGE_DEFENSE_TROOPS]]
+
+        [[BAD_FUEL]]
 
         // not for description
         [[AVERAGE_PLANETARY_SHIELDS]]


### PR DESCRIPTION
As discussed [in the forums](https://www.freeorion.org/forum/viewtopic.php?f=28&t=10985#p97400) Scylior need a nerf.

Making supply and fuel bad hinders early expansion compared to the other species.

I playtested twice until about turn 50 and got interesting early games. Not sure if the nerf is enough but it is certainly good. 
