### PR TITLE
[default-only] KISS hard targeting

### DIFF
--- a/default/python/AI/AIDependencies.py
+++ b/default/python/AI/AIDependencies.py
@@ -379,15 +379,15 @@ WEAPON_ROF_UPGRADE_DICT = {
 
 FIGHTER_DAMAGE_UPGRADE_DICT = {
     # "PARTNAME": tuple((tech_name, dmg_upgrade), (tech_name2, dmg_upgrade2), ...)
-    "FT_HANGAR_1": (("SHP_FIGHTERS_2", 1), ("SHP_FIGHTERS_3", 1), ("SHP_FIGHTERS_4", 1)),
-    "FT_HANGAR_2": (("SHP_FIGHTERS_2", 2), ("SHP_FIGHTERS_3", 3), ("SHP_FIGHTERS_4", 5)),
-    "FT_HANGAR_3": (("SHP_FIGHTERS_2", 3), ("SHP_FIGHTERS_3", 4), ("SHP_FIGHTERS_4", 7)),
+    "FT_HANGAR_1": (("SHP_FIGHTERS_2", 0), ("SHP_FIGHTERS_3", 0), ("SHP_FIGHTERS_4", 0)),
+    "FT_HANGAR_2": (("SHP_FIGHTERS_2", 2), ("SHP_FIGHTERS_3", 2), ("SHP_FIGHTERS_4", 2)),
+    "FT_HANGAR_3": (("SHP_FIGHTERS_2", 3), ("SHP_FIGHTERS_3", 3), ("SHP_FIGHTERS_4", 3)),
     "FT_HANGAR_4": (),
 }
 
 FIGHTER_CAPACITY_UPGRADE_DICT = {
     # "PARTNAME": tuple((tech_name, capacity_upgrade), (tech_name2, capacity_upgrade2), ...)
-    "FT_HANGAR_1": (),
+    "FT_HANGAR_1": (("SHP_FIGHTERS_2", 1), ("SHP_FIGHTERS_3", 1), ("SHP_FIGHTERS_4", 1)),
     "FT_HANGAR_2": (),
     "FT_HANGAR_3": (),
     "FT_HANGAR_4": (),
@@ -658,11 +658,12 @@ PILOT_ROF_MODIFIER_DICT = {
 
 PILOT_FIGHTERDAMAGE_MODIFIER_DICT = {
     # TRAIT:    {hangar_name: effect, hangar_name2: effect2,...}
+    # TODO FT_HANGAR_1 fighters are not able to attack ships so pilot damage modifier does not apply
     "NO":       {},
-    "BAD":      {"FT_HANGAR_1": -1, "FT_HANGAR_2": -2, "FT_HANGAR_3": -3, "FT_HANGAR_4": -4},
-    "GOOD":     {"FT_HANGAR_1":  1, "FT_HANGAR_2":  2, "FT_HANGAR_3":  3, "FT_HANGAR_4": 4},
-    "GREAT":    {"FT_HANGAR_1":  2, "FT_HANGAR_2":  4, "FT_HANGAR_3":  6, "FT_HANGAR_4": 8},
-    "ULTIMATE": {"FT_HANGAR_1":  3, "FT_HANGAR_2":  6, "FT_HANGAR_3":  9, "FT_HANGAR_4": 12},
+    "BAD":      {"FT_HANGAR_1":  0, "FT_HANGAR_2": -2, "FT_HANGAR_3": -3, "FT_HANGAR_4": -4},
+    "GOOD":     {"FT_HANGAR_1":  0, "FT_HANGAR_2":  2, "FT_HANGAR_3":  3, "FT_HANGAR_4": 4},
+    "GREAT":    {"FT_HANGAR_1":  0, "FT_HANGAR_2":  4, "FT_HANGAR_3":  6, "FT_HANGAR_4": 8},
+    "ULTIMATE": {"FT_HANGAR_1":  0, "FT_HANGAR_2":  6, "FT_HANGAR_3":  9, "FT_HANGAR_4": 12},
 }
 
 PILOT_FIGHTER_CAPACITY_MODIFIER_DICT = {
@@ -675,8 +676,8 @@ PILOT_FIGHTER_CAPACITY_MODIFIER_DICT = {
 }
 
 HANGAR_LAUNCH_CAPACITY_MODIFIER_DICT = {
-    # hangar_name: {bay_name: effect, bay_name2: effect, ...}
-    "FT_HANGAR_1": {"FT_BAY_1": 2},
+    # hangar_name: {bay_name: ((tech_name, effect), ...), bay_name2: ((tech_name, effect), ...}
+    "FT_HANGAR_1": {"FT_BAY_1": (("SHP_FIGHTERS_1", 1), ("SHP_FIGHTERS_2", 1), ("SHP_FIGHTERS_3", 1), ("SHP_FIGHTERS_4", 1))},
 }
 # </editor-fold>
 

--- a/default/python/AI/AIDependencies.py
+++ b/default/python/AI/AIDependencies.py
@@ -382,7 +382,7 @@ FIGHTER_DAMAGE_UPGRADE_DICT = {
     "FT_HANGAR_1": (("SHP_FIGHTERS_2", 0), ("SHP_FIGHTERS_3", 0), ("SHP_FIGHTERS_4", 0)),
     "FT_HANGAR_2": (("SHP_FIGHTERS_2", 2), ("SHP_FIGHTERS_3", 2), ("SHP_FIGHTERS_4", 2)),
     "FT_HANGAR_3": (("SHP_FIGHTERS_2", 3), ("SHP_FIGHTERS_3", 3), ("SHP_FIGHTERS_4", 3)),
-    "FT_HANGAR_4": (),
+    "FT_HANGAR_4": (("SHP_FIGHTERS_2", 6), ("SHP_FIGHTERS_3", 6), ("SHP_FIGHTERS_4", 6)),
 }
 
 FIGHTER_CAPACITY_UPGRADE_DICT = {
@@ -660,10 +660,10 @@ PILOT_FIGHTERDAMAGE_MODIFIER_DICT = {
     # TRAIT:    {hangar_name: effect, hangar_name2: effect2,...}
     # TODO FT_HANGAR_1 fighters are not able to attack ships so pilot damage modifier does not apply
     "NO":       {},
-    "BAD":      {"FT_HANGAR_1":  0, "FT_HANGAR_2": -2, "FT_HANGAR_3": -3, "FT_HANGAR_4": -4},
-    "GOOD":     {"FT_HANGAR_1":  0, "FT_HANGAR_2":  2, "FT_HANGAR_3":  3, "FT_HANGAR_4": 4},
-    "GREAT":    {"FT_HANGAR_1":  0, "FT_HANGAR_2":  4, "FT_HANGAR_3":  6, "FT_HANGAR_4": 8},
-    "ULTIMATE": {"FT_HANGAR_1":  0, "FT_HANGAR_2":  6, "FT_HANGAR_3":  9, "FT_HANGAR_4": 12},
+    "BAD":      {"FT_HANGAR_1":  0, "FT_HANGAR_2": -1, "FT_HANGAR_3": -1, "FT_HANGAR_4": -1},
+    "GOOD":     {"FT_HANGAR_1":  0, "FT_HANGAR_2":  1, "FT_HANGAR_3":  1, "FT_HANGAR_4": 1},
+    "GREAT":    {"FT_HANGAR_1":  0, "FT_HANGAR_2":  2, "FT_HANGAR_3":  2, "FT_HANGAR_4": 2},
+    "ULTIMATE": {"FT_HANGAR_1":  0, "FT_HANGAR_2":  3, "FT_HANGAR_3":  3, "FT_HANGAR_4": 3},
 }
 
 PILOT_FIGHTER_CAPACITY_MODIFIER_DICT = {

--- a/default/python/AI/ShipDesignAI.py
+++ b/default/python/AI/ShipDesignAI.py
@@ -1584,10 +1584,10 @@ class ShipDesigner(object):
 
     def _calculate_fighter_launch_rate(self, bay_parts, hangar_part_name):
         launch_rate = 0
-        bays_bonus = AIDependencies.HANGAR_LAUNCH_CAPACITY_MODIFIER_DICT.get(hangar_part_name, {})
+        bays_tech_bonus = AIDependencies.HANGAR_LAUNCH_CAPACITY_MODIFIER_DICT.get(hangar_part_name, {})
         for bay_part in bay_parts:
             launch_rate += bay_part.capacity
-            launch_rate += bays_bonus.get(bay_part.name, 0)
+            launch_rate += _get_tech_bonus(bays_tech_bonus, bay_part.name)
         return launch_rate
 
     def _calculate_hangar_damage(self, hangar_part, ignore_species=False):

--- a/default/python/AI/ShipDesignAI.py
+++ b/default/python/AI/ShipDesignAI.py
@@ -1589,7 +1589,7 @@ class ShipDesigner(object):
             bay_launch_capacity_modifier_dict = AIDependencies.HANGAR_LAUNCH_CAPACITY_MODIFIER_DICT.get(hangar_part_name, {})
         for bay_part in bay_parts:
             launch_rate += bay_part.capacity
-            if {} != bays_tech_bonus:
+            if {} != bay_launch_capacity_modifier_dict:
                 launch_rate += _get_tech_bonus(bay_launch_capacity_modifier_dict, bay_part.name)
         return launch_rate
 

--- a/default/python/AI/ShipDesignAI.py
+++ b/default/python/AI/ShipDesignAI.py
@@ -1584,10 +1584,13 @@ class ShipDesigner(object):
 
     def _calculate_fighter_launch_rate(self, bay_parts, hangar_part_name):
         launch_rate = 0
-        bays_tech_bonus = AIDependencies.HANGAR_LAUNCH_CAPACITY_MODIFIER_DICT.get(hangar_part_name, {})
+        bay_launch_capacity_modifier_dict = {}
+        if hangar_part_name != None:
+            bay_launch_capacity_modifier_dict = AIDependencies.HANGAR_LAUNCH_CAPACITY_MODIFIER_DICT.get(hangar_part_name, {})
         for bay_part in bay_parts:
             launch_rate += bay_part.capacity
-            launch_rate += _get_tech_bonus(bays_tech_bonus, bay_part.name)
+            if {} != bays_tech_bonus:
+                launch_rate += _get_tech_bonus(bay_launch_capacity_modifier_dict, bay_part.name)
         return launch_rate
 
     def _calculate_hangar_damage(self, hangar_part, ignore_species=False):
@@ -2368,7 +2371,7 @@ def _get_tech_bonus(upgrade_dict, part_name):
             _raised_warnings.add(part_name)
             error(("WARNING: Encountered unknown part (%s): "
                    "The AI can play on but its damage estimates may be incorrect leading to worse decision-making. "
-                   "Please update AIDependencies.py") % part_name, exc_info=True)
+                   "Please update AIDependencies.py - %s") % (part_name, upgrade_dict), exc_info=True)
         return 0
     total_tech_bonus = 0
     for tech, bonus in upgrades:

--- a/default/python/AI/ShipDesignAI.py
+++ b/default/python/AI/ShipDesignAI.py
@@ -1585,11 +1585,11 @@ class ShipDesigner(object):
     def _calculate_fighter_launch_rate(self, bay_parts, hangar_part_name):
         launch_rate = 0
         bay_launch_capacity_modifier_dict = {}
-        if hangar_part_name != None:
+        if hangar_part_name:
             bay_launch_capacity_modifier_dict = AIDependencies.HANGAR_LAUNCH_CAPACITY_MODIFIER_DICT.get(hangar_part_name, {})
         for bay_part in bay_parts:
             launch_rate += bay_part.capacity
-            if {} != bay_launch_capacity_modifier_dict:
+            if bay_launch_capacity_modifier_dict:
                 launch_rate += _get_tech_bonus(bay_launch_capacity_modifier_dict, bay_part.name)
         return launch_rate
 

--- a/default/scripting/ship_parts/FighterBay/FT_BAY_1.focs.txt
+++ b/default/scripting/ship_parts/FighterBay/FT_BAY_1.focs.txt
@@ -4,7 +4,7 @@ Part
     class = FighterBay
     capacity = 2
     mountableSlotTypes = External
-    buildcost = 20 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
+    buildcost = 10 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 1
     tags = [ "PEDIA_PC_FIGHTER_BAY" ]
     location = OwnedBy empire = Source.Owner

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_1.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_1.focs.txt
@@ -23,7 +23,7 @@ Part
             activation = Source
             stackinggroup = "INTERCEPTOR_FAST_LAUNCH_EFFECT"
             effects = [
-                SetMaxCapacity partname = "FT_BAY_1" value = (PartsInShipDesign name = "FT_BAY_1" design = Target.DesignID) * (
+                SetMaxCapacity partname = "FT_BAY_1" value = (
                     3 +
                     Statistic If Condition = OwnerHasTech Name = "SHP_FIGHTERS_2" +
                     Statistic If Condition = OwnerHasTech Name = "SHP_FIGHTERS_3" +

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_1.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_1.focs.txt
@@ -3,14 +3,14 @@ Part
     description = "FT_HANGAR_1_DESC"
     exclusions = [ "FT_HANGAR_0" "FT_HANGAR_2" "FT_HANGAR_3" "FT_HANGAR_4" ]
     class = FighterHangar
-    capacity = 4
+    capacity = 3
     damage = 1
     combatTargets = And [
         [[COMBAT_TARGETS_VISIBLE_ENEMY]]
         Fighter
     ]
     mountableSlotTypes = Internal
-    buildcost = 15 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
+    buildcost = 10 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 1
     tags = [ "PEDIA_PC_FIGHTER_HANGAR" ]
     location = OwnedBy empire = Source.Owner
@@ -24,7 +24,7 @@ Part
             stackinggroup = "INTERCEPTOR_FAST_LAUNCH_EFFECT"
             effects = [
                 SetMaxCapacity partname = "FT_BAY_1" value = (PartsInShipDesign name = "FT_BAY_1" design = Target.DesignID) * (
-                    4 +
+                    3 +
                     Statistic If Condition = OwnerHasTech Name = "SHP_FIGHTERS_2" +
                     Statistic If Condition = OwnerHasTech Name = "SHP_FIGHTERS_3" +
                     Statistic If Condition = OwnerHasTech Name = "SHP_FIGHTERS_4"

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_1.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_1.focs.txt
@@ -23,7 +23,12 @@ Part
             activation = Source
             stackinggroup = "INTERCEPTOR_FAST_LAUNCH_EFFECT"
             effects = [
-                SetMaxCapacity partname = "FT_BAY_1" value = Value + 2
+                SetMaxCapacity partname = "FT_BAY_1" value = (PartsInShipDesign name = "FT_BAY_1" design = Target.DesignID) * (
+                    4 +
+                    Statistic If Condition = OwnerHasTech Name = "SHP_FIGHTERS_2" +
+                    Statistic If Condition = OwnerHasTech Name = "SHP_FIGHTERS_3" +
+                    Statistic If Condition = OwnerHasTech Name = "SHP_FIGHTERS_4"
+                )
             ]
     ]
     icon = "icons/ship_parts/fighter06.png"

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_1.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_1.focs.txt
@@ -5,19 +5,9 @@ Part
     class = FighterHangar
     capacity = 4
     damage = 1
-    combatTargets = OrderedAlternativesOf [
-        // Target Bombers and Heavy Bombers first
-        And [
-            [[COMBAT_TARGETS_VISIBLE_ENEMY]]
-            Fighter
-            Or [
-               DesignHasPart name = "FT_HANGAR_3"
-               DesignHasPart name = "FT_HANGAR_4"
-            ]
-        ]
-        And [ [[COMBAT_TARGETS_VISIBLE_ENEMY]]  Fighter ]
-        // if no fighters: target enemy ships
-        And [ [[COMBAT_TARGETS_VISIBLE_ENEMY]]  [[COMBAT_TARGETS_NOT_DESTROYED_SHIP]] ]
+    combatTargets = And [
+        [[COMBAT_TARGETS_VISIBLE_ENEMY]]
+        Fighter
     ]
     mountableSlotTypes = Internal
     buildcost = 15 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_2.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_2.focs.txt
@@ -4,7 +4,7 @@ Part
     exclusions = [ "FT_HANGAR_0" "FT_HANGAR_1" "FT_HANGAR_3" "FT_HANGAR_4" ]
     class = FighterHangar
     capacity = 3
-    damage = 3
+    damage = 4
     combatTargets = And [
         [[COMBAT_TARGETS_VISIBLE_ENEMY]]
         Or [
@@ -13,7 +13,7 @@ Part
         ]
     ]
     mountableSlotTypes = Internal
-    buildcost = 20 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
+    buildcost = 15 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 1
     tags = [ "PEDIA_PC_FIGHTER_HANGAR" ]
     location = OwnedBy empire = Source.Owner

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_3.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_3.focs.txt
@@ -4,13 +4,13 @@ Part
     exclusions = [ "FT_HANGAR_0" "FT_HANGAR_1" "FT_HANGAR_2" "FT_HANGAR_4" ]
     class = FighterHangar
     capacity = 2
-    damage = 5
+    damage = 6
     combatTargets = And [
         [[COMBAT_TARGETS_VISIBLE_ENEMY]]
         [[COMBAT_TARGETS_NOT_DESTROYED_SHIP]]
     ]
     mountableSlotTypes = Internal
-    buildcost = 25 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
+    buildcost = 20 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 1
     tags = [ "PEDIA_PC_FIGHTER_HANGAR" ]
     location = OwnedBy empire = Source.Owner

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_3.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_3.focs.txt
@@ -5,9 +5,9 @@ Part
     class = FighterHangar
     capacity = 2
     damage = 5
-    combatTargets = OrderedAlternativesOf [
-        And [ [[COMBAT_TARGETS_VISIBLE_ENEMY]]  [[COMBAT_TARGETS_NOT_DESTROYED_SHIP]] ]
-        And [ [[COMBAT_TARGETS_VISIBLE_ENEMY]]  Fighter ]
+    combatTargets = And [
+        [[COMBAT_TARGETS_VISIBLE_ENEMY]]
+        [[COMBAT_TARGETS_NOT_DESTROYED_SHIP]]
     ]
     mountableSlotTypes = Internal
     buildcost = 25 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_4.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_4.focs.txt
@@ -7,7 +7,10 @@ Part
     damage = 12
     combatTargets = And [
         [[COMBAT_TARGETS_VISIBLE_ENEMY]]
-        [[COMBAT_TARGETS_NOT_DESTROYED_SHIP]]
+        Or [
+           [[COMBAT_TARGETS_NOT_DESTROYED_SHIP]]
+           [[COMBAT_TARGETS_PLANET_WITH_DEFENSE]]
+        ]
     ]
     mountableSlotTypes = Internal
     buildcost = 50 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_4.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_4.focs.txt
@@ -4,13 +4,13 @@ Part
     exclusions = [ "FT_HANGAR_0" "FT_HANGAR_1" "FT_HANGAR_2" "FT_HANGAR_3" ]
     class = FighterHangar
     capacity = 1
-    damage = 10
-    combatTargets = OrderedAlternativesOf [
-        And [ [[COMBAT_TARGETS_VISIBLE_ENEMY]]  [[COMBAT_TARGETS_NOT_DESTROYED_SHIP]] ]
-        And [ [[COMBAT_TARGETS_VISIBLE_ENEMY]]  Fighter ]
+    damage = 12
+    combatTargets = And [
+        [[COMBAT_TARGETS_VISIBLE_ENEMY]]
+        [[COMBAT_TARGETS_NOT_DESTROYED_SHIP]]
     ]
     mountableSlotTypes = Internal
-    buildcost = 30 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
+    buildcost = 50 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 1
     tags = [ "PEDIA_PC_FIGHTER_HANGAR" ]
     location = OwnedBy empire = Source.Owner

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_4.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_4.focs.txt
@@ -13,7 +13,7 @@ Part
         ]
     ]
     mountableSlotTypes = Internal
-    buildcost = 50 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
+    buildcost = 25 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 1
     tags = [ "PEDIA_PC_FIGHTER_HANGAR" ]
     location = OwnedBy empire = Source.Owner

--- a/default/scripting/ship_parts/ShortRange/SR_SPINAL_ANTIMATTER.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_SPINAL_ANTIMATTER.focs.txt
@@ -3,6 +3,13 @@ Part
     description = "SR_SPINAL_ANTIMATTER_DESC"
     class = ShortRange
     damage = 100
+    combatTargets = And [
+        [[COMBAT_TARGETS_VISIBLE_ENEMY]]
+        Or [
+           [[COMBAT_TARGETS_NOT_DESTROYED_SHIP]]
+           [[COMBAT_TARGETS_PLANET_WITH_DEFENSE]]
+        ]
+    ]
     mountableSlotTypes = Core
     buildcost = 250 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 4
@@ -13,3 +20,4 @@ Part
 #include "shortrange.macros"
 
 #include "/scripting/common/upkeep.macros"
+#include "/scripting/ship_parts/targeting.macros"

--- a/default/scripting/ship_parts/ShortRange/SR_WEAPON_1_1.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_WEAPON_1_1.focs.txt
@@ -4,6 +4,13 @@ Part
     class = ShortRange
     damage = 3
     NoDefaultCapacityEffect
+    combatTargets = And [
+        [[COMBAT_TARGETS_VISIBLE_ENEMY]]
+        Or [
+           [[COMBAT_TARGETS_NOT_DESTROYED_SHIP]]
+           [[COMBAT_TARGETS_PLANET_WITH_DEFENSE]]
+        ]
+    ]
     mountableSlotTypes = External
     buildcost = 20 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 1
@@ -16,3 +23,4 @@ Part
 #include "shortrange.macros"
 
 #include "/scripting/common/upkeep.macros"
+#include "/scripting/ship_parts/targeting.macros"

--- a/default/scripting/ship_parts/ShortRange/SR_WEAPON_2_1.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_WEAPON_2_1.focs.txt
@@ -4,6 +4,13 @@ Part
     class = ShortRange
     damage = 5
     NoDefaultCapacityEffect
+    combatTargets = And [
+        [[COMBAT_TARGETS_VISIBLE_ENEMY]]
+        Or [
+           [[COMBAT_TARGETS_NOT_DESTROYED_SHIP]]
+           [[COMBAT_TARGETS_PLANET_WITH_DEFENSE]]
+        ]
+    ]
     mountableSlotTypes = External
     buildcost = 30 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 2
@@ -16,3 +23,4 @@ Part
 #include "shortrange.macros"
 
 #include "/scripting/common/upkeep.macros"
+#include "/scripting/ship_parts/targeting.macros"

--- a/default/scripting/ship_parts/ShortRange/SR_WEAPON_3_1.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_WEAPON_3_1.focs.txt
@@ -4,6 +4,13 @@ Part
     class = ShortRange
     damage = 9
     NoDefaultCapacityEffect
+    combatTargets = And [
+        [[COMBAT_TARGETS_VISIBLE_ENEMY]]
+        Or [
+           [[COMBAT_TARGETS_NOT_DESTROYED_SHIP]]
+           [[COMBAT_TARGETS_PLANET_WITH_DEFENSE]]
+        ]
+    ]
     mountableSlotTypes = External
     buildcost = 40 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 3
@@ -16,3 +23,4 @@ Part
 #include "shortrange.macros"
 
 #include "/scripting/common/upkeep.macros"
+#include "/scripting/ship_parts/targeting.macros"

--- a/default/scripting/ship_parts/ShortRange/SR_WEAPON_4_1.focs.txt
+++ b/default/scripting/ship_parts/ShortRange/SR_WEAPON_4_1.focs.txt
@@ -4,6 +4,13 @@ Part
     class = ShortRange
     damage = 15
     NoDefaultCapacityEffect
+    combatTargets = And [
+        [[COMBAT_TARGETS_VISIBLE_ENEMY]]
+        Or [
+           [[COMBAT_TARGETS_NOT_DESTROYED_SHIP]]
+           [[COMBAT_TARGETS_PLANET_WITH_DEFENSE]]
+        ]
+    ]
     mountableSlotTypes = External
     buildcost = 60 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 4
@@ -16,3 +23,4 @@ Part
 #include "shortrange.macros"
 
 #include "/scripting/common/upkeep.macros"
+#include "/scripting/ship_parts/targeting.macros"

--- a/default/scripting/species/common/weapons.macros
+++ b/default/scripting/species/common/weapons.macros
@@ -25,17 +25,15 @@ BAD_WEAPONS
                 Ship
                 Armed
                 Or [
-                    DesignHasPart name = "FT_HANGAR_1"
                     DesignHasPart name = "FT_HANGAR_2"
                     DesignHasPart name = "FT_HANGAR_3"
                     DesignHasPart name = "FT_HANGAR_4"
                 ]
             ]
             effects = [
-                SetMaxSecondaryStat partname = "FT_HANGAR_1" value = Value - 0.5
                 SetMaxSecondaryStat partname = "FT_HANGAR_2" value = Value - 1
-                SetMaxSecondaryStat partname = "FT_HANGAR_3" value = Value - 2
-                SetMaxSecondaryStat partname = "FT_HANGAR_4" value = Value - 3
+                SetMaxSecondaryStat partname = "FT_HANGAR_3" value = Value - 1
+                SetMaxSecondaryStat partname = "FT_HANGAR_4" value = Value - 1
             ]
 
         EffectsGroup
@@ -76,17 +74,15 @@ GOOD_WEAPONS
                 Ship
                 Armed
                 Or [
-                    DesignHasPart name = "FT_HANGAR_1"
                     DesignHasPart name = "FT_HANGAR_2"
                     DesignHasPart name = "FT_HANGAR_3"
                     DesignHasPart name = "FT_HANGAR_4"
                 ]
             ]
             effects = [
-                SetMaxSecondaryStat partname = "FT_HANGAR_1" value = Value + 0.5
                 SetMaxSecondaryStat partname = "FT_HANGAR_2" value = Value + 1
-                SetMaxSecondaryStat partname = "FT_HANGAR_3" value = Value + 2
-                SetMaxSecondaryStat partname = "FT_HANGAR_4" value = Value + 3
+                SetMaxSecondaryStat partname = "FT_HANGAR_3" value = Value + 1
+                SetMaxSecondaryStat partname = "FT_HANGAR_4" value = Value + 1
             ]
 
         EffectsGroup
@@ -127,17 +123,15 @@ GREAT_WEAPONS
                 Ship
                 Armed
                 Or [
-                    DesignHasPart name = "FT_HANGAR_1"
                     DesignHasPart name = "FT_HANGAR_2"
                     DesignHasPart name = "FT_HANGAR_3"
                     DesignHasPart name = "FT_HANGAR_4"
                 ]
             ]
             effects = [
-                SetMaxSecondaryStat partname = "FT_HANGAR_1" value = Value + 1
                 SetMaxSecondaryStat partname = "FT_HANGAR_2" value = Value + 2
-                SetMaxSecondaryStat partname = "FT_HANGAR_3" value = Value + 3
-                SetMaxSecondaryStat partname = "FT_HANGAR_4" value = Value + 5
+                SetMaxSecondaryStat partname = "FT_HANGAR_3" value = Value + 2
+                SetMaxSecondaryStat partname = "FT_HANGAR_4" value = Value + 2
             ]
 
         EffectsGroup
@@ -178,17 +172,15 @@ ULTIMATE_WEAPONS
                 Ship
                 Armed
                 Or [
-                    DesignHasPart name = "FT_HANGAR_1"
                     DesignHasPart name = "FT_HANGAR_2"
                     DesignHasPart name = "FT_HANGAR_3"
                     DesignHasPart name = "FT_HANGAR_4"
                 ]
             ]
             effects = [
-                SetMaxSecondaryStat partname = "FT_HANGAR_1" value = Value + 2
-                SetMaxSecondaryStat partname = "FT_HANGAR_2" value = Value + 4
-                SetMaxSecondaryStat partname = "FT_HANGAR_3" value = Value + 6
-                SetMaxSecondaryStat partname = "FT_HANGAR_4" value = Value + 8
+                SetMaxSecondaryStat partname = "FT_HANGAR_2" value = Value + 3
+                SetMaxSecondaryStat partname = "FT_HANGAR_3" value = Value + 3
+                SetMaxSecondaryStat partname = "FT_HANGAR_4" value = Value + 3
             ]
 
         EffectsGroup

--- a/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_1.focs.txt
+++ b/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_1.focs.txt
@@ -12,6 +12,7 @@ Tech
         Item type = ShipPart name = "FT_HANGAR_1"
         Item type = ShipPart name = "FT_HANGAR_2"
         Item type = ShipPart name = "FT_HANGAR_3"
+        Item type = ShipPart name = "FT_HANGAR_4"
     ]
     graphic = "icons/ship_parts/fighter05.png"
 

--- a/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_2.focs.txt
+++ b/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_2.focs.txt
@@ -23,6 +23,8 @@ Tech
             ]
             accountinglabel = "SHP_FIGHTERS_2"
             effects = [
+// FIXME WTF Target.DesignId is accepted but returns zero while Target.DesignID does the right thing
+// TODO also test/document (PartOfClassInShipDesign class = FighterWeapon design = Target.DesignID) 
                 SetMaxCapacity      partname = "FT_HANGAR_1" value = Value + (PartsInShipDesign name = "FT_HANGAR_1" design = Target.DesignID)
                 SetMaxSecondaryStat partname = "FT_HANGAR_2" value = Value + 2
                 SetMaxSecondaryStat partname = "FT_HANGAR_3" value = Value + 3

--- a/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_2.focs.txt
+++ b/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_2.focs.txt
@@ -19,6 +19,7 @@ Tech
                     DesignHasPart  name = "FT_HANGAR_1"
                     DesignHasPart  name = "FT_HANGAR_2"
                     DesignHasPart  name = "FT_HANGAR_3"
+                    DesignHasPart  name = "FT_HANGAR_4"
                 ]
             ]
             accountinglabel = "SHP_FIGHTERS_2"
@@ -28,7 +29,8 @@ Tech
                 SetMaxCapacity      partname = "FT_HANGAR_1" value = Value + (PartsInShipDesign name = "FT_HANGAR_1" design = Target.DesignID)
                 SetMaxSecondaryStat partname = "FT_HANGAR_2" value = Value + 2
                 SetMaxSecondaryStat partname = "FT_HANGAR_3" value = Value + 3
-                ]
+                SetMaxSecondaryStat partname = "FT_HANGAR_4" value = Value + 6
+            ]
     graphic = "icons/ship_parts/fighter05.png"
 
 #include "/scripting/common/base_prod.macros"

