### PR TITLE
Add CombatBout ValueRef

### DIFF
--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -992,14 +992,15 @@ namespace {
     };
 
     /// A collection of information the autoresolution must keep around
-    struct AutoresolveInfo {
+    struct AutoresolveInfo : SharedAutoresolveInfo {
+        int                             bout;
         std::set<int>                   valid_attacker_object_ids;  // all objects that can attack
         std::map<int, EmpireCombatInfo> empire_infos;               // empire specific information, indexed by empire id
-        CombatInfo&                     combat_info;
         int                             next_fighter_id = -1000001; // give fighters negative ids so as to avoid clashes with any positive-id of persistent UniverseObjects
         std::set<int>                   destroyed_object_ids;       // objects that have been destroyed so far during this combat
 
-        explicit AutoresolveInfo(CombatInfo& combat_info_) :
+        explicit AutoresolveInfo(int bout_, CombatInfo& combat_info_) :
+            bout(bout_),
             combat_info(combat_info_)
         {
             PopulateAttackers();
@@ -1362,7 +1363,7 @@ namespace {
     }
 
     void ShootAllWeapons(std::shared_ptr<UniverseObject> attacker,
-                         AutoresolveInfo& combat_state, int bout, int round,
+                         AutoresolveInfo& combat_state, int round,
                          AttacksEventPtr& attacks_event,
                          WeaponsPlatformEvent::WeaponsPlatformEventPtr& platform_event,
                          std::shared_ptr<FightersAttackFightersEvent>& fighter_on_fighter_event)
@@ -1381,7 +1382,6 @@ namespace {
         }
         TraceLogger(combat) << "Species targeting condition: " << species_targetting_condition->Dump();
 
-        BackgroundContext combat_context = BackgroundContext(bout, combat_state.combat_info.empire_object_visibility);
         for (const PartAttackInfo& weapon : weapons) {
             // skip non-direct-fire weapons (as only direct fire weapons can "shoot").
             // fighter launches handled separately
@@ -1404,7 +1404,7 @@ namespace {
             AddAllObjectsSet(combat_state.combat_info.objects, targets);
 
             // attacker is source object for condition evaluation. use combat-specific vis info.
-            ScriptingContext context(attacker, combat_context);
+            ScriptingContext context(attacker, combat_state);
 
             // apply species targeting condition and then weapon targeting condition
             species_targetting_condition->Eval(context, targets, rejected_targets, Condition::MATCHES);
@@ -1431,7 +1431,7 @@ namespace {
             auto targetx = std::const_pointer_cast<UniverseObject>(target);
 
             // do actual attacks
-            Attack(attacker, weapon, targetx, combat_state.combat_info, bout, round,
+            Attack(attacker, weapon, targetx, combat_state.combat_info, combat_state.bout, round,
                    attacks_event, platform_event, fighter_on_fighter_event);
 
         } // end for over weapons
@@ -1479,7 +1479,7 @@ namespace {
 
     void LaunchFighters(std::shared_ptr<UniverseObject> attacker,
                         const std::vector<PartAttackInfo>& weapons,
-                        AutoresolveInfo& combat_state, int bout, int round,
+                        AutoresolveInfo& combat_state, int round,
                         FighterLaunchesEventPtr& launches_event)
     {
         if (weapons.empty()) {
@@ -1523,7 +1523,7 @@ namespace {
 
             // combat event
             CombatEventPtr launch_event = std::make_shared<FighterLaunchEvent>(
-                bout, attacker->ID(), attacker_owner_id, new_fighter_ids.size());
+                combat_state.bout, attacker->ID(), attacker_owner_id, new_fighter_ids.size());
             launches_event->AddEvent(launch_event);
 
 
@@ -1629,13 +1629,13 @@ namespace {
         }
     }
 
-    void CombatRound(int bout, AutoresolveInfo& combat_state) {
+    void CombatRound(AutoresolveInfo& combat_state) {
         CombatInfo& combat_info = combat_state.combat_info;
 
-        auto bout_event = std::make_shared<BoutEvent>(bout);
+        auto bout_event = std::make_shared<BoutEvent>(combat_state.bout);
         combat_info.combat_events.push_back(bout_event);
         if (combat_state.valid_attacker_object_ids.empty()) {
-            DebugLogger(combat) << "Combat bout " << bout << " aborted due to no remaining attackers.";
+            DebugLogger(combat) << "Combat bout " << combat_state.bout << " aborted due to no remaining attackers.";
             return;
         }
 
@@ -1654,7 +1654,7 @@ namespace {
         auto attacks_event = std::make_shared<AttacksEvent>();
         bout_event->AddEvent(attacks_event);
 
-        auto fighter_on_fighter_event = std::make_shared<FightersAttackFightersEvent>(bout);
+        auto fighter_on_fighter_event = std::make_shared<FightersAttackFightersEvent>(combat_state.bout);
         bout_event->AddEvent(fighter_on_fighter_event);
 
         int round = 1;  // counter of events during the current combat bout
@@ -1677,10 +1677,10 @@ namespace {
             DebugLogger(combat) << "Planet: " << planet->Name();
 
             auto platform_event = std::make_shared<WeaponsPlatformEvent>(
-                bout, planet->ID(), planet->Owner());
+                combat_state.bout, planet->ID(), planet->Owner());
             attacks_event->AddEvent(platform_event);
 
-            ShootAllWeapons(planet, combat_state, bout, round++,
+            ShootAllWeapons(planet, combat_state, round++,
                             attacks_event, platform_event, fighter_on_fighter_event);
         }
 
@@ -1699,9 +1699,9 @@ namespace {
             DebugLogger(combat) << "Attacker: " << attacker->Name();
 
             auto platform_event = std::make_shared<WeaponsPlatformEvent>(
-                bout, attacker->ID(), attacker->Owner());
+                combat_state.bout, attacker->ID(), attacker->Owner());
 
-            ShootAllWeapons(attacker, combat_state, bout, round++,
+            ShootAllWeapons(attacker, combat_state, round++,
                             attacks_event, platform_event, fighter_on_fighter_event);
 
             if (!platform_event->AreSubEventsEmpty(attacker->Owner()))
@@ -1713,7 +1713,7 @@ namespace {
         // Launch fighters (which can attack in any subsequent combat bouts).
         // There is no point to launching fighters during the last bout, since
         // they won't get any chance to attack during this combat
-        if (bout < GetGameRules().Get<int>("RULE_NUM_COMBAT_ROUNDS")) {
+        if (combat_state.bout < GetGameRules().Get<int>("RULE_NUM_COMBAT_ROUNDS")) {
             auto launches_event = std::make_shared<FighterLaunchesEvent>();
             for (const auto& attacker : combat_info.objects.find<Ship>(shuffled_attackers)) {
                 if (!attacker)
@@ -1724,7 +1724,7 @@ namespace {
                 }
                 auto weapons = GetWeapons(attacker);  // includes info about fighter launches with PC_FIGHTER_BAY part class, and direct fire weapons (ships, planets, or fighters) with PC_DIRECT_WEAPON part class
 
-                LaunchFighters(attacker, weapons, combat_state, bout, round++,
+                LaunchFighters(attacker, weapons, combat_state, round++,
                                launches_event);
 
                 DebugLogger(combat) << "Attacker: " << attacker->Name();
@@ -1803,7 +1803,7 @@ namespace {
             combat_info.combat_events.push_back(stealth_change_event);
 
         /// Remove all who died in the bout
-        combat_state.CullTheDead(bout, bout_event);
+        combat_state.CullTheDead(combat_state.bout, bout_event);
 
         // Backpropagate meters so that next round tests can use the results of the previous round
         for (auto obj : combat_info.objects.all())
@@ -1855,8 +1855,8 @@ void AutoResolveCombat(CombatInfo& combat_info) {
 
         DebugLogger(combat) << "Combat at " << system->Name() << " ("
                             << combat_info.system_id << ") Bout " << bout;
-
-        CombatRound(bout, combat_state);
+        combat_state.bout = bout;
+        CombatRound(combat_state);
         last_bout = bout;
     } // end for over combat arounds
 

--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -1381,6 +1381,7 @@ namespace {
         }
         TraceLogger(combat) << "Species targeting condition: " << species_targetting_condition->Dump();
 
+        BackgroundContext combat_context = BackgroundContext(bout, combat_state.combat_info.empire_object_visibility);
         for (const PartAttackInfo& weapon : weapons) {
             // skip non-direct-fire weapons (as only direct fire weapons can "shoot").
             // fighter launches handled separately
@@ -1403,7 +1404,7 @@ namespace {
             AddAllObjectsSet(combat_state.combat_info.objects, targets);
 
             // attacker is source object for condition evaluation. use combat-specific vis info.
-            ScriptingContext context(attacker, combat_state.combat_info.empire_object_visibility);
+            ScriptingContext context(attacker, combat_context);
 
             // apply species targeting condition and then weapon targeting condition
             species_targetting_condition->Eval(context, targets, rejected_targets, Condition::MATCHES);

--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -992,15 +992,14 @@ namespace {
     };
 
     /// A collection of information the autoresolution must keep around
-    struct AutoresolveInfo : SharedAutoresolveInfo {
-        int                             bout;
+    struct AutoresolveInfo {
         std::set<int>                   valid_attacker_object_ids;  // all objects that can attack
         std::map<int, EmpireCombatInfo> empire_infos;               // empire specific information, indexed by empire id
+        CombatInfo&                     combat_info;
         int                             next_fighter_id = -1000001; // give fighters negative ids so as to avoid clashes with any positive-id of persistent UniverseObjects
         std::set<int>                   destroyed_object_ids;       // objects that have been destroyed so far during this combat
 
-        explicit AutoresolveInfo(int bout_, CombatInfo& combat_info_) :
-            bout(bout_),
+        explicit AutoresolveInfo(CombatInfo& combat_info_) :
             combat_info(combat_info_)
         {
             PopulateAttackers();
@@ -1404,7 +1403,7 @@ namespace {
             AddAllObjectsSet(combat_state.combat_info.objects, targets);
 
             // attacker is source object for condition evaluation. use combat-specific vis info.
-            ScriptingContext context(attacker, combat_state);
+            ScriptingContext context(attacker, combat_state.combat_info);
 
             // apply species targeting condition and then weapon targeting condition
             species_targetting_condition->Eval(context, targets, rejected_targets, Condition::MATCHES);
@@ -1431,7 +1430,7 @@ namespace {
             auto targetx = std::const_pointer_cast<UniverseObject>(target);
 
             // do actual attacks
-            Attack(attacker, weapon, targetx, combat_state.combat_info, combat_state.bout, round,
+            Attack(attacker, weapon, targetx, combat_state.combat_info, combat_state.combat_info.bout, round,
                    attacks_event, platform_event, fighter_on_fighter_event);
 
         } // end for over weapons
@@ -1523,7 +1522,7 @@ namespace {
 
             // combat event
             CombatEventPtr launch_event = std::make_shared<FighterLaunchEvent>(
-                combat_state.bout, attacker->ID(), attacker_owner_id, new_fighter_ids.size());
+                combat_state.combat_info.bout, attacker->ID(), attacker_owner_id, new_fighter_ids.size());
             launches_event->AddEvent(launch_event);
 
 
@@ -1632,10 +1631,10 @@ namespace {
     void CombatRound(AutoresolveInfo& combat_state) {
         CombatInfo& combat_info = combat_state.combat_info;
 
-        auto bout_event = std::make_shared<BoutEvent>(combat_state.bout);
+        auto bout_event = std::make_shared<BoutEvent>(combat_info.bout);
         combat_info.combat_events.push_back(bout_event);
         if (combat_state.valid_attacker_object_ids.empty()) {
-            DebugLogger(combat) << "Combat bout " << combat_state.bout << " aborted due to no remaining attackers.";
+            DebugLogger(combat) << "Combat bout " << combat_info.bout << " aborted due to no remaining attackers.";
             return;
         }
 
@@ -1654,7 +1653,7 @@ namespace {
         auto attacks_event = std::make_shared<AttacksEvent>();
         bout_event->AddEvent(attacks_event);
 
-        auto fighter_on_fighter_event = std::make_shared<FightersAttackFightersEvent>(combat_state.bout);
+        auto fighter_on_fighter_event = std::make_shared<FightersAttackFightersEvent>(combat_info.bout);
         bout_event->AddEvent(fighter_on_fighter_event);
 
         int round = 1;  // counter of events during the current combat bout
@@ -1677,7 +1676,7 @@ namespace {
             DebugLogger(combat) << "Planet: " << planet->Name();
 
             auto platform_event = std::make_shared<WeaponsPlatformEvent>(
-                combat_state.bout, planet->ID(), planet->Owner());
+                combat_info.bout, planet->ID(), planet->Owner());
             attacks_event->AddEvent(platform_event);
 
             ShootAllWeapons(planet, combat_state, round++,
@@ -1699,7 +1698,7 @@ namespace {
             DebugLogger(combat) << "Attacker: " << attacker->Name();
 
             auto platform_event = std::make_shared<WeaponsPlatformEvent>(
-                combat_state.bout, attacker->ID(), attacker->Owner());
+                combat_info.bout, attacker->ID(), attacker->Owner());
 
             ShootAllWeapons(attacker, combat_state, round++,
                             attacks_event, platform_event, fighter_on_fighter_event);
@@ -1708,12 +1707,12 @@ namespace {
                 attacks_event->AddEvent(platform_event);
         }
 
-        auto stealth_change_event = std::make_shared<StealthChangeEvent>(bout);
+        auto stealth_change_event = std::make_shared<StealthChangeEvent>(combat_info.bout);
 
         // Launch fighters (which can attack in any subsequent combat bouts).
         // There is no point to launching fighters during the last bout, since
         // they won't get any chance to attack during this combat
-        if (combat_state.bout < GetGameRules().Get<int>("RULE_NUM_COMBAT_ROUNDS")) {
+        if (combat_info.bout < GetGameRules().Get<int>("RULE_NUM_COMBAT_ROUNDS")) {
             auto launches_event = std::make_shared<FighterLaunchesEvent>();
             for (const auto& attacker : combat_info.objects.find<Ship>(shuffled_attackers)) {
                 if (!attacker)
@@ -1803,7 +1802,7 @@ namespace {
             combat_info.combat_events.push_back(stealth_change_event);
 
         /// Remove all who died in the bout
-        combat_state.CullTheDead(combat_state.bout, bout_event);
+        combat_state.CullTheDead(combat_info.bout, bout_event);
 
         // Backpropagate meters so that next round tests can use the results of the previous round
         for (auto obj : combat_info.objects.all())
@@ -1855,7 +1854,7 @@ void AutoResolveCombat(CombatInfo& combat_info) {
 
         DebugLogger(combat) << "Combat at " << system->Name() << " ("
                             << combat_info.system_id << ") Bout " << bout;
-        combat_state.bout = bout;
+        combat_info.bout = bout;
         CombatRound(combat_state);
         last_bout = bout;
     } // end for over combat arounds

--- a/combat/CombatSystem.h
+++ b/combat/CombatSystem.h
@@ -9,6 +9,7 @@
 #include <boost/serialization/split_member.hpp>
 #include <boost/serialization/version.hpp>
 
+
 /** Contains information about the state of a combat before or after the combat
   * occurs. */
 struct CombatInfo {
@@ -37,6 +38,7 @@ public:
     std::set<int>                       destroyed_object_ids;           ///< ids of objects destroyed during this battle
     std::map<int, std::set<int>>        destroyed_object_knowers;       ///< indexed by empire ID, the set of ids of objects the empire knows were destroyed during the combat
     Universe::EmpireObjectVisibilityMap empire_object_visibility;       ///< indexed by empire id and object id, the visibility level the empire has of each object.  may be increased during battle
+    int                                 bout = 0;
     std::vector<CombatEventPtr>         combat_events;                  ///< list of combat attack events that occur in combat
 
     float   GetMonsterDetection() const;
@@ -62,11 +64,6 @@ private:
 
 /** Auto-resolves a battle. */
 void AutoResolveCombat(CombatInfo& combat_info);
-
-struct SharedAutoresolveInfo {
-    int                                 bout;
-    Universe::EmpireObjectVisibilityMap GetEmpireObjectVisibilityMap()
-}
 
 template <class Archive>
 void CombatInfo::save(Archive & ar, const unsigned int version) const
@@ -127,5 +124,7 @@ void CombatInfo::load(Archive & ar, const unsigned int version)
     empire_object_visibility.swap(filtered_empire_object_visibility);
     combat_events.swap(           filtered_combat_events);
 }
+
+static const CombatInfo s_empty_combat_info = {};
 
 #endif // _CombatSystem_h_

--- a/combat/CombatSystem.h
+++ b/combat/CombatSystem.h
@@ -38,8 +38,6 @@ public:
     std::set<int>                       damaged_object_ids;             ///< ids of objects damaged during this battle
     std::set<int>                       destroyed_object_ids;           ///< ids of objects destroyed during this battle
     std::map<int, std::set<int>>        destroyed_object_knowers;       ///< indexed by empire ID, the set of ids of objects the empire knows were destroyed during the combat
-    //Universe::EmpireObjectVisibilityMap empire_object_visibility;       ///< indexed by empire id and object id, the visibility level the empire has of each object.  may be increased during battle
-    //int                                 bout = 0;
     std::vector<CombatEventPtr>         combat_events;                  ///< list of combat attack events that occur in combat
 
     float   GetMonsterDetection() const;

--- a/combat/CombatSystem.h
+++ b/combat/CombatSystem.h
@@ -2,6 +2,7 @@
 #define _CombatSystem_h_
 
 #include "../universe/Universe.h"
+#include "../universe/ScriptingContext.h"
 #include "../util/AppInterface.h"
 #include "CombatEvent.h"
 
@@ -12,7 +13,7 @@
 
 /** Contains information about the state of a combat before or after the combat
   * occurs. */
-struct CombatInfo {
+struct CombatInfo : public ScriptingCombatInfo {
 public:
     /** \name Structors */ //@{
     CombatInfo() = default;
@@ -37,8 +38,8 @@ public:
     std::set<int>                       damaged_object_ids;             ///< ids of objects damaged during this battle
     std::set<int>                       destroyed_object_ids;           ///< ids of objects destroyed during this battle
     std::map<int, std::set<int>>        destroyed_object_knowers;       ///< indexed by empire ID, the set of ids of objects the empire knows were destroyed during the combat
-    Universe::EmpireObjectVisibilityMap empire_object_visibility;       ///< indexed by empire id and object id, the visibility level the empire has of each object.  may be increased during battle
-    int                                 bout = 0;
+    //Universe::EmpireObjectVisibilityMap empire_object_visibility;       ///< indexed by empire id and object id, the visibility level the empire has of each object.  may be increased during battle
+    //int                                 bout = 0;
     std::vector<CombatEventPtr>         combat_events;                  ///< list of combat attack events that occur in combat
 
     float   GetMonsterDetection() const;
@@ -124,7 +125,5 @@ void CombatInfo::load(Archive & ar, const unsigned int version)
     empire_object_visibility.swap(filtered_empire_object_visibility);
     combat_events.swap(           filtered_combat_events);
 }
-
-static const CombatInfo s_empty_combat_info = {};
 
 #endif // _CombatSystem_h_

--- a/combat/CombatSystem.h
+++ b/combat/CombatSystem.h
@@ -63,6 +63,11 @@ private:
 /** Auto-resolves a battle. */
 void AutoResolveCombat(CombatInfo& combat_info);
 
+struct SharedAutoresolveInfo {
+    int                                 bout;
+    Universe::EmpireObjectVisibilityMap GetEmpireObjectVisibilityMap()
+}
+
 template <class Archive>
 void CombatInfo::save(Archive & ar, const unsigned int version) const
 {

--- a/parse/IntValueRefParser.cpp
+++ b/parse/IntValueRefParser.cpp
@@ -52,7 +52,8 @@ parse::detail::simple_int_parser_rules::simple_int_parser_rules(const parse::lex
         ;
 
     free_variable_name
-        =   tok.CurrentTurn_
+        =   tok.CombatBout_
+        |   tok.CurrentTurn_
         |   tok.GalaxyAge_
         |   tok.GalaxyMaxAIAggression_
         |   tok.GalaxyMonsterFrequency_

--- a/parse/Tokens.h
+++ b/parse/Tokens.h
@@ -57,6 +57,7 @@
     (ClockwiseNextPlanetType)                   \
     (Colony)                                    \
     (Colour)                                    \
+    (CombatBout)                                \
     (CombatTargets)                             \
     (Condition)                                 \
     (Construction)                              \

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -7366,7 +7366,7 @@ bool VisibleToEmpire::Match(const ScriptingContext& local_context) const {
     if (local_context.background.empty()) {
         return VisibleToEmpireSimpleMatch(empire_id, Universe::EmpireObjectVisibilityMap())(candidate);
     } else {
-        const Universe::EmpireObjectVisibilityMap& empire_object_vis_map_override = boost::any_cast<Universe::EmpireObjectVisibilityMap&>(local_context.background);
+        const Universe::EmpireObjectVisibilityMap& empire_object_vis_map_override = boost::any_cast<Universe::EmpireObjectVisibilityMap>(local_context.background);
         return VisibleToEmpireSimpleMatch(empire_id, empire_object_vis_map_override)(candidate);
     }
 }

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -7307,7 +7307,7 @@ void VisibleToEmpire::Eval(const ScriptingContext& parent_context,
 
         // need to check visibility of each candidate object separately
         EvalImpl(matches, non_matches, search_domain,
-                 VisibleToEmpireSimpleMatch(empire_id, parent_context.background.empire_object_visibility));
+                 VisibleToEmpireSimpleMatch(empire_id, parent_context.GetEmpireObjectVisibilityMap()));
     } else {
         // re-evaluate empire id for each candidate object
         Condition::Eval(parent_context, matches, non_matches, search_domain);
@@ -7357,7 +7357,7 @@ bool VisibleToEmpire::Match(const ScriptingContext& local_context) const {
     }
 
     int empire_id = m_empire_id->Eval(local_context);
-    return VisibleToEmpireSimpleMatch(empire_id, local_context.background.empire_object_visibility)(candidate);
+    return VisibleToEmpireSimpleMatch(empire_id, local_context.GetEmpireObjectVisibilityMap())(candidate);
 }
 
 void VisibleToEmpire::SetTopLevelContent(const std::string& content_name) {

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -7307,7 +7307,7 @@ void VisibleToEmpire::Eval(const ScriptingContext& parent_context,
 
         // need to check visibility of each candidate object separately
         EvalImpl(matches, non_matches, search_domain,
-                 VisibleToEmpireSimpleMatch(empire_id, parent_context.GetEmpireObjectVisibilityMap()));
+                 VisibleToEmpireSimpleMatch(empire_id, parent_context.combat_info.empire_object_visibility));
     } else {
         // re-evaluate empire id for each candidate object
         Condition::Eval(parent_context, matches, non_matches, search_domain);
@@ -7357,7 +7357,7 @@ bool VisibleToEmpire::Match(const ScriptingContext& local_context) const {
     }
 
     int empire_id = m_empire_id->Eval(local_context);
-    return VisibleToEmpireSimpleMatch(empire_id, local_context.GetEmpireObjectVisibilityMap())(candidate);
+    return VisibleToEmpireSimpleMatch(empire_id, local_context.combat_info.empire_object_visibility)(candidate);
 }
 
 void VisibleToEmpire::SetTopLevelContent(const std::string& content_name) {

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -7306,14 +7306,8 @@ void VisibleToEmpire::Eval(const ScriptingContext& parent_context,
         int empire_id = m_empire_id->Eval(parent_context);
 
         // need to check visibility of each candidate object separately
-        if (parent_context.background.empty()) {
-            EvalImpl(matches, non_matches, search_domain,
-                     VisibleToEmpireSimpleMatch(empire_id, Universe::EmpireObjectVisibilityMap()));
-        } else {
-            auto& empire_object_vis_map_override = boost::any_cast<const Universe::EmpireObjectVisibilityMap>(parent_context.background); 
-            EvalImpl(matches, non_matches, search_domain,
-                     VisibleToEmpireSimpleMatch(empire_id, empire_object_vis_map_override));
-        }
+        EvalImpl(matches, non_matches, search_domain,
+                 VisibleToEmpireSimpleMatch(empire_id, parent_context.background.empire_object_visibility));
     } else {
         // re-evaluate empire id for each candidate object
         Condition::Eval(parent_context, matches, non_matches, search_domain);
@@ -7363,12 +7357,7 @@ bool VisibleToEmpire::Match(const ScriptingContext& local_context) const {
     }
 
     int empire_id = m_empire_id->Eval(local_context);
-    if (local_context.background.empty()) {
-        return VisibleToEmpireSimpleMatch(empire_id, Universe::EmpireObjectVisibilityMap())(candidate);
-    } else {
-        const Universe::EmpireObjectVisibilityMap& empire_object_vis_map_override = boost::any_cast<Universe::EmpireObjectVisibilityMap>(local_context.background);
-        return VisibleToEmpireSimpleMatch(empire_id, empire_object_vis_map_override)(candidate);
-    }
+    return VisibleToEmpireSimpleMatch(empire_id, local_context.background.empire_object_visibility)(candidate);
 }
 
 void VisibleToEmpire::SetTopLevelContent(const std::string& content_name) {

--- a/universe/ScriptingContext.h
+++ b/universe/ScriptingContext.h
@@ -2,7 +2,6 @@
 #define _ScriptingContext_h_
 
 #include "Universe.h"
-#include "../combat/CombatSystem.h"
 
 #include <boost/any.hpp>
 
@@ -10,11 +9,21 @@
 
 class UniverseObject;
 
+struct FO_COMMON_API ScriptingCombatInfo {
+    ScriptingCombatInfo() {}
+    ScriptingCombatInfo(int bout_, const Universe::EmpireObjectVisibilityMap& vis) :
+        bout(bout_),
+        empire_object_visibility(vis)
+    {}
+
+    int bout = 0;
+    Universe::EmpireObjectVisibilityMap empire_object_visibility;
+};
+
 struct ScriptingContext {
     /** Empty context.  Useful for evaluating ValueRef::Constant that don't
       * depend on their context. */
-    ScriptingContext()
-    {}
+    ScriptingContext() = default;
 
     /** Context with only a source object.  Useful for evaluating effectsgroup
       * scope and activation conditions that have no external candidates or
@@ -27,7 +36,7 @@ struct ScriptingContext {
       * conditions. Useful in combat resolution when the visibility of objects
       * may be different from the overall universe visibility. */
     ScriptingContext(std::shared_ptr<const UniverseObject> source_,
-                     const CombatInfo& combat_info_) :
+                     const ScriptingCombatInfo& combat_info_) :
         source(source_),
         combat_info(combat_info_)
     {}
@@ -85,12 +94,15 @@ struct ScriptingContext {
         current_value(current_value_)
     {}
 
+    static const ScriptingCombatInfo s_empty_combat_info;
+
     std::shared_ptr<const UniverseObject>   source;
     std::shared_ptr<UniverseObject>         effect_target;
     std::shared_ptr<const UniverseObject>   condition_root_candidate;
     std::shared_ptr<const UniverseObject>   condition_local_candidate;
     const boost::any                        current_value;
-    const CombatInfo&                       combat_info = s_empty_combat_info;
+    //
+    const ScriptingCombatInfo&              combat_info = ScriptingCombatInfo();
 };
 
 #endif // _ScriptingContext_h_

--- a/universe/ScriptingContext.h
+++ b/universe/ScriptingContext.h
@@ -9,22 +9,6 @@
 
 class UniverseObject;
 
-struct BackgroundContext {
-public:
-    BackgroundContext()
-    {}
-
-    BackgroundContext(int bout_, Universe::EmpireObjectVisibilityMap& empire_object_visibility_) :
-        bout(bout_),
-        empire_object_visibility(empire_object_visibility_)
-    {}
-
-    int bout;
-    Universe::EmpireObjectVisibilityMap empire_object_visibility;       ///< indexed by empire id and object id, the visibility level the empire has of each object.  may be increas
-    static const BackgroundContext s_empty_scripting_context_background;
-};
-const BackgroundContext BackgroundContext::s_empty_scripting_context_background = {};
-
 struct ScriptingContext {
     /** Empty context.  Useful for evaluating ValueRef::Constant that don't
       * depend on their context. */
@@ -42,9 +26,9 @@ struct ScriptingContext {
       * conditions. Useful in combat resolution when the visibility of objects
       * may be different from the overall universe visibility. */
     ScriptingContext(std::shared_ptr<const UniverseObject> source_,
-                     const BackgroundContext& background_) :
+                     const Universe::EmpireObjectVisibilityMap& visibility_map) :
         source(source_),
-        background(background_)
+        empire_object_vis_map_override(visibility_map)
     {}
 
     ScriptingContext(std::shared_ptr<const UniverseObject> source_,
@@ -70,7 +54,7 @@ struct ScriptingContext {
         condition_root_candidate(parent_context.condition_root_candidate),
         condition_local_candidate(parent_context.condition_local_candidate),
         current_value(current_value_),
-        background(parent_context.background)
+        empire_object_vis_map_override(parent_context.empire_object_vis_map_override)
     {}
 
     /** For recursive evaluation of Conditions.  Keeps source and effect_target
@@ -86,7 +70,7 @@ struct ScriptingContext {
                                             condition_local_candidate_),    // if parent context doesn't already have a root candidate, the new local candidate is the root
         condition_local_candidate(      condition_local_candidate_),        // new local candidate
         current_value(                  parent_context.current_value),
-        background(                     parent_context.background)
+        empire_object_vis_map_override( parent_context.empire_object_vis_map_override)
     {}
 
     ScriptingContext(std::shared_ptr<const UniverseObject> source_,
@@ -105,8 +89,7 @@ struct ScriptingContext {
     std::shared_ptr<const UniverseObject>   condition_root_candidate;
     std::shared_ptr<const UniverseObject>   condition_local_candidate;
     const boost::any                        current_value;
-
-    const BackgroundContext&                background = BackgroundContext::s_empty_scripting_context_background;
+    Universe::EmpireObjectVisibilityMap     empire_object_vis_map_override;
 };
 
 #endif // _ScriptingContext_h_

--- a/universe/ScriptingContext.h
+++ b/universe/ScriptingContext.h
@@ -9,6 +9,20 @@
 
 class UniverseObject;
 
+struct BackgroundContext {
+public:
+    BackgroundContext()
+    {}
+
+    BackgroundContext(int bout_, Universe::EmpireObjectVisibilityMap& empire_object_visibility_) :
+        bout(bout_),
+        empire_object_visibility(empire_object_visibility_)
+    {}
+
+    int bout;
+    Universe::EmpireObjectVisibilityMap empire_object_visibility;       ///< indexed by empire id and object id, the visibility level the empire has of each object.  may be increas
+};
+
 struct ScriptingContext {
     /** Empty context.  Useful for evaluating ValueRef::Constant that don't
       * depend on their context. */
@@ -26,9 +40,9 @@ struct ScriptingContext {
       * conditions. Useful in combat resolution when the visibility of objects
       * may be different from the overall universe visibility. */
     ScriptingContext(std::shared_ptr<const UniverseObject> source_,
-                     const boost::any& background_) :
-    source(source_)//,
-    //        background(boost::any(std::ref(background_)))
+                     const BackgroundContext& background_) :
+        source(source_),
+        background(background_)
     {}
 
     ScriptingContext(std::shared_ptr<const UniverseObject> source_,
@@ -70,7 +84,7 @@ struct ScriptingContext {
                                             condition_local_candidate_),    // if parent context doesn't already have a root candidate, the new local candidate is the root
         condition_local_candidate(      condition_local_candidate_),        // new local candidate
         current_value(                  parent_context.current_value),
-        background( parent_context.background)
+        background(                     parent_context.background)
     {}
 
     ScriptingContext(std::shared_ptr<const UniverseObject> source_,
@@ -89,7 +103,7 @@ struct ScriptingContext {
     std::shared_ptr<const UniverseObject>   condition_root_candidate;
     std::shared_ptr<const UniverseObject>   condition_local_candidate;
     const boost::any                        current_value;
-    const boost::any                        background = boost::any();
+    const BackgroundContext                 background;
 };
 
 #endif // _ScriptingContext_h_

--- a/universe/ScriptingContext.h
+++ b/universe/ScriptingContext.h
@@ -21,9 +21,9 @@ public:
 
     int bout;
     Universe::EmpireObjectVisibilityMap empire_object_visibility;       ///< indexed by empire id and object id, the visibility level the empire has of each object.  may be increas
-
+    static const BackgroundContext s_empty_scripting_context_background;
 };
-static const BackgroundContext theEmptyBackground = BackgroundContext();
+const BackgroundContext BackgroundContext::s_empty_scripting_context_background = {};
 
 struct ScriptingContext {
     /** Empty context.  Useful for evaluating ValueRef::Constant that don't
@@ -106,7 +106,7 @@ struct ScriptingContext {
     std::shared_ptr<const UniverseObject>   condition_local_candidate;
     const boost::any                        current_value;
 
-    const BackgroundContext&               background = theEmptyBackground;
+    const BackgroundContext&                background = BackgroundContext::s_empty_scripting_context_background;
 };
 
 #endif // _ScriptingContext_h_

--- a/universe/ScriptingContext.h
+++ b/universe/ScriptingContext.h
@@ -21,7 +21,9 @@ public:
 
     int bout;
     Universe::EmpireObjectVisibilityMap empire_object_visibility;       ///< indexed by empire id and object id, the visibility level the empire has of each object.  may be increas
+
 };
+static const BackgroundContext theEmptyBackground = BackgroundContext();
 
 struct ScriptingContext {
     /** Empty context.  Useful for evaluating ValueRef::Constant that don't
@@ -103,7 +105,8 @@ struct ScriptingContext {
     std::shared_ptr<const UniverseObject>   condition_root_candidate;
     std::shared_ptr<const UniverseObject>   condition_local_candidate;
     const boost::any                        current_value;
-    const BackgroundContext                 background;
+
+    const BackgroundContext&               background = theEmptyBackground;
 };
 
 #endif // _ScriptingContext_h_

--- a/universe/ScriptingContext.h
+++ b/universe/ScriptingContext.h
@@ -9,6 +9,8 @@
 
 class UniverseObject;
 
+/** combat/CombatInfo extends this ScriptingCombatInfo in order
+  * to give Conditions and ValueRefs access to combat related data */
 struct FO_COMMON_API ScriptingCombatInfo {
     ScriptingCombatInfo() {}
     ScriptingCombatInfo(int bout_, const Universe::EmpireObjectVisibilityMap& vis) :
@@ -16,9 +18,10 @@ struct FO_COMMON_API ScriptingCombatInfo {
         empire_object_visibility(vis)
     {}
 
-    int bout = 0;
-    Universe::EmpireObjectVisibilityMap empire_object_visibility;
+    int bout = 0; ///< current combat bout, used with CombatBout ValueRef for implementing bout dependent targeting. First combat bout is 1
+    Universe::EmpireObjectVisibilityMap empire_object_visibility; ///< indexed by empire id and object id, the visibility level the empire has of each object.  may be increased during battle
 };
+FO_COMMON_API const ScriptingCombatInfo EMPTY_COMBAT_INFO{};
 
 struct ScriptingContext {
     /** Empty context.  Useful for evaluating ValueRef::Constant that don't
@@ -94,15 +97,12 @@ struct ScriptingContext {
         current_value(current_value_)
     {}
 
-    static const ScriptingCombatInfo s_empty_combat_info;
-
     std::shared_ptr<const UniverseObject>   source;
     std::shared_ptr<UniverseObject>         effect_target;
     std::shared_ptr<const UniverseObject>   condition_root_candidate;
     std::shared_ptr<const UniverseObject>   condition_local_candidate;
     const boost::any                        current_value;
-    //
-    const ScriptingCombatInfo&              combat_info = ScriptingCombatInfo();
+    const ScriptingCombatInfo&              combat_info = EMPTY_COMBAT_INFO;
 };
 
 #endif // _ScriptingContext_h_

--- a/universe/ScriptingContext.h
+++ b/universe/ScriptingContext.h
@@ -2,6 +2,7 @@
 #define _ScriptingContext_h_
 
 #include "Universe.h"
+#include "../combat/CombatSystem.h"
 
 #include <boost/any.hpp>
 
@@ -26,9 +27,9 @@ struct ScriptingContext {
       * conditions. Useful in combat resolution when the visibility of objects
       * may be different from the overall universe visibility. */
     ScriptingContext(std::shared_ptr<const UniverseObject> source_,
-                     const Universe::EmpireObjectVisibilityMap& visibility_map) :
+                     const CombatInfo& combat_info_) :
         source(source_),
-        empire_object_vis_map_override(visibility_map)
+        combat_info(combat_info_)
     {}
 
     ScriptingContext(std::shared_ptr<const UniverseObject> source_,
@@ -54,7 +55,7 @@ struct ScriptingContext {
         condition_root_candidate(parent_context.condition_root_candidate),
         condition_local_candidate(parent_context.condition_local_candidate),
         current_value(current_value_),
-        empire_object_vis_map_override(parent_context.empire_object_vis_map_override)
+        combat_info(parent_context.combat_info)
     {}
 
     /** For recursive evaluation of Conditions.  Keeps source and effect_target
@@ -70,7 +71,7 @@ struct ScriptingContext {
                                             condition_local_candidate_),    // if parent context doesn't already have a root candidate, the new local candidate is the root
         condition_local_candidate(      condition_local_candidate_),        // new local candidate
         current_value(                  parent_context.current_value),
-        empire_object_vis_map_override( parent_context.empire_object_vis_map_override)
+        combat_info( parent_context.combat_info)
     {}
 
     ScriptingContext(std::shared_ptr<const UniverseObject> source_,
@@ -89,7 +90,7 @@ struct ScriptingContext {
     std::shared_ptr<const UniverseObject>   condition_root_candidate;
     std::shared_ptr<const UniverseObject>   condition_local_candidate;
     const boost::any                        current_value;
-    Universe::EmpireObjectVisibilityMap     empire_object_vis_map_override;
+    const CombatInfo&                       combat_info = s_empty_combat_info;
 };
 
 #endif // _ScriptingContext_h_

--- a/universe/ScriptingContext.h
+++ b/universe/ScriptingContext.h
@@ -27,8 +27,8 @@ struct ScriptingContext {
       * may be different from the overall universe visibility. */
     ScriptingContext(std::shared_ptr<const UniverseObject> source_,
                      const boost::any& background_) :
-        source(source_),
-        background(background_)
+    source(source_)//,
+    //        background(boost::any(std::ref(background_)))
     {}
 
     ScriptingContext(std::shared_ptr<const UniverseObject> source_,
@@ -89,7 +89,7 @@ struct ScriptingContext {
     std::shared_ptr<const UniverseObject>   condition_root_candidate;
     std::shared_ptr<const UniverseObject>   condition_local_candidate;
     const boost::any                        current_value;
-    const boost::any&                       background = boost::any();
+    const boost::any                        background = boost::any();
 };
 
 #endif // _ScriptingContext_h_

--- a/universe/ScriptingContext.h
+++ b/universe/ScriptingContext.h
@@ -26,9 +26,9 @@ struct ScriptingContext {
       * conditions. Useful in combat resolution when the visibility of objects
       * may be different from the overall universe visibility. */
     ScriptingContext(std::shared_ptr<const UniverseObject> source_,
-                     const Universe::EmpireObjectVisibilityMap& visibility_map) :
+                     const boost::any& background_) :
         source(source_),
-        empire_object_vis_map_override(visibility_map)
+        background(background_)
     {}
 
     ScriptingContext(std::shared_ptr<const UniverseObject> source_,
@@ -54,7 +54,7 @@ struct ScriptingContext {
         condition_root_candidate(parent_context.condition_root_candidate),
         condition_local_candidate(parent_context.condition_local_candidate),
         current_value(current_value_),
-        empire_object_vis_map_override(parent_context.empire_object_vis_map_override)
+        background(parent_context.background)
     {}
 
     /** For recursive evaluation of Conditions.  Keeps source and effect_target
@@ -70,7 +70,7 @@ struct ScriptingContext {
                                             condition_local_candidate_),    // if parent context doesn't already have a root candidate, the new local candidate is the root
         condition_local_candidate(      condition_local_candidate_),        // new local candidate
         current_value(                  parent_context.current_value),
-        empire_object_vis_map_override( parent_context.empire_object_vis_map_override)
+        background( parent_context.background)
     {}
 
     ScriptingContext(std::shared_ptr<const UniverseObject> source_,
@@ -89,7 +89,7 @@ struct ScriptingContext {
     std::shared_ptr<const UniverseObject>   condition_root_candidate;
     std::shared_ptr<const UniverseObject>   condition_local_candidate;
     const boost::any                        current_value;
-    Universe::EmpireObjectVisibilityMap     empire_object_vis_map_override;
+    const boost::any&                       background = boost::any();
 };
 
 #endif // _ScriptingContext_h_

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -1865,6 +1865,7 @@ void Universe::SetEmpireSpecialVisibility(int empire_id, int object_id,
         m_empire_object_visible_specials[empire_id][object_id].erase(special_name);
 }
 
+
 namespace {
     /** for each empire: for each position where the empire has detector objects,
       * what is the empire's detection range at that location?  (this is the

--- a/universe/Universe.h
+++ b/universe/Universe.h
@@ -593,6 +593,7 @@ private:
     void serialize(Archive& ar, const unsigned int version);
 };
 
+
 /** Compute a checksum for each of the universe's content managers. Each value will be of the form
     ("BuildingManager", <checksum>) */
 FO_COMMON_API std::map<std::string, unsigned int> CheckSumContent();

--- a/universe/ValueRefs.cpp
+++ b/universe/ValueRefs.cpp
@@ -835,6 +835,13 @@ double Variable<double>::Eval(const ScriptingContext& context) const
             return planet->DistanceFromOriginalType();
         return 0.0;
 
+    } else if (property_name == "CombatBout") {
+        if ((!context.background.empty()) && context.background.type() == std::typeid(std::tuple)) {
+            auto & contents = context.background;
+            return contents
+        }
+        return 0.0;
+
     } else if (property_name == "CurrentTurn") {
         return CurrentTurn();
 
@@ -875,6 +882,12 @@ int Variable<int>::Eval(const ScriptingContext& context) const
     IF_CURRENT_VALUE(int)
 
     if (m_ref_type == NON_OBJECT_REFERENCE) {
+        if (property_name == "CombatBout") {
+            if ((!context.background.empty()) && context.background.type() == std::typeid(std::tuple))
+                return context.background.empty());
+            return 0.0;
+        }
+
         if (property_name == "CurrentTurn")
             return CurrentTurn();
         if (property_name == "GalaxySize")

--- a/universe/ValueRefs.cpp
+++ b/universe/ValueRefs.cpp
@@ -836,7 +836,7 @@ double Variable<double>::Eval(const ScriptingContext& context) const
         return 0.0;
 
     } else if (property_name == "CombatBout") {
-        return context.background.bout;
+        return context.bout;
 
     } else if (property_name == "CurrentTurn") {
         return CurrentTurn();
@@ -879,7 +879,7 @@ int Variable<int>::Eval(const ScriptingContext& context) const
 
     if (m_ref_type == NON_OBJECT_REFERENCE) {
         if (property_name == "CombatBout")
-            return context.background.bout;
+            return context.bout;
         if (property_name == "CurrentTurn")
             return CurrentTurn();
         if (property_name == "GalaxySize")

--- a/universe/ValueRefs.cpp
+++ b/universe/ValueRefs.cpp
@@ -836,7 +836,7 @@ double Variable<double>::Eval(const ScriptingContext& context) const
         return 0.0;
 
     } else if (property_name == "CombatBout") {
-        return context.bout;
+        return context.combat_info.bout;
 
     } else if (property_name == "CurrentTurn") {
         return CurrentTurn();
@@ -879,7 +879,7 @@ int Variable<int>::Eval(const ScriptingContext& context) const
 
     if (m_ref_type == NON_OBJECT_REFERENCE) {
         if (property_name == "CombatBout")
-            return context.bout;
+            return context.combat_info.bout;
         if (property_name == "CurrentTurn")
             return CurrentTurn();
         if (property_name == "GalaxySize")

--- a/universe/ValueRefs.cpp
+++ b/universe/ValueRefs.cpp
@@ -835,12 +835,8 @@ double Variable<double>::Eval(const ScriptingContext& context) const
             return planet->DistanceFromOriginalType();
         return 0.0;
 
-    } else if (property_name == "CombatBout") {        
-        if ((!context.background.empty()) && (typeid(context.background) == typeid(int))) {
-            int contents = boost::any_cast<int>(context.background);
-            return contents;
-        }
-        return 0.0;
+    } else if (property_name == "CombatBout") {
+        return context.background.bout;
 
     } else if (property_name == "CurrentTurn") {
         return CurrentTurn();
@@ -882,12 +878,8 @@ int Variable<int>::Eval(const ScriptingContext& context) const
     IF_CURRENT_VALUE(int)
 
     if (m_ref_type == NON_OBJECT_REFERENCE) {
-        if (property_name == "CombatBout") {
-            if ((!context.background.empty()) && (typeid(context.background) == typeid(int)))
-                return 0.0;
-            return 0.0;
-        }
-
+        if (property_name == "CombatBout")
+            return context.background.bout;
         if (property_name == "CurrentTurn")
             return CurrentTurn();
         if (property_name == "GalaxySize")

--- a/universe/ValueRefs.cpp
+++ b/universe/ValueRefs.cpp
@@ -835,10 +835,10 @@ double Variable<double>::Eval(const ScriptingContext& context) const
             return planet->DistanceFromOriginalType();
         return 0.0;
 
-    } else if (property_name == "CombatBout") {
-        if ((!context.background.empty()) && context.background.type() == std::typeid(std::tuple)) {
-            auto & contents = context.background;
-            return contents
+    } else if (property_name == "CombatBout") {        
+        if ((!context.background.empty()) && (typeid(context.background) == typeid(int))) {
+            int contents = boost::any_cast<int>(context.background);
+            return contents;
         }
         return 0.0;
 
@@ -883,8 +883,8 @@ int Variable<int>::Eval(const ScriptingContext& context) const
 
     if (m_ref_type == NON_OBJECT_REFERENCE) {
         if (property_name == "CombatBout") {
-            if ((!context.background.empty()) && context.background.type() == std::typeid(std::tuple))
-                return context.background.empty());
+            if ((!context.background.empty()) && (typeid(context.background) == typeid(int)))
+                return 0.0;
             return 0.0;
         }
 


### PR DESCRIPTION
You can use this CombatBout ValueRef in combatTargets conditions to query the current combat bout.
E.g. (CombatBout == 1) will match all objects if combat is in the first bout

The ScriptingContext constructor which is used only in combat gets the current bout passed as a new parameter.

