### PR TITLE
Prune stale translations

### DIFF
--- a/default/stringtables/cz.txt
+++ b/default/stringtables/cz.txt
@@ -1234,10 +1234,6 @@ METER_POPULATION
 populace
 
 # Meter types
-METER_HEALTH
-zdraví
-
-# Meter types
 METER_INDUSTRY
 průmysl
 

--- a/default/stringtables/cz.txt
+++ b/default/stringtables/cz.txt
@@ -151,9 +151,6 @@ COMMAND_LINE_USAGE
 COMMAND_LINE_DEFAULT
 '''Standardní: '''
 
-OPTIONS_DB_HELP
-Vytisknout tuto nápovědu.
-
 OPTIONS_DB_GENERATE_CONFIG_XML
 Využívá všech nastavení z jakékoli stávající config.xml souboru a ty, uvedené na příkazové řádce vytvořit config.xml souboru. Tím se přepíše stávající soubor config.xml, pokud existuje.
 
@@ -1048,14 +1045,8 @@ SITREP_EMPIRE_ELIMINATED
 ANCIENT_RUINS_SPECIAL
 Starobylé ruiny
 
-ANCIENT_RUINS_SPECIAL_DESCRIPTION
-Tato planeta má na povrchu zříceniny budov vyspělých starověkých ras, které byly zapomenuty v historických knihách.Objevením získáte bonus k výzkumu.
-
 ECCENTRIC_ORBIT_SPECIAL
 Excentrická orbita
-
-ECCENTRIC_ORBIT_SPECIAL_DESC
-Dráha této planety je velmi výstřední. Má velký rozdíl mezi jeho nejbližší a nejdelší vzdálenosti k její hvězdě. Celkové oslunění se výrazně liší v průběhu celého roku. Různé podmínky brzdí rozvoj infrastruktury, ale poskytne prospěšný základ pro výzkum.
 
 MINERALS_SPECIAL
 Bohatá na minerály
@@ -1361,32 +1352,17 @@ Zkoumánním struktury mozku a jeho funkcí jako např. elektrochemické a kvant
 LRN_ALGO_ELEGANCE
 Elegantní algoritmy
 
-LRN_ALGO_ELEGANCE_DESC
-S rostoucí složitostí problémů v analýze dat jsou konvenční algoritmy přetíženy. Od této fáze vývoje je nutné najít jiné algoritmické přístupy a funkce, pro které je nezbytná elegance řešení a také musí být optimalizovány esteticky a metaforicky.
-
 LRN_TRANSLING_THT
 Multinárodní jazyk
-
-LRN_TRANSLING_THT_DESC
-Různí myslitelé se potýkají s pravidly cizího jazyka,který se chtějí naučit, jsou vnímáni průměrně,protože jsou omezeny stanovenými druhy projevu. Výjimečných myslitelé mohou překonat omezení jazyka,myšlení a analýzy na vynikající úrovni. Ale pouze velcí myslitelé zůstávají v izolaci a zbytečné,pokládající si otázku: Jak všem vyjádřit bez adekvátního jazyka záblesky jejich inspirace?
 
 LRN_PSIONICS
 Psionická komunikace
 
-LRN_PSIONICS_DESC
-Díky hlubokému zkoumání nebo umělému vylepšení, může mozek rozvíjet dovednosti, které mu umožní komunikovat přímo bez omezení fyzického těla s okolním vesmírem. Komunikace jako jsou např.:telepatie, empatie, jasnovidectví, předvídání, psychokineze a psychoenergetika mohou nahradit banální biologické nebo technologické alternativy.Avšak vedlejší účinky těchto sil, včetně sebekontroly, změny osobnosti, mohou mít dalekosáhlé důsledky pro vztah mezi takto nadanými a nenadaných organismy.
-
 LRN_ARTIF_MINDS
 Umělá inteligence
 
-LRN_ARTIF_MINDS_DESC
-Zatímco klasické počítače, mají téměř nulovou inteligenci a znají pouze matematický systém, a tak jim chybí důležité vlastnosti, jako jsou sebeuvědomění, vědomí nebo pocit. Vytvořením dokonalé umělé inteligence, lze tyto vlastnosti vytvářet a upravovat. Tato zjištění otevírají nové možnosti v oblasti kognitivních věd a vytváření nových Metaparadigmat.
-
 LRN_XENOARCH
 Xenoarcheologie
-
-LRN_XENOARCH_DESC
-Současná soustava říší, ras a civilizací, nejsou první ani jediní, kteří žili v této galaxii. Památky, zříceniny a zvěsti o starších lidských uskupení se mohou najít na opuštěnch planetách, asteroidech, či zničené lodě plovoucí v prázdném prostoru. Hledáním a dešifrováním těchto informací je poskytnuta příležitost k objevování dávných tajemstvích a možnost poučit se z nich, nebo dokonce varovaní díky starým poznatkům.
 
 LRN_GRAVITONICS
 Graviton

--- a/default/stringtables/de.txt
+++ b/default/stringtables/de.txt
@@ -1281,9 +1281,6 @@ Speichert ob der Vollbildmodus zu den gespeicherten Wert zurückgesetzt werden s
 OPTIONS_DB_DUMP_EFFECTS_GROUPS_DESC
 Entscheidet ob ein Abbild der Effektgruppen in die Beschreibung von Technologien, Gebäuden und Schiffsteilen eingefügt werden.
 
-OPTIONS_DB_VERBOSE_LOGGING_DESC
-Schaltet die ausführliche Protokollierung der Inhalte des Universums und Effektberechnung.
-
 OPTIONS_DB_VERBOSE_SITREP_DESC
 Schaltet das Einfügen der Situationsberichte mit Fehlerausgabe ein.
 
@@ -2113,30 +2110,8 @@ Nachrichten
 MAP_PRODUCTION_TITLE
 Produktion
 
-MAP_PROD_WASTED_TITLE
-Ungenutzte Produktion
-
-# %1% number of production points generated.
-# %2% number of production points currently not used for production.
-MAP_PROD_WASTED_TEXT
-'''Gesamte Produktion : %1%
-Verschwendete Produkt. : %2%
-
-Hier klicken um das Produktionsmenü zu öffnen'''
-
 MAP_RESEARCH_TITLE
 Forschung
-
-MAP_RES_WASTED_TITLE
-Ungenutzte Forschung
-
-# %1% number of research points generated.
-# %2% number of research points currently not used for research.
-MAP_RES_WASTED_TEXT
-'''Gesamte Forschung : %1%
-Verschwendete Forsch. : %2%
-
-Hier klicken um das Forschungsmenü zu öffnen'''
 
 MAP_POPULATION_DISTRIBUTION
 Volkszählung
@@ -2158,12 +2133,6 @@ Handel
 
 MAP_TRADE_TEXT
 Handelsleistung des gesamten Imperiums. (Handel tut nichts)
-
-MAP_FLEET_TITLE
-Flottenstärke
-
-MAP_FLEET_TEXT
-Gesamtanzahl Schiffe
 
 
 ##
@@ -2602,7 +2571,7 @@ Krieg erklären
 PEACE_PROPOSAL
 Friedensangebot
 
-PEACE_PROPOSAL_CANEL
+PEACE_PROPOSAL_CANCEL
 Friedensangebot annullieren
 
 PEACE_ACCEPT
@@ -2824,12 +2793,6 @@ Neuen Entwurfsnamen eingeben:
 DESIGN_INVALID
 Ungültiger Entwurf
 
-DESIGN_OBSOLETE
-Veralteter Entwurf
-
-DESIGN_WND_ADD
-Neuen Entwurf hinzufügen
-
 
 ##
 ## Statistics
@@ -3041,9 +3004,6 @@ CATEGORY_GUIDES
 
 CATEGORY_GAME_CONCEPTS
 *Spielkonzepte*
-
-CATEGORY_USER_INTERFACE
-*Benutzeroberfläche*
 
 GROWTH_ARTICLE_SHORT_DESC
 Wachstum
@@ -4515,10 +4475,6 @@ METER_TARGET_POPULATION
 Ziel Bevölkerung
 
 # Meter types
-METER_TARGET_HEALTH
-Ziel Gesundheit
-
-# Meter types
 METER_TARGET_INDUSTRY
 Ziel Industrie
 
@@ -4559,24 +4515,12 @@ METER_MAX_TROOPS
 Max Truppen
 
 # Meter types
-METER_MAX_REBEL_TROOPS
-Max Rebellen Truppen
-
-# Meter types
 METER_MAX_SUPPLY
 Max Versorgung
 
 # Meter types
 METER_POPULATION
 Bevölkerung
-
-# Meter types
-METER_HEALTH
-Gesundheit
-
-# Meter types
-METER_GROWTH
-Wachstum
 
 # Meter types
 METER_INDUSTRY
@@ -4812,9 +4756,6 @@ Sternenklasse
 #DESC_VAR_TARGETPOPULATION
 #[[METER_TARGET_POPULATION]]
 
-#DESC_VAR_TARGETHEALTH
-#[[METER_TARGET_HEALTH]]
-
 #DESC_VAR_TARGETINDUSTRY
 #[[METER_TARGET_INDUSTRY]]
 
@@ -4850,9 +4791,6 @@ Sternenklasse
 
 #DESC_VAR_POPULATION
 #[[METER_POPULATION]]
-
-#DESC_VAR_HEALTH
-#[[METER_HEALTH]]
 
 #DESC_VAR_INDUSTRY
 #[[METER_INDUSTRY]]
@@ -8795,12 +8733,6 @@ Empfang der Nachricht bestätigt.
 
 OPTIONS_PAGE_HOTKEYS
 Tastaturkürzel
-
-HOTKEYS_Z_COMBAT
-Kampffenster
-
-HOTKEYS_MAP
-Kartenfenster
 
 HOTKEYS_GENERAL
 Allgemeine Kürzel

--- a/default/stringtables/de.txt
+++ b/default/stringtables/de.txt
@@ -891,9 +891,6 @@ COMMAND_LINE_USAGE
 COMMAND_LINE_DEFAULT
 '''Standard: '''
 
-OPTIONS_DB_HELP
-Diese Hilfemeldung ausgeben.
-
 OPTIONS_DB_GENERATE_CONFIG_XML
 Übernimmt die Standardeinstellungen, die Einstellungen einer bestehenden config.xml Datei und jene aus der Kommandozeile um eine config.xml Datei zu erzeugen. Dies überschreibt die momentane config.xml Datei, falls vorhanden.
 
@@ -1210,21 +1207,6 @@ OPTIONS_DB_GAMESETUP_PLANET_DENSITY
 '''Anzahl der Planeten je System, die in der Galaxie erzeugt werden soll.
 '''
 
-OPTIONS_DB_GAMESETUP_STARLANE_FREQUENCY
-Anzahl der Sternstraßen, die in der Galaxie erzeugt werden sollen.
-
-OPTIONS_DB_GAMESETUP_SPECIALS_FREQUENCY
-Wie häufig Besonderheiten in der Galaxie auftreten sollen.
-
-OPTIONS_DB_GAMESETUP_MONSTER_FREQUENCY
-Wie häufig Monster in der Galaxie auftreten sollen.
-
-OPTIONS_DB_GAMESETUP_NATIVE_FREQUENCY
-Wie häufig Eingeborene in der Galaxie auftreten sollen.
-
-OPTIONS_DB_GAMESETUP_AI_MAX_AGGRESSION
-Die maximale Aggressionsstufe für KI Gegner.
-
 OPTIONS_DB_GAMESETUP_EMPIRE_NAME
 Der Name Ihres Imperiums.
 
@@ -1238,9 +1220,6 @@ OPTIONS_DB_GAMESETUP_STARTING_SPECIES_NAME
 '''Die Spezies mit der in Ihrem Imperium gestartet wird.
 
 Es hat keine Wirkung auf Planeten Ihres Imperiums die durch andere Spezies Kolonisiert worden sind.'''
-
-OPTIONS_DB_GAMESETUP_NUM_AI_PLAYERS
-Die Anzahl KI Gegner im Spiel.
 
 OPTIONS_DB_UI_TECH_LAYOUT_HORZ_SPACING
 Horizontaler Abstand zwischen Technologien im Technologiebildschirm, gemessen in Vielfachen der Breite einer einzelnen Theorie Technologie.
@@ -2675,9 +2654,6 @@ RESEARCH_QUEUE_EMPIRE
 RESEARCH_INFO_RP
 FP
 
-RESEARCH_QUEUE_PROMPT
-Klicke doppelt oder mit Shift auf ein verfügbares Objekt um es zur Forschungswarteschlange hinzufügen.
-
 
 ##
 ## Build selector window
@@ -3046,17 +3022,11 @@ Handel
 METER_CONSTRUCTION_VALUE_LABEL
 Infrastruktur
 
-METER_CONSTRUCTION_VALUE_DESC
-Die Bezeichnung Infrastruktur bezieht sich auf sämtliche Netzwerke, die einen kolonialisierten Planeten betreffen: Energie, Transport, Telekommunikation und soziale Einrichtungen für die Bewohner.
-
 METER_HAPPINESS_VALUE_LABEL
 Zufriedenheit
 
 METER_FUEL_VALUE_LABEL
 Treibstoff
-
-METER_FUEL_VALUE_DESC
-Treibstoff erlaubt Schiffe entlang der Sternstraßen zu reisen. Für jede Sternstraße verbraucht ein Schiff 1 Einheit Treibstoff. Treibstoff wird bei keiner anderen Aktion verbraucht. Die [[metertype METER_SUPPLY]] tanken ein Schiff vollständig auf. Wenn ein Schiff jenseits einer verbündeten Sternstraße reist, wird der Treibstoff langsam wiederhergestellt, sobald sich das Schiff nicht mehr auf einer Sternstraße befindet.
 
 METER_SHIELD_VALUE_LABEL
 Schild
@@ -3084,21 +3054,8 @@ Die Truppenstärke auf einem Planeten spiegelt die Schlagkraft der dort stationi
 METER_DETECTION_VALUE_LABEL
 Erkennungsreichweite
 
-METER_DETECTION_VALUE_DESC
-'''Die Erkennungsreichweite sagt aus, wie weit die Sensoren reichen. Ein Imperium kann nur Objekte erkennen, deren  [[metertype METER_STEALTH]] kleiner oder gleich der [[encyclopedia DETECTION_TITLE]] sind und innerhalb der Erkennungsreichweite eines eigenen Raumschiffes oder Planeten liegt.
-
-Raumschiffe und Planeten haben einen Erkennungsreichweitenanzeiger. Es gibt im Optionsmenü die Möglichkeit, die Erkennungsreichweite für die Galaxiekarte anzuzeigen oder auszublenden.'''
-
 METER_STEALTH_VALUE_LABEL
 Tarnung
-
-METER_DETECTION_STRENGTH_VALUE_LABEL
-Erkennung Stärke
-
-METER_DETECTION_STRENGTH_VALUE_DESC
-'''Der Begriff Erkennung Stärke stellt das technologische Niveau der Sensoren eines Imperiums dar. Ein Imperium kann nur Objekte sehen, die einen [[metertype METER_STEALTH]]s-Wert haben, der kleiner oder gleich groß ist, wie die, seiner eigenen Erkennung Stärke und sich innerhalb der [[metertype METER_DETECTION]] eines Raumschiffes oder Planeten befindet.
-
-Imperien haben eines Erkennungsstärke Mass.'''
 
 PEACE_TITLE
 Frieden
@@ -3138,16 +3095,6 @@ Roboterspezies sind intelligente Maschinen. Die maximale Bevölkerung dieser Spe
 
 PHOTOTROPHIC_SPECIES_TITLE
 Phototropher Stoffwechsel
-
-PHOTOTROPHIC_SPECIES_TEXT
-'''Phototrophe Spezies leben hauptsächlich oder vollständig von Sonnelicht. Die maximalen Bevölkerungen dieser Spezies sind stark beeinflusst von der Helligkeit des Sternes im jeweiligen System - umso heller, desto besser. Es gibt keine speziellen Wachstumsboni.
-
-Population changes:
-Blue Star: Tiny +3 , Small +6 , Medium +9 , Large +12 , Huge +15.
-White Star: Tiny +1.5 , Small +3 , Medium +4.5 , Large +6 , Huge +7.5.
-Yellow Star, Orange Star: No changes.
-Red Star, Neutron Star: Tiny -1 , Small -2 , Medium -3 , Large -4 , Huge -5.
-Black Hole, No Star: Tiny -10 , Small -20 , Medium -30 , Large -40 , Huge -50.'''
 
 TELEPATHIC_TITLE
 Telepathie
@@ -3736,137 +3683,11 @@ Bevorzugt erdähnliche Planeten.
 [[encyclopedia ORGANIC_SPECIES_TITLE]]
 '''
 
-#SP_SCYLIOR
-#Scylior
-
-SP_SCYLIOR_GAMEPLAY_DESC
-'''Besitzt drei Tentakel, aquatischer Nautilus.
-Bevorzugt ozeanische Planeten.
-[[encyclopedia ORGANIC_SPECIES_TITLE]]
-'''
-
-#SP_GYSACHE
-#Gysache
-
-#SP_CHATO
-#Chato
-
-#SP_TRITH
-#Trith
-
-#SP_HAPPY
-#Happybirthday
-
-#SP_HHHOH
-#Hhhoh
-
-#SP_EAXAW
-#Eaxaw
-
-#SP_DERTHREAN
-#Derthrean
-
-#SP_LAENFA
-#Laenfa
-
-#SP_TAEGHIRUS
-#Tae Ghirus
-
-#SP_MUURSH
-#Mu Ursh
-
-#SP_GEORGE
-#George
-
-#SP_CRAY
-#Cray
-
-#SP_ETTY
-#Etty
-
-#SP_CYNOS
-#Cynos
-
-#SP_PHINNERT
-#Phinnert
-
-#SP_EGASSEM
-#Egassem
-
-#SP_SSLITH
-#Sslith
-
-#SP_FIFTYSEVEN
-#Fifty-seven
-
-#SP_SETINON
-#Setinon
-
-#SP_NYMNMN
-#Nymnmn
-
-#SP_TRENCHERS
-#Trenchers
-
-#SP_RAAAGH
-#Raaagh
-
-#SP_BEIGEGOO
-#Beige Goo
-
-#SP_SILEXIAN
-#Silexian
-
-#SP_KOBUNTURA
-#Kobuntura
-
-#SP_UGMORS
-#Ugmors
-
-#SP_GISGUFGTHRIM
-#Gis Guf Gthrim
-
-#SP_HIDDENGARDENER
-#Hidden Gardener
-
-#SP_ABADDONI
-#Abaddoni
-
-#SP_ACIREMA
-#Acirema
-
-#SP_OURBOOLS
-#Ourbools
-
 SP_OURBOOLS_GAMEPLAY_DESC
 '''Riesige Blinde Schwimmer die, die Schwerkraft "sehen" können.
 Bevorzugt ozeanische Planeten.
 [[encyclopedia ORGANIC_SPECIES_TITLE]]
 '''
-
-#SP_VOLP
-#Volp-Uglush
-
-#SP_FURTHEST
-#Furthest
-
-#SP_BANFORO
-#Banforo
-
-#SP_KILANDOW
-#Kilandow
-
-#SP_MISIORLA
-#Misiorla
-
-#SP_EXOBOT
-#Exobot
-
-#SP_EXPERIMENTOR
-#Experimentor
-
-#SP_SUPER_TEST
-#Super Testers
 
 
 ##
@@ -4016,11 +3837,6 @@ Dafür ermöglicht diese Anomalie aber auch das Durchführen von Experimenten, d
 RESONANT_MOON_SPECIAL
 Resonanzmond
 
-RESONANT_MOON_SPECIAL_DESC
-'''Erhöht [[metertype METER_STEALTH]] von Gebäuden auf diesem Planeten und von eigenen Schiffen in diesem System um 10.
-
-Dieser Planet hat einen natürlichen Satelliten, dessen Umlaufzeit genauso lang ist, wie seine Rotationsperiode. Daher hat der Mond eine "dunkle Seite", die dem Planeten stets abgewandt ist und sich hervorragend für Geheimanlagen eignet. Der Bereich zwischen Mond und Planet ist zudem ein gutes Versteck für Gebäude und Flotten.  
-
 COMPUTRONIUM_SPECIAL
 Computroniummond
 
@@ -4031,11 +3847,6 @@ Der Mond dieses Planeten ist in Wirklichkeit ein von einer verschwundenen Zivili
 
 HONEYCOMB_SPECIAL
 Honigwabe
