### PR TITLE
Silence Refuel Message if less than 1 MaxFuel. Set 0.x MaxFuel to 0

### DIFF
--- a/default/scripting/ship_hulls/ship_hulls.macros
+++ b/default/scripting/ship_hulls/ship_hulls.macros
@@ -128,6 +128,7 @@ REFUEL_MESSAGE
     activation = And [
         Stationary
         (Source.Fuel < 1)
+        (Source.MaxFuel >= 1)
         (Source.Fuel
          + @1@ * (Statistic If Condition = Turn low = Source.ArrivedOnTurn + 1)
          + 0.1 * (Statistic If Condition = DesignHasPart name = "FU_RAMSCOOP")
@@ -197,6 +198,17 @@ HULL_FUEL_EFFICIENCY_EFFECTSGROUP
             accountinglabel = "@1@_FUEL_EFFICIENCY_LABEL"
             priority = [[VERY_LATE_PRIORITY]]
             effects = SetMaxFuel value = @2@ * Statistic If Condition = And [ Object id = Source.ID HasTag name = "@1@_FUEL_EFFICIENCY" ]
+
+     EffectsGroup
+            description = "MAX_FUEL_LESS_THAN_ONE_DESC"
+            scope = And [
+                Ship
+                Source
+                MaxFuel high = 0.9999
+            ]
+            accountinglabel = "MAX_FUEL_LESS_THAN_ONE_LABEL"
+            priority = [[METER_OVERRIDE_PRIORITY]]
+            effects = SetMaxFuel value = 0
 '''
 
 #include "/scripting/common/priorities.macros"

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -15217,6 +15217,12 @@ Hull <i>%2%</i> [[encyclopedia FUEL_EFFICIENCY_TITLE]] 100%%
 BAD_FUEL_EFFICIENCY_LABEL
 Hull <i>%2%</i> [[encyclopedia FUEL_EFFICIENCY_TITLE]] 60%%
 
+MAX_FUEL_LESS_THAN_ONE_DESC
+Refueling Impossible
+
+MAX_FUEL_LESS_THAN_ONE_LABEL
+Fuel Tank Too Small for Refuel (Max Fuel < 1.0)
+
 SPATIAL_FLUX_MALUS
 Flux Interference
 


### PR DESCRIPTION
If you have BAD_FUEL it is still possible to have less than 1.0 MaxFuel on a BAD_FUEL_EFFICIENCY hull.
Also for there may be other effects in future.

So
* Check that MaxFuel is at least one for writing refuel message
* At the end of effect application set MaxFuel to Zero if it is less than one (itended to help the user)

These solutions were somewhere disccussed (i believe as comments in a merged PR) but I can not find it.