### PR TITLE
Shift supply check and Inform about weapon upgrade

### DIFF
--- a/default/scripting/techs/ship_weapons/ship_weapons.macros
+++ b/default/scripting/techs/ship_weapons/ship_weapons.macros
@@ -18,6 +18,23 @@ WEAPON_BASE_EFFECTS
             ]
             accountinglabel = "@1@"
             effects = SetCapacity partname = "@1@" value = Value + [[ARBITRARY_BIG_NUMBER_FOR_METER_TOPUP]]
+
+// Inform the researching empire that ships in supply will get upgraded before next combat
+          EffectsGroup
+           scope = Source
+           activation = (CurrentTurn == TurnTechResearched empire = Source.Owner name = CurrentContent)
+           effects =
+             GenerateSitRepMessage
+              message = "SITREP_WEAPON_UPGRADE_IMMINENT"
+              label = "SITREP_WEAPON_UPGRADE_IMMINENT_LABEL"
+              icon = "icons/tech/active_radar.png"
+              parameters = [
+                  tag = "empire"    data = Source.Owner
+                  tag = "shippart"  data = @1@
+              ]
+              empire = Target.Owner
+
+
 '''
 
 // @1@ part name

--- a/default/scripting/techs/ship_weapons/ship_weapons.macros
+++ b/default/scripting/techs/ship_weapons/ship_weapons.macros
@@ -19,28 +19,12 @@ WEAPON_BASE_EFFECTS
             accountinglabel = "@1@"
             effects = SetCapacity partname = "@1@" value = Value + [[ARBITRARY_BIG_NUMBER_FOR_METER_TOPUP]]
 
-// Inform the researching empire that ships in supply will get upgraded before next combat
-          EffectsGroup
-           scope = Source
-           activation = (CurrentTurn == TurnTechResearched empire = Source.Owner name = CurrentContent)
-           effects =
-             GenerateSitRepMessage
-              message = "SITREP_WEAPON_UPGRADE_IMMINENT"
-              label = "SITREP_WEAPON_UPGRADE_IMMINENT_LABEL"
-              icon = "icons/tech/active_radar.png"
-              parameters = [
-                  tag = "empire"    data = Source.Owner
-                  tag = "shippart"  data = @1@
-              ]
-              empire = Target.Owner
-
-
 '''
 
 // @1@ part name
 // @2@ value added to max capacity
 WEAPON_UPGRADE_CAPACITY_EFFECTS
-'''
+'''   [
         EffectsGroup
             scope = And [
                         [[EMPIRE_OWNED_SHIP_WITH_PART]]
@@ -48,6 +32,25 @@ WEAPON_UPGRADE_CAPACITY_EFFECTS
             ]
             accountinglabel = "@1@"
             effects = SetMaxCapacity partname = "@1@" value = Value + @2@
-            '''
+
+// Inform the researching empire that ships in supply will get upgraded before next combat
+        EffectsGroup
+           scope = Source
+           activation = (CurrentTurn == TurnTechResearched empire = Source.Owner name = CurrentContent)
+           effects =
+             GenerateSitRepMessage
+              message = "SITREP_WEAPON_UPGRADE_IMMINENT %empire%  %shippart%  %rawtext:t%"
+              label = "SITREP_WEAPON_UPGRADE_IMMINENT_LABEL"
+              NoStringTableLookup
+              icon = "icons/tech/active_radar.png"
+              parameters = [
+                  tag = "empire"    data = Source.Owner
+                  tag = "shippart"  data = "@1@"
+                  tag = "t"   data = CurrentContent
+              ]
+              empire = Target.Owner
+
+
+      ]'''
 
 #include "../techs.macros"

--- a/default/scripting/techs/ship_weapons/ship_weapons.macros
+++ b/default/scripting/techs/ship_weapons/ship_weapons.macros
@@ -40,7 +40,7 @@ WEAPON_UPGRADE_CAPACITY_EFFECTS
             effects = GenerateSitRepMessage
               message = "SITREP_WEAPONS_UPGRADED"
               label = "SITREP_WEAPONS_UPGRADED_LABEL"
-              icon = "icons/tech/active_radar.png"
+              icon = "icons/tech/categories/ship_weapons.png"
               parameters = [
                   tag = "empire"    data = Source.Owner
                   tag = "shippart"  data = "@1@"

--- a/default/scripting/techs/ship_weapons/ship_weapons.macros
+++ b/default/scripting/techs/ship_weapons/ship_weapons.macros
@@ -35,21 +35,19 @@ WEAPON_UPGRADE_CAPACITY_EFFECTS
 
 // Inform the researching empire that ships in supply will get upgraded before next combat
         EffectsGroup
-           scope = Source
-           activation = (CurrentTurn == TurnTechResearched empire = Source.Owner name = CurrentContent)
-           effects =
-             GenerateSitRepMessage
-              message = "SITREP_WEAPON_UPGRADE_IMMINENT %empire%  %shippart%  %rawtext:t%"
-              label = "SITREP_WEAPON_UPGRADE_IMMINENT_LABEL"
-              NoStringTableLookup
+            scope = Source
+            activation = (CurrentTurn == TurnTechResearched empire = Source.Owner name = CurrentContent)
+            effects = GenerateSitRepMessage
+              message = "SITREP_WEAPONS_UPGRADED"
+              label = "SITREP_WEAPONS_UPGRADED_LABEL"
               icon = "icons/tech/active_radar.png"
               parameters = [
                   tag = "empire"    data = Source.Owner
                   tag = "shippart"  data = "@1@"
-                  tag = "t"   data = CurrentContent
+                  tag = "tech"   data = CurrentContent
+                  tag = "dam"   data = @2@
               ]
               empire = Target.Owner
-
 
       ]'''
 

--- a/default/scripting/techs/techs.macros
+++ b/default/scripting/techs/techs.macros
@@ -19,7 +19,7 @@ EMPIRE_OWNED_SHIP_WITH_PART
 // SHIP_PART_UPGRADE_RESUPPLY_CHECK(CurrentContent)
 SHIP_PART_UPGRADE_RESUPPLY_CHECK
 '''
-           ( LocalCandidate.LastTurnResupplied > TurnTechResearched empire = LocalCandidate.Owner name = @1@ )
+           ( LocalCandidate.LastTurnResupplied >= TurnTechResearched empire = LocalCandidate.Owner name = @1@ )
 '''
 
 ARBITRARY_BIG_NUMBER_FOR_METER_TOPUP

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -6596,6 +6596,12 @@ SITREP_BUILDING_TYPE_UNLOCKED
 SITREP_BUILDING_TYPE_UNLOCKED_LABEL
 Building Type Unlocked
 
+SITREP_WEAPONS_UPGRADED
+All %shippart% weapons on supplied ships have been upgraded to %tech%. Upgraded weapons do %rawtext:dam% extra damage per shot
+
+SITREP_WEAPONS_UPGRADED_LABEL
+Weapon Tech Upgrade
+
 SITREP_COMBAT_SYSTEM
 At %system%: there was %combat%.
 


### PR DESCRIPTION
With the recent changes SHIP_PART_UPGRADE_RESUPPLY_CHECK applied changes on turn late (regression).

This PR fixes that and adds an informational sitrep about weapon part upgrades.

[forum discussion](https://www.freeorion.org/forum/viewtopic.php?f=28&t=11374&p=97657#p97657)
