### PR TITLE
Unify GG::Clr operations

### DIFF
--- a/GG/GG/Clr.h
+++ b/GG/GG/Clr.h
@@ -70,6 +70,13 @@ struct Clr
 
 GG_API std::ostream& operator<<(std::ostream& os, const Clr& pt);
 
+inline Clr InvertClr(const Clr& clr)
+{
+    return Clr(255 - clr.r,
+               255 - clr.g,
+               255 - clr.b,
+               clr.a);
+}
 
 /** Named ctor that constructs a Clr from four floats that represent the color
     channels (each must be >= 0.0 and <= 1.0). */

--- a/GG/GG/Clr.h
+++ b/GG/GG/Clr.h
@@ -78,6 +78,14 @@ inline Clr InvertClr(const Clr& clr)
                clr.a);
 }
 
+inline Clr BlendClr(const Clr& src, const Clr& dst, float factor)
+{
+    return Clr(static_cast<unsigned char>(src.r * factor + dst.r * (1 - factor)),
+               static_cast<unsigned char>(src.g * factor + dst.g * (1 - factor)),
+               static_cast<unsigned char>(src.b * factor + dst.b * (1 - factor)),
+               static_cast<unsigned char>(src.a * factor + dst.a * (1 - factor)));
+}
+
 /** Named ctor that constructs a Clr from four floats that represent the color
     channels (each must be >= 0.0 and <= 1.0). */
 inline Clr FloatClr(float r, float g, float b, float a)

--- a/GG/GG/Clr.h
+++ b/GG/GG/Clr.h
@@ -70,6 +70,28 @@ struct Clr
 
 GG_API std::ostream& operator<<(std::ostream& os, const Clr& pt);
 
