### PR TITLE
Use objectmap interface

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -649,10 +649,11 @@ void Empire::UpdateSystemSupplyRanges(const std::set<int>& known_objects) {
 
     // as of this writing, only planets can generate supply propagation
     std::vector<std::shared_ptr<const UniverseObject>> owned_planets;
-    for (int object_id : known_objects) {
-        if (auto planet = GetPlanet(object_id))
-            if (planet->OwnedBy(this->EmpireID()))
-                owned_planets.push_back(planet);
+    for (const auto& int planet: Objects().find<Planet>(known_objects)) {
+        if (!planet)
+            continue;
+        if (planet->OwnedBy(this->EmpireID()))
+            owned_planets.push_back(planet);
     }
 
     //std::cout << "... empire owns " << owned_planets.size() << " planets" << std::endl;
@@ -1944,7 +1945,7 @@ void Empire::CheckProductionProgress() {
         // create actual thing(s) being produced
         switch (elem.item.build_type) {
         case BT_BUILDING: {
-            auto planet = GetPlanet(elem.location);
+            auto planet = Objects().get<Planet>(elem.location);
 
             // create new building
             auto building = universe.InsertNew<Building>(m_id, elem.item.name, m_id);
@@ -1977,7 +1978,7 @@ void Empire::CheckProductionProgress() {
                 species_name = location_pop_center->SpeciesName();
             else if (auto location_ship = std::dynamic_pointer_cast<const Ship>(build_location))
                 species_name = location_ship->SpeciesName();
-            else if (auto capital_planet = GetPlanet(this->CapitalID()))
+            else if (auto capital_planet = Objects().get<Planet>(this->CapitalID()))
                 species_name = capital_planet->SpeciesName();
             // else give up...
             if (species_name.empty()) {

--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -94,12 +94,12 @@ std::shared_ptr<const UniverseObject> Empire::Source() const {
         return nullptr;
 
     // Use the current source if valid
-    auto valid_current_source = GetUniverseObject(m_source_id);
+    auto valid_current_source = Objects().get(m_source_id);
     if (valid_current_source && valid_current_source->OwnedBy(m_id))
         return valid_current_source;
 
     // Try the capital
-    auto capital_as_source = GetUniverseObject(m_capital_id);
+    auto capital_as_source = Objects().get(m_capital_id);
     if (capital_as_source && capital_as_source->OwnedBy(m_id)) {
         m_source_id = m_capital_id;
         return capital_as_source;
@@ -142,7 +142,7 @@ void Empire::SetCapitalID(int id) {
     if (possible_capital && possible_capital->OwnedBy(m_id))
         m_capital_id = id;
 
-    auto possible_source = GetUniverseObject(id);
+    auto possible_source = Objects().get(id);
     if (possible_source && possible_source->OwnedBy(m_id))
         m_source_id = id;
 }
@@ -458,7 +458,7 @@ bool Empire::ProducibleItem(BuildType build_type, int location_id) const {
         return false;
 
     // must own the production location...
-    auto location = GetUniverseObject(location_id);
+    auto location = Objects().get(location_id);
     if (!location) {
         WarnLogger() << "Empire::ProducibleItem for BT_STOCKPILE unable to get location object with id " << location_id;
         return false;
@@ -495,7 +495,7 @@ bool Empire::ProducibleItem(BuildType build_type, const std::string& name, int l
     if (!building_type || !building_type->Producible())
         return false;
 
-    auto build_location = GetUniverseObject(location);
+    auto build_location = Objects().get(location);
     if (!build_location)
         return false;
 
@@ -525,7 +525,7 @@ bool Empire::ProducibleItem(BuildType build_type, int design_id, int location) c
     if (!ship_design || !ship_design->Producible())
         return false;
 
-    auto build_location = GetUniverseObject(location);
+    auto build_location = Objects().get(location);
     if (!build_location) return false;
 
     if (build_type == BT_SHIP) {
@@ -558,7 +558,7 @@ bool Empire::EnqueuableItem(BuildType build_type, const std::string& name, int l
     if (!building_type || !building_type->Producible())
         return false;
 
-    auto build_location = GetUniverseObject(location);
+    auto build_location = Objects().get(location);
     if (!build_location)
         return false;
 
@@ -649,7 +649,7 @@ void Empire::UpdateSystemSupplyRanges(const std::set<int>& known_objects) {
 
     // as of this writing, only planets can generate supply propagation
     std::vector<std::shared_ptr<const UniverseObject>> owned_planets;
-    for (const auto& int planet: Objects().find<Planet>(known_objects)) {
+    for (const auto& planet: Objects().find<Planet>(known_objects)) {
         if (!planet)
             continue;
         if (planet->OwnedBy(this->EmpireID()))
@@ -1833,7 +1833,7 @@ void Empire::CheckProductionProgress() {
                 build_description = "unknown build type";
         }
 
-        auto build_location = GetUniverseObject(elem.location);
+        auto build_location = Objects().get(elem.location);
         if (!build_location || (elem.item.build_type == BT_BUILDING && build_location->ObjectType() != OBJ_PLANET)) {
             ErrorLogger() << "Couldn't get valid build location for completed " << build_description;
             continue;
@@ -1867,7 +1867,7 @@ void Empire::CheckProductionProgress() {
             if (consumption_impossible)
                 break;
             for (auto& special_meter : special_type.second) {
-                auto obj = GetUniverseObject(special_meter.first);
+                auto obj = Objects().get(special_meter.first);
                 float capacity = obj ? obj->SpecialCapacity(special_type.first) : 0.0f;
                 if (capacity < special_meter.second * elem.blocksize) {
                     consumption_impossible = true;
@@ -1880,7 +1880,7 @@ void Empire::CheckProductionProgress() {
             if (consumption_impossible)
                 break;
             for (auto& object_meter : meter_type.second) {
-                auto obj = GetUniverseObject(object_meter.first);
+                auto obj = Objects().get(object_meter.first);
                 const Meter* meter = obj ? obj->GetMeter(meter_type.first) : nullptr;
                 if (!meter || meter->Current() < object_meter.second * elem.blocksize) {
                     consumption_impossible = true;
@@ -1911,7 +1911,7 @@ void Empire::CheckProductionProgress() {
         // consume the item's special and meter consumption
         for (auto& special_type : sc) {
             for (auto& special_meter : special_type.second) {
-                auto obj = GetUniverseObject(special_meter.first);
+                auto obj = Objects().get(special_meter.first);
                 if (!obj)
                     continue;
                 if (!obj->HasSpecial(special_type.first))
@@ -1923,7 +1923,7 @@ void Empire::CheckProductionProgress() {
         }
         for (auto& meter_type : mc) {
             for (const auto& object_meter : meter_type.second) {
-                auto obj = GetUniverseObject(object_meter.first);
+                auto obj = Objects().get(object_meter.first);
                 if (!obj)
                     continue;
                 Meter*meter = obj->GetMeter(meter_type.first);
@@ -2144,7 +2144,7 @@ void Empire::CheckProductionProgress() {
                     if (rally_point_id != INVALID_OBJECT_ID) {
                         if (Objects().get<System>(rally_point_id)) {
                             next_fleet->CalculateRouteTo(rally_point_id);
-                        } else if (auto rally_obj = GetUniverseObject(rally_point_id)) {
+                        } else if (auto rally_obj = Objects().get(rally_point_id)) {
                             if (Objects().get<System>(rally_obj->SystemID()))
                                 next_fleet->CalculateRouteTo(rally_obj->SystemID());
                         } else {

--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -700,8 +700,7 @@ void Empire::UpdateUnobstructedFleets() {
     const std::set<int>& known_destroyed_objects =
         GetUniverse().EmpireKnownDestroyedObjectIDs(this->EmpireID());
 
-    for (int system_id : m_supply_unobstructed_systems) {
-        auto system = GetSystem(system_id);
+    for (const auto& system : Objects().find<System>(m_supply_unobstructed_systems)) {
         if (!system)
             continue;
 
@@ -709,7 +708,7 @@ void Empire::UpdateUnobstructedFleets() {
             if (known_destroyed_objects.count(fleet->ID()))
                 continue;
             if (fleet->OwnedBy(m_id))
-                fleet->SetArrivalStarlane(system_id);
+                fleet->SetArrivalStarlane(system->ID());
         }
     }
 }
@@ -833,59 +832,56 @@ void Empire::UpdateSupplyUnobstructedSystems(const std::set<int>& known_systems,
 
 
     // check each potential supplyable system for whether it can propagate supply.
-    for (int sys_id : known_systems) {
-        auto sys = GetSystem(sys_id);
-        if (!sys) {
-            ErrorLogger() << "Empire::UpdateSupplyUnobstructedSystems tried to look up known by non existant system with id " << sys_id;
+    for (const auto& sys : Objects().find<System>(known_systems)) {
+        if (!sys)
             continue;
-        }
 
         // has empire ever seen this system with partial or better visibility?
-        if (!systems_with_at_least_partial_visibility_at_some_point.count(sys_id)) {
-            TraceLogger(supply) << "System " << sys->Name() << " (" << sys_id << ") has never been seen";
+        if (!systems_with_at_least_partial_visibility_at_some_point.count(sys->ID())) {
+            TraceLogger(supply) << "System " << sys->Name() << " (" << sys->ID() << ") has never been seen";
             continue;
         }
 
         // if system is explored, then whether it can propagate supply depends
         // on what friendly / enemy ships and planets are in the system
 
-        if (unrestricted_friendly_systems.count(sys_id)) {
+        if (unrestricted_friendly_systems.count(sys->ID())) {
             // in unrestricted friendly systems, supply can propagate
-            m_supply_unobstructed_systems.insert(sys_id);
-            TraceLogger(supply) << "System " << sys->Name() << " (" << sys_id << ") +++ is unrestricted and friendly";
+            m_supply_unobstructed_systems.insert(sys->ID());
+            TraceLogger(supply) << "System " << sys->Name() << " (" << sys->ID() << ") +++ is unrestricted and friendly";
 
-        } else if (systems_containing_friendly_fleets.count(sys_id)) {
+        } else if (systems_containing_friendly_fleets.count(sys->ID())) {
             // if there are unrestricted friendly ships, and no unrestricted enemy fleets, supply can propagate
-            if (!unrestricted_obstruction_systems.count(sys_id)) {
-                m_supply_unobstructed_systems.insert(sys_id);
-                TraceLogger(supply) << "System " << sys->Name() << " (" << sys_id << ") +++ has friendly fleets and no obstructions";
+            if (!unrestricted_obstruction_systems.count(sys->ID())) {
+                m_supply_unobstructed_systems.insert(sys->ID());
+                TraceLogger(supply) << "System " << sys->Name() << " (" << sys->ID() << ") +++ has friendly fleets and no obstructions";
             } else {
-                TraceLogger(supply) << "System " << sys->Name() << " (" << sys_id << ") --- is has friendly fleets but has obstructions";
+                TraceLogger(supply) << "System " << sys->Name() << " (" << sys->ID() << ") --- is has friendly fleets but has obstructions";
             }
 
-        } else if (!systems_containing_obstructing_objects.count(sys_id)) {
+        } else if (!systems_containing_obstructing_objects.count(sys->ID())) {
             // if there are no friendly fleets or obstructing enemy fleets, supply can propagate
-            m_supply_unobstructed_systems.insert(sys_id);
-            TraceLogger(supply) << "System " << sys->Name() << " (" << sys_id << ") +++ has no obstructing objects";
+            m_supply_unobstructed_systems.insert(sys->ID());
+            TraceLogger(supply) << "System " << sys->Name() << " (" << sys->ID() << ") +++ has no obstructing objects";
 
-        } else if (!systems_with_lane_preserving_fleets.count(sys_id)) {
+        } else if (!systems_with_lane_preserving_fleets.count(sys->ID())) {
             // if there are obstructing enemy fleets but no friendly fleets that could maintain
             // lane access, supply cannot propagate and this empire's available system exit
-            TraceLogger(supply) << "System " << sys->Name() << " (" << sys_id << ") --- has no lane preserving fleets";
+            TraceLogger(supply) << "System " << sys->Name() << " (" << sys->ID() << ") --- has no lane preserving fleets";
 
             // lanes for this system are cleared
-            if (!m_preserved_system_exit_lanes[sys_id].empty()) {
+            if (!m_preserved_system_exit_lanes[sys->ID()].empty()) {
                 std::stringstream ssca;
                 ssca << "Empire::UpdateSupplyUnobstructedSystems clearing preserved lanes for system ("
-                     << sys_id << "); available lanes were:";
-                for (int system_id : m_preserved_system_exit_lanes[sys_id])
+                     << sys->ID() << "); available lanes were:";
+                for (int system_id : m_preserved_system_exit_lanes[sys->ID()])
                     ssca << system_id << ", ";
                 TraceLogger(supply) << ssca.str();
             }
-            m_preserved_system_exit_lanes[sys_id].clear();
+            m_preserved_system_exit_lanes[sys->ID()].clear();
 
         } else {
-            TraceLogger(supply) << "Empire::UpdateSupplyUnobstructedSystems : Restricted system " << sys_id << " with no friendly fleets, no obustrcting enemy fleets, and no lane-preserving fleets";
+            TraceLogger(supply) << "Empire::UpdateSupplyUnobstructedSystems : Restricted system " << sys->ID() << " with no friendly fleets, no obustrcting enemy fleets, and no lane-preserving fleets";
         }
     }
 }
@@ -894,8 +890,7 @@ void Empire::RecordPendingLaneUpdate(int start_system_id, int dest_system_id) {
     if (!m_supply_unobstructed_systems.count(start_system_id))
         m_pending_system_exit_lanes[start_system_id].insert(dest_system_id);
     else { // if the system is unobstructed, mark all its lanes as avilable
-        auto system = GetSystem(start_system_id);
-        for (const auto& lane : system->StarlanesWormholes()) {
+        for (const auto& lane : Objects().get<System>(start_system_id)->StarlanesWormholes()) {
             m_pending_system_exit_lanes[start_system_id].insert(lane.first); // will add both starlanes and wormholes
         }
     }
@@ -1492,7 +1487,7 @@ void Empire::AddHullType(const std::string& name) {
 }
 
 void Empire::AddExploredSystem(int ID) {
-    if (GetSystem(ID))
+    if (Objects().get<System>(ID))
         m_explored_systems.insert(ID);
     else
         ErrorLogger() << "Empire::AddExploredSystem given an invalid system id: " << ID;
@@ -1843,7 +1838,7 @@ void Empire::CheckProductionProgress() {
             ErrorLogger() << "Couldn't get valid build location for completed " << build_description;
             continue;
         }
-        auto system = GetSystem(build_location->SystemID());
+        auto system = Objects().get<System>(build_location->SystemID());
         // TODO: account for shipyards and/or other ship production
         // sites that are in interstellar space, if needed
         if (!system) {
@@ -2058,7 +2053,7 @@ void Empire::CheckProductionProgress() {
 
     // create fleets for new ships and put ships into fleets
     for (auto& entry : system_new_ships) {
-        auto system = GetSystem(entry.first);
+        auto system = Objects().get<System>(entry.first);
         if (!system) {
             ErrorLogger() << "Couldn't get system with id " << entry.first << " for creating new fleets for newly produced ships";
             continue;
@@ -2147,10 +2142,10 @@ void Empire::CheckProductionProgress() {
                     next_fleet->SetAggressive(next_fleet->HasArmedShips());
 
                     if (rally_point_id != INVALID_OBJECT_ID) {
-                        if (GetSystem(rally_point_id)) {
+                        if (Objects().get<System>(rally_point_id)) {
                             next_fleet->CalculateRouteTo(rally_point_id);
                         } else if (auto rally_obj = GetUniverseObject(rally_point_id)) {
-                            if (GetSystem(rally_obj->SystemID()))
+                            if (Objects().get<System>(rally_obj->SystemID()))
                                 next_fleet->CalculateRouteTo(rally_obj->SystemID());
                         } else {
                             ErrorLogger() << "Unable to find system to route to with rally point id: " << rally_point_id;

--- a/Empire/PopulationPool.cpp
+++ b/Empire/PopulationPool.cpp
@@ -19,10 +19,10 @@ void PopulationPool::SetPopCenters(const std::vector<int>& pop_center_ids) {
 void PopulationPool::Update() {
     m_population = 0.0f;
     // sum population from all PopCenters in this pool
-    for (int pop_center_id : m_pop_center_ids) {
-        if (auto center = GetPopCenter(pop_center_id)) {
-            m_population += center->CurrentMeterValue(METER_POPULATION);
-        }
+    for (const auto& center : Objects().find<PopCenter>(m_pop_center_ids)) {
+        if (!center)
+            continue;
+        m_population += center->CurrentMeterValue(METER_POPULATION);
     }
     ChangedSignal();
 }

--- a/Empire/ProductionQueue.cpp
+++ b/Empire/ProductionQueue.cpp
@@ -365,7 +365,7 @@ bool ProductionQueue::ProductionItem::EnqueueConditionPassedAt(int location_id) 
     switch (build_type) {
     case BT_BUILDING: {
         if (const BuildingType* bt = GetBuildingType(name)) {
-            auto location_obj = GetUniverseObject(location_id);
+            auto location_obj = Objects().get(location_id);
             const Condition::Condition* c = bt->EnqueueLocation();
             if (!c)
                 return true;
@@ -402,7 +402,7 @@ ProductionQueue::ProductionItem::CompletionSpecialConsumption(int location_id) c
     switch (build_type) {
     case BT_BUILDING: {
         if (const BuildingType* bt = GetBuildingType(name)) {
-            auto location_obj = GetUniverseObject(location_id);
+            auto location_obj = Objects().get(location_id);
             ScriptingContext context(location_obj);
 
             for (const auto& psc : bt->ProductionSpecialConsumption()) {
@@ -428,7 +428,7 @@ ProductionQueue::ProductionItem::CompletionSpecialConsumption(int location_id) c
     }
     case BT_SHIP: {
         if (const ShipDesign* sd = GetShipDesign(design_id)) {
-            auto location_obj = GetUniverseObject(location_id);
+            auto location_obj = Objects().get(location_id);
             ScriptingContext context(location_obj);
 
             if (const HullType* ht = GetHullType(sd->Hull())) {
@@ -469,7 +469,7 @@ ProductionQueue::ProductionItem::CompletionMeterConsumption(int location_id) con
     switch (build_type) {
     case BT_BUILDING: {
         if (const BuildingType* bt = GetBuildingType(name)) {
-            auto obj = GetUniverseObject(location_id);
+            auto obj = Objects().get(location_id);
             ScriptingContext context(obj);
 
             for (const auto& pmc : bt->ProductionMeterConsumption()) {
@@ -482,7 +482,7 @@ ProductionQueue::ProductionItem::CompletionMeterConsumption(int location_id) con
     }
     case BT_SHIP: {
         if (const ShipDesign* sd = GetShipDesign(design_id)) {
-            auto obj = GetUniverseObject(location_id);
+            auto obj = Objects().get(location_id);
             ScriptingContext context(obj);
 
             if (const HullType* ht = GetHullType(sd->Hull())) {

--- a/Empire/Supply.cpp
+++ b/Empire/Supply.cpp
@@ -182,7 +182,7 @@ std::string SupplyManager::Dump(int empire_id) const {
 
                 for (const auto& trav : m_supply_starlane_traversals.at(empire_supply.first)) {
                     if (trav.first == sys->ID()) {
-                        auto obj = GetUniverseObject(trav.second);
+                        auto obj = Objects().get(trav.second);
                         if (obj)
                             retval += obj->PublicName(empire_id) + " (" + std::to_string(obj->ID()) + ")  ";
                     }
@@ -192,7 +192,7 @@ std::string SupplyManager::Dump(int empire_id) const {
                 retval += "Traversals to here from: ";
                 for (const auto& trav : m_supply_starlane_traversals.at(empire_supply.first)) {
                     if (trav.second == sys->ID()) {
-                        auto obj = GetUniverseObject(trav.first);
+                        auto obj = Objects().get(trav.first);
                         if (obj)
                             retval += obj->PublicName(empire_id) + " (" + std::to_string(obj->ID()) + ")  ";
                     }
@@ -202,7 +202,7 @@ std::string SupplyManager::Dump(int empire_id) const {
                 retval += "Blocked Traversals from here to: ";
                 for (const auto& trav : m_supply_starlane_obstructed_traversals.at(empire_supply.first)) {
                     if (trav.first == sys->ID()) {
-                        auto obj = GetUniverseObject(trav.second);
+                        auto obj = Objects().get(trav.second);
                         if (obj)
                             retval += obj->PublicName(empire_id) + " (" + std::to_string(obj->ID()) + ")  ";
                     }
@@ -212,7 +212,7 @@ std::string SupplyManager::Dump(int empire_id) const {
                 retval += "Blocked Traversals to here from: ";
                 for (const auto& trav : m_supply_starlane_obstructed_traversals.at(empire_supply.first)) {
                     if (trav.second == sys->ID()) {
-                        auto obj = GetUniverseObject(trav.first);
+                        auto obj = Objects().get(trav.first);
                         if (obj)
                             retval += obj->PublicName(empire_id) + " (" + std::to_string(obj->ID()) + ")  ";
                     }

--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -1374,7 +1374,7 @@ void BuildDesignatorWnd::SelectDefaultPlanet() {
     // only checking visible objects for this clients empire (and not the
     // latest known objects) as an empire shouldn't be able to use a planet or
     // system it can't currently see as a production location.
-    auto sys = GetSystem(system_id);
+    auto sys = Objects().get<System>(system_id);
     if (!sys) {
         ErrorLogger() << "BuildDesignatorWnd::SelectDefaultPlanet couldn't get system with id " << system_id;
         return;

--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -176,7 +176,7 @@ namespace {
         if (!empire)
             return nullptr;
 
-        if (auto source = GetUniverseObject(empire->CapitalID()))
+        if (auto source = Objects().get(empire->CapitalID()))
             return source;
 
         // not a valid source?!  scan through all objects to find one owned by this empire
@@ -201,9 +201,9 @@ namespace {
         }
         auto source = GetSourceObjectForEmpire(empire_id);
         if (only_failed_conditions)
-            return ConditionFailedDescription(enqueue_conditions, GetUniverseObject(candidate_object_id), source);
+            return ConditionFailedDescription(enqueue_conditions, Objects().get(candidate_object_id), source);
         else
-            return ConditionDescription(enqueue_conditions, GetUniverseObject(candidate_object_id), source);
+            return ConditionDescription(enqueue_conditions, Objects().get(candidate_object_id), source);
     }
 
     std::string LocationConditionDescription(int ship_design_id, int candidate_object_id,
@@ -230,9 +230,9 @@ namespace {
         auto source = GetSourceObjectForEmpire(empire_id);
 
         if (only_failed_conditions)
-            return ConditionFailedDescription(location_conditions, GetUniverseObject(candidate_object_id), source);
+            return ConditionFailedDescription(location_conditions, Objects().get(candidate_object_id), source);
         else
-            return ConditionDescription(location_conditions, GetUniverseObject(candidate_object_id), source);
+            return ConditionDescription(location_conditions, Objects().get(candidate_object_id), source);
     }
 
     std::shared_ptr<GG::BrowseInfoWnd> ProductionItemRowBrowseWnd(const ProductionQueue::ProductionItem& item,
@@ -259,7 +259,7 @@ namespace {
             const std::string& enqueue_and_location_condition_failed_text =
                 EnqueueAndLocationConditionDescription(item.name, candidate_object_id, empire_id, true);
             if (!enqueue_and_location_condition_failed_text.empty())
-                if (auto location = GetUniverseObject(candidate_object_id)) {
+                if (auto location = Objects().get(candidate_object_id)) {
                     std::string failed_cond_loc = boost::io::str(
                         FlexibleFormat(UserString("PRODUCTION_WND_TOOLTIP_FAILED_COND")) % location->Name());
                     main_text += "\n\n" + failed_cond_loc + ":\n" + enqueue_and_location_condition_failed_text;
@@ -315,7 +315,7 @@ namespace {
             const std::string& location_condition_failed_text =
                 LocationConditionDescription(item.design_id, candidate_object_id, empire_id, true);
             if (!location_condition_failed_text.empty())
-                if (auto location = GetUniverseObject(candidate_object_id)) {
+                if (auto location = Objects().get(candidate_object_id)) {
                     std::string failed_cond_loc = boost::io::str(FlexibleFormat(
                         UserString("PRODUCTION_WND_TOOLTIP_FAILED_COND")) % location->Name());
                     main_text += ("\n\n" + failed_cond_loc + ":\n" + location_condition_failed_text);
@@ -652,7 +652,7 @@ void BuildDesignatorWnd::BuildSelector::SetEmpireID(int empire_id/* = ALL_EMPIRE
 
 void BuildDesignatorWnd::BuildSelector::Refresh() {
     ScopedTimer timer("BuildDesignatorWnd::BuildSelector::Refresh()");
-    if (auto prod_loc = GetUniverseObject(this->m_production_location))
+    if (auto prod_loc = Objects().get(this->m_production_location))
         this->SetName(boost::io::str(FlexibleFormat(UserString("PRODUCTION_WND_BUILD_ITEMS_TITLE_LOCATION")) % prod_loc->Name()));
     else
         this->SetName(UserString("PRODUCTION_WND_BUILD_ITEMS_TITLE"));

--- a/UI/BuildingsPanel.cpp
+++ b/UI/BuildingsPanel.cpp
@@ -96,7 +96,7 @@ void BuildingsPanel::Update() {
         DetachChild(indicator.get());
     m_building_indicators.clear();
 
-    auto planet = GetPlanet(m_planet_id);
+    auto planet = Objects().get<Planet>(m_planet_id);
     if (!planet) {
         ErrorLogger() << "BuildingsPanel::Update couldn't get planet with id " << m_planet_id;
         return;

--- a/UI/BuildingsPanel.cpp
+++ b/UI/BuildingsPanel.cpp
@@ -117,7 +117,7 @@ void BuildingsPanel::Update() {
         if (this_client_stale_object_info.count(object_id))
             continue;
 
-        auto building = GetBuilding(object_id);
+        auto building = Objects().get<Building>(object_id);
         if (!building) {
             ErrorLogger() << "BuildingsPanel::Update couldn't get building with id: " << object_id << " on planet " << planet->Name();
             continue;
@@ -259,7 +259,7 @@ BuildingIndicator::BuildingIndicator(GG::X w, int building_id) :
     GG::Wnd(GG::X0, GG::Y0, w, GG::Y(Value(w)), GG::INTERACTIVE),
     m_building_id(building_id)
 {
-    if (auto building = GetBuilding(m_building_id))
+    if (auto building = Objects().get<Building>(m_building_id))
         building->StateChangedSignal.connect(
             boost::bind(&BuildingIndicator::RequirePreRender, this));
 }
@@ -350,7 +350,7 @@ void BuildingIndicator::PreRender() {
 void BuildingIndicator::Refresh() {
     SetBrowseModeTime(GetOptionsDB().Get<int>("ui.tooltip.delay"));
 
-    auto building = GetBuilding(m_building_id);
+    auto building = Objects().get<Building>(m_building_id);
     if (!building)
         return;
 
@@ -400,7 +400,7 @@ void BuildingIndicator::RClick(const GG::Pt& pt, GG::Flags<GG::ModKey> mod_keys)
     // queued production item, and that the owner of the building is this
     // client's player's empire
     int empire_id = HumanClientApp::GetApp()->EmpireID();
-    auto building = GetBuilding(m_building_id);
+    auto building = Objects().get<Building>(m_building_id);
     if (!building)
         return;
 

--- a/UI/BuildingsPanel.cpp
+++ b/UI/BuildingsPanel.cpp
@@ -68,7 +68,7 @@ void BuildingsPanel::CompleteConstruction() {
         boost::bind(&BuildingsPanel::ExpandCollapseButtonPressed, this));
 
     // get owner, connect its production queue changed signal to update this panel
-    auto planet = GetUniverseObject(m_planet_id);
+    auto planet = Objects().get(m_planet_id);
     if (planet) {
         if (const Empire* empire = GetEmpire(planet->Owner())) {
             const ProductionQueue& queue = empire->GetProductionQueue();

--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -799,7 +799,7 @@ bool ClientUI::ZoomToPlanetPedia(int id) {
 }
 
 bool ClientUI::ZoomToSystem(int id) {
-    if (auto system = GetSystem(id)) {
+    if (auto system = Objects().get<System>(id)) {
         ZoomToSystem(system);
         return true;
     }

--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -807,7 +807,7 @@ bool ClientUI::ZoomToSystem(int id) {
 }
 
 bool ClientUI::ZoomToFleet(int id) {
-    if (auto fleet = GetFleet(id)) {
+    if (auto fleet = Objects().get<Fleet>(id)) {
         ZoomToFleet(fleet);
         return true;
     }

--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -815,7 +815,7 @@ bool ClientUI::ZoomToFleet(int id) {
 }
 
 bool ClientUI::ZoomToShip(int id) {
-    if (auto ship = GetShip(id))
+    if (auto ship = Objects().get<Ship>(id))
         return ZoomToFleet(ship->FleetID());
     return false;
 }

--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -821,7 +821,7 @@ bool ClientUI::ZoomToShip(int id) {
 }
 
 bool ClientUI::ZoomToBuilding(int id) {
-    if (auto building = GetBuilding(id)) {
+    if (auto building = Objects().get<Building>(id)) {
         ZoomToBuildingType(building->BuildingTypeName());
         return ZoomToPlanet(building->PlanetID());
     }

--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -829,7 +829,7 @@ bool ClientUI::ZoomToBuilding(int id) {
 }
 
 bool ClientUI::ZoomToField(int id) {
-    //if (auto field = GetField(id)) {
+    //if (auto field = Objects().get<Field>(id)) {
     //  // TODO: implement this
     //}
     return false;

--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -975,7 +975,7 @@ bool ClientUI::ZoomToEncyclopediaEntry(const std::string& str) {
 }
 
 void ClientUI::DumpObject(int object_id) {
-    auto obj = GetUniverseObject(object_id);
+    auto obj = Objects().get(object_id);
     if (!obj)
         return;
     m_message_wnd->HandleLogMessage(obj->Dump() + "\n");

--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -783,7 +783,7 @@ bool ClientUI::ZoomToObject(int id) {
 }
 
 bool ClientUI::ZoomToPlanet(int id) {
-    if (auto planet = GetPlanet(id)) {
+    if (auto planet = Objects().get<Planet>(id)) {
         GetMapWnd()->CenterOnObject(planet->SystemID());
         GetMapWnd()->SelectSystem(planet->SystemID());
         GetMapWnd()->SelectPlanet(id);
@@ -793,7 +793,7 @@ bool ClientUI::ZoomToPlanet(int id) {
 }
 
 bool ClientUI::ZoomToPlanetPedia(int id) {
-    if (GetPlanet(id))
+    if (Objects().get<Planet>(id))
         GetMapWnd()->ShowPlanet(id);
     return false;
 }

--- a/UI/CombatReport/CombatLogWnd.cpp
+++ b/UI/CombatReport/CombatLogWnd.cpp
@@ -587,7 +587,7 @@ void CombatLogWnd::Impl::SetLog(int log_id) {
     int client_empire_id = HumanClientApp::GetApp()->EmpireID();
 
     // Write Header text
-    auto system = GetSystem(log->system_id);
+    auto system = Objects().get<System>(log->system_id);
     const std::string& sys_name = (system ? system->PublicName(client_empire_id) : UserString("ERROR"));
     DebugLogger(combat_log) << "Showing combat log #" << log_id << " at " << sys_name << " (" << log->system_id
                             << ") with " << log->combat_events.size() << " events";

--- a/UI/CombatReport/GraphicalSummary.cpp
+++ b/UI/CombatReport/GraphicalSummary.cpp
@@ -732,7 +732,7 @@ void GraphicalSummaryWnd::MakeSummaries(int log_id) {
         for (int object_id : log->object_ids) {
             if (object_id < 0)
                 continue;   // fighters and invalid objects
-            auto object = GetUniverseObject(object_id);
+            auto object = Objects().get(object_id);
             if (!object) {
                 ErrorLogger() << "GraphicalSummaryWnd::MakeSummaries couldn't find object with id: " << object_id;
                 continue;

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -1642,7 +1642,7 @@ void PartsListBox::Populate() {
     // get empire id and location to use for cost and time comparisons
     int loc_id = INVALID_OBJECT_ID;
     if (empire) {
-        auto location = GetUniverseObject(empire->CapitalID());
+        auto location = Objects().get(empire->CapitalID());
         loc_id = location ? location->ID() : INVALID_OBJECT_ID;
     }
 

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -1702,7 +1702,7 @@ namespace {
             for (auto& obj : nonempty_empire_fleets) {
                 std::string fleet_link = LinkTaggedIDText(VarText::FLEET_ID_TAG, obj->ID(), obj->PublicName(client_empire_id));
                 std::string system_link;
-                if (auto system = GetSystem(obj->SystemID())) {
+                if (auto system = Objects().get<System>(obj->SystemID())) {
                     std::string sys_name = system->ApparentName(client_empire_id);
                     system_link = LinkTaggedIDText(VarText::SYSTEM_ID_TAG, system->ID(), sys_name);
                     detailed_description += str(FlexibleFormat(UserString("OWNED_FLEET_AT_SYSTEM"))

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -1162,7 +1162,7 @@ namespace {
             return INVALID_OBJECT_ID;
         }
         // get a location where the empire might build something.
-        auto location = GetUniverseObject(empire->CapitalID());
+        auto location = Objects().get(empire->CapitalID());
         // no capital?  scan through all objects to find one owned by this empire
         // TODO: only loop over planets?
         // TODO: pass in a location condition, and pick a location that matches it if possible
@@ -2496,7 +2496,7 @@ namespace {
             return;
         int client_empire_id = HumanClientApp::GetApp()->EmpireID();
 
-        auto obj = GetUniverseObject(id);
+        auto obj = Objects().get(id);
         if (!obj) {
             ErrorLogger() << "EncyclopediaDetailPanel::Refresh couldn't find UniverseObject with id " << item_name;
             return;

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -2548,13 +2548,11 @@ namespace {
             }
         }
 
-        for (const auto& pop_center_id : empire->GetPopulationPool().PopCenterIDs()) {
-            auto obj = GetUniverseObject(pop_center_id);
-            auto pc = std::dynamic_pointer_cast<const PopCenter>(obj);
-            if (!pc)
+        for (const auto& pop_center : Objects().find<PopCenter>(empire->GetPopulationPool().PopCenterIDs())) {
+            if (!pop_center)
                 continue;
 
-            const std::string& species_name = pc->SpeciesName();
+            const std::string& species_name = pop_center->SpeciesName();
             if (species_name.empty())
                 continue;
 

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -2316,7 +2316,7 @@ namespace {
 
         if (selected_ship != INVALID_OBJECT_ID) {
             chosen_ships.insert(selected_ship);
-            if (const auto this_ship = GetShip(selected_ship)) {
+            if (const auto this_ship = Objects().get<Ship>(selected_ship)) {
                 if (!this_ship->SpeciesName().empty())
                     additional_species.insert(this_ship->SpeciesName());
                 if (!this_ship->OwnedBy(client_empire_id)) {
@@ -2336,10 +2336,11 @@ namespace {
                 }
             }
         }
-        for (int ship_id : chosen_ships)
-            if (const auto this_ship = GetShip(ship_id))
-                if (!this_ship->SpeciesName().empty())
-                    additional_species.insert(this_ship->SpeciesName());
+        for (const auto& this_ship : Objects().find<Ship>(chosen_ships)) {
+            if (!this_ship || !this_ship->SpeciesName().empty())
+                continue;
+            additional_species.insert(this_ship->SpeciesName());
+        }
         std::vector<std::string> species_list(additional_species.begin(), additional_species.end());
         detailed_description = GetDetailedDescriptionBase(design);
 
@@ -2433,7 +2434,7 @@ namespace {
         int selected_ship = fleet_manager.SelectedShipID();
         if (selected_ship != INVALID_OBJECT_ID) {
             chosen_ships.insert(selected_ship);
-            if (const auto this_ship = GetShip(selected_ship)) {
+            if (const auto this_ship = Objects().get<Ship>(selected_ship)) {
                 if (!additional_species.empty() && ((this_ship->InitialMeterValue(METER_MAX_SHIELD) > 0) || !this_ship->OwnedBy(client_empire_id))) {
                     enemy_DR = this_ship->InitialMeterValue(METER_MAX_SHIELD);
                     DebugLogger() << "Using selected ship for enemy values, DR: " << enemy_DR;
@@ -2451,10 +2452,11 @@ namespace {
                 }
             }
         }
-        for (int ship_id : chosen_ships)
-            if (const auto this_ship = GetShip(ship_id))
-                if (!this_ship->SpeciesName().empty())
-                    additional_species.insert(this_ship->SpeciesName());
+        for (const auto& this_ship : Objects().find<Ship>(chosen_ships)) {
+            if (!this_ship || !this_ship->SpeciesName().empty())
+                continue;
+            additional_species.insert(this_ship->SpeciesName());
+        }
         std::vector<std::string> species_list(additional_species.begin(), additional_species.end());
         detailed_description = GetDetailedDescriptionBase(incomplete_design.get());
 

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -290,7 +290,7 @@ namespace {
                 } else {
                     species_entry += "(" + std::to_string(species->Homeworlds().size()) + "):  ";
                     for (int homeworld_id : species->Homeworlds()) {
-                        if (std::shared_ptr<const Planet> homeworld = GetPlanet(homeworld_id)) {
+                        if (std::shared_ptr<const Planet> homeworld = Objects().get<Planet>(homeworld_id)) {
                             known_homeworlds.insert(homeworld_id);
                             // if known, add to beginning
                             homeworld_info = LinkTaggedIDText(VarText::PLANET_ID_TAG, homeworld_id, homeworld->PublicName(client_empire_id)) + "   " + homeworld_info;
@@ -1543,7 +1543,7 @@ namespace {
             detailed_description += str(FlexibleFormat(UserString("ENC_AUTO_TIME_COST_INVARIANT_STR")) % UserString("ENC_VERB_PRODUCE_STR"));
         } else {
             detailed_description += str(FlexibleFormat(UserString("ENC_AUTO_TIME_COST_VARIABLE_STR")) % UserString("ENC_VERB_PRODUCE_STR"));
-            if (auto planet = GetPlanet(this_location_id)) {
+            if (auto planet = Objects().get<Planet>(this_location_id)) {
                 int local_cost = building_type->ProductionCost(client_empire_id, this_location_id);
                 int local_time = building_type->ProductionTime(client_empire_id, this_location_id);
                 std::string local_name = planet->Name();
@@ -1657,7 +1657,7 @@ namespace {
 
         // Capital
         name = empire->Name();
-        auto capital = GetPlanet(empire->CapitalID());
+        auto capital = Objects().get<Planet>(empire->CapitalID());
         if (capital)
             detailed_description += UserString("EMPIRE_CAPITAL") +
                 LinkTaggedIDText(VarText::PLANET_ID_TAG, capital->ID(), capital->Name());
@@ -2057,7 +2057,7 @@ namespace {
         } else {
             detailed_description += UserString("HOMEWORLD") + "\n";
             for (int hw_id : species->Homeworlds()) {
-                if (auto homeworld = GetPlanet(hw_id))
+                if (auto homeworld = Objects().get<Planet>(hw_id))
                     detailed_description += LinkTaggedIDText(VarText::PLANET_ID_TAG, hw_id,
                                                              homeworld->PublicName(client_empire_id)) + "\n";
                 else
@@ -2072,7 +2072,7 @@ namespace {
         if (sp_op_it != species_object_populations.end()) {
             const auto& object_pops = sp_op_it->second;
             for (const auto& object_pop : object_pops) {
-                auto plt = GetPlanet(object_pop.first);
+                auto plt = Objects().get<Planet>(object_pop.first);
                 if (!plt)
                     continue;
                 if (plt->SpeciesName() != item_name) {
@@ -2288,7 +2288,7 @@ namespace {
 
         std::set<std::string> additional_species; // from currently selected planet and fleets, if any
         const auto& map_wnd = ClientUI::GetClientUI()->GetMapWnd();
-        if (const auto planet = GetPlanet(map_wnd->SelectedPlanetID())) {
+        if (const auto planet = Objects().get<Planet>(map_wnd->SelectedPlanetID())) {
             if (!planet->SpeciesName().empty())
                 additional_species.insert(planet->SpeciesName());
         }
@@ -2424,7 +2424,7 @@ namespace {
         enemy_shots.insert(typical_shot);
         std::set<std::string> additional_species; // TODO: from currently selected planet and ship, if any
         const auto& map_wnd = ClientUI::GetClientUI()->GetMapWnd();
-        if (const auto planet = GetPlanet(map_wnd->SelectedPlanetID())) {
+        if (const auto planet = Objects().get<Planet>(map_wnd->SelectedPlanetID())) {
             if (!planet->SpeciesName().empty())
                 additional_species.insert(planet->SpeciesName());
         }
@@ -2726,7 +2726,7 @@ namespace {
         general_type = UserString("SP_PLANET_SUITABILITY");
 
         int planet_id = boost::lexical_cast<int>(item_name);
-        auto planet = GetPlanet(planet_id);
+        auto planet = Objects().get<Planet>(planet_id);
 
         // show image of planet environment at the top of the suitability report
         const auto& filenames = PlanetEnvFilenames(planet->Type());

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -2308,7 +2308,7 @@ namespace {
                     selected_fleet_id = *selected_fleets.begin();
                 else if (fleet_wnd->FleetIDs().size() > 0)
                     selected_fleet_id = *fleet_wnd->FleetIDs().begin();
-                if (auto selected_fleet = GetFleet(selected_fleet_id))
+                if (auto selected_fleet = Objects().get<Fleet>(selected_fleet_id))
                     if (!selected_fleet->ShipIDs().empty())
                         selected_ship = *selected_fleet->ShipIDs().begin();
             }
@@ -2330,10 +2330,10 @@ namespace {
                 }
             }
         } else if (fleet_manager.ActiveFleetWnd()) {
-            for (int fleet_id : fleet_manager.ActiveFleetWnd()->SelectedFleetIDs()) {
-                if (const auto this_fleet = GetFleet(fleet_id)) {
-                    chosen_ships.insert(this_fleet->ShipIDs().begin(), this_fleet->ShipIDs().end());
-                }
+            for (const auto& fleet : Objects().find<Fleet>(fleet_manager.ActiveFleetWnd()->SelectedFleetIDs())) {
+                if (!fleet)
+                    continue;
+                chosen_ships.insert(fleet->ShipIDs().begin(), fleet->ShipIDs().end());
             }
         }
         for (const auto& this_ship : Objects().find<Ship>(chosen_ships)) {
@@ -2446,10 +2446,10 @@ namespace {
                 }
             }
         } else if (fleet_manager.ActiveFleetWnd()) {
-            for (int fleet_id : fleet_manager.ActiveFleetWnd()->SelectedFleetIDs()) {
-                if (const auto this_fleet = GetFleet(fleet_id)) {
-                    chosen_ships.insert(this_fleet->ShipIDs().begin(), this_fleet->ShipIDs().end());
-                }
+            for (const auto& fleet : Objects().find<Fleet>(fleet_manager.ActiveFleetWnd()->SelectedFleetIDs())) {
+                if (!fleet)
+                    continue;
+                chosen_ships.insert(fleet->ShipIDs().begin(), fleet->ShipIDs().end());
             }
         }
         for (const auto& this_ship : Objects().find<Ship>(chosen_ships)) {

--- a/UI/FieldIcon.cpp
+++ b/UI/FieldIcon.cpp
@@ -81,7 +81,7 @@ void FieldIcon::SizeMove(const GG::Pt& ul, const GG::Pt& lr) {
 }
 
 void FieldIcon::Refresh() {
-    if (auto field = GetField(m_field_id))
+    if (auto field = Objects().get<Field>(m_field_id))
         m_texture = ClientUI::FieldTexture(field->FieldTypeName());
 }
 
@@ -98,7 +98,7 @@ void FieldIcon::RClick(const GG::Pt& pt, GG::Flags<GG::ModKey> mod_keys) {
     if (!Disabled())
         RightClickedSignal(m_field_id);
 
-    auto field = GetField(m_field_id);
+    auto field = Objects().get<Field>(m_field_id);
     if (!field)
         return;
     const std::string& field_type_name = field->FieldTypeName();

--- a/UI/FleetButton.cpp
+++ b/UI/FleetButton.cpp
@@ -309,7 +309,6 @@ void FleetButton::LayoutIcons() {
     // refresh fleet button tooltip
     if (m_fleet_blockaded) {
         std::shared_ptr<Fleet> fleet;
-        std::shared_ptr<System> current_system;
         std::string available_exits = "";
         int available_exits_count = 0;
 
@@ -318,13 +317,11 @@ void FleetButton::LayoutIcons() {
             fleet = GetFleet(*m_fleets.begin());
         else return;
 
-        current_system = GetSystem(fleet->SystemID());
-
-        for (const auto& target_system_id : current_system->StarlanesWormholes()) {
+        for (const auto& target_system_id : Objects().get<System>(fleet->SystemID())->StarlanesWormholes()) {
             if (fleet->BlockadedAtSystem(fleet->SystemID(), target_system_id.first))
                 continue;
 
-            std::shared_ptr<System> target_system = GetSystem(target_system_id.first);
+            auto target_system = Objects().get<System>(target_system_id.first);
             if (target_system) {
                 available_exits += "\n" + target_system->ApparentName(HumanClientApp::GetApp()->EmpireID());
                 available_exits_count++;

--- a/UI/FleetButton.cpp
+++ b/UI/FleetButton.cpp
@@ -147,7 +147,7 @@ FleetButton::FleetButton(const std::vector<int>& fleet_IDs, SizeType size_type) 
         first_fleet = *fleets.begin();
     if (first_fleet && first_fleet->SystemID() == INVALID_OBJECT_ID && first_fleet->NextSystemID() != INVALID_OBJECT_ID) {
         int next_sys_id = first_fleet->NextSystemID();
-        if (auto obj = GetUniverseObject(next_sys_id)) {
+        if (auto obj = Objects().get(next_sys_id)) {
             // fleet is not in a system and has a valid next destination, so can orient it in that direction
             // fleet icons might not appear on the screen in the exact place corresponding to their
             // actual universe position, but if they're moving along a starlane, this code will assume

--- a/UI/FleetButton.cpp
+++ b/UI/FleetButton.cpp
@@ -76,14 +76,10 @@ FleetButton::FleetButton(const std::vector<int>& fleet_IDs, SizeType size_type) 
 {
     std::vector<std::shared_ptr<const Fleet>> fleets;
     fleets.reserve(fleet_IDs.size());
-    m_fleets.reserve(fleet_IDs.size());
-    for (int fleet_id : fleet_IDs) {
-        auto fleet = GetFleet(fleet_id);
-        if (!fleet) {
-            ErrorLogger() << "FleetButton::FleetButton couldn't get fleet with id " << fleet_id;
+    for (const auto& fleet : Objects().find<Fleet>(fleet_IDs)) {
+        if (!fleet)
             continue;
-        }
-        m_fleets.push_back(fleet_id);
+        m_fleets.push_back(fleet->ID());
         fleets.push_back(fleet);
     }
 
@@ -314,7 +310,7 @@ void FleetButton::LayoutIcons() {
 
         if (!m_fleets.empty())
             // can just pick first fleet because all fleets in system should have same exits
-            fleet = GetFleet(*m_fleets.begin());
+            fleet = Objects().get<Fleet>(*m_fleets.begin());
         else return;
 
         for (const auto& target_system_id : Objects().get<System>(fleet->SystemID())->StarlanesWormholes()) {

--- a/UI/FleetButton.cpp
+++ b/UI/FleetButton.cpp
@@ -116,12 +116,12 @@ FleetButton::FleetButton(const std::vector<int>& fleet_IDs, SizeType size_type) 
         bool monsters = true;
         // find if any ship in fleets in button is not a monster
         for (auto& fleet : fleets) {
-            for (int ship_id : fleet->ShipIDs()) {
-                if (auto ship = GetShip(ship_id)) {
-                    if (!ship->IsMonster()) {
-                        monsters = false;
-                        break;
-                    }
+            for (const auto& ship : Objects().find<Ship>(fleet->ShipIDs())) {
+                if (!ship)
+                    continue;
+                if (!ship->IsMonster()) {
+                    monsters = false;
+                    break;
                 }
             }
         }

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -101,8 +101,8 @@ namespace {
 
         int client_empire_id = HumanClientApp::GetApp()->EmpireID();
 
-        std::shared_ptr<const System> dest_sys = GetSystem(fleet->FinalDestinationID());
-        std::shared_ptr<const System> cur_sys = GetSystem(fleet->SystemID());
+        const auto dest_sys = Objects().get<System>(fleet->FinalDestinationID());
+        const auto cur_sys = Objects().get<System>(fleet->SystemID());
         bool returning_to_current_system = (dest_sys == cur_sys) && !fleet->TravelRoute().empty();
         if (dest_sys && (dest_sys != cur_sys || returning_to_current_system)) {
             std::pair<int, int> eta = fleet->ETA();       // .first is turns to final destination.  .second is turns to next system on route
@@ -209,7 +209,7 @@ namespace {
             return;
 
         std::shared_ptr<const Ship> first_ship = *ships.begin();
-        auto system = GetSystem(first_ship->SystemID());
+        auto system = Objects().get<System>(first_ship->SystemID());
         if (!system)
             return;
 
@@ -292,7 +292,7 @@ namespace {
             return;
         }
 
-        auto system = GetSystem(target_fleet->SystemID());
+        auto system = Objects().get<System>(target_fleet->SystemID());
         if (!system) {
             ErrorLogger() << "MergeFleetsIntoFleet couldn't get system for the target fleet";
             return;
@@ -2915,7 +2915,7 @@ void FleetWnd::SetStatIconValues() {
 
 void FleetWnd::RefreshStateChangedSignals() {
     m_system_connection.disconnect();
-    if (auto system = GetSystem(m_system_id))
+    if (auto system = Objects().get<System>(m_system_id))
         m_system_connection = system->StateChangedSignal.connect(
             boost::bind(&FleetWnd::RequireRefresh, this), boost::signals2::at_front);
 
@@ -3048,7 +3048,7 @@ void FleetWnd::Refresh() {
         }
         fleet_locations_ids.swap(fleets_near_enough);
 
-    } else if (auto system = GetSystem(m_system_id)) {
+    } else if (auto system = Objects().get<System>(m_system_id)) {
         location = {m_system_id, GG::Pt(GG::X(system->X()), GG::Y(system->Y()))};
 
     } else {
@@ -3068,7 +3068,7 @@ void FleetWnd::Refresh() {
         m_new_fleet_drop_target->SetSystemID(m_system_id);
 
     // If the location is a system add in any ships from m_empire_id that are in the system.
-    if (auto system = GetSystem(m_system_id)) {
+    if (auto system = Objects().get<System>(m_system_id)) {
         m_fleet_ids.clear();
         // get fleets to show from system, based on required ownership
         for (auto& fleet : Objects().find<Fleet>(system->FleetIDs())) {
@@ -3381,7 +3381,7 @@ void FleetWnd::FleetRightClicked(GG::ListBox::iterator it, const GG::Pt& pt, con
     if (!fleet)
         return;
 
-    auto system = GetSystem(fleet->SystemID());
+    auto system = Objects().get<System>(fleet->SystemID());
     std::set<int> ship_ids_set = fleet->ShipIDs();
 
     std::vector<int> damaged_ship_ids;
@@ -3698,7 +3698,7 @@ namespace {
             return "";
 
         int nearest_system_id(GetPathfinder()->NearestSystemTo(fleet->X(), fleet->Y()));
-        if (auto system = GetSystem(nearest_system_id)) {
+        if (auto system = Objects().get<System>(nearest_system_id)) {
             const std::string& sys_name = system->ApparentName(client_empire_id);
             return sys_name;
         }
@@ -3717,7 +3717,7 @@ std::string FleetWnd::TitleText() const {
     // FleetWnd's empire and system
     const Empire* empire = GetEmpire(m_empire_id);
 
-    if (auto system = GetSystem(m_system_id)) {
+    if (auto system = Objects().get<System>(m_system_id)) {
         const std::string& sys_name = system->ApparentName(client_empire_id);
         return (empire
                 ? boost::io::str(FlexibleFormat(UserString("FW_EMPIRE_FLEETS_AT_SYSTEM")) %

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -254,8 +254,8 @@ namespace {
         // get endpoints of lane in universe.  may be different because on-
         // screen lanes are drawn between system circles, not system centres
         int empire_id = HumanClientApp::GetApp()->EmpireID();
-        auto prev = GetEmpireKnownObject(lane_start_sys_id, empire_id);
-        auto next = GetEmpireKnownObject(lane_end_sys_id, empire_id);
+        auto prev = EmpireKnownObjects(empire_id).get(lane_start_sys_id);
+        auto next = EmpireKnownObjects(empire_id).get(lane_end_sys_id);
         if (!next || !prev) {
             ErrorLogger() << "ScreenPosOnStarlane couldn't find next system " << lane_start_sys_id << " or prev system " << lane_end_sys_id;
             return boost::none;

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -3953,7 +3953,7 @@ void MapWnd::InitFieldRenderingBuffers() {
 
     for (auto& field_icon : m_field_icons) {
         bool current_field_visible = universe.GetObjectVisibilityByEmpire(field_icon.first, empire_id) > VIS_BASIC_VISIBILITY;
-        auto field = GetField(field_icon.first);
+        auto field = Objects().get<Field>(field_icon.first);
         if (!field)
             continue;
         const float FIELD_SIZE = field->InitialMeterValue(METER_SIZE);  // field size is its radius
@@ -4764,7 +4764,7 @@ void MapWnd::DoSystemIconsLayout() {
 void MapWnd::DoFieldIconsLayout() {
     // position and resize field icons
     for (auto& field_icon : m_field_icons) {
-        auto field = GetField(field_icon.first);
+        auto field = Objects().get<Field>(field_icon.first);
         if (!field) {
             ErrorLogger() << "MapWnd::DoFieldIconsLayout couldn't get field with id " << field_icon.first;
             continue;

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -687,7 +687,7 @@ public:
             }
         }
         // get detection ranges for planets in the selected system (if any)
-        if (const auto system = GetSystem(sel_system_id)) {
+        if (const auto system = Objects().get<System>(sel_system_id)) {
             for (const auto& planet : Objects().find<Planet>(system->PlanetIDs())) {
                 if (!planet)
                     continue;
@@ -2061,7 +2061,7 @@ void MapWnd::RenderSystems() {
             // render circles around systems that have at least one starlane, if they are enabled
             if (!circles) continue;
 
-            if (auto system = GetSystem(system_icon.first)) {
+            if (auto system = Objects().get<System>(system_icon.first)) {
                 if (system->NumStarlanes() > 0) {
                     bool has_empire_planet = false;
                     bool has_neutrals = false;
@@ -3074,7 +3074,7 @@ void MapWnd::InitSystemRenderingBuffers() {
     for (const auto& system_icon : m_system_icons) {
         const auto& icon = system_icon.second;
         int system_id = system_icon.first;
-        auto system = GetSystem(system_id);
+        auto system = Objects().get<System>(system_id);
         if (!system) {
             ErrorLogger() << "MapWnd::InitSystemRenderingBuffers couldn't get system with id " << system_id;
             continue;
@@ -3517,7 +3517,7 @@ namespace {
                 //DebugLogger() << "Empire " << empire_id << "; Planet (" << object_id << ") is named " << planet->Name();
 
                 int system_id = planet->SystemID();
-                auto system = GetSystem(system_id);
+                auto system = Objects().get<System>(system_id);
                 if (!system)
                     continue;
 
@@ -3610,7 +3610,7 @@ namespace {
             if (this_client_known_destroyed_objects.count(system_id))
                 continue;
 
-            auto start_system = GetSystem(system_id);
+            auto start_system = Objects().get<System>(system_id);
             if (!start_system) {
                 ErrorLogger() << "GetFullLanesToRender couldn't get system with id " << system_id;
                 continue;
@@ -3627,7 +3627,7 @@ namespace {
                 if (this_client_known_destroyed_objects.count(lane_end_sys_id))
                     continue;
 
-                auto dest_system = GetSystem(render_lane.first);
+                auto dest_system = Objects().get<System>(render_lane.first);
                 if (!dest_system)
                     continue;
 
@@ -3705,7 +3705,7 @@ namespace {
             if (this_client_known_destroyed_objects.count(system_id))
                 continue;
 
-            auto start_system = GetSystem(system_id);
+            auto start_system = Objects().get<System>(system_id);
             if (!start_system) {
                 ErrorLogger() << "GetFullLanesToRender couldn't get system with id " << system_id;
                 continue;
@@ -3722,7 +3722,7 @@ namespace {
                 if (this_client_known_destroyed_objects.count(lane_end_sys_id))
                     continue;
 
-                auto dest_system = GetSystem(render_lane.first);
+                auto dest_system = Objects().get<System>(render_lane.first);
                 if (!dest_system)
                     continue;
                 //std::cout << "colouring lanes between " << start_system->Name() << " and " << dest_system->Name() << std::endl;
@@ -3793,7 +3793,7 @@ namespace {
             if (this_client_known_destroyed_objects.count(system_id))
                 continue;
 
-            auto start_system = GetSystem(system_id);
+            auto start_system = Objects().get<System>(system_id);
             if (!start_system) {
                 ErrorLogger() << "MapWnd::InitStarlaneRenderingBuffers couldn't get system with id " << system_id;
                 continue;
@@ -3810,7 +3810,7 @@ namespace {
                 if (this_client_known_destroyed_objects.count(lane_end_sys_id))
                     continue;
 
-                auto dest_system = GetSystem(render_lane.first);
+                auto dest_system = Objects().get<System>(render_lane.first);
                 if (!dest_system)
                     continue;
                 //std::cout << "colouring lanes between " << start_system->Name() << " and " << dest_system->Name() << std::endl;
@@ -3867,7 +3867,7 @@ namespace {
             if (this_client_known_destroyed_objects.count(system_id))
                 continue;
 
-            auto start_system = GetSystem(system_id);
+            auto start_system = Objects().get<System>(system_id);
             if (!start_system) {
                 ErrorLogger() << "GetFullLanesToRender couldn't get system with id " << system_id;
                 continue;
@@ -3884,7 +3884,7 @@ namespace {
                 if (this_client_known_destroyed_objects.count(lane_end_sys_id))
                     continue;
 
-                auto dest_system = GetSystem(render_lane.first);
+                auto dest_system = Objects().get<System>(render_lane.first);
                 if (!dest_system)
                     continue;
 
@@ -4213,7 +4213,7 @@ void MapWnd::InitScaleCircleRenderingBuffer() {
     if (radius < 5)
         return;
 
-    auto selected_system = GetSystem(SidePanel::SystemID());
+    auto selected_system = Objects().get<System>(SidePanel::SystemID());
     if (!selected_system)
         return;
 
@@ -4428,7 +4428,7 @@ void MapWnd::ReselectLastSystem() {
 
 void MapWnd::SelectSystem(int system_id) {
     //std::cout << "MapWnd::SelectSystem(" << system_id << ")" << std::endl;
-    auto system = GetSystem(system_id);
+    auto system = Objects().get<System>(system_id);
     if (!system && system_id != INVALID_OBJECT_ID) {
         ErrorLogger() << "MapWnd::SelectSystem couldn't find system with id " << system_id << " so is selected no system instead";
         system_id = INVALID_OBJECT_ID;
@@ -4749,7 +4749,7 @@ void MapWnd::DoSystemIconsLayout() {
     // position and resize system icons and gaseous substance
     const int SYSTEM_ICON_SIZE = SystemIconSize();
     for (auto& system_icon : m_system_icons) {
-        auto system = GetSystem(system_icon.first);
+        auto system = Objects().get<System>(system_icon.first);
         if (!system) {
             ErrorLogger() << "MapWnd::DoSystemIconsLayout couldn't get system with id " << system_icon.first;
             continue;
@@ -4783,7 +4783,7 @@ void MapWnd::DoFleetButtonsLayout() {
 
     auto place_system_fleet_btn = [this](const std::unordered_map<int, std::unordered_set<std::shared_ptr<FleetButton>>>::value_type& system_and_btns, bool is_departing) {
         // calculate system icon position
-        auto system = GetSystem(system_and_btns.first);
+        auto system = Objects().get<System>(system_and_btns.first);
         if (!system) {
             ErrorLogger() << "MapWnd::DoFleetButtonsLayout couldn't find system with id " << system_and_btns.first;
             return;
@@ -4924,7 +4924,7 @@ namespace {
             && !fleet->TravelRoute().empty()
             && fleet->SystemID() != INVALID_OBJECT_ID)
         {
-            auto system = GetSystem(fleet->SystemID());
+            auto system = Objects().get<System>(fleet->SystemID());
             if (system)
                 return system;
             ErrorLogger() << "Couldn't get system with id " << fleet->SystemID()
@@ -4941,7 +4941,7 @@ namespace {
              || fleet->TravelRoute().empty())
             && fleet->SystemID() != INVALID_OBJECT_ID)
         {
-            auto system = GetSystem(fleet->SystemID());
+            auto system = Objects().get<System>(fleet->SystemID());
             if (system)
                 return system;
             ErrorLogger() << "Couldn't get system with id " << fleet->SystemID()
@@ -4962,7 +4962,7 @@ namespace {
         int sys1_id = fleet->PreviousSystemID();
         int sys2_id = fleet->NextSystemID();
 
-        auto sys1 = GetSystem(sys1_id);
+        auto sys1 = Objects().get<System>(sys1_id);
         if (!sys1)
             return boost::none;
         if (sys1->HasStarlaneTo(sys2_id))
@@ -5343,20 +5343,20 @@ void MapWnd::SystemRightClicked(int system_id, GG::Flags<GG::ModKey> mod_keys) {
 
         } else if (mas == MAS_AddStarlane) {
             int selected_system_id = SidePanel::SystemID();
-            if (GetSystem(selected_system_id)) {
+            if (Objects().get<System>(selected_system_id)) {
                 net.SendMessage(ModeratorActionMessage(
                     Moderator::AddStarlane(system_id, selected_system_id)));
             }
 
         } else if (mas == MAS_RemoveStarlane) {
             int selected_system_id = SidePanel::SystemID();
-            if (GetSystem(selected_system_id)) {
+            if (Objects().get<System>(selected_system_id)) {
                 net.SendMessage(ModeratorActionMessage(
                     Moderator::RemoveStarlane(system_id, selected_system_id)));
             }
         } else if (mas == MAS_SetOwner) {
             int empire_id = m_moderator_wnd->SelectedEmpire();
-            auto system = GetSystem(system_id);
+            auto system = Objects().get<System>(system_id);
             if (!system)
                 return;
 
@@ -5511,9 +5511,9 @@ void MapWnd::PlotFleetMovement(int system_id, bool execute_move, bool append) {
         // disallow "offroad" (direct non-starlane non-wormhole) travel
         if (route.size() == 2 && *route.begin() != *route.rbegin()) {
             int begin_id = *route.begin();
-            auto begin_sys = GetSystem(begin_id);
+            auto begin_sys = Objects().get<System>(begin_id);
             int end_id = *route.rbegin();
-            auto end_sys = GetSystem(end_id);
+            auto end_sys = Objects().get<System>(end_id);
 
             if (!begin_sys->HasStarlaneTo(end_id) && !begin_sys->HasWormholeTo(end_id) &&
                 !end_sys->HasStarlaneTo(begin_id) && !end_sys->HasWormholeTo(begin_id))
@@ -6888,15 +6888,16 @@ namespace {
         auto owned_planets = Objects().find<Planet>(OwnedVisitor<Planet>(empire_id));
 
         // get IDs of systems that contain any owned planets
-        std::unordered_set<int> system_ids;
+        std::set<int> system_ids;
         for (auto& obj : owned_planets)
         { system_ids.insert(obj->SystemID()); }
 
         // store systems, sorted alphabetically
         std::set<std::pair<std::string, int>, CustomRowCmp> system_names_ids;
-        for (int system_id : system_ids) {
-            if (auto sys = GetSystem(system_id))
-                system_names_ids.insert({sys->Name(), sys->ID()});
+        for (const auto& sys : Objects().find<System>(system_ids)) {
+            if (!sys)
+                continue;
+            system_names_ids.insert({sys->Name(), sys->ID()});
         }
 
         return system_names_ids;
@@ -6911,7 +6912,7 @@ bool MapWnd::ZoomToPrevOwnedSystem() {
 
     // find currently selected system in list
     auto it = system_names_ids.rend();
-    auto sel_sys = GetSystem(SidePanel::SystemID());
+    auto sel_sys = Objects().get<System>(SidePanel::SystemID());
     if (sel_sys) {
         it = std::find(system_names_ids.rbegin(), system_names_ids.rend(),  std::make_pair(sel_sys->Name(), sel_sys->ID()));
         if (it != system_names_ids.rend())
@@ -6937,7 +6938,7 @@ bool MapWnd::ZoomToNextOwnedSystem() {
     auto it = system_names_ids.end();
 
     // find currently selected system in list
-    auto sel_sys = GetSystem(SidePanel::SystemID());
+    auto sel_sys = Objects().get<System>(SidePanel::SystemID());
     if (sel_sys) {
         it = std::find(system_names_ids.begin(), system_names_ids.end(), std::make_pair(sel_sys->Name(), sel_sys->ID()));
         if (it != system_names_ids.end())
@@ -6961,7 +6962,7 @@ bool MapWnd::ZoomToPrevSystem() {
 
     // find currently selected system in list
     auto it = system_names_ids.rend();
-    auto sel_sys = GetSystem(SidePanel::SystemID());
+    auto sel_sys = Objects().get<System>(SidePanel::SystemID());
     if (sel_sys) {
         it = std::find(system_names_ids.rbegin(), system_names_ids.rend(),  std::make_pair(sel_sys->Name(), sel_sys->ID()));
         if (it != system_names_ids.rend())
@@ -6986,7 +6987,7 @@ bool MapWnd::ZoomToNextSystem() {
     auto it = system_names_ids.end();
 
     // find currently selected system in list
-    auto sel_sys = GetSystem(SidePanel::SystemID());
+    auto sel_sys = Objects().get<System>(SidePanel::SystemID());
     if (sel_sys) {
         it = std::find(system_names_ids.begin(), system_names_ids.end(), std::make_pair(sel_sys->Name(), sel_sys->ID()));
         if (it != system_names_ids.end())
@@ -7259,7 +7260,7 @@ bool MapWnd::IsFleetExploring(const int fleet_id){
 }
 
 namespace {
-    typedef std::unordered_set<int> SystemIDListType;
+    typedef std::set<int> SystemIDListType;
     typedef std::unordered_set<int> FleetIDListType;
     typedef std::vector<int> RouteListType;
     typedef std::pair<double, RouteListType> OrderedRouteType;
@@ -7306,8 +7307,8 @@ namespace {
 
     /** Get the shortest suitable route from @p start_id to @p destination_id as known to @p empire_id */
     OrderedRouteType GetShortestRoute(int empire_id, int start_id, int destination_id) {
-        auto start_system = GetSystem(start_id);
-        auto dest_system = GetSystem(destination_id);
+        auto start_system = Objects().get<System>(start_id);
+        auto dest_system = Objects().get<System>(destination_id);
         if (!start_system || !dest_system) {
             WarnLogger() << "Invalid start or destination system";
             return OrderedRouteType();
@@ -7648,12 +7649,11 @@ void MapWnd::DispatchFleetsExploring() {
     // Populate list of unexplored systems
     timer.EnterSection("unexplored systems");
     SystemIDListType unexplored_systems;
-    for (int system_id : candidates_unknown_systems) {
-        auto system = GetSystem(system_id);
+    for (const auto& system : Objects().find<System>(candidates_unknown_systems)) {
         if (!system)
             continue;
         if (!empire->HasExploredSystem(system->ID()) &&
-            !systems_being_explored.count(system_id))
+            !systems_being_explored.count(system->ID()))
         { unexplored_systems.insert(system->ID()); }
     }
     timer.EnterSection("");
@@ -7675,16 +7675,13 @@ void MapWnd::DispatchFleetsExploring() {
     // Determine fleet routes for each unexplored system
     timer.EnterSection("fleet_routes");
     std::unordered_map<int, int> fleet_route_count;
-    for (const auto& unexplored_system_id : unexplored_systems) {
-        auto unexplored_system = GetSystem(unexplored_system_id);
-        if (!unexplored_system) {
-            WarnLogger() << "Invalid system " << unexplored_system_id;
+    for (const auto& unexplored_system : Objects().find<System>(unexplored_systems)) {
+        if (!unexplored_system)
             continue;
-        }
 
         for (const auto& fleet_id : idle_fleets) {
             if (max_routes_per_system > 0 &&
-                fleet_route_count[unexplored_system_id] > max_routes_per_system)
+                fleet_route_count[unexplored_system->ID()] > max_routes_per_system)
             { break; }
 
             auto fleet = GetFleet(fleet_id);
@@ -7697,7 +7694,7 @@ void MapWnd::DispatchFleetsExploring() {
 
             auto route = GetOrderedFleetRoute(fleet, unexplored_system);
             if (route.first > 0.0) {
-                ++fleet_route_count[unexplored_system_id];
+                ++fleet_route_count[unexplored_system->ID()];
                 fleet_routes.emplace(route);
             }
         }

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -688,12 +688,12 @@ public:
         }
         // get detection ranges for planets in the selected system (if any)
         if (const auto system = GetSystem(sel_system_id)) {
-            for (int planet_id : system->PlanetIDs()) {
-                if (const auto planet = GetPlanet(planet_id)) {
-                    const float planet_range = planet->InitialMeterValue(METER_DETECTION);
-                    if (planet_range > 20)
-                        fixed_distances.insert(planet_range);
-                }
+            for (const auto& planet : Objects().find<Planet>(system->PlanetIDs())) {
+                if (!planet)
+                    continue;
+                const float planet_range = planet->InitialMeterValue(METER_DETECTION);
+                if (planet_range > 20)
+                    fixed_distances.insert(planet_range);
             }
         }
 
@@ -3510,7 +3510,7 @@ namespace {
             for (int object_id : available_pp_group.first) {
                 // this_pool += std::to_string(object_id) +", ";
 
-                auto planet = GetPlanet(object_id);
+                auto planet = Objects().get<Planet>(object_id);
                 if (!planet)
                     continue;
 
@@ -5397,7 +5397,7 @@ void MapWnd::PlanetDoubleClicked(int planet_id) {
         return;
 
     // retrieve system_id from planet_id
-    auto planet = GetPlanet(planet_id);
+    auto planet = Objects().get<Planet>(planet_id);
     if (!planet)
         return;
 

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -674,15 +674,15 @@ public:
             if (auto fleet = GetFleet(fleet_id)) {
                 if (fleet->Speed() > 20)
                     fixed_distances.insert(fleet->Speed());
-                for (int ship_id : fleet->ShipIDs()) {
-                    if (auto ship = GetShip(ship_id)) {
-                        const float ship_range = ship->InitialMeterValue(METER_DETECTION);
-                        if (ship_range > 20)
-                            fixed_distances.insert(ship_range);
-                        const float ship_speed = ship->Speed();
-                        if (ship_speed > 20)
-                            fixed_distances.insert(ship_speed);
-                    }
+                for (const auto& ship : Objects().find<Ship>(fleet->ShipIDs())) {
+                    if (!ship)
+                        continue;
+                    const float ship_range = ship->InitialMeterValue(METER_DETECTION);
+                    if (ship_range > 20)
+                        fixed_distances.insert(ship_range);
+                    const float ship_speed = ship->Speed();
+                    if (ship_speed > 20)
+                        fixed_distances.insert(ship_speed);
                 }
             }
         }

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -4412,7 +4412,7 @@ void MapWnd::ShowEncyclopediaEntry(const std::string& str) {
 }
 
 void MapWnd::CenterOnObject(int id) {
-    if (auto obj = GetUniverseObject(id))
+    if (auto obj = Objects().get(id))
         CenterOnMapCoord(obj->X(), obj->Y());
 }
 
@@ -4709,7 +4709,7 @@ void MapWnd::ForgetObject(int id) {
     // Tell the server to change what the empire wants to know
     // in future so that the server doesn't keep resending this
     // object information.
-    auto obj = GetUniverseObject(id);
+    auto obj = Objects().get(id);
     if (!obj)
         return;
 
@@ -6490,7 +6490,7 @@ void MapWnd::ShowProduction() {
     // home system (ie. where the capital is)
     if (SidePanel::SystemID() == INVALID_OBJECT_ID) {
         if (const Empire* empire = GetEmpire(HumanClientApp::GetApp()->EmpireID()))
-            if (auto obj = GetUniverseObject(empire->CapitalID()))
+            if (auto obj = Objects().get(empire->CapitalID()))
                 SelectSystem(obj->SystemID());
     } else {
         // if a system is already shown, make sure a planet gets selected by
@@ -6858,7 +6858,7 @@ bool MapWnd::ZoomToHomeSystem() {
     int home_id = empire->CapitalID();
 
     if (home_id != INVALID_OBJECT_ID) {
-        auto object = GetUniverseObject(home_id);
+        auto object = Objects().get(home_id);
         if (!object)
             return false;
         CenterOnObject(object->SystemID());
@@ -7103,8 +7103,7 @@ bool MapWnd::ZoomToSystemWithWastedPP() {
     if (obj_group.empty())
         return false; // shouldn't happen?
     for (const auto& obj_ids : wasted_PP_objects) {
-        for (int obj_id : obj_ids) {
-            auto obj = GetUniverseObject(obj_id);
+        for (const auto& obj : Objects().find<UniverseObject>(obj_ids)) {
             if (obj && obj->SystemID() != INVALID_OBJECT_ID) {
                 // found object with wasted PP that is in a system.  zoom there.
                 CenterOnObject(obj->SystemID());

--- a/UI/MeterBrowseWnd.cpp
+++ b/UI/MeterBrowseWnd.cpp
@@ -130,7 +130,7 @@ void MeterBrowseWnd::Initialize() {
     const GG::X TOTAL_WIDTH = MeterBrowseLabelWidth() + MeterBrowseValueWidth();
 
     // get objects and meters to verify that they exist
-    auto obj = GetUniverseObject(m_object_id);
+    auto obj = Objects().get(m_object_id);
     if (!obj) {
         ErrorLogger() << "MeterBrowseWnd couldn't get object with id " << m_object_id;
         return;
@@ -238,7 +238,7 @@ namespace {
         int obj_id, const MeterType& meter_type)
     {
         // get object and meter, aborting if not valid
-        auto obj = GetUniverseObject(obj_id);
+        auto obj = Objects().get(obj_id);
         if (!obj) {
             ErrorLogger() << "Couldn't get object with id " << obj_id;
             return boost::none;
@@ -262,7 +262,7 @@ namespace {
 }
 
 void MeterBrowseWnd::UpdateSummary() {
-    auto obj = GetUniverseObject(m_object_id);
+    auto obj = Objects().get(m_object_id);
     if (!obj)
         return;
 
@@ -331,7 +331,7 @@ void MeterBrowseWnd::UpdateEffectLabelsAndValues(GG::Y& top) {
 
     // add label-value pairs for each alteration recorded for this meter
     for (const auto& info : *maybe_info_vec) {
-        auto source = GetUniverseObject(info.source_id);
+        auto source = Objects().get(info.source_id);
 
         std::string text;
         std::string name;

--- a/UI/MeterBrowseWnd.cpp
+++ b/UI/MeterBrowseWnd.cpp
@@ -446,7 +446,7 @@ void ShipDamageBrowseWnd::Initialize() {
     const GG::X TOTAL_WIDTH = MeterBrowseLabelWidth() + MeterBrowseValueWidth();
 
     // get objects and meters to verify that they exist
-    auto ship = GetShip(m_object_id);
+    auto ship = Objects().get<Ship>(m_object_id);
     if (!ship) {
         ErrorLogger() << "ShipDamageBrowseWnd couldn't get ship with id " << m_object_id;
         return;
@@ -484,7 +484,7 @@ void ShipDamageBrowseWnd::UpdateImpl(std::size_t mode, const Wnd* target) {
 }
 
 void ShipDamageBrowseWnd::UpdateSummary() {
-    auto ship = GetShip(m_object_id);
+    auto ship = Objects().get<Ship>(m_object_id);
     if (!ship)
         return;
 
@@ -509,7 +509,7 @@ void ShipDamageBrowseWnd::UpdateEffectLabelsAndValues(GG::Y& top) {
     m_effect_labels_and_values.clear();
 
     // get object and meter, aborting if not valid
-    auto ship = GetShip(m_object_id);
+    auto ship = Objects().get<Ship>(m_object_id);
     if (!ship) {
         ErrorLogger() << "ShipDamageBrowseWnd::UpdateEffectLabelsAndValues couldn't get ship with id " << m_object_id;
         return;
@@ -624,7 +624,7 @@ void ShipFightersBrowseWnd::Initialize() {
     const GG::Clr BG_COLOR = ClientUI::WndColor();
 
     // get objects and meters to verify that they exist
-    auto ship = GetShip(m_object_id);
+    auto ship = Objects().get<Ship>(m_object_id);
     if (!ship) {
         ErrorLogger() << "Couldn't get ship with id " << m_object_id;
         return;
@@ -679,7 +679,7 @@ void ShipFightersBrowseWnd::UpdateImpl(std::size_t mode, const Wnd* target) {
 }
 
 void ShipFightersBrowseWnd::UpdateSummary() {
-    auto ship = GetShip(m_object_id);
+    auto ship = Objects().get<Ship>(m_object_id);
     if (!ship)
         return;
 
@@ -751,7 +751,7 @@ void ShipFightersBrowseWnd::UpdateEffectLabelsAndValues(GG::Y& top) {
     m_hangar_list->DetachChildren();
 
     // early return if no valid ship, ship design, or no parts in the design
-    auto ship = GetShip(m_object_id);
+    auto ship = Objects().get<Ship>(m_object_id);
     if (!ship) {
         ErrorLogger() << "Couldn't get ship with id " << m_object_id;
         return;

--- a/UI/MeterBrowseWnd.cpp
+++ b/UI/MeterBrowseWnd.cpp
@@ -354,7 +354,7 @@ void MeterBrowseWnd::UpdateEffectLabelsAndValues(GG::Y& top) {
         case ECT_BUILDING: {
             name.clear();
             if (const auto& building = std::dynamic_pointer_cast<const Building>(source))
-                if (const auto& planet = GetPlanet(building->PlanetID()))
+                if (const auto& planet = Objects().get<Planet>(building->PlanetID()))
                     name = planet->Name();
             const std::string& label_template = (info.custom_label.empty()
                 ? UserString("TT_BUILDING")

--- a/UI/MilitaryPanel.cpp
+++ b/UI/MilitaryPanel.cpp
@@ -39,7 +39,7 @@ void MilitaryPanel::CompleteConstruction() {
 
     SetName("MilitaryPanel");
 
-    auto planet = this->GetPlanet();
+    auto planet = Objects().get<Planet>(m_planet_id);
     if (!planet)
         throw std::invalid_argument("Attempted to construct a MilitaryPanel with an object id is not a Planet");
 
@@ -188,20 +188,6 @@ void MilitaryPanel::DoLayout() {
     }
 
     SetCollapsed(!s_expanded_map[m_planet_id]);
-}
-
-std::shared_ptr<const Planet> MilitaryPanel::GetPlanet() const {
-    auto obj = GetUniverseObject(m_planet_id);
-    if (!obj) {
-        ErrorLogger() << "MilitaryPanel tried to get an object with an invalid m_planet_id";
-        return nullptr;
-    }
-    auto planet = std::dynamic_pointer_cast<const Planet>(obj);
-    if (!planet) {
-        ErrorLogger() << "MilitaryPanel failed casting an object pointer to a Planet pointer";
-        return nullptr;
-    }
-    return planet;
 }
 
 std::map<int, bool> MilitaryPanel::s_expanded_map;

--- a/UI/MilitaryPanel.cpp
+++ b/UI/MilitaryPanel.cpp
@@ -46,7 +46,7 @@ void MilitaryPanel::CompleteConstruction() {
     m_expand_button->LeftPressedSignal.connect(
         boost::bind(&MilitaryPanel::ExpandCollapseButtonPressed, this));
 
-    const auto obj = GetUniverseObject(m_planet_id);
+    const auto obj = Objects().get(m_planet_id);
     if (!obj) {
         ErrorLogger() << "Invalid object id " << m_planet_id;
         return;
@@ -100,7 +100,7 @@ void MilitaryPanel::ExpandCollapse(bool expanded) {
 }
 
 void MilitaryPanel::Update() {
-    auto obj = GetUniverseObject(m_planet_id);
+    auto obj = Objects().get(m_planet_id);
     if (!obj) {
         ErrorLogger() << "MilitaryPanel::Update coudln't get object with id  " << m_planet_id;
         return;

--- a/UI/MilitaryPanel.h
+++ b/UI/MilitaryPanel.h
@@ -47,9 +47,6 @@ private:
     /** object id for the Planet that this panel displays */
     int m_planet_id;
 
-    /** returns the Planet object with id m_planet_id */
-    std::shared_ptr<const Planet> GetPlanet() const;
-
     /** Icons for the associated meter type. */
     std::vector<std::pair<MeterType, std::shared_ptr<StatisticIcon>>> m_meter_stats;
 

--- a/UI/MultiIconValueIndicator.cpp
+++ b/UI/MultiIconValueIndicator.cpp
@@ -116,12 +116,9 @@ void MultiIconValueIndicator::Update() {
     for (std::size_t i = 0; i < m_icons.size(); ++i) {
         assert(m_icons[i]);
         double total = 0.0;
-        for (int object_id : m_object_ids) {
-            auto obj = GetUniverseObject(object_id);
-            if (!obj) {
-                ErrorLogger() << "MultiIconValueIndicator::Update couldn't get object with id " << object_id;
+        for (const auto& obj : Objects().find<UniverseObject>(m_object_ids)) {
+            if (!obj)
                 continue;
-            }
             //DebugLogger() << "MultiIconValueIndicator::Update object:";
             //DebugLogger() << obj->Dump();
             auto type = m_meter_types[i].first;

--- a/UI/MultiIconValueIndicator.cpp
+++ b/UI/MultiIconValueIndicator.cpp
@@ -54,7 +54,7 @@ void MultiIconValueIndicator::CompleteConstruction() {
         // special case for population meter for an indicator showing only a
         // single popcenter: icon is species icon, rather than generic pop icon
         if (PRIMARY_METER_TYPE == METER_POPULATION && m_object_ids.size() == 1) {
-            if (auto pc = GetPopCenter(*m_object_ids.begin()))
+            if (auto pc = Objects().get<PopCenter>(*m_object_ids.begin()))
                 texture = ClientUI::SpeciesIcon(pc->SpeciesName());
         }
 
@@ -67,7 +67,7 @@ void MultiIconValueIndicator::CompleteConstruction() {
         m_icons.back()->RightClickedSignal.connect([this, meter, meter_string](const GG::Pt& pt) {
             auto popup = GG::Wnd::Create<CUIPopupMenu>(pt.x, pt.y);
 
-            auto pc = GetPopCenter(*(this->m_object_ids.begin()));
+            auto pc = Objects().get<PopCenter>(*(this->m_object_ids.begin()));
             if (meter == METER_POPULATION && pc && this->m_object_ids.size() == 1) {
                 auto species_name = pc->SpeciesName();
                 if (!species_name.empty()) {

--- a/UI/MultiMeterStatusBar.cpp
+++ b/UI/MultiMeterStatusBar.cpp
@@ -203,7 +203,7 @@ void MultiMeterStatusBar::Update() {
     m_projected_values.clear(); // projected current value of .first MeterTypes for the start of next turn
     m_target_max_values.clear();// current values of the .second MeterTypes in m_meter_types
 
-    auto obj = GetUniverseObject(m_object_id);
+    auto obj = Objects().get(m_object_id);
     if (!obj) {
         ErrorLogger() << "MultiMeterStatusBar couldn't get object with id " << m_object_id;
         return;

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -2570,7 +2570,7 @@ void ObjectListWnd::ObjectRightClicked(GG::ListBox::iterator it, const GG::Pt& p
         for (const auto& entry : m_list_box->Selections()) {
             ObjectRow *row = dynamic_cast<ObjectRow *>(entry->get());
             if (row) {
-                auto one_planet = GetPlanet(row->ObjectID());
+                auto one_planet = Objects().get<Planet>(row->ObjectID());
                 if (one_planet && one_planet->OwnedBy(app->EmpireID())) {
                     for (const std::string& planet_focus : one_planet->AvailableFoci())
                         all_foci[planet_focus]++;
@@ -2600,7 +2600,7 @@ void ObjectListWnd::ObjectRightClicked(GG::ListBox::iterator it, const GG::Pt& p
                     if (!row)
                         continue;
 
-                    auto one_planet = GetPlanet(row->ObjectID());
+                    auto one_planet = Objects().get<Planet>(row->ObjectID());
                     if (!(one_planet && one_planet->OwnedBy(app->EmpireID())))
                         continue;
 
@@ -2634,7 +2634,7 @@ void ObjectListWnd::ObjectRightClicked(GG::ListBox::iterator it, const GG::Pt& p
                     ObjectRow* row = dynamic_cast<ObjectRow*>(entry->get());
                     if (!row)
                         continue;
-                    auto one_planet = GetPlanet(row->ObjectID());
+                    auto one_planet = Objects().get<Planet>(row->ObjectID());
                     if (!one_planet || !one_planet->OwnedBy(app->EmpireID()) || !cur_empire->ProducibleItem(BT_SHIP, ship_design, row->ObjectID()))
                         continue;
                     ProductionQueue::ProductionItem ship_item(BT_SHIP, ship_design);
@@ -2672,7 +2672,7 @@ void ObjectListWnd::ObjectRightClicked(GG::ListBox::iterator it, const GG::Pt& p
                     ObjectRow *row = dynamic_cast<ObjectRow *>(selection->get());
                     if (!row)
                         continue;
-                    std::shared_ptr<Planet> one_planet = GetPlanet(row->ObjectID());
+                    std::shared_ptr<Planet> one_planet = Objects().get<Planet>(row->ObjectID());
                     if (!one_planet || !one_planet->OwnedBy(app->EmpireID())
                         || !cur_empire->EnqueuableItem(BT_BUILDING, bld, row->ObjectID())
                         || !cur_empire->ProducibleItem(BT_BUILDING, bld, row->ObjectID()))

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -1468,7 +1468,7 @@ public:
             AttachChild(m_dot);
         }
 
-        auto obj = GetUniverseObject(m_object_id);
+        auto obj = Objects().get(m_object_id);
         auto textures = ObjectTextures(obj);
 
         m_icon = GG::Wnd::Create<MultiTextureStaticGraphic>(
@@ -1549,7 +1549,7 @@ private:
     void RefreshCache() const {
         m_column_val_cache.clear();
         m_column_val_cache.reserve(NUM_COLUMNS);
-        auto obj = GetUniverseObject(m_object_id);
+        auto obj = Objects().get(m_object_id);
         ScriptingContext context(obj);
 
         // get currently displayed column value refs, put values into this panel's cache
@@ -2264,7 +2264,7 @@ private:
     void AddObjectRow(int object_id, int container, const std::set<int>& contents,
                       int indent, GG::ListBox::iterator it)
     {
-        auto obj = GetUniverseObject(object_id);
+        auto obj = Objects().get(object_id);
         if (!obj)
             return;
         const GG::Pt row_size = ListRowSize();
@@ -2356,7 +2356,7 @@ private:
     void ObjectStateChanged(int object_id) {
         if (object_id == INVALID_OBJECT_ID)
             return;
-        auto obj = GetUniverseObject(object_id);
+        auto obj = Objects().get(object_id);
         DebugLogger() << "ObjectListBox::ObjectStateChanged: " << obj->Name();
         if (!obj)
             return;
@@ -2549,7 +2549,7 @@ void ObjectListWnd::ObjectRightClicked(GG::ListBox::iterator it, const GG::Pt& p
     // create popup menu with object commands in it
     popup->AddMenuItem(GG::MenuItem(UserString("DUMP"), false, false, dump_action));
 
-    auto obj = GetUniverseObject(object_id);
+    auto obj = Objects().get(object_id);
     //DebugLogger() << "ObjectListBox::ObjectStateChanged: " << obj->Name();
     if (!obj)
         return;

--- a/UI/PopulationPanel.cpp
+++ b/UI/PopulationPanel.cpp
@@ -48,17 +48,17 @@ void PopulationPanel::CompleteConstruction() {
     m_meter_stats.push_back({
         METER_POPULATION,
         GG::Wnd::Create<StatisticIcon>(ClientUI::SpeciesIcon(pop->SpeciesName()),
-                                       obj->InitialMeterValue(METER_POPULATION), 3, false,
+                                       pop->InitialMeterValue(METER_POPULATION), 3, false,
                                        MeterIconSize().x, MeterIconSize().y)});
     m_meter_stats.push_back({
         METER_HAPPINESS,
         GG::Wnd::Create<StatisticIcon>(ClientUI::MeterIcon(METER_HAPPINESS),
-                                       obj->InitialMeterValue(METER_HAPPINESS), 3, false,
+                                       pop->InitialMeterValue(METER_HAPPINESS), 3, false,
                                        MeterIconSize().x, MeterIconSize().y)});
     m_meter_stats.push_back({
         METER_CONSTRUCTION,
         GG::Wnd::Create<StatisticIcon>(ClientUI::MeterIcon(METER_CONSTRUCTION),
-                                       obj->InitialMeterValue(METER_CONSTRUCTION), 3, false,
+                                       pop->InitialMeterValue(METER_CONSTRUCTION), 3, false,
                                        MeterIconSize().x, MeterIconSize().y)});
 
     // meter and production indicators

--- a/UI/PopulationPanel.cpp
+++ b/UI/PopulationPanel.cpp
@@ -38,12 +38,7 @@ void PopulationPanel::CompleteConstruction() {
     m_expand_button->LeftPressedSignal.connect(
         boost::bind(&PopulationPanel::ExpandCollapseButtonPressed, this));
 
-    const auto obj = GetUniverseObject(m_popcenter_id);
-    if (!obj) {
-        ErrorLogger() << "Attempted to construct a PopulationPanel with an invalid object id " << m_popcenter_id;
-        return;
-    }
-    auto pop = GetPopCenter();
+    auto pop = Objects().get<PopCenter>(m_popcenter_id);
     if (!pop) {
         ErrorLogger() << "Attempted to construct a PopulationPanel with an object id that is not a popcenter: " << m_popcenter_id;
         return;
@@ -76,7 +71,7 @@ void PopulationPanel::CompleteConstruction() {
             std::string meter_string = boost::lexical_cast<std::string>(meter_type);
 
             auto popup = GG::Wnd::Create<CUIPopupMenu>(pt.x, pt.y);
-            auto pc = this->GetPopCenter();
+            auto pc = Objects().get<PopCenter>(m_popcenter_id);
             if (meter_type == METER_POPULATION && pc) {
                 std::string species_name = pc->SpeciesName();
                 if (!species_name.empty()) {
@@ -127,7 +122,7 @@ void PopulationPanel::Update() {
         m_multi_icon_value_indicator->ClearToolTip(meter_stat.first);
     }
 
-    auto pop = GetPopCenter();
+    auto pop = Objects().get<PopCenter>(m_popcenter_id);
     if (!pop) {
         ErrorLogger() << "PopulationPanel::Update couldn't get PopCenter or couldn't get UniverseObject";
         return;
@@ -216,15 +211,6 @@ void PopulationPanel::DoLayout() {
     }
 
     SetCollapsed(!s_expanded_map[m_popcenter_id]);
-}
-
-std::shared_ptr<const PopCenter> PopulationPanel::GetPopCenter() const {
-    auto pop = ::GetPopCenter(m_popcenter_id);
-    if (!pop) {
-        ErrorLogger() << "PopulationPanel tried to get an object with an invalid m_popcenter_id: " << m_popcenter_id;
-        return nullptr;
-    }
-    return pop;
 }
 
 std::map<int, bool> PopulationPanel::s_expanded_map;

--- a/UI/PopulationPanel.h
+++ b/UI/PopulationPanel.h
@@ -50,9 +50,6 @@ private:
     /** object id for the PopulationCenter that this panel displays */
     int m_popcenter_id = INVALID_OBJECT_ID;
 
-    /** returns the PopCenter object with id m_popcenter_id */
-    std::shared_ptr<const PopCenter> GetPopCenter() const;
-
     /** Icons for the associated meter type. */
     std::vector<std::pair<MeterType, std::shared_ptr<StatisticIcon>>> m_meter_stats;
 

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -723,7 +723,7 @@ namespace {
 
             if (build_type == BT_SHIP) {
                 // for ships, add a set rally point command
-                if (auto system = GetSystem(SidePanel::SystemID())) {
+                if (auto system = Objects().get<System>(SidePanel::SystemID())) {
                     std::string rally_prompt = boost::io::str(FlexibleFormat(UserString("RALLY_QUEUE_ITEM")) % system->PublicName(HumanClientApp::GetApp()->EmpireID()));
                     popup->AddMenuItem(GG::MenuItem(rally_prompt,               false, false, rally_to_action));
                 }

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -274,7 +274,7 @@ namespace {
             main_text += UserString("BUILD_ITEM_TYPE_PROJECT") + "\n";
 
             item_name = UserString(elem.item.name);
-            auto loc = GetUniverseObject(elem.location);
+            auto loc = Objects().get(elem.location);
             location_ok = loc && loc->OwnedBy(elem.empire_id) && (std::dynamic_pointer_cast<const ResourceCenter>(loc));
 
             total_cost = 1.0;
@@ -282,12 +282,12 @@ namespace {
             icon = ClientUI::MeterIcon(METER_STOCKPILE);
         }
 
-        if (std::shared_ptr<UniverseObject> rally_object = GetUniverseObject(elem.rally_point_id)) {
+        if (auto rally_object = Objects().get(elem.rally_point_id)) {
             main_text += boost::io::str(FlexibleFormat(UserString("PRODUCTION_QUEUE_RALLIED_TO"))
                                         % rally_object->Name()) + "\n";
         }
 
-        if (std::shared_ptr<UniverseObject> location = GetUniverseObject(elem.location))
+        if (auto location = Objects().get(elem.location))
             main_text += boost::io::str(FlexibleFormat(UserString("PRODUCTION_QUEUE_ENQUEUED_ITEM_LOCATION"))
                                         % location->Name()) + "\n";
 
@@ -454,7 +454,7 @@ namespace {
         std::string location_text;
         bool system_selected = false;
         bool rally_dest_selected = (elem.rally_point_id != INVALID_OBJECT_ID && elem.rally_point_id == SidePanel::SystemID());
-        if (std::shared_ptr<const UniverseObject> location = GetUniverseObject(elem.location)) {
+        if (const auto location = Objects().get(elem.location)) {
             system_selected = (location->SystemID() != INVALID_OBJECT_ID && location ->SystemID() == SidePanel::SystemID());
             if (GetOptionsDB().Get<bool>("ui.queue.production_location.shown")) {
                 if (rally_dest_selected && !system_selected) {
@@ -1119,7 +1119,7 @@ void ProductionWnd::UpdateInfoPanel() {
 
     // find if there is a local location
     int prod_loc_id = this->SelectedPlanetID();
-    auto loc_obj = GetUniverseObject(prod_loc_id);
+    auto loc_obj = Objects().get(prod_loc_id);
     if (!loc_obj) {
         // clear local info...
         m_production_info_panel->ClearLocalInfo();

--- a/UI/ResourcePanel.cpp
+++ b/UI/ResourcePanel.cpp
@@ -43,7 +43,7 @@ void ResourcePanel::CompleteConstruction() {
 
     SetName("ResourcePanel");
 
-    auto res = GetResCenter();
+    auto res = Objects().get<ResourceCenter>(m_rescenter_id);
     if (!res)
         throw std::invalid_argument("Attempted to construct a ResourcePanel with an UniverseObject that is not a ResourceCenter");
 
@@ -222,15 +222,6 @@ void ResourcePanel::DoLayout() {
     }
 
     SetCollapsed(!s_expanded_map[m_rescenter_id]);
-}
-
-std::shared_ptr<const ResourceCenter> ResourcePanel::GetResCenter() const {
-    auto res = GetResourceCenter(m_rescenter_id);
-    if (!res) {
-        ErrorLogger() << "ResourcePanel tried to get an object with an invalid m_rescenter_id";
-        return nullptr;
-    }
-    return res;
 }
 
 std::map<int, bool> ResourcePanel::s_expanded_map;

--- a/UI/ResourcePanel.cpp
+++ b/UI/ResourcePanel.cpp
@@ -50,7 +50,7 @@ void ResourcePanel::CompleteConstruction() {
     m_expand_button->LeftPressedSignal.connect(
         boost::bind(&ResourcePanel::ExpandCollapseButtonPressed, this));
 
-    const auto obj = GetUniverseObject(m_rescenter_id);
+    const auto obj = Objects().get(m_rescenter_id);
     if (!obj) {
         ErrorLogger() << "Invalid object id " << m_rescenter_id;
         return;
@@ -132,7 +132,7 @@ void ResourcePanel::Update() {
         m_multi_icon_value_indicator->ClearToolTip(meter_stat.first);
     }
 
-    auto obj = GetUniverseObject(m_rescenter_id);
+    auto obj = Objects().get(m_rescenter_id);
     if (!obj) {
         ErrorLogger() << "BuildingPanel::Update couldn't get object with id " << m_rescenter_id;
         return;

--- a/UI/ResourcePanel.h
+++ b/UI/ResourcePanel.h
@@ -50,9 +50,6 @@ private:
     /** object id for the ResourceCenter that this panel displays */
     int m_rescenter_id;
 
-    /** returns the ResourceCenter object with id m_rescenter_id */
-    std::shared_ptr<const ResourceCenter> GetResCenter() const;
-
     /** Icons for the associated meter type. */
     std::vector<std::pair<MeterType, std::shared_ptr<StatisticIcon>>> m_meter_stats;
 

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -2434,7 +2434,7 @@ void SidePanel::PlanetPanel::FocusDropListSelectionChangedSlot(GG::DropDownList:
         return;
     }
 
-    auto res = GetResourceCenter(m_planet_id);
+    auto res = Objects().get<ResourceCenter>(m_planet_id);
     if (!res) {
         ErrorLogger() << "PlanetPanel::FocusDropListSelectionChanged couldn't convert object with id " << m_planet_id << " to a ResourceCenter";
         return;

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -1531,11 +1531,8 @@ void SidePanel::PlanetPanel::Refresh() {
     // check for shipyard
     const auto& known_destroyed_object_ids =
         GetUniverse().EmpireKnownDestroyedObjectIDs(client_empire_id);
-    for (int building_id : planet->BuildingIDs()) {
-        auto building = GetBuilding(building_id);
-        if (!building)
-            continue;
-        if (known_destroyed_object_ids.count(building_id))
+    for (const auto& building : Objects().find<Building>(planet->BuildingIDs())) {
+        if (!building || known_destroyed_object_ids.count(building->ID()))
             continue;
         if (building->HasTag(TAG_SHIPYARD)) {
             has_shipyard = true;

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -1268,8 +1268,7 @@ namespace {
             return retval;
 
         // is there a valid single selected ship in the active FleetWnd?
-        for (int ship_id : FleetUIManager::GetFleetUIManager().SelectedShipIDs()) {
-            auto ship = GetShip(ship_id);
+        for (const auto& ship : Objects().find<Ship>(FleetUIManager::GetFleetUIManager().SelectedShipIDs())) {
             if (!ship || ship->SystemID() != system_id)
                 continue;
             if (!ship->CanBombard() || !ship->OwnedBy(HumanClientApp::GetApp()->EmpireID()))
@@ -1287,10 +1286,12 @@ std::shared_ptr<const Ship> ValidSelectedColonyShip(int system_id) {
         return nullptr;
 
     // is there a valid selected ship in the active FleetWnd?
-    for (int ship_id : FleetUIManager::GetFleetUIManager().SelectedShipIDs())
-        if (auto ship = GetShip(ship_id))
-            if (ship->SystemID() == system_id && ship->CanColonize() && ship->OwnedBy(HumanClientApp::GetApp()->EmpireID()))
-                return ship;
+    for (const auto& ship : Objects().find<Ship>(FleetUIManager::GetFleetUIManager().SelectedShipIDs())) {
+        if (!ship)
+            continue;
+        if (ship->SystemID() == system_id && ship->CanColonize() && ship->OwnedBy(HumanClientApp::GetApp()->EmpireID()))
+            return ship;
+    }
     return nullptr;
 }
 
@@ -1571,7 +1572,7 @@ void SidePanel::PlanetPanel::Refresh() {
 
     auto selected_colony_ship = ValidSelectedColonyShip(SidePanel::SystemID());
     if (!selected_colony_ship && FleetUIManager::GetFleetUIManager().SelectedShipIDs().empty())
-        selected_colony_ship = GetShip(AutomaticallyChosenColonyShip(m_planet_id));
+        selected_colony_ship = Objects().get<Ship>(AutomaticallyChosenColonyShip(m_planet_id));
 
     auto invasion_ships = ValidSelectedInvasionShips(SidePanel::SystemID());
     if (invasion_ships.empty()) {
@@ -2317,7 +2318,7 @@ void SidePanel::PlanetPanel::ClickColonize() {
         // find colony ship and order it to colonize
         auto ship = ValidSelectedColonyShip(SidePanel::SystemID());
         if (!ship)
-            ship = GetShip(AutomaticallyChosenColonyShip(m_planet_id));
+            ship = Objects().get<Ship>(AutomaticallyChosenColonyShip(m_planet_id));
 
         if (!ship) {
             ErrorLogger() << "SidePanel::PlanetPanel::ClickColonize valid colony not found!";

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -2461,7 +2461,7 @@ void SidePanel::PlanetPanel::EnableOrderIssuing(bool enable/* = true*/) {
 
     m_buildings_panel->EnableOrderIssuing(enable);
 
-    auto obj = GetUniverseObject(m_planet_id);
+    auto obj = Objects().get(m_planet_id);
     if (!enable || !obj || !obj->OwnedBy(HumanClientApp::GetApp()->EmpireID()))
         m_focus_drop->Disable();
     else

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -775,7 +775,7 @@ namespace {
         int SystemID() const { return m_system_id; }
 
         SortKeyType SortKey(std::size_t column) const override
-        { return GetSystem(m_system_id)->Name() + std::to_string(m_system_id); }
+        { return Objects().get<System>(m_system_id)->Name() + std::to_string(m_system_id); }
 
     private:
         int m_system_id;
@@ -801,7 +801,7 @@ class SidePanel::SystemNameDropDownList : public CUIDropDownList {
         if (!system_row)
             return;
 
-        auto system = GetSystem(system_row->SystemID());
+        auto system = Objects().get<System>(system_row->SystemID());
         if (!system)
             return;
 
@@ -1305,7 +1305,7 @@ int AutomaticallyChosenColonyShip(int target_planet_id) {
     if (!target_planet)
         return INVALID_OBJECT_ID;
     int system_id = target_planet->SystemID();
-    auto system = GetSystem(system_id);
+    auto system = Objects().get<System>(system_id);
     if (!system)
         return INVALID_OBJECT_ID;
     // is planet a valid colonization target?
@@ -1417,7 +1417,7 @@ std::set<std::shared_ptr<const Ship>> AutomaticallyChosenInvasionShips(int targe
     if (!target_planet)
         return retval;
     int system_id = target_planet->SystemID();
-    auto system = GetSystem(system_id);
+    auto system = Objects().get<System>(system_id);
     if (!system)
         return retval;
 
@@ -1459,7 +1459,7 @@ std::set<std::shared_ptr<const Ship>> AutomaticallyChosenBombardShips(int target
     if (!target_planet)
         return retval;
     int system_id = target_planet->SystemID();
-    auto system = GetSystem(system_id);
+    auto system = Objects().get<System>(system_id);
     if (!system)
         return retval;
 
@@ -1921,7 +1921,7 @@ void SidePanel::PlanetPanel::Refresh() {
                                  " (id: " << m_planet_id << ") without having seen it before!";
             }
 
-            auto system = GetSystem(planet->SystemID());
+            auto system = Objects().get<System>(planet->SystemID());
             if (system && system->GetVisibility(client_empire_id) <= VIS_BASIC_VISIBILITY) { // HACK: system is basically visible or less, so we must not be in detection range of the planet.
                 detection_info = UserString("PL_NOT_IN_RANGE");
             }
@@ -2043,7 +2043,7 @@ void SidePanel::PlanetPanel::RClick(const GG::Pt& pt, GG::Flags<GG::ModKey> mod_
     if (!planet)
         return;
 
-    auto system = GetSystem(planet->SystemID());
+    auto system = Objects().get<System>(planet->SystemID());
 
     // determine which other empires are at peace with client empire and have
     // an owned object in this fleet's system
@@ -2556,7 +2556,7 @@ void SidePanel::PlanetPanelContainer::SetPlanets(const std::vector<int>& planet_
         if (!planet)
             continue;
         int system_id = planet->SystemID();
-        auto system = GetSystem(system_id);
+        auto system = Objects().get<System>(system_id);
         if (!system) {
             ErrorLogger() << "PlanetPanelContainer::SetPlanets couldn't find system of planet" << planet->Name();
             continue;
@@ -2838,7 +2838,7 @@ namespace {
             }
             m_labels_and_amounts.clear();
 
-            auto system = GetSystem(m_system_id);
+            auto system = Objects().get<System>(m_system_id);
             if (!system)
                 return;
 
@@ -3153,7 +3153,7 @@ void SidePanel::RefreshInPreRender() {
 
 
     // connect state changed and insertion signals for planets and fleets in system
-    auto system = GetSystem(s_system_id);
+    auto system = Objects().get<System>(s_system_id);
     if (!system) {
         ErrorLogger() << "SidePanel::Refresh couldn't get system with id " << s_system_id;
         return;
@@ -3177,7 +3177,7 @@ void SidePanel::RefreshInPreRender() {
 }
 
 void SidePanel::RefreshSystemNames() {
-    //auto system = GetSystem(s_system_id);
+    //auto system = Objects().get<System>(s_system_id);
     //if (!system)
     //    return;
 
@@ -3242,7 +3242,7 @@ void SidePanel::RefreshImpl() {
 
     RefreshSystemNames();
 
-    auto system = GetSystem(s_system_id);
+    auto system = Objects().get<System>(s_system_id);
     // if no system object, there is nothing to populate with.  early abort.
     if (!system)
         return;
@@ -3411,7 +3411,7 @@ void SidePanel::DoLayout() {
     GG::GUI::PreRenderWindow(m_planet_panel_container);
 
     // hide scrollbar if there is no planets in the system
-    auto system = GetSystem(s_system_id);
+    auto system = Objects().get<System>(s_system_id);
     if (system) {
         if (system->PlanetIDs().empty())
             m_planet_panel_container->HideScrollbar();
@@ -3507,7 +3507,7 @@ bool SidePanel::PlanetSelectable(int planet_id) const {
     if (!m_selection_enabled)
         return false;
 
-    auto system = GetSystem(s_system_id);
+    auto system = Objects().get<System>(s_system_id);
     if (!system)
         return false;
 
@@ -3563,7 +3563,7 @@ void SidePanel::SetSystem(int system_id) {
     if (s_system_id == system_id)
         return;
 
-    auto system = GetSystem(system_id);
+    auto system = Objects().get<System>(system_id);
     if (!system) {
         s_system_id = INVALID_OBJECT_ID;
         return;
@@ -3571,7 +3571,7 @@ void SidePanel::SetSystem(int system_id) {
 
     s_system_id = system_id;
 
-    if (GetSystem(s_system_id))
+    if (Objects().get<System>(s_system_id))
         PlaySidePanelOpenSound();
 
     // refresh sidepanels

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -1143,7 +1143,7 @@ namespace {
     bool IsAvailable(std::shared_ptr<const Ship> ship, int system_id, int empire_id) {
         if (!ship)
             return false;
-        auto fleet = GetFleet(ship->FleetID());
+        auto fleet = Objects().get<Fleet>(ship->FleetID());
         if (!fleet)
             return false;
         if (ship->SystemID() == system_id &&
@@ -1158,7 +1158,7 @@ namespace {
     bool AvailableToColonize(std::shared_ptr<const Ship> ship, int system_id, int empire_id) {
         if (!ship)
             return false;
-        auto fleet = GetFleet(ship->FleetID());
+        auto fleet = Objects().get<Fleet>(ship->FleetID());
         if (!fleet)
             return false;
         if (IsAvailable(ship, system_id, empire_id) &&
@@ -1171,7 +1171,7 @@ namespace {
     bool AvailableToInvade(std::shared_ptr<const Ship> ship, int system_id, int empire_id) {
         if (!ship)
             return false;
-        auto fleet = GetFleet(ship->FleetID());
+        auto fleet = Objects().get<Fleet>(ship->FleetID());
         if (!fleet)
             return false;
         if (IsAvailable(ship, system_id, empire_id) &&
@@ -1184,7 +1184,7 @@ namespace {
     bool AvailableToBombard(std::shared_ptr<const Ship> ship, int system_id, int empire_id) {
         if (!ship)
             return false;
-        auto fleet = GetFleet(ship->FleetID());
+        auto fleet = Objects().get<Fleet>(ship->FleetID());
         if (!fleet)
             return false;
         if (IsAvailable(ship, system_id, empire_id) &&

--- a/UI/SpecialsPanel.cpp
+++ b/UI/SpecialsPanel.cpp
@@ -65,7 +65,7 @@ void SpecialsPanel::Update() {
 
 
     // get specials to display
-    auto obj = GetUniverseObject(m_object_id);
+    auto obj = Objects().get(m_object_id);
     if (!obj) {
         ErrorLogger() << "SpecialsPanel::Update couldn't get object with id " << m_object_id;
         return;

--- a/UI/SystemIcon.cpp
+++ b/UI/SystemIcon.cpp
@@ -99,7 +99,7 @@ OwnerColoredSystemName::OwnerColoredSystemName(int system_id, int font_size,
 
     int client_empire_id = HumanClientApp::GetApp()->EmpireID();
 
-    auto system = GetSystem(system_id);
+    auto system = Objects().get<System>(system_id);
     if (!system)
         return;
 
@@ -261,7 +261,7 @@ void SystemIcon::CompleteConstruction() {
     GG::Control::CompleteConstruction();
 
     ClientUI* ui = ClientUI::GetClientUI();
-    if (auto system = GetSystem(m_system_id)) {
+    if (auto system = Objects().get<System>(m_system_id)) {
         StarType star_type = system->GetStarType();
         m_disc_texture = ui->GetModuloTexture(ClientUI::ArtDir() / "stars",
                                               ClientUI::StarTypeFilePrefixes()[star_type],
@@ -647,7 +647,7 @@ void SystemIcon::Refresh() {
     std::string name;
     m_system_connection.disconnect();
 
-    auto system = GetSystem(m_system_id);
+    auto system = Objects().get<System>(m_system_id);
     if (system) {
         name = system->Name();
         m_system_connection = system->StateChangedSignal.connect(

--- a/UI/SystemResourceSummaryBrowseWnd.cpp
+++ b/UI/SystemResourceSummaryBrowseWnd.cpp
@@ -179,7 +179,7 @@ void SystemResourceSummaryBrowseWnd::UpdateProduction(GG::Y& top) {
     }
     m_production_labels_and_amounts.clear();
 
-    auto system = GetSystem(m_system_id);
+    auto system = Objects().get<System>(m_system_id);
     if (!system || m_resource_type == INVALID_RESOURCE_TYPE)
         return;
 
@@ -270,7 +270,7 @@ void SystemResourceSummaryBrowseWnd::UpdateAllocation(GG::Y& top) {
     }
     m_allocation_labels_and_amounts.clear();
 
-    auto system = GetSystem(m_system_id);
+    auto system = Objects().get<System>(m_system_id);
     if (!system || m_resource_type == INVALID_RESOURCE_TYPE)
         return;
 

--- a/combat/CombatEvents.cpp
+++ b/combat/CombatEvents.cpp
@@ -89,7 +89,7 @@ namespace {
     /// with the content being the public name from the point of view of empire_id.
     /// Returns UserString("ENC_COMBAT_UNKNOWN_OBJECT") if object_id is not found.
     std::string PublicNameLink(int empire_id, int object_id) {
-        auto object = GetUniverseObject(object_id);
+        auto object = Objects().get(object_id);
         if (object) {
             const std::string& name = object->PublicName(empire_id);
             const std::string& tag = LinkTag(object->ObjectType());
@@ -317,7 +317,7 @@ std::string InitialStealthEvent::DebugString() const {
         ss << " Viewing Empire: " << EmpireLink(empire_object_vis.first) << "\n";
 
         for (const auto& viewed_object : empire_object_vis.second) {
-            const auto obj = GetUniverseObject(viewed_object.first);
+            const auto obj = Objects().get(viewed_object.first);
             int owner_id = obj ? obj->Owner() : ALL_EMPIRES;
             ss << FighterOrPublicNameLink(ALL_EMPIRES, viewed_object.first, owner_id);
         }
@@ -344,7 +344,7 @@ std::string InitialStealthEvent::CombatLogDescription(int viewing_empire_id) con
         // Check Visibility of objects, report those that are not visible.
         std::vector<std::string> cloaked_attackers;
         for (auto& object_vis : visible_objects) {
-            const auto obj = GetUniverseObject(object_vis.first);
+            const auto obj = Objects().get(object_vis.first);
             const auto name = obj ? obj->Name() : UserString("UNKNOWN");
             DebugLogger() << " ... object: " << name << " (" << object_vis.first << ") has vis: " << object_vis.second;
             if (object_vis.second > VIS_NO_VISIBILITY)
@@ -686,7 +686,7 @@ std::string IncapacitationEvent::DebugString() const {
 
 
 std::string IncapacitationEvent::CombatLogDescription(int viewing_empire_id) const {
-    auto object = GetUniverseObject(object_id);
+    auto object = Objects().get(object_id);
     std::string template_str, object_str;
     int owner_id = object_owner_id;
 

--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -42,7 +42,7 @@ CombatInfo::CombatInfo(int system_id_, int turn_) :
     turn(turn_),
     system_id(system_id_)
 {
-    auto system = ::GetSystem(system_id);
+    auto system = Objects().get<System>(system_id);
     if (!system) {
         ErrorLogger() << "CombatInfo constructed with invalid system id: " << system_id;
         return;

--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -231,7 +231,7 @@ void CombatInfo::InitializeObjectVisibility() {
                 }
                 if (vis < VIS_PARTIAL_VISIBILITY && GetGameRules().Get<bool>("RULE_AGGRESSIVE_SHIPS_COMBAT_VISIBLE")) {
                     if (auto ship = std::dynamic_pointer_cast<Ship>(obj)) {
-                        if (auto fleet = ::GetFleet(ship->FleetID())) {
+                        if (auto fleet = Objects().get<Fleet>(ship->FleetID())) {
                             if (fleet->Aggressive()) {
                                 vis = VIS_PARTIAL_VISIBILITY;
                                 DebugLogger() << "Ship " << obj->Name() << " visible from aggressive fleet";

--- a/python/EmpireWrapper.cpp
+++ b/python/EmpireWrapper.cpp
@@ -170,9 +170,10 @@ namespace {
         std::map<std::set<int>, float> planets_with_available_pp;
         for (const auto& objects_pp : prod_queue.AvailablePP(industry_pool)) {
             std::set<int> planets;
-            for (int object_id : objects_pp.first) {
-                if (/* auto planet = */ GetPlanet(object_id))
-                    planets.insert(object_id);
+            for (const auto& planet : Objects().find<Planet>(objects_pp.first)) {
+                if (!planet)
+                    continue;
+                planets.insert(planet->ID());
             }
             if (!planets.empty())
                 planets_with_available_pp[planets] = objects_pp.second;
@@ -186,9 +187,10 @@ namespace {
         std::map<std::set<int>, float> planets_with_allocated_pp;
         for (const auto& objects_pp : prod_queue.AllocatedPP()) {
             std::set<int> planets;
-            for (int object_id : objects_pp.first) {
-                if (GetPlanet(object_id))
-                    planets.insert(object_id);
+            for (const auto& planet : Objects().find<Planet>(objects_pp.first)) {
+                if (!planet)
+                    continue;
+                planets.insert(planet->ID());
             }
             if (!planets.empty())
                 planets_with_allocated_pp[planets] = objects_pp.second;
@@ -203,9 +205,10 @@ namespace {
         std::set<std::set<int>> planets_with_wasted_pp;
         for (const auto& objects : prod_queue.ObjectsWithWastedPP(industry_pool)) {
                  std::set<int> planets;
-                 for (int object_id : objects) {
-                     if (GetPlanet(object_id))
-                         planets.insert(object_id);
+                 for (const auto& planet : Objects().find<Planet>(objects)) {
+                    if (!planet)
+                        continue;
+                    planets.insert(planet->ID());
                  }
                  if (!planets.empty())
                      planets_with_wasted_pp.insert(planets);

--- a/python/UniverseWrapper.cpp
+++ b/python/UniverseWrapper.cpp
@@ -66,7 +66,7 @@ namespace {
     const Planet*           GetPlanetP(const Universe& universe, int id)
     { return ::Objects().get<Planet>(id).operator->(); }
     const System*           GetSystemP(const Universe& universe, int id)
-    { return ::GetSystem(id).operator->(); }
+    { return ::Objects().get<System>(id).operator->(); }
     const Field*            GetFieldP(const Universe& universe, int id)
     { return ::GetField(id).operator->();  }
     const Building*         GetBuildingP(const Universe& universe, int id)

--- a/python/UniverseWrapper.cpp
+++ b/python/UniverseWrapper.cpp
@@ -68,7 +68,7 @@ namespace {
     const System*           GetSystemP(const Universe& universe, int id)
     { return ::Objects().get<System>(id).operator->(); }
     const Field*            GetFieldP(const Universe& universe, int id)
-    { return ::GetField(id).operator->();  }
+    { return ::Objects().get<Field>(id).operator->();  }
     const Building*         GetBuildingP(const Universe& universe, int id)
     { return ::Objects().get<Building>(id).operator->(); }
 

--- a/python/UniverseWrapper.cpp
+++ b/python/UniverseWrapper.cpp
@@ -62,7 +62,7 @@ namespace {
     const Ship*             GetShipP(const Universe& universe, int id)
     { return ::Objects().get<Ship>(id).operator->(); }
     const Fleet*            GetFleetP(const Universe& universe, int id)
-    { return ::GetFleet(id).operator->(); }
+    { return ::Objects().get<Fleet>(id).operator->(); }
     const Planet*           GetPlanetP(const Universe& universe, int id)
     { return ::Objects().get<Planet>(id).operator->(); }
     const System*           GetSystemP(const Universe& universe, int id)

--- a/python/UniverseWrapper.cpp
+++ b/python/UniverseWrapper.cpp
@@ -70,7 +70,7 @@ namespace {
     const Field*            GetFieldP(const Universe& universe, int id)
     { return ::GetField(id).operator->();  }
     const Building*         GetBuildingP(const Universe& universe, int id)
-    { return ::GetBuilding(id).operator->(); }
+    { return ::Objects().get<Building>(id).operator->(); }
 
     template<typename T>
     std::vector<int> ObjectIDs(const Universe& universe)

--- a/python/UniverseWrapper.cpp
+++ b/python/UniverseWrapper.cpp
@@ -58,7 +58,7 @@ namespace {
     // need to deal with std::shared_ptr class.
     // Please don't use this trick elsewhere to grab a raw UniverseObject*!
     const UniverseObject*   GetUniverseObjectP(const Universe& universe, int id)
-    { return ::GetUniverseObject(id).operator->(); }
+    { return ::Objects().get<UniverseObject>(id).operator->(); }
     const Ship*             GetShipP(const Universe& universe, int id)
     { return ::Objects().get<Ship>(id).operator->(); }
     const Fleet*            GetFleetP(const Universe& universe, int id)

--- a/python/UniverseWrapper.cpp
+++ b/python/UniverseWrapper.cpp
@@ -60,7 +60,7 @@ namespace {
     const UniverseObject*   GetUniverseObjectP(const Universe& universe, int id)
     { return ::GetUniverseObject(id).operator->(); }
     const Ship*             GetShipP(const Universe& universe, int id)
-    { return ::GetShip(id).operator->(); }
+    { return ::Objects().get<Ship>(id).operator->(); }
     const Fleet*            GetFleetP(const Universe& universe, int id)
     { return ::GetFleet(id).operator->(); }
     const Planet*           GetPlanetP(const Universe& universe, int id)

--- a/python/UniverseWrapper.cpp
+++ b/python/UniverseWrapper.cpp
@@ -64,7 +64,7 @@ namespace {
     const Fleet*            GetFleetP(const Universe& universe, int id)
     { return ::GetFleet(id).operator->(); }
     const Planet*           GetPlanetP(const Universe& universe, int id)
-    { return ::GetPlanet(id).operator->(); }
+    { return ::Objects().get<Planet>(id).operator->(); }
     const System*           GetSystemP(const Universe& universe, int id)
     { return ::GetSystem(id).operator->(); }
     const Field*            GetFieldP(const Universe& universe, int id)

--- a/python/server/ServerWrapper.cpp
+++ b/python/server/ServerWrapper.cpp
@@ -739,7 +739,7 @@ namespace {
             return INVALID_OBJECT_ID;
         }
 
-        auto system = GetSystem(planet->SystemID());
+        auto system = Objects().get<System>(planet->SystemID());
         if (!system) {
             ErrorLogger() << "CreateBuilding: couldn't get system for planet";
             return INVALID_OBJECT_ID;
@@ -816,7 +816,7 @@ namespace {
             return INVALID_OBJECT_ID;
         }
 
-        auto system = GetSystem(fleet->SystemID());
+        auto system = Objects().get<System>(fleet->SystemID());
         if (!system) {
             ErrorLogger() << "CreateShip: couldn't get system for fleet";
             return INVALID_OBJECT_ID;
@@ -923,7 +923,7 @@ namespace {
 
     int CreateFieldInSystem(const std::string& field_type_name, double size, int system_id) {
         // check if system exists and get system
-        auto system = GetSystem(system_id);
+        auto system = Objects().get<System>(system_id);
         if (!system) {
             ErrorLogger() << "CreateFieldInSystem: couldn't get system with ID" << system_id;
             return INVALID_OBJECT_ID;
@@ -973,7 +973,7 @@ namespace {
 
     // Wrappers for System class member functions
     StarType SystemGetStarType(int system_id) {
-        auto system = GetSystem(system_id);
+        auto system = Objects().get<System>(system_id);
         if (!system) {
             ErrorLogger() << "SystemGetStarType: couldn't get system with ID " << system_id;
             return INVALID_STAR_TYPE;
@@ -988,7 +988,7 @@ namespace {
             return;
         }
 
-        auto system = GetSystem(system_id);
+        auto system = Objects().get<System>(system_id);
         if (!system) {
             ErrorLogger() << "SystemSetStarType : Couldn't get system with ID " << system_id;
             return;
@@ -998,7 +998,7 @@ namespace {
     }
 
     int SystemGetNumOrbits(int system_id) {
-        auto system = GetSystem(system_id);
+        auto system = Objects().get<System>(system_id);
         if (!system) {
             ErrorLogger() << "SystemGetNumOrbits : Couldn't get system with ID " << system_id;
             return 0;
@@ -1008,7 +1008,7 @@ namespace {
 
     list SystemFreeOrbits(int system_id) {
         list py_orbits;
-        auto system = GetSystem(system_id);
+        auto system = Objects().get<System>(system_id);
         if (!system) {
             ErrorLogger() << "SystemFreeOrbits : Couldn't get system with ID " << system_id;
             return py_orbits;
@@ -1019,7 +1019,7 @@ namespace {
     }
 
     bool SystemOrbitOccupied(int system_id, int orbit) {
-        auto system = GetSystem(system_id);
+        auto system = Objects().get<System>(system_id);
         if (!system) {
             ErrorLogger() << "SystemOrbitOccupied : Couldn't get system with ID " << system_id;
             return 0;
@@ -1028,7 +1028,7 @@ namespace {
     }
 
     int SystemOrbitOfPlanet(int system_id, int planet_id) {
-        auto system = GetSystem(system_id);
+        auto system = Objects().get<System>(system_id);
         if (!system) {
             ErrorLogger() << "SystemOrbitOfPlanet : Couldn't get system with ID " << system_id;
             return 0;
@@ -1038,7 +1038,7 @@ namespace {
 
     list SystemGetPlanets(int system_id) {
         list py_planets;
-        auto system = GetSystem(system_id);
+        auto system = Objects().get<System>(system_id);
         if (!system) {
             ErrorLogger() << "SystemGetPlanets : Couldn't get system with ID " << system_id;
             return py_planets;
@@ -1050,7 +1050,7 @@ namespace {
 
     list SystemGetFleets(int system_id) {
         list py_fleets;
-        auto system = GetSystem(system_id);
+        auto system = Objects().get<System>(system_id);
         if (!system) {
             ErrorLogger() << "SystemGetFleets : Couldn't get system with ID " << system_id;
             return py_fleets;
@@ -1063,7 +1063,7 @@ namespace {
     list SystemGetStarlanes(int system_id) {
         list py_starlanes;
         // get source system
-        auto system = GetSystem(system_id);
+        auto system = Objects().get<System>(system_id);
         if (!system) {
             ErrorLogger() << "SystemGetStarlanes : Couldn't get system with ID " << system_id;
             return py_starlanes;
@@ -1083,12 +1083,12 @@ namespace {
 
     void SystemAddStarlane(int from_sys_id, int to_sys_id) {
         // get source and destination system, check that both exist
-        auto from_sys = GetSystem(from_sys_id);
+        auto from_sys = Objects().get<System>(from_sys_id);
         if (!from_sys) {
             ErrorLogger() << "SystemAddStarlane : Couldn't find system with ID " << from_sys_id;
             return;
         }
-        auto to_sys = GetSystem(to_sys_id);
+        auto to_sys = Objects().get<System>(to_sys_id);
         if (!to_sys) {
             ErrorLogger() << "SystemAddStarlane : Couldn't find system with ID " << to_sys_id;
             return;
@@ -1100,12 +1100,12 @@ namespace {
 
     void SystemRemoveStarlane(int from_sys_id, int to_sys_id) {
         // get source and destination system, check that both exist
-        auto from_sys = GetSystem(from_sys_id);
+        auto from_sys = Objects().get<System>(from_sys_id);
         if (!from_sys) {
             ErrorLogger() << "SystemRemoveStarlane : Couldn't find system with ID " << from_sys_id;
             return;
         }
-        auto to_sys = GetSystem(to_sys_id);
+        auto to_sys = Objects().get<System>(to_sys_id);
         if (!to_sys) {
             ErrorLogger() << "SystemRemoveStarlane : Couldn't find system with ID " << to_sys_id;
             return;

--- a/python/server/ServerWrapper.cpp
+++ b/python/server/ServerWrapper.cpp
@@ -216,7 +216,7 @@ namespace {
         Condition::ObjectSet objs;
         boost::python::stl_input_iterator<int> end;
         for (boost::python::stl_input_iterator<int> id(obj_ids); id != end; ++id) {
-            if (auto obj = GetUniverseObject(*id))
+            if (auto obj = Objects().get(*id))
                 objs.push_back(obj);
             else
                 ErrorLogger() << "FilterIDsWithCondition:: Passed an invalid universe object id " << *id;
@@ -540,7 +540,7 @@ namespace {
     //
     // Wrappers for common UniverseObject class member funtions
     object GetName(int object_id) {
-        auto obj = GetUniverseObject(object_id);
+        auto obj = Objects().get(object_id);
         if (!obj) {
             ErrorLogger() << "GetName: Couldn't get object with ID " << object_id;
             return object("");
@@ -549,7 +549,7 @@ namespace {
     }
 
     void SetName(int object_id, const std::string& name) {
-        auto obj = GetUniverseObject(object_id);
+        auto obj = Objects().get(object_id);
         if (!obj) {
             ErrorLogger() << "RenameUniverseObject: Couldn't get object with ID " << object_id;
             return;
@@ -558,7 +558,7 @@ namespace {
     }
 
     double GetX(int object_id) {
-        auto obj = GetUniverseObject(object_id);
+        auto obj = Objects().get(object_id);
         if (!obj) {
             ErrorLogger() << "GetX: Couldn't get object with ID " << object_id;
             return UniverseObject::INVALID_POSITION;
@@ -567,7 +567,7 @@ namespace {
     }
 
     double GetY(int object_id) {
-        auto obj = GetUniverseObject(object_id);
+        auto obj = Objects().get(object_id);
         if (!obj) {
             ErrorLogger() << "GetY: Couldn't get object with ID " << object_id;
             return UniverseObject::INVALID_POSITION;
@@ -576,7 +576,7 @@ namespace {
     }
 
     tuple GetPos(int object_id) {
-        auto obj = GetUniverseObject(object_id);
+        auto obj = Objects().get(object_id);
         if (!obj) {
             ErrorLogger() << "GetPos: Couldn't get object with ID " << object_id;
             return make_tuple(UniverseObject::INVALID_POSITION,
@@ -586,7 +586,7 @@ namespace {
     }
 
     int GetOwner(int object_id) {
-        auto obj = GetUniverseObject(object_id);
+        auto obj = Objects().get(object_id);
         if (!obj) {
             ErrorLogger() << "GetOwner: Couldn't get object with ID " << object_id;
             return ALL_EMPIRES;
@@ -596,7 +596,7 @@ namespace {
 
     void AddSpecial(int object_id, const std::string special_name) {
         // get the universe object and check if it exists
-        auto obj = GetUniverseObject(object_id);
+        auto obj = Objects().get(object_id);
         if (!obj) {
             ErrorLogger() << "AddSpecial: Couldn't get object with ID " << object_id;
             return;
@@ -615,7 +615,7 @@ namespace {
 
     void RemoveSpecial(int object_id, const std::string special_name) {
         // get the universe object and check if it exists
-        auto obj = GetUniverseObject(object_id);
+        auto obj = Objects().get(object_id);
         if (!obj) {
             ErrorLogger() << "RemoveSpecial: Couldn't get object with ID " << object_id;
             return;
@@ -942,7 +942,7 @@ namespace {
         boost::python::stl_input_iterator<int> end;
         for (boost::python::stl_input_iterator<int> id(obj_ids);
              id != end; ++id) {
-            if (auto obj = GetUniverseObject(*id)) {
+            if (auto obj = Objects().get(*id)) {
                 py_systems.append(obj->SystemID());
             } else {
                 ErrorLogger() << "Passed an invalid universe object id " << *id;

--- a/python/server/ServerWrapper.cpp
+++ b/python/server/ServerWrapper.cpp
@@ -1117,7 +1117,7 @@ namespace {
 
     // Wrapper for Planet class member functions
     PlanetType PlanetGetType(int planet_id) {
-        auto planet = GetPlanet(planet_id);
+        auto planet = Objects().get<Planet>(planet_id);
         if (!planet) {
             ErrorLogger() << "PlanetGetType: Couldn't get planet with ID " << planet_id;
             return INVALID_PLANET_TYPE;
@@ -1126,7 +1126,7 @@ namespace {
     }
 
     void PlanetSetType(int planet_id, PlanetType planet_type) {
-        auto planet = GetPlanet(planet_id);
+        auto planet = Objects().get<Planet>(planet_id);
         if (!planet) {
             ErrorLogger() << "PlanetSetType: Couldn't get planet with ID " << planet_id;
             return;
@@ -1144,7 +1144,7 @@ namespace {
     }
 
     PlanetSize PlanetGetSize(int planet_id) {
-        auto planet = GetPlanet(planet_id);
+        auto planet = Objects().get<Planet>(planet_id);
         if (!planet) {
             ErrorLogger() << "PlanetGetSize: Couldn't get planet with ID " << planet_id;
             return INVALID_PLANET_SIZE;
@@ -1153,7 +1153,7 @@ namespace {
     }
 
     void PlanetSetSize(int planet_id, PlanetSize planet_size) {
-        auto planet = GetPlanet(planet_id);
+        auto planet = Objects().get<Planet>(planet_id);
         if (!planet) {
             ErrorLogger() << "PlanetSetSize: Couldn't get planet with ID " << planet_id;
             return;
@@ -1169,7 +1169,7 @@ namespace {
     }
 
     object PlanetGetSpecies(int planet_id) {
-        auto planet = GetPlanet(planet_id);
+        auto planet = Objects().get<Planet>(planet_id);
         if (!planet) {
             ErrorLogger() << "PlanetGetSpecies: Couldn't get planet with ID " << planet_id;
             return object("");
@@ -1178,7 +1178,7 @@ namespace {
     }
 
     void PlanetSetSpecies(int planet_id, const std::string& species_name) {
-        auto planet = GetPlanet(planet_id);
+        auto planet = Objects().get<Planet>(planet_id);
         if (!planet) {
             ErrorLogger() << "PlanetSetSpecies: Couldn't get planet with ID " << planet_id;
             return;
@@ -1187,7 +1187,7 @@ namespace {
     }
 
     object PlanetGetFocus(int planet_id) {
-        auto planet = GetPlanet(planet_id);
+        auto planet = Objects().get<Planet>(planet_id);
         if (!planet) {
             ErrorLogger() << "PlanetGetFocus: Couldn't get planet with ID " << planet_id;
             return object("");
@@ -1196,7 +1196,7 @@ namespace {
     }
 
     void PlanetSetFocus(int planet_id, const std::string& focus) {
-        auto planet = GetPlanet(planet_id);
+        auto planet = Objects().get<Planet>(planet_id);
         if (!planet) {
             ErrorLogger() << "PlanetSetSpecies: Couldn't get planet with ID " << planet_id;
             return;
@@ -1206,7 +1206,7 @@ namespace {
 
     list PlanetAvailableFoci(int planet_id) {
         list py_foci;
-        auto planet = GetPlanet(planet_id);
+        auto planet = Objects().get<Planet>(planet_id);
         if (!planet) {
             ErrorLogger() << "PlanetAvailableFoci: Couldn't get planet with ID " << planet_id;
             return py_foci;
@@ -1218,7 +1218,7 @@ namespace {
     }
 
     bool PlanetMakeOutpost(int planet_id, int empire_id) {
-        auto planet = GetPlanet(planet_id);
+        auto planet = Objects().get<Planet>(planet_id);
         if (!planet) {
             ErrorLogger() << "PlanetMakeOutpost: couldn't get planet with ID:" << planet_id;
             return false;
@@ -1233,7 +1233,7 @@ namespace {
     }
 
     bool PlanetMakeColony(int planet_id, int empire_id, const std::string& species, double population) {
-        auto planet = GetPlanet(planet_id);
+        auto planet = Objects().get<Planet>(planet_id);
         if (!planet) {
             ErrorLogger() << "PlanetMakeColony: couldn't get planet with ID:" << planet_id;
             return false;
@@ -1256,7 +1256,7 @@ namespace {
     }
 
     object PlanetCardinalSuffix(int planet_id) {
-        auto planet = GetPlanet(planet_id);
+        auto planet = Objects().get<Planet>(planet_id);
         if (!planet) {
             ErrorLogger() << "PlanetCardinalSuffix: couldn't get planet with ID:" << planet_id;
             return object(UserString("ERROR"));

--- a/python/server/ServerWrapper.cpp
+++ b/python/server/ServerWrapper.cpp
@@ -810,7 +810,7 @@ namespace {
         }
 
         // get fleet and check if it exists
-        auto fleet = GetFleet(fleet_id);
+        auto fleet = Objects().get<Fleet>(fleet_id);
         if (!fleet) {
             ErrorLogger() << "CreateShip: couldn't get fleet with ID " << fleet_id;
             return INVALID_OBJECT_ID;

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -2056,7 +2056,7 @@ namespace {
 
     void GetEmpireFleetsAtSystem(std::map<int, std::set<int>>& empire_fleets, int system_id) {
         empire_fleets.clear();
-        auto system = GetSystem(system_id);
+        auto system = Objects().get<System>(system_id);
         if (!system)
             return;
         for (auto& fleet : Objects().find<const Fleet>(system->FleetIDs())) {
@@ -2066,7 +2066,7 @@ namespace {
 
     void GetEmpirePlanetsAtSystem(std::map<int, std::set<int>>& empire_planets, int system_id) {
         empire_planets.clear();
-        auto system = GetSystem(system_id);
+        auto system = Objects().get<System>(system_id);
         if (!system)
             return;
         for (auto& planet : Objects().find<const Planet>(system->PlanetIDs())) {
@@ -2081,7 +2081,7 @@ namespace {
                                           int empire_id, int system_id)
     {
         visible_fleets.clear();
-        auto system = GetSystem(system_id);
+        auto system = Objects().get<System>(system_id);
         if (!system)
             return; // no such system
         const auto& fleet_ids = system->FleetIDs();
@@ -2146,7 +2146,7 @@ namespace {
                                            int empire_id, int system_id)
     {
         visible_planets.clear();
-        auto system = GetSystem(system_id);
+        auto system = Objects().get<System>(system_id);
         if (!system)
             return; // no such system
         const auto& planet_ids = system->PlanetIDs();
@@ -2216,7 +2216,7 @@ namespace {
         if (empire_fleets_here.empty())
             return false;
 
-        auto this_system = GetSystem(system_id);
+        auto this_system = Objects().get<System>(system_id);
         DebugLogger(combat) << "CombatConditionsInSystem() for system (" << system_id << ") " << this_system->Name();
         // which empires have aggressive ships here? (including monsters as id ALL_EMPIRES)
         std::set<int> empires_with_aggressive_fleets_here;
@@ -2438,7 +2438,7 @@ namespace {
 
             // update system ownership after combat.  may be necessary if the
             // combat caused planets to change ownership.
-            if (auto system = GetSystem(combat_info.system_id)) {
+            if (auto system = Objects().get<System>(combat_info.system_id)) {
                 // ensure all participants get updates on system.  this ensures
                 // that an empire who lose all objects in the system still
                 // knows about a change in system ownership
@@ -2662,7 +2662,7 @@ namespace {
             return false;
         }
 
-        auto system = GetSystem(ship->SystemID());
+        auto system = Objects().get<System>(ship->SystemID());
 
         // destroy colonizing ship, and its fleet if now empty
         auto fleet = GetFleet(ship->FleetID());
@@ -2739,7 +2739,7 @@ namespace {
                 continue;
             }
             int system_id = planet->SystemID();
-            auto system = GetSystem(system_id);
+            auto system = Objects().get<System>(system_id);
             if (!system) {
                 ErrorLogger() << "HandleColonization couldn't get system with id " << system_id;
                 continue;
@@ -2847,7 +2847,7 @@ namespace {
             // how many troops are invading?
             planet_empire_troops[invade_planet_id][ship->Owner()] += ship->TroopCapacity();
 
-            auto system = GetSystem(ship->SystemID());
+            auto system = Objects().get<System>(ship->SystemID());
 
             // destroy invading ships and their fleets if now empty
             auto fleet = GetFleet(ship->FleetID());
@@ -3039,7 +3039,7 @@ namespace {
                 // gifted object must be in a system
                 if (gifted_obj->SystemID() == INVALID_OBJECT_ID)
                     continue;
-                auto system = GetSystem(gifted_obj->SystemID());
+                auto system = Objects().get<System>(gifted_obj->SystemID());
                 if (!system)
                     continue;
 
@@ -3094,7 +3094,7 @@ namespace {
 
             DebugLogger() << "... ship: " << ship->ID() << " ordered scrapped";
 
-            auto system = GetSystem(ship->SystemID());
+            auto system = Objects().get<System>(ship->SystemID());
             if (system)
                 system->Remove(ship->ID());
 
@@ -3135,7 +3135,7 @@ namespace {
             if (auto planet = Objects().get<Planet>(building->PlanetID()))
                 planet->RemoveBuilding(building->ID());
 
-            if (auto system = GetSystem(building->SystemID()))
+            if (auto system = Objects().get<System>(building->SystemID()))
                 system->Remove(building->ID());
 
             // record scrapping in empire stats
@@ -3179,7 +3179,7 @@ namespace {
             if (!fleet->Empty())
                 continue;
 
-            auto sys = GetSystem(fleet->SystemID());
+            auto sys = Objects().get<System>(fleet->SystemID());
             if (sys)
                 sys->Remove(fleet->ID());
 

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -2167,7 +2167,7 @@ namespace {
                 if (planet_vis <= VIS_BASIC_VISIBILITY)
                     continue;
                 // skip planets that have no owner and that are unpopulated; don't matter for combat conditions test
-                auto planet = GetPlanet(planet_id);
+                auto planet = Objects().get<Planet>(planet_id);
                 if (planet->Unowned() && planet->InitialMeterValue(METER_POPULATION) <= 0.0f)
                     continue;
                 visible_planets.insert(planet->ID());
@@ -2292,8 +2292,7 @@ namespace {
             GetPlanetsVisibleToEmpireAtSystem(aggressive_empire_visible_planets, aggressive_empire_id, system_id);
 
             // is any planet owned by an empire at war with aggressive empire?
-            for (int planet_id : aggressive_empire_visible_planets) {
-                auto planet = GetPlanet(planet_id);
+            for (const auto& planet : Objects().find<Planet>(aggressive_empire_visible_planets)) {
                 if (!planet)
                     continue;
                 int visible_planet_empire_id = planet->Owner();
@@ -2601,7 +2600,7 @@ namespace {
     void UpdateEmpireInvasionInfo(const std::map<int, std::map<int, double>>& planet_empire_invasion_troops) {
         for (const auto& planet_empire_troops : planet_empire_invasion_troops) {
             int planet_id = planet_empire_troops.first;
-            auto planet = GetPlanet(planet_id);
+            auto planet = Objects().get<Planet>(planet_id);
             if (!planet)
                 continue;
             const auto& planet_species = planet->SpeciesName();
@@ -2629,7 +2628,7 @@ namespace {
             ErrorLogger() << "ColonizePlanet couldn't get ship with id " << ship_id;
             return false;
         }
-        auto planet = GetPlanet(planet_id);
+        auto planet = Objects().get<Planet>(planet_id);
         if (!planet) {
             ErrorLogger() << "ColonizePlanet couldn't get planet with id " << planet_id;
             return false;
@@ -2705,7 +2704,7 @@ namespace {
 
             ship->SetColonizePlanet(INVALID_OBJECT_ID); // reset so failed colonization doesn't leave ship with hanging colonization order set
 
-            auto planet = GetPlanet(colonize_planet_id);
+            auto planet = Objects().get<Planet>(colonize_planet_id);
             if (!planet)
                 continue;
 
@@ -2736,7 +2735,7 @@ namespace {
             int colonizing_ship_id = *empire_ships_colonizing.begin();
 
             int planet_id = planet_colonization.first;
-            auto planet = GetPlanet(planet_id);
+            auto planet = Objects().get<Planet>(planet_id);
             if (!planet) {
                 ErrorLogger() << "HandleColonization couldn't get planet with id " << planet_id;
                 continue;
@@ -2837,7 +2836,7 @@ namespace {
             int invade_planet_id = ship->OrderedInvadePlanet();
             if (invade_planet_id == INVALID_OBJECT_ID)
                 continue;
-            auto planet = GetPlanet(invade_planet_id);
+            auto planet = Objects().get<Planet>(invade_planet_id);
             if (!planet)
                 continue;
             planet->ResetIsAboutToBeInvaded();
@@ -2895,7 +2894,7 @@ namespace {
         // process each planet's ground combats
         for (auto& planet_combat : planet_empire_troops) {
             int planet_id = planet_combat.first;
-            auto planet = GetPlanet(planet_id);
+            auto planet = Objects().get<Planet>(planet_id);
             std::set<int> all_involved_empires;
             int planet_initial_owner_id = planet->Owner();
 
@@ -3135,7 +3134,7 @@ namespace {
             if (!building->OrderedScrapped())
                 continue;
 
-            if (auto planet = GetPlanet(building->PlanetID()))
+            if (auto planet = Objects().get<Planet>(building->PlanetID()))
                 planet->RemoveBuilding(building->ID());
 
             if (auto system = GetSystem(building->SystemID()))

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -2468,7 +2468,7 @@ namespace {
 
                 for (int dest_obj_id : empire_kdos.second) {
                     //DebugLogger() << "Creating destroyed object sitrep for empire " << empire_id << " and object " << dest_obj_id;
-                    //if (auto obj = GetEmpireKnownObject(dest_obj_id, empire_id)) {
+                    //if (auto obj = EmpireKnownObjects(empire_id).get(dest_obj_id)) {
                     //    DebugLogger() << "Object known to empire: " << obj->Dump();
                     //} else {
                     //    DebugLogger() << "Object not known to empire";

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -2093,14 +2093,13 @@ namespace {
         TraceLogger(combat) << "\t** GetFleetsVisibleToEmpire " << empire_id << " at system " << system->Name();
         // for visible fleets by an empire, check visibility of fleets by that empire
         if (empire_id != ALL_EMPIRES) {
-            for (int fleet_id : fleet_ids) {
-                auto fleet = GetFleet(fleet_id);
+            for (const auto& fleet : Objects().find<Fleet>(fleet_ids)) {
                 if (!fleet)
                     continue;
                 if (fleet->OwnedBy(empire_id))
                     continue;   // don't care about fleets owned by the same empire for determining combat conditions
                 Visibility fleet_vis = GetUniverse().GetObjectVisibilityByEmpire(fleet->ID(), empire_id);
-                TraceLogger(combat) << "\t\tfleet (" << fleet_id << ") has visibility rank " << fleet_vis;
+                TraceLogger(combat) << "\t\tfleet (" << fleet->ID() << ") has visibility rank " << fleet_vis;
                 if (fleet_vis >= VIS_BASIC_VISIBILITY)
                     visible_fleets.insert(fleet->ID());
             }
@@ -2121,8 +2120,7 @@ namespace {
         }
 
         // test each ship in each fleet for visibility by best monster detection here
-        for (int fleet_id : fleet_ids) {
-            auto fleet = GetFleet(fleet_id);
+        for (const auto& fleet : Objects().find<Fleet>(fleet_ids)) {
             if (!fleet)
                 continue;
             if (fleet->Unowned()) {
@@ -2222,8 +2220,7 @@ namespace {
         std::set<int> empires_with_aggressive_fleets_here;
         for (auto& empire_fleets : empire_fleets_here) {
             int empire_id = empire_fleets.first;
-            for (int fleet_id : empire_fleets.second) {
-                auto fleet = GetFleet(fleet_id);
+            for (const auto& fleet : Objects().find<Fleet>(empire_fleets.second)) {
                 if (!fleet)
                     continue;
                 // an unarmed Monster will not trigger combat
@@ -2317,8 +2314,7 @@ namespace {
             GetFleetsVisibleToEmpireAtSystem(aggressive_empire_visible_fleets, aggressive_empire_id, system_id);
 
             // is any fleet owned by an empire at war with aggressive empire?
-            for (int fleet_id : aggressive_empire_visible_fleets) {
-                auto fleet = GetFleet(fleet_id);
+            for (const auto& fleet : Objects().find<Fleet>(aggressive_empire_visible_fleets)) {
                 if (!fleet)
                     continue;
                 int visible_fleet_empire_id = fleet->Owner();
@@ -2665,7 +2661,7 @@ namespace {
         auto system = Objects().get<System>(ship->SystemID());
 
         // destroy colonizing ship, and its fleet if now empty
-        auto fleet = GetFleet(ship->FleetID());
+        auto fleet = Objects().get<Fleet>(ship->FleetID());
         if (fleet) {
             fleet->RemoveShips({ship->ID()});
             if (fleet->Empty()) {
@@ -2850,7 +2846,7 @@ namespace {
             auto system = Objects().get<System>(ship->SystemID());
 
             // destroy invading ships and their fleets if now empty
-            auto fleet = GetFleet(ship->FleetID());
+            auto fleet = Objects().get<Fleet>(ship->FleetID());
             if (fleet) {
                 fleet->RemoveShips({ship->ID()});
                 if (fleet->Empty()) {
@@ -3098,7 +3094,7 @@ namespace {
             if (system)
                 system->Remove(ship->ID());
 
-            auto fleet = GetFleet(ship->FleetID());
+            auto fleet = Objects().get<Fleet>(ship->FleetID());
             if (fleet) {
                 fleet->RemoveShips({ship->ID()});
                 if (fleet->Empty()) {

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -2532,7 +2532,7 @@ namespace {
             // TODO: fix similar issue for overlogging on attacker side
             std::set<int> already_logged__target_ships;
             for (const auto& attack_event : events_that_killed) {
-                auto attacker = GetUniverseObject(attack_event->attacker_id);
+                auto attacker = Objects().get(attack_event->attacker_id);
                 if (!attacker)
                     continue;
                 int attacker_empire_id = attacker->Owner();
@@ -3428,7 +3428,7 @@ void ServerApp::PostCombatProcessTurns() {
     // check for loss of empire capitals
     for (auto& entry : empires) {
         int capital_id = entry.second->CapitalID();
-        if (auto capital = GetUniverseObject(capital_id)) {
+        if (auto capital = Objects().get(capital_id)) {
             if (!capital->OwnedBy(entry.first))
                 entry.second->SetCapitalID(INVALID_OBJECT_ID);
         } else {
@@ -3530,7 +3530,7 @@ void ServerApp::PostCombatProcessTurns() {
     // check for loss of empire capitals
     for (auto& entry : empires) {
         int capital_id = entry.second->CapitalID();
-        if (auto capital = GetUniverseObject(capital_id)) {
+        if (auto capital = Objects().get(capital_id)) {
             if (!capital->OwnedBy(entry.first))
                 entry.second->SetCapitalID(INVALID_OBJECT_ID);
         } else {

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -2113,8 +2113,7 @@ namespace {
 
         // get best monster detection strength here.  Use monster detection meters for this...
         float monster_detection_strength_here = 0.0f;
-        for (int ship_id : system->ShipIDs()) {
-            auto ship = GetShip(ship_id);
+        for (const auto& ship : Objects().find<Ship>(system->ShipIDs())) {
             if (!ship || !ship->Unowned())  // only want unowned / monster ships
                 continue;
             if (ship->InitialMeterValue(METER_DETECTION) > monster_detection_strength_here)
@@ -2131,8 +2130,7 @@ namespace {
                 continue;
             }
 
-            for (int ship_id : fleet->ShipIDs()) {
-                auto ship = GetShip(ship_id);
+            for (const auto& ship : Objects().find<Ship>(fleet->ShipIDs())) {
                 if (!ship)
                     continue;
                 // if a ship is low enough stealth, its fleet can be seen by monsters
@@ -2405,7 +2403,7 @@ namespace {
 
                     // record if empire should be informed of potential fleet
                     // destruction (which is checked later)
-                    if (auto ship = GetShip(object_id)) {
+                    if (auto ship = Objects().get<Ship>(object_id)) {
                         if (ship->FleetID() != INVALID_OBJECT_ID)
                             empires_to_update_of_fleet_destruction[ship->FleetID()].insert(empire_id);
                     }
@@ -2540,7 +2538,7 @@ namespace {
                 int attacker_empire_id = attacker->Owner();
                 Empire* attacker_empire = GetEmpire(attacker_empire_id);
 
-                auto target_ship = GetShip(attack_event->target_id);
+                auto target_ship = Objects().get<Ship>(attack_event->target_id);
                 if (!target_ship)
                     continue;
                 int target_empire_id = target_ship->Owner();
@@ -2623,7 +2621,7 @@ namespace {
 
     /** Does colonization, with safety checks */
     bool ColonizePlanet(int ship_id, int planet_id) {
-        auto ship = GetShip(ship_id);
+        auto ship = Objects().get<Ship>(ship_id);
         if (!ship) {
             ErrorLogger() << "ColonizePlanet couldn't get ship with id " << ship_id;
             return false;
@@ -2771,7 +2769,7 @@ namespace {
                 continue;
 
             // before actual colonization, which deletes the colony ship, store ship info for later use with sitrep generation
-            auto ship = GetShip(colonizing_ship_id);
+            auto ship = Objects().get<Ship>(colonizing_ship_id);
             if (!ship)
                 ErrorLogger() << "HandleColonization couldn't get ship with id " << colonizing_ship_id;
             const auto& species_name = ship ? ship->SpeciesName() : "";

--- a/universe/Building.cpp
+++ b/universe/Building.cpp
@@ -269,7 +269,7 @@ float BuildingType::ProductionCost(int empire_id, int location_id) const {
 
         const auto arbitrary_large_number = 999999.9f;
 
-        auto location = GetUniverseObject(location_id);
+        auto location = Objects().get(location_id);
         if (!location && !m_production_cost->TargetInvariant())
             return arbitrary_large_number;
 
@@ -297,7 +297,7 @@ int BuildingType::ProductionTime(int empire_id, int location_id) const {
 
         const auto arbitrary_large_number = 9999;
 
-        auto location = GetUniverseObject(location_id);
+        auto location = Objects().get(location_id);
         if (!location && !m_production_time->TargetInvariant())
             return arbitrary_large_number;
 
@@ -315,7 +315,7 @@ bool BuildingType::ProductionLocation(int empire_id, int location_id) const {
     if (!m_location)
         return true;
 
-    auto location = GetUniverseObject(location_id);
+    auto location = Objects().get(location_id);
     if (!location)
         return false;
 
@@ -330,7 +330,7 @@ bool BuildingType::EnqueueLocation(int empire_id, int location_id) const {
     if (!m_enqueue_location)
         return true;
 
-    auto location = GetUniverseObject(location_id);
+    auto location = Objects().get(location_id);
     if (!location)
         return false;
 

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -3212,7 +3212,7 @@ std::string InSystem::Description(bool negated/* = false*/) const {
     int system_id = INVALID_OBJECT_ID;
     if (m_system_id && m_system_id->ConstantExpr())
         system_id = m_system_id->Eval();
-    if (auto system = GetSystem(system_id))
+    if (auto system = Objects().get<System>(system_id))
         system_str = system->Name();
     else if (m_system_id)
         system_str = m_system_id->Description();
@@ -3259,7 +3259,7 @@ void InSystem::GetDefaultInitialCandidateObjects(const ScriptingContext& parent_
 
     // simple case of a single specified system id; can add just objects in that system
     int system_id = m_system_id->Eval(parent_context);
-    auto system = GetSystem(system_id);
+    auto system = Objects().get<System>(system_id);
     if (!system)
         return;
 
@@ -3367,7 +3367,7 @@ std::string ObjectID::Description(bool negated/* = false*/) const {
     int object_id = INVALID_OBJECT_ID;
     if (m_object_id && m_object_id->ConstantExpr())
         object_id = m_object_id->Eval();
-    if (auto system = GetSystem(object_id))
+    if (auto system = Objects().get<System>(object_id))
         object_str = system->Name();
     else if (m_object_id)
         object_str = m_object_id->Description();
@@ -4807,7 +4807,7 @@ namespace {
             if (!candidate)
                 return false;
 
-            std::shared_ptr<const System> system = GetSystem(candidate->SystemID());
+            std::shared_ptr<const System> system = Objects().get<System>(candidate->SystemID());
             if (system || (system = std::dynamic_pointer_cast<const System>(candidate)))
                 return !m_types.empty() && std::count(m_types.begin(), m_types.end(), system->GetStarType());
 
@@ -4911,7 +4911,7 @@ bool StarType::Match(const ScriptingContext& local_context) const {
         return false;
     }
 
-    std::shared_ptr<const System> system = GetSystem(candidate->SystemID());
+    std::shared_ptr<const System> system = Objects().get<System>(candidate->SystemID());
     if (system || (system = std::dynamic_pointer_cast<const System>(candidate))) {
         for (auto& type : m_types) {
             if (type->Eval(local_context) == system->GetStarType())
@@ -7833,7 +7833,7 @@ namespace {
 
             // check all existing lanes of currently-being-checked system
             for (const auto& lane : sys_existing_lanes) {
-                auto lane_end_sys3 = GetSystem(lane.first);
+                auto lane_end_sys3 = Objects().get<System>(lane.first);
                 if (!lane_end_sys3)
                     continue;
                 // don't need to check against existing lanes that include one
@@ -7882,7 +7882,7 @@ namespace {
             // destination objects
             std::set<std::shared_ptr<const System>> dest_systems;
             for (auto& obj : destination_objects) {
-                if (auto sys = GetSystem(obj->SystemID()))
+                if (auto sys = Objects().get<System>(obj->SystemID()))
                     dest_systems.insert(sys);
             }
             std::copy(dest_systems.begin(), dest_systems.end(), std::inserter(m_destination_systems, m_destination_systems.end()));
@@ -7895,7 +7895,7 @@ namespace {
             // get system from candidate
             auto candidate_sys = std::dynamic_pointer_cast<const System>(candidate);
             if (!candidate_sys)
-                candidate_sys = GetSystem(candidate->SystemID());
+                candidate_sys = Objects().get<System>(candidate->SystemID());
             if (!candidate_sys)
                 return false;
 
@@ -7917,7 +7917,7 @@ namespace {
             // present lanes of the candidate system
             //TraceLogger() << "... Checking lanes of candidate system: " << candidate->UniverseObject::Name() << std::endl;
             for (const auto& lane : candidate_sys->StarlanesWormholes()) {
-                auto candidate_existing_lane_end_sys = GetSystem(lane.first);
+                auto candidate_existing_lane_end_sys = Objects().get<System>(lane.first);
                 if (!candidate_existing_lane_end_sys)
                     continue;
 
@@ -7938,7 +7938,7 @@ namespace {
                 // check this destination system's existing lanes against a lane
                 // to the candidate system
                 for (const auto& dest_lane : dest_sys->StarlanesWormholes()) {
-                    auto dest_lane_end_sys = GetSystem(dest_lane.first);
+                    auto dest_lane_end_sys = Objects().get<System>(dest_lane.first);
                     if (!dest_lane_end_sys)
                         continue;
 

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -8209,7 +8209,7 @@ bool Stationary::Match(const ScriptingContext& local_context) const {
     auto fleet = std::dynamic_pointer_cast<const Fleet>(candidate);
     if (!fleet)
         if (auto ship = std::dynamic_pointer_cast<const Ship>(candidate))
-            fleet = GetFleet(ship->FleetID());
+            fleet = Objects().get<Fleet>(ship->FleetID());
 
     if (fleet) {
         // if a fleet is available, it is "moving", or not stationary, if it's
@@ -8267,7 +8267,7 @@ bool Aggressive::Match(const ScriptingContext& local_context) const {
     auto fleet = std::dynamic_pointer_cast<const Fleet>(candidate);
     if (!fleet)
         if (auto ship = std::dynamic_pointer_cast<const Ship>(candidate))
-            fleet = GetFleet(ship->FleetID());
+            fleet = Objects().get<Fleet>(ship->FleetID());
 
     if (!fleet)
         return false;

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -1511,7 +1511,7 @@ namespace {
             auto planet = std::dynamic_pointer_cast<const Planet>(candidate);
             std::shared_ptr<const ::Building> building;
             if (!planet && (building = std::dynamic_pointer_cast<const ::Building>(candidate))) {
-                planet = GetPlanet(building->PlanetID());
+                planet = Objects().get<Planet>(building->PlanetID());
             }
             if (!planet)
                 return false;
@@ -1644,7 +1644,7 @@ bool Homeworld::Match(const ScriptingContext& local_context) const {
     auto planet = std::dynamic_pointer_cast<const Planet>(candidate);
     std::shared_ptr<const ::Building> building;
     if (!planet && (building = std::dynamic_pointer_cast<const ::Building>(candidate))) {
-        planet = GetPlanet(building->PlanetID());
+        planet = Objects().get<Planet>(building->PlanetID());
     }
     if (!planet)
         return false;
@@ -3473,7 +3473,7 @@ namespace {
             auto planet = std::dynamic_pointer_cast<const Planet>(candidate);
             std::shared_ptr<const ::Building> building;
             if (!planet && (building = std::dynamic_pointer_cast<const ::Building>(candidate))) {
-                planet = GetPlanet(building->PlanetID());
+                planet = Objects().get<Planet>(building->PlanetID());
             }
             if (planet) {
                 // is it one of the specified building types?
@@ -3590,7 +3590,7 @@ bool PlanetType::Match(const ScriptingContext& local_context) const {
     auto planet = std::dynamic_pointer_cast<const Planet>(candidate);
     std::shared_ptr<const ::Building> building;
     if (!planet && (building = std::dynamic_pointer_cast<const ::Building>(candidate))) {
-        planet = GetPlanet(building->PlanetID());
+        planet = Objects().get<Planet>(building->PlanetID());
     }
     if (planet) {
         for (auto& type : m_types) {
@@ -3657,7 +3657,7 @@ namespace {
             auto planet = std::dynamic_pointer_cast<const Planet>(candidate);
             std::shared_ptr<const ::Building> building;
             if (!planet && (building = std::dynamic_pointer_cast<const ::Building>(candidate))) {
-                planet = GetPlanet(building->PlanetID());
+                planet = Objects().get<Planet>(building->PlanetID());
             }
             if (planet) {
                 // is it one of the specified building types?
@@ -3777,7 +3777,7 @@ bool PlanetSize::Match(const ScriptingContext& local_context) const {
     auto planet = std::dynamic_pointer_cast<const Planet>(candidate);
     std::shared_ptr<const ::Building> building;
     if (!planet && (building = std::dynamic_pointer_cast<const ::Building>(candidate))) {
-        planet = GetPlanet(building->PlanetID());
+        planet = Objects().get<Planet>(building->PlanetID());
     }
     if (planet) {
         for (auto& size : m_sizes) {
@@ -3850,7 +3850,7 @@ namespace {
             auto planet = std::dynamic_pointer_cast<const Planet>(candidate);
             std::shared_ptr<const ::Building> building;
             if (!planet && (building = std::dynamic_pointer_cast<const ::Building>(candidate))) {
-                planet = GetPlanet(building->PlanetID());
+                planet = Objects().get<Planet>(building->PlanetID());
             }
             if (planet) {
                 // is it one of the specified building types?
@@ -3994,7 +3994,7 @@ bool PlanetEnvironment::Match(const ScriptingContext& local_context) const {
     auto planet = std::dynamic_pointer_cast<const Planet>(candidate);
     std::shared_ptr<const ::Building> building;
     if (!planet && (building = std::dynamic_pointer_cast<const ::Building>(candidate))) {
-        planet = GetPlanet(building->PlanetID());
+        planet = Objects().get<Planet>(building->PlanetID());
     }
     if (!planet)
         return false;
@@ -4085,7 +4085,7 @@ namespace {
             }
             // is it a building on a planet?
             if (auto building = std::dynamic_pointer_cast<const ::Building>(candidate)) {
-                auto planet = GetPlanet(building->PlanetID());
+                auto planet = Objects().get<Planet>(building->PlanetID());
                 const std::string& species_name = planet->SpeciesName();
                 // if the planet (which IS a popcenter) has a species and that species is one of those specified...
                 return !species_name.empty() && (m_names.empty() || std::count(m_names.begin(), m_names.end(), species_name));
@@ -4207,7 +4207,7 @@ bool Species::Match(const ScriptingContext& local_context) const {
     auto planet = std::dynamic_pointer_cast<const Planet>(candidate);
     std::shared_ptr<const ::Building> building;
     if (!planet && (building = std::dynamic_pointer_cast<const ::Building>(candidate))) {
-        planet = GetPlanet(building->PlanetID());
+        planet = Objects().get<Planet>(building->PlanetID());
     }
     if (planet) {
         if (m_names.empty()) {
@@ -4624,7 +4624,7 @@ namespace {
             auto res_center = std::dynamic_pointer_cast<const ResourceCenter>(candidate);
             std::shared_ptr<const ::Building> building;
             if (!res_center && (building = std::dynamic_pointer_cast<const ::Building>(candidate))) {
-                if (auto planet = GetPlanet(building->PlanetID()))
+                if (auto planet = Objects().get<Planet>(building->PlanetID()))
                     res_center = std::dynamic_pointer_cast<const ResourceCenter>(planet);
             }
             if (res_center) {
@@ -4736,7 +4736,7 @@ bool FocusType::Match(const ScriptingContext& local_context) const {
     auto res_center = std::dynamic_pointer_cast<const ResourceCenter>(candidate);
     std::shared_ptr<const ::Building> building;
     if (!res_center && (building = std::dynamic_pointer_cast<const ::Building>(candidate))) {
-        if (auto planet = GetPlanet(building->PlanetID()))
+        if (auto planet = Objects().get<Planet>(building->PlanetID()))
             res_center = std::dynamic_pointer_cast<const ResourceCenter>(planet);
     }
     if (res_center) {
@@ -8461,7 +8461,7 @@ namespace {
                 auto candidate_planet = std::dynamic_pointer_cast<const Planet>(candidate);
                 std::shared_ptr<const ::Building> building;
                 if (!candidate_planet && (building = std::dynamic_pointer_cast<const ::Building>(candidate)))
-                    candidate_planet = GetPlanet(building->PlanetID());
+                    candidate_planet = Objects().get<Planet>(building->PlanetID());
                 if (candidate_planet) {
                     int candidate_planet_id = candidate_planet->ID();
                     // can only match if the from_object is (or is on) the same planet
@@ -8469,7 +8469,7 @@ namespace {
                         auto from_obj_planet = std::dynamic_pointer_cast<const Planet>(from_object);
                         std::shared_ptr<const ::Building> from_building;
                         if (!from_obj_planet && (from_building = std::dynamic_pointer_cast<const ::Building>(from_object)))
-                            from_obj_planet = GetPlanet(from_building->PlanetID());
+                            from_obj_planet = Objects().get<Planet>(from_building->PlanetID());
                         if (from_obj_planet && from_obj_planet->ID() == candidate_planet_id)
                             return true;
                     }
@@ -8630,7 +8630,7 @@ bool CanColonize::Match(const ScriptingContext& local_context) const {
             ErrorLogger() << "CanColonize couldn't cast supposedly building candidate";
             return false;
         }
-        auto planet = GetPlanet(building->PlanetID());
+        auto planet = Objects().get<Planet>(building->PlanetID());
         if (!planet) {
             ErrorLogger() << "CanColonize couldn't get building's planet";
             return false;
@@ -8703,7 +8703,7 @@ bool CanProduceShips::Match(const ScriptingContext& local_context) const {
             ErrorLogger() << "CanProduceShips couldn't cast supposedly building candidate";
             return false;
         }
-        auto planet = GetPlanet(building->PlanetID());
+        auto planet = Objects().get<Planet>(building->PlanetID());
         if (!planet) {
             ErrorLogger() << "CanProduceShips couldn't get building's planet";
             return false;

--- a/universe/Effects.cpp
+++ b/universe/Effects.cpp
@@ -1441,7 +1441,7 @@ void CreateBuilding::Execute(const ScriptingContext& context) const {
     auto location = std::dynamic_pointer_cast<Planet>(context.effect_target);
     if (!location)
         if (auto location_building = std::dynamic_pointer_cast<Building>(context.effect_target))
-            location = GetPlanet(location_building->PlanetID());
+            location = Objects().get<Planet>(location_building->PlanetID());
     if (!location) {
         ErrorLogger() << "CreateBuilding::Execute couldn't get a Planet object at which to create the building";
         return;
@@ -2479,7 +2479,7 @@ void MoveTo::Execute(const ScriptingContext& context) const {
         if (!dest_planet) {
             auto dest_building = std::dynamic_pointer_cast<Building>(destination);
             if (dest_building) {
-                dest_planet = GetPlanet(dest_building->PlanetID());
+                dest_planet = Objects().get<Planet>(dest_building->PlanetID());
             }
         }
         if (!dest_planet)
@@ -2497,7 +2497,7 @@ void MoveTo::Execute(const ScriptingContext& context) const {
             old_sys->Remove(building->ID());
         building->SetSystem(INVALID_OBJECT_ID);
 
-        if (auto old_planet = GetPlanet(building->PlanetID()))
+        if (auto old_planet = Objects().get<Planet>(building->PlanetID()))
             old_planet->RemoveBuilding(building->ID());
 
         dest_planet->AddBuilding(building->ID());

--- a/universe/Effects.cpp
+++ b/universe/Effects.cpp
@@ -327,7 +327,7 @@ void Effect::Execute(const TargetsCauses& targets_causes,
     { return; }
     // apply this effect for each source causing it
     for (const auto& targets_entry : targets_causes) {
-        ScriptingContext source_context(GetUniverseObject(targets_entry.first.source_object_id));
+        ScriptingContext source_context(Objects().get(targets_entry.first.source_object_id));
         Execute(source_context, targets_entry.second.target_set,
                 accounting_map, targets_entry.second.effect_cause,
                 only_meter_effects, only_appearance_effects,

--- a/universe/Effects.cpp
+++ b/universe/Effects.cpp
@@ -70,7 +70,7 @@ namespace {
 
         // remove ship from old fleet / system, put into new system if necessary
         if (ship->SystemID() != system->ID()) {
-            if (auto old_system = GetSystem(ship->SystemID())) {
+            if (auto old_system = Objects().get<System>(ship->SystemID())) {
                 old_system->Remove(ship->ID());
                 ship->SetSystem(INVALID_OBJECT_ID);
             }
@@ -112,13 +112,13 @@ namespace {
             return;
         }
 
-        auto next_system = GetSystem(new_next_system);
+        auto next_system = Objects().get<System>(new_next_system);
         if (!next_system) {
             ErrorLogger() << "UpdateFleetRoute couldn't get new next system with id: " << new_next_system;
             return;
         }
 
-        if (new_previous_system != INVALID_OBJECT_ID && !GetSystem(new_previous_system)) {
+        if (new_previous_system != INVALID_OBJECT_ID && !Objects().get<System>(new_previous_system)) {
             ErrorLogger() << "UpdateFleetRoute couldn't get new previous system with id: " << new_previous_system;
         }
 
@@ -1160,7 +1160,7 @@ void SetOwner::Execute(const ScriptingContext& context) const {
 
         // move ship into new fleet
         std::shared_ptr<Fleet> new_fleet;
-        if (auto system = GetSystem(ship->SystemID()))
+        if (auto system = Objects().get<System>(ship->SystemID()))
             new_fleet = CreateNewFleet(system, ship);
         else
             new_fleet = CreateNewFleet(ship->X(), ship->Y(), ship);
@@ -1328,7 +1328,7 @@ void CreatePlanet::Execute(const ScriptingContext& context) const {
         ErrorLogger() << "CreatePlanet::Execute passed no target object";
         return;
     }
-    auto system = GetSystem(context.effect_target->SystemID());
+    auto system = Objects().get<System>(context.effect_target->SystemID());
     if (!system) {
         ErrorLogger() << "CreatePlanet::Execute couldn't get a System object at which to create the planet";
         return;
@@ -1470,7 +1470,7 @@ void CreateBuilding::Execute(const ScriptingContext& context) const {
 
     building->SetOwner(location->Owner());
 
-    auto system = GetSystem(location->SystemID());
+    auto system = Objects().get<System>(location->SystemID());
     if (system)
         system->Insert(building);
 
@@ -1560,7 +1560,7 @@ void CreateShip::Execute(const ScriptingContext& context) const {
         return;
     }
 
-    auto system = GetSystem(context.effect_target->SystemID());
+    auto system = Objects().get<System>(context.effect_target->SystemID());
     if (!system) {
         ErrorLogger() << "CreateShip::Execute passed a target not in a system";
         return;
@@ -2114,7 +2114,7 @@ void AddStarlanes::Execute(const ScriptingContext& context) const {
     }
     auto target_system = std::dynamic_pointer_cast<System>(context.effect_target);
     if (!target_system)
-        target_system = GetSystem(context.effect_target->SystemID());
+        target_system = Objects().get<System>(context.effect_target->SystemID());
     if (!target_system)
         return; // nothing to do!
 
@@ -2133,7 +2133,7 @@ void AddStarlanes::Execute(const ScriptingContext& context) const {
     for (auto& endpoint_object : endpoint_objects) {
         auto endpoint_system = std::dynamic_pointer_cast<const System>(endpoint_object);
         if (!endpoint_system)
-            endpoint_system = GetSystem(endpoint_object->SystemID());
+            endpoint_system = Objects().get<System>(endpoint_object->SystemID());
         if (!endpoint_system)
             continue;
         endpoint_systems.insert(std::const_pointer_cast<System>(endpoint_system));
@@ -2180,7 +2180,7 @@ void RemoveStarlanes::Execute(const ScriptingContext& context) const {
     }
     auto target_system = std::dynamic_pointer_cast<System>(context.effect_target);
     if (!target_system)
-        target_system = GetSystem(context.effect_target->SystemID());
+        target_system = Objects().get<System>(context.effect_target->SystemID());
     if (!target_system)
         return; // nothing to do!
 
@@ -2200,7 +2200,7 @@ void RemoveStarlanes::Execute(const ScriptingContext& context) const {
     for (auto& endpoint_object : endpoint_objects) {
         auto endpoint_system = std::dynamic_pointer_cast<const System>(endpoint_object);
         if (!endpoint_system)
-            endpoint_system = GetSystem(endpoint_object->SystemID());
+            endpoint_system = Objects().get<System>(endpoint_object->SystemID());
         if (!endpoint_system)
             continue;
         endpoint_systems.insert(std::const_pointer_cast<System>(endpoint_system));
@@ -2297,13 +2297,13 @@ void MoveTo::Execute(const ScriptingContext& context) const {
     auto destination = std::const_pointer_cast<UniverseObject>(*valid_locations.begin());
 
     // get previous system from which to remove object if necessary
-    auto old_sys = GetSystem(context.effect_target->SystemID());
+    auto old_sys = Objects().get<System>(context.effect_target->SystemID());
 
     // do the moving...
     if (auto fleet = std::dynamic_pointer_cast<Fleet>(context.effect_target)) {
         // fleets can be inserted into the system that contains the destination
         // object (or the destination object itself if it is a system)
-        if (auto dest_system = GetSystem(destination->SystemID())) {
+        if (auto dest_system = Objects().get<System>(destination->SystemID())) {
             if (fleet->SystemID() != dest_system->ID()) {
                 // remove fleet from old system, put into new system
                 if (old_sys)
@@ -2394,7 +2394,7 @@ void MoveTo::Execute(const ScriptingContext& context) const {
                 ship->SetSystem(INVALID_OBJECT_ID);
             }
 
-            if (auto new_sys = GetSystem(dest_sys_id)) {
+            if (auto new_sys = Objects().get<System>(dest_sys_id)) {
                 // ship is moving to a new system. insert it.
                 new_sys->Insert(ship);
             } else {
@@ -2426,7 +2426,7 @@ void MoveTo::Execute(const ScriptingContext& context) const {
 
         } else {
             // need to create a new fleet for ship
-            if (auto dest_system = GetSystem(dest_sys_id)) {
+            if (auto dest_system = Objects().get<System>(dest_sys_id)) {
                 CreateNewFleet(dest_system, ship);                          // creates new fleet, inserts fleet into system and ship into fleet
                 ExploreSystem(dest_system->ID(), ship);
 
@@ -2443,7 +2443,7 @@ void MoveTo::Execute(const ScriptingContext& context) const {
     } else if (auto planet = std::dynamic_pointer_cast<Planet>(context.effect_target)) {
         // planets need to be located in systems, so get system that contains destination object
 
-        auto dest_system = GetSystem(destination->SystemID());
+        auto dest_system = Objects().get<System>(destination->SystemID());
         if (!dest_system)
             return; // can't move a planet to a non-system
 
@@ -2488,7 +2488,7 @@ void MoveTo::Execute(const ScriptingContext& context) const {
         if (dest_planet->ID() == building->PlanetID())
             return; // nothing to do
 
-        auto dest_system = GetSystem(destination->SystemID());
+        auto dest_system = Objects().get<System>(destination->SystemID());
         if (!dest_system)
             return;
 
@@ -2624,7 +2624,7 @@ void MoveInOrbit::Execute(const ScriptingContext& context) const {
     if (target->X() == new_x && target->Y() == new_y)
         return;
 
-    auto old_sys = GetSystem(target->SystemID());
+    auto old_sys = Objects().get<System>(target->SystemID());
 
     if (auto system = std::dynamic_pointer_cast<System>(target)) {
         system->MoveTo(new_x, new_y);
@@ -2787,7 +2787,7 @@ void MoveTowards::Execute(const ScriptingContext& context) const {
         // containment situation
 
     } else if (auto fleet = std::dynamic_pointer_cast<Fleet>(target)) {
-        auto old_sys = GetSystem(fleet->SystemID());
+        auto old_sys = Objects().get<System>(fleet->SystemID());
         if (old_sys)
             old_sys->Remove(fleet->ID());
         fleet->SetSystem(INVALID_OBJECT_ID);
@@ -2803,7 +2803,7 @@ void MoveTowards::Execute(const ScriptingContext& context) const {
         UpdateFleetRoute(fleet, INVALID_OBJECT_ID, INVALID_OBJECT_ID);
 
     } else if (auto ship = std::dynamic_pointer_cast<Ship>(target)) {
-        auto old_sys = GetSystem(ship->SystemID());
+        auto old_sys = Objects().get<System>(ship->SystemID());
         if (old_sys)
             old_sys->Remove(ship->ID());
         ship->SetSystem(INVALID_OBJECT_ID);
@@ -2821,7 +2821,7 @@ void MoveTowards::Execute(const ScriptingContext& context) const {
         }
 
     } else if (auto field = std::dynamic_pointer_cast<Field>(target)) {
-        auto old_sys = GetSystem(field->SystemID());
+        auto old_sys = Objects().get<System>(field->SystemID());
         if (old_sys)
             old_sys->Remove(field->ID());
         field->SetSystem(INVALID_OBJECT_ID);

--- a/universe/Effects.cpp
+++ b/universe/Effects.cpp
@@ -78,7 +78,7 @@ namespace {
         }
 
         if (ship->FleetID() != INVALID_OBJECT_ID) {
-            if (auto old_fleet = GetFleet(ship->FleetID())) {
+            if (auto old_fleet = Objects().get<Fleet>(ship->FleetID())) {
                 old_fleet->RemoveShips({ship->ID()});
             }
         }
@@ -1152,7 +1152,7 @@ void SetOwner::Execute(const ScriptingContext& context) const {
     if (auto ship = std::dynamic_pointer_cast<Ship>(context.effect_target)) {
         // assigning ownership of a ship requires updating the containing
         // fleet, or splitting ship off into a new fleet at the same location
-        auto fleet = GetFleet(ship->FleetID());
+        auto fleet = Objects().get<Fleet>(ship->FleetID());
         if (!fleet)
             return;
         if (fleet->Owner() == empire_id)
@@ -2356,7 +2356,7 @@ void MoveTo::Execute(const ScriptingContext& context) const {
             auto dest_fleet = std::dynamic_pointer_cast<const Fleet>(destination);
             if (!dest_fleet)
                 if (auto dest_ship = std::dynamic_pointer_cast<const Ship>(destination))
-                    dest_fleet = GetFleet(dest_ship->FleetID());
+                    dest_fleet = Objects().get<Fleet>(dest_ship->FleetID());
             if (dest_fleet) {
                 UpdateFleetRoute(fleet, dest_fleet->NextSystemID(), dest_fleet->PreviousSystemID());
 
@@ -2375,7 +2375,7 @@ void MoveTo::Execute(const ScriptingContext& context) const {
         if (!dest_fleet) {
             auto dest_ship = std::dynamic_pointer_cast<Ship>(destination);
             if (dest_ship)
-                dest_fleet = GetFleet(dest_ship->FleetID());
+                dest_fleet = Objects().get<Fleet>(dest_ship->FleetID());
         }
         if (dest_fleet && dest_fleet->ID() == ship->FleetID())
             return; // already in destination fleet. nothing to do.
@@ -2405,7 +2405,7 @@ void MoveTo::Execute(const ScriptingContext& context) const {
             // may create a fleet for ship below...
         }
 
-        auto old_fleet = GetFleet(ship->FleetID());
+        auto old_fleet = Objects().get<Fleet>(ship->FleetID());
 
         if (dest_fleet && same_owners) {
             // ship is moving to a different fleet owned by the same empire, so
@@ -2650,7 +2650,7 @@ void MoveInOrbit::Execute(const ScriptingContext& context) const {
             old_sys->Remove(ship->ID());
         ship->SetSystem(INVALID_OBJECT_ID);
 
-        auto old_fleet = GetFleet(ship->FleetID());
+        auto old_fleet = Objects().get<Fleet>(ship->FleetID());
         if (old_fleet) {
             old_fleet->RemoveShips({ship->ID()});
             if (old_fleet->Empty()) {
@@ -2808,7 +2808,7 @@ void MoveTowards::Execute(const ScriptingContext& context) const {
             old_sys->Remove(ship->ID());
         ship->SetSystem(INVALID_OBJECT_ID);
 
-        auto old_fleet = GetFleet(ship->FleetID());
+        auto old_fleet = Objects().get<Fleet>(ship->FleetID());
         if (old_fleet)
             old_fleet->RemoveShips({ship->ID()});
         ship->SetFleetID(INVALID_OBJECT_ID);

--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -117,9 +117,9 @@ void Fleet::Copy(std::shared_ptr<const UniverseObject> copied_object, int empire
     if (vis >= VIS_BASIC_VISIBILITY) {
         m_ships =                         copied_fleet->VisibleContainedObjectIDs(empire_id);
 
-        m_next_system = ((GetEmpireKnownSystem(copied_fleet->m_next_system, empire_id))
+        m_next_system = ((EmpireKnownObjects(empire_id).get<System>(copied_fleet->m_next_system))
                          ? copied_fleet->m_next_system : INVALID_OBJECT_ID);
-        m_prev_system = ((GetEmpireKnownSystem(copied_fleet->m_prev_system, empire_id))
+        m_prev_system = ((EmpireKnownObjects(empire_id).get<System>(copied_fleet->m_prev_system))
                          ? copied_fleet->m_prev_system : INVALID_OBJECT_ID);
         m_arrived_this_turn =             copied_fleet->m_arrived_this_turn;
         m_arrival_starlane =              copied_fleet->m_arrival_starlane;
@@ -456,7 +456,7 @@ std::list<MovePathNode> Fleet::MovePath(const std::list<int>& route, bool flag_b
             ++route_it;
             if (route_it != route.end()) {
                 // update next system on route and distance to it from current position
-                next_system = GetEmpireKnownSystem(*route_it, this->Owner());
+                next_system = EmpireKnownObjects(this->Owner()).get<System>(*route_it);
                 if (next_system) {
                     TraceLogger() << "Fleet::MovePath checking unrestriced lane travel from Sys("
                                   <<  cur_system->ID() << ") to Sys(" << (next_system && next_system->ID()) << ")";

--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -206,8 +206,7 @@ int Fleet::MaxShipAgeInTurns() const {
 
     bool fleet_is_scrapped = true;
     int retval = 0;
-    for (int ship_id : m_ships) {
-        auto ship = GetShip(ship_id);
+    for (const auto& ship : Objects().find<Ship>(m_ships)) {
         if (!ship || ship->OrderedScrapped())
             continue;
         if (ship->AgeInTurns() > retval)
@@ -1293,8 +1292,7 @@ float Fleet::Speed() const {
 
     bool fleet_is_scrapped = true;
     float retval = MAX_SHIP_SPEED;  // max speed no ship can go faster than
-    for (int ship_id : m_ships) {
-        auto ship = GetShip(ship_id);
+    for (const auto& ship : Objects().find<Ship>(m_ships)) {
         if (!ship || ship->OrderedScrapped())
             continue;
         if (ship->Speed() < retval)
@@ -1314,15 +1312,12 @@ float Fleet::Damage() const {
 
     bool fleet_is_scrapped = true;
     float retval = 0.0f;
-    for (int ship_id : m_ships) {
-        if (auto ship = GetShip(ship_id)) {
-            if (!ship->OrderedScrapped()) {
-                if (const auto design = ship->Design()){
-                    retval += design->Attack();
-                }
-                fleet_is_scrapped = false;
-            }
-        }
+    for (const auto& ship : Objects().find<Ship>(m_ships)) {
+        if (!ship || ship->OrderedScrapped())
+            continue;
+        if (const auto design = ship->Design())
+            retval += design->Attack();
+        fleet_is_scrapped = false;
     }
 
     if (fleet_is_scrapped)
@@ -1337,13 +1332,11 @@ float Fleet::Structure() const {
 
     bool fleet_is_scrapped = true;
     float retval = 0.0f;
-    for (int ship_id : m_ships) {
-        if (auto ship = GetShip(ship_id)) {
-            if (!ship->OrderedScrapped()) {
-                retval += ship->CurrentMeterValue(METER_STRUCTURE);
-                fleet_is_scrapped = false;
-            }
-        }
+    for (const auto& ship : Objects().find<Ship>(m_ships)) {
+        if (!ship || ship->OrderedScrapped())
+            continue;
+        retval += ship->CurrentMeterValue(METER_STRUCTURE);
+        fleet_is_scrapped = false;
     }
 
     if (fleet_is_scrapped)
@@ -1358,13 +1351,11 @@ float Fleet::Shields() const {
 
     bool fleet_is_scrapped = true;
     float retval = 0.0f;
-    for (int ship_id : m_ships) {
-        if (auto ship = GetShip(ship_id)) {
-            if (!ship->OrderedScrapped()) {
-                retval += ship->CurrentMeterValue(METER_SHIELD);
-                fleet_is_scrapped = false;
-            }
-        }
+    for (const auto& ship : Objects().find<Ship>(m_ships)) {
+        if (!ship || ship->OrderedScrapped())
+            continue;
+        retval += ship->CurrentMeterValue(METER_SHIELD);
+        fleet_is_scrapped = false;
     }
 
     if (fleet_is_scrapped)
@@ -1380,10 +1371,10 @@ std::string Fleet::GenerateFleetName() {
         return UserString("NEW_FLEET_NAME_NO_NUMBER");
 
     std::vector<std::shared_ptr<const Ship>> ships;
-    for (int ship_id : m_ships) {
-        if (auto ship = GetShip(ship_id)) {
-            ships.push_back(ship);
-        }
+    for (const auto& ship : Objects().find<Ship>(m_ships)) {
+        if (!ship)
+            continue;
+        ships.push_back(ship);
     }
 
     auto it = ships.begin();

--- a/universe/Fleet.cpp
+++ b/universe/Fleet.cpp
@@ -1100,7 +1100,7 @@ void Fleet::CalculateRouteTo(int target_system_id) {
             ErrorLogger() << "Fleet::CalculateRoute got empty route from ShortestPath";
             return;
         }
-        auto obj = GetUniverseObject(sys_list1.front());
+        auto obj = Objects().get(sys_list1.front());
         if (!obj) {
             ErrorLogger() << "Fleet::CalculateRoute couldn't get path start object with id " << path1.first.front();
             return;
@@ -1121,7 +1121,7 @@ void Fleet::CalculateRouteTo(int target_system_id) {
             ErrorLogger() << "Fleet::CalculateRoute got empty route from ShortestPath";
             return;
         }
-        obj = GetUniverseObject(sys_list2.front());
+        obj = Objects().get(sys_list2.front());
         if (!obj) {
             ErrorLogger() << "Fleet::CalculateRoute couldn't get path start object with id " << path2.first.front();
             return;

--- a/universe/Pathfinder.cpp
+++ b/universe/Pathfinder.cpp
@@ -733,7 +733,7 @@ namespace {
         std::shared_ptr<const Fleet> retval = std::dynamic_pointer_cast<const Fleet>(obj);
         if (!retval) {
             if (auto ship = std::dynamic_pointer_cast<const Ship>(obj))
-                retval = GetFleet(ship->FleetID());
+                retval = Objects().get<Fleet>(ship->FleetID());
         }
         return retval;
     }

--- a/universe/Pathfinder.cpp
+++ b/universe/Pathfinder.cpp
@@ -766,12 +766,12 @@ double Pathfinder::LinearDistance(int system1_id, int system2_id) const {
 }
 
 double Pathfinder::PathfinderImpl::LinearDistance(int system1_id, int system2_id) const {
-    std::shared_ptr<const System> system1 = GetSystem(system1_id);
+    const auto system1 = Objects().get<System>(system1_id);
     if (!system1) {
         ErrorLogger() << "Universe::LinearDistance passed invalid system id: " << system1_id;
         throw std::out_of_range("system1_id invalid");
     }
-    std::shared_ptr<const System> system2 = GetSystem(system2_id);
+    const auto system2 = Objects().get<System>(system2_id);
     if (!system2) {
         ErrorLogger() << "Universe::LinearDistance passed invalid system id: " << system2_id;
         throw std::out_of_range("system2_id invalid");
@@ -830,7 +830,7 @@ namespace {
             return nullptr;
 
         int system_id = obj->SystemID();
-        auto system = GetSystem(system_id);
+        auto system = Objects().get<System>(system_id);
         if (system)
             return system_id;
 
@@ -1051,8 +1051,8 @@ double Pathfinder::PathfinderImpl::ShortestPathDistance(int object1_id, int obje
     if (!obj2)
         return -1;
 
-    std::shared_ptr<const System> system_one = GetSystem(obj1->SystemID());
-    std::shared_ptr<const System> system_two = GetSystem(obj2->SystemID());
+    auto system_one = Objects().get<System>(obj1->SystemID());
+    auto system_two = Objects().get<System>(obj2->SystemID());
     std::pair< std::list< int >, double > path_len_pair;
     double dist1(0.0), dist2(0.0);
     std::shared_ptr<const Fleet> fleet;
@@ -1061,7 +1061,7 @@ double Pathfinder::PathfinderImpl::ShortestPathDistance(int object1_id, int obje
         fleet = FleetFromObject(obj1);
         if (!fleet)
             return -1;
-        if (std::shared_ptr<const System> next_sys = GetSystem(fleet->NextSystemID())) {
+        if (auto next_sys = Objects().get<System>(fleet->NextSystemID())) {
             system_one = next_sys;
             dist1 = std::sqrt(pow((next_sys->X() - fleet->X()), 2) + pow((next_sys->Y() - fleet->Y()), 2));
         }
@@ -1071,7 +1071,7 @@ double Pathfinder::PathfinderImpl::ShortestPathDistance(int object1_id, int obje
         fleet = FleetFromObject(obj2);
         if (!fleet)
             return -1;
-        if (std::shared_ptr<const System> next_sys = GetSystem(fleet->NextSystemID())) {
+        if (auto next_sys = Objects().get<System>(fleet->NextSystemID())) {
             system_two = next_sys;
             dist2 = std::sqrt(pow((next_sys->X() - fleet->X()), 2) + pow((next_sys->Y() - fleet->Y()), 2));
         }

--- a/universe/Pathfinder.cpp
+++ b/universe/Pathfinder.cpp
@@ -518,7 +518,7 @@ namespace {
                 int sys_id_2 = sys_id_property_map[sys_graph_index_2];
 
                 // look up lane between systems
-                std::shared_ptr<const System> system1 = GetEmpireKnownSystem(sys_id_1, m_empire_id);
+                std::shared_ptr<const System> system1 = EmpireKnownObjects(m_empire_id).get<System>(sys_id_1);
                 if (!system1) {
                     ErrorLogger() << "EdgeDescriptor::operator() couldn't find system with id " << sys_id_1;
                     return false;
@@ -589,12 +589,12 @@ namespace {
                 int sys_id_2 = sys_id_property_map[sys_graph_index_2];
 
                 // look up objects in system
-                auto system1 = GetEmpireKnownSystem(sys_id_1, m_empire_id);
+                auto system1 = EmpireKnownObjects(m_empire_id).get<System>(sys_id_1);
                 if (!system1) {
                     ErrorLogger() << "Invalid source system " << sys_id_1;
                     return true;
                 }
-                auto system2 = GetEmpireKnownSystem(sys_id_2, m_empire_id);
+                auto system2 = EmpireKnownObjects(m_empire_id).get<System>(sys_id_2);
                 if (!system2) {
                     ErrorLogger() << "Invalid target system " << sys_id_2;
                     return true;
@@ -1138,7 +1138,7 @@ bool Pathfinder::SystemHasVisibleStarlanes(int system_id, int empire_id) const
 { return pimpl->SystemHasVisibleStarlanes(system_id, empire_id); }
 
 bool Pathfinder::PathfinderImpl::SystemHasVisibleStarlanes(int system_id, int empire_id) const {
-    if (auto system = GetEmpireKnownSystem(system_id, empire_id))
+    if (auto system = EmpireKnownObjects(empire_id).get<System>(system_id))
         if (!system->StarlanesWormholes().empty())
             return true;
     return false;
@@ -1413,7 +1413,7 @@ void Pathfinder::PathfinderImpl::InitializeSystemGraph(
     // add edges for all starlanes
     for (size_t system1_index = 0; system1_index < system_ids.size(); ++system1_index) {
         int system1_id = system_ids[system1_index];
-        std::shared_ptr<const System> system1 = GetEmpireKnownSystem(system1_id, for_empire_id);
+        std::shared_ptr<const System> system1 = EmpireKnownObjects(for_empire_id).get<System>(system1_id);
         //std::shared_ptr<const System> & system1 = systems[system1_index];
 
         // add edges and edge weights

--- a/universe/Pathfinder.cpp
+++ b/universe/Pathfinder.cpp
@@ -851,7 +851,7 @@ namespace {
 
     /** Return the location of the object with id \p object_id.*/
     GeneralizedLocationType GeneralizedLocation(int object_id) {
-        auto obj = GetUniverseObject(object_id);
+        auto obj = Objects().get(object_id);
         return GeneralizedLocation(obj);
     }
 
@@ -1043,11 +1043,11 @@ double Pathfinder::PathfinderImpl::ShortestPathDistance(int object1_id, int obje
     // If one or both objects are (in) a fleet between systems, use the destination system
     // and add the distance from the fleet to the destination system, essentially calculating
     // the distance travelled until both could be in the same system.
-    std::shared_ptr<const UniverseObject> obj1 = GetUniverseObject(object1_id);
+    const auto obj1 = Objects().get(object1_id);
     if (!obj1)
         return -1;
 
-    std::shared_ptr<const UniverseObject> obj2 = GetUniverseObject(object2_id);
+    const auto obj2 = Objects().get(object2_id);
     if (!obj2)
         return -1;
 

--- a/universe/Planet.cpp
+++ b/universe/Planet.cpp
@@ -436,7 +436,7 @@ std::string Planet::CardinalSuffix() const {
         return retval;
     }
 
-    auto cur_system = GetSystem(SystemID());
+    auto cur_system = Objects().get<System>(SystemID());
     // Early return for no system
     if (!cur_system) {
         ErrorLogger() << "Planet " << Name() << "(" << ID()
@@ -656,7 +656,7 @@ void Planet::Conquer(int conquerer) {
             // destroy object
             //DebugLogger() << "Planet::Conquer destroying object: " << building->Name();
             this->RemoveBuilding(building->ID());
-            if (auto system = GetSystem(this->SystemID()))
+            if (auto system = Objects().get<System>(this->SystemID()))
                 system->Remove(building->ID());
             GetUniverse().Destroy(building->ID());
         } else if (cap_result == CR_RETAIN) {

--- a/universe/Planet.cpp
+++ b/universe/Planet.cpp
@@ -611,9 +611,11 @@ void Planet::Reset() {
     GetMeter(METER_REBEL_TROOPS)->Reset();
 
     if (m_is_about_to_be_colonized && !OwnedBy(ALL_EMPIRES)) {
-        for (int building_id : m_buildings)
-            if (auto building = GetBuilding(building_id))
-                building->Reset();
+        for (const auto& building : Objects().find<Building>(m_buildings)) {
+            if (!building)
+                continue;
+            building->Reset();
+        }
     }
 
     //m_turn_last_conquered left unchanged
@@ -710,9 +712,11 @@ bool Planet::Colonize(int empire_id, const std::string& species_name, double pop
         Reset();
     } else {
         PopCenter::Reset();
-        for (int building_id : m_buildings)
-            if (auto building = GetBuilding(building_id))
-                building->Reset();
+        for (const auto& building : Objects().find<Building>(m_buildings)) {
+            if (!building)
+                continue;
+            building->Reset();
+        }
         m_is_about_to_be_colonized = false;
         m_is_about_to_be_invaded = false;
         m_is_about_to_be_bombarded = false;

--- a/universe/Planet.cpp
+++ b/universe/Planet.cpp
@@ -468,7 +468,7 @@ std::string Planet::CardinalSuffix() const {
             continue;
         }
 
-        PlanetType other_planet_type = GetPlanet(sys_orbit)->Type();
+        PlanetType other_planet_type = Objects().get<Planet>(sys_orbit)->Type();
         if (other_planet_type == INVALID_PLANET_TYPE)
             continue;
 

--- a/universe/Ship.cpp
+++ b/universe/Ship.cpp
@@ -117,7 +117,7 @@ void Ship::Copy(std::shared_ptr<const UniverseObject> copied_object, int empire_
     if (vis >= VIS_BASIC_VISIBILITY) {
         if (this->m_fleet_id != copied_ship->m_fleet_id) {
             // as with other containers, removal from the old container is triggered by the contained Object; removal from System is handled by UniverseObject::Copy
-            if (auto old_fleet = GetFleet(this->m_fleet_id))
+            if (auto old_fleet = Objects().get<Fleet>(this->m_fleet_id))
                 old_fleet->RemoveShips({this->ID()});
             this->m_fleet_id = copied_ship->m_fleet_id; // as with other containers (Systems), actual insertion into fleet ships set is handled by the fleet
         }

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -483,7 +483,7 @@ float PartType::ProductionCost(int empire_id, int location_id, int in_design_id/
 
     const auto arbitrary_large_number = 999999.9f;
 
-    auto location = GetUniverseObject(location_id);
+    auto location = Objects().get(location_id);
     if (!location && !m_production_cost->TargetInvariant())
         return arbitrary_large_number;
 
@@ -507,7 +507,7 @@ int PartType::ProductionTime(int empire_id, int location_id, int in_design_id/* 
     else if (m_production_time->SourceInvariant() && m_production_time->TargetInvariant())
         return m_production_time->Eval(ScriptingContext(nullptr, nullptr, in_design_id));
 
-    auto location = GetUniverseObject(location_id);
+    auto location = Objects().get(location_id);
     if (!location && !m_production_time->TargetInvariant())
         return arbitrary_large_number;
 
@@ -659,7 +659,7 @@ float HullType::ProductionCost(int empire_id, int location_id, int in_design_id/
 
     const auto arbitrary_large_number = 999999.9f;
 
-    auto location = GetUniverseObject(location_id);
+    auto location = Objects().get(location_id);
     if (!location && !m_production_cost->TargetInvariant())
         return arbitrary_large_number;
 
@@ -683,7 +683,7 @@ int HullType::ProductionTime(int empire_id, int location_id, int in_design_id/* 
 
     const auto arbitrary_large_number = 999999;
 
-    auto location = GetUniverseObject(location_id);
+    auto location = Objects().get(location_id);
     if (!location && !m_production_time->TargetInvariant())
         return arbitrary_large_number;
 
@@ -1072,7 +1072,7 @@ bool ShipDesign::ProductionLocation(int empire_id, int location_id) const {
     }
 
     // must own the production location...
-    auto location = GetUniverseObject(location_id);
+    auto location = Objects().get(location_id);
     if (!location) {
         WarnLogger() << "ShipDesign::ProductionLocation unable to get location object with id " << location_id;
         return false;

--- a/universe/Special.cpp
+++ b/universe/Special.cpp
@@ -154,7 +154,7 @@ float Special::InitialCapacity(int object_id) const {
     if (!m_initial_capacity)
         return 0.0f;
 
-    auto obj = GetUniverseObject(object_id);
+    auto obj = Objects().get(object_id);
     if (!obj)
         return 0.0f;
 

--- a/universe/Species.cpp
+++ b/universe/Species.cpp
@@ -308,7 +308,7 @@ PlanetType Species::NextBetterPlanetType(PlanetType initial_planet_type) const {
 }
 
 void Species::AddHomeworld(int homeworld_id) {
-    if (!GetUniverseObject(homeworld_id))
+    if (!Objects().get(homeworld_id))
         DebugLogger() << "Species asked to add homeworld id " << homeworld_id << " but there is no such object in the Universe";
     if (m_homeworlds.count(homeworld_id))
         return;

--- a/universe/System.cpp
+++ b/universe/System.cpp
@@ -437,7 +437,7 @@ void System::Remove(int id) {
     m_objects.erase(id);
 
     if (removed_fleet) {
-        if (auto fleet = GetFleet(id))
+        if (auto fleet = Objects().get<Fleet>(id))
             FleetsRemovedSignal({fleet});
     }
     StateChangedSignal();

--- a/universe/System.cpp
+++ b/universe/System.cpp
@@ -287,16 +287,16 @@ bool System::HasWormholeTo(int id) const {
 int  System::Owner() const {
     // Check if all of the owners are the same empire.
     int first_owner_found(ALL_EMPIRES);
-    for (int planet_id : m_planets) {
-        if (auto planet = GetPlanet(planet_id)) {
-            const int owner = planet->Owner();
-            if (owner == ALL_EMPIRES)
-                continue;
-            if (first_owner_found == ALL_EMPIRES)
-                first_owner_found = owner;
-            if (first_owner_found != owner)
-                return ALL_EMPIRES;
-        }
+    for (const auto& planet : Objects().find<Planet>(m_planets)) {
+        if (!planet)
+            continue;
+        const int owner = planet->Owner();
+        if (owner == ALL_EMPIRES)
+            continue;
+        if (first_owner_found == ALL_EMPIRES)
+            first_owner_found = owner;
+        if (first_owner_found != owner)
+            return ALL_EMPIRES;
     }
     return first_owner_found;
 }

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -2746,7 +2746,7 @@ std::set<int> Universe::RecursiveDestroy(int object_id) {
 
     if (auto ship = std::dynamic_pointer_cast<Ship>(obj)) {
         // if a ship is being deleted, and it is the last ship in its fleet, then the empty fleet should also be deleted
-        auto fleet = GetFleet(ship->FleetID());
+        auto fleet = Objects().get<Fleet>(ship->FleetID());
         if (fleet) {
             fleet->RemoveShips({ship->ID()});
             if (fleet->Empty()) {

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -2813,7 +2813,7 @@ std::set<int> Universe::RecursiveDestroy(int object_id) {
         // ships, since everything in system is being destroyed
 
     } else if (auto building = std::dynamic_pointer_cast<Building>(obj)) {
-        auto planet = GetPlanet(building->PlanetID());
+        auto planet = Objects().get<Planet>(building->PlanetID());
         if (planet)
             planet->RemoveBuilding(object_id);
         if (system)

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -2742,7 +2742,7 @@ std::set<int> Universe::RecursiveDestroy(int object_id) {
         return retval;
     }
 
-    auto system = GetSystem(obj->SystemID());
+    auto system = Objects().get<System>(obj->SystemID());
 
     if (auto ship = std::dynamic_pointer_cast<Ship>(obj)) {
         // if a ship is being deleted, and it is the last ship in its fleet, then the empty fleet should also be deleted

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -1627,7 +1627,7 @@ void Universe::ExecuteEffects(const Effect::TargetsCauses& targets_causes,
 
     for (auto& entry : m_marked_destroyed) {
         int obj_id = entry.first;
-        auto obj = GetUniverseObject(obj_id);
+        auto obj = Objects().get(obj_id);
         if (!obj)
             continue;
 
@@ -1680,10 +1680,10 @@ namespace {
 }
 
 void Universe::CountDestructionInStats(int object_id, int source_object_id) {
-    auto obj = GetUniverseObject(object_id);
+    auto obj = Objects().get(object_id);
     if (!obj)
         return;
-    auto source = GetUniverseObject(source_object_id);
+    auto source = Objects().get(source_object_id);
     if (!source)
         return;
 
@@ -1734,7 +1734,7 @@ void Universe::ApplyEffectDerivedVisibilities() {
         for (const auto& object_entry : empire_entry.second) {
             if (object_entry.first <= INVALID_OBJECT_ID)
                 continue;   // can't set a non-object's visibility
-            auto target = GetUniverseObject(object_entry.first);
+            auto target = Objects().get(object_entry.first);
             if (!target)
                 continue;   // don't need to set a non-gettable object's visibility
 
@@ -1751,7 +1751,7 @@ void Universe::ApplyEffectDerivedVisibilities() {
             // evaluate valuerefs and and store visibility of object
             for (auto& source_ref_entry : object_entry.second) {
                 // set up context for executing ValueRef to determine visibility to set
-                auto source = GetUniverseObject(source_ref_entry.first);
+                auto source = Objects().get(source_ref_entry.first);
                 ScriptingContext context(source, target, target_initial_vis);
 
                 const auto val_ref = source_ref_entry.second;
@@ -1854,7 +1854,7 @@ void Universe::SetEmpireSpecialVisibility(int empire_id, int object_id,
 {
     if (empire_id == ALL_EMPIRES || special_name.empty() || object_id == INVALID_OBJECT_ID)
         return;
-    //auto obj = GetUniverseObject(object_id);
+    //auto obj = Objects().get(object_id);
     //if (!obj)
     //    return;
     //if (!obj->HasSpecial(special_name))

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -1843,7 +1843,7 @@ void Universe::SetEmpireObjectVisibility(int empire_id, int object_id, Visibilit
 
     // if object is a ship, empire also gets knowledge of its design
     if (vis >= VIS_PARTIAL_VISIBILITY) {
-        if (auto ship = GetShip(object_id))
+        if (auto ship = Objects().get<Ship>(object_id))
             SetEmpireKnowledgeOfShipDesign(ship->DesignID(), empire_id);
     }
 }
@@ -2433,7 +2433,7 @@ namespace {
                         obj_vis_map[obj_id] = allied_vis;
                         if (allied_vis < VIS_PARTIAL_VISIBILITY)
                             continue;
-                        if (auto ship = GetShip(obj_id))
+                        if (auto ship = Objects().get<Ship>(obj_id))
                             universe.SetEmpireKnowledgeOfShipDesign(ship->DesignID(), empire_id);
                     }
                 }

--- a/universe/UniverseGenerator.cpp
+++ b/universe/UniverseGenerator.cpp
@@ -814,7 +814,7 @@ void SetNativePopulationValues(ObjectMap& object_map) {
 
 bool SetEmpireHomeworld(Empire* empire, int planet_id, std::string species_name) {
     // get home planet and system, check if they exist
-    auto home_planet = GetPlanet(planet_id);
+    auto home_planet = Objects().get<Planet>(planet_id);
     std::shared_ptr<System> home_system;
     if (home_planet)
         home_system = GetSystem(home_planet->SystemID());

--- a/universe/UniverseGenerator.cpp
+++ b/universe/UniverseGenerator.cpp
@@ -815,13 +815,11 @@ void SetNativePopulationValues(ObjectMap& object_map) {
 bool SetEmpireHomeworld(Empire* empire, int planet_id, std::string species_name) {
     // get home planet and system, check if they exist
     auto home_planet = Objects().get<Planet>(planet_id);
-    std::shared_ptr<System> home_system;
-    if (home_planet)
-        home_system = GetSystem(home_planet->SystemID());
-    if (!home_planet || !home_system) {
-        ErrorLogger() << "SetEmpireHomeworld: couldn't get homeworld or system for empire" << empire->EmpireID();
+    if (!home_planet)
         return false;
-    }
+    auto home_system = Objects().get<System>(home_planet->SystemID());
+    if (!home_system)
+        return false;
 
     DebugLogger() << "SetEmpireHomeworld: setting system " << home_system->ID()
                   << " (planet " <<  home_planet->ID() << ") to be home system for empire " << empire->EmpireID();

--- a/universe/UniverseObject.cpp
+++ b/universe/UniverseObject.cpp
@@ -302,7 +302,7 @@ void UniverseObject::Move(double x, double y)
 { MoveTo(m_x + x, m_y + y); }
 
 void UniverseObject::MoveTo(int object_id)
-{ MoveTo(GetUniverseObject(object_id)); }
+{ MoveTo(Objects().get(object_id)); }
 
 void UniverseObject::MoveTo(std::shared_ptr<UniverseObject> object) {
     if (!object) {

--- a/universe/UniverseObject.cpp
+++ b/universe/UniverseObject.cpp
@@ -169,7 +169,7 @@ UniverseObjectType UniverseObject::ObjectType() const
 { return INVALID_UNIVERSE_OBJECT_TYPE; }
 
 std::string UniverseObject::Dump(unsigned short ntabs) const {
-    auto system = GetSystem(this->SystemID());
+    auto system = Objects().get<System>(this->SystemID());
 
     std::stringstream os;
 
@@ -185,7 +185,7 @@ std::string UniverseObject::Dump(unsigned short ntabs) const {
     } else {
         os << "  at: (" << this->X() << ", " << this->Y() << ")";
         int near_id = GetPathfinder()->NearestSystemTo(this->X(), this->Y());
-        auto near_system = GetSystem(near_id);
+        auto near_system = Objects().get<System>(near_id);
         if (near_system) {
             const std::string& sys_name = near_system->Name();
             if (sys_name.empty())

--- a/universe/ValueRefs.cpp
+++ b/universe/ValueRefs.cpp
@@ -86,7 +86,7 @@ namespace {
                     ErrorLogger() << "FollowReference : Unable to get system for object";
             } else if (property_name == "Fleet") {
                 if (auto s = std::dynamic_pointer_cast<const Ship>(obj)) {
-                    obj = GetFleet(s->FleetID());
+                    obj = Objects().get<Fleet>(s->FleetID());
                 } else {
                     ErrorLogger() << "FollowReference : object not a ship, so can't get its fleet";
                     obj = nullptr;
@@ -155,7 +155,7 @@ namespace {
             } else if (property_name_part == "Fleet") {
                 if (auto s = std::dynamic_pointer_cast<const Ship>(obj))  {
                     retval += "(" + std::to_string(s->FleetID()) + "): ";
-                    obj = GetFleet(s->FleetID());
+                    obj = Objects().get<Fleet>(s->FleetID());
                 } else
                     obj = nullptr;
             }

--- a/universe/ValueRefs.cpp
+++ b/universe/ValueRefs.cpp
@@ -81,7 +81,7 @@ namespace {
                 }
             } else if (property_name == "System") {
                 if (obj)
-                    obj = GetSystem(obj->SystemID());
+                    obj = Objects().get<System>(obj->SystemID());
                 if (!obj)
                     ErrorLogger() << "FollowReference : Unable to get system for object";
             } else if (property_name == "Fleet") {
@@ -150,7 +150,7 @@ namespace {
             } else if (property_name_part == "System") {
                 if (obj) {
                     retval += "(" + std::to_string(obj->SystemID()) + "): ";
-                    obj = GetSystem(obj->SystemID());
+                    obj = Objects().get<System>(obj->SystemID());
                 }
             } else if (property_name_part == "Fleet") {
                 if (auto s = std::dynamic_pointer_cast<const Ship>(obj))  {
@@ -1040,7 +1040,7 @@ int Variable<int>::Eval(const ScriptingContext& context) const
     else if (property_name == "LastTurnBattleHere") {
         if (auto const_system = std::dynamic_pointer_cast<const System>(object))
             return const_system->LastTurnBattleHere();
-        else if (auto system = GetSystem(object->SystemID()))
+        else if (auto system = Objects().get<System>(object->SystemID()))
             return system->LastTurnBattleHere();
         return INVALID_GAME_TURN;
 
@@ -1070,7 +1070,7 @@ int Variable<int>::Eval(const ScriptingContext& context) const
 
     }
     else if (property_name == "Orbit") {
-        if (auto system = GetSystem(object->SystemID()))
+        if (auto system = Objects().get<System>(object->SystemID()))
             return system->OrbitOfPlanet(object->ID());
         return -1;
 

--- a/universe/ValueRefs.cpp
+++ b/universe/ValueRefs.cpp
@@ -74,7 +74,7 @@ namespace {
             std::string property_name = *first;
             if (property_name == "Planet") {
                 if (auto b = std::dynamic_pointer_cast<const Building>(obj)) {
-                    obj = GetPlanet(b->PlanetID());
+                    obj = Objects().get<Planet>(b->PlanetID());
                 } else {
                     ErrorLogger() << "FollowReference : object not a building, so can't get its planet.";
                     obj = nullptr;
@@ -144,7 +144,7 @@ namespace {
             if (property_name_part == "Planet") {
                 if (auto b = std::dynamic_pointer_cast<const Building>(obj)) {
                     retval += "(" + std::to_string(b->PlanetID()) + "): ";
-                    obj = GetPlanet(b->PlanetID());
+                    obj = Objects().get<Planet>(b->PlanetID());
                 } else
                     obj = nullptr;
             } else if (property_name_part == "System") {
@@ -1374,7 +1374,7 @@ PlanetEnvironment ComplexVariable<PlanetEnvironment>::Eval(const ScriptingContex
         int planet_id = INVALID_OBJECT_ID;
         if (m_int_ref1)
             planet_id = m_int_ref1->Eval(context);
-        const auto planet = GetPlanet(planet_id);
+        const auto planet = Objects().get<Planet>(planet_id);
         if (!planet)
             return INVALID_PLANET_ENVIRONMENT;
 

--- a/universe/ValueRefs.cpp
+++ b/universe/ValueRefs.cpp
@@ -2006,7 +2006,7 @@ int ComplexVariable<int>::Eval(const ScriptingContext& context) const
             object_id = m_int_ref1->Eval(context);
         if (object_id == INVALID_OBJECT_ID)
             return 0;
-        auto object = GetUniverseObject(object_id);
+        auto object = Objects().get(object_id);
         if (!object)
             return 0;
 
@@ -2192,14 +2192,14 @@ double ComplexVariable<double>::Eval(const ScriptingContext& context) const
         int object1_id = INVALID_OBJECT_ID;
         if (m_int_ref1)
             object1_id = m_int_ref1->Eval(context);
-        auto obj1 = GetUniverseObject(object1_id);
+        auto obj1 = Objects().get(object1_id);
         if (!obj1)
             return 0.0;
 
         int object2_id = INVALID_OBJECT_ID;
         if (m_int_ref2)
             object2_id = m_int_ref2->Eval(context);
-        auto obj2 = GetUniverseObject(object2_id);
+        auto obj2 = Objects().get(object2_id);
         if (!obj2)
             return 0.0;
 
@@ -2247,7 +2247,7 @@ double ComplexVariable<double>::Eval(const ScriptingContext& context) const
         int object_id = INVALID_OBJECT_ID;
         if (m_int_ref1)
             object_id = m_int_ref1->Eval(context);
-        auto object = GetUniverseObject(object_id);
+        auto object = Objects().get(object_id);
         if (!object)
             return 0.0;
 
@@ -2263,7 +2263,7 @@ double ComplexVariable<double>::Eval(const ScriptingContext& context) const
         int object_id = INVALID_OBJECT_ID;
         if (m_int_ref1)
             object_id = m_int_ref1->Eval(context);
-        auto object = GetUniverseObject(object_id);
+        auto object = Objects().get(object_id);
         if (!object)
             return 0.0;
         auto ship = std::dynamic_pointer_cast<const Ship>(object);
@@ -2949,7 +2949,7 @@ std::string NameLookup::Eval(const ScriptingContext& context) const {
 
     switch (m_lookup_type) {
     case OBJECT_NAME: {
-        auto obj = GetUniverseObject(m_value_ref->Eval(context));
+        auto obj = Objects().get(m_value_ref->Eval(context));
         return obj ? obj->Name() : "";
         break;
     }

--- a/util/AppInterface.h
+++ b/util/AppInterface.h
@@ -129,9 +129,6 @@ inline std::shared_ptr<UniverseObject> GetEmpireKnownObject(int object_id, int e
 inline std::shared_ptr<ResourceCenter> GetEmpireKnownResourceCenter(int object_id, int empire_id)
 { return IApp::GetApp()->EmpireKnownObjects(empire_id).get<ResourceCenter>(object_id); }
 
-inline std::shared_ptr<PopCenter> GetPopCenter(int object_id)
-{ return IApp::GetApp()->GetUniverse().Objects().get<PopCenter>(object_id); }
-
 inline std::shared_ptr<PopCenter> GetEmpireKnownPopCenter(int object_id, int empire_id)
 { return IApp::GetApp()->EmpireKnownObjects(empire_id).get<PopCenter>(object_id); }
 

--- a/util/AppInterface.h
+++ b/util/AppInterface.h
@@ -120,9 +120,6 @@ inline ObjectMap& EmpireKnownObjects(int empire_id)
 { return IApp::GetApp()->EmpireKnownObjects(empire_id); }
 
 /** Accessor for individual objects. */
-inline std::shared_ptr<UniverseObject> GetEmpireKnownObject(int object_id, int empire_id)
-{ return IApp::GetApp()->EmpireKnownObject(object_id, empire_id); }
-
 inline std::shared_ptr<ResourceCenter> GetEmpireKnownResourceCenter(int object_id, int empire_id)
 { return IApp::GetApp()->EmpireKnownObjects(empire_id).get<ResourceCenter>(object_id); }
 

--- a/util/AppInterface.h
+++ b/util/AppInterface.h
@@ -162,9 +162,6 @@ inline std::shared_ptr<Fleet> GetFleet(int object_id)
 inline std::shared_ptr<Fleet> GetEmpireKnownFleet(int object_id, int empire_id)
 { return IApp::GetApp()->EmpireKnownObjects(empire_id).get<Fleet>(object_id); }
 
-inline std::shared_ptr<Building> GetBuilding(int object_id)
-{ return IApp::GetApp()->GetUniverse().Objects().get<Building>(object_id); }
-
 inline std::shared_ptr<Building> GetEmpireKnownBuilding(int object_id, int empire_id)
 { return IApp::GetApp()->EmpireKnownObjects(empire_id).get<Building>(object_id); }
 

--- a/util/AppInterface.h
+++ b/util/AppInterface.h
@@ -138,9 +138,6 @@ inline std::shared_ptr<PopCenter> GetPopCenter(int object_id)
 inline std::shared_ptr<PopCenter> GetEmpireKnownPopCenter(int object_id, int empire_id)
 { return IApp::GetApp()->EmpireKnownObjects(empire_id).get<PopCenter>(object_id); }
 
-inline std::shared_ptr<Planet> GetPlanet(int object_id)
-{ return IApp::GetApp()->GetUniverse().Objects().get<Planet>(object_id); }
-
 inline std::shared_ptr<Planet> GetEmpireKnownPlanet(int object_id, int empire_id)
 { return IApp::GetApp()->EmpireKnownObjects(empire_id).get<Planet>(object_id); }
 

--- a/util/AppInterface.h
+++ b/util/AppInterface.h
@@ -129,9 +129,6 @@ inline std::shared_ptr<PopCenter> GetEmpireKnownPopCenter(int object_id, int emp
 inline std::shared_ptr<Planet> GetEmpireKnownPlanet(int object_id, int empire_id)
 { return IApp::GetApp()->EmpireKnownObjects(empire_id).get<Planet>(object_id); }
 
-inline std::shared_ptr<System> GetEmpireKnownSystem(int object_id, int empire_id)
-{ return IApp::GetApp()->EmpireKnownObjects(empire_id).get<System>(object_id); }
-
 inline std::shared_ptr<Field> GetEmpireKnownField(int object_id, int empire_id)
 { return IApp::GetApp()->EmpireKnownObjects(empire_id).get<Field>(object_id); }
 

--- a/util/AppInterface.h
+++ b/util/AppInterface.h
@@ -119,28 +119,6 @@ inline ObjectMap& Objects()
 inline ObjectMap& EmpireKnownObjects(int empire_id)
 { return IApp::GetApp()->EmpireKnownObjects(empire_id); }
 
-/** Accessor for individual objects. */
-inline std::shared_ptr<ResourceCenter> GetEmpireKnownResourceCenter(int object_id, int empire_id)
-{ return IApp::GetApp()->EmpireKnownObjects(empire_id).get<ResourceCenter>(object_id); }
-
-inline std::shared_ptr<PopCenter> GetEmpireKnownPopCenter(int object_id, int empire_id)
-{ return IApp::GetApp()->EmpireKnownObjects(empire_id).get<PopCenter>(object_id); }
-
-inline std::shared_ptr<Planet> GetEmpireKnownPlanet(int object_id, int empire_id)
-{ return IApp::GetApp()->EmpireKnownObjects(empire_id).get<Planet>(object_id); }
-
-inline std::shared_ptr<Field> GetEmpireKnownField(int object_id, int empire_id)
-{ return IApp::GetApp()->EmpireKnownObjects(empire_id).get<Field>(object_id); }
-
-inline std::shared_ptr<Ship> GetEmpireKnownShip(int object_id, int empire_id)
-{ return IApp::GetApp()->EmpireKnownObjects(empire_id).get<Ship>(object_id); }
-
-inline std::shared_ptr<Fleet> GetEmpireKnownFleet(int object_id, int empire_id)
-{ return IApp::GetApp()->EmpireKnownObjects(empire_id).get<Fleet>(object_id); }
-
-inline std::shared_ptr<Building> GetEmpireKnownBuilding(int object_id, int empire_id)
-{ return IApp::GetApp()->EmpireKnownObjects(empire_id).get<Building>(object_id); }
-
 /** Returns the object name of the universe object. This can be apperant object
  * name, if the application isn't supposed to see the real object name. */
 inline std::string GetVisibleObjectName(std::shared_ptr<const UniverseObject> object)

--- a/util/AppInterface.h
+++ b/util/AppInterface.h
@@ -120,9 +120,6 @@ inline ObjectMap& EmpireKnownObjects(int empire_id)
 { return IApp::GetApp()->EmpireKnownObjects(empire_id); }
 
 /** Accessor for individual objects. */
-inline std::shared_ptr<UniverseObject> GetUniverseObject(int object_id)
-{ return IApp::GetApp()->GetUniverseObject(object_id); }
-
 inline std::shared_ptr<UniverseObject> GetEmpireKnownObject(int object_id, int empire_id)
 { return IApp::GetApp()->EmpireKnownObject(object_id, empire_id); }
 

--- a/util/AppInterface.h
+++ b/util/AppInterface.h
@@ -141,9 +141,6 @@ inline std::shared_ptr<PopCenter> GetEmpireKnownPopCenter(int object_id, int emp
 inline std::shared_ptr<Planet> GetEmpireKnownPlanet(int object_id, int empire_id)
 { return IApp::GetApp()->EmpireKnownObjects(empire_id).get<Planet>(object_id); }
 
-inline std::shared_ptr<System> GetSystem(int object_id)
-{ return IApp::GetApp()->GetUniverse().Objects().get<System>(object_id); }
-
 inline std::shared_ptr<System> GetEmpireKnownSystem(int object_id, int empire_id)
 { return IApp::GetApp()->EmpireKnownObjects(empire_id).get<System>(object_id); }
 

--- a/util/AppInterface.h
+++ b/util/AppInterface.h
@@ -153,9 +153,6 @@ inline std::shared_ptr<Field> GetField(int object_id)
 inline std::shared_ptr<Field> GetEmpireKnownField(int object_id, int empire_id)
 { return IApp::GetApp()->EmpireKnownObjects(empire_id).get<Field>(object_id); }
 
-inline std::shared_ptr<Ship> GetShip(int object_id)
-{ return IApp::GetApp()->GetUniverse().Objects().get<Ship>(object_id); }
-
 inline std::shared_ptr<Ship> GetEmpireKnownShip(int object_id, int empire_id)
 { return IApp::GetApp()->EmpireKnownObjects(empire_id).get<Ship>(object_id); }
 

--- a/util/AppInterface.h
+++ b/util/AppInterface.h
@@ -141,9 +141,6 @@ inline std::shared_ptr<Field> GetEmpireKnownField(int object_id, int empire_id)
 inline std::shared_ptr<Ship> GetEmpireKnownShip(int object_id, int empire_id)
 { return IApp::GetApp()->EmpireKnownObjects(empire_id).get<Ship>(object_id); }
 
-inline std::shared_ptr<Fleet> GetFleet(int object_id)
-{ return IApp::GetApp()->GetUniverse().Objects().get<Fleet>(object_id); }
-
 inline std::shared_ptr<Fleet> GetEmpireKnownFleet(int object_id, int empire_id)
 { return IApp::GetApp()->EmpireKnownObjects(empire_id).get<Fleet>(object_id); }
 

--- a/util/AppInterface.h
+++ b/util/AppInterface.h
@@ -138,9 +138,6 @@ inline std::shared_ptr<Planet> GetEmpireKnownPlanet(int object_id, int empire_id
 inline std::shared_ptr<System> GetEmpireKnownSystem(int object_id, int empire_id)
 { return IApp::GetApp()->EmpireKnownObjects(empire_id).get<System>(object_id); }
 
-inline std::shared_ptr<Field> GetField(int object_id)
-{ return IApp::GetApp()->GetUniverse().Objects().get<Field>(object_id); }
-
 inline std::shared_ptr<Field> GetEmpireKnownField(int object_id, int empire_id)
 { return IApp::GetApp()->EmpireKnownObjects(empire_id).get<Field>(object_id); }
 

--- a/util/AppInterface.h
+++ b/util/AppInterface.h
@@ -126,9 +126,6 @@ inline std::shared_ptr<UniverseObject> GetUniverseObject(int object_id)
 inline std::shared_ptr<UniverseObject> GetEmpireKnownObject(int object_id, int empire_id)
 { return IApp::GetApp()->EmpireKnownObject(object_id, empire_id); }
 
-inline std::shared_ptr<ResourceCenter> GetResourceCenter(int object_id)
-{ return IApp::GetApp()->GetUniverse().Objects().get<ResourceCenter>(object_id); }
-
 inline std::shared_ptr<ResourceCenter> GetEmpireKnownResourceCenter(int object_id, int empire_id)
 { return IApp::GetApp()->EmpireKnownObjects(empire_id).get<ResourceCenter>(object_id); }
 

--- a/util/ModeratorAction.cpp
+++ b/util/ModeratorAction.cpp
@@ -50,7 +50,7 @@ Moderator::SetOwner::SetOwner(int object_id, int new_owner_empire_id) :
 {}
 
 void Moderator::SetOwner::Execute() const {
-    auto obj = GetUniverseObject(m_object_id);
+    auto obj = Objects().get(m_object_id);
     if (!obj) {
         ErrorLogger() << "Moderator::SetOwner::Execute couldn't get object with id: " << m_object_id;
         return;

--- a/util/ModeratorAction.cpp
+++ b/util/ModeratorAction.cpp
@@ -80,12 +80,12 @@ Moderator::AddStarlane::AddStarlane(int system_1_id, int system_2_id) :
 {}
 
 void Moderator::AddStarlane::Execute() const {
-    std::shared_ptr<System> sys1 = GetSystem(m_id_1);
+    auto sys1 = Objects().get<System>(m_id_1);
     if (!sys1) {
         ErrorLogger() << "Moderator::AddStarlane::Execute couldn't get system with id: " << m_id_1;
         return;
     }
-    std::shared_ptr<System> sys2 = GetSystem(m_id_2);
+    auto sys2 = Objects().get<System>(m_id_2);
     if (!sys2) {
         ErrorLogger() << "Moderator::AddStarlane::Execute couldn't get system with id: " << m_id_2;
         return;
@@ -116,12 +116,12 @@ Moderator::RemoveStarlane::RemoveStarlane(int system_1_id, int system_2_id) :
 {}
 
 void Moderator::RemoveStarlane::Execute() const {
-    std::shared_ptr<System> sys1 = GetSystem(m_id_1);
+    auto sys1 = Objects().get<System>(m_id_1);
     if (!sys1) {
         ErrorLogger() << "Moderator::RemoveStarlane::Execute couldn't get system with id: " << m_id_1;
         return;
     }
-    std::shared_ptr<System> sys2 = GetSystem(m_id_2);
+    auto sys2 = Objects().get<System>(m_id_2);
     if (!sys2) {
         ErrorLogger() << "Moderator::RemoveStarlane::Execute couldn't get system with id: " << m_id_2;
         return;
@@ -208,7 +208,7 @@ Moderator::CreatePlanet::CreatePlanet(int system_id, PlanetType planet_type, Pla
 {}
 
 void Moderator::CreatePlanet::Execute() const {
-    std::shared_ptr<System> location = GetSystem(m_system_id);
+    auto location = Objects().get<System>(m_system_id);
     if (!location) {
         ErrorLogger() << "CreatePlanet::Execute couldn't get a System object at which to create the planet";
         return;

--- a/util/Order.cpp
+++ b/util/Order.cpp
@@ -75,7 +75,7 @@ bool RenameOrder::Check(int empire, int object, const std::string& new_name) {
         return false;
     }
 
-    auto obj = GetUniverseObject(object);
+    auto obj = Objects().get(object);
 
     if (!obj) {
         ErrorLogger() << "RenameOrder::Check() : passed an invalid object.";
@@ -104,7 +104,7 @@ void RenameOrder::ExecuteImpl() const {
 
     GetValidatedEmpire();
 
-    auto obj = GetUniverseObject(m_object);
+    auto obj = Objects().get(m_object);
 
     obj->Rename(m_name);
 }
@@ -1176,7 +1176,7 @@ ScrapOrder::ScrapOrder(int empire, int object_id) :
 }
 
 bool ScrapOrder::Check(int empire_id, int object_id) {
-    auto obj = GetUniverseObject(object_id);
+    auto obj = Objects().get(object_id);
 
     if (!obj) {
         ErrorLogger() << "IssueScrapOrder : passed an invalid object_id";
@@ -1292,7 +1292,7 @@ bool GiveObjectToEmpireOrder::Check(int empire_id, int object_id, int recipient_
         return false;
     }
 
-    auto obj = GetUniverseObject(object_id);
+    auto obj = Objects().get(object_id);
     if (!obj) {
         ErrorLogger() << "IssueGiveObjectToEmpireOrder : passed invalid object id";
         return false;

--- a/util/Order.cpp
+++ b/util/Order.cpp
@@ -290,7 +290,7 @@ bool FleetMoveOrder::Check(int empire_id, int fleet_id, int dest_system_id, bool
         return false;
     }
 
-    auto dest_system = GetEmpireKnownSystem(dest_system_id, empire_id);
+    auto dest_system = EmpireKnownObjects(empire_id).get<System>(dest_system_id);
     if (!dest_system) {
         ErrorLogger() << "Empire with id " << empire_id << " ordered fleet to move to system with id " << dest_system_id << " but no such system is known to that empire";
         return false;

--- a/util/Order.cpp
+++ b/util/Order.cpp
@@ -209,14 +209,14 @@ void NewFleetOrder::ExecuteImpl() const {
 
     // new fleet will get same m_arrival_starlane as fleet of the first ship in the list.
     auto first_ship = validated_ships[0];
-    auto first_fleet = GetFleet(first_ship->FleetID());
+    auto first_fleet = Objects().get<Fleet>(first_ship->FleetID());
     if (first_fleet)
         fleet->SetArrivalStarlane(first_fleet->ArrivalStarlane());
 
     std::unordered_set<std::shared_ptr<Fleet>> modified_fleets;
     // remove ships from old fleet(s) and add to new
     for (auto& ship : validated_ships) {
-        if (auto old_fleet = GetFleet(ship->FleetID())) {
+        if (auto old_fleet = Objects().get<Fleet>(ship->FleetID())) {
             modified_fleets.insert(old_fleet);
             old_fleet->RemoveShips({ship->ID()});
         }
@@ -261,7 +261,7 @@ FleetMoveOrder::FleetMoveOrder(int empire_id, int fleet_id, int dest_system_id,
     if (!Check(empire_id, fleet_id, dest_system_id))
         return;
 
-    auto fleet = GetFleet(FleetID());
+    auto fleet = Objects().get<Fleet>(FleetID());
 
     int start_system = fleet->SystemID();
     if (start_system == INVALID_OBJECT_ID)
@@ -279,7 +279,7 @@ FleetMoveOrder::FleetMoveOrder(int empire_id, int fleet_id, int dest_system_id,
 }
 
 bool FleetMoveOrder::Check(int empire_id, int fleet_id, int dest_system_id, bool append) {
-    auto fleet = GetFleet(fleet_id);
+    auto fleet = Objects().get<Fleet>(fleet_id);
     if (!fleet) {
         ErrorLogger() << "Empire with id " << empire_id << " ordered fleet with id " << fleet_id << " to move, but no such fleet exists";
         return false;
@@ -308,7 +308,7 @@ void FleetMoveOrder::ExecuteImpl() const {
     // convert list of ids to list of System
     std::list<int> route_list;
 
-    auto fleet = GetFleet(FleetID());
+    auto fleet = Objects().get<Fleet>(FleetID());
 
     if (m_append && !fleet->TravelRoute().empty()){
         route_list = fleet->TravelRoute();
@@ -349,7 +349,7 @@ FleetTransferOrder::FleetTransferOrder(int empire, int dest_fleet,
 }
 
 bool FleetTransferOrder::Check(int empire_id, int dest_fleet_id, const std::vector<int>& ship_ids) {
-    auto fleet = GetFleet(dest_fleet_id);
+    auto fleet = Objects().get<Fleet>(dest_fleet_id);
     if (!fleet) {
         ErrorLogger() << "Empire attempted to move ships to a nonexistant fleet";
         return false;
@@ -403,7 +403,7 @@ void FleetTransferOrder::ExecuteImpl() const {
         return;
 
     // look up the destination fleet
-    auto target_fleet = GetFleet(DestinationFleet());
+    auto target_fleet = Objects().get<Fleet>(DestinationFleet());
 
     // check that all ships are in the same system
     auto ships = Objects().find<Ship>(m_add_ships);
@@ -413,7 +413,7 @@ void FleetTransferOrder::ExecuteImpl() const {
     // remove from old fleet(s)
     std::set<std::shared_ptr<Fleet>> modified_fleets;
     for (auto& ship : ships) {
-        if (auto source_fleet = GetFleet(ship->FleetID())) {
+        if (auto source_fleet = Objects().get<Fleet>(ship->FleetID())) {
             source_fleet->RemoveShips({ship->ID()});
             modified_fleets.insert(source_fleet);
         }
@@ -464,7 +464,7 @@ bool ColonizeOrder::Check(int empire_id, int ship_id, int planet_id) {
         ErrorLogger() << "ColonizeOrder::Check() : passed an invalid ship_id " << ship_id;
         return false;
     }
-    auto fleet = GetFleet(ship->FleetID());
+    auto fleet = Objects().get<Fleet>(ship->FleetID());
     if (!fleet) {
         ErrorLogger() << "ColonizeOrder::Check() : ship with passed ship_id has invalid fleet_id";
         return false;
@@ -543,7 +543,7 @@ void ColonizeOrder::ExecuteImpl() const {
     planet->SetIsAboutToBeColonized(true);
     ship->SetColonizePlanet(m_planet);
 
-    if (auto fleet = GetFleet(ship->FleetID()))
+    if (auto fleet = Objects().get<Fleet>(ship->FleetID()))
         fleet->StateChangedSignal();
 }
 
@@ -571,7 +571,7 @@ bool ColonizeOrder::UndoImpl() const {
     planet->SetIsAboutToBeColonized(false);
     ship->ClearColonizePlanet();
 
-    if (auto fleet = GetFleet(ship->FleetID()))
+    if (auto fleet = Objects().get<Fleet>(ship->FleetID()))
         fleet->StateChangedSignal();
 
     return true;
@@ -607,7 +607,7 @@ bool InvadeOrder::Check(int empire_id, int ship_id, int planet_id) {
     }
 
     // get fleet of ship
-    auto fleet = GetFleet(ship->FleetID());
+    auto fleet = Objects().get<Fleet>(ship->FleetID());
     if (!fleet) {
         ErrorLogger() << "IssueInvadeOrder : ship with passed ship_id has invalid fleet_id";
         return false;
@@ -673,7 +673,7 @@ void InvadeOrder::ExecuteImpl() const {
     planet->SetIsAboutToBeInvaded(true);
     ship->SetInvadePlanet(m_planet);
 
-    if (auto fleet = GetFleet(ship->FleetID()))
+    if (auto fleet = Objects().get<Fleet>(ship->FleetID()))
         fleet->StateChangedSignal();
 }
 
@@ -697,7 +697,7 @@ bool InvadeOrder::UndoImpl() const {
     planet->SetIsAboutToBeInvaded(false);
     ship->ClearInvadePlanet();
 
-    if (auto fleet = GetFleet(ship->FleetID()))
+    if (auto fleet = Objects().get<Fleet>(ship->FleetID()))
         fleet->StateChangedSignal();
 
     return true;
@@ -781,7 +781,7 @@ void BombardOrder::ExecuteImpl() const {
     planet->SetIsAboutToBeBombarded(true);
     ship->SetBombardPlanet(m_planet);
 
-    if (auto fleet = GetFleet(ship->FleetID()))
+    if (auto fleet = Objects().get<Fleet>(ship->FleetID()))
         fleet->StateChangedSignal();
 }
 
@@ -805,7 +805,7 @@ bool BombardOrder::UndoImpl() const {
     planet->SetIsAboutToBeBombarded(false);
     ship->ClearBombardPlanet();
 
-    if (auto fleet = GetFleet(ship->FleetID()))
+    if (auto fleet = Objects().get<Fleet>(ship->FleetID()))
         fleet->StateChangedSignal();
 
     return true;
@@ -1243,7 +1243,7 @@ AggressiveOrder::AggressiveOrder(int empire, int object_id, bool aggression/* = 
 }
 
 bool AggressiveOrder::Check(int empire_id, int object_id, bool aggression) {
-    auto fleet = GetFleet(object_id);
+    auto fleet = Objects().get<Fleet>(object_id);
     if (!fleet) {
         ErrorLogger() << "IssueAggressionOrder : no fleet with passed id";
         return false;
@@ -1263,7 +1263,7 @@ void AggressiveOrder::ExecuteImpl() const {
     if (!Check(EmpireID(), m_object_id, m_aggression))
         return;
 
-    auto fleet = GetFleet(m_object_id);
+    auto fleet = Objects().get<Fleet>(m_object_id);
 
     fleet->SetAggressive(m_aggression);
 }
@@ -1331,7 +1331,7 @@ void GiveObjectToEmpireOrder::ExecuteImpl() const {
     if (!Check(EmpireID(), m_object_id, m_recipient_empire_id))
         return;
 
-    if (auto fleet = GetFleet(m_object_id))
+    if (auto fleet = Objects().get<Fleet>(m_object_id))
         fleet->SetGiveToEmpire(m_recipient_empire_id);
     else if (auto planet = Objects().get<Planet>(m_object_id))
         planet->SetGiveToEmpire(m_recipient_empire_id);
@@ -1341,7 +1341,7 @@ bool GiveObjectToEmpireOrder::UndoImpl() const {
     GetValidatedEmpire();
     int empire_id = EmpireID();
 
-    if (auto fleet = GetFleet(m_object_id)) {
+    if (auto fleet = Objects().get<Fleet>(m_object_id)) {
         if (fleet->OwnedBy(empire_id)) {
             fleet->ClearGiveToEmpire();
             return true;

--- a/util/Order.cpp
+++ b/util/Order.cpp
@@ -161,7 +161,7 @@ bool NewFleetOrder::Check(int empire, const std::string& fleet_name, const std::
         ErrorLogger() << "Empire attempted to create a new fleet outside a system";
         return false;
     }
-    auto system = GetSystem(system_id);
+    auto system = Objects().get<System>(system_id);
     if (!system) {
         ErrorLogger() << "Empire attempted to create a new fleet in a nonexistant system";
         return false;
@@ -182,7 +182,7 @@ void NewFleetOrder::ExecuteImpl() const {
     auto validated_ships = Objects().find<Ship>(m_ship_ids);
 
     int system_id = validated_ships[0]->SystemID();
-    auto system = GetSystem(system_id);
+    auto system = Objects().get<System>(system_id);
 
     std::shared_ptr<Fleet> fleet;
     if (m_fleet_id == INVALID_OBJECT_ID) {
@@ -238,7 +238,7 @@ void NewFleetOrder::ExecuteImpl() const {
         if (!modified_fleet->Empty())
             modified_fleet->StateChangedSignal();
         else {
-            if (auto modified_fleet_system = GetSystem(modified_fleet->SystemID()))
+            if (auto modified_fleet_system = Objects().get<System>(modified_fleet->SystemID()))
                 modified_fleet_system->Remove(modified_fleet->ID());
 
             GetUniverse().Destroy(modified_fleet->ID());
@@ -438,7 +438,7 @@ void FleetTransferOrder::ExecuteImpl() const {
         if (!modified_fleet->Empty())
             modified_fleet->StateChangedSignal();
         else {
-            if (auto system = GetSystem(modified_fleet->SystemID()))
+            if (auto system = Objects().get<System>(modified_fleet->SystemID()))
                 system->Remove(modified_fleet->ID());
 
             GetUniverse().Destroy(modified_fleet->ID());
@@ -1303,7 +1303,7 @@ bool GiveObjectToEmpireOrder::Check(int empire_id, int object_id, int recipient_
         return false;
     }
 
-    auto system = GetSystem(obj->SystemID());
+    auto system = Objects().get<System>(obj->SystemID());
     if (!system) {
         ErrorLogger() << "IssueGiveObjectToEmpireOrder : couldn't get system of object";
         return false;

--- a/util/Order.cpp
+++ b/util/Order.cpp
@@ -487,7 +487,7 @@ bool ColonizeOrder::Check(int empire_id, int ship_id, int planet_id) {
         return false;
     }
 
-    auto planet = GetPlanet(planet_id);
+    auto planet = Objects().get<Planet>(planet_id);
     float colonist_capacity = ship->ColonyCapacity();
     if (!planet) {
         ErrorLogger() << "ColonizeOrder::Check() : couldn't get planet with id " << planet_id;
@@ -541,7 +541,7 @@ void ColonizeOrder::ExecuteImpl() const {
         return;
 
     auto ship = GetShip(m_ship);
-    auto planet = GetPlanet(m_planet);
+    auto planet = Objects().get<Planet>(m_planet);
 
     planet->SetIsAboutToBeColonized(true);
     ship->SetColonizePlanet(m_planet);
@@ -551,7 +551,7 @@ void ColonizeOrder::ExecuteImpl() const {
 }
 
 bool ColonizeOrder::UndoImpl() const {
-    auto planet = GetPlanet(m_planet);
+    auto planet = Objects().get<Planet>(m_planet);
     if (!planet) {
         ErrorLogger() << "ColonizeOrder::UndoImpl couldn't get planet with id " << m_planet;
         return false;
@@ -622,7 +622,7 @@ bool InvadeOrder::Check(int empire_id, int ship_id, int planet_id) {
         return false;
     }
 
-    auto planet = GetPlanet(planet_id);
+    auto planet = Objects().get<Planet>(planet_id);
     if (!planet) {
         ErrorLogger() << "InvadeOrder::ExecuteImpl couldn't get planet with id " << planet_id;
         return false;
@@ -668,7 +668,7 @@ void InvadeOrder::ExecuteImpl() const {
         return;
 
     auto ship = GetShip(m_ship);
-    auto planet = GetPlanet(m_planet);
+    auto planet = Objects().get<Planet>(m_planet);
 
     // note: multiple ships, from same or different empires, can invade the same planet on the same turn
     DebugLogger() << "InvadeOrder::ExecuteImpl set for ship " << m_ship << " "
@@ -681,7 +681,7 @@ void InvadeOrder::ExecuteImpl() const {
 }
 
 bool InvadeOrder::UndoImpl() const {
-    auto planet = GetPlanet(m_planet);
+    auto planet = Objects().get<Planet>(m_planet);
     if (!planet) {
         ErrorLogger() << "InvadeOrder::UndoImpl couldn't get planet with id " << m_planet;
         return false;
@@ -737,7 +737,7 @@ bool BombardOrder::Check(int empire_id, int ship_id, int planet_id) {
         return false;
     }
 
-    auto planet = GetPlanet(planet_id);
+    auto planet = Objects().get<Planet>(planet_id);
     if (!planet) {
         ErrorLogger() << "BombardOrder::ExecuteImpl couldn't get planet with id " << planet_id;
         return false;
@@ -775,7 +775,7 @@ void BombardOrder::ExecuteImpl() const {
         return;
 
     auto ship = GetShip(m_ship);
-    auto planet = GetPlanet(m_planet);
+    auto planet = Objects().get<Planet>(m_planet);
 
     // note: multiple ships, from same or different empires, can bombard the same planet on the same turn
     DebugLogger() << "BombardOrder::ExecuteImpl set for ship " << m_ship << " "
@@ -789,7 +789,7 @@ void BombardOrder::ExecuteImpl() const {
 }
 
 bool BombardOrder::UndoImpl() const {
-    auto planet = GetPlanet(m_planet);
+    auto planet = Objects().get<Planet>(m_planet);
     if (!planet) {
         ErrorLogger() << "BombardOrder::UndoImpl couldn't get planet with id " << m_planet;
         return false;
@@ -827,7 +827,7 @@ ChangeFocusOrder::ChangeFocusOrder(int empire, int planet, const std::string& fo
 }
 
 bool ChangeFocusOrder::Check(int empire_id, int planet_id, const std::string& focus) {
-    auto planet = GetPlanet(planet_id);
+    auto planet = Objects().get<Planet>(planet_id);
 
     if (!planet) {
         ErrorLogger() << "Illegal planet id specified in change planet focus order.";
@@ -853,7 +853,7 @@ void ChangeFocusOrder::ExecuteImpl() const {
     if (!Check(EmpireID(), m_planet, m_focus))
         return;
 
-    auto planet = GetPlanet(m_planet);
+    auto planet = Objects().get<Planet>(m_planet);
 
     planet->SetFocus(m_focus);
 }
@@ -1336,7 +1336,7 @@ void GiveObjectToEmpireOrder::ExecuteImpl() const {
 
     if (auto fleet = GetFleet(m_object_id))
         fleet->SetGiveToEmpire(m_recipient_empire_id);
-    else if (auto planet = GetPlanet(m_object_id))
+    else if (auto planet = Objects().get<Planet>(m_object_id))
         planet->SetGiveToEmpire(m_recipient_empire_id);
 }
 
@@ -1349,7 +1349,7 @@ bool GiveObjectToEmpireOrder::UndoImpl() const {
             fleet->ClearGiveToEmpire();
             return true;
         }
-    } else if (auto planet = GetPlanet(m_object_id)) {
+    } else if (auto planet = Objects().get<Planet>(m_object_id)) {
         if (planet->OwnedBy(empire_id)) {
             planet->ClearGiveToEmpire();
             return true;

--- a/util/Order.cpp
+++ b/util/Order.cpp
@@ -1209,7 +1209,7 @@ void ScrapOrder::ExecuteImpl() const {
 
     if (auto ship = Objects().get<Ship>(m_object_id)) {
         ship->SetOrderedScrapped(true);
-    } else if (std::shared_ptr<Building> building = GetBuilding(m_object_id)) {
+    } else if (auto building = Objects().get<Building>(m_object_id)) {
         building->SetOrderedScrapped(true);
     }
 }
@@ -1221,7 +1221,7 @@ bool ScrapOrder::UndoImpl() const {
     if (auto ship = Objects().get<Ship>(m_object_id)) {
         if (ship->OwnedBy(empire_id))
             ship->SetOrderedScrapped(false);
-    } else if (auto building = GetBuilding(m_object_id)) {
+    } else if (auto building = Objects().get<Building>(m_object_id)) {
         if (building->OwnedBy(empire_id))
             building->SetOrderedScrapped(false);
     } else {

--- a/util/SitRepEntry.cpp
+++ b/util/SitRepEntry.cpp
@@ -205,7 +205,7 @@ namespace {
 }
 
 SitRepEntry CreateCombatDamagedObjectSitRep(int object_id, int combat_system_id, int empire_id) {
-    auto obj = GetUniverseObject(object_id);
+    auto obj = Objects().get(object_id);
     if (!obj)
         return GenericCombatDamagedObjectSitrep(combat_system_id);
 

--- a/util/SitRepEntry.cpp
+++ b/util/SitRepEntry.cpp
@@ -374,8 +374,7 @@ SitRepEntry CreateFleetArrivedAtDestinationSitRep(int system_id, int fleet_id, i
 
     //bool system_contains_recipient_empire_planets = false;
     //if (const System* system = GetSystem(system_id)) {
-    //    for (int planet_id : system->FindObjectIDs<Planet>()) {
-    //        const Planet* planet = GetPlanet(planet_id);
+    //    for (const auto& planet : system->all<Planet>()) {
     //        if (!planet || planet->Unowned())
     //            continue;
     //        if (planet->OwnedBy(recipient_empire_id)) {

--- a/util/SitRepEntry.cpp
+++ b/util/SitRepEntry.cpp
@@ -373,7 +373,7 @@ SitRepEntry CreateFleetArrivedAtDestinationSitRep(int system_id, int fleet_id, i
     auto fleet = GetFleet(fleet_id);
 
     //bool system_contains_recipient_empire_planets = false;
-    //if (const System* system = GetSystem(system_id)) {
+    //if (const System* system = Objects().get<System>(system_id)) {
     //    for (const auto& planet : system->all<Planet>()) {
     //        if (!planet || planet->Unowned())
     //            continue;

--- a/util/SitRepEntry.cpp
+++ b/util/SitRepEntry.cpp
@@ -370,7 +370,7 @@ SitRepEntry CreatePlanetOutpostedSitRep(int planet_id) {
 }
 
 SitRepEntry CreateFleetArrivedAtDestinationSitRep(int system_id, int fleet_id, int recipient_empire_id) {
-    auto fleet = GetFleet(fleet_id);
+    auto fleet = Objects().get<Fleet>(fleet_id);
 
     //bool system_contains_recipient_empire_planets = false;
     //if (const System* system = Objects().get<System>(system_id)) {

--- a/util/SitRepEntry.cpp
+++ b/util/SitRepEntry.cpp
@@ -408,7 +408,7 @@ SitRepEntry CreateFleetArrivedAtDestinationSitRep(int system_id, int fleet_id, i
             sitrep.AddVariable(VarText::FLEET_ID_TAG,      std::to_string(fleet_id));
             int ship_id = *fleet->ShipIDs().begin();
             sitrep.AddVariable(VarText::SHIP_ID_TAG,       std::to_string(ship_id));
-            if (auto ship = GetShip(ship_id))
+            if (auto ship = Objects().get<Ship>(ship_id))
                 sitrep.AddVariable(VarText::DESIGN_ID_TAG, std::to_string(ship->DesignID()));
             return sitrep;
         } else {
@@ -444,7 +444,7 @@ SitRepEntry CreateFleetArrivedAtDestinationSitRep(int system_id, int fleet_id, i
             sitrep.AddVariable(VarText::EMPIRE_ID_TAG,     std::to_string(fleet->Owner()));
             int ship_id = *fleet->ShipIDs().begin();
             sitrep.AddVariable(VarText::SHIP_ID_TAG,       std::to_string(ship_id));
-            if (auto ship = GetShip(ship_id))
+            if (auto ship = Objects().get<Ship>(ship_id))
                 sitrep.AddVariable(VarText::DESIGN_ID_TAG, std::to_string(ship->DesignID()));
             return sitrep;
         } else {
@@ -471,7 +471,7 @@ SitRepEntry CreateFleetArrivedAtDestinationSitRep(int system_id, int fleet_id, i
             sitrep.AddVariable(VarText::EMPIRE_ID_TAG,     std::to_string(fleet->Owner()));
             int ship_id = *fleet->ShipIDs().begin();
             sitrep.AddVariable(VarText::SHIP_ID_TAG,       std::to_string(ship_id));
-            if (auto ship = GetShip(ship_id))
+            if (auto ship = Objects().get<Ship>(ship_id))
                 sitrep.AddVariable(VarText::DESIGN_ID_TAG, std::to_string(ship->DesignID()));
             return sitrep;
         } else {

--- a/util/SitRepEntry.cpp
+++ b/util/SitRepEntry.cpp
@@ -253,7 +253,7 @@ SitRepEntry CreateCombatDamagedObjectSitRep(int object_id, int combat_system_id,
 }
 
 SitRepEntry CreateCombatDestroyedObjectSitRep(int object_id, int combat_system_id, int empire_id) {
-    auto obj = GetEmpireKnownObject(object_id, empire_id);
+    auto obj = EmpireKnownObjects(empire_id).get(object_id);
     if (!obj) {
         DebugLogger() << "Object " << object_id << " does not exist!!!";
         return GenericCombatDestroyedObjectSitrep(combat_system_id);

--- a/util/VarText.cpp
+++ b/util/VarText.cpp
@@ -60,7 +60,7 @@ namespace {
         } catch (...) {
             return boost::none;
         }
-        auto obj = GetUniverseObject(object_id);
+        auto obj = Objects().get(object_id);
         if (!obj)
             return boost::none;
 


### PR DESCRIPTION
This PR replaces and removes various "convenience" Get* functions and replaces them with the corresponding `ObjectMap::get`, `ObjectMap::find` or `ObjectMap::all` call.  Using a consistent interface prevents misuse (e.g. `GetPlanet` in a for each loop, where `ObjectMap::find<Planet>` would be more consistent) and gives better insight, searchability and comparision capabilities for further API improvements.