### PR TITLE
Make utility scripts  use Python3 and become PEP-8 compliant

### DIFF
--- a/check/st-tool.py
+++ b/check/st-tool.py
@@ -1,8 +1,6 @@
 #!/usr/bin/python3
 import argparse
 import datetime
-import errno
-import os
 import re
 import subprocess
 import sys
@@ -14,6 +12,7 @@ STRING_TABLE_KEY_PATTERN = r'^[A-Z0-9_]+$'
 INTERNAL_REFERENCE_PATTERN = r'\[\[(?P<ref_type>(?:(?:encyclopedia|(?:building|field|meter)type|predefinedshipdesign|ship(?:hull|part)|special|species|tech) )?)(?P<key>{})\]\]'
 # Provides the named capture groups 'sha', 'old_line', 'new_line' and 'range'
 GIT_BLAME_INCREMENTAL_PATTERN = r'^(?P<sha>[0-9a-f]{40}) (?P<old_line>[1-9][0-9]*) (?P<new_line>[1-9][0-9]*)(?P<range> [1-9][0-9]*)?$'
+
 
 class StringTableEntry(object):
     def __init__(self, key, keyline, value, notes, value_times):
@@ -137,7 +136,7 @@ class StringTable(object):
         section = []
         entries = []
         includes = []
-        blames = OrderedDict();
+        blames = OrderedDict()
 
         key = None
         keyline = None
@@ -264,7 +263,7 @@ class StringTable(object):
                 vline_end = fline
                 continue
 
-            raise ValueError("{}:{}: Impossible parser state; last valid line: {}".format(fpath, fline_start, line))
+            raise ValueError("{}:{}: Impossible parser state; last valid line: {}".format(fpath, vline_start, line))
 
         if key:
             raise ValueError("{}:{}: Key '{}' without value".format(fpath, vline_start, key))
@@ -347,10 +346,10 @@ class StringTable(object):
                 if left[key].value == right[key].value:
                     identical.add(key)
                 if (left[key].value.startswith('[[') and 2 == left[key].value.count('[') and
-                    left[key].value.endswith(']]') and 2 == left[key].value.count(']')):
+                        left[key].value.endswith(']]') and 2 == left[key].value.count(']')):
                     left_pure_reference.add(key)
                 if (right[key].value.startswith('[[') and 2 == right[key].value.count('[') and
-                    right[key].value.endswith(']]') and 2 == right[key].value.count(']')):
+                        right[key].value.endswith(']]') and 2 == right[key].value.count(']')):
                     right_pure_reference.add(key)
                 if len(left[key].value_times) != len(right[key].value_times):
                     layout_mismatch.add(key)
@@ -369,7 +368,7 @@ class StringTable(object):
             untranslated=untranslated, identical=identical,
             layout_mismatch=layout_mismatch)
 
-    @staticmethod 
+    @staticmethod
     def sync(reference, source):
         entries = []
 
@@ -549,7 +548,8 @@ if __name__ == "__main__":
         title="verbs", description="For more details run `{} <verb> --help`.".format(root_parser.prog),
     )
 
