### PR TITLE
Remove cmp method usages (removed in python3)

### DIFF
--- a/default/python/AI/ColonisationAI.py
+++ b/default/python/AI/ColonisationAI.py
@@ -419,7 +419,7 @@ def get_colony_fleets():
     colonization_timer.start('Evaluate Outpost Opportunities')
 
     sorted_planets = evaluated_colony_planets.items()
-    sorted_planets.sort(lambda x, y: cmp(x[1], y[1]), reverse=True)
+    sorted_planets.sort(key=itemgetter(1), reverse=True)
 
     _print_colony_candidate_table(sorted_planets, show_detail=False)
 
@@ -438,7 +438,7 @@ def get_colony_fleets():
     colonization_timer.stop()
 
     sorted_outposts = evaluated_outpost_planets.items()
-    sorted_outposts.sort(lambda x, y: cmp(x[1], y[1]), reverse=True)
+    sorted_outposts.sort(key=itemgetter(1), reverse=True)
 
     _print_outpost_candidate_table(sorted_outposts)
 
@@ -1194,7 +1194,7 @@ def send_colony_ships(colony_fleet_ids, evaluated_planets, mission_type):
             for rating in ratings:
                 if rating[0] >= 0.75 * best_scores.get(pid, [9999])[0]:
                     potential_targets.append((pid, rating))
-        potential_targets.sort(lambda x, y: cmp(x[1], y[1]), reverse=True)
+        potential_targets.sort(key=itemgetter(1), reverse=True)
 
     # added a lot of checking because have been getting mysterious exception, after too many recursions to get info
     fleet_pool = set(fleet_pool)

--- a/default/python/AI/PriorityAI.py
+++ b/default/python/AI/PriorityAI.py
@@ -1,5 +1,6 @@
 import math
 from logging import debug
+from operator import itemgetter
 
 import freeOrionAIInterface as fo  # pylint: disable=import-error
 
@@ -490,7 +491,7 @@ def _calculate_top_production_queue_priority():
         production_queue_priorities[priorityType] = aistate.get_priority(priorityType)
 
     sorted_priorities = production_queue_priorities.items()
-    sorted_priorities.sort(lambda x, y: cmp(x[1], y[1]), reverse=True)
+    sorted_priorities.sort(key=itemgetter(1), reverse=True)
     top_production_queue_priority = -1
     for evaluationPair in sorted_priorities:
         if top_production_queue_priority < 0:

--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -20,6 +20,7 @@ from EnumsAI import (EmpireProductionTypes, FocusType, MissionType, PriorityType
                      get_priority_production_types, )
 from character.character_module import Aggression
 from freeorion_tools import AITimer, chat_human, ppstring, tech_is_complete
+from operator import itemgetter
 from turn_state import state
 
 _best_military_design_rating_cache = {}  # indexed by turn, values are rating of the military design of the turn
@@ -1222,7 +1223,7 @@ def generate_production_orders():
         production_priorities[priority_type] = int(max(0, (aistate.get_priority(priority_type)) ** 0.5))
 
     sorted_priorities = production_priorities.items()
-    sorted_priorities.sort(lambda x, y: cmp(x[1], y[1]), reverse=True)
+    sorted_priorities.sort(key=itemgetter(1), reverse=True)
 
     top_score = -1
 

--- a/default/python/AI/ResourcesAI.py
+++ b/default/python/AI/ResourcesAI.py
@@ -10,6 +10,7 @@ have their future focus decided.
 # Note: The algorithm is not stable with respect to pid order.  i.e. Two empire with
 #       exactly the same colonies, but different pids may make different choices.
 from logging import info, warn, debug
+from operator import itemgetter
 
 import freeOrionAIInterface as fo  # pylint: disable=import-error
 from aistate_interface import get_aistate
@@ -262,7 +263,7 @@ class Reporter(object):
             resource_priorities[priority_type] = aistate.get_priority(priority_type)
 
         sorted_priorities = resource_priorities.items()
-        sorted_priorities.sort(lambda x, y: cmp(x[1], y[1]), reverse=True)
+        sorted_priorities.sort(key=itemgetter(1), reverse=True)
         top_priority = -1
         for evaluation_priority, evaluation_score in sorted_priorities:
             if top_priority < 0:


### PR DESCRIPTION
Replace usage of `cmp` in `sort` with key function. 

PS. one left `cmp` cal was untouched since it will be removed together with the method he is in.
