### PR TITLE
[AI] Update flake to newest version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ _lint_python_common: &_lint_python_common
   dist: bionic
   language: python
   install:
-    - pip install flake8-putty==0.4.0
+    - pip install flake8==3.7.9
   before_script:
     - cd default/python
   script:

--- a/default/python/AI/FreeOrionAI.py
+++ b/default/python/AI/FreeOrionAI.py
@@ -372,7 +372,7 @@ def generateOrders():  # pylint: disable=invalid-name
             statprof.stop()
             statprof.display()
             statprof.start()
-        except:
+        except:  # noqa: E722
             pass
 
 

--- a/default/python/AI/MilitaryAI.py
+++ b/default/python/AI/MilitaryAI.py
@@ -706,7 +706,7 @@ def get_military_fleets(mil_fleets_ids=None, try_reset=True, thisround="Main"):
         else:
             try:
                 capital_sys_id = next(iter(aistate.fleetStatus.items()))[1]['sysID']
-            except:
+            except:  # noqa: E722
                 pass
 
     num_targets = max(10, PriorityAI.allotted_outpost_targets)

--- a/default/python/AI/ProductionAI.py
+++ b/default/python/AI/ProductionAI.py
@@ -283,7 +283,7 @@ def generate_production_orders():
             try:
                 if fo.getBuildingType(type_id).canBeProduced(empire.empireID, homeworld.id):
                     possible_building_type_ids.append(type_id)
-            except:
+            except:  # noqa: E722
                 if fo.getBuildingType(type_id) is None:
                     debug("For empire %d, 'available Building Type priority_id' %s returns None from fo.getBuildingType(type_id)" % (empire.empireID, type_id))
                 else:
@@ -334,7 +334,7 @@ def generate_production_orders():
                 try:
                     res = fo.issueEnqueueBuildingProductionOrder("BLD_SHIPYARD_BASE", homeworld.id)
                     debug("Enqueueing BLD_SHIPYARD_BASE, with result %d" % res)
-                except:
+                except:  # noqa: E722
                     warning("Can't build shipyard at new capital, probably no population; we're hosed")
 
             for building_name in ["BLD_SHIPYARD_ORG_ORB_INC"]:
@@ -347,7 +347,7 @@ def generate_production_orders():
                             building_expense += cost / time
                             res = fo.issueRequeueProductionOrder(production_queue.size - 1, 0)  # move to front
                             debug("Requeueing %s to front of build queue, with result %d" % (building_name, res))
-                    except:
+                    except:  # noqa: E722
                         error("Exception triggered and caught: ", exc_info=True)
 
             if ("BLD_IMPERIAL_PALACE" in possible_building_types) and ("BLD_IMPERIAL_PALACE" not in (capital_buildings + queued_building_names)):
@@ -717,7 +717,7 @@ def generate_production_orders():
                             continue
                         try:
                             distance_map[sys_id] = universe.jumpDistance(homeworld.systemID, sys_id)
-                        except:
+                        except:  # noqa: E722
                             pass
                     use_sys = ([(-1, INVALID_ID)] + sorted([(dist, sys_id) for sys_id, dist in distance_map.items()]))[:2][-1][-1]  # kinda messy, but ensures a value
                 if use_sys != INVALID_ID:
@@ -730,7 +730,7 @@ def generate_production_orders():
                             building_expense += cost / time  # production_queue[production_queue.size -1].blocksize *
                             res = fo.issueRequeueProductionOrder(production_queue.size - 1, 0)  # move to front
                             debug("Requeueing %s to front of build queue, with result %d", building_name, res)
-                    except:
+                    except:  # noqa: E722
                         debug("problem queueing BLD_SOL_ORB_GEN at planet %s of system", use_loc, use_sys)
                         pass
 
@@ -756,7 +756,7 @@ def generate_production_orders():
                     continue
                 try:
                     distance_map[sys_id] = universe.jumpDistance(nominal_home.systemID, sys_id)
