### PR TITLE
Remove boost::lexical_cast within << operator chains

### DIFF
--- a/Empire/ResourcePool.cpp
+++ b/Empire/ResourcePool.cpp
@@ -103,7 +103,7 @@ void ResourcePool::SetStockpile(float d)
 { m_stockpile = d; }
 
 void ResourcePool::Update() {
-    //DebugLogger() << "ResourcePool::Update for type " << boost::lexical_cast<std::string>(m_type);
+    //DebugLogger() << "ResourcePool::Update for type " << m_type;
     // sum production from all ResourceCenters in each group, for resource point type appropriate for this pool
     MeterType meter_type = ResourceToMeter(m_type);
     MeterType target_meter_type = ResourceToTargetMeter(m_type);

--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -1203,7 +1203,7 @@ void BuildDesignatorWnd::ShowType(BuildType type, bool refresh_list) {
     } else if (type == BT_STOCKPILE) {
         m_build_selector->ShowType(type, refresh_list);
     } else {
-        ErrorLogger() << "BuildDesignatorWnd::ShowType(" << boost::lexical_cast<std::string>(type) << ")";
+        ErrorLogger() << "BuildDesignatorWnd::ShowType(" << type << ")";
         throw std::invalid_argument("BuildDesignatorWnd::ShowType was passed an invalid BuildType");
     }
 }
