### PR TITLE
Force py3 build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -227,12 +227,13 @@ endif()
 ## Collect project dependencies.
 ##
 
-set(MINIMUM_PYTHON_VERSION 2.7)
+set(MINIMUM_PYTHON_VERSION 3.6)
 set(MINIMUM_BOOST_VERSION 1.58.0)
 
 find_package(Threads)
 find_package(PythonInterp ${MINIMUM_PYTHON_VERSION} REQUIRED)
 find_package(PythonLibs ${MINIMUM_PYTHON_VERSION} REQUIRED)
+find_package(Python ${MINIMUM_PYTHON_VERSION} REQUIRED)
 find_package(Boost ${MINIMUM_BOOST_VERSION}
     COMPONENTS
         date_time
@@ -245,25 +246,9 @@ find_package(Boost ${MINIMUM_BOOST_VERSION}
         serialization
         system
         thread
+        python${Python_VERSION_MAJOR}${Python_VERSION_MINOR}
     REQUIRED)
-if(${Boost_VERSION} GREATER 106699) # boost >= 1.67
-    find_package(Boost COMPONENTS python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR} REQUIRED)
-    set(Boost_PYTHON_LIBRARY ${Boost_PYTHON${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}_LIBRARY})
-else()
-    # boost python suffixes are determined by distributives
-    # try different alternatives
-    find_package(Boost OPTIONAL_COMPONENTS python${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR})
-    if(Boost_PYTHON${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}_FOUND)
-        set(Boost_PYTHON_LIBRARY ${Boost_PYTHON${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}_LIBRARY})
-    else()
-        find_package(Boost OPTIONAL_COMPONENTS python-py${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR})
-        if(Boost_PYTHON-PY${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}_FOUND)
-            set(Boost_PYTHON_LIBRARY ${Boost_PYTHON-PY${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}_LIBRARY})
-        else()
-            find_package(Boost COMPONENTS python REQUIRED)
-        endif()
-    endif()
-endif()
+set(Boost_PYTHON_LIBRARY ${Boost_PYTHON${PYTHON_VERSION_MAJOR}${PYTHON_VERSION_MINOR}_LIBRARY})
 
 find_package(ZLIB REQUIRED)
 if(NOT BUILD_HEADLESS)

--- a/cmake/make_versioncpp.py
+++ b/cmake/make_versioncpp.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python2
 
+from __future__ import print_function
 
 import sys
 import os
@@ -43,27 +44,27 @@ class Generator(object):
 
     def execute(self, version, branch, build_no, build_sys):
         if build_no == INVALID_BUILD_NO:
-            print "WARNING: Can't determine git commit!"
+            print("WARNING: Can't determine git commit!")
 
         if os.path.isfile(self.outfile):
             with open(self.outfile) as check_file:
                 check_file_contents = check_file.read()
                 if build_no == INVALID_BUILD_NO:
                     if version in check_file_contents:
-                        print "Version matches version in existing Version.cpp, skip regenerating it"
+                        print("Version matches version in existing Version.cpp, skip regenerating it")
                         return
                 elif build_no in check_file_contents:
-                    print "Build number matches build number in existing Version.cpp, skip regenerating it"
+                    print("Build number matches build number in existing Version.cpp, skip regenerating it")
                     return
 
         try:
             with open(self.infile) as template_file:
                 template = Template(template_file.read())
         except:
-            print "WARNING: Can't access %s, %s not updated!" % (self.infile, self.outfile)
+            print("WARNING: Can't access %s, %s not updated!" % (self.infile, self.outfile))
             return
 
-        print "Writing file: %s" % self.outfile
+        print("Writing file: %s" % self.outfile)
         with open(self.outfile, "w") as generated_file:
             generated_file.write(self.compile_output(template, version, branch, build_no, build_sys))
 
@@ -91,7 +92,7 @@ class NsisInstScriptGenerator(Generator):
                 FreeOrion_DLL_LIST_INSTALL="\n  ".join(['File "..\\' + fname + '"' for fname in dll_files]),
                 FreeOrion_DLL_LIST_UNINSTALL="\n  ".join(['Delete "$INSTDIR\\' + fname + '"' for fname in dll_files]))
         else:
