### PR TITLE
Simplify public logger interface

### DIFF
--- a/python/LoggingWrapper.cpp
+++ b/python/LoggingWrapper.cpp
@@ -69,19 +69,19 @@ namespace {
         // if that log level is disabled.
         switch (log_level) {
         case LogLevel::trace:
-            FO_LOGGER(python, LogLevel::trace) << python_logger << boost::log::add_value("SrcFilename", filename) << boost::log::add_value("SrcLinenum", lineno) << " : " << msg;
+            FO_LOGGER(LogLevel::trace, python) << python_logger << boost::log::add_value("SrcFilename", filename) << boost::log::add_value("SrcLinenum", lineno) << " : " << msg;
             break;
         case LogLevel::debug:
-            FO_LOGGER(python, LogLevel::debug) << python_logger << boost::log::add_value("SrcFilename", filename) << boost::log::add_value("SrcLinenum", lineno) << " : " << msg;
+            FO_LOGGER(LogLevel::debug, python) << python_logger << boost::log::add_value("SrcFilename", filename) << boost::log::add_value("SrcLinenum", lineno) << " : " << msg;
             break;
         case LogLevel::info:
-            FO_LOGGER(python, LogLevel::info)  << python_logger << boost::log::add_value("SrcFilename", filename) << boost::log::add_value("SrcLinenum", lineno) << " : " << msg;
+            FO_LOGGER(LogLevel::info, python)  << python_logger << boost::log::add_value("SrcFilename", filename) << boost::log::add_value("SrcLinenum", lineno) << " : " << msg;
             break;
         case LogLevel::warn:
-            FO_LOGGER(python, LogLevel::warn)  << python_logger << boost::log::add_value("SrcFilename", filename) << boost::log::add_value("SrcLinenum", lineno) << " : " << msg;
+            FO_LOGGER(LogLevel::warn, python)  << python_logger << boost::log::add_value("SrcFilename", filename) << boost::log::add_value("SrcLinenum", lineno) << " : " << msg;
             break;
         case LogLevel::error:
-            FO_LOGGER(python, LogLevel::error) << python_logger << boost::log::add_value("SrcFilename", filename) << boost::log::add_value("SrcLinenum", lineno) << " : " << msg;
+            FO_LOGGER(LogLevel::error, python) << python_logger << boost::log::add_value("SrcFilename", filename) << boost::log::add_value("SrcLinenum", lineno) << " : " << msg;
             break;
         }
     }

--- a/python/LoggingWrapper.cpp
+++ b/python/LoggingWrapper.cpp
@@ -47,33 +47,7 @@ namespace {
         }
     }
 
