### PR TITLE
Add codeowners for russian translation

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
+# Code owners for translation stringtables
 ru.txt @Cjkjvfnby @o01eg

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+ru.txt @Cjkjvfnby @o01eg


### PR DESCRIPTION
This feature allows to auto-assign reviewers.  This is useful for external collaborators, who can do a PR but have no permission to request a review. 

If multiple persons are assigned, the first one should leave a comment about his plans to avoid double review.