-            print "WARNING: no dll files for installer package found"
+            print("WARNING: no dll files for installer package found")
             return template.substitute(
                 FreeOrion_VERSION=version,
                 FreeOrion_BRANCH=branch,
@@ -102,8 +103,8 @@ class NsisInstScriptGenerator(Generator):
 
 
 if 3 != len(sys.argv):
-    print "ERROR: invalid parameters."
-    print "make_versioncpp.py <project rootdir> <build system name>"
+    print("ERROR: invalid parameters.")
+    print("make_versioncpp.py <project rootdir> <build system name>")
     quit()
 
 os.chdir(sys.argv[1])
@@ -124,18 +125,18 @@ branch = ""
 build_no = INVALID_BUILD_NO
 
 try:
-    branch = check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD']).strip()
+    branch = check_output(['git', 'rev-parse', '--abbrev-ref', 'HEAD'], universal_newlines=True).strip()
     if (branch == "master") or (branch[:7] == "release"):
         branch = ""
     else:
         branch += " "
-    commit = check_output(["git", "show", "-s", "--format=%h", "--abbrev=7", "HEAD"]).strip()
-    timestamp = float(check_output(["git", "show", "-s", "--format=%ct", "HEAD"]).strip())
+    commit = check_output(["git", "show", "-s", "--format=%h", "--abbrev=7", "HEAD"], universal_newlines=True).strip()
+    timestamp = float(check_output(["git", "show", "-s", "--format=%ct", "HEAD"], universal_newlines=True).strip())
     build_no = ".".join([datetime.utcfromtimestamp(timestamp).strftime("%Y-%m-%d"), commit])
 except:
-    print "WARNING: git not installed or not setup correctly"
+    print("WARNING: git not installed or not setup correctly")
 
 for generator in generators:
     generator.execute(version, branch, build_no, build_sys)
 
-print "Building v%s %sbuild %s" % (version, branch, build_no)
+print("Building v%s %sbuild %s" % (version, branch, build_no))

--- a/python/AI/AIFramework.cpp
+++ b/python/AI/AIFramework.cpp
@@ -112,7 +112,11 @@ bool PythonAI::InitModules() {
 
     // allows the "freeOrionAIInterface" C++ module to be imported within Python code
     try {
+#if PY_VERSION_HEX >= 0x03000000
+        PyInit_freeOrionAIInterface();
+#else
         initfreeOrionAIInterface();
+#endif
     } catch (...) {
         ErrorLogger() << "Unable to initialize 'freeOrionAIInterface' AI Python module";
         return false;

--- a/python/CommonFramework.cpp
+++ b/python/CommonFramework.cpp
@@ -94,7 +94,12 @@ bool PythonBase::Initialize()
 
     // allow the "freeorion_logger" C++ module to be imported within Python code
     try {
+#if PY_VERSION_HEX >= 0x03000000
+        PyInit_freeorion_logger();
+#else
         initfreeorion_logger();
+#endif
+
     } catch (...) {
         ErrorLogger() << "Unable to initialize FreeOrion Python logging module";
         return false;

--- a/python/server/ServerFramework.cpp
+++ b/python/server/ServerFramework.cpp
@@ -61,7 +61,11 @@ bool PythonServer::InitModules() {
 
     // Allow the "freeorion" C++ module to be imported within Python code
     try {
+#if PY_VERSION_HEX >= 0x03000000
+        PyInit_freeorion();
+#else
         initfreeorion();
+#endif
     } catch (...) {
         ErrorLogger() << "Unable to initialize 'freeorion' server Python module";
         return false;


### PR DESCRIPTION
Trying to force a python3 build.

Had to port Init functions for python3 builds.
Had to port make_versioncpp.py to python3.

Then tweaked CMake to force using python3 for everything.

The game builds! It even starts up to the main menu! But then starting a single user game fails. Somehow I think that boost-python/AI stuff is broken, as I get an error that I am "disconnected from server" instead of the world getting populated / game starting.

Is freeorion capable of operating in pure python3? If not, I shall be requesting removal of freeorion from Ubuntu 20.04 LTS due in April.