### PR TITLE
Reset Rules to Defaults in Client when Returning to Intro Screen

### DIFF
--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -127,6 +127,7 @@ IntroMenu::IntroMenu(my_context ctx) :
 {
     TraceLogger(FSM) << "(HumanClientFSM) IntroMenu";
     Client().GetClientUI().ShowIntroScreen();
+    GetGameRules().ResetToDefaults();
 }
 
 IntroMenu::~IntroMenu() {


### PR DESCRIPTION
Resets rules to default value when returning to the intro screen menu. This prevents an issue where after playing a game with modified rules, such as a loaded save gamed, the default setting for a new game and the rule values in the intro screen pedia would be those of the previously-played game, rather than the defined rule default values.