### PR TITLE
Fix log filters not applying while setting a new log level

### DIFF
--- a/util/Logger.cpp
+++ b/util/Logger.cpp
@@ -307,7 +307,6 @@ namespace {
             std::lock_guard<std::mutex> lock(m_mutex);
 
             auto used_threshold = ForcedThreshold() ? *ForcedThreshold() : threshold;
-            logging::core::get()->reset_filter();
             m_min_channel_severity[source] = used_threshold;
             logging::core::get()->set_filter(m_min_channel_severity);
 


### PR DESCRIPTION
By resetting the filter before registering the new and updated filter, there was a short time frame where logging filters were not applied (as logging is handled asynchronously). As such, e.g. TraceLogger statements could be (partially) logged while log level was set to Debug and higher, see e.g. #2604.