--- a/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_2.focs.txt
+++ b/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_2.focs.txt
@@ -23,7 +23,7 @@ Tech
             ]
             accountinglabel = "SHP_FIGHTERS_2"
             effects = [
-                SetMaxSecondaryStat partname = "FT_HANGAR_1" value = Value + 1
+                SetMaxCapacity      partname = "FT_HANGAR_1" value = Value + (PartsInShipDesign name = "FT_HANGAR_1" design = Target.DesignID)
                 SetMaxSecondaryStat partname = "FT_HANGAR_2" value = Value + 2
                 SetMaxSecondaryStat partname = "FT_HANGAR_3" value = Value + 3
                 ]

--- a/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_3.focs.txt
+++ b/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_3.focs.txt
@@ -24,8 +24,8 @@ Tech
             accountinglabel = "SHP_FIGHTERS_3"
             effects = [
                 SetMaxCapacity      partname = "FT_HANGAR_1" value = Value + (PartsInShipDesign name = "FT_HANGAR_1" design = Target.DesignID)
-                SetMaxSecondaryStat partname = "FT_HANGAR_2" value = Value + 3
-                SetMaxSecondaryStat partname = "FT_HANGAR_3" value = Value + 4
+                SetMaxSecondaryStat partname = "FT_HANGAR_2" value = Value + 2
+                SetMaxSecondaryStat partname = "FT_HANGAR_3" value = Value + 3
                 ]
     graphic = "icons/ship_parts/fighter05.png"
 

