### PR TITLE
Make synchronous sending in io context queue

### DIFF
--- a/network/ServerNetworking.h
+++ b/network/ServerNetworking.h
@@ -311,7 +311,7 @@ private:
     void HandleMessageBodyRead(boost::system::error_code error, std::size_t bytes_transferred);
     void HandleMessageHeaderRead(boost::system::error_code error, std::size_t bytes_transferred);
     void AsyncReadMessage();
-    void SyncWriteMessage(const Message& message);
+    static void AsyncWriteMessage(PlayerConnectionPtr self, Message message);
     static void AsyncErrorHandler(PlayerConnectionPtr self, boost::system::error_code handled_error, boost::system::error_code error);
 
     boost::asio::io_context&        m_service;


### PR DESCRIPTION
Follows up #2609. Yet another preparation to solve #2607.

Imitates asynchronous sending with processing synchronous sending in io context queue.