### PR TITLE
Use relative pathes for project header includes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -357,8 +357,6 @@ target_compile_definitions(freeorioncommon
 target_include_directories(freeorioncommon SYSTEM
     PUBLIC
         $<TARGET_PROPERTY:GiGi::GiGi,INCLUDE_DIRECTORIES>
-    PRIVATE
-        ${CMAKE_SOURCE_DIR}
 )
 
 target_link_libraries(freeorioncommon

--- a/Empire/PopulationPool.cpp
+++ b/Empire/PopulationPool.cpp
@@ -1,8 +1,8 @@
 #include "PopulationPool.h"
 
-#include "universe/Enums.h"
-#include "universe/PopCenter.h"
-#include "util/AppInterface.h"
+#include "../universe/Enums.h"
+#include "../universe/PopCenter.h"
+#include "../util/AppInterface.h"
 
 PopulationPool::PopulationPool()
 {}

--- a/msvc2017/Common/Common.vcxproj
+++ b/msvc2017/Common/Common.vcxproj
@@ -114,7 +114,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_USRDLL;FREEORION_WIN32;_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>../../../include/;../../GG/;../../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../../../include/;../../GG/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <WholeProgramOptimization>false</WholeProgramOptimization>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
@@ -135,7 +135,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_USRDLL;FREEORION_WIN32;_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>../../../include/;../../GG/;../../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../../../include/;../../GG/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <WholeProgramOptimization>false</WholeProgramOptimization>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>

--- a/msvc2017/Parsers/Parsers.vcxproj
+++ b/msvc2017/Parsers/Parsers.vcxproj
@@ -109,7 +109,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_USRDLL;PARSERS_EXPORTS;FREEORION_WIN32;_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>../../../include/;../../GG/;../../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../../../include/;../../GG/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)$(TargetName).pch</PrecompiledHeaderOutputFile>
@@ -140,7 +140,7 @@
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_USRDLL;PARSERS_EXPORTS;FREEORION_WIN32;_DLL;%(PreprocessorDefinitions)</PreprocessorDefinitions>
-      <AdditionalIncludeDirectories>../../../include/;../../GG/;../../;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>../../../include/;../../GG/;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
       <PrecompiledHeaderFile>StdAfx.h</PrecompiledHeaderFile>
       <PrecompiledHeaderOutputFile>$(IntDir)$(TargetName).pch</PrecompiledHeaderOutputFile>

--- a/util/EnumText.cpp
+++ b/util/EnumText.cpp
@@ -1,6 +1,6 @@
 #include "EnumText.h"
 
-#include "util/i18n.h"
+#include "i18n.h"
 
 namespace{
     const std::string EMPTY_STRING;

--- a/util/OptionsDB.cpp
+++ b/util/OptionsDB.cpp
@@ -1,11 +1,10 @@
 #include "OptionsDB.h"
 
+#include "Directories.h"
 #include "i18n.h"
 #include "Logger.h"
 #include "OptionValidators.h"
 #include "XMLDoc.h"
-
-#include "util/Directories.h"
 
 #include <iostream>
 #include <iomanip>

--- a/util/Version.cpp.in
+++ b/util/Version.cpp.in
@@ -1,4 +1,4 @@
-#include "util/Version.h"
+#include "Version.h"
 
 //! @file
 //!     Implement a free function to access the application version.


### PR DESCRIPTION
This PR removes the rarely used ability to include project header files relative to the project root  by removing the project root from the include search path.

This makes the usage of includes a bit more consistent.