### PR TITLE
Add CMake target for ClangFormat check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,8 +31,15 @@ _linux_setup_common: &_linux_setup_common
       libsdl2-dev
       libvorbis-dev
       cppcheck
+      clang-format-10
       doxygen
+      python3-colorama
       python3-pip
+    - >
+      sudo update-alternatives
+      --install /usr/bin/clang-format clang-format /usr/bin/clang-format-10 100
+      --slave /usr/bin/clang-format-diff clang-format-diff /usr/bin/clang-format-diff-10
+      --slave /usr/bin/git-clang-format git-clang-format /usr/bin/git-clang-format-10
     - python3 -m pip install flake8==3.7.9
   before_script:
     - mkdir build
@@ -55,6 +62,14 @@ _test_python_common: &_test_python_common
 
 jobs:
   include:
+    - name: Lint C++ code with clang-format
+      <<: *_linux_setup_common
+      stage: lint
+      script:
+        - cmake ..
+        - cmake --build . --target check-cpp-format
+      after_success: ~
+
     - name: Lint AI with Python 3.5
       <<: *_linux_setup_common
       stage: lint

--- a/Empire/InfluenceQueue.cpp
+++ b/Empire/InfluenceQueue.cpp
@@ -12,67 +12,67 @@
 
 
 namespace {
-    const float EPSILON = 0.01f;
 
-    //void AddRules(GameRules& rules)
-    //{}
-    //bool temp_bool = RegisterGameRules(&AddRules);
+const float EPSILON = 0.01f;
 
-    //float CalculateNewInfluenceStockpile(int empire_id, float starting_stockpile, float project_transfer_to_stockpile,
-    //                                     float available_IP, float allocated_IP, float allocated_stockpile_IP)
-    //{
-    //    TraceLogger() << "CalculateNewInfluenceStockpile for empire " << empire_id;
-    //    const Empire* empire = GetEmpire(empire_id);
-    //    if (!empire) {
-    //        ErrorLogger() << "CalculateNewInfluenceStockpile() passed null empire.  doing nothing.";
-    //        return 0.0f;
-    //    }
-    //    TraceLogger() << " ... stockpile used: " << allocated_stockpile_IP;
-    //    float new_contributions = available_IP - allocated_IP;
-    //    return starting_stockpile + new_contributions + project_transfer_to_stockpile - allocated_stockpile_IP;
-    //}
+//void AddRules(GameRules& rules)
+//{}
+//bool temp_bool = RegisterGameRules(&AddRules);
 
-    const InfluenceQueue::Element EMPTY_ELEMENT;
+//float CalculateNewInfluenceStockpile(int empire_id, float starting_stockpile, float project_transfer_to_stockpile,
+//                                     float available_IP, float allocated_IP, float allocated_stockpile_IP)
+//{
+//    TraceLogger() << "CalculateNewInfluenceStockpile for empire " << empire_id;
+//    const Empire* empire = GetEmpire(empire_id);
+//    if (!empire) {
+//        ErrorLogger() << "CalculateNewInfluenceStockpile() passed null empire.  doing nothing.";
+//        return 0.0f;
+//    }
+//    TraceLogger() << " ... stockpile used: " << allocated_stockpile_IP;
+//    float new_contributions = available_IP - allocated_IP;
+//    return starting_stockpile + new_contributions + project_transfer_to_stockpile - allocated_stockpile_IP;
+//}
 
-    /** Sets the allocated_IP value for each Element in the passed
-      * InfluenceQueue \a queue. Elements are allocated IP based on their need,
-      * the limits they can be given per turn, and the amount available to the
-      * empire. Also checks if elements will be completed this turn. */
-    //void SetInfluenceQueueElementSpending(
-    //    float available_IP, float available_stockpile,
-    //    InfluenceQueue::QueueType& queue,
-    //    float& allocated_IP, float& allocated_stockpile_IP,
-    //    int& projects_in_progress, bool simulating)
-    //{
-    //    projects_in_progress = 0;
-    //    allocated_IP = 0.0f;
-    //    allocated_stockpile_IP = 0.0f;
+const InfluenceQueue::Element EMPTY_ELEMENT;
 
-    //    float dummy_IP_source = 0.0f;
-    //    float stockpile_transfer = 0.0f;
+/** Sets the allocated_IP value for each Element in the passed
+    * InfluenceQueue \a queue. Elements are allocated IP based on their need,
+    * the limits they can be given per turn, and the amount available to the
+    * empire. Also checks if elements will be completed this turn. */
+//void SetInfluenceQueueElementSpending(
+//    float available_IP, float available_stockpile,
+//    InfluenceQueue::QueueType& queue,
+//    float& allocated_IP, float& allocated_stockpile_IP,
+//    int& projects_in_progress, bool simulating)
+//{
+//    projects_in_progress = 0;
+//    allocated_IP = 0.0f;
+//    allocated_stockpile_IP = 0.0f;
 
-    //    //DebugLogger() << "queue size: " << queue.size();
-    //    int i = 0;
-    //    for (auto& queue_element : queue) {
-    //        queue_element.allocated_ip = 0.0f;  // default, to be updated below...
-    //        if (queue_element.paused) {
-    //            TraceLogger() << "allocation: " << queue_element.allocated_ip
-    //                          << "  to: " << queue_element.name
-    //                          << "  due to it being paused";
-    //            ++i;
-    //            continue;
-    //        }
+//    float dummy_IP_source = 0.0f;
+//    float stockpile_transfer = 0.0f;
 
-    //        ++i;
-    //    }
-    //}
+//    //DebugLogger() << "queue size: " << queue.size();
+//    int i = 0;
+//    for (auto& queue_element : queue) {
+//        queue_element.allocated_ip = 0.0f;  // default, to be updated below...
+//        if (queue_element.paused) {
+//            TraceLogger() << "allocation: " << queue_element.allocated_ip
+//                          << "  to: " << queue_element.name
+//                          << "  due to it being paused";
+//            ++i;
+//            continue;
+//        }
+
+//        ++i;
+//    }
+//}
+
 }
 
 
