### PR TITLE
Simplify StatisticIcon

### DIFF
--- a/UI/CUIControls.cpp
+++ b/UI/CUIControls.cpp
@@ -1385,16 +1385,26 @@ void StatisticIcon::DoLayout() {
 
     // Precompute text elements
     GG::Font::TextAndElementsAssembler text_elements(*ClientUI::GetFont());
-    text_elements.AddOpenTag(ValueColor(0))
+    text_elements.AddOpenTag(ClientUI::TextColor())
         .AddText(DoubleToString(std::get<0>(m_values[0]), std::get<1>(m_values[0]), std::get<2>(m_values[0])))
         .AddCloseTag("rgba");
-    if (m_values.size() > 1)
+    if (m_values.size() > 1) {
+        GG::Clr clr = ClientUI::TextColor();
+
+        int effectiveSign = EffectiveSign(std::get<0>(m_values.at(1)));
+
+        if (effectiveSign == -1)
+            clr = ClientUI::StatDecrColor();
+        if (effectiveSign == 1)
+            clr = ClientUI::StatIncrColor();
+
         text_elements
             .AddText(" (")
-            .AddOpenTag(ValueColor(1))
+            .AddOpenTag(clr)
             .AddText(DoubleToString(std::get<0>(m_values[1]), std::get<1>(m_values[1]), std::get<2>(m_values[1])))
             .AddCloseTag("rgba")
             .AddText(")");
+    }
 
     // Calculate location and format
     GG::Flags<GG::TextFormat> format;
@@ -1420,20 +1430,6 @@ void StatisticIcon::DoLayout() {
        m_text->SetText(text_elements.Text(), text_elements.Elements());
        m_text->SizeMove(text_ul, text_lr);
     }
-}
-
-GG::Clr StatisticIcon::ValueColor(size_t index) const {
-    if (m_values.empty() || index >= m_values.size())
-        return ClientUI::TextColor();
-
-    int effectiveSign = EffectiveSign(std::get<0>(m_values.at(index)));
-
-    if (index == 0) return ClientUI::TextColor();
-
-    if (effectiveSign == -1) return ClientUI::StatDecrColor();
-    if (effectiveSign == 1) return ClientUI::StatIncrColor();
-
-    return ClientUI::TextColor();
 }
 
 GG::Pt StatisticIcon::MinUsableSize() const {

--- a/UI/CUIControls.cpp
+++ b/UI/CUIControls.cpp
@@ -1323,15 +1323,13 @@ void StatisticIcon::PreRender() {
     DoLayout();
 }
 
-double StatisticIcon::GetValue(int index) const {
-    if (index < 0) throw std::invalid_argument("negative index passed to StatisticIcon::Value");
+double StatisticIcon::GetValue(size_t index) const {
     if (index > 1) throw std::invalid_argument("index greater than 1 passed to StatisticIcon::Value.  Only 1 or 2 values, with indices 0 or 1, supported.");
     if (index >= m_values.size()) throw std::invalid_argument("index greater than largest index available passed to StatisticIcon::Value");
     return std::get<0>(m_values[index]);
 }
 
-void StatisticIcon::SetValue(double value, int index) {
-    if (index < 0) throw std::invalid_argument("negative index passed to StatisticIcon::SetValue");
+void StatisticIcon::SetValue(double value, size_t index) {
     if (index > 1) throw std::invalid_argument("index greater than 1 passed to StatisticIcon::SetValue.  Only 1 or 2 values, with indices 0 or 1, supported.");
     if (index + 1 > m_values.size()) {
         auto entry = std::tuple<double, int, bool>(m_values[0]);
@@ -1424,8 +1422,8 @@ void StatisticIcon::DoLayout() {
     }
 }
 
-GG::Clr StatisticIcon::ValueColor(int index) const {
-    if (m_values.empty() || index >= m_values.size() || index < 0)
+GG::Clr StatisticIcon::ValueColor(size_t index) const {
+    if (m_values.empty() || index >= m_values.size())
         return ClientUI::TextColor();
 
     int effectiveSign = EffectiveSign(std::get<0>(m_values.at(index)));

--- a/UI/CUIControls.cpp
+++ b/UI/CUIControls.cpp
@@ -1309,26 +1309,6 @@ StatisticIcon::StatisticIcon(const std::shared_ptr<GG::Texture> texture,
     m_icon = GG::Wnd::Create<GG::StaticGraphic>(texture, GG::GRAPHIC_FITGRAPHIC);
 }
 
-StatisticIcon::StatisticIcon(const std::shared_ptr<GG::Texture> texture,
-                             double value0, double value1, int digits0, int digits1,
-                             bool showsign0, bool showsign1,
-                             GG::X w /*= GG::X1*/, GG::Y h /*= GG::Y1*/) :
-    GG::Control(GG::X0, GG::Y0, w, h, GG::INTERACTIVE),
-    m_num_values(2),
-    m_values(std::vector<double>(2, 0.0)),
-    m_digits(std::vector<int>(2, 2)),
-    m_show_signs(std::vector<bool>(2, false))
-{
-    m_icon = GG::Wnd::Create<GG::StaticGraphic>(texture, GG::GRAPHIC_FITGRAPHIC);
-
-    m_values[0] = value0;
-    m_values[1] = value1;
-    m_digits[0] = digits0;
-    m_digits[1] = digits1;
-    m_show_signs[0] = showsign0;
-    m_show_signs[1] = showsign1;
-}
-
 void StatisticIcon::CompleteConstruction() {
     GG::Control::CompleteConstruction();
 

--- a/UI/CUIControls.h
+++ b/UI/CUIControls.h
@@ -473,7 +473,6 @@ public:
 
 private:
     void    DoLayout();
-    GG::Clr ValueColor(size_t index) const;    ///< returns colour in which to draw value
 
     /// The value, precision and sign of the statistic value
     std::vector<std::tuple<double, int, bool>> m_values;

--- a/UI/CUIControls.h
+++ b/UI/CUIControls.h
@@ -443,7 +443,7 @@ public:
     void CompleteConstruction() override;
 
     /** \name Accessors */ //@{
-    double GetValue(int index = 0) const;
+    double GetValue(size_t index = 0) const;
     GG::Pt MinUsableSize() const override;
     //@}
 
@@ -465,7 +465,7 @@ public:
 
     void MouseWheel(const GG::Pt& pt, int move, GG::Flags<GG::ModKey> mod_keys) override;
 
-    void SetValue(double value, int index = 0);  ///< sets displayed \a value with \a index
+    void SetValue(double value, size_t index = 0);  ///< sets displayed \a value with \a index
     //@}
 
     mutable boost::signals2::signal<void ()>    LeftClickedSignal;
@@ -473,7 +473,7 @@ public:
 
 private:
     void    DoLayout();
-    GG::Clr ValueColor(int index) const;    ///< returns colour in which to draw value
+    GG::Clr ValueColor(size_t index) const;    ///< returns colour in which to draw value
 
     /// The value, precision and sign of the statistic value
     std::vector<std::tuple<double, int, bool>> m_values;

--- a/UI/CUIControls.h
+++ b/UI/CUIControls.h
@@ -438,11 +438,6 @@ public:
     StatisticIcon(const std::shared_ptr<GG::Texture> texture,
                   double value, int digits, bool showsign,
                   GG::X w = GG::X1, GG::Y h = GG::Y1); ///< initializes with one value
-
-    StatisticIcon(const std::shared_ptr<GG::Texture> texture,
-                  double value0, double value1, int digits0, int digits1,
-                  bool showsign0, bool showsign1,
-                  GG::X w = GG::X1, GG::Y h = GG::Y1); ///< initializes with two values
     //@}
 
     void CompleteConstruction() override;

--- a/UI/CUIControls.h
+++ b/UI/CUIControls.h
@@ -475,12 +475,10 @@ private:
     void    DoLayout();
     GG::Clr ValueColor(int index) const;    ///< returns colour in which to draw value
 
-    int                                 m_num_values = 0;
-    std::vector<double>                 m_values;
-    std::vector<int>                    m_digits;
-    std::vector<bool>                   m_show_signs;
-    std::shared_ptr<GG::StaticGraphic>  m_icon = nullptr;
-    std::shared_ptr<GG::Label>          m_text = nullptr;
+    /// The value, precision and sign of the statistic value
+    std::vector<std::tuple<double, int, bool>> m_values;
+    std::shared_ptr<GG::StaticGraphic>         m_icon = nullptr;
+    std::shared_ptr<GG::Label>                 m_text = nullptr;
 };
 
 class CUIToolBar : public GG::Control {


### PR DESCRIPTION
This PR simplifies the implementation of the StatisticIcon class.  The changes consist of:

* Removal of unused method.
* Use std::tuple to store representation state instead of multiple std::vector instances.
* Change interface to prevent signed vs unsigned comparision.
* Inline single use method.