### PR TITLE
Use typename keyword within template statements

### DIFF
--- a/Empire/Diplomacy.h
+++ b/Empire/Diplomacy.h
@@ -36,7 +36,7 @@ private:
     DiplomaticMessageType   m_type;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 

--- a/Empire/Empire.h
+++ b/Empire/Empire.h
@@ -463,7 +463,7 @@ private:
 
     friend class boost::serialization::access;
     Empire();
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 

--- a/Empire/EmpireManager.h
+++ b/Empire/EmpireManager.h
@@ -106,7 +106,7 @@ private:
     friend class ServerApp;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 

--- a/Empire/PopulationPool.h
+++ b/Empire/PopulationPool.h
@@ -33,11 +33,11 @@ private:
     float               m_population = 0.0f;    ///< total population of all PopCenters in pool
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
-template <class Archive>
+template <typename Archive>
 void PopulationPool::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_NVP(m_pop_center_ids);

--- a/Empire/ProductionQueue.h
+++ b/Empire/ProductionQueue.h
@@ -45,7 +45,7 @@ struct FO_COMMON_API ProductionQueue {
 
     private:
         friend class boost::serialization::access;
-        template <class Archive>
+        template <typename Archive>
         void serialize(Archive& ar, const unsigned int version);
     };
 
@@ -92,7 +92,7 @@ struct FO_COMMON_API ProductionQueue {
 
     private:
         friend class boost::serialization::access;
-        template <class Archive>
+        template <typename Archive>
         void serialize(Archive& ar, const unsigned int version);
     };
 
@@ -185,7 +185,7 @@ private:
     int                             m_empire_id = ALL_EMPIRES;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 

--- a/Empire/ResearchQueue.h
+++ b/Empire/ResearchQueue.h
@@ -33,7 +33,7 @@ struct FO_COMMON_API ResearchQueue {
         bool        paused = false;
     private:
         friend class boost::serialization::access;
-        template <class Archive>
+        template <typename Archive>
         void serialize(Archive& ar, const unsigned int version);
     };
 
@@ -99,7 +99,7 @@ private:
     int         m_empire_id = ALL_EMPIRES;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 

--- a/Empire/ResourcePool.h
+++ b/Empire/ResourcePool.h
@@ -65,7 +65,7 @@ private:
     ResourceType                    m_type;                                             ///< what kind of resource does this pool hold?
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -73,7 +73,7 @@ private:
 BOOST_CLASS_VERSION(ResourcePool, 1)
 
 // template implementations
-template <class Archive>
+template <typename Archive>
 void ResourcePool::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_NVP(m_type)

--- a/Empire/Supply.h
+++ b/Empire/Supply.h
@@ -116,7 +116,7 @@ private:
 
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 

