### PR TITLE
Don't clean empire readiness on player list changes

### DIFF
--- a/UI/PlayerListWnd.h
+++ b/UI/PlayerListWnd.h
@@ -16,6 +16,7 @@ public:
 
     //! \name Accessors //@{
     std::set<int>   SelectedPlayerIDs() const;
+    std::set<int>   ReadyEmpiresIDs() const; ///< Returns set of ready empires to restore them on updating player list
     //@}
 
     //! \name Mutators //@{
@@ -24,7 +25,7 @@ public:
     void            HandleEmpireStatusUpdate(Message::PlayerStatus player_status, int about_empire_id);
     void            HandleDiplomaticMessageChange(int empire1_id, int empire2_id);
     void            Update();
-    void            Refresh();
+    void            Refresh(bool clean_empire_status);
     void            Clear();
 
     void            SetSelectedPlayers(const std::set<int>& player_ids);

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -814,7 +814,7 @@ boost::statechart::result PlayingGame::react(const TurnTimeout& msg) {
 boost::statechart::result PlayingGame::react(const PlayerInfoMsg& msg) {
     DebugLogger(FSM) << "(PlayerFSM) PlayingGame::PlayerInfoMsg message received: " << msg.m_message.Text();
     ExtractPlayerInfoMessageData(msg.m_message, Client().Players());
-    Client().GetClientUI().GetPlayerListWnd()->Refresh();
+    Client().GetClientUI().GetPlayerListWnd()->Refresh(false);
     return discard_event();
 }
 
@@ -879,7 +879,7 @@ boost::statechart::result WaitingForGameStart::react(const GameStart& msg) {
     if (is_new_game && Client().Networking().PlayerIsHost(Client().PlayerID()))
         Client().Autosave();
 
-    Client().GetClientUI().GetPlayerListWnd()->Refresh();
+    Client().GetClientUI().GetPlayerListWnd()->Refresh(true);
     Client().GetClientUI().GetMapWnd()->ResetTimeoutClock(0);
 
     return transit<PlayingTurn>();
@@ -939,7 +939,7 @@ boost::statechart::result WaitingForTurnData::react(const TurnUpdate& msg) {
 
     Client().HandleTurnUpdate();
 
-    Client().GetClientUI().GetPlayerListWnd()->Refresh();
+    Client().GetClientUI().GetPlayerListWnd()->Refresh(true);
     Client().GetClientUI().GetMapWnd()->ResetTimeoutClock(0);
 
     return transit<PlayingTurn>();


### PR DESCRIPTION
Fixes introduced in #2544 issue when player doesn't see ready status of other empires. Related thread https://freeorion.org/forum/viewtopic.php?p=97587#p97587.