--- a/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_3.focs.txt
+++ b/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_3.focs.txt
@@ -19,6 +19,7 @@ Tech
                     DesignHasPart  name = "FT_HANGAR_1"
                     DesignHasPart  name = "FT_HANGAR_2"
                     DesignHasPart  name = "FT_HANGAR_3"
+                    DesignHasPart  name = "FT_HANGAR_4"
                 ]
             ]
             accountinglabel = "SHP_FIGHTERS_3"
@@ -26,7 +27,8 @@ Tech
                 SetMaxCapacity      partname = "FT_HANGAR_1" value = Value + (PartsInShipDesign name = "FT_HANGAR_1" design = Target.DesignID)
                 SetMaxSecondaryStat partname = "FT_HANGAR_2" value = Value + 2
                 SetMaxSecondaryStat partname = "FT_HANGAR_3" value = Value + 3
-                ]
+                SetMaxSecondaryStat partname = "FT_HANGAR_4" value = Value + 6
+            ]
     graphic = "icons/ship_parts/fighter05.png"
 
 #include "/scripting/common/base_prod.macros"

--- a/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_3.focs.txt
+++ b/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_3.focs.txt
@@ -23,7 +23,7 @@ Tech
             ]
             accountinglabel = "SHP_FIGHTERS_3"
             effects = [
-                SetMaxSecondaryStat partname = "FT_HANGAR_1" value = Value + 1
+                SetMaxCapacity      partname = "FT_HANGAR_1" value = Value + (PartsInShipDesign name = "FT_HANGAR_1" design = Target.DesignID)
                 SetMaxSecondaryStat partname = "FT_HANGAR_2" value = Value + 3
                 SetMaxSecondaryStat partname = "FT_HANGAR_3" value = Value + 4
                 ]

