### PR TITLE
Add unit test for AI savegame compression

### DIFF
--- a/default/python/AI/savegame_codec/__init__.py
+++ b/default/python/AI/savegame_codec/__init__.py
@@ -44,4 +44,4 @@ Example usage:
 
 from ._decoder import decode, load_savegame_string
 from ._definitions import CanNotSaveGameException, InvalidSaveGameException
-from ._encoder import encode, build_savegame_string
+from ._encoder import encode, build_savegame_string, compress

--- a/default/python/AI/savegame_codec/_encoder.py
+++ b/default/python/AI/savegame_codec/_encoder.py
@@ -39,10 +39,14 @@ def build_savegame_string(use_compression=True):
     from aistate_interface import get_aistate
     savegame_string = encode(get_aistate())
     if use_compression:
-        import base64
-        import zlib
-        savegame_string = base64.b64encode(zlib.compress(six.ensure_binary(savegame_string, 'utf-8')))
+        savegame_string = compress(savegame_string)
     return savegame_string
+
+
+def compress(string):
+    import base64
+    import zlib
+    return base64.b64encode(zlib.compress(six.ensure_binary(string, 'utf-8')))
 
 
 def encode(o):

--- a/default/python/tests/AI/test_savegame_manager.py
+++ b/default/python/tests/AI/test_savegame_manager.py
@@ -71,18 +71,26 @@ def simple_object(request, ):
     return request.param
 
 
-def check_encoding(obj):
+def check_encoding(obj, use_compression=False):
     retval = savegame_codec.encode(obj)
     assert retval
     assert isinstance(retval, str)
 
-    restored_obj = savegame_codec.decode(retval)
+    if use_compression:
+        retval = savegame_codec.compress(retval)
+        restored_obj = savegame_codec.load_savegame_string(retval)
+    else:
+        restored_obj = savegame_codec.decode(retval)
     assert type(restored_obj) == type(obj)
     assert restored_obj == obj
 
 
 def test_encoding_simple_object(simple_object):
     check_encoding(simple_object)
+
+
+def test_encoding_simple_object_with_compression(simple_object):
+    check_encoding(simple_object, True)
 
 
 def test_encoding_function():


### PR DESCRIPTION
The compression&decompression was previously not covered by unit tests. 

Catches an error introduced in #2860.