### PR TITLE
Set ship speed for new ships to be affected by Interstellar Logistics

### DIFF
--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -1974,7 +1974,7 @@ void Empire::CheckProductionProgress() {
                 // have been applied, letting new ships start with maxed
                 // everything that is traced with an associated max meter.
                 ship->SetShipMetersToMax();
-                // set ship speed so that it can be affected by Interstellar Logistic check for non-zero speed
+                // set ship speed so that it can be affected by non-zero speed checks
                 if (auto* design = GetShipDesign(elem.item.design_id))
                     ship->GetMeter(METER_SPEED)->Set(design->Speed(), design->Speed());
                 ship->BackPropagateMeters();

--- a/Empire/Empire.cpp
+++ b/Empire/Empire.cpp
@@ -1974,6 +1974,9 @@ void Empire::CheckProductionProgress() {
                 // have been applied, letting new ships start with maxed
                 // everything that is traced with an associated max meter.
                 ship->SetShipMetersToMax();
+                // set ship speed so that it can be affected by Interstellar Logistic check for non-zero speed
+                if (auto* design = GetShipDesign(elem.item.design_id))
+                    ship->GetMeter(METER_SPEED)->Set(design->Speed(), design->Speed());
                 ship->BackPropagateMeters();
 
                 ship->Rename(NewShipName());


### PR DESCRIPTION
As per @geoffthemedio [suggestion](https://www.freeorion.org/forum/viewtopic.php?f=28&t=11639&p=101086#p101086).
I don't know what should I do for this to appear as authored by Geoff.

Tested and works fine.
Not extensively tested to see if it might cause any trouble.