### PR TITLE
Test if gcc compiler suffers from c++/94190 bug

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,6 +212,8 @@ if(UNIX AND NOT APPLE)
     add_definitions(-DENABLE_BINRELOC -DBINPATH=\"${CMAKE_INSTALL_FULL_BINDIR}\" -DSHAREPATH=\"${CMAKE_INSTALL_FULL_DATADIR}\")
 endif()
 
+include(TestForBug2795)
+
 
 ##
 ## Collect project dependencies.

--- a/cmake/TestForBug2795.cmake
+++ b/cmake/TestForBug2795.cmake
@@ -1,0 +1,53 @@
+# This file is a CMake configuration source compile check
+#
+# G++ 10.0.1 had a regression bug, which causes boost::serialization to fail
+# to compile because the underlying type of a strong typedef template did not
+# expose its ++/-- post operators.
+#
+# For more details see:
+#   https://github.com/freeorion/freeorion/issues/2795
+#   https://github.com/boostorg/serialization/issues/192
+#   https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94190
+
+
+include(CheckCXXSourceCompiles)
+
+# Enforce compiler to be invoked with C locale to ensure non-localized
+# error messages.
+set(_locale_vars LC_ALL LC_MESSAGES LANG)
+foreach(v IN LISTS _locale_vars)
+    set(_locale_vars_saved_${v} "$ENV{${v}}")
+    set(ENV{${v}} C)
+endforeach()
+
+check_cxx_source_compiles("
+struct A
+{
+    int _i;
+    operator int&() { return _i; }
+};
+
+template <typename T> void f()
+{
+    A a;
+    a++; // triggers bug
+}
+
+int main() { f<int>(); }
+" NOT_GNU_CXX_BUG_94190 FAIL_REGEX "no post-decrement operator for type")
+
+if(NOT NOT_GNU_CXX_BUG_94190)
+    message(FATAL_ERROR
+        "The found version of the g++ compiler suffers from bug"
+        " https://gcc.gnu.org/bugzilla/show_bug.cgi?id=94190"
+        " which triggers a known bug in combination with boost::serialization."
+        " Please update the compiler to a more recent version of g++ or"
+        " use an alternative compiler."
+        " After update rebuild the project from a clean build tree."
+    )
+endif()
+
+# Restore locale settings
+foreach(v IN LISTS _locale_vars)
+    set(ENV{${v}} ${_locale_vars_saved_${v}})
+endforeach()


### PR DESCRIPTION
The CMake build system now fails now with instructions on g++ releases, which suffer from bug c++/94190.

Fixes #2795

I didn't bother to provide a workaround, as Fedora has already provided a patched version of g++ and I cannot test such workaround.