### PR TITLE
Inform other empires about detection increase

### DIFF
--- a/default/customizations/custom_sitreps.txt
+++ b/default/customizations/custom_sitreps.txt
@@ -104,6 +104,33 @@ EffectsGroup
             ]
             empire = Source.Owner
 
+EffectsGroup
+    scope = And [
+        Capital
+        Not OwnedBy empire = Source.Owner
+        Number low = 1 condition = And [
+            // maybe speed up by ORing subcategories
+            OwnedBy empire = Source.Owner
+            VisibleToEmpire empire = RootCandidate.Owner
+        ]
+    ]
+    activation = Or [
+       (CurrentTurn == TurnTechResearched empire = Source.Owner name = "SPY_DETECT_2")
+       (CurrentTurn == TurnTechResearched empire = Source.Owner name = "SPY_DETECT_3")
+       (CurrentTurn == TurnTechResearched empire = Source.Owner name = "SPY_DETECT_4")
+       (CurrentTurn == TurnTechResearched empire = Source.Owner name = "SPY_DETECT_5")
+    ]
+    priority = [[END_CLEANUP_PRIORITY]]
+    effects =
+        GenerateSitRepMessage
+            message = "SITREP_EMPIRE_TECH_RESEARCHED_DETECTION"
+            label = "SITREP_EMPIRE_TECH_RESEARCHED_DETECTION_LABEL"
+            icon = "icons/tech/active_radar.png"
+            parameters = [
+                tag = "empire"    data = Source.Owner
+                tag = "dstrength" data = EmpireMeterValue empire = Source.Owner meter = "METER_DETECTION_STRENGTH"
+            ]
+            empire = Target.Owner
 
 EffectsGroup
     scope = And [

--- a/default/customizations/custom_sitreps.txt
+++ b/default/customizations/custom_sitreps.txt
@@ -104,15 +104,11 @@ EffectsGroup
             ]
             empire = Source.Owner
 
+// Tell all the others that you have better detection tech (the information is public anyway)
 EffectsGroup
     scope = And [
         Capital
         Not OwnedBy empire = Source.Owner
-        Number low = 1 condition = And [
-            // maybe speed up by ORing subcategories
-            OwnedBy empire = Source.Owner
-            VisibleToEmpire empire = RootCandidate.Owner
-        ]
     ]
     activation = Or [
        (CurrentTurn == TurnTechResearched empire = Source.Owner name = "SPY_DETECT_2")

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -6576,7 +6576,7 @@ SITREP_EMPIRE_TECH_RESEARCHED_DETECTION
 The %empire% [[encyclopedia DETECTION_TITLE]] has upgraded to %rawtext:dstrength%
 
 SITREP_EMPIRE_TECH_RESEARCHED_DETECTION_LABEL
-Enemy Tech Upgrade
+Empire Detection Tech Upgrade
 
 SITREP_TECH_UNLOCKED
 %tech% has been unlocked and can now be researched.

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -6572,6 +6572,12 @@ SITREP_TECH_RESEARCHED
 SITREP_TECH_RESEARCHED_LABEL
 Tech Researched
 
+SITREP_EMPIRE_TECH_RESEARCHED_DETECTION
+The %empire% upgraded their detection technology to %rawtext:dstrength% [[encyclopedia DETECTION_TITLE]]
+
+SITREP_EMPIRE_TECH_RESEARCHED_DETECTION_LABEL
+Enemy Tech Upgrade
+
 SITREP_TECH_UNLOCKED
 %tech% has been unlocked and can now be researched.
 

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -6573,7 +6573,7 @@ SITREP_TECH_RESEARCHED_LABEL
 Tech Researched
 
 SITREP_EMPIRE_TECH_RESEARCHED_DETECTION
-The %empire% upgraded their detection technology to %rawtext:dstrength% [[encyclopedia DETECTION_TITLE]]
+The %empire% [[encyclopedia DETECTION_TITLE]] has upgraded to %rawtext:dstrength%
 
 SITREP_EMPIRE_TECH_RESEARCHED_DETECTION_LABEL
 Enemy Tech Upgrade


### PR DESCRIPTION
As the SitReps for newly researched tech are generated on the same turn as the meter effects this is a simple implementation to inform players that they observed another empire upgrading their detection tech. 

So this supersedes #2344

[SitRep for enemy sensor tech advances?](https://www.freeorion.org/forum/viewtopic.php?f=6&t=11150)