-                except:
+                except:  # noqa: E722
                     pass
             red_sys_list = sorted([(dist, sys_id) for sys_id, dist in distance_map.items()])
             for dist, sys_id in red_sys_list:
@@ -783,7 +783,7 @@ def generate_production_orders():
                             chat_human("Enqueueing %s at planet %s , with result %d" % (building_name, planet_used, res))
                         res = fo.issueRequeueProductionOrder(production_queue.size - 1, 0)  # move to front
                         debug("Requeueing %s to front of build queue, with result %d", building_name, res)
-                except:
+                except:  # noqa: E722
                     debug("problem queueing %s at planet %s" % (building_name, planet_used))
 
     building_name = "BLD_BLACK_HOLE_POW_GEN"
@@ -804,7 +804,7 @@ def generate_production_orders():
                         continue
                     try:
                         distance_map[sys_id] = universe.jumpDistance(homeworld.systemID, sys_id)
-                    except:
+                    except:  # noqa: E722
                         pass
                 use_sys = ([(-1, INVALID_ID)] + sorted([(dist, sys_id) for sys_id, dist in distance_map.items()]))[:2][-1][-1]  # kinda messy, but ensures a value
             if use_sys != INVALID_ID:
@@ -815,7 +815,7 @@ def generate_production_orders():
                     if res:
                         res = fo.issueRequeueProductionOrder(production_queue.size - 1, 0)  # move to front
                         debug("Requeueing %s to front of build queue, with result %d" % (building_name, res))
-                except:
+                except:  # noqa: E722
                     warning("problem queueing BLD_BLACK_HOLE_POW_GEN at planet %s of system %s", use_loc, use_sys)
                     pass
 
@@ -834,7 +834,7 @@ def generate_production_orders():
                 if res:
                     res = fo.issueRequeueProductionOrder(production_queue.size - 1, 0)  # move to front
                     debug("Requeueing %s to front of build queue, with result %d", building_name, res)
-            except:
+            except:  # noqa: E722
                 pass
 
     building_name = "BLD_GENOME_BANK"
@@ -852,7 +852,7 @@ def generate_production_orders():
                 if res:
                     res = fo.issueRequeueProductionOrder(production_queue.size - 1, 0)  # move to front
                     debug("Requeueing %s to front of build queue, with result %d", building_name, res)
-            except:
+            except:  # noqa: E722
                 pass
 
     building_name = "BLD_NEUTRONIUM_EXTRACTOR"
@@ -894,7 +894,7 @@ def generate_production_orders():
                     if res:
                         res = fo.issueRequeueProductionOrder(production_queue.size - 1, 0)  # move to front
                         debug("Requeueing %s to front of build queue, with result %d", building_name, res)
-                except:
+                except:  # noqa: E722
                     warning("problem queueing BLD_NEUTRONIUM_EXTRACTOR at planet %s of system %s" % (use_loc, use_sys))
                     pass
 

--- a/default/python/AI/ResearchAI.py
+++ b/default/python/AI/ResearchAI.py
@@ -691,7 +691,7 @@ def generate_classic_research_orders():
                     debug("    Enqueued Tech: %20s \t\t %8.0f \t %8.0f", name, this_cost, cum_cost)
                 else:
                     warning("    Failed attempt to enqueued Tech: " + name)
-            except:
+            except:  # noqa: E722
                 warning("    Failed attempt to enqueued Tech: " + name, exc_info=True)
 
         debug('\n\nAll techs:')

--- a/default/python/AI/freeorion_tools/_freeorion_tools.py
+++ b/default/python/AI/freeorion_tools/_freeorion_tools.py
@@ -111,7 +111,7 @@ class ConsoleLogHandler(logging.Handler):
         except (KeyboardInterrupt, SystemExit):
             raise
         # Hide errors from within the ConsoleLogHandler
-        except:
+        except:  # noqa: E722
             self.handleError(record)
 
 
@@ -217,7 +217,7 @@ def tuple_to_dict(tup):
     except TypeError:
         try:
             return {k: v for k, v in [tup]}
