### PR TITLE
 Use outgoing message queue and asynchronously send messages from the server

### DIFF
--- a/network/ServerNetworking.cpp
+++ b/network/ServerNetworking.cpp
@@ -191,7 +191,7 @@ void PlayerConnection::SendMessage(const Message& message) {
         ErrorLogger(network) << "PlayerConnection::SendMessage can't send message when not transmit connected";
         return;
     }
-    m_service.post(boost::bind(&PlayerConnection::AsyncWriteMessage, shared_from_this(), message));
+    m_service.post(boost::bind(&PlayerConnection::SendMessageImpl, shared_from_this(), message));
 }
 
 bool PlayerConnection::IsEstablished() const {
@@ -466,26 +466,51 @@ void PlayerConnection::AsyncReadMessage() {
                                         boost::asio::placeholders::bytes_transferred));
 }
 
-void PlayerConnection::AsyncWriteMessage(PlayerConnectionPtr self, Message message) {
-    // Synchronously write and asynchronously signal the errors.  This prevents PlayerConnections
-    // being removed from the list while iterating to transmit to multiple receivers.
-    Message::HeaderBuffer header_buf;
-    HeaderToBuffer(message, header_buf);
+void PlayerConnection::SendMessageImpl(PlayerConnectionPtr self, Message message) {
+    bool start_write = self->m_outgoing_messages.empty();
+    self->m_outgoing_messages.push_back(Message());
+    swap(self->m_outgoing_messages.back(), message);
+    if (start_write)
+        self->AsyncWriteMessage();
+}
+
+void PlayerConnection::AsyncWriteMessage() {
+    if (!m_valid) {
+        ErrorLogger(network) << "PlayerConnection::AsyncWriteMessage(): player id = " << m_ID
+                             << ". Socket is closed. Dropping message.";
+        return;
+    }
+
+    HeaderToBuffer(m_outgoing_messages.front(), m_outgoing_header);
     std::vector<boost::asio::const_buffer> buffers;
-    buffers.push_back(boost::asio::buffer(header_buf));
-    buffers.push_back(boost::asio::buffer(message.Data(), message.Size()));
+    buffers.push_back(boost::asio::buffer(m_outgoing_header));
+    buffers.push_back(boost::asio::buffer(m_outgoing_messages.front().Data(),
+                                          m_outgoing_messages.front().Size()));
+    boost::asio::async_write(m_socket, buffers,
+                             boost::bind(&PlayerConnection::HandleMessageWrite, shared_from_this(),
+                                         boost::asio::placeholders::error,
+                                         boost::asio::placeholders::bytes_transferred));
+}
 
-    boost::system::error_code error;
-    boost::asio::write(self->m_socket, buffers, error);
-
+void PlayerConnection::HandleMessageWrite(PlayerConnectionPtr self,
+                                          boost::system::error_code error,
+                                          std::size_t bytes_transferred)
+{
     if (error) {
         self->m_valid = false;
-        ErrorLogger(network) << "PlayerConnection::SyncWriteMessage(): player id = " << self->m_ID
-                             << " message " << MessageTypeName(message.Type())
+        ErrorLogger(network) << "PlayerConnection::AsyncWriteMessage(): player id = " << self->m_ID
                              << " error #" << error.value() << " \"" << error.message() << "\"";
         boost::asio::high_resolution_timer t(self->m_service);
         t.async_wait(boost::bind(&PlayerConnection::AsyncErrorHandler, self, error, boost::asio::placeholders::error));
+        return;
     }
+
+    if (static_cast<int>(bytes_transferred) != static_cast<int>(Message::HeaderBufferSize) + self->m_outgoing_header[Message::Parts::SIZE])
+        return;
+
+    self->m_outgoing_messages.pop_front();
+    if (!self->m_outgoing_messages.empty())
+        self->AsyncWriteMessage();
 }
 
 void PlayerConnection::AsyncErrorHandler(PlayerConnectionPtr self, boost::system::error_code handled_error,

--- a/network/ServerNetworking.h
+++ b/network/ServerNetworking.h
@@ -311,13 +311,19 @@ private:
     void HandleMessageBodyRead(boost::system::error_code error, std::size_t bytes_transferred);
     void HandleMessageHeaderRead(boost::system::error_code error, std::size_t bytes_transferred);
     void AsyncReadMessage();
-    static void AsyncWriteMessage(PlayerConnectionPtr self, Message message);
+    void AsyncWriteMessage();
+    static void HandleMessageWrite(PlayerConnectionPtr self,
+                                   boost::system::error_code error,
+                                   std::size_t bytes_transferred);
+    static void SendMessageImpl(PlayerConnectionPtr self, Message message);
     static void AsyncErrorHandler(PlayerConnectionPtr self, boost::system::error_code handled_error, boost::system::error_code error);
 
     boost::asio::io_context&        m_service;
     boost::asio::ip::tcp::socket    m_socket;
     Message::HeaderBuffer           m_incoming_header_buffer;
     Message                         m_incoming_message;
+    Message::HeaderBuffer           m_outgoing_header;
+    std::list<Message>              m_outgoing_messages;
     int                             m_ID = Networking::INVALID_PLAYER_ID;
     std::string                     m_player_name;
     bool                            m_new_connection = true;

--- a/network/ServerNetworking.h
+++ b/network/ServerNetworking.h
@@ -315,6 +315,9 @@ private:
     static void HandleMessageWrite(PlayerConnectionPtr self,
                                    boost::system::error_code error,
                                    std::size_t bytes_transferred);
+
+    /** Places message to the end of sending queue and start asynchronous write if \a message was
+        first in the queue. */
     static void SendMessageImpl(PlayerConnectionPtr self, Message message);
     static void AsyncErrorHandler(PlayerConnectionPtr self, boost::system::error_code handled_error, boost::system::error_code error);
 

--- a/network/ServerNetworking.h
+++ b/network/ServerNetworking.h
@@ -311,7 +311,7 @@ private:
     void HandleMessageBodyRead(boost::system::error_code error, std::size_t bytes_transferred);
     void HandleMessageHeaderRead(boost::system::error_code error, std::size_t bytes_transferred);
     void AsyncReadMessage();
-    void SyncWriteMessage(const Message& message);
+    static void AsyncWriteMessage(PlayerConnectionPtr self, Message message);
     static void AsyncErrorHandler(PlayerConnectionPtr self, boost::system::error_code handled_error, boost::system::error_code error);
 
     boost::asio::io_context&        m_service;


### PR DESCRIPTION
Fixes #2607. Follows up #2609 and #2611.

Copies client's message code to work with server's player connection.