### PR TITLE
Restrict interceptor launch bay upgrade to tech of own empire

### DIFF
--- a/default/scripting/ship_parts/FighterHangar/FT_HANGAR_1.focs.txt
+++ b/default/scripting/ship_parts/FighterHangar/FT_HANGAR_1.focs.txt
@@ -22,14 +22,12 @@ Part
             ]
             activation = Source
             stackinggroup = "INTERCEPTOR_FAST_LAUNCH_EFFECT"
-            effects = [
-                SetMaxCapacity partname = "FT_BAY_1" value = (
-                    3 +
-                    Statistic If Condition = OwnerHasTech Name = "SHP_FIGHTERS_2" +
-                    Statistic If Condition = OwnerHasTech Name = "SHP_FIGHTERS_3" +
-                    Statistic If Condition = OwnerHasTech Name = "SHP_FIGHTERS_4"
-                )
-            ]
+            effects = SetMaxCapacity partname = "FT_BAY_1" value = (
+                3 +
+                Statistic If Condition = And [ Target  OwnerHasTech Name = "SHP_FIGHTERS_2" ] +
+                Statistic If Condition = And [ Target  OwnerHasTech Name = "SHP_FIGHTERS_3" ] +
+                Statistic If Condition = And [ Target  OwnerHasTech Name = "SHP_FIGHTERS_4" ]
+            )
     ]
     icon = "icons/ship_parts/fighter06.png"
 


### PR DESCRIPTION
Bugfix for issue #2902 

OwnerHasTech does not restrict empire by itself, so a filter had to be added.