--- a/GG/GG/Base.h
+++ b/GG/GG/Base.h
@@ -47,11 +47,11 @@ namespace GG {
 
 extern GG_API const bool INSTRUMENT_ALL_SIGNALS;
 
-template <class FlagType>
+template <typename FlagType>
 class Flags;
 class ModKey;
 
-template <class T>
+template <typename T>
 class ScopedAssign
 {
 public:

--- a/GG/GG/Enum.h
+++ b/GG/GG/Enum.h
@@ -46,7 +46,7 @@ namespace GG {
     /** This class is not meant for public consumption.
       * Access this class through the functions generated
       * in the GG_ENUM or GG_CLASS_ENUM macro invocation. */
-    template <class EnumType>
+    template <typename EnumType>
     class EnumMap {
     public:
         const std::string& operator[](EnumType value) const;
@@ -64,7 +64,7 @@ namespace GG {
     /** Do not call this function directly.
       * Instead, rely on the functions generated
       * by the GG_ENUM or GG_CLASS_ENUM macro invocations. */
-    template <class EnumType>
+    template <typename EnumType>
     EnumMap<EnumType>& GetEnumMap() {
         static EnumMap<EnumType> map;
         return map;
@@ -73,7 +73,7 @@ namespace GG {
     /** Do not call this function directly.
       * Instead, rely on the functions generated
       * by the GG_ENUM or GG_CLASS_ENUM macro invocations. */
-    template <class EnumType>
+    template <typename EnumType>
     void BuildEnumMap(EnumMap<EnumType>& map, const std::string& enum_name, const char* comma_separated_names) {
         std::stringstream name_stream(comma_separated_names);
 
@@ -145,7 +145,7 @@ namespace GG {
       /////////////
      // EnumMap //
     /////////////
-    template <class EnumType>
+    template <typename EnumType>
     const std::string& EnumMap<EnumType>::operator[](EnumType value) const {
         auto it = m_value_to_name_map.find(value);
         if (it != m_value_to_name_map.end()) {
@@ -156,7 +156,7 @@ namespace GG {
         }
     }
 
-    template <class EnumType>
+    template <typename EnumType>
     EnumType EnumMap<EnumType>::operator[](const std::string& name) const {
         auto it = m_name_to_value_map.find(name);
         if (it != m_name_to_value_map.end()) {
@@ -166,12 +166,12 @@ namespace GG {
         }
     }
 
-    template <class EnumType>
+    template <typename EnumType>
     size_t EnumMap<EnumType>::size() const {
         return m_name_to_value_map.size();
     }
 
-    template <class EnumType>
+    template <typename EnumType>
     void EnumMap<EnumType>::Insert(int& default_value, const std::string& entry) {
         std::stringstream name_and_value(entry);
 

--- a/GG/GG/Flags.h
+++ b/GG/GG/Flags.h
@@ -57,7 +57,7 @@ namespace detail {
 
 /** \brief Metafunction predicate that evaluates as true iff \a T is a GG flag
     type, declared by using GG_FLAG_TYPE. */
-template <class T>
+template <typename T>
 struct is_flag_type : std::false_type {};
 
 
@@ -142,7 +142,7 @@ struct is_flag_type : std::false_type {};
     unloaded.  \note All user-instantiated FlagSpecs must provide their own
     implementations of the instance() static function (all the GG-provided
     FlagSpec instantiations provide such implementations already). */
-template <class FlagType>
+template <typename FlagType>
 class GG_API FlagSpec
 {
 public:
@@ -257,17 +257,17 @@ private:
 };
 
 
-template <class FlagType>
+template <typename FlagType>
 class Flags;
 
-template <class FlagType>
+template <typename FlagType>
 std::ostream& operator<<(std::ostream& os, Flags<FlagType> flags);
 
 /** \brief A set of flags of the same type.
 
     Individual flags and sets of flags can be passed as parameters and/or be
     stored as member variables in Flags objects. */
-template <class FlagType>
+template <typename FlagType>
 class Flags
 {
 private:
@@ -351,7 +351,7 @@ private:
 };
 
 /** Writes \a flags to \a os in the format "flag1 | flag2 | ... flagn". */
-template <class FlagType>
+template <typename FlagType>
 std::ostream& operator<<(std::ostream& os, Flags<FlagType> flags)
 {
     unsigned int flags_data = flags.m_flags;
@@ -370,7 +370,7 @@ std::ostream& operator<<(std::ostream& os, Flags<FlagType> flags)
 
 /** Returns a Flags object that consists of the bitwise-or of \a lhs and \a
     rhs. */
-template <class FlagType>
+template <typename FlagType>
 Flags<FlagType> operator|(Flags<FlagType> lhs, Flags<FlagType> rhs)
 {
     Flags<FlagType> retval(lhs);
@@ -380,19 +380,19 @@ Flags<FlagType> operator|(Flags<FlagType> lhs, Flags<FlagType> rhs)
 
 /** Returns a Flags object that consists of the bitwise-or of \a lhs and \a
     rhs. */
-template <class FlagType>
+template <typename FlagType>
 Flags<FlagType> operator|(Flags<FlagType> lhs, FlagType rhs)
 { return lhs | Flags<FlagType>(rhs); }
 
 /** Returns a Flags object that consists of the bitwise-or of \a lhs and \a
     rhs. */
-template <class FlagType>
+template <typename FlagType>
 Flags<FlagType> operator|(FlagType lhs, Flags<FlagType> rhs)
 { return Flags<FlagType>(lhs) | rhs; }
 
 /** Returns a Flags object that consists of the bitwise-or of \a lhs and \a
     rhs. */
-template <class FlagType>
+template <typename FlagType>
 typename std::enable_if<
     is_flag_type<FlagType>::value,
     Flags<FlagType>
@@ -402,7 +402,7 @@ operator|(FlagType lhs, FlagType rhs)
 
 /** Returns a Flags object that consists of the bitwise-and of \a lhs and \a
     rhs. */
-template <class FlagType>
+template <typename FlagType>
 Flags<FlagType> operator&(Flags<FlagType> lhs, Flags<FlagType> rhs)
 {
     Flags<FlagType> retval(lhs);
@@ -412,19 +412,19 @@ Flags<FlagType> operator&(Flags<FlagType> lhs, Flags<FlagType> rhs)
 
 /** Returns a Flags object that consists of the bitwise-and of \a lhs and \a
     rhs. */
-template <class FlagType>
+template <typename FlagType>
 Flags<FlagType> operator&(Flags<FlagType> lhs, FlagType rhs)
 { return lhs & Flags<FlagType>(rhs); }
 
 /** Returns a Flags object that consists of the bitwise-and of \a lhs and \a
     rhs. */
-template <class FlagType>
+template <typename FlagType>
 Flags<FlagType> operator&(FlagType lhs, Flags<FlagType> rhs)
 { return Flags<FlagType>(lhs) & rhs; }
 
 /** Returns a Flags object that consists of the bitwise-and of \a lhs and \a
     rhs. */
-template <class FlagType>
+template <typename FlagType>
 typename std::enable_if<
     is_flag_type<FlagType>::value,
     Flags<FlagType>
@@ -434,7 +434,7 @@ operator&(FlagType lhs, FlagType rhs)
 
 /** Returns a Flags object that consists of the bitwise-xor of \a lhs and \a
     rhs. */
-template <class FlagType>
+template <typename FlagType>
 Flags<FlagType> operator^(Flags<FlagType> lhs, Flags<FlagType> rhs)
 {
     Flags<FlagType> retval(lhs);
@@ -444,19 +444,19 @@ Flags<FlagType> operator^(Flags<FlagType> lhs, Flags<FlagType> rhs)
 
 /** Returns a Flags object that consists of the bitwise-xor of \a lhs and \a
     rhs. */
-template <class FlagType>
+template <typename FlagType>
 Flags<FlagType> operator^(Flags<FlagType> lhs, FlagType rhs)
 { return lhs ^ Flags<FlagType>(rhs); }
 
 /** Returns a Flags object that consists of the bitwise-xor of \a lhs and \a
     rhs. */
-template <class FlagType>
+template <typename FlagType>
 Flags<FlagType> operator^(FlagType lhs, Flags<FlagType> rhs)
 { return Flags<FlagType>(lhs) ^ rhs; }
 
 /** Returns a Flags object that consists of the bitwise-xor of \a lhs and \a
     rhs. */
-template <class FlagType>
+template <typename FlagType>
 typename std::enable_if<
     is_flag_type<FlagType>::value,
     Flags<FlagType>
@@ -466,7 +466,7 @@ operator^(FlagType lhs, FlagType rhs)
 
 /** Returns a Flags object that consists of all the flags known to
     FlagSpec<FlagType>::instance() except those in \a flags. */
-template <class FlagType>
+template <typename FlagType>
 Flags<FlagType> operator~(Flags<FlagType> flags)
 {
     Flags<FlagType> retval;
@@ -479,7 +479,7 @@ Flags<FlagType> operator~(Flags<FlagType> flags)
 
 /** Returns a Flags object that consists of all the flags known to
     FlagSpec<FlagType>::instance() except \a flag. */
-template <class FlagType>
+template <typename FlagType>
 typename std::enable_if<
     is_flag_type<FlagType>::value,
     Flags<FlagType>

--- a/GG/GG/Font.h
+++ b/GG/GG/Font.h
@@ -467,7 +467,7 @@ public:
         UnicodeCharsets in the range [first, last).  \throw Font::Exception
         Throws a subclass of Font::Exception if the condition specified for
         the subclass is met. */
-    template <class CharSetIter>
+    template <typename CharSetIter>
     Font(const std::string& font_filename, unsigned int pts,
          CharSetIter first, CharSetIter last);
 
@@ -476,7 +476,7 @@ public:
         contents \a file_contents.  \throw Font::Exception Throws a subclass
         of Font::Exception if the condition specified for the subclass is
         met. */
-    template <class CharSetIter>
+    template <typename CharSetIter>
     Font(const std::string& font_filename, unsigned int pts,
          const std::vector<unsigned char>& file_contents,
          CharSetIter first, CharSetIter last);
@@ -800,7 +800,7 @@ public:
 
     /** Returns true iff this manager contains a font with the given filename
         and point size, containing the given charsets. */
-    template <class CharSetIter>
+    template <typename CharSetIter>
     bool HasFont(const std::string& font_filename, unsigned int pts,
                  CharSetIter first, CharSetIter last) const;
     //@}
@@ -820,7 +820,7 @@ public:
     /** Returns a shared_ptr to the requested font, supporting all the
         code points in the UnicodeCharsets in the range [first, last).  \note
         May load font if unavailable at time of request. */
-    template <class CharSetIter>
+    template <typename CharSetIter>
     std::shared_ptr<Font> GetFont(const std::string& font_filename, unsigned int pts,
                                   CharSetIter first, CharSetIter last);
 
@@ -828,7 +828,7 @@ public:
         points in the UnicodeCharsets in the range [first, last), from the
         in-memory contents \a file_contents.  \note May load font if
         unavailable at time of request. */
-    template <class CharSetIter>
+    template <typename CharSetIter>
     std::shared_ptr<Font> GetFont(const std::string& font_filename, unsigned int pts,
                                   const std::vector<unsigned char>& file_contents,
                                   CharSetIter first, CharSetIter last);
@@ -840,7 +840,7 @@ public:
 
 private:
     FontManager();
-    template <class CharSetIter>
+    template <typename CharSetIter>
     std::shared_ptr<Font> GetFontImpl(const std::string& font_filename, unsigned int pts,
                                       const std::vector<unsigned char>* file_contents,
                                       CharSetIter first, CharSetIter last);
@@ -859,17 +859,17 @@ GG_API FontManager& GetFontManager();
 GG_EXCEPTION(FailedFTLibraryInit);
 
 namespace detail {
-    template <class CharT, bool CharIsSigned = boost::is_signed<CharT>::value>
+    template <typename CharT, bool CharIsSigned = boost::is_signed<CharT>::value>
     struct ValidUTFChar;
 
-    template <class CharT>
+    template <typename CharT>
     struct ValidUTFChar<CharT, true>
     {
         bool operator()(CharT c)
             { return 0x0 <= c; }
     };
 
-    template <class CharT>
+    template <typename CharT>
     struct ValidUTFChar<CharT, false>
     {
         bool operator()(CharT c)
@@ -888,7 +888,7 @@ namespace detail {
 
 
 // template implementations
-template <class CharSetIter>
+template <typename CharSetIter>
 GG::Font::Font(const std::string& font_filename, unsigned int pts,
                CharSetIter first, CharSetIter last) :
     m_font_filename(font_filename),
@@ -913,7 +913,7 @@ GG::Font::Font(const std::string& font_filename, unsigned int pts,
     }
 }
 
-template <class CharSetIter>
+template <typename CharSetIter>
 GG::Font::Font(const std::string& font_filename, unsigned int pts,
                const std::vector<unsigned char>& file_contents,
                CharSetIter first, CharSetIter last) :
@@ -938,7 +938,7 @@ GG::Font::Font(const std::string& font_filename, unsigned int pts,
     Init(wrapper.m_face);
 }
 
-template <class CharSetIter>
+template <typename CharSetIter>
 bool GG::FontManager::HasFont(const std::string& font_filename, unsigned int pts,
                               CharSetIter first, CharSetIter last) const
 {
@@ -954,13 +954,13 @@ bool GG::FontManager::HasFont(const std::string& font_filename, unsigned int pts
     return retval;
 }
 
-template <class CharSetIter>
+template <typename CharSetIter>
 std::shared_ptr<GG::Font>
 GG::FontManager::GetFont(const std::string& font_filename, unsigned int pts,
                          CharSetIter first, CharSetIter last)
 { return GetFontImpl(font_filename, pts, nullptr, first, last); }
 
-template <class CharSetIter>
+template <typename CharSetIter>
 std::shared_ptr<GG::Font>
 GG::FontManager::GetFont(const std::string& font_filename, unsigned int pts,
                          const std::vector<unsigned char>& file_contents,
@@ -968,7 +968,7 @@ GG::FontManager::GetFont(const std::string& font_filename, unsigned int pts,
 { return GetFontImpl(font_filename, pts, &file_contents, first, last); }
 
 
-template <class CharSetIter>
+template <typename CharSetIter>
 std::shared_ptr<GG::Font>
 GG::FontManager::GetFontImpl(const std::string& font_filename, unsigned int pts,
                              const std::vector<unsigned char>* file_contents,

--- a/GG/GG/GGFwd.h
+++ b/GG/GG/GGFwd.h
@@ -45,7 +45,7 @@ namespace GG {
 
     typedef TextControl Label;
 
-    template <class T>
+    template <typename T>
     class Spin;
 }
 

--- a/GG/GG/GLClientAndServerBuffer.h
+++ b/GG/GG/GLClientAndServerBuffer.h
@@ -34,7 +34,7 @@ protected:
 // GLClientAndServerBufferBase
 // template class for buffers with different types of content
 ///////////////////////////////////////////////////////////////////////////
-template <class vtype> 
+template <typename vtype>
 class GG_API GLClientAndServerBufferBase : public GLBufferBase
 {
 private:

--- a/GG/GG/GUI.h
+++ b/GG/GG/GUI.h
@@ -126,7 +126,7 @@ private:
     struct OrCombiner
     {
         typedef bool result_type; 
-        template<class InIt> bool operator()(InIt first, InIt last) const;
+        template <typename InIt> bool operator()(InIt first, InIt last) const;
     };
 
 public:
@@ -330,14 +330,14 @@ public:
 
     /** Returns a shared_ptr to the desired font, supporting all the
         characters in the UnicodeCharsets in the range [first, last). */
-    template <class CharSetIter>
+    template <typename CharSetIter>
     std::shared_ptr<Font> GetFont(const std::string& font_filename, unsigned int pts,
                                   CharSetIter first, CharSetIter last);
 
     /** Returns a shared_ptr to the desired font, supporting all the
         characters in the UnicodeCharsets in the range [first, last), from the
         in-memory contents \a file_contents. */
-    template <class CharSetIter>
+    template <typename CharSetIter>
     std::shared_ptr<Font> GetFont(const std::string& font_filename, unsigned int pts,
                                   const std::vector<unsigned char>& file_contents,
                                   CharSetIter first, CharSetIter last);
@@ -491,7 +491,7 @@ GG_API Flags<ModKey> MassagedAccelModKeys(Flags<ModKey> mod_keys);
 
 
 // template implementations
-template<class InIt> 
+template <typename InIt>
 bool GUI::OrCombiner::operator()(InIt first, InIt last) const
 {
     bool retval = false;
@@ -500,12 +500,12 @@ bool GUI::OrCombiner::operator()(InIt first, InIt last) const
     return retval;
 }
 
-template <class CharSetIter>
+template <typename CharSetIter>
 std::shared_ptr<Font> GUI::GetFont(const std::string& font_filename, unsigned int pts,
                                    CharSetIter first, CharSetIter last)
 { return GetFontManager().GetFont(font_filename, pts, first, last); }
 
-template <class CharSetIter>
+template <typename CharSetIter>
 std::shared_ptr<Font> GUI::GetFont(const std::string& font_filename, unsigned int pts,
                                    const std::vector<unsigned char>& file_contents,
                                    CharSetIter first, CharSetIter last)

--- a/GG/GG/ListBox.h
+++ b/GG/GG/ListBox.h
@@ -488,7 +488,7 @@ public:
 
         If you want to use operator<() with a Row subclass DerivedRow that has
         a custom SortKeyType, use DefaultRowCmp<DerivedRow>. */
-    template <class RowType>
+    template <typename RowType>
     struct DefaultRowCmp
     {
         /** Returns true iff lhs.SortKey( \a column ) < rhs.SortKey( \a column ). */
@@ -662,7 +662,7 @@ private:
 
 
 // template implementations
-template <class RowType>
+template <typename RowType>
 bool GG::ListBox::DefaultRowCmp<RowType>::operator()(const GG::ListBox::Row& lhs, const GG::ListBox::Row& rhs, std::size_t column) const
 {
     return static_cast<const RowType&>(lhs).SortKey(column) < static_cast<const RowType&>(rhs).SortKey(column);

--- a/GG/GG/Slider.h
+++ b/GG/GG/Slider.h
@@ -53,7 +53,7 @@ class WndEvent;
     increase upward by default.  Note that it is acceptable to define a range
     that increases from min to max, or one that decreases from min to max;
     both are legal. */
-template <class T>
+template <typename T>
 class Slider : public Control
 {
 public:
@@ -151,10 +151,10 @@ private:
 };
 
 // template implementations
-template <class T>
+template <typename T>
 const T Slider<T>::INVALID_PAGE_SIZE = std::numeric_limits<T>::max();
 
-template <class T>
+template <typename T>
 Slider<T>::Slider(T min, T max, Orientation orientation,
                   Clr color, int unsigned tab_width, int unsigned line_width/* = 5*/,
                   Flags<WndFlag> flags/* = INTERACTIVE*/) :
@@ -175,7 +175,7 @@ Slider<T>::Slider(T min, T max, Orientation orientation,
     Control::SetColor(color);
 }
 
-template <class T>
+template <typename T>
 void Slider<T>::CompleteConstruction()
 {
     AttachChild(m_tab);
@@ -188,7 +188,7 @@ void Slider<T>::CompleteConstruction()
     }
 }
 
-template <class T>
+template <typename T>
 Pt Slider<T>::MinUsableSize() const
 {
     Pt tab_min = m_tab->MinUsableSize();
@@ -196,31 +196,31 @@ Pt Slider<T>::MinUsableSize() const
               m_orientation == VERTICAL ? Size().y : tab_min.y);
 }
 
-template <class T>
+template <typename T>
 T Slider<T>::Posn() const
 { return m_posn; }
 
-template <class T>
+template <typename T>
 std::pair<T, T> Slider<T>::SliderRange() const
 { return std::pair<T, T>(m_range_min, m_range_max); }
 
-template <class T>
+template <typename T>
 T Slider<T>::PageSize() const
 { return m_page_sz != INVALID_PAGE_SIZE ? m_page_sz : (m_range_max - m_range_min) / 10; }
 
-template <class T>
+template <typename T>
 Orientation Slider<T>::GetOrientation() const
 { return m_orientation; }
 
-template <class T>
+template <typename T>
 unsigned int Slider<T>::TabWidth() const
 { return m_tab_width; }
 
-template <class T>
+template <typename T>
 unsigned int Slider<T>::LineWidth() const
 { return m_line_width; }
 
-template <class T>
+template <typename T>
 void Slider<T>::Render()
 {
     const Pt UL = UpperLeft();
@@ -242,7 +242,7 @@ void Slider<T>::Render()
     FlatRectangle(ul, lr, color_to_use, CLR_BLACK, 1);
 }
 
-template <class T>
+template <typename T>
 void Slider<T>::SizeMove(const Pt& ul, const Pt& lr)
 {
     Wnd::SizeMove(ul, lr);
@@ -253,21 +253,21 @@ void Slider<T>::SizeMove(const Pt& ul, const Pt& lr)
     MoveTabToPosn();
 }
 
-template <class T>
+template <typename T>
 void Slider<T>::Disable(bool b/* = true*/)
 {
     Control::Disable(b);
     m_tab->Disable(b);
 }
 
-template <class T>
+template <typename T>
 void Slider<T>::SetColor(Clr c)
 {
     Control::SetColor(c);
     m_tab->SetColor(c);
 }
 
-template <class T>
+template <typename T>
 void Slider<T>::SizeSlider(T min, T max)
 {
     assert(m_range_min != m_range_max);
@@ -281,27 +281,27 @@ void Slider<T>::SizeSlider(T min, T max)
         MoveTabToPosn();
 }
 
-template <class T>
+template <typename T>
 void Slider<T>::SetMax(T max)
 { SizeSlider(m_range_min, max); }
 
-template <class T>
+template <typename T>
 void Slider<T>::SetMin(T min)
 { SizeSlider(min, m_range_max); }
 
-template <class T>
+template <typename T>
 void Slider<T>::SlideTo(T p)
 { SlideToImpl(p, false); }
 
-template <class T>
+template <typename T>
 void Slider<T>::SetPageSize(T size)
 { m_page_sz = size; }
 
-template <class T>
+template <typename T>
 Button* Slider<T>::Tab() const
 { return m_tab.get(); }
 
-template <class T>
+template <typename T>
 T Slider<T>::PtToPosn(const Pt& pt) const
 {
     Pt ul = UpperLeft(), lr = LowerRight();
@@ -321,11 +321,11 @@ T Slider<T>::PtToPosn(const Pt& pt) const
     return m_range_min + static_cast<T>((m_range_max - m_range_min) * fractional_distance);
 }
 
-template <class T>
+template <typename T>
 void Slider<T>::LClick(const Pt& pt, Flags<ModKey> mod_keys)
 { SlideToImpl(m_posn < PtToPosn(pt) ? m_posn + PageSize() : m_posn - PageSize(), true); }
 
-template <class T>
+template <typename T>
 void Slider<T>::KeyPress(Key key, std::uint32_t key_code_point, Flags<ModKey> mod_keys)
 {
     if (!Disabled()) {
@@ -367,7 +367,7 @@ void Slider<T>::KeyPress(Key key, std::uint32_t key_code_point, Flags<ModKey> mo
     }
 }
 
-template <class T>
+template <typename T>
 bool Slider<T>::EventFilter(Wnd* w, const WndEvent& event)
 {
     if (w == m_tab.get()) {
@@ -406,7 +406,7 @@ bool Slider<T>::EventFilter(Wnd* w, const WndEvent& event)
     return false;
 }
 
-template <class T>
+template <typename T>
 void Slider<T>::MoveTabToPosn()
 {
     assert((m_range_min <= m_posn && m_posn <= m_range_max) ||
@@ -421,7 +421,7 @@ void Slider<T>::MoveTabToPosn()
         m_tab->MoveTo(Pt(X(pixel_distance), m_tab->RelativeUpperLeft().y));
 }
 
-template <class T>
+template <typename T>
 void Slider<T>::UpdatePosn()
 {
     T old_posn = m_posn;
@@ -433,7 +433,7 @@ void Slider<T>::UpdatePosn()
         SlidSignal(m_posn, m_range_min, m_range_max);
 }
 
-template <class T>
+template <typename T>
 void Slider<T>::SlideToImpl(T p, bool signal)
 {
     T old_posn = m_posn;
@@ -450,12 +450,12 @@ void Slider<T>::SlideToImpl(T p, bool signal)
     }
 }
 
-template <class T>
+template <typename T>
 Slider<T>::SlidEcho::SlidEcho(const std::string& name) :
     m_name(name)
 {}
 
-template <class T>
+template <typename T>
 void Slider<T>::SlidEcho::operator()(T pos, T min, T max)
 {
     std::cerr << "GG SIGNAL : " << m_name

--- a/GG/GG/Spin.h
+++ b/GG/GG/Spin.h
@@ -44,8 +44,8 @@ namespace GG {
 
 // forward declaration of helper functions and classes
 namespace spin_details {
-    template <class T> T mod(T, T);
-    template <class T> T div(T, T);
+    template <typename T> T mod(T, T);
+    template <typename T> T div(T, T);
 }
 
 
@@ -68,7 +68,7 @@ namespace spin_details {
     at arbitrary sizes, and note that Spin buttons are always H wide by H/2
     tall, where H is the height of the Spin, less the thickness of the Spin's
     border. */
-template <class T>
+template <typename T>
 class Spin : public Control
 {
 public:
@@ -172,7 +172,7 @@ private:
 
 
 // template implementations
-template<class T>
+template <typename T>
 Spin<T>::Spin(T value, T step, T min, T max, bool edits, const std::shared_ptr<Font>& font, Clr color,
               Clr text_color/* = CLR_BLACK*/) :
     Control(X0, Y0, X1, font->Height() + 2 * PIXEL_MARGIN, INTERACTIVE),
@@ -193,7 +193,7 @@ Spin<T>::Spin(T value, T step, T min, T max, bool edits, const std::shared_ptr<F
         ValueChangedSignal.connect(&ValueChangedEcho);
 }
 
-template<class T>
+template <typename T>
 void Spin<T>::CompleteConstruction()
 {
     const auto& style = GetStyleFactory();
@@ -208,11 +208,11 @@ void Spin<T>::CompleteConstruction()
     Spin<T>::SetEditTextFromValue();
 }
 
-template<class T>
+template <typename T>
 Spin<T>::~Spin()
 {}
 
-template<class T>
+template <typename T>
 Pt Spin<T>::MinUsableSize() const
 {
     Pt edit_min = m_edit->MinUsableSize();
@@ -222,47 +222,47 @@ Pt Spin<T>::MinUsableSize() const
               std::max(up_min.y + down_min.y, edit_min.y) + 2 * BORDER_THICK);
 }
 
-template<class T>
+template <typename T>
 T Spin<T>::Value() const
 { return m_value; }
 
-template<class T>
+template <typename T>
 T Spin<T>::StepSize() const
 { return m_step_size; }
 
-template<class T>
+template <typename T>
 T Spin<T>::MinValue() const
 { return m_min_value; }
 
-template<class T>
+template <typename T>
 T Spin<T>::MaxValue() const
 { return m_max_value; }
 
-template<class T>
+template <typename T>
 bool Spin<T>::Editable() const 
 { return m_editable; }
 
-template<class T>
+template <typename T>
 X Spin<T>::ButtonWidth() const
 { return m_button_width; }
 
-template<class T>
+template <typename T>
 Clr Spin<T>::TextColor() const
 { return m_edit->TextColor(); }
 
-template<class T>
+template <typename T>
 Clr Spin<T>::InteriorColor() const
 { return m_edit->InteriorColor(); }
 
-template<class T>
+template <typename T>
 Clr Spin<T>::HiliteColor() const
 { return m_edit->HiliteColor(); }
 
-template<class T>
+template <typename T>
 Clr Spin<T>::SelectedTextColor() const
 { return m_edit->SelectedTextColor(); }
 
-template<class T>
+template <typename T>
 void Spin<T>::Render()
 {
     Clr color_to_use = Disabled() ? DisabledColor(Color()) : Color();
@@ -271,7 +271,7 @@ void Spin<T>::Render()
     BeveledRectangle(ul, lr, int_color_to_use, color_to_use, false, BORDER_THICK);
 }
 
-template<class T>
+template <typename T>
 void Spin<T>::SizeMove(const Pt& ul, const Pt& lr)
 {
     Wnd::SizeMove(ul, lr);
@@ -284,7 +284,7 @@ void Spin<T>::SizeMove(const Pt& ul, const Pt& lr)
                             Pt(BUTTON_X_POS + m_button_width, BORDER_THICK + BUTTONS_HEIGHT));
 }
 
-template<class T>
+template <typename T>
 void Spin<T>::Disable(bool b/* = true*/)
 {
     Control::Disable(b);
@@ -293,7 +293,7 @@ void Spin<T>::Disable(bool b/* = true*/)
     m_down_button->Disable(b);
 }
 
-template<class T>
+template <typename T>
 void Spin<T>::SetColor(Clr c)
 {
     Control::SetColor(c);
@@ -301,26 +301,26 @@ void Spin<T>::SetColor(Clr c)
     m_down_button->SetColor(c);
 }
 
-template<class T>
+template <typename T>
 void Spin<T>::Incr()
 { SetValueImpl(m_value + m_step_size, false); }
 
-template<class T>
+template <typename T>
 void Spin<T>::Decr()
 { SetValueImpl(m_value - m_step_size, false); }
 
-template<class T>
+template <typename T>
 void Spin<T>::SetValue(T value)
 { SetValueImpl(value, false); }
 
-template<class T>
+template <typename T>
 void Spin<T>::SetStepSize(T step)
 {
     m_step_size = step;
     SetValue(m_value);
 }
 
-template<class T>
+template <typename T>
 void Spin<T>::SetMinValue(T value)
 {
     m_min_value = value;
@@ -328,7 +328,7 @@ void Spin<T>::SetMinValue(T value)
         SetValue(m_min_value);
 }
 
-template<class T>
+template <typename T>
 void Spin<T>::SetMaxValue(T value)
 {
     m_max_value = value;
@@ -336,11 +336,11 @@ void Spin<T>::SetMaxValue(T value)
         SetValue(m_max_value);
 }
 
-template<class T>
+template <typename T>
 void Spin<T>::SetTextColor(Clr c)
 { m_edit->SetTextColor(c); }
 
-template<class T>
+template <typename T>
 void Spin<T>::SetButtonWidth(X width)
 {
     if (1 <= width) {
@@ -351,31 +351,31 @@ void Spin<T>::SetButtonWidth(X width)
     }
 }
 
-template<class T>
+template <typename T>
 void Spin<T>::SetInteriorColor(Clr c)
 { m_edit->SetInteriorColor(c); }
 
-template<class T>
+template <typename T>
 void Spin<T>::SetHiliteColor(Clr c)
 { m_edit->SetHiliteColor(c); }
 
-template<class T>
+template <typename T>
 void Spin<T>::SetSelectedTextColor(Clr c)
 { m_edit->SetSelectedTextColor(c); }
 
-template<class T>
+template <typename T>
 Button* Spin<T>::UpButton() const
 { return m_up_button.get(); }
 
-template<class T>
+template <typename T>
 Button* Spin<T>::DownButton() const
 { return m_down_button.get(); }
 
-template<class T>
+template <typename T>
 Edit* Spin<T>::GetEdit() const
 { return m_edit.get(); }
 
-template<class T>
+template <typename T>
 void Spin<T>::KeyPress(Key key, std::uint32_t key_code_point, Flags<ModKey> mod_keys)
 {
     if (Disabled()) {
@@ -405,7 +405,7 @@ void Spin<T>::KeyPress(Key key, std::uint32_t key_code_point, Flags<ModKey> mod_
     }
 }
 
-template<class T>
+template <typename T>
 void Spin<T>::MouseWheel(const Pt& pt, int move, Flags<ModKey> mod_keys)
 {
     if (Disabled()) {
@@ -419,7 +419,7 @@ void Spin<T>::MouseWheel(const Pt& pt, int move, Flags<ModKey> mod_keys)
         DecrImpl(true);
 }
 
-template<class T>
+template <typename T>
 bool Spin<T>::EventFilter(Wnd* w, const WndEvent& event)
 {
     if (w == m_edit.get()) {
@@ -433,14 +433,14 @@ bool Spin<T>::EventFilter(Wnd* w, const WndEvent& event)
     return false;
 }
 
-template<class T>
+template <typename T>
 void Spin<T>::SetEditTextFromValue()
 {
     if (m_edit)
         m_edit->SetText(std::to_string(m_value));
 }
 
-template<class T>
+template <typename T>
 void Spin<T>::ConnectSignals()
 {
     m_edit->FocusUpdateSignal.connect(
@@ -451,7 +451,7 @@ void Spin<T>::ConnectSignals()
         boost::bind(&Spin::DecrImpl, this, true));
 }
 
-template<class T>
+template <typename T>
 void Spin<T>::ValueUpdated(const std::string& val_text)
 {
     T value;
@@ -464,15 +464,15 @@ void Spin<T>::ValueUpdated(const std::string& val_text)
     SetValueImpl(value, true);
 }
 
-template<class T>
+template <typename T>
 void Spin<T>::IncrImpl(bool signal)
 { SetValueImpl(static_cast<T>(m_value + m_step_size), signal); }
 
-template<class T>
+template <typename T>
 void Spin<T>::DecrImpl(bool signal)
 { SetValueImpl(static_cast<T>(m_value - m_step_size), signal); }
 
-template<class T>
+template <typename T>
 void Spin<T>::SetValueImpl(T value, bool signal)
 {
     //std::cout << "Spin<T>::SetValueImpl(" << value << ", " << signal << ")" << std::endl;
@@ -507,15 +507,15 @@ void Spin<T>::SetValueImpl(T value, bool signal)
         ValueChangedSignal(m_value);
 }
 
-template <class T>
+template <typename T>
 void Spin<T>::ValueChangedEcho(const T& value)
 { std::cerr << "GG SIGNAL : Spin<>::ValueChangedSignal(value=" << value << ")\n"; }
 
 
 namespace spin_details {
     // provides a typesafe mod function
-    template <class T> inline
-    T mod (T dividend, T divisor) {return static_cast<T>(dividend % divisor);}
+    template <typename T>
+    inline T mod (T dividend, T divisor) {return static_cast<T>(dividend % divisor);}
 
     // template specializations
     template <> inline
@@ -526,8 +526,8 @@ namespace spin_details {
     long double mod<long double> (long double dividend, long double divisor) {return std::fmod(dividend, divisor);}
 
     // provides a typesafe div function
-    template <class T> inline 
-    T div (T dividend, T divisor) {return static_cast<T>(dividend / divisor);}
+    template <typename T>
+    inline T div (T dividend, T divisor) {return static_cast<T>(dividend / divisor);}
 
     // template specializations
     template <> inline

--- a/GG/GG/StyleFactory.h
+++ b/GG/GG/StyleFactory.h
@@ -44,7 +44,7 @@ class GroupBox;
 class ListBox;
 class RadioButtonGroup;
 class Scroll;
-template <class T>
+template <typename T>
 class Slider;
 class StateButton;
 class TabBar;

--- a/GG/GG/TextControl.h
+++ b/GG/GG/TextControl.h
@@ -164,7 +164,8 @@ public:
         it cannot perform a requested cast, though >> will return a
         default-constructed T if one cannot be deduced from the control's
         text. */
-    template <class T> void operator>>(T& t) const;
+    template <typename T>
+    void operator>>(T& t) const;
 
     /** Returns the value of the control's text, interpreted as an object of
         type T.  If the control's text can be interpreted as an object of type
@@ -178,7 +179,8 @@ public:
         is handy for validating data in a dialog box; Otherwise, using
         operator>>(), you may get the default value, even though the text in
         the control may not be the default value at all, but garbage. */
-    template <class T> T GetValue() const;
+    template <typename T>
+    T GetValue() const;
 
     /** Returns the control's text; allows TextControl's to be used as
         std::string's. */
@@ -277,7 +279,7 @@ public:
         type is void, so multiple << operations cannot be strung together.
         \throw boost::bad_lexical_cast boost::lexical_cast throws
         boost::bad_lexical_cast when it is confused.*/
-    template <class T>
+    template <typename T>
     void operator<<(T t);
 
     void  operator+=(const std::string& s); ///< Appends \a s to text.
@@ -354,7 +356,7 @@ typedef TextControl Label;
 } // namespace GG
 
 // template implementations
-template <class T>
+template <typename T>
 void GG::TextControl::operator>>(T& t) const
 {
     try {
@@ -364,11 +366,11 @@ void GG::TextControl::operator>>(T& t) const
     }
 }
 
-template <class T>
+template <typename T>
 T GG::TextControl::GetValue() const
 { return boost::lexical_cast<T, std::string>(m_text); }
 
-template <class T>
+template <typename T>
 void GG::TextControl::operator<<(T t)
 { SetText(boost::lexical_cast<std::string>(t)); }
 

--- a/GG/GG/dialogs/ColorDlg.h
+++ b/GG/GG/dialogs/ColorDlg.h
@@ -36,7 +36,7 @@
 namespace GG {
 
 class Font;
-template <class T>
+template <typename T>
 class Slider;
 
 /** \brief Contains the necessary data to represent a color in HSV space, with

--- a/GG/src/Font.cpp
+++ b/GG/src/Font.cpp
@@ -77,7 +77,7 @@ namespace {
     const std::string ALIGN_RIGHT_TAG = "right";
     const std::string PRE_TAG = "pre";
 
-    template <class T>
+    template <typename T>
     T NextPowerOfTwo(T input)
     {
         T value(1);

--- a/GG/src/GLClientAndServerBuffer.cpp
+++ b/GG/src/GLClientAndServerBuffer.cpp
@@ -42,7 +42,7 @@ void GLBufferBase::harmonizeBufferType(GLBufferBase& other)
 ///////////////////////////////////////////////////////////////////////////
 // GLClientAndServerBufferBase<vtype> template
 ///////////////////////////////////////////////////////////////////////////
-template <class vtype>
+template <typename vtype>
 GLClientAndServerBufferBase<vtype>::GLClientAndServerBufferBase(std::size_t elementsPerItem) :
     GLBufferBase(),
     b_data(),
@@ -50,26 +50,26 @@ GLClientAndServerBufferBase<vtype>::GLClientAndServerBufferBase(std::size_t elem
     b_elements_per_item(elementsPerItem)
 {}
 
-template <class vtype>
+template <typename vtype>
 std::size_t GLClientAndServerBufferBase<vtype>::size() const
 { return b_size; }
 
-template <class vtype>
+template <typename vtype>
 bool GLClientAndServerBufferBase<vtype>::empty() const
 { return b_size == 0; }
 
-template <class vtype>
+template <typename vtype>
 void GLClientAndServerBufferBase<vtype>::reserve(std::size_t num_items)
 { b_data.reserve(num_items * b_elements_per_item); }
 
-template <class vtype>
+template <typename vtype>
 void GLClientAndServerBufferBase<vtype>::store(vtype item)
 {
     b_data.push_back(item);
     b_size=b_data.size() / b_elements_per_item;
 }
 
-template <class vtype>
+template <typename vtype>
 void GLClientAndServerBufferBase<vtype>::store(vtype item1, vtype item2)
 {
     b_data.push_back(item1);
@@ -77,7 +77,7 @@ void GLClientAndServerBufferBase<vtype>::store(vtype item1, vtype item2)
     b_size=b_data.size() / b_elements_per_item;
 }
 
-template <class vtype>
+template <typename vtype>
 void GLClientAndServerBufferBase<vtype>::store(vtype item1, vtype item2, vtype item3)
 {
     b_data.push_back(item1);
@@ -86,7 +86,7 @@ void GLClientAndServerBufferBase<vtype>::store(vtype item1, vtype item2, vtype i
     b_size=b_data.size() / b_elements_per_item;
 }
 
-template <class vtype> 
+template <typename vtype>
 void GLClientAndServerBufferBase<vtype>::store(vtype item1, vtype item2, vtype item3, vtype item4)
 {
     b_data.push_back(item1);
@@ -96,7 +96,7 @@ void GLClientAndServerBufferBase<vtype>::store(vtype item1, vtype item2, vtype i
     b_size=b_data.size() / b_elements_per_item;
 }
 
-template <class vtype>
+template <typename vtype>
 void GLClientAndServerBufferBase<vtype>::createServerBuffer()
 {
     glGenBuffers(1, &b_name);
@@ -110,7 +110,8 @@ void GLClientAndServerBufferBase<vtype>::createServerBuffer()
     glBindBuffer(GL_ARRAY_BUFFER, 0);
 }
 
-template <class vtype> void GLClientAndServerBufferBase<vtype>::clear()
+template <typename vtype>
+void GLClientAndServerBufferBase<vtype>::clear()
 {
     dropServerBuffer();
     b_size = 0;

--- a/GG/src/Texture.cpp
+++ b/GG/src/Texture.cpp
@@ -55,7 +55,7 @@
 using namespace GG;
 
 namespace {
-    template <class T>
+    template <typename T>
     T PowerOfTwo(T input)
     {
         T value(1);

--- a/UI/CUISlider.h
+++ b/UI/CUISlider.h
@@ -6,7 +6,7 @@
 #include <GG/Slider.h>
 
 /** a FreeOrion Slider control */
-template <class T>
+template <typename T>
 class CUISlider : public GG::Slider<T>
 {
 public:

--- a/UI/CUISpin.h
+++ b/UI/CUISpin.h
@@ -18,7 +18,7 @@ namespace detail {
 
 
 /** a FreeOrion Spin control */
-template <class T>
+template <typename T>
 class CUISpin : public GG::Spin<T>
 {
 public:
@@ -51,7 +51,7 @@ public:
     //@}
 };
 
-template <class T>
+template <typename T>
 void CUISpin<T>::SetEditTextFromValue()
 { GG::Spin<T>::SetEditTextFromValue(); }
 

--- a/UI/ClientUI.cpp
+++ b/UI/ClientUI.cpp
@@ -575,7 +575,7 @@ namespace {
     const std::string MESSAGE_WND_NAME = "map.messages";
     const std::string PLAYER_LIST_WND_NAME = "map.empires";
 
-    template <class OptionType, class PredicateType>
+    template <typename OptionType, typename PredicateType>
     void ConditionalForward(const std::string& option_name,
                             const OptionsDB::OptionChangedSignalType::slot_type& slot,
                             OptionType ref_val,
@@ -585,7 +585,7 @@ namespace {
             slot();
     }
 
-    template <class OptionType, class PredicateType>
+    template <typename OptionType, typename PredicateType>
     void ConditionalConnectOption(const std::string& option_name,
                                   const OptionsDB::OptionChangedSignalType::slot_type& slot,
                                   OptionType ref_val,

--- a/UI/Hotkeys.h
+++ b/UI/Hotkeys.h
@@ -161,7 +161,7 @@ private:
     const GG::Wnd* target;
 };
 
-template<class W>
+template <typename W>
 class FocusWindowIsA {
 public:
     bool operator()() const {

--- a/UI/ObjectListWnd.cpp
+++ b/UI/ObjectListWnd.cpp
@@ -401,7 +401,7 @@ namespace {
 
     const std::string FILTER_OPTIONS_WND_NAME = "object-list-filter";
 
-    template <class enumT>
+    template <typename enumT>
     std::unique_ptr<ValueRef::ValueRef<enumT>> CopyEnumValueRef(const ValueRef::ValueRef<enumT>* const value_ref) {
         if (auto constant = dynamic_cast<const ValueRef::Constant<enumT>*>(value_ref))
             return std::make_unique<ValueRef::Constant<enumT>>(constant->Value());

--- a/combat/CombatEvent.h
+++ b/combat/CombatEvent.h
@@ -75,7 +75,7 @@ struct FO_COMMON_API CombatEvent {
 
 private:
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 

--- a/combat/CombatEvents.cpp
+++ b/combat/CombatEvents.cpp
@@ -145,7 +145,7 @@ std::string BoutBeginEvent::DebugString() const {
 std::string BoutBeginEvent::CombatLogDescription(int viewing_empire_id) const
 { return str(FlexibleFormat(UserString("ENC_ROUND_BEGIN")) % bout); }
 
-template <class Archive>
+template <typename Archive>
 void BoutBeginEvent::serialize(Archive& ar, const unsigned int version) {
     ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(CombatEvent);
     ar & BOOST_SERIALIZATION_NVP(bout);
@@ -197,7 +197,7 @@ std::vector<ConstCombatEventPtr> BoutEvent::SubEvents(int viewing_empire_id) con
     return all_events;
 }
 
-template <class Archive>
+template <typename Archive>
 void BoutEvent::serialize(Archive& ar, const unsigned int version) {
     ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(CombatEvent);
     ar & BOOST_SERIALIZATION_NVP(bout)
@@ -277,7 +277,7 @@ std::vector<ConstCombatEventPtr> SimultaneousEvents::SubEvents(int viewing_empir
 }
 
 
-template <class Archive>
+template <typename Archive>
 void SimultaneousEvents::serialize(Archive& ar, const unsigned int version) {
     ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(CombatEvent);
     ar & BOOST_SERIALIZATION_NVP(events);
@@ -365,7 +365,7 @@ std::string InitialStealthEvent::CombatLogDescription(int viewing_empire_id) con
     return desc;
 }
 
-template <class Archive>
+template <typename Archive>
 void InitialStealthEvent::serialize(Archive& ar, const unsigned int version) {
     ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(CombatEvent);
     ar & BOOST_SERIALIZATION_NVP(empire_to_object_visibility);
@@ -500,7 +500,7 @@ std::vector<ConstCombatEventPtr> StealthChangeEvent::SubEvents(int viewing_empir
     return all_events;
 }
 
-template <class Archive>
+template <typename Archive>
 void StealthChangeEvent::serialize(Archive& ar, const unsigned int version) {
     ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(CombatEvent);
     ar & BOOST_SERIALIZATION_NVP(bout)
@@ -522,7 +522,7 @@ void StealthChangeEvent::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchiv
 template
 void StealthChangeEvent::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive& ar, const unsigned int version);
 
-template <class Archive>
+template <typename Archive>
 void StealthChangeEvent::StealthChangeEventDetail::serialize(Archive& ar, const unsigned int version) {
     ar  & BOOST_SERIALIZATION_NVP(attacker_id)
         & BOOST_SERIALIZATION_NVP(target_id)
@@ -619,7 +619,7 @@ boost::optional<int> WeaponFireEvent::PrincipalFaction(int viewing_empire_id) co
 }
 
 
-template <class Archive>
+template <typename Archive>
 void WeaponFireEvent::serialize(Archive& ar, const unsigned int version) {
     ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(CombatEvent);
 
@@ -720,7 +720,7 @@ boost::optional<int> IncapacitationEvent::PrincipalFaction(int viewing_empire_id
 { return object_owner_id; }
 
 
-template <class Archive>
+template <typename Archive>
 void IncapacitationEvent::serialize (Archive& ar, const unsigned int version) {
     ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(CombatEvent);
     if (version < 2) {
@@ -825,7 +825,7 @@ std::string FightersAttackFightersEvent::CombatLogDescription(int viewing_empire
 }
 
 
-template <class Archive>
+template <typename Archive>
 void FightersAttackFightersEvent::serialize(Archive& ar, const unsigned int version) {
     ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(CombatEvent);
     ar & BOOST_SERIALIZATION_NVP(bout)
@@ -893,7 +893,7 @@ std::string FighterLaunchEvent::CombatLogDescription(int viewing_empire_id) cons
 boost::optional<int> FighterLaunchEvent::PrincipalFaction(int viewing_empire_id) const
 { return fighter_owner_empire_id; }
 
-template <class Archive>
+template <typename Archive>
 void FighterLaunchEvent::serialize (Archive& ar, const unsigned int version) {
     ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(CombatEvent);
     ar & BOOST_SERIALIZATION_NVP(bout)
@@ -997,7 +997,7 @@ std::string FightersDestroyedEvent::CombatLogDescription(int viewing_empire_id) 
 }
 
 
-template <class Archive>
+template <typename Archive>
 void FightersDestroyedEvent::serialize(Archive& ar, const unsigned int version) {
     ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(CombatEvent);
     ar & BOOST_SERIALIZATION_NVP(bout)
@@ -1122,7 +1122,7 @@ std::vector<ConstCombatEventPtr> WeaponsPlatformEvent::SubEvents(int viewing_emp
 boost::optional<int> WeaponsPlatformEvent::PrincipalFaction(int viewing_empire_id) const
 { return attacker_owner_id; }
 
-template <class Archive>
+template <typename Archive>
 void WeaponsPlatformEvent::serialize(Archive& ar, const unsigned int version) {
     ar & BOOST_SERIALIZATION_BASE_OBJECT_NVP(CombatEvent);
     ar & BOOST_SERIALIZATION_NVP(bout)

--- a/combat/CombatEvents.h
+++ b/combat/CombatEvents.h
@@ -31,7 +31,7 @@ struct FO_COMMON_API BoutBeginEvent : public CombatEvent {
 
 private:
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -62,7 +62,7 @@ private:
     std::vector<CombatEventPtr> events;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -88,7 +88,7 @@ protected:
     std::vector<CombatEventPtr> events;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -119,7 +119,7 @@ private:
     EmpireToObjectVisibilityMap empire_to_object_visibility;// filled by AutoresolveInfo::ReportInvisibleObjects
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -154,7 +154,7 @@ struct FO_COMMON_API StealthChangeEvent : public CombatEvent {
         Visibility visibility;
 
         friend class boost::serialization::access;
-        template <class Archive>
+        template <typename Archive>
         void serialize(Archive& ar, const unsigned int version);
     };
 
@@ -163,7 +163,7 @@ private:
     std::map<int, std::vector<StealthChangeEventDetailPtr>> events;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -206,7 +206,7 @@ struct FO_COMMON_API WeaponFireEvent : public CombatEvent {
 
 private:
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -225,7 +225,7 @@ struct FO_COMMON_API IncapacitationEvent : public CombatEvent {
 
 private:
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -245,7 +245,7 @@ private:
     std::map<std::pair<int, int>, unsigned int> events;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -266,7 +266,7 @@ struct FO_COMMON_API FighterLaunchEvent : public CombatEvent {
 
 private:
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -285,7 +285,7 @@ private:
     std::map<int, unsigned int> events;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -313,7 +313,7 @@ private:
     std::map<int, std::vector<WeaponFireEvent::WeaponFireEventPtr>> events;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 

--- a/combat/CombatLogManager.cpp
+++ b/combat/CombatLogManager.cpp
@@ -89,14 +89,14 @@ CombatLog::CombatLog(const CombatInfo& combat_info) :
     }
 }
 
-template <class Archive>
+template <typename Archive>
 void CombatParticipantState::serialize(Archive& ar, const unsigned int version)
 {
     ar & BOOST_SERIALIZATION_NVP(current_health)
        & BOOST_SERIALIZATION_NVP(max_health);
 }
 
-template <class Archive>
+template <typename Archive>
 void CombatLog::serialize(Archive& ar, const unsigned int version)
 {
     // CombatEvents are serialized only through
@@ -163,7 +163,7 @@ class CombatLogManager::Impl {
 
     /** Serialize log headers so that the receiving LogManager can then request
         complete logs in the background.*/
-    template <class Archive>
+    template <typename Archive>
     void SerializeIncompleteLogs(Archive& ar, const unsigned int version);
     //@}
 
@@ -171,7 +171,7 @@ class CombatLogManager::Impl {
     void SetLog(int log_id, const CombatLog& log);
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 
     private:
@@ -245,7 +245,7 @@ boost::optional<std::vector<int>> CombatLogManager::Impl::IncompleteLogIDs() con
     return ids;
 }
 
-template <class Archive>
+template <typename Archive>
 void CombatLogManager::Impl::SerializeIncompleteLogs(Archive& ar, const unsigned int version)
 {
     int old_latest_log_id = m_latest_log_id;
@@ -258,7 +258,7 @@ void CombatLogManager::Impl::SerializeIncompleteLogs(Archive& ar, const unsigned
             m_incomplete_logs.insert(old_latest_log_id);
 }
 
-template <class Archive>
+template <typename Archive>
 void CombatLogManager::Impl::serialize(Archive& ar, const unsigned int version)
 {
     std::map<int, CombatLog> logs;
@@ -305,7 +305,7 @@ CombatLogManager& CombatLogManager::GetCombatLogManager() {
     return manager;
 }
 
-template <class Archive>
+template <typename Archive>
 void CombatLogManager::SerializeIncompleteLogs(Archive& ar, const unsigned int version)
 { m_impl->SerializeIncompleteLogs(ar, version); }
 
@@ -321,7 +321,7 @@ void CombatLogManager::SerializeIncompleteLogs<freeorion_xml_oarchive>(freeorion
 template
 void CombatLogManager::SerializeIncompleteLogs<freeorion_xml_iarchive>(freeorion_xml_iarchive& ar, const unsigned int version);
 
-template <class Archive>
+template <typename Archive>
 void CombatLogManager::serialize(Archive& ar, const unsigned int version)
 { m_impl->serialize(ar, version); }
 

--- a/combat/CombatLogManager.h
+++ b/combat/CombatLogManager.h
@@ -22,7 +22,7 @@ struct FO_COMMON_API CombatParticipantState {
     CombatParticipantState(const UniverseObject& object);
 private:
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -40,7 +40,7 @@ struct FO_COMMON_API CombatLog {
     std::map<int, CombatParticipantState> participant_states;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -66,7 +66,7 @@ public:
 
     /** Serialize log headers so that the receiving LogManager can then request
         complete logs in the background.*/
-    template <class Archive>
+    template <typename Archive>
     void SerializeIncompleteLogs(Archive& ar, const unsigned int version);
     //@}
 
@@ -81,7 +81,7 @@ private:
     std::unique_ptr<Impl> const m_impl;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 

--- a/combat/CombatSystem.h
+++ b/combat/CombatSystem.h
@@ -53,9 +53,9 @@ private:
     void    InitializeObjectVisibility();
 
     friend class boost::serialization::access;
-    template<class Archive>
+    template <typename Archive>
     void save(Archive & ar, const unsigned int version) const;
-    template<class Archive>
+    template <typename Archive>
     void load(Archive & ar, const unsigned int version);
     BOOST_SERIALIZATION_SPLIT_MEMBER()
 };
@@ -63,7 +63,7 @@ private:
 /** Auto-resolves a battle. */
 void AutoResolveCombat(CombatInfo& combat_info);
 
-template <class Archive>
+template <typename Archive>
 void CombatInfo::save(Archive & ar, const unsigned int version) const
 {
     std::set<int>                       filtered_empire_ids;
@@ -93,7 +93,7 @@ void CombatInfo::save(Archive & ar, const unsigned int version) const
         & BOOST_SERIALIZATION_NVP(filtered_combat_events);
 }
 
-template <class Archive>
+template <typename Archive>
 void CombatInfo::load(Archive & ar, const unsigned int version)
 {
     std::set<int>                       filtered_empire_ids;

--- a/python/EmpireWrapper.cpp
+++ b/python/EmpireWrapper.cpp
@@ -73,7 +73,7 @@ namespace {
 
     const Meter* (Empire::*EmpireGetMeter)(const std::string&) const = &Empire::GetMeter;
 
-    template<class T1, class T2>
+    template<typename T1, typename T2>
     struct PairToTupleConverter {
         static PyObject* convert(const std::pair<T1, T2>& pair) {
             return boost::python::incref(boost::python::make_tuple(pair.first, pair.second).ptr());

--- a/universe/Building.h
+++ b/universe/Building.h
@@ -61,7 +61,7 @@ public:
              int produced_by_empire_id = ALL_EMPIRES);
 
 protected:
-    template <class T> friend void boost::python::detail::value_destroyer<false>::execute(T const volatile* p);
+    template <typename T> friend void boost::python::detail::value_destroyer<false>::execute(T const volatile* p);
 
 public:
     ~Building() {}
@@ -78,7 +78,7 @@ private:
     int         m_produced_by_empire_id = ALL_EMPIRES;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 

--- a/universe/Condition.h
+++ b/universe/Condition.h
@@ -99,7 +99,7 @@ private:
     virtual bool Match(const ScriptingContext& local_context) const;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 

--- a/universe/ConditionAll.h
+++ b/universe/ConditionAll.h
@@ -29,7 +29,7 @@ struct FO_COMMON_API All final : public Condition {
 
 private:
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 

--- a/universe/ConditionSource.h
+++ b/universe/ConditionSource.h
@@ -29,7 +29,7 @@ private:
     bool Match(const ScriptingContext& local_context) const override;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -110,7 +110,7 @@ namespace {
       * \a pred to each object, to test if it should remain in its current set
       * or be transferred from the \a search_domain specified set into the
       * other. */
-    template <class Pred>
+    template <typename Pred>
     void EvalImpl(Condition::ObjectSet& matches, Condition::ObjectSet& non_matches,
                   Condition::SearchDomain search_domain, const Pred& pred)
     {

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -98,7 +98,7 @@ private:
     std::unique_ptr<Condition> m_condition;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -125,7 +125,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<int>> m_high;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -169,7 +169,7 @@ private:
     std::unique_ptr<Condition> m_condition;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -198,7 +198,7 @@ struct FO_COMMON_API None final : public Condition {
 
 private:
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -228,7 +228,7 @@ private:
     EmpireAffiliationType m_affiliation;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -258,7 +258,7 @@ private:
     bool Match(const ScriptingContext& local_context) const override;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -288,7 +288,7 @@ private:
     bool Match(const ScriptingContext& local_context) const override;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -318,7 +318,7 @@ private:
     std::vector<std::unique_ptr<ValueRef::ValueRef<std::string>>> m_names;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -345,7 +345,7 @@ private:
     bool Match(const ScriptingContext& local_context) const override;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -372,7 +372,7 @@ private:
     bool Match(const ScriptingContext& local_context) const override;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -397,7 +397,7 @@ private:
     bool Match(const ScriptingContext& local_context) const override;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -425,7 +425,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<UniverseObjectType>> m_type;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -453,7 +453,7 @@ private:
     std::vector<std::unique_ptr<ValueRef::ValueRef<std::string>>> m_names;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -491,7 +491,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<int>>            m_since_turn_high;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -518,7 +518,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<std::string>> m_name;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -545,7 +545,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<int>> m_high;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -577,7 +577,7 @@ private:
     std::unique_ptr<Condition> m_condition;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -609,7 +609,7 @@ private:
     std::unique_ptr<Condition> m_condition;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -636,7 +636,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<int>> m_system_id;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -663,7 +663,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<int>> m_object_id;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -692,7 +692,7 @@ private:
     std::vector<std::unique_ptr<ValueRef::ValueRef<::PlanetType>>> m_types;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -721,7 +721,7 @@ private:
     std::vector<std::unique_ptr<ValueRef::ValueRef<::PlanetSize>>> m_sizes;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -752,7 +752,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<std::string>> m_species_name;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -782,7 +782,7 @@ private:
     std::vector<std::unique_ptr<ValueRef::ValueRef<std::string>>> m_names;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -824,7 +824,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<int>>            m_high;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -851,7 +851,7 @@ private:
     std::vector<std::unique_ptr<ValueRef::ValueRef<std::string>>> m_names;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -877,7 +877,7 @@ private:
     std::vector<std::unique_ptr<ValueRef::ValueRef<::StarType>>> m_types;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -904,7 +904,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<std::string>> m_name;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -936,7 +936,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<std::string>> m_name;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -968,7 +968,7 @@ private:
     ShipPartClass m_class;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -995,7 +995,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<std::string>> m_name;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -1020,7 +1020,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<int>> m_design_id;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -1045,7 +1045,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<int>> m_empire_id;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -1070,7 +1070,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<double>> m_chance;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -1100,7 +1100,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<double>> m_high;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -1194,7 +1194,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<double>> m_high;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -1222,7 +1222,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<int>>         m_empire_id;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -1251,7 +1251,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<int>>         m_empire_id;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -1280,7 +1280,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<int>> m_empire_id;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -1309,7 +1309,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<int>>         m_empire_id;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -1334,7 +1334,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<int>> m_empire_id;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -1364,7 +1364,7 @@ private:
     std::unique_ptr<Condition> m_condition;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -1394,7 +1394,7 @@ private:
     std::unique_ptr<Condition> m_condition;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -1427,7 +1427,7 @@ private:
     std::unique_ptr<Condition> m_condition;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -1453,7 +1453,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<int>> m_empire_id;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -1479,7 +1479,7 @@ private:
     bool Match(const ScriptingContext& local_context) const override;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -1515,7 +1515,7 @@ private:
     bool m_aggressive;   // false to match passive ships/fleets
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -1541,7 +1541,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<int>> m_empire_id;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -1570,7 +1570,7 @@ private:
     std::unique_ptr<Condition> m_condition;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -1595,7 +1595,7 @@ private:
     bool Match(const ScriptingContext& local_context) const override;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -1620,7 +1620,7 @@ private:
     bool Match(const ScriptingContext& local_context) const override;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -1646,7 +1646,7 @@ private:
     std::unique_ptr<Condition> m_by_object_condition;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -1699,7 +1699,7 @@ private:
     ComparisonType m_compare_type2 = INVALID_COMPARISON;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -1730,7 +1730,7 @@ private:
     ContentType m_content_type;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -1759,7 +1759,7 @@ private:
     ContentType m_content_type;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -1790,7 +1790,7 @@ private:
     std::vector<std::unique_ptr<Condition>> m_operands;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -1817,7 +1817,7 @@ private:
     std::vector<std::unique_ptr<Condition>> m_operands;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -1840,7 +1840,7 @@ private:
     std::unique_ptr<Condition> m_operand;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -1867,7 +1867,7 @@ private:
     std::vector<std::unique_ptr<Condition>> m_operands;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -1897,16 +1897,16 @@ private:
     std::string m_desc_stringtable_key;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
 // template implementations
-template <class Archive>
+template <typename Archive>
 void Condition::serialize(Archive& ar, const unsigned int version)
 {}
 
-template <class Archive>
+template <typename Archive>
 void Number::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
@@ -1915,7 +1915,7 @@ void Number::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_condition);
 }
 
-template <class Archive>
+template <typename Archive>
 void Turn::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
@@ -1923,7 +1923,7 @@ void Turn::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_high);
 }
 
-template <class Archive>
+template <typename Archive>
 void SortedNumberOf::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
@@ -1933,15 +1933,15 @@ void SortedNumberOf::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_condition);
 }
 
-template <class Archive>
+template <typename Archive>
 void All::serialize(Archive& ar, const unsigned int version)
 { ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition); }
 
-template <class Archive>
+template <typename Archive>
 void None::serialize(Archive& ar, const unsigned int version)
 { ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition); }
 
-template <class Archive>
+template <typename Archive>
 void EmpireAffiliation::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
@@ -1949,52 +1949,52 @@ void EmpireAffiliation::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_affiliation);
 }
 
-template <class Archive>
+template <typename Archive>
 void Source::serialize(Archive& ar, const unsigned int version)
 { ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition); }
 
-template <class Archive>
+template <typename Archive>
 void RootCandidate::serialize(Archive& ar, const unsigned int version)
 { ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition); }
 
-template <class Archive>
+template <typename Archive>
 void Target::serialize(Archive& ar, const unsigned int version)
 { ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition); }
 
-template <class Archive>
+template <typename Archive>
 void Homeworld::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
         & BOOST_SERIALIZATION_NVP(m_names);
 }
 
-template <class Archive>
+template <typename Archive>
 void Capital::serialize(Archive& ar, const unsigned int version)
 { ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition); }
 
-template <class Archive>
+template <typename Archive>
 void Monster::serialize(Archive& ar, const unsigned int version)
 { ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition); }
 
-template <class Archive>
+template <typename Archive>
 void Armed::serialize(Archive& ar, const unsigned int version)
 { ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition); }
 
-template <class Archive>
+template <typename Archive>
 void Type::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
         & BOOST_SERIALIZATION_NVP(m_type);
 }
 
-template <class Archive>
+template <typename Archive>
 void Building::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
         & BOOST_SERIALIZATION_NVP(m_names);
 }
 
-template <class Archive>
+template <typename Archive>
 void HasSpecial::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
@@ -2005,14 +2005,14 @@ void HasSpecial::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_since_turn_high);
 }
 
-template <class Archive>
+template <typename Archive>
 void HasTag::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
         & BOOST_SERIALIZATION_NVP(m_name);
 }
 
-template <class Archive>
+template <typename Archive>
 void CreatedOnTurn::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
@@ -2020,49 +2020,49 @@ void CreatedOnTurn::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_high);
 }
 
-template <class Archive>
+template <typename Archive>
 void Contains::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
         & BOOST_SERIALIZATION_NVP(m_condition);
 }
 
-template <class Archive>
+template <typename Archive>
 void ContainedBy::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
         & BOOST_SERIALIZATION_NVP(m_condition);
 }
 
-template <class Archive>
+template <typename Archive>
 void InSystem::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
         & BOOST_SERIALIZATION_NVP(m_system_id);
 }
 
-template <class Archive>
+template <typename Archive>
 void ObjectID::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
         & BOOST_SERIALIZATION_NVP(m_object_id);
 }
 
-template <class Archive>
+template <typename Archive>
 void PlanetType::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
         & BOOST_SERIALIZATION_NVP(m_types);
 }
 
-template <class Archive>
+template <typename Archive>
 void PlanetSize::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
         & BOOST_SERIALIZATION_NVP(m_sizes);
 }
 
-template <class Archive>
+template <typename Archive>
 void PlanetEnvironment::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
@@ -2070,14 +2070,14 @@ void PlanetEnvironment::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_species_name);
 }
 
-template <class Archive>
+template <typename Archive>
 void Species::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
         & BOOST_SERIALIZATION_NVP(m_names);
 }
 
-template <class Archive>
+template <typename Archive>
 void Enqueued::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
@@ -2089,28 +2089,28 @@ void Enqueued::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_high);
 }
 
-template <class Archive>
+template <typename Archive>
 void FocusType::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
         & BOOST_SERIALIZATION_NVP(m_names);
 }
 
-template <class Archive>
+template <typename Archive>
 void StarType::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
         & BOOST_SERIALIZATION_NVP(m_types);
 }
 
-template <class Archive>
+template <typename Archive>
 void DesignHasHull::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
         & BOOST_SERIALIZATION_NVP(m_name);
 }
 
-template <class Archive>
+template <typename Archive>
 void DesignHasPart::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
@@ -2119,7 +2119,7 @@ void DesignHasPart::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_name);
 }
 
-template <class Archive>
+template <typename Archive>
 void DesignHasPartClass::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
@@ -2128,35 +2128,35 @@ void DesignHasPartClass::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_class);
 }
 
-template <class Archive>
+template <typename Archive>
 void PredefinedShipDesign::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
         & BOOST_SERIALIZATION_NVP(m_name);
 }
 
-template <class Archive>
+template <typename Archive>
 void NumberedShipDesign::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
         & BOOST_SERIALIZATION_NVP(m_design_id);
 }
 
-template <class Archive>
+template <typename Archive>
 void ProducedByEmpire::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
         & BOOST_SERIALIZATION_NVP(m_empire_id);
 }
 
-template <class Archive>
+template <typename Archive>
 void Chance::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
         & BOOST_SERIALIZATION_NVP(m_chance);
 }
 
-template <class Archive>
+template <typename Archive>
 void MeterValue::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
@@ -2165,7 +2165,7 @@ void MeterValue::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_high);
 }
 
-template <class Archive>
+template <typename Archive>
 void EmpireStockpileValue::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
@@ -2174,7 +2174,7 @@ void EmpireStockpileValue::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_empire_id);
 }
 
-template <class Archive>
+template <typename Archive>
 void OwnerHasTech::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
@@ -2182,7 +2182,7 @@ void OwnerHasTech::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_empire_id);
 }
 
-template <class Archive>
+template <typename Archive>
 void OwnerHasBuildingTypeAvailable::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
@@ -2190,7 +2190,7 @@ void OwnerHasBuildingTypeAvailable::serialize(Archive& ar, const unsigned int ve
         & BOOST_SERIALIZATION_NVP(m_empire_id);
 }
 
-template <class Archive>
+template <typename Archive>
 void OwnerHasShipDesignAvailable::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
@@ -2198,7 +2198,7 @@ void OwnerHasShipDesignAvailable::serialize(Archive& ar, const unsigned int vers
         & BOOST_SERIALIZATION_NVP(m_empire_id);
 }
 
-template <class Archive>
+template <typename Archive>
 void OwnerHasShipPartAvailable::serialize(Archive& ar,
                                           const unsigned int version)
 {
@@ -2207,14 +2207,14 @@ void OwnerHasShipPartAvailable::serialize(Archive& ar,
         & BOOST_SERIALIZATION_NVP(m_empire_id);
 }
 
-template <class Archive>
+template <typename Archive>
 void VisibleToEmpire::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
         & BOOST_SERIALIZATION_NVP(m_empire_id);
 }
 
-template <class Archive>
+template <typename Archive>
 void WithinDistance::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
@@ -2222,7 +2222,7 @@ void WithinDistance::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_condition);
 }
 
-template <class Archive>
+template <typename Archive>
 void WithinStarlaneJumps::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
@@ -2230,41 +2230,41 @@ void WithinStarlaneJumps::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_condition);
 }
 
-template <class Archive>
+template <typename Archive>
 void CanAddStarlaneConnection::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
         & BOOST_SERIALIZATION_NVP(m_condition);
 }
 
-template <class Archive>
+template <typename Archive>
 void ExploredByEmpire::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
         & BOOST_SERIALIZATION_NVP(m_empire_id);
 }
 
-template <class Archive>
+template <typename Archive>
 void Stationary::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition);
 }
 
-template <class Archive>
+template <typename Archive>
 void Aggressive::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
         & BOOST_SERIALIZATION_NVP(m_aggressive);
 }
 
-template <class Archive>
+template <typename Archive>
 void FleetSupplyableByEmpire::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
         & BOOST_SERIALIZATION_NVP(m_empire_id);
 }
 
-template <class Archive>
+template <typename Archive>
 void ResourceSupplyConnectedByEmpire::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
@@ -2272,26 +2272,26 @@ void ResourceSupplyConnectedByEmpire::serialize(Archive& ar, const unsigned int 
         & BOOST_SERIALIZATION_NVP(m_condition);
 }
 
-template <class Archive>
+template <typename Archive>
 void CanColonize::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition);
 }
 
-template <class Archive>
+template <typename Archive>
 void CanProduceShips::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition);
 }
 
-template <class Archive>
+template <typename Archive>
 void OrderedBombarded::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
         & BOOST_SERIALIZATION_NVP(m_by_object_condition);
 }
 
-template <class Archive>
+template <typename Archive>
 void ValueTest::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
@@ -2308,7 +2308,7 @@ void ValueTest::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_compare_type2);
 }
 
