### PR TITLE
Don't use Enter as OK in Galaxy Setup

### DIFF
--- a/UI/GalaxySetupWnd.cpp
+++ b/UI/GalaxySetupWnd.cpp
@@ -1091,9 +1091,8 @@ void GalaxySetupWnd::Render() {
 }
 
 void GalaxySetupWnd::KeyPress(GG::Key key, std::uint32_t key_code_point, GG::Flags<GG::ModKey> mod_keys) {
-    if (!m_ok->Disabled() && (key == GG::GGK_RETURN || key == GG::GGK_KP_ENTER)) // Same behaviour as if "OK" was pressed
-        OkClicked();
-    else if (key == GG::GGK_ESCAPE) // Same behaviour as if "Cancel" was pressed
+    // Enter is no longer accepted as OK as it could clash with ALT-Enter
+    if (key == GG::GGK_ESCAPE) // Same behaviour as if "Cancel" was pressed
         CancelClicked();
 }
 


### PR DESCRIPTION
On Galaxy Setup screen, pressing Alt-Enter (to enter fullscreen mode)
would start the game instead. Don't use ALT-Enter as OK in Galaxy
Setup.

Closes #2588.