### PR TITLE
Add local variables to python exception logging

### DIFF
--- a/default/python/AI/freeorion_tools/_freeorion_tools.py
+++ b/default/python/AI/freeorion_tools/_freeorion_tools.py
@@ -10,6 +10,7 @@ import traceback
 from functools import wraps
 from logging import debug, error
 from aistate_interface import get_aistate
+from common.configure_logging import FOLogFormatter
 
 import freeOrionAIInterface as fo  # pylint: disable=import-error
 
@@ -131,8 +132,8 @@ class ConsoleLogHandler(logging.Handler):
 console_handler = ConsoleLogHandler()
 
 console_handler.setFormatter(
-    logging.Formatter(RED % ('%s : %%(filename)s:%%(funcName)s():%%(lineno)d  - %%(message)s'
-                             % fo.userString('AI_ERROR_MSG'))))
+    FOLogFormatter(RED % ('%s : %%(filename)s:%%(funcName)s():%%(lineno)d  - %%(message)s'
+                          % fo.userString('AI_ERROR_MSG'))))
 
 console_handler.setLevel(logging.ERROR)
 

--- a/default/python/common/configure_logging.py
+++ b/default/python/common/configure_logging.py
@@ -157,16 +157,24 @@ class _LoggerHandler(logging.Handler):
         }[level]
 
     def emit(self, record):
-        record.message = record.getMessage()
-        msg = str(record.message) + "\n"
-        if record.exc_info:
-            if not isinstance(record.exc_info, tuple):
-                # record.exc_info is not a local variable and will be garbage collected when record
-                # is garbage collected by the logging library
-                record.exc_info = sys.exc_info()
-            traceback_msg = "".join(traceback.format_exception(*record.exc_info))
-            msg += traceback_msg
+        msg = self.format(record)
         self.logger(msg, str(record.filename), record.lineno)
+
+
+class FOLogFormatter(logging.Formatter):
+
+    def formatException(self, ei):
+        exc_text = "".join(traceback.format_exception(*ei))
+        tb = ei[2]
+        if not tb:
+            return exc_text
+        while tb.tb_next:
+            tb = tb.tb_next
+
+        exc_text += "Local context: "
+        exc_text += str(tb.tb_frame.f_locals)
+        exc_text += "\n"
+        return exc_text
 
 
 class _SingleLevelFilter(logging.Filter):
@@ -183,6 +191,7 @@ def _create_narrow_handler(level):
     """Create a handler for logger that forwards a single level of log
     to the appropriate stream in the C++ app."""
     h = _LoggerHandler(level)
+    h.setFormatter(FOLogFormatter())
     h.addFilter(_SingleLevelFilter(level))
     h.setLevel(level)
     return h


### PR DESCRIPTION
This PR extracts the local variables from the last traceback frame and adds them to the log record. Makes it a bit easier to understand the context of errors in reports where a savegame can not be supplied.

Example log output:
```
21:55:21.173441 {0x00002a04} [error] python : FreeOrionAI.py:73 : Exception division by zero occurred during generateOrders
21:55:21.173441 {0x00002a04} [error] python : FreeOrionAI.py:73 : Traceback (most recent call last):
21:55:21.173441 {0x00002a04} [error] python : FreeOrionAI.py:73 :   File "C:/FOPy3\32\FreeOrion\default\python\AI\FreeOrionAI.py", line 70, in _error_handler
21:55:21.173441 {0x00002a04} [error] python : FreeOrionAI.py:73 :     res = func(*args, **kwargs)
21:55:21.173441 {0x00002a04} [error] python : FreeOrionAI.py:73 :   File "C:/FOPy3/32/FreeOrion/default/python\common\listeners.py", line 42, in wrapper
21:55:21.173441 {0x00002a04} [error] python : FreeOrionAI.py:73 :     res = funct(*args)
21:55:21.173441 {0x00002a04} [error] python : FreeOrionAI.py:73 :   File "C:/FOPy3\32\FreeOrion\default\python\AI\FreeOrionAI.py", line 369, in generateOrders
21:55:21.173441 {0x00002a04} [error] python : FreeOrionAI.py:73 :     failing_func(2)
21:55:21.173441 {0x00002a04} [error] python : FreeOrionAI.py:73 :   File "C:/FOPy3\32\FreeOrion\default\python\AI\FreeOrionAI.py", line 382, in failing_func
21:55:21.173441 {0x00002a04} [error] python : FreeOrionAI.py:73 :     print(x/z)  # throws for x = 2
21:55:21.173441 {0x00002a04} [error] python : FreeOrionAI.py:73 : ZeroDivisionError: division by zero
21:55:21.173441 {0x00002a04} [error] python : FreeOrionAI.py:73 : Local context: {'y': 2, 'z': 0, 'x': 2}
```