-template <class Archive>
+template <typename Archive>
 void Location::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
@@ -2317,7 +2317,7 @@ void Location::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_content_type);
 }
 
-template <class Archive>
+template <typename Archive>
 void CombatTarget::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
@@ -2325,35 +2325,35 @@ void CombatTarget::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_content_type);
 }
 
-template <class Archive>
+template <typename Archive>
 void And::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
         & BOOST_SERIALIZATION_NVP(m_operands);
 }
 
-template <class Archive>
+template <typename Archive>
 void Or::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
         & BOOST_SERIALIZATION_NVP(m_operands);
 }
 
-template <class Archive>
+template <typename Archive>
 void Not::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
         & BOOST_SERIALIZATION_NVP(m_operand);
 }
 
-template <class Archive>
+template <typename Archive>
 void OrderedAlternativesOf::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)
         & BOOST_SERIALIZATION_NVP(m_operands);
 }
 
-template <class Archive>
+template <typename Archive>
 void Described::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Condition)

--- a/universe/Effect.h
+++ b/universe/Effect.h
@@ -108,7 +108,7 @@ namespace Effect {
 
     private:
         friend class boost::serialization::access;
-        template <class Archive>
+        template <typename Archive>
         void serialize(Archive& ar, const unsigned int version);
     };
 
