### PR TITLE
Add Alliance to Peace in AFFIL_ALLY conditions

### DIFF
--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -1193,7 +1193,7 @@ namespace {
                 if (m_empire_id == candidate->Owner())
                     return false;
                 DiplomaticStatus status = Empires().GetDiplomaticStatus(m_empire_id, candidate->Owner());
-                return (status == DIPLO_PEACE);
+                return (status >= DIPLO_PEACE);
                 break;
             }
 

--- a/universe/Effect.cpp
+++ b/universe/Effect.cpp
@@ -3241,7 +3241,7 @@ void GenerateSitRepMessage::Execute(const ScriptingContext& context) const {
                 continue;
 
             DiplomaticStatus status = Empires().GetDiplomaticStatus(recipient_id, empire_id.first);
-            if (status == DIPLO_PEACE)
+            if (status >= DIPLO_PEACE)
                 recipient_empire_ids.insert(empire_id.first);
         }
         break;
@@ -3507,7 +3507,7 @@ void SetVisibility::Execute(const ScriptingContext& context) const {
                 continue;
 
             DiplomaticStatus status = Empires().GetDiplomaticStatus(empire_id, empire_entry.first);
-            if (status == DIPLO_PEACE)
+            if (status >= DIPLO_PEACE)
                 empire_ids.insert(empire_entry.first);
         }
         break;


### PR DESCRIPTION
Stopgap fix for AFFIL_ALLY conditions to evaluate to true on Alliances in addition to Peace, until such time that a separate AFFIL_PEACE and its associated parsers and handlers are needed/can be introduced.