### PR TITLE
Make AI aware of allowed combat targets

### DIFF
--- a/default/python/AI/AIDependencies.py
+++ b/default/python/AI/AIDependencies.py
@@ -758,6 +758,40 @@ SYSTEM_SHIP_FACILITIES = frozenset((
 # <editor-fold desc="Shipdesign/-parts">
 PART_KRILL_SPAWNER = "SP_KRILL_SPAWNER"
 
+
+# <editor-fold desc="Allowed Combat Targets">
+# TODO: Inherit from enum.Flag after switch to Python 3.6+
+class CombatTarget:
+    NONE = 0
+    SHIP = 1 << 0
+    PLANET = 1 << 1
+    FIGHTER = 1 << 2
+    ANY = SHIP | PLANET | FIGHTER
+
+    # map from weapon to allowed targets
+    PART_ALLOWED_TARGETS = {
+        "SR_WEAPON_0_1": FIGHTER,
+        "SR_WEAPON_1_1": SHIP | PLANET,
+        "SR_WEAPON_2_1": SHIP | PLANET,
+        "SR_WEAPON_3_1": SHIP | PLANET,
+        "SR_WEAPON_4_1": SHIP | PLANET,
+        "SR_SPINAL_ANTIMATTER": SHIP | PLANET,
+        "FT_HANGAR_0": NONE,
+        "FT_HANGAR_1": FIGHTER,
+        "FT_HANGAR_2": SHIP | FIGHTER,
+        "FT_HANGAR_3": SHIP,
+        "FT_HANGAR_4": SHIP | PLANET,
+        # monster weapons
+        "SR_ARC_DISRUPTOR": ANY,
+        "SR_ICE_BEAM": ANY,
+        "SR_JAWS": ANY,
+        "SR_PLASMA_DISCHARGE": ANY,
+        "SR_SPINES": ANY,
+        "SR_TENTACLE": ANY,
+        "FT_HANGAR_KRILL": SHIP | FIGHTER,
+    }
+# </editor-fold>
+
 # <editor-fold desc="Effect Scripting for Shipdesigns">
 # <editor-fold desc="Tokens">
 # known tokens the AI can handle

--- a/default/python/AI/AIstate.py
+++ b/default/python/AI/AIstate.py
@@ -73,6 +73,10 @@ def convert_to_version(state, version):
     if version == 5:
         state['last_turn_played'] = 0
 
+    if version == 6:
+        # Anti-Fighter stats were added to CombatRatingAI
+        state['_AIstate__empire_standard_enemy'] = state['_AIstate__empire_standard_enemy'] + (0, False)
+
     #   state["some_new_member"] = some_default_value
     #   del state["some_removed_member"]
     #   state["list_changed_to_set"] = set(state["list_changed_to_set"])
@@ -100,7 +104,7 @@ class AIstate(object):
     via boost. If desiring to store a reference to a UniverseObject store its
     object id instead; for enum values store their int conversion value.
     """
-    version = 5
+    version = 6
 
     def __init__(self, aggression):
         # Do not allow to create AIstate instances with an invalid version number.

--- a/default/python/AI/AIstate.py
+++ b/default/python/AI/AIstate.py
@@ -74,8 +74,8 @@ def convert_to_version(state, version):
         state['last_turn_played'] = 0
 
     if version == 6:
-        # Anti-Fighter stats were added to CombatRatingAI
-        state['_AIstate__empire_standard_enemy'] = state['_AIstate__empire_standard_enemy'] + (0, False)
+        # Anti-fighter and anti-planet stats were added to CombatRatingAI
+        state['_AIstate__empire_standard_enemy'] = state['_AIstate__empire_standard_enemy'] + (0, False) + (0, False)
 
     #   state["some_new_member"] = some_default_value
     #   del state["some_removed_member"]

--- a/default/python/AI/CombatRatingsAI.py
+++ b/default/python/AI/CombatRatingsAI.py
@@ -246,13 +246,13 @@ class ShipCombatStats(object):
         enemy_stats = enemy_stats or get_aistate().get_standard_enemy()
 
         my_attacks, my_structure, my_shields = self.get_basic_stats()
-        e_avg_attack = 1
+        # e_avg_attack = 1
         if enemy_stats:
             e_attacks, e_structure, e_shields = enemy_stats.get_basic_stats()
             if e_attacks:
-                e_num_attacks = sum(n for n in e_attacks.values())
+                # e_num_attacks = sum(n for n in e_attacks.values())
                 e_total_attack = sum(n*dmg for dmg, n in e_attacks.items())
-                e_avg_attack = e_total_attack / e_num_attacks
+                # e_avg_attack = e_total_attack / e_num_attacks
                 e_net_attack = sum(n*max(dmg - my_shields, .001) for dmg, n in e_attacks.items())
                 e_net_attack = max(e_net_attack, .1*e_total_attack)
                 shield_factor = e_total_attack / e_net_attack
@@ -274,10 +274,8 @@ class ShipCombatStats(object):
         fighter_damage_per_bout = total_fighter_damage / 3
         my_total_attack += fighter_damage_per_bout
 
-        # consider fighter protection factor
-        fighters_shot_down = (1-survival_rate**2) * launched_1st_bout + (1-survival_rate) * launched_2nd_bout
-        damage_prevented = fighters_shot_down * e_avg_attack
-        my_structure += damage_prevented
+        # TODO: Consider enemy fighters
+
         return _rating()
 
     def get_rating_vs_planets(self):

--- a/default/python/AI/CombatRatingsAI.py
+++ b/default/python/AI/CombatRatingsAI.py
@@ -178,10 +178,10 @@ class ShipCombatStats(object):
                 pc = get_part_type(partname).partClass
                 if pc == fo.shipPartClass.shortRange:
                     allowed_targets = get_allowed_targets(partname)
-                    # TODO: Determine shot count from weapon shots
+                    damage = ship.currentPartMeterValue(meter_choice, partname)
+                    shots = ship.currentPartMeterValue(fo.meterType.secondaryStat, partname)
                     if allowed_targets & CombatTarget.SHIP:
-                        damage = ship.currentPartMeterValue(meter_choice, partname)
-                        attacks[damage] = attacks.get(damage, 0) + 1
+                        attacks[damage] = attacks.get(damage, 0) + shots
                     if allowed_targets & CombatTarget.FIGHTER:
                         flak_shots += 1
                 elif pc == fo.shipPartClass.fighterBay:

--- a/default/python/AI/ShipDesignAI.py
+++ b/default/python/AI/ShipDesignAI.py
@@ -699,12 +699,15 @@ class DesignStats(object):
         self.fighter_damage = 0
         self.flak_shots = 0
         self.has_interceptors = False
+        self.damage_vs_planets = 0
+        self.has_bomber = False
 
     def convert_to_combat_stats(self):
         """Return a tuple as expected by CombatRatingsAI"""
         return (self.attacks, self.structure, self.shields,
                 self.fighter_capacity, self.fighter_launch_rate, self.fighter_damage,
-                self.flak_shots, self.has_interceptors)
+                self.flak_shots, self.has_interceptors,
+                self.damage_vs_planets, self.has_bomber)
 
 
 class ShipDesigner(object):
@@ -905,6 +908,8 @@ class ShipDesigner(object):
                     self.design_stats.attacks[capacity] = self.design_stats.attacks.get(capacity, 0) + shots
                 if allowed_targets & AIDependencies.CombatTarget.FIGHTER:
                     self.design_stats.flak_shots += shots
+                if allowed_targets & AIDependencies.CombatTarget.PLANET:
+                    self.design_stats.damage_vs_planets += capacity*shots
             elif partclass in SHIELDS:
                 shield_counter += 1
                 if shield_counter == 1:
@@ -928,6 +933,8 @@ class ShipDesigner(object):
                     self.design_stats.fighter_capacity = 0
                     self.design_stats.fighter_damage = 0
                     self.design_stats.fighter_launch_rate = 0
+                    self.design_stats.has_interceptors = False
+                    self.design_stats.has_bomber = False
                 else:
                     allowed_targets = CombatRatingsAI.get_allowed_targets(part.name)
                     self.design_stats.fighter_capacity += self._calculate_hangar_capacity(part)
@@ -935,6 +942,8 @@ class ShipDesigner(object):
                         self.design_stats.fighter_damage = self._calculate_hangar_damage(part)
                     if allowed_targets & AIDependencies.CombatTarget.FIGHTER:
                         self.design_stats.has_interceptors = True
+                    if allowed_targets & AIDependencies.CombatTarget.PLANET:
+                        self.design_stats.has_bomber = True
 
         if len(bay_parts) > 0:
             hangar_part_name = None


### PR DESCRIPTION
This PR allows the AI to understand combat targets better. More work is required to make full use of it but some improvements are:

* The AI should understand now that Flaks and Interceptors will not deal damage to ships
* The AI should understand now that Decoy spamming is no longer effective
* The AI should have a more accurate estimation of its strength against planets

Adapted to changes in #2665. Should resolve #2786.

Known limitations: The AI does not build Flak or Interceptors yet to specifically counter enemy carriers.