### PR TITLE
Fix bug introduced by #2577

### DIFF
--- a/default/scripting/ship_hulls/ship_hulls.macros
+++ b/default/scripting/ship_hulls/ship_hulls.macros
@@ -204,11 +204,12 @@ HULL_FUEL_EFFICIENCY_EFFECTSGROUP
             scope = And [
                 Ship
                 Source
-                MaxFuel high = 0.9999
+                // Issue #2567: using Not (Value(Source.MaxFuel) >= 1.0) here in the scope condition wrongly matches any object
             ]
             accountinglabel = "MAX_FUEL_LESS_THAN_ONE_LABEL"
             priority = [[METER_OVERRIDE_PRIORITY]]
-            effects = SetMaxFuel value = 0
+            effects = If condition = Not (Value(Source.MaxFuel) >= 1) effects = SetMaxFuel value = 0
+            // Issue #2567: using Value(Source.Fuel < 1) wrongly matches any object
 '''
 
 #include "/scripting/common/priorities.macros"

--- a/default/scripting/ship_hulls/ship_hulls.macros
+++ b/default/scripting/ship_hulls/ship_hulls.macros
@@ -204,12 +204,11 @@ HULL_FUEL_EFFICIENCY_EFFECTSGROUP
             scope = And [
                 Ship
                 Source
-                // Issue #2567: using Not (Value(Source.MaxFuel) >= 1.0) here in the scope condition wrongly matches any object
             ]
             accountinglabel = "MAX_FUEL_LESS_THAN_ONE_LABEL"
             priority = [[METER_OVERRIDE_PRIORITY]]
-            effects = If condition = Not (Value(Source.MaxFuel) >= 1) effects = SetMaxFuel value = 0
-            // Issue #2567: using Value(Source.Fuel < 1) wrongly matches any object
+            // Have to use Value() in effects, as all scope and activation conditions are evaluated before applying any effect
+            effects = If condition = (Value(Source.MaxFuel) < 1) effects = SetMaxFuel value = 0
 '''
 
 #include "/scripting/common/priorities.macros"

--- a/default/scripting/ship_hulls/ship_hulls.macros
+++ b/default/scripting/ship_hulls/ship_hulls.macros
@@ -192,8 +192,8 @@ HULL_FUEL_EFFICIENCY_EFFECTSGROUP
 '''     EffectsGroup
             description = "HULL_FUEL_EFFICIENCY_DESC"
             scope = And [
-                Ship
                 Source
+                Ship
             ]
             accountinglabel = "@1@_FUEL_EFFICIENCY_LABEL"
             priority = [[VERY_LATE_PRIORITY]]
@@ -202,8 +202,8 @@ HULL_FUEL_EFFICIENCY_EFFECTSGROUP
      EffectsGroup
             description = "MAX_FUEL_LESS_THAN_ONE_DESC"
             scope = And [
-                Ship
                 Source
+                Ship
             ]
             accountinglabel = "MAX_FUEL_LESS_THAN_ONE_LABEL"
             priority = [[METER_OVERRIDE_PRIORITY]]

--- a/default/scripting/ship_hulls/ship_hulls.macros
+++ b/default/scripting/ship_hulls/ship_hulls.macros
@@ -199,6 +199,10 @@ HULL_FUEL_EFFICIENCY_EFFECTSGROUP
             priority = [[VERY_LATE_PRIORITY]]
             effects = SetMaxFuel value = @2@ * Statistic If Condition = And [ Object id = Source.ID HasTag name = "@1@_FUEL_EFFICIENCY" ]
 
+     // If a ship has less than one maximum fuel it will never be able to travel out of supply so refueling does not make sense.
+     // In order to communicate that and to prevent wrong refuel sitreps, we set the maximum fuel for that case to zero
+     // I need the final MaxFuel value to decide if we should zero it.
+     // Scope and activation conditions are evaluated before the effects so using an If condition = Value() in effects expression instead
      EffectsGroup
             description = "MAX_FUEL_LESS_THAN_ONE_DESC"
             scope = And [
@@ -207,7 +211,6 @@ HULL_FUEL_EFFICIENCY_EFFECTSGROUP
             ]
             accountinglabel = "MAX_FUEL_LESS_THAN_ONE_LABEL"
             priority = [[METER_OVERRIDE_PRIORITY]]
-            // Have to use Value() in effects, as all scope and activation conditions are evaluated before applying any effect
             effects = If condition = (Value(Source.MaxFuel) < 1) effects = SetMaxFuel value = 0
 '''
 


### PR DESCRIPTION
MaxFuel in scope condition checks against the initial value which is always zero when calculating fuel for display in the encyclopedia. So this sets fuel always to zero. This condition commit was by mistake pushed to #2577 and merged as a fix for #2576 .

This PR fixes this by checking against the current value in effect evaluation.
