### PR TITLE
Fix 2900 tweak universe generation constants

### DIFF
--- a/default/python/universe_generation/empires.py
+++ b/default/python/universe_generation/empires.py
@@ -70,14 +70,14 @@ def count_planets_in_systems(systems, planet_types_filter=HS_ACCEPTABLE_PLANET_T
 def vicinity_range(systems_per_empire):
     """
     Calculates the vicinity range (jumps away from home world) for the specified number of systems per empire.
-    This limit the square root of systems_per_empire with a minimum value of HS_MIN_VICINITY_RANGE and
+    This limit is the square root of systems_per_empire with a minimum value of HS_MIN_VICINITY_RANGE and
     a maximum value of HS_MAX_VICINITY_RANGE.
     """
     return min(HS_MAX_VICINITY_RANGE, max(HS_MIN_VICINITY_RANGE, int(systems_per_empire**0.5)))
 
 
 def calculate_home_system_merit(system, systems_per_empire):
-    """Calculate the system's merit as the number of planets within its vecinity range."""
+    """Calculate the system's merit as the number of planets within its vicinity range."""
     return count_planets_in_systems(fo.systems_within_jumps_unordered(vicinity_range(systems_per_empire), [system]))
 
 

--- a/default/python/universe_generation/empires.py
+++ b/default/python/universe_generation/empires.py
@@ -194,14 +194,14 @@ class HomeSystemFinder:
 
                 # Quit successfully if the lowest merit system meets the minimum threshold
                 if merit >= min_planets_in_vicinity_limit(
-                        len(fo.systems_within_jumps_unordered(vicinity_range(self.systems_per_empire), [system]))
+                        len(fo.systems_within_jumps_unordered(vicinity_range(self.systems_per_empire), [system])),
                         self.planet_density):
                     break
 
         return best_candidate
 
 
-def find_home_systems(num_home_systems, pool_list, jump_distance, min_jump_distance, systems_per_empire):
+def find_home_systems(num_home_systems, pool_list, jump_distance, min_jump_distance, systems_per_empire, planet_density):
     """
     Tries to find a specified number of home systems which are as far apart from each other as possible.
     Starts with the specified jump distance and reduces that limit until enough systems can be found or the
@@ -211,7 +211,7 @@ def find_home_systems(num_home_systems, pool_list, jump_distance, min_jump_dista
     of the pool for logging purposes as second element.
     """
 
-    finder = HomeSystemFinder(num_home_systems, systems_per_empire)
+    finder = HomeSystemFinder(num_home_systems, systems_per_empire, planet_density)
     # try to find home systems, decrease the min jumps until enough systems can be found, or the jump distance drops
     # below the specified minimum jump distance (which means failure)
     while jump_distance >= min_jump_distance:
@@ -367,8 +367,7 @@ def compile_home_system_list(num_home_systems, systems, gsd):
         systems_in_vicinity = fo.systems_within_jumps_unordered(vicinity_range(systems_per_empire), [system])
         if len(systems_in_vicinity) >= min_systems_in_vicinity:
             pool_matching_sys_limit.append(system)
-            if count_planets_in_systems(systems_in_vicinity) >= 
-                    min_planets_in_vicinity_limit(len(systems_in_vicinity), gsd.planet_density):
+            if count_planets_in_systems(systems_in_vicinity) >= min_planets_in_vicinity_limit(len(systems_in_vicinity), gsd.planet_density):
                 pool_matching_sys_and_planet_limit.append(system)
     print(len(pool_matching_sys_and_planet_limit),
           "systems meet the min systems and planets in the near vicinity limit")
@@ -390,7 +389,7 @@ def compile_home_system_list(num_home_systems, systems, gsd):
         # specify 0 as number of requested home systems to pick as much systems as possible
         (pool_matching_sys_limit, "pool of systems that meet at least the min systems limit"),
     ]