-    format_parser = verb_parsers.add_parser('format',
+    format_parser = verb_parsers.add_parser(
+        'format',
         help="format a string table and exit",
         description=textwrap.dedent("""\
         Pretty prints a given string table onto the standard output.
@@ -569,10 +569,12 @@ if __name__ == "__main__":
         """),
         formatter_class=argparse.RawTextHelpFormatter)
     format_parser.set_defaults(action=format_action)
-    format_parser.add_argument('source', metavar='SOURCE', help="string table to format",
+    format_parser.add_argument(
+        'source', metavar='SOURCE', help="string table to format",
         type=argparse.FileType(encoding='utf-8', errors='strict'))
 
-    sync_parser = verb_parsers.add_parser('sync',
+    sync_parser = verb_parsers.add_parser(
+        'sync',
         help="synchronize two string tables and exit",
         description=textwrap.dedent("""\
         Synchronizes two string tables by copying over translation entry key,
@@ -587,12 +589,15 @@ if __name__ == "__main__":
         """),
         formatter_class=argparse.RawTextHelpFormatter)
     sync_parser.set_defaults(action=sync_action)
-    sync_parser.add_argument('reference', metavar='REFERENCE', help="reference string table",
+    sync_parser.add_argument(
+        'reference', metavar='REFERENCE', help="reference string table",
         type=argparse.FileType(encoding='utf-8', errors='strict'))
-    sync_parser.add_argument('source', metavar='SOURCE', help="string table to sync",
+    sync_parser.add_argument(
+        'source', metavar='SOURCE', help="string table to sync",
         type=argparse.FileType(encoding='utf-8', errors='strict'))
 
-    rename_key_parser = verb_parsers.add_parser('rename-key',
+    rename_key_parser = verb_parsers.add_parser(
+        'rename-key',
         help="rename all occurences of a key within a stringtable and exit",
         description=textwrap.dedent("""\
         Replace all occurances of a translation entry key within the given key,
@@ -602,12 +607,14 @@ if __name__ == "__main__":
         """),
         formatter_class=argparse.RawTextHelpFormatter)
     rename_key_parser.set_defaults(action=rename_key_action)
-    rename_key_parser.add_argument('source', metavar='SOURCE', help="string table to rename old key within",
+    rename_key_parser.add_argument(
+        'source', metavar='SOURCE', help="string table to rename old key within",
         type=argparse.FileType(encoding='utf-8', errors='strict'))
     rename_key_parser.add_argument('old_key', metavar='OLD_KEY', help="key to rename")
     rename_key_parser.add_argument('new_key', metavar='NEW_KEY', help="new key name")
 
-    check_parser = verb_parsers.add_parser('check',
+    check_parser = verb_parsers.add_parser(
+        'check',
         help="check a stringtable for consistency and exit",
         description=textwrap.dedent("""\
         Check if all references within translation entries are provided by the source or
@@ -615,13 +622,16 @@ if __name__ == "__main__":
         """),
         formatter_class=argparse.RawTextHelpFormatter)
     check_parser.set_defaults(action=check_action)
-    check_parser.add_argument('-r', '--reference', metavar='REFERENCE', help="reference string table",
+    check_parser.add_argument(
+        '-r', '--reference', metavar='REFERENCE', help="reference string table",
         type=argparse.FileType(encoding='utf-8', errors='strict'))
-    check_parser.add_argument('sources', metavar='SOURCES', help="string tables to check",
+    check_parser.add_argument(
+        'sources', metavar='SOURCES', help="string tables to check",
         nargs='+',
         type=argparse.FileType(encoding='utf-8', errors='strict'))
 
-    compare_parser = verb_parsers.add_parser('compare',
+    compare_parser = verb_parsers.add_parser(
+        'compare',
         help="compare two string tables and exit",
         description=textwrap.dedent("""\
         Compare two string tables and point out differences between them.
@@ -629,9 +639,11 @@ if __name__ == "__main__":
         formatter_class=argparse.RawTextHelpFormatter)
     compare_parser.set_defaults(action=compare_action)
     compare_parser.add_argument('-s', '--summary-only', help="print only a summary of differences", action='store_true', dest='summary_only')
-    compare_parser.add_argument('reference', metavar='REFERENCE', help="reference string table",
+    compare_parser.add_argument(
+        'reference', metavar='REFERENCE', help="reference string table",
         type=argparse.FileType(encoding='utf-8', errors='strict'))
-    compare_parser.add_argument('source', metavar='SOURCE', help="string table to compare",
+    compare_parser.add_argument(
+        'source', metavar='SOURCE', help="string table to compare",
         type=argparse.FileType(encoding='utf-8', errors='strict'))
 
     args = root_parser.parse_args()

--- a/cmake/make_versioncpp.py
+++ b/cmake/make_versioncpp.py
@@ -60,7 +60,7 @@ class Generator(object):
         try:
             with open(self.infile) as template_file:
                 template = Template(template_file.read())
-        except:
+        except IOError:
             print("WARNING: Can't access %s, %s not updated!" % (self.infile, self.outfile))
             return
 
@@ -136,7 +136,7 @@ try:
     commit = check_output(["git", "show", "-s", "--format=%h", "--abbrev=7", "HEAD"], universal_newlines=True).strip()
     timestamp = float(check_output(["git", "show", "-s", "--format=%ct", "HEAD"], universal_newlines=True).strip())
     build_no = ".".join([datetime.utcfromtimestamp(timestamp).strftime("%Y-%m-%d"), commit])
-except:
+except IOError:
     print("WARNING: git not installed or not setup correctly")
 
 for generator in generators:

--- a/default/scripting/buildings/colonies/SP_ABADDONI.focs.txt
+++ b/default/scripting/buildings/colonies/SP_ABADDONI.focs.txt
@@ -64,7 +64,7 @@ BuildingType
     ]
     effectsgroups = [
         [[LIFECYCLE_MANIP_POPULATION_EFFECTS("SP_ABADDONI")]]
-        
+
         EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
@@ -82,7 +82,7 @@ BuildingType
                     ]
                     empire = Source.Owner
             ]
-            
+
         EffectsGroup
             scope = Source
             activation = Turn low = Source.CreationTurn + 2

--- a/default/scripting/buildings/colonies/SP_BANFORO.focs.txt
+++ b/default/scripting/buildings/colonies/SP_BANFORO.focs.txt
@@ -90,7 +90,7 @@ BuildingType
     ]
     effectsgroups = [
         [[LIFECYCLE_MANIP_POPULATION_EFFECTS("SP_BANFORO")]]
-        
+
         EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
@@ -108,7 +108,7 @@ BuildingType
                     ]
                     empire = Source.Owner
             ]
-            
+
         EffectsGroup
             scope = Source
             activation = Turn low = Source.CreationTurn + 2

--- a/default/scripting/buildings/colonies/SP_CHATO.focs.txt
+++ b/default/scripting/buildings/colonies/SP_CHATO.focs.txt
@@ -64,7 +64,7 @@ BuildingType
     ]
     effectsgroups = [
         [[LIFECYCLE_MANIP_POPULATION_EFFECTS("SP_CHATO")]]
-        
+
         EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
@@ -82,7 +82,7 @@ BuildingType
                     ]
                     empire = Source.Owner
             ]
-            
+
         EffectsGroup
             scope = Source
             activation = Turn low = Source.CreationTurn + 2

--- a/default/scripting/buildings/colonies/SP_CRAY.focs.txt
+++ b/default/scripting/buildings/colonies/SP_CRAY.focs.txt
@@ -64,7 +64,7 @@ BuildingType
     ]
     effectsgroups = [
         [[LIFECYCLE_MANIP_POPULATION_EFFECTS("SP_CRAY")]]
-        
+
         EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
@@ -82,7 +82,7 @@ BuildingType
                     ]
                     empire = Source.Owner
             ]
-            
+
         EffectsGroup
             scope = Source
             activation = Turn low = Source.CreationTurn + 2

--- a/default/scripting/buildings/colonies/SP_DERTHREAN.focs.txt
+++ b/default/scripting/buildings/colonies/SP_DERTHREAN.focs.txt
@@ -64,7 +64,7 @@ BuildingType
     ]
     effectsgroups = [
         [[LIFECYCLE_MANIP_POPULATION_EFFECTS("SP_DERTHREAN")]]
-        
+
         EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
@@ -82,7 +82,7 @@ BuildingType
                     ]
                     empire = Source.Owner
             ]
-            
+
         EffectsGroup
             scope = Source
             activation = Turn low = Source.CreationTurn + 2

--- a/default/scripting/buildings/colonies/SP_EAXAW.focs.txt
+++ b/default/scripting/buildings/colonies/SP_EAXAW.focs.txt
@@ -64,7 +64,7 @@ BuildingType
     ]
     effectsgroups = [
         [[LIFECYCLE_MANIP_POPULATION_EFFECTS("SP_EAXAW")]]
-        
+
         EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
@@ -82,7 +82,7 @@ BuildingType
                     ]
                     empire = Source.Owner
             ]
-            
+
         EffectsGroup
             scope = Source
             activation = Turn low = Source.CreationTurn + 2

--- a/default/scripting/buildings/colonies/SP_EGASSEM.focs.txt
+++ b/default/scripting/buildings/colonies/SP_EGASSEM.focs.txt
@@ -64,7 +64,7 @@ BuildingType
     ]
     effectsgroups = [
         [[LIFECYCLE_MANIP_POPULATION_EFFECTS("SP_EGASSEM")]]
-        
+
         EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
@@ -82,7 +82,7 @@ BuildingType
                     ]
                     empire = Source.Owner
             ]
-            
+
         EffectsGroup
             scope = Source
             activation = Turn low = Source.CreationTurn + 2

--- a/default/scripting/buildings/colonies/SP_ETTY.focs.txt
+++ b/default/scripting/buildings/colonies/SP_ETTY.focs.txt
@@ -64,7 +64,7 @@ BuildingType
     ]
     effectsgroups = [
         [[LIFECYCLE_MANIP_POPULATION_EFFECTS("SP_ETTY")]]
-        
+
         EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
@@ -82,7 +82,7 @@ BuildingType
                     ]
                     empire = Source.Owner
             ]
-            
+
         EffectsGroup
             scope = Source
             activation = Turn low = Source.CreationTurn + 2

--- a/default/scripting/buildings/colonies/SP_EXOBOT.focs.txt
+++ b/default/scripting/buildings/colonies/SP_EXOBOT.focs.txt
@@ -25,7 +25,7 @@ BuildingType
     ]
     effectsgroups = [
         [[LIFECYCLE_MANIP_POPULATION_EFFECTS("SP_EXOBOT")]]
-        
+
         EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
@@ -43,7 +43,7 @@ BuildingType
                     ]
                     empire = Source.Owner
             ]
-            
+
         EffectsGroup
             scope = Source
             activation = Turn low = Source.CreationTurn + 2

--- a/default/scripting/buildings/colonies/SP_FULVER.focs.txt
+++ b/default/scripting/buildings/colonies/SP_FULVER.focs.txt
@@ -64,7 +64,7 @@ BuildingType
     ]
     effectsgroups = [
         [[LIFECYCLE_MANIP_POPULATION_EFFECTS("SP_FULVER")]]
-        
+
         EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
@@ -82,7 +82,7 @@ BuildingType
                     ]
                     empire = Source.Owner
             ]
-            
+
         EffectsGroup
             scope = Source
             activation = Turn low = Source.CreationTurn + 2

--- a/default/scripting/buildings/colonies/SP_FURTHEST.focs.txt
+++ b/default/scripting/buildings/colonies/SP_FURTHEST.focs.txt
@@ -64,7 +64,7 @@ BuildingType
     ]
     effectsgroups = [
         [[LIFECYCLE_MANIP_POPULATION_EFFECTS("SP_FURTHEST")]]
-        
+
         EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
@@ -82,7 +82,7 @@ BuildingType
                     ]
                     empire = Source.Owner
             ]
-            
+
         EffectsGroup
             scope = Source
             activation = Turn low = Source.CreationTurn + 2

--- a/default/scripting/buildings/colonies/SP_GEORGE.focs.txt
+++ b/default/scripting/buildings/colonies/SP_GEORGE.focs.txt
@@ -64,7 +64,7 @@ BuildingType
     ]
     effectsgroups = [
         [[LIFECYCLE_MANIP_POPULATION_EFFECTS("SP_GEORGE")]]
-        
+
         EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
@@ -82,7 +82,7 @@ BuildingType
                     ]
                     empire = Source.Owner
             ]
-            
+
         EffectsGroup
             scope = Source
             activation = Turn low = Source.CreationTurn + 2

--- a/default/scripting/buildings/colonies/SP_GYSACHE.focs.txt
+++ b/default/scripting/buildings/colonies/SP_GYSACHE.focs.txt
@@ -64,7 +64,7 @@ BuildingType
     ]
     effectsgroups = [
         [[LIFECYCLE_MANIP_POPULATION_EFFECTS("SP_GYSACHE")]]
-        
+
         EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
@@ -82,7 +82,7 @@ BuildingType
                     ]
                     empire = Source.Owner
             ]
-            
+
         EffectsGroup
             scope = Source
             activation = Turn low = Source.CreationTurn + 2

--- a/default/scripting/buildings/colonies/SP_HAPPY.focs.txt
+++ b/default/scripting/buildings/colonies/SP_HAPPY.focs.txt
@@ -64,7 +64,7 @@ BuildingType
     ]
     effectsgroups = [
         [[LIFECYCLE_MANIP_POPULATION_EFFECTS("SP_HAPPY")]]
-        
+
         EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
@@ -82,7 +82,7 @@ BuildingType
                     ]
                     empire = Source.Owner
             ]
-            
+
         EffectsGroup
             scope = Source
             activation = Turn low = Source.CreationTurn + 2

--- a/default/scripting/buildings/colonies/SP_HHHOH.focs.txt
+++ b/default/scripting/buildings/colonies/SP_HHHOH.focs.txt
@@ -64,7 +64,7 @@ BuildingType
     ]
     effectsgroups = [
         [[LIFECYCLE_MANIP_POPULATION_EFFECTS("SP_HHHOH")]]
-        
+
         EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
@@ -82,7 +82,7 @@ BuildingType
                     ]
                     empire = Source.Owner
             ]
-            
+
         EffectsGroup
             scope = Source
             activation = Turn low = Source.CreationTurn + 2

--- a/default/scripting/buildings/colonies/SP_HUMAN.focs.txt
+++ b/default/scripting/buildings/colonies/SP_HUMAN.focs.txt
@@ -64,7 +64,7 @@ BuildingType
     ]
     effectsgroups = [
         [[LIFECYCLE_MANIP_POPULATION_EFFECTS("SP_HUMAN")]]
-        
+
         EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
@@ -82,7 +82,7 @@ BuildingType
                     ]
                     empire = Source.Owner
             ]
-            
+
         EffectsGroup
             scope = Source
             activation = Turn low = Source.CreationTurn + 2

--- a/default/scripting/buildings/colonies/SP_KILANDOW.focs.txt
+++ b/default/scripting/buildings/colonies/SP_KILANDOW.focs.txt
@@ -90,7 +90,7 @@ BuildingType
     ]
     effectsgroups = [
         [[LIFECYCLE_MANIP_POPULATION_EFFECTS("SP_KILANDOW")]]
-        
+
         EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
@@ -108,7 +108,7 @@ BuildingType
                     ]
                     empire = Source.Owner
             ]
-            
+
         EffectsGroup
             scope = Source
             activation = Turn low = Source.CreationTurn + 2

--- a/default/scripting/buildings/colonies/SP_KOBUNTURA.focs.txt
+++ b/default/scripting/buildings/colonies/SP_KOBUNTURA.focs.txt
@@ -64,7 +64,7 @@ BuildingType
     ]
     effectsgroups = [
         [[LIFECYCLE_MANIP_POPULATION_EFFECTS("SP_KOBUNTURA")]]
-        
+
         EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
@@ -82,7 +82,7 @@ BuildingType
                     ]
                     empire = Source.Owner
             ]
-            
+
         EffectsGroup
             scope = Source
             activation = Turn low = Source.CreationTurn + 2

--- a/default/scripting/buildings/colonies/SP_LAENFA.focs.txt
+++ b/default/scripting/buildings/colonies/SP_LAENFA.focs.txt
@@ -64,7 +64,7 @@ BuildingType
     ]
     effectsgroups = [
         [[LIFECYCLE_MANIP_POPULATION_EFFECTS("SP_LAENFA")]]
-        
+
         EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
@@ -82,7 +82,7 @@ BuildingType
                     ]
                     empire = Source.Owner
             ]
-            
+
         EffectsGroup
             scope = Source
             activation = Turn low = Source.CreationTurn + 2

--- a/default/scripting/buildings/colonies/SP_MISIORLA.focs.txt
+++ b/default/scripting/buildings/colonies/SP_MISIORLA.focs.txt
@@ -90,7 +90,7 @@ BuildingType
     ]
     effectsgroups = [
         [[LIFECYCLE_MANIP_POPULATION_EFFECTS("SP_MISIORLA")]]
-        
+
         EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
@@ -108,7 +108,7 @@ BuildingType
                     ]
                     empire = Source.Owner
             ]
-            
+
         EffectsGroup
             scope = Source
             activation = Turn low = Source.CreationTurn + 2

--- a/default/scripting/buildings/colonies/SP_MUURSH.focs.txt
+++ b/default/scripting/buildings/colonies/SP_MUURSH.focs.txt
@@ -64,7 +64,7 @@ BuildingType
     ]
     effectsgroups = [
         [[LIFECYCLE_MANIP_POPULATION_EFFECTS("SP_MUURSH")]]
-        
+
         EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
@@ -82,7 +82,7 @@ BuildingType
                     ]
                     empire = Source.Owner
             ]
-            
+
         EffectsGroup
             scope = Source
             activation = Turn low = Source.CreationTurn + 2

--- a/default/scripting/buildings/colonies/SP_PHINNERT.focs.txt
+++ b/default/scripting/buildings/colonies/SP_PHINNERT.focs.txt
@@ -64,7 +64,7 @@ BuildingType
     ]
     effectsgroups = [
         [[LIFECYCLE_MANIP_POPULATION_EFFECTS("SP_PHINNERT")]]
-        
+
         EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
@@ -82,7 +82,7 @@ BuildingType
                     ]
                     empire = Source.Owner
             ]
-            
+
         EffectsGroup
             scope = Source
             activation = Turn low = Source.CreationTurn + 2

--- a/default/scripting/buildings/colonies/SP_REPLICON.focs.txt
+++ b/default/scripting/buildings/colonies/SP_REPLICON.focs.txt
@@ -64,7 +64,7 @@ BuildingType
     ]
     effectsgroups = [
         [[LIFECYCLE_MANIP_POPULATION_EFFECTS("SP_REPLICON")]]
-        
+
         EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
@@ -82,7 +82,7 @@ BuildingType
                     ]
                     empire = Source.Owner
             ]
-            
+
         EffectsGroup
             scope = Source
             activation = Turn low = Source.CreationTurn + 2

--- a/default/scripting/buildings/colonies/SP_SCYLIOR.focs.txt
+++ b/default/scripting/buildings/colonies/SP_SCYLIOR.focs.txt
@@ -64,7 +64,7 @@ BuildingType
     ]
     effectsgroups = [
         [[LIFECYCLE_MANIP_POPULATION_EFFECTS("SP_SCYLIOR")]]
-        
+
         EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
@@ -82,7 +82,7 @@ BuildingType
                     ]
                     empire = Source.Owner
             ]
-            
+
         EffectsGroup
             scope = Source
             activation = Turn low = Source.CreationTurn + 2

--- a/default/scripting/buildings/colonies/SP_SETINON.focs.txt
+++ b/default/scripting/buildings/colonies/SP_SETINON.focs.txt
@@ -64,7 +64,7 @@ BuildingType
     ]
     effectsgroups = [
         [[LIFECYCLE_MANIP_POPULATION_EFFECTS("SP_SETINON")]]
-        
+
         EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
@@ -82,7 +82,7 @@ BuildingType
                     ]
                     empire = Source.Owner
             ]
-            
+
         EffectsGroup
             scope = Source
             activation = Turn low = Source.CreationTurn + 2

--- a/default/scripting/buildings/colonies/SP_SILEXIAN.focs.txt
+++ b/default/scripting/buildings/colonies/SP_SILEXIAN.focs.txt
@@ -64,7 +64,7 @@ BuildingType
     ]
     effectsgroups = [
         [[LIFECYCLE_MANIP_POPULATION_EFFECTS("SP_SILEXIAN")]]
-        
+
         EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
@@ -82,7 +82,7 @@ BuildingType
                     ]
                     empire = Source.Owner
             ]
-            
+
         EffectsGroup
             scope = Source
             activation = Turn low = Source.CreationTurn + 2

--- a/default/scripting/buildings/colonies/SP_SLY.focs.txt
+++ b/default/scripting/buildings/colonies/SP_SLY.focs.txt
@@ -64,7 +64,7 @@ BuildingType
     ]
     effectsgroups = [
         [[LIFECYCLE_MANIP_POPULATION_EFFECTS("SP_SLY")]]
-        
+
         EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
@@ -82,7 +82,7 @@ BuildingType
                     ]
                     empire = Source.Owner
             ]
-            
+
         EffectsGroup
             scope = Source
             activation = Turn low = Source.CreationTurn + 2

--- a/default/scripting/buildings/colonies/SP_SSLITH.focs.txt
+++ b/default/scripting/buildings/colonies/SP_SSLITH.focs.txt
@@ -64,7 +64,7 @@ BuildingType
     ]
     effectsgroups = [
         [[LIFECYCLE_MANIP_POPULATION_EFFECTS("SP_SSLITH")]]
-        
+
         EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
@@ -82,7 +82,7 @@ BuildingType
                     ]
                     empire = Source.Owner
             ]
-            
+
         EffectsGroup
             scope = Source
             activation = Turn low = Source.CreationTurn + 2

--- a/default/scripting/buildings/colonies/SP_SUPER_TEST.focs.txt
+++ b/default/scripting/buildings/colonies/SP_SUPER_TEST.focs.txt
@@ -66,7 +66,7 @@ BuildingType
     ]
     effectsgroups = [
         [[LIFECYCLE_MANIP_POPULATION_EFFECTS("SP_SUPER_TEST")]]
-        
+
         EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
@@ -84,7 +84,7 @@ BuildingType
                     ]
                     empire = Source.Owner
             ]
-            
+
         EffectsGroup
             scope = Source
             activation = Turn low = Source.CreationTurn + 2

--- a/default/scripting/buildings/colonies/SP_TAEGHIRUS.focs.txt
+++ b/default/scripting/buildings/colonies/SP_TAEGHIRUS.focs.txt
@@ -64,7 +64,7 @@ BuildingType
     ]
     effectsgroups = [
         [[LIFECYCLE_MANIP_POPULATION_EFFECTS("SP_TAEGHIRUS")]]
-        
+
         EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
@@ -82,7 +82,7 @@ BuildingType
                     ]
                     empire = Source.Owner
             ]
-            
+
         EffectsGroup
             scope = Source
             activation = Turn low = Source.CreationTurn + 2

--- a/default/scripting/buildings/colonies/SP_TRITH.focs.txt
+++ b/default/scripting/buildings/colonies/SP_TRITH.focs.txt
@@ -64,7 +64,7 @@ BuildingType
     ]
     effectsgroups = [
         [[LIFECYCLE_MANIP_POPULATION_EFFECTS("SP_TRITH")]]
-        
+
         EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
@@ -82,7 +82,7 @@ BuildingType
                     ]
                     empire = Source.Owner
             ]
-            
+
         EffectsGroup
             scope = Source
             activation = Turn low = Source.CreationTurn + 2

--- a/default/scripting/buildings/colonies/SP_UGMORS.focs.txt
+++ b/default/scripting/buildings/colonies/SP_UGMORS.focs.txt
@@ -64,7 +64,7 @@ BuildingType
     ]
     effectsgroups = [
         [[LIFECYCLE_MANIP_POPULATION_EFFECTS("SP_UGMORS")]]
-        
+
         EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
@@ -82,7 +82,7 @@ BuildingType
                     ]
                     empire = Source.Owner
             ]
-            
+
         EffectsGroup
             scope = Source
             activation = Turn low = Source.CreationTurn + 2

--- a/default/scripting/buildings/colonies/col_bld_gen.py
+++ b/default/scripting/buildings/colonies/col_bld_gen.py
@@ -108,7 +108,7 @@ BuildingType
     ]
     effectsgroups = [
         [[LIFECYCLE_MANIP_POPULATION_EFFECTS("${id}")]]
-        
+
         EffectsGroup
             scope = And [
                 Object id = Source.PlanetID
@@ -126,7 +126,7 @@ BuildingType
                     ]
                     empire = Source.Owner
             ]
-            
+
         EffectsGroup
             scope = Source
             activation = Turn low = Source.CreationTurn + 2

--- a/msvc2017/update_stdafx.py
+++ b/msvc2017/update_stdafx.py
@@ -1,12 +1,11 @@
-#!/usr/bin/env python2
+#!/usr/bin/python3
 
-import sys
 import os
 import re
 
 MIN_CPP_INCLUDE_COUNT = 5
-EXCLUDE_LIBS          = ["GG"]
-IGNORE_INCLUDES       = ["StdAfx.h", "stdafx.h"]
+EXCLUDE_LIBS = ["GG"]
+IGNORE_INCLUDES = ["StdAfx.h", "stdafx.h"]
 
 PREAMBLE = """
 #pragma once
@@ -14,7 +13,7 @@ PREAMBLE = """
 // We include all external headers used in any of the header files,
 // plus external headers used in at least five .cpp files.
 
-// https://hownot2code.com/2016/08/16/stdafx-h/ 
+// https://hownot2code.com/2016/08/16/stdafx-h/
 
 """
 
@@ -30,9 +29,9 @@ POSTAMBLE = """
 
 
 def find_files_from_vcxproj(vcxproj, includetype, fileextension):
-    pattern         = "^\s*<" + includetype + "\s+Include=\"(?P<include>[^\"]+" + fileextension + ")\"\s*/>"
+    pattern = r"^\s*<" + includetype + r"\s+Include=\"(?P<include>[^\"]+" + fileextension + r")\"\s*/>"
     vcxproj_pattern = re.compile(pattern)
-    base_path       = os.path.dirname(vcxproj)
+    base_path = os.path.dirname(vcxproj)
 
     with open(vcxproj) as f:
         for i, line in enumerate(f):
@@ -40,15 +39,17 @@ def find_files_from_vcxproj(vcxproj, includetype, fileextension):
             if match and match.group('include') not in IGNORE_INCLUDES:
                 yield os.path.join(base_path, match.group('include'))
 
-include_pattern = re.compile("^#include[ \t]+<(?P<include>(?:(?P<lib>[^/>]+)/)?[^>]+)>")
-ifdef_pattern = re.compile("^\s*#if(?:def)?\s")
-endif_pattern = re.compile("^\s*#endif")
 
-def find_includes_from_cpp_or_h(filename): 
+include_pattern = re.compile(r"^#include[ \t]+<(?P<include>(?:(?P<lib>[^/>]+)/)?[^>]+)>")
+ifdef_pattern = re.compile(r"^\s*#if(?:def)?\s")
+endif_pattern = re.compile(r"^\s*#endif")
+
+
+def find_includes_from_cpp_or_h(filename):
     if_nesting_level = 0
     with open(filename) as f:
         for i, line in enumerate(f):
-            if  ifdef_pattern.match(line):
+            if ifdef_pattern.match(line):
                 if_nesting_level += 1
             elif endif_pattern.match(line):
                 if_nesting_level -= 1
@@ -57,16 +58,17 @@ def find_includes_from_cpp_or_h(filename):
                 if match and match.group('include') not in IGNORE_INCLUDES:
                     yield (match.group('include'), match.group('lib'))
 
+
 def assemble_precompile_header_includes(headeronly_vcxproj_files, vcxproj_files):
-    headers_includes = { }
-    cpp_includes     = { }
+    headers_includes = {}
+    cpp_includes = {}
 
     index = -1
     for vcxproj in (headeronly_vcxproj_files + vcxproj_files):
         index = index + 1
         for include_file in find_files_from_vcxproj(vcxproj, "ClInclude", ".h"):
             for include, lib in find_includes_from_cpp_or_h(include_file):
-                if include in headers_includes: 
+                if include in headers_includes:
                     continue
                 headers_includes[include] = (index, vcxproj, lib)
 
@@ -75,8 +77,8 @@ def assemble_precompile_header_includes(headeronly_vcxproj_files, vcxproj_files)
         index = index + 1
         for include_file in find_files_from_vcxproj(vcxproj, "ClCompile", ".cpp"):
             for include, lib in find_includes_from_cpp_or_h(include_file):
-                if not include in cpp_includes: 
-                    cpp_includes[include]    = [index, vcxproj, lib, 1]
+                if include not in cpp_includes:
+                    cpp_includes[include] = [index, vcxproj, lib, 1]
                 else:
                     cpp_includes[include][3] = cpp_includes[include][3] + 1
 
@@ -84,54 +86,54 @@ def assemble_precompile_header_includes(headeronly_vcxproj_files, vcxproj_files)
                 headers_includes[include][0],
                 headers_includes[include][1],
                 headers_includes[include][2],
-                include, 
-                0) for include in headers_includes]   
+                include,
+                0) for include in headers_includes]
     headers.sort()
 
-    cpps   = [('includes from .cpp', 
-                cpp_includes[include][0],
-                cpp_includes[include][1],
-                cpp_includes[include][2],
-                include,
-                cpp_includes[include][3]
-                ) for include in cpp_includes
-                         if not include in headers_includes 
-                            and cpp_includes[include][3] >= MIN_CPP_INCLUDE_COUNT
-            ]
+    cpps = [
+        (
+            'includes from .cpp',
+            cpp_includes[include][0],
+            cpp_includes[include][1],
+            cpp_includes[include][2],
+            include,
+            cpp_includes[include][3]
+        ) for include in cpp_includes
+        if include not in headers_includes
+        and cpp_includes[include][3] >= MIN_CPP_INCLUDE_COUNT
+    ]
     cpps.sort()
 
     return headers + cpps
 
+
 def update_stdafx_h(stdafx_h_filename, header_only_vcxproj_files, vcxproj_files):
     last_type = ""
     last_proj = ""
-    last_lib  = None
+    last_lib = None
 
     lines = []
 
-    for type, index, proj, lib, include, count in assemble_precompile_header_includes(header_only_vcxproj_files, vcxproj_files):
-        
+    for type, index, proj, lib, include, count \
+            in assemble_precompile_header_includes(header_only_vcxproj_files, vcxproj_files):
         if lib in EXCLUDE_LIBS:
             continue
         if type != last_type:
             if last_type:
                 lines.append("")
-            lines.append("// " + '-' * len(type)) 
-            lines.append("// " + type) 
+            lines.append("// " + '-' * len(type))
+            lines.append("// " + type)
             last_type = type
         if last_proj != proj:
-            lines.append("") 
+            lines.append("")
             lines.append("// " + os.path.splitext(os.path.basename(proj))[0])
             last_proj = proj
         if last_lib != lib:
             if lib:
-                lines.append("") 
+                lines.append("")
             last_lib = lib
 
         include_directive = "#include <" + include + ">"
-        #if count > 0:
-        #    include_directive += ' ' * max(50 - len(include_directive), 0)
-        #    include_directive += " // included in " + str(count) + " .cpp files"
 
         lines.append(include_directive)
 
@@ -140,12 +142,13 @@ def update_stdafx_h(stdafx_h_filename, header_only_vcxproj_files, vcxproj_files)
         f.write("\n".join(lines))
         f.write(POSTAMBLE)
 
-update_stdafx_h("Parsers/StdAfx.h",    [], ["Parsers/Parsers.vcxproj"])
-update_stdafx_h("Common/StdAfx.h",     [], ["Common/Common.vcxproj"])
 
-update_stdafx_h("FreeOrion/StdAfx.h",  ["Common/Common.vcxproj", "GiGi/GiGi.vcxproj"],
-                                       ["FreeOrion/FreeOrion.vcxproj"])
-update_stdafx_h("FreeOrionD/StdAfx.h", ["Common/Common.vcxproj"],   ["FreeOrionD/FreeOrionD.vcxproj"])
-update_stdafx_h("FreeOrionCA/StdAfx.h",["Common/Common.vcxproj"],   ["FreeOrionCA/FreeOrionCA.vcxproj"])
+update_stdafx_h("Parsers/StdAfx.h",     [], ["Parsers/Parsers.vcxproj"])
+update_stdafx_h("Common/StdAfx.h",      [], ["Common/Common.vcxproj"])
 
-update_stdafx_h("GiGi/StdAfx.h",       [],                    ["GiGi/GiGi.vcxproj"])
+update_stdafx_h("FreeOrion/StdAfx.h",   ["Common/Common.vcxproj", "GiGi/GiGi.vcxproj"],
+                                        ["FreeOrion/FreeOrion.vcxproj"])
+update_stdafx_h("FreeOrionD/StdAfx.h",  ["Common/Common.vcxproj"],   ["FreeOrionD/FreeOrionD.vcxproj"])
+update_stdafx_h("FreeOrionCA/StdAfx.h", ["Common/Common.vcxproj"],   ["FreeOrionCA/FreeOrionCA.vcxproj"])
+
+update_stdafx_h("GiGi/StdAfx.h",        [],                    ["GiGi/GiGi.vcxproj"])


### PR DESCRIPTION
This PR takes the various utilitiy scripts located across the source tree and makes them PEP-8 compliant according to the Flake8 configuration used in the CI linting job.

Those scripts are currently not covered by CI as the job only checks the files within the `default/python` directory.