### PR TITLE
Fix behaviour of cookies storage with new config policy

### DIFF
--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -687,7 +687,8 @@ void HumanClientApp::MultiPlayerGame() {
             if (!GetOptionsDB().OptionExists(cookie_option + ".cookie"))
                 GetOptionsDB().Add<std::string>(cookie_option + ".cookie", "OPTIONS_DB_SERVER_COOKIE", "");
             if (!GetOptionsDB().OptionExists(cookie_option + ".address"))
-                GetOptionsDB().Add<std::string>(cookie_option + ".address", "OPTIONS_DB_SERVER_COOKIE", server_dest);
+                GetOptionsDB().Add<std::string>(cookie_option + ".address", "OPTIONS_DB_SERVER_COOKIE", "");
+            GetOptionsDB().Set(cookie_option + ".address", server_dest);
             std::string cookie_str = GetOptionsDB().Get<std::string>(cookie_option + ".cookie");
             boost::uuids::string_generator gen;
             cookie = gen(cookie_str);

--- a/client/human/HumanClientApp.cpp
+++ b/client/human/HumanClientApp.cpp
@@ -50,6 +50,7 @@
 #include <boost/optional/optional.hpp>
 #include <boost/serialization/vector.hpp>
 #include <boost/algorithm/string.hpp>
+#include <boost/uuid/uuid_io.hpp>
 #include <boost/uuid/nil_generator.hpp>
 #include <boost/uuid/string_generator.hpp>
 
@@ -685,7 +686,7 @@ void HumanClientApp::MultiPlayerGame() {
         try {
             std::string cookie_option = EncodeServerAddressOption(server_dest);
             if (!GetOptionsDB().OptionExists(cookie_option + ".cookie"))
-                GetOptionsDB().Add<std::string>(cookie_option + ".cookie", "OPTIONS_DB_SERVER_COOKIE", "");
+                GetOptionsDB().Add<std::string>(cookie_option + ".cookie", "OPTIONS_DB_SERVER_COOKIE", boost::uuids::to_string(cookie));
             if (!GetOptionsDB().OptionExists(cookie_option + ".address"))
                 GetOptionsDB().Add<std::string>(cookie_option + ".address", "OPTIONS_DB_SERVER_COOKIE", "");
             GetOptionsDB().Set(cookie_option + ".address", server_dest);

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -19,6 +19,7 @@
 
 #include <boost/format.hpp>
 #include <boost/uuid/uuid_io.hpp>
+#include <boost/uuid/nil_generator.hpp>
 #include <thread>
 
 /** \page statechart_notes Notes on Boost Statechart transitions
@@ -351,7 +352,8 @@ boost::statechart::result WaitingForMPJoinAck::react(const JoinGame& msg) {
             try {
                 std::string cookie_option = HumanClientApp::EncodeServerAddressOption(Client().Networking().Destination());
                 GetOptionsDB().Remove(cookie_option + ".cookie");
-                GetOptionsDB().Add(cookie_option + ".cookie", "OPTIONS_DB_SERVER_COOKIE", boost::uuids::to_string(cookie));
+                GetOptionsDB().Add(cookie_option + ".cookie", "OPTIONS_DB_SERVER_COOKIE", boost::uuids::to_string(boost::uuids::nil_uuid()));
+                GetOptionsDB().Set(cookie_option + ".cookie", boost::uuids::to_string(cookie));
                 GetOptionsDB().Commit();
             } catch(const std::exception& err) {
                 WarnLogger() << "Cann't save cookie for server " << Client().Networking().Destination() << ": "

--- a/client/human/HumanClientFSM.cpp
+++ b/client/human/HumanClientFSM.cpp
@@ -351,8 +351,9 @@ boost::statechart::result WaitingForMPJoinAck::react(const JoinGame& msg) {
         if (!cookie.is_nil()) {
             try {
                 std::string cookie_option = HumanClientApp::EncodeServerAddressOption(Client().Networking().Destination());
-                GetOptionsDB().Remove(cookie_option + ".cookie");
-                GetOptionsDB().Add(cookie_option + ".cookie", "OPTIONS_DB_SERVER_COOKIE", boost::uuids::to_string(boost::uuids::nil_uuid()));
+                if (!GetOptionsDB().OptionExists(cookie_option + ".cookie")) {
+                    GetOptionsDB().Add(cookie_option + ".cookie", "OPTIONS_DB_SERVER_COOKIE", boost::uuids::to_string(boost::uuids::nil_uuid()));
+                }
                 GetOptionsDB().Set(cookie_option + ".cookie", boost::uuids::to_string(cookie));
                 GetOptionsDB().Commit();
             } catch(const std::exception& err) {


### PR DESCRIPTION
Make actual values and default value to be different so they will be stored in the config file.