### PR TITLE
Fix headless compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -118,6 +118,24 @@ jobs:
         - cmake -DBUILD_TESTING=ON ..
         - cmake --build . -- -j 2
 
+    - name: Build headless FreeOrion on Ubunutu 18.04 (Bionic)
+      <<: *_build_cpp_common
+      os: linux
+      dist: bionic
+      services:
+        - docker
+      before_install:
+        - docker pull freeorion/freeorion-travis-build
+        # mount ccache dir and set its environment variable
+        # timeout before Travis kills jobs so that ccache is always at least partially populated
+        - >
+          function cmake {
+              docker run -v "${TRAVIS_BUILD_DIR}:/freeorion"  -v "${HOME}/.ccache:/ccache_dir" -e CCACHE_DIR='/ccache_dir' -w /freeorion/build freeorion/freeorion-travis-build timeout 40m /usr/bin/cmake $@
+          }
+      script:
+        - cmake -DBUILD_HEADLESS=ON -DBUILD_TESTING=ON ..
+        - cmake --build . -- -j 2
+
     - name: Build FreeOrion on MacOS 10.12
       <<: *_build_cpp_common
       os: osx

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -261,14 +261,12 @@ if(BUILD_TESTING)
     add_subdirectory(test)
 endif()
 
-if(NOT BUILD_HEADLESS)
-    set(BUILD_DEVEL_PACKAGE OFF CACHE INTERNAL "Disables installation of GiGi development files." FORCE)
-    set(_ORIG_CMAKE_INSTALL_LIBDIR ${CMAKE_INSTALL_LIBDIR})
-    set(CMAKE_INSTALL_LIBDIR "${FreeOrion_INSTALL_LIBDIR}")
-    add_subdirectory(GG)
-    set(CMAKE_INSTALL_LIBDIR ${_ORIG_CMAKE_INSTALL_LIBDIR})
-    unset(_ORIG_CMAKE_INSTALL_LIBDIR)
-endif()
+set(BUILD_DEVEL_PACKAGE OFF CACHE INTERNAL "Disables installation of GiGi development files." FORCE)
+set(_ORIG_CMAKE_INSTALL_LIBDIR ${CMAKE_INSTALL_LIBDIR})
+set(CMAKE_INSTALL_LIBDIR "${FreeOrion_INSTALL_LIBDIR}")
+add_subdirectory(GG)
+set(CMAKE_INSTALL_LIBDIR ${_ORIG_CMAKE_INSTALL_LIBDIR})
+unset(_ORIG_CMAKE_INSTALL_LIBDIR)
 
 set_property(DIRECTORY APPEND
     PROPERTY COMPILE_DEFINITIONS
@@ -350,12 +348,16 @@ if(APPLE)
 endif()
 
 target_compile_definitions(freeorioncommon
+    PUBLIC
+        -DBOOST_ALL_DYN_LINK
     PRIVATE
-    -DFREEORION_BUILD_COMMON
-    -DFREEORION_PYTHON_VERSION=\"${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}\"
+        -DFREEORION_BUILD_COMMON
+        -DFREEORION_PYTHON_VERSION=\"${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}\"
 )
 
 target_include_directories(freeorioncommon SYSTEM
+    PUBLIC
+        $<TARGET_PROPERTY:GiGi::GiGi,INCLUDE_DIRECTORIES>
     PRIVATE
         ${CMAKE_SOURCE_DIR}
 )
@@ -373,8 +375,6 @@ target_link_libraries(freeorioncommon
         Boost::thread
         Boost::serialization
         ZLIB::ZLIB
-    PUBLIC
-        GiGi::GiGi
     PRIVATE
         ${CORE_FOUNDATION_LIBRARY}
 )
@@ -411,6 +411,13 @@ target_include_directories(freeorionparseobj
         $<TARGET_PROPERTY:GiGi::GiGi,INCLUDE_DIRECTORIES>
 )
 
+if(NOT BUILD_HEADLESS)
+    target_link_libraries(freeorioncommon
+        PUBLIC
+            GiGi::GiGi
+    )
+endif()
+
 set_property(TARGET freeorionparseobj
     PROPERTY
     POSITION_INDEPENDENT_CODE ON
@@ -436,6 +443,8 @@ target_compile_options(freeorionparseobj
 )
 
 target_compile_definitions(freeorionparseobj
+    PUBLIC
+        -DBOOST_ALL_DYN_LINK
     PRIVATE
         -DNDEBUG
         -DFREEORION_BUILD_PARSE

--- a/GG/CMakeLists.txt
+++ b/GG/CMakeLists.txt
@@ -54,6 +54,7 @@ option(BUILD_SDL_DRIVER "Builds GG SDL support (the GiGiSDL library)." ON)
 option(BUILD_DOCUMENTATION "Builds HTML documentation." OFF)
 option(BUILD_TESTING "Build the testing tree." OFF)
 option(BUILD_DEVEL_PACKAGE "Install development files." ON)
+option(BUILD_HEADLESS "Headless components: server and AI." OFF)
 
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
@@ -82,31 +83,32 @@ set(MINIMUM_BOOST_VERSION 1.58.0)
 
 find_package(Boost ${MINIMUM_BOOST_VERSION} COMPONENTS filesystem regex system REQUIRED)
 
-find_package(OpenGL REQUIRED)
-find_package(GLEW REQUIRED)
-find_package(Freetype REQUIRED)
-
-if(NOT OPENGL_GLU_FOUND)
-    message(FATAL_ERROR "OpenGL GLU library not found.")
+if(NOT BUILD_HEADLESS)
+    find_package(OpenGL REQUIRED)
+    find_package(GLEW REQUIRED)
+    find_package(Freetype REQUIRED)
+    
+    if(NOT OPENGL_GLU_FOUND)
+        message(FATAL_ERROR "OpenGL GLU library not found.")
+    endif()
+    
+    if(ENABLE_PNG_TEXTURES)
+        find_package(PNG REQUIRED)
+        set(int_have_png 1)
+    else()
+        set(int_have_png 0)
+    endif()
+    
+    if(ENABLE_TIFF_TEXTURES)
+        find_package(TIFF REQUIRED)
+        set(int_have_tiff 1)
+    else()
+        set(int_have_tiff 0)
+    endif()
+    set(SDL_NO_MAIN true)
+    
+    find_package(SDL REQUIRED)
 endif()
-
-if(ENABLE_PNG_TEXTURES)
-    find_package(PNG REQUIRED)
-    set(int_have_png 1)
-else()
-    set(int_have_png 0)
-endif()
-
-if(ENABLE_TIFF_TEXTURES)
-    find_package(TIFF REQUIRED)
-    set(int_have_tiff 1)
-else()
-    set(int_have_tiff 0)
-endif()
-set(SDL_NO_MAIN true)
-
-find_package(SDL REQUIRED)
-
 
 include_directories(
     ${CMAKE_CURRENT_SOURCE_DIR}
@@ -140,78 +142,85 @@ target_compile_definitions(GiGi
 )
 
 target_include_directories(GiGi
-    INTERFACE
-        ${OPENGL_INCLUDE_DIR}
-    PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
-    PRIVATE
-        ${FREETYPE_INCLUDE_DIRS}
-)
-
-target_link_libraries(GiGi
-    PUBLIC
-        GLEW::GLEW
-        Boost::boost
-        Boost::disable_autolinking
-        Boost::dynamic_linking
-        Boost::filesystem
-        ${OPENGL_gl_LIBRARY}
-        ${OPENGL_glu_LIBRARY}
-    PRIVATE
-        Boost::regex
-        ${FREETYPE_LIBRARIES}
-)
-
-if(TARGET PNG::PNG)
-    target_link_libraries(GiGi PRIVATE PNG::PNG)
-endif()
-
-if(TARGET TIFF::TIFF)
-    target_link_libraries(GiGi PRIVATE TIFF::TIFF)
-endif()
-
-
-add_library(GiGiSDL "")
-
-add_library(GiGi::GiGiSDL ALIAS GiGiSDL)
-
-target_include_directories(GiGiSDL SYSTEM
-    INTERFACE
-        ${SDL_INCLUDE_DIR}
     PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
 )
 
-target_link_libraries(GiGiSDL
-    PUBLIC
-        GiGi::GiGi
-        ${SDL_LIBRARIES}
-    PRIVATE
-        Boost::boost
-        Boost::disable_autolinking
-        Boost::dynamic_linking
-)
+set_target_properties(GiGi PROPERTIES LINKER_LANGUAGE CXX)
 
+if(NOT BUILD_HEADLESS)
+    target_include_directories(GiGi
+        INTERFACE
+            ${OPENGL_INCLUDE_DIR}
+        PRIVATE
+            ${FREETYPE_INCLUDE_DIRS}
+    )
 
-##
-## Recurse into sources.
-##
-
-add_subdirectory(GG)
-add_subdirectory(src)
-
-if(BUILD_TESTING)
-    enable_testing()
-    enable_coverage()
-
-    if(NOT TARGET unittest)
-        add_custom_target(unittest
-            COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
-            COMMENT "Run tests for ${CMAKE_PROJECT_NAME}"
-        )
+    target_link_libraries(GiGi
+        PUBLIC
+            GLEW::GLEW
+            Boost::boost
+            Boost::disable_autolinking
+            Boost::dynamic_linking
+            Boost::filesystem
+            ${OPENGL_gl_LIBRARY}
+            ${OPENGL_glu_LIBRARY}
+        PRIVATE
+            Boost::regex
+            ${FREETYPE_LIBRARIES}
+    )
+    
+    if(TARGET PNG::PNG)
+        target_link_libraries(GiGi PRIVATE PNG::PNG)
     endif()
-
-    add_subdirectory(test)
+    
+    if(TARGET TIFF::TIFF)
+        target_link_libraries(GiGi PRIVATE TIFF::TIFF)
+    endif()
+    
+    
+    add_library(GiGiSDL "")
+    
+    add_library(GiGi::GiGiSDL ALIAS GiGiSDL)
+    
+    target_include_directories(GiGiSDL SYSTEM
+        INTERFACE
+            ${SDL_INCLUDE_DIR}
+        PUBLIC
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+    )
+    
+    target_link_libraries(GiGiSDL
+        PUBLIC
+            GiGi::GiGi
+            ${SDL_LIBRARIES}
+        PRIVATE
+            Boost::boost
+            Boost::disable_autolinking
+            Boost::dynamic_linking
+    )
+    
+    
+    ##
+    ## Recurse into sources.
+    ##
+    
+    add_subdirectory(GG)
+    add_subdirectory(src)
+    
+    if(BUILD_TESTING)
+        enable_testing()
+        enable_coverage()
+    
+        if(NOT TARGET unittest)
+            add_custom_target(unittest
+                COMMAND ${CMAKE_CTEST_COMMAND} --output-on-failure
+                COMMENT "Run tests for ${CMAKE_PROJECT_NAME}"
+            )
+        endif()
+    
+        add_subdirectory(test)
+    endif()
 endif()
 
 if(BUILD_DOCUMENTATION)
@@ -231,7 +240,7 @@ if(BUILD_DEVEL_PACKAGE)
     )
 endif()
 
-if(UNIX AND NOT APPLE)
+if(UNIX AND NOT APPLE AND NOT BUILD_HEADLESS)
     install(
         TARGETS GiGi
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -243,7 +252,7 @@ if(UNIX AND NOT APPLE)
     )
 endif()
 
-if(UNIX AND BUILD_DEVEL_PACKAGE)
+if(UNIX AND BUILD_DEVEL_PACKAGE AND NOT BUILD_HEADLESS)
     get_pkg_config_libs(pkg_config_libs ${GiGi_LINK_LIBS})
 
     configure_file(
@@ -261,7 +270,7 @@ if(UNIX AND BUILD_DEVEL_PACKAGE)
 endif()
 
 
-if(UNIX AND NOT APPLE)
+if(UNIX AND NOT APPLE AND NOT BUILD_HEADLESS)
     install(
         TARGETS GiGiSDL
         LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
@@ -273,7 +282,7 @@ if(UNIX AND NOT APPLE)
     )
 endif()
 
-if(UNIX AND BUILD_DEVEL_PACKAGE)
+if(UNIX AND BUILD_DEVEL_PACKAGE AND NOT BUILD_HEADLESS)
     get_pkg_config_libs(pkg_config_libs ${GiGiSDL_LINK_LIBS})
 
     configure_file(


### PR DESCRIPTION
For server-side deploy freeorion should be able to build without graphic libraries. Common and server code depends on `GG::Clr` and `GG_ENUM`.

Before it was enough to use include files from GiGi without it compilation, but after https://github.com/freeorion/freeorion/pull/2751 it stared to require GiGi project.