### PR TITLE
Use uniform begin/end naming for constant iterators

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -927,8 +927,8 @@ const std::map<int, std::set<int>> Empire::KnownStarlanes() const {
     TraceLogger(supply) << "Empire::KnownStarlanes for empire " << m_id;
 
     const std::set<int>& known_destroyed_objects = universe.EmpireKnownDestroyedObjectIDs(this->EmpireID());
-    for (auto sys_it = Objects().const_begin<System>();
-         sys_it != Objects().const_end<System>(); ++sys_it)
+    for (auto sys_it = Objects().begin<System>();
+         sys_it != Objects().end<System>(); ++sys_it)
     {
         int start_id = sys_it->ID();
         TraceLogger(supply) << "system " << start_id << " has up to " << sys_it->StarlanesWormholes().size() << " lanes / wormholes";
@@ -961,8 +961,8 @@ const std::map<int, std::set<int>> Empire::VisibleStarlanes() const {
     const Universe& universe = GetUniverse();
     const ObjectMap& objects = universe.Objects();
 
-    for (auto sys_it = objects.const_begin<System>();
-         sys_it != objects.const_end<System>(); ++sys_it)
+    for (auto sys_it = objects.begin<System>();
+         sys_it != objects.end<System>(); ++sys_it)
     {
         int start_id = sys_it->ID();
 

--- a/GG/GG/ZList.h
+++ b/GG/GG/ZList.h
@@ -59,14 +59,14 @@ public:
     /** RenderOrderIterable can be iterated in back to front render order. */
     struct RenderOrderIterable {
         RenderOrderIterable(const std::list<std::shared_ptr<Wnd>>& list) :
-            m_list(list.crbegin(), list.crend())
+            m_list(list.rbegin(), list.rend())
         {}
 
-        std::vector<std::shared_ptr<Wnd>>::const_iterator begin()
-        { return m_list.cbegin(); }
+        std::vector<std::shared_ptr<Wnd>>::const_iterator begin() const
+        { return m_list.begin(); }
 
-        std::vector<std::shared_ptr<Wnd>>::const_iterator end()
-        { return m_list.cend(); }
+        std::vector<std::shared_ptr<Wnd>>::const_iterator end() const
+        { return m_list.end(); }
 
         private:
         const std::vector<std::shared_ptr<Wnd>> m_list;

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -1279,7 +1279,7 @@ namespace {
 
         const std::regex dot { "\\.+" };
         const std::vector<std::string> nodes {
-            std::sregex_token_iterator(name.cbegin(), name.cend(), dot, -1),
+            std::sregex_token_iterator(name.begin(), name.end(), dot, -1),
             std::sregex_token_iterator()
         };
 

--- a/combat/CombatLogManager.cpp
+++ b/combat/CombatLogManager.cpp
@@ -84,8 +84,8 @@ CombatLog::CombatLog(const CombatInfo& combat_info) :
 {
     // compile all remaining and destroyed objects' ids
     object_ids = combat_info.destroyed_object_ids;
-    for (auto it = combat_info.objects.const_begin();
-         it != combat_info.objects.const_end(); ++it)
+    for (auto it = combat_info.objects.begin();
+         it != combat_info.objects.end(); ++it)
     {
         object_ids.insert(it->ID());
         participant_states[it->ID()] = CombatParticipantState(**it);

--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -84,7 +84,7 @@ std::shared_ptr<System> CombatInfo::GetSystem()
 
 float CombatInfo::GetMonsterDetection() const {
     float monster_detection = 0.0;
-    for (auto it = objects.const_begin(); it != objects.const_end(); ++it) {
+    for (auto it = objects.begin(); it != objects.end(); ++it) {
         auto obj = *it;
         if (obj->Unowned() && (obj->ObjectType() == OBJ_SHIP || obj->ObjectType() == OBJ_PLANET ))
             monster_detection = std::max(monster_detection, obj->InitialMeterValue(METER_DETECTION));
@@ -1076,8 +1076,8 @@ namespace {
             std::vector<int> delete_list;
             delete_list.reserve(combat_info.objects.NumObjects());
 
-            for (auto it = combat_info.objects.const_begin();
-                 it != combat_info.objects.const_end(); ++it)
+            for (auto it = combat_info.objects.begin();
+                 it != combat_info.objects.end(); ++it)
             {
                 auto obj = *it;
 
@@ -1286,8 +1286,8 @@ namespace {
 
         // Populate lists of things that can attack. List attackers also by empire.
         void PopulateAttackers() {
-            for (auto it = combat_info.objects.const_begin();
-                 it != combat_info.objects.const_end(); ++it)
+            for (auto it = combat_info.objects.begin();
+                 it != combat_info.objects.end(); ++it)
             {
                 auto obj = *it;
                 bool can_attack{ObjectCanAttack(obj)};

--- a/universe/ObjectMap.cpp
+++ b/universe/ObjectMap.cpp
@@ -49,7 +49,7 @@ void ObjectMap::Copy(const ObjectMap& copied_map, int empire_id/* = ALL_EMPIRES*
 
     // loop through objects in copied map, copying or cloning each depending
     // on whether there already is a corresponding object in this map
-    for (const_iterator<> it = copied_map.const_begin(); it != copied_map.const_end(); ++it)
+    for (const_iterator<> it = copied_map.begin(); it != copied_map.end(); ++it)
         this->CopyObject(*it, empire_id);
 }
 
@@ -138,7 +138,7 @@ std::vector<std::shared_ptr<UniverseObject>> ObjectMap::FindObjects(const std::s
 
 std::vector<std::shared_ptr<const UniverseObject>> ObjectMap::FindObjects(const UniverseObjectVisitor& visitor) const {
     std::vector<std::shared_ptr<const UniverseObject>> result;
-    for (auto it = const_begin(); it != const_end(); ++it) {
+    for (auto it = begin(); it != end(); ++it) {
         if (auto obj = it->Accept(visitor))
             result.push_back(Object(obj->ID()));
     }
@@ -156,7 +156,7 @@ std::vector<std::shared_ptr<UniverseObject>> ObjectMap::FindObjects(const Univer
 
 std::vector<int> ObjectMap::FindObjectIDs(const UniverseObjectVisitor& visitor) const {
     std::vector<int> result;
-    for (auto it = const_begin(); it != const_end(); ++it) {
+    for (auto it = begin(); it != end(); ++it) {
         if (it->Accept(visitor))
             result.push_back(it->ID());
     }
@@ -178,11 +178,11 @@ ObjectMap::iterator<> ObjectMap::begin()
 ObjectMap::iterator<> ObjectMap::end()
 { return end<UniverseObject>(); }
 
-ObjectMap::const_iterator<> ObjectMap::const_begin() const
-{ return const_begin<UniverseObject>(); }
+ObjectMap::const_iterator<> ObjectMap::begin() const
+{ return begin<UniverseObject>(); }
 
-ObjectMap::const_iterator<> ObjectMap::const_end() const
-{ return const_end<UniverseObject>(); }
+ObjectMap::const_iterator<> ObjectMap::end() const
+{ return end<UniverseObject>(); }
 
 void ObjectMap::InsertCore(std::shared_ptr<UniverseObject> item, int empire_id/* = ALL_EMPIRES*/) {
     FOR_EACH_MAP(TryInsertIntoMap, item);
@@ -394,7 +394,7 @@ void ObjectMap::CopyObjectsToSpecializedMaps() {
 std::string ObjectMap::Dump(unsigned short ntabs) const {
     std::ostringstream dump_stream;
     dump_stream << "ObjectMap contains UniverseObjects: " << std::endl;
-    for (const_iterator<> it = const_begin(); it != const_end(); ++it)
+    for (const_iterator<> it = begin(); it != end(); ++it)
         dump_stream << it->Dump(ntabs) << std::endl;
     dump_stream << std::endl;
     return dump_stream.str();

--- a/universe/ObjectMap.h
+++ b/universe/ObjectMap.h
@@ -256,17 +256,17 @@ public:
     // these first 4 are primarily for convenience
     iterator<>              begin();
     iterator<>              end();
-    const_iterator<>        const_begin() const;
-    const_iterator<>        const_end() const;
+    const_iterator<>        begin() const;
+    const_iterator<>        end() const;
 
     template <class T>
     iterator<T>             begin();
     template <class T>
     iterator<T>             end();
     template <class T>
-    const_iterator<T>       const_begin() const;
+    const_iterator<T>       begin() const;
     template <class T>
-    const_iterator<T>       const_end() const;
+    const_iterator<T>       end() const;
 
     std::string             Dump(unsigned short ntabs = 0) const;
 
@@ -412,11 +412,11 @@ ObjectMap::iterator<T> ObjectMap::end()
 { return iterator<T>(Map<typename std::remove_const<T>::type>().end(), *this); }
 
 template <class T>
-ObjectMap::const_iterator<T> ObjectMap::const_begin() const
+ObjectMap::const_iterator<T> ObjectMap::begin() const
 { return const_iterator<T>(Map<typename std::remove_const<T>::type>().begin(), *this); }
 
 template <class T>
-ObjectMap::const_iterator<T> ObjectMap::const_end() const
+ObjectMap::const_iterator<T> ObjectMap::end() const
 { return const_iterator<T>(Map<typename std::remove_const<T>::type>().end(), *this); }
 
 template <class T>
@@ -440,7 +440,7 @@ std::shared_ptr<T> ObjectMap::Object(int id) {
 template <class T>
 std::vector<std::shared_ptr<const T>> ObjectMap::FindObjects() const {
     std::vector<std::shared_ptr<const T>> result;
-    for (auto it = const_begin<T>(); it != const_end<T>(); ++it)
+    for (auto it = begin<T>(); it != end<T>(); ++it)
         result.push_back(*it);
     return result;
 }

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -241,7 +241,7 @@ std::set<int> Universe::EmpireVisibleObjectIDs(int empire_id/* = ALL_EMPIRES*/) 
 
     // check each object's visibility against all empires, including the object
     // if an empire has visibility of it
-    for (auto obj_it = m_objects.const_begin(); obj_it != m_objects.const_end(); ++obj_it) {
+    for (auto obj_it = m_objects.begin(); obj_it != m_objects.end(); ++obj_it) {
         int id = obj_it->ID();
         for (int detector_empire_id : empire_ids) {
             Visibility vis = GetObjectVisibilityByEmpire(id, detector_empire_id);
@@ -1958,8 +1958,8 @@ namespace {
         auto empire_detection_strengths = GetEmpiresDetectionStrengths(empire_id);
 
         // filter objects as detectors for this empire or detectable objects
-        for (auto object_it = objects.const_begin();
-             object_it != objects.const_end(); ++object_it)
+        for (auto object_it = objects.begin();
+             object_it != objects.end(); ++object_it)
         {
             auto obj = *object_it;
             int object_id = object_it->ID();
@@ -2143,8 +2143,8 @@ namespace {
     void SetAllObjectsVisibleToAllEmpires() {
         Universe& universe = GetUniverse();
         // set every object visible to all empires
-        for (auto obj_it = Objects().const_begin();
-             obj_it != Objects().const_end(); ++obj_it)
+        for (auto obj_it = Objects().begin();
+             obj_it != Objects().end(); ++obj_it)
         {
             for (auto& empire_entry : Empires()) {
                 // objects
@@ -2164,7 +2164,7 @@ namespace {
         // map from empire ID to ID of systems where those empires own at least one object
         std::map<int, std::set<int>> empires_systems_with_owned_objects;
         // get systems where empires have owned objects
-        for (auto it = objects.const_begin(); it != objects.const_end(); ++it) {
+        for (auto it = objects.begin(); it != objects.end(); ++it) {
             auto obj = *it;
             if (obj->Unowned() || obj->SystemID() == INVALID_OBJECT_ID)
                 continue;
@@ -2203,8 +2203,8 @@ namespace {
                                                Universe::EmpireObjectVisibilityMap& empire_object_visibility)
     {
         // propagate visibility from contained to container objects
-        for (auto container_object_it = objects.const_begin();
-             container_object_it != objects.const_end(); ++container_object_it)
+        for (auto container_object_it = objects.begin();
+             container_object_it != objects.end(); ++container_object_it)
         {
             int container_obj_id = container_object_it->ID();
 
@@ -2655,8 +2655,8 @@ void Universe::UpdateEmpireStaleObjectKnowledge() {
 
 
         // fleets that are not visible and that contain no ships or only stale ships are stale
-        for (auto obj_it = latest_known_objects.const_begin();
-             obj_it != latest_known_objects.const_end(); ++obj_it)
+        for (auto obj_it = latest_known_objects.begin();
+             obj_it != latest_known_objects.end(); ++obj_it)
         {
             if (obj_it->ObjectType() != OBJ_FLEET)
                 continue;
@@ -3092,7 +3092,7 @@ void Universe::GetEmpireObjectVisibilityMap(EmpireObjectVisibilityMap& empire_ob
     // than no visibility of.  TODO: include what requested empire knows about
     // other empires' visibilites of objects
     empire_object_visibility.clear();
-    for (auto it = m_objects.const_begin(); it != m_objects.const_end(); ++it) {
+    for (auto it = m_objects.begin(); it != m_objects.end(); ++it) {
         int object_id = it->ID();
         Visibility vis = GetObjectVisibilityByEmpire(object_id, encoding_empire);
         if (vis > VIS_NO_VISIBILITY)


### PR DESCRIPTION
Use a consistent iterator interface naming within the source base by relying
on the compiler to select the proper begin()/end() pair with or without
const-ness to enable ranged based for loops for some operations.

Split out from #2722