### PR TITLE
Fix initial unlock SitReps

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -1357,6 +1357,10 @@ void Empire::AddNewlyResearchedTechToGrantAtStartOfNextTurn(const std::string& n
     auto result = m_newly_researched_techs.insert(name);
     if (result.second)
         AddSitRepEntry(CreateTechResearchedSitRep(name));
+
+    // Unlock items now as the SitReps get generated already for CurrentTurn()+1
+    for (const ItemSpec& item : tech->UnlockedItems())
+        UnlockItem(item);  // potential infinite if a tech (in)directly unlocks itself?
 }
 
 void Empire::ApplyNewTechs() {
@@ -1367,9 +1371,8 @@ void Empire::ApplyNewTechs() {
             continue;
         }
 
-        for (const ItemSpec& item : tech->UnlockedItems())
-            UnlockItem(item);  // potential infinite if a tech (in)directly unlocks itself?
-
+        // Items are already unlocked
+        // Register the techs with CurrentTurn() as this gets called after turn increase
         if (!m_techs.count(new_tech))
             m_techs[new_tech] = CurrentTurn();
     }

--- a/util/SitRepEntry.cpp
+++ b/util/SitRepEntry.cpp
@@ -103,7 +103,7 @@ SitRepEntry CreateBuildingBuiltSitRep(int building_id, int planet_id) {
 SitRepEntry CreateTechUnlockedSitRep(const std::string& tech_name) {
     SitRepEntry sitrep(
         UserStringNop("SITREP_TECH_UNLOCKED"),
-        CurrentTurn(),
+        CurrentTurn() <= 0 ? BEFORE_FIRST_TURN + 1 : CurrentTurn(),
         "icons/sitrep/tech_unlocked.png",
         UserStringNop("SITREP_TECH_UNLOCKED_LABEL"), true);
     sitrep.AddVariable(VarText::TECH_TAG,          tech_name);
@@ -113,7 +113,7 @@ SitRepEntry CreateTechUnlockedSitRep(const std::string& tech_name) {
 SitRepEntry CreateBuildingTypeUnlockedSitRep(const std::string& building_type_name) {
     SitRepEntry sitrep(
         UserStringNop("SITREP_BUILDING_TYPE_UNLOCKED"),
-        CurrentTurn(),
+        CurrentTurn() <= 0 ? BEFORE_FIRST_TURN + 1 : CurrentTurn(),
         "icons/sitrep/building_type_unlocked.png",
         UserStringNop("SITREP_BUILDING_TYPE_UNLOCKED_LABEL"), true);
     sitrep.AddVariable(VarText::BUILDING_TYPE_TAG,  building_type_name);
@@ -123,7 +123,7 @@ SitRepEntry CreateBuildingTypeUnlockedSitRep(const std::string& building_type_na
 SitRepEntry CreateShipHullUnlockedSitRep(const std::string& ship_hull_name) {
     SitRepEntry sitrep(
         UserStringNop("SITREP_SHIP_HULL_UNLOCKED"),
-        CurrentTurn(),
+        CurrentTurn() <= 0 ? BEFORE_FIRST_TURN + 1 : CurrentTurn(),
         "icons/sitrep/ship_hull_unlocked.png",
         UserStringNop("SITREP_SHIP_HULL_UNLOCKED_LABEL"), true);
     sitrep.AddVariable(VarText::SHIP_HULL_TAG,      ship_hull_name);
@@ -133,7 +133,7 @@ SitRepEntry CreateShipHullUnlockedSitRep(const std::string& ship_hull_name) {
 SitRepEntry CreateShipPartUnlockedSitRep(const std::string& ship_part_name) {
     SitRepEntry sitrep(
         UserStringNop("SITREP_SHIP_PART_UNLOCKED"),
-        CurrentTurn(),
+        CurrentTurn() <= 0 ? BEFORE_FIRST_TURN + 1 : CurrentTurn(),
         "icons/sitrep/ship_part_unlocked.png",
         UserStringNop("SITREP_SHIP_PART_UNLOCKED_LABEL"), true);
     sitrep.AddVariable(VarText::SHIP_PART_TAG,      ship_part_name);

--- a/util/SitRepEntry.cpp
+++ b/util/SitRepEntry.cpp
@@ -103,7 +103,7 @@ SitRepEntry CreateBuildingBuiltSitRep(int building_id, int planet_id) {
 SitRepEntry CreateTechUnlockedSitRep(const std::string& tech_name) {
     SitRepEntry sitrep(
         UserStringNop("SITREP_TECH_UNLOCKED"),
-        CurrentTurn() <= 0 ? BEFORE_FIRST_TURN + 1 : CurrentTurn(),
+        CurrentTurn() + 1,
         "icons/sitrep/tech_unlocked.png",
         UserStringNop("SITREP_TECH_UNLOCKED_LABEL"), true);
     sitrep.AddVariable(VarText::TECH_TAG,          tech_name);
@@ -113,7 +113,7 @@ SitRepEntry CreateTechUnlockedSitRep(const std::string& tech_name) {
 SitRepEntry CreateBuildingTypeUnlockedSitRep(const std::string& building_type_name) {
     SitRepEntry sitrep(
         UserStringNop("SITREP_BUILDING_TYPE_UNLOCKED"),
-        CurrentTurn() <= 0 ? BEFORE_FIRST_TURN + 1 : CurrentTurn(),
+        CurrentTurn() + 1,
         "icons/sitrep/building_type_unlocked.png",
         UserStringNop("SITREP_BUILDING_TYPE_UNLOCKED_LABEL"), true);
     sitrep.AddVariable(VarText::BUILDING_TYPE_TAG,  building_type_name);
@@ -123,7 +123,7 @@ SitRepEntry CreateBuildingTypeUnlockedSitRep(const std::string& building_type_na
 SitRepEntry CreateShipHullUnlockedSitRep(const std::string& ship_hull_name) {
     SitRepEntry sitrep(
         UserStringNop("SITREP_SHIP_HULL_UNLOCKED"),
-        CurrentTurn() <= 0 ? BEFORE_FIRST_TURN + 1 : CurrentTurn(),
+        CurrentTurn() + 1,
         "icons/sitrep/ship_hull_unlocked.png",
         UserStringNop("SITREP_SHIP_HULL_UNLOCKED_LABEL"), true);
     sitrep.AddVariable(VarText::SHIP_HULL_TAG,      ship_hull_name);
@@ -133,7 +133,7 @@ SitRepEntry CreateShipHullUnlockedSitRep(const std::string& ship_hull_name) {
 SitRepEntry CreateShipPartUnlockedSitRep(const std::string& ship_part_name) {
     SitRepEntry sitrep(
         UserStringNop("SITREP_SHIP_PART_UNLOCKED"),
-        CurrentTurn() <= 0 ? BEFORE_FIRST_TURN + 1 : CurrentTurn(),
+        CurrentTurn() + 1,
         "icons/sitrep/ship_part_unlocked.png",
         UserStringNop("SITREP_SHIP_PART_UNLOCKED_LABEL"), true);
     sitrep.AddVariable(VarText::SHIP_PART_TAG,      ship_part_name);


### PR DESCRIPTION
Geoff partly fixed this while I was working on it simultaneously, this adds some finetuning of initial unlock sitreps.

As technology research was shifted after turn increase, SitReps for items unlocked by tech
are shown one turn after they are actually available (e.g. one turn after you can actually
enqueue Automated History Analyser).

This implementation fixes it by shifting the target turn for the unlock SitReps by minus one.
This makes a problem with the messages for initially unlocked items because those are registered
in minimal integer turn (e.g. -32767) which is 1+BEFORE_FIRST_TURN.

In order to fix this for turn zero or smaller I set the sitrep to a specific value.
If I set it to -1 , there are actually shown two different initial turns in the SitRep (one for
the real initial turn and one for -1)

This implementation fixes it by setting the sitrep turn to BEFORE_FIRST_TURN + 1

But usually for all that SitRep code, CurrentTurn()+1 is used so in future there might be a code
path for which the used CurrentTurn()+0 is wrong.

Also manipulating the turn number seems hackish.

So a better implementation could be to reverse the timing of the unlock by shifting it from
ApplyNewTechs to AddNewlyResearchedTechToGrantAtStartOfNextTurn.