-        except:
+        except:  # noqa: E722
             error("Can't convert tuple_list to dict: %s", tup)
             return {}
 

--- a/default/python/common/charting/charts.py
+++ b/default/python/common/charting/charts.py
@@ -127,7 +127,7 @@ def main():
             allData[details['name']] = data
             empireColors[details['name']] = details['color']
             species[details['name']] = details['species']
-        except:
+        except:  # noqa: E722
             print("error processing %s" % lfile)
             print("Error: exception triggered and caught: ", traceback.format_exc())
 

--- a/default/python/common/configure_logging.py
+++ b/default/python/common/configure_logging.py
@@ -129,7 +129,7 @@ class _stdXLikeStream(object):
                 line_number = frame.f_lineno
                 function_name = frame.f_code.co_name
                 filename = frame.f_code.co_filename
-            except:
+            except:  # noqa: E722
                 (filename, line_number, function_name) = ("", "", "")
             finally:
                 # Explicitly del references to the caller's frame to avoid persistent reference cycles

--- a/default/python/tox.ini
+++ b/default/python/tox.ini
@@ -1,19 +1,25 @@
 [flake8]
 max-line-length=120
-putty-ignore =
-  *.py : +E121,E123,E126,E226,E24,E704,W503 # default ignore list
-  AI/AIDependencies.py : +E241
-  AI/FreeOrionAI.py : +E402,E722
-  AI/savegame_codec/__init__.py : +F401
-  AI/freeorion_tools/__init__.py : +F401,F403
-  auth/auth.py : +E402
-  chat/chat.py : +E402
-  turn_events/turn_events.py : +E402
-  universe_generation/universe_generator.py : +E402
-  universe_generation/universe_tables.py : +E201,E122,E231
-  stub_generator/__init__.py : +F401
-  tests/conftest.py : +E402,F401
-  # TODO: fix these warnings
-  *.py : +E501 # temp ignore of the line too long
+
+ignore = E121,E123,E126,E226,E24,E704,W503 # default ignore list
+# TODO: fix these warnings
+extend-ignore =
+    E501, # Long lines
+    W504  # Line break occurred after a binary operator
+
+per-file-ignores =
+  AI/FreeOrionAI.py:E402
+  AI/AIDependencies.py: E241
+  AI/savegame_codec/__init__.py: F401
+  AI/freeorion_tools/__init__.py: F401,F403
+  auth/auth.py: E402
+  chat/chat.py: E402
+  turn_events/turn_events.py: E402
+  universe_generation/universe_generator.py: E402
+  universe_generation/universe_tables.py: E201,E122,E231
+  stub_generator/__init__.py: F401
+  tests/conftest.py: E402,F401
+
 exclude =
   common/six.py
+  *_venv/

--- a/default/python/universe_generation/planets.py
+++ b/default/python/universe_generation/planets.py
@@ -66,7 +66,7 @@ def calc_planet_size(star_type, orbit, planet_density, galaxy_shape):
             if max_roll < roll:
                 max_roll = roll
                 planet_size = size
-    except:
+    except:  # noqa: E722
         # in case of an error play it safe and set planet size to invalid
         planet_size = fo.planetSize.unknown
         util.report_error("Python calc_planet_size: Pick planet size failed" + str(sys.exc_info()[1]))

--- a/default/python/universe_generation/starsystems.py
+++ b/default/python/universe_generation/starsystems.py
@@ -36,7 +36,7 @@ def pick_star_type(galaxy_age):
             if max_roll < roll:
                 max_roll = roll
                 star_type = candidate
-    except:
+    except:  # noqa: E722
         # in case of an error play save and set star type to invalid
         star_type = fo.starType.unknown
         util.report_error("Python pick_star_type: Pick star type failed\n" + sys.exc_info()[1])


### PR DESCRIPTION
flake8-putty uses an old version of the flake8.  This plugin is not required anymore since this feature is present in the flake8.

I have update tox.ini for new format and set `noqa: E722`