--- a/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_4.focs.txt
+++ b/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_4.focs.txt
@@ -24,8 +24,8 @@ Tech
             accountinglabel = "SHP_FIGHTERS_3"
             effects = [
                 SetMaxCapacity      partname = "FT_HANGAR_1" value = Value + (PartsInShipDesign name = "FT_HANGAR_1" design = Target.DesignID)
-                SetMaxSecondaryStat partname = "FT_HANGAR_2" value = Value + 5
-                SetMaxSecondaryStat partname = "FT_HANGAR_3" value = Value + 7
+                SetMaxSecondaryStat partname = "FT_HANGAR_2" value = Value + 2
+                SetMaxSecondaryStat partname = "FT_HANGAR_3" value = Value + 3
                 ]
     graphic = "icons/ship_parts/fighter05.png"
 

--- a/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_4.focs.txt
+++ b/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_4.focs.txt
@@ -23,7 +23,7 @@ Tech
             ]
             accountinglabel = "SHP_FIGHTERS_3"
             effects = [
-                SetMaxSecondaryStat partname = "FT_HANGAR_1" value = Value + 1
+                SetMaxCapacity      partname = "FT_HANGAR_1" value = Value + (PartsInShipDesign name = "FT_HANGAR_1" design = Target.DesignID)
                 SetMaxSecondaryStat partname = "FT_HANGAR_2" value = Value + 5
                 SetMaxSecondaryStat partname = "FT_HANGAR_3" value = Value + 7
                 ]

