### PR TITLE
Made CMAKE_PREFIX_PATH configurable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ set(CMAKE_LIBRARY_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 
 if(WIN32)
     # Location of the FreeOrionSDK root
-    set(CMAKE_PREFIX_PATH "${CMAKE_SOURCE_DIR}/..")
+    set(CMAKE_PREFIX_PATH "${CMAKE_SOURCE_DIR}/.." CACHE PATH "Location of the FreeOrionSDK root")
     # Search dependency DLLs inside FreeOrionSDK
     target_dependencies_add_search_path("${CMAKE_PREFIX_PATH}/bin")
     set(CMAKE_INSTALL_BINDIR ".")


### PR DESCRIPTION
This enabled building outside SDK directory on Windows.

Kept the old hard-coded value as default.

---

Rationale:
When I was trying to build freeorion outside the SDK directory (even outside freeorion source directory, but that's beside the point), almost everything worked by supplying correct paths through CMake gui.
The only thing that didn't work was copying various dependencies, like python27.dll, because they were searched for in paths like: `${CMAKE_PREFIX_PATH}/bin/python27.dll`

`${CMAKE_PREFIX_PATH}` was hard-coded as `"${CMAKE_SOURCE_DIR}/.."`, which made the assumption, that freeorion is checked out inside SDK directory.

Some people like to keep sources and build artifacts in separate directory hierarchies. For such people being able to *customize* the `CMAKE_PREFIX_PATH` will be quite useful.

For others, this MR keeps the default value.

If discussion on forum is needed, pleasue use [this topic](https://www.freeorion.org/forum/viewtopic.php?f=24&t=11262).
