### PR TITLE
Add game rule to enable allied fleet repair

### DIFF
--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -97,6 +97,7 @@ Notable changes to the FreeOrion project will be documented in this file.
     - Aggressive fleets are always visible at the start of combat
     - Enable a part-based upkeep calculation rather than ship-based
     - Empires are only told that another empire has researched a tech when both empires have researched it - currently may break client-side meter estimate calculations
+    - Allow Drydocks building and Fleet Field Repair tech to repair ships of allied empires
 
 #### Balance
 

--- a/default/scripting/buildings/shipyards/ORBITAL_DRYDOCK.focs.txt
+++ b/default/scripting/buildings/shipyards/ORBITAL_DRYDOCK.focs.txt
@@ -25,7 +25,13 @@ BuildingType
             scope = And [
                 Ship
                 InSystem id = Source.SystemID
-                OwnedBy empire = Source.Owner
+                Or [
+                    OwnedBy empire = Source.Owner
+                    And [
+                        ((GameRule name = "RULE_ENABLE_ALLIED_REPAIR") > 0)
+                        OwnedBy affiliation = AllyOf empire = Source.Owner
+                    ]
+                ]
                 Structure high = LocalCandidate.MaxStructure - 0.001
             ]
             activation = And [
@@ -54,7 +60,13 @@ BuildingType
             scope = And [
                 Ship
                 InSystem id = Source.SystemID
-                OwnedBy empire = Source.Owner
+                Or [
+                    OwnedBy empire = Source.Owner
+                    And [
+                        ((GameRule name = "RULE_ENABLE_ALLIED_REPAIR") > 0)
+                        OwnedBy affiliation = AllyOf empire = Source.Owner
+                    ]
+                ]
                 Structure low = LocalCandidate.MaxStructure - 
                     [[ORB_DRYDOCK_REPAIR_VAL(LocalCandidate.MaxStructure)]] - 0.001
                     high = LocalCandidate.MaxStructure - 0.001
@@ -85,7 +97,13 @@ BuildingType
             scope = And [
                 Ship
                 InSystem id = Source.SystemID
-                OwnedBy empire = Source.Owner
+                Or [
+                    OwnedBy empire = Source.Owner
+                    And [
+                        ((GameRule name = "RULE_ENABLE_ALLIED_REPAIR") > 0)
+                        OwnedBy affiliation = AllyOf empire = Source.Owner
+                    ]
+                ]
                 Structure high = LocalCandidate.MaxStructure -
                     [[ORB_DRYDOCK_REPAIR_VAL(LocalCandidate.MaxStructure)]]
                 Turn low = LocalCandidate.ArrivedOnTurn + 1
@@ -115,7 +133,13 @@ BuildingType
             scope = And [
                 Ship
                 InSystem id = Source.SystemID
-                OwnedBy empire = Source.Owner
+                Or [
+                    OwnedBy empire = Source.Owner
+                    And [
+                        ((GameRule name = "RULE_ENABLE_ALLIED_REPAIR") > 0)
+                        OwnedBy affiliation = AllyOf empire = Source.Owner
+                    ]
+                ]
                 Structure high = LocalCandidate.MaxStructure - 0.001
                 Turn low = LocalCandidate.ArrivedOnTurn + 1
                 (Source.Planet.Happiness < [[CONST_ORB_DRYDOCK_MIN_HAPPY]])
@@ -176,7 +200,13 @@ PLANET_OWNED_DRYDOCK_HIGHEST_HAPPINESS
 '''MaximumNumberOf Number = 1 SortKey = LocalCandidate.Happiness Condition = And [
     Planet
     InSystem id = Source.SystemID
-    OwnedBy empire = Source.Owner
+    Or [
+        OwnedBy empire = Source.Owner
+        And [
+            ((GameRule name = "RULE_ENABLE_ALLIED_REPAIR") > 0)
+            OwnedBy affiliation = AllyOf empire = Source.Owner
+        ]
+    ]
     Contains
         Building name = "BLD_SHIPYARD_ORBITAL_DRYDOCK"
 ]

--- a/default/scripting/game_rules.focs.txt
+++ b/default/scripting/game_rules.focs.txt
@@ -126,3 +126,10 @@ GameRule
     category = "BALANCE"
     type = Toggle
     default = Off
+
+GameRule
+    name = "RULE_ENABLE_ALLIED_REPAIR"
+    description = "RULE_ENABLE_ALLIED_REPAIR_DESC"
+    category = "MULTIPLAYER"
+    type = Toggle
+    default = Off

--- a/default/scripting/techs/ship_parts/damage_control/SHP_FLEET_REPAIR.focs.txt
+++ b/default/scripting/techs/ship_parts/damage_control/SHP_FLEET_REPAIR.focs.txt
@@ -16,11 +16,18 @@ Tech
                 Ship
                 InSystem
                 Stationary
-                OwnedBy empire = Source.Owner
+                Or [
+                    OwnedBy empire = Source.Owner
+                    And [
+                        ((GameRule name = "RULE_ENABLE_ALLIED_REPAIR") > 0)
+                        OwnedBy affiliation = AllyOf empire = Source.Owner
+                    ]
+                ]
                 Turn low = LocalCandidate.System.LastTurnBattleHere + 1
                 Structure high = LocalCandidate.MaxStructure - 0.001
                 ResupplyableBy empire = Source.Owner
             ]
+	    stackinggroup = "FLEET_REPAIR"
             effects = SetStructure value = Value + (Target.MaxStructure/10)
 
 #include "/scripting/common/base_prod.macros"

--- a/default/stringtables/en.txt
+++ b/default/stringtables/en.txt
@@ -1227,6 +1227,12 @@ Use part-based upkeep
 RULE_SHIP_PART_BASED_UPKEEP_DESC
 Calculate upkeep based on ship parts instead of ships themselves.
 
+RULE_ENABLE_ALLIED_REPAIR
+Drydocks and Fleet Field Repair repair allied ships
+
+RULE_ENABLE_ALLIED_REPAIR_DESC
+Allow Drydocks building and Fleet Field Repair tech to repair ships of allied empires.
+
 RULE_SHOW_DETAILED_EMPIRES_DATA
 Show detailed empires data
 


### PR DESCRIPTION
Adds game rule to enable fleet repair at allied Drydock and with allies' Fleet Field Repair tech.

Supposed to be enabled in the teamed games.

Forum thread: https://freeorion.org/forum/viewtopic.php?f=6&t=11456
