### PR TITLE
Cheaper shields

### DIFF
--- a/default/scripting/ship_parts/Shield/SH_BLACK.focs.txt
+++ b/default/scripting/ship_parts/Shield/SH_BLACK.focs.txt
@@ -5,7 +5,7 @@ Part
     class = Shield
     capacity = 15
     mountableSlotTypes = Internal
-    buildcost = 150 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
+    buildcost = 100 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 6
     tags = [ "PEDIA_PC_SHIELD" ]
     location = OwnedBy empire = Source.Owner

--- a/default/scripting/ship_parts/Shield/SH_BLACK.focs.txt
+++ b/default/scripting/ship_parts/Shield/SH_BLACK.focs.txt
@@ -5,7 +5,7 @@ Part
     class = Shield
     capacity = 15
     mountableSlotTypes = Internal
-    buildcost = 100 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
+    buildcost = 120 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 6
     tags = [ "PEDIA_PC_SHIELD" ]
     location = OwnedBy empire = Source.Owner

--- a/default/scripting/ship_parts/Shield/SH_DEFENSE_GRID.focs.txt
+++ b/default/scripting/ship_parts/Shield/SH_DEFENSE_GRID.focs.txt
@@ -5,8 +5,8 @@ Part
     class = Shield
     capacity = 3
     mountableSlotTypes = Internal
-    buildcost = 30 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
-    buildtime = 2
+    buildcost = 20 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
+    buildtime = 3
     tags = [ "PEDIA_PC_SHIELD" ]
     location = OwnedBy empire = Source.Owner
     icon = "icons/ship_parts/defense_grid.png"

--- a/default/scripting/ship_parts/Shield/SH_DEFLECTOR.focs.txt
+++ b/default/scripting/ship_parts/Shield/SH_DEFLECTOR.focs.txt
@@ -5,7 +5,7 @@ Part
     class = Shield
     capacity = 5
     mountableSlotTypes = Internal
-    buildcost = 50 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
+    buildcost = 30 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 4
     tags = [ "PEDIA_PC_SHIELD" ]
     location = OwnedBy empire = Source.Owner

--- a/default/scripting/ship_parts/Shield/SH_DEFLECTOR.focs.txt
+++ b/default/scripting/ship_parts/Shield/SH_DEFLECTOR.focs.txt
@@ -5,7 +5,7 @@ Part
     class = Shield
     capacity = 5
     mountableSlotTypes = Internal
-    buildcost = 30 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
+    buildcost = 35 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 4
     tags = [ "PEDIA_PC_SHIELD" ]
     location = OwnedBy empire = Source.Owner

--- a/default/scripting/ship_parts/Shield/SH_MULTISPEC.focs.txt
+++ b/default/scripting/ship_parts/Shield/SH_MULTISPEC.focs.txt
@@ -5,7 +5,7 @@ Part
     class = Shield
     capacity = 10
     mountableSlotTypes = Internal
-    buildcost = 100 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
+    buildcost = 80 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 8
     tags = [ "PEDIA_PC_SHIELD" ]
     location = OwnedBy empire = Source.Owner

--- a/default/scripting/ship_parts/Shield/SH_PLASMA.focs.txt
+++ b/default/scripting/ship_parts/Shield/SH_PLASMA.focs.txt
@@ -5,7 +5,7 @@ Part
     class = Shield
     capacity = 9
     mountableSlotTypes = Internal
-    buildcost = 90 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
+    buildcost = 60 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 5
     tags = [ "PEDIA_PC_SHIELD" ]
     location = OwnedBy empire = Source.Owner

--- a/default/scripting/ship_parts/Shield/SH_ROBOTIC_INTERFACE_SHIELDS.focs.txt
+++ b/default/scripting/ship_parts/Shield/SH_ROBOTIC_INTERFACE_SHIELDS.focs.txt
@@ -4,7 +4,7 @@ Part
     class = Shield
     capacity = 0
     mountableSlotTypes = [Internal]
-    buildcost = 50 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
+    buildcost = 40 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 4
     tags = [ "PEDIA_PC_SHIELD" ]
     location = And [

--- a/default/scripting/ship_parts/Shield/SH_ROBOTIC_INTERFACE_SHIELDS.focs.txt
+++ b/default/scripting/ship_parts/Shield/SH_ROBOTIC_INTERFACE_SHIELDS.focs.txt
@@ -4,7 +4,7 @@ Part
     class = Shield
     capacity = 0
     mountableSlotTypes = [Internal]
-    buildcost = 70 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
+    buildcost = 50 * [[FLEET_UPKEEP_MULTIPLICATOR]] * [[SHIP_PART_COST_MULTIPLIER]]
     buildtime = 4
     tags = [ "PEDIA_PC_SHIELD" ]
     location = And [


### PR DESCRIPTION
With the addition of fighters (that ignore shields), shields became considerably less useful, to the point of they being a liability. The main problem being its cost: you can fare much better with more, cheaper, unshielded ships. Also competing with hangars for internal slots.

This PR reduces shield part costs roughly a 33%, except for three cases:
- Black Shield (-25%), because it is end-game shield capable of significantly reduce the damage of every weapon but fighters, coupled with late game hulls with many external slots to prorate the cost. In ships with huge armor stats that can be OP.
- Multispectral shield (-20%), because it comes with a big boost to stealth (+60) and was already cheap compared to Plasma shield (9 vs 10 strength).
- Robotic Interface Shield (-42%), because it was even less popular than the other shields and seemed to deserve a bigger bump.

Edit: Deflector shield (strength 5) goes from 50 to 30 (-40%). Maybe 35 PP would make more sense...

[Forum thread](https://www.freeorion.org/forum/viewtopic.php?f=6&t=11547)