### PR TITLE
Groom TechTreeLayout

### DIFF
--- a/UI/TechTreeLayout.cpp
+++ b/UI/TechTreeLayout.cpp
@@ -75,24 +75,6 @@ unsigned int TechTreeLayout::Column::Size() {
     return 0;
 }
 
-TechTreeLayout::Node* TechTreeLayout::Column::Seek(Node* m, int direction) {
-    if (!m || direction == 0)
-        return nullptr;
-
-    Node* n = nullptr;
-    int i = m->row;
-
-    // find next node adjacent to node m in requested direction
-    while (!n || n == m) {
-        if (i < 0 || i >= static_cast<int>(column.size()))
-            return nullptr;
-
-        n = column[i];
-        i += direction;
-    }
-    return n;
-}
-
 
 ////////////////
 // class Edge //
@@ -429,7 +411,19 @@ bool TechTreeLayout::Node::Wobble(Column& column) {
 
     // find neighbour
     int direction = (dist > 0) ? 1 : -1;
-    Node* n = column.Seek(this, direction);
+    Node* n = nullptr;
+    int i = row;
+
+    // find next node adjacent to node this in requested direction
+    while (!n || n == this) {
+        if (i < 0 || i >= static_cast<int>(column.column.size())) {
+            n = nullptr;
+            break;
+        }
+
+        n = column.column[i];
+        i += direction;
+    }
 
     // try to switch node with neighbour node
     if (n) {

--- a/UI/TechTreeLayout.cpp
+++ b/UI/TechTreeLayout.cpp
@@ -67,14 +67,6 @@ bool TechTreeLayout::Column::Place(int index, TechTreeLayout::Node* node) {
     return false;
 }
 
-unsigned int TechTreeLayout::Column::Size() {
-    for (unsigned int i = column.size(); i --> 0; ) {
-        if (column[i])
-            return i;
-    }
-    return 0;
-}
-
 
 ////////////////
 // class Edge //
@@ -205,8 +197,14 @@ void TechTreeLayout::DoLayout(double column_width, double row_height, double x_m
     //4.d. count used rows and columns
     unsigned int column_count = row_index.size();
     unsigned int row_count = 0;
-    for (int i = row_index.size(); i-->0;)
-        row_count = std::max(row_count, row_index[i].Size());
+    for (int i = row_index.size(); i-->0;) {
+        unsigned int cur_row_count = 0;
+        for (unsigned int j = row_index[i].column.size(); j --> 0; ) {
+            if (row_index[i].column[j])
+                cur_row_count = j;
+        }
+        row_count = std::max(row_count, cur_row_count);
+    }
     //4.e. set size
     for (int i = m_nodes.size(); i --> 0 ; )
          m_nodes[i]->CalculateCoordinate(column_width, internal_height);

--- a/UI/TechTreeLayout.cpp
+++ b/UI/TechTreeLayout.cpp
@@ -73,17 +73,6 @@ bool TechTreeLayout::Column::Place(int index, TechTreeLayout::Node* node) {
     return false;
 }
 
-bool TechTreeLayout::Column::Move(int to, TechTreeLayout::Node* node) {
-    if (Fit(to, node)) {
-        for (int i = node->row + node->weight; i-->node->row; )
-            column[i] = nullptr;
-
-        Place(to, node);
-        return true;
-    }
-    return false;
-}
-
 unsigned int TechTreeLayout::Column::Size() {
     for (unsigned int i = column.size(); i --> 0; ) {
         if (column[i])
@@ -431,7 +420,12 @@ bool TechTreeLayout::Node::Wobble(Column& column) {
     new_dist = CalculateFamilyDistance(closest_free_index);
     double improvement = std::abs(dist) - std::abs(new_dist);
     if (improvement > 0.25) {
-        if (column.Move(closest_free_index , this)) {
+        if (column.Fit(closest_free_index, this)) {
+            for (int i = row + weight; i --> row; )
+                column.column[i] = nullptr;
+
+            column.Place(closest_free_index, this);
+
             //std::cout << m_name << ":" << dist << " -> " << new_dist <<"\n";
             return true;
         }

--- a/UI/TechTreeLayout.cpp
+++ b/UI/TechTreeLayout.cpp
@@ -36,12 +36,6 @@ bool TechTreeLayout::Column::Fit(int index, TechTreeLayout::Node* node) {
     return true;
 }
 
-bool TechTreeLayout::Column::PlaceClosestFreeIndex(int index, TechTreeLayout::Node* node) {
-    if (Place(ClosestFreeIndex(index, node), node))
-        return true;
-    return false; //should never happen :-)
-}
-
 int TechTreeLayout::Column::ClosestFreeIndex(int index, TechTreeLayout::Node* node) {
     // search for free node nearest to ideal index:
     // start at ideal, then search in adjacent indices above and below
@@ -607,10 +601,8 @@ void TechTreeLayout::Node::DoLayout(std::vector<Column>& row_index, bool cat) {
     // if any parents or children have been placed, put this node in next free
     // space after the ideal node.  if no parents or children have been placed,
     // put node at start of row
-    if (count != 0)
-        row_index[depth].PlaceClosestFreeIndex(index / count, this);
-    else
-        row_index[depth].PlaceClosestFreeIndex(1, this);
+    int index_offset = (count != 0) ? index / count : 1;
+    row_index[depth].Place(row_index[depth].ClosestFreeIndex(index_offset, this), this);
 }
 
 void TechTreeLayout::Node::CreateEdges(double x_margin, double column_width, double row_height) {

--- a/UI/TechTreeLayout.cpp
+++ b/UI/TechTreeLayout.cpp
@@ -1,4 +1,6 @@
 #include "TechTreeLayout.h"
+
+#include "../universe/Tech.h"
 #include "../util/Logger.h"
 #include <algorithm>
 #include <cmath>
@@ -19,10 +21,6 @@ namespace  {
 //////////////////
 // class Column //
 //////////////////
-TechTreeLayout::Column::Column() :
-    m_column()
-{}
-
 bool TechTreeLayout::Column::Fit(int index, TechTreeLayout::Node* node) {
     if (0 >= index)
         return false;
@@ -160,29 +158,12 @@ void TechTreeLayout::Edge::Debug() const {
     DebugLogger() << "\n";
 }
 
-///////////////////////
-// class LayoutGraph //
-///////////////////////
-/**
- * creates a new empty graph
- */
-TechTreeLayout::TechTreeLayout() :
-    m_width(0),
-    m_height(0),
-    m_row_count(0),
-    m_column_count(0),
-    m_node_map(),
-    m_nodes()
-{}
-
 /**
  * releases all resources
  */
 TechTreeLayout::~TechTreeLayout() {
     for (Node* node : m_nodes)
         delete node;
-    m_nodes.clear();
-    m_node_map.clear();
 }
 
 /**

--- a/UI/TechTreeLayout.cpp
+++ b/UI/TechTreeLayout.cpp
@@ -25,12 +25,12 @@ bool TechTreeLayout::Column::Fit(int index, TechTreeLayout::Node* node) {
     if (0 >= index)
         return false;
 
-    int size = m_column.size();
-    if (index + node->GetWeight() > size)
-        m_column.resize(index + node->GetWeight(), nullptr);
+    int size = column.size();
+    if (index + node->weight > size)
+        column.resize(index + node->weight, nullptr);
 
-    for (int j = index + node->GetWeight(); j-->index; ) {
-        if (m_column[j] != nullptr && m_column[j] != node)
+    for (int j = index + node->weight; j-->index; ) {
+        if (column[j] != nullptr && column[j] != node)
             return false;
     }
     return true;
@@ -64,10 +64,10 @@ int TechTreeLayout::Column::ClosestFreeIndex(int index, TechTreeLayout::Node* no
 
 bool TechTreeLayout::Column::Place(int index, TechTreeLayout::Node* node) {
     if (Fit(index, node)) {
-        for (int i = index + node->GetWeight(); i-->index; )
-            m_column[i] = node;
+        for (int i = index + node->weight; i-->index; )
+            column[i] = node;
 
-        node->m_row = index;
+        node->row = index;
         return true;
     }
     return false;
@@ -75,8 +75,8 @@ bool TechTreeLayout::Column::Place(int index, TechTreeLayout::Node* node) {
 
 bool TechTreeLayout::Column::Move(int to, TechTreeLayout::Node* node) {
     if (Fit(to, node)) {
-        for (int i = node->m_row + node->GetWeight(); i-->node->m_row; )
-            m_column[i] = nullptr;
+        for (int i = node->row + node->weight; i-->node->row; )
+            column[i] = nullptr;
 
         Place(to, node);
         return true;
@@ -85,8 +85,8 @@ bool TechTreeLayout::Column::Move(int to, TechTreeLayout::Node* node) {
 }
 
 unsigned int TechTreeLayout::Column::Size() {
-    for (unsigned int i = m_column.size(); i --> 0; ) {
-        if (m_column[i])
+    for (unsigned int i = column.size(); i --> 0; ) {
+        if (column[i])
             return i;
     }
     return 0;
@@ -97,31 +97,31 @@ TechTreeLayout::Node* TechTreeLayout::Column::Seek(Node* m, int direction) {
         return nullptr;
 
     Node* n = nullptr;
-    int i = m->m_row;
+    int i = m->row;
 
     // find next node adjacent to node m in requested direction
     while (!n || n == m) {
-        if (i < 0 || i >= static_cast<int>(m_column.size()))
+        if (i < 0 || i >= static_cast<int>(column.size()))
             return nullptr;
 
-        n = m_column[i];
+        n = column[i];
         i += direction;
     }
     return n;
 }
 
 bool TechTreeLayout::Column::Swap(Node* m, Node* n) {
-    if (m->GetWeight() != n->GetWeight()) {
+    if (m->weight != n->weight) {
         //if they have different size shifting would be needed
         return false;
     }
-    for (int i = 0; i < m->GetWeight(); i++) {
-        m_column[m->m_row + i] = n;
-        m_column[n->m_row + i] = m;
+    for (int i = 0; i < m->weight; i++) {
+        column[m->row + i] = n;
+        column[n->row + i] = m;
     }
-    int t_row = m->m_row;
-    m->m_row = n->m_row;
-    n->m_row = t_row;
+    int t_row = m->row;
+    m->row = n->row;
+    n->row = t_row;
     return true;
 }
 
@@ -133,9 +133,6 @@ TechTreeLayout::Edge::Edge(const std::string& from, const std::string& to) :
     m_from(from),
     m_to(to)
 { assert(GetTech(from) && GetTech(to)); }
-
-TechTreeLayout::Edge::~Edge()
-{ m_points.clear(); }
 
 const std::string& TechTreeLayout::Edge::GetTechFrom() const
 { return m_from; }
@@ -177,13 +174,13 @@ void TechTreeLayout::DoLayout(double column_width, double row_height, double x_m
     double internal_height = row_height / NODE_CELL_HEIGHT; // node has NODE_CELL_HEIGHT rows internally
     //1. set all node depths from root parents
     for (Node* node : m_nodes)
-        if (node->IsStartNode())
+        if (node->parents.empty())
             node->SetDepthRecursive(0);    // also sets all children's depths
 
     // find max node depth
     int max_node_depth = 0;
     for (Node* node : m_nodes)
-        max_node_depth = std::max(max_node_depth, node->GetDepth());
+        max_node_depth = std::max(max_node_depth, node->depth);
 
     //2. create placeholder nodes
     DebugLogger() << "TechTreeLayout::DoLayout creating placeholder nodes...";
@@ -194,8 +191,8 @@ void TechTreeLayout::DoLayout(double column_width, double row_height, double x_m
     //3. put nodes into containers for each depth column
     std::vector<std::vector<Node*>> nodes_at_each_depth(max_node_depth + 1);
     for (Node* node : m_nodes) {
-        assert((node->GetDepth() >= 0) && (node->GetDepth() < static_cast<int>(nodes_at_each_depth.size())));
-        nodes_at_each_depth[node->GetDepth()].push_back(node);
+        assert((node->depth >= 0) && (node->depth < static_cast<int>(nodes_at_each_depth.size())));
+        nodes_at_each_depth[node->depth].push_back(node);
     }
     // sort within each depth column
     for (auto& level : nodes_at_each_depth)
@@ -235,7 +232,7 @@ void TechTreeLayout::DoLayout(double column_width, double row_height, double x_m
     for (int column : column_order) {
         std::string current_category;
         for (Node* node : nodes_at_each_depth[column]) {
-            const Tech* node_tech = GetTech(node->GetTech());
+            const Tech* node_tech = GetTech(node->tech_name);
             const std::string& node_category = node_tech ? node_tech->Category() : "";
             bool new_category = node_category != current_category;
             node->DoLayout(row_index, new_category);
@@ -248,7 +245,7 @@ void TechTreeLayout::DoLayout(double column_width, double row_height, double x_m
     while (movement) {
         movement = false;
         for (unsigned int i = m_nodes.size(); i --> 0;) {
-            if (m_nodes[i]->Wobble(row_index[m_nodes[i]->m_depth])) {
+            if (m_nodes[i]->Wobble(row_index[m_nodes[i]->depth])) {
                 movement = true;
                 break;
             }
@@ -310,7 +307,7 @@ const std::vector<TechTreeLayout::Edge*>& TechTreeLayout::GetOutEdges(const std:
         Debug();
         throw "node missing";
     } else {
-        return (*item).second->GetOutEdges();
+        return (*item).second->outgoing_edges;
     }
 }
 
@@ -320,7 +317,7 @@ void TechTreeLayout::Debug() const {
 }
 
 void TechTreeLayout::Clear() {
-    //!!! IMPORTANT !!! Node have to be delete in order m_depth ascending or we will access freed memory!
+    //!!! IMPORTANT !!! Node have to be delete in order depth ascending or we will access freed memory!
     for (Node* node : m_nodes)
         delete node;
     m_nodes.clear();
@@ -334,22 +331,22 @@ void TechTreeLayout::Clear() {
  * creates a node for that tech
  */
 TechTreeLayout::Node::Node(const std::string& tech, GG::X width, GG::Y height) :
-    m_tech(tech),
+    weight(NODE_CELL_HEIGHT),
+    tech_name(tech),
+    place_holder(false),
     m_width(Value(width)),
-    m_height(Value(height)),
-    m_place_holder(false),
-    m_weight(NODE_CELL_HEIGHT)
-{ assert(width > 0 && height > 0 && ::GetTech(tech)); }
+    m_height(Value(height))
+{ assert(width > 0 && height > 0 && GetTech(tech)); }
 
 /**
  * recursively creates dummy nodes between parent and child
  */
 TechTreeLayout::Node::Node(Node* parent, Node* child, std::vector<Node*>& nodes) :
-    m_tech(),
+    weight(LINE_CELL_HEIGHT),
+    tech_name(),
+    place_holder(true),
     m_width(0),
-    m_height(0),
-    m_place_holder(true),
-    m_weight(LINE_CELL_HEIGHT)
+    m_height(0)
 {
     assert(parent != 0 && child != 0);
     // ensure passed in nodes are valid
@@ -363,67 +360,52 @@ TechTreeLayout::Node::Node(Node* parent, Node* child, std::vector<Node*>& nodes)
     //DebugLogger() << "Node::Node given parent " << parent
     //                       << " and child: " << child;
 
-    //DebugLogger() << "Node::Node given parent with depth " << parent->m_depth
-    //                       << "  and child with depth: " << child->m_depth;
+    //DebugLogger() << "Node::Node given parent with depth " << parent->depth
+    //                       << "  and child with depth: " << child->depth;
 
     // ensure there is space to insert node between parent and child nodes
-    if (child->m_depth <= parent->m_depth + 1) {
+    if (child->depth <= parent->depth + 1) {
         ErrorLogger() << "no space to insert a dummy node!";
-        m_depth = child->m_depth;
+        depth = child->depth;
         return;
     }
 
     //DebugLogger() << "Node::Node adding dummy node: " << this
-    //                       << "  between parent node tech: " << parent->m_tech
-    //                       << "  and child node tech: " << child->m_tech;
+    //                       << "  between parent node tech: " << parent->tech_name
+    //                       << "  and child node tech: " << child->tech_name;
 
     // add node to main node bookkeeping
     nodes.push_back(this);
 
     // copy parent/child connectivity
-    m_depth = parent->m_depth + 1;
-    m_tech = child->m_tech;
-    m_parents.push_back(parent);
-    m_children.push_back(child);
-    m_primary_child = child;
+    depth = parent->depth + 1;
+    tech_name = child->tech_name;
+    parents.push_back(parent);
+    children.push_back(child);
+    primary_child = child;
 
     // update child's parents to point to this node instead of input parent
-    for (Node*& child_parent_ref : child->m_parents) {
+    for (Node*& child_parent_ref : child->parents) {
         if (child_parent_ref == parent)
             child_parent_ref = this;
     }
 
     // update parent's child node pointers to instead point to this node
-    for (Node*& parent_child_ref : parent->m_children) {
+    for (Node*& parent_child_ref : parent->children) {
         if (parent_child_ref == child)
             parent_child_ref = this;
     }
-    if (parent->m_primary_child == child)
-        parent->m_primary_child = this;
+    if (parent->primary_child == child)
+        parent->primary_child = this;
 }
 
 TechTreeLayout::Node::~Node() {
-    m_children.clear();
-    m_parents.clear();
-    for (Edge* out_edge : m_out_edges)
+    children.clear();
+    parents.clear();
+    for (Edge* out_edge : outgoing_edges)
         delete out_edge;
-    m_out_edges.clear();
+    outgoing_edges.clear();
 }
-
-int TechTreeLayout::Node::GetDepth() const
-{ return m_depth; }
-
-const std::string& TechTreeLayout::Node::GetTech() const
-{ return m_tech; }
-
-int TechTreeLayout::Node::GetNumberOfChildren() const
-{ return m_children.size(); }
-
-int TechTreeLayout::Node::GetNumberOfParents() const
-{ return m_parents.size(); }
-
-const std::vector<TechTreeLayout::Edge*>& TechTreeLayout::Node::GetOutEdges() const
-{ return m_out_edges; }
 
 const GG::X TechTreeLayout::Node::GetX() const
 { return GG::X(static_cast<int>(m_x)); }
@@ -432,41 +414,32 @@ const GG::Y TechTreeLayout::Node::GetY() const
 { return GG::Y(static_cast<int>(m_y)); }
 
 void TechTreeLayout::Node::CalculateCoordinate(double column_width, double row_height) {
-    m_x = (static_cast<double>(m_depth) - 0.5) * column_width;
-    m_y = m_row * row_height;
+    m_x = (static_cast<double>(depth) - 0.5) * column_width;
+    m_y = row * row_height;
 }
 
-bool TechTreeLayout::Node::IsFinalNode() const
-{ return m_children.empty(); }
-
-bool TechTreeLayout::Node::IsStartNode() const
-{ return m_parents.empty(); }
-
-bool TechTreeLayout::Node::IsPlaceHolder() const
-{ return m_place_holder; }
-
 double TechTreeLayout::Node::CalculateFamilyDistance(int row) {
-    int familysize = m_parents.size() + m_children.size();
+    int familysize = parents.size() + children.size();
     if (familysize == 0)
         return 0;
 
     double distance = 0;
-    for (const Node* node : m_children)
+    for (const Node* node : children)
         if (node)
-            distance += std::abs(node->m_row - row);
-    for (const Node* node : m_parents)
+            distance += std::abs(node->row - row);
+    for (const Node* node : parents)
         if (node)
-            distance += std::abs(node->m_row - row);
+            distance += std::abs(node->row - row);
 
     return distance / familysize;
 }
 
 bool TechTreeLayout::Node::Wobble(Column& column) {
     double dist, new_dist, s_dist, new_s_dist;
-    dist = CalculateFamilyDistance(m_row);
+    dist = CalculateFamilyDistance(row);
 
     //try to find free space arround optimal position
-    int closest_free_index = column.ClosestFreeIndex(static_cast<int>(m_row + dist + 0.5), this);
+    int closest_free_index = column.ClosestFreeIndex(static_cast<int>(row + dist + 0.5), this);
 
     //check if that space is better
     new_dist = CalculateFamilyDistance(closest_free_index);
@@ -486,9 +459,9 @@ bool TechTreeLayout::Node::Wobble(Column& column) {
 
     // try to switch node with neighbour node
     if (n) {
-        s_dist     = n->CalculateFamilyDistance(n->m_row);
-        new_s_dist = n->CalculateFamilyDistance(   m_row);
-        new_dist   =    CalculateFamilyDistance(n->m_row);
+        s_dist     = n->CalculateFamilyDistance(n->row);
+        new_s_dist = n->CalculateFamilyDistance(   row);
+        new_dist   =    CalculateFamilyDistance(n->row);
         improvement = std::abs(dist) + std::abs(s_dist) - std::abs(new_dist) - std::abs(new_s_dist);
         if (improvement > 0.25) { // 0 produces endless loop
             if (column.Swap(this, n)) {
@@ -501,45 +474,45 @@ bool TechTreeLayout::Node::Wobble(Column& column) {
 }
 
 bool TechTreeLayout::Node::operator<(const TechTreeLayout::Node& y) const {
-    if (m_depth == y.m_depth) {
-        const Tech* this_node_tech = ::GetTech(m_tech);
+    if (depth == y.depth) {
+        const Tech* this_node_tech = GetTech(tech_name);
         assert(this_node_tech);
-        const Tech* y_node_tech = ::GetTech(y.m_tech);
+        const Tech* y_node_tech = GetTech(y.tech_name);
         assert(y_node_tech);
 
         if (this_node_tech->Category() == y_node_tech->Category())
-            return m_tech < y.m_tech;
+            return tech_name < y.tech_name;
         return this_node_tech->Category() < y_node_tech->Category();
     }
-    return m_depth < y.m_depth;
+    return depth < y.depth;
 }
 
 void TechTreeLayout::Node::AddChild(Node* node) {
-    //DebugLogger() << "Node::AddChild this node: " << this << " for tech: " << m_tech << "  with child node: " << node << "  for tech: " << node->GetTech();
+    //DebugLogger() << "Node::AddChild this node: " << this << " for tech: " << tech_name << "  with child node: " << node << "  for tech: " << node->tech_name;
     assert(node);
-    m_children.push_back(node);
-    node->m_parents.push_back(this);
-    //Note: m_primary_child is used as sorting criteria
+    children.push_back(node);
+    node->parents.push_back(this);
+    //Note: primary_child is used as sorting criteria
     // nodes with the same child get drawn "together"
     // so we need to choose wisely which node is our heir
     // 1. we prefere childs with the same category
     // 2. we order lexically
-    if (!m_primary_child) {
+    if (!primary_child) {
         //no choice
-        m_primary_child = node;
+        primary_child = node;
         return;
     }
 
-    if (node->m_place_holder)
+    if (node->place_holder)
         return;
 
     //reaching this case means we will get crossing lines
     //we decide which node is the better child for layout decisions
-    const Tech* this_node_tech = ::GetTech(m_tech);
+    const Tech* this_node_tech = GetTech(tech_name);
     assert(this_node_tech);
-    const Tech* child_node_tech = ::GetTech(m_primary_child->m_tech);
+    const Tech* child_node_tech = GetTech(primary_child->tech_name);
     assert(child_node_tech);
-    const Tech* input_node_tech = ::GetTech(node->m_tech);
+    const Tech* input_node_tech = GetTech(node->tech_name);
     assert(input_node_tech);
 
     int n = ((child_node_tech->Category() == this_node_tech->Category()) ? 0 : 1)
@@ -547,90 +520,81 @@ void TechTreeLayout::Node::AddChild(Node* node) {
         +  ((input_node_tech->Category() == this_node_tech->Category()) ? 0 : 2);
     switch (n) {
     case 0: //both categories fit
-        if (node->m_tech < m_primary_child->m_tech)
-            m_primary_child = node;
+        if (node->tech_name < primary_child->tech_name)
+            primary_child = node;
         break;
-    case 1:  //only m_primary_child category fits
-        //keep m_primary_child 
+    case 1:  //only primary_child category fits
+        //keep primary_child
         break;
     case 2: //only node category fits
-        m_primary_child = node;
+        primary_child = node;
         break;
     case 3: //both categories are wrong
         if (input_node_tech->Category() < child_node_tech->Category())
-            m_primary_child = node;
+            primary_child = node;
         //else keep child
         break;
     }
 }
 
 void TechTreeLayout::Node::SetDepthRecursive(int depth) {
-    m_depth = std::max(depth, m_depth);
+    this->depth = std::max(depth, this->depth);
     // set children's depths
-    for (Node* node : m_children)
-        node->SetDepthRecursive(m_depth + 1);
+    for (Node* node : children)
+        node->SetDepthRecursive(this->depth + 1);
 }
 
 void TechTreeLayout::Node::CreatePlaceHolder(std::vector<Node*>& nodes) {
     //DebugLogger() << "Creating PlaceHolder for node " << this;
     //DebugLogger().flush();
-    //DebugLogger() << "  for tech: " << m_tech;
+    //DebugLogger() << "  for tech: " << tech_name;
     //DebugLogger().flush();
-    //DebugLogger() << "  which has " << m_children.size() << " children:";
+    //DebugLogger() << "  which has " << children.size() << " children:";
     //DebugLogger().flush();
-    //for (const Node* child : m_children) {
-    //    DebugLogger() << "      child: " << child << " with tech: " << child->GetTech();
+    //for (const Node* child : children) {
+    //    DebugLogger() << "      child: " << child << " with tech: " << child->tech_name;
     //}
 
 
-    for (Node* child : m_children) {
-        //DebugLogger() << "   processing child: " << child << " with tech: " << child->GetTech();
+    for (Node* child : children) {
+        //DebugLogger() << "   processing child: " << child << " with tech: " << child->tech_name;
 
 
         Node* current_parent_node = this;
 
-        // record extra height of placeholder or node in child row
-        if (current_parent_node->m_depth + 1 < child->m_depth) {
-            m_children_rows += LINE_CELL_HEIGHT;
-        } else {
-            m_children_rows += NODE_CELL_HEIGHT;
-        }
-
-
-        //DebugLogger() << "Dummy nodes from " << this->m_tech << " to child: " << child->GetTech();
+        //DebugLogger() << "Dummy nodes from " << this->tech_name << " to child: " << child->tech_name;
         //int dummy_nodes_added = 0;
-        while (current_parent_node->m_depth + 1 < child->m_depth) {
+        while (current_parent_node->depth + 1 < child->depth) {
             // there is at least one column gap beween the horizontal positions
             // of this node and this child node.
             //
             // to fill the gap visually, create dummy node(s) in the columns
             // between them.
-            //DebugLogger() << "next column depth: " << current_parent_node->m_depth + 1
-            //                       << "  child_depth: " << child->m_depth;
+            //DebugLogger() << "next column depth: " << current_parent_node->depth + 1
+            //                       << "  child_depth: " << child->depth;
             //DebugLogger() << "current_parent_node: " << current_parent_node
             //                       << " child: " << child;
             auto dummy_node = new Node(current_parent_node, child, nodes);
-            //DebugLogger() << "new dummy node depth: " << dummy_node->m_depth;
+            //DebugLogger() << "new dummy node depth: " << dummy_node->depth;
             current_parent_node = dummy_node;
             //++dummy_nodes_added;
         }
-        //DebugLogger() << "done adding dummy nodes.  current_parent node depth + 1: " << current_parent_node->m_depth + 1 << "  child depth: " << child->m_depth;
+        //DebugLogger() << "done adding dummy nodes.  current_parent node depth + 1: " << current_parent_node->depth + 1 << "  child depth: " << child->depth;
         //if (dummy_nodes_added > 0) {
-        //    DebugLogger() << "added " << dummy_nodes_added << " dummy nodes for from tech " << m_tech;
+        //    DebugLogger() << "added " << dummy_nodes_added << " dummy nodes for from tech " << tech_name;
         //}
 
-        //DebugLogger() << " node now has " << m_children.size() << " children:";
+        //DebugLogger() << " node now has " << children.size() << " children:";
         //DebugLogger().flush();
-        //for (Node* child : m_children) {
-        //    DebugLogger() << "      child: " << child << " with tech: " << child->GetTech();
+        //for (Node* child : children) {
+        //    DebugLogger() << "      child: " << child << " with tech: " << child->tech_name;
         //}
     }
-    m_children_rows = std::max(m_children_rows, NODE_CELL_HEIGHT);
 }
 
 void TechTreeLayout::Node::DoLayout(std::vector<Column>& row_index, bool cat) {
     //assert(row_height > 0 && column_width > 0 && row_index != 0);
-    if (m_row != -1) return; //already done
+    if (row != -1) return; //already done
 
     // find average row index of node's children and parents
 
@@ -638,76 +602,76 @@ void TechTreeLayout::Node::DoLayout(std::vector<Column>& row_index, bool cat) {
     int index = 0;
     int count = 0;
     //check children
-    for (int i = m_children.size(); i --> 0;) {
-        if (m_children[i]->m_row != -1) {
-            index += m_children[i]->m_row;
+    for (int i = children.size(); i --> 0;) {
+        if (children[i]->row != -1) {
+            index += children[i]->row;
             count++;
         }
     }
     //check parents
-    for (int i = m_parents.size(); i --> 0;) {
-        if (m_parents[i]->m_row != -1) {
-            index += m_parents[i]->m_row;
+    for (int i = parents.size(); i --> 0;) {
+        if (parents[i]->row != -1) {
+            index += parents[i]->row;
             count++;
         }
     }
-    if (static_cast<int>(row_index.size()) < m_depth + 1) row_index.resize(m_depth + 1);
+    if (static_cast<int>(row_index.size()) < depth + 1) row_index.resize(depth + 1);
 
     // if any parents or children have been placed, put this node in next free
     // space after the ideal node.  if no parents or children have been placed,
     // put node at start of row
     if (count != 0)
-        row_index[m_depth].PlaceClosestFreeIndex(index / count, this);
+        row_index[depth].PlaceClosestFreeIndex(index / count, this);
     else
-        row_index[m_depth].PlaceClosestFreeIndex(1, this);
+        row_index[depth].PlaceClosestFreeIndex(1, this);
 }
 
 void TechTreeLayout::Node::CreateEdges(double x_margin, double column_width, double row_height) {
     assert(column_width > 0);
-    for (int i = m_children.size(); i --> 0; ) {
+    for (int i = children.size(); i --> 0; ) {
         //find next real node and create coordinates
-        Node* next = m_children[i];
-        while (next->m_place_holder) { 
+        Node* next = children[i];
+        while (next->place_holder) {
             next->CalculateCoordinate(column_width, row_height);
-            next = next->m_primary_child; 
+            next = next->primary_child;
         }
-        const std::string& to = next->m_tech;
+        const std::string& to = next->tech_name;
         //create drawing path
-        next = m_children[i];
-        auto edge = new Edge(m_tech, to);
+        next = children[i];
+        auto edge = new Edge(tech_name, to);
         //from, line start
         edge->AddPoint(m_x, m_y + m_height / 2); // start on the left side of the node
         edge->AddPoint(m_x + m_width + x_margin, m_y + m_height / 2);
         //draw line until a real tech is reached
-        while (next->m_place_holder) {
+        while (next->place_holder) {
             //horizontal line bypassing the placeholder
             edge->AddPoint(next->m_x - 2 * x_margin, next->m_y);
             edge->AddPoint(next->m_x + m_width + x_margin, next->m_y);
-            next = next->m_primary_child;
+            next = next->primary_child;
         }
         //to, line end
         edge->AddPoint(next->m_x - 2 * x_margin, next->m_y + next->m_height / 2); //double space for arrow
         edge->AddPoint(next->m_x, next->m_y + next->m_height / 2); // the end has to be exact for the arrow head
         //store drawing path
-        m_out_edges.push_back(edge);
+        outgoing_edges.push_back(edge);
     }
 }
 
 void TechTreeLayout::Node::Debug() const {
-    DebugLogger() << "Tech - " << m_tech << " (" << m_x << "," << m_y << ") #" << m_depth << "\n";
+    DebugLogger() << "Tech - " << tech_name << " (" << m_x << "," << m_y << ") #" << depth << "\n";
     DebugLogger() << "  Parents - ";
-    for (int i = m_parents.size(); i --> 0; )
-        DebugLogger() << m_parents[i]->m_tech << "#" << m_parents[i]->m_depth;
+    for (int i = parents.size(); i --> 0; )
+        DebugLogger() << parents[i]->tech_name << "#" << parents[i]->depth;
 
     DebugLogger() << "\n";
     DebugLogger() << "  Children - ";
-    for (int i = m_children.size(); i --> 0; )
-        DebugLogger() << m_children[i]->m_tech << "#" << m_children[i]->m_depth;;
+    for (int i = children.size(); i --> 0; )
+        DebugLogger() << children[i]->tech_name << "#" << children[i]->depth;;
 
     DebugLogger() << "\n";
 
-    for (int i = m_out_edges.size(); i-->0; ) {
+    for (int i = outgoing_edges.size(); i-->0; ) {
         DebugLogger() << "     - ";
-        m_out_edges[i]->Debug();
+        outgoing_edges[i]->Debug();
     }
 }

--- a/UI/TechTreeLayout.cpp
+++ b/UI/TechTreeLayout.cpp
@@ -8,15 +8,8 @@
 namespace  {
     const int NODE_CELL_HEIGHT = 2;
     const int LINE_CELL_HEIGHT = 1;
+}
 
-///////////////////////////
-// struct NodePointerCmp //
-///////////////////////////
-    struct NodePointerCmp {
-        bool operator()(const TechTreeLayout::Node* x, const TechTreeLayout::Node* y) const
-        { return x && y && (*x) < (*y); }
-    };
-} //namespace
 
 //////////////////
 // class Column //
@@ -139,8 +132,7 @@ void TechTreeLayout::DoLayout(double column_width, double row_height, double x_m
     }
     // sort within each depth column
     for (auto& level : nodes_at_each_depth)
-    { std::sort(level.begin(), level.end(), NodePointerCmp()); }
-
+        std::sort(level.begin(), level.end(), [](Node* l, Node* r) -> bool { return *l < *r; });
 
     //4. do layout
     std::vector<Column> row_index = std::vector<Column>(nodes_at_each_depth.size());

--- a/UI/TechTreeLayout.cpp
+++ b/UI/TechTreeLayout.cpp
@@ -110,20 +110,6 @@ TechTreeLayout::Node* TechTreeLayout::Column::Seek(Node* m, int direction) {
     return n;
 }
 
-bool TechTreeLayout::Column::Swap(Node* m, Node* n) {
-    if (m->weight != n->weight) {
-        //if they have different size shifting would be needed
-        return false;
-    }
-    for (int i = 0; i < m->weight; i++) {
-        column[m->row + i] = n;
-        column[n->row + i] = m;
-    }
-    int t_row = m->row;
-    m->row = n->row;
-    n->row = t_row;
-    return true;
-}
 
 ////////////////
 // class Edge //
@@ -464,7 +450,14 @@ bool TechTreeLayout::Node::Wobble(Column& column) {
         new_dist   =    CalculateFamilyDistance(n->row);
         improvement = std::abs(dist) + std::abs(s_dist) - std::abs(new_dist) - std::abs(new_s_dist);
         if (improvement > 0.25) { // 0 produces endless loop
-            if (column.Swap(this, n)) {
+            if (weight == n->weight) {
+                for (int i = 0; i < weight; i++) {
+                    column.column[row + i] = n;
+                    column.column[n->row + i] = this;
+                }
+                int t_row = row;
+                row = n->row;
+                n->row = t_row;
                 //std::cout << "(S)" << m_name  << ":" << dist << " -> " << new_dist << " & "<< n->m_name  << ":" << s_dist << " -> " << new_s_dist << "\n";
                 return true;
             }

--- a/UI/TechTreeLayout.h
+++ b/UI/TechTreeLayout.h
@@ -217,8 +217,6 @@ public:
 
     auto Place(int index, TechTreeLayout::Node* node) -> bool;
 
-    auto Move(int to, TechTreeLayout::Node* node) -> bool;
-
     auto Seek(Node* m, int direction) -> Node*;
 
     auto Size() -> unsigned int;

--- a/UI/TechTreeLayout.h
+++ b/UI/TechTreeLayout.h
@@ -215,8 +215,6 @@ public:
 
     auto Place(int index, TechTreeLayout::Node* node) -> bool;
 
-    auto Size() -> unsigned int;
-
     std::vector<TechTreeLayout::Node*> column;
 };
 

--- a/UI/TechTreeLayout.h
+++ b/UI/TechTreeLayout.h
@@ -215,8 +215,6 @@ public:
 
     auto Place(int index, TechTreeLayout::Node* node) -> bool;
 
-    auto Seek(Node* m, int direction) -> Node*;
-
     auto Size() -> unsigned int;
 
     std::vector<TechTreeLayout::Node*> column;

--- a/UI/TechTreeLayout.h
+++ b/UI/TechTreeLayout.h
@@ -211,8 +211,6 @@ class TechTreeLayout::Column {
 public:
     auto Fit(int index, TechTreeLayout::Node* node) -> bool;
 
-    auto PlaceClosestFreeIndex(int index, TechTreeLayout::Node* node) -> bool;
-
     auto ClosestFreeIndex(int index, TechTreeLayout::Node* node) -> int;
 
     auto Place(int index, TechTreeLayout::Node* node) -> bool;

--- a/UI/TechTreeLayout.h
+++ b/UI/TechTreeLayout.h
@@ -1,12 +1,12 @@
 #ifndef _TechTreeLayout_h_
 #define _TechTreeLayout_h_
+
 #include <map>
 #include <list>
 #include <string>
 #include <vector>
 
 #include <GG/PtRect.h>
-#include "../universe/Tech.h"
 
 
 /**
@@ -61,108 +61,202 @@
 class TechTreeLayout {
 public:
     class Node;
+
     class Edge;
+
     class Column;
-    TechTreeLayout();
+
     ~TechTreeLayout();
-    void                        AddNode(const std::string& tech, GG::X width, GG::Y height);
-    const Node*                 GetNode(const std::string & name) const;
-    void                        AddEdge(const std::string & parent, const std::string & child);
-    const GG::X                 GetWidth() const;
-    const GG::Y                 GetHeight() const;
-    double                      GetWidth(const std::string & name ) const;
-    double                      GetHeight(const std::string & name ) const;
-    void                        Clear();
-    void                        DoLayout( double column_width, double row_height, double x_margin);
-    const std::vector<Edge*>&   GetOutEdges(const std::string & name) const;
-    void                        Debug() const;
+
+    void AddNode(std::string const & tech, GG::X width, GG::Y height);
+
+    auto GetNode(std::string const & name) const -> Node const *;
+
+    auto GetWidth(std::string const & name) const -> double;
+
+    auto GetHeight(std::string const & name) const;
+
+    void AddEdge(std::string const & parent, std::string const & child);
+
+    auto GetOutEdges(std::string const & name) const -> std::vector<Edge*> const &;
+
+    auto GetWidth() const -> GG::X const;
+
+    auto GetHeight() const -> GG::Y const;
+
+    void Clear();
+
+    void DoLayout( double column_width, double row_height, double x_margin);
+
+    void Debug() const;
+
 private:
-    double                          m_width; //width of the complete graph
-    double                          m_height; //height of the complete graph
-    int                             m_row_count;
-    int                             m_column_count;
-    std::map< std::string, Node*>   m_node_map; //map name->node for external access by name
-    std::vector<Node*>              m_nodes; // list of nodes for sorting
+    //! width of the complete graph
+    double m_width = 0;
+
+    //! height of the complete graph
+    double m_height = 0;
+
+    int m_row_count = 0;
+
+    int m_column_count = 0;
+
+    //! map name->node for external access by name
+    std::map<std::string, Node*> m_node_map;
+
+    //! list of nodes for sorting
+    std::vector<Node*> m_nodes;
 };
+
 
 class TechTreeLayout::Edge {
 public:
-    Edge(const std::string& from, const std::string& to);
+    Edge(std::string const & from, std::string const & to);
+
     ~Edge();
-    const std::string&  GetTechFrom() const;
-    const std::string&  GetTechTo() const;
-    void                ReadPoints(std::vector<std::pair<double,double>> & points) const;
-    void                AddPoint(double x, double y);
-    void                Debug() const;
+
+    auto GetTechFrom() const -> std::string const &;
+
+    auto GetTechTo() const -> std::string const &;
+
+    void ReadPoints(std::vector<std::pair<double,double>> & points) const;
+
+    void AddPoint(double x, double y);
+
+    void Debug() const;
+
 private:
-    std::vector<std::pair<double, double>>  m_points;   // point list of connection
-    std::string                             m_from;     //source tech
-    std::string                             m_to;       //destination tech
+    //! point list of connection
+    std::vector<std::pair<double, double>> m_points;
+
+    //! source tech
+    std::string m_from;
+
+    //! destination tech
+    std::string m_to;
 };
+
 
 class TechTreeLayout::Node {
     friend class TechTreeLayout;
+
     friend class Column;
+
 public:
-    Node(const std::string& tech, GG::X width, GG::Y height);
+    Node(std::string const & tech, GG::X width, GG::Y height);
+
     ~Node();
 
-    const GG::X                 GetX() const;
-    const GG::Y                 GetY() const;
-    int                         GetDepth() const;
-    const std::string&          GetTech() const;
-    const std::vector<Edge*>&   GetOutEdges() const;
-    int                         GetNumberOfChildren() const;
-    int                         GetNumberOfParents() const;
-    void                        Debug() const;
-    bool                        IsFinalNode() const;
-    bool                        IsStartNode() const;
-    int                         GetWeight() const { return m_weight; };
+    auto GetX() const -> GG::X const;
 
-    bool operator<(const Node& y) const;
+    auto GetY() const -> GG::Y const;
+
+    auto GetDepth() const -> int;
+
+    auto GetTech() const -> std::string const &;
+
+    auto GetOutEdges() const -> std::vector<Edge *> const &;
+
+    auto GetNumberOfChildren() const -> int;
+
+    auto GetNumberOfParents() const -> int;
+
+    void Debug() const;
+
+    auto IsFinalNode() const -> bool;
+
+    auto IsStartNode() const -> bool;
+
+    auto GetWeight() const -> int
+    { return m_weight; };
+
+    auto operator<(Node const & y) const -> bool;
 
 private:
     Node(Node* parent, Node* child, std::vector<Node*>& nodes);
 
-    bool    Wobble(Column & column);
-    bool    IsPlaceHolder() const;
-    void    AddChild(Node* node);
-    void    SetDepthRecursive(int depth);
-    double  CalculateFamilyDistance(int row);
-    void    CreatePlaceHolder(std::vector<Node*>& nodes);
-    void    DoLayout(std::vector<Column> & row_index, bool cat);
-    void    CalculateCoordinate(double column_width, double row_height);
-    void    CreateEdges(double x_margin, double column_width, double row_height);
+    auto Wobble(Column & column) -> bool;
 
-    int                 m_depth = -1;   // depth 1 available at beginning 2 one requisite etc
-    int                 m_row = -1;     // layout row, every node is organized in a straight tabelle system
-    std::string         m_tech;         // name
-    double              m_x = 0.0;      // left border
-    double              m_y = 0.0;      // top border
-    double              m_width;        // width
-    double              m_height;       // height
-    bool                m_place_holder; // is place holder
-    int                 m_children_rows = 0; // height in cells for layouting
-    std::vector<Node*>  m_parents;      // parents
-    std::vector<Node*>  m_children;     // children
-    Node*               m_primary_child = nullptr; // primary child for layout
-    std::vector<Edge*>  m_out_edges;    // outgoing edges
-    const int           m_weight;       // height in rows
+    auto IsPlaceHolder() const -> bool;
 
+    void AddChild(Node* node);
+
+    void SetDepthRecursive(int depth);
+
+    auto CalculateFamilyDistance(int row) -> double;
+
+    void CreatePlaceHolder(std::vector<Node*>& nodes);
+
+    void DoLayout(std::vector<Column> & row_index, bool cat);
+
+    void CalculateCoordinate(double column_width, double row_height);
+
+    void CreateEdges(double x_margin, double column_width, double row_height);
+
+    //! depth 1 available at beginning 2 one requisite etc
+    int m_depth = -1;
+
+    //! layout row, every node is organized in a straight tabelle system
+    int m_row = -1;
+
+    //! name
+    std::string m_tech;
+
+    //! left border
+    double m_x = 0.0;
+
+    //! top border
+    double m_y = 0.0;
+
+    //! width
+    double m_width;
+
+    //! height
+    double m_height;
+
+    //! is place holder
+    bool m_place_holder;
+
+    //! height in cells for layouting
+    int m_children_rows = 0;
+
+    //! parents
+    std::vector<Node*> m_parents;
+
+    //! children
+    std::vector<Node*> m_children;
+
+    //! primary child for layout
+    Node* m_primary_child = nullptr;
+
+    //! outgoing edges
+    std::vector<Edge*> m_out_edges;
+
+    //! height in rows
+    int const m_weight;
 };
+
 
 class TechTreeLayout::Column {
 public:
-    Column();
-    bool            Fit(int index, TechTreeLayout::Node* node);
-    bool            PlaceClosestFreeIndex(int index, TechTreeLayout::Node* node);
-    int             ClosestFreeIndex(int index, TechTreeLayout::Node* node);
-    bool            Place(int index, TechTreeLayout::Node* node);
-    bool            Move(int to, TechTreeLayout::Node* node);
-    Node*           Seek(Node* m, int direction);
-    bool            Swap(Node* m, Node* n);
-    unsigned int    Size();
+    auto Fit(int index, TechTreeLayout::Node* node) -> bool;
+
+    auto PlaceClosestFreeIndex(int index, TechTreeLayout::Node* node) -> bool;
+
+    auto ClosestFreeIndex(int index, TechTreeLayout::Node* node) -> int;
+
+    auto Place(int index, TechTreeLayout::Node* node) -> bool;
+
+    auto Move(int to, TechTreeLayout::Node* node) -> bool;
+
+    auto Seek(Node* m, int direction) -> Node*;
+
+    auto Swap(Node* m, Node* n) -> bool;
+
+    auto Size() -> unsigned int;
+
 private:
     std::vector<TechTreeLayout::Node*> m_column;
 };
+
 #endif

--- a/UI/TechTreeLayout.h
+++ b/UI/TechTreeLayout.h
@@ -221,11 +221,8 @@ public:
 
     auto Seek(Node* m, int direction) -> Node*;
 
-    auto Swap(Node* m, Node* n) -> bool;
-
     auto Size() -> unsigned int;
 
-private:
     std::vector<TechTreeLayout::Node*> column;
 };
 

--- a/UI/TechTreeLayout.h
+++ b/UI/TechTreeLayout.h
@@ -2,7 +2,6 @@
 #define _TechTreeLayout_h_
 
 #include <map>
-#include <list>
 #include <string>
 #include <vector>
 
@@ -13,7 +12,7 @@
  * This class stores internal information for layouting the tech graph.
  * The whole space is organized in a table.
  * Every tech is assign a tech level, or depth, which is the maximum distance it is from start techs.
- * Every tech level (m_depth) is one column.
+ * Every tech level (depth) is one column.
  * The first column has depth 1 techs, 2nd column has depth 2 tech, etc.
  * An initial column is filled with techs grouped by category (may be middle or first, or ? column)
  * Nodes in adjacent columns are placed near the average of children or parent nodes in adjacent columns
@@ -113,8 +112,6 @@ class TechTreeLayout::Edge {
 public:
     Edge(std::string const & from, std::string const & to);
 
-    ~Edge();
-
     auto GetTechFrom() const -> std::string const &;
 
     auto GetTechTo() const -> std::string const &;
@@ -151,24 +148,7 @@ public:
 
     auto GetY() const -> GG::Y const;
 
-    auto GetDepth() const -> int;
-
-    auto GetTech() const -> std::string const &;
-
-    auto GetOutEdges() const -> std::vector<Edge *> const &;
-
-    auto GetNumberOfChildren() const -> int;
-
-    auto GetNumberOfParents() const -> int;
-
     void Debug() const;
-
-    auto IsFinalNode() const -> bool;
-
-    auto IsStartNode() const -> bool;
-
-    auto GetWeight() const -> int
-    { return m_weight; };
 
     auto operator<(Node const & y) const -> bool;
 
@@ -176,8 +156,6 @@ private:
     Node(Node* parent, Node* child, std::vector<Node*>& nodes);
 
     auto Wobble(Column & column) -> bool;
-
-    auto IsPlaceHolder() const -> bool;
 
     void AddChild(Node* node);
 
@@ -193,14 +171,27 @@ private:
 
     void CreateEdges(double x_margin, double column_width, double row_height);
 
+    std::vector<Node*> parents;
+
+    std::vector<Node*> children;
+
     //! depth 1 available at beginning 2 one requisite etc
-    int m_depth = -1;
+    int depth = -1;
 
     //! layout row, every node is organized in a straight tabelle system
-    int m_row = -1;
+    int row = -1;
 
-    //! name
-    std::string m_tech;
+    //! height in rows
+    const int weight;
+
+    std::string tech_name;
+
+    bool place_holder;
+
+    // primary child for layout
+    Node* primary_child = nullptr;
+
+    std::vector<Edge*> outgoing_edges;
 
     //! left border
     double m_x = 0.0;
@@ -213,27 +204,6 @@ private:
 
     //! height
     double m_height;
-
-    //! is place holder
-    bool m_place_holder;
-
-    //! height in cells for layouting
-    int m_children_rows = 0;
-
-    //! parents
-    std::vector<Node*> m_parents;
-
-    //! children
-    std::vector<Node*> m_children;
-
-    //! primary child for layout
-    Node* m_primary_child = nullptr;
-
-    //! outgoing edges
-    std::vector<Edge*> m_out_edges;
-
-    //! height in rows
-    int const m_weight;
 };
 
 
@@ -256,7 +226,7 @@ public:
     auto Size() -> unsigned int;
 
 private:
-    std::vector<TechTreeLayout::Node*> m_column;
+    std::vector<TechTreeLayout::Node*> column;
 };
 
 #endif


### PR DESCRIPTION
This PR simplifies the implementation of te `TechTreeLayout` class and its utility classes by:

* Unfolding member functions only used once in the implementation.
* Removing getters from the `Node`, `Edge` and `Column` utility classes and replacing them with public access to the attribute.  Those were only shared between `TechTreeLayout` and the utility classes anyway.
* Format the member function declarations by using signatures with trailing return types.

This PR splits out the grooming aspect of #2141 