### PR TITLE
Reference Production Queue Elements by UUID

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -1272,7 +1272,7 @@ void Empire::MoveProductionWithinQueue(int index, int new_index) {
         new_index < 0 || static_cast<int>(m_production_queue.size()) <= new_index)
     {
         DebugLogger() << "Empire::MoveProductionWithinQueue index: " << index << "  new index: "
-                               << new_index << "  queue size: " << m_production_queue.size();
+                      << new_index << "  queue size: " << m_production_queue.size();
         ErrorLogger() << "Attempted to move a production queue item to or from an invalid index.";
         return;
     }

--- a/Empire/ProductionQueue.cpp
+++ b/Empire/ProductionQueue.cpp
@@ -528,7 +528,7 @@ std::string ProductionQueue::ProductionItem::Dump() const {
 // ProductionQueue::Element //
 //////////////////////////////
 ProductionQueue::Element::Element() :
-     m_uuid(boost::uuids::nil_generator()())
+     uuid(boost::uuids::nil_generator()())
 {}
 
 ProductionQueue::Element::Element(ProductionItem item_, int empire_id_, int ordered_,
@@ -543,7 +543,7 @@ ProductionQueue::Element::Element(ProductionItem item_, int empire_id_, int orde
     blocksize_memory(blocksize_),
     paused(paused_),
     allowed_imperial_stockpile_use(allowed_imperial_stockpile_use_),
-    m_uuid(boost::uuids::nil_generator()())
+    uuid(boost::uuids::nil_generator()())
 {}
 
 ProductionQueue::Element::Element(BuildType build_type, std::string name, int empire_id_, int ordered_,
@@ -691,6 +691,22 @@ const ProductionQueue::Element& ProductionQueue::operator[](int i) const {
     if (i < 0 || i >= static_cast<int>(m_queue.size()))
         throw std::out_of_range("Tried to access ProductionQueue element out of bounds");
     return m_queue[i];
+}
+
+ProductionQueue::const_iterator ProductionQueue::find(boost::uuids::uuid uuid) const {
+    if (uuid == boost::uuids::nil_generator()())
+        return m_queue.end();
+    for (auto it = m_queue.begin(); it != m_queue.end(); ++it)
+        if (it->uuid == uuid)
+            return it;
+    return m_queue.end();
+}
+
+int ProductionQueue::IndexOfUUID(boost::uuids::uuid uuid) const {
+    auto it = find(uuid);
+    if (it == end())
+        return -1;
+    return std::distance(begin(), it);
 }
 
 void ProductionQueue::Update() {

--- a/Empire/ProductionQueue.cpp
+++ b/Empire/ProductionQueue.cpp
@@ -527,7 +527,8 @@ std::string ProductionQueue::ProductionItem::Dump() const {
 //////////////////////////////
 // ProductionQueue::Element //
 //////////////////////////////
-ProductionQueue::Element::Element()
+ProductionQueue::Element::Element() :
+     m_uuid(boost::uuids::nil_generator()())
 {}
 
 ProductionQueue::Element::Element(ProductionItem item_, int empire_id_, int ordered_,
@@ -541,7 +542,8 @@ ProductionQueue::Element::Element(ProductionItem item_, int empire_id_, int orde
     location(location_),
     blocksize_memory(blocksize_),
     paused(paused_),
-    allowed_imperial_stockpile_use(allowed_imperial_stockpile_use_)
+    allowed_imperial_stockpile_use(allowed_imperial_stockpile_use_),
+    m_uuid(boost::uuids::nil_generator()())
 {}
 
 ProductionQueue::Element::Element(BuildType build_type, std::string name, int empire_id_, int ordered_,

--- a/Empire/ProductionQueue.h
+++ b/Empire/ProductionQueue.h
@@ -83,7 +83,7 @@ struct FO_COMMON_API ProductionQueue {
         int                 rally_point_id = INVALID_OBJECT_ID;
         bool                paused = false;
         bool                allowed_imperial_stockpile_use = true;
-        boost::uuids::uuid  m_uuid;
+        boost::uuids::uuid  uuid;
 
         std::string Dump() const;
 
@@ -137,7 +137,6 @@ struct FO_COMMON_API ProductionQueue {
     /** Returns sets of object ids that have more available than allocated PP */
     std::set<std::set<int>> ObjectsWithWastedPP(const std::shared_ptr<ResourcePool>& industry_pool) const;
 
-
     // STL container-like interface
     bool            empty() const;
     unsigned int    size() const;
@@ -146,13 +145,16 @@ struct FO_COMMON_API ProductionQueue {
     const_iterator  find(int i) const;
     const Element&  operator[](int i) const;
 
+    const_iterator  find(boost::uuids::uuid uuid) const;
+    int             IndexOfUUID(boost::uuids::uuid uuid) const;
+
     /** \name Mutators */ //@{
     /** Recalculates the PPs spent on and number of turns left for each project in the queue.  Also
       * determines the number of projects in progress, and the industry consumed by projects
       * in each resource-sharing group of systems.  Does not actually "spend" the PP; a later call to
       * empire->CheckProductionProgress() will actually spend PP, remove items from queue and create them
       * in the universe. */
-    void Update();
+    void        Update();
 
     // STL container-like interface
     void        push_back(const Element& element);

--- a/Empire/ProductionQueue.h
+++ b/Empire/ProductionQueue.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <boost/serialization/access.hpp>
 #include <boost/signals2/signal.hpp>
+#include <boost/uuid/uuid.hpp>
 
 class ResourcePool;
 FO_COMMON_API extern const int INVALID_DESIGN_ID;
@@ -67,21 +68,22 @@ struct FO_COMMON_API ProductionQueue {
                 int location_, bool paused_ = false,
                 bool allowed_imperial_stockpile_use_ = true);
 
-        ProductionItem  item;
-        int             empire_id = ALL_EMPIRES;
-        int             ordered = 0;                ///< how many of item (blocks) to produce
-        int             blocksize = 1;              ///< size of block to produce (default=1)
-        int             remaining = 0;              ///< how many left to produce
-        int             location = INVALID_OBJECT_ID;///< the ID of the UniverseObject at which this item is being produced
-        float           allocated_pp = 0.0f;        ///< PP allocated to this ProductionQueue Element by Empire production update
-        float           progress = 0.0f;            ///< fraction of this item that is complete.
-        float           progress_memory = 0.0f;     ///< updated by server turn processing; aides in allowing blocksize changes to be undone in same turn w/o progress loss
-        int             blocksize_memory = 1;       ///< used along with progress_memory
-        int             turns_left_to_next_item = -1;
-        int             turns_left_to_completion = -1;
-        int             rally_point_id = INVALID_OBJECT_ID;
-        bool            paused = false;
-        bool            allowed_imperial_stockpile_use = true;
+        ProductionItem      item;
+        int                 empire_id = ALL_EMPIRES;
+        int                 ordered = 0;                ///< how many of item (blocks) to produce
+        int                 blocksize = 1;              ///< size of block to produce (default=1)
+        int                 remaining = 0;              ///< how many left to produce
+        int                 location = INVALID_OBJECT_ID;///< the ID of the UniverseObject at which this item is being produced
+        float               allocated_pp = 0.0f;        ///< PP allocated to this ProductionQueue Element by Empire production update
+        float               progress = 0.0f;            ///< fraction of this item that is complete.
+        float               progress_memory = 0.0f;     ///< updated by server turn processing; aides in allowing blocksize changes to be undone in same turn w/o progress loss
+        int                 blocksize_memory = 1;       ///< used along with progress_memory
+        int                 turns_left_to_next_item = -1;
+        int                 turns_left_to_completion = -1;
+        int                 rally_point_id = INVALID_OBJECT_ID;
+        bool                paused = false;
+        bool                allowed_imperial_stockpile_use = true;
+        boost::uuids::uuid  m_uuid;
 
         std::string Dump() const;
 

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -31,6 +31,7 @@
 #include <boost/lexical_cast.hpp>
 //TODO: replace with std::make_unique when transitioning to C++14
 #include <boost/smart_ptr/make_unique.hpp>
+#include <boost/uuid/random_generator.hpp>
 
 #include <iterator>
 #include <sstream>
@@ -2635,7 +2636,10 @@ void ObjectListWnd::ObjectRightClicked(GG::ListBox::iterator it, const GG::Pt& p
                     if (!one_planet || !one_planet->OwnedBy(app->EmpireID()) || !cur_empire->ProducibleItem(BT_SHIP, ship_design, row->ObjectID()))
                         continue;
                     ProductionQueue::ProductionItem ship_item(BT_SHIP, ship_design);
-                    app->Orders().IssueOrder(std::make_shared<ProductionQueueOrder>(app->EmpireID(), ship_item, 1, row->ObjectID(), pos));
+                    auto new_uuid = boost::uuids::random_generator()();
+                    app->Orders().IssueOrder(std::make_shared<ProductionQueueOrder>(
+                        ProductionQueueOrder::PLACE_IN_QUEUE, app->EmpireID(),
+                        new_uuid, ship_item, 1, row->ObjectID(), pos));
                     needs_queue_update = true;
                 }
                 if (needs_queue_update)
@@ -2666,10 +2670,10 @@ void ObjectListWnd::ObjectRightClicked(GG::ListBox::iterator it, const GG::Pt& p
                 std::string bld = entry.first;
                 bool needs_queue_update(false);
                 for (const auto& selection : m_list_box->Selections()) {
-                    ObjectRow *row = dynamic_cast<ObjectRow *>(selection->get());
+                    auto row = dynamic_cast<ObjectRow *>(selection->get());
                     if (!row)
                         continue;
-                    std::shared_ptr<Planet> one_planet = Objects().get<Planet>(row->ObjectID());
+                    auto one_planet = Objects().get<Planet>(row->ObjectID());
                     if (!one_planet || !one_planet->OwnedBy(app->EmpireID())
                         || !cur_empire->EnqueuableItem(BT_BUILDING, bld, row->ObjectID())
                         || !cur_empire->ProducibleItem(BT_BUILDING, bld, row->ObjectID()))
@@ -2677,7 +2681,10 @@ void ObjectListWnd::ObjectRightClicked(GG::ListBox::iterator it, const GG::Pt& p
                         continue;
                     }
                     ProductionQueue::ProductionItem bld_item(BT_BUILDING, bld);
-                    app->Orders().IssueOrder(std::make_shared<ProductionQueueOrder>(app->EmpireID(), bld_item, 1, row->ObjectID(), pos));
+                    auto new_uuid = boost::uuids::random_generator()();
+                    app->Orders().IssueOrder(std::make_shared<ProductionQueueOrder>(
+                        ProductionQueueOrder::PLACE_IN_QUEUE, app->EmpireID(),
+                        new_uuid, bld_item, 1, row->ObjectID(), pos));
                     needs_queue_update = true;
                 }
                 if (needs_queue_update)

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -24,6 +24,7 @@
 #include <boost/cast.hpp>
 #include <boost/range/numeric.hpp>
 #include <boost/range/adaptor/map.hpp>
+#include <boost/uuid/random_generator.hpp>
 
 #include <cmath>
 #include <iterator>
@@ -1037,10 +1038,13 @@ void ProductionWnd::QueueItemMoved(const GG::ListBox::iterator& row_it, const GG
     auto direction = original_position < position;
     int corrected_position = position + (direction ? 1 : 0);
 
-    HumanClientApp::GetApp()->Orders().IssueOrder(
-        std::make_shared<ProductionQueueOrder>(client_empire_id,
-                                               original_position,
-                                               corrected_position));
+    auto queue_it = empire->GetProductionQueue().find(position);
+
+    if (queue_it != empire->GetProductionQueue().end())
+        HumanClientApp::GetApp()->Orders().IssueOrder(
+            std::make_shared<ProductionQueueOrder>(ProductionQueueOrder::MOVE_ITEM_TO_INDEX,
+                                                   client_empire_id, queue_it->uuid,
+                                                   corrected_position));
     empire->UpdateProductionQueue();
 }
 
@@ -1175,8 +1179,12 @@ void ProductionWnd::AddBuildToQueueSlot(const ProductionQueue::ProductionItem& i
     if (!empire)
         return;
 
+    auto new_uuid = boost::uuids::random_generator()();
+
     HumanClientApp::GetApp()->Orders().IssueOrder(
-        std::make_shared<ProductionQueueOrder>(client_empire_id, item, number, location, pos));
+        std::make_shared<ProductionQueueOrder>(ProductionQueueOrder::PLACE_IN_QUEUE,
+                                               client_empire_id, new_uuid,
+                                               item, number, location, pos));
 
     empire->UpdateProductionQueue();
     m_build_designator_wnd->CenterOnBuild(pos >= 0 ? pos : m_queue_wnd->GetQueueListBox()->NumRows() - 1);
@@ -1190,8 +1198,13 @@ void ProductionWnd::ChangeBuildQuantitySlot(int queue_idx, int quantity) {
     if (!empire)
         return;
 
-    HumanClientApp::GetApp()->Orders().IssueOrder(
-        std::make_shared<ProductionQueueOrder>(client_empire_id, queue_idx, quantity, true));
+    auto queue_it = empire->GetProductionQueue().find(queue_idx);
+
+    if (queue_it != empire->GetProductionQueue().end())
+        HumanClientApp::GetApp()->Orders().IssueOrder(
+            std::make_shared<ProductionQueueOrder>(ProductionQueueOrder::SET_QUANTITY,
+                                                   client_empire_id, queue_it->uuid,
+                                                   quantity));
 
     empire->UpdateProductionQueue();
 }
@@ -1204,8 +1217,13 @@ void ProductionWnd::ChangeBuildQuantityBlockSlot(int queue_idx, int quantity, in
     if (!empire)
         return;
 
-    HumanClientApp::GetApp()->Orders().IssueOrder(
-        std::make_shared<ProductionQueueOrder>(client_empire_id, queue_idx, quantity, blocksize));
+    auto queue_it = empire->GetProductionQueue().find(queue_idx);
+
+    if (queue_it != empire->GetProductionQueue().end())
+        HumanClientApp::GetApp()->Orders().IssueOrder(
+            std::make_shared<ProductionQueueOrder>(ProductionQueueOrder::SET_QUANTITY_AND_BLOCK_SIZE,
+                                                   client_empire_id, queue_it->uuid,
+                                                   quantity, blocksize));
 
     empire->UpdateProductionQueue();
 }
@@ -1218,8 +1236,13 @@ void ProductionWnd::DeleteQueueItem(GG::ListBox::iterator it) {
     if (!empire)
         return;
 
-    HumanClientApp::GetApp()->Orders().IssueOrder(
-        std::make_shared<ProductionQueueOrder>(client_empire_id, std::distance(m_queue_wnd->GetQueueListBox()->begin(), it)));
+    auto idx = std::distance(m_queue_wnd->GetQueueListBox()->begin(), it);
+    auto queue_it = empire->GetProductionQueue().find(idx);
+
+    if (queue_it != empire->GetProductionQueue().end())
+        HumanClientApp::GetApp()->Orders().IssueOrder(
+            std::make_shared<ProductionQueueOrder>(ProductionQueueOrder::REMOVE_FROM_QUEUE,
+                                                   client_empire_id, queue_it->uuid));
 
     empire->UpdateProductionQueue();
 }
@@ -1234,9 +1257,8 @@ void ProductionWnd::QueueItemClickedSlot(GG::ListBox::iterator it, const GG::Pt&
 }
 
 void ProductionWnd::QueueItemDoubleClickedSlot(GG::ListBox::iterator it, const GG::Pt& pt, const GG::Flags<GG::ModKey>& modkeys) {
-    if (m_queue_wnd->GetQueueListBox()->DisplayingValidQueueItems()) {
+    if (m_queue_wnd->GetQueueListBox()->DisplayingValidQueueItems())
         m_build_designator_wnd->CenterOnBuild(std::distance(m_queue_wnd->GetQueueListBox()->begin(), it), true);
-    }
 }
 
 void ProductionWnd::QueueItemRallied(GG::ListBox::iterator it, int object_id) {
@@ -1255,9 +1277,14 @@ void ProductionWnd::QueueItemRallied(GG::ListBox::iterator it, int object_id) {
     if (rally_point_id == INVALID_OBJECT_ID)
         return;
 
-    HumanClientApp::GetApp()->Orders().IssueOrder(
-        std::make_shared<ProductionQueueOrder>(client_empire_id, std::distance(m_queue_wnd->GetQueueListBox()->begin(), it),
-                                               rally_point_id, false, false));
+    auto idx = std::distance(m_queue_wnd->GetQueueListBox()->begin(), it);
+    auto queue_it = empire->GetProductionQueue().find(idx);
+
+    if (queue_it != empire->GetProductionQueue().end())
+        HumanClientApp::GetApp()->Orders().IssueOrder(
+            std::make_shared<ProductionQueueOrder>(ProductionQueueOrder::SET_RALLY_POINT,
+                                                   client_empire_id, queue_it->uuid,
+                                                   rally_point_id));
 
     empire->UpdateProductionQueue();
 }
@@ -1270,9 +1297,13 @@ void ProductionWnd::QueueItemPaused(GG::ListBox::iterator it, bool pause) {
     if (!empire)
         return;
 
-    HumanClientApp::GetApp()->Orders().IssueOrder(
-        std::make_shared<ProductionQueueOrder>(client_empire_id, std::distance(m_queue_wnd->GetQueueListBox()->begin(), it),
-                                               pause, -1.0f));
+    auto idx = std::distance(m_queue_wnd->GetQueueListBox()->begin(), it);
+    auto queue_it = empire->GetProductionQueue().find(idx);
+
+    if (queue_it != empire->GetProductionQueue().end())
+        HumanClientApp::GetApp()->Orders().IssueOrder(
+            std::make_shared<ProductionQueueOrder>(ProductionQueueOrder::PAUSE_PRODUCTION,
+                                                   client_empire_id, queue_it->uuid));
 
     empire->UpdateProductionQueue();
 }
@@ -1285,9 +1316,13 @@ void ProductionWnd::QueueItemDuped(GG::ListBox::iterator it) {
     if (!empire)
         return;
 
-    HumanClientApp::GetApp()->Orders().IssueOrder(
-        std::make_shared<ProductionQueueOrder>(client_empire_id, std::distance(m_queue_wnd->GetQueueListBox()->begin(), it),
-                                               -1.0f, -1.0f));
+    auto idx = std::distance(m_queue_wnd->GetQueueListBox()->begin(), it);
+    auto queue_it = empire->GetProductionQueue().find(idx);
+
+    if (queue_it != empire->GetProductionQueue().end())
+        HumanClientApp::GetApp()->Orders().IssueOrder(
+            std::make_shared<ProductionQueueOrder>(ProductionQueueOrder::DUPLICATE_ITEM,
+                                                   client_empire_id, queue_it->uuid));
 
     empire->UpdateProductionQueue();
 }
@@ -1300,9 +1335,12 @@ void ProductionWnd::QueueItemSplit(GG::ListBox::iterator it) {
     if (!empire)
         return;
 
-    HumanClientApp::GetApp()->Orders().IssueOrder(
-        std::make_shared<ProductionQueueOrder>(client_empire_id, std::distance(m_queue_wnd->GetQueueListBox()->begin(), it),
-                                               -1.0f));
+    auto idx = std::distance(m_queue_wnd->GetQueueListBox()->begin(), it);
+    auto queue_it = empire->GetProductionQueue().find(idx);
+
+    if (queue_it != empire->GetProductionQueue().end())
+        HumanClientApp::GetApp()->Orders().IssueOrder(
+            std::make_shared<ProductionQueueOrder>(ProductionQueueOrder::SPLIT_INCOMPLETE, client_empire_id, queue_it->uuid));
 
     empire->UpdateProductionQueue();
 }
@@ -1315,9 +1353,12 @@ void ProductionWnd::QueueItemUseImperialPP(GG::ListBox::iterator it, bool allow)
     if (!empire)
         return;
 
-    HumanClientApp::GetApp()->Orders().IssueOrder(
-        OrderPtr(new ProductionQueueOrder(client_empire_id, std::distance(m_queue_wnd->GetQueueListBox()->begin(), it),
-                                          allow, -1.0f, -1.0f)));
+    auto idx = std::distance(m_queue_wnd->GetQueueListBox()->begin(), it);
+    auto queue_it = empire->GetProductionQueue().find(idx);
+
+    if (queue_it != empire->GetProductionQueue().end())
+        HumanClientApp::GetApp()->Orders().IssueOrder(
+            OrderPtr(new ProductionQueueOrder(ProductionQueueOrder::ALLOW_STOCKPILE_USE, client_empire_id, queue_it->uuid)));
 
     empire->UpdateProductionQueue();
 }

--- a/client/AI/AIWrapper.cpp
+++ b/client/AI/AIWrapper.cpp
@@ -357,8 +357,12 @@ namespace {
             return 0;
         }
 
+        auto uuid = boost::uuids::random_generator()();
+        auto item = ProductionQueue::ProductionItem(BT_BUILDING, item_name);
+
         AIClientApp::GetApp()->Orders().IssueOrder(
-            std::make_shared<ProductionQueueOrder>(empire_id, ProductionQueue::ProductionItem(BT_BUILDING, item_name), 1, location_id));
+            std::make_shared<ProductionQueueOrder>(ProductionQueueOrder::PLACE_IN_QUEUE,
+                                                   empire_id, uuid, item, 1, location_id));
 
         return 1;
     }
@@ -376,8 +380,12 @@ namespace {
             return 0;
         }
 
+        auto uuid = boost::uuids::random_generator()();
+        auto item = ProductionQueue::ProductionItem(BT_SHIP, design_id);
+
         AIClientApp::GetApp()->Orders().IssueOrder(
-            std::make_shared<ProductionQueueOrder>(empire_id, ProductionQueue::ProductionItem(BT_SHIP, design_id), 1, location_id));
+            std::make_shared<ProductionQueueOrder>(ProductionQueueOrder::PLACE_IN_QUEUE,
+                                                   empire_id, uuid, item, 1, location_id));
 
         return 1;
     }
@@ -400,8 +408,13 @@ namespace {
             return 0;
         }
 
-        AIClientApp::GetApp()->Orders().IssueOrder(
-            std::make_shared<ProductionQueueOrder>(empire_id, queue_index, new_quantity, new_blocksize));
+        auto queue_it = empire->GetProductionQueue().find(queue_index);
+
+        if (queue_it != empire->GetProductionQueue().end())
+            AIClientApp::GetApp()->Orders().IssueOrder(
+                std::make_shared<ProductionQueueOrder>(ProductionQueueOrder::SET_QUANTITY_AND_BLOCK_SIZE,
+                                                       empire_id, queue_it->uuid,
+                                                       new_quantity, new_blocksize));
 
         return 1;
     }
@@ -437,8 +450,12 @@ namespace {
             return 0;
         }
 
-        AIClientApp::GetApp()->Orders().IssueOrder(
-            std::make_shared<ProductionQueueOrder>(empire_id, old_queue_index, new_queue_index));
+        auto queue_it = empire->GetProductionQueue().find(old_queue_index);
+
+        if (queue_it != empire->GetProductionQueue().end())
+            AIClientApp::GetApp()->Orders().IssueOrder(
+            std::make_shared<ProductionQueueOrder>(ProductionQueueOrder::MOVE_ITEM_TO_INDEX,
+                                                   empire_id, queue_it->uuid, new_queue_index));
 
         return 1;
     }
@@ -457,8 +474,12 @@ namespace {
             return 0;
         }
 
-        AIClientApp::GetApp()->Orders().IssueOrder(
-            std::make_shared<ProductionQueueOrder>(empire_id, queue_index));
+        auto queue_it = empire->GetProductionQueue().find(queue_index);
+
+        if (queue_it != empire->GetProductionQueue().end())
+            AIClientApp::GetApp()->Orders().IssueOrder(
+                std::make_shared<ProductionQueueOrder>(ProductionQueueOrder::REMOVE_FROM_QUEUE,
+                                                       empire_id, queue_it->uuid));
 
         return 1;
     }
@@ -477,8 +498,12 @@ namespace {
             return 0;
         }
 
-        AIClientApp::GetApp()->Orders().IssueOrder(
-            std::make_shared<ProductionQueueOrder>(empire_id, queue_index, pause, 0.0f));
+        auto queue_it = empire->GetProductionQueue().find(queue_index);
+
+        if (queue_it != empire->GetProductionQueue().end())
+            AIClientApp::GetApp()->Orders().IssueOrder(
+                std::make_shared<ProductionQueueOrder>(ProductionQueueOrder::PAUSE_PRODUCTION,
+                                                       empire_id, queue_it->uuid));
 
         return 1;
     }
@@ -497,8 +522,12 @@ namespace {
             return 0;
         }
 
-        AIClientApp::GetApp()->Orders().IssueOrder(
-            std::make_shared<ProductionQueueOrder>(empire_id, queue_index, use_stockpile, 0.0f, 0.0f));
+        auto queue_it = empire->GetProductionQueue().find(queue_index);
+
+        if (queue_it != empire->GetProductionQueue().end())
+            AIClientApp::GetApp()->Orders().IssueOrder(
+                std::make_shared<ProductionQueueOrder>(ProductionQueueOrder::ALLOW_STOCKPILE_USE,
+                                                       empire_id, queue_it->uuid));
 
         return 1;
     }

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -3187,12 +3187,9 @@ namespace {
 
 void ServerApp::PreCombatProcessTurns() {
     ScopedTimer timer("ServerApp::PreCombatProcessTurns", true);
-    ObjectMap& objects = m_universe.Objects();
 
     m_universe.ResetAllObjectMeters(false, true);   // revert current meter values to initial values prior to update after incrementing turn number during previous post-combat turn processing.
-
     m_universe.UpdateEmpireVisibilityFilteredSystemGraphs();
-
 
     DebugLogger() << "ServerApp::ProcessTurns executing orders";
 
@@ -3268,7 +3265,7 @@ void ServerApp::PreCombatProcessTurns() {
 
 
     // fleet movement
-    auto fleets = objects.all<Fleet>();
+    auto fleets = Objects().all<Fleet>();
     for (auto& fleet : fleets) {
         if (fleet)
             fleet->ClearArrivalFlag();

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -802,15 +802,7 @@ ParsedShipDesign::ParsedShipDesign(
 // ShipDesign
 ////////////////////////////////////////////////
 ShipDesign::ShipDesign() :
-    m_uuid(boost::uuids::nil_generator()()),
-    m_designed_on_turn(UniverseObject::INVALID_OBJECT_AGE),
-    m_designed_by_empire(ALL_EMPIRES),
-    m_hull(),
-    m_parts(),
-    m_is_monster(false),
-    m_icon(),
-    m_3D_model(),
-    m_name_desc_in_stringtable(false)
+    m_uuid(boost::uuids::nil_generator()())
 {}
 
 ShipDesign::ShipDesign(const boost::optional<std::invalid_argument>& should_throw,
@@ -1423,6 +1415,7 @@ bool operator ==(const ShipDesign& first, const ShipDesign& second) {
     std::map<std::string, int> first_parts;
     std::map<std::string, int> second_parts;
 
+    // don't care if order is different, as long as the types and numbers of parts is the same
     for (const std::string& part_name : first.Parts())
     { ++first_parts[part_name]; }
 

--- a/util/Order.h
+++ b/util/Order.h
@@ -519,17 +519,29 @@ private:
   * \a empire's queue. */
 class FO_COMMON_API ProductionQueueOrder : public Order {
 public:
+    enum ProdQueueOrderAction : int {
+        INVALID_PROD_QUEUE_ACTION = -1,
+        PLACE_IN_QUEUE,
+        REMOVE_FROM_QUEUE,
+        SPLIT_INCOMPLETE,
+        DUPLICATE_ITEM,
+        SET_QUANTITY_AND_BLOCK_SIZE,
+        SET_QUANTITY,
+        MOVE_ITEM_TO_INDEX,
+        SET_RALLY_POINT,
+        PAUSE_PRODUCTION,
+        RESUME_PRODUCTION,
+        ALLOW_STOCKPILE_USE,
+        DISALLOW_STOCKPILE_USE,
+        NUM_PROD_QUEUE_ACTIONS
+    };
+
     /** \name Structors */ //@{
-    ProductionQueueOrder(int empire, const ProductionQueue::ProductionItem& item, int number, int location, int pos = -1);
-    ProductionQueueOrder(int empire, int index, int new_quantity, bool dummy);
-    ProductionQueueOrder(int empire, int index, int rally_point_id, bool dummy1, bool dummy2);
-    ProductionQueueOrder(int empire, int index, int new_quantity, int new_blocksize);
-    ProductionQueueOrder(int empire, int index, int new_index);
-    ProductionQueueOrder(int empire, int index);
-    ProductionQueueOrder(int empire, int index, bool pause, float dummy);
-    ProductionQueueOrder(int empire, int index, float dummy1);
-    ProductionQueueOrder(int empire, int index, float dummy1, float dummy2);
-    ProductionQueueOrder(int empire, int index, bool allow_use_imperial_pp, float dummy, float dummy2);
+    ProductionQueueOrder(ProdQueueOrderAction action, int empire, boost::uuids::uuid uuid,
+                         const ProductionQueue::ProductionItem& item,
+                         int number, int location, int pos = -1);
+    ProductionQueueOrder(ProdQueueOrderAction action, int empire, boost::uuids::uuid uuid,
+                         int num1 = -1, int num2 = -1);
     //@}
 
 private:
@@ -538,28 +550,16 @@ private:
     void ExecuteImpl() const override;
 
     ProductionQueue::ProductionItem m_item;
-    int m_number = 0;
     int m_location = INVALID_OBJECT_ID;
-    //int m_index = INVALID_INDEX;
     int m_new_quantity = INVALID_QUANTITY;
     int m_new_blocksize = INVALID_QUANTITY;
     int m_new_index = INVALID_INDEX;
     int m_rally_point_id = INVALID_OBJECT_ID;
-    int m_pause = INVALID_PAUSE_RESUME;
-    int m_split_incomplete = INVALID_SPLIT_INCOMPLETE;
-    int m_dupe = INVALID_SPLIT_INCOMPLETE;
-    int m_use_imperial_pp = INVALID_USE_IMPERIAL_PP;
     boost::uuids::uuid m_uuid = boost::uuids::nil_generator()();
+    ProdQueueOrderAction m_action = INVALID_PROD_QUEUE_ACTION;
 
     static const int INVALID_INDEX = -500;
     static const int INVALID_QUANTITY = -1000;
-    static const int PAUSE = 1;
-    static const int RESUME = 2;
-    static const int INVALID_PAUSE_RESUME = -1;
-    static const int INVALID_SPLIT_INCOMPLETE = -1;
-    static const int USE_IMPERIAL_PP = 4;
-    static const int DONT_USE_IMPERIAL_PP = 8;
-    static const int INVALID_USE_IMPERIAL_PP = -4;
 
     friend class boost::serialization::access;
     template <class Archive>

--- a/util/Order.h
+++ b/util/Order.h
@@ -555,7 +555,7 @@ private:
     int m_new_blocksize = INVALID_QUANTITY;
     int m_new_index = INVALID_INDEX;
     int m_rally_point_id = INVALID_OBJECT_ID;
-    boost::uuids::uuid m_uuid = boost::uuids::nil_generator()();
+    boost::uuids::uuid m_uuid;
     ProdQueueOrderAction m_action = INVALID_PROD_QUEUE_ACTION;
 
     static const int INVALID_INDEX = -500;

--- a/util/Order.h
+++ b/util/Order.h
@@ -540,7 +540,7 @@ private:
     ProductionQueue::ProductionItem m_item;
     int m_number = 0;
     int m_location = INVALID_OBJECT_ID;
-    int m_index = INVALID_INDEX;
+    //int m_index = INVALID_INDEX;
     int m_new_quantity = INVALID_QUANTITY;
     int m_new_blocksize = INVALID_QUANTITY;
     int m_new_index = INVALID_INDEX;
@@ -549,6 +549,7 @@ private:
     int m_split_incomplete = INVALID_SPLIT_INCOMPLETE;
     int m_dupe = INVALID_SPLIT_INCOMPLETE;
     int m_use_imperial_pp = INVALID_USE_IMPERIAL_PP;
+    boost::uuids::uuid m_uuid = boost::uuids::nil_generator()();
 
     static const int INVALID_INDEX = -500;
     static const int INVALID_QUANTITY = -1000;

--- a/util/SerializeEmpire.cpp
+++ b/util/SerializeEmpire.cpp
@@ -12,6 +12,7 @@
 
 #include "Serialize.ipp"
 #include <boost/serialization/version.hpp>
+#include <boost/uuid/random_generator.hpp>
 
 
 template <class Archive>
@@ -74,7 +75,31 @@ void ProductionQueue::Element::serialize(Archive& ar, const unsigned int version
         & BOOST_SERIALIZATION_NVP(rally_point_id)
         & BOOST_SERIALIZATION_NVP(paused)
         & BOOST_SERIALIZATION_NVP(allowed_imperial_stockpile_use);
+    if (Archive::is_saving::value) {
+        // Serialization of m_uuid as a primitive doesn't work as expected from
+        // the documentation.  This workaround instead serializes a string
+        // representation.
+        auto string_uuid = boost::uuids::to_string(m_uuid);
+        ar & BOOST_SERIALIZATION_NVP(string_uuid);
+
+    } else (Archive::is_loading::value && version < 2) {
+        // assign a random ID to this element so that future-issued orders can refer to it
+        m_uuid = boost::uuids::random_generator()();
+
+    } else {
+        // convert string back into UUID
+        std::string string_uuid;
+        ar && BOOST_SERIALIZATION_NVP(string_uuid);
+
+        try {
+            m_uuid = boost::lexical_cast<boost::uuids::uuid>(string_uuid);
+        } catch (const boost::bad_lexical_cast&) {
+            m_uuid = boost::uuids::random_generator()();
+        }
+    }
 }
+
+BOOST_CLASS_VERSION(ProductionQueue::Element, 2)
 
 template void ProductionQueue::Element::serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive&, const unsigned int);
 template void ProductionQueue::Element::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive&, const unsigned int);

--- a/util/SerializeEmpire.cpp
+++ b/util/SerializeEmpire.cpp
@@ -75,26 +75,27 @@ void ProductionQueue::Element::serialize(Archive& ar, const unsigned int version
         & BOOST_SERIALIZATION_NVP(rally_point_id)
         & BOOST_SERIALIZATION_NVP(paused)
         & BOOST_SERIALIZATION_NVP(allowed_imperial_stockpile_use);
+
     if (Archive::is_saving::value) {
-        // Serialization of m_uuid as a primitive doesn't work as expected from
+        // Serialization of uuid as a primitive doesn't work as expected from
         // the documentation.  This workaround instead serializes a string
         // representation.
-        auto string_uuid = boost::uuids::to_string(m_uuid);
+        auto string_uuid = boost::uuids::to_string(uuid);
         ar & BOOST_SERIALIZATION_NVP(string_uuid);
 
-    } else (Archive::is_loading::value && version < 2) {
+     } else if (Archive::is_loading::value && version < 2) {
         // assign a random ID to this element so that future-issued orders can refer to it
-        m_uuid = boost::uuids::random_generator()();
+        uuid = boost::uuids::random_generator()();
 
     } else {
         // convert string back into UUID
         std::string string_uuid;
-        ar && BOOST_SERIALIZATION_NVP(string_uuid);
+        ar & BOOST_SERIALIZATION_NVP(string_uuid);
 
         try {
-            m_uuid = boost::lexical_cast<boost::uuids::uuid>(string_uuid);
+            uuid = boost::lexical_cast<boost::uuids::uuid>(string_uuid);
         } catch (const boost::bad_lexical_cast&) {
-            m_uuid = boost::uuids::random_generator()();
+            uuid = boost::uuids::random_generator()();
         }
     }
 }

--- a/util/SerializeOrderSet.cpp
+++ b/util/SerializeOrderSet.cpp
@@ -15,14 +15,17 @@ BOOST_CLASS_EXPORT(RenameOrder)
 BOOST_CLASS_EXPORT(NewFleetOrder)
 BOOST_CLASS_VERSION(NewFleetOrder, 1)
 BOOST_CLASS_EXPORT(FleetMoveOrder)
+BOOST_CLASS_VERSION(FleetMoveOrder, 2)
 BOOST_CLASS_EXPORT(FleetTransferOrder)
 BOOST_CLASS_EXPORT(ColonizeOrder)
 BOOST_CLASS_EXPORT(InvadeOrder)
 BOOST_CLASS_EXPORT(BombardOrder)
 BOOST_CLASS_EXPORT(ChangeFocusOrder)
 BOOST_CLASS_EXPORT(ResearchQueueOrder)
-BOOST_CLASS_EXPORT(ProductionQueueOrder, 1)
+BOOST_CLASS_EXPORT(ProductionQueueOrder)
+BOOST_CLASS_VERSION(ProductionQueueOrder, 2)
 BOOST_CLASS_EXPORT(ShipDesignOrder)
+BOOST_CLASS_VERSION(ShipDesignOrder, 1)
 BOOST_CLASS_EXPORT(ScrapOrder)
 BOOST_CLASS_EXPORT(AggressiveOrder)
 BOOST_CLASS_EXPORT(GiveObjectToEmpireOrder)
@@ -72,8 +75,6 @@ void FleetMoveOrder::serialize(Archive& ar, const unsigned int version)
         m_append = false;
     }
 }
-
-BOOST_CLASS_VERSION(FleetMoveOrder, 2);
 
 template <class Archive>
 void FleetTransferOrder::serialize(Archive& ar, const unsigned int version)
@@ -217,8 +218,6 @@ void ShipDesignOrder::serialize(Archive& ar, const unsigned int version)
     ar  & BOOST_SERIALIZATION_NVP(m_3D_model);
     ar  & BOOST_SERIALIZATION_NVP(m_name_desc_in_stringtable);
 }
-
-BOOST_CLASS_VERSION(ShipDesignOrder, 1)
 
 template <class Archive>
 void ScrapOrder::serialize(Archive& ar, const unsigned int version)


### PR DESCRIPTION
Adds a UUID to production queue elements, and adapts orders accordingly.

Might help with https://github.com/freeorion/freeorion/issues/2438

Also adds an enum to specify and track what kind of ProductionQueueOrder an order is, rather than deducing it from the other stored order info.