### PR TITLE
Design mainwindow layout

### DIFF
--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -3948,6 +3948,8 @@ public:
     /** Replace an existing design.*/
     void ReplaceDesign();
 
+    void ToggleDescriptionEditor();
+  
     void HighlightSlotType(std::vector<ShipSlotType>& slot_types);   //!< renders slots of the indicated types differently, perhaps to indicate that that those slots can be drop targets for a particular part?
 
     /** Track changes in base type. */
@@ -4015,8 +4017,8 @@ private:
     std::shared_ptr<GG::StaticGraphic>          m_background_image = nullptr;
     std::shared_ptr<GG::Label>                  m_design_name_label = nullptr;
     std::shared_ptr<GG::Edit>                   m_design_name = nullptr;
-    std::shared_ptr<GG::Label>                  m_design_description_label = nullptr;
-    std::shared_ptr<GG::Edit>                   m_design_description = nullptr;
+    std::shared_ptr<GG::StateButton>            m_design_description_toggle = nullptr;
+    std::shared_ptr<GG::MultiEdit>              m_design_description_edit = nullptr;
     std::shared_ptr<GG::Button>                 m_replace_button = nullptr;
     std::shared_ptr<GG::Button>                 m_confirm_button = nullptr;
     std::shared_ptr<GG::Button>                 m_clear_button = nullptr;
@@ -4037,8 +4039,8 @@ void DesignWnd::MainPanel::CompleteConstruction() {
 
     m_design_name_label = GG::Wnd::Create<CUILabel>(UserString("DESIGN_WND_DESIGN_NAME"), GG::FORMAT_RIGHT, GG::INTERACTIVE);
     m_design_name = GG::Wnd::Create<CUIEdit>(UserString("DESIGN_NAME_DEFAULT"));
-    m_design_description_label = GG::Wnd::Create<CUILabel>(UserString("DESIGN_WND_DESIGN_DESCRIPTION"), GG::FORMAT_RIGHT, GG::INTERACTIVE);
-    m_design_description = GG::Wnd::Create<CUIEdit>(UserString("DESIGN_DESCRIPTION_DEFAULT"));
+    m_design_description_toggle = GG::Wnd::Create<CUIStateButton>(UserString("DESIGN_WND_DESIGN_DESCRIPTION"),GG::FORMAT_CENTER, std::make_shared<CUILabelButtonRepresenter>());
+    m_design_description_edit = GG::Wnd::Create<CUIMultiEdit>(UserString("DESIGN_DESCRIPTION_DEFAULT"));
     m_replace_button = Wnd::Create<CUIButton>(UserString("DESIGN_WND_UPDATE"));
     m_confirm_button = Wnd::Create<CUIButton>(UserString("DESIGN_WND_ADD_FINISHED"));
     m_clear_button = Wnd::Create<CUIButton>(UserString("DESIGN_WND_CLEAR"));
@@ -4048,8 +4050,8 @@ void DesignWnd::MainPanel::CompleteConstruction() {
 
     AttachChild(m_design_name_label);
     AttachChild(m_design_name);
-    AttachChild(m_design_description_label);
-    AttachChild(m_design_description);
+    AttachChild(m_design_description_toggle);
+    AttachChild(m_design_description_edit);
     AttachChild(m_replace_button);
     AttachChild(m_confirm_button);
     AttachChild(m_clear_button);
@@ -4060,6 +4062,7 @@ void DesignWnd::MainPanel::CompleteConstruction() {
         boost::bind(&DesignWnd::MainPanel::DesignNameEditedSlot, this, _1));
     m_replace_button->LeftClickedSignal.connect(DesignReplacedSignal);
     m_confirm_button->LeftClickedSignal.connect(DesignConfirmedSignal);
+    m_design_description_toggle->CheckedSignal.connect(boost::bind(&DesignWnd::MainPanel::ToggleDescriptionEditor,this));
     DesignChangedSignal.connect(boost::bind(&DesignWnd::MainPanel::DesignChanged, this));
     DesignReplacedSignal.connect(boost::bind(&DesignWnd::MainPanel::ReplaceDesign, this));
     DesignConfirmedSignal.connect(boost::bind(&DesignWnd::MainPanel::AddDesign, this));
@@ -4133,9 +4136,9 @@ DesignWnd::MainPanel::ValidatedNameAndDescription() const
 
     // Is the descrition a stringtable index or the same as the saved designs value
     const std::string desc_index =
-        (UserStringExists(m_design_description->Text()) ? m_design_description->Text() :
+        (UserStringExists(m_design_description_edit->Text()) ? m_design_description_edit->Text() :
          ((maybe_saved && (*maybe_saved)->LookupInStringtable()
-           && (m_design_description->Text() == (*maybe_saved)->Description())) ? (*maybe_saved)->Description(false) : ""));
+           && (m_design_description_edit->Text() == (*maybe_saved)->Description())) ? (*maybe_saved)->Description(false) : ""));
 
     // Are both the title and the description string table lookup values
     if (!name_index.empty() && !desc_index.empty())
