### PR TITLE
Remove GLU dependency

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -31,8 +31,6 @@ FreeOrion depends on the following libraries or APIs to run:
 
   * OpenGL - 2.1 or later ; usually provided by the graphic card driver or
     Operating System
-  * OpenGL Utilities (GLU) ; usually provided by the graphic card driver or
-    Operating System
   * OpenAL - It's recommended to use the [OpenAL Soft] implementation
   * [Boost] - 1.58 or later
   * [zlib]

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -242,11 +242,6 @@ find_package(ZLIB REQUIRED)
 if(NOT BUILD_HEADLESS)
     find_package(Freetype REQUIRED)
     find_package(OpenGL REQUIRED)
-
-    if(NOT OPENGL_GLU_FOUND)
-        message(FATAL_ERROR "OpenGL GLU library not found.")
-    endif()
-
     find_package(OpenAL REQUIRED)
     find_package(Ogg REQUIRED)
     find_package(Vorbis REQUIRED)
@@ -625,7 +620,6 @@ if(NOT BUILD_HEADLESS)
         freeorionparse
         GiGi::GiGiSDL
         ${OPENGL_gl_LIBRARY}
-        ${OPENGL_glu_LIBRARY}
         ${OPENAL_LIBRARY}
         ${OGG_LIBRARIES}
         ${VORBIS_LIBRARIES}

--- a/ChangeLog.md
+++ b/ChangeLog.md
@@ -9,6 +9,7 @@ Notable changes to the FreeOrion project will be documented in this file.
 #### Technical / Internal
 
 - C++14 is now supported and required to compile.
+- Removed OpenGL Utility (GLU) library dependency.
 
 
 ## [v0.4.9] - 2020-02-02

--- a/GG/CMakeLists.txt
+++ b/GG/CMakeLists.txt
@@ -83,11 +83,7 @@ if(NOT BUILD_HEADLESS)
     find_package(OpenGL REQUIRED)
     find_package(GLEW REQUIRED)
     find_package(Freetype REQUIRED)
-    
-    if(NOT OPENGL_GLU_FOUND)
-        message(FATAL_ERROR "OpenGL GLU library not found.")
-    endif()
-    
+
     if(ENABLE_PNG_TEXTURES)
         find_package(PNG REQUIRED)
         set(int_have_png 1)
@@ -160,7 +156,6 @@ if(NOT BUILD_HEADLESS)
             Boost::dynamic_linking
             Boost::filesystem
             ${OPENGL_gl_LIBRARY}
-            ${OPENGL_glu_LIBRARY}
         PRIVATE
             Boost::regex
             ${FREETYPE_LIBRARIES}
@@ -329,7 +324,7 @@ endif()
 # Deb-specific settings
 set(CPACK_DEBIAN_PACKAGE_SECTION libs)
 
-set(CPACK_DEBIAN_PACKAGE_DEPENDS "libgl1-mesa-glx | libgl1, libglu1-mesa | libglu, libfreetype6")
+set(CPACK_DEBIAN_PACKAGE_DEPENDS "libgl1-mesa-glx | libgl1, libfreetype6")
 set(CPACK_DEBIAN_PACKAGE_DEPENDS "${CPACK_DEBIAN_PACKAGE_DEPENDS}, gigi (= ${GIGI_VERSION})")
 
 if(BUILD_SDL_DRIVER)
@@ -337,7 +332,7 @@ if(BUILD_SDL_DRIVER)
 endif()
 
 if(BUILD_DEVEL_PACKAGE)
-    set(CPACK_DEBIAN_PACKAGE_DEPENDS "boost-devel (>= 1.44.0), libgl1-mesa-dev | libgl-dev, libglu1-mesa-dev | libglu-dev, libfreetype6-dev")
+    set(CPACK_DEBIAN_PACKAGE_DEPENDS "boost-devel (>= 1.44.0), libgl1-mesa-dev | libgl-dev, libfreetype6-dev")
     set(CPACK_DEBIAN_PACKAGE_DEPENDS "${CPACK_DEBIAN_PACKAGE_DEPENDS}, gigi-dev (= ${GIGI_VERSION})")
 endif()
 

--- a/GG/GG/Texture.h
+++ b/GG/GG/Texture.h
@@ -108,15 +108,6 @@ public:
     void Init(X width, Y height, const unsigned char* image, GLenum format, GLenum type,
               unsigned bytes_per_pixel, bool mipmap = false);
 