-    home_systems = find_home_systems(num_home_systems, pool_list, min_jumps, HS_MIN_DISTANCE_PRIORITY_LIMIT, systems_per_empire)
+    home_systems = find_home_systems(num_home_systems, pool_list, min_jumps, HS_MIN_DISTANCE_PRIORITY_LIMIT, systems_per_empire, gsd.planet_density)
 
     # check if the first attempt delivered a list with enough home systems
     # if not, we make our second attempt, this time disregarding the filtered pools and using all systems, starting
@@ -398,7 +397,7 @@ def compile_home_system_list(num_home_systems, systems, gsd):
     # systems as possible
     if len(home_systems) < num_home_systems:
         print("Second attempt: trying to pick home systems from all systems")
-        home_systems = find_home_systems(num_home_systems, [(systems, "complete pool")], min_jumps, 1, systems_per_empire)
+        home_systems = find_home_systems(num_home_systems, [(systems, "complete pool")], min_jumps, 1, systems_per_empire, gsd.planet_density)
 
     # check if the selection process delivered a list with enough home systems
     # if not, our galaxy obviously is too crowded, report an error and return an empty list
@@ -446,8 +445,7 @@ def compile_home_system_list(num_home_systems, systems, gsd):
         systems_in_vicinity = fo.systems_within_jumps_unordered(vicinity_range(systems_per_empire), [home_system])
         num_systems_in_vicinity = len(systems_in_vicinity)
         num_planets_in_vicinity = count_planets_in_systems(systems_in_vicinity)
-        num_planets_to_add = min_planets_in_vicinity_limit(num_systems_in_vicinity, gsd.planet_density)
-                             - num_planets_in_vicinity
+        num_planets_to_add = min_planets_in_vicinity_limit(num_systems_in_vicinity, gsd.planet_density) - num_planets_in_vicinity
         print("Home system", home_system, "has", num_systems_in_vicinity, "systems and", num_planets_in_vicinity,
               "planets in the near vicinity, required minimum:",
               min_planets_in_vicinity_limit(num_systems_in_vicinity, gsd.planet_density))

--- a/default/python/universe_generation/empires.py
+++ b/default/python/universe_generation/empires.py
@@ -147,7 +147,6 @@ class HomeSystemFinder:
         # Cap the number of attempts to the smaller of the number of systems in the pool, or 100
         attempts = min(100, len(systems_pool))
 
-
         while attempts and num_complete_misses_remaining:
             # use a local pool of all candidate systems better than the worst threshold merit
             all_merit_system = [(m, s) for (m, s) in all_merit_system if m > current_merit_lower_bound]
@@ -347,8 +346,7 @@ def compile_home_system_list(num_home_systems, systems, gsd):
     # b.) lower than the minimum jump distance limit that should be considered high priority (see options.py),
     #     otherwise no attempt at all would be made to enforce the other requirements for home systems (see below)
     systems_per_empire = len(systems)/num_home_systems
-    min_jumps = min( max(int(systems_per_empire**(0.75)), HS_MIN_DISTANCE_PRIORITY_LIMIT),
-                     HS_MAX_JUMP_DISTANCE_LIMIT)
+    min_jumps = min(max(int(systems_per_empire**(0.75)), HS_MIN_DISTANCE_PRIORITY_LIMIT), HS_MAX_JUMP_DISTANCE_LIMIT)
 
     # home systems must have a certain minimum of systems and planets in their near vicinity
     # we will try to select our home systems from systems that match this criteria, if that fails, we will select our