-    // Setup file sink, formatting, and \p name channel filter for \p logger.
-    void ConfigurePythonLogger(NamedThreadedLogger& logger, const std::string& name) {
-        if (name.empty())
-            return;
-
-        SetLoggerThreshold(name, default_log_level_threshold);
-
-        ApplyConfigurationToFileSinkFrontEnd(
-            name,
-            std::bind(ConfigureFileSinkFrontEnd, std::placeholders::_1, name));
-
-        LoggerCreatedSignal(name);
-    }
-
-    // Place in source file to create the previously defined global logger \p name
-#define DeclareThreadSafePythonLogger(name)                       \
-    BOOST_LOG_INLINE_GLOBAL_LOGGER_INIT(                          \
-        FO_GLOBAL_LOGGER_NAME(name), NamedThreadedLogger)         \
-    {                                                             \
-        auto lg = NamedThreadedLogger(                            \
-            (boost::log::keywords::severity = LogLevel::debug),   \
-            (boost::log::keywords::channel = #name));             \
-        ConfigurePythonLogger(lg, #name);                         \
-        return lg;                                                \
-    }
-
-    DeclareThreadSafePythonLogger(python);
+    DeclareThreadSafeLogger(python);
 
     // Assemble a python message that is the same as the C++ message format.
     void PythonLogger(const std::string& msg,

--- a/util/Logger.cpp
+++ b/util/Logger.cpp
@@ -141,19 +141,16 @@ namespace {
         return forced_threshold;
     }
 
-    using TextFileSinkBackend  = sinks::text_file_backend;
-    using TextFileSinkFrontend = sinks::synchronous_sink<TextFileSinkBackend>;
-
-    boost::shared_ptr<TextFileSinkBackend>& FileSinkBackend() {
+    boost::shared_ptr<LoggerTextFileSinkFrontend::sink_backend_type>& FileSinkBackend() {
         // Create the sink backend as a function local static variable to avoid the static
         // initilization fiasco.
-        static boost::shared_ptr<TextFileSinkBackend> m_sink_backend;
+        static boost::shared_ptr<LoggerTextFileSinkFrontend::sink_backend_type> m_sink_backend;
         return m_sink_backend;
     }
 
     /** Create a new file sink front end for \p file_sink_backend for \p channel_name and
         configure it with \p configure_front_end. */
-    void ConfigureToFileSinkFrontEndCore(const boost::shared_ptr<TextFileSinkBackend>& file_sink_backend,
+    void ConfigureToFileSinkFrontEndCore(const boost::shared_ptr<LoggerTextFileSinkFrontend::sink_backend_type>& file_sink_backend,
                                          const std::string& channel_name,
                                          const LoggerFileSinkFrontEndConfigurer& configure_front_end);
 
@@ -167,12 +164,12 @@ namespace {
     class LoggersToSinkFrontEnds {
         /// m_mutex serializes access from different threads
         std::mutex m_mutex = {};
-        std::unordered_map<std::string, boost::shared_ptr<TextFileSinkFrontend>> m_names_to_front_ends = {};
+        std::unordered_map<std::string, boost::shared_ptr<LoggerTextFileSinkFrontend>> m_names_to_front_ends = {};
         std::unordered_map<std::string, LoggerFileSinkFrontEndConfigurer> m_names_to_front_end_configurers = {};
         public:
 
         void AddOrReplaceLoggerName(const std::string& channel_name,
-                                    boost::shared_ptr<TextFileSinkFrontend> front_end = nullptr)
+                                    boost::shared_ptr<LoggerTextFileSinkFrontend> front_end = nullptr)
         {
             std::lock_guard<std::mutex> lock(m_mutex);
 
@@ -210,7 +207,7 @@ namespace {
         }
 
         /** Configure front ends for any logger with stored configuration functions. */
-        void ConfigureFrontEnds(const boost::shared_ptr<TextFileSinkBackend>& file_sink_backend) {
+        void ConfigureFrontEnds(const boost::shared_ptr<LoggerTextFileSinkFrontend::sink_backend_type>& file_sink_backend) {
             for (const auto& name_and_conf: m_names_to_front_end_configurers)
                 ConfigureToFileSinkFrontEndCore(file_sink_backend, name_and_conf.first, name_and_conf.second);
         }
@@ -239,28 +236,12 @@ namespace {
         return loggers_names_to_front_ends;
     }
 
-    void ConfigureFileSinkFrontEnd(TextFileSinkFrontend& sink_frontend, const std::string& channel_name) {
-        // Create the format
-        sink_frontend.set_formatter(
-            expr::stream
-            << expr::format_date_time<boost::posix_time::ptime>("TimeStamp", "%H:%M:%S.%f")
-            << " {" << thread_id << "}"
-            << " [" << log_severity << "] "
-            << DisplayName(channel_name)
-            << " : " << log_src_filename << ":" << log_src_linenum << " : "
-            << expr::message
-        );
-
-        // Set a filter to only format this channel
-        sink_frontend.set_filter(log_channel == channel_name);
-    }
-
-    void ConfigureToFileSinkFrontEndCore(const boost::shared_ptr<TextFileSinkBackend>& file_sink_backend,
+    void ConfigureToFileSinkFrontEndCore(const boost::shared_ptr<LoggerTextFileSinkFrontend::sink_backend_type>& file_sink_backend,
                                          const std::string& channel_name,
                                          const LoggerFileSinkFrontEndConfigurer& configure_front_end)
     {
         // Create a sink frontend for formatting.
-        auto sink_frontend = boost::make_shared<TextFileSinkFrontend>(file_sink_backend);
+        auto sink_frontend = boost::make_shared<LoggerTextFileSinkFrontend>(file_sink_backend);
 
         configure_front_end(*sink_frontend);
 
@@ -343,7 +324,7 @@ void InitLoggingSystem(const std::string& log_file, const std::string& _unnamed_
 
     // Create a sink backend that logs to a file
     auto& file_sink_backend = FileSinkBackend();
-    file_sink_backend = boost::make_shared<TextFileSinkBackend>(
+    file_sink_backend = boost::make_shared<LoggerTextFileSinkFrontend::sink_backend_type>(
         keywords::file_name = log_file.c_str(),
         keywords::auto_flush = true
     );
@@ -408,6 +389,22 @@ namespace {
         LoggerCreatedSignal = LoggerCreatedSignalType();
         return true;
     };
+}
+
+void ConfigureFileSinkFrontEnd(LoggerTextFileSinkFrontend& sink_frontend, const std::string& channel_name) {
+    // Create the format
+    sink_frontend.set_formatter(
+        expr::stream
+        << expr::format_date_time<boost::posix_time::ptime>("TimeStamp", "%H:%M:%S.%f")
+        << " {" << thread_id << "}"
+        << " [" << log_severity << "] "
+        << DisplayName(channel_name)
+        << " : " << log_src_filename << ":" << log_src_linenum << " : "
+        << expr::message
+    );
+
+    // Set a filter to only format this channel
+    sink_frontend.set_filter(log_channel == channel_name);
 }
 
 void ConfigureLogger(NamedThreadedLogger& logger, const std::string& name) {

--- a/util/Logger.cpp
+++ b/util/Logger.cpp
@@ -3,6 +3,7 @@
 #include <boost/log/core.hpp>
 #include <boost/log/trivial.hpp>
 #include <boost/log/expressions.hpp>
+#include <boost/log/attributes/current_thread_id.hpp>
 #include <boost/log/attributes/value_extraction.hpp>
 #include <boost/log/expressions/keyword.hpp>
 #include <boost/log/sinks/frontend_requirements.hpp>
@@ -270,6 +271,12 @@ const std::string& DefaultExecLoggerName()
 
 std::vector<std::string> CreatedLoggersNames()
 { return GetLoggersToSinkFrontEnds().LoggersNames(); }
+
+BOOST_LOG_ATTRIBUTE_KEYWORD(log_severity, "Severity", LogLevel);
+BOOST_LOG_ATTRIBUTE_KEYWORD(log_channel, "Channel", std::string)
+BOOST_LOG_ATTRIBUTE_KEYWORD(log_src_filename, "SrcFilename", std::string);
+BOOST_LOG_ATTRIBUTE_KEYWORD(log_src_linenum, "SrcLinenum", int);
+BOOST_LOG_ATTRIBUTE_KEYWORD(thread_id, "ThreadID", boost::log::attributes::current_thread_id::value_type);
 
 namespace {
 

--- a/util/Logger.h
+++ b/util/Logger.h
@@ -3,8 +3,6 @@
 
 #include <boost/log/sources/severity_channel_logger.hpp>
 #include <boost/log/utility/manipulators/add_value.hpp>
-#include <boost/log/sinks/sync_frontend.hpp>
-#include <boost/log/sinks/text_file_backend.hpp>
 #include <boost/log/sources/global_logger_storage.hpp>
 #include <boost/signals2/signal.hpp>
 
@@ -209,24 +207,12 @@ FO_COMMON_API void OverrideAllLoggersThresholds(const boost::optional<LogLevel>&
 
 FO_COMMON_API const std::string& DefaultExecLoggerName();
 
-/** Apply \p configure_front_end to a new FileSinkFrontEnd for \p channel_name.  During static
-    initialization if the backend does not yet exist, then \p configure_front_end will be
-    stored until the backend is created.*/
-using LoggerTextFileSinkFrontend = boost::log::sinks::synchronous_sink<boost::log::sinks::text_file_backend>;
-using LoggerFileSinkFrontEndConfigurer = std::function<void(LoggerTextFileSinkFrontend& sink_frontend)>;
-FO_COMMON_API void ApplyConfigurationToFileSinkFrontEnd(
-    const std::string& channel_name,
-    const LoggerFileSinkFrontEndConfigurer& configure_front_end);
-
 /** A type for loggers (sources) that allows for severity and a logger name (channel in
     boost parlance) and supports multithreading.*/
 using NamedThreadedLogger = boost::log::sources::severity_channel_logger_mt<
     LogLevel,     ///< the type of the severity level
     std::string   ///< the channel name of the logger
     >;
-
-// Setup the file sink for @p logger
-FO_COMMON_API void ConfigureFileSinkFrontEnd(LoggerTextFileSinkFrontend& sink_frontend, const std::string& channel_name);
 
 // Setup file sink, formatting, and \p name channel filter for \p logger.
 FO_COMMON_API void ConfigureLogger(NamedThreadedLogger& logger, const std::string& name);

--- a/util/Logger.h
+++ b/util/Logger.h
@@ -1,9 +1,7 @@
 #ifndef _Logger_h_
 #define _Logger_h_
 
-#include <boost/log/attributes/current_thread_id.hpp>
 #include <boost/log/sources/severity_channel_logger.hpp>
-#include <boost/log/expressions/keyword.hpp>
 #include <boost/log/utility/manipulators/add_value.hpp>
 #include <boost/log/sinks/sync_frontend.hpp>
 #include <boost/log/sinks/text_file_backend.hpp>
@@ -275,12 +273,6 @@ BOOST_LOG_INLINE_GLOBAL_LOGGER_INIT(                                    \
 }
 
 #endif
-
-BOOST_LOG_ATTRIBUTE_KEYWORD(log_severity, "Severity", LogLevel);
-BOOST_LOG_ATTRIBUTE_KEYWORD(log_channel, "Channel", std::string)
-BOOST_LOG_ATTRIBUTE_KEYWORD(log_src_filename, "SrcFilename", std::string);
-BOOST_LOG_ATTRIBUTE_KEYWORD(log_src_linenum, "SrcLinenum", int);
-BOOST_LOG_ATTRIBUTE_KEYWORD(thread_id, "ThreadID", boost::log::attributes::current_thread_id::value_type);
 
 #define __BASE_FILENAME__ (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : strrchr(__FILE__, '\\') ? strrchr(__FILE__, '\\') + 1 : __FILE__)
 


### PR DESCRIPTION
The current header file `util/Logger.h` leaks some implementation details, which are actually should not be exposed as they increase the compile time for every file which includes it.

This PR tries to sweep some of it under the rug to improve compile time for users of the logger.

There is also potential to remove the boost::signal2 header from the logger but that requires extra work and care so this PR can be merged as is.

Some statistics:

I've used the `g++ -ftime-report` but left out the compilation steps, which were below 10% contributing to the overall time. Also keep in mind that the display of time variables is maybe a subpart of another bigger step or there was waiting for some IO operation, which is why the the percentage maybe does not sum up.

Mostly relevant is the `usr` column or `user` row, which where the compiler were actually working, `sys` indicates times where the operating system were doing work for the compiler (e.g. opening files or allocating memory). And the `wall` column or `real` row  is the overall real time (wall clock) spent.

The other g++ command uses the `-H` flag, which prints out all includes files recursively.  It does a bit of post processing and prints out the included files, as the preprocessor would find it, this may or may not repeat subtrees.

master: Overall build time (clean build tree and empty ccache):
```
$ time ninja
[...]
real	33m44,170s
user	183m17,328s
sys	13m58,895s
```

simplify-logger: Overall build time (clean build tree and empty ccache):
```
$ time ninja
[...]
real	27m25,150s
user	165m45,789s
sys	11m40,391s
```

master:parse/ConditionParser7.cpp (A template heavy implementation file)
```
$ g++ -ftime-report   -DBINPATH="/usr/local/bin" -DBOOST_ALL_DYN_LINK -DBOOST_GIL_IO_ENABLE_GRAY_ALPHA -DENABLE_BINRELOC -DFONS_USE_FREETYPE -DFREEORION_BUILD_PARSE -DFREEORION_LINUX -DNDEBUG -DSHAREPATH="/usr/local/share" -I/home/adrian/Projects/freeorion/freeorion.git/GG -IGG -I/usr/include/freetype2  -O2 -DNDEBUG -fPIC -fvisibility=hidden   -Wall -std=c++14 -o CMakeFiles/freeorionparseobj.dir/parse/ConditionParser7.cpp.o -c /home/adrian/Projects/freeorion/freeorion.git/parse/ConditionParser7.cpp

Time variable                                   usr           sys          wall               GGC
 phase setup                        :   0.00 (  0%)   0.00 (  0%)   0.01 (  0%)    1352 kB (  0%)
 phase parsing                      :  11.63 ( 53%)   3.17 ( 65%)  14.92 ( 55%) 1338217 kB ( 68%)
 phase lang. deferred               :   4.38 ( 20%)   0.82 ( 17%)   5.24 ( 19%)  366594 kB ( 19%)
 phase opt and generate             :   5.97 ( 27%)   0.86 ( 18%)   6.91 ( 26%)  249194 kB ( 13%)
[...]
 |overload resolution               :   4.15 ( 19%)   0.96 ( 20%)   5.31 ( 20%)  374733 kB ( 19%)
[...]
 preprocessing                      :   2.02 (  9%)   0.82 ( 17%)   2.91 ( 11%)  399151 kB ( 20%)
[...]
 template instantiation             :   9.92 ( 45%)   2.31 ( 48%)  12.39 ( 46%)  946172 kB ( 48%)
[...]
 TOTAL                              :  21.98          4.85         27.08        1955369 kB

$ g++ -H  -DBINPATH="/usr/local/bin" -DBOOST_ALL_DYN_LINK -DBOOST_GIL_IO_ENABLE_GRAY_ALPHA -DENABLE_BINRELOC -DFONS_USE_FREETYPE -DFREEORION_BUILD_PARSE -DFREEORION_LINUX -DNDEBUG -DSHAREPATH="/usr/local/share" -I/home/adrian/Projects/freeorion/freeorion.git/GG -IGG -I/usr/include/freetype2  -O2 -DNDEBUG -fPIC -fvisibility=hidden   -Wall -std=c++14 -o CMakeFiles/freeorionparseobj.dir/parse/ConditionParser7.cpp.o -c /home/adrian/Projects/freeorion/freeorion.git/parse/ConditionParser7.cpp 2>&1 | grep '^\.' | wc -l
4091
```

simplify-logger:parse/ConditionParser7.cpp (A template heavy implementation file)
```
$ g++ -ftime-report   -DBINPATH="/usr/local/bin" -DBOOST_ALL_DYN_LINK -DBOOST_GIL_IO_ENABLE_GRAY_ALPHA -DENABLE_BINRELOC -DFONS_USE_FREETYPE -DFREEORION_BUILD_PARSE -DFREEORION_LINUX -DNDEBUG -DSHAREPATH="/usr/local/share" -I/home/adrian/Projects/freeorion/freeorion.git/GG -IGG -I/usr/include/freetype2  -O2 -DNDEBUG -fPIC -fvisibility=hidden   -Wall -std=c++14 -o CMakeFiles/freeorionparseobj.dir/parse/ConditionParser7.cpp.o -c /home/adrian/Projects/freeorion/freeorion.git/parse/ConditionParser7.cpp

Time variable                                   usr           sys          wall               GGC
[...]
 phase parsing                      :  13.24 ( 60%)   3.82 ( 71%)  17.24 ( 63%) 1261651 kB ( 65%)
 phase lang. deferred               :   3.74 ( 17%)   0.81 ( 15%)   4.57 ( 17%)  366096 kB ( 19%)
 phase opt and generate             :   4.93 ( 23%)   0.77 ( 14%)   5.74 ( 21%)  314376 kB ( 16%)
[...]
 |overload resolution               :   4.73 ( 22%)   1.27 ( 24%)   5.77 ( 21%)  373407 kB ( 19%)
[...]
 preprocessing                      :   1.77 (  8%)   0.72 ( 13%)   2.38 (  9%)  395840 kB ( 20%)
[...]
 template instantiation             :  11.67 ( 53%)   3.10 ( 57%)  15.07 ( 55%)  942357 kB ( 48%)
[...]
 TOTAL                              :  21.91          5.40         27.56        1943486 kB

$ g++ -H  -DBINPATH="/usr/local/bin" -DBOOST_ALL_DYN_LINK -DBOOST_GIL_IO_ENABLE_GRAY_ALPHA -DENABLE_BINRELOC -DFONS_USE_FREETYPE -DFREEORION_BUILD_PARSE -DFREEORION_LINUX -DNDEBUG -DSHAREPATH="/usr/local/share" -I/home/adrian/Projects/freeorion/freeorion.git/GG -IGG -I/usr/include/freetype2  -O2 -DNDEBUG -fPIC -fvisibility=hidden   -Wall -std=c++14 -o CMakeFiles/freeorionparseobj.dir/parse/ConditionParser7.cpp.o -c /home/adrian/Projects/freeorion/freeorion.git/parse/ConditionParser7.cpp 2>&1 | grep '^\.' | wc -l
3894
```

master:universe/UnlockableItem.cpp (a simple implementation file with few dependencies)
```
$ g++ -ftime-report -DBINPATH="/usr/local/bin" -DBOOST_ALL_DYN_LINK -DENABLE_BINRELOC -DFREEORION_BUILD_COMMON -DFREEORION_LINUX -DFREEORION_PYTHON_VERSION="3.7" -DSHAREPATH="/usr/local/share" -Dfreeorioncommon_EXPORTS -isystem /home/adrian/Projects/freeorion/freeorion.git/GG -isystem GG -isystem /usr/include/freetype2 -isystem /home/adrian/Projects/freeorion/freeorion.git  -O2 -DNDEBUG -fPIC -fvisibility=hidden   -Wall -std=c++14 -o CMakeFiles/freeorioncommon.dir/universe/UnlockableItem.cpp.o -c /home/adrian/Projects/freeorion/freeorion.git/universe/UnlockableItem.cpp

Time variable                                   usr           sys          wall               GGC
[...]
 phase parsing                      :   2.38 ( 69%)   1.00 ( 88%)   3.40 ( 73%)  427558 kB ( 87%)
[...]
 preprocessing                      :   0.98 ( 28%)   0.42 ( 37%)   1.42 ( 31%)  218245 kB ( 44%)
 parser (global)                    :   0.23 (  7%)   0.17 ( 15%)   0.38 (  8%)   62178 kB ( 13%)
 parser struct body                 :   0.35 ( 10%)   0.10 (  9%)   0.49 ( 11%)   54792 kB ( 11%)
[...]
 template instantiation             :   0.64 ( 19%)   0.24 ( 21%)   0.84 ( 18%)   95112 kB ( 19%)
[...]
 TOTAL                              :   3.45          1.14          4.63         493379 kB

$ g++ -H -DBINPATH="/usr/local/bin" -DBOOST_ALL_DYN_LINK -DENABLE_BINRELOC -DFREEORION_BUILD_COMMON -DFREEORION_LINUX -DFREEORION_PYTHON_VERSION="3.7" -DSHAREPATH="/usr/local/share" -Dfreeorioncommon_EXPORTS -isystem /home/adrian/Projects/freeorion/freeorion.git/GG -isystem GG -isystem /usr/include/freetype2 -isystem /home/adrian/Projects/freeorion/freeorion.git  -O2 -DNDEBUG -fPIC -fvisibility=hidden   -Wall -std=c++14 -o CMakeFiles/freeorioncommon.dir/universe/UnlockableItem.cpp.o -c /home/adrian/Projects/freeorion/freeorion.git/universe/UnlockableItem.cpp 2>&1 | grep '^\.' | wc -l
2541
```

simplifiy-logger:universe/UnlockableItem.cpp (a simple implementation file with few dependencies)
```
$ g++ -ftime-report -DBINPATH="/usr/local/bin" -DBOOST_ALL_DYN_LINK -DENABLE_BINRELOC -DFREEORION_BUILD_COMMON -DFREEORION_LINUX -DFREEORION_PYTHON_VERSION="3.7" -DSHAREPATH="/usr/local/share" -Dfreeorioncommon_EXPORTS -isystem /home/adrian/Projects/freeorion/freeorion.git/GG -isystem GG -isystem /usr/include/freetype2 -isystem /home/adrian/Projects/freeorion/freeorion.git  -O2 -DNDEBUG -fPIC -fvisibility=hidden   -Wall -std=c++14 -o CMakeFiles/freeorioncommon.dir/universe/UnlockableItem.cpp.o -c /home/adrian/Projects/freeorion/freeorion.git/universe/UnlockableItem.cpp

Time variable                                   usr           sys          wall               GGC
[...]
 phase parsing                      :   1.40 ( 66%)   0.65 ( 84%)   2.07 ( 71%)  247973 kB ( 83%)
 phase lang. deferred               :   0.22 ( 10%)   0.07 (  9%)   0.29 ( 10%)   29425 kB ( 10%)
[...]
 |overload resolution               :   0.22 ( 10%)   0.11 ( 14%)   0.34 ( 12%)   29120 kB ( 10%)
[...]
 preprocessing                      :   0.51 ( 24%)   0.27 ( 35%)   0.69 ( 24%)   90755 kB ( 30%)
 parser (global)                    :   0.21 ( 10%)   0.10 ( 13%)   0.33 ( 11%)   51168 kB ( 17%)
 parser struct body                 :   0.21 ( 10%)   0.06 (  8%)   0.20 (  7%)   37384 kB ( 13%)
[...]
 template instantiation             :   0.40 ( 19%)   0.19 ( 25%)   0.62 ( 21%)   71691 kB ( 24%)
[...]
 TOTAL                              :   2.12          0.77          2.92         298030 kB

$ g++ -H -DBINPATH="/usr/local/bin" -DBOOST_ALL_DYN_LINK -DENABLE_BINRELOC -DFREEORION_BUILD_COMMON -DFREEORION_LINUX -DFREEORION_PYTHON_VERSION="3.7" -DSHAREPATH="/usr/local/share" -Dfreeorioncommon_EXPORTS -isystem /home/adrian/Projects/freeorion/freeorion.git/GG -isystem GG -isystem /usr/include/freetype2 -isystem /home/adrian/Projects/freeorion/freeorion.git  -O2 -DNDEBUG -fPIC -fvisibility=hidden   -Wall -std=c++14 -o CMakeFiles/freeorioncommon.dir/universe/UnlockableItem.cpp.o -c /home/adrian/Projects/freeorion/freeorion.git/universe/UnlockableItem.cpp 2>&1 | grep '^\.' | wc -l
1689
```