### PR TITLE
Fix G++ warnings

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -1376,7 +1376,7 @@ void Empire::AddNewlyResearchedTechToGrantAtStartOfNextTurn(const std::string& n
         return;
 
     // Mark given tech to be granted at next turn. If it was already marked, skip writing a SitRep message
-    auto result = m_newly_researched_techs.insert(name);
+    m_newly_researched_techs.insert(name);
 }
 
 void Empire::ApplyNewTechs() {

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -2242,7 +2242,7 @@ void Font::HandleTag(const std::shared_ptr<FormattingTag>& tag, double* orig_col
                     } else {
                         well_formed_tag = false;
                     }
-                } catch (boost::bad_lexical_cast) {
+                } catch (const boost::bad_lexical_cast&) {
                     try {
                         double color[4];
                         color[0] = lexical_cast<double>(tag->params[0]);
@@ -2259,7 +2259,7 @@ void Font::HandleTag(const std::shared_ptr<FormattingTag>& tag, double* orig_col
                         } else {
                             well_formed_tag = false;
                         }
-                    } catch (boost::bad_lexical_cast) {
+                    } catch (const boost::bad_lexical_cast&) {
                         well_formed_tag = false;
                     }
                 }

--- a/GG/src/nanovg/stb_image.h
+++ b/GG/src/nanovg/stb_image.h
@@ -1355,6 +1355,9 @@ static unsigned char *stbi__convert_format(unsigned char *data, int img_n, int r
       unsigned char *src  = data + j * x * img_n   ;
       unsigned char *dest = good + j * x * req_comp;
 
+      #pragma GCC diagnostic push
+      #pragma GCC diagnostic ignored "-Wmisleading-indentation"
+
       #define COMBO(a,b)  ((a)*8+(b))
       #define CASE(a,b)   case COMBO(a,b): for(i=x-1; i >= 0; --i, src += a, dest += b)
       // convert source image with img_n components to one with req_comp components;
@@ -1375,6 +1378,8 @@ static unsigned char *stbi__convert_format(unsigned char *data, int img_n, int r
          default: STBI_ASSERT(0);
       }
       #undef CASE
+
+      #pragma GCC diagnostic pop
    }
 
    STBI_FREE(data);

--- a/python/server/ServerWrapper.cpp
+++ b/python/server/ServerWrapper.cpp
@@ -91,10 +91,6 @@ namespace {
     object GetResourceDirWrapper()
     { return object(PathToString(GetResourceDir())); }
 
-    // Wrapper for GetUserConfigDir
-    object GetUserConfigDirWrapper()
-    { return object(PathToString(GetUserConfigDir())); }
-
     // Wrapper for getting empire objects
     list GetAllEmpires() {
         list empire_list;

--- a/util/Serialize.ipp
+++ b/util/Serialize.ipp
@@ -2,8 +2,6 @@
 #undef int64_t
 #endif
 
-#include <boost/static_assert.hpp>
-#include <boost/detail/endian.hpp>
 #include <boost/version.hpp>
 
 #if BOOST_VERSION == 105800

--- a/util/i18n.cpp
+++ b/util/i18n.cpp
@@ -254,20 +254,6 @@ namespace {
 
         return mag;
     }
-
-    int TestRounding() {
-        for (double num : {-0.001, -0.02, 0.0001,
-                           84.5, 90.9, 99.9,
-                           9999.9, 245.1, 2451.1, 12451.1, 1124451.1})
-        {
-            std::cout << "n: " << num
-                      << "  r2: " << DoubleToString(num, 2, false)
-                      << "  r3: " << DoubleToString(num, 3, false)
-                      << "  r5: " << DoubleToString(num, 5, false) << std::endl;
-        }
-        exit(0);
-    }
-    //int dummy = TestRounding();
 }
 
 std::string DoubleToString(double val, int digits, bool always_show_sign) {


### PR DESCRIPTION
This PR fixes some problematic code, which causes G++ to emit warnings:

* Remove unused and deprecated boost header for endian detection, which emits a warning since boost 1.69.0.
* Remove unreferenced functions.
* Remove unused local variables.
* Catch exceptions by reference in GG Font implementation.
* Add pragma stament block to std_image.h to let GCC ignore multiple "misleading indentations" (talking about pendantic).

The remaining warning about the std::move call in MovableEnvelope was kept as I couldn't yet read into possible consequences of that change.

The warning about violated strict aliasing rules in Effect.cpp require some bigger redesign of the EffectBase interface to be fixed.