### PR TITLE
Update build docs

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -46,7 +46,7 @@ FreeOrion depends on the following libraries or APIs to run:
 
 For Windows and Mac OS X a [Software Development Kit] is provided as download to
 compile FreeOrion from source. It contains the preconfigured and -compiled build
-and runtime dependencies for the Visual Studio v140 toolchain on Windows and
+and runtime dependencies for the Visual Studio v141 toolchain on Windows and
 Mac OS X 10.9 SDK with Xcode 6.4 or later on Mac OS X.
 
 For Linux or other Operating Systems the build and runtime dependencies should

--- a/BUILD.md
+++ b/BUILD.md
@@ -44,10 +44,10 @@ FreeOrion depends on the following libraries or APIs to run:
 
 ## Obtaining FreeOrion Source Code and Software Dependencies
 
-For Windows and Mac OS X a [FreeOrion Software Development Kit] is provided as
-download to compile FreeOrion from source. It contains the preconfigured and
--compiled build and runtime dependencies for the Visual Studio v140 toolchain on
-Windows and Mac OS X 10.9 SDK with Xcode 6.4 or later on Mac OS X.
+For Windows and Mac OS X a [Software Development Kit] is provided as download to
+compile FreeOrion from source. It contains the preconfigured and -compiled build
+and runtime dependencies for the Visual Studio v140 toolchain on Windows and
+Mac OS X 10.9 SDK with Xcode 6.4 or later on Mac OS X.
 
 For Linux or other Operating Systems the build and runtime dependencies should
 be installed by the preferred way for the respective OS (e.g. via Package
@@ -188,7 +188,7 @@ This will leave you with a build of FreeOrion executables.
 [OpenAL Soft]: http://kcat.strangesoft.net/openal.html
 [libvorbis]: https://xiph.org/downloads/
 [SDL2]: https://www.libsdl.org/download-2.0.php
-[FreeOrionSDK]: https://github.com/freeorion/freeorion-sdk
+[Software Development Kit]: https://github.com/freeorion/freeorion-sdk
 [FreeOrionSDK v11]: https://github.com/freeorion/freeorion-sdk/releases/tag/v11
 [FreeOrion Releases]: https://github.com/freeorion/freeorion/releases
 [make jobs]: https://www.gnu.org/software/make/manual/html_node/Parallel.html

--- a/BUILD.md
+++ b/BUILD.md
@@ -56,9 +56,9 @@ manager or compiling from source).
 Step by step procedure:
 
  * On Windows:
-   * Download the [FreeOrionSDK v10] from the FreeOrionSDK respository releases.
+   * Download the [FreeOrionSDK v11] from the FreeOrionSDK respository releases.
  * On Mac OS X:
-   * The [FreeOrionSDK v10] is downloaded automatically when CMake creates the
+   * The [FreeOrionSDK v11] is downloaded automatically when CMake creates the
      build environment.
  * Linux and other Operating Systems:
    * Install build and runtime dependencies by the preferred way for the
@@ -189,6 +189,6 @@ This will leave you with a build of FreeOrion executables.
 [libvorbis]: https://xiph.org/downloads/
 [SDL2]: https://www.libsdl.org/download-2.0.php
 [FreeOrionSDK]: https://github.com/freeorion/freeorion-sdk
-[FreeOrionSDK v10]: https://github.com/freeorion/freeorion-sdk/releases/tag/v10
+[FreeOrionSDK v11]: https://github.com/freeorion/freeorion-sdk/releases/tag/v11
 [FreeOrion Releases]: https://github.com/freeorion/freeorion/releases
 [make jobs]: https://www.gnu.org/software/make/manual/html_node/Parallel.html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,10 +28,10 @@ that you're working on the bug.  If you want to implement a new feature, get in
 touch with the developers via the [FreeOrion Forum] to check if the feature complies
 with our idea of the game.
 
-To start contributing, first clone [FreeOrion Git] repository.  After that, create
-a branch with a concise name; if the branch implements an issue call it
-`fix-<Issue Number>`.  To publish your contribution, create a [Pull Request] and
-wait for feedback from the developers.
+To start contributing, first clone [FreeOrion Git] repository by following the
+[Build Instructions](BUILD.md).  After that, create a branch with a concise name;
+if the branch implements an issue call it `fix-<Issue Number>`.  To publish your
+contribution, create a [Pull Request] and wait for feedback from the developers.
 
 By submitting a pull request, you agree to license its contents under the applicable
 [FreeOrion license(s)].


### PR DESCRIPTION
This PR syncs the build instructions with reality:

* Refer to the now required SDK v11 to download.
* The SDK only provides dependencies built with and for the v141 MSVC toolchain.
* Fix link to freeorion-sdk project.
* Mention build instructions early on within contribution guidelines to avoid confusion for reader.