### PR TITLE
Remove GG:::ListBox::Row constructor default parameters

### DIFF
--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -134,7 +134,7 @@ public:
 
         /** \name Structors */ ///@{
         Row();
-        Row(X w, Y h, const std::string& drag_drop_data_type, Alignment align = ALIGN_VCENTER, unsigned int margin = 2);
+        Row(X w, Y h);
         virtual ~Row();
         //@}
 

--- a/GG/src/ListBox.cpp
+++ b/GG/src/ListBox.cpp
@@ -201,16 +201,14 @@ namespace {
 // GG::ListBox::Row
 ////////////////////////////////////////////////
 ListBox::Row::Row() :
-    Control(X0, Y0, ListBox::DEFAULT_ROW_WIDTH, ListBox::DEFAULT_ROW_HEIGHT),
-    m_row_alignment(ALIGN_VCENTER)
+    Row(ListBox::DEFAULT_ROW_WIDTH, ListBox::DEFAULT_ROW_HEIGHT)
 {}
 
-ListBox::Row::Row(X w, Y h, const std::string& drag_drop_data_type,
-                  Alignment align/* = ALIGN_VCENTER*/, unsigned int margin/* = 2*/) : 
+ListBox::Row::Row(X w, Y h) :
     Control(X0, Y0, w, h),
-    m_row_alignment(align),
-    m_margin(margin)
-{ SetDragDropDataType(drag_drop_data_type); }
+    m_row_alignment(ALIGN_VCENTER),
+    m_margin(ListBox::DEFAULT_MARGIN)
+{}
 
 void ListBox::Row::CompleteConstruction()
 { SetLayout(Wnd::Create<DeferredLayout>(X0, Y0, Width(), Height(), 1, 1, m_margin, m_margin)); }
@@ -488,9 +486,12 @@ void ListBox::Row::SetMargin(unsigned int margin)
         return;
 
     m_margin = margin;
-    auto&& layout = GetLayout();
-    layout->SetBorderMargin(margin);
-    layout->SetCellMargin(margin);
+    auto layout = GetLayout();
+    if (layout)
+    {
+        layout->SetBorderMargin(margin);
+        layout->SetCellMargin(margin);
+    }
 }
 
 void ListBox::Row::SetNormalized(bool normalized)

