### PR TITLE
Apply newly added techs before final meter estimation

### DIFF
--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -3548,8 +3548,18 @@ void ServerApp::PostCombatProcessTurns() {
     m_universe.UpdateEmpireObjectVisibilities();
 
 
+    DebugLogger() << "ServerApp::PostCombatProcessTurns applying Newly Added Techs";
+    // apply new techs
+    for (auto& entry : empires) {
+        Empire* empire = entry.second;
+        if (empire && !empire->Eliminated())
+            empire->ApplyNewTechs();
+    }
+
+
     TraceLogger(effects) << "ServerApp::PostCombatProcessTurns Before Final Meter Estimate Update: ";
     TraceLogger(effects) << objects.Dump();
+
 
     // redo meter estimates to hopefully be consistent with what happens in clients
     m_universe.UpdateMeterEstimates(false);
@@ -3570,14 +3580,6 @@ void ServerApp::PostCombatProcessTurns() {
     for (auto& entry : empires)
         entry.second->UpdateOwnedObjectCounters();
     GetSpeciesManager().UpdatePopulationCounter();
-
-
-    // apply new techs
-    for (auto& entry : empires) {
-        Empire* empire = entry.second;
-        if (empire && !empire->Eliminated())
-            empire->ApplyNewTechs();
-    }
 
 
     // indicate that the clients are waiting for their new gamestate


### PR DESCRIPTION
Move ApplyNewTechs call Before Final Meter Estimate Update in PostCombatProcessTurns in order to do correct predictions for next turn values on server side.

[Forum discussion](https://www.freeorion.org/forum/viewtopic.php?f=28&t=11388&p=97773#p97773) 

Test target meter estimation and it looks good for empire and planetary output.
When i play humans i have 9 RP for all, i research first Algorithmic Elegance and get the "tech researched" message on turn 4. Planetary values are: currently 9RP, target 11RP and next turn 10RP. Empire values are 10RP used/output and 11RP target. Then the values grow as expected each turn until 11RP.


By moving it up we also move it before the following calls
    UpdateEmpireSupply(true);
    m_universe.UpdateEmpireLatestKnownObjectsAndVisibilityTurns();
    m_universe.UpdateStatRecords();
    for (auto& entry : empires)
        entry.second->UpdateOwnedObjectCounters();
    GetSpeciesManager().UpdatePopulationCounter();

Reasoning that there are no unintended side-effects by this move:
  supply update is meter based - OK (meter backpropagation already happened)
  visibility is based on stealth and detection meters - OK
  stat records - probably OK; FOCS statistics are evaluated here those should not change game state. Number of technologies would include newly added techs (which is ok)
  update object counters - should be OK, tech does not directly add/remove/change objects
  population counters - should be OK, tech does not directly add/remove population