--- a/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_4.focs.txt
+++ b/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_4.focs.txt
@@ -19,6 +19,7 @@ Tech
                     DesignHasPart  name = "FT_HANGAR_1"
                     DesignHasPart  name = "FT_HANGAR_2"
                     DesignHasPart  name = "FT_HANGAR_3"
+                    DesignHasPart  name = "FT_HANGAR_4"
                 ]
             ]
             accountinglabel = "SHP_FIGHTERS_3"
@@ -26,7 +27,8 @@ Tech
                 SetMaxCapacity      partname = "FT_HANGAR_1" value = Value + (PartsInShipDesign name = "FT_HANGAR_1" design = Target.DesignID)
                 SetMaxSecondaryStat partname = "FT_HANGAR_2" value = Value + 2
                 SetMaxSecondaryStat partname = "FT_HANGAR_3" value = Value + 3
-                ]
+                SetMaxSecondaryStat partname = "FT_HANGAR_4" value = Value + 6
+            ]
     graphic = "icons/ship_parts/fighter05.png"
 
 #include "/scripting/common/base_prod.macros"

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -11994,13 +11994,13 @@ SHP_FIGHTERS_3
 Plasma Fighters
 
 SHP_FIGHTERS_3_DESC
-Upgrades the fighters of all carriers within [[metertype METER_SUPPLY]] to have laser weaponry. [[encyclopedia DAMAGE_TITLE]] from fighters in a [[shippart FT_HANGAR_2]] is increased by 2 and [[shippart FT_HANGAR_3]] by 3. For [[shippart FT_HANGAR_1]] fighters the capacity as well as the launch rate of the [[shippart FT_BAY_1]] is increased by 1.
+Upgrades the fighters of all carriers within [[metertype METER_SUPPLY]] to have plasma weaponry. [[encyclopedia DAMAGE_TITLE]] from fighters in a [[shippart FT_HANGAR_2]] is increased by 2 and [[shippart FT_HANGAR_3]] by 3. For [[shippart FT_HANGAR_1]] fighters the capacity as well as the launch rate of the [[shippart FT_BAY_1]] is increased by 1.
 
 SHP_FIGHTERS_4
 Death Ray Fighters
 
 SHP_FIGHTERS_4_DESC
