### PR TITLE
Boolify Condition invariants

### DIFF
--- a/universe/Condition.h
+++ b/universe/Condition.h
@@ -55,7 +55,7 @@ struct FO_COMMON_API Condition {
     //! condition is a subcondition to another Condition or a ValueRef, this
     //! condition may be evaluated once and its result used to match all local
     //! candidates to that condition.
-    virtual bool RootCandidateInvariant() const
+    bool RootCandidateInvariant() const
     { return m_root_candidate_invariant; }
 
     //! (Almost) all conditions are varying with local candidates; this is the
@@ -67,12 +67,12 @@ struct FO_COMMON_API Condition {
 
     //! Returns true iff this condition's evaluation does not reference the
     //! target object.
-    virtual bool TargetInvariant() const
+    bool TargetInvariant() const
     { return m_target_invariant; }
 
     //! Returns true iff this condition's evaluation does not reference the
     //! source object.
-    virtual bool SourceInvariant() const
+    bool SourceInvariant() const
     { return m_source_invariant; }
 
     virtual std::string Description(bool negated = false) const = 0;

--- a/universe/Condition.h
+++ b/universe/Condition.h
@@ -16,12 +16,6 @@ namespace Condition {
 
 typedef std::vector<std::shared_ptr<const UniverseObject>> ObjectSet;
 
-enum Invariance : int {
-    UNKNOWN_INVARIANCE, ///< This condition hasn't yet calculated this invariance type
-    INVARIANT,          ///< This condition is invariant to a particular type of object change
-    VARIANT             ///< This condition's result depends on the state of a particular object
-};
-
 enum SearchDomain : int {
     NON_MATCHES,    ///< The Condition will only examine items in the non matches set; those that match the Condition will be inserted into the matches set.
     MATCHES         ///< The Condition will only examine items in the matches set; those that do not match the Condition will be inserted into the nonmatches set.
@@ -88,9 +82,9 @@ struct FO_COMMON_API Condition {
     { return 0; }
 
 protected:
-    Invariance m_root_candidate_invariant = UNKNOWN_INVARIANCE;
-    Invariance m_target_invariant = UNKNOWN_INVARIANCE;
-    Invariance m_source_invariant = UNKNOWN_INVARIANCE;
+    bool m_root_candidate_invariant = false;
+    bool m_target_invariant = false;
+    bool m_source_invariant = false;
 
 private:
     struct MatchHelper;

--- a/universe/Condition.h
+++ b/universe/Condition.h
@@ -50,30 +50,30 @@ struct FO_COMMON_API Condition {
     virtual void GetDefaultInitialCandidateObjects(const ScriptingContext& parent_context,
                                                    ObjectSet& condition_non_targets) const;
 
-    /** Returns true iff this condition's evaluation does not reference
-      * the RootCandidate objects.  This requirement ensures that if this
-      * condition is a subcondition to another Condition or a ValueRef, this
-      * condition may be evaluated once and its result used to match all local
-      * candidates to that condition. */
+    //! Returns true iff this condition's evaluation does not reference
+    //! the RootCandidate objects.  This requirement ensures that if this
+    //! condition is a subcondition to another Condition or a ValueRef, this
+    //! condition may be evaluated once and its result used to match all local
+    //! candidates to that condition.
     virtual bool RootCandidateInvariant() const
-    { return false; }
+    { return m_root_candidate_invariant; }
 
-    /** (Almost) all conditions are varying with local candidates; this is the
-      * point of evaluating a condition.  This funciton is provided for
-      * consistency with ValueRef, which may not depend on the local candidiate
-      * of an enclosing condition. */
+    //! (Almost) all conditions are varying with local candidates; this is the
+    //! point of evaluating a condition.  This funciton is provided for
+    //! consistency with ValueRef, which may not depend on the local candidiate
+    //! of an enclosing condition.
     bool LocalCandidateInvariant() const
     { return false; }
 
-    /** Returns true iff this condition's evaluation does not reference the
-      * target object.*/
+    //! Returns true iff this condition's evaluation does not reference the
+    //! target object.
     virtual bool TargetInvariant() const
-    { return false; }
+    { return m_target_invariant; }
 
-    /** Returns true iff this condition's evaluation does not reference the
-      * source object.*/
+    //! Returns true iff this condition's evaluation does not reference the
+    //! source object.
     virtual bool SourceInvariant() const
-    { return false; }
+    { return m_source_invariant; }
 
     virtual std::string Description(bool negated = false) const = 0;
     virtual std::string Dump(unsigned short ntabs = 0) const = 0;

--- a/universe/ConditionAll.h
+++ b/universe/ConditionAll.h
@@ -17,12 +17,6 @@ struct FO_COMMON_API All final : public Condition {
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
-    bool RootCandidateInvariant() const override
-    { return true; }
-    bool TargetInvariant() const override
-    { return true; }
-    bool SourceInvariant() const override
-    { return true; }
     void SetTopLevelContent(const std::string& content_name) override
     {}
     unsigned int GetCheckSum() const override;

--- a/universe/ConditionAll.h
+++ b/universe/ConditionAll.h
@@ -10,7 +10,7 @@ namespace Condition {
 
 /** Matches all objects. */
 struct FO_COMMON_API All final : public Condition {
-    All() : Condition() {}
+    All();
 
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,

--- a/universe/ConditionSource.h
+++ b/universe/ConditionSource.h
@@ -15,10 +15,6 @@ struct FO_COMMON_API Source final : public Condition {
     bool operator==(const Condition& rhs) const override;
     void GetDefaultInitialCandidateObjects(const ScriptingContext& parent_context,
                                            ObjectSet& condition_non_targets) const override;
-    bool RootCandidateInvariant() const override
-    { return true; }
-    bool TargetInvariant() const override
-    { return true; }
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override

--- a/universe/ConditionSource.h
+++ b/universe/ConditionSource.h
@@ -10,7 +10,7 @@ namespace Condition {
 
 /** Matches the source object only. */
 struct FO_COMMON_API Source final : public Condition {
-    Source() : Condition() {}
+    Source();
 
     bool operator==(const Condition& rhs) const override;
     void GetDefaultInitialCandidateObjects(const ScriptingContext& parent_context,

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -2737,6 +2737,11 @@ unsigned int CreatedOnTurn::GetCheckSum() const {
 ///////////////////////////////////////////////////////////
 // Contains                                              //
 ///////////////////////////////////////////////////////////
+Contains::Contains(std::unique_ptr<Condition>&& condition) :
+    Condition(),
+    m_condition(std::move(condition))
+{}
+
 bool Contains::operator==(const Condition& rhs) const {
     if (this == &rhs)
         return true;

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -6701,7 +6701,12 @@ OwnerHasShipDesignAvailable::OwnerHasShipDesignAvailable(
     Condition(),
     m_id(std::move(design_id)),
     m_empire_id(std::move(empire_id))
-{}
+{
+    auto operands = {m_id.get(), m_empire_id.get()};
+    m_root_candidate_invariant = boost::algorithm::all_of(operands, [](auto& e){ return !e || e->RootCandidateInvariant(); });
+    m_target_invariant = boost::algorithm::all_of(operands, [](auto& e){ return !e || e->TargetInvariant(); });
+    m_source_invariant = boost::algorithm::all_of(operands, [](auto& e){ return !e || e->SourceInvariant(); });
+}
 
 OwnerHasShipDesignAvailable::OwnerHasShipDesignAvailable(int design_id) :
     OwnerHasShipDesignAvailable(nullptr, std::move(std::make_unique<ValueRef::Constant<int>>(design_id)))
@@ -6774,21 +6779,6 @@ void OwnerHasShipDesignAvailable::Eval(const ScriptingContext& parent_context,
         // re-evaluate allowed turn range for each candidate object
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
-}
-
-bool OwnerHasShipDesignAvailable::RootCandidateInvariant() const {
-    return (!m_empire_id || m_empire_id->RootCandidateInvariant()) &&
-           (!m_id || m_id->RootCandidateInvariant());
-}
-
-bool OwnerHasShipDesignAvailable::TargetInvariant() const {
-    return (!m_empire_id || m_empire_id->TargetInvariant()) &&
-           (!m_id || m_id->TargetInvariant());
-}
-
-bool OwnerHasShipDesignAvailable::SourceInvariant() const {
-    return (!m_empire_id || m_empire_id->SourceInvariant()) &&
-           (!m_id || m_id->SourceInvariant());
 }
 
 std::string OwnerHasShipDesignAvailable::Description(bool negated/* = false*/) const {

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -2937,6 +2937,11 @@ unsigned int Contains::GetCheckSum() const {
 ///////////////////////////////////////////////////////////
 // ContainedBy                                           //
 ///////////////////////////////////////////////////////////
+ContainedBy::ContainedBy(std::unique_ptr<Condition>&& condition) :
+    Condition(),
+    m_condition(std::move(condition))
+{}
+
 bool ContainedBy::operator==(const Condition& rhs) const {
     if (this == &rhs)
         return true;

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -2749,7 +2749,11 @@ unsigned int CreatedOnTurn::GetCheckSum() const {
 Contains::Contains(std::unique_ptr<Condition>&& condition) :
     Condition(),
     m_condition(std::move(condition))
-{}
+{
+    m_root_candidate_invariant = m_condition->RootCandidateInvariant();
+    m_target_invariant = m_condition->TargetInvariant();
+    m_source_invariant = m_condition->SourceInvariant();
+}
 
 bool Contains::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -2882,15 +2886,6 @@ void Contains::Eval(const ScriptingContext& parent_context,
         EvalImpl(matches, non_matches, search_domain, ContainsSimpleMatch(subcondition_matches));
     }
 }
-
-bool Contains::RootCandidateInvariant() const
-{ return m_condition->RootCandidateInvariant(); }
-
-bool Contains::TargetInvariant() const
-{ return m_condition->TargetInvariant(); }
-
-bool Contains::SourceInvariant() const
-{ return m_condition->SourceInvariant(); }
 
 std::string Contains::Description(bool negated/* = false*/) const {
     return str(FlexibleFormat((!negated)

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -6556,7 +6556,17 @@ OwnerHasBuildingTypeAvailable::OwnerHasBuildingTypeAvailable(
     Condition(),
     m_name(std::move(name)),
     m_empire_id(std::move(empire_id))
-{}
+{
+    m_root_candidate_invariant =
+        (!m_empire_id || m_empire_id->RootCandidateInvariant()) &&
+        (!m_name || m_name->RootCandidateInvariant());
+    m_target_invariant =
+        (!m_empire_id || m_empire_id->TargetInvariant()) &&
+        (!m_name || m_name->TargetInvariant());
+    m_source_invariant =
+        (!m_empire_id || m_empire_id->SourceInvariant()) &&
+        (!m_name || m_name->SourceInvariant());
+}
 
 OwnerHasBuildingTypeAvailable::OwnerHasBuildingTypeAvailable(const std::string& name) :
     OwnerHasBuildingTypeAvailable(nullptr, std::move(std::make_unique<ValueRef::Constant<std::string>>(name)))
@@ -6629,21 +6639,6 @@ void OwnerHasBuildingTypeAvailable::Eval(const ScriptingContext& parent_context,
         // re-evaluate allowed turn range for each candidate object
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
-}
-
-bool OwnerHasBuildingTypeAvailable::RootCandidateInvariant() const {
-    return (!m_empire_id || m_empire_id->RootCandidateInvariant()) &&
-           (!m_name || m_name->RootCandidateInvariant());
-}
-
-bool OwnerHasBuildingTypeAvailable::TargetInvariant() const {
-    return (!m_empire_id || m_empire_id->TargetInvariant()) &&
-           (!m_name || m_name->TargetInvariant());
-}
-
-bool OwnerHasBuildingTypeAvailable::SourceInvariant() const {
-    return (!m_empire_id || m_empire_id->SourceInvariant()) &&
-           (!m_name || m_name->SourceInvariant());
 }
 
 std::string OwnerHasBuildingTypeAvailable::Description(bool negated/* = false*/) const {

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -9005,7 +9005,12 @@ Location::Location(ContentType content_type,
     m_name1(std::move(name1)),
     m_name2(std::move(name2)),
     m_content_type(content_type)
-{}
+{
+    auto operands = {m_name1.get(), m_name2.get()};
+    m_root_candidate_invariant = boost::algorithm::all_of(operands, [](auto& e){ return !e || e->RootCandidateInvariant(); });
+    m_target_invariant = boost::algorithm::all_of(operands, [](auto& e){ return !e || e->TargetInvariant(); });
+    m_source_invariant = boost::algorithm::all_of(operands, [](auto& e){ return !e || e->SourceInvariant(); });
+}
 
 bool Location::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -9056,21 +9061,6 @@ void Location::Eval(const ScriptingContext& parent_context,
         // re-evaluate value and ranges for each candidate object
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
-}
-
-bool Location::RootCandidateInvariant() const {
-    return (!m_name1    || m_name1->RootCandidateInvariant()) &&
-           (!m_name2    || m_name2->RootCandidateInvariant());
-}
-
-bool Location::TargetInvariant() const {
-    return (!m_name1    || m_name1->TargetInvariant()) &&
-           (!m_name2    || m_name2->TargetInvariant());
-}
-
-bool Location::SourceInvariant() const {
-    return (!m_name1    || m_name1->SourceInvariant()) &&
-           (!m_name2    || m_name2->SourceInvariant());
 }
 
 std::string Location::Description(bool negated/* = false*/) const {

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -10298,6 +10298,12 @@ const std::vector<Condition*> OrderedAlternativesOf::Operands() const {
 ///////////////////////////////////////////////////////////
 // Described                                             //
 ///////////////////////////////////////////////////////////
+Described::Described(std::unique_ptr<Condition>&& condition, const std::string& desc_stringtable_key) :
+    Condition(),
+    m_condition(std::move(condition)),
+    m_desc_stringtable_key(desc_stringtable_key)
+{}
+
 bool Described::operator==(const Condition& rhs) const {
     if (this == &rhs)
         return true;

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -8626,6 +8626,10 @@ unsigned int ResourceSupplyConnectedByEmpire::GetCheckSum() const {
 ///////////////////////////////////////////////////////////
 // CanColonize                                           //
 ///////////////////////////////////////////////////////////
+CanColonize::CanColonize() :
+    Condition()
+{}
+
 bool CanColonize::operator==(const Condition& rhs) const
 { return Condition::operator==(rhs); }
 

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -5699,7 +5699,12 @@ MeterValue::MeterValue(MeterType meter,
     m_meter(meter),
     m_low(std::move(low)),
     m_high(std::move(high))
-{}
+{
+    auto operands = {m_low.get(), m_high.get()};
+    m_root_candidate_invariant = boost::algorithm::all_of(operands, [](auto& e){ return !e || e->RootCandidateInvariant(); });
+    m_target_invariant = boost::algorithm::all_of(operands, [](auto& e){ return !e || e->TargetInvariant(); });
+    m_source_invariant = boost::algorithm::all_of(operands, [](auto& e){ return !e || e->SourceInvariant(); });
+}
 
 bool MeterValue::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -5803,15 +5808,6 @@ void MeterValue::Eval(const ScriptingContext& parent_context,
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
 }
-
-bool MeterValue::RootCandidateInvariant() const
-{ return (!m_low || m_low->RootCandidateInvariant()) && (!m_high || m_high->RootCandidateInvariant()); }
-
-bool MeterValue::TargetInvariant() const
-{ return (!m_low || m_low->TargetInvariant()) && (!m_high || m_high->TargetInvariant()); }
-
-bool MeterValue::SourceInvariant() const
-{ return (!m_low || m_low->SourceInvariant()) && (!m_high || m_high->SourceInvariant()); }
 
 std::string MeterValue::Description(bool negated/* = false*/) const {
     std::string low_str = (m_low ? (m_low->ConstantExpr() ?

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -1814,6 +1814,10 @@ unsigned int Monster::GetCheckSum() const {
 ///////////////////////////////////////////////////////////
 // Armed                                                 //
 ///////////////////////////////////////////////////////////
+Armed::Armed() :
+    Condition()
+{}
+
 bool Armed::operator==(const Condition& rhs) const
 { return Condition::operator==(rhs); }
 

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -6841,7 +6841,17 @@ OwnerHasShipPartAvailable::OwnerHasShipPartAvailable(
     Condition(),
     m_name(std::move(name)),
     m_empire_id(std::move(empire_id))
-{}
+{
+    m_root_candidate_invariant =
+        (!m_empire_id || m_empire_id->RootCandidateInvariant()) &&
+        (!m_name || m_name->RootCandidateInvariant());
+    m_target_invariant =
+        (!m_empire_id || m_empire_id->TargetInvariant()) &&
+        (!m_name || m_name->TargetInvariant());
+    m_source_invariant =
+        (!m_empire_id || m_empire_id->TargetInvariant()) &&
+        (!m_name || m_name->TargetInvariant());
+}
 
 OwnerHasShipPartAvailable::OwnerHasShipPartAvailable(const std::string& name) :
     OwnerHasShipPartAvailable(nullptr, std::move(std::make_unique<ValueRef::Constant<std::string>>(name)))
@@ -6915,21 +6925,6 @@ void OwnerHasShipPartAvailable::Eval(const ScriptingContext& parent_context,
         // re-evaluate allowed turn range for each candidate object
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
-}
-
-bool OwnerHasShipPartAvailable::RootCandidateInvariant() const {
-    return (!m_empire_id || m_empire_id->RootCandidateInvariant()) &&
-           (!m_name || m_name->RootCandidateInvariant());
-}
-
-bool OwnerHasShipPartAvailable::TargetInvariant() const {
-    return (!m_empire_id || m_empire_id->TargetInvariant()) &&
-           (!m_name || m_name->TargetInvariant());
-}
-
-bool OwnerHasShipPartAvailable::SourceInvariant() const {
-    return (!m_empire_id || m_empire_id->TargetInvariant()) &&
-           (!m_name || m_name->TargetInvariant());
 }
 
 std::string OwnerHasShipPartAvailable::Description(bool negated/* = false*/) const {

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -1407,6 +1407,10 @@ unsigned int Source::GetCheckSum() const {
 ///////////////////////////////////////////////////////////
 // RootCandidate                                         //
 ///////////////////////////////////////////////////////////
+RootCandidate::RootCandidate() :
+    Condition()
+{}
+
 bool RootCandidate::operator==(const Condition& rhs) const
 { return Condition::operator==(rhs); }
 

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -4283,8 +4283,7 @@ Enqueued::Enqueued(std::unique_ptr<ValueRef::ValueRef<int>>&& design_id,
 {}
 
 Enqueued::Enqueued() :
-    Condition(),
-    m_build_type(BT_NOT_BUILDING)
+    Enqueued(BT_NOT_BUILDING, nullptr, nullptr, nullptr)
 {}
 
 Enqueued::Enqueued(BuildType build_type,

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -8257,6 +8257,15 @@ unsigned int Stationary::GetCheckSum() const {
 ///////////////////////////////////////////////////////////
 // Aggressive                                            //
 ///////////////////////////////////////////////////////////
+Aggressive::Aggressive() :
+    Aggressive(true)
+{}
+
+Aggressive::Aggressive(bool aggressive) :
+    Condition(),
+    m_aggressive(aggressive)
+{}
+
 bool Aggressive::operator==(const Condition& rhs) const
 { return Condition::operator==(rhs); }
 

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -2576,7 +2576,12 @@ CreatedOnTurn::CreatedOnTurn(std::unique_ptr<ValueRef::ValueRef<int>>&& low,
     Condition(),
     m_low(std::move(low)),
     m_high(std::move(high))
-{}
+{
+    auto operands = {m_low.get(), m_high.get()};
+    m_root_candidate_invariant = boost::algorithm::all_of(operands, [](auto& e){ return !e || e->RootCandidateInvariant(); });
+    m_target_invariant = boost::algorithm::all_of(operands, [](auto& e){ return !e || e->TargetInvariant(); });
+    m_source_invariant = boost::algorithm::all_of(operands, [](auto& e){ return !e || e->SourceInvariant(); });
+}
 
 bool CreatedOnTurn::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -2627,15 +2632,6 @@ void CreatedOnTurn::Eval(const ScriptingContext& parent_context,
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
 }
-
-bool CreatedOnTurn::RootCandidateInvariant() const
-{ return ((!m_low || m_low->RootCandidateInvariant()) && (!m_high || m_high->RootCandidateInvariant())); }
-
-bool CreatedOnTurn::TargetInvariant() const
-{ return ((!m_low || m_low->TargetInvariant()) && (!m_high || m_high->TargetInvariant())); }
-
-bool CreatedOnTurn::SourceInvariant() const
-{ return ((!m_low || m_low->SourceInvariant()) && (!m_high || m_high->SourceInvariant())); }
 
 std::string CreatedOnTurn::Description(bool negated/* = false*/) const {
     std::string low_str = (m_low ? (m_low->ConstantExpr() ?

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -1082,6 +1082,10 @@ unsigned int All::GetCheckSum() const {
 ///////////////////////////////////////////////////////////
 // None                                                  //
 ///////////////////////////////////////////////////////////
+None::None() :
+    Condition()
+{}
+
 void None::Eval(const ScriptingContext& parent_context,
                 ObjectSet& matches, ObjectSet& non_matches,
                 SearchDomain search_domain/* = NON_MATCHES*/) const

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -2471,13 +2471,11 @@ unsigned int HasSpecial::GetCheckSum() const {
 // HasTag                                                //
 ///////////////////////////////////////////////////////////
 HasTag::HasTag() :
-    Condition(),
-    m_name()
+    HasTag(std::unique_ptr<ValueRef::ValueRef<std::string>>{})
 {}
 
 HasTag::HasTag(const std::string& name) :
-    Condition(),
-    m_name(std::make_unique<ValueRef::Constant<std::string>>(name))
+    HasTag(std::move(std::make_unique<ValueRef::Constant<std::string>>(name)))
 {}
 
 HasTag::HasTag(std::unique_ptr<ValueRef::ValueRef<std::string>>&& name) :

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -8724,7 +8724,11 @@ unsigned int CanColonize::GetCheckSum() const {
 ///////////////////////////////////////////////////////////
 CanProduceShips::CanProduceShips() :
     Condition()
-{}
+{
+    m_root_candidate_invariant = true;
+    m_target_invariant = true;
+    m_source_invariant = true;
+}
 
 bool CanProduceShips::operator==(const Condition& rhs) const
 { return Condition::operator==(rhs); }

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -6248,7 +6248,12 @@ EmpireStockpileValue::EmpireStockpileValue(ResourceType stockpile,
     m_stockpile(stockpile),
     m_low(std::move(low)),
     m_high(std::move(high))
-{}
+{
+    auto operands = {m_low.get(), m_high.get()};
+    m_root_candidate_invariant = boost::algorithm::all_of(operands, [](auto& e){ return !e || e->RootCandidateInvariant(); });
+    m_target_invariant = boost::algorithm::all_of(operands, [](auto& e){ return !e || e->TargetInvariant(); });
+    m_source_invariant = boost::algorithm::all_of(operands, [](auto& e){ return !e || e->SourceInvariant(); });
+}
 
 bool EmpireStockpileValue::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -6302,15 +6307,6 @@ void EmpireStockpileValue::Eval(const ScriptingContext& parent_context,
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
 }
-
-bool EmpireStockpileValue::RootCandidateInvariant() const
-{ return (m_low->RootCandidateInvariant() && m_high->RootCandidateInvariant()); }
-
-bool EmpireStockpileValue::TargetInvariant() const
-{ return (m_low->TargetInvariant() && m_high->TargetInvariant()); }
-
-bool EmpireStockpileValue::SourceInvariant() const
-{ return (m_low->SourceInvariant() && m_high->SourceInvariant()); }
 
 std::string EmpireStockpileValue::Description(bool negated/* = false*/) const {
     std::string low_str = m_low->ConstantExpr() ?

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -9650,7 +9650,11 @@ const std::vector<Condition*> And::Operands() const {
 Or::Or(std::vector<std::unique_ptr<Condition>>&& operands) :
     Condition(),
     m_operands(std::move(operands))
-{ SetConditionVariance(m_operands, m_root_candidate_invariant, m_target_invariant, m_source_invariant); }
+{
+    m_root_candidate_invariant = boost::algorithm::all_of(m_operands, [](auto& e){ return !e || e->RootCandidateInvariant(); });
+    m_target_invariant = boost::algorithm::all_of(m_operands, [](auto& e){ return !e || e->TargetInvariant(); });
+    m_source_invariant = boost::algorithm::all_of(m_operands, [](auto& e){ return !e || e->SourceInvariant(); });
+}
 
 Or::Or(std::unique_ptr<Condition>&& operand1,
        std::unique_ptr<Condition>&& operand2,
@@ -9668,7 +9672,9 @@ Or::Or(std::unique_ptr<Condition>&& operand1,
     if (operand4)
         m_operands.push_back(std::move(operand4));
 
-    SetConditionVariance(m_operands, m_root_candidate_invariant, m_target_invariant, m_source_invariant);
+    m_root_candidate_invariant = boost::algorithm::all_of(m_operands, [](auto& e){ return !e || e->RootCandidateInvariant(); });
+    m_target_invariant = boost::algorithm::all_of(m_operands, [](auto& e){ return !e || e->TargetInvariant(); });
+    m_source_invariant = boost::algorithm::all_of(m_operands, [](auto& e){ return !e || e->SourceInvariant(); });
 }
 
 bool Or::operator==(const Condition& rhs) const {
@@ -9737,15 +9743,6 @@ void Or::Eval(const ScriptingContext& parent_context, ObjectSet& matches,
         // conditions
     }
 }
-
-bool Or::RootCandidateInvariant() const
-{ return m_root_candidate_invariant; }
-
-bool Or::TargetInvariant() const
-{ return m_target_invariant; }
-
-bool Or::SourceInvariant() const
-{ return m_source_invariant; }
 
 std::string Or::Description(bool negated/* = false*/) const {
     std::string values_str;

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -3320,7 +3320,11 @@ unsigned int InSystem::GetCheckSum() const {
 ObjectID::ObjectID(std::unique_ptr<ValueRef::ValueRef<int>>&& object_id) :
     Condition(),
     m_object_id(std::move(object_id))
-{}
+{
+    m_root_candidate_invariant = !m_object_id || m_object_id->RootCandidateInvariant();
+    m_target_invariant = !m_object_id || m_object_id->TargetInvariant();
+    m_source_invariant = !m_object_id || m_object_id->SourceInvariant();
+}
 
 bool ObjectID::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -3367,15 +3371,6 @@ void ObjectID::Eval(const ScriptingContext& parent_context,
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
 }
-
-bool ObjectID::RootCandidateInvariant() const
-{ return !m_object_id || m_object_id->RootCandidateInvariant(); }
-
-bool ObjectID::TargetInvariant() const
-{ return !m_object_id || m_object_id->TargetInvariant(); }
-
-bool ObjectID::SourceInvariant() const
-{ return !m_object_id || m_object_id->SourceInvariant(); }
 
 std::string ObjectID::Description(bool negated/* = false*/) const {
     std::string object_str;

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -8025,7 +8025,11 @@ unsigned int CanAddStarlaneConnection::GetCheckSum() const {
 ExploredByEmpire::ExploredByEmpire(std::unique_ptr<ValueRef::ValueRef<int>>&& empire_id) :
     Condition(),
     m_empire_id(std::move(empire_id))
-{}
+{
+    m_root_candidate_invariant = m_empire_id->RootCandidateInvariant();
+    m_target_invariant = m_empire_id->TargetInvariant();
+    m_source_invariant = m_empire_id->SourceInvariant();
+}
 
 bool ExploredByEmpire::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -8078,15 +8082,6 @@ void ExploredByEmpire::Eval(const ScriptingContext& parent_context,
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
 }
-
-bool ExploredByEmpire::RootCandidateInvariant() const
-{ return m_empire_id->RootCandidateInvariant(); }
-
-bool ExploredByEmpire::TargetInvariant() const
-{ return m_empire_id->TargetInvariant(); }
-
-bool ExploredByEmpire::SourceInvariant() const
-{ return m_empire_id->SourceInvariant(); }
 
 std::string ExploredByEmpire::Description(bool negated/* = false*/) const {
     std::string empire_str;

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -1448,6 +1448,10 @@ unsigned int RootCandidate::GetCheckSum() const {
 ///////////////////////////////////////////////////////////
 // Target                                                //
 ///////////////////////////////////////////////////////////
+Target::Target() :
+    Condition()
+{}
+
 bool Target::operator==(const Condition& rhs) const
 { return Condition::operator==(rhs); }
 

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -5434,7 +5434,11 @@ unsigned int DesignHasPartClass::GetCheckSum() const {
 PredefinedShipDesign::PredefinedShipDesign(std::unique_ptr<ValueRef::ValueRef<std::string>>&& name) :
     Condition(),
     m_name(std::move(name))
-{}
+{
+    m_root_candidate_invariant = !m_name || m_name->RootCandidateInvariant();
+    m_target_invariant = !m_name || m_name->TargetInvariant();
+    m_source_invariant = !m_name || m_name->SourceInvariant();
+}
 
 bool PredefinedShipDesign::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -5506,15 +5510,6 @@ void PredefinedShipDesign::Eval(const ScriptingContext& parent_context,
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
 }
-
-bool PredefinedShipDesign::RootCandidateInvariant() const
-{ return !m_name || m_name->RootCandidateInvariant(); }
-
-bool PredefinedShipDesign::TargetInvariant() const
-{ return !m_name || m_name->TargetInvariant(); }
-
-bool PredefinedShipDesign::SourceInvariant() const
-{ return !m_name || m_name->SourceInvariant(); }
 
 std::string PredefinedShipDesign::Description(bool negated/* = false*/) const {
     std::string name_str;

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -4663,7 +4663,11 @@ unsigned int FocusType::GetCheckSum() const {
 StarType::StarType(std::vector<std::unique_ptr<ValueRef::ValueRef< ::StarType>>>&& types) :
     Condition(),
     m_types(std::move(types))
-{}
+{
+    m_root_candidate_invariant = boost::algorithm::all_of(m_types, [](auto& e){ return e->RootCandidateInvariant(); });
+    m_target_invariant = boost::algorithm::all_of(m_types, [](auto& e){ return e->TargetInvariant(); });
+    m_source_invariant = boost::algorithm::all_of(m_types, [](auto& e){ return e->SourceInvariant(); });
+}
 
 bool StarType::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -4731,30 +4735,6 @@ void StarType::Eval(const ScriptingContext& parent_context,
         // re-evaluate contained objects for each candidate object
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
-}
-
-bool StarType::RootCandidateInvariant() const {
-    for (auto& type : m_types) {
-        if (!type->RootCandidateInvariant())
-            return false;
-    }
-    return true;
-}
-
-bool StarType::TargetInvariant() const {
-    for (auto& type : m_types) {
-        if (!type->TargetInvariant())
-            return false;
-    }
-    return true;
-}
-
-bool StarType::SourceInvariant() const {
-    for (auto& type : m_types) {
-        if (!type->SourceInvariant())
-            return false;
-    }
-    return true;
 }
 
 std::string StarType::Description(bool negated/* = false*/) const {

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -1791,7 +1791,11 @@ unsigned int Capital::GetCheckSum() const {
 ///////////////////////////////////////////////////////////
 Monster::Monster() :
     Condition()
-{}
+{
+    m_root_candidate_invariant = true;
+    m_target_invariant = true;
+    m_source_invariant = true;
+}
 
 bool Monster::operator==(const Condition& rhs) const
 { return Condition::operator==(rhs); }

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -8151,7 +8151,11 @@ ResourceSupplyConnectedByEmpire::ResourceSupplyConnectedByEmpire(
     Condition(),
     m_empire_id(std::move(empire_id)),
     m_condition(std::move(condition))
-{}
+{
+    m_root_candidate_invariant = m_empire_id->RootCandidateInvariant() && m_condition->RootCandidateInvariant();
+    m_target_invariant = m_empire_id->TargetInvariant() && m_condition->TargetInvariant();
+    m_source_invariant = m_empire_id->SourceInvariant() && m_condition->SourceInvariant();
+}
 
 bool ResourceSupplyConnectedByEmpire::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -8261,15 +8265,6 @@ void ResourceSupplyConnectedByEmpire::Eval(const ScriptingContext& parent_contex
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
 }
-
-bool ResourceSupplyConnectedByEmpire::RootCandidateInvariant() const
-{ return m_empire_id->RootCandidateInvariant() && m_condition->RootCandidateInvariant(); }
-
-bool ResourceSupplyConnectedByEmpire::TargetInvariant() const
-{ return m_empire_id->TargetInvariant() && m_condition->TargetInvariant(); }
-
-bool ResourceSupplyConnectedByEmpire::SourceInvariant() const
-{ return m_empire_id->SourceInvariant() && m_condition->SourceInvariant(); }
 
 bool ResourceSupplyConnectedByEmpire::Match(const ScriptingContext& local_context) const {
     auto candidate = local_context.condition_local_candidate;

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -8739,7 +8739,12 @@ ValueTest::ValueTest(std::unique_ptr<ValueRef::ValueRef<double>>&& value_ref1,
     m_value_ref3(std::move(value_ref3)),
     m_compare_type1(comp1),
     m_compare_type2(comp2)
-{}
+{
+    auto operands = {m_value_ref1.get(), m_value_ref2.get(), m_value_ref3.get()};
+    m_root_candidate_invariant = boost::algorithm::all_of(operands, [](auto& e){ return !e || e->RootCandidateInvariant(); });
+    m_target_invariant = boost::algorithm::all_of(operands, [](auto& e){ return !e || e->TargetInvariant(); });
+    m_source_invariant = boost::algorithm::all_of(operands, [](auto& e){ return !e || e->SourceInvariant(); });
+}
 
 ValueTest::ValueTest(std::unique_ptr<ValueRef::ValueRef<std::string>>&& value_ref1,
                      ComparisonType comp1,
@@ -8753,9 +8758,10 @@ ValueTest::ValueTest(std::unique_ptr<ValueRef::ValueRef<std::string>>&& value_re
     m_compare_type1(comp1),
     m_compare_type2(comp2)
 {
-    /*DebugLogger() << "String ValueTest(" << value_ref1->Dump(ntabs) << " "
-                                         << CompareTypeString(comp1) << " "
-                                         << value_ref2->Dump(ntabs) << ")";*/
+    auto operands = {m_string_value_ref1.get(), m_string_value_ref2.get(), m_string_value_ref3.get()};
+    m_root_candidate_invariant = boost::algorithm::all_of(operands, [](auto& e){ return !e || e->RootCandidateInvariant(); });
+    m_target_invariant = boost::algorithm::all_of(operands, [](auto& e){ return !e || e->TargetInvariant(); });
+    m_source_invariant = boost::algorithm::all_of(operands, [](auto& e){ return !e || e->SourceInvariant(); });
 }
 
 ValueTest::ValueTest(std::unique_ptr<ValueRef::ValueRef<int>>&& value_ref1,
@@ -8770,7 +8776,10 @@ ValueTest::ValueTest(std::unique_ptr<ValueRef::ValueRef<int>>&& value_ref1,
     m_compare_type1(comp1),
     m_compare_type2(comp2)
 {
-    //DebugLogger() << "ValueTest(double)";
+    auto operands = {m_int_value_ref1.get(), m_int_value_ref2.get(), m_int_value_ref3.get()};
+    m_root_candidate_invariant = boost::algorithm::all_of(operands, [](auto& e){ return !e || e->RootCandidateInvariant(); });
+    m_target_invariant = boost::algorithm::all_of(operands, [](auto& e){ return !e || e->TargetInvariant(); });
+    m_source_invariant = boost::algorithm::all_of(operands, [](auto& e){ return !e || e->SourceInvariant(); });
 }
 
 bool ValueTest::operator==(const Condition& rhs) const {
@@ -8832,42 +8841,6 @@ void ValueTest::Eval(const ScriptingContext& parent_context,
         // re-evaluate value and ranges for each candidate object
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
-}
-
-bool ValueTest::RootCandidateInvariant() const {
-    return (!m_value_ref1           || m_value_ref1->RootCandidateInvariant()) &&
-           (!m_value_ref2           || m_value_ref2->RootCandidateInvariant()) &&
-           (!m_value_ref3           || m_value_ref3->RootCandidateInvariant()) &&
-           (!m_string_value_ref1    || m_string_value_ref1->RootCandidateInvariant()) &&
-           (!m_string_value_ref2    || m_string_value_ref2->RootCandidateInvariant()) &&
-           (!m_string_value_ref3    || m_string_value_ref3->RootCandidateInvariant()) &&
-           (!m_int_value_ref1       || m_int_value_ref1->RootCandidateInvariant()) &&
-           (!m_int_value_ref2       || m_int_value_ref2->RootCandidateInvariant()) &&
-           (!m_int_value_ref3       || m_int_value_ref3->RootCandidateInvariant());
-}
-
-bool ValueTest::TargetInvariant() const {
-    return (!m_value_ref1           || m_value_ref1->TargetInvariant()) &&
-           (!m_value_ref2           || m_value_ref2->TargetInvariant()) &&
-           (!m_value_ref3           || m_value_ref3->TargetInvariant()) &&
-           (!m_string_value_ref1    || m_string_value_ref1->TargetInvariant()) &&
-           (!m_string_value_ref2    || m_string_value_ref2->TargetInvariant()) &&
-           (!m_string_value_ref3    || m_string_value_ref3->TargetInvariant()) &&
-           (!m_int_value_ref1       || m_int_value_ref1->TargetInvariant()) &&
-           (!m_int_value_ref2       || m_int_value_ref2->TargetInvariant()) &&
-           (!m_int_value_ref3       || m_int_value_ref3->TargetInvariant());
-}
-
-bool ValueTest::SourceInvariant() const {
-    return (!m_value_ref1           || m_value_ref1->SourceInvariant()) &&
-           (!m_value_ref2           || m_value_ref2->SourceInvariant()) &&
-           (!m_value_ref3           || m_value_ref3->SourceInvariant()) &&
-           (!m_string_value_ref1    || m_string_value_ref1->SourceInvariant()) &&
-           (!m_string_value_ref2    || m_string_value_ref2->SourceInvariant()) &&
-           (!m_string_value_ref3    || m_string_value_ref3->SourceInvariant()) &&
-           (!m_int_value_ref1       || m_int_value_ref1->SourceInvariant()) &&
-           (!m_int_value_ref2       || m_int_value_ref2->SourceInvariant()) &&
-           (!m_int_value_ref3       || m_int_value_ref3->SourceInvariant());
 }
 
 std::string ValueTest::Description(bool negated/* = false*/) const {

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -1509,7 +1509,11 @@ Homeworld::Homeworld() :
 Homeworld::Homeworld(std::vector<std::unique_ptr<ValueRef::ValueRef<std::string>>>&& names) :
     Condition(),
     m_names(std::move(names))
-{}
+{
+    m_root_candidate_invariant = boost::algorithm::all_of(m_names, [](auto& e){ return e->RootCandidateInvariant(); });
+    m_target_invariant = boost::algorithm::all_of(m_names, [](auto& e){ return e->TargetInvariant(); });
+    m_source_invariant = boost::algorithm::all_of(m_names, [](auto& e){ return e->SourceInvariant(); });
+}
 
 bool Homeworld::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -1605,30 +1609,6 @@ void Homeworld::Eval(const ScriptingContext& parent_context,
         // re-evaluate allowed names for each candidate object
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
-}
-
-bool Homeworld::RootCandidateInvariant() const {
-    for (auto& name : m_names) {
-        if (!name->RootCandidateInvariant())
-            return false;
-    }
-    return true;
-}
-
-bool Homeworld::TargetInvariant() const {
-    for (auto& name : m_names) {
-        if (!name->TargetInvariant())
-            return false;
-    }
-    return true;
-}
-
-bool Homeworld::SourceInvariant() const {
-    for (auto& name : m_names) {
-        if (!name->SourceInvariant())
-            return false;
-    }
-    return true;
 }
 
 std::string Homeworld::Description(bool negated/* = false*/) const {

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -1041,6 +1041,10 @@ unsigned int SortedNumberOf::GetCheckSum() const {
 ///////////////////////////////////////////////////////////
 // All                                                   //
 ///////////////////////////////////////////////////////////
+All::All() :
+    Condition()
+{}
+
 void All::Eval(const ScriptingContext& parent_context,
                           ObjectSet& matches, ObjectSet& non_matches,
                           SearchDomain search_domain/* = NON_MATCHES*/) const

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -6410,7 +6410,17 @@ OwnerHasTech::OwnerHasTech(std::unique_ptr<ValueRef::ValueRef<int>>&& empire_id,
     Condition(),
     m_name(std::move(name)),
     m_empire_id(std::move(empire_id))
-{}
+{
+    m_root_candidate_invariant =
+        (!m_empire_id || m_empire_id->RootCandidateInvariant()) &&
+        (!m_name || m_name->RootCandidateInvariant());
+    m_target_invariant =
+        (!m_empire_id || m_empire_id->TargetInvariant()) &&
+        (!m_name || m_name->TargetInvariant());
+    m_source_invariant =
+        (!m_empire_id || m_empire_id->SourceInvariant()) &&
+        (!m_name || m_name->SourceInvariant());
+}
 
 OwnerHasTech::OwnerHasTech(std::unique_ptr<ValueRef::ValueRef<std::string>>&& name) :
     OwnerHasTech(nullptr, std::move(name))
@@ -6479,21 +6489,6 @@ void OwnerHasTech::Eval(const ScriptingContext& parent_context,
         // re-evaluate allowed turn range for each candidate object
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
-}
-
-bool OwnerHasTech::RootCandidateInvariant() const {
-    return (!m_empire_id || m_empire_id->RootCandidateInvariant()) &&
-           (!m_name || m_name->RootCandidateInvariant());
-}
-
-bool OwnerHasTech::TargetInvariant() const {
-    return (!m_empire_id || m_empire_id->TargetInvariant()) &&
-           (!m_name || m_name->TargetInvariant());
-}
-
-bool OwnerHasTech::SourceInvariant() const {
-    return (!m_empire_id || m_empire_id->SourceInvariant()) &&
-           (!m_name || m_name->SourceInvariant());
 }
 
 std::string OwnerHasTech::Description(bool negated/* = false*/) const {

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -1087,7 +1087,11 @@ unsigned int All::GetCheckSum() const {
 ///////////////////////////////////////////////////////////
 None::None() :
     Condition()
-{}
+{
+    m_root_candidate_invariant = true;
+    m_target_invariant = true;
+    m_source_invariant = true;
+}
 
 void None::Eval(const ScriptingContext& parent_context,
                 ObjectSet& matches, ObjectSet& non_matches,

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -4926,7 +4926,18 @@ DesignHasPart::DesignHasPart(std::unique_ptr<ValueRef::ValueRef<std::string>>&& 
     m_low(std::move(low)),
     m_high(std::move(high)),
     m_name(std::move(name))
-{}
+{
+    auto operands = {m_low.get(), m_high.get()};
+    m_root_candidate_invariant =
+        (!m_name || m_name->RootCandidateInvariant()) &&
+        boost::algorithm::all_of(operands, [](auto& e){ return !e || e->RootCandidateInvariant(); });
+    m_target_invariant =
+        (!m_name || m_name->TargetInvariant()) &&
+        boost::algorithm::all_of(operands, [](auto& e){ return !e || e->TargetInvariant(); });
+    m_source_invariant =
+        (!m_name || m_name->SourceInvariant()) &&
+        boost::algorithm::all_of(operands, [](auto& e){ return !e || e->SourceInvariant(); });
+}
 
 bool DesignHasPart::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -5012,21 +5023,6 @@ void DesignHasPart::Eval(const ScriptingContext& parent_context,
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
 }
-
-bool DesignHasPart::RootCandidateInvariant() const
-{   return (!m_low || m_low->RootCandidateInvariant()) &&
-           (!m_high || m_high->RootCandidateInvariant()) &&
-           (!m_name || m_name->RootCandidateInvariant()); }
-
-bool DesignHasPart::TargetInvariant() const
-{   return (!m_low || m_low->TargetInvariant()) &&
-           (!m_high || m_high->TargetInvariant()) &&
-           (!m_name || m_name->TargetInvariant()); }
-
-bool DesignHasPart::SourceInvariant() const
-{   return (!m_low || m_low->SourceInvariant()) &&
-           (!m_high || m_high->SourceInvariant()) &&
-           (!m_name || m_name->SourceInvariant()); }
 
 std::string DesignHasPart::Description(bool negated/* = false*/) const {
     std::string low_str = "1";

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -6791,13 +6791,11 @@ OwnerHasBuildingTypeAvailable::OwnerHasBuildingTypeAvailable(
 {}
 
 OwnerHasBuildingTypeAvailable::OwnerHasBuildingTypeAvailable(const std::string& name) :
-    Condition(),
-    m_name(std::make_unique<ValueRef::Constant<std::string>>(name))
+    OwnerHasBuildingTypeAvailable(nullptr, std::move(std::make_unique<ValueRef::Constant<std::string>>(name)))
 {}
 
 OwnerHasBuildingTypeAvailable::OwnerHasBuildingTypeAvailable(std::unique_ptr<ValueRef::ValueRef<std::string>>&& name) :
-    Condition(),
-    m_name(std::move(name))
+    OwnerHasBuildingTypeAvailable(nullptr, std::move(name))
 {}
 
 bool OwnerHasBuildingTypeAvailable::operator==(const Condition& rhs) const {

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -325,7 +325,18 @@ Number::Number(std::unique_ptr<ValueRef::ValueRef<int>>&& low,
     m_low(std::move(low)),
     m_high(std::move(high)),
     m_condition(std::move(condition))
-{}
+{
+    auto operands = {m_low.get(), m_high.get()};
+    m_root_candidate_invariant =
+        m_condition->RootCandidateInvariant() &&
+        boost::algorithm::all_of(operands, [](auto& e){ return !e || e->RootCandidateInvariant(); });
+    m_target_invariant =
+        m_condition->TargetInvariant() &&
+        boost::algorithm::all_of(operands, [](auto& e){ return !e || e->TargetInvariant(); });
+    m_source_invariant =
+        m_condition->SourceInvariant() &&
+        boost::algorithm::all_of(operands, [](auto& e){ return !e || e->SourceInvariant(); });
+}
 
 bool Number::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -421,24 +432,6 @@ void Number::Eval(const ScriptingContext& parent_context,
             non_matches.clear();
         }
     }
-}
-
-bool Number::RootCandidateInvariant() const {
-    return (!m_low || m_low->RootCandidateInvariant()) &&
-           (!m_high || m_high->RootCandidateInvariant()) &&
-           m_condition->RootCandidateInvariant();
-}
-
-bool Number::TargetInvariant() const {
-    return (!m_low || m_low->TargetInvariant()) &&
-           (!m_high || m_high->TargetInvariant()) &&
-           m_condition->TargetInvariant();
-}
-
-bool Number::SourceInvariant() const {
-    return (!m_low || m_low->SourceInvariant()) &&
-           (!m_high || m_high->SourceInvariant()) &&
-           m_condition->SourceInvariant();
 }
 
 bool Number::Match(const ScriptingContext& local_context) const {

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -9485,7 +9485,9 @@ And::And(std::unique_ptr<Condition>&& operand1, std::unique_ptr<Condition>&& ope
     if (operand4)
         m_operands.push_back(std::move(operand4));
 
-    SetConditionVariance(m_operands, m_root_candidate_invariant, m_target_invariant, m_source_invariant);
+    m_root_candidate_invariant = boost::algorithm::all_of(m_operands, [](auto& e){ return !e || e->RootCandidateInvariant(); });
+    m_target_invariant = boost::algorithm::all_of(m_operands, [](auto& e){ return !e || e->TargetInvariant(); });
+    m_source_invariant = boost::algorithm::all_of(m_operands, [](auto& e){ return !e || e->SourceInvariant(); });
 }
 
 bool And::operator==(const Condition& rhs) const {
@@ -9571,15 +9573,6 @@ void And::Eval(const ScriptingContext& parent_context, ObjectSet& matches,
     TraceLogger(conditions) << "And::Eval final matches (" << matches.size() << "): " << ObjList(matches)
                             << " and non_matches (" << non_matches.size() << "): " << ObjList(non_matches);
 }
-
-bool And::RootCandidateInvariant() const
-{ return m_root_candidate_invariant; }
-
-bool And::TargetInvariant() const
-{ return m_target_invariant; }
-
-bool And::SourceInvariant() const
-{ return m_source_invariant; }
 
 std::string And::Description(bool negated/* = false*/) const {
     std::string values_str;

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -9844,15 +9844,6 @@ void Not::Eval(const ScriptingContext& parent_context, ObjectSet& matches, Objec
     }
 }
 
-bool Not::RootCandidateInvariant() const
-{ return m_root_candidate_invariant; }
-
-bool Not::TargetInvariant() const
-{ return m_target_invariant; }
-
-bool Not::SourceInvariant() const
-{ return m_source_invariant; }
-
 std::string Not::Description(bool negated/* = false*/) const
 { return m_operand->Description(!negated); }
 

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -628,8 +628,7 @@ unsigned int Turn::GetCheckSum() const {
 ///////////////////////////////////////////////////////////
 SortedNumberOf::SortedNumberOf(std::unique_ptr<ValueRef::ValueRef<int>>&& number,
                                std::unique_ptr<Condition>&& condition) :
-    m_number(std::move(number)),
-    m_condition(std::move(condition))
+    SortedNumberOf(std::move(number), nullptr, SORT_RANDOM, std::move(condition))
 {}
 
 SortedNumberOf::SortedNumberOf(std::unique_ptr<ValueRef::ValueRef<int>>&& number,

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -7586,7 +7586,11 @@ unsigned int WithinStarlaneJumps::GetCheckSum() const {
 CanAddStarlaneConnection::CanAddStarlaneConnection(std::unique_ptr<Condition>&& condition) :
     Condition(),
     m_condition(std::move(condition))
-{}
+{
+    m_root_candidate_invariant = m_condition->RootCandidateInvariant();
+    m_target_invariant = m_condition->TargetInvariant();
+    m_source_invariant = m_condition->SourceInvariant();
+}
 
 bool CanAddStarlaneConnection::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -7973,15 +7977,6 @@ void CanAddStarlaneConnection::Eval(const ScriptingContext& parent_context,
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
 }
-
-bool CanAddStarlaneConnection::RootCandidateInvariant() const
-{ return m_condition->RootCandidateInvariant(); }
-
-bool CanAddStarlaneConnection::TargetInvariant() const
-{ return m_condition->TargetInvariant(); }
-
-bool CanAddStarlaneConnection::SourceInvariant() const
-{ return m_condition->SourceInvariant(); }
 
 std::string CanAddStarlaneConnection::Description(bool negated/* = false*/) const {
     return str(FlexibleFormat((!negated)

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -9571,30 +9571,30 @@ unsigned int CombatTarget::GetCheckSum() const {
 ///////////////////////////////////////////////////////////
 namespace {
     void SetConditionVariance(std::vector<std::unique_ptr<Condition>>& operands,
-                              Invariance& root_invariant,
-                              Invariance& target_invariant,
-                              Invariance& source_invariant)
+                              bool& root_invariant,
+                              bool& target_invariant,
+                              bool& source_invariant)
     {
-        root_invariant = INVARIANT;
+        root_invariant = true;
         for (auto& operand : operands) {
             if (!operand->RootCandidateInvariant()) {
-                root_invariant = VARIANT;
+                root_invariant = false;
                 break;
             }
         }
 
-        target_invariant = INVARIANT;
+        target_invariant = true;
         for (auto& operand : operands) {
             if (!operand->TargetInvariant()) {
-                target_invariant = VARIANT;
+                target_invariant = false;
                 break;
             }
         }
 
-        source_invariant = INVARIANT;
+        source_invariant = true;
         for (auto& operand : operands) {
             if (!operand->SourceInvariant()) {
-                source_invariant = VARIANT;
+                source_invariant = false;
                 break;
             }
         }
@@ -9708,13 +9708,13 @@ void And::Eval(const ScriptingContext& parent_context, ObjectSet& matches,
 }
 
 bool And::RootCandidateInvariant() const
-{ return m_root_candidate_invariant == INVARIANT; }
+{ return m_root_candidate_invariant; }
 
 bool And::TargetInvariant() const
-{ return m_target_invariant == INVARIANT; }
+{ return m_target_invariant; }
 
 bool And::SourceInvariant() const
-{ return m_source_invariant == INVARIANT; }
+{ return m_source_invariant; }
 
 std::string And::Description(bool negated/* = false*/) const {
     std::string values_str;
@@ -9881,13 +9881,13 @@ void Or::Eval(const ScriptingContext& parent_context, ObjectSet& matches,
 }
 
 bool Or::RootCandidateInvariant() const
-{ return m_root_candidate_invariant == INVARIANT; }
+{ return m_root_candidate_invariant; }
 
 bool Or::TargetInvariant() const
-{ return m_target_invariant == INVARIANT; }
+{ return m_target_invariant; }
 
 bool Or::SourceInvariant() const
-{ return m_source_invariant == INVARIANT; }
+{ return m_source_invariant; }
 
 std::string Or::Description(bool negated/* = false*/) const {
     std::string values_str;
@@ -9952,9 +9952,9 @@ Not::Not(std::unique_ptr<Condition>&& operand) :
     Condition(),
     m_operand(std::move(operand))
 {
-    m_root_candidate_invariant = m_operand->RootCandidateInvariant() ? INVARIANT : VARIANT;
-    m_target_invariant = m_operand->TargetInvariant() ? INVARIANT : VARIANT;
-    m_source_invariant = m_operand->SourceInvariant() ? INVARIANT : VARIANT;
+    m_root_candidate_invariant = m_operand->RootCandidateInvariant();
+    m_target_invariant = m_operand->TargetInvariant();
+    m_source_invariant = m_operand->SourceInvariant();
 }
 
 bool Not::operator==(const Condition& rhs) const {
@@ -9990,13 +9990,13 @@ void Not::Eval(const ScriptingContext& parent_context, ObjectSet& matches, Objec
 }
 
 bool Not::RootCandidateInvariant() const
-{ return m_root_candidate_invariant == INVARIANT; }
+{ return m_root_candidate_invariant; }
 
 bool Not::TargetInvariant() const
-{ return m_target_invariant == INVARIANT; }
+{ return m_target_invariant; }
 
 bool Not::SourceInvariant() const
-{ return m_source_invariant == INVARIANT; }
+{ return m_source_invariant; }
 
 std::string Not::Description(bool negated/* = false*/) const
 { return m_operand->Description(!negated); }
@@ -10156,13 +10156,13 @@ void OrderedAlternativesOf::Eval(const ScriptingContext& parent_context,
 }
 
 bool OrderedAlternativesOf::RootCandidateInvariant() const
-{ return m_root_candidate_invariant == INVARIANT; }
+{ return m_root_candidate_invariant; }
 
 bool OrderedAlternativesOf::TargetInvariant() const
-{ return m_target_invariant == INVARIANT; }
+{ return m_target_invariant; }
 
 bool OrderedAlternativesOf::SourceInvariant() const
-{ return m_source_invariant == INVARIANT; }
+{ return m_source_invariant; }
 
 std::string OrderedAlternativesOf::Description(bool negated/* = false*/) const {
     std::string values_str;

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -5670,7 +5670,11 @@ unsigned int NumberedShipDesign::GetCheckSum() const {
 ProducedByEmpire::ProducedByEmpire(std::unique_ptr<ValueRef::ValueRef<int>>&& empire_id) :
     Condition(),
     m_empire_id(std::move(empire_id))
-{}
+{
+    m_root_candidate_invariant = !m_empire_id || m_empire_id->RootCandidateInvariant();
+    m_target_invariant = !m_empire_id || m_empire_id->TargetInvariant();
+    m_source_invariant = !m_empire_id || m_empire_id->SourceInvariant();
+}
 
 bool ProducedByEmpire::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -5722,15 +5726,6 @@ void ProducedByEmpire::Eval(const ScriptingContext& parent_context,
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
 }
-
-bool ProducedByEmpire::RootCandidateInvariant() const
-{ return !m_empire_id || m_empire_id->RootCandidateInvariant(); }
-
-bool ProducedByEmpire::TargetInvariant() const
-{ return !m_empire_id || m_empire_id->TargetInvariant(); }
-
-bool ProducedByEmpire::SourceInvariant() const
-{ return !m_empire_id || m_empire_id->SourceInvariant(); }
 
 std::string ProducedByEmpire::Description(bool negated/* = false*/) const {
     std::string empire_str;

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -8209,7 +8209,11 @@ unsigned int ExploredByEmpire::GetCheckSum() const {
 ///////////////////////////////////////////////////////////
 Stationary::Stationary() :
     Condition()
-{}
+{
+    m_root_candidate_invariant = true;
+    m_target_invariant = true;
+    m_source_invariant = true;
+}
 
 bool Stationary::operator==(const Condition& rhs) const
 { return Condition::operator==(rhs); }

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -1768,6 +1768,10 @@ unsigned int Capital::GetCheckSum() const {
 ///////////////////////////////////////////////////////////
 // Monster                                               //
 ///////////////////////////////////////////////////////////
+Monster::Monster() :
+    Condition()
+{}
+
 bool Monster::operator==(const Condition& rhs) const
 { return Condition::operator==(rhs); }
 

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -9446,7 +9446,11 @@ CombatTarget::CombatTarget(ContentType content_type,
     Condition(),
     m_name(std::move(name)),
     m_content_type(content_type)
-{}
+{
+    m_root_candidate_invariant = !m_name || m_name->RootCandidateInvariant();
+    m_target_invariant = !m_name|| m_name->TargetInvariant();
+    m_source_invariant = !m_name || m_name->SourceInvariant();
+}
 
 bool CombatTarget::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -9496,15 +9500,6 @@ void CombatTarget::Eval(const ScriptingContext& parent_context,
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
 }
-
-bool CombatTarget::RootCandidateInvariant() const
-{ return (!m_name || m_name->RootCandidateInvariant()); }
-
-bool CombatTarget::TargetInvariant() const
-{ return (!m_name|| m_name->TargetInvariant()); }
-
-bool CombatTarget::SourceInvariant() const
-{ return (!m_name || m_name->SourceInvariant()); }
 
 std::string CombatTarget::Description(bool negated/* = false*/) const {
     std::string name_str;
@@ -9610,7 +9605,11 @@ namespace {
 And::And(std::vector<std::unique_ptr<Condition>>&& operands) :
     Condition(),
     m_operands(std::move(operands))
-{ SetConditionVariance(m_operands, m_root_candidate_invariant, m_target_invariant, m_source_invariant); }
+{
+    m_root_candidate_invariant = boost::algorithm::all_of(m_operands, [](auto& e){ return !e || e->RootCandidateInvariant(); });
+    m_target_invariant = boost::algorithm::all_of(m_operands, [](auto& e){ return !e || e->TargetInvariant(); });
+    m_source_invariant = boost::algorithm::all_of(m_operands, [](auto& e){ return !e || e->SourceInvariant(); });
+}
 
 And::And(std::unique_ptr<Condition>&& operand1, std::unique_ptr<Condition>&& operand2,
          std::unique_ptr<Condition>&& operand3, std::unique_ptr<Condition>&& operand4) :

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -1463,7 +1463,11 @@ unsigned int RootCandidate::GetCheckSum() const {
 ///////////////////////////////////////////////////////////
 Target::Target() :
     Condition()
-{}
+{
+    m_root_candidate_invariant = true;
+    m_target_invariant = false;
+    m_source_invariant = true;
+}
 
 bool Target::operator==(const Condition& rhs) const
 { return Condition::operator==(rhs); }

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -1841,7 +1841,11 @@ unsigned int Monster::GetCheckSum() const {
 ///////////////////////////////////////////////////////////
 Armed::Armed() :
     Condition()
-{}
+{
+    m_root_candidate_invariant = true;
+    m_target_invariant = true;
+    m_source_invariant = true;
+}
 
 bool Armed::operator==(const Condition& rhs) const
 { return Condition::operator==(rhs); }

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -5454,11 +5454,6 @@ PredefinedShipDesign::PredefinedShipDesign(std::unique_ptr<ValueRef::ValueRef<st
     m_name(std::move(name))
 {}
 
-PredefinedShipDesign::PredefinedShipDesign(ValueRef::ValueRef<std::string>* name) :
-    Condition(),
-    m_name(name)
-{}
-
 bool PredefinedShipDesign::operator==(const Condition& rhs) const {
     if (this == &rhs)
         return true;

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -1720,6 +1720,10 @@ unsigned int Homeworld::GetCheckSum() const {
 ///////////////////////////////////////////////////////////
 // Capital                                               //
 ///////////////////////////////////////////////////////////
+Capital::Capital() :
+    Condition()
+{}
+
 bool Capital::operator==(const Condition& rhs) const
 { return Condition::operator==(rhs); }
 

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -628,7 +628,21 @@ SortedNumberOf::SortedNumberOf(std::unique_ptr<ValueRef::ValueRef<int>>&& number
     m_sort_key(std::move(sort_key_ref)),
     m_sorting_method(sorting_method),
     m_condition(std::move(condition))
-{}
+{
+    m_root_candidate_invariant =
+        (!m_number || m_number->RootCandidateInvariant()) &&
+        (!m_sort_key || m_sort_key->RootCandidateInvariant()) &&
+        (!m_condition || m_condition->RootCandidateInvariant());
+    m_target_invariant =
+        (!m_number || m_number->TargetInvariant()) &&
+        (!m_sort_key || m_sort_key->TargetInvariant()) &&
+        (!m_condition || m_condition->TargetInvariant());
+    m_source_invariant =
+        (!m_number || m_number->SourceInvariant()) &&
+        (!m_sort_key || m_sort_key->SourceInvariant()) &&
+        (!m_condition || m_condition->SourceInvariant());
+
+}
 
 bool SortedNumberOf::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -909,21 +923,6 @@ void SortedNumberOf::Eval(const ScriptingContext& parent_context,
         // possibly having transferred some objects into non_matches from matches
     }
 }
-
-bool SortedNumberOf::RootCandidateInvariant() const
-{ return ((!m_number || m_number->SourceInvariant()) &&
-          (!m_sort_key || m_sort_key->SourceInvariant()) &&
-          (!m_condition || m_condition->SourceInvariant())); }
-
-bool SortedNumberOf::TargetInvariant() const
-{ return ((!m_number || m_number->SourceInvariant()) &&
-          (!m_sort_key || m_sort_key->SourceInvariant()) &&
-          (!m_condition || m_condition->SourceInvariant())); }
-
-bool SortedNumberOf::SourceInvariant() const
-{ return ((!m_number || m_number->SourceInvariant()) &&
-          (!m_sort_key || m_sort_key->SourceInvariant()) &&
-          (!m_condition || m_condition->SourceInvariant())); }
 
 std::string SortedNumberOf::Description(bool negated/* = false*/) const {
     std::string number_str = m_number->ConstantExpr() ? m_number->Dump() : m_number->Description();

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -7113,7 +7113,17 @@ WithinDistance::WithinDistance(std::unique_ptr<ValueRef::ValueRef<double>>&& dis
     Condition(),
     m_distance(std::move(distance)),
     m_condition(std::move(condition))
-{}
+{
+    m_root_candidate_invariant =
+        m_distance->RootCandidateInvariant() &&
+        m_condition->RootCandidateInvariant();
+    m_target_invariant =
+        m_distance->TargetInvariant() &&
+        m_condition->TargetInvariant();
+    m_source_invariant =
+        m_distance->SourceInvariant() &&
+        m_condition->SourceInvariant();
+}
 
 bool WithinDistance::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -7179,15 +7189,6 @@ void WithinDistance::Eval(const ScriptingContext& parent_context,
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
 }
-
-bool WithinDistance::RootCandidateInvariant() const
-{ return m_distance->RootCandidateInvariant() && m_condition->RootCandidateInvariant(); }
-
-bool WithinDistance::TargetInvariant() const
-{ return m_distance->TargetInvariant() && m_condition->TargetInvariant(); }
-
-bool WithinDistance::SourceInvariant() const
-{ return m_distance->SourceInvariant() && m_condition->SourceInvariant(); }
 
 std::string WithinDistance::Description(bool negated/* = false*/) const {
     std::string value_str = m_distance->ConstantExpr() ?

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -8260,7 +8260,11 @@ unsigned int Aggressive::GetCheckSum() const {
 FleetSupplyableByEmpire::FleetSupplyableByEmpire(std::unique_ptr<ValueRef::ValueRef<int>>&& empire_id) :
     Condition(),
     m_empire_id(std::move(empire_id))
-{}
+{
+    m_root_candidate_invariant = m_empire_id->RootCandidateInvariant();
+    m_target_invariant = m_empire_id->TargetInvariant();
+    m_source_invariant = m_empire_id->SourceInvariant();
+}
 
 bool FleetSupplyableByEmpire::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -8317,15 +8321,6 @@ void FleetSupplyableByEmpire::Eval(const ScriptingContext& parent_context,
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
 }
-
-bool FleetSupplyableByEmpire::RootCandidateInvariant() const
-{ return m_empire_id->RootCandidateInvariant(); }
-
-bool FleetSupplyableByEmpire::TargetInvariant() const
-{ return m_empire_id->TargetInvariant(); }
-
-bool FleetSupplyableByEmpire::SourceInvariant() const
-{ return m_empire_id->SourceInvariant(); }
 
 std::string FleetSupplyableByEmpire::Description(bool negated/* = false*/) const {
     std::string empire_str;

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -1418,7 +1418,11 @@ unsigned int Source::GetCheckSum() const {
 ///////////////////////////////////////////////////////////
 RootCandidate::RootCandidate() :
     Condition()
-{}
+{
+    m_root_candidate_invariant = false;
+    m_target_invariant = true;
+    m_source_invariant = true;
+}
 
 bool RootCandidate::operator==(const Condition& rhs) const
 { return Condition::operator==(rhs); }

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -8703,6 +8703,10 @@ unsigned int CanColonize::GetCheckSum() const {
 ///////////////////////////////////////////////////////////
 // CanProduceShips                                       //
 ///////////////////////////////////////////////////////////
+CanProduceShips::CanProduceShips() :
+    Condition()
+{}
+
 bool CanProduceShips::operator==(const Condition& rhs) const
 { return Condition::operator==(rhs); }
 

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -3968,7 +3968,11 @@ unsigned int PlanetEnvironment::GetCheckSum() const {
 Species::Species(std::vector<std::unique_ptr<ValueRef::ValueRef<std::string>>>&& names) :
     Condition(),
     m_names(std::move(names))
-{}
+{
+    m_root_candidate_invariant = boost::algorithm::all_of(m_names, [](auto& e){ return e->RootCandidateInvariant(); });
+    m_target_invariant = boost::algorithm::all_of(m_names, [](auto& e){ return e->TargetInvariant(); });
+    m_source_invariant = boost::algorithm::all_of(m_names, [](auto& e){ return e->SourceInvariant(); });
+}
 
 Species::Species() :
     Species(std::vector<std::unique_ptr<ValueRef::ValueRef<std::string>>>{})
@@ -4056,30 +4060,6 @@ void Species::Eval(const ScriptingContext& parent_context,
         // re-evaluate allowed building types range for each candidate object
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
-}
-
-bool Species::RootCandidateInvariant() const {
-    for (auto& name : m_names) {
-        if (!name->RootCandidateInvariant())
-            return false;
-    }
-    return true;
-}
-
-bool Species::TargetInvariant() const {
-    for (auto& name : m_names) {
-        if (!name->TargetInvariant())
-            return false;
-    }
-    return true;
-}
-
-bool Species::SourceInvariant() const {
-    for (auto& name : m_names) {
-        if (!name->SourceInvariant())
-            return false;
-    }
-    return true;
 }
 
 std::string Species::Description(bool negated/* = false*/) const {

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -3573,7 +3573,11 @@ unsigned int PlanetType::GetCheckSum() const {
 PlanetSize::PlanetSize(std::vector<std::unique_ptr<ValueRef::ValueRef< ::PlanetSize>>>&& sizes) :
     Condition(),
     m_sizes(std::move(sizes))
-{}
+{
+    m_root_candidate_invariant = boost::algorithm::all_of(m_sizes, [](auto& e){ return e->RootCandidateInvariant(); });
+    m_target_invariant = boost::algorithm::all_of(m_sizes, [](auto& e){ return e->TargetInvariant(); });
+    m_source_invariant = boost::algorithm::all_of(m_sizes, [](auto& e){ return e->SourceInvariant(); });
+}
 
 bool PlanetSize::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -3650,30 +3654,6 @@ void PlanetSize::Eval(const ScriptingContext& parent_context,
         // re-evaluate contained objects for each candidate object
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
-}
-
-bool PlanetSize::RootCandidateInvariant() const {
-    for (auto& size : m_sizes) {
-        if (!size->RootCandidateInvariant())
-            return false;
-    }
-    return true;
-}
-
-bool PlanetSize::TargetInvariant() const {
-    for (auto& size : m_sizes) {
-        if (!size->TargetInvariant())
-            return false;
-    }
-    return true;
-}
-
-bool PlanetSize::SourceInvariant() const {
-    for (auto& size : m_sizes) {
-        if (!size->SourceInvariant())
-            return false;
-    }
-    return true;
 }
 
 std::string PlanetSize::Description(bool negated/* = false*/) const {

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -5114,7 +5114,12 @@ DesignHasPartClass::DesignHasPartClass(ShipPartClass part_class,
     m_low(std::move(low)),
     m_high(std::move(high)),
     m_class(std::move(part_class))
-{}
+{
+    auto operands = {m_low.get(), m_high.get()};
+    m_root_candidate_invariant = boost::algorithm::all_of(operands, [](auto& e){ return !e || e->RootCandidateInvariant(); });
+    m_target_invariant = boost::algorithm::all_of(operands, [](auto& e){ return !e || e->TargetInvariant(); });
+    m_source_invariant = boost::algorithm::all_of(operands, [](auto& e){ return !e || e->SourceInvariant(); });
+}
 
 bool DesignHasPartClass::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -5191,15 +5196,6 @@ void DesignHasPartClass::Eval(const ScriptingContext& parent_context,
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
 }
-
-bool DesignHasPartClass::RootCandidateInvariant() const
-{ return (!m_low || m_low->RootCandidateInvariant()) && (!m_high || m_high->RootCandidateInvariant()); }
-
-bool DesignHasPartClass::TargetInvariant() const
-{ return (!m_low || m_low->TargetInvariant()) && (!m_high || m_high->TargetInvariant()); }
-
-bool DesignHasPartClass::SourceInvariant() const
-{ return (!m_low || m_low->SourceInvariant()) && (!m_high || m_high->SourceInvariant()); }
 
 std::string DesignHasPartClass::Description(bool negated/* = false*/) const {
     std::string low_str = "1";

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -26,6 +26,7 @@
 #include "../Empire/EmpireManager.h"
 #include "../Empire/Supply.h"
 
+#include <boost/algorithm/cxx11/all_of.hpp>
 #include <boost/algorithm/string/case_conv.hpp>
 #include <boost/bind.hpp>
 #include <boost/graph/adjacency_list.hpp>
@@ -9280,38 +9281,6 @@ unsigned int CombatTarget::GetCheckSum() const {
 ///////////////////////////////////////////////////////////
 // And                                                   //
 ///////////////////////////////////////////////////////////
-namespace {
-    void SetConditionVariance(std::vector<std::unique_ptr<Condition>>& operands,
-                              bool& root_invariant,
-                              bool& target_invariant,
-                              bool& source_invariant)
-    {
-        root_invariant = true;
-        for (auto& operand : operands) {
-            if (!operand->RootCandidateInvariant()) {
-                root_invariant = false;
-                break;
-            }
-        }
-
-        target_invariant = true;
-        for (auto& operand : operands) {
-            if (!operand->TargetInvariant()) {
-                target_invariant = false;
-                break;
-            }
-        }
-
-        source_invariant = true;
-        for (auto& operand : operands) {
-            if (!operand->SourceInvariant()) {
-                source_invariant = false;
-                break;
-            }
-        }
-    }
-}
-
 And::And(std::vector<std::unique_ptr<Condition>>&& operands) :
     Condition(),
     m_operands(std::move(operands))

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -10239,7 +10239,11 @@ Described::Described(std::unique_ptr<Condition>&& condition, const std::string& 
     Condition(),
     m_condition(std::move(condition)),
     m_desc_stringtable_key(desc_stringtable_key)
-{}
+{
+    m_root_candidate_invariant = !m_condition || m_condition->RootCandidateInvariant();
+    m_target_invariant = !m_condition || m_condition->TargetInvariant();
+    m_source_invariant = !m_condition || m_condition->SourceInvariant();
+}
 
 bool Described::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -10274,15 +10278,6 @@ std::string Described::Description(bool negated/* = false*/) const {
         return m_condition->Description(negated);
     return "";
 }
-
-bool Described::RootCandidateInvariant() const
-{ return !m_condition || m_condition->RootCandidateInvariant(); }
-
-bool Described::TargetInvariant() const
-{ return !m_condition || m_condition->TargetInvariant(); }
-
-bool Described::SourceInvariant() const
-{ return !m_condition || m_condition->SourceInvariant(); }
 
 void Described::SetTopLevelContent(const std::string& content_name) {
     if (m_condition)

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -8275,7 +8275,11 @@ Aggressive::Aggressive() :
 Aggressive::Aggressive(bool aggressive) :
     Condition(),
     m_aggressive(aggressive)
-{}
+{
+    m_root_candidate_invariant = true;
+    m_target_invariant = true;
+    m_source_invariant = true;
+}
 
 bool Aggressive::operator==(const Condition& rhs) const
 { return Condition::operator==(rhs); }

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -1042,7 +1042,11 @@ unsigned int SortedNumberOf::GetCheckSum() const {
 ///////////////////////////////////////////////////////////
 All::All() :
     Condition()
-{}
+{
+    m_root_candidate_invariant = true;
+    m_target_invariant = true;
+    m_source_invariant = true;
+}
 
 void All::Eval(const ScriptingContext& parent_context,
                           ObjectSet& matches, ObjectSet& non_matches,

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -1369,7 +1369,11 @@ unsigned int EmpireAffiliation::GetCheckSum() const {
 ///////////////////////////////////////////////////////////
 Source::Source() :
     Condition()
-{}
+{
+    m_root_candidate_invariant = true;
+    m_target_invariant = true;
+    m_source_invariant = false;
+}
 
 bool Source::operator==(const Condition& rhs) const
 { return Condition::operator==(rhs); }

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -7249,7 +7249,11 @@ WithinStarlaneJumps::WithinStarlaneJumps(std::unique_ptr<ValueRef::ValueRef<int>
     Condition(),
     m_jumps(std::move(jumps)),
     m_condition(std::move(condition))
-{}
+{
+    m_root_candidate_invariant = m_jumps->RootCandidateInvariant() && m_condition->RootCandidateInvariant();
+    m_target_invariant = m_jumps->TargetInvariant() && m_condition->TargetInvariant();
+    m_source_invariant = m_jumps->SourceInvariant() && m_condition->SourceInvariant();
+}
 
 bool WithinStarlaneJumps::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -7287,15 +7291,6 @@ void WithinStarlaneJumps::Eval(const ScriptingContext& parent_context,
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
 }
-
-bool WithinStarlaneJumps::RootCandidateInvariant() const
-{ return m_jumps->RootCandidateInvariant() && m_condition->RootCandidateInvariant(); }
-
-bool WithinStarlaneJumps::TargetInvariant() const
-{ return m_jumps->TargetInvariant() && m_condition->TargetInvariant(); }
-
-bool WithinStarlaneJumps::SourceInvariant() const
-{ return m_jumps->SourceInvariant() && m_condition->SourceInvariant(); }
 
 std::string WithinStarlaneJumps::Description(bool negated/* = false*/) const {
     std::string value_str = m_jumps->ConstantExpr() ? std::to_string(m_jumps->Eval()) : m_jumps->Description();

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -6069,7 +6069,18 @@ EmpireMeterValue::EmpireMeterValue(std::unique_ptr<ValueRef::ValueRef<int>>&& em
     m_meter(meter),
     m_low(std::move(low)),
     m_high(std::move(high))
-{}
+{
+    auto operands = {m_low.get(), m_high.get()};
+    m_root_candidate_invariant =
+        (!m_empire_id || m_empire_id->RootCandidateInvariant()) &&
+        boost::algorithm::all_of(operands, [](auto& e){ return !e || e->RootCandidateInvariant(); });
+    m_target_invariant =
+        (!m_empire_id || m_empire_id->TargetInvariant()) &&
+        boost::algorithm::all_of(operands, [](auto& e){ return !e || e->TargetInvariant(); });
+    m_source_invariant =
+        (!m_empire_id || m_empire_id->SourceInvariant()) &&
+        boost::algorithm::all_of(operands, [](auto& e){ return !e || e->SourceInvariant(); });
+}
 
 bool EmpireMeterValue::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -6123,24 +6134,6 @@ void EmpireMeterValue::Eval(const ScriptingContext& parent_context,
         // re-evaluate allowed turn range for each candidate object
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
-}
-
-bool EmpireMeterValue::RootCandidateInvariant() const {
-    return (!m_empire_id || m_empire_id->RootCandidateInvariant()) &&
-           (!m_low || m_low->RootCandidateInvariant()) &&
-           (!m_high || m_high->RootCandidateInvariant());
-}
-
-bool EmpireMeterValue::TargetInvariant() const {
-    return (!m_empire_id || m_empire_id->TargetInvariant()) &&
-           (!m_low || m_low->TargetInvariant()) &&
-           (!m_high || m_high->TargetInvariant());
-}
-
-bool EmpireMeterValue::SourceInvariant() const {
-    return (!m_empire_id || m_empire_id->SourceInvariant()) &&
-           (!m_low || m_low->SourceInvariant()) &&
-           (!m_high || m_high->SourceInvariant());
 }
 
 std::string EmpireMeterValue::Description(bool negated/* = false*/) const {

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -6941,13 +6941,11 @@ OwnerHasShipDesignAvailable::OwnerHasShipDesignAvailable(
 {}
 
 OwnerHasShipDesignAvailable::OwnerHasShipDesignAvailable(int design_id) :
-    Condition(),
-    m_id(std::make_unique<ValueRef::Constant<int>>(design_id))
+    OwnerHasShipDesignAvailable(nullptr, std::move(std::make_unique<ValueRef::Constant<int>>(design_id)))
 {}
 
 OwnerHasShipDesignAvailable::OwnerHasShipDesignAvailable(std::unique_ptr<ValueRef::ValueRef<int>>&& design_id) :
-    Condition(),
-    m_id(std::move(design_id))
+    OwnerHasShipDesignAvailable(nullptr, std::move(design_id))
 {}
 
 bool OwnerHasShipDesignAvailable::operator==(const Condition& rhs) const {

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -1362,6 +1362,10 @@ unsigned int EmpireAffiliation::GetCheckSum() const {
 ///////////////////////////////////////////////////////////
 // Source                                                //
 ///////////////////////////////////////////////////////////
+Source::Source() :
+    Condition()
+{}
+
 bool Source::operator==(const Condition& rhs) const
 { return Condition::operator==(rhs); }
 

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -2229,12 +2229,15 @@ unsigned int Building::GetCheckSum() const {
 // HasSpecial                                            //
 ///////////////////////////////////////////////////////////
 HasSpecial::HasSpecial() :
-    Condition()
+    HasSpecial(nullptr, std::unique_ptr<ValueRef::ValueRef<int>>{}, std::unique_ptr<ValueRef::ValueRef<int>>{})
+{}
+
+HasSpecial::HasSpecial(const std::string& name) :
+    HasSpecial(std::move(std::make_unique<ValueRef::Constant<std::string>>(name)), std::unique_ptr<ValueRef::ValueRef<int>>{}, std::unique_ptr<ValueRef::ValueRef<int>>{})
 {}
 
 HasSpecial::HasSpecial(std::unique_ptr<ValueRef::ValueRef<std::string>>&& name) :
-    Condition(),
-    m_name(std::move(name))
+    HasSpecial(std::move(name), std::unique_ptr<ValueRef::ValueRef<int>>{}, std::unique_ptr<ValueRef::ValueRef<int>>{})
 {}
 
 HasSpecial::HasSpecial(std::unique_ptr<ValueRef::ValueRef<std::string>>&& name,
@@ -2253,11 +2256,6 @@ HasSpecial::HasSpecial(std::unique_ptr<ValueRef::ValueRef<std::string>>&& name,
     m_name(std::move(name)),
     m_capacity_low(std::move(capacity_low)),
     m_capacity_high(std::move(capacity_high))
-{}
-
-HasSpecial::HasSpecial(const std::string& name) :
-    Condition(),
-    m_name(std::make_unique<ValueRef::Constant<std::string>>(name))
 {}
 
 bool HasSpecial::operator==(const Condition& rhs) const {

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -1128,13 +1128,11 @@ EmpireAffiliation::EmpireAffiliation(std::unique_ptr<ValueRef::ValueRef<int>>&& 
 {}
 
 EmpireAffiliation::EmpireAffiliation(std::unique_ptr<ValueRef::ValueRef<int>>&& empire_id) :
-    m_empire_id(std::move(empire_id)),
-    m_affiliation(AFFIL_SELF)
+    EmpireAffiliation(std::move(empire_id), AFFIL_SELF)
 {}
 
 EmpireAffiliation::EmpireAffiliation(EmpireAffiliationType affiliation) :
-    m_empire_id(nullptr),
-    m_affiliation(affiliation)
+    EmpireAffiliation(nullptr, affiliation)
 {}
 
 bool EmpireAffiliation::operator==(const Condition& rhs) const {

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -6273,10 +6273,7 @@ unsigned int ShipPartMeterValue::GetCheckSum() const {
 EmpireMeterValue::EmpireMeterValue(const std::string& meter,
                                    std::unique_ptr<ValueRef::ValueRef<double>>&& low,
                                    std::unique_ptr<ValueRef::ValueRef<double>>&& high) :
-    Condition(),
-    m_meter(meter),
-    m_low(std::move(low)),
-    m_high(std::move(high))
+    EmpireMeterValue(nullptr, meter, std::move(low), std::move(high))
 {}
 
 EmpireMeterValue::EmpireMeterValue(std::unique_ptr<ValueRef::ValueRef<int>>&& empire_id,

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -2050,7 +2050,11 @@ unsigned int Type::GetCheckSum() const {
 Building::Building(std::vector<std::unique_ptr<ValueRef::ValueRef<std::string>>>&& names) :
     Condition(),
     m_names(std::move(names))
-{}
+{
+    m_root_candidate_invariant = boost::algorithm::all_of(m_names, [](auto& e){ return e->RootCandidateInvariant(); });
+    m_target_invariant = boost::algorithm::all_of(m_names, [](auto& e){ return e->TargetInvariant(); });
+    m_source_invariant = boost::algorithm::all_of(m_names, [](auto& e){ return e->SourceInvariant(); });
+}
 
 bool Building::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -2122,30 +2126,6 @@ void Building::Eval(const ScriptingContext& parent_context,
         // re-evaluate allowed building types range for each candidate object
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
-}
-
-bool Building::RootCandidateInvariant() const {
-    for (auto& name : m_names) {
-        if (!name->RootCandidateInvariant())
-            return false;
-    }
-    return true;
-}
-
-bool Building::TargetInvariant() const {
-    for (auto& name : m_names) {
-        if (!name->TargetInvariant())
-            return false;
-    }
-    return true;
-}
-
-bool Building::SourceInvariant() const {
-    for (auto& name : m_names) {
-        if (!name->SourceInvariant())
-            return false;
-    }
-    return true;
 }
 
 std::string Building::Description(bool negated/* = false*/) const {

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -4494,7 +4494,11 @@ unsigned int Enqueued::GetCheckSum() const {
 FocusType::FocusType(std::vector<std::unique_ptr<ValueRef::ValueRef<std::string>>>&& names) :
     Condition(),
     m_names(std::move(names))
-{}
+{
+    m_root_candidate_invariant = boost::algorithm::all_of(m_names, [](auto& e){ return e->RootCandidateInvariant(); });
+    m_target_invariant = boost::algorithm::all_of(m_names, [](auto& e){ return e->TargetInvariant(); });
+    m_source_invariant = boost::algorithm::all_of(m_names, [](auto& e){ return e->SourceInvariant(); });
+}
 
 bool FocusType::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -4570,30 +4574,6 @@ void FocusType::Eval(const ScriptingContext& parent_context,
         // re-evaluate allowed building types range for each candidate object
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
-}
-
-bool FocusType::RootCandidateInvariant() const {
-    for (auto& name : m_names) {
-        if (!name->RootCandidateInvariant())
-            return false;
-    }
-    return true;
-}
-
-bool FocusType::TargetInvariant() const {
-    for (auto& name : m_names) {
-        if (!name->TargetInvariant())
-            return false;
-    }
-    return true;
-}
-
-bool FocusType::SourceInvariant() const {
-    for (auto& name : m_names) {
-        if (!name->SourceInvariant())
-            return false;
-    }
-    return true;
 }
 
 std::string FocusType::Description(bool negated/* = false*/) const {

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -4951,7 +4951,11 @@ unsigned int StarType::GetCheckSum() const {
 DesignHasHull::DesignHasHull(std::unique_ptr<ValueRef::ValueRef<std::string>>&& name) :
     Condition(),
     m_name(std::move(name))
-{}
+{
+    m_root_candidate_invariant = !m_name || m_name->RootCandidateInvariant();
+    m_target_invariant = !m_name || m_name->TargetInvariant();
+    m_source_invariant = !m_name || m_name->SourceInvariant();
+}
 
 bool DesignHasHull::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -5010,15 +5014,6 @@ void DesignHasHull::Eval(const ScriptingContext& parent_context,
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
 }
-
-bool DesignHasHull::RootCandidateInvariant() const
-{ return (!m_name || m_name->RootCandidateInvariant()); }
-
-bool DesignHasHull::TargetInvariant() const
-{ return (!m_name || m_name->TargetInvariant()); }
-
-bool DesignHasHull::SourceInvariant() const
-{ return (!m_name || m_name->SourceInvariant()); }
 
 std::string DesignHasHull::Description(bool negated/* = false*/) const {
     std::string name_str;

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -7091,13 +7091,11 @@ OwnerHasShipPartAvailable::OwnerHasShipPartAvailable(
 {}
 
 OwnerHasShipPartAvailable::OwnerHasShipPartAvailable(const std::string& name) :
-    Condition(),
-    m_name(std::make_unique<ValueRef::Constant<std::string>>(name))
+    OwnerHasShipPartAvailable(nullptr, std::move(std::make_unique<ValueRef::Constant<std::string>>(name)))
 {}
 
 OwnerHasShipPartAvailable::OwnerHasShipPartAvailable(std::unique_ptr<ValueRef::ValueRef<std::string>>&& name) :
-    Condition(),
-    m_name(std::move(name))
+    OwnerHasShipPartAvailable(nullptr, std::move(name))
 {}
 
 bool OwnerHasShipPartAvailable::operator==(const Condition& rhs) const {

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -8726,7 +8726,11 @@ unsigned int CanProduceShips::GetCheckSum() const {
 OrderedBombarded::OrderedBombarded(std::unique_ptr<Condition>&& by_object_condition) :
     Condition(),
     m_by_object_condition(std::move(by_object_condition))
-{}
+{
+    m_root_candidate_invariant = m_by_object_condition->RootCandidateInvariant();
+    m_target_invariant = m_by_object_condition->TargetInvariant();
+    m_source_invariant = m_by_object_condition->SourceInvariant();
+}
 
 bool OrderedBombarded::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -8792,15 +8796,6 @@ void OrderedBombarded::Eval(const ScriptingContext& parent_context,
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
 }
-
-bool OrderedBombarded::RootCandidateInvariant() const
-{ return m_by_object_condition->RootCandidateInvariant(); }
-
-bool OrderedBombarded::TargetInvariant() const
-{ return m_by_object_condition->TargetInvariant(); }
-
-bool OrderedBombarded::SourceInvariant() const
-{ return m_by_object_condition->SourceInvariant(); }
 
 std::string OrderedBombarded::Description(bool negated/* = false*/) const {
     std::string by_str;

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -1883,7 +1883,11 @@ unsigned int Armed::GetCheckSum() const {
 Type::Type(std::unique_ptr<ValueRef::ValueRef<UniverseObjectType>>&& type) :
     Condition(),
     m_type(std::move(type))
-{}
+{
+    m_root_candidate_invariant = m_type->RootCandidateInvariant();
+    m_target_invariant = m_type->TargetInvariant();
+    m_source_invariant = m_type->SourceInvariant();
+}
 
 Type::Type(UniverseObjectType type) :
     Type(std::move(std::make_unique<ValueRef::Constant<UniverseObjectType>>(type)))
@@ -1953,15 +1957,6 @@ void Type::Eval(const ScriptingContext& parent_context,
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
 }
-
-bool Type::RootCandidateInvariant() const
-{ return m_type->RootCandidateInvariant(); }
-
-bool Type::TargetInvariant() const
-{ return m_type->TargetInvariant(); }
-
-bool Type::SourceInvariant() const
-{ return m_type->SourceInvariant(); }
 
 std::string Type::Description(bool negated/* = false*/) const {
     std::string value_str = m_type->ConstantExpr() ?

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -1739,7 +1739,11 @@ unsigned int Homeworld::GetCheckSum() const {
 ///////////////////////////////////////////////////////////
 Capital::Capital() :
     Condition()
-{}
+{
+    m_root_candidate_invariant = true;
+    m_target_invariant = true;
+    m_source_invariant = true;
+}
 
 bool Capital::operator==(const Condition& rhs) const
 { return Condition::operator==(rhs); }

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -1133,7 +1133,11 @@ EmpireAffiliation::EmpireAffiliation(std::unique_ptr<ValueRef::ValueRef<int>>&& 
                                      EmpireAffiliationType affiliation) :
     m_empire_id(std::move(empire_id)),
     m_affiliation(affiliation)
-{}
+{
+    m_root_candidate_invariant = !m_empire_id || m_empire_id->RootCandidateInvariant();
+    m_target_invariant = !m_empire_id || m_empire_id->TargetInvariant();
+    m_source_invariant = !m_empire_id || m_empire_id->SourceInvariant();
+}
 
 EmpireAffiliation::EmpireAffiliation(std::unique_ptr<ValueRef::ValueRef<int>>&& empire_id) :
     EmpireAffiliation(std::move(empire_id), AFFIL_SELF)
@@ -1255,15 +1259,6 @@ void EmpireAffiliation::Eval(const ScriptingContext& parent_context,
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
 }
-
-bool EmpireAffiliation::RootCandidateInvariant() const
-{ return m_empire_id ? m_empire_id->RootCandidateInvariant() : true; }
-
-bool EmpireAffiliation::TargetInvariant() const
-{ return m_empire_id ? m_empire_id->TargetInvariant() : true; }
-
-bool EmpireAffiliation::SourceInvariant() const
-{ return m_empire_id ? m_empire_id->SourceInvariant() : true; }
 
 std::string EmpireAffiliation::Description(bool negated/* = false*/) const {
     std::string empire_str;

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -5567,7 +5567,11 @@ unsigned int PredefinedShipDesign::GetCheckSum() const {
 NumberedShipDesign::NumberedShipDesign(std::unique_ptr<ValueRef::ValueRef<int>>&& design_id) :
     Condition(),
     m_design_id(std::move(design_id))
-{}
+{
+    m_root_candidate_invariant = !m_design_id || m_design_id->RootCandidateInvariant();
+    m_target_invariant = !m_design_id || m_design_id->TargetInvariant();
+    m_source_invariant = !m_design_id || m_design_id->SourceInvariant();
+}
 
 bool NumberedShipDesign::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -5621,15 +5625,6 @@ void NumberedShipDesign::Eval(const ScriptingContext& parent_context,
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
 }
-
-bool NumberedShipDesign::RootCandidateInvariant() const
-{ return !m_design_id || m_design_id->RootCandidateInvariant(); }
-
-bool NumberedShipDesign::TargetInvariant() const
-{ return !m_design_id || m_design_id->TargetInvariant(); }
-
-bool NumberedShipDesign::SourceInvariant() const
-{ return !m_design_id || m_design_id->SourceInvariant(); }
 
 std::string NumberedShipDesign::Description(bool negated/* = false*/) const {
     std::string id_str = m_design_id->ConstantExpr() ?

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -477,7 +477,12 @@ Turn::Turn(std::unique_ptr<ValueRef::ValueRef<int>>&& low,
            std::unique_ptr<ValueRef::ValueRef<int>>&& high) :
     m_low(std::move(low)),
     m_high(std::move(high))
-{}
+{
+    auto operands = {m_low.get(), m_high.get()};
+    m_root_candidate_invariant = boost::algorithm::all_of(operands, [](auto& e){ return !e || e->RootCandidateInvariant(); });
+    m_target_invariant = boost::algorithm::all_of(operands, [](auto& e){ return !e || e->TargetInvariant(); });
+    m_source_invariant = boost::algorithm::all_of(operands, [](auto& e){ return !e || e->SourceInvariant(); });
+}
 
 bool Turn::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -529,15 +534,6 @@ void Turn::Eval(const ScriptingContext& parent_context,
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
 }
-
-bool Turn::RootCandidateInvariant() const
-{ return (!m_low || m_low->RootCandidateInvariant()) && (!m_high || m_high->RootCandidateInvariant()); }
-
-bool Turn::TargetInvariant() const
-{ return (!m_low || m_low->TargetInvariant()) && (!m_high || m_high->TargetInvariant()); }
-
-bool Turn::SourceInvariant() const
-{ return (!m_low || m_low->SourceInvariant()) && (!m_high || m_high->SourceInvariant()); }
 
 std::string Turn::Description(bool negated/* = false*/) const {
     std::string low_str;

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -8643,7 +8643,11 @@ unsigned int ResourceSupplyConnectedByEmpire::GetCheckSum() const {
 ///////////////////////////////////////////////////////////
 CanColonize::CanColonize() :
     Condition()
-{}
+{
+    m_root_candidate_invariant = true;
+    m_target_invariant = true;
+    m_source_invariant = true;
+}
 
 bool CanColonize::operator==(const Condition& rhs) const
 { return Condition::operator==(rhs); }

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -7641,6 +7641,11 @@ unsigned int WithinStarlaneJumps::GetCheckSum() const {
 ///////////////////////////////////////////////////////////
 // CanAddStarlaneConnection                              //
 ///////////////////////////////////////////////////////////
+CanAddStarlaneConnection::CanAddStarlaneConnection(std::unique_ptr<Condition>&& condition) :
+    Condition(),
+    m_condition(std::move(condition))
+{}
+
 bool CanAddStarlaneConnection::operator==(const Condition& rhs) const {
     if (this == &rhs)
         return true;

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -8200,6 +8200,10 @@ unsigned int ExploredByEmpire::GetCheckSum() const {
 ///////////////////////////////////////////////////////////
 // Stationary                                            //
 ///////////////////////////////////////////////////////////
+Stationary::Stationary() :
+    Condition()
+{}
+
 bool Stationary::operator==(const Condition& rhs) const
 { return Condition::operator==(rhs); }
 

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -3728,7 +3728,17 @@ PlanetEnvironment::PlanetEnvironment(std::vector<std::unique_ptr<ValueRef::Value
     Condition(),
     m_environments(std::move(environments)),
     m_species_name(std::move(species_name_ref))
-{}
+{
+    m_root_candidate_invariant =
+        (!m_species_name || m_species_name->RootCandidateInvariant()) &&
+        boost::algorithm::all_of(m_environments, [](auto& e){ return !e || e->RootCandidateInvariant(); });
+    m_target_invariant =
+        (!m_species_name || m_species_name->TargetInvariant()) &&
+        boost::algorithm::all_of(m_environments, [](auto& e){ return !e || e->TargetInvariant(); });
+    m_source_invariant =
+        (!m_species_name || m_species_name->SourceInvariant()) &&
+        boost::algorithm::all_of(m_environments, [](auto& e){ return !e || e->SourceInvariant(); });
+}
 
 bool PlanetEnvironment::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -3815,36 +3825,6 @@ void PlanetEnvironment::Eval(const ScriptingContext& parent_context,
         // re-evaluate contained objects for each candidate object
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
-}
-
-bool PlanetEnvironment::RootCandidateInvariant() const {
-    if (m_species_name && !m_species_name->RootCandidateInvariant())
-        return false;
-    for (auto& environment : m_environments) {
-        if (!environment->RootCandidateInvariant())
-            return false;
-    }
-    return true;
-}
-
-bool PlanetEnvironment::TargetInvariant() const {
-    if (m_species_name && !m_species_name->TargetInvariant())
-        return false;
-    for (auto& environment : m_environments) {
-        if (!environment->TargetInvariant())
-            return false;
-    }
-    return true;
-}
-
-bool PlanetEnvironment::SourceInvariant() const {
-    if (m_species_name && !m_species_name->SourceInvariant())
-        return false;
-    for (auto& environment : m_environments) {
-        if (!environment->SourceInvariant())
-            return false;
-    }
-    return true;
 }
 
 std::string PlanetEnvironment::Description(bool negated/* = false*/) const {

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -5894,7 +5894,18 @@ ShipPartMeterValue::ShipPartMeterValue(std::unique_ptr<ValueRef::ValueRef<std::s
     m_meter(meter),
     m_low(std::move(low)),
     m_high(std::move(high))
-{}
+{
+    auto operands = {m_low.get(), m_high.get()};
+    m_root_candidate_invariant =
+        (!m_part_name || m_part_name->RootCandidateInvariant()) &&
+        boost::algorithm::all_of(operands, [](auto& e){ return !e || e->RootCandidateInvariant(); });
+    m_target_invariant =
+        (!m_part_name || m_part_name->TargetInvariant()) &&
+        boost::algorithm::all_of(operands, [](auto& e){ return !e || e->TargetInvariant(); });
+    m_source_invariant =
+        (!m_part_name || m_part_name->SourceInvariant()) &&
+        boost::algorithm::all_of(operands, [](auto& e){ return !e || e->SourceInvariant(); });
+}
 
 bool ShipPartMeterValue::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -5962,24 +5973,6 @@ void ShipPartMeterValue::Eval(const ScriptingContext& parent_context,
         // re-evaluate allowed turn range for each candidate object
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
-}
-
-bool ShipPartMeterValue::RootCandidateInvariant() const {
-    return ((!m_part_name || m_part_name->RootCandidateInvariant()) &&
-            (!m_low || m_low->RootCandidateInvariant()) &&
-            (!m_high || m_high->RootCandidateInvariant()));
-}
-
-bool ShipPartMeterValue::TargetInvariant() const {
-    return ((!m_part_name || m_part_name->TargetInvariant()) &&
-            (!m_low || m_low->TargetInvariant()) &&
-            (!m_high || m_high->TargetInvariant()));
-}
-
-bool ShipPartMeterValue::SourceInvariant() const {
-    return ((!m_part_name || m_part_name->SourceInvariant()) &&
-            (!m_low || m_low->SourceInvariant()) &&
-            (!m_high || m_high->SourceInvariant()));
 }
 
 std::string ShipPartMeterValue::Description(bool negated/* = false*/) const {

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -2503,7 +2503,11 @@ HasTag::HasTag(const std::string& name) :
 HasTag::HasTag(std::unique_ptr<ValueRef::ValueRef<std::string>>&& name) :
     Condition(),
     m_name(std::move(name))
-{}
+{
+    m_root_candidate_invariant = !m_name || m_name->RootCandidateInvariant();
+    m_target_invariant = !m_name || m_name->TargetInvariant();
+    m_source_invariant = !m_name || m_name->SourceInvariant();
+}
 
 bool HasTag::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -2564,15 +2568,6 @@ void HasTag::Eval(const ScriptingContext& parent_context,
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
 }
-
-bool HasTag::RootCandidateInvariant() const
-{ return !m_name || m_name->RootCandidateInvariant(); }
-
-bool HasTag::TargetInvariant() const
-{ return !m_name || m_name->TargetInvariant(); }
-
-bool HasTag::SourceInvariant() const
-{ return !m_name || m_name->SourceInvariant(); }
 
 std::string HasTag::Description(bool negated/* = false*/) const {
     std::string name_str;

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -6640,8 +6640,7 @@ OwnerHasTech::OwnerHasTech(std::unique_ptr<ValueRef::ValueRef<int>>&& empire_id,
 {}
 
 OwnerHasTech::OwnerHasTech(std::unique_ptr<ValueRef::ValueRef<std::string>>&& name) :
-    Condition(),
-    m_name(std::move(name))
+    OwnerHasTech(nullptr, std::move(name))
 {}
 
 bool OwnerHasTech::operator==(const Condition& rhs) const {

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -3168,7 +3168,11 @@ unsigned int ContainedBy::GetCheckSum() const {
 InSystem::InSystem(std::unique_ptr<ValueRef::ValueRef<int>>&& system_id) :
     Condition(),
     m_system_id(std::move(system_id))
-{}
+{
+    m_root_candidate_invariant = !m_system_id || m_system_id->RootCandidateInvariant();
+    m_target_invariant = !m_system_id || m_system_id->TargetInvariant();
+    m_source_invariant = !m_system_id || m_system_id->SourceInvariant();
+}
 
 bool InSystem::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -3218,15 +3222,6 @@ void InSystem::Eval(const ScriptingContext& parent_context,
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
 }
-
-bool InSystem::RootCandidateInvariant() const
-{ return !m_system_id || m_system_id->RootCandidateInvariant(); }
-
-bool InSystem::TargetInvariant() const
-{ return !m_system_id || m_system_id->TargetInvariant(); }
-
-bool InSystem::SourceInvariant() const
-{ return !m_system_id || m_system_id->SourceInvariant(); }
 
 std::string InSystem::Description(bool negated/* = false*/) const {
     std::string system_str;

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -5779,7 +5779,11 @@ unsigned int ProducedByEmpire::GetCheckSum() const {
 Chance::Chance(std::unique_ptr<ValueRef::ValueRef<double>>&& chance) :
     Condition(),
     m_chance(std::move(chance))
-{}
+{
+    m_root_candidate_invariant = !m_chance || m_chance->RootCandidateInvariant();
+    m_target_invariant = !m_chance || m_chance->TargetInvariant();
+    m_source_invariant = !m_chance || m_chance->SourceInvariant();
+}
 
 bool Chance::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -5824,15 +5828,6 @@ void Chance::Eval(const ScriptingContext& parent_context,
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
 }
-
-bool Chance::RootCandidateInvariant() const
-{ return !m_chance || m_chance->RootCandidateInvariant(); }
-
-bool Chance::TargetInvariant() const
-{ return !m_chance || m_chance->TargetInvariant(); }
-
-bool Chance::SourceInvariant() const
-{ return !m_chance || m_chance->SourceInvariant(); }
 
 std::string Chance::Description(bool negated/* = false*/) const {
     if (m_chance->ConstantExpr()) {

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -3408,7 +3408,11 @@ unsigned int ObjectID::GetCheckSum() const {
 PlanetType::PlanetType(std::vector<std::unique_ptr<ValueRef::ValueRef< ::PlanetType>>>&& types) :
     Condition(),
     m_types(std::move(types))
-{}
+{
+    m_root_candidate_invariant = boost::algorithm::all_of(m_types, [](auto& e){ return e->RootCandidateInvariant(); });
+    m_target_invariant = boost::algorithm::all_of(m_types, [](auto& e){ return e->TargetInvariant(); });
+    m_source_invariant = boost::algorithm::all_of(m_types, [](auto& e){ return e->SourceInvariant(); });
+}
 
 bool PlanetType::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -3482,30 +3486,6 @@ void PlanetType::Eval(const ScriptingContext& parent_context,
         // re-evaluate contained objects for each candidate object
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
-}
-
-bool PlanetType::RootCandidateInvariant() const {
-    for (auto& type : m_types) {
-        if (!type->RootCandidateInvariant())
-            return false;
-    }
-    return true;
-}
-
-bool PlanetType::TargetInvariant() const {
-    for (auto& type : m_types) {
-        if (!type->TargetInvariant())
-            return false;
-    }
-    return true;
-}
-
-bool PlanetType::SourceInvariant() const {
-    for (auto& type : m_types) {
-        if (!type->SourceInvariant())
-            return false;
-    }
-    return true;
 }
 
 std::string PlanetType::Description(bool negated/* = false*/) const {

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -4054,8 +4054,7 @@ Species::Species(std::vector<std::unique_ptr<ValueRef::ValueRef<std::string>>>&&
 {}
 
 Species::Species() :
-    Condition(),
-    m_names()
+    Species(std::vector<std::unique_ptr<ValueRef::ValueRef<std::string>>>{})
 {}
 
 bool Species::operator==(const Condition& rhs) const {

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -7206,7 +7206,11 @@ unsigned int OwnerHasShipPartAvailable::GetCheckSum() const {
 VisibleToEmpire::VisibleToEmpire(std::unique_ptr<ValueRef::ValueRef<int>>&& empire_id) :
     Condition(),
     m_empire_id(std::move(empire_id))
-{}
+{
+    m_root_candidate_invariant = !m_empire_id || m_empire_id->RootCandidateInvariant();
+    m_target_invariant = !m_empire_id || m_empire_id->TargetInvariant();
+    m_source_invariant = !m_empire_id || m_empire_id->SourceInvariant();
+}
 
 bool VisibleToEmpire::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -7272,15 +7276,6 @@ void VisibleToEmpire::Eval(const ScriptingContext& parent_context,
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
 }
-
-bool VisibleToEmpire::RootCandidateInvariant() const
-{ return !m_empire_id || m_empire_id->RootCandidateInvariant(); }
-
-bool VisibleToEmpire::TargetInvariant() const
-{ return !m_empire_id || m_empire_id->TargetInvariant(); }
-
-bool VisibleToEmpire::SourceInvariant() const
-{ return !m_empire_id || m_empire_id->SourceInvariant(); }
 
 std::string VisibleToEmpire::Description(bool negated/* = false*/) const {
     std::string empire_str;

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -2229,7 +2229,18 @@ HasSpecial::HasSpecial(std::unique_ptr<ValueRef::ValueRef<std::string>>&& name,
     m_name(std::move(name)),
     m_since_turn_low(std::move(since_turn_low)),
     m_since_turn_high(std::move(since_turn_high))
-{}
+{
+    auto operands = {m_since_turn_low.get(), m_since_turn_high.get()};
+    m_root_candidate_invariant =
+        (!m_name || m_name->RootCandidateInvariant()) &&
+        boost::algorithm::all_of(operands, [](auto& e){ return !e || e->RootCandidateInvariant(); });
+    m_target_invariant =
+        (!m_name || m_name->TargetInvariant()) &&
+        boost::algorithm::all_of(operands, [](auto& e){ return !e || e->TargetInvariant(); });
+    m_source_invariant =
+        (!m_name || m_name->SourceInvariant()) &&
+        boost::algorithm::all_of(operands, [](auto& e){ return !e || e->SourceInvariant(); });
+}
 
 HasSpecial::HasSpecial(std::unique_ptr<ValueRef::ValueRef<std::string>>&& name,
                        std::unique_ptr<ValueRef::ValueRef<double>>&& capacity_low,
@@ -2238,7 +2249,18 @@ HasSpecial::HasSpecial(std::unique_ptr<ValueRef::ValueRef<std::string>>&& name,
     m_name(std::move(name)),
     m_capacity_low(std::move(capacity_low)),
     m_capacity_high(std::move(capacity_high))
-{}
+{
+    auto operands = {m_capacity_low.get(), m_capacity_high.get()};
+    m_root_candidate_invariant =
+        (!m_name || m_name->RootCandidateInvariant()) &&
+        boost::algorithm::all_of(operands, [](auto& e){ return !e || e->RootCandidateInvariant(); });
+    m_target_invariant =
+        (!m_name || m_name->TargetInvariant()) &&
+        boost::algorithm::all_of(operands, [](auto& e){ return !e || e->TargetInvariant(); });
+    m_source_invariant =
+        (!m_name || m_name->SourceInvariant()) &&
+        boost::algorithm::all_of(operands, [](auto& e){ return !e || e->SourceInvariant(); });
+}
 
 bool HasSpecial::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -2317,27 +2339,6 @@ void HasSpecial::Eval(const ScriptingContext& parent_context,
         Condition::Eval(parent_context, matches, non_matches, search_domain);
     }
 }
-
-bool HasSpecial::RootCandidateInvariant() const
-{ return ((!m_name || m_name->RootCandidateInvariant()) &&
-          (!m_capacity_low || m_capacity_low->RootCandidateInvariant()) &&
-          (!m_capacity_high || m_capacity_high->RootCandidateInvariant()) &&
-          (!m_since_turn_low || m_since_turn_low->RootCandidateInvariant()) &&
-          (!m_since_turn_high || m_since_turn_high->RootCandidateInvariant())); }
-
-bool HasSpecial::TargetInvariant() const
-{ return ((!m_name || m_name->TargetInvariant()) &&
-          (!m_capacity_low || m_capacity_low->TargetInvariant()) &&
-          (!m_capacity_high || m_capacity_high->TargetInvariant()) &&
-          (!m_since_turn_low || m_since_turn_low->TargetInvariant()) &&
-          (!m_since_turn_high || m_since_turn_high->TargetInvariant())); }
-
-bool HasSpecial::SourceInvariant() const
-{ return ((!m_name || m_name->SourceInvariant()) &&
-          (!m_capacity_low || m_capacity_low->SourceInvariant()) &&
-          (!m_capacity_high || m_capacity_high->SourceInvariant()) &&
-          (!m_since_turn_low || m_since_turn_low->SourceInvariant()) &&
-          (!m_since_turn_high || m_since_turn_high->SourceInvariant())); }
 
 std::string HasSpecial::Description(bool negated/* = false*/) const {
     std::string name_str;

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -9883,7 +9883,9 @@ OrderedAlternativesOf::OrderedAlternativesOf(
     Condition(),
     m_operands(std::move(operands))
 {
-    SetConditionVariance(m_operands, m_root_candidate_invariant, m_target_invariant, m_source_invariant);
+    m_root_candidate_invariant = boost::algorithm::all_of(m_operands, [](auto& e){ return !e || e->RootCandidateInvariant(); });
+    m_target_invariant = boost::algorithm::all_of(m_operands, [](auto& e){ return !e || e->TargetInvariant(); });
+    m_source_invariant = boost::algorithm::all_of(m_operands, [](auto& e){ return !e || e->SourceInvariant(); });
 }
 
 bool OrderedAlternativesOf::operator==(const Condition& rhs) const {
@@ -10000,15 +10002,6 @@ void OrderedAlternativesOf::Eval(const ScriptingContext& parent_context,
         FCMoveContent(matches, non_matches);
     }
 }
-
-bool OrderedAlternativesOf::RootCandidateInvariant() const
-{ return m_root_candidate_invariant; }
-
-bool OrderedAlternativesOf::TargetInvariant() const
-{ return m_target_invariant; }
-
-bool OrderedAlternativesOf::SourceInvariant() const
-{ return m_source_invariant; }
 
 std::string OrderedAlternativesOf::Description(bool negated/* = false*/) const {
     std::string values_str;

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -1859,8 +1859,7 @@ Type::Type(std::unique_ptr<ValueRef::ValueRef<UniverseObjectType>>&& type) :
 {}
 
 Type::Type(UniverseObjectType type) :
-    Condition(),
-    m_type(std::make_unique<ValueRef::Constant<UniverseObjectType>>(type))
+    Type(std::move(std::make_unique<ValueRef::Constant<UniverseObjectType>>(type)))
 {}
 
 bool Type::operator==(const Condition& rhs) const {

--- a/universe/Conditions.cpp
+++ b/universe/Conditions.cpp
@@ -2949,7 +2949,11 @@ unsigned int Contains::GetCheckSum() const {
 ContainedBy::ContainedBy(std::unique_ptr<Condition>&& condition) :
     Condition(),
     m_condition(std::move(condition))
-{}
+{
+    m_root_candidate_invariant = m_condition->RootCandidateInvariant();
+    m_target_invariant = m_condition->TargetInvariant();
+    m_source_invariant = m_condition->SourceInvariant();
+}
 
 bool ContainedBy::operator==(const Condition& rhs) const {
     if (this == &rhs)
@@ -3096,15 +3100,6 @@ void ContainedBy::Eval(const ScriptingContext& parent_context,
         EvalImpl(matches, non_matches, search_domain, ContainedBySimpleMatch(subcondition_matches));
     }
 }
-
-bool ContainedBy::RootCandidateInvariant() const
-{ return m_condition->RootCandidateInvariant(); }
-
-bool ContainedBy::TargetInvariant() const
-{ return m_condition->TargetInvariant(); }
-
-bool ContainedBy::SourceInvariant() const
-{ return m_condition->SourceInvariant(); }
 
 std::string ContainedBy::Description(bool negated/* = false*/) const {
     return str(FlexibleFormat((!negated)

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -1741,9 +1741,6 @@ struct FO_COMMON_API Described final : public Condition {
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override
     { return m_condition ? m_condition->Dump(ntabs) : ""; }

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -819,9 +819,6 @@ struct FO_COMMON_API DesignHasHull final : public Condition {
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
     void GetDefaultInitialCandidateObjects(const ScriptingContext& parent_context,
                                            ObjectSet& condition_non_targets) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -1141,9 +1141,6 @@ struct FO_COMMON_API OwnerHasShipPartAvailable final : public Condition {
     bool            operator==(const Condition& rhs) const override;
     void            Eval(const ScriptingContext& parent_context, ObjectSet& matches,
                          ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
-    bool            RootCandidateInvariant() const override;
-    bool            TargetInvariant() const override;
-    bool            SourceInvariant() const override;
     std::string     Description(bool negated = false) const override;
     std::string     Dump(unsigned short ntabs = 0) const override;
     void            SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -557,9 +557,6 @@ struct FO_COMMON_API InSystem final : public Condition {
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
     void GetDefaultInitialCandidateObjects(const ScriptingContext& parent_context,
                                            ObjectSet& condition_non_targets) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -307,12 +307,6 @@ struct FO_COMMON_API Capital final : public Condition {
     bool operator==(const Condition& rhs) const override;
     void GetDefaultInitialCandidateObjects(const ScriptingContext& parent_context,
                                            ObjectSet& condition_non_targets) const override;
-    bool RootCandidateInvariant() const override
-    { return true; }
-    bool TargetInvariant() const override
-    { return true; }
-    bool SourceInvariant() const override
-    { return true; }
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -1512,9 +1512,6 @@ struct FO_COMMON_API ValueTest final : public Condition {
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -1663,9 +1663,6 @@ struct FO_COMMON_API Not final : public Condition {
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -533,9 +533,6 @@ struct FO_COMMON_API ContainedBy final : public Condition {
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
     void GetDefaultInitialCandidateObjects(const ScriptingContext& parent_context,
                                            ObjectSet& condition_non_targets) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -327,12 +327,6 @@ struct FO_COMMON_API Monster final : public Condition {
     bool operator==(const Condition& rhs) const override;
     void GetDefaultInitialCandidateObjects(const ScriptingContext& parent_context,
                                            ObjectSet& condition_non_targets) const override;
-    bool RootCandidateInvariant() const override
-    { return true; }
-    bool TargetInvariant() const override
-    { return true; }
-    bool SourceInvariant() const override
-    { return true; }
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -774,9 +774,6 @@ struct FO_COMMON_API StarType final : public Condition {
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -265,8 +265,7 @@ private:
 
 /** Matches the target of an effect being executed. */
 struct FO_COMMON_API Target final : public Condition {
-    Target() : Condition() {}
-
+    Target();
     bool operator==(const Condition& rhs) const override;
     void GetDefaultInitialCandidateObjects(const ScriptingContext& parent_context,
                                            ObjectSet& condition_non_targets) const override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -1360,9 +1360,6 @@ struct FO_COMMON_API ResourceSupplyConnectedByEmpire final : public Condition {
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -1089,9 +1089,6 @@ struct FO_COMMON_API OwnerHasBuildingTypeAvailable final : public Condition {
     bool            operator==(const Condition& rhs) const override;
     void            Eval(const ScriptingContext& parent_context, ObjectSet& matches,
                          ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
-    bool            RootCandidateInvariant() const override;
-    bool            TargetInvariant() const override;
-    bool            SourceInvariant() const override;
     std::string     Description(bool negated = false) const override;
     std::string     Dump(unsigned short ntabs = 0) const override;
     void            SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -1115,9 +1115,6 @@ struct FO_COMMON_API OwnerHasShipDesignAvailable final : public Condition {
     bool            operator==(const Condition& rhs) const override;
     void            Eval(const ScriptingContext& parent_context, ObjectSet& matches,
                          ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
-    bool            RootCandidateInvariant() const override;
-    bool            TargetInvariant() const override;
-    bool            SourceInvariant() const override;
     std::string     Description(bool negated = false) const override;
     std::string     Dump(unsigned short ntabs = 0) const override;
     void            SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -234,12 +234,6 @@ struct FO_COMMON_API RootCandidate final : public Condition {
     bool operator==(const Condition& rhs) const override;
     void GetDefaultInitialCandidateObjects(const ScriptingContext& parent_context,
                                            ObjectSet& condition_non_targets) const override;
-    bool RootCandidateInvariant() const override
-    { return false; }
-    bool TargetInvariant() const override
-    { return true; }
-    bool SourceInvariant() const override
-    { return true; }
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -508,9 +508,6 @@ struct FO_COMMON_API Contains final : public Condition {
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
     void GetDefaultInitialCandidateObjects(const ScriptingContext& parent_context,
                                            ObjectSet& condition_non_targets) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -366,9 +366,6 @@ struct FO_COMMON_API Type final : public Condition {
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
     void GetDefaultInitialCandidateObjects(const ScriptingContext& parent_context,
                                            ObjectSet& condition_non_targets) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -1500,9 +1500,6 @@ struct FO_COMMON_API OrderedBombarded final : public Condition {
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     virtual void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -206,9 +206,6 @@ struct FO_COMMON_API EmpireAffiliation final : public Condition {
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -1507,12 +1507,6 @@ struct FO_COMMON_API CanColonize final : public Condition {
     explicit CanColonize();
 
     bool operator==(const Condition& rhs) const override;
-    bool RootCandidateInvariant() const override
-    { return true; }
-    bool TargetInvariant() const override
-    { return true; }
-    bool SourceInvariant() const override
-    { return true; }
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -716,9 +716,6 @@ struct FO_COMMON_API Enqueued final : public Condition {
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
     void GetDefaultInitialCandidateObjects(const ScriptingContext& parent_context,
                                            ObjectSet& condition_non_targets) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -952,9 +952,6 @@ struct FO_COMMON_API MeterValue final : public Condition {
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -1410,9 +1410,6 @@ struct FO_COMMON_API FleetSupplyableByEmpire final : public Condition {
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -347,8 +347,7 @@ private:
 
 /** Matches space monsters. */
 struct FO_COMMON_API Monster final : public Condition {
-    Monster() : Condition() {}
-
+    Monster();
     bool operator==(const Condition& rhs) const override;
     void GetDefaultInitialCandidateObjects(const ScriptingContext& parent_context,
                                            ObjectSet& condition_non_targets) const override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -280,9 +280,6 @@ struct FO_COMMON_API Homeworld final : public Condition {
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
     void GetDefaultInitialCandidateObjects(const ScriptingContext& parent_context,
                                            ObjectSet& condition_non_targets) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -461,9 +461,6 @@ struct FO_COMMON_API CreatedOnTurn final : public Condition {
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -345,12 +345,6 @@ private:
 struct FO_COMMON_API Armed final : public Condition {
     Armed();
     bool operator==(const Condition& rhs) const override;
-    bool RootCandidateInvariant() const override
-    { return true; }
-    bool TargetInvariant() const override
-    { return true; }
-    bool SourceInvariant() const override
-    { return true; }
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -419,9 +419,6 @@ struct FO_COMMON_API HasSpecial final : public Condition {
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -1851,11 +1851,7 @@ private:
 /** Matches whatever its subcondition matches, but has a customized description
   * string that is returned by Description() by looking up in the stringtable. */
 struct FO_COMMON_API Described final : public Condition {
-    Described(std::unique_ptr<Condition>&& condition, const std::string& desc_stringtable_key) :
-        Condition(),
-            m_condition(std::move(condition)),
-        m_desc_stringtable_key(desc_stringtable_key)
-    {}
+    Described(std::unique_ptr<Condition>&& condition, const std::string& desc_stringtable_key);
 
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -1578,7 +1578,7 @@ private:
 
 /** Matches objects whose species has the ability to produce ships. */
 struct FO_COMMON_API CanProduceShips final : public Condition {
-    CanProduceShips() : Condition() {}
+    CanProduceShips();
 
     bool operator==(const Condition& rhs) const override;
     bool RootCandidateInvariant() const override

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -107,9 +107,6 @@ struct FO_COMMON_API Turn final : public Condition {
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -1498,9 +1498,6 @@ public:
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -1609,9 +1609,6 @@ public:
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -1686,9 +1686,6 @@ struct FO_COMMON_API OrderedAlternativesOf final : public Condition {
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -165,7 +165,7 @@ struct FO_COMMON_API SortedNumberOf final : public Condition {
 private:
     std::unique_ptr<ValueRef::ValueRef<int>> m_number;
     std::unique_ptr<ValueRef::ValueRef<double>> m_sort_key;
-    SortingMethod m_sorting_method = SORT_RANDOM;
+    SortingMethod m_sorting_method;
     std::unique_ptr<Condition> m_condition;
 
     friend class boost::serialization::access;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -1660,7 +1660,11 @@ private:
 // template implementations
 template <typename Archive>
 void Condition::serialize(Archive& ar, const unsigned int version)
-{}
+{
+    ar  & BOOST_SERIALIZATION_NVP(m_root_candidate_invariant)
+        & BOOST_SERIALIZATION_NVP(m_target_invariant)
+        & BOOST_SERIALIZATION_NVP(m_source_invariant);
+}
 
 template <typename Archive>
 void Number::serialize(Archive& ar, const unsigned int version)

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -1391,10 +1391,7 @@ private:
   * any other lanes, pass too close to another system, or be too close in angle
   * to an existing lane. */
 struct FO_COMMON_API CanAddStarlaneConnection : Condition {
-    explicit CanAddStarlaneConnection(std::unique_ptr<Condition>&& condition) :
-        Condition(),
-        m_condition(std::move(condition))
-    {}
+    explicit CanAddStarlaneConnection(std::unique_ptr<Condition>&& condition);
 
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -601,9 +601,6 @@ struct FO_COMMON_API PlanetType final : public Condition {
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
     void GetDefaultInitialCandidateObjects(const ScriptingContext& parent_context,
                                            ObjectSet& condition_non_targets) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -547,11 +547,7 @@ private:
   * \a condition.  Container objects are Systems, Planets (which contain
   * Buildings), and Fleets (which contain Ships). */
 struct FO_COMMON_API Contains final : public Condition {
-    Contains(std::unique_ptr<Condition>&& condition) :
-        Condition(),
-        m_condition(std::move(condition))
-    {}
-
+    Contains(std::unique_ptr<Condition>&& condition);
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -962,7 +962,6 @@ private:
   * \a name */
 struct FO_COMMON_API PredefinedShipDesign final : public Condition {
     explicit PredefinedShipDesign(std::unique_ptr<ValueRef::ValueRef<std::string>>&& name);
-    explicit PredefinedShipDesign(ValueRef::ValueRef<std::string>* name);
 
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -1008,9 +1008,6 @@ struct FO_COMMON_API EmpireMeterValue final : public Condition {
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -819,9 +819,6 @@ struct FO_COMMON_API DesignHasPart final : public Condition {
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
     void GetDefaultInitialCandidateObjects(const ScriptingContext& parent_context,
                                            ObjectSet& condition_non_targets) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -972,9 +972,6 @@ struct FO_COMMON_API Chance final : public Condition {
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -1063,9 +1063,6 @@ struct FO_COMMON_API OwnerHasTech final : public Condition {
     bool            operator==(const Condition& rhs) const override;
     void            Eval(const ScriptingContext& parent_context, ObjectSet& matches,
                          ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
-    bool            RootCandidateInvariant() const override;
-    bool            TargetInvariant() const override;
-    bool            SourceInvariant() const override;
     std::string     Description(bool negated = false) const override;
     std::string     Dump(unsigned short ntabs = 0) const override;
     void            SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -1190,9 +1190,6 @@ struct FO_COMMON_API WithinDistance final : public Condition {
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -579,11 +579,7 @@ private:
   * \a condition.  Container objects are Systems, Planets (which contain
   * Buildings), and Fleets (which contain Ships). */
 struct FO_COMMON_API ContainedBy final : public Condition {
-    ContainedBy(std::unique_ptr<Condition>&& condition) :
-        Condition(),
-        m_condition(std::move(condition))
-    {}
-
+    ContainedBy(std::unique_ptr<Condition>&& condition);
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -148,9 +148,6 @@ struct FO_COMMON_API SortedNumberOf final : public Condition {
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
     void GetDefaultInitialCandidateObjects(const ScriptingContext& parent_context,
                                            ObjectSet& condition_non_targets) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -456,9 +456,6 @@ struct FO_COMMON_API HasTag final : public Condition {
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -1443,7 +1443,7 @@ private:
 /** Matches objects that are moving. ... What does that mean?  Departing this
   * turn, or were located somewhere else last turn...? */
 struct FO_COMMON_API Stationary final : public Condition {
-    explicit Stationary() : Condition() {}
+    explicit Stationary();
 
     bool operator==(const Condition& rhs) const override;
     bool RootCandidateInvariant() const override

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -639,9 +639,6 @@ struct FO_COMMON_API PlanetEnvironment final : public Condition {
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
     void GetDefaultInitialCandidateObjects(const ScriptingContext& parent_context,
                                            ObjectSet& condition_non_targets) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -630,9 +630,6 @@ struct FO_COMMON_API PlanetSize final : public Condition {
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
     void GetDefaultInitialCandidateObjects(const ScriptingContext& parent_context,
                                            ObjectSet& condition_non_targets) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -1233,9 +1233,6 @@ struct FO_COMMON_API VisibleToEmpire final : public Condition {
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -236,8 +236,7 @@ private:
   * whole compound condition, rather than an object just being matched in a
   * subcondition in order to evaluate the outer condition. */
 struct FO_COMMON_API RootCandidate final : public Condition {
-    RootCandidate() : Condition() {}
-
+    RootCandidate();
     bool operator==(const Condition& rhs) const override;
     void GetDefaultInitialCandidateObjects(const ScriptingContext& parent_context,
                                            ObjectSet& condition_non_targets) const override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -185,12 +185,6 @@ struct FO_COMMON_API None final : public Condition {
     { /* efficient rejection of everything. */ }
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
-    bool RootCandidateInvariant() const override
-    { return true; }
-    bool TargetInvariant() const override
-    { return true; }
-    bool SourceInvariant() const override
-    { return true; }
     void SetTopLevelContent(const std::string& content_name) override
     {}
     unsigned int GetCheckSum() const override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -373,8 +373,7 @@ private:
 
 /** Matches armed ships and monsters. */
 struct FO_COMMON_API Armed final : public Condition {
-    Armed() : Condition() {}
-
+    Armed();
     bool operator==(const Condition& rhs) const override;
     bool RootCandidateInvariant() const override
     { return true; }

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -1618,9 +1618,6 @@ struct FO_COMMON_API And final : public Condition {
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
     void GetDefaultInitialCandidateObjects(const ScriptingContext& parent_context,
                                            ObjectSet& condition_non_targets) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -1320,9 +1320,6 @@ struct FO_COMMON_API CanAddStarlaneConnection : Condition {
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -388,9 +388,6 @@ struct FO_COMMON_API Building final : public Condition {
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
     void GetDefaultInitialCandidateObjects(const ScriptingContext& parent_context,
                                            ObjectSet& condition_non_targets) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -1429,12 +1429,6 @@ struct FO_COMMON_API Aggressive final : public Condition {
     explicit Aggressive(bool aggressive);
 
     bool operator==(const Condition& rhs) const override;
-    bool RootCandidateInvariant() const override
-    { return true; }
-    bool TargetInvariant() const override
-    { return true; }
-    bool SourceInvariant() const override
-    { return true; }
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -906,9 +906,6 @@ struct FO_COMMON_API PredefinedShipDesign final : public Condition {
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -1468,14 +1468,8 @@ private:
 
 /** Matches objects that are aggressive fleets or are in aggressive fleets. */
 struct FO_COMMON_API Aggressive final : public Condition {
-    explicit Aggressive() :
-        Condition(),
-        m_aggressive(true)
-    {}
-    explicit Aggressive(bool aggressive) :
-        Condition(),
-        m_aggressive(aggressive)
-    {}
+    explicit Aggressive();
+    explicit Aggressive(bool aggressive);
 
     bool operator==(const Condition& rhs) const override;
     bool RootCandidateInvariant() const override

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -685,9 +685,6 @@ struct FO_COMMON_API Species final : public Condition {
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
     void GetDefaultInitialCandidateObjects(const ScriptingContext& parent_context,
                                            ObjectSet& condition_non_targets) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -848,9 +848,6 @@ struct FO_COMMON_API DesignHasPartClass final : public Condition {
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
     void GetDefaultInitialCandidateObjects(const ScriptingContext& parent_context,
                                            ObjectSet& condition_non_targets) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -257,12 +257,6 @@ struct FO_COMMON_API Target final : public Condition {
     bool operator==(const Condition& rhs) const override;
     void GetDefaultInitialCandidateObjects(const ScriptingContext& parent_context,
                                            ObjectSet& condition_non_targets) const override;
-    bool RootCandidateInvariant() const override
-    { return true; }
-    bool TargetInvariant() const override
-    { return false; }
-    bool SourceInvariant() const override
-    { return true; }
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -749,9 +749,6 @@ struct FO_COMMON_API FocusType final : public Condition {
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void GetDefaultInitialCandidateObjects(const ScriptingContext& parent_context,

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -928,9 +928,6 @@ struct FO_COMMON_API NumberedShipDesign final : public Condition {
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -1526,12 +1526,6 @@ struct FO_COMMON_API CanProduceShips final : public Condition {
     CanProduceShips();
 
     bool operator==(const Condition& rhs) const override;
-    bool RootCandidateInvariant() const override
-    { return true; }
-    bool TargetInvariant() const override
-    { return true; }
-    bool SourceInvariant() const override
-    { return true; }
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -1217,9 +1217,6 @@ struct FO_COMMON_API WithinStarlaneJumps final : public Condition {
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -1553,7 +1553,7 @@ private:
 
 /** Matches objects whose species has the ability to found new colonies. */
 struct FO_COMMON_API CanColonize final : public Condition {
-    explicit CanColonize() : Condition() {}
+    explicit CanColonize();
 
     bool operator==(const Condition& rhs) const override;
     bool RootCandidateInvariant() const override

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -1643,9 +1643,6 @@ struct FO_COMMON_API Or final : public Condition {
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     virtual void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -1409,12 +1409,6 @@ struct FO_COMMON_API Stationary final : public Condition {
     explicit Stationary();
 
     bool operator==(const Condition& rhs) const override;
-    bool RootCandidateInvariant() const override
-    { return true; }
-    bool TargetInvariant() const override
-    { return true; }
-    bool SourceInvariant() const override
-    { return true; }
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -176,8 +176,7 @@ private:
 /** Matches no objects. Currently only has an experimental use for efficient immediate rejection as the top-line condition.
  *  Essentially the entire point of this Condition is to provide the specialized GetDefaultInitialCandidateObjects() */
 struct FO_COMMON_API None final : public Condition {
-    None() : Condition() {}
-
+    None();
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -950,9 +950,6 @@ struct FO_COMMON_API ProducedByEmpire final : public Condition {
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -980,9 +980,6 @@ struct FO_COMMON_API ShipPartMeterValue final : public Condition {
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -1343,9 +1343,6 @@ struct FO_COMMON_API ExploredByEmpire final : public Condition {
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -1036,9 +1036,6 @@ struct FO_COMMON_API EmpireStockpileValue final : public Condition {
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -82,9 +82,6 @@ struct FO_COMMON_API Number final : public Condition {
     bool operator==(const Condition& rhs) const override;
     void Eval(const ScriptingContext& parent_context, ObjectSet& matches,
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -581,9 +581,6 @@ struct FO_COMMON_API ObjectID final : public Condition {
               ObjectSet& non_matches, SearchDomain search_domain = NON_MATCHES) const override;
     void GetDefaultInitialCandidateObjects(const ScriptingContext& parent_context,
                                            ObjectSet& condition_non_targets) const override;
-    bool RootCandidateInvariant() const override;
-    bool TargetInvariant() const override;
-    bool SourceInvariant() const override;
     std::string Description(bool negated = false) const override;
     std::string Dump(unsigned short ntabs = 0) const override;
     void SetTopLevelContent(const std::string& content_name) override;

--- a/universe/Conditions.h
+++ b/universe/Conditions.h
@@ -321,8 +321,7 @@ private:
 
 /** Matches planets that are an empire's capital. */
 struct FO_COMMON_API Capital final : public Condition {
-    Capital() : Condition() {}
-
+    Capital();
     bool operator==(const Condition& rhs) const override;
     void GetDefaultInitialCandidateObjects(const ScriptingContext& parent_context,
                                            ObjectSet& condition_non_targets) const override;


### PR DESCRIPTION
This PR:

- Replaces the `Condition::Invariance` enum with a boolean flag. `Condition`s are now variant unless configured otherwise.
- Moves all `Condition::Condition` subclass constructors into the `universe/Conditions.cpp` implementation file.
- Removes unused `Condition::Condition` subclass constructors.
- Uses delegated constructors on `Condition::Condition` subclasses, where an appropriate target constructor already existed.
- Lets the `Condition::Condition` invariance getters return the corresponding attribute instead of being overwritten by subclasses.
- Lets the `Condition::Condition` subclass constructors assign their invariances instead of quering it on evaluation time.
- Prevents the `Condition::Condition` invariance getters from being overwritten by subclasses.