@@ -4145,7 +4148,7 @@ DesignWnd::MainPanel::ValidatedNameAndDescription() const
 
     return std::make_pair(
         I18nString(false, (IsDesignNameValid()) ? m_design_name->Text() : UserString("DESIGN_NAME_DEFAULT")),
-        I18nString(false, m_design_description->Text()));
+        I18nString(false, m_design_description_edit->Text()));
 }
 
 const DesignWnd::MainPanel::I18nString DesignWnd::MainPanel::ValidatedDesignName() const
@@ -4194,7 +4197,7 @@ void DesignWnd::MainPanel::SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
 void DesignWnd::MainPanel::Sanitize() {
     SetHull(nullptr, false);
     m_design_name->SetText(UserString("DESIGN_NAME_DEFAULT"));
-    m_design_description->SetText(UserString("DESIGN_DESCRIPTION_DEFAULT"));
+    m_design_description_edit->SetText(UserString("DESIGN_DESCRIPTION_DEFAULT"));
     // disconnect old empire design signal
     m_empire_designs_changed_signal.disconnect();
 }
@@ -4420,7 +4423,7 @@ void DesignWnd::MainPanel::SetDesign(const ShipDesign* ship_design) {
     }
 
     m_design_name->SetText(ship_design->Name());
-    m_design_description->SetText(ship_design->Description());
+    m_design_description_edit->SetText(ship_design->Description());
 
     bool suppress_design_changed_signal = true;
     SetHull(ship_design->GetHull(), !suppress_design_changed_signal);