--- a/UI/BuildDesignatorWnd.cpp
+++ b/UI/BuildDesignatorWnd.cpp
@@ -447,10 +447,12 @@ namespace {
     public:
         ProductionItemRow(GG::X w, GG::Y h, const ProductionQueue::ProductionItem& item,
                           int empire_id, int location_id) :
-            GG::ListBox::Row(w, h, "", GG::ALIGN_NONE, 0),
+            GG::ListBox::Row(w, h),
             m_item(item)
         {
             SetName("ProductionItemRow");
+            SetMargin(0);
+            SetRowAlignment(GG::ALIGN_NONE);
             SetChildClippingMode(ClipToClient);
 
             if (m_item.build_type == BT_SHIP) {

--- a/UI/CUIControls.cpp
+++ b/UI/CUIControls.cpp
@@ -1279,7 +1279,7 @@ const GG::Y CUISimpleDropDownListRow::DEFAULT_ROW_HEIGHT(22);
 
 CUISimpleDropDownListRow::CUISimpleDropDownListRow(const std::string& row_text,
                                                    GG::Y row_height/* = DEFAULT_ROW_HEIGHT*/) :
-    GG::ListBox::Row(GG::X1, row_height, ""),
+    GG::ListBox::Row(GG::X1, row_height),
     m_row_label(GG::Wnd::Create<CUILabel>(row_text, GG::FORMAT_LEFT | GG::FORMAT_NOWRAP))
 {}
 
@@ -1498,8 +1498,9 @@ namespace {
     // row type used in the SpeciesSelector
     struct SpeciesRow : public GG::ListBox::Row {
         SpeciesRow(const Species* species, GG::X w, GG::Y h) :
-            GG::ListBox::Row(w, h, "", GG::ALIGN_VCENTER, 0)
+            GG::ListBox::Row(w, h)
         {
+            SetMargin(0);
             if (!species)
                 return;
             const std::string& species_name = species->Name();
@@ -1510,8 +1511,9 @@ namespace {
 
         SpeciesRow(const std::string& species_name, const std::string& localized_name, const std::string& species_desc,
                    GG::X w, GG::Y h, std::shared_ptr<GG::Texture> species_icon) :
-            GG::ListBox::Row(w, h, "", GG::ALIGN_VCENTER, 0)
+            GG::ListBox::Row(w, h)
         {
+            SetMargin(0);
             GG::Wnd::SetName(species_name);
             Init(species_name, localized_name, species_desc, w, h, species_icon);
         };
@@ -1620,7 +1622,7 @@ namespace {
         };
 
         ColorRow(const GG::Clr& color, GG::Y h) :
-            GG::ListBox::Row(GG::X(Value(h)), h, ""),
+            GG::ListBox::Row(GG::X(Value(h)), h),
             m_color_square(GG::Wnd::Create<ColorSquare>(color, h))
         {}
 

--- a/UI/CensusBrowseWnd.cpp
+++ b/UI/CensusBrowseWnd.cpp
@@ -167,7 +167,8 @@ void CensusBrowseWnd::CompleteConstruction() {
 
     // add species rows
     for (auto it = counts_species.rbegin(); it != counts_species.rend(); ++it) {
-        auto row = GG::Wnd::Create<GG::ListBox::Row>(m_list->Width(), ROW_HEIGHT, "Census Species Row");
+        auto row = GG::Wnd::Create<GG::ListBox::Row>(m_list->Width(), ROW_HEIGHT);
+        row->SetDragDropDataType("Census Species Row");
         row->push_back(GG::Wnd::Create<CensusRowPanel>(m_list->Width(), ROW_HEIGHT, it->second, it->first, true));
         m_list->Insert(row);
         row->Resize(GG::Pt(m_list->Width(), ROW_HEIGHT));
@@ -201,7 +202,8 @@ void CensusBrowseWnd::CompleteConstruction() {
         //DebugLogger() << "Census checking for tag '"<< tag_ord <<"'";
         auto it2 = m_tag_counts.find(tag_ord);
         if (it2 != m_tag_counts.end()) {
-            auto row = GG::Wnd::Create<GG::ListBox::Row>(m_list->Width(), ROW_HEIGHT, "Census Characteristics Row");
+            auto row = GG::Wnd::Create<GG::ListBox::Row>(m_list->Width(), ROW_HEIGHT);
+            row->SetDragDropDataType("Census Characteristics Row");
             row->push_back(GG::Wnd::Create<CensusRowPanel>(m_tags_list->Width(), ROW_HEIGHT, it2->first, it2->second, false));
             m_tags_list->Insert(row);
             row->Resize(GG::Pt(m_list->Width(), ROW_HEIGHT));

--- a/UI/DesignWnd.cpp
+++ b/UI/DesignWnd.cpp
@@ -1349,7 +1349,7 @@ private:
 };
 
 PartsListBox::PartsListBoxRow::PartsListBoxRow(GG::X w, GG::Y h, const AvailabilityManager& availabilities_state) :
-    CUIListBox::Row(w, h, ""),    // drag_drop_data_type = "" implies not draggable row
+    CUIListBox::Row(w, h),
     m_availabilities_state(availabilities_state)
 {}
 
@@ -2306,8 +2306,9 @@ void BasesListBox::HullAndNamePanel::SetDisplayName(const std::string& name) {
 }
 
 BasesListBox::BasesListBoxRow::BasesListBoxRow(GG::X w, GG::Y h, const std::string& hull, const std::string& name) :
-    CUIListBox::Row(w, h, BASES_LIST_BOX_DROP_TYPE)
+    CUIListBox::Row(w, h)
 {
+    SetDragDropDataType(BASES_LIST_BOX_DROP_TYPE);
     if (hull.empty()) {
         ErrorLogger() << "No hull name provided for ship row display.";
         return;

--- a/UI/FleetWnd.cpp
+++ b/UI/FleetWnd.cpp
@@ -1007,7 +1007,7 @@ namespace {
     class ShipRow : public GG::ListBox::Row {
     public:
         ShipRow(GG::X w, GG::Y h, int ship_id) :
-            GG::ListBox::Row(w, h, ""),
+            GG::ListBox::Row(w, h),
             m_ship_id(ship_id)
         {
             SetName("ShipRow");
@@ -1795,9 +1795,11 @@ namespace {
     class FleetRow : public GG::ListBox::Row {
     public:
         FleetRow(int fleet_id, GG::X w, GG::Y h) :
-            GG::ListBox::Row(w, h, Objects().get<Fleet>(fleet_id) ? FLEET_DROP_TYPE_STRING : ""),
+            GG::ListBox::Row(w, h),
             m_fleet_id(fleet_id)
         {
+            if (Objects().get<Fleet>(fleet_id))
+                SetDragDropDataType(FLEET_DROP_TYPE_STRING);
             SetName("FleetRow");
             SetChildClippingMode(ClipToClient);
         }

--- a/UI/GalaxySetupWnd.cpp
+++ b/UI/GalaxySetupWnd.cpp
@@ -77,12 +77,12 @@ namespace {
     class RuleListRow : public GG::ListBox::Row {
     public:
         RuleListRow(GG::X w, GG::Y h, std::shared_ptr<RowContentsWnd> contents) :
-            GG::ListBox::Row(w, h, ""),
+            GG::ListBox::Row(w, h),
             m_contents(std::forward<std::shared_ptr<RowContentsWnd>>(contents))
         {}
 
         RuleListRow(GG::X w, GG::Y h, std::shared_ptr<Wnd> contents, int indentation = 0) :
-            GG::ListBox::Row(w, h, "")
+            GG::ListBox::Row(w, h)
         {
             if (contents)
                 m_contents = GG::Wnd::Create<RowContentsWnd>(w, h, std::forward<std::shared_ptr<GG::Wnd>>(contents), indentation);
@@ -393,8 +393,10 @@ namespace {
     // row type used in the SpeciesSelector
     struct UserStringRow : public GG::ListBox::Row {
         UserStringRow(const std::string& key, GG::X w, GG::Y h) :
-            GG::ListBox::Row(w, h, "", GG::ALIGN_VCENTER, 0)
+            GG::ListBox::Row(w, h)
         {
+            SetMargin(0);
+            SetRowAlignment(GG::ALIGN_VCENTER);
             GG::Wnd::SetName(key);
         }
 

--- a/UI/MeterBrowseWnd.cpp
+++ b/UI/MeterBrowseWnd.cpp
@@ -560,7 +560,7 @@ namespace {
          * @param [in] base_value optional; If greater than 0.0f: the value label is formatted to "value of base_value"
          */
         ShipFightersBrowseRow(const std::string& label, int qty, double value, double base_value = 0.0f) :
-            GG::ListBox::Row(FighterBrowseListWidth(), MeterBrowseRowHeight(), "")
+            GG::ListBox::Row(FighterBrowseListWidth(), MeterBrowseRowHeight())
         {
             const GG::Clr QTY_COLOR = GG::CLR_GRAY;
 

--- a/UI/MultiplayerLobbyWnd.cpp
+++ b/UI/MultiplayerLobbyWnd.cpp
@@ -48,12 +48,12 @@ namespace {
     // players or the host.
     struct PlayerRow : GG::ListBox::Row {
         PlayerRow() :
-            GG::ListBox::Row(GG::X(90), PlayerRowHeight(), ""),
+            GG::ListBox::Row(GG::X(90), PlayerRowHeight()),
             m_player_data(),
             m_player_id(Networking::INVALID_PLAYER_ID)
         {}
         PlayerRow(const PlayerSetupData& player_data, int player_id) :
-            GG::ListBox::Row(GG::X(90), PlayerRowHeight(), ""),
+            GG::ListBox::Row(GG::X(90), PlayerRowHeight()),
             m_player_data(player_data),
             m_player_id(player_id)
         {}
@@ -84,9 +84,10 @@ namespace {
             {}
 
             TypeRow(GG::X w, GG::Y h, Networking::ClientType type_, bool show_add_drop = false) :
-                GG::DropDownList::Row(w, h, "PlayerTypeSelectorRow"),
+                GG::DropDownList::Row(w, h),
                 type(type_)
             {
+                SetDragDropDataType("PlayerTypeSelectorRow");
                 switch (type) {
                 case Networking::CLIENT_TYPE_AI_PLAYER:
                     if (show_add_drop)
@@ -693,7 +694,7 @@ void MultiPlayerLobbyWnd::CompleteConstruction() {
 }
 
 MultiPlayerLobbyWnd::PlayerLabelRow::PlayerLabelRow(GG::X width /* = GG::X(580)*/) :
-    GG::ListBox::Row(width, PlayerRowHeight(), "")
+    GG::ListBox::Row(width, PlayerRowHeight())
 {}
 
 void MultiPlayerLobbyWnd::PlayerLabelRow::CompleteConstruction() {

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -649,7 +649,7 @@ private:
     class ConditionRow : public GG::ListBox::Row {
     public:
         ConditionRow(const std::string& key, GG::Y row_height) :
-            GG::ListBox::Row(GG::X1, row_height, ""),
+            GG::ListBox::Row(GG::X1, row_height),
             m_condition_key(key),
             m_label(GG::Wnd::Create<CUILabel>(UserString(m_condition_key), GG::FORMAT_LEFT | GG::FORMAT_NOWRAP))
         {}
@@ -670,7 +670,7 @@ private:
     class StringRow : public GG::ListBox::Row {
     public:
         StringRow(const std::string& text, GG::Y row_height, bool stringtable_lookup = true) :
-            GG::ListBox::Row(GG::X1, row_height, ""),
+            GG::ListBox::Row(GG::X1, row_height),
             m_string(text)
         {
             const std::string& label = (text.empty() ? EMPTY_STRING :
@@ -1581,13 +1581,16 @@ public:
     ObjectRow(GG::X w, GG::Y h, std::shared_ptr<const UniverseObject> obj, bool expanded,
               int container_object_panel, const id_range& contained_object_panels,
               int indent) :
-        GG::ListBox::Row(w, h, "", GG::ALIGN_CENTER, 1),
+        GG::ListBox::Row(w, h),
         m_container_object_panel(container_object_panel),
         m_contained_object_panels(contained_object_panels.begin(), contained_object_panels.end()),
         m_obj_init(obj),
         m_expanded_init(expanded),
         m_indent_init(indent)
-    {}
+    {
+        SetMargin(1);
+        SetRowAlignment(GG::ALIGN_VCENTER);
+    }
 
     void CompleteConstruction() override {
         GG::ListBox::Row::CompleteConstruction();
@@ -1806,8 +1809,10 @@ private:
 class ObjectHeaderRow : public GG::ListBox::Row {
 public:
     ObjectHeaderRow(GG::X w, GG::Y h) :
-        GG::ListBox::Row(w, h, "", GG::ALIGN_CENTER, 1)
+        GG::ListBox::Row(w, h)
     {
+        SetMargin(1);
+        SetRowAlignment(GG::ALIGN_CENTER);
         m_panel = GG::Wnd::Create<ObjectHeaderPanel>(w, h);
     }
 

--- a/UI/OptionsWnd.cpp
+++ b/UI/OptionsWnd.cpp
@@ -313,14 +313,14 @@ namespace {
     class OptionsListRow : public GG::ListBox::Row {
     public:
         OptionsListRow(GG::X w, GG::Y h, std::shared_ptr<RowContentsWnd> contents) :
-            GG::ListBox::Row(w, h, ""),
+            GG::ListBox::Row(w, h),
             m_contents(std::forward<std::shared_ptr<RowContentsWnd>>(contents))
         {
             SetChildClippingMode(ClipToClient);
         }
 
         OptionsListRow(GG::X w, GG::Y h, std::shared_ptr<Wnd> contents, int indentation = 0) :
-            GG::ListBox::Row(w, h, "")
+            GG::ListBox::Row(w, h)
         {
             SetChildClippingMode(ClipToClient);
             if (contents)

--- a/UI/PlayerListWnd.cpp
+++ b/UI/PlayerListWnd.cpp
@@ -607,11 +607,13 @@ namespace {
     class PlayerRow : public GG::ListBox::Row {
     public:
         PlayerRow(GG::X w, GG::Y h, int player_id, int empire_id) :
-            GG::ListBox::Row(w, h, "", GG::ALIGN_NONE, 0),
+            GG::ListBox::Row(w, h),
             m_player_id(player_id),
             m_empire_id(empire_id),
             m_panel(nullptr)
         {
+            SetMargin(0);
+            SetRowAlignment(GG::ALIGN_NONE);
             SetName("PlayerRow");
             SetChildClippingMode(ClipToClient);
         }

--- a/UI/ProductionWnd.cpp
+++ b/UI/ProductionWnd.cpp
@@ -330,11 +330,11 @@ namespace {
 
     struct QueueRow : GG::ListBox::Row {
         QueueRow(GG::X w, const ProductionQueue::Element& elem_, int queue_index_) :
-            GG::ListBox::Row(w, QueueProductionItemPanel::DefaultHeight(),
-                             BuildDesignatorWnd::PRODUCTION_ITEM_DROP_TYPE),
+            GG::ListBox::Row(w, QueueProductionItemPanel::DefaultHeight()),
             queue_index(queue_index_),
             elem(elem_)
         {
+            SetDragDropDataType(BuildDesignatorWnd::PRODUCTION_ITEM_DROP_TYPE);
             const Empire* empire = GetEmpire(HumanClientApp::GetApp()->EmpireID());
             float total_cost(1.0f);
             int minimum_turns(1);

--- a/UI/QueueListBox.cpp
+++ b/UI/QueueListBox.cpp
@@ -11,7 +11,7 @@
 // PromptRow
 ////////////////////////////////////////////////////////////
 PromptRow::PromptRow(GG::X w, const std::string& prompt) :
-    GG::ListBox::Row(w, GG::Y(20), ""),
+    GG::ListBox::Row(w, GG::Y(20)),
     m_prompt(
         GG::Wnd::Create<CUILabel>(
             prompt,

--- a/UI/ResearchWnd.cpp
+++ b/UI/ResearchWnd.cpp
@@ -67,9 +67,10 @@ namespace {
     //////////////////////////////////////////////////
     struct QueueRow : GG::ListBox::Row {
         QueueRow(GG::X w, const ResearchQueue::Element& queue_element) :
-            GG::ListBox::Row(w, QueueTechPanel::DefaultHeight(), "RESEARCH_QUEUE_ROW"),
+            GG::ListBox::Row(w, QueueTechPanel::DefaultHeight()),
             elem(queue_element)
         {
+            SetDragDropDataType("RESEARCH_QUEUE_ROW");
             RequirePreRender();
             Resize(GG::Pt(w, QueueTechPanel::DefaultHeight()));
         }

--- a/UI/SidePanel.cpp
+++ b/UI/SidePanel.cpp
@@ -787,9 +787,10 @@ namespace {
     class SystemRow : public GG::ListBox::Row {
     public:
         SystemRow(int system_id, GG::Y h) :
-            GG::ListBox::Row(GG::X1, h, "SystemRow"),
+            GG::ListBox::Row(GG::X1, h),
             m_system_id(system_id)
         {
+            SetDragDropDataType("SystemRow");
             SetName("SystemRow");
             RequirePreRender();
         }
@@ -1821,7 +1822,8 @@ void SidePanel::PlanetPanel::Refresh() {
                 ClientUI::ArtDir() / planet->FocusIcon(focus_name), true);
             auto graphic = GG::Wnd::Create<GG::StaticGraphic>(texture, GG::GRAPHIC_FITGRAPHIC | GG::GRAPHIC_PROPSCALE);
             graphic->Resize(GG::Pt(MeterIconSize().x*3/2, MeterIconSize().y*3/2));
-            auto row = GG::Wnd::Create<GG::DropDownList::Row>(graphic->Width(), graphic->Height(), "FOCUS");
+            auto row = GG::Wnd::Create<GG::DropDownList::Row>(graphic->Width(), graphic->Height());
+            row->SetDragDropDataType("FOCUS");
 
             row->SetBrowseModeTime(GetOptionsDB().Get<int>("ui.tooltip.delay"));
             row->SetBrowseText(

--- a/UI/SitRepPanel.cpp
+++ b/UI/SitRepPanel.cpp
@@ -319,7 +319,7 @@ namespace {
     class SitRepRow : public GG::ListBox::Row {
     public:
         SitRepRow(GG::X w, GG::Y h, const SitRepEntry& sitrep) :
-            GG::ListBox::Row(w, h, ""),
+            GG::ListBox::Row(w, h),
             m_sitrep(sitrep)
         {
             SetName("SitRepRow");

--- a/UI/TechTreeWnd.cpp
+++ b/UI/TechTreeWnd.cpp
@@ -1615,11 +1615,11 @@ bool TechTreeWnd::TechListBox::TechRowCmp(const GG::ListBox::Row& lhs, const GG:
 }
 
 TechTreeWnd::TechListBox::TechRow::TechRow(GG::X w, const std::string& tech_name) :
-    CUIListBox::Row(w, GG::Y(ClientUI::Pts() * 2 + 5), "TechListBox::TechRow"),
+    CUIListBox::Row(w, GG::Y(ClientUI::Pts() * 2 + 5)),
     m_tech(tech_name),
     m_background_color(ClientUI::WndColor()),
     m_enqueued(false)
-{}
+{ SetDragDropDataType("TechListBox::TechRow"); }
 
 void TechTreeWnd::TechListBox::TechRow::CompleteConstruction() {
 
@@ -1758,7 +1758,7 @@ void TechTreeWnd::TechListBox::CompleteConstruction() {
     GG::X row_width = Width() - ClientUI::ScrollWidth() - ClientUI::Pts();
     std::vector<GG::X> col_widths = TechRow::ColWidths(row_width);
     const GG::Y HEIGHT(Value(col_widths[0]));
-    m_header_row = GG::Wnd::Create<GG::ListBox::Row>(row_width, HEIGHT, "");
+    m_header_row = GG::Wnd::Create<GG::ListBox::Row>(row_width, HEIGHT);
 
     auto graphic_col = GG::Wnd::Create<CUILabel>("");  // graphic
     graphic_col->Resize(GG::Pt(col_widths[0], HEIGHT));


### PR DESCRIPTION
Most subclasses only use a specific combination of settings, which can
be set via setters.  Also the parameterized constructor client to set
the drag and drop datatype always to `""` (not draggable), even if the
row is not draggable.