### PR TITLE
Don't expect CMake policy CMP0044 OLD behaviour anymore

### DIFF
--- a/GG/CMakeLists.txt
+++ b/GG/CMakeLists.txt
@@ -25,10 +25,6 @@
 
 cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 
-if(POLICY CMP0044)
-    cmake_policy(SET CMP0044 OLD)
-endif()
-
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_HOME_DIRECTORY}/cmake)
 
 


### PR DESCRIPTION
The build system is already [CMP0044](https://cmake.org/cmake/help/latest/policy/CMP0044.html) compliant and starting with CMake 3.11 the OLD policy value introduces a deprecation warning during build configuration time.