### PR TITLE
Use boost::ranges for ObjectMap::all function

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -107,10 +107,10 @@ std::shared_ptr<const UniverseObject> Empire::Source() const {
 
     // Find any object owned by the empire
     // TODO determine if ExistingObjects() is faster and acceptable
-    for (const auto& obj_it : Objects()) {
-        if (obj_it->OwnedBy(m_id)) {
-            m_source_id = obj_it->ID();
-            return (obj_it);
+    for (const auto& obj : Objects().all()) {
+        if (obj->OwnedBy(m_id)) {
+            m_source_id = obj->ID();
+            return obj;
         }
     }
 
@@ -931,11 +931,10 @@ const std::map<int, std::set<int>> Empire::KnownStarlanes() const {
     TraceLogger(supply) << "Empire::KnownStarlanes for empire " << m_id;
 
     const std::set<int>& known_destroyed_objects = universe.EmpireKnownDestroyedObjectIDs(this->EmpireID());
-    for (auto sys_it = Objects().begin<System>();
-         sys_it != Objects().end<System>(); ++sys_it)
+    for (const auto& sys : Objects().all<System>())
     {
-        int start_id = sys_it->ID();
-        TraceLogger(supply) << "system " << start_id << " has up to " << sys_it->StarlanesWormholes().size() << " lanes / wormholes";
+        int start_id = sys->ID();
+        TraceLogger(supply) << "system " << start_id << " has up to " << sys->StarlanesWormholes().size() << " lanes / wormholes";
 
         // exclude lanes starting at systems known to be destroyed
         if (known_destroyed_objects.count(start_id)) {
@@ -943,7 +942,7 @@ const std::map<int, std::set<int>> Empire::KnownStarlanes() const {
             continue;
         }
 
-        for (const auto& lane : sys_it->StarlanesWormholes()) {
+        for (const auto& lane : sys->StarlanesWormholes()) {
             int end_id = lane.first;
             bool is_wormhole = lane.second;
             if (is_wormhole || known_destroyed_objects.count(end_id))
@@ -965,17 +964,16 @@ const std::map<int, std::set<int>> Empire::VisibleStarlanes() const {
     const Universe& universe = GetUniverse();
     const ObjectMap& objects = universe.Objects();
 
-    for (auto sys_it = objects.begin<System>();
-         sys_it != objects.end<System>(); ++sys_it)
+    for (const auto& sys : objects.all<System>())
     {
-        int start_id = sys_it->ID();
+        int start_id = sys->ID();
 
         // is system visible to this empire?
         if (universe.GetObjectVisibilityByEmpire(start_id, m_id) <= VIS_NO_VISIBILITY)
             continue;
 
         // get system's visible lanes for this empire
-        for (auto& lane : sys_it->VisibleStarlanesWormholes(m_id)) {
+        for (auto& lane : sys->VisibleStarlanesWormholes(m_id)) {
             if (lane.second)
                 continue;   // is a wormhole, not a starlane
             int end_id = lane.first;

--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -181,7 +181,7 @@ namespace {
             return source;
 
         // not a valid source?!  scan through all objects to find one owned by this empire
-        for (const auto& obj : GetUniverse().Objects()) {
+        for (const auto& obj : GetUniverse().Objects().all()) {
             if (obj->OwnedBy(empire_id))
                 return obj;
         }

--- a/UI/ChatWnd.cpp
+++ b/UI/ChatWnd.cpp
@@ -139,16 +139,15 @@ void MessageWndEdit::FindGameWords() {
         m_game_words.insert(entry.second->Name());
         m_game_words.insert(entry.second->PlayerName());
     }
-    auto& objs = GetUniverse().Objects();
     // add system names
-    for (auto sys_it = objs.begin<System>(); sys_it != objs.end<System>(); ++sys_it) {
-        if (sys_it->Name() != "")
-            m_game_words.insert(sys_it->Name());
+    for (auto& system : GetUniverse().Objects().all<System>()) {
+        if (system->Name() != "")
+            m_game_words.insert(system->Name());
     }
      // add ship names
-    for (auto ship_it = objs.begin<Ship>(); ship_it != objs.end<Ship>(); ++ship_it) {
-        if (ship_it->Name() != "")
-            m_game_words.insert(ship_it->Name());
+    for (auto& ship : GetUniverse().Objects().all<Ship>()) {
+        if (ship->Name() != "")
+            m_game_words.insert(ship->Name());
     }
      // add ship design names
 

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -1146,7 +1146,7 @@ namespace {
         // TODO: only loop over planets?
         // TODO: pass in a location condition, and pick a location that matches it if possible
         if (!location) {
-            for (const auto& obj : Objects()) {
+            for (const auto& obj : Objects().all()) {
                 if (obj->OwnedBy(empire_id)) {
                     location = obj;
                     break;
@@ -1577,7 +1577,7 @@ namespace {
 
         // objects that have special
         std::vector<std::shared_ptr<const UniverseObject>> objects_with_special;
-        for (const auto& obj : Objects())
+        for (const auto& obj : Objects().all())
             if (obj->Specials().count(item_name))
                 objects_with_special.push_back(obj);
 

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -2723,7 +2723,7 @@ void MapWnd::InitTurn() {
     ObjectMap& objects = Objects();
 
     TraceLogger(effects) << "MapWnd::InitTurn initial:";
-    for (auto obj : objects)
+    for (auto obj : objects.all())
         TraceLogger(effects) << obj->Dump();
 
     timer.EnterSection("system graph");

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -473,9 +473,7 @@ namespace {
                 return;
 
             const auto& destroyed_objects = GetUniverse().EmpireKnownDestroyedObjectIDs(m_empire_id);
-            for (auto ship_it = Objects().begin<Ship>(); ship_it != Objects().end<Ship>(); ++ship_it) {
-                auto ship = *ship_it;
-
+            for (auto& ship : Objects().all<Ship>()) {
                 if (!ship->OwnedBy(m_empire_id) || destroyed_objects.count(ship->ID()))
                     continue;
                 m_values[FLEET_DETAIL_SHIP_COUNT]++;
@@ -2753,8 +2751,7 @@ void MapWnd::InitTurn() {
 
     timer.EnterSection("fleet signals");
     // connect system fleet add and remove signals
-    for (auto sys_it = objects.begin<System>(); sys_it != objects.end<System>(); ++sys_it) {
-        auto system = *sys_it;
+    for (auto& system : objects.all<System>()) {
         m_system_fleet_insert_remove_signals[system->ID()].push_back(system->FleetsInsertedSignal.connect(
             boost::bind(&MapWnd::FleetsInsertedSignalHandler, this, _1)));
         m_system_fleet_insert_remove_signals[system->ID()].push_back(system->FleetsRemovedSignal.connect(
@@ -2946,8 +2943,8 @@ void MapWnd::InitTurnRendering() {
     m_system_icons.clear();
 
     // create system icons
-    for (auto sys_it = objects.begin<System>(); sys_it != objects.end<System>(); ++sys_it) {
-        int sys_id = (*sys_it)->ID();
+    for (auto& sys : objects.all<System>()) {
+        int sys_id = sys->ID();
 
         // skip known destroyed objects
         if (this_client_known_destroyed_objects.count(sys_id))
@@ -2993,8 +2990,8 @@ void MapWnd::InitTurnRendering() {
     m_field_icons.clear();
 
     // create field icons
-    for (auto fld_it = objects.begin<Field>(); fld_it != objects.end<Field>(); ++fld_it) {
-        int fld_id = (*fld_it)->ID();
+    for (auto& field : objects.all<Field>()) {
+        int fld_id = field->ID();
 
         // skip known destroyed and stale fields
         if (this_client_known_destroyed_objects.count(fld_id))
@@ -4044,7 +4041,7 @@ void MapWnd::InitVisibilityRadiiRenderingBuffers() {
     // for each map position and empire, find max value of detection range at that position
     std::map<std::pair<int, std::pair<float, float>>, float> empire_position_max_detection_ranges;
 
-    for (const auto& obj : Objects()) {
+    for (auto& obj : objects.all<UniverseObject>()) {
         int object_id = obj->ID();
         // skip destroyed objects
         if (destroyed_object_ids.count(object_id))
@@ -5142,8 +5139,9 @@ void MapWnd::RefreshFleetSignals() {
     ScopedTimer timer("RefreshFleetSignals()", true);
     // disconnect old fleet statechangedsignal connections
     for (auto& con : m_fleet_state_change_signals)
-        con.second.disconnect();
+    { con.second.disconnect(); }
     m_fleet_state_change_signals.clear();
+
 
     // connect fleet change signals to update fleet movement lines, so that ordering
     // fleets to move updates their displayed path and rearranges fleet buttons (if necessary)
@@ -6676,8 +6674,7 @@ void MapWnd::RefreshFleetResourceIndicator() {
     const auto& this_client_known_destroyed_objects = GetUniverse().EmpireKnownDestroyedObjectIDs(empire_id);
 
     int total_fleet_count = 0;
-    for (auto shp_it = Objects().begin<Ship>(); shp_it != Objects().end<Ship>(); ++shp_it) {
-        const auto& ship = *shp_it;
+    for (auto& ship : Objects().all<Ship>()) {
         if (ship->OwnedBy(empire_id) && !this_client_known_destroyed_objects.count(ship->ID()))
             total_fleet_count++;
     }
@@ -6903,8 +6900,7 @@ namespace {
     std::set<std::pair<std::string, int>, CustomRowCmp> GetSystemNamesIDs() {
         // get systems, store alphabetized
         std::set<std::pair<std::string, int>, CustomRowCmp> system_names_ids;
-        for (auto sys_it = Objects().begin<System>(); sys_it != Objects().end<System>(); ++sys_it) {
-            const auto& system = *sys_it;
+        for (auto& system : Objects().all<System>()) {
             system_names_ids.insert({system->Name(), system->ID()});
         }
         return system_names_ids;
@@ -6916,7 +6912,7 @@ namespace {
         // get IDs of systems that contain any owned planets
         std::unordered_set<int> system_ids;
         for (auto& obj : owned_planets)
-            system_ids.insert(obj->SystemID());
+        { system_ids.insert(obj->SystemID()); }
 
         // store systems, sorted alphabetically
         std::set<std::pair<std::string, int>, CustomRowCmp> system_names_ids;

--- a/UI/MapWnd.h
+++ b/UI/MapWnd.h
@@ -275,21 +275,6 @@ private:
 
     void RefreshFleetButtonSelectionIndicators();    //!< marks (only) selected fleets' buttons as selected
 
-    /** Connect all \p fleets StateChangedSignal to RefreshFleetButtons. */
-    void AddFleetsStateChangedSignal(const std::vector<std::shared_ptr<Fleet>>& fleets);
-
-    /** Disconnect all \p fleets StateChangedSignal from RefreshFleetButtons. */
-    void RemoveFleetsStateChangedSignal(const std::vector<std::shared_ptr<Fleet>>& fleets);
-
-    /** Handle FleetsInsertedSignal by connecting signals and refreshing fleet
-        buttons. */
-    void FleetsInsertedSignalHandler(const std::vector<std::shared_ptr<Fleet>>& fleets);
-
-    /** Handle FleetsRemovedSignal by disconnecting signals and refreshing fleet
-        buttons. */
-    void FleetsRemovedSignalHandler(const std::vector<std::shared_ptr<Fleet>>& fleets);
-
-
     void DoFleetButtonsLayout();                     //!< does layout of fleet buttons
 
     /** Return fleets ids of all fleet buttons containing or overlapping the
@@ -307,8 +292,6 @@ private:
 
     void DoSystemIconsLayout();          //!< does layout of system icons
     void DoFieldIconsLayout();           //!< does layout of field icons
-
-    void RefreshFleetSignals();          //!< disconnects and reconnects all fleet change signals
 
     void RefreshSliders();               //!< shows or hides sliders on map
 

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -2030,7 +2030,7 @@ public:
         std::map<int, std::set<int>>    planet_buildings;
         std::set<int>                   fields;
 
-        for (const auto& obj : GetUniverse().Objects()) {
+        for (const auto& obj : GetUniverse().Objects().all()) {
             if (!ObjectShown(obj))
                 continue;
 

--- a/combat/CombatLogManager.cpp
+++ b/combat/CombatLogManager.cpp
@@ -84,11 +84,10 @@ CombatLog::CombatLog(const CombatInfo& combat_info) :
 {
     // compile all remaining and destroyed objects' ids
     object_ids = combat_info.destroyed_object_ids;
-    for (auto it = combat_info.objects.begin();
-         it != combat_info.objects.end(); ++it)
+    for (const auto& obj : combat_info.objects.all())
     {
-        object_ids.insert(it->ID());
-        participant_states[it->ID()] = CombatParticipantState(**it);
+        object_ids.insert(obj->ID());
+        participant_states[obj->ID()] = CombatParticipantState(*obj);
     }
 }
 

--- a/python/UniverseWrapper.cpp
+++ b/python/UniverseWrapper.cpp
@@ -77,7 +77,7 @@ namespace {
     {
         std::vector<int> result;
         auto objs = universe.Objects().all<T>();
-        result.reserve(objs.size());
+        result.reserve(universe.Objects().size<T>());
         for (const auto& obj : objs)
             result.push_back(obj->ID());
         return result;

--- a/python/UniverseWrapper.cpp
+++ b/python/UniverseWrapper.cpp
@@ -76,9 +76,8 @@ namespace {
     std::vector<int> ObjectIDs(const Universe& universe)
     {
         std::vector<int> result;
-        auto objs = universe.Objects().all<T>();
         result.reserve(universe.Objects().size<T>());
-        for (const auto& obj : objs)
+        for (const auto& obj : universe.Objects().all<T>())
             result.push_back(obj->ID());
         return result;
     }

--- a/python/UniverseWrapper.cpp
+++ b/python/UniverseWrapper.cpp
@@ -76,9 +76,10 @@ namespace {
     std::vector<int> ObjectIDs(const Universe& universe)
     {
         std::vector<int> result;
-        result.reserve(universe.Objects().size());
-        for (auto it = universe.Objects().begin<T>(); it != universe.Objects().end<T>(); ++it)
-            result.push_back(it->ID());
+        auto objs = universe.Objects().all<T>();
+        result.reserve(objs.size());
+        for (const auto& obj : objs)
+            result.push_back(obj->ID());
         return result;
     }
 

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -2356,7 +2356,7 @@ namespace {
       * updating after combat. */
     void BackProjectSystemCombatInfoObjectMeters(std::vector<CombatInfo>& combats) {
         for (CombatInfo& combat : combats) {
-            for (const auto& object : combat.objects)
+            for (const auto& object : combat.objects.all())
                 object->BackPropagateMeters();
         }
     }
@@ -3517,7 +3517,7 @@ void ServerApp::PostCombatProcessTurns() {
     TraceLogger(effects) << objects.Dump();
 
     // Planet depopulation, some in-C++ meter modifications
-    for (const auto& obj : objects) {
+    for (const auto& obj : objects.all()) {
         obj->PopGrowthProductionResearchPhase();
         obj->ClampMeters();  // ensures no meters are over MAX.  probably redundant with ClampMeters() in Universe::ApplyMeterEffectsAndUpdateMeters()
     }

--- a/universe/ObjectMap.cpp
+++ b/universe/ObjectMap.cpp
@@ -68,7 +68,7 @@ void ObjectMap::Copy(const ObjectMap& copied_map, int empire_id/* = ALL_EMPIRES*
 
     // loop through objects in copied map, copying or cloning each depending
     // on whether there already is a corresponding object in this map
-    for (const auto& obj : copied_map)
+    for (const auto& obj : copied_map.all())
         this->CopyObject(obj, empire_id);
 }
 
@@ -248,7 +248,7 @@ void ObjectMap::AuditContainment(const std::set<int>& destroyed_object_ids) {
     std::map<int, std::set<int>> contained_ships;
     std::map<int, std::set<int>> contained_fields;
 
-    for (const auto& contained : *this) {
+    for (const auto& contained : all()) {
         if (destroyed_object_ids.count(contained->ID()))
             continue;
 
@@ -285,7 +285,7 @@ void ObjectMap::AuditContainment(const std::set<int>& destroyed_object_ids) {
     }
 
     // set contained objects of all possible containers
-    for (const auto& obj : *this) {
+    for (const auto& obj : all()) {
         if (obj->ObjectType() == OBJ_SYSTEM) {
             auto sys = std::dynamic_pointer_cast<System>(obj);
             if (!sys)
@@ -321,7 +321,7 @@ void ObjectMap::CopyObjectsToSpecializedMaps() {
 std::string ObjectMap::Dump(unsigned short ntabs) const {
     std::ostringstream dump_stream;
     dump_stream << "ObjectMap contains UniverseObjects: " << std::endl;
-    for (const auto& obj : *this)
+    for (const auto& obj : all())
         dump_stream << obj->Dump(ntabs) << std::endl;
     dump_stream << std::endl;
     return dump_stream.str();

--- a/universe/ObjectMap.h
+++ b/universe/ObjectMap.h
@@ -2,6 +2,8 @@
 #define _Object_Map_h_
 
 
+#include <boost/range/any_range.hpp>
+#include <boost/range/size.hpp>
 #include <boost/range/adaptor/map.hpp>
 #include <boost/serialization/access.hpp>
 
@@ -66,21 +68,17 @@ public:
     template <class T = UniverseObject>
     std::shared_ptr<T> get(int id);
 
-    /** Returns a vector containing the objects with ids in \a object_ids that
-      * are of type T */
-    template <class T = UniverseObject>
-    std::vector<std::shared_ptr<const T>> find(const std::vector<int>& object_ids) const;
-
-    template <class T = UniverseObject>
-    std::vector<std::shared_ptr<const T>> find(const std::set<int>& object_ids) const;
+    using id_range = boost::any_range<int, boost::forward_traversal_tag>;
 
     /** Returns a vector containing the objects with ids in \a object_ids that
       * are of type T */
     template <class T = UniverseObject>
-    std::vector<std::shared_ptr<T>> find(const std::vector<int>& object_ids);
+    std::vector<std::shared_ptr<const T>> find(const id_range& object_ids) const;
 
+    /** Returns a vector containing the objects with ids in \a object_ids that
+      * are of type T */
     template <class T = UniverseObject>
-    std::vector<std::shared_ptr<T>> find(const std::set<int>& object_ids);
+    std::vector<std::shared_ptr<T>> find(const id_range& object_ids);
 
     /** Returns all the objects that match \a visitor */
     template <class T = UniverseObject>
@@ -253,9 +251,9 @@ std::shared_ptr<T> ObjectMap::get(int id) {
 }
 
 template <class T>
-std::vector<std::shared_ptr<const T>> ObjectMap::find(const std::vector<int>& object_ids) const {
+std::vector<std::shared_ptr<const T>> ObjectMap::find(const id_range& object_ids) const {
     std::vector<std::shared_ptr<const T>> retval;
-    retval.reserve(object_ids.size());
+    retval.reserve(boost::size(object_ids));
     typedef typename std::remove_const<T>::type mutableT;
     for (int object_id : object_ids) {
         auto map_it = Map<mutableT>().find(object_id);
@@ -266,35 +264,9 @@ std::vector<std::shared_ptr<const T>> ObjectMap::find(const std::vector<int>& ob
 }
 
 template <class T>
-std::vector<std::shared_ptr<const T>> ObjectMap::find(const std::set<int>& object_ids) const {
-    std::vector<std::shared_ptr<const T>> retval;
-    retval.reserve(object_ids.size());
-    typedef typename std::remove_const<T>::type mutableT;
-    for (int object_id : object_ids) {
-        auto map_it = Map<mutableT>().find(object_id);
-        if (map_it != Map<mutableT>().end())
-            retval.push_back(std::shared_ptr<const T>(map_it->second));
-    }
-    return retval;
-}
-
-template <class T>
-std::vector<std::shared_ptr<T>> ObjectMap::find(const std::vector<int>& object_ids) {
+std::vector<std::shared_ptr<T>> ObjectMap::find(const id_range& object_ids) {
     std::vector<std::shared_ptr<T>> retval;
-    retval.reserve(object_ids.size());
-    typedef typename std::remove_const<T>::type mutableT;
-    for (int object_id : object_ids) {
-        auto map_it = Map<mutableT>().find(object_id);
-        if (map_it != Map<mutableT>().end())
-            retval.push_back(std::shared_ptr<T>(map_it->second));
-    }
-    return retval;
-}
-
-template <class T>
-std::vector<std::shared_ptr<T>> ObjectMap::find(const std::set<int>& object_ids) {
-    std::vector<std::shared_ptr<T>> retval;
-    retval.reserve(object_ids.size());
+    retval.reserve(boost::size(object_ids));
     typedef typename std::remove_const<T>::type mutableT;
     for (int object_id : object_ids) {
         auto map_it = Map<mutableT>().find(object_id);

--- a/universe/ObjectMap.h
+++ b/universe/ObjectMap.h
@@ -2,6 +2,7 @@
 #define _Object_Map_h_
 
 
+#include <boost/range/adaptor/map.hpp>
 #include <boost/serialization/access.hpp>
 
 #include "../util/Export.h"
@@ -216,11 +217,15 @@ public:
 
     /** Returns all the objects of type T */
     template <class T = UniverseObject>
-    std::vector<std::shared_ptr<const T>> all() const;
+    boost::select_second_const_range<container_type<T>> all() const {
+        return Map<T>() | boost::adaptors::map_values;
+    }
 
     /** Returns all the objects of type T */
     template <class T = UniverseObject>
-    std::vector<std::shared_ptr<T>> all();
+    boost::select_second_mutable_range<container_type<T>> all() {
+        return Map<T>() | boost::adaptors::map_values;
+    }
 
     /** Returns the IDs of all objects not known to have been destroyed. */
     std::vector<int>        FindExistingObjectIDs() const;
@@ -396,24 +401,6 @@ std::shared_ptr<T> ObjectMap::get(int id) {
         it != Map<typename std::remove_const<T>::type>().end()
             ? it->second
             : nullptr);
-}
-
-template <class T>
-std::vector<std::shared_ptr<const T>> ObjectMap::all() const {
-    std::vector<std::shared_ptr<const T>> result;
-    result.reserve(size<T>());
-    for (const auto& entry : Map<T>())
-        result.push_back(entry.second);
-    return result;
-}
-
-template <class T>
-std::vector<std::shared_ptr<T>> ObjectMap::all() {
-    std::vector<std::shared_ptr<T>> result;
-    result.reserve(Map<T>().size());
-    for (const auto& entry : Map<T>())
-        result.push_back(entry.second);
-    return result;
 }
 
 template <class T>

--- a/universe/ObjectMap.h
+++ b/universe/ObjectMap.h
@@ -36,131 +36,6 @@ public:
     template <typename T>
     using container_type = std::map<int, std::shared_ptr<T>>;
 
-    template <typename T>
-    struct iterator : private container_type<T>::iterator {
-        iterator(const typename container_type<T>::iterator& base, ObjectMap& owner) :
-            container_type<T>::iterator(base),
-            m_owner(owner)
-        { Refresh(); }
-
-        std::shared_ptr<T> operator *() const
-        { return m_current_ptr; }
-
-        // The result of this operator is not intended to be stored, so it's safe to
-        // return a reference to an instance variable that's going to be soon overwritten.
-        std::shared_ptr<T>& operator ->() const
-        { return m_current_ptr; }
-
-        iterator& operator ++() {
-            container_type<T>::iterator::operator++();
-            Refresh();
-            return *this;
-        }
-
-        iterator operator ++(int) {
-            iterator result = iterator(container_type<T>::iterator::operator++(0), m_owner);
-            Refresh();
-            return result;
-        }
-
-        iterator& operator --() {
-            container_type<T>::iterator::operator--();
-            Refresh();
-            return *this;
-        }
-
-        iterator operator --(int) {
-            iterator result = iterator(container_type<T>::iterator::operator--(0), m_owner);
-            Refresh();
-            return result;
-        }
-
-        bool operator ==(const iterator& other) const
-        { return (typename container_type<T>::iterator(*this) == other); }
-
-        bool operator !=(const iterator& other) const
-        { return (typename container_type<T>::iterator(*this) != other);}
-
-    private:
-        mutable std::shared_ptr<T> m_current_ptr;
-        ObjectMap& m_owner;
-
-        // We always want m_current_ptr to be pointing to our parent iterator's
-        // current item, if it is a valid object. Otherwise, we just want to
-        // return a "null" pointer.  We assume that we are dealing with valid
-        // iterators in the range [begin(), end()].
-        void Refresh() const {
-            if (typename container_type<T>::iterator(*this) == (m_owner.Map<T>().end())) {
-                m_current_ptr = nullptr;
-            } else {
-                m_current_ptr = std::shared_ptr<T>(container_type<T>::iterator::operator*().second);
-            }
-        }
-    };
-
-    template <typename T>
-    struct const_iterator : private container_type<T>::const_iterator {
-        const_iterator(const typename container_type<T>::const_iterator& base,
-                       const ObjectMap& owner) :
-            container_type<T>::const_iterator(base),
-            m_owner(owner)
-        { Refresh(); }
-
-        std::shared_ptr<const T> operator *() const
-        { return m_current_ptr; }
-
-        // The result of this operator is not intended to be stored, so it's safe to
-        // return a reference to an instance variable that's going to be soon overwritten.
-        std::shared_ptr<const T>& operator ->() const
-        { return m_current_ptr; }
-
-        const_iterator& operator ++() {
-            container_type<T>::const_iterator::operator++();
-            Refresh();
-            return *this;
-        }
-
-        const_iterator operator ++(int) {
-            const_iterator result = container_type<T>::const_iterator::operator++(0);
-            Refresh();
-            return result;
-        }
-
-        const_iterator& operator --() {
-            container_type<T>::const_iterator::operator--();
-            Refresh();
-            return *this;
-        }
-
-        const_iterator operator --(int) {
-            const_iterator result = container_type<T>::const_iterator::operator--(0);
-            Refresh();
-            return result;
-        }
-
-        bool operator ==(const const_iterator& other) const
-        { return (typename container_type<T>::const_iterator(*this) == other); }
-
-        bool operator !=(const const_iterator& other) const
-        { return (typename container_type<T>::const_iterator(*this) != other); }
-
-    private:
-        // See iterator for comments.
-        mutable std::shared_ptr<const T> m_current_ptr;
-        const ObjectMap& m_owner;
-
-        // We always want m_current_ptr to be pointing to our parent iterator's current item, if it is a valid object.
-        // Otherwise, we just want to return a "null" pointer.  We assume that we are dealing with valid iterators in
-        // the range [begin(), end()].
-        void Refresh() const {
-            if (typename container_type<T>::const_iterator(*this) == (m_owner.Map<T>().end())) {
-                m_current_ptr = nullptr;
-            } else {
-                m_current_ptr = std::shared_ptr<T>(container_type<T>::const_iterator::operator*().second);
-            }
-        }
-    };
-
     /** \name Structors */ //@{
     ObjectMap();
     ~ObjectMap();
@@ -232,16 +107,6 @@ public:
 
     /** Returns highest used object ID in this ObjectMap */
     int                     HighestObjectID() const;
-
-    /** iterators */
-    template <class T = UniverseObject>
-    iterator<T>             begin();
-    template <class T = UniverseObject>
-    iterator<T>             end();
-    template <class T = UniverseObject>
-    const_iterator<T>       begin() const;
-    template <class T = UniverseObject>
-    const_iterator<T>       end() const;
 
     std::string             Dump(unsigned short ntabs = 0) const;
 
@@ -368,22 +233,6 @@ private:
     template <class Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
-
-template <class T>
-ObjectMap::iterator<T> ObjectMap::begin()
-{ return iterator<T>(Map<typename std::remove_const<T>::type>().begin(), *this); }
-
-template <class T>
-ObjectMap::iterator<T> ObjectMap::end()
-{ return iterator<T>(Map<typename std::remove_const<T>::type>().end(), *this); }
-
-template <class T>
-ObjectMap::const_iterator<T> ObjectMap::begin() const
-{ return const_iterator<T>(Map<typename std::remove_const<T>::type>().begin(), *this); }
-
-template <class T>
-ObjectMap::const_iterator<T> ObjectMap::end() const
-{ return const_iterator<T>(Map<typename std::remove_const<T>::type>().end(), *this); }
 
 template <class T>
 std::shared_ptr<const T> ObjectMap::get(int id) const {

--- a/universe/UniverseGenerator.cpp
+++ b/universe/UniverseGenerator.cpp
@@ -784,7 +784,7 @@ void SetActiveMetersToTargetMaxCurrentValues(ObjectMap& object_map) {
     TraceLogger(effects) << "SetActiveMetersToTargetMaxCurrentValues";
     // check for each pair of meter types.  if both exist, set active
     // meter current value equal to target meter current value.
-    for (const auto& object : object_map) {
+    for (const auto& object : object_map.all()) {
         TraceLogger(effects) << "  object: " << object->Name() << " (" << object->ID() << ")";
         for (auto& entry : AssociatedMeterTypes()) {
             if (Meter* meter = object->GetMeter(entry.first)) {
@@ -800,7 +800,7 @@ void SetActiveMetersToTargetMaxCurrentValues(ObjectMap& object_map) {
 }
 
 void SetNativePopulationValues(ObjectMap& object_map) {
-    for (const auto& object : object_map) {
+    for (const auto& object : object_map.all()) {
         Meter* meter = object->GetMeter(METER_POPULATION);
         Meter* targetmax_meter = object->GetMeter(METER_TARGET_POPULATION);
         // only applies to unowned planets

--- a/universe/UniverseGenerator.cpp
+++ b/universe/UniverseGenerator.cpp
@@ -658,9 +658,11 @@ void GenerateStarlanes(int max_jumps_between_systems, int max_starlane_length) {
     std::map<int, std::set<int>> potential_system_lanes;
 
     // get systems
-    auto sys_vec = Objects().all<System>();
+    auto sys_rng = Objects().all<System>();
+    std::vector<std::shared_ptr<System>> sys_vec;
     std::map<int, std::shared_ptr<System>> sys_map;
-    std::transform(sys_vec.begin(), sys_vec.end(), std::inserter(sys_map, sys_map.end()),
+    std::copy(sys_rng.begin(), sys_rng.end(), std::back_inserter(sys_vec));
+    std::transform(sys_rng.begin(), sys_rng.end(), std::inserter(sys_map, sys_map.end()),
                    [](const std::shared_ptr<System>& p) { return std::make_pair(p->ID(), p); });
 
     // generate lanes

--- a/util/ModeratorAction.cpp
+++ b/util/ModeratorAction.cpp
@@ -157,8 +157,7 @@ namespace {
     std::string GenerateSystemName() {
         static std::vector<std::string> star_names = UserStringList("STAR_NAMES");
 
-        const ObjectMap& objects = Objects();
-        std::vector<std::shared_ptr<const System>> systems = objects.all<System>();
+        auto systems = Objects().all<System>();
 
         // pick a name for the system
         for (const std::string& star_name : star_names) {

--- a/util/ModeratorAction.cpp
+++ b/util/ModeratorAction.cpp
@@ -157,13 +157,11 @@ namespace {
     std::string GenerateSystemName() {
         static std::vector<std::string> star_names = UserStringList("STAR_NAMES");
 
-        auto systems = Objects().all<System>();
-
         // pick a name for the system
         for (const std::string& star_name : star_names) {
             // does an existing system have this name?
             bool dupe = false;
-            for (auto& system : systems) {
+            for (auto& system : Objects().all<System>()) {
                 if (system->Name() == star_name) {
                     dupe = true;
                     break;  // another system has this name. skip to next potential name.


### PR DESCRIPTION
This PR:

* prevents the generation of an intermediate std::vector for ObjectMap::all calls and returns an boost range instead.
* Accepts a boost::any_range<int> as an input for the ObjectMap::find function to prevent code duplication.
* Drops the ObjectMap::{begin,end} interface and replaces it with the corresponding ObjectMap::{all,find} calls.