-/////////////////////////////
-// InfluenceQueue::Element //
-/////////////////////////////
-std::string InfluenceQueue::Element::Dump() const {
+auto InfluenceQueue::Element::Dump() const -> std::string
+{
     std::stringstream retval;
     retval << "InfluenceQueue::Element: name: " << name << "  empire id: " << empire_id;
     retval << "  allocated: " << allocated_ip;
@@ -83,30 +83,30 @@ std::string InfluenceQueue::Element::Dump() const {
 }
 
 
-////////////////////
-// InfluenceQueue //
-////////////////////
-bool InfluenceQueue::InQueue(const std::string& name) const {
+auto InfluenceQueue::InQueue(const std::string& name) const -> bool
+{
     return std::any_of(m_queue.begin(), m_queue.end(),
                        [name](const Element& e){ return e.name == name; });
 }
 
-float InfluenceQueue::AllocatedStockpileIP() const
-{ return 0.0f; } // todo
+auto InfluenceQueue::AllocatedStockpileIP() const -> float // todo
+{ return 0.0f; }
 
-InfluenceQueue::const_iterator InfluenceQueue::find(const std::string& item_name) const
+auto InfluenceQueue::find(const std::string& item_name) const -> const_iterator
 { return std::find_if(begin(), end(), [&](const auto& e) { return e.name == item_name; }); }
 
-const InfluenceQueue::Element& InfluenceQueue::operator[](std::size_t i) const {
+auto InfluenceQueue::operator[](std::size_t i) const -> const Element&
+{
     if (i >= m_queue.size())
         return EMPTY_ELEMENT;
     return m_queue[i];
 }
 
-const InfluenceQueue::Element& InfluenceQueue::operator[](int i) const
+auto InfluenceQueue::operator[](int i) const -> const Element&
 { return operator[](static_cast<std::size_t>(i)); }
 
-void InfluenceQueue::Update() {
+void InfluenceQueue::Update()
+{
     const Empire* empire = GetEmpire(m_empire_id);
     if (!empire) {
         ErrorLogger() << "InfluenceQueue::Update passed null empire.  doing nothing.";
@@ -149,22 +149,24 @@ void InfluenceQueue::Update() {
     InfluenceQueueChangedSignal();
 }
 
-void InfluenceQueue::erase(int i) {
+void InfluenceQueue::erase(int i)
+{
     if (i > 0 && i < static_cast<int>(m_queue.size()))
         m_queue.erase(begin() + i);
 }
 
-InfluenceQueue::iterator InfluenceQueue::find(const std::string& item_name)
+auto InfluenceQueue::find(const std::string& item_name) -> iterator
 { return std::find_if(begin(), end(), [&](const auto& e) { return e.name == item_name; }); }
 
-InfluenceQueue::Element& InfluenceQueue::operator[](int i) {
+auto InfluenceQueue::operator[](int i) -> Element&
+{
     assert(0 <= i && i < static_cast<int>(m_queue.size()));
     return m_queue[i];
 }
 
-void InfluenceQueue::clear() {
+void InfluenceQueue::clear()
+{
     m_queue.clear();
     m_projects_in_progress = 0;
     InfluenceQueueChangedSignal();
 }
-

--- a/Empire/InfluenceQueue.h
+++ b/Empire/InfluenceQueue.h
@@ -17,19 +17,25 @@ FO_COMMON_API extern const int INVALID_OBJECT_ID;
 FO_COMMON_API extern const int ALL_EMPIRES;
 
 
-struct FO_COMMON_API InfluenceQueue {
-    /** The type of a single element in the Influence queue. */
-    struct FO_COMMON_API Element {
+struct FO_COMMON_API InfluenceQueue
+{
+    //! The type of a single element in the Influence queue.
+    struct FO_COMMON_API Element
+    {
         explicit Element() = default;
+
         Element(int empire_id_, std::string name_, bool paused_ = false) :
             name(std::move(name_)),
             empire_id(empire_id_),
             paused(paused_)
         {}
 
-        std::string     name;                       ///< name of influence project
+        //! Name of influence project
+        std::string     name;
         int             empire_id = ALL_EMPIRES;
-        float           allocated_ip = 0.0f;        ///< IP allocated to this InfluenceQueue Element by Empire Influence update
+        //! IP allocated to this InfluenceQueue Element by Empire Influence
+        //! update
+        float           allocated_ip = 0.0f;
         bool            paused = false;
 
         std::string Dump() const;
@@ -42,59 +48,83 @@ struct FO_COMMON_API InfluenceQueue {
 
     typedef std::deque<Element> QueueType;
 
-    /** The InfluenceQueue iterator type.  Dereference yields a Element. */
+    //! The InfluenceQueue iterator type.  Dereference yields a Element.
     typedef QueueType::iterator iterator;
-    /** The const InfluenceQueue iterator type.  Dereference yields a Element. */
+
+    //! The const InfluenceQueue iterator type.  Dereference yields a Element.
     typedef QueueType::const_iterator const_iterator;
 
     explicit InfluenceQueue(int empire_id) :
         m_empire_id(empire_id)
     {}
 
-    bool    InQueue(const std::string& name) const;
+    auto InQueue(const std::string& name) const -> bool;
 
-    int     ProjectsInProgress() const { return m_projects_in_progress; }
-    float   TotalIPsSpent() const { return m_total_IPs_spent; };
-    int     EmpireID() const { return m_empire_id; }
+    auto ProjectsInProgress() const -> int
+    { return m_projects_in_progress; }
 
-    /** Returns amount of stockpile IP allocated to Influence queue elements. */
-    float AllocatedStockpileIP() const;
+    auto TotalIPsSpent() const -> float
+    { return m_total_IPs_spent; };
 
-    /** Returns the value expected for the Influence Stockpile for the next
-      * turn, based on the current InfluenceQueue allocations. */
-    float ExpectedNewStockpileAmount() const { return m_expected_new_stockpile_amount; }
+    auto EmpireID() const -> int
+    { return m_empire_id; }
 
+    //! Returns amount of stockpile IP allocated to Influence queue elements.
+    auto AllocatedStockpileIP() const -> float;
 
-    // STL container-like interface
-    bool            empty() const { return m_queue.empty(); }
-    unsigned int    size() const { return m_queue.size(); }
-    const_iterator  begin() const { return m_queue.begin(); }
-    const_iterator  end() const { return m_queue.end(); }
-    const_iterator  find(const std::string& item_name) const;
-    const Element&  operator[](std::size_t i) const;
-    const Element&  operator[](int i) const;
+    //! Returns the value expected for the Influence Stockpile for the next
+    //! turn, based on the current InfluenceQueue allocations.
+    auto ExpectedNewStockpileAmount() const -> float
+    { return m_expected_new_stockpile_amount; }
 
-
-    /** Recalculates the PPs spent on and number of turns left for each project in the queue.  Also
-      * determines the number of projects in progress, and the industry consumed by projects
-      * in each resource-sharing group of systems.  Does not actually "spend" the PP; a later call to
-      * empire->CheckInfluenceProgress() will actually spend PP, remove items from queue and create them
-      * in the universe. */
+    //! Recalculates the PPs spent on and number of turns left for each project
+    //! in the queue.  Also determines the number of projects in progress, and
+    //! the industry consumed by projects * in each resource-sharing group of
+    //! systems.  Does not actually "spend" the PP; a later call to
+    //! empire->CheckInfluenceProgress() will actually spend PP, remove items
+    //! from queue and create them in the universe.
     void Update();
 
+    auto empty() const -> bool
+    { return m_queue.empty(); }
 
-    // STL container-like interface
-    void        push_back(const Element& element) { m_queue.push_back(element); }
-    void        insert(iterator it, const Element& element) { m_queue.insert(it, element); }
-    void        erase(int i);
-    iterator    erase(iterator it) { return m_queue.erase(it); }
+    auto size() const -> std::size_t
+    { return m_queue.size(); }
 
-    iterator    begin() { return m_queue.begin(); }
-    iterator    end() { return m_queue.end(); }
-    iterator    find(const std::string& item_name);
-    Element&    operator[](int i);
+    auto begin() const -> const_iterator
+    { return m_queue.begin(); }
 
-    void        clear();
+    auto end() const -> const_iterator
+    { return m_queue.end(); }
+
+    auto find(const std::string& item_name) const -> const_iterator;
+
+    auto operator[](std::size_t i) const -> const Element&;
+
+    auto operator[](int i) const -> const Element&;
+
+    void push_back(const Element& element)
+    { m_queue.push_back(element); }
+
+    void insert(iterator it, const Element& element)
+    { m_queue.insert(it, element); }
+
+    void erase(int i);
+
+    auto erase(iterator it) -> iterator
+    { return m_queue.erase(it); }
+
+    auto begin() -> iterator
+    { return m_queue.begin(); }
+
+    auto end() -> iterator
+    { return m_queue.end(); }
+
+    auto find(const std::string& item_name) -> iterator;
+
+    auto operator[](int i) -> Element&;
+
+    void clear();
 
     mutable boost::signals2::signal<void ()> InfluenceQueueChangedSignal;
 

--- a/check/CMakeLists.txt
+++ b/check/CMakeLists.txt
@@ -49,7 +49,7 @@ if(TARGET ClangFormat::clang-format)
             ${PROJECT_SOURCE_DIR}/universe/*.cpp
             ${PROJECT_SOURCE_DIR}/util/*.h
             ${PROJECT_SOURCE_DIR}/util/*.cpp
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
         COMMENT "Check C++ for malformatted code"
         USES_TERMINAL
     )

--- a/check/CMakeLists.txt
+++ b/check/CMakeLists.txt
@@ -20,6 +20,7 @@ if(TARGET ClangFormat::clang-format)
         ${CMAKE_CURRENT_SOURCE_DIR}/clang-format-report.py
             --config=${CMAKE_CURRENT_SOURCE_DIR}/clang-format
             --clang-format-executable=$<TARGET_FILE:ClangFormat::clang-format>
+            --color
             ${PROJECT_SOURCE_DIR}/client/*.h
             ${PROJECT_SOURCE_DIR}/client/*.cpp
             ${PROJECT_SOURCE_DIR}/client/AI/*.h

--- a/check/CMakeLists.txt
+++ b/check/CMakeLists.txt
@@ -16,39 +16,31 @@ if(TARGET Cppcheck::cppcheck)
 endif()
 
 if(TARGET ClangFormat::clang-format)
+    list(APPEND CHECK_CPP_FORMAT_SOURCES "")
+
+    get_target_property(TARGET_SOURCES freeorioncommon SOURCES)
+    list(APPEND CHECK_CPP_FORMAT_SOURCES "${TARGET_SOURCES}")
+
+    get_target_property(TARGET_SOURCES freeorionparseobj SOURCES)
+    list(APPEND CHECK_CPP_FORMAT_SOURCES "${TARGET_SOURCES}")
+
+    get_target_property(TARGET_SOURCES freeoriond SOURCES)
+    list(APPEND CHECK_CPP_FORMAT_SOURCES "${TARGET_SOURCES}")
+
+    get_target_property(TARGET_SOURCES freeorionca SOURCES)
+    list(APPEND CHECK_CPP_FORMAT_SOURCES "${TARGET_SOURCES}")
+
+    if(TARGET freeorion)
+        get_target_property(TARGET_SOURCES freeorion SOURCES)
+        list(APPEND CHECK_CPP_FORMAT_SOURCES "${TARGET_SOURCES}")
+    endif()
+
     add_custom_target(check-cpp-format
         ${CMAKE_CURRENT_SOURCE_DIR}/clang-format-report.py
             --config=${CMAKE_CURRENT_SOURCE_DIR}/clang-format
             --clang-format-executable=$<TARGET_FILE:ClangFormat::clang-format>
             --color
-            ${PROJECT_SOURCE_DIR}/client/*.h
-            ${PROJECT_SOURCE_DIR}/client/*.cpp
-            ${PROJECT_SOURCE_DIR}/client/AI/*.h
-            ${PROJECT_SOURCE_DIR}/client/AI/*.cpp
-            ${PROJECT_SOURCE_DIR}/client/human/*.h
-            ${PROJECT_SOURCE_DIR}/client/human/*.cpp
-            ${PROJECT_SOURCE_DIR}/combat/*.h
-            ${PROJECT_SOURCE_DIR}/combat/*.cpp
-            ${PROJECT_SOURCE_DIR}/Empire/*.h
-            ${PROJECT_SOURCE_DIR}/Empire/*.cpp
-            ${PROJECT_SOURCE_DIR}/network/*.h
-            ${PROJECT_SOURCE_DIR}/network/*.cpp
-            ${PROJECT_SOURCE_DIR}/parse/*.h
-            ${PROJECT_SOURCE_DIR}/parse/*.cpp
-            ${PROJECT_SOURCE_DIR}/python/*.h
-            ${PROJECT_SOURCE_DIR}/python/*.cpp
-            ${PROJECT_SOURCE_DIR}/server/*.h
-            ${PROJECT_SOURCE_DIR}/server/*.cpp
-            ${PROJECT_SOURCE_DIR}/test/parse/*.h
-            ${PROJECT_SOURCE_DIR}/test/parse/*.cpp
-            ${PROJECT_SOURCE_DIR}/UI/*.h
-            ${PROJECT_SOURCE_DIR}/UI/*.cpp
-            ${PROJECT_SOURCE_DIR}/UI/CombatReport/*.h
-            ${PROJECT_SOURCE_DIR}/UI/CombatReport/*.cpp
-            ${PROJECT_SOURCE_DIR}/universe/*.h
-            ${PROJECT_SOURCE_DIR}/universe/*.cpp
-            ${PROJECT_SOURCE_DIR}/util/*.h
-            ${PROJECT_SOURCE_DIR}/util/*.cpp
+            ${CHECK_CPP_FORMAT_SOURCES}
         WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
         COMMENT "Check C++ for malformatted code"
         USES_TERMINAL

--- a/check/CMakeLists.txt
+++ b/check/CMakeLists.txt
@@ -1,4 +1,5 @@
 find_package(CPPCheck)
+find_package(ClangFormat)
 find_package(Flake8)
 find_package(PythonInterp ${MINIMUM_PYTHON_VERSION})
 
@@ -11,6 +12,45 @@ if(TARGET Cppcheck::cppcheck)
             --std=c++14
             ${PROJECT_SOURCE_DIR}
         COMMENT "Check C++ for problematic code"
+    )
+endif()
+
+if(TARGET ClangFormat::clang-format)
+    add_custom_target(check-cpp-format
+        ${CMAKE_CURRENT_SOURCE_DIR}/clang-format-report.py
+            --config=${CMAKE_CURRENT_SOURCE_DIR}/clang-format
+            --clang-format-executable=$<TARGET_FILE:ClangFormat::clang-format>
+            ${PROJECT_SOURCE_DIR}/client/*.h
+            ${PROJECT_SOURCE_DIR}/client/*.cpp
+            ${PROJECT_SOURCE_DIR}/client/AI/*.h
+            ${PROJECT_SOURCE_DIR}/client/AI/*.cpp
+            ${PROJECT_SOURCE_DIR}/client/human/*.h
+            ${PROJECT_SOURCE_DIR}/client/human/*.cpp
+            ${PROJECT_SOURCE_DIR}/combat/*.h
+            ${PROJECT_SOURCE_DIR}/combat/*.cpp
+            ${PROJECT_SOURCE_DIR}/Empire/*.h
+            ${PROJECT_SOURCE_DIR}/Empire/*.cpp
+            ${PROJECT_SOURCE_DIR}/network/*.h
+            ${PROJECT_SOURCE_DIR}/network/*.cpp
+            ${PROJECT_SOURCE_DIR}/parse/*.h
+            ${PROJECT_SOURCE_DIR}/parse/*.cpp
+            ${PROJECT_SOURCE_DIR}/python/*.h
+            ${PROJECT_SOURCE_DIR}/python/*.cpp
+            ${PROJECT_SOURCE_DIR}/server/*.h
+            ${PROJECT_SOURCE_DIR}/server/*.cpp
+            ${PROJECT_SOURCE_DIR}/test/parse/*.h
+            ${PROJECT_SOURCE_DIR}/test/parse/*.cpp
+            ${PROJECT_SOURCE_DIR}/UI/*.h
+            ${PROJECT_SOURCE_DIR}/UI/*.cpp
+            ${PROJECT_SOURCE_DIR}/UI/CombatReport/*.h
+            ${PROJECT_SOURCE_DIR}/UI/CombatReport/*.cpp
+            ${PROJECT_SOURCE_DIR}/universe/*.h
+            ${PROJECT_SOURCE_DIR}/universe/*.cpp
+            ${PROJECT_SOURCE_DIR}/util/*.h
+            ${PROJECT_SOURCE_DIR}/util/*.cpp
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        COMMENT "Check C++ for malformatted code"
+        USES_TERMINAL
     )
 endif()
 
@@ -28,6 +68,10 @@ if(NOT TARGET check)
     add_custom_target(check
         COMMENT "Run code quality checks"
     )
+endif()
+
+if(TARGET check-cpp-format)
+    add_dependencies(check check-cpp-format)
 endif()
 
 if(TARGET check-cpp)

--- a/check/clang-format
+++ b/check/clang-format
@@ -1,0 +1,5 @@
+---
+Language:        Cpp
+DisableFormat:   true
+...
+

--- a/check/clang-format
+++ b/check/clang-format
@@ -1,5 +1,93 @@
 ---
 Language:        Cpp
-DisableFormat:   true
+# BasedOnStyle:  LLVM
+AccessModifierOffset: -4
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: false
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: true
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: true
+AllowShortIfStatementsOnASingleLine: false
+AllowShortLoopsOnASingleLine: false
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: false
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:
+  AfterClass:      true
+  AfterControlStatement: true
+  AfterEnum:       false
+  AfterFunction:   true
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     true
+  AfterUnion:      true
+  BeforeCatch:     true
+  BeforeElse:      true
+  IndentBraces:    false
+  SplitEmptyRecord: false
+  SplitEmptyNamespace: false
+BreakBeforeBinaryOperators: NonAssignment
+BreakBeforeBraces: Allman
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: true
+ColumnLimit:     0
+CommentPragmas:  '^ IWYU pragma:'
+CompactNamespaces: true
+ConstructorInitializerAllOnOneLineOrOnePerLine: false
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: false
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories: 
+  - Regex:           '^"(llvm|llvm-c|clang|clang-c)/'
+    Priority:        2
+  - Regex:           '^(<|"(gtest|isl|json)/)'
+    Priority:        3
+  - Regex:           '.*'
+    Priority:        1
+IndentCaseLabels: false
+IndentWidth:     4
+IndentWrappedFunctionNames: false
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 2
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: true
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Cpp11
+TabWidth:        8
+UseTab:          Never
 ...
 

--- a/check/clang-format-report.py
+++ b/check/clang-format-report.py
@@ -1,0 +1,99 @@
+#!/usr/bin/python3
+
+from __future__ import print_function
+from distutils.spawn import find_executable
+from distutils.version import StrictVersion
+from subprocess import check_output
+import argparse
+import difflib
+import sys
+import json
+import yaml
+
+
+def collect_format_differences(file_path, args):
+    original = None
+    with open(file_path, 'r') as f:
+        original = f.read().splitlines(keepends=True)
+    formatted = check_output([args.clang_format_executable, '-style='+args.clang_format, '-sort-includes=false', file_path]).decode('utf-8').splitlines(keepends=True)
+    original_lno = 0
+    formatted_lno = 0
+    hunks = []
+    current_hunk = None
+    for line in difflib.ndiff(original, formatted):
+        if line.startswith('? '):
+            continue
+        if line.startswith(' ') or line.startswith('-'):
+            original_lno += 1
+        if line.startswith(' ') or line.startswith('+'):
+            formatted_lno += 1
+        if line.startswith(' '):
+            if current_hunk:
+                hunks.append(current_hunk)
+                current_hunk = None
+            continue
+        if line.startswith('?'):
+            continue
+        if not current_hunk:
+            current_hunk = {
+                'from': original_lno,
+                'to': original_lno,
+                'added': '',
+                'removed': ''
+            }
+        if line.startswith('+'):
+            current_hunk['added'] += line[2:]
+        if line.startswith('-'):
+            current_hunk['removed'] += line[2:]
+            current_hunk['to'] = original_lno
+    return hunks
+
+
+def print_gcc_report(file_path, differences):
+    for hunk in differences:
+        print('{}:{}: Formatting difference, clang-format suggests diff:\n{}\n{}'.format(
+            file_path,
+            hunk['from'],
+            '\n'.join(['-' + line for line in hunk['removed'].splitlines()]),
+            '\n'.join(['+' + line for line in hunk['added'].splitlines()])
+        ))
+
+
+def main():
+    arg_parser = argparse.ArgumentParser(
+        description='Report differences between current and expected C++ format'
+    )
+    arg_parser.add_argument(
+        '--config', '-c', nargs='?', type=argparse.FileType('r'),
+        default='.clang-config', help='A clang-format configuration'
+    )
+    arg_parser.add_argument(
+        '--clang-format-executable', default='clang-format',
+        help='Name or path to the clang-format executable'
+    )
+    arg_parser.add_argument(
+        'files', nargs='+', help='A list of files to scan for mismatches'
+    )
+
+    args = arg_parser.parse_args()
+
+    if 'clang-format' == args.clang_format_executable:
+        args.clang_format_executable = find_executable('clang-format')
+    if not args.clang_format_executable:
+        print("Unable to locate `clang-format` executable.", file=sys.stderr)
+        exit(1)
+
+    if hasattr(yaml, '__version__') and StrictVersion(yaml.__version__) >= StrictVersion('5.1'):
+        args.clang_format = json.dumps(yaml.load(args.config, Loader=yaml.FullLoader))
+    else:
+        args.clang_format = json.dumps(yaml.load(args.config))
+    report = print_gcc_report
+
+    for file_path in args.files:
+        print("Checking format of {}".format(file_path))
+        differences = collect_format_differences(file_path, args)
+        report(file_path, differences)
+
+
+if __name__ == "__main__":
+    main()

--- a/check/clang-format-report.py
+++ b/check/clang-format-report.py
@@ -11,6 +11,7 @@ try:
 except ImportError:
     HAS_COLORAMA=False
 import difflib
+import os
 import sys
 import json
 import yaml
@@ -115,16 +116,17 @@ def main():
     exit_code = 0
 
     for file_path in args.files:
+        rel_path = os.path.relpath(file_path, os.getcwd())
         brighten_beg = '';
         brighten_end = '';
         if HAS_COLORAMA and args.color:
             brighten_beg = colorama.Style.BRIGHT;
             brighten_end = colorama.Style.RESET_ALL;
-        print("{}Checking format of {}:{}".format(brighten_beg, file_path, brighten_end))
+        print("{}Checking format of {}:{}".format(brighten_beg, rel_path, brighten_end))
         differences = collect_format_differences(file_path, args)
         if len(differences):
             exit_code = 1
-        report(file_path, differences, args)
+        report(rel_path, differences, args)
 
     exit(exit_code)
 

--- a/check/clang-format-report.py
+++ b/check/clang-format-report.py
@@ -89,10 +89,16 @@ def main():
         args.clang_format = json.dumps(yaml.load(args.config))
     report = print_gcc_report
 
+    exit_code = 0
+
     for file_path in args.files:
         print("Checking format of {}".format(file_path))
         differences = collect_format_differences(file_path, args)
+        if len(differences):
+            exit_code = 1
         report(file_path, differences)
+
+    exit(exit_code)
 
 
 if __name__ == "__main__":

--- a/cmake/FindClangFormat.cmake
+++ b/cmake/FindClangFormat.cmake
@@ -1,0 +1,23 @@
+find_program(CLANGFORMAT_EXECUTABLE
+    NAMES clang-format
+    DOC "A tool for C/C++ code formatting"
+)
+
+if(CLANG-FORMAT_EXECUTABLE)
+    execute_process(COMMAND ${CLANGFORMAT_EXECUTABLE} "-version" OUTPUT_VARIABLE CLANGFORMAT_VERSION OUTPUT_STRIP_TRAILING_WHITESPACE)
+    string(REGEX REPLACE "clang-format version ([0-9]+)\\.([0-9]+)\\.([0-9]+).*" "\\1.\\2.\\3" CLANGFORMAT_VERSION ${CLANGFORMAT_VERSION})
+endif()
+
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(ClangFormat REQUIRED_VARS CLANGFORMAT_EXECUTABLE VERSION_VAR CLANGFORMAT_VERSION)
+
+mark_as_advanced(
+    CLANGFORMAT_EXECUTABLE
+)
+
+if(CLANGFORMAT_FOUND)
+    if(NOT TARGET ClangFormat::clang-format)
+        add_executable(ClangFormat::clang-format IMPORTED)
+        set_property(TARGET ClangFormat::clang-format PROPERTY IMPORTED_LOCATION ${CLANGFORMAT_EXECUTABLE})
+    endif()
+endif()


### PR DESCRIPTION
This PR introduces the `check-cpp-format` target to the CMake build system. 

T his target, when executed, run the [ClangFormat](https://clang.llvm.org/docs/ClangFormat.html) tool over all C++ source files (and headers) and reports discrepancies between the source code formatting present on disk and the expected format according to the ClangFormat configuration.  No actual formatting is done, the output is intended for CI checks.

The current configuration is a mere suggestion based on the LLVM project formatting guidelines, but heavily adopted to the existing FreeOrion project style (as far as this is possible) and had some personal preferences included so I need to revise it again.

This is also a very old  work in progress branch, so the generated reports are not well to read yet and sources are not taken from the existing targets but are a hardcoded list.  Also this PR is missing  a CI job declaration to run this during the lint stage on every commit.

Fixes: #2306

* [x] Add exit code `1` to `check/clang-format-report.py` to indicate formatting mismatches.
* [x] Add CI lint job to run `check-cpp-format` target on every commit.
* [x] Ditch Docker image (#3072)
* [ ] Look into formatting setting for short function formatting, don't enforce Allman.
* [x] Pull sources from other targets.
* [x] Use colorama for nicer report output.
* [ ] Provide unified diff formatter to generate diff usable with git am(?)