### PR TITLE
Queue items at top from object list

### DIFF
--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -3516,11 +3516,17 @@ Latest known [[metertype METER_STEALTH]] is out of date. Actual stealth exceeds 
 MENUITEM_SET_FOCUS
 Set focus
 
+MENUITEM_ENQUEUE_SHIPDESIGN_TO_TOP_OF_QUEUE
+Add Ship to Top of Queue
+
 MENUITEM_ENQUEUE_SHIPDESIGN
-Queue Ship
+Add Ship to Queue
+
+MENUITEM_ENQUEUE_BUILDING_TO_TOP_OF_QUEUE
+Add Building to Top of Queue
 
 MENUITEM_ENQUEUE_BUILDING
-Queue Building
+Add Building to Queue
 
 ##
 ## Side panel/Resources panel


### PR DESCRIPTION
Let player enqueue ships and buildings at the top of the queue in
addition to bottom from object list window.