### PR TITLE
[prototype] fighter based missile FOCS-only

### DIFF
--- a/default/scripting/ship_parts/FighterBay/FT_BAY_MISSILE.focs.txt
+++ b/default/scripting/ship_parts/FighterBay/FT_BAY_MISSILE.focs.txt
@@ -1,0 +1,14 @@
+Part
+    name = "FT_BAY_MISSILE"
+    description = "FT_BAY_MISSILE_DESC"
+    exclusions = [ "FT_HANGAR_0" "FT_HANGAR_1" "FT_HANGAR_2" "FT_HANGAR_3" "FT_HANGAR_4" "FT_BAY_1" ]
+    class = FighterBay
+    capacity = 4
+    mountableSlotTypes = External
+    buildcost = 20 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
+    buildtime = 1
+    tags = [ "PEDIA_PC_FIGHTER_BAY" ]
+    location = OwnedBy empire = Source.Owner
+    icon = "icons/ship_parts/nuclear_missile.png"
+
+#include "/scripting/common/upkeep.macros"

--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_MISSILE.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_MISSILE.focs.txt
@@ -1,0 +1,89 @@
+Part
+    name = "FT_HANGAR_MISSILE"
+    description = "FT_HANGAR_MISSILE_DESC"
+    exclusions = [ "FT_HANGAR_0" "FT_HANGAR_1" "FT_HANGAR_2" "FT_HANGAR_3" "FT_HANGAR_4" "FT_HANGAR_MISSILE" "FT_BAY_1" ]
+    class = FighterHangar
+    // Capacity is set to launch capacity per launch bay (4)
+    // MaxCapacity is also set to that value
+    // "Real" missile capacity (storage) is four times launch capacity plus once launch capacity per bay (4 per launch bay)
+    // As default for UI we put four times launch capacity
+    capacity = 16
+    damage = 3
+    // There is a problem with storage/resupply and launching:
+    //   resupply happens in Fleet.cpp in movement phase and sets all parts capacity to maximum capacity
+    //   but hangar capacity has to be equal to launch capacity (because missile should only launch in bout 1)
+    // without that resupply, MaxCapacity could be set to real missile storage capacity to give the user a hint
+    // or even better a launch condition which only allows launching in bout 1
+//    NoDefaultCapacityEffect
+    combatTargets = And [
+        (CombatBout == 3)
+        [[COMBAT_TARGETS_VISIBLE_ENEMY]]
+        Or [
+            [[COMBAT_TARGETS_NOT_DESTROYED_SHIP]]
+            Fighter
+        ]
+    ]
+    mountableSlotTypes = Internal
+    buildcost = 20 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
+    buildtime = 1
+    tags = [ "PEDIA_PC_FIGHTER_HANGAR" ]
+    location = OwnedBy empire = Source.Owner
+    effectsgroups = [
+        EffectsGroup
+            scope = Source
+            activation = (Source.LastTurnActiveInBattle == CurrentTurn)
+            stackinggroup = "SET_MISSILE_STORAGE"
+            accountinglabel = "MISSILE_STORAGE_USE"
+            effects = [
+             // SetMaxCapacity partname = "FT_HANGAR_MISSILE"           value = max(0, ( SpecialCapacity  name = "MISSILE_STORAGE_CAPACITY" object = Source.ID ) - ( [[MISSILE_LAUNCHES]] ) )
+                SetMaxCapacity partname = "FT_HANGAR_MISSILE"           value = min( ( [[MISSILE_LAUNCHES]] ) , max(0, ( SpecialCapacity  name = "MISSILE_STORAGE_CAPACITY" object = Source.ID ) - ( [[MISSILE_LAUNCHES]] ) ) )
+                SetSpecialCapacity name = "MISSILE_STORAGE_CAPACITY" capacity = max(0, ( SpecialCapacity  name = "MISSILE_STORAGE_CAPACITY" object = Source.ID ) - ( [[MISSILE_LAUNCHES]] ) )
+            ]
+
+       EffectsGroup
+            scope = Source
+            activation = Or [ Not HasSpecial name = "MISSILE_STORAGE_CAPACITY" And [
+                InSystem
+                Stationary
+                (Source.LastTurnActiveInBattle < CurrentTurn)
+                // For allied supply needs to be moved to a tech i guess
+                ResupplyableBy empire = Source.Owner
+            ] ]
+            stackinggroup = "SET_MISSILE_STORAGE"
+            accountinglabel = "MISSILE_STORAGE_RESUPPLY_LABEL"
+            effects = [
+                SetSpecialCapacity name = "MISSILE_STORAGE_CAPACITY" capacity = 16 + [[MISSILE_LAUNCHES]]
+             // SetMaxCapacity partname = "FT_HANGAR_MISSILE"           value = 16 + [[MISSILE_LAUNCHES]]
+                SetMaxCapacity partname = "FT_HANGAR_MISSILE"           value = [[MISSILE_LAUNCHES]]
+            ]
+
+       EffectsGroup
+            scope = Source
+            activation = Source
+            stackinggroup = "SET_MISSILE_STORAGE"
+            accountinglabel = "MISSILE_STORAGE_FALLBACK_LABEL"
+            effects = [
+             // SetMaxCapacity partname = "FT_HANGAR_MISSILE" value = ( SpecialCapacity  name = "MISSILE_STORAGE_CAPACITY" object = Source.ID )
+                SetMaxCapacity partname = "FT_HANGAR_MISSILE" value = min( ( [[MISSILE_LAUNCHES]] ) , max(0, SpecialCapacity  name = "MISSILE_STORAGE_CAPACITY" object = Source.ID ) )
+            ]
+
+        EffectsGroup
+            scope = And [
+                Source
+            ]
+            activation = Source
+            stackinggroup = "SET_MISSILE_LAUNCH_CAPACITY"
+            effects = [
+                // Launchable missiles
+                SetCapacity partname = "FT_HANGAR_MISSILE" value = [[MISSILE_LAUNCHES]]
+            ]
+    ]
+
+    icon = "icons/ship_parts/nuclear_missile.png"
+
+MISSILE_LAUNCHES
+'''4 * PartsInShipDesign name = "FT_BAY_MISSILE" design = Source.DesignID'''
+
+#include "/scripting/common/upkeep.macros"
+#include "/scripting/techs/techs.macros"
+#include "/scripting/ship_parts/targeting.macros"

