### PR TITLE
Balance - double base hull cost, but triple internal slots

### DIFF
--- a/default/scripting/ship_designs/SD_BASE_DECOY.focs.txt
+++ b/default/scripting/ship_designs/SD_BASE_DECOY.focs.txt
@@ -3,6 +3,10 @@ ShipDesign
     uuid = "08a58b08-0929-496d-84fc-faa91424ca10"
     description = "SD_BASE_DECOY_DESC"
     hull = "SH_COLONY_BASE"
-    parts = ""
+    parts = [
+        ""
+        ""
+        ""
+    ]
     icon = "icons/ship_hulls/colony_base_hull_small.png"
     model = "some model"

--- a/default/scripting/ship_designs/required/SD_COLONY_BASE.focs.txt
+++ b/default/scripting/ship_designs/required/SD_COLONY_BASE.focs.txt
@@ -3,6 +3,10 @@ ShipDesign
     uuid = "08a58b08-0929-496d-84fc-faa91424ca11"
     description = "SD_COLONY_BASE_DESC"
     hull = "SH_COLONY_BASE"
-    parts = "CO_COLONY_POD"
+    parts = [
+        "CO_COLONY_POD"
+        ""
+        ""
+    ]
     icon = "icons/ship_hulls/colony_base_hull_small.png"  // These designs may specify a ship icon, but if not the hull's icon is used.
     model = "seed"

--- a/default/scripting/ship_designs/required/SD_CRYONIC_COLONY_BASE.focs.txt
+++ b/default/scripting/ship_designs/required/SD_CRYONIC_COLONY_BASE.focs.txt
@@ -3,6 +3,10 @@ ShipDesign
     uuid = "08a58b08-0929-496d-84fc-faa91424ca15"
     description = "SD_CRYONIC_COLONY_BASE_DESC"
     hull = "SH_COLONY_BASE"
-    parts = "CO_SUSPEND_ANIM_POD"
+    parts = [
+        "CO_SUSPEND_ANIM_POD"
+        ""
+        ""
+    ]
     icon = "icons/ship_hulls/colony_base_hull_small.png"  
     model = "seed"

--- a/default/scripting/ship_designs/required/SD_OUTPOST_BASE.focs.txt
+++ b/default/scripting/ship_designs/required/SD_OUTPOST_BASE.focs.txt
@@ -3,5 +3,9 @@ ShipDesign
     uuid = "08a58b08-0929-496d-84fc-faa91424ca16"
     description = "SD_OUTPOST_BASE_DESC"
     hull = "SH_COLONY_BASE"
-    parts = "CO_OUTPOST_POD"
+    parts = [
+        "CO_OUTPOST_POD"
+        ""
+        ""
+    ]
     model = "seed"

--- a/default/scripting/ship_designs/required/SD_TROOP_DROP.focs.txt
+++ b/default/scripting/ship_designs/required/SD_TROOP_DROP.focs.txt
@@ -5,5 +5,7 @@ ShipDesign
     hull = "SH_COLONY_BASE"
     parts = [
         "GT_TROOP_POD"
+        "GT_TROOP_POD"
+        "GT_TROOP_POD"
     ]
     model = "mark1"

--- a/default/scripting/ship_designs/required/SD_TROOP_DROP_HEAVY.focs.txt
+++ b/default/scripting/ship_designs/required/SD_TROOP_DROP_HEAVY.focs.txt
@@ -5,5 +5,7 @@ ShipDesign
     hull = "SH_COLONY_BASE"
     parts = [
         "GT_TROOP_POD_2"
+        "GT_TROOP_POD_2"
+        "GT_TROOP_POD_2"
     ]
     model = "mark1"

--- a/default/scripting/ship_hulls/SH_COLONY_BASE.focs.txt
+++ b/default/scripting/ship_hulls/SH_COLONY_BASE.focs.txt
@@ -10,7 +10,7 @@ Hull
         Slot type = Internal position = (0.50, 0.50)
         Slot type = Internal position = (0.62, 0.50)
     ]
-    buildCost = 6
+    buildCost = 6 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_HULL_COST_MULTIPLIER]]
     buildTime = 3
     tags = [ "PEDIA_HULL_LINE_GENERIC" ]
     location = OwnedBy empire = Source.Owner
@@ -20,3 +20,5 @@ Hull
     graphic = "hulls_design/colony_base_hull.png"
 
 #include "ship_hulls.macros"
+
+#include "/scripting/common/upkeep.macros"

--- a/default/scripting/ship_hulls/SH_COLONY_BASE.focs.txt
+++ b/default/scripting/ship_hulls/SH_COLONY_BASE.focs.txt
@@ -4,9 +4,13 @@ Hull
     speed = 0
     fuel = 0
     stealth = 5
-    structure = 2
-    slots = Slot type = Internal position = (0.50, 0.50)
-    buildCost = 3
+    structure = 3
+    slots = [
+        Slot type = Internal position = (0.38, 0.50)
+        Slot type = Internal position = (0.50, 0.50)
+        Slot type = Internal position = (0.62, 0.50)
+    ]
+    buildCost = 6
     buildTime = 3
     tags = [ "PEDIA_HULL_LINE_GENERIC" ]
     location = OwnedBy empire = Source.Owner


### PR DESCRIPTION
[forum discussion](https://www.freeorion.org/forum/viewtopic.php?f=6&t=11402) 

As the upping the production cost is KISS and AI can handle it better, we try this first before trying to change targeting priorities.
 
* +1 structure
* Doubling the cost should make comsats more expensive cannon fodder
  +3PP cost for colonisers or outpost does not make much difference
* Three internal slots makes for about 2PP hull cost per troop.
  Note that a while ago this was only 1PP hull cost per troop and that
  was not considered a problem AFAIK
* you can still trigger combat

Another TODO for making comsat spam less a problem:
* count unfinished ships in the production queue for hull and part upkeep
* maybe increase bouts per combat to four - this nerfs all cannonfodder by maybe 50%