### PR TITLE
Replace boost::timer

### DIFF
--- a/AI/AIInterface.cpp
+++ b/AI/AIInterface.cpp
@@ -20,7 +20,6 @@
 #include "../util/Order.h"
 #include "../util/OrderSet.h"
 
-#include <boost/timer.hpp>
 #include <boost/python/str.hpp>
 #include <boost/uuid/random_generator.hpp>
 

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -28,7 +28,6 @@
 
 #include <boost/cast.hpp>
 #include <boost/function.hpp>
-#include <boost/timer.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/fstream.hpp>

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -686,7 +686,7 @@ void EncyclopediaDetailPanel::DoLayout() {
     const int BTN_WIDTH = 24;
     const int Y_OFFSET = 22;
 
-    SectionedScopedTimer timer("EncyclopediaDetailPanel::DoLayout", std::chrono::milliseconds(1));
+    SectionedScopedTimer timer("EncyclopediaDetailPanel::DoLayout", true, std::chrono::milliseconds(1), true);
 
     // name
     GG::Pt ul = GG::Pt(GG::X(6), GG::Y(Y_OFFSET));
@@ -709,7 +709,7 @@ void EncyclopediaDetailPanel::DoLayout() {
     // main verbose description (fluff, effects, unlocks, ...)
     ul = GG::Pt(BORDER_LEFT, ICON_SIZE + BORDER_BOTTOM + TEXT_MARGIN_Y + Y_OFFSET + 1);
     lr = GG::Pt(Width() - BORDER_RIGHT, Height() - BORDER_BOTTOM*3 - PTS - 4);
-    timer.EnterSection("description->SizeMove");
+    timer.EnterSection("m_scroll_panel->SizeMove");
     m_scroll_panel->SizeMove(ul, lr);
     timer.EnterSection("");
 

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -686,7 +686,7 @@ void EncyclopediaDetailPanel::DoLayout() {
     const int BTN_WIDTH = 24;
     const int Y_OFFSET = 22;
 
-    SectionedScopedTimer timer("EncyclopediaDetailPanel::DoLayout", true, std::chrono::milliseconds(1), true);
+    SectionedScopedTimer timer("EncyclopediaDetailPanel::DoLayout");
 
     // name
     GG::Pt ul = GG::Pt(GG::X(6), GG::Y(Y_OFFSET));

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -686,8 +686,7 @@ void EncyclopediaDetailPanel::DoLayout() {
     const int BTN_WIDTH = 24;
     const int Y_OFFSET = 22;
 
-    SectionedScopedTimer timer("EncyclopediaDetailPanel::DoLayout",
-                               std::chrono::milliseconds(1));
+    SectionedScopedTimer timer("EncyclopediaDetailPanel::DoLayout", std::chrono::milliseconds(1));
 
     // name
     GG::Pt ul = GG::Pt(GG::X(6), GG::Y(Y_OFFSET));

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -2713,7 +2713,7 @@ void MapWnd::EnableOrderIssuing(bool enable/* = true*/) {
 void MapWnd::InitTurn() {
     int turn_number = CurrentTurn();
     DebugLogger() << "Initializing turn " << turn_number;
-    SectionedScopedTimer timer("MapWnd::InitTurn", true, std::chrono::milliseconds(1), true);
+    SectionedScopedTimer timer("MapWnd::InitTurn");
     timer.EnterSection("init");
 
     //DebugLogger() << GetSupplyManager().Dump();
@@ -7594,7 +7594,7 @@ namespace {
 
 void MapWnd::DispatchFleetsExploring() {
     DebugLogger() << "MapWnd::DispatchFleetsExploring called";
-    SectionedScopedTimer timer("MapWnd::DispatchFleetsExploring", true, std::chrono::microseconds(1), true);
+    SectionedScopedTimer timer("MapWnd::DispatchFleetsExploring");
 
     int empire_id = HumanClientApp::GetApp()->EmpireID();
     const Empire *empire = GetEmpire(empire_id);

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -51,7 +51,6 @@
 #include "../network/ClientNetworking.h"
 #include "../client/human/HumanClientApp.h"
 
-#include <boost/timer.hpp>
 #include <boost/graph/graph_concepts.hpp>
 #include <boost/unordered_map.hpp>
 #include <boost/optional/optional.hpp>

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -2713,7 +2713,7 @@ void MapWnd::EnableOrderIssuing(bool enable/* = true*/) {
 void MapWnd::InitTurn() {
     int turn_number = CurrentTurn();
     DebugLogger() << "Initializing turn " << turn_number;
-    SectionedScopedTimer timer("MapWnd::InitTurn", std::chrono::milliseconds(1));
+    SectionedScopedTimer timer("MapWnd::InitTurn", true, std::chrono::milliseconds(1), true);
     timer.EnterSection("init");
 
     //DebugLogger() << GetSupplyManager().Dump();
@@ -7594,7 +7594,7 @@ namespace {
 
 void MapWnd::DispatchFleetsExploring() {
     DebugLogger() << "MapWnd::DispatchFleetsExploring called";
-    SectionedScopedTimer timer("MapWnd::DispatchFleetsExploring", true);
+    SectionedScopedTimer timer("MapWnd::DispatchFleetsExploring", true, std::chrono::microseconds(1), true);
 
     int empire_id = HumanClientApp::GetApp()->EmpireID();
     const Empire *empire = GetEmpire(empire_id);

--- a/UI/TechTreeWnd.cpp
+++ b/UI/TechTreeWnd.cpp
@@ -12,6 +12,7 @@
 #include "../util/Logger.h"
 #include "../util/OptionsDB.h"
 #include "../util/Directories.h"
+#include "../util/ScopedTimer.h"
 #include "../universe/Tech.h"
 #include "../universe/Effect.h"
 #include "../universe/ValueRef.h"
@@ -28,8 +29,6 @@
 #include <GG/StaticGraphic.h>
 
 #include <algorithm>
-
-#include <boost/timer.hpp>
 
 namespace {
     const std::string RES_PEDIA_WND_NAME = "research.pedia";
@@ -1842,7 +1841,7 @@ void TechTreeWnd::TechListBox::Update(bool populate /* = true */) {
     DebugLogger() << "Tech List Box Updating";
 
     double insertion_elapsed = 0.0;
-    boost::timer insertion_timer;
+    ScopedTimer insertion_timer;
     GG::X row_width = Width() - ClientUI::ScrollWidth() - ClientUI::Pts();
 
     // Try to preserve the first row, only works if a row for the tech is still visible
@@ -1870,7 +1869,7 @@ void TechTreeWnd::TechListBox::Update(bool populate /* = true */) {
             tech_row->Update();
             insertion_timer.restart();
             auto listbox_row_it = Insert(tech_row);
-            insertion_elapsed += insertion_timer.elapsed();
+            insertion_elapsed += insertion_timer.duration();
             if (!first_tech_set && row.first == first_tech_shown) {
                 first_tech_set = true;
                 SetFirstRowShown(listbox_row_it);
@@ -1900,7 +1899,7 @@ void TechTreeWnd::TechListBox::Populate(bool update /* = true*/) {
 
     GG::X row_width = Width() - ClientUI::ScrollWidth() - ClientUI::Pts();
 
-    boost::timer creation_timer;
+    ScopedTimer creation_timer;
 
     // Skip lookup check when starting with empty cache
     bool new_cache = m_tech_row_cache.empty();
@@ -1909,9 +1908,7 @@ void TechTreeWnd::TechListBox::Populate(bool update /* = true*/) {
             m_tech_row_cache.emplace(tech->Name(), GG::Wnd::Create<TechRow>(row_width, tech->Name()));
     }
 
-    auto creation_elapsed = creation_timer.elapsed();
-
-    DebugLogger() << "Tech List Box Populating Done,  Creation time = " << (creation_elapsed * 1000) << "ms";
+    DebugLogger() << "Tech List Box Populating Done,  Creation time = " << creation_timer.DurationString();
 
     if (update)
         Update(false);

--- a/msvc2017/Parsers/StdAfx.h
+++ b/msvc2017/Parsers/StdAfx.h
@@ -26,7 +26,6 @@
 #include <boost/spirit/include/phoenix.hpp>
 #include <boost/spirit/include/qi.hpp>
 #include <boost/spirit/include/support_argument.hpp>
-#include <boost/timer.hpp>
 #include <boost/uuid/uuid.hpp>
 
 // ------------------

--- a/network/Message.cpp
+++ b/network/Message.cpp
@@ -23,7 +23,6 @@
 #include <boost/serialization/set.hpp>
 #include <boost/serialization/vector.hpp>
 #include <boost/serialization/weak_ptr.hpp>
-#include <boost/timer.hpp>
 #include <boost/date_time/posix_time/time_serialize.hpp>
 #include <boost/uuid/uuid_serialize.hpp>
 #include <boost/uuid/uuid_io.hpp>
@@ -821,9 +820,9 @@ void ExtractGameStartMessageData(const Message& msg, bool& single_player_game, i
                    >> BOOST_SERIALIZATION_NVP(current_turn);
                 GetUniverse().EncodingEmpire() = empire_id;
 
-                boost::timer deserialize_timer;
+                ScopedTimer deserialize_timer;
                 ia >> BOOST_SERIALIZATION_NVP(empires);
-                DebugLogger() << "ExtractGameStartMessage empire deserialization time " << (deserialize_timer.elapsed() * 1000.0);
+                DebugLogger() << "ExtractGameStartMessage empire deserialization time " << deserialize_timer.DurationString();
 
                 ia >> BOOST_SERIALIZATION_NVP(species);
                 combat_logs.Clear();    // only needed when loading new game, not when incrementally serializing logs on turn update
@@ -832,7 +831,7 @@ void ExtractGameStartMessageData(const Message& msg, bool& single_player_game, i
 
                 deserialize_timer.restart();
                 Deserialize(ia, universe);
-                DebugLogger() << "ExtractGameStartMessage universe deserialization time " << (deserialize_timer.elapsed() * 1000.0);
+                DebugLogger() << "ExtractGameStartMessage universe deserialization time " << deserialize_timer.DurationString();
 
 
                 ia >> BOOST_SERIALIZATION_NVP(players)
@@ -866,9 +865,10 @@ void ExtractGameStartMessageData(const Message& msg, bool& single_player_game, i
                >> BOOST_SERIALIZATION_NVP(current_turn);
             GetUniverse().EncodingEmpire() = empire_id;
 
-            boost::timer deserialize_timer;
+            ScopedTimer deserialize_timer;
             ia >> BOOST_SERIALIZATION_NVP(empires);
-            DebugLogger() << "ExtractGameStartMessage empire deserialization time " << (deserialize_timer.elapsed() * 1000.0);
+
+            DebugLogger() << "ExtractGameStartMessage empire deserialization time " << deserialize_timer.DurationString();
 
             ia >> BOOST_SERIALIZATION_NVP(species);
             combat_logs.Clear();    // only needed when loading new game, not when incrementally serializing logs on turn update
@@ -877,29 +877,29 @@ void ExtractGameStartMessageData(const Message& msg, bool& single_player_game, i
 
             deserialize_timer.restart();
             Deserialize(ia, universe);
-            DebugLogger() << "ExtractGameStartMessage universe deserialization time " << (deserialize_timer.elapsed() * 1000.0);
+            DebugLogger() << "ExtractGameStartMessage universe deserialization time " << deserialize_timer.DurationString();;
 
 
             ia >> BOOST_SERIALIZATION_NVP(players)
                >> BOOST_SERIALIZATION_NVP(loaded_game_data);
-            TraceLogger() << "ExtractGameStartMessage players and loaded_game_data=" << loaded_game_data << " deserialization time " << (deserialize_timer.elapsed() * 1000.0);
+            TraceLogger() << "ExtractGameStartMessage players and loaded_game_data=" << loaded_game_data << " deserialization time " << deserialize_timer.DurationString();
             if (loaded_game_data) {
                 Deserialize(ia, orders);
-                TraceLogger() << "ExtractGameStartMessage orders deserialization time " << (deserialize_timer.elapsed() * 1000.0);
+                TraceLogger() << "ExtractGameStartMessage orders deserialization time " << deserialize_timer.DurationString();
                 ia >> BOOST_SERIALIZATION_NVP(ui_data_available);
                 if (ui_data_available)
                     ia >> BOOST_SERIALIZATION_NVP(ui_data);
-                TraceLogger() << "ExtractGameStartMessage UI data " << ui_data_available << " deserialization time " << (deserialize_timer.elapsed() * 1000.0);
+                TraceLogger() << "ExtractGameStartMessage UI data " << ui_data_available << " deserialization time " << deserialize_timer.DurationString();
                 ia >> BOOST_SERIALIZATION_NVP(save_state_string_available);
                 if (save_state_string_available)
                     ia >> BOOST_SERIALIZATION_NVP(save_state_string);
-                TraceLogger() << "ExtractGameStartMessage save state " << save_state_string_available << " deserialization time " << (deserialize_timer.elapsed() * 1000.0);
+                TraceLogger() << "ExtractGameStartMessage save state " << save_state_string_available << " deserialization time " << deserialize_timer.DurationString();
             } else {
                 ui_data_available = false;
                 save_state_string_available = false;
             }
             ia >> BOOST_SERIALIZATION_NVP(galaxy_setup_data);
-            TraceLogger() << "ExtractGameStartMessage galaxy setup data deserialization time " << (deserialize_timer.elapsed() * 1000.0);
+            TraceLogger() << "ExtractGameStartMessage galaxy setup data deserialization time " << deserialize_timer.DurationString();
         }
 
     } catch (const std::exception& err) {

--- a/parse/ParseImpl.h
+++ b/parse/ParseImpl.h
@@ -176,7 +176,7 @@ namespace parse { namespace detail {
 
     template <typename Grammar, typename Arg1>
     bool parse_file(const lexer& lexer, const boost::filesystem::path& path, Arg1& arg1) {
-        SectionedScopedTimer timer("parse_file \"" + path.filename().string()  + "\"", true, std::chrono::milliseconds(10), true);
+        SectionedScopedTimer timer("parse_file \"" + path.filename().string()  + "\"", std::chrono::milliseconds(10));
 
         std::string filename;
         std::string file_contents;
@@ -200,7 +200,7 @@ namespace parse { namespace detail {
 
     template <typename Grammar, typename Arg1, typename Arg2>
     bool parse_file(const lexer& lexer, const boost::filesystem::path& path, Arg1& arg1, Arg2& arg2) {
-        SectionedScopedTimer timer("parse_file \"" + path.filename().string()  + "\"", true, std::chrono::microseconds(1000), true);
+        SectionedScopedTimer timer("parse_file \"" + path.filename().string()  + "\"", std::chrono::milliseconds(10));
 
         std::string filename;
         std::string file_contents;

--- a/parse/ParseImpl.h
+++ b/parse/ParseImpl.h
@@ -176,7 +176,7 @@ namespace parse { namespace detail {
 
     template <typename Grammar, typename Arg1>
     bool parse_file(const lexer& lexer, const boost::filesystem::path& path, Arg1& arg1) {
-        SectionedScopedTimer timer("parse_file \"" + path.filename().string()  + "\"", std::chrono::milliseconds(10));
+        SectionedScopedTimer timer("parse_file \"" + path.filename().string()  + "\"", true, std::chrono::milliseconds(10), true);
 
         std::string filename;
         std::string file_contents;
@@ -200,7 +200,7 @@ namespace parse { namespace detail {
 
     template <typename Grammar, typename Arg1, typename Arg2>
     bool parse_file(const lexer& lexer, const boost::filesystem::path& path, Arg1& arg1, Arg2& arg2) {
-        SectionedScopedTimer timer("parse_file \"" + path.filename().string()  + "\"", std::chrono::microseconds(1000));
+        SectionedScopedTimer timer("parse_file \"" + path.filename().string()  + "\"", true, std::chrono::microseconds(1000), true);
 
         std::string filename;
         std::string file_contents;

--- a/parse/ParseImpl.h
+++ b/parse/ParseImpl.h
@@ -8,7 +8,6 @@
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/filesystem/path.hpp>
 #include <boost/spirit/include/qi.hpp>
-#include <boost/timer.hpp>
 
 #include <GG/Clr.h>
 

--- a/python/AI/AIFramework.cpp
+++ b/python/AI/AIFramework.cpp
@@ -6,6 +6,7 @@
 #include "../../util/Logger.h"
 #include "../../util/i18n.h"
 #include "../../util/OptionsDB.h"
+#include "../../util/ScopedTimer.h"
 #include "../../Empire/Empire.h"
 #include "../../Empire/Diplomacy.h"
 #include "../CommonFramework.h"
@@ -18,7 +19,6 @@
 #include <boost/python/suite/indexing/map_indexing_suite.hpp>
 #include <boost/python/docstring_options.hpp>
 #include <boost/mpl/vector.hpp>
-#include <boost/timer.hpp>
 #include <boost/python/list.hpp>
 #include <boost/python/extract.hpp>
 #include <boost/python/scope.hpp>
@@ -139,7 +139,7 @@ void PythonAI::GenerateOrders() {
     DebugLogger() << "PythonAI::GenerateOrders : initializing turn";
     //AIInterface::InitTurn();
 
-    boost::timer order_timer;
+    ScopedTimer order_timer;
     try {
         // call Python function that generates orders for current turn
         //DebugLogger() << "PythonAI::GenerateOrders : getting generate orders object";
@@ -154,7 +154,7 @@ void PythonAI::GenerateOrders() {
         ErrorLogger() << "PythonAI::GenerateOrders : Python error caught.  Partial orders sent to server";
     }
     AIInterface::DoneTurn();
-    DebugLogger() << "PythonAI::GenerateOrders order generating time: " << (order_timer.elapsed() * 1000.0) << " ms";
+    DebugLogger() << "PythonAI::GenerateOrders order generating time: " << order_timer.DurationString();
 }
 
 void PythonAI::HandleChatMessage(int sender_id, const std::string& msg) {

--- a/python/AI/AIWrapper.cpp
+++ b/python/AI/AIWrapper.cpp
@@ -21,7 +21,6 @@
 #include <boost/python/suite/indexing/vector_indexing_suite.hpp>
 #include <boost/python/suite/indexing/map_indexing_suite.hpp>
 #include <boost/mpl/vector.hpp>
-#include <boost/timer.hpp>
 #include <boost/python/list.hpp>
 #include <boost/python/extract.hpp>
 #include <boost/python/scope.hpp>

--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -15,7 +15,6 @@
 #include "../Empire/Supply.h"
 
 #include <boost/bind.hpp>
-#include <boost/timer.hpp>
 
 namespace {
     const bool ALLOW_ALLIED_SUPPLY = true;

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -1224,7 +1224,7 @@ void Universe::GetEffectsAndTargets(Effect::TargetsCauses& targets_causes,
     boost::shared_mutex global_mutex;
     boost::unique_lock<boost::shared_mutex> global_lock(global_mutex); // create after run_queue, destroy before run_queue
 
-    SectionedScopedTimer type_timer("Effect TargetSets Evaluation", true, std::chrono::microseconds(0));
+    SectionedScopedTimer type_timer("Effect TargetSets Evaluation", true, std::chrono::microseconds(0), true);
 
     // 1) EffectsGroups from Species
     type_timer.EnterSection("species");

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -1224,7 +1224,7 @@ void Universe::GetEffectsAndTargets(Effect::TargetsCauses& targets_causes,
     boost::shared_mutex global_mutex;
     boost::unique_lock<boost::shared_mutex> global_lock(global_mutex); // create after run_queue, destroy before run_queue
 
-    SectionedScopedTimer type_timer("Effect TargetSets Evaluation", true, std::chrono::microseconds(0), true);
+    SectionedScopedTimer type_timer("Effect TargetSets Evaluation", std::chrono::microseconds(0));
 
     // 1) EffectsGroups from Species
     type_timer.EnterSection("species");

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -1213,28 +1213,26 @@ void Universe::GetEffectsAndTargets(Effect::TargetsCauses& targets_causes,
     std::map<int, std::shared_ptr<ConditionCache>> cached_source_condition_matches;
 
     // prepopulate the cache for safe concurrent access
-    for (const auto& obj : m_objects.all()) {
+    for (const auto& obj : m_objects.all())
         cached_source_condition_matches[obj->ID()] = std::make_shared<ConditionCache>();
-    }
-
     cached_source_condition_matches[INVALID_OBJECT_ID] = std::make_shared<ConditionCache>();
-
     ConditionCache& invariant_condition_matches = *cached_source_condition_matches[INVALID_OBJECT_ID];
 
-    std::list<Effect::TargetsCauses> targets_causes_reorder_buffer; // create before run_queue, destroy after run_queue
+    std::list<Effect::TargetsCauses> targets_causes_reorder_buffer; // list not vector to avoid invaliding iterators when pushing more items onto list due to vector reallocation
     unsigned int num_threads = static_cast<unsigned int>(std::max(1, EffectsProcessingThreads()));
     RunQueue<StoreTargetsAndCausesOfEffectsGroupsWorkItem> run_queue(num_threads);
     boost::shared_mutex global_mutex;
     boost::unique_lock<boost::shared_mutex> global_lock(global_mutex); // create after run_queue, destroy before run_queue
 
+    SectionedScopedTimer type_timer("Effect TargetSets Evaluation", true, std::chrono::microseconds(0));
 
     // 1) EffectsGroups from Species
+    type_timer.EnterSection("species");
     TraceLogger(effects) << "Universe::GetEffectsAndTargets for SPECIES";
-    ScopedTimer type_timer;
-    ScopedTimer eval_timer;
 
     // find each species planets in single pass, maintaining object map order per-species
     std::map<std::string, std::vector<std::shared_ptr<const UniverseObject>>> species_objects;
+
     for (auto& planet : m_objects.all<Planet>()) {
         if (m_destroyed_object_ids.count(planet->ID()))
             continue;
@@ -1248,9 +1246,6 @@ void Universe::GetEffectsAndTargets(Effect::TargetsCauses& targets_causes,
         }
         species_objects[species_name].push_back(planet);
     }
-
-    double planet_species_time = type_timer.duration();
-    type_timer.restart();
 
     // find each species ships in single pass, maintaining object map order per-species
     for (auto& ship : m_objects.all<Ship>()) {
@@ -1266,7 +1261,6 @@ void Universe::GetEffectsAndTargets(Effect::TargetsCauses& targets_causes,
         }
         species_objects[species_name].push_back(ship);
     }
-    double ship_species_time = type_timer.duration();
 
     // enforce species effects order
     for (const auto& entry : GetSpeciesManager()) {
@@ -1289,8 +1283,8 @@ void Universe::GetEffectsAndTargets(Effect::TargetsCauses& targets_causes,
     }
 
     // 2) EffectsGroups from Specials
+    type_timer.EnterSection("specials");
     TraceLogger(effects) << "Universe::GetEffectsAndTargets for SPECIALS";
-    type_timer.restart();
     std::map<std::string, std::vector<std::shared_ptr<const UniverseObject>>> specials_objects;
     // determine objects with specials in a single pass
     for (const auto& obj : m_objects.all()) {
@@ -1324,11 +1318,10 @@ void Universe::GetEffectsAndTargets(Effect::TargetsCauses& targets_causes,
                 global_mutex));
         }
     }
-    double special_time = type_timer.duration();
 
     // 3) EffectsGroups from Techs
+    type_timer.EnterSection("techs");
     TraceLogger(effects) << "Universe::GetEffectsAndTargets for TECHS";
-    type_timer.restart();
     std::list<std::vector<std::shared_ptr<const UniverseObject>>> tech_sources;
     for (auto& entry : Empires()) {
         const Empire* empire = entry.second;
@@ -1352,12 +1345,10 @@ void Universe::GetEffectsAndTargets(Effect::TargetsCauses& targets_causes,
             }
         }
     }
-    double tech_time = type_timer.duration();
 
     // 4) EffectsGroups from Buildings
+    type_timer.EnterSection("buildings");
     TraceLogger(effects) << "Universe::GetEffectsAndTargets for BUILDINGS";
-    type_timer.restart();
-
     // determine buildings of each type in a single pass
     std::map<std::string, std::vector<std::shared_ptr<const UniverseObject>>> buildings_by_type;
     for (auto& building : m_objects.all<Building>()) {
@@ -1392,16 +1383,16 @@ void Universe::GetEffectsAndTargets(Effect::TargetsCauses& targets_causes,
                 global_mutex));
         }
     }
-    double building_time = type_timer.duration();
 
     // 5) EffectsGroups from Ship Hull and Ship Parts
+    type_timer.EnterSection("ship hull/parts");
     TraceLogger(effects) << "Universe::GetEffectsAndTargets for SHIPS hulls and parts";
-    type_timer.restart();
     // determine ship hulls and parts of each type in a single pass
     // the same ship might be added multiple times if it contains the part multiple times
     // recomputing targets for the same ship and part is kind of silly here, but shouldn't hurt
     std::map<std::string, std::vector<std::shared_ptr<const UniverseObject>>> ships_by_hull_type;
     std::map<std::string, std::vector<std::shared_ptr<const UniverseObject>>> ships_by_part_type;
+
     for (auto& ship : m_objects.all<Ship>()) {
         if (m_destroyed_object_ids.count(ship->ID()))
             continue;
@@ -1468,11 +1459,10 @@ void Universe::GetEffectsAndTargets(Effect::TargetsCauses& targets_causes,
                 global_mutex));
         }
     }
-    double ships_time = type_timer.duration();
 
     // 6) EffectsGroups from Fields
+    type_timer.EnterSection("fields");
     TraceLogger(effects) << "Universe::GetEffectsAndTargets for FIELDS";
-    type_timer.restart();
     // determine fields of each type in a single pass
     std::map<std::string, std::vector<std::shared_ptr<const UniverseObject>>> fields_by_type;
     for (auto& field : m_objects.all<Field>()) {
@@ -1508,30 +1498,16 @@ void Universe::GetEffectsAndTargets(Effect::TargetsCauses& targets_causes,
                 global_mutex));
         }
     }
-    double fields_time = type_timer.duration();
 
+    type_timer.EnterSection("eval waiting");
     run_queue.Wait(global_lock);
-    double eval_time = eval_timer.duration();
 
-    eval_timer.restart();
     // add results to targets_causes in issue order
-    // FIXME: each job is an effectsgroup, and we need that separation for
-    // execution anyway, so maintain it here instead of merging.
-    for (const Effect::TargetsCauses& job_results : targets_causes_reorder_buffer) {
-        for (const std::pair<Effect::SourcedEffectsGroup, Effect::TargetsAndCause>& result : job_results) {
-            targets_causes.push_back(result);
-        }
-    }
-    double reorder_time = eval_timer.duration();
-    DebugLogger() << "Issue times: planet species: " << planet_species_time*1000
-                  << " ship species: " << ship_species_time*1000
-                  << " specials: " << special_time*1000
-                  << " techs: " << tech_time*1000
-                  << " buildings: " << building_time*1000
-                  << " hulls/parts: " << ships_time*1000
-                  << " fields: " << fields_time*1000;
-    DebugLogger() << "Evaluation time: " << eval_time*1000
-                  << " reorder time: " << reorder_time*1000;
+    // FIXME: each job is an effectsgroup, and we need that separation for execution anyway, so maintain it here instead of merging.
+    type_timer.EnterSection("reordering");
+    for (const auto& job_results : targets_causes_reorder_buffer)
+        for (const auto& result : job_results)
+            targets_causes.push_back(result);   // looping over targets_causes_reorder_buffer to sum up the sizes of job_results in order to reserve space in targets_causes was slower than just push_back into targets_causes and letting it reallocate itself as needed, in my test
 }
 
 void Universe::ExecuteEffects(const Effect::TargetsCauses& targets_causes,

--- a/util/ScopedTimer.cpp
+++ b/util/ScopedTimer.cpp
@@ -173,28 +173,19 @@ public:
 
     /** The destructor will print the table of accumulated times. */
     ~Impl() {
-        if (!m_enable_output)
+        if (!m_enable_output || !m_sections)
             return;
 
-        std::chrono::nanoseconds duration =
-            std::chrono::high_resolution_clock::now() - m_start;
+        std::chrono::nanoseconds duration = std::chrono::high_resolution_clock::now() - m_start;
 
-        if (duration > m_threshold)
+        if (duration < m_threshold)
             return;
 
-        // No table so use basic ScopedTimer output.
-        if (!m_sections)
-            return;
+        EnterSection("");   // Stop the final section
 
-        //Stop the final section.
-        EnterSection("");
+        if (m_sections->m_section_names.size() == 1 && *m_sections->m_section_names.begin() == "")
+            return; // Don't print the table if the only section is the default section
 
-        // Don't print the table if the only section is the default section
-        auto only_section_is_the_default =
-            (m_sections->m_section_names.size() == 1
-             && *m_sections->m_section_names.begin() == "");
-        if (only_section_is_the_default)
-            return;
 
         //Print the section times followed by the total time elapsed.
 
@@ -212,7 +203,7 @@ public:
             }
 
             // is duration yet long enough to output?
-            if (jt->second > m_threshold)
+            if (jt->second < m_threshold)
                 continue;
 
             // Create a header with padding, so all times align.

--- a/util/ScopedTimer.cpp
+++ b/util/ScopedTimer.cpp
@@ -73,7 +73,7 @@ public:
             ss << std::chrono::duration_cast<std::chrono::microseconds>(duration).count() << " µs";
 
         } else if (duration >= std::chrono::microseconds(2)) {
-            auto ns{std::chrono::duration_cast<std::chrono::microseconds>(duration).count()};
+            auto ns{std::chrono::duration_cast<std::chrono::nanoseconds>(duration).count()};
             ss << (ns / 100) / 10.0 << " µs";    // round to 10ths of microseconds
 
         } else {

--- a/util/ScopedTimer.cpp
+++ b/util/ScopedTimer.cpp
@@ -179,8 +179,8 @@ class SectionedScopedTimer::Impl : public ScopedTimer::Impl {
     };
 
 public:
-    Impl(const std::string& timed_name, bool enable_output,
-         std::chrono::microseconds threshold, bool unify_section_duration_units) :
+    Impl(const std::string& timed_name, std::chrono::microseconds threshold,
+         bool enable_output, bool unify_section_duration_units) :
         ScopedTimer::Impl(timed_name, enable_output, threshold),
         m_unify_units(unify_section_duration_units)
     {}
@@ -283,10 +283,10 @@ private:
 };
 
 SectionedScopedTimer::SectionedScopedTimer(const std::string& timed_name,
-                                           bool enable_output,
                                            std::chrono::microseconds threshold,
+                                           bool enable_output,
                                            bool unify_section_duration_units) :
-    m_impl(new Impl(timed_name, enable_output, threshold, unify_section_duration_units))
+    m_impl(new Impl(timed_name, threshold, enable_output, unify_section_duration_units))
 {}
 
 // ~SectionedScopedTimer is required because Impl is defined here.

--- a/util/ScopedTimer.cpp
+++ b/util/ScopedTimer.cpp
@@ -55,14 +55,30 @@ public:
 
     static void FormatDuration(std::stringstream& ss, const std::chrono::nanoseconds& duration) {
         ss << std::setw(8) << std::right;
-        if (duration >= std::chrono::seconds(2))
+        if (duration >= std::chrono::seconds(20)) {
             ss << std::chrono::duration_cast<std::chrono::seconds>(duration).count() << " s";
-        else if (duration >= std::chrono::milliseconds(2))
+
+        } else if (duration >= std::chrono::seconds(2)) {
+            auto ms{std::chrono::duration_cast<std::chrono::milliseconds>(duration).count()};
+            ss << (ms / 100) / 10.0 << " s";    // round to 10ths of seconds
+
+        } else if (duration >= std::chrono::milliseconds(20)) {
             ss << std::chrono::duration_cast<std::chrono::milliseconds>(duration).count() << " ms";
-        else if (duration >= std::chrono::microseconds(2))
+
+        } else if (duration >= std::chrono::milliseconds(2)) {
+            auto ms{std::chrono::duration_cast<std::chrono::microseconds>(duration).count()};
+            ss << (ms / 100) / 10.0 << " ms";    // round to 10ths of milliseconds
+
+        } else if (duration >= std::chrono::microseconds(20)) {
             ss << std::chrono::duration_cast<std::chrono::microseconds>(duration).count() << " µs";
-        else
+
+        } else if (duration >= std::chrono::microseconds(2)) {
+            auto ns{std::chrono::duration_cast<std::chrono::microseconds>(duration).count()};
+            ss << (ns / 100) / 10.0 << " µs";    // round to 10ths of microseconds
+
+        } else {
             ss << std::chrono::duration_cast<std::chrono::nanoseconds>(duration).count() << " ns";
+        }
     }
 
     std::chrono::high_resolution_clock::time_point m_start;

--- a/util/ScopedTimer.h
+++ b/util/ScopedTimer.h
@@ -18,10 +18,15 @@
 //! print output.
 class FO_COMMON_API ScopedTimer {
 public:
-    ScopedTimer(const std::string& timed_name, bool enable_output = false,
-                std::chrono::microseconds threshold = std::chrono::milliseconds(1));
+    explicit ScopedTimer(const std::string& timed_name = "", bool enable_output = false,
+                         std::chrono::microseconds threshold = std::chrono::milliseconds(1));
     ScopedTimer(const std::string& timed_name, std::chrono::microseconds threshold);
     ~ScopedTimer();
+
+    void restart();
+
+    double duration() const;
+    std::string DurationString() const;
 
     class Impl;
 

--- a/util/ScopedTimer.h
+++ b/util/ScopedTimer.h
@@ -100,8 +100,8 @@ private:
 class FO_COMMON_API SectionedScopedTimer {
 public:
     SectionedScopedTimer(const std::string& timed_name, bool enable_output = false,
-                         std::chrono::microseconds threshold = std::chrono::milliseconds(1));
-    SectionedScopedTimer(const std::string& timed_name, std::chrono::microseconds threshold);
+                         std::chrono::microseconds threshold = std::chrono::milliseconds(1),
+                         bool unify_section_duration_units = false);
     ~SectionedScopedTimer();
 
     //! Start recording times for @p section_name.

--- a/util/ScopedTimer.h
+++ b/util/ScopedTimer.h
@@ -63,7 +63,7 @@ private:
 //! ```{.cpp}
 //! void function_to_profile () {
 //!
-//!     SectionedScopedTimer timer("Title", std::chrono::milliseconds(1));
+//!     SectionedScopedTimer timer("Title");
 //!     timer.EnterSection("initial section");
 //!
 //!     profiled_code();
@@ -99,9 +99,10 @@ private:
 //! ```
 class FO_COMMON_API SectionedScopedTimer {
 public:
-    SectionedScopedTimer(const std::string& timed_name, bool enable_output = false,
-                         std::chrono::microseconds threshold = std::chrono::milliseconds(1),
-                         bool unify_section_duration_units = false);
+    explicit SectionedScopedTimer(const std::string& timed_name,
+                                  std::chrono::microseconds threshold = std::chrono::milliseconds(1),
+                                  bool enable_output = true,
+                                  bool unify_section_duration_units = true);
     ~SectionedScopedTimer();
 
     //! Start recording times for @p section_name.


### PR DESCRIPTION
As reported [here](https://www.freeorion.org/forum/viewtopic.php?f=9&t=11501) `boost::timer` is deprecated. This adapts `ScopedTimer` to replace it.