### PR TITLE
Fix ship designs after slot changes (Self Gravi & Titanic)

### DIFF
--- a/default/scripting/ship_designs/SD_GRAVITATING1.focs.txt
+++ b/default/scripting/ship_designs/SD_GRAVITATING1.focs.txt
@@ -7,7 +7,6 @@ ShipDesign
         "SR_WEAPON_3_1"
         "SR_WEAPON_3_1"
         "SR_WEAPON_3_1"
-        "SR_WEAPON_3_1"
         "SR_WEAPON_0_1"
         ""
         "AR_DIAMOND_PLATE"

--- a/default/scripting/ship_designs/SD_GRAVITATING2.focs.txt
+++ b/default/scripting/ship_designs/SD_GRAVITATING2.focs.txt
@@ -7,7 +7,6 @@ ShipDesign
         "SR_WEAPON_4_1"
         "SR_WEAPON_4_1"
         "SR_WEAPON_4_1"
-        "SR_WEAPON_4_1"
         "SR_WEAPON_0_1"
         "FU_SINGULARITY_ENGINE_CORE"
         "AR_XENTRONIUM_PLATE"

--- a/default/scripting/ship_designs/SD_ROBO_TITAN1.focs.txt
+++ b/default/scripting/ship_designs/SD_ROBO_TITAN1.focs.txt
@@ -11,7 +11,6 @@ ShipDesign
         "SR_WEAPON_4_1"
         "SR_WEAPON_4_1"
         "SR_WEAPON_4_1"
-        "SR_WEAPON_4_1"
         "AR_XENTRONIUM_PLATE"
         "AR_XENTRONIUM_PLATE"
         "FT_BAY_1"


### PR DESCRIPTION
370cf80da4c03ff2ecff1742e075a094af3d563a changed slots for heavy asteroid, logistics facilitator, and self gravitational hulls.

61ae7f82cd28f4e9a0eaddf625ef95b711a99b00 changed slots for scattered asteroid, and titanic hull.

This commit adjusts premade designs accordingly.

Also without the fix the CI tests are broken.