### PR TITLE
Make COMBAT_TARGETS_PLANET_WITH_DEFENSE macro consider infrastructure

### DIFF
--- a/default/scripting/ship_parts/targeting.macros
+++ b/default/scripting/ship_parts/targeting.macros
@@ -22,11 +22,12 @@ COMBAT_TARGETS_NOT_DESTROYED_SHIP
 '''
 
 COMBAT_TARGETS_PLANET_WITH_DEFENSE
-'''         And [
+'''        And [
             Planet
             Or [
-               Not Shield high = 0
-               Not Defense high = 0
+                Not Shield high = 0
+                Not Defense high = 0
+                Not Construction high = 0
             ]
         ]
 '''


### PR DESCRIPTION
Fixes #2488 as suggested by @agrrr3 in [this post](https://www.freeorion.org/forum/viewtopic.php?f=28&t=11600&p=100633#p100612).

Tested with mass drivers against an Acirema HW, Furthest HW with Moderate Tech Special, and a Gysache AI HW without Planetary Defense Regeneration.
