### PR TITLE
Improve python logger interface

### DIFF
--- a/default/python/common/configure_logging.py
+++ b/default/python/common/configure_logging.py
@@ -136,7 +136,7 @@ class _stdXLikeStream:
             (filename, line_number, function_name) = ("", "", "")
 
         try:
-            self.logger(msg, "python", str(os.path.split(filename)[1]), str(function_name), str(line_number))
+            self.logger(msg, str(os.path.split(filename)[1]), str(line_number))
 
         finally:
             # Explicitly del references to the caller's frame to avoid persistent reference cycles
@@ -168,8 +168,7 @@ class _LoggerHandler(logging.Handler):
                 record.exc_info = sys.exc_info()
             traceback_msg = "".join(traceback.format_exception(*record.exc_info))
             msg += traceback_msg
-        self.logger(msg, "python", str(record.filename),
-                    str(record.funcName), str(record.lineno))
+        self.logger(msg, str(record.filename), str(record.lineno))
 
 
 class _SingleLevelFilter(logging.Filter):

--- a/default/python/common/configure_logging.py
+++ b/default/python/common/configure_logging.py
@@ -125,24 +125,22 @@ class _stdXLikeStream:
             frame = sys._getframe(1)
             try:
                 line_number = frame.f_lineno
-                function_name = frame.f_code.co_name
                 filename = frame.f_code.co_filename
             except:  # noqa: E722
-                (filename, line_number, function_name) = ("", "", "")
+                (filename, line_number) = ("", "")
             finally:
                 # Explicitly del references to the caller's frame to avoid persistent reference cycles
                 del frame
         else:
-            (filename, line_number, function_name) = ("", "", "")
+            (filename, line_number) = ("", "")
 
         try:
-            self.logger(msg, str(os.path.split(filename)[1]), str(line_number))
+            self.logger(msg, str(os.path.split(filename)[1]), line_number)
 
         finally:
             # Explicitly del references to the caller's frame to avoid persistent reference cycles
             del filename
             del line_number
-            del function_name
 
 
 class _LoggerHandler(logging.Handler):
@@ -168,7 +166,7 @@ class _LoggerHandler(logging.Handler):
                 record.exc_info = sys.exc_info()
             traceback_msg = "".join(traceback.format_exception(*record.exc_info))
             msg += traceback_msg
-        self.logger(msg, str(record.filename), str(record.lineno))
+        self.logger(msg, str(record.filename), record.lineno)
 
 
 class _SingleLevelFilter(logging.Filter):

--- a/python/LoggingWrapper.cpp
+++ b/python/LoggingWrapper.cpp
@@ -67,73 +67,29 @@ namespace {
         // Assembling the log in the stream input to the logger means that the
         // string assembly is gated by the log level.  logs are not assembled
         // if that log level is disabled.
-        switch (log_level) {
-        case LogLevel::trace:
-            FO_LOGGER(LogLevel::trace, python) << python_logger << boost::log::add_value("SrcFilename", filename) << boost::log::add_value("SrcLinenum", lineno) << " : " << msg;
-            break;
-        case LogLevel::debug:
-            FO_LOGGER(LogLevel::debug, python) << python_logger << boost::log::add_value("SrcFilename", filename) << boost::log::add_value("SrcLinenum", lineno) << " : " << msg;
-            break;
-        case LogLevel::info:
-            FO_LOGGER(LogLevel::info, python)  << python_logger << boost::log::add_value("SrcFilename", filename) << boost::log::add_value("SrcLinenum", lineno) << " : " << msg;
-            break;
-        case LogLevel::warn:
-            FO_LOGGER(LogLevel::warn, python)  << python_logger << boost::log::add_value("SrcFilename", filename) << boost::log::add_value("SrcLinenum", lineno) << " : " << msg;
-            break;
-        case LogLevel::error:
-            FO_LOGGER(LogLevel::error, python) << python_logger << boost::log::add_value("SrcFilename", filename) << boost::log::add_value("SrcLinenum", lineno) << " : " << msg;
-            break;
-        }
+        FO_LOGGER(log_level, python) << python_logger << boost::log::add_value("SrcFilename", filename) << boost::log::add_value("SrcLinenum", lineno) << " : " << msg;
     }
 
