### PR TITLE
Add support to delegate empire access

### DIFF
--- a/default/python/auth/auth.py
+++ b/default/python/auth/auth.py
@@ -78,3 +78,7 @@ class AuthProvider:
                 psd.starting_team = NO_TEAM_ID
                 players.append(psd)
         return players
+
+    def get_player_delegation(self, player_name):
+        """Returns list of players delegated by this player"""
+        return []

--- a/python/server/ServerFramework.h
+++ b/python/server/ServerFramework.h
@@ -19,6 +19,7 @@ public:
     bool IsRequireAuthOrReturnRoles(const std::string& player_name, bool &result, Networking::AuthRoles& roles) const; // Wraps call to AuthProvider's method is_require_auth
     bool IsSuccessAuthAndReturnRoles(const std::string& player_name, const std::string& auth, bool &result, Networking::AuthRoles& roles) const; // Wraps call to AuthProvider's method is_success_auth
     bool FillListPlayers(std::list<PlayerSetupData>& players) const; // Wraps call to AuthProvider's method list_player
+    bool GetPlayerDelegation(const std::string& player_name, std::list<std::string> &result) const; // Wraps call to AuthProvider's method get_player_delegation
     bool LoadChatHistory(boost::circular_buffer<ChatHistoryEntity>& chat_history); // Wraps call to ChatProvider's method load_history
     bool PutChatHistoryEntity(const ChatHistoryEntity& chat_history_entity); // Wraps call to ChatProvider's method put_history_entity
 

--- a/server/ServerApp.h
+++ b/server/ServerApp.h
@@ -190,10 +190,14 @@ public:
     void DropPlayerEmpireLink(int planet_id);
 
     /** Adds new player to running game.
-      * Search empire by player's name and return empire id if success and ALL_EMPIRES if no empire found.
+      * Search empire by player's name or delegation list if \a target_empire_id set and return
+      * empire id if success and ALL_EMPIRES if no empire found.
       * Simply sends GAME_START message so established player knows he is in the game.
       * Notificates the player about statuses of other empires. */
-    int AddPlayerIntoGame(const PlayerConnectionPtr& player_connection);
+    int AddPlayerIntoGame(const PlayerConnectionPtr& player_connection, int target_empire_id);
+
+    /** Get list of players delegated by \a player_name */
+    std::list<std::string> GetPlayerDelegation(const std::string& player_name);
 
     /** Sets turn to be expired. Server doesn't wait for human player turns. */
     void ExpireTurn();


### PR DESCRIPTION
Adds delegation feature like in https://freeciv.fandom.com/wiki/NEWS-2.4.0 except server command. Follows up #2618 

<s>It uses ingame lobby to choose desired empire so I have to remove auto-choice based on player name. Without it player cannot choose himself.

As it is a important feature for long multiplayer games and it requires UI changes I prefer to have it 0.4.9 or even next test build.</s>