### PR TITLE
Simplify predicates

### DIFF
--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -273,8 +273,8 @@ namespace {
 
         float accumulator_current = 0.0f;
 
-        for (auto obj : Objects().find(OwnedVisitor<UniverseObject>(empire_id))) {
-            if (!obj || !obj->OwnedBy(empire_id))
+        for (auto obj : Objects().find(OwnedVisitor(empire_id))) {
+            if (!obj)
                 continue;
             if (obj->Meters().count(METER_SUPPLY) > 0)
                 accumulator_current += obj->CurrentMeterValue(METER_SUPPLY);

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -1681,7 +1681,7 @@ namespace {
 
 
         // Planets
-        auto empire_planets = Objects().find<Planet>(OwnedVisitor<Planet>(empire_id));
+        auto empire_planets = Objects().find<Planet>(OwnedVisitor(empire_id));
         if (!empire_planets.empty()) {
             detailed_description += "\n\n" + UserString("OWNED_PLANETS");
             for (auto& obj : empire_planets) {
@@ -1693,7 +1693,7 @@ namespace {
 
         // Fleets
         std::vector<std::shared_ptr<const UniverseObject>> nonempty_empire_fleets;
-        for (const auto& fleet : Objects().find<Fleet>(OwnedVisitor<Fleet>(empire_id))) {
+        for (const auto& fleet : Objects().find<Fleet>(OwnedVisitor(empire_id))) {
             if (!fleet->Empty())
                 nonempty_empire_fleets.push_back(fleet);
         }

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -7314,7 +7314,7 @@ namespace {
         }
 
         auto ignore_hostile = GetOptionsDB().Get<bool>("ui.fleet.explore.hostile.ignored");
-        auto fleet_pred = std::make_shared<HostileVisitor<Fleet>>(empire_id);
+        auto fleet_pred = std::make_shared<HostileVisitor>(empire_id);
         std::pair<std::list<int>, double> route_distance;
 
         if (ignore_hostile)

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -6885,7 +6885,7 @@ namespace {
     }
 
     std::set<std::pair<std::string, int>, CustomRowCmp> GetOwnedSystemNamesIDs(int empire_id) {
-        auto owned_planets = Objects().find<Planet>(OwnedVisitor<Planet>(empire_id));
+        auto owned_planets = Objects().find<Planet>(OwnedVisitor(empire_id));
 
         // get IDs of systems that contain any owned planets
         std::unordered_set<int> system_ids;
@@ -7044,7 +7044,7 @@ bool MapWnd::ZoomToNextIdleFleet() {
 }
 
 bool MapWnd::ZoomToPrevFleet() {
-    auto vec = GetUniverse().Objects().find<Fleet>(OwnedVisitor<Fleet>(HumanClientApp::GetApp()->EmpireID()));
+    auto vec = GetUniverse().Objects().find<Fleet>(OwnedVisitor(HumanClientApp::GetApp()->EmpireID()));
     auto it = std::find_if(vec.begin(), vec.end(),
         [this](const std::shared_ptr<UniverseObject>& o){ return o->ID() == this->m_current_fleet_id; });
     const auto& destroyed_object_ids = GetUniverse().DestroyedObjectIds();
@@ -7065,7 +7065,7 @@ bool MapWnd::ZoomToPrevFleet() {
 }
 
 bool MapWnd::ZoomToNextFleet() {
-    auto vec = GetUniverse().Objects().find<Fleet>(OwnedVisitor<Fleet>(HumanClientApp::GetApp()->EmpireID()));
+    auto vec = GetUniverse().Objects().find<Fleet>(OwnedVisitor(HumanClientApp::GetApp()->EmpireID()));
     auto it = std::find_if(vec.begin(), vec.end(),
         [this](const std::shared_ptr<UniverseObject>& o){ return o->ID() == this->m_current_fleet_id; });
     auto& destroyed_object_ids = GetUniverse().DestroyedObjectIds();

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -3280,7 +3280,7 @@ void SidePanel::RefreshImpl() {
     if (m_selection_enabled) {
         int empire_id = HumanClientApp::GetApp()->EmpireID();
         if (empire_id != ALL_EMPIRES)
-            vistor = std::make_shared<OwnedVisitor<Planet>>(empire_id);
+            vistor = std::make_shared<OwnedVisitor>(empire_id);
     }
     m_planet_panel_container->SetValidSelectionPredicate(vistor);
 
@@ -3528,7 +3528,7 @@ bool SidePanel::PlanetSelectable(int planet_id) const {
     std::shared_ptr<UniverseObjectVisitor> selectable_visitor;
     int empire_id = HumanClientApp::GetApp()->EmpireID();
     if (empire_id != ALL_EMPIRES)
-        selectable_visitor = std::make_shared<OwnedVisitor<Planet>>(empire_id);
+        selectable_visitor = std::make_shared<OwnedVisitor>(empire_id);
 
     if (!selectable_visitor)
         return true;

--- a/python/UniverseWrapper.cpp
+++ b/python/UniverseWrapper.cpp
@@ -121,7 +121,7 @@ namespace {
 
     std::vector<int> ShortestNonHostilePath(const Universe& universe, int start_sys, int end_sys, int empire_id) {
         std::vector<int> retval;
-        auto fleet_pred = std::make_shared<HostileVisitor<System>>(empire_id);
+        auto fleet_pred = std::make_shared<HostileVisitor>(empire_id);
         std::pair<std::list<int>, int> path = universe.GetPathfinder()->ShortestPath(start_sys, end_sys, empire_id, fleet_pred);
         std::copy(path.first.begin(), path.first.end(), std::back_inserter(retval));
         return retval;

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -1780,7 +1780,7 @@ bool ServerApp::EliminatePlayer(const PlayerConnectionPtr& player_connection) {
     }
 
     // test for colonies count
-    auto planets = Objects().find<Planet>(OwnedVisitor<Planet>(empire_id));
+    auto planets = Objects().find<Planet>(OwnedVisitor(empire_id));
     if (planets.size() > static_cast<size_t>(GetGameRules().Get<int>("RULE_CONCEDE_COLONIES_THRESHOLD"))) {
         player_connection->SendMessage(ErrorMessage(UserStringNop("ERROR_CONCEDE_EXCEED_COLONIES"), false));
         return false;
@@ -1790,12 +1790,12 @@ bool ServerApp::EliminatePlayer(const PlayerConnectionPtr& player_connection) {
     empire->Eliminate();
 
     // destroy owned ships
-    for (auto& obj : Objects().find<Ship>(OwnedVisitor<Ship>(empire_id))) {
+    for (auto& obj : Objects().find<Ship>(OwnedVisitor(empire_id))) {
         obj->SetOwner(ALL_EMPIRES);
         GetUniverse().RecursiveDestroy(obj->ID());
     }
     // destroy owned buildings
-    for (auto& obj : Objects().find<Building>(OwnedVisitor<Building>(empire_id))) {
+    for (auto& obj : Objects().find<Building>(OwnedVisitor(empire_id))) {
         obj->SetOwner(ALL_EMPIRES);
         GetUniverse().RecursiveDestroy(obj->ID());
     }
@@ -2050,8 +2050,8 @@ namespace {
       * definition of elimination.  As of this writing, elimination means
       * having no ships and no planets. */
     bool EmpireEliminated(int empire_id) {
-          return (Objects().find<Planet>(OwnedVisitor<Planet>(empire_id)).empty() &&    // no planets
-                  Objects().find<Ship>(OwnedVisitor<Ship>(empire_id)).empty());      // no ship
+          return (Objects().find<Planet>(OwnedVisitor(empire_id)).empty() &&  // no planets
+                  Objects().find<Ship>(OwnedVisitor(empire_id)).empty());     // no ship
       }
 
     void GetEmpireFleetsAtSystem(std::map<int, std::set<int>>& empire_fleets, int system_id) {

--- a/universe/Predicates.cpp
+++ b/universe/Predicates.cpp
@@ -111,3 +111,19 @@ std::shared_ptr<UniverseObject> OwnedVisitor::Visit(std::shared_ptr<UniverseObje
     return nullptr;
 }
 
+////////////////////////////////////////////////
+// HostileVisitor
+////////////////////////////////////////////////
+HostileVisitor::HostileVisitor(int viewing_empire, int owning_empire) :
+    viewing_empire_id(viewing_empire),
+    owning_empire_id(owning_empire)
+{}
+
+HostileVisitor::~HostileVisitor() = default;
+
+std::shared_ptr<UniverseObject> HostileVisitor::Visit(std::shared_ptr<UniverseObject> obj) const
+{
+    if (obj->HostileToEmpire(viewing_empire_id))
+        return obj;
+    return nullptr;
+}

--- a/universe/Predicates.cpp
+++ b/universe/Predicates.cpp
@@ -94,3 +94,20 @@ std::shared_ptr<UniverseObject> MovingFleetVisitor::Visit(std::shared_ptr<Fleet>
         return obj;
     return nullptr;
 }
+
+////////////////////////////////////////////////
+// OwnedVisitor
+////////////////////////////////////////////////
+OwnedVisitor::OwnedVisitor(int empire) :
+    empire_id(empire)
+{}
+
+OwnedVisitor::~OwnedVisitor() = default;
+
+std::shared_ptr<UniverseObject> OwnedVisitor::Visit(std::shared_ptr<UniverseObject> obj) const
+{
+    if (obj->OwnedBy(empire_id))
+        return obj;
+    return nullptr;
+}
+

--- a/universe/Predicates.h
+++ b/universe/Predicates.h
@@ -93,31 +93,16 @@ struct FO_COMMON_API MovingFleetVisitor : UniverseObjectVisitor
 };
 
 /** returns obj iff \a obj is owned by the empire with id \a empire, and \a obj is of type T. */
-template <class T>
-struct OwnedVisitor : UniverseObjectVisitor
+struct FO_COMMON_API OwnedVisitor : UniverseObjectVisitor
 {
     OwnedVisitor(int empire = ALL_EMPIRES);
 
-    virtual ~OwnedVisitor()
-    {}
+    virtual ~OwnedVisitor();
 
-    std::shared_ptr<UniverseObject> Visit(std::shared_ptr<T> obj) const override;
+    std::shared_ptr<UniverseObject> Visit(std::shared_ptr<UniverseObject> obj) const override;
 
     const int empire_id;
 };
-
-template <class T>
-OwnedVisitor<T>::OwnedVisitor(int empire) :
-    empire_id(empire)
-{}
-
-template <class T>
-std::shared_ptr<UniverseObject> OwnedVisitor<T>::Visit(std::shared_ptr<T> obj) const
-{
-    if (obj->OwnedBy(empire_id))
-        return obj;
-    return nullptr;
-}
 
 template <class T>
 struct HostileVisitor : UniverseObjectVisitor

--- a/universe/Predicates.h
+++ b/universe/Predicates.h
@@ -104,32 +104,16 @@ struct FO_COMMON_API OwnedVisitor : UniverseObjectVisitor
     const int empire_id;
 };
 
-template <class T>
-struct HostileVisitor : UniverseObjectVisitor
+struct FO_COMMON_API HostileVisitor : UniverseObjectVisitor
 {
     HostileVisitor(int viewing_empire, int owning_empire = ALL_EMPIRES);
 
-    virtual ~HostileVisitor()
-    {}
+    virtual ~HostileVisitor();
 
-    std::shared_ptr<UniverseObject> Visit(std::shared_ptr<T> obj) const override;
+    std::shared_ptr<UniverseObject> Visit(std::shared_ptr<UniverseObject> obj) const override;
 
     const int viewing_empire_id;
     const int owning_empire_id;
 };
-
-template <class T>
-HostileVisitor<T>::HostileVisitor(int viewing_empire, int owning_empire) :
-    viewing_empire_id(viewing_empire),
-    owning_empire_id(owning_empire)
-{}
-
-template <class T>
-std::shared_ptr<UniverseObject> HostileVisitor<T>::Visit(std::shared_ptr<T> obj) const
-{
-    if (obj->HostileToEmpire(viewing_empire_id))
-        return obj;
-    return nullptr;
-}
 
 #endif // _Predicates_h_


### PR DESCRIPTION
This PR removes the template parameters from the existing two ObjectMap predicates `OwnedVisitor` and `HostileVisitor` as both check against general UniverseObject properties, which makes templating unnessecary.