### PR TITLE
Replace some boost libraries with c++14 features

### DIFF
--- a/GG/GG/BrowseInfoWnd.h
+++ b/GG/GG/BrowseInfoWnd.h
@@ -34,8 +34,6 @@
 #include <GG/Font.h>
 #include <GG/GLClientAndServerBuffer.h>
 
-#include <boost/function.hpp>
-
 
 namespace GG {
 
@@ -79,7 +77,7 @@ public:
         currently-set cursor, this BrowseInfoWnd, and the Wnd that is
         displaying this BrowseInfoWnd as parameters, and returns the desired
         upper-left corner of this BrowseInfoWnd. */
-    mutable boost::function<
+    mutable std::function<
         Pt (const Pt&, const std::shared_ptr<Cursor>&, const BrowseInfoWnd&, const Wnd&)
     > PositionWnd;
 

--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -37,12 +37,12 @@
 #include <GG/Texture.h>
 #include <GG/UnicodeCharsets.h>
 
-#include <boost/unordered_map.hpp>
 #include <boost/graph/graph_concepts.hpp>
 
 #include <memory>
 #include <set>
 #include <stack>
+#include <unordered_map>
 
 
 struct FT_FaceRec_;
@@ -691,7 +691,7 @@ private:
         X           width;         ///< The width of the glyph only
     };
 
-    typedef boost::unordered_map<std::uint32_t, Glyph> GlyphMap;
+    typedef std::unordered_map<std::uint32_t, Glyph> GlyphMap;
 
     FT_Error          GetFace(FT_Face& face);
     FT_Error          GetFace(const std::vector<unsigned char>& file_contents, FT_Face& face);

--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -414,7 +414,7 @@ public:
         row sorting.  Note that \a sort_cmp is assumed to produce an ascending
         order when used to sort; setting the LIST_SORTDESCENDING style can be
         used to produce a reverse sort. */
-    void SetSortCmp(const boost::function<bool (const Row&, const Row&, std::size_t)>& sort_cmp);
+    void SetSortCmp(const std::function<bool (const Row&, const Row&, std::size_t)>& sort_cmp);
 
     /** Fixes the column widths; by default, an empty ListBox will take on the
         number of columns of its first added row. \note The number of columns
@@ -633,7 +633,7 @@ private:
     bool                    m_clip_cells = false;       ///< if true, the contents of each cell will be clipped to the visible area of that cell (TODO: currently unused)
     std::size_t             m_sort_col = 0;             ///< the index of the column data used to sort the list
 
-    boost::function<bool (const Row&, const Row&, std::size_t)>
+    std::function<bool (const Row&, const Row&, std::size_t)>
                             m_sort_cmp;                 ///< the predicate used to sort the values in the m_sort_col column of two rows
 
     bool                    m_allow_drops = false;      ///< are we accepting drops

--- a/GG/src/GUI.cpp
+++ b/GG/src/GUI.cpp
@@ -847,8 +847,7 @@ GUI*                       GUI::s_gui = nullptr;
 
 // member functions
 GUI::GUI(const std::string& app_name) :
-    // TODO:: use std::make_unique when switching to C++14
-    m_impl(new GUIImpl())
+    m_impl(std::make_unique<GUIImpl>())
 {
     assert(!s_gui);
     s_gui = this;

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -84,7 +84,7 @@ namespace {
     class RowSorter // used to sort rows by a certain column (which may contain some empty cells)
     {
     public:
-        RowSorter(const boost::function<bool (const ListBox::Row&, const ListBox::Row&, std::size_t)>& cmp,
+        RowSorter(const std::function<bool (const ListBox::Row&, const ListBox::Row&, std::size_t)>& cmp,
                   std::size_t col, bool invert) :
             m_cmp(cmp),
             m_sort_col(col),
@@ -97,7 +97,7 @@ namespace {
         { return m_invert ? m_cmp(*r, *l, m_sort_col) : m_cmp(*l, *r, m_sort_col); }
 
     private:
-        boost::function<bool (const ListBox::Row&, const ListBox::Row&, std::size_t)> m_cmp;
+        std::function<bool (const ListBox::Row&, const ListBox::Row&, std::size_t)> m_cmp;
         std::size_t m_sort_col;
         bool m_invert;
     };
@@ -1361,7 +1361,7 @@ void ListBox::SetSortCol(std::size_t n)
         Resort();
 }
 
-void ListBox::SetSortCmp(const boost::function<bool (const Row&, const Row&, std::size_t)>& sort_cmp)
+void ListBox::SetSortCmp(const std::function<bool (const Row&, const Row&, std::size_t)>& sort_cmp)
 {
     m_sort_cmp = sort_cmp;
     if (!(m_style & LIST_NOSORT))

--- a/GG/src/Texture.cpp
+++ b/GG/src/Texture.cpp
@@ -209,10 +209,10 @@ void Texture::Load(const boost::filesystem::path& path, bool mipmap/* = false*/)
     std::string filename = path.generic_string();
 #endif
 
-    BOOST_STATIC_ASSERT((sizeof(gil::gray8_pixel_t) == 1));
-    BOOST_STATIC_ASSERT((sizeof(gil::gray_alpha8_pixel_t) == 2));
-    BOOST_STATIC_ASSERT((sizeof(gil::rgb8_pixel_t) == 3));
-    BOOST_STATIC_ASSERT((sizeof(gil::rgba8_pixel_t) == 4));
+    static_assert(sizeof(gil::gray8_pixel_t) == 1, "gray8 pixel type does not match expected type size");
+    static_assert(sizeof(gil::gray_alpha8_pixel_t) == 2, "gray_alpha8 pixel type does not match expected type size");
+    static_assert(sizeof(gil::rgb8_pixel_t) == 3, "rgb8 pixel type does not match expected type size");
+    static_assert(sizeof(gil::rgba8_pixel_t) == 4, "rgba8 pixel type does not match expected type size");
 
 #ifdef BOOST_GIL_USES_MP11
     typedef boost::mp11::mp_list<

--- a/GG/src/gilext/io/png_io.hpp
+++ b/GG/src/gilext/io/png_io.hpp
@@ -33,7 +33,6 @@
 extern "C" {
 #include <png.h>
 }
-#include <boost/static_assert.hpp>
 #include <boost/gil/gil_config.hpp>
 #include <boost/gil/utilities.hpp>
 #include <boost/gil/extension/io/io_error.hpp>
