### PR TITLE
Don't automatically choose empire based on player name in the in-game lobby

### DIFF
--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -429,6 +429,7 @@ void ServerFSM::UpdateIngameLobby() {
     MultiplayerLobbyData dummy_lobby_data(std::move(galaxy_data));
     dummy_lobby_data.m_any_can_edit = false;
     dummy_lobby_data.m_new_game = false;
+    dummy_lobby_data.m_in_game = true;
     dummy_lobby_data.m_start_locked = true;
     dummy_lobby_data.m_save_game_current_turn = m_server.CurrentTurn();
     dummy_lobby_data.m_save_game_empire_data = CompileSaveGameEmpireData();

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -294,7 +294,8 @@ struct FO_COMMON_API MultiplayerLobbyData : public GalaxySetupData {
         m_players(),
         m_save_game(),
         m_save_game_empire_data(),
-        m_save_game_current_turn(0)
+        m_save_game_current_turn(0),
+        m_in_game(false)
     {}
 
     MultiplayerLobbyData(const GalaxySetupData& base) :
@@ -305,7 +306,8 @@ struct FO_COMMON_API MultiplayerLobbyData : public GalaxySetupData {
         m_players(),
         m_save_game(),
         m_save_game_empire_data(),
-        m_save_game_current_turn(0)
+        m_save_game_current_turn(0),
+        m_in_game(false)
     {}
 
     MultiplayerLobbyData(GalaxySetupData&& base) :
@@ -316,7 +318,8 @@ struct FO_COMMON_API MultiplayerLobbyData : public GalaxySetupData {
         m_players(),
         m_save_game(),
         m_save_game_empire_data(),
-        m_save_game_current_turn(0)
+        m_save_game_current_turn(0),
+        m_in_game(false)
     {}
     //@}
 
@@ -334,6 +337,7 @@ struct FO_COMMON_API MultiplayerLobbyData : public GalaxySetupData {
     int                                         m_save_game_current_turn;
 
     std::string                                 m_start_lock_cause;
+    bool                                        m_in_game; ///< In-game lobby
 
 private:
     friend class boost::serialization::access;
@@ -341,7 +345,7 @@ private:
     void serialize(Archive& ar, const unsigned int version);
 };
 
-BOOST_CLASS_VERSION(MultiplayerLobbyData, 1);
+BOOST_CLASS_VERSION(MultiplayerLobbyData, 2);
 
 /** The data structure stores information about latest chat massages. */
 struct FO_COMMON_API ChatHistoryEntity {

--- a/util/SerializeMultiplayerCommon.cpp
+++ b/util/SerializeMultiplayerCommon.cpp
@@ -259,6 +259,9 @@ void MultiplayerLobbyData::serialize(Archive& ar, const unsigned int version)
     if (version >= 1) {
         ar & BOOST_SERIALIZATION_NVP(m_save_game_current_turn);
     }
+    if (version >= 2) {
+        ar & BOOST_SERIALIZATION_NVP(m_in_game);
+    }
 }
 
 template void MultiplayerLobbyData::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, const unsigned int);


### PR DESCRIPTION
Extracted from #2617 to separately manage UI and protocol changes.

As it is a required changes for #2617 which is a important feature for long multiplayer games I prefer to have it 0.4.9 or even next test build.

Actually its a bug when a player see himself in the in-games lobby if he doesn't play this empire.
