### PR TITLE
Fix use of lane-wormhole flag as system id

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -914,9 +914,10 @@ const std::map<int, std::set<int>> Empire::KnownStarlanes() const {
             continue;
 
         for (const auto& lane : sys_it->StarlanesWormholes()) {
-            if (lane.second || known_destroyed_objects.count(lane.second))
-                continue;   // is a wormhole, not a starlane, or is connected to a known destroyed system
             int end_id = lane.first;
+            bool is_wormhole = lane.second;
+            if (is_wormhole || known_destroyed_objects.count(end_id))
+                continue;   // is a wormhole, not a starlane, or is connected to a known destroyed system
             retval[start_id].insert(end_id);
             retval[end_id].insert(start_id);
         }


### PR DESCRIPTION
Fix issue where the flag for whether a lane is a wormhole was used as a system ID to check if a lane was connected to a destroyed system in order to decide whether an empire "knows about" the lane. A consequence of this was that if system 0 was destroyed and an empire was aware of this destruction, then all lanes were considered not known to the empire and couldn't be used for supply propagation.

Should fix #2719