+//! Returns the lightened version of color clr.  LightenClr leaves the alpha
+//! channel unchanged, and multiplies the other channels by some factor.
+inline Clr LightenClr(const Clr& clr, float factor = 2.0)
+{
+    return Clr(
+        std::min(static_cast<int>(clr.r * factor), 255),
+        std::min(static_cast<int>(clr.g * factor), 255),
+        std::min(static_cast<int>(clr.b * factor), 255),
+        clr.a);
+}
+
+//! Returns the darkened version of color clr.  DarkenClr leaves the alpha
+//! channel unchanged, and divides the other channels by some factor.
+inline Clr DarkenClr(const Clr& clr, float factor = 2.0)
+{
+    return Clr(
+        static_cast<int>(clr.r / factor),
+        static_cast<int>(clr.g / factor),
+        static_cast<int>(clr.b / factor),
+        clr.a);
+}
+
 inline Clr InvertClr(const Clr& clr)
 {
     return Clr(255 - clr.r,

--- a/GG/GG/DrawUtil.h
+++ b/GG/GG/DrawUtil.h
@@ -36,16 +36,6 @@ namespace GG {
     /** Calls the appropriate version of glColor*() with \a clr. */
     GG_API void glColor(Clr clr);
 
-    /** Returns the lightened version of color clr.  LightColor leaves the
-        alpha channel unchanged, and multiplies the other channels by some
-        factor.  (The factor is defined within LightColor().) */
-    GG_API Clr LightColor(Clr clr);
-
-    /** Returns the darkened version of color clr.  DarkColor leaves the alpha
-        channel unchanged, and divides the other channels by some factor.
-        (The factor is defined within DarkColor().) */
-    GG_API Clr DarkColor(Clr clr);
-
     /** Returns the "disabled" (grayed) version of color clr.  DisabledColor
         leaves the alpha channel unchanged, and adjusts the other channels in
         the direction of gray (GG_CLR_GRAY) by a factor between 0.0 and 1.0.

--- a/GG/GG/Spin.h
+++ b/GG/GG/Spin.h
@@ -31,7 +31,6 @@
 #define _GG_Spin_h_
 
 #include <GG/Button.h>
-#include <GG/DrawUtil.h>
 #include <GG/Edit.h>
 #include <GG/GUI.h>
 #include <GG/StyleFactory.h>

--- a/GG/src/Button.cpp
+++ b/GG/src/Button.cpp
@@ -542,7 +542,7 @@ void BeveledTabRepresenter::Render(const StateButton& button) const
     Pt cl_lr = button.ClientLowerRight();
     Pt tx_ul = Pt();
 
-    Clr color_to_use = button.Checked() ? button.Color() : DarkColor(button.Color());
+    Clr color_to_use = button.Checked() ? button.Color() : DarkenClr(button.Color());
     color_to_use = button.Disabled() ? DisabledColor(color_to_use) : color_to_use;
     if (!button.Checked()) {
         cl_ul.y += BEVEL;

--- a/GG/src/Cursor.cpp
+++ b/GG/src/Cursor.cpp
@@ -24,7 +24,6 @@
    
 #include <GG/Cursor.h>
 
-#include <GG/DrawUtil.h>
 #include <GG/Texture.h>
 
 

--- a/GG/src/DrawUtil.cpp
+++ b/GG/src/DrawUtil.cpp
@@ -556,26 +556,6 @@ namespace GG {
     void glColor(Clr clr)
     { glColor4ub(clr.r, clr.g, clr.b, clr.a); }
 
-    Clr LightColor(Clr clr)
-    {
-        const double scale_factor = 2.0;   // factor by which the color is lightened
-        Clr retval = clr;
-        retval.r = std::min(static_cast<int>(retval.r * scale_factor), 255);
-        retval.g = std::min(static_cast<int>(retval.g * scale_factor), 255);
-        retval.b = std::min(static_cast<int>(retval.b * scale_factor), 255);
-        return retval;
-    }
-
-    Clr DarkColor(Clr clr)
-    {
-        const double scale_factor = 2.0;   // factor by which the color is darkened
-        Clr retval = clr;
-        retval.r = static_cast<int>(retval.r / scale_factor);
-        retval.g = static_cast<int>(retval.g / scale_factor);
-        retval.b = static_cast<int>(retval.b / scale_factor);
-        return retval;
-    }
-
     Clr DisabledColor(Clr clr)
     {
         Clr retval = clr;
@@ -787,8 +767,8 @@ namespace GG {
                           bool bevel_bottom/* = true*/)
     {
         Rectangle(ul, lr, color,
-                  (up ? LightColor(border_color) : DarkColor(border_color)),
-                  (up ? DarkColor(border_color) : LightColor(border_color)),
+                  (up ? LightenClr(border_color) : DarkenClr(border_color)),
+                  (up ? DarkenClr(border_color) : LightenClr(border_color)),
                   bevel_thick, bevel_left, bevel_top, bevel_right, bevel_bottom);
     }
 
@@ -805,8 +785,8 @@ namespace GG {
                                  unsigned int bevel_thick/* = 2*/)
     {
         RoundedRectangle(ul, lr, color,
-                         (up ? LightColor(border_color) : DarkColor(border_color)),
-                         (up ? DarkColor(border_color) : LightColor(border_color)),
+                         (up ? LightenClr(border_color) : DarkenClr(border_color)),
+                         (up ? DarkenClr(border_color) : LightenClr(border_color)),
                          corner_radius, bevel_thick);
     }
 
@@ -814,7 +794,7 @@ namespace GG {
     { Check(ul, lr, color, color, color); }
 
     void BeveledCheck(Pt ul, Pt lr, Clr color)
-    { Check(ul, lr, color, LightColor(color), DarkColor(color)); }
+    { Check(ul, lr, color, LightenClr(color), DarkenClr(color)); }
 
     void FlatX(Pt ul, Pt lr, Clr color)
     { XMark(ul, lr, color, color, color); }
@@ -822,8 +802,8 @@ namespace GG {
     void Bubble(Pt ul, Pt lr, Clr color, bool up/* = true*/)
     {
         BubbleArc(ul, lr, color,
-                  (up ? DarkColor(color) : LightColor(color)),
-                  (up ? LightColor(color) : DarkColor(color)),
+                  (up ? DarkenClr(color) : LightenClr(color)),
+                  (up ? LightenClr(color) : DarkenClr(color)),
                   0, 0);
     }
 
@@ -833,16 +813,16 @@ namespace GG {
     void BeveledCircle(Pt ul, Pt lr, Clr color, Clr border_color, bool up/* = true*/, unsigned int bevel_thick/* = 2*/)
     {
         CircleArc(ul, lr, color,
-                  (up ? DarkColor(border_color) : LightColor(border_color)),
-                  (up ? LightColor(border_color) : DarkColor(border_color)),
+                  (up ? DarkenClr(border_color) : LightenClr(border_color)),
+                  (up ? LightenClr(border_color) : DarkenClr(border_color)),
                   bevel_thick, 0, 0);
     }
 
     void BubbleRectangle(Pt ul, Pt lr, Clr color, bool up, unsigned int corner_radius/* = 5*/)
     {
         ::BubbleRectangle(ul, lr, color,
-                          (up ? LightColor(color) : DarkColor(color)),
-                          (up ? DarkColor(color) : LightColor(color)),
+                          (up ? LightenClr(color) : DarkenClr(color)),
+                          (up ? DarkenClr(color) : LightenClr(color)),
                           corner_radius);
     }
 } // namespace GG

--- a/GG/src/DrawUtil.cpp
+++ b/GG/src/DrawUtil.cpp
@@ -249,10 +249,7 @@ namespace { // file-scope constants and functions
         for (int j = first_slice_idx; j <= last_slice_idx; ++j) { // calculate the color value for each needed point
             int X = (j > SLICES ? (j - SLICES) : j) * 2, Y = X + 1;
             double color_scale_factor = (SQRT2OVER2 * (unit_vertices[X] + unit_vertices[Y]) + 1) / 2; // this is essentially the dot product of (x,y) with (sqrt2over2,sqrt2over2), the direction of the light source, scaled to the range [0,1]
-            colors[j] = Clr(GLubyte(color3.r * (1 - color_scale_factor) + color2.r * color_scale_factor),
-                            GLubyte(color3.g * (1 - color_scale_factor) + color2.g * color_scale_factor),
-                            GLubyte(color3.b * (1 - color_scale_factor) + color2.b * color_scale_factor),
-                            GLubyte(color3.a * (1 - color_scale_factor) + color2.a * color_scale_factor));
+            colors[j] = BlendClr(color2, color3, color_scale_factor);
         }
 
         glPushMatrix();
@@ -266,10 +263,8 @@ namespace { // file-scope constants and functions
         double x = cos(-theta1),
             y = sin(-theta1);
         double color_scale_factor = (SQRT2OVER2 * (x + y) + 1) / 2;
-        glColor4ub(GLubyte(color3.r * (1 - color_scale_factor) + color2.r * color_scale_factor),
-                   GLubyte(color3.g * (1 - color_scale_factor) + color2.g * color_scale_factor),
-                   GLubyte(color3.b * (1 - color_scale_factor) + color2.b * color_scale_factor),
-                   GLubyte(color3.a * (1 - color_scale_factor) + color2.a * color_scale_factor));
+        Clr clr = BlendClr(color2, color3, color_scale_factor);
+        glColor4ub(clr.r, clr.g, clr.b, clr.a);
         glVertex2f(x, y);
         // angles in between theta1 and theta2, if any
         for (int i = first_slice_idx; i <= last_slice_idx; ++i) {
@@ -281,10 +276,8 @@ namespace { // file-scope constants and functions
         x = cos(-theta2);
         y = sin(-theta2);
         color_scale_factor = (SQRT2OVER2 * (x + y) + 1) / 2;
-        glColor4ub(GLubyte(color3.r * (1 - color_scale_factor) + color2.r * color_scale_factor),
-                   GLubyte(color3.g * (1 - color_scale_factor) + color2.g * color_scale_factor),
-                   GLubyte(color3.b * (1 - color_scale_factor) + color2.b * color_scale_factor),
-                   GLubyte(color3.a * (1 - color_scale_factor) + color2.a * color_scale_factor));
+        clr = BlendClr(color2, color3, color_scale_factor);
+        glColor4ub(clr.r, clr.g, clr.b, clr.a);
         glVertex2f(x, y);
         glEnd();
         glPopMatrix();
@@ -331,10 +324,7 @@ namespace { // file-scope constants and functions
         for (int j = first_slice_idx; j <= last_slice_idx; ++j) { // calculate the color value for each needed point
             int X = (j > SLICES ? (j - SLICES) : j) * 2, Y = X + 1;
             double color_scale_factor = (SQRT2OVER2 * (unit_vertices[X] + unit_vertices[Y]) + 1) / 2; // this is essentially the dot product of (x,y) with (sqrt2over2,sqrt2over2), the direction of the light source, scaled to the range [0,1]
-            colors[j] = Clr(GLubyte(border_color2.r * (1 - color_scale_factor) + border_color1.r * color_scale_factor),
-                            GLubyte(border_color2.g * (1 - color_scale_factor) + border_color1.g * color_scale_factor),
-                            GLubyte(border_color2.b * (1 - color_scale_factor) + border_color1.b * color_scale_factor),
-                            GLubyte(border_color2.a * (1 - color_scale_factor) + border_color1.a * color_scale_factor));
+            colors[j] = BlendClr(border_color1, border_color2, color_scale_factor);
         }
 
         glPushMatrix();
@@ -359,10 +349,8 @@ namespace { // file-scope constants and functions
         glBegin(GL_QUAD_STRIP);
         // point on circle at angle theta1
         double color_scale_factor = (SQRT2OVER2 * (theta1_x + theta1_y) + 1) / 2;
-        glColor4ub(GLubyte(border_color2.r * (1 - color_scale_factor) + border_color1.r * color_scale_factor),
-                   GLubyte(border_color2.g * (1 - color_scale_factor) + border_color1.g * color_scale_factor),
-                   GLubyte(border_color2.b * (1 - color_scale_factor) + border_color1.b * color_scale_factor),
-                   GLubyte(border_color2.a * (1 - color_scale_factor) + border_color1.a * color_scale_factor));
+        Clr clr = BlendClr(border_color1, border_color2, color_scale_factor);
+        glColor4ub(clr.r, clr.g, clr.b, clr.a);
         glVertex2f(theta1_x, theta1_y);
         glVertex2f(theta1_x * inner_radius, theta1_y * inner_radius);
         // angles in between theta1 and theta2, if any
@@ -374,10 +362,8 @@ namespace { // file-scope constants and functions
         }
         // theta2
         color_scale_factor = (SQRT2OVER2 * (theta2_x + theta2_y) + 1) / 2;
-        glColor4ub(GLubyte(border_color2.r * (1 - color_scale_factor) + border_color1.r * color_scale_factor),
-                   GLubyte(border_color2.g * (1 - color_scale_factor) + border_color1.g * color_scale_factor),
-                   GLubyte(border_color2.b * (1 - color_scale_factor) + border_color1.b * color_scale_factor),
-                   GLubyte(border_color2.a * (1 - color_scale_factor) + border_color1.a * color_scale_factor));
+        clr = BlendClr(border_color1, border_color2, color_scale_factor);
+        glColor4ub(clr.r, clr.g, clr.b, clr.a);
         glVertex2f(theta2_x, theta2_y);
         glVertex2f(theta2_x * inner_radius, theta2_y * inner_radius);
         glEnd();
@@ -408,7 +394,7 @@ namespace { // file-scope constants and functions
         int rad = static_cast<int>(corner_radius);
 
         double color_scale_factor = (SQRT2OVER2 * (0 + 1) + 1) / 2;
-        GG::Clr clr = border_color2 * (1 - color_scale_factor) + border_color1 * color_scale_factor;
+        Clr clr = BlendClr(border_color1, border_color2, color_scale_factor);
         // top
         vert_buf.store(lr.x - rad,      ul.y);
         vert_buf.store(ul.x + rad,      ul.y);
@@ -424,7 +410,7 @@ namespace { // file-scope constants and functions
 
 
         color_scale_factor = (SQRT2OVER2 * (-1 + 0) + 1) / 2;
-        clr = border_color2 * (1 - color_scale_factor) + border_color1 * color_scale_factor;
+        clr = BlendClr(border_color1, border_color2, color_scale_factor);
         // right
         vert_buf.store(lr.x,            ul.y + rad);
         vert_buf.store(lr.x - thick,    ul.y + rad);
@@ -485,10 +471,7 @@ namespace { // file-scope constants and functions
 
         // top
         double color_scale_factor = (SQRT2OVER2 * (0 + 1) + 1) / 2;
-        Clr scaled_color(GLubyte(color3.r * (1 - color_scale_factor) + color2.r * color_scale_factor),
-                         GLubyte(color3.g * (1 - color_scale_factor) + color2.g * color_scale_factor),
-                         GLubyte(color3.b * (1 - color_scale_factor) + color2.b * color_scale_factor),
-                         GLubyte(color3.a * (1 - color_scale_factor) + color2.a * color_scale_factor));
+        Clr scaled_color = BlendClr(color2, color3, color_scale_factor);
 
         GL2DVertexBuffer verts;
         verts.reserve(20);
@@ -516,10 +499,7 @@ namespace { // file-scope constants and functions
 
         // right
         color_scale_factor = (SQRT2OVER2 * (-1 + 0) + 1) / 2;
-        scaled_color = Clr(GLubyte(color3.r * (1 - color_scale_factor) + color2.r * color_scale_factor),
-                           GLubyte(color3.g * (1 - color_scale_factor) + color2.g * color_scale_factor),
-                           GLubyte(color3.b * (1 - color_scale_factor) + color2.b * color_scale_factor),
-                           GLubyte(color3.a * (1 - color_scale_factor) + color2.a * color_scale_factor));
+        scaled_color = BlendClr(color2, color3, color_scale_factor);
         colours.store(color1);
         colours.store(color1);
         verts.store(lr.x - rad, ul.y + rad);

--- a/GG/src/DropDownList.cpp
+++ b/GG/src/DropDownList.cpp
@@ -680,8 +680,8 @@ void DropDownList::Render()
     Pt ul = UpperLeft();
 
     Clr border_color = Disabled() ? DisabledColor(LB()->Color()) : LB()->Color();
-    Clr border_color1 = DarkColor(border_color);
-    Clr border_color2 = LightColor(border_color);
+    Clr border_color1 = DarkenClr(border_color);
+    Clr border_color2 = LightenClr(border_color);
     Clr interior_color = Disabled() ? DisabledColor(LB()->m_int_color) : LB()->m_int_color;
 
 

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -26,7 +26,6 @@
 
 #include <GG/GUI.h>
 #include <GG/Base.h>
-#include <GG/DrawUtil.h>
 #include <GG/StyleFactory.h>
 #include <GG/utf8/checked.h>
 #include <GG/GLClientAndServerBuffer.h>

--- a/GG/src/GroupBox.cpp
+++ b/GG/src/GroupBox.cpp
@@ -87,8 +87,8 @@ void GroupBox::Render()
 {
     Pt ul = UpperLeft(), lr = LowerRight() - Pt(X1, Y1);
     ul.y += TopOfFrame(m_label != nullptr, m_font);
-    Clr light = LightColor(m_color);
-    Clr dark = DarkColor(m_color);
+    Clr light = LightenClr(m_color);
+    Clr dark = DarkenClr(m_color);
     const int GAP_FROM_TEXT = 2;
     int vertices[24] = {
         Value(ul.x) + FRAME_THICK + PIXEL_MARGIN - GAP_FROM_TEXT, Value(ul.y),

--- a/GG/src/SDL/SDLGUI.cpp
+++ b/GG/src/SDL/SDLGUI.cpp
@@ -30,8 +30,6 @@
 #include <cctype>
 #include <iostream>
 
-#include <GG/DrawUtil.h>
-
 #include <boost/format.hpp>
 
 using namespace GG;

--- a/GG/src/TabWnd.cpp
+++ b/GG/src/TabWnd.cpp
@@ -24,7 +24,6 @@
 
 #include <GG/TabWnd.h>
 
-#include <GG/DrawUtil.h>
 #include <GG/Layout.h>
 #include <GG/StyleFactory.h>
 #include <GG/WndEvent.h>

--- a/GG/src/dialogs/ColorDlg.cpp
+++ b/GG/src/dialogs/ColorDlg.cpp
@@ -24,7 +24,6 @@
 
 #include <GG/dialogs/ColorDlg.h>
 
-#include <GG/DrawUtil.h>
 #include <GG/Font.h>
 #include <GG/GLClientAndServerBuffer.h>
 #include <GG/GUI.h>

--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -23,7 +23,6 @@
 #include "../universe/ValueRef.h"
 #include "../client/human/HumanClientApp.h"
 
-#include <GG/DrawUtil.h>
 #include <GG/Layout.h>
 #include <GG/StaticGraphic.h>
 

--- a/UI/BuildingsPanel.cpp
+++ b/UI/BuildingsPanel.cpp
@@ -284,9 +284,9 @@ BuildingIndicator::BuildingIndicator(GG::X w, const std::string& building_type,
     m_progress_bar = GG::Wnd::Create<MultiTurnProgressBar>(total_turns,
                                                            turns_completed,
                                                            next_progress,
-                                                           GG::LightColor(ClientUI::TechWndProgressBarBackgroundColor()),
+                                                           GG::LightenClr(ClientUI::TechWndProgressBarBackgroundColor()),
                                                            ClientUI::TechWndProgressBarColor(),
-                                                           GG::LightColor(ClientUI::ResearchableTechFillColor()));
+                                                           GG::LightenClr(ClientUI::ResearchableTechFillColor()));
 
 }
 

--- a/UI/BuildingsPanel.cpp
+++ b/UI/BuildingsPanel.cpp
@@ -1,7 +1,6 @@
 #include "BuildingsPanel.h"
 
 #include <GG/Button.h>
-#include <GG/DrawUtil.h>
 #include <GG/StaticGraphic.h>
 
 #include "../util/i18n.h"

--- a/UI/CUIControls.cpp
+++ b/UI/CUIControls.cpp
@@ -16,7 +16,6 @@
 
 #include <GG/utf8/checked.h>
 #include <GG/dialogs/ColorDlg.h>
-#include <GG/DrawUtil.h>
 #include <GG/GUI.h>
 #include <GG/Layout.h>
 

--- a/UI/CUIControls.cpp
+++ b/UI/CUIControls.cpp
@@ -609,7 +609,7 @@ void CUITabBar::DistinguishCurrentTab(const std::vector<GG::StateButton*>& tab_b
         if (index == i)
             tab->SetTextColor(text_color);
         else
-            tab->SetTextColor(DarkColor(text_color));
+            tab->SetTextColor(DarkenClr(text_color));
     }
 }
 
@@ -796,7 +796,7 @@ void CUIDropDownList::Render() {
     GG::Clr lb_color = LB()->Color();
     GG::Clr border_color = Disabled() ? DisabledColor(lb_color) : lb_color;
     if (GG::GUI::GetGUI()->FocusWnd().get() == this)
-        border_color = GG::LightColor(border_color);
+        border_color = GG::LightenClr(border_color);
     GG::Clr interior_color = Disabled() ? DisabledColor(InteriorColor()) : InteriorColor();
 
     glPushMatrix();
@@ -956,7 +956,7 @@ void CUIEdit::Render() {
     GG::Clr color = Color();
     GG::Clr border_color = Disabled() ? DisabledColor(color) : color;
     if (GG::GUI::GetGUI()->FocusWnd().get() == this)
-        border_color = GG::LightColor(border_color);
+        border_color = GG::LightenClr(border_color);
     GG::Clr int_color_to_use = Disabled() ? DisabledColor(InteriorColor()) : InteriorColor();
 
 
@@ -1101,7 +1101,7 @@ void CUIMultiEdit::Render() {
     GG::Clr color = Color();
     GG::Clr border_color =      Disabled()  ?   DisabledColor(color)            :   color;
     if (GG::GUI::GetGUI()->FocusWnd().get() == this)
-        border_color = GG::LightColor(border_color);
+        border_color = GG::LightenClr(border_color);
     GG::Clr int_color_to_use =  Disabled()  ?   DisabledColor(InteriorColor())  :   InteriorColor();
 
     GG::Pt ul = UpperLeft(), lr = LowerRight();
@@ -2145,12 +2145,12 @@ void MultiTurnProgressBar::Render() {
         segment_verts.reserve(2 * m_num_segments);
         segment_colors.reserve(2 * m_num_segments);
 
-        GG::Clr current_colour(GG::DarkColor(m_clr_bar));
+        GG::Clr current_colour(GG::DarkenClr(m_clr_bar));
 
         for (int n = 1; n < m_num_segments; ++n) {
             GG::X separator_x(ul.x + Width() * n / m_num_segments);
             if (separator_x > comp_rect.lr.x)
-                current_colour = GG::LightColor(m_clr_bg);
+                current_colour = GG::LightenClr(m_clr_bg);
             segment_verts.store(separator_x, ul.y);
             segment_verts.store(separator_x, lr.y);
             segment_colors.store(current_colour);
@@ -2178,7 +2178,7 @@ void MultiTurnProgressBar::Render() {
         pred_verts.activate();
         glColor(m_clr_outline);
         glDrawArrays(GL_QUAD_STRIP, 0, 10);
-        glColor(GG::LightColor(m_clr_bar));
+        glColor(GG::LightenClr(m_clr_bar));
         glDrawArrays(GL_QUADS, 10, 4);
     }
 

--- a/UI/CUIStyle.cpp
+++ b/UI/CUIStyle.cpp
@@ -125,7 +125,7 @@ std::shared_ptr<GG::StateButton> CUIStyle::NewTabBarTab(
 {
     auto retval = GG::Wnd::Create<CUIStateButton>(str, format, std::make_shared<CUITabRepresenter>());
     retval->SetColor(ClientUI::WndColor());
-    retval->GetLabel()->SetTextColor(DarkColor(ClientUI::TextColor()));
+    retval->GetLabel()->SetTextColor(DarkenClr(ClientUI::TextColor()));
     retval->Resize(retval->MinUsableSize() + GG::Pt(GG::X(12), GG::Y0));
     return retval;
 }

--- a/UI/CUIWnd.cpp
+++ b/UI/CUIWnd.cpp
@@ -12,7 +12,6 @@
 #include "../util/Directories.h"
 #include "../util/Logger.h"
 
-#include <GG/DrawUtil.h>
 #include <GG/GUI.h>
 
 #include <limits>

--- a/UI/CUIWnd.cpp
+++ b/UI/CUIWnd.cpp
@@ -322,11 +322,11 @@ void CUIWnd::Render() {
         auto focus_wnd = GG::GUI::GetGUI()->FocusWnd();
         bool highlight = (focus_wnd.get() == this || this->IsAncestorOf(focus_wnd));
 
-        flashing ? glColor(GG::LightColor(ClientUI::WndColor())) : glColor(ClientUI::WndColor());
+        flashing ? glColor(GG::LightenClr(ClientUI::WndColor())) : glColor(ClientUI::WndColor());
         glDrawArrays(GL_TRIANGLE_FAN,   m_buffer_indices[1].first, m_buffer_indices[1].second);
-        flashing || highlight ? glColor(GG::LightColor(ClientUI::WndOuterBorderColor())) : glColor(ClientUI::WndOuterBorderColor());
+        flashing || highlight ? glColor(GG::LightenClr(ClientUI::WndOuterBorderColor())) : glColor(ClientUI::WndOuterBorderColor());
         glDrawArrays(GL_LINE_LOOP,      m_buffer_indices[1].first, m_buffer_indices[1].second);
-        flashing ? glColor(GG::LightColor(ClientUI::WndInnerBorderColor())) : glColor(ClientUI::WndInnerBorderColor());
+        flashing ? glColor(GG::LightenClr(ClientUI::WndInnerBorderColor())) : glColor(ClientUI::WndInnerBorderColor());
         glDrawArrays(GL_LINE_LOOP,      m_buffer_indices[2].first, m_buffer_indices[2].second);
 
         if (m_resizable) {

--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -34,7 +34,6 @@
 
 #include <GG/Clr.h>
 #include <GG/dialogs/ThreeButtonDlg.h>
-#include <GG/DrawUtil.h>
 #include <GG/GUI.h>
 #include <GG/RichText/ImageBlock.h>
 #include <GG/UnicodeCharsets.h>

--- a/UI/CombatReport/GraphicalSummary.cpp
+++ b/UI/CombatReport/GraphicalSummary.cpp
@@ -11,7 +11,6 @@
 #include "../../combat/CombatLogManager.h"
 
 #include <GG/ClrConstants.h>
-#include <GG/DrawUtil.h>
 #include <GG/Layout.h>
 
 #include <boost/format.hpp>

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -22,7 +22,6 @@
 #include "../universe/ShipDesign.h"
 #include "../universe/Enums.h"
 
-#include <GG/DrawUtil.h>
 #include <GG/StaticGraphic.h>
 #include <GG/TabWnd.h>
 

--- a/UI/EncyclopediaDetailPanel.cpp
+++ b/UI/EncyclopediaDetailPanel.cpp
@@ -36,7 +36,6 @@
 #include "../client/human/HumanClientApp.h"
 #include "../combat/CombatLogManager.h"
 
-#include <GG/DrawUtil.h>
 #include <GG/GUI.h>
 #include <GG/RichText/RichText.h>
 #include <GG/ScrollPanel.h>

--- a/UI/FieldIcon.cpp
+++ b/UI/FieldIcon.cpp
@@ -7,7 +7,6 @@
 #include "../util/AppInterface.h"
 #include "../util/i18n.h"
 
-#include <GG/DrawUtil.h>
 #include <GG/StaticGraphic.h>
 #include <GG/DynamicGraphic.h>
 #include <GG/WndEvent.h>

--- a/UI/FleetButton.cpp
+++ b/UI/FleetButton.cpp
@@ -15,7 +15,6 @@
 #include "../universe/Enums.h"
 #include "../Empire/Empire.h"
 
-#include <GG/DrawUtil.h>
 #include <GG/GLClientAndServerBuffer.h>
 
 #include <algorithm>

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -23,7 +23,6 @@
 #include "../network/Message.h"
 #include "../Empire/Empire.h"
 
-#include <GG/DrawUtil.h>
 #include <GG/Enum.h>
 #include <GG/GUI.h>
 #include <GG/Layout.h>

--- a/UI/GalaxySetupWnd.cpp
+++ b/UI/GalaxySetupWnd.cpp
@@ -15,7 +15,6 @@
 
 #include <boost/filesystem/fstream.hpp>
 
-#include <GG/DrawUtil.h>
 #include <GG/StaticGraphic.h>
 #include <GG/Layout.h>
 #include <GG/TabWnd.h>

--- a/UI/GraphControl.cpp
+++ b/UI/GraphControl.cpp
@@ -4,7 +4,6 @@
 #include "CUIControls.h"
 #include "../util/i18n.h"
 
-#include <GG/DrawUtil.h>
 #include <GG/ClrConstants.h>
 
 

--- a/UI/GraphControl.cpp
+++ b/UI/GraphControl.cpp
@@ -291,9 +291,9 @@ void GraphControl::DoLayout() {
         for (double line_y = shown_y_min + step; line_y <= shown_y_max; line_y = line_y + step) {
             const auto& screen_y = static_cast<float>((line_y - shown_y_min) * HEIGHT / y_range);
             m_vert_buf.store(GG::X1, -screen_y);    // OpenGL is positive down / negative up
-            m_colour_buf.store(GG::LightColor(ClientUI::WndColor()));
+            m_colour_buf.store(GG::LightenClr(ClientUI::WndColor()));
             m_vert_buf.store(GG::X(WIDTH - 1), -screen_y);
-            m_colour_buf.store(GG::LightColor(ClientUI::WndColor()));
+            m_colour_buf.store(GG::LightenClr(ClientUI::WndColor()));
 
             if (m_log_scale)
                 m_y_scale_ticks[GG::Y(-screen_y)] = std::pow(10.0, std::round(line_y));

--- a/UI/IconTextBrowseWnd.cpp
+++ b/UI/IconTextBrowseWnd.cpp
@@ -1,6 +1,5 @@
 #include "IconTextBrowseWnd.h"
 
-#include <GG/DrawUtil.h>
 #include <GG/StaticGraphic.h>
 
 #include "ClientUI.h"

--- a/UI/InGameMenu.cpp
+++ b/UI/InGameMenu.cpp
@@ -15,7 +15,6 @@
 
 #include <GG/Button.h>
 #include <GG/Clr.h>
-#include <GG/DrawUtil.h>
 #include <GG/dialogs/ThreeButtonDlg.h>
 
 #include <boost/filesystem/operations.hpp>

--- a/UI/IntroScreen.cpp
+++ b/UI/IntroScreen.cpp
@@ -17,7 +17,6 @@
 #include "../util/XMLDoc.h"
 
 #include <GG/GUI.h>
-#include <GG/DrawUtil.h>
 #include <GG/StaticGraphic.h>
 #include <GG/Texture.h>
 #include <GG/Layout.h>

--- a/UI/LinkText.cpp
+++ b/UI/LinkText.cpp
@@ -11,7 +11,6 @@
 #include "../util/Directories.h"
 #include "../universe/Enums.h"
 
-#include <GG/DrawUtil.h>
 #include <GG/WndEvent.h>
 #include <GG/GUI.h>
 #include <boost/xpressive/xpressive.hpp>

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -3743,7 +3743,7 @@ namespace {
                 if (under_alloc_res_grp_core_members
                     && under_alloc_res_grp_core_members->count(start_system->ID()))
                 {
-                    lane_colour_to_use = GG::DarkColor(GG::Clr(255-lane_colour.r, 255-lane_colour.g, 255-lane_colour.b, lane_colour.a));
+                    lane_colour_to_use = GG::DarkenClr(GG::InvertClr(lane_colour));
                 }
 
                 auto start_core = member_to_core.find(start_system->ID());

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -57,7 +57,6 @@
 #include <boost/range/numeric.hpp>
 #include <boost/range/adaptor/map.hpp>
 
-#include <GG/DrawUtil.h>
 #include <GG/Layout.h>
 #include <GG/MultiEdit.h>
 #include <GG/PtRect.h>

--- a/UI/MeterBrowseWnd.cpp
+++ b/UI/MeterBrowseWnd.cpp
@@ -1,7 +1,5 @@
 #include "MeterBrowseWnd.h"
 
-#include <GG/DrawUtil.h>
-
 #include "../util/i18n.h"
 #include "../util/Logger.h"
 #include "../util/GameRules.h"

--- a/UI/MultiplayerLobbyWnd.cpp
+++ b/UI/MultiplayerLobbyWnd.cpp
@@ -1,7 +1,6 @@
 #include "MultiplayerLobbyWnd.h"
 
 #include <GG/Button.h>
-#include <GG/DrawUtil.h>
 #include <GG/Layout.h>
 #include <GG/StaticGraphic.h>
 

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -25,7 +25,6 @@
 #include "../universe/ValueRefs.h"
 #include "../universe/Enums.h"
 
-#include <GG/DrawUtil.h>
 #include <GG/Layout.h>
 
 #include <boost/lexical_cast.hpp>

--- a/UI/PlayerListWnd.cpp
+++ b/UI/PlayerListWnd.cpp
@@ -14,8 +14,6 @@
 #include "../universe/System.h"
 #include "../universe/Enums.h"
 
-#include <GG/DrawUtil.h>
-
 #include <algorithm>
 
 namespace {

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -490,7 +490,7 @@ namespace {
         const Empire* this_client_empire = GetEmpire(client_empire_id);
         if (this_client_empire && (system_selected || rally_dest_selected)) {
             auto empire_color = this_client_empire->Color();
-            auto rally_color = GG::DarkColor(GG::Clr(255 - empire_color.r, 255 - empire_color.g, 255 - empire_color.b, empire_color.a));
+            auto rally_color = GG::DarkColor(GG::InvertClr(empire_color));
             auto location_color = system_selected ? empire_color : rally_color;
             m_location_text = GG::Wnd::Create<GG::TextControl>(GG::X0, GG::Y0, GG::X1, GG::Y1, "<s>" + location_text + "</s>",
                                                   ClientUI::GetBoldFont(), location_color, GG::FORMAT_TOP | GG::FORMAT_RIGHT);

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -49,7 +49,7 @@ namespace {
                    GG::Y h, bool inProgress, bool amBlockType) :
             Control(GG::X0, GG::Y0, nwidth, h, GG::NO_WND_FLAGS)
         {
-            GG::Clr txtClr = inProgress ? GG::LightColor(ClientUI::ResearchableTechTextAndBorderColor()) : ClientUI::ResearchableTechTextAndBorderColor();
+            GG::Clr txtClr = inProgress ? GG::LightenClr(ClientUI::ResearchableTechTextAndBorderColor()) : ClientUI::ResearchableTechTextAndBorderColor();
             std::string nameText;
             if (amBlockType)
                 nameText = boost::io::str(FlexibleFormat(UserString("PRODUCTION_QUEUE_MULTIPLES")) % quantity);
@@ -122,9 +122,9 @@ namespace {
 
             DisableDropArrow();
             SetStyle(GG::LIST_LEFT | GG::LIST_NOSORT);
-            SetColor(inProgress ? GG::LightColor(ClientUI::ResearchableTechTextAndBorderColor())
+            SetColor(inProgress ? GG::LightenClr(ClientUI::ResearchableTechTextAndBorderColor())
                                 : ClientUI::ResearchableTechTextAndBorderColor());
-            SetInteriorColor(inProgress ? GG::LightColor(ClientUI::ResearchableTechFillColor())
+            SetInteriorColor(inProgress ? GG::LightenClr(ClientUI::ResearchableTechFillColor())
                                         : ClientUI::ResearchableTechFillColor());
             SetNumCols(1);
 
@@ -426,7 +426,7 @@ namespace {
         SetChildClippingMode(ClipToClient);
 
         GG::Clr clr = m_in_progress
-            ? GG::LightColor(ClientUI::ResearchableTechTextAndBorderColor())
+            ? GG::LightenClr(ClientUI::ResearchableTechTextAndBorderColor())
             : ClientUI::ResearchableTechTextAndBorderColor();
 
         // get graphic and player-visible name text for item
@@ -490,7 +490,7 @@ namespace {
         const Empire* this_client_empire = GetEmpire(client_empire_id);
         if (this_client_empire && (system_selected || rally_dest_selected)) {
             auto empire_color = this_client_empire->Color();
-            auto rally_color = GG::DarkColor(GG::InvertClr(empire_color));
+            auto rally_color = GG::DarkenClr(GG::InvertClr(empire_color));
             auto location_color = system_selected ? empire_color : rally_color;
             m_location_text = GG::Wnd::Create<GG::TextControl>(GG::X0, GG::Y0, GG::X1, GG::Y1, "<s>" + location_text + "</s>",
                                                   ClientUI::GetBoldFont(), location_color, GG::FORMAT_TOP | GG::FORMAT_RIGHT);
@@ -508,12 +508,12 @@ namespace {
 
         GG::Clr outline_color = ClientUI::ResearchableTechFillColor();
         if (m_in_progress)
-            outline_color = GG::LightColor(outline_color);
+            outline_color = GG::LightenClr(outline_color);
 
         m_progress_bar = GG::Wnd::Create<MultiTurnProgressBar>(m_total_turns,
                                                                perc_complete,
                                                                next_progress,
-                                                               GG::LightColor(ClientUI::TechWndProgressBarBackgroundColor()),
+                                                               GG::LightenClr(ClientUI::TechWndProgressBarBackgroundColor()),
                                                                ClientUI::TechWndProgressBarColor(),
                                                                outline_color);
 
@@ -627,10 +627,10 @@ namespace {
 
     void QueueProductionItemPanel::Render() {
         GG::Clr fill = m_in_progress
-            ? GG::LightColor(ClientUI::ResearchableTechFillColor())
+            ? GG::LightenClr(ClientUI::ResearchableTechFillColor())
             : ClientUI::ResearchableTechFillColor();
         GG::Clr text_and_border = m_in_progress
-            ? GG::LightColor(ClientUI::ResearchableTechTextAndBorderColor())
+            ? GG::LightenClr(ClientUI::ResearchableTechTextAndBorderColor())
             : ClientUI::ResearchableTechTextAndBorderColor();
 
         glDisable(GL_TEXTURE_2D);

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -17,7 +17,6 @@
 #include "../universe/ShipDesign.h"
 #include "../universe/Enums.h"
 
-#include <GG/DrawUtil.h>
 #include <GG/Layout.h>
 #include <GG/StaticGraphic.h>
 

--- a/UI/QueueListBox.cpp
+++ b/UI/QueueListBox.cpp
@@ -3,7 +3,6 @@
 #include "../util/i18n.h"
 #include "../util/Logger.h"
 
-#include <GG/DrawUtil.h>
 #include <GG/WndEvent.h>
 
 #include <boost/cast.hpp>

--- a/UI/QueueListBox.cpp
+++ b/UI/QueueListBox.cpp
@@ -24,7 +24,7 @@ void PromptRow::CompleteConstruction() {
 
     m_prompt->MoveTo(GG::Pt(GG::X(2), GG::Y(2)));
     m_prompt->Resize(GG::Pt(Width() - 10, Height()));
-    m_prompt->SetTextColor(GG::LightColor(ClientUI::TextColor()));
+    m_prompt->SetTextColor(GG::LightenClr(ClientUI::TextColor()));
     m_prompt->ClipText(true);
     Resize(GG::Pt(Width(), m_prompt->Height()));
     push_back(m_prompt);

--- a/UI/ResearchWnd.cpp
+++ b/UI/ResearchWnd.cpp
@@ -153,7 +153,7 @@ namespace {
             m_total_turns = tech->ResearchTime(m_empire_id);
 
         GG::Clr clr = m_in_progress
-                        ? GG::LightColor(ClientUI::ResearchableTechTextAndBorderColor())
+                        ? GG::LightenClr(ClientUI::ResearchableTechTextAndBorderColor())
                         : ClientUI::ResearchableTechTextAndBorderColor();
 
         GG::Y top(MARGIN);
@@ -184,12 +184,12 @@ namespace {
         }
         GG::Clr outline_color = ClientUI::ResearchableTechFillColor();
         if (m_in_progress)
-            outline_color = GG::LightColor(outline_color);
+            outline_color = GG::LightenClr(outline_color);
 
         m_progress_bar = GG::Wnd::Create<MultiTurnProgressBar>(total_time,
                                                                perc_complete,
                                                                next_progress,
-                                                               GG::LightColor(ClientUI::TechWndProgressBarBackgroundColor()),
+                                                               GG::LightenClr(ClientUI::TechWndProgressBarBackgroundColor()),
                                                                ClientUI::TechWndProgressBarColor(),
                                                                outline_color);
 
@@ -232,8 +232,8 @@ namespace {
     }
 
     void QueueTechPanel::Render() {
-        GG::Clr fill = m_in_progress ? GG::LightColor(ClientUI::ResearchableTechFillColor()) : ClientUI::ResearchableTechFillColor();
-        GG::Clr text_and_border = m_in_progress ? GG::LightColor(ClientUI::ResearchableTechTextAndBorderColor()) : ClientUI::ResearchableTechTextAndBorderColor();
+        GG::Clr fill = m_in_progress ? GG::LightenClr(ClientUI::ResearchableTechFillColor()) : ClientUI::ResearchableTechFillColor();
+        GG::Clr text_and_border = m_in_progress ? GG::LightenClr(ClientUI::ResearchableTechTextAndBorderColor()) : ClientUI::ResearchableTechTextAndBorderColor();
 
         glDisable(GL_TEXTURE_2D);
         Draw(fill, true);

--- a/UI/ResearchWnd.cpp
+++ b/UI/ResearchWnd.cpp
@@ -13,7 +13,6 @@
 #include "../util/ScopedTimer.h"
 #include "../client/human/HumanClientApp.h"
 
-#include <GG/DrawUtil.h>
 #include <GG/Layout.h>
 #include <GG/StaticGraphic.h>
 

--- a/UI/SaveFileDialog.cpp
+++ b/UI/SaveFileDialog.cpp
@@ -15,7 +15,6 @@
 #include <GG/Button.h>
 #include <GG/Clr.h>
 #include <GG/dialogs/ThreeButtonDlg.h>
-#include <GG/DrawUtil.h>
 #include <GG/utf8/checked.h>
 
 #include <boost/filesystem/path.hpp>

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -34,7 +34,6 @@
 #include "../util/ScopedTimer.h"
 #include "../client/human/HumanClientApp.h"
 
-#include <GG/DrawUtil.h>
 #include <GG/DynamicGraphic.h>
 #include <GG/GUI.h>
 #include <GG/Layout.h>

--- a/UI/SitRepPanel.cpp
+++ b/UI/SitRepPanel.cpp
@@ -12,7 +12,6 @@
 #include "../util/SitRepEntry.h"
 #include "../universe/ShipDesign.h"
 
-#include <GG/DrawUtil.h>
 #include <GG/Layout.h>
 
 #include <boost/lexical_cast.hpp>

--- a/UI/SystemIcon.cpp
+++ b/UI/SystemIcon.cpp
@@ -20,7 +20,6 @@
 #include "../util/OptionsDB.h"
 #include "../Empire/Empire.h"
 
-#include <GG/DrawUtil.h>
 #include <GG/StaticGraphic.h>
 #include <GG/utf8/checked.h>
 #include <GG/utf8/core.h>

--- a/UI/TechTreeWnd.cpp
+++ b/UI/TechTreeWnd.cpp
@@ -22,7 +22,6 @@
 #include "TechTreeArcs.h"
 #include "Hotkeys.h"
 
-#include <GG/DrawUtil.h>
 #include <GG/GLClientAndServerBuffer.h>
 #include <GG/GUI.h>
 #include <GG/Layout.h>


### PR DESCRIPTION
This PR consolidates various color related operation, which were implemented locally multiple times.

The operations were implemented or moved to the GG::Clr header as inline functions. This covers:

* GG::LightenClr
* GG::DarkenClr
* GG::BlendClr
* GG::InvertClr

The PR also removes unused GG/DrawUtil.h includes in various places.