@@ -186,7 +186,7 @@ namespace Effect {
 
     private:
         friend class boost::serialization::access;
-        template <class Archive>
+        template <typename Archive>
         void serialize(Archive& ar, const unsigned int version);
     };
 

--- a/universe/Effects.h
+++ b/universe/Effects.h
@@ -13,7 +13,7 @@ namespace Condition {
 }
 
 namespace ValueRef {
-    template <class T>
+    template <typename T>
     struct ValueRef;
 }
 
@@ -31,7 +31,7 @@ public:
 
 private:
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -72,7 +72,7 @@ private:
     std::string m_accounting_label;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -114,7 +114,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<double>>         m_value;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -151,7 +151,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<double>> m_value;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -176,7 +176,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<double>> m_value;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -197,7 +197,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<int>> m_empire_id;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -218,7 +218,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<PlanetType>> m_type;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -240,7 +240,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<PlanetSize>> m_size;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -259,7 +259,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<std::string>> m_species_name;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -278,7 +278,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<int>> m_empire_id;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -301,7 +301,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<double>>         m_opinion;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -324,7 +324,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<double>>         m_opinion;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -349,7 +349,7 @@ private:
     std::vector<std::unique_ptr<Effect>>                m_effects_to_apply_after;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -371,7 +371,7 @@ private:
     std::vector<std::unique_ptr<Effect>>                m_effects_to_apply_after;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -406,7 +406,7 @@ private:
     std::vector<std::unique_ptr<Effect>>                m_effects_to_apply_after;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -440,7 +440,7 @@ private:
     std::vector<std::unique_ptr<Effect>>                m_effects_to_apply_after;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -472,7 +472,7 @@ private:
     std::vector<std::unique_ptr<Effect>>                m_effects_to_apply_after;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -492,7 +492,7 @@ public:
 
 private:
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -515,7 +515,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<double>> m_capacity;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -535,7 +535,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<std::string>> m_name;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -554,7 +554,7 @@ private:
     std::unique_ptr<Condition::Condition> m_other_lane_endpoint_condition;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -573,7 +573,7 @@ private:
     std::unique_ptr<Condition::Condition> m_other_lane_endpoint_condition;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -592,7 +592,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<StarType>> m_type;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -613,7 +613,7 @@ private:
     std::unique_ptr<Condition::Condition> m_location_condition;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -640,7 +640,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<double>> m_focus_y;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -666,7 +666,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<double>> m_dest_y;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -687,7 +687,7 @@ private:
     std::unique_ptr<Condition::Condition> m_location_condition;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -705,7 +705,7 @@ private:
     bool m_aggressive;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -724,7 +724,7 @@ private:
     std::string m_reason_string;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -747,7 +747,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<int>>            m_empire_id;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -766,7 +766,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<int>>            m_empire_id;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -827,7 +827,7 @@ private:
     bool                    m_stringtable_lookup;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -848,7 +848,7 @@ private:
     std::unique_ptr<ValueRef::ValueRef<double>> m_size;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -868,7 +868,7 @@ private:
     std::string m_texture;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -906,7 +906,7 @@ private:
     std::unique_ptr<Condition::Condition> m_condition;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -950,13 +950,13 @@ private:
     std::vector<std::unique_ptr<Effect>> m_false_effects;     // effects to execute if m_target_condition does not match target object
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
 
 // template implementations
-template <class Archive>
+template <typename Archive>
 void EffectsGroup::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_NVP(m_scope)
@@ -967,17 +967,17 @@ void EffectsGroup::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_content_name);
 }
 
-template <class Archive>
+template <typename Archive>
 void Effect::serialize(Archive& ar, const unsigned int version)
 {}
 
-template <class Archive>
+template <typename Archive>
 void NoOp::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect);
 }
 
-template <class Archive>
+template <typename Archive>
 void SetMeter::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
@@ -986,7 +986,7 @@ void SetMeter::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_accounting_label);
 }
 
-template <class Archive>
+template <typename Archive>
 void SetShipPartMeter::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
@@ -995,7 +995,7 @@ void SetShipPartMeter::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_value);
 }
 
-template <class Archive>
+template <typename Archive>
 void SetEmpireMeter::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
@@ -1004,7 +1004,7 @@ void SetEmpireMeter::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_value);
 }
 
-template <class Archive>
+template <typename Archive>
 void SetEmpireStockpile::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
@@ -1013,42 +1013,42 @@ void SetEmpireStockpile::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_value);
 }
 
-template <class Archive>
+template <typename Archive>
 void SetEmpireCapital::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
         & BOOST_SERIALIZATION_NVP(m_empire_id);
 }
 
-template <class Archive>
+template <typename Archive>
 void SetPlanetType::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
         & BOOST_SERIALIZATION_NVP(m_type);
 }
 
-template <class Archive>
+template <typename Archive>
 void SetPlanetSize::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
         & BOOST_SERIALIZATION_NVP(m_size);
 }
 
-template <class Archive>
+template <typename Archive>
 void SetSpecies::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
         & BOOST_SERIALIZATION_NVP(m_species_name);
 }
 
-template <class Archive>
+template <typename Archive>
 void SetOwner::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
         & BOOST_SERIALIZATION_NVP(m_empire_id);
 }
 
-template <class Archive>
+template <typename Archive>
 void CreatePlanet::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
@@ -1058,7 +1058,7 @@ void CreatePlanet::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_effects_to_apply_after);
 }
 
-template <class Archive>
+template <typename Archive>
 void CreateBuilding::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
@@ -1067,7 +1067,7 @@ void CreateBuilding::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_effects_to_apply_after);
 }
 
-template <class Archive>
+template <typename Archive>
 void CreateShip::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
@@ -1079,7 +1079,7 @@ void CreateShip::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_effects_to_apply_after);
 }
 
-template <class Archive>
+template <typename Archive>
 void CreateField::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
@@ -1091,7 +1091,7 @@ void CreateField::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_effects_to_apply_after);
 }
 
-template <class Archive>
+template <typename Archive>
 void CreateSystem::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
@@ -1102,13 +1102,13 @@ void CreateSystem::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_effects_to_apply_after);
 }
 
-template <class Archive>
+template <typename Archive>
 void Destroy::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect);
 }
 
-template <class Archive>
+template <typename Archive>
 void AddSpecial::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
@@ -1116,42 +1116,42 @@ void AddSpecial::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_capacity);
 }
 
-template <class Archive>
+template <typename Archive>
 void RemoveSpecial::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
         & BOOST_SERIALIZATION_NVP(m_name);
 }
 
-template <class Archive>
+template <typename Archive>
 void AddStarlanes::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
         & BOOST_SERIALIZATION_NVP(m_other_lane_endpoint_condition);
 }
 
-template <class Archive>
+template <typename Archive>
 void RemoveStarlanes::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
         & BOOST_SERIALIZATION_NVP(m_other_lane_endpoint_condition);
 }
 
-template <class Archive>
+template <typename Archive>
 void SetStarType::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
         & BOOST_SERIALIZATION_NVP(m_type);
 }
 
-template <class Archive>
+template <typename Archive>
 void MoveTo::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
         & BOOST_SERIALIZATION_NVP(m_location_condition);
 }
 
-template <class Archive>
+template <typename Archive>
 void MoveInOrbit::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
@@ -1161,7 +1161,7 @@ void MoveInOrbit::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_focus_y);
 }
 
-template <class Archive>
+template <typename Archive>
 void MoveTowards::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
@@ -1171,28 +1171,28 @@ void MoveTowards::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_dest_y);
 }
 
-template <class Archive>
+template <typename Archive>
 void SetDestination::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
         & BOOST_SERIALIZATION_NVP(m_location_condition);
 }
 
-template <class Archive>
+template <typename Archive>
 void SetAggression::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
         & BOOST_SERIALIZATION_NVP(m_aggressive);
 }
 
-template <class Archive>
+template <typename Archive>
 void Victory::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
         & BOOST_SERIALIZATION_NVP(m_reason_string);
 }
 
-template <class Archive>
+template <typename Archive>
 void SetEmpireTechProgress::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
@@ -1201,7 +1201,7 @@ void SetEmpireTechProgress::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_empire_id);
 }
 
-template <class Archive>
+template <typename Archive>
 void GiveEmpireTech::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
@@ -1209,7 +1209,7 @@ void GiveEmpireTech::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_empire_id);
 }
 
-template <class Archive>
+template <typename Archive>
 void GenerateSitRepMessage::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
@@ -1223,7 +1223,7 @@ void GenerateSitRepMessage::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_stringtable_lookup);
 }
 
-template <class Archive>
+template <typename Archive>
 void SetOverlayTexture::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
@@ -1231,14 +1231,14 @@ void SetOverlayTexture::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_size);
 }
 
-template <class Archive>
+template <typename Archive>
 void SetTexture::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
         & BOOST_SERIALIZATION_NVP(m_texture);
 }
 
-template <class Archive>
+template <typename Archive>
 void SetVisibility::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)
@@ -1248,7 +1248,7 @@ void SetVisibility::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_condition);
 }
 
-template <class Archive>
+template <typename Archive>
 void Conditional::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Effect)

--- a/universe/Field.h
+++ b/universe/Field.h
@@ -53,7 +53,7 @@ public:
     ~Field();
 
 protected:
-    template <class T> friend void boost::python::detail::value_destroyer<false>::execute(T const volatile* p);
+    template <typename T> friend void boost::python::detail::value_destroyer<false>::execute(T const volatile* p);
 
     /** Returns new copy of this Field. */
     Field* Clone(int empire_id = ALL_EMPIRES) const override;
@@ -63,7 +63,7 @@ private:
     std::string m_type_name;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 

--- a/universe/Fleet.h
+++ b/universe/Fleet.h
@@ -149,7 +149,7 @@ public:
     Fleet(const std::string& name, double x, double y, int owner);      ///< general ctor taking name, position and owner id
 
 protected:
-    template <class T> friend void boost::python::detail::value_destroyer<false>::execute(T const volatile* p);
+    template <typename T> friend void boost::python::detail::value_destroyer<false>::execute(T const volatile* p);
 
 public:
     ~Fleet() {}
@@ -183,7 +183,7 @@ private:
     int                         m_arrival_starlane = INVALID_OBJECT_ID; // see comment for ArrivalStarlane()
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 

--- a/universe/IDAllocator.cpp
+++ b/universe/IDAllocator.cpp
@@ -283,7 +283,7 @@ std::string IDAllocator::StateString() const {
     return ss.str();
 }
 