-    /** Frees any currently-held memory and creates a texture from subarea of
-        supplied array \a image.  \throw GG::Texture::Exception Throws
-        applicable subclass if the texture creation fails in one of the
-        specified ways. */
-    void Init(X x, Y y, X width, Y height, X image_width,
-              const unsigned char* image, GLenum format, GLenum type,
-              unsigned int bytes_per_pixel, bool mipmap = false);
-
-    void SetWrap(GLenum s, GLenum t);         ///< sets the opengl texture wrap modes associated with opengl texture m_opengl_id
     void SetFilters(GLenum min, GLenum mag);  ///< sets the opengl min/mag filter modes associated with opengl texture m_opengl_id
     void Clear();  ///< frees the opengl texture object associated with this object
     //@}

--- a/GG/src/SDL/SDLGUI.cpp
+++ b/GG/src/SDL/SDLGUI.cpp
@@ -363,8 +363,6 @@ void SDLGUI::SDLInit()
 
 void SDLGUI::GLInit()
 {
-    double ratio = Value(m_app_width) * 1.0 / Value(m_app_height);
-
     glEnable(GL_LIGHTING);
     glEnable(GL_LIGHT0);
     glEnable(GL_DEPTH_TEST);
@@ -375,7 +373,24 @@ void SDLGUI::GLInit()
     glViewport(0, 0, Value(m_app_width), Value(m_app_height));
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
-    gluPerspective(50.0, ratio, 1.0, 10.0);
+
+    // set up perspective with vertical FOV of 50°. 1:1 application
+    // window ratio, near plane of 1.0 and far plane of 10.0
+    float ratio = Value(m_app_width) * 1.0f / Value(m_app_height);
+    float radians = 50.0f * M_PI / 180.0f;
+    float near = 1.0f;
+    float far = 10.0f;
+    float cotangent = std::cos(radians) / std::sin(radians);
+
+    float projection[4][4] = { 0.0f };
+    projection[0][0] = cotangent / ratio;
+    projection[1][1] = cotangent;
+    projection[2][2] = -((far + near) / (far - near));
+    projection[2][3] = -1.0f;
+    projection[3][2] = -((2.0f * far * near) / (far - near));
+    projection[3][3] = 0.0f;
+
+    glMultMatrixf(&projection[0][0]);
 }
 
 void SDLGUI::HandleSystemEvents()

--- a/GG/src/Texture.cpp
+++ b/GG/src/Texture.cpp
@@ -310,27 +310,6 @@ void Texture::Load(const boost::filesystem::path& path, bool mipmap/* = false*/)
     Init(m_default_width, m_default_height, image_data, m_format, m_type, m_bytes_pp, mipmap);
 }
 
-void Texture::Init(X x, Y y, X width, Y height, X image_width, const unsigned char* image,
-                   GLenum format, GLenum type, unsigned int bytes_per_pixel, bool mipmap/* = false*/)
-{
-    glPushClientAttrib(GL_CLIENT_PIXEL_STORE_BIT);
-    glPixelStorei(GL_UNPACK_SWAP_BYTES, false);
-    glPixelStorei(GL_UNPACK_LSB_FIRST, false);
-    glPixelStorei(GL_UNPACK_ROW_LENGTH, Value(image_width));
-    glPixelStorei(GL_UNPACK_SKIP_ROWS, Value(y));
-    glPixelStorei(GL_UNPACK_SKIP_PIXELS, Value(x));
-    glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-
-    try {
-        InitFromRawData(width, height, image, format, type, bytes_per_pixel, mipmap);
-    } catch (...) {
-        glPopClientAttrib();
-        throw;
-    }
-
-    glPopClientAttrib();
-}
-
 void Texture::Init(X width, Y height, const unsigned char* image, GLenum format, GLenum type,
                    unsigned int bytes_per_pixel, bool mipmap/* = false*/)
 {
@@ -350,17 +329,6 @@ void Texture::Init(X width, Y height, const unsigned char* image, GLenum format,
     }
 
     glPopClientAttrib();
-}
-
-void Texture::SetWrap(GLenum s, GLenum t)
-{
-    m_wrap_s = s;
-    m_wrap_t = t;
-    if (m_opengl_id) {
-        glBindTexture(GL_TEXTURE_2D, m_opengl_id);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, m_wrap_s);
-        glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, m_wrap_t);
-    }
 }
 
 void Texture::SetFilters(GLenum min, GLenum mag)