-Upgrades the fighters of all carriers within [[metertype METER_SUPPLY]] to have laser weaponry. [[encyclopedia DAMAGE_TITLE]] from fighters in a [[shippart FT_HANGAR_2]] is increased by 2 and [[shippart FT_HANGAR_3]] by 3. For [[shippart FT_HANGAR_1]] fighters the capacity as well as the launch rate of the [[shippart FT_BAY_1]] is increased by 1.
+Upgrades the fighters of all carriers within [[metertype METER_SUPPLY]] to have death ray weaponry. [[encyclopedia DAMAGE_TITLE]] from fighters in a [[shippart FT_HANGAR_2]] is increased by 2 and [[shippart FT_HANGAR_3]] by 3. For [[shippart FT_HANGAR_1]] fighters the capacity as well as the launch rate of the [[shippart FT_BAY_1]] is increased by 1.
 
 SHP_WEAPON_1_2
 Mass Driver 2

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -11988,19 +11988,19 @@ SHP_FIGHTERS_2
 Laser Fighters
 
 SHP_FIGHTERS_2_DESC
-Upgrades the fighters of all carriers within [[metertype METER_SUPPLY]] to have laser weaponry. [[encyclopedia DAMAGE_TITLE]] from fighters in a [[shippart FT_HANGAR_1]] is increased by 1, [[shippart FT_HANGAR_2]] is increased by 2 and [[shippart FT_HANGAR_3]] by 3.
+Upgrades the fighters of all carriers within [[metertype METER_SUPPLY]] to have laser weaponry. [[encyclopedia DAMAGE_TITLE]] from fighters in a [[shippart FT_HANGAR_2]] is increased by 2 and [[shippart FT_HANGAR_3]] by 3. For [[shippart FT_HANGAR_1]] fighters the capacity as well as the launch rate of the [[shippart FT_BAY_1]] is increased by 1.
 
 SHP_FIGHTERS_3
 Plasma Fighters
 
 SHP_FIGHTERS_3_DESC
-Upgrades the fighters of all carriers within [[metertype METER_SUPPLY]] to have plasma weaponry. [[encyclopedia DAMAGE_TITLE]] from fighters in a [[shippart FT_HANGAR_1]] is increased by 1, [[shippart FT_HANGAR_2]] is increased by 3 and [[shippart FT_HANGAR_3]] by 4.
+Upgrades the fighters of all carriers within [[metertype METER_SUPPLY]] to have plasma weaponry. [[encyclopedia DAMAGE_TITLE]] from fighters in a [[shippart FT_HANGAR_2]] is increased by 3 and [[shippart FT_HANGAR_3]] by 4. For [[shippart FT_HANGAR_1]] fighters the capacity as well as the launch rate of the [[shippart FT_BAY_1]] is increased by 1.
 
 SHP_FIGHTERS_4
 Death Ray Fighters
 
 SHP_FIGHTERS_4_DESC