@@ -45,16 +44,16 @@ namespace boost { namespace gil {
 /// \brief Determines whether the given view type is supported for reading
 template <typename View>
 struct png_read_support {
-    BOOST_STATIC_CONSTANT(bool,is_supported=
-                          (detail::png_read_support_private<typename channel_type<View>::type,
-                                                            typename color_space_type<View>::type>::is_supported));
-    BOOST_STATIC_CONSTANT(int,bit_depth=
-                          (detail::png_read_support_private<typename channel_type<View>::type,
-                                                            typename color_space_type<View>::type>::bit_depth));
-    BOOST_STATIC_CONSTANT(int,color_type=
-                          (detail::png_read_support_private<typename channel_type<View>::type,
-                                                            typename color_space_type<View>::type>::color_type));
-    BOOST_STATIC_CONSTANT(bool, value=is_supported);
+    static bool constexpr is_supported =
+        (detail::png_read_support_private<typename channel_type<View>::type,
+                                          typename color_space_type<View>::type>::is_supported);
+    static int constexpr bit_depth =
+        (detail::png_read_support_private<typename channel_type<View>::type,
+                                          typename color_space_type<View>::type>::bit_depth);
+    static int constexpr color_type =
+        (detail::png_read_support_private<typename channel_type<View>::type,
+                                          typename color_space_type<View>::type>::color_type);
+    static bool constexpr value = is_supported;
 };
 
 /// \ingroup PNG_IO
@@ -64,7 +63,7 @@ struct png_read_support {
 /// compatible with the ones specified by View, or if its dimensions don't match the ones of the view.
 template <typename View>
 inline void png_read_view(const char* filename,const View& view) {
-    BOOST_STATIC_ASSERT(png_read_support<View>::is_supported);
+    static_assert(png_read_support<View>::is_supported, "No PNG file read support for given View");
     detail::png_reader m(filename);
     m.apply(view);
 }
@@ -83,7 +82,7 @@ inline void png_read_view(const std::string& filename,const View& view) {
 /// compatible with the ones specified by Image
 template <typename Image>
 inline void png_read_image(const char* filename,Image& im) {
-    BOOST_STATIC_ASSERT(png_read_support<typename Image::view_t>::is_supported);
+    static_assert(png_read_support<typename Image::view_t>::is_supported, "No PNG file read support for given Image");
     detail::png_reader m(filename);
     m.read_image(im);
 }
@@ -186,16 +185,16 @@ inline void png_read_and_convert_image(const boost::filesystem::path& path,Image
 /// \brief Determines whether the given view type is supported for writing
 template <typename View>
 struct png_write_support {
-    BOOST_STATIC_CONSTANT(bool,is_supported=
-                          (detail::png_write_support_private<typename channel_type<View>::type,
-                                                             typename color_space_type<View>::type>::is_supported));
-    BOOST_STATIC_CONSTANT(int,bit_depth=
-                          (detail::png_write_support_private<typename channel_type<View>::type,
-                                                             typename color_space_type<View>::type>::bit_depth));
-    BOOST_STATIC_CONSTANT(int,color_type=
-                          (detail::png_write_support_private<typename channel_type<View>::type,
-                                                             typename color_space_type<View>::type>::color_type));
-    BOOST_STATIC_CONSTANT(bool, value=is_supported);
+    static bool constexpr is_supported =
+        (detail::png_write_support_private<typename channel_type<View>::type,
+                                           typename color_space_type<View>::type>::is_supported);
+    static int constexpr bit_depth =
+        (detail::png_write_support_private<typename channel_type<View>::type,
+                                           typename color_space_type<View>::type>::bit_depth);
+    static int constexpr color_type =
+        (detail::png_write_support_private<typename channel_type<View>::type,
+                                           typename color_space_type<View>::type>::color_type);
+    static bool constexpr value = is_supported;
 };
 
 /// \ingroup PNG_IO
@@ -204,7 +203,7 @@ struct png_write_support {
 /// Throws std::ios_base::failure if it fails to create the file.
 template <typename View>
 inline void png_write_view(const char* filename,const View& view) {
-    BOOST_STATIC_ASSERT(png_write_support<View>::is_supported);
+    static_assert(png_write_support<View>::is_supported, "No PNG file write support for given Image");
     detail::png_writer m(filename);
     m.apply(view);
 }

--- a/GG/src/gilext/io/png_io_private.hpp
+++ b/GG/src/gilext/io/png_io_private.hpp
@@ -22,7 +22,6 @@
 
 #include <algorithm>
 #include <vector>
-#include <boost/static_assert.hpp>
 #include <boost/gil/gil_all.hpp>
 #include <boost/gil/extension/io/io_error.hpp>
 #include "../color_convert.hpp"
@@ -36,132 +35,130 @@ namespace detail {
 static const std::size_t PNG_BYTES_TO_CHECK = 4;
 
 // lbourdev: These can be greatly simplified, for example:
-template <typename Cs> struct png_color_type {BOOST_STATIC_CONSTANT(int,color_type=0);};
-template<> struct png_color_type<gray_t>       { BOOST_STATIC_CONSTANT(int,color_type=PNG_COLOR_TYPE_GRAY); };
-template<> struct png_color_type<gray_alpha_t> { BOOST_STATIC_CONSTANT(int,color_type=PNG_COLOR_TYPE_GRAY_ALPHA); };
-template<> struct png_color_type<rgb_t>        { BOOST_STATIC_CONSTANT(int,color_type=PNG_COLOR_TYPE_RGB); };
-template<> struct png_color_type<rgba_t>       { BOOST_STATIC_CONSTANT(int,color_type=PNG_COLOR_TYPE_RGBA); };
+template <typename Cs> struct png_color_type {static int constexpr color_type = 0;};
+template<> struct png_color_type<gray_t>       { static int constexpr color_type = PNG_COLOR_TYPE_GRAY; };
+template<> struct png_color_type<gray_alpha_t> { static int constexpr color_type = PNG_COLOR_TYPE_GRAY_ALPHA; };
+template<> struct png_color_type<rgb_t>        { static int constexpr color_type = PNG_COLOR_TYPE_RGB; };
+template<> struct png_color_type<rgba_t>       { static int constexpr color_type = PNG_COLOR_TYPE_RGBA; };
 
-template <typename Channel,typename ColorSpace> struct png_is_supported {BOOST_STATIC_CONSTANT(bool,value=false);};
-template <> struct png_is_supported<boost::uint8_t,gray_t>        {BOOST_STATIC_CONSTANT(bool,value=true);};
-template <> struct png_is_supported<boost::uint8_t,gray_alpha_t>  {BOOST_STATIC_CONSTANT(bool,value=true);};
-template <> struct png_is_supported<boost::uint8_t,rgb_t>         {BOOST_STATIC_CONSTANT(bool,value=true);};
-template <> struct png_is_supported<boost::uint8_t,rgba_t>        {BOOST_STATIC_CONSTANT(bool,value=true);};
-template <> struct png_is_supported<boost::uint16_t,gray_t>       {BOOST_STATIC_CONSTANT(bool,value=true);};
-template <> struct png_is_supported<boost::uint16_t,gray_alpha_t> {BOOST_STATIC_CONSTANT(bool,value=true);};
-template <> struct png_is_supported<boost::uint16_t,rgb_t>        {BOOST_STATIC_CONSTANT(bool,value=true);};
-template <> struct png_is_supported<boost::uint16_t,rgba_t>       {BOOST_STATIC_CONSTANT(bool,value=true);};
-
-template <typename Channel> struct png_bit_depth {BOOST_STATIC_CONSTANT(int,bit_depth=sizeof(Channel)*8);};
+template <typename Channel,typename ColorSpace> struct png_is_supported {static bool constexpr value = false;};
+template <> struct png_is_supported<boost::uint8_t,gray_t>        {static bool constexpr value = true;};
+template <> struct png_is_supported<boost::uint8_t,gray_alpha_t>  {static bool constexpr value = true;};
+template <> struct png_is_supported<boost::uint8_t,rgb_t>         {static bool constexpr value = true;};
+template <> struct png_is_supported<boost::uint8_t,rgba_t>        {static bool constexpr value = true;};
+template <> struct png_is_supported<boost::uint16_t,gray_t>       {static bool constexpr value = true;};
+template <> struct png_is_supported<boost::uint16_t,gray_alpha_t> {static bool constexpr value = true;};
+template <> struct png_is_supported<boost::uint16_t,rgb_t>        {static bool constexpr value = true;};
+template <> struct png_is_supported<boost::uint16_t,rgba_t>       {static bool constexpr value = true;};
 
 template <typename Channel,typename ColorSpace>
 struct png_read_support_private {
-    BOOST_STATIC_CONSTANT(bool,is_supported=false);
-    BOOST_STATIC_CONSTANT(int,bit_depth=0);
-    BOOST_STATIC_CONSTANT(int,color_type=0);
+    static bool constexpr is_supported = false;
+    static int constexpr bit_depth = 0;
+    static int constexpr color_type = 0;
 };
 template <>
 struct png_read_support_private<boost::uint8_t,gray_t> {
-    BOOST_STATIC_CONSTANT(bool,is_supported=true);
-    BOOST_STATIC_CONSTANT(int,bit_depth=8);
-    BOOST_STATIC_CONSTANT(int,color_type=PNG_COLOR_TYPE_GRAY);
+    static bool constexpr is_supported = true;
+    static int constexpr bit_depth = 8;
+    static int constexpr color_type = PNG_COLOR_TYPE_GRAY;
 };
 template <>
 struct png_read_support_private<boost::uint8_t,gray_alpha_t> {
-    BOOST_STATIC_CONSTANT(bool,is_supported=true);
-    BOOST_STATIC_CONSTANT(int,bit_depth=8);
-    BOOST_STATIC_CONSTANT(int,color_type=PNG_COLOR_TYPE_GRAY_ALPHA);
+    static bool constexpr is_supported = true;
+    static int constexpr bit_depth = 8;
+    static int constexpr color_type = PNG_COLOR_TYPE_GRAY_ALPHA;
 };
 template <>
 struct png_read_support_private<boost::uint8_t,rgb_t> {
-    BOOST_STATIC_CONSTANT(bool,is_supported=true);
-    BOOST_STATIC_CONSTANT(int,bit_depth=8);
-    BOOST_STATIC_CONSTANT(int,color_type=PNG_COLOR_TYPE_RGB);
+    static bool constexpr is_supported = true;
+    static int constexpr bit_depth = 8;
+    static int constexpr color_type = PNG_COLOR_TYPE_RGB;
 };
 template <>
 struct png_read_support_private<boost::uint8_t,rgba_t> {
-    BOOST_STATIC_CONSTANT(bool,is_supported=true);
-    BOOST_STATIC_CONSTANT(int,bit_depth=8);
-    BOOST_STATIC_CONSTANT(int,color_type=PNG_COLOR_TYPE_RGBA);
+    static bool constexpr is_supported = true;
+    static int constexpr bit_depth = 8;
+    static int constexpr color_type = PNG_COLOR_TYPE_RGBA;
 };
 template <>
 struct png_read_support_private<boost::uint16_t,gray_t> {
-    BOOST_STATIC_CONSTANT(bool,is_supported=true);
-    BOOST_STATIC_CONSTANT(int,bit_depth=16);
-    BOOST_STATIC_CONSTANT(int,color_type=PNG_COLOR_TYPE_GRAY);
+    static bool constexpr is_supported = true;
+    static int constexpr bit_depth = 16;
+    static int constexpr color_type = PNG_COLOR_TYPE_GRAY;
 };
 template <>
 struct png_read_support_private<boost::uint16_t,gray_alpha_t> {
-    BOOST_STATIC_CONSTANT(bool,is_supported=true);
-    BOOST_STATIC_CONSTANT(int,bit_depth=16);
-    BOOST_STATIC_CONSTANT(int,color_type=PNG_COLOR_TYPE_GRAY_ALPHA);
+    static bool constexpr is_supported = true;
+    static int constexpr bit_depth = 16;
+    static int constexpr color_type = PNG_COLOR_TYPE_GRAY_ALPHA;
 };
 template <>
 struct png_read_support_private<boost::uint16_t,rgb_t> {
-    BOOST_STATIC_CONSTANT(bool,is_supported=true);
-    BOOST_STATIC_CONSTANT(int,bit_depth=16);
-    BOOST_STATIC_CONSTANT(int,color_type=PNG_COLOR_TYPE_RGB);
+    static bool constexpr is_supported = true;
+    static int constexpr bit_depth = 16;
+    static int constexpr color_type = PNG_COLOR_TYPE_RGB;
 };
 template <>
 struct png_read_support_private<boost::uint16_t,rgba_t> {
-    BOOST_STATIC_CONSTANT(bool,is_supported=true);
-    BOOST_STATIC_CONSTANT(int,bit_depth=16);
-    BOOST_STATIC_CONSTANT(int,color_type=PNG_COLOR_TYPE_RGBA);
+    static bool constexpr is_supported = true;
+    static int constexpr bit_depth = 16;
+    static int constexpr color_type = PNG_COLOR_TYPE_RGBA;
 };
 
 template <typename Channel,typename ColorSpace>
 struct png_write_support_private {
-    BOOST_STATIC_CONSTANT(bool,is_supported=false);
-    BOOST_STATIC_CONSTANT(int,bit_depth=0);
-    BOOST_STATIC_CONSTANT(int,color_type=0);
+    static bool constexpr is_supported = false;
+    static int constexpr bit_depth = 0;
+    static int constexpr color_type = 0;
 };
 template <>
 struct png_write_support_private<boost::uint8_t,gray_t> {
-    BOOST_STATIC_CONSTANT(bool,is_supported=true);
-    BOOST_STATIC_CONSTANT(int,bit_depth=8);
-    BOOST_STATIC_CONSTANT(int,color_type=PNG_COLOR_TYPE_GRAY);
+    static bool constexpr is_supported = true;
+    static int constexpr bit_depth = 8;
+    static int constexpr color_type = PNG_COLOR_TYPE_GRAY;
 };
 template<>
 struct png_write_support_private<boost::uint8_t,gray_alpha_t> {
-    BOOST_STATIC_CONSTANT(bool,is_supported=true);
-    BOOST_STATIC_CONSTANT(int,bit_depth=8);
-    BOOST_STATIC_CONSTANT(int,color_type=PNG_COLOR_TYPE_GRAY_ALPHA);
+    static bool constexpr is_supported = true;
+    static int constexpr bit_depth = 8;
+    static int constexpr color_type = PNG_COLOR_TYPE_GRAY_ALPHA;
 };
 template <>
 struct png_write_support_private<boost::uint8_t,rgb_t> {
-    BOOST_STATIC_CONSTANT(bool,is_supported=true);
-    BOOST_STATIC_CONSTANT(int,bit_depth=8);
-    BOOST_STATIC_CONSTANT(int,color_type=PNG_COLOR_TYPE_RGB);
+    static bool constexpr is_supported = true;
+    static int constexpr bit_depth = 8;
+    static int constexpr color_type = PNG_COLOR_TYPE_RGB;
 };
 template <>
 struct png_write_support_private<boost::uint8_t,rgba_t> {
-    BOOST_STATIC_CONSTANT(bool,is_supported=true);
-    BOOST_STATIC_CONSTANT(int,bit_depth=8);
-    BOOST_STATIC_CONSTANT(int,color_type=PNG_COLOR_TYPE_RGBA);
+    static bool constexpr is_supported = true;
+    static int constexpr bit_depth = 8;
+    static int constexpr color_type = PNG_COLOR_TYPE_RGBA;
 };
 template <>
 struct png_write_support_private<boost::uint16_t,gray_t> {
-    BOOST_STATIC_CONSTANT(bool,is_supported=true);
-    BOOST_STATIC_CONSTANT(int,bit_depth=16);
-    BOOST_STATIC_CONSTANT(int,color_type=PNG_COLOR_TYPE_GRAY);
+    static bool constexpr is_supported = true;
+    static int constexpr bit_depth = 16;
+    static int constexpr color_type = PNG_COLOR_TYPE_GRAY;
 };
 template <>
 struct png_write_support_private<boost::uint16_t,gray_alpha_t> {
-    BOOST_STATIC_CONSTANT(bool,is_supported=true);
-    BOOST_STATIC_CONSTANT(int,bit_depth=16);
-    BOOST_STATIC_CONSTANT(int,color_type=PNG_COLOR_TYPE_GRAY_ALPHA);
+    static bool constexpr is_supported = true;
+    static int constexpr bit_depth = 16;
+    static int constexpr color_type = PNG_COLOR_TYPE_GRAY_ALPHA;
 };
 template <>
 struct png_write_support_private<boost::uint16_t,rgb_t> {
-    BOOST_STATIC_CONSTANT(bool,is_supported=true);
-    BOOST_STATIC_CONSTANT(int,bit_depth=16);
-    BOOST_STATIC_CONSTANT(int,color_type=PNG_COLOR_TYPE_RGB);
+    static bool constexpr is_supported = true;
+    static int constexpr bit_depth = 16;
+    static int constexpr color_type = PNG_COLOR_TYPE_RGB;
 };
 template <>
 struct png_write_support_private<boost::uint16_t,rgba_t> {
-    BOOST_STATIC_CONSTANT(bool,is_supported=true);
-    BOOST_STATIC_CONSTANT(int,bit_depth=16);
-    BOOST_STATIC_CONSTANT(int,color_type=PNG_COLOR_TYPE_RGBA);
+    static bool constexpr is_supported = true;
+    static int constexpr bit_depth = 16;
+    static int constexpr color_type = PNG_COLOR_TYPE_RGBA;
 };
 
 class png_reader : public file_mgr {

--- a/UI/CUIControls.cpp
+++ b/UI/CUIControls.cpp
@@ -203,7 +203,7 @@ void CUIButton::RenderUnpressed() {
 SettableInWindowCUIButton::SettableInWindowCUIButton(const GG::SubTexture& unpressed,
                                                      const GG::SubTexture& pressed,
                                                      const GG::SubTexture& rollover,
-                                                     boost::function<bool(const SettableInWindowCUIButton*, const GG::Pt&)> in_window_function) :
+                                                     std::function<bool (const SettableInWindowCUIButton*, const GG::Pt&)> in_window_function) :
     CUIButton(unpressed, pressed, rollover)
 { m_in_window_func = in_window_function; }
 

--- a/UI/CUIControls.h
+++ b/UI/CUIControls.h
@@ -17,8 +17,6 @@
 #include <GG/dialogs/FileDlg.h>
 #include <GG/GLClientAndServerBuffer.h>
 
-#include <boost/function.hpp>
-
 #include "LinkText.h"
 
 /** \file
@@ -82,14 +80,14 @@ protected:
 class SettableInWindowCUIButton : public CUIButton {
 public:
     /** \name Structors */ //@{
-    SettableInWindowCUIButton(const GG::SubTexture& unpressed, const GG::SubTexture& pressed, const GG::SubTexture& rollover, boost::function<bool(const SettableInWindowCUIButton*, const GG::Pt&)> in_window_function);
+    SettableInWindowCUIButton(const GG::SubTexture& unpressed, const GG::SubTexture& pressed, const GG::SubTexture& rollover, std::function<bool (const SettableInWindowCUIButton*, const GG::Pt&)> in_window_function);
     //@}
     /** \name Accessors */ //@{
     bool InWindow(const GG::Pt& pt) const override;
     //@}
 
 private:
-    boost::function<bool(const SettableInWindowCUIButton*, const GG::Pt&)>    m_in_window_func;
+    std::function<bool (const SettableInWindowCUIButton*, const GG::Pt&)>    m_in_window_func;
 };
 
 /** a FreeOrion triangular arrow button */

--- a/UI/CombatReport/GraphicalSummary.cpp
+++ b/UI/CombatReport/GraphicalSummary.cpp
@@ -608,9 +608,6 @@ private:
     std::vector<std::shared_ptr<ToggleData>>    m_toggles;
 
     struct ToggleData : public boost::signals2::trackable {
-        typedef bool (BarSizer::*ToggleGetter)() const;
-        typedef void (BarSizer::*ToggleSetter)(bool value);
-
         std::string label_true;
         std::string label_false;
         std::string tip_true;

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -27,7 +27,6 @@
 #include <GG/TabWnd.h>
 
 #include <boost/cast.hpp>
-#include <boost/function.hpp>
 #include <boost/algorithm/string/replace.hpp>
 #include <boost/filesystem/operations.hpp>
 #include <boost/filesystem/fstream.hpp>

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -34,8 +34,6 @@
 #include <boost/uuid/random_generator.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/uuid/random_generator.hpp>
-//TODO: replace with std::make_unique when transitioning to C++14
-#include <boost/smart_ptr/make_unique.hpp>
 
 #include <algorithm>
 #include <iterator>
@@ -582,7 +580,7 @@ namespace {
 
         } else {
             // Add the new saved design.
-            std::unique_ptr<ShipDesign> design_copy{boost::make_unique<ShipDesign>(design)};
+            std::unique_ptr<ShipDesign> design_copy{std::make_unique<ShipDesign>(design)};
 
             const auto save_path = CreateSaveFileNameForDesign(design);
 
@@ -1103,8 +1101,8 @@ namespace {
 //////////////////////////////////////////////////
 
 ShipDesignManager::ShipDesignManager() :
-    m_displayed_designs(boost::make_unique<DisplayedShipDesignManager>()),
-    m_saved_designs(boost::make_unique<SavedDesignsManager>())
+    m_displayed_designs(std::make_unique<DisplayedShipDesignManager>()),
+    m_saved_designs(std::make_unique<SavedDesignsManager>())
 {}
 
 ShipDesignManager::~ShipDesignManager()
@@ -1119,10 +1117,10 @@ void ShipDesignManager::StartGame(int empire_id, bool is_new_game) {
 
     DebugLogger() << "ShipDesignManager initializing. New game " << is_new_game;
 
-    m_displayed_designs = boost::make_unique<DisplayedShipDesignManager>();
+    m_displayed_designs = std::make_unique<DisplayedShipDesignManager>();
     auto displayed_designs = dynamic_cast<DisplayedShipDesignManager*>(m_displayed_designs.get());
 
-    m_saved_designs = boost::make_unique<SavedDesignsManager>();
+    m_saved_designs = std::make_unique<SavedDesignsManager>();
     auto saved_designs = dynamic_cast<SavedDesignsManager*>(m_saved_designs.get());
     saved_designs->StartParsingDesignsFromFileSystem(is_new_game);
 
@@ -1184,7 +1182,7 @@ ShipDesignManager::Designs* ShipDesignManager::DisplayedDesigns() {
     if (retval == nullptr) {
         ErrorLogger() << "ShipDesignManager m_displayed_designs was not correctly initialized "
                       << "with ShipDesignManager::GameStart().";
-        m_displayed_designs = boost::make_unique<DisplayedShipDesignManager>();
+        m_displayed_designs = std::make_unique<DisplayedShipDesignManager>();
         return m_displayed_designs.get();
     }
     return retval;
@@ -1195,7 +1193,7 @@ ShipDesignManager::Designs* ShipDesignManager::SavedDesigns() {
     if (retval == nullptr) {
         ErrorLogger() << "ShipDesignManager m_saved_designs was not correctly initialized "
                       << "with ShipDesignManager::GameStart().";
-        m_saved_designs = boost::make_unique<SavedDesignsManager>();
+        m_saved_designs = std::make_unique<SavedDesignsManager>();
         return m_saved_designs.get();
     }
     return retval;

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -30,9 +30,8 @@
 #include <GG/StaticGraphic.h>
 
 #include <boost/cast.hpp>
-#include <boost/unordered_map.hpp>
-#include <tuple>
 
+#include <tuple>
 #include <unordered_set>
 
 

--- a/UI/MapWnd.cpp
+++ b/UI/MapWnd.cpp
@@ -1044,7 +1044,7 @@ void MapWnd::CompleteConstruction() {
 
     // create custom InWindow function for Menu button that extends its
     // clickable area to the adjacent edges of the toolbar containing it
-    boost::function<bool(const SettableInWindowCUIButton*, const GG::Pt&)> in_window_func =
+    std::function<bool (const SettableInWindowCUIButton*, const GG::Pt&)> in_window_func =
         boost::bind(&InRect, boost::bind(&WndLeft, _1), boost::bind(&WndTop, m_toolbar.get()),
                              boost::bind(&WndRight, _1), boost::bind(&WndBottom, _1),
                     _2);

--- a/UI/MapWnd.h
+++ b/UI/MapWnd.h
@@ -10,7 +10,6 @@
 #include "../universe/Fleet.h"
 #include "FleetButton.h"
 
-#include <boost/unordered_map.hpp>
 #include <boost/functional/hash.hpp>
 
 #include <chrono>
@@ -446,7 +445,7 @@ private:
 
     double                                      m_zoom_steps_in = 1.0;          //!< number of zoom steps in.  each 1.0 step increases display scaling by the same zoom step factor
     std::shared_ptr<SidePanel>                  m_side_panel = nullptr;         //!< planet view panel on the side of the main map
-    boost::unordered_map<int, std::shared_ptr<SystemIcon>> m_system_icons;      //!< system icons in the main map, indexed by system id
+    std::unordered_map<int, std::shared_ptr<SystemIcon>> m_system_icons;      //!< system icons in the main map, indexed by system id
     std::map<int, std::shared_ptr<FieldIcon>>   m_field_icons;                  //!< field icons in the main map, indexed by field id
     std::shared_ptr<SitRepPanel>                m_sitrep_panel = nullptr;       //!< sitrep panel
     std::shared_ptr<ResearchWnd>                m_research_wnd = nullptr;       //!< research screen
@@ -492,12 +491,12 @@ private:
                        boost::hash<std::pair<double, double>>>
         m_offroad_fleet_buttons;
 
-    boost::unordered_map<int, std::shared_ptr<FleetButton>>
+    std::unordered_map<int, std::shared_ptr<FleetButton>>
         m_fleet_buttons;                        //!< fleet icons, index by fleet
 
-    boost::unordered_map<int, boost::signals2::connection>
+    std::unordered_map<int, boost::signals2::connection>
         m_fleet_state_change_signals;
-    boost::unordered_map<int, std::vector<boost::signals2::connection>>
+    std::unordered_map<int, std::vector<boost::signals2::connection>>
         m_system_fleet_insert_remove_signals;
 
     std::map<int, MovementLineData> m_fleet_lines;                  //!< lines used for moving fleets in the main map

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -29,8 +29,6 @@
 #include <GG/Layout.h>
 
 #include <boost/lexical_cast.hpp>
-//TODO: replace with std::make_unique when transitioning to C++14
-#include <boost/smart_ptr/make_unique.hpp>
 #include <boost/uuid/random_generator.hpp>
 
 #include <iterator>
@@ -70,15 +68,15 @@ namespace {
         const std::vector<UniverseObjectType>& object_types)
     {
         if (object_types.empty())
-            return boost::make_unique<Condition::None>();
+            return std::make_unique<Condition::None>();
 
         if (object_types.size() == 1)
-            return boost::make_unique<Condition::Type>(*object_types.begin());
+            return std::make_unique<Condition::Type>(*object_types.begin());
 
         std::vector<std::unique_ptr<Condition::Condition>> subconditions;
         for (auto obj_type : object_types)
-            subconditions.emplace_back(boost::make_unique<Condition::Type>(obj_type));
-        return boost::make_unique<Condition::Or>(std::move(subconditions));
+            subconditions.emplace_back(std::make_unique<Condition::Type>(obj_type));
+        return std::make_unique<Condition::Or>(std::move(subconditions));
     }
 
     // returns default value (eg. 0 or an empty string) unless object is of
@@ -90,15 +88,15 @@ namespace {
         std::unique_ptr<ValueRef::ValueRef<T>>&& value_ref)
     {
         if (object_types.empty())
-            return boost::make_unique<ValueRef::Constant<T>>(T());
+            return std::make_unique<ValueRef::Constant<T>>(T());
 
-        return boost::make_unique<ValueRef::Operation<T>>(  // evaluates and returns value_ref if contained Statistic returns a non-empty string
+        return std::make_unique<ValueRef::Operation<T>>(  // evaluates and returns value_ref if contained Statistic returns a non-empty string
             ValueRef::TIMES,
-            boost::make_unique<ValueRef::Statistic<T>>(     // returns non-empty string if the source object matches the object type condition
+            std::make_unique<ValueRef::Statistic<T>>(     // returns non-empty string if the source object matches the object type condition
                 nullptr,                                    // property value value ref not used for IF statistic
                 ValueRef::IF,
-                boost::make_unique<Condition::And>(         // want this statistic to return true only if the source object has the specified object type, if there exists any object of that type in the universe
-                    boost::make_unique<Condition::Source>(),
+                std::make_unique<Condition::And>(         // want this statistic to return true only if the source object has the specified object type, if there exists any object of that type in the universe
+                    std::make_unique<Condition::Source>(),
                     ConditionForObjectTypes(object_types)
                 )
             ),
@@ -109,23 +107,23 @@ namespace {
     std::unique_ptr<ValueRef::Variable<std::string>> StringValueRef(
         const std::string& token)
     {
-        return boost::make_unique<ValueRef::Variable<std::string>>(
+        return std::make_unique<ValueRef::Variable<std::string>>(
             ValueRef::SOURCE_REFERENCE, token);
     }
 
     std::unique_ptr<ValueRef::Variable<std::string>> UserStringValueRef(
         const std::string& token)
     {
-        return boost::make_unique<ValueRef::UserStringLookup<std::string>>(
-            boost::make_unique<ValueRef::Variable<std::string>>(
+        return std::make_unique<ValueRef::UserStringLookup<std::string>>(
+            std::make_unique<ValueRef::Variable<std::string>>(
                 ValueRef::SOURCE_REFERENCE, token));
     }
 
     std::unique_ptr<ValueRef::Variable<std::string>> UserStringVecValueRef(
         const std::string& token)
     {
-        return boost::make_unique<ValueRef::UserStringLookup<std::vector<std::string>>>(
-            boost::make_unique<ValueRef::Variable<std::vector<std::string>>>(
+        return std::make_unique<ValueRef::UserStringLookup<std::vector<std::string>>>(
+            std::make_unique<ValueRef::Variable<std::vector<std::string>>>(
                 ValueRef::SOURCE_REFERENCE, token));
     }
 
@@ -133,16 +131,16 @@ namespace {
     std::unique_ptr<ValueRef::Variable<std::string>> StringCastedValueRef(
         const std::string& token)
     {
-        return boost::make_unique<ValueRef::StringCast<T>>(
-            boost::make_unique<ValueRef::Variable<T>>(
+        return std::make_unique<ValueRef::StringCast<T>>(
+            std::make_unique<ValueRef::Variable<T>>(
                 ValueRef::SOURCE_REFERENCE, token));
     }
 
     std::unique_ptr<ValueRef::Variable<std::string>> StringCastedImmediateValueRef(
         const std::string& token)
     {
-        return boost::make_unique<ValueRef::StringCast<double>>(
-            boost::make_unique<ValueRef::Variable<double>>(
+        return std::make_unique<ValueRef::StringCast<double>>(
+            std::make_unique<ValueRef::Variable<double>>(
                 ValueRef::SOURCE_REFERENCE, token, true));
     }
 
@@ -155,8 +153,8 @@ namespace {
         std::unique_ptr<ValueRef::ValueRef<std::string>>&& string_ref1 = nullptr,
         std::unique_ptr<ValueRef::ValueRef<std::string>>&& string_ref2 = nullptr)
     {
-        return boost::make_unique<ValueRef::StringCast<T>>(
-            boost::make_unique<ValueRef::ComplexVariable<T>>(
+        return std::make_unique<ValueRef::StringCast<T>>(
+            std::make_unique<ValueRef::ComplexVariable<T>>(
                 token, std::move(int_ref1), std::move(int_ref2),
                 std::move(int_ref3), std::move(string_ref1), std::move(string_ref2))
         );
@@ -166,22 +164,22 @@ namespace {
         return StringCastedComplexValueRef<double>(
             propagated ? "PropagatedSystemSupplyRange" :"SystemSupplyRange",
             nullptr,
-            boost::make_unique<ValueRef::Variable<int>>(ValueRef::SOURCE_REFERENCE, "SystemID"));
+            std::make_unique<ValueRef::Variable<int>>(ValueRef::SOURCE_REFERENCE, "SystemID"));
     }
 
     std::unique_ptr<ValueRef::Variable<std::string>> SystemSupplyDistanceValueRef() {
         return StringCastedComplexValueRef<double>(
             "PropagatedSystemSupplyDistance",
             nullptr,
-            boost::make_unique<ValueRef::Variable<int>>(ValueRef::SOURCE_REFERENCE, "SystemID"));
+            std::make_unique<ValueRef::Variable<int>>(ValueRef::SOURCE_REFERENCE, "SystemID"));
     }
 
 
     std::unique_ptr<ValueRef::Variable<std::string>> DesignCostValueRef() {
         return StringCastedComplexValueRef<double>(
             "ShipDesignCost",
-            boost::make_unique<ValueRef::Variable<int>>(ValueRef::SOURCE_REFERENCE, "DesignID"),
-            boost::make_unique<ValueRef::Variable<int>>(ValueRef::SOURCE_REFERENCE, "ProducedByEmpireID"),
+            std::make_unique<ValueRef::Variable<int>>(ValueRef::SOURCE_REFERENCE, "DesignID"),
+            std::make_unique<ValueRef::Variable<int>>(ValueRef::SOURCE_REFERENCE, "ProducedByEmpireID"),
             nullptr);   // TODO: try to get a valid production location for the owner empire?
     }
 
@@ -189,30 +187,30 @@ namespace {
         const std::string& species_name)
     {
         return ObjectTypeFilteredRef<std::string>({OBJ_PLANET},
-            boost::make_unique<ValueRef::UserStringLookup<PlanetEnvironment>>(
-                boost::make_unique<ValueRef::ComplexVariable<PlanetEnvironment>>(
+            std::make_unique<ValueRef::UserStringLookup<PlanetEnvironment>>(
+                std::make_unique<ValueRef::ComplexVariable<PlanetEnvironment>>(
                     "PlanetEnvironmentForSpecies",
-                    boost::make_unique<ValueRef::Variable<int>>(ValueRef::SOURCE_REFERENCE, "ID"),
+                    std::make_unique<ValueRef::Variable<int>>(ValueRef::SOURCE_REFERENCE, "ID"),
                     nullptr,
                     nullptr,
-                    boost::make_unique<ValueRef::Constant<std::string>>(species_name))));
+                    std::make_unique<ValueRef::Constant<std::string>>(species_name))));
     }
 
     template <typename T>
     std::unique_ptr<ValueRef::Variable<std::string>> UserStringCastedValueRef(
         const std::string& token)
     {
-        return boost::make_unique<ValueRef::UserStringLookup<std::string>>(
-            boost::make_unique<ValueRef::StringCast<T>>(
-                boost::make_unique<ValueRef::Variable<T>>(
+        return std::make_unique<ValueRef::UserStringLookup<std::string>>(
+            std::make_unique<ValueRef::StringCast<T>>(
+                std::make_unique<ValueRef::Variable<T>>(
                     ValueRef::SOURCE_REFERENCE, token)));
     }
 
     std::unique_ptr<ValueRef::Variable<std::string>> ObjectNameValueRef(
         const std::string& token)
     {
-        return boost::make_unique<ValueRef::NameLookup>(
-            boost::make_unique<ValueRef::Variable<int>>(
+        return std::make_unique<ValueRef::NameLookup>(
+            std::make_unique<ValueRef::Variable<int>>(
                 ValueRef::SOURCE_REFERENCE, token),
             ValueRef::NameLookup::OBJECT_NAME);
     }
@@ -220,8 +218,8 @@ namespace {
     std::unique_ptr<ValueRef::Variable<std::string>> EmpireNameValueRef(
         const std::string& token)
     {
-        return boost::make_unique<ValueRef::NameLookup>(
-            boost::make_unique<ValueRef::Variable<int>>(
+        return std::make_unique<ValueRef::NameLookup>(
+            std::make_unique<ValueRef::Variable<int>>(
                 ValueRef::SOURCE_REFERENCE, token),
             ValueRef::NameLookup::EMPIRE_NAME);
     }
@@ -229,8 +227,8 @@ namespace {
     std::unique_ptr<ValueRef::Variable<std::string>> DesignNameValueRef(
         const std::string& token)
     {
-        return boost::make_unique<ValueRef::NameLookup>(
-            boost::make_unique<ValueRef::Variable<int>>(
+        return std::make_unique<ValueRef::NameLookup>(
+            std::make_unique<ValueRef::Variable<int>>(
                 ValueRef::SOURCE_REFERENCE, token),
             ValueRef::NameLookup::SHIP_DESIGN_NAME);
     }
@@ -406,8 +404,8 @@ namespace {
     template <class enumT>
     std::unique_ptr<ValueRef::ValueRef<enumT>> CopyEnumValueRef(const ValueRef::ValueRef<enumT>* const value_ref) {
         if (auto constant = dynamic_cast<const ValueRef::Constant<enumT>*>(value_ref))
-            return boost::make_unique<ValueRef::Constant<enumT>>(constant->Value());
-        return boost::make_unique<ValueRef::Constant<enumT>>(enumT(-1));
+            return std::make_unique<ValueRef::Constant<enumT>>(constant->Value());
+        return std::make_unique<ValueRef::Constant<enumT>>(enumT(-1));
     }
 
     std::map<std::string, std::string> object_list_cond_description_map;
@@ -489,7 +487,7 @@ public:
         GG::Control(x, y, CONDITION_WIDGET_WIDTH, GG::Y1, GG::INTERACTIVE)
     {
         if (!initial_condition) {
-            auto init_condition = boost::make_unique<Condition::All>();
+            auto init_condition = std::make_unique<Condition::All>();
             Init(init_condition.get());
         } else {
             Init(initial_condition);
@@ -512,21 +510,21 @@ public:
     std::unique_ptr<Condition::Condition> GetCondition() {
         auto row_it = m_class_drop->CurrentItem();
         if (row_it == m_class_drop->end())
-            return boost::make_unique<Condition::All>();
+            return std::make_unique<Condition::All>();
         ConditionRow* condition_row = dynamic_cast<ConditionRow*>(row_it->get());
         if (!condition_row)
-            return boost::make_unique<Condition::All>();
+            return std::make_unique<Condition::All>();
         const std::string& condition_key = condition_row->GetKey();
 
         if (condition_key == ALL_CONDITION) {
-            return boost::make_unique<Condition::All>();
+            return std::make_unique<Condition::All>();
 
         } else if (condition_key == EMPIREAFFILIATION_CONDITION) {
             EmpireAffiliationType affil = AFFIL_SELF;
 
             const std::string& empire_name = GetString();
             if (empire_name.empty())
-                return boost::make_unique<Condition::EmpireAffiliation>(affil);
+                return std::make_unique<Condition::EmpireAffiliation>(affil);
 
             // get id of empire matching name
             int empire_id = ALL_EMPIRES;
@@ -536,25 +534,25 @@ public:
                     break;
                 }
             }
-            return boost::make_unique<Condition::EmpireAffiliation>(
-                boost::make_unique<ValueRef::Constant<int>>(empire_id), affil);
+            return std::make_unique<Condition::EmpireAffiliation>(
+                std::make_unique<ValueRef::Constant<int>>(empire_id), affil);
 
         } else if (condition_key == HOMEWORLD_CONDITION) {
             const std::string& species_name = GetString();
             if (species_name.empty())
-                return boost::make_unique<Condition::Homeworld>();
+                return std::make_unique<Condition::Homeworld>();
             std::vector<std::unique_ptr<ValueRef::ValueRef<std::string>>> names;
-            names.push_back(boost::make_unique<ValueRef::Constant<std::string>>(species_name));
-            return boost::make_unique<Condition::Homeworld>(std::move(names));
+            names.push_back(std::make_unique<ValueRef::Constant<std::string>>(species_name));
+            return std::make_unique<Condition::Homeworld>(std::move(names));
 
         } else if (condition_key == CANCOLONIZE_CONDITION) {
-            return boost::make_unique<Condition::CanColonize>();
+            return std::make_unique<Condition::CanColonize>();
 
         } else if (condition_key == CANPRODUCESHIPS_CONDITION) {
-            return boost::make_unique<Condition::CanProduceShips>();
+            return std::make_unique<Condition::CanProduceShips>();
 
         } else if (condition_key == HASSPECIAL_CONDITION) {
-            return boost::make_unique<Condition::HasSpecial>(GetString());
+            return std::make_unique<Condition::HasSpecial>(GetString());
 
         } else if (condition_key == HASGROWTHSPECIAL_CONDITION) {
             std::vector<std::unique_ptr<Condition::Condition>> operands;
@@ -562,30 +560,30 @@ public:
             std::istringstream template_stream(UserString("FUNCTIONAL_GROWTH_SPECIALS_LIST"));
             for (auto stream_it = std::istream_iterator<std::string>(template_stream);
                  stream_it != std::istream_iterator<std::string>(); stream_it++)
-            { operands.push_back(boost::make_unique<Condition::HasSpecial>(*stream_it)); }
+            { operands.push_back(std::make_unique<Condition::HasSpecial>(*stream_it)); }
 
-            std::unique_ptr<Condition::Condition> this_cond = boost::make_unique<Condition::Or>(std::move(operands));
+            std::unique_ptr<Condition::Condition> this_cond = std::make_unique<Condition::Or>(std::move(operands));
             object_list_cond_description_map[this_cond->Description()] = HASGROWTHSPECIAL_CONDITION;
             return this_cond;
 
         } else if (condition_key == ASTWITHPTYPE_CONDITION) { // And [Planet PlanetType PT_ASTEROIDS ContainedBy And [System Contains PlanetType X]]
             std::vector<std::unique_ptr<Condition::Condition>> operands1;
-            operands1.push_back(boost::make_unique<Condition::Type>(boost::make_unique<ValueRef::Constant<UniverseObjectType>>(OBJ_PLANET)));
+            operands1.push_back(std::make_unique<Condition::Type>(std::make_unique<ValueRef::Constant<UniverseObjectType>>(OBJ_PLANET)));
             const std::string& text = GetString();
             if (text == UserString("CONDITION_ANY")) {
                 std::vector<std::unique_ptr<ValueRef::ValueRef<PlanetType>>> copytype;
-                copytype.push_back(boost::make_unique<ValueRef::Constant<PlanetType>>(PT_ASTEROIDS));
-                operands1.push_back(boost::make_unique<Condition::Not>(boost::make_unique<Condition::PlanetType>(std::move(copytype))));
+                copytype.push_back(std::make_unique<ValueRef::Constant<PlanetType>>(PT_ASTEROIDS));
+                operands1.push_back(std::make_unique<Condition::Not>(std::make_unique<Condition::PlanetType>(std::move(copytype))));
             } else {
-                operands1.push_back(boost::make_unique<Condition::PlanetType>(GetEnumValueRefVec< ::PlanetType>()));
+                operands1.push_back(std::make_unique<Condition::PlanetType>(GetEnumValueRefVec< ::PlanetType>()));
             }
             std::vector<std::unique_ptr<Condition::Condition>> operands2;
-            operands2.push_back(boost::make_unique<Condition::Type>(boost::make_unique<ValueRef::Constant<UniverseObjectType>>(OBJ_SYSTEM)));
+            operands2.push_back(std::make_unique<Condition::Type>(std::make_unique<ValueRef::Constant<UniverseObjectType>>(OBJ_SYSTEM)));
             std::vector<std::unique_ptr<ValueRef::ValueRef<PlanetType>>> maintype;
-            maintype.push_back(boost::make_unique<ValueRef::Constant<PlanetType>>(PT_ASTEROIDS));
-            operands2.push_back(boost::make_unique<Condition::Contains>(boost::make_unique<Condition::PlanetType>(std::move(maintype))));
-            operands1.push_back(boost::make_unique<Condition::ContainedBy>(boost::make_unique<Condition::And>(std::move(operands2))));
-            std::unique_ptr<Condition::Condition> this_cond = boost::make_unique<Condition::And>(std::move(operands1));
+            maintype.push_back(std::make_unique<ValueRef::Constant<PlanetType>>(PT_ASTEROIDS));
+            operands2.push_back(std::make_unique<Condition::Contains>(std::make_unique<Condition::PlanetType>(std::move(maintype))));
+            operands1.push_back(std::make_unique<Condition::ContainedBy>(std::make_unique<Condition::And>(std::move(operands2))));
+            std::unique_ptr<Condition::Condition> this_cond = std::make_unique<Condition::And>(std::move(operands1));
             object_list_cond_description_map[this_cond->Description()] = ASTWITHPTYPE_CONDITION;
             return this_cond;
 
@@ -594,55 +592,55 @@ public:
             const std::string& text = GetString();
             if (text == UserString("CONDITION_ANY")) {
                 std::vector<std::unique_ptr<ValueRef::ValueRef<PlanetType>>> copytype;
-                    copytype.push_back(boost::make_unique<ValueRef::Constant<PlanetType>>(PT_GASGIANT));
-                    operands1.push_back(boost::make_unique<Condition::Not>(boost::make_unique<Condition::PlanetType>(std::move(copytype))));
+                    copytype.push_back(std::make_unique<ValueRef::Constant<PlanetType>>(PT_GASGIANT));
+                    operands1.push_back(std::make_unique<Condition::Not>(std::make_unique<Condition::PlanetType>(std::move(copytype))));
             } else
-                operands1.push_back(boost::make_unique<Condition::PlanetType>(GetEnumValueRefVec< ::PlanetType>()));
+                operands1.push_back(std::make_unique<Condition::PlanetType>(GetEnumValueRefVec< ::PlanetType>()));
             std::vector<std::unique_ptr<Condition::Condition>> operands2;
-            operands2.push_back(boost::make_unique<Condition::Type>(boost::make_unique<ValueRef::Constant<UniverseObjectType>>(OBJ_SYSTEM)));
+            operands2.push_back(std::make_unique<Condition::Type>(std::make_unique<ValueRef::Constant<UniverseObjectType>>(OBJ_SYSTEM)));
             std::vector<std::unique_ptr<ValueRef::ValueRef<PlanetType>>> maintype;
-            maintype.push_back(boost::make_unique<ValueRef::Constant<PlanetType>>(PT_GASGIANT));
-            operands2.push_back(boost::make_unique<Condition::Contains>(boost::make_unique<Condition::PlanetType>(std::move(maintype))));
-            operands1.push_back(boost::make_unique<Condition::ContainedBy>(boost::make_unique<Condition::And>(std::move(operands2))));
-            std::unique_ptr<Condition::Condition> this_cond = boost::make_unique<Condition::And>(std::move(operands1));
+            maintype.push_back(std::make_unique<ValueRef::Constant<PlanetType>>(PT_GASGIANT));
+            operands2.push_back(std::make_unique<Condition::Contains>(std::make_unique<Condition::PlanetType>(std::move(maintype))));
+            operands1.push_back(std::make_unique<Condition::ContainedBy>(std::make_unique<Condition::And>(std::move(operands2))));
+            std::unique_ptr<Condition::Condition> this_cond = std::make_unique<Condition::And>(std::move(operands1));
             object_list_cond_description_map[this_cond->Description()] = GGWITHPTYPE_CONDITION;
             return this_cond;
 
         } else if (condition_key == HASTAG_CONDITION) {
-            return boost::make_unique<Condition::HasTag>(GetString());
+            return std::make_unique<Condition::HasTag>(GetString());
 
         } else if (condition_key == MONSTER_CONDITION) {
-            return boost::make_unique<Condition::Monster>();
+            return std::make_unique<Condition::Monster>();
 
         } else if (condition_key == CAPITAL_CONDITION) {
-            return boost::make_unique<Condition::Capital>();
+            return std::make_unique<Condition::Capital>();
 
         } else if (condition_key == ARMED_CONDITION) {
-            return boost::make_unique<Condition::Armed>();
+            return std::make_unique<Condition::Armed>();
 
         } else if (condition_key == STATIONARY_CONDITION) {
-            return boost::make_unique<Condition::Stationary>();
+            return std::make_unique<Condition::Stationary>();
 
         } else if (condition_key == SPECIES_CONDITION) {
-            return boost::make_unique<Condition::Species>(GetStringValueRefVec());
+            return std::make_unique<Condition::Species>(GetStringValueRefVec());
 
         } else if (condition_key == PLANETSIZE_CONDITION) {
-            return boost::make_unique<Condition::PlanetSize>(GetEnumValueRefVec< ::PlanetSize>());
+            return std::make_unique<Condition::PlanetSize>(GetEnumValueRefVec< ::PlanetSize>());
 
         } else if (condition_key == PLANETTYPE_CONDITION) {
-            return boost::make_unique<Condition::PlanetType>(GetEnumValueRefVec< ::PlanetType>());
+            return std::make_unique<Condition::PlanetType>(GetEnumValueRefVec< ::PlanetType>());
 
         } else if (condition_key == FOCUSTYPE_CONDITION) {
-            return boost::make_unique<Condition::FocusType>(GetStringValueRefVec());
+            return std::make_unique<Condition::FocusType>(GetStringValueRefVec());
 
         } else if (condition_key == STARTYPE_CONDITION) {
-            return boost::make_unique<Condition::StarType>(GetEnumValueRefVec< ::StarType>());
+            return std::make_unique<Condition::StarType>(GetEnumValueRefVec< ::StarType>());
 
         } else if (condition_key == METERVALUE_CONDITION) {
-            return boost::make_unique<Condition::MeterValue>(GetEnum< ::MeterType>(), GetDouble1ValueRef(), GetDouble2ValueRef());
+            return std::make_unique<Condition::MeterValue>(GetEnum< ::MeterType>(), GetDouble1ValueRef(), GetDouble2ValueRef());
         }
 
-        return boost::make_unique<Condition::All>();
+        return std::make_unique<Condition::All>();
     }
 
     void Render() override
@@ -707,7 +705,7 @@ private:
     }
 
     std::unique_ptr<ValueRef::ValueRef<std::string>> GetStringValueRef()
-    { return boost::make_unique<ValueRef::Constant<std::string>>(GetString()); }
+    { return std::make_unique<ValueRef::Constant<std::string>>(GetString()); }
 
     std::vector<std::unique_ptr<ValueRef::ValueRef<std::string>>> GetStringValueRefVec() {
         std::vector<std::unique_ptr<ValueRef::ValueRef<std::string>>> retval;
@@ -723,7 +721,7 @@ private:
     }
 
     std::unique_ptr<ValueRef::ValueRef<int>> GetInt1ValueRef()
-    { return boost::make_unique<ValueRef::Constant<int>>(GetInt1()); }
+    { return std::make_unique<ValueRef::Constant<int>>(GetInt1()); }
 
     int GetInt2() {
         if (m_param_spin2)
@@ -733,7 +731,7 @@ private:
     }
 
     std::unique_ptr<ValueRef::ValueRef<int>> GetInt2ValueRef()
-    { return boost::make_unique<ValueRef::Constant<int>>(GetInt2()); }
+    { return std::make_unique<ValueRef::Constant<int>>(GetInt2()); }
 
     double GetDouble1() {
         if (m_param_spin1)
@@ -743,7 +741,7 @@ private:
     }
 
     std::unique_ptr<ValueRef::ValueRef<double>> GetDouble1ValueRef()
-    { return boost::make_unique<ValueRef::Constant<double>>(GetDouble1()); }
+    { return std::make_unique<ValueRef::Constant<double>>(GetDouble1()); }
 
     double GetDouble2() {
         if (m_param_spin2)
@@ -753,7 +751,7 @@ private:
     }
 
     std::unique_ptr<ValueRef::ValueRef<double>> GetDouble2ValueRef()
-    { return boost::make_unique<ValueRef::Constant<double>>(GetDouble2()); }
+    { return std::make_unique<ValueRef::Constant<double>>(GetDouble2()); }
 
     template <typename T>
     T GetEnum() {
@@ -769,7 +767,7 @@ private:
 
     template <typename T>
     std::unique_ptr<ValueRef::ValueRef<T>> GetEnumValueRef()
-    { return boost::make_unique<ValueRef::Constant<T>>(GetEnum<T>()); }
+    { return std::make_unique<ValueRef::Constant<T>>(GetEnum<T>()); }
 
     template <typename T>
     std::vector<std::unique_ptr<ValueRef::ValueRef<T>>> GetEnumValueRefVec() {
@@ -1886,7 +1884,7 @@ public:
 
         SetVScrollWheelIncrement(Value(ListRowHeight())*4);
 
-        m_filter_condition = boost::make_unique<Condition::All>();
+        m_filter_condition = std::make_unique<Condition::All>();
 
         //m_visibilities[OBJ_BUILDING].insert(SHOW_VISIBLE);
         //m_visibilities[OBJ_BUILDING].insert(SHOW_PREVIOUSLY_VISIBLE);

--- a/UI/ShaderProgram.cpp
+++ b/UI/ShaderProgram.cpp
@@ -7,8 +7,6 @@
 #include "../util/Logger.h"
 
 #include <boost/filesystem/fstream.hpp>
-//TODO: replace with std::make_unique when transitioning to C++14
-#include <boost/smart_ptr/make_unique.hpp>
 
 
 namespace {
@@ -141,7 +139,7 @@ std::unique_ptr<ShaderProgram> ShaderProgram::shaderProgramFactory(const std::st
                                                                    const std::string& fragment_shader)
 {
     if (HumanClientApp::GetApp()->GLVersion() >= 2.0f)
-        return boost::make_unique<ShaderProgram>(vertex_shader,fragment_shader);
+        return std::make_unique<ShaderProgram>(vertex_shader,fragment_shader);
     return nullptr;
 }
 

--- a/UI/ShaderProgram.cpp
+++ b/UI/ShaderProgram.cpp
@@ -1,6 +1,7 @@
 #include "ShaderProgram.h"
 
 #include <cassert>
+#include <functional>
 #include <iostream>
 
 #include "../client/human/HumanClientApp.h"
@@ -221,12 +222,11 @@ void ShaderProgram::Bind(const std::string& name, std::size_t element_size, cons
     assert(1 <= element_size && element_size <= 4);
     assert((floats.size() % element_size) == 0);
 
-    typedef void (* UniformFloatArrayFn)(GLint, GLsizei, const GLfloat*);
-    UniformFloatArrayFn functions[] =
-        { UniformFloatArrayFn(glUniform1fv),
-          UniformFloatArrayFn(glUniform2fv),
-          UniformFloatArrayFn(glUniform3fv),
-          UniformFloatArrayFn(glUniform4fv)
+    std::function<void (GLint, GLsizei, const GLfloat*)> functions[] =
+        { glUniform1fv,
+          glUniform2fv,
+          glUniform3fv,
+          glUniform4fv
         };
 
     glGetError();
@@ -294,12 +294,11 @@ void ShaderProgram::BindInts(const std::string& name, std::size_t element_size, 
     assert(1 <= element_size && element_size <= 4);
     assert((ints.size() % element_size) == 0);
 
-    typedef void (* UniformIntegerArrayFn)(GLint, GLsizei, const GLint*);
-    UniformIntegerArrayFn functions[] =
-        { UniformIntegerArrayFn(glUniform1iv),
-          UniformIntegerArrayFn(glUniform2iv),
-          UniformIntegerArrayFn(glUniform3iv),
-          UniformIntegerArrayFn(glUniform4iv)
+    std::function<void (GLint, GLsizei, const GLint*)> functions[] =
+        { glUniform1iv,
+          glUniform2iv,
+          glUniform3iv,
+          glUniform4iv
         };
 
     glGetError();

--- a/combat/CombatLogManager.cpp
+++ b/combat/CombatLogManager.cpp
@@ -7,7 +7,6 @@
 #include "../util/Logger.h"
 #include "CombatEvents.h"
 
-#include <boost/unordered_map.hpp>
 
 namespace {
     static float MaxHealth(const UniverseObject& object) {
@@ -177,7 +176,7 @@ class CombatLogManager::Impl {
     void serialize(Archive& ar, const unsigned int version);
 
     private:
-    boost::unordered_map<int, CombatLog> m_logs;
+    std::unordered_map<int, CombatLog> m_logs;
     /** Set of logs ids that do not have bodies and need to be fetched from the server. */
     std::set<int>                        m_incomplete_logs;
     int                                  m_latest_log_id;

--- a/combat/CombatSystem.cpp
+++ b/combat/CombatSystem.cpp
@@ -24,8 +24,6 @@
 
 #include "../network/Message.h"
 
-//TODO: replace with std::make_unique when transitioning to C++14
-#include <boost/smart_ptr/make_unique.hpp>
 #include <boost/format.hpp>
 
 #include <iterator>
@@ -260,113 +258,113 @@ namespace {
     Condition::Condition* VisibleEnemyOfOwnerCondition() {
         return new Condition::Or(
             // unowned candidate object case
-            boost::make_unique<Condition::And>(
-                boost::make_unique<Condition::EmpireAffiliation>(AFFIL_NONE),   // unowned candidate object
+            std::make_unique<Condition::And>(
+                std::make_unique<Condition::EmpireAffiliation>(AFFIL_NONE),   // unowned candidate object
 
-                boost::make_unique<Condition::ValueTest>(           // when source object is owned (ie. not the same owner as the candidate object)
-                    boost::make_unique<ValueRef::Variable<int>>(
+                std::make_unique<Condition::ValueTest>(           // when source object is owned (ie. not the same owner as the candidate object)
+                    std::make_unique<ValueRef::Variable<int>>(
                         ValueRef::SOURCE_REFERENCE, "Owner"),
                     Condition::NOT_EQUAL,
-                    boost::make_unique<ValueRef::Variable<int>>(
+                    std::make_unique<ValueRef::Variable<int>>(
                         ValueRef::CONDITION_LOCAL_CANDIDATE_REFERENCE, "Owner")),
 
-                boost::make_unique<Condition::VisibleToEmpire>(     // when source object's owner empire can detect the candidate object
-                    boost::make_unique<ValueRef::Variable<int>>(    // source's owner empire id
+                std::make_unique<Condition::VisibleToEmpire>(     // when source object's owner empire can detect the candidate object
+                    std::make_unique<ValueRef::Variable<int>>(    // source's owner empire id
                         ValueRef::SOURCE_REFERENCE, "Owner"))),
 
             // owned candidate object case
-            boost::make_unique<Condition::And>(
-                boost::make_unique<Condition::EmpireAffiliation>(AFFIL_ANY),    // candidate is owned by an empire
+            std::make_unique<Condition::And>(
+                std::make_unique<Condition::EmpireAffiliation>(AFFIL_ANY),    // candidate is owned by an empire
 
-                boost::make_unique<Condition::EmpireAffiliation>(               // candidate is owned by enemy of source's owner
-                    boost::make_unique<ValueRef::Variable<int>>(
+                std::make_unique<Condition::EmpireAffiliation>(               // candidate is owned by enemy of source's owner
+                    std::make_unique<ValueRef::Variable<int>>(
                         ValueRef::SOURCE_REFERENCE, "Owner"), AFFIL_ENEMY),
 
-                boost::make_unique<Condition::VisibleToEmpire>(     // when source empire can detect the candidate object
-                    boost::make_unique<ValueRef::Variable<int>>(    // source's owner empire id
+                std::make_unique<Condition::VisibleToEmpire>(     // when source empire can detect the candidate object
+                    std::make_unique<ValueRef::Variable<int>>(    // source's owner empire id
                         ValueRef::SOURCE_REFERENCE, "Owner"))
             ))
         ;
     }
 
     const std::unique_ptr<Condition::Condition> is_enemy_ship_or_fighter =
-        boost::make_unique<Condition::And>(
-            boost::make_unique<Condition::Or>(
-                boost::make_unique<Condition::And>(
-                    boost::make_unique<Condition::Type>(OBJ_SHIP),
-                    boost::make_unique<Condition::Not>(
-                        boost::make_unique<Condition::MeterValue>(
+        std::make_unique<Condition::And>(
+            std::make_unique<Condition::Or>(
+                std::make_unique<Condition::And>(
+                    std::make_unique<Condition::Type>(OBJ_SHIP),
+                    std::make_unique<Condition::Not>(
+                        std::make_unique<Condition::MeterValue>(
                             METER_STRUCTURE,
                             nullptr,
-                            boost::make_unique<ValueRef::Constant<double>>(0.0)))),
-                boost::make_unique<Condition::Type>(OBJ_FIGHTER)),
+                            std::make_unique<ValueRef::Constant<double>>(0.0)))),
+                std::make_unique<Condition::Type>(OBJ_FIGHTER)),
             std::unique_ptr<Condition::Condition>{VisibleEnemyOfOwnerCondition()});
 
     const std::unique_ptr<Condition::Condition> is_enemy_ship =
-        boost::make_unique<Condition::And>(
-            boost::make_unique<Condition::Type>(OBJ_SHIP),
+        std::make_unique<Condition::And>(
+            std::make_unique<Condition::Type>(OBJ_SHIP),
 
-            boost::make_unique<Condition::Not>(
-                boost::make_unique<Condition::MeterValue>(
+            std::make_unique<Condition::Not>(
+                std::make_unique<Condition::MeterValue>(
                     METER_STRUCTURE,
                     nullptr,
-                    boost::make_unique<ValueRef::Constant<double>>(0.0))),
+                    std::make_unique<ValueRef::Constant<double>>(0.0))),
 
             std::unique_ptr<Condition::Condition>{VisibleEnemyOfOwnerCondition()});
 
     const std::unique_ptr<Condition::Condition> is_enemy_ship_fighter_or_armed_planet =
-        boost::make_unique<Condition::And>(
+        std::make_unique<Condition::And>(
             std::unique_ptr<Condition::Condition>{VisibleEnemyOfOwnerCondition()},  // enemies
-            boost::make_unique<Condition::Or>(
-                boost::make_unique<Condition::Or>(
-                    boost::make_unique<Condition::And>(
-                        boost::make_unique<Condition::Type>(OBJ_SHIP),
-                        boost::make_unique<Condition::Not>(
-                            boost::make_unique<Condition::MeterValue>(
+            std::make_unique<Condition::Or>(
+                std::make_unique<Condition::Or>(
+                    std::make_unique<Condition::And>(
+                        std::make_unique<Condition::Type>(OBJ_SHIP),
+                        std::make_unique<Condition::Not>(
+                            std::make_unique<Condition::MeterValue>(
                                 METER_STRUCTURE,
                                 nullptr,
-                                boost::make_unique<ValueRef::Constant<double>>(0.0)))),
-                    boost::make_unique<Condition::Type>(OBJ_FIGHTER)),
+                                std::make_unique<ValueRef::Constant<double>>(0.0)))),
+                    std::make_unique<Condition::Type>(OBJ_FIGHTER)),
 
-                boost::make_unique<Condition::And>(
-                    boost::make_unique<Condition::Type>(OBJ_PLANET),
-                    boost::make_unique<Condition::Or>(
-                        boost::make_unique<Condition::Not>(
-                            boost::make_unique<Condition::MeterValue>(
+                std::make_unique<Condition::And>(
+                    std::make_unique<Condition::Type>(OBJ_PLANET),
+                    std::make_unique<Condition::Or>(
+                        std::make_unique<Condition::Not>(
+                            std::make_unique<Condition::MeterValue>(
                                 METER_DEFENSE,
                                 nullptr,
-                                boost::make_unique<ValueRef::Constant<double>>(0.0))),
-                        boost::make_unique<Condition::Not>(
-                            boost::make_unique<Condition::MeterValue>(
+                                std::make_unique<ValueRef::Constant<double>>(0.0))),
+                        std::make_unique<Condition::Not>(
+                            std::make_unique<Condition::MeterValue>(
                                 METER_SHIELD,
                                 nullptr,
-                                boost::make_unique<ValueRef::Constant<double>>(0.0))),
-                        boost::make_unique<Condition::Not>(
-                            boost::make_unique<Condition::MeterValue>(
+                                std::make_unique<ValueRef::Constant<double>>(0.0))),
+                        std::make_unique<Condition::Not>(
+                            std::make_unique<Condition::MeterValue>(
                                 METER_CONSTRUCTION,
                                 nullptr,
-                                boost::make_unique<ValueRef::Constant<double>>(0.0)))))));
+                                std::make_unique<ValueRef::Constant<double>>(0.0)))))));
 
     const std::unique_ptr<Condition::Condition> if_source_is_planet_then_ships_else_all =
-        boost::make_unique<Condition::Or>(
-            boost::make_unique<Condition::And>(     // if source is a planet, match ships
-                boost::make_unique<Condition::Number>(
-                    boost::make_unique<ValueRef::Constant<int>>(1), // minimum objects matching subcondition
+        std::make_unique<Condition::Or>(
+            std::make_unique<Condition::And>(     // if source is a planet, match ships
+                std::make_unique<Condition::Number>(
+                    std::make_unique<ValueRef::Constant<int>>(1), // minimum objects matching subcondition
                     nullptr,
-                    boost::make_unique<Condition::And>(             // subcondition: source is a planet
-                        boost::make_unique<Condition::Source>(),
-                        boost::make_unique<Condition::Type>(OBJ_PLANET)
+                    std::make_unique<Condition::And>(             // subcondition: source is a planet
+                        std::make_unique<Condition::Source>(),
+                        std::make_unique<Condition::Type>(OBJ_PLANET)
                     )
                 ),
-                boost::make_unique<Condition::Type>(OBJ_SHIP)
+                std::make_unique<Condition::Type>(OBJ_SHIP)
             ),
 
-            boost::make_unique<Condition::Number>(  // if source is not a planet, match anything
+            std::make_unique<Condition::Number>(  // if source is not a planet, match anything
                 nullptr,
-                boost::make_unique<ValueRef::Constant<int>>(0),     // maximum objects matching subcondition
-                boost::make_unique<Condition::And>(                 // subcondition: source is a planet
-                    boost::make_unique<Condition::Source>(),
-                    boost::make_unique<Condition::Type>(OBJ_PLANET)
+                std::make_unique<ValueRef::Constant<int>>(0),     // maximum objects matching subcondition
+                std::make_unique<Condition::And>(                 // subcondition: source is a planet
+                    std::make_unique<Condition::Source>(),
+                    std::make_unique<Condition::Type>(OBJ_PLANET)
                 )
             )
         );

--- a/msvc2017/Common/StdAfx.h
+++ b/msvc2017/Common/StdAfx.h
@@ -79,7 +79,6 @@
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/type_traits/remove_const.hpp>
-#include <boost/unordered_map.hpp>
 #include <boost/uuid/nil_generator.hpp>
 #include <boost/uuid/uuid.hpp>
 #include <boost/variant.hpp>

--- a/msvc2017/FreeOrion/StdAfx.h
+++ b/msvc2017/FreeOrion/StdAfx.h
@@ -79,7 +79,6 @@
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/type_traits/remove_const.hpp>
-#include <boost/unordered_map.hpp>
 #include <boost/uuid/nil_generator.hpp>
 #include <boost/uuid/uuid.hpp>
 #include <boost/variant.hpp>

--- a/msvc2017/FreeOrion/StdAfx.h
+++ b/msvc2017/FreeOrion/StdAfx.h
@@ -98,7 +98,6 @@
 #include <GL/glew.h>
 
 #include <boost/algorithm/string/trim.hpp>
-#include <boost/function.hpp>
 #include <boost/graph/graph_concepts.hpp>
 #include <boost/mpl/assert.hpp>
 #include <boost/signals2/trackable.hpp>

--- a/msvc2017/FreeOrion/StdAfx.h
+++ b/msvc2017/FreeOrion/StdAfx.h
@@ -102,7 +102,6 @@
 #include <boost/graph/graph_concepts.hpp>
 #include <boost/mpl/assert.hpp>
 #include <boost/signals2/trackable.hpp>
-#include <boost/static_assert.hpp>
 #include <boost/type_traits/is_integral.hpp>
 #include <boost/utility/enable_if.hpp>
 

--- a/msvc2017/FreeOrionCA/StdAfx.h
+++ b/msvc2017/FreeOrionCA/StdAfx.h
@@ -79,7 +79,6 @@
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/type_traits/remove_const.hpp>
-#include <boost/unordered_map.hpp>
 #include <boost/uuid/nil_generator.hpp>
 #include <boost/uuid/uuid.hpp>
 #include <boost/variant.hpp>

--- a/msvc2017/FreeOrionD/StdAfx.h
+++ b/msvc2017/FreeOrionD/StdAfx.h
@@ -79,7 +79,6 @@
 #include <boost/thread/mutex.hpp>
 #include <boost/thread/shared_mutex.hpp>
 #include <boost/type_traits/remove_const.hpp>
-#include <boost/unordered_map.hpp>
 #include <boost/uuid/nil_generator.hpp>
 #include <boost/uuid/uuid.hpp>
 #include <boost/variant.hpp>

--- a/msvc2017/FreeOrionD/StdAfx.h
+++ b/msvc2017/FreeOrionD/StdAfx.h
@@ -90,7 +90,6 @@
 #include <boost/asio.hpp>
 #include <boost/asio/high_resolution_timer.hpp>
 #include <boost/circular_buffer.hpp>
-#include <boost/function.hpp>
 #include <boost/mpl/list.hpp>
 #include <boost/preprocessor/seq/for_each.hpp>
 #include <boost/python.hpp>

--- a/msvc2017/GiGi/StdAfx.h
+++ b/msvc2017/GiGi/StdAfx.h
@@ -44,7 +44,6 @@
 #include <boost/optional/optional.hpp>
 #include <boost/signals2/signal.hpp>
 #include <boost/signals2/trackable.hpp>
-#include <boost/static_assert.hpp>
 #include <boost/type_traits/is_integral.hpp>
 #include <boost/unordered_map.hpp>
 #include <boost/utility/enable_if.hpp>

--- a/msvc2017/GiGi/StdAfx.h
+++ b/msvc2017/GiGi/StdAfx.h
@@ -36,7 +36,6 @@
 
 #include <boost/algorithm/string/trim.hpp>
 #include <boost/filesystem/path.hpp>
-#include <boost/function.hpp>
 #include <boost/functional/hash.hpp>
 #include <boost/graph/graph_concepts.hpp>
 #include <boost/lexical_cast.hpp>

--- a/msvc2017/GiGi/StdAfx.h
+++ b/msvc2017/GiGi/StdAfx.h
@@ -44,7 +44,6 @@
 #include <boost/signals2/signal.hpp>
 #include <boost/signals2/trackable.hpp>
 #include <boost/type_traits/is_integral.hpp>
-#include <boost/unordered_map.hpp>
 #include <boost/utility/enable_if.hpp>
 
 #ifdef _MSC_VER

--- a/parse/BuildingsParser.cpp
+++ b/parse/BuildingsParser.cpp
@@ -11,8 +11,6 @@
 #include "../universe/Condition.h"
 #include "../universe/ValueRef.h"
 
-//TODO: replace with std::make_unique when transitioning to C++14
-#include <boost/smart_ptr/make_unique.hpp>
 
 #define DEBUG_PARSERS 0
 
@@ -35,7 +33,7 @@ namespace {
                          const std::string& icon,
                          bool& pass)
     {
-        auto building_type = boost::make_unique<BuildingType>(
+        auto building_type = std::make_unique<BuildingType>(
             name, description, *common_params.OpenEnvelope(pass), capture_result, icon);
 
         building_types.insert(std::make_pair(building_type->Name(), std::move(building_type)));

--- a/parse/CommonParamsParser.cpp
+++ b/parse/CommonParamsParser.cpp
@@ -14,8 +14,7 @@
 #include "../universe/ValueRefs.h"
 
 #include <boost/spirit/include/phoenix.hpp>
-//TODO: replace with std::make_unique when transitioning to C++14
-#include <boost/smart_ptr/make_unique.hpp>
+
 
 namespace phoenix = boost::phoenix;
 

--- a/parse/ConditionParser.cpp
+++ b/parse/ConditionParser.cpp
@@ -9,9 +9,6 @@
 #include "ConditionParser7.h"
 
 
-//TODO: replace with std::make_unique when transitioning to C++14
-#include <boost/smart_ptr/make_unique.hpp>
-
 namespace parse {
     struct conditions_parser_grammar::Impl {
         Impl(conditions_parser_grammar& conditions_parser_grammar,
@@ -43,7 +40,7 @@ namespace parse {
         detail::Labeller& label
     ) :
         conditions_parser_grammar::base_type(start, "conditions_parser_grammar"),
-        m_impl(boost::make_unique<conditions_parser_grammar::Impl>(*this, tok, label))
+        m_impl(std::make_unique<conditions_parser_grammar::Impl>(*this, tok, label))
     {
         start
             = m_impl->condition_parser_1

--- a/parse/EffectParser.cpp
+++ b/parse/EffectParser.cpp
@@ -10,8 +10,6 @@
 #include "../universe/Effect.h"
 
 #include <boost/spirit/include/phoenix.hpp>
-//TODO: replace with std::make_unique when transitioning to C++14
-#include <boost/smart_ptr/make_unique.hpp>
 
 namespace parse {
 
@@ -26,7 +24,7 @@ namespace parse {
         bool& pass)
     {
         return detail::MovableEnvelope<Effect::EffectsGroup>(
-            boost::make_unique<Effect::EffectsGroup>(
+            std::make_unique<Effect::EffectsGroup>(
                 scope.OpenEnvelope(pass),
                 activation.OpenEnvelope(pass),
                 OpenEnvelopes(effects, pass),
@@ -69,7 +67,7 @@ namespace parse {
         const detail::value_ref_grammar<std::string>& string_grammar
     ) :
         effects_parser_grammar::base_type(start, "effects_parser_grammar"),
-        m_impl(boost::make_unique<effects_parser_grammar::Impl>(*this, tok, label, condition_parser, string_grammar))
+        m_impl(std::make_unique<effects_parser_grammar::Impl>(*this, tok, label, condition_parser, string_grammar))
     {
         start
             = m_impl->effect_parser_1

--- a/parse/FieldsParser.cpp
+++ b/parse/FieldsParser.cpp
@@ -7,8 +7,6 @@
 #include "../universe/Field.h"
 
 #include <boost/spirit/include/phoenix.hpp>
-//TODO: replace with std::make_unique when transitioning to C++14
-#include <boost/smart_ptr/make_unique.hpp>
 
 
 #define DEBUG_PARSERS 0
@@ -31,7 +29,7 @@ namespace {
                           const std::string& graphic,
                           bool& pass)
     {
-        auto fieldtype_ptr = boost::make_unique<FieldType>(
+        auto fieldtype_ptr = std::make_unique<FieldType>(
             name, description, stealth, tags,
             (effects ? OpenEnvelopes(*effects, pass) : std::vector<std::unique_ptr<Effect::EffectsGroup>>()),
             graphic);

--- a/parse/FleetPlansParser.cpp
+++ b/parse/FleetPlansParser.cpp
@@ -8,8 +8,6 @@
 #include "../util/Directories.h"
 
 #include <boost/spirit/include/phoenix.hpp>
-//TODO: replace with std::make_unique when transitioning to C++14
-#include <boost/smart_ptr/make_unique.hpp>
 
 #define DEBUG_PARSERS 0
 
@@ -27,7 +25,7 @@ namespace {
         bool lookup_names)
     {
         plans.push_back(
-            boost::make_unique<FleetPlan>(
+            std::make_unique<FleetPlan>(
                 fleet_name, ship_design_names, lookup_names));
     }
     BOOST_PHOENIX_ADAPT_FUNCTION(void, insert_fleet_plan_, insert_fleet_plan, 4)

--- a/parse/MonsterFleetPlansParser.cpp
+++ b/parse/MonsterFleetPlansParser.cpp
@@ -10,8 +10,6 @@
 #include "../util/Directories.h"
 
 #include <boost/spirit/include/phoenix.hpp>
-//TODO: replace with std::make_unique when transitioning to C++14
-#include <boost/smart_ptr/make_unique.hpp>
 
 #define DEBUG_PARSERS 0
 
@@ -32,7 +30,7 @@ namespace {
         bool& pass)
     {
         plans.push_back(
-            boost::make_unique<MonsterFleetPlan>(
+            std::make_unique<MonsterFleetPlan>(
                 fleet_name, ship_design_names,
                 (spawn_rate ? *spawn_rate : 1.0),
                 (spawn_limit ? *spawn_limit : 9999),

--- a/parse/ReportParseError.cpp
+++ b/parse/ReportParseError.cpp
@@ -93,7 +93,7 @@ void parse::detail::default_send_error_string(const std::string& str) {
     std::cout << str +"\n" << std::flush;
 }
 
-boost::function<void (const std::string&)> parse::report_error_::send_error_string =
+std::function<void (const std::string&)> parse::report_error_::send_error_string =
     &detail::default_send_error_string;
 
 namespace {

--- a/parse/ReportParseError.h
+++ b/parse/ReportParseError.h
@@ -45,7 +45,7 @@ namespace parse {
             send_error_string(error_string);
         }
 
-        static boost::function<void (const std::string&)> send_error_string;
+        static std::function<void (const std::string&)> send_error_string;
 
     private:
         std::pair<text_iterator, unsigned int> line_start_and_line_number(

--- a/parse/ShipDesignsParser.cpp
+++ b/parse/ShipDesignsParser.cpp
@@ -9,8 +9,7 @@
 #include <boost/uuid/nil_generator.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/optional/optional.hpp>
-//TODO: replace with std::make_unique when transitioning to C++14
-#include <boost/smart_ptr/make_unique.hpp>
+
 
 FO_COMMON_API extern const int ALL_EMPIRES;
 
@@ -31,7 +30,7 @@ namespace {
                             const std::string& icon, const std::string& model,
                             bool name_desc_in_stringtable, const boost::uuids::uuid& uuid)
     {
-        auto design = boost::make_unique<ParsedShipDesign>(
+        auto design = std::make_unique<ParsedShipDesign>(
             name, description, 0, ALL_EMPIRES, hull, parts, icon, model,
             name_desc_in_stringtable, false, uuid);
 

--- a/parse/ShipHullsParser.cpp
+++ b/parse/ShipHullsParser.cpp
@@ -14,8 +14,7 @@
 #include "../universe/ValueRef.h"
 
 #include <boost/spirit/include/phoenix.hpp>
-//TODO: replace with std::make_unique when transitioning to C++14
-#include <boost/smart_ptr/make_unique.hpp>
+
 
 #define DEBUG_PARSERS 0
 
@@ -40,7 +39,7 @@ namespace {
                          const boost::optional<std::vector<HullType::Slot>>& slots,
                          const std::string& icon, const std::string& graphic)
     {
-        auto hulltype = boost::make_unique<HullType>(
+        auto hulltype = std::make_unique<HullType>(
             stats, std::move(*common_params), more_common_params,
             (slots ? *slots : std::vector<HullType::Slot>()),
             icon, graphic);

--- a/parse/ShipPartsParser.cpp
+++ b/parse/ShipPartsParser.cpp
@@ -15,8 +15,7 @@
 #include "../universe/ValueRef.h"
 
 #include <boost/spirit/include/phoenix.hpp>
-//TODO: replace with std::make_unique when transitioning to C++14
-#include <boost/smart_ptr/make_unique.hpp>
+
 
 #define DEBUG_PARSERS 0
 
@@ -57,7 +56,7 @@ namespace {
         std::tie(capacity, stat2, combat_targets) = capacity_and_stat2_and_targets;
 
 
-        auto part_type = boost::make_unique<PartType>(
+        auto part_type = std::make_unique<PartType>(
             part_class,
             (capacity ? *capacity : 0.0),
             (stat2 ? *stat2 : 1.0),

--- a/parse/SpecialsParser.cpp
+++ b/parse/SpecialsParser.cpp
@@ -8,8 +8,7 @@
 #include "../universe/ValueRef.h"
 
 #include <boost/spirit/include/phoenix.hpp>
-//TODO: replace with std::make_unique when transitioning to C++14
-#include <boost/smart_ptr/make_unique.hpp>
+
 
 #define DEBUG_PARSERS 0
 
@@ -57,7 +56,7 @@ namespace {
     };
 
     void insert_special(std::map<std::string, std::unique_ptr<Special>>& specials, special_pod special_, bool& pass) {
-        auto special_ptr = boost::make_unique<Special>(
+        auto special_ptr = std::make_unique<Special>(
             special_.name, special_.description,
             (special_.stealth ? special_.stealth->OpenEnvelope(pass) : nullptr),
             (special_.effects ? OpenEnvelopes(*special_.effects, pass) : std::vector<std::unique_ptr<Effect::EffectsGroup>>()),

--- a/parse/SpeciesParser.cpp
+++ b/parse/SpeciesParser.cpp
@@ -13,8 +13,6 @@
 #include "../universe/Species.h"
 
 #include <boost/spirit/include/phoenix.hpp>
-//TODO: replace with std::make_unique when transitioning to C++14
-#include <boost/smart_ptr/make_unique.hpp>
 
 
 #define DEBUG_PARSERS 0
@@ -63,7 +61,7 @@ namespace {
         const SpeciesStuff& foci_preferred_tags_graphic,
         bool& pass)
     {
-        auto species_ptr = boost::make_unique<Species>(
+        auto species_ptr = std::make_unique<Species>(
             strings,
             (foci_preferred_tags_graphic.foci ? *foci_preferred_tags_graphic.foci : std::vector<FocusType>()),
             (foci_preferred_tags_graphic.preferred_focus ? *foci_preferred_tags_graphic.preferred_focus : std::string()),

--- a/parse/TechsParser.cpp
+++ b/parse/TechsParser.cpp
@@ -14,8 +14,6 @@
 
 #include <boost/spirit/include/phoenix.hpp>
 #include <boost/spirit/include/qi_as.hpp>
-//TODO: replace with std::make_unique when transitioning to C++14
-#include <boost/smart_ptr/make_unique.hpp>
 
 
 #define DEBUG_PARSERS 0
@@ -58,7 +56,7 @@ namespace {
                      const boost::optional<std::string>& graphic,
                      bool& pass)
     {
-        auto tech_ptr = boost::make_unique<Tech>(
+        auto tech_ptr = std::make_unique<Tech>(
             *tech_info.OpenEnvelope(pass),
             (effects ? parse::detail::OpenEnvelopes(*effects, pass) : std::vector<std::unique_ptr<Effect::EffectsGroup>>()),
             (prerequisites ? *prerequisites : std::set<std::string>()),
@@ -76,7 +74,7 @@ namespace {
     void insert_category(std::map<std::string, std::unique_ptr<TechCategory>>& categories,
                          const std::string& name, const std::string& graphic, const GG::Clr& color)
     {
-        auto category_ptr = boost::make_unique<TechCategory>(name, graphic, color);
+        auto category_ptr = std::make_unique<TechCategory>(name, graphic, color);
         categories.insert(std::make_pair(category_ptr->name, std::move(category_ptr)));
     }
 

--- a/python/EmpireWrapper.cpp
+++ b/python/EmpireWrapper.cpp
@@ -14,7 +14,6 @@
 
 #include <GG/Clr.h>
 
-#include <boost/function.hpp>
 #include <boost/mpl/vector.hpp>
 #include <boost/python.hpp>
 #include <boost/python/suite/indexing/map_indexing_suite.hpp>

--- a/python/UniverseWrapper.cpp
+++ b/python/UniverseWrapper.cpp
@@ -103,12 +103,12 @@ namespace {
         double retval = universe.GetPathfinder()->LinearDistance(system1_id, system2_id);
         return retval;
     }
-    boost::function<double(const Universe&, int, int)> LinearDistanceFunc =                     &LinearDistance;
+    std::function<double (const Universe&, int, int)> LinearDistanceFunc = &LinearDistance;
 
     int JumpDistanceBetweenObjects(const Universe& universe, int object1_id, int object2_id) {
         return universe.GetPathfinder()->JumpDistanceBetweenObjects(object1_id, object2_id);
     }
-    boost::function<int(const Universe&, int, int)> JumpDistanceFunc =                          &JumpDistanceBetweenObjects;
+    std::function<int (const Universe&, int, int)> JumpDistanceFunc = &JumpDistanceBetweenObjects;
 
     std::vector<int> ShortestPath(const Universe& universe, int start_sys, int end_sys, int empire_id) {
         std::vector<int> retval;
@@ -116,7 +116,7 @@ namespace {
         std::copy(path.first.begin(), path.first.end(), std::back_inserter(retval));
         return retval;
     }
-    boost::function<std::vector<int>(const Universe&, int, int, int)> ShortestPathFunc =        &ShortestPath;
+    std::function<std::vector<int> (const Universe&, int, int, int)> ShortestPathFunc = &ShortestPath;
 
     std::vector<int> ShortestNonHostilePath(const Universe& universe, int start_sys, int end_sys, int empire_id) {
         std::vector<int> retval;
@@ -125,12 +125,12 @@ namespace {
         std::copy(path.first.begin(), path.first.end(), std::back_inserter(retval));
         return retval;
     }
-    boost::function<std::vector<int>(const Universe&, int, int, int)> ShortestNonHostilePathFunc = &ShortestNonHostilePath;
+    std::function<std::vector<int> (const Universe&, int, int, int)> ShortestNonHostilePathFunc = &ShortestNonHostilePath;
 
     double ShortestPathDistance(const Universe& universe, int object1_id, int object2_id) {
         return universe.GetPathfinder()->ShortestPathDistance(object1_id, object2_id);
     }
-    boost::function<double(const Universe&, int, int)> ShortestPathDistanceFunc =               &ShortestPathDistance;
+    std::function<double (const Universe&, int, int)> ShortestPathDistanceFunc = &ShortestPathDistance;
 
     std::vector<int> LeastJumpsPath(const Universe& universe, int start_sys, int end_sys, int empire_id) {
         std::vector<int> retval;
@@ -138,7 +138,7 @@ namespace {
         std::copy(path.first.begin(), path.first.end(), std::back_inserter(retval));
         return retval;
     }
-    boost::function<std::vector<int>(const Universe&, int, int, int)> LeastJumpsFunc =          &LeastJumpsPath;
+    std::function<std::vector<int> (const Universe&, int, int, int)> LeastJumpsFunc = &LeastJumpsPath;
 
     bool SystemsConnectedP(const Universe& universe, int system1_id, int system2_id, int empire_id=ALL_EMPIRES) {
         //DebugLogger() << "SystemsConnected!(" << system1_id << ", " << system2_id << ")";
@@ -146,12 +146,12 @@ namespace {
         //DebugLogger() << "SystemsConnected! retval: " << retval;
         return retval;
     }
-    boost::function<bool(const Universe&, int, int, int)> SystemsConnectedFunc =                &SystemsConnectedP;
+    std::function<bool (const Universe&, int, int, int)> SystemsConnectedFunc = &SystemsConnectedP;
 
     bool SystemHasVisibleStarlanesP(const Universe& universe, int system_id, int empire_id = ALL_EMPIRES) {
         return universe.GetPathfinder()->SystemHasVisibleStarlanes(system_id, empire_id);
     }
-    boost::function<bool(const Universe&, int, int)> SystemHasVisibleStarlanesFunc =            &SystemHasVisibleStarlanesP;
+    std::function<bool (const Universe&, int, int)> SystemHasVisibleStarlanesFunc = &SystemHasVisibleStarlanesP;
 
     std::vector<int> ImmediateNeighborsP(const Universe& universe, int system1_id, int empire_id = ALL_EMPIRES) {
         std::vector<int> retval;
@@ -159,7 +159,7 @@ namespace {
         { retval.push_back(entry.second); }
         return retval;
     }
-    boost::function<std::vector<int> (const Universe&, int, int)> ImmediateNeighborsFunc =      &ImmediateNeighborsP;
+    std::function<std::vector<int> (const Universe&, int, int)> ImmediateNeighborsFunc = &ImmediateNeighborsP;
 
     std::map<int, double> SystemNeighborsMapP(const Universe& universe, int system1_id, int empire_id = ALL_EMPIRES) {
         std::map<int, double> retval;
@@ -167,7 +167,7 @@ namespace {
         { retval[entry.second] = entry.first; }
         return retval;
     }
-    boost::function<std::map<int, double> (const Universe&, int, int)> SystemNeighborsMapFunc = &SystemNeighborsMapP;
+    std::function<std::map<int, double> (const Universe&, int, int)> SystemNeighborsMapFunc = &SystemNeighborsMapP;
 
     const Meter*            (UniverseObject::*ObjectGetMeter)(MeterType) const =                &UniverseObject::GetMeter;
     const std::map<MeterType, Meter>&
@@ -187,11 +187,11 @@ namespace {
 
     const std::string& ShipDesignName(const ShipDesign& ship_design)
     { return ship_design.Name(false); }
-    boost::function<const std::string& (const ShipDesign&)> ShipDesignNameFunc =                &ShipDesignName;
+    std::function<const std::string& (const ShipDesign&)> ShipDesignNameFunc = &ShipDesignName;
 
     const std::string& ShipDesignDescription(const ShipDesign& ship_design)
     { return ship_design.Description(false); }
-    boost::function<const std::string& (const ShipDesign&)> ShipDesignDescriptionFunc =         &ShipDesignDescription;
+    std::function<const std::string& (const ShipDesign&)> ShipDesignDescriptionFunc = &ShipDesignDescription;
 
     bool                    (*ValidDesignHullAndParts)(const std::string& hull,
                                                        const std::vector<std::string>& parts) = &ShipDesign::ValidDesign;
@@ -210,7 +210,7 @@ namespace {
         }
         return results;
     }
-    boost::function<std::vector<int> (const ShipDesign&)> AttackStatsFunc =                 &AttackStatsP;
+    std::function<std::vector<int> (const ShipDesign&)> AttackStatsFunc = &AttackStatsP;
 
     std::vector<ShipSlotType> HullSlots(const HullType& hull) {
         std::vector<ShipSlotType> retval;
@@ -218,7 +218,7 @@ namespace {
             retval.push_back(slot.type);
         return retval;
     }
-    boost::function<std::vector<ShipSlotType> (const HullType&)> HullSlotsFunc =                &HullSlots;
+    std::function<std::vector<ShipSlotType> (const HullType&)> HullSlotsFunc = &HullSlots;
 
     unsigned int            (HullType::*NumSlotsTotal)(void) const =                            &HullType::NumSlots;
     unsigned int            (HullType::*NumSlotsOfSlotType)(ShipSlotType) const =               &HullType::NumSlots;

--- a/server/ServerApp.cpp
+++ b/server/ServerApp.cpp
@@ -44,8 +44,6 @@
 #include <boost/date_time/posix_time/time_formatters.hpp>
 #include <boost/uuid/random_generator.hpp>
 #include <boost/uuid/uuid_io.hpp>
-//TODO: replace with std::make_unique when transitioning to C++14
-#include <boost/smart_ptr/make_unique.hpp>
 
 #include <ctime>
 #include <thread>
@@ -1982,7 +1980,7 @@ int ServerApp::EffectsProcessingThreads() const
 { return GetOptionsDB().Get<int>("effects.server.threads"); }
 
 void ServerApp::AddEmpireTurn(int empire_id, const PlayerSaveGameData& psgd)
-{ m_turn_sequence[empire_id] = boost::make_unique<PlayerSaveGameData>(psgd); }
+{ m_turn_sequence[empire_id] = std::make_unique<PlayerSaveGameData>(psgd); }
 
 void ServerApp::RemoveEmpireTurn(int empire_id)
 { m_turn_sequence.erase(empire_id); }

--- a/server/ServerFSM.cpp
+++ b/server/ServerFSM.cpp
@@ -25,8 +25,6 @@
 #include <boost/functional/hash.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/uuid/nil_generator.hpp>
-//TODO: replace with std::make_unique when transitioning to C++14
-#include <boost/smart_ptr/make_unique.hpp>
 #include <boost/date_time/posix_time/posix_time.hpp>
 
 #include <GG/ClrConstants.h>
@@ -3075,7 +3073,7 @@ sc::result WaitingForTurnEnd::react(const TurnOrders& msg) {
         DebugLogger(FSM) << "WaitingForTurnEnd.TurnOrders : Received orders from player " << player_id
                          << " for empire " << empire_id << " count of " << order_set->size();
 
-        server.SetEmpireSaveGameData(empire_id, boost::make_unique<PlayerSaveGameData>(sender->PlayerName(), empire_id,
+        server.SetEmpireSaveGameData(empire_id, std::make_unique<PlayerSaveGameData>(sender->PlayerName(), empire_id,
                                      order_set, ui_data, save_state_string,
                                      client_type));
         empire->SetReady(true);

--- a/server/ServerNetworking.cpp
+++ b/server/ServerNetworking.cpp
@@ -6,9 +6,6 @@
 #include "../universe/ValueRefs.h"
 #include "../parse/Parse.h"
 
-//TODO: replace with std::make_unique when transitioning to C++14
-#include <boost/smart_ptr/make_unique.hpp>
-
 #include <boost/iterator/filter_iterator.hpp>
 #include <boost/asio/high_resolution_timer.hpp>
 #include <boost/uuid/nil_generator.hpp>
@@ -98,22 +95,22 @@ private:
         std::string reply;
         try {
             if (parse::int_free_variable(message)) {
-                auto value_ref = boost::make_unique<ValueRef::Variable<int>>(ValueRef::NON_OBJECT_REFERENCE, message);
+                auto value_ref = std::make_unique<ValueRef::Variable<int>>(ValueRef::NON_OBJECT_REFERENCE, message);
                 reply = std::to_string(value_ref->Eval(ScriptingContext()));
                 DebugLogger(network) << "DiscoveryServer evaluated expression as integer with result: " << reply;
 
             } else if (parse::double_free_variable(message)) {
-                auto value_ref = boost::make_unique<ValueRef::Variable<double>>(ValueRef::NON_OBJECT_REFERENCE, message);
+                auto value_ref = std::make_unique<ValueRef::Variable<double>>(ValueRef::NON_OBJECT_REFERENCE, message);
                 reply = std::to_string(value_ref->Eval(ScriptingContext()));
                 DebugLogger(network) << "DiscoveryServer evaluated expression as double with result: " << reply;
 
             } else if (parse::string_free_variable(message)) {
-                auto value_ref = boost::make_unique<ValueRef::Variable<std::string>>(ValueRef::NON_OBJECT_REFERENCE, message);
+                auto value_ref = std::make_unique<ValueRef::Variable<std::string>>(ValueRef::NON_OBJECT_REFERENCE, message);
                 reply = value_ref->Eval(ScriptingContext());
                 DebugLogger(network) << "DiscoveryServer evaluated expression as string with result: " << reply;
 
             //} else {
-            //    auto value_ref = boost::make_unique<ValueRef::Variable<std::vector<std::string>>>(ValueRef::NON_OBJECT_REFERENCE, message);
+            //    auto value_ref = std::make_unique<ValueRef::Variable<std::vector<std::string>>>(ValueRef::NON_OBJECT_REFERENCE, message);
             //    auto result = value_ref->Eval(ScriptingContext());
             //    for (auto entry : result)
             //        reply += entry + "\n";

--- a/server/ServerNetworking.cpp
+++ b/server/ServerNetworking.cpp
@@ -712,7 +712,7 @@ ServerNetworking::established_iterator ServerNetworking::established_end() {
 
 void ServerNetworking::HandleNextEvent() {
     if (!m_event_queue.empty()) {
-        boost::function<void ()> f = m_event_queue.front();
+        std::function<void ()> f = m_event_queue.front();
         m_event_queue.pop();
         f();
     }

--- a/server/ServerNetworking.h
+++ b/server/ServerNetworking.h
@@ -4,11 +4,11 @@
 #include "../network/Message.h"
 
 #include <boost/asio.hpp>
-#include <boost/function.hpp>
 #include <boost/iterator/filter_iterator.hpp>
 #include <boost/signals2/signal.hpp>
 #include <boost/functional/hash.hpp>
 
+#include <functional>
 #include <memory>
 #include <queue>
 #include <set>
@@ -18,9 +18,9 @@ class DiscoveryServer;
 class PlayerConnection;
 
 typedef std::shared_ptr<PlayerConnection> PlayerConnectionPtr;
-typedef boost::function<void (Message, PlayerConnectionPtr)> MessageAndConnectionFn;
-typedef boost::function<void (PlayerConnectionPtr)> ConnectionFn;
-typedef boost::function<void ()> NullaryFn;
+typedef std::function<void (Message, PlayerConnectionPtr)> MessageAndConnectionFn;
+typedef std::function<void (PlayerConnectionPtr)> ConnectionFn;
+typedef std::function<void ()> NullaryFn;
 
 /** Data associated with cookie */
 struct CookieData {

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -27,8 +27,6 @@
 #include <boost/graph/adjacency_list.hpp>
 #include <boost/graph/st_connected.hpp>
 
-//TODO: replace with std::make_unique when transitioning to C++14
-#include <boost/smart_ptr/make_unique.hpp>
 
 using boost::io::str;
 
@@ -1829,7 +1827,7 @@ Type::Type(std::unique_ptr<ValueRef::ValueRef<UniverseObjectType>>&& type) :
 
 Type::Type(UniverseObjectType type) :
     Condition(),
-    m_type(boost::make_unique<ValueRef::Constant<UniverseObjectType>>(type))
+    m_type(std::make_unique<ValueRef::Constant<UniverseObjectType>>(type))
 {}
 
 bool Type::operator==(const Condition& rhs) const {
@@ -2240,8 +2238,7 @@ HasSpecial::HasSpecial(std::unique_ptr<ValueRef::ValueRef<std::string>>&& name,
 
 HasSpecial::HasSpecial(const std::string& name) :
     Condition(),
-    // TODO: Use std::make_unique when adopting C++14
-    m_name(new ValueRef::Constant<std::string>(name)),
+    m_name(std::make_unique<ValueRef::Constant<std::string>>(name)),
     m_capacity_low(nullptr),
     m_capacity_high(nullptr),
     m_since_turn_low(nullptr),
@@ -2467,8 +2464,7 @@ HasTag::HasTag() :
 
 HasTag::HasTag(const std::string& name) :
     Condition(),
-    // TODO: Use std::make_unique when adopting C++14
-    m_name(new ValueRef::Constant<std::string>(name))
+    m_name(std::make_unique<ValueRef::Constant<std::string>>(name))
 {}
 
 HasTag::HasTag(std::unique_ptr<ValueRef::ValueRef<std::string>>&& name) :
@@ -6793,8 +6789,7 @@ OwnerHasBuildingTypeAvailable::OwnerHasBuildingTypeAvailable(
 
 OwnerHasBuildingTypeAvailable::OwnerHasBuildingTypeAvailable(const std::string& name) :
     Condition(),
-    // TODO: Use std::make_unique when adopting C++14
-    m_name(new ValueRef::Constant<std::string>(name)),
+    m_name(std::make_unique<ValueRef::Constant<std::string>>(name)),
     m_empire_id(nullptr)
 {}
 
@@ -6948,8 +6943,7 @@ OwnerHasShipDesignAvailable::OwnerHasShipDesignAvailable(
 
 OwnerHasShipDesignAvailable::OwnerHasShipDesignAvailable(int design_id) :
     Condition(),
-    // TODO: Use std::make_unique when adopting C++14
-    m_id(new ValueRef::Constant<int>(design_id)),
+    m_id(std::make_unique<ValueRef::Constant<int>>(design_id)),
     m_empire_id(nullptr)
 {}
 
@@ -7103,8 +7097,7 @@ OwnerHasShipPartAvailable::OwnerHasShipPartAvailable(
 
 OwnerHasShipPartAvailable::OwnerHasShipPartAvailable(const std::string& name) :
     Condition(),
-    // TODO: Use std::make_unique when adopting C++14
-    m_name(new ValueRef::Constant<std::string>(name))
+    m_name(std::make_unique<ValueRef::Constant<std::string>>(name))
 {}
 
 OwnerHasShipPartAvailable::OwnerHasShipPartAvailable(std::unique_ptr<ValueRef::ValueRef<std::string>>&& name) :

--- a/universe/Effects.cpp
+++ b/universe/Effects.cpp
@@ -24,8 +24,6 @@
 #include "Enums.h"
 
 #include <boost/filesystem/fstream.hpp>
-//TODO: replace with std::make_unique when transitioning to C++14
-#include <boost/smart_ptr/make_unique.hpp>
 
 #include <cctype>
 #include <iterator>
@@ -775,7 +773,7 @@ unsigned int SetShipPartMeter::GetCheckSum() const {
 // SetEmpireMeter                                        //
 ///////////////////////////////////////////////////////////
 SetEmpireMeter::SetEmpireMeter(const std::string& meter, std::unique_ptr<ValueRef::ValueRef<double>>&& value) :
-    m_empire_id(boost::make_unique<ValueRef::Variable<int>>(ValueRef::EFFECT_TARGET_REFERENCE, std::vector<std::string>(1, "Owner"))),
+    m_empire_id(std::make_unique<ValueRef::Variable<int>>(ValueRef::EFFECT_TARGET_REFERENCE, std::vector<std::string>(1, "Owner"))),
     m_meter(meter),
     m_value(std::move(value))
 {}
@@ -881,7 +879,7 @@ unsigned int SetEmpireMeter::GetCheckSum() const {
 ///////////////////////////////////////////////////////////
 SetEmpireStockpile::SetEmpireStockpile(ResourceType stockpile,
                                        std::unique_ptr<ValueRef::ValueRef<double>>&& value) :
-    m_empire_id(boost::make_unique<ValueRef::Variable<int>>(ValueRef::EFFECT_TARGET_REFERENCE, std::vector<std::string>(1, "Owner"))),
+    m_empire_id(std::make_unique<ValueRef::Variable<int>>(ValueRef::EFFECT_TARGET_REFERENCE, std::vector<std::string>(1, "Owner"))),
     m_stockpile(stockpile),
     m_value(std::move(value))
 {}
@@ -942,7 +940,7 @@ unsigned int SetEmpireStockpile::GetCheckSum() const {
 // SetEmpireCapital                                      //
 ///////////////////////////////////////////////////////////
 SetEmpireCapital::SetEmpireCapital() :
-    m_empire_id(boost::make_unique<ValueRef::Variable<int>>(ValueRef::EFFECT_TARGET_REFERENCE, std::vector<std::string>(1, "Owner")))
+    m_empire_id(std::make_unique<ValueRef::Variable<int>>(ValueRef::EFFECT_TARGET_REFERENCE, std::vector<std::string>(1, "Owner")))
 {}
 
 SetEmpireCapital::SetEmpireCapital(std::unique_ptr<ValueRef::ValueRef<int>>&& empire_id) :
@@ -2014,8 +2012,8 @@ unsigned int Destroy::GetCheckSum() const {
 // AddSpecial                                            //
 ///////////////////////////////////////////////////////////
 AddSpecial::AddSpecial(const std::string& name, float capacity) :
-    m_name(boost::make_unique<ValueRef::Constant<std::string>>(name)),
-    m_capacity(boost::make_unique<ValueRef::Constant<double>>(capacity))
+    m_name(std::make_unique<ValueRef::Constant<std::string>>(name)),
+    m_capacity(std::make_unique<ValueRef::Constant<double>>(capacity))
 {}
 
 AddSpecial::AddSpecial(std::unique_ptr<ValueRef::ValueRef<std::string>>&& name,
@@ -2066,7 +2064,7 @@ unsigned int AddSpecial::GetCheckSum() const {
 // RemoveSpecial                                         //
 ///////////////////////////////////////////////////////////
 RemoveSpecial::RemoveSpecial(const std::string& name) :
-    m_name(boost::make_unique<ValueRef::Constant<std::string>>(name))
+    m_name(std::make_unique<ValueRef::Constant<std::string>>(name))
 {}
 
 RemoveSpecial::RemoveSpecial(std::unique_ptr<ValueRef::ValueRef<std::string>>&& name) :
@@ -3035,7 +3033,7 @@ SetEmpireTechProgress::SetEmpireTechProgress(std::unique_ptr<ValueRef::ValueRef<
     m_empire_id(
         empire_id
         ? std::move(empire_id)
-        : boost::make_unique<ValueRef::Variable<int>>(ValueRef::EFFECT_TARGET_REFERENCE, std::vector<std::string>(1, "Owner")))
+        : std::make_unique<ValueRef::Variable<int>>(ValueRef::EFFECT_TARGET_REFERENCE, std::vector<std::string>(1, "Owner")))
 {}
 
 void SetEmpireTechProgress::Execute(const ScriptingContext& context) const {

--- a/universe/Field.cpp
+++ b/universe/Field.cpp
@@ -15,24 +15,23 @@
 
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/filesystem/fstream.hpp>
-//TODO: replace with std::make_unique when transitioning to C++14
-#include <boost/smart_ptr/make_unique.hpp>
+
 
 namespace {
     std::shared_ptr<Effect::EffectsGroup>
     IncreaseMeter(MeterType meter_type, double increase) {
         typedef std::vector<std::unique_ptr<Effect::Effect>> Effects;
-        auto scope = boost::make_unique<Condition::Source>();
+        auto scope = std::make_unique<Condition::Source>();
         std::unique_ptr<Condition::Source> activation = nullptr;
         auto vr =
-            boost::make_unique<ValueRef::Operation<double>>(
+            std::make_unique<ValueRef::Operation<double>>(
                 ValueRef::PLUS,
-                boost::make_unique<ValueRef::Variable<double>>(
+                std::make_unique<ValueRef::Variable<double>>(
                     ValueRef::EFFECT_TARGET_VALUE_REFERENCE, std::vector<std::string>()),
-                boost::make_unique<ValueRef::Constant<double>>(increase)
+                std::make_unique<ValueRef::Constant<double>>(increase)
             );
         auto effects = Effects();
-        effects.push_back(boost::make_unique<Effect::SetMeter>(meter_type, std::move(vr)));
+        effects.push_back(std::make_unique<Effect::SetMeter>(meter_type, std::move(vr)));
         return std::make_shared<Effect::EffectsGroup>(std::move(scope), std::move(activation), std::move(effects));
     }
 }

--- a/universe/Pathfinder.cpp
+++ b/universe/Pathfinder.cpp
@@ -108,10 +108,10 @@ namespace {
         // the function so that the function still has the required signature.
 
         /// Cache miss handler
-        typedef boost::function<void (size_t &/*ii*/, Row /*row*/)> cache_miss_handler;
+        typedef std::function<void (size_t &/*ii*/, Row /*row*/)> cache_miss_handler;
 
         /// A function to examine an entire row cache hit
-        typedef boost::function<void (size_t &/*ii*/, const Row /*row*/)> cache_hit_handler;
+        typedef std::function<void (size_t &/*ii*/, const Row /*row*/)> cache_hit_handler;
 
         /** Retrieve a single element at (\p ii, \p jj).
           * On cache miss call the \p fill_row which must fill the row

--- a/universe/Pathfinder.h
+++ b/universe/Pathfinder.h
@@ -3,8 +3,6 @@
 
 #include "UniverseObject.h"
 
-#include <boost/unordered_map.hpp>
-
 #include <vector>
 #include <map>
 #include <set>

--- a/universe/ShipDesign.cpp
+++ b/universe/ShipDesign.cpp
@@ -25,8 +25,7 @@
 #include <boost/uuid/random_generator.hpp>
 #include <boost/uuid/uuid_io.hpp>
 #include <boost/lexical_cast.hpp>
-//TODO: replace with std::make_unique when transitioning to C++14
-#include <boost/smart_ptr/make_unique.hpp>
+
 
 extern FO_COMMON_API const int INVALID_DESIGN_ID = -1;
 
@@ -54,18 +53,18 @@ namespace {
                   std::unique_ptr<ValueRef::ValueRef<double>>&& increase_vr)
     {
         typedef std::vector<std::unique_ptr<Effect::Effect>> Effects;
-        auto scope = boost::make_unique<Condition::Source>();
-        auto activation = boost::make_unique<Condition::Source>();
+        auto scope = std::make_unique<Condition::Source>();
+        auto activation = std::make_unique<Condition::Source>();
 
         auto vr =
-            boost::make_unique<ValueRef::Operation<double>>(
+            std::make_unique<ValueRef::Operation<double>>(
                 ValueRef::PLUS,
-                boost::make_unique<ValueRef::Variable<double>>(
+                std::make_unique<ValueRef::Variable<double>>(
                     ValueRef::EFFECT_TARGET_VALUE_REFERENCE, std::vector<std::string>()),
                 std::move(increase_vr)
             );
         auto effects = Effects();
-        effects.push_back(boost::make_unique<Effect::SetMeter>(meter_type, std::move(vr)));
+        effects.push_back(std::make_unique<Effect::SetMeter>(meter_type, std::move(vr)));
         return std::make_shared<Effect::EffectsGroup>(std::move(scope), std::move(activation), std::move(effects));
     }
 
@@ -73,7 +72,7 @@ namespace {
     // by the specified amount \a fixed_increase
     std::shared_ptr<Effect::EffectsGroup>
     IncreaseMeter(MeterType meter_type, float fixed_increase) {
-        auto increase_vr = boost::make_unique<ValueRef::Constant<double>>(fixed_increase);
+        auto increase_vr = std::make_unique<ValueRef::Constant<double>>(fixed_increase);
         return IncreaseMeter(meter_type, std::move(increase_vr));
     }
 
@@ -88,12 +87,12 @@ namespace {
         if (scaling_factor_rule_name.empty())
             return IncreaseMeter(meter_type, base_increase);
 
-        auto increase_vr = boost::make_unique<ValueRef::Operation<double>>(
+        auto increase_vr = std::make_unique<ValueRef::Operation<double>>(
             ValueRef::TIMES,
-            boost::make_unique<ValueRef::Constant<double>>(base_increase),
-            boost::make_unique<ValueRef::ComplexVariable<double>>(
+            std::make_unique<ValueRef::Constant<double>>(base_increase),
+            std::make_unique<ValueRef::ComplexVariable<double>>(
                 "GameRule", nullptr, nullptr, nullptr,
-                boost::make_unique<ValueRef::Constant<std::string>>(scaling_factor_rule_name)
+                std::make_unique<ValueRef::Constant<std::string>>(scaling_factor_rule_name)
             )
         );
 
@@ -108,24 +107,24 @@ namespace {
                   float increase, bool allow_stacking = true)
     {
         typedef std::vector<std::unique_ptr<Effect::Effect>> Effects;
-        auto scope = boost::make_unique<Condition::Source>();
-        auto activation = boost::make_unique<Condition::Source>();
+        auto scope = std::make_unique<Condition::Source>();
+        auto activation = std::make_unique<Condition::Source>();
 
-        auto value_vr = boost::make_unique<ValueRef::Operation<double>>(
+        auto value_vr = std::make_unique<ValueRef::Operation<double>>(
             ValueRef::PLUS,
-            boost::make_unique<ValueRef::Variable<double>>(
+            std::make_unique<ValueRef::Variable<double>>(
                 ValueRef::EFFECT_TARGET_VALUE_REFERENCE, std::vector<std::string>()),
-            boost::make_unique<ValueRef::Constant<double>>(increase)
+            std::make_unique<ValueRef::Constant<double>>(increase)
         );
 
         auto part_name_vr =
-            boost::make_unique<ValueRef::Constant<std::string>>(part_name);
+            std::make_unique<ValueRef::Constant<std::string>>(part_name);
 
         std::string stacking_group = (allow_stacking ? "" :
             (part_name + "_" + boost::lexical_cast<std::string>(meter_type) + "_PartMeter"));
 
         auto effects = Effects();
-        effects.push_back(boost::make_unique<Effect::SetShipPartMeter>(
+        effects.push_back(std::make_unique<Effect::SetShipPartMeter>(
                               meter_type, std::move(part_name_vr), std::move(value_vr)));
 
         return std::make_shared<Effect::EffectsGroup>(
@@ -1658,7 +1657,7 @@ LoadShipDesignsAndManifestOrderFromParseResults(
     auto& disk_ordering = designs_paths_and_ordering.second;
 
     for (auto&& design_and_path : designs_and_paths) {
-        auto design = boost::make_unique<ShipDesign>(*design_and_path.first);
+        auto design = std::make_unique<ShipDesign>(*design_and_path.first);
 
         // If the UUID is nil this is a legacy design that needs a new UUID
         if(design->UUID() == boost::uuids::uuid{{0}}) {

--- a/universe/Species.cpp
+++ b/universe/Species.cpp
@@ -15,8 +15,6 @@
 #include "../util/ScopedTimer.h"
 
 #include <boost/filesystem/fstream.hpp>
-//TODO: replace with std::make_unique when transitioning to C++14
-#include <boost/smart_ptr/make_unique.hpp>
 
 #include <iterator>
 
@@ -133,23 +131,23 @@ void Species::Init() {
         // (not uninhabitable) environment for this species
         std::vector<std::unique_ptr<ValueRef::ValueRef< ::PlanetEnvironment>>> environments_vec;
         environments_vec.push_back(
-            boost::make_unique<ValueRef::Constant<PlanetEnvironment>>( ::PE_UNINHABITABLE));
+            std::make_unique<ValueRef::Constant<PlanetEnvironment>>( ::PE_UNINHABITABLE));
         auto this_species_name_ref =
-            boost::make_unique<ValueRef::Constant<std::string>>(m_name);  // m_name specifies this species
+            std::make_unique<ValueRef::Constant<std::string>>(m_name);  // m_name specifies this species
         auto enviro_cond = std::unique_ptr<Condition::Condition>(
-            boost::make_unique<Condition::Not>(
+            std::make_unique<Condition::Not>(
                 std::unique_ptr<Condition::Condition>(
-                    boost::make_unique<Condition::PlanetEnvironment>(
+                    std::make_unique<Condition::PlanetEnvironment>(
                         std::move(environments_vec), std::move(this_species_name_ref)))));
 
-        auto type_cond = std::unique_ptr<Condition::Condition>(boost::make_unique<Condition::Type>(
-            boost::make_unique<ValueRef::Constant<UniverseObjectType>>( ::OBJ_POP_CENTER)));
+        auto type_cond = std::unique_ptr<Condition::Condition>(std::make_unique<Condition::Type>(
+            std::make_unique<ValueRef::Constant<UniverseObjectType>>( ::OBJ_POP_CENTER)));
 
         std::vector<std::unique_ptr<Condition::Condition>> operands;
         operands.push_back(std::move(enviro_cond));
         operands.push_back(std::move(type_cond));
 
-        m_location = std::unique_ptr<Condition::Condition>(boost::make_unique<Condition::And>(std::move(operands)));
+        m_location = std::unique_ptr<Condition::Condition>(std::make_unique<Condition::And>(std::move(operands)));
     }
     m_location->SetTopLevelContent(m_name);
 

--- a/util/OptionsDB.h
+++ b/util/OptionsDB.h
@@ -9,6 +9,7 @@
 #include <boost/filesystem/fstream.hpp>
 #include <boost/signals2/signal.hpp>
 
+#include <functional>
 #include <map>
 #include <unordered_set>
 
@@ -20,7 +21,9 @@ class XMLElement;
 /////////////////////////////////////////////
 // Free Functions
 /////////////////////////////////////////////
-typedef void (*OptionsDBFn)(OptionsDB&); ///< the function signature for functions that add Options to the OptionsDB (void (OptionsDB&))
+
+//! The function signature for functions that add Options to the OptionsDB (void (OptionsDB&))
+typedef std::function<void (OptionsDB&)> OptionsDBFn;
 
 /** adds \a function to a vector of pointers to functions that add Options to
   * the OptionsDB.  This function returns a boolean so that it can be used to

--- a/util/ScopedTimer.cpp
+++ b/util/ScopedTimer.cpp
@@ -2,7 +2,6 @@
 
 #include "Logger.h"
 
-#include <boost/unordered_map.hpp>
 #include <boost/chrono.hpp>
 
 #include <iomanip>
@@ -164,7 +163,7 @@ class SectionedScopedTimer::Impl : public ScopedTimer::Impl {
         }
 
         //Table of section durations
-        typedef boost::unordered_map<std::string, std::chrono::nanoseconds> SectionTable;
+        typedef std::unordered_map<std::string, std::chrono::nanoseconds> SectionTable;
         SectionTable m_table;
 
         // Currently running section start time and iterator

--- a/util/VarText.cpp
+++ b/util/VarText.cpp
@@ -11,6 +11,7 @@
 
 #include <boost/xpressive/xpressive.hpp>
 
+#include <functional>
 #include <map>
 
 namespace xpr = boost::xpressive;
@@ -51,7 +52,7 @@ namespace {
     //! @param data
     //!     Data values The signature of functions that generate substitution
     //!     strings for tags.
-    typedef boost::optional<std::string> (*TagString)(const std::string& data);
+    typedef std::function<boost::optional<std::string> (const std::string& data)> TagString;
 
     //! Get string substitute for a tag that is a universe object
     boost::optional<std::string> UniverseObjectString(const std::string& data, const std::string& tag) {


### PR DESCRIPTION
This PR replaces various functionality currently provided by boost or were self rolled with their standard library equivalent or their range compatible counterpart:

* `boost::make_unique` becomes `std::make_unique`.
* `BOOST_STATIC_ASSERT` becomes `static_assert`.
* `BOOST_STATIC_CONSTANT` becomes `constexpr`.
* `boost::function` or regular function pointer types become `std::function`.
* `boost::unordered_map` becomes `std::unordered_map`.
* Use `boost::algorithm::all_of` instead of hand written loop (equivalent to `std::all_of`).