--- a/GG/test/acceptance/runner/Application.cpp
+++ b/GG/test/acceptance/runner/Application.cpp
@@ -206,9 +206,16 @@ void MinimalGGApp::GLInit() {
     projection[3][3] = 0.0f;
 
     glMultMatrixf(&projection[0][0]);
-    gluLookAt(0.0, 0.0, 5.0,
-              0.0, 0.0, 0.0,
-              0.0, 1.0, 0.0);
+
+    // set up camera in -5.0 z offset from origin looking at origin
+    GLfloat view[4][4] = { 0.0 };
+    view[0][0] = -1.0;
+    view[1][1] = -1.0;
+    view[2][2] = 1.0;
+    view[3][3] = 1.0;
+
+    glMultMatrixf(&view[0][0]);
+    glTranslated(-0.0, -0.0, -5.0);
     glMatrixMode(GL_MODELVIEW);
 }
 

--- a/GG/test/acceptance/runner/Application.cpp
+++ b/GG/test/acceptance/runner/Application.cpp
@@ -181,8 +181,6 @@ void MinimalGGApp::Render() {
 // application-dependent.  Note that this method is called before Render() is
 // ever called.
 void MinimalGGApp::GLInit() {
-    double ratio = Value(AppWidth() * 1.0) / Value(AppHeight());
-
     glEnable(GL_BLEND);
     glEnable(GL_CULL_FACE);
     glEnable(GL_DEPTH_TEST);
@@ -190,7 +188,24 @@ void MinimalGGApp::GLInit() {
     glViewport(0, 0, Value(AppWidth()), Value(AppHeight()));
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
-    gluPerspective(50.0, ratio, 1.0, 10.0);
+
+    // set up perspective with vertical FOV of 50°. 1:1 application
+    // window ratio, near plane of 1.0 and far plane of 10.0
+    float ratio = Value(AppWidth() * 1.0f) / Value(AppHeight());
+    float radians = 50.0f * M_PI / 180.f;
+    float near = 1.0f;
+    float far = 10.0f;
+    float cotangent = std::cos(radians) / std::sin(radians);
+
+    float projection[4][4] = { 0.0f };
+    projection[0][0] = cotangent / ratio;
+    projection[1][1] = cotangent;
+    projection[2][2] = -((far + near) / (far - near));
+    projection[2][3] = -1.0f;
+    projection[3][2] = -((2.0f * far * near) / (far - near));
+    projection[3][3] = 0.0f;
+
+    glMultMatrixf(&projection[0][0]);
     gluLookAt(0.0, 0.0, 5.0,
               0.0, 0.0, 0.0,
               0.0, 1.0, 0.0);

--- a/UI/ShaderProgram.cpp
+++ b/UI/ShaderProgram.cpp
@@ -15,9 +15,17 @@ namespace {
     void CHECK_ERROR(const char* fn, const char* e) {
         GLenum error = glGetError();
         if (error != GL_NO_ERROR) {
+            const char* error_msg = "";
+
+            switch(error) {
+                case GL_INVALID_ENUM:      error_msg = "invalid enumerant"; break;
+                case GL_INVALID_VALUE:     error_msg = "invalid value";     break;
+                case GL_INVALID_OPERATION: error_msg = "invalid operation"; break;
+            }
+
             ErrorLogger() << fn << " () :"
                                    << " GL error on " << e << ": "
-                                   << "'" << gluErrorString(error) << "'";
+                                   << "'" << error_msg << "'";
         }
     }
 
@@ -82,7 +90,6 @@ ShaderProgram::ShaderProgram(const std::string& vertex_shader, const std::string
     glGetError();
 
     m_program_id = glCreateProgram();
-    CHECK_ERROR("ShaderProgram::ShaderProgram", "glCreateProgram()");
 
     const char* strings[1] = { nullptr };
 

--- a/msvc2017/opengl.dependency.props
+++ b/msvc2017/opengl.dependency.props
@@ -7,7 +7,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup>
     <Link>
-      <AdditionalDependencies>opengl32.lib;glu32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>opengl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup />

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -46,7 +46,6 @@ parts:
             - libfreetype6-dev
             - libgl1-mesa-dev
             - libglew-dev
-            - libglu1-mesa-dev
             - libjpeg-dev
             - libogg-dev
             - libopenal-dev


### PR DESCRIPTION
This PR replaces all existing `glu*` function calls with functional equivalents.

This is a small step towards cutting ties with the fixed function pipeline and allowing the usage of EGL, which in turn would allow the usage of Wayland, building on Android, and the new Linux OpenGL ABI (GLVND).