### PR TITLE
Remove seemingly unnecessary use of deprecated std::unary_function.

### DIFF
--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -214,7 +214,8 @@ public:
         bool operator()(const iterator& lhs, const iterator& rhs) const;
     };
 
-    struct IteratorHash : std::unary_function<iterator, std::size_t> {
+    struct IteratorHash
+    {
         std::size_t operator()(const iterator& it) const
         { return boost::hash<const std::shared_ptr<Row>>()(*it); }
     };


### PR DESCRIPTION
Seems to resolve https://github.com/freeorion/freeorion/issues/2782