--- a/default/python/universe_generation/empires.py
+++ b/default/python/universe_generation/empires.py
@@ -86,7 +86,7 @@ def min_planets_in_vicinity_limit(num_systems, planet_density):
     Calculates the minimum planet limit for the specified number of systems and planet density.
     This limit is the number of systems multiplied by 1, 1.5 or 2 depending on planet density.
     """
-    return int(num_systems * (1 + planet_density)/2.0)
+    return int(num_systems * planet_density / 2.0)
 
 
 class HomeSystemFinder:

--- a/default/python/universe_generation/empires.py
+++ b/default/python/universe_generation/empires.py
@@ -5,8 +5,7 @@ import freeorion as fo
 import universe_statistics
 from names import get_name_list, random_name
 from options import (HS_ACCEPTABLE_PLANET_SIZES, HS_ACCEPTABLE_PLANET_TYPES, HS_MAX_JUMP_DISTANCE_LIMIT,
-                     HS_MIN_DISTANCE_PRIORITY_LIMIT, HS_MIN_PLANETS_IN_VICINITY_PER_SYSTEM,
-                     HS_MIN_PLANETS_IN_VICINITY_TOTAL, HS_MIN_SYSTEMS_IN_VICINITY, HS_VICINITY_RANGE)
+                     HS_MIN_DISTANCE_PRIORITY_LIMIT, HS_MIN_VICINITY_RANGE, HS_MAX_VICINITY_RANGE)
 from planets import calc_planet_size, calc_planet_type, planet_sizes_real, planet_types_real
 from starsystems import pick_star_type, star_types_real
 from util import report_error
@@ -68,26 +67,36 @@ def count_planets_in_systems(systems, planet_types_filter=HS_ACCEPTABLE_PLANET_T
     return num_planets
 
 
-def calculate_home_system_merit(system):
-    """Calculate the system's merit as the number of planets within HS_VICINTIY_RANGE."""
-    return count_planets_in_systems(fo.systems_within_jumps_unordered(HS_VICINITY_RANGE, [system]))
+def vicinity_range(systems_per_empire):
+    """
+    Calculates the vicinity range (jumps away from home world) for the specified number of systems per empire.
+    This limit the square root of systems_per_empire with a minimum value of HS_MIN_VICINITY_RANGE and
+    a maximum value of HS_MAX_VICINITY_RANGE.
+    """
+    return min(HS_MAX_VICINITY_RANGE, max(HS_MIN_VICINITY_RANGE, int(systems_per_empire**0.5)))
 
 
-def min_planets_in_vicinity_limit(num_systems):
+def calculate_home_system_merit(system, systems_per_empire):
+    """Calculate the system's merit as the number of planets within its vecinity range."""
+    return count_planets_in_systems(fo.systems_within_jumps_unordered(vicinity_range(systems_per_empire), [system]))
+
+
+def min_planets_in_vicinity_limit(num_systems, planet_density):
     """
-    Calculates the minimum planet limit for the specified number of systems.
-    This limit is the lower of HS_MIN_PLANETS_IN_VICINITY_TOTAL or HS_MIN_PLANETS_IN_VICINITY_PER_SYSTEM
-    planets per system.
+    Calculates the minimum planet limit for the specified number of systems and planet density.
+    This limit is the number of systems multiplied by 1, 1.5 or 2 depending on planet density.
     """
-    return min(HS_MIN_PLANETS_IN_VICINITY_TOTAL, num_systems * HS_MIN_PLANETS_IN_VICINITY_PER_SYSTEM)
+    return int(num_systems * (1 + planet_density)/2.0)
 
 
 class HomeSystemFinder:
     """Finds a set of home systems with a least ''num_home_systems'' systems."""
-    def __init__(self, _num_home_systems):
+    def __init__(self, _num_home_systems, _systems_per_empire, _planet_density):
         # cache of sytem merits
         self.system_merit = {}
         self.num_home_systems = _num_home_systems