-    void PythonLoggerWrapper(const LogLevel log_level, const std::string& msg,
-                             const std::string& logger_name, const std::string& filename,
-                             /*const std::string& function_name,*/ const std::string& lineno)
+
+    template<LogLevel log_level>
+    void PythonLoggerWrapper(const std::string& msg, const std::string& logger_name, const std::string& filename,
+                             const std::string& function_name, const std::string& lineno)
     {
+        (void)function_name;
         static std::stringstream log_stream("");
         send_to_log(log_stream, msg,
                     std::bind(&PythonLogger, std::placeholders::_1,
                               log_level, logger_name, filename, /*function_name,*/ lineno));
-    }
-
-
-    // debug/stdout logger
-    void PythonLoggerDebug(const std::string& msg, const std::string& logger_name,
-                           const std::string& filename, const std::string& function_name, const std::string& lineno)
-    {
-        PythonLoggerWrapper(LogLevel::debug, msg, logger_name, filename, /*function_name,*/ lineno);
-    }
-
-
-    // info logger
-    void PythonLoggerInfo(const std::string& msg, const std::string& logger_name,
-                          const std::string& filename, const std::string& function_name, const std::string& lineno)
-    {
-        PythonLoggerWrapper(LogLevel::info, msg, logger_name, filename, /*function_name,*/ lineno);
-    }
-
-    // warn logger
-    void PythonLoggerWarn(const std::string& msg, const std::string& logger_name,
-                          const std::string& filename, const std::string& function_name, const std::string& lineno)
-    {
-        PythonLoggerWrapper(LogLevel::warn, msg, logger_name, filename, /*function_name,*/ lineno);
-    }
-
-    // error logger
-    void PythonLoggerError(const std::string& msg, const std::string& logger_name,
-                           const std::string& filename, const std::string& function_name, const std::string& lineno)
-    {
-        PythonLoggerWrapper(LogLevel::error, msg, logger_name, filename, /*function_name,*/ lineno);
     }
 }
 
 namespace FreeOrionPython {
     using boost::python::def;
     void WrapLogger() {
-        def("debug", PythonLoggerDebug);
-        def("info", PythonLoggerInfo);
-        def("warn", PythonLoggerWarn);
-        def("error", PythonLoggerError);
-        def("fatal", PythonLoggerError);
+        def("debug", PythonLoggerWrapper<LogLevel::debug>);
+        def("info", PythonLoggerWrapper<LogLevel::info>);
+        def("warn", PythonLoggerWrapper<LogLevel::warn>);
+        def("error", PythonLoggerWrapper<LogLevel::error>);
+        def("fatal", PythonLoggerWrapper<LogLevel::error>);
     }
 }

--- a/python/LoggingWrapper.cpp
+++ b/python/LoggingWrapper.cpp
@@ -49,7 +49,6 @@ namespace {
     // Assemble a python message that is the same as the C++ message format.
     void PythonLogger(const std::string& msg,
                       const LogLevel log_level,
-                      const std::string& python_logger,
                       const std::string& filename,
                       // const std::string& function_name,
                       const std::string& linenostr)
@@ -64,22 +63,21 @@ namespace {
         // Assembling the log in the stream input to the logger means that the
         // string assembly is gated by the log level.  logs are not assembled
         // if that log level is disabled.
-        FO_LOGGER(log_level, python) << python_logger
-                                     << boost::log::add_value("SrcFilename", filename)
+        FO_LOGGER(log_level, python) << boost::log::add_value("SrcFilename", filename)
                                      << boost::log::add_value("SrcLinenum", lineno)
-                                     << " : " << msg;
+                                     << msg;
     }
 
 
     template<LogLevel log_level>
-    void PythonLoggerWrapper(const std::string& msg, const std::string& logger_name, const std::string& filename,
+    void PythonLoggerWrapper(const std::string& msg, const std::string& filename,
                              const std::string& function_name, const std::string& lineno)
     {
         (void)function_name;
         static std::stringstream log_stream("");
         send_to_log(log_stream, msg,
                     std::bind(&PythonLogger, std::placeholders::_1,
-                              log_level, logger_name, filename, /*function_name,*/ lineno));
+                              log_level, filename, /*function_name,*/ lineno));
     }
 }
 

