### PR TITLE
Fix exception warning

### DIFF
--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -133,7 +133,7 @@ namespace {
             fs::path path = FilenameToPath(file);
             return boost::algorithm::ends_with(file, STRINGTABLE_FILE_SUFFIX) &&
                 fs::exists(path) && !fs::is_directory(path);
-        } catch (std::exception ex) {
+        } catch (const std::exception&) {
         }
         return false;
     }
@@ -145,7 +145,7 @@ namespace {
             fs::path path = FilenameToPath(file);
             return boost::algorithm::ends_with(file, FONT_FILE_SUFFIX) &&
                 fs::exists(path) && !fs::is_directory(path);
-        } catch (std::exception ex) {
+        } catch (const std::exception&) {
         }
         return false;
     }
@@ -157,7 +157,7 @@ namespace {
             fs::path path = FilenameToPath(file);
             return boost::algorithm::ends_with(file, MUSIC_FILE_SUFFIX) &&
                 fs::exists(path) && !fs::is_directory(path);
-        } catch (std::exception ex) {
+        } catch (const std::exception&) {
         }
         return false;
     }
@@ -169,7 +169,7 @@ namespace {
             fs::path path = FilenameToPath(file);
             return boost::algorithm::ends_with(file, SOUND_FILE_SUFFIX) &&
                 fs::exists(path) && !fs::is_directory(path);
-        } catch (std::exception ex) {
+        } catch (const std::exception&) {
         }
         return false;
     }
@@ -180,7 +180,7 @@ namespace {
         try {
             fs::path path = FilenameToPath(file);
             return fs::exists(path) && fs::is_directory(path);
-        } catch (std::exception ex) {
+        } catch (const std::exception&) {
         }
         return false;
     }

--- a/combat/CombatLogManager.cpp
+++ b/combat/CombatLogManager.cpp
@@ -124,7 +124,7 @@ void CombatLog::serialize(Archive& ar, const unsigned int version)
         TraceLogger() << "CombatLog::serialize turn " << turn << "  combat at " << system_id << "  combat events size: " << combat_events.size();
     try {
         ar  & BOOST_SERIALIZATION_NVP(combat_events);
-    } catch (std::exception e) {
+    } catch (const std::exception& e) {
         ErrorLogger() << "combat events serializing failed!: caught exception: " << e.what();
     }
 


### PR DESCRIPTION
There are nine places where exceptions are caught by value instead of by reference. This patch changes these to const&. Patch provided by spikethehobbit on the forum.