### PR TITLE
ValueRef::ComplexVariable separate property dispatch

### DIFF
--- a/universe/ValueRefs.cpp
+++ b/universe/ValueRefs.cpp
@@ -2015,6 +2015,29 @@ double ComplexVariable<double>::Eval(const ScriptingContext& context) const
 {
     const std::string& variable_name = m_property_name.back();
 
+    std::function<float (const ShipHull&)> hull_property{nullptr};
+
+    if (variable_name == "HullFuel")
+        hull_property = &ShipHull::Fuel;
+    else if (variable_name == "HullStealth")
+        hull_property = &ShipHull::Stealth;
+    else if (variable_name == "HullStructure")
+        hull_property = &ShipHull::Structure;
+    else if (variable_name == "HullSpeed")
+        hull_property = &ShipHull::Speed;
+
+    if (hull_property) {
+        std::string ship_hull_name;
+        if (m_string_ref1)
+            ship_hull_name = m_string_ref1->Eval(context);
+
+        const ShipHull* ship_hull = GetShipHull(ship_hull_name);
+        if (!ship_hull)
+            return 0.0f;
+
+        return hull_property(*ship_hull);
+    }
+
     // empire properties indexed by integers
     if (variable_name == "PropagatedSystemSupplyRange" ||
         variable_name == "SystemSupplyRange" ||
@@ -2067,54 +2090,6 @@ double ComplexVariable<double>::Eval(const ScriptingContext& context) const
         } catch (...) {
         }
         return 0.0;
-    }
-    else if (variable_name == "HullFuel") {
-        std::string ship_hull_name;
-        if (m_string_ref1)
-            ship_hull_name = m_string_ref1->Eval(context);
-
-        const ShipHull* ship_hull = GetShipHull(ship_hull_name);
-        if (!ship_hull)
-            return 0.0;
-
-        return ship_hull->Fuel();
-
-    }
-    else if (variable_name == "HullStealth") {
-        std::string ship_hull_name;
-        if (m_string_ref1)
-            ship_hull_name = m_string_ref1->Eval(context);
-
-        const ShipHull* ship_hull = GetShipHull(ship_hull_name);
-        if (!ship_hull)
-            return 0.0;
-
-        return ship_hull->Stealth();
-
-    }
-    else if (variable_name == "HullStructure") {
-        std::string ship_hull_name;
-        if (m_string_ref1)
-            ship_hull_name = m_string_ref1->Eval(context);
-
-        const ShipHull* ship_hull = GetShipHull(ship_hull_name);
-        if (!ship_hull)
-            return 0.0f;
-
-        return ship_hull->Structure();
-
-    }
-    else if (variable_name == "HullSpeed") {
-        std::string ship_hull_name;
-        if (m_string_ref1)
-            ship_hull_name = m_string_ref1->Eval(context);
-
-        const ShipHull* ship_hull = GetShipHull(ship_hull_name);
-        if (!ship_hull)
-            return 0.0;
-
-        return ship_hull->Speed();
-
     }
     else if (variable_name == "PartCapacity") {
         std::string ship_part_name;

--- a/universe/ValueRefs.cpp
+++ b/universe/ValueRefs.cpp
@@ -2308,8 +2308,42 @@ std::string ComplexVariable<std::string>::Eval(const ScriptingContext& context) 
 {
     const std::string& variable_name = m_property_name.back();
 
+    std::function<std::string (const Empire&)> empire_property{nullptr};
+    auto null_property = [](const Empire&) -> std::string { return ""; };
+
     // unindexed empire properties
-    if (variable_name == "LowestCostEnqueuedTech") {
+    if (variable_name == "LowestCostEnqueuedTech")
+        empire_property = &Empire::LeastExpensiveEnqueuedTech;
+    else if (variable_name == "HighestCostEnqueuedTech")
+        empire_property = &Empire::MostExpensiveEnqueuedTech;
+    else if (variable_name == "TopPriorityEnqueuedTech")
+        empire_property = &Empire::TopPriorityEnqueuedTech;
+    else if (variable_name == "MostSpentEnqueuedTech")
+        empire_property = &Empire::MostRPSpentEnqueuedTech;
+    else if (variable_name == "LowestCostResearchableTech")
+        empire_property = &Empire::LeastExpensiveResearchableTech;
+    else if (variable_name == "HighestCostResearchableTech")
+        empire_property = &Empire::MostExpensiveResearchableTech;
+    else if (variable_name == "TopPriorityResearchableTech")
+        empire_property = &Empire::TopPriorityResearchableTech;
+    else if (variable_name == "MostSpentResearchableTech")
+        empire_property = &Empire::MostExpensiveResearchableTech;
+    else if (variable_name == "MostSpentTransferrableTech")
+        empire_property = null_property;
+    else if (variable_name == "RandomTransferrableTech")
+        empire_property = null_property;
+    else if (variable_name == "MostPopulousSpecies")
+        empire_property = null_property;
+    else if (variable_name == "MostHappySpecies")
+        empire_property = null_property;
+    else if (variable_name == "LeastHappySpecies")
+        empire_property = null_property;
+    else if (variable_name == "RandomColonizableSpecies")
+        empire_property = null_property;
+    else if (variable_name == "RandomControlledSpecies")
+        empire_property = null_property;
+
+    if (empire_property) {
         int empire_id = ALL_EMPIRES;
         if (m_int_ref1) {
             empire_id = m_int_ref1->Eval(context);
@@ -2319,45 +2353,11 @@ std::string ComplexVariable<std::string>::Eval(const ScriptingContext& context) 
         const Empire* empire = GetEmpire(empire_id);
         if (!empire)
             return "";
-        return empire->LeastExpensiveEnqueuedTech();
 
-    } else if (variable_name == "HighestCostEnqueuedTech") {
-        int empire_id = ALL_EMPIRES;
-        if (m_int_ref1) {
-            empire_id = m_int_ref1->Eval(context);
-            if (empire_id == ALL_EMPIRES)
-                return "";
-        }
-        const Empire* empire = GetEmpire(empire_id);
-        if (!empire)
-            return "";
-        return empire->MostExpensiveEnqueuedTech();
+        return empire_property(*empire);
+    }
 
-    } else if (variable_name == "TopPriorityEnqueuedTech") {
-        int empire_id = ALL_EMPIRES;
-        if (m_int_ref1) {
-            empire_id = m_int_ref1->Eval(context);
-            if (empire_id == ALL_EMPIRES)
-                return "";
-        }
-        const Empire* empire = GetEmpire(empire_id);
-        if (!empire)
-            return "";
-        return empire->TopPriorityEnqueuedTech();
-
-    } else if (variable_name == "MostSpentEnqueuedTech") {
-        int empire_id = ALL_EMPIRES;
-        if (m_int_ref1) {
-            empire_id = m_int_ref1->Eval(context);
-            if (empire_id == ALL_EMPIRES)
-                return "";
-        }
-        const Empire* empire = GetEmpire(empire_id);
-        if (!empire)
-            return "";
-        return empire->MostRPSpentEnqueuedTech();
-
-    } else if (variable_name == "RandomEnqueuedTech") {
+    if (variable_name == "RandomEnqueuedTech") {
         int empire_id = ALL_EMPIRES;
         if (m_int_ref1) {
             empire_id = m_int_ref1->Eval(context);
@@ -2374,53 +2374,6 @@ std::string ComplexVariable<std::string>::Eval(const ScriptingContext& context) 
             return "";
         std::size_t idx = RandSmallInt(0, static_cast<int>(all_enqueued_techs.size()) - 1);
         return *std::next(all_enqueued_techs.begin(), idx);
-    } else if (variable_name == "LowestCostResearchableTech") {
-        int empire_id = ALL_EMPIRES;
-        if (m_int_ref1) {
-            empire_id = m_int_ref1->Eval(context);
-            if (empire_id == ALL_EMPIRES)
-                return "";
-        }
-        const Empire* empire = GetEmpire(empire_id);
-        if (!empire)
-            return "";
-        return empire->LeastExpensiveResearchableTech();
-
-    } else if (variable_name == "HighestCostResearchableTech") {
-        int empire_id = ALL_EMPIRES;
-        if (m_int_ref1) {
-            empire_id = m_int_ref1->Eval(context);
-            if (empire_id == ALL_EMPIRES)
-                return "";
-        }
-        const Empire* empire = GetEmpire(empire_id);
-        if (!empire)
-            return "";
-        return empire->MostExpensiveResearchableTech();
-
-    } else if (variable_name == "TopPriorityResearchableTech") {
-        int empire_id = ALL_EMPIRES;
-        if (m_int_ref1) {
-            empire_id = m_int_ref1->Eval(context);
-            if (empire_id == ALL_EMPIRES)
-                return "";
-        }
-        const Empire* empire = GetEmpire(empire_id);
-        if (!empire)
-            return "";
-        return empire->TopPriorityResearchableTech();
-
-    } else if (variable_name == "MostSpentResearchableTech") {
-        int empire_id = ALL_EMPIRES;
-        if (m_int_ref1) {
-            empire_id = m_int_ref1->Eval(context);
-            if (empire_id == ALL_EMPIRES)
-                return "";
-        }
-        const Empire* empire = GetEmpire(empire_id);
-        if (!empire)
-            return "";
-        return empire->MostExpensiveResearchableTech();
 
     } else if (variable_name == "RandomResearchableTech") {
         int empire_id = ALL_EMPIRES;
@@ -2546,83 +2499,6 @@ std::string ComplexVariable<std::string>::Eval(const ScriptingContext& context) 
             }
         }
         return retval;
-
-    } else if (variable_name == "MostSpentTransferrableTech") {
-        int empire_id = ALL_EMPIRES;
-        if (m_int_ref1) {
-            empire_id = m_int_ref1->Eval(context);
-            if (empire_id == ALL_EMPIRES)
-                return "";
-        }
-        const Empire* empire = GetEmpire(empire_id);
-        if (!empire)
-            return "";
-
-    } else if (variable_name == "RandomTransferrableTech") {
-        int empire_id = ALL_EMPIRES;
-        if (m_int_ref1) {
-            empire_id = m_int_ref1->Eval(context);
-            if (empire_id == ALL_EMPIRES)
-                return "";
-        }
-        const Empire* empire = GetEmpire(empire_id);
-        if (!empire)
-            return "";
-
-    } else if (variable_name == "MostPopulousSpecies") {
-        int empire_id = ALL_EMPIRES;
-        if (m_int_ref1) {
-            empire_id = m_int_ref1->Eval(context);
-            if (empire_id == ALL_EMPIRES)
-                return "";
-        }
-        const Empire* empire = GetEmpire(empire_id);
-        if (!empire)
-            return "";
-
-    } else if (variable_name == "MostHappySpecies") {
-        int empire_id = ALL_EMPIRES;
-        if (m_int_ref1) {
-            empire_id = m_int_ref1->Eval(context);
-            if (empire_id == ALL_EMPIRES)
-                return "";
-        }
-        const Empire* empire = GetEmpire(empire_id);
-        if (!empire)
-            return "";
-
-    } else if (variable_name == "LeastHappySpecies") {
-        int empire_id = ALL_EMPIRES;
-        if (m_int_ref1) {
-            empire_id = m_int_ref1->Eval(context);
-            if (empire_id == ALL_EMPIRES)
-                return "";
-        }
-        const Empire* empire = GetEmpire(empire_id);
-        if (!empire)
-            return "";
-
-    } else if (variable_name == "RandomColonizableSpecies") {
-        int empire_id = ALL_EMPIRES;
-        if (m_int_ref1) {
-            empire_id = m_int_ref1->Eval(context);
-            if (empire_id == ALL_EMPIRES)
-                return "";
-        }
-        const Empire* empire = GetEmpire(empire_id);
-        if (!empire)
-            return "";
-
-    } else if (variable_name == "RandomControlledSpecies") {
-        int empire_id = ALL_EMPIRES;
-        if (m_int_ref1) {
-            empire_id = m_int_ref1->Eval(context);
-            if (empire_id == ALL_EMPIRES)
-                return "";
-        }
-        const Empire* empire = GetEmpire(empire_id);
-        if (!empire)
-            return "";
     }
 
     // non-empire properties


### PR DESCRIPTION
This PR separates the dispatching of object properties into binding (converting the property string into a callable binding and the actual dispatching of the call with the current evaluated object.

This is a preparation to move the binding step out of the ValueRef::ComplexVariable::Eval member function to avoid the string comparision, which happens currently during every ValueRef::ComplexVariable evaluation and to overall simplify the ValueRef implementations.

I have separated this from PR #2927 as this PR also contains some more complex unfolding of helper functions.  I would suggest to check every commit by itself or even create separate PRs for each commit.

Contains a not yet merged PR, therefor blocked-by: #2927 #2926 