### PR TITLE
Build freeorion with python3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,13 +48,6 @@ _test_python_common: &_test_python_common
 
 jobs:
   include:
-    - name: Lint AI with Python 2.7
-      <<: *_lint_python_common
-      python: 2.7
-      before_install:
-        - alias pip=/usr/bin/pip
-        - alias python=/usr/bin/python2
-
     - name: Lint AI with Python 3.5
       <<: *_lint_python_common
       python: 3.5
@@ -141,12 +134,6 @@ jobs:
       script:
         - cmake -GXcode -DBUILD_TESTING=ON ..
         - cmake --build . --config Release -- -parallelizeTargets -jobs $(sysctl hw.ncpu | awk '{print $2}')
-
-    - name: Unittest AI with Python 2.7
-      <<: *_test_python_common
-      python: 2.7
-      before_install:
-        - alias pip=/usr/bin/pip
 
     - name: Unittest AI with Python 3.5
       <<: *_test_python_common

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -95,7 +95,7 @@ if(APPLE)
     # Location of the FreeOrionSDK root
     set(CMAKE_PREFIX_PATH "${CMAKE_BINARY_DIR}/dep/")
     set(CMAKE_FRAMEWORK_PATH "${CMAKE_BINARY_DIR}/dep/Frameworks")
-    set(CMAKE_PROGRAM_PATH "${CMAKE_FRAMEWORK_PATH}/Python.framework/Versions/Current/bin")
+    set(CMAKE_PROGRAM_PATH "${CMAKE_FRAMEWORK_PATH}/Python.framework/Versions/3.5/bin")
 endif()
 
 if(UNIX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -352,6 +352,7 @@ endif()
 target_compile_definitions(freeorioncommon
     PRIVATE
     -DFREEORION_BUILD_COMMON
+    -DFREEORION_PYTHON_VERSION=\"${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}\"
 )
 
 target_include_directories(freeorioncommon SYSTEM

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,7 +217,7 @@ endif()
 ## Collect project dependencies.
 ##
 
-set(MINIMUM_PYTHON_VERSION 2.7)
+set(MINIMUM_PYTHON_VERSION 3.5)
 set(MINIMUM_BOOST_VERSION 1.58.0)
 
 find_package(Threads)
@@ -235,13 +235,8 @@ find_package(Boost ${MINIMUM_BOOST_VERSION}
         thread
     REQUIRED)
 
-if(${Boost_MAJOR_VERSION}.${Boost_MINOR_VERSION} VERSION_GREATER 1.66.0)
-    find_package(Boost COMPONENTS python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR} REQUIRED)
-    set(Boost_PYTHON_SUFFIX "${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}")
-else()
-    find_package(Boost COMPONENTS python REQUIRED)
-    set(Boost_PYTHON_SUFFIX "")
-endif()
+find_package(Boost COMPONENTS python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR} REQUIRED)
+set(Boost_PYTHON_SUFFIX "${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}")
 
 find_package(ZLIB REQUIRED)
 if(NOT BUILD_HEADLESS)

--- a/client/AI/AIFramework.cpp
+++ b/client/AI/AIFramework.cpp
@@ -108,16 +108,14 @@ bool PythonAI::Initialize() {
         return false;
 }
 
