### PR TITLE
Expose empire stat records to python API

### DIFF
--- a/default/python/AI/freeorion_tools/_freeorion_tools.py
+++ b/default/python/AI/freeorion_tools/_freeorion_tools.py
@@ -23,6 +23,16 @@ def dict_from_map(thismap):
     return {el.key(): el.data() for el in thismap}
 
 
+def dict_from_map_recursive(thismap):
+    retval = {}
+    try:
+        for el in thismap:
+            retval[el.key()] = dict_from_map_recursive(el.data())
+        return retval
+    except:
+        return dict_from_map(thismap)
+
+
 def get_ai_tag_grade(tag_list, tag_type):
     """
     Accepts a list of string tags and a tag_type (like 'WEAPONS').

--- a/default/python/AI/freeorion_tools/_freeorion_tools.py
+++ b/default/python/AI/freeorion_tools/_freeorion_tools.py
@@ -29,7 +29,7 @@ def dict_from_map_recursive(thismap):
         for el in thismap:
             retval[el.key()] = dict_from_map_recursive(el.data())
         return retval
-    except:
+    except Exception:
         return dict_from_map(thismap)
 
 

--- a/default/python/AI/freeorion_tools/extend_freeorion_AI_interface.py
+++ b/default/python/AI/freeorion_tools/extend_freeorion_AI_interface.py
@@ -46,7 +46,7 @@ from functools import wraps
 from logging import debug
 
 import freeOrionAIInterface as fo
-from ._freeorion_tools import dict_from_map
+from ._freeorion_tools import dict_from_map, dict_from_map_recursive
 
 
 PLANET = 'P'
@@ -63,6 +63,14 @@ def to_dict(method):
     return wrapper
 
 
+def to_dict_recursive(method):
+    @wraps(method)
+    def wrapper(*args):
+        return dict_from_map_recursive(method(*args))
+
+    return wrapper
+
+
 def to_str(prefix, id, name):
     return '{}_{}<{}>'.format(prefix, id, name)
 
@@ -71,7 +79,7 @@ def patch_interface():
     fo.universe.getVisibilityTurnsMap = to_dict(fo.universe.getVisibilityTurnsMap)
     fo.empire.supplyProjections = to_dict(fo.empire.supplyProjections)
     fo.GameRules.getRulesAsStrings = to_dict(fo.GameRules.getRulesAsStrings)
-    fo.universe.statRecords = to_dict(fo.universe.statRecords)
+    fo.universe.statRecords = to_dict_recursive(fo.universe.statRecords)
 
     fo.to_str = to_str
 
@@ -106,9 +114,6 @@ def patch_interface():
         return str(dict_from_map(int_int_map))
 
     fo.IntIntMap.__str__ = int_int_map_to_string
-
-    fo.StatRecordsMap.__getitem__ = to_dict(fo.StatRecordsMap.__getitem__)
-    fo.IntIntDblMapMap.__getitem__ = to_dict(fo.IntIntDblMapMap.__getitem__)
 
 
 def logger(callable_object, argument_wrappers=None):

--- a/default/python/AI/freeorion_tools/extend_freeorion_AI_interface.py
+++ b/default/python/AI/freeorion_tools/extend_freeorion_AI_interface.py
@@ -107,6 +107,9 @@ def patch_interface():
 
     fo.IntIntMap.__str__ = int_int_map_to_string
 
+    fo.StatRecordsMap.__getitem__ = to_dict(fo.StatRecordsMap.__getitem__)
+    fo.IntIntDblMapMap.__getitem__ = to_dict(fo.IntIntDblMapMap.__getitem__)
+
 
 def logger(callable_object, argument_wrappers=None):
     """

--- a/default/python/AI/freeorion_tools/extend_freeorion_AI_interface.py
+++ b/default/python/AI/freeorion_tools/extend_freeorion_AI_interface.py
@@ -71,6 +71,7 @@ def patch_interface():
     fo.universe.getVisibilityTurnsMap = to_dict(fo.universe.getVisibilityTurnsMap)
     fo.empire.supplyProjections = to_dict(fo.empire.supplyProjections)
     fo.GameRules.getRulesAsStrings = to_dict(fo.GameRules.getRulesAsStrings)
