### PR TITLE
Don't overwrite ship design with same ID

### DIFF
--- a/universe/Universe.cpp
+++ b/universe/Universe.cpp
@@ -442,6 +442,10 @@ bool Universe::InsertShipDesignID(ShipDesign* ship_design, boost::optional<int> 
         return false;
     }
 
+    if (m_ship_designs.count(id)) {
+        ErrorLogger() << "Ship design id " << id << " already exists.";
+        return false;
+    }
     ship_design->SetID(id);
     m_ship_designs[id] = ship_design;
     return true;

--- a/util/Order.cpp
+++ b/util/Order.cpp
@@ -1204,9 +1204,13 @@ void ShipDesignOrder::ExecuteImpl() const {
             // On the client create a new design id
             universe.InsertShipDesign(new_ship_design);
             m_design_id = new_ship_design->ID();
+            DebugLogger() << "ShipDesignOrder::ExecuteImpl Create new ship design ID " << m_design_id;
         } else {
             // On the server use the design id passed from the client
-            universe.InsertShipDesignID(new_ship_design, EmpireID(), m_design_id);
+            if (!universe.InsertShipDesignID(new_ship_design, EmpireID(), m_design_id)) {
+                ErrorLogger() << "Couldn't insert ship design by ID " << m_design_id;
+                return;
+            }
         }
 
         universe.SetEmpireKnowledgeOfShipDesign(m_design_id, EmpireID());


### PR DESCRIPTION
As ship design is referenced by its ID from production queue, changes here could lead to
incorrect ship production.

Fixes #2883 in terms of forbidding change ship design for ID. It doesn't solves issue which leads to ID collision.