+bool PythonAI::InitImports() {
+    DebugLogger() << "Initializing AI Python imports";
+    // allows the "freeOrionAIInterface" C++ module to be imported within Python code
+    return PyImport_AppendInittab("freeOrionAIInterface", &PyInit_freeOrionAIInterface) != -1;
+}
+
 bool PythonAI::InitModules() {
     DebugLogger() << "Initializing AI Python modules";
-
-    // allows the "freeOrionAIInterface" C++ module to be imported within Python code
-    try {
-        initfreeOrionAIInterface();
-    } catch (...) {
-        ErrorLogger() << "Unable to initialize 'freeOrionAIInterface' AI Python module";
-        return false;
-    }
 
     // Confirm existence of the directory containing the AI Python scripts
     // and add it to Pythons sys.path to make sure Python will find our scripts
@@ -148,7 +146,7 @@ void PythonAI::GenerateOrders() {
         generateOrdersPythonFunction();
     } catch (const error_already_set& err) {
         HandleErrorAlreadySet();
-        if (!IsPythonRunning())
+        if (!IsPythonRunning() || GetOptionsDB().Get<bool>("testing"))
             throw;
 
         ErrorLogger() << "PythonAI::GenerateOrders : Python error caught.  Partial orders sent to server";

--- a/client/AI/AIFramework.h
+++ b/client/AI/AIFramework.h
@@ -29,6 +29,8 @@ class PythonAI : public PythonBase {
 public:
     bool Initialize();
 
+    /** Initializes AI Python imports. */
+    bool InitImports() override;
     /** Initializes AI Python modules. */
     bool InitModules() override;
 

--- a/cmake/make_versioncpp.py
+++ b/cmake/make_versioncpp.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 
 from __future__ import print_function
 
@@ -90,7 +90,9 @@ class NsisInstScriptGenerator(Generator):
                 FreeOrion_BUILD_NO=build_no,
                 FreeOrion_BUILDSYS=build_sys,
                 FreeOrion_DLL_LIST_INSTALL="\n  ".join(['File "..\\' + fname + '"' for fname in dll_files]),
-                FreeOrion_DLL_LIST_UNINSTALL="\n  ".join(['Delete "$INSTDIR\\' + fname + '"' for fname in dll_files]))
+                FreeOrion_DLL_LIST_UNINSTALL="\n  ".join(['Delete "$INSTDIR\\' + fname + '"' for fname in dll_files]),
+                FreeOrion_PYTHON_VERSION="%d%d" % (sys.version_info.major, sys.version_info.minor))
+
         else:
             print("WARNING: no dll files for installer package found")
             return template.substitute(
@@ -99,7 +101,8 @@ class NsisInstScriptGenerator(Generator):
                 FreeOrion_BUILD_NO=build_no,
                 FreeOrion_BUILDSYS=build_sys,
                 FreeOrion_DLL_LIST_INSTALL="",
-                FreeOrion_DLL_LIST_UNINSTALL="")
+                FreeOrion_DLL_LIST_UNINSTALL="",
+                FreeOrion_PYTHON_VERSION="")
 
 
 if 3 != len(sys.argv):

--- a/default/python/mypy.ini
+++ b/default/python/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 2.7
+python_version = 3.5
 warn_return_any = True
 warn_unused_configs = True
 files = common,auth,chat,turn_events,universe_generation,AI

--- a/doc/tag_parser.py
+++ b/doc/tag_parser.py
@@ -48,7 +48,7 @@ def add_doc_source(_file_name, _line_number, _content, _tags):
 
 
 def parse_file(_parse_file, _tags):
-    with open(_parse_file, 'r') as f:
+    with open(_parse_file, 'r', encoding='utf-8') as f:
         match_line = 0
         content = []
         special_comments_this_file = None

--- a/msvc2017/Common/Common.vcxproj
+++ b/msvc2017/Common/Common.vcxproj
@@ -161,14 +161,14 @@
     </None>
     <CustomBuild Include="..\..\util\Version.cpp.in">
       <FileType>Document</FileType>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">"$(SolutionDir)..\python2.7.exe" "$(SolutionDir)..\cmake\make_versioncpp.py" "$(SolutionDir).." "MSVC 2017"</Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"$(SolutionDir)..\python2.7.exe" "$(SolutionDir)..\cmake\make_versioncpp.py" "$(SolutionDir).." "MSVC 2017"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">"$(SolutionDir)..\python3.5.exe" "$(SolutionDir)..\cmake\make_versioncpp.py" "$(SolutionDir).." "MSVC 2017"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">"$(SolutionDir)..\python3.5.exe" "$(SolutionDir)..\cmake\make_versioncpp.py" "$(SolutionDir).." "MSVC 2017"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)..\util\Version.cpp;%(Outputs)</Outputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)..\util\Version.cpp;%(Outputs)</Outputs>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(SolutionDir)..\.git;%(AdditionalInputs)</AdditionalInputs>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(SolutionDir)..\.git;%(AdditionalInputs)</AdditionalInputs>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">"$(SolutionDir)..\python2.7.exe" "$(SolutionDir)..\cmake\make_versioncpp.py" "$(SolutionDir).." "MSVC 2017 Debug"</Command>
-      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"$(SolutionDir)..\python2.7.exe" "$(SolutionDir)..\cmake\make_versioncpp.py" "$(SolutionDir).." "MSVC 2017 Debug"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">"$(SolutionDir)..\python3.5.exe" "$(SolutionDir)..\cmake\make_versioncpp.py" "$(SolutionDir).." "MSVC 2017 Debug"</Command>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">"$(SolutionDir)..\python3.5.exe" "$(SolutionDir)..\cmake\make_versioncpp.py" "$(SolutionDir).." "MSVC 2017 Debug"</Command>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)..\util\Version.cpp;%(Outputs)</Outputs>
       <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(SolutionDir)..\util\Version.cpp;%(Outputs)</Outputs>
       <AdditionalInputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(SolutionDir)..\.git;%(AdditionalInputs)</AdditionalInputs>