-Upgrades the fighters of all carriers within [[metertype METER_SUPPLY]] to have death ray weaponry. [[encyclopedia DAMAGE_TITLE]] from fighters in a [[shippart FT_HANGAR_1]] is increased by 1, [[shippart FT_HANGAR_2]] is increased by 5 and [[shippart FT_HANGAR_3]] by 7.
+Upgrades the fighters of all carriers within [[metertype METER_SUPPLY]] to have death ray weaponry. [[encyclopedia DAMAGE_TITLE]] from fighters in a [[shippart FT_HANGAR_2]] is increased by 5 and [[shippart FT_HANGAR_3]] by 7. For [[shippart FT_HANGAR_1]] fighters the capacity as well as the launch rate of the [[shippart FT_BAY_1]] is increased by 1.
 
 SHP_WEAPON_1_2
 Mass Driver 2
@@ -13329,7 +13329,7 @@ FT_BAY_1
 Launch Bay
 
 FT_BAY_1_DESC
-Launch system for fighters.
+Launch system for fighters. Launches [[FT_HANGAR_1_FIGHTER]] faster: Can launch all fighters in a single [[shippart FT_HANGAR_1]].
 
 FT_HANGAR_0
 Decoy Hangar
@@ -13347,7 +13347,7 @@ FT_HANGAR_1_FIGHTER
 Interceptor
 
 FT_HANGAR_1_DESC
-Storage system for minimally armed fighters. Can attack enemy fighters only.
+Storage system for minimally armed fighters. Can attack enemy fighters only. Launches faster: A [[shippart FT_BAY_1]] can launch all fighters in a single [[shippart FT_HANGAR_1]].
 
 FT_HANGAR_2
 Fighter Hangar

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -13377,7 +13377,7 @@ FT_HANGAR_4_FIGHTER
 Heavy-Bomber
 
 FT_HANGAR_4_DESC
-Storage system for heavily armed fighters.
+Storage system for heavily armed fighters. Can attack enemy ships and planets.
 
 FT_HANGAR_KRILL
 Krill Swarm

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -13400,7 +13400,7 @@ SR_WEAPON_1_1
 Mass Driver
 
 SR_WEAPON_1_1_DESC
-'''The Mass Driver, a basic weapon.
+'''The Mass Driver, a basic weapon. Attacks ships and planets.
 
 Upgrading the weapon technology will increase the shot damage.
 
@@ -13410,7 +13410,7 @@ SR_WEAPON_2_1
 Laser Weapon
 
 SR_WEAPON_2_1_DESC
-'''The Laser, a more powerful ship's weapon than the Mass Driver.
+'''The Laser, a more powerful ship's weapon than the Mass Driver. Attacks ships and planets.
 
 Upgrading the weapon technology will increase the shot damage.
 
@@ -13420,7 +13420,7 @@ SR_WEAPON_3_1
 Plasma Cannons
 
 SR_WEAPON_3_1_DESC
-'''The Plasma Cannon, a more powerful ship's weapon than the Laser.
+'''The Plasma Cannon, a more powerful ship's weapon than the Laser. Attacks ships and planets.
 
 Upgrading the weapon technology will increase the shot damage.
 
@@ -13430,7 +13430,7 @@ SR_WEAPON_4_1
 Death Ray
 
 SR_WEAPON_4_1_DESC
-'''The Death Ray, a more powerful ship's weapon than the Plasma Cannon.
+'''The Death Ray, a more powerful ship's weapon than the Plasma Cannon. Attacks ships and planets.
 
 Upgrading the weapon technology will increase the shot damage.
 
@@ -13452,7 +13452,7 @@ SR_SPINAL_ANTIMATTER
 Spinal Antimatter Cannon
 
 SR_SPINAL_ANTIMATTER_DESC
-A huge spinal mount mass driver firing heavy projectiles made of antimatter.
+A huge spinal mount mass driver firing heavy projectiles made of antimatter. Attacks ships and planets.
 
 SR_JAWS
 Jaws

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -13365,7 +13365,7 @@ FT_HANGAR_3_FIGHTER
 Bomber
 
 FT_HANGAR_3_DESC
-Storage system for moderately armed fighters.
+Storage system for moderately armed fighters. Can attack enemy ships only.
 
 FT_HANGAR_4
 Heavy-Bomber Hangar

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -13356,7 +13356,7 @@ FT_HANGAR_2_FIGHTER
 Fighter
 
 FT_HANGAR_2_DESC
-Storage system for lightly armed fighters.
+Storage system for lightly armed fighters. Can attack enemy ships and fighters.
 
 FT_HANGAR_3
 Bomber Hangar

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -11982,25 +11982,28 @@ SHP_FIGHTERS_1_DESC
 
 A [[encyclopedia PC_FIGHTER_BAY]] can launch a number of fighters in each combat round. These fighters will then be both valid targets and able to attack ships and other fighters in subsequent combat rounds, but a single hit from any source will destroy a fighter. Unlike [[encyclopedia DAMAGE_TITLE]] inflicted by regular weapons, fighter damage ignores [[metertype METER_SHIELD]] on warships (they fire from within the shields).
 
