### PR TITLE
Add ShipDesignsInProduction ValueRef and use it for upkeep

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -2224,6 +2224,16 @@ void Empire::UpdateOwnedObjectCounters() {
         m_ship_designs_owned[ship->DesignID()]++;
     }
 
+    // ships in the queue for which production started
+    m_ship_designs_in_production.clear();
+    for (const auto& elem : m_production_queue) {
+        ProductionQueue::ProductionItem item = elem.item;
+
+        if ((item.build_type == BT_SHIP) && (elem.progress > 0.0f)) {
+            m_ship_designs_in_production[item.design_id] += elem.blocksize;
+        }
+    }
+
     // update ship part counts
     m_ship_part_types_owned.clear();
     m_ship_part_class_owned.clear();

--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -1354,7 +1354,7 @@ void Empire::AddNewlyResearchedTechToGrantAtStartOfNextTurn(const std::string& n
         return;
 
     // Mark given tech to be granted at next turn. If it was already marked, skip writing a SitRep message
-    auto result = m_newly_researched_techs.insert(name);
+    m_newly_researched_techs.insert(name);
 }
 
 void Empire::ApplyNewTechs() {

--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -349,6 +349,8 @@ public:
 
     std::map<std::string, int>& SpeciesPlanetsInvaded() { return m_species_planets_invaded; }
 
+    std::map<int, int>&         ShipDesignsInProduction() { return m_ship_designs_in_production; }
+
     std::map<std::string, int>& SpeciesShipsProduced()  { return m_species_ships_produced; }
     std::map<int, int>&         ShipDesignsProduced()   { return m_ship_designs_produced; }
 
@@ -423,6 +425,8 @@ private:
     std::map<std::string, int>      m_species_colonies_owned;   ///< how many colonies of each species does this empire currently own?
     int                             m_outposts_owned = 0;       ///< how many uncolonized outposts does this empire currently own?
     std::map<std::string, int>      m_building_types_owned;     ///< how many buildings does this empire currently own?
+
+    std::map<int, int>              m_ship_designs_in_production;   ///< how many ships of each design has this empire in active production in its production queue
 
     std::map<int, int>              m_empire_ships_destroyed;   ///< how many ships of each empire has this empire destroyed?
     std::map<int, int>              m_ship_designs_destroyed;   ///< how many ships of each design has this empire destroyed?

--- a/default/scripting/common/upkeep.macros
+++ b/default/scripting/common/upkeep.macros
@@ -3,12 +3,16 @@ COLONY_UPKEEP_MULTIPLICATOR
 
 FLEET_UPKEEP_MULTIPLICATOR
 '''(1 +
-    (1 - (GameRule name = "RULE_SHIP_PART_BASED_UPKEEP")) * 0.01 * (ShipDesignsOwned empire = Source.Owner) +
-    (GameRule name = "RULE_SHIP_PART_BASED_UPKEEP") * ((0.002 * ShipPartsOwned empire =
-        Source.Owner class = ShortRange) + (0.002 * ShipPartsOwned empire = Source.Owner class =
-        FighterHangar) + (0.002 * ShipPartsOwned empire = Source.Owner class = Armour) + (0.002 *
-        ShipPartsOwned empire = Source.Owner class = Troops) + (0.002 * ShipDesignsOwned empire =
-        Source.Owner)))'''
+    (1 - (GameRule name = "RULE_SHIP_PART_BASED_UPKEEP")) * (
+        (0.01 * ShipDesignsOwned empire = Source.Owner) +
+        (0.01 * ShipDesignsInProduction empire = Source.Owner)) +
+    (GameRule name = "RULE_SHIP_PART_BASED_UPKEEP") * (
+        (0.002 * ShipPartsOwned empire = Source.Owner class = ShortRange) +
+        (0.002 * ShipPartsOwned empire = Source.Owner class = FighterHangar) +
+        (0.002 * ShipPartsOwned empire = Source.Owner class = Armour) +
+        (0.002 * ShipPartsOwned empire = Source.Owner class = Troops) +
+        (0.002 * ShipDesignsOwned empire = Source.Owner) +
+        (0.01 * ShipDesignsInProduction empire = Source.Owner)))'''
 
 SHIP_HULL_COST_MULTIPLIER
 '''(GameRule name = "RULE_SHIP_HULL_COST_FACTOR")'''

--- a/parse/IntComplexValueRefParser.cpp
+++ b/parse/IntComplexValueRefParser.cpp
@@ -145,6 +145,7 @@ namespace parse {
             =   (
                     (   tok.ShipDesignsDestroyed_
                     |   tok.ShipDesignsLost_
+                    |   tok.ShipDesignsInProduction_
                     |   tok.ShipDesignsOwned_
                     |   tok.ShipDesignsProduced_
                     |   tok.ShipDesignsScrapped_
@@ -202,7 +203,7 @@ namespace parse {
         part_class_in_ship_design.name("PartOfClassInShipDesign");
         part_class_as_int.name("PartClass");
         ship_parts_owned.name("ShipPartsOwned");
-        empire_design_ref.name("ShipDesignsDestroyed, ShipDesignsLost, ShipDesignsOwned, ShipDesignsProduced, or ShipDesignsScrapped");
+        empire_design_ref.name("ShipDesignsDestroyed, ShipDesignsInProduction, ShipDesignsLost, ShipDesignsOwned, ShipDesignsProduced, or ShipDesignsScrapped");
         slots_in_hull.name("SlotsInHull");
         slots_in_ship_design.name("SlotsInShipDesign");
         special_added_on_turn.name("SpecialAddedOnTurn");

--- a/parse/Tokens.h
+++ b/parse/Tokens.h
@@ -425,6 +425,7 @@
     (ShipDesign)                                \
     (ShipDesignOrdering)                        \
     (ShipDesignsDestroyed)                      \
+    (ShipDesignsInProduction)                   \
     (ShipDesignsLost)                           \
     (ShipDesignsOwned)                          \
     (ShipDesignsProduced)                       \

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1342,10 +1342,6 @@ void ServerApp::LoadGameInit(const std::vector<PlayerSaveGameData>& player_save_
     // so need to be reinitialized when loading based on the gamestate
     m_universe.InitializeSystemGraph();
 
-    EmpireManager& empires = Empires();
-    for (auto& entry : empires)
-        entry.second->UpdateOwnedObjectCounters();
-
     UpdateEmpireSupply(true);  // precombat type supply update
 
     std::map<int, PlayerInfo> player_info_map = GetPlayerInfoMap();

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1342,6 +1342,10 @@ void ServerApp::LoadGameInit(const std::vector<PlayerSaveGameData>& player_save_
     // so need to be reinitialized when loading based on the gamestate
     m_universe.InitializeSystemGraph();
 
+    EmpireManager& empires = Empires();
+    for (auto& entry : empires)
+        entry.second->UpdateOwnedObjectCounters();
+
     UpdateEmpireSupply(true);  // precombat type supply update
 
     std::map<int, PlayerInfo> player_info_map = GetPlayerInfoMap();

--- a/universe/ValueRef.cpp
+++ b/universe/ValueRef.cpp
@@ -1505,6 +1505,8 @@ namespace {
             return empire->ShipDesignsLost();
         if (parsed_map_name == "ShipDesignsOwned")
             return empire->ShipDesignsOwned();
+        if (parsed_map_name == "ShipDesignsInProduction")
+            return empire->ShipDesignsInProduction();
         if (parsed_map_name == "ShipDesignsProduced")
             return empire->ShipDesignsProduced();
         if (parsed_map_name == "ShipDesignsScrapped")
@@ -1764,6 +1766,7 @@ int ComplexVariable<int>::Eval(const ScriptingContext& context) const
     // empire properties indexed by integers
     if (variable_name == "EmpireShipsDestroyed" ||
         variable_name == "ShipDesignsDestroyed" ||
+        variable_name == "ShipDesignsInProduction" ||
         variable_name == "ShipDesignsLost" ||
         variable_name == "ShipDesignsOwned" ||
         variable_name == "ShipDesignsProduced" ||

--- a/util/SerializeEmpire.cpp
+++ b/util/SerializeEmpire.cpp
@@ -190,6 +190,7 @@ void Empire::serialize(Archive& ar, const unsigned int version)
             & BOOST_SERIALIZATION_NVP(m_species_ships_destroyed)
             & BOOST_SERIALIZATION_NVP(m_species_planets_invaded)
 
+            & BOOST_SERIALIZATION_NVP(m_ship_designs_in_production)
             & BOOST_SERIALIZATION_NVP(m_species_ships_produced)
             & BOOST_SERIALIZATION_NVP(m_ship_designs_produced)
             & BOOST_SERIALIZATION_NVP(m_species_ships_lost)


### PR DESCRIPTION
ShipDesignsInProduction returns the (count of) empire's ship batches in the production queue
if work on that project already started i.e. if you already spent PP on it.

[forum discussion](https://www.freeorion.org/forum/viewtopic.php?f=6&t=11414)

NOTE: As we do not (yet) count the ship parts in the queue, part upkeep assumes the same cost
per ship in the queue as for ship based upkeep (equating to four ship parts).
This makes upkeep especially for unfinished decoys quite more expensive than for finished decoys.
It might make sense to penalize keeping unfinished projects in the queue.

This also calls UpdateOwnedObjectCounters when loading the game.
It is possible that other update calls are missing e.g. for statistics