-
-HONEYCOMB_SPECIAL_DESC
-'''Solange dieser Planet auf [[metertype METER_INDUSTRY]] fokussiert ist, erhalten alle via [[metertype METER_SUPPLY]] verbundenen Planeten, die auf [[METER_INDUSTRY]] fokussiert sind, 0,5 [[metertype METER_TARGET_INDUSTRY]] pro [[metertype METER_POPULATION]].
-
-Die Honigwabe ist ein Planet, der von den Erbauern vor langer Zeit zu einem Lager umfunktioniert wurde. Nahezu alle Planeten in den umliegenden Systemen wurden vollständig abgebaut und ihre Bestandteile lagern nun getrennt sortiert in gigantischen Röhren in der Planetenkruste. Der Bestand reicht von seltenen und wertvollen Elementen über schwer herstellbare Moleküle bis hin zu einer Vielzahl an Energiequellen. Die Absicht hinter dieser Ansammlung ist unklar, ebenso wie der Grund, warum sie nie zum Einsatz kam.
 
 PHILOSOPHER_SPECIAL
 Philosophenplanet
@@ -4079,11 +3890,6 @@ Tief unter der eisigen Kruste dieses Planeten liegt ein prähistorischer weißer
 
 HEAD_ON_A_SPIKE_SPECIAL
 Kopf auf einem Pfahl
-
-HEAD_ON_A_SPIKE_SPECIAL_DESC
-'''Der Kopf des einstmaligen Imperators ruht aufgespießt für alle sichtbar und erfüllt die Herzen aller Feinde mit Furcht.
-
-Schiffe anderer Imperien innerhalb von 100uu, ob feindlich oder nicht, verlieren leicht an [[metertype METER_SHIELD]], [[metertype METER_STRUCTURE]] und Waffenstärke.'''
 
 HEAD_ON_A_SPIKE_SPECIAL_EFFECT
 Angsterfüllt
@@ -5420,9 +5226,6 @@ Was ist ein Gott? Befasst sich ein Gott damit, ob er sich moralisch und wohlwoll
 GRO_PLANET_ECOL
 Planetare Ökologie
 
-GRO_PLANET_ECOL_DESC
-Agrikultureller und medizinischer Fortschritt kann die Bevölkerungssterblichkeit drastisch reduzieren; daraufhin entwickelt sich ein zeitlich begrenztes hyperexponentielles Wachstum. Schliesslich ergeben sich durch die Flächenkapazität des Planeten und das Netzwerk des Lebens, das er versorgen muss, neue Grenzen für das Wachstum. Das Verständnis der natürlichen Ökologie und ihrer Reaktion auf Belastungen hilft dabei, sie zu erhalten, damit auch künftige Generationen ihre Vorzüge ausschöpfen können.
-
 GRO_GENETIC_ENG
 Gentechnik
 
@@ -5444,23 +5247,11 @@ Traditionelle Gentherapie verändert den genetischen Kode und bringt ihn dann in
 GRO_LIFECYCLE_MAN
 Lebenszyklus Manipulation
 
-GRO_LIFECYCLE_MAN_DESC
-'''Through chemical manipulation and cryonics, life processes may be halted without terminating them permanently. Beings in this state are preserved indefinitely, consume no resources and require very little storage - not living - space. With this technique, the capacity of colony ships can be greatly increased.
-
-Die meisten komplexen Organismen durchschreiten während ihres Lebens physiologische Stadien, manchmal abgegrenzt durch Metamorphose oder auch kaum wahrnehmlich durch einen langsamen Altersprozess. In vielen Fällen sind eines oder mehrere dieser Stadien, zumindest zu einer gewissen Zeit, nützlicher und wünschenswerter als andere. Durch exakte Kontrolle hormonaler und mentaler Mechanismen wird es möglich, Lebensstadien drastisch zu verkürzen oder herauszuzögern, wodurch in einem Bruchteil des natürlichen Zeitrahmens voll entwickelte Individuen geschaffen werden können und die existierenden Individuen ihre Funktionalität niemals einbüßen und so praktisch unsterblich werden.'''
-
 GRO_ADV_ECOMAN
 Fortgeschrittene Ökomanipulation
 
 GRO_XENO_GENETICS
 Xenogenetik
-
-GRO_XENO_GENETICS_DESC
-'''Erhöht die maximale Bevölkerung von Planeten des Typs [[PE_ADEQUATE]] & [[PE_POOR]], abhängig von deren Größe; [[SZ_TINY]]: +2, [[SZ_SMALL]]: +4, [[SZ_MEDIUM]]: +6, [[SZ_LARGE]]: +8, [[SZ_HUGE]]: +10, sowie Planeten des Typs [[PE_HOSTILE]]; [[SZ_TINY]]: +1, [[SZ_SMALL]]: +2, [[SZ_MEDIUM]]: +3, [[SZ_LARGE]]: +4, [[SZ_HUGE]]: +5.
-
-The study of other life forms often exemplifies the weaknesses inherent in one's own species. By studying other life forms and using that knowledge to improve upon one's own genetic code, it is possible to develop many useful adaptations that would be otherwise impossible.
-
-Der frühen Genetik sind durch die natürlich vorhandenen Organismen Grenzen gesetzt, da die Methoden der Gentechnik ausschliesslich auf ihnen basieren. Darüber hinaus ist die Genetik durch die physikalischen Mechanismen des genetischen Kodes wie seine Unterbringung, Veränderung und Ausdruck in erwachsenen Individuen limitiert. Durch den Vergleich sich entsprechender Systeme in unterschiedlichen Ökosystemen und ihren Organismen sind weitreichende Erkenntnisse möglich, die zu neuen Entwicklungen in den altbekannten genetischen Systemen Ansporn geben.'''
 
 GRO_NANOTECH_MED
 Nanomedizin
@@ -5472,13 +5263,6 @@ Während genetische Modifikationen die Effekte unerwünschter oder schädlicher 
 
 GRO_XENO_HYBRIDS
 Xenohybridisierung
-
-GRO_XENO_HYBRIDS_DESC
-'''Erhöht die Maximale Bevölkerung von Planeten des Typs [[PE_POOR]], abhängig von deren Größe; [[SZ_TINY]]: +1, [[SZ_SMALL]]: +2, [[SZ_MEDIUM]]: +3, [[SZ_LARGE]]: +4, [[SZ_HUGE]]: +5, sowie Planeten des Typs [[PE_HOSTILE]]; [[SZ_TINY]]: +2, [[SZ_SMALL]]: +4, [[SZ_MEDIUM]]: +6, [[SZ_LARGE]]: +8, [[SZ_HUGE]]: +10.
-
-Often, the native fauna of a planet are far better suited to a planet's environment than any colonists who would try to inhabit it. These adverse effects can include anything from weather patterns to the planet's size. Through xenological hybridization, a genetically adapted form of the colonizing species can be developed with the advantageous traits of the native fauna, thus allowing more of the planet to be inhabited.
-
-Ganz gleich, wie umfassend das Verständnis für ein biologisches System ist oder wie geschickt es verbessert wurde, es wird immer durch sein innewohnendes Wesen eingeschränkt. Strukturen und grundlegende Physiologie können nur in den Grenzen der Biologie eines einzelnen Planeten verändert werden. Durch das Verständnis fremder Biologie können unterschiedliche Systeme vereint werden und so eine völlig neue hybride Biologie geschaffen werden, die bessere Fähigkeiten als ihre einzelnen Ursprünge besitzt.'''
 
 GRO_NANO_CYBERNET
 Nanokybernetik
@@ -5561,13 +5345,6 @@ Mit zunehmender Automatisierung in der Produktion wird die Maschinerie fähig, s
 
 PRO_NDIM_ASSMB
 N-Dimensionale Montage
-
-PRO_NDIM_ASSMB_DESC
-''' Unlocks the Hyperspatial Dam
-
-Once the greatest fear of N-dimensional physicists, now the noblest goal. To deliberately create a hyperspatial rift between our universe and the next, but inside a dimensional bubble, safely separate from known space-time. Once this is accomplished, it would be a relatively simple matter to tap into the enormous flow of energy that would travel across the rift.
-
-Die Geometrie des physikalischen Raums hat schon immer die Montage von Objekten in diesem Raum behindert. Objekte können sich nicht am gleichen Ort befinden und Volumen nicht gleichzeitig offen und geschlossen vorliegen, wenn sich ihre Existenz auf drei Dimensionen beschränkt. Mit dem Überschreiten dieser Grenzen können störende Objektteile in Taschendimensionen und somit aus dem Weg gefaltet werden; kontinuierliche Linien können an Massen vorbeigeleitet werden, indem man "von der Achse" abweicht. Ähnliche Methoden werden auch angewandt, um niederdimensionale Objekte in Konfigurationen zu arrangieren, die ohne höherdimensionale Montagewege unmöglich wären.'''
 
 PRO_SINGULAR_GEN
 Singularitätskonstruktion
@@ -5668,13 +5445,6 @@ Erhöht die Bevölkerungskapazität auf allen bewohnbaren Planeten, abhängig vo
 
 CON_NDIM_STRC
 N-Dimensionale Gebäude
-
-CON_NDIM_STRC_DESC
-'''Erhöht die Bevölkerungskapazität auf allen bewohnbaren Planeten, abhängig von deren Größe; [[SZ_TINY]]: +2, [[SZ_SMALL]]: +4, [[SZ_MEDIUM]]: +6, [[SZ_LARGE]]: +8, [[SZ_HUGE]]: +10.
-
-The primary limiting factors on a planets population capacity are environmental desirability and space. By phasing basic infrastructure development into multiple dimensions, spatial limitations are all but eliminated, and under ideal environmental conditions, the maximum population of a planet can be greatly increased.
-
-Von allen bizzaren Kunststücken der angewandten Physik hat die Fähigkeit, den Raum in sich selbst zu falten, den direktesten und tiefgreifendsten Einfluss auf die Form und das Design von Gebäuden. Das Potential ist endlos, und das wortwörtlich: Flure biegen sich zurück an ihren Beginn oder werden so verdreht, dass ihre Decke der Boden wird. Darüber hinaus löst sich das Konzept des Städtewachstums in Wohlgefallen auf, da eine beliebige Anzahl Personen in einem willkürlich kleinen Volumen sicher in einer angrenzenden Existenzebene untergebracht werden können.'''
 
 SHP_GAL_EXPLO
 Galaktische Erkundung
@@ -5803,17 +5573,6 @@ Bioterroranlage
 GRO_BIOTERROR_DESC
 Ein Forschungszentrum erschaffen, um sicher die gefährlichsten Biologischen Waffen zu entwickeln, versteckt vor neugierigen Augen. Biologische Waffen wirken zu langsam um in einem offenen miliärischen Konflikt wirksam zu sein, als Terrorwaffe sind sie unerreicht, eine langsam wachsende Kontamination verbreitet Angst und Schrecken. Bilder von verzweifelten Personen, in Quarantäne gehalten durch ihre eigene Regierung, säen Verzweiflung jenseits der betroffenen Gebiete. Jedoch müssen größte Sicherheitsmaßnahmen eingehalten werden, wenn man solche Organismen entwickelt, um sicherzustellen, dass sie nicht versehentlich freigesetzt werden. Außerdem ist strikte Geheimhaltung notwendig, um nicht zu riskieren, dass diplomatische Beziehungen mit anderen Imperien und zur eigenen Bevölkerung leiden.
 
-#GRO_CYBORG
-#Cyborgs
-
-GRO_CYBORG_DESC
-'''Erhöht die Maximale Bevölkerung von Planeten des Typs [[PE_HOSTILE]], abhängig von deren Größe; [[SZ_TINY]]: +2, [[SZ_SMALL]]: +4, [[SZ_MEDIUM]]: +6, [[SZ_LARGE]]: +8, [[SZ_HUGE]]: +10.
-
-A highly versatile fusion of organism and machine, capable of adapting to a tremendous variety of circumstances. Spontaneous generation of specialized organs and mechanically enhanced strength permit cyborgs to exist with ease in nearly any environment.'''
-
-#GRO_GAIA_TRANS
-#Gaia Transformation
-
 LRN_OBSERVATORY_I
 Observatorium
 
@@ -5827,11 +5586,6 @@ Der Durchschnittsbürger verschwendet wortwörtlich sein Hirn, das eine der best
 
 LRN_STELLAR_TOMOGRAPHY
 Stellartomographie
-
-LRN_STELLAR_TOMOGRAPHY_DESC
-'''Increases target [[metertype METER_RESEARCH]] on planets with the Research focus per Population by 1, 0.75, 0.5, or 0.2 in systems with Black Hole stars, Neutron stars, Blue or white stars, and Yellow, Orange or Red stars, respectively.
-
-Ein Netzwerk spezialisierter Satelliten kann mit tomographischen Methoden die Vorgänge im Inneren eines Sterns rekonstruieren. Diese schwer herzustellenden Bedingungen, besonders die in exotischen Sterntypen, sind für diverse Forschungsprojekte ideal.'''
 
 LRN_ENCLAVE_VOID
 Enklave der Leere
@@ -6270,11 +6024,6 @@ Orbitale Produktionsanlage für den Bau interstellarer militärischer Raumschiff
 BLD_SHIPYARD_ORBITAL_DRYDOCK
 Orbitales Trockendock
 
-BLD_SHIPYARD_ORBITAL_DRYDOCK_DESC
-'''Dies ist eine Aufrüstung für [[buildingtype BLD_SHIPYARD_BASE]]en. Sie wird für die Herstellung aller größeren Schiffsrümpfe sowie für weitere Werftaufrüstungen benötigt. Diese Aufrüstung kann außerdem die [[metertype METER_STRUCTURE]] beschädigter Schiffe reparieren.
-
-Beim Bau eines großen interstellaren Fahrzeuges ist es unpraktisch, die schweren Bauteile per Weltraumlift zu befördern. Weitaus praktischer ist es, die Bauteile zum Zusammenbau im Orbit vor Ort zu konstruieren, um sich den Transport von der Planetenoberfläche zu ersparen.'''
-
 BLD_SHIPYARD_CON_NANOROBO
 Nanobot-Verarbeitungseinheit
 
@@ -6403,15 +6152,6 @@ Zum Entwerfen universell verwendbarer Werkzeuge ist ein Verständis der physisch
 
 Ein Imperium kann auf bis zu sechs Planeten Akademien unterhalten. Jede Akademie benötigt eine zufriedene [[metertype METER_POPULATION]] einer anderen Spezies und muss mindestens drei Sternstraßensprünge von den anderen Akademien entfernt sein.'''
 
-#BLD_MEGALITH
-#Megalith
-
-BLD_MEGALITH_DESC
-'''Kann nur auf der Heimatwelt des Imperiums mit [[buildingtype BLD_IMPERIAL_PALACE]] errichtet werden. Wenn vorhanden, erreichen alle Ressourcenmeter auf dem Planeten ihre Zielwerte in nur einem Zug.
-Erhöht [[metertype METER_TARGET_CONSTRUCTION]] um 30. Erhöht [[metertype METER_SUPPLY]] auf allen Planeten im Imperium um 1. Erhöht [[metertype METER_TROOPS]] aller bevölkerter Planeten innerhalb von 2 Sternstraßensprüngen um 10.
-
-Ein außergewöhnlich großer Sternenkratzer mit einem Durchmesser von mehreren Kilometern. Eine Inspiration für Architekten im gesamten Imperium.'''
-
 BLD_SPACE_ELEVATOR
 Weltraumlift
 
@@ -6483,19 +6223,6 @@ Erschafft einen [[fieldtype FLD_SUBSPACE_RIFT]] mit 100uu Radius um das Gebäude
 BLD_HYPER_DAM
 Hyperspatialdamm
 
-BLD_HYPER_DAM_DESC
-'''Energieversorgung für über [[metertype METER_SUPPLY]] verbundene Planeten mit Industriefokus, aber ohne Zugriff auf einen [[buildingtype BLD_BLACK_HOLE_POW_GEN]]. Erhöht [[metertype METER_TARGET_INDUSTRY]] auf solchen Planeten um 1 pro [[metertype METER_POPULATION]], aber reduziert [[metertype METER_TARGET_POPULATION]] entsprechend der Planetengröße:
-• ([[SZ_TINY]] -1)
-• ([[SZ_SMALL]] -2)
-• ([[SZ_MEDIUM]] -3)
-• ([[SZ_LARGE]] -4)
-• ([[SZ_HUGE]] -5)
-[[NO_STACK_SUPPLY_CONNECTION_TEXT]]
-
-Ein kontrollierter Riss in der Struktur des Universums, genutzt als Energiequelle. Jeder Planet unterhält eigene Dämme, während ein einzelnes Kontrollzentrum dafür sorgt, dass das Zeit-Raum-Kontinuum unter der Belastung nicht zusammenbricht. Der Einsatz eines Dammes hat für die Bevölkerung gesundheitliche Folgen, außer in Systemen mit einem [[STAR_BLACK]].
-
-Dieses Gebäude hat keinen Nutzen für Planeten, die mit einem [[buildingtype BLD_BLACK_HOLE_POW_GEN]] verbunden sind, stellt aber eine Alternative dar, falls ein solcher nicht gebaut werden kann.'''
-
 BLD_SOL_ACCEL
 Solarbeschleuniger
 
@@ -6516,16 +6243,6 @@ Ein elektrischer Generator in niedriger Umlaufbahn, welcher aus der Sonne, die e
 
 BLD_CLONING_CENTER
 Kloncenter
-
-BLD_CLONING_CENTER_DESC
-'''Erhöht [[metertype METER_TARGET_POPULATION]] auf allen Planeten entsprechend ihrer Größe:
-• ([[SZ_TINY]] +1)
-• ([[SZ_SMALL]] +2)
-• ([[SZ_MEDIUM]] +3)
-• ([[SZ_LARGE]] +4)
-• ([[SZ_HUGE]] +5)
-
-Das [[tech GRO_INDUSTRY_CLONE]] ermöglicht die industrielle Anfertigung ganzer Völker und schafft so neue Bewohner für das Imperium.'''
 
 BLD_TERRAFORM
 Terraformation