+Piloting traits affect [[FT_HANGAR_2]], [[FT_HANGAR_3]], and [[FT_HANGAR_4]] fighters in the same way: bad piloting reduces damage by 1 per fighter; good piloting increases damage by 1, great piloting by 2, and ultimate piloting by 3 per fighter shot.
+Piloting traits do not affect [[FT_HANGAR_1]] fighters.
+
 At the end of combat, carriers will collect any fighters that have survived. If a carrier is in [[metertype METER_SUPPLY]] immediately after movement is resolved, it will refill hangars to maximum.'''
 
 SHP_FIGHTERS_2
 Laser Fighters
 
 SHP_FIGHTERS_2_DESC
-Upgrades the fighters of all carriers within [[metertype METER_SUPPLY]] to have laser weaponry. [[encyclopedia DAMAGE_TITLE]] from fighters in a [[shippart FT_HANGAR_2]] is increased by 2 and [[shippart FT_HANGAR_3]] by 3. For [[shippart FT_HANGAR_1]] fighters the capacity as well as the launch rate of the [[shippart FT_BAY_1]] is increased by 1.
+Upgrades the fighters of all carriers within [[metertype METER_SUPPLY]] to have laser weaponry. [[encyclopedia DAMAGE_TITLE]] from fighters in a [[shippart FT_HANGAR_2]] is increased by 2, [[shippart FT_HANGAR_3]] by 3, and [[shippart FT_HANGAR_4]] by 6. For [[shippart FT_HANGAR_1]] fighters the capacity as well as the launch rate of the [[shippart FT_BAY_1]] is increased by 1.
 
 SHP_FIGHTERS_3
 Plasma Fighters
 
 SHP_FIGHTERS_3_DESC
-Upgrades the fighters of all carriers within [[metertype METER_SUPPLY]] to have plasma weaponry. [[encyclopedia DAMAGE_TITLE]] from fighters in a [[shippart FT_HANGAR_2]] is increased by 2 and [[shippart FT_HANGAR_3]] by 3. For [[shippart FT_HANGAR_1]] fighters the capacity as well as the launch rate of the [[shippart FT_BAY_1]] is increased by 1.
+Upgrades the fighters of all carriers within [[metertype METER_SUPPLY]] to have plasma weaponry. [[encyclopedia DAMAGE_TITLE]] from fighters in a [[shippart FT_HANGAR_2]] is increased by 2, [[shippart FT_HANGAR_3]] by 3, and [[shippart FT_HANGAR_4]] by 6. For [[shippart FT_HANGAR_1]] fighters the capacity as well as the launch rate of the [[shippart FT_BAY_1]] is increased by 1.
 
 SHP_FIGHTERS_4
 Death Ray Fighters
 
 SHP_FIGHTERS_4_DESC
-Upgrades the fighters of all carriers within [[metertype METER_SUPPLY]] to have death ray weaponry. [[encyclopedia DAMAGE_TITLE]] from fighters in a [[shippart FT_HANGAR_2]] is increased by 2 and [[shippart FT_HANGAR_3]] by 3. For [[shippart FT_HANGAR_1]] fighters the capacity as well as the launch rate of the [[shippart FT_BAY_1]] is increased by 1.
+Upgrades the fighters of all carriers within [[metertype METER_SUPPLY]] to have death ray weaponry. [[encyclopedia DAMAGE_TITLE]] from fighters in a [[shippart FT_HANGAR_2]] is increased by 2, [[shippart FT_HANGAR_3]] by 3, and [[shippart FT_HANGAR_4]] by 6. For [[shippart FT_HANGAR_1]] fighters the capacity as well as the launch rate of the [[shippart FT_BAY_1]] is increased by 1.
 
 SHP_WEAPON_1_2
 Mass Driver 2

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -11994,13 +11994,13 @@ SHP_FIGHTERS_3
 Plasma Fighters
 
 SHP_FIGHTERS_3_DESC
-Upgrades the fighters of all carriers within [[metertype METER_SUPPLY]] to have plasma weaponry. [[encyclopedia DAMAGE_TITLE]] from fighters in a [[shippart FT_HANGAR_2]] is increased by 3 and [[shippart FT_HANGAR_3]] by 4. For [[shippart FT_HANGAR_1]] fighters the capacity as well as the launch rate of the [[shippart FT_BAY_1]] is increased by 1.
+Upgrades the fighters of all carriers within [[metertype METER_SUPPLY]] to have laser weaponry. [[encyclopedia DAMAGE_TITLE]] from fighters in a [[shippart FT_HANGAR_2]] is increased by 2 and [[shippart FT_HANGAR_3]] by 3. For [[shippart FT_HANGAR_1]] fighters the capacity as well as the launch rate of the [[shippart FT_BAY_1]] is increased by 1.
 
 SHP_FIGHTERS_4
 Death Ray Fighters
 
 SHP_FIGHTERS_4_DESC
-Upgrades the fighters of all carriers within [[metertype METER_SUPPLY]] to have death ray weaponry. [[encyclopedia DAMAGE_TITLE]] from fighters in a [[shippart FT_HANGAR_2]] is increased by 5 and [[shippart FT_HANGAR_3]] by 7. For [[shippart FT_HANGAR_1]] fighters the capacity as well as the launch rate of the [[shippart FT_BAY_1]] is increased by 1.
+Upgrades the fighters of all carriers within [[metertype METER_SUPPLY]] to have laser weaponry. [[encyclopedia DAMAGE_TITLE]] from fighters in a [[shippart FT_HANGAR_2]] is increased by 2 and [[shippart FT_HANGAR_3]] by 3. For [[shippart FT_HANGAR_1]] fighters the capacity as well as the launch rate of the [[shippart FT_BAY_1]] is increased by 1.
 
 SHP_WEAPON_1_2
 Mass Driver 2

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -13347,7 +13347,7 @@ FT_HANGAR_1_FIGHTER
 Interceptor
 
 FT_HANGAR_1_DESC
-Storage system for minimally armed fighters.
+Storage system for minimally armed fighters. Can attack enemy fighters only.
 
 FT_HANGAR_2
 Fighter Hangar


### PR DESCRIPTION
This implements KISS hard targeting - weapons can only shoot at a certain class of targets. Each target has an equal probability to be hit.

Mass drivers, Lasers, Plasmas, Death Rays, and Spinal antimatter cannon attack ships and planets (no fighters)
Flak cannon only attacks fighters
Interceptors attack enemy fighters only. Fighter tech increases capacity and launch rate of interceptor fighters instead of damage
Fighters attack ships and fighters.
Bombers attack ships only.

Also balancing for the fighters. Making launch bay and hangars cheaper and slightly less effective (but more cost efficient). Also the structure is now more uniform so it is easier to compare
10 PP: Launch bay  (was 20PP)
25 PP: 1 Heavy Bomber, 12 damage (was deactivated)
20 PP: 2 Bombers, 6 damage, get a +3 damage bonus per tech level. (was 25PP, 5 damage, but had higher damage for death ray fighters)
15 PP: 3 Fighters, 4 damage, get a +2 damage bonus per tech level. Ignoring launching and targeting Fighters have a comparable power level to Bombers. (was  20PP, 3 damage, but had higher damage for death ray fighters)
10PP: 3 Interceptors only kill fighters. Can launch 50% faster compared to Fighter. Each tech gives one extra Interceptor and launch capacity. (Was 15 PP, 4 interceptors, but had damage increase against ships)

Interceptors are not affected by pilot trait. Fighters/Bombers/Heavy Bombers get the same damage malus/bonus per fighter: Bad/Avrg/Good/Great/Ultimate -1/+0/+1/+2/+3

This means Fighters Hangars benefit most from pilot trait as those launch three fighters (and Heavy Bombers are the least affected).

As the base damage is "the same", the types of fighters are differentiated by their launch patterns, concentration, targeting, and pilot traits.

Flak vs Interceptors is a great low-tech option, an ok mid-tech good-pilot option, and late game not really interesting. Fighters need more external slots but can do real damage. Interceptors are probably better if the enemy employs Fighters - they act as chaff, but they need more research and need extra internal slots.

[forum discussion](https://www.freeorion.org/forum/viewtopic.php?f=6&t=11352&sid=6e51eec70784a37bed608c2bab8aad2f)

There are no client/server changes. So using the default directory of this branch with your freeorion 0.4.9 would work but is a bit outdated. To get the release version use. #2756 which  applies this code to the 0.4.9 stream