### PR TITLE
Improve SitRepPanel::SizeMove() performance

### DIFF
--- a/UI/SitRepPanel.cpp
+++ b/UI/SitRepPanel.cpp
@@ -463,7 +463,6 @@ void SitRepPanel::SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
 
     if (old_size != GG::Wnd::Size()) {
         DoLayout();
-        Update();
         if (!m_sitreps_lb->Empty())
             m_sitreps_lb->SetFirstRowShown(std::next(m_sitreps_lb->begin(),
                                                      first_visible_queue_row));


### PR DESCRIPTION
Before this PR, resizing the SitRep window causes the UI to freeze/lag when multiple (N>10) sitrep entries are displayed (i.e. not filtered out).

When resizing the SitRep window, the entries contained in the ListBox are not expected to change. It is therefore unnecessary to rebuild all its contents, i.e. to call the very expensive SitRepPanel::Update().

Tested and seems to work fine ingame: No noticable slowdown of the UI while resizing and all entries are displayed / responding as expected.