@@ -6554,20 +6271,8 @@ Entfernt ein [[encyclopedia KRAKEN_NEST_SPECIAL]], [[encyclopedia SNOWFLAKE_NEST
 BLD_NEUTRONIUM_EXTRACTOR
 Neutroniumextrahierer
 
-BLD_NEUTRONIUM_EXTRACTOR_DESC
-'''Gewährt dem Imperium Zugriff auf Neutronium, welches einer [[buildingtype BLD_NEUTRONIUM_FORGE]] die Herstellung von Schiffsbauteilen wie der [[shippart AR_NEUTRONIUM_PLATE]] ermöglicht.
-[[BUILDING_AVAILABLE_ON_OUTPOSTS]].
-
-Um aus Neutronium Bauteile herzustellen, muss es erst aus [[STAR_NEUTRON]]en extrahiert werden. Das gewonnene Neutronium wird anschließend zu [[BLD_NEUTRONIUM_FORGE]]n verfrachtet.'''
-
 BLD_NEUTRONIUM_FORGE
 Neutroniumschmiede
-
-BLD_NEUTRONIUM_FORGE_DESC
-'''Dies ist eine Aufrüstung für [[buildingtype BLD_SHIPYARD_BASE]]en. Sie wird für die Herstellung von Schiffen mit Neutroniumbauteilen benötigt.
-
-Die industrielle Verarbeitung von Neutronium ist nur in hochspezialisierten Anlagen möglich, welche auf [[encyclopedia OUTPOSTS_TITLE]] nicht errichtet werden können.
-[[MACRO_NEUTRONIUM_BUILDINGS]]'''
 
 BLD_NEUTRONIUM_SYNTH
 Neutroniumsynthesierer
@@ -6631,10 +6336,6 @@ Wandelt einen Asteroidengürtel oder Gasriesen in einen künstlichen Planeten um
 BLD_ART_PARADISE_PLANET
 Künstliche Paradieswelt
 
-BLD_ART_PARADISE_PLANET_DESC
-'''Wandelt einen Asteroidengürtel oder Gasriesen in einen künstlichen Planeten um. Aus [[PT_ASTEROIDS]] werden [[SZ_TINY]]e [[PT_BARREN]]e Planeten und aus [[PT_GASGIANT]]n werden [[SZ_HUGE]]e [[PT_BARREN]]e Planeten. Der Planet erhält zudem die [[special GAIA_SPECIAL]]-Besonderheit, welche den Planeten schrittweise umwandelt, bis er perfekt zu seinen Bewohnern passt.
-[[ARTIFICIAL_PLANET_PROCESS_LOCATION]]'''
-
 BLD_ART_MOON
 Künstlicher Mond
 
@@ -6650,9 +6351,6 @@ Solarverjüngerer
 
 BLD_SOL_REJUV_DESC
 Versorgt einen Stern mit zusätzlichem Brennstoff, um ihn künstlich zu verjüngern. Der Stern wird um eine Stufe jünger, gemäß der folgenden Reihenfolge: [[STAR_RED]], [[STAR_ORANGE]], [[STAR_YELLOW]], [[STAR_WHITE]], [[STAR_BLUE]]. Dieser Prozess kann auch von einem [[encyclopedia OUTPOSTS_TITLE]] aus durchgeführt werden.
-
-BLD_TRANSFORMER_DESC
-Ein vielseitiges, extrem teures Gebäude, dass den Effekt anderer Gebäude replizieren kann. Wird aktiviert, indem ein entsprechender Fokus gewählt wird. Kann den Effekt der Gebäudetypen [[buildingtype BLD_BIOTERROR_PROJECTOR]], [[buildingtype BLD_STARGATE]], [[buildingtype BLD_PLANET_DRIVE]] und [[buildingtype BLD_SPATIAL_DISTORT_GEN]] nachahmen, sofern die entsprechende Technologie bereits verfügbar ist.
 
 BLD_PLANET_CLOAK
 Planetares Tarngerät
@@ -6678,11 +6376,6 @@ Um das Tor zu nutzen, muss der Fokus des Startplaneten auf [[FOCUS_STARGATE_SEND
 
 BLD_GAS_GIANT_GEN
 Gasriesengenerator
-
-BLD_GAS_GIANT_GEN_DESC
-'''Kann nur auf [[PT_GASGIANT]]n errichtet werden und gewährt 10 [[metertype METER_TARGET_INDUSTRY]] an alle Planeten mit Industriefokus im selben System. Weitere [[BLD_GAS_GIANT_GEN]]en im selben System haben keinen Effekt.
-
-Ein Stromgenerator, der aus [[PT_GASGIANT]]en Energie gewinnt.'''
 
 BLD_STARLANE_BORE
 Sternstraßenbohrer
@@ -7034,34 +6727,14 @@ SR_WEAPON_0_1_DESC
 SR_WEAPON_1_1
 Massenkatapult
 
-SR_WEAPON_1_1_DESC
-'''Die Grundbewaffnung für Kriegsschiffe. Weitere Erforschung der Waffentechnik erhöht den verursachten [[encyclopedia DAMAGE_TITLE]].
-
-[[SR_WEAPON_1_1]]e verursachen 1 Punkt zusätzlichen [[encyclopedia DAMAGE_TITLE]] für jeden Level in der Pilotenfähigkeit der Spezies, die sie konstruiert hat (-1 Schaden für schlechte Piloten).'''
-
 SR_WEAPON_2_1
 Laserwaffe
-
-SR_WEAPON_2_1_DESC
-'''Eine leistungsfähigere Schiffswaffe als das Massenkatapult. Weitere Erforschung der Waffentechnik erhöht den verursachten [[encyclopedia DAMAGE_TITLE]].
-
-[[SR_WEAPON_2_1]]n verursachen 2 Punkte zusätzlichen [[DAMAGE_TITLE]] für jeden Level in der Pilotenfähigkeit der Spezies, die sie konstruiert hat (-2 Schaden für schlechte Piloten). Auf Schiffen mit [[shiphull SH_ORGANIC]] kann ein [[shippart SP_SOLAR_CONCENTRATOR]] den [[DAMAGE_TITLE]] ebenfalls steigern.'''
 
 SR_WEAPON_3_1
 Plasmakanone
 
-SR_WEAPON_3_1_DESC
-'''Eine leistungsfähigere Schiffswaffe als der Laser. Weitere Erforschung der Waffentechnik erhöht den verursachten [[encyclopedia DAMAGE_TITLE]].
-
-[[SR_WEAPON_3_1]]n verursachen 3 Punkte zusätzlichen [[encyclopedia DAMAGE_TITLE]] für jeden Level in der Pilotenfähigkeit der Spezies, die sie konstruiert hat (-3 Schaden für schlechte Piloten).'''
-
 SR_WEAPON_4_1
 Todesstrahl
-
-SR_WEAPON_4_1_DESC
-'''Eine leistungsfähigere Schiffswaffe als die Plasmakanone. Weitere Erforschung der Waffentechnik erhöht den verursachten [[encyclopedia DAMAGE_TITLE]].
-
-[[SR_WEAPON_4_1]]en verursachen 5 Punkte zusätzlichen [[encyclopedia DAMAGE_TITLE]] für jeden Level in der Pilotenfähigkeit der Spezies, die sie konstruiert hat (-5 Schaden für schlechte Piloten).'''
 
 SR_SPINAL_ANTIMATTER
 Antimateriekanone
@@ -7395,11 +7068,6 @@ SH_MULTISPEC_DESC
 SH_ROBOTIC_INTERFACE_SHIELDS
 Robotikinterface: Schild
 
-SH_ROBOTIC_INTERFACE_SHIELDS_DESC
-'''Verleiht [[metertype METER_SHIELD]] für jedes Schiff mit [[SH_ROBOTIC_INTERFACE_SHIELDS]] vor Ort. Jedes zusätzliche Schiff verleiht einen geringeren Bonus, der höchstmögliche Wert beträgt 20. Kann nur in Schiffen mit [[encyclopedia HULL_LINE_ROBOTIC]] und [[encyclopedia ROBOTIC_SPECIES_TITLE]]-Besatzung genutzt werden.
-
-Robotische Spezies sind in der Lage, sich zu einem Netzwerk zu verbinden und dadurch ihre Rechenleistung drastisch zu erhöhen. [[SH_ROBOTIC_INTERFACE_SHIELDS]] nutzt dieses Netzwerk, um die Flugbahn eintreffender Geschosse zu berechnen und durch gezieltes Fokussieren des Schutzschildes abzuwehren.'''
-
 CO_COLONY_POD
 Besiedlungsmodul
 
@@ -7514,10 +7182,6 @@ Eine mächtige negative Energie-Waffe [[SHIP_WEAPON_QUICKLY_REDUCE]] [[ENEMY_PLA
 
 SP_CHAOS_WAVE
 Chaoswelle
-
-SP_CHAOS_WAVE_DESC
-'''Eine mächtige Waffe [[SHIP_WEAPON_QUICKLY_REDUCE]] [[ENEMY_PLANET_ANY_POP]].
-WARNUNG: Entfernt auch die [[special GAIA_SPECIAL]]-Besonderheit, falls vorhanden.'''
 
 SP_NOVA_BOMB
 Novabombe
@@ -7831,47 +7495,11 @@ Mit wenigen externen Steckplätzen ist dieser Rumpf für die Frontlinie ungeeign
 SH_ENDOSYMBIOTIC
 Endosymbiotischer Rumpf
 
-SH_ENDOSYMBIOTIC_DESC
-'''Dieser lebende einzellige Rumpf steht mit seiner Besatzung in einer symbiotischen Beziehung. Die Besatzung lebt im Zellplasma und fungiert als Organellen. Der Rumpf hat vier externe und drei interne Steckplätze.
-Organisches Wachstum: Startet mit 5 [[metertype METER_STRUCTURE]], aber wächst um 15 [[metertype METER_STRUCTURE]] über 30 Züge.
-
-[[metertype METER_STEALTH]] ist hoch, [[metertype METER_DETECTION]] ist hoch und [[metertype METER_SPEED]] ist hoch.
-
-[[LIVING_HULL_AUTO_REGEN]]
-
-Eignet sich hervorragend als Kriegsschiff, Aufklärer oder Plünderer.
-
-[[BLD_SHIPYARD_BASE_ORG_ORB_INC_ORG_XENO_FAC_ORG_CELL_GRO_CHAMB_REQUIRED]]'''
-
 SH_RAVENOUS
 Gefräßiger Rumpf
 
-SH_RAVENOUS_DESC
-'''Dieser nichtlebende organische Rumpf - oder 'Zombie'-Rumpf - wurde aus dem Blut und Fleisch seiner Brüder gebaut. Er hat fünf externe und zwei interne Steckplätze.
-Organisches Wachstum: Startet mit 5 [[metertype METER_STRUCTURE]], aber wächst um 20 [[metertype METER_STRUCTURE]] über 40 Züge.
-
-[[metertype METER_STEALTH]] ist durchschnittlich, [[metertype METER_DETECTION]] ist sehr hoch und [[metertype METER_SPEED]] ist hoch.
-
-Hat großes Potential als schnelles, mächtiges Kriegsschiff.
-
-Dieser Rumpf erhält keinen Bonus auf die Regeneration von [[metertype METER_STRUCTURE]] oder [[metertype METER_FUEL]].
-
-[[BLD_SHIPYARD_BASE_ORG_ORB_INC_ORG_XENO_FAC_REQUIRED]]'''
-
 SH_BIOADAPTIVE
 Bio-Adaptiver Rumpf
-
-SH_BIOADAPTIVE_DESC
-'''Ein lebender Rumpf mit Körper und Geist in Einklang, Meister der Heilung und Ausdauer. Er hat drei externe und drei interne Steckplätze.
-Organisches Wachstum: Startet mit 15 [[metertype METER_STRUCTURE]], aber wächst um 25 [[metertype METER_STRUCTURE]] über 50 Züge.
-
-[[metertype METER_STEALTH]] ist sehr hoch, [[metertype METER_DETECTION]] ist sehr hoch und [[metertype METER_SPEED]] ist hoch.
-
-Hat großes Potential als getarntes Kriegsschiff, Aufklärer oder Plünderer.
-
-Dieser lebende Rumpf regeneriert außerhalb von Kämpfen und Blockaden mit jedem Zug [[metertype METER_STRUCTURE]] gleich ihrem derzeitigen Wert. Ein Schiff mit mindestens halber Struktur ist so in nur einem Zug vollkommen repariert. Außerdem regeneriert der Rumpf mit jeden Zug 0,2 [[metertype METER_FUEL]].
-
-[[BLD_SHIPYARD_BASE_ORG_ORB_INC_ORG_CELL_GRO_CHAMB_REQUIRED]]'''
 
 SH_SENTIENT
 Empfindungsfähiger Rumpf
@@ -7979,9 +7607,6 @@ SH_XENTRONIUM_DESC
 
 SH_COLONY_BASE
 Siedler-Basisrumpf
-
-SH_COLONY_BASE_DESC
-Konzipiert zum Gründen einer Siedlung auf einem anderen Planeten im selben System. Kann sein System nicht verlassen oder sich schnell im System bewegen und hat nur einen internen Steckplatz.
 
 SH_FLOATER_BODY
 Schwimmerkörper

--- a/default/stringtables/de.txt
+++ b/default/stringtables/de.txt
@@ -6651,9 +6651,6 @@ Solarverjüngerer
 BLD_SOL_REJUV_DESC
 Versorgt einen Stern mit zusätzlichem Brennstoff, um ihn künstlich zu verjüngern. Der Stern wird um eine Stufe jünger, gemäß der folgenden Reihenfolge: [[STAR_RED]], [[STAR_ORANGE]], [[STAR_YELLOW]], [[STAR_WHITE]], [[STAR_BLUE]]. Dieser Prozess kann auch von einem [[encyclopedia OUTPOSTS_TITLE]] aus durchgeführt werden.
 
-BLD_TRANSFORMER
-Transformer
-
 BLD_TRANSFORMER_DESC
 Ein vielseitiges, extrem teures Gebäude, dass den Effekt anderer Gebäude replizieren kann. Wird aktiviert, indem ein entsprechender Fokus gewählt wird. Kann den Effekt der Gebäudetypen [[buildingtype BLD_BIOTERROR_PROJECTOR]], [[buildingtype BLD_STARGATE]], [[buildingtype BLD_PLANET_DRIVE]] und [[buildingtype BLD_SPATIAL_DISTORT_GEN]] nachahmen, sofern die entsprechende Technologie bereits verfügbar ist.
 
@@ -6927,15 +6924,6 @@ BLD_COL_SUPER_TEST_DESC
 ## Hull and ship part description templates
 ##
 
-# %1% hull base starlane speed.
-# %2% hull base fuel capacity.
-# %3% hull base starlane speed.
-# %4% hull base structure value.
-HULL_DESC
-'''[[metertype METER_SPEED]]: %1%
-[[metertype METER_FUEL]]: %2%
-[[metertype METER_STRUCTURE]]: %4%'''
-
 # %1% ship part capacity (fuel, troops, colonists, fighters).
 PART_DESC_CAPACITY
 Fassungsvermögen: %1%
@@ -6947,10 +6935,6 @@ Stärke: %1%
 # %1% ship part strength (shield).
 PART_DESC_SHIELD_STRENGTH
 Schildstärke: %1%
-
-# %1% ship part strength (detection).
-PART_DESC_DETECTION
-[[metertype METER_DETECTION]]: %1%
 
 # %1% ship part damage done (direct fire weapons).
 # %2% number of shots done per attack.

--- a/default/stringtables/es.txt
+++ b/default/stringtables/es.txt
@@ -107,9 +107,6 @@ Corbeta I
 SD_SMALL_MARK1_DESC
 Pequeña y barata nave con catapulta electromagnéticap.
 
-SD_SMALL_MARK2_DESC
-Pequeña y barata nave con catapulta electromagnéticap.
-
 SD_MARK_1
 Fragata I
 
@@ -1933,10 +1930,6 @@ METER_TARGET_POPULATION
 Población Objetivo
 
 # Meter types
-METER_TARGET_HEALTH
-Salud Objetivo
-
-# Meter types
 METER_TARGET_INDUSTRY
 Indústria Objetivo
 
@@ -1971,10 +1964,6 @@ Defensa Máxima
 # Meter types
 METER_POPULATION
 Población
-
-# Meter types
-METER_HEALTH
-Salud
 
 # Meter types
 METER_INDUSTRY

--- a/default/stringtables/es.txt
+++ b/default/stringtables/es.txt
@@ -172,11 +172,6 @@ Flota de Batalla
 ## Status update messages
 ##
 
-SERVER_WONT_START
-'''El servidor no ha podido ser lanzado.
-
-Nota para usuarios de GNU/Linux: Se supone que el ejecutable del servidor esta en el directorio de trabajo.  Si freeorion fue ejecutado desde otro lugar que no fuese el directorio donde se encuentra el binario, necesitaras salir y reiniciar desde ese directorio.'''
-
 SERVER_TIMEOUT
 El servidor no responde
 
@@ -211,9 +206,6 @@ Uso:
 
 COMMAND_LINE_DEFAULT
 Por defecto:
-
-OPTIONS_DB_HELP
-Imprime este mensaje de ayuda.
 
 OPTIONS_DB_GENERATE_CONFIG_XML
 Usa todas las configuraciones a partir de cualquier fichero config.xml existente y las que se den por la terminal, para generar un fichero config.xml. Esto sobreescribe el actual config.xml, si existe.
@@ -482,24 +474,6 @@ Establece el tamaño de los planetas mas pequeños en el panel lateral.
 OPTIONS_DB_UI_SIDEPANEL_PLANET_SHOWN
 Establece si se muestran renderizados o no los planetas, asteroides en el panel lateral.
 
-OPTIONS_DB_GAMESETUP_STARS
-Número de estrellas en la galaxia generadas.
-
-OPTIONS_DB_GAMESETUP_GALAXY_SHAPE
-La forma de la galaxia que se generará.
-
-OPTIONS_DB_GAMESETUP_GALAXY_AGE
-La edad de la galaxia que se generará.
-
-OPTIONS_DB_GAMESETUP_PLANET_DENSITY
-El número de planetas por sistema que sera generado.
-
-OPTIONS_DB_GAMESETUP_STARLANE_FREQUENCY
-El número de líneas estelares en la galaxia para ser generado.
-
-OPTIONS_DB_GAMESETUP_SPECIALS_FREQUENCY
-La frecuencia de especiales que aparecen en la galaxia para ser generados.
-
 OPTIONS_DB_GAMESETUP_EMPIRE_NAME
 El nombre usado en juego por tu imperio.
 
@@ -508,12 +482,6 @@ El nombre usado en el juego para representar al jugador en el modo solitario.
 
 OPTIONS_DB_GAMESETUP_EMPIRE_COLOR
 El color usado en juego por tu imperio.
-
-OPTIONS_DB_GAMESETUP_STARTING_SPECIES_NAME
-La especie en tu mundo origen al inicio del juego.
-
-OPTIONS_DB_GAMESETUP_NUM_AI_PLAYERS
-El número de oponentes IA que jugaran la partida.
 
 OPTIONS_DB_UI_TECH_LAYOUT_HORZ_SPACING
 El espaciado horizontal a ser introducido entre tecnologías en el árbol tecnológico, en múltiplos del ancho de una sola teoría tecnológica.
@@ -1686,36 +1654,16 @@ El imperio %empire% ha sido eliminado.
 ## Species
 ##
 
-SP_GYSACHE
-GYSACHE
-
-SP_GYSACHE_DESC
-Cobardes Herbivoros.
-
-SP_TRITH_DESC
-Desconsolados xenófobos telépatas.
-
 
 ##
 ## Specials
 ##
 
-GAIA_SPECIAL_DESC
-'''Este planeta ha sido esencialmente transformado en un organismo viviente, permitiendo que cambie y se adapte para suplir las necesidades de su población.
-
-Dobla la agricultura objetivo del planeta, salud y población.'''
-
 ANCIENT_RUINS_DEPLETED_SPECIAL
 Ruinas Antiguas
 
-ANCIENT_RUINS_DEPLETED_SPECIAL_DESC
-Este planeta guarda las ruinas de una antigua raza avanzada, que han sido olvidados en los libros de historia, triplicando la investigación en el planeta e incrementado la investigación en mundos enfocados a través del imperio por 1/20, no acumulable.
-
 ANCIENT_RUINS_SPECIAL
 Ruinas Antiguas
-
-ANCIENT_RUINS_SPECIAL_DESCRIPTION
-En este planeta se encuentran las ruinas de una antigua raza, que han sido olvidadas en los libros de historia. Proporcionan bonificación a la investigación.
 
 ECCENTRIC_ORBIT_SPECIAL
 Órbita Excéntrica
@@ -1727,9 +1675,6 @@ La distancia de suministro desde este planeta se reduce en 1, pero la investigac
 
 RESONANT_MOON_SPECIAL
 Luna Resonante
-
-RESONANT_MOON_SPECIAL_DESC
-Este planeta tiene un satelite natural, cuyo periodo orbital esta en resonancia 1:1 con su periodo rotacional, causando un lado oscuro permanente que no se ve desde el planeta.  Este lado oscuro es perfecto para emplazar infraestructuras clandestinas.
 
 MINERALS_SPECIAL
 Rico en Minerales
@@ -2457,32 +2402,17 @@ Las estructuras y funciones del cerebro son determinadas. La electroquímica y n
 LRN_ALGO_ELEGANCE
 Algoritmia elegante
 
-LRN_ALGO_ELEGANCE_DESC
-Con cada vez mayor dificultad para el análisis de datos, las medidas tradicionales de la eficiencia de los algoritmos se volvieron inútiles debido a la irreductible complejidad. En ese punto, otras mediciones de las formas y funciones de los algoritmos cobran significado, estética y metafóricamente, la elegancia de la solución debe ser optimizada.
-
 LRN_TRANSLING_THT
 Pensamiento Translingüístico
-
-LRN_TRANSLING_THT_DESC
-Las mentes inferiores luchan, o aceptan los limites del lenguaje que han aprendido. Las mentes adecuadas se limitan y se sienten obligadas por los conceptos que les han dado para expresarse. Las autenticas mentes superiores superan libremente los limites del lenguaje, formando y analizando pensamientos que rondan lo trascendental. Pero si las grandes mentes son aisladas y futiles, sin un lenguaje con el que expresar sus pensamientos, no podrán compartir su interior.
 
 LRN_PSIONICS
 Psiónicos
 
-LRN_PSIONICS_DESC
-Mediante introspección o mejoras artificiales, el cerebro puede desarrollar habilidades para interactuar directamente con el universo que lo rodea, sobrepasando las limitaciones de un cuerpo físico. Poderes como la telepatía, empatía, clarividencia, pre-ciencia, telequinesis y psicoenergias reemplazan o superan a la biología mundana o a las tecnologías alternativas. Las aplicaciones de estos poderes, incluyendo el control mental, alteración personal y posesión tiene profundas implicaciones para las relaciones entre personas con y sin talento.
-
 LRN_ARTIF_MINDS
 Mentes Artificiales
 
-LRN_ARTIF_MINDS_DESC
-Mientras que las computadores tradicionales tienen una inteligencia insondable y habilidades de computo, se echa en falta las cualidades esenciales de supervivencia, consciencia o sensibilidad. Con el desarrollo de verdaderas mentes artificiales, esas cantidades pueden ser sintetizadas, modificadas y alteradas. Estas investigaciones abren nuevas posibilidades para la investigación en ciencias cognitivas y nuevos metaparadigmas.
-
 LRN_XENOARCH
 Xenoarqueología
-
-LRN_XENOARCH_DESC
-Los imperios contemporáneos, razas y civilizaciones no son los primeros o únicos seres que han vivido en la galaxia. Restos, ruinas y rumores de los ancianos pueden ser encontrados en los planetas desérticos y asteroides sin vida, o viajando por el espacio. Encontrarlos y descifrarlos tiene un gran potencial para revelar secretos, enseñar lecciones, o avisar sobre peligros del conocimiento antiguo.
 
 LRN_GRAVITONICS
 Gravitónicos
@@ -2498,9 +2428,6 @@ Tiempo atrás, teorías sencillas, describían subelementos de las cuatro fuerza
 
 LRN_FORCE_FIELD
 Campos de Fuerza Armónicos
-
-LRN_FORCE_FIELD_DESC
-Como el análisis del sonido, electromagnetismo, fuertes y débiles fuerzas pueden ser expresadas como superposiciones armónicas cuánticas de onda estática de partículas de fuerza-carga. Amplificando selectivamente estos armónicos, las fuerzas pueden ser controladas arbitrariamente para escudos, ataques, control o soporte.
 
 LRN_MIND_VOID
 Mente del Vacío
@@ -2523,14 +2450,8 @@ Anteriores teóricos de supercuerdas hablan de 10, 11 ó 26 universos dimensiona
 LRN_UNIF_CONC
 Conciencia Unificada
 
-LRN_UNIF_CONC_DESC
-La comunicación telepática entre individuos o interfaces mente-máquina solo permite lo mas básico, intercambios triviales y superficiales de pensamientos e ideas.  Mentes verdaderamente unidas funcionan como una única consciencia, con las habilidades y conocimiento sumadas de las partes que los constituyen y actuando como una entidad única.  Esto tiene un enorme potencial, pero también implica riesgos, en que la unión no puede buscar su propia destrucción, que es necesario para las mentes originales para ser recuperadas.  Alternativamente, una de las mentes puede dominar a las demás, controlando o destruyendo las otras, no formando una unión armoniosa equivalente.
-
 LRN_QUANT_NET
 Red Cuántica
-
-LRN_QUANT_NET_DESC
-Cada particula esta conectada inextricablemente en el nivel cuantico de cada particula con la que previamente ha interactuado.  Viejas ideas mecánicas sobre la causa y el efecto no se aplican en este nivel y las particulas pueden “comunicarse” instantaneamente a través de grandes distancias.  Cuando una completa comprensión de este fenomeno es adquirido, acciones selectivas a pequeña escala a una distancia entre dos puntos cualquiera puede conseguirse instantaneamente y los límites de velocidad relativistas no se aplican en la tranferencia de información.
 
 LRN_TRANSCEND
 Transcendencia de Singularidad
@@ -2540,9 +2461,6 @@ LRN_TRANSCEND_DESC
 
 GRO_PLANET_ECOL
 Ecología Planetaria
-
-GRO_PLANET_ECOL_DESC
-La agricultura y la ciencia médica pueden incrementar drasticamente la supervivencia, causando que el crecimiento de la población sea hiperexponencial por un tiempo.  A veces, nuevos límites para crecer surgen de la capacidad de almacenamiento de un planeta, y el ecosistema que lo soporta.  Comprendiendo la ecología natural y su interacción a extremos permite al sistema ser sostenido, y sus beneficios cosechados por las generaciones futuras.
 
 GRO_GENETIC_ENG
 Ingeniería Genética
@@ -2565,26 +2483,14 @@ La ingeniería tradicional genética altera códigos genéticos e implementa o a
 GRO_LIFECYCLE_MAN
 Manipulación del Ciclo de Vida
 
-GRO_LIFECYCLE_MAN_DESC
-La mayoría de organismos complejos progresan a través de estados psicológicos durante su vida, claramente separados por metamorfosis o por el envejecimiento.  En muchos casos, uno o mas de estos estados son, al menos en un tiempo dado, mas útiles y deseables que otros.  Con un delicado control hormonal o mecanismos mentales, es posible acelerar o frenar cada estado, permitiendo producir individuos desarrollados y funcionales en una fracción del tiempo natural, convirtiendolos efectivamente en inmortales.
-
 GRO_XENO_GENETICS
 Geneticas Xenológicas
-
-GRO_XENO_GENETICS_DESC
-Anteriores estudios genéticos se veían limitados por las muestras de organismos naturales disponibles en los que basar sus modificaciones.  Así mismo, estas modificaciones están restringidas en los limites de los mecanismos físicos del código genético guardado o la alteración y expresión en individuos desarrollados.  Investigando los sistemas equivalentes en ecosistemas totalmente diferentes y organismos, grandes visiones o revelaciones pueden ocurrir, estimulando nuevos desarrollos en mas sistemas familiares genéticos.
 
 GRO_NANOTECH_MED
 Medicina Nanotecnológica
 
-GRO_NANOTECH_MED_DESC
-Mientras que las alteraciones genéticas pueden reparar o deshacer los efectos de mutaciones no deseadas o para corregir desajustes bioquímicos, tratar mayores traumas físicos y defectos congénitos no genéticos requiere medidas correctivas físicas.  La nanotecnología puede ser usada para cumplir esas tareas, con dos ventajas importantes:  La corrección se puede llevar a cabo sin cirugía invasiva o riesgos secundarios asociados y el tiempo de reacción para el tratamiento se ve enormemente reducido, ya que las herramientas para hacer el trabajo están siempre en su sitio y listas para funcionar.
-
 GRO_XENO_HYBRIDS
 Hybridación Xenológica
-
-GRO_XENO_HYBRIDS_DESC
-Independientemente de lo bien que se comprenda una habilidad mejorada, un sistema biológico esta limitado por su naturaleza inherente.  Las estructuras y la psicología básica solo pueden ser alteradas en los confines biológicos de un solo planeta.  Con la compresión de otras biologias, los dispares sistemas pueden ser fusionados, formando una biología híbrida, con habilidades potenciales y mayores rasgos que los de cualquiera de sus partes.
 
 GRO_NANO_CYBERNET
 Cibernética Nanotecnológica
@@ -2601,31 +2507,14 @@ La sensibilidad tal y como la conocemos siempre ha sido vista como inextricablem
 GRO_ENERGY_META
 Metabolismo de Pura Energía
 
-GRO_ENERGY_META_DESC
-El último estado de desarrollo físico es transcender a todo lo físico.  Sin cuerpo, los individuos y la sociedad pueden moverse, crecer y existir libremente, sin obstáculos por culpa de innecesarios limites físicos y procesos metabólicos ineficientes que gastan la energía que soporta la homeostasis.
-
 PRO_MICROGRAV_MAN
 Manufactura Microgravitacional
-
-PRO_MICROGRAV_MAN_DESC
-La micro-gravedad de planeta de órbita baja ofrece un gran potencial para nuevos diseños de instalaciones de manufactura, equipamiento y técnicas imposibles en la superficie de los planetas.  Los sólidos pueden ser mantenidos en su sitio con un soporte mínimo.  Líquidos y gases flotan libres, cambiando de forma solo por la tensión de la superficie, a menos que se manipulen.  El equipamiento de la fábricas puede ser organizado en 3 dimensiones.  Estas condiciones permiten grandes incrementos en la eficiencia y la productividad, si son explotados adecuadamente.
 
 PRO_ROBOTIC_PROD
 Producción Robótica
 
-PRO_ROBOTIC_PROD_DESC
-A pesar de diseños iniciales e instalaciones de alto nivel, la puesta en marcha todavía requiere de supervisión activa.  La supresión de los operadores en los procesos actuales de producción, elimina muchos problemas.  Los robots trabajan continuamente sin perpetuas demandas de mayores compensaciones económicas.  Los robots tienen una mayor tolerancia a las condiciones ambientales peligrosas en fábricas y no requieren espacio habitable adicional.  Los robots llevan a cabo las tares asignadas rápidamente, o por lo menos tan bien como han sido instruidos.
-
-PRO_EXOBOTS_DESC
-'''Exobots, como se les conoce comúnmente, son una maravilla del encuentro entre forma y función. Son robots que se diseñaron para cumplir casi cualquier trabajo industrial, en campos que van desde la electrónica a la construcción a gran escala. Fáciles de producir en masa, sirven mejor en las colonias que carecen de la infraestructura y fuerza de trabajo para dedicarse a fábricas especializadas. Cada colonia recibe un equipo estándar de exobots, aumentando su construcción durante las primeras fases del desarrollo.
-
-Incrementa la indústria objetivo en todos los planetas con el enfoque de Indústria por un quinto de la población del planeta y la minería objetivo en todos los planetas con enfoque de Minería por 10.'''
-
 PRO_FUSION_GEN
 Generación de Fusión
-
-PRO_FUSION_GEN_DESC
-Reacciones termonucleares explosivas o incontroladas son relativamente simples de causar a escala, desde cabezas tácticas nucleares hasta hornos estelares supergigantes.  La generación de energía controlable, estable y práctica a partir de la reacción es algo mas difícil.  El proceso sigue siendo atractivo, debido a la fuente casi ilimitada de combustible y las potenciales operaciones libres de emisiones.
 
 PRO_NANOTECH_PROD
 Producción Nanotecnológica
@@ -2636,32 +2525,17 @@ Las técnicas tradicionales de producción estan fundamentalmente limitadas por 
 PRO_ORBITAL_GEN
 Generación Orbital
 
-PRO_ORBITAL_GEN_DESC
-Cuerpos planetarios de órbita baja proveen numerosos beneficios para la generación de energía, en comparación con la superficie planetaria.  La exposición directa a la radiación solar cercana sin atenuaciones atmosféricas y los órdenes de magnitud de grandes estructuras que pueden ser ensambladas en micro-gravedad para recogerlos, son ventajas significativas.  La energía resultante puede ser usada en órbita o puede ser dirigida al planeta para soportar la indústria de la superficie.  Así mismo, nuevos mecanismos de conversión de energía hacen que este disponible en órbita, incluyendo el acoplamiento de los campos magnéticos planetarios, intercambios momentáneos orbitales y calientamiento por fricción con las atmósferas planetarias, que son únicamente aplicables para aplicaciones especializadas.
-
 PRO_SENTIENT_AUTOMATION
 Automatización Sensible
-
-PRO_SENTIENT_AUTOMATION_DESC
-Cuando el equipamiento se automatiza, es capaz de replicarse y mantenerse por si mismo sin soporte externo, excepto por los materiales primarios necesarios y un producto final solicitado o sugerido a ser producido.  Cuando son controlados por una mente artificial, el sistema entero puede aprender, planear, reaccionar y adaptarse de manera autónoma y lo puede hacer sin las tradicionales ineficiencias necesarias para albergar y emplear trabajadores.
 
 PRO_NDIM_ASSMB
 Ensamblaje N-Dimensional
 
-PRO_NDIM_ASSMB_DESC
-La geometría del espacio físico siempre ha sido un impedimento mayor para ensamblar objetos en el espacio.  Los objetos no pueden ser colocados y los volúmenes no pueden ser cerrados y abiertos si su existencia se limita a tres dimensiones.  Sobrepasando esta limitación, partes del objeto pueden ser desplegadas de la forma en dimensiones de bolsillo y las líneas continuas se pueden pasar alrededor de otras masas “fuera de eje”.  Mecanismos similares son usados para ensamblar objetos en menores dimensiones con configuraciones que podrian ser imposibles sin vías de dimensiones superiores.
-
 PRO_SINGULAR_GEN
 Generación de Singuralidad
 
-PRO_SINGULAR_GEN_DESC
-Cuando la materia es atraída hacia un singularidad por la curvatura intensa del espacio tiempo o por campos gravitacionales, la materia forma un disco de acreción y es comprimido y calentado inmensamente.  Radiaciones de alta energía emitidas desde el disco se pueden capturar y aprovechar para generar electricidad.  El horizonte del evento de la singularidad misma también emite radiación para aniquilar los pares virtuales de partícula anti-partícula que se forman cerca.  Este método de generación eléctrica es significativamente mas delicado e inestable que el usado con el disco de acreción, pero produce incluso mas producción también.
-
 PRO_ZERO_GEN
 Generación Punto Cero
-
-PRO_ZERO_GEN_DESC
-Cualquier mecanismo de generación de energía que requiere suministro de combustible esta limitado por la relativa relación masa-energía: no se puede producir mas energía que la masa equivalente consumida, incluso con una eficiencia perfecta.  Al hacer uso de la energía inherente del vacío o energía Punto Cero, una fuente infinita de energía efectiva es posible.  El porcentaje o electricidad de esta extracción es también teóricamente ilimitada, con limites solo en los medios para recolectar y usar la producción.
 
 PRO_NEUTRONIUM_EXTRACTION
 Extracción de Neutronium
@@ -2678,9 +2552,6 @@ La forma de una estructura o espacio inhabitado no es meramente guiado por las l
 CON_ORGANIC_STRC
 Estructura Orgánica
 
-CON_ORGANIC_STRC_DESC
-Edificios formados por minerales inanimados son funcionales y en ocasiones elegantes y los que se realizan con formas orgánicas muertas son simples y baratas.  Las estructuras vivientes actuales, pueden crecer en su forma final sin trabajo adicional, así como cierto grado de auto reparación.  Pueden también auto regular naturalmente sus medio ambientes internos o potencialmente adaptándose  a variados y cambiantes ambientes cuando sea necesario durante o después de su crecimiento inicial.
-
 CON_ARCH_MONOFILS
 Monofilamento Arquitectural
 
@@ -2696,20 +2567,11 @@ Una vez ciertos umbrales de rendimiento son sobrepasados, medir las propiedades 
 CON_FRC_ENRG_STRC
 Estructuras Fuerza-Energía
 
-CON_FRC_ENRG_STRC_DESC
-Cuando fuerzas y energía pueden ser manipuladas como se desee para proporcionar la misma funcionalidad que las superficies sólidas, no hay una necesidad esencial para tener materiales físicos encapsulando a los ocupantes de un edificio.  Las estructuras compuestas enteramente de energía tienen muchas ventajas, incluyendo la simple reconfiguración, resistencia, portabilidad y nuevas posibilidades de diseño.
-
 CON_CONTGRAV_ARCH
 Arquitectura Gravitacional Controlada
 
-CON_CONTGRAV_ARCH_DESC
-Controlando integramente la fuerza y orientación de fuerzas gravitacionales que actúan sobre una estructura existente, los diseños pueden simultáneamente exhibir la libertad de la ingravidez y la utilidad de definir arriba y abajo.  La estructura misma, y el medio ambiente local que busca proporcionar, puede tomar cualquier forma en el espacio, extendiendose a grandes distancias, bucle sobre si mismo y haciendo interconexiones arbitrarias.  Simultáneamente, los medio ambientes locales pueden  administrarse con un remolcador útil, que pueden variar de o ser completamente diferentes de áreas adyacentes.  Una versatilidad como esta permite nuevos diseños funcionales para la sociedad, manufactura y otros usos.
-
 CON_GAL_INFRA
 Infraestructura Galáctica
-
-CON_GAL_INFRA_DESC
-La integración y el desarrollo de las infraestructuras en mundos con gran capacidad productiva en una red galáctica unificada, es uno de los mayores esfuerzos logísticos concebibles.  Una vez completo, la funcionalidad del sistema unifica los mundos que lo componen.  Transporte integrado, alojamiento, mantenimiento y herramientas de construcción pueden ser desplegados de forma fluida donde sea necesario para optimizar la asignación de recursos o ajustar cambios.
 
 CON_ART_HEAVENLY
 Cuerpos Celestiales Artificiales
@@ -2720,14 +2582,8 @@ Una gran masa de una pequeña luna o mas grande no es suficiente para concebir l
 CON_TRANS_ARCH
 Arquitectura Transcendental
 
-CON_TRANS_ARCH_DESC
-La conclusión de diseños unificados funcionales óptimos con elegancia en la forma.  Una estructura transcendente expande e inspira las mentes de sus ocupantes u observadores en su forma, lugar, substancia e integración, sea a través de la escala imponente, énfasis en una idea perfecta, percepción o la falta de la misma o absoluta simplicidad y adecuación para un fin.
-
 CON_NDIM_STRC
 Estructuras N-Dimensionales
-
-CON_NDIM_STRC_DESC
-De todos los rasgos bizarros de física aplicada, la habilidad para doblar el espacio a si mismo tiene la mas directa y profunda influencia en la forma y diseño estructural.  El infinito potencial, literalmente como pasillos estan hechos para doblegarse sobre sus principios o del revés para que su cielo se convierta en suelo.  Así mismo, el concepto de la expansión humana se convierte en algo anecdótico, ya que cualquier número de personas puede caber en un pequeño volumen arbitrario, a buen recaudo en un plano adyacente de existencia.
 
 SHP_GAL_EXPLO
 Exploración Galáctica
@@ -2738,14 +2594,8 @@ El descubrimiento de los viajes interestelares mediante las líneas estelares im
 SHP_INTSTEL_LOG
 Logística Interestelar
 
-SHP_INTSTEL_LOG_DESC
-Suministrar efectivamente naves, ordenando el movimiento general de flota e incluso organizando el movimiento de naves especificas en batalla requiere de una comprensión compleja de navegación y detección asi como los métodos de adquisición de información.
-
 SHP_MIL_ROBO_CONT
 Control Robótico Militar
-
-SHP_MIL_ROBO_CONT_DESC
-El control robótico puede ser usado efectivamente para tareas como la agricultura, minería e indústria; la extensión natural de este concepto es desarrollar equipamiento robótico militar capaz de operar una nave independientemente.  Esto permitirá una gran versatilidad en el diseño, ya que la necesidad de aparatosos sistemas de soporte de vida serian eliminados.  Los cascos producidos con esta tecnología pueden también llevar a cabo reparaciones peligrosas sin preocuparse por la seguridad y limitaciones biológicas de ingenieros vivos.
 
 SHP_SPACE_FLUX_DRIVE
 Motor Espacial Fluido
@@ -2773,9 +2623,6 @@ Los dispositivos tradicionales de propulsión operan en objetos de relativamente
 
 SHP_TRANSSPACE_DRIVE
 Motor Trans-Espacial
-
-SHP_TRANSSPACE_DRIVE_DESC
-Incluso cuando las dimensiones espaciales son sesgadas por efectos relativistas, un objeto generalmente tiene una constante en las características del espacio-tiempo.  Creando un dispositivo que altere las características del espacio-tiempo mismo usando efectos casi relativistas, sería posible crear un método rápido y sigiloso.
 
 SHP_MIDCOMB_LOG
 Logística en Pleno Combate
@@ -2840,14 +2687,8 @@ De manera habitual, la manipulación de energía requiere que tenga forma de mat
 SHP_QUANT_ENRG_MAG
 Magnificación Energética Cuántica
 
-SHP_QUANT_ENRG_MAG_DESC
-Debido a la incertidumbre cuántica, es posible para una partícula ganar arbitrariamente una pequeña cantidad de energía o para nuevas partículas para tener una existencia temporal.  Detectando y magnificando estas fluctuaciones en la energía cuántica, sería posible incrementar tremendamente las capacidades de un casco de energía.
-
 SHP_ENRG_BOUND_MAN
 Manipulación de Energía Límite
-
-SHP_ENRG_BOUND_MAN_DESC
-Tanto si son construidos, crecidos o adaptados desde una estructura pre-existente, las naves compuestas de materia deben tener una estructura lógica y coordinada para permitir incluso una utilidad básica.  Aunque la energía pura no tiene esas restricciones.  Esto permite a un casco de energía pura tener cualquier forma, aunque  inútil desde un punto de vista material.
 
 SHP_SOLAR_CONT
 Contención Solar
@@ -2945,9 +2786,6 @@ En imperios particularmente expansivos, la necesidad de mover naves a lugares de
 CON_ART_PLANET
 Planeta Artificial
 
-CON_ART_PLANET_DESC
-Gigantes de gas y cinturones de asteroides ofrecen una oportunidad única de recursos, no solo como sitios donde adquirir valiosos - y a veces extramadamente raros - recursos, pero como materias primas dentro y fuera de si mismas para la producción de planetas artificiales.  Estos planetas ofreceran nuevos centros de producción, sistemas previamente vacios u ocupados.  Además, varias mejoras clave del planeta pueden ser modificadas o añadidas durante el proceso de construcción, permitiendo potencialmente especificar el tamaño y ambiente o ciertos especiales de planetas a ser añadidos.
-
 CON_PALACE_EXCLUDE
 Palacio Excluidor
 
@@ -2993,11 +2831,6 @@ Permite la terraformación remota
 GRO_CYBORG
 Ciborgs
 
-GRO_CYBORG_DESC
-'''Una versátil fusión de organismo y máquina, capaz de adaptarse a una tremenda variedad de circunstancias.  La generación espontanea de órganos especializados y fuerza mecánicamente mejorada permite a los ciborgs existir con facilidad en cualquier ambiente.
-
-Incrementa la población que puede ser sostenida por planetas Hostil, Pobre y Adecuado a 5, 10, 15, 20 y 25 para planetas Diminuto, Pequeño, Medio, Grande y Gigante, respectivamente.  La Salud en planetas Hostil y Pobre se incrementa por 10 y la Salud de planetas Adecuado por 5.'''
-
 GRO_GAIA_TRANS
 Transformación de Gaia
 
@@ -3022,24 +2855,11 @@ Diferentes tipos de estrella no solo tienen sus propios atributos distintivos y 
 LRN_DISTRIB_THOUGHT
 Red Distribuida de Computadores
 
-LRN_DISTRIB_THOUGHT_DESC
-El ciudadano medio malgasta literalmente su mente, uno de los dispositivos de computación mas finos del universo. Al hacer uso de los ciclos de inactividad del cerebro sobre una gran masa de población mediante simples transreceptores cibernéticos, los centros de investigación del mundo tienen acceso a un poder puro y duro de computación barata y abundante.
-
 LRN_STELLAR_TOMOGRAPHY
 Tomografía Estelar
 
-LRN_STELLAR_TOMOGRAPHY_DESC
-'''Una red de satelites especializados puede usar métodos de tomografia para reconstruir las actividades que ocurren en lo profundo de una estrella.  De otra forma las costosas condiciones para producir son ideales para una variedad de investigaciones forzosas, con grandes beneficios para tipos de estrella exóticas.    Proporciona +4 a la investigación por 10 de población en mundos enfocados en investigación primaria en sistemas con agujeros negros.  Proporciona +3 a planetas en sistemas con estrellas neutrón.  Proporciona +2 a planetas en sistemas con estrellas blancas o azules.  Proporciona +1 a planetas con estrellas rojas, naranjas o amarillas.
-
-Multiplica la investigación objetivo de todos los planetas con enfoque en investigación r 2. 1.75, 1.5 o 1.25 en sistemas con estrellas Agujero Negro, Neutron, Azul o Blanco y Amarillo, Naranja o Roja, respectivamente.'''
-
 LRN_SPATIAL_DISTORT_GEN
 Generador de Distorsión Espacial
-
-LRN_SPATIAL_DISTORT_GEN_DESC
-'''Manipulando las propiedades dimensionales de una línea estelar, sería posible plegarla selectivamente para que una nave en camino con una velocidad suficientemente baja pueda volver por donde vino, gastando su tiempo y combustible.
-
-Alternativamente, la nave puede ser enviada al azar a otra línea estelar adyacente al edificio.'''
 
 LRN_GATEWAY_VOID
 Puerta al Vacío
@@ -3061,11 +2881,6 @@ Colapsando con cuidado una estrella roja, un Agujero Negro puede ser formado.  E
 
 LRN_PSY_DOM
 Dominación Psicogenica
-
-LRN_PSY_DOM_DESC
-'''Es difícil forzar una conciencia individual a someterse al control mental total de otros seres contra su voluntad.  Manipulando las fases temporales involucradas, la fuerza mental ejercida por una población sobre un periodo de horas puede ser interpuesto para llevar en un solo individuo en segundos, creando una casi irresistible compulsión para juntar la mente unificada.
-
-Tiene un 10% de probabilidad de tomar el control de cualquier nave enemiga entre un salto de línea estelar de una colonia perteneciente al imperio, teniendo en cuenta que la nave no es propiedad de un imperio que también tenga esta tecnología.'''
 
 MIND_CONTROL_SHORT_DESC
 Permite el Control Mental
@@ -3185,9 +3000,6 @@ Todas las colonias empiezan el juego con una detección de nivel 20 y la parte d
 SPY_DETECT_2
 Radar Activo
 
-SPY_DETECT_2_DESC
-Desbloquea la parte de nave del Radar Activo.
-
 SPY_DETECT_3
 Escaner de Neutrones
 
@@ -3205,9 +3017,6 @@ Desbloquea la parte de nave Sensores e incrementa la detección de todos los pla
 SPY_STEALTH_1
 Amortiguador Electromagnético
 
-SPY_STEALTH_1_DESC
-Desbloquea la parte de nave Amortiguador Electromagnético e incrementa la ocultación de todos los planetas, sistemas y edificios por 5.  Esta bonificación no es acumulativa con las de otras tecnologías de ocultación.
-
 SPY_STEALTH_2
 Campo de Absorción
 
@@ -3218,9 +3027,6 @@ Incrementa la ocultación de todos los planetas, sistemas y edificios por 30.  E
 
 SPY_STEALTH_3
 Camuflaje Dimensional
-
-SPY_STEALTH_3_DESC
-Desbloquea la parte de nave Camuflaje Dimensional e incrementa la salud de todos los planetas, sistemas y edificios por 55. Esta bonificación no es acumulativa con otras tecnologías de ocultación.
 
 SPY_STEALTH_4
 Camuflaje de Fase
@@ -3286,9 +3092,6 @@ Esta nave insignia se construye a partir de asteroides grandiosos, algunos de lo
 
 SHP_ORG_HULL
 Casco Orgánico
-
-SHP_ORG_HULL_DESC
-Este es el tipo de casco orgánico mas básico:  un casco viviente crecido a partir de la unidad de vida más básica y forjado en la batalla.  Tiene tres espacios externos y uno interno.  La ocultación es elevada y la velocidad media, pero su estructura es un poco baja.  Este casco regenera estructura y combustible entre combates.
 
 SHP_ENDOSYMB_HULL
 Casco Endosimbiótico
@@ -3381,68 +3184,35 @@ Instalación de producción orbital para el ensamblaje de naves interestelares m
 BLD_SHIPYARD_ORBITAL_DRYDOCK
 Dique seco Orbital
 
-BLD_SHIPYARD_ORBITAL_DRYDOCK_DESC
-Instalaciones astilleras expandidas orbitales que permiten la producción de mas grandes diseños de cascos de naves que un astillero básico.
-
 BLD_SHIPYARD_CON_NANOROBO
 Unidad de Proceso Nanorobotica
-
-BLD_SHIPYARD_CON_NANOROBO_DESC
-La producción de millones de nanorobots de mantenimiento y su conexión a una sola IA principal requiere  mas extensivas instalaciones roboticas que la producción de cascos roboticos básicos.  Este edificio es capaz de facilitar la construcción de cascos roboticos mas avanzados que la Unidad de Proceso Robotica.  Esta es una mejora para el Dique Seco Orbital y permite la producción de Cascos NanoRoboticos y Cascos Roboticos.
 
 BLD_SHIPYARD_CON_GEOINT
 Instalación Geointegrada
 
-BLD_SHIPYARD_CON_GEOINT_DESC
-Cuando las necesidades de un astillero son suficientemente grandes, ya no es práctico para el y el planeta en el que se construye seguir siendo entidades separadas. Es mas útil integrarlas en una unidad armoniosa, extendiendo el astillero por debajo de la superficie hasta una órbita geosincrona, haciendo total uso de todos los aspectos geologicos del planeta.  Esta es una mejora para el Dique Seco Orbital y permite la producción de Cascos Titanicos y Cascos Auto-Gravitatorios.
-
 BLD_SHIPYARD_CON_ADV_ENGINE
 Bahia de Ingeniería Avanzada
-
-BLD_SHIPYARD_CON_ADV_ENGINE_DESC
-Una extremadamente bien desarrollada instalación de ingeniería que se especializa en la producción del Motor Trans-Espacial, pero también es capaz de producir el Motor Espacial Fluido.  Esta es una mejora para el Dique Seco Orbital y permite la construcción de Cascos Espaciales Fluidos y Cascos Trans-Espaciales.  Además, esta mejora permite a cualquier astillero en el imperio o imperio aliado producir naves con Torpedos Antimateria y Torpedos de Plasma.
 
 BLD_SHIPYARD_AST
 Procesador de Asteroide
 
-BLD_SHIPYARD_AST_DESC
-Un astillero dedicado con el proposito de cazar asteroides y usarlos como cascos de naves.  Solo puede ser construido en un cinturon de asteroides.  Esta es una mejora para el Astillero Básico y es requirido para la producción de todos los cascos de asteroide y las consiguientes mejoras para astilleros de asteroide.
-
 BLD_SHIPYARD_AST_REF
 Procesador de Reformación de Asteroide
-
-BLD_SHIPYARD_AST_REF_DESC
-Una extensiva instalación dedicada a fusionar, forjar, deconstruir y reconstruir asteroides preexistentes para formar partes de nave y cascos.  Esta es una mejora para el Astillero de Asteroide y permite la producción de Enjambres de Nano-Asteroide, Cascos de Asteroide Compuesto y Cascos de Nave Insignia de Asteroide Esparcido.  Además, esta mejora permite a cualquier astillero en el imperio o imperio aliado para producir partes de nave con Armadura Blindada de Roca.
 
 BLD_SHIPYARD_ORG_ORB_INC
 Incubador Orbital
 
-BLD_SHIPYARD_ORG_ORB_INC_DESC
-Un astillero diseñado para cumplir las necesidades de criaturas espaciales maduras.  Las condiciones en el astillero deben cumplir las especificaciones exactas para que las naves puedan seguir con vida y desarrollarse.  Cualquier nave viva sin acabar tiene posibilidades de ser destruida si el astillero es suficientemente dañado.  Esta es una mejora para el Astillero Básico y es requerido para el desarrollo de todos los cascos orgánicos con la excepción de Casco Estáticos Multicelulares y la producción de todas las mejoras posteriores de astilleros orgánicos.
-
 BLD_SHIPYARD_ORG_CELL_GRO_CHAMB
 Cámara de Crecimiento Celular
-
-BLD_SHIPYARD_ORG_CELL_GRO_CHAMB_DESC
-Una mejora de astillero especializado capaz de incrementar el tamaño de organismos monocelulares a proporciones verdaderamente masivas.  Esta es una mejora para el Astillero Orgánico y permite el desarrollo de Cascos Protoplásmicos.  La presencia de esta mejora y la mejora de Instalación Xenocoordinadora en el mismo planeta permite el desarrollo de Cascos Endosimbióticos.  La presencia de estas dos mejoras en cualquier sitio del imperio o imperio aliado permite la producción de partes de nave Bio-Interceptor.
 
 BLD_SHIPYARD_ORG_XENO_FAC
 Instalación Xenocoordinadora
 
-BLD_SHIPYARD_ORG_XENO_FAC_DESC
-Una instalación dedicada a crear una relación totalmente simbiótica entre la nave y su tripulación.  Esta es una mejora para el Astillero Orgánico y permite el desarrollo de Cascos Simbióticos.  La presencia de esta mejora y la mejora Cámara de Crecimiento Celular en el mismo planeta permite el desarrollo de Cascos Endosimbióticos.  La presencia de estas dos mejoras en cualquier parte del imperio o imperio aliado permite la producción de partes de nave Bio-Interceptor.
-
 BLD_SHIPYARD_ENRG_COMP
 Compresor de Energía
 
-BLD_SHIPYARD_ENRG_COMP_DESC
-Un astillero altamente especializado diseñado para crear y montar partes en grandes haces de energía densamente comprimida.  Este es un proceso frágil y este astillero sufrira una majestuosa explosión si recibe aunque sea una pequeña cantidad de daño.  Esta es una mejora para el Astillero Básico y es requerido para la formación de todos los cascos de energía y futuras mejoras de astillero de casco de energía.
-
 BLD_SHIPYARD_ENRG_SOLAR
 Unidad de Contención Solar
-
-BLD_SHIPYARD_ENRG_SOLAR_DESC
-La tarea de crear un sol en miniatura es una fastuosa tarea por si misma.  La producción de un cuerpo así en el que partes de nave puedan ser montadas con seguridad lo es más aún.  Esta es una mejora para el Compresor de Energía y permite la formación de Cascos Solares.
 
 BLD_BIOTERROR_PROJECTOR
 Base de Proyección Bioterror
@@ -3461,13 +3231,6 @@ Decrementa la ocultación de todos los objetos en el mismo sistema por 45.  Este
 BLD_INDUSTRY_CENTER
 Centro Industrial
 
-BLD_INDUSTRY_CENTER_DESC
-'''Inicialmente proporciona +5 a la indústria a 100 de distancia en línea directa de la instalación, no acumulable, en mundos enfocados en la indústria.
-
-[[tech PRO_INDUSTRY_CENTER_II]] aumenta la bonificación de refinamiento en +6 e incrementa la distancia en 200.
-
-[[tech PRO_INDUSTRY_CENTER_III]] aumenta la bonificación de refinamiento en +7 e incrementa la distancia en 300.'''
-
 BLD_MEGALITH
 Megalito
 
@@ -3478,9 +3241,6 @@ Este edificio establece la capital de dueño del imperio, por encima de cualquie
 
 BLD_SPACE_ELEVATOR
 Ascensor Espacial
-
-BLD_SPACE_ELEVATOR_DESC
-Un enorme y prácticamente irrompible cable atado a un satélite en la órbita baja geoestacionaria en un lado, y una plataforma lanzadera en el límite del planeta en el otro. El ascensor espacial aumenta el comercio del sistema entero.
 
 BLD_GENOME_BANK
 Banco de Genomas
@@ -3493,34 +3253,14 @@ Incrementa la agricultura objetivo en planetas enfocados en agricultura por una 
 BLD_GAIA_TRANS
 Transformación de Gaia
 
-BLD_GAIA_TRANS_DESC
-'''Convierte un planeta en un mundo Gaia mediante un programa de ordenador basado en celulas sensibles, casi divinas.  Este planeta maravilloso para la vista y famoso a través de la galaxia conocida como una celebración de la vida y la harmonia.  Los habitantes de este mundo piensan y actuan como parte de un organismo mayor, sirviendo sus necesidades simultáneamente consigo mismo.
-
-Los planetas Gaia tienen una salud, agricultura y población doble.'''
-
 BLD_COLLECTIVE_NET
 Red de pensamiento colectivo
-
-BLD_COLLECTIVE_NET_DESC
-'''Transfiriendo la mente en el ciberespacio, millares de mentes pueden actuar como una, resolviendo los problemas y haciendo posible descubrimientos que una sola mente no podría lograr.
-
-Incrementa la agricultura objetivo en planetas con enfoque en Agricultura por la mitad de la población del planeta, en planetas objetivo con enfoque Industrial por la mitad de la población del planeta, en planetas objetivo de minería con enfoque en Minería por 20 y planetas objetivo de investigación con enfoque en Investigación por la mitad.
-
-Viajes de Línea Estelar entre 500 uus crearan disrupción en la efectivada de este edificio y eliminar estas bonificaciones.'''
 
 BLD_GATEWAY_VOID
 Puerta al Vacío
 
-BLD_GATEWAY_VOID_DESC
-Una brecha dimensional capaz de magnificar el potencial destructivo de la Mente del Vacío en una región localizada.  Cualquier nave que entre en el sistema sin pasar a través del mismo turno son destruidas y todas las colonias son reducidas al estatus de puesto avanzado, con una población máxima de un decimo.  Es imposible para cualquiera que este fuera del sistema que contenga este edificio ver lo que hay.
-
 BLD_ENCLAVE_VOID
 Enclave del Vacío
-
-BLD_ENCLAVE_VOID_DESC
-'''La población de un planeta entero es perfilada genéticamente hacia la Mente del Vacío y dedicada a canalizar su sabiduría para el imperio. Los ciudadanos del Enclave del Vacío son considerados como sacerdotes, los canales de un pensamiento y sabiduría mas elevados. En todos los asuntos de importancia para el imperio, se busca su consejo. Los emisarios del Enclave pueden incluso ser enviados para participar en los proyectos de investigación del imperio. Este mundo nunca puede exceder la producción industrial o de minería por más de 30.
-
-Multiplica la investigación objetivo en todos los planetas con enfoque en Investigación por 1.5.'''
 
 BLD_ART_BLACK_HOLE
 Agujero Negro Artificial
@@ -3531,11 +3271,6 @@ Una singularidad construida en una órbita lejana de un sistema. Su poder sirve 
 BLD_HYPER_DAM
 Dique Hiperespacial
 
-BLD_HYPER_DAM_DESC
-'''Un rasguño en la tela del universo, controlado y enjaulado de forma segura. El dique hiperespacial sirve como una fuente de energía casi ilimitada para el sector entero.
-
-Incrementa la indústria objetivo en planetas con enfoque en Indústria por la población del planeta y decrementa la salud en estos planetas por 5.'''
-
 BLD_SOL_ACCEL
 Acelerador Solar
 
@@ -3544,17 +3279,6 @@ Un Acelerador Solar incrementa la edad de una estrella artificialmente acelerand
 
 BLD_SOL_ORB_GEN
 Generador Solar Orbital
-
-BLD_SOL_ORB_GEN_DESC
-'''Un generador en una órbita solar baja diseñado para atrapar directamente la energía de una estrella.  Ya que diferentes tipos de estrella producen diferentes cantidades de energía, la bonificación a la indústria del sistema depende del tipo de estrella.
-
-Estrellas Azul y Blanca proporcionan una bonificación igual a la población del planeta a la indústria objetivo con enfoque en Indústria en el mismo sistema.
-
-Estrellas Amarilla y Naranja proporcionan una bonificación igual a la mitad de la población del planeta a la indústria objetivo en planetas con enfoque en Indústria en el mismo sistema.
-
-Estrellas Roja proporcionan una bonificación igual a una cuarta parte de la población del planeta a la indústria objetivo en planetas con enfoque en Indústria en el mismo sistema.
-
-Este edificio puede ser construido en un puesto de avanzada.'''
 
 BLD_CLONING_CENTER
 Centro de Clonación
@@ -3587,14 +3311,8 @@ Permite la construcción de naves con partes de nave de Neutronio.'''
 BLD_NEUTRONIUM_FORGE
 Forja de Neutronio
 
-BLD_NEUTRONIUM_FORGE_DESC
-El proceso industrial de neutronio requiere una instalación especializada extensiva.  Este edificio es requerido para construir cualquier nave con partes de neutronio.  A diferencia de la mayoría de astilleros y mejoras, este edificio no puede ser construido en un puesto de avanzada.
-
 BLD_NEUTRONIUM_SYNTH
 Sintetizador de Neutronio
-
-BLD_NEUTRONIUM_SYNTH_DESC
-Un antiguo edificio diseñado hace mucho tiempo para sintetizar neutronio.  Un imperio con este edificio no necesita un Extractor de Neutronio para construir partes de nave de neutronio.
 
 BLD_CONC_CAMP
 Campos de Concentración
@@ -3606,9 +3324,6 @@ Decrementa la población del planeta a un ritmo de 3 por turno e incrementa la i
 
 BLD_BLACK_HOLE_POW_GEN
 Generador de Energía de Agujero Negro
-
-BLD_BLACK_HOLE_POW_GEN_DESC
-Este edificio proporciona una bonificación a la indústria máxima del doble de la población del planeta para todos los planetas en el imperio con enfoque en Indústria.  Este edificio puede ser construido en un puesto de avanzada.
 
 BLD_PLANET_DRIVE
 Motor Planetario de Línea Estelar
@@ -3635,11 +3350,6 @@ Forma un planeta artificial a partir de un cinturón de asteroides o un gigante 
 BLD_ART_MOON
 Luna Artificial
 
-BLD_ART_MOON_DESC
-'''Forma una luna artificial con un periodo orbital 1:1 - periodo de resonancia rotacional.  Esto permite que la construcción de edificios especiales que solo pueden ser construidos con una luna resonante.
-
-Esto no puede ser construido en un Gigante de Gas o Cinturon de Asteroides.'''
-
 BLD_SOL_REJUV
 Rejuvenecedor Solar
 
@@ -3657,9 +3367,6 @@ Este edificio puede tener los efectos de un Replicador, un Dispositivo de Oculta
 BLD_PLANET_CLOAK
 Dispositivo de Ocultación Planetario
 
-BLD_PLANET_CLOAK_DESC
-Ajustando fases de partes de un planeta dentro y afuera en el espacio-tiempo, su ocultación puede ser incrementada masivamente.
-
 BLD_SPATIAL_DISTORT_GEN
 Generador de Distorsión Espacial
 
@@ -3669,15 +3376,8 @@ Manipulando las propiedades dimensionales de una línea estelar, sería posible 
 BLD_STARGATE
 Puerta Estelar
 
-BLD_STARGATE_DESC
-'''Capaz de crear un atajo mediante el espacio-tiempo entre si mismo y cualquier otra puerta estelar que pertenezca al imperio.
-Para activar la puerta estelar, establece el planeta al enfoque Puerta Estelar y construye un activador de puerta estelar en el planeta en el sistema origen y una baliza de puerta estelar en un planeta con enfoque Puerta Estelar en el sistema destino.'''
-
 BLD_GAS_GIANT_GEN
 Generador de Gigante de Gas
-
-BLD_GAS_GIANT_GEN_DESC
-Un generador de energía diseñado para recolectar la energía de un Gigante de Gas.  Este edificio solo puede ser construido en un gigante de gas y proporciona una bonificación a la indústria de los planetas con enfoque en Indústria en el mismo sistema de un cuarto de la población de los planetas.
 
 BLD_COLONY_BASE
 Colonia Base
@@ -3690,16 +3390,6 @@ Crea una nave Colonia Base que puede ser usada para colonizar otro planeta en el
 ## Hull and ship part description templates
 ##
 
-# %1% hull base starlane speed.
-# %2% hull base fuel capacity.
-# %3% hull base starlane speed.
-# %4% hull base structure value.
-HULL_DESC
-'''Velocidad de Línea Estelar: %1%
-Capacidad de Combustible: %2%
-Velocidad de Combate: %3%
-Salud: %4%'''
-
 # %1% ship part capacity (fuel, troops, colonists, fighters).
 PART_DESC_CAPACITY
 Capacidad: %1%
@@ -3707,13 +3397,6 @@ Capacidad: %1%
 # %1% ship part strength (other).
 PART_DESC_STRENGTH
 Fuerza: %1%
-
-# %1% ship part damage done (direct fire weapons).
-# %2% number of shots done per attack.
-PART_DESC_DIRECT_FIRE_STATS
-'''Daño: %1%
-Cadencia de Disparo: %2% disparos/turno
-Alcance: %3%'''
 
 
 ##
@@ -3837,26 +3520,14 @@ Genera energía usando generación Punto Cero y convirtiendolo en combustible us
 ST_CLOAK_1
 Amortiguador Electromagnético
 
-ST_CLOAK_1_DESC
-Mejora la ocultación de la nave amortiguando emisiones electromagnéticas de los sistemas.  Solo puede compensar una pequeña parte de las emisiones y no servirá con partes que produzcan grandes emisiones, si están presentes.
-
 ST_CLOAK_2
 Campo de Absorción
-
-ST_CLOAK_2_DESC
-Crea un campo de absorción alrededor de la nave, transformandola efectivamente en un cuerpo negro perfecto.
 
 ST_CLOAK_3
 Ocultación Dimensional
 
-ST_CLOAK_3_DESC
-Esconde este nave entre rizos dimensionales, incrementando enormemente su ocultación.
-
 ST_CLOAK_4
 Ocultación de Fase
-
-ST_CLOAK_4_DESC
-Modula la frecuencia de cualquier onda emitida desde la nave para parecer radiación de fondo.
 
 AR_ZORTRIUM_PLATE
 Armadura Blindada de Zortrium
@@ -3885,20 +3556,11 @@ Admirable defensa con masa moderada
 SH_DEFENSE_GRID
 Red de Defensa
 
-SH_DEFENSE_GRID_DESC
-Pobre defensa sin masa extra
-
 SH_DEFLECTOR
 Escudo Deflector
 
-SH_DEFLECTOR_DESC
-Gran defensa con poca masa
-
 SH_MULTISPEC
 Escudo Multi-Espectral
-
-SH_MULTISPEC_DESC
-Poderoso Escudo capaz de proteger una nave dentro de una estrella.  Proporciona una alta bonificación a la ocultación en el mapa de galaxia cuando la nave esta en una estrella que no sea un Agujero Negro o una Estrella Neutron y permite a la nave a entrar en una estrella en combate.
 
 CO_COLONY_POD
 Capsula Colonial
@@ -3930,254 +3592,98 @@ Distingue irregularidades geométricas naturales de naves enemigas manipulando d
 SH_ROBOTIC
 Casco Robótico
 
-SH_ROBOTIC_DESC
-'''Este casco esta completamente automatizado y funciona bajo los principios del Control Robótico Militar.  Como el casco standard y restaura su estructura entre combates, pero tiene una baja estructura máxima.
-
-Además de un Astillero Básico y un Dique Seco Orbital, o una Unidad de Proceso Robótica o una Unidad de Proceso Nanorobótica, es necesario para ser construido en el planeta.'''
-
 SH_SPATIAL_FLUX
 Casco Espacial Fluido
-
-SH_SPATIAL_FLUX_DESC
-'''Este casco diminuto es capaz de alcanzar una inmensa velocidad debido a la potencia del Motor Espacial Fluido.  Solo tiene dos espacios externos y su estructura máxima es baja, la ocultación es muy elevada, pero recibe una gran penalización cuando esta en movimiento o en combate en la mapa de galaxia.
-
-Además de un Astillero Básico y un Dique Seco Orbital, o una Bahía de Ingeniería o una Bahía Avanzada de Ingeniería es necesario para ser construido en el planeta.'''
 
 SH_SELF_GRAVITATING
 Casco Auto-Gravitatorio
 
-SH_SELF_GRAVITATING_DESC
-'''Este casco es inmenso tanto en tamaño como en potencia, con ocho espacios externos y dos internos.  Es bastante robusto, con una estructura máxima elevada, pero con una ocultación y velocidad penosas.
-
-Además de un Astillero Básico y un Dique Seco Orbital, o un Megaprocesador Militar o una Instalación Geointegrada es necesario para ser construido en el planeta.'''
-
 SH_NANOROBOTIC
 Casco Nano-Robótico
-
-SH_NANOROBOTIC_DESC
-'''Este casco automatizado es grande y rápido y es capaz de auto repararse usando millones de nano-robots.  Tiene seis espacios externos y uno interno, pero tiene una ocultación baja y es muy frágil, aunque regenera su estructura entre combates.
-
-Requiere un Astillero Básico, un Dique Seco Orbital y una Unidad de Proceso Nanorobótica en el planeta donde se construye.'''
 
 SH_TITANIC
 Casco Titánico
 
-SH_TITANIC_DESC
-'''Este extraordinariamente gran casco requiere un poco de ingeniería incluso para moverse.  Tiene dieciséis espacios externos y tres internos y su estructura máxima es muy elevada, pero a costa de la velocidad y ocultación.
-
-Requiere un Astillero Básico, un Dique Seco Orbital y una Instalación Geointegrada en el planeta donde se construye.'''
-
 SH_TRANSSPATIAL
 Casco Trans-Espacial
-
-SH_TRANSSPATIAL_DESC
-'''Este casco es capaz de viajar oculto y a una velocidad increíble debido a su Motor Trans-Espacial.  Solo tiene un slot externo y su estructura máxima es extremadamente baja.
-
-Requiere un Astillero Básico, un Dique Seco Orbital y una Bahía Avanzada de Ingeniería en el planeta donde se construye.'''
 
 SH_LOGISTICS_FACILITATOR
 Facilitador Logístico
 
-SH_LOGISTICS_FACILITATOR_DESC
-'''Esta nave insignia organizadora esta diseñada para organizar y dirigir transferencias de tripulación y objetos en medio de la batalla.  Tiene siete espacios externos y dos internos.  Su velocidad es baja, pero su estructura máxima muy elevada.  Además, su propia flota de cargueros ocultos permite la transferencia de material y personal durante la batalla, permitiendo que todas las naves amigas recuperar estructura durante el combate y recuperar completamente la estructura entre combates.
-
-Requiere un Astillero Básico, un Dique Seco Orbital una Unidad de Proceso Nanorobótica, una Instalación Geointegrada, una Bahía Avanzada de Ingeniería y Ensamblaje Logístico Militar para poder ser construido.'''
-
 SH_ASTEROID
 Casco de Asteroide
-
-SH_ASTEROID_DESC
-'''Este casco se construye a partir de un asteroide de tamaño considerable.  Mas espacioso que el casco standard, tiene cuatro espacios externos y dos internos.  La velocidad y estructura son relativamente bajas, pero es muy barato de construir.  Este casco recibe una gran bonificación a la ocultación en el mapa de galaxia cuando esta en un sistema con un cinturón de asteroides y en combate cuando se oculta en ellos.
-
-Requiere un Astillero Básico y un Procesador de Asteroide en el cinturón de asteroides donde se produce.'''
 
 SH_SMALL_ASTEROID
 Casco de Asteroide Pequeño
 
-SH_SMALL_ASTEROID_DESC
-'''Este casco se construye a partir de un asteroide muy pequeño. Solo tiene un espacio externo y otro interno.  La velocidad es muy buena, pero su estructura es muy baja.  Este casco recibe una gran bonificación a la ocultación en el mapa de galaxia cuando esta en un sistema con un cinturón de asteroides y en combate cuando se oculta en ellos.
-
-Requiere un Astillero Básico y un Procesador de Asteroide en el cinturón de asteroides donde se produce.'''
-
 SH_HEAVY_ASTEROID
 Casco de Asteroide Pesado
-
-SH_HEAVY_ASTEROID_DESC
-'''Este casco se construye a partir de un asteroide gigantesco. Tiene seis espacios externos y tres internos.  La velocidad es muy baja, pero su estructura es moderadamente alta.  Este casco recibe una gran bonificación a la ocultación en el mapa de galaxia cuando esta en un sistema con un cinturón de asteroides y en combate cuando se oculta en ellos.
-
-Requiere un Astillero Básico y un Procesador de Asteroide en el cinturón de asteroides donde se produce.'''
 
 SH_CAMOUFLAGE_ASTEROID
 Casco de Asteroide Camuflado
 
-SH_CAMOUFLAGE_ASTEROID_DESC
-'''Este asteroide esta diseñado para asemejarse a un asteroide real.  Tiene cuatro espacios internos y ninguno interno.  La estructura es moderada, pero la velocidad es bastante baja.  Este casco consigue una tremenda bonificación a la ocultación en el mapa de galaxia cuando esta en un sistema que contiene un cinturón de asteroides y en combate cuando se oculta en uno de ellos.
-
-Requiere un Astillero Básico y un Procesador de Asteroide en el cinturón de asteroides donde se produce.'''
-
 SH_SMALL_CAMOUFLAGE_ASTEROID
 Casco de Asteroide Pequeño Camuflado
-
-SH_SMALL_CAMOUFLAGE_ASTEROID_DESC
-'''Este casco de asteroide camuflado es capaz de usar partes de nave de asteroide camufladas en su exterior, aunque debe ser construido con un tamaño menor para compensar y evitar perdidas en su bonificación de ocultación.  Tiene un espacio exterior y uno interior.  La velocidad es moderada, pero su estructura bastante baja.  Este casco tiene un tremendo bonificador a su ocultación en el mapa de galaxia cuando esta en un sistema que contenga un cinturón de asteroides y en combate cuando se esconde detrás de uno.
-
-Requiere un Astillero Básico y un Procesador de Asteroide en el cinturón de asteroides donde se produce.'''
 
 SH_AGREGATE_ASTEROID
 Casco de Asteroide Agregado
 
-SH_AGREGATE_ASTEROID_DESC
-'''Este casco masivo esta formado por la combinación de varios asteroides grandes.  Tiene cincuenta espacios externos y cuatro internos.  La estructura es buena, pero su velocidad es muy baja.  Este casco recibe una gran bonificación a la ocultación en el mapa de galaxia cuando esta en un sistema con un cinturón de asteroides y en combate cuando se oculta en ellos.
-
-Requiere un Astillero Básico y un Procesador de Asteroide y una Instalación de Reformado de Asteroides en el cinturón de asteroides donde se produce.'''
-
 SH_MINIASTEROID_SWARM
 Enjambre de Mini-Asteroides
-
-SH_MINIASTEROID_SWARM_DESC
-'''Este casco se construye a partir de un asteroide pequeño, donde muchos de los trozos se han dividido para formar numerosos asteroides diminutos, controlados por el casco principal.  Estos asteroides protegen a la nave, otorgando una bonificación a sus escudos.  Este casco tiene dos espacios externos pero ninguno interno.  La estructura es muy baja, pero con una velocidad alta.  Este casco recibe una gran bonificación a la ocultación en el mapa de galaxia cuando esta en un sistema con un cinturón de asteroides y en combate cuando se oculta en ellos.
-
-Requiere un Astillero Básico y un Procesador de Asteroide y una Instalación de Reformado de Asteroides en el cinturón de asteroides donde se produce.'''
 
 SH_SCATTERED_ASTEROID
 Casco de Asteroide Esparcido
 
-SH_SCATTERED_ASTEROID_DESC
-'''Esta nave insignia se construye a partir de asteroides grandiosos, alguno de los cuales han sido combinados para formar el casco principal.  Estos asteroides protegen a  la nave principal, así como cualquier nave amiga que la acompañe, otorgando una bonificación a sus escudos para todas las naves que te pertenezcan y las naves aliadas en las cercanias.  Como el casco de asteroide compuesto,  tiene quince espacios externos y cuatro internos.  La velocidad es muy baja, pero la estructura es elevada.  Este casco recibe una gran bonificación a la ocultación en el mapa de galaxia cuando esta en un sistema con un cinturón de asteroides y en combate cuando se oculta en ellos.
-
-Requiere un Astillero Básico y un Procesador de Asteroide y una Instalación de Reformado de Asteroides en el cinturón de asteroides donde se produce.'''
-
 SH_CRYSTALLIZED_ASTEROID
 Casco de Asteroide Cristalizado
-
-SH_CRYSTALLIZED_ASTEROID_DESC
-'''Este robusto casco se construye a partir de asteroides grandiosos, endurecido con técnicas avanzadas de cristalización. Como el Casco de Asteroide normal, tiene cuatro espacios externos y dos internos.  La velocidad es algo baja, pero su estructura es extremadamente alta.  Este casco recibe una gran bonificación a la ocultación en el mapa de galaxia cuando esta en un sistema con un cinturón de asteroides y en combate cuando se oculta en ellos.
-
-Requiere un Astillero Básico y un Procesador de Asteroide y un Módulo de Cristalización en el cinturón de asteroides donde se produce.'''
 
 SH_ORGANIC
 Casco Orgánico
 
-SH_ORGANIC_DESC
-'''Este es el tipo de casco orgánico mas básico:  un casco viviente crecido a partir de la unidad de vida más básica y forjado en la batalla.  Tiene tres espacios externos y uno interno.  La ocultación es elevada y la velocidad media, pero su estructura es un poco baja.  Este casco regenera estructura y combustible entre combates.
-
-Requiere un Astillero Básico y un Incubador Orbital en el planeta en el que se construye.'''
-
 SH_STATIC_MULTICELLULAR
 Casco Multicelular Estático
-
-SH_STATIC_MULTICELLULAR_DESC
-'''Aunque empezara siendo orgánico, este casco no tiene vida, producido mediante fundición multicelular.  La versatilidad del interior y la falta de necesidad para órganos internos incrementa su capacidad, pero sin sistemas vivos para mantener la estructura es muy débil.  Tiene tres espacios externos y dos internos.  La ocultación es moderada y su velocidad buena, pero su estructura es muy baja.  A diferencia de la mayoría de cascos orgánicos, no regenera ni la estructura ni el combustible entre combates.
-
-Requiere un Astillero Básico y un Ensamblaje Orgánico Industrial en el planeta en el que se construye.'''
 
 SH_ENDOMORPHIC
 Casco Endomórfico
 
-SH_ENDOMORPHIC_DESC
-'''Este casco viviente contiene componentes multicelulares sin vida para un modularidad interna mayor.  Este casco tiene cuatro espacios externos y tres internos.  La ocultación es buena y la velocidad moderada, pero la estructura es baja.  Este casco regenera estructura y combustible entre combates.
-
-Requiere un Astillero Básico, un Incubador Orbital y un Ensamblador Orgánico Industrial en el planeta en el que se construye.'''
-
 SH_SYMBIOTIC
 Casco Simbiótico
-
-SH_SYMBIOTIC_DESC
-'''Este casco viviente existe en una relación simbiótica con su tripulación, incrementando su ocultación y velocidad. Tiene dos espacios externos y uno interno.  La ocultación, velocidad y estructura son buenas.  Este casco regenera estructura y combustible entre combates.
-
-Requiere un Astillero Básico, un Incubador Orbital y una Instalación de Xenocoordinación en el planeta en el que se construye.'''
 
 SH_PROTOPLASMIC
 Casco Protoplásmico
 
-SH_PROTOPLASMIC_DESC
-'''Este casco monocelular suspende sus partes internas en un citoplasma en vez de montarlos en una estructura sólida interna.  Tiene tres espacios externos e internos.  La velocidad es moderada y su ocultación alta, pero su estructura es muy baja.  Este casco regenera estructura y combustible entre combates.
-
-Requiere un Astillero Básico, un Incubador Orbital y una Cámara de Crecimiento Celular en el planeta en el que se construye.'''
-
 SH_ENDOSYMBIOTIC
 Casco Endosimbiótico
-
-SH_ENDOSYMBIOTIC_DESC
-'''Este casco monocelular existe en una relación simbiótica con su tripulación, suspendiendolos en citoplasma y usando sus órganos.  Tiene tres espacios externos y dos internos.  La velocidad y ocultación son buenas y su estructura moderada.  Este casco regenera estructura y combustible entre combates.
-
-Requiere un Astillero Básico, un Incubador Orbital, una Instalación de Xenocoordinación y una Cámara de Crecimiento Celular en el planeta en el que se construye.'''
 
 SH_RAVENOUS
 Casco Famélico
 
-SH_RAVENOUS_DESC
-'''Este casco viviente surge de la sangre de sus hermanos.  Tiene cuatro espacios externos y dos internos.  La ocultación es baja, pero la velocidad y estructura elevadas.  A diferencia de la mayoría de cascos orgánicos, el Casco Famélico solo regenera combustible entre combates.
-
-Requiere un Astillero Básico, un Incubador Orbital y una Cámara de Maduración Competitiva en el planeta en el que se construye.'''
-
 SH_BIOADAPTIVE
 Casco Bio-Adaptivo
-
-SH_BIOADAPTIVE_DESC
-'''Este casco viviente tiene una mente y cuerpo en perfecta armonía, permitiendo que reaccione y se adapte a su entorno con una eficiencia sin parangón.  Solo tiene dos espacios internos y externos, pero la ocultación, velocidad y estructura son muy elevados.  Este casco regenera combustible y recupera completamente su estructura entre combates.
-
-Requiere un Astillero Básico, un Incubador Orbital y una Unidad de Modificación Bioneuronal en el planeta en el que se construye.'''
 
 SH_SENTIENT
 Casco Sensible
 
-SH_SENTIENT_DESC
-'''Esta nave insignia consciente de si misma tiene poderosas habilidades analíticas  y una tremenda capacidad de memorización, que le permite dirigir naves amigas y proporcionar información útil y tácticas sutiles en combate, otorgando una bonificación a la salud y detección para todas las naves amigas que la acompañen.  Tiene seis espacios externos y tres internos.  Tiene una velocidad baja, pero una ocultación y estructura buenas.  Este casco regenera estructura y combustible entre combates.
-
-Requiere un Astillero Básico, un Incubador Orbital, una Cámara de Maduración Competitiva y una Unidad de Modificación Neuronal en el planeta en el que se construye.'''
-
 SH_COMPRESSED_ENERGY
 Casco de Energía Comprimida
-
-SH_COMPRESSED_ENERGY_DESC
-'''Este casco rápido se compone enteramente de energía comprimida y solo tiene un espacio externo.  La estructura es baja, pero su ocultación y velocidad son muy elevadas.  Este casco requiere una gran cantidad de energía para ser construido y solo puede hacerse en un sistema con una estrella de tipo Blanca, Azul o Agujero Negro.
-
-Requiere un Astillero Básico y un Compresor de Energía en el planeta en el que se construye.'''
 
 SH_FRACTAL_ENERGY
 Casco de Energía Fractal
 
-SH_FRACTAL_ENERGY_DESC
-'''Este casco, aunque pequeño, tiene una superficie fractal que le permite montar muchas mas partes que un casco standard.  Tiene veinte espacios externos pero ninguno interno.  La ocultación es muy baja, pero su estructura y velocidad son moderadas.  Este casco requiere una enorme cantidad de energía para ser construida y solo puede hacerse en un sistema con una estrella de tipo Azul o Agujero Negro.
-
-Requiere un Astillero Básico, un Compresor de Energía y una Formación Enfocada de Energía Controlada en el planeta en el que se construye.'''
-
 SH_QUANTUM_ENERGY
 Casco de Energía Cuántica
-
-SH_QUANTUM_ENERGY_DESC
-'''Este casco magnifica las fluctuaciones de energía cuántica para incrementar su propio poder.  Tiene siete espacios externos y tres internos.  La velocidad y estructura son muy elevadas, pero su ocultación muy baja.  Este casco requiere una enorme cantidad de energía para ser construido y solo puede hacerse en un sistema con una estrella de tipo Azul o Agujero Negro.
-
-Requiere un Astillero Básico, un Compresor de Energía y una Formación Enfocada de Energía Controlada en el planeta en el que se construye.'''
 
 SH_SOLAR
 Casco Solar
 
-SH_SOLAR_DESC
-'''Esta majestuosa nave insignia es esencialmente un sol en miniatura y como tal es una gran fuente de combustible y visibilidad.  Todas las naves amigas recuperan completamente el combustible entre combates y todas las naves enemigas en la vecindad reciben una penalización a la ocultación.  Este casco tiene 18 espacios externos y 9 internos - una mayor capacidad interna que cualquier otro casco.  La estructura es extremadamente alta pero la velocidad y la ocultación son muy bajas.  Aun así, esta nave tiene la habilidad de entrar en una estrella y esconderse, otorgando la ocultación perfecta en el mapa de galaxia cuando esta en un sistema con una estrella de cualquiera que no sea Agujero Negro o Neutrónica y en combate, cuando se esconde en esa estrella.  Esta nave requiere una cantidad tremenda de energía para construirla y debe captar energía desde colisiones partícula-antipartícula en el evento del horizonte de un Agujero Negro en su formación.
-
-Requiere un Astillero Básico, un Compresor de Energía y una Unidad de Contención Solar en el planeta en el que se construye.'''
-
 SH_BASIC_LARGE
 Casco Standard
-
-SH_BASIC_LARGE_DESC
-'''Casco interestelar básico.
-
-Requiere un Astillero Básico y un Dique Seco Orbital en el planeta en el que se construye.'''
 
 SH_XENTRONIUM
 Casco de Xentronio
 
-SH_XENTRONIUM_DESC
-Un casco construido principalmente de xentronio.  Aunque pequeño, tiene una extrema estructura máxima.
-
 SH_COLONY_BASE
 Casco de Colonia Base
-
-SH_COLONY_BASE_DESC
-Un casco diseñado para crear una colonia en otro planeta del sistema.  No puede moverse entre sistemas o de forma rápida dentro del sistema.
 
 
 ##

--- a/default/stringtables/fi.txt
+++ b/default/stringtables/fi.txt
@@ -163,9 +163,6 @@ COMMAND_LINE_USAGE
 COMMAND_LINE_DEFAULT
 '''Oletus: '''
 
-OPTIONS_DB_HELP
-Tulosta ohje.
-
 OPTIONS_DB_GENERATE_CONFIG_XML
 Käyttää kaikkia asetuksia mistä tahansa olemassa olevasta config.xml tiedostosta sekä komentoriville syötettyjä tietoja luodakseen config.xml tiedoston. Tämä tiedosto korvaa mahdollisen jo olemassa olevan config.xml tiedoston.
 
@@ -349,24 +346,6 @@ Asettaa tähtijärjestelmän sivupaneelin koon.
 OPTIONS_DB_UI_SIDEPANEL_PLANET_SHOWN
 Asettaa näytetäänkö renderöidyt planeetat / asteroidit sivupaneelissa.
 
-OPTIONS_DB_GAMESETUP_STARS
-Tähtien määrä luotavassa galaksissa.
-
-OPTIONS_DB_GAMESETUP_GALAXY_SHAPE
-Luotavan galaksin muoto.
-
-OPTIONS_DB_GAMESETUP_GALAXY_AGE
-Luotavan galaksin ikä.
-
-OPTIONS_DB_GAMESETUP_PLANET_DENSITY
-Planeettojen määrä tähtijärjestelmässä luotavassa galaksissa.
-
-OPTIONS_DB_GAMESETUP_STARLANE_FREQUENCY
-Tähtilinjojen määrä luotavassa galaksissa.
-
-OPTIONS_DB_GAMESETUP_SPECIALS_FREQUENCY
-Erikoisuuksien esiintyminen luotavassa galaksissa.
-
 OPTIONS_DB_GAMESETUP_EMPIRE_NAME
 Pelissä käyttämäsi imperiumin nimi.
 
@@ -375,12 +354,6 @@ Pelissä käyttämäsi nimi.
 
 OPTIONS_DB_GAMESETUP_EMPIRE_COLOR
 Pelissä käyttämäsi imperiumin väri.
-
-OPTIONS_DB_GAMESETUP_STARTING_SPECIES_NAME
-Kotiplaneettasi laji pelin alussa.
-
-OPTIONS_DB_GAMESETUP_NUM_AI_PLAYERS
-Tekoälyvastustajien määrä pelissä.
 
 OPTIONS_DB_STRINGTABLE_FILENAME
 Asettaa käännöstiedoston.
@@ -1509,9 +1482,6 @@ SITREP_EMPIRE_ELIMINATED
 SP_HUMAN
 Ihmiset
 
-SP_HUMAN_DESC
-Normi.
-
 
 ##
 ## Specials
@@ -1520,14 +1490,8 @@ Normi.
 ANCIENT_RUINS_SPECIAL
 Muinaisia raunioita
 
-ANCIENT_RUINS_SPECIAL_DESCRIPTION
-Tällä planeetalla on jäänteitä kehittyneestä muinaisesta sivilisaatiosta. Näiden jäänteiden tutkiminen antaa bonuksen tutkimukseen.
-
 ECCENTRIC_ORBIT_SPECIAL
 Epäsäännöllinen kiertorata
-
-ECCENTRIC_ORBIT_SPECIAL_DESC
-Tämän planeetan kiertorata on hyvin epäsäännöllinen. Planeetan etäisyys tähdestä, jota se kiertää vaihtelee suuresti, ja näin ollen planeetan saama säteilymäärä ei ole tasainen vuoden ympäri. Vaihtelevat olosuhteet haittaavat infrastruktuurin kehittymistä, mutta tarjoavat hedelmällisen maaperän tutkimukselle.
 
 MINERALS_SPECIAL
 Mineraalirikas
@@ -2218,9 +2182,6 @@ Avaa ydinohjuksen, aluksen osa.
 SPY_DETECT_2
 Aktiivitutka
 
-SPY_DETECT_2_DESC
-Avaa aktiivitutkan, aluksen osa.
-
 SHP_DEUTERIUM_TANK
 Deuteriumtankki
 
@@ -2242,16 +2203,6 @@ Laivatelakka
 ## Hull and ship part description templates
 ##
 
-# %1% hull base starlane speed.
-# %2% hull base fuel capacity.
-# %3% hull base starlane speed.
-# %4% hull base structure value.
-HULL_DESC
-'''Tähtilinjanopeus: %1%
-Polttoainekapasiteetti: %2%
-Taistelunopeus: %3%
-Kestävyys: %4%'''
-
 # %1% ship part capacity (fuel, troops, colonists, fighters).
 PART_DESC_CAPACITY
 Kapasiteetti: %1%
@@ -2259,13 +2210,6 @@ Kapasiteetti: %1%
 # %1% ship part strength (other).
 PART_DESC_STRENGTH
 Vahvuus: %1%
-
-# %1% ship part damage done (direct fire weapons).
-# %2% number of shots done per attack.
-PART_DESC_DIRECT_FIRE_STATS
-'''Vahinko: %1%
-Tulinopeus: %2% laukausta/vuoro
-Kantama: %3%'''
 
 
 ##
@@ -2292,9 +2236,6 @@ Keskinkertainen havainnointikyky, suuri häiverangaistus alukselle
 
 SH_DEFENSE_GRID
 Puolustusverkko
-
-SH_DEFENSE_GRID_DESC
-Heikko puolustus, joka ei tuo lisämassaa
 
 
 ##

--- a/default/stringtables/fi.txt
+++ b/default/stringtables/fi.txt
@@ -1702,10 +1702,6 @@ METER_TARGET_POPULATION
 Tavoite väestö
 
 # Meter types
-METER_TARGET_HEALTH
-Tavoite terveys
-
-# Meter types
 METER_TARGET_INDUSTRY
 Tavoite teollisuus
 
@@ -1740,10 +1736,6 @@ Max Puolustus
 # Meter types
 METER_POPULATION
 Väestö
-
-# Meter types
-METER_HEALTH
-Terveys
 
 # Meter types
 METER_INDUSTRY

--- a/default/stringtables/it.txt
+++ b/default/stringtables/it.txt
@@ -296,9 +296,6 @@ COMMAND_LINE_USAGE
 COMMAND_LINE_DEFAULT
 '''Predefiniti: '''
 
-OPTIONS_DB_HELP
-Mostra questo messaggio di aiuto.
-
 OPTIONS_DB_GENERATE_CONFIG_XML
 Utilizza tutte le impostazioni da qualsiasi file config.xml esistente e quelli indicati sulla riga di comando per generare un file config.xml. Questo sovrascriverà il file config.xml corrente, se esiste.
 
@@ -566,26 +563,6 @@ Imposta la dimensione del pianeta rotante più grande nel pannello laterale del 
 OPTIONS_DB_UI_SIDEPANEL_PLANET_MIN_DIAMETER
 Imposta la dimensione del pianeta rotante più piccolo nel pannello laterale del sistema.
 
-OPTIONS_DB_GAMESETUP_STARS
-'''Il numero approssimativo di sistemi per la galassia che sarà generata.
-Per una partita bilanciata il numero consigliato è 15-30 sistemi per impero.
-Numeri molto elevati di sistemi potrebbero causare dei rallentamenti di FreeOrion, specialmente nelle fasi avanzate.'''
-
-OPTIONS_DB_GAMESETUP_GALAXY_SHAPE
-La forma della galassia da generare.
-
-OPTIONS_DB_GAMESETUP_GALAXY_AGE
-L'età della galassia da generare.
-
-OPTIONS_DB_GAMESETUP_PLANET_DENSITY
-Il numero di pianeti per sistema da generare.
-
-OPTIONS_DB_GAMESETUP_STARLANE_FREQUENCY
-Il numero di rotte da generare.
-
-OPTIONS_DB_GAMESETUP_SPECIALS_FREQUENCY
-Il numero di apparizioni speciali da generare.
-
 OPTIONS_DB_GAMESETUP_EMPIRE_NAME
 Il nome del tuo impero.
 
@@ -594,9 +571,6 @@ Il nome usato nel gioco dal giocatore.
 
 OPTIONS_DB_GAMESETUP_EMPIRE_COLOR
 Il colore usato per il tuo impero.
-
-OPTIONS_DB_GAMESETUP_NUM_AI_PLAYERS
-Il numero di avversari IA nel gioco.
 
 OPTIONS_DB_UI_TECH_LAYOUT_HORZ_SPACING
 La spaziatura orizzontale fra tecnologie nell'albero tecnologico, in multipli della larghezza di ogni singola tecnologia.
@@ -1752,9 +1726,6 @@ Ricerca
 RESEARCH_INFO_RP
 PR
 
-RESEARCH_QUEUE_PROMPT
-Doppio click oppure Shift-click su un elemento disponibile per aggiungerlo alla coda di ricerca.
-
 
 ##
 ## Build selector window
@@ -2032,23 +2003,8 @@ Popolazione
 METER_INDUSTRY_VALUE_LABEL
 Industria
 
-METER_INDUSTRY_VALUE_DESC
-'''L'industria rappresenta la produzione e la modifica di beni fisici. È necessaria per la produzione di edifici, navi spaziali e altri progetti.
-
-L'industria di un pianeta può essere utilizzata per qualsiasi progetto di produzione di [[enciclopedia METER_SUPPLY]] linea pianeti collegati. La produzione di qualunque industria non in funzione viene sprecata ad ogni turno.
-
-Ogni progetto ha un numero minimo di turni necessari per essere costruito. Per esempio, se un progetto che è costato 15 PP, e ha avuto un tempo minimo di 3 giri, 5 PPS è il massimo che potrebbe essere messo verso il suo completamento per turno.
-Il progetto nella parte superiore della coda è dato PP prima. Qualunque PP rimanenti vengono poi dati al progetto successivo in coda, e se vi è ancora più attuale dalla prossima - e così via. È possibile modificare la priorità degli elementi della coda trascinando gli elementi più importanti più vicini alla cima.
-'''
-
 METER_RESEARCH_VALUE_LABEL
 Ricerca
-
-METER_RESEARCH_VALUE_DESC
-'''La ricerca (o PR "Punti Ricerca") di tutti i pianeti dell'impero è combinata per la scoperta di nuove tecnologie. Qualsiasi punto ricerca che non possa essere speso per ricercare una tecnologia è perso ad ogni turno. Ogni tecnologia ha un numero minimo di turni richiesto per essere ricercato. Per esempio, se una tecnologia che costa 15 PR e riechiede un tempo minimo di 3 turni, 5 PR è il massimo per turno che può essere assegnato al suo completamento.
-Alla tecnologia in cima alla coda è assegnata la priorità di ricerca con il massimo numero di PR consentito.  Ogni PR restante è poi fornito alla prossima tecnologia in coda, stessa cosa dicasi per la tecnologia successiva - e così via. È possibile modificare la priorità degli elementi della coda trascinando gli elementi più importanti più vicini alla cima.
-
-La ricerca non richiede la connessione di linee[[metertype METER_SUPPLY]] per essere utilizzata.'''
 
 METER_TRADE_VALUE_LABEL
 Commercio
@@ -2056,29 +2012,14 @@ Commercio
 METER_CONSTRUCTION_VALUE_LABEL
 Infrastrutture
 
-METER_CONSTRUCTION_VALUE_DESC
-Il termine infrastruttura si riferisce a strutture tecniche che supportano un pianeta colonizzato: servizi di energia, trasporti, telecomunicazioni e sociali per i cittadini.
-
 METER_HAPPINESS_VALUE_LABEL
 Felicità
-
-METER_HAPPINESS_VALUE_DESC
-La felicità non svolge ancora nessuna funzione.
 
 METER_FUEL_VALUE_LABEL
 Carburante
 
 METER_SHIELD_VALUE_LABEL
 Scudi
-
-METER_SHIELD_VALUE_DESC
-'''Il termine scudi combina tutti i tipi di campi di forza protettivi. Vengono rigenerati ad ogni turno e solitamente sono le prime protezioni che gli attacchi in arrivo devono superare. Ci sono due tipi distinti di scudi che funzionano in modo molto diverso: scudi nave e scudi barriera planetari.
-
- Scudi nave: Riducono il danno sostenuto da ciascun colpo tramite la resistenza agli attacchi della parte di scudo. Un'arma può penetrare uno scudo solo se il valore del suo danno è superiore alla resistenza dello scudo stesso.
-
-Scudi barriera planetari: Funzionano come una sorta di armatura planetaria. La loro forza è ridotta ad ogni colpo fino a quando non si esauriscono del tutto, ulteriori colpi potranno finalmente riuscire a superare le difese e danneggiare le strutture planetarie. Gli scudi barriera planetari rigenerano la loro forza ogni turno di un certo valore.
-
-Sia le navi spaziali che pianeti hanno un misuratore di Scudi.'''
 
 METER_DEFENSE_VALUE_LABEL
 Difesa
@@ -2100,11 +2041,6 @@ Il misuratore delle truppe su un pianeta rappresenta il potere delle forze di te
 METER_DETECTION_VALUE_LABEL
 Raggio di Rilevamento
 
-METER_DETECTION_VALUE_DESC
-'''Il Raggio di Rilevamento rappresenta il numero di uu che i sensori possono raggiungere. Un impero può vedere solo gli oggetti che hanno un valore di [[metertype METER_STEALTH]] inferiore o uguale alla sua [[encyclopedia DETECTION_TITLE]] e si trova nel Raggio di Rilevamento controllato da una nave spaziale o pianeta.
-
-Navi spaziali e pianeti hanno un misuratore di Raggio di Rilevamento. C'è l'opzione per visualizzare i cerchi del Raggio di Rilevamento nella sezione Mappa Galassia del menu Opzioni.'''
-
 METER_STEALTH_VALUE_LABEL
 Occultamento
 
@@ -2115,12 +2051,6 @@ Navi spaziali, strutture, speciali, sistemi e pianeti hanno un misuratore di Occ
 
 METER_DETECTION_STRENGTH_VALUE_LABEL
 Forza di Rilevamento
-
-METER_DETECTION_STRENGTH_VALUE_DESC
-'''Il termine Forza di Rilevamento rappresenta il livello tecnologico dei sensori di un impero. Un impero può vedere solo gli oggetti che hanno un valore di [[metertype METER_STEALTH]] inferiore o uguale alla sua Forza di Rlevamento e sono all'interno di un [[metertype METER_DETECTION]] controllato da una nave spaziale o un pianeta.
-
-Gli imperi hanno un misuratore di Forza di Rilevamento.'''
-
 
 PEACE_TITLE
 Pace
@@ -2136,9 +2066,6 @@ Gli avamposti sono stazioni non presidiate che possono essere fondate in luoghi 
 
 GROWTH_FOCUS_TITLE
 Focus sulla Crescita
-
-GROWTH_FOCUS_TEXT
-Il focus sulla crescita rappresenta l'esportazione di materiali rari e sostanze che aiutano la crescita della popolazione di una determinata specie. È disponibile solo in determinate situazioni: su alcuni mondi e su pianeti con speciali caratteristiche di crescita. Un pianeta incentrato sulla crescita aumenta la popolazione massima solo su altri pianeti ad esso collegati da linee di [[enciclopedia METER_SUPPLY]]. Un pianeta natale focalizzato sulla crescita aiuta solo altri pianeti della stessa specie. Pianeti con caratteristiche speciali di crescita, fanno progredire lo sviluppo di una singola specie, per esempio, alcuni aiutano lo sviluppo delle specie organiche.
 
 TRADE_FOCUS_TITLE
 Focus sul Commercio
@@ -2548,30 +2475,6 @@ Preferenze Ambientali:
 
 SP_HUMAN
 Umano
-
-SP_HUMAN_DESC
-'''Per lo più innocui. Tutte le statistiche medie per scopi di prova.
-Preferiscono pianeti terrestri.
-[[encyclopedia ORGANIC_SPECIES_TITLE]]
-'''
-
-SP_SCYLIOR_GAMEPLAY_DESC
-'''Tri-Tentacoli, nautiloidi acquatici.
-Preferiscono pianeti oceanici.
-[[encyclopedia ORGANIC_SPECIES_TITLE]]
-'''
-
-SP_GYSACHE_GAMEPLAY_DESC
-'''Codardi, bizzarri erbivori simil-pecore.
-Preferiscono pianeti paludosi.
-[[encyclopedia ORGANIC_SPECIES_TITLE]]
-'''
-
-SP_CHATO_GAMEPLAY_DESC
-'''Entità cristalline sessili che cavalcano gli animali Goshk.
-Preferiscono pianeti tossici.
-[[encyclopedia PHOTOTROPHIC_SPECIES_TITLE]]
-'''
 
 
 ##
@@ -3110,9 +3013,6 @@ Singolarità Trascendentale
 GRO_PLANET_ECOL
 Ecologia Planetaria
 
-GRO_PLANET_ECOL_DESC
-L'agricoltura e la scienza medica aumentano drasticamente la capacità di sopravvivenza, inducendo, per un certo tempo, una crescita demografica esponenziale. Ma, prima o poi, nuovi limiti di crescita insorgono nella capacità di trasporto di un pianeta e nella interconnessione vitale che lo supporta. La comprensione dell'Ecologia e la sua interazione agli stress ambientali consente il sostenimento del sistema ed il godimento dei relativi vantaggi per le generazioni future.
-
 GRO_GENETIC_ENG
 Ingegneria Genetica
 
@@ -3130,11 +3030,6 @@ Medicina Genetica
 
 GRO_LIFECYCLE_MAN
 Controllo del Ciclo Vitale
-
-GRO_LIFECYCLE_MAN_DESC
-'''Attraverso manipolazioni chimiche e criogeniche, i processi di vita possono essere interrotti senza terminarli definitivamente. Gli esseri in questo stato sono conservati a tempo indeterminato, non consumano risorse e richiedono un po di stoccaggio - non vivono - nello spazio. Con questa tecnica, la capacità delle navi colonie può essere notevolmente aumentata.
-
-Gli organismi più complessi si sviluppano attraverso varie fasi fisiologiche durante una vita, se distintamente separati da metamorfosi oppure sfocate dal lento invecchiamento. In molti casi, una o più di queste fasi sono, almeno in un dato momento, più utili e desiderabili di altre. Con delicato controllo dei meccanismi ormonali o mentali, diventa possibile velocizzare o rallentare drasticamente ogni fase, permettendo agli individui completamente sviluppati e funzionali di essere prodotti in una frazione del tempo naturale e per quegli individui rimanere funzionale a tempo indeterminato diventando effettivamente immortali.'''
 
 GRO_ADV_ECOMAN
 Ecomanipolazione Avanzata
@@ -3505,9 +3400,6 @@ Scanner Omnidirezionale
 SPY_STEALTH_1
 Smorzatore Elettromagnetico
 
-SPY_STEALTH_1_DESC
-Sblocca la parte della nave elettromagnetica e aumenta la velocità [[metertype METER_STEALTH]] Di tutti i pianeti e gli edifici di 20. Questo bonus non è cumulativo con quello di altre tecniche stealth.
-
 SPY_STEALTH_2
 Campo di Assorbimento
 
@@ -3626,16 +3518,6 @@ Portale Spaziale
 ## Hull and ship part description templates
 ##
 
-# %1% hull base starlane speed.
-# %2% hull base fuel capacity.
-# %3% hull base starlane speed.
-# %4% hull base structure value.
-HULL_DESC
-'''Velocità Rotta Spaziale: %1%
-Capacità Carburante: %2%
-Velocità di Combattimento: %3%
-Salute: %4%'''
-
 # %1% ship part capacity (fuel, troops, colonists, fighters).
 PART_DESC_CAPACITY
 Capacità: %1%
@@ -3643,12 +3525,6 @@ Capacità: %1%
 # %1% ship part strength (other).
 PART_DESC_STRENGTH
 Resistenza: %1%
-
-# %1% ship part damage done (direct fire weapons).
-# %2% number of shots done per attack.
-PART_DESC_DIRECT_FIRE_STATS
-'''Danno Attacco: %1%
-
 
 SR_ION_CANNON
 Cannone a Ioni
@@ -3686,18 +3562,10 @@ Scanner Neutronico
 DT_DETECTOR_4
 Sensori
 
-FU_N_DIMENSIONAL_ENGINE_MATRIX_DESC
-'''Aumenta la velocità di Starlane entro 15. 
-
-La ricerca su N-Dimensionale nel subspazio ha determinato una matrice di motore più efficiente.'''
-
 
 ##
 ## Ship parts
 ##
-
-FU_SINGULARITY_ENGINE_CORE_DESC
-'''Un cugino più piccolo della diga Hyperspace attrezzata per le navi, il motore singolo aumenta drasticamente la generazione di energia. Aumenta la velocità di Starlane entro 20. '''
 
 ST_CLOAK_1
 Smorzatore Elettromagnetico

--- a/default/stringtables/it.txt
+++ b/default/stringtables/it.txt
@@ -1313,30 +1313,8 @@ Guida
 MAP_PRODUCTION_TITLE
 Produzione
 
-MAP_PROD_WASTED_TITLE
-Produzione Inutilizzata
-
-# %1% number of production points generated.
-# %2% number of production points currently not used for production.
-MAP_PROD_WASTED_TEXT
-'''Produzione Totale : %1%
-Produzione Sprecata : %2%
-
-Click qui per aprire il menu di produzione'''
-
 MAP_RESEARCH_TITLE
 Ricerca
-
-MAP_RES_WASTED_TITLE
-Ricerca Inutilizzata
-
-# %1% number of research points generated.
-# %2% number of research points currently not used for research.
-MAP_RES_WASTED_TEXT
-'''Ricerca Totale : %1%
-Ricerca Sprecata : %2%
-
-Click qui per aprire il menu di ricerca'''
 
 MAP_POPULATION_DISTRIBUTION
 Censimento
@@ -1352,12 +1330,6 @@ Commercio
 
 MAP_TRADE_TEXT
 Commercio totale impero. (Commercio non fa nulla)
-
-MAP_FLEET_TITLE
-Conteggio Flotte
-
-MAP_FLEET_TEXT
-Numero totale di navi
 
 
 ##
@@ -1699,7 +1671,7 @@ Dichiara Guerra
 PEACE_PROPOSAL
 Proponi Pace
 
-PEACE_PROPOSAL_CANEL
+PEACE_PROPOSAL_CANCEL
 Annulla Proposta di Pace
 
 PEACE_ACCEPT
@@ -2459,9 +2431,6 @@ SITREP_SHIP_DAMAGED_AT_SYSTEM
 
 SITREP_UNOWNED_SHIP_DAMAGED_AT_SYSTEM
 La %shipdesign% è stata danneggiata da %system%.
-
-SITREP_PLANET_BOMBARDED_AT_SYSTEM
-%empire% pianeta %planet% è stato bombardato da %system%.
 
 SITREP_GROUND_BATTLE
 Una battaglia si è verificata sul pianeta %planet%.
@@ -3680,10 +3649,6 @@ Resistenza: %1%
 PART_DESC_DIRECT_FIRE_STATS
 '''Danno Attacco: %1%
 
-
-
-SR_WEAPON_2_DESC
-Bassa potenza e massa
 
 SR_ION_CANNON
 Cannone a Ioni

--- a/default/stringtables/it.txt
+++ b/default/stringtables/it.txt
@@ -2049,9 +2049,6 @@ METER_STEALTH_VALUE_DESC
 
 Navi spaziali, strutture, speciali, sistemi e pianeti hanno un misuratore di Occultamento.'''
 
-METER_DETECTION_STRENGTH_VALUE_LABEL
-Forza di Rilevamento
-
 PEACE_TITLE
 Pace
 

--- a/default/stringtables/nl.txt
+++ b/default/stringtables/nl.txt
@@ -1425,15 +1425,6 @@ planet omgeving
 DESC_VAR_STARTYPE
 ster type
 
-DESC_VAR_MAXFUEL
-max brandstof
-
-DESC_VAR_MAXSHIELD
-max schild
-
-DESC_VAR_MAXDEFENSE
-max defensie
-
 DESC_VAR_TRADESTOCKPILE
 handel voorraad
 

--- a/default/stringtables/nl.txt
+++ b/default/stringtables/nl.txt
@@ -1340,10 +1340,6 @@ METER_POPULATION
 populatie
 
 # Meter types
-METER_HEALTH
-gezondheid
-
-# Meter types
 METER_INDUSTRY
 industrie
 

--- a/default/stringtables/nl.txt
+++ b/default/stringtables/nl.txt
@@ -105,9 +105,6 @@ COMMAND_LINE_USAGE
 COMMAND_LINE_DEFAULT
 '''Standaard: '''
 
-OPTIONS_DB_HELP
-Geef dit help bericht weer.
-
 OPTIONS_DB_GENERATE_CONFIG_XML
 Gebruikt alle instellingen van ieder bestaand config.xml bestand en de instellingen die op de commandoregel gegeven worden om een config.xml bestand te genereren. Dit overschrijft het huidige config.xml bestand, als het bestaat.
 
@@ -282,24 +279,6 @@ Indien waar, klikken op meerdere vloot knoppen zal meerdere vloot vensters gelij
 OPTIONS_DB_UI_WINDOW_QUICKCLOSE
 Sluit open vensters zoals de vloot venster en het systeem zijpaneel als u op de hoofdkaart rechts-klikt.
 
-OPTIONS_DB_GAMESETUP_STARS
-Het aantal sterren om in de melkweg te genereren.
-
-OPTIONS_DB_GAMESETUP_GALAXY_SHAPE
-De vorm van de melkweg om te genereren.
-
-OPTIONS_DB_GAMESETUP_GALAXY_AGE
-De leeftijd van de melkweg om te genereren.
-
-OPTIONS_DB_GAMESETUP_PLANET_DENSITY
-Het aantal planeten per systeem in de melkweg om te genereren.
-
-OPTIONS_DB_GAMESETUP_STARLANE_FREQUENCY
-Het aantal sterrenbanen in de melkweg om te genereren.
-
-OPTIONS_DB_GAMESETUP_SPECIALS_FREQUENCY
-'''De frequentie van verschijning van specials in de melkweg om te genereren. '''
-
 OPTIONS_DB_UI_TECH_LAYOUT_HORZ_SPACING
 De horizontale afstand tussen technologiÃ«n in het onderzoeksvenster, in meerdere van de breedte voor iedere enkele theorie technologie.
 
@@ -328,15 +307,6 @@ Het volume (0 tot 255) waarop de muziek afgespeeld moet worden.
 
 FILE_DLG_FILES
 Bestand(en):
-
-FILE_DLG_OVERWRITE_PROMPT
-%1% bestaat.\nMag het overschreven worden?
-
-FILE_DLG_FILENAME_IS_A_DIRECTORY
-"%1%"\nis een directory.
-
-FILE_DLG_FILE_DOES_NOT_EXIST
-Bestand "%1%"\nbestaat niet.
 
 FILE_DLG_DEVICE_IS_NOT_READY
 Apparaat is niet gereed.
@@ -1162,14 +1132,8 @@ SITREP_FLEET_ARRIVED_AT_DESTINATION
 ANCIENT_RUINS_SPECIAL
 Oude Ruïnes
 
-ANCIENT_RUINS_SPECIAL_DESCRIPTION
-Deze planeet bevat de ruÃ¯nes van een geavanceerde oude soort, die vergeten en niet in de geschiedenisboeken terug te vinden zijn, dit geeft een bonus in onderzoek.
-
 ECCENTRIC_ORBIT_SPECIAL
 Eccentrische Omloopbaan
-
-ECCENTRIC_ORBIT_SPECIAL_DESC
-De omloopbaan van deze planeet is zeer eccentrisch. Er is een groot verschil tussen de afstand met zijn ster gedurende het jaar. De hoeveelheid energie die de planeet van de ster ontvangt verschilt sterk gedurende het jaar. Deze fluctuerende condities beperken infrastructuurontwikkeling, maar geven een voordelig platform voor onderzoek.
 
 MINERALS_SPECIAL
 Minerale Rijkdom
@@ -1524,29 +1488,14 @@ De structuren en hun functies in het brein worden bepaald. De electroschemische 
 LRN_ALGO_ELEGANCE
 Algoritmische Elegantie
 
-LRN_ALGO_ELEGANCE_DESC
-Met toenemende complexiteit van gegevens analyse problemen, traditionele metingen van de algoritme efficientie worden steeds minder bruikbaar door de beperkingen van onomkeerbare complexiteit. Op dit punt worden andere meetmethoden van algoritmische vorm en functie significant; esthetisch en metaforisch, de elegantie van de oplossing moet geoptimaliseerd worden.
-
 LRN_TRANSLING_THT
 Translinguïstiek
-
-LRN_TRANSLING_THT_DESC
-Een minder intellect worstelt met, of accepteert de beperkingen van de taalt die ze geleerd hebben. Toerijkende intellectuelen bereiken en voelen een beperking door de concepten om dingen te verwoorden. Echt grote intellectuelen kunnen zich ontdoen van de ketens van de taal, vormen en analyseren gedachten over de rand van een verhevenheid. Maar mindere grote intellectuelen zullen geisoleerd en onbeduidend achterblijven, want zonder taal om gedachten over te brengen, hoe moeten zij hun inzichten delen?
-
-LRN_PSIONICS_DESC
-Door diepe introspectie of kunstmatige verbeteringen kan het brein eigenschappen ontwikkelen om directe interactie met het universum eromheen uit te voeren, daarmee beperkingen van het fysieke lichaam te omzijlen. Krachten als telepathie, empathie, helderziendheid, voorkennis, telekinese en psycho-energetica vervangen hun normaal biologische of technologische alternatieven. Toepassing van deze krachten, inclusief hersenspoelen, personaliteitsverandering en bezetenheid hebben diepe implicaties voor relaties tussen getallenteerde en niet-getallenteerde wezens.
 
 LRN_ARTIF_MINDS
 Kunstmatig Verstand
 
-LRN_ARTIF_MINDS_DESC
-Terwijl traditionele computers een bijna onmeetbare intelligentie en calculerend vermogen hebben, missen ze de essentiele kwaliteiten van het begrip dat ze bestaan, bewustzijn en waarneming. Met de ontwikkeling van echte kunstmatig verstand kunnen deze kwaliteiten gesynthetiseerd, aangepast en veranderd worden. Deze onderzoeken openen nieuwe onderzoekswegen in congnitieve wetenschappen en nieuwe metaparadigma's.
-
 LRN_XENOARCH
 Xenoarchaeologie
-
-LRN_XENOARCH_DESC
-De hedendaagse rijken, rassen en enkele-ster beschavingen zijn niet de eerste of enige wezens die in dit universum hebben geleefd. Overblijfselen, ruines en geruchten van oude beschavingen kunnen op verlaten planeten, levenloze astroiden of zwervend door de open ruimte gevonden worden. Het vinden en ontcijferen van dergelijke aanwijzingen heeft grote potentie om geheimen te onthullen, lessen te leren of waarschuwingen over vergeten kennis te geven.
 
 LRN_GRAVITONICS
 Gravitoniek
@@ -1562,9 +1511,6 @@ Vroege, naïve theoriën beschreven onderdelen van de vier fundamentele krachten
 
 LRN_FORCE_FIELD
 Krachtveld Harmoniciteit
-
-LRN_FORCE_FIELD_DESC
-Net zoals met Fourier analyse op geluid, kunnen elektromagnetisme, sterke en zwakke krachten uitgedrukt worden in harmonische superposities van quantumgolven van krachtdragende deeltjes. Door deze harmonische golven selectief te versterken, kunnen de krachten gemanilpuleerd worden om als schild, ondersteuning, opslag of als wapen gebruikt te worden.
 
 LRN_MIND_VOID
 Gedachte van het Lege
@@ -1587,9 +1533,6 @@ Vroege superstring theoretici spraken over 10, 11 of 26 dimensionele universums,
 GRO_PLANET_ECOL
 Planetaire Ecologie
 
-GRO_PLANET_ECOL_DESC
-Agrocultuur en medische wetenschappen kunnen overleving drastisch vergroten, waardoor de populatiegroei gedurende een tijd hyperexponentieel kan groeien. Uiteindelijk zullen nieuwe limieten voor de groeicapaciteit van een planeet en het interverbonden web van leven dat het ondersteunt verschijnen. Begrip van natuurlijke ecologie en zijn interactie met stressfactoren laten het systeem ondersteunen en de nakomende generaties er voordeel uit halen.
-
 GRO_GENETIC_ENG
 Genetische Modificatie
 
@@ -1611,38 +1554,20 @@ Traditionele Genetische Modificatie past de genetische code aan, implementeert d
 GRO_LIFECYCLE_MAN
 Levenscyclus Manipulatie
 
-GRO_LIFECYCLE_MAN_DESC
-Meeste complexe organismen gaan door een proces door verschillende fysiologische stadia gedurende een leven, zowel via duidelijk gescheiden metamorphoses als vage, continue verouderingsprocessen. In veel gevallen is een of meerdere van deze stadiums meer bruikbaar en gewenst dan andere. Door nauwkeurige controle van hormonale en mentale mechanismen wordt het mogelijk om de snelheid van elk stadium te versnellen of vertragen, waardoor volledig ontwikkelde en functionele individuen geproduceerd kunnen worden in een fractie van de natuurlijke tijdsspan. Die individuen blijven daarnaast ook oneindig functioneel, waardoor ze zo goed als onsterfelijk worden.
-
 GRO_XENO_GENETICS
 Xenologische Genetica
-
-GRO_XENO_GENETICS_DESC
-Vroege genetica is beperkt door de beschikbaarheid van monsters van natuurlijk voorkomende organismen om modificaties op te baseren. Daarnaast zijn deze modificaties beperkt binnen de limieten van de fysische mechanismen voor de opslag, aanpassing en expressie van de genetische code in ontwikkelde individuen. Door equivalente systemen in compleet verschillende ecosystemen en organismen te onderzoeken kan meer inzicht en openbaringen verkregen verkregen worden, waardoor nieuwe ontwikkelingen in meer bekende genetische systemen versneld worden.
 
 GRO_NANOTECH_MED
 Nanotech Medicijn
 
-GRO_NANOTECH_MED_DESC
-Terwijl genetische aanpassingen de effecten van ongewenste of schadelijke mutaties of onjuiste biochemische balansen kan repareren of ongedaan maken, kunnen grote fysische trauma's en niet-genetische aangeboren afwijkingen alleen met fysische aanpassingen behandeld worden. Nanotechnologie kan gebruikt worden om dit te bereiken, met twee voordelen: Aanpassingen kunnen zonder invasieve operaties en bijbehordende secundaire schade en risico's gedaan worden, en de tijd voor de behandeling is sterk gereduceerd aangezien de gereedschappen om de taak te doen altijd op de juiste plaats en klaar voor gebruik zijn.
-
 PRO_MICROGRAV_MAN
 Microzwaartekracht Productie
-
-PRO_MICROGRAV_MAN_DESC
-De microzwaartekracht van een lage omloopbaan rond een planeet biedt veel potentie voor nieuwe productiehal ontwerpen, apparatuur ontwerpen en technieken die niet mogelijk zijn op een planeetoppervlakte. Vaste stoffen kunnen met minimale ondersteuning op hun plaats gehouden worden. Vloeistoffen en gassen verplaatsen zich vrij, gevormd door hun oppervlaktespanning, tenzij ze anders gemanipuleerd worden. Fabrieksapparatuur kan optimaal in 3 dimensies geplaatst worden. Indien op de juiste manier toegepast kunnen deze condities de efficientie en het productieproces sterk vergroten.
 
 PRO_ROBOTIC_PROD
 Robotische Productie
 
-PRO_ROBOTIC_PROD_DESC
-Hoewel de het initieel ontwerp hoge eisen stelt en de initiele implementatie van de fabrieken nog steeds supervisie vereisen, zal de vervanging van het bedieningspersoneel van het feitelijke productieproces vele bottlenecks elimineren. Robots werken continue, zonder doorlopende eisen voor meer economische compensatie. Robots hebben veel meer tolerantie voor gevaarlijke omgevingscondities in de fabriek en vereisen geen additionele leefruimte buiten de werkplek. Robots vervullen hun taak foutloos, of ten minste zo goed als ze worden opgedragen.
-
 PRO_FUSION_GEN
 Fusie Generatie
-
-PRO_FUSION_GEN_DESC
-Explosieve of ongecontrolleerde thermonucleaire reacties zijn relatief eenvoudig te maken op de schaal van kleine tactische kernkoppen tot supergigantische stellaire ovens. Controlleerbare, stabiele en praktische energieproductie van dergelijke reacties is iets wat moeilijker. Het proces blijft aantrekkelijk doordat er een bijna-onbeperkte aanvoer van energie ontstaat die emissie-vrij verloopt.
 
 SHP_GAL_EXPLO
 Galactische Ontdekkingsreizen
@@ -1672,9 +1597,6 @@ Vergroot Planeet Populatie
 
 GRO_BIOTERROR
 Bioterreur Faciliteiten
-
-SPY_DETECT_2_DESC
-Ontsluit Actieve Radar scheepsonderdeel.
 
 
 ##

--- a/default/stringtables/pl.txt
+++ b/default/stringtables/pl.txt
@@ -131,9 +131,6 @@ COMMAND_LINE_USAGE
 COMMAND_LINE_DEFAULT
 '''Domyślne: '''
 
-OPTIONS_DB_HELP
-Wyświetl ten tekst pomocniczy.
-
 OPTIONS_DB_GENERATE_CONFIG_XML
 Używa wszystkich ustawień z obecnego pliku config.xml o ile taki istnieje oraz tych podanych z linii komend do wygenerowania nowego pliku config.xml . Ta operacja nadpisze obecny plik config.xml , jeśli istnieje.
 
@@ -374,32 +371,11 @@ Ustala rozmiar największych renderowanych, obracających się planet w panelu b
 OPTIONS_DB_UI_SIDEPANEL_PLANET_MIN_DIAMETER
 Ustala rozmiar najmniejszych renderowanych, obracających się planet w panelu bocznym.
 
-OPTIONS_DB_GAMESETUP_STARS
-Ilość gwiazd w galaktyce do wygenerowania.
-
-OPTIONS_DB_GAMESETUP_GALAXY_SHAPE
-Kształt galaktyki do wygenerowania.
-
-OPTIONS_DB_GAMESETUP_GALAXY_AGE
-Wiek galaktyki do wygenerowania.
-
-OPTIONS_DB_GAMESETUP_PLANET_DENSITY
-Ilość planet w każdym systemie w galaktyce do wygenerowania.
-
-OPTIONS_DB_GAMESETUP_STARLANE_FREQUENCY
-Ilość szlaków gwiezdnych w galaktyce do wygenerowania.
-
-OPTIONS_DB_GAMESETUP_SPECIALS_FREQUENCY
-Częstotliwość pojawiania się elementów specjalnych w galaktyce do wygenerowania.
-
 OPTIONS_DB_GAMESETUP_EMPIRE_NAME
 Nazwa dla Twojego imperium w grze.
 
 OPTIONS_DB_GAMESETUP_EMPIRE_COLOR
 Kolor Twojego imperium w grze.
-
-OPTIONS_DB_GAMESETUP_NUM_AI_PLAYERS
-Ilość przeciwników SI w grze.
 
 OPTIONS_DB_UI_TECH_LAYOUT_HORZ_SPACING
 Poziomy odstęp pomiędzy technologiami na ekranie technologii, wyrażony w wielokrotności szerokości jednej teorii technologicznej.
@@ -432,21 +408,6 @@ Plik(i):
 
 FILE_DLG_FILE_TYPES
 Typ(y):
-
-FILE_DLG_OVERWRITE_PROMPT
-'''%1% już istnieje.
-
-Nadpisać?'''
-
-FILE_DLG_FILENAME_IS_A_DIRECTORY
-'''"%1%"
-
-jest katalogiem.'''
-
-FILE_DLG_FILE_DOES_NOT_EXIST
-'''Plik "%1%"
-
-nie istnieje.'''
 
 FILE_DLG_DEVICE_IS_NOT_READY
 Urządzenie nie jest gotowe.
@@ -924,9 +885,6 @@ Wcześniejsze naiwne teorie opisywały tą teorię jako synteza czterech podstaw
 LRN_FORCE_FIELD
 Harmoniczność pól siłowych
 
-LRN_FORCE_FIELD_DESC
-Podobnie jak w przypadku analizy Fouriera fal dźwiękowych, elektromagnetyzm, a także silne i słabe siły mogą być wyrażona jako harmoniczne fale stojące superpozycji kwantowej pola sił. Poprzez selektywne rozszerzenie harmoniczności tych fal, siły te mogą być dowolnie kontrolowane zapewniając w określonych warunkach ekranowanie, wzmocnienie, osłonę lub podparcie.
-
 LRN_MIND_VOID_DESC
 Nie jesteśmy sami w kosmosie... ale dlaczego nasze poszukiwania są tak ograniczone? Wiele kultur w mitach, legendach lub poprzez gorącą wiarę wskazuje na swego rodzaju wyższą świadomość. Można kochać lub walczyć z ideą Boga czy innego obserwatora, jest jednak oczywiste, że coś - być może wszechświat na pewnym poziomie - jest żywe, świadome, obserwujące.
 
@@ -965,12 +923,6 @@ Zwiększa zasięg okrętu powiększając jego zasoby paliwa.
 BLD_OBSERVATORY
 Obserwatorium
 
-BLD_OBSERVATORY_DESC
-'''Naturalne rozszerzenie teleskopów przemysłowych i informacyjnych, wyposażające je w wojskowe algorytmy umożliwiające wykrywanie obiektów na dużych odległościach. Planeta, na której wybudowano obserwatorium wysyła w kosmos potężne impulsy wykrywające. Z tego powodu ukrycie takiej planety staje się bardzo trudne. Z drugiej strony, impulsy te mogą zostać odbite przez wszystkie obiekty znajdujące się we względnej bliskości planety, co bardzo ułatwia wykrywanie takich obiektów z zaprzyjaźnionych planet znajdujących się w zasięgu obserwatorium.
-
-Dodaje +10 do współczynnika Wykrywanie na wszystkich zaprzyjaźnionych planetach znajdujących się w odległości nie większej niż 200.
-Na planecie, na której wybudowano obserwatorium współczynnik Ukrywanie zmniejsza się o 10.'''
-
 
 ##
 ## Hull and ship part description templates
@@ -1002,32 +954,17 @@ DT_DETECTOR_2_DESC
 ST_CLOAK_1
 Tłumik elektromagnetyczny
 
-ST_CLOAK_1_DESC
-Zmniejsza wykrywalność okrętu, na którym został zamontowany, poprzez tłumienie emisji elektromagnetycznych generowanych przez systemy okrętu. Może skompensować tylko niewielką ilość takich emisji, dlatego elementy generujące wiele szumów nie będą przez niego skutecznie maskowane.
-
 SH_DEFENSE_GRID
 Siatka ochronna
-
-SH_DEFENSE_GRID_DESC
-Słaba ochrona, ale nie dodaje masy.
 
 SH_DEFLECTOR
 Osłony
 
-SH_DEFLECTOR_DESC
-Mocna ochrona przy zachowaniu niewielkiej masy.
-
 CO_COLONY_POD
 Kapsuła kolonizacyjna
 
-CO_COLONY_POD_DESC
-Umożliwia osadnikom przetrwanie podróży do nowej planety. Umożliwia okrętom kolonizowanie nowych światów.
-
 CO_SUSPEND_ANIM_POD
 Krioniczna kapsuła kolonizacyjna.
-
-CO_SUSPEND_ANIM_POD_DESC
-W trakcie podróży kolonizacyjnej osadnicy utrzymywani są w stanie obniżonego metabolizmu, dzięki czemu nie ma konieczności ich żywienia, a to z kolei zwiększa liczbę osadników przenoszonych przez jeden okręt.
 
 
 ##

--- a/default/stringtables/sv.txt
+++ b/default/stringtables/sv.txt
@@ -99,9 +99,6 @@ Spelare %1% har inte längre förbindelse med servern.
 ## Command-line and options database entries
 ##
 
-OPTIONS_DB_HELP
-Skriv ut detta hjälpmeddelande.
-
 OPTIONS_DB_BG_MUSIC
 Väljer bakgrundsspår att spela.
 
@@ -168,24 +165,6 @@ Ljudfilen som spelas då muspekaren flyttas ovanför en systemikon.
 OPTIONS_DB_UI_SOUND_SIDEPANEL_OPEN
 Ljudfilen som spelas då systemets sidpanel öppnas.
 
-OPTIONS_DB_GAMESETUP_STARS
-Antalet stjärnor i galaxen som kommer att genereras.
-
-OPTIONS_DB_GAMESETUP_GALAXY_SHAPE
-Formen på galaxen som kommer att genereras.
-
-OPTIONS_DB_GAMESETUP_GALAXY_AGE
-Galaxens ålder som kommer att genereras.
-
-OPTIONS_DB_GAMESETUP_PLANET_DENSITY
-Antalet planeter per system i galaxen som kommer att genereras.
-
-OPTIONS_DB_GAMESETUP_STARLANE_FREQUENCY
-Antalet stjärnfarleder i galaxen som kommer att genereras.
-
-OPTIONS_DB_GAMESETUP_SPECIALS_FREQUENCY
-Förekomsten av specialare i galaxen som kommer att genereras.
-
 
 ##
 ## File dialog
@@ -196,15 +175,6 @@ Fil(er):
 
 FILE_DLG_FILE_TYPES
 Typ(er):
-
-FILE_DLG_OVERWRITE_PROMPT
-%1% existerar redan.\nVill du skriva över den?
-
-FILE_DLG_FILENAME_IS_A_DIRECTORY
-"%1%"\när en katalog.
-
-FILE_DLG_FILE_DOES_NOT_EXIST
-Fil "%1%"\nexisterar inte.
 
 
 ##
@@ -1006,14 +976,8 @@ SITREP_FLEET_ARRIVED_AT_DESTINATION
 ANCIENT_RUINS_SPECIAL
 Uråldriga ruiner
 
-ANCIENT_RUINS_SPECIAL_DESCRIPTION
-Denna planet hyser ruiner efter en högutvecklad forntida ras, vars kännedom för länge sedan gått förlorad. Ger en bonus till din forskning i form av högre avkastning.
-
 ECCENTRIC_ORBIT_SPECIAL
 Excentrisk bana
-
-ECCENTRIC_ORBIT_SPECIAL_DESC
-Denna planets bana är väldigt excentrisk. Den har ett stort avstånd mellan dess närmaste och mest avlägsna ansats till dess stjärna. De omväxlande förhållandena hämmar utveckling av infrastruktur, men skapar ett gynnande underlag för forskning.
 
 MINERALS_SPECIAL
 Rik på mineraler

--- a/default/stringtables/sv.txt
+++ b/default/stringtables/sv.txt
@@ -1148,10 +1148,6 @@ METER_POPULATION
 population
 
 # Meter types
-METER_HEALTH
-hälsa
-
-# Meter types
 METER_INDUSTRY
 industri
 

--- a/default/stringtables/sv.txt
+++ b/default/stringtables/sv.txt
@@ -1225,15 +1225,6 @@ objekttyp
 DESC_VAR_STARTYPE
 stjärntyp
 
-DESC_VAR_MAXFUEL
-maximalt bränsle
-
-DESC_VAR_MAXSHIELD
-maximal sköld
-
-DESC_VAR_MAXDEFENSE
-maximalt försvar
-
 DESC_VAR_TRADESTOCKPILE
 handelsreserv
 


### PR DESCRIPTION
This PR drops stale translation entries from the unmaintained translation tables.

To identify stale entries one of the following condition applies:
* The entry key does not exist in en.txt
* The entry value is identical to the corresponding en.txt entry
* The entry exists despite the corresponding en.txt entry is only a substitution reference (the whole value is enclosed via `[[]]`).
* The entry value has a different amount of lines than the corresponding en.txt entry

Except from the last condition I would consider those unambigious.  For the last one I would rather remove potentially good (only difference by e.g. whitespace shuffling) over keeping potentially bad translation entries (describing outdated gameplay elements wrongly) as those leave the everlasting first bad impression to players.  Also the application layout expects the format used in the en.txt so its more likely to see bad rendering when using different layouts.

The PR only covers stringtables without any active maintance so the default action was the removal of entries with some exceptions where the change was obviously of cosmetic nature.