### PR TITLE
Simplify ObjectMap interface

### DIFF
--- a/AI/AIInterface.cpp
+++ b/AI/AIInterface.cpp
@@ -173,7 +173,7 @@ namespace AIInterface {
             // ownership to all, while remembering which planets this is done
             // to.
             universe.InhibitUniverseObjectSignals(true);
-            for (auto& planet : universe.Objects().FindObjects<Planet>()) {
+            for (auto& planet : universe.Objects().all<Planet>()) {
                  if (planet->Unowned()) {
                      unowned_planets.push_back(planet);
                      planet->SetOwner(player_id);

--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -699,7 +699,7 @@ void Empire::UpdateUnobstructedFleets() {
         if (!system)
             continue;
 
-        for (auto& fleet : Objects().FindObjects<Fleet>(system->FleetIDs())) {
+        for (auto& fleet : Objects().find<Fleet>(system->FleetIDs())) {
             if (known_destroyed_objects.count(fleet->ID()))
                 continue;
             if (fleet->OwnedBy(m_id))
@@ -762,7 +762,7 @@ void Empire::UpdateSupplyUnobstructedSystems(const std::set<int>& known_systems,
     std::set<int> unrestricted_friendly_systems;
     std::set<int> systems_containing_obstructing_objects;
     std::set<int> unrestricted_obstruction_systems;
-    for (auto& fleet : GetUniverse().Objects().FindObjects<Fleet>()) {
+    for (auto& fleet : GetUniverse().Objects().all<Fleet>()) {
         int system_id = fleet->SystemID();
         if (system_id == INVALID_OBJECT_ID) {
             continue;   // not in a system, so can't affect system obstruction

--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -678,15 +678,14 @@ void Empire::UpdateSystemSupplyRanges() {
     const ObjectMap& empire_known_objects = EmpireKnownObjects(this->EmpireID());
 
     // get ids of objects partially or better visible to this empire.
-    std::vector<int> known_objects_vec = empire_known_objects.FindObjectIDs();
     const std::set<int>& known_destroyed_objects = universe.EmpireKnownDestroyedObjectIDs(this->EmpireID());
 
     std::set<int> known_objects_set;
 
     // exclude objects known to have been destroyed (or rather, include ones that aren't known by this empire to be destroyed)
-    for (int object_id : known_objects_vec)
-        if (!known_destroyed_objects.count(object_id))
-            known_objects_set.insert(object_id);
+    for (const auto& obj : empire_known_objects.all())
+        if (!known_destroyed_objects.count(obj->ID()))
+            known_objects_set.insert(obj->ID());
     UpdateSystemSupplyRanges(known_objects_set);
 }
 
@@ -713,15 +712,14 @@ void Empire::UpdateSupplyUnobstructedSystems(bool precombat /*=false*/) {
 
     // get ids of systems partially or better visible to this empire.
     // TODO: make a UniverseObjectVisitor for objects visible to an empire at a specified visibility or greater
-    std::vector<int> known_systems_vec = EmpireKnownObjects(this->EmpireID()).FindObjectIDs<System>();
     const std::set<int>& known_destroyed_objects = universe.EmpireKnownDestroyedObjectIDs(this->EmpireID());
 
     std::set<int> known_systems_set;
 
     // exclude systems known to have been destroyed (or rather, include ones that aren't known to be destroyed)
-    for (int system_id : known_systems_vec)
-        if (!known_destroyed_objects.count(system_id))
-            known_systems_set.insert(system_id);
+    for (const auto& sys : EmpireKnownObjects(this->EmpireID()).all<System>())
+        if (!known_destroyed_objects.count(sys->ID()))
+            known_systems_set.insert(sys->ID());
     UpdateSupplyUnobstructedSystems(known_systems_set, precombat);
 }
 

--- a/Empire/ResourcePool.cpp
+++ b/Empire/ResourcePool.cpp
@@ -125,7 +125,7 @@ void ResourcePool::Update() {
     // system.  If a group does, place the object into that system group's set
     // of objects.  If no group contains the object, place the object in its own
     // single-object group.
-    for (auto& obj : Objects().FindObjects<const UniverseObject>(m_object_ids)) {
+    for (auto& obj : Objects().find<const UniverseObject>(m_object_ids)) {
         int object_id = obj->ID();
         int object_system_id = obj->SystemID();
         // can't generate resources when not in a system

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -481,20 +481,15 @@ void SupplyManager::Update() {
                 if (auto sys = GetSystem(sys_id)) {
                     std::vector<int> obj_ids;
                     std::copy(sys->ContainedObjectIDs().begin(), sys->ContainedObjectIDs().end(), std::back_inserter(obj_ids));
-                    for (auto& obj : Objects().find(obj_ids)) {
-                        if (!obj)
+                    for (auto& planet : Objects().find<Planet>(obj_ids)) {
+                        if (!planet)
                             continue;
-                        if (!obj->OwnedBy(empire_id))
+                        if (!planet->OwnedBy(empire_id))
                             continue;
-                        if (obj->ObjectType() == OBJ_PLANET) {
-                            if (auto planet = std::dynamic_pointer_cast<Planet>(obj)) {
-                                if (!planet->SpeciesName().empty())
-                                    has_colony = true;
-                                else
-                                    has_outpost = true;
-                                continue;
-                            }
-                        }
+                        if (!planet->SpeciesName().empty())
+                            has_colony = true;
+                        else
+                            has_outpost = true;
                     }
                 }
                 if (has_colony)

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -256,7 +256,7 @@ namespace {
         float accumulator_current = 0.0f;
         float accumulator_max = 0.0f;
 
-        for (auto obj : Objects().FindObjects(sys->ObjectIDs())) {
+        for (auto obj : Objects().find(sys->ObjectIDs())) {
             if (!obj || !obj->OwnedBy(empire_id))
                 continue;
             if (obj->Meters().count(METER_SUPPLY) > 0)
@@ -273,7 +273,7 @@ namespace {
 
         float accumulator_current = 0.0f;
 
-        for (auto obj : Objects().FindObjects(OwnedVisitor<UniverseObject>(empire_id))) {
+        for (auto obj : Objects().find(OwnedVisitor<UniverseObject>(empire_id))) {
             if (!obj || !obj->OwnedBy(empire_id))
                 continue;
             if (obj->Meters().count(METER_SUPPLY) > 0)
@@ -353,7 +353,7 @@ void SupplyManager::Update() {
     // probably temporary: additional restriction here for supply propagation
     // but not for general system obstruction as determind within Empire::UpdateSupplyUnobstructedSystems
     /////
-    const auto fleets = GetUniverse().Objects().FindObjects<Fleet>();
+    const auto fleets = GetUniverse().Objects().all<Fleet>();
 
     for (const auto& entry : Empires()) {
         int empire_id = entry.first;
@@ -481,7 +481,7 @@ void SupplyManager::Update() {
                 if (auto sys = GetSystem(sys_id)) {
                     std::vector<int> obj_ids;
                     std::copy(sys->ContainedObjectIDs().begin(), sys->ContainedObjectIDs().end(), std::back_inserter(obj_ids));
-                    for (auto& obj : Objects().FindObjects(obj_ids)) {
+                    for (auto& obj : Objects().find(obj_ids)) {
                         if (!obj)
                             continue;
                         if (!obj->OwnedBy(empire_id))

--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -1091,7 +1091,7 @@ void BuildDesignatorWnd::CenterOnBuild(int queue_idx, bool open) {
     const ProductionQueue& queue = empire->GetProductionQueue();
     if (0 <= queue_idx && queue_idx < static_cast<int>(queue.size())) {
         int location_id = queue[queue_idx].location;
-        if (auto build_location = objects.at(location_id)) {
+        if (auto build_location = objects.get(location_id)) {
             // centre map on system of build location
             int system_id = build_location->SystemID();
             auto&& map = ClientUI::GetClientUI()->GetMapWnd();

--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -1091,7 +1091,7 @@ void BuildDesignatorWnd::CenterOnBuild(int queue_idx, bool open) {
     const ProductionQueue& queue = empire->GetProductionQueue();
     if (0 <= queue_idx && queue_idx < static_cast<int>(queue.size())) {
         int location_id = queue[queue_idx].location;
-        if (auto build_location = objects.Object(location_id)) {
+        if (auto build_location = objects.at(location_id)) {
             // centre map on system of build location
             int system_id = build_location->SystemID();
             auto&& map = ClientUI::GetClientUI()->GetMapWnd();
@@ -1381,7 +1381,7 @@ void BuildDesignatorWnd::SelectDefaultPlanet() {
         return;
     }
 
-    auto planets = Objects().FindObjects<const Planet>(sys->PlanetIDs());
+    auto planets = Objects().find<const Planet>(sys->PlanetIDs());
 
     if (planets.empty()) {
         this->SelectPlanet(INVALID_OBJECT_ID);

--- a/UI/ChatWnd.cpp
+++ b/UI/ChatWnd.cpp
@@ -140,12 +140,12 @@ void MessageWndEdit::FindGameWords() {
         m_game_words.insert(entry.second->PlayerName());
     }
     // add system names
-    for (auto& system : GetUniverse().Objects().FindObjects<System>()) {
+    for (auto& system : GetUniverse().Objects().all<System>()) {
         if (system->Name() != "")
             m_game_words.insert(system->Name());
     }
      // add ship names
-    for (auto& ship : GetUniverse().Objects().FindObjects<Ship>()) {
+    for (auto& ship : GetUniverse().Objects().all<Ship>()) {
         if (ship->Name() != "")
             m_game_words.insert(ship->Name());
     }

--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -764,7 +764,7 @@ std::string ClientUI::FormatTimestamp(boost::posix_time::ptime timestamp) {
 
 bool ClientUI::ZoomToObject(const std::string& name) {
     // try first by finding the object by name
-    for (auto& obj : GetUniverse().Objects().FindObjects<UniverseObject>())
+    for (auto& obj : GetUniverse().Objects().all<UniverseObject>())
         if (boost::iequals(obj->Name(), name))
             return ZoomToObject(obj->ID());
 

--- a/UI/CombatReport/CombatLogWnd.cpp
+++ b/UI/CombatReport/CombatLogWnd.cpp
@@ -103,8 +103,7 @@ namespace {
     {
         decltype(SegregateForces(owners, objects, categories, order)) forces;
 
-        for (int object_id : objects) {
-            auto object = Objects().at(object_id);
+        for (const auto& object: Objects().find(objects)) {
             if (!object)
                 continue;
 

--- a/UI/CombatReport/CombatLogWnd.cpp
+++ b/UI/CombatReport/CombatLogWnd.cpp
@@ -104,7 +104,7 @@ namespace {
         decltype(SegregateForces(owners, objects, categories, order)) forces;
 
         for (int object_id : objects) {
-            auto object = Objects().Object(object_id);
+            auto object = Objects().at(object_id);
             if (!object)
                 continue;
 

--- a/UI/CombatReport/GraphicalSummary.cpp
+++ b/UI/CombatReport/GraphicalSummary.cpp
@@ -269,7 +269,7 @@ public:
         m_sizer(sizer),
         m_hovered(false)
     {
-        auto object = Objects().at(participant.object_id);
+        auto object = Objects().get(participant.object_id);
         if (object) {
             SetBrowseText(object->PublicName(ClientApp::GetApp()->EmpireID()) + " " +
                           DoubleToString(participant.current_health, 3, false) + "/" +

--- a/UI/CombatReport/GraphicalSummary.cpp
+++ b/UI/CombatReport/GraphicalSummary.cpp
@@ -269,7 +269,7 @@ public:
         m_sizer(sizer),
         m_hovered(false)
     {
-        auto object = Objects().Object(participant.object_id);
+        auto object = Objects().at(participant.object_id);
         if (object) {
             SetBrowseText(object->PublicName(ClientApp::GetApp()->EmpireID()) + " " +
                           DoubleToString(participant.current_health, 3, false) + "/" +

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -297,7 +297,7 @@ namespace {
 
                 // occupied planets
                 std::vector<std::shared_ptr<const Planet>> species_occupied_planets;
-                for (auto& planet : Objects().FindObjects<Planet>()) {
+                for (auto& planet : Objects().all<Planet>()) {
                     if ((planet->SpeciesName() == entry.first) && !known_homeworlds.count(planet->ID()))
                         species_occupied_planets.push_back(planet);
                 }
@@ -365,7 +365,7 @@ namespace {
             }
 
         } else if (dir_name == "ENC_SHIP") {
-            for (auto& ship : Objects().FindObjects<Ship>()) {
+            for (auto& ship : Objects().all<Ship>()) {
                 const std::string& ship_name = ship->PublicName(client_empire_id);
                 sorted_entries_list.insert({ship_name,
                                             {LinkTaggedIDText(VarText::SHIP_ID_TAG, ship->ID(), ship_name) + "  ",
@@ -373,7 +373,7 @@ namespace {
             }
 
         } else if (dir_name == "ENC_MONSTER") {
-            for (auto& ship : Objects().FindObjects<Ship>()) {
+            for (auto& ship : Objects().all<Ship>()) {
                 if (!ship->IsMonster())
                     continue;
                 const std::string& ship_name = ship->PublicName(client_empire_id);
@@ -395,7 +395,7 @@ namespace {
             }
 
         } else if (dir_name == "ENC_FLEET") {
-            for (auto& fleet : Objects().FindObjects<Fleet>()) {
+            for (auto& fleet : Objects().all<Fleet>()) {
                 const std::string& flt_name = fleet->PublicName(client_empire_id);
                 sorted_entries_list.insert({flt_name,
                                             {LinkTaggedIDText(VarText::FLEET_ID_TAG, fleet->ID(), flt_name) + "  ",
@@ -403,7 +403,7 @@ namespace {
             }
 
         } else if (dir_name == "ENC_PLANET") {
-            for (auto& planet : Objects().FindObjects<Planet>()) {
+            for (auto& planet : Objects().all<Planet>()) {
                 const std::string& plt_name = planet->PublicName(client_empire_id);
                 sorted_entries_list.insert({plt_name,
                                             {LinkTaggedIDText(VarText::PLANET_ID_TAG, planet->ID(), plt_name) + "  ",
@@ -411,7 +411,7 @@ namespace {
             }
 
         } else if (dir_name == "ENC_BUILDING") {
-            for (auto& building : Objects().FindObjects<Building>()) {
+            for (auto& building : Objects().all<Building>()) {
                 const std::string& bld_name = building->PublicName(client_empire_id);
                 sorted_entries_list.insert({bld_name,
                                             {LinkTaggedIDText(VarText::BUILDING_ID_TAG, building->ID(), bld_name) + "  ",
@@ -419,7 +419,7 @@ namespace {
             }
 
         } else if (dir_name == "ENC_SYSTEM") {
-            for (auto& system : Objects().FindObjects<System>()) {
+            for (auto& system : Objects().all<System>()) {
                 const std::string& sys_name = system->ApparentName(client_empire_id);
                 sorted_entries_list.insert({sys_name,
                                             {LinkTaggedIDText(VarText::SYSTEM_ID_TAG, system->ID(), sys_name) + "  ",
@@ -427,7 +427,7 @@ namespace {
             }
 
         } else if (dir_name == "ENC_FIELD") {
-            for (auto& field : Objects().FindObjects<Field>()) {
+            for (auto& field : Objects().all<Field>()) {
                 const std::string& field_name = field->Name();
                 sorted_entries_list.insert({field_name,
                                             {LinkTaggedIDText(VarText::FIELD_ID_TAG, field->ID(), field_name) + "  ",
@@ -1659,7 +1659,7 @@ namespace {
 
 
         // Planets
-        auto empire_planets = Objects().FindObjects(OwnedVisitor<Planet>(empire_id));
+        auto empire_planets = Objects().find(OwnedVisitor<Planet>(empire_id));
         if (!empire_planets.empty()) {
             detailed_description += "\n\n" + UserString("OWNED_PLANETS");
             for (auto& obj : empire_planets) {
@@ -1671,7 +1671,7 @@ namespace {
 
         // Fleets
         std::vector<std::shared_ptr<const UniverseObject>> nonempty_empire_fleets;
-        for (auto& maybe_fleet : Objects().FindObjects(OwnedVisitor<Fleet>(empire_id))) {
+        for (auto& maybe_fleet : Objects().find(OwnedVisitor<Fleet>(empire_id))) {
             if (auto fleet = std::dynamic_pointer_cast<const Fleet>(maybe_fleet))
                 if (!fleet->Empty())
                     nonempty_empire_fleets.push_back(fleet);

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -1659,7 +1659,7 @@ namespace {
 
 
         // Planets
-        auto empire_planets = Objects().find(OwnedVisitor<Planet>(empire_id));
+        auto empire_planets = Objects().find<Planet>(OwnedVisitor<Planet>(empire_id));
         if (!empire_planets.empty()) {
             detailed_description += "\n\n" + UserString("OWNED_PLANETS");
             for (auto& obj : empire_planets) {
@@ -1671,10 +1671,9 @@ namespace {
 
         // Fleets
         std::vector<std::shared_ptr<const UniverseObject>> nonempty_empire_fleets;
-        for (auto& maybe_fleet : Objects().find(OwnedVisitor<Fleet>(empire_id))) {
-            if (auto fleet = std::dynamic_pointer_cast<const Fleet>(maybe_fleet))
-                if (!fleet->Empty())
-                    nonempty_empire_fleets.push_back(fleet);
+        for (const auto& fleet : Objects().find<Fleet>(OwnedVisitor<Fleet>(empire_id))) {
+            if (!fleet->Empty())
+                nonempty_empire_fleets.push_back(fleet);
         }
         if (!nonempty_empire_fleets.empty()) {
             detailed_description += "\n\n" + UserString("OWNED_FLEETS") + "\n";

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -202,7 +202,7 @@ namespace {
         std::set<int> original_fleet_ids;           // ids of fleets from which ships were taken
 
         // validate ships in each group, and generate fleet names for those ships
-        std::vector<std::shared_ptr<const Ship>> ships = Objects().FindObjects<const Ship>(ship_ids);
+        std::vector<std::shared_ptr<const Ship>> ships = Objects().find<const Ship>(ship_ids);
         if (ships.empty())
             return;
 
@@ -246,7 +246,7 @@ namespace {
 
         // select ships with the requested design id
         std::vector<int> ships_of_design_ids;
-        for (auto& ship : Objects().FindObjects<Ship>(ship_ids)) {
+        for (auto& ship : Objects().find<Ship>(ship_ids)) {
             if (ship->DesignID() == design_id)
                 ships_of_design_ids.push_back(ship->ID());
         }
@@ -267,7 +267,7 @@ namespace {
 
         // sort ships by ID into container, indexed by design id
         std::map<int, std::vector<int>> designs_ship_ids;
-        for (auto& ship : Objects().FindObjects<Ship>(ship_ids)) {
+        for (auto& ship : Objects().find<Ship>(ship_ids)) {
             designs_ship_ids[ship->DesignID()].push_back(ship->ID());
         }
 
@@ -300,7 +300,7 @@ namespace {
 
         // filter fleets in system to select just those owned by this client's
         // empire, and collect their ship ids
-        std::vector<std::shared_ptr<Fleet>> all_system_fleets = Objects().FindObjects<Fleet>(system->FleetIDs());
+        std::vector<std::shared_ptr<Fleet>> all_system_fleets = Objects().find<Fleet>(system->FleetIDs());
         std::vector<int> empire_system_fleet_ids;
         empire_system_fleet_ids.reserve(all_system_fleets.size());
         std::vector<std::shared_ptr<Fleet>> empire_system_fleets;
@@ -1422,7 +1422,7 @@ void FleetDataPanel::Refresh() {
             return std::all_of(
                 fleet->ShipIDs().begin(), fleet->ShipIDs().end(),
                 [&pred](const int ship_id) {
-                    const auto& ship = Objects().Object<const Ship>(ship_id);
+                    const auto& ship = Objects().at<const Ship>(ship_id);
                     if (!ship) {
                         WarnLogger() << "Object map is missing ship with expected id " << ship_id;
                         return false;
@@ -1502,7 +1502,7 @@ void FleetDataPanel::RefreshStateChangedSignals() {
     m_fleet_connection = fleet->StateChangedSignal.connect(
         boost::bind(&FleetDataPanel::RequireRefresh, this));
 
-    for (auto& ship : Objects().FindObjects<const Ship>(fleet->ShipIDs()))
+    for (auto& ship : Objects().find<const Ship>(fleet->ShipIDs()))
         m_ship_connections.push_back(
             ship->StateChangedSignal.connect(
                 boost::bind(&FleetDataPanel::RequireRefresh, this)));
@@ -1528,7 +1528,7 @@ void FleetDataPanel::SetStatIconValues() {
 
     fuels.reserve(fleet->NumShips());
     speeds.reserve(fleet->NumShips());
-    for (auto& ship : Objects().FindObjects<const Ship>(fleet->ShipIDs())) {
+    for (auto& ship : Objects().find<const Ship>(fleet->ShipIDs())) {
         int ship_id = ship->ID();
         // skip known destroyed and stale info objects
         if (this_client_known_destroyed_objects.count(ship_id))
@@ -2866,11 +2866,11 @@ void FleetWnd::SetStatIconValues() {
     float troop_tally =     0.0f;
     float colony_tally =    0.0f;
 
-    for (auto& fleet : Objects().FindObjects<const Fleet>(m_fleet_ids)) {
+    for (auto& fleet : Objects().find<const Fleet>(m_fleet_ids)) {
         if ( !(((m_empire_id == ALL_EMPIRES) && (fleet->Unowned())) || fleet->OwnedBy(m_empire_id)) )
             continue;
 
-        for (auto& ship : Objects().FindObjects<const Ship>(fleet->ShipIDs())) {
+        for (auto& ship : Objects().find<const Ship>(fleet->ShipIDs())) {
             int ship_id = ship->ID();
 
             // skip known destroyed and stale info objects
@@ -3068,7 +3068,7 @@ void FleetWnd::Refresh() {
     if (auto system = GetSystem(m_system_id)) {
         m_fleet_ids.clear();
         // get fleets to show from system, based on required ownership
-        for (auto& fleet : Objects().FindObjects<Fleet>(system->FleetIDs())) {
+        for (auto& fleet : Objects().find<Fleet>(system->FleetIDs())) {
             int fleet_id = fleet->ID();
 
             // skip known destroyed and stale info objects
@@ -3419,7 +3419,7 @@ void FleetWnd::FleetRightClicked(GG::ListBox::iterator it, const GG::Pt& pt, con
     // an owned object in this fleet's system
     std::set<int> peaceful_empires_in_system;
     if (system) {
-        for (auto& obj : Objects().FindObjects<const UniverseObject>(system->ObjectIDs())) {
+        for (auto& obj : Objects().find<const UniverseObject>(system->ObjectIDs())) {
             if (obj->GetVisibility(client_empire_id) < VIS_PARTIAL_VISIBILITY)
                 continue;
             if (obj->Owner() == client_empire_id || obj->Unowned())
@@ -3785,7 +3785,7 @@ void FleetWnd::UniverseObjectDeleted(std::shared_ptr<const UniverseObject> obj) 
     // remove deleted fleet's row
     for (auto it = m_fleets_lb->begin(); it != m_fleets_lb->end(); ++it) {
         int row_fleet_id = FleetInRow(it);
-        if (objects.Object<Fleet>(row_fleet_id) == deleted_fleet) {
+        if (objects.at<Fleet>(row_fleet_id) == deleted_fleet) {
             m_fleets_lb->Erase(it);
             break;
         }

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -1422,7 +1422,7 @@ void FleetDataPanel::Refresh() {
             return std::all_of(
                 fleet->ShipIDs().begin(), fleet->ShipIDs().end(),
                 [&pred](const int ship_id) {
-                    const auto& ship = Objects().at<const Ship>(ship_id);
+                    const auto& ship = Objects().get<const Ship>(ship_id);
                     if (!ship) {
                         WarnLogger() << "Object map is missing ship with expected id " << ship_id;
                         return false;
@@ -3785,7 +3785,7 @@ void FleetWnd::UniverseObjectDeleted(std::shared_ptr<const UniverseObject> obj) 
     // remove deleted fleet's row
     for (auto it = m_fleets_lb->begin(); it != m_fleets_lb->end(); ++it) {
         int row_fleet_id = FleetInRow(it);
-        if (objects.at<Fleet>(row_fleet_id) == deleted_fleet) {
+        if (objects.get<Fleet>(row_fleet_id) == deleted_fleet) {
             m_fleets_lb->Erase(it);
             break;
         }

--- a/UI/LinkText.cpp
+++ b/UI/LinkText.cpp
@@ -210,7 +210,7 @@ std::string ColorByOwner::Decorate(const std::string& object_id_str, const std::
     const Empire* empire = nullptr;
     // get object indicated by object_id, and then get object's owner, if any
     int object_id = CastStringToInt(object_id_str);
-    auto object = Objects().at(object_id);
+    auto object = Objects().get(object_id);
     if (object && !object->Unowned())
         empire = GetEmpire(object->Owner());
     if (empire)

--- a/UI/LinkText.cpp
+++ b/UI/LinkText.cpp
@@ -210,7 +210,7 @@ std::string ColorByOwner::Decorate(const std::string& object_id_str, const std::
     const Empire* empire = nullptr;
     // get object indicated by object_id, and then get object's owner, if any
     int object_id = CastStringToInt(object_id_str);
-    auto object = Objects().Object(object_id);
+    auto object = Objects().at(object_id);
     if (object && !object->Unowned())
         empire = GetEmpire(object->Owner());
     if (empire)

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -2852,7 +2852,7 @@ void MapWnd::InitTurn() {
 
     if (turn_number == 1 && this_client_empire) {
         // start first turn with player's system selected
-        if (auto obj = objects.at(this_client_empire->CapitalID())) {
+        if (auto obj = objects.get(this_client_empire->CapitalID())) {
             SelectSystem(obj->SystemID());
             CenterOnMapCoord(obj->X(), obj->Y());
         }
@@ -4066,7 +4066,7 @@ void MapWnd::InitVisibilityRadiiRenderingBuffers() {
             auto ship = std::dynamic_pointer_cast<const Ship>(obj);
             if (!ship)
                 continue;
-            auto fleet = objects.at<Fleet>(ship->FleetID());
+            auto fleet = objects.get<Fleet>(ship->FleetID());
             if (!fleet)
                 continue;
             int cur_id = fleet->SystemID();
@@ -4697,7 +4697,7 @@ void MapWnd::ForgetObject(int id) {
     // If there is only 1 ship in a fleet, forget the fleet
     auto ship = std::dynamic_pointer_cast<const Ship>(obj);
     if (ship) {
-        if (auto ship_s_fleet = GetUniverse().Objects().at<const Fleet>(ship->FleetID())) {
+        if (auto ship_s_fleet = GetUniverse().Objects().get<const Fleet>(ship->FleetID())) {
             bool only_ship_in_fleet = ship_s_fleet->NumShips() == 1;
             if (only_ship_in_fleet)
                 return ForgetObject(ship->FleetID());
@@ -4806,7 +4806,7 @@ void MapWnd::DoFleetButtonsLayout() {
             std::shared_ptr<const Fleet> fleet;
 
             // skip button if it has no fleets (somehow...?) or if the first fleet in the button is 0
-            if (fb->Fleets().empty() || !(fleet = objects.at<Fleet>(*fb->Fleets().begin()))) {
+            if (fb->Fleets().empty() || !(fleet = objects.get<Fleet>(*fb->Fleets().begin()))) {
                 ErrorLogger() << "DoFleetButtonsLayout couldn't get first fleet for button";
                 continue;
             }
@@ -4830,7 +4830,7 @@ void MapWnd::DoFleetButtonsLayout() {
             std::shared_ptr<const Fleet> fleet;
 
             // skip button if it has no fleets (somehow...?) or if the first fleet in the button is 0
-            if (fb->Fleets().empty() || !(fleet = objects.at<Fleet>(*fb->Fleets().begin()))) {
+            if (fb->Fleets().empty() || !(fleet = objects.get<Fleet>(*fb->Fleets().begin()))) {
                 ErrorLogger() << "DoFleetButtonsLayout couldn't get first fleet for button";
                 continue;
             }

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -6913,7 +6913,7 @@ namespace {
     }
 
     std::set<std::pair<std::string, int>, CustomRowCmp> GetOwnedSystemNamesIDs(int empire_id) {
-        auto owned_planets = Objects().find(OwnedVisitor<Planet>(empire_id));
+        auto owned_planets = Objects().find<Planet>(OwnedVisitor<Planet>(empire_id));
 
         // get IDs of systems that contain any owned planets
         std::unordered_set<int> system_ids;

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -4483,10 +4483,9 @@ void MapWnd::ReselectLastFleet() {
 
     // search through stored selected fleets' ids and remove ids of missing fleets
     std::set<int> missing_fleets;
-    for (int fleet_id : m_selected_fleet_ids) {
-        auto fleet = objects.at<Fleet>(fleet_id);
+    for (const auto& fleet : objects.find<Fleet>(m_selected_fleet_ids)) {
         if (!fleet)
-            missing_fleets.insert(fleet_id);
+            missing_fleets.insert(fleet->ID());
     }
     for (int fleet_id : missing_fleets)
         m_selected_fleet_ids.erase(fleet_id);
@@ -6839,8 +6838,7 @@ void MapWnd::RefreshPopulationIndicator() {
     const ObjectMap& objects = Objects();
 
     //tally up all species population counts
-    for (int pop_center_id : pop_center_ids) {
-        auto pc = objects.at<PopCenter>(pop_center_id);
+    for (const auto& pc : objects.find<PopCenter>(pop_center_ids)) {
         if (!pc)
             continue;
 

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -473,7 +473,7 @@ namespace {
                 return;
 
             const auto& destroyed_objects = GetUniverse().EmpireKnownDestroyedObjectIDs(m_empire_id);
-            for (auto& ship : Objects().FindObjects<Ship>()) {
+            for (auto& ship : Objects().all<Ship>()) {
                 if (!ship->OwnedBy(m_empire_id) || destroyed_objects.count(ship->ID()))
                     continue;
                 m_values[FLEET_DETAIL_SHIP_COUNT]++;
@@ -2069,7 +2069,7 @@ void MapWnd::RenderSystems() {
                     std::map<int, int> colony_count_by_empire_id;
                     const std::set<int>& known_destroyed_object_ids = GetUniverse().EmpireKnownDestroyedObjectIDs(HumanClientApp::GetApp()->EmpireID());
 
-                    for (auto& planet : Objects().FindObjects<const Planet>(system->PlanetIDs())) {
+                    for (auto& planet : Objects().find<const Planet>(system->PlanetIDs())) {
                         if (known_destroyed_object_ids.count(planet->ID()) > 0)
                             continue;
 
@@ -2751,7 +2751,7 @@ void MapWnd::InitTurn() {
 
     timer.EnterSection("fleet signals");
     // connect system fleet add and remove signals
-    for (auto& system : objects.FindObjects<System>()) {
+    for (auto& system : objects.all<System>()) {
         m_system_fleet_insert_remove_signals[system->ID()].push_back(system->FleetsInsertedSignal.connect(
             boost::bind(&MapWnd::FleetsInsertedSignalHandler, this, _1)));
         m_system_fleet_insert_remove_signals[system->ID()].push_back(system->FleetsRemovedSignal.connect(
@@ -2852,7 +2852,7 @@ void MapWnd::InitTurn() {
 
     if (turn_number == 1 && this_client_empire) {
         // start first turn with player's system selected
-        if (auto obj = objects.Object(this_client_empire->CapitalID())) {
+        if (auto obj = objects.at(this_client_empire->CapitalID())) {
             SelectSystem(obj->SystemID());
             CenterOnMapCoord(obj->X(), obj->Y());
         }
@@ -2943,7 +2943,7 @@ void MapWnd::InitTurnRendering() {
     m_system_icons.clear();
 
     // create system icons
-    for (auto& sys : objects.FindObjects<System>()) {
+    for (auto& sys : objects.all<System>()) {
         int sys_id = sys->ID();
 
         // skip known destroyed objects
@@ -2990,7 +2990,7 @@ void MapWnd::InitTurnRendering() {
     m_field_icons.clear();
 
     // create field icons
-    for (auto& field : objects.FindObjects<Field>()) {
+    for (auto& field : objects.all<Field>()) {
         int fld_id = field->ID();
 
         // skip known destroyed and stale fields
@@ -4042,7 +4042,7 @@ void MapWnd::InitVisibilityRadiiRenderingBuffers() {
     // for each map position and empire, find max value of detection range at that position
     std::map<std::pair<int, std::pair<float, float>>, float> empire_position_max_detection_ranges;
 
-    for (auto& obj : objects.FindObjects<UniverseObject>()) {
+    for (auto& obj : objects.all<UniverseObject>()) {
         int object_id = obj->ID();
         // skip destroyed objects
         if (destroyed_object_ids.count(object_id))
@@ -4066,7 +4066,7 @@ void MapWnd::InitVisibilityRadiiRenderingBuffers() {
             auto ship = std::dynamic_pointer_cast<const Ship>(obj);
             if (!ship)
                 continue;
-            auto fleet = objects.Object<Fleet>(ship->FleetID());
+            auto fleet = objects.at<Fleet>(ship->FleetID());
             if (!fleet)
                 continue;
             int cur_id = fleet->SystemID();
@@ -4484,7 +4484,7 @@ void MapWnd::ReselectLastFleet() {
     // search through stored selected fleets' ids and remove ids of missing fleets
     std::set<int> missing_fleets;
     for (int fleet_id : m_selected_fleet_ids) {
-        auto fleet = objects.Object<Fleet>(fleet_id);
+        auto fleet = objects.at<Fleet>(fleet_id);
         if (!fleet)
             missing_fleets.insert(fleet_id);
     }
@@ -4698,7 +4698,7 @@ void MapWnd::ForgetObject(int id) {
     // If there is only 1 ship in a fleet, forget the fleet
     auto ship = std::dynamic_pointer_cast<const Ship>(obj);
     if (ship) {
-        if (auto ship_s_fleet = GetUniverse().Objects().Object<const Fleet>(ship->FleetID())) {
+        if (auto ship_s_fleet = GetUniverse().Objects().at<const Fleet>(ship->FleetID())) {
             bool only_ship_in_fleet = ship_s_fleet->NumShips() == 1;
             if (only_ship_in_fleet)
                 return ForgetObject(ship->FleetID());
@@ -4807,7 +4807,7 @@ void MapWnd::DoFleetButtonsLayout() {
             std::shared_ptr<const Fleet> fleet;
 
             // skip button if it has no fleets (somehow...?) or if the first fleet in the button is 0
-            if (fb->Fleets().empty() || !(fleet = objects.Object<Fleet>(*fb->Fleets().begin()))) {
+            if (fb->Fleets().empty() || !(fleet = objects.at<Fleet>(*fb->Fleets().begin()))) {
                 ErrorLogger() << "DoFleetButtonsLayout couldn't get first fleet for button";
                 continue;
             }
@@ -4831,7 +4831,7 @@ void MapWnd::DoFleetButtonsLayout() {
             std::shared_ptr<const Fleet> fleet;
 
             // skip button if it has no fleets (somehow...?) or if the first fleet in the button is 0
-            if (fb->Fleets().empty() || !(fleet = objects.Object<Fleet>(*fb->Fleets().begin()))) {
+            if (fb->Fleets().empty() || !(fleet = objects.at<Fleet>(*fb->Fleets().begin()))) {
                 ErrorLogger() << "DoFleetButtonsLayout couldn't get first fleet for button";
                 continue;
             }
@@ -5150,8 +5150,7 @@ void MapWnd::RefreshFleetSignals() {
 
     // connect fleet change signals to update fleet movement lines, so that ordering
     // fleets to move updates their displayed path and rearranges fleet buttons (if necessary)
-    auto fleets = Objects().FindObjects<Fleet>();
-    AddFleetsStateChangedSignal(fleets);
+    AddFleetsStateChangedSignal(Objects().all<Fleet>());
 }
 
 void MapWnd::RefreshSliders() {
@@ -5388,7 +5387,7 @@ void MapWnd::SystemRightClicked(int system_id, GG::Flags<GG::ModKey> mod_keys) {
             if (!system)
                 return;
 
-            for (auto& obj : Objects().FindObjects<const UniverseObject>(system->ContainedObjectIDs())) {
+            for (auto& obj : Objects().find<const UniverseObject>(system->ContainedObjectIDs())) {
                 UniverseObjectType obj_type = obj->ObjectType();
                 if (obj_type >= OBJ_BUILDING && obj_type < OBJ_SYSTEM) {
                     net.SendMessage(ModeratorActionMessage(
@@ -6680,7 +6679,7 @@ void MapWnd::RefreshFleetResourceIndicator() {
     const auto& this_client_known_destroyed_objects = GetUniverse().EmpireKnownDestroyedObjectIDs(empire_id);
 
     int total_fleet_count = 0;
-    for (auto& ship : Objects().FindObjects<Ship>()) {
+    for (auto& ship : Objects().all<Ship>()) {
         if (ship->OwnedBy(empire_id) && !this_client_known_destroyed_objects.count(ship->ID()))
             total_fleet_count++;
     }
@@ -6841,8 +6840,7 @@ void MapWnd::RefreshPopulationIndicator() {
 
     //tally up all species population counts
     for (int pop_center_id : pop_center_ids) {
-        auto obj = objects.Object(pop_center_id);
-        auto pc = std::dynamic_pointer_cast<const PopCenter>(obj);
+        auto pc = objects.at<PopCenter>(pop_center_id);
         if (!pc)
             continue;
 
@@ -6908,14 +6906,14 @@ namespace {
     std::set<std::pair<std::string, int>, CustomRowCmp> GetSystemNamesIDs() {
         // get systems, store alphabetized
         std::set<std::pair<std::string, int>, CustomRowCmp> system_names_ids;
-        for (auto& system : Objects().FindObjects<System>()) {
+        for (auto& system : Objects().all<System>()) {
             system_names_ids.insert({system->Name(), system->ID()});
         }
         return system_names_ids;
     }
 
     std::set<std::pair<std::string, int>, CustomRowCmp> GetOwnedSystemNamesIDs(int empire_id) {
-        auto owned_planets = Objects().FindObjects(OwnedVisitor<Planet>(empire_id));
+        auto owned_planets = Objects().find(OwnedVisitor<Planet>(empire_id));
 
         // get IDs of systems that contain any owned planets
         std::unordered_set<int> system_ids;

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -7032,16 +7032,17 @@ bool MapWnd::ZoomToNextSystem() {
 }
 
 bool MapWnd::ZoomToPrevIdleFleet() {
-    auto vec = GetUniverse().Objects().FindObjectIDs(StationaryFleetVisitor(HumanClientApp::GetApp()->EmpireID()));
-    auto it = std::find(vec.begin(), vec.end(), m_current_fleet_id);
+    auto vec = GetUniverse().Objects().find<Fleet>(StationaryFleetVisitor(HumanClientApp::GetApp()->EmpireID()));
+    auto it = std::find_if(vec.begin(), vec.end(),
+        [this](const std::shared_ptr<UniverseObject>& o){ return o->ID() == this->m_current_fleet_id; });
     const auto& destroyed_object_ids = GetUniverse().DestroyedObjectIds();
     if (it != vec.begin())
         --it;
     else
         it = vec.end();
-    while (it != vec.begin() && (it == vec.end() || destroyed_object_ids.count(*it)))
+    while (it != vec.begin() && (it == vec.end() || destroyed_object_ids.count((*it)->ID())))
         --it;
-    m_current_fleet_id = it != vec.end() ? *it : vec.empty() ? INVALID_OBJECT_ID : vec.back();
+    m_current_fleet_id = it != vec.end() ? (*it)->ID() : vec.empty() ? INVALID_OBJECT_ID : vec.back()->ID();
 
     if (m_current_fleet_id != INVALID_OBJECT_ID) {
         CenterOnObject(m_current_fleet_id);
@@ -7052,14 +7053,15 @@ bool MapWnd::ZoomToPrevIdleFleet() {
 }
 
 bool MapWnd::ZoomToNextIdleFleet() {
-    auto vec = GetUniverse().Objects().FindObjectIDs(StationaryFleetVisitor(HumanClientApp::GetApp()->EmpireID()));
-    auto it = std::find(vec.begin(), vec.end(), m_current_fleet_id);
+    auto vec = GetUniverse().Objects().find<Fleet>(StationaryFleetVisitor(HumanClientApp::GetApp()->EmpireID()));
+    auto it = std::find_if(vec.begin(), vec.end(),
+        [this](const std::shared_ptr<UniverseObject>& o){ return o->ID() == this->m_current_fleet_id; });
     const auto& destroyed_object_ids = GetUniverse().DestroyedObjectIds();
     if (it != vec.end())
         ++it;
-    while (it != vec.end() && destroyed_object_ids.count(*it))
+    while (it != vec.end() && destroyed_object_ids.count((*it)->ID()))
         ++it;
-    m_current_fleet_id = it != vec.end() ? *it : vec.empty() ? INVALID_OBJECT_ID : vec.front();
+    m_current_fleet_id = it != vec.end() ? (*it)->ID() : vec.empty() ? INVALID_OBJECT_ID : vec.front()->ID();
 
     if (m_current_fleet_id != INVALID_OBJECT_ID) {
         CenterOnObject(m_current_fleet_id);
@@ -7070,16 +7072,17 @@ bool MapWnd::ZoomToNextIdleFleet() {
 }
 
 bool MapWnd::ZoomToPrevFleet() {
-    auto vec = GetUniverse().Objects().FindObjectIDs(OwnedVisitor<Fleet>(HumanClientApp::GetApp()->EmpireID()));
-    auto it = std::find(vec.begin(), vec.end(), m_current_fleet_id);
+    auto vec = GetUniverse().Objects().find<Fleet>(OwnedVisitor<Fleet>(HumanClientApp::GetApp()->EmpireID()));
+    auto it = std::find_if(vec.begin(), vec.end(),
+        [this](const std::shared_ptr<UniverseObject>& o){ return o->ID() == this->m_current_fleet_id; });
     const auto& destroyed_object_ids = GetUniverse().DestroyedObjectIds();
     if (it != vec.begin())
         --it;
     else
         it = vec.end();
-    while (it != vec.begin() && (it == vec.end() || destroyed_object_ids.count(*it)))
+    while (it != vec.begin() && (it == vec.end() || destroyed_object_ids.count((*it)->ID())))
         --it;
-    m_current_fleet_id = it != vec.end() ? *it : vec.empty() ? INVALID_OBJECT_ID : vec.back();
+    m_current_fleet_id = it != vec.end() ? (*it)->ID() : vec.empty() ? INVALID_OBJECT_ID : vec.back()->ID();
 
     if (m_current_fleet_id != INVALID_OBJECT_ID) {
         CenterOnObject(m_current_fleet_id);
@@ -7090,14 +7093,15 @@ bool MapWnd::ZoomToPrevFleet() {
 }
 
 bool MapWnd::ZoomToNextFleet() {
-    auto vec = GetUniverse().Objects().FindObjectIDs(OwnedVisitor<Fleet>(HumanClientApp::GetApp()->EmpireID()));
-    auto it = std::find(vec.begin(), vec.end(), m_current_fleet_id);
+    auto vec = GetUniverse().Objects().find<Fleet>(OwnedVisitor<Fleet>(HumanClientApp::GetApp()->EmpireID()));
+    auto it = std::find_if(vec.begin(), vec.end(),
+        [this](const std::shared_ptr<UniverseObject>& o){ return o->ID() == this->m_current_fleet_id; });
     auto& destroyed_object_ids = GetUniverse().DestroyedObjectIds();
     if (it != vec.end())
         ++it;
-    while (it != vec.end() && destroyed_object_ids.count(*it))
+    while (it != vec.end() && destroyed_object_ids.count((*it)->ID()))
         ++it;
-    m_current_fleet_id = it != vec.end() ? *it : vec.empty() ? INVALID_OBJECT_ID : vec.front();
+    m_current_fleet_id = it != vec.end() ? (*it)->ID() : vec.empty() ? INVALID_OBJECT_ID : vec.front()->ID();
 
     if (m_current_fleet_id != INVALID_OBJECT_ID) {
         CenterOnObject(m_current_fleet_id);

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -903,7 +903,7 @@ private:
             // collect all valid tags on any object in universe
             std::set<std::string> all_tags;
 
-            for (auto& obj : GetUniverse().Objects().FindObjects<UniverseObject>()) {
+            for (auto& obj : GetUniverse().Objects().all<UniverseObject>()) {
                 auto tags = obj->Tags();
                 all_tags.insert(tags.begin(), tags.end());
             }
@@ -991,7 +991,7 @@ private:
 
             // collect all valid foci on any object in universe
             std::set<std::string> all_foci;
-            for (auto& planet : Objects().FindObjects<Planet>()) {
+            for (auto& planet : Objects().all<Planet>()) {
                 auto obj_foci = planet->AvailableFoci();
                 std::copy(obj_foci.begin(), obj_foci.end(),
                           std::inserter(all_foci, all_foci.end()));

--- a/UI/PlayerListWnd.cpp
+++ b/UI/PlayerListWnd.cpp
@@ -437,7 +437,7 @@ namespace {
             const std::set<int>& this_client_known_destroyed_objects = GetUniverse().EmpireKnownDestroyedObjectIDs(HumanClientApp::GetApp()->EmpireID());
             const std::set<int>& this_client_stale_object_info       = GetUniverse().EmpireStaleKnowledgeObjectIDs(HumanClientApp::GetApp()->EmpireID());
 
-            for (auto& ship : objects.FindObjects<Ship>()) {
+            for (auto& ship : objects.all<Ship>()) {
                 if (empire) {
                     if (ship->Owner() == empire->EmpireID()
                         && !this_client_known_destroyed_objects.count(ship->ID())
@@ -447,7 +447,7 @@ namespace {
                 }
             }
 
-            for (auto& planet : objects.FindObjects<Planet>()) {
+            for (auto& planet : objects.all<Planet>()) {
                 if (empire) {
                     if (planet->Owner() == empire->EmpireID()) {
                         empires_planet_count      += 1;

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -1253,7 +1253,7 @@ namespace {
 
         // is there a valid single selected ship in the active FleetWnd?
         for (int ship_id : FleetUIManager::GetFleetUIManager().SelectedShipIDs())
-            if (auto ship = GetUniverse().Objects().Object<Ship>(ship_id))
+            if (auto ship = GetUniverse().Objects().at<Ship>(ship_id))
                 if (ship->SystemID() == system_id && ship->HasTroops() && ship->OwnedBy(HumanClientApp::GetApp()->EmpireID()))
                     retval.insert(ship);
 
@@ -1314,8 +1314,8 @@ int AutomaticallyChosenColonyShip(int target_planet_id) {
 
     PlanetType target_planet_type = target_planet->Type();
 
-    // todo: return vector of ships from system ids using new Objects().FindObjects<Ship>(system->FindObjectIDs())
-    auto ships = Objects().FindObjects<const Ship>(system->ShipIDs());
+    // todo: return vector of ships from system ids using new Objects().find<Ship>(system->FindObjectIDs())
+    auto ships = Objects().find<const Ship>(system->ShipIDs());
     std::vector<std::shared_ptr<const Ship>> capable_and_available_colony_ships;
     capable_and_available_colony_ships.reserve(ships.size());
 
@@ -1429,7 +1429,7 @@ std::set<std::shared_ptr<const Ship>> AutomaticallyChosenInvasionShips(int targe
     double defending_troops = target_planet->InitialMeterValue(METER_TROOPS);
 
     double invasion_troops = 0;
-    for (auto& ship : Objects().FindObjects<Ship>()) {
+    for (auto& ship : Objects().all<Ship>()) {
         if (!AvailableToInvade(ship, system_id, empire_id))
             continue;
 
@@ -1466,7 +1466,7 @@ std::set<std::shared_ptr<const Ship>> AutomaticallyChosenBombardShips(int target
     if (target_planet->OwnedBy(empire_id))
         return retval;
 
-    for (auto& ship : Objects().FindObjects<Ship>()) {
+    for (auto& ship : Objects().all<Ship>()) {
         // owned ship is capable of bombarding a planet in this system
         if (!AvailableToBombard(ship, system_id, empire_id))
             continue;
@@ -2051,7 +2051,7 @@ void SidePanel::PlanetPanel::RClick(const GG::Pt& pt, GG::Flags<GG::ModKey> mod_
     // an owned object in this fleet's system
     std::set<int> peaceful_empires_in_system;
     if (system) {
-        auto system_objects = Objects().FindObjects<const UniverseObject>(system->ObjectIDs());
+        auto system_objects = Objects().find<const UniverseObject>(system->ObjectIDs());
         for (auto& obj : system_objects) {
             if (obj->GetVisibility(client_empire_id) < VIS_PARTIAL_VISIBILITY)
                 continue;
@@ -2857,7 +2857,7 @@ namespace {
 
             GG::Y top = row_height;
             // add label-value pair for each resource-producing object in system to indicate amount of resource produced
-            auto objects = Objects().FindObjects<const Planet>(system->ContainedObjectIDs());
+            auto objects = Objects().find<const Planet>(system->ContainedObjectIDs());
             for (const auto& planet : objects) {
                 // Ignore empty planets
                 if (planet->Unowned() && planet->SpeciesName().empty())
@@ -3164,12 +3164,12 @@ void SidePanel::RefreshInPreRender() {
         return;
     }
 
-    for (auto& planet : Objects().FindObjects<Planet>(system->PlanetIDs())) {
+    for (auto& planet : Objects().find<Planet>(system->PlanetIDs())) {
         s_system_connections.insert(planet->ResourceCenterChangedSignal.connect(
                                         SidePanel::ResourceCenterChangedSignal));
     }
 
-    for (auto& fleet : Objects().FindObjects<Fleet>(system->FleetIDs())) {
+    for (auto& fleet : Objects().find<Fleet>(system->FleetIDs())) {
         s_fleet_state_change_signals[fleet->ID()] = fleet->StateChangedSignal.connect(
                                                         &SidePanel::Update);
     }
@@ -3205,7 +3205,7 @@ void SidePanel::RefreshSystemNames() {
     // maintaing the list by incrementally inserting/deleting system
     // names, then this approach should also be dropped.
     std::set<std::pair<std::string, int>> sorted_systems;
-    for (auto& system : Objects().FindObjects<System>()) {
+    for (auto& system : Objects().all<System>()) {
         // Skip rows for systems that aren't known to this client, except the selected system
         if (!system->Name().empty() || system->ID() == s_system_id)
             sorted_systems.insert({system->Name(), system->ID()});
@@ -3302,7 +3302,7 @@ void SidePanel::RefreshImpl() {
     int all_owner_id = ALL_EMPIRES;
     bool all_planets_share_owner = true;
     std::vector<int> all_planets, player_planets;
-    for (auto& planet : Objects().FindObjects<const Planet>(planet_ids)) {
+    for (auto& planet : Objects().find<const Planet>(planet_ids)) {
         // If it is neither owned nor populated with natives, it can be ignored.
         if (planet->Unowned() && planet->SpeciesName().empty())
             continue;

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -1252,10 +1252,10 @@ namespace {
             return retval;
 
         // is there a valid single selected ship in the active FleetWnd?
-        for (int ship_id : FleetUIManager::GetFleetUIManager().SelectedShipIDs())
-            if (auto ship = GetUniverse().Objects().at<Ship>(ship_id))
-                if (ship->SystemID() == system_id && ship->HasTroops() && ship->OwnedBy(HumanClientApp::GetApp()->EmpireID()))
-                    retval.insert(ship);
+        for (const auto& ship : GetUniverse().Objects().find<Ship>(
+                FleetUIManager::GetFleetUIManager().SelectedShipIDs()))
+            if (ship->SystemID() == system_id && ship->HasTroops() && ship->OwnedBy(HumanClientApp::GetApp()->EmpireID()))
+                retval.insert(ship);
 
         return retval;
     }

--- a/UI/SystemIcon.cpp
+++ b/UI/SystemIcon.cpp
@@ -118,7 +118,7 @@ OwnerColoredSystemName::OwnerColoredSystemName(int system_id, int font_size,
     bool capital = false, homeworld = false, has_shipyard = false, has_neutrals = false, has_player_planet = false;
 
     std::set<int> owner_empire_ids;
-    auto system_planets = Objects().FindObjects<const Planet>(system->PlanetIDs());
+    auto system_planets = Objects().find<const Planet>(system->PlanetIDs());
 
     for (auto& planet : system_planets) {
         int planet_id = planet->ID();
@@ -151,7 +151,7 @@ OwnerColoredSystemName::OwnerColoredSystemName(int system_id, int font_size,
 
         // does planet contain a shipyard?
         if (!has_shipyard) {
-            for (auto& building : Objects().FindObjects<const Building>(planet->BuildingIDs())) {
+            for (auto& building : Objects().find<const Building>(planet->BuildingIDs())) {
                 int building_id = building->ID();
 
                 if (known_destroyed_object_ids.count(building_id))

--- a/UI/SystemResourceSummaryBrowseWnd.cpp
+++ b/UI/SystemResourceSummaryBrowseWnd.cpp
@@ -188,7 +188,7 @@ void SystemResourceSummaryBrowseWnd::UpdateProduction(GG::Y& top) {
 
 
     // add label-value pair for each resource-producing object in system to indicate amount of resource produced
-    auto objects = Objects().FindObjects<const UniverseObject>(system->ContainedObjectIDs());
+    auto objects = Objects().find<const UniverseObject>(system->ContainedObjectIDs());
 
     for (auto& obj : objects) {
         // display information only for the requested player
@@ -279,7 +279,7 @@ void SystemResourceSummaryBrowseWnd::UpdateAllocation(GG::Y& top) {
 
 
     // add label-value pair for each resource-consuming object in system to indicate amount of resource consumed
-    for (auto& obj : Objects().FindObjects<const UniverseObject>(system->ContainedObjectIDs())) {
+    for (auto& obj : Objects().find<const UniverseObject>(system->ContainedObjectIDs())) {
         // display information only for the requested player
         if (m_empire_id != ALL_EMPIRES && !obj->OwnedBy(m_empire_id))
             continue;   // if m_empire_id == ALL_EMPIRES, display resource production for all empires.  otherwise, skip this resource production if it's not owned by the requested player

--- a/client/ClientApp.cpp
+++ b/client/ClientApp.cpp
@@ -54,7 +54,7 @@ SupplyManager& ClientApp::GetSupplyManager()
 { return m_supply_manager; }
 
 std::shared_ptr<UniverseObject> ClientApp::GetUniverseObject(int object_id)
-{ return GetUniverse().Objects().Object(object_id); }
+{ return GetUniverse().Objects().at(object_id); }
 
 ObjectMap& ClientApp::EmpireKnownObjects(int empire_id) {
     // observers and moderators should have accurate info about what each empire knows
@@ -67,7 +67,7 @@ ObjectMap& ClientApp::EmpireKnownObjects(int empire_id) {
 }
 
 std::shared_ptr<UniverseObject> ClientApp::EmpireKnownObject(int object_id, int empire_id)
-{ return EmpireKnownObjects(empire_id).Object(object_id); }
+{ return EmpireKnownObjects(empire_id).at(object_id); }
 
 const OrderSet& ClientApp::Orders() const
 { return m_orders; }

--- a/client/ClientApp.cpp
+++ b/client/ClientApp.cpp
@@ -54,7 +54,7 @@ SupplyManager& ClientApp::GetSupplyManager()
 { return m_supply_manager; }
 
 std::shared_ptr<UniverseObject> ClientApp::GetUniverseObject(int object_id)
-{ return GetUniverse().Objects().at(object_id); }
+{ return GetUniverse().Objects().get(object_id); }
 
 ObjectMap& ClientApp::EmpireKnownObjects(int empire_id) {
     // observers and moderators should have accurate info about what each empire knows
@@ -67,7 +67,7 @@ ObjectMap& ClientApp::EmpireKnownObjects(int empire_id) {
 }
 
 std::shared_ptr<UniverseObject> ClientApp::EmpireKnownObject(int object_id, int empire_id)
-{ return EmpireKnownObjects(empire_id).at(object_id); }
+{ return EmpireKnownObjects(empire_id).get(object_id); }
 
 const OrderSet& ClientApp::Orders() const
 { return m_orders; }

--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -77,10 +77,10 @@ CombatInfo::CombatInfo(int system_id_, int turn_) :
 }
 
 std::shared_ptr<const System> CombatInfo::GetSystem() const
-{ return this->objects.at<System>(this->system_id); }
+{ return this->objects.get<System>(this->system_id); }
 
 std::shared_ptr<System> CombatInfo::GetSystem()
-{ return this->objects.at<System>(this->system_id); }
+{ return this->objects.get<System>(this->system_id); }
 
 float CombatInfo::GetMonsterDetection() const {
     float monster_detection = 0.0;
@@ -1619,7 +1619,7 @@ namespace {
 
         DebugLogger() << "Returning fighters to ships:";
         for (auto& entry : ships_fighters_to_add_back) {
-            auto ship = combat_info.objects.at<Ship>(entry.first);
+            auto ship = combat_info.objects.get<Ship>(entry.first);
             if (!ship) {
                 ErrorLogger(combat) << "Couldn't get ship with id " << entry.first << " for fighter to return to...";
                 continue;
@@ -1817,7 +1817,7 @@ void AutoResolveCombat(CombatInfo& combat_info) {
     if (combat_info.objects.empty())
         return;
 
-    auto system = combat_info.objects.at<System>(combat_info.system_id);
+    auto system = combat_info.objects.get<System>(combat_info.system_id);
     if (!system)
         ErrorLogger() << "AutoResolveCombat couldn't get system with id " << combat_info.system_id;
     else

--- a/python/UniverseWrapper.cpp
+++ b/python/UniverseWrapper.cpp
@@ -72,20 +72,14 @@ namespace {
     const Building*         GetBuildingP(const Universe& universe, int id)
     { return ::GetBuilding(id).operator->(); }
 
-    std::vector<int>        ObjectIDs(const Universe& universe)
-    { return Objects().FindObjectIDs(); }
-    std::vector<int>        FleetIDs(const Universe& universe)
-    { return Objects().FindObjectIDs<Fleet>(); }
-    std::vector<int>        SystemIDs(const Universe& universe)
-    { return Objects().FindObjectIDs<System>(); }
-    std::vector<int>        FieldIDs(const Universe& universe)
-    { return Objects().FindObjectIDs<Field>(); }
-    std::vector<int>        PlanetIDs(const Universe& universe)
-    { return Objects().FindObjectIDs<Planet>(); }
-    std::vector<int>        ShipIDs(const Universe& universe)
-    { return Objects().FindObjectIDs<Ship>(); }
-    std::vector<int>        BuildingIDs(const Universe& universe)
-    { return Objects().FindObjectIDs<Building>(); }
+    template<typename T>
+    std::vector<int> ObjectIDs(const Universe& universe)
+    {
+        std::vector<int> result(universe.Objects().size<T>(), INVALID_OBJECT_ID);
+        for (const auto& obj : universe.Objects().all<T>())
+            result.push_back(obj->ID());
+        return result;
+    }
 
     std::vector<std::string>SpeciesFoci(const Species& species) {
         std::vector<std::string> retval;
@@ -351,13 +345,13 @@ namespace FreeOrionPython {
             .def("getBuilding",                 make_function(GetBuildingP,         return_value_policy<reference_existing_object>()))
             .def("getGenericShipDesign",        &Universe::GetGenericShipDesign,    return_value_policy<reference_existing_object>(), "Returns the ship design (ShipDesign) with the indicated name (string).")
 
-            .add_property("allObjectIDs",       make_function(ObjectIDs,            return_value_policy<return_by_value>()))
-            .add_property("fleetIDs",           make_function(FleetIDs,             return_value_policy<return_by_value>()))
-            .add_property("systemIDs",          make_function(SystemIDs,            return_value_policy<return_by_value>()))
-            .add_property("fieldIDs",           make_function(FieldIDs,             return_value_policy<return_by_value>()))
-            .add_property("planetIDs",          make_function(PlanetIDs,            return_value_policy<return_by_value>()))
-            .add_property("shipIDs",            make_function(ShipIDs,              return_value_policy<return_by_value>()))
-            .add_property("buildingIDs",        make_function(BuildingIDs,          return_value_policy<return_by_value>()))
+            .add_property("allObjectIDs",       make_function(ObjectIDs<UniverseObject>,  return_value_policy<return_by_value>()))
+            .add_property("fleetIDs",           make_function(ObjectIDs<Fleet>,           return_value_policy<return_by_value>()))
+            .add_property("systemIDs",          make_function(ObjectIDs<System>,          return_value_policy<return_by_value>()))
+            .add_property("fieldIDs",           make_function(ObjectIDs<Field>,           return_value_policy<return_by_value>()))
+            .add_property("planetIDs",          make_function(ObjectIDs<Planet>,          return_value_policy<return_by_value>()))
+            .add_property("shipIDs",            make_function(ObjectIDs<Ship>,            return_value_policy<return_by_value>()))
+            .add_property("buildingIDs",        make_function(ObjectIDs<Building>,        return_value_policy<return_by_value>()))
             .def("destroyedObjectIDs",          make_function(&Universe::EmpireKnownDestroyedObjectIDs,
                                                                                     return_value_policy<return_by_value>()))
 

--- a/python/server/ServerWrapper.cpp
+++ b/python/server/ServerWrapper.cpp
@@ -675,7 +675,7 @@ namespace {
     }
 
     int CreatePlanet(PlanetSize size, PlanetType planet_type, int system_id, int orbit, const std::string& name) {
-        auto system = Objects().at<System>(system_id);
+        auto system = Objects().get<System>(system_id);
 
         // Perform some validity checks
         // Check if system with id system_id exists
@@ -733,7 +733,7 @@ namespace {
     }
 
     int CreateBuilding(const std::string& building_type, int planet_id, int empire_id) {
-        auto planet = Objects().at<Planet>(planet_id);
+        auto planet = Objects().get<Planet>(planet_id);
         if (!planet) {
             ErrorLogger() << "CreateBuilding: couldn't get planet with ID " << planet_id;
             return INVALID_OBJECT_ID;
@@ -765,7 +765,7 @@ namespace {
 
     int CreateFleet(const std::string& name, int system_id, int empire_id, bool aggressive = false) {
         // Get system and check if it exists
-        auto system = Objects().at<System>(system_id);
+        auto system = Objects().get<System>(system_id);
         if (!system) {
             ErrorLogger() << "CreateFleet: couldn't get system with ID " << system_id;
             return INVALID_OBJECT_ID;

--- a/python/server/ServerWrapper.cpp
+++ b/python/server/ServerWrapper.cpp
@@ -675,7 +675,7 @@ namespace {
     }
 
     int CreatePlanet(PlanetSize size, PlanetType planet_type, int system_id, int orbit, const std::string& name) {
-        auto system = Objects().Object<System>(system_id);
+        auto system = Objects().at<System>(system_id);
 
         // Perform some validity checks
         // Check if system with id system_id exists
@@ -733,7 +733,7 @@ namespace {
     }
 
     int CreateBuilding(const std::string& building_type, int planet_id, int empire_id) {
-        auto planet = Objects().Object<Planet>(planet_id);
+        auto planet = Objects().at<Planet>(planet_id);
         if (!planet) {
             ErrorLogger() << "CreateBuilding: couldn't get planet with ID " << planet_id;
             return INVALID_OBJECT_ID;
@@ -765,7 +765,7 @@ namespace {
 
     int CreateFleet(const std::string& name, int system_id, int empire_id, bool aggressive = false) {
         // Get system and check if it exists
-        auto system = Objects().Object<System>(system_id);
+        auto system = Objects().at<System>(system_id);
         if (!system) {
             ErrorLogger() << "CreateFleet: couldn't get system with ID " << system_id;
             return INVALID_OBJECT_ID;

--- a/python/server/ServerWrapper.cpp
+++ b/python/server/ServerWrapper.cpp
@@ -643,16 +643,16 @@ namespace {
 
     list GetAllObjects() {
         list py_all_objects;
-        for (int object_id : Objects().FindObjectIDs()) {
-            py_all_objects.append(object_id);
+        for (const auto& object : Objects().all()) {
+            py_all_objects.append(object->ID());
         }
         return py_all_objects;
     }
 
     list GetSystems() {
         list py_systems;
-        for (int system_id : Objects().FindObjectIDs<System>()) {
-            py_systems.append(system_id);
+        for (const auto& system : Objects().all<System>()) {
+            py_systems.append(system->ID());
         }
         return py_systems;
     }

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1812,12 +1812,12 @@ bool ServerApp::EliminatePlayer(const PlayerConnectionPtr& player_connection) {
     empire->Eliminate();
 
     // destroy owned ships
-    for (auto& obj : Objects().find(OwnedVisitor<Ship>(empire_id))) {
+    for (auto& obj : Objects().find<Ship>(OwnedVisitor<Ship>(empire_id))) {
         obj->SetOwner(ALL_EMPIRES);
         GetUniverse().RecursiveDestroy(obj->ID());
     }
     // destroy owned buildings
-    for (auto& obj : Objects().find(OwnedVisitor<Building>(empire_id))) {
+    for (auto& obj : Objects().find<Building>(OwnedVisitor<Building>(empire_id))) {
         obj->SetOwner(ALL_EMPIRES);
         GetUniverse().RecursiveDestroy(obj->ID());
     }
@@ -2085,8 +2085,8 @@ namespace {
       * definition of elimination.  As of this writing, elimination means
       * having no ships and no planets. */
     bool EmpireEliminated(int empire_id) {
-          return (Objects().find(OwnedVisitor<Planet>(empire_id)).empty() &&    // no planets
-                  Objects().find(OwnedVisitor<Ship>(empire_id)).empty());      // no ship
+          return (Objects().find<Planet>(OwnedVisitor<Planet>(empire_id)).empty() &&    // no planets
+                  Objects().find<Ship>(OwnedVisitor<Ship>(empire_id)).empty());      // no ship
       }
 
     void GetEmpireFleetsAtSystem(std::map<int, std::set<int>>& empire_fleets, int system_id) {
@@ -3417,13 +3417,7 @@ void ServerApp::UpdateMonsterTravelRestrictions() {
         bool empires_present = false;
         bool unrestricted_empires_present = false;
         std::vector<std::shared_ptr<Fleet>> monsters;
-        for (auto maybe_fleet : m_universe.Objects().find(system->FleetIDs())) {
-            auto fleet = std::dynamic_pointer_cast<Fleet>(maybe_fleet);
-            if (!fleet) {
-                ErrorLogger() << "Non Fleet object in system(" << system->ID()
-                              << ") fleets with id = " << maybe_fleet->ID();
-                continue;
-            }
+        for (const auto& fleet : m_universe.Objects().find<Fleet>(system->FleetIDs())) {
             // will not require visibility for empires to block clearing of monster travel restrictions
             // unrestricted lane access (i.e, (fleet->ArrivalStarlane() == system->ID()) ) is used as a proxy for
             // order of arrival -- if an enemy has unrestricted lane access and you don't, they must have arrived

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1802,8 +1802,8 @@ bool ServerApp::EliminatePlayer(const PlayerConnectionPtr& player_connection) {
     }
 
     // test for colonies count
-    std::vector<int> planet_ids = Objects().FindObjectIDs(OwnedVisitor<Planet>(empire_id));
-    if (planet_ids.size() > static_cast<size_t>(GetGameRules().Get<int>("RULE_CONCEDE_COLONIES_THRESHOLD"))) {
+    auto planets = Objects().find<Planet>(OwnedVisitor<Planet>(empire_id));
+    if (planets.size() > static_cast<size_t>(GetGameRules().Get<int>("RULE_CONCEDE_COLONIES_THRESHOLD"))) {
         player_connection->SendMessage(ErrorMessage(UserStringNop("ERROR_CONCEDE_EXCEED_COLONIES"), false));
         return false;
     }
@@ -1822,10 +1822,8 @@ bool ServerApp::EliminatePlayer(const PlayerConnectionPtr& player_connection) {
         GetUniverse().RecursiveDestroy(obj->ID());
     }
     // unclaim owned planets
-    for (int planet_id : planet_ids) {
-        auto planet = GetPlanet(planet_id);
-        if (planet)
-            planet->Reset();
+    for (const auto& planet : planets) {
+        planet->Reset();
     }
 
     // Don't wait for turn
@@ -2380,9 +2378,9 @@ namespace {
         combats.clear();
         // for each system, find if a combat will occur in it, and if so, assemble
         // necessary information about that combat in combats
-        for (int sys_id : GetUniverse().Objects().FindObjectIDs<System>()) {
-            if (CombatConditionsInSystem(sys_id)) {
-                combats.push_back(CombatInfo(sys_id, CurrentTurn()));
+        for (const auto& sys : GetUniverse().Objects().all<System>()) {
+            if (CombatConditionsInSystem(sys->ID())) {
+                combats.push_back(CombatInfo(sys->ID(), CurrentTurn()));
             }
         }
     }

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -286,13 +286,13 @@ SupplyManager& ServerApp::GetSupplyManager()
 { return m_supply_manager; }
 
 std::shared_ptr<UniverseObject> ServerApp::GetUniverseObject(int object_id)
-{ return m_universe.Objects().at(object_id); }
+{ return m_universe.Objects().get(object_id); }
 
 ObjectMap& ServerApp::EmpireKnownObjects(int empire_id)
 { return m_universe.EmpireKnownObjects(empire_id); }
 
 std::shared_ptr<UniverseObject> ServerApp::EmpireKnownObject(int object_id, int empire_id)
-{ return m_universe.EmpireKnownObjects(empire_id).at(object_id); }
+{ return m_universe.EmpireKnownObjects(empire_id).get(object_id); }
 
 ServerNetworking& ServerApp::Networking()
 { return m_networking; }

--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -1991,10 +1991,10 @@ void Type::GetDefaultInitialCandidateObjects(const ScriptingContext& parent_cont
         }
     }
     if (found_type) {
-        //if (int(condition_non_targets.size()) < Objects().NumObjects()) {
+        //if (int(condition_non_targets.size()) < Objects().size()) {
         //    DebugLogger() << "Type::GetBaseNonMatches will provide " << condition_non_targets.size()
         //                  << " objects of type " << GetType()->Eval() << " rather than "
-        //                  << Objects().NumObjects() << " total objects";
+        //                  << Objects().size() << " total objects";
         //}
     } else {
         ConditionBase::GetDefaultInitialCandidateObjects(parent_context, condition_non_targets);
@@ -2832,7 +2832,7 @@ void Contains::Eval(const ScriptingContext& parent_context,
 
         // initialize subcondition candidates from local candidate's contents
         const ObjectMap& objects = Objects();
-        ObjectSet subcondition_matches = objects.FindObjects(local_context.condition_local_candidate->ContainedObjectIDs());
+        ObjectSet subcondition_matches = objects.find(local_context.condition_local_candidate->ContainedObjectIDs());
 
         // apply subcondition to candidates
         if (!subcondition_matches.empty()) {
@@ -3046,7 +3046,7 @@ void ContainedBy::Eval(const ScriptingContext& parent_context,
         if (local_context.condition_local_candidate->SystemID() != INVALID_OBJECT_ID)
             container_object_ids.insert(local_context.condition_local_candidate->SystemID());
 
-        ObjectSet subcondition_matches = objects.FindObjects(container_object_ids);
+        ObjectSet subcondition_matches = objects.find(container_object_ids);
 
         // apply subcondition to candidates
         if (!subcondition_matches.empty()) {
@@ -3124,7 +3124,7 @@ bool ContainedBy::Match(const ScriptingContext& local_context) const {
     if (candidate->ContainerObjectID() != INVALID_OBJECT_ID && candidate->ContainerObjectID() != candidate->SystemID())
         containers.insert(candidate->ContainerObjectID());
 
-    ObjectSet container_objects = Objects().FindObjects<const UniverseObject>(containers);
+    ObjectSet container_objects = Objects().find<const UniverseObject>(containers);
     if (container_objects.empty())
         return false;
 
@@ -3273,7 +3273,7 @@ void InSystem::GetDefaultInitialCandidateObjects(const ScriptingContext& parent_
 
     const ObjectMap& obj_map = Objects();
     const std::set<int>& system_object_ids = system->ObjectIDs();
-    auto sys_objs = obj_map.FindObjects(system_object_ids);
+    auto sys_objs = obj_map.find(system_object_ids);
 
     // insert all objects that have the specified system id
     condition_non_targets.reserve(sys_objs.size() + 1);
@@ -5114,7 +5114,7 @@ namespace {
             std::shared_ptr<const Ship> ship = nullptr;
             if (auto fighter = std::dynamic_pointer_cast<const ::Fighter>(candidate)) {
                 // it is a fighter
-                ship = Objects().Object<Ship>(fighter->LaunchedFrom());
+                ship = Objects().at<Ship>(fighter->LaunchedFrom());
             } else {
                 ship = std::dynamic_pointer_cast<const ::Ship>(candidate);
             }
@@ -7665,7 +7665,7 @@ namespace {
 
         // loop over all existing lanes in all systems, checking if a lane
         // beween the specified systems would cross any of the existing lanes
-        for (auto& system : objects.FindObjects<System>()) {
+        for (auto& system : objects.all<System>()) {
             if (system == lane_end_sys1 || system == lane_end_sys2)
                 continue;
 
@@ -7699,7 +7699,7 @@ namespace {
             return true;
 
         const ObjectMap& objects = Objects();
-        auto systems = objects.FindObjects<System>();
+        auto systems = objects.all<System>();
 
         // loop over all existing systems, checking if each is too close to a
         // lane between the specified lane endpoints

--- a/universe/Condition.cpp
+++ b/universe/Condition.cpp
@@ -5114,7 +5114,7 @@ namespace {
             std::shared_ptr<const Ship> ship = nullptr;
             if (auto fighter = std::dynamic_pointer_cast<const ::Fighter>(candidate)) {
                 // it is a fighter
-                ship = Objects().at<Ship>(fighter->LaunchedFrom());
+                ship = Objects().get<Ship>(fighter->LaunchedFrom());
             } else {
                 ship = std::dynamic_pointer_cast<const ::Ship>(candidate);
             }

--- a/universe/Effect.cpp
+++ b/universe/Effect.cpp
@@ -155,7 +155,7 @@ namespace {
         for (const std::string& star_name : star_names) {
             // does an existing system have this name?
             bool dupe = false;
-            for (auto& system : Objects().FindObjects<System>()) {
+            for (auto& system : Objects().all<System>()) {
                 if (system->Name() == star_name) {
                     dupe = true;
                     break;  // another systme has this name. skip to next potential name.
@@ -2311,7 +2311,7 @@ void MoveTo::Execute(const ScriptingContext& context) const {
                 dest_system->Insert(fleet);
 
                 // also move ships of fleet
-                for (auto& ship : Objects().FindObjects<Ship>(fleet->ShipIDs())) {
+                for (auto& ship : Objects().find<Ship>(fleet->ShipIDs())) {
                     if (old_sys)
                         old_sys->Remove(ship->ID());
                     dest_system->Insert(ship);
@@ -2332,7 +2332,7 @@ void MoveTo::Execute(const ScriptingContext& context) const {
             fleet->MoveTo(destination);
 
             // also move ships of fleet
-            for (auto& ship : Objects().FindObjects<Ship>(fleet->ShipIDs())) {
+            for (auto& ship : Objects().find<Ship>(fleet->ShipIDs())) {
                 if (old_sys)
                     old_sys->Remove(ship->ID());
                 ship->SetSystem(INVALID_OBJECT_ID);
@@ -2458,7 +2458,7 @@ void MoveTo::Execute(const ScriptingContext& context) const {
         dest_system->Insert(planet);  // let system pick an orbit
 
         // also insert buildings of planet into system.
-        for (auto& building : Objects().FindObjects<Building>(planet->BuildingIDs())) {
+        for (auto& building : Objects().find<Building>(planet->BuildingIDs())) {
             if (old_sys)
                 old_sys->Remove(building->ID());
             dest_system->Insert(building);
@@ -2521,12 +2521,12 @@ void MoveTo::Execute(const ScriptingContext& context) const {
             system->Insert(destination);
 
         // find fleets / ships at destination location and insert into system
-        for (auto& obj : Objects().FindObjects<Fleet>()) {
+        for (auto& obj : Objects().all<Fleet>()) {
             if (obj->X() == system->X() && obj->Y() == system->Y())
                 system->Insert(obj);
         }
 
-        for (auto& obj : Objects().FindObjects<Ship>()) {
+        for (auto& obj : Objects().all<Ship>()) {
             if (obj->X() == system->X() && obj->Y() == system->Y())
                 system->Insert(obj);
         }
@@ -2637,7 +2637,7 @@ void MoveInOrbit::Execute(const ScriptingContext& context) const {
         fleet->MoveTo(new_x, new_y);
         UpdateFleetRoute(fleet, INVALID_OBJECT_ID, INVALID_OBJECT_ID);
 
-        for (auto& ship : Objects().FindObjects<Ship>(fleet->ShipIDs())) {
+        for (auto& ship : Objects().find<Ship>(fleet->ShipIDs())) {
             if (old_sys)
                 old_sys->Remove(ship->ID());
             ship->SetSystem(INVALID_OBJECT_ID);
@@ -2779,7 +2779,7 @@ void MoveTowards::Execute(const ScriptingContext& context) const {
 
     if (auto system = std::dynamic_pointer_cast<System>(target)) {
         system->MoveTo(new_x, new_y);
-        for (auto& obj : Objects().FindObjects<UniverseObject>(system->ObjectIDs())) {
+        for (auto& obj : Objects().find<UniverseObject>(system->ObjectIDs())) {
             obj->MoveTo(new_x, new_y);
         }
         // don't need to remove objects from system or insert into it, as all
@@ -2792,7 +2792,7 @@ void MoveTowards::Execute(const ScriptingContext& context) const {
             old_sys->Remove(fleet->ID());
         fleet->SetSystem(INVALID_OBJECT_ID);
         fleet->MoveTo(new_x, new_y);
-        for (auto& ship : Objects().FindObjects<Ship>(fleet->ShipIDs())) {
+        for (auto& ship : Objects().find<Ship>(fleet->ShipIDs())) {
             if (old_sys)
                 old_sys->Remove(ship->ID());
             ship->SetSystem(INVALID_OBJECT_ID);

--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -646,7 +646,7 @@ namespace {
         return std::any_of(
             ship_ids.begin(), ship_ids.end(),
             [&pred](const int ship_id) {
-                const auto& ship = Objects().at<const Ship>(ship_id);
+                const auto& ship = Objects().get<const Ship>(ship_id);
                 if (!ship) {
                     WarnLogger() << "Object map is missing ship with expected id " << ship_id;
                     return false;

--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -30,7 +30,7 @@ namespace {
     void MoveFleetWithShips(Fleet& fleet, double x, double y){
         fleet.MoveTo(x, y);
 
-        for (auto& ship : Objects().FindObjects<Ship>(fleet.ShipIDs())) {
+        for (auto& ship : Objects().find<Ship>(fleet.ShipIDs())) {
             ship->MoveTo(x, y);
         }
     }
@@ -38,7 +38,7 @@ namespace {
     void InsertFleetWithShips(Fleet& fleet, std::shared_ptr<System>& system){
         system->Insert(fleet.shared_from_this());
 
-        for (auto& ship : Objects().FindObjects<Ship>(fleet.ShipIDs())) {
+        for (auto& ship : Objects().find<Ship>(fleet.ShipIDs())) {
             system->Insert(ship);
         }
     }
@@ -585,7 +585,7 @@ float Fleet::Fuel() const {
     float fuel = Meter::LARGE_VALUE;
     bool is_fleet_scrapped = true;
 
-    for (auto& ship : Objects().FindObjects<const Ship>(m_ships)) {
+    for (auto& ship : Objects().find<const Ship>(m_ships)) {
         const Meter* meter = ship->UniverseObject::GetMeter(METER_FUEL);
         if (!meter) {
             ErrorLogger() << "Fleet::Fuel skipping ship with no fuel meter";
@@ -611,7 +611,7 @@ float Fleet::MaxFuel() const {
     float max_fuel = Meter::LARGE_VALUE;
     bool is_fleet_scrapped = true;
 
-    for (auto& ship : Objects().FindObjects<const Ship>(m_ships)) {
+    for (auto& ship : Objects().find<const Ship>(m_ships)) {
         const Meter* meter = ship->UniverseObject::GetMeter(METER_MAX_FUEL);
         if (!meter) {
             ErrorLogger() << "Fleet::MaxFuel skipping ship with no max fuel meter";
@@ -641,12 +641,12 @@ namespace {
                    const std::set<int>& ship_ids)
     {
         // Searching for each Ship one at a time is faster than
-        // FindObjects(ship_ids), because an early exit avoids searching the
+        // find(ship_ids), because an early exit avoids searching the
         // remaining ids.
         return std::any_of(
             ship_ids.begin(), ship_ids.end(),
             [&pred](const int ship_id) {
-                const auto& ship = Objects().Object<const Ship>(ship_id);
+                const auto& ship = Objects().at<const Ship>(ship_id);
                 if (!ship) {
                     WarnLogger() << "Object map is missing ship with expected id " << ship_id;
                     return false;
@@ -717,7 +717,7 @@ float Fleet::ResourceOutput(ResourceType type) const {
         return output;
 
     // determine resource output of each ship in this fleet
-    for (auto& ship : Objects().FindObjects<const Ship>(m_ships)) {
+    for (auto& ship : Objects().find<const Ship>(m_ships)) {
         output += ship->CurrentMeterValue(meter_type);
     }
     return output;
@@ -796,7 +796,7 @@ void Fleet::MovementPhase() {
         supply_unobstructed_systems.insert(empire->SupplyUnobstructedSystems().begin(),
                                            empire->SupplyUnobstructedSystems().end());
 
-    auto ships = Objects().FindObjects<Ship>(m_ships);
+    auto ships = Objects().find<Ship>(m_ships);
 
     // if owner of fleet can resupply ships at the location of this fleet, then
     // resupply all ships in this fleet
@@ -1222,18 +1222,18 @@ bool Fleet::BlockadedAtSystem(int start_system_id, int dest_system_id) const {
     }
 
     float lowest_ship_stealth = 99999.9f; // arbitrary large number. actual stealth of ships should be less than this...
-    for (auto& ship : Objects().FindObjects<const Ship>(this->ShipIDs())) {
+    for (auto& ship : Objects().find<const Ship>(this->ShipIDs())) {
         if (lowest_ship_stealth > ship->CurrentMeterValue(METER_STEALTH))
             lowest_ship_stealth = ship->CurrentMeterValue(METER_STEALTH);
     }
 
     float monster_detection = 0.0f;
-    auto fleets = Objects().FindObjects<const Fleet>(current_system->FleetIDs());
+    auto fleets = Objects().find<const Fleet>(current_system->FleetIDs());
     for (auto& fleet : fleets) {
         if (!fleet->Unowned())
             continue;
 
-        for (auto& ship : Objects().FindObjects<const Ship>(fleet->ShipIDs())) {
+        for (auto& ship : Objects().find<const Ship>(fleet->ShipIDs())) {
             float cur_detection = ship->CurrentMeterValue(METER_DETECTION);
             if (cur_detection >= monster_detection)
                 monster_detection = cur_detection;

--- a/universe/ObjectMap.cpp
+++ b/universe/ObjectMap.cpp
@@ -37,18 +37,18 @@
 
 namespace {
     template<class T>
-    static void ClearMap(std::map<int, std::shared_ptr<T>>& map)
+    static void ClearMap(ObjectMap::container_type<T>& map)
     { map.clear(); }
 
     template <class T>
-    static void TryInsertIntoMap(std::map<int, std::shared_ptr<T>>& map, std::shared_ptr<UniverseObject> item)
+    static void TryInsertIntoMap(ObjectMap::container_type<T>& map, std::shared_ptr<UniverseObject> item)
     {
         if (dynamic_cast<T*>(item.get()))
             map[item->ID()] = std::dynamic_pointer_cast<T, UniverseObject>(item);
     }
 
     template<class T>
-    void EraseFromMap(std::map<int, std::shared_ptr<T>>& map, int id)
+    void EraseFromMap(ObjectMap::container_type<T>& map, int id)
     { map.erase(id); }
 }
 
@@ -370,79 +370,79 @@ std::shared_ptr<UniverseObject> ObjectMap::ExistingObject(int id) {
 // Static helpers
 
 template<class T>
-void ObjectMap::SwapMap(std::map<int, std::shared_ptr<T>>& map, ObjectMap& rhs)
+void ObjectMap::SwapMap(ObjectMap::container_type<T>& map, ObjectMap& rhs)
 { map.swap(rhs.Map<T>()); }
 
 // template specializations
 
 template <>
-const std::map<int, std::shared_ptr<UniverseObject>>& ObjectMap::Map() const
+const ObjectMap::container_type<UniverseObject>& ObjectMap::Map() const
 { return m_objects; }
 
 template <>
-const std::map<int, std::shared_ptr<ResourceCenter>>& ObjectMap::Map() const
+const ObjectMap::container_type<ResourceCenter>& ObjectMap::Map() const
 { return m_resource_centers; }
 
 template <>
-const std::map<int, std::shared_ptr<PopCenter>>& ObjectMap::Map() const
+const ObjectMap::container_type<PopCenter>& ObjectMap::Map() const
 { return m_pop_centers; }
 
 template <>
-const std::map<int, std::shared_ptr<Ship>>& ObjectMap::Map() const
+const ObjectMap::container_type<Ship>& ObjectMap::Map() const
 { return m_ships; }
 
 template <>
-const std::map<int, std::shared_ptr<Fleet>>& ObjectMap::Map() const
+const ObjectMap::container_type<Fleet>& ObjectMap::Map() const
 { return m_fleets; }
 
 template <>
-const std::map<int, std::shared_ptr<Planet>>& ObjectMap::Map() const
+const ObjectMap::container_type<Planet>& ObjectMap::Map() const
 { return m_planets; }
 
 template <>
-const std::map<int, std::shared_ptr<System>>& ObjectMap::Map() const
+const ObjectMap::container_type<System>& ObjectMap::Map() const
 { return m_systems; }
 
 template <>
-const std::map<int, std::shared_ptr<Building>>& ObjectMap::Map() const
+const ObjectMap::container_type<Building>& ObjectMap::Map() const
 { return m_buildings; }
 
 template <>
-const std::map<int, std::shared_ptr<Field>>& ObjectMap::Map() const
+const ObjectMap::container_type<Field>& ObjectMap::Map() const
 { return m_fields; }
 
 template <>
-std::map<int, std::shared_ptr<UniverseObject>>& ObjectMap::Map()
+ObjectMap::container_type<UniverseObject>& ObjectMap::Map()
 { return m_objects; }
 
 template <>
-std::map<int, std::shared_ptr<ResourceCenter>>& ObjectMap::Map()
+ObjectMap::container_type<ResourceCenter>& ObjectMap::Map()
 { return m_resource_centers; }
 
 template <>
-std::map<int, std::shared_ptr<PopCenter>>& ObjectMap::Map()
+ObjectMap::container_type<PopCenter>& ObjectMap::Map()
 { return m_pop_centers; }
 
 template <>
-std::map<int, std::shared_ptr<Ship>>& ObjectMap::Map()
+ObjectMap::container_type<Ship>& ObjectMap::Map()
 { return m_ships; }
 
 template <>
-std::map<int, std::shared_ptr<Fleet>>& ObjectMap::Map()
+ObjectMap::container_type<Fleet>& ObjectMap::Map()
 { return m_fleets; }
 
 template <>
-std::map<int, std::shared_ptr<Planet>>& ObjectMap::Map()
+ObjectMap::container_type<Planet>& ObjectMap::Map()
 { return m_planets; }
 
 template <>
-std::map<int, std::shared_ptr<System>>& ObjectMap::Map()
+ObjectMap::container_type<System>& ObjectMap::Map()
 { return m_systems; }
 
 template <>
-std::map<int, std::shared_ptr<Building>>& ObjectMap::Map()
+ObjectMap::container_type<Building>& ObjectMap::Map()
 { return m_buildings; }
 
 template <>
-std::map<int, std::shared_ptr<Field>>& ObjectMap::Map()
+ObjectMap::container_type<Field>& ObjectMap::Map()
 { return m_fields; }

--- a/universe/ObjectMap.cpp
+++ b/universe/ObjectMap.cpp
@@ -49,7 +49,7 @@ void ObjectMap::Copy(const ObjectMap& copied_map, int empire_id/* = ALL_EMPIRES*
 
     // loop through objects in copied map, copying or cloning each depending
     // on whether there already is a corresponding object in this map
-    for (const_iterator<> it = copied_map.begin(); it != copied_map.end(); ++it)
+    for (const_iterator<UniverseObject> it = copied_map.begin(); it != copied_map.end(); ++it)
         this->CopyObject(*it, empire_id);
 }
 
@@ -90,52 +90,6 @@ int ObjectMap::NumObjects() const
 bool ObjectMap::Empty() const
 { return m_objects.empty(); }
 
-std::shared_ptr<const UniverseObject> ObjectMap::Object(int id) const
-{ return Object<UniverseObject>(id); }
-
-std::shared_ptr<UniverseObject> ObjectMap::Object(int id)
-{ return Object<UniverseObject>(id); }
-
-std::vector<std::shared_ptr<const UniverseObject>> ObjectMap::FindObjects(const std::vector<int>& object_ids) const {
-    std::vector<std::shared_ptr<const UniverseObject>> result;
-    for (int object_id : object_ids)
-        if (auto obj = Object(object_id))
-            result.push_back(obj);
-        else
-            ErrorLogger() << "ObjectMap::FindObjects couldn't find object with id " << object_id;
-    return result;
-}
-
-std::vector<std::shared_ptr<const UniverseObject>> ObjectMap::FindObjects(const std::set<int>& object_ids) const {
-    std::vector<std::shared_ptr<const UniverseObject>> result;
-    for (int object_id : object_ids)
-        if (auto obj = Object(object_id))
-            result.push_back(obj);
-        else
-            ErrorLogger() << "ObjectMap::FindObjects couldn't find object with id " << object_id;
-    return result;
-}
-
-std::vector<std::shared_ptr<UniverseObject>> ObjectMap::FindObjects(const std::vector<int>& object_ids) {
-    std::vector<std::shared_ptr<UniverseObject>> result;
-    for (int object_id : object_ids)
-        if (auto obj = Object(object_id))
-            result.push_back(obj);
-        else
-            ErrorLogger() << "ObjectMap::FindObjects couldn't find object with id " << object_id;
-    return result;
-}
-
-std::vector<std::shared_ptr<UniverseObject>> ObjectMap::FindObjects(const std::set<int>& object_ids) {
-    std::vector<std::shared_ptr<UniverseObject>> result;
-    for (int object_id : object_ids)
-        if (auto obj = Object(object_id))
-            result.push_back(obj);
-        else
-            ErrorLogger() << "ObjectMap::FindObjects couldn't find object with id " << object_id;
-    return result;
-}
-
 std::vector<std::shared_ptr<const UniverseObject>> ObjectMap::FindObjects(const UniverseObjectVisitor& visitor) const {
     std::vector<std::shared_ptr<const UniverseObject>> result;
     for (auto it = begin(); it != end(); ++it) {
@@ -171,18 +125,6 @@ int ObjectMap::HighestObjectID() const {
         return INVALID_OBJECT_ID;
     return m_objects.rbegin()->first;
 }
-
-ObjectMap::iterator<> ObjectMap::begin()
-{ return begin<UniverseObject>(); }
-
-ObjectMap::iterator<> ObjectMap::end()
-{ return end<UniverseObject>(); }
-
-ObjectMap::const_iterator<> ObjectMap::begin() const
-{ return begin<UniverseObject>(); }
-
-ObjectMap::const_iterator<> ObjectMap::end() const
-{ return end<UniverseObject>(); }
 
 void ObjectMap::InsertCore(std::shared_ptr<UniverseObject> item, int empire_id/* = ALL_EMPIRES*/) {
     FOR_EACH_MAP(TryInsertIntoMap, item);
@@ -394,7 +336,7 @@ void ObjectMap::CopyObjectsToSpecializedMaps() {
 std::string ObjectMap::Dump(unsigned short ntabs) const {
     std::ostringstream dump_stream;
     dump_stream << "ObjectMap contains UniverseObjects: " << std::endl;
-    for (const_iterator<> it = begin(); it != end(); ++it)
+    for (const_iterator<UniverseObject> it = begin(); it != end(); ++it)
         dump_stream << it->Dump(ntabs) << std::endl;
     dump_stream << std::endl;
     return dump_stream.str();

--- a/universe/ObjectMap.cpp
+++ b/universe/ObjectMap.cpp
@@ -106,18 +106,6 @@ ObjectMap* ObjectMap::Clone(int empire_id) const {
 bool ObjectMap::empty() const
 { return m_objects.empty(); }
 
-std::vector<int> ObjectMap::FindObjectIDs(const UniverseObjectVisitor& visitor) const {
-    std::vector<int> result;
-    for (auto obj : *this) {
-        if (obj->Accept(visitor))
-            result.push_back(obj->ID());
-    }
-    return result;
-}
-
-std::vector<int> ObjectMap::FindObjectIDs() const
-{ return FindObjectIDs<UniverseObject>(); }
-
 int ObjectMap::HighestObjectID() const {
     if (m_objects.empty())
         return INVALID_OBJECT_ID;

--- a/universe/ObjectMap.cpp
+++ b/universe/ObjectMap.cpp
@@ -106,24 +106,6 @@ ObjectMap* ObjectMap::Clone(int empire_id) const {
 bool ObjectMap::empty() const
 { return m_objects.empty(); }
 
-std::vector<std::shared_ptr<const UniverseObject>> ObjectMap::find(const UniverseObjectVisitor& visitor) const {
-    std::vector<std::shared_ptr<const UniverseObject>> result;
-    for (auto obj : *this) {
-        if (obj->Accept(visitor))
-            result.push_back(at(obj->ID()));
-    }
-    return result;
-}
-
-std::vector<std::shared_ptr<UniverseObject>> ObjectMap::find(const UniverseObjectVisitor& visitor) {
-    std::vector<std::shared_ptr<UniverseObject>> result;
-    for (const auto& obj : *this) {
-        if (std::shared_ptr<UniverseObject> match = obj->Accept(visitor))
-            result.push_back(at(match->ID()));
-    }
-    return result;
-}
-
 std::vector<int> ObjectMap::FindObjectIDs(const UniverseObjectVisitor& visitor) const {
     std::vector<int> result;
     for (auto obj : *this) {

--- a/universe/ObjectMap.cpp
+++ b/universe/ObjectMap.cpp
@@ -34,6 +34,25 @@
                                             f(m_existing_buildings, ##__VA_ARGS__);        \
                                             f(m_existing_fields, ##__VA_ARGS__); }
 
+
+namespace {
+    template<class T>
+    static void ClearMap(std::map<int, std::shared_ptr<T>>& map)
+    { map.clear(); }
+
+    template <class T>
+    static void TryInsertIntoMap(std::map<int, std::shared_ptr<T>>& map, std::shared_ptr<UniverseObject> item)
+    {
+        if (dynamic_cast<T*>(item.get()))
+            map[item->ID()] = std::dynamic_pointer_cast<T, UniverseObject>(item);
+    }
+
+    template<class T>
+    void EraseFromMap(std::map<int, std::shared_ptr<T>>& map, int id)
+    { map.erase(id); }
+}
+
+
 /////////////////////////////////////////////
 // class ObjectMap
 /////////////////////////////////////////////
@@ -351,24 +370,8 @@ std::shared_ptr<UniverseObject> ObjectMap::ExistingObject(int id) {
 // Static helpers
 
 template<class T>
-void ObjectMap::EraseFromMap(std::map<int, std::shared_ptr<T>>& map, int id)
-{ map.erase(id); }
-
-template<class T>
-void ObjectMap::ClearMap(std::map<int, std::shared_ptr<T>>& map)
-{ map.clear(); }
-
-template<class T>
 void ObjectMap::SwapMap(std::map<int, std::shared_ptr<T>>& map, ObjectMap& rhs)
 { map.swap(rhs.Map<T>()); }
-
-template <class T>
-void ObjectMap::TryInsertIntoMap(std::map<int, std::shared_ptr<T>>& map,
-                                 std::shared_ptr<UniverseObject> item)
-{
-    if (dynamic_cast<T*>(item.get()))
-        map[item->ID()] = std::dynamic_pointer_cast<T, UniverseObject>(item);
-}
 
 // template specializations
 

--- a/universe/ObjectMap.cpp
+++ b/universe/ObjectMap.cpp
@@ -90,7 +90,7 @@ void ObjectMap::CopyObject(std::shared_ptr<const UniverseObject> source, int emp
     if (GetUniverse().GetObjectVisibilityByEmpire(source_id, empire_id) <= VIS_NO_VISIBILITY)
         return;
 
-    if (std::shared_ptr<UniverseObject> destination = this->at(source_id)) {
+    if (auto destination = this->get(source_id)) {
         destination->Copy(source, empire_id); // there already is a version of this object present in this ObjectMap, so just update it
     } else {
         insertCore(std::shared_ptr<UniverseObject>(source->Clone()), empire_id); // this object is not yet present in this ObjectMap, so add a new UniverseObject object for it
@@ -117,7 +117,7 @@ void ObjectMap::insertCore(std::shared_ptr<UniverseObject> item, int empire_id/*
     if (item &&
         !GetUniverse().EmpireKnownDestroyedObjectIDs(empire_id).count(item->ID()))
     {
-        auto this_item = this->at(item->ID());
+        auto this_item = this->get(item->ID());
         m_existing_objects[item->ID()] = this_item;
         switch (item->ObjectType()) {
             case OBJ_BUILDING:
@@ -203,7 +203,7 @@ void ObjectMap::UpdateCurrentDestroyedObjects(const std::set<int>& destroyed_obj
             continue;
         if (destroyed_object_ids.count(entry.first))
             continue;
-        auto this_item = this->at(entry.first);
+        auto this_item = this->get(entry.first);
         m_existing_objects[entry.first] = this_item;
         switch (entry.second->ObjectType()) {
             case OBJ_BUILDING:
@@ -260,7 +260,7 @@ void ObjectMap::AuditContainment(const std::set<int>& destroyed_object_ids) {
             continue;
 
         // store systems' contained objects
-        if (this->at(sys_id)) { // although this is expected to be a system, can't use Object<System> here due to CopyForSerialize not copying the type-specific objects info
+        if (this->get(sys_id)) { // although this is expected to be a system, can't use Object<System> here due to CopyForSerialize not copying the type-specific objects info
             contained_objs[sys_id].insert(contained_id);
 
             if (type == OBJ_PLANET)
@@ -276,11 +276,11 @@ void ObjectMap::AuditContainment(const std::set<int>& destroyed_object_ids) {
         }
 
         // store planets' contained buildings
-        if (type == OBJ_BUILDING && this->at(alt_id))
+        if (type == OBJ_BUILDING && this->get(alt_id))
             contained_buildings[alt_id].insert(contained_id);
 
         // store fleets' contained ships
-        if (type == OBJ_SHIP && this->at(alt_id))
+        if (type == OBJ_SHIP && this->get(alt_id))
             contained_ships[alt_id].insert(contained_id);
     }
 

--- a/universe/ObjectMap.cpp
+++ b/universe/ObjectMap.cpp
@@ -49,8 +49,8 @@ void ObjectMap::Copy(const ObjectMap& copied_map, int empire_id/* = ALL_EMPIRES*
 
     // loop through objects in copied map, copying or cloning each depending
     // on whether there already is a corresponding object in this map
-    for (const_iterator<UniverseObject> it = copied_map.begin(); it != copied_map.end(); ++it)
-        this->CopyObject(*it, empire_id);
+    for (const auto& obj : copied_map)
+        this->CopyObject(obj, empire_id);
 }
 
 void ObjectMap::CopyForSerialize(const ObjectMap& copied_map) {
@@ -92,8 +92,8 @@ bool ObjectMap::Empty() const
 
 std::vector<std::shared_ptr<const UniverseObject>> ObjectMap::FindObjects(const UniverseObjectVisitor& visitor) const {
     std::vector<std::shared_ptr<const UniverseObject>> result;
-    for (auto it = begin(); it != end(); ++it) {
-        if (auto obj = it->Accept(visitor))
+    for (auto obj : *this) {
+        if (obj->Accept(visitor))
             result.push_back(Object(obj->ID()));
     }
     return result;
@@ -110,9 +110,9 @@ std::vector<std::shared_ptr<UniverseObject>> ObjectMap::FindObjects(const Univer
 
 std::vector<int> ObjectMap::FindObjectIDs(const UniverseObjectVisitor& visitor) const {
     std::vector<int> result;
-    for (auto it = begin(); it != end(); ++it) {
-        if (it->Accept(visitor))
-            result.push_back(it->ID());
+    for (auto obj : *this) {
+        if (obj->Accept(visitor))
+            result.push_back(obj->ID());
     }
     return result;
 }
@@ -328,16 +328,15 @@ void ObjectMap::AuditContainment(const std::set<int>& destroyed_object_ids) {
 
 void ObjectMap::CopyObjectsToSpecializedMaps() {
     FOR_EACH_SPECIALIZED_MAP(ClearMap);
-    for (auto it = Map<UniverseObject>().begin();
-         it != Map<UniverseObject>().end(); ++it)
-    { FOR_EACH_SPECIALIZED_MAP(TryInsertIntoMap, it->second); }
+    for (const auto& entry : Map<UniverseObject>())
+    { FOR_EACH_SPECIALIZED_MAP(TryInsertIntoMap, entry.second); }
 }
 
 std::string ObjectMap::Dump(unsigned short ntabs) const {
     std::ostringstream dump_stream;
     dump_stream << "ObjectMap contains UniverseObjects: " << std::endl;
-    for (const_iterator<UniverseObject> it = begin(); it != end(); ++it)
-        dump_stream << it->Dump(ntabs) << std::endl;
+    for (const auto& obj : *this)
+        dump_stream << obj->Dump(ntabs) << std::endl;
     dump_stream << std::endl;
     return dump_stream.str();
 }

--- a/universe/ObjectMap.h
+++ b/universe/ObjectMap.h
@@ -171,57 +171,54 @@ public:
     //@}
 
     /** \name Accessors */ //@{
-    /** Returns number of objects in this ObjectMap */
-    int NumObjects() const;
-
     /** Returns the number of objects of the specified class in this ObjectMap. */
-    template <class T>
-    int NumObjects() const;
+    template <class T=UniverseObject>
+    int size() const;
 
     /** Returns true if this ObjectMap contains no objects */
-    bool Empty() const;
+    bool empty() const;
 
     /** Returns a pointer to the object of type T with ID number \a id.
       * Returns a null std::shared_ptr if none exists or the object with
       * ID \a id is not of type T. */
     template <class T = UniverseObject>
-    std::shared_ptr<const T> Object(int id) const;
+    std::shared_ptr<const T> at(int id) const;
 
     /** Returns a pointer to the object of type T with ID number \a id.
       * Returns a null std::shared_ptr if none exists or the object with
       * ID \a id is not of type T. */
     template <class T = UniverseObject>
-    std::shared_ptr<T> Object(int id);
+    std::shared_ptr<T> at(int id);
 
     /** Returns a vector containing the objects with ids in \a object_ids that
       * are of type T */
     template <class T = UniverseObject>
-    std::vector<std::shared_ptr<const T>> FindObjects(const std::vector<int>& object_ids) const;
+    std::vector<std::shared_ptr<const T>> find(const std::vector<int>& object_ids) const;
 
     template <class T = UniverseObject>
-    std::vector<std::shared_ptr<const T>> FindObjects(const std::set<int>& object_ids) const;
+    std::vector<std::shared_ptr<const T>> find(const std::set<int>& object_ids) const;
 
     /** Returns a vector containing the objects with ids in \a object_ids that
       * are of type T */
     template <class T = UniverseObject>
-    std::vector<std::shared_ptr<T>> FindObjects(const std::vector<int>& object_ids);
+    std::vector<std::shared_ptr<T>> find(const std::vector<int>& object_ids);
 
     template <class T = UniverseObject>
-    std::vector<std::shared_ptr<T>> FindObjects(const std::set<int>& object_ids);
+    std::vector<std::shared_ptr<T>> find(const std::set<int>& object_ids);
 
     /** Returns all the objects that match \a visitor */
-    std::vector<std::shared_ptr<const UniverseObject>> FindObjects(const UniverseObjectVisitor& visitor) const;
+    std::vector<std::shared_ptr<const UniverseObject>> find(const UniverseObjectVisitor& visitor) const;
 
     /** Returns all the objects that match \a visitor */
-    std::vector<std::shared_ptr<UniverseObject>> FindObjects(const UniverseObjectVisitor& visitor);
+    std::vector<std::shared_ptr<UniverseObject>> find(const UniverseObjectVisitor& visitor);
 
     /** Returns all the objects of type T */
     template <class T = UniverseObject>
-    std::vector<std::shared_ptr<const T>> FindObjects() const;
+    std::vector<std::shared_ptr<const T>> all() const;
 
     /** Returns all the objects of type T */
     template <class T = UniverseObject>
-    std::vector<std::shared_ptr<T>> FindObjects();
+    std::vector<std::shared_ptr<T>> all();
 
     /** Returns the IDs of all the objects that match \a visitor */
     std::vector<int>        FindObjectIDs(const UniverseObjectVisitor& visitor) const;
@@ -309,18 +306,18 @@ public:
       * If there already was an object in the map with the id \a id then
       * that object will be removed. */
     template <class T>
-    void Insert(std::shared_ptr<T> obj, int empire_id = ALL_EMPIRES);
+    void insert(std::shared_ptr<T> obj, int empire_id = ALL_EMPIRES);
 
     /** Removes object with id \a id from map, and returns that object, if
       * there was an object under that ID in the map.  If no such object
       * existed in the map, a null shared_ptr is returned and nothing is
       * removed. The ObjectMap will no longer share ownership of the
       * returned object. */
-    std::shared_ptr<UniverseObject> Remove(int id);
+    std::shared_ptr<UniverseObject> erase(int id);
 
     /** Empties map, removing shared ownership by this map of all
       * previously contained objects. */
-    void Clear();
+    void clear();
 
     /** Swaps the contents of *this with \a rhs. */
     void swap(ObjectMap& rhs);
@@ -337,7 +334,7 @@ public:
     //@}
 
 private:
-    void InsertCore(std::shared_ptr<UniverseObject> item, int empire_id = ALL_EMPIRES);
+    void insertCore(std::shared_ptr<UniverseObject> item, int empire_id = ALL_EMPIRES);
 
     void CopyObjectsToSpecializedMaps();
 
@@ -392,7 +389,7 @@ ObjectMap::const_iterator<T> ObjectMap::end() const
 { return const_iterator<T>(Map<typename std::remove_const<T>::type>().end(), *this); }
 
 template <class T>
-std::shared_ptr<const T> ObjectMap::Object(int id) const {
+std::shared_ptr<const T> ObjectMap::at(int id) const {
     auto it = Map<typename std::remove_const<T>::type>().find(id);
     return std::shared_ptr<const T>(
         it != Map<typename std::remove_const<T>::type>().end()
@@ -401,7 +398,7 @@ std::shared_ptr<const T> ObjectMap::Object(int id) const {
 }
 
 template <class T>
-std::shared_ptr<T> ObjectMap::Object(int id) {
+std::shared_ptr<T> ObjectMap::at(int id) {
     auto it = Map<typename std::remove_const<T>::type>().find(id);
     return std::shared_ptr<T>(
         it != Map<typename std::remove_const<T>::type>().end()
@@ -410,7 +407,7 @@ std::shared_ptr<T> ObjectMap::Object(int id) {
 }
 
 template <class T>
-std::vector<std::shared_ptr<const T>> ObjectMap::FindObjects() const {
+std::vector<std::shared_ptr<const T>> ObjectMap::all() const {
     std::vector<std::shared_ptr<const T>> result;
     for (const auto& entry : Map<T>())
         result.push_back(entry.second);
@@ -418,7 +415,7 @@ std::vector<std::shared_ptr<const T>> ObjectMap::FindObjects() const {
 }
 
 template <class T>
-std::vector<std::shared_ptr<T>> ObjectMap::FindObjects() {
+std::vector<std::shared_ptr<T>> ObjectMap::all() {
     std::vector<std::shared_ptr<T>> result;
     for (const auto& entry : Map<T>())
         result.push_back(entry.second);
@@ -434,7 +431,7 @@ std::vector<int> ObjectMap::FindObjectIDs() const {
 }
 
 template <class T>
-std::vector<std::shared_ptr<const T>> ObjectMap::FindObjects(const std::vector<int>& object_ids) const {
+std::vector<std::shared_ptr<const T>> ObjectMap::find(const std::vector<int>& object_ids) const {
     std::vector<std::shared_ptr<const T>> retval;
     typedef typename std::remove_const<T>::type mutableT;
     for (int object_id : object_ids) {
@@ -446,7 +443,7 @@ std::vector<std::shared_ptr<const T>> ObjectMap::FindObjects(const std::vector<i
 }
 
 template <class T>
-std::vector<std::shared_ptr<const T>> ObjectMap::FindObjects(const std::set<int>& object_ids) const {
+std::vector<std::shared_ptr<const T>> ObjectMap::find(const std::set<int>& object_ids) const {
     std::vector<std::shared_ptr<const T>> retval;
     typedef typename std::remove_const<T>::type mutableT;
     for (int object_id : object_ids) {
@@ -458,7 +455,7 @@ std::vector<std::shared_ptr<const T>> ObjectMap::FindObjects(const std::set<int>
 }
 
 template <class T>
-std::vector<std::shared_ptr<T>> ObjectMap::FindObjects(const std::vector<int>& object_ids) {
+std::vector<std::shared_ptr<T>> ObjectMap::find(const std::vector<int>& object_ids) {
     std::vector<std::shared_ptr<T>> retval;
     typedef typename std::remove_const<T>::type mutableT;
     for (int object_id : object_ids) {
@@ -470,7 +467,7 @@ std::vector<std::shared_ptr<T>> ObjectMap::FindObjects(const std::vector<int>& o
 }
 
 template <class T>
-std::vector<std::shared_ptr<T>> ObjectMap::FindObjects(const std::set<int>& object_ids) {
+std::vector<std::shared_ptr<T>> ObjectMap::find(const std::set<int>& object_ids) {
     std::vector<std::shared_ptr<T>> retval;
     typedef typename std::remove_const<T>::type mutableT;
     for (int object_id : object_ids) {
@@ -482,14 +479,14 @@ std::vector<std::shared_ptr<T>> ObjectMap::FindObjects(const std::set<int>& obje
 }
 
 template <class T>
-int ObjectMap::NumObjects() const
+int ObjectMap::size() const
 { return Map<typename std::remove_const<T>::type>().size(); }
 
 template <class T>
-void ObjectMap::Insert(std::shared_ptr<T> item, int empire_id /* = ALL_EMPIRES */) {
+void ObjectMap::insert(std::shared_ptr<T> item, int empire_id /* = ALL_EMPIRES */) {
     if (!item)
         return;
-    InsertCore(std::dynamic_pointer_cast<UniverseObject>(item), empire_id);
+    insertCore(std::dynamic_pointer_cast<UniverseObject>(item), empire_id);
 }
 
 // template specializations

--- a/universe/ObjectMap.h
+++ b/universe/ObjectMap.h
@@ -33,9 +33,12 @@ FO_COMMON_API extern const int ALL_EMPIRES;
 class FO_COMMON_API ObjectMap {
 public:
     template <typename T>
-    struct iterator : private std::map<int, std::shared_ptr<T>>::iterator {
-        iterator(const typename std::map<int, std::shared_ptr<T>>::iterator& base, ObjectMap& owner) :
-            std::map<int, std::shared_ptr<T>>::iterator(base),
+    using container_type = std::map<int, std::shared_ptr<T>>;
+
+    template <typename T>
+    struct iterator : private container_type<T>::iterator {
+        iterator(const typename container_type<T>::iterator& base, ObjectMap& owner) :
+            container_type<T>::iterator(base),
             m_owner(owner)
         { Refresh(); }
 
@@ -48,34 +51,34 @@ public:
         { return m_current_ptr; }
 
         iterator& operator ++() {
-            std::map<int, std::shared_ptr<T>>::iterator::operator++();
+            container_type<T>::iterator::operator++();
             Refresh();
             return *this;
         }
 
         iterator operator ++(int) {
-            iterator result = iterator(std::map<int, std::shared_ptr<T>>::iterator::operator++(0), m_owner);
+            iterator result = iterator(container_type<T>::iterator::operator++(0), m_owner);
             Refresh();
             return result;
         }
 
         iterator& operator --() {
-            std::map<int, std::shared_ptr<T>>::iterator::operator--();
+            container_type<T>::iterator::operator--();
             Refresh();
             return *this;
         }
 
         iterator operator --(int) {
-            iterator result = iterator(std::map<int, std::shared_ptr<T>>::iterator::operator--(0), m_owner);
+            iterator result = iterator(container_type<T>::iterator::operator--(0), m_owner);
             Refresh();
             return result;
         }
 
         bool operator ==(const iterator& other) const
-        { return (typename std::map<int, std::shared_ptr<T>>::iterator(*this) == other); }
+        { return (typename container_type<T>::iterator(*this) == other); }
 
         bool operator !=(const iterator& other) const
-        { return (typename std::map<int, std::shared_ptr<T>>::iterator(*this) != other);}
+        { return (typename container_type<T>::iterator(*this) != other);}
 
     private:
         mutable std::shared_ptr<T> m_current_ptr;
@@ -86,19 +89,19 @@ public:
         // return a "null" pointer.  We assume that we are dealing with valid
         // iterators in the range [begin(), end()].
         void Refresh() const {
-            if (typename std::map<int, std::shared_ptr<T>>::iterator(*this) == (m_owner.Map<T>().end())) {
+            if (typename container_type<T>::iterator(*this) == (m_owner.Map<T>().end())) {
                 m_current_ptr = nullptr;
             } else {
-                m_current_ptr = std::shared_ptr<T>(std::map<int, std::shared_ptr<T>>::iterator::operator*().second);
+                m_current_ptr = std::shared_ptr<T>(container_type<T>::iterator::operator*().second);
             }
         }
     };
 
     template <typename T>
-    struct const_iterator : private std::map<int, std::shared_ptr<T>>::const_iterator {
-        const_iterator(const typename std::map<int, std::shared_ptr<T>>::const_iterator& base,
+    struct const_iterator : private container_type<T>::const_iterator {
+        const_iterator(const typename container_type<T>::const_iterator& base,
                        const ObjectMap& owner) :
-            std::map<int, std::shared_ptr<T>>::const_iterator(base),
+            container_type<T>::const_iterator(base),
             m_owner(owner)
         { Refresh(); }
 
@@ -111,34 +114,34 @@ public:
         { return m_current_ptr; }
 
         const_iterator& operator ++() {
-            std::map<int, std::shared_ptr<T>>::const_iterator::operator++();
+            container_type<T>::const_iterator::operator++();
             Refresh();
             return *this;
         }
 
         const_iterator operator ++(int) {
-            const_iterator result = std::map<int, std::shared_ptr<T>>::const_iterator::operator++(0);
+            const_iterator result = container_type<T>::const_iterator::operator++(0);
             Refresh();
             return result;
         }
 
         const_iterator& operator --() {
-            std::map<int, std::shared_ptr<T>>::const_iterator::operator--();
+            container_type<T>::const_iterator::operator--();
             Refresh();
             return *this;
         }
 
         const_iterator operator --(int) {
-            const_iterator result = std::map<int, std::shared_ptr<T>>::const_iterator::operator--(0);
+            const_iterator result = container_type<T>::const_iterator::operator--(0);
             Refresh();
             return result;
         }
 
         bool operator ==(const const_iterator& other) const
-        { return (typename std::map<int, std::shared_ptr<T>>::const_iterator(*this) == other); }
+        { return (typename container_type<T>::const_iterator(*this) == other); }
 
         bool operator !=(const const_iterator& other) const
-        { return (typename std::map<int, std::shared_ptr<T>>::const_iterator(*this) != other); }
+        { return (typename container_type<T>::const_iterator(*this) != other); }
 
     private:
         // See iterator for comments.
@@ -149,10 +152,10 @@ public:
         // Otherwise, we just want to return a "null" pointer.  We assume that we are dealing with valid iterators in
         // the range [begin(), end()].
         void Refresh() const {
-            if (typename std::map<int, std::shared_ptr<T>>::const_iterator(*this) == (m_owner.Map<T>().end())) {
+            if (typename container_type<T>::const_iterator(*this) == (m_owner.Map<T>().end())) {
                 m_current_ptr = nullptr;
             } else {
-                m_current_ptr = std::shared_ptr<T>(std::map<int, std::shared_ptr<T>>::const_iterator::operator*().second);
+                m_current_ptr = std::shared_ptr<T>(container_type<T>::const_iterator::operator*().second);
             }
         }
     };
@@ -250,23 +253,23 @@ public:
 
     /**  */
     std::shared_ptr<UniverseObject> ExistingObject(int id);
-    const std::map<int, std::shared_ptr<UniverseObject>>& ExistingObjects()
+    const container_type<UniverseObject>& ExistingObjects()
     { return m_existing_objects; }
-    const std::map<int, std::shared_ptr<UniverseObject>>& ExistingResourceCenters()
+    const container_type<UniverseObject>& ExistingResourceCenters()
     { return m_existing_resource_centers; }
-    const std::map<int, std::shared_ptr<UniverseObject>>& ExistingPopCenters()
+    const container_type<UniverseObject>& ExistingPopCenters()
     { return m_existing_pop_centers; }
-    const std::map<int, std::shared_ptr<UniverseObject>>& ExistingShips()
+    const container_type<UniverseObject>& ExistingShips()
     { return m_existing_ships; }
-    const std::map<int, std::shared_ptr<UniverseObject>>& ExistingFleets()
+    const container_type<UniverseObject>& ExistingFleets()
     { return m_existing_fleets; }
-    const std::map<int, std::shared_ptr<UniverseObject>>& ExistingPlanets()
+    const container_type<UniverseObject>& ExistingPlanets()
     { return m_existing_planets; }
-    const std::map<int, std::shared_ptr<UniverseObject>>& ExistingSystems()
+    const container_type<UniverseObject>& ExistingSystems()
     { return m_existing_systems; }
-    const std::map<int, std::shared_ptr<UniverseObject>>& ExistingBuildings()
+    const container_type<UniverseObject>& ExistingBuildings()
     { return m_existing_buildings; }
-    const std::map<int, std::shared_ptr<UniverseObject>>& ExistingFields()
+    const container_type<UniverseObject>& ExistingFields()
     { return m_existing_fields; }
 
     //@}
@@ -339,33 +342,33 @@ private:
     void CopyObjectsToSpecializedMaps();
 
     template <class T>
-    const std::map<int, std::shared_ptr<T>>& Map() const;
+    const container_type<T>& Map() const;
 
     template <class T>
-    std::map<int, std::shared_ptr<T>>& Map();
+    container_type<T>& Map();
 
     template <class T>
-    static void SwapMap(std::map<int, std::shared_ptr<T>>& map, ObjectMap& rhs);
+    static void SwapMap(container_type<T>& map, ObjectMap& rhs);
 
-    std::map<int, std::shared_ptr<UniverseObject>> m_objects;
-    std::map<int, std::shared_ptr<ResourceCenter>> m_resource_centers;
-    std::map<int, std::shared_ptr<PopCenter>> m_pop_centers;
-    std::map<int, std::shared_ptr<Ship>> m_ships;
-    std::map<int, std::shared_ptr<Fleet>> m_fleets;
-    std::map<int, std::shared_ptr<Planet>> m_planets;
-    std::map<int, std::shared_ptr<System>> m_systems;
-    std::map<int, std::shared_ptr<Building>> m_buildings;
-    std::map<int, std::shared_ptr<Field>> m_fields;
+    container_type<UniverseObject> m_objects;
+    container_type<ResourceCenter> m_resource_centers;
+    container_type<PopCenter> m_pop_centers;
+    container_type<Ship> m_ships;
+    container_type<Fleet> m_fleets;
+    container_type<Planet> m_planets;
+    container_type<System> m_systems;
+    container_type<Building> m_buildings;
+    container_type<Field> m_fields;
 
-    std::map<int, std::shared_ptr<UniverseObject>> m_existing_objects;
-    std::map<int, std::shared_ptr<UniverseObject>> m_existing_resource_centers;
-    std::map<int, std::shared_ptr<UniverseObject>> m_existing_pop_centers;
-    std::map<int, std::shared_ptr<UniverseObject>> m_existing_ships;
-    std::map<int, std::shared_ptr<UniverseObject>> m_existing_fleets;
-    std::map<int, std::shared_ptr<UniverseObject>> m_existing_planets;
-    std::map<int, std::shared_ptr<UniverseObject>> m_existing_systems;
-    std::map<int, std::shared_ptr<UniverseObject>> m_existing_buildings;
-    std::map<int, std::shared_ptr<UniverseObject>> m_existing_fields;
+    container_type<UniverseObject> m_existing_objects;
+    container_type<UniverseObject> m_existing_resource_centers;
+    container_type<UniverseObject> m_existing_pop_centers;
+    container_type<UniverseObject> m_existing_ships;
+    container_type<UniverseObject> m_existing_fleets;
+    container_type<UniverseObject> m_existing_planets;
+    container_type<UniverseObject> m_existing_systems;
+    container_type<UniverseObject> m_existing_buildings;
+    container_type<UniverseObject> m_existing_fields;
 
     friend class boost::serialization::access;
     template <class Archive>
@@ -492,57 +495,57 @@ void ObjectMap::Insert(std::shared_ptr<T> item, int empire_id /* = ALL_EMPIRES *
 // template specializations
 
 template <>
-FO_COMMON_API const std::map<int, std::shared_ptr<UniverseObject>>& ObjectMap::Map() const;
+FO_COMMON_API const ObjectMap::container_type<UniverseObject>& ObjectMap::Map() const;
 
 template <>
-FO_COMMON_API const std::map<int, std::shared_ptr<ResourceCenter>>& ObjectMap::Map() const;
+FO_COMMON_API const ObjectMap::container_type<ResourceCenter>& ObjectMap::Map() const;
 
 template <>
-FO_COMMON_API const std::map<int, std::shared_ptr<PopCenter>>& ObjectMap::Map() const;
+FO_COMMON_API const ObjectMap::container_type<PopCenter>& ObjectMap::Map() const;
 
 template <>
-FO_COMMON_API const std::map<int, std::shared_ptr<Ship>>& ObjectMap::Map() const;
+FO_COMMON_API const ObjectMap::container_type<Ship>& ObjectMap::Map() const;
 
 template <>
-FO_COMMON_API const std::map<int, std::shared_ptr<Fleet>>& ObjectMap::Map() const;
+FO_COMMON_API const ObjectMap::container_type<Fleet>& ObjectMap::Map() const;
 
 template <>
-FO_COMMON_API const std::map<int, std::shared_ptr<Planet>>& ObjectMap::Map() const;
+FO_COMMON_API const ObjectMap::container_type<Planet>& ObjectMap::Map() const;
 
 template <>
-FO_COMMON_API const std::map<int, std::shared_ptr<System>>& ObjectMap::Map() const;
+FO_COMMON_API const ObjectMap::container_type<System>& ObjectMap::Map() const;
 
 template <>
-FO_COMMON_API const std::map<int, std::shared_ptr<Building>>& ObjectMap::Map() const;
+FO_COMMON_API const ObjectMap::container_type<Building>& ObjectMap::Map() const;
 
 template <>
-FO_COMMON_API const std::map<int, std::shared_ptr<Field>>& ObjectMap::Map() const;
+FO_COMMON_API const ObjectMap::container_type<Field>& ObjectMap::Map() const;
 
 template <>
-FO_COMMON_API std::map<int, std::shared_ptr<UniverseObject>>& ObjectMap::Map();
+FO_COMMON_API ObjectMap::container_type<UniverseObject>& ObjectMap::Map();
 
 template <>
-FO_COMMON_API std::map<int, std::shared_ptr<ResourceCenter>>& ObjectMap::Map();
+FO_COMMON_API ObjectMap::container_type<ResourceCenter>& ObjectMap::Map();
 
 template <>
-FO_COMMON_API std::map<int, std::shared_ptr<PopCenter>>& ObjectMap::Map();
+FO_COMMON_API ObjectMap::container_type<PopCenter>& ObjectMap::Map();
 
 template <>
-FO_COMMON_API std::map<int, std::shared_ptr<Ship>>& ObjectMap::Map();
+FO_COMMON_API ObjectMap::container_type<Ship>& ObjectMap::Map();
 
 template <>
-FO_COMMON_API std::map<int, std::shared_ptr<Fleet>>& ObjectMap::Map();
+FO_COMMON_API ObjectMap::container_type<Fleet>& ObjectMap::Map();
 
 template <>
-FO_COMMON_API std::map<int, std::shared_ptr<Planet>>& ObjectMap::Map();
+FO_COMMON_API ObjectMap::container_type<Planet>& ObjectMap::Map();
 
 template <>
-FO_COMMON_API std::map<int, std::shared_ptr<System>>& ObjectMap::Map();
+FO_COMMON_API ObjectMap::container_type<System>& ObjectMap::Map();
 
 template <>
-FO_COMMON_API std::map<int, std::shared_ptr<Building>>& ObjectMap::Map();
+FO_COMMON_API ObjectMap::container_type<Building>& ObjectMap::Map();
 
 template <>
-FO_COMMON_API std::map<int, std::shared_ptr<Field>>& ObjectMap::Map();
+FO_COMMON_API ObjectMap::container_type<Field>& ObjectMap::Map();
 
 #endif

--- a/universe/ObjectMap.h
+++ b/universe/ObjectMap.h
@@ -32,7 +32,7 @@ FO_COMMON_API extern const int ALL_EMPIRES;
 /** Contains a set of objects that make up a (known or complete) Universe. */
 class FO_COMMON_API ObjectMap {
 public:
-    template <class T = UniverseObject>
+    template <typename T>
     struct iterator : private std::map<int, std::shared_ptr<T>>::iterator {
         iterator(const typename std::map<int, std::shared_ptr<T>>::iterator& base, ObjectMap& owner) :
             std::map<int, std::shared_ptr<T>>::iterator(base),
@@ -94,7 +94,7 @@ public:
         }
     };
 
-    template <class T = UniverseObject>
+    template <typename T>
     struct const_iterator : private std::map<int, std::shared_ptr<T>>::const_iterator {
         const_iterator(const typename std::map<int, std::shared_ptr<T>>::const_iterator& base,
                        const ObjectMap& owner) :
@@ -178,48 +178,32 @@ public:
     /** Returns true if this ObjectMap contains no objects */
     bool Empty() const;
 
-    /** Returns a pointer to the universe object with ID number \a id,
-      * or a null std::shared_ptr if none exists */
-    std::shared_ptr<const UniverseObject> Object(int id) const;
-
-    /** Returns a pointer to the universe object with ID number \a id,
-      * or a null std::shared_ptr if none exists */
-    std::shared_ptr<UniverseObject> Object(int id);
-
     /** Returns a pointer to the object of type T with ID number \a id.
       * Returns a null std::shared_ptr if none exists or the object with
       * ID \a id is not of type T. */
-    template <class T>
+    template <class T = UniverseObject>
     std::shared_ptr<const T> Object(int id) const;
 
     /** Returns a pointer to the object of type T with ID number \a id.
       * Returns a null std::shared_ptr if none exists or the object with
       * ID \a id is not of type T. */
-    template <class T>
+    template <class T = UniverseObject>
     std::shared_ptr<T> Object(int id);
-
-    /** Returns a vector containing the objects with ids in \a object_ids */
-    std::vector<std::shared_ptr<const UniverseObject>> FindObjects(const std::vector<int>& object_ids) const;
-    std::vector<std::shared_ptr<const UniverseObject>> FindObjects(const std::set<int>& object_ids) const;
-
-    /** Returns a vector containing the objects with ids in \a object_ids */
-    std::vector<std::shared_ptr<UniverseObject>> FindObjects(const std::vector<int>& object_ids);
-    std::vector<std::shared_ptr<UniverseObject>> FindObjects(const std::set<int>& object_ids);
 
     /** Returns a vector containing the objects with ids in \a object_ids that
       * are of type T */
-    template <class T>
+    template <class T = UniverseObject>
     std::vector<std::shared_ptr<const T>> FindObjects(const std::vector<int>& object_ids) const;
 
-    template <class T>
+    template <class T = UniverseObject>
     std::vector<std::shared_ptr<const T>> FindObjects(const std::set<int>& object_ids) const;
 
     /** Returns a vector containing the objects with ids in \a object_ids that
       * are of type T */
-    template <class T>
+    template <class T = UniverseObject>
     std::vector<std::shared_ptr<T>> FindObjects(const std::vector<int>& object_ids);
 
-    template <class T>
+    template <class T = UniverseObject>
     std::vector<std::shared_ptr<T>> FindObjects(const std::set<int>& object_ids);
 
     /** Returns all the objects that match \a visitor */
@@ -229,11 +213,11 @@ public:
     std::vector<std::shared_ptr<UniverseObject>> FindObjects(const UniverseObjectVisitor& visitor);
 
     /** Returns all the objects of type T */
-    template <class T>
+    template <class T = UniverseObject>
     std::vector<std::shared_ptr<const T>> FindObjects() const;
 
     /** Returns all the objects of type T */
-    template <class T>
+    template <class T = UniverseObject>
     std::vector<std::shared_ptr<T>> FindObjects();
 
     /** Returns the IDs of all the objects that match \a visitor */
@@ -253,19 +237,13 @@ public:
     int                     HighestObjectID() const;
 
     /** iterators */
-    // these first 4 are primarily for convenience
-    iterator<>              begin();
-    iterator<>              end();
-    const_iterator<>        begin() const;
-    const_iterator<>        end() const;
-
-    template <class T>
+    template <class T = UniverseObject>
     iterator<T>             begin();
-    template <class T>
+    template <class T = UniverseObject>
     iterator<T>             end();
-    template <class T>
+    template <class T = UniverseObject>
     const_iterator<T>       begin() const;
-    template <class T>
+    template <class T = UniverseObject>
     const_iterator<T>       end() const;
 
     std::string             Dump(unsigned short ntabs = 0) const;

--- a/universe/ObjectMap.h
+++ b/universe/ObjectMap.h
@@ -344,15 +344,6 @@ private:
     template <class T>
     std::map<int, std::shared_ptr<T>>& Map();
 
-    template<class T>
-    static void ClearMap(std::map<int, std::shared_ptr<T>>& map);
-
-    template <class T>
-    static void TryInsertIntoMap(std::map<int, std::shared_ptr<T>>& map, std::shared_ptr<UniverseObject> item);
-
-    template <class T>
-    static void EraseFromMap(std::map<int, std::shared_ptr<T>>& map, int id);
-
     template <class T>
     static void SwapMap(std::map<int, std::shared_ptr<T>>& map, ObjectMap& rhs);
 

--- a/universe/ObjectMap.h
+++ b/universe/ObjectMap.h
@@ -222,18 +222,8 @@ public:
     template <class T = UniverseObject>
     std::vector<std::shared_ptr<T>> all();
 
-    /** Returns the IDs of all the objects that match \a visitor */
-    std::vector<int>        FindObjectIDs(const UniverseObjectVisitor& visitor) const;
-
-    /** Returns the IDs of all the objects of type T */
-    template <class T>
-    std::vector<int>        FindObjectIDs() const;
-
     /** Returns the IDs of all objects not known to have been destroyed. */
     std::vector<int>        FindExistingObjectIDs() const;
-
-    /** Returns the IDs of all objects in this ObjectMap */
-    std::vector<int>        FindObjectIDs() const;
 
     /** Returns highest used object ID in this ObjectMap */
     int                     HighestObjectID() const;
@@ -421,14 +411,6 @@ std::vector<std::shared_ptr<T>> ObjectMap::all() {
     std::vector<std::shared_ptr<T>> result;
     for (const auto& entry : Map<T>())
         result.push_back(entry.second);
-    return result;
-}
-
-template <class T>
-std::vector<int> ObjectMap::FindObjectIDs() const {
-    std::vector<int> result;
-    for (const auto& entry : Map<T>())
-        result.push_back(entry.first);
     return result;
 }
 

--- a/universe/ObjectMap.h
+++ b/universe/ObjectMap.h
@@ -207,10 +207,12 @@ public:
     std::vector<std::shared_ptr<T>> find(const std::set<int>& object_ids);
 
     /** Returns all the objects that match \a visitor */
-    std::vector<std::shared_ptr<const UniverseObject>> find(const UniverseObjectVisitor& visitor) const;
+    template <class T = UniverseObject>
+    std::vector<std::shared_ptr<const T>> find(const UniverseObjectVisitor& visitor) const;
 
     /** Returns all the objects that match \a visitor */
-    std::vector<std::shared_ptr<UniverseObject>> find(const UniverseObjectVisitor& visitor);
+    template <class T = UniverseObject>
+    std::vector<std::shared_ptr<T>> find(const UniverseObjectVisitor& visitor);
 
     /** Returns all the objects of type T */
     template <class T = UniverseObject>
@@ -476,6 +478,28 @@ std::vector<std::shared_ptr<T>> ObjectMap::find(const std::set<int>& object_ids)
             retval.push_back(std::shared_ptr<T>(map_it->second));
     }
     return retval;
+}
+
+template <class T>
+std::vector<std::shared_ptr<const T>> ObjectMap::find(const UniverseObjectVisitor& visitor) const {
+    std::vector<std::shared_ptr<const T>> result;
+    typedef typename std::remove_const<T>::type mutableT;
+    for (auto entry : Map<mutableT>()) {
+        if (entry.second->Accept(visitor))
+            result.push_back(entry.second);
+    }
+    return result;
+}
+
+template <class T>
+std::vector<std::shared_ptr<T>> ObjectMap::find(const UniverseObjectVisitor& visitor) {
+    std::vector<std::shared_ptr<T>> result;
+    typedef typename std::remove_const<T>::type mutableT;
+    for (const auto& entry : Map<mutableT>()) {
+        if (entry.second->Accept(visitor))
+            result.push_back(entry.second);
+    }
+    return result;
 }
 
 template <class T>

--- a/universe/ObjectMap.h
+++ b/universe/ObjectMap.h
@@ -182,13 +182,13 @@ public:
       * Returns a null std::shared_ptr if none exists or the object with
       * ID \a id is not of type T. */
     template <class T = UniverseObject>
-    std::shared_ptr<const T> at(int id) const;
+    std::shared_ptr<const T> get(int id) const;
 
     /** Returns a pointer to the object of type T with ID number \a id.
       * Returns a null std::shared_ptr if none exists or the object with
       * ID \a id is not of type T. */
     template <class T = UniverseObject>
-    std::shared_ptr<T> at(int id);
+    std::shared_ptr<T> get(int id);
 
     /** Returns a vector containing the objects with ids in \a object_ids that
       * are of type T */
@@ -381,7 +381,7 @@ ObjectMap::const_iterator<T> ObjectMap::end() const
 { return const_iterator<T>(Map<typename std::remove_const<T>::type>().end(), *this); }
 
 template <class T>
-std::shared_ptr<const T> ObjectMap::at(int id) const {
+std::shared_ptr<const T> ObjectMap::get(int id) const {
     auto it = Map<typename std::remove_const<T>::type>().find(id);
     return std::shared_ptr<const T>(
         it != Map<typename std::remove_const<T>::type>().end()
@@ -390,7 +390,7 @@ std::shared_ptr<const T> ObjectMap::at(int id) const {
 }
 
 template <class T>
-std::shared_ptr<T> ObjectMap::at(int id) {
+std::shared_ptr<T> ObjectMap::get(int id) {
     auto it = Map<typename std::remove_const<T>::type>().find(id);
     return std::shared_ptr<T>(
         it != Map<typename std::remove_const<T>::type>().end()

--- a/universe/ObjectMap.h
+++ b/universe/ObjectMap.h
@@ -418,25 +418,24 @@ std::shared_ptr<T> ObjectMap::Object(int id) {
 template <class T>
 std::vector<std::shared_ptr<const T>> ObjectMap::FindObjects() const {
     std::vector<std::shared_ptr<const T>> result;
-    for (auto it = begin<T>(); it != end<T>(); ++it)
-        result.push_back(*it);
+    for (const auto& entry : Map<T>())
+        result.push_back(entry.second);
     return result;
 }
 
 template <class T>
 std::vector<std::shared_ptr<T>> ObjectMap::FindObjects() {
     std::vector<std::shared_ptr<T>> result;
-    for (auto it = begin<T>(); it != end<T>(); ++it)
-        result.push_back(*it);
+    for (const auto& entry : Map<T>())
+        result.push_back(entry.second);
     return result;
 }
 
 template <class T>
 std::vector<int> ObjectMap::FindObjectIDs() const {
     std::vector<int> result;
-    for (auto it = Map<typename std::remove_const<T>::type>().begin();
-         it != Map<typename std::remove_const<T>::type>().end(); ++it)
-    { result.push_back(it->first); }
+    for (const auto& entry : Map<T>())
+        result.push_back(entry.first);
     return result;
 }
 

--- a/universe/Pathfinder.cpp
+++ b/universe/Pathfinder.cpp
@@ -607,7 +607,7 @@ namespace {
                 }
 
                 // Discard edge if it finds a contained object or matches either system for visitor
-                for (auto object : EmpireKnownObjects(m_empire_id).FindObjects(*m_pred.get())) {
+                for (auto object : EmpireKnownObjects(m_empire_id).find(*m_pred.get())) {
                     if (!object)
                         continue;
                     // object is destination system
@@ -1354,7 +1354,7 @@ int Pathfinder::PathfinderImpl::NearestSystemTo(double x, double y) const {
     double min_dist2 = DBL_MAX;
     int min_dist2_sys_id = INVALID_OBJECT_ID;
 
-    auto systems = Objects().FindObjects<System>();
+    auto systems = Objects().all<System>();
 
     for (auto const& system : systems) {
         double xs = system->X();

--- a/universe/Planet.cpp
+++ b/universe/Planet.cpp
@@ -640,7 +640,7 @@ void Planet::Conquer(int conquerer) {
     Empire::ConquerProductionQueueItemsAtLocation(ID(), conquerer);
 
     // deal with UniverseObjects (eg. buildings) located on this planet
-    for (auto& building : Objects().FindObjects<Building>(m_buildings)) {
+    for (auto& building : Objects().find<Building>(m_buildings)) {
         const BuildingType* type = GetBuildingType(building->BuildingTypeName());
 
         // determine what to do with building of this type...
@@ -752,7 +752,7 @@ bool Planet::Colonize(int empire_id, const std::string& species_name, double pop
     SetOwner(empire_id);
 
     // if there are buildings on the planet, set the specified empire as their owner too
-    for (auto& building : Objects().FindObjects<Building>(BuildingIDs()))
+    for (auto& building : Objects().find<Building>(BuildingIDs()))
     { building->SetOwner(empire_id); }
 
     return true;

--- a/universe/System.cpp
+++ b/universe/System.cpp
@@ -570,7 +570,7 @@ std::map<int, bool> System::VisibleStarlanesWormholes(int empire_id) const {
 
     // get moving fleets owned by empire
     std::vector<std::shared_ptr<const Fleet>> moving_empire_fleets;
-    for (auto& object : objects.FindObjects(MovingFleetVisitor())) {
+    for (auto& object : objects.find(MovingFleetVisitor())) {
         if (auto fleet = std::dynamic_pointer_cast<const Fleet>(object))
             if (fleet->OwnedBy(empire_id))
                 moving_empire_fleets.push_back(fleet);

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -363,7 +363,7 @@ std::set<std::string> Universe::GetObjectVisibleSpecialsByEmpire(int object_id, 
             return std::set<std::string>();
         return object_it->second;
     } else {
-        auto obj = m_objects.at(object_id);
+        auto obj = m_objects.get(object_id);
         if (!obj)
             return std::set<std::string>();
         // all specials visible
@@ -623,7 +623,7 @@ void Universe::InitMeterEstimatesAndDiscrepancies() {
         if (m_destroyed_object_ids.count(object_id))
             continue;
         // get object
-        auto obj = m_objects.at(object_id);
+        auto obj = m_objects.get(object_id);
         if (!obj) {
             ErrorLogger() << "Universe::InitMeterEstimatesAndDiscrepancies couldn't find an object that was in the effect accounting map...?";
             continue;
@@ -692,7 +692,7 @@ void Universe::UpdateMeterEstimates(int object_id, bool update_contained_objects
         if (collected_ids.count(cur_id))
             return true;
 
-        auto cur_object = m_objects.at(cur_id);
+        auto cur_object = m_objects.get(cur_id);
         if (!cur_object) {
             ErrorLogger() << "Universe::UpdateMeterEstimates tried to get an invalid object for id " << cur_id
                           << " in container " << container_id
@@ -1805,7 +1805,7 @@ void Universe::ForgetKnownObject(int empire_id, int object_id) {
     if (objects.empty())
         return;
 
-    auto obj = objects.at(object_id);
+    auto obj = objects.get(object_id);
     if (!obj) {
         ErrorLogger() << "ForgetKnownObject empire: " << empire_id
                       << " bad object id: " << object_id;
@@ -1826,7 +1826,7 @@ void Universe::ForgetKnownObject(int empire_id, int object_id) {
 
     int container_id = obj->ContainerObjectID();
     if (container_id != INVALID_OBJECT_ID) {
-        if (auto container = objects.at(container_id)) {
+        if (auto container = objects.get(container_id)) {
             if (auto system = std::dynamic_pointer_cast<System>(container))
                 system->Remove(object_id);
             else if (auto planet = std::dynamic_pointer_cast<Planet>(container))
@@ -1913,7 +1913,7 @@ namespace {
             } else if (obj->ObjectType() == OBJ_SHIP) {
                 auto ship = std::dynamic_pointer_cast<const Ship>(obj);
                 if (ship)
-                    fleet = Objects().at<Fleet>(ship->FleetID());
+                    fleet = Objects().get<Fleet>(ship->FleetID());
             }
             if (fleet) {
                 int cur_id = fleet->SystemID();
@@ -2396,7 +2396,7 @@ namespace {
                     continue;
 
                 int object_id = obj_entry.first;
-                auto obj = objects.at(object_id);
+                auto obj = objects.get(object_id);
                 if (!obj)
                     continue;
 
@@ -2565,7 +2565,7 @@ void Universe::UpdateEmpireLatestKnownObjectsAndVisibilityTurns() {
             // update empire's latest known data about object, based on current visibility and historical visibility and knowledge of object
 
             // is there already last known version of an UniverseObject stored for this empire?
-            if (auto known_obj = known_object_map.at(object_id)) {
+            if (auto known_obj = known_object_map.get(object_id)) {
                 known_obj->Copy(full_object, empire_id);                    // already a stored version of this object for this empire.  update it, limited by visibility this empire has for this object this turn
             } else {
                 if (auto new_obj = std::shared_ptr<UniverseObject>(full_object->Clone(empire_id)))    // no previously-recorded version of this object for this empire.  create a new one, copying only the information limtied by visibility, leaving the rest as default values
@@ -2747,7 +2747,7 @@ void Universe::SetEmpireKnowledgeOfShipDesign(int ship_design_id, int empire_id)
 
 void Universe::Destroy(int object_id, bool update_destroyed_object_knowers/* = true*/) {
     // remove object from any containing UniverseObject
-    auto obj = m_objects.at(object_id);
+    auto obj = m_objects.get(object_id);
     if (!obj) {
         ErrorLogger() << "Universe::Destroy called for nonexistant object with id: " << object_id;
         return;
@@ -2774,7 +2774,7 @@ void Universe::Destroy(int object_id, bool update_destroyed_object_knowers/* = t
 std::set<int> Universe::RecursiveDestroy(int object_id) {
     std::set<int> retval;
 
-    auto obj = m_objects.at(object_id);
+    auto obj = m_objects.get(object_id);
     if (!obj) {
         DebugLogger() << "Universe::RecursiveDestroy asked to destroy nonexistant object with id " << object_id;
         return retval;
@@ -2873,7 +2873,7 @@ bool Universe::Delete(int object_id) {
     DebugLogger() << "Universe::Delete with ID: " << object_id;
     // find object amongst existing objects and delete directly, without storing
     // any info about the previous object (as is done for destroying an object)
-    auto obj = m_objects.at(object_id);
+    auto obj = m_objects.get(object_id);
     if (!obj) {
         ErrorLogger() << "Tried to delete a nonexistant object with id: " << object_id;
         return false;

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -2687,26 +2687,24 @@ void Universe::UpdateEmpireStaleObjectKnowledge() {
             bool fleet_stale = true;
             // check each ship. if any are visible or not visible but not stale,
             // fleet is not stale
-            for (int ship_id : fleet->ShipIDs()) {
-                auto ship = latest_known_objects.at<Ship>(ship_id);
-
+            for (const auto& ship : latest_known_objects.find<Ship>(fleet->ShipIDs())) {
                 // if ship doesn't think it's in this fleet, doesn't count.
                 if (!ship || ship->FleetID() != fleet_id)
                     continue;
 
                 // if ship is destroyed, doesn't count
-                if (destroyed_set.count(ship_id))
+                if (destroyed_set.count(ship->ID()))
                     continue;
 
                 // is contained ship visible? If so, fleet is not stale.
-                auto vis_it = vis_map.find(ship_id);
+                auto vis_it = vis_map.find(ship->ID());
                 if (vis_it != vis_map.end() && vis_it->second > VIS_NO_VISIBILITY) {
                     fleet_stale = false;
                     break;
                 }
 
                 // is contained ship not visible and not stale? if so, fleet is not stale
-                if (!stale_set.count(ship_id)) {
+                if (!stale_set.count(ship->ID())) {
                     fleet_stale = false;
                     break;
                 }

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -854,18 +854,10 @@ void Universe::UpdateMeterEstimatesImpl(const std::vector<int>& objects_vec, boo
 
 }
 
-void Universe::BackPropagateObjectMeters(const std::vector<int>& object_ids) {
-    // copy current meter values to initial values
-    for (auto& obj : m_objects.find(object_ids))
-        obj->BackPropagateMeters();
-}
-
 void Universe::BackPropagateObjectMeters()
 {
-    std::vector<int> result;
     for (const auto& obj : m_objects.all())
-        result.push_back(obj->ID());
-    BackPropagateObjectMeters(result);
+        obj->BackPropagateMeters();
 }
 
 namespace {

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -861,7 +861,12 @@ void Universe::BackPropagateObjectMeters(const std::vector<int>& object_ids) {
 }
 
 void Universe::BackPropagateObjectMeters()
-{ BackPropagateObjectMeters(m_objects.FindObjectIDs()); }
+{
+    std::vector<int> result;
+    for (const auto& obj : m_objects.all())
+        result.push_back(obj->ID());
+    BackPropagateObjectMeters(result);
+}
 
 namespace {
     /** Used by GetEffectsAndTargets to process a vector of effects groups.
@@ -1202,8 +1207,8 @@ void Universe::GetEffectsAndTargets(Effect::TargetsCauses& targets_causes,
     std::map<int, std::shared_ptr<ConditionCache>> cached_source_condition_matches;
 
     // prepopulate the cache for safe concurrent access
-    for (int obj_id : m_objects.FindObjectIDs()) {
-        cached_source_condition_matches[obj_id] = std::make_shared<ConditionCache>();
+    for (const auto& obj : m_objects.all()) {
+        cached_source_condition_matches[obj->ID()] = std::make_shared<ConditionCache>();
     }
 
     cached_source_condition_matches[INVALID_OBJECT_ID] = std::make_shared<ConditionCache>();
@@ -2895,11 +2900,9 @@ void Universe::EffectDestroy(int object_id, int source_object_id) {
 }
 
 void Universe::InitializeSystemGraph(int for_empire_id) {
-    auto system_ids = ::EmpireKnownObjects(for_empire_id).FindObjectIDs<System>();
-    std::vector<std::shared_ptr<const System>> systems;
-    for (size_t system1_index = 0; system1_index < system_ids.size(); ++system1_index) {
-        int system1_id = system_ids[system1_index];
-        systems.push_back(GetEmpireKnownSystem(system1_id, for_empire_id));
+    std::vector<int> system_ids;
+    for (const auto& system : ::EmpireKnownObjects(for_empire_id).all<System>()) {
+        system_ids.push_back(system->ID());
     }
 
     m_pathfinder->InitializeSystemGraph(system_ids, for_empire_id);

--- a/universe/Universe.h
+++ b/universe/Universe.h
@@ -254,9 +254,6 @@ public:
     /** Sets all objects' meters' initial values to their current values. */
     void BackPropagateObjectMeters();
 
-    /** Sets indicated objects' meters' initial values to their current values. */
-    void BackPropagateObjectMeters(const std::vector<int>& object_ids);
-
     /** Determines which empires can see which objects at what visibility
       * level, based on  */
     void UpdateEmpireObjectVisibilities();

--- a/universe/UniverseGenerator.cpp
+++ b/universe/UniverseGenerator.cpp
@@ -658,7 +658,7 @@ void GenerateStarlanes(int max_jumps_between_systems, int max_starlane_length) {
     std::map<int, std::set<int>> potential_system_lanes;
 
     // get systems
-    auto sys_vec = Objects().FindObjects<System>();
+    auto sys_vec = Objects().all<System>();
     std::map<int, std::shared_ptr<System>> sys_map;
     std::transform(sys_vec.begin(), sys_vec.end(), std::inserter(sys_map, sys_map.end()),
                    [](const std::shared_ptr<System>& p) { return std::make_pair(p->ID(), p); });
@@ -768,7 +768,7 @@ void GenerateStarlanes(int max_jumps_between_systems, int max_starlane_length) {
     }
 
     // add the starlane to the stars
-    for (auto& sys : Objects().FindObjects<System>()) {
+    for (auto& sys : Objects().all<System>()) {
         const auto& sys_lanes = system_lanes[sys->ID()];
         for (auto& lane_end_id : sys_lanes)
             sys->AddStarlane(lane_end_id);

--- a/util/AppInterface.h
+++ b/util/AppInterface.h
@@ -127,52 +127,52 @@ inline std::shared_ptr<UniverseObject> GetEmpireKnownObject(int object_id, int e
 { return IApp::GetApp()->EmpireKnownObject(object_id, empire_id); }
 
 inline std::shared_ptr<ResourceCenter> GetResourceCenter(int object_id)
-{ return IApp::GetApp()->GetUniverse().Objects().Object<ResourceCenter>(object_id); }
+{ return IApp::GetApp()->GetUniverse().Objects().at<ResourceCenter>(object_id); }
 
 inline std::shared_ptr<ResourceCenter> GetEmpireKnownResourceCenter(int object_id, int empire_id)
-{ return IApp::GetApp()->EmpireKnownObjects(empire_id).Object<ResourceCenter>(object_id); }
+{ return IApp::GetApp()->EmpireKnownObjects(empire_id).at<ResourceCenter>(object_id); }
 
 inline std::shared_ptr<PopCenter> GetPopCenter(int object_id)
-{ return IApp::GetApp()->GetUniverse().Objects().Object<PopCenter>(object_id); }
+{ return IApp::GetApp()->GetUniverse().Objects().at<PopCenter>(object_id); }
 
 inline std::shared_ptr<PopCenter> GetEmpireKnownPopCenter(int object_id, int empire_id)
-{ return IApp::GetApp()->EmpireKnownObjects(empire_id).Object<PopCenter>(object_id); }
+{ return IApp::GetApp()->EmpireKnownObjects(empire_id).at<PopCenter>(object_id); }
 
 inline std::shared_ptr<Planet> GetPlanet(int object_id)
-{ return IApp::GetApp()->GetUniverse().Objects().Object<Planet>(object_id); }
+{ return IApp::GetApp()->GetUniverse().Objects().at<Planet>(object_id); }
 
 inline std::shared_ptr<Planet> GetEmpireKnownPlanet(int object_id, int empire_id)
-{ return IApp::GetApp()->EmpireKnownObjects(empire_id).Object<Planet>(object_id); }
+{ return IApp::GetApp()->EmpireKnownObjects(empire_id).at<Planet>(object_id); }
 
 inline std::shared_ptr<System> GetSystem(int object_id)
-{ return IApp::GetApp()->GetUniverse().Objects().Object<System>(object_id); }
+{ return IApp::GetApp()->GetUniverse().Objects().at<System>(object_id); }
 
 inline std::shared_ptr<System> GetEmpireKnownSystem(int object_id, int empire_id)
-{ return IApp::GetApp()->EmpireKnownObjects(empire_id).Object<System>(object_id); }
+{ return IApp::GetApp()->EmpireKnownObjects(empire_id).at<System>(object_id); }
 
 inline std::shared_ptr<Field> GetField(int object_id)
-{ return IApp::GetApp()->GetUniverse().Objects().Object<Field>(object_id); }
+{ return IApp::GetApp()->GetUniverse().Objects().at<Field>(object_id); }
 
 inline std::shared_ptr<Field> GetEmpireKnownField(int object_id, int empire_id)
-{ return IApp::GetApp()->EmpireKnownObjects(empire_id).Object<Field>(object_id); }
+{ return IApp::GetApp()->EmpireKnownObjects(empire_id).at<Field>(object_id); }
 
 inline std::shared_ptr<Ship> GetShip(int object_id)
-{ return IApp::GetApp()->GetUniverse().Objects().Object<Ship>(object_id); }
+{ return IApp::GetApp()->GetUniverse().Objects().at<Ship>(object_id); }
 
 inline std::shared_ptr<Ship> GetEmpireKnownShip(int object_id, int empire_id)
-{ return IApp::GetApp()->EmpireKnownObjects(empire_id).Object<Ship>(object_id); }
+{ return IApp::GetApp()->EmpireKnownObjects(empire_id).at<Ship>(object_id); }
 
 inline std::shared_ptr<Fleet> GetFleet(int object_id)
-{ return IApp::GetApp()->GetUniverse().Objects().Object<Fleet>(object_id); }
+{ return IApp::GetApp()->GetUniverse().Objects().at<Fleet>(object_id); }
 
 inline std::shared_ptr<Fleet> GetEmpireKnownFleet(int object_id, int empire_id)
-{ return IApp::GetApp()->EmpireKnownObjects(empire_id).Object<Fleet>(object_id); }
+{ return IApp::GetApp()->EmpireKnownObjects(empire_id).at<Fleet>(object_id); }
 
 inline std::shared_ptr<Building> GetBuilding(int object_id)
-{ return IApp::GetApp()->GetUniverse().Objects().Object<Building>(object_id); }
+{ return IApp::GetApp()->GetUniverse().Objects().at<Building>(object_id); }
 
 inline std::shared_ptr<Building> GetEmpireKnownBuilding(int object_id, int empire_id)
-{ return IApp::GetApp()->EmpireKnownObjects(empire_id).Object<Building>(object_id); }
+{ return IApp::GetApp()->EmpireKnownObjects(empire_id).at<Building>(object_id); }
 
 /** Returns the object name of the universe object. This can be apperant object
  * name, if the application isn't supposed to see the real object name. */

--- a/util/AppInterface.h
+++ b/util/AppInterface.h
@@ -127,52 +127,52 @@ inline std::shared_ptr<UniverseObject> GetEmpireKnownObject(int object_id, int e
 { return IApp::GetApp()->EmpireKnownObject(object_id, empire_id); }
 
 inline std::shared_ptr<ResourceCenter> GetResourceCenter(int object_id)
-{ return IApp::GetApp()->GetUniverse().Objects().at<ResourceCenter>(object_id); }
+{ return IApp::GetApp()->GetUniverse().Objects().get<ResourceCenter>(object_id); }
 
 inline std::shared_ptr<ResourceCenter> GetEmpireKnownResourceCenter(int object_id, int empire_id)
-{ return IApp::GetApp()->EmpireKnownObjects(empire_id).at<ResourceCenter>(object_id); }
+{ return IApp::GetApp()->EmpireKnownObjects(empire_id).get<ResourceCenter>(object_id); }
 
 inline std::shared_ptr<PopCenter> GetPopCenter(int object_id)
-{ return IApp::GetApp()->GetUniverse().Objects().at<PopCenter>(object_id); }
+{ return IApp::GetApp()->GetUniverse().Objects().get<PopCenter>(object_id); }
 
 inline std::shared_ptr<PopCenter> GetEmpireKnownPopCenter(int object_id, int empire_id)
-{ return IApp::GetApp()->EmpireKnownObjects(empire_id).at<PopCenter>(object_id); }
+{ return IApp::GetApp()->EmpireKnownObjects(empire_id).get<PopCenter>(object_id); }
 
 inline std::shared_ptr<Planet> GetPlanet(int object_id)
-{ return IApp::GetApp()->GetUniverse().Objects().at<Planet>(object_id); }
+{ return IApp::GetApp()->GetUniverse().Objects().get<Planet>(object_id); }
 
 inline std::shared_ptr<Planet> GetEmpireKnownPlanet(int object_id, int empire_id)
-{ return IApp::GetApp()->EmpireKnownObjects(empire_id).at<Planet>(object_id); }
+{ return IApp::GetApp()->EmpireKnownObjects(empire_id).get<Planet>(object_id); }
 
 inline std::shared_ptr<System> GetSystem(int object_id)
-{ return IApp::GetApp()->GetUniverse().Objects().at<System>(object_id); }
+{ return IApp::GetApp()->GetUniverse().Objects().get<System>(object_id); }
 
 inline std::shared_ptr<System> GetEmpireKnownSystem(int object_id, int empire_id)
-{ return IApp::GetApp()->EmpireKnownObjects(empire_id).at<System>(object_id); }
+{ return IApp::GetApp()->EmpireKnownObjects(empire_id).get<System>(object_id); }
 
 inline std::shared_ptr<Field> GetField(int object_id)
-{ return IApp::GetApp()->GetUniverse().Objects().at<Field>(object_id); }
+{ return IApp::GetApp()->GetUniverse().Objects().get<Field>(object_id); }
 
 inline std::shared_ptr<Field> GetEmpireKnownField(int object_id, int empire_id)
-{ return IApp::GetApp()->EmpireKnownObjects(empire_id).at<Field>(object_id); }
+{ return IApp::GetApp()->EmpireKnownObjects(empire_id).get<Field>(object_id); }
 
 inline std::shared_ptr<Ship> GetShip(int object_id)
-{ return IApp::GetApp()->GetUniverse().Objects().at<Ship>(object_id); }
+{ return IApp::GetApp()->GetUniverse().Objects().get<Ship>(object_id); }
 
 inline std::shared_ptr<Ship> GetEmpireKnownShip(int object_id, int empire_id)
-{ return IApp::GetApp()->EmpireKnownObjects(empire_id).at<Ship>(object_id); }
+{ return IApp::GetApp()->EmpireKnownObjects(empire_id).get<Ship>(object_id); }
 
 inline std::shared_ptr<Fleet> GetFleet(int object_id)
-{ return IApp::GetApp()->GetUniverse().Objects().at<Fleet>(object_id); }
+{ return IApp::GetApp()->GetUniverse().Objects().get<Fleet>(object_id); }
 
 inline std::shared_ptr<Fleet> GetEmpireKnownFleet(int object_id, int empire_id)
-{ return IApp::GetApp()->EmpireKnownObjects(empire_id).at<Fleet>(object_id); }
+{ return IApp::GetApp()->EmpireKnownObjects(empire_id).get<Fleet>(object_id); }
 
 inline std::shared_ptr<Building> GetBuilding(int object_id)
-{ return IApp::GetApp()->GetUniverse().Objects().at<Building>(object_id); }
+{ return IApp::GetApp()->GetUniverse().Objects().get<Building>(object_id); }
 
 inline std::shared_ptr<Building> GetEmpireKnownBuilding(int object_id, int empire_id)
-{ return IApp::GetApp()->EmpireKnownObjects(empire_id).at<Building>(object_id); }
+{ return IApp::GetApp()->EmpireKnownObjects(empire_id).get<Building>(object_id); }
 
 /** Returns the object name of the universe object. This can be apperant object
  * name, if the application isn't supposed to see the real object name. */

--- a/util/ModeratorAction.cpp
+++ b/util/ModeratorAction.cpp
@@ -158,7 +158,7 @@ namespace {
         static std::vector<std::string> star_names = UserStringList("STAR_NAMES");
 
         const ObjectMap& objects = Objects();
-        std::vector<std::shared_ptr<const System>> systems = objects.FindObjects<System>();
+        std::vector<std::shared_ptr<const System>> systems = objects.all<System>();
 
         // pick a name for the system
         for (const std::string& star_name : star_names) {

--- a/util/Order.cpp
+++ b/util/Order.cpp
@@ -370,7 +370,7 @@ bool FleetTransferOrder::Check(int empire_id, int dest_fleet_id, const std::vect
 
     bool invalid_ships {false};
 
-    for (auto ship : Objects().FindObjects<Ship>(ship_ids)) {
+    for (auto ship : Objects().find<Ship>(ship_ids)) {
         if (!ship) {
             ErrorLogger() << "IssueFleetTransferOrder : passed an invalid ship_id";
             invalid_ships = true;
@@ -409,7 +409,7 @@ void FleetTransferOrder::ExecuteImpl() const {
     auto target_fleet = GetFleet(DestinationFleet());
 
     // check that all ships are in the same system
-    auto ships = Objects().FindObjects<Ship>(m_add_ships);
+    auto ships = Objects().find<Ship>(m_add_ships);
 
     GetUniverse().InhibitUniverseObjectSignals(true);
 
@@ -1317,7 +1317,7 @@ bool GiveObjectToEmpireOrder::Check(int empire_id, int object_id, int recipient_
         return false;
     }
 
-    auto system_objects = Objects().FindObjects<const UniverseObject>(system->ObjectIDs());
+    auto system_objects = Objects().find<const UniverseObject>(system->ObjectIDs());
     if (!std::any_of(system_objects.begin(), system_objects.end(),
                      [recipient_empire_id](const std::shared_ptr<const UniverseObject> o){ return o->Owner() == recipient_empire_id; }))
     {

--- a/util/SerializeUniverse.cpp
+++ b/util/SerializeUniverse.cpp
@@ -110,7 +110,7 @@ void Universe::serialize(Archive& ar, const unsigned int version)
     }
 
     ar  & BOOST_SERIALIZATION_NVP(objects);
-    DebugLogger() << "Universe::serialize : " << serializing_label << " " << objects.NumObjects() << " objects";
+    DebugLogger() << "Universe::serialize : " << serializing_label << " " << objects.size() << " objects";
     if (Archive::is_loading::value) {
         m_objects.swap(objects);
     }
@@ -166,9 +166,9 @@ void Universe::serialize(Archive& ar, const unsigned int version)
     if (Archive::is_saving::value) {
         DebugLogger() << "Universe::serialize : Cleaning up temporary data";
         // clean up temporary objects in temporary ObjectMaps.
-        objects.Clear();
+        objects.clear();
         for (auto& elko : empire_latest_known_objects)
-        { elko.second.Clear(); }
+        { elko.second.clear(); }
     }
 
     if (Archive::is_loading::value) {


### PR DESCRIPTION
This PR simplifies the ObjectMap class interface:

* Use established naming conventions to mimic std containers.
  * NumObjects - size
  * Empty -> empty
  * Object -> get
  * FindObjects (with some query parameter) -> find
  * FindObjects (without query parameter) -> all
  * const_{begin,end} -> {begin, end} with const modifier
  * Insert -> insert
  * Remove -> erase
  * Clear -> clear
* Remove non-templates variants if they can be substituted by the template equivalent
  * begin
  * end
  * const_end
  * const_begin
  * FindObjects
  * Object
  * NumObjects
* Reimplement ObjectMap::find(const UniverseObjectVisitor&) as template member function to query only a subtype with an applied visitor.
* Remove internal ObjectMap helpers from class interface.
* Replace FindObjectIDs convenience functions with the corresponding all or find equivalent.