+        self.systems_per_empire = _systems_per_empire
+        self.planet_density = _planet_density
 
     def find_home_systems_for_min_jump_distance(self, systems_pool, min_jumps):
         """
@@ -108,7 +117,7 @@ class HomeSystemFinder:
         # precalculate the system merits
         for system in systems_pool:
             if system not in self.system_merit:
-                self.system_merit[system] = calculate_home_system_merit(system)
+                self.system_merit[system] = calculate_home_system_merit(system, self.systems_per_empire)
 
         # The list of merits and systems sorted in descending order by merit.
         all_merit_system = sorted([(self.system_merit[s], s)
@@ -137,6 +146,7 @@ class HomeSystemFinder:
 
         # Cap the number of attempts to the smaller of the number of systems in the pool, or 100
         attempts = min(100, len(systems_pool))
+
 
         while attempts and num_complete_misses_remaining:
             # use a local pool of all candidate systems better than the worst threshold merit
@@ -184,13 +194,14 @@ class HomeSystemFinder:
 
                 # Quit successfully if the lowest merit system meets the minimum threshold
                 if merit >= min_planets_in_vicinity_limit(
-                        len(fo.systems_within_jumps_unordered(HS_VICINITY_RANGE, [system]))):
+                        len(fo.systems_within_jumps_unordered(vicinity_range(self.systems_per_empire), [system]))
+                        self.planet_density):
                     break
 
         return best_candidate
 
 
-def find_home_systems(num_home_systems, pool_list, jump_distance, min_jump_distance):
+def find_home_systems(num_home_systems, pool_list, jump_distance, min_jump_distance, systems_per_empire):
     """
     Tries to find a specified number of home systems which are as far apart from each other as possible.
     Starts with the specified jump distance and reduces that limit until enough systems can be found or the
