### PR TITLE
Fix finalization segfaults for upcoming python3

### DIFF
--- a/python/CommonFramework.h
+++ b/python/CommonFramework.h
@@ -1,6 +1,7 @@
 #ifndef __FreeOrion__Python__CommonFramework__
 #define __FreeOrion__Python__CommonFramework__
 
+#include <boost/optional.hpp>
 #include <boost/python.hpp>
 #include <boost/python/dict.hpp>
 
@@ -36,7 +37,6 @@ public:
     bool IsPythonRunning();
 
     bool         Initialize();                         // initializes and runs the Python interpreter, prepares the Python environment
-    void         Finalize();                           // stops Python interpreter and releases its resources
     virtual bool InitModules() = 0;                    // initializes Python modules, must be implemented by derived classes
     void         SetCurrentDir(const std::string dir); // sets Python current work directory or throws error_already_set
     void         AddToSysPath(const std::string dir);  // adds directory to Python sys.path or throws error_already_set
@@ -45,6 +45,7 @@ public:
     std::vector<std::string> ErrorReport();            // wraps call to error report function defined on the Python side
 
 private:
+    void         Finalize();                           // stops Python interpreter and releases its resources
     // A copy of the systemExit exception to compare with returned
     // exceptions.  It can't be created in the exception handler.
     boost::python::object   m_system_exit;
@@ -54,7 +55,7 @@ private:
     char                    m_home_dir[1024];
     char                    m_program_name[1024];
 #endif
-    boost::python::dict     m_namespace;
+    boost::optional<boost::python::dict> m_namespace; // stores main namespace in optional to be finalized before Python interpreter
     boost::python::object*  m_python_module_error;  // used to track if and which Python module contains the "error_report" function ErrorReport should call
 };
 

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -127,7 +127,10 @@ ServerApp::ServerApp() :
 
 ServerApp::~ServerApp() {
     DebugLogger() << "ServerApp::~ServerApp";
-    m_python_server.Finalize();
+
+    // Calling Py_Finalize here causes segfault when m_python_server destructing with its python
+    // object fields
+
     CleanupAIs();
     delete m_fsm;
     DebugLogger() << "Server exited cleanly.";


### PR DESCRIPTION
In Python3 it's fobidden to call object desructors after python finalizaton.
Fix finalization segfaults by enforcing object finalization before Python interpreter.

Extracted from #2653