--- a/msvc2017/FreeOrionCA/FreeOrionCA.vcxproj
+++ b/msvc2017/FreeOrionCA/FreeOrionCA.vcxproj
@@ -110,7 +110,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;FREEORION_BUILD_AI;FREEORION_WIN32;GiGi_EXPORTS;_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>../../../include/;../../GG/;../../../include/python2.7/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../../../include/;../../GG/;../../../include/python3.5/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)$(TargetName).pch</PrecompiledHeaderOutputFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -137,7 +137,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;FREEORION_BUILD_AI;FREEORION_WIN32;GiGi_EXPORTS;_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>../../../include/;../../GG/;../../../include/python2.7/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../../../include/;../../GG/;../../../include/python3.5/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)$(TargetName).pch</PrecompiledHeaderOutputFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>

--- a/msvc2017/FreeOrionD/FreeOrionD.vcxproj
+++ b/msvc2017/FreeOrionD/FreeOrionD.vcxproj
@@ -110,7 +110,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;FREEORION_BUILD_SERVER;FREEORION_WIN32;GiGi_EXPORTS;_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>../../../include/;../../GG/;../../../include/python2.7/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../../../include/;../../GG/;../../../include/python3.5/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)$(TargetName).pch</PrecompiledHeaderOutputFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
@@ -138,7 +138,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;FREEORION_BUILD_SERVER;FREEORION_WIN32;GiGi_EXPORTS;_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>../../../include/;../../GG/;../../../include/python2.7/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../../../include/;../../GG/;../../../include/python3.5/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)$(TargetName).pch</PrecompiledHeaderOutputFile>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>

--- a/packaging/windows_installer.nsi.in
+++ b/packaging/windows_installer.nsi.in
@@ -60,7 +60,7 @@ Section "MainSection" SEC01
   Delete "$$INSTDIR\vcredist_x86.exe"
 
   ${FreeOrion_DLL_LIST_INSTALL}
-  File "..\Python27.zip"
+  File "..\Python${FreeOrion_PYTHON_VERSION}.zip"
   File "..\FreeorionCA.exe"
   File "..\FreeorionD.exe"
   File "..\Freeorion.exe"

--- a/packaging/windows_installer.nsi.in
+++ b/packaging/windows_installer.nsi.in
@@ -108,7 +108,7 @@ Section Uninstall
   SetShellVarContext all
 
   ${FreeOrion_DLL_LIST_UNINSTALL}
-  Delete "$$INSTDIR\Python27.zip"
+  Delete "$$INSTDIR\Python${FreeOrion_PYTHON_VERSION}.zip"
   Delete "$$INSTDIR\FreeorionCA.exe"
   Delete "$$INSTDIR\FreeorionD.exe"
   Delete "$$INSTDIR\Freeorion.exe"

--- a/python/CommonFramework.h
+++ b/python/CommonFramework.h
@@ -53,8 +53,8 @@ private:
 
     // some helper objects needed to initialize and run the Python interface
 #if defined(FREEORION_MACOSX) || defined(FREEORION_WIN32)
-    wchar_t                 m_home_dir[1024];
-    wchar_t                 m_program_name[1024];
+    wchar_t*                m_home_dir;
+    wchar_t*                m_program_name;
 #endif
     boost::optional<boost::python::dict> m_namespace; // stores main namespace in optional to be finalized before Python interpreter
     boost::python::object*  m_python_module_error;  // used to track if and which Python module contains the "error_report" function ErrorReport should call

--- a/python/CommonFramework.h
+++ b/python/CommonFramework.h
@@ -37,6 +37,7 @@ public:
     bool IsPythonRunning();
 
     bool         Initialize();                         // initializes and runs the Python interpreter, prepares the Python environment
+    virtual bool InitImports() = 0;                    // initializes Python imports, must be implemented by derived classes
     virtual bool InitModules() = 0;                    // initializes Python modules, must be implemented by derived classes
     void         SetCurrentDir(const std::string dir); // sets Python current work directory or throws error_already_set
     void         AddToSysPath(const std::string dir);  // adds directory to Python sys.path or throws error_already_set
@@ -52,8 +53,8 @@ private:
 
     // some helper objects needed to initialize and run the Python interface
 #if defined(FREEORION_MACOSX) || defined(FREEORION_WIN32)
-    char                    m_home_dir[1024];
-    char                    m_program_name[1024];
+    wchar_t                 m_home_dir[1024];
+    wchar_t                 m_program_name[1024];
 #endif
     boost::optional<boost::python::dict> m_namespace; // stores main namespace in optional to be finalized before Python interpreter
     boost::python::object*  m_python_module_error;  // used to track if and which Python module contains the "error_report" function ErrorReport should call

--- a/python/UniverseWrapper.cpp
+++ b/python/UniverseWrapper.cpp
@@ -90,11 +90,9 @@ namespace {
         return retval;
     }
 
