### PR TITLE
Ship weapons target dangerous, vulnerable, damaged ships first

### DIFF
--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_1.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_1.focs.txt
@@ -6,14 +6,19 @@ Part
     capacity = 4
     damage = 1
     combatTargets = OrderedAlternativesOf [
-        // Target Bombers and Heavy Bombers first
+        // Rather target Bombers and Heavy Bombers
         And [
             [[COMBAT_TARGETS_VISIBLE_ENEMY]]
             Fighter
             Or [
                DesignHasPart name = "FT_HANGAR_3"
                DesignHasPart name = "FT_HANGAR_4"
+               // Low chance to intercept other fighters. Higher if few bombers present
+               Random probability = 0.1
             ]
+            // If there are few bombers intercept other fighters
+            // NumberOf doesnt work for fighters, also number should be fleet dependent
+            NumberOf number = 3 condition = Fighter
         ]
         And [ [[COMBAT_TARGETS_VISIBLE_ENEMY]]  Fighter ]
         // if no fighters: target enemy ships

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_3.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_3.focs.txt
@@ -6,7 +6,7 @@ Part
     capacity = 2
     damage = 5
     combatTargets = OrderedAlternativesOf [
-        And [ [[COMBAT_TARGETS_VISIBLE_ENEMY]]  [[COMBAT_TARGETS_NOT_DESTROYED_SHIP]] ]
+        [[DEFAULT_SHIP_WEAPON_COMBAT_TARGETS]]
         And [ [[COMBAT_TARGETS_VISIBLE_ENEMY]]  Fighter ]
     ]
     mountableSlotTypes = Internal

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_4.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_4.focs.txt
@@ -6,7 +6,7 @@ Part
     capacity = 1
     damage = 10
     combatTargets = OrderedAlternativesOf [
-        And [ [[COMBAT_TARGETS_VISIBLE_ENEMY]]  [[COMBAT_TARGETS_NOT_DESTROYED_SHIP]] ]
+        [[DEFAULT_SHIP_WEAPON_COMBAT_TARGETS]]
         And [ [[COMBAT_TARGETS_VISIBLE_ENEMY]]  Fighter ]
     ]
     mountableSlotTypes = Internal

--- a/default/scripting/ship_parts/ShortRange/SR_JAWS.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_JAWS.focs.txt
@@ -3,6 +3,7 @@ Part
     description = "SR_JAWS_DESC"
     class = ShortRange
     damage = 5
+    combatTargets = [[DEFAULT_SHIP_WEAPON_COMBAT_TARGETS]]
     mountableSlotTypes = External
     buildcost = 20 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 1
@@ -13,3 +14,4 @@ Part
 #include "shortrange.macros"
 
 #include "/scripting/common/upkeep.macros"
+#include "/scripting/ship_parts/targeting.macros"

--- a/default/scripting/ship_parts/ShortRange/SR_PLASMA_DISCHARGE.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_PLASMA_DISCHARGE.focs.txt
@@ -3,6 +3,7 @@ Part
     description = "SR_PLASMA_DISCHARGE_DESC"
     class = ShortRange
     damage = 20
+    combatTargets = [[DEFAULT_SHIP_WEAPON_COMBAT_TARGETS]]
     mountableSlotTypes = External
     buildcost = 40 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 3
@@ -13,3 +14,4 @@ Part
 #include "shortrange.macros"
 
 #include "/scripting/common/upkeep.macros"
+#include "/scripting/ship_parts/targeting.macros"

--- a/default/scripting/ship_parts/ShortRange/SR_SPINAL_ANTIMATTER.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_SPINAL_ANTIMATTER.focs.txt
@@ -3,6 +3,7 @@ Part
     description = "SR_SPINAL_ANTIMATTER_DESC"
     class = ShortRange
     damage = 100
+    combatTargets = [[DEFAULT_SHIP_WEAPON_COMBAT_TARGETS]]
     mountableSlotTypes = Core
     buildcost = 250 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 4
@@ -13,3 +14,4 @@ Part
 #include "shortrange.macros"
 
 #include "/scripting/common/upkeep.macros"
+#include "/scripting/ship_parts/targeting.macros"

--- a/default/scripting/ship_parts/ShortRange/SR_SPINES.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_SPINES.focs.txt
@@ -3,6 +3,7 @@ Part
     description = "SR_SPINES_DESC"
     class = ShortRange
     damage = 20
+    combatTargets = [[DEFAULT_SHIP_WEAPON_COMBAT_TARGETS]]
     mountableSlotTypes = External
     buildcost = 40 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 3
@@ -13,3 +14,4 @@ Part
 #include "shortrange.macros"
 
 #include "/scripting/common/upkeep.macros"
+#include "/scripting/ship_parts/targeting.macros"

--- a/default/scripting/ship_parts/ShortRange/SR_TENTACLE.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_TENTACLE.focs.txt
@@ -3,6 +3,7 @@ Part
     description = "SR_TENTACLE_DESC"
     class = ShortRange
     damage = 5
+    combatTargets = [[DEFAULT_SHIP_WEAPON_COMBAT_TARGETS]]
     mountableSlotTypes = External
     buildcost = 30 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 2
@@ -13,3 +14,4 @@ Part
 #include "shortrange.macros"
 
 #include "/scripting/common/upkeep.macros"
+#include "/scripting/ship_parts/targeting.macros"

--- a/default/scripting/ship_parts/ShortRange/SR_WEAPON_1_1.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_WEAPON_1_1.focs.txt
@@ -4,6 +4,7 @@ Part
     class = ShortRange
     damage = 3
     NoDefaultCapacityEffect
+    combatTargets = [[DEFAULT_SHIP_WEAPON_COMBAT_TARGETS]]
     mountableSlotTypes = External
     buildcost = 20 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 1
@@ -16,3 +17,5 @@ Part
 #include "shortrange.macros"
 
 #include "/scripting/common/upkeep.macros"
+#include "/scripting/ship_parts/targeting.macros"
+

--- a/default/scripting/ship_parts/ShortRange/SR_WEAPON_2_1.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_WEAPON_2_1.focs.txt
@@ -4,6 +4,7 @@ Part
     class = ShortRange
     damage = 5
     NoDefaultCapacityEffect
+    combatTargets = [[DEFAULT_SHIP_WEAPON_COMBAT_TARGETS]]
     mountableSlotTypes = External
     buildcost = 30 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 2
@@ -16,3 +17,4 @@ Part
 #include "shortrange.macros"
 
 #include "/scripting/common/upkeep.macros"
+#include "/scripting/ship_parts/targeting.macros"

--- a/default/scripting/ship_parts/ShortRange/SR_WEAPON_3_1.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_WEAPON_3_1.focs.txt
@@ -4,6 +4,7 @@ Part
     class = ShortRange
     damage = 9
     NoDefaultCapacityEffect
+    combatTargets = [[DEFAULT_SHIP_WEAPON_COMBAT_TARGETS]]
     mountableSlotTypes = External
     buildcost = 40 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 3
@@ -16,3 +17,4 @@ Part
 #include "shortrange.macros"
 
 #include "/scripting/common/upkeep.macros"
+#include "/scripting/ship_parts/targeting.macros"

--- a/default/scripting/ship_parts/ShortRange/SR_WEAPON_4_1.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_WEAPON_4_1.focs.txt
@@ -4,6 +4,7 @@ Part
     class = ShortRange
     damage = 15
     NoDefaultCapacityEffect
+    combatTargets = [[DEFAULT_SHIP_WEAPON_COMBAT_TARGETS]]
     mountableSlotTypes = External
     buildcost = 60 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 4
@@ -16,3 +17,4 @@ Part
 #include "shortrange.macros"
 
 #include "/scripting/common/upkeep.macros"
+#include "/scripting/ship_parts/targeting.macros"

--- a/default/scripting/ship_parts/targeting.macros
+++ b/default/scripting/ship_parts/targeting.macros
@@ -1,3 +1,50 @@
+DEFAULT_SHIP_WEAPON_COMBAT_TARGETS
+''' And [
+        [[COMBAT_TARGETS_VISIBLE_ENEMY]]
+        Or [
+           // Shoot at about one enemy per weapon per average - ships with fewer weapon parts are actually more focussed
+           MaximumNumberOf number = Max( 3, ( Source.Fleet.NumShips * [[COUNT_SHIP_WEAPONS(Source.DesignID)]] ) )
+                           sortkey = [[DEFAULT_TARGET_SHIP_VALUE]]
+                           condition = And [
+              InSystem id = Source.SystemID
+              [[COMBAT_TARGETS_VISIBLE_ENEMY]]
+              [[COMBAT_TARGETS_NOT_DESTROYED_SHIP]]
+           ]
+           // Rarely attacking fighters
+           // Not sure if that means that about 10 percent of fighters are matched
+           // or if that means there is a 10 percent chance that all fighters match
+           And [
+               Random probability = 0.1
+               Fighter
+           ]
+        ]
+    ]
+'''
+
+
+// It is good to shoot dangerous, vulnerable ships              which could be repaired to be even more dangerous
+DEFAULT_TARGET_SHIP_VALUE
+''' ( LocalCandidate.Attack / Max(1,LocalCandidate.Structure) + ( ( LocalCandidate.MaxStructure - LocalCandidate.Structure) / LocalCandidate.MaxStructure / 2 ) ) '''
+// Also some way to access the current shot ship part or at least the shot damage would be nice
+
+
+// Arrgh maintenance nightmare
+// @1@ Ship Design ID
+COUNT_SHIP_WEAPONS
+''' (
+    PartsInShipDesign name = "SR_WEAPON_1_1" design = @1@ +
+    PartsInShipDesign name = "SR_WEAPON_2_1" design = @1@ +
+    PartsInShipDesign name = "SR_WEAPON_3_1" design = @1@ +
+    PartsInShipDesign name = "SR_WEAPON_4_1" design = @1@ +
+    PartsInShipDesign name = "SR_ICE_BEAM" design = @1@ +
+    PartsInShipDesign name = "SR_JAWS" design = @1@ +
+    PartsInShipDesign name = "SR_PLASMA_DISCHARGE" design = @1@ +
+    PartsInShipDesign name = "SR_SPINAL_ANTIMATTER" design = @1@ +
+    PartsInShipDesign name = "SR_SPINES" design = @1@ +
+    PartsInShipDesign name = "SR_TENTACLE" design = @1@
+    )
+'''
+
 // If unowned or owner has not unlocked the ship part yet.
 COMBAT_TARGETS_VISIBLE_ENEMY
 '''        Or [        // unowned target, when attacker is owned by an empire, and target is visible to that empire


### PR DESCRIPTION
This is WIP and mostly for furthering discussion.

[forum post by telos](https://www.freeorion.org/forum/viewtopic.php?p=98396#p98396)

For all ship weapons (including Bombers and monster weapons) but flak cannon:
Targeting a number of enemy vessels. Possible targets are fighters (10% chance of being included) and N most-juicy ships.

N is an approximation of the total number of shots shot by the attacking fleet.

most-juicy targets are ships which have a high Attack value and low structure (Attack divided by structure). 
Also damaged ships ared juicy: Half as juicy as attack value is the number of already lost structure. 

There is also a small change which makes interceptor targeting less rigid.

Implemented but untested. No idea if this works.

Play-Testing wanted if this is more suitable than the current targeting scheme.