### PR TITLE
Delay SINGULARITY_GEN, reduce ART_BLACK_HOLE build time

### DIFF
--- a/default/python/AI/ResearchAI.py
+++ b/default/python/AI/ResearchAI.py
@@ -999,7 +999,7 @@ def generate_classic_research_orders():
     if True:  # just to help with cold-folding / organization
         if (fo.currentTurn() > 50 and len(AIstate.empireStars.get(fo.starType.blackHole, [])) != 0 and
                 aistate.character.may_research_tech_classic("PRO_SINGULAR_GEN") and not tech_is_complete(Dep.PRO_SINGULAR_GEN) and
-                tech_is_complete(Dep.PRO_SOL_ORB_GEN)):
+                tech_is_complete("LRN_EVERYTHING")):
             # sing_tech_list = [ "LRN_GRAVITONICS" , "PRO_SINGULAR_GEN"]  # formerly also "CON_ARCH_PSYCH", "CON_CONC_CAMP",
             sing_gen_tech = fo.getTech(Dep.PRO_SINGULAR_GEN)
             sing_tech_list = [pre_req for pre_req in sing_gen_tech.recursivePrerequisites(empire_id) if not tech_is_complete(pre_req)]

--- a/default/scripting/buildings/ART_BLACK_HOLE.focs.txt
+++ b/default/scripting/buildings/ART_BLACK_HOLE.focs.txt
@@ -1,8 +1,8 @@
 BuildingType
     name = "BLD_ART_BLACK_HOLE"
     description = "BLD_ART_BLACK_HOLE_DESC"
-    buildcost = 40 * [[BUILDING_COST_MULTIPLIER]]
-    buildtime = 10
+    buildcost = 45 * [[BUILDING_COST_MULTIPLIER]]
+    buildtime = 6
     location = And [
         Planet
         Not Contains Building name = "BLD_ART_BLACK_HOLE"

--- a/default/scripting/techs/production/SINGULAR_GEN.focs.txt
+++ b/default/scripting/techs/production/SINGULAR_GEN.focs.txt
@@ -7,7 +7,7 @@ Tech
     researchturns = 4
     tags = [ "PEDIA_PRODUCTION_CATEGORY" ]
     prerequisites = [
-        "LRN_GRAVITONICS"
+        "LRN_TIME_MECH"
         "PRO_SOL_ORB_GEN"
     ]
     unlock = Item type = Building name = "BLD_BLACK_HOLE_POW_GEN"


### PR DESCRIPTION
Makes Singularity Generation tech require Temporal Mechanics and reduces build time or Artificial Black Hole (from 10 to 6), so that empires with a nearby Black Hole with planets doesn't have a great advantage over empires that must research Artificial Black Hole.

[Forum thread](https://www.freeorion.org/forum/viewtopic.php?f=6&t=11661&p=101501).