### PR TITLE
Use boost signals to handle context menu in StatisticIcon

### DIFF
--- a/UI/CUIControls.cpp
+++ b/UI/CUIControls.cpp
@@ -1361,14 +1361,12 @@ void StatisticIcon::LClick(const GG::Pt& pt, GG::Flags<GG::ModKey> mod_keys) {
     if (Disabled())
         return;
     LeftClickedSignal(pt);
-    ForwardEventToParent();
 }
 
 void StatisticIcon::RClick(const GG::Pt& pt, GG::Flags<GG::ModKey> mod_keys) {
     if (Disabled())
         return;
     RightClickedSignal(pt);
-    ForwardEventToParent();
 }
 
 void StatisticIcon::MouseWheel(const GG::Pt& pt, int move, GG::Flags<GG::ModKey> mod_keys)

--- a/UI/CUIControls.cpp
+++ b/UI/CUIControls.cpp
@@ -1360,14 +1360,14 @@ void StatisticIcon::RButtonDown(const GG::Pt& pt, GG::Flags<GG::ModKey> mod_keys
 void StatisticIcon::LClick(const GG::Pt& pt, GG::Flags<GG::ModKey> mod_keys) {
     if (Disabled())
         return;
-    LeftClickedSignal();
+    LeftClickedSignal(pt);
     ForwardEventToParent();
 }
 
 void StatisticIcon::RClick(const GG::Pt& pt, GG::Flags<GG::ModKey> mod_keys) {
     if (Disabled())
         return;
-    RightClickedSignal();
+    RightClickedSignal(pt);
     ForwardEventToParent();
 }
 

--- a/UI/CUIControls.cpp
+++ b/UI/CUIControls.cpp
@@ -1372,6 +1372,23 @@ void StatisticIcon::RClick(const GG::Pt& pt, GG::Flags<GG::ModKey> mod_keys) {
 void StatisticIcon::MouseWheel(const GG::Pt& pt, int move, GG::Flags<GG::ModKey> mod_keys)
 { ForwardEventToParent(); }
 
+void StatisticIcon::AcceptDrops(const GG::Pt& pt, std::vector<std::shared_ptr<GG::Wnd>> wnds, GG::Flags<GG::ModKey> mod_keys)
+{ ForwardEventToParent(); }
+
+void StatisticIcon::DragDropEnter(const GG::Pt& pt, std::map<const GG::Wnd*, bool>& drop_wnds_acceptable,
+                                  GG::Flags<GG::ModKey> mod_keys)
+{ ForwardEventToParent(); }
+
+void StatisticIcon::DragDropHere(const GG::Pt& pt, std::map<const GG::Wnd*, bool>& drop_wnds_acceptable,
+                                 GG::Flags<GG::ModKey> mod_keys)
+{ ForwardEventToParent(); }
+
+void StatisticIcon::CheckDrops(const GG::Pt& pt, std::map<const GG::Wnd*, bool>& drop_wnds_acceptable, GG::Flags<GG::ModKey> mod_keys)
+{ ForwardEventToParent(); }
+
+void StatisticIcon::DragDropLeave()
+{ ForwardEventToParent(); }
+
 void StatisticIcon::DoLayout() {
     // arrange child controls horizontally if icon is wider than it is high, or vertically otherwise
     int icon_dim = std::min(Value(Height()), Value(Width()));

--- a/UI/CUIControls.h
+++ b/UI/CUIControls.h
@@ -465,6 +465,19 @@ public:
 
     void MouseWheel(const GG::Pt& pt, int move, GG::Flags<GG::ModKey> mod_keys) override;
 
+    void AcceptDrops(const GG::Pt& pt, std::vector<std::shared_ptr<GG::Wnd>> wnds, GG::Flags<GG::ModKey> mod_keys) override;
+
+    void DragDropEnter(const GG::Pt& pt, std::map<const GG::Wnd*, bool>& drop_wnds_acceptable,
+                       GG::Flags<GG::ModKey> mod_keys) override;
+
+    void DragDropHere(const GG::Pt& pt, std::map<const GG::Wnd*, bool>& drop_wnds_acceptable,
+                      GG::Flags<GG::ModKey> mod_keys) override;
+
+    void CheckDrops(const GG::Pt& pt, std::map<const GG::Wnd*, bool>& drop_wnds_acceptable,
+                    GG::Flags<GG::ModKey> mod_keys) override;
+
+    void DragDropLeave() override;
+
     void SetValue(double value, size_t index = 0);  ///< sets displayed \a value with \a index
     //@}
 

--- a/UI/CUIControls.h
+++ b/UI/CUIControls.h
@@ -468,8 +468,8 @@ public:
     void SetValue(double value, size_t index = 0);  ///< sets displayed \a value with \a index
     //@}
 
-    mutable boost::signals2::signal<void ()>    LeftClickedSignal;
-    mutable boost::signals2::signal<void ()>    RightClickedSignal;
+    mutable boost::signals2::signal<void (const GG::Pt&)> LeftClickedSignal;
+    mutable boost::signals2::signal<void (const GG::Pt&)> RightClickedSignal;
 
 private:
     void    DoLayout();

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -1080,8 +1080,6 @@ public:
     mutable boost::signals2::signal<void (const std::vector<int>&)> NewFleetFromShipsSignal;
 
 protected:
-    bool EventFilter(GG::Wnd* w, const GG::WndEvent& event) override;
-
     void DropsAcceptable(DropsAcceptableIter first, DropsAcceptableIter last,
                          const GG::Pt& pt, GG::Flags<GG::ModKey> mod_keys) const override;
 
@@ -1339,64 +1337,6 @@ void FleetDataPanel::SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
     //std::cout << "FleetDataPanel::SizeMove new size: (" << Value(Width()) << ", " << Value(Height()) << ")" << std::endl;
     if (old_size != Size())
         DoLayout();
-}
-
-bool FleetDataPanel::EventFilter(GG::Wnd* w, const GG::WndEvent& event) {
-    //std::cout << "FleetDataPanel::EventFilter " << EventTypeName(event) << std::endl << std::flush;
-
-    if (w == this || !w)
-        return false;
-
-    switch (event.Type()) {
-    case GG::WndEvent::RClick: {
-        MeterType meter_type = INVALID_METER_TYPE;
-        for (const auto& meter_type_stat_icon_pair : m_stat_icons) {
-            if (!meter_type_stat_icon_pair.second || meter_type_stat_icon_pair.second.get() != w)
-                continue;
-            meter_type = meter_type_stat_icon_pair.first;
-            break;
-        }
-        if (meter_type == INVALID_METER_TYPE)
-            return false;
-
-        std::string meter_string = boost::lexical_cast<std::string>(meter_type);
-        std::string meter_title;
-        if (UserStringExists(meter_string))
-            meter_title = UserString(meter_string);
-
-        bool retval = false;
-        auto zoom_article_action = [&retval, &meter_string]() { retval = ClientUI::GetClientUI()->ZoomToMeterTypeArticle(meter_string);};
-
-        auto pt = event.Point();
-        auto popup = GG::Wnd::Create<CUIPopupMenu>(pt.x, pt.y);
-
-        if (!meter_title.empty()) {
-            std::string popup_label = boost::io::str(FlexibleFormat(UserString("ENC_LOOKUP")) %
-                                                                    meter_title);
-            popup->AddMenuItem(GG::MenuItem(popup_label, false, false, zoom_article_action));
-        }
-        popup->Run();
-
-        return retval;
-        break;
-    }
-
-    case GG::WndEvent::DragDropEnter:
-    case GG::WndEvent::DragDropHere:
-    case GG::WndEvent::CheckDrops:
-    case GG::WndEvent::DragDropLeave:
-    case GG::WndEvent::DragDroppedOn:
-        if (w == this) {
-            ErrorLogger() << "FleetDataPanel::EventFilter w == this";
-            return false;
-        }
-        HandleEvent(event);
-        return true;
-        break;
-
-    default:
-        return false;
-    }
 }
 
 void FleetDataPanel::ToggleAggression() {
@@ -1813,10 +1753,22 @@ void FleetDataPanel::Init() {
 
         for (const auto& entry : meters_icons_browsetext) {
             auto icon = GG::Wnd::Create<StatisticIcon>(std::get<1>(entry), 0, 0, false, StatIconSize().x, StatIconSize().y);
-            m_stat_icons.push_back({std::get<0>(entry), icon});
+            auto meter_type = std::get<0>(entry);
+            m_stat_icons.push_back({meter_type, icon});
             icon->SetBrowseModeTime(tooltip_delay);
             icon->SetBrowseText(UserString(std::get<2>(entry)));
-            icon->InstallEventFilter(shared_from_this());
+            icon->RightClickedSignal.connect([meter_type](const GG::Pt& pt){
+                std::string meter_string = boost::lexical_cast<std::string>(meter_type);
+
+                auto zoom_article_action = [meter_string]() { ClientUI::GetClientUI()->ZoomToMeterTypeArticle(meter_string); };
+
+                auto popup = GG::Wnd::Create<CUIPopupMenu>(pt.x, pt.y);
+
+                std::string popup_label = boost::io::str(FlexibleFormat(UserString("ENC_LOOKUP")) %
+                                                                        UserString(meter_string));
+                popup->AddMenuItem(GG::MenuItem(popup_label, false, false, zoom_article_action));
+                popup->Run();
+            });
             AttachChild(icon);
             icon->SetBrowseModeTime(tooltip_delay);
         }

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -627,7 +627,6 @@ namespace {
         void Render() override;
         void PreRender() override;
 
-        bool EventFilter(GG::Wnd* w, const GG::WndEvent& event) override;
         void SizeMove(const GG::Pt& ul, const GG::Pt& lr) override;
 
         void Select(bool b);
@@ -978,7 +977,18 @@ namespace {
             auto icon = GG::Wnd::Create<StatisticIcon>(entry.second, 0, 0, false, StatIconSize().x, StatIconSize().y);
             m_stat_icons.push_back({entry.first, icon});
             AttachChild(icon);
-            icon->InstallEventFilter(shared_from_this());
+            std::string meter_string = boost::lexical_cast<std::string>(entry.first);
+
+            icon->RightClickedSignal.connect([meter_string](const GG::Pt& pt) {
+                auto zoom_article_action = [meter_string]() { ClientUI::GetClientUI()->ZoomToMeterTypeArticle(meter_string); };
+                std::string popup_label = boost::io::str(FlexibleFormat(UserString("ENC_LOOKUP")) %
+                                                                        UserString(meter_string));
+
+                auto popup = GG::Wnd::Create<CUIPopupMenu>(pt.x, pt.y);
+                popup->AddMenuItem(GG::MenuItem(popup_label, false, false, zoom_article_action));
+
+                popup->Run();
+            });
         }
 
         // bookkeeping
@@ -989,42 +999,6 @@ namespace {
             m_fleet_connection = fleet->StateChangedSignal.connect(
                 boost::bind(&ShipDataPanel::RequireRefresh, this));
     }
-
-    bool ShipDataPanel::EventFilter(GG::Wnd* w, const GG::WndEvent& event) {
-        if (event.Type() != GG::WndEvent::RClick || !w)
-            return false;
-
-        MeterType meter_type = INVALID_METER_TYPE;
-        for (const auto& meter_type_stat_icon_pair : m_stat_icons) {
-            if (!meter_type_stat_icon_pair.second || meter_type_stat_icon_pair.second.get() != w)
-                continue;
-            meter_type = meter_type_stat_icon_pair.first;
-            break;
-        }
-        if (meter_type == INVALID_METER_TYPE)
-            return false;
-
-        std::string meter_string = boost::lexical_cast<std::string>(meter_type);
-        std::string meter_title;
-        if (UserStringExists(meter_string))
-            meter_title = UserString(meter_string);
-
-        bool retval = false;
-        auto zoom_article_action = [&retval, &meter_string]() { retval = ClientUI::GetClientUI()->ZoomToMeterTypeArticle(meter_string);};
-
-        auto pt = event.Point();
-        auto popup = GG::Wnd::Create<CUIPopupMenu>(pt.x, pt.y);
-
-        if (!meter_title.empty()) {
-            std::string popup_label = boost::io::str(FlexibleFormat(UserString("ENC_LOOKUP")) %
-                                                                    meter_title);
-            popup->AddMenuItem(GG::MenuItem(popup_label, false, false, zoom_article_action));
-        }
-        popup->Run();
-
-        return retval;
-    }
-
 
     ////////////////////////////////////////////////
     // ShipRow

--- a/UI/MilitaryPanel.h
+++ b/UI/MilitaryPanel.h
@@ -20,8 +20,6 @@ public:
     void CompleteConstruction() override;
 
     /** \name Accessors */ //@{
-    bool EventFilter(GG::Wnd* w, const GG::WndEvent& event) override;
-
     int PlanetID() const { return m_planet_id; }
     //@}
 

--- a/UI/MultiIconValueIndicator.cpp
+++ b/UI/MultiIconValueIndicator.cpp
@@ -62,7 +62,29 @@ void MultiIconValueIndicator::CompleteConstruction() {
         GG::Pt icon_ul(x, GG::Y(EDGE_PAD));
         GG::Pt icon_lr = icon_ul + GG::Pt(IconWidth(), IconHeight() + ClientUI::Pts()*3/2);
         m_icons.back()->SizeMove(icon_ul, icon_lr);
-        m_icons.back()->InstallEventFilter(shared_from_this());
+        auto meter = meter_type.first;
+        auto meter_string = boost::lexical_cast<std::string>(meter_type.first);
+        m_icons.back()->RightClickedSignal.connect([this, meter, meter_string](const GG::Pt& pt) {
+            auto popup = GG::Wnd::Create<CUIPopupMenu>(pt.x, pt.y);
+
+            auto pc = GetPopCenter(*(this->m_object_ids.begin()));
+            if (meter == METER_POPULATION && pc && this->m_object_ids.size() == 1) {
+                auto species_name = pc->SpeciesName();
+                if (!species_name.empty()) {
+                    auto zoom_species_action = [species_name]() { ClientUI::GetClientUI()->ZoomToSpecies(species_name); };
+                    std::string species_label = boost::io::str(FlexibleFormat(UserString("ENC_LOOKUP")) %
+                                                                              UserString(species_name));
+                    popup->AddMenuItem(GG::MenuItem(species_label, false, false, zoom_species_action));
+                }
+            }
+
+
+            auto zoom_article_action = [meter_string]() { ClientUI::GetClientUI()->ZoomToMeterTypeArticle(meter_string);};
+            std::string popup_label = boost::io::str(FlexibleFormat(UserString("ENC_LOOKUP")) %
+                                                                    UserString(meter_string));
+            popup->AddMenuItem(GG::MenuItem(popup_label, false, false, zoom_article_action));
+            popup->Run();
+        });
         AttachChild(m_icons.back());
         x += IconWidth() + IconSpacing();
     }
@@ -124,56 +146,4 @@ void MultiIconValueIndicator::ClearToolTip(MeterType meter_type) {
     for (unsigned int i = 0; i < m_icons.size(); ++i)
         if (m_meter_types.at(i).first == meter_type)
             m_icons.at(i)->ClearBrowseInfoWnd();
-}
-
-bool MultiIconValueIndicator::EventFilter(GG::Wnd* w, const GG::WndEvent& event) {
-    if (event.Type() != GG::WndEvent::RClick)
-        return false;
-    const GG::Pt& pt = event.Point();
-
-    MeterType meter_type = INVALID_METER_TYPE;
-    for (unsigned int i = 0; i < m_icons.size(); ++i) {
-        try {
-            if (m_icons.at(i).get() == w) {
-                meter_type = m_meter_types.at(i).first;
-                break;
-            }
-        } catch(std::out_of_range &e) {
-            ErrorLogger() << e.what();
-            return false;
-        }
-    }
-    if (meter_type == INVALID_METER_TYPE)
-        return false;
-
-    std::string meter_string = boost::lexical_cast<std::string>(meter_type);
-    std::string meter_title;
-    if (UserStringExists(meter_string))
-        meter_title = UserString(meter_string);
-
-    std::string species_name;
-
-    bool retval = false;
-    auto zoom_species_action = [&retval, &species_name]() { retval = ClientUI::GetClientUI()->ZoomToSpecies(species_name); };
-    auto zoom_article_action = [&retval, &meter_string]() { retval = ClientUI::GetClientUI()->ZoomToMeterTypeArticle(meter_string);};
-
-    auto popup = GG::Wnd::Create<CUIPopupMenu>(pt.x, pt.y);
-
-    auto pc = GetPopCenter(*m_object_ids.begin());
-    if (meter_type == METER_POPULATION && pc && m_object_ids.size() == 1) {
-        species_name = pc->SpeciesName();
-        if (!species_name.empty()) {
-            std::string species_label = boost::io::str(FlexibleFormat(UserString("ENC_LOOKUP")) % UserString(species_name));
-            popup->AddMenuItem(GG::MenuItem(species_label, false, false, zoom_species_action));
-        }
-    }
-
-    if (!meter_title.empty()) {
-        std::string popup_label = boost::io::str(FlexibleFormat(UserString("ENC_LOOKUP")) %
-                                                                meter_title);
-        popup->AddMenuItem(GG::MenuItem(popup_label, false, false, zoom_article_action));
-    }
-    popup->Run();
-
-    return retval;
 }

--- a/UI/MultiIconValueIndicator.h
+++ b/UI/MultiIconValueIndicator.h
@@ -24,7 +24,6 @@ public:
 
     void Render() override;
     void MouseWheel(const GG::Pt& pt, int move, GG::Flags<GG::ModKey> mod_keys) override;
-    bool EventFilter(GG::Wnd* w, const GG::WndEvent& event) override;
     void Update();
     void SetToolTip(MeterType meter_type, const std::shared_ptr<GG::BrowseInfoWnd>& browse_wnd);
     void ClearToolTip(MeterType meter_type);

--- a/UI/PopulationPanel.h
+++ b/UI/PopulationPanel.h
@@ -28,8 +28,6 @@ public:
     /** \name Mutators */ //@{
     void PreRender() override;
 
-    bool EventFilter(GG::Wnd* w, const GG::WndEvent& event) override;
-
     /** expands or collapses panel to show details or just summary info */
     void ExpandCollapse(bool expanded);
 

--- a/UI/ResourcePanel.h
+++ b/UI/ResourcePanel.h
@@ -28,8 +28,6 @@ public:
     /** \name Mutators */ //@{
     void PreRender() override;
 
-    bool EventFilter(GG::Wnd* w, const GG::WndEvent& event) override;
-
     /** expands or collapses panel to show details or just summary info */
     void ExpandCollapse(bool expanded);
 

--- a/UI/SpecialsPanel.cpp
+++ b/UI/SpecialsPanel.cpp
@@ -103,7 +103,20 @@ void SpecialsPanel::Update() {
             ClientUI::SpecialIcon(special->Name()), UserString(special->Name()), desc));
         m_icons[entry.first] = graphic;
 
-        graphic->InstallEventFilter(shared_from_this());
+        auto special_name = entry.first;
+
+        graphic->RightClickedSignal.connect([special_name](const GG::Pt& pt) {
+            auto zoom_action = [special_name]() {
+                ClientUI::GetClientUI()->ZoomToSpecial(special_name);
+            };
+
+            auto popup = GG::Wnd::Create<CUIPopupMenu>(pt.x, pt.y);
+            std::string popup_label = boost::io::str(FlexibleFormat(UserString("ENC_LOOKUP")) % UserString(special_name));
+
+            popup->AddMenuItem(GG::MenuItem(popup_label, false, false, zoom_action));
+
+            popup->Run();
+        });
     }
 
     const GG::X AVAILABLE_WIDTH = Width() - EDGE_PAD;
@@ -128,30 +141,4 @@ void SpecialsPanel::Update() {
     } else {
         Resize(GG::Pt(Width(), y + SPECIAL_ICON_HEIGHT + EDGE_PAD*2));
     }
-}
-
-bool SpecialsPanel::EventFilter(GG::Wnd* w, const GG::WndEvent& event) {
-    if (event.Type() != GG::WndEvent::RClick)
-        return false;
-    const GG::Pt& pt = event.Point();
-
-    for (const auto& entry : m_icons) {
-        if (entry.second.get() != w)
-            continue;
-
-        bool retval = false;
-        auto zoom_action = [&entry, &retval]() {
-            retval = true;
-            ClientUI::GetClientUI()->ZoomToSpecial(entry.first);
-        };
-
-        auto popup = GG::Wnd::Create<CUIPopupMenu>(pt.x, pt.y);
-        std::string popup_label = boost::io::str(FlexibleFormat(UserString("ENC_LOOKUP")) % UserString(entry.first));
-
-        popup->AddMenuItem(GG::MenuItem(popup_label, false, false, zoom_action));
-
-        popup->Run();
-        return retval;
-    }
-    return false;
 }

--- a/UI/SpecialsPanel.h
+++ b/UI/SpecialsPanel.h
@@ -22,7 +22,6 @@ public:
     void Render() override;
     void MouseWheel(const GG::Pt& pt, int move, GG::Flags<GG::ModKey> mod_keys) override;
     void SizeMove(const GG::Pt& ul, const GG::Pt& lr) override;
-    bool EventFilter(GG::Wnd* w, const GG::WndEvent& event) override;
     void Update();          ///< regenerates indicators according specials on object
     //@}
 


### PR DESCRIPTION
Instead of using the GG filter event mechanism to handle the context menu of the various information panels, this PR now uses boost signals and callbacks.  This removes the need to find the associated context menu destination via some id lookup and simplifies the context menu callback.