### PR TITLE
Issue #2551 changes

### DIFF
--- a/client/human/HumanClientApp.h
+++ b/client/human/HumanClientApp.h
@@ -180,6 +180,7 @@ private:
 
     bool m_single_player_game = true;   ///< true when this game is a single-player game
     bool m_game_started = false;        ///< true when a game is currently in progress
+    bool m_exit_handled = false;        ///< true when the exit logic is already being handled
     bool m_connected = false;           ///< true if we are in a state in which we are supposed to be connected to the server
     int  m_auto_turns = 0;              ///< auto turn counter
     bool m_have_window_focus = true;

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -2579,6 +2579,9 @@ The Save Game button is disabled, either because this is a multiplayer game in w
 GAME_MENU_REALLY_CONCEDE
 Confirm conceding? This empire will be removed from the game.
 
+GAME_MENU_CONFIRM_NOT_READY
+Confirm quit? Orders not finalized.
+
 
 ##
 ## Save game dialog


### PR DESCRIPTION
For Issue #2551 created by @o01eg. These changes prompt the user for confirmation when leaving a multiplayer game without setting their status to ready.