-template <class Archive>
+template <typename Archive>
 void IDAllocator::SerializeForEmpire(Archive& ar, const unsigned int version, int empire_id) {
     DebugLogger(IDallocator) << (Archive::is_loading::value ? "Deserialize " : "Serialize ")
                              << "IDAllocator()  server id = "

--- a/universe/IDAllocator.h
+++ b/universe/IDAllocator.h
@@ -65,7 +65,7 @@ public:
     void ObfuscateBeforeSerialization();
 
     /** Serialize while stripping out information not known to \p empire_id. */
-    template <class Archive>
+    template <typename Archive>
         void SerializeForEmpire(Archive& ar, const unsigned int version, int empire_id);
 
 private:

--- a/universe/Meter.h
+++ b/universe/Meter.h
@@ -54,14 +54,14 @@ private:
     float m_initial_value = DEFAULT_VALUE;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
 BOOST_CLASS_VERSION(Meter, 1)
 
 // template implementations
-template <class Archive>
+template <typename Archive>
 void Meter::serialize(Archive& ar, const unsigned int version)
 {
     if (Archive::is_loading::value && version < 1) {

--- a/universe/ObjectMap.cpp
+++ b/universe/ObjectMap.cpp
@@ -37,18 +37,18 @@
 
 
 namespace {
-    template<class T>
+    template <typename T>
     static void ClearMap(ObjectMap::container_type<T>& map)
     { map.clear(); }
 
-    template <class T>
+    template <typename T>
     static void TryInsertIntoMap(ObjectMap::container_type<T>& map, std::shared_ptr<UniverseObject> item)
     {
         if (dynamic_cast<T*>(item.get()))
             map[item->ID()] = std::dynamic_pointer_cast<T, UniverseObject>(item);
     }
 
-    template<class T>
+    template <typename T>
     void EraseFromMap(ObjectMap::container_type<T>& map, int id)
     { map.erase(id); }
 }
@@ -337,7 +337,7 @@ std::shared_ptr<const UniverseObject> ObjectMap::ExistingObject(int id) const {
 
 // Static helpers
 
-template<class T>
+template <typename T>
 void ObjectMap::SwapMap(ObjectMap::container_type<T>& map, ObjectMap& rhs)
 { map.swap(rhs.Map<T>()); }
 

--- a/universe/ObjectMap.h
+++ b/universe/ObjectMap.h
@@ -50,7 +50,7 @@ public:
 
     /** \name Accessors */ //@{
     /** Returns the number of objects of the specified class in this ObjectMap. */
-    template <class T=UniverseObject>
+    template <typename T = UniverseObject>
     std::size_t size() const;
 
     /** Returns true if this ObjectMap contains no objects */
@@ -59,42 +59,42 @@ public:
     /** Returns a pointer to the object of type T with ID number \a id.
       * Returns a null std::shared_ptr if none exists or the object with
       * ID \a id is not of type T. */
-    template <class T = UniverseObject>
+    template <typename T = UniverseObject>
     std::shared_ptr<const T> get(int id) const;
 
     /** Returns a pointer to the object of type T with ID number \a id.
       * Returns a null std::shared_ptr if none exists or the object with
       * ID \a id is not of type T. */
-    template <class T = UniverseObject>
+    template <typename T = UniverseObject>
     std::shared_ptr<T> get(int id);
 
     using id_range = boost::any_range<int, boost::forward_traversal_tag>;
 
     /** Returns a vector containing the objects with ids in \a object_ids that
       * are of type T */
-    template <class T = UniverseObject>
+    template <typename T = UniverseObject>
     std::vector<std::shared_ptr<const T>> find(const id_range& object_ids) const;
 
     /** Returns a vector containing the objects with ids in \a object_ids that
       * are of type T */
-    template <class T = UniverseObject>
+    template <typename T = UniverseObject>
     std::vector<std::shared_ptr<T>> find(const id_range& object_ids);
 
     /** Returns all the objects that match \a visitor */
-    template <class T = UniverseObject>
+    template <typename T = UniverseObject>
     std::vector<std::shared_ptr<const T>> find(const UniverseObjectVisitor& visitor) const;
 
     /** Returns all the objects that match \a visitor */
-    template <class T = UniverseObject>
+    template <typename T = UniverseObject>
     std::vector<std::shared_ptr<T>> find(const UniverseObjectVisitor& visitor);
 
     /** Returns all the objects of type T */
-    template <class T = UniverseObject>
+    template <typename T = UniverseObject>
     boost::select_second_const_range<container_type<T>> all() const
     { return Map<T>() | boost::adaptors::map_values; }
 
     /** Returns all the objects of type T */
-    template <class T = UniverseObject>
+    template <typename T = UniverseObject>
     boost::select_second_mutable_range<container_type<T>> all()
     { return Map<T>() | boost::adaptors::map_values; }
 
@@ -163,7 +163,7 @@ public:
     /** Adds object \a obj to the map under its ID, if it is a valid object.
       * If there already was an object in the map with the id \a id then
       * that object will be removed. */
-    template <class T>
+    template <typename T>
     void insert(std::shared_ptr<T> obj, int empire_id = ALL_EMPIRES);
 
     /** Removes object with id \a id from map, and returns that object, if
@@ -196,13 +196,13 @@ private:
 
     void CopyObjectsToSpecializedMaps();
 
-    template <class T>
+    template <typename T>
     const container_type<T>& Map() const;
 
-    template <class T>
+    template <typename T>
     container_type<T>& Map();
 
-    template <class T>
+    template <typename T>
     static void SwapMap(container_type<T>& map, ObjectMap& rhs);
 
     container_type<UniverseObject>  m_objects;
@@ -226,11 +226,11 @@ private:
     container_type<const UniverseObject>  m_existing_fields;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
-template <class T>
+template <typename T>
 std::shared_ptr<const T> ObjectMap::get(int id) const {
     auto it = Map<typename std::remove_const<T>::type>().find(id);
     return std::shared_ptr<const T>(
@@ -239,7 +239,7 @@ std::shared_ptr<const T> ObjectMap::get(int id) const {
             : nullptr);
 }
 
-template <class T>
+template <typename T>
 std::shared_ptr<T> ObjectMap::get(int id) {
     auto it = Map<typename std::remove_const<T>::type>().find(id);
     return std::shared_ptr<T>(
@@ -248,7 +248,7 @@ std::shared_ptr<T> ObjectMap::get(int id) {
             : nullptr);
 }
 
-template <class T>
+template <typename T>
 std::vector<std::shared_ptr<const T>> ObjectMap::find(const id_range& object_ids) const {
     std::vector<std::shared_ptr<const T>> retval;
     retval.reserve(boost::size(object_ids));
@@ -261,7 +261,7 @@ std::vector<std::shared_ptr<const T>> ObjectMap::find(const id_range& object_ids
     return retval;
 }
 
-template <class T>
+template <typename T>
 std::vector<std::shared_ptr<T>> ObjectMap::find(const id_range& object_ids) {
     std::vector<std::shared_ptr<T>> retval;
     retval.reserve(boost::size(object_ids));
@@ -274,7 +274,7 @@ std::vector<std::shared_ptr<T>> ObjectMap::find(const id_range& object_ids) {
     return retval;
 }
 
-template <class T>
+template <typename T>
 std::vector<std::shared_ptr<const T>> ObjectMap::find(const UniverseObjectVisitor& visitor) const {
     std::vector<std::shared_ptr<const T>> result;
     typedef typename std::remove_const<T>::type mutableT;
@@ -286,7 +286,7 @@ std::vector<std::shared_ptr<const T>> ObjectMap::find(const UniverseObjectVisito
     return result;
 }
 
-template <class T>
+template <typename T>
 std::vector<std::shared_ptr<T>> ObjectMap::find(const UniverseObjectVisitor& visitor) {
     std::vector<std::shared_ptr<T>> result;
     typedef typename std::remove_const<T>::type mutableT;
@@ -298,11 +298,11 @@ std::vector<std::shared_ptr<T>> ObjectMap::find(const UniverseObjectVisitor& vis
     return result;
 }
 
-template <class T>
+template <typename T>
 std::size_t ObjectMap::size() const
 { return Map<typename std::remove_const<T>::type>().size(); }
 
-template <class T>
+template <typename T>
 void ObjectMap::insert(std::shared_ptr<T> item, int empire_id /* = ALL_EMPIRES */) {
     if (!item)
         return;

--- a/universe/Pathfinder.cpp
+++ b/universe/Pathfinder.cpp
@@ -41,7 +41,8 @@ namespace {
         The table is assumed symmetric.  If present row i element j will
         equal row j element i.
      */
-    template <class T> struct distance_matrix_storage {
+    template <typename T>
+    struct distance_matrix_storage {
         typedef T value_type;  ///< An integral type for number of hops.
         typedef std::vector<T>& row_ref;  ///< A reference to row type
 
@@ -85,7 +86,7 @@ namespace {
     //may be true that because this is a computed value that depends on
     //the system topology that almost never changes that the
     //synchronization costs way out-weigh the saved computation costs.
-    template <class Storage, class T = typename Storage::value_type, class Row = typename Storage::row_ref>
+    template <typename Storage, typename T = typename Storage::value_type, typename Row = typename Storage::row_ref>
     class distance_matrix_cache {
         public:
         distance_matrix_cache(Storage& the_storage) : m_storage(the_storage) {}
@@ -224,7 +225,7 @@ namespace SystemPathing {
         struct FoundDestination {}; // exception type thrown when destination is found
 
         PathFindingShortCircuitingVisitor(int dest_system) : destination_system(dest_system) {}
-        template <class Vertex, class Graph>
+        template <typename Vertex, typename Graph>
         void operator()(Vertex u, Graph& g)
         {
             if (static_cast<int>(u) == destination_system)
@@ -238,7 +239,8 @@ namespace SystemPathing {
       *  - short-circuit exit on found match
       *  - maximum search depth
       */
-    template <class Graph, class Edge, class Vertex> class BFSVisitorImpl
+    template <typename Graph, typename Edge, typename Vertex>
+    class BFSVisitorImpl
     {
     public:
         class FoundDestination {};
@@ -308,7 +310,7 @@ namespace SystemPathing {
       * just that system in it, and the path lenth is 0.  If there is no path
       * between the two vertices, then the list is empty and the path length
       * is -1.0 */
-    template <class Graph>
+    template <typename Graph>
     std::pair<std::list<int>, double> ShortestPathImpl(const Graph& graph, int system1_id, int system2_id,
                                                        double linear_distance, const boost::unordered_map<int, size_t>& id_to_graph_index)
     {
@@ -388,7 +390,7 @@ namespace SystemPathing {
       * as system2_id, the path has just that system in it, and the path lenth
       * is 0.  If there is no path between the two vertices, then the list is
       * empty and the path length is -1 */
-    template <class Graph>
+    template <typename Graph>
     std::pair<std::list<int>, int> LeastJumpsPathImpl(const Graph& graph, int system1_id, int system2_id,
                                                       const boost::unordered_map<int, size_t>& id_to_graph_index,
                                                       int max_jumps = INT_MAX)
@@ -452,7 +454,7 @@ namespace SystemPathing {
         return retval;
     }
 
-    template <class Graph>
+    template <typename Graph>
     std::multimap<double, int> ImmediateNeighborsImpl(const Graph& graph, int system_id,
                                                       const boost::unordered_map<int, size_t>& id_to_graph_index)
     {

--- a/universe/Planet.h
+++ b/universe/Planet.h
@@ -130,7 +130,7 @@ public:
     ~Planet() {}
 
 protected:
-    template <class T>
+    template <typename T>
     friend void boost::python::detail::value_destroyer<false>::execute(T const volatile* p);
 
 protected:
@@ -174,7 +174,7 @@ private:
     std::string     m_surface_texture;  // intentionally not serialized; set by local effects
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 

--- a/universe/PopCenter.h
+++ b/universe/PopCenter.h
@@ -58,12 +58,12 @@ private:
     std::string m_species_name = "";                            ///< the name of the species that occupies this planet
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
 // template implementations
-template <class Archive>
+template <typename Archive>
 void PopCenter::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_NVP(m_species_name);

--- a/universe/ResourceCenter.h
+++ b/universe/ResourceCenter.h
@@ -74,12 +74,12 @@ private:
     virtual void            AddMeter(MeterType meter_type) = 0;             ///< implementation should add a meter to the object so that it can be accessed with the GetMeter() functions
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
 // template implementations
-template <class Archive>
+template <typename Archive>
 void ResourceCenter::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_NVP(m_focus)

--- a/universe/Ship.h
+++ b/universe/Ship.h
@@ -122,7 +122,7 @@ public:
          int produced_by_empire_id = ALL_EMPIRES);
 
 protected:
-    template <class T> friend void boost::python::detail::value_destroyer<false>::execute(T const volatile* p);
+    template <typename T> friend void boost::python::detail::value_destroyer<false>::execute(T const volatile* p);
 
 public:
     ~Ship() {}
@@ -143,7 +143,7 @@ private:
     int             m_last_resupplied_on_turn = BEFORE_FIRST_TURN;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 

--- a/universe/ShipDesign.h
+++ b/universe/ShipDesign.h
@@ -246,7 +246,7 @@ private:
     bool    m_producible = false;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 

--- a/universe/ShipPart.h
+++ b/universe/ShipPart.h
@@ -155,12 +155,12 @@ private:
     std::unique_ptr<Condition::Condition>               m_combat_targets;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
 
-template <class Archive>
+template <typename Archive>
 void ShipPart::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_NVP(m_name)

--- a/universe/ShipPartHull.h
+++ b/universe/ShipPartHull.h
@@ -45,7 +45,7 @@ struct HullTypeStats {
     bool    default_stealth_effects = true;
     bool    default_structure_effects = true;
 
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int) {
         ar  & BOOST_SERIALIZATION_NVP(fuel)
             & BOOST_SERIALIZATION_NVP(speed)
@@ -156,7 +156,7 @@ private:
     std::string                                         m_icon;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -225,7 +225,7 @@ FO_COMMON_API const HullType* GetHullType(const std::string& name);
 
 
 // template implementations
-template <class Archive>
+template <typename Archive>
 void HullType::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_NVP(m_name)

--- a/universe/Special.h
+++ b/universe/Special.h
@@ -85,7 +85,7 @@ private:
     std::string                                         m_graphic ="";
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -97,7 +97,7 @@ FO_COMMON_API const Special* GetSpecial(const std::string& name);
 FO_COMMON_API std::vector<std::string> SpecialNames();
 
 // template implementations
-template <class Archive>
+template <typename Archive>
 void Special::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_NVP(m_name)

--- a/universe/Species.h
+++ b/universe/Species.h
@@ -352,7 +352,7 @@ private:
     static SpeciesManager* s_instance;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 

--- a/universe/System.h
+++ b/universe/System.h
@@ -139,7 +139,7 @@ protected:
     System(StarType star, const std::map<int, bool>& lanes_and_holes,
            const std::string& name, double x, double y);
 
-    template <class T> friend void boost::python::detail::value_destroyer<false>::execute(T const volatile* p);
+    template <typename T> friend void boost::python::detail::value_destroyer<false>::execute(T const volatile* p);
 
 public:
     ~System() {}
@@ -165,7 +165,7 @@ private:
     double              m_overlay_size = 1.0;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 

--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -82,17 +82,20 @@ namespace {
     // determining how much of their speed is consumed by the jump
     // unused variable const double    WORMHOLE_TRAVEL_DISTANCE = 0.1;
 
-    template <class Key, class Value> struct constant_property
+    template <typename Key, typename Value>
+    struct constant_property
     { Value m_value; };
 }
 
 namespace boost {
-    template <class Key, class Value> struct property_traits<constant_property<Key, Value>> {
+    template <typename Key, typename Value>
+    struct property_traits<constant_property<Key, Value>> {
         typedef Value value_type;
         typedef Key key_type;
         typedef readable_property_map_tag category;
     };
-    template <class Key, class Value> const Value& get(const constant_property<Key, Value>& pmap, const Key&) { return pmap.m_value; }
+    template <typename Key, typename Value>
+    const Value& get(const constant_property<Key, Value>& pmap, const Key&) { return pmap.m_value; }
 }
 
 

--- a/universe/Universe.h
+++ b/universe/Universe.h
@@ -51,7 +51,8 @@ namespace Effect {
 }
 
 namespace ValueRef {
-    template <class T> struct ValueRef;
+    template <typename T>
+    struct ValueRef;
 }
 
 #if defined(_MSC_VER)
@@ -589,7 +590,7 @@ private:
     std::unique_ptr<IDAllocator> const m_design_id_allocator;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 

--- a/universe/UniverseObject.h
+++ b/universe/UniverseObject.h
@@ -198,7 +198,7 @@ protected:
     UniverseObject();
     UniverseObject(const std::string name, double x, double y);
 
-    template <class T> friend void boost::python::detail::value_destroyer<false>::execute(T const volatile* p);
+    template <typename T> friend void boost::python::detail::value_destroyer<false>::execute(T const volatile* p);
 
 public:
     virtual ~UniverseObject();
@@ -234,7 +234,7 @@ private:
     int                                             m_created_on_turn = INVALID_GAME_TURN;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 

--- a/universe/ValueRef.h
+++ b/universe/ValueRef.h
@@ -10,7 +10,7 @@ namespace ValueRef {
 
 /** The base class for all ValueRef classes.  This class provides the public
   * interface for a ValueRef expression tree. */
-template <class T>
+template <typename T>
 struct FO_COMMON_API ValueRef
 {
     virtual ~ValueRef()
@@ -63,7 +63,7 @@ struct FO_COMMON_API ValueRef
 
 private:
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 

--- a/universe/ValueRefs.h
+++ b/universe/ValueRefs.h
@@ -33,7 +33,7 @@ class UniverseObject;
 
 namespace ValueRef {
 /** the constant value leaf ValueRef class. */
-template <class T>
+template <typename T>
 struct FO_COMMON_API Constant final : public ValueRef<T>
 {
     explicit Constant(T value);
@@ -67,7 +67,7 @@ private:
     std::string m_top_level_content;    // in the special case that T is std::string and m_value is "CurrentContent", return this instead
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -83,7 +83,7 @@ enum ReferenceType : int {
 
 /** The variable value ValueRef class.  The value returned by this node is
   * taken from the gamestate, most often from the Source or Target objects. */
-template <class T>
+template <typename T>
 struct FO_COMMON_API Variable : public ValueRef<T>
 {
     explicit Variable(ReferenceType ref_type, const std::string& property_name = "",
@@ -115,7 +115,7 @@ protected:
 
 private:
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -124,7 +124,7 @@ private:
   * \a property_name is computed for each object that matches
   * \a sampling_condition and the statistic indicated by \a stat_type is
   * calculated from them and returned. */
-template <class T>
+template <typename T>
 struct FO_COMMON_API Statistic final : public Variable<T>
 {
     Statistic(std::unique_ptr<ValueRef<T>>&& value_ref,
@@ -172,13 +172,13 @@ private:
     std::unique_ptr<ValueRef<T>>          m_value_ref;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
 /** The complex variable ValueRef class. The value returned by this node
   * is taken from the gamestate. */
-template <class T>
+template <typename T>
 struct FO_COMMON_API ComplexVariable final : public Variable<T>
 {
     explicit ComplexVariable(const std::string& variable_name,
@@ -214,14 +214,14 @@ protected:
 
 private:
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
 /** The variable static_cast class.  The value returned by this node is taken
   * from the ctor \a value_ref parameter's FromType value, static_cast to
   * ToType. */
-template <class FromType, class ToType>
+template <typename FromType, typename ToType>
 struct FO_COMMON_API StaticCast final : public Variable<ToType>
 {
     template <typename T>
@@ -253,14 +253,14 @@ private:
     std::unique_ptr<ValueRef<FromType>> m_value_ref;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
 /** The variable lexical_cast to string class.  The value returned by this node
   * is taken from the ctor \a value_ref parameter's FromType value,
   * lexical_cast to std::string */
-template <class FromType>
+template <typename FromType>
 struct FO_COMMON_API StringCast final : public Variable<std::string>
 {
     StringCast(std::unique_ptr<ValueRef<FromType>>&& value_ref);
@@ -284,13 +284,13 @@ private:
     std::unique_ptr<ValueRef<FromType>> m_value_ref;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
 /** Looks up a string ValueRef or vector of string ValueRefs, and returns
   * and returns the UserString equivalent(s). */
-template <class FromType>
+template <typename FromType>
 struct FO_COMMON_API UserStringLookup final : public Variable<std::string> {
     explicit UserStringLookup(std::unique_ptr<ValueRef<FromType>>&& value_ref);
 
@@ -313,7 +313,7 @@ private:
     std::unique_ptr<ValueRef<FromType>> m_value_ref;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -351,7 +351,7 @@ private:
     LookupType m_lookup_type;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -387,7 +387,7 @@ enum OpType : int {
   * value substitution, value comparisons, or random value selection or
   * random number generation are performed on the child(ren) of this node, and
   * the result is returned. */
-template <class T>
+template <typename T>
 struct FO_COMMON_API Operation final : public ValueRef<T>
 {
     /** Binary operation ctor. */
@@ -435,7 +435,7 @@ private:
     T                                           m_cached_const_value = T();
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -473,7 +473,7 @@ FO_COMMON_API std::string StatisticDescription(StatisticType stat_type,
 ///////////////////////////////////////////////////////////
 // ValueRef                                          //
 ///////////////////////////////////////////////////////////
-template <class T>
+template <typename T>
 bool ValueRef<T>::operator==(const ValueRef<T>& rhs) const
 {
     if (&rhs == this)
@@ -483,20 +483,20 @@ bool ValueRef<T>::operator==(const ValueRef<T>& rhs) const
     return true;
 }
 
-template <class T>
-template <class Archive>
+template <typename T>
+template <typename Archive>
 void ValueRef<T>::serialize(Archive& ar, const unsigned int version)
 {}
 
 ///////////////////////////////////////////////////////////
 // Constant                                              //
 ///////////////////////////////////////////////////////////
-template <class T>
+template <typename T>
 Constant<T>::Constant(T value) :
     m_value(value)
 {}
 
-template <class T>
+template <typename T>
 bool Constant<T>::operator==(const ValueRef<T>& rhs) const
 {
     if (&rhs == this)
@@ -508,23 +508,23 @@ bool Constant<T>::operator==(const ValueRef<T>& rhs) const
     return m_value == rhs_.m_value && m_top_level_content == rhs_.m_top_level_content;
 }
 
-template <class T>
+template <typename T>
 T Constant<T>::Value() const
 { return m_value; }
 
-template <class T>
+template <typename T>
 T Constant<T>::Eval(const ScriptingContext& context) const
 { return m_value; }
 
-template <class T>
+template <typename T>
 std::string Constant<T>::Description() const
 { return UserString(boost::lexical_cast<std::string>(m_value)); }
 
-template <class T>
+template <typename T>
 void Constant<T>::SetTopLevelContent(const std::string& content_name)
 { m_top_level_content = content_name; }
 
-template <class T>
+template <typename T>
 unsigned int Constant<T>::GetCheckSum() const
 {
     unsigned int retval{0};
@@ -574,8 +574,8 @@ FO_COMMON_API std::string Constant<std::string>::Dump(unsigned short ntabs) cons
 template <>
 FO_COMMON_API std::string Constant<std::string>::Eval(const ScriptingContext& context) const;
 
-template <class T>
-template <class Archive>
+template <typename T>
+template <typename Archive>
 void Constant<T>::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(ValueRef)
@@ -586,7 +586,7 @@ void Constant<T>::serialize(Archive& ar, const unsigned int version)
 ///////////////////////////////////////////////////////////
 // Variable                                              //
 ///////////////////////////////////////////////////////////
-template <class T>
+template <typename T>
 Variable<T>::Variable(ReferenceType ref_type, const std::vector<std::string>& property_name,
                       bool return_immediate_value) :
     m_ref_type(ref_type),
@@ -594,7 +594,7 @@ Variable<T>::Variable(ReferenceType ref_type, const std::vector<std::string>& pr
     m_return_immediate_value(return_immediate_value)
 {}
 
-template <class T>
+template <typename T>
 Variable<T>::Variable(ReferenceType ref_type, const std::string& property_name,
                       bool return_immediate_value) :
     m_ref_type(ref_type),
@@ -604,7 +604,7 @@ Variable<T>::Variable(ReferenceType ref_type, const std::string& property_name,
     m_property_name.push_back(property_name);
 }
 
-template <class T>
+template <typename T>
 Variable<T>::Variable(ReferenceType ref_type,
                       const boost::optional<std::string>& container_name,
                       const std::string& property_name,
@@ -619,7 +619,7 @@ Variable<T>::Variable(ReferenceType ref_type,
     m_property_name.push_back(property_name);
 }
 
-template <class T>
+template <typename T>
 bool Variable<T>::operator==(const ValueRef<T>& rhs) const
 {
     if (&rhs == this)
@@ -632,43 +632,43 @@ bool Variable<T>::operator==(const ValueRef<T>& rhs) const
            (m_return_immediate_value == rhs_.m_return_immediate_value);
 }
 
-template <class T>
+template <typename T>
 ReferenceType Variable<T>::GetReferenceType() const
 { return m_ref_type; }
 
-template <class T>
+template <typename T>
 const std::vector<std::string>& Variable<T>::PropertyName() const
 { return m_property_name; }
 
-template <class T>
+template <typename T>
 bool Variable<T>::ReturnImmediateValue() const
 { return m_return_immediate_value; }
 
-template <class T>
+template <typename T>
 bool Variable<T>::RootCandidateInvariant() const
 { return m_ref_type != CONDITION_ROOT_CANDIDATE_REFERENCE; }
 
-template <class T>
+template <typename T>
 bool Variable<T>::LocalCandidateInvariant() const
 { return m_ref_type != CONDITION_LOCAL_CANDIDATE_REFERENCE; }
 
-template <class T>
+template <typename T>
 bool Variable<T>::TargetInvariant() const
 { return m_ref_type != EFFECT_TARGET_REFERENCE && m_ref_type != EFFECT_TARGET_VALUE_REFERENCE; }
 
-template <class T>
+template <typename T>
 bool Variable<T>::SourceInvariant() const
 { return m_ref_type != SOURCE_REFERENCE; }
 
-template <class T>
+template <typename T>
 std::string Variable<T>::Description() const
 { return FormatedDescriptionPropertyNames(m_ref_type, m_property_name, m_return_immediate_value); }
 
-template <class T>
+template <typename T>
 std::string Variable<T>::Dump(unsigned short ntabs) const
 { return ReconstructName(m_property_name, m_ref_type, m_return_immediate_value); }
 
-template <class T>
+template <typename T>
 unsigned int Variable<T>::GetCheckSum() const
 {
     unsigned int retval{0};
@@ -711,8 +711,8 @@ FO_COMMON_API std::string Variable<std::string>::Eval(const ScriptingContext& co
 template <>
 FO_COMMON_API std::vector<std::string> Variable<std::vector<std::string>>::Eval(const ScriptingContext& context) const;
 
-template <class T>
-template <class Archive>
+template <typename T>
+template <typename Archive>
 void Variable<T>::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(ValueRef)
@@ -724,7 +724,7 @@ void Variable<T>::serialize(Archive& ar, const unsigned int version)
 ///////////////////////////////////////////////////////////
 // Statistic                                             //
 ///////////////////////////////////////////////////////////
-template <class T>
+template <typename T>
 Statistic<T>::Statistic(std::unique_ptr<ValueRef<T>>&& value_ref, StatisticType stat_type,
                         std::unique_ptr<Condition::Condition>&& sampling_condition) :
     Variable<T>(NON_OBJECT_REFERENCE, ""),
@@ -733,7 +733,7 @@ Statistic<T>::Statistic(std::unique_ptr<ValueRef<T>>&& value_ref, StatisticType 
     m_value_ref(std::move(value_ref))
 {}
 
-template <class T>
+template <typename T>
 bool Statistic<T>::operator==(const ValueRef<T>& rhs) const
 {
     if (&rhs == this)
@@ -759,7 +759,7 @@ bool Statistic<T>::operator==(const ValueRef<T>& rhs) const
     return true;
 }
 
-template <class T>
+template <typename T>
 void Statistic<T>::GetConditionMatches(const ScriptingContext& context,
                                        Condition::ObjectSet& condition_targets,
                                        Condition::Condition* condition) const
@@ -770,7 +770,7 @@ void Statistic<T>::GetConditionMatches(const ScriptingContext& context,
     condition->Eval(context, condition_targets);
 }
 
-template <class T>
+template <typename T>
 void Statistic<T>::GetObjectPropertyValues(const ScriptingContext& context,
                                            const Condition::ObjectSet& objects,
                                            std::map<std::shared_ptr<const UniverseObject>, T>& object_property_values) const
@@ -787,7 +787,7 @@ void Statistic<T>::GetObjectPropertyValues(const ScriptingContext& context,
     }
 }
 
-template <class T>
+template <typename T>
 bool Statistic<T>::RootCandidateInvariant() const
 {
     return Variable<T>::RootCandidateInvariant() &&
@@ -795,7 +795,7 @@ bool Statistic<T>::RootCandidateInvariant() const
            (!m_value_ref || m_value_ref->RootCandidateInvariant());
 }
 
-template <class T>
+template <typename T>
 bool Statistic<T>::LocalCandidateInvariant() const
 {
     // don't need to check if sampling condition is LocalCandidateInvariant, as
@@ -805,7 +805,7 @@ bool Statistic<T>::LocalCandidateInvariant() const
            (!m_value_ref || m_value_ref->LocalCandidateInvariant());
 }
 
-template <class T>
+template <typename T>
 bool Statistic<T>::TargetInvariant() const
 {
     return Variable<T>::TargetInvariant() &&
@@ -813,7 +813,7 @@ bool Statistic<T>::TargetInvariant() const
            (!m_value_ref || m_value_ref->TargetInvariant());
 }
 
-template <class T>
+template <typename T>
 bool Statistic<T>::SourceInvariant() const
 {
     return Variable<T>::SourceInvariant() &&
@@ -821,7 +821,7 @@ bool Statistic<T>::SourceInvariant() const
            (!m_value_ref || m_value_ref->SourceInvariant());
 }
 
-template <class T>
+template <typename T>
 std::string Statistic<T>::Description() const
 {
     if (m_value_ref)
@@ -835,7 +835,7 @@ std::string Statistic<T>::Description() const
     return StatisticDescription(m_stat_type, "", m_sampling_condition ? m_sampling_condition->Description() : "");
 }
 
-template <class T>
+template <typename T>
 std::string Statistic<T>::Dump(unsigned short ntabs) const
 {
     std::string retval = "Statistic ";
@@ -862,7 +862,7 @@ std::string Statistic<T>::Dump(unsigned short ntabs) const
     return retval;
 }
 
-template <class T>
+template <typename T>
 void Statistic<T>::SetTopLevelContent(const std::string& content_name)
 {
     if (m_sampling_condition)
@@ -871,7 +871,7 @@ void Statistic<T>::SetTopLevelContent(const std::string& content_name)
         m_value_ref->SetTopLevelContent(content_name);
 }
 
-template <class T>
+template <typename T>
 T Statistic<T>::Eval(const ScriptingContext& context) const
 {
     Condition::ObjectSet condition_matches;
@@ -924,7 +924,7 @@ T Statistic<T>::Eval(const ScriptingContext& context) const
     return most_common_property_value_it->first;
 }
 
-template <class T>
+template <typename T>
 unsigned int Statistic<T>::GetCheckSum() const
 {
     unsigned int retval{0};
@@ -946,7 +946,7 @@ FO_COMMON_API int Statistic<int>::Eval(const ScriptingContext& context) const;
 template <>
 FO_COMMON_API std::string Statistic<std::string>::Eval(const ScriptingContext& context) const;
 
-template <class T>
+template <typename T>
 T Statistic<T>::ReduceData(const std::map<std::shared_ptr<const UniverseObject>, T>& object_property_values) const
 {
     if (object_property_values.empty())
@@ -1116,8 +1116,8 @@ T Statistic<T>::ReduceData(const std::map<std::shared_ptr<const UniverseObject>,
     }
 }
 
-template <class T>
-template <class Archive>
+template <typename T>
+template <typename Archive>
 void Statistic<T>::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Variable)
@@ -1129,7 +1129,7 @@ void Statistic<T>::serialize(Archive& ar, const unsigned int version)
 ///////////////////////////////////////////////////////////
 // ComplexVariable                                       //
 ///////////////////////////////////////////////////////////
-template <class T>
+template <typename T>
 ComplexVariable<T>::ComplexVariable(const std::string& variable_name,
                                     std::unique_ptr<ValueRef<int>>&& int_ref1,
                                     std::unique_ptr<ValueRef<int>>&& int_ref2,
@@ -1145,7 +1145,7 @@ ComplexVariable<T>::ComplexVariable(const std::string& variable_name,
     m_string_ref2(std::move(string_ref2))
 {}
 
-template <class T>
+template <typename T>
 bool ComplexVariable<T>::operator==(const ValueRef<T>& rhs) const
 {
     if (&rhs == this)
@@ -1207,27 +1207,27 @@ bool ComplexVariable<T>::operator==(const ValueRef<T>& rhs) const
     return true;
 }
 
-template <class T>
+template <typename T>
 const ValueRef<int>* ComplexVariable<T>::IntRef1() const
 { return m_int_ref1.get(); }
 
-template <class T>
+template <typename T>
 const ValueRef<int>* ComplexVariable<T>::IntRef2() const
 { return m_int_ref2.get(); }
 
-template <class T>
+template <typename T>
 const ValueRef<int>* ComplexVariable<T>::IntRef3() const
 { return m_int_ref3.get(); }
 
-template <class T>
+template <typename T>
 const ValueRef<std::string>* ComplexVariable<T>::StringRef1() const
 { return m_string_ref1.get(); }
 
-template <class T>
+template <typename T>
 const ValueRef<std::string>* ComplexVariable<T>::StringRef2() const
 { return m_string_ref2.get(); }
 
-template <class T>
+template <typename T>
 bool ComplexVariable<T>::RootCandidateInvariant() const
 {
     return Variable<T>::RootCandidateInvariant()
@@ -1238,7 +1238,7 @@ bool ComplexVariable<T>::RootCandidateInvariant() const
         && (!m_string_ref2 || m_string_ref2->RootCandidateInvariant());
 }
 
-template <class T>
+template <typename T>
 bool ComplexVariable<T>::LocalCandidateInvariant() const
 {
     return (!m_int_ref1 || m_int_ref1->LocalCandidateInvariant())
@@ -1248,7 +1248,7 @@ bool ComplexVariable<T>::LocalCandidateInvariant() const
         && (!m_string_ref2 || m_string_ref2->LocalCandidateInvariant());
 }
 
-template <class T>
+template <typename T>
 bool ComplexVariable<T>::TargetInvariant() const
 {
     return (!m_int_ref1 || m_int_ref1->TargetInvariant())
@@ -1258,7 +1258,7 @@ bool ComplexVariable<T>::TargetInvariant() const
         && (!m_string_ref2 || m_string_ref2->TargetInvariant());
 }
 
-template <class T>
+template <typename T>
 bool ComplexVariable<T>::SourceInvariant() const
 {
     return (!m_int_ref1 || m_int_ref1->SourceInvariant())
@@ -1268,7 +1268,7 @@ bool ComplexVariable<T>::SourceInvariant() const
         && (!m_string_ref2 || m_string_ref2->SourceInvariant());
 }
 
-template <class T>
+template <typename T>
 std::string ComplexVariable<T>::Description() const
 {
     std::string retval = ComplexVariableDescription(
@@ -1283,7 +1283,7 @@ std::string ComplexVariable<T>::Description() const
     return retval;
 }
 
-template <class T>
+template <typename T>
 std::string ComplexVariable<T>::Dump(unsigned short ntabs) const
 {
     return ComplexVariableDump(this->m_property_name,
@@ -1294,7 +1294,7 @@ std::string ComplexVariable<T>::Dump(unsigned short ntabs) const
                                m_string_ref2 ? m_string_ref2.get() : nullptr);
 }
 
-template <class T>
+template <typename T>
 void ComplexVariable<T>::SetTopLevelContent(const std::string& content_name)
 {
     if (m_int_ref1)
@@ -1309,7 +1309,7 @@ void ComplexVariable<T>::SetTopLevelContent(const std::string& content_name)
         m_string_ref2->SetTopLevelContent(content_name);
 }
 
-template <class T>
+template <typename T>
 unsigned int ComplexVariable<T>::GetCheckSum() const
 {
     unsigned int retval{0};
@@ -1363,8 +1363,8 @@ FO_COMMON_API std::string ComplexVariable<int>::Dump(unsigned short ntabs) const
 template <>
 FO_COMMON_API std::string ComplexVariable<std::string>::Dump(unsigned short ntabs) const;
 
-template <class T>
-template <class Archive>
+template <typename T>
+template <typename Archive>
 void ComplexVariable<T>::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Variable)
@@ -1378,7 +1378,7 @@ void ComplexVariable<T>::serialize(Archive& ar, const unsigned int version)
 ///////////////////////////////////////////////////////////
 // StaticCast                                            //
 ///////////////////////////////////////////////////////////
-template <class FromType, class ToType>
+template <typename FromType, typename ToType>
 template <typename T>
 StaticCast<FromType, ToType>::StaticCast(
     T&& value_ref,
@@ -1387,7 +1387,7 @@ StaticCast<FromType, ToType>::StaticCast(
     m_value_ref(std::move(value_ref))
 {}
 
-template <class FromType, class ToType>
+template <typename FromType, typename ToType>
 template <typename T>
 StaticCast<FromType, ToType>::StaticCast(
     T&& value_ref,
@@ -1398,7 +1398,7 @@ StaticCast<FromType, ToType>::StaticCast(
     m_value_ref(std::move(value_ref))
 {}
 
-template <class FromType, class ToType>
+template <typename FromType, typename ToType>
 bool StaticCast<FromType, ToType>::operator==(const ValueRef<ToType>& rhs) const
 {
     if (&rhs == this)
@@ -1420,42 +1420,42 @@ bool StaticCast<FromType, ToType>::operator==(const ValueRef<ToType>& rhs) const
     return true;
 }
 
-template <class FromType, class ToType>
+template <typename FromType, typename ToType>
 ToType StaticCast<FromType, ToType>::Eval(const ScriptingContext& context) const
 { return static_cast<ToType>(m_value_ref->Eval(context)); }
 
-template <class FromType, class ToType>
+template <typename FromType, typename ToType>
 bool StaticCast<FromType, ToType>::RootCandidateInvariant() const
 { return m_value_ref->RootCandidateInvariant(); }
 
-template <class FromType, class ToType>
+template <typename FromType, typename ToType>
 bool StaticCast<FromType, ToType>::LocalCandidateInvariant() const
 { return m_value_ref->LocalCandidateInvariant(); }
 
-template <class FromType, class ToType>
+template <typename FromType, typename ToType>
 bool StaticCast<FromType, ToType>::TargetInvariant() const
 { return m_value_ref->TargetInvariant(); }
 
-template <class FromType, class ToType>
+template <typename FromType, typename ToType>
 bool StaticCast<FromType, ToType>::SourceInvariant() const
 { return m_value_ref->SourceInvariant(); }
 
-template <class FromType, class ToType>
+template <typename FromType, typename ToType>
 std::string StaticCast<FromType, ToType>::Description() const
 { return m_value_ref->Description(); }
 
-template <class FromType, class ToType>
+template <typename FromType, typename ToType>
 std::string StaticCast<FromType, ToType>::Dump(unsigned short ntabs) const
 { return m_value_ref->Dump(ntabs); }
 
-template <class FromType, class ToType>
+template <typename FromType, typename ToType>
 void StaticCast<FromType, ToType>::SetTopLevelContent(const std::string& content_name)
 {
     if (m_value_ref)
         m_value_ref->SetTopLevelContent(content_name);
 }
 
-template <class FromType, class ToType>
+template <typename FromType, typename ToType>
 unsigned int StaticCast<FromType, ToType>::GetCheckSum() const
 {
     unsigned int retval{0};
@@ -1466,8 +1466,8 @@ unsigned int StaticCast<FromType, ToType>::GetCheckSum() const
     return retval;
 }
 
-template <class FromType, class ToType>
-template <class Archive>
+template <typename FromType, typename ToType>
+template <typename Archive>
 void StaticCast<FromType, ToType>::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(ValueRef)
@@ -1477,7 +1477,7 @@ void StaticCast<FromType, ToType>::serialize(Archive& ar, const unsigned int ver
 ///////////////////////////////////////////////////////////
 // StringCast                                            //
 ///////////////////////////////////////////////////////////
-template <class FromType>
+template <typename FromType>
 StringCast<FromType>::StringCast(std::unique_ptr<ValueRef<FromType>>&& value_ref) :
     Variable<std::string>(NON_OBJECT_REFERENCE),
     m_value_ref(std::move(value_ref))
@@ -1492,7 +1492,7 @@ StringCast<FromType>::StringCast(std::unique_ptr<ValueRef<FromType>>&& value_ref
     }
 }
 
-template <class FromType>
+template <typename FromType>
 bool StringCast<FromType>::operator==(const ValueRef<std::string>& rhs) const
 {
     if (&rhs == this)
@@ -1514,7 +1514,7 @@ bool StringCast<FromType>::operator==(const ValueRef<std::string>& rhs) const
     return true;
 }
 
-template <class FromType>
+template <typename FromType>
 std::string StringCast<FromType>::Eval(const ScriptingContext& context) const
 {
     if (!m_value_ref)
@@ -1527,7 +1527,7 @@ std::string StringCast<FromType>::Eval(const ScriptingContext& context) const
     return retval;
 }
 
-template <class FromType>
+template <typename FromType>
 unsigned int StringCast<FromType>::GetCheckSum() const
 {
     unsigned int retval{0};
@@ -1547,38 +1547,38 @@ FO_COMMON_API std::string StringCast<int>::Eval(const ScriptingContext& context)
 template <>
 FO_COMMON_API std::string StringCast<std::vector<std::string>>::Eval(const ScriptingContext& context) const;
 
-template <class FromType>
+template <typename FromType>
 bool StringCast<FromType>::RootCandidateInvariant() const
 { return m_value_ref->RootCandidateInvariant(); }
 
-template <class FromType>
+template <typename FromType>
 bool StringCast<FromType>::LocalCandidateInvariant() const
 { return m_value_ref->LocalCandidateInvariant(); }
 
-template <class FromType>
+template <typename FromType>
 bool StringCast<FromType>::TargetInvariant() const
 { return m_value_ref->TargetInvariant(); }
 
-template <class FromType>
+template <typename FromType>
 bool StringCast<FromType>::SourceInvariant() const
 { return m_value_ref->SourceInvariant(); }
 
-template <class FromType>
+template <typename FromType>
 std::string StringCast<FromType>::Description() const
 { return m_value_ref->Description(); }
 
-template <class FromType>
+template <typename FromType>
 std::string StringCast<FromType>::Dump(unsigned short ntabs) const
 { return m_value_ref->Dump(ntabs); }
 
-template <class FromType>
+template <typename FromType>
 void StringCast<FromType>::SetTopLevelContent(const std::string& content_name) {
     if (m_value_ref)
         m_value_ref->SetTopLevelContent(content_name);
 }
 
-template <class FromType>
-template <class Archive>
+template <typename FromType>
+template <typename Archive>
 void StringCast<FromType>::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(ValueRef)
@@ -1588,7 +1588,7 @@ void StringCast<FromType>::serialize(Archive& ar, const unsigned int version)
 ///////////////////////////////////////////////////////////
 // UserStringLookup                                      //
 ///////////////////////////////////////////////////////////
-template <class FromType>
+template <typename FromType>
 UserStringLookup<FromType>::UserStringLookup(std::unique_ptr<ValueRef<FromType>>&& value_ref) :
     Variable<std::string>(NON_OBJECT_REFERENCE),
     m_value_ref(std::move(value_ref))
@@ -1603,7 +1603,7 @@ UserStringLookup<FromType>::UserStringLookup(std::unique_ptr<ValueRef<FromType>>
     }
 }
 
-template <class FromType>
+template <typename FromType>
 bool UserStringLookup<FromType>::operator==(const ValueRef<std::string>& rhs) const {
     if (&rhs == this)
         return true;
@@ -1625,7 +1625,7 @@ bool UserStringLookup<FromType>::operator==(const ValueRef<std::string>& rhs) co
     return true;
 }
 
-template <class FromType>
+template <typename FromType>
 std::string UserStringLookup<FromType>::Eval(const ScriptingContext& context) const {
     if (!m_value_ref)
         return "";
@@ -1641,49 +1641,49 @@ FO_COMMON_API std::string UserStringLookup<std::string>::Eval(const ScriptingCon
 template <>
 FO_COMMON_API std::string UserStringLookup<std::vector<std::string>>::Eval(const ScriptingContext& context) const;
 
-template <class FromType>
+template <typename FromType>
 bool UserStringLookup<FromType>::RootCandidateInvariant() const
 {
     return m_value_ref->RootCandidateInvariant();
 }
 
-template <class FromType>
+template <typename FromType>
 bool UserStringLookup<FromType>::LocalCandidateInvariant() const
 {
     return !m_value_ref || m_value_ref->LocalCandidateInvariant();
 }
 
-template <class FromType>
+template <typename FromType>
 bool UserStringLookup<FromType>::TargetInvariant() const
 {
     return !m_value_ref || m_value_ref->TargetInvariant();
 }
 
-template <class FromType>
+template <typename FromType>
 bool UserStringLookup<FromType>::SourceInvariant() const
 {
     return !m_value_ref || m_value_ref->SourceInvariant();
 }
 
-template <class FromType>
+template <typename FromType>
 std::string UserStringLookup<FromType>::Description() const
 {
     return m_value_ref->Description();
 }
 
-template <class FromType>
+template <typename FromType>
 std::string UserStringLookup<FromType>::Dump(unsigned short ntabs) const
 {
     return m_value_ref->Dump(ntabs);
 }
 
-template <class FromType>
+template <typename FromType>
 void UserStringLookup<FromType>::SetTopLevelContent(const std::string& content_name) {
     if (m_value_ref)
         m_value_ref->SetTopLevelContent(content_name);
 }
 
-template <class FromType>
+template <typename FromType>
 unsigned int UserStringLookup<FromType>::GetCheckSum() const
 {
     unsigned int retval{0};
@@ -1694,8 +1694,8 @@ unsigned int UserStringLookup<FromType>::GetCheckSum() const
     return retval;
 }
 
-template <class FromType>
-template <class Archive>
+template <typename FromType>
+template <typename Archive>
 void UserStringLookup<FromType>::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(ValueRef<std::string>)
@@ -1705,7 +1705,7 @@ void UserStringLookup<FromType>::serialize(Archive& ar, const unsigned int versi
 ///////////////////////////////////////////////////////////
 // NameLookup                                            //
 ///////////////////////////////////////////////////////////
-template <class Archive>
+template <typename Archive>
 void NameLookup::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(ValueRef<std::string>)
@@ -1716,7 +1716,7 @@ void NameLookup::serialize(Archive& ar, const unsigned int version)
 ///////////////////////////////////////////////////////////
 // Operation                                             //
 ///////////////////////////////////////////////////////////
-template <class T>
+template <typename T>
 Operation<T>::Operation(OpType op_type,
                         std::unique_ptr<ValueRef<T>>&& operand1,
                         std::unique_ptr<ValueRef<T>>&& operand2) :
@@ -1730,7 +1730,7 @@ Operation<T>::Operation(OpType op_type,
     CacheConstValue();
 }
 
-template <class T>
+template <typename T>
 Operation<T>::Operation(OpType op_type, std::unique_ptr<ValueRef<T>>&& operand) :
     m_op_type(op_type)
 {
@@ -1740,7 +1740,7 @@ Operation<T>::Operation(OpType op_type, std::unique_ptr<ValueRef<T>>&& operand) 
     CacheConstValue();
 }
 
-template <class T>
+template <typename T>
 Operation<T>::Operation(OpType op_type, std::vector<std::unique_ptr<ValueRef<T>>>&& operands) :
     m_op_type(op_type),
     m_operands(std::move(operands))
@@ -1749,7 +1749,7 @@ Operation<T>::Operation(OpType op_type, std::vector<std::unique_ptr<ValueRef<T>>
     CacheConstValue();
 }
 
-template <class T>
+template <typename T>
 void Operation<T>::DetermineIfConstantExpr()
 {
     if (m_op_type == RANDOM_UNIFORM || m_op_type == RANDOM_PICK) {
@@ -1767,7 +1767,7 @@ void Operation<T>::DetermineIfConstantExpr()
     }
 }
 
-template <class T>
+template <typename T>
 void Operation<T>::CacheConstValue()
 {
     if (!m_constant_expr)
@@ -1776,7 +1776,7 @@ void Operation<T>::CacheConstValue()
     m_cached_const_value = this->EvalImpl(ScriptingContext());
 }
 
-template <class T>
+template <typename T>
 bool Operation<T>::operator==(const ValueRef<T>& rhs) const
 {
     if (&rhs == this)
@@ -1805,11 +1805,11 @@ bool Operation<T>::operator==(const ValueRef<T>& rhs) const
     return true;
 }
 
-template <class T>
+template <typename T>
 OpType Operation<T>::GetOpType() const
 { return m_op_type; }
 
-template <class T>
+template <typename T>
 const ValueRef<T>* Operation<T>::LHS() const
 {
     if (m_operands.empty())
@@ -1817,7 +1817,7 @@ const ValueRef<T>* Operation<T>::LHS() const
     return m_operands[0].get();
 }
 
-template <class T>
+template <typename T>
 const ValueRef<T>* Operation<T>::RHS() const
 {
     if (m_operands.size() < 2)
@@ -1825,7 +1825,7 @@ const ValueRef<T>* Operation<T>::RHS() const
     return m_operands[1].get();
 }
 
-template <class T>
+template <typename T>
 const std::vector<ValueRef<T>*> Operation<T>::Operands() const
 {
     std::vector<ValueRef<T>*> retval(m_operands.size());
@@ -1834,7 +1834,7 @@ const std::vector<ValueRef<T>*> Operation<T>::Operands() const
     return retval;
 }
 
-template <class T>
+template <typename T>
 T Operation<T>::Eval(const ScriptingContext& context) const
 {
     if (m_constant_expr)
@@ -1842,7 +1842,7 @@ T Operation<T>::Eval(const ScriptingContext& context) const
     return this->EvalImpl(context);
 }
 
-template <class T>
+template <typename T>
 T Operation<T>::EvalImpl(const ScriptingContext& context) const
 {
     switch (m_op_type) {
@@ -1925,7 +1925,7 @@ T Operation<T>::EvalImpl(const ScriptingContext& context) const
     throw std::runtime_error("ValueRef::Operation<T>::EvalImpl evaluated with an unknown or invalid OpType.");
 }
 
-template <class T>
+template <typename T>
 unsigned int Operation<T>::GetCheckSum() const
 {
     unsigned int retval{0};
@@ -1948,7 +1948,7 @@ FO_COMMON_API double Operation<double>::EvalImpl(const ScriptingContext& context
 template <>
 FO_COMMON_API int Operation<int>::EvalImpl(const ScriptingContext& context) const;
 
-template <class T>
+template <typename T>
 bool Operation<T>::RootCandidateInvariant() const
 {
     if (m_op_type == RANDOM_UNIFORM || m_op_type == RANDOM_PICK)
@@ -1960,7 +1960,7 @@ bool Operation<T>::RootCandidateInvariant() const
     return true;
 }
 
-template <class T>
+template <typename T>
 bool Operation<T>::LocalCandidateInvariant() const
 {
     if (m_op_type == RANDOM_UNIFORM || m_op_type == RANDOM_PICK)
@@ -1972,7 +1972,7 @@ bool Operation<T>::LocalCandidateInvariant() const
     return true;
 }
 
-template <class T>
+template <typename T>
 bool Operation<T>::TargetInvariant() const
 {
     if (m_op_type == RANDOM_UNIFORM || m_op_type == RANDOM_PICK)
@@ -1984,7 +1984,7 @@ bool Operation<T>::TargetInvariant() const
     return true;
 }
 
-template <class T>
+template <typename T>
 bool Operation<T>::SourceInvariant() const
 {
     if (m_op_type == RANDOM_UNIFORM || m_op_type == RANDOM_PICK)
@@ -1996,7 +1996,7 @@ bool Operation<T>::SourceInvariant() const
     return true;
 }
 
-template <class T>
+template <typename T>
 bool Operation<T>::SimpleIncrement() const
 {
     if (m_op_type != PLUS && m_op_type != MINUS)
@@ -2011,7 +2011,7 @@ bool Operation<T>::SimpleIncrement() const
     return lhs->GetReferenceType() == EFFECT_TARGET_VALUE_REFERENCE;
 }
 
-template <class T>
+template <typename T>
 std::string Operation<T>::Description() const
 {
     if (m_op_type == NEGATE) {
@@ -2127,7 +2127,7 @@ std::string Operation<T>::Description() const
     return retval;
 }
 
-template <class T>
+template <typename T>
 std::string Operation<T>::Dump(unsigned short ntabs) const
 {
     if (m_op_type == NEGATE) {
@@ -2243,7 +2243,7 @@ std::string Operation<T>::Dump(unsigned short ntabs) const
     return retval;
 }
 
-template <class T>
+template <typename T>
 void Operation<T>::SetTopLevelContent(const std::string& content_name) {
     for (auto& operand : m_operands) {
         if (operand)
@@ -2251,8 +2251,8 @@ void Operation<T>::SetTopLevelContent(const std::string& content_name) {
     }
 }
 
-template <class T>
-template <class Archive>
+template <typename T>
+template <typename Archive>
 void Operation<T>::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(ValueRef)

--- a/util/CheckSums.h
+++ b/util/CheckSums.h
@@ -19,14 +19,14 @@ namespace CheckSums {
     FO_COMMON_API void CheckSumCombine(unsigned int& sum, const std::string& c);
 
     // integeral types
-    template <class T>
+    template <typename T>
     void CheckSumCombine(unsigned int& sum, T t,
                          typename std::enable_if<std::is_signed<T>::value, T>::type* = nullptr)
     {
         sum += static_cast<unsigned int>(std::abs(t));
         sum %= CHECKSUM_MODULUS;
     }
-    template <class T>
+    template <typename T>
     void CheckSumCombine(unsigned int& sum, T t,
                          typename std::enable_if<std::is_unsigned<T>::value, T>::type* = nullptr)
     {
@@ -35,7 +35,7 @@ namespace CheckSums {
     }
 
     // classes that have GetCheckSum methods
-    template <class C>
+    template <typename C>
     void CheckSumCombine(unsigned int& sum, const C& c,
                          decltype(std::declval<C>().GetCheckSum())* = nullptr)
     {
@@ -45,7 +45,7 @@ namespace CheckSums {
     }
 
     // enums
-    template <class T>
+    template <typename T>
     void CheckSumCombine(unsigned int& sum, T t,
                          typename std::enable_if<std::is_enum<T>::value, T>::type* = nullptr)
     {
@@ -54,21 +54,21 @@ namespace CheckSums {
     }
 
     // pointer types
-    template <class T>
+    template <typename T>
     void CheckSumCombine(unsigned int& sum, const T* p)
     {
         TraceLogger() << "CheckSumCombine(T*): " << typeid(p).name();
         if (p)
             CheckSumCombine(sum, *p);
     }
-    template <class T>
+    template <typename T>
     void CheckSumCombine(unsigned int& sum, const typename std::shared_ptr<T>& p)
     {
         TraceLogger() << "CheckSumCombine(shared_ptr<T>): " << typeid(p).name();
         if (p)
             CheckSumCombine(sum, *p);
     }
-    template <class T>
+    template <typename T>
     void CheckSumCombine(unsigned int& sum, const typename std::unique_ptr<T>& p)
     {
         TraceLogger() << "CheckSumCombine(unique_ptr<T>): " << typeid(p).name();
@@ -77,7 +77,7 @@ namespace CheckSums {
     }
 
     // pairs (including map value types)
-    template <class C, class D>
+    template <typename C, typename D>
     void CheckSumCombine(unsigned int& sum, const std::pair<C, D>& p)
     {
         TraceLogger() << "CheckSumCombine(pair): " << typeid(p).name();
@@ -86,7 +86,7 @@ namespace CheckSums {
     }
 
     // iterable containers
-    template <class C>
+    template <typename C>
     void CheckSumCombine(unsigned int& sum, const C& c,
                          decltype(std::declval<C>().begin())* = nullptr,
                          decltype(std::declval<C>().end())* = nullptr)

--- a/util/GameRules.h
+++ b/util/GameRules.h
@@ -103,7 +103,7 @@ public:
     /** Adds a rule, optionally with a custom validator.
         Adds option setup.rules.{RULE_NAME} to override default value and
         option setup.rules.server-locked.{RULE_NAME} to block rule changes from players */
-    template <class T>
+    template <typename T>
     void Add(const std::string& name, const std::string& description,
              const std::string& category, T default_value,
              bool engine_interal, const ValidatorBase& validator = Validator<T>())

--- a/util/ModeratorAction.h
+++ b/util/ModeratorAction.h
@@ -34,7 +34,7 @@ public:
 
 private:
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -52,7 +52,7 @@ private:
     int m_object_id;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -71,7 +71,7 @@ private:
     int m_new_owner_empire_id;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -90,7 +90,7 @@ private:
     int m_id_2;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -109,7 +109,7 @@ private:
     int m_id_2;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -129,7 +129,7 @@ private:
     StarType    m_star_type;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -149,7 +149,7 @@ private:
     PlanetSize  m_planet_size;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 

--- a/util/MultiplayerCommon.h
+++ b/util/MultiplayerCommon.h
@@ -78,7 +78,7 @@ struct FO_COMMON_API GalaxySetupData {
 
 private:
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -101,7 +101,7 @@ struct FO_COMMON_API SaveGameUIData {
 
 private:
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -143,7 +143,7 @@ struct FO_COMMON_API SaveGameEmpireData {
 
 private:
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -170,7 +170,7 @@ struct FO_COMMON_API PlayerSaveHeaderData {
 
 private:
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -200,7 +200,7 @@ struct FO_COMMON_API PlayerSaveGameData : public PlayerSaveHeaderData {
 
 private:
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -221,7 +221,7 @@ struct FO_COMMON_API ServerSaveGameData {
 
 private:
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -256,7 +256,7 @@ struct PlayerSetupData {
 
 private:
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 bool FO_COMMON_API operator==(const PlayerSetupData& lhs, const PlayerSetupData& rhs);
@@ -283,7 +283,7 @@ struct SinglePlayerSetupData : public GalaxySetupData {
 
 private:
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -344,7 +344,7 @@ struct FO_COMMON_API MultiplayerLobbyData : public GalaxySetupData {
 
 private:
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -364,7 +364,7 @@ struct FO_COMMON_API ChatHistoryEntity {
 
 private:
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -392,7 +392,7 @@ struct PlayerInfo {
     bool                    host;           ///< true iff this is the host player
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 

--- a/util/OptionValidators.h
+++ b/util/OptionValidators.h
@@ -13,16 +13,20 @@
 
 // these are needed by the StepValidator
 namespace details {
-    template <class T> inline T mod (T dividend, T divisor)
+    template <typename T>
+    inline T mod (T dividend, T divisor)
     { return (dividend % divisor); }
 
-    template <> inline float mod<float>(float dividend, float divisor)
+    template <>
+    inline float mod<float>(float dividend, float divisor)
     { return std::fmod(dividend, divisor); }
 
-    template <> inline double mod<double>(double dividend, double divisor)
+    template <>
+    inline double mod<double>(double dividend, double divisor)
     { return std::fmod(dividend, divisor); }
 
-    template <> inline long double mod<long double>(long double dividend, long double divisor)
+    template <>
+    inline long double mod<long double>(long double dividend, long double divisor)
     { return std::fmod(dividend, divisor); }
 }
 
@@ -43,7 +47,7 @@ struct ValidatorBase
 };
 
 /** determines if a string is a valid value for an OptionsDB option */
-template <class T>
+template <typename T>
 struct Validator : public ValidatorBase
 {
     boost::any Validate(const std::string& str) const override
@@ -73,7 +77,7 @@ struct Validator<std::vector<std::string>> : public ValidatorBase
 };
 
 /** a Validator that constrains the range of valid values */
-template <class T>
+template <typename T>
 struct RangedValidator : public Validator<T>
 {
     RangedValidator(const T& min, const T& max) : m_min(min), m_max(max) {}
@@ -96,7 +100,7 @@ struct RangedValidator : public Validator<T>
     (eg: 0, 25, 50, ...).  The steps are assumed to begin at the
     validated type's default-constructed value, unless another origin
     is specified. */
-template <class T>
+template <typename T>
 struct StepValidator : public Validator<T>
 {
     StepValidator(const T& step, const T& origin = T()) : m_step_size(step), m_origin(origin) {}
@@ -116,7 +120,7 @@ struct StepValidator : public Validator<T>
 };
 
 /** a Validator similar to a StepValidator, but that further constrains the valid values to be within a certain range (eg: [25, 50, ..., 200]). */
-template <class T>
+template <typename T>
 struct RangedStepValidator : public Validator<T>
 {
 public:
@@ -143,7 +147,7 @@ public:
 
 /// a Validator that specifies a finite number of valid values.
 /** Probably won't work well with floating point types. */
-template <class T>
+template <typename T>
 struct DiscreteValidator : public Validator<T>
 {
     DiscreteValidator(const T& single_value) :
@@ -154,7 +158,7 @@ struct DiscreteValidator : public Validator<T>
         m_values(values)
     { }
 
-    template <class iter>
+    template <typename iter>
     DiscreteValidator(iter start, iter finish) :
         m_values(start, finish)
     { }
@@ -184,7 +188,7 @@ struct DiscreteValidator : public Validator<T>
 /** Stores and owns clones of the provided validators in std::unique_ptr.
  *  Always calls m_validator_a->Validate(). Only calls m_validator_b->Validate()
  *  if the first one throws. */
-template <class T>
+template <typename T>
 struct OrValidator : public Validator<T>
 {
     OrValidator(const Validator<T>& validator_a,

--- a/util/OptionsDB.h
+++ b/util/OptionsDB.h
@@ -135,7 +135,7 @@ public:
     /** returns the value of option \a name. Note that the exact type of item
       * stored in the option \a name must be known in advance.  This means that
       * Get() must be called as Get<int>("foo"), etc. */
-    template <class T>
+    template <typename T>
     T Get(const std::string& name) const
     {
         auto it = m_options.find(name);
@@ -157,7 +157,7 @@ public:
     /** returns the default value of option \a name. Note that the exact type
       * of item stored in the option \a name must be known in advance.  This
       * means that GetDefault() must be called as Get<int>("foo"), etc. */
-    template <class T>
+    template <typename T>
     T GetDefault(const std::string& name) const
     {
         auto it = m_options.find(name);
@@ -216,7 +216,7 @@ public:
     mutable OptionRemovedSignalType OptionRemovedSignal; ///< the change removed signal object for this DB
 
     /** adds an Option, optionally with a custom validator */
-    template <class T>
+    template <typename T>
     void Add(const std::string& name, const std::string& description, T default_value,
              const ValidatorBase& validator = Validator<T>(), bool storable = true,
              const std::string& section = std::string())
@@ -246,7 +246,7 @@ public:
 
     /** adds an Option with an alternative one-character shortened name,
       * optionally with a custom validator */
-    template <class T>
+    template <typename T>
     void Add(char short_name, const std::string& name, const std::string& description, T default_value,
              const ValidatorBase& validator = Validator<T>(), bool storable = true,
              const std::string& section = std::string())
@@ -329,7 +329,7 @@ public:
     void RemoveUnrecognized(const std::string& prefix = "");
 
     /** sets the value of option \a name to \a value */
-    template <class T>
+    template <typename T>
     void Set(const std::string& name, const T& value)
     {
         auto it = m_options.find(name);
@@ -339,7 +339,7 @@ public:
     }
 
     /** Set the default value of option @p name to @p value */
-    template <class T>
+    template <typename T>
     void SetDefault(const std::string& name, const T& value) {
         std::map<std::string, Option>::iterator it = m_options.find(name);
         if (!OptionExists(it))

--- a/util/Order.h
+++ b/util/Order.h
@@ -86,7 +86,7 @@ private:
     mutable bool m_executed = false;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -131,7 +131,7 @@ private:
     std::string m_name;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -184,7 +184,7 @@ private:
     bool m_aggressive;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -238,7 +238,7 @@ private:
     bool m_append = false;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -285,7 +285,7 @@ private:
     std::vector<int> m_add_ships;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -334,7 +334,7 @@ private:
     int m_planet = INVALID_OBJECT_ID;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -383,7 +383,7 @@ private:
     int m_planet = INVALID_OBJECT_ID;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -430,7 +430,7 @@ private:
     int m_planet = INVALID_OBJECT_ID;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -469,7 +469,7 @@ private:
     std::string m_focus;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -504,7 +504,7 @@ private:
     static const int INVALID_PAUSE_RESUME = -1;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -563,7 +563,7 @@ private:
     static const int INVALID_QUANTITY = -1000;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -638,7 +638,7 @@ private:
     // end details of design to create
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -679,7 +679,7 @@ private:
     int m_object_id = INVALID_OBJECT_ID;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -724,7 +724,7 @@ private:
     bool m_aggression = false;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -770,7 +770,7 @@ private:
     int m_recipient_empire_id = ALL_EMPIRES;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -805,7 +805,7 @@ private:
     int m_object_id = INVALID_OBJECT_ID;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 

--- a/util/OrderSet.h
+++ b/util/OrderSet.h
@@ -85,12 +85,12 @@ private:
     std::set<int> m_last_deleted_orders; ///< set of ids deleted orders
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
 // Template Implementations
-template <class Archive>
+template <typename Archive>
 void OrderSet::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_NVP(m_orders);

--- a/util/RunQueue.h
+++ b/util/RunQueue.h
@@ -8,10 +8,10 @@
 #include <boost/thread/thread.hpp>
 #include <vector>
 
-template <class WorkItem>
+template <typename WorkItem>
 class RunQueue;
 
-template <class WorkItem>
+template <typename WorkItem>
 struct ThreadQueue : public boost::noncopyable {
     RunQueue<WorkItem>*     global_queue;
     volatile unsigned       running_queue_size;
@@ -26,7 +26,7 @@ struct ThreadQueue : public boost::noncopyable {
     void operator ()();
 };
 
-template <class WorkItem>
+template <typename WorkItem>
 class RunQueue : public boost::noncopyable {
 public:
     RunQueue(unsigned n_threads);

--- a/util/RunQueue.tcc
+++ b/util/RunQueue.tcc
@@ -4,7 +4,7 @@
 #include <boost/thread/thread.hpp>
 #include <algorithm>
 
-template <class WorkItem>
+template <typename WorkItem>
 ThreadQueue<WorkItem>::ThreadQueue(RunQueue<WorkItem>* the_global_queue) : work_queue_1(), work_queue_2() {
     global_queue         = the_global_queue;
     running_queue_size   = 0U;
@@ -14,7 +14,7 @@ ThreadQueue<WorkItem>::ThreadQueue(RunQueue<WorkItem>* the_global_queue) : work_
     thread = boost::thread(boost::ref(*this));
 }
 
-template <class WorkItem>
+template <typename WorkItem>
 void ThreadQueue<WorkItem>::operator ()() {
     while (true) {
         while (running_queue_size) {
@@ -45,7 +45,7 @@ void ThreadQueue<WorkItem>::operator ()() {
     }
 }
 
-template <class WorkItem>
+template <typename WorkItem>
 RunQueue<WorkItem>::RunQueue(unsigned n_threads) :
     m_terminate (false),
     m_schedule_mutex(),
@@ -62,7 +62,7 @@ RunQueue<WorkItem>::RunQueue(unsigned n_threads) :
     }
 }
 
-template <class WorkItem>
+template <typename WorkItem>
 RunQueue<WorkItem>::~RunQueue() {
     {
         boost::shared_lock<boost::shared_mutex> schedule_lock(m_schedule_mutex);
@@ -73,7 +73,7 @@ RunQueue<WorkItem>::~RunQueue() {
         thread_queue->thread.join();
 }
 
-template <class WorkItem>
+template <typename WorkItem>
 void RunQueue<WorkItem>::AddWork(WorkItem* item) {
     boost::shared_lock<boost::shared_mutex> schedule_lock(m_schedule_mutex);
     const unsigned old_transfer_queue_size = m_transfer_queue_size++;
@@ -85,7 +85,8 @@ void RunQueue<WorkItem>::AddWork(WorkItem* item) {
 }
 
 namespace {
-    template <class Lockable> class scoped_unlock : public boost::noncopyable {
+    template <typename Lockable>
+    class scoped_unlock : public boost::noncopyable {
     private:
         Lockable& m_lockable;
     public:
@@ -94,7 +95,7 @@ namespace {
     };
 }
 
-template <class WorkItem>
+template <typename WorkItem>
 void RunQueue<WorkItem>::Wait(boost::unique_lock<boost::shared_mutex>& lock) {
     scoped_unlock< boost::unique_lock<boost::shared_mutex> > wait_unlock(lock); // create before schedule_lock, destroy after schedule_lock
     boost::unique_lock<boost::shared_mutex> schedule_lock(m_schedule_mutex); // create after wait_unlock, destroy before wait_unlock
@@ -110,7 +111,7 @@ void RunQueue<WorkItem>::Wait(boost::unique_lock<boost::shared_mutex>& lock) {
     }
 }
 
-template <class WorkItem>
+template <typename WorkItem>
 bool RunQueue<WorkItem>::Schedule(ThreadQueue<WorkItem>& requested_by) {
     boost::unique_lock<boost::shared_mutex> schedule_lock(m_schedule_mutex);
     unsigned total_workload;
@@ -195,7 +196,7 @@ bool RunQueue<WorkItem>::Schedule(ThreadQueue<WorkItem>& requested_by) {
     return false; // should be unreachable
 }
 
-template <class WorkItem>
+template <typename WorkItem>
 void RunQueue<WorkItem>::GetTotalWorkload(unsigned& total_workload, unsigned& scheduleable_workload) {
     total_workload = scheduleable_workload = m_transfer_queue_size;
 

--- a/util/SaveGamePreviewUtils.cpp
+++ b/util/SaveGamePreviewUtils.cpp
@@ -125,7 +125,7 @@ bool SaveGamePreviewData::Valid() const
 void SaveGamePreviewData::SetBinary(bool bin)
 { description = bin ? BIN_SAVE_FILE_DESCRIPTION : XML_SAVE_FILE_DESCRIPTION; }
 
-template<class Archive>
+template <typename Archive>
 void SaveGamePreviewData::serialize(Archive& ar, unsigned int version)
 {
     if (version >= 2) {
@@ -160,7 +160,7 @@ template void SaveGamePreviewData::serialize<freeorion_xml_oarchive>(freeorion_x
 template void SaveGamePreviewData::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, unsigned int);
 
 
-template<class Archive>
+template <typename Archive>
 void FullPreview::serialize(Archive& ar, unsigned int version)
 {
     ar & BOOST_SERIALIZATION_NVP(filename)

--- a/util/SaveGamePreviewUtils.h
+++ b/util/SaveGamePreviewUtils.h
@@ -43,7 +43,7 @@ struct FO_COMMON_API SaveGamePreviewData {
     unsigned int        uncompressed_text_size = 0;     /// How many bytes capacity does the uncompressed save text take up? (ie. the part that was / will be compressed with zlib for compressed xml format saves)
     unsigned int        compressed_text_size = 0;       /// How many bytes capacity does the compressed save text take up?
 
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, unsigned int version);
 };
 
@@ -61,7 +61,7 @@ struct FO_COMMON_API FullPreview {
     GalaxySetupData     galaxy;
 private:
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -72,7 +72,7 @@ struct FO_COMMON_API PreviewInformation {
     std::vector<FullPreview>    previews;       /// The previews of the saves in this folder
 private:
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 

--- a/util/Serialize.h
+++ b/util/Serialize.h
@@ -27,27 +27,27 @@ typedef boost::archive::xml_oarchive freeorion_xml_oarchive;
 //!     transmit longs across machines with different bit-size architectures.
 
 //! Serialize @p universe to output archive @p oa.
-template <class Archive>
+template <typename Archive>
 FO_COMMON_API void Serialize(Archive& oa, const Universe& universe);
 
 //! Serialize @p object_map to output archive @p oa.
-template <class Archive>
+template <typename Archive>
 void Serialize(Archive& oa, const std::map<int, std::shared_ptr<UniverseObject>>& objects);
 
 //! Serialize @p order_set to output archive @p oa.
-template <class Archive>
+template <typename Archive>
 void Serialize(Archive& oa, const OrderSet& order_set);
 
 //! Deserialize @p universe from input archive @p ia.
-template <class Archive>
+template <typename Archive>
 FO_COMMON_API void Deserialize(Archive& ia, Universe& universe);
 
 //! Deserialize @p object_map from input archive @p ia.
-template <class Archive>
+template <typename Archive>
 void Deserialize(Archive& ia, std::map<int, std::shared_ptr<UniverseObject>>& objects);
 
 //! Deserialize @p order_set from input archive @p ia.
-template <class Archive>
+template <typename Archive>
 void Deserialize(Archive& ia, OrderSet& order_set);
 
 #endif // _Serialize_h_

--- a/util/Serialize.ipp
+++ b/util/Serialize.ipp
@@ -27,7 +27,7 @@
 
 namespace boost { namespace serialization {
 
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, GG::Clr& clr, const unsigned int version)
     {
         ar  & BOOST_SERIALIZATION_NVP(clr.r)

--- a/util/SerializeEmpire.cpp
+++ b/util/SerializeEmpire.cpp
@@ -15,7 +15,7 @@
 #include <boost/uuid/random_generator.hpp>
 
 
-template <class Archive>
+template <typename Archive>
 void ResearchQueue::Element::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_NVP(name)
@@ -30,7 +30,7 @@ template void ResearchQueue::Element::serialize<freeorion_bin_iarchive>(freeorio
 template void ResearchQueue::Element::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, const unsigned int);
 template void ResearchQueue::Element::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
 
-template <class Archive>
+template <typename Archive>
 void ResearchQueue::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_NVP(m_queue)
@@ -44,7 +44,7 @@ template void ResearchQueue::serialize<freeorion_bin_iarchive>(freeorion_bin_iar
 template void ResearchQueue::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, const unsigned int);
 template void ResearchQueue::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
 
-template <class Archive>
+template <typename Archive>
 void ProductionQueue::ProductionItem::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_NVP(build_type)
@@ -57,7 +57,7 @@ template void ProductionQueue::ProductionItem::serialize<freeorion_bin_iarchive>
 template void ProductionQueue::ProductionItem::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, const unsigned int);
 template void ProductionQueue::ProductionItem::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
 
-template <class Archive>
+template <typename Archive>
 void ProductionQueue::Element::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_NVP(item)
@@ -107,7 +107,7 @@ template void ProductionQueue::Element::serialize<freeorion_bin_iarchive>(freeor
 template void ProductionQueue::Element::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, const unsigned int);
 template void ProductionQueue::Element::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
 
-template <class Archive>
+template <typename Archive>
 void ProductionQueue::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_NVP(m_queue)
@@ -123,7 +123,7 @@ template void ProductionQueue::serialize<freeorion_bin_iarchive>(freeorion_bin_i
 template void ProductionQueue::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, const unsigned int);
 template void ProductionQueue::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
 
-template <class Archive>
+template <typename Archive>
 void Empire::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_NVP(m_id)
@@ -256,7 +256,7 @@ namespace {
     { return std::make_pair(std::max(id1, ind2), std::min(id1, ind2)); }
 }
 
-template <class Archive>
+template <typename Archive>
 void EmpireManager::serialize(Archive& ar, const unsigned int version)
 {
     if (Archive::is_loading::value) {
@@ -308,7 +308,7 @@ template void EmpireManager::serialize<freeorion_bin_iarchive>(freeorion_bin_iar
 template void EmpireManager::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, const unsigned int);
 template void EmpireManager::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
 
-template <class Archive>
+template <typename Archive>
 void DiplomaticMessage::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_NVP(m_sender_empire)
@@ -321,7 +321,7 @@ template void DiplomaticMessage::serialize<freeorion_bin_iarchive>(freeorion_bin
 template void DiplomaticMessage::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, const unsigned int);
 template void DiplomaticMessage::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
 
-template <class Archive>
+template <typename Archive>
 void SupplyManager::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_NVP(m_supply_starlane_traversals)

--- a/util/SerializeModeratorAction.cpp
+++ b/util/SerializeModeratorAction.cpp
@@ -13,7 +13,7 @@ BOOST_CLASS_EXPORT(Moderator::CreateSystem)
 BOOST_CLASS_EXPORT(Moderator::CreatePlanet)
 
 
-template <class Archive>
+template <typename Archive>
 void Moderator::ModeratorAction::serialize(Archive& ar, const unsigned int version)
 {}
 
@@ -22,7 +22,7 @@ template void Moderator::ModeratorAction::serialize<freeorion_bin_iarchive>(free
 template void Moderator::ModeratorAction::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, const unsigned int);
 template void Moderator::ModeratorAction::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
 
-template <class Archive>
+template <typename Archive>
 void Moderator::DestroyUniverseObject::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(ModeratorAction)
@@ -34,7 +34,7 @@ template void Moderator::DestroyUniverseObject::serialize<freeorion_bin_iarchive
 template void Moderator::DestroyUniverseObject::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, const unsigned int);
 template void Moderator::DestroyUniverseObject::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
 
-template <class Archive>
+template <typename Archive>
 void Moderator::SetOwner::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(ModeratorAction)
@@ -47,7 +47,7 @@ template void Moderator::SetOwner::serialize<freeorion_bin_iarchive>(freeorion_b
 template void Moderator::SetOwner::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, const unsigned int);
 template void Moderator::SetOwner::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
 
-template <class Archive>
+template <typename Archive>
 void Moderator::AddStarlane::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(ModeratorAction)
@@ -60,7 +60,7 @@ template void Moderator::AddStarlane::serialize<freeorion_bin_iarchive>(freeorio
 template void Moderator::AddStarlane::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, const unsigned int);
 template void Moderator::AddStarlane::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
 
-template <class Archive>
+template <typename Archive>
 void Moderator::RemoveStarlane::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(ModeratorAction)
@@ -73,7 +73,7 @@ template void Moderator::RemoveStarlane::serialize<freeorion_bin_iarchive>(freeo
 template void Moderator::RemoveStarlane::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, const unsigned int);
 template void Moderator::RemoveStarlane::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
 
-template <class Archive>
+template <typename Archive>
 void Moderator::CreateSystem::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(ModeratorAction)
@@ -87,7 +87,7 @@ template void Moderator::CreateSystem::serialize<freeorion_bin_iarchive>(freeori
 template void Moderator::CreateSystem::serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive&, const unsigned int);
 template void Moderator::CreateSystem::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
 
-template <class Archive>
+template <typename Archive>
 void Moderator::CreatePlanet::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(ModeratorAction)

--- a/util/SerializeMultiplayerCommon.cpp
+++ b/util/SerializeMultiplayerCommon.cpp
@@ -13,7 +13,7 @@
 #include <boost/uuid/uuid_io.hpp>
 
 
-template <class Archive>
+template <typename Archive>
 void GalaxySetupData::serialize(Archive& ar, const unsigned int version)
 {
     if (Archive::is_saving::value && m_encoding_empire != ALL_EMPIRES && (!GetOptionsDB().Get<bool>("network.server.publish-seed"))) {
@@ -52,7 +52,7 @@ template void GalaxySetupData::serialize<freeorion_xml_oarchive>(freeorion_xml_o
 template void GalaxySetupData::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
 
 
-template <class Archive>
+template <typename Archive>
 void SinglePlayerSetupData::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(GalaxySetupData)
@@ -67,7 +67,7 @@ template void SinglePlayerSetupData::serialize<freeorion_xml_oarchive>(freeorion
 template void SinglePlayerSetupData::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
 
 
-template <class Archive>
+template <typename Archive>
 void SaveGameUIData::serialize(Archive& ar, const unsigned int version)
 {
     TraceLogger() << "SaveGameUIData::serialize " << (Archive::is_saving::value ? "saving" : "loading")
@@ -159,7 +159,7 @@ template void SaveGameUIData::serialize<freeorion_xml_oarchive>(freeorion_xml_oa
 template void SaveGameUIData::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
 
 
-template <class Archive>
+template <typename Archive>
 void SaveGameEmpireData::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_NVP(m_empire_id)
@@ -181,7 +181,7 @@ template void SaveGameEmpireData::serialize<freeorion_xml_oarchive>(freeorion_xm
 template void SaveGameEmpireData::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
 
 
-template <class Archive>
+template <typename Archive>
 void PlayerSaveHeaderData::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_NVP(m_name)
@@ -195,7 +195,7 @@ template void PlayerSaveHeaderData::serialize<freeorion_xml_oarchive>(freeorion_
 template void PlayerSaveHeaderData::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
 
 
-template <class Archive>
+template <typename Archive>
 void PlayerSaveGameData::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_NVP(m_name)
@@ -216,7 +216,7 @@ template void PlayerSaveGameData::serialize<freeorion_xml_oarchive>(freeorion_xm
 template void PlayerSaveGameData::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
 
 
-template <class Archive>
+template <typename Archive>
 void ServerSaveGameData::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_NVP(m_current_turn);
@@ -228,7 +228,7 @@ template void ServerSaveGameData::serialize<freeorion_xml_oarchive>(freeorion_xm
 template void ServerSaveGameData::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
 
 
-template <class Archive>
+template <typename Archive>
 void PlayerSetupData::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_NVP(m_player_name)
@@ -253,7 +253,7 @@ template void PlayerSetupData::serialize<freeorion_xml_oarchive>(freeorion_xml_o
 template void PlayerSetupData::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
 
 
-template <class Archive>
+template <typename Archive>
 void MultiplayerLobbyData::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(GalaxySetupData)
@@ -278,7 +278,7 @@ template void MultiplayerLobbyData::serialize<freeorion_xml_oarchive>(freeorion_
 template void MultiplayerLobbyData::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
 
 
-template <class Archive>
+template <typename Archive>
 void ChatHistoryEntity::serialize(Archive& ar, const unsigned int version)
 {
     if (version < 1) {
@@ -299,7 +299,7 @@ template void ChatHistoryEntity::serialize<freeorion_xml_oarchive>(freeorion_xml
 template void ChatHistoryEntity::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive&, const unsigned int);
 
 
-template <class Archive>
+template <typename Archive>
 void PlayerInfo::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_NVP(name)

--- a/util/SerializeOrderSet.cpp
+++ b/util/SerializeOrderSet.cpp
@@ -32,7 +32,7 @@ BOOST_CLASS_EXPORT(GiveObjectToEmpireOrder)
 BOOST_CLASS_EXPORT(ForgetOrder)
 
 
-template <class Archive>
+template <typename Archive>
 void Order::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_NVP(m_empire);
@@ -44,7 +44,7 @@ void Order::serialize(Archive& ar, const unsigned int version)
     }
 }
 
-template <class Archive>
+template <typename Archive>
 void RenameOrder::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Order)
@@ -52,7 +52,7 @@ void RenameOrder::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_name);
 }
 
-template <class Archive>
+template <typename Archive>
 void NewFleetOrder::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Order)
@@ -62,7 +62,7 @@ void NewFleetOrder::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_aggressive);
 }
 
-template <class Archive>
+template <typename Archive>
 void FleetMoveOrder::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Order)
@@ -76,7 +76,7 @@ void FleetMoveOrder::serialize(Archive& ar, const unsigned int version)
     }
 }
 
-template <class Archive>
+template <typename Archive>
 void FleetTransferOrder::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Order)
@@ -84,7 +84,7 @@ void FleetTransferOrder::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_add_ships);
 }
 
-template <class Archive>
+template <typename Archive>
 void ColonizeOrder::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Order)
@@ -92,7 +92,7 @@ void ColonizeOrder::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_planet);
 }
 
-template <class Archive>
+template <typename Archive>
 void InvadeOrder::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Order)
@@ -100,7 +100,7 @@ void InvadeOrder::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_planet);
 }
 
-template <class Archive>
+template <typename Archive>
 void BombardOrder::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Order)
@@ -108,7 +108,7 @@ void BombardOrder::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_planet);
 }
 
-template <class Archive>
+template <typename Archive>
 void ChangeFocusOrder::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Order)
@@ -116,7 +116,7 @@ void ChangeFocusOrder::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_focus);
 }
 
-template <class Archive>
+template <typename Archive>
 void ResearchQueueOrder::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Order)
@@ -126,7 +126,7 @@ void ResearchQueueOrder::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_pause);
 }
 
-template <class Archive>
+template <typename Archive>
 void ProductionQueueOrder::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Order)
@@ -187,7 +187,7 @@ void ProductionQueueOrder::serialize(Archive& ar, const unsigned int version)
     }
 }
 
-template <class Archive>
+template <typename Archive>
 void ShipDesignOrder::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Order);
@@ -227,14 +227,14 @@ void ShipDesignOrder::serialize(Archive& ar, const unsigned int version)
     ar  & BOOST_SERIALIZATION_NVP(m_name_desc_in_stringtable);
 }
 
-template <class Archive>
+template <typename Archive>
 void ScrapOrder::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Order)
         & BOOST_SERIALIZATION_NVP(m_object_id);
 }
 
-template <class Archive>
+template <typename Archive>
 void AggressiveOrder::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Order)
@@ -242,7 +242,7 @@ void AggressiveOrder::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_aggression);
 }
 
-template <class Archive>
+template <typename Archive>
 void GiveObjectToEmpireOrder::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Order)
@@ -250,20 +250,20 @@ void GiveObjectToEmpireOrder::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_recipient_empire_id);
 }
 
-template <class Archive>
+template <typename Archive>
 void ForgetOrder::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(Order)
         & BOOST_SERIALIZATION_NVP(m_object_id);
 }
 
-template <class Archive>
+template <typename Archive>
 void Serialize(Archive& oa, const OrderSet& order_set)
 { oa << BOOST_SERIALIZATION_NVP(order_set); }
 template void Serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive& oa, const OrderSet& order_set);
 template void Serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive& oa, const OrderSet& order_set);
 
-template <class Archive>
+template <typename Archive>
 void Deserialize(Archive& ia, OrderSet& order_set)
 { ia >> BOOST_SERIALIZATION_NVP(order_set); }
 template void Deserialize<freeorion_bin_iarchive>(freeorion_bin_iarchive& ia, OrderSet& order_set);

--- a/util/SerializeUniverse.cpp
+++ b/util/SerializeUniverse.cpp
@@ -34,7 +34,7 @@ BOOST_CLASS_VERSION(ShipDesign, 2)
 BOOST_CLASS_EXPORT(Universe)
 BOOST_CLASS_VERSION(Universe, 1)
 
-template <class Archive>
+template <typename Archive>
 void ObjectMap::serialize(Archive& ar, const unsigned int version)
 {
     ar & BOOST_SERIALIZATION_NVP(m_objects);
@@ -44,7 +44,7 @@ void ObjectMap::serialize(Archive& ar, const unsigned int version)
         CopyObjectsToSpecializedMaps();
 }
 
-template <class Archive>
+template <typename Archive>
 void Universe::serialize(Archive& ar, const unsigned int version)
 {
     ObjectMap                       objects;
@@ -195,7 +195,7 @@ void Universe::serialize(Archive& ar, const unsigned int version)
     DebugLogger() << "Universe " << serializing_label << " done";
 }
 
-template <class Archive>
+template <typename Archive>
 void UniverseObject::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_NVP(m_id)
@@ -209,7 +209,7 @@ void UniverseObject::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_created_on_turn);
 }
 
-template <class Archive>
+template <typename Archive>
 void System::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(UniverseObject)
@@ -225,14 +225,14 @@ void System::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_last_turn_battle_here);
 }
 
-template <class Archive>
+template <typename Archive>
 void Field::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(UniverseObject)
         & BOOST_SERIALIZATION_NVP(m_type_name);
 }
 
-template <class Archive>
+template <typename Archive>
 void Planet::serialize(Archive& ar, const unsigned int version)
 {
    ar   & BOOST_SERIALIZATION_BASE_OBJECT_NVP(UniverseObject)
@@ -267,7 +267,7 @@ void Planet::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_last_turn_attacked_by_ship);
 }
 
-template <class Archive>
+template <typename Archive>
 void Building::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(UniverseObject)
@@ -277,7 +277,7 @@ void Building::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_produced_by_empire_id);
 }
 
-template <class Archive>
+template <typename Archive>
 void Fleet::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(UniverseObject)
@@ -295,7 +295,7 @@ void Fleet::serialize(Archive& ar, const unsigned int version)
         & BOOST_SERIALIZATION_NVP(m_arrival_starlane);
 }
 
-template <class Archive>
+template <typename Archive>
 void Ship::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(UniverseObject)
@@ -317,7 +317,7 @@ void Ship::serialize(Archive& ar, const unsigned int version)
     }
 }
 
-template <class Archive>
+template <typename Archive>
 void ShipDesign::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_NVP(m_id)
@@ -370,7 +370,7 @@ void SpeciesManager::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive& a
 template
 void SpeciesManager::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive& ar, const unsigned int version);
 
-template <class Archive>
+template <typename Archive>
 void SpeciesManager::serialize(Archive& ar, const unsigned int version)
 {
     // Don't need to send all the data about species, as this is derived from
@@ -420,25 +420,25 @@ void System::serialize<freeorion_bin_iarchive>(freeorion_bin_iarchive& ar, const
 template
 void System::serialize<freeorion_xml_iarchive>(freeorion_xml_iarchive& ar, const unsigned int version);
 
-template <class Archive>
+template <typename Archive>
 void Serialize(Archive& oa, const Universe& universe)
 { oa << BOOST_SERIALIZATION_NVP(universe); }
 template FO_COMMON_API void Serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive& oa, const Universe& universe);
 template FO_COMMON_API void Serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive& oa, const Universe& universe);
 
-template <class Archive>
+template <typename Archive>
 void Serialize(Archive& oa, const std::map<int, std::shared_ptr<UniverseObject>>& objects)
 { oa << BOOST_SERIALIZATION_NVP(objects); }
 template void Serialize<freeorion_bin_oarchive>(freeorion_bin_oarchive& oa, const std::map<int, std::shared_ptr<UniverseObject>>& objects);
 template void Serialize<freeorion_xml_oarchive>(freeorion_xml_oarchive& oa, const std::map<int, std::shared_ptr<UniverseObject>>& objects);
 
-template <class Archive>
+template <typename Archive>
 void Deserialize(Archive& ia, Universe& universe)
 { ia >> BOOST_SERIALIZATION_NVP(universe); }
 template FO_COMMON_API void Deserialize<freeorion_bin_iarchive>(freeorion_bin_iarchive& ia, Universe& universe);
 template FO_COMMON_API void Deserialize<freeorion_xml_iarchive>(freeorion_xml_iarchive& ia, Universe& universe);
 
-template <class Archive>
+template <typename Archive>
 void Deserialize(Archive& ia, std::map<int, std::shared_ptr<UniverseObject>>& objects)
 { ia >> BOOST_SERIALIZATION_NVP(objects); }
 template void Deserialize<freeorion_bin_iarchive>(freeorion_bin_iarchive& ia, std::map<int, std::shared_ptr<UniverseObject>>& objects);

--- a/util/SitRepEntry.h
+++ b/util/SitRepEntry.h
@@ -31,7 +31,7 @@ private:
     std::string m_label;
 
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
@@ -67,7 +67,7 @@ FO_COMMON_API SitRepEntry CreateSitRep(const std::string& template_string, int t
                                        const std::vector<std::pair<std::string, std::string>>& parameters, const std::string label = "", bool stringtable_lookup = true);
 //! @}
 
-template <class Archive>
+template <typename Archive>
 void SitRepEntry::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_BASE_OBJECT_NVP(VarText)

--- a/util/VarText.h
+++ b/util/VarText.h
@@ -194,11 +194,11 @@ protected:
 
 private:
     friend class boost::serialization::access;
-    template <class Archive>
+    template <typename Archive>
     void serialize(Archive& ar, const unsigned int version);
 };
 
-template <class Archive>
+template <typename Archive>
 void VarText::serialize(Archive& ar, const unsigned int version)
 {
     ar  & BOOST_SERIALIZATION_NVP(m_template_string)

--- a/util/base64_filter.h
+++ b/util/base64_filter.h
@@ -126,7 +126,7 @@ struct urlsafe_base64_traits
 };
 
 
-template<class Derived, class CharT, std::streamsize MaxBlockSize>
+template<typename Derived, typename CharT, std::streamsize MaxBlockSize>
 class arbitrary_positional_facade;
 
 class core_access
@@ -134,23 +134,23 @@ class core_access
 #if defined(BOOST_NO_MEMBER_TEMPLATE_FRIENDS)
 public:
 #else
-    template<class Derived, class CharT, std::streamsize MaxBlockSize>
+    template<typename Derived, typename CharT, std::streamsize MaxBlockSize>
     friend class arbitrary_positional_facade;
 
     friend struct device_operations;
 
-    template<class Device>
+    template <typename Device>
     friend struct filter_operations;
 #endif
 
-    template<class RepositionalSource, class CharT>
+    template<typename RepositionalSource, typename CharT>
     static std::streamsize read_blocks(
         RepositionalSource& src, CharT* s, std::streamsize n)
     {
         return src.read_blocks(s, n);
     }
 
-    template<class RepositionalInputFilter, class Source>
+    template<typename RepositionalInputFilter, typename Source>
     static std::streamsize read_blocks(
         RepositionalInputFilter& filter, Source& src,
         typename boost::iostreams::char_type_of<Source>::type* s,
@@ -159,14 +159,14 @@ public:
         return filter.read_blocks(src, s, n);
     }
 
-    template<class RepositionalSink, class CharT>
+    template<typename RepositionalSink, typename CharT>
     static std::streamsize write_blocks(
         RepositionalSink& sink, const CharT* s, std::streamsize n)
     {
         return sink.write_blocks(s, n);
     }
 
-    template<class RepositionalOutputFilter, class Sink>
+    template<typename RepositionalOutputFilter, typename Sink>
     static std::streamsize write_blocks(
         RepositionalOutputFilter& filter, Sink& sink,
         const typename boost::iostreams::char_type_of<Sink>::type* s,
@@ -175,14 +175,14 @@ public:
         return filter.write_blocks(sink, s, n);
     }
 
-    template<class RepositionalSink, class CharT>
+    template<typename RepositionalSink, typename CharT>
     static void close_with_flush(
         RepositionalSink& sink, const CharT* s, std::streamsize n)
     {
         return sink.close_with_flush(s, n);
     }
 
-    template<class RepositionalOutputFilter, class Sink>
+    template<typename RepositionalOutputFilter, typename Sink>
     static void close_with_flush(
         RepositionalOutputFilter& filter, Sink& sink,
         const typename boost::iostreams::char_type_of<Sink>::type* s,
@@ -191,7 +191,7 @@ public:
         return filter.close_with_flush(sink, s, n);
     }
 
-    template<class RepositionalDevice>
+    template <typename RepositionalDevice>
     static std::streampos seek_blocks(
         RepositionalDevice& dev,
         boost::iostreams::stream_offset off, BOOST_IOS::seekdir way)
@@ -201,14 +201,14 @@ public:
 
     struct device_operations
     {
-        template<class RepositionalDevice, class CharT>
+        template<typename RepositionalDevice, typename CharT>
         std::streamsize read_blocks(
             RepositionalDevice& t, CharT* s, std::streamsize n) const
         {
             return core_access::read_blocks(t, s, n);
         }
 
-        template<class RepositionalDevice, class CharT>
+        template<typename RepositionalDevice, typename CharT>
         std::streamsize write_blocks(
             RepositionalDevice& t, const CharT* s, std::streamsize n) const
         {
@@ -216,7 +216,7 @@ public:
         }
     };
 
-    template<class Device>
+    template <typename Device>
     struct filter_operations
     {
         typedef typename boost::iostreams::
@@ -226,14 +226,14 @@ public:
 
         explicit filter_operations(Device& dev) : dev_ptr_(&dev) {}
 
-        template<class RepositionalInputFilter>
+        template <typename RepositionalInputFilter>
         std::streamsize read_blocks(
             RepositionalInputFilter& t, char_type* s, std::streamsize n) const
         {
             return core_access::read_blocks(t, *dev_ptr_, s, n);
         }
 
-        template<class RepositionalOutputFilter>
+        template <typename RepositionalOutputFilter>
         std::streamsize write_blocks(
             RepositionalOutputFilter& t,
             const char_type* s, std::streamsize n) const
@@ -243,7 +243,7 @@ public:
     };
 };
 
-template<class Derived, class CharT, std::streamsize MaxBlockSize>
+template<typename Derived, typename CharT, std::streamsize MaxBlockSize>
 class arbitrary_positional_facade
 {
 private:
@@ -279,7 +279,7 @@ public:
         return read_impl(core_access::device_operations(), s, n);
     }
 
-    template<class Source>
+    template <typename Source>
     std::streamsize read(Source& src, char_type* s, std::streamsize n)
     {
         return read_impl(core_access::filter_operations<Source>(src), s, n);
@@ -290,7 +290,7 @@ public:
         return write_impl(core_access::device_operations(), s, n);
     }
 
-    template<class Sink>
+    template <typename Sink>
     std::streamsize write(Sink& sink, const char_type* s, std::streamsize n)
     {
         return write_impl(core_access::filter_operations<Sink>(sink), s, n);
@@ -302,7 +302,7 @@ public:
         core_access::close_with_flush(derived(), buffer_, count_);
     }
 
-    template<class Sink>
+    template <typename Sink>
     void close(Sink& sink)
     {
         BOOST_ASSERT(count_ < block_size_);
@@ -390,7 +390,7 @@ private:
     std::streamsize block_size_;
     std::streamsize count_;
 
-    template<class Op>
+    template <typename Op>
     std::streamsize read_impl(const Op& op, char_type* s, std::streamsize n)
     {
         std::streamsize total = 0;
@@ -443,7 +443,7 @@ private:
         return total != 0 ? total : -1;
     }
 
-    template<class Op>
+    template <typename Op>
     std::streamsize write_impl(
         const Op& op, const char_type* s, std::streamsize n)
     {
@@ -493,7 +493,7 @@ private:
 };
 
 
-template<class Traits>
+template <typename Traits>
 class basic_base64_encoder
     : public arbitrary_positional_facade<basic_base64_encoder<Traits>, char, 3>
 {
@@ -530,7 +530,7 @@ private:
         dst[3] = Traits::encode((tmp      ) & 0x3F);
     }
 
-    template<class Sink>
+    template <typename Sink>
     std::streamsize write_blocks(Sink& sink, const char* s, std::streamsize n)
     {
         for (int i = 0; i < n; ++i)
@@ -543,7 +543,7 @@ private:
         return n*3;
     }
 
-    template<class Sink>
+    template <typename Sink>
     void close_with_flush(Sink& sink, const char* s, std::streamsize n)
     {
         if (n != 0)
@@ -563,7 +563,7 @@ private:
     }
 };
 
-template<class Traits>
+template <typename Traits>
 class basic_base64_decoder
     : public arbitrary_positional_facade<basic_base64_decoder<Traits>, char, 3>
 {
@@ -620,7 +620,7 @@ private:
         return n;
     }
 
-    template<class Source>
+    template <typename Source>
     std::streamsize read_blocks(Source& src, char* s, std::streamsize n)
     {
         std::streamsize total = 0;
@@ -638,7 +638,7 @@ private:
         return (total != 0) ? total : -1;
     }
 
-    template<class Source>
+    template <typename Source>
     void close_with_flush(Source&, const char*, std::streamsize)
     {
     }


### PR DESCRIPTION
Functional identical to the `class` keyword.  However using `typename` makes grepping the source code easier when searching for classes.