--- a/python/LoggingWrapper.cpp
+++ b/python/LoggingWrapper.cpp
@@ -50,7 +50,6 @@ namespace {
     void PythonLogger(const std::string& msg,
                       const LogLevel log_level,
                       const std::string& filename,
-                      // const std::string& function_name,
                       const std::string& linenostr)
     {
         int lineno{0};
@@ -71,13 +70,12 @@ namespace {
 
     template<LogLevel log_level>
     void PythonLoggerWrapper(const std::string& msg, const std::string& filename,
-                             const std::string& function_name, const std::string& lineno)
+                             const std::string& lineno)
     {
-        (void)function_name;
         static std::stringstream log_stream("");
         send_to_log(log_stream, msg,
                     std::bind(&PythonLogger, std::placeholders::_1,
-                              log_level, filename, /*function_name,*/ lineno));
+                              log_level, filename, lineno));
     }
 }
 

--- a/python/LoggingWrapper.cpp
+++ b/python/LoggingWrapper.cpp
@@ -73,9 +73,10 @@ namespace {
                              const std::string& lineno)
     {
         static std::stringstream log_stream("");
-        send_to_log(log_stream, msg,
-                    std::bind(&PythonLogger, std::placeholders::_1,
-                              log_level, filename, lineno));
+        auto logger_func = [&](const std::string& arg) {
+            PythonLogger(arg, log_level, filename, lineno);
+        };
+        send_to_log(log_stream, msg, logger_func);
     }
 }
 

--- a/python/LoggingWrapper.cpp
+++ b/python/LoggingWrapper.cpp
@@ -2,11 +2,8 @@
 
 #include "../util/Logger.h"
 
-#include <boost/log/expressions.hpp>
-#include <boost/log/support/date_time.hpp>
+#include <boost/log/utility/manipulators/add_value.hpp>
 #include <boost/python.hpp>
-
-namespace expr = boost::log::expressions;
 
 namespace {
     // Expose interface for redirecting standard output and error to FreeOrion
@@ -67,7 +64,10 @@ namespace {
         // Assembling the log in the stream input to the logger means that the
         // string assembly is gated by the log level.  logs are not assembled
         // if that log level is disabled.
-        FO_LOGGER(log_level, python) << python_logger << boost::log::add_value("SrcFilename", filename) << boost::log::add_value("SrcLinenum", lineno) << " : " << msg;
+        FO_LOGGER(log_level, python) << python_logger
+                                     << boost::log::add_value("SrcFilename", filename)
+                                     << boost::log::add_value("SrcLinenum", lineno)
+                                     << " : " << msg;
     }
 
 

--- a/python/LoggingWrapper.cpp
+++ b/python/LoggingWrapper.cpp
@@ -46,35 +46,15 @@ namespace {
 
     DeclareThreadSafeLogger(python);
 
-    // Assemble a python message that is the same as the C++ message format.
-    void PythonLogger(const std::string& msg,
-                      const LogLevel log_level,
-                      const std::string& filename,
-                      const std::string& linenostr)
-    {
-        int lineno{0};
-
-        try {
-            lineno = std::stoi(linenostr);
-        } catch(...)
-        {}
-
-        // Assembling the log in the stream input to the logger means that the
-        // string assembly is gated by the log level.  logs are not assembled
-        // if that log level is disabled.
-        FO_LOGGER(log_level, python) << boost::log::add_value("SrcFilename", filename)
-                                     << boost::log::add_value("SrcLinenum", lineno)
-                                     << msg;
-    }
-
-
     template<LogLevel log_level>
     void PythonLoggerWrapper(const std::string& msg, const std::string& filename,
-                             const std::string& lineno)
+                             const int lineno)
     {
         static std::stringstream log_stream("");
         auto logger_func = [&](const std::string& arg) {
-            PythonLogger(arg, log_level, filename, lineno);
+            FO_LOGGER(log_level, python) << boost::log::add_value("SrcFilename", filename)
+                                         << boost::log::add_value("SrcLinenum", lineno)
+                                         << arg;
         };
         send_to_log(log_stream, msg, logger_func);
     }


### PR DESCRIPTION
Simplifications to the logger interface and fix for some formatting issue introduced in #2880: Since that change, the "python :" part was printed twice in logs, e.g.

```01:37:50.761509 {0x00002b1c} [debug] python : InvasionAI.py:451 : python : Invasion eval of P_2338<Adams γ I>```