-    void UpdateMetersWrapper(const Universe& universe, const boost::python::list& objList) {
-        std::vector<int> objvec;
-        int const numObjects = boost::python::len(objList);
-        for (int i = 0; i < numObjects; i++)
-            objvec.push_back(boost::python::extract<int>(objList[i]));
+    void UpdateMetersWrapper(const Universe& universe, const boost::python::object& objIter) {
+        boost::python::stl_input_iterator<int> begin(objIter), end;
+        std::vector<int> objvec(begin, end);
         GetUniverse().UpdateMeterEstimates(objvec);
     }
 

--- a/server/ServerFramework.cpp
+++ b/server/ServerFramework.cpp
@@ -57,16 +57,14 @@ BOOST_PYTHON_MODULE(freeorion) {
 namespace {
 }
 
+bool PythonServer::InitImports() {
+    DebugLogger() << "Initializing server Python imports";
+    // Allow the "freeorion" C++ module to be imported within Python code
+    return PyImport_AppendInittab("freeorion", &PyInit_freeorion) != -1;
+}
+
 bool PythonServer::InitModules() {
     DebugLogger() << "Initializing server Python modules";
-
-    // Allow the "freeorion" C++ module to be imported within Python code
-    try {
-        initfreeorion();
-    } catch (...) {
-        ErrorLogger() << "Unable to initialize 'freeorion' server Python module";
-        return false;
-    }
 
     // Confirm existence of the directory containing the universe generation
     // Python scripts and add it to Pythons sys.path to make sure Python will

--- a/server/ServerFramework.h
+++ b/server/ServerFramework.h
@@ -11,6 +11,8 @@
 
 class PythonServer : public PythonBase {
 public:
+    /** Initializes server Python imports. */
+    bool InitImports() override;
     /** Initializes server Python modules. */
     bool InitModules() override;
 

--- a/test/system/SmokeTestHostless.cpp
+++ b/test/system/SmokeTestHostless.cpp
@@ -243,8 +243,9 @@ BOOST_AUTO_TEST_CASE(hostless_server) {
         while (ProcessMessages(start_time, MAX_WAITING_SEC));
     }
 
-    if (launch_server && server)
+    if (launch_server && server) {
         BOOST_REQUIRE(server->Terminate());
+    }
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/util/Directories.cpp
+++ b/util/Directories.cpp
@@ -34,7 +34,7 @@ namespace {
    globaldir: FreeOrion.app/Contents/Resources
    bindir:  FreeOrion.app/Contents/Executables
    configpath: ~/Library/FreeOrion/config.xml
-   pythonhome: FreeOrion.app/Contents/Frameworks/Python.framework/Versions/Current
+   pythonhome: FreeOrion.app/Contents/Frameworks/Python.framework/Versions/{PythonMajor}.{PythonMinor}
 */
 namespace {
     fs::path   s_user_dir;
@@ -88,8 +88,7 @@ void InitDirs(const std::string& argv0) {
     s_user_dir      =   fs::path(getenv("HOME")) / "Library" / "Application Support" / "FreeOrion";
     s_bin_dir       =   app_path / "Executables";
     s_config_path   =   s_user_dir / "config.xml";
-    // ToDo: get python version from linked boost python library
-    s_python_home   =   app_path / "Frameworks" / "Python.framework" / "Versions" / "3.5";
+    s_python_home   =   app_path / "Frameworks" / "Python.framework" / "Versions" / FREEORION_PYTHON_VERSION;
 
     fs::path p = s_user_dir;
     if (!exists(p))

--- a/util/Directories.cpp
+++ b/util/Directories.cpp
@@ -88,7 +88,8 @@ void InitDirs(const std::string& argv0) {
     s_user_dir      =   fs::path(getenv("HOME")) / "Library" / "Application Support" / "FreeOrion";
     s_bin_dir       =   app_path / "Executables";
     s_config_path   =   s_user_dir / "config.xml";
-    s_python_home   =   app_path / "Frameworks" / "Python.framework" / "Versions" / "Current";
+    // ToDo: get python version from linked boost python library
+    s_python_home   =   app_path / "Frameworks" / "Python.framework" / "Versions" / "3.5";
 
     fs::path p = s_user_dir;
     if (!exists(p))


### PR DESCRIPTION
Changes boost::python usages to be appropriate for python3.
Drops lints and tests for python2.
<s>Changes all python code to python3.
@freeorion/ai-team I didn't check if AI produce correct orders. At least it doesn't produce exceptions so freeorion system tests are passed.</s>

WIP:
<s>- Fix `ReadOnlyDict` tests. Implement it with `collections.Mapping` (see https://stackoverflow.com/questions/19022868/how-to-make-dictionary-read-only-in-python )
- Fix `default/python/common/charting/charts.py`</s>