@@ -200,7 +211,7 @@ def find_home_systems(num_home_systems, pool_list, jump_distance, min_jump_dista
     of the pool for logging purposes as second element.
     """
 
-    finder = HomeSystemFinder(num_home_systems)
+    finder = HomeSystemFinder(num_home_systems, systems_per_empire)
     # try to find home systems, decrease the min jumps until enough systems can be found, or the jump distance drops
     # below the specified minimum jump distance (which means failure)
     while jump_distance >= min_jump_distance:
@@ -335,14 +346,17 @@ def compile_home_system_list(num_home_systems, systems, gsd):
     #     and with large galaxies an excessive amount of time can be used in failed attempts
     # b.) lower than the minimum jump distance limit that should be considered high priority (see options.py),
     #     otherwise no attempt at all would be made to enforce the other requirements for home systems (see below)
-    min_jumps = min(HS_MAX_JUMP_DISTANCE_LIMIT, max(int(len(systems) / (num_home_systems * 2)),
-                                                    HS_MIN_DISTANCE_PRIORITY_LIMIT))
+    systems_per_empire = len(systems)/num_home_systems
+    min_jumps = min( max(int(systems_per_empire**(0.75)), HS_MIN_DISTANCE_PRIORITY_LIMIT),
+                     HS_MAX_JUMP_DISTANCE_LIMIT)
 
     # home systems must have a certain minimum of systems and planets in their near vicinity
     # we will try to select our home systems from systems that match this criteria, if that fails, we will select our
     # home systems from all systems and add the missing number planets to the systems in their vicinity afterwards
     # the minimum system and planet limit and the jump range that defines the "near vicinity" are controlled by the
     # HS_* option constants in options.py (see there)
+    # Here we adjust those values to the number of systems per empire in this galaxy
+    min_systems_in_vicinity = int(vicinity_range(systems_per_empire)**((4+gsd.starlane_frequency)/3.0))
 
     # we start by building two additional pools of systems: one that contains all systems that match the criteria
     # completely (meets the min systems and planets limit), and one that contains all systems that match the criteria
@@ -350,10 +364,11 @@ def compile_home_system_list(num_home_systems, systems, gsd):
     pool_matching_sys_and_planet_limit = []
     pool_matching_sys_limit = []
     for system in systems:
-        systems_in_vicinity = fo.systems_within_jumps_unordered(HS_VICINITY_RANGE, [system])
-        if len(systems_in_vicinity) >= HS_MIN_SYSTEMS_IN_VICINITY:
+        systems_in_vicinity = fo.systems_within_jumps_unordered(vicinity_range(systems_per_empire), [system])
+        if len(systems_in_vicinity) >= min_systems_in_vicinity:
             pool_matching_sys_limit.append(system)
-            if count_planets_in_systems(systems_in_vicinity) >= min_planets_in_vicinity_limit(len(systems_in_vicinity)):
+            if count_planets_in_systems(systems_in_vicinity) >= 
+                    min_planets_in_vicinity_limit(len(systems_in_vicinity), gsd.planet_density):
                 pool_matching_sys_and_planet_limit.append(system)
     print(len(pool_matching_sys_and_planet_limit),
           "systems meet the min systems and planets in the near vicinity limit")
@@ -375,7 +390,7 @@ def compile_home_system_list(num_home_systems, systems, gsd):
         # specify 0 as number of requested home systems to pick as much systems as possible
         (pool_matching_sys_limit, "pool of systems that meet at least the min systems limit"),
     ]
-    home_systems = find_home_systems(num_home_systems, pool_list, min_jumps, HS_MIN_DISTANCE_PRIORITY_LIMIT)
+    home_systems = find_home_systems(num_home_systems, pool_list, min_jumps, HS_MIN_DISTANCE_PRIORITY_LIMIT, systems_per_empire)
 
     # check if the first attempt delivered a list with enough home systems
     # if not, we make our second attempt, this time disregarding the filtered pools and using all systems, starting
@@ -383,7 +398,7 @@ def compile_home_system_list(num_home_systems, systems, gsd):
     # systems as possible
     if len(home_systems) < num_home_systems:
         print("Second attempt: trying to pick home systems from all systems")
-        home_systems = find_home_systems(num_home_systems, [(systems, "complete pool")], min_jumps, 1)
+        home_systems = find_home_systems(num_home_systems, [(systems, "complete pool")], min_jumps, 1, systems_per_empire)
 
     # check if the selection process delivered a list with enough home systems
     # if not, our galaxy obviously is too crowded, report an error and return an empty list
@@ -396,7 +411,7 @@ def compile_home_system_list(num_home_systems, systems, gsd):
     if len(home_systems) > num_home_systems:
         # yes: calculate the number of planets in the near vicinity of each system
         # and store that value with each system in a map
-        hs_planets_in_vicinity_map = {s: calculate_home_system_merit(s) for s in home_systems}
+        hs_planets_in_vicinity_map = {s: calculate_home_system_merit(s, systems_per_empire) for s in home_systems}
         # sort the home systems by the number of planets in their near vicinity using the map
         # now only pick the number of home systems we need, taking those with the highest number of planets
         home_systems = sorted(home_systems, key=hs_planets_in_vicinity_map.get, reverse=True)[:num_home_systems]
@@ -428,12 +443,14 @@ def compile_home_system_list(num_home_systems, systems, gsd):
     print("Checking if home systems have the required minimum of planets within the near vicinity...")
     for home_system in home_systems:
         # calculate the number of missing planets, and add them if this number is > 0
-        systems_in_vicinity = fo.systems_within_jumps_unordered(HS_VICINITY_RANGE, [home_system])
+        systems_in_vicinity = fo.systems_within_jumps_unordered(vicinity_range(systems_per_empire), [home_system])
         num_systems_in_vicinity = len(systems_in_vicinity)
         num_planets_in_vicinity = count_planets_in_systems(systems_in_vicinity)
-        num_planets_to_add = min_planets_in_vicinity_limit(num_systems_in_vicinity) - num_planets_in_vicinity
+        num_planets_to_add = min_planets_in_vicinity_limit(num_systems_in_vicinity, gsd.planet_density)
+                             - num_planets_in_vicinity
         print("Home system", home_system, "has", num_systems_in_vicinity, "systems and", num_planets_in_vicinity,
-              "planets in the near vicinity, required minimum:", min_planets_in_vicinity_limit(num_systems_in_vicinity))
+              "planets in the near vicinity, required minimum:",
+              min_planets_in_vicinity_limit(num_systems_in_vicinity, gsd.planet_density))
         if num_planets_to_add > 0:
             systems_in_vicinity.remove(home_system)  # don't add planets to the home system, so remove it from the list
             # sort the systems_in_vicinity before adding, since the C++ engine doesn't guarrantee the same

--- a/default/python/universe_generation/options.py
+++ b/default/python/universe_generation/options.py
@@ -30,25 +30,18 @@ NAMING_LARGE_GALAXY_SIZE = 200  # a galaxy with 200+ star systems is considered 
 # These options are needed in the home system selection/placement process. They determine the minimum number of
 # systems and planets that a home system must have in its near vicinity, define the extend of this "near vicinity", etc.
 
-# The following two options are used to determine the minimum number of systems and planets. This limit is
-# HS_MIN_SYSTEMS_IN_VICINITY systems and HS_MIN_PLANETS_IN_VICINITY_PER_SYSTEM planets per system within the near
-# vicinity of a home system, capped at HS_MIN_PLANETS_IN_VICINITY_TOTAL
-# HS_MIN_SYSTEMS_IN_VICINITY = 12
-# HS_MIN_PLANETS_IN_VICINITY_TOTAL = 12
-# HS_MIN_PLANETS_IN_VICINITY_PER_SYSTEM = 1
-
-# This option defines the extend of what is considered the "near vicinity" of a home system. This are all systems that
-# are within the number of jumps specified by HS_VICINITY_RANGE.
+# These two options define the minimum and maximum extend of what is considered the "near vicinity" of a home system.
+# This are all systems that are within the number of jumps specified by vicinity_range(systems_per_empire).
 HS_MIN_VICINITY_RANGE = 2
 HS_MAX_VICINITY_RANGE = 7
 
-# This options sets the maximum starting value for the minimum jump distance limit required between home systems.
+# This option sets the maximum starting value for the minimum jump distance limit required between home systems.
 # With large galaxies an excessive amount of time can be used in failed attempts to select home systems, so defining
 # an upper limit for the home system selection process to use when calculating the starting value for the minimum
 # jump distance limit is reasonable.
 HS_MAX_JUMP_DISTANCE_LIMIT = 20
 
-# This options defines the minimum jump distance limit between home systems that should be considered high priority.
+# This option defines the minimum jump distance limit between home systems that should be considered high priority.
 # As long as the jump distance limit which home systems must at least be apart does not get reduced below this limit
 # during the home system selection process, the minimum systems in home system vicinity requirement takes
 # precedence over the jump distance limit. If the jump distance limit drops below this minimum jump distance limit,

--- a/default/python/universe_generation/options.py
+++ b/default/python/universe_generation/options.py
@@ -58,5 +58,5 @@ HS_MIN_DISTANCE_PRIORITY_LIMIT = 4
 # These two options define which types of planets are counted when determining the number of planets in the near
 # vicinity of a home system. HS_ACCEPTABLE_PLANET_SIZES is actually only needed for the process of adding planets
 # to the near vicinity of a home system in case that's needed to meet the limit.
-HS_ACCEPTABLE_PLANET_TYPES = planet_types_real + (fo.planetType.asteroids,fo.planetType.gasGiant,)
-HS_ACCEPTABLE_PLANET_SIZES = planet_sizes_real + (fo.planetSize.asteroids,fo.planetSize.gasGiant,)
+HS_ACCEPTABLE_PLANET_TYPES = planet_types_real + (fo.planetType.asteroids, fo.planetType.gasGiant,)
+HS_ACCEPTABLE_PLANET_SIZES = planet_sizes_real + (fo.planetSize.asteroids, fo.planetSize.gasGiant,)

--- a/default/python/universe_generation/options.py
+++ b/default/python/universe_generation/options.py
@@ -33,29 +33,30 @@ NAMING_LARGE_GALAXY_SIZE = 200  # a galaxy with 200+ star systems is considered 
 # The following two options are used to determine the minimum number of systems and planets. This limit is
 # HS_MIN_SYSTEMS_IN_VICINITY systems and HS_MIN_PLANETS_IN_VICINITY_PER_SYSTEM planets per system within the near
 # vicinity of a home system, capped at HS_MIN_PLANETS_IN_VICINITY_TOTAL
-HS_MIN_SYSTEMS_IN_VICINITY = 8
-HS_MIN_PLANETS_IN_VICINITY_TOTAL = 10
-HS_MIN_PLANETS_IN_VICINITY_PER_SYSTEM = 1
+# HS_MIN_SYSTEMS_IN_VICINITY = 12
+# HS_MIN_PLANETS_IN_VICINITY_TOTAL = 12
+# HS_MIN_PLANETS_IN_VICINITY_PER_SYSTEM = 1
 
 # This option defines the extend of what is considered the "near vicinity" of a home system. This are all systems that
 # are within the number of jumps specified by HS_VICINITY_RANGE.
-HS_VICINITY_RANGE = 3
+HS_MIN_VICINITY_RANGE = 2
+HS_MAX_VICINITY_RANGE = 7
 
 # This options sets the maximum starting value for the minimum jump distance limit required between home systems.
 # With large galaxies an excessive amount of time can be used in failed attempts to select home systems, so defining
 # an upper limit for the home system selection process to use when calculating the starting value for the minimum
 # jump distance limit is reasonable.
-HS_MAX_JUMP_DISTANCE_LIMIT = 10
+HS_MAX_JUMP_DISTANCE_LIMIT = 20
 
 # This options defines the minimum jump distance limit between home systems that should be considered high priority.
 # As long as the jump distance limit which home systems must at least be apart does not get reduced below this limit
 # during the home system selection process, the minimum systems in home system vicinity requirement takes
 # precedence over the jump distance limit. If the jump distance limit drops below this minimum jump distance limit,
 # the process is restarted giving the jump distance limit precedence.
-HS_MIN_DISTANCE_PRIORITY_LIMIT = 5
+HS_MIN_DISTANCE_PRIORITY_LIMIT = 4
 
 # These two options define which types of planets are counted when determining the number of planets in the near
 # vicinity of a home system. HS_ACCEPTABLE_PLANET_SIZES is actually only needed for the process of adding planets
 # to the near vicinity of a home system in case that's needed to meet the limit.
-HS_ACCEPTABLE_PLANET_TYPES = planet_types_real + (fo.planetType.asteroids,)
-HS_ACCEPTABLE_PLANET_SIZES = planet_sizes_real + (fo.planetSize.asteroids,)
+HS_ACCEPTABLE_PLANET_TYPES = planet_types_real + (fo.planetType.asteroids,fo.planetType.gasGiant,)
+HS_ACCEPTABLE_PLANET_SIZES = planet_sizes_real + (fo.planetSize.asteroids,fo.planetSize.gasGiant,)


### PR DESCRIPTION
This is intended to improve balance of colonization opportunities of empires at universe generation.

It reduces differences in raw number of planets availability between different empires due to randomness of number of systems in vicinity and number of planets per system in that vicinity. It does so by including into calculations the galaxy starlane and planet densities and making them all dependent on systems per empire.
It also ensures that empires in big galaxies can start further apart from each other in big galaxies, by allowing longer minimum jump distances between HW systems (up to a minimum of 20 jumps for galaxies with 55 systems per empire), but still allowing the algorithm to fall back to shorter minimum distances if the desired distances are unattainable.

It does **not** address the great variability in planet environments that can happen between different empires. That is, the problem of some empires starting with many good/adequate planets nearby while others only get poor/hostile planets is still present. This will be further alleviated by an incoming rebalancing of the Exobot species based on Voker57's proposal (https://github.com/Voker57/freeorion/commit/8bd4af7b43896c77fe168da99cb88c1c8ed1eda8).

Generating galaxies of 1000 systems and 20 empires take ~2 seconds to generate in an Intel i7-4710HQ laptop (2.5-3.5 GHz) with 8 GB RAM.

Fixes #2900 