@@ -1215,7 +1215,7 @@ void BuildDesignatorWnd::ShowAllTypes(bool refresh_list) {
 }
 
 void BuildDesignatorWnd::HideType(BuildType type, bool refresh_list) {
-    DebugLogger() << "BuildDesignatorWnd::HideType(" << boost::lexical_cast<std::string>(type) << ")";
+    DebugLogger() << "BuildDesignatorWnd::HideType(" << type << ")";
     if (type == BT_BUILDING || type == BT_SHIP) {
         m_build_selector->HideType(type, refresh_list);
         m_build_selector->m_build_type_buttons[type]->SetCheck(false);

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -886,7 +886,7 @@ namespace {
             else if (ship->UniverseObject::GetMeter(stat_name))
                 return ship->InitialMeterValue(stat_name);
 
-            ErrorLogger() << "ShipDataPanel::StatValue couldn't get stat of name: " << boost::lexical_cast<std::string>(stat_name);
+            ErrorLogger() << "ShipDataPanel::StatValue couldn't get stat of name: " << stat_name;
         }
         return 0.0;
     }

--- a/UI/SystemResourceSummaryBrowseWnd.cpp
+++ b/UI/SystemResourceSummaryBrowseWnd.cpp
@@ -294,7 +294,7 @@ void SystemResourceSummaryBrowseWnd::UpdateAllocation(GG::Y& top) {
         // don't add summary entries for objects that consume no resource.  (otherwise there would be a loooong pointless list of 0's
         if (allocation <= 0.0) {
             if (allocation < 0.0)
-                ErrorLogger() << "object " << obj->Name() << " is reported having negative " << boost::lexical_cast<std::string>(m_resource_type) << " consumption";
+                ErrorLogger() << "object " << obj->Name() << " is reported having negative " << m_resource_type << " consumption";
             continue;
         }
 

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -382,7 +382,7 @@ void ServerApp::SetAIsProcessPriorityToLow(bool set_to_low) {
 
 void ServerApp::HandleMessage(const Message& msg, PlayerConnectionPtr player_connection) {
 
-    //DebugLogger() << "ServerApp::HandleMessage type " << boost::lexical_cast<std::string>(msg.Type());
+    //DebugLogger() << "ServerApp::HandleMessage type " << msg.Type();
     m_networking.UpdateCookie(player_connection->Cookie()); // update cookie expire date
 
     switch (msg.Type()) {

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -1213,8 +1213,7 @@ ShipDesign::MaybeInvalidDesign(const std::string& hull_in,
         if (!part_type->CanMountInSlotType(slot_type)) {
             if (produce_log)
                 DebugLogger() << "Invalid ShipDesign part \"" << part_name << "\" can't be mounted in "
-                              << boost::lexical_cast<std::string>(slot_type) << " slot"
-                              << ". Removing \"" << part_name <<"\"";
+                              << slot_type << " slot. Removing \"" << part_name <<"\"";
             is_valid = false;
             continue;
         }

--- a/universe/System.cpp
+++ b/universe/System.cpp
@@ -446,7 +446,7 @@ void System::Remove(int id) {
 void System::SetStarType(StarType type) {
     m_star = type;
     if (m_star <= INVALID_STAR_TYPE || NUM_STAR_TYPES <= m_star)
-        ErrorLogger() << "System::SetStarType set star type to " << boost::lexical_cast<std::string>(type);
+        ErrorLogger() << "System::SetStarType set star type to " << type;
     StateChangedSignal();
 }
 

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -543,14 +543,14 @@ void Universe::ApplyMeterEffectsAndUpdateMeters(bool do_accounting) {
     for (const auto& object : m_objects.all()) {
         TraceLogger(effects) << "object " << object->Name() << " (" << object->ID() << ") before resetting meters: ";
         for (auto const& meter_pair : object->Meters()) {
-            TraceLogger(effects) << "    meter: " << boost::lexical_cast<std::string>(meter_pair.first)
+            TraceLogger(effects) << "    meter: " << meter_pair.first
                                  << "  value: " << meter_pair.second.Current();
         }
         object->ResetTargetMaxUnpairedMeters();
         object->ResetPairedActiveMeters();
         TraceLogger(effects) << "object " << object->Name() << " (" << object->ID() << ") after resetting meters: ";
         for (auto const& meter_pair : object->Meters()) {
-            TraceLogger(effects) << "    meter: " << boost::lexical_cast<std::string>(meter_pair.first)
+            TraceLogger(effects) << "    meter: " << meter_pair.first
                                  << "  value: " << meter_pair.second.Current();
         }
     }
@@ -687,7 +687,7 @@ void Universe::InitMeterEstimatesAndDiscrepancies() {
             // add discrepancy adjustment to meter accounting
             account_map[type].emplace_back(INVALID_OBJECT_ID, ECT_UNKNOWN_CAUSE, discrepancy, meter.Current());
 
-            TraceLogger(effects) << "... ... " << boost::lexical_cast<std::string>(type) << ": " << discrepancy;
+            TraceLogger(effects) << "... ... " << type << ": " << discrepancy;
         }
     }
 }

--- a/universe/UniverseGenerator.cpp
+++ b/universe/UniverseGenerator.cpp
@@ -789,7 +789,7 @@ void SetActiveMetersToTargetMaxCurrentValues(ObjectMap& object_map) {
         for (auto& entry : AssociatedMeterTypes()) {
             if (Meter* meter = object->GetMeter(entry.first)) {
                 if (Meter* targetmax_meter = object->GetMeter(entry.second)) {
-                    TraceLogger(effects) << "    meter: " << boost::lexical_cast<std::string>(entry.first)
+                    TraceLogger(effects) << "    meter: " << entry.first
                                          << "  before: " << meter->Current()
                                          << "  set to: " << targetmax_meter->Current();
                     meter->SetCurrent(targetmax_meter->Current());

--- a/universe/UniverseObject.cpp
+++ b/universe/UniverseObject.cpp
@@ -173,7 +173,7 @@ std::string UniverseObject::Dump(unsigned short ntabs) const {
 
     std::stringstream os;
 
-    os << boost::lexical_cast<std::string>(this->ObjectType()) << " "
+    os << this->ObjectType() << " "
        << this->ID() << ": "
        << this->Name();
     if (system) {


### PR DESCRIPTION
The call to `boost::lexical_cast<std::string>` is unnecessary for custom types within ostream chains, as those types have to provide an `std::ostream operator<<` anyway to support `boost::lexical_cast`.