+    fo.universe.statRecords = to_dict(fo.universe.statRecords)
 
     fo.to_str = to_str
 

--- a/python/UniverseWrapper.cpp
+++ b/python/UniverseWrapper.cpp
@@ -317,6 +317,10 @@ namespace FreeOrionPython {
         class_<std::vector<ShipSlotType>>("ShipSlotVec")
             .def(boost::python::vector_indexing_suite<std::vector<ShipSlotType>, true>())
         ;
+        class_<std::map<std::string, std::string>>("StringsMap")
+            .def(boost::python::map_indexing_suite<std::map<std::string, std::string>, true>())
+        ;
+
         class_<std::map<MeterType, Meter>>("MeterTypeMeterMap")
             .def(boost::python::map_indexing_suite<std::map<MeterType, Meter>, true>())
         ;
@@ -327,6 +331,15 @@ namespace FreeOrionPython {
         ;
         class_<Ship::PartMeterMap>("ShipPartMeterMap")
             .def(boost::python::map_indexing_suite<Ship::PartMeterMap>())
+        ;
+
+        class_<std::map<std::string, std::map<int, std::map<int, double>>>>("StatRecordsMap")
+            .def(boost::python::map_indexing_suite<
+                 std::map<std::string, std::map<int, std::map<int, double>>>, true>())
+        ;
+        class_<std::map<int, std::map<int, double>>>("IntIntDblMapMap")
+            .def(boost::python::map_indexing_suite<
+                 std::map<int, std::map<int, double>>, true>())
         ;
 
         ///////////////////////////
@@ -377,15 +390,15 @@ namespace FreeOrionPython {
             .def("getBuilding",                 make_function(GetBuildingP,         return_value_policy<reference_existing_object>()))
             .def("getGenericShipDesign",        &Universe::GetGenericShipDesign,    return_value_policy<reference_existing_object>(), "Returns the ship design (ShipDesign) with the indicated name (string).")
 
-            .add_property("allObjectIDs",       make_function(ObjectIDs<UniverseObject>,  return_value_policy<return_by_value>()))
-            .add_property("fleetIDs",           make_function(ObjectIDs<Fleet>,           return_value_policy<return_by_value>()))
-            .add_property("systemIDs",          make_function(ObjectIDs<System>,          return_value_policy<return_by_value>()))
-            .add_property("fieldIDs",           make_function(ObjectIDs<Field>,           return_value_policy<return_by_value>()))
-            .add_property("planetIDs",          make_function(ObjectIDs<Planet>,          return_value_policy<return_by_value>()))
-            .add_property("shipIDs",            make_function(ObjectIDs<Ship>,            return_value_policy<return_by_value>()))
-            .add_property("buildingIDs",        make_function(ObjectIDs<Building>,        return_value_policy<return_by_value>()))
+            .add_property("allObjectIDs",       make_function(ObjectIDs<UniverseObject>,return_value_policy<return_by_value>()))
+            .add_property("fleetIDs",           make_function(ObjectIDs<Fleet>,         return_value_policy<return_by_value>()))
+            .add_property("systemIDs",          make_function(ObjectIDs<System>,        return_value_policy<return_by_value>()))
+            .add_property("fieldIDs",           make_function(ObjectIDs<Field>,         return_value_policy<return_by_value>()))
+            .add_property("planetIDs",          make_function(ObjectIDs<Planet>,        return_value_policy<return_by_value>()))
+            .add_property("shipIDs",            make_function(ObjectIDs<Ship>,          return_value_policy<return_by_value>()))
+            .add_property("buildingIDs",        make_function(ObjectIDs<Building>,      return_value_policy<return_by_value>()))
             .def("destroyedObjectIDs",          make_function(&Universe::EmpireKnownDestroyedObjectIDs,
-                                                                                    return_value_policy<return_by_value>()))
+                                                              return_value_policy<return_by_value>()))
 
             .def("systemHasStarlane",           make_function(
                                                     SystemHasVisibleStarlanesFunc,
@@ -470,6 +483,16 @@ namespace FreeOrionPython {
                                                     &Universe::GetObjectVisibilityByEmpire,
                                                     return_value_policy<return_by_value>()
                                                 ))
+
+            // Indexed by stat name (string), contains a map indexed by empire id,
+            // contains a map from turn number (int) to stat value (double).
+            .def("statRecords",                 make_function(
+                                                    &Universe::GetStatRecords,
+                                                    return_value_policy<reference_existing_object>()),
+                                                "Empire statistics recorded by the server each turn. Indexed first by "
+                                                "staistic name (string), then by empire id (int), then by turn "
+                                                "number (int), pointing to the statisic value (double)."
+                                                )
 
             .def("dump",                        &DumpObjects)
         ;
@@ -807,11 +830,6 @@ namespace FreeOrionPython {
             .add_property("maxAIAggression",    make_function(&GalaxySetupData::GetAggression,      return_value_policy<return_by_value>()))
             .add_property("gameUID",            make_function(&GalaxySetupData::GetGameUID,         return_value_policy<return_by_value>()),
                                                 &GalaxySetupData::SetGameUID);
-
-
-        class_<std::map<std::string, std::string>>("StringsMap")
-            .def(boost::python::map_indexing_suite<std::map<std::string, std::string>, true>())
-        ;
 
         class_<GameRules, noncopyable>("GameRules", no_init)
             .add_property("empty",              make_function(&GameRules::Empty,                return_value_policy<return_by_value>()))


### PR DESCRIPTION
Additional Python-side glue code probably needed for usability. My attempts at doing so weren't successful. Not yet useful, but the stat names are at least visible in Python:

````
[28 Apr 21:47:57] Human_Player: start 2
[28 Apr 21:47:57] AI_1: Entering debug mode
Print 'stop' to exit.
Local variables:
  ai  aistate
  u   universe
  e   empire
[28 Apr 21:48:04] Human_Player: print(u.statRecords())
[28 Apr 21:48:04] AI_1: {'SHIPS_PRODUCED': <freeOrionAIInterface.IntIntDblMapMap object at 0x043C4260>, 'SHIPS_LOST': <freeOrionAIInterface.IntIntDblMapMap object at 0x043C4230>, 'PP_OUTPUT': <freeOrionAIInterface.IntIntDblMapMap object at 0x043C4E90>, 'PLANETS_BOMBED': <freeOrionAIInterface.IntIntDblMapMap object at 0x043C4D70>, 'ARMED_MONSTER_COUNT': <freeOrionAIInterface.IntIntDblMapMap object at 0x043C4AA0>, 'SHIPS_SCRAPPED': <freeOrionAIInterface.IntIntDblMapMap object at 0x03BD9C20>, 'SHIP_COUNT': <freeOrionAIInterface.IntIntDblMapMap object at 0x03BD9A10>, 'RP_OUTPUT': <freeOrionAIInterface.IntIntDblMapMap object at 0x043C4F20>, 'BATTLESHIP_COUNT': <freeOrionAIInterface.IntIntDblMapMap object at 0x043C4BC0>, 'TOTAL_POPULATION_STAT': <freeOrionAIInterface.IntIntDblMapMap object at 0x03BD9A40>, 'BUILDINGS_SCRAPPED': <freeOrionAIInterface.IntIntDblMapMap object at 0x043C4B90>, 'BUILDINGS_PRODUCED': <freeOrionAIInterface.IntIntDblMapMap object at 0x043C4C80>, 'PLANET_COUNT': <freeOrionAIInterface.IntIntDblMapMap object at 0x043C4E60>, 'PLANETS_INVADED': <freeOrionAIInterface.IntIntDblMapMap object at 0x043C4E30>, 'PLANETS_DEPOPULATED': <freeOrionAIInterface.IntIntDblMapMap object at 0x043C4DD0>, 'COLONIES_COUNT': <freeOrionAIInterface.IntIntDblMapMap object at 0x043C4C20>, 'SHIPS_DESTROYED': <freeOrionAIInterface.IntIntDblMapMap object at 0x043C4F80>, 'MILITARY_STRENGTH_STAT': <freeOrionAIInterface.IntIntDblMapMap object at 0x043C4DA0>}
````