--- a/default/scripting/specials/MISSILE_STORAGE_CAPACITY.focs.txt
+++ b/default/scripting/specials/MISSILE_STORAGE_CAPACITY.focs.txt
@@ -1,0 +1,6 @@
+Special
+    name = "MISSILE_STORAGE_CAPACITY"
+    description = "MISSILE_STORAGE_CAPACITY_DESC"
+    spawnrate = 0
+    spawnlimit = 0
+    graphic = "icons/ship_parts/nuclear_missile.png"

--- a/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_MISSILE.focs.txt
+++ b/default/scripting/techs/ship_weapons/fighters/SHP_FIGHTERS_MISSILE.focs.txt
@@ -1,0 +1,16 @@
+Tech
+    name = "SHP_FIGHTERS_MISSILE"
+    description = "SHP_FIGHTERS_MISSILE_DESC"
+    short_description = "SHIP_WEAPON_UNLOCK_SHORT_DESC"
+    category = "SHIP_WEAPONS_CATEGORY"
+    researchcost = 6 * [[TECH_COST_MULTIPLIER]]
+    researchturns = 3
+    tags = [ "PEDIA_FIGHTER_TECHS" ]
+    prerequisites = "SHP_ROOT_AGGRESSION"
+    unlock = [
+        Item type = ShipPart name = "FT_BAY_MISSILE"
+        Item type = ShipPart name = "FT_HANGAR_MISSILE"
+    ]
+    graphic = "icons/ship_parts/nuclear_missile.png"
+
+#include "/scripting/common/base_prod.macros"


### PR DESCRIPTION
    [prototype] Add SHP_FIGHTERS_MISSILE tech FT_BAY_ and FT_HANGAR_MISSILE too

This should not go into master/a release. It is a prototype so one can try a new type of weapon.

Note this depends on another commit/PR #2698.

[forum discussion](https://www.freeorion.org/forum/viewtopic.php?f=6&t=11474)
    
    This provides a FOCS-only prototype for missile weapon
    
    Gameplay
    * missiles launch on bout 1, do nothing in bout 2, and do 3 shield-piercing damage in bout 3
    * missiles target ships and fighters (no planets)
    * as many 20PP FT_BAY_MISSILE external parts as you like (provide each 4 bout-1 launch capacity and 4 missiles munition)
    * up to one 20PP FT_HANGAR_MISSILE internal part per ship (necessary, also provides 16 missiles munition)
    
    Technical:
    * uses MISSILE_STORAGE_CAPACITY special to track actual missile storage
    * hangar capacity is set to launch capacity so missiles only launch in bout 1
    * target condition only targets enemies in bout 3 (i.e. bout 1 lauch, bout 2 shot-me-down, bout 3 damage others)
    * recaptured missiles are effectively ignored as storage gets always lowered by launch capacity after battle
    * Note this cuts MaxCapacity down to launch rate to prevent unwanted resupply
      else MaxCapacity could be used to show current capacity to user
    * Own specific resupply effect is ignored because of resupply hardcoded in backend (in Fleet AFAICR)
    
    Tactical:
    * can easily build designs which launch enormous amounts of missiles
    * enemy can shield ships by fielding fighters
    * enemy wants to shoot down missiles in bout two
    * enemy's Interceptors are both effective as chaff as well as taking down misisles
    * you can shield your missiles using Interceptors
    * you can shield your Fighters/Bombers by shooting missiles
    * you have to take care of your supply lines if
    * if you want to use missiles in enemy territory or longer battles you can put fewer launchers
    
    Balancing questions
    * probably munition rate of hangar should be higher. maybe launchers should not carry munition (e.g. hangar: 32 launcher: 0 )
    * having only one launch bay is not really juicy - its comparable..
    ** offensively to a Fighter bay/hangar but doing 25% percent less damage (if three combat bouts and not shot down before)
    ** defensively to a slightly expensive Interceptor bay/hangar
    ** ... so maybe prefer missiles over Interceptors if you do not want to target enemy's fighters
    * starting with two launch bays you do not have to supply extra hangars so damage and chaff potential goes up
    * robo hull probably needs to loose an external part slot if this is in (4 launchers seems OP)
    
    Ugly
    * in order to not change current code, part exclusions do not work if adding fighter parts afterwards
    * no UI currently to show missile storage
    * missiles will provide cover after bout 3 even if "exploded"
    * unconditional launching
    * no specific resupply condition
    * are shown as fighters in combat log and also get recaptured at end of battle
    * damage is not scaled accordingly to number of bouts