@@ -4451,7 +4454,7 @@ void DesignWnd::MainPanel::SetDesignComponents(const std::string& hull,
 {
     SetDesignComponents(hull, parts);
     m_design_name->SetText(name);
-    m_design_description->SetText(desc);
+    m_design_description_edit->SetText(desc);
 }
 
 void DesignWnd::MainPanel::HighlightSlotType(std::vector<ShipSlotType>& slot_types) {
@@ -4528,11 +4531,14 @@ void DesignWnd::MainPanel::DoLayout() {
     m_design_name->SizeMove(ul, GG::Pt(GG::X(ClientWidth()-PAD), ul.y+m_design_name->MinUsableSize().y));
 
 	ul=GG::Pt(GG::X(PAD), GG::Y(m_design_name->RelativeLowerRight().y+PAD));
-	lr= ul+GG::Pt(m_design_description_label->MinUsableSize().x, m_design_description->MinUsableSize().y);
-    m_design_description_label->SizeMove(ul, lr);
+	// Apparently calling minuseablesize on the button itself doesn't work
+	lr= ul+GG::Pt(m_design_description_toggle->GetLabel()->MinUsableSize().x+10, m_design_name->MinUsableSize().y);
+    m_design_description_toggle->SizeMove(ul, lr);
 
-    ul.x = m_design_description_label->RelativeLowerRight().x + PAD;
-    m_design_description->SizeMove(ul, GG::Pt(GG::X(ClientWidth()-PAD),ul.y+m_design_description->MinUsableSize().y));
+    ul.x = m_design_description_toggle->RelativeLowerRight().x + PAD;
+    m_design_description_edit->SizeMove(ul, GG::Pt(GG::X(ClientWidth()-PAD),ul.y+PTS*4+8));
+	if (m_design_description_toggle->Checked()) { m_design_description_edit->Show() ; }
+	else { m_design_description_edit->Hide(); }
 
     // place background image of hull
     ul.x = GG::X0;
@@ -4955,6 +4961,10 @@ void DesignWnd::MainPanel::ReplaceDesign() {
     DesignChangedSignal();
 }
 
+void DesignWnd::MainPanel::ToggleDescriptionEditor() {
+  if (m_design_description_toggle->Checked()) { m_design_description_edit->Show() ; }
+  else { m_design_description_edit->Hide(); }
+}
 
 //////////////////////////////////////////////////
 // DesignWnd                                    //

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -4504,45 +4504,35 @@ void DesignWnd::MainPanel::DoLayout() {
 
     const int PTS = ClientUI::Pts();
     const GG::X PTS_WIDE(PTS / 2);           // guess at how wide per character the font needs
-    const GG::Y BUTTON_HEIGHT(PTS * 2);
-    const GG::X LABEL_WIDTH = PTS_WIDE * 15;
     const int PAD = 6;
-    const int GUESSTIMATE_NUM_CHARS_IN_BUTTON_TEXT = 25;    // rough guesstimate... avoid overly long part class names
-    const GG::X BUTTON_WIDTH = PTS_WIDE*GUESSTIMATE_NUM_CHARS_IN_BUTTON_TEXT;
+	
+	GG::Pt ul,lr,ll,ur,mus;
+	lr = ClientSize() - GG::Pt(GG::X(PAD), GG::Y(PAD));
+    m_confirm_button->SizeMove(lr - m_confirm_button->MinUsableSize(), lr);
 
-    GG::X edit_right = ClientWidth();
-    GG::X confirm_right = ClientWidth() - PAD;
+	mus=m_replace_button->MinUsableSize();
+	ul = m_confirm_button->RelativeUpperLeft() - GG::Pt(mus.x+PAD, GG::Y(0));
+    m_replace_button->SizeMove(ul, ul+mus);
 
-    GG::Pt lr = GG::Pt(confirm_right, BUTTON_HEIGHT) + GG::Pt(GG::X0, GG::Y(PAD));
-    GG::Pt ul = lr - GG::Pt(BUTTON_WIDTH, BUTTON_HEIGHT);
-    m_confirm_button->SizeMove(ul, lr);
-
-    lr = lr - GG::Pt(BUTTON_WIDTH, GG::Y(0))- GG::Pt(GG::X(PAD),GG::Y(0));
-    ul = lr - GG::Pt(BUTTON_WIDTH, BUTTON_HEIGHT);
-    m_replace_button->SizeMove(ul, lr);
-
-    edit_right = ul.x - PAD;
-
-    lr = ClientSize() + GG::Pt(-GG::X(PAD), -GG::Y(PAD));
-    ul = lr - GG::Pt(BUTTON_WIDTH, BUTTON_HEIGHT);
-    m_clear_button->SizeMove(ul, lr);
+	ll= GG::Pt(GG::X(PAD), ClientHeight() - PAD);
+	mus=m_clear_button->MinUsableSize();
+	ul = ll-GG::Pt(GG::X0, mus.y);
+    m_clear_button->SizeMove(ul, ul+mus);
 
     ul = GG::Pt(GG::X(PAD), GG::Y(PAD));
-    lr = ul + GG::Pt(LABEL_WIDTH, m_design_name->MinUsableSize().y);
+	// adjust based on the (bigger) height of the edit bar 
+	lr= ul+GG::Pt(m_design_name_label->MinUsableSize().x, m_design_name->MinUsableSize().y);
     m_design_name_label->SizeMove(ul, lr);
 
-    ul.x += lr.x;
-    lr.x = edit_right;
-    m_design_name->SizeMove(ul, lr);
+	ul= GG::Pt(m_design_name_label->RelativeLowerRight().x+PAD, GG::Y(PAD));
+    m_design_name->SizeMove(ul, GG::Pt(GG::X(ClientWidth()-PAD), ul.y+m_design_name->MinUsableSize().y));
 
-    ul.x = GG::X(PAD);
-    ul.y += (m_design_name->Height() + PAD);
-    lr = ul + GG::Pt(LABEL_WIDTH, m_design_name->MinUsableSize().y);
+	ul=GG::Pt(GG::X(PAD), GG::Y(m_design_name->RelativeLowerRight().y+PAD));
+	lr= ul+GG::Pt(m_design_description_label->MinUsableSize().x, m_design_description->MinUsableSize().y);
     m_design_description_label->SizeMove(ul, lr);
 
-    ul.x = lr.x + PAD;
-    lr.x = confirm_right;
-    m_design_description->SizeMove(ul, lr);
+    ul.x = m_design_description_label->RelativeLowerRight().x + PAD;
+    m_design_description->SizeMove(ul, GG::Pt(GG::X(ClientWidth()-PAD),ul.y+m_design_description->MinUsableSize().y));
 
     // place background image of hull
     ul.x = GG::X0;


### PR DESCRIPTION
I find this layout more natural (buttons at the bottom right). And it can be squeezed in less space.

Ideally I think add and update should be a single button that changes when the name is new, with no text just an icon. And the panels should be moved (pedia moved left of main panel and parts spread laterally).
