### PR TITLE
Optimizing Effect Accounting

### DIFF
--- a/UI/MeterBrowseWnd.cpp
+++ b/UI/MeterBrowseWnd.cpp
@@ -257,6 +257,7 @@ namespace {
         if (meter_it == meter_map.end() || meter_it->second.empty())
             return boost::none;
 
+        //DebugLogger() << "GetAccountingInfo() map load?: " << effect_accounting_map.load_factor() << " / " << effect_accounting_map.max_load_factor();
         return meter_it->second;
     }
 }

--- a/UI/MeterBrowseWnd.cpp
+++ b/UI/MeterBrowseWnd.cpp
@@ -257,7 +257,6 @@ namespace {
         if (meter_it == meter_map.end() || meter_it->second.empty())
             return boost::none;
 
-        //DebugLogger() << "GetAccountingInfo() map load?: " << effect_accounting_map.load_factor() << " / " << effect_accounting_map.max_load_factor();
         return meter_it->second;
     }
 }

--- a/universe/EffectAccounting.cpp
+++ b/universe/EffectAccounting.cpp
@@ -22,8 +22,18 @@ Effect::EffectCause::EffectCause(EffectsCauseType cause_type_, const std::string
 Effect::AccountingInfo::AccountingInfo() :
     EffectCause(),
     source_id(INVALID_OBJECT_ID),
-    meter_change(0.0),
-    running_meter_total(0.0)
+    meter_change(0.0f),
+    running_meter_total(0.0f)
+{}
+
+Effect::AccountingInfo::AccountingInfo(
+    int source_id_, EffectsCauseType cause_type_, float meter_change_,
+    float running_meter_total_, const std::string& specific_cause_,
+    const std::string& custom_label_) :
+    EffectCause(cause_type_, specific_cause_, custom_label_),
+    source_id(source_id_),
+    meter_change(meter_change_),
+    running_meter_total(running_meter_total_)
 {}
 
 bool Effect::AccountingInfo::operator==(const Effect::AccountingInfo& rhs) const {

--- a/universe/EffectAccounting.h
+++ b/universe/EffectAccounting.h
@@ -9,6 +9,7 @@
 #include <map>
 #include <string>
 #include <vector>
+#include <unordered_map>
 
 #include "../util/Export.h"
 

--- a/universe/EffectAccounting.h
+++ b/universe/EffectAccounting.h
@@ -4,6 +4,7 @@
 
 #include "EnumsFwd.h"
 
+#include <boost/container/flat_map.hpp>
 #include <memory>
 #include <map>
 #include <string>
@@ -32,6 +33,10 @@ namespace Effect {
       * by effects groups acting on meters of objects. */
     struct FO_COMMON_API AccountingInfo : public EffectCause {
         AccountingInfo();
+        AccountingInfo(int source_id_, EffectsCauseType cause_type_, float meter_change_,
+                       float running_meter_total_, const std::string& specific_cause_ = "",
+                       const std::string& custom_label_ = "");
+
         bool operator==(const AccountingInfo& rhs) const;
 
         int     source_id;          ///< source object of effect
@@ -41,7 +46,7 @@ namespace Effect {
 
     /** Effect accounting information for all meters of all objects that are
       * acted on by effects. */
-    typedef std::map<int, std::map<MeterType, std::vector<AccountingInfo>>> AccountingMap;
+    typedef std::unordered_map<int, boost::container::flat_map<MeterType, std::vector<AccountingInfo>>> AccountingMap;
 
     /** Combination of targets and cause for an effects group. */
     struct TargetsAndCause {
@@ -61,11 +66,11 @@ namespace Effect {
     };
 
     /** Discrepancy between meter's value at start of turn, and the value that
-      * this client calculate that the meter should have with the knowledge
+      * this client calculates that the meter should have with the knowledge
       * available -> the unknown factor affecting the meter.  This is used
       * when generating effect accounting, in the case where the expected
       * and actual meter values don't match. */
-    typedef std::map<int, std::map<MeterType, double>> DiscrepancyMap;
+    typedef std::unordered_map<int, boost::container::flat_map<MeterType, double>> DiscrepancyMap;
 
     /** Map from (effects group and source object) to target set of for
       * that effects group with that source object.  A multimap is used

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -614,8 +614,6 @@ void Universe::InitMeterEstimatesAndDiscrepancies() {
         obj_discrep.reserve(obj->Meters().size());
         for (const auto& meter_pair : obj->Meters()) {
             // inserting in order into initially-empty map should always put next item efficiently at end
-            //obj_discrep.insert_or_assign(obj_discrep.end(), meter_pair.first, meter_pair.second.Current());
-            //obj_discrep.insert(obj_discrep.end(), std::pair<MeterType, double>{meter_pair.first, meter_pair.second.Current()});
             obj_discrep.emplace_hint(obj_discrep.end(), meter_pair.first, meter_pair.second.Current());
         }
     }

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -595,27 +595,40 @@ void Universe::ApplyGenerateSitRepEffects() {
 }
 
 void Universe::InitMeterEstimatesAndDiscrepancies() {
-    DebugLogger() << "Universe::InitMeterEstimatesAndDiscrepancies";
-    ScopedTimer timer("Universe::InitMeterEstimatesAndDiscrepancies");
+    DebugLogger(effects) << "Universe::InitMeterEstimatesAndDiscrepancies";
+    ScopedTimer timer("Universe::InitMeterEstimatesAndDiscrepancies", true, std::chrono::microseconds(1));
 
     // clear old discrepancies and accounting
     m_effect_discrepancy_map.clear();
     m_effect_accounting_map.clear();
+    m_effect_discrepancy_map.reserve(m_objects.size());
+    m_effect_accounting_map.reserve(m_objects.size());
 
-    DebugLogger() << "IMEAD: updating meter estimates";
+    TraceLogger(effects) << "IMEAD: updating meter estimates";
 
     // save starting meter vales
-    Effect::DiscrepancyMap starting_current_meter_values;
-    for (const auto& obj : m_objects)
-        for (const auto& meter_pair : obj->Meters())
-            starting_current_meter_values[obj->ID()][meter_pair.first] = meter_pair.second.Current();
+    std::unordered_map<int, boost::container::flat_map<MeterType, double>> starting_current_meter_values;
+    starting_current_meter_values.reserve(m_objects.size());
+    for (const auto& obj : m_objects) {
+        auto& obj_discrep = starting_current_meter_values[obj->ID()];
+        obj_discrep.reserve(obj->Meters().size());
+        for (const auto& meter_pair : obj->Meters()) {
+            // inserting in order into initially-empty map should always put next item efficiently at end
+            //obj_discrep.insert_or_assign(obj_discrep.end(), meter_pair.first, meter_pair.second.Current());
+            //obj_discrep.insert(obj_discrep.end(), std::pair<MeterType, double>{meter_pair.first, meter_pair.second.Current()});
+            obj_discrep.emplace_hint(obj_discrep.end(), meter_pair.first, meter_pair.second.Current());
+        }
+    }
 
 
     // generate new estimates (normally uses discrepancies, but in this case will find none)
     UpdateMeterEstimates();
 
 
-    DebugLogger() << "IMEAD: determining discrepancies";
+    TraceLogger(effects) << "IMEAD: determining discrepancies";
+    TraceLogger(effects) << "Initial accounting map size: " << m_effect_accounting_map.size()
+                         << "   and discrepancy map size: " << m_effect_discrepancy_map.size();
+
     // determine meter max discrepancies
     for (auto& entry : m_effect_accounting_map) {
         int object_id = entry.first;
@@ -625,43 +638,53 @@ void Universe::InitMeterEstimatesAndDiscrepancies() {
         // get object
         auto obj = m_objects.get(object_id);
         if (!obj) {
-            ErrorLogger() << "Universe::InitMeterEstimatesAndDiscrepancies couldn't find an object that was in the effect accounting map...?";
+            ErrorLogger(effects) << "Universe::InitMeterEstimatesAndDiscrepancies couldn't find an object that was in the effect accounting map...?";
             continue;
         }
+        if (obj->Meters().empty())
+            continue;
 
         TraceLogger(effects) << "... discrepancies for " << obj->Name() << " (" << obj->ID() << "):";
+
+        auto& account_map = entry.second;
+        account_map.reserve(obj->Meters().size());
+
+        // discrepancies should be empty before this loop, so emplacing / assigning should be fine here (without overwriting existing data)
+        auto dis_map_it = m_effect_discrepancy_map.emplace_hint(m_effect_discrepancy_map.end(), object_id, boost::container::flat_map<MeterType, double>{});
+        auto& discrep_map = dis_map_it->second;
+        discrep_map.reserve(obj->Meters().size());
+
+        auto& start_map = starting_current_meter_values[object_id];
+        start_map.reserve(obj->Meters().size());
+
+        TraceLogger(effects) << "For object " << object_id << " initial accounting map size: "
+                             << account_map.size() << "  discrep map size: " << discrep_map.size()
+                             << "  and starting meters map size: " << start_map.size();
 
         // every meter has a value at the start of the turn, and a value after
         // updating with known effects
         for (auto& meter_pair : obj->Meters()) {
             MeterType type = meter_pair.first;
-
-            // skip paired active meters, as differences in these are expected
-            // and persistent, and not a "discrepancy"
+            // skip paired active meters, as differences in these are expected and persistent, and not a "discrepancy"
             if (type >= METER_POPULATION && type <= METER_TROOPS)
                 continue;
+            Meter& meter = meter_pair.second;
 
             // discrepancy is the difference between expected and actual meter
             // values at start of turn. here "expected" is what the meter value
             // was before updating the meters, and actual is what it is now
             // after updating the meters based on the known universe.
-            Meter& meter = meter_pair.second;
-            float discrepancy = starting_current_meter_values[object_id][type] - meter.Current();
+            float discrepancy = start_map[type] - meter.Current();
             if (discrepancy == 0.0f) continue;   // no discrepancy for this meter
 
-            // add to discrepancy map
-            m_effect_discrepancy_map[object_id][type] = discrepancy;
+            // add to discrepancy map. as above, should have been empty before this loop.
+            discrep_map.emplace_hint(discrep_map.end(), type, discrepancy);
 
             // correct current max meter estimate for discrepancy
             meter.AddToCurrent(discrepancy);
 
             // add discrepancy adjustment to meter accounting
-            Effect::AccountingInfo info;
-            info.cause_type = ECT_UNKNOWN_CAUSE;
-            info.meter_change = discrepancy;
-            info.running_meter_total = meter.Current();
-
-            m_effect_accounting_map[object_id][type].push_back(info);
+            account_map[type].emplace_back(INVALID_OBJECT_ID, ECT_UNKNOWN_CAUSE, discrepancy, meter.Current());
 
             TraceLogger(effects) << "... ... " << boost::lexical_cast<std::string>(type) << ": " << discrepancy;
         }
@@ -740,6 +763,7 @@ void Universe::UpdateMeterEstimates(const std::vector<int>& objects_vec) {
         objects_set.insert(object_id);
     }
     std::vector<int> final_objects_vec;
+    final_objects_vec.reserve(objects_set.size());
     std::copy(objects_set.begin(), objects_set.end(), std::back_inserter(final_objects_vec));
     if (!final_objects_vec.empty())
         UpdateMeterEstimatesImpl(final_objects_vec, GetOptionsDB().Get<bool>("effects.accounting.enabled"));
@@ -769,20 +793,17 @@ void Universe::UpdateMeterEstimatesImpl(const std::vector<int>& objects_vec, boo
         if (!do_accounting)
             continue;
 
-        // record current value(s) of meters after resetting
-        for (MeterType type = MeterType(0); type != NUM_METER_TYPES;
-             type = MeterType(type + 1))
-        {
-            if (Meter* meter = obj->GetMeter(type)) {
-                Effect::AccountingInfo info;
-                info.source_id = INVALID_OBJECT_ID;
-                info.cause_type = ECT_INHERENT;
-                info.meter_change = meter->Current() - Meter::DEFAULT_VALUE;
-                info.running_meter_total = meter->Current();
+        auto& meters = obj->Meters();
+        auto& account_map = m_effect_accounting_map[obj_id];
+        account_map.clear();    // remove any old accounting info. this should be redundant here.
+        account_map.reserve(meters.size());
 
-                if (info.meter_change != 0.0f)
-                    m_effect_accounting_map[obj_id][type].push_back(info);
-            }
+        for (auto& meter_pair : meters) {
+            MeterType type = meter_pair.first;
+            const auto& meter = meter_pair.second;
+            float meter_change = meter.Current() - Meter::DEFAULT_VALUE;
+            if (meter_change != 0.0f)
+                account_map[type].emplace_back(INVALID_OBJECT_ID, ECT_INHERENT, meter_change, meter.Current());
         }
     }
 
@@ -814,6 +835,8 @@ void Universe::UpdateMeterEstimatesImpl(const std::vector<int>& objects_vec, boo
             if (dis_it == m_effect_discrepancy_map.end())
                 continue;   // no discrepancy, so skip to next object
 
+            auto& account_map = m_effect_accounting_map[obj_id];    // reserving space now should be redundant with previous manipulations
+
             // apply all meters' discrepancies
             for (auto& entry : dis_it->second) {
                 MeterType type = entry.first;
@@ -830,12 +853,7 @@ void Universe::UpdateMeterEstimatesImpl(const std::vector<int>& objects_vec, boo
 
                 meter->AddToCurrent(discrepancy);
 
-                Effect::AccountingInfo info;
-                info.cause_type = ECT_UNKNOWN_CAUSE;
-                info.meter_change = discrepancy;
-                info.running_meter_total = meter->Current();
-
-                m_effect_accounting_map[obj_id][type].push_back(info);
+                account_map[type].emplace_back(INVALID_OBJECT_ID, ECT_UNKNOWN_CAUSE, discrepancy, meter->Current());
             }
         }
     }
@@ -1188,7 +1206,7 @@ void Universe::GetEffectsAndTargets(Effect::TargetsCauses& targets_causes,
     // transfer target objects from input vector to a set
     Effect::TargetSet all_potential_targets = m_objects.find(target_objects);
 
-    TraceLogger(effects) << "target objects:";
+    TraceLogger(effects) << "GetEffectsAndTargets target objects:";
     for (auto& obj : all_potential_targets)
         TraceLogger(effects) << obj->Dump();
 

--- a/universe/Universe.h
+++ b/universe/Universe.h
@@ -19,6 +19,7 @@
 #include <set>
 #include <string>
 #include <vector>
+#include <unordered_map>
 
 #include "../util/Export.h"
 

--- a/universe/Universe.h
+++ b/universe/Universe.h
@@ -11,6 +11,7 @@
 #include <boost/signals2/signal.hpp>
 #include <boost/serialization/access.hpp>
 #include <boost/thread/shared_mutex.hpp>
+#include <boost/container/flat_map.hpp>
 
 #include <list>
 #include <map>
@@ -45,9 +46,9 @@ namespace Effect {
     struct SourcedEffectsGroup;
     class EffectsGroup;
     typedef std::vector<std::shared_ptr<UniverseObject>> TargetSet;
-    typedef std::map<int, std::map<MeterType, std::vector<AccountingInfo>>> AccountingMap;
+    typedef std::unordered_map<int, boost::container::flat_map<MeterType, std::vector<AccountingInfo>>> AccountingMap;
     typedef std::vector<std::pair<SourcedEffectsGroup, TargetsAndCause>> TargetsCauses;
-    typedef std::map<int, std::map<MeterType, double>> DiscrepancyMap;
+    typedef std::unordered_map<int, boost::container::flat_map<MeterType, double>> DiscrepancyMap;
 }
 
 namespace ValueRef {


### PR DESCRIPTION
Various optimizations for effect accounting. Seems to reduce time taken moderately in my tests.  Includes:
-Using `flat_map` instead of `map` for meter-value pair storage
-Using `unordered_map` for indexing by object ID
-Reserving space in containers before